### PR TITLE
Fixed build on OSX 10.7 Lion

### DIFF
--- a/scipy/lib/blas/fblaswrap_veclib_c.c.src
+++ b/scipy/lib/blas/fblaswrap_veclib_c.c.src
@@ -1,3 +1,4 @@
+#include <complex.h>
 #include <vecLib/vecLib.h>
 
 //#define WRAP_F77(a) wcblas_##a##_

--- a/scipy/linalg/src/fblaswrap_veclib_c.c
+++ b/scipy/linalg/src/fblaswrap_veclib_c.c
@@ -1,3 +1,4 @@
+#include <complex.h>
 #include <vecLib/vecLib.h>
 
 //#define WRAP_F77(a) wcblas_##a##_

--- a/scipy/sparse/linalg/eigen/arpack/ARPACK/FWRAPPERS/veclib_cabi_c.c
+++ b/scipy/sparse/linalg/eigen/arpack/ARPACK/FWRAPPERS/veclib_cabi_c.c
@@ -1,3 +1,4 @@
+#include <complex.h>
 #include <vecLib/vecLib.h>
 
 #define WRAP_F77(a) a##_


### PR DESCRIPTION
Added the line:
# include <complex.h>

to the top of these files:

scipy/linalg/src/fblaswrap_veclib_c.c
scipy/lib/blas/fblaswrap_veclib_c.c.src
scipy/sparse/linalg/eigen/arpack/ARPACK/FWRAPPERS/veclib_cabi_c.c

et voila -- it builds and runs as it used to.
