### PR TITLE
Squareform binary fix

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1407,6 +1407,9 @@ def squareform(X, force="no", checks=True):
     """
 
     X = _convert_to_double(np.asarray(X, order='c'))
+    # Check for a scalar (happens on conversion for non-double dtypes)
+    if np.isscalar(X):
+       X = np.array([X], order='c')
 
     if not np.issubsctype(X, np.double):
         raise TypeError('A double array must be passed.')

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1502,12 +1502,12 @@ class TestSquareForm(TestCase):
         self.assertTrue(rv[1,0] == 8.3)
 
     def test_squareform_one_binary_vector(self):
-	"""Tests squareform on a 1x1 binary matrix
-	(conversion to double was causing problems."""
-	v = np.ones((1,), dtype=np.bool)
-	rv = squareform(v)
-	self.assertTrue(rv.shape == (2,2))
-	self.assertTrue(rv[0,1])
+        """Tests squareform on a 1x1 binary matrix
+        (conversion to double was causing problems."""
+        v = np.ones((1,), dtype=np.bool)
+        rv = squareform(v)
+        self.assertTrue(rv.shape == (2,2))
+        self.assertTrue(rv[0,1])
 
     def test_squareform_2by2_matrix(self):
         "Tests squareform on a 2x2 matrix."

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1501,6 +1501,14 @@ class TestSquareForm(TestCase):
         self.assertTrue(rv[0,1] == 8.3)
         self.assertTrue(rv[1,0] == 8.3)
 
+    def test_squareform_one_binary_vector(self):
+	"""Tests squareform on a 1x1 binary matrix
+	(conversion to double was causing problems."""
+	v = np.ones((1,), dtype=np.bool)
+	rv = squareform(v)
+	self.assertTrue(rv.shape == (2,2))
+	self.assertTrue(rv[0,1])
+
     def test_squareform_2by2_matrix(self):
         "Tests squareform on a 2x2 matrix."
         A = np.zeros((2,2))


### PR DESCRIPTION
I discovered what I consider an (extremely minor) bug in scipy.spatial.squareform.

I had code to test for connection that looked like this:
squareform(pdist(X) < some_value)

The comparison is being done before squareform to save computation time. However, for a trivial test case where X has only two entries (and thus the output of pdist is a length 1 vector array) squareform fails because in the conversion from binary to double the array is converted to a scalar.

I've made a test case and a patch to detect the conversion to scalar in squareform.

An alternative solution would be to modify _convert_to_double to retain the array shape during conversion - but since that function is used widely I wasn't sure if this is the intended behaviour.
