### PR TITLE
BUG: use dedicated npy_intp instead of int to store memory offset in NI_Label. Closes #742

### DIFF
--- a/scipy/ndimage/src/ni_measure.c
+++ b/scipy/ndimage/src/ni_measure.c
@@ -132,7 +132,7 @@ int NI_Label(PyArrayObject* input, PyArrayObject* strct,
             Int32 neighbor = 0;
             /* iterate over structuring element: */
             for(ll = 0; ll < filter_size; ll++) {
-                int offset = oo[ll];
+                npy_intp offset = oo[ll];
                 if (offset != mask_value) {
                     Int32 tt = *(Int32*)(po + offset);
                     if (tt > 0) {


### PR DESCRIPTION
There was request on the Debian python-modules mailing list, so I looked into the issue and came up with a tentative patch.  I haven't had a chance to test extensively, but the patch seems to be minimal enough ;-)

Thanks in advance
