### PR TITLE
BUG: Couldn't build from source distribution with existing version.py

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -106,15 +106,28 @@ del _num
 del linalg
 __all__.remove('linalg')
 
+# We first need to detect if we're being called as part of the scipy
+# setup procedure itself in a reliable manner.
 try:
-    from scipy.__config__ import show as show_config
-except ImportError:
-    msg = """Error importing scipy: you cannot import scipy while
-    being in scipy source directory; please exit the scipy source
-    tree first, and relaunch your python intepreter."""
-    raise ImportError(msg)
-from scipy.version import version as __version__
+    __SCIPY_SETUP__
+except NameError:
+    __SCIPY_SETUP__ = False
 
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().bench
+
+if __SCIPY_SETUP__:
+    import sys as _sys
+    _sys.stderr.write('Running from scipy source directory.\n')
+    del _sys
+else:
+    try:
+        from scipy.__config__ import show as show_config
+    except ImportError:
+        msg = """Error importing scipy: you cannot import scipy while
+        being in scipy source directory; please exit the scipy source
+        tree first, and relaunch your python intepreter."""
+        raise ImportError(msg)
+    from scipy.version import version as __version__
+
+    from numpy.testing import Tester
+    test = Tester().test
+    bench = Tester().bench

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,11 @@ import subprocess
 import shutil
 import re
 
+if sys.version_info[0] < 3:
+    import __builtin__ as builtins
+else:
+    import builtins
+
 CLASSIFIERS = """\
 Development Status :: 4 - Beta
 Intended Audience :: Science/Research
@@ -79,8 +84,11 @@ def git_version():
 if os.path.exists('MANIFEST'):
     os.remove('MANIFEST')
 
-os.environ['NO_SCIPY_IMPORT'] = 'SciPy/setup.py'
-
+# This is a bit hackish: we are setting a global variable so that the main
+# numpy __init__ can detect if it is being loaded by the setup routine, to
+# avoid attempting to load components that aren't built yet.  While ugly, it's
+# a lot more robust than what was previously being used.
+builtins.__SCIPY_SETUP__ = True
 
 def write_version_py(filename='scipy/version.py'):
     cnt = """


### PR DESCRIPTION
I'm not able to build 0.10.0b1 from the source distribution at SourceForge (http://sourceforge.net/projects/scipy/files/scipy/0.10.0b1/scipy-0.10.0b1.tar.gz/download)

scott@godzilla:tmp$ tar -xzf scipy-0.10.0b1.tar.gz 
scott@godzilla:tmp$ cd scipy-0.10.0b1
scott@godzilla:scipy-0.10.0b1$ python setup.py build
Traceback (most recent call last):
  File "setup.py", line 188, in <module>
    setup_package()
  File "setup.py", line 165, in setup_package
    write_version_py()
  File "setup.py", line 105, in write_version_py
    from scipy.version import git_revision as GIT_REVISION
  File "/home/scott/tmp/scipy-0.10.0b1/scipy/**init**.py", line 115, in <module>
    raise ImportError(msg)
ImportError: Error importing scipy: you cannot import scipy while
    being in scipy source directory; please exit the scipy source
    tree first, and relaunch your python intepreter.

The problem was introduced by commit https://github.com/scipy/scipy/commit/74dccec7b8e8cbf056d2d7383f26619c63acd0e7, this pull request uses the workaround from Numpy and works on my Linux system.

Review welcome..
