### PR TITLE
Fixing a special.gamma overrun in gamma.pdf

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -3061,7 +3061,7 @@ class gamma_gen(rv_continuous):
     def _rvs(self, a):
         return mtrand.standard_gamma(a, self._size)
     def _pdf(self, x, a):
-        return x**(a-1)*exp(-x)/special.gamma(a)
+        return exp(self._logpdf(x, a))
     def _logpdf(self, x, a):
         return (a-1)*log(x) - x - gamln(a)
     def _cdf(self, x, a):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -332,6 +332,17 @@ class TestSkellam(TestCase):
         assert_almost_equal(stats.skellam.cdf(k, mu1, mu2), skcdfR, decimal=5)
 
 
+class TestGamma(TestCase):
+
+    def test_pdf(self):
+        # a few test cases to compare with R
+        pdf = stats.gamma.pdf(90, 394, scale=1./5)
+        assert_almost_equal(pdf, 0.002312341)
+
+        pdf = stats.gamma.pdf(3, 10, scale=1./5)
+        assert_almost_equal(pdf, 0.1620358)
+
+
 class TestHypergeom(TestCase):
     def test_precision(self):
         # comparison number from mpmath


### PR DESCRIPTION
Copied from https://github.com/scipy/scipy-svn/pull/5

---

wesm opened this pull request February 21, 2011
Fixing a special.gamma overrun in gamma.pdf
There are more to be found in distributions.py-- I'll fix them as I find them.
