### PR TITLE
Implement thin SVD at the LAPACK level.

### DIFF
--- a/scipy/linalg/decomp_svd.py
+++ b/scipy/linalg/decomp_svd.py
@@ -67,10 +67,6 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False):
     diagsvd : return the Sigma matrix, given the vector s
 
     """
-    # A hack until full_matrices == 0 support is fixed here.
-    if full_matrices == 0:
-        import numpy.linalg
-        return numpy.linalg.svd(a, full_matrices=0, compute_uv=compute_uv)
     a1 = asarray_chkfinite(a)
     if len(a1.shape) != 2:
         raise ValueError('expected matrix')
@@ -80,7 +76,7 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False):
     if gesdd.module_name[:7] == 'flapack':
         lwork = calc_lwork.gesdd(gesdd.prefix, m, n, compute_uv)[1]
         u,s,v,info = gesdd(a1,compute_uv = compute_uv, lwork = lwork,
-                                                overwrite_a = overwrite_a)
+                           full_matrices=full_matrices, overwrite_a = overwrite_a)
     else: # 'clapack'
         raise NotImplementedError('calling gesdd from %s' % gesdd.module_name)
     if info > 0:

--- a/scipy/linalg/generic_flapack.pyf
+++ b/scipy/linalg/generic_flapack.pyf
@@ -360,30 +360,33 @@ interface
 
    end subroutine <tchar=s,d,c,z>getri
 
-   subroutine <tchar=s,d>gesdd(m,n,minmn,du,dvt,a,compute_uv,u,s,vt,work,lwork,iwork,info)
-   
+   subroutine <tchar=s,d>gesdd(m,n,minmn,u0,u1,vt0,vt1,a,compute_uv,full_matrices,u,s,vt,work,lwork,iwork,info)
+
    ! u,s,vt,info = gesdd(a,compute_uv=1,lwork=..,overwrite_a=0)
    ! Compute the singular value decomposition (SVD):
    !   A = U * SIGMA * transpose(V)
    ! A - M x N matrix
-   ! U - M x M matrix
-   ! SIGMA - M x N zero matrix with a main diagonal filled with min(M,N) 
-   !               singular values  
-   ! transpose(V) - N x N matrix
+   ! U - M x M matrix or min(M,N) x N if full_matrices=False
+   ! SIGMA - M x N zero matrix with a main diagonal filled with min(M,N)
+   !               singular values
+   ! transpose(V) - N x N matrix or N x min(M,N) if full_matrices=False
 
-   callstatement (*f2py_func)((compute_uv?"A":"N"),&m,&n,a,&m,s,u,&du,vt,&dvt,work,&lwork,iwork,&info)
+   callstatement (*f2py_func)((compute_uv?(full_matrices?"A":"S"):"N"),&m,&n,a,&m,s,u,&u0,vt,&vt0,work,&lwork,iwork,&info)
    callprotoargument char*,int*,int*,<type_in_c>*,int*,<type_in_c>*,<type_in_c>*,int*,<type_in_c>*,int*,<type_in_c>*,int*,int*,int*
 
    integer intent(in),optional,check(compute_uv==0||compute_uv==1):: compute_uv = 1
+   integer intent(in),optional,check(full_matrices==0||full_matrices==1):: full_matrices = 1
    integer intent(hide),depend(a):: m = shape(a,0)
    integer intent(hide),depend(a):: n = shape(a,1)
    integer intent(hide),depend(m,n):: minmn = MIN(m,n)
-   integer intent(hide),depend(compute_uv,minmn) :: du = (compute_uv?m:1)
-   integer intent(hide),depend(compute_uv,n) :: dvt = (compute_uv?n:1)
+   integer intent(hide),depend(compute_uv,minmn) :: u0 = (compute_uv?m:1)
+   integer intent(hide),depend(compute_uv,minmn, full_matrices) :: u1 = (compute_uv?(full_matrices?m:minmn):1)
+   integer intent(hide),depend(compute_uv,minmn, full_matrices) :: vt0 = (compute_uv?(full_matrices?n:minmn):1)
+   integer intent(hide),depend(compute_uv,minmn) :: vt1 = (compute_uv?n:1)
    <type_in> dimension(m,n),intent(in,copy,aligned8) :: a
    <type_in> dimension(minmn),intent(out),depend(minmn) :: s
-   <type_in> dimension(du,du),intent(out),depend(du) :: u
-   <type_in> dimension(dvt,dvt),intent(out),depend(dvt) :: vt
+   <type_in> dimension(u0,u1),intent(out),depend(u0, u1) :: u
+   <type_in> dimension(vt0,vt1),intent(out),depend(vt0, vt1) :: vt
    <type_in> dimension(lwork),intent(hide,cache),depend(lwork) :: work
    integer optional,intent(in),depend(minmn,compute_uv) &
         :: lwork = (compute_uv?4*minmn*minmn+MAX(m,n)+9*minmn:MAX(14*minmn+4,10*minmn+2+25*(25+8))+MAX(m,n))
@@ -394,30 +397,33 @@ interface
 
    end subroutine <tchar=s,d>gesdd
 
-   subroutine <tchar=c,z>gesdd(m,n,minmn,du,dvt,a,compute_uv,u,s,vt,work,rwork,lwork,iwork,info)
-   
+   subroutine <tchar=c,z>gesdd(m,n,minmn,u0,u1,vt0,vt1,a,compute_uv,full_matrices,u,s,vt,work,rwork,lwork,iwork,info)
+
    ! u,s,vt,info = gesdd(a,compute_uv=1,lwork=..,overwrite_a=0)
    ! Compute the singular value decomposition (SVD):
    !   A = U * SIGMA * conjugate-transpose(V)
    ! A - M x N matrix
-   ! U - M x M matrix
-   ! SIGMA - M x N zero matrix with a main diagonal filled with min(M,N) 
-   !               singular values  
-   ! conjugate-transpose(V) - N x N matrix
+   ! U - M x M matrix or min(M,N) x N if full_matrices=False
+   ! SIGMA - M x N zero matrix with a main diagonal filled with min(M,N)
+   !               singular values
+   ! transpose(V) - N x N matrix or N x min(M,N) if full_matrices=False
 
-   callstatement (*f2py_func)((compute_uv?"A":"N"),&m,&n,a,&m,s,u,&du,vt,&dvt,work,&lwork,rwork,iwork,&info)
+   callstatement (*f2py_func)((compute_uv?(full_matrices?"A":"S"):"N"),&m,&n,a,&m,s,u,&u0,vt,&vt0,work,&lwork,rwork,iwork,&info)
    callprotoargument char*,int*,int*,<type_in_c>*,int*,<rtype_in_c>*,<type_in_c>*,int*,<type_in_c>*,int*,<type_in_c>*,int*,<rtype_in_c>*,int*,int*
 
    integer intent(in),optional,check(compute_uv==0||compute_uv==1):: compute_uv = 1
+   integer intent(in),optional,check(full_matrices==0||full_matrices==1):: full_matrices = 1
    integer intent(hide),depend(a):: m = shape(a,0)
    integer intent(hide),depend(a):: n = shape(a,1)
    integer intent(hide),depend(m,n):: minmn = MIN(m,n)
-   integer intent(hide),depend(compute_uv,minmn) :: du = (compute_uv?m:1)
-   integer intent(hide),depend(compute_uv,n) :: dvt = (compute_uv?n:1)
+   integer intent(hide),depend(compute_uv,minmn) :: u0 = (compute_uv?m:1)
+   integer intent(hide),depend(compute_uv,minmn, full_matrices) :: u1 = (compute_uv?(full_matrices?m:minmn):1)
+   integer intent(hide),depend(compute_uv,minmn, full_matrices) :: vt0 = (compute_uv?(full_matrices?n:minmn):1)
+   integer intent(hide),depend(compute_uv,minmn) :: vt1 = (compute_uv?n:1)
    <type_in> dimension(m,n),intent(in,copy) :: a
    <rtype_in> dimension(minmn),intent(out),depend(minmn) :: s
-   <type_in> dimension(du,du),intent(out),depend(du) :: u
-   <type_in> dimension(dvt,dvt),intent(out),depend(dvt) :: vt
+   <type_in> dimension(u0,u1),intent(out),depend(u0,u1) :: u
+   <type_in> dimension(vt0,vt1),intent(out),depend(vt0,vt1) :: vt
    <type_in> dimension(lwork),intent(hide,cache),depend(lwork) :: work
    <rtype_in> dimension((compute_uv?5*minmn*minmn+7*minmn:5*minmn)),intent(hide,cache),depend(minmn,compute_uv) :: rwork
    integer optional,intent(in),depend(minmn,compute_uv) &
@@ -427,7 +433,6 @@ interface
    integer intent(out)::info
 
    end subroutine <tchar=c,z>gesdd
-
 
    subroutine <tchar=s,d>gelss(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,lwork,info)
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -737,74 +737,80 @@ class TestSVD(TestCase):
 
     def test_simple(self):
         a = [[1,2,3],[1,20,3],[2,5,6]]
-        u,s,vh = svd(a)
-        assert_array_almost_equal(dot(transpose(u),u),identity(3))
-        assert_array_almost_equal(dot(transpose(vh),vh),identity(3))
-        sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
-        for i in range(len(s)): sigma[i,i] = s[i]
-        assert_array_almost_equal(dot(dot(u,sigma),vh),a)
+        for full_matrices in (True, False):
+            u,s,vh = svd(a, full_matrices=full_matrices)
+            assert_array_almost_equal(dot(transpose(u),u),identity(3))
+            assert_array_almost_equal(dot(transpose(vh),vh),identity(3))
+            sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
+            for i in range(len(s)): sigma[i,i] = s[i]
+            assert_array_almost_equal(dot(dot(u,sigma),vh),a)
 
     def test_simple_singular(self):
         a = [[1,2,3],[1,2,3],[2,5,6]]
-        u,s,vh = svd(a)
-        assert_array_almost_equal(dot(transpose(u),u),identity(3))
-        assert_array_almost_equal(dot(transpose(vh),vh),identity(3))
-        sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
-        for i in range(len(s)): sigma[i,i] = s[i]
-        assert_array_almost_equal(dot(dot(u,sigma),vh),a)
+        for full_matrices in (True, False):
+            u,s,vh = svd(a, full_matrices=full_matrices)
+            assert_array_almost_equal(dot(transpose(u),u),identity(3))
+            assert_array_almost_equal(dot(transpose(vh),vh),identity(3))
+            sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
+            for i in range(len(s)): sigma[i,i] = s[i]
+            assert_array_almost_equal(dot(dot(u,sigma),vh),a)
 
     def test_simple_underdet(self):
         a = [[1,2,3],[4,5,6]]
-        u,s,vh = svd(a)
-        assert_array_almost_equal(dot(transpose(u),u),identity(2))
-        assert_array_almost_equal(dot(transpose(vh),vh),identity(3))
-        sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
-        for i in range(len(s)): sigma[i,i] = s[i]
-        assert_array_almost_equal(dot(dot(u,sigma),vh),a)
+        for full_matrices in (True, False):
+            u,s,vh = svd(a, full_matrices=full_matrices)
+            assert_array_almost_equal(dot(transpose(u),u),identity(u.shape[0]))
+            sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
+            for i in range(len(s)): sigma[i,i] = s[i]
+            assert_array_almost_equal(dot(dot(u,sigma),vh),a)
 
     def test_simple_overdet(self):
         a = [[1,2],[4,5],[3,4]]
-        u,s,vh = svd(a)
-        assert_array_almost_equal(dot(transpose(u),u),identity(3))
-        assert_array_almost_equal(dot(transpose(vh),vh),identity(2))
-        sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
-        for i in range(len(s)): sigma[i,i] = s[i]
-        assert_array_almost_equal(dot(dot(u,sigma),vh),a)
+        for full_matrices in (True, False):
+            u,s,vh = svd(a, full_matrices=full_matrices)
+            assert_array_almost_equal(dot(transpose(u),u), identity(u.shape[1]))
+            assert_array_almost_equal(dot(transpose(vh),vh),identity(2))
+            sigma = zeros((u.shape[1],vh.shape[0]),s.dtype.char)
+            for i in range(len(s)): sigma[i,i] = s[i]
+            assert_array_almost_equal(dot(dot(u,sigma),vh),a)
 
     def test_random(self):
         n = 20
         m = 15
         for i in range(3):
             for a in [random([n,m]),random([m,n])]:
-                u,s,vh = svd(a)
-                assert_array_almost_equal(dot(transpose(u),u),identity(len(u)))
-                assert_array_almost_equal(dot(transpose(vh),vh),identity(len(vh)))
-                sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
-                for i in range(len(s)): sigma[i,i] = s[i]
-                assert_array_almost_equal(dot(dot(u,sigma),vh),a)
+                for full_matrices in (True, False):
+                    u,s,vh = svd(a, full_matrices=full_matrices)
+                    assert_array_almost_equal(dot(transpose(u),u),identity(u.shape[1]))
+                    assert_array_almost_equal(dot(vh, transpose(vh)),identity(vh.shape[0]))
+                    sigma = zeros((u.shape[1],vh.shape[0]),s.dtype.char)
+                    for i in range(len(s)): sigma[i,i] = s[i]
+                    assert_array_almost_equal(dot(dot(u,sigma),vh),a)
 
     def test_simple_complex(self):
         a = [[1,2,3],[1,2j,3],[2,5,6]]
-        u,s,vh = svd(a)
-        assert_array_almost_equal(dot(conj(transpose(u)),u),identity(3))
-        assert_array_almost_equal(dot(conj(transpose(vh)),vh),identity(3))
-        sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
-        for i in range(len(s)): sigma[i,i] = s[i]
-        assert_array_almost_equal(dot(dot(u,sigma),vh),a)
+        for full_matrices in (True, False):
+            u,s,vh = svd(a, full_matrices=full_matrices)
+            assert_array_almost_equal(dot(conj(transpose(u)),u),identity(u.shape[1]))
+            assert_array_almost_equal(dot(conj(transpose(vh)),vh),identity(vh.shape[0]))
+            sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
+            for i in range(len(s)): sigma[i,i] = s[i]
+            assert_array_almost_equal(dot(dot(u,sigma),vh),a)
 
     def test_random_complex(self):
         n = 20
         m = 15
         for i in range(3):
-            for a in [random([n,m]),random([m,n])]:
-                a = a + 1j*random(list(a.shape))
-                u,s,vh = svd(a)
-                assert_array_almost_equal(dot(conj(transpose(u)),u),identity(len(u)))
-                # This fails when [m,n]
-                #assert_array_almost_equal(dot(conj(transpose(vh)),vh),identity(len(vh),dtype=vh.dtype.char))
-                sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
-                for i in range(len(s)): sigma[i,i] = s[i]
-                assert_array_almost_equal(dot(dot(u,sigma),vh),a)
+            for full_matrices in (True, False):
+                for a in [random([n,m]),random([m,n])]:
+                    a = a + 1j*random(list(a.shape))
+                    u,s,vh = svd(a, full_matrices=full_matrices)
+                    assert_array_almost_equal(dot(conj(transpose(u)),u),identity(u.shape[1]))
+                    # This fails when [m,n]
+                    #assert_array_almost_equal(dot(conj(transpose(vh)),vh),identity(len(vh),dtype=vh.dtype.char))
+                    sigma = zeros((u.shape[1],vh.shape[0]),s.dtype.char)
+                    for i in range(len(s)): sigma[i,i] = s[i]
+                    assert_array_almost_equal(dot(dot(u,sigma),vh),a)
 
 class TestSVDVals(TestCase):
 
@@ -1065,22 +1071,22 @@ class TestSchur(TestCase):
         assert_array_almost_equal(dot(dot(zc,tc),transp(conj(zc))),a)
         tc2,zc2 = rsf2csf(tc,zc)
         assert_array_almost_equal(dot(dot(zc2,tc2),transp(conj(zc2))),a)
-        
+
     def test_sort(self):
         a = [[4.,3.,1.,-1.],[-4.5,-3.5,-1.,1.],[9.,6.,-4.,4.5],[6.,4.,-3.,3.5]]
         s,u,sdim = schur(a,sort='lhp')
-        assert_array_almost_equal([[0.1134,0.5436,0.8316,0.], 
-                                   [-0.1134,-0.8245,0.5544,0.], 
-                                   [-0.8213,0.1308,0.0265,-0.5547], 
+        assert_array_almost_equal([[0.1134,0.5436,0.8316,0.],
+                                   [-0.1134,-0.8245,0.5544,0.],
+                                   [-0.8213,0.1308,0.0265,-0.5547],
                                    [-0.5475,0.0872,0.0177,0.8321]],
                                   u,3)
-        assert_array_almost_equal([[-1.4142,0.1456,-11.5816,-7.7174], 
-                                   [0.,-0.5000,9.4472,-0.7184], 
-                                   [0.,0.,1.4142,-0.1456], 
+        assert_array_almost_equal([[-1.4142,0.1456,-11.5816,-7.7174],
+                                   [0.,-0.5000,9.4472,-0.7184],
+                                   [0.,0.,1.4142,-0.1456],
                                    [0.,0.,0.,0.5]],
                                   s,3)
         assert_equal(2,sdim)
-                                  
+
         s,u,sdim = schur(a,sort='rhp')
         assert_array_almost_equal([[0.4862,-0.4930,0.1434,-0.7071],
                                    [-0.4862,0.4930,-0.1434,-0.7071],
@@ -1093,7 +1099,7 @@ class TestSchur(TestCase):
                                    [0.,0.,0.,-0.5]],
                                   s,3)
         assert_equal(2,sdim)
-                                  
+
         s,u,sdim = schur(a,sort='iuc')
         assert_array_almost_equal([[0.5547,0.,-0.5721,-0.6042],
                                    [-0.8321,0.,-0.3814,-0.4028],
@@ -1106,7 +1112,7 @@ class TestSchur(TestCase):
                                    [0.,0.,0.,-1.4142]],
                                   s,3)
         assert_equal(2,sdim)
-                                  
+
         s,u,sdim = schur(a,sort='ouc')
         assert_array_almost_equal([[0.4862,-0.5134,0.7071,0.],
                                    [-0.4862,0.5134,0.7071,0.],
@@ -1119,7 +1125,7 @@ class TestSchur(TestCase):
                                    [0.,0.,0.,0.5000]],
                                   s,3)
         assert_equal(2,sdim)
-                                  
+
         rhp_function = lambda x: x >= 0.0
         s,u,sdim = schur(a,sort=rhp_function)
         assert_array_almost_equal([[0.4862,-0.4930,0.1434,-0.7071],
@@ -1133,7 +1139,7 @@ class TestSchur(TestCase):
                                    [0.,0.,0.,-0.5]],
                                   s,3)
         assert_equal(2,sdim)
-                                  
+
     def test_sort_errors(self):
         a = [[4.,3.,1.,-1.],[-4.5,-3.5,-1.,1.],[9.,6.,-4.,4.5],[6.,4.,-3.,3.5]]
         assert_raises(ValueError, schur, a, sort='unsupported')


### PR DESCRIPTION
Before this, the thin SVD was implemented (as a temporary hack) by
calling the numpy routine. This implements the options missing in the
LAPACK gesdd bindings (keyword full_matrices) so that it can be used
to perform the thin SVD.

I also extended the tests so that it tests with both full_matrices={True, False}.
