### PR TITLE
Fix for ticket #1489 -- Fix the handling of a row or columns of zeros in stats.fisher_exact.

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2285,6 +2285,14 @@ def fisher_exact(table, alternative='two-sided'):
     if not c.shape == (2, 2):
         raise ValueError("The input `table` must be of shape (2, 2).")
 
+    if np.any(c < 0):
+        raise ValueError("All values in `table` must be nonnegative.")
+
+    if 0 in c.sum(axis=0) or 0 in c.sum(axis=1):
+        # If both values in a row or column are zero, the p-value is 1 and
+        # the odds ratio is NaN.
+        return np.nan, 1.0
+
     if c[1,0] > 0 and c[0,1] > 0:
         oddsratio = c[0,0] * c[1,1] / float(c[1,0] * c[0,1])
     else:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -422,6 +422,16 @@ class TestFisherExact(TestCase):
         assert_raises(ValueError, stats.fisher_exact,
                       np.arange(6).reshape(2, 3))
 
+    def test_row_or_col_zero(self):
+        tables = ([[0, 0], [5, 10]],
+                  [[5, 10], [0, 0]],
+                  [[0, 5], [0, 10]],
+                  [[5, 0], [10, 0]])
+        for table in tables:
+            oddsratio, pval = stats.fisher_exact(table)
+            assert_equal(pval, 1.0)
+            assert_equal(oddsratio, np.nan)
+
     def test_less_greater(self):
         tables = ([[2, 7], [8, 2]],
                   [[200, 7], [8, 300]],


### PR DESCRIPTION
As discussed in ticket #1489 (http://projects.scipy.org/scipy/ticket/1489), when the 2x2 table has a row or column of zeros, fisher_exact should return oddsratio=np.nan and pvalue=1.0.
