### PR TITLE
BUG: kurtosistest raise ValueError if sample size too small (similar to c

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1193,6 +1193,10 @@ def kurtosistest(a, axis=0):
     """
     a, axis = _chk_asarray(a, axis)
     n = float(a.shape[axis])
+    if n < 5:
+        raise ValueError(
+            "kurtosistest requires at least 5 observations; %i observations"
+            " were given." % int(n))
     if n < 20:
         warnings.warn(
             "kurtosistest only valid for n>=20 ... continuing anyway, n=%i" %

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1531,6 +1531,14 @@ def test_skewtest_too_few_samples():
     x = np.arange(7.0)
     assert_raises(ValueError, stats.skewtest, x)
 
+def test_kurtosistest_too_few_samples():
+    """Regression test for ticket #1425.
+
+    kurtosistest requires at least 5 samples; 4 should raise a ValueError.
+    """
+    x = np.arange(4.0)
+    assert_raises(ValueError, stats.kurtosistest, x)
+
 def mannwhitneyu():
     x = np.array([ 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
         1., 1., 1., 1., 1., 1., 1., 1., 2., 1., 1., 1., 1., 1., 1., 1.,


### PR DESCRIPTION
BUG: kurtosistest raise ValueError if sample size too small (similar to changes in skewtest)

partial solution to http://projects.scipy.org/scipy/ticket/1425

note: I haven't tested this, just copied from Warren's changes
