### PR TITLE
TST: clean up test noise from floating point operations.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,7 @@ include setupscons.py
 include setupegg.py
 include setup.py
 include scipy/*.py
-# Adding scons build relateed files not found by distutils
+# Adding scons build related files not found by distutils
 recursive-include scipy SConstruct SConscript
 # Add py3tool
 include tools/py3tool.py

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -91,7 +91,12 @@ def test_hyp2f1_real_some_points():
     dataset = [p + (float(mpmath.hyp2f1(*p)),) for p in pts]
     dataset = np.array(dataset, dtype=np.float_)
 
-    FuncData(sc.hyp2f1, dataset, (0,1,2,3), 4, rtol=1e-10).check()
+    olderr = np.seterr(invalid='ignore')
+    try:
+        FuncData(sc.hyp2f1, dataset, (0,1,2,3), 4, rtol=1e-10).check()
+    finally:
+        np.seterr(**olderr)
+
 
 @mpmath_check('0.14')
 def test_hyp2f1_some_points_2():
@@ -127,7 +132,12 @@ def test_hyp2f1_real_some():
                         continue
                     dataset.append((a, b, c, z, v))
     dataset = np.array(dataset, dtype=np.float_)
-    FuncData(sc.hyp2f1, dataset, (0,1,2,3), 4, rtol=1e-9).check()
+
+    olderr = np.seterr(invalid='ignore')
+    try:
+        FuncData(sc.hyp2f1, dataset, (0,1,2,3), 4, rtol=1e-9).check()
+    finally:
+        np.seterr(**olderr)
 
 @mpmath_check('0.12')
 @dec.slow
@@ -220,4 +230,9 @@ def test_lpmv():
     dataset = np.array(dataset, dtype=np.float_)
 
     evf = lambda mu,nu,x: sc.lpmv(mu.astype(int), nu, x)
-    FuncData(evf, dataset, (0,1,2), 3, rtol=1e-10, atol=1e-14).check()
+
+    olderr = np.seterr(invalid='ignore')
+    try:
+        FuncData(evf, dataset, (0,1,2), 3, rtol=1e-10, atol=1e-14).check()
+    finally:
+        np.seterr(**olderr)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -165,6 +165,7 @@ def _silence_fp_errors(func):
     wrap.__name__ = func.__name__
     return wrap
 
+@_silence_fp_errors
 def test_cont_basic():
     # this test skips slow distributions
     for distname, arg in distcont[:]:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -701,21 +701,30 @@ def test_regression_ticket_1326():
     #adjust to avoid nan with 0*log(0)
     assert_almost_equal(stats.chi2.pdf(0.0, 2), 0.5, 14)
 
+
 def test_regression_tukey_lambda():
     """ Make sure that Tukey-Lambda distribution correctly handles non-positive lambdas.
     """
     x = np.linspace(-5.0, 5.0, 101)
-    for lam in [0.0, -1.0, -2.0, np.array([[-1.0], [0.0], [-2.0]])]:
+
+    olderr = np.seterr(divide='ignore')
+    try:
+        for lam in [0.0, -1.0, -2.0, np.array([[-1.0], [0.0], [-2.0]])]:
+            p = stats.tukeylambda.pdf(x, lam)
+            assert_((p != 0.0).all())
+            assert_(~np.isnan(p).all())
+
+        lam = np.array([[-1.0], [0.0], [2.0]])
         p = stats.tukeylambda.pdf(x, lam)
-        assert_((p != 0.0).all())
-        assert_(~np.isnan(p).all())
-    lam = np.array([[-1.0], [0.0], [2.0]])
-    p = stats.tukeylambda.pdf(x, lam)
+    finally:
+        np.seterr(**olderr)
+
     assert_(~np.isnan(p).all())
     assert_((p[0] != 0.0).all())
     assert_((p[1] != 0.0).all())
     assert_((p[2] != 0.0).any())
     assert_((p[2] == 0.0).any())
+
 
 def test_regression_ticket_1421():
     """Regression test for ticket #1421 - correction discrete docs."""
@@ -725,3 +734,4 @@ def test_regression_ticket_1421():
 
 if __name__ == "__main__":
     run_module_suite()
+


### PR DESCRIPTION
The one thing that needs checking is the change in stats/test_cont_basic.py - do we want to do it like this or special-case the levy_l tests (which are generating the noise). 

I actually prefer this, because these tests are a maintenance headache.
