### PR TITLE
scipy.optimize doc additions

### DIFF
--- a/scipy/optimize/cobyla.py
+++ b/scipy/optimize/cobyla.py
@@ -18,7 +18,8 @@ def fmin_cobyla(func, x0, cons, args=(), consargs=None, rhobeg=1.0, rhoend=1e-4,
                 iprint=1, maxfun=1000, disp=None):
     """
     Minimize a function using the Constrained Optimization BY Linear
-    Approximation (COBYLA) method.
+    Approximation (COBYLA) method. This method wraps a FORTRAN 
+    implentation of the algorithm. 
 
     Parameters
     ----------
@@ -37,9 +38,10 @@ def fmin_cobyla(func, x0, cons, args=(), consargs=None, rhobeg=1.0, rhoend=1e-4,
         use same extra arguments as those passed to func).
         Use ``()`` for no extra arguments.
     rhobeg :
-        Reasonable initial changes to the variables.
+        Reasonable initial changes to the variables. 
     rhoend :
-        Final accuracy in the optimization (not precisely guaranteed).
+        Final accuracy in the optimization (not precisely guaranteed). This 
+        is a lower bound on the size of the trust region.
     iprint : {0, 1, 2, 3}
         Controls the frequency of output; 0 implies no output.  Deprecated.
     disp : {0, 1, 2, 3}
@@ -51,6 +53,48 @@ def fmin_cobyla(func, x0, cons, args=(), consargs=None, rhobeg=1.0, rhoend=1e-4,
     -------
     x : ndarray
         The argument that minimises `f`.
+    
+    Notes
+    -----
+    This algorithm is based on linear approximations to the objective 
+    function and each constraint. We briefly describe the algorithm.
+    
+    Suppose the function is being minimized over k variables. At the 
+    jth iteration the algorithm has k+1 points v_1, ..., v_(k+1),
+    an approximate solution x_j, and a radius RHO_j.
+    (i.e. linear plus a constant) approximations to the objective 
+    function and constraint functions such that their function values
+    agree with the linear approximation on the k+1 points v_1,.., v_(k+1).
+    This gives a linear program to solve (where the linear approximations
+    of the constraint functions are constrained to be non-negative). 
+    
+    However the linear approximations are likely only good 
+    approximations near the current simplex, so the linear program is
+    given the further requirement that the solution, which
+    will become x_(j+1), must be within RHO_j from x_j. RHO_j only
+    decreases, never increases. The initial RHO_j is rhobeg and the
+    final RHO_j is rhoend. In this way COBYLA's iterations behave
+    like a trust region algorithm.
+
+    Additionally, the linear program may be inconsistent, or the
+    approximation may give poor improvement. For details about 
+    how these issues are resolved, as well as how the points v_i are 
+    updated, refer to the source code or the references below. 
+    
+
+    References
+    ----------
+    Powell M.J.D. (1994), "A direct search optimization method that models
+    the objective and constraint functions by linear interpolation.", in 
+    Advances in Optimization and Numerical Analysis, eds. S. Gomez and 
+    J-P Hennart, Kluwer Academic (Dordrecht), pp. 51-67
+
+    Powell M.J.D. (1998), "Direct search algorithms for optimization
+    calculations", Acta Numerica 7, 287-336
+
+    Powell M.J.D. (2007), "A view of algorithms for optimization without
+    derivatives", Cambridge University Technical Report DAMTP 2007/NA03
+
 
     Examples
     --------
@@ -75,6 +119,8 @@ def fmin_cobyla(func, x0, cons, args=(), consargs=None, rhobeg=1.0, rhoend=1e-4,
         array([-0.70710685,  0.70710671])
 
     The exact solution is (-sqrt(2)/2, sqrt(2)/2).
+
+
 
     """
     err = "cons must be a sequence of callable functions or a single"\

--- a/scipy/optimize/nnls.py
+++ b/scipy/optimize/nnls.py
@@ -6,7 +6,8 @@ __all__ = ['nnls']
 
 def nnls(A,b):
     """
-    Solve ``argmin_x || Ax - b ||_2`` for ``x>=0``.
+    Solve ``argmin_x || Ax - b ||_2`` for ``x>=0``. This is a wrapper
+    for a FORTAN non-negative least squares solver. 
 
     Parameters
     ----------
@@ -24,7 +25,13 @@ def nnls(A,b):
 
     Notes
     -----
-    This is a wrapper for ``NNLS.F``.
+    The FORTRAN code was published in the book below. The algorithm 
+    is an active set method. It solves the KKT (Karush-Kuhn-Tucker) 
+    conditions for the non-negative least squares problem. 
+    
+    References
+    ----------
+    Lawson C., Hanson R.J., (1987) Solving Least Squares Problems, SIAM 
 
     """
 

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -179,7 +179,8 @@ def wrap_function(function, args):
 def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
          full_output=0, disp=1, retall=0, callback=None):
     """
-    Minimize a function using the downhill simplex algorithm.
+    Minimize a function using the downhill simplex algorithm. This algorithm
+    only uses function values, not dervatives or second dervatives. 
 
     Parameters
     ----------
@@ -229,7 +230,25 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
     Notes
     -----
     Uses a Nelder-Mead simplex algorithm to find the minimum of function of
-    one or more variables.
+    one or more variables. 
+
+    This algorithm has a long history of successful use in applications.
+    But it will usually be slower than an algorithm that uses first or 
+    second derivative information. In practice it can have poor 
+    performance in high-dimensional problems and is not robust to 
+    minimizing complicated functions. Additionally, there currently is not
+    a complete theory describing when the algorithm will successfully 
+    find the minimum or the speed of convergence. 
+
+    References
+    ----------
+    Nelder, J.A. and Mead, R. (1965), "A simplex method for function
+    minimization", The Computer Journal, 7, pp. 308-313
+    Wright, M.H. (1996), "Direct Search Methods: Once Scorned, Now 
+    Respectable", in Numerical Analysis 1995, Proceedings of the 
+    1995 Dundee Biennial Conference in Numerical Analysis, D.F. 
+    Griffiths and G.A. Watson (Eds.), Addison Wesley Longman,
+    Harlow, UK, pp. 191-208.
 
     """
     fcalls, func = wrap_function(func, args)
@@ -379,6 +398,31 @@ def approx_fprime(xk,f,epsilon,*args):
     return grad
 
 def check_grad(func, grad, x0, *args):
+    """Check the correctness of a gradient function 
+    by comparing it against a finite-difference approximation
+    of the gradient.
+
+    Parameters
+    ----------
+    func: callable func(x0,*args)
+        Function whose derivative is to be checked
+    grad: callable grad(x0, *args)
+        Gradient of func
+    x0: ndarray
+        Points to check grad against finite difference 
+        approximation of grad using func.
+    args: optional
+        Extra arguments passed to func and grad
+
+    Returns
+    -------
+    err: float
+        The square root of the sum of squares (i.e. the 2-norm)
+        of the difference between grad(x0, *args) and the 
+        finite difference approximation of grad using func at the 
+        points x0. 
+
+    """
     return sqrt(sum((grad(x0,*args)-approx_fprime(x0,func,_epsilon,*args))**2))
 
 def approx_fhess_p(x0,p,fprime,epsilon,*args):
@@ -449,8 +493,11 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
     -----
     Optimize the function, f, whose gradient is given by fprime
     using the quasi-Newton method of Broyden, Fletcher, Goldfarb,
-    and Shanno (BFGS) See Wright, and Nocedal 'Numerical
-    Optimization', 1999, pg. 198.
+    and Shanno (BFGS) 
+    
+    References
+    ----------
+    Wright, and Nocedal 'Numerical Optimization', 1999, pg. 198.
 
     """
     x0 = asarray(x0).flatten()
@@ -720,7 +767,8 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
 def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
              epsilon=_epsilon, maxiter=None, full_output=0, disp=1, retall=0,
              callback=None):
-    """Minimize a function using the Newton-CG method.
+    """Unconstrained minimization of a function using the Newton-CG method.
+    
 
     Parameters
     ----------
@@ -786,8 +834,21 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
     approximated using finite differences on `fprime`. `fhess_p`
     must compute the hessian times an arbitrary vector. If it is not
     given, finite-differences on `fprime` are used to compute
-    it. See Wright & Nocedal, 'Numerical Optimization', 1999,
-    pg. 140.
+    it.  
+
+    Newton-CG methods are also called truncated Newton methods. This
+    function differs from scipy.optimize.fmin_tnc because
+    
+    1. scipy.optimize.fmin_ncg is written purely in python using numpy
+        and scipy while scipy.optimize.fmin_tnc calls a C function.
+    2. scipy.optimize.fmin_ncg is only for unconstrained minimization
+        while scipy.optimize.fmin_tnc is for unconstrained minimization 
+        or box constrained minimization. (Box constraints give
+        lower and upper bounds for each variable seperately.) 
+    
+    References
+    ----------
+    Wright & Nocedal, 'Numerical Optimization', 1999, pg. 140.
 
     """
     x0 = asarray(x0).flatten()
@@ -1428,7 +1489,8 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
                 maxfun=None, full_output=0, disp=1, retall=0, callback=None,
                 direc=None):
     """
-    Minimize a function using modified Powell's method.
+    Minimize a function using modified Powell's method. This method
+    only uses function values, not derivatives.
 
     Parameters
     ----------
@@ -1485,8 +1547,36 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
     Notes
     -----
     Uses a modification of Powell's method to find the minimum of
-    a function of N variables.
+    a function of N variables. Powell's method is a conjugate 
+    direction method. 
+    
+    The algorithm has two loops. The outer loop
+    merely iterates over the inner loop. The inner loop minimizes
+    over each current direction in the direction set. At the end 
+    of the inner loop, if certain conditions are met, the direction 
+    that gave the largest decrease is dropped and replaced with 
+    the difference between the current estiamted x and the estimated 
+    x from the beginning of the inner-loop. 
+    
+    The technical conditions for replacing the direction of greatest
+    increase amount to checking that 
+    
+    1. No further gain can be made along the 
+    direction of greatest increase from that iteration
+    2.The direction of greatest increase accounted for a large sufficient
+    fraction of the decrease in the function value from that
+    iteration of the inner loop. 
+    
 
+    References
+    ----------
+    Powell M.J.D. (1964) An efficient method for finding the minimum of a
+    function of several variables without calculating derivatives,
+    Computer Journal, 7 (2):155-162. 
+
+    Press W., Teukolsky S.A., Vetterling W.T., and Flannery B.P.: 
+    Numerical Recipes (any edition), Cambridge University Press
+    
     """
     # we need to use a mutable object here that we can update in the
     # wrapper function

--- a/scipy/optimize/tnc.py
+++ b/scipy/optimize/tnc.py
@@ -88,28 +88,38 @@ def fmin_tnc(func, x0, fprime=None, args=(), approx_grad=0,
              rescale=-1, disp=None):
     """
     Minimize a function with variables subject to bounds, using
-    gradient information.
+    gradient information in a truncated Newton algorithm. This 
+    method wraps a C implementation of the algorithm. 
 
     Parameters
     ----------
     func : callable ``func(x, *args)``
-        Function to minimize.  Should return f and g, where f is
+        Function to minimize.  Must do one of
+        1. Return f and g, where f is
         the value of the function and g its gradient (a list of
-        floats).  If the function returns None, the minimization
+        floats).  
+        2. Return the function value but supply gradient function
+        seperately as fprime
+        3. Return the function value and set approx_grad=True.
+        If the function returns None, the minimization
         is aborted.
     x0 : list of floats
         Initial estimate of minimum.
     fprime : callable ``fprime(x, *args)``
-        Gradient of func. If None, then func must return the
-        function value and the gradient (``f,g = func(x, *args)``).
+        Gradient of func. If None, then either func must return the
+        function value and the gradient (``f,g = func(x, *args)``)
+        or approx_grad must be True.
     args : tuple
         Arguments to pass to function.
     approx_grad : bool
         If true, approximate the gradient numerically.
     bounds : list
-        (min, max) pairs for each element in x, defining the
+        (min, max) pairs for each element in x0, defining the
         bounds on that parameter. Use None or +/-inf for one of
         min or max when there is no bound in that direction.
+    epsilon: float
+        Used if approx_grad is True. The stepsize in a finite
+        difference approximation for fprime. 
     scale : list of floats
         Scaling factors to apply to each variable.  If None, the
         factors are up-low for interval bounded variables and
@@ -170,6 +180,41 @@ def fmin_tnc(func, x0, fprime=None, args=(), approx_grad=0,
         The number of function evaluations.
     rc : int
         Return code as defined in the RCSTRINGS dict.
+
+
+    Notes
+    -----
+    The underlying algorithm is truncated Newton, also called 
+    Newton Conjugate-Gradient. This method differs from 
+    scipy.optimize.fmin_ncg in that
+    
+    1. It wraps a C implementation of the algorithm
+    2. It allows each variable to be given an upper and lower bound.
+
+    The algorithm incoporates the bound constraints by determining
+    the descent direction as in an unconstrained truncated Newton, 
+    but never taking a step-size large enough to leave the space
+    of feasible x's. The algorithm keeps track of a set of 
+    currently active constraints, and ignores them when computing 
+    the minimum allowable step size. (The x's associated with the
+    active constraint are kept fixed.) If the maximum allowable 
+    step size is zero then a new constraint is added. At the end
+    of each iteration one of the constraints may be deemed no 
+    longer active and removed. A constraint is considered 
+    no longer active is if it is currently active 
+    but the gradient for that variable points inward from the 
+    constraint. The specific constraint removed is the one
+    associated with the variable of largest index whose 
+    constraint is no longer active. 
+
+
+    References
+    ----------
+    Wright S., Nocedal J. (2006), 'Numerical Optimization'
+
+    Nash S.G. (1984), "Newton-Type Minimization Via the Lanczos Method",
+    SIAM Journal of Numerical Analysis 21, pp. 770-778
+
 
     """
     x0 = asarray(x0, dtype=float).tolist()

--- a/scipy/optimize/tnc/tnc.c
+++ b/scipy/optimize/tnc/tnc.c
@@ -223,7 +223,6 @@ static void dneg1(int n, double v[]);
  *
  * where x is a vector of n real variables. The method used is
  * a truncated-newton algorithm (see "newton-type minimization via
- * the lanczos algorithm" by s.g. nash (technical report 378, math.
  * the lanczos method" by s.g. nash (siam j. numer. anal. 21 (1984),
  * pp. 770-778).  this algorithm finds a local minimum of f(x). It does
  * not assume that the function f is convex (and so cannot guarantee a

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -5127,8 +5127,11 @@ class uniform_gen(rv_continuous):
     """A uniform continuous random variable.
 
     This distribution is constant between `loc` and ``loc = scale``.
+    
+    %(before_notes)s
 
-    %(default)s
+    %(example)s
+
     """
     def _rvs(self):
         return mtrand.uniform(0.0,1.0,self._size)

--- a/scipy/stats/info.py
+++ b/scipy/stats/info.py
@@ -103,6 +103,7 @@ Continuous distributions
    gamma             -- Gamma
    gengamma          -- Generalized gamma
    genhalflogistic   -- Generalized Half Logistic
+   gilbrat           -- Gilbrat
    gompertz          -- Gompertz (Truncated Gumbel)
    gumbel_r          -- Right Sided Gumbel, Log-Weibull, Fisher-Tippett, Extreme Value Type I
    gumbel_l          -- Left Sided Gumbel, etc.
@@ -122,7 +123,6 @@ Continuous distributions
    loggamma          -- Log-Gamma
    loglaplace        -- Log-Laplace (Log Double Exponential)
    lognorm           -- Log-Normal
-   gilbrat           -- Gilbrat
    lomax             -- Lomax (Pareto of the second kind)
    maxwell           -- Maxwell
    mielke            -- Mielke's Beta-Kappa


### PR DESCRIPTION
I noticed several scipy.optimize methods which were non-standard had very little or no documentation. I added notes on the algorithms and references. 

Specifically I made the following additions:
*COBYLA is not a very common method and finding a description of the algorithm was not simple. I added a short description and references to the docs. 
*powell's method is also not very common. It mostly seems popular because it's in Numerical Recipes, but there isn't a lot of easy documentation for it online, so I added notes and references.
*truncated Newton and Newton conjugate gradient are two different names for the same algorithm. This made the distinction between fmin_tnc and fmin_ncg unclear, so I added some notes to help explain the difference. 
*Given that fmin is the simplest and most generic optimization algorithm to use, I added a few notes explaining the limitations of the Nelder-Mead simplex algorithm. 
*I added a short explanation and reference for the nnls method. It appears to be a well-known and well-used method, but it's not commonly taught in optimization courses. 
*check_grad had no documentation, so I added some. 

I also fixed two small bugs in the scipy.stats docs (an out of alphabetical order distribution and the scipy.stats uniform examples incorrectly rendering).  
