### PR TITLE
QR decomposition with Q multiplication

### DIFF
--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -127,7 +127,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
     if mode not in ['economic', 'raw'] or M < N:
         R = numpy.triu(qr)
     else:
-        R = numpy.triu(qr[:, :N])
+        R = numpy.triu(qr[:N, :])
 
     if pivoting:
         Rj = R, jpvt

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -107,8 +107,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
         # 'qr' are used below, but set to 'full' anyway to be sure
         mode = 'full'
     # 'raw' is used only internally by qr_multiply, not documented on purpose
-    if (not mode in ['full', 'qr', 'r', 'economic', 'raw']
-                 ) and c is None:
+    if mode not in ['full', 'qr', 'r', 'economic', 'raw']:
         raise ValueError(
                  "Mode argument should be one of ['full', 'r', 'economic']")
 

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -159,8 +159,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
 
     return (Q,) + Rj
 
-def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
-    overwrite_a=False, overwrite_c=False, lwork=None):
+def qr_multiply(a, c, mode='right', **kwargs):
     """Calculate the QR decomposition and multiply Q with a matrix.
 
     Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
@@ -214,6 +213,12 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
     """
     if not mode in ['left', 'right']:
         raise ValueError("Mode argument should be one of ['left', 'right']")
+    pivoting = kwargs.get("pivoting", False)
+    conjugate = kwargs.get("conjugate", False)
+    overwrite_a = kwargs.get("overwrite_a", False)
+    overwrite_c = kwargs.get("overwrite_c", False)
+    lwork = kwargs.get("lwork", None)
+
     c = numpy.asarray_chkfinite(c)
     onedim = c.ndim == 1
     if onedim:

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -127,7 +127,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
         qr, tau = safecall(geqrf, "geqrf", a1, lwork=lwork,
             overwrite_a=overwrite_a)
 
-    if not mode == 'economic' or M < N:
+    if mode not in ['economic', 'raw'] or M < N:
         R = numpy.triu(qr)
     else:
         R = numpy.triu(qr[:N, :N])

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -233,15 +233,14 @@ def qr_multiply(a, c, mode='right', pivoting=False, overwrite_a=False,
     Q = Q[:, :min(M, N)]
     if M > N and mode == "left":
         if overwrite_c:
-            cc = c.T.conjugate()
+            cc = c
         else:
-            cc = numpy.zeros((c.shape[1], max(M, N)),
-                dtype=c.dtype, order="F")
-            cc[:, :c.shape[0]] = c.T.conjugate()
+            cc = numpy.zeros((M, c.shape[1]), dtype=c.dtype, order="F")
+            cc[:c.shape[0], :] = c
             overwrite_c = True
-        lr = "R"
-    elif c.flags["C_CONTIGUOUS"] and (
-            mode == "left" or M <= N) and trans == "T":
+        lr = "L"
+        trans = "N"
+    elif c.flags["C_CONTIGUOUS"] and trans == "T":
         cc = c.T
         lr = "R" if mode == "left" else "L"
     else: 

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -36,7 +36,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
     lwork : int, optional
         Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
         is computed.
-    mode : {'full', 'r', 'economic'} if c is None,
+    mode : {'full', 'r', 'economic'}
         Determines what information is to be returned: either both Q and R
         ('full', default), only R ('r'), both Q and R but computed in
         economy-size ('economic', see Notes).
@@ -180,15 +180,12 @@ def qr_multiply(a, c, mode='right', pivoting=False, overwrite_a=False,
         if mode is 'right', a.shape[0].
     pivoting : bool, optional
         Whether or not factorization should include pivoting for rank-revealing
-        qr decomposition. If pivoting, compute the decomposition
-        :lm:`A P = Q R` as above, but where P is chosen such that the diagonal
-        of R is non-increasing.
+        qr decomposition, see the documentation of qr.
     overwrite_a : bool, optional
         Whether data in a is overwritten (may improve performance)
     lwork : int, optional
         Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
         is computed.
-        
     overwrite_c: bool, optional
         Whether data in c is overwritten (may improve performance)
         

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -168,9 +168,9 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
             raise ValueError("illegal value in %d-th argument of internal geqrf"
                                                                         % -info)
     if not mode == 'economic' or M < N:
-        R = special_matrices.triu(qr)
+        R = numpy.triu(qr)
     else:
-        R = special_matrices.triu(qr[0:N, 0:N])
+        R = numpy.triu(qr[:N, :N])
 
     if mode == 'r':
         if pivoting:
@@ -179,7 +179,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
             return R
 
     if mode == 'reflectors':
-        Q = special_matrices.tril(qr, -1)
+        Q = numpy.tril(qr, -1)
         numpy.fill_diagonal(Q[:len(tau), :len(tau)], 1)
         Q[:, :len(tau)] *= tau
         if pivoting:

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -85,18 +85,16 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
     If ``mode=economic``, the shapes of Q and R are (M, K) and (K, N) instead
     of (M,M) and (M,N), with ``K=min(M,N)``.
 
-    If ''mode=reflectors'', the matrix Q is represented as a product of
+    If ``mode=reflectors``, the matrix Q is represented as a product of
     elementary reflectors
 
       Q = H[1] H[2] . . . H[k], where k = min(m,n).
 
     Each H[i] has the form
 
-     H[i] = I - tau * v * v.T
+     H[i] = I - (1 / v[i]) * v * v.T
 
-    where tau is a real/complex scalar, and v is a real/complex vector
-    with v[:i] = 0 and v[i] = 1; v[i:m] is stored on exit in
-    A(i+1:m,i), and tau in TAU(i).
+    where v is a vector with v[:i] = 0. v is returned as Q[:, i]
 
     Examples
     --------

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -239,18 +239,15 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
         trans = "C"
 
     Q = Q[:, :min(M, N)]
-    if M > N and mode == "left":
-        if overwrite_c:
-            cc = c
-        elif conjugate:
+    if M > N and mode == "left" and not overwrite_c:
+        if conjugate:
             cc = numpy.zeros((c.shape[1], M), dtype=c.dtype, order="F")
             cc[:, :c.shape[0]] = c.T
-            lr = "R"
         else:
             cc = numpy.zeros((M, c.shape[1]), dtype=c.dtype, order="F")
             cc[:c.shape[0], :] = c
-            lr = "L"
             trans = "N"
+        lr = "R" if conjugate else "L"
         overwrite_c = True
     elif c.flags["C_CONTIGUOUS"] and trans == "T":
         cc = c.T

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -227,7 +227,8 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
         return Q, R, jpvt
     return Q, R
 
-def qr_mult(*args, **kwargs):
+def qr_mult(a, c, mode='right', pivoting=False, overwrite_a=False,
+    overwrite_c=False, lwork=None):
     """Calculate the QR decomposition and multiply Q with a matrix.
 
     Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
@@ -237,25 +238,25 @@ def qr_mult(*args, **kwargs):
     ----------
     a : array, shape (M, N)
         Matrix to be decomposed
-    overwrite_a : bool, optional
-        Whether data in a is overwritten (may improve performance)
-    lwork : int, optional
-        Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
-        is computed.
+    c : array, one- or two-dimensional
+        calculate the product of c and q, depending on the mode:
     mode : {'left', 'right'} 
         dot(Q, c) is returned if mode is 'left',
         dot(c, Q) is returned if mode is 'right'.
-        
+        the shape of c must be appropriate for the matrix multiplications,
+        if mode is 'left', min(a.shape) == c.shape[0],
+        if mode is 'right', a.shape[0].
     pivoting : bool, optional
         Whether or not factorization should include pivoting for rank-revealing
         qr decomposition. If pivoting, compute the decomposition
         :lm:`A P = Q R` as above, but where P is chosen such that the diagonal
         of R is non-increasing.
-    c : array, two-dimensional
-        calculate the product of c and q, depending on the mode:
-        'left': dot(Q, c)
-        'right': dot(c, Q)
-        the shape of c must be appropriate for the matrix multiplications
+    overwrite_a : bool, optional
+        Whether data in a is overwritten (may improve performance)
+    lwork : int, optional
+        Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
+        is computed.
+        
     overwrite_c: bool, optional
         Whether data in c is overwritten (may improve performance)
         
@@ -279,7 +280,7 @@ def qr_mult(*args, **kwargs):
     This is an interface to the LAPACK routines dgeqrf, zgeqrf,
     dormqr, zunmqr, dgeqp3, and zgeqp3.
     """
-    return qr(*args, **kwargs)
+    return qr(a, overwrite_a, lwork, mode, pivoting, c, overwrite_c)
 
 def qr_old(a, overwrite_a=False, lwork=None):
     """Compute QR decomposition of a matrix.

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -223,8 +223,10 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
             c = c[numpy.newaxis, :]
 
     a = numpy.asarray(a) # chkfinite done in qr
-    if (mode == "left" and min(a.shape) != c.shape[0]) or (
-        mode == "right" and a.shape[0] != c.shape[1]):
+    M, N = a.shape
+    if not (mode == "left" and (min(a.shape) == c.shape[0] or
+                    overwrite_c and M > N and M == c.shape[0]) or
+            mode == "right" and  a.shape[0] == c.shape[1]):
         raise ValueError("objects are not aligned") 
 
     raw = qr(a, overwrite_a, lwork, "raw", pivoting)
@@ -237,7 +239,6 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
         gor_un_mqr, = get_lapack_funcs(('unmqr',), (Q,))
         trans = "C"
 
-    M, N = Q.shape
     Q = Q[:, :min(M, N)]
     if M > N and mode == "left":
         if overwrite_c:

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -201,6 +201,12 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
             Q, = safecall(gor_un_gqr, "gorgqr/gungqr", qqr, tau, lwork=lwork,
                 overwrite_a=1)
     else:
+        c = asarray_chkfinite(c)
+        if c.ndim == 1:
+            if mode == "left":
+                c = c[:, numpy.newaxis]
+            else:
+                c = c[numpy.newaxis, :]
         if find_best_lapack_type((a1,))[0] in ('s', 'd'):
             gor_un_mqr, = get_lapack_funcs(('ormqr',), (qr,))
             trans = "T"

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -151,7 +151,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
 
     if pivoting:
         geqp3, = get_lapack_funcs(('geqp3',), (a1,))
-        qr, jpvt, tau = safecall(geqp3, "geqp3", a1, overwrite_a=1)
+        qr, jpvt, tau = safecall(geqp3, "geqp3", a1, overwrite_a=overwrite_a)
         jpvt -= 1 # geqp3 returns a 1-based index array, so subtract 1
     else:
         geqrf, = get_lapack_funcs(('geqrf',), (a1,))

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -8,7 +8,7 @@ from lapack import get_lapack_funcs, find_best_lapack_type
 from misc import _datacopied
 
 # XXX: what is qr_old, should it be kept?
-__all__ = ['qr', 'qr_mult', 'rq', 'qr_old']
+__all__ = ['qr', 'qr_multiply', 'rq', 'qr_old']
 
 def safecall(f, name, *args, **kwargs):
     lwork = kwargs.pop("lwork", None)
@@ -227,7 +227,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
         return Q, R, jpvt
     return Q, R
 
-def qr_mult(a, c, mode='right', pivoting=False, overwrite_a=False,
+def qr_multiply(a, c, mode='right', pivoting=False, overwrite_a=False,
     overwrite_c=False, lwork=None):
     """Calculate the QR decomposition and multiply Q with a matrix.
 

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -38,35 +38,22 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
         Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
         is computed.
     mode : {'full', 'r', 'economic', 'reflectors'} if c is None,
-        or {'left', 'right'} if c is given.
         Determines what information is to be returned: either both Q and R
         ('full', default), only R ('r'), both Q and R but computed in
         economy-size ('economic', see Notes), or the elementary
         reflectors of Q, and R ('reflectors', see Notes).
-        In case c is given, dot(Q, c) is returned if mode is left,
-        dot(c, Q) is returned if mode is right.
         
     pivoting : bool, optional
         Whether or not factorization should include pivoting for rank-revealing
         qr decomposition. If pivoting, compute the decomposition
         :lm:`A P = Q R` as above, but where P is chosen such that the diagonal
         of R is non-increasing.
-    c : array, two-dimensional
-        calculate the product of c and q, depending on the mode:
-        'left': dot(Q, c)
-        'right': dot(c, Q)
-        the shape of c must be appropriate for the matrix multiplications
-    overwrite_c: bool, optional
-        Whether data in c is overwritten (may improve performance)
-        
 
     Returns
     -------
     Q : double or complex ndarray
         Of shape (M, M), or (M, K) for ``mode='economic'``.  Not returned if
         ``mode='r'``.
-    CQ : double or complex ndarray
-        the product of Q and c, as defined in mode
     R : double or complex ndarray
         Of shape (M, N), or (K, N) for ``mode='economic'``.  ``K = min(M, N)``.
     P : integer ndarray
@@ -240,7 +227,59 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
         return Q, R, jpvt
     return Q, R
 
+def qr_mult(*args, **kwargs):
+    """Calculate the QR decomposition and multiply Q with a matrix.
 
+    Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
+    and R upper triangular.
+
+    Parameters
+    ----------
+    a : array, shape (M, N)
+        Matrix to be decomposed
+    overwrite_a : bool, optional
+        Whether data in a is overwritten (may improve performance)
+    lwork : int, optional
+        Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
+        is computed.
+    mode : {'left', 'right'} 
+        dot(Q, c) is returned if mode is 'left',
+        dot(c, Q) is returned if mode is 'right'.
+        
+    pivoting : bool, optional
+        Whether or not factorization should include pivoting for rank-revealing
+        qr decomposition. If pivoting, compute the decomposition
+        :lm:`A P = Q R` as above, but where P is chosen such that the diagonal
+        of R is non-increasing.
+    c : array, two-dimensional
+        calculate the product of c and q, depending on the mode:
+        'left': dot(Q, c)
+        'right': dot(c, Q)
+        the shape of c must be appropriate for the matrix multiplications
+    overwrite_c: bool, optional
+        Whether data in c is overwritten (may improve performance)
+        
+
+    Returns
+    -------
+    CQ : double or complex ndarray
+        the product of Q and c, as defined in mode
+    R : double or complex ndarray
+        Of shape (K, N), ``K = min(M, N)``.
+    P : integer ndarray
+        Of shape (N,) for ``pivoting=True``. Not returned if ``pivoting=False``.
+
+    Raises
+    ------
+    LinAlgError
+        Raised if decomposition fails
+
+    Notes
+    -----
+    This is an interface to the LAPACK routines dgeqrf, zgeqrf,
+    dormqr, zunmqr, dgeqp3, and zgeqp3.
+    """
+    return qr(*args, **kwargs)
 
 def qr_old(a, overwrite_a=False, lwork=None):
     """Compute QR decomposition of a matrix.

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -217,10 +217,9 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
     c = numpy.asarray_chkfinite(c)
     onedim = c.ndim == 1
     if onedim:
+        c = c.reshape(1, len(c))
         if mode == "left":
-            c = c[:, numpy.newaxis]
-        else:
-            c = c[numpy.newaxis, :]
+            c = c.T
 
     a = numpy.asarray(a) # chkfinite done in qr
     M, N = a.shape

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -177,7 +177,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
         dot(c, Q) is returned if mode is 'right'.
         the shape of c must be appropriate for the matrix multiplications,
         if mode is 'left', min(a.shape) == c.shape[0],
-        if mode is 'right', a.shape[0].
+        if mode is 'right', a.shape[0] == c.shape[1].
     pivoting : bool, optional
         Whether or not factorization should include pivoting for rank-revealing
         qr decomposition, see the documentation of qr.
@@ -221,6 +221,11 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
             c = c[:, numpy.newaxis]
         else:
             c = c[numpy.newaxis, :]
+
+    a = numpy.asarray(a) # chkfinite done in qr
+    if (mode == "left" and min(a.shape) != c.shape[0]) or (
+        mode == "right" and a.shape[0] != c.shape[1]):
+        raise ValueError("objects are not aligned") 
 
     raw = qr(a, overwrite_a, lwork, "raw", pivoting)
     Q, tau = raw[:2]

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -212,7 +212,8 @@ def qr_multiply(a, c, mode='right', pivoting=False, overwrite_a=False,
     if not mode in ['left', 'right']:
         raise ValueError("Mode argument should be one of ['left', 'right']")
     c = numpy.asarray_chkfinite(c)
-    if c.ndim == 1:
+    onedim = c.ndim == 1
+    if onedim:
         if mode == "left":
             c = c[:, numpy.newaxis]
         else:
@@ -253,6 +254,8 @@ def qr_multiply(a, c, mode='right', pivoting=False, overwrite_a=False,
         cQ = cQ.T.conjugate()
     if mode == "right":
         cQ = cQ[:, :min(M, N)]
+    if onedim:
+        cQ = cQ.ravel()
 
     return (cQ,) + raw[2:]
 

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -1,10 +1,8 @@
 """QR decomposition functions."""
 
 import numpy
-from numpy import asarray_chkfinite
 
 # Local imports
-import special_matrices
 from blas import get_blas_funcs
 from lapack import get_lapack_funcs, find_best_lapack_type
 from misc import _datacopied
@@ -147,7 +145,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
         raise ValueError(
                  "Mode argument should be one of ['left', 'right']")
 
-    a1 = asarray_chkfinite(a)
+    a1 = numpy.asarray_chkfinite(a)
     if len(a1.shape) != 2:
         raise ValueError("expected 2D array")
     M, N = a1.shape
@@ -201,7 +199,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
             Q, = safecall(gor_un_gqr, "gorgqr/gungqr", qqr, tau, lwork=lwork,
                 overwrite_a=1)
     else:
-        c = asarray_chkfinite(c)
+        c = numpy.asarray_chkfinite(c)
         if c.ndim == 1:
             if mode == "left":
                 c = c[:, numpy.newaxis]
@@ -270,7 +268,7 @@ def qr_old(a, overwrite_a=False, lwork=None):
     Raises LinAlgError if decomposition fails
 
     """
-    a1 = asarray_chkfinite(a)
+    a1 = numpy.asarray_chkfinite(a)
     if len(a1.shape) != 2:
         raise ValueError('expected matrix')
     M,N = a1.shape
@@ -286,7 +284,7 @@ def qr_old(a, overwrite_a=False, lwork=None):
                                                                     % -info)
     gemm, = get_blas_funcs(('gemm',), (qr,))
     t = qr.dtype.char
-    R = special_matrices.triu(qr)
+    R = numpy.triu(qr)
     Q = numpy.identity(M, dtype=t)
     ident = numpy.identity(M, dtype=t)
     zeros = numpy.zeros
@@ -348,7 +346,7 @@ def rq(a, overwrite_a=False, lwork=None, mode='full'):
         raise ValueError(\
                  "Mode argument should be one of ['full', 'r', 'economic']")
 
-    a1 = asarray_chkfinite(a)
+    a1 = numpy.asarray_chkfinite(a)
     if len(a1.shape) != 2:
         raise ValueError('expected matrix')
     M, N = a1.shape
@@ -364,9 +362,9 @@ def rq(a, overwrite_a=False, lwork=None, mode='full'):
         raise ValueError('illegal value in %d-th argument of internal gerqf'
                                                                     % -info)
     if not mode == 'economic' or N < M:
-        R = special_matrices.triu(rq, N-M)
+        R = numpy.triu(rq, N-M)
     else:
-        R = special_matrices.triu(rq[-M:, -M:])
+        R = numpy.triu(rq[-M:, -M:])
 
     if mode == 'r':
         return R

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -8,7 +8,7 @@ from lapack import get_lapack_funcs, find_best_lapack_type
 from misc import _datacopied
 
 # XXX: what is qr_old, should it be kept?
-__all__ = ['qr', 'rq', 'qr_old']
+__all__ = ['qr', 'qr_mult', 'rq', 'qr_old']
 
 def safecall(f, name, *args, **kwargs):
     lwork = kwargs.pop("lwork", None)

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -51,10 +51,10 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
 
     Returns
     -------
-    Q : double or complex ndarray
+    Q : float or complex ndarray
         Of shape (M, M), or (M, K) for ``mode='economic'``.  Not returned if
         ``mode='r'``.
-    R : double or complex ndarray
+    R : float or complex ndarray
         Of shape (M, N), or (K, N) for ``mode='economic'``.  ``K = min(M, N)``.
     P : integer ndarray
         Of shape (N,) for ``pivoting=True``. Not returned if ``pivoting=False``.
@@ -262,9 +262,9 @@ def qr_mult(*args, **kwargs):
 
     Returns
     -------
-    CQ : double or complex ndarray
+    CQ : float or complex ndarray
         the product of Q and c, as defined in mode
-    R : double or complex ndarray
+    R : float or complex ndarray
         Of shape (K, N), ``K = min(M, N)``.
     P : integer ndarray
         Of shape (N,) for ``pivoting=True``. Not returned if ``pivoting=False``.
@@ -299,8 +299,8 @@ def qr_old(a, overwrite_a=False, lwork=None):
 
     Returns
     -------
-    Q : double or complex array, shape (M, M)
-    R : double or complex array, shape (M, N)
+    Q : float or complex array, shape (M, M)
+    R : float or complex array, shape (M, N)
         Size K = min(M, N)
 
     Raises LinAlgError if decomposition fails
@@ -357,8 +357,8 @@ def rq(a, overwrite_a=False, lwork=None, mode='full'):
 
     Returns
     -------
-    R : double array, shape (M, N)
-    Q : double or complex array, shape (M, M)
+    R : float array, shape (M, N)
+    Q : float or complex array, shape (M, M)
 
     Raises LinAlgError if decomposition fails
 

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -170,9 +170,10 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
             return R
 
     if mode == 'reflectors':
-        Q = numpy.tril(qr, -1)
-        numpy.fill_diagonal(Q[:len(tau), :len(tau)], 1)
-        Q[:, :len(tau)] *= tau
+        K = min(M, N)
+        Q = numpy.tril(qr[:, :K], -1)
+        numpy.fill_diagonal(Q[:K, :K], 1)
+        Q *= tau
         if pivoting:
             return Q, R, jpvt
         else:

--- a/scipy/linalg/generic_flapack.pyf
+++ b/scipy/linalg/generic_flapack.pyf
@@ -658,7 +658,7 @@ interface
 
      character intent(in),check(*side=='L'||*side=='R'):: side
      character intent(in),check(*trans=='N'||*trans=='C'):: trans
-     integer intent(hide),depend(side,a,c):: m = (*side=='L')?shape(a,1):shape(c,0)
+     integer intent(hide),depend(c):: m = shape(c,0)
      integer intent(hide),depend(c):: n = shape(c,1)
      integer intent(hide),depend(a):: k = shape(a,1)
      <type_in> dimension(lda,k),intent(in):: a

--- a/scipy/linalg/generic_flapack.pyf
+++ b/scipy/linalg/generic_flapack.pyf
@@ -621,6 +621,56 @@ interface
      integer intent(out) :: info
    end subroutine <tchar=c,z>ungqr
 
+   subroutine <tchar=s,d>ormqr(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
+
+   ! cq,work,info = ormqr(side,trans,a,tau,c,lwork)
+   ! multiplies the real matrix C with the real orthogonal matrix Q,
+   ! which is defined as the first N columns of a product of K elementary
+   ! reflectors of order M (e.g. output of geqrf)
+
+     callstatement (*f2py_func)(side,trans,&m,&n,&k,a,&lda,tau,c,&ldc,work,&lwork,&info)
+     callprotoargument char*,char*,int*,int*,int*,<type_in_c>*,int*,<type_in_c>*,<type_in_c>*,int*,<type_in_c>*,int*,int*
+
+     character intent(in),check(*side=='L'||*side=='R'):: side
+     character intent(in),check(*trans=='N'||*trans=='T'):: trans
+     integer intent(hide),depend(side,a,c):: m = (*side=='L')?shape(a,1):shape(c,0)
+     integer intent(hide),depend(c):: n = shape(c,1)
+     integer intent(hide),depend(a):: k = shape(a,1)
+     <type_in> dimension(lda,k),intent(in):: a
+     integer intent(hide),depend(a):: lda = shape(a, 0)
+     <type_in> dimension(k),intent(in):: tau
+     <type_in> dimension(ldc,n),intent(in,out,copy,out=cq):: c
+     integer intent(hide),depend(c):: ldc = shape(c, 0)
+     <type_in> dimension(MAX(lwork,1)),intent(out):: work
+     integer intent(in):: lwork
+     integer intent(out) :: info
+   end subroutine <tchar=s,d>ormqr
+
+   subroutine <tchar=c,z>unmqr(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
+
+   ! cq,work,info = unmqr(side,trans,a,tau,c,lwork)
+   ! multiplies the complex matrix C with the complex unitary matrix Q,
+   ! which is defined as the first N columns of a product of K elementary
+   ! reflectors of order M (e.g. output of geqrf)
+
+     callstatement (*f2py_func)(side,trans,&m,&n,&k,a,&lda,tau,c,&ldc,work,&lwork,&info)
+     callprotoargument char*,char*,int*,int*,int*,<type_in_c>*,int*,<type_in_c>*,<type_in_c>*,int*,<type_in_c>*,int*,int*
+
+     character intent(in),check(*side=='L'||*side=='R'):: side
+     character intent(in),check(*trans=='N'||*trans=='C'):: trans
+     integer intent(hide),depend(side,a,c):: m = (*side=='L')?shape(a,1):shape(c,0)
+     integer intent(hide),depend(c):: n = shape(c,1)
+     integer intent(hide),depend(a):: k = shape(a,1)
+     <type_in> dimension(lda,k),intent(in):: a
+     integer intent(hide),depend(a):: lda = shape(a, 0)
+     <type_in> dimension(k),intent(in):: tau
+     <type_in> dimension(ldc,n),intent(in,out,copy,out=cq):: c
+     integer intent(hide),depend(c):: ldc = shape(c, 0)
+     <type_in> dimension(MAX(lwork,1)),intent(out):: work
+     integer intent(in):: lwork
+     integer intent(out) :: info
+   end subroutine <tchar=c,z>unmqr
+
    subroutine <tchar=s,d>orgrq(m,n,k,a,tau,work,lwork,info)
 
    ! q,work,info = orgrq(a,lwork=3*n,overwrite_a=0)

--- a/scipy/linalg/generic_flapack.pyf
+++ b/scipy/linalg/generic_flapack.pyf
@@ -633,7 +633,7 @@ interface
 
      character intent(in),check(*side=='L'||*side=='R'):: side
      character intent(in),check(*trans=='N'||*trans=='T'):: trans
-     integer intent(hide),depend(side,a,c):: m = (*side=='L')?shape(a,1):shape(c,0)
+     integer intent(hide),depend(c):: m = shape(c,0)
      integer intent(hide),depend(c):: n = shape(c,1)
      integer intent(hide),depend(a):: k = shape(a,1)
      <type_in> dimension(lda,k),intent(in):: a

--- a/scipy/linalg/info.py
+++ b/scipy/linalg/info.py
@@ -32,8 +32,6 @@ Basics
    pinv - Pseudo-inverse (Moore-Penrose) using lstsq
    pinv2 - Pseudo-inverse using svd
    kron - Kronecker product of two arrays
-   tril - Construct a lower-triangular matrix from a given matrix
-   triu - Construct an upper-triangular matrix from a given matrix
 
 Eigenvalue Problems
 ===================

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -8,14 +8,14 @@ __all__ = ['expm','expm2','expm3','cosm','sinm','tanm','coshm','sinhm',
 from numpy import asarray, Inf, dot, floor, eye, diag, exp, \
      product, logical_not, ravel, transpose, conjugate, \
      cast, log, ogrid, imag, real, absolute, amax, sign, \
-     isfinite, sqrt, identity, single
+     isfinite, sqrt, identity, single, triu
 from numpy import matrix as mat
 import numpy as np
 
 # Local imports
 from misc import norm
 from basic import solve, inv
-from special_matrices import triu, all_mat
+from special_matrices import all_mat
 from decomp import eig
 from decomp_svd import orth, svd
 from decomp_schur import schur, rsf2csf

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -3,122 +3,13 @@ import math
 import numpy as np
 from scipy.misc import comb
 
-__all__ = ['tri', 'tril', 'triu', 'toeplitz', 'circulant', 'hankel',
-           'hadamard', 'leslie', 'all_mat', 'kron', 'block_diag', 'companion',
-           'hilbert', 'invhilbert']
+__all__ = ['toeplitz', 'circulant', 'hankel', 'hadamard', 'leslie', 'all_mat',
+           'kron', 'block_diag', 'companion', 'hilbert', 'invhilbert']
 
 
 #-----------------------------------------------------------------------------
 # matrix construction functions
 #-----------------------------------------------------------------------------
-
-def tri(N, M=None, k=0, dtype=None):
-    """
-    Construct (N, M) matrix filled with ones at and below the k-th diagonal.
-
-    The matrix has A[i,j] == 1 for i <= j + k
-
-    Parameters
-    ----------
-    N : integer
-        The size of the first dimension of the matrix.
-    M : integer or None
-        The size of the second dimension of the matrix. If `M` is None,
-        `M = N` is assumed.
-    k : integer
-        Number of subdiagonal below which matrix is filled with ones.
-        `k` = 0 is the main diagonal, `k` < 0 subdiagonal and `k` > 0
-        superdiagonal.
-    dtype : dtype
-        Data type of the matrix.
-
-    Returns
-    -------
-    A : array, shape (N, M)
-
-    Examples
-    --------
-    >>> from scipy.linalg import tri
-    >>> tri(3, 5, 2, dtype=int)
-    array([[1, 1, 1, 0, 0],
-           [1, 1, 1, 1, 0],
-           [1, 1, 1, 1, 1]])
-    >>> tri(3, 5, -1, dtype=int)
-    array([[0, 0, 0, 0, 0],
-           [1, 0, 0, 0, 0],
-           [1, 1, 0, 0, 0]])
-
-    """
-    if M is None: M = N
-    if type(M) == type('d'):
-        #pearu: any objections to remove this feature?
-        #       As tri(N,'d') is equivalent to tri(N,dtype='d')
-        dtype = M
-        M = N
-    m = np.greater_equal(np.subtract.outer(np.arange(N), np.arange(M)),-k)
-    if dtype is None:
-        return m
-    else:
-        return m.astype(dtype)
-
-def tril(m, k=0):
-    """Construct a copy of a matrix with elements above the k-th diagonal zeroed.
-
-    Parameters
-    ----------
-    m : array
-        Matrix whose elements to return
-    k : integer
-        Diagonal above which to zero elements.
-        k == 0 is the main diagonal, k < 0 subdiagonal and k > 0 superdiagonal.
-
-    Returns
-    -------
-    A : array, shape m.shape, dtype m.dtype
-
-    Examples
-    --------
-    >>> from scipy.linalg import tril
-    >>> tril([[1,2,3],[4,5,6],[7,8,9],[10,11,12]], -1)
-    array([[ 0,  0,  0],
-           [ 4,  0,  0],
-           [ 7,  8,  0],
-           [10, 11, 12]])
-
-    """
-    m = np.asarray(m)
-    out = tri(m.shape[0], m.shape[1], k=k, dtype=m.dtype.char)*m
-    return out
-
-def triu(m, k=0):
-    """Construct a copy of a matrix with elements below the k-th diagonal zeroed.
-
-    Parameters
-    ----------
-    m : array
-        Matrix whose elements to return
-    k : integer
-        Diagonal below which to zero elements.
-        k == 0 is the main diagonal, k < 0 subdiagonal and k > 0 superdiagonal.
-
-    Returns
-    -------
-    A : array, shape m.shape, dtype m.dtype
-
-    Examples
-    --------
-    >>> from scipy.linalg import tril
-    >>> triu([[1,2,3],[4,5,6],[7,8,9],[10,11,12]], -1)
-    array([[ 1,  2,  3],
-           [ 4,  5,  6],
-           [ 0,  8,  9],
-           [ 0,  0, 12]])
-
-    """
-    m = np.asarray(m)
-    out = (1-tri(m.shape[0], m.shape[1], k-1, m.dtype.char))*m
-    return out
-
 
 def toeplitz(c, r=None):
     """

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1212,7 +1212,7 @@ class TestQR(TestCase):
             cq,r = qr(a, mode="right", c=identity(m))
             assert_array_almost_equal(cq, q)
 
-    def test_random_tall(self):
+    def test_random_tall_pivoting(self):
         # full version pivoting
         m = 200
         n = 100
@@ -1239,7 +1239,7 @@ class TestQR(TestCase):
             assert_equal(q.shape, (m,n))
             assert_equal(r.shape, (n,n))
 
-    def test_random_tall_e(self):
+    def test_random_tall_e_pivoting(self):
         # economy version pivoting
         m = 200
         n = 100

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1112,6 +1112,27 @@ class TestQR(TestCase):
         qc,r = qr_multiply(a, identity(3))
         assert_array_almost_equal(q, qc)
 
+    def test_simple_complex_left_conjugate(self):
+        a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
+        q,r = qr(a)
+        c = [1, 2, 3+4j]
+        qc,r = qr_multiply(a, c, "left", conjugate=True)
+        assert_array_almost_equal(dot(q.conjugate(), c), qc)
+
+    def test_simple_complex_tall_left_conjugate(self):
+        a = [[3,3+4j],[5,2+2j],[3,2]]
+        q,r = qr(a)
+        c = [1, 2, 3+4j]
+        qc,r = qr_multiply(a, c, "left", conjugate=True)
+        assert_array_almost_equal(dot(q.conjugate(), c), qc)
+
+    def test_simple_complex_right_conjugate(self):
+        a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
+        q,r = qr(a)
+        c = [1, 2, 3+4j]
+        qc,r = qr_multiply(a, c, conjugate=True)
+        assert_array_almost_equal(dot(c, q.conjugate()), qc)
+
     def test_simple_complex_pivoting(self):
         a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
         q,r,p = qr(a, pivoting=True)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -16,7 +16,7 @@ from numpy.testing import TestCase, assert_equal, assert_array_almost_equal, \
 
 from scipy.linalg import eig, eigvals, lu, svd, svdvals, cholesky, qr, \
      schur, rsf2csf, lu_solve, lu_factor, solve, diagsvd, hessenberg, rq, \
-     eig_banded, eigvals_banded, eigh, eigvalsh, qr_mult, LinAlgError
+     eig_banded, eigvals_banded, eigh, eigvalsh, qr_multiply, LinAlgError
 from scipy.linalg.flapack import dgbtrf, dgbtrs, zgbtrf, zgbtrs, \
      dsbev, dsbevd, dsbevx, zhbevd, zhbevx
 
@@ -867,18 +867,18 @@ class TestQR(TestCase):
         a = [[8,2,3],[2,9,3],[5,3,6]]
         q,r = qr(a)
         c = [1, 2, 3]
-        qc,r = qr_mult(a, c, "left") 
+        qc,r = qr_multiply(a, c, "left") 
         assert_array_almost_equal(dot(q, c), qc[:, 0])
-        qc,r = qr_mult(a, identity(3), "left")
+        qc,r = qr_multiply(a, identity(3), "left")
         assert_array_almost_equal(q, qc)
 
     def test_simple_right(self):
         a = [[8,2,3],[2,9,3],[5,3,6]]
         q,r = qr(a)
         c = [1, 2, 3]
-        qc,r = qr_mult(a, c)
+        qc,r = qr_multiply(a, c)
         assert_array_almost_equal(dot(c, q), qc[0, :])
-        qc,r = qr_mult(a, identity(3))
+        qc,r = qr_multiply(a, identity(3))
         assert_array_almost_equal(q, qc)
 
     def test_simple_pivoting(self):
@@ -896,14 +896,14 @@ class TestQR(TestCase):
         a = [[8,2,3],[2,9,3],[5,3,6]]
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3]
-        qc,r,jpvt = qr_mult(a, c, "left", True)
+        qc,r,jpvt = qr_multiply(a, c, "left", True)
         assert_array_almost_equal(dot(q, c), qc[:, 0])
 
     def test_simple_right_pivoting(self):
         a = [[8,2,3],[2,9,3],[5,3,6]]
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3]
-        qc,r,jpvt = qr_mult(a, c, pivoting=True)
+        qc,r,jpvt = qr_multiply(a, c, pivoting=True)
         assert_array_almost_equal(dot(c, q), qc[0, :])
 
     def test_simple_trap(self):
@@ -967,37 +967,37 @@ class TestQR(TestCase):
         a = [[8,2],[2,9],[5,3]]
         q,r = qr(a, mode="economic") 
         c = [1, 2]
-        qc,r = qr_mult(a, c, "left")
+        qc,r = qr_multiply(a, c, "left")
         assert_array_almost_equal(dot(q, c), qc[:, 0])
-        qc,r = qr_mult(a, identity(2), "left")
+        qc,r = qr_multiply(a, identity(2), "left")
         assert_array_almost_equal(qc, q)
 
     def test_simple_tall_left_pivoting(self):
         a = [[8,2],[2,9],[5,3]]
         q,r,jpvt = qr(a, mode="economic", pivoting=True)
         c = [1, 2]
-        qc,r,kpvt = qr_mult(a, c, "left", True)
+        qc,r,kpvt = qr_multiply(a, c, "left", True)
         assert_array_equal(jpvt, kpvt)
         assert_array_almost_equal(dot(q, c), qc[:, 0])
-        qc,r,jpvt = qr_mult(a, identity(2), "left", True)
+        qc,r,jpvt = qr_multiply(a, identity(2), "left", True)
         assert_array_almost_equal(qc, q)
 
     def test_simple_tall_right(self):
         a = [[8,2],[2,9],[5,3]]
         q,r = qr(a, mode="economic")
         c = [1, 2, 3]
-        cq,r = qr_mult(a, c)
+        cq,r = qr_multiply(a, c)
         assert_array_almost_equal(dot(c, q), cq[0, :])
-        cq,r = qr_mult(a, identity(3))
+        cq,r = qr_multiply(a, identity(3))
         assert_array_almost_equal(cq, q)
 
     def test_simple_tall_right_pivoting(self):
         a = [[8,2],[2,9],[5,3]]
         q,r,jpvt = qr(a, pivoting=True, mode="economic")
         c = [1, 2, 3]
-        cq,r,jpvt = qr_mult(a, c, pivoting=True)
+        cq,r,jpvt = qr_multiply(a, c, pivoting=True)
         assert_array_almost_equal(dot(c, q), cq[0, :])
-        cq,r,jpvt = qr_mult(a, identity(3), pivoting=True)
+        cq,r,jpvt = qr_multiply(a, identity(3), pivoting=True)
         assert_array_almost_equal(cq, q)
 
     def test_simple_fat(self):
@@ -1050,36 +1050,36 @@ class TestQR(TestCase):
         a = [[8,2,3],[2,9,5]]
         q,r = qr(a, mode="economic") 
         c = [1, 2]
-        qc,r = qr_mult(a, c, "left")
+        qc,r = qr_multiply(a, c, "left")
         assert_array_almost_equal(dot(q, c), qc[:, 0])
-        qc,r = qr_mult(a, identity(2), "left")
+        qc,r = qr_multiply(a, identity(2), "left")
         assert_array_almost_equal(qc, q)
 
     def test_simple_fat_left_pivoting(self):
         a = [[8,2,3],[2,9,5]]
         q,r,jpvt = qr(a, mode="economic", pivoting=True)
         c = [1, 2]
-        qc,r,jpvt = qr_mult(a, c, "left", True)
+        qc,r,jpvt = qr_multiply(a, c, "left", True)
         assert_array_almost_equal(dot(q, c), qc[:, 0])
-        qc,r,jpvt = qr_mult(a, identity(2), "left", True)
+        qc,r,jpvt = qr_multiply(a, identity(2), "left", True)
         assert_array_almost_equal(qc, q)
 
     def test_simple_fat_right(self):
         a = [[8,2,3],[2,9,5]]
         q,r = qr(a, mode="economic")
         c = [1, 2]
-        cq,r = qr_mult(a, c)
+        cq,r = qr_multiply(a, c)
         assert_array_almost_equal(dot(c, q), cq[0, :])
-        cq,r = qr_mult(a, identity(2))
+        cq,r = qr_multiply(a, identity(2))
         assert_array_almost_equal(cq, q)
 
     def test_simple_fat_right_pivoting(self):
         a = [[8,2,3],[2,9,5]]
         q,r,jpvt = qr(a, pivoting=True, mode="economic")
         c = [1, 2]
-        cq,r,jpvt = qr_mult(a, c, pivoting=True)
+        cq,r,jpvt = qr_multiply(a, c, pivoting=True)
         assert_array_almost_equal(dot(c, q), cq[0, :])
-        cq,r,jpvt = qr_mult(a, identity(2), pivoting=True)
+        cq,r,jpvt = qr_multiply(a, identity(2), pivoting=True)
         assert_array_almost_equal(cq, q)
 
     def test_simple_complex(self):
@@ -1092,18 +1092,18 @@ class TestQR(TestCase):
         a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
         q,r = qr(a)
         c = [1, 2, 3+4j]
-        qc,r = qr_mult(a, c, "left")
+        qc,r = qr_multiply(a, c, "left")
         assert_array_almost_equal(dot(q, c), qc[:, 0])
-        qc,r = qr_mult(a, identity(3), "left")
+        qc,r = qr_multiply(a, identity(3), "left")
         assert_array_almost_equal(q, qc)
 
     def test_simple_complex_right(self):
         a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
         q,r = qr(a)
         c = [1, 2, 3+4j]
-        qc,r = qr_mult(a, c)
+        qc,r = qr_multiply(a, c)
         assert_array_almost_equal(dot(c, q), qc[0, :])
-        qc,r = qr_mult(a, identity(3))
+        qc,r = qr_multiply(a, identity(3))
         assert_array_almost_equal(q, qc)
 
     def test_simple_complex_pivoting(self):
@@ -1121,14 +1121,14 @@ class TestQR(TestCase):
         a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3+4j]
-        qc,r,jpvt = qr_mult(a, c, "left", True)
+        qc,r,jpvt = qr_multiply(a, c, "left", True)
         assert_array_almost_equal(dot(q, c), qc[:, 0])
 
     def test_simple_complex_right_pivoting(self):
         a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3+4j]
-        qc,r,jpvt = qr_mult(a, c, pivoting=True)
+        qc,r,jpvt = qr_multiply(a, c, pivoting=True)
         assert_array_almost_equal(dot(c, q), qc[0, :])
 
     def test_random(self):
@@ -1145,9 +1145,9 @@ class TestQR(TestCase):
             a = random([n,n])
             q,r = qr(a)
             c = random([n])
-            qc,r = qr_mult(a, c, "left")
+            qc,r = qr_multiply(a, c, "left")
             assert_array_almost_equal(dot(q, c), qc[:, 0])
-            qc,r = qr_mult(a, identity(n), "left")
+            qc,r = qr_multiply(a, identity(n), "left")
             assert_array_almost_equal(q, qc)
 
     def test_random_right(self):
@@ -1156,9 +1156,9 @@ class TestQR(TestCase):
             a = random([n,n])
             q,r = qr(a)
             c = random([n])
-            cq,r = qr_mult(a, c)
+            cq,r = qr_multiply(a, c)
             assert_array_almost_equal(dot(c, q), cq[0, :])
-            cq,r = qr_mult(a, identity(n))
+            cq,r = qr_multiply(a, identity(n))
             assert_array_almost_equal(q, cq)
 
     def test_random_pivoting(self):
@@ -1192,9 +1192,9 @@ class TestQR(TestCase):
             a = random([m,n])
             q,r = qr(a, mode="economic") 
             c = random([n])
-            qc,r = qr_mult(a, c, "left")
+            qc,r = qr_multiply(a, c, "left")
             assert_array_almost_equal(dot(q, c), qc[:, 0])
-            qc,r = qr_mult(a, identity(n), "left")
+            qc,r = qr_multiply(a, identity(n), "left")
             assert_array_almost_equal(qc, q)
 
     def test_random_tall_right(self):
@@ -1205,9 +1205,9 @@ class TestQR(TestCase):
             a = random([m,n])
             q,r = qr(a, mode="economic") 
             c = random([m])
-            cq,r = qr_mult(a, c)
+            cq,r = qr_multiply(a, c)
             assert_array_almost_equal(dot(c, q), cq[0, :])
-            cq,r = qr_mult(a, identity(m))
+            cq,r = qr_multiply(a, identity(m))
             assert_array_almost_equal(cq, q)
 
     def test_random_tall_pivoting(self):
@@ -1291,9 +1291,9 @@ class TestQR(TestCase):
             a = random([n,n])+1j*random([n,n])
             q,r = qr(a)
             c = random([n])+1j*random([n])
-            qc,r = qr_mult(a, c, "left")
+            qc,r = qr_multiply(a, c, "left")
             assert_array_almost_equal(dot(q, c), qc[:, 0])
-            qc,r = qr_mult(a, identity(n), "left")
+            qc,r = qr_multiply(a, identity(n), "left")
             assert_array_almost_equal(q, qc)
 
     def test_random_complex_right(self):
@@ -1302,9 +1302,9 @@ class TestQR(TestCase):
             a = random([n,n])+1j*random([n,n])
             q,r = qr(a)
             c = random([n])+1j*random([n])
-            cq,r = qr_mult(a, c)
+            cq,r = qr_multiply(a, c)
             assert_array_almost_equal(dot(c, q), cq[0, :])
-            cq,r = qr_mult(a, identity(n))
+            cq,r = qr_multiply(a, identity(n))
             assert_array_almost_equal(q, cq)
 
     def test_random_complex_pivoting(self):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -898,7 +898,7 @@ class TestQR(TestCase):
         a = [[8,2,3],[2,9,3],[5,3,6]]
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3]
-        qc,r,jpvt = qr_multiply(a, c, "left", True)
+        qc,r,jpvt = qr_multiply(a, c, "left", pivoting=True)
         assert_array_almost_equal(dot(q, c), qc)
 
     def test_simple_right_pivoting(self):
@@ -982,10 +982,10 @@ class TestQR(TestCase):
         a = [[8,2],[2,9],[5,3]]
         q,r,jpvt = qr(a, mode="economic", pivoting=True)
         c = [1, 2]
-        qc,r,kpvt = qr_multiply(a, c, "left", True)
+        qc,r,kpvt = qr_multiply(a, c, "left", pivoting=True)
         assert_array_equal(jpvt, kpvt)
         assert_array_almost_equal(dot(q, c), qc)
-        qc,r,jpvt = qr_multiply(a, identity(2), "left", True)
+        qc,r,jpvt = qr_multiply(a, identity(2), "left", pivoting=True)
         assert_array_almost_equal(qc, q)
 
     def test_simple_tall_right(self):
@@ -1067,9 +1067,9 @@ class TestQR(TestCase):
         a = [[8,2,3],[2,9,5]]
         q,r,jpvt = qr(a, mode="economic", pivoting=True)
         c = [1, 2]
-        qc,r,jpvt = qr_multiply(a, c, "left", True)
+        qc,r,jpvt = qr_multiply(a, c, "left", pivoting=True)
         assert_array_almost_equal(dot(q, c), qc)
-        qc,r,jpvt = qr_multiply(a, identity(2), "left", True)
+        qc,r,jpvt = qr_multiply(a, identity(2), "left", pivoting=True)
         assert_array_almost_equal(qc, q)
 
     def test_simple_fat_right(self):
@@ -1151,7 +1151,7 @@ class TestQR(TestCase):
         a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3+4j]
-        qc,r,jpvt = qr_multiply(a, c, "left", True)
+        qc,r,jpvt = qr_multiply(a, c, "left", pivoting=True)
         assert_array_almost_equal(dot(q, c), qc)
 
     def test_simple_complex_right_pivoting(self):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -868,7 +868,7 @@ class TestQR(TestCase):
         q,r = qr(a)
         c = [1, 2, 3]
         qc,r2 = qr_multiply(a, c, "left") 
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
         assert_array_almost_equal(r, r2)
         qc,r2 = qr_multiply(a, identity(3), "left")
         assert_array_almost_equal(q, qc)
@@ -878,7 +878,7 @@ class TestQR(TestCase):
         q,r = qr(a)
         c = [1, 2, 3]
         qc,r2 = qr_multiply(a, c)
-        assert_array_almost_equal(dot(c, q), qc[0, :])
+        assert_array_almost_equal(dot(c, q), qc)
         assert_array_almost_equal(r, r2)
         qc,r = qr_multiply(a, identity(3))
         assert_array_almost_equal(q, qc)
@@ -899,14 +899,14 @@ class TestQR(TestCase):
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3]
         qc,r,jpvt = qr_multiply(a, c, "left", True)
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
 
     def test_simple_right_pivoting(self):
         a = [[8,2,3],[2,9,3],[5,3,6]]
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3]
         qc,r,jpvt = qr_multiply(a, c, pivoting=True)
-        assert_array_almost_equal(dot(c, q), qc[0, :])
+        assert_array_almost_equal(dot(c, q), qc)
 
     def test_simple_trap(self):
         a = [[8,2,3],[2,9,3]]
@@ -970,7 +970,7 @@ class TestQR(TestCase):
         q,r = qr(a, mode="economic") 
         c = [1, 2]
         qc,r2 = qr_multiply(a, c, "left")
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
         assert_array_almost_equal(r, r2)
         qc,r = qr_multiply(a, identity(2), "left")
         assert_array_almost_equal(qc, q)
@@ -981,7 +981,7 @@ class TestQR(TestCase):
         c = [1, 2]
         qc,r,kpvt = qr_multiply(a, c, "left", True)
         assert_array_equal(jpvt, kpvt)
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
         qc,r,jpvt = qr_multiply(a, identity(2), "left", True)
         assert_array_almost_equal(qc, q)
 
@@ -990,7 +990,7 @@ class TestQR(TestCase):
         q,r = qr(a, mode="economic")
         c = [1, 2, 3]
         cq,r2 = qr_multiply(a, c)
-        assert_array_almost_equal(dot(c, q), cq[0, :])
+        assert_array_almost_equal(dot(c, q), cq)
         assert_array_almost_equal(r, r2)
         cq,r = qr_multiply(a, identity(3))
         assert_array_almost_equal(cq, q)
@@ -1000,7 +1000,7 @@ class TestQR(TestCase):
         q,r,jpvt = qr(a, pivoting=True, mode="economic")
         c = [1, 2, 3]
         cq,r,jpvt = qr_multiply(a, c, pivoting=True)
-        assert_array_almost_equal(dot(c, q), cq[0, :])
+        assert_array_almost_equal(dot(c, q), cq)
         cq,r,jpvt = qr_multiply(a, identity(3), pivoting=True)
         assert_array_almost_equal(cq, q)
 
@@ -1055,7 +1055,7 @@ class TestQR(TestCase):
         q,r = qr(a, mode="economic") 
         c = [1, 2]
         qc,r2 = qr_multiply(a, c, "left")
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
         assert_array_almost_equal(r, r2)
         qc,r = qr_multiply(a, identity(2), "left")
         assert_array_almost_equal(qc, q)
@@ -1065,7 +1065,7 @@ class TestQR(TestCase):
         q,r,jpvt = qr(a, mode="economic", pivoting=True)
         c = [1, 2]
         qc,r,jpvt = qr_multiply(a, c, "left", True)
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
         qc,r,jpvt = qr_multiply(a, identity(2), "left", True)
         assert_array_almost_equal(qc, q)
 
@@ -1074,7 +1074,7 @@ class TestQR(TestCase):
         q,r = qr(a, mode="economic")
         c = [1, 2]
         cq,r2 = qr_multiply(a, c)
-        assert_array_almost_equal(dot(c, q), cq[0, :])
+        assert_array_almost_equal(dot(c, q), cq)
         assert_array_almost_equal(r, r2)
         cq,r = qr_multiply(a, identity(2))
         assert_array_almost_equal(cq, q)
@@ -1084,7 +1084,7 @@ class TestQR(TestCase):
         q,r,jpvt = qr(a, pivoting=True, mode="economic")
         c = [1, 2]
         cq,r,jpvt = qr_multiply(a, c, pivoting=True)
-        assert_array_almost_equal(dot(c, q), cq[0, :])
+        assert_array_almost_equal(dot(c, q), cq)
         cq,r,jpvt = qr_multiply(a, identity(2), pivoting=True)
         assert_array_almost_equal(cq, q)
 
@@ -1099,7 +1099,7 @@ class TestQR(TestCase):
         q,r = qr(a)
         c = [1, 2, 3+4j]
         qc,r = qr_multiply(a, c, "left")
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
         qc,r = qr_multiply(a, identity(3), "left")
         assert_array_almost_equal(q, qc)
 
@@ -1108,7 +1108,7 @@ class TestQR(TestCase):
         q,r = qr(a)
         c = [1, 2, 3+4j]
         qc,r = qr_multiply(a, c)
-        assert_array_almost_equal(dot(c, q), qc[0, :])
+        assert_array_almost_equal(dot(c, q), qc)
         qc,r = qr_multiply(a, identity(3))
         assert_array_almost_equal(q, qc)
 
@@ -1128,14 +1128,14 @@ class TestQR(TestCase):
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3+4j]
         qc,r,jpvt = qr_multiply(a, c, "left", True)
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
 
     def test_simple_complex_right_pivoting(self):
         a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3+4j]
         qc,r,jpvt = qr_multiply(a, c, pivoting=True)
-        assert_array_almost_equal(dot(c, q), qc[0, :])
+        assert_array_almost_equal(dot(c, q), qc)
 
     def test_random(self):
         n = 20
@@ -1152,7 +1152,7 @@ class TestQR(TestCase):
             q,r = qr(a)
             c = random([n])
             qc,r = qr_multiply(a, c, "left")
-            assert_array_almost_equal(dot(q, c), qc[:, 0])
+            assert_array_almost_equal(dot(q, c), qc)
             qc,r = qr_multiply(a, identity(n), "left")
             assert_array_almost_equal(q, qc)
 
@@ -1163,7 +1163,7 @@ class TestQR(TestCase):
             q,r = qr(a)
             c = random([n])
             cq,r = qr_multiply(a, c)
-            assert_array_almost_equal(dot(c, q), cq[0, :])
+            assert_array_almost_equal(dot(c, q), cq)
             cq,r = qr_multiply(a, identity(n))
             assert_array_almost_equal(q, cq)
 
@@ -1199,7 +1199,7 @@ class TestQR(TestCase):
             q,r = qr(a, mode="economic") 
             c = random([n])
             qc,r = qr_multiply(a, c, "left")
-            assert_array_almost_equal(dot(q, c), qc[:, 0])
+            assert_array_almost_equal(dot(q, c), qc)
             qc,r = qr_multiply(a, identity(n), "left")
             assert_array_almost_equal(qc, q)
 
@@ -1212,7 +1212,7 @@ class TestQR(TestCase):
             q,r = qr(a, mode="economic") 
             c = random([m])
             cq,r = qr_multiply(a, c)
-            assert_array_almost_equal(dot(c, q), cq[0, :])
+            assert_array_almost_equal(dot(c, q), cq)
             cq,r = qr_multiply(a, identity(m))
             assert_array_almost_equal(cq, q)
 
@@ -1298,7 +1298,7 @@ class TestQR(TestCase):
             q,r = qr(a)
             c = random([n])+1j*random([n])
             qc,r = qr_multiply(a, c, "left")
-            assert_array_almost_equal(dot(q, c), qc[:, 0])
+            assert_array_almost_equal(dot(q, c), qc)
             qc,r = qr_multiply(a, identity(n), "left")
             assert_array_almost_equal(q, qc)
 
@@ -1309,7 +1309,7 @@ class TestQR(TestCase):
             q,r = qr(a)
             c = random([n])+1j*random([n])
             cq,r = qr_multiply(a, c)
-            assert_array_almost_equal(dot(c, q), cq[0, :])
+            assert_array_almost_equal(dot(c, q), cq)
             cq,r = qr_multiply(a, identity(n))
             assert_array_almost_equal(q, cq)
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1115,6 +1115,19 @@ class TestQR(TestCase):
         qc,r = qr_multiply(a, identity(3))
         assert_array_almost_equal(q, qc)
 
+    def test_simple_tall_complex_left(self):
+        a = [[8,2+3j],[2,9],[5+7j,3]]
+        q,r = qr(a, mode="economic") 
+        c = [1, 2+2j]
+        qc,r2 = qr_multiply(a, c, "left")
+        assert_array_almost_equal(dot(q, c), qc)
+        assert_array_almost_equal(r, r2)
+        c = array([1,2,0])
+        qc,r2 = qr_multiply(a, c, "left", overwrite_c=True)
+        assert_array_almost_equal(dot(q, c[:2]), qc)
+        qc,r = qr_multiply(a, identity(2), "left")
+        assert_array_almost_equal(qc, q)
+
     def test_simple_complex_left_conjugate(self):
         a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
         q,r = qr(a)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -898,8 +898,6 @@ class TestQR(TestCase):
     def test_simple_left_pivoting(self):
         a = [[8,2,3],[2,9,3],[5,3,6]]
         q,r,jpvt = qr(a, pivoting=True)
-        d = abs(diag(r))
-        assert_(all(d[1:] <= d[:-1]))
         c = [1, 2, 3]
         qc,r,jpvt = qr(a, mode="left", pivoting=True, c=c)
         assert_array_almost_equal(dot(q, c), qc[:, 0])
@@ -907,8 +905,6 @@ class TestQR(TestCase):
     def test_simple_right_pivoting(self):
         a = [[8,2,3],[2,9,3],[5,3,6]]
         q,r,jpvt = qr(a, pivoting=True)
-        d = abs(diag(r))
-        assert_(all(d[1:] <= d[:-1]))
         c = [1, 2, 3]
         qc,r,jpvt = qr(a, mode="right", pivoting=True, c=c)
         assert_array_almost_equal(dot(c, q), qc[0, :])
@@ -982,8 +978,6 @@ class TestQR(TestCase):
     def test_simple_tall_left_pivoting(self):
         a = [[8,2],[2,9],[5,3]]
         q,r,jpvt = qr(a, mode="economic", pivoting=True)
-        d = abs(diag(r))
-        assert_(all(d[1:] <= d[:-1]))
         c = [1, 2]
         qc,r,jpvt = qr(a, pivoting="True", mode="left", c=c)
         assert_array_almost_equal(dot(q, c), qc[:, 0])
@@ -1002,8 +996,6 @@ class TestQR(TestCase):
     def test_simple_tall_right_pivoting(self):
         a = [[8,2],[2,9],[5,3]]
         q,r,jpvt = qr(a, pivoting=True, mode="economic")
-        d = abs(diag(r))
-        assert_(all(d[1:] <= d[:-1]))
         c = [1, 2, 3]
         cq,r,jpvt = qr(a, pivoting="True", mode="right", c=c)
         assert_array_almost_equal(dot(c, q), cq[0, :])
@@ -1068,8 +1060,6 @@ class TestQR(TestCase):
     def test_simple_fat_left_pivoting(self):
         a = [[8,2,3],[2,9,5]]
         q,r,jpvt = qr(a, mode="economic", pivoting=True)
-        d = abs(diag(r))
-        assert_(all(d[1:] <= d[:-1]))
         c = [1, 2]
         qc,r,jpvt = qr(a, pivoting="True", mode="left", c=c)
         assert_array_almost_equal(dot(q, c), qc[:, 0])
@@ -1088,8 +1078,6 @@ class TestQR(TestCase):
     def test_simple_fat_right_pivoting(self):
         a = [[8,2,3],[2,9,5]]
         q,r,jpvt = qr(a, pivoting=True, mode="economic")
-        d = abs(diag(r))
-        assert_(all(d[1:] <= d[:-1]))
         c = [1, 2]
         cq,r,jpvt = qr(a, pivoting="True", mode="right", c=c)
         assert_array_almost_equal(dot(c, q), cq[0, :])
@@ -1134,8 +1122,6 @@ class TestQR(TestCase):
     def test_simple_complex_left_pivoting(self):
         a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
         q,r,jpvt = qr(a, pivoting=True)
-        d = abs(diag(r))
-        assert_(all(d[1:] <= d[:-1]))
         c = [1, 2, 3+4j]
         qc,r,jpvt = qr(a, mode="left", pivoting=True, c=c)
         assert_array_almost_equal(dot(q, c), qc[:, 0])
@@ -1143,8 +1129,6 @@ class TestQR(TestCase):
     def test_simple_complex_right_pivoting(self):
         a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
         q,r,jpvt = qr(a, pivoting=True)
-        d = abs(diag(r))
-        assert_(all(d[1:] <= d[:-1]))
         c = [1, 2, 3+4j]
         qc,r,jpvt = qr(a, mode="right", pivoting=True, c=c)
         assert_array_almost_equal(dot(c, q), qc[0, :])

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1121,8 +1121,8 @@ class TestQR(TestCase):
 
     def test_simple_complex_tall_left_conjugate(self):
         a = [[3,3+4j],[5,2+2j],[3,2]]
-        q,r = qr(a)
-        c = [1, 2, 3+4j]
+        q,r = qr(a, mode='economic')
+        c = [1, 3+4j]
         qc,r = qr_multiply(a, c, "left", conjugate=True)
         assert_array_almost_equal(dot(q.conjugate(), c), qc)
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -867,17 +867,19 @@ class TestQR(TestCase):
         a = [[8,2,3],[2,9,3],[5,3,6]]
         q,r = qr(a)
         c = [1, 2, 3]
-        qc,r = qr_multiply(a, c, "left") 
+        qc,r2 = qr_multiply(a, c, "left") 
         assert_array_almost_equal(dot(q, c), qc[:, 0])
-        qc,r = qr_multiply(a, identity(3), "left")
+        assert_array_almost_equal(r, r2)
+        qc,r2 = qr_multiply(a, identity(3), "left")
         assert_array_almost_equal(q, qc)
 
     def test_simple_right(self):
         a = [[8,2,3],[2,9,3],[5,3,6]]
         q,r = qr(a)
         c = [1, 2, 3]
-        qc,r = qr_multiply(a, c)
+        qc,r2 = qr_multiply(a, c)
         assert_array_almost_equal(dot(c, q), qc[0, :])
+        assert_array_almost_equal(r, r2)
         qc,r = qr_multiply(a, identity(3))
         assert_array_almost_equal(q, qc)
 
@@ -967,8 +969,9 @@ class TestQR(TestCase):
         a = [[8,2],[2,9],[5,3]]
         q,r = qr(a, mode="economic") 
         c = [1, 2]
-        qc,r = qr_multiply(a, c, "left")
+        qc,r2 = qr_multiply(a, c, "left")
         assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(r, r2)
         qc,r = qr_multiply(a, identity(2), "left")
         assert_array_almost_equal(qc, q)
 
@@ -986,8 +989,9 @@ class TestQR(TestCase):
         a = [[8,2],[2,9],[5,3]]
         q,r = qr(a, mode="economic")
         c = [1, 2, 3]
-        cq,r = qr_multiply(a, c)
+        cq,r2 = qr_multiply(a, c)
         assert_array_almost_equal(dot(c, q), cq[0, :])
+        assert_array_almost_equal(r, r2)
         cq,r = qr_multiply(a, identity(3))
         assert_array_almost_equal(cq, q)
 
@@ -1050,8 +1054,9 @@ class TestQR(TestCase):
         a = [[8,2,3],[2,9,5]]
         q,r = qr(a, mode="economic") 
         c = [1, 2]
-        qc,r = qr_multiply(a, c, "left")
+        qc,r2 = qr_multiply(a, c, "left")
         assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(r, r2)
         qc,r = qr_multiply(a, identity(2), "left")
         assert_array_almost_equal(qc, q)
 
@@ -1068,8 +1073,9 @@ class TestQR(TestCase):
         a = [[8,2,3],[2,9,5]]
         q,r = qr(a, mode="economic")
         c = [1, 2]
-        cq,r = qr_multiply(a, c)
+        cq,r2 = qr_multiply(a, c)
         assert_array_almost_equal(dot(c, q), cq[0, :])
+        assert_array_almost_equal(r, r2)
         cq,r = qr_multiply(a, identity(2))
         assert_array_almost_equal(cq, q)
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -862,6 +862,27 @@ class TestQR(TestCase):
         q,r = qr(a)
         assert_array_almost_equal(dot(transpose(q),q),identity(3))
         assert_array_almost_equal(dot(q,r),a)
+        c = [1, 2, 3]
+        qc,r = qr(a, mode="left", c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+
+    def test_simple_left(self):
+        a = [[8,2,3],[2,9,3],[5,3,6]]
+        q,r = qr(a)
+        c = [1, 2, 3]
+        qc,r = qr(a, mode="left", c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        qc,r = qr(a, mode="left", c=identity(3))
+        assert_array_almost_equal(q, qc)
+
+    def test_simple_right(self):
+        a = [[8,2,3],[2,9,3],[5,3,6]]
+        q,r = qr(a)
+        c = [1, 2, 3]
+        qc,r = qr(a, mode="right", c=c)
+        assert_array_almost_equal(dot(c, q), qc[0, :])
+        qc,r = qr(a, mode="right", c=identity(3))
+        assert_array_almost_equal(q, qc)
 
     def test_simple_pivoting(self):
         a = np.asarray([[8,2,3],[2,9,3],[5,3,6]])
@@ -873,6 +894,24 @@ class TestQR(TestCase):
         q2,r2 = qr(a[:,p])
         assert_array_almost_equal(q,q2)
         assert_array_almost_equal(r,r2)
+
+    def test_simple_left_pivoting(self):
+        a = [[8,2,3],[2,9,3],[5,3,6]]
+        q,r,jpvt = qr(a, pivoting=True)
+        d = abs(diag(r))
+        assert_(all(d[1:] <= d[:-1]))
+        c = [1, 2, 3]
+        qc,r,jpvt = qr(a, mode="left", pivoting=True, c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+
+    def test_simple_right_pivoting(self):
+        a = [[8,2,3],[2,9,3],[5,3,6]]
+        q,r,jpvt = qr(a, pivoting=True)
+        d = abs(diag(r))
+        assert_(all(d[1:] <= d[:-1]))
+        c = [1, 2, 3]
+        qc,r,jpvt = qr(a, mode="right", pivoting=True, c=c)
+        assert_array_almost_equal(dot(c, q), qc[0, :])
 
     def test_simple_trap(self):
         a = [[8,2,3],[2,9,3]]
@@ -931,6 +970,46 @@ class TestQR(TestCase):
         assert_array_almost_equal(q,q2)
         assert_array_almost_equal(r,r2)
 
+    def test_simple_tall_left(self):
+        a = [[8,2],[2,9],[5,3]]
+        q,r = qr(a, mode="economic") 
+        c = [1, 2]
+        qc,r = qr(a, mode="left", c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        qc,r = qr(a, mode="left", c=identity(2))
+        assert_array_almost_equal(qc, q)
+
+    def test_simple_tall_left_pivoting(self):
+        a = [[8,2],[2,9],[5,3]]
+        q,r,jpvt = qr(a, mode="economic", pivoting=True)
+        d = abs(diag(r))
+        assert_(all(d[1:] <= d[:-1]))
+        c = [1, 2]
+        qc,r,jpvt = qr(a, pivoting="True", mode="left", c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        qc,r,jpvt = qr(a, pivoting="True", mode="left", c=identity(2))
+        assert_array_almost_equal(qc, q)
+
+    def test_simple_tall_right(self):
+        a = [[8,2],[2,9],[5,3]]
+        q,r = qr(a, mode="economic")
+        c = [1, 2, 3]
+        cq,r = qr(a, mode="right", c=c)
+        assert_array_almost_equal(dot(c, q), cq[0, :])
+        cq,r = qr(a, mode="right", c=identity(3))
+        assert_array_almost_equal(cq, q)
+
+    def test_simple_tall_right_pivoting(self):
+        a = [[8,2],[2,9],[5,3]]
+        q,r,jpvt = qr(a, pivoting=True, mode="economic")
+        d = abs(diag(r))
+        assert_(all(d[1:] <= d[:-1]))
+        c = [1, 2, 3]
+        cq,r,jpvt = qr(a, pivoting="True", mode="right", c=c)
+        assert_array_almost_equal(dot(c, q), cq[0, :])
+        cq,r,jpvt = qr(a, pivoting="True", mode="right", c=identity(3))
+        assert_array_almost_equal(cq, q)
+
     def test_simple_fat(self):
         # full version
         a = [[8,2,5],[2,9,3]]
@@ -977,11 +1056,69 @@ class TestQR(TestCase):
         assert_array_almost_equal(q,q2)
         assert_array_almost_equal(r,r2)
 
+    def test_simple_fat_left(self):
+        a = [[8,2,3],[2,9,5]]
+        q,r = qr(a, mode="economic") 
+        c = [1, 2]
+        qc,r = qr(a, mode="left", c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        qc,r = qr(a, mode="left", c=identity(2))
+        assert_array_almost_equal(qc, q)
+
+    def test_simple_fat_left_pivoting(self):
+        a = [[8,2,3],[2,9,5]]
+        q,r,jpvt = qr(a, mode="economic", pivoting=True)
+        d = abs(diag(r))
+        assert_(all(d[1:] <= d[:-1]))
+        c = [1, 2]
+        qc,r,jpvt = qr(a, pivoting="True", mode="left", c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        qc,r,jpvt = qr(a, pivoting="True", mode="left", c=identity(2))
+        assert_array_almost_equal(qc, q)
+
+    def test_simple_fat_right(self):
+        a = [[8,2,3],[2,9,5]]
+        q,r = qr(a, mode="economic")
+        c = [1, 2]
+        cq,r = qr(a, mode="right", c=c)
+        assert_array_almost_equal(dot(c, q), cq[0, :])
+        cq,r = qr(a, mode="right", c=identity(2))
+        assert_array_almost_equal(cq, q)
+
+    def test_simple_fat_right_pivoting(self):
+        a = [[8,2,3],[2,9,5]]
+        q,r,jpvt = qr(a, pivoting=True, mode="economic")
+        d = abs(diag(r))
+        assert_(all(d[1:] <= d[:-1]))
+        c = [1, 2]
+        cq,r,jpvt = qr(a, pivoting="True", mode="right", c=c)
+        assert_array_almost_equal(dot(c, q), cq[0, :])
+        cq,r,jpvt = qr(a, pivoting="True", mode="right", c=identity(2))
+        assert_array_almost_equal(cq, q)
+
     def test_simple_complex(self):
         a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
         q,r = qr(a)
         assert_array_almost_equal(dot(conj(transpose(q)),q),identity(3))
         assert_array_almost_equal(dot(q,r),a)
+
+    def test_simple_complex_left(self):
+        a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
+        q,r = qr(a)
+        c = [1, 2, 3+4j]
+        qc,r = qr(a, mode="left", c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        qc,r = qr(a, mode="left", c=identity(3))
+        assert_array_almost_equal(q, qc)
+
+    def test_simple_complex_right(self):
+        a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
+        q,r = qr(a)
+        c = [1, 2, 3+4j]
+        qc,r = qr(a, mode="right", c=c)
+        assert_array_almost_equal(dot(c, q), qc[0, :])
+        qc,r = qr(a, mode="right", c=identity(3))
+        assert_array_almost_equal(q, qc)
 
     def test_simple_complex_pivoting(self):
         a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
@@ -994,6 +1131,24 @@ class TestQR(TestCase):
         assert_array_almost_equal(q,q2)
         assert_array_almost_equal(r,r2)
 
+    def test_simple_complex_left_pivoting(self):
+        a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
+        q,r,jpvt = qr(a, pivoting=True)
+        d = abs(diag(r))
+        assert_(all(d[1:] <= d[:-1]))
+        c = [1, 2, 3+4j]
+        qc,r,jpvt = qr(a, mode="left", pivoting=True, c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+
+    def test_simple_complex_right_pivoting(self):
+        a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
+        q,r,jpvt = qr(a, pivoting=True)
+        d = abs(diag(r))
+        assert_(all(d[1:] <= d[:-1]))
+        c = [1, 2, 3+4j]
+        qc,r,jpvt = qr(a, mode="right", pivoting=True, c=c)
+        assert_array_almost_equal(dot(c, q), qc[0, :])
+
     def test_random(self):
         n = 20
         for k in range(2):
@@ -1001,6 +1156,28 @@ class TestQR(TestCase):
             q,r = qr(a)
             assert_array_almost_equal(dot(transpose(q),q),identity(n))
             assert_array_almost_equal(dot(q,r),a)
+
+    def test_random_left(self):
+        n = 20
+        for k in range(2):
+            a = random([n,n])
+            q,r = qr(a)
+            c = random([n])
+            qc,r = qr(a, mode="left", c=c)
+            assert_array_almost_equal(dot(q, c), qc[:, 0])
+            qc,r = qr(a, mode="left", c=identity(n))
+            assert_array_almost_equal(q, qc)
+
+    def test_random_right(self):
+        n = 20
+        for k in range(2):
+            a = random([n,n])
+            q,r = qr(a)
+            c = random([n])
+            cq,r = qr(a, mode="right", c=c)
+            assert_array_almost_equal(dot(c, q), cq[0, :])
+            cq,r = qr(a, mode="right", c=identity(n))
+            assert_array_almost_equal(q, cq)
 
     def test_random_pivoting(self):
         n = 20
@@ -1024,6 +1201,32 @@ class TestQR(TestCase):
             q,r = qr(a)
             assert_array_almost_equal(dot(transpose(q),q),identity(m))
             assert_array_almost_equal(dot(q,r),a)
+
+    def test_random_tall_left(self):
+        # full version
+        m = 200
+        n = 100
+        for k in range(2):
+            a = random([m,n])
+            q,r = qr(a, mode="economic") 
+            c = random([n])
+            qc,r = qr(a, mode="left", c=c)
+            assert_array_almost_equal(dot(q, c), qc[:, 0])
+            qc,r = qr(a, mode="left", c=identity(n))
+            assert_array_almost_equal(qc, q)
+
+    def test_random_tall_right(self):
+        # full version
+        m = 200
+        n = 100
+        for k in range(2):
+            a = random([m,n])
+            q,r = qr(a, mode="economic") 
+            c = random([m])
+            cq,r = qr(a, mode="right", c=c)
+            assert_array_almost_equal(dot(c, q), cq[0, :])
+            cq,r = qr(a, mode="right", c=identity(m))
+            assert_array_almost_equal(cq, q)
 
     def test_random_tall(self):
         # full version pivoting
@@ -1099,6 +1302,28 @@ class TestQR(TestCase):
             q,r = qr(a)
             assert_array_almost_equal(dot(conj(transpose(q)),q),identity(n))
             assert_array_almost_equal(dot(q,r),a)
+
+    def test_random_complex_left(self):
+        n = 20
+        for k in range(2):
+            a = random([n,n])+1j*random([n,n])
+            q,r = qr(a)
+            c = random([n])+1j*random([n])
+            qc,r = qr(a, mode="left", c=c)
+            assert_array_almost_equal(dot(q, c), qc[:, 0])
+            qc,r = qr(a, mode="left", c=identity(n))
+            assert_array_almost_equal(q, qc)
+
+    def test_random_complex_right(self):
+        n = 20
+        for k in range(2):
+            a = random([n,n])+1j*random([n,n])
+            q,r = qr(a)
+            c = random([n])+1j*random([n])
+            cq,r = qr(a, mode="right", c=c)
+            assert_array_almost_equal(dot(c, q), cq[0, :])
+            cq,r = qr(a, mode="right", c=identity(n))
+            assert_array_almost_equal(q, cq)
 
     def test_random_complex_pivoting(self):
         n = 20

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -972,6 +972,9 @@ class TestQR(TestCase):
         qc,r2 = qr_multiply(a, c, "left")
         assert_array_almost_equal(dot(q, c), qc)
         assert_array_almost_equal(r, r2)
+        c = array([1,2,0])
+        qc,r2 = qr_multiply(a, c, "left", overwrite_c=True)
+        assert_array_almost_equal(dot(q, c[:2]), qc)
         qc,r = qr_multiply(a, identity(2), "left")
         assert_array_almost_equal(qc, q)
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -725,7 +725,7 @@ class TestLUSolve(TestCase):
             lu_a = lu_factor(a)
             x2 = lu_solve(lu_a,b)
 
-            assert_array_equal(x1,x2)
+            assert_array_almost_equal(x1,x2)
 
 class TestSVD(TestCase):
     def setUp(self):


### PR DESCRIPTION
A QR decomposition is done in two steps: firstly, 
R is calculated and an intermediate form of Q
(the so called "elementary reflectors"), and in a second
step, Q is actually calculated.

The second step, however, can be costly and 
thus is not done if you are not interested in Q. The
QR decomposition code already allows for not
calculating Q.

Very often, however, one is interested in Q only in
order to multiply it with a vector c. This can be done
without ever calculating Q.

This pull request adds support for two things: 
firstly, one can get the intermediate result 
(the "elementary reflectors") by selecting the 
respective mode of the QR decomposition, and
secondly, (more important), one can tell the
QR decomposition code to multiply Q with a 
vector c (more generally: a matrix c, which is
equivalent to several vectors), and return the
result instead of Q. Since in this case Q is
never calculated, this is more efficient.

Thirdly, this pull requests contains some minor
code cleanup, that someone should have a look
at, and fourthly, some tests are added for the 
additional features.

All four new features are in mostly independent
commits, so if someone doesn't like one of them
just kick them out.
