### PR TITLE
Made change to address http://projects.scipy.org/scipy/ticket/1531

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -407,7 +407,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, **kw):
     >>> popt, pcov = curve_fit(func, x, yn)
 
     """
-    if p0 is None or isscalar(p0):
+    if p0 is None:
         # determine number of parameters by inspecting the function
         import inspect
         args, varargs, varkw, defaults = inspect.getargspec(f)
@@ -416,7 +416,13 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, **kw):
             raise ValueError(msg)
         if p0 is None:
             p0 = 1.0
-        p0 = [p0]*(len(args)-1)
+        if 'self' in args:
+            p0 = [p0]*(len(args)-2)
+        else:
+            p0 = [p0]*(len(args)-1)            
+
+    if isscalar(p0):
+        p0 = array([p0])
 
     args = (xdata, ydata, f)
     if sigma is None:

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -407,7 +407,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, **kw):
     >>> popt, pcov = curve_fit(func, x, yn)
 
     """
-    if p0 is None or isscalar(p0):
+    if p0 is None:
         # determine number of parameters by inspecting the function
         import inspect
         args, varargs, varkw, defaults = inspect.getargspec(f)
@@ -417,6 +417,9 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, **kw):
         if p0 is None:
             p0 = 1.0
         p0 = [p0]*(len(args)-1)
+
+    if isscalar(p0):
+        p0 = array([p0])
 
     args = (xdata, ydata, f)
     if sigma is None:

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -424,9 +424,6 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, **kw):
     if isscalar(p0):
         p0 = array([p0])
 
-    if isscalar(p0):
-        p0 = array([p0])
-
     args = (xdata, ydata, f)
     if sigma is None:
         func = _general_function

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -221,7 +221,22 @@ class TestCurveFit(TestCase):
         assert_(len(popt) == 2)
         assert_(pcov.shape == (2,2))
         assert_array_almost_equal(popt, [1.7989, 1.1642], decimal=4)
-        assert_array_almost_equal(pcov, [[0.0852, -0.1260],[-0.1260, 0.1912]], decimal=4)
+        assert_array_almost_equal(pcov, [[0.0852, -0.1260],[-0.1260,
+        0.1912]], decimal=4)
+        
+    def test_class_instance(self):
+        class test_self(object):
+            """This class tests if curve_fit passes the correct number
+        of arguments when the model function is a class instance
+        method."""
+            def func(x, a, b):
+                return b*x**a
+        test_self_inst = test_self()
+        popt, pcov = curve_fit(test_self_inst.func, self.x, self.y)
+        assert_(pcov.shape == (2,2))
+        assert_array_almost_equal(popt, [1.7989, 1.1642], decimal=4)
+        assert_array_almost_equal(pcov, [[0.0852, -0.1260],[-0.1260,
+        0.1912]], decimal=4)
 
 
 class TestFixedPoint(TestCase):


### PR DESCRIPTION
Now, if p0 is given and is scalar, it is recast as a numpy array with a size of 1.  
