### PR TITLE
BUG: netcdf: don't write NetCDF 3 unsupported int64 arrays

### DIFF
--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -124,3 +124,16 @@ def test_read_example_data():
         f = netcdf_file(fname, 'r')
         f = netcdf_file(fname, 'r', mmap=False)
 
+def test_write_invalid_dtype():
+    dtypes = ['int64', 'uint64']
+    if np.dtype('int').itemsize == 8:   # 64-bit machines
+        dtypes.append('int')
+    if np.dtype('uint').itemsize == 8:   # 64-bit machines
+        dtypes.append('uint')
+
+    f = netcdf_file(BytesIO(), 'w')
+    f.createDimension('time', N_EG_ELS)
+    for dt in dtypes:
+        yield assert_raises, ValueError, \
+            f.createVariable, 'time', dt, ('time',)
+    f.close()


### PR DESCRIPTION
np.dtype('int').itemsize is 4 on my 32-bit system, and
8 on my 64-bit system.

Running the example from the doc, with type changed to 'int'
on my 64-bit system, produced this:

```
$ ncdump simple.nc
...
data:

 time = 0, 0, 0, 1, 0, 2, 0, 3, 0, 4 ;
}
```

On my 32-bit system, it produced the correct result:

```
$ ncdump simple.nc
netcdf simple {
...
data:

 time = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ;
}
```

Also, added support for uint8, which is equivalent to
NC_CHAR.
