### PR TITLE
BUG: fix Python 3 build.

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -73,48 +73,62 @@ Utility tools
 
 """
 
-__all__ = ['test']
-
-from numpy import show_config as show_numpy_config
-if show_numpy_config is None:
-    raise ImportError("Cannot import scipy when running from numpy source directory.")
-from numpy import __version__ as __numpy_version__
-
-# Import numpy symbols to scipy name space
-import numpy as _num
-from numpy import oldnumeric
-from numpy import *
-from numpy.random import rand, randn
-from numpy.fft import fft, ifft
-from numpy.lib.scimath import *
-
-# Emit a warning if numpy is too old
-majver, minver = [float(i) for i in _num.version.version.split('.')[:2]]
-if majver < 1 or (majver == 1 and minver < 5):
-    import warnings
-    warnings.warn("Numpy 1.5.0 or above is recommended for this version of " \
-                  "scipy (detected version %s)" % _num.version.version,
-                  UserWarning)
-
-__all__ += ['oldnumeric']+_num.__all__
-
-__all__ += ['randn', 'rand', 'fft', 'ifft']
-
-del _num
-# Remove the linalg imported from numpy so that the scipy.linalg package can be
-# imported.
-del linalg
-__all__.remove('linalg')
-
+# We first need to detect if we're being called as part of the scipy setup
+# procedure itself in a reliable manner.
 try:
-    from scipy.__config__ import show as show_config
-except ImportError:
-    msg = """Error importing scipy: you cannot import scipy while
-    being in scipy source directory; please exit the scipy source
-    tree first, and relaunch your python intepreter."""
-    raise ImportError(msg)
-from scipy.version import version as __version__
+    __SCIPY_SETUP__
+except NameError:
+    __SCIPY_SETUP__ = False
 
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().bench
+
+if __SCIPY_SETUP__:
+    import sys as _sys
+    _sys.stderr.write('Running from scipy source directory.\n')
+    del _sys
+else:
+
+    __all__ = ['test']
+
+    from numpy import show_config as show_numpy_config
+    if show_numpy_config is None:
+        raise ImportError("Cannot import scipy when running from numpy source directory.")
+    from numpy import __version__ as __numpy_version__
+
+    # Import numpy symbols to scipy name space
+    import numpy as _num
+    from numpy import oldnumeric
+    from numpy import *
+    from numpy.random import rand, randn
+    from numpy.fft import fft, ifft
+    from numpy.lib.scimath import *
+
+    # Emit a warning if numpy is too old
+    majver, minver = [float(i) for i in _num.version.version.split('.')[:2]]
+    if majver < 1 or (majver == 1 and minver < 5):
+        import warnings
+        warnings.warn("Numpy 1.5.0 or above is recommended for this version of " \
+                      "scipy (detected version %s)" % _num.version.version,
+                      UserWarning)
+
+    __all__ += ['oldnumeric']+_num.__all__
+
+    __all__ += ['randn', 'rand', 'fft', 'ifft']
+
+    del _num
+    # Remove the linalg imported from numpy so that the scipy.linalg package
+    # can be imported.
+    del linalg
+    __all__.remove('linalg')
+
+    try:
+        from scipy.__config__ import show as show_config
+    except ImportError:
+        msg = """Error importing scipy: you cannot import scipy while
+        being in scipy source directory; please exit the scipy source
+        tree first, and relaunch your python intepreter."""
+        raise ImportError(msg)
+    from scipy.version import version as __version__
+
+    from numpy.testing import Tester
+    test = Tester().test
+    bench = Tester().bench

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,11 @@ import subprocess
 import shutil
 import re
 
+if sys.version_info[0] < 3:
+    import __builtin__ as builtins
+else:
+    import builtins
+
 CLASSIFIERS = """\
 Development Status :: 4 - Beta
 Intended Audience :: Science/Research
@@ -79,7 +84,11 @@ def git_version():
 if os.path.exists('MANIFEST'):
     os.remove('MANIFEST')
 
-os.environ['NO_SCIPY_IMPORT'] = 'SciPy/setup.py'
+# This is a bit hackish: we are setting a global variable so that the main
+# scipy __init__ can detect if it is being loaded by the setup routine, to
+# avoid attempting to load components that aren't built yet.  While ugly, it's
+# a lot more robust than what was previously being used.
+builtins.__SCIPY_SETUP__ = True
 
 
 def write_version_py(filename='scipy/version.py'):


### PR DESCRIPTION
This is high priority since the Py3K build seems to be completely broken. This does get scipy to build again, although there are some test failures. Those may be fixed by Christoph Gohlke's patch though.

Bug was probably introduced when removing the PackageLoader stuff.
Fix is the same as how this issue is solved in numpy.
