### PR TITLE
Refactoring get_blas_funcs and added docstring.

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -6,9 +6,7 @@
 __all__ = ['solve', 'solve_triangular', 'solveh_banded', 'solve_banded',
             'inv', 'det', 'lstsq', 'pinv', 'pinv2']
 
-from numpy import asarray, zeros, sum, conjugate, dot, transpose, \
-        asarray_chkfinite,  single
-import numpy
+import numpy as np
 
 from flinalg import get_flinalg_funcs
 from lapack import get_lapack_funcs
@@ -44,7 +42,7 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False, overwrite_b=False
     Raises LinAlgError if a is singular
 
     """
-    a1, b1 = map(asarray_chkfinite,(a,b))
+    a1, b1 = map(np.asarray_chkfinite,(a,b))
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
     if a1.shape[0] != b1.shape[0]:
@@ -112,7 +110,7 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
 
     """
 
-    a1, b1 = map(asarray_chkfinite,(a,b))
+    a1, b1 = map(np.asarray_chkfinite,(a,b))
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
     if a1.shape[0] != b1.shape[0]:
@@ -165,7 +163,7 @@ def solve_banded((l, u), ab, b, overwrite_ab=False, overwrite_b=False,
         The solution to the system a x = b
 
     """
-    a1, b1 = map(asarray_chkfinite, (ab, b))
+    a1, b1 = map(np.asarray_chkfinite, (ab, b))
 
     # Validate shapes.
     if a1.shape[-1] != b1.shape[0]:
@@ -177,7 +175,7 @@ def solve_banded((l, u), ab, b, overwrite_ab=False, overwrite_b=False,
     overwrite_b = overwrite_b or _datacopied(b1, b)
 
     gbsv, = get_lapack_funcs(('gbsv',), (a1, b1))
-    a2 = zeros((2*l+u+1, a1.shape[1]), dtype=gbsv.dtype)
+    a2 = np.zeros((2*l+u+1, a1.shape[1]), dtype=gbsv.dtype)
     a2[l:,:] = a1
     lu, piv, x, info = gbsv(l, u, a2, b1, overwrite_ab=True,
                                                 overwrite_b=overwrite_b)
@@ -230,7 +228,7 @@ def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False):
 
     """
 
-    ab, b = map(asarray_chkfinite, (ab, b))
+    ab, b = map(np.asarray_chkfinite, (ab, b))
 
     # Validate shapes.
     if ab.shape[-1] != b.shape[0]:
@@ -282,7 +280,7 @@ def inv(a, overwrite_a=False):
            [ 0.,  1.]])
 
     """
-    a1 = asarray_chkfinite(a)
+    a1 = np.asarray_chkfinite(a)
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
     overwrite_a = overwrite_a or _datacopied(a1, a)
@@ -302,9 +300,9 @@ def inv(a, overwrite_a=False):
     #     to do that.
     if getrf.module_name[:7] == 'clapack' != getri.module_name[:7]:
         # ATLAS 3.2.1 has getrf but not getri.
-        lu, piv, info = getrf(transpose(a1), rowmajor=0,
+        lu, piv, info = getrf(np.transpose(a1), rowmajor=0,
                                                 overwrite_a=overwrite_a)
-        lu = transpose(lu)
+        lu = np.transpose(lu)
     else:
         lu, piv, info = getrf(a1, overwrite_a=overwrite_a)
     if info == 0:
@@ -347,7 +345,7 @@ def det(a, overwrite_a=False):
     -----
     The determinant is computed via LU factorization, LAPACK routine z/dgetrf.
     """
-    a1 = asarray_chkfinite(a)
+    a1 = np.asarray_chkfinite(a)
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
     overwrite_a = overwrite_a or _datacopied(a1, a)
@@ -406,7 +404,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False):
     optimize.nnls : linear least squares with non-negativity constraint
 
     """
-    a1, b1 = map(asarray_chkfinite, (a, b))
+    a1, b1 = map(np.asarray_chkfinite, (a, b))
     if len(a1.shape) != 2:
         raise ValueError('expected matrix')
     m, n = a1.shape
@@ -420,7 +418,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False):
     if n > m:
         # need to extend b matrix as it will be filled with
         # a larger solution matrix
-        b2 = zeros((n, nrhs), dtype=gelss.dtype)
+        b2 = np.zeros((n, nrhs), dtype=gelss.dtype)
         if len(b1.shape) == 2:
             b2[:m,:] = b1
         else:
@@ -440,11 +438,11 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False):
     if info < 0:
         raise ValueError('illegal value in %d-th argument of internal gelss'
                                                                     % -info)
-    resids = asarray([], dtype=x.dtype)
+    resids = np.asarray([], dtype=x.dtype)
     if n < m:
         x1 = x[:n]
         if rank == n:
-            resids = sum(abs(x[n:])**2, axis=0)
+            resids = np.sum(np.abs(x[n:])**2, axis=0)
         x = x1
     return x, resids, rank, s
 
@@ -481,8 +479,8 @@ def pinv(a, cond=None, rcond=None):
     True
 
     """
-    a = asarray_chkfinite(a)
-    b = numpy.identity(a.shape[0], dtype=a.dtype)
+    a = np.asarray_chkfinite(a)
+    b = np.identity(a.shape[0], dtype=a.dtype)
     if rcond is not None:
         cond = rcond
     return lstsq(a, b, cond=cond)[0]
@@ -523,21 +521,21 @@ def pinv2(a, cond=None, rcond=None):
     True
 
     """
-    a = asarray_chkfinite(a)
+    a = np.asarray_chkfinite(a)
     u, s, vh = decomp_svd.svd(a)
     t = u.dtype.char
     if rcond is not None:
         cond = rcond
     if cond in [None,-1]:
-        eps = numpy.finfo(float).eps
-        feps = numpy.finfo(single).eps
+        eps = np.finfo(np.float).eps
+        feps = np.finfo(np.single).eps
         _array_precision = {'f': 0, 'd': 1, 'F': 0, 'D': 1}
         cond = {0: feps*1e3, 1: eps*1e6}[_array_precision[t]]
     m, n = a.shape
-    cutoff = cond*numpy.maximum.reduce(s)
-    psigma = zeros((m, n), t)
+    cutoff = cond*np.maximum.reduce(s)
+    psigma = np.zeros((m, n), t)
     for i in range(len(s)):
         if s[i] > cutoff:
-            psigma[i,i] = 1.0/conjugate(s[i])
+            psigma[i,i] = 1.0/np.conjugate(s[i])
     #XXX: use lapack/blas routines for dot
-    return transpose(conjugate(dot(dot(u,psigma),vh)))
+    return np.transpose(np.conjugate(np.dot(np.dot(u,psigma),vh)))

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -5,7 +5,7 @@
 
 __all__ = ['get_blas_funcs']
 
-import numpy
+import numpy as np
 # The following ensures that possibly missing flavor (C or Fortran) is
 # replaced with the available one. If none is available, exception
 # is raised at the first attempt to use the resources.
@@ -61,7 +61,7 @@ def get_blas_funcs(names, arrays=(), dtype=None):
     n_arrays = len(arrays)
     blas_funcs = []
     unpack = False
-    dtype = numpy.dtype(dtype)
+    dtype = np.dtype(dtype)
 
     if isinstance(names, str):
         names = (names,)

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -1,5 +1,6 @@
 #
 # Author: Pearu Peterson, March 2002
+#         refactoring by Fabian Pedregosa, March 2010
 #
 
 __all__ = ['get_blas_funcs']
@@ -9,57 +10,67 @@ __all__ = ['get_blas_funcs']
 # replaced with the available one. If none is available, exception
 # is raised at the first attempt to use the resources.
 
-from scipy.linalg import fblas
-from scipy.linalg import cblas
+from scipy.linalg import cblas, fblas
 if hasattr(cblas,'empty_module'):
     cblas = fblas
 elif hasattr(fblas,'empty_module'):
     fblas = cblas
 
-_type_conv = {'f':'s', 'd':'d', 'F':'c', 'D':'z'} # 'd' will be default for 'i',..
+ # 'd' will be default for 'i',..
+_type_conv = {'f':'s', 'd':'d', 'F':'c', 'D':'z'}
 _inv_type_conv = {'s':'f','d':'d','c':'F','z':'D'}
 
-def has_column_major_storage(arr):
-    """Is array stored in column-major format"""
-    return arr.flags['FORTRAN']
 
-def get_blas_funcs(names,arrays=(),debug=0):
-    """Return available BLAS function objects with names.
-    arrays are used to determine the optimal prefix of
-    BLAS routines.
+def get_blas_funcs(names, arrays=()):
+    """Return available BLAS function objects from names.
 
+    Arrays are used to determine the optimal prefix of BLAS routines.
+
+    Parameters
+    ----------
+    names : iterable of strings
+        Names of BLAS functions withouth type prefix.
+
+    arrays : iterable of arrays, optional
+        Arrays can be given to determine optiomal prefix of BLAS
+        routines. If not given, double-precision routines will be
+        used.
+
+    Returns
+    -------
+    funcs : list
+        List of functions.
+
+    Notes
+    -----
+    This routines automatically chooses between Fortran/C
+    interfaces. Fortran code is used whenever possible for arrays with
+    column major order. In all other cases, C code is preferred.
     """
-    ordering = []
-    for i in range(len(arrays)):
-        t = arrays[i].dtype.char
-        if t not in _type_conv:
-            t = 'd'
-        ordering.append((t,i))
-    if ordering:
-        ordering.sort()
-        required_prefix = _type_conv[ordering[0][0]]
-    else:
-        required_prefix = 'd'
-    typecode = _inv_type_conv[required_prefix]
-    # Default lookup:
-    if ordering and has_column_major_storage(arrays[ordering[0][1]]):
-        # prefer Fortran code for leading array with column major order
-        m1,m2 = fblas,cblas
-    else:
-        # in all other cases, C code is preferred
-        m1,m2 = cblas,fblas
-    funcs = []
-    for name in names:
-        if name=='ger' and typecode in 'FD':
-            name = 'gerc'
-        func_name = required_prefix + name
-        func = getattr(m1,func_name,None)
+
+    n_arrays = len(arrays)
+    blas_funcs = []
+
+    for i, name in enumerate(names):
+        module1 = (cblas, 'cblas')
+        module2 = (fblas, 'fblas')
+        prefix = 'd'
+
+        if i < n_arrays:
+            prefix = _type_conv.get(arrays[i].dtype.char, 'd')
+            if arrays[i].flags['FORTRAN']:
+                module1, module2 = module2, module1
+
+        func_name = prefix + name
+        func = getattr(module1[0], func_name, None)
+        module_name = module1[1]
         if func is None:
-            func = getattr(m2,func_name)
-            func.module_name = m2.__name__.split('.')[-1]
-        else:
-            func.module_name = m1.__name__.split('.')[-1]
-        func.prefix = required_prefix
-        func.typecode = typecode
-        funcs.append(func)
-    return tuple(funcs)
+            func = getattr(module2[0], func_name, None)
+            module_name = module2[1]
+        if func is None:
+            raise ValueError(
+                'BLAS function %s could not be found' % func_name)
+        func.module_name = module_name
+        func.typecode = _inv_type_conv[prefix]
+        blas_funcs.append(func)
+    return blas_funcs

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -87,8 +87,7 @@ def get_blas_funcs(names, arrays=(), dtype=None):
         if func is None:
             raise ValueError(
                 'BLAS function %s could not be found' % func_name)
-        func.module_name = module_name
-        func.typecode = prefix
+        func.module_name, func.typecode = module_name, prefix
         blas_funcs.append(func)
 
     if unpack:

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -5,7 +5,7 @@
 
 __all__ = ['get_blas_funcs']
 
-
+import numpy
 # The following ensures that possibly missing flavor (C or Fortran) is
 # replaced with the available one. If none is available, exception
 # is raised at the first attempt to use the resources.
@@ -18,48 +18,65 @@ elif hasattr(fblas,'empty_module'):
 
  # 'd' will be default for 'i',..
 _type_conv = {'f':'s', 'd':'d', 'F':'c', 'D':'z'}
-_inv_type_conv = {'s':'f','d':'d','c':'F','z':'D'}
 
 
-def get_blas_funcs(names, arrays=()):
+def get_blas_funcs(names, arrays=(), dtype=None):
     """Return available BLAS function objects from names.
 
     Arrays are used to determine the optimal prefix of BLAS routines.
 
     Parameters
     ----------
-    names : iterable of strings
-        Names of BLAS functions withouth type prefix.
+    names : str or sequence of str
+        Name(s) of BLAS functions withouth type prefix.
 
-    arrays : iterable of arrays, optional
+    arrays : sequency of ndarrays, optional
         Arrays can be given to determine optiomal prefix of BLAS
         routines. If not given, double-precision routines will be
         used.
 
+    dtype : str or dtype, optional
+        Data-type specifier. Not used if `arrays` is non-empty.
+
+
     Returns
     -------
     funcs : list
-        List of functions.
+        List containing the found function(s).
+
 
     Notes
     -----
     This routines automatically chooses between Fortran/C
     interfaces. Fortran code is used whenever possible for arrays with
     column major order. In all other cases, C code is preferred.
+
+    In BLAS, the naming convention is that all functions start with a
+    type prefix, which depends on the type of the principal
+    matrix. These can be one of {'s', 'd', 'c', 'z'} for the numpy
+    types {float32, float64, complex64, complex128} respectevely, and
+    are stored in attribute `typecode` of the returned functions.
     """
 
     n_arrays = len(arrays)
     blas_funcs = []
+    unpack = False
+    dtype = numpy.dtype(dtype)
+
+    if isinstance(names, str):
+        names = (names,)
+        unpack = True
 
     for i, name in enumerate(names):
         module1 = (cblas, 'cblas')
         module2 = (fblas, 'fblas')
-        prefix = 'd'
 
         if i < n_arrays:
             prefix = _type_conv.get(arrays[i].dtype.char, 'd')
             if arrays[i].flags['FORTRAN']:
                 module1, module2 = module2, module1
+        else:
+            prefix = _type_conv.get(dtype.char, 'd')
 
         func_name = prefix + name
         func = getattr(module1[0], func_name, None)
@@ -71,6 +88,10 @@ def get_blas_funcs(names, arrays=()):
             raise ValueError(
                 'BLAS function %s could not be found' % func_name)
         func.module_name = module_name
-        func.typecode = _inv_type_conv[prefix]
+        func.typecode = prefix
         blas_funcs.append(func)
-    return blas_funcs
+
+    if unpack:
+        return blas_funcs[0]
+    else:
+        return blas_funcs

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -22,7 +22,7 @@ from numpy import array, asarray_chkfinite, asarray, diag, zeros, ones, \
 # Local imports
 from scipy.linalg import calc_lwork
 from misc import LinAlgError, _datacopied
-from lapack import get_lapack_funcs
+from lapack import get_lapack_funcs, find_best_lapack_type
 from blas import get_blas_funcs
 
 
@@ -753,8 +753,11 @@ def hessenberg(a, calc_q=False, overwrite_a=False):
         return hq
 
     # XXX: Use ORGHR routines to compute q.
-    ger,gemm = get_blas_funcs(('ger','gemm'), (hq,hq))
-    typecode = hq.dtype.char
+    typecode = hq.dtype
+    if find_best_lapack_type((hq,))[0] in ('s', 'd'):
+        ger, gemm = get_blas_funcs(('ger','gemm'), dtype=typecode)
+    else:
+        ger, gemm = get_blas_funcs(('gerc', 'gemm'), dtype=typecode)
     q = None
     for i in range(lo, hi):
         if tau[i]==0.0:

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -22,7 +22,7 @@ from numpy import array, asarray_chkfinite, asarray, diag, zeros, ones, \
 # Local imports
 from scipy.linalg import calc_lwork
 from misc import LinAlgError, _datacopied
-from lapack import get_lapack_funcs, find_best_lapack_type
+from lapack import get_lapack_funcs
 from blas import get_blas_funcs
 
 
@@ -754,10 +754,7 @@ def hessenberg(a, calc_q=False, overwrite_a=False):
 
     # XXX: Use ORGHR routines to compute q.
     typecode = hq.dtype
-    if find_best_lapack_type((hq,))[0] in ('s', 'd'):
-        ger, gemm = get_blas_funcs(('ger','gemm'), dtype=typecode)
-    else:
-        ger, gemm = get_blas_funcs(('gerc', 'gemm'), dtype=typecode)
+    ger,gemm = get_blas_funcs(('ger','gemm'), dtype=typecode)
     q = None
     for i in range(lo, hi):
         if tau[i]==0.0:

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -753,7 +753,7 @@ def hessenberg(a, calc_q=False, overwrite_a=False):
         return hq
 
     # XXX: Use ORGHR routines to compute q.
-    ger,gemm = get_blas_funcs(('ger','gemm'), (hq,))
+    ger,gemm = get_blas_funcs(('ger','gemm'), (hq,hq))
     typecode = hq.dtype.char
     q = None
     for i in range(lo, hi):

--- a/scipy/linalg/generic_fblas2.pyf
+++ b/scipy/linalg/generic_fblas2.pyf
@@ -147,6 +147,24 @@ subroutine <tchar=c,z>geru(m,n,alpha,x,incx,y,incy,a,lda)
     integer intent(hide), depend(m) :: lda=m
 end subroutine <tchar=c,z>geru
 
+
+subroutine <tchar=c,z>ger(m,n,alpha,x,incx,y,incy,a,lda)
+! a = ger(alpha,x,y,incx=1,incy=1,a=0,overwrite_x=1,overwrite_y=1,overwrite_a=0)
+! Calculate a <- alpha*x*y^H + a
+! This is just an alias for gerc when array is complex
+    fortranname <tchar=c,z>gerc
+    integer intent(hide),depend(x) :: m = len(x)
+    integer intent(hide),depend(y) :: n = len(y)
+    <type_in> intent(in) :: alpha
+    <type_in> dimension(m),intent(in,overwrite) :: x
+    integer optional,intent(in),check(incx==1||incx==-1) :: incx = 1
+    <type_in> dimension(n),intent(in,overwrite) :: y
+    integer optional,intent(in),check(incy==1||incy==-1) :: incy = 1
+    <type_in> dimension(m,n),intent(in,out,copy),optional :: a = <type_convert=0>
+    integer intent(hide), depend(m) :: lda=m
+end subroutine <tchar=c,z>ger
+
+
 subroutine <tchar=c,z>gerc(m,n,alpha,x,incx,y,incy,a,lda)
 ! a = ger(alpha,x,y,incx=1,incy=1,a=0,overwrite_x=1,overwrite_y=1,overwrite_a=0)
 ! Calculate a <- alpha*x*y^H + a

--- a/scipy/linalg/generic_fblas2.pyf
+++ b/scipy/linalg/generic_fblas2.pyf
@@ -147,24 +147,6 @@ subroutine <tchar=c,z>geru(m,n,alpha,x,incx,y,incy,a,lda)
     integer intent(hide), depend(m) :: lda=m
 end subroutine <tchar=c,z>geru
 
-
-subroutine <tchar=c,z>ger(m,n,alpha,x,incx,y,incy,a,lda)
-! a = ger(alpha,x,y,incx=1,incy=1,a=0,overwrite_x=1,overwrite_y=1,overwrite_a=0)
-! Calculate a <- alpha*x*y^H + a
-! This is just an alias for gerc when array is complex
-    fortranname <tchar=c,z>gerc
-    integer intent(hide),depend(x) :: m = len(x)
-    integer intent(hide),depend(y) :: n = len(y)
-    <type_in> intent(in) :: alpha
-    <type_in> dimension(m),intent(in,overwrite) :: x
-    integer optional,intent(in),check(incx==1||incx==-1) :: incx = 1
-    <type_in> dimension(n),intent(in,overwrite) :: y
-    integer optional,intent(in),check(incy==1||incy==-1) :: incy = 1
-    <type_in> dimension(m,n),intent(in,out,copy),optional :: a = <type_convert=0>
-    integer intent(hide), depend(m) :: lda=m
-end subroutine <tchar=c,z>ger
-
-
 subroutine <tchar=c,z>gerc(m,n,alpha,x,incx,y,incy,a,lda)
 ! a = ger(alpha,x,y,incx=1,incy=1,a=0,overwrite_x=1,overwrite_y=1,overwrite_a=0)
 ! Calculate a <- alpha*x*y^H + a

--- a/scipy/linalg/generic_fblas2.pyf
+++ b/scipy/linalg/generic_fblas2.pyf
@@ -148,6 +148,23 @@ subroutine <tchar=c,z>geru(m,n,alpha,x,incx,y,incy,a,lda)
 end subroutine <tchar=c,z>geru
 
 
+subroutine <tchar=c,z>ger(m,n,alpha,x,incx,y,incy,a,lda)
+! a = ger(alpha,x,y,incx=1,incy=1,a=0,overwrite_x=1,overwrite_y=1,overwrite_a=0)
+! Calculate a <- alpha*x*y^H + a
+! This is just an alias for gerc when array is complex
+    fortranname <tchar=c,z>gerc
+    integer intent(hide),depend(x) :: m = len(x)
+    integer intent(hide),depend(y) :: n = len(y)
+    <type_in> intent(in) :: alpha
+    <type_in> dimension(m),intent(in,overwrite) :: x
+    integer optional,intent(in),check(incx==1||incx==-1) :: incx = 1
+    <type_in> dimension(n),intent(in,overwrite) :: y
+    integer optional,intent(in),check(incy==1||incy==-1) :: incy = 1
+    <type_in> dimension(m,n),intent(in,out,copy),optional :: a = <type_convert=0>
+    integer intent(hide), depend(m) :: lda=m
+end subroutine <tchar=c,z>ger
+
+
 subroutine <tchar=c,z>gerc(m,n,alpha,x,incx,y,incy,a,lda)
 ! a = ger(alpha,x,y,incx=1,incy=1,a=0,overwrite_x=1,overwrite_y=1,overwrite_a=0)
 ! Calculate a <- alpha*x*y^H + a

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -12,7 +12,7 @@ Run tests if scipy is installed:
 
 import math
 
-import numpy
+import numpy as np
 from numpy.testing import TestCase, run_module_suite, assert_equal, \
     assert_almost_equal, assert_array_almost_equal
     
@@ -23,8 +23,8 @@ def test_get_blas_funcs():
     # fortran-ordered
     f1, f2, f3 = get_blas_funcs(
         ('axpy', 'axpy', 'axpy'),
-        (numpy.empty((2,2), dtype=numpy.complex64, order='F'),
-         numpy.empty((2,2), dtype=numpy.complex128, order='C'))
+        (np.empty((2,2), dtype=np.complex64, order='F'),
+         np.empty((2,2), dtype=np.complex128, order='C'))
         )
 
     assert_equal(f1.typecode, 'c')
@@ -37,11 +37,10 @@ def test_get_blas_funcs():
     assert_equal(f1.typecode, 'd')
 
     # check also dtype interface
-    f1 = get_blas_funcs('gemm', dtype=numpy.complex64)
+    f1 = get_blas_funcs('gemm', dtype=np.complex64)
     assert_equal(f1.typecode, 'c')
     f1 = get_blas_funcs('gemm', dtype='F')
     assert_equal(f1.typecode, 'c')
-
 
 class TestCBLAS1Simple(TestCase):
 

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -12,10 +12,26 @@ Run tests if scipy is installed:
 
 import math
 
+import numpy
 from numpy.testing import TestCase, run_module_suite, assert_equal, \
     assert_almost_equal, assert_array_almost_equal
     
-from scipy.linalg import fblas, cblas
+from scipy.linalg import fblas, cblas, get_blas_funcs
+
+
+def test_blas_funcs_order():
+    # check that it returns Fortran code for arrays that are
+    # fortran-ordered
+    f1, f2, f3 = get_blas_funcs(
+        ('axpy', 'axpy', 'axpy'),
+        (numpy.empty((2,2), dtype=numpy.complex64, order='F'),
+         numpy.empty((2,2), dtype=numpy.complex128, order='C'))
+        )
+
+    assert_equal(f1.typecode, 'F')
+    assert_equal(f1.module_name, 'fblas')
+    assert_equal(f2.typecode, 'D')
+    assert_equal(f2.module_name, 'cblas')
 
 
 class TestCBLAS1Simple(TestCase):

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -42,8 +42,6 @@ def test_get_blas_funcs():
     f1 = get_blas_funcs('gemm', dtype='F')
     assert_equal(f1.typecode, 'c')
 
-#    assert_raises(
-
 
 class TestCBLAS1Simple(TestCase):
 

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -27,8 +27,10 @@ def test_get_blas_funcs():
          np.empty((2,2), dtype=np.complex128, order='C'))
         )
 
-    assert_equal(f1.typecode, 'c')
-    assert_equal(f1.module_name, 'fblas')
+    # get_blas_funcs will choose libraries depending on most generic
+    # array
+    assert_equal(f1.typecode, 'z')
+    assert_equal(f1.module_name, 'cblas')
     assert_equal(f2.typecode, 'z')
     assert_equal(f2.module_name, 'cblas')
 

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -18,8 +18,7 @@ from numpy.testing import TestCase, run_module_suite, assert_equal, \
     
 from scipy.linalg import fblas, cblas, get_blas_funcs
 
-
-def test_blas_funcs_order():
+def test_get_blas_funcs():
     # check that it returns Fortran code for arrays that are
     # fortran-ordered
     f1, f2, f3 = get_blas_funcs(
@@ -28,10 +27,22 @@ def test_blas_funcs_order():
          numpy.empty((2,2), dtype=numpy.complex128, order='C'))
         )
 
-    assert_equal(f1.typecode, 'F')
+    assert_equal(f1.typecode, 'c')
     assert_equal(f1.module_name, 'fblas')
-    assert_equal(f2.typecode, 'D')
+    assert_equal(f2.typecode, 'z')
     assert_equal(f2.module_name, 'cblas')
+
+    # check defaults.
+    f1 = get_blas_funcs('rotg')
+    assert_equal(f1.typecode, 'd')
+
+    # check also dtype interface
+    f1 = get_blas_funcs('gemm', dtype=numpy.complex64)
+    assert_equal(f1.typecode, 'c')
+    f1 = get_blas_funcs('gemm', dtype='F')
+    assert_equal(f1.typecode, 'c')
+
+#    assert_raises(
 
 
 class TestCBLAS1Simple(TestCase):


### PR DESCRIPTION
Make get_blas_funcs simpler, cleaner and 20% faster. Removed
unnecessary code (array 'ordering' sorting, module name splitting) and
moved gerc shortcut into generic_fblas2.pyf file, so that no checking
is necessary in the python code. This also would make it simpler and
cheaper to add other alias (like norm for complex numbers).

Other enhacements is the dtype and ordering of arrays is checked
individually, so that that arrays with different dtype/orderings can
be given, and it will return the more appropriate one (see attached
test). I think this behaviour is what most users would expect.

Also removed keyword debug (which had no impact), and added a more
comprehensible exception when BLAS function is not found.
