### PR TITLE
DOCS: Updated scipy.anneal docs

### DIFF
--- a/scipy/optimize/anneal.py
+++ b/scipy/optimize/anneal.py
@@ -202,16 +202,7 @@ def anneal(func, x0, args=(), schedule='fast', full_output=0,
     -------
     xmin : ndarray
         Point giving smallest value found.
-    retval : int
-        Flag indicating stopping condition::
-
-                0 : Cooled to global optimum
-                1 : Cooled to final temperature
-                2 : Maximum function evaluations
-                3 : Maximum cooling iterations reached
-                4 : Maximum accepted query locations reached
-
-    Jmin : float
+    Jmin : float 
         Minimum value of function found.
     T : float
         Final temperature.
@@ -221,7 +212,79 @@ def anneal(func, x0, args=(), schedule='fast', full_output=0,
         Number of cooling iterations.
     accept : int
         Number of tests accepted.
+    retval : int
+        Flag indicating stopping condition::
 
+                0 : Points no longer changing
+                1 : Cooled to final temperature
+                2 : Maximum function evaluations
+                3 : Maximum cooling iterations reached
+                4 : Maximum accepted query locations reached
+                5 : Final point not the minimum amongst encountered points
+
+
+    Notes
+    -----
+    Simulated annealing is a random algorithm which uses no derivative
+    information from the function being optimized. In practice it has 
+    been more useful in discrete optimization than continuous 
+    optimization, as there are usually better algorithms for continuous
+    optimization problems. 
+
+    Some experimentation by trying the difference temperature 
+    schedules and altering their parameters is likely required to
+    obtain good performance. 
+
+    The randomness in the algorithm comes from random sampling in numpy.
+    To obtain the same results you can call numpy.random.seed with the
+    same seed immediately before calling scipy.optimize.anneal. 
+
+    We give a brief description of how the three temperature schedules
+    generate new points and vary their temperature. Temperatures are
+    only updated with iterations in the outer loop. The inner loop is
+    over loop over xrange(dwell), and new points are generated for
+    every iteration in the inner loop. (Though whether the proposed 
+    new points are accepted is probabilistic.) 
+    
+
+    For readability, let d denote the dimension of the inputs to func. 
+    Also, let x_old denote the previous state, and k denote the 
+    iteration number of the outer loop. All other variables not 
+    defined below are input variables to scipy.optimize.anneal itself. 
+
+    In the 'fast' schedule the updates are 
+    
+    ::
+
+        u ~ Uniform(0, 1, size=d)
+        y = sgn(u - 0.5) * T * ((1+ 1/T)**abs(2u-1) -1.0)
+        xc = y * (upper - lower)
+        x_new = x_old + xc
+
+        c = n * exp(-n * quench)
+        T_new = T0 * exp(-c * k**quench)
+
+    
+    In the 'cauchy' schedule the updates are
+
+    ::
+
+        u ~ Uniform(-pi/2, pi/2, size=d)
+        xc = learn_rate * T * tan(u)
+        x_new = x_old + xc
+
+        T_new = T0 / (1+k)
+
+    In the 'boltzmann' schedule the updates are
+   
+    ::
+
+        std = minimum( sqrt(T) * ones(d), (upper-lower) / (3*learn_rate) )
+        y ~ Normal(0, std, size=d)
+        x_new = x_old + learn_rate * y
+
+        T_new = T0 / log(1+k)
+     
     """
     x0 = asarray(x0)
     lower = asarray(lower)
@@ -238,7 +301,7 @@ def anneal(func, x0, args=(), schedule='fast', full_output=0,
         x0 = schedule.getstart_temp(best_state)
     else:
         best_state.x = None
-        best_state.cost = 300e8
+        best_state.cost = numpy.Inf
 
     last_state.x = asarray(x0).copy()
     fval = func(x0,*args)
@@ -251,7 +314,7 @@ def anneal(func, x0, args=(), schedule='fast', full_output=0,
     fqueue = [100, 300, 500, 700]
     iters = 0
     while 1:
-        for n in range(dwell):
+        for n in xrange(dwell):
             current_state.x = schedule.update_guess(last_state.x)
             current_state.cost = func(current_state.x,*args)
             schedule.feval += 1

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -180,7 +180,7 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
          full_output=0, disp=1, retall=0, callback=None):
     """
     Minimize a function using the downhill simplex algorithm. This algorithm
-    only uses function values, not dervatives or second dervatives. 
+    only uses function values. No dervatives or second derivatives are used. 
 
     Parameters
     ----------
@@ -236,9 +236,9 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
     But it will usually be slower than an algorithm that uses first or 
     second derivative information. In practice it can have poor 
     performance in high-dimensional problems and is not robust to 
-    minimizing complicated functions. Additionally, there currently is not
-    a complete theory describing when the algorithm will successfully 
-    find the minimum or the speed of convergence. 
+    minimizing complicated functions. Additionally, there currently is no
+    complete theory describing when the algorithm will successfully 
+    converge to the minimum, or how fast it will if it does.  
 
     References
     ----------
@@ -1562,10 +1562,10 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
     increase amount to checking that 
     
     1. No further gain can be made along the 
-    direction of greatest increase from that iteration
+        direction of greatest increase from that iteration
     2.The direction of greatest increase accounted for a large sufficient
-    fraction of the decrease in the function value from that
-    iteration of the inner loop. 
+        fraction of the decrease in the function value from that
+        iteration of the inner loop. 
     
 
     References

--- a/scipy/optimize/tnc.py
+++ b/scipy/optimize/tnc.py
@@ -191,6 +191,7 @@ def fmin_tnc(func, x0, fprime=None, args=(), approx_grad=0,
     1. It wraps a C implementation of the algorithm
     2. It allows each variable to be given an upper and lower bound.
 
+
     The algorithm incoporates the bound constraints by determining
     the descent direction as in an unconstrained truncated Newton, 
     but never taking a step-size large enough to leave the space


### PR DESCRIPTION
This is a correction and addition to the anneal docs, with a couple of very minor grammar changes in other scipy.optimize docs. 

A question on the scipy-user mailing list earlier this week pointed out the docs' description of return values was out of date. Additionally, the docs contained no information about the different temperature schedules, so that was added. 

And two minor adjustments were made to the code: an iterate over range was changed to an iteration over xrange, and if no initial value was given the starting value was set to np.Inf instead of 300e8.  
