### PR TITLE
FIX: return a complex BLAS routine for complex256 dtype.

### DIFF
--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -17,7 +17,7 @@ elif hasattr(fblas,'empty_module'):
     fblas = cblas
 
  # 'd' will be default for 'i',..
-_type_conv = {'f':'s', 'd':'d', 'F':'c', 'D':'z'}
+_type_conv = {'f':'s', 'd':'d', 'F':'c', 'D':'z', 'G':'z'}
 
 # some convenience alias for complex functions
 _blas_alias = {'cnrm2' : 'scnrm2', 'znrm2' : 'dznrm2',

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -44,6 +44,10 @@ def test_get_blas_funcs():
     f1 = get_blas_funcs('gemm', dtype='F')
     assert_equal(f1.typecode, 'c')
 
+    # extended precision complex
+    f1 = get_blas_funcs('gemm', dtype=np.complex256)
+    assert_equal(f1.typecode, 'z')
+
 def test_get_blas_funcs_alias():
     # check alias for get_blas_funcs
     f, g = get_blas_funcs(('nrm2', 'dot'), dtype=np.complex64)

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -45,7 +45,7 @@ def test_get_blas_funcs():
     assert_equal(f1.typecode, 'c')
 
     # extended precision complex
-    f1 = get_blas_funcs('gemm', dtype=np.complex256)
+    f1 = get_blas_funcs('gemm', dtype=np.longcomplex)
     assert_equal(f1.typecode, 'z')
 
 def test_get_blas_funcs_alias():

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -23,8 +23,8 @@ def test_get_blas_funcs():
     # fortran-ordered
     f1, f2, f3 = get_blas_funcs(
         ('axpy', 'axpy', 'axpy'),
-        (np.empty((2,2), dtype=np.complex64, order='F'),
-         np.empty((2,2), dtype=np.complex128, order='C'))
+        (np.empty((2,2), dtype=np.singlecomplex, order='F'),
+         np.empty((2,2), dtype=np.doublecomplex, order='C'))
         )
 
     # get_blas_funcs will choose libraries depending on most generic
@@ -39,7 +39,7 @@ def test_get_blas_funcs():
     assert_equal(f1.typecode, 'd')
 
     # check also dtype interface
-    f1 = get_blas_funcs('gemm', dtype=np.complex64)
+    f1 = get_blas_funcs('gemm', dtype=np.singlecomplex)
     assert_equal(f1.typecode, 'c')
     f1 = get_blas_funcs('gemm', dtype='F')
     assert_equal(f1.typecode, 'c')
@@ -50,7 +50,7 @@ def test_get_blas_funcs():
 
 def test_get_blas_funcs_alias():
     # check alias for get_blas_funcs
-    f, g = get_blas_funcs(('nrm2', 'dot'), dtype=np.complex64)
+    f, g = get_blas_funcs(('nrm2', 'dot'), dtype=np.singlecomplex)
     assert f.typecode == 'c'
     assert g.typecode == 'c'
 


### PR DESCRIPTION
Before of this, get_blas_funcs returned a double function for that
dtype.
