### PR TITLE
QR decomposition with Q multiplication

### DIFF
--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -212,7 +212,8 @@ def qr_multiply(a, c, mode='right', pivoting=False, overwrite_a=False,
     if not mode in ['left', 'right']:
         raise ValueError("Mode argument should be one of ['left', 'right']")
     c = numpy.asarray_chkfinite(c)
-    if c.ndim == 1:
+    onedim = c.ndim == 1
+    if onedim:
         c = c.reshape(1, len(c))
         if mode == "left":
             c = c.T
@@ -251,6 +252,8 @@ def qr_multiply(a, c, mode='right', pivoting=False, overwrite_a=False,
         cQ = cQ.T.conjugate()
     if mode == "right":
         cQ = cQ[:, :min(M, N)]
+    if onedim:
+        cQ = cQ.ravel()
 
     return (cQ,) + raw[2:]
 

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -159,8 +159,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
 
     return (Q,) + Rj
 
-def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
-    overwrite_a=False, overwrite_c=False, lwork=None):
+def qr_multiply(a, c, mode='right', **kwargs):
     """Calculate the QR decomposition and multiply Q with a matrix.
 
     Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
@@ -214,6 +213,12 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
     """
     if not mode in ['left', 'right']:
         raise ValueError("Mode argument should be one of ['left', 'right']")
+    pivoting = kwargs.get("pivoting", False)
+    conjugate = kwargs.get("conjugate", False)
+    overwrite_a = kwargs.get("overwrite_a", False)
+    overwrite_c = kwargs.get("overwrite_c", False)
+    lwork = kwargs.get("lwork", None)
+
     c = numpy.asarray_chkfinite(c)
     onedim = c.ndim == 1
     if onedim:

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -160,7 +160,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
     return (Q,) + Rj
 
 def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
-    overwrite_a=False, overwrite_c=False, lwork=None):
+    overwrite_a=False, overwrite_c=False):
     """Calculate the QR decomposition and multiply Q with a matrix.
 
     Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
@@ -186,9 +186,6 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
         than explicit conjugation.
     overwrite_a : bool, optional
         Whether data in a is overwritten (may improve performance)
-    lwork : int, optional
-        Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
-        is computed.
     overwrite_c: bool, optional
         Whether data in c is overwritten (may improve performance).
         If this is used, c must be big enough to keep the result,
@@ -231,7 +228,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
             mode == "right" and M == c.shape[1]):
         raise ValueError("objects are not aligned") 
 
-    raw = qr(a, overwrite_a, lwork, "raw", pivoting)
+    raw = qr(a, overwrite_a, None, "raw", pivoting)
     Q, tau = raw[:2]
 
     if find_best_lapack_type((Q,))[0] in ('s', 'd'):
@@ -260,7 +257,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
         cc = c
         lr = "L" if mode == "left" else "R"
     cQ, = safecall(gor_un_mqr, "gormqr/gunmqr", lr, trans, Q, tau, cc,
-            lwork=lwork, overwrite_c=overwrite_c)
+            overwrite_c=overwrite_c)
     if trans != "N":
         cQ = cQ.T
     if mode == "right":

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -159,7 +159,8 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
 
     return (Q,) + Rj
 
-def qr_multiply(a, c, mode='right', **kwargs):
+def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
+    overwrite_a=False, overwrite_c=False, lwork=None):
     """Calculate the QR decomposition and multiply Q with a matrix.
 
     Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
@@ -215,12 +216,6 @@ def qr_multiply(a, c, mode='right', **kwargs):
     """
     if not mode in ['left', 'right']:
         raise ValueError("Mode argument should be one of ['left', 'right']")
-    pivoting = kwargs.get("pivoting", False)
-    conjugate = kwargs.get("conjugate", False)
-    overwrite_a = kwargs.get("overwrite_a", False)
-    overwrite_c = kwargs.get("overwrite_c", False)
-    lwork = kwargs.get("lwork", None)
-
     c = numpy.asarray_chkfinite(c)
     onedim = c.ndim == 1
     if onedim:

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -49,10 +49,10 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
 
     Returns
     -------
-    Q : double or complex ndarray
+    Q : float or complex ndarray
         Of shape (M, M), or (M, K) for ``mode='economic'``.  Not returned if
         ``mode='r'``.
-    R : double or complex ndarray
+    R : float or complex ndarray
         Of shape (M, N), or (K, N) for ``mode='economic'``.  ``K = min(M, N)``.
     P : integer ndarray
         Of shape (N,) for ``pivoting=True``. Not returned if ``pivoting=False``.
@@ -238,9 +238,9 @@ def qr_multiply(*args, **kwargs):
 
     Returns
     -------
-    CQ : double or complex ndarray
+    CQ : float or complex ndarray
         the product of Q and c, as defined in mode
-    R : double or complex ndarray
+    R : float or complex ndarray
         Of shape (K, N), ``K = min(M, N)``.
     P : integer ndarray
         Of shape (N,) for ``pivoting=True``. Not returned if ``pivoting=False``.
@@ -275,8 +275,8 @@ def qr_old(a, overwrite_a=False, lwork=None):
 
     Returns
     -------
-    Q : double or complex array, shape (M, M)
-    R : double or complex array, shape (M, N)
+    Q : float or complex array, shape (M, M)
+    R : float or complex array, shape (M, N)
         Size K = min(M, N)
 
     Raises LinAlgError if decomposition fails
@@ -333,8 +333,8 @@ def rq(a, overwrite_a=False, lwork=None, mode='full'):
 
     Returns
     -------
-    R : double array, shape (M, N)
-    Q : double or complex array, shape (M, M)
+    R : float array, shape (M, N)
+    Q : float or complex array, shape (M, M)
 
     Raises LinAlgError if decomposition fails
 

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -150,9 +150,9 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
             raise ValueError("illegal value in %d-th argument of internal geqrf"
                                                                         % -info)
     if not mode == 'economic' or M < N:
-        R = special_matrices.triu(qr)
+        R = numpy.triu(qr)
     else:
-        R = special_matrices.triu(qr[0:N, 0:N])
+        R = numpy.triu(qr[:N, :N])
 
     if mode == 'r':
         if pivoting:

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -8,7 +8,7 @@ from lapack import get_lapack_funcs, find_best_lapack_type
 from misc import _datacopied
 
 # XXX: what is qr_old, should it be kept?
-__all__ = ['qr', 'rq', 'qr_old']
+__all__ = ['qr', 'qr_multiply', 'rq', 'qr_old']
 
 def safecall(f, name, *args, **kwargs):
     lwork = kwargs.pop("lwork", None)
@@ -46,22 +46,12 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
         qr decomposition. If pivoting, compute the decomposition
         :lm:`A P = Q R` as above, but where P is chosen such that the diagonal
         of R is non-increasing.
-    c : array, two-dimensional
-        calculate the product of c and q, depending on the mode:
-        'left': dot(Q, c)
-        'right': dot(c, Q)
-        the shape of c must be appropriate for the matrix multiplications
-    overwrite_c: bool, optional
-        Whether data in c is overwritten (may improve performance)
-        
 
     Returns
     -------
     Q : double or complex ndarray
         Of shape (M, M), or (M, K) for ``mode='economic'``.  Not returned if
         ``mode='r'``.
-    CQ : double or complex ndarray
-        the product of Q and c, as defined in mode
     R : double or complex ndarray
         Of shape (M, N), or (K, N) for ``mode='economic'``.  ``K = min(M, N)``.
     P : integer ndarray
@@ -213,7 +203,59 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
         return Q, R, jpvt
     return Q, R
 
+def qr_multiply(*args, **kwargs):
+    """Calculate the QR decomposition and multiply Q with a matrix.
 
+    Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
+    and R upper triangular.
+
+    Parameters
+    ----------
+    a : array, shape (M, N)
+        Matrix to be decomposed
+    overwrite_a : bool, optional
+        Whether data in a is overwritten (may improve performance)
+    lwork : int, optional
+        Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
+        is computed.
+    mode : {'left', 'right'} 
+        dot(Q, c) is returned if mode is 'left',
+        dot(c, Q) is returned if mode is 'right'.
+        
+    pivoting : bool, optional
+        Whether or not factorization should include pivoting for rank-revealing
+        qr decomposition. If pivoting, compute the decomposition
+        :lm:`A P = Q R` as above, but where P is chosen such that the diagonal
+        of R is non-increasing.
+    c : array, two-dimensional
+        calculate the product of c and q, depending on the mode:
+        'left': dot(Q, c)
+        'right': dot(c, Q)
+        the shape of c must be appropriate for the matrix multiplications
+    overwrite_c: bool, optional
+        Whether data in c is overwritten (may improve performance)
+        
+
+    Returns
+    -------
+    CQ : double or complex ndarray
+        the product of Q and c, as defined in mode
+    R : double or complex ndarray
+        Of shape (K, N), ``K = min(M, N)``.
+    P : integer ndarray
+        Of shape (N,) for ``pivoting=True``. Not returned if ``pivoting=False``.
+
+    Raises
+    ------
+    LinAlgError
+        Raised if decomposition fails
+
+    Notes
+    -----
+    This is an interface to the LAPACK routines dgeqrf, zgeqrf,
+    dormqr, zunmqr, dgeqp3, and zgeqp3.
+    """
+    return qr(*args, **kwargs)
 
 def qr_old(a, overwrite_a=False, lwork=None):
     """Compute QR decomposition of a matrix.

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -102,10 +102,8 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
     ((9, 6), (6, 6), (6,))
 
     """
-    if mode == 'qr':
-        # 'qr' was the old default, equivalent to 'full'. Neither 'full' nor
-        # 'qr' are used below, but set to 'full' anyway to be sure
-        mode = 'full'
+    # 'qr' was the old default, equivalent to 'full'. Neither 'full' nor
+    # 'qr' are used below.
     # 'raw' is used only internally by qr_multiply, not documented on purpose
     if mode not in ['full', 'qr', 'r', 'economic', 'raw']:
         raise ValueError(
@@ -129,19 +127,17 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
     if mode not in ['economic', 'raw'] or M < N:
         R = numpy.triu(qr)
     else:
-        R = numpy.triu(qr[:N, :N])
+        R = numpy.triu(qr[:N, :])
+
+    if pivoting:
+        Rj = R, jpvt
+    else:
+        Rj = R,
 
     if mode == 'r':
-        if pivoting:
-            return R, jpvt
-        else:
-            return R
-
-    if mode == 'raw':
-        if pivoting:
-            return qr, tau, R, jpvt
-        else:
-            return qr, tau, R
+        return Rj
+    elif mode == 'raw':
+        return (qr, tau) + Rj
 
     if find_best_lapack_type((a1,))[0] in ('s', 'd'):
         gor_un_gqr, = get_lapack_funcs(('orgqr',), (qr,))
@@ -149,7 +145,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
         gor_un_gqr, = get_lapack_funcs(('ungqr',), (qr,))
 
     if M < N:
-        Q, = safecall(gor_un_gqr, "gorgqr/gungqr", qr[:,0:M], tau,
+        Q, = safecall(gor_un_gqr, "gorgqr/gungqr", qr[:, :M], tau,
             lwork=lwork, overwrite_a=1)
     elif mode == 'economic':
         Q, = safecall(gor_un_gqr, "gorgqr/gungqr", qr, tau, lwork=lwork,
@@ -161,9 +157,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
         Q, = safecall(gor_un_gqr, "gorgqr/gungqr", qqr, tau, lwork=lwork,
             overwrite_a=1)
 
-    if pivoting:
-        return Q, R, jpvt
-    return Q, R
+    return (Q,) + Rj
 
 def qr_multiply(a, c, mode='right', pivoting=False, overwrite_a=False,
     overwrite_c=False, lwork=None):

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -203,7 +203,8 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
         return Q, R, jpvt
     return Q, R
 
-def qr_multiply(*args, **kwargs):
+def qr_multiply(a, c, mode='right', pivoting=False, overwrite_a=False,
+    overwrite_c=False, lwork=None):
     """Calculate the QR decomposition and multiply Q with a matrix.
 
     Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
@@ -213,25 +214,25 @@ def qr_multiply(*args, **kwargs):
     ----------
     a : array, shape (M, N)
         Matrix to be decomposed
-    overwrite_a : bool, optional
-        Whether data in a is overwritten (may improve performance)
-    lwork : int, optional
-        Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
-        is computed.
+    c : array, one- or two-dimensional
+        calculate the product of c and q, depending on the mode:
     mode : {'left', 'right'} 
         dot(Q, c) is returned if mode is 'left',
         dot(c, Q) is returned if mode is 'right'.
-        
+        the shape of c must be appropriate for the matrix multiplications,
+        if mode is 'left', min(a.shape) == c.shape[0],
+        if mode is 'right', a.shape[0].
     pivoting : bool, optional
         Whether or not factorization should include pivoting for rank-revealing
         qr decomposition. If pivoting, compute the decomposition
         :lm:`A P = Q R` as above, but where P is chosen such that the diagonal
         of R is non-increasing.
-    c : array, two-dimensional
-        calculate the product of c and q, depending on the mode:
-        'left': dot(Q, c)
-        'right': dot(c, Q)
-        the shape of c must be appropriate for the matrix multiplications
+    overwrite_a : bool, optional
+        Whether data in a is overwritten (may improve performance)
+    lwork : int, optional
+        Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
+        is computed.
+        
     overwrite_c: bool, optional
         Whether data in c is overwritten (may improve performance)
         
@@ -255,7 +256,7 @@ def qr_multiply(*args, **kwargs):
     This is an interface to the LAPACK routines dgeqrf, zgeqrf,
     dormqr, zunmqr, dgeqp3, and zgeqp3.
     """
-    return qr(*args, **kwargs)
+    return qr(a, overwrite_a, lwork, mode, pivoting, c, overwrite_c)
 
 def qr_old(a, overwrite_a=False, lwork=None):
     """Compute QR decomposition of a matrix.

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -267,6 +267,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
 
     return (cQ,) + raw[1:]
 
+@numpy.deprecate
 def qr_old(a, overwrite_a=False, lwork=None):
     """Compute QR decomposition of a matrix.
 

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -228,9 +228,10 @@ def qr_multiply(a, c, mode='right', **kwargs):
 
     a = numpy.asarray(a) # chkfinite done in qr
     M, N = a.shape
-    if not (mode == "left" and (min(a.shape) == c.shape[0] or
-                    overwrite_c and M > N and M == c.shape[0]) or
-            mode == "right" and  a.shape[0] == c.shape[1]):
+    if not (mode == "left" and
+                (not overwrite_c and min(M, N) == c.shape[0] or
+                     overwrite_c and M == c.shape[0]) or
+            mode == "right" and M == c.shape[1]):
         raise ValueError("objects are not aligned") 
 
     raw = qr(a, overwrite_a, lwork, "raw", pivoting)

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -174,6 +174,12 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
             Q, = safecall(gor_un_gqr, "gorgqr/gungqr", qqr, tau, lwork=lwork,
                 overwrite_a=1)
     else:
+        c = asarray_chkfinite(c)
+        if c.ndim == 1:
+            c = c.reshape(1, len(c))
+            if mode == "left":
+                c = c.T
+
         if find_best_lapack_type((a1,))[0] in ('s', 'd'):
             gor_un_mqr, = get_lapack_funcs(('ormqr',), (qr,))
             trans = "T"

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -163,7 +163,7 @@ def qr_multiply(a, c, mode='right', **kwargs):
     """Calculate the QR decomposition and multiply Q with a matrix.
 
     Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
-    and R upper triangular.
+    and R upper triangular. Multiply Q with a vector or a matrix c.
 
     Parameters
     ----------
@@ -189,7 +189,9 @@ def qr_multiply(a, c, mode='right', **kwargs):
         Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
         is computed.
     overwrite_c: bool, optional
-        Whether data in c is overwritten (may improve performance)
+        Whether data in c is overwritten (may improve performance).
+        If this is used, c must be big enough to keep the result,
+        i.e. c.shape[0] = a.shape[0] if mode is 'left'.
         
 
     Returns

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -137,7 +137,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
     if mode == 'r':
         return Rj
     elif mode == 'raw':
-        return (qr, tau) + Rj
+        return ((qr, tau),) + Rj
 
     if find_best_lapack_type((a1,))[0] in ('s', 'd'):
         gor_un_gqr, = get_lapack_funcs(('orgqr',), (qr,))
@@ -229,7 +229,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
         raise ValueError("objects are not aligned") 
 
     raw = qr(a, overwrite_a, None, "raw", pivoting)
-    Q, tau = raw[:2]
+    Q, tau = raw[0]
 
     if find_best_lapack_type((Q,))[0] in ('s', 'd'):
         gor_un_mqr, = get_lapack_funcs(('ormqr',), (Q,))
@@ -265,7 +265,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
     if onedim:
         cQ = cQ.ravel()
 
-    return (cQ,) + raw[2:]
+    return (cQ,) + raw[1:]
 
 def qr_old(a, overwrite_a=False, lwork=None):
     """Compute QR decomposition of a matrix.

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -254,10 +254,7 @@ def qr_multiply(a, c, mode='right', **kwargs):
             trans = "N"
         lr = "R" if conjugate else "L"
         overwrite_c = True
-    elif c.flags["C_CONTIGUOUS"] and trans == "T":
-        cc = c.T
-        lr = "R" if mode == "left" else "L"
-    elif conjugate:
+    elif c.flags["C_CONTIGUOUS"] and trans == "T" or conjugate:
         cc = c.T
         lr = "R" if mode == "left" else "L"
     else: 

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -13,7 +13,8 @@ from misc import _datacopied
 __all__ = ['qr', 'rq', 'qr_old']
 
 
-def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
+def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
+    overwrite_c=False):
     """Compute QR decomposition of a matrix.
 
     Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
@@ -37,12 +38,22 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
         qr decomposition. If pivoting, compute the decomposition
         :lm:`A P = Q R` as above, but where P is chosen such that the diagonal
         of R is non-increasing.
+    c : array, two-dimensional
+        calculate the product of c and q, depending on the mode:
+        'left': dot(Q, c)
+        'right': dot(c, Q)
+        the shape of c must be appropriate for the matrix multiplications
+    overwrite_c: bool, optional
+        Whether data in c is overwritten (may improve performance)
+        
 
     Returns
     -------
     Q : double or complex ndarray
         Of shape (M, M), or (M, K) for ``mode='economic'``.  Not returned if
         ``mode='r'``.
+    CQ : double or complex ndarray
+        the product of Q and c, as defined in mode
     R : double or complex ndarray
         Of shape (M, N), or (K, N) for ``mode='economic'``.  ``K = min(M, N)``.
     P : integer ndarray
@@ -98,9 +109,15 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
         # 'qr' was the old default, equivalent to 'full'. Neither 'full' nor
         # 'qr' are used below, but set to 'full' anyway to be sure
         mode = 'full'
-    if not mode in ['full', 'qr', 'r', 'economic']:
-        raise ValueError(\
-                 "Mode argument should be one of ['full', 'r', 'economic']")
+    if (not mode in ['full', 'qr', 'r', 'economic']
+                 ) and c is None:
+        raise ValueError(
+                 "Mode argument should be one of "
+                 "['full', 'r', 'economic']")
+    if (not mode in ['left', 'right']
+                 ) and c is not None:
+        raise ValueError(
+                 "Mode argument should be one of ['left', 'right']")
 
     a1 = asarray_chkfinite(a)
     if len(a1.shape) != 2:
@@ -143,29 +160,64 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
         else:
             return R
 
-    if find_best_lapack_type((a1,))[0] in ('s', 'd'):
-        gor_un_gqr, = get_lapack_funcs(('orgqr',), (qr,))
-    else:
-        gor_un_gqr, = get_lapack_funcs(('ungqr',), (qr,))
+    if c is None:
+        if find_best_lapack_type((a1,))[0] in ('s', 'd'):
+            gor_un_gqr, = get_lapack_funcs(('orgqr',), (qr,))
+        else:
+            gor_un_gqr, = get_lapack_funcs(('ungqr',), (qr,))
 
-    if M < N:
-        # get optimal work array
-        Q, work, info = gor_un_gqr(qr[:,0:M], tau, lwork=-1, overwrite_a=1)
-        lwork = work[0].real.astype(numpy.int)
-        Q, work, info = gor_un_gqr(qr[:,0:M], tau, lwork=lwork, overwrite_a=1)
-    elif mode == 'economic':
-        # get optimal work array
-        Q, work, info = gor_un_gqr(qr, tau, lwork=-1, overwrite_a=1)
-        lwork = work[0].real.astype(numpy.int)
-        Q, work, info = gor_un_gqr(qr, tau, lwork=lwork, overwrite_a=1)
+        if M < N:
+            # get optimal work array
+            Q, work, info = gor_un_gqr(qr[:,0:M], tau, lwork=-1, overwrite_a=1)
+            lwork = work[0].real.astype(numpy.int)
+            Q, work, info = gor_un_gqr(qr[:,0:M], tau, lwork=lwork,
+                overwrite_a=1)
+        elif mode == 'economic':
+            # get optimal work array
+            Q, work, info = gor_un_gqr(qr, tau, lwork=-1, overwrite_a=1)
+            lwork = work[0].real.astype(numpy.int)
+            Q, work, info = gor_un_gqr(qr, tau, lwork=lwork, overwrite_a=1)
+        else:
+            t = qr.dtype.char
+            qqr = numpy.empty((M, M), dtype=t)
+            qqr[:,0:N] = qr
+            # get optimal work array
+            Q, work, info = gor_un_gqr(qqr, tau, lwork=-1, overwrite_a=1)
+            lwork = work[0].real.astype(numpy.int)
+            Q, work, info = gor_un_gqr(qqr, tau, lwork=lwork, overwrite_a=1)
     else:
-        t = qr.dtype.char
-        qqr = numpy.empty((M, M), dtype=t)
-        qqr[:,0:N] = qr
-        # get optimal work array
-        Q, work, info = gor_un_gqr(qqr, tau, lwork=-1, overwrite_a=1)
+        if find_best_lapack_type((a1,))[0] in ('s', 'd'):
+            gor_un_mqr, = get_lapack_funcs(('ormqr',), (qr,))
+            trans = "T"
+        else:
+            gor_un_mqr, = get_lapack_funcs(('unmqr',), (qr,))
+            trans = "C"
+
+        qr = qr[:, :min(M, N)]
+        if M > N and mode == "left":
+            if overwrite_c:
+                cc = c
+            else:
+                cc = numpy.zeros((M, c.shape[1]), dtype=c.dtype, order="F")
+                cc[:c.shape[0], :] = c
+                overwrite_c = True
+            lr = "L"
+            trans = "N"
+        elif c.flags["C_CONTIGUOUS"] and trans == "T":
+            cc = c.T
+            lr = "R" if mode == "left" else "L"
+        else: 
+            trans = "N"
+            cc = c
+            lr = "L" if mode == "left" else "R"
+        Q, work, info = gor_un_mqr(lr, trans, qr, tau, cc, lwork=-1)
         lwork = work[0].real.astype(numpy.int)
-        Q, work, info = gor_un_gqr(qqr, tau, lwork=lwork, overwrite_a=1)
+        Q, work, info = gor_un_mqr(lr, trans, qr, tau, cc, lwork=lwork,
+            overwrite_c=overwrite_c)
+        if trans != "N":
+            Q = Q.T.conjugate()
+        if mode == "right":
+            Q = Q[:, :min(M, N)]
 
     if info < 0:
         raise ValueError("illegal value in %d-th argument of internal gorgqr"

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -159,8 +159,8 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False):
 
     return (Q,) + Rj
 
-def qr_multiply(a, c, mode='right', pivoting=False, overwrite_a=False,
-    overwrite_c=False, lwork=None):
+def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
+    overwrite_a=False, overwrite_c=False, lwork=None):
     """Calculate the QR decomposition and multiply Q with a matrix.
 
     Calculate the decomposition :lm:`A = Q R` where Q is unitary/orthogonal
@@ -181,6 +181,9 @@ def qr_multiply(a, c, mode='right', pivoting=False, overwrite_a=False,
     pivoting : bool, optional
         Whether or not factorization should include pivoting for rank-revealing
         qr decomposition, see the documentation of qr.
+    conjugate : bool, optional
+        Whether Q should be complex-conjugated. This might be faster
+        than explicit conjugation.
     overwrite_a : bool, optional
         Whether data in a is overwritten (may improve performance)
     lwork : int, optional
@@ -230,16 +233,20 @@ def qr_multiply(a, c, mode='right', pivoting=False, overwrite_a=False,
 
     M, N = Q.shape
     Q = Q[:, :min(M, N)]
-    if M > N and mode == "left":
-        if overwrite_c:
-            cc = c
+    if M > N and mode == "left" and not overwrite_c:
+        if conjugate:
+            cc = numpy.zeros((c.shape[1], M), dtype=c.dtype, order="F")
+            cc[:, :c.shape[0]] = c.T
         else:
             cc = numpy.zeros((M, c.shape[1]), dtype=c.dtype, order="F")
             cc[:c.shape[0], :] = c
-            overwrite_c = True
-        lr = "L"
-        trans = "N"
+            trans = "N"
+        lr = "R" if conjugate else "L"
+        overwrite_c = True
     elif c.flags["C_CONTIGUOUS"] and trans == "T":
+        cc = c.T
+        lr = "R" if mode == "left" else "L"
+    elif conjugate:
         cc = c.T
         lr = "R" if mode == "left" else "L"
     else: 
@@ -249,7 +256,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, overwrite_a=False,
     cQ, = safecall(gor_un_mqr, "gormqr/gunmqr", lr, trans, Q, tau, cc,
             lwork=lwork, overwrite_c=overwrite_c)
     if trans != "N":
-        cQ = cQ.T.conjugate()
+        cQ = cQ.T
     if mode == "right":
         cQ = cQ[:, :min(M, N)]
     if onedim:

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -1,10 +1,8 @@
 """QR decomposition functions."""
 
 import numpy
-from numpy import asarray_chkfinite
 
 # Local imports
-import special_matrices
 from blas import get_blas_funcs
 from lapack import get_lapack_funcs, find_best_lapack_type
 from misc import _datacopied
@@ -129,7 +127,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
         raise ValueError(
                  "Mode argument should be one of ['left', 'right']")
 
-    a1 = asarray_chkfinite(a)
+    a1 = numpy.asarray_chkfinite(a)
     if len(a1.shape) != 2:
         raise ValueError("expected 2D array")
     M, N = a1.shape
@@ -174,7 +172,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
             Q, = safecall(gor_un_gqr, "gorgqr/gungqr", qqr, tau, lwork=lwork,
                 overwrite_a=1)
     else:
-        c = asarray_chkfinite(c)
+        c = numpy.asarray_chkfinite(c)
         if c.ndim == 1:
             c = c.reshape(1, len(c))
             if mode == "left":
@@ -242,7 +240,7 @@ def qr_old(a, overwrite_a=False, lwork=None):
     Raises LinAlgError if decomposition fails
 
     """
-    a1 = asarray_chkfinite(a)
+    a1 = numpy.asarray_chkfinite(a)
     if len(a1.shape) != 2:
         raise ValueError('expected matrix')
     M,N = a1.shape
@@ -258,7 +256,7 @@ def qr_old(a, overwrite_a=False, lwork=None):
                                                                     % -info)
     gemm, = get_blas_funcs(('gemm',), (qr,))
     t = qr.dtype.char
-    R = special_matrices.triu(qr)
+    R = numpy.triu(qr)
     Q = numpy.identity(M, dtype=t)
     ident = numpy.identity(M, dtype=t)
     zeros = numpy.zeros
@@ -320,7 +318,7 @@ def rq(a, overwrite_a=False, lwork=None, mode='full'):
         raise ValueError(\
                  "Mode argument should be one of ['full', 'r', 'economic']")
 
-    a1 = asarray_chkfinite(a)
+    a1 = numpy.asarray_chkfinite(a)
     if len(a1.shape) != 2:
         raise ValueError('expected matrix')
     M, N = a1.shape
@@ -336,9 +334,9 @@ def rq(a, overwrite_a=False, lwork=None, mode='full'):
         raise ValueError('illegal value in %d-th argument of internal gerqf'
                                                                     % -info)
     if not mode == 'economic' or N < M:
-        R = special_matrices.triu(rq, N-M)
+        R = numpy.triu(rq, N-M)
     else:
-        R = special_matrices.triu(rq[-M:, -M:])
+        R = numpy.triu(rq[-M:, -M:])
 
     if mode == 'r':
         return R

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -250,10 +250,10 @@ def qr_multiply(a, c, mode='right', **kwargs):
     if M > N and mode == "left" and not overwrite_c:
         if conjugate:
             cc = numpy.zeros((c.shape[1], M), dtype=c.dtype, order="F")
-            cc[:, :c.shape[0]] = c.T
+            cc[:, :N] = c.T
         else:
             cc = numpy.zeros((M, c.shape[1]), dtype=c.dtype, order="F")
-            cc[:c.shape[0], :] = c
+            cc[:N, :] = c
             trans = "N"
         lr = "R" if conjugate else "L"
         overwrite_c = True

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -177,7 +177,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
         dot(c, Q) is returned if mode is 'right'.
         the shape of c must be appropriate for the matrix multiplications,
         if mode is 'left', min(a.shape) == c.shape[0],
-        if mode is 'right', a.shape[0].
+        if mode is 'right', a.shape[0] == c.shape[1].
     pivoting : bool, optional
         Whether or not factorization should include pivoting for rank-revealing
         qr decomposition, see the documentation of qr.
@@ -221,6 +221,13 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
         if mode == "left":
             c = c.T
 
+    a = numpy.asarray(a) # chkfinite done in qr
+    M, N = a.shape
+    if not (mode == "left" and (min(a.shape) == c.shape[0] or
+                    overwrite_c and M > N and M == c.shape[0]) or
+            mode == "right" and  a.shape[0] == c.shape[1]):
+        raise ValueError("objects are not aligned") 
+
     raw = qr(a, overwrite_a, lwork, "raw", pivoting)
     Q, tau = raw[:2]
 
@@ -231,7 +238,6 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
         gor_un_mqr, = get_lapack_funcs(('unmqr',), (Q,))
         trans = "C"
 
-    M, N = Q.shape
     Q = Q[:, :min(M, N)]
     if M > N and mode == "left" and not overwrite_c:
         if conjugate:

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -12,6 +12,16 @@ from misc import _datacopied
 # XXX: what is qr_old, should it be kept?
 __all__ = ['qr', 'rq', 'qr_old']
 
+def safecall(f, name, *args, **kwargs):
+    lwork = kwargs.pop("lwork", None)
+    if lwork is None:
+        ret = f(*args, lwork=-1, **kwargs)
+        lwork = ret[-2][0].real.astype(numpy.int)
+    ret = f(*args, lwork=lwork, **kwargs)
+    if ret[-1] < 0:
+        raise ValueError("illegal value in %d-th argument of internal %s"
+                         % (-ret[-1], name))
+    return ret[:-2]
 
 def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
     overwrite_c=False):
@@ -127,28 +137,13 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
 
     if pivoting:
         geqp3, = get_lapack_funcs(('geqp3',), (a1,))
-        if lwork is None or lwork == -1:
-            # get optimal work array
-            qr, jpvt, tau, work, info = geqp3(a1, lwork=-1, overwrite_a=1)
-            lwork = work[0].real.astype(numpy.int)
-
-        qr, jpvt, tau, work, info = geqp3(a1, lwork=lwork,
-            overwrite_a=overwrite_a)
+        qr, jpvt, tau = safecall(geqp3, "geqp3", a1, overwrite_a=overwrite_a)
         jpvt -= 1 # geqp3 returns a 1-based index array, so subtract 1
-        if info < 0:
-            raise ValueError("illegal value in %d-th argument of internal geqp3"
-                                                                        % -info)
     else:
         geqrf, = get_lapack_funcs(('geqrf',), (a1,))
-        if lwork is None or lwork == -1:
-            # get optimal work array
-            qr, tau, work, info = geqrf(a1, lwork=-1, overwrite_a=1)
-            lwork = work[0].real.astype(numpy.int)
+        qr, tau = safecall(geqrf, "geqrf", a1, lwork=lwork,
+            overwrite_a=overwrite_a)
 
-        qr, tau, work, info = geqrf(a1, lwork=lwork, overwrite_a=overwrite_a)
-        if info < 0:
-            raise ValueError("illegal value in %d-th argument of internal geqrf"
-                                                                        % -info)
     if not mode == 'economic' or M < N:
         R = numpy.triu(qr)
     else:
@@ -167,24 +162,17 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
             gor_un_gqr, = get_lapack_funcs(('ungqr',), (qr,))
 
         if M < N:
-            # get optimal work array
-            Q, work, info = gor_un_gqr(qr[:,0:M], tau, lwork=-1, overwrite_a=1)
-            lwork = work[0].real.astype(numpy.int)
-            Q, work, info = gor_un_gqr(qr[:,0:M], tau, lwork=lwork,
-                overwrite_a=1)
+            Q, = safecall(gor_un_gqr, "gorgqr/gungqr", qr[:,0:M], tau,
+                lwork=lwork, overwrite_a=1)
         elif mode == 'economic':
-            # get optimal work array
-            Q, work, info = gor_un_gqr(qr, tau, lwork=-1, overwrite_a=1)
-            lwork = work[0].real.astype(numpy.int)
-            Q, work, info = gor_un_gqr(qr, tau, lwork=lwork, overwrite_a=1)
+            Q, = safecall(gor_un_gqr, "gorgqr/gungqr", qr, tau, lwork=lwork,
+                overwrite_a=1)
         else:
             t = qr.dtype.char
             qqr = numpy.empty((M, M), dtype=t)
-            qqr[:,0:N] = qr
-            # get optimal work array
-            Q, work, info = gor_un_gqr(qqr, tau, lwork=-1, overwrite_a=1)
-            lwork = work[0].real.astype(numpy.int)
-            Q, work, info = gor_un_gqr(qqr, tau, lwork=lwork, overwrite_a=1)
+            qqr[:, :N] = qr
+            Q, = safecall(gor_un_gqr, "gorgqr/gungqr", qqr, tau, lwork=lwork,
+                overwrite_a=1)
     else:
         if find_best_lapack_type((a1,))[0] in ('s', 'd'):
             gor_un_mqr, = get_lapack_funcs(('ormqr',), (qr,))
@@ -210,18 +198,13 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False, c=None,
             trans = "N"
             cc = c
             lr = "L" if mode == "left" else "R"
-        Q, work, info = gor_un_mqr(lr, trans, qr, tau, cc, lwork=-1)
-        lwork = work[0].real.astype(numpy.int)
-        Q, work, info = gor_un_mqr(lr, trans, qr, tau, cc, lwork=lwork,
-            overwrite_c=overwrite_c)
+        Q, = safecall(gor_un_mqr, "gormqr/gunmqr", lr, trans, qr, tau, cc,
+            lwork=lwork, overwrite_c=overwrite_c)
         if trans != "N":
             Q = Q.T.conjugate()
         if mode == "right":
             Q = Q[:, :min(M, N)]
 
-    if info < 0:
-        raise ValueError("illegal value in %d-th argument of internal gorgqr"
-                                                                    % -info)
     if pivoting:
         return Q, R, jpvt
     return Q, R

--- a/scipy/linalg/generic_flapack.pyf
+++ b/scipy/linalg/generic_flapack.pyf
@@ -504,6 +504,7 @@ interface
    ! Compute a QR factorization of a real M-by-N matrix A with column pivoting:
    !   A * P = Q * R.
 
+     threadsafe
      callstatement (*f2py_func)(&m,&n,a,&m,jpvt,tau,work,&lwork,&info)
      callprotoargument int*,int*,<type_in_c>*,int*,int*,<type_in_c>*,<type_in_c>*,int*,int*
 
@@ -524,6 +525,7 @@ interface
    ! Compute a QR factorization of a complex M-by-N matrix A with column pivoting:
    !   A * P = Q * R.
 
+     threadsafe
      callstatement (*f2py_func)(&m,&n,a,&m,jpvt,tau,work,&lwork,rwork,&info)
      callprotoargument int*,int*,<type_in_c>*,int*,int*,<type_in_c>*,<type_in_c>*,int*,<type_in_c>*,int*
 
@@ -545,6 +547,7 @@ interface
    ! Compute a QR factorization of a real M-by-N matrix A:
    !   A = Q * R.
 
+     threadsafe
      callstatement (*f2py_func)(&m,&n,a,&m,tau,work,&lwork,&info)
      callprotoargument int*,int*,<type_in_c>*,int*,<type_in_c>*,<type_in_c>*,int*,int*
 
@@ -564,6 +567,7 @@ interface
    ! Compute an RQ factorization of a real M-by-N matrix A:
    !   A = R * Q.
 
+     threadsafe
      callstatement (*f2py_func)(&m,&n,a,&m,tau,work,&lwork,&info)
      callprotoargument int*,int*,<type_in_c>*,int*,<type_in_c>*,<type_in_c>*,int*,int*
 
@@ -584,6 +588,7 @@ interface
    ! which is defined as the first N columns of a product of K elementary
    ! reflectors of order M (e.g. output of geqrf)
 
+     threadsafe
      callstatement (*f2py_func)(&m,&n,&k,a,&m,tau,work,&lwork,&info)
      callprotoargument int*,int*,int*,<type_in_c>*,int*,<type_in_c>*,<type_in_c>*,int*,int*
 
@@ -605,6 +610,7 @@ interface
    ! which is defined as the first N columns of a product of K elementary
    ! reflectors of order M (e.g. output of geqrf)
 
+     threadsafe
      callstatement (*f2py_func)(&m,&n,&k,a,&m,tau,work,&lwork,&info)
      callprotoargument int*,int*,int*,<type_in_c>*,int*,<type_in_c>*,<type_in_c>*,int*,int*
 
@@ -626,6 +632,7 @@ interface
    ! which is defined as the first N columns of a product of K elementary
    ! reflectors of order M (e.g. output of geqrf)
 
+     threadsafe
      callstatement (*f2py_func)(side,trans,&m,&n,&k,a,&lda,tau,c,&ldc,work,&lwork,&info)
      callprotoargument char*,char*,int*,int*,int*,<type_in_c>*,int*,<type_in_c>*,<type_in_c>*,int*,<type_in_c>*,int*,int*
 
@@ -651,6 +658,7 @@ interface
    ! which is defined as the first N columns of a product of K elementary
    ! reflectors of order M (e.g. output of geqrf)
 
+     threadsafe
      callstatement (*f2py_func)(side,trans,&m,&n,&k,a,&lda,tau,c,&ldc,work,&lwork,&info)
      callprotoargument char*,char*,int*,int*,int*,<type_in_c>*,int*,<type_in_c>*,<type_in_c>*,int*,<type_in_c>*,int*,int*
 
@@ -676,6 +684,7 @@ interface
    ! which is defined as the first N columns of a product of K elementary
    ! reflectors of order M (e.g. output of gerqf)
 
+     threadsafe
      callstatement (*f2py_func)(&m,&n,&k,a,&m,tau,work,&lwork,&info)
      callprotoargument int*,int*,int*,<type_in_c>*,int*,<type_in_c>*,<type_in_c>*,int*,int*
 
@@ -697,6 +706,7 @@ interface
    ! which is defined as the first N columns of a product of K elementary
    ! reflectors of order M (e.g. output of gerqf)
 
+     threadsafe
      callstatement (*f2py_func)(&m,&n,&k,a,&m,tau,work,&lwork,&info)
      callprotoargument int*,int*,int*,<type_in_c>*,int*,<type_in_c>*,<type_in_c>*,int*,int*
 

--- a/scipy/linalg/generic_flapack.pyf
+++ b/scipy/linalg/generic_flapack.pyf
@@ -619,6 +619,56 @@ interface
      integer intent(out) :: info
    end subroutine <tchar=c,z>ungqr
 
+   subroutine <tchar=s,d>ormqr(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
+
+   ! cq,work,info = ormqr(side,trans,a,tau,c,lwork)
+   ! multiplies the real matrix C with the real orthogonal matrix Q,
+   ! which is defined as the first N columns of a product of K elementary
+   ! reflectors of order M (e.g. output of geqrf)
+
+     callstatement (*f2py_func)(side,trans,&m,&n,&k,a,&lda,tau,c,&ldc,work,&lwork,&info)
+     callprotoargument char*,char*,int*,int*,int*,<type_in_c>*,int*,<type_in_c>*,<type_in_c>*,int*,<type_in_c>*,int*,int*
+
+     character intent(in),check(*side=='L'||*side=='R'):: side
+     character intent(in),check(*trans=='N'||*trans=='T'):: trans
+     integer intent(hide),depend(c):: m = shape(c,0)
+     integer intent(hide),depend(c):: n = shape(c,1)
+     integer intent(hide),depend(a):: k = shape(a,1)
+     <type_in> dimension(lda,k),intent(in):: a
+     integer intent(hide),depend(a):: lda = shape(a, 0)
+     <type_in> dimension(k),intent(in):: tau
+     <type_in> dimension(ldc,n),intent(in,out,copy,out=cq):: c
+     integer intent(hide),depend(c):: ldc = shape(c, 0)
+     <type_in> dimension(MAX(lwork,1)),intent(out):: work
+     integer intent(in):: lwork
+     integer intent(out) :: info
+   end subroutine <tchar=s,d>ormqr
+
+   subroutine <tchar=c,z>unmqr(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
+
+   ! cq,work,info = unmqr(side,trans,a,tau,c,lwork)
+   ! multiplies the complex matrix C with the complex unitary matrix Q,
+   ! which is defined as the first N columns of a product of K elementary
+   ! reflectors of order M (e.g. output of geqrf)
+
+     callstatement (*f2py_func)(side,trans,&m,&n,&k,a,&lda,tau,c,&ldc,work,&lwork,&info)
+     callprotoargument char*,char*,int*,int*,int*,<type_in_c>*,int*,<type_in_c>*,<type_in_c>*,int*,<type_in_c>*,int*,int*
+
+     character intent(in),check(*side=='L'||*side=='R'):: side
+     character intent(in),check(*trans=='N'||*trans=='C'):: trans
+     integer intent(hide),depend(c):: m = shape(c,0)
+     integer intent(hide),depend(c):: n = shape(c,1)
+     integer intent(hide),depend(a):: k = shape(a,1)
+     <type_in> dimension(lda,k),intent(in):: a
+     integer intent(hide),depend(a):: lda = shape(a, 0)
+     <type_in> dimension(k),intent(in):: tau
+     <type_in> dimension(ldc,n),intent(in,out,copy,out=cq):: c
+     integer intent(hide),depend(c):: ldc = shape(c, 0)
+     <type_in> dimension(MAX(lwork,1)),intent(out):: work
+     integer intent(in):: lwork
+     integer intent(out) :: info
+   end subroutine <tchar=c,z>unmqr
+
    subroutine <tchar=s,d>orgrq(m,n,k,a,tau,work,lwork,info)
 
    ! q,work,info = orgrq(a,lwork=3*n,overwrite_a=0)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1143,6 +1143,27 @@ class TestQR(TestCase):
         qc,r = qr_multiply(a, identity(2), "left")
         assert_array_almost_equal(qc, q)
 
+    def test_simple_complex_left_conjugate(self):
+        a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
+        q,r = qr(a)
+        c = [1, 2, 3+4j]
+        qc,r = qr_multiply(a, c, "left", conjugate=True)
+        assert_array_almost_equal(dot(q.conjugate(), c), qc)
+
+    def test_simple_complex_tall_left_conjugate(self):
+        a = [[3,3+4j],[5,2+2j],[3,2]]
+        q,r = qr(a)
+        c = [1, 2, 3+4j]
+        qc,r = qr_multiply(a, c, "left", conjugate=True)
+        assert_array_almost_equal(dot(q.conjugate(), c), qc)
+
+    def test_simple_complex_right_conjugate(self):
+        a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
+        q,r = qr(a)
+        c = [1, 2, 3+4j]
+        qc,r = qr_multiply(a, c, conjugate=True)
+        assert_array_almost_equal(dot(c, q.conjugate()), qc)
+
     def test_simple_complex_pivoting(self):
         a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
         q,r,p = qr(a, pivoting=True)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -863,6 +863,24 @@ class TestQR(TestCase):
         assert_array_almost_equal(dot(transpose(q),q),identity(3))
         assert_array_almost_equal(dot(q,r),a)
 
+    def test_simple_left(self):
+        a = [[8,2,3],[2,9,3],[5,3,6]]
+        q,r = qr(a)
+        c = [1, 2, 3]
+        qc,r = qr(a, mode="left", c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        qc,r = qr(a, mode="left", c=identity(3))
+        assert_array_almost_equal(q, qc)
+
+    def test_simple_right(self):
+        a = [[8,2,3],[2,9,3],[5,3,6]]
+        q,r = qr(a)
+        c = [1, 2, 3]
+        qc,r = qr(a, mode="right", c=c)
+        assert_array_almost_equal(dot(c, q), qc[0, :])
+        qc,r = qr(a, mode="right", c=identity(3))
+        assert_array_almost_equal(q, qc)
+
     def test_simple_pivoting(self):
         a = np.asarray([[8,2,3],[2,9,3],[5,3,6]])
         q,r,p = qr(a, pivoting=True)
@@ -873,6 +891,20 @@ class TestQR(TestCase):
         q2,r2 = qr(a[:,p])
         assert_array_almost_equal(q,q2)
         assert_array_almost_equal(r,r2)
+
+    def test_simple_left_pivoting(self):
+        a = [[8,2,3],[2,9,3],[5,3,6]]
+        q,r,jpvt = qr(a, pivoting=True)
+        c = [1, 2, 3]
+        qc,r,jpvt = qr(a, mode="left", pivoting=True, c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+
+    def test_simple_right_pivoting(self):
+        a = [[8,2,3],[2,9,3],[5,3,6]]
+        q,r,jpvt = qr(a, pivoting=True)
+        c = [1, 2, 3]
+        qc,r,jpvt = qr(a, mode="right", pivoting=True, c=c)
+        assert_array_almost_equal(dot(c, q), qc[0, :])
 
     def test_simple_trap(self):
         a = [[8,2,3],[2,9,3]]
@@ -931,6 +963,42 @@ class TestQR(TestCase):
         assert_array_almost_equal(q,q2)
         assert_array_almost_equal(r,r2)
 
+    def test_simple_tall_left(self):
+        a = [[8,2],[2,9],[5,3]]
+        q,r = qr(a, mode="economic") 
+        c = [1, 2]
+        qc,r = qr(a, mode="left", c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        qc,r = qr(a, mode="left", c=identity(2))
+        assert_array_almost_equal(qc, q)
+
+    def test_simple_tall_left_pivoting(self):
+        a = [[8,2],[2,9],[5,3]]
+        q,r,jpvt = qr(a, mode="economic", pivoting=True)
+        c = [1, 2]
+        qc,r,jpvt = qr(a, pivoting="True", mode="left", c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        qc,r,jpvt = qr(a, pivoting="True", mode="left", c=identity(2))
+        assert_array_almost_equal(qc, q)
+
+    def test_simple_tall_right(self):
+        a = [[8,2],[2,9],[5,3]]
+        q,r = qr(a, mode="economic")
+        c = [1, 2, 3]
+        cq,r = qr(a, mode="right", c=c)
+        assert_array_almost_equal(dot(c, q), cq[0, :])
+        cq,r = qr(a, mode="right", c=identity(3))
+        assert_array_almost_equal(cq, q)
+
+    def test_simple_tall_right_pivoting(self):
+        a = [[8,2],[2,9],[5,3]]
+        q,r,jpvt = qr(a, pivoting=True, mode="economic")
+        c = [1, 2, 3]
+        cq,r,jpvt = qr(a, pivoting="True", mode="right", c=c)
+        assert_array_almost_equal(dot(c, q), cq[0, :])
+        cq,r,jpvt = qr(a, pivoting="True", mode="right", c=identity(3))
+        assert_array_almost_equal(cq, q)
+
     def test_simple_fat(self):
         # full version
         a = [[8,2,5],[2,9,3]]
@@ -977,11 +1045,65 @@ class TestQR(TestCase):
         assert_array_almost_equal(q,q2)
         assert_array_almost_equal(r,r2)
 
+    def test_simple_fat_left(self):
+        a = [[8,2,3],[2,9,5]]
+        q,r = qr(a, mode="economic") 
+        c = [1, 2]
+        qc,r = qr(a, mode="left", c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        qc,r = qr(a, mode="left", c=identity(2))
+        assert_array_almost_equal(qc, q)
+
+    def test_simple_fat_left_pivoting(self):
+        a = [[8,2,3],[2,9,5]]
+        q,r,jpvt = qr(a, mode="economic", pivoting=True)
+        c = [1, 2]
+        qc,r,jpvt = qr(a, pivoting="True", mode="left", c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        qc,r,jpvt = qr(a, pivoting="True", mode="left", c=identity(2))
+        assert_array_almost_equal(qc, q)
+
+    def test_simple_fat_right(self):
+        a = [[8,2,3],[2,9,5]]
+        q,r = qr(a, mode="economic")
+        c = [1, 2]
+        cq,r = qr(a, mode="right", c=c)
+        assert_array_almost_equal(dot(c, q), cq[0, :])
+        cq,r = qr(a, mode="right", c=identity(2))
+        assert_array_almost_equal(cq, q)
+
+    def test_simple_fat_right_pivoting(self):
+        a = [[8,2,3],[2,9,5]]
+        q,r,jpvt = qr(a, pivoting=True, mode="economic")
+        c = [1, 2]
+        cq,r,jpvt = qr(a, pivoting="True", mode="right", c=c)
+        assert_array_almost_equal(dot(c, q), cq[0, :])
+        cq,r,jpvt = qr(a, pivoting="True", mode="right", c=identity(2))
+        assert_array_almost_equal(cq, q)
+
     def test_simple_complex(self):
         a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
         q,r = qr(a)
         assert_array_almost_equal(dot(conj(transpose(q)),q),identity(3))
         assert_array_almost_equal(dot(q,r),a)
+
+    def test_simple_complex_left(self):
+        a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
+        q,r = qr(a)
+        c = [1, 2, 3+4j]
+        qc,r = qr(a, mode="left", c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        qc,r = qr(a, mode="left", c=identity(3))
+        assert_array_almost_equal(q, qc)
+
+    def test_simple_complex_right(self):
+        a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
+        q,r = qr(a)
+        c = [1, 2, 3+4j]
+        qc,r = qr(a, mode="right", c=c)
+        assert_array_almost_equal(dot(c, q), qc[0, :])
+        qc,r = qr(a, mode="right", c=identity(3))
+        assert_array_almost_equal(q, qc)
 
     def test_simple_complex_pivoting(self):
         a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
@@ -994,6 +1116,20 @@ class TestQR(TestCase):
         assert_array_almost_equal(q,q2)
         assert_array_almost_equal(r,r2)
 
+    def test_simple_complex_left_pivoting(self):
+        a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
+        q,r,jpvt = qr(a, pivoting=True)
+        c = [1, 2, 3+4j]
+        qc,r,jpvt = qr(a, mode="left", pivoting=True, c=c)
+        assert_array_almost_equal(dot(q, c), qc[:, 0])
+
+    def test_simple_complex_right_pivoting(self):
+        a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
+        q,r,jpvt = qr(a, pivoting=True)
+        c = [1, 2, 3+4j]
+        qc,r,jpvt = qr(a, mode="right", pivoting=True, c=c)
+        assert_array_almost_equal(dot(c, q), qc[0, :])
+
     def test_random(self):
         n = 20
         for k in range(2):
@@ -1001,6 +1137,28 @@ class TestQR(TestCase):
             q,r = qr(a)
             assert_array_almost_equal(dot(transpose(q),q),identity(n))
             assert_array_almost_equal(dot(q,r),a)
+
+    def test_random_left(self):
+        n = 20
+        for k in range(2):
+            a = random([n,n])
+            q,r = qr(a)
+            c = random([n])
+            qc,r = qr(a, mode="left", c=c)
+            assert_array_almost_equal(dot(q, c), qc[:, 0])
+            qc,r = qr(a, mode="left", c=identity(n))
+            assert_array_almost_equal(q, qc)
+
+    def test_random_right(self):
+        n = 20
+        for k in range(2):
+            a = random([n,n])
+            q,r = qr(a)
+            c = random([n])
+            cq,r = qr(a, mode="right", c=c)
+            assert_array_almost_equal(dot(c, q), cq[0, :])
+            cq,r = qr(a, mode="right", c=identity(n))
+            assert_array_almost_equal(q, cq)
 
     def test_random_pivoting(self):
         n = 20
@@ -1024,6 +1182,32 @@ class TestQR(TestCase):
             q,r = qr(a)
             assert_array_almost_equal(dot(transpose(q),q),identity(m))
             assert_array_almost_equal(dot(q,r),a)
+
+    def test_random_tall_left(self):
+        # full version
+        m = 200
+        n = 100
+        for k in range(2):
+            a = random([m,n])
+            q,r = qr(a, mode="economic") 
+            c = random([n])
+            qc,r = qr(a, mode="left", c=c)
+            assert_array_almost_equal(dot(q, c), qc[:, 0])
+            qc,r = qr(a, mode="left", c=identity(n))
+            assert_array_almost_equal(qc, q)
+
+    def test_random_tall_right(self):
+        # full version
+        m = 200
+        n = 100
+        for k in range(2):
+            a = random([m,n])
+            q,r = qr(a, mode="economic") 
+            c = random([m])
+            cq,r = qr(a, mode="right", c=c)
+            assert_array_almost_equal(dot(c, q), cq[0, :])
+            cq,r = qr(a, mode="right", c=identity(m))
+            assert_array_almost_equal(cq, q)
 
     def test_random_tall_pivoting(self):
         # full version pivoting
@@ -1099,6 +1283,28 @@ class TestQR(TestCase):
             q,r = qr(a)
             assert_array_almost_equal(dot(conj(transpose(q)),q),identity(n))
             assert_array_almost_equal(dot(q,r),a)
+
+    def test_random_complex_left(self):
+        n = 20
+        for k in range(2):
+            a = random([n,n])+1j*random([n,n])
+            q,r = qr(a)
+            c = random([n])+1j*random([n])
+            qc,r = qr(a, mode="left", c=c)
+            assert_array_almost_equal(dot(q, c), qc[:, 0])
+            qc,r = qr(a, mode="left", c=identity(n))
+            assert_array_almost_equal(q, qc)
+
+    def test_random_complex_right(self):
+        n = 20
+        for k in range(2):
+            a = random([n,n])+1j*random([n,n])
+            q,r = qr(a)
+            c = random([n])+1j*random([n])
+            cq,r = qr(a, mode="right", c=c)
+            assert_array_almost_equal(dot(c, q), cq[0, :])
+            cq,r = qr(a, mode="right", c=identity(n))
+            assert_array_almost_equal(q, cq)
 
     def test_random_complex_pivoting(self):
         n = 20

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -885,17 +885,19 @@ class TestQR(TestCase):
         a = [[8,2,3],[2,9,3],[5,3,6]]
         q,r = qr(a)
         c = [1, 2, 3]
-        qc,r = qr_multiply(a, c, "left") 
+        qc,r2 = qr_multiply(a, c, "left") 
         assert_array_almost_equal(dot(q, c), qc[:, 0])
-        qc,r = qr_multiply(a, identity(3), "left")
+        assert_array_almost_equal(r, r2)
+        qc,r2 = qr_multiply(a, identity(3), "left")
         assert_array_almost_equal(q, qc)
 
     def test_simple_right(self):
         a = [[8,2,3],[2,9,3],[5,3,6]]
         q,r = qr(a)
         c = [1, 2, 3]
-        qc,r = qr_multiply(a, c)
+        qc,r2 = qr_multiply(a, c)
         assert_array_almost_equal(dot(c, q), qc[0, :])
+        assert_array_almost_equal(r, r2)
         qc,r = qr_multiply(a, identity(3))
         assert_array_almost_equal(q, qc)
 
@@ -985,8 +987,9 @@ class TestQR(TestCase):
         a = [[8,2],[2,9],[5,3]]
         q,r = qr(a, mode="economic") 
         c = [1, 2]
-        qc,r = qr_multiply(a, c, "left")
+        qc,r2 = qr_multiply(a, c, "left")
         assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(r, r2)
         qc,r = qr_multiply(a, identity(2), "left")
         assert_array_almost_equal(qc, q)
 
@@ -1004,8 +1007,9 @@ class TestQR(TestCase):
         a = [[8,2],[2,9],[5,3]]
         q,r = qr(a, mode="economic")
         c = [1, 2, 3]
-        cq,r = qr_multiply(a, c)
+        cq,r2 = qr_multiply(a, c)
         assert_array_almost_equal(dot(c, q), cq[0, :])
+        assert_array_almost_equal(r, r2)
         cq,r = qr_multiply(a, identity(3))
         assert_array_almost_equal(cq, q)
 
@@ -1068,8 +1072,9 @@ class TestQR(TestCase):
         a = [[8,2,3],[2,9,5]]
         q,r = qr(a, mode="economic") 
         c = [1, 2]
-        qc,r = qr_multiply(a, c, "left")
+        qc,r2 = qr_multiply(a, c, "left")
         assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(r, r2)
         qc,r = qr_multiply(a, identity(2), "left")
         assert_array_almost_equal(qc, q)
 
@@ -1086,8 +1091,9 @@ class TestQR(TestCase):
         a = [[8,2,3],[2,9,5]]
         q,r = qr(a, mode="economic")
         c = [1, 2]
-        cq,r = qr_multiply(a, c)
+        cq,r2 = qr_multiply(a, c)
         assert_array_almost_equal(dot(c, q), cq[0, :])
+        assert_array_almost_equal(r, r2)
         cq,r = qr_multiply(a, identity(2))
         assert_array_almost_equal(cq, q)
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -886,7 +886,7 @@ class TestQR(TestCase):
         q,r = qr(a)
         c = [1, 2, 3]
         qc,r2 = qr_multiply(a, c, "left") 
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
         assert_array_almost_equal(r, r2)
         qc,r2 = qr_multiply(a, identity(3), "left")
         assert_array_almost_equal(q, qc)
@@ -896,7 +896,7 @@ class TestQR(TestCase):
         q,r = qr(a)
         c = [1, 2, 3]
         qc,r2 = qr_multiply(a, c)
-        assert_array_almost_equal(dot(c, q), qc[0, :])
+        assert_array_almost_equal(dot(c, q), qc)
         assert_array_almost_equal(r, r2)
         qc,r = qr_multiply(a, identity(3))
         assert_array_almost_equal(q, qc)
@@ -924,7 +924,7 @@ class TestQR(TestCase):
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3]
         qc,r,jpvt = qr_multiply(a, c, pivoting=True)
-        assert_array_almost_equal(dot(c, q), qc[0, :])
+        assert_array_almost_equal(dot(c, q), qc)
 
     def test_simple_trap(self):
         a = [[8,2,3],[2,9,3]]
@@ -988,7 +988,7 @@ class TestQR(TestCase):
         q,r = qr(a, mode="economic") 
         c = [1, 2]
         qc,r2 = qr_multiply(a, c, "left")
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
         assert_array_almost_equal(r, r2)
         qc,r = qr_multiply(a, identity(2), "left")
         assert_array_almost_equal(qc, q)
@@ -999,7 +999,7 @@ class TestQR(TestCase):
         c = [1, 2]
         qc,r,kpvt = qr_multiply(a, c, "left", True)
         assert_array_equal(jpvt, kpvt)
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
         qc,r,jpvt = qr_multiply(a, identity(2), "left", True)
         assert_array_almost_equal(qc, q)
 
@@ -1008,7 +1008,7 @@ class TestQR(TestCase):
         q,r = qr(a, mode="economic")
         c = [1, 2, 3]
         cq,r2 = qr_multiply(a, c)
-        assert_array_almost_equal(dot(c, q), cq[0, :])
+        assert_array_almost_equal(dot(c, q), cq)
         assert_array_almost_equal(r, r2)
         cq,r = qr_multiply(a, identity(3))
         assert_array_almost_equal(cq, q)
@@ -1018,7 +1018,7 @@ class TestQR(TestCase):
         q,r,jpvt = qr(a, pivoting=True, mode="economic")
         c = [1, 2, 3]
         cq,r,jpvt = qr_multiply(a, c, pivoting=True)
-        assert_array_almost_equal(dot(c, q), cq[0, :])
+        assert_array_almost_equal(dot(c, q), cq)
         cq,r,jpvt = qr_multiply(a, identity(3), pivoting=True)
         assert_array_almost_equal(cq, q)
 
@@ -1073,7 +1073,7 @@ class TestQR(TestCase):
         q,r = qr(a, mode="economic") 
         c = [1, 2]
         qc,r2 = qr_multiply(a, c, "left")
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
         assert_array_almost_equal(r, r2)
         qc,r = qr_multiply(a, identity(2), "left")
         assert_array_almost_equal(qc, q)
@@ -1083,7 +1083,7 @@ class TestQR(TestCase):
         q,r,jpvt = qr(a, mode="economic", pivoting=True)
         c = [1, 2]
         qc,r,jpvt = qr_multiply(a, c, "left", True)
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
         qc,r,jpvt = qr_multiply(a, identity(2), "left", True)
         assert_array_almost_equal(qc, q)
 
@@ -1092,7 +1092,7 @@ class TestQR(TestCase):
         q,r = qr(a, mode="economic")
         c = [1, 2]
         cq,r2 = qr_multiply(a, c)
-        assert_array_almost_equal(dot(c, q), cq[0, :])
+        assert_array_almost_equal(dot(c, q), cq)
         assert_array_almost_equal(r, r2)
         cq,r = qr_multiply(a, identity(2))
         assert_array_almost_equal(cq, q)
@@ -1102,7 +1102,7 @@ class TestQR(TestCase):
         q,r,jpvt = qr(a, pivoting=True, mode="economic")
         c = [1, 2]
         cq,r,jpvt = qr_multiply(a, c, pivoting=True)
-        assert_array_almost_equal(dot(c, q), cq[0, :])
+        assert_array_almost_equal(dot(c, q), cq)
         cq,r,jpvt = qr_multiply(a, identity(2), pivoting=True)
         assert_array_almost_equal(cq, q)
 
@@ -1117,7 +1117,7 @@ class TestQR(TestCase):
         q,r = qr(a)
         c = [1, 2, 3+4j]
         qc,r = qr_multiply(a, c, "left")
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
         qc,r = qr_multiply(a, identity(3), "left")
         assert_array_almost_equal(q, qc)
 
@@ -1126,7 +1126,7 @@ class TestQR(TestCase):
         q,r = qr(a)
         c = [1, 2, 3+4j]
         qc,r = qr_multiply(a, c)
-        assert_array_almost_equal(dot(c, q), qc[0, :])
+        assert_array_almost_equal(dot(c, q), qc)
         qc,r = qr_multiply(a, identity(3))
         assert_array_almost_equal(q, qc)
 
@@ -1159,14 +1159,14 @@ class TestQR(TestCase):
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3+4j]
         qc,r,jpvt = qr_multiply(a, c, "left", True)
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
 
     def test_simple_complex_right_pivoting(self):
         a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3+4j]
         qc,r,jpvt = qr_multiply(a, c, pivoting=True)
-        assert_array_almost_equal(dot(c, q), qc[0, :])
+        assert_array_almost_equal(dot(c, q), qc)
 
     def test_random(self):
         n = 20
@@ -1183,7 +1183,7 @@ class TestQR(TestCase):
             q,r = qr(a)
             c = random([n])
             qc,r = qr_multiply(a, c, "left")
-            assert_array_almost_equal(dot(q, c), qc[:, 0])
+            assert_array_almost_equal(dot(q, c), qc)
             qc,r = qr_multiply(a, identity(n), "left")
             assert_array_almost_equal(q, qc)
 
@@ -1194,7 +1194,7 @@ class TestQR(TestCase):
             q,r = qr(a)
             c = random([n])
             cq,r = qr_multiply(a, c)
-            assert_array_almost_equal(dot(c, q), cq[0, :])
+            assert_array_almost_equal(dot(c, q), cq)
             cq,r = qr_multiply(a, identity(n))
             assert_array_almost_equal(q, cq)
 
@@ -1230,7 +1230,7 @@ class TestQR(TestCase):
             q,r = qr(a, mode="economic") 
             c = random([n])
             qc,r = qr_multiply(a, c, "left")
-            assert_array_almost_equal(dot(q, c), qc[:, 0])
+            assert_array_almost_equal(dot(q, c), qc)
             qc,r = qr_multiply(a, identity(n), "left")
             assert_array_almost_equal(qc, q)
 
@@ -1243,7 +1243,7 @@ class TestQR(TestCase):
             q,r = qr(a, mode="economic") 
             c = random([m])
             cq,r = qr_multiply(a, c)
-            assert_array_almost_equal(dot(c, q), cq[0, :])
+            assert_array_almost_equal(dot(c, q), cq)
             cq,r = qr_multiply(a, identity(m))
             assert_array_almost_equal(cq, q)
 
@@ -1329,7 +1329,7 @@ class TestQR(TestCase):
             q,r = qr(a)
             c = random([n])+1j*random([n])
             qc,r = qr_multiply(a, c, "left")
-            assert_array_almost_equal(dot(q, c), qc[:, 0])
+            assert_array_almost_equal(dot(q, c), qc)
             qc,r = qr_multiply(a, identity(n), "left")
             assert_array_almost_equal(q, qc)
 
@@ -1340,7 +1340,7 @@ class TestQR(TestCase):
             q,r = qr(a)
             c = random([n])+1j*random([n])
             cq,r = qr_multiply(a, c)
-            assert_array_almost_equal(dot(c, q), cq[0, :])
+            assert_array_almost_equal(dot(c, q), cq)
             cq,r = qr_multiply(a, identity(n))
             assert_array_almost_equal(q, cq)
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -990,6 +990,9 @@ class TestQR(TestCase):
         qc,r2 = qr_multiply(a, c, "left")
         assert_array_almost_equal(dot(q, c), qc)
         assert_array_almost_equal(r, r2)
+        c = array([1,2,0])
+        qc,r2 = qr_multiply(a, c, "left", overwrite_c=True)
+        assert_array_almost_equal(dot(q, c[:2]), qc)
         qc,r = qr_multiply(a, identity(2), "left")
         assert_array_almost_equal(qc, q)
 
@@ -1152,8 +1155,8 @@ class TestQR(TestCase):
 
     def test_simple_complex_tall_left_conjugate(self):
         a = [[3,3+4j],[5,2+2j],[3,2]]
-        q,r = qr(a)
-        c = [1, 2, 3+4j]
+        q,r = qr(a, mode='economic')
+        c = [1, 3+4j]
         qc,r = qr_multiply(a, c, "left", conjugate=True)
         assert_array_almost_equal(dot(q.conjugate(), c), qc)
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -917,7 +917,7 @@ class TestQR(TestCase):
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3]
         qc,r,jpvt = qr_multiply(a, c, "left", pivoting=True)
-        assert_array_almost_equal(dot(q, c), qc[:, 0])
+        assert_array_almost_equal(dot(q, c), qc)
 
     def test_simple_right_pivoting(self):
         a = [[8,2,3],[2,9,3],[5,3,6]]

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1091,9 +1091,9 @@ class TestQR(TestCase):
         a = [[3,3+4j,5],[5,2,2+7j],[3,2,7]]
         q,r = qr(a)
         c = [1, 2, 3+4j]
-        qc,r = qr(a, mode="left", c=c)
+        qc,r = qr_multiply(a, c, "left")
         assert_array_almost_equal(dot(q, c), qc[:, 0])
-        qc,r = qr(a, mode="left", c=identity(3))
+        qc,r = qr_multiply(a, identity(3), "left")
         assert_array_almost_equal(q, qc)
 
     def test_simple_complex_right(self):
@@ -1144,9 +1144,9 @@ class TestQR(TestCase):
             a = random([n,n])
             q,r = qr(a)
             c = random([n])
-            qc,r = qr(a, mode="left", c=c)
+            qc,r = qr_multiply(a, c, "left")
             assert_array_almost_equal(dot(q, c), qc[:, 0])
-            qc,r = qr(a, mode="left", c=identity(n))
+            qc,r = qr_multiply(a, identity(n), "left")
             assert_array_almost_equal(q, qc)
 
     def test_random_right(self):
@@ -1155,9 +1155,9 @@ class TestQR(TestCase):
             a = random([n,n])
             q,r = qr(a)
             c = random([n])
-            cq,r = qr(a, mode="right", c=c)
+            cq,r = qr_multiply(a, c)
             assert_array_almost_equal(dot(c, q), cq[0, :])
-            cq,r = qr(a, mode="right", c=identity(n))
+            cq,r = qr_multiply(a, identity(n))
             assert_array_almost_equal(q, cq)
 
     def test_random_pivoting(self):
@@ -1290,9 +1290,9 @@ class TestQR(TestCase):
             a = random([n,n])+1j*random([n,n])
             q,r = qr(a)
             c = random([n])+1j*random([n])
-            qc,r = qr(a, mode="left", c=c)
+            qc,r = qr_multiply(a, c, "left")
             assert_array_almost_equal(dot(q, c), qc[:, 0])
-            qc,r = qr(a, mode="left", c=identity(n))
+            qc,r = qr_multiply(a, identity(n), "left")
             assert_array_almost_equal(q, qc)
 
     def test_random_complex_right(self):
@@ -1301,9 +1301,9 @@ class TestQR(TestCase):
             a = random([n,n])+1j*random([n,n])
             q,r = qr(a)
             c = random([n])+1j*random([n])
-            cq,r = qr(a, mode="right", c=c)
+            cq,r = qr_multiply(a, c)
             assert_array_almost_equal(dot(c, q), cq[0, :])
-            cq,r = qr(a, mode="right", c=identity(n))
+            cq,r = qr_multiply(a, identity(n))
             assert_array_almost_equal(q, cq)
 
     def test_random_complex_pivoting(self):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -916,7 +916,7 @@ class TestQR(TestCase):
         a = [[8,2,3],[2,9,3],[5,3,6]]
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3]
-        qc,r,jpvt = qr_multiply(a, c, "left", True)
+        qc,r,jpvt = qr_multiply(a, c, "left", pivoting=True)
         assert_array_almost_equal(dot(q, c), qc[:, 0])
 
     def test_simple_right_pivoting(self):
@@ -1000,10 +1000,10 @@ class TestQR(TestCase):
         a = [[8,2],[2,9],[5,3]]
         q,r,jpvt = qr(a, mode="economic", pivoting=True)
         c = [1, 2]
-        qc,r,kpvt = qr_multiply(a, c, "left", True)
+        qc,r,kpvt = qr_multiply(a, c, "left", pivoting=True)
         assert_array_equal(jpvt, kpvt)
         assert_array_almost_equal(dot(q, c), qc)
-        qc,r,jpvt = qr_multiply(a, identity(2), "left", True)
+        qc,r,jpvt = qr_multiply(a, identity(2), "left", pivoting=True)
         assert_array_almost_equal(qc, q)
 
     def test_simple_tall_right(self):
@@ -1085,9 +1085,9 @@ class TestQR(TestCase):
         a = [[8,2,3],[2,9,5]]
         q,r,jpvt = qr(a, mode="economic", pivoting=True)
         c = [1, 2]
-        qc,r,jpvt = qr_multiply(a, c, "left", True)
+        qc,r,jpvt = qr_multiply(a, c, "left", pivoting=True)
         assert_array_almost_equal(dot(q, c), qc)
-        qc,r,jpvt = qr_multiply(a, identity(2), "left", True)
+        qc,r,jpvt = qr_multiply(a, identity(2), "left", pivoting=True)
         assert_array_almost_equal(qc, q)
 
     def test_simple_fat_right(self):
@@ -1182,7 +1182,7 @@ class TestQR(TestCase):
         a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3+4j]
-        qc,r,jpvt = qr_multiply(a, c, "left", True)
+        qc,r,jpvt = qr_multiply(a, c, "left", pivoting=True)
         assert_array_almost_equal(dot(q, c), qc)
 
     def test_simple_complex_right_pivoting(self):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -916,7 +916,7 @@ class TestQR(TestCase):
         a = [[8,2,3],[2,9,3],[5,3,6]]
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3]
-        qc,r,jpvt = qr_multiply(a, c, "left", pivoting=True)
+        qc,r,jpvt = qr_multiply(a, c, "left", True)
         assert_array_almost_equal(dot(q, c), qc)
 
     def test_simple_right_pivoting(self):
@@ -1000,10 +1000,10 @@ class TestQR(TestCase):
         a = [[8,2],[2,9],[5,3]]
         q,r,jpvt = qr(a, mode="economic", pivoting=True)
         c = [1, 2]
-        qc,r,kpvt = qr_multiply(a, c, "left", pivoting=True)
+        qc,r,kpvt = qr_multiply(a, c, "left", True)
         assert_array_equal(jpvt, kpvt)
         assert_array_almost_equal(dot(q, c), qc)
-        qc,r,jpvt = qr_multiply(a, identity(2), "left", pivoting=True)
+        qc,r,jpvt = qr_multiply(a, identity(2), "left", True)
         assert_array_almost_equal(qc, q)
 
     def test_simple_tall_right(self):
@@ -1085,9 +1085,9 @@ class TestQR(TestCase):
         a = [[8,2,3],[2,9,5]]
         q,r,jpvt = qr(a, mode="economic", pivoting=True)
         c = [1, 2]
-        qc,r,jpvt = qr_multiply(a, c, "left", pivoting=True)
+        qc,r,jpvt = qr_multiply(a, c, "left", True)
         assert_array_almost_equal(dot(q, c), qc)
-        qc,r,jpvt = qr_multiply(a, identity(2), "left", pivoting=True)
+        qc,r,jpvt = qr_multiply(a, identity(2), "left", True)
         assert_array_almost_equal(qc, q)
 
     def test_simple_fat_right(self):
@@ -1182,7 +1182,7 @@ class TestQR(TestCase):
         a = np.asarray([[3,3+4j,5],[5,2,2+7j],[3,2,7]])
         q,r,jpvt = qr(a, pivoting=True)
         c = [1, 2, 3+4j]
-        qc,r,jpvt = qr_multiply(a, c, "left", pivoting=True)
+        qc,r,jpvt = qr_multiply(a, c, "left", True)
         assert_array_almost_equal(dot(q, c), qc)
 
     def test_simple_complex_right_pivoting(self):


### PR DESCRIPTION
This is a rebased branch of https://github.com/scipy/scipy/pull/55
which had gotten a bit too long and complicated.

A QR decomposition is done in two steps: firstly,
R is calculated and an intermediate form of Q
(the so called "elementary reflectors"), and in a second
step, Q is actually calculated.

The second step, however, can be costly and
thus is not done if you are not interested in Q. The
QR decomposition code already allows for not
calculating Q.

Very often, however, one is interested in Q only in
order to multiply it with a vector c. This can be done
without ever calculating Q.

This pull request adds support for two things:
firstly, one can get the intermediate result
(the "elementary reflectors") by selecting the
respective mode of the QR decomposition, and
secondly, (more important), one can tell the
QR decomposition code to multiply Q with a
vector c (more generally: a matrix c, which is
equivalent to several vectors), and return the
result instead of Q. Since in this case Q is
never calculated, this is more efficient.

Thirdly, this pull requests contains some minor
code cleanup, that someone should have a look
at, and fourthly, some tests are added for the
additional features.

All four new features are in mostly independent
commits, so if someone doesn't like one of them
just kick them out.
