### PR TITLE
ENH: chkfinite flag in scipy.linalg

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -17,7 +17,7 @@ import decomp_svd
 
 # Linear equations
 def solve(a, b, sym_pos=False, lower=False, overwrite_a=False, overwrite_b=False,
-          debug=False):
+          debug=False, chkfinite=True):
     """Solve the equation a x = b for x
 
     Parameters
@@ -33,6 +33,10 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False, overwrite_b=False
         Allow overwriting data in a (may enhance performance)
     overwrite_b : boolean
         Allow overwriting data in b (may enhance performance)
+    chkfinite : boolean
+        If true checks the elements of a,b are finite numbers. If
+        false does no checking and passes through matrices to
+        underlying algorithm.
 
     Returns
     -------
@@ -42,7 +46,10 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False, overwrite_b=False
     Raises LinAlgError if a is singular
 
     """
-    a1, b1 = map(np.asarray_chkfinite,(a,b))
+    if chkfinite:
+        a1, b1 = map(np.asarray_chkfinite,(a,b))
+    else:
+        a1, b1 = map(np.asarray, (a,b))
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
     if a1.shape[0] != b1.shape[0]:
@@ -70,7 +77,7 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False, overwrite_b=False
                                                                     % -info)
 
 def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
-                     overwrite_b=False, debug=False):
+                     overwrite_b=False, debug=False, chkfinite=True):
     """Solve the equation `a x = b` for `x`, assuming a is a triangular matrix.
 
     Parameters
@@ -98,6 +105,11 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
     overwrite_b : boolean
         Allow overwriting data in b (may enhance performance)
 
+    chkfinite : boolean
+        If true checks the elements of a,b are finite numbers. If
+        false does no checking and passes through matrices to
+        underlying algorithm.
+
     Returns
     -------
     x : array, shape (M,) or (M, N) depending on b
@@ -113,7 +125,10 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
     .. versionadded:: 0.9.0
     """
 
-    a1, b1 = map(np.asarray_chkfinite,(a,b))
+    if chkfinite:
+        a1, b1 = map(np.asarray_chkfinite,(a,b))
+    else:
+        a1, b1 = map(np.asarray, (a,b))
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
     if a1.shape[0] != b1.shape[0]:
@@ -133,10 +148,9 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
     raise ValueError('illegal value in %d-th argument of internal trtrs')
 
 def solve_banded((l, u), ab, b, overwrite_ab=False, overwrite_b=False,
-          debug=False):
+                debug=False, chkfinite=True):
     """
     Solve the equation a x = b for x, assuming a is banded matrix.
-
     The matrix a is stored in ab using the matrix diagonal ordered form::
 
         ab[u + i - j, j] == a[i,j]
@@ -160,6 +174,10 @@ def solve_banded((l, u), ab, b, overwrite_ab=False, overwrite_b=False,
         Discard data in ab (may enhance performance)
     overwrite_b : boolean
         Discard data in b (may enhance performance)
+    chkfinite : boolean
+        If true checks the elements of ab, b are finite numbers. If
+        false does no checking and passes through matrices to
+        underlying algorithm.
 
     Returns
     -------
@@ -167,8 +185,11 @@ def solve_banded((l, u), ab, b, overwrite_ab=False, overwrite_b=False,
         The solution to the system a x = b
 
     """
-    a1, b1 = map(np.asarray_chkfinite, (ab, b))
 
+    if chkfinite:
+        a1, b1 = map(np.asarray_chkfinite, (ab, b))
+    else:
+        a1, b1 = map(np.asarray, (ab,b))
     # Validate shapes.
     if a1.shape[-1] != b1.shape[0]:
         raise ValueError("shapes of ab and b are not compatible.")
@@ -189,7 +210,8 @@ def solve_banded((l, u), ab, b, overwrite_ab=False, overwrite_b=False,
         raise LinAlgError("singular matrix")
     raise ValueError('illegal value in %d-th argument of internal gbsv' % -info)
 
-def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False):
+def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False,
+                    chkfinite=True):
     """Solve equation a x = b. a is Hermitian positive-definite banded matrix.
 
     The matrix a is stored in ab either in lower diagonal or upper
@@ -224,6 +246,10 @@ def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False):
         Discard data in b (may enhance performance)
     lower : boolean
         Is the matrix in the lower form. (Default is upper form)
+    chkfinite : boolean
+        If true checks the elements of ab, b are finite numbers. If
+        false does no checking and passes through matrices to
+        underlying algorithm.
 
     Returns
     -------
@@ -232,8 +258,10 @@ def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False):
 
     """
 
-    ab, b = map(np.asarray_chkfinite, (ab, b))
-
+    if chkfinite:
+        ab, b = map(np.asarray_chkfinite, (ab, b))
+    else:
+        ab, b = map(np.asarray, (ab,b))
     # Validate shapes.
     if ab.shape[-1] != b.shape[0]:
         raise ValueError("shapes of ab and b are not compatible.")
@@ -250,7 +278,7 @@ def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False):
 
 
 # matrix inversion
-def inv(a, overwrite_a=False):
+def inv(a, overwrite_a=False, chkfinite=True):
     """
     Compute the inverse of a matrix.
 
@@ -260,6 +288,10 @@ def inv(a, overwrite_a=False):
         Square matrix to be inverted.
     overwrite_a : bool, optional
         Discard data in `a` (may improve performance). Default is False.
+    chkfinite : boolean
+        If true checks the elements of a,b are finite numbers. If
+        false does no checking and passes through matrices to
+        underlying algorithm.
 
     Returns
     -------
@@ -284,7 +316,11 @@ def inv(a, overwrite_a=False):
            [ 0.,  1.]])
 
     """
-    a1 = np.asarray_chkfinite(a)
+
+    if chkfinite:
+        a1 = np.asarray_chkfinite(a)
+    else:
+        a1 = np.asarray(a)
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
     overwrite_a = overwrite_a or _datacopied(a1, a)
@@ -333,12 +369,16 @@ def inv(a, overwrite_a=False):
 
 ### Determinant
 
-def det(a, overwrite_a=False):
+def det(a, overwrite_a=False, chkfinite=True):
     """Compute the determinant of a matrix
 
     Parameters
     ----------
     a : array, shape (M, M)
+    chkfinite : boolean
+        If true checks the elements of a,b are finite numbers. If
+        false does no checking and passes through matrices to
+        underlying algorithm.
 
     Returns
     -------
@@ -349,7 +389,10 @@ def det(a, overwrite_a=False):
     -----
     The determinant is computed via LU factorization, LAPACK routine z/dgetrf.
     """
-    a1 = np.asarray_chkfinite(a)
+    if chkfinite:
+        a1 = np.asarray_chkfinite(a)
+    else:
+        a1 = np.asarray(a)
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
     overwrite_a = overwrite_a or _datacopied(a1, a)
@@ -362,7 +405,8 @@ def det(a, overwrite_a=False):
 
 ### Linear Least Squares
 
-def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False):
+def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
+            chkfinite=True):
     """
     Compute least-squares solution to equation Ax = b.
 
@@ -382,6 +426,10 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False):
         Discard data in `a` (may enhance performance). Default is False.
     overwrite_b : bool, optional
         Discard data in `b` (may enhance performance). Default is False.
+    chkfinite : boolean
+        If true checks the elements of a,b are finite numbers. If
+        false does no checking and passes through matrices to
+        underlying algorithm.
 
     Returns
     -------
@@ -408,7 +456,11 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False):
     optimize.nnls : linear least squares with non-negativity constraint
 
     """
-    a1, b1 = map(np.asarray_chkfinite, (a, b))
+
+    if chkfinite:
+        a1,b1 = map(np.asarray_chkfinite, (a,b))
+    else:
+        a1,b1 = map(np.asarray, (a,b))
     if len(a1.shape) != 2:
         raise ValueError('expected matrix')
     m, n = a1.shape
@@ -441,6 +493,11 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False):
     else:
         raise NotImplementedError('calling gelss from %s' % gelss.module_name)
     if info > 0:
+        print info
+        print v
+        print x
+        print s
+        print rank
         raise LinAlgError("SVD did not converge in Linear Least Squares")
     if info < 0:
         raise ValueError('illegal value in %d-th argument of internal gelss'
@@ -454,7 +511,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False):
     return x, resids, rank, s
 
 
-def pinv(a, cond=None, rcond=None):
+def pinv(a, cond=None, rcond=None, chkfinite=True):
     """Compute the (Moore-Penrose) pseudo-inverse of a matrix.
 
     Calculate a generalized inverse of a matrix using a least-squares
@@ -468,6 +525,10 @@ def pinv(a, cond=None, rcond=None):
         Cutoff for 'small' singular values in the least-squares solver.
         Singular values smaller than rcond*largest_singular_value are
         considered zero.
+    chkfinite : boolean
+        If true checks the elements of a,b are finite numbers. If
+        false does no checking and passes through matrices to
+        underlying algorithm.
 
     Returns
     -------
@@ -486,14 +547,17 @@ def pinv(a, cond=None, rcond=None):
     True
 
     """
-    a = np.asarray_chkfinite(a)
+    if chkfinite:
+        a = np.asarray_chkfinite(a)
+    else:
+        a = np.asarray(a)
     b = np.identity(a.shape[0], dtype=a.dtype)
     if rcond is not None:
         cond = rcond
     return lstsq(a, b, cond=cond)[0]
 
 
-def pinv2(a, cond=None, rcond=None):
+def pinv2(a, cond=None, rcond=None, chkfinite=True):
     """Compute the (Moore-Penrose) pseudo-inverse of a matrix.
 
     Calculate a generalized inverse of a matrix using its
@@ -510,6 +574,10 @@ def pinv2(a, cond=None, rcond=None):
         considered zero.
 
         If None or -1, suitable machine precision is used.
+    chkfinite : boolean
+        If true checks the elements of a,b are finite numbers. If
+        false does no checking and passes through matrices to
+        underlying algorithm.
 
     Returns
     -------
@@ -528,7 +596,10 @@ def pinv2(a, cond=None, rcond=None):
     True
 
     """
-    a = np.asarray_chkfinite(a)
+    if chkfinite:
+        a = np.asarray_chkfinite(a)
+    else:
+        a = np.asarray(a)
     u, s, vh = decomp_svd.svd(a)
     t = u.dtype.char
     if rcond is not None:

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -17,7 +17,7 @@ import decomp_svd
 
 # Linear equations
 def solve(a, b, sym_pos=False, lower=False, overwrite_a=False, overwrite_b=False,
-          debug=False, chkfinite=True):
+          debug=False, check_finite=True):
     """Solve the equation a x = b for x
 
     Parameters
@@ -33,7 +33,7 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False, overwrite_b=False
         Allow overwriting data in a (may enhance performance)
     overwrite_b : boolean
         Allow overwriting data in b (may enhance performance)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a,b are finite numbers. If
         false does no checking and passes through matrices to
         underlying algorithm.
@@ -46,7 +46,7 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False, overwrite_b=False
     Raises LinAlgError if a is singular
 
     """
-    if chkfinite:
+    if check_finite:
         a1, b1 = map(np.asarray_chkfinite,(a,b))
     else:
         a1, b1 = map(np.asarray, (a,b))
@@ -77,7 +77,7 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False, overwrite_b=False
                                                                     % -info)
 
 def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
-                     overwrite_b=False, debug=False, chkfinite=True):
+                     overwrite_b=False, debug=False, check_finite=True):
     """Solve the equation `a x = b` for `x`, assuming a is a triangular matrix.
 
     Parameters
@@ -105,7 +105,7 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
     overwrite_b : boolean
         Allow overwriting data in b (may enhance performance)
 
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a,b are finite numbers. If
         false does no checking and passes through matrices to
         underlying algorithm.
@@ -125,7 +125,7 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
     .. versionadded:: 0.9.0
     """
 
-    if chkfinite:
+    if check_finite:
         a1, b1 = map(np.asarray_chkfinite,(a,b))
     else:
         a1, b1 = map(np.asarray, (a,b))
@@ -148,7 +148,7 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
     raise ValueError('illegal value in %d-th argument of internal trtrs')
 
 def solve_banded((l, u), ab, b, overwrite_ab=False, overwrite_b=False,
-                debug=False, chkfinite=True):
+                debug=False, check_finite=True):
     """
     Solve the equation a x = b for x, assuming a is banded matrix.
     The matrix a is stored in ab using the matrix diagonal ordered form::
@@ -174,7 +174,7 @@ def solve_banded((l, u), ab, b, overwrite_ab=False, overwrite_b=False,
         Discard data in ab (may enhance performance)
     overwrite_b : boolean
         Discard data in b (may enhance performance)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of ab, b are finite numbers. If
         false does no checking and passes through matrices to
         underlying algorithm.
@@ -186,7 +186,7 @@ def solve_banded((l, u), ab, b, overwrite_ab=False, overwrite_b=False,
 
     """
 
-    if chkfinite:
+    if check_finite:
         a1, b1 = map(np.asarray_chkfinite, (ab, b))
     else:
         a1, b1 = map(np.asarray, (ab,b))
@@ -211,7 +211,7 @@ def solve_banded((l, u), ab, b, overwrite_ab=False, overwrite_b=False,
     raise ValueError('illegal value in %d-th argument of internal gbsv' % -info)
 
 def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False,
-                    chkfinite=True):
+                    check_finite=True):
     """Solve equation a x = b. a is Hermitian positive-definite banded matrix.
 
     The matrix a is stored in ab either in lower diagonal or upper
@@ -246,7 +246,7 @@ def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False,
         Discard data in b (may enhance performance)
     lower : boolean
         Is the matrix in the lower form. (Default is upper form)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of ab, b are finite numbers. If
         false does no checking and passes through matrices to
         underlying algorithm.
@@ -258,7 +258,7 @@ def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False,
 
     """
 
-    if chkfinite:
+    if check_finite:
         ab, b = map(np.asarray_chkfinite, (ab, b))
     else:
         ab, b = map(np.asarray, (ab,b))
@@ -278,7 +278,7 @@ def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False,
 
 
 # matrix inversion
-def inv(a, overwrite_a=False, chkfinite=True):
+def inv(a, overwrite_a=False, check_finite=True):
     """
     Compute the inverse of a matrix.
 
@@ -288,7 +288,7 @@ def inv(a, overwrite_a=False, chkfinite=True):
         Square matrix to be inverted.
     overwrite_a : bool, optional
         Discard data in `a` (may improve performance). Default is False.
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a are finite numbers. If
         false does no checking and passes matrix through to
         underlying algorithm.
@@ -317,7 +317,7 @@ def inv(a, overwrite_a=False, chkfinite=True):
 
     """
 
-    if chkfinite:
+    if check_finite:
         a1 = np.asarray_chkfinite(a)
     else:
         a1 = np.asarray(a)
@@ -369,13 +369,13 @@ def inv(a, overwrite_a=False, chkfinite=True):
 
 ### Determinant
 
-def det(a, overwrite_a=False, chkfinite=True):
+def det(a, overwrite_a=False, check_finite=True):
     """Compute the determinant of a matrix
 
     Parameters
     ----------
     a : array, shape (M, M)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a are finite numbers. If
         false does no checking and passes matrix through to
         underlying algorithm.
@@ -389,7 +389,7 @@ def det(a, overwrite_a=False, chkfinite=True):
     -----
     The determinant is computed via LU factorization, LAPACK routine z/dgetrf.
     """
-    if chkfinite:
+    if check_finite:
         a1 = np.asarray_chkfinite(a)
     else:
         a1 = np.asarray(a)
@@ -406,7 +406,7 @@ def det(a, overwrite_a=False, chkfinite=True):
 ### Linear Least Squares
 
 def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
-            chkfinite=True):
+            check_finite=True):
     """
     Compute least-squares solution to equation Ax = b.
 
@@ -426,7 +426,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
         Discard data in `a` (may enhance performance). Default is False.
     overwrite_b : bool, optional
         Discard data in `b` (may enhance performance). Default is False.
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a,b are finite numbers. If
         false does no checking and passes through matrices to
         underlying algorithm.
@@ -457,7 +457,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
 
     """
 
-    if chkfinite:
+    if check_finite:
         a1,b1 = map(np.asarray_chkfinite, (a,b))
     else:
         a1,b1 = map(np.asarray, (a,b))
@@ -511,7 +511,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     return x, resids, rank, s
 
 
-def pinv(a, cond=None, rcond=None, chkfinite=True):
+def pinv(a, cond=None, rcond=None, check_finite=True):
     """Compute the (Moore-Penrose) pseudo-inverse of a matrix.
 
     Calculate a generalized inverse of a matrix using a least-squares
@@ -525,7 +525,7 @@ def pinv(a, cond=None, rcond=None, chkfinite=True):
         Cutoff for 'small' singular values in the least-squares solver.
         Singular values smaller than rcond*largest_singular_value are
         considered zero.
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a are finite numbers. If
         false does no checking and passes matrix through to
         underlying algorithm.
@@ -547,7 +547,7 @@ def pinv(a, cond=None, rcond=None, chkfinite=True):
     True
 
     """
-    if chkfinite:
+    if check_finite:
         a = np.asarray_chkfinite(a)
     else:
         a = np.asarray(a)
@@ -557,7 +557,7 @@ def pinv(a, cond=None, rcond=None, chkfinite=True):
     return lstsq(a, b, cond=cond)[0]
 
 
-def pinv2(a, cond=None, rcond=None, chkfinite=True):
+def pinv2(a, cond=None, rcond=None, check_finite=True):
     """Compute the (Moore-Penrose) pseudo-inverse of a matrix.
 
     Calculate a generalized inverse of a matrix using its
@@ -574,7 +574,7 @@ def pinv2(a, cond=None, rcond=None, chkfinite=True):
         considered zero.
 
         If None or -1, suitable machine precision is used.
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a are finite numbers. If
         false does no checking and passes matrix through to
         underlying algorithm.
@@ -596,7 +596,7 @@ def pinv2(a, cond=None, rcond=None, chkfinite=True):
     True
 
     """
-    if chkfinite:
+    if check_finite:
         a = np.asarray_chkfinite(a)
     else:
         a = np.asarray(a)

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -289,8 +289,8 @@ def inv(a, overwrite_a=False, chkfinite=True):
     overwrite_a : bool, optional
         Discard data in `a` (may improve performance). Default is False.
     chkfinite : boolean
-        If true checks the elements of a,b are finite numbers. If
-        false does no checking and passes through matrices to
+        If true checks the elements of a are finite numbers. If
+        false does no checking and passes matrix through to
         underlying algorithm.
 
     Returns
@@ -376,8 +376,8 @@ def det(a, overwrite_a=False, chkfinite=True):
     ----------
     a : array, shape (M, M)
     chkfinite : boolean
-        If true checks the elements of a,b are finite numbers. If
-        false does no checking and passes through matrices to
+        If true checks the elements of a are finite numbers. If
+        false does no checking and passes matrix through to
         underlying algorithm.
 
     Returns
@@ -526,8 +526,8 @@ def pinv(a, cond=None, rcond=None, chkfinite=True):
         Singular values smaller than rcond*largest_singular_value are
         considered zero.
     chkfinite : boolean
-        If true checks the elements of a,b are finite numbers. If
-        false does no checking and passes through matrices to
+        If true checks the elements of a are finite numbers. If
+        false does no checking and passes matrix through to
         underlying algorithm.
 
     Returns
@@ -575,8 +575,8 @@ def pinv2(a, cond=None, rcond=None, chkfinite=True):
 
         If None or -1, suitable machine precision is used.
     chkfinite : boolean
-        If true checks the elements of a,b are finite numbers. If
-        false does no checking and passes through matrices to
+        If true checks the elements of a are finite numbers. If
+        false does no checking and passes matrix through to
         underlying algorithm.
 
     Returns

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -78,7 +78,8 @@ def _geneig(a1, b1, left, right, overwrite_a, overwrite_b):
         return w, vl
     return w, vr
 
-def eig(a, b=None, left=False, right=True, overwrite_a=False, overwrite_b=False):
+def eig(a, b=None, left=False, right=True, overwrite_a=False,
+            overwrite_b=False, chkfinite=True):
     """Solve an ordinary or generalized eigenvalue problem of a square matrix.
 
     Find eigenvalues w and right or left eigenvectors of a general matrix::
@@ -105,6 +106,10 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False, overwrite_b=False)
         Whether to overwrite data in a (may improve performance)
     overwrite_b : boolean
         Whether to overwrite data in b (may improve performance)
+    chkfinite : boolean
+        If true checks the elements of a,b are finite numbers. If
+        false does no checking and passes matrices through to
+        underlying algorithm.
 
     Returns
     -------
@@ -128,13 +133,19 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False, overwrite_b=False)
     eigh : eigenvalues and right eigenvectors for symmetric/Hermitian arrays
 
     """
-    a1 = asarray_chkfinite(a)
+    if chkfinite:
+        a1 = asarray_chkfinite(a)
+    else:
+        a1 = asarray(a)
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
     overwrite_a = overwrite_a or (_datacopied(a1, a))
     if b is not None:
-        b1 = asarray_chkfinite(b)
-        overwrite_b = overwrite_b or _datacopied(b1, b)
+        if chkfinite:
+            b1 = asarray_chkfinite(b)
+        else:
+            b1 = asarray(b)
+       overwrite_b = overwrite_b or _datacopied(b1, b)
         if len(b1.shape) != 2 or b1.shape[0] != b1.shape[1]:
             raise ValueError('expected square matrix')
         if b1.shape != a1.shape:
@@ -193,7 +204,8 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False, overwrite_b=False)
     return w, vr
 
 def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
-         overwrite_b=False, turbo=True, eigvals=None, type=1):
+         overwrite_b=False, turbo=True, eigvals=None, type=1,
+         chkfinite=True):
     """Solve an ordinary or generalized eigenvalue problem for a complex
     Hermitian or real symmetric matrix.
 
@@ -235,6 +247,10 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
         Whether to overwrite data in a (may improve performance)
     overwrite_b : boolean
         Whether to overwrite data in b (may improve performance)
+    chkfinite : boolean
+        If true checks the elements of a,b are finite numbers. If
+        false does no checking and passes matrices through to
+        underlying algorithm.
 
     Returns
     -------
@@ -261,7 +277,10 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     eig : eigenvalues and right eigenvectors for non-symmetric arrays
 
     """
-    a1 = asarray_chkfinite(a)
+    if chkfinite:
+        a1 = asarray_chkfinite(a)
+    else:
+        a1 = asarray(a)
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
     overwrite_a = overwrite_a or (_datacopied(a1, a))
@@ -270,7 +289,10 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     else:
         cplx = False
     if b is not None:
-        b1 = asarray_chkfinite(b)
+        if chkfinite:
+            b1 = asarray_chkfinite(b)
+        else:
+            b1 = asarray(b)
         overwrite_b = overwrite_b or _datacopied(b1, b)
         if len(b1.shape) != 2 or b1.shape[0] != b1.shape[1]:
             raise ValueError('expected square matrix')
@@ -382,7 +404,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
                           " computed." % (info-b1.shape[0]))
 
 def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
-               select='a', select_range=None, max_ev = 0):
+               select='a', select_range=None, max_ev = 0, chkfinite=True):
     """Solve real symmetric or complex hermitian band matrix eigenvalue problem.
 
     Find eigenvalues w and optionally right eigenvectors v of a::
@@ -441,6 +463,11 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
 
         In doubt, leave this parameter untouched.
 
+    chkfinite : boolean
+        If true checks the elements of a_band are finite numbers. If
+        false does no checking and passes matrix through to
+        underlying algorithm.
+
     Returns
     -------
     w : array, shape (M,)
@@ -455,7 +482,10 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
 
     """
     if eigvals_only or overwrite_a_band:
-        a1 = asarray_chkfinite(a_band)
+        if chkfinite:
+            a1 = asarray_chkfinite(a_band)
+        else:
+            a1 = asarray(a_band)
         overwrite_a_band = overwrite_a_band or (_datacopied(a1, a_band))
     else:
         a1 = array(a_band)
@@ -533,7 +563,7 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
         return w
     return w, v
 
-def eigvals(a, b=None, overwrite_a=False):
+def eigvals(a, b=None, overwrite_a=False, chkfinite=True):
     """Compute eigenvalues from an ordinary or generalized eigenvalue problem.
 
     Find eigenvalues of a general matrix::
@@ -550,6 +580,10 @@ def eigvals(a, b=None, overwrite_a=False):
         If omitted, identity matrix is assumed.
     overwrite_a : boolean
         Whether to overwrite data in a (may improve performance)
+    chkfinite : boolean
+        If true checks the elements of a,b are finite numbers. If
+        false does no checking and passes matrices through to
+        underlying algorithm.
 
     Returns
     -------
@@ -566,10 +600,12 @@ def eigvals(a, b=None, overwrite_a=False):
     eigh : eigenvalues and eigenvectors of symmetric/Hermitean arrays.
 
     """
-    return eig(a, b=b, left=0, right=0, overwrite_a=overwrite_a)
+    return eig(a, b=b, left=0, right=0, overwrite_a=overwrite_a,
+                chkfinite=True)
 
 def eigvalsh(a, b=None, lower=True, overwrite_a=False,
-             overwrite_b=False, turbo=True, eigvals=None, type=1):
+             overwrite_b=False, turbo=True, eigvals=None, type=1,
+             chkfinite=True):
     """Solve an ordinary or generalized eigenvalue problem for a complex
     Hermitian or real symmetric matrix.
 
@@ -607,6 +643,10 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
         Whether to overwrite data in a (may improve performance)
     overwrite_b : boolean
         Whether to overwrite data in b (may improve performance)
+    chkfinite : boolean
+        If true checks the elements of a,b are finite numbers. If
+        false does no checking and passes matrices through to
+        underlying algorithm.
 
     Returns
     -------
@@ -628,10 +668,10 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
     """
     return eigh(a, b=b, lower=lower, eigvals_only=True,
                 overwrite_a=overwrite_a, overwrite_b=overwrite_b,
-                turbo=turbo, eigvals=eigvals, type=type)
+                turbo=turbo, eigvals=eigvals, type=type, chkfinite=chkfinite)
 
 def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
-                   select='a', select_range=None):
+                   select='a', select_range=None, chkfinite=True):
     """Solve real symmetric or complex hermitian band matrix eigenvalue problem.
 
     Find eigenvalues w of a::
@@ -681,6 +721,10 @@ def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
         ======  ========================================
     select_range : (min, max)
         Range of selected eigenvalues
+    chkfinite : boolean
+        If true checks the elements of a_band are finite numbers. If
+        false does no checking and passes matrix through to
+        underlying algorithm.
 
     Returns
     -------
@@ -700,12 +744,12 @@ def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
     """
     return eig_banded(a_band, lower=lower, eigvals_only=1,
                       overwrite_a_band=overwrite_a_band, select=select,
-                      select_range=select_range)
+                      select_range=select_range, chkfinite=chkfinite)
 
 _double_precision = ['i','l','d']
 
 
-def hessenberg(a, calc_q=False, overwrite_a=False):
+def hessenberg(a, calc_q=False, overwrite_a=False, chkfinite=True):
     """Compute Hessenberg form of a matrix.
 
     The Hessenberg decomposition is
@@ -723,6 +767,10 @@ def hessenberg(a, calc_q=False, overwrite_a=False):
         Whether to compute the transformation matrix
     overwrite_a : boolean
         Whether to ovewrite data in a (may improve performance)
+    chkfinite : boolean
+        If true checks the elements of a are finite numbers. If
+        false does no checking and passes matrix through to
+        underlying algorithm.
 
     Returns
     -------
@@ -734,7 +782,10 @@ def hessenberg(a, calc_q=False, overwrite_a=False):
         Unitary/orthogonal similarity transformation matrix s.t. A = Q H Q^H
 
     """
-    a1 = asarray(a)
+    if chkfinite:
+        a1 = asarray_chkfinite(a)
+    else:
+        a1 = asarray(a)
     if len(a1.shape) != 2 or (a1.shape[0] != a1.shape[1]):
         raise ValueError('expected square matrix')
     overwrite_a = overwrite_a or (_datacopied(a1, a))

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -79,7 +79,7 @@ def _geneig(a1, b1, left, right, overwrite_a, overwrite_b):
     return w, vr
 
 def eig(a, b=None, left=False, right=True, overwrite_a=False,
-            overwrite_b=False, chkfinite=True):
+            overwrite_b=False, check_finite=True):
     """Solve an ordinary or generalized eigenvalue problem of a square matrix.
 
     Find eigenvalues w and right or left eigenvectors of a general matrix::
@@ -106,7 +106,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
         Whether to overwrite data in a (may improve performance)
     overwrite_b : boolean
         Whether to overwrite data in b (may improve performance)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a,b are finite numbers. If
         false does no checking and passes matrices through to
         underlying algorithm.
@@ -133,7 +133,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     eigh : eigenvalues and right eigenvectors for symmetric/Hermitian arrays
 
     """
-    if chkfinite:
+    if check_finite:
         a1 = asarray_chkfinite(a)
     else:
         a1 = asarray(a)
@@ -141,11 +141,11 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
         raise ValueError('expected square matrix')
     overwrite_a = overwrite_a or (_datacopied(a1, a))
     if b is not None:
-        if chkfinite:
+        if check_finite:
             b1 = asarray_chkfinite(b)
         else:
             b1 = asarray(b)
-       overwrite_b = overwrite_b or _datacopied(b1, b)
+        overwrite_b = overwrite_b or _datacopied(b1, b)
         if len(b1.shape) != 2 or b1.shape[0] != b1.shape[1]:
             raise ValueError('expected square matrix')
         if b1.shape != a1.shape:
@@ -205,7 +205,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
 
 def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
          overwrite_b=False, turbo=True, eigvals=None, type=1,
-         chkfinite=True):
+         check_finite=True):
     """Solve an ordinary or generalized eigenvalue problem for a complex
     Hermitian or real symmetric matrix.
 
@@ -247,7 +247,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
         Whether to overwrite data in a (may improve performance)
     overwrite_b : boolean
         Whether to overwrite data in b (may improve performance)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a,b are finite numbers. If
         false does no checking and passes matrices through to
         underlying algorithm.
@@ -277,7 +277,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     eig : eigenvalues and right eigenvectors for non-symmetric arrays
 
     """
-    if chkfinite:
+    if check_finite:
         a1 = asarray_chkfinite(a)
     else:
         a1 = asarray(a)
@@ -289,7 +289,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
     else:
         cplx = False
     if b is not None:
-        if chkfinite:
+        if check_finite:
             b1 = asarray_chkfinite(b)
         else:
             b1 = asarray(b)
@@ -404,7 +404,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
                           " computed." % (info-b1.shape[0]))
 
 def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
-               select='a', select_range=None, max_ev = 0, chkfinite=True):
+               select='a', select_range=None, max_ev = 0, check_finite=True):
     """Solve real symmetric or complex hermitian band matrix eigenvalue problem.
 
     Find eigenvalues w and optionally right eigenvectors v of a::
@@ -463,7 +463,7 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
 
         In doubt, leave this parameter untouched.
 
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a_band are finite numbers. If
         false does no checking and passes matrix through to
         underlying algorithm.
@@ -482,7 +482,7 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
 
     """
     if eigvals_only or overwrite_a_band:
-        if chkfinite:
+        if check_finite:
             a1 = asarray_chkfinite(a_band)
         else:
             a1 = asarray(a_band)
@@ -563,7 +563,7 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
         return w
     return w, v
 
-def eigvals(a, b=None, overwrite_a=False, chkfinite=True):
+def eigvals(a, b=None, overwrite_a=False, check_finite=True):
     """Compute eigenvalues from an ordinary or generalized eigenvalue problem.
 
     Find eigenvalues of a general matrix::
@@ -580,7 +580,7 @@ def eigvals(a, b=None, overwrite_a=False, chkfinite=True):
         If omitted, identity matrix is assumed.
     overwrite_a : boolean
         Whether to overwrite data in a (may improve performance)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a,b are finite numbers. If
         false does no checking and passes matrices through to
         underlying algorithm.
@@ -601,11 +601,11 @@ def eigvals(a, b=None, overwrite_a=False, chkfinite=True):
 
     """
     return eig(a, b=b, left=0, right=0, overwrite_a=overwrite_a,
-                chkfinite=True)
+                check_finite=check_finite)
 
 def eigvalsh(a, b=None, lower=True, overwrite_a=False,
              overwrite_b=False, turbo=True, eigvals=None, type=1,
-             chkfinite=True):
+             check_finite=True):
     """Solve an ordinary or generalized eigenvalue problem for a complex
     Hermitian or real symmetric matrix.
 
@@ -643,7 +643,7 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
         Whether to overwrite data in a (may improve performance)
     overwrite_b : boolean
         Whether to overwrite data in b (may improve performance)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a,b are finite numbers. If
         false does no checking and passes matrices through to
         underlying algorithm.
@@ -668,10 +668,11 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
     """
     return eigh(a, b=b, lower=lower, eigvals_only=True,
                 overwrite_a=overwrite_a, overwrite_b=overwrite_b,
-                turbo=turbo, eigvals=eigvals, type=type, chkfinite=chkfinite)
+                turbo=turbo, eigvals=eigvals, type=type,
+                check_finite=check_finite)
 
 def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
-                   select='a', select_range=None, chkfinite=True):
+                   select='a', select_range=None, check_finite=True):
     """Solve real symmetric or complex hermitian band matrix eigenvalue problem.
 
     Find eigenvalues w of a::
@@ -721,7 +722,7 @@ def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
         ======  ========================================
     select_range : (min, max)
         Range of selected eigenvalues
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a_band are finite numbers. If
         false does no checking and passes matrix through to
         underlying algorithm.
@@ -744,12 +745,12 @@ def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
     """
     return eig_banded(a_band, lower=lower, eigvals_only=1,
                       overwrite_a_band=overwrite_a_band, select=select,
-                      select_range=select_range, chkfinite=chkfinite)
+                      select_range=select_range, check_finite=check_finite)
 
 _double_precision = ['i','l','d']
 
 
-def hessenberg(a, calc_q=False, overwrite_a=False, chkfinite=True):
+def hessenberg(a, calc_q=False, overwrite_a=False, check_finite=True):
     """Compute Hessenberg form of a matrix.
 
     The Hessenberg decomposition is
@@ -767,7 +768,7 @@ def hessenberg(a, calc_q=False, overwrite_a=False, chkfinite=True):
         Whether to compute the transformation matrix
     overwrite_a : boolean
         Whether to ovewrite data in a (may improve performance)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a are finite numbers. If
         false does no checking and passes matrix through to
         underlying algorithm.
@@ -782,7 +783,7 @@ def hessenberg(a, calc_q=False, overwrite_a=False, chkfinite=True):
         Unitary/orthogonal similarity transformation matrix s.t. A = Q H Q^H
 
     """
-    if chkfinite:
+    if check_finite:
         a1 = asarray_chkfinite(a)
     else:
         a1 = asarray(a)

--- a/scipy/linalg/decomp_cholesky.py
+++ b/scipy/linalg/decomp_cholesky.py
@@ -10,10 +10,14 @@ __all__ = ['cholesky', 'cho_factor', 'cho_solve', 'cholesky_banded',
             'cho_solve_banded']
 
 
-def _cholesky(a, lower=False, overwrite_a=False, clean=True, chkfinite=True):
+def _cholesky(a, lower=False, overwrite_a=False, clean=True,
+                check_finite=True):
     """Common code for cholesky() and cho_factor()."""
 
-    a1 = asarray_chkfinite(a)
+    if check_finite:
+        a1 = asarray_chkfinite(a)
+    else:
+        a1 = asarray(a)
     if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
         raise ValueError('expected square matrix')
 
@@ -27,7 +31,7 @@ def _cholesky(a, lower=False, overwrite_a=False, clean=True, chkfinite=True):
                                                                     % -info)
     return c, lower
 
-def cholesky(a, lower=False, overwrite_a=False, chkfinite=True):
+def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
     """Compute the Cholesky decomposition of a matrix.
 
     Returns the Cholesky decomposition, :lm:`A = L L^*` or :lm:`A = U^* U`
@@ -42,9 +46,9 @@ def cholesky(a, lower=False, overwrite_a=False, chkfinite=True):
         (Default: upper-triangular)
     overwrite_a : boolean
         Whether to overwrite data in a (may improve performance)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a are finite numbers. If
-        false does no checking and passes matrix through to 
+        false does no checking and passes matrix through to
         underlying algorithm.
 
     Returns
@@ -68,11 +72,11 @@ def cholesky(a, lower=False, overwrite_a=False, chkfinite=True):
 
     """
     c, lower = _cholesky(a, lower=lower, overwrite_a=overwrite_a, clean=True,
-                            chkfinite=chkfinite)
+                            check_finite=check_finite)
     return c
 
 
-def cho_factor(a, lower=False, overwrite_a=False, chkfinite=True):
+def cho_factor(a, lower=False, overwrite_a=False, check_finite=True):
     """Compute the Cholesky decomposition of a matrix, to use in cho_solve
 
     Returns a matrix containing the Cholesky decomposition,
@@ -93,9 +97,9 @@ def cho_factor(a, lower=False, overwrite_a=False, chkfinite=True):
         (Default: upper-triangular)
     overwrite_a : boolean
         Whether to overwrite data in a (may improve performance)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a are finite numbers. If
-        false does no checking and passes matrix through to 
+        false does no checking and passes matrix through to
         underlying algorithm.
 
     Returns
@@ -118,11 +122,11 @@ def cho_factor(a, lower=False, overwrite_a=False, chkfinite=True):
 
     """
     c, lower = _cholesky(a, lower=lower, overwrite_a=overwrite_a, clean=False,
-                            chkfinite=chkfinite)
+                            check_finite=check_finite)
     return c, lower
 
 
-def cho_solve((c, lower), b, overwrite_b=False, chkfinite=True):
+def cho_solve((c, lower), b, overwrite_b=False, check_finite=True):
     """Solve the linear equations A x = b, given the Cholesky factorization of A.
 
     Parameters
@@ -130,10 +134,10 @@ def cho_solve((c, lower), b, overwrite_b=False, chkfinite=True):
     (c, lower) : tuple, (array, bool)
         Cholesky factorization of a, as given by cho_factor
     b : array
-        Right-hand side    
-    chkfinite : boolean
+        Right-hand side
+    check_finite : boolean
         If true checks the elements of c,b are finite numbers. If
-        false does no checking and passes matrices through to 
+        false does no checking and passes matrices through to
         underlying algorithm.
 
     Returns
@@ -146,8 +150,8 @@ def cho_solve((c, lower), b, overwrite_b=False, chkfinite=True):
     cho_factor : Cholesky factorization of a matrix
 
     """
-    
-    if chkfinite:
+
+    if check_finite:
         b1 = asarray_chkfinite(b)
         c = asarray_chkfinite(c)
     else:
@@ -167,7 +171,7 @@ def cho_solve((c, lower), b, overwrite_b=False, chkfinite=True):
                                                                     % -info)
     return x
 
-def cholesky_banded(ab, overwrite_ab=False, lower=False, chkfinite=True):
+def cholesky_banded(ab, overwrite_ab=False, lower=False, check_finite=True):
     """Cholesky decompose a banded Hermitian positive-definite matrix
 
     The matrix a is stored in ab either in lower diagonal or upper
@@ -196,9 +200,9 @@ def cholesky_banded(ab, overwrite_ab=False, lower=False, chkfinite=True):
         Discard data in ab (may enhance performance)
     lower : boolean
         Is the matrix in the lower form. (Default is upper form)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of ab are finite numbers. If
-        false does no checking and passes matrix through to 
+        false does no checking and passes matrix through to
         underlying algorithm.
 
     Returns
@@ -207,7 +211,7 @@ def cholesky_banded(ab, overwrite_ab=False, lower=False, chkfinite=True):
         Cholesky factorization of a, in the same banded format as ab
 
     """
-    if chkfinite:
+    if check_finite:
         ab = asarray_chkfinite(ab)
     else:
         ab = asarray(ab)
@@ -222,7 +226,7 @@ def cholesky_banded(ab, overwrite_ab=False, lower=False, chkfinite=True):
     return c
 
 
-def cho_solve_banded((cb, lower), b, overwrite_b=False, chkfinite=True):
+def cho_solve_banded((cb, lower), b, overwrite_b=False, check_finite=True):
     """Solve the linear equations A x = b, given the Cholesky factorization of A.
 
     Parameters
@@ -234,9 +238,9 @@ def cho_solve_banded((cb, lower), b, overwrite_b=False, chkfinite=True):
         Right-hand side
     overwrite_b : bool
         If True, the function will overwrite the values in `b`.
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of cb, b are finite numbers. If
-        false does no checking and passes matrices through to 
+        false does no checking and passes matrices through to
         underlying algorithm.
 
     Returns
@@ -255,7 +259,7 @@ def cho_solve_banded((cb, lower), b, overwrite_b=False, chkfinite=True):
 
     """
 
-    if chkfinite:
+    if check_finite:
         cb = asarray_chkfinite(cb)
         b = asarray_chkfinite(b)
     else:

--- a/scipy/linalg/decomp_lu.py
+++ b/scipy/linalg/decomp_lu.py
@@ -12,7 +12,7 @@ from flinalg import get_flinalg_funcs
 __all__ = ['lu', 'lu_solve', 'lu_factor']
 
 
-def lu_factor(a, overwrite_a=False, chkfinite=True):
+def lu_factor(a, overwrite_a=False, check_finite=True):
     """Compute pivoted LU decomposition of a matrix.
 
     The decomposition is::
@@ -28,9 +28,9 @@ def lu_factor(a, overwrite_a=False, chkfinite=True):
         Matrix to decompose
     overwrite_a : boolean
         Whether to overwrite data in A (may increase performance)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a are finite numbers. If
-        false does no checking and passes matrix through to 
+        false does no checking and passes matrix through to
         underlying algorithm.
 
     Returns
@@ -51,7 +51,7 @@ def lu_factor(a, overwrite_a=False, chkfinite=True):
     This is a wrapper to the *GETRF routines from LAPACK.
 
     """
-    if chkfinite:
+    if check_finite:
         a1 = asarray(a)
     else:
         a1 = asarray_chkfinite(a)
@@ -69,7 +69,7 @@ def lu_factor(a, overwrite_a=False, chkfinite=True):
     return lu, piv
 
 
-def lu_solve((lu, piv), b, trans=0, overwrite_b=False, chkfinite=True):
+def lu_solve((lu, piv), b, trans=0, overwrite_b=False, check_finite=True):
     """Solve an equation system, a x = b, given the LU factorization of a
 
     Parameters
@@ -88,9 +88,9 @@ def lu_solve((lu, piv), b, trans=0, overwrite_b=False, chkfinite=True):
         1      a^T x = b
         2      a^H x = b
         =====  =========
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of b are finite numbers. If
-        false does no checking and passes matrix through to 
+        false does no checking and passes matrix through to
         underlying algorithm.
 
     Returns
@@ -103,7 +103,7 @@ def lu_solve((lu, piv), b, trans=0, overwrite_b=False, chkfinite=True):
     lu_factor : LU factorize a matrix
 
     """
-    if chkfinite:
+    if check_finite:
         b1 = asarray_chkfinite(b)
     else:
         b1 = asarray(b)
@@ -119,7 +119,7 @@ def lu_solve((lu, piv), b, trans=0, overwrite_b=False, chkfinite=True):
                                                                     % -info)
 
 
-def lu(a, permute_l=False, overwrite_a=False, chkfinite=True):
+def lu(a, permute_l=False, overwrite_a=False, check_finite=True):
     """Compute pivoted LU decompostion of a matrix.
 
     The decomposition is::
@@ -137,9 +137,9 @@ def lu(a, permute_l=False, overwrite_a=False, chkfinite=True):
         Perform the multiplication P*L  (Default: do not permute)
     overwrite_a : boolean
         Whether to overwrite data in a (may improve performance)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a are finite numbers. If
-        false does no checking and passes matrix through to 
+        false does no checking and passes matrix through to
         underlying algorithm.
 
     Returns
@@ -165,7 +165,7 @@ def lu(a, permute_l=False, overwrite_a=False, chkfinite=True):
     This is a LU factorization routine written for Scipy.
 
     """
-    if chkfinite:
+    if check_finite:
         a1 = asarray_chkfinite(a)
     else:
         a1 = asarray(a)

--- a/scipy/linalg/decomp_lu.py
+++ b/scipy/linalg/decomp_lu.py
@@ -12,7 +12,7 @@ from flinalg import get_flinalg_funcs
 __all__ = ['lu', 'lu_solve', 'lu_factor']
 
 
-def lu_factor(a, overwrite_a=False):
+def lu_factor(a, overwrite_a=False, chkfinite=True):
     """Compute pivoted LU decomposition of a matrix.
 
     The decomposition is::
@@ -28,6 +28,10 @@ def lu_factor(a, overwrite_a=False):
         Matrix to decompose
     overwrite_a : boolean
         Whether to overwrite data in A (may increase performance)
+    chkfinite : boolean
+        If true checks the elements of a are finite numbers. If
+        false does no checking and passes matrix through to 
+        underlying algorithm.
 
     Returns
     -------
@@ -47,7 +51,10 @@ def lu_factor(a, overwrite_a=False):
     This is a wrapper to the *GETRF routines from LAPACK.
 
     """
-    a1 = asarray(a)
+    if chkfinite:
+        a1 = asarray(a)
+    else:
+        a1 = asarray_chkfinite(a)
     if len(a1.shape) != 2 or (a1.shape[0] != a1.shape[1]):
         raise ValueError('expected square matrix')
     overwrite_a = overwrite_a or (_datacopied(a1, a))
@@ -62,7 +69,7 @@ def lu_factor(a, overwrite_a=False):
     return lu, piv
 
 
-def lu_solve((lu, piv), b, trans=0, overwrite_b=False):
+def lu_solve((lu, piv), b, trans=0, overwrite_b=False, chkfinite=True):
     """Solve an equation system, a x = b, given the LU factorization of a
 
     Parameters
@@ -81,6 +88,10 @@ def lu_solve((lu, piv), b, trans=0, overwrite_b=False):
         1      a^T x = b
         2      a^H x = b
         =====  =========
+    chkfinite : boolean
+        If true checks the elements of b are finite numbers. If
+        false does no checking and passes matrix through to 
+        underlying algorithm.
 
     Returns
     -------
@@ -92,7 +103,10 @@ def lu_solve((lu, piv), b, trans=0, overwrite_b=False):
     lu_factor : LU factorize a matrix
 
     """
-    b1 = asarray_chkfinite(b)
+    if chkfinite:
+        b1 = asarray_chkfinite(b)
+    else:
+        b1 = asarray(b)
     overwrite_b = overwrite_b or _datacopied(b1, b)
     if lu.shape[0] != b1.shape[0]:
         raise ValueError("incompatible dimensions.")
@@ -105,7 +119,7 @@ def lu_solve((lu, piv), b, trans=0, overwrite_b=False):
                                                                     % -info)
 
 
-def lu(a, permute_l=False, overwrite_a=False):
+def lu(a, permute_l=False, overwrite_a=False, chkfinite=True):
     """Compute pivoted LU decompostion of a matrix.
 
     The decomposition is::
@@ -123,6 +137,10 @@ def lu(a, permute_l=False, overwrite_a=False):
         Perform the multiplication P*L  (Default: do not permute)
     overwrite_a : boolean
         Whether to overwrite data in a (may improve performance)
+    chkfinite : boolean
+        If true checks the elements of a are finite numbers. If
+        false does no checking and passes matrix through to 
+        underlying algorithm.
 
     Returns
     -------
@@ -147,7 +165,10 @@ def lu(a, permute_l=False, overwrite_a=False):
     This is a LU factorization routine written for Scipy.
 
     """
-    a1 = asarray_chkfinite(a)
+    if chkfinite:
+        a1 = asarray_chkfinite(a)
+    else:
+        a1 = asarray(a)
     if len(a1.shape) != 2:
         raise ValueError('expected matrix')
     overwrite_a = overwrite_a or (_datacopied(a1, a))

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -24,7 +24,8 @@ def safecall(f, name, *args, **kwargs):
                          % (-ret[-1], name))
     return ret[:-2]
 
-def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
+def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
+        chkfinite=True):
     """Compute QR decomposition of a matrix.
 
     Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
@@ -50,6 +51,10 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
         qr decomposition. If pivoting, compute the decomposition
         :lm:`A P = Q R` as above, but where P is chosen such that the diagonal
         of R is non-increasing.
+    chkfinite : boolean
+        If true checks the elements of a are finite numbers. If
+        false does no checking and passes matrix through to
+        underlying algorithm.
 
     Returns
     -------
@@ -114,7 +119,10 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
         raise ValueError(
                  "Mode argument should be one of ['full', 'r', 'economic', 'raw']")
 
-    a1 = numpy.asarray_chkfinite(a)
+    if chkfinite:
+        a1 = numpy.asarray_chkfinite(a)
+    else:
+        a1 = numpy.asarray(a)
     if len(a1.shape) != 2:
         raise ValueError("expected 2D array")
     M, N = a1.shape
@@ -284,7 +292,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
     return (cQ,) + raw[1:]
 
 @numpy.deprecate
-def qr_old(a, overwrite_a=False, lwork=None):
+def qr_old(a, overwrite_a=False, lwork=None, chkfinite=True):
     """Compute QR decomposition of a matrix.
 
     Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
@@ -299,6 +307,10 @@ def qr_old(a, overwrite_a=False, lwork=None):
     lwork : integer
         Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
         is computed.
+    chkfinite : boolean
+        If true checks the elements of a are finite numbers. If
+        false does no checking and passes matrix through to
+        underlying algorithm.
 
     Returns
     -------
@@ -309,7 +321,10 @@ def qr_old(a, overwrite_a=False, lwork=None):
     Raises LinAlgError if decomposition fails
 
     """
-    a1 = numpy.asarray_chkfinite(a)
+    if chkfinite:
+        a1 = numpy.asarray_chkfinite(a)
+    else:
+        a1 = numpy.asarray(a)
     if len(a1.shape) != 2:
         raise ValueError('expected matrix')
     M,N = a1.shape
@@ -338,7 +353,7 @@ def qr_old(a, overwrite_a=False, lwork=None):
     return Q, R
 
 
-def rq(a, overwrite_a=False, lwork=None, mode='full'):
+def rq(a, overwrite_a=False, lwork=None, mode='full', chkfinite=True):
     """Compute RQ decomposition of a square real matrix.
 
     Calculate the decomposition :lm:`A = R Q` where Q is unitary/orthogonal
@@ -357,6 +372,10 @@ def rq(a, overwrite_a=False, lwork=None, mode='full'):
         Determines what information is to be returned: either both Q and R
         ('full', default), only R ('r') or both Q and R but computed in
         economy-size ('economic', see Notes).
+    chkfinite : boolean
+        If true checks the elements of a are finite numbers. If
+        false does no checking and passes matrix through to
+        underlying algorithm.
 
     Returns
     -------
@@ -387,7 +406,10 @@ def rq(a, overwrite_a=False, lwork=None, mode='full'):
         raise ValueError(\
                  "Mode argument should be one of ['full', 'r', 'economic']")
 
-    a1 = numpy.asarray_chkfinite(a)
+    if chkfinite:
+        a1 = numpy.asarray_chkfinite(a)
+    else:
+        a1 = numpy.asarray(a)
     if len(a1.shape) != 2:
         raise ValueError('expected matrix')
     M, N = a1.shape

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -25,7 +25,7 @@ def safecall(f, name, *args, **kwargs):
     return ret[:-2]
 
 def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
-        chkfinite=True):
+        check_finite=True):
     """Compute QR decomposition of a matrix.
 
     Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
@@ -51,7 +51,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
         qr decomposition. If pivoting, compute the decomposition
         :lm:`A P = Q R` as above, but where P is chosen such that the diagonal
         of R is non-increasing.
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a are finite numbers. If
         false does no checking and passes matrix through to
         underlying algorithm.
@@ -119,7 +119,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
         raise ValueError(
                  "Mode argument should be one of ['full', 'r', 'economic', 'raw']")
 
-    if chkfinite:
+    if check_finite:
         a1 = numpy.asarray_chkfinite(a)
     else:
         a1 = numpy.asarray(a)
@@ -292,7 +292,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
     return (cQ,) + raw[1:]
 
 @numpy.deprecate
-def qr_old(a, overwrite_a=False, lwork=None, chkfinite=True):
+def qr_old(a, overwrite_a=False, lwork=None, check_finite=True):
     """Compute QR decomposition of a matrix.
 
     Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
@@ -307,7 +307,7 @@ def qr_old(a, overwrite_a=False, lwork=None, chkfinite=True):
     lwork : integer
         Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
         is computed.
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a are finite numbers. If
         false does no checking and passes matrix through to
         underlying algorithm.
@@ -321,7 +321,7 @@ def qr_old(a, overwrite_a=False, lwork=None, chkfinite=True):
     Raises LinAlgError if decomposition fails
 
     """
-    if chkfinite:
+    if check_finite:
         a1 = numpy.asarray_chkfinite(a)
     else:
         a1 = numpy.asarray(a)
@@ -353,7 +353,7 @@ def qr_old(a, overwrite_a=False, lwork=None, chkfinite=True):
     return Q, R
 
 
-def rq(a, overwrite_a=False, lwork=None, mode='full', chkfinite=True):
+def rq(a, overwrite_a=False, lwork=None, mode='full', check_finite=True):
     """Compute RQ decomposition of a square real matrix.
 
     Calculate the decomposition :lm:`A = R Q` where Q is unitary/orthogonal
@@ -372,7 +372,7 @@ def rq(a, overwrite_a=False, lwork=None, mode='full', chkfinite=True):
         Determines what information is to be returned: either both Q and R
         ('full', default), only R ('r') or both Q and R but computed in
         economy-size ('economic', see Notes).
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a are finite numbers. If
         false does no checking and passes matrix through to
         underlying algorithm.
@@ -406,7 +406,7 @@ def rq(a, overwrite_a=False, lwork=None, mode='full', chkfinite=True):
         raise ValueError(\
                  "Mode argument should be one of ['full', 'r', 'economic']")
 
-    if chkfinite:
+    if check_finite:
         a1 = numpy.asarray_chkfinite(a)
     else:
         a1 = numpy.asarray(a)

--- a/scipy/linalg/decomp_schur.py
+++ b/scipy/linalg/decomp_schur.py
@@ -15,7 +15,7 @@ __all__ = ['schur', 'rsf2csf']
 _double_precision = ['i','l','d']
 
 def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
-            chkfinite=True):
+            check_finite=True):
     """Compute Schur decomposition of a matrix.
 
     The Schur decomposition is
@@ -47,9 +47,9 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
             'iuc'   Inside the unit circle (x*x.conjugate() <= 1.0)
             'ouc'   Outside the unit circle (x*x.conjugate() > 1.0)
         Defaults to None (no sorting).
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a are finite numbers. If
-        false does no checking and passes matrix through to 
+        false does no checking and passes matrix through to
         underlying algorithm.
 
     Returns
@@ -82,7 +82,7 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
     """
     if not output in ['real','complex','r','c']:
         raise ValueError("argument must be 'real', or 'complex'")
-    if chkfinite:
+    if check_finite:
         a1 = asarray_chkfinite(a)
     else:
         a1 = asarray(a)
@@ -171,7 +171,7 @@ def _castCopy(type, *arrays):
         return cast_arrays
 
 
-def rsf2csf(T, Z, chkfinite=True):
+def rsf2csf(T, Z, check_finite=True):
     """Convert real Schur form to complex Schur form.
 
     Convert a quasi-diagonal real-valued Schur form to the upper triangular
@@ -183,9 +183,9 @@ def rsf2csf(T, Z, chkfinite=True):
         Real Schur form of the original matrix
     Z : array, shape (M, M)
         Schur transformation matrix
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of T,Z are finite numbers. If
-        false does no checking and passes matrices through to 
+        false does no checking and passes matrices through to
         underlying algorithm.
 
     Returns
@@ -200,7 +200,7 @@ def rsf2csf(T, Z, chkfinite=True):
     schur : Schur decompose a matrix
 
     """
-    if chkfinite:
+    if check_finite:
         Z, T = map(asarray_chkfinite, (Z, T))
     else:
         Z,T = map(asarray, (Z,T))

--- a/scipy/linalg/decomp_schur.py
+++ b/scipy/linalg/decomp_schur.py
@@ -1,7 +1,7 @@
 """Schur decomposition functions."""
 
 import numpy
-from numpy import asarray_chkfinite, single
+from numpy import asarray_chkfinite, single, asarray
 
 # Local imports.
 import misc
@@ -14,7 +14,8 @@ __all__ = ['schur', 'rsf2csf']
 
 _double_precision = ['i','l','d']
 
-def schur(a, output='real', lwork=None, overwrite_a=False, sort=None):
+def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
+            chkfinite=True):
     """Compute Schur decomposition of a matrix.
 
     The Schur decomposition is
@@ -46,6 +47,10 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None):
             'iuc'   Inside the unit circle (x*x.conjugate() <= 1.0)
             'ouc'   Outside the unit circle (x*x.conjugate() > 1.0)
         Defaults to None (no sorting).
+    chkfinite : boolean
+        If true checks the elements of a are finite numbers. If
+        false does no checking and passes matrix through to 
+        underlying algorithm.
 
     Returns
     -------
@@ -77,7 +82,10 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None):
     """
     if not output in ['real','complex','r','c']:
         raise ValueError("argument must be 'real', or 'complex'")
-    a1 = asarray_chkfinite(a)
+    if chkfinite:
+        a1 = asarray_chkfinite(a)
+    else:
+        a1 = asarray(a)
     if len(a1.shape) != 2 or (a1.shape[0] != a1.shape[1]):
         raise ValueError('expected square matrix')
     typ = a1.dtype.char
@@ -163,7 +171,7 @@ def _castCopy(type, *arrays):
         return cast_arrays
 
 
-def rsf2csf(T, Z):
+def rsf2csf(T, Z, chkfinite=True):
     """Convert real Schur form to complex Schur form.
 
     Convert a quasi-diagonal real-valued Schur form to the upper triangular
@@ -175,6 +183,10 @@ def rsf2csf(T, Z):
         Real Schur form of the original matrix
     Z : array, shape (M, M)
         Schur transformation matrix
+    chkfinite : boolean
+        If true checks the elements of T,Z are finite numbers. If
+        false does no checking and passes matrices through to 
+        underlying algorithm.
 
     Returns
     -------
@@ -188,7 +200,10 @@ def rsf2csf(T, Z):
     schur : Schur decompose a matrix
 
     """
-    Z, T = map(asarray_chkfinite, (Z, T))
+    if chkfinite:
+        Z, T = map(asarray_chkfinite, (Z, T))
+    else:
+        Z,T = map(asarray, (Z,T))
     if len(Z.shape) != 2 or Z.shape[0] != Z.shape[1]:
         raise ValueError("matrix must be square.")
     if len(T.shape) != 2 or T.shape[0] != T.shape[1]:

--- a/scipy/linalg/decomp_svd.py
+++ b/scipy/linalg/decomp_svd.py
@@ -12,7 +12,7 @@ __all__ = ['svd', 'svdvals', 'diagsvd', 'orth']
 
 
 def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
-            chkfinite=True):
+            check_finite=True):
     """Singular Value Decomposition.
 
     Factorizes the matrix a into two unitary matrices U and Vh and
@@ -31,7 +31,7 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
         Whether to compute also U, Vh in addition to s (Default: true)
     overwrite_a : boolean
         Whether data in a is overwritten (may improve performance)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a are finite numbers. If
         false does no checking and passes matrix through to
         underlying algorithm.
@@ -72,7 +72,7 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     diagsvd : return the Sigma matrix, given the vector s
 
     """
-    if chkfinite:
+    if check_finite:
         a1 = asarray_chkfinite(a)
     else:
         a1 = asarray(a)
@@ -97,7 +97,7 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     else:
         return s
 
-def svdvals(a, overwrite_a=False, chkfinite=True):
+def svdvals(a, overwrite_a=False, check_finite=True):
     """Compute singular values of a matrix.
 
     Parameters
@@ -106,7 +106,7 @@ def svdvals(a, overwrite_a=False, chkfinite=True):
         Matrix to decompose
     overwrite_a : boolean
         Whether data in a is overwritten (may improve performance)
-    chkfinite : boolean
+    check_finite : boolean
         If true checks the elements of a are finite numbers. If
         false does no checking and passes matrix through to
         underlying algorithm.
@@ -124,7 +124,8 @@ def svdvals(a, overwrite_a=False, chkfinite=True):
     diagsvd : return the Sigma matrix, given the vector s
 
     """
-    return svd(a, compute_uv=0, overwrite_a=overwrite_a, chkfinite=chkfinite)
+    return svd(a, compute_uv=0, overwrite_a=overwrite_a,
+                check_finite=check_finite)
 
 def diagsvd(s, M, N):
     """Construct the sigma matrix in SVD from singular values and size M,N.

--- a/scipy/linalg/decomp_svd.py
+++ b/scipy/linalg/decomp_svd.py
@@ -32,8 +32,8 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     overwrite_a : boolean
         Whether data in a is overwritten (may improve performance)
     chkfinite : boolean
-        If true checks the elements of a,b are finite numbers. If
-        false does no checking and passes matrices through to
+        If true checks the elements of a are finite numbers. If
+        false does no checking and passes matrix through to
         underlying algorithm.
 
     Returns

--- a/scipy/linalg/decomp_svd.py
+++ b/scipy/linalg/decomp_svd.py
@@ -1,7 +1,7 @@
 """SVD decomposition functions."""
 
 import numpy
-from numpy import asarray_chkfinite, zeros, r_, diag
+from numpy import asarray_chkfinite, asarray, zeros, r_, diag
 from scipy.linalg import calc_lwork
 
 # Local imports.
@@ -11,7 +11,8 @@ from lapack import get_lapack_funcs
 __all__ = ['svd', 'svdvals', 'diagsvd', 'orth']
 
 
-def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False):
+def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
+            chkfinite=True):
     """Singular Value Decomposition.
 
     Factorizes the matrix a into two unitary matrices U and Vh and
@@ -30,6 +31,10 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False):
         Whether to compute also U, Vh in addition to s (Default: true)
     overwrite_a : boolean
         Whether data in a is overwritten (may improve performance)
+    chkfinite : boolean
+        If true checks the elements of a,b are finite numbers. If
+        false does no checking and passes matrices through to
+        underlying algorithm.
 
     Returns
     -------
@@ -67,7 +72,10 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False):
     diagsvd : return the Sigma matrix, given the vector s
 
     """
-    a1 = asarray_chkfinite(a)
+    if chkfinite:
+        a1 = asarray_chkfinite(a)
+    else:
+        a1 = asarray(a)
     if len(a1.shape) != 2:
         raise ValueError('expected matrix')
     m,n = a1.shape
@@ -89,7 +97,7 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False):
     else:
         return s
 
-def svdvals(a, overwrite_a=False):
+def svdvals(a, overwrite_a=False, chkfinite=True):
     """Compute singular values of a matrix.
 
     Parameters
@@ -98,6 +106,10 @@ def svdvals(a, overwrite_a=False):
         Matrix to decompose
     overwrite_a : boolean
         Whether data in a is overwritten (may improve performance)
+    chkfinite : boolean
+        If true checks the elements of a are finite numbers. If
+        false does no checking and passes matrix through to
+        underlying algorithm.
 
     Returns
     -------
@@ -112,7 +124,7 @@ def svdvals(a, overwrite_a=False):
     diagsvd : return the Sigma matrix, given the vector s
 
     """
-    return svd(a, compute_uv=0, overwrite_a=overwrite_a)
+    return svd(a, compute_uv=0, overwrite_a=overwrite_a, chkfinite=chkfinite)
 
 def diagsvd(s, M, N):
     """Construct the sigma matrix in SVD from singular values and size M,N.

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -87,7 +87,7 @@ class TestSolveBanded(TestCase):
             x = solve_banded((l, u), ab, b)
             assert_array_almost_equal(dot(a, x), b)
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a = array([[ 1.0, 20,  0,  0],
                    [ -30,  4,  6,  0],
                    [   2,  1, 20,  2],
@@ -98,7 +98,7 @@ class TestSolveBanded(TestCase):
                     [   2, -1,  0,  0]])
         l,u = 2,1
         b4 = array([10.0, 0.0, 2.0, 14.0])
-        x = solve_banded((l, u), ab, b4, chkfinite=False)
+        x = solve_banded((l, u), ab, b4, check_finite=False)
         assert_array_almost_equal(dot(a, x), b4)
 
     def test_bad_shape(self):
@@ -241,7 +241,7 @@ class TestSolveHBanded(TestCase):
                           [1.0,  1.0]])
         assert_array_almost_equal(x, expected)
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         # Solve
         # [ 4 1 0]     [1]
         # [ 1 4 1] X = [4]
@@ -249,7 +249,7 @@ class TestSolveHBanded(TestCase):
         # with the RHS as a 1D array.
         ab = array([[-99, 1.0, 1.0], [4.0, 4.0, 4.0]])
         b = array([1.0, 4.0, 1.0])
-        x = solveh_banded(ab, b, chkfinite=False)
+        x = solveh_banded(ab, b, check_finite=False)
         assert_array_almost_equal(x, [0.0, 1.0, 0.0])
 
     def test_bad_shapes(self):
@@ -364,11 +364,11 @@ class TestSolve(TestCase):
             x = solve(a,b,sym_pos=1)
             assert_array_almost_equal(dot(a,x),b)
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a = [[1,20],[-30,4]]
         for b in ([[1,0],[0,1]],[1,0],
                   [[2,1],[-30,4]]):
-            x = solve(a,b, chkfinite=False)
+            x = solve(a,b, check_finite=False)
             assert_array_almost_equal(dot(a,x),b)
 
 
@@ -404,13 +404,13 @@ class TestSolveTriangular(TestCase):
         sol = solve_triangular(A, b, lower=True, trans=1)
         assert_array_almost_equal(sol, [[.5-.5j, -.25-.25j], [0, 0.5]])
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         """
         solve_triangular on a simple 2x2 matrix.
         """
         A = array([[1,0], [1,2]])
         b = [1, 1]
-        sol = solve_triangular(A, b, lower=True, chkfinite=False)
+        sol = solve_triangular(A, b, lower=True, check_finite=False)
         assert_array_almost_equal(sol, [1, 0])
 
 
@@ -449,9 +449,9 @@ class TestInv(TestCase):
             a_inv = inv(a)
             assert_array_almost_equal(dot(a,a_inv),
                                       identity(n))
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a = [[1,2],[3,4]]
-        a_inv = inv(a, chkfinite=False)
+        a_inv = inv(a, check_finite=False)
         assert_array_almost_equal(dot(a,a_inv),
                                   [[1,0],[0,1]])
 
@@ -486,9 +486,9 @@ class TestDet(TestCase):
             d2 = basic_det(a)
             assert_almost_equal(d1,d2)
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a = [[1,2],[3,4]]
-        a_det = det(a, chkfinite=False)
+        a_det = det(a, check_finite=False)
         assert_almost_equal(a_det,-2.0)
 
 
@@ -583,11 +583,11 @@ class TestLstsq(TestCase):
             #XXX: check definition of res
             assert_array_almost_equal(x,direct_lstsq(a,b,1))
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a = [[1,20],[-30,4]]
         for b in ([[1,0],[0,1]],[1,0],
                   [[2,1],[-30,4]]):
-            x = lstsq(a,b, chkfinite=False)[0]
+            x = lstsq(a,b, check_finite=False)[0]
             assert_array_almost_equal(dot(a,x),b)
 
 
@@ -617,11 +617,11 @@ class TestPinv(TestCase):
         a_pinv2 = pinv2(a)
         assert_array_almost_equal(a_pinv,a_pinv2)
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a=array([[1,2,3],[4,5,6.],[7,8,10]])
-        a_pinv = pinv(a, chkfinite=False)
+        a_pinv = pinv(a, check_finite=False)
         assert_array_almost_equal(dot(a,a_pinv),[[1,0,0],[0,1,0],[0,0,1]])
-        a_pinv = pinv2(a, chkfinite=False)
+        a_pinv = pinv2(a, check_finite=False)
         assert_array_almost_equal(dot(a,a_pinv),[[1,0,0],[0,1,0],[0,0,1]])
 
 class TestNorm(object):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -87,6 +87,20 @@ class TestSolveBanded(TestCase):
             x = solve_banded((l, u), ab, b)
             assert_array_almost_equal(dot(a, x), b)
 
+    def test_chkfinite(self):
+        a = array([[ 1.0, 20,  0,  0],
+                   [ -30,  4,  6,  0],
+                   [   2,  1, 20,  2],
+                   [   0, -1,  7, 14]])
+        ab = array([[ 0.0, 20,  6,  2],
+                    [   1,  4, 20, 14],
+                    [ -30,  1,  7,  0],
+                    [   2, -1,  0,  0]])
+        l,u = 2,1
+        b4 = array([10.0, 0.0, 2.0, 14.0])
+        x = solve_banded((l, u), ab, b4, chkfinite=False)
+        assert_array_almost_equal(dot(a, x), b4)
+
     def test_bad_shape(self):
         ab = array([[ 0.0, 20,  6,  2],
                     [   1,  4, 20, 14],
@@ -227,6 +241,17 @@ class TestSolveHBanded(TestCase):
                           [1.0,  1.0]])
         assert_array_almost_equal(x, expected)
 
+    def test_chkfinite(self):
+        # Solve
+        # [ 4 1 0]     [1]
+        # [ 1 4 1] X = [4]
+        # [ 0 1 4]     [1]
+        # with the RHS as a 1D array.
+        ab = array([[-99, 1.0, 1.0], [4.0, 4.0, 4.0]])
+        b = array([1.0, 4.0, 1.0])
+        x = solveh_banded(ab, b, chkfinite=False)
+        assert_array_almost_equal(x, [0.0, 1.0, 0.0])
+
     def test_bad_shapes(self):
         ab = array([[-99, 1.0, 1.0],
                     [4.0, 4.0, 4.0]])
@@ -255,6 +280,7 @@ class TestSolve(TestCase):
                   [[2,1],[-30,4]]):
             x = solve(a,b)
             assert_array_almost_equal(dot(a,x),b)
+
 
     def test_simple_sym(self):
         a = [[2,3],[3,5]]
@@ -338,6 +364,13 @@ class TestSolve(TestCase):
             x = solve(a,b,sym_pos=1)
             assert_array_almost_equal(dot(a,x),b)
 
+    def test_chkfinite(self):
+        a = [[1,20],[-30,4]]
+        for b in ([[1,0],[0,1]],[1,0],
+                  [[2,1],[-30,4]]):
+            x = solve(a,b, chkfinite=False)
+            assert_array_almost_equal(dot(a,x),b)
+
 
 class TestSolveTriangular(TestCase):
 
@@ -370,6 +403,15 @@ class TestSolveTriangular(TestCase):
         b = identity(2)
         sol = solve_triangular(A, b, lower=True, trans=1)
         assert_array_almost_equal(sol, [[.5-.5j, -.25-.25j], [0, 0.5]])
+
+    def test_chkfinite(self):
+        """
+        solve_triangular on a simple 2x2 matrix.
+        """
+        A = array([[1,0], [1,2]])
+        b = [1, 1]
+        sol = solve_triangular(A, b, lower=True, chkfinite=False)
+        assert_array_almost_equal(sol, [1, 0])
 
 
 
@@ -407,6 +449,11 @@ class TestInv(TestCase):
             a_inv = inv(a)
             assert_array_almost_equal(dot(a,a_inv),
                                       identity(n))
+    def test_chkfinite(self):
+        a = [[1,2],[3,4]]
+        a_inv = inv(a, chkfinite=False)
+        assert_array_almost_equal(dot(a,a_inv),
+                                  [[1,0],[0,1]])
 
 
 class TestDet(TestCase):
@@ -438,6 +485,11 @@ class TestDet(TestCase):
             d1 = det(a)
             d2 = basic_det(a)
             assert_almost_equal(d1,d2)
+
+    def test_chkfinite(self):
+        a = [[1,2],[3,4]]
+        a_det = det(a, chkfinite=False)
+        assert_almost_equal(a_det,-2.0)
 
 
 def direct_lstsq(a,b,cmplx=0):
@@ -531,6 +583,13 @@ class TestLstsq(TestCase):
             #XXX: check definition of res
             assert_array_almost_equal(x,direct_lstsq(a,b,1))
 
+    def test_chkfinite(self):
+        a = [[1,20],[-30,4]]
+        for b in ([[1,0],[0,1]],[1,0],
+                  [[2,1],[-30,4]]):
+            x = lstsq(a,b, chkfinite=False)[0]
+            assert_array_almost_equal(dot(a,x),b)
+
 
 class TestPinv(TestCase):
 
@@ -558,6 +617,12 @@ class TestPinv(TestCase):
         a_pinv2 = pinv2(a)
         assert_array_almost_equal(a_pinv,a_pinv2)
 
+    def test_chkfinite(self):
+        a=array([[1,2,3],[4,5,6.],[7,8,10]])
+        a_pinv = pinv(a, chkfinite=False)
+        assert_array_almost_equal(dot(a,a_pinv),[[1,0,0],[0,1,0],[0,0,1]])
+        a_pinv = pinv2(a, chkfinite=False)
+        assert_array_almost_equal(dot(a,a_pinv),[[1,0,0],[0,1,0],[0,0,1]])
 
 class TestNorm(object):
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -129,9 +129,9 @@ class TestEigVals(TestCase):
                    (9+1j-sqrt(92+6j))/2]
         assert_array_almost_equal(w,exact_w)
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a = [[1,2,3],[1,2,3],[2,5,6]]
-        w = eigvals(a, chkfinite=False)
+        w = eigvals(a, check_finite=False)
         exact_w = [(9+sqrt(93))/2,0,(9-sqrt(93))/2]
         assert_array_almost_equal(w,exact_w)
 
@@ -248,9 +248,9 @@ class TestEig(object):
         finally:
             np.seterr(**olderr)
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a = [[1,2,3],[1,2,3],[2,5,6]]
-        w,v = eig(a, chkfinite=False)
+        w,v = eig(a, check_finite=False)
         exact_w = [(9+sqrt(93))/2,0,(9-sqrt(93))/2]
         v0 = array([1,1,(1+sqrt(93)/3)/2])
         v1 = array([3.,0,-1])
@@ -456,7 +456,7 @@ class TestEigBanded(TestCase):
         assert_array_almost_equal(sort(w_herm_val),
                                   self.w_herm_lin[ind1:ind2+1])
 
-        w_sym = eigvals_banded(self.bandmat_sym, chkfinite=False)
+        w_sym = eigvals_banded(self.bandmat_sym, check_finite=False)
         w_sym = w_sym.real
         assert_array_almost_equal(sort(w_sym), self.w_sym_lin)
 
@@ -510,7 +510,7 @@ class TestEigBanded(TestCase):
         assert_array_almost_equal(abs(evec_herm_val),
                                   abs(self.evec_herm_lin[:,ind1:ind2+1]) )
 
-        w_sym, evec_sym = eig_banded(self.bandmat_sym, chkfinite=False)
+        w_sym, evec_sym = eig_banded(self.bandmat_sym, check_finite=False)
         evec_sym_ = evec_sym[:,argsort(w_sym.real)]
         assert_array_almost_equal(sort(w_sym), self.w_sym_lin)
         assert_array_almost_equal(abs(evec_sym_), abs(self.evec_sym_lin))
@@ -711,8 +711,8 @@ class TestLU(TestCase):
         """Check lu decomposition on medium size, rectangular matrix."""
         self._test_common(self.cmed)
 
-    def test_chkfinite(self):
-        p, l, u = lu(self.a, chkfinite=False)
+    def test_check_finite(self):
+        p, l, u = lu(self.a, check_finite=False)
         assert_array_almost_equal(dot(dot(p,l),u), self.a)
 
     def test_simple_known(self):
@@ -761,13 +761,13 @@ class TestLUSolve(TestCase):
 
             assert_array_almost_equal(x1,x2)
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a = random((10,10))
         b = random((10,))
         x1 = solve(a,b)
 
-        lu_a = lu_factor(a, chkfinite=False)
-        x2 = lu_solve(lu_a,b, chkfinite=False)
+        lu_a = lu_factor(a, check_finite=False)
+        x2 = lu_solve(lu_a,b, check_finite=False)
 
         assert_array_almost_equal(x1,x2)
 
@@ -852,9 +852,9 @@ class TestSVD(TestCase):
                     for i in range(len(s)): sigma[i,i] = s[i]
                     assert_array_almost_equal(dot(dot(u,sigma),vh),a)
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a = [[1,2,3],[1,20,3],[2,5,6]]
-        u,s,vh = svd(a, chkfinite=False)
+        u,s,vh = svd(a, check_finite=False)
         assert_array_almost_equal(dot(transpose(u),u),identity(3))
         assert_array_almost_equal(dot(transpose(vh),vh),identity(3))
         sigma = zeros((u.shape[0],vh.shape[0]),s.dtype.char)
@@ -899,9 +899,9 @@ class TestSVDVals(TestCase):
         assert_(len(s) == 2)
         assert_(s[0] >= s[1])
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a = [[1,2,3],[1,2,3],[2,5,6]]
-        s = svdvals(a, chkfinite=False)
+        s = svdvals(a, check_finite=False)
         assert_(len(s) == 3)
         assert_(s[0] >= s[1] >= s[2])
 
@@ -1440,9 +1440,9 @@ class TestQR(TestCase):
             assert_array_almost_equal(q,q2)
             assert_array_almost_equal(r,r2)
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a = [[8,2,3],[2,9,3],[5,3,6]]
-        q,r = qr(a, chkfinite=False)
+        q,r = qr(a, check_finite=False)
         assert_array_almost_equal(dot(transpose(q),q),identity(3))
         assert_array_almost_equal(dot(q,r),a)
 
@@ -1543,9 +1543,9 @@ class TestRQ(TestCase):
             assert_equal(q.shape, (m, n))
             assert_equal(r.shape, (m, m))
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a = [[8,2,3],[2,9,3],[5,3,6]]
-        r,q = rq(a, chkfinite=False)
+        r,q = rq(a, check_finite=False)
         assert_array_almost_equal(dot(q, transpose(q)),identity(3))
         assert_array_almost_equal(dot(r,q),a)
 
@@ -1638,9 +1638,9 @@ class TestSchur(TestCase):
         assert_raises(ValueError, schur, a, sort='unsupported')
         assert_raises(ValueError, schur, a, sort=1)
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a = [[8,12,3],[2,9,3],[10,3,6]]
-        t,z = schur(a, chkfinite=False)
+        t,z = schur(a, check_finite=False)
         assert_array_almost_equal(dot(dot(z,t),transp(conj(z))),a)
 
 
@@ -1691,14 +1691,14 @@ class TestHessenberg(TestCase):
             h1 = dot(transp(conj(q)),dot(a,q))
             assert_array_almost_equal(h1,h)
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a = [[-149, -50,-154],
              [ 537, 180, 546],
              [ -27,  -9, -25]]
         h1 = [[-149.0000,42.2037,-156.3165],
               [-537.6783,152.5511,-554.9272],
               [0,0.0728, 2.4489]]
-        h,q = hessenberg(a,calc_q=1, chkfinite=False)
+        h,q = hessenberg(a,calc_q=1, check_finite=False)
         assert_array_almost_equal(dot(transp(q),dot(a,q)),h)
         assert_array_almost_equal(h,h1,decimal=4)
 

--- a/scipy/linalg/tests/test_decomp_cholesky.py
+++ b/scipy/linalg/tests/test_decomp_cholesky.py
@@ -23,6 +23,14 @@ class TestCholesky(TestCase):
         a = dot(c,transpose(c))
         assert_array_almost_equal(cholesky(a,lower=1),c)
 
+    def test_chkfinite(self):
+        a = [[8,2,3],[2,9,3],[3,3,6]]
+        c = cholesky(a, chkfinite=False)
+        assert_array_almost_equal(dot(transpose(c),c),a)
+        c = transpose(c)
+        a = dot(c,transpose(c))
+        assert_array_almost_equal(cholesky(a,lower=1, chkfinite=False),c)
+
     def test_simple_complex(self):
         m = array([[3+1j,3+4j,5],[0,2+2j,2+7j],[0,0,7+4j]])
         a = dot(transpose(conjugate(m)),m)
@@ -65,6 +73,25 @@ class TestCholesky(TestCase):
 class TestCholeskyBanded(TestCase):
     """Tests for cholesky_banded() and cho_solve_banded."""
 
+    def test_chkfinite(self):
+        # Symmetric positive definite banded matrix `a`
+        a = array([[4.0, 1.0, 0.0, 0.0],
+                    [1.0, 4.0, 0.5, 0.0],
+                    [0.0, 0.5, 4.0, 0.2],
+                    [0.0, 0.0, 0.2, 4.0]])
+        # Banded storage form of `a`.
+        ab = array([[-1.0, 1.0, 0.5, 0.2],
+                     [4.0, 4.0, 4.0, 4.0]])
+        c = cholesky_banded(ab, lower=False, chkfinite=False)
+        ufac = zeros_like(a)
+        ufac[range(4),range(4)] = c[-1]
+        ufac[(0,1,2),(1,2,3)] = c[0,1:]
+        assert_array_almost_equal(a, dot(ufac.T, ufac))
+
+        b = array([0.0, 0.5, 4.2, 4.2])
+        x = cho_solve_banded((c, False), b, chkfinite=False)
+        assert_array_almost_equal(x, [0.0, 0.0, 1.0, 1.0])
+  
     def test_upper_real(self):
         # Symmetric positive definite banded matrix `a`
         a = array([[4.0, 1.0, 0.0, 0.0],

--- a/scipy/linalg/tests/test_decomp_cholesky.py
+++ b/scipy/linalg/tests/test_decomp_cholesky.py
@@ -23,13 +23,13 @@ class TestCholesky(TestCase):
         a = dot(c,transpose(c))
         assert_array_almost_equal(cholesky(a,lower=1),c)
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         a = [[8,2,3],[2,9,3],[3,3,6]]
-        c = cholesky(a, chkfinite=False)
+        c = cholesky(a, check_finite=False)
         assert_array_almost_equal(dot(transpose(c),c),a)
         c = transpose(c)
         a = dot(c,transpose(c))
-        assert_array_almost_equal(cholesky(a,lower=1, chkfinite=False),c)
+        assert_array_almost_equal(cholesky(a,lower=1, check_finite=False),c)
 
     def test_simple_complex(self):
         m = array([[3+1j,3+4j,5],[0,2+2j,2+7j],[0,0,7+4j]])
@@ -73,7 +73,7 @@ class TestCholesky(TestCase):
 class TestCholeskyBanded(TestCase):
     """Tests for cholesky_banded() and cho_solve_banded."""
 
-    def test_chkfinite(self):
+    def test_check_finite(self):
         # Symmetric positive definite banded matrix `a`
         a = array([[4.0, 1.0, 0.0, 0.0],
                     [1.0, 4.0, 0.5, 0.0],
@@ -82,16 +82,16 @@ class TestCholeskyBanded(TestCase):
         # Banded storage form of `a`.
         ab = array([[-1.0, 1.0, 0.5, 0.2],
                      [4.0, 4.0, 4.0, 4.0]])
-        c = cholesky_banded(ab, lower=False, chkfinite=False)
+        c = cholesky_banded(ab, lower=False, check_finite=False)
         ufac = zeros_like(a)
         ufac[range(4),range(4)] = c[-1]
         ufac[(0,1,2),(1,2,3)] = c[0,1:]
         assert_array_almost_equal(a, dot(ufac.T, ufac))
 
         b = array([0.0, 0.5, 4.2, 4.2])
-        x = cho_solve_banded((c, False), b, chkfinite=False)
+        x = cho_solve_banded((c, False), b, check_finite=False)
         assert_array_almost_equal(x, [0.0, 0.0, 1.0, 1.0])
-  
+
     def test_upper_real(self):
         # Symmetric positive definite banded matrix `a`
         a = array([[4.0, 1.0, 0.0, 0.0],


### PR DESCRIPTION
I added a chkfinite flag to all scipy.linalg functions where it made sense to do so. This flag allows the user to disable the checking for finite floating point numbers in argument arrays. By default the inputs are still verified to be finite. Previously the user had no way to turn off this checking. 

This is a desirable change because the checking can be fairly time consuming but also irrelevant for users that have already verified their data otherwise. In particular, it's a useless overhead if the user is repeatedly linalg operations on subarrays of a large array whose elements have already been verified. 

(Of course, the downside is some functions hang if given np.Inf or np.NaN as inputs. And othertimes the programs will perform the operations but output garbage, which possibly might be hard to detect as garbage.) 

Tests to check the flag worked were added to the existing tests in scipy.lingalg. 
