### PR TITLE
Use LAPACK workspace query in gelss.

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -13,6 +13,7 @@ import numpy
 from flinalg import get_flinalg_funcs
 from lapack import get_lapack_funcs
 from misc import LinAlgError, _datacopied
+from scipy.linalg import calc_lwork
 import decomp_svd
 
 

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -13,7 +13,6 @@ import numpy
 from flinalg import get_flinalg_funcs
 from lapack import get_lapack_funcs
 from misc import LinAlgError, _datacopied
-from scipy.linalg import calc_lwork
 import decomp_svd
 
 
@@ -429,10 +428,13 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False):
     overwrite_a = overwrite_a or _datacopied(a1, a)
     overwrite_b = overwrite_b or _datacopied(b1, b)
     if gelss.module_name[:7] == 'flapack':
-        lwork = calc_lwork.gelss(gelss.prefix, m, n, nrhs)[1]
-        v, x, s, rank, info = gelss(a1, b1, cond=cond, lwork=lwork,
-                                                overwrite_a=overwrite_a,
-                                                overwrite_b=overwrite_b)
+        # get optimal work array
+        work = gelss(a1, b1, lwork=-1)[4]
+        lwork = work[0].real.astype(numpy.int)
+        v, x, s, rank, work, info = gelss(
+            a1, b1, cond=cond, lwork=lwork, overwrite_a=overwrite_a,
+            overwrite_b=overwrite_b)
+
     else:
         raise NotImplementedError('calling gelss from %s' % gelss.module_name)
     if info > 0:

--- a/scipy/linalg/generic_flapack.pyf
+++ b/scipy/linalg/generic_flapack.pyf
@@ -431,7 +431,7 @@ interface
 
    subroutine <tchar=s,d>gelss(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,lwork,info)
 
-   ! v,x,s,rank,info = gelss(a,b,cond=-1.0,overwrite_a=0,overwrite_b=0)
+   ! v,x,s,rank,work,info = gelss(a,b,cond=-1.0,overwrite_a=0,overwrite_b=0)
    ! Solve Minimize 2-norm(A * X - B).
 
      callstatement (*f2py_func)(&m,&n,&nrhs,a,&m,b,&maxmn,s,&cond,&r,work,&lwork,&info)
@@ -447,23 +447,22 @@ interface
      <type_in> dimension(maxmn,nrhs),check(maxmn==shape(b,0)),depend(maxmn) :: b
      intent(in,out,copy,out=x) b
 
-     integer intent(out)::info
-
-     integer optional,intent(in),depend(nrhs,minmn,maxmn), &
-          check(lwork>=1) &
-          :: lwork=3*minmn+MAX(2*minmn,MAX(maxmn,nrhs))
-          !check(lwork>=3*minmn+MAX(2*minmn,MAX(maxmn,nrhs)))
-     <type_in> dimension(lwork),intent(hide),depend(lwork) :: work
-
      <type_in> intent(in),optional :: cond = -1.0
      integer intent(out,out=rank) :: r
      <type_in> intent(out),dimension(minmn),depend(minmn) :: s
+
+     integer optional,intent(in),depend(nrhs,minmn,maxmn),&
+          check(lwork>=1||lwork==-1) &
+          :: lwork=3*minmn+MAX(2*minmn,MAX(maxmn,nrhs))
+          !check(lwork>=3*minmn+MAX(2*minmn,MAX(maxmn,nrhs)))
+     <type_in> dimension(MAX(lwork,1)),intent(out),depend(lwork) :: work
+     integer intent(out)::info
 
    end subroutine <tchar=s,d>gelss
 
    subroutine <tchar=c,z>gelss(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,rwork,lwork,info)
 
-   ! v,x,s,rank,info = gelss(a,b,cond=-1.0,overwrite_a=0,overwrite_b=0)
+   ! v,x,s,rank,work,info = gelss(a,b,cond=-1.0,overwrite_a=0,overwrite_b=0)
    ! Solve Minimize 2-norm(A * X - B).
 
      callstatement (*f2py_func)(&m,&n,&nrhs,a,&m,b,&maxmn,s,&cond,&r,work,&lwork,rwork,&info)
@@ -479,18 +478,17 @@ interface
      <type_in> dimension(maxmn,nrhs),check(maxmn==shape(b,0)),depend(maxmn) :: b
      intent(in,out,copy,out=x) b
 
-     integer intent(out)::info
-
-     integer optional,intent(in),depend(nrhs,minmn,maxmn), &
-          check(lwork>=1) &
-          :: lwork=2*minmn+MAX(maxmn,nrhs)
-          ! check(lwork>=2*minmn+MAX(maxmn,nrhs))
-     <type_in> dimension(lwork),intent(hide),depend(lwork) :: work
-     <rtype_in> dimension(5*minmn-1),intent(hide),depend(lwork) :: rwork
-
      <rtype_in> intent(in),optional :: cond = -1.0
      integer intent(out,out=rank) :: r
      <rtype_in> intent(out),dimension(minmn),depend(minmn) :: s
+
+     integer optional,intent(in),depend(nrhs,minmn,maxmn),&
+          check(lwork>=1||lwork==-1) &
+          :: lwork=2*minmn+MAX(maxmn,nrhs)
+          ! check(lwork>=2*minmn+MAX(maxmn,nrhs))
+     <type_in> dimension(MAX(lwork,1)),intent(out),depend(lwork) :: work
+     <type_in> dimension(5*minmn-1),intent(hide),depend(lwork) :: rwork
+     integer intent(out)::info
 
    end subroutine <tchar=c,z>gelss
 


### PR DESCRIPTION
I think it is safer to use the LAPACK workspace query instead of calc_lwork when called LAPACK routines. Most of the time it's like this, but for some reason not on gelss. This should solve some problems reported to the mailing list:

http://mail.scipy.org/pipermail/scipy-dev/2011-April/016173.html

I also did some re-ordering in the pyf file for readability. This removes the dependencie of calc_lwork in linalg.basic.
