### PR TITLE
Adding generalized and shift-invert support for ARPACK wrapper

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/ARPACK/SRC/dnaup2.f
+++ b/scipy/sparse/linalg/eigen/arpack/ARPACK/SRC/dnaup2.f
@@ -664,6 +664,18 @@ c
             else if (nev .eq. 1 .and. kplusp .gt. 3) then
                nev = 2
             end if
+
+c           %---- Scipy fix ------------------------------------------------
+c           | We must keep nev below this value, as otherwise we can get
+c           | np == 0 (note that dngets below can bump nev by 1). If np == 0,
+c           | the next call to `dnaitr` will write out-of-bounds.
+c           |
+            if (nev .gt. kplusp - 2) then
+               nev = kplusp - 2
+            end if
+c           |
+c           %---- Scipy fix end --------------------------------------------
+
             np = kplusp - nev
 c     
 c           %---------------------------------------%

--- a/scipy/sparse/linalg/eigen/arpack/ARPACK/SRC/snaup2.f
+++ b/scipy/sparse/linalg/eigen/arpack/ARPACK/SRC/snaup2.f
@@ -664,6 +664,18 @@ c
             else if (nev .eq. 1 .and. kplusp .gt. 3) then
                nev = 2
             end if
+
+c           %---- Scipy fix ------------------------------------------------
+c           | We must keep nev below this value, as otherwise we can get
+c           | np == 0 (note that dngets below can bump nev by 1). If np == 0,
+c           | the next call to `dnaitr` will write out-of-bounds.
+c           |
+            if (nev .gt. kplusp - 2) then
+               nev = kplusp - 2
+            end if
+c           |
+c           %---- Scipy fix end --------------------------------------------
+
             np = kplusp - nev
 c     
 c           %---------------------------------------%

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -35,7 +35,6 @@ Uses ARPACK: http://www.caam.rice.edu/software/ARPACK/
 # ------------
 # ARPACK and handle shifted and shift-inverse computations
 # for eigenvalues by providing a shift (sigma) and a solver.
-# This is currently not implemented
 
 __docformat__ = "restructuredtext en"
 
@@ -44,13 +43,52 @@ __all___=['eigs', 'eigsh', 'svds', 'ArpackNoConvergence']
 import _arpack
 import numpy as np
 from scipy.sparse.linalg.interface import aslinearoperator, LinearOperator
-from scipy.sparse import csc_matrix, csr_matrix, isspmatrix
+from scipy.sparse import identity, csc_matrix, csr_matrix, isspmatrix, isspmatrix_csr
 from scipy.linalg import lu_factor, lu_solve
+from scipy.sparse.sputils import isdense
+from scipy.sparse.linalg import cg, cgs, minres, gmres, factorized
 
 _type_conv = {'f':'s', 'd':'d', 'F':'c', 'D':'z'}
 _ndigits = {'f':5, 'd':12, 'F':5, 'D':12}
 
-_NAUPD_ERRORS = {
+DNAUPD_ERRORS = {
+    0: "Normal exit.",
+    1: "Maximum number of iterations taken. "
+       "All possible eigenvalues of OP has been found. IPARAM(5) "
+       "returns the number of wanted converged Ritz values.",
+    2: "No longer an informational error. Deprecated starting "
+       "with release 2 of ARPACK.",
+    3: "No shifts could be applied during a cycle of the "
+       "Implicitly restarted Arnoldi iteration. One possibility "
+       "is to increase the size of NCV relative to NEV. ",
+    -1: "N must be positive.",
+    -2: "NEV must be positive.",
+    -3: "NCV-NEV >= 2 and less than or equal to N.",
+    -4: "The maximum number of Arnoldi update iterations allowed "
+        "must be greater than zero.",
+    -5: " WHICH must be one of 'LM', 'SM', 'LR', 'SR', 'LI', 'SI'",
+    -6: "BMAT must be one of 'I' or 'G'.",
+    -7: "Length of private work array WORKL is not sufficient.",
+    -8: "Error return from LAPACK eigenvalue calculation;",
+    -9: "Starting vector is zero.",
+    -10: "IPARAM(7) must be 1,2,3,4.",
+    -11: "IPARAM(7) = 1 and BMAT = 'G' are incompatable.",
+    -12: "IPARAM(1) must be equal to 0 or 1.",
+    -13: "NEV and WHICH = 'BE' are incompatable.",
+    -9999: "Could not build an Arnoldi factorization. "
+           "IPARAM(5) returns the size of the current Arnoldi "
+           "factorization. The user is advised to check that "
+           "enough workspace and array storage has been allocated."
+}
+
+SNAUPD_ERRORS = DNAUPD_ERRORS
+
+ZNAUPD_ERRORS = DNAUPD_ERRORS.copy()
+ZNAUPD_ERRORS[-10] = "IPARAM(7) must be 1,2,3."
+
+CNAUPD_ERRORS = ZNAUPD_ERRORS
+
+DSAUPD_ERRORS = {
     0: "Normal exit.",
     1: "Maximum number of iterations taken. "
        "All possible eigenvalues of OP has been found.",
@@ -80,7 +118,9 @@ _NAUPD_ERRORS = {
            "enough workspace and array storage has been allocated.",
 }
 
-_NEUPD_ERRORS = {
+SSAUPD_ERRORS = DSAUPD_ERRORS
+
+DNEUPD_ERRORS = {
     0: "Normal exit.",
     1: "The Schur form computed by LAPACK routine dlahqr "
        "could not be reordered by LAPACK routine dtrsen. "
@@ -113,7 +153,65 @@ _NEUPD_ERRORS = {
          "DNEUPD",
 }
 
-_SEUPD_ERRORS = {
+SNEUPD_ERRORS = DNEUPD_ERRORS.copy()
+SNEUPD_ERRORS[1] = ("The Schur form computed by LAPACK routine slahqr "
+                    "could not be reordered by LAPACK routine strsen . "
+                    "Re-enter subroutine dneupd  with IPARAM(5)=NCV and "
+                    "increase the size of the arrays DR and DI to have "
+                    "dimension at least dimension NCV and allocate at least "
+                    "NCV columns for Z. NOTE: Not necessary if Z and V share "
+                    "the same space. Please notify the authors if this error "
+                    "occurs.")
+SNEUPD_ERRORS[-14] = ("SNAUPD did not find any eigenvalues to sufficient "
+                      "accuracy.")
+SNEUPD_ERRORS[-15] = ("SNEUPD got a different count of the number of converged "
+                      "Ritz values than SNAUPD got.  This indicates the user "
+                      "probably made an error in passing data from SNAUPD to "
+                      "SNEUPD or that the data was modified before entering "
+                      "SNEUPD")
+
+ZNEUPD_ERRORS = {0: "Normal exit.",
+                 1: "The Schur form computed by LAPACK routine csheqr "
+                    "could not be reordered by LAPACK routine ztrsen. "
+                    "Re-enter subroutine zneupd with IPARAM(5)=NCV and "
+                    "increase the size of the array D to have "
+                    "dimension at least dimension NCV and allocate at least "
+                    "NCV columns for Z. NOTE: Not necessary if Z and V share "
+                    "the same space. Please notify the authors if this error "
+                    "occurs.",
+                 -1: "N must be positive.",
+                 -2: "NEV must be positive.",
+                 -3: "NCV-NEV >= 1 and less than or equal to N.",
+                 -5: "WHICH must be one of 'LM', 'SM', 'LR', 'SR', 'LI', 'SI'",
+                 -6: "BMAT must be one of 'I' or 'G'.",
+                 -7: "Length of private work WORKL array is not sufficient.",
+                 -8: "Error return from LAPACK eigenvalue calculation. "
+                     "This should never happened.",
+                 -9: "Error return from calculation of eigenvectors. "
+                     "Informational error from LAPACK routine ztrevc.",
+                 -10: "IPARAM(7) must be 1,2,3",
+                 -11: "IPARAM(7) = 1 and BMAT = 'G' are incompatible.",
+                 -12: "HOWMNY = 'S' not yet implemented",
+                 -13: "HOWMNY must be one of 'A' or 'P' if RVEC = .true.",
+                 -14: "ZNAUPD did not find any eigenvalues to sufficient "
+                      "accuracy.",
+                 -15: "ZNEUPD got a different count of the number of converged "
+                      "Ritz values than ZNAUPD got.  This indicates the user "
+                      "probably made an error in passing data from ZNAUPD to "
+                      "ZNEUPD or that the data was modified before entering "
+                      "ZNEUPD"
+}
+
+CNEUPD_ERRORS = ZNEUPD_ERRORS.copy()
+CNEUPD_ERRORS[-14] = ("CNAUPD did not find any eigenvalues to sufficient "
+                      "accuracy.")
+CNEUPD_ERRORS[-15] = ("CNEUPD got a different count of the number of converged "
+                      "Ritz values than CNAUPD got.  This indicates the user "
+                      "probably made an error in passing data from CNAUPD to "
+                      "CNEUPD or that the data was modified before entering "
+                      "CNEUPD")
+
+DSEUPD_ERRORS = {
     0: "Normal exit.",
     -1: "N must be positive.",
     -2: "NEV must be positive.",
@@ -136,6 +234,29 @@ _SEUPD_ERRORS = {
           "DSEUPD  or that the data was modified before entering  "
           "DSEUPD.")
 }
+
+SSEUPD_ERRORS = DSEUPD_ERRORS.copy()
+SSEUPD_ERRORS[-14] = ("SSAUPD  did not find any eigenvalues "
+                      "to sufficient accuracy.")
+SSEUPD_ERRORS[-17] = ("SSEUPD  got a different count of the number of "
+                      "converged "
+                      "Ritz values than SSAUPD  got.  This indicates the user "
+                      "probably made an error in passing data from SSAUPD  to "
+                      "SSEUPD  or that the data was modified before entering  "
+                      "SSEUPD.")
+
+_SAUPD_ERRORS = {'d': DSAUPD_ERRORS,
+                 's': SSAUPD_ERRORS}
+_NAUPD_ERRORS = {'d': DNAUPD_ERRORS,
+                 's': SNAUPD_ERRORS,
+                 'z': ZNAUPD_ERRORS,
+                 'c': CNAUPD_ERRORS}
+_SEUPD_ERRORS = {'d': DSEUPD_ERRORS,
+                 's': SSEUPD_ERRORS}
+_NEUPD_ERRORS = {'d': DNEUPD_ERRORS,
+                 's': SNEUPD_ERRORS,
+                 'z': ZNEUPD_ERRORS,
+                 'c': CNEUPD_ERRORS}
 
 # accepted values of parameter WHICH in _SEUPD
 _SEUPD_WHICH = ['LM', 'SM', 'LA', 'SA', 'BE']
@@ -191,8 +312,11 @@ class _ArpackParams(object):
             self.resid = np.zeros(n, tp)
             info = 0
 
-        if sigma is not None:
-            raise NotImplementedError("shifted eigenproblem not supported yet")
+        if sigma is None:
+            #sigma not used
+            self.sigma = 0
+        else:
+            self.sigma = sigma
 
         if ncv is None:
             ncv = 2 * k + 1
@@ -266,8 +390,8 @@ class _SymmetricArpackParams(_ArpackParams):
         #    Arguments should be
         #       matvec      = None [not used]
         #       M_matvec    = left multiplication by M
+        #                     or None, if M is the identity
         #       Minv_matvec = left multiplication by [A-sigma*M]^-1
-        
         if mode==1:
             if matvec is None:
                 raise ValueError("matvec must be specified for mode=1")
@@ -283,7 +407,6 @@ class _SymmetricArpackParams(_ArpackParams):
             self.OP   = matvec
             self.B    = lambda x: x
             self.bmat = 'I'
-
         elif mode==2:
             if matvec is None:
                 raise ValueError("matvec must be specified for mode=2")
@@ -297,19 +420,22 @@ class _SymmetricArpackParams(_ArpackParams):
             self.OPb  = matvec
             self.B    = M_matvec
             self.bmat = 'G'
-
         elif mode==3:
             if matvec is not None:
                 raise ValueError("matvec must not be specified for mode=3")
-            if M_matvec is None:
-                raise ValueError("M_matvec must be specified for mode=3")
             if Minv_matvec is None:
                 raise ValueError("Minv_matvec must be specified for mode=3")
-
-            self.OP   = lambda x: Minv_matvec(M_matvec(x))
-            self.OPa  = Minv_matvec
-            self.B    = M_matvec
-            self.bmat = 'G'
+            
+            if M_matvec is None:
+                self.OP = Minv_matvec
+                self.OPa = Minv_matvec
+                self.B = lambda x: x
+                self.bmat = 'I'
+            else:
+                self.OP   = lambda x: Minv_matvec(M_matvec(x))
+                self.OPa  = Minv_matvec
+                self.B    = M_matvec
+                self.bmat = 'G'
         else:
             raise ValueError("mode=%i not implemented" % mode)
         
@@ -330,8 +456,12 @@ class _SymmetricArpackParams(_ArpackParams):
         ltr = _type_conv[self.tp]
         if ltr not in ["s", "d"]:
             raise ValueError("Input matrix is not real-valued.")
+
         self._arpack_solver = _arpack.__dict__[ltr + 'saupd']
         self._arpack_extract = _arpack.__dict__[ltr + 'seupd']
+
+        self.iterate_infodict = _SAUPD_ERRORS[ltr]
+        self.extract_infodict = _SEUPD_ERRORS[ltr]
 
         self.ipntr = np.zeros(11, "int")
 
@@ -354,7 +484,7 @@ class _SymmetricArpackParams(_ArpackParams):
                 self.workd[xslice] = self.OPb(self.workd[xslice])
                 self.workd[yslice] = self.OPa(self.workd[xslice])
             else:
-                Bxslice = slice(self.ipntr[2]-1, self.ipntr[2]-1+n)
+                Bxslice = slice(self.ipntr[2]-1, self.ipntr[2]-1+self.n)
                 self.workd[yslice] = self.OPa(self.workd[Bxslice])
         elif self.ido == 2:
             self.workd[yslice] = self.B(self.workd[xslice])
@@ -368,22 +498,23 @@ class _SymmetricArpackParams(_ArpackParams):
             elif self.info == 1:
                 self._raise_no_convergence()
             else:
-                raise ArpackError(self.info)
+                raise ArpackError(self.info, infodict=self.iterate_infodict)
 
     def extract(self, return_eigenvectors):
         rvec = return_eigenvectors
         ierr = 0
         howmny = 'A' # return all eigenvectors
         sselect = np.zeros(self.ncv, 'int') # unused
-        sigma = 0.0 # no shifts, not implemented
-
-        d, z, ierr = self._arpack_extract(rvec, howmny, sselect, sigma, self.bmat,
-                self.which, self.k, self.tol, self.resid, self.v,
-                self.iparam[0:7], self.ipntr, self.workd[0:2*self.n],
-                self.workl,ierr)
+        
+        d, z, ierr = self._arpack_extract(rvec, howmny, sselect, self.sigma, 
+                                          self.bmat, self.which, self.k, 
+                                          self.tol, self.resid, self.v,
+                                          self.iparam[0:7], self.ipntr, 
+                                          self.workd[0:2*self.n],
+                                          self.workl, ierr)
 
         if ierr != 0:
-            raise ArpackError(ierr, infodict=_SEUPD_ERRORS)
+            raise ArpackError(ierr, infodict=self.extract_infodict)
 
         k_ok = self.iparam[4]
         d = d[:k_ok]
@@ -402,10 +533,35 @@ class _UnsymmetricArpackParams(_ArpackParams):
         #  mode = 1:
         #    Solve the standard eigenvalue problem:
         #      A*x = lambda*x
+        #       A - square matrix
         #    Arguments should be   
         #       matvec      = left multiplication by A
         #       M_matvec    = None [not used]
         #       Minv_matvec = None [not used]
+        #
+        #  mode = 2:
+        #    Solve the generalized eigenvalue problem:
+        #      A*x = lambda*M*x
+        #       A - square matrix
+        #       M - symmetric, positive semi-definite
+        #    Arguments should be   
+        #       matvec      = left multiplication by A
+        #       M_matvec    = left multiplication by M
+        #       Minv_matvec = left multiplication by M^-1
+        #
+        #  mode = 3,4:
+        #    Solve the general eigenvalue problem in shift-invert mode:
+        #      A*x = lambda*M*x
+        #       A - square matrix
+        #       M - symmetric, positive semi-definite
+        #    Arguments should be
+        #       matvec      = None [not used]
+        #       M_matvec    = left multiplication by M
+        #                     or None, if M is the identity
+        #       Minv_matvec = left multiplication by [A-sigma*M]^-1
+        #    if A is real and mode==3, use the real part of Minv_matvec
+        #    if A is real and mode==4, use the imag part of Minv_matvec
+        #    if A is complex and mode==3, use real and imag parts of Minv_matvec
         if mode==1:
             if matvec is None:
                 raise ValueError("matvec must be specified for mode=1")
@@ -421,7 +577,6 @@ class _UnsymmetricArpackParams(_ArpackParams):
             self.OP   = matvec
             self.B    = lambda x: x
             self.bmat = 'I'
-
         elif mode==2:
             if matvec is None:
                 raise ValueError("matvec must be specified for mode=2")
@@ -434,10 +589,36 @@ class _UnsymmetricArpackParams(_ArpackParams):
             self.OPa  = Minv_matvec
             self.OPb  = matvec
             self.B    = M_matvec
-            self.bmat = 'G'
-        
+            self.bmat = 'G'        
+        elif mode in (3,4):
+            if matvec is not None:
+                raise ValueError("matvec must not be specified "
+                                 "for mode in (3,4)")
+            if Minv_matvec is None:
+                raise ValueError("Minv_matvec must be specified "
+                                 "for mode in (3,4)")
+
+            if tp in 'DF': #complex type
+                if mode==3:
+                    self.OPa = Minv_matvec
+                else:
+                    raise ValueError("mode=4 invalid for complex A")
+            else:
+                if mode==3:
+                    self.OPa = lambda x: np.real(Minv_matvec(x))
+                else:
+                    self.OPa = lambda x: np.imag(Minv_matvec(x))
+            if M_matvec is None:
+                self.B = lambda x: x
+                self.bmat = 'I'
+                self.OP = self.OPa
+            else:
+                self.B = M_matvec
+                self.bmat = 'G'
+                self.OP = lambda x: self.OPa(M_matvec(x))
         else:
             raise ValueError("mode=%i not implemented" % mode)
+        
         if which not in _NEUPD_WHICH:
             raise ValueError("Parameter which must be one of %s" % ' '.join(_NEUPD_WHICH))
         if k >= n-1:
@@ -457,6 +638,9 @@ class _UnsymmetricArpackParams(_ArpackParams):
         self._arpack_solver = _arpack.__dict__[ltr + 'naupd']
         self._arpack_extract = _arpack.__dict__[ltr + 'neupd']
 
+        self.iterate_infodict = _NAUPD_ERRORS[ltr]
+        self.extract_infodict = _NEUPD_ERRORS[ltr]
+
         self.ipntr = np.zeros(14, "int")
 
         if self.tp in 'FD':
@@ -465,6 +649,7 @@ class _UnsymmetricArpackParams(_ArpackParams):
             self.rwork = None
 
     def iterate(self):
+        #print "resid:",self.resid
         if self.tp in 'fd':
             self.ido, self.resid, self.v, self.iparam, self.ipntr, self.info = \
                 self._arpack_solver(self.ido, self.bmat, self.which, self.k, 
@@ -473,9 +658,11 @@ class _UnsymmetricArpackParams(_ArpackParams):
                                     self.info)
         else:
             self.ido, self.resid, self.v, self.iparam, self.ipntr, self.info =\
-                self._arpack_solver(self.ido, self.bmat, self.which, self.k, self.tol,
-                        self.resid, self.v, self.iparam, self.ipntr,
-                        self.workd, self.workl, self.rwork, self.info)
+                self._arpack_solver(self.ido, self.bmat, self.which, self.k, 
+                                    self.tol, self.resid, self.v, self.iparam, 
+                                    self.ipntr, self.workd, self.workl, 
+                                    self.rwork, self.info)
+        #print "   ",self.resid,self.ido
 
         xslice = slice(self.ipntr[0]-1, self.ipntr[0]-1+self.n)
         yslice = slice(self.ipntr[1]-1, self.ipntr[1]-1+self.n)
@@ -486,11 +673,8 @@ class _UnsymmetricArpackParams(_ArpackParams):
             # compute y = Op*x
             if self.mode in (1,2):
                 self.workd[yslice] = self.OP(self.workd[xslice])
-            #elif self.mode==2:
-            #    self.workd[xslice] = self.OPb(self.workd[xslice])
-            #    self.workd[yslice] = self.OPa(self.workd[xslice])
             else:
-                Bxslice = slice(self.ipntr[2]-1, self.ipntr[2]-1+n)
+                Bxslice = slice(self.ipntr[2]-1, self.ipntr[2]-1+self.n)
                 self.workd[yslice] = self.OPa(self.workd[Bxslice])
         elif self.ido == 2:
             self.workd[yslice] = self.B(self.workd[xslice])
@@ -504,7 +688,7 @@ class _UnsymmetricArpackParams(_ArpackParams):
             elif self.info == 1:
                 self._raise_no_convergence()
             else:
-                raise ArpackError(self.info)
+                raise ArpackError(self.info, infodict=self.iterate_infodict)
 
     def extract(self, return_eigenvectors):
         k, n = self.k, self.n
@@ -512,8 +696,8 @@ class _UnsymmetricArpackParams(_ArpackParams):
         ierr = 0
         howmny = 'A' # return all eigenvectors
         sselect = np.zeros(self.ncv, 'int') # unused
-        sigmai = 0.0 # no shifts, not implemented
-        sigmar = 0.0 # no shifts, not implemented
+        sigmar = np.real(self.sigma)
+        sigmai = np.imag(self.sigma)
         workev = np.zeros(3 * self.ncv, self.tp)
 
         if self.tp in 'fd':
@@ -528,7 +712,7 @@ class _UnsymmetricArpackParams(_ArpackParams):
                        self.workd, self.workl, self.info)
 
             if ierr != 0:
-                raise ArpackError(ierr, infodict=_NEUPD_ERRORS)
+                raise ArpackError(ierr, infodict=self.extract_infodict)
 
             # The ARPACK nonsymmetric real and double interface (s,d)naupd
             # return eigenvalues and eigenvectors in real (float,double) arrays.
@@ -539,20 +723,28 @@ class _UnsymmetricArpackParams(_ArpackParams):
             # Arrange the eigenvectors: complex eigenvectors are stored as
             # real,imaginary in consecutive columns
             z = zr.astype(self.tp.upper())
+            nreturned = self.iparam[4] # number of good eigenvalues returned
             i = 0
+
             while i<=k:
                 # check if complex
                 if abs(d[i].imag) != 0:
                     # this is a complex conjugate pair with eigenvalues
                     # in consecutive columns
-                    z[:,i] = zr[:,i] + 1.0j * zr[:,i+1]
-                    z[:,i+1] = z[:,i].conjugate()
-                    i +=1
+                    if i<k:
+                        z[:,i] = zr[:,i] + 1.0j * zr[:,i+1]
+                        z[:,i+1] = z[:,i].conjugate()
+                        i +=1
+                    else:
+                        #last eigenvalue is complex: the imaginary part of
+                        # the eigenvector has not been returned
+                        #this can only happen if nreturned > k, so we'll
+                        # throw out this case.
+                        nreturned-=1
                 i += 1
 
             # Now we have k+1 possible eigenvalues and eigenvectors
             # Return the ones specified by the keyword "which"
-            nreturned = self.iparam[4] # number of good eigenvalues returned
             if nreturned <= k:
                 # we got less or equal as many eigenvalues we wanted
                 d = d[:nreturned]
@@ -586,7 +778,7 @@ class _UnsymmetricArpackParams(_ArpackParams):
                            self.workd, self.workl, self.rwork, ierr)
 
             if ierr != 0:
-                raise ArpackError(ierr, infodict=_NEUPD_ERRORS)
+                raise ArpackError(ierr, infodict=self.extract_infodict)
 
             k_ok = self.iparam[4]
             d = d[:k_ok]
@@ -614,14 +806,122 @@ class LU_inv(LinearOperator):
     """
     def __init__(self,M):
         self.M_lu = lu_factor(M)
-        LinearOperator.__init__(self, M.shape, self._matvec)
+        if hasattr(M,'dtype'):
+            dtype = M.dtype
+        else:
+            x = np.zeros(M.shape[1])
+            dtype = (M*x).dtype
+        LinearOperator.__init__(self, M.shape, self._matvec, dtype=dtype)
     def _matvec(self,x):
         return lu_solve(self.M_lu,x)
 
+class iter_inv(LinearOperator):
+    """
+    iter_inv:
+       helper class to repeatedly solve M*x=b
+       using an iterative method.
+    """
+    def __init__(self, M, ifunc=gmres):
+        self.M = M
+        self.ifunc = ifunc
+        if hasattr(M,'dtype'):
+            dtype = M.dtype
+        else:
+            x = np.zeros(M.shape[1])
+            dtype = (M*x).dtype
+        LinearOperator.__init__(self, M.shape, self._matvec, dtype=dtype)
+    def _matvec(self,x):
+        b,info = self.ifunc(self.M,x)
+        if info != 0:
+            raise ValueError("Error in inverting M: function "
+                             "%s did not converge (info = %i)." 
+                             % (self.ifunc.__name__,info))
+        return b
+
+class iter_OPinv(LinearOperator):
+    """
+    iter_OPinv:
+       helper class to repeatedly solve [A-sigma*M]*x = b
+       using an iterative method
+    """
+    def __init__(self, A, M, sigma, ifunc=gmres):
+        self.A = A
+        self.M = M
+        self.sigma = sigma
+        self.ifunc = ifunc
+        
+        x = np.zeros(A.shape[1])
+        if M is None:
+            dtype = self.mult_func_M_None(x).dtype
+            self.OP = LinearOperator(self.A.shape,
+                                     self.mult_func_M_None,
+                                     dtype = dtype)
+        else:
+            dtype = self.mult_func(x).dtype
+            self.OP = LinearOperator(self.A.shape,
+                                     self.mult_func,
+                                     dtype = dtype)
+        LinearOperator.__init__(self, A.shape, self._matvec, dtype=dtype)
+    
+    def mult_func(self,x):
+        return self.A.matvec(x) - self.sigma*self.M.matvec(x)
+    
+    def mult_func_M_None(self,x):
+        return self.A.matvec(x) - self.sigma*x
+
+    def _matvec(self,x):
+        b,info = self.ifunc(self.OP,x)
+        if info != 0:
+            raise ValueError("Error in inverting [A-sigma*M]: function "
+                             "%s did not converge (info = %i)." 
+                             % (self.ifunc.__name__,info))
+        return b
+
+def get_inv_matvec(M):
+    if isdense(M):
+        return LU_inv(M).matvec 
+    elif isspmatrix(M):
+        if isspmatrix_csr(M):
+            M = M.T
+        return factorized(M)
+    else:
+        return iter_inv(M).matvec
+
+def get_OPinv_matvec(A,M,sigma,symmetric=False):
+    if sigma==0:
+        return get_inv_matvec(A)
+
+    if M is None:
+        #M is the identity matrix
+        if isdense(A):
+            A = np.copy(A)
+            A.flat[::A.shape[1]+1] -= sigma
+            return LU_inv(A).matvec
+        elif isspmatrix(A):
+            A = A - sigma * identity(A.shape[0])
+            if symmetric and isspmatrix_csr(A):
+                A = A.T
+            return factorized(A.tocsc())
+        else:
+            return iter_OPinv(_aslinearoperator_with_dtype(A), 
+                              M, sigma).matvec
+    else:
+        if ((not isdense(A) and not isspmatrix(A)) or 
+            (not isdense(M) and not isspmatrix(M))):
+            return iter_OPinv(_aslinearoperator_with_dtype(A),
+                              _aslinearoperator_with_dtype(M),
+                              sigma).matvec
+        elif isdense(A) or isdense(M):
+            return LU_inv(A - sigma * M).matvec
+        else:
+            OP = A - sigma * M
+            if symmetric and isspmatrix_csr(OP): 
+                OP = OP.T
+            return factorized(OP.tocsc())
 
 def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
-         ncv=None, maxiter=None, tol=0, Minv=None,
-         return_eigenvectors=True):
+         ncv=None, maxiter=None, tol=0, Minv=None, OPinv=None,
+         OPpart = None, return_eigenvectors=True):
     """
     Find k eigenvalues and eigenvectors of the square matrix A.
 
@@ -634,10 +934,9 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
     Parameters
     ----------
-    A : matrix, array, or object with matvec(x) method
-        An N x N matrix, array, or an object with matvec(x) method to perform
-        the matrix vector product A * x.  The sparse matrix formats
-        in scipy.sparse are appropriate for A.
+    A : An N x N real or complex matrix, array, or an object with matvec(x) 
+        method to perform the matrix vector product A * x.  The sparse 
+        matrix formats in scipy.sparse are appropriate for A.
     k : integer
         The number of eigenvalues and eigenvectors desired.
         `k` must be smaller than N. It is not possible to compute all
@@ -653,15 +952,36 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
     Other Parameters
     ----------------
-    M : matrix or array
-        A symmetric positive-definite matrix for the generalized
-        eigenvalue problem ``A * x = w * M * x``.  
-        eigsh internally computes the LU decomposition of M for repeated 
-        solutions of M*x = b.  Alternatively, the user can supply the 
-        function Minv, which returns x given b
+    M : An N x N matrix, array, sparse matrix, or linear operator representing 
+        a real symmetric positive-definite matrix (for sigma==None) or
+        a real symmetric positive semi-definite matrix (for sigma!=None)
+        for the generalized eigenvalue problem ``A * x = w * M * x``.  
+        When sigma==None, eigs requires an operator to compute the 
+        solution of the linear equation M * x = b.  
+        This is done internally via a (sparse) LU decomposition for an 
+        explicit matrix, or via an iterative solver for a general 
+        linear operator.  Alternatively, the user can supply the matrix 
+        or operator Minv, which gives Minv(b) = M^-1 * b 
     sigma : real or complex
-        (Not implemented)
-        Find eigenvalues near sigma.  Shift spectrum by sigma.
+        (not implemented for real A)
+        Find eigenvalues near sigma using shift-invert mode.  This requires
+        an operator to compute the solution of the linear system 
+        [A - sigma * M] * x = b, where M is the identity matrix if unspecified.
+        This is performed internally via a (sparse) LU decomposition for 
+        explicit matrices A & M, or via an iterative solver if either A
+        or M is a general linear operator.  Alternatively, the user can 
+        supply the matrix or operator OPinv, which gives 
+        OPinv * b = [A - sigma * M]^-1 * b.
+        For a real matrix A, shift-invert can either be done in imaginary 
+        mode or real mode, specified by the parameter OPpart ('r' or 'i').  
+        If OPpart == 'r' (default), the keyword 'which' refers to the 
+        shifted values
+          mu = 1/2 * [ 1/(v-sigma) + 1/(v-conjg(sigma)) ]
+        If OPpart == 'i', the keyword 'which' refers to the shifted values
+          mu = 1/2i * [ 1/(v-sigma) - 1/(v-conjg(sigma)) ]
+        For a complex matrix A, shift invert is done in complex mode, and
+        'which' refers to the shifted values
+          mu = 1/(v-sigma)
     v0 : array
         Starting vector for iteration.
     ncv : integer
@@ -677,6 +997,9 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
          - 'LI' : largest imaginary part
          - 'SI' : smallest imaginary part
 
+        When sigma != None, 'which' refers to the shifted eigenvalues
+         (see discussion in 'sigma', above)
+
     maxiter : integer
         Maximum number of Arnoldi update iterations allowed
     tol : float
@@ -684,8 +1007,13 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
         The default value of 0 implies machine precision.
     return_eigenvectors : boolean
         Return eigenvectors (True) in addition to eigenvalues
-    Minv : function
-        See notes in M, above
+    Minv : N x N matrix, array, sparse matrix, or linear operator
+        See notes in M, above.
+    OPinv : N x N matrix, array, sparse matrix, or linear operator
+        See notes in sigma, above.
+    OPpart : 'r' or 'i'.  
+        (Not implemented)
+        See notes in sigma, above
 
     Raises
     ------
@@ -699,6 +1027,7 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     See Also
     --------
     eigsh : eigenvalues and eigenvectors for symmetric matrix A
+    svds : singular value decomposition for a matrix A
 
     Notes
     -----
@@ -724,28 +1053,79 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
        Solution of Large Scale Eigenvalue Problems by Implicitly Restarted
        Arnoldi Methods. SIAM, Philadelphia, PA, 1998.
     """
-    A = _aslinearoperator_with_dtype(A)
     if A.shape[0] != A.shape[1]:
         raise ValueError('expected square matrix (shape=%s)' % (A.shape,))
+    if (M is not None) and (M.shape != A.shape):
+        raise ValueError('wrong M dimensions %s, should be %s' 
+                         % (M.shape,A.shape) )
     n = A.shape[0]
 
-    matvec = lambda x : A.matvec(x)
+    if k<=0 or k>=n:
+        raise ValueError("k must be between 1 and rank(A)-1")
 
-    if M is None:
-        mode = 1
+    if sigma is None:
+        A = _aslinearoperator_with_dtype(A)
         matvec = A.matvec
-        M_matvec = None
-        Minv_matvec = None
-        if Minv is not None:
-            print "Warning: eigsh: user supplied Minv but not M.  Ignoring it"
+
+        if OPinv is not None:
+            raise ValueError("OPinv should not be specified "
+                             "with sigma = None.")
+        if OPpart is not None:
+            raise ValueError("OPpart should not be specified with "
+                             "sigma = None or complex A")
+        
+        if M is None:
+            #standard eigenvalue problem
+            mode = 1
+            M_matvec = None
+            Minv_matvec = None
+            if Minv is not None:
+                raise ValueError("Minv should not be "
+                                 "specified with M = None.")
+        else:
+            #general eigenvalue problem
+            mode = 2
+            if Minv is None:
+                Minv_matvec = get_inv_matvec(M)
+            else:
+                Minv = _aslinearoperator_with_dtype(Minv)
+                Minv_matvec = Minv.matvec
+            M_matvec = _aslinearoperator_with_dtype(M).matvec
     else:
-        mode = 2
-        matvec = A.matvec
-        M_matvec    = lambda x: np.dot(M,x)
-        if Minv is None:
-            Minv_matvec = LU_inv(M).matvec 
-        else: 
-            Minv_matvec = Minv
+        #sigma is not None: shift-invert mode
+        if np.issubdtype(A.dtype, np.complexfloating):
+            if OPpart is not None:
+                raise ValueError("OPpart should not be specified with "
+                                 "sigma = None or complex A")
+            mode = 3
+        else:
+            raise ValueError("Nonsymmetric real shift-invert is not "
+                             "yet available.  Try converting matrix "
+                             "to complex")
+        #JTV: shifts for real A lead to segmentation faults and other
+        # hard-to-track memory errors.  I'm going to leave them out
+        # for now.
+        
+        #elif OPpart is None or OPpart.lower() == 'r':
+        #    mode = 3
+        #elif OPpart.lower() == 'i':
+        #    mode = 4
+        #else:
+        #    raise ValueError("OPpart must be one of ('r','i')")
+        
+        matvec = None
+        if Minv is not None:
+            raise ValueError("Minv should not be specified when sigma is")
+        if OPinv is None:
+            Minv_matvec = get_OPinv_matvec(A, M, sigma, symmetric=False)
+        else:
+            OPinv = _aslinearoperator_with_dtype(OPinv)
+            Minv_matvec = OPinv.matvec
+        if M is None:
+            M_matvec = None
+        else:
+            M = _aslinearoperator_with_dtype(M)
+            M_matvec = M.matvec        
 
     params = _UnsymmetricArpackParams(n, k, A.dtype.char, matvec, mode,
                                       M_matvec, Minv_matvec, sigma,
@@ -757,7 +1137,7 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     return params.extract(return_eigenvectors)
 
 def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
-          ncv=None, maxiter=None, tol=0, Minv=None,
+          ncv=None, maxiter=None, tol=0, Minv=None, OPinv=None,
           return_eigenvectors=True):
     """
     Find k eigenvalues and eigenvectors of the real symmetric square matrix A.
@@ -771,12 +1151,13 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
     Parameters
     ----------
-    A : matrix or array with real entries or object with matvec(x) method
-        An N x N real symmetric matrix or array or an object with matvec(x)
+    A : An N x N real symmetric matrix or array or an object with matvec(x)
         method to perform the matrix vector product A * x.  The sparse
         matrix formats in scipy.sparse are appropriate for A.
     k : integer
         The number of eigenvalues and eigenvectors desired.
+        `k` must be smaller than N. It is not possible to compute all
+        eigenvectors of a matrix.
 
     Returns
     -------
@@ -788,15 +1169,27 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
     Other Parameters
     ----------------
-    M : matrix or array
-        A symmetric positive-definite matrix for the generalized
-        eigenvalue problem ``A * x = w * M * x``.  
-        eigsh internally computes the LU decomposition of M for repeated 
-        solutions of M*x = b.  Alternatively, the user can supply the 
-        function Minv, which returns x given b
-    sigma : real
-        (Not implemented)
-        Find eigenvalues near sigma.  Shift spectrum by sigma.
+    M : An N x N matrix, array, sparse matrix, or linear operator representing
+        a real symmetric positive-definite matrix (for sigma==None) or
+        a real symmetric positive semi-definite matrix (for sigma!=None)
+        for the generalized eigenvalue problem ``A * x = w * M * x``.  
+        If sigma==None, eigsh requires an operator to compute the 
+        solution of the linear equation M*x = b.  
+        This is done internally via a (sparse) LU decomposition for an 
+        explicit matrix, or via an iterative solver for a general linear 
+        operator.  Alternatively, the user can supply the matrix or 
+        operator Minv, which yields x = Minv*b 
+    sigma : real or complex
+        Find eigenvalues near sigma using shift-invert mode.  This requires
+        an operator to compute the solution of the linear system 
+        [A - sigma * M] x = b, where M is the identity matrix if unspecified.
+        This is done internally via a (sparse) LU decomposition for 
+        explicit matrices A & M, or via an iterative solver if either A
+        or M is a general linear operator.  Alternatively, the user can 
+        supply the matrix or operator OPinv, which gives 
+        OPinv * b = [A - sigma * M]^-1 * b .
+        Note that when sigma is specified, the keyword "which" (below) refers
+        to the shifted eigenvalues 1/(v-sigma).
     v0 : array
         Starting vector for iteration.
     ncv : integer
@@ -811,6 +1204,8 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
          - 'SM' : Smallest (in magnitude) eigenvalues
          - 'BE' : Half (k/2) from each end of the spectrum
                   When k is odd, return one more (k/2+1) from the high end
+        When sigma != None, 'which' refers to the 
+          shifted eigenvalues 1/(v-sigma)
     maxiter : integer
         Maximum number of Arnoldi update iterations allowed
     tol : float
@@ -818,8 +1213,10 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         The default value of 0 implies machine precision.
     return_eigenvectors : boolean
         Return eigenvectors (True) in addition to eigenvalues
-    Minv : function
+    Minv : N x N matrix, array, sparse matrix, or linear operator
         See notes in M, above
+    OPinv : N x N matrix, array, sparse matrix, or linear operator
+        See notes in sigma, above.
 
     Raises
     ------
@@ -833,6 +1230,7 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     See Also
     --------
     eigs : eigenvalues and eigenvectors for a general (nonsymmetric) matrix A
+    svds : singular value decomposition for a matrix A
 
     Notes
     -----
@@ -856,26 +1254,56 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
        Solution of Large Scale Eigenvalue Problems by Implicitly Restarted
        Arnoldi Methods. SIAM, Philadelphia, PA, 1998.
     """
-    A = _aslinearoperator_with_dtype(A)
     if A.shape[0] != A.shape[1]:
         raise ValueError('expected square matrix (shape=%s)' % (A.shape,))
+    if (M is not None) and (M.shape != A.shape):
+        raise ValueError('wrong M dimensions %s, should be %s' 
+                         % (M.shape,A.shape) )
     n = A.shape[0]
+    
+    if k<=0 or k>=n:
+        raise ValueError("k must be between 1 and rank(A)-1")
 
-    if M is None:
-        mode        = 1
-        matvec      = A.matvec
-        M_matvec    = None
-        Minv_matvec = None
-        if Minv is not None:
-            print "Warning: eigsh: user supplied Minv but not M.  Ignoring it"
+    if sigma is None:
+        A = _aslinearoperator_with_dtype(A)
+        matvec = A.matvec
+        
+        if OPinv is not None:
+            raise ValueError("OPinv should not be specified "
+                             "with sigma = None.")
+        if M is None:
+            #standard eigenvalue problem
+            mode = 1
+            M_matvec = None
+            Minv_matvec = None
+            if Minv is not None:
+                raise ValueError("Minv should not be "
+                                 "specified with M = None.")
+        else:
+            #general eigenvalue problem
+            mode = 2
+            if Minv is None:
+                Minv_matvec = get_inv_matvec(M)
+            else:
+                Minv = _aslinearoperator_with_dtype(Minv)
+                Minv_matvec = Minv.matvec
+            M_matvec = _aslinearoperator_with_dtype(M).matvec
     else:
-        mode        = 2
-        matvec      = lambda x: A.matvec(x)
-        M_matvec    = lambda x: np.dot(M,x)
-        if Minv is None:
-            Minv_matvec = LU_inv(M).matvec 
-        else: 
-            Minv_matvec = Minv
+        #sigma is not None: shift-invert mode
+        mode = 3
+        matvec = None
+        if Minv is not None:
+            raise ValueError("Minv should not be specified when sigma is")
+        if OPinv is None:
+            Minv_matvec = get_OPinv_matvec(A, M, sigma, symmetric=True)
+        else:
+            OPinv = _aslinearoperator_with_dtype(OPinv)
+            Minv_matvec = OPinv.matvec
+        if M is None:
+            M_matvec = None
+        else:
+            M = _aslinearoperator_with_dtype(M)
+            M_matvec = M.matvec
 
     params = _SymmetricArpackParams(n, k, A.dtype.char, matvec, mode,
                                     M_matvec, Minv_matvec, sigma,

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1367,11 +1367,12 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         Return eigenvectors (True) in addition to eigenvalues
     mode : string ['normal' | 'buckling' | 'cayley']
         Specify strategy to use for shift-invert mode.  This argument applies
-        only if sigma != None.  For shift-invert mode, ARPACK internally
-        solves the eigenvalue problem ``OP * x'[i] = w'[i] * B * x'[i]``
-        and transforms the resulting Ritz vectors x'[i] and Ritz values
-        w'[i] into the desired eigenvectors and eigenvalues of the 
-        problem ``A * x[i] = w[i] * M * x[i]``.
+        only for real-valued A and sigma != None.  For shift-invert mode, 
+        ARPACK internally solves the eigenvalue problem 
+        ``OP * x'[i] = w'[i] * B * x'[i]`` 
+        and transforms the resulting Ritz vectors x'[i] and Ritz values w'[i] 
+        into the desired eigenvectors and eigenvalues of the problem 
+        ``A * x[i] = w[i] * M * x[i]``.
         The modes are as follows:
           - 'normal'   : OP = [A - sigma * M]^-1 * M
                          B = M

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -47,7 +47,7 @@ from scipy.sparse import identity, csc_matrix, csr_matrix, \
     isspmatrix, isspmatrix_csr
 from scipy.linalg import lu_factor, lu_solve
 from scipy.sparse.sputils import isdense
-from scipy.sparse.linalg import cg, cgs, minres, gmres, splu
+from scipy.sparse.linalg import gmres, splu
 from scipy.linalg.lapack import get_lapack_funcs
 
 
@@ -937,7 +937,8 @@ class IterInv(LinearOperator):
         if tol <= 0:
             # when tol=0, ARPACK uses machine tolerance as calculated
             # by LAPACK's _LAMCH function.  We should match this
-            lamch, = get_lapack_funcs(('lamch',), np.array(0, dtype=M.dtype))
+            typ = M.dtype.char.lower()
+            lamch, = get_lapack_funcs(('lamch',), (np.array(0, dtype=typ),))
             tol = lamch('e')
         self.M = M
         self.ifunc = ifunc
@@ -968,7 +969,8 @@ class IterOpInv(LinearOperator):
         if tol <= 0:
             # when tol=0, ARPACK uses machine tolerance as calculated
             # by LAPACK's _LAMCH function.  We should match this
-            lamch, = get_lapack_funcs(('lamch',), np.array(0, dtype=A.dtype))
+            typ = A.dtype.char.lower()
+            lamch, = get_lapack_funcs(('lamch',), (np.array(0, dtype=typ),))
             tol = lamch('e')
         self.A = A
         self.M = M
@@ -1086,9 +1088,10 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     M : An N x N matrix, array, sparse matrix, or LinearOperator representing
         the operation M*x for the generalized eigenvalue problem
           ``A * x = w * M * x``
-        M must represent a real symmetric matrix.  Additionally:
-         * If sigma==None, M must be positive definite
-         * If sigma is specified, M must be positive semi-definite
+        M must represent a real symmetric matrix.  For best results, M should
+        be of the same type as A.  Additionally:
+         * If sigma==None, M is positive definite
+         * If sigma is specified, M is positive semi-definite
         If sigma==None, eigs requires an operator to compute the solution
         of the linear equation `M * x = b`. This is done internally via a
         (sparse) LU decomposition for an explicit matrix M, or via an
@@ -1119,19 +1122,18 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     ncv : integer
         The number of Lanczos vectors generated
         `ncv` must be greater than `k`; it is recommended that ``ncv > 2*k``.
-    which : string
+    which : string ['LM' | 'SM' | 'LR' | 'SR' | 'LI' | 'SI']
         Which `k` eigenvectors and eigenvalues to find:
-
          - 'LM' : largest magnitude
          - 'SM' : smallest magnitude
          - 'LR' : largest real part
          - 'SR' : smallest real part
          - 'LI' : largest imaginary part
          - 'SI' : smallest imaginary part
-
         When sigma != None, 'which' refers to the shifted eigenvalues w'[i]
-         (see discussion in 'sigma', above)
-
+        (see discussion in 'sigma', above).  ARPACK is generally better 
+        at finding large values than small values.  If small eigenvalues are
+        desired, consider using shift-invert mode for better performance.
     maxiter : integer
         Maximum number of Arnoldi update iterations allowed
     tol : float
@@ -1186,9 +1188,14 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     """
     if A.shape[0] != A.shape[1]:
         raise ValueError('expected square matrix (shape=%s)' % (A.shape,))
-    if (M is not None) and (M.shape != A.shape):
-        raise ValueError('wrong M dimensions %s, should be %s'
-                         % (M.shape, A.shape))
+    if M is not None:
+        if M.shape != A.shape:
+            raise ValueError('wrong M dimensions %s, should be %s'
+                             % (M.shape, A.shape))
+        if np.dtype(M.dtype).char.lower() != np.dtype(A.dtype).char.lower():
+            import warnings
+            warnings.warn('M does not have the same type precision as A. '
+                          'This may adversely affect ARPACK convergence')
     n = A.shape[0]
 
     if k <= 0 or k >= n:
@@ -1299,7 +1306,8 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     M : An N x N matrix, array, sparse matrix, or linear operator representing
         the operation M * x for the generalized eigenvalue problem
           ``A * x = w * M * x``.
-        M must represent a real, symmetric matrix.  Additionally:
+        M must represent a real, symmetric matrix.  For best results, M should
+        be of the same type as A.  Additionally:
          * If sigma == None, M is symmetric positive definite
          * If sigma is specified, M is symmetric positive semi-definite
          * In buckling mode, M is symmetric indefinite.
@@ -1318,8 +1326,15 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         solver if either A or M is a general linear operator.
         Alternatively, the user can supply the matrix or operator OPinv,
         which gives x = OPinv * b = [A - sigma * M]^-1 * b.
-        Note that when sigma is specified, the keyword 'which' (below)
-        refers to the shifted eigenvalues w'[i] = 1 / (w[i] - sigma).
+        Note that when sigma is specified, the keyword 'which' refers to 
+        the shifted eigenvalues w'[i] where:
+         - if mode == 'normal',
+             w'[i] = 1 / (w[i] - sigma)
+         - if mode == 'cayley',
+             w'[i] = (w[i] + sigma) / (w[i] - sigma)
+         - if mode == 'buckling',
+             w'[i] = w[i] / (w[i] - sigma)
+        (see further discussion in 'mode' below)
     v0 : array
         Starting vector for iteration.
     ncv : integer
@@ -1327,15 +1342,18 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         ncv must be greater than k and smaller than n;
         it is recommended that ncv > 2*k
     which : string ['LM' | 'SM' | 'LA' | 'SA' | 'BE']
-        Which k eigenvectors and eigenvalues to find:
+        If A is a complex hermitian matrix, 'BE' is invalid.
+        Which `k` eigenvectors and eigenvalues to find:
          - 'LM' : Largest (in magnitude) eigenvalues
          - 'SM' : Smallest (in magnitude) eigenvalues
          - 'LA' : Largest (algebraic) eigenvalues
          - 'SA' : Smallest (algebraic) eigenvalues
          - 'BE' : Half (k/2) from each end of the spectrum
                   When k is odd, return one more (k/2+1) from the high end
-        When sigma != None, 'which' refers to the shifted eigenvalues
-          w'[i] = 1 / (w[i] - sigma)
+        When sigma != None, 'which' refers to the shifted eigenvalues w'[i]
+        (see discussion in 'sigma', above).  ARPACK is generally better 
+        at finding large values than small values.  If small eigenvalues are
+        desired, consider using shift-invert mode for better performance.
     maxiter : integer
         Maximum number of Arnoldi update iterations allowed
     tol : float
@@ -1350,16 +1368,24 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     mode : string ['normal' | 'buckling' | 'cayley']
         Specify strategy to use for shift-invert mode.  This argument applies
         only if sigma != None.  For shift-invert mode, ARPACK internally
-        solves the eigenvalue problem ``OP * x[i] = w[i] * B * x[i]``
+        solves the eigenvalue problem ``OP * x'[i] = w'[i] * B * x'[i]``
+        and transforms the resulting Ritz vectors x'[i] and Ritz values
+        w'[i] into the desired eigenvectors and eigenvalues of the 
+        problem ``A * x[i] = w[i] * M * x[i]``.
+        The modes are as follows:
           - 'normal'   : OP = [A - sigma * M]^-1 * M
                          B = M
+                         w'[i] = 1 / (w[i] - sigma)
           - 'buckling' : OP = [A - sigma * M]^-1 * A
                          B = A
+                         w'[i] = w[i] / (w[i] - sigma)
           - 'cayley'   : OP = [A - sigma * M]^-1 * [A + sigma * M]
                          B = M
-        ARPACK transforms the resulting eigenvectors into the desired solution
-        of the problem ``A * x[i] = w[i] * M * x[i]``.  The choice of mode
-        can affect the stability of convergence (see [2] for a discussion)
+                         w'[i] = (w[i] + sigma) / (w[i] - sigma)
+        The choice of mode will affect which eigenvalues are selected by
+        the keyword 'which', and can also impact the stability of 
+        convergence (see [2] for a discussion)
+
     Raises
     ------
     ArpackNoConvergence
@@ -1401,6 +1427,12 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         if mode != 'normal':
             raise ValueError("mode=%s cannot be used with "
                              "complex matrix A" % mode)
+        if which == 'BE':
+            raise ValueError("which='BE' cannot be used with complex matrix A")
+        elif which == 'LA':
+            which = 'LR'
+        elif which == 'SA':
+            which = 'SR'
         ret = eigs(A, k, M=M, sigma=sigma, which=which, v0=v0,
                    ncv=ncv, maxiter=maxiter, tol=tol,
                    return_eigenvectors=return_eigenvectors, Minv=Minv,
@@ -1413,9 +1445,14 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
     if A.shape[0] != A.shape[1]:
         raise ValueError('expected square matrix (shape=%s)' % (A.shape,))
-    if (M is not None) and (M.shape != A.shape):
-        raise ValueError('wrong M dimensions %s, should be %s'
-                         % (M.shape, A.shape))
+    if M is not None:
+        if M.shape != A.shape:
+            raise ValueError('wrong M dimensions %s, should be %s'
+                             % (M.shape, A.shape))
+        if np.dtype(M.dtype).char.lower() != np.dtype(A.dtype).char.lower():
+            import warnings
+            warnings.warn('M does not have the same type precision as A. '
+                          'This may adversely affect ARPACK convergence')
     n = A.shape[0]
 
     if k <= 0 or k >= n:

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1053,7 +1053,6 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
         the user can supply the matrix or operator Minv, which gives 
         x = Minv * b = M^-1 * b 
     sigma : real or complex
-        [not implemented for real A]
         Find eigenvalues near sigma using shift-invert mode.  This requires
         an operator to compute the solution of the linear system 
         `[A - sigma * M] * x = b`, where M is the identity matrix if 
@@ -1102,7 +1101,6 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     OPinv : N x N matrix, array, sparse matrix, or linear operator
         See notes in sigma, above.
     OPpart : 'r' or 'i'.  
-        [Not implemented]
         See notes in sigma, above
 
     Raises

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -38,18 +38,22 @@ Uses ARPACK: http://www.caam.rice.edu/software/ARPACK/
 
 __docformat__ = "restructuredtext en"
 
-__all___=['eigs', 'eigsh', 'svds', 'ArpackNoConvergence']
+__all___ = ['eigs', 'eigsh', 'svds', 'ArpackNoConvergence']
 
 import _arpack
 import numpy as np
 from scipy.sparse.linalg.interface import aslinearoperator, LinearOperator
-from scipy.sparse import identity, csc_matrix, csr_matrix, isspmatrix, isspmatrix_csr
+from scipy.sparse import identity, csc_matrix, csr_matrix, \
+    isspmatrix, isspmatrix_csr
 from scipy.linalg import lu_factor, lu_solve
 from scipy.sparse.sputils import isdense
-from scipy.sparse.linalg import cg, cgs, minres, gmres, factorized
+from scipy.sparse.linalg import cg, cgs, minres, gmres, splu
+from scipy.linalg.lapack import get_lapack_funcs
 
-_type_conv = {'f':'s', 'd':'d', 'F':'c', 'D':'z'}
-_ndigits = {'f':5, 'd':12, 'F':5, 'D':12}
+
+
+_type_conv = {'f': 's', 'd': 'd', 'F': 'c', 'D': 'z'}
+_ndigits = {'f': 5, 'd': 12, 'F': 5, 'D': 12}
 
 DNAUPD_ERRORS = {
     0: "Normal exit.",
@@ -164,11 +168,11 @@ SNEUPD_ERRORS[1] = ("The Schur form computed by LAPACK routine slahqr "
                     "occurs.")
 SNEUPD_ERRORS[-14] = ("SNAUPD did not find any eigenvalues to sufficient "
                       "accuracy.")
-SNEUPD_ERRORS[-15] = ("SNEUPD got a different count of the number of converged "
-                      "Ritz values than SNAUPD got.  This indicates the user "
-                      "probably made an error in passing data from SNAUPD to "
-                      "SNEUPD or that the data was modified before entering "
-                      "SNEUPD")
+SNEUPD_ERRORS[-15] = ("SNEUPD got a different count of the number of "
+                      "converged Ritz values than SNAUPD got.  This indicates "
+                      "the user probably made an error in passing data from "
+                      "SNAUPD to SNEUPD or that the data was modified before "
+                      "entering SNEUPD")
 
 ZNEUPD_ERRORS = {0: "Normal exit.",
                  1: "The Schur form computed by LAPACK routine csheqr "
@@ -195,21 +199,21 @@ ZNEUPD_ERRORS = {0: "Normal exit.",
                  -13: "HOWMNY must be one of 'A' or 'P' if RVEC = .true.",
                  -14: "ZNAUPD did not find any eigenvalues to sufficient "
                       "accuracy.",
-                 -15: "ZNEUPD got a different count of the number of converged "
-                      "Ritz values than ZNAUPD got.  This indicates the user "
-                      "probably made an error in passing data from ZNAUPD to "
-                      "ZNEUPD or that the data was modified before entering "
-                      "ZNEUPD"
+                 -15: "ZNEUPD got a different count of the number of "
+                      "converged Ritz values than ZNAUPD got.  This "
+                      "indicates the user probably made an error in passing "
+                      "data from ZNAUPD to ZNEUPD or that the data was "
+                      "modified before entering ZNEUPD"
 }
 
 CNEUPD_ERRORS = ZNEUPD_ERRORS.copy()
 CNEUPD_ERRORS[-14] = ("CNAUPD did not find any eigenvalues to sufficient "
                       "accuracy.")
-CNEUPD_ERRORS[-15] = ("CNEUPD got a different count of the number of converged "
-                      "Ritz values than CNAUPD got.  This indicates the user "
-                      "probably made an error in passing data from CNAUPD to "
-                      "CNEUPD or that the data was modified before entering "
-                      "CNEUPD")
+CNEUPD_ERRORS[-15] = ("CNEUPD got a different count of the number of "
+                      "converged Ritz values than CNAUPD got.  This indicates "
+                      "the user probably made an error in passing data from "
+                      "CNAUPD to CNEUPD or that the data was modified before "
+                      "entering CNEUPD")
 
 DSEUPD_ERRORS = {
     0: "Normal exit.",
@@ -273,6 +277,7 @@ class ArpackError(RuntimeError):
         msg = infodict.get(info, "Unknown error")
         RuntimeError.__init__(self, "ARPACK error %d: %s" % (info, msg))
 
+
 class ArpackNoConvergence(ArpackError):
     """
     ARPACK iteration did not converge
@@ -289,7 +294,8 @@ class ArpackNoConvergence(ArpackError):
         ArpackError.__init__(self, -1, {-1: msg})
         self.eigenvalues = eigenvalues
         self.eigenvectors = eigenvectors
-        
+
+
 class _ArpackParams(object):
     def __init__(self, n, k, tp, mode=1, sigma=None,
                  ncv=None, v0=None, maxiter=None, which="LM", tol=0):
@@ -322,7 +328,7 @@ class _ArpackParams(object):
             ncv = 2 * k + 1
         ncv = min(ncv, n)
 
-        self.v = np.zeros((n, ncv), tp) # holds Ritz vectors
+        self.v = np.zeros((n, ncv), tp)  # holds Ritz vectors
         self.iparam = np.zeros(11, "int")
 
         # set solver mode and parameters
@@ -358,6 +364,7 @@ class _ArpackParams(object):
             k_ok = 0
         raise ArpackNoConvergence(msg % (num_iter, k_ok, self.k), ev, vec)
 
+
 class _SymmetricArpackParams(_ArpackParams):
     def __init__(self, n, k, tp, matvec, mode=1, M_matvec=None,
                  Minv_matvec=None, sigma=None,
@@ -365,9 +372,9 @@ class _SymmetricArpackParams(_ArpackParams):
         # The following modes are supported:
         #  mode = 1:
         #    Solve the standard eigenvalue problem:
-        #      A*x = lambda*x : 
+        #      A*x = lambda*x :
         #       A - symmetric
-        #    Arguments should be   
+        #    Arguments should be
         #       matvec      = left multiplication by A
         #       M_matvec    = None [not used]
         #       Minv_matvec = None [not used]
@@ -413,51 +420,47 @@ class _SymmetricArpackParams(_ArpackParams):
         #       M_matvec    = left multiplication by M
         #                     or None, if M is the identity
         #       Minv_matvec = left multiplication by [A-sigma*M]^-1
-        if mode==1:
+        if mode == 1:
             if matvec is None:
                 raise ValueError("matvec must be specified for mode=1")
             if M_matvec is not None:
                 raise ValueError("M_matvec cannot be specified for mode=1")
             if Minv_matvec is not None:
                 raise ValueError("Minv_matvec cannot be specified for mode=1")
-                
-            assert matvec is not None
-            assert M_matvec is None
-            assert Minv_matvec is None
 
-            self.OP   = matvec
-            self.B    = lambda x: x
+            self.OP = matvec
+            self.B = lambda x: x
             self.bmat = 'I'
-        elif mode==2:
+        elif mode == 2:
             if matvec is None:
                 raise ValueError("matvec must be specified for mode=2")
             if M_matvec is None:
                 raise ValueError("M_matvec must be specified for mode=2")
             if Minv_matvec is None:
                 raise ValueError("Minv_matvec must be specified for mode=2")
-            
-            self.OP   = lambda x: Minv_matvec(matvec(x))
-            self.OPa  = Minv_matvec
-            self.OPb  = matvec
-            self.B    = M_matvec
+
+            self.OP = lambda x: Minv_matvec(matvec(x))
+            self.OPa = Minv_matvec
+            self.OPb = matvec
+            self.B = M_matvec
             self.bmat = 'G'
-        elif mode==3:
+        elif mode == 3:
             if matvec is not None:
                 raise ValueError("matvec must not be specified for mode=3")
             if Minv_matvec is None:
                 raise ValueError("Minv_matvec must be specified for mode=3")
-            
+
             if M_matvec is None:
                 self.OP = Minv_matvec
                 self.OPa = Minv_matvec
                 self.B = lambda x: x
                 self.bmat = 'I'
             else:
-                self.OP   = lambda x: Minv_matvec(M_matvec(x))
-                self.OPa  = Minv_matvec
-                self.B    = M_matvec
+                self.OP = lambda x: Minv_matvec(M_matvec(x))
+                self.OPa = Minv_matvec
+                self.B = M_matvec
                 self.bmat = 'G'
-        elif mode==4:
+        elif mode == 4:
             if matvec is None:
                 raise ValueError("matvec must be specified for mode=4")
             if M_matvec is not None:
@@ -465,10 +468,10 @@ class _SymmetricArpackParams(_ArpackParams):
             if Minv_matvec is None:
                 raise ValueError("Minv_matvec must be specified for mode=4")
             self.OPa = Minv_matvec
-            self.OP  = lambda x: self.OPa(matvec(x))
-            self.B   = matvec
+            self.OP = lambda x: self.OPa(matvec(x))
+            self.B = matvec
             self.bmat = 'G'
-        elif mode==5:
+        elif mode == 5:
             if matvec is None:
                 raise ValueError("matvec must be specified for mode=5")
             if Minv_matvec is None:
@@ -476,22 +479,22 @@ class _SymmetricArpackParams(_ArpackParams):
 
             self.OPa = Minv_matvec
             self.A_matvec = matvec
-            
+
             if M_matvec is None:
                 self.OP = lambda x: Minv_matvec(matvec(x) + sigma * x)
                 self.B = lambda x: x
                 self.bmat = 'I'
             else:
-                self.OP   = lambda x: Minv_matvec(matvec(x) 
-                                                  + sigma * M_matvec(x))
-                self.B    = M_matvec
+                self.OP = lambda x: Minv_matvec(matvec(x)
+                                                + sigma * M_matvec(x))
+                self.B = M_matvec
                 self.bmat = 'G'
-            
         else:
             raise ValueError("mode=%i not implemented" % mode)
-        
+
         if which not in _SEUPD_WHICH:
-            raise ValueError("which must be one of %s" % ' '.join(_SEUPD_WHICH))
+            raise ValueError("which must be one of %s"
+                             % ' '.join(_SEUPD_WHICH))
         if k >= n:
             raise ValueError("k must be less than rank(A), k=%d" % k)
 
@@ -510,7 +513,7 @@ class _SymmetricArpackParams(_ArpackParams):
 
         self._arpack_solver = _arpack.__dict__[ltr + 'saupd']
         self._arpack_extract = _arpack.__dict__[ltr + 'seupd']
-        
+
         self.iterate_infodict = _SAUPD_ERRORS[ltr]
         self.extract_infodict = _SEUPD_ERRORS[ltr]
 
@@ -518,29 +521,29 @@ class _SymmetricArpackParams(_ArpackParams):
 
     def iterate(self):
         self.ido, self.resid, self.v, self.iparam, self.ipntr, self.info = \
-            self._arpack_solver(self.ido, self.bmat, self.which, self.k, self.tol,
-                    self.resid, self.v, self.iparam, self.ipntr,
-                    self.workd, self.workl, self.info)
+            self._arpack_solver(self.ido, self.bmat, self.which, self.k,
+                                self.tol, self.resid, self.v, self.iparam,
+                                self.ipntr, self.workd, self.workl, self.info)
 
-        xslice = slice(self.ipntr[0]-1, self.ipntr[0]-1+self.n)
-        yslice = slice(self.ipntr[1]-1, self.ipntr[1]-1+self.n)
+        xslice = slice(self.ipntr[0] - 1, self.ipntr[0] - 1 + self.n)
+        yslice = slice(self.ipntr[1] - 1, self.ipntr[1] - 1 + self.n)
         if self.ido == -1:
             # initialization
             self.workd[yslice] = self.OP(self.workd[xslice])
         elif self.ido == 1:
             # compute y = Op*x
-            if self.mode==1:
+            if self.mode == 1:
                 self.workd[yslice] = self.OP(self.workd[xslice])
-            elif self.mode==2:
+            elif self.mode == 2:
                 self.workd[xslice] = self.OPb(self.workd[xslice])
                 self.workd[yslice] = self.OPa(self.workd[xslice])
-            elif self.mode==5:
-                Bxslice = slice(self.ipntr[2]-1, self.ipntr[2]-1+self.n)
+            elif self.mode == 5:
+                Bxslice = slice(self.ipntr[2] - 1, self.ipntr[2] - 1 + self.n)
                 Ax = self.A_matvec(self.workd[xslice])
-                self.workd[yslice] = self.OPa(Ax + 
-                                              self.sigma * self.workd[Bxslice])
+                self.workd[yslice] = self.OPa(Ax + (self.sigma *
+                                                    self.workd[Bxslice]))
             else:
-                Bxslice = slice(self.ipntr[2]-1, self.ipntr[2]-1+self.n)
+                Bxslice = slice(self.ipntr[2] - 1, self.ipntr[2] - 1 + self.n)
                 self.workd[yslice] = self.OPa(self.workd[Bxslice])
         elif self.ido == 2:
             self.workd[yslice] = self.B(self.workd[xslice])
@@ -559,30 +562,28 @@ class _SymmetricArpackParams(_ArpackParams):
     def extract(self, return_eigenvectors):
         rvec = return_eigenvectors
         ierr = 0
-        howmny = 'A' # return all eigenvectors
-        sselect = np.zeros(self.ncv, 'int') # unused
-        
-        d, z, ierr = self._arpack_extract(rvec, howmny, sselect, self.sigma, 
-                                          self.bmat, self.which, self.k, 
+        howmny = 'A'  # return all eigenvectors
+        sselect = np.zeros(self.ncv, 'int')  # unused
+        d, z, ierr = self._arpack_extract(rvec, howmny, sselect, self.sigma,
+                                          self.bmat, self.which, self.k,
                                           self.tol, self.resid, self.v,
-                                          self.iparam[0:7], self.ipntr, 
-                                          self.workd[0:2*self.n],
+                                          self.iparam[0:7], self.ipntr,
+                                          self.workd[0:2 * self.n],
                                           self.workl, ierr)
-
         if ierr != 0:
             raise ArpackError(ierr, infodict=self.extract_infodict)
-
         k_ok = self.iparam[4]
         d = d[:k_ok]
-        z = z[:,:k_ok]
+        z = z[:, :k_ok]
 
         if return_eigenvectors:
             return d, z
         else:
             return d
 
+
 class _UnsymmetricArpackParams(_ArpackParams):
-    def __init__(self, n, k, tp, matvec, mode=1, M_matvec=None, 
+    def __init__(self, n, k, tp, matvec, mode=1, M_matvec=None,
                  Minv_matvec=None, sigma=None,
                  ncv=None, v0=None, maxiter=None, which="LM", tol=0):
         # The following modes are supported:
@@ -590,7 +591,7 @@ class _UnsymmetricArpackParams(_ArpackParams):
         #    Solve the standard eigenvalue problem:
         #      A*x = lambda*x
         #       A - square matrix
-        #    Arguments should be   
+        #    Arguments should be
         #       matvec      = left multiplication by A
         #       M_matvec    = None [not used]
         #       Minv_matvec = None [not used]
@@ -600,7 +601,7 @@ class _UnsymmetricArpackParams(_ArpackParams):
         #      A*x = lambda*M*x
         #       A - square matrix
         #       M - symmetric, positive semi-definite
-        #    Arguments should be   
+        #    Arguments should be
         #       matvec      = left multiplication by A
         #       M_matvec    = left multiplication by M
         #       Minv_matvec = left multiplication by M^-1
@@ -617,36 +618,33 @@ class _UnsymmetricArpackParams(_ArpackParams):
         #       Minv_matvec = left multiplication by [A-sigma*M]^-1
         #    if A is real and mode==3, use the real part of Minv_matvec
         #    if A is real and mode==4, use the imag part of Minv_matvec
-        #    if A is complex and mode==3, use real and imag parts of Minv_matvec
-        if mode==1:
+        #    if A is complex and mode==3,
+        #       use real and imag parts of Minv_matvec
+        if mode == 1:
             if matvec is None:
                 raise ValueError("matvec must be specified for mode=1")
             if M_matvec is not None:
                 raise ValueError("M_matvec cannot be specified for mode=1")
             if Minv_matvec is not None:
                 raise ValueError("Minv_matvec cannot be specified for mode=1")
-                
-            assert matvec is not None
-            assert M_matvec is None
-            assert Minv_matvec is None
 
-            self.OP   = matvec
-            self.B    = lambda x: x
+            self.OP = matvec
+            self.B = lambda x: x
             self.bmat = 'I'
-        elif mode==2:
+        elif mode == 2:
             if matvec is None:
                 raise ValueError("matvec must be specified for mode=2")
             if M_matvec is None:
                 raise ValueError("M_matvec must be specified for mode=2")
             if Minv_matvec is None:
                 raise ValueError("Minv_matvec must be specified for mode=2")
-            
-            self.OP   = lambda x: Minv_matvec(matvec(x))
-            self.OPa  = Minv_matvec
-            self.OPb  = matvec
-            self.B    = M_matvec
-            self.bmat = 'G'        
-        elif mode in (3,4):
+
+            self.OP = lambda x: Minv_matvec(matvec(x))
+            self.OPa = Minv_matvec
+            self.OPb = matvec
+            self.B = M_matvec
+            self.bmat = 'G'
+        elif mode in (3, 4):
             if matvec is None:
                 raise ValueError("matvec must be specified "
                                  "for mode in (3,4)")
@@ -655,14 +653,13 @@ class _UnsymmetricArpackParams(_ArpackParams):
                                  "for mode in (3,4)")
 
             self.matvec = matvec
-
-            if tp in 'DF': #complex type
-                if mode==3:
+            if tp in 'DF':  # complex type
+                if mode == 3:
                     self.OPa = Minv_matvec
                 else:
                     raise ValueError("mode=4 invalid for complex A")
-            else: #real type
-                if mode==3:
+            else:  # real type
+                if mode == 3:
                     self.OPa = lambda x: np.real(Minv_matvec(x))
                 else:
                     self.OPa = lambda x: np.imag(Minv_matvec(x))
@@ -676,18 +673,19 @@ class _UnsymmetricArpackParams(_ArpackParams):
                 self.OP = lambda x: self.OPa(M_matvec(x))
         else:
             raise ValueError("mode=%i not implemented" % mode)
-        
+
         if which not in _NEUPD_WHICH:
-            raise ValueError("Parameter which must be one of %s" % ' '.join(_NEUPD_WHICH))
-        if k >= n-1:
+            raise ValueError("Parameter which must be one of %s"
+                             % ' '.join(_NEUPD_WHICH))
+        if k >= n - 1:
             raise ValueError("k must be less than rank(A)-1, k=%d" % k)
 
         _ArpackParams.__init__(self, n, k, tp, mode, sigma,
                                ncv, v0, maxiter, which, tol)
 
-        if self.ncv > n or self.ncv <= k+1:
+        if self.ncv > n or self.ncv <= k + 1:
             raise ValueError("ncv must be k+1<ncv<=n, ncv=%s" % self.ncv)
-                                                 
+
         self.workd = np.zeros(3 * n, self.tp)
         self.workl = np.zeros(3 * self.ncv * (self.ncv + 2), self.tp)
 
@@ -707,29 +705,29 @@ class _UnsymmetricArpackParams(_ArpackParams):
 
     def iterate(self):
         if self.tp in 'fd':
-            self.ido, self.resid, self.v, self.iparam, self.ipntr, self.info = \
-                self._arpack_solver(self.ido, self.bmat, self.which, self.k, 
-                                    self.tol, self.resid, self.v, self.iparam, 
-                                    self.ipntr,  self.workd, self.workl, 
+            self.ido, self.resid, self.v, self.iparam, self.ipntr, self.info =\
+                self._arpack_solver(self.ido, self.bmat, self.which, self.k,
+                                    self.tol, self.resid, self.v, self.iparam,
+                                    self.ipntr,  self.workd, self.workl,
                                     self.info)
         else:
             self.ido, self.resid, self.v, self.iparam, self.ipntr, self.info =\
-                self._arpack_solver(self.ido, self.bmat, self.which, self.k, 
-                                    self.tol, self.resid, self.v, self.iparam, 
-                                    self.ipntr, self.workd, self.workl, 
+                self._arpack_solver(self.ido, self.bmat, self.which, self.k,
+                                    self.tol, self.resid, self.v, self.iparam,
+                                    self.ipntr, self.workd, self.workl,
                                     self.rwork, self.info)
 
-        xslice = slice(self.ipntr[0]-1, self.ipntr[0]-1+self.n)
-        yslice = slice(self.ipntr[1]-1, self.ipntr[1]-1+self.n)
+        xslice = slice(self.ipntr[0] - 1, self.ipntr[0] - 1 + self.n)
+        yslice = slice(self.ipntr[1] - 1, self.ipntr[1] - 1 + self.n)
         if self.ido == -1:
             # initialization
             self.workd[yslice] = self.OP(self.workd[xslice])
         elif self.ido == 1:
             # compute y = Op*x
-            if self.mode in (1,2):
+            if self.mode in (1, 2):
                 self.workd[yslice] = self.OP(self.workd[xslice])
             else:
-                Bxslice = slice(self.ipntr[2]-1, self.ipntr[2]-1+self.n)
+                Bxslice = slice(self.ipntr[2] - 1, self.ipntr[2] - 1 + self.n)
                 self.workd[yslice] = self.OPa(self.workd[Bxslice])
         elif self.ido == 2:
             self.workd[yslice] = self.B(self.workd[xslice])
@@ -749,84 +747,86 @@ class _UnsymmetricArpackParams(_ArpackParams):
         k, n = self.k, self.n
 
         ierr = 0
-        howmny = 'A' # return all eigenvectors
-        sselect = np.zeros(self.ncv, 'int') # unused
+        howmny = 'A'  # return all eigenvectors
+        sselect = np.zeros(self.ncv, 'int')  # unused
         sigmar = np.real(self.sigma)
         sigmai = np.imag(self.sigma)
         workev = np.zeros(3 * self.ncv, self.tp)
 
         if self.tp in 'fd':
-            dr = np.zeros(k+1, self.tp)
-            di = np.zeros(k+1, self.tp)
-            zr = np.zeros((n, k+1), self.tp)
-            dr, di, zr, ierr=\
+            dr = np.zeros(k + 1, self.tp)
+            di = np.zeros(k + 1, self.tp)
+            zr = np.zeros((n, k + 1), self.tp)
+            dr, di, zr, ierr = \
                 self._arpack_extract(return_eigenvectors,
                        howmny, sselect, sigmar, sigmai, workev,
                        self.bmat, self.which, k, self.tol, self.resid,
                        self.v, self.iparam, self.ipntr,
                        self.workd, self.workl, self.info)
-            
             if ierr != 0:
                 raise ArpackError(ierr, infodict=self.extract_infodict)
+            nreturned = self.iparam[4]  # number of good eigenvalues returned
 
-            nreturned = self.iparam[4] # number of good eigenvalues returned
-                
             # Build complex eigenvalues from real and imaginary parts
             d = dr + 1.0j * di
-            
+
             # Arrange the eigenvectors: complex eigenvectors are stored as
             # real,imaginary in consecutive columns
             z = zr.astype(self.tp.upper())
 
             # The ARPACK nonsymmetric real and double interface (s,d)naupd
-            # return eigenvalues and eigenvectors in real (float,double) arrays.
+            # return eigenvalues and eigenvectors in real (float,double)
+            # arrays.
+
+            # Efficiency: this should check that return_eigenvectors == True
+            #  before going through this construction.
             if sigmai == 0:
                 i = 0
-                while i<=k:
+                while i <= k:
                     # check if complex
                     if abs(d[i].imag) != 0:
                         # this is a complex conjugate pair with eigenvalues
                         # in consecutive columns
-                        if i<k:
-                            z[:,i] = zr[:,i] + 1.0j * zr[:,i+1]
-                            z[:,i+1] = z[:,i].conjugate()
-                            i +=1
-                        else:
-                            #last eigenvalue is complex: the imaginary part of
-                            # the eigenvector has not been returned
-                            #this can only happen if nreturned > k, so we'll
-                            # throw out this case.
-                            nreturned-=1
-                    i += 1
-
-            else: 
-                # real matrix, mode 3 or 4, imag(sigma) is nonzero: 
-                # see remark 3 in <s,d>neupd.f
-                # Build complex eigenvalues from real and imaginary parts
-                i = 0
-                while i<=k:
-                    if abs(d[i].imag)==0:
-                        d[i] = np.dot(zr[:,i], self.matvec(zr[:,i]))
-                    else:
-                        if i<k:
-                            z[:,i] = zr[:,i] + 1.0j * zr[:,i+1]
-                            z[:,i+1] = z[:,i].conjugate()
-                            d[i] = ((np.dot(zr[:,i], 
-                                            self.matvec(zr[:, i]))
-                                     + np.dot(zr[:, i + 1], 
-                                              self.matvec(zr[:, i + 1])))
-                                    + 1j * (np.dot(zr[:, i],
-                                                   self.matvec(zr[:, i + 1]))
-                                            - np.dot(zr[:, i + 1], 
-                                                     self.matvec(zr[:, i]))))
-                            d[i+1] = d[i].conj()
+                        if i < k:
+                            z[:, i] = zr[:, i] + 1.0j * zr[:, i + 1]
+                            z[:, i + 1] = z[:, i].conjugate()
                             i += 1
                         else:
                             #last eigenvalue is complex: the imaginary part of
                             # the eigenvector has not been returned
                             #this can only happen if nreturned > k, so we'll
                             # throw out this case.
-                            nreturned-=1
+                            nreturned -= 1
+                    i += 1
+
+            else:
+                # real matrix, mode 3 or 4, imag(sigma) is nonzero:
+                # see remark 3 in <s,d>neupd.f
+                # Build complex eigenvalues from real and imaginary parts
+                i = 0
+                while i <= k:
+                    if abs(d[i].imag) == 0:
+                        d[i] = np.dot(zr[:, i], self.matvec(zr[:, i]))
+                    else:
+                        if i < k:
+                            z[:, i] = zr[:, i] + 1.0j * zr[:, i + 1]
+                            z[:, i + 1] = z[:, i].conjugate()
+                            d[i] = ((np.dot(zr[:, i],
+                                            self.matvec(zr[:, i]))
+                                     + np.dot(zr[:, i + 1],
+                                              self.matvec(zr[:, i + 1])))
+                                    + 1j * (np.dot(zr[:, i],
+                                                   self.matvec(zr[:, i + 1]))
+                                            - np.dot(zr[:, i + 1],
+                                                     self.matvec(zr[:, i]))))
+                            d[i + 1] = d[i].conj()
+                            i += 1
+                        else:
+                            #last eigenvalue is complex: the imaginary part of
+                            # the eigenvector has not been returned
+                            #this can only happen if nreturned > k, so we'll
+                            # throw out this case.
+                            nreturned -= 1
                     i += 1
 
             # Now we have k+1 possible eigenvalues and eigenvectors
@@ -835,25 +835,25 @@ class _UnsymmetricArpackParams(_ArpackParams):
             if nreturned <= k:
                 # we got less or equal as many eigenvalues we wanted
                 d = d[:nreturned]
-                z = z[:,:nreturned]
+                z = z[:, :nreturned]
             else:
                 # we got one extra eigenvalue (likely a cc pair, but which?)
                 # cut at approx precision for sorting
-                rd = np.round(d, decimals = _ndigits[self.tp])
-                if self.which in ['LR','SR']:
+                rd = np.round(d, decimals=_ndigits[self.tp])
+                if self.which in ['LR', 'SR']:
                     ind = np.argsort(rd.real)
-                elif self.which in ['LI','SI']:
+                elif self.which in ['LI', 'SI']:
                     # for LI,SI ARPACK returns largest,smallest
                     # abs(imaginary) why?
                     ind = np.argsort(abs(rd.imag))
                 else:
                     ind = np.argsort(abs(rd))
-                if self.which in ['LR','LM','LI']:
+                if self.which in ['LR', 'LM', 'LI']:
                     d = d[ind[-k:]]
-                    z = z[:,ind[-k:]]
-                if self.which in ['SR','SM','SI']:
+                    z = z[:, ind[-k:]]
+                if self.which in ['SR', 'SM', 'SI']:
                     d = d[ind[:k]]
-                    z = z[:,ind[:k]]    
+                    z = z[:, ind[:k]]
         else:
             # complex is so much simpler...
             d, z, ierr =\
@@ -868,157 +868,200 @@ class _UnsymmetricArpackParams(_ArpackParams):
 
             k_ok = self.iparam[4]
             d = d[:k_ok]
-            z = z[:,:k_ok]
-
+            z = z[:, :k_ok]
 
         if return_eigenvectors:
             return d, z
         else:
             return d
 
+
 def _aslinearoperator_with_dtype(m):
     m = aslinearoperator(m)
     if not hasattr(m, 'dtype'):
         x = np.zeros(m.shape[1])
-        m.dtype = (m*x).dtype
+        m.dtype = (m * x).dtype
     return m
 
-
-class LU_inv(LinearOperator):
+class SpLuInv(LinearOperator):
     """
-    LU_inv:
+    SpLuInv:
+       helper class to repeatedly solve M*x=b
+       using a sparse LU-decopposition of M
+    """
+    def __init__(self, M):
+        self.M_lu = splu(M)
+        if hasattr(M, 'dtype'):
+            dtype = M.dtype
+        else:
+            x = np.zeros(M.shape[1])
+            dtype = (M * x).dtype
+        LinearOperator.__init__(self, M.shape, self._matvec, dtype=dtype)
+        self.isreal = not np.issubdtype(self.dtype, np.complexfloating)
+
+    def _matvec(self, x):
+        # careful here: splu.solve will throw away imaginary 
+        # part of x if M is real
+        if self.isreal and np.issubdtype(x.dtype, np.complexfloating):
+            return (self.M_lu.solve(np.real(x)) 
+                    + 1j * self.M_lu.solve(np.imag(x)))
+        else:
+            return self.M_lu.solve(x)
+
+class LuInv(LinearOperator):
+    """
+    LuInv:
        helper class to repeatedly solve M*x=b
        using an LU-decomposition of M
     """
-    def __init__(self,M):
+    def __init__(self, M):
         self.M_lu = lu_factor(M)
-        if hasattr(M,'dtype'):
+        if hasattr(M, 'dtype'):
             dtype = M.dtype
         else:
             x = np.zeros(M.shape[1])
-            dtype = (M*x).dtype
+            dtype = (M * x).dtype
         LinearOperator.__init__(self, M.shape, self._matvec, dtype=dtype)
-    def _matvec(self,x):
-        return lu_solve(self.M_lu,x)
 
-class iter_inv(LinearOperator):
+    def _matvec(self, x):
+        return lu_solve(self.M_lu, x)
+
+
+class IterInv(LinearOperator):
     """
-    iter_inv:
+    IterInv:
        helper class to repeatedly solve M*x=b
        using an iterative method.
     """
-    def __init__(self, M, ifunc=gmres):
+    def __init__(self, M, ifunc=gmres, tol=0):
+        if tol <= 0:
+            # when tol=0, ARPACK uses machine tolerance as calculated
+            # by LAPACK's _LAMCH function.  We should match this
+            lamch, = get_lapack_funcs(('lamch',), np.array(0, dtype=M.dtype))
+            tol = lamch('e')
         self.M = M
         self.ifunc = ifunc
-        if hasattr(M,'dtype'):
+        self.tol = tol
+        if hasattr(M, 'dtype'):
             dtype = M.dtype
         else:
             x = np.zeros(M.shape[1])
-            dtype = (M*x).dtype
+            dtype = (M * x).dtype
         LinearOperator.__init__(self, M.shape, self._matvec, dtype=dtype)
-    def _matvec(self,x):
-        b,info = self.ifunc(self.M,x)
+
+    def _matvec(self, x):
+        b, info = self.ifunc(self.M, x, tol=self.tol)
         if info != 0:
             raise ValueError("Error in inverting M: function "
-                             "%s did not converge (info = %i)." 
-                             % (self.ifunc.__name__,info))
+                             "%s did not converge (info = %i)."
+                             % (self.ifunc.__name__, info))
         return b
 
-class iter_OPinv(LinearOperator):
+
+class IterOpInv(LinearOperator):
     """
-    iter_OPinv:
+    IterOpInv:
        helper class to repeatedly solve [A-sigma*M]*x = b
        using an iterative method
-    """
-    def __init__(self, A, M, sigma, ifunc=gmres):
+    """ 
+    def __init__(self, A, M, sigma, ifunc=gmres, tol=0):
+        if tol <= 0:
+            # when tol=0, ARPACK uses machine tolerance as calculated
+            # by LAPACK's _LAMCH function.  We should match this
+            lamch, = get_lapack_funcs(('lamch',), np.array(0, dtype=A.dtype))
+            tol = lamch('e')
         self.A = A
         self.M = M
         self.sigma = sigma
         self.ifunc = ifunc
-        
+        self.tol = tol
+
         x = np.zeros(A.shape[1])
         if M is None:
             dtype = self.mult_func_M_None(x).dtype
             self.OP = LinearOperator(self.A.shape,
                                      self.mult_func_M_None,
-                                     dtype = dtype)
+                                     dtype=dtype)
         else:
             dtype = self.mult_func(x).dtype
             self.OP = LinearOperator(self.A.shape,
                                      self.mult_func,
-                                     dtype = dtype)
+                                     dtype=dtype)
         LinearOperator.__init__(self, A.shape, self._matvec, dtype=dtype)
-    
-    def mult_func(self,x):
-        return self.A.matvec(x) - self.sigma*self.M.matvec(x)
-    
-    def mult_func_M_None(self,x):
-        return self.A.matvec(x) - self.sigma*x
 
-    def _matvec(self,x):
-        b,info = self.ifunc(self.OP,x)
+    def mult_func(self, x):
+        return self.A.matvec(x) - self.sigma * self.M.matvec(x)
+
+    def mult_func_M_None(self, x):
+        return self.A.matvec(x) - self.sigma * x
+
+    def _matvec(self, x):
+        b, info = self.ifunc(self.OP, x, tol=self.tol)
         if info != 0:
             raise ValueError("Error in inverting [A-sigma*M]: function "
-                             "%s did not converge (info = %i)." 
-                             % (self.ifunc.__name__,info))
+                             "%s did not converge (info = %i)."
+                             % (self.ifunc.__name__, info))
         return b
 
-def get_inv_matvec(M):
+def get_inv_matvec(M, tol=0):
     if isdense(M):
-        return LU_inv(M).matvec 
+        return LuInv(M).matvec
     elif isspmatrix(M):
         if isspmatrix_csr(M):
             M = M.T
-        return factorized(M)
+        return SpLuInv(M).matvec
     else:
-        return iter_inv(M).matvec
+        return IterInv(M, tol=tol).matvec
 
-def get_OPinv_matvec(A,M,sigma,symmetric=False):
-    if sigma==0:
-        return get_inv_matvec(A)
+
+def get_OPinv_matvec(A, M, sigma, symmetric=False, tol=0):
+    if sigma == 0:
+        return get_inv_matvec(A, tol=tol)
 
     if M is None:
         #M is the identity matrix
         if isdense(A):
-            if np.issubdtype(A.dtype, np.complexfloating) or np.imag(sigma)==0:
+            if (np.issubdtype(A.dtype, np.complexfloating)
+                or np.imag(sigma) == 0):
                 A = np.copy(A)
             else:
                 A = A + 0j
-            A.flat[::A.shape[1]+1] -= sigma
-            return LU_inv(A).matvec
+            A.flat[::A.shape[1] + 1] -= sigma
+            return LuInv(A).matvec
         elif isspmatrix(A):
             A = A - sigma * identity(A.shape[0])
             if symmetric and isspmatrix_csr(A):
                 A = A.T
-            return factorized(A.tocsc())
+            return SpLuInv(A.tocsc()).matvec
         else:
-            return iter_OPinv(_aslinearoperator_with_dtype(A), 
-                              M, sigma).matvec
+            return IterOpInv(_aslinearoperator_with_dtype(A),
+                              M, sigma, tol=tol).matvec
     else:
-        if ((not isdense(A) and not isspmatrix(A)) or 
+        if ((not isdense(A) and not isspmatrix(A)) or
             (not isdense(M) and not isspmatrix(M))):
-            return iter_OPinv(_aslinearoperator_with_dtype(A),
+            return IterOpInv(_aslinearoperator_with_dtype(A),
                               _aslinearoperator_with_dtype(M),
-                              sigma).matvec
+                              sigma, tol=tol).matvec
         elif isdense(A) or isdense(M):
-            return LU_inv(A - sigma * M).matvec
+            return LuInv(A - sigma * M).matvec
         else:
             OP = A - sigma * M
-            if symmetric and isspmatrix_csr(OP): 
+            if symmetric and isspmatrix_csr(OP):
                 OP = OP.T
-            return factorized(OP.tocsc())
+            return SpLuInv(OP.tocsc()).matvec
+
 
 def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
-         ncv=None, maxiter=None, tol=0, Minv=None, OPinv=None,
-         OPpart = None, return_eigenvectors=True):
+         ncv=None, maxiter=None, tol=0, return_eigenvectors=True,
+         Minv=None, OPinv=None, OPpart=None):
     """
     Find k eigenvalues and eigenvectors of the square matrix A.
 
     Solves ``A * x[i] = w[i] * x[i]``, the standard eigenvalue problem
     for w[i] eigenvalues with corresponding eigenvectors x[i].
 
-    If M is specified, solves ``A * x[i] = w[i] * M * x[i]``, the 
-    generalized eigenvalue problem for w[i] eigenvalues 
+    If M is specified, solves ``A * x[i] = w[i] * M * x[i]``, the
+    generalized eigenvalue problem for w[i] eigenvalues
     with corresponding eigenvectors x[i]
 
     Parameters
@@ -1040,34 +1083,34 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
     Other Parameters
     ----------------
-    M : An N x N matrix, array, sparse matrix, or LinearOperator representing 
+    M : An N x N matrix, array, sparse matrix, or LinearOperator representing
         the operation M*x for the generalized eigenvalue problem
           ``A * x = w * M * x``
         M must represent a real symmetric matrix.  Additionally:
          * If sigma==None, M must be positive definite
          * If sigma is specified, M must be positive semi-definite
-        If sigma==None, eigs requires an operator to compute the solution 
-        of the linear equation `M * x = b`. This is done internally via a 
-        (sparse) LU decomposition for an explicit matrix M, or via an 
-        iterative solver for a general linear operator.  Alternatively, 
-        the user can supply the matrix or operator Minv, which gives 
-        x = Minv * b = M^-1 * b 
+        If sigma==None, eigs requires an operator to compute the solution
+        of the linear equation `M * x = b`. This is done internally via a
+        (sparse) LU decomposition for an explicit matrix M, or via an
+        iterative solver for a general linear operator.  Alternatively,
+        the user can supply the matrix or operator Minv, which gives
+        x = Minv * b = M^-1 * b
     sigma : real or complex
         Find eigenvalues near sigma using shift-invert mode.  This requires
-        an operator to compute the solution of the linear system 
-        `[A - sigma * M] * x = b`, where M is the identity matrix if 
-        unspecified. This is computed internally via a (sparse) LU 
-        decomposition for explicit matrices A & M, or via an iterative 
-        solver if either A or M is a general linear operator.  
-        Alternatively, the user can supply the matrix or operator OPinv, 
+        an operator to compute the solution of the linear system
+        `[A - sigma * M] * x = b`, where M is the identity matrix if
+        unspecified. This is computed internally via a (sparse) LU
+        decomposition for explicit matrices A & M, or via an iterative
+        solver if either A or M is a general linear operator.
+        Alternatively, the user can supply the matrix or operator OPinv,
         which gives x = OPinv * b = [A - sigma * M]^-1 * b.
-        For a real matrix A, shift-invert can either be done in imaginary 
-        mode or real mode, specified by the parameter OPpart ('r' or 'i'). \
+        For a real matrix A, shift-invert can either be done in imaginary
+        mode or real mode, specified by the parameter OPpart ('r' or 'i').
         Note that when sigma is specified, the keyword 'which' (below)
         refers to the shifted eigenvalues w'[i] where:
-         * If A is real and OPpart == 'r' (default), 
+         * If A is real and OPpart == 'r' (default),
             w'[i] = 1/2 * [ 1/(w[i]-sigma) + 1/(w[i]-conj(sigma)) ]
-         * If A is real and OPpart == 'i', 
+         * If A is real and OPpart == 'i',
             w'[i] = 1/2i * [ 1/(w[i]-sigma) - 1/(w[i]-conj(sigma)) ]
          * If A is complex,
             w'[i] = 1/(w[i]-sigma)
@@ -1100,7 +1143,7 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
         See notes in M, above.
     OPinv : N x N matrix, array, sparse matrix, or linear operator
         See notes in sigma, above.
-    OPpart : 'r' or 'i'.  
+    OPpart : 'r' or 'i'.
         See notes in sigma, above
 
     Raises
@@ -1116,7 +1159,7 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     --------
     eigsh : eigenvalues and eigenvectors for symmetric matrix A
     svds : singular value decomposition for a matrix A
-    
+
     Notes
     -----
     This function is a wrapper to the ARPACK [1]_ SNEUPD, DNEUPD, CNEUPD,
@@ -1144,11 +1187,11 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     if A.shape[0] != A.shape[1]:
         raise ValueError('expected square matrix (shape=%s)' % (A.shape,))
     if (M is not None) and (M.shape != A.shape):
-        raise ValueError('wrong M dimensions %s, should be %s' 
-                         % (M.shape,A.shape) )
+        raise ValueError('wrong M dimensions %s, should be %s'
+                         % (M.shape, A.shape))
     n = A.shape[0]
 
-    if k<=0 or k>=n:
+    if k <= 0 or k >= n:
         raise ValueError("k must be between 1 and rank(A)-1")
 
     if sigma is None:
@@ -1160,7 +1203,7 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
         if OPpart is not None:
             raise ValueError("OPpart should not be specified with "
                              "sigma = None or complex A")
-        
+
         if M is None:
             #standard eigenvalue problem
             mode = 1
@@ -1173,7 +1216,7 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
             #general eigenvalue problem
             mode = 2
             if Minv is None:
-                Minv_matvec = get_inv_matvec(M)
+                Minv_matvec = get_inv_matvec(M, tol=tol)
             else:
                 Minv = _aslinearoperator_with_dtype(Minv)
                 Minv_matvec = Minv.matvec
@@ -1188,18 +1231,18 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
         elif OPpart is None or OPpart.lower() == 'r':
             mode = 3
         elif OPpart.lower() == 'i':
-            if np.imag(sigma)==0:
-                raise ValueError("OPpart cannot be 'i' if "
-                                 "sigma is real")
+            if np.imag(sigma) == 0:
+                raise ValueError("OPpart cannot be 'i' if sigma is real")
             mode = 4
         else:
             raise ValueError("OPpart must be one of ('r','i')")
-        
+
         matvec = _aslinearoperator_with_dtype(A).matvec
         if Minv is not None:
             raise ValueError("Minv should not be specified when sigma is")
         if OPinv is None:
-            Minv_matvec = get_OPinv_matvec(A, M, sigma, symmetric=False)
+            Minv_matvec = get_OPinv_matvec(A, M, sigma,
+                                           symmetric=False, tol=tol)
         else:
             OPinv = _aslinearoperator_with_dtype(OPinv)
             Minv_matvec = OPinv.matvec
@@ -1217,17 +1260,19 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
     return params.extract(return_eigenvectors)
 
+
 def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
-          ncv=None, maxiter=None, tol=0, Minv=None, OPinv=None,
-          return_eigenvectors=True, mode='normal'):
+          ncv=None, maxiter=None, tol=0, return_eigenvectors=True,
+          Minv=None, OPinv=None, mode='normal'):
     """
-    Find k eigenvalues and eigenvectors of the real symmetric square matrix A.
+    Find k eigenvalues and eigenvectors of the real symmetric square matrix
+    or complex hermitian matrix A.
 
     Solves ``A * x[i] = w[i] * x[i]``, the standard eigenvalue problem for
     w[i] eigenvalues with corresponding eigenvectors x[i].
 
-    If M is specified, solves ``A * x[i] = w[i] * M * x[i]``, the 
-    generalized eigenvalue problem for w[i] eigenvalues 
+    If M is specified, solves ``A * x[i] = w[i] * M * x[i]``, the
+    generalized eigenvalue problem for w[i] eigenvalues
     with corresponding eigenvectors x[i]
 
 
@@ -1252,28 +1297,28 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     Other Parameters
     ----------------
     M : An N x N matrix, array, sparse matrix, or linear operator representing
-        the operation M * x for the generalized eigenvalue problem 
-          ``A * x = w * M * x``.  
+        the operation M * x for the generalized eigenvalue problem
+          ``A * x = w * M * x``.
         M must represent a real, symmetric matrix.  Additionally:
-         * If sigma==None, M must be symmetric positive definite
-         * If sigma is specified, M must be symmetric positive semi-definite
-         * In buckling mode, M must be symmetric indefinite.
-        If sigma==None, eigsh requires an operator to compute the solution 
-        of the linear equation `M * x = b`. This is done internally via a 
-        (sparse) LU decomposition for an explicit matrix M, or via an 
-        iterative solver for a general linear operator.  Alternatively, 
+         * If sigma == None, M is symmetric positive definite
+         * If sigma is specified, M is symmetric positive semi-definite
+         * In buckling mode, M is symmetric indefinite.
+        If sigma == None, eigsh requires an operator to compute the solution
+        of the linear equation `M * x = b`. This is done internally via a
+        (sparse) LU decomposition for an explicit matrix M, or via an
+        iterative solver for a general linear operator.  Alternatively,
         the user can supply the matrix or operator Minv, which gives
         x = Minv * b = M^-1 * b
     sigma : real
         Find eigenvalues near sigma using shift-invert mode.  This requires
-        an operator to compute the solution of the linear system 
-        `[A - sigma * M] x = b`, where M is the identity matrix if 
-        unspecified.  This is computed internally via a (sparse) LU 
-        decomposition for explicit matrices A & M, or via an iterative 
-        solver if either A or M is a general linear operator.  
-        Alternatively, the user can supply the matrix or operator OPinv, 
-        which gives x = OPinv * b = [A - sigma * M]^-1 * b .
-        Note that when sigma is specified, the keyword 'which' (below) 
+        an operator to compute the solution of the linear system
+        `[A - sigma * M] x = b`, where M is the identity matrix if
+        unspecified.  This is computed internally via a (sparse) LU
+        decomposition for explicit matrices A & M, or via an iterative
+        solver if either A or M is a general linear operator.
+        Alternatively, the user can supply the matrix or operator OPinv,
+        which gives x = OPinv * b = [A - sigma * M]^-1 * b.
+        Note that when sigma is specified, the keyword 'which' (below)
         refers to the shifted eigenvalues w'[i] = 1 / (w[i] - sigma).
     v0 : array
         Starting vector for iteration.
@@ -1281,12 +1326,12 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         The number of Lanczos vectors generated
         ncv must be greater than k and smaller than n;
         it is recommended that ncv > 2*k
-    which : string
+    which : string ['LM' | 'SM' | 'LA' | 'SA' | 'BE']
         Which k eigenvectors and eigenvalues to find:
-         - 'LA' : Largest (algebraic) eigenvalues
-         - 'SA' : Smallest (algebraic) eigenvalues
          - 'LM' : Largest (in magnitude) eigenvalues
          - 'SM' : Smallest (in magnitude) eigenvalues
+         - 'LA' : Largest (algebraic) eigenvalues
+         - 'SA' : Smallest (algebraic) eigenvalues
          - 'BE' : Half (k/2) from each end of the spectrum
                   When k is odd, return one more (k/2+1) from the high end
         When sigma != None, 'which' refers to the shifted eigenvalues
@@ -1302,16 +1347,16 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         See notes in sigma, above.
     return_eigenvectors : boolean
         Return eigenvectors (True) in addition to eigenvalues
-    mode : ['normal' | 'buckling' | 'cayley']
+    mode : string ['normal' | 'buckling' | 'cayley']
         Specify strategy to use for shift-invert mode.  This argument applies
         only if sigma != None.  For shift-invert mode, ARPACK internally
         solves the eigenvalue problem ``OP * x[i] = w[i] * B * x[i]``
-          if mode=='normal'   : OP = [A - sigma * M]^-1 * M
-                                B = M
-          if mode=='buckling' : OP = [A - sigma * M]^-1 * A
-                                B = A
-          if mode=='cayley'   : OP = [A - sigma * M]^-1 * [A + sigma * M]
-                                B = M
+          - 'normal'   : OP = [A - sigma * M]^-1 * M
+                         B = M
+          - 'buckling' : OP = [A - sigma * M]^-1 * A
+                         B = A
+          - 'cayley'   : OP = [A - sigma * M]^-1 * [A + sigma * M]
+                         B = M
         ARPACK transforms the resulting eigenvectors into the desired solution
         of the problem ``A * x[i] = w[i] * M * x[i]``.  The choice of mode
         can affect the stability of convergence (see [2] for a discussion)
@@ -1328,7 +1373,7 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     --------
     eigs : eigenvalues and eigenvectors for a general (nonsymmetric) matrix A
     svds : singular value decomposition for a matrix A
-    
+
     Notes
     -----
     This function is a wrapper to the ARPACK [1]_ SSEUPD and DSEUPD
@@ -1351,28 +1396,35 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
        Solution of Large Scale Eigenvalue Problems by Implicitly Restarted
        Arnoldi Methods. SIAM, Philadelphia, PA, 1998.
     """
+    # complex hermitian matrices should be solved with eigs
+    if np.issubdtype(A.dtype, np.complexfloating):
+        if mode != 'normal':
+            raise ValueError("mode=%s cannot be used with "
+                             "complex matrix A" % mode)
+        ret = eigs(A, k, M=M, sigma=sigma, which=which, v0=v0,
+                   ncv=ncv, maxiter=maxiter, tol=tol,
+                   return_eigenvectors=return_eigenvectors, Minv=Minv,
+                   OPinv=OPinv)
+
+        if return_eigenvectors:
+            return ret[0].real, ret[1]
+        else:
+            return ret.real
+
     if A.shape[0] != A.shape[1]:
         raise ValueError('expected square matrix (shape=%s)' % (A.shape,))
     if (M is not None) and (M.shape != A.shape):
-        raise ValueError('wrong M dimensions %s, should be %s' 
-                         % (M.shape,A.shape) )
+        raise ValueError('wrong M dimensions %s, should be %s'
+                         % (M.shape, A.shape))
     n = A.shape[0]
-    
-    #complex hermitian matrices should be solved with eigs
-    if np.issubdtype(A.dtype, np.complexfloating):
-        if mode != 'normal': raise ValueError("mode=%s cannot be used with "
-                                              "complex matrix A" % mode)
-        return eigs(A, k, M=M, sigma=sigma, which=which, v0=v0,
-                    ncv=ncv, maxiter=maxiter, tol=tol, Minv=Minv,
-                    OPinv=OPinv, return_eigenvectors=return_eigenvectors)
-    
-    if k<=0 or k>=n:
+
+    if k <= 0 or k >= n:
         raise ValueError("k must be between 1 and rank(A)-1")
 
     if sigma is None:
         A = _aslinearoperator_with_dtype(A)
         matvec = A.matvec
-        
+
         if OPinv is not None:
             raise ValueError("OPinv should not be specified "
                              "with sigma = None.")
@@ -1388,22 +1440,23 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
             #general eigenvalue problem
             mode = 2
             if Minv is None:
-                Minv_matvec = get_inv_matvec(M)
+                Minv_matvec = get_inv_matvec(M, tol=tol)
             else:
                 Minv = _aslinearoperator_with_dtype(Minv)
                 Minv_matvec = Minv.matvec
             M_matvec = _aslinearoperator_with_dtype(M).matvec
     else:
-        #sigma is not None: shift-invert mode
+        # sigma is not None: shift-invert mode
         if Minv is not None:
             raise ValueError("Minv should not be specified when sigma is")
-        
-        #normal mode
+
+        # normal mode
         if mode == 'normal':
             mode = 3
             matvec = None
             if OPinv is None:
-                Minv_matvec = get_OPinv_matvec(A, M, sigma, symmetric=True)
+                Minv_matvec = get_OPinv_matvec(A, M, sigma,
+                                               symmetric=True, tol=tol)
             else:
                 OPinv = _aslinearoperator_with_dtype(OPinv)
                 Minv_matvec = OPinv.matvec
@@ -1412,30 +1465,33 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
             else:
                 M = _aslinearoperator_with_dtype(M)
                 M_matvec = M.matvec
-        
-        #buckling mode
+
+        # buckling mode
         elif mode == 'buckling':
             mode = 4
             if OPinv is None:
-                Minv_matvec = get_OPinv_matvec(A, M, sigma, symmetric=True)
+                Minv_matvec = get_OPinv_matvec(A, M, sigma,
+                                               symmetric=True, tol=tol)
             else:
                 Minv_matvec = _aslinearoperator_with_dtype(OPinv).matvec
             matvec = _aslinearoperator_with_dtype(A).matvec
             M_matvec = None
 
-        #cayley-transform mode
+        # cayley-transform mode
         elif mode == 'cayley':
             mode = 5
             matvec = _aslinearoperator_with_dtype(A).matvec
             if OPinv is None:
-                Minv_matvec = get_OPinv_matvec(A, M, sigma, symmetric=True)
+                Minv_matvec = get_OPinv_matvec(A, M, sigma,
+                                               symmetric=True, tol=tol)
             else:
                 Minv_matvec = _aslinearoperator_with_dtype(OPinv).matvec
             if M is None:
                 M_matvec = None
             else:
-                M_matvec = _aslinearoperator_with_dtype(M).matvec  
- 
+                M_matvec = _aslinearoperator_with_dtype(M).matvec
+
+        # unrecognized mode
         else:
             raise ValueError("unrecognized mode '%s'" % mode)
 
@@ -1447,6 +1503,7 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         params.iterate()
 
     return params.extract(return_eigenvectors)
+
 
 def svds(A, k=6, ncv=None, tol=0):
     """Compute k singular values/vectors for a sparse matrix using ARPACK.
@@ -1495,7 +1552,7 @@ def svds(A, k=6, ncv=None, tol=0):
     XH_X = LinearOperator(matvec=matvec_XH_X, dtype=X.dtype,
                           shape=(X.shape[1], X.shape[1]))
 
-    eigvals, eigvec = eigensolver(XH_X, k=k, tol=tol**2)
+    eigvals, eigvec = eigensolver(XH_X, k=k, tol=tol ** 2)
     s = np.sqrt(eigvals)
 
     if n > m:

--- a/scipy/sparse/linalg/eigen/arpack/setup.py
+++ b/scipy/sparse/linalg/eigen/arpack/setup.py
@@ -41,7 +41,7 @@ def configuration(parent_package='',top_path=None):
     else:
         arpack_sources += [join('ARPACK', 'FWRAPPERS', 'dummy.f')]
 
-    config.add_library('arpack', sources=arpack_sources,
+    config.add_library('arpack_scipy', sources=arpack_sources,
                        include_dirs=[join('ARPACK', 'SRC')],
                        depends = [join('ARPACK', 'FWRAPPERS',
                                        'veclib_cabi_f.f'),
@@ -53,7 +53,7 @@ def configuration(parent_package='',top_path=None):
 
     config.add_extension('_arpack',
                          sources='arpack.pyf.src',
-                         libraries=['arpack'],
+                         libraries=['arpack_scipy'],
                          extra_info = lapack_opt
                         )
 

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -19,6 +19,35 @@ from scipy.sparse.linalg.eigen.arpack import eigs, eigsh, svds, \
 
 from scipy.linalg import svd
 
+def generate_matrix(N, complex=False, hermitian=False, 
+                    pos_definite=False, sparse=False):
+    M = np.random.random((N,N))
+    if complex:
+        M = M + 1j * np.random.random((N,N))
+
+    if hermitian:
+        if pos_definite:
+            if sparse:
+                i = np.arange(N)
+                j = np.random.randint(N, size=N-2)
+                i, j = np.meshgrid(i, j)
+                M[i,j] = 0
+            M = np.dot(M.conj(), M.T)
+        else:
+            M = np.dot(M.conj(), M.T)
+            if sparse:
+                i = np.random.randint(N, size=N * N / 4)
+                j = np.random.randint(N, size=N * N / 4)
+                ind = np.where(i == j)
+                j[ind] = (j[ind] + 1) % N
+                M[i,j] = 0
+                M[j,i] = 0
+    else:
+        if sparse:
+            i = np.random.randint(N, size=N * N / 2)
+            j = np.random.randint(N, size=N * N / 2)
+            M[i,j] = 0
+    return M
 
 def _aslinearoperator_with_dtype(m):
     m = aslinearoperator(m)
@@ -47,233 +76,197 @@ def assert_array_almost_equal_cc(actual, desired, decimal=7,
                                   err_msg, verbose)
 
 # precision for tests
-_ndigits = {'f': 4, 'd': 12, 'F': 4, 'D': 12}
-
-# types of matrices to use
-_mattypes = [csr_matrix,
-             _aslinearoperator_with_dtype,
-             lambda x:x]
-
+_ndigits = {'f': 3, 'd': 11, 'F': 3, 'D': 11}
 
 class TestArpack(TestCase):
-    def argsort_which(self, eval, typ, k, which, sigma=None, OPpart=None):
+    def argsort_which(self, eval, typ, k, which, 
+                      sigma=None, OPpart=None, mode=None):
         if sigma is None:
-            reval = round(eval, decimals=_ndigits[typ])
+            reval = np.round(eval, decimals=_ndigits[typ])
         else:
-            if OPpart is None:
-                reval = round(1. / (eval - sigma), decimals=_ndigits[typ])
-            elif OPpart == 'r':
-                reval = 0.5 * (1. / (eval - sigma) 
-                               + 1. / (eval - np.conj(sigma)))
-                reval = round(reval, decimals=_ndigits[typ])
-            elif OPpart == 'i':
-                reval = -0.5j * (1. / (eval - sigma) 
+            if mode is None or mode=='normal':
+                if OPpart is None:
+                    reval = 1. / (eval - sigma)
+                elif OPpart == 'r':
+                    reval = 0.5 * (1. / (eval - sigma) 
+                                   + 1. / (eval - np.conj(sigma)))
+                elif OPpart == 'i':
+                    reval = -0.5j * (1. / (eval - sigma) 
                                  - 1. / (eval - np.conj(sigma)))
-                reval = round(reval, decimals=_ndigits[typ])
+            elif mode=='cayley':
+                reval = (eval + sigma) / (eval - sigma)
+            elif mode=='buckling':
+                reval = eval / (eval - sigma)
+            else:
+                raise ValueError("mode='%s' not recognized" % mode)
+            
+            reval = np.round(reval, decimals=_ndigits[typ])
+
         if which in ['LM', 'SM']:
-            ind = argsort(abs(reval))
-        elif which in ['LR', 'SR']:
-            ind = argsort(reval.real)
+            ind = np.argsort(abs(reval))
+        elif which in ['LR', 'SR', 'LA', 'SA', 'BE']:
+            ind = np.argsort(np.real(reval))
         elif which in ['LI', 'SI']:
             # for LI,SI ARPACK returns largest,smallest abs(imaginary) why?
-            ind = argsort(abs(reval.imag))
+            ind = np.argsort(abs(reval.imag))
         else:
-            ind = argsort(abs(reval))
-
-        if which in ['LR', 'LM', 'LI']:
+            raise ValueError("which='%s' is unrecognized" % which)
+        
+        if which in ['LM', 'LA', 'LR', 'LI']:
             return ind[-k:]
-        elif which in ['SR', 'SM', 'SI']:
+        elif which in ['SM', 'SA', 'SR', 'SI']:
             return ind[:k]
         elif which == 'BE':
             return np.concatenate((ind[:k/2], ind[k/2-k:]))
-        
 
     def eval_evec(self, d, typ, k, which, sigma=None, v0=None,
-                  conv=None, OPpart=None, mode='normal'):
+                  mattype=None, OPpart=None, mode='normal'):
         general = ('bmat' in d)
         if general:
             err = ("error for %s:general, typ=%s, which=%s, sigma=%s, "
-                   "conv=%s, OPpart=%s, mode=%s" % (self.__class__.__name__,
+                   "mattype=%s, OPpart=%s, mode=%s" % (self.__class__.__name__,
                                                     typ, which, sigma,
-                                                    conv, OPpart, mode))
+                                                    mattype, OPpart, mode))
         else:
             err = ("error for %s:standard, typ=%s, which=%s, sigma=%s, "
-                   "conv=%s, OPpart=%s, mode=%s" % (self.__class__.__name__,
+                   "mattype=%s, OPpart=%s, mode=%s" % (self.__class__.__name__,
                                                     typ, which, sigma,
-                                                    conv, OPpart, mode))
+                                                    mattype, OPpart, mode))
 
         a = d['mat'].astype(typ)
-        if conv is not None:
-            a = conv(a)
-        if v0 == None:
-            v0 = d['v0']
-        #get exact eigenvalues
+        if mattype is None:
+            ac = a
+        else:
+            ac = mattype(a)
+        
+        if general:
+            b = d['bmat'].astype(typ.lower())
+            if mattype is None:
+                bc = b
+            else:
+                bc = mattype(b)
+        
+        # get exact eigenvalues
         exact_eval = d['eval'].astype(typ.upper())
-        ind = self.argsort_which(exact_eval, typ, k, which, sigma, OPpart)
+        ind = self.argsort_which(exact_eval, typ, k, which,
+                                 sigma, OPpart, mode)
         exact_eval = exact_eval[ind]
-        # compute eigenvalues
+        
+        # compute arpack eigenvalues
         kwargs = dict(which=which, v0=v0, sigma=sigma)
         if self.eigs is eigsh:
             kwargs['mode'] = mode
         else:
             kwargs['OPpart'] = OPpart
-
+            
         if general:
-            b = d['bmat'].astype(typ)
-            if conv is not None:
-                b = conv(b)
-            eval, evec = self.eigs(a, k, b, **kwargs)
+            eval, evec = self.eigs(ac, k, bc, **kwargs)
         else:
-            eval, evec = self.eigs(a, k, **kwargs)
-        ind = self.argsort_which(eval, typ, k, which, sigma, OPpart)
+            eval, evec = self.eigs(ac, k, **kwargs)
+
+        ind = self.argsort_which(eval, typ, k, which,
+                                 sigma, OPpart, mode)
         eval = eval[ind]
+        evec = evec[:,ind]
         
-        #assert_array_almost_equal_cc(eval, exact_eval, decimal=_ndigits[typ])
+        # check eigenvalues
+        assert_array_almost_equal_cc(eval, exact_eval, decimal=_ndigits[typ])
 
+        # check eigenvectors
+        LHS = np.dot(a, evec)
         if general:
-            assert_array_almost_equal(np.dot(d['mat'], evec),
-                                      eval * np.dot(d['bmat'], evec),
-                                      decimal=_ndigits[typ],
-                                      err_msg = err)
+            RHS = eval * np.dot(b, evec)
         else:
-            assert_array_almost_equal(np.dot(d['mat'], evec),
-                                      eval * evec,
-                                      decimal=_ndigits[typ],
-                                      err_msg = err)
+            RHS = eval * evec
+            
+        assert_array_almost_equal(RHS, LHS,
+                                  decimal=_ndigits[typ],
+                                  err_msg = err)
 
+def modes(sigma):
+    if sigma is None:
+        return ["normal"]
+    else:
+        return ["normal", "cayley", "buckling"]
 
 class TestSymmetric(TestArpack):
     def setUp(self):
         self.eigs = eigsh
-        self.which = ['LM']#, 'SM', 'BE']
-        self.modes = ['normal']#, 'buckling', 'cayley']
+        self.which = ['LM', 'SM', 'LA', 'SA', 'BE']
+        self.mattypes = [csr_matrix, aslinearoperator, np.asarray]
+        self.sigmas_modes = {None : ['normal'],
+                             0.5 : ['normal', 'buckling', 'cayley']}
+
+        #generate matrices
+        N = 6
+        np.random.seed(11)
+        Ar = generate_matrix(N, hermitian=True, pos_definite=True)
+        M = generate_matrix(N, hermitian=True, pos_definite=True)
+        Ac = generate_matrix(N, hermitian=True, pos_definite=True, complex=True)
+        v0 = np.random.random(N)
 
         # standard symmetric problem
         SS = {}
-        SS['mat'] = array([[2.0, 0.0, 0.0, -1., 0.0, -1.],
-                           [0.0, 2.0, 0.0, -1., 0.0, -1.],
-                           [0.0, 0.0, 2.0, -1., 0.0, -1.],
-                           [-1., -1., -1., 4.0, 0.0, -1.],
-                           [0.0, 0.0, 0.0, 0.0, 1.0, -1.],
-                           [-1., -1., -1., -1., -1., 5.0]])
-        SS['eval'] = array([0, 1, 2, 2, 5, 6])
-        SS['v0'] = array([0.39574246391875789,
-                          0.00086496039750016962,
-                          -0.9227205789982591,
-                          -0.9165671495278005,
-                          0.1175963848841306,
-                          -0.29962625203712179])
-        self.standard = [SS]
+        SS['mat'] = Ar
+        SS['v0'] = v0
+        SS['eval'] = eigh(SS['mat'], eigvals_only=True)
 
         # general symmetric problem
-        SG = {}
-        SG['mat'] = SS['mat']
-        SG['bmat'] = array([[3.0, -3., 0.0, -1., 0.0, -1.],
-                            [-3., 10., 0.0, 7.0, 3.0, 5.0],
-                            [0.0, 0.0, 10., 1.0, 3.0, 0.0],
-                            [-1., 7.0, 1.0, 11., 0.0, 1.0],
-                            [0.0, 3.0, 3.0, 0.0, 8.0, -1.],
-                            [-1., 5.0, 0.0, 1.0, -1., 10.]])
-        SG['eval'] = array([0.0,
-                            1.4360859298239867e-01,
-                            2.0496461767247975e-01,
-                            5.0507316521393908e-01,
-                            6.0317191682460070e-01,
-                            1.9075146642093827e+01])
-        SG['v0'] = SS['v0']
-        self.general = [SG]
+        GS = {}
+        GS['mat'] = Ar
+        GS['bmat'] = M
+        GS['v0'] = v0
+        GS['eval'] = eigh(GS['mat'], GS['bmat'], eigvals_only=True)
 
-        #standard complex hermitian problem
-        random.seed(1234)
-        HS = {}
-        HS['mat'] = random.rand(6, 6) + 1j * random.rand(6, 6)
-        HS['mat'] = np.dot(HS['mat'], HS['mat'].conj().T)
-        HS['eval'] = eigh(HS['mat'], eigvals_only=True)
-        HS['v0'] = SS['v0']
-        self.standard_hermitian = [HS]
+        # standard hermitian problem
+        SH = {}
+        SH['mat'] = Ac
+        SH['v0'] = v0
+        SH['eval'] = eigh(SH['mat'], eigvals_only=True)
 
-        #general complex hermitian problem
-        HG = {}
-        HG['mat'] = HS['mat']
-        HG['bmat'] = SG['bmat']
-        HG['eval'] = eigh(HG['mat'], HG['bmat'], eigvals_only=True)
-        HG['v0'] = HS['v0']
-        self.general_hermitian = [HG]
+        # general hermitian problem
+        GH = {}
+        GH['mat'] = Ac
+        GH['bmat'] = M
+        GH['v0'] = v0
+        GH['eval'] = eigh(GH['mat'], GH['bmat'], eigvals_only=True)
 
-    def test_standard_symmetric_modes(self):
+        self.real_test_cases = [SS, GS]
+        self.complex_test_cases = [SH, GH]
+
+    def test_symmetric_modes(self):
         k = 2
-        for d in self.standard:
+        for D in self.real_test_cases:
             for typ in 'fd':
                 for which in self.which:
-                    for conv in _mattypes:
-                        for sigma in (None, 0.5):
-                            if sigma is None:
-                                self.eval_evec(d, typ, k, which,
-                                               sigma=sigma, conv=conv)
-                            else:
-                                for mode in self.modes:
-                                    self.eval_evec(d, typ, k, which,
-                                                   sigma=sigma, conv=conv,
-                                                   mode=mode)
+                    for mattype in self.mattypes:
+                        for (sigma, modes) in self.sigmas_modes.iteritems():
+                            for mode in modes:
+                                self.eval_evec(D, typ, k, which, sigma=sigma, 
+                                               mattype=mattype, mode=mode)
     
-    def test_general_symmetric_modes(self):
+    def test_hermitian_modes(self):
         k = 2
-        for d in self.general:
-            for typ in 'fd':
+        for D in self.complex_test_cases:
+            for typ in 'FD':
                 for which in self.which:
-                    for conv in _mattypes:
-                        for sigma in (None, 0.5):
-                            if sigma is None:
-                                self.eval_evec(d, typ, k, which,
-                                               sigma=sigma, conv=conv)
-                            else:
-                                for mode in self.modes:
-                                    self.eval_evec(d, typ, k, which,
-                                                   sigma=sigma, conv=conv,
-                                                   mode=mode)
-    
-    def test_standard_hermitian_modes(self):
-        k = 2
-        for d in self.standard_hermitian:
-            for typ in 'FD':
-                for which in self.which[:2]:
-                    for conv in _mattypes:
-                        for sigma in (None, 0.5):
-                            self.eval_evec(d, typ, k, which,
-                                           sigma=sigma, conv=conv)
+                    if which == 'BE': continue
+                    for mattype in self.mattypes:
+                        for sigma in self.sigmas_modes:
+                            self.eval_evec(D, typ, k, which, 
+                                           sigma=sigma, mattype=mattype)
 
-    def test_general_hermitian_modes(self):
+    def test_symmetric_starting_vector(self):
         k = 2
-        for d in self.general_hermitian:
-            for typ in 'FD':
-                for which in self.which[:2]:
-                    for conv in _mattypes:
-                        for sigma in (None, 0.5):
-                            self.eval_evec(d, typ, k, which,
-                                           sigma=sigma, conv=conv)
-
-    def test_standard_symmetric_starting_vector(self):
-        k = 2
-        for d in self.standard:
+        for D in self.real_test_cases:
             for typ in 'fd':
-                A = d['mat']
-                n = A.shape[0]
-                v0 = random.rand(n).astype(typ)
-                self.eval_evec(d, typ, k, which='LM', v0=v0)
+                v0 = random.rand(len(D['v0'])).astype(typ)
+                self.eval_evec(D, typ, k, which='LM', v0=v0)
 
-    def test_general_symmetric_starting_vector(self):
-        k = 2
-        for d in self.general:
-            for typ in 'fd':
-                A = d['mat']
-                n = A.shape[0]
-                v0 = random.rand(n).astype(typ)
-                self.eval_evec(d, typ, k, which='LM', v0=v0)
-
-    def test_standard_symmetric_no_convergence(self):
+    def test_symmetric_no_convergence(self):
         np.random.seed(1234)
-        m = np.random.rand(30, 30)
-        m = m + m.T
+        m = generate_matrix(30, hermitian=True, pos_definite=True)
+
         try:
             w, v = eigsh(m, 4, which='LM', v0=m[:, 0], maxiter=5)
             raise AssertionError("Spurious no-error exit")
@@ -282,122 +275,76 @@ class TestSymmetric(TestArpack):
             if k <= 0:
                 raise AssertionError("Spurious no-eigenvalues-found case")
             w, v = err.eigenvalues, err.eigenvectors
-            for ww, vv in zip(w, v.T):
-                assert_array_almost_equal(dot(m, vv), ww * vv,
-                                          decimal=_ndigits['d'])
-    """
+            assert_array_almost_equal(dot(m, v), w * v, decimal=_ndigits['d'])
 
 class TestNonSymmetric(TestArpack):
     def setUp(self):
         self.eigs = eigs
-        self.which = ['LM', 'SM', 'LR', 'SR', 'LI', 'SI']
-        self.sigmas = [None, 0.1, 0.1 + 0.1j]
+        self.which = ['LM', 'LR', 'LI']#, 'SM', 'LR', 'SR', 'LI', 'SI']
+        self.mattypes = [csr_matrix, aslinearoperator, np.asarray]
+        self.sigmas_OPparts = {None : [None],
+                               0.1 : ['r'], 
+                               0.1 + 0.1j : ['r', 'i']}
 
-        #standard nonsymmetric test case A*x = w*x
-        NS = {}
-        NS['mat'] = array([[-2., -8., 1.0, 2.0, -5.],
-                           [6.0, 6.0, 0.0, 2.0, 1.0],
-                           [0.0, 4.0, -2., 11., 0.0],
-                           [1.0, 6.0, 1.0, 0.0, -4.],
-                           [2.0, -6., 4.0, 9.0, -3]])
-        NS['v0'] = array([0.39574246391875789,
-                          0.00086496039750016962,
-                          -0.9227205789982591,
-                          -0.9165671495278005,
-                          0.1175963848841306])
-        NS['eval'] = array([-5.4854094033782888 + 0.0j,
-                             -2.2169058544873783 + 8.5966096591588261j,
-                             -2.2169058544873783 - 8.5966096591588261j,
-                             4.4596105561765107 + 3.8007839204319454j,
-                             4.4596105561765107 - 3.8007839204319454j], 'D')
-        self.standard = [NS]
+        #generate matrices
+        N = 6
+        np.random.seed(0)
+        Ar = generate_matrix(N)
+        M = generate_matrix(N, hermitian=True, pos_definite=True)
+        Ac = generate_matrix(N, complex=True)
+        v0 = np.random.random(N)
 
-        #general nonsymmetric test case A*x = w*B*x
-        NG = {}
-        NG['mat'] = NS['mat']
-        NG['bmat'] = array([[11., 0.0, 0.0, -1., -2.],
-                            [0.0, 9.0, 2.0, 0.0, 0.0],
-                            [0.0, 2.0, 1.0, 0.0, -1.],
-                            [-1., 0.0, 0.0, 10., 1.0],
-                            [-2., 0.0, -1., 1.0, 13.]])
+        # standard real nonsymmetric problem
+        SNR = {}
+        SNR['mat'] = Ar
+        SNR['v0'] = v0
+        SNR['eval'] = eig(SNR['mat'], left=False, right=False)
 
-        NG['eval'] = array([-4.1690059397428412 + 0.j,
-                             0.3168657188570727 + 0.4432894295551382j,
-                             0.3168657188570727 - 0.4432894295551382j,
-                             -0.5102635838808636 + 1.3352613149875483j,
-                             -0.5102635838808637 - 1.3352613149875483j], 'D')
-        NG['v0'] = array([0.39574246391875789,
-                          0.00086496039750016962,
-                          -0.9227205789982591,
-                          -0.9165671495278005,
-                          0.1175963848841306])
-        self.general = [NG]
+        # general real nonsymmetric problem
+        GNR = {}
+        GNR['mat'] = Ar
+        GNR['bmat'] = M
+        GNR['v0'] = v0
+        GNR['eval'] = eig(GNR['mat'], GNR['bmat'], left=False, right=False)
+        
+        # standard complex nonsymmetric problem
+        SNC = {}
+        SNC['mat'] = Ac
+        SNC['v0'] = v0
+        SNC['eval'] = eig(SNC['mat'], left=False, right=False)
 
-        #standard complex nonsymmetric case A*x = w*x
-        NCS = {}
-        NCS['mat'] = NS['mat'] + 1j * (NS['mat'] + 1)
-        NCS['eval'] = eig(NCS['mat'], left=False, right=False)
-        NCS['v0'] = NG['v0']
-        self.standard_complex = [NCS]
+        # general complex nonsymmetric problem
+        GNC = {}
+        GNC['mat'] = Ac
+        GNC['bmat'] = M
+        GNC['v0'] = v0
+        GNC['eval'] = eig(GNC['mat'], GNC['bmat'], left=False, right=False)
+        
+        self.real_test_cases = [SNR, GNR]
+        self.complex_test_cases = [SNC, GNC]
 
-        #general complex nonsymmetric case A*x = w*M*x
-        NCG = {}
-        NCG['mat'] = NCS['mat']
-        NCG['bmat'] = NG['bmat']
-        NCG['eval'] = eig(NCS['mat'], NCG['bmat'], left=False, right=False)
-        NCG['v0'] = NG['v0']
-        self.general_complex = [NCG]
-    """
-    def test_standard_nonsymmetric_modes(self):
+    def test_real_nonsymmetric_modes(self):
         k = 2
-        for d in self.standard:
+        for D in self.real_test_cases:
             for typ in 'fd':
-                for sigma in self.sigmas:
-                    if sigma is not None and np.imag(sigma) != 0:
-                        OPparts = 'ri'
-                    else:
-                        OPparts = (None,)
-                    for OPpart in OPparts:
-                        for which in self.which:
-                            for conv in _mattypes:
-                                self.eval_evec(d, typ, k, which, sigma=sigma,
-                                               conv=conv, OPpart=OPpart)
-    
-    def test_general_nonsymmetric_modes(self):
-        k = 2
-        for d in self.general:
-            for typ in 'fd':
-                for sigma in self.sigmas:
-                    if sigma is not None and np.imag(sigma) != 0:
-                        OPparts = 'ri'
-                    else:
-                        OPparts = (None,)
-                    for OPpart in OPparts:
-                        for which in self.which:
-                            for conv in _mattypes:
-                                self.eval_evec(d, typ, k, which, sigma=sigma,
-                                               conv=conv, OPpart=OPpart)
+                for which in self.which:
+                    for mattype in self.mattypes:
+                        for sigma, OPparts in self.sigmas_OPparts.iteritems():
+                            for OPpart in OPparts:
+                                self.eval_evec(D, typ, k, which, sigma=sigma,
+                                               mattype=mattype, OPpart=OPpart)
 
-    def test_complex_standard_nonsymmetric_modes(self):
+    def test_complex_nonsymmetric_modes(self):
         k = 2
-        for d in self.standard_complex:
+        for D in self.real_test_cases:
             for typ in 'FD':
-                for sigma in self.sigmas:
-                    for which in self.which:
-                        for conv in _mattypes:
-                            self.eval_evec(d, typ, k, which,
-                                           sigma=sigma, conv=conv)
+                for which in self.which:
+                    for mattype in self.mattypes:
+                        for sigma in self.sigmas_OPparts:
+                            self.eval_evec(D, typ, k, which, sigma=sigma,
+                                           mattype=mattype)
 
-    def test_complex_general_nonsymmetric_modes(self):
-        k = 2
-        for d in self.general_complex:
-            for typ in 'FD':
-                for sigma in self.sigmas:
-                    for which in self.which:
-                        for conv in _mattypes:
-                            self.eval_evec(d, typ, k, which,
-                                           sigma=sigma, conv=conv)
-
+"""
     def test_standard_nonsymmetric_starting_vector(self):
         k = 2
         sigma = None
@@ -444,13 +391,6 @@ def test_eigen_bad_kwargs():
     # Test eigen on wrong keyword argument
     A = csc_matrix(np.zeros((2, 2)))
     assert_raises(ValueError, eigs, A, which='XX')
-
-
-def test_eigs_operator():
-    # Check inferring LinearOperator dtype
-    fft_op = LinearOperator((6, 6), np.fft.fft)
-    w, v = eigs(fft_op, k=3)
-    assert_equal(w.dtype, np.complex_)
 
 
 def sorted_svd(m, k):

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -207,6 +207,7 @@ class TestNonSymmetric(TestArpack):
     def setUp(self):
         self.eigs = eigs
         self.which = ['LM','SM','LR', 'SR', 'LI', 'SI']
+        self.sigmas = [None,0.1+0.1j]
 
         #standard nonsymmetric test case A*x = w*x
         NS={}
@@ -269,27 +270,27 @@ class TestNonSymmetric(TestArpack):
     
     def test_standard_nonsymmetric_modes(self):
         k=2
-        sigma = None
         for d in self.standard:
             for typ in 'fd':
-                for which in self.which:
-                    for conv in _mattypes:
-                        self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)
+                for sigma in self.sigmas:
+                    for which in self.which:
+                        for conv in _mattypes:
+                            self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)
     
     def test_general_nonsymmetric_modes(self):
         k=2
-        sigma = None
         for d in self.general:
             for typ in 'fd':
-                for which in self.which:
-                    for conv in _mattypes:
-                        self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)
+                for sigma in self.sigmas:
+                    for which in self.which:
+                        for conv in _mattypes:
+                            self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)
 
     def test_complex_standard_nonsymmetric_modes(self):
         k=2
         for d in self.standard_complex:
             for typ in 'FD':
-                for sigma in (None,0.1+0.1j):
+                for sigma in self.sigmas:
                     for which in self.which:
                         for conv in _mattypes:
                             self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)
@@ -298,7 +299,7 @@ class TestNonSymmetric(TestArpack):
         k=2
         for d in self.general_complex:
             for typ in 'FD':
-                for sigma in (None,0.1+0.1j):
+                for sigma in self.sigmas:
                     for which in self.which:
                         for conv in _mattypes:
                             self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -76,7 +76,7 @@ def assert_array_almost_equal_cc(actual, desired, decimal=7,
                                   err_msg, verbose)
 
 # precision for tests
-_ndigits = {'f': 3, 'd': 11, 'F': 2, 'D': 8}
+_ndigits = {'f': 3, 'd': 11, 'F': 3, 'D': 11}
 
 class TestArpack(TestCase):
     def argsort_which(self, eval, typ, k, which, 

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -19,98 +19,144 @@ from scipy.sparse.linalg.eigen.arpack import eigs, eigsh, svds, \
 
 from scipy.linalg import svd
 
+
 def _aslinearoperator_with_dtype(m):
     m = aslinearoperator(m)
     if not hasattr(m, 'dtype'):
         x = np.zeros(m.shape[1])
-        m.dtype = (m*x).dtype
+        m.dtype = (m * x).dtype
     return m
 
-def assert_almost_equal_cc(actual,desired,decimal=7,err_msg='',verbose=True):
+
+def assert_almost_equal_cc(actual, desired, decimal=7,
+                           err_msg='', verbose=True):
     # almost equal or complex conjugates almost equal
     try:
-        assert_almost_equal(actual,desired,decimal,err_msg,verbose)
+        assert_almost_equal(actual, desired, decimal, err_msg, verbose)
     except:
-        assert_almost_equal(actual,conj(desired),decimal,err_msg,verbose)
+        assert_almost_equal(actual, conj(desired), decimal, err_msg, verbose)
 
 
-def assert_array_almost_equal_cc(actual,desired,decimal=7,
-                                 err_msg='',verbose=True):
+def assert_array_almost_equal_cc(actual, desired, decimal=7,
+                                 err_msg='', verbose=True):
     # almost equal or complex conjugates almost equal
     try:
-        assert_array_almost_equal(actual,desired,decimal,err_msg,verbose)
+        assert_array_almost_equal(actual, desired, decimal, err_msg, verbose)
     except:
-        assert_array_almost_equal(actual,conj(desired),decimal,err_msg,verbose)
+        assert_array_almost_equal(actual, conj(desired), decimal,
+                                  err_msg, verbose)
 
 # precision for tests
-_ndigits = {'f':4, 'd':12, 'F':4, 'D':12}
+_ndigits = {'f': 4, 'd': 12, 'F': 4, 'D': 12}
 
 # types of matrices to use
 _mattypes = [csr_matrix,
-             _aslinearoperator_with_dtype, 
+             _aslinearoperator_with_dtype,
              lambda x:x]
 
+
 class TestArpack(TestCase):
-    def argsort_which(self,eval,typ,k,which,sigma=None):
+    def argsort_which(self, eval, typ, k, which, sigma=None, OPpart=None):
         if sigma is None:
-            reval=round(eval,decimals=_ndigits[typ])
+            reval = round(eval, decimals=_ndigits[typ])
         else:
-            reval=round(1./(eval-sigma),decimals=_ndigits[typ])
-        if which in ['LR','SR']:
-            ind=argsort(reval.real)
-        elif which in ['LI','SI']:
+            if OPpart is None:
+                reval = round(1. / (eval - sigma), decimals=_ndigits[typ])
+            elif OPpart == 'r':
+                reval = 0.5 * (1. / (eval - sigma) 
+                               + 1. / (eval - np.conj(sigma)))
+                reval = round(reval, decimals=_ndigits[typ])
+            elif OPpart == 'i':
+                reval = -0.5j * (1. / (eval - sigma) 
+                                 - 1. / (eval - np.conj(sigma)))
+                reval = round(reval, decimals=_ndigits[typ])
+        if which in ['LM', 'SM']:
+            ind = argsort(abs(reval))
+        elif which in ['LR', 'SR']:
+            ind = argsort(reval.real)
+        elif which in ['LI', 'SI']:
             # for LI,SI ARPACK returns largest,smallest abs(imaginary) why?
-            ind=argsort(abs(reval.imag))
+            ind = argsort(abs(reval.imag))
         else:
-            ind=argsort(abs(reval))
+            ind = argsort(abs(reval))
 
-        if which in ['LR','LM','LI']:
+        if which in ['LR', 'LM', 'LI']:
             return ind[-k:]
-        if which in ['SR','SM','SI']:
+        elif which in ['SR', 'SM', 'SI']:
             return ind[:k]
+        elif which == 'BE':
+            return np.concatenate((ind[:k/2], ind[k/2-k:]))
+        
 
-    def eval_evec(self,d,typ,k,which,sigma=None,v0=None,conv=None,
-                  mode='normal'):
+    def eval_evec(self, d, typ, k, which, sigma=None, v0=None,
+                  conv=None, OPpart=None, mode='normal'):
         general = ('bmat' in d)
-        a=d['mat'].astype(typ)
+        if general:
+            err = ("error for %s:general, typ=%s, which=%s, sigma=%s, "
+                   "conv=%s, OPpart=%s, mode=%s" % (self.__class__.__name__,
+                                                    typ, which, sigma,
+                                                    conv, OPpart, mode))
+        else:
+            err = ("error for %s:standard, typ=%s, which=%s, sigma=%s, "
+                   "conv=%s, OPpart=%s, mode=%s" % (self.__class__.__name__,
+                                                    typ, which, sigma,
+                                                    conv, OPpart, mode))
+
+        a = d['mat'].astype(typ)
         if conv is not None:
-            a=conv(a)
+            a = conv(a)
         if v0 == None:
             v0 = d['v0']
         #get exact eigenvalues
-        exact_eval=d['eval'].astype(typ.upper())
-        ind=self.argsort_which(exact_eval,typ,k,which,sigma)
-        exact_eval=exact_eval[ind]
+        exact_eval = d['eval'].astype(typ.upper())
+        ind = self.argsort_which(exact_eval, typ, k, which, sigma, OPpart)
+        exact_eval = exact_eval[ind]
         # compute eigenvalues
         kwargs = dict(which=which, v0=v0, sigma=sigma)
         if self.eigs is eigsh:
             kwargs['mode'] = mode
+        else:
+            kwargs['OPpart'] = OPpart
 
         if general:
-            b=d['bmat'].astype(typ)
+            b = d['bmat'].astype(typ)
             if conv is not None:
                 b = conv(b)
-            eval,evec=self.eigs(a,k,b,**kwargs)
+            eval, evec = self.eigs(a, k, b, **kwargs)
         else:
-            eval,evec=self.eigs(a,k,**kwargs)
-        ind=self.argsort_which(eval,typ,k,which,sigma)
-        eval=eval[ind]
+            eval, evec = self.eigs(a, k, **kwargs)
+        ind = self.argsort_which(eval, typ, k, which, sigma, OPpart)
+        eval = eval[ind]
+        
+        #assert_array_almost_equal_cc(eval, exact_eval, decimal=_ndigits[typ])
+
+        if general:
+            assert_array_almost_equal(np.dot(d['mat'], evec),
+                                      eval * np.dot(d['bmat'], evec),
+                                      decimal=_ndigits[typ],
+                                      err_msg = err)
+        else:
+            assert_array_almost_equal(np.dot(d['mat'], evec),
+                                      eval * evec,
+                                      decimal=_ndigits[typ],
+                                      err_msg = err)
+
 
 class TestSymmetric(TestArpack):
     def setUp(self):
         self.eigs = eigsh
-        self.which = ['LM','SM','BE']
-        self.modes = ['normal','buckling','cayley']
+        self.which = ['LM']#, 'SM', 'BE']
+        self.modes = ['normal']#, 'buckling', 'cayley']
 
         # standard symmetric problem
         SS = {}
-        SS['mat']=array([[ 2.,  0.,  0., -1.,  0., -1.],
-                         [ 0.,  2.,  0., -1.,  0., -1.],
-                         [ 0.,  0.,  2., -1.,  0., -1.],
-                         [-1., -1., -1.,  4.,  0., -1.],
-                         [ 0.,  0.,  0.,  0.,  1., -1.],
-                         [-1., -1., -1., -1., -1.,  5.]])
-        SS['eval']=array([0,1,2,2,5,6])        
+        SS['mat'] = array([[2.0, 0.0, 0.0, -1., 0.0, -1.],
+                           [0.0, 2.0, 0.0, -1., 0.0, -1.],
+                           [0.0, 0.0, 2.0, -1., 0.0, -1.],
+                           [-1., -1., -1., 4.0, 0.0, -1.],
+                           [0.0, 0.0, 0.0, 0.0, 1.0, -1.],
+                           [-1., -1., -1., -1., -1., 5.0]])
+        SS['eval'] = array([0, 1, 2, 2, 5, 6])
         SS['v0'] = array([0.39574246391875789,
                           0.00086496039750016962,
                           -0.9227205789982591,
@@ -118,81 +164,118 @@ class TestSymmetric(TestArpack):
                           0.1175963848841306,
                           -0.29962625203712179])
         self.standard = [SS]
-        
+
         # general symmetric problem
         SG = {}
         SG['mat'] = SS['mat']
-        SG['bmat'] = array([[ 3., -3.,  0., -1.,  0., -1.],
-                            [-3., 10.,  0.,  7.,  3.,  5.],
-                            [ 0.,  0., 10.,  1.,  3.,  0.],
-                            [-1.,  7.,  1., 11.,  0.,  1.],
-                            [ 0.,  3.,  3.,  0.,  8., -1.],
-                            [-1.,  5.,  0.,  1., -1., 10.]])
+        SG['bmat'] = array([[3.0, -3., 0.0, -1., 0.0, -1.],
+                            [-3., 10., 0.0, 7.0, 3.0, 5.0],
+                            [0.0, 0.0, 10., 1.0, 3.0, 0.0],
+                            [-1., 7.0, 1.0, 11., 0.0, 1.0],
+                            [0.0, 3.0, 3.0, 0.0, 8.0, -1.],
+                            [-1., 5.0, 0.0, 1.0, -1., 10.]])
         SG['eval'] = array([0.0,
                             1.4360859298239867e-01,
                             2.0496461767247975e-01,
-                            5.0507316521393908e-01,   
-                            6.0317191682460070e-01,   
+                            5.0507316521393908e-01,
+                            6.0317191682460070e-01,
                             1.9075146642093827e+01])
-        SG['v0']= SS['v0']
+        SG['v0'] = SS['v0']
         self.general = [SG]
-    
+
+        #standard complex hermitian problem
+        random.seed(1234)
+        HS = {}
+        HS['mat'] = random.rand(6, 6) + 1j * random.rand(6, 6)
+        HS['mat'] = np.dot(HS['mat'], HS['mat'].conj().T)
+        HS['eval'] = eigh(HS['mat'], eigvals_only=True)
+        HS['v0'] = SS['v0']
+        self.standard_hermitian = [HS]
+
+        #general complex hermitian problem
+        HG = {}
+        HG['mat'] = HS['mat']
+        HG['bmat'] = SG['bmat']
+        HG['eval'] = eigh(HG['mat'], HG['bmat'], eigvals_only=True)
+        HG['v0'] = HS['v0']
+        self.general_hermitian = [HG]
+
     def test_standard_symmetric_modes(self):
-        k=2
+        k = 2
         for d in self.standard:
             for typ in 'fd':
                 for which in self.which:
                     for conv in _mattypes:
-                        for sigma in (None,0.5):
+                        for sigma in (None, 0.5):
                             if sigma is None:
-                                self.eval_evec(d,typ,k,which,
-                                               sigma=sigma,conv=conv)
+                                self.eval_evec(d, typ, k, which,
+                                               sigma=sigma, conv=conv)
                             else:
                                 for mode in self.modes:
-                                    self.eval_evec(d, typ, k, which, 
-                                                   sigma=sigma,conv=conv,
+                                    self.eval_evec(d, typ, k, which,
+                                                   sigma=sigma, conv=conv,
                                                    mode=mode)
-                                    
+    
     def test_general_symmetric_modes(self):
-        k=2
+        k = 2
         for d in self.general:
             for typ in 'fd':
                 for which in self.which:
                     for conv in _mattypes:
-                        for sigma in (None,0.5):
+                        for sigma in (None, 0.5):
                             if sigma is None:
-                                self.eval_evec(d,typ,k,which,
-                                               sigma=sigma,conv=conv)
+                                self.eval_evec(d, typ, k, which,
+                                               sigma=sigma, conv=conv)
                             else:
                                 for mode in self.modes:
-                                    self.eval_evec(d,typ,k,which,
-                                                   sigma=sigma,conv=conv,
+                                    self.eval_evec(d, typ, k, which,
+                                                   sigma=sigma, conv=conv,
                                                    mode=mode)
+    
+    def test_standard_hermitian_modes(self):
+        k = 2
+        for d in self.standard_hermitian:
+            for typ in 'FD':
+                for which in self.which[:2]:
+                    for conv in _mattypes:
+                        for sigma in (None, 0.5):
+                            self.eval_evec(d, typ, k, which,
+                                           sigma=sigma, conv=conv)
+
+    def test_general_hermitian_modes(self):
+        k = 2
+        for d in self.general_hermitian:
+            for typ in 'FD':
+                for which in self.which[:2]:
+                    for conv in _mattypes:
+                        for sigma in (None, 0.5):
+                            self.eval_evec(d, typ, k, which,
+                                           sigma=sigma, conv=conv)
 
     def test_standard_symmetric_starting_vector(self):
-        k=2
+        k = 2
         for d in self.standard:
             for typ in 'fd':
-                A=d['mat']
-                n=A.shape[0]
+                A = d['mat']
+                n = A.shape[0]
                 v0 = random.rand(n).astype(typ)
-                self.eval_evec(d,typ,k,which='LM',v0=v0)
+                self.eval_evec(d, typ, k, which='LM', v0=v0)
 
     def test_general_symmetric_starting_vector(self):
-        k=2
+        k = 2
         for d in self.general:
             for typ in 'fd':
-                A=d['mat']
-                n=A.shape[0]
+                A = d['mat']
+                n = A.shape[0]
                 v0 = random.rand(n).astype(typ)
-                self.eval_evec(d,typ,k,which='LM',v0=v0)
+                self.eval_evec(d, typ, k, which='LM', v0=v0)
 
     def test_standard_symmetric_no_convergence(self):
         np.random.seed(1234)
         m = np.random.rand(30, 30)
         m = m + m.T
         try:
-            w, v = eigsh(m, 4, which='LM', v0=m[:,0], maxiter=5)
+            w, v = eigsh(m, 4, which='LM', v0=m[:, 0], maxiter=5)
             raise AssertionError("Spurious no-error exit")
         except ArpackNoConvergence, err:
             k = len(err.eigenvalues)
@@ -200,51 +283,49 @@ class TestSymmetric(TestArpack):
                 raise AssertionError("Spurious no-eigenvalues-found case")
             w, v = err.eigenvalues, err.eigenvectors
             for ww, vv in zip(w, v.T):
-                assert_array_almost_equal(dot(m, vv), ww*vv,
+                assert_array_almost_equal(dot(m, vv), ww * vv,
                                           decimal=_ndigits['d'])
+    """
 
 class TestNonSymmetric(TestArpack):
     def setUp(self):
         self.eigs = eigs
-        self.which = ['LM','SM','LR', 'SR', 'LI', 'SI']
-        self.sigmas = [None,0.1+0.1j]
+        self.which = ['LM', 'SM', 'LR', 'SR', 'LI', 'SI']
+        self.sigmas = [None, 0.1, 0.1 + 0.1j]
 
         #standard nonsymmetric test case A*x = w*x
-        NS={}
-        NS['mat']= array([[-2., -8.,  1.,  2., -5.],
-                          [ 6.,  6.,  0.,  2.,  1.],
-                          [ 0.,  4., -2., 11.,  0.],
-                          [ 1.,  6.,  1.,  0., -4.],
-                          [ 2., -6.,  4.,  9., -3]])
-        
+        NS = {}
+        NS['mat'] = array([[-2., -8., 1.0, 2.0, -5.],
+                           [6.0, 6.0, 0.0, 2.0, 1.0],
+                           [0.0, 4.0, -2., 11., 0.0],
+                           [1.0, 6.0, 1.0, 0.0, -4.],
+                           [2.0, -6., 4.0, 9.0, -3]])
         NS['v0'] = array([0.39574246391875789,
                           0.00086496039750016962,
                           -0.9227205789982591,
                           -0.9165671495278005,
                           0.1175963848841306])
-        NS['eval']=array([ -5.4854094033782888+0.0j,
-                            -2.2169058544873783+8.5966096591588261j,
-                            -2.2169058544873783-8.5966096591588261j,
-                            4.4596105561765107+3.8007839204319454j,
-                            4.4596105561765107-3.8007839204319454j],'D')
+        NS['eval'] = array([-5.4854094033782888 + 0.0j,
+                             -2.2169058544873783 + 8.5966096591588261j,
+                             -2.2169058544873783 - 8.5966096591588261j,
+                             4.4596105561765107 + 3.8007839204319454j,
+                             4.4596105561765107 - 3.8007839204319454j], 'D')
         self.standard = [NS]
 
         #general nonsymmetric test case A*x = w*B*x
-        NG={}
-        NG['mat'] =  NS['mat']
+        NG = {}
+        NG['mat'] = NS['mat']
+        NG['bmat'] = array([[11., 0.0, 0.0, -1., -2.],
+                            [0.0, 9.0, 2.0, 0.0, 0.0],
+                            [0.0, 2.0, 1.0, 0.0, -1.],
+                            [-1., 0.0, 0.0, 10., 1.0],
+                            [-2., 0.0, -1., 1.0, 13.]])
 
-        NG['bmat'] = array([[11.,  0.,  0., -1., -2.],
-                            [ 0.,  9.,  2.,  0.,  0.],
-                            [ 0.,  2.,  1.,  0., -1.],
-                            [-1.,  0.,  0., 10.,  1.],
-                            [-2.,  0., -1.,  1., 13.]])
-
-        NG['eval'] = array([-4.1690059397428412+0.j,
-                             0.3168657188570727+0.4432894295551382j,
-                             0.3168657188570727-0.4432894295551382j,
-                             -0.5102635838808636+1.3352613149875483j,
-                             -0.5102635838808637-1.3352613149875483j])
-        
+        NG['eval'] = array([-4.1690059397428412 + 0.j,
+                             0.3168657188570727 + 0.4432894295551382j,
+                             0.3168657188570727 - 0.4432894295551382j,
+                             -0.5102635838808636 + 1.3352613149875483j,
+                             -0.5102635838808637 - 1.3352613149875483j], 'D')
         NG['v0'] = array([0.39574246391875789,
                           0.00086496039750016962,
                           -0.9227205789982591,
@@ -253,83 +334,95 @@ class TestNonSymmetric(TestArpack):
         self.general = [NG]
 
         #standard complex nonsymmetric case A*x = w*x
-        NCS={}
-        NCS['mat'] = NS['mat'] + 1j*(NS['mat']+1)
-        NCS['eval'] = eig(NCS['mat'],left=False,right=False)
+        NCS = {}
+        NCS['mat'] = NS['mat'] + 1j * (NS['mat'] + 1)
+        NCS['eval'] = eig(NCS['mat'], left=False, right=False)
         NCS['v0'] = NG['v0']
         self.standard_complex = [NCS]
 
         #general complex nonsymmetric case A*x = w*M*x
-        NCG={}
+        NCG = {}
         NCG['mat'] = NCS['mat']
         NCG['bmat'] = NG['bmat']
-        NCG['eval'] = eig(NCS['mat'],NCG['bmat'],left=False,right=False)
+        NCG['eval'] = eig(NCS['mat'], NCG['bmat'], left=False, right=False)
         NCG['v0'] = NG['v0']
         self.general_complex = [NCG]
-        
-    
+    """
     def test_standard_nonsymmetric_modes(self):
-        k=2
+        k = 2
         for d in self.standard:
             for typ in 'fd':
                 for sigma in self.sigmas:
-                    for which in self.which:
-                        for conv in _mattypes:
-                            self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)
+                    if sigma is not None and np.imag(sigma) != 0:
+                        OPparts = 'ri'
+                    else:
+                        OPparts = (None,)
+                    for OPpart in OPparts:
+                        for which in self.which:
+                            for conv in _mattypes:
+                                self.eval_evec(d, typ, k, which, sigma=sigma,
+                                               conv=conv, OPpart=OPpart)
     
     def test_general_nonsymmetric_modes(self):
-        k=2
+        k = 2
         for d in self.general:
             for typ in 'fd':
                 for sigma in self.sigmas:
-                    for which in self.which:
-                        for conv in _mattypes:
-                            self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)
+                    if sigma is not None and np.imag(sigma) != 0:
+                        OPparts = 'ri'
+                    else:
+                        OPparts = (None,)
+                    for OPpart in OPparts:
+                        for which in self.which:
+                            for conv in _mattypes:
+                                self.eval_evec(d, typ, k, which, sigma=sigma,
+                                               conv=conv, OPpart=OPpart)
 
     def test_complex_standard_nonsymmetric_modes(self):
-        k=2
+        k = 2
         for d in self.standard_complex:
             for typ in 'FD':
                 for sigma in self.sigmas:
                     for which in self.which:
                         for conv in _mattypes:
-                            self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)
+                            self.eval_evec(d, typ, k, which,
+                                           sigma=sigma, conv=conv)
 
     def test_complex_general_nonsymmetric_modes(self):
-        k=2
+        k = 2
         for d in self.general_complex:
             for typ in 'FD':
                 for sigma in self.sigmas:
                     for which in self.which:
                         for conv in _mattypes:
-                            self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)
-        
+                            self.eval_evec(d, typ, k, which,
+                                           sigma=sigma, conv=conv)
 
     def test_standard_nonsymmetric_starting_vector(self):
-        k=2
+        k = 2
         sigma = None
         for d in self.standard:
             for typ in 'fd':
-                A=d['mat']
-                n=A.shape[0]
+                A = d['mat']
+                n = A.shape[0]
                 v0 = random.rand(n).astype(typ)
-                self.eval_evec(d,typ,k,which='LM',sigma=sigma,v0=v0)
+                self.eval_evec(d, typ, k, which='LM', sigma=sigma, v0=v0)
 
     def test_general_nonsymmetric_starting_vector(self):
-        k=2
+        k = 2
         sigma = None
         for d in self.general:
             for typ in 'fd':
-                A=d['mat']
-                n=A.shape[0]
+                A = d['mat']
+                n = A.shape[0]
                 v0 = random.rand(n).astype(typ)
-                self.eval_evec(d,typ,k,which='LM',sigma=sigma,v0=v0)
+                self.eval_evec(d, typ, k, which='LM', sigma=sigma, v0=v0)
 
     def test_standard_nonsymmetric_no_convergence(self):
         np.random.seed(1234)
         m = np.random.rand(30, 30)
         try:
-            w, v = eigs(m, 4, which='LM', v0=m[:,0], maxiter=5)
+            w, v = eigs(m, 4, which='LM', v0=m[:, 0], maxiter=5)
             raise AssertionError("Spurious no-error exit")
         except ArpackNoConvergence, err:
             k = len(err.eigenvalues)
@@ -337,18 +430,19 @@ class TestNonSymmetric(TestArpack):
                 raise AssertionError("Spurious no-eigenvalues-found case")
             w, v = err.eigenvalues, err.eigenvectors
             for ww, vv in zip(w, v.T):
-                assert_array_almost_equal(dot(m, vv), ww*vv,
+                assert_array_almost_equal(dot(m, vv), ww * vv,
                                           decimal=_ndigits['d'])
+    """
 
 def test_eigen_bad_shapes():
     # A is not square.
-    A = csc_matrix(np.zeros((2,3)))
+    A = csc_matrix(np.zeros((2, 3)))
     assert_raises(ValueError, eigs, A)
 
 
 def test_eigen_bad_kwargs():
     # Test eigen on wrong keyword argument
-    A = csc_matrix(np.zeros((2,2)))
+    A = csc_matrix(np.zeros((2, 2)))
     assert_raises(ValueError, eigs, A, which='XX')
 
 
@@ -357,6 +451,7 @@ def test_eigs_operator():
     fft_op = LinearOperator((6, 6), np.fft.fft)
     w, v = eigs(fft_op, k=3)
     assert_equal(w.dtype, np.complex_)
+
 
 def sorted_svd(m, k):
     """Compute svd of a dense matrix m, and return singular vectors/values
@@ -368,8 +463,10 @@ def sorted_svd(m, k):
 
     return u[:, ii], s[ii], vh[ii]
 
+
 def svd_estimate(u, s, vh):
     return np.dot(u, np.dot(np.diag(s), vh))
+
 
 class TestSparseSvd(TestCase):
     def test_simple_real(self):
@@ -396,16 +493,16 @@ class TestSparseSvd(TestCase):
     def test_simple_complex(self):
         x = np.array([[1, 2, 3],
                       [3, 4, 3],
-                      [1+1j, 0, 2],
+                      [1 + 1j, 0, 2],
                       [0, 0, 1]], np.complex)
-        y = np.array([[1, 2, 3, 8+5j],
-                      [3-2j, 4, 3, 5],
+        y = np.array([[1, 2, 3, 8 + 5j],
+                      [3 - 2j, 4, 3, 5],
                       [1, 0, 2, 3],
                       [0, 0, 1, 0]], np.complex)
         z = csc_matrix(x)
 
         for m in [x, x.T.conjugate(), x.T, y, y.conjugate(), z, z.T]:
-            for k in range(1, min(m.shape)-1):
+            for k in range(1, min(m.shape) - 1):
                 u, s, vh = sorted_svd(m, k)
                 su, ss, svh = svds(m, k)
 
@@ -413,6 +510,6 @@ class TestSparseSvd(TestCase):
                 sm_hat = svd_estimate(su, ss, svh)
 
                 assert_array_almost_equal_nulp(m_hat, sm_hat, nulp=1000)
-        
+
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -108,7 +108,6 @@ class TestArpack(TestCase):
             ind = np.argsort(np.real(reval))
         elif which in ['LI', 'SI']:
             # for LI,SI ARPACK returns largest,smallest abs(imaginary) why?
-            print '-'
             if typ.islower():
                 ind = np.argsort(abs(np.imag(reval)))
             else:
@@ -172,15 +171,9 @@ class TestArpack(TestCase):
         evec = evec[:,ind]
         
         # check eigenvalues
-        try:
-            assert_array_almost_equal_cc(eval, exact_eval, 
-                                         decimal=_ndigits[typ],
-                                         err_msg=err)
-        except:
-            print err
-            print eval_a
-            print exact_eval_a
-            
+        assert_array_almost_equal_cc(eval, exact_eval, 
+                                     decimal=_ndigits[typ],
+                                     err_msg=err)
 
         # check eigenvectors
         LHS = np.dot(a, evec)
@@ -189,12 +182,10 @@ class TestArpack(TestCase):
         else:
             RHS = eval * evec
             
-        try:
-            assert_array_almost_equal(LHS, RHS,
-                                      decimal=_ndigits[typ],
-                                      err_msg=err)
-        except:
-            print err
+        assert_array_almost_equal(LHS, RHS,
+                                  decimal=_ndigits[typ],
+                                  err_msg=err)
+
 
 def modes(sigma):
     if sigma is None:
@@ -346,9 +337,6 @@ class TestNonSymmetric(TestArpack):
         self.real_test_cases = [SNR, GNR]
         self.complex_test_cases = [SNC, GNC]
 
-        for D in self.real_test_cases + self.complex_test_cases:
-            print D['eval']
-
     # This leads to memory errors.  Not sure the source...
     #
     #def test_real_nonsymmetric_modes(self):
@@ -361,7 +349,7 @@ class TestNonSymmetric(TestArpack):
     #                        for OPpart in OPparts:
     #                            self.eval_evec(D, typ, k, which, sigma=sigma,
     #                                           mattype=mattype, OPpart=OPpart)
-
+        
     def test_complex_nonsymmetric_modes(self):
         k = 2
         for D in self.complex_test_cases:
@@ -371,7 +359,6 @@ class TestNonSymmetric(TestArpack):
                         for sigma in self.sigmas_OPparts:
                             self.eval_evec(D, typ, k, which, sigma=sigma,
                                            mattype=mattype)
-
 
     def test_standard_nonsymmetric_starting_vector(self):
         k = 2

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
 __usage__ = """
 To run tests locally:
   python tests/test_arpack.py [-l<int>] [-v<int>]
 
 """
+
 import numpy as np
 
 from numpy.testing import assert_almost_equal, assert_array_almost_equal, \
@@ -11,12 +11,20 @@ from numpy.testing import assert_almost_equal, assert_array_almost_equal, \
         assert_raises, verbose, assert_equal
 
 from numpy import array, finfo, argsort, dot, round, conj, random
-from scipy.sparse import csc_matrix, isspmatrix
-from scipy.sparse.linalg import LinearOperator
+from scipy.linalg import eig, eigh
+from scipy.sparse import csc_matrix, csr_matrix, lil_matrix, isspmatrix
+from scipy.sparse.linalg import LinearOperator, aslinearoperator
 from scipy.sparse.linalg.eigen.arpack import eigs, eigsh, svds, \
      ArpackNoConvergence
 
 from scipy.linalg import svd
+
+def _aslinearoperator_with_dtype(m):
+    m = aslinearoperator(m)
+    if not hasattr(m, 'dtype'):
+        x = np.zeros(m.shape[1])
+        m.dtype = (m*x).dtype
+    return m
 
 def assert_almost_equal_cc(actual,desired,decimal=7,err_msg='',verbose=True):
     # almost equal or complex conjugates almost equal
@@ -34,171 +42,273 @@ def assert_array_almost_equal_cc(actual,desired,decimal=7,
     except:
         assert_array_almost_equal(actual,conj(desired),decimal,err_msg,verbose)
 
-
-
 # precision for tests
 _ndigits = {'f':4, 'd':12, 'F':4, 'D':12}
 
+# types of matrices to use
+_mattypes = [csr_matrix,
+             _aslinearoperator_with_dtype, 
+             lambda x:x]
+
 class TestArpack(TestCase):
+    def argsort_which(self,eval,typ,k,which,sigma=None):
+        if sigma is None:
+            reval=round(eval,decimals=_ndigits[typ])
+        else:
+            reval=round(1./(eval-sigma),decimals=_ndigits[typ])
+        if which in ['LR','SR']:
+            ind=argsort(reval.real)
+        elif which in ['LI','SI']:
+            # for LI,SI ARPACK returns largest,smallest abs(imaginary) why?
+            ind=argsort(abs(reval.imag))
+        else:
+            ind=argsort(abs(reval))
 
+        if which in ['LR','LM','LI']:
+            return ind[-k:]
+        if which in ['SR','SM','SI']:
+            return ind[:k]
+
+    def eval_evec(self,d,typ,k,which,sigma=None,v0=None,conv=None):
+        general = ('bmat' in d)
+        a=d['mat'].astype(typ)
+        if conv is not None:
+            a=conv(a)
+        if v0 == None:
+            v0 = d['v0']
+        #get exact eigenvalues
+        exact_eval=d['eval'].astype(typ.upper())
+        ind=self.argsort_which(exact_eval,typ,k,which,sigma)
+        exact_eval=exact_eval[ind]
+        # compute eigenvalues
+        if general:
+            b=d['bmat'].astype(typ)
+            if conv is not None:
+                b = conv(b)
+            eval,evec=self.eigs(a,k,b,which=which,v0=v0,sigma=sigma)
+        else:
+            eval,evec=self.eigs(a,k,which=which,v0=v0,sigma=sigma)
+        ind=self.argsort_which(eval,typ,k,which,sigma)
+        eval=eval[ind]
+
+class TestSymmetric(TestArpack):
     def setUp(self):
-        self.symmetric=[]
-        self.generalized_symmetric=[]
-        self.nonsymmetric=[]
-        self.generalized_nonsymmetric=[]
-        
-        #standard symmetric test case A*x = w*x
-        S1={}
-        S1['mat']=\
-        array([[ 2.,  0.,  0., -1.,  0., -1.],
-               [ 0.,  2.,  0., -1.,  0., -1.],
-               [ 0.,  0.,  2., -1.,  0., -1.],
-               [-1., -1., -1.,  4.,  0., -1.],
-               [ 0.,  0.,  0.,  0.,  1., -1.],
-               [-1., -1., -1., -1., -1.,  5.]])
+        self.eigs = eigsh
+        self.modes = ['LM','SM','BE']
 
-        S1['v0']= array([0.39574246391875789,
-                         0.00086496039750016962,
-                         -0.9227205789982591,
-                         -0.9165671495278005,
-                         0.1175963848841306,
-                         -0.29962625203712179])
-
-        S1['eval']=array([0,1,2,2,5,6])
-        self.symmetric.append(S1)
-        
-        #generalized symmetric test case A*x = w*B*x
-        GS1={}
-        GS1['mat'] = S1['mat']
-
-        GS1['bmat'] = array([[ 15., -2., -8., -1., -3., -7.],
-                             [ -2., 10., -2.,  0.,  3.,  1.],
-                             [ -8., -2., 20., -6.,  4., -2.],
-                             [ -1.,  0., -6., 12.,  3.,  8.],
-                             [ -3.,  3.,  4.,  3.,  5.,  1.],
-                             [ -7.,  1., -2.,  8.,  1., 14.]])
-
-        GS1['v0']= array([0.39574246391875789,
+        # standard symmetric problem
+        SS = {}
+        SS['mat']=array([[ 2.,  0.,  0., -1.,  0., -1.],
+                         [ 0.,  2.,  0., -1.,  0., -1.],
+                         [ 0.,  0.,  2., -1.,  0., -1.],
+                         [-1., -1., -1.,  4.,  0., -1.],
+                         [ 0.,  0.,  0.,  0.,  1., -1.],
+                         [-1., -1., -1., -1., -1.,  5.]])
+        SS['eval']=array([0,1,2,2,5,6])        
+        SS['v0'] = array([0.39574246391875789,
                           0.00086496039750016962,
                           -0.9227205789982591,
                           -0.9165671495278005,
                           0.1175963848841306,
                           -0.29962625203712179])
+        self.standard = [SS]
+        
+        # general symmetric problem
+        SG = {}
+        SG['mat'] = SS['mat']
+        SG['bmat'] = array([[ 3., -3.,  0., -1.,  0., -1.],
+                            [-3., 10.,  0.,  7.,  3.,  5.],
+                            [ 0.,  0., 10.,  1.,  3.,  0.],
+                            [-1.,  7.,  1., 11.,  0.,  1.],
+                            [ 0.,  3.,  3.,  0.,  8., -1.],
+                            [-1.,  5.,  0.,  1., -1., 10.]])
+        SG['eval'] = array([0.0,
+                            1.4360859298239867e-01,
+                            2.0496461767247975e-01,
+                            5.0507316521393908e-01,   
+                            6.0317191682460070e-01,   
+                            1.9075146642093827e+01])
+        SG['v0']= SS['v0']
+        self.general = [SG]
+    
+    def test_standard_symmetric_modes(self):
+        k=2
+        for d in self.standard:
+            for typ in 'fd':
+                for which in self.modes:
+                    for sigma in (None,0.5):
+                        for conv in _mattypes:
+                            self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)
+    
+    def test_general_symmetric_modes(self):
+        k=2
+        for d in self.general:
+            for typ in 'fd':
+                for which in self.modes:
+                    for sigma in (None,0.5):
+                        for conv in _mattypes:
+                            self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)
 
-        GS1['eval'] = array( [0, 
-                              0.075962794805133169,
-                              0.17591368395508336,
-                              0.31668444692674252,   
-                              0.69905548427573028,   
-                              5.7488864874925927] )
-        self.generalized_symmetric.append(GS1)
+    def test_standard_symmetric_starting_vector(self):
+        k=2
+        for d in self.standard:
+            for typ in 'fd':
+                A=d['mat']
+                n=A.shape[0]
+                v0 = random.rand(n).astype(typ)
+                self.eval_evec(d,typ,k,which='LM',v0=v0)
+
+    def test_general_symmetric_starting_vector(self):
+        k=2
+        for d in self.general:
+            for typ in 'fd':
+                A=d['mat']
+                n=A.shape[0]
+                v0 = random.rand(n).astype(typ)
+                self.eval_evec(d,typ,k,which='LM',v0=v0)
+
+    def test_standard_symmetric_no_convergence(self):
+        np.random.seed(1234)
+        m = np.random.rand(30, 30)
+        m = m + m.T
+        try:
+            w, v = eigsh(m, 4, which='LM', v0=m[:,0], maxiter=5)
+            raise AssertionError("Spurious no-error exit")
+        except ArpackNoConvergence, err:
+            k = len(err.eigenvalues)
+            if k <= 0:
+                raise AssertionError("Spurious no-eigenvalues-found case")
+            w, v = err.eigenvalues, err.eigenvectors
+            for ww, vv in zip(w, v.T):
+                assert_array_almost_equal(dot(m, vv), ww*vv,
+                                          decimal=_ndigits['d'])
+
+class TestNonSymmetric(TestArpack):
+    def setUp(self):
+        self.eigs = eigs
+        self.modes = ['LM','SM','LR', 'SR', 'LI', 'SI']
 
         #standard nonsymmetric test case A*x = w*x
-        N1={}
-        N1['mat']=\
-            array([[-2., -8.,  1.,  2., -5.],
-                   [ 6.,  6.,  0.,  2.,  1.],
-                   [ 0.,  4., -2., 11.,  0.],
-                   [ 1.,  6.,  1.,  0., -4.],
-                   [ 2., -6.,  4.,  9., -3]])
-
-        N1['v0'] = array([0.39574246391875789,
+        NS={}
+        NS['mat']= array([[-2., -8.,  1.,  2., -5.],
+                          [ 6.,  6.,  0.,  2.,  1.],
+                          [ 0.,  4., -2., 11.,  0.],
+                          [ 1.,  6.,  1.,  0., -4.],
+                          [ 2., -6.,  4.,  9., -3]])
+        
+        NS['v0'] = array([0.39574246391875789,
                           0.00086496039750016962,
                           -0.9227205789982591,
                           -0.9165671495278005,
                           0.1175963848841306])
-
-        N1['eval']=\
-            array([ -5.4854094033782888+0.0j,
-                     -2.2169058544873783+8.5966096591588261j,
-                     -2.2169058544873783-8.5966096591588261j,
-                     4.4596105561765107+3.8007839204319454j,
-                     4.4596105561765107-3.8007839204319454j],'D')
-        self.nonsymmetric.append(N1)
+        NS['eval']=array([ -5.4854094033782888+0.0j,
+                            -2.2169058544873783+8.5966096591588261j,
+                            -2.2169058544873783-8.5966096591588261j,
+                            4.4596105561765107+3.8007839204319454j,
+                            4.4596105561765107-3.8007839204319454j],'D')
+        self.standard = [NS]
 
         #general nonsymmetric test case A*x = w*B*x
-        GN1={}
-        GN1['mat'] =  array([[-2., -8.,  1.,  2., -5.],
-                             [ 6.,  6.,  0.,  2.,  1.],
-                             [ 0.,  4., -2., 11.,  0.],
-                             [ 1.,  6.,  1.,  0., -4.],
-                             [ 2., -6.,  4.,  9., -3.]])
+        NG={}
+        NG['mat'] =  NS['mat']
 
-        GN1['bmat'] = array([[ 3.,  1., -1.,  1.,  0.],
-                             [ 1., 11., -1.,  8.,  4.],
-                             [-1., -1.,  5., -2.,  1.],
-                             [ 1.,  8., -2.,  8.,  3.],
-                             [ 0.,  4.,  1.,  3.,  3.]])
+        NG['bmat'] = array([[11.,  0.,  0., -1., -2.],
+                            [ 0.,  9.,  2.,  0.,  0.],
+                            [ 0.,  2.,  1.,  0., -1.],
+                            [-1.,  0.,  0., 10.,  1.],
+                            [-2.,  0., -1.,  1., 13.]])
+
+        NG['eval'] = array([-4.1690059397428412+0.j,
+                             0.3168657188570727+0.4432894295551382j,
+                             0.3168657188570727-0.4432894295551382j,
+                             -0.5102635838808636+1.3352613149875483j,
+                             -0.5102635838808637-1.3352613149875483j])
         
-        GN1['v0'] = array([0.39574246391875789,
-                           0.00086496039750016962,
-                           -0.9227205789982591,
-                           -0.9165671495278005,
-                           0.1175963848841306])
+        NG['v0'] = array([0.39574246391875789,
+                          0.00086496039750016962,
+                          -0.9227205789982591,
+                          -0.9165671495278005,
+                          0.1175963848841306])
+        self.general = [NG]
 
-        GN1['eval'] = array([-1.3679863347125234+7.1308076390812118j,
-                              -1.3679863347125234-7.1308076390812118j,
-                              0.3250391033748413+0.811851223838731j,
-                              0.3250391033748413-0.811851223838731j,
-                              -1.2739671290201331+0.j])
+        #standard complex nonsymmetric case A*x = w*x
+        NCS={}
+        NCS['mat'] = NS['mat'] + 1j*(NS['mat']+1)
+        NCS['eval'] = eig(NCS['mat'],left=False,right=False)
+        NCS['v0'] = NG['v0']
+        self.standard_complex = [NCS]
 
-        self.generalized_nonsymmetric.append(GN1)
+        #general complex nonsymmetric case A*x = w*M*x
+        NCG={}
+        NCG['mat'] = NCS['mat']
+        NCG['bmat'] = NG['bmat']
+        NCG['eval'] = eig(NCS['mat'],NCG['bmat'],left=False,right=False)
+        NCG['v0'] = NG['v0']
+        self.general_complex = [NCG]
+        
+    
+    def test_standard_nonsymmetric_modes(self):
+        k=2
+        sigma = None
+        for d in self.standard:
+            for typ in 'fd':
+                for which in self.modes:
+                    for conv in _mattypes:
+                        self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)
+    
+    def test_general_nonsymmetric_modes(self):
+        k=2
+        sigma = None
+        for d in self.general:
+            for typ in 'fd':
+                for which in self.modes:
+                    for conv in _mattypes:
+                        self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)
 
+    def test_complex_standard_nonsymmetric_modes(self):
+        k=2
+        for d in self.standard_complex:
+            for typ in 'FD':
+                for sigma in (None,0.1+0.1j):
+                    for which in self.modes:
+                        for conv in _mattypes:
+                            self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)
+
+    def test_complex_general_nonsymmetric_modes(self):
+        k=2
+        for d in self.general_complex:
+            for typ in 'FD':
+                for sigma in (None,0.1+0.1j):
+                    for which in self.modes:
+                        for conv in _mattypes:
+                            self.eval_evec(d,typ,k,which,sigma=sigma,conv=conv)
         
 
-class TestEigenSymmetric(TestArpack):
-
-    def get_exact_eval(self,d,typ,k,which):
-        eval=d['eval'].astype(typ)
-        ind=argsort(eval)
-        eval=eval[ind]
-        if which=='LM':
-            return eval[-k:]
-        if which=='SM':
-            return eval[:k]
-        if which=='BE':
-            # one ev from each end - if k is odd, extra ev on high end
-            l=k//2
-            h=k//2+k%2
-            low=range(len(eval))[:l]
-            high=range(len(eval))[-h:]
-            return eval[low+high]
-
-    def eval_evec(self,d,typ,k,which,v0=None):
-        a=d['mat'].astype(typ)
-        if v0 == None:
-            v0 = d['v0']
-        exact_eval=self.get_exact_eval(d,typ,k,which)
-        eval,evec=eigsh(a,k,which=which,v0=v0)
-        # check eigenvalues
-        assert_array_almost_equal(eval,exact_eval,decimal=_ndigits[typ])
-        # check eigenvectors A*evec=eval*evec
-        for i in range(k):
-            assert_array_almost_equal(dot(a,evec[:,i]),
-                                      eval[i]*evec[:,i],
-                                      decimal=_ndigits[typ])
-
-    def test_symmetric_modes(self):
+    def test_standard_nonsymmetric_starting_vector(self):
         k=2
-        for typ in 'fd':
-            for which in ['LM','SM','BE']:
-                self.eval_evec(self.symmetric[0],typ,k,which)
+        sigma = None
+        for d in self.standard:
+            for typ in 'fd':
+                A=d['mat']
+                n=A.shape[0]
+                v0 = random.rand(n).astype(typ)
+                self.eval_evec(d,typ,k,which='LM',sigma=sigma,v0=v0)
 
-    def test_starting_vector(self):
+    def test_general_nonsymmetric_starting_vector(self):
         k=2
-        for typ in 'fd':
-            A=self.symmetric[0]['mat']
-            n=A.shape[0]
-            v0 = random.rand(n).astype(typ)
-            self.eval_evec(self.symmetric[0],typ,k,which='LM',v0=v0)
+        sigma = None
+        for d in self.general:
+            for typ in 'fd':
+                A=d['mat']
+                n=A.shape[0]
+                v0 = random.rand(n).astype(typ)
+                self.eval_evec(d,typ,k,which='LM',sigma=sigma,v0=v0)
 
-
-    def test_no_convergence(self):
+    def test_standard_nonsymmetric_no_convergence(self):
         np.random.seed(1234)
         m = np.random.rand(30, 30)
-        m = m + m.T
         try:
-            w, v = eigsh(m, 4, which='LM', v0=m[:,0], maxiter=5)
+            w, v = eigs(m, 4, which='LM', v0=m[:,0], maxiter=5)
             raise AssertionError("Spurious no-error exit")
         except ArpackNoConvergence, err:
             k = len(err.eigenvalues)
@@ -208,346 +318,6 @@ class TestEigenSymmetric(TestArpack):
             for ww, vv in zip(w, v.T):
                 assert_array_almost_equal(dot(m, vv), ww*vv,
                                           decimal=_ndigits['d'])
-
-
-class TestEigenGeneralSymmetric(TestArpack):
-    def get_exact_eval(self,d,typ,k,which):
-        eval=d['eval'].astype(typ)
-        ind=argsort(eval)
-        eval=eval[ind]
-        if which=='LM':
-            return eval[-k:]
-        if which=='SM':
-            return eval[:k]
-        if which=='BE':
-            # one ev from each end - if k is odd, extra ev on high end
-            l=k//2
-            h=k//2+k%2
-            low=range(len(eval))[:l]
-            high=range(len(eval))[-h:]
-            return eval[low+high]
-
-    def eval_evec(self,d,typ,k,which,v0=None):
-        a=d['mat'].astype(typ)
-        b=d['bmat'].astype(typ)
-        if v0 == None:
-            v0 = d['v0']
-        exact_eval=self.get_exact_eval(d,typ,k,which)
-        eval,evec=eigsh(a,k,b,which=which,v0=v0)
-        # check eigenvalues
-        assert_array_almost_equal(eval,exact_eval,decimal=_ndigits[typ])
-        # check eigenvectors A*evec=eval*evec
-        for i in range(k):
-            assert_array_almost_equal(dot(a,evec[:,i]),
-                                      eval[i]*dot(b,evec[:,i]),
-                                      decimal=_ndigits[typ])
-
-    def test_symmetric_modes(self):
-        k=2
-        for typ in 'fd':
-            for which in ['LM','SM','BE']:
-                self.eval_evec(self.generalized_symmetric[0],typ,k,which)
-
-    def test_starting_vector(self):
-        k=2
-        for typ in 'fd':
-            A=self.symmetric[0]['mat']
-            n=A.shape[0]
-            v0 = random.rand(n).astype(typ)
-            self.eval_evec(self.generalized_symmetric[0],typ,k,which='LM',v0=v0)
-
-
-    def test_no_convergence(self):
-        np.random.seed(1234)
-        m = np.random.rand(30, 30)
-        m = m + m.T
-        try:
-            w, v = eigsh(m, 4, which='LM', v0=m[:,0], maxiter=5)
-            raise AssertionError("Spurious no-error exit")
-        except ArpackNoConvergence, err:
-            k = len(err.eigenvalues)
-            if k <= 0:
-                raise AssertionError("Spurious no-eigenvalues-found case")
-            w, v = err.eigenvalues, err.eigenvectors
-            for ww, vv in zip(w, v.T):
-                assert_array_almost_equal(dot(m, vv), ww*vv,
-                                          decimal=_ndigits['d'])
-
-
-class TestEigenComplexSymmetric(TestArpack):
-
-    def sort_choose(self,eval,typ,k,which):
-        # sort and choose the eigenvalues and eigenvectors
-        # both for the exact answer and that returned from ARPACK
-        reval=round(eval,decimals=_ndigits[typ])
-        ind=argsort(reval)
-        if which=='LM' or which=='LR':
-            return ind[-k:]
-        if which=='SM' or which=='SR':
-            return ind[:k]
-
-    def eval_evec(self,d,typ,k,which,v0=None):
-        a=d['mat'].astype(typ)
-        if v0 == None:
-            v0 = d['v0']
-        # get exact eigenvalues
-        exact_eval=d['eval'].astype(typ)
-        ind=self.sort_choose(exact_eval,typ,k,which)
-        exact_eval=exact_eval[ind]
-        # compute eigenvalues
-        eval,evec=eigs(a,k,which=which,v0=v0)
-        ind=self.sort_choose(eval,typ,k,which)
-        eval=eval[ind]
-        evec=evec[:,ind]
-
-        # check eigenvalues
-        assert_array_almost_equal(eval,exact_eval,decimal=_ndigits[typ])
-        # check eigenvectors A*evec=eval*evec
-        for i in range(k):
-            assert_array_almost_equal(dot(a,evec[:,i]),
-                                      eval[i]*evec[:,i],
-                                      decimal=_ndigits[typ])
-
-    def test_complex_symmetric_modes(self):
-        k=2
-        for typ in 'FD':
-            for which in ['LM','SM','LR','SR']:
-                self.eval_evec(self.symmetric[0],typ,k,which)
-
-
-    def test_no_convergence(self):
-        np.random.seed(1234)
-        m = np.random.rand(30, 30) + 1j*np.random.rand(30, 30)
-        try:
-            w, v = eigs(m, 3, which='LM', v0=m[:,0], maxiter=30)
-            raise AssertionError("Spurious no-error exit")
-        except ArpackNoConvergence, err:
-            k = len(err.eigenvalues)
-            if k <= 0:
-                raise AssertionError("Spurious no-eigenvalues-found case")
-            w, v = err.eigenvalues, err.eigenvectors
-            for ww, vv in zip(w, v.T):
-                assert_array_almost_equal(dot(m, vv), ww*vv,
-                                          decimal=_ndigits['D'])
-
-class TestEigenNonSymmetric(TestArpack):
-
-
-    def sort_choose(self,eval,typ,k,which):
-        reval=round(eval,decimals=_ndigits[typ])
-        if which in ['LR','SR']:
-            ind=argsort(reval.real)
-        elif which in ['LI','SI']:
-            # for LI,SI ARPACK returns largest,smallest abs(imaginary) why?
-            ind=argsort(abs(reval.imag))
-        else:
-            ind=argsort(abs(reval))
-
-        if which in ['LR','LM','LI']:
-            return ind[-k:]
-        if which in ['SR','SM','SI']:
-            return ind[:k]
-
-
-    def eval_evec(self,d,typ,k,which,v0=None):
-        a=d['mat'].astype(typ)
-        if v0 == None:
-            v0 = d['v0']
-        # get exact eigenvalues
-        exact_eval=d['eval'].astype(typ.upper())
-        ind=self.sort_choose(exact_eval,typ,k,which)
-        exact_eval=exact_eval[ind]
-        # compute eigenvalues
-        eval,evec=eigs(a,k,which=which,v0=v0)
-        ind=self.sort_choose(eval,typ,k,which)
-        eval=eval[ind]
-        evec=evec[:,ind]
-        # check eigenvalues
-        # check eigenvectors A*evec=eval*evec
-        for i in range(k):
-            assert_almost_equal_cc(eval[i],exact_eval[i],decimal=_ndigits[typ])
-            assert_array_almost_equal_cc(dot(a,evec[:,i]),
-                                      eval[i]*evec[:,i],
-                                      decimal=_ndigits[typ])
-
-
-    def test_nonsymmetric_modes(self):
-        k=2
-        for typ in 'fd':
-            for which in ['LI','LR','LM','SM','SR','SI']:
-                for m in self.nonsymmetric:
-                    self.eval_evec(m,typ,k,which)
-
-
-
-    def test_starting_vector(self):
-        k=2
-        for typ in 'fd':
-            A=self.nonsymmetric[0]['mat']
-            n=A.shape[0]
-            v0 = random.rand(n).astype(typ)
-            self.eval_evec(self.nonsymmetric[0],
-                           typ,k,which='LM',v0=v0)
-
-    def test_no_convergence(self):
-        np.random.seed(1234)
-        m = np.random.rand(30, 30)
-        try:
-            w, v = eigs(m, 3, which='LM', v0=m[:,0], maxiter=30)
-            raise AssertionError("Spurious no-error exit")
-        except ArpackNoConvergence, err:
-            k = len(err.eigenvalues)
-            if k <= 0:
-                raise AssertionError("Spurious no-eigenvalues-found case")
-            w, v = err.eigenvalues, err.eigenvectors
-            for ww, vv in zip(w, v.T):
-                assert_array_almost_equal(dot(m, vv), ww*vv,
-                                          decimal=_ndigits['d'])
-
-
-class TestEigenGeneralNonSymmetric(TestArpack):
-
-
-    def sort_choose(self,eval,typ,k,which):
-        reval=round(eval,decimals=_ndigits[typ])
-        if which in ['LR','SR']:
-            ind=argsort(reval.real)
-        elif which in ['LI','SI']:
-            # for LI,SI ARPACK returns largest,smallest abs(imaginary) why?
-            ind=argsort(abs(reval.imag))
-        else:
-            ind=argsort(abs(reval))
-
-        if which in ['LR','LM','LI']:
-            return ind[-k:]
-        if which in ['SR','SM','SI']:
-            return ind[:k]
-
-
-    def eval_evec(self,d,typ,k,which,v0=None):
-        a=d['mat'].astype(typ)
-        b=d['bmat'].astype(typ)
-        if v0 == None:
-            v0 = d['v0']
-        # get exact eigenvalues
-        exact_eval=d['eval'].astype(typ.upper())
-        ind=self.sort_choose(exact_eval,typ,k,which)
-        exact_eval=exact_eval[ind]
-        # compute eigenvalues
-        eval,evec=eigs(a,k,b,which=which,v0=v0)
-        ind=self.sort_choose(eval,typ,k,which)
-        eval=eval[ind]
-        evec=evec[:,ind]
-        # check eigenvalues
-        # check eigenvectors A*evec=eval*evec
-        for i in range(k):
-            assert_almost_equal_cc(eval[i],exact_eval[i],decimal=_ndigits[typ])
-            assert_array_almost_equal_cc(dot(a,evec[:,i]),
-                                      eval[i]*np.dot(b,evec[:,i]),
-                                      decimal=_ndigits[typ])
-
-
-    def test_nonsymmetric_modes(self):
-        k=2
-        for typ in 'fd':
-            for which in ['LI','LR','LM','SM','SR','SI']:
-                for m in self.generalized_nonsymmetric:
-                    self.eval_evec(m,typ,k,which)
-
-
-
-    def test_starting_vector(self):
-        k=2
-        for typ in 'fd':
-            A=self.symmetric[0]['mat']
-            n=A.shape[0]
-            v0 = random.rand(n).astype(typ)
-            self.eval_evec(self.generalized_symmetric[0],
-                           typ,k,which='LM',v0=v0)
-
-    def test_no_convergence(self):
-        np.random.seed(1234)
-        m = np.random.rand(30, 30)
-        try:
-            w, v = eigs(m, 3, which='LM', v0=m[:,0], maxiter=30)
-            raise AssertionError("Spurious no-error exit")
-        except ArpackNoConvergence, err:
-            k = len(err.eigenvalues)
-            if k <= 0:
-                raise AssertionError("Spurious no-eigenvalues-found case")
-            w, v = err.eigenvalues, err.eigenvectors
-            for ww, vv in zip(w, v.T):
-                assert_array_almost_equal(dot(m, vv), ww*vv,
-                                          decimal=_ndigits['d'])
-
-
-class TestEigenComplexNonSymmetric(TestArpack):
-
-    def sort_choose(self,eval,typ,k,which):
-        eps=finfo(typ).eps
-        reval=round(eval,decimals=_ndigits[typ])
-        if which in ['LR','SR']:
-            ind=argsort(reval)
-        elif which in ['LI','SI']:
-            ind=argsort(reval.imag)
-        else:
-            ind=argsort(abs(reval))
-
-        if which in ['LR','LI','LM']:
-            return ind[-k:]
-        if which in ['SR','SI','SM']:
-            return ind[:k]
-
-    def eval_evec(self,d,typ,k,which,v0=None):
-        a=d['mat'].astype(typ)
-        if v0 == None:
-            v0 = d['v0']
-        # get exact eigenvalues
-        exact_eval=d['eval'].astype(typ.upper())
-        ind=self.sort_choose(exact_eval,typ,k,which)
-        exact_eval=exact_eval[ind]
-        if verbose >= 3:
-            print "exact"
-            print exact_eval
-
-
-        # compute eigenvalues
-        eval,evec=eigs(a,k,which=which,v0=v0)
-        ind=self.sort_choose(eval,typ,k,which)
-        eval=eval[ind]
-        evec=evec[:,ind]
-        if verbose >= 3:
-            print eval
-        # check eigenvalues
-        # check eigenvectors A*evec=eval*evec
-        for i in range(k):
-            assert_almost_equal_cc(eval[i],exact_eval[i],decimal=_ndigits[typ])
-            assert_array_almost_equal_cc(dot(a,evec[:,i]),
-                                      eval[i]*evec[:,i],
-                                      decimal=_ndigits[typ])
-
-    def test_complex_nonsymmetric_modes(self):
-        k=2
-        for typ in 'FD':
-            for which in ['LI','LR','LM','SI','SR','SM']:
-                for m in self.nonsymmetric:
-                    self.eval_evec(m,typ,k,which)
-
-
-    def test_no_convergence(self):
-        np.random.seed(1234)
-        m = np.random.rand(30, 30) + 1j*np.random.rand(30, 30)
-        try:
-            w, v = eigs(m, 3, which='LM', v0=m[:,0], maxiter=30)
-            raise AssertionError("Spurious no-error exit")
-        except ArpackNoConvergence, err:
-            k = len(err.eigenvalues)
-            if k <= 0:
-                raise AssertionError("Spurious no-eigenvalues-found case")
-            w, v = err.eigenvalues, err.eigenvectors
-            for ww, vv in zip(w, v.T):
-                assert_array_almost_equal(dot(m, vv), ww*vv,
-                                          decimal=_ndigits['D'])
 
 def test_eigen_bad_shapes():
     # A is not square.
@@ -622,6 +392,6 @@ class TestSparseSvd(TestCase):
                 sm_hat = svd_estimate(su, ss, svh)
 
                 assert_array_almost_equal_nulp(m_hat, sm_hat, nulp=1000)
-
+        
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -19,6 +19,9 @@ from scipy.sparse.linalg.eigen.arpack import eigs, eigsh, svds, \
 
 from scipy.linalg import svd
 
+# precision for tests
+_ndigits = {'f': 3, 'd': 11, 'F': 3, 'D': 11}
+
 def generate_matrix(N, complex=False, hermitian=False, 
                     pos_definite=False, sparse=False):
     M = np.random.random((N,N))
@@ -49,6 +52,7 @@ def generate_matrix(N, complex=False, hermitian=False,
             M[i,j] = 0
     return M
 
+
 def _aslinearoperator_with_dtype(m):
     m = aslinearoperator(m)
     if not hasattr(m, 'dtype'):
@@ -75,126 +79,134 @@ def assert_array_almost_equal_cc(actual, desired, decimal=7,
         assert_array_almost_equal(actual, conj(desired), decimal,
                                   err_msg, verbose)
 
-# precision for tests
-_ndigits = {'f': 3, 'd': 11, 'F': 3, 'D': 11}
 
-class TestArpack(TestCase):
-    def argsort_which(self, eval, typ, k, which, 
-                      sigma=None, OPpart=None, mode=None):
-        if sigma is None:
-            reval = np.round(eval, decimals=_ndigits[typ])
-        else:
-            if mode is None or mode=='normal':
-                if OPpart is None:
-                    reval = 1. / (eval - sigma)
-                elif OPpart == 'r':
-                    reval = 0.5 * (1. / (eval - sigma) 
-                                   + 1. / (eval - np.conj(sigma)))
-                elif OPpart == 'i':
-                    reval = -0.5j * (1. / (eval - sigma) 
-                                 - 1. / (eval - np.conj(sigma)))
-            elif mode=='cayley':
-                reval = (eval + sigma) / (eval - sigma)
-            elif mode=='buckling':
-                reval = eval / (eval - sigma)
-            else:
-                raise ValueError("mode='%s' not recognized" % mode)
-            
-            reval = np.round(reval, decimals=_ndigits[typ])
-
-        if which in ['LM', 'SM']:
-            ind = np.argsort(abs(reval))
-        elif which in ['LR', 'SR', 'LA', 'SA', 'BE']:
-            ind = np.argsort(np.real(reval))
-        elif which in ['LI', 'SI']:
-            # for LI,SI ARPACK returns largest,smallest abs(imaginary) why?
-            if typ.islower():
-                ind = np.argsort(abs(np.imag(reval)))
-            else:
-                ind = np.argsort(np.imag(reval))
-        else:
-            raise ValueError("which='%s' is unrecognized" % which)
-        
-        if which in ['LM', 'LA', 'LR', 'LI']:
-            return ind[-k:]
-        elif which in ['SM', 'SA', 'SR', 'SI']:
-            return ind[:k]
-        elif which == 'BE':
-            return np.concatenate((ind[:k/2], ind[k/2-k:]))
-
-    def eval_evec(self, d, typ, k, which, sigma=None, v0=None,
-                  mattype=np.asarray, OPpart=None, mode='normal'):
-        general = ('bmat' in d)
-        if general:
-            err = ("error for %s:general, typ=%s, which=%s, sigma=%s, "
-                   "mattype=%s, OPpart=%s, mode=%s" % (self.__class__.__name__,
-                                                       typ, which, sigma,
-                                                       mattype.__name__,
-                                                       OPpart, mode))
-        else:
-            err = ("error for %s:standard, typ=%s, which=%s, sigma=%s, "
-                   "mattype=%s, OPpart=%s, mode=%s" % (self.__class__.__name__,
-                                                       typ, which, sigma,
-                                                       mattype.__name__,
-                                                       OPpart, mode))
-
-        a = d['mat'].astype(typ)
-        ac = mattype(a)
-        
-        if general:
-            b = d['bmat'].astype(typ.lower())
-            bc = mattype(b)
-        
-        # get exact eigenvalues
-        exact_eval = d['eval'].astype(typ.upper())
-        ind = self.argsort_which(exact_eval, typ, k, which,
-                                 sigma, OPpart, mode)
-        exact_eval_a = exact_eval
-        exact_eval = exact_eval[ind]
-        
-        # compute arpack eigenvalues
-        kwargs = dict(which=which, v0=v0, sigma=sigma)
-        if self.eigs is eigsh:
-            kwargs['mode'] = mode
-        else:
-            kwargs['OPpart'] = OPpart
-            
-        if general:
-            eval, evec = self.eigs(ac, k, bc, **kwargs)
-        else:
-            eval, evec = self.eigs(ac, k, **kwargs)
-
-        ind = self.argsort_which(eval, typ, k, which,
-                                 sigma, OPpart, mode)
-        eval_a = eval
-        eval = eval[ind]
-        evec = evec[:,ind]
-        
-        # check eigenvalues
-        assert_array_almost_equal_cc(eval, exact_eval, 
-                                     decimal=_ndigits[typ],
-                                     err_msg=err)
-
-        # check eigenvectors
-        LHS = np.dot(a, evec)
-        if general:
-            RHS = eval * np.dot(b, evec)
-        else:
-            RHS = eval * evec
-            
-        assert_array_almost_equal(LHS, RHS,
-                                  decimal=_ndigits[typ],
-                                  err_msg=err)
-
-
-def modes(sigma):
+def argsort_which(eval, typ, k, which, 
+                  sigma=None, OPpart=None, mode=None):
+    # return sorted indices of eigenvalues using the "which" keyword
+    # from eigs and eigsh
     if sigma is None:
-        return ["normal"]
+        reval = np.round(eval, decimals=_ndigits[typ])
     else:
-        return ["normal", "cayley", "buckling"]
+        if mode is None or mode=='normal':
+            if OPpart is None:
+                reval = 1. / (eval - sigma)
+            elif OPpart == 'r':
+                reval = 0.5 * (1. / (eval - sigma) 
+                               + 1. / (eval - np.conj(sigma)))
+            elif OPpart == 'i':
+                reval = -0.5j * (1. / (eval - sigma) 
+                                 - 1. / (eval - np.conj(sigma)))
+        elif mode=='cayley':
+            reval = (eval + sigma) / (eval - sigma)
+        elif mode=='buckling':
+            reval = eval / (eval - sigma)
+        else:
+            raise ValueError("mode='%s' not recognized" % mode)
+            
+        reval = np.round(reval, decimals=_ndigits[typ])
 
-class TestSymmetric(TestArpack):
-    def setUp(self):
+    if which in ['LM', 'SM']:
+        ind = np.argsort(abs(reval))
+    elif which in ['LR', 'SR', 'LA', 'SA', 'BE']:
+        ind = np.argsort(np.real(reval))
+    elif which in ['LI', 'SI']:
+        # for LI,SI ARPACK returns largest,smallest abs(imaginary) why?
+        if typ.islower():
+            ind = np.argsort(abs(np.imag(reval)))
+        else:
+            ind = np.argsort(np.imag(reval))
+    else:
+        raise ValueError("which='%s' is unrecognized" % which)
+        
+    if which in ['LM', 'LA', 'LR', 'LI']:
+        return ind[-k:]
+    elif which in ['SM', 'SA', 'SR', 'SI']:
+        return ind[:k]
+    elif which == 'BE':
+        return np.concatenate((ind[:k/2], ind[k/2-k:]))
+
+
+def eval_evec(symmetric, d, typ, k, which, v0=None, sigma=None,
+              mattype=np.asarray, OPpart=None, mode='normal'):
+    general = ('bmat' in d)
+    
+    if symmetric:
+        eigs_func = eigsh
+    else:
+        eigs_func = eigs
+
+    if general:
+        err = ("error for %s:general, typ=%s, which=%s, sigma=%s, "
+               "mattype=%s, OPpart=%s, mode=%s" % (eigs_func.__name__,
+                                                   typ, which, sigma,
+                                                   mattype.__name__,
+                                                   OPpart, mode))
+    else:
+        err = ("error for %s:standard, typ=%s, which=%s, sigma=%s, "
+               "mattype=%s, OPpart=%s, mode=%s" % (eigs_func.__name__,
+                                                   typ, which, sigma,
+                                                   mattype.__name__,
+                                                   OPpart, mode))
+
+    a = d['mat'].astype(typ)
+    ac = mattype(a)
+    
+    if general:
+        b = d['bmat'].astype(typ.lower())
+        bc = mattype(b)
+        
+    # get exact eigenvalues
+    exact_eval = d['eval'].astype(typ.upper())
+    ind = argsort_which(exact_eval, typ, k, which,
+                        sigma, OPpart, mode)
+    exact_eval_a = exact_eval
+    exact_eval = exact_eval[ind]
+        
+    # compute arpack eigenvalues
+    kwargs = dict(which=which, v0=v0, sigma=sigma)
+    if eigs_func is eigsh:
+        kwargs['mode'] = mode
+    else:
+        kwargs['OPpart'] = OPpart
+            
+    if general:
+        try:
+            eval, evec = eigs_func(ac, k, bc, **kwargs)
+        except ArpackNoConvergence:
+            kwargs['maxiter'] = 20*a.shape[0]
+            eval, evec = eigs_func(ac, k, bc, **kwargs)
+    else:
+        try:
+            eval, evec = eigs_func(ac, k, **kwargs)
+        except ArpackNoConvergence:
+            kwargs['maxiter'] = 20*a.shape[0]
+            eval, evec = eigs_func(ac, k, **kwargs)
+
+    ind = argsort_which(eval, typ, k, which,
+                        sigma, OPpart, mode)
+    eval_a = eval
+    eval = eval[ind]
+    evec = evec[:,ind]
+    
+    # check eigenvalues
+    assert_array_almost_equal_cc(eval, exact_eval, 
+                                 decimal=_ndigits[typ],
+                                 err_msg=err)
+
+    # check eigenvectors
+    LHS = np.dot(a, evec)
+    if general:
+        RHS = eval * np.dot(b, evec)
+    else:
+        RHS = eval * evec
+        
+    assert_array_almost_equal(LHS, RHS,
+                              decimal=_ndigits[typ],
+                              err_msg=err)
+
+
+class SymmetricParams:
+    def __init__(self):
         self.eigs = eigsh
         self.which = ['LM', 'SM', 'LA', 'SA', 'BE']
         self.mattypes = [csr_matrix, aslinearoperator, np.asarray]
@@ -243,53 +255,8 @@ class TestSymmetric(TestArpack):
         self.real_test_cases = [SS, GS]
         self.complex_test_cases = [SH, GH]
     
-    def test_symmetric_modes(self):
-        k = 2
-        for D in self.real_test_cases:
-            for typ in 'fd':
-                for which in self.which:
-                    for mattype in self.mattypes:
-                        for (sigma, modes) in self.sigmas_modes.iteritems():
-                            for mode in modes:
-                                self.eval_evec(D, typ, k, which, sigma=sigma, 
-                                               mattype=mattype, mode=mode)
-    
-    def test_hermitian_modes(self):
-        k = 2
-        for D in self.complex_test_cases:
-            for typ in 'FD':
-                for which in self.which:
-                    if which == 'BE': continue
-                    for mattype in self.mattypes:
-                        for sigma in self.sigmas_modes:
-                            self.eval_evec(D, typ, k, which, 
-                                           sigma=sigma, mattype=mattype)
-
-    def test_symmetric_starting_vector(self):
-        k = 2
-        for D in self.real_test_cases:
-            for typ in 'fd':
-                v0 = random.rand(len(D['v0'])).astype(typ)
-                self.eval_evec(D, typ, k, which='LM', v0=v0)
-
-    def test_symmetric_no_convergence(self):
-        np.random.seed(1234)
-        m = generate_matrix(30, hermitian=True, pos_definite=True)
-
-        try:
-            w, v = eigsh(m, 4, which='LM', v0=m[:, 0], maxiter=5)
-            raise AssertionError("Spurious no-error exit")
-        except ArpackNoConvergence, err:
-            k = len(err.eigenvalues)
-            if k <= 0:
-                raise AssertionError("Spurious no-eigenvalues-found case")
-            w, v = err.eigenvalues, err.eigenvectors
-            assert_array_almost_equal(dot(m, v), w * v, decimal=_ndigits['d'])
-    
-
-
-class TestNonSymmetric(TestArpack):
-    def setUp(self):
+class NonSymmetricParams:
+    def __init__(self):
         self.eigs = eigs
         self.which = ['LM', 'LR', 'LI']#, 'SM', 'LR', 'SR', 'LI', 'SI']
         self.mattypes = [csr_matrix, aslinearoperator, np.asarray]
@@ -337,63 +304,127 @@ class TestNonSymmetric(TestArpack):
         self.real_test_cases = [SNR, GNR]
         self.complex_test_cases = [SNC, GNC]
 
-    # This leads to memory errors.  Not sure the source...
-    #
-    #def test_real_nonsymmetric_modes(self):
-    #    k = 2
-    #    for D in self.real_test_cases:
-    #        for typ in 'fd':
-    #            for which in self.which:
-    #                for mattype in self.mattypes:
-    #                    for sigma, OPparts in self.sigmas_OPparts.iteritems():
-    #                        for OPpart in OPparts:
-    #                            self.eval_evec(D, typ, k, which, sigma=sigma,
-    #                                           mattype=mattype, OPpart=OPpart)
-        
-    def test_complex_nonsymmetric_modes(self):
-        k = 2
-        for D in self.complex_test_cases:
-            for typ in 'DF':
-                for which in self.which:
-                    for mattype in self.mattypes:
-                        for sigma in self.sigmas_OPparts:
-                            self.eval_evec(D, typ, k, which, sigma=sigma,
-                                           mattype=mattype)
 
-    def test_standard_nonsymmetric_starting_vector(self):
-        k = 2
-        sigma = None
-        for d in self.complex_test_cases:
-            for typ in 'FD':
-                A = d['mat']
-                n = A.shape[0]
-                v0 = random.rand(n).astype(typ)
-                self.eval_evec(d, typ, k, which='LM', sigma=sigma, v0=v0)
+def test_symmetric_modes():
+    params = SymmetricParams()
+    k = 2
+    symmetric = True
+    for D in params.real_test_cases:
+        for typ in 'fd':
+            for which in params.which:
+                for mattype in params.mattypes:
+                    for (sigma, modes) in params.sigmas_modes.iteritems():
+                        for mode in modes:
+                            yield  (eval_evec, symmetric, D, typ, k, which,
+                                    None, sigma, mattype, None, mode)
 
-    def test_general_nonsymmetric_starting_vector(self):
-        k = 2
-        sigma = None
-        for d in self.complex_test_cases:
-            for typ in 'FD':
-                A = d['mat']
-                n = A.shape[0]
-                v0 = random.rand(n).astype(typ)
-                self.eval_evec(d, typ, k, which='LM', sigma=sigma, v0=v0)
 
-    def test_standard_nonsymmetric_no_convergence(self):
-        np.random.seed(1234)
-        m = generate_matrix(30, complex=True)
-        try:
-            w, v = eigs(m, 4, which='LM', v0=m[:, 0], maxiter=5)
-            raise AssertionError("Spurious no-error exit")
-        except ArpackNoConvergence, err:
-            k = len(err.eigenvalues)
-            if k <= 0:
-                raise AssertionError("Spurious no-eigenvalues-found case")
-            w, v = err.eigenvalues, err.eigenvectors
-            for ww, vv in zip(w, v.T):
-                assert_array_almost_equal(dot(m, vv), ww * vv,
-                                          decimal=_ndigits['d'])
+def test_hermitian_modes():
+    params = SymmetricParams()
+    k = 2
+    symmetric = True
+    for D in params.complex_test_cases:
+        for typ in 'FD':
+            for which in params.which:
+                if which == 'BE': continue  # BE invalid for complex
+                for mattype in params.mattypes:
+                    for sigma in params.sigmas_modes:
+                        yield  (eval_evec, symmetric, D, typ, k, which,
+                                None, sigma, mattype)
+
+
+def test_symmetric_starting_vector():
+    params = SymmetricParams()
+    k = 2
+    symmetric = True
+    for D in params.real_test_cases:
+        for typ in 'fd':
+            v0 = random.rand(len(D['v0'])).astype(typ)
+            yield (eval_evec, symmetric, D, typ, k, 'LM', v0)
+
+
+def test_symmetric_no_convergence():
+    np.random.seed(1234)
+    m = generate_matrix(30, hermitian=True, pos_definite=True)
+
+    try:
+        w, v = eigsh(m, 4, which='LM', v0=m[:, 0], maxiter=5)
+        raise AssertionError("Spurious no-error exit")
+    except ArpackNoConvergence, err:
+        k = len(err.eigenvalues)
+        if k <= 0:
+            raise AssertionError("Spurious no-eigenvalues-found case")
+        w, v = err.eigenvalues, err.eigenvectors
+        assert_array_almost_equal(dot(m, v), w * v, decimal=_ndigits['d'])
+    
+
+def test_real_nonsymmetric_modes():
+    params = NonSymmetricParams()
+    k = 2
+    symmetric = False
+    for D in params.real_test_cases:
+        for typ in 'fd':
+            for which in params.which:
+                for mattype in params.mattypes:
+                    for sigma, OPparts in params.sigmas_OPparts.iteritems():
+                        for OPpart in OPparts:
+                            yield (eval_evec, symmetric, D, typ, k, which,
+                                   None, sigma, mattype, OPpart)
+
+
+def test_complex_nonsymmetric_modes():
+    params = NonSymmetricParams()
+    k = 2
+    symmetric = False
+    for D in params.complex_test_cases:
+        for typ in 'DF':
+            for which in params.which:
+                for mattype in params.mattypes:
+                    for sigma in params.sigmas_OPparts:
+                        yield (eval_evec, symmetric, D, typ, k, which,
+                               None, sigma, mattype)
+
+
+def test_standard_nonsymmetric_starting_vector():
+    params = NonSymmetricParams()
+    k = 2
+    sigma = None
+    symmetric = False
+    for d in params.complex_test_cases:
+        for typ in 'FD':
+            A = d['mat']
+            n = A.shape[0]
+            v0 = random.rand(n).astype(typ)
+            yield (eval_evec, symmetric, d, typ, k, "LM", v0, sigma)
+
+
+def test_general_nonsymmetric_starting_vector():
+    params = NonSymmetricParams()
+    k = 2
+    sigma = None
+    symmetric = False
+    for d in params.complex_test_cases:
+        for typ in 'FD':
+            A = d['mat']
+            n = A.shape[0]
+            v0 = random.rand(n).astype(typ)
+            yield (eval_evec, symmetric, d, typ, k, "LM", v0, sigma)
+
+
+def test_standard_nonsymmetric_no_convergence():
+    np.random.seed(1234)
+    m = generate_matrix(30, complex=True)
+    try:
+        w, v = eigs(m, 4, which='LM', v0=m[:, 0], maxiter=5)
+        raise AssertionError("Spurious no-error exit")
+    except ArpackNoConvergence, err:
+        k = len(err.eigenvalues)
+        if k <= 0:
+            raise AssertionError("Spurious no-eigenvalues-found case")
+        w, v = err.eigenvalues, err.eigenvectors
+        for ww, vv in zip(w, v.T):
+            assert_array_almost_equal(dot(m, vv), ww * vv,
+                                      decimal=_ndigits['d'])
     
 
 def test_eigen_bad_shapes():
@@ -407,6 +438,23 @@ def test_eigen_bad_kwargs():
     A = csc_matrix(np.zeros((2, 2)))
     assert_raises(ValueError, eigs, A, which='XX')
 
+
+def test_ticket_1459_arpack_crash():
+    N = 6
+    k = 2
+
+    np.random.seed(2301)
+    A = np.random.random((N,N))
+    v0 = np.array([-0.71063568258907849895, -0.83185111795729227424,
+                   -0.34365925382227402451, 0.46122533684552280420,
+                   -0.58001341115969040629, -0.78844877570084292984e-01])
+
+    # Should not crash:
+    evals, evecs = eigs(A, k, v0=v0)
+
+
+#----------------------------------------------------------------------
+# sparse SVD tests
 
 def sorted_svd(m, k):
     #Compute svd of a dense matrix m, and return singular vectors/values
@@ -423,48 +471,49 @@ def svd_estimate(u, s, vh):
     return np.dot(u, np.dot(np.diag(s), vh))
 
 
-class TestSparseSvd(TestCase):
-    def test_simple_real(self):
-        x = np.array([[1, 2, 3],
-                      [3, 4, 3],
-                      [1, 0, 2],
-                      [0, 0, 1]], np.float)
-        y = np.array([[1, 2, 3, 8],
-                      [3, 4, 3, 5],
-                      [1, 0, 2, 3],
-                      [0, 0, 1, 0]], np.float)
-        z = csc_matrix(x)
+def test_svd_simple_real():
+    x = np.array([[1, 2, 3],
+                  [3, 4, 3],
+                  [1, 0, 2],
+                  [0, 0, 1]], np.float)
+    y = np.array([[1, 2, 3, 8],
+                  [3, 4, 3, 5],
+                  [1, 0, 2, 3],
+                  [0, 0, 1, 0]], np.float)
+    z = csc_matrix(x)
 
-        for m in [x.T, x, y, z, z.T]:
-            for k in range(1, min(m.shape)):
-                u, s, vh = sorted_svd(m, k)
-                su, ss, svh = svds(m, k)
+    for m in [x.T, x, y, z, z.T]:
+        for k in range(1, min(m.shape)):
+            u, s, vh = sorted_svd(m, k)
+            su, ss, svh = svds(m, k)
 
-                m_hat = svd_estimate(u, s, vh)
-                sm_hat = svd_estimate(su, ss, svh)
+            m_hat = svd_estimate(u, s, vh)
+            sm_hat = svd_estimate(su, ss, svh)
 
-                assert_array_almost_equal_nulp(m_hat, sm_hat, nulp=1000)
+            assert_array_almost_equal_nulp(m_hat, sm_hat, nulp=1000)
 
-    def test_simple_complex(self):
-        x = np.array([[1, 2, 3],
-                      [3, 4, 3],
-                      [1 + 1j, 0, 2],
-                      [0, 0, 1]], np.complex)
-        y = np.array([[1, 2, 3, 8 + 5j],
-                      [3 - 2j, 4, 3, 5],
-                      [1, 0, 2, 3],
-                      [0, 0, 1, 0]], np.complex)
-        z = csc_matrix(x)
 
-        for m in [x, x.T.conjugate(), x.T, y, y.conjugate(), z, z.T]:
-            for k in range(1, min(m.shape) - 1):
-                u, s, vh = sorted_svd(m, k)
-                su, ss, svh = svds(m, k)
+def test_simple_complex():
+    x = np.array([[1, 2, 3],
+                  [3, 4, 3],
+                  [1 + 1j, 0, 2],
+                  [0, 0, 1]], np.complex)
+    y = np.array([[1, 2, 3, 8 + 5j],
+                  [3 - 2j, 4, 3, 5],
+                  [1, 0, 2, 3],
+                  [0, 0, 1, 0]], np.complex)
+    z = csc_matrix(x)
 
-                m_hat = svd_estimate(u, s, vh)
-                sm_hat = svd_estimate(su, ss, svh)
+    for m in [x, x.T.conjugate(), x.T, y, y.conjugate(), z, z.T]:
+        for k in range(1, min(m.shape) - 1):
+            u, s, vh = sorted_svd(m, k)
+            su, ss, svh = svds(m, k)
 
-                assert_array_almost_equal_nulp(m_hat, sm_hat, nulp=1000)
+            m_hat = svd_estimate(u, s, vh)
+            sm_hat = svd_estimate(su, ss, svh)
+
+            assert_array_almost_equal_nulp(m_hat, sm_hat, nulp=1000)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Currently ARPACK is only supported for standard eigenvalue problems.  This is an attempt to unlock all the rich options available in ARPACK, notably generalized eigenvalue problems and shift-invert modes which allow the user to find clusters of eigenvalues that are not necessarily large or small.
