### PR TITLE
BUG: Removed using non-api np functions in tests

### DIFF
--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -564,17 +564,17 @@ class TestFftn(TestCase):
 
     def test_shape_axes_argument2(self):
         # Change shape of the last axis
-        x = numpy.random.random((10, 5, 3, 7))
+        x = numpy.random.random_sample((10, 5, 3, 7))
         y = fftn(x, axes=(-1,), shape=(8,))
         assert_array_almost_equal(y, fft(x, axis=-1, n=8))
 
         # Change shape of an arbitrary axis which is not the last one
-        x = numpy.random.random((10, 5, 3, 7))
+        x = numpy.random.random_sample((10, 5, 3, 7))
         y = fftn(x, axes=(-2,), shape=(8,))
         assert_array_almost_equal(y, fft(x, axis=-2, n=8))
 
         # Change shape of axes: cf #244, where shape and axes were mixed up
-        x = numpy.random.random((4,4,2))
+        x = numpy.random.random_sample((4,4,2))
         y = fftn(x, axes=(-3,-2), shape=(8,8))
         assert_array_almost_equal(y, numpy.fft.fftn(x, axes=(-3, -2), s=(8, 8)))
 

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -19,19 +19,19 @@ datapath = os.path.dirname(__file__)
 
 class TestPILUtil(TestCase):
     def test_imresize(self):
-        im = np.random.random((10,20))
+        im = np.random.random_sample((10,20))
         for T in np.sctypes['float'] + [float]:
             # 1.1 rounds to below 1.1 for float16, 1.101 works
             im1 = pilutil.imresize(im,T(1.101))
             assert_equal(im1.shape,(11,22))
 
     def test_imresize2(self):
-        im = np.random.random((20,30))
+        im = np.random.random_sample((20,30))
         im2 = pilutil.imresize(im, (30,40), interp='bicubic')
         assert_equal(im2.shape, (30,40))
 
     def test_imresize3(self):
-        im = np.random.random((15,30))
+        im = np.random.random_sample((15,30))
         im2 = pilutil.imresize(im, (30,60), interp='nearest')
         assert_equal(im2.shape, (30,60))
 

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -95,7 +95,7 @@ class TestSplu(object):
     def test_splu_basic(self):
         # Test basic splu functionality.
         n = 30
-        a = random.random((n, n))
+        a = random.random_sample((n, n))
         a[a < 0.95] = 0
         # First test with a singular matrix
         a[:, 0] = 0
@@ -114,7 +114,7 @@ class TestSplu(object):
     def test_splu_perm(self):
         # Test the permutation vectors exposed by splu.
         n = 30
-        a = random.random((n, n))
+        a = random.random_sample((n, n))
         a[a < 0.95] = 0
         # Make a diagonal dominant, to make sure it is not singular
         a += 4*eye(n)
@@ -136,7 +136,7 @@ class TestSplu(object):
     def test_lu_refcount(self):
         # Test that we are keeping track of the reference count with splu.
         n = 30
-        a = random.random((n, n))
+        a = random.random_sample((n, n))
         a[a < 0.95] = 0
         # Make a diagonal dominant, to make sure it is not singular
         a += 4*eye(n)

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -29,9 +29,9 @@ _atol = _rtol
 
 def generate_matrix(N, complex=False, hermitian=False,
                     pos_definite=False, sparse=False):
-    M = np.random.random((N,N))
+    M = np.random.random_sample((N,N))
     if complex:
-        M = M + 1j * np.random.random((N,N))
+        M = M + 1j * np.random.random_sample((N,N))
 
     if hermitian:
         if pos_definite:
@@ -220,7 +220,7 @@ class SymmetricParams:
                             pos_definite=True).astype('f').astype('d')
         Ac = generate_matrix(N, hermitian=True, pos_definite=True,
                              complex=True).astype('F').astype('D')
-        v0 = np.random.random(N)
+        v0 = np.random.random_sample(N)
 
         # standard symmetric problem
         SS = DictWithRepr("std-symmetric")
@@ -269,7 +269,7 @@ class NonSymmetricParams:
         M = generate_matrix(N, hermitian=True,
                             pos_definite=True).astype('f').astype('d')
         Ac = generate_matrix(N, complex=True).astype('F').astype('D')
-        v0 = np.random.random(N)
+        v0 = np.random.random_sample(N)
 
         # standard real nonsymmetric problem
         SNR = DictWithRepr("std-real-nonsym")
@@ -443,7 +443,7 @@ def test_ticket_1459_arpack_crash():
         k = 2
 
         np.random.seed(2301)
-        A = np.random.random((N, N)).astype(dtype)
+        A = np.random.random_sample((N, N)).astype(dtype)
         v0 = np.array([-0.71063568258907849895, -0.83185111795729227424,
                        -0.34365925382227402451, 0.46122533684552280420,
                        -0.58001341115969040629, -0.78844877570084292984e-01],

--- a/scipy/special/tests/test_spfun_stats.py
+++ b/scipy/special/tests/test_spfun_stats.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numpy.testing import assert_array_equal, TestCase, run_module_suite
+from numpy.testing import assert_array_almost_equal
 
 from scipy.special import gammaln, multigammaln
 
@@ -24,7 +25,8 @@ class TestMultiGammaLn(TestCase):
         tr = multigammaln(a, d)
         assert_array_equal(tr.shape, a.shape)
         for i in range(a.size):
-            assert_array_equal(tr.ravel()[i], multigammaln(a.ravel()[i], d))
+            assert_array_almost_equal(tr.ravel()[i],
+                                      multigammaln(a.ravel()[i], d))
 
     def test_bararg(self):
         try:

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -1187,7 +1187,7 @@ class rv_continuous(rv_generic):
     ##(return 1-d using self._size to get number)
     def _rvs(self, *args):
         ## Use basic inverse cdf algorithm for RV generation as default.
-        U = mtrand.sample(self._size)
+        U = mtrand.random_sample(self._size)
         Y = self._ppf(U,*args)
         return Y
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2767,8 +2767,8 @@ def linregress(x, y=None):
     --------
     >>> from scipy import stats
     >>> import numpy as np
-    >>> x = np.random.random(10)
-    >>> y = np.random.random(10)
+    >>> x = np.random.rand(10)
+    >>> y = np.random.rand(10)
     >>> slope, intercept, r_value, p_value, std_err = stats.linregress(x,y)
 
     # To get coefficient of determination (r_squared)


### PR DESCRIPTION
A number of tests (and one place in scipy.stats) made a call to a function numpy.random.random, which doesn't exist in the numpy referernce docs. It's an alias for numpy.random.random_sample. I replaced them with their proper names. 

This doesn't change anything in the functionality of scipy or what the user sees, it's just a protection against api changes in numpy. (api changes which, admittedly, I would like to make. Nonetheless, it's not good practice to use functions not in the numpy reference.) 
