### PR TITLE
Avoid unnecesary ComplexWarning in workspace query.

### DIFF
--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -51,7 +51,7 @@ def _geneig(a1, b, left, right, overwrite_a, overwrite_b):
     if ggev.module_name[:7] == 'clapack':
         raise NotImplementedError('calling ggev from %s' % ggev.module_name)
     res = ggev(a1, b1, lwork=-1)
-    lwork = res[-2][0]
+    lwork = res[-2][0].real.astype(numpy.int)
     if ggev.prefix in 'cz':
         alpha, beta, vl, vr, work, info = ggev(a1, b1, cvl, cvr, lwork,
                                                     overwrite_a, overwrite_b)


### PR DESCRIPTION
Small fix. I already did remove some of these in b1061c53282b8e9cf8bddc1fd9f7c06e5e1820d4, I think this is the last one.
