### PR TITLE
Signal: Add type III/IV filter calculation to firwin2

### DIFF
--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -441,7 +441,7 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=1.0, antisym
 
     if ftype == 2 and gain[-1] != 0.0:
         raise ValueError("A Type II filter must have zero gain at the Nyquist rate.")
-    elif ftype == 3 and gain[0] != gain[-1] != 0.0:
+    elif ftype == 3 and (gain[0] != 0.0 or gain[-1] != 0.0):
         raise ValueError("A Type III filter must have zero gain at zero and Nyquist rates.")
     elif ftype == 4 and gain[0] != 0.0:
         raise ValueError("A Type IV filter must have zero gain at zero rate.")

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -463,7 +463,11 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=1.0, antisym
     # Adjust the phases of the coefficients so that the first `ntaps` of the
     # inverse FFT are the desired filter coefficients.
     shift = np.exp(-(numtaps - 1) / 2. * 1.j * np.pi * x / nyq)
-    fx2 = fx * shift * (1j if ftype > 2 else 1.0)
+    if ftype > 2:
+        shift *= 1j
+        
+    fx2 = fx * shift
+                    
 
     # Use irfft to compute the inverse FFT.
     out_full = irfft(fx2)
@@ -480,7 +484,7 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=1.0, antisym
     out = out_full[:numtaps] * wind
 
     if ftype == 3:
-        out[out.size / 2] = 0.0
+        out[out.size // 2] = 0.0
 
     return out
 

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -310,7 +310,7 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
 #
 # Rewritten by Warren Weckesser, 2010.
 
-def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=1.0):
+def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=1.0, antisymmetric=False):
     """FIR filter design using the window method.
 
     From the given frequencies `freq` and corresponding gains `gain`,
@@ -321,8 +321,7 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=1.0):
     ----------
     numtaps : int
         The number of taps in the FIR filter.  `numtaps` must be less than
-        `nfreqs`.  If the gain at the Nyquist rate, `gain[-1]`, is not 0,
-        then `numtaps` must be odd.
+        `nfreqs`.
 
     freq : array-like, 1D
         The frequency sampling points. Typically 0.0 to 1.0 with 1.0 being
@@ -334,7 +333,9 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=1.0):
         be 0, and the last value must be `nyq`.
 
     gain : array-like
-        The filter gains at the frequency sampling points.
+        The filter gains at the frequency sampling points. Certain
+        constraints to gain values, depending on the filter type, are applied,
+        see Notes for details.
 
     nfreqs : int, optional
         The size of the interpolation mesh used to construct the filter.
@@ -351,6 +352,10 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=1.0):
     nyq : float
         Nyquist frequency.  Each frequency in `freq` must be between 0 and
         `nyq` (inclusive).
+
+    antisymmetric : bool
+        Flag setting wither resulting impulse responce is symmetric/antisymmetric.
+        See Notes for more details.
 
     Returns
     -------
@@ -379,10 +384,19 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=1.0):
     first `numtaps` coefficients of this kernel, scaled by `window`, are
     returned.
 
-    The FIR filter will have linear phase.  The filter is Type I if `numtaps`
-    is odd and Type II if `numtaps` is even.  Because Type II filters always
-    have a zero at the Nyquist frequency, `numtaps` must be odd if `gain[-1]`
-    is not zero.
+    The FIR filter will have linear phase. The type of filter is determined by
+    the value of 'numtaps` and `antisymmetric` flag.
+    There are four possible combinations:
+       - odd  `numtaps`, `antisymmetric` is False, type I filter is produced
+       - even `numtaps`, `antisymmetric` is False, type II filter is produced
+       - odd  `numtaps`, `antisymmetric` is True, type III filter is produced
+       - even `numtaps`, `antisymmetric` is True, type IV filter is produced
+
+    Magnitude response of all but type I filters are subjects to following
+    constraints:
+       - type II  -- zero at the Nyquist frequency
+       - type III -- zero at zero and Nyquist frequencies
+       - type IV  -- zero at zero frequency
 
     .. versionadded:: 0.9.0
 
@@ -414,9 +428,23 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=1.0):
     if (d2 == 0).any():
         raise ValueError('A value in freq must not occur more than twice.')
 
-    if numtaps % 2 == 0 and gain[-1] != 0.0:
-        raise ValueError("A filter with an even number of coefficients must "
-                            "have zero gain at the Nyquist rate.")
+    if antisymmetric:
+        if numtaps % 2 == 0:
+            ftype = 4
+        else:
+            ftype = 3
+    else:
+        if numtaps % 2 == 0:
+            ftype = 2
+        else:
+            ftype = 1
+
+    if ftype == 2 and gain[-1] != 0.0:
+        raise ValueError("A Type II filter must have zero gain at the Nyquist rate.")
+    elif ftype == 3 and gain[0] != gain[-1] != 0.0:
+        raise ValueError("A Type III filter must have zero gain at zero and Nyquist rates.")
+    elif ftype == 4 and gain[0] != 0.0:
+        raise ValueError("A Type IV filter must have zero gain at zero rate.")
 
     if nfreqs is None:
         nfreqs = 1 + 2 ** int(ceil(log(numtaps, 2)))
@@ -435,7 +463,7 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=1.0):
     # Adjust the phases of the coefficients so that the first `ntaps` of the
     # inverse FFT are the desired filter coefficients.
     shift = np.exp(-(numtaps - 1) / 2. * 1.j * np.pi * x / nyq)
-    fx2 = fx * shift
+    fx2 = fx * shift * (1j if ftype > 2 else 1.0)
 
     # Use irfft to compute the inverse FFT.
     out_full = irfft(fx2)
@@ -450,6 +478,9 @@ def firwin2(numtaps, freq, gain, nfreqs=None, window='hamming', nyq=1.0):
     # Keep only the first `numtaps` coefficients in `out`, and multiply by
     # the window.
     out = out_full[:numtaps] * wind
+
+    if ftype == 3:
+        out[out.size / 2] = 0.0
 
     return out
 

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -254,8 +254,20 @@ class TestFirwin2(TestCase):
         # `freq` does not start at 0.0.
         assert_raises(ValueError, firwin2, 50, [0.5, 1.0], [0.0, 1.0])
 
-        # Even number of taps, but the gain at 1 is not zero.
+        # Type II filter, but the gain at nyquist rate is not zero.
         assert_raises(ValueError, firwin2, 16, [0.0, 0.5, 1.0], [0.0, 1.0, 1.0])
+
+        # Type III filter, but the gains at nyquist and zero rate are not zero.
+        assert_raises(ValueError, firwin2, 17, [0.0, 0.5, 1.0], [0.0, 1.0, 1.0], 
+                      antisymmetric=True)
+        assert_raises(ValueError, firwin2, 17, [0.0, 0.5, 1.0], [1.0, 1.0, 0.0], 
+                      antisymmetric=True)
+        assert_raises(ValueError, firwin2, 17, [0.0, 0.5, 1.0], [1.0, 1.0, 1.0], 
+                      antisymmetric=True)
+
+        # Type VI filter, but the gain at zero rate is not zero.
+        assert_raises(ValueError, firwin2, 16, [0.0, 0.5, 1.0], [1.0, 1.0, 0.0],
+                      antisymmetric=True)
 
     def test01(self):
         width = 0.04
@@ -311,6 +323,20 @@ class TestFirwin2(TestCase):
         m = np.arange(0, ntaps) - alpha
         h = 0.5 * sinc(0.5 * m)
         assert_array_almost_equal(h, taps)
+
+    def test05(self):
+        """Test firwin2 for calculating Type IV filters"""
+        ntaps = 1500
+
+        freq = [0.0, 1.0]
+        gain = [0.0, 1.0] 
+        taps = firwin2(ntaps, freq, gain, window=None, antisymmetric=True)
+        assert_array_almost_equal(taps[: ntaps // 2], -taps[ntaps // 2:][::-1])
+
+
+        freqs, response = freqz(taps, worN=2048)
+        assert_array_almost_equal(abs(response), freqs / np.pi, decimal=4)
+
 
     def test_nyq(self):
         taps1 = firwin2(80, [0.0, 0.5, 1.0], [1.0, 1.0, 0.0])

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -337,6 +337,20 @@ class TestFirwin2(TestCase):
         freqs, response = freqz(taps, worN=2048)
         assert_array_almost_equal(abs(response), freqs / np.pi, decimal=4)
 
+    def test06(self):
+        """Test firwin2 for calculating Type III filters"""
+        ntaps = 1501
+
+        freq = [0.0, 0.5, 0.55,  1.0]
+        gain = [0.0, 0.5, 0.0,   0.0] 
+        taps = firwin2(ntaps, freq, gain, window=None, antisymmetric=True)
+        assert_equal(taps[ntaps // 2], 0.0)
+        assert_array_almost_equal(taps[: ntaps // 2], -taps[ntaps // 2 + 1:][::-1])
+
+        freqs, response1 = freqz(taps, worN=2048)
+        response2        = np.interp(freqs / np.pi, freq, gain)
+        assert_array_almost_equal(abs(response1), response2, decimal=3)
+
 
     def test_nyq(self):
         taps1 = firwin2(80, [0.0, 0.5, 1.0], [1.0, 1.0, 0.0])


### PR DESCRIPTION
Since current version of firwin2 allows only to calculate type II and type III filters, and it would be really nice to be able to use it for type III and type IV filters(one example of such usage would be calculation of k-th order differentiators) I decided to add such functionality to it. This commit is a result of my labors.

Changes to firwin2 are really small and trivial: special flag which controls whither resulting impulse response is  symmetric or asymmetric is introduced, and based on the value of this flag a pi/2 phase shit is introduced to frequency response(to which inverse DFT is applied).

Not sure if I should have opened a ticket at http://projects.scipy.org/scipy or would this pull request be enough?
