### PR TITLE
Minor performance fix to scipy.io.idl

### DIFF
--- a/scipy/io/idl.py
+++ b/scipy/io/idl.py
@@ -618,13 +618,15 @@ def _replace_heap(variable, heap):
 
     elif isinstance(variable, np.ndarray):
 
-        # Loop over values
-        for iv in range(variable.size):
+        # Loop over values if type is np.object_
+        if variable.dtype.type is np.object_:
 
-            replace, new = _replace_heap(variable.item(iv), heap)
+            for iv in range(variable.size):
 
-            if replace:
-                variable.itemset(iv, new)
+                replace, new = _replace_heap(variable.item(iv), heap)
+
+                if replace:
+                    variable.itemset(iv, new)
 
         return False, variable
 


### PR DESCRIPTION
This is a minor performance fix for scipy.io.idl, but since I don't foresee any other commits in the near future, I thought it'd be better to request it to be merged now. The fix is to avoid looking for object pointers in arrays that aren't of type 'object'.
