### PR TITLE
Deprecate maxentropy

### DIFF
--- a/scipy/maxentropy/__init__.py
+++ b/scipy/maxentropy/__init__.py
@@ -1,5 +1,19 @@
 from info import __doc__
 from maxentropy import *
+from scipy.misc import logsumexp
 
 from numpy.testing import Tester
 test = Tester().test
+
+import warnings
+warnings.warn("""
+The scipy.maxentropy module is deprecated in scipy 0.10, and scheduled to be
+removed in 0.11.
+
+If you are using some of the functionality in this module and are of the
+opinion that it should be kept or moved somewhere - or you are even interested
+to maintain/improve this whole module - please ask on the scipy-dev mailing
+list.
+
+The logsumexp function has already been moved to scipy.misc.""",
+DeprecationWarning)

--- a/scipy/maxentropy/info.py
+++ b/scipy/maxentropy/info.py
@@ -2,6 +2,10 @@
 Routines for fitting maximum entropy models
 ===========================================
 
+.. warning:: This module is deprecated in scipy 0.10, and will be removed in
+             0.11. Do not use this module in your new code. For questions about
+             this deprecation, please ask on the scipy-dev mailing list.
+
 Contains two classes for fitting maximum entropy models (also known
 as "exponential family" models) subject to linear constraints on the
 expectations of arbitrary feature statistics.  One class, "model", is

--- a/scipy/maxentropy/maxentropy.py
+++ b/scipy/maxentropy/maxentropy.py
@@ -74,7 +74,8 @@ import numpy as np
 from numpy import exp, asarray
 from scipy import optimize
 from scipy.linalg import norm
-from scipy.maxentropy.maxentutils import logsumexp, arrayexp, \
+from scipy.misc import logsumexp
+from scipy.maxentropy.maxentutils import arrayexp, \
         innerprod, innerprodtranspose, columnmeans, columnvariances, \
         flatten, DivergenceError, sparsefeaturematrix
 

--- a/scipy/maxentropy/maxentutils.py
+++ b/scipy/maxentropy/maxentutils.py
@@ -26,14 +26,7 @@ import cmath
 import numpy
 from numpy import log, exp, asarray, ndarray, empty
 from scipy import sparse
-
-def logsumexp(a):
-    """Compute the log of the sum of exponentials log(e^{a_1}+...e^{a_n})
-    of the components of the array a, avoiding numerical overflow.
-    """
-    a = asarray(a)
-    a_max = a.max()
-    return a_max + log((exp(a-a_max)).sum())
+from scipy.misc import logsumexp
 
 
 def _logsumexpcomplex(values):

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -3,14 +3,41 @@ Functions which are common and require SciPy Base and Level 1 SciPy
 (special, linalg)
 """
 
-from numpy import exp, asarray, arange, newaxis, hstack, product, array, \
+from numpy import exp, log, asarray, arange, newaxis, hstack, product, array, \
                   where, zeros, extract, place, pi, sqrt, eye, poly1d, dot, r_
 
-__all__ = ['factorial','factorial2','factorialk','comb',
+__all__ = ['logsumexp', 'factorial','factorial2','factorialk','comb',
            'central_diff_weights', 'derivative', 'pade', 'lena']
 
 # XXX: the factorial functions could move to scipy.special, and the others
 # to numpy perhaps?
+
+def logsumexp(a):
+    """Compute the log of the sum of exponentials of input elements.
+
+    Parameters
+    ----------
+    a : array_like
+        Input array.
+
+    Returns
+    -------
+    res : ndarray
+        The result, ``np.log(np.sum(np.exp(a)))`` calculated in a numerically
+        more stable way.
+
+    See Also
+    --------
+    numpy.logaddexp, numpy.logaddexp2
+
+    Notes
+    -----
+    Numpy has a logaddexp function which is very similar to `logsumexp`.
+
+    """
+    a = asarray(a)
+    a_max = a.max()
+    return a_max + log((exp(a-a_max)).sum())
 
 def factorial(n,exact=0):
     """

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -1,7 +1,8 @@
+import numpy as np
+from numpy.testing import assert_array_equal, assert_almost_equal, \
+                          assert_array_almost_equal
 
-from numpy.testing import assert_array_equal,  assert_array_almost_equal
-
-from scipy.misc import pade
+from scipy.misc import pade, logsumexp
 
 
 def test_pade_trivial():
@@ -30,3 +31,18 @@ def test_pade_4term_exp():
     assert_array_almost_equal(nump.c, [1.0])
     assert_array_almost_equal(denomp.c, [-1.0/6, 0.5,  -1.0, 1.0])
 
+def test_logsumexp():
+    """Test whether logsumexp() function correctly handles large inputs."""
+    a = np.arange(200)
+    desired = np.log(np.sum(np.exp(a)))
+    assert_almost_equal(logsumexp(a), desired)
+
+    # Now test with large numbers
+    b = [1000,1000]
+    desired = 1000.0 + np.log(2.0)
+    assert_almost_equal(logsumexp(b), desired)
+
+    n = 1000
+    b = np.ones(n)*10000
+    desired = 10000.0 + np.log(n)
+    assert_almost_equal(logsumexp(b), desired)


### PR DESCRIPTION
This was discussed on-list before, no objections. 

Can't find a way to disable the warning when running test suite, but I don't think that matters much.
