### PR TITLE
FIX: Use more stable BLAS routines for euclidean norm.

### DIFF
--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -53,6 +53,10 @@ def get_blas_funcs(names,arrays=(),debug=0):
         if name=='ger' and typecode in 'FD':
             name = 'gerc'
         func_name = required_prefix + name
+        if name == 'nrm2' and typecode == 'D':
+            func_name = 'dznrm2'
+        elif name == 'nrm2' and typecode == 'F':
+            func_name = 'scnrm2'
         func = getattr(m1,func_name,None)
         if func is None:
             func = getattr(m2,func_name)

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -1,12 +1,20 @@
 import numpy as np
 from numpy.linalg import LinAlgError
+from blas import get_blas_funcs
 
 __all__ = ['LinAlgError', 'norm']
 
 
 def norm(a, ord=None):
-    # Differs from numpy only in non-finite handling
-    return np.linalg.norm(np.asarray_chkfinite(a), ord=ord)
+    # Differs from numpy in non-finite handling and in implementation
+    # of the 2-norm, where more stable BLAS routines are used.
+    a = np.asarray_chkfinite(a)
+    if a.ndim == 1 and ord in (2, None) and a.dtype.kind in 'fdFD':
+        nrm2, = get_blas_funcs(('nrm2',), (a,))
+        return nrm2(a)
+    else:
+        return np.linalg.norm(a, ord=ord)
+
 norm.__doc__ = np.linalg.norm.__doc__
 
 def _datacopied(arr, original):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -19,12 +19,14 @@ Run tests if linalg is not installed:
   python tests/test_basic.py
 """
 
+import numpy as np
 from numpy import arange, array, dot, zeros, identity, conjugate, transpose, \
         float32
 import numpy.linalg as linalg
 
 from numpy.testing import TestCase, rand, run_module_suite, assert_raises, \
-    assert_equal, assert_almost_equal, assert_array_almost_equal, assert_
+    assert_equal, assert_almost_equal, assert_array_almost_equal, assert_, \
+    assert_allclose
 
 from scipy.linalg import solve, inv, det, lstsq, pinv, pinv2, norm,\
         solve_banded, solveh_banded, solve_triangular
@@ -561,6 +563,24 @@ class TestNorm(object):
     def test_zero_norm(self):
         assert_equal(norm([1,0,3], 0), 2)
         assert_equal(norm([1,2,3], 0), 3)
+
+    def test_types(self):
+        for dtype in np.typecodes['AllFloat']:
+            x = np.array([1,2,3], dtype=dtype)
+            tol = max(1e-15, np.finfo(dtype).eps.real * 20)
+            assert_allclose(norm(x), np.sqrt(14), rtol=tol)
+            assert_allclose(norm(x, 2), np.sqrt(14), rtol=tol)
+
+    def test_overflow(self):
+        # unlike numpy's norm, this one is
+        # safe on overflow
+        a = array([1e20], dtype=float32)
+        assert_almost_equal(norm(a), a)
+
+    def test_stable(self):
+        # more stable than numpy's norm
+        a = array([1e4] + [1]*10000, dtype=float32)
+        assert_almost_equal(norm(a) - 1e4, 0.5)
 
 class TestOverwrite(object):
     def test_solve(self):


### PR DESCRIPTION
Copied from https://github.com/scipy/scipy-svn/pull/4

---

fabianp opened this pull request February 18, 2011
FIX: Use more stable BLAS routines for euclidean norm.
Edit
The BLAS routine nrm2 is more stable and resistant to (over/under)flow. Use this in scipy.linalg and add some test.

---

pv commented February 21, 2011
Needs some work: nrm2 is not available for all types, so a type check needs also be made. Those changes here:

https://github.com/pv/scipy-work/tree/fabianp-norm-blas

I'm thinking that the BLAS functions should be cached -- get_blas_funcs is probably not too fast.

---

fabianp commented February 21, 2011
Hi Pauli. Thanks for the changes, I'll work some more on this and take a closer look into get_blas_func(), I think I might be able to clean it a bit.

Also, same problem arises for the frobenius norm (take as matrix A = diag(a)), I'll try to fix that too.
