### PR TITLE
Fix names of two test functions so they have unique names.

### DIFF
--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1025,7 +1025,7 @@ class TestQR(TestCase):
             assert_array_almost_equal(dot(transpose(q),q),identity(m))
             assert_array_almost_equal(dot(q,r),a)
 
-    def test_random_tall(self):
+    def test_random_tall_pivoting(self):
         # full version pivoting
         m = 200
         n = 100
@@ -1052,7 +1052,7 @@ class TestQR(TestCase):
             assert_equal(q.shape, (m,n))
             assert_equal(r.shape, (n,n))
 
-    def test_random_tall_e(self):
+    def test_random_tall_e_pivoting(self):
         # economy version pivoting
         m = 200
         n = 100


### PR DESCRIPTION
When I made my original pull request (44) I accidentally named two of my new test functions the same as the ones I was basing them off of. This request fixes that. It is a fairly minor change, I think.
