### PR TITLE
Qr with pivoting

### DIFF
--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -116,7 +116,7 @@ def qr(a, overwrite_a=False, lwork=None, pivoting=False, mode='full'):
 
         qr, jpvt, tau, work, info = geqp3(a1, lwork=lwork,
             overwrite_a=overwrite_a)
-        jpvt -= 1
+        jpvt -= 1 # geqp3 returns a 1-based index array, so subtract 1
         if info < 0:
             raise ValueError("illegal value in %d-th argument of internal geqp3"
                                                                         % -info)

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -1,4 +1,4 @@
-# Additions by Collin Stocks, July 2011
+# Additions by Collin RM Stocks, July 2011
 
 """QR decomposition functions."""
 

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -55,7 +55,7 @@ def qr(a, overwrite_a=False, lwork=None, pivoting=False, mode='full'):
     Notes
     -----
     This is an interface to the LAPACK routines dgeqrf, zgeqrf,
-    dorgqr, zungqr, and geqp3.
+    dorgqr, zungqr, dgeqp3, and zgeqp3.
 
     If ``mode=economic``, the shapes of Q and R are (M, K) and (K, N) instead
     of (M,M) and (M,N), with ``K=min(M,N)``.

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -15,7 +15,7 @@ from misc import _datacopied
 __all__ = ['qr', 'rq', 'qr_old']
 
 
-def qr(a, overwrite_a=False, lwork=None, pivoting=False, mode='full'):
+def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
     """Compute QR decomposition of a matrix.
 
     Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
@@ -30,15 +30,15 @@ def qr(a, overwrite_a=False, lwork=None, pivoting=False, mode='full'):
     lwork : int, optional
         Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
         is computed.
+    mode : {'full', 'r', 'economic'}
+        Determines what information is to be returned: either both Q and R
+        ('full', default), only R ('r') or both Q and R but computed in
+        economy-size ('economic', see Notes).
     pivoting : bool, optional
         Whether or not factorization should include pivoting for rank-revealing
         qr decomposition. If pivoting, compute the decomposition
         :lm:`A P = Q R` as above, but where P is chosen such that the diagonal
         of R is non-increasing.
-    mode : {'full', 'r', 'economic'}
-        Determines what information is to be returned: either both Q and R
-        ('full', default), only R ('r') or both Q and R but computed in
-        economy-size ('economic', see Notes).
 
     Returns
     -------
@@ -88,7 +88,7 @@ def qr(a, overwrite_a=False, lwork=None, pivoting=False, mode='full'):
     >>> q4.shape, r4.shape, p4.shape
     ((9, 9), (9, 6), (6,))
 
-    >>> q5, r5, p5 = linalg.qr(a, pivoting=True, mode='economic')
+    >>> q5, r5, p5 = linalg.qr(a, mode='economic', pivoting=True)
     >>> q5.shape, r5.shape, p5.shape
     ((9, 6), (6, 6), (6,))
 

--- a/scipy/linalg/generic_flapack.pyf
+++ b/scipy/linalg/generic_flapack.pyf
@@ -495,10 +495,10 @@ interface
 
    end subroutine <tchar=c,z>gelss
 
-   subroutine <tchar=s,d,c,z>geqp3(m,n,a,jpvt,tau,work,lwork,info)
+   subroutine <tchar=s,d>geqp3(m,n,a,jpvt,tau,work,lwork,info)
 
-   ! qr_a,jpvt,tau,work,info = geqp3(a,lwork=3*n,overwrite_a=0)
-   ! Compute a QR factorization of a general M-by-N matrix A with column pivoting:
+   ! qr_a,jpvt,tau,work,info = geqp3(a,lwork=3*(n+1),overwrite_a=0)
+   ! Compute a QR factorization of a real M-by-N matrix A with column pivoting:
    !   A * P = Q * R.
 
      callstatement (*f2py_func)(&m,&n,a,&m,jpvt,tau,work,&lwork,&info)
@@ -510,10 +510,31 @@ interface
      integer dimension(n),intent(out) :: jpvt
      <type_in> dimension(MIN(m,n)),intent(out) :: tau
 
-     integer optional,intent(in),depend(n),check(lwork>=n||lwork==-1) :: lwork=3*n
+     integer optional,intent(in),depend(n),check(lwork>=n||lwork==-1) :: lwork=3*(n+1)
      <type_in> dimension(MAX(lwork,1)),intent(out),depend(lwork) :: work
      integer intent(out) :: info
-   end subroutine <tchar=s,d,c,z>geqp3
+   end subroutine <tchar=s,d>geqp3
+
+   subroutine <tchar=c,z>geqp3(m,n,a,jpvt,tau,work,lwork,rwork,info)
+
+   ! qr_a,jpvt,tau,work,info = geqp3(a,lwork,overwrite_a=0)
+   ! Compute a QR factorization of a complex M-by-N matrix A with column pivoting:
+   !   A * P = Q * R.
+
+     callstatement (*f2py_func)(&m,&n,a,&m,jpvt,tau,work,&lwork,rwork,&info)
+     callprotoargument int*,int*,<type_in_c>*,int*,int*,<type_in_c>*,<type_in_c>*,int*,<type_in_c>*,int*
+
+     integer intent(hide),depend(a):: m = shape(a,0)
+     integer intent(hide),depend(a):: n = shape(a,1)
+     <type_in> dimension(m,n),intent(in,out,copy,out=qr,aligned8) :: a
+     integer dimension(n),intent(out) :: jpvt
+     <type_in> dimension(MIN(m,n)),intent(out) :: tau
+
+     integer optional,intent(in),depend(n),check(lwork>=n||lwork==-1) :: lwork=3*(n+1)
+     <type_in> dimension(MAX(lwork,1)),intent(out),depend(lwork) :: work
+     <type_in> dimension(2*n),intent(hide),depend(n) :: rwork
+     integer intent(out) :: info
+   end subroutine <tchar=c,z>geqp3
 
    subroutine <tchar=s,d,c,z>geqrf(m,n,a,tau,work,lwork,info)
 

--- a/scipy/linalg/generic_flapack.pyf
+++ b/scipy/linalg/generic_flapack.pyf
@@ -7,7 +7,7 @@
 !
 ! Additions by Travis Oliphant
 ! Additions by Tiziano Zito
-! Additions by Collin Stocks
+! Additions by Collin RM Stocks
 ! Usage:
 !   f2py -c generic_flapack.pyf -L/usr/local/lib/atlas -llapack -lf77blas -lcblas -latlas -lg2c
 

--- a/scipy/linalg/generic_flapack.pyf
+++ b/scipy/linalg/generic_flapack.pyf
@@ -7,6 +7,7 @@
 !
 ! Additions by Travis Oliphant
 ! Additions by Tiziano Zito
+! Additions by Collin Stocks
 ! Usage:
 !   f2py -c generic_flapack.pyf -L/usr/local/lib/atlas -llapack -lf77blas -lcblas -latlas -lg2c
 
@@ -493,6 +494,26 @@ interface
      <rtype_in> intent(out),dimension(minmn),depend(minmn) :: s
 
    end subroutine <tchar=c,z>gelss
+
+   subroutine <tchar=s,d,c,z>geqp3(m,n,a,jpvt,tau,work,lwork,info)
+
+   ! qr_a,jpvt,tau,work,info = geqp3(a,lwork=3*n,overwrite_a=0)
+   ! Compute a QR factorization of a general M-by-N matrix A with column pivoting:
+   !   A * P = Q * R.
+
+     callstatement (*f2py_func)(&m,&n,a,&m,jpvt,tau,work,&lwork,&info)
+     callprotoargument int*,int*,<type_in_c>*,int*,int*,<type_in_c>*,<type_in_c>*,int*,int*
+
+     integer intent(hide),depend(a):: m = shape(a,0)
+     integer intent(hide),depend(a):: n = shape(a,1)
+     <type_in> dimension(m,n),intent(in,out,copy,out=qr,aligned8) :: a
+     integer dimension(n),intent(out) :: jpvt
+     <type_in> dimension(MIN(m,n)),intent(out) :: tau
+
+     integer optional,intent(in),depend(n),check(lwork>=n||lwork==-1) :: lwork=3*n
+     <type_in> dimension(MAX(lwork,1)),intent(out),depend(lwork) :: work
+     integer intent(out) :: info
+   end subroutine <tchar=s,d,c,z>geqp3
 
    subroutine <tchar=s,d,c,z>geqrf(m,n,a,tau,work,lwork,info)
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Created by: Pearu Peterson, March 2002
+# Additions by Collin Stocks, July 2011
 #
 """ Test functions for linalg.decomp module
 
@@ -861,11 +862,29 @@ class TestQR(TestCase):
         assert_array_almost_equal(dot(transpose(q),q),identity(3))
         assert_array_almost_equal(dot(q,r),a)
 
+    def test_simple_pivoted(self):
+        a = np.asarray([[8,2,3],[2,9,3],[5,3,6]])
+        q,r,p = qr(a, pivoted=True)
+        assert_array_almost_equal(dot(transpose(q),q),identity(3))
+        assert_array_almost_equal(dot(q,r),a[:,p])
+        q2,r2 = qr(a[:,p])
+        assert_array_almost_equal(q,q2)
+        assert_array_almost_equal(r,r2)
+
     def test_simple_trap(self):
         a = [[8,2,3],[2,9,3]]
         q,r = qr(a)
         assert_array_almost_equal(dot(transpose(q),q),identity(2))
         assert_array_almost_equal(dot(q,r),a)
+
+    def test_simple_trap_pivoted(self):
+        a = np.asarray([[8,2,3],[2,9,3]])
+        q,r,p = qr(a, pivoted=True)
+        assert_array_almost_equal(dot(transpose(q),q),identity(2))
+        assert_array_almost_equal(dot(q,r),a[:,p])
+        q2,r2 = qr(a[:,p])
+        assert_array_almost_equal(q,q2)
+        assert_array_almost_equal(r,r2)
 
     def test_simple_tall(self):
         # full version
@@ -873,6 +892,16 @@ class TestQR(TestCase):
         q,r = qr(a)
         assert_array_almost_equal(dot(transpose(q),q),identity(3))
         assert_array_almost_equal(dot(q,r),a)
+
+    def test_simple_tall_pivoted(self):
+        # full version pivoted
+        a = np.asarray([[8,2],[2,9],[5,3]])
+        q,r,p = qr(a, pivoted=True)
+        assert_array_almost_equal(dot(transpose(q),q),identity(3))
+        assert_array_almost_equal(dot(q,r),a[:,p])
+        q2,r2 = qr(a[:,p])
+        assert_array_almost_equal(q,q2)
+        assert_array_almost_equal(r,r2)
 
     def test_simple_tall_e(self):
         # economy version
@@ -883,6 +912,16 @@ class TestQR(TestCase):
         assert_equal(q.shape, (3,2))
         assert_equal(r.shape, (2,2))
 
+    def test_simple_tall_e_pivoted(self):
+        # economy version pivoted
+        a = np.asarray([[8,2],[2,9],[5,3]])
+        q,r,p = qr(a, pivoted=True, mode='economic')
+        assert_array_almost_equal(dot(transpose(q),q),identity(2))
+        assert_array_almost_equal(dot(q,r),a[:,p])
+        q2,r2 = qr(a[:,p], mode='economic')
+        assert_array_almost_equal(q,q2)
+        assert_array_almost_equal(r,r2)
+
     def test_simple_fat(self):
         # full version
         a = [[8,2,5],[2,9,3]]
@@ -892,6 +931,18 @@ class TestQR(TestCase):
         assert_equal(q.shape, (2,2))
         assert_equal(r.shape, (2,3))
 
+    def test_simple_fat_pivoted(self):
+        # full version pivoted
+        a = np.asarray([[8,2,5],[2,9,3]])
+        q,r,p = qr(a, pivoted=True)
+        assert_array_almost_equal(dot(transpose(q),q),identity(2))
+        assert_array_almost_equal(dot(q,r),a[:,p])
+        assert_equal(q.shape, (2,2))
+        assert_equal(r.shape, (2,3))
+        q2,r2 = qr(a[:,p])
+        assert_array_almost_equal(q,q2)
+        assert_array_almost_equal(r,r2)
+
     def test_simple_fat_e(self):
         # economy version
         a = [[8,2,3],[2,9,5]]
@@ -900,6 +951,18 @@ class TestQR(TestCase):
         assert_array_almost_equal(dot(q,r),a)
         assert_equal(q.shape, (2,2))
         assert_equal(r.shape, (2,3))
+
+    def test_simple_fat_e_pivoted(self):
+        # economy version pivoted
+        a = np.asarray([[8,2,3],[2,9,5]])
+        q,r,p = qr(a, pivoted=True, mode='economic')
+        assert_array_almost_equal(dot(transpose(q),q),identity(2))
+        assert_array_almost_equal(dot(q,r),a[:,p])
+        assert_equal(q.shape, (2,2))
+        assert_equal(r.shape, (2,3))
+        q2,r2 = qr(a[:,p], mode='economic')
+        assert_array_almost_equal(q,q2)
+        assert_array_almost_equal(r,r2)
 
     def test_simple_complex(self):
         a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
@@ -915,6 +978,17 @@ class TestQR(TestCase):
             assert_array_almost_equal(dot(transpose(q),q),identity(n))
             assert_array_almost_equal(dot(q,r),a)
 
+    def test_random_pivoted(self):
+        n = 20
+        for k in range(2):
+            a = random([n,n])
+            q,r,p = qr(a, pivoted=True)
+            assert_array_almost_equal(dot(transpose(q),q),identity(n))
+            assert_array_almost_equal(dot(q,r),a[:,p])
+            q2,r2 = qr(a[:,p])
+            assert_array_almost_equal(q,q2)
+            assert_array_almost_equal(r,r2)
+
     def test_random_tall(self):
         # full version
         m = 200
@@ -924,6 +998,19 @@ class TestQR(TestCase):
             q,r = qr(a)
             assert_array_almost_equal(dot(transpose(q),q),identity(m))
             assert_array_almost_equal(dot(q,r),a)
+
+    def test_random_tall(self):
+        # full version pivoted
+        m = 200
+        n = 100
+        for k in range(2):
+            a = random([m,n])
+            q,r,p = qr(a, pivoted=True)
+            assert_array_almost_equal(dot(transpose(q),q),identity(m))
+            assert_array_almost_equal(dot(q,r),a[:,p])
+            q2,r2 = qr(a[:,p])
+            assert_array_almost_equal(q,q2)
+            assert_array_almost_equal(r,r2)
 
     def test_random_tall_e(self):
         # economy version
@@ -937,6 +1024,21 @@ class TestQR(TestCase):
             assert_equal(q.shape, (m,n))
             assert_equal(r.shape, (n,n))
 
+    def test_random_tall_e(self):
+        # economy version pivoted
+        m = 200
+        n = 100
+        for k in range(2):
+            a = random([m,n])
+            q,r,p = qr(a, pivoted=True, mode='economic')
+            assert_array_almost_equal(dot(transpose(q),q),identity(n))
+            assert_array_almost_equal(dot(q,r),a[:,p])
+            assert_equal(q.shape, (m,n))
+            assert_equal(r.shape, (n,n))
+            q2,r2 = qr(a[:,p], mode='economic')
+            assert_array_almost_equal(q,q2)
+            assert_array_almost_equal(r,r2)
+
     def test_random_trap(self):
         m = 100
         n = 200
@@ -945,6 +1047,18 @@ class TestQR(TestCase):
             q,r = qr(a)
             assert_array_almost_equal(dot(transpose(q),q),identity(m))
             assert_array_almost_equal(dot(q,r),a)
+
+    def test_random_trap_pivoted(self):
+        m = 100
+        n = 200
+        for k in range(2):
+            a = random([m,n])
+            q,r,p = qr(a, pivoted=True)
+            assert_array_almost_equal(dot(transpose(q),q),identity(m))
+            assert_array_almost_equal(dot(q,r),a[:,p])
+            q2,r2 = qr(a[:,p])
+            assert_array_almost_equal(q,q2)
+            assert_array_almost_equal(r,r2)
 
     def test_random_complex(self):
         n = 20

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Created by: Pearu Peterson, March 2002
-# Additions by Collin Stocks, July 2011
+# Additions by Collin RM Stocks, July 2011
 #
 """ Test functions for linalg.decomp module
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -862,9 +862,11 @@ class TestQR(TestCase):
         assert_array_almost_equal(dot(transpose(q),q),identity(3))
         assert_array_almost_equal(dot(q,r),a)
 
-    def test_simple_pivoted(self):
+    def test_simple_pivoting(self):
         a = np.asarray([[8,2,3],[2,9,3],[5,3,6]])
-        q,r,p = qr(a, pivoted=True)
+        q,r,p = qr(a, pivoting=True)
+        d = abs(diag(r))
+        assert_(all(d[1:] <= d[:-1]))
         assert_array_almost_equal(dot(transpose(q),q),identity(3))
         assert_array_almost_equal(dot(q,r),a[:,p])
         q2,r2 = qr(a[:,p])
@@ -877,9 +879,11 @@ class TestQR(TestCase):
         assert_array_almost_equal(dot(transpose(q),q),identity(2))
         assert_array_almost_equal(dot(q,r),a)
 
-    def test_simple_trap_pivoted(self):
+    def test_simple_trap_pivoting(self):
         a = np.asarray([[8,2,3],[2,9,3]])
-        q,r,p = qr(a, pivoted=True)
+        q,r,p = qr(a, pivoting=True)
+        d = abs(diag(r))
+        assert_(all(d[1:] <= d[:-1]))
         assert_array_almost_equal(dot(transpose(q),q),identity(2))
         assert_array_almost_equal(dot(q,r),a[:,p])
         q2,r2 = qr(a[:,p])
@@ -893,10 +897,12 @@ class TestQR(TestCase):
         assert_array_almost_equal(dot(transpose(q),q),identity(3))
         assert_array_almost_equal(dot(q,r),a)
 
-    def test_simple_tall_pivoted(self):
-        # full version pivoted
+    def test_simple_tall_pivoting(self):
+        # full version pivoting
         a = np.asarray([[8,2],[2,9],[5,3]])
-        q,r,p = qr(a, pivoted=True)
+        q,r,p = qr(a, pivoting=True)
+        d = abs(diag(r))
+        assert_(all(d[1:] <= d[:-1]))
         assert_array_almost_equal(dot(transpose(q),q),identity(3))
         assert_array_almost_equal(dot(q,r),a[:,p])
         q2,r2 = qr(a[:,p])
@@ -912,10 +918,12 @@ class TestQR(TestCase):
         assert_equal(q.shape, (3,2))
         assert_equal(r.shape, (2,2))
 
-    def test_simple_tall_e_pivoted(self):
-        # economy version pivoted
+    def test_simple_tall_e_pivoting(self):
+        # economy version pivoting
         a = np.asarray([[8,2],[2,9],[5,3]])
-        q,r,p = qr(a, pivoted=True, mode='economic')
+        q,r,p = qr(a, pivoting=True, mode='economic')
+        d = abs(diag(r))
+        assert_(all(d[1:] <= d[:-1]))
         assert_array_almost_equal(dot(transpose(q),q),identity(2))
         assert_array_almost_equal(dot(q,r),a[:,p])
         q2,r2 = qr(a[:,p], mode='economic')
@@ -931,10 +939,12 @@ class TestQR(TestCase):
         assert_equal(q.shape, (2,2))
         assert_equal(r.shape, (2,3))
 
-    def test_simple_fat_pivoted(self):
-        # full version pivoted
+    def test_simple_fat_pivoting(self):
+        # full version pivoting
         a = np.asarray([[8,2,5],[2,9,3]])
-        q,r,p = qr(a, pivoted=True)
+        q,r,p = qr(a, pivoting=True)
+        d = abs(diag(r))
+        assert_(all(d[1:] <= d[:-1]))
         assert_array_almost_equal(dot(transpose(q),q),identity(2))
         assert_array_almost_equal(dot(q,r),a[:,p])
         assert_equal(q.shape, (2,2))
@@ -952,10 +962,12 @@ class TestQR(TestCase):
         assert_equal(q.shape, (2,2))
         assert_equal(r.shape, (2,3))
 
-    def test_simple_fat_e_pivoted(self):
-        # economy version pivoted
+    def test_simple_fat_e_pivoting(self):
+        # economy version pivoting
         a = np.asarray([[8,2,3],[2,9,5]])
-        q,r,p = qr(a, pivoted=True, mode='economic')
+        q,r,p = qr(a, pivoting=True, mode='economic')
+        d = abs(diag(r))
+        assert_(all(d[1:] <= d[:-1]))
         assert_array_almost_equal(dot(transpose(q),q),identity(2))
         assert_array_almost_equal(dot(q,r),a[:,p])
         assert_equal(q.shape, (2,2))
@@ -978,11 +990,13 @@ class TestQR(TestCase):
             assert_array_almost_equal(dot(transpose(q),q),identity(n))
             assert_array_almost_equal(dot(q,r),a)
 
-    def test_random_pivoted(self):
+    def test_random_pivoting(self):
         n = 20
         for k in range(2):
             a = random([n,n])
-            q,r,p = qr(a, pivoted=True)
+            q,r,p = qr(a, pivoting=True)
+            d = abs(diag(r))
+            assert_(all(d[1:] <= d[:-1]))
             assert_array_almost_equal(dot(transpose(q),q),identity(n))
             assert_array_almost_equal(dot(q,r),a[:,p])
             q2,r2 = qr(a[:,p])
@@ -1000,12 +1014,14 @@ class TestQR(TestCase):
             assert_array_almost_equal(dot(q,r),a)
 
     def test_random_tall(self):
-        # full version pivoted
+        # full version pivoting
         m = 200
         n = 100
         for k in range(2):
             a = random([m,n])
-            q,r,p = qr(a, pivoted=True)
+            q,r,p = qr(a, pivoting=True)
+            d = abs(diag(r))
+            assert_(all(d[1:] <= d[:-1]))
             assert_array_almost_equal(dot(transpose(q),q),identity(m))
             assert_array_almost_equal(dot(q,r),a[:,p])
             q2,r2 = qr(a[:,p])
@@ -1025,12 +1041,14 @@ class TestQR(TestCase):
             assert_equal(r.shape, (n,n))
 
     def test_random_tall_e(self):
-        # economy version pivoted
+        # economy version pivoting
         m = 200
         n = 100
         for k in range(2):
             a = random([m,n])
-            q,r,p = qr(a, pivoted=True, mode='economic')
+            q,r,p = qr(a, pivoting=True, mode='economic')
+            d = abs(diag(r))
+            assert_(all(d[1:] <= d[:-1]))
             assert_array_almost_equal(dot(transpose(q),q),identity(n))
             assert_array_almost_equal(dot(q,r),a[:,p])
             assert_equal(q.shape, (m,n))
@@ -1048,12 +1066,14 @@ class TestQR(TestCase):
             assert_array_almost_equal(dot(transpose(q),q),identity(m))
             assert_array_almost_equal(dot(q,r),a)
 
-    def test_random_trap_pivoted(self):
+    def test_random_trap_pivoting(self):
         m = 100
         n = 200
         for k in range(2):
             a = random([m,n])
-            q,r,p = qr(a, pivoted=True)
+            q,r,p = qr(a, pivoting=True)
+            d = abs(diag(r))
+            assert_(all(d[1:] <= d[:-1]))
             assert_array_almost_equal(dot(transpose(q),q),identity(m))
             assert_array_almost_equal(dot(q,r),a[:,p])
             q2,r2 = qr(a[:,p])

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -982,6 +982,17 @@ class TestQR(TestCase):
         assert_array_almost_equal(dot(conj(transpose(q)),q),identity(3))
         assert_array_almost_equal(dot(q,r),a)
 
+    def test_simple_complex_pivoting(self):
+        a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
+        q,r,p = qr(a, pivoting=True)
+        d = abs(diag(r))
+        assert_(all(d[1:] <= d[:-1]))
+        assert_array_almost_equal(dot(conj(transpose(q)),q),identity(3))
+        assert_array_almost_equal(dot(q,r),a[:,p])
+        q2,r2 = qr(a[:,p])
+        assert_array_almost_equal(q,q2)
+        assert_array_almost_equal(r,r2)
+
     def test_random(self):
         n = 20
         for k in range(2):
@@ -1087,6 +1098,19 @@ class TestQR(TestCase):
             q,r = qr(a)
             assert_array_almost_equal(dot(conj(transpose(q)),q),identity(n))
             assert_array_almost_equal(dot(q,r),a)
+
+    def test_random_complex_pivoting(self):
+        n = 20
+        for k in range(2):
+            a = random([n,n])+1j*random([n,n])
+            q,r,p = qr(a, pivoting=True)
+            d = abs(diag(r))
+            assert_(all(d[1:] <= d[:-1]))
+            assert_array_almost_equal(dot(conj(transpose(q)),q),identity(n))
+            assert_array_almost_equal(dot(q,r),a[:,p])
+            q2,r2 = qr(a[:,p])
+            assert_array_almost_equal(q,q2)
+            assert_array_almost_equal(r,r2)
 
 class TestRQ(TestCase):
 


### PR DESCRIPTION
I've added functionality to linalg.qr(). It now has an optional boolean keyword argument, ``pivoting'' which signals that QR decomposition should be computed with pivoting. See http://en.wikipedia.org/wiki/Qr_decomposition#Column_pivoting if you need more details on what that means.

This is implemented by wrapping <s,d,c,z>geqp3 from the lapack library.

This feature is necessary in order to replicate the behavior of MatLab's stepwisefit() function, an implementation of which I plan to submit to scikits.statsmodels, since they (via their mailing list) have shown interest in such an implementation.

I have included fairly comprehensive tests of the new functionality, as you can verify.

This patch addresses ticket #1473.

Thanks for considering this patch.

-- Talia
