### PR TITLE
Statsticket1421

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -360,6 +360,13 @@ docdict_discrete['frozennote'] = _doc_default_frozen_note
 docdict_discrete['example'] = _doc_default_example.replace('[0.9,]',
                                   'Replace with reasonable value')
 
+_doc_default_before_notes = ''.join([_doc_default_longsummary,
+                                     _doc_allmethods,
+                                     _doc_default_callparams,
+                                     _doc_default_frozen_note])
+
+docdict_discrete['before_notes'] = _doc_default_before_notes
+
 _doc_default_disc = ''.join([docdict_discrete['longsummary'],
                              docdict_discrete['allmethods'],
                              docdict_discrete['frozennote'],

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -682,5 +682,11 @@ def test_regression_tukey_lambda():
     assert_((p[2] != 0.0).any())
     assert_((p[2] == 0.0).any())
 
+def test_regression_ticket_1421():
+    """Regression test for ticket #1421 - correction discrete docs."""
+    assert_('pdf(x, mu, loc=0, scale=1)' not in stats.poisson.__doc__)
+    assert_('poisson.pmf(x,' in stats.poisson.__doc__)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
bugfix discrete distribution doc templates use incorrect template from the continuous distributions

Note: I didn't test this. It looks ok to commit but needs testing first.
(Otherwise this can wait until I have set up my computer for testing scipy changes, which I will need to do for any more _serious_ changes.)
