### PR TITLE
Allow loading from file-like in scipy.io.arff

### DIFF
--- a/scipy/io/arff/__init__.py
+++ b/scipy/io/arff/__init__.py
@@ -12,6 +12,7 @@ Examples
 --------
 
 >>> from scipy.io import arff
+>>> from cStringIO import StringIO
 >>> content = \"\"\"
 ... @relation foo
 ... @attribute width  numeric
@@ -22,10 +23,8 @@ Examples
 ... 4.5,3.75,green
 ... 3.0,4.00,red
 ... \"\"\"
->>> f = open('testdata.arff', 'w')
->>> f.write(content)
->>> f.close()
->>> data, meta = arff.loadarff('testdata.arff')
+>>> f = StringIO(content)
+>>> data, meta = arff.loadarff(f)
 >>> data
 array([(5.0, 3.25, 'blue'), (4.5, 3.75, 'green'), (3.0, 4.0, 'red')],
       dtype=[('width', '<f8'), ('height', '<f8'), ('color', '|S6')])

--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -454,7 +454,7 @@ class MetaData(object):
         return attr_types
 
 
-def loadarff(filename):
+def loadarff(f):
     """
     Read an arff file.
 
@@ -466,8 +466,8 @@ def loadarff(filename):
 
     Parameters
     ----------
-    filename : str
-       the name of the file
+    f : file-like or str
+       File-like object to read from, or filename to open.
 
     Returns
     -------
@@ -499,7 +499,7 @@ def loadarff(filename):
     points as NaNs.
 
     """
-    ofile = open(filename)
+    ofile = f if hasattr(f, 'read') else open(f, 'rt')
 
     # Parse the header file
     try:

--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -500,7 +500,13 @@ def loadarff(f):
 
     """
     ofile = f if hasattr(f, 'read') else open(f, 'rt')
+    try:
+        return _loadarff(ofile)
+    finally:
+        if ofile is not f:  # only close what we opened
+            ofile.close()
 
+def _loadarff(ofile):
     # Parse the header file
     try:
         rel, attr = read_header(ofile)

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -53,7 +53,7 @@ class DataTest(TestCase):
         data1, meta1 = loadarff(f1)
         data2, meta2 = loadarff(f2)
         assert_(data1 == data2)
-        assert_(meta1 == meta2)
+        assert_(repr(meta1) == repr(meta2))
 
 
 class MissingDataTest(TestCase):

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 from os.path import join as pjoin
+from cStringIO import StringIO
 
 import numpy as np
 
@@ -44,6 +45,15 @@ class DataTest(TestCase):
             for j in range(4):
                 assert_array_almost_equal(expect4_data[i][j], data[i][j])
         assert_equal(meta.types(), expected_types)
+
+    def test_filelike(self):
+        """Test reading from file-like object (StringIO)"""
+        f1 = open(test1)
+        f2 = StringIO(open(test1).read())
+        data1, meta1 = loadarff(f1)
+        data2, meta2 = loadarff(f2)
+        assert_(data1 == data2)
+        assert_(meta1 == meta2)
 
 
 class MissingDataTest(TestCase):


### PR DESCRIPTION
`loadarff` would previously only accept a filename as argument. This can be very cumbersome, as is evident from `io.arff`'s current docstring, so I implemented loading from an arbitrary file-like object.

The patch includes a test.
