### PR TITLE
Allow strict casting

### DIFF
--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -454,11 +454,7 @@ class netcdf_file(object):
                 if isinstance(sample, class_): break
 
         typecode, size = TYPEMAP[nc_type]
-        if typecode is 'c':
-            dtype_ = '>c'
-        else:
-            dtype_ = '>%s' % typecode
-            if size > 1: dtype_ += str(size)
+        dtype_ = '>%s' % typecode
 
         values = asarray(values, dtype=dtype_)
 
@@ -627,11 +623,7 @@ class netcdf_file(object):
         begin = [self._unpack_int, self._unpack_int64][self.version_byte-1]()
 
         typecode, size = TYPEMAP[nc_type]
-        if typecode is 'c':
-            dtype_ = '>c'
-        else:
-            dtype_ = '>%s' % typecode
-            if size > 1: dtype_ += str(size)
+        dtype_ = '>%s' % typecode
 
         return name, dimensions, shape, attributes, typecode, size, dtype_, begin, vsize
 
@@ -646,7 +638,7 @@ class netcdf_file(object):
         self.fp.read(-count % 4)  # read padding
 
         if typecode is not 'c':
-            values = fromstring(values, dtype='>%s%d' % (typecode, size))
+            values = fromstring(values, dtype='>%s' % typecode)
             if values.shape == (1,): values = values[0]
         else:
             values = values.rstrip(asbytes('\x00'))

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -447,7 +447,11 @@ def generic_gradient_magnitude(input, derivative, output = None,
                              *extra_arguments, **extra_keywords)
             numpy.multiply(tmp, tmp, tmp)
             output += tmp
-        numpy.sqrt(output, output)
+        # This allows the sqrt to work with a different default casting
+        if numpy.version.short_version > '1.6.1':
+            numpy.sqrt(output, output, casting='unsafe')
+        else:
+            numpy.sqrt(output, output)
     else:
         output[...] = input[...]
     return return_value

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -669,7 +669,7 @@ class TestNdimage:
             output = ndimage.gaussian_gradient_magnitude(array,
                                                                        1.0)
             expected = tmp1 * tmp1 + tmp2 * tmp2
-            numpy.sqrt(expected, expected)
+            expected = numpy.sqrt(expected).astype(type)
             assert_array_almost_equal(expected, output)
 
     def test_gaussian_gradient_magnitude02(self):
@@ -684,7 +684,7 @@ class TestNdimage:
             ndimage.gaussian_gradient_magnitude(array, 1.0,
                                                            output)
             expected = tmp1 * tmp1 + tmp2 * tmp2
-            numpy.sqrt(expected, expected)
+            expected = numpy.sqrt(expected).astype(type)
             assert_array_almost_equal(expected, output)
 
     def test_generic_gradient_magnitude01(self):


### PR DESCRIPTION
This fixes a bug in netcdf, and tweaks ndimage so that it will work with a tighter default casting policy in NumPy. The errors are discussed here:

http://mail.scipy.org/pipermail/numpy-discussion/2011-June/056632.html
