### PR TITLE
Added switches to order the eignevalues in the Schur decomposition result

### DIFF
--- a/doc/release/0.10.0-notes.rst
+++ b/doc/release/0.10.0-notes.rst
@@ -38,7 +38,12 @@ about our function's call signatures.
 New features
 ============
 
+Additional decomposition options (``scipy.linalg``)
+---------------------------------------------------
 
+A sort keyword has been added to the Schur decomposition routine 
+(``scipy.linalg.schur``) to allow the sorting of eigenvalues in
+the resultant Schur form.
 
 Deprecated features
 ===================

--- a/scipy/linalg/decomp_schur.py
+++ b/scipy/linalg/decomp_schur.py
@@ -54,6 +54,9 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None):
     Z : array, shape (M, M)
         An unitary Schur transformation matrix for A.
         It is real-valued for the real Schur decomposition.
+    sdim : integer
+        If and only if sorting was requested, a third return value will
+        contain the number of eigenvalues satisfying the sort condition.
 
     Raises
     ------
@@ -65,7 +68,7 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None):
            reordered due to a failure to separate eigenvalues, usually because
            of poor conditioning
         3. If eigenvalue sorting was requested, roundoff errors caused the
-           leading eigenvalues to satisfy the sorting condition
+           leading eigenvalues to no longer satisfy the sorting condition
 
     See also
     --------
@@ -104,9 +107,9 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None):
         elif sort == 'rhp':
             sfunction = lambda x: (x.real >= 0.0)
         elif sort == 'iuc':
-            sfunction = lambda x: (abs(x*x.conjugate()) <= 1.0)
+            sfunction = lambda x: (abs(x) <= 1.0)
         elif sort == 'ouc':
-            sfunction = lambda x: (abs(x*x.conjugate()) > 1.0)
+            sfunction = lambda x: (abs(x) > 1.0)
         else:
             raise ValueError("sort parameter must be None, a callable, or " +
                 "one of ('lhp','rhp','iuc','ouc')")
@@ -124,7 +127,11 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None):
         raise LinAlgError('Leading eigenvalues do not satisfy sort condition.')
     elif info > 0:
         raise LinAlgError("Schur form not found.  Possibly ill-conditioned.")
-    return result[0], result[-3]
+        
+    if sort_t == 0:
+        return result[0], result[-3]
+    else:
+        return result[0], result[-3], result[1]
 
 
 eps = numpy.finfo(float).eps

--- a/scipy/linalg/decomp_schur.py
+++ b/scipy/linalg/decomp_schur.py
@@ -55,6 +55,18 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None):
         An unitary Schur transformation matrix for A.
         It is real-valued for the real Schur decomposition.
 
+    Raises
+    ------
+    LinAlgError
+        Error raised under three conditions:
+        1. The algorithm failed due to a failure of the QR algorithm to 
+           compute all eigenvalues
+        2. If eigenvalue sorting was requested, the eigenvalues could not be
+           reordered due to a failure to separate eigenvalues, usually because
+           of poor conditioning
+        3. If eigenvalue sorting was requested, roundoff errors caused the
+           leading eigenvalues to satisfy the sorting condition
+
     See also
     --------
     rsf2csf : Convert real Schur form to complex Schur form

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1053,7 +1053,33 @@ class TestSchur(TestCase):
         assert_array_almost_equal(dot(dot(zc,tc),transp(conj(zc))),a)
         tc2,zc2 = rsf2csf(tc,zc)
         assert_array_almost_equal(dot(dot(zc2,tc2),transp(conj(zc2))),a)
-
+        
+    def test_sort(self):
+        a = [[4.,3.,1.,-1.],[-4.5,-3.5,-1.,1.],[9.,6.,-4.,4.5],[6.,4.,-3.,3.5]]
+        s,u = schur(a,sort='lhp')
+        assert_array_almost_equal([[0.1134,0.5436,0.8316,0.], \
+                                   [-0.1134,-0.8245,0.5544,0.], \
+                                   [-0.8213,0.1308,0.0265,-0.5547], \
+                                   [-0.5475,0.0872,0.0177,0.8321]],
+                                  u,3)
+        assert_array_almost_equal([[-1.4142,0.1456,-11.5816,-7.7174], \
+                                   [0.,-0.5000,9.4472,-0.7184], \
+                                   [0.,0.,1.4142,-0.1456], \
+                                   [0.,0.,0.,0.5]],
+                                  s,3)
+                                  
+        s,u = schur(a,sort='rhp')
+        assert_array_almost_equal([[0.4862,-0.4930,0.1434,-0.7071], \
+                                   [-0.4862,0.4930,-0.1434,-0.7071], \
+                                   [0.6042,0.3944,-0.6924,0.], \
+                                   [0.4028,0.5986,0.6924,0.]], \
+                                  u,3)
+        assert_array_almost_equal([[1.4142,-0.9270,4.5368,-14.4130], \
+                                   [0.,0.5,6.5809,-3.1870], \
+                                   [0.,0.,-1.4142,0.9270], \
+                                   [0.,0.,0.,-0.5]],
+                                  s,3)
+        
 class TestHessenberg(TestCase):
 
     def test_simple(self):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1127,27 +1127,6 @@ class TestSchur(TestCase):
         assert_raises(ValueError, schur, a, sort='unsupported')
         assert_raises(ValueError, schur, a, sort=1)
 
-        # Attempt to capture an ill-conditioned matrix that will cause an
-        # eigenvalue ordering error (cond = Inf)
-        ill_conditioned = [[0.6712, 0.3562, 0.3482, 0.8289],
-                           [0.2901, 0.0732, 0.9824, 0.4673],
-                           [0.6712, 0.3562, 0.3482, 0.8289],
-                           [0.2901, 0.0732, 0.9824, 0.4673]]
-        assert_raises(LinAlgError, schur, ill_conditioned, sort='rhp', 
-                      output='real')
-                      
-        # Test with a matrix with enormous scaling issues to attempt to cause
-        # Schur ordering to fail due to roundoff issues
-        #
-        # NOTE: This test case relies on rounding errors.  It may fail on many
-        #       platforms, and, therefore, is commented out.
-        #poorly_scaled = [[0.7365, 0.9383, 0.5741, 0.9796],
-        #                 [0.3980, 0.6419, 0.5199, 0.7424]]
-        #poorly_scaled = np.vstack((poorly_scaled,
-        #                           (-1.0E+32)*np.asarray(poorly_scaled)))
-        #assert_raises(LinAlgError, schur, poorly_scaled, sort='rhp', 
-        #              output='real')
-        
 class TestHessenberg(TestCase):
 
     def test_simple(self):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -20,7 +20,7 @@ from numpy.testing import TestCase, assert_equal, assert_array_almost_equal, \
 
 from scipy.linalg import eig, eigvals, lu, svd, svdvals, cholesky, qr, \
      schur, rsf2csf, lu_solve, lu_factor, solve, diagsvd, hessenberg, rq, \
-     eig_banded, eigvals_banded, eigh, eigvalsh
+     eig_banded, eigvals_banded, eigh, eigvalsh, LinAlgError
 from scipy.linalg.flapack import dgbtrf, dgbtrs, zgbtrf, zgbtrs, \
      dsbev, dsbevd, dsbevx, zhbevd, zhbevx
 
@@ -1057,28 +1057,88 @@ class TestSchur(TestCase):
     def test_sort(self):
         a = [[4.,3.,1.,-1.],[-4.5,-3.5,-1.,1.],[9.,6.,-4.,4.5],[6.,4.,-3.,3.5]]
         s,u = schur(a,sort='lhp')
-        assert_array_almost_equal([[0.1134,0.5436,0.8316,0.], \
-                                   [-0.1134,-0.8245,0.5544,0.], \
-                                   [-0.8213,0.1308,0.0265,-0.5547], \
+        assert_array_almost_equal([[0.1134,0.5436,0.8316,0.], 
+                                   [-0.1134,-0.8245,0.5544,0.], 
+                                   [-0.8213,0.1308,0.0265,-0.5547], 
                                    [-0.5475,0.0872,0.0177,0.8321]],
                                   u,3)
-        assert_array_almost_equal([[-1.4142,0.1456,-11.5816,-7.7174], \
-                                   [0.,-0.5000,9.4472,-0.7184], \
-                                   [0.,0.,1.4142,-0.1456], \
+        assert_array_almost_equal([[-1.4142,0.1456,-11.5816,-7.7174], 
+                                   [0.,-0.5000,9.4472,-0.7184], 
+                                   [0.,0.,1.4142,-0.1456], 
                                    [0.,0.,0.,0.5]],
                                   s,3)
                                   
         s,u = schur(a,sort='rhp')
-        assert_array_almost_equal([[0.4862,-0.4930,0.1434,-0.7071], \
-                                   [-0.4862,0.4930,-0.1434,-0.7071], \
-                                   [0.6042,0.3944,-0.6924,0.], \
-                                   [0.4028,0.5986,0.6924,0.]], \
+        assert_array_almost_equal([[0.4862,-0.4930,0.1434,-0.7071],
+                                   [-0.4862,0.4930,-0.1434,-0.7071],
+                                   [0.6042,0.3944,-0.6924,0.],
+                                   [0.4028,0.5986,0.6924,0.]],
                                   u,3)
-        assert_array_almost_equal([[1.4142,-0.9270,4.5368,-14.4130], \
-                                   [0.,0.5,6.5809,-3.1870], \
-                                   [0.,0.,-1.4142,0.9270], \
+        assert_array_almost_equal([[1.4142,-0.9270,4.5368,-14.4130],
+                                   [0.,0.5,6.5809,-3.1870],
+                                   [0.,0.,-1.4142,0.9270],
                                    [0.,0.,0.,-0.5]],
                                   s,3)
+                                  
+        s,u = schur(a,sort='iuc')
+        assert_array_almost_equal([[0.5547,0.,-0.5721,-0.6042],
+                                   [-0.8321,0.,-0.3814,-0.4028],
+                                   [0.,0.7071,-0.5134,0.4862],
+                                   [0.,0.7071,0.5134,-0.4862]],
+                                  u,3)
+        assert_array_almost_equal([[-0.5000,0.0000,-6.5809,-4.0974],
+                                   [0.,0.5000,-3.3191,-14.4130],
+                                   [0.,0.,1.4142,2.1573],
+                                   [0.,0.,0.,-1.4142]],
+                                  s,3)
+                                  
+        s,u = schur(a,sort='ouc')
+        assert_array_almost_equal([[0.4862,-0.5134,0.7071,0.],
+                                   [-0.4862,0.5134,0.7071,0.],
+                                   [0.6042,0.5721,0.,-0.5547],
+                                   [0.4028,0.3814,0.,0.8321]],
+                                  u,3)
+        assert_array_almost_equal([[1.4142,-2.1573,14.4130,4.0974],
+                                   [0.,-1.4142,3.3191,6.5809],
+                                   [0.,0.,-0.5000,0.],
+                                   [0.,0.,0.,0.5000]],
+                                  s,3)
+                                  
+        rhp_function = lambda x: x >= 0.0
+        s,u = schur(a,sort=rhp_function)
+        assert_array_almost_equal([[0.4862,-0.4930,0.1434,-0.7071],
+                                   [-0.4862,0.4930,-0.1434,-0.7071],
+                                   [0.6042,0.3944,-0.6924,0.],
+                                   [0.4028,0.5986,0.6924,0.]],
+                                  u,3)
+        assert_array_almost_equal([[1.4142,-0.9270,4.5368,-14.4130],
+                                   [0.,0.5,6.5809,-3.1870],
+                                   [0.,0.,-1.4142,0.9270],
+                                   [0.,0.,0.,-0.5]],
+                                  s,3)
+                                  
+    def test_sort_errors(self):
+        a = [[4.,3.,1.,-1.],[-4.5,-3.5,-1.,1.],[9.,6.,-4.,4.5],[6.,4.,-3.,3.5]]
+        assert_raises(ValueError, schur, a, sort='unsupported')
+        assert_raises(ValueError, schur, a, sort=1)
+
+        # Attempt to capture an ill-conditioned matrix that will cause an
+        # eigenvalue ordering error (cond = Inf)
+        ill_conditioned = [[0.6712, 0.3562, 0.3482, 0.8289],
+                           [0.2901, 0.0732, 0.9824, 0.4673],
+                           [0.6712, 0.3562, 0.3482, 0.8289],
+                           [0.2901, 0.0732, 0.9824, 0.4673]]
+        assert_raises(LinAlgError, schur, ill_conditioned, sort='rhp', 
+                      output='real')
+                      
+        # Test with a matrix with enormous scaling issues to attempt to cause
+        # Schur ordering to fail due to roundoff issues
+        poorly_scaled = [[0.7365, 0.9383, 0.5741, 0.9796],
+                         [0.3980, 0.6419, 0.5199, 0.7424]]
+        poorly_scaled = np.vstack((poorly_scaled,
+                                   (-1.0E+32)*np.asarray(poorly_scaled)))
+        assert_raises(LinAlgError, schur, poorly_scaled, sort='rhp', 
+                      output='real')
         
 class TestHessenberg(TestCase):
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1056,7 +1056,7 @@ class TestSchur(TestCase):
         
     def test_sort(self):
         a = [[4.,3.,1.,-1.],[-4.5,-3.5,-1.,1.],[9.,6.,-4.,4.5],[6.,4.,-3.,3.5]]
-        s,u = schur(a,sort='lhp')
+        s,u,sdim = schur(a,sort='lhp')
         assert_array_almost_equal([[0.1134,0.5436,0.8316,0.], 
                                    [-0.1134,-0.8245,0.5544,0.], 
                                    [-0.8213,0.1308,0.0265,-0.5547], 
@@ -1067,8 +1067,9 @@ class TestSchur(TestCase):
                                    [0.,0.,1.4142,-0.1456], 
                                    [0.,0.,0.,0.5]],
                                   s,3)
+        assert_equal(2,sdim)
                                   
-        s,u = schur(a,sort='rhp')
+        s,u,sdim = schur(a,sort='rhp')
         assert_array_almost_equal([[0.4862,-0.4930,0.1434,-0.7071],
                                    [-0.4862,0.4930,-0.1434,-0.7071],
                                    [0.6042,0.3944,-0.6924,0.],
@@ -1079,8 +1080,9 @@ class TestSchur(TestCase):
                                    [0.,0.,-1.4142,0.9270],
                                    [0.,0.,0.,-0.5]],
                                   s,3)
+        assert_equal(2,sdim)
                                   
-        s,u = schur(a,sort='iuc')
+        s,u,sdim = schur(a,sort='iuc')
         assert_array_almost_equal([[0.5547,0.,-0.5721,-0.6042],
                                    [-0.8321,0.,-0.3814,-0.4028],
                                    [0.,0.7071,-0.5134,0.4862],
@@ -1091,8 +1093,9 @@ class TestSchur(TestCase):
                                    [0.,0.,1.4142,2.1573],
                                    [0.,0.,0.,-1.4142]],
                                   s,3)
+        assert_equal(2,sdim)
                                   
-        s,u = schur(a,sort='ouc')
+        s,u,sdim = schur(a,sort='ouc')
         assert_array_almost_equal([[0.4862,-0.5134,0.7071,0.],
                                    [-0.4862,0.5134,0.7071,0.],
                                    [0.6042,0.5721,0.,-0.5547],
@@ -1103,9 +1106,10 @@ class TestSchur(TestCase):
                                    [0.,0.,-0.5000,0.],
                                    [0.,0.,0.,0.5000]],
                                   s,3)
+        assert_equal(2,sdim)
                                   
         rhp_function = lambda x: x >= 0.0
-        s,u = schur(a,sort=rhp_function)
+        s,u,sdim = schur(a,sort=rhp_function)
         assert_array_almost_equal([[0.4862,-0.4930,0.1434,-0.7071],
                                    [-0.4862,0.4930,-0.1434,-0.7071],
                                    [0.6042,0.3944,-0.6924,0.],
@@ -1116,6 +1120,7 @@ class TestSchur(TestCase):
                                    [0.,0.,-1.4142,0.9270],
                                    [0.,0.,0.,-0.5]],
                                   s,3)
+        assert_equal(2,sdim)
                                   
     def test_sort_errors(self):
         a = [[4.,3.,1.,-1.],[-4.5,-3.5,-1.,1.],[9.,6.,-4.,4.5],[6.,4.,-3.,3.5]]
@@ -1133,12 +1138,15 @@ class TestSchur(TestCase):
                       
         # Test with a matrix with enormous scaling issues to attempt to cause
         # Schur ordering to fail due to roundoff issues
-        poorly_scaled = [[0.7365, 0.9383, 0.5741, 0.9796],
-                         [0.3980, 0.6419, 0.5199, 0.7424]]
-        poorly_scaled = np.vstack((poorly_scaled,
-                                   (-1.0E+32)*np.asarray(poorly_scaled)))
-        assert_raises(LinAlgError, schur, poorly_scaled, sort='rhp', 
-                      output='real')
+        #
+        # NOTE: This test case relies on rounding errors.  It may fail on many
+        #       platforms, and, therefore, is commented out.
+        #poorly_scaled = [[0.7365, 0.9383, 0.5741, 0.9796],
+        #                 [0.3980, 0.6419, 0.5199, 0.7424]]
+        #poorly_scaled = np.vstack((poorly_scaled,
+        #                           (-1.0E+32)*np.asarray(poorly_scaled)))
+        #assert_raises(LinAlgError, schur, poorly_scaled, sort='rhp', 
+        #              output='real')
         
 class TestHessenberg(TestCase):
 


### PR DESCRIPTION
This modification allows for ordering the eigenvalues in the result of a Schur decomposition in two ways.  Specifically, the modification allows the eigenvalues in the upper left block of the decomposition result to lie in either the left-hand plane (real(lambda_i) < 0) or the right-hand plane (real(lambda_i) > 0).  The sorting is supported and handled by the underlying LAPACK *GEES call.  This functionality is relatively common and necessary in some cases (e.g. solving the Sylvester equation).
