### PR TITLE
BUG: solve segfaults in sparse.linalg.isolve on OS X.

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/SConscript
+++ b/scipy/sparse/linalg/eigen/arpack/SConscript
@@ -1,3 +1,4 @@
+# vim:syntax=python
 from os.path import join as pjoin
 
 from numscons import GetNumpyEnvironment

--- a/scipy/sparse/linalg/isolve/SConscript
+++ b/scipy/sparse/linalg/isolve/SConscript
@@ -6,7 +6,7 @@ from os.path import join as pjoin, splitext
 from numscons import GetNumpyEnvironment
 from numscons import CheckF77LAPACK
 
-from numscons import write_info
+from numscons import write_info, IsAccelerate, IsVeclib
 
 env = GetNumpyEnvironment(ARGUMENTS)
 env.Tool('f2py')
@@ -53,4 +53,21 @@ for method in raw_sources:
     res = env.FromFTemplate(target, pjoin('iterative', method))
     sources.append(res[0])
 
-env.NumpyPythonExtension('_iterative', source = sources)
+#--------------------------------------------------
+# BLAS wrapper to fix ABI incompatibilities on OS X
+# -------------------------------------------------
+use_c_calling = IsAccelerate(env, "lapack") or IsVeclib(env, "lapack") 
+
+if use_c_calling: 
+    blas_wrapper = ['veclib_cabi_c.c', 'veclib_cabi_f.f'] 
+else: 
+    blas_wrapper = ['dummy.f'] 
+
+blas_wrapper = [pjoin('iterative', 'FWRAPPERS', wrapper) \
+                for wrapper in blas_wrapper]
+
+env.AppendUnique(LIBPATH = ['.'])
+veclibwrap_lib = env.DistutilsStaticExtLibrary('_veclibwrap', source=blas_wrapper)
+env.Prepend(LIBS='_veclibwrap')
+
+env.NumpyPythonExtension('_iterative', source=sources)

--- a/scipy/sparse/linalg/isolve/iterative/BiCGREVCOM.f.src
+++ b/scipy/sparse/linalg/isolve/iterative/BiCGREVCOM.f.src
@@ -113,7 +113,7 @@
       <rt>   TOL, BNRM2, RHOTOL, 
      $       <sdsd=s,d,s,d>GETBREAK,  
      $       <rc=s,d,sc,dz>NRM2
-      <_t>  ALPHA, BETA, RHO, RHO1, <xdot=sdot,ddot,cdotc,zdotc>
+      <_t>  ALPHA, BETA, RHO, RHO1, <xdot=sdot,ddot,wcdotc,wzdotc>
 *
 *     indicates where to resume from. Only valid when IJOB = 2!
       INTEGER RLBL

--- a/scipy/sparse/linalg/isolve/iterative/BiCGSTABREVCOM.f.src
+++ b/scipy/sparse/linalg/isolve/iterative/BiCGSTABREVCOM.f.src
@@ -117,7 +117,7 @@
      $     RHOTOL, OMEGATOL, <sdsd=s,d,s,d>GETBREAK, 
      $     <rc=s,d,sc,dz>NRM2
       <_t>   ALPHA, BETA, RHO, RHO1, OMEGA, TMPVAL,
-     $     <xdot=sdot,ddot,cdotc,zdotc>
+     $     <xdot=sdot,ddot,wcdotc,wzdotc>
 *     indicates where to resume from. Only valid when IJOB = 2!
       INTEGER RLBL
 *

--- a/scipy/sparse/linalg/isolve/iterative/CGREVCOM.f.src
+++ b/scipy/sparse/linalg/isolve/iterative/CGREVCOM.f.src
@@ -100,7 +100,7 @@
 *     .. Local Scalars ..
       INTEGER          MAXIT, R, Z, P, Q, NEED1, NEED2
       <_t>             ALPHA, BETA, RHO, RHO1,
-     $     <xdot=sdot,ddot,cdotc,zdotc>
+     $     <xdot=sdot,ddot,wcdotc,wzdotc>
       <rt>             <rc=s,d,sc,dz>NRM2, TOL
 *
 *     indicates where to resume from. Only valid when IJOB = 2!

--- a/scipy/sparse/linalg/isolve/iterative/CGSREVCOM.f.src
+++ b/scipy/sparse/linalg/isolve/iterative/CGSREVCOM.f.src
@@ -118,7 +118,7 @@
      $       <rc=s,d,sc,dz>NRM2
 
       <_t>   ALPHA, BETA, RHO, RHO1, TMPVAL,
-     $     <xdot=sdot,ddot,cdotc,zdotc>
+     $     <xdot=sdot,ddot,wcdotc,wzdotc>
 *     ..
 *     indicates where to resume from. Only valid when IJOB = 2!
       INTEGER RLBL

--- a/scipy/sparse/linalg/isolve/iterative/FWRAPPERS/dummy.f
+++ b/scipy/sparse/linalg/isolve/iterative/FWRAPPERS/dummy.f
@@ -1,0 +1,57 @@
+      double complex function wzdotc(n, zx, incx, zy, incy)
+      double complex zx(*), zy(*), z
+      double complex zdotc
+      integer n, incx, incy
+      
+      z = zdotc(n, zx, incx, zy, incy)
+      wzdotc = z
+      
+      end
+      
+      double complex function wzdotu(n, zx, incx, zy, incy)
+      double complex zx(*), zy(*), z, zdotu
+      integer n, incx, incy
+      
+      z = zdotu(n, zx, incx, zy, incy)
+      wzdotu = z
+      
+      return
+      end
+      
+      complex function wcdotc(n, cx, incx, cy, incy)
+      complex cx(*), cy(*), c, cdotc
+      integer n, incx, incy
+      
+      c = cdotc(n, cx, incx, cy, incy)
+      wcdotc = c
+      
+      return
+      end
+      
+      complex function wcdotu(n, cx, incx, cy, incy)
+      complex cx(*), cy(*), c, cdotu
+      integer n, incx, incy
+      
+      c = cdotu(n, cx, incx, cy, incy)
+      wcdotu = c
+      
+      return
+      end
+
+      complex function wcladiv(x, y)
+      complex x, y, z
+      complex cladiv
+      
+      z = cladiv(x, y)
+      wcladiv = z
+      return
+      end
+
+      double complex function wzladiv(x, y)
+      double complex x, y, z
+      double complex zladiv
+      
+      z = zladiv(x, y)
+      wzladiv = z
+      return
+      end

--- a/scipy/sparse/linalg/isolve/iterative/FWRAPPERS/veclib_cabi_c.c
+++ b/scipy/sparse/linalg/isolve/iterative/FWRAPPERS/veclib_cabi_c.c
@@ -1,0 +1,26 @@
+#include <complex.h>
+#include <vecLib/vecLib.h>
+
+#define WRAP_F77(a) a##_
+void WRAP_F77(veclib_cdotc)(const int *N, const complex float *X, const int *incX,
+const complex float *Y, const int *incY, complex float *dotc)
+{
+    cblas_cdotc_sub(*N, X, *incX, Y, *incY, dotc);
+}
+
+void WRAP_F77(veclib_cdotu)(const int *N, const complex float *X, const int *incX,
+const complex float *Y, const int *incY, complex float* dotu)
+{
+    cblas_cdotu_sub(*N, X, *incX, Y, *incY, dotu);
+}
+
+void WRAP_F77(veclib_zdotc)(const int *N, const double complex *X, const int
+*incX, const double complex *Y, const int *incY, double complex *dotu)
+{
+    cblas_zdotc_sub(*N, X, *incX, Y, *incY, dotu);
+}
+void WRAP_F77(veclib_zdotu)(const int *N, const double complex *X, const int
+*incX, const double complex *Y, const int *incY, double complex *dotu)
+{
+    cblas_zdotu_sub(*N, X, *incX, Y, *incY, dotu);
+}

--- a/scipy/sparse/linalg/isolve/iterative/FWRAPPERS/veclib_cabi_f.f
+++ b/scipy/sparse/linalg/isolve/iterative/FWRAPPERS/veclib_cabi_f.f
@@ -1,0 +1,55 @@
+      double complex function wzdotc(n, zx, incx, zy, incy)
+      double complex zx(*), zy(*), z
+      integer n, incx, incy
+      
+      call veclib_zdotc(n, zx, incx, zy, incy, z)
+      
+      wzdotc = z
+      return
+      end
+      
+      double complex function wzdotu(n, zx, incx, zy, incy)
+      double complex zx(*), zy(*), z
+      integer n, incx, incy
+      
+      call veclib_zdotu(n, zx, incx, zy, incy, z)
+      
+      wzdotu = z
+      return
+      end
+      
+      complex function wcdotc(n, cx, incx, cy, incy)
+      complex cx(*), cy(*), c
+      integer n, incx, incy
+      
+      call veclib_cdotc(n, cx, incx, cy, incy, c)
+      
+      wcdotc = c
+      return
+      end
+      
+      complex function wcdotu(n, cx, incx, cy, incy)
+      complex cx(*), cy(*), c
+      integer n, incx, incy
+      
+      call veclib_cdotu(n, cx, incx, cy, incy, c)
+      
+      wcdotu = c
+      return
+      end
+
+      complex function wcladiv(x, y)
+      complex x, y, z
+      
+      call cladiv(z, x, y)
+      wcladiv = z
+      return
+      end
+
+      double complex function wzladiv(x, y)
+      double complex x, y, z
+      
+      call zladiv(z, x, y)
+      wzladiv = z
+      return
+      end

--- a/scipy/sparse/linalg/isolve/iterative/GMRESREVCOM.f.src
+++ b/scipy/sparse/linalg/isolve/iterative/GMRESREVCOM.f.src
@@ -104,7 +104,7 @@
 *     .. Local Scalars ..
       INTEGER             I, MAXIT, AV, GIV, H, R, S, V, W, Y,
      $                    NEED1, NEED2
-      <_t>  <xdot=sdot,ddot,cdotc,zdotc>
+      <_t>  <xdot=sdot,ddot,wcdotc,wzdotc>
       <_t>  toz
       <_t>    TMPVAL
       <rt>    BNRM2, RNORM, TOL,  
@@ -416,7 +416,7 @@
       <rt=real,double precision,real,double precision>    
      $     <rc=s,d,sc,dz>NRM2, ONE
       PARAMETER        ( ONE = 1.0D+0 )
-      <_t>    <xdot=sdot,ddot,cdotc,zdotc>
+      <_t>    <xdot=sdot,ddot,wcdotc,wzdotc>
       <_t>    TMPVAL
       EXTERNAL         <_c>AXPY, <_c>COPY, <xdot>, <rc>NRM2, <_c>SCAL
 *

--- a/scipy/sparse/linalg/isolve/iterative/QMRREVCOM.f.src
+++ b/scipy/sparse/linalg/isolve/iterative/QMRREVCOM.f.src
@@ -129,7 +129,7 @@
 
       <_t>   BETA, GAMMA, GAMMA1, DELTA, EPS, ETA, XI, 
      $       RHO, RHO1, THETA, THETA1, C1, TMPVAL,
-     $     <xdot=sdot,ddot,cdotc,zdotc>,
+     $     <xdot=sdot,ddot,wcdotc,wzdotc>,
      $     toz
 *
 *     indicates where to resume from. Only valid when IJOB = 2!

--- a/scipy/sparse/linalg/isolve/setup.py
+++ b/scipy/sparse/linalg/isolve/setup.py
@@ -7,6 +7,24 @@ from distutils.dep_util import newer_group, newer
 from glob import glob
 from os.path import join
 
+
+def needs_veclib_wrapper(info):
+    """Returns true if needs special veclib wrapper."""
+    import re
+    r_accel = re.compile("Accelerate")
+    r_vec = re.compile("vecLib")
+    res = False
+    try:
+        tmpstr = info['extra_link_args']
+        for i in tmpstr:
+            if r_accel.search(i) or r_vec.search(i):
+                res = True
+    except KeyError:
+        pass
+
+    return res
+
+
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.system_info import get_info, NotFoundError
 
@@ -30,16 +48,27 @@ def configuration(parent_package='',top_path=None):
                'QMRREVCOM.f.src',
 #               'SORREVCOM.f.src'
                ]
+
+    if needs_veclib_wrapper(lapack_opt):
+        methods += [join('FWRAPPERS', 'veclib_cabi_f.f'),
+                    join('FWRAPPERS', 'veclib_cabi_c.c')]
+    else:
+        methods += [join('FWRAPPERS', 'dummy.f')]
+
+
     Util = ['STOPTEST2.f.src','getbreak.f.src']
     sources = Util + methods + ['_iterative.pyf.src']
     config.add_extension('_iterative',
-                         sources = [join('iterative',x) for x in sources],
-                         extra_info = lapack_opt
+                         sources=[join('iterative', x) for x in sources],
+                         extra_info=lapack_opt,
+                         depends=[join('iterative', 'FWRAPPERS', x) for x in
+                         ['veclib_cabi_f.f', 'veclib_cabi_c.c', 'dummy.f']]
                          )
 
     config.add_data_dir('tests')
 
     return config
+
 
 if __name__ == '__main__':
     from numpy.distutils.core import setup


### PR DESCRIPTION
BUG: solve segfaults in sparse.linalg.isolve on OS X.  Closes #1321 and #1472.

Builds with both distutils and numscons, test suite completes without segfaults. There's one error and one failure when running the sparse.linalg tests on the distutils build:

```
======================================================================
ERROR: test_arpack.test_complex_nonsymmetric_modes(False, <gen-cmplx-nonsym>, 'F', 2, 'LM', None, None, <function aslinearoperator at 0xea83bf0>)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/site-packages/nose-1.0.0-py2.6.egg/nose/case.py", line 187, in runTest
    self.test(*self.arg)
  File "/Users/rgommers/Code/scipy/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py", line 168, in eval_evec
    eval, evec = eigs_func(ac, k, bc, **kwargs)
  File "/Users/rgommers/Code/scipy/scipy/sparse/linalg/eigen/arpack/arpack.py", line 1251, in eigs
    params.iterate()
  File "/Users/rgommers/Code/scipy/scipy/sparse/linalg/eigen/arpack/arpack.py", line 727, in iterate
    self.workd[yslice] = self.OP(self.workd[xslice])
  File "/Users/rgommers/Code/scipy/scipy/sparse/linalg/eigen/arpack/arpack.py", line 641, in <lambda>
    self.OP = lambda x: Minv_matvec(matvec(x))
  File "/Users/rgommers/Code/scipy/scipy/sparse/linalg/interface.py", line 123, in matvec
    y = self._matvec(x)
  File "/Users/rgommers/Code/scipy/scipy/sparse/linalg/eigen/arpack/arpack.py", line 945, in _matvec
    % (self.ifunc.__name__, info))
ValueError: Error in inverting M: function gmres did not converge (info = 60).

======================================================================
FAIL: test_iterative.test_convergence(<function qmr at 0xea83530>, <nonsymposdef>)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/site-packages/nose-1.0.0-py2.6.egg/nose/case.py", line 187, in runTest
    self.test(*self.arg)
  File "/Users/rgommers/Code/scipy/scipy/sparse/linalg/isolve/tests/test_iterative.py", line 152, in check_convergence
    assert_equal(info,0)
  File "/Users/rgommers/Code/numpy/numpy/testing/utils.py", line 313, in assert_equal
    raise AssertionError(msg)
AssertionError: 
Items are not equal:
 ACTUAL: 100
 DESIRED: 0
```

With the numscons build I only get the qmr failure. Not sure why the result is different.
