### PR TITLE
Update isolve doc strings

### DIFF
--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -16,8 +16,7 @@ common_doc1 = \
 """
 Parameters
 ----------
-A : {sparse matrix, dense matrix, LinearOperator}
-    The N-by-N matrix of the linear system"""
+A : {sparse matrix, dense matrix, LinearOperator}"""
 
 common_doc2 = \
 """b : {array, matrix}
@@ -64,10 +63,10 @@ xtype : {'f','d','F','D'}
 """
 
 
-def set_docstring(header, Ainfo, footer):
+def set_docstring(header, Ainfo, footer=''):
     def combine(fn):
         fn.__doc__ = '\n'.join((header, common_doc1,
-                               '    ' + Ainfo,
+                               '    ' + Ainfo.replace('\n', '\n    '),
                                common_doc2, footer))
         return fn
     return combine
@@ -75,8 +74,9 @@ def set_docstring(header, Ainfo, footer):
 
 
 @set_docstring('Use BIConjugate Gradient iteration to solve A x = b',
+               'The real or complex N-by-N matrix of the linear system\n'
                'It is required that the linear operator can produce\n'
-               '    ``Ax`` and ``A^T x``.', '')
+               '``Ax`` and ``A^T x``.')
 def bicg(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None):
     A,M,x,b,postprocess = make_system(A,M,x0,b,xtype)
 
@@ -138,8 +138,8 @@ def bicg(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=Non
     return postprocess(x), info
 
 @set_docstring('Use BIConjugate Gradient STABilized iteration to solve A x = b',
-               '``A`` must represent a hermitian, positive definite matrix',
-               '')
+               'The real or complex N-by-N matrix of the linear system\n'
+               '``A`` must represent a hermitian, positive definite matrix')
 def bicgstab(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None):
     A,M,x,b,postprocess = make_system(A,M,x0,b,xtype)
 
@@ -198,8 +198,8 @@ def bicgstab(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback
     return postprocess(x), info
 
 @set_docstring('Use Conjugate Gradient iteration to solve A x = b',
-               '``A`` must represent a hermitian, positive definite matrix',
-               '')
+               'The real or complex N-by-N matrix of the linear system\n'
+               '``A`` must represent a hermitian, positive definite matrix')
 def cg(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None):
     A,M,x,b,postprocess = make_system(A,M,x0,b,xtype)
 
@@ -258,8 +258,7 @@ def cg(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None)
 
 
 @set_docstring('Use Conjugate Gradient Squared iteration to solve A x = b',
-               '``A`` must represent a real-valued matrix',
-               '')
+               'The real-valued N-by-N matrix of the linear system')
 def cgs(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None):
     A,M,x,b,postprocess = make_system(A,M,x0,b,xtype)
 
@@ -323,7 +322,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, xtype=None, M=Non
     Parameters
     ----------
     A : {sparse matrix, dense matrix, LinearOperator}
-        The N-by-N matrix of the linear system.
+        The real or complex N-by-N matrix of the linear system.
     b : {array, matrix}
         Right hand side of the linear system. Has shape (N,) or (N,1).
 

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -12,13 +12,15 @@ _type_conv = {'f':'s', 'd':'d', 'F':'c', 'D':'z'}
 
 
 # Part of the docstring common to all iterative solvers
-common_doc = \
+common_doc1 = \
 """
 Parameters
 ----------
 A : {sparse matrix, dense matrix, LinearOperator}
-    The N-by-N matrix of the linear system.
-b : {array, matrix}
+    The N-by-N matrix of the linear system"""
+
+common_doc2 = \
+"""b : {array, matrix}
     Right hand side of the linear system. Has shape (N,) or (N,1).
 
 Returns
@@ -62,15 +64,19 @@ xtype : {'f','d','F','D'}
 """
 
 
-def set_docstring(header, footer):
+def set_docstring(header, Ainfo, footer):
     def combine(fn):
-        fn.__doc__ = header + '\n' + common_doc + '\n' + footer
+        fn.__doc__ = '\n'.join((header, common_doc1,
+                               '    ' + Ainfo,
+                               common_doc2, footer))
         return fn
     return combine
 
 
 
-@set_docstring('Use BIConjugate Gradient iteration to solve A x = b','')
+@set_docstring('Use BIConjugate Gradient iteration to solve A x = b',
+               'It is required that the linear operator can produce\n'
+               '    ``Ax`` and ``A^T x``.', '')
 def bicg(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None):
     A,M,x,b,postprocess = make_system(A,M,x0,b,xtype)
 
@@ -131,7 +137,9 @@ def bicg(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=Non
 
     return postprocess(x), info
 
-@set_docstring('Use BIConjugate Gradient STABilized iteration to solve A x = b','')
+@set_docstring('Use BIConjugate Gradient STABilized iteration to solve A x = b',
+               '``A`` must represent a hermitian, positive definite matrix',
+               '')
 def bicgstab(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None):
     A,M,x,b,postprocess = make_system(A,M,x0,b,xtype)
 
@@ -189,7 +197,9 @@ def bicgstab(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback
 
     return postprocess(x), info
 
-@set_docstring('Use Conjugate Gradient iteration to solve A x = b','')
+@set_docstring('Use Conjugate Gradient iteration to solve A x = b',
+               '``A`` must represent a hermitian, positive definite matrix',
+               '')
 def cg(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None):
     A,M,x,b,postprocess = make_system(A,M,x0,b,xtype)
 
@@ -247,7 +257,9 @@ def cg(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None)
     return postprocess(x), info
 
 
-@set_docstring('Use Conjugate Gradient Squared iteration to solve A x = b','')
+@set_docstring('Use Conjugate Gradient Squared iteration to solve A x = b',
+               '``A`` must represent a real-valued matrix',
+               '')
 def cgs(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None):
     A,M,x,b,postprocess = make_system(A,M,x0,b,xtype)
 
@@ -476,7 +488,9 @@ def qmr(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M1=None, M2=None, cal
     Parameters
     ----------
     A : {sparse matrix, dense matrix, LinearOperator}
-        The N-by-N matrix of the linear system.
+        The real-valued N-by-N matrix of the linear system.
+        It is required that the linear operator can produce
+        ``Ax`` and ``A^T x``.
     b : {array, matrix}
         Right hand side of the linear system. Has shape (N,) or (N,1).
 

--- a/scipy/sparse/linalg/isolve/lgmres.py
+++ b/scipy/sparse/linalg/isolve/lgmres.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 from scipy.linalg import get_blas_funcs
-from iterative import set_docstring
 from utils import make_system
 
 __all__ = ['lgmres']

--- a/scipy/sparse/linalg/isolve/lgmres.py
+++ b/scipy/sparse/linalg/isolve/lgmres.py
@@ -24,7 +24,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
     Parameters
     ----------
     A : {sparse matrix, dense matrix, LinearOperator}
-        The N-by-N matrix of the linear system.
+        The real or complex N-by-N matrix of the linear system.
     b : {array, matrix}
         Right hand side of the linear system. Has shape (N,) or (N,1).
     x0  : {array, matrix}

--- a/scipy/sparse/linalg/isolve/lsqr.py
+++ b/scipy/sparse/linalg/isolve/lsqr.py
@@ -126,7 +126,7 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
     Parameters
     ----------
     A : {sparse matrix, ndarray, LinearOperatorLinear}
-        Representation of an mxn matrix.  It is required that
+        Representation of an m-by-n matrix.  It is required that
         the linear operator can produce ``Ax`` and ``A^T x``.
     b : (m,) ndarray
         Right-hand side vector ``b``.

--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -10,7 +10,7 @@ __all__ = ['minres']
 header = \
 """Use MINimum RESidual iteration to solve Ax=b
 
-MINRES minimizes norm(A*x - b) for the symmetric matrix A.  Unlike
+MINRES minimizes norm(A*x - b) for a real symmetric matrix A.  Unlike
 the Conjugate Gradient method, A can be indefinite or singular.
 
 If shift != 0 then the method solves (A - shift*I)x = b
@@ -33,7 +33,9 @@ This file is a translation of the following MATLAB implementation:
     http://www.stanford.edu/group/SOL/software/minres/matlab/
 """
 
-@set_docstring(header,footer)
+@set_docstring(header,
+               '``A`` must represent a real-valued, symmetric matrix',
+               footer)
 def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None, xtype=None,
            M=None, callback=None, show=False, check=False):
     A,M,x,b,postprocess = make_system(A,M,x0,b,xtype)

--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -16,7 +16,7 @@ the Conjugate Gradient method, A can be indefinite or singular.
 If shift != 0 then the method solves (A - shift*I)x = b
 """
 
-Ainfo = "The real-valued N-by-N matrix of the linear system"
+Ainfo = "The real symmetric N-by-N matrix of the linear system"
 
 footer = \
 """

--- a/scipy/sparse/linalg/isolve/minres.py
+++ b/scipy/sparse/linalg/isolve/minres.py
@@ -16,6 +16,8 @@ the Conjugate Gradient method, A can be indefinite or singular.
 If shift != 0 then the method solves (A - shift*I)x = b
 """
 
+Ainfo = "The real-valued N-by-N matrix of the linear system"
+
 footer = \
 """
 Notes
@@ -34,7 +36,7 @@ This file is a translation of the following MATLAB implementation:
 """
 
 @set_docstring(header,
-               '``A`` must represent a real-valued, symmetric matrix',
+               Ainfo,
                footer)
 def minres(A, b, x0=None, shift=0.0, tol=1e-5, maxiter=None, xtype=None,
            M=None, callback=None, show=False, check=False):


### PR DESCRIPTION
Many of the iterative solvers in `scipy.sparse.linalg.isolve` have restrictions on the form of the input matrix that are not currently mentioned in the function documentation.  This pull request supplements the doc-strings with clarifying notes on some of these restrictions.
