### PR TITLE
Hilbert matrix

### DIFF
--- a/doc/release/0.10.0-notes.rst
+++ b/doc/release/0.10.0-notes.rst
@@ -53,6 +53,14 @@ A sort keyword has been added to the Schur decomposition routine
 (``scipy.linalg.schur``) to allow the sorting of eigenvalues in
 the resultant Schur form.
 
+Additional special matrices (``scipy.linalg``)
+----------------------------------------------
+
+The following functions were added to ``scipy.linalg``::
+
+    hilbert - Create a Hilbert matrix.
+    
+
 Deprecated features
 ===================
 

--- a/doc/release/0.10.0-notes.rst
+++ b/doc/release/0.10.0-notes.rst
@@ -56,10 +56,8 @@ the resultant Schur form.
 Additional special matrices (``scipy.linalg``)
 ----------------------------------------------
 
-The following functions were added to ``scipy.linalg``::
+The functions ``hilbert`` and ``invhilbert`` were added to ``scipy.linalg``.
 
-    hilbert - Create a Hilbert matrix.
-    
 
 Deprecated features
 ===================

--- a/doc/source/linalg.rst
+++ b/doc/source/linalg.rst
@@ -88,6 +88,8 @@ Special Matrices
    companion
    hadamard
    hankel
+   hilbert
+   invhilbert
    kron
    leslie
    toeplitz

--- a/doc/source/tutorial/linalg.rst
+++ b/doc/source/tutorial/linalg.rst
@@ -843,6 +843,10 @@ Hadamard              `scipy.linalg.hadamard`    Construct a Hadamard matrix.
 --------------------  -------------------------  ---------------------------------------------------------
 Hankel                `scipy.linalg.hankel`      Construct a Hankel matrix.
 --------------------  -------------------------  ---------------------------------------------------------
+Hilbert               `scipy.linalg.hilbert`     Construct a Hilbert matrix.
+--------------------  -------------------------  ---------------------------------------------------------
+Invert Hilbert        `scipy.linalg.invhilbert`  Construct the inverse of a Hilbert matrix.
+--------------------  -------------------------  ---------------------------------------------------------
 Leslie                `scipy.linalg.leslie`      Create a Leslie matrix.
 --------------------  -------------------------  ---------------------------------------------------------
 Toeplitz              `scipy.linalg.toeplitz`    Construct a Toeplitz matrix.

--- a/doc/source/tutorial/linalg.rst
+++ b/doc/source/tutorial/linalg.rst
@@ -845,7 +845,7 @@ Hankel                `scipy.linalg.hankel`      Construct a Hankel matrix.
 --------------------  -------------------------  ---------------------------------------------------------
 Hilbert               `scipy.linalg.hilbert`     Construct a Hilbert matrix.
 --------------------  -------------------------  ---------------------------------------------------------
-Invert Hilbert        `scipy.linalg.invhilbert`  Construct the inverse of a Hilbert matrix.
+Inverse Hilbert       `scipy.linalg.invhilbert`  Construct the inverse of a Hilbert matrix.
 --------------------  -------------------------  ---------------------------------------------------------
 Leslie                `scipy.linalg.leslie`      Create a Leslie matrix.
 --------------------  -------------------------  ---------------------------------------------------------

--- a/scipy/linalg/info.py
+++ b/scipy/linalg/info.py
@@ -86,6 +86,7 @@ Special Matrices
    hadamard - Hadamard matrix of order 2**n
    hankel - Hankel matrix
    hilbert - Hilbert matrix
+   invhilbert - Inverse Hilbert matrix
    kron - Kronecker product of two arrays
    leslie - Leslie matrix
    toeplitz - Toeplitz matrix

--- a/scipy/linalg/info.py
+++ b/scipy/linalg/info.py
@@ -85,6 +85,7 @@ Special Matrices
    companion - Companion matrix
    hadamard - Hadamard matrix of order 2**n
    hankel - Hankel matrix
+   hilbert - Hilbert matrix
    kron - Kronecker product of two arrays
    leslie - Leslie matrix
    toeplitz - Toeplitz matrix

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -5,7 +5,7 @@ from scipy.misc import comb
 
 __all__ = ['tri', 'tril', 'triu', 'toeplitz', 'circulant', 'hankel',
            'hadamard', 'leslie', 'all_mat', 'kron', 'block_diag', 'companion',
-           'hilbert']
+           'hilbert', 'invhilbert']
 
 
 #-----------------------------------------------------------------------------
@@ -606,3 +606,63 @@ def hilbert(n):
     values = 1.0 / (1.0 + np.arange(2 * n - 1))
     h = hankel(values[:n], r=values[n-1:])
     return h
+
+
+def invhilbert(n, exact=False):
+    """Compute the inverse of the Hilbert matrix of order `n`.
+    
+    Parameters
+    ----------
+    n : int
+        The order of the Hilbert matrix.
+    exact : bool
+        If False, the data type of the array that is returned in np.float64,
+        and the array is an approximation of the inverse.
+        If True, the array is exact integer array.  To represent the exact
+        inverse when n > 14, the returned array is an object array of long
+        integers.  For n <= 14, the exact inverse is returned as an array
+        with data type np.int64.
+
+    Returns
+    -------
+    invh : ndarray with shape (n, n)
+        The data type of the array is np.float64 is exact is False.
+        If exact is True, the data type is either np.int64 (for n <= 14)
+        or object (for n > 14).  In the latter case, the objects in the
+        array will be long integers.
+
+    Examples
+    --------
+    >>> invhilbert(4)
+    array([[   16.,  -120.,   240.,  -140.],
+           [ -120.,  1200., -2700.,  1680.],
+           [  240., -2700.,  6480., -4200.],
+           [ -140.,  1680., -4200.,  2800.]])
+    >>> invhilbert(4, exact=True)
+    array([[   16,  -120,   240,  -140],
+           [ -120,  1200, -2700,  1680],
+           [  240, -2700,  6480, -4200],
+           [ -140,  1680, -4200,  2800]], dtype=int64)
+    >>> invhilbert(16)[7,7]
+    4.2475099528537506e+19
+    >>> invhilbert(16, exact=True)[7,7]
+    42475099528537378560L
+    """
+    if exact:
+        if n > 14:
+            dtype = object
+        else:
+            dtype = np.int64
+    else:
+        dtype = np.float64
+    invh = np.empty((n, n), dtype=dtype)
+    for i in xrange(n):
+        for j in xrange(0, i + 1):
+            s = i + j
+            invh[i, j] = ((-1)**s * (s + 1) *
+                          comb(n + i, n - j - 1, exact) *
+                          comb(n + j, n - i - 1, exact) *
+                          comb(s, i, exact) ** 2)
+            if i != j:
+                invh[j, i] = invh[i, j]
+    return invh

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -1,9 +1,11 @@
 
 import math
 import numpy as np
+from scipy.misc import comb
 
 __all__ = ['tri', 'tril', 'triu', 'toeplitz', 'circulant', 'hankel',
-           'hadamard', 'leslie', 'all_mat', 'kron', 'block_diag', 'companion']
+           'hadamard', 'leslie', 'all_mat', 'kron', 'block_diag', 'companion',
+           'hilbert']
 
 
 #-----------------------------------------------------------------------------
@@ -571,3 +573,36 @@ def companion(a):
     c[0] = first_row
     c[range(1,n-1), range(0, n-2)] = 1
     return c
+
+
+def hilbert(n):
+    """Create a Hilbert matrix of order n.
+    
+    Returns the `n` by `n` array with entries `h[i,j] = 1 / (i + j + 1)`.
+
+    Parameters
+    ----------
+    n : int
+        The size of the array to create.
+
+    Returns
+    -------
+    h : ndarray with shape (n, n)
+        The Hilber matrix.
+        
+    Notes
+    -----
+    
+    .. versionadded:: 0.10.0
+
+    Examples
+    --------
+    >>> hilbert(3)
+    array([[ 1.        ,  0.5       ,  0.33333333],
+           [ 0.5       ,  0.33333333,  0.25      ],
+           [ 0.33333333,  0.25      ,  0.2       ]])
+
+    """
+    values = 1.0 / (1.0 + np.arange(2 * n - 1))
+    h = hankel(values[:n], r=values[n-1:])
+    return h

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -592,7 +592,6 @@ def hilbert(n):
         
     Notes
     -----
-    
     .. versionadded:: 0.10.0
 
     Examples
@@ -630,6 +629,10 @@ def invhilbert(n, exact=False):
         If exact is True, the data type is either np.int64 (for n <= 14)
         or object (for n > 14).  In the latter case, the objects in the
         array will be long integers.
+
+    Notes
+    -----    
+    .. versionadded:: 0.10.0
 
     Examples
     --------

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -2,10 +2,11 @@
 
 from numpy import arange, add, array, eye, copy
 from numpy.testing import TestCase, run_module_suite, assert_raises, \
-    assert_equal, assert_array_equal
+    assert_equal, assert_array_equal, assert_array_almost_equal
 
 from scipy.linalg import toeplitz, hankel, circulant, hadamard, leslie, \
-                            companion, tri, triu, tril, kron, block_diag
+                            companion, tri, triu, tril, kron, block_diag, \
+                            hilbert
 
 
 def get_mat(n):
@@ -263,6 +264,20 @@ class TestKron:
                           [ 30, 40 ],
                           [ 33, 44 ]])
         assert_array_equal(a, expected)
+
+
+class TestHilbert(TestCase):
+
+    def test_basic(self):
+        h3 = array([[1.0,  1/2., 1/3.],
+                    [1/2., 1/3., 1/4.],
+                    [1/3., 1/4., 1/5.]])
+        assert_array_almost_equal(hilbert(3), h3)
+
+        assert_array_equal(hilbert(1), [[1.0]])
+        
+        h0 = hilbert(0)
+        assert_equal(h0.shape, (0,0))
 
 
 if __name__ == "__main__":

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -6,7 +6,7 @@ from numpy.testing import TestCase, run_module_suite, assert_raises, \
 
 from scipy.linalg import toeplitz, hankel, circulant, hadamard, leslie, \
                             companion, tri, triu, tril, kron, block_diag, \
-                            hilbert
+                            hilbert, invhilbert
 
 
 def get_mat(n):
@@ -278,6 +278,42 @@ class TestHilbert(TestCase):
         
         h0 = hilbert(0)
         assert_equal(h0.shape, (0,0))
+
+
+class TestInvHilbert(TestCase):
+
+    def test_basic(self):
+        invh1 = array([[1]])
+        assert_array_equal(invhilbert(1, exact=True), invh1)
+        assert_array_equal(invhilbert(1), invh1)
+
+        invh2 = array([[ 4, -6],
+                       [-6, 12]])
+        assert_array_equal(invhilbert(2, exact=True), invh2)
+        assert_array_almost_equal(invhilbert(2), invh2)
+
+        invh3 = array([[  9,  -36,  30],
+                       [-36,  192, -180],
+                        [30, -180,  180]])
+        assert_array_equal(invhilbert(3, exact=True), invh3)
+        assert_array_almost_equal(invhilbert(3), invh3)
+
+        invh4 = array([[  16,  -120,   240,  -140],
+                       [-120,  1200, -2700,  1680],
+                       [ 240, -2700,  6480, -4200],
+                       [-140,  1680, -4200,  2800]])
+        assert_array_equal(invhilbert(4, exact=True), invh4)
+        assert_array_almost_equal(invhilbert(4), invh4)
+
+        invh5 = array([[   25,   -300,    1050,  -1400,     630],
+                       [ -300,   4800,  -18900,   26880, -12600],
+                       [ 1050, -18900,   79380, -117600,  56700],
+                       [-1400,  26880, -117600,  179200, -88200],
+                       [  630, -12600,   56700,  -88200,  44100]])
+        assert_array_equal(invhilbert(5, exact=True), invh5)
+        assert_array_almost_equal(invhilbert(5), invh5)
+
+        # FIXME: Create a test for n > 14.
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add `hilbert` and `invhilbert` to the suite of special matrices available in scipy.linalg.

Note that when exact=True is passed to invhilbert with n > 14, the return array is an object array, where the objects are long integers.  That seemed like the best way to create an exact matrix.
