### PR TITLE
ENH: sparse: add a new `diags` function

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -36,6 +36,7 @@ Building sparse matrices:
    identity - Identity matrix in sparse format
    kron - kronecker product of two sparse matrices
    kronsum - kronecker sum of sparse matrices
+   diags - Return a sparse matrix from diagonals
    spdiags - Return a sparse matrix from diagonals
    tril - Lower triangular portion of a matrix in sparse format
    triu - Upper triangular portion of a matrix in sparse format

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -4,7 +4,7 @@
 __docformat__ = "restructuredtext en"
 
 __all__ = [ 'spdiags', 'eye', 'identity', 'kron', 'kronsum',
-            'hstack', 'vstack', 'bmat', 'rand']
+            'hstack', 'vstack', 'bmat', 'rand', 'diags']
 
 
 from warnings import warn
@@ -40,6 +40,7 @@ def spdiags(data, diags, m, n, format=None):
 
     See Also
     --------
+    diags : more convenient form of this function
     dia_matrix : the sparse DIAgonal format.
 
     Examples
@@ -54,6 +55,110 @@ def spdiags(data, diags, m, n, format=None):
 
     """
     return dia_matrix((data, diags), shape=(m,n)).asformat(format)
+
+def diags(diagonals, offsets, shape=None, format=None, dtype=None):
+    """
+    Construct a sparse matrix from diagonals.
+
+    .. versionadded:: 0.11
+
+    Parameters
+    ----------
+    diagonals : sequence of array_like
+        Sequence of arrays containing the matrix diagonals,
+        corresponding to `offsets`.
+    offsets  : sequence of int
+        Diagonals to set:
+          - k = 0  the main diagonal
+          - k > 0  the k-th upper diagonal
+          - k < 0  the k-th lower diagonal
+    shape : tuple of int, optional
+        Shape of the result. If omitted, a square matrix large enough
+        to contain the diagonals is returned.
+    format : {"dia", "csr", "csc", "lil", ...}, optional
+        Matrix format of the result.  By default (format=None) an
+        appropriate sparse matrix format is returned.  This choice is
+        subject to change.
+    dtype : dtype, optional
+        Data type of the matrix.
+
+    See Also
+    --------
+    spdiags : construct matrix from diagonals
+
+    Notes
+    -----
+    This function differs from `spdiags` in the way it handles
+    off-diagonals.
+
+    The result from `diags` is the sparse equivalent of::
+
+        np.diag(diagonals[0], offsets[0])
+        + ...
+        + np.diag(diagonals[k], offsets[k])
+
+    Repeated diagonal offsets are disallowed.
+
+    Examples
+    --------
+    >>> diagonals = [[1,2,3,4], [1,2,3], [1,2]]
+    >>> diags(diagonals, [0, -1, 2]).todense()
+    matrix([[1, 0, 1, 0],
+            [1, 2, 0, 2],
+            [0, 2, 3, 0],
+            [0, 0, 3, 4]])
+
+    Broadcasting of scalars is supported (but shape needs to be
+    specified):
+
+    >>> diags([1, -2, 1], [-1, 0, 1], shape=(4, 4)).todense()
+    matrix([[-2.,  1.,  0.,  0.],
+            [ 1., -2.,  1.,  0.],
+            [ 0.,  1., -2.,  1.],
+            [ 0.,  0.,  1., -2.]])
+
+    """
+    offsets = np.atleast_1d(offsets)
+    diagonals = map(np.atleast_1d, diagonals)
+
+    # Basic check
+    if len(diagonals) != len(offsets):
+        raise ValueError("Different number of diagonals and offsets.")
+
+    # Determine shape, if omitted
+    if shape is None:
+        m = len(diagonals[0]) + abs(int(offsets[0]))
+        shape = (m, m)
+
+    # Determine data type, if omitted
+    if dtype is None:
+        dtype = np.common_type(*diagonals)
+
+    # Construct data array
+    m, n = shape
+
+    M = max([min(m + offset, n - offset) + max(0, offset)
+             for offset in offsets])
+    M = max(0, M)
+    data_arr = np.zeros((len(offsets), M), dtype=dtype)
+
+    for j, diagonal in enumerate(diagonals):
+        offset = offsets[j]
+        k = max(0, offset)
+        length = min(m + offset, n - offset)
+        if length <= 0:
+            raise ValueError("Offset %d (index %d) out of bounds" % (offset, j))
+        try:
+            data_arr[j, k:k+length] = diagonal
+        except ValueError:
+            if len(diagonal) != length and len(diagonal) != 1:
+                raise ValueError(
+                    "Diagonal length (index %d: %d at offset %d) does not "
+                    "agree with matrix size (%d, %d)." % (
+                    j, len(diagonal), offset, m, n))
+            raise
+
+    return dia_matrix((data_arr, offsets), shape=(m, n)).asformat(format)
 
 def identity(n, dtype='d', format=None):
     """Identity matrix in sparse format

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -3,7 +3,7 @@
 import numpy as np
 from numpy import array, matrix
 from numpy.testing import TestCase, run_module_suite, assert_equal, \
-        assert_array_equal, assert_raises
+        assert_array_equal, assert_raises, assert_array_almost_equal_nulp
 
 
 from scipy.sparse import csr_matrix, coo_matrix
@@ -63,6 +63,112 @@ class TestConstructUtils(TestCase):
         for d,o,m,n,result in cases:
             assert_equal( construct.spdiags(d,o,m,n).todense(), result )
 
+    def test_diags(self):
+        a = array([1, 2, 3, 4, 5])
+        b = array([6, 7, 8, 9, 10])
+        c = array([11, 12, 13, 14, 15])
+
+        cases = []
+        cases.append( ([a[:1]],  0,  (1, 1), [[1]]) )
+        cases.append( ([a[:1]], [0], (1, 1), [[1]]) )
+        cases.append( ([a[:1]], [0], (2, 1), [[1],[0]]) )
+        cases.append( ([a[:1]], [0], (1, 2), [[1,0]]) )
+        cases.append( ([a[:1]], [1], (1, 2), [[0,1]]) )
+        cases.append( ([a[:2]], [0], (2, 2), [[1,0],[0,2]]) )
+        cases.append( ([a[:1]],[-1], (2, 2), [[0,0],[1,0]]) )
+        cases.append( ([a[:3]], [0], (3, 4), [[1,0,0,0],[0,2,0,0],[0,0,3,0]]) )
+        cases.append( ([a[:3]], [1], (3, 4), [[0,1,0,0],[0,0,2,0],[0,0,0,3]]) )
+        cases.append( ([a[:3]], [2], (3, 5), [[0,0,1,0,0],[0,0,0,2,0],[0,0,0,0,3]]) )
+
+        cases.append( ([a[:3],b[:1]], [0,2], (3, 3), [[1,0,6],[0,2,0],[0,0,3]]) )
+        cases.append( ([a[:2],b[:3]], [-1,0], (3, 4), [[6,0,0,0],[1,7,0,0],[0,2,8,0]]) )
+        cases.append( ([a[:4],b[:3]], [2,-3], (6, 6), [[0,0,1,0,0,0],
+                                                     [0,0,0,2,0,0],
+                                                     [0,0,0,0,3,0],
+                                                     [6,0,0,0,0,4],
+                                                     [0,7,0,0,0,0],
+                                                     [0,0,8,0,0,0]]) )
+
+        cases.append( ([a[:4],b,c[:4]], [-1,0,1], (5, 5),    [[ 6,11, 0, 0, 0],
+                                                            [ 1, 7,12, 0, 0],
+                                                            [ 0, 2, 8,13, 0],
+                                                            [ 0, 0, 3, 9,14],
+                                                            [ 0, 0, 0, 4,10]]) )
+        cases.append( ([a[:2],b[:3],c], [-4,2,-1], (6, 5), [[ 0, 0, 6, 0, 0],
+                                                          [11, 0, 0, 7, 0],
+                                                          [ 0,12, 0, 0, 8],
+                                                          [ 0, 0,13, 0, 0],
+                                                          [ 1, 0, 0,14, 0],
+                                                          [ 0, 2, 0, 0,15]]) )
+
+        # scalar case: broadcasting
+        cases.append( ([1,-2,1], [1,0,-1], (3, 3), [[ -2,  1,  0],
+                                                    [  1, -2,  1],
+                                                    [  0,  1, -2]]) )
+
+        for d, o, shape, result in cases:
+            try:
+                assert_equal(construct.diags(d, o, shape=shape).todense(),
+                             result)
+
+                if shape[0] == shape[1] and hasattr(d[0], '__len__'):
+                    # should be able to find the shape automatically
+                    assert_equal(construct.diags(d, o).todense(), result)
+            except:
+                print "%r %r %r" % (d, o, shape)
+                raise
+
+    def test_diags_bad(self):
+        a = array([1, 2, 3, 4, 5])
+        b = array([6, 7, 8, 9, 10])
+        c = array([11, 12, 13, 14, 15])
+
+        cases = []
+        cases.append( ([a[:0]],  0,  (1, 1)) )
+        cases.append( ([a], [0], (1, 1)) )
+        cases.append( ([a[:3],b], [0,2], (3, 3)) )
+        cases.append( ([a[:4],b,c[:3]], [-1,0,1], (5, 5)) )
+        cases.append( ([a[:2],c,b[:3]], [-4,2,-1], (6, 5)) )
+        cases.append( ([a[:2],c,b[:3]], [-4,2,-1], None) )
+        cases.append( ([], [-4,2,-1], None) )
+        cases.append( ([1], [-4], (4, 4)) )
+        cases.append( ([a[:0]], [-1], (1, 2)) )
+
+        for d, o, shape in cases:
+            try:
+                assert_raises(ValueError, construct.diags, d, o, shape)
+            except:
+                print "%r %r %r" % (d, o, shape)
+                raise
+
+        assert_raises(TypeError, construct.diags, [[None]], [0])
+
+    def test_diags_vs_diag(self):
+        # Check that
+        #
+        #    diags([a, b, ...], [i, j, ...]) == diag(a, i) + diag(b, j) + ...
+        #
+
+        np.random.seed(1234)
+
+        for n_diags in [1, 2, 3, 4, 5, 10]:
+            n = 1 + n_diags//2 + np.random.randint(0, 10)
+
+            offsets = np.arange(-n+1, n-1)
+            np.random.shuffle(offsets)
+            offsets = offsets[:n_diags]
+
+            diagonals = [np.random.rand(n - abs(q)) for q in offsets]
+
+            mat = construct.diags(diagonals, offsets)
+            dense_mat = sum([np.diag(x, j) for x, j in zip(diagonals, offsets)])
+
+            assert_array_almost_equal_nulp(mat.todense(), dense_mat)
+
+    def test_diags_dtype(self):
+        x = construct.diags([2.2], [0], shape=(2, 2), dtype=int)
+        assert_equal(x.dtype, int)
+        assert_equal(x.todense(), [[2, 0], [0, 2]])
 
     def test_identity(self):
         assert_equal(construct.identity(1).toarray(), [[1]])


### PR DESCRIPTION
This function does essentially the same job as `spdiags`, but its offset
semantics is more natural (and agrees with np.diag), making commonly
occurring matrix assembly tasks somewhat easier. It also supports
broadcasting, so constant-diagonal matrices are easy to construct.
