### PR TITLE
Changed print warning to warnings.warn in quadpack.py

### DIFF
--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -282,7 +282,8 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
             else:
                 return retval[:-1] + (msg,)
         else:
-            print "Warning: " + msg
+            from warnings import warn
+            warn(msg, Warning)
             return retval[:-1]
     else:
         raise ValueError(msg)


### PR DESCRIPTION
integrate.quadpack.quad prints a warning. I think this should be avoided.
