### PR TITLE
Enh: interface to unconstrained minimization algorithms for multivariate functions

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -126,6 +126,7 @@ Utility Functions
 """
 
 from optimize import *
+from minimize import *
 from minpack import *
 from zeros import *
 from anneal import *

--- a/scipy/optimize/anneal.py
+++ b/scipy/optimize/anneal.py
@@ -154,7 +154,7 @@ class _state(object):
 def anneal(func, x0, args=(), schedule='fast', full_output=0,
            T0=None, Tf=1e-12, maxeval=None, maxaccept=None, maxiter=400,
            boltzmann=1.0, learn_rate=0.5, feps=1e-6, quench=1.0, m=1.0, n=1.0,
-           lower=-100, upper=100, dwell=50):
+           lower=-100, upper=100, dwell=50, disp=True):
     """Minimize a function using simulated annealing.
 
     Schedule is a schedule class implementing the annealing schedule.
@@ -197,6 +197,8 @@ def anneal(func, x0, args=(), schedule='fast', full_output=0,
         Lower and upper bounds on `x`.
     dwell : int
         The number of times to search the space at each temperature.
+    disp : bool
+        Set to True to print convergence messages.
 
     Returns
     -------
@@ -335,9 +337,11 @@ def anneal(func, x0, args=(), schedule='fast', full_output=0,
             retval = 0
             if abs(af[-1]-best_state.cost) > feps*10:
                 retval = 5
-                print "Warning: Cooled to %f at %s but this is not" \
-                      % (squeeze(last_state.cost), str(squeeze(last_state.x))) \
-                      + " the smallest point found."
+                if disp:
+                    print "Warning: Cooled to %f at %s but this is not" \
+                          % (squeeze(last_state.cost),
+                             str(squeeze(last_state.x))) \
+                          + " the smallest point found."
             break
         if (Tf is not None) and (schedule.T < Tf):
             retval = 1
@@ -346,7 +350,8 @@ def anneal(func, x0, args=(), schedule='fast', full_output=0,
             retval = 2
             break
         if (iters > maxiter):
-            print "Warning: Maximum number of iterations exceeded."
+            if disp:
+                print "Warning: Maximum number of iterations exceeded."
             retval = 3
             break
         if (maxaccept is not None) and (schedule.accepted > maxaccept):

--- a/scipy/optimize/anneal.py
+++ b/scipy/optimize/anneal.py
@@ -309,7 +309,44 @@ def anneal(func, x0, args=(), schedule='fast', full_output=0,
         return x, info['status']
 
 def _minimize_anneal(func, x0, args=(), options={}, full_output=0):
-    """minimize: Anneal method"""
+    """
+    Minimization of scalar function of one or more variables using the
+    simulated annealing algorithm.
+
+    Options for the simulated annealing algorithm are:
+        disp : bool
+            Set to True to print convergence messages.
+        schedule : str
+            Annealing schedule to use. One of: 'fast', 'cauchy' or
+            'boltzmann'.
+        T0 : float
+            Initial Temperature (estimated as 1.2 times the largest
+            cost-function deviation over random points in the range).
+        Tf : float
+            Final goal temperature.
+        maxfev : int
+            Maximum number of function evaluations to make.
+        maxaccept : int
+            Maximum changes to accept.
+        maxiter : int
+            Maximum number of iterations to perform.
+        boltzmann : float
+            Boltzmann constant in acceptance test (increase for less
+            stringent test at each temperature).
+        learn_rate : float
+            Scale constant for adjusting guesses.
+        ftol : float
+            Relative error in ``fun(x)`` acceptable for convergence.
+        quench, m, n : float
+            Parameters to alter fast_sa schedule.
+        lower, upper : float or ndarray
+            Lower and upper bounds on `x`.
+        dwell : int
+            The number of times to search the space at each temperature.
+
+    This function is called by the `minimize` function with
+    `method=anneal`. It is not supposed to be called directly.
+    """
     # retrieve useful options
     schedule   = options.get('schedule', 'fast')
     T0         = options.get('T0')

--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -69,6 +69,8 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
                 Order of norm (Inf is max, -Inf is min).
             eps : int or ndarray
                 If `jac` is approximated, use this value for the step size.
+            direc : ndarray
+                Initial set of direction vectors for the Powell method.
     full_output : bool, optional
         If True, return optional outputs.  Default is False.
     callback : callable, optional
@@ -104,7 +106,7 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
             nit: int
                 Number of iterations.
             direc: ndarray
-                Current direction set.
+                Current set of direction vectors for the Powell method.
             allvecs : list
                 Solution at each iteration (if ``retall == True``).
 

--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -179,92 +179,22 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
        Numerical Recipes (any edition), Cambridge University Press
     .. [6] Wright & Nocedal, 'Numerical Optimization', 1999.
     """
-    if full_output:
-        info = dict()
-    elif retall: # retall implies full_output, issue a warning otherwise
-        warn('retall is ignored since full_output=False.', RuntimeWarning)
-
     if method.lower() == 'nelder-mead':
-        out = _minimize_neldermead(fun, x0, args, options, full_output,
-                                   retall, callback)
-
-        if full_output:
-            x, info['fun'], info['nit'], info['nfev'], info['status'] = \
-                    out[:5]
-            if retall:
-                info['allvecs'] = out[5]
-        else:
-            if retall:
-                x = out[0]
-            else:
-                x = out
-
+        return _minimize_neldermead(fun, x0, args, options, full_output,
+                                    retall, callback)
     elif method.lower() == 'powell':
-        out = _minimize_powell(fun, x0, args, options, full_output, retall,
-                               callback)
-
-        if full_output:
-            x, info['fun'], info['direc'], info['nit'], info['nfev'], \
-                    info['status'] = out[:6]
-            if retall:
-                info['allvecs'] = out[6]
-        else:
-            if retall:
-                x = out[0]
-            else:
-                x = out
-
+        return _minimize_powell(fun, x0, args, options, full_output,
+                                retall, callback)
     elif method.lower() == 'cg':
-        out = _minimize_cg(fun, x0, args, jac, options, full_output,
-                           retall, callback)
-
-        if full_output:
-            x, info['fun'], info['nfev'], info['njev'], info['status'] = \
-                    out[:5]
-            if retall:
-                info['allvecs'] = out[5]
-        else:
-            if retall:
-                x = out[0]
-            else:
-                x = out
-
+        return _minimize_cg(fun, x0, args, jac, options, full_output,
+                            retall, callback)
     elif method.lower() == 'bfgs':
-        out = _minimize_bfgs(fun, x0, args, jac, options, full_output,
-                             retall, callback)
-
-        if full_output:
-            x, info['fun'], info['jac'], info['hess'], info['nfev'], \
-                    info['njev'], info['status'] = out[:7]
-            if retall:
-                info['allvecs'] = out[7]
-        else:
-            if retall:
-                x = out[0]
-            else:
-                x = out
-
+        return _minimize_bfgs(fun, x0, args, jac, options, full_output,
+                              retall, callback)
     elif method.lower() == 'newton-cg':
         if jac == None:
             raise ValueError('Jacobian is required for Newton-CG method')
-        out = _minimize_ncg(fun, x0, args, jac, hess, hessp, options,
-                            full_output, retall, callback)
-
-        if full_output:
-            x, info['fun'], info['nfev'], info['njev'], info['nhev'], \
-                    info['status'] = out[:6]
-            if retall:
-                info['allvecs'] = out[6]
-        else:
-            if retall:
-                x = out[0]
-            else:
-                x = out
-
+        return _minimize_ncg(fun, x0, args, jac, hess, hessp, options,
+                             full_output, retall, callback)
     else:
         raise ValueError('Unknown solver %s' % method)
-
-    if full_output:
-        return x, info
-    else:
-        return x

--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -145,67 +145,50 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
     This section describes the available solvers that can be selected by the
     'method' parameter.  Respective solver options are also listed here.
 
-    By default, this function uses the *Nelder-Mead* simplex algorithm
-    [1]_, [2]_, [3]_ to find the minimum of a function of one or more
-    variables.  This algorithm has a long history of successful use in
-    applications.  However, it will usually be slower than an algorithm that
-    uses first or second derivative information.  In practice it can have poor
-    performance for high-dimensional problems and is not robust when
-    minimizing complicated functions.  Additionally, there currently is no
-    complete theory describing when the algorithm will successfully
-    converge to the global minimum, or how fast it will if it does.
+    Method *Nelder-Mead* uses the Simplex algorithm [1]_, [2]_. This
+    algorithm has been successful in many applications but other algorithms
+    using the first and/or second derivatives information might be preferred
+    for their better performances and robustness in general.
 
     Relevant `options` are: `xtol`, `ftol`, `maxiter`, `maxfev`, `disp`.
 
 
-    Method *Powell* is a modification of Powell's method [4]_, [5]_ to find
-    the minimum of a function of N variables.  Powell's method is a
-    conjugate direction method.
-
-    The algorithm has two loops.  The outer loop merely iterates over the
-    inner loop.  The inner loop minimizes over each current direction in the
-    direction set.  At the end of the inner loop, if certain conditions are
-    met, the direction that gave the largest decrease is dropped and
-    replaced with the difference between the current estimate of the solution
-    and the estimate from the beginning of the inner loop.
-
-    The technical conditions for replacing the direction of greatest
-    increase amount to checking that::
-
-      1. No further gain can be made along the direction of greatest increase
-         from that iteration.
-      2. The direction of greatest increase accounted for a large sufficient
-         fraction of the decrease in the function value from that iteration of
-         the inner loop.
+    Method *Powell* is a modification of Powell's method [3]_, [4]_ which
+    is a conjugate direction method. It performs sequential one-dimensional
+    minimizations along each vector of the directions set (`direc` field in
+    `options` and `info`), which is updated at each iteration of the main
+    minimization loop. The function need not be differentiable, and no
+    derivatives are taken.
 
     Relevant `options` are: `xtol`, `ftol`, `maxiter`, `maxfev`, `disp`.
 
 
     Method *CG* uses a nonlinear conjugate gradient algorithm by Polak and
-    Ribiere as described in [6]_ pp. 120-122.
+    Ribière, a variant of the Fletcher-Reeves method described in [5]_ pp.
+    120—122. Only the first derivatives are used.
 
     Relevant `options` are: `gtol`, `norm`, `maxiter`, `eps`, `disp`.
 
 
     Method *BFGS* uses the quasi-Newton method of Broyden, Fletcher,
-    Goldfarb, and Shanno (BFGS) [6]_ pp. 198.
+    Goldfarb, and Shanno (BFGS) [5]_ pp. 136. It uses the first derivatives
+    only. BFGS has proven good performance even for non-smooth
+    optimizations
 
     Relevant `options` are: `gtol`, `norm`, `maxiter`, `eps`, `disp`.
 
 
-    Method *Newton-CG* uses a Newton-CG algorithm [6]_ pp.140. Newton-CG
-    methods are also called truncated Newton methods. See also `fmin_tnc`
-    for a box-constrained minimization with a similar algorithm.
+    Method *Newton-CG* uses a Newton-CG algorithm [5]_ pp. 168 (also known
+    as the truncated Newton method). It uses a CG method to the compute the
+    search direction. See also `fmin_tnc` for a box-constrained
+    minimization with a similar algorithm.
 
     Relevant `options` are: `xtol`, `maxiter`, `eps`, `disp`.
 
 
     Method *Anneal* uses simulated annealing, which is a probabilistic
     metaheuristic algorithm for global optimization. It uses no derivative
-    information from the function being optimized. In practice it has been
-    more useful in discrete optimization than continuous optimization, as
-    there are usually better algorithms for continuous optimization
-    problems.
+    information from the function being optimized.
 
     Relevant `options` are: `schedule`, `T0`, `Tf`, `maxfev`, `maxaccept`,
     `maxiter`, `boltzmann`, `learn_rate`, `ftol`, `quench`, `m`, `n`,
@@ -213,19 +196,21 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
 
     References
     ----------
-    .. [1] Nelder, J.A. and Mead, R. (1965), "A simplex method for function
-       minimization", The Computer Journal, 7, pp. 308-313
-    .. [2] Wright, M.H. (1996), "Direct Search Methods: Once Scorned, Now
-       Respectable", in Numerical Analysis 1995, Proceedings of the
-       1995 Dundee Biennial Conference in Numerical Analysis, D.F.
-    .. [3] Griffiths and G.A. Watson (Eds.), Addison Wesley Longman,
-       Harlow, UK, pp. 191-208.
-    .. [4] Powell M.J.D. (1964) An efficient method for finding the minimum of a
-       function of several variables without calculating derivatives,
-       Computer Journal, 7 (2):155-162.
-    .. [5] Press W., Teukolsky S.A., Vetterling W.T., and Flannery B.P.:
-       Numerical Recipes (any edition), Cambridge University Press
-    .. [6] Wright & Nocedal, 'Numerical Optimization', 1999.
+    .. [1] Nelder, J A, and R Mead. 1965. A Simplex Method for Function
+        Minimization. The Computer Journal 7: 308–13.
+    .. [2] Wright M H. 1996. Direct search methods: Once scorned, now
+        respectable, in Numerical Analysis 1995: Proceedings of the 1995
+        Dundee Biennial Conference in Numerical Analysis (Eds. D F
+        Griffiths and G A Watson). Addison Wesley Longman, Harlow, UK.
+        191–208.
+    .. [3] Powell, M J D. 1964. An efficient method for finding the minimum of
+       a function of several variables without calculating derivatives. The
+       Computer Journal 7: 155—162.
+    .. [4] Press W, S A Teukolsky, W T Vetterling and B P Flannery.
+       Numerical Recipes (any edition), Cambridge University Press.
+    .. [5] Nocedal, J, and S J Wright. 2006. Numerical Optimization.
+       Springer New York.
+
 
     """
     if method.lower() == 'nelder-mead':

--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -52,11 +52,8 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
         on `jac` are used to compute it.
     options : dict, optional
         A dictionary of solver options with the keys:
-            disp : int
-                If positive, information on the progress of the
-                optimization is displayed. Different level of details are
-                available depending on the solver. Most solvers consider
-                either 0 or 1 (i.e. Boolean) values for `disp`.
+            disp : bool
+                Set to True to print convergence messages.
             xtol : float
                 Relative error in solution `xopt` acceptable for convergence.
             ftol : float

--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -265,11 +265,11 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
                              full_output, retall, callback)
     elif method.lower() == 'anneal':
         if callback:
-            raise warn("Method 'Anneal' does not support callback.",
-                       RuntimeWarning)
+            warn("Method 'Anneal' does not support callback.",
+                 RuntimeWarning)
         if retall:
-            raise warn("Method 'Anneal' does not support retall option.",
-                       RuntimeWarning)
+            warn("Method 'Anneal' does not support retall option.",
+                 RuntimeWarning)
         return _minimize_anneal(fun, x0, args, options, full_output)
     else:
         raise ValueError('Unknown solver %s' % method)

--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -164,8 +164,8 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
 
 
     Method *CG* uses a nonlinear conjugate gradient algorithm by Polak and
-    Ribière, a variant of the Fletcher-Reeves method described in [5]_ pp.
-    120—122. Only the first derivatives are used.
+    Ribiere, a variant of the Fletcher-Reeves method described in [5]_ pp.
+    120-122. Only the first derivatives are used.
 
     Relevant `options` are: `gtol`, `norm`, `maxiter`, `eps`, `disp`.
 
@@ -197,15 +197,15 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
     References
     ----------
     .. [1] Nelder, J A, and R Mead. 1965. A Simplex Method for Function
-        Minimization. The Computer Journal 7: 308–13.
+        Minimization. The Computer Journal 7: 308-13.
     .. [2] Wright M H. 1996. Direct search methods: Once scorned, now
         respectable, in Numerical Analysis 1995: Proceedings of the 1995
         Dundee Biennial Conference in Numerical Analysis (Eds. D F
         Griffiths and G A Watson). Addison Wesley Longman, Harlow, UK.
-        191–208.
+        191-208.
     .. [3] Powell, M J D. 1964. An efficient method for finding the minimum of
        a function of several variables without calculating derivatives. The
-       Computer Journal 7: 155—162.
+       Computer Journal 7: 155-162.
     .. [4] Press W, S A Teukolsky, W T Vetterling and B P Flannery.
        Numerical Recipes (any edition), Cambridge University Press.
     .. [5] Nocedal, J, and S J Wright. 2006. Numerical Optimization.

--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -58,7 +58,7 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
                 Relative error in solution `xopt` acceptable for convergence.
             ftol : float
                 Relative error in ``fun(xopt)`` acceptable for convergence.
-            maxit : int
+            maxiter : int
                 Maximum number of iterations to perform.
             maxfev : int
                 Maximum number of function evaluations to make.
@@ -123,7 +123,7 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
     complete theory describing when the algorithm will successfully
     converge to the global minimum, or how fast it will if it does.
 
-    Relevant `options` are: `xtol`, `ftol`, `maxit`, `maxfev`, `disp`.
+    Relevant `options` are: `xtol`, `ftol`, `maxiter`, `maxfev`, `disp`.
 
 
     Method *Powell* is a modification of Powell's method [4]_, [5]_ to find
@@ -146,19 +146,19 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
          fraction of the decrease in the function value from that iteration of
          the inner loop.
 
-    Relevant `options` are: `xtol`, `ftol`, `maxit`, `maxfev`, `disp`.
+    Relevant `options` are: `xtol`, `ftol`, `maxiter`, `maxfev`, `disp`.
 
 
     Method *CG* uses a nonlinear conjugate gradient algorithm by Polak and
     Ribiere as described in [6]_ pp. 120-122.
 
-    Relevant `options` are: `gtol`, `norm`, `maxit`, `eps`, `disp`.
+    Relevant `options` are: `gtol`, `norm`, `maxiter`, `eps`, `disp`.
 
 
     Method *BFGS* uses the quasi-Newton method of Broyden, Fletcher,
     Goldfarb, and Shanno (BFGS) [6]_ pp. 198
 
-    Relevant `options` are: `gtol`, `norm`, `maxit`, `eps`, `disp`.
+    Relevant `options` are: `gtol`, `norm`, `maxiter`, `eps`, `disp`.
 
 
     Method *Newton-CG* uses a Newton-CG algorithm [6]_ pp.140. Newton-CG
@@ -166,7 +166,7 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
     with method='TNC' for a box-constrained minimization with a similar
     algorithm.
 
-    Relevant `options` are: `xtol`, `maxit`, `eps`, `disp`.
+    Relevant `options` are: `xtol`, `maxiter`, `eps`, `disp`.
 
     References
     ----------

--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -192,8 +192,6 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
         return _minimize_bfgs(fun, x0, args, jac, options, full_output,
                               retall, callback)
     elif method.lower() == 'newton-cg':
-        if jac == None:
-            raise ValueError('Jacobian is required for Newton-CG method')
         return _minimize_ncg(fun, x0, args, jac, hess, hessp, options,
                              full_output, retall, callback)
     else:

--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -9,20 +9,22 @@ Functions
 
 """
 
+
 __all__ = ['minimize']
 
+
 from warnings import warn
-from numpy import Inf
-from optimize import _epsilon
+
 # unconstrained minimization
 from optimize import _minimize_neldermead, _minimize_powell, \
         _minimize_cg, _minimize_bfgs, _minimize_ncg
+
 
 def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
              hessp=None, options=dict(), full_output=False, callback=None,
              retall=False):
     """
-    Minimization of scalar function of several variables.
+    Minimization of scalar function of one or more variables.
 
     Parameters
     ----------
@@ -30,25 +32,25 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
         Objective function.
     x0 : ndarray
         Initial guess.
-    args : tuple
+    args : tuple, optional
         Extra arguments passed to the objective function and its
         derivatives (Jacobian, Hessian).
-    method : str
-        Type of solver amongst:
-            'Nelder-Mead', 'Powell', 'CG', 'BFGS', 'Newton-CG'.
-    jac : callable
+    method : str, optional
+        Type of solver.  Should be one of:
+            {'Nelder-Mead', 'Powell', 'CG', 'BFGS', 'Newton-CG'}.
+    jac : callable, optional
         Jacobian of objective function (if None, Jacobian will be
-        estimate numerically). Only for CG, BFGS, Newton-CG.
-    hess, hessp : callable
+        estimated numerically). Only for CG, BFGS, Newton-CG.
+    hess, hessp : callable, optional
         Hessian of objective function or Hessian of objective function
-        times and arbitrary vector p. Only for Newton-CG.
-        Only one of `hessp` or `hess` need to be given.  If `hess` is
+        times an arbitrary vector p.  Only for Newton-CG.
+        Only one of `hessp` or `hess` needs to be given.  If `hess` is
         provided, then `hessp` will be ignored.  If neither `hess` nor
         `hessp` is provided, then the hessian product will be approximated
-        using finite differences on `jac`. `hessp` must compute the hessian
-        times an arbitrary vector. If it is not given, finite-differences
+        using finite differences on `jac`.  `hessp` must compute the hessian
+        times an arbitrary vector.  If it is not given, finite-differences
         on `jac` are used to compute it.
-    options : dict
+    options : dict, optional
         A dictionary of solver options with the keys:
             disp : int
                 If positive, information on the progress of the
@@ -56,42 +58,42 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
                 available depending on the solver. Most solvers consider
                 either 0 or 1 (i.e. Boolean) values for `disp`.
             xtol : float
-                Relative error in xopt acceptable for convergence.
+                Relative error in solution `xopt` acceptable for convergence.
             ftol : float
-                Relative error in fun(xopt) acceptable for convergence.
+                Relative error in ``fun(xopt)`` acceptable for convergence.
             maxit : int
                 Maximum number of iterations to perform.
             maxfev : int
                 Maximum number of function evaluations to make.
             gtol : float
-                Gradient norm must be less than gtol before successful
+                Gradient norm must be less than `gtol` before successful
                 termination.
             norm : float
-                Order of norm (Inf is max, -Inf is min)
+                Order of norm (Inf is max, -Inf is min).
             eps : int or ndarray
                 If `jac` is approximated, use this value for the step size.
-    full_output : bool
-        If True, return optional outputs.
-    callback : callable
-        Called after each iteration, as callback(xk), where xk is the
+    full_output : bool, optional
+        If True, return optional outputs.  Default is False.
+    callback : callable, optional
+        Called after each iteration, as ``callback(xk)``, where ``xk`` is the
         current parameter vector.
-    retall : bool
-        If True, return a list of the solution at each iteration. (Implies
-        full_output=True, ignored otherwise.)
+    retall : bool, optional
+        If True, return a list of the solution at each iteration.  This is only
+        done if `full_output` is True.
 
     Returns
     -------
-    x : ndarray
+    xopt : ndarray
         The solution.
     info : dict
         A dictionary of optional outputs with the keys:
-            solution : array
-                The solution (same as `x`).
+            solution : ndarray
+                The solution (same as `xopt`).
             success : bool
                 Boolean flag indicating if a solution was found.
             status : int
-                An integer flag indicating the type of termination. Its
-                value depends on the underlying solver. Refer to message
+                An integer flag indicating the type of termination.  Its
+                value depends on the underlying solver.  Refer to `message`
                 for more information.
             message : str
                 A string message giving information about the cause of the
@@ -104,48 +106,48 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
                 jacobian and hessian.
             nit: int
                 Number of iterations.
-            direc: array
+            direc: ndarray
                 Current direction set.
             allvecs : list
-                Solution at each iteration (if retall==True).
+                Solution at each iteration (if ``retall == True``).
 
     Notes
     -----
-    This section describes the available solver to be selected by the
-    'method' parameter. Respective solver options are also listed here.
+    This section describes the available solvers that can be selected by the
+    'method' parameter.  Respective solver options are also listed here.
 
     By default, this function uses the *Nelder-Mead* simplex algorithm
-    [1]_,[2]_,[3]_ to find the a minimum of function of one or more
-    variables. This algorithm has a long history of successful use in
-    applications. But it will usually be slower than an algorithm that uses
-    first or second derivative information. In practice it can have poor
-    performance in high-dimensional problems and is not robust to
-    minimizing complicated functions. Additionally, there currently is no
+    [1]_, [2]_, [3]_ to find the minimum of a function of one or more
+    variables.  This algorithm has a long history of successful use in
+    applications.  However, it will usually be slower than an algorithm that
+    uses first or second derivative information.  In practice it can have poor
+    performance for high-dimensional problems and is not robust when
+    minimizing complicated functions.  Additionally, there currently is no
     complete theory describing when the algorithm will successfully
-    converge to the minimum, or how fast it will if it does.
+    converge to the global minimum, or how fast it will if it does.
 
     Relevant `options` are: `xtol`, `ftol`, `maxit`, `maxfev`, `disp`.
 
 
     Method *Powell* is a modification of Powell's method [4]_, [5]_ to find
-    the minimum of a function of N variables. Powell's method is a
+    the minimum of a function of N variables.  Powell's method is a
     conjugate direction method.
 
-    The algorithm has two loops. The outer loop merely iterates over the
-    inner loop. The inner loop minimizes over each current direction in the
-    direction set. At the end of the inner loop, if certain conditions are
+    The algorithm has two loops.  The outer loop merely iterates over the
+    inner loop.  The inner loop minimizes over each current direction in the
+    direction set.  At the end of the inner loop, if certain conditions are
     met, the direction that gave the largest decrease is dropped and
-    replaced with the difference between the current estiamted x and the
-    estimated x from the beginning of the inner-loop.
+    replaced with the difference between the current estimate of the solution
+    and the estimate from the beginning of the inner loop.
 
     The technical conditions for replacing the direction of greatest
-    increase amount to checking that
+    increase amount to checking that::
 
-    1. No further gain can be made along the direction of greatest increase
-       from that iteration.
-    2. The direction of greatest increase accounted for a large sufficient
-       fraction of the decrease in the function value from that iteration of
-       the inner loop.
+      1. No further gain can be made along the direction of greatest increase
+         from that iteration.
+      2. The direction of greatest increase accounted for a large sufficient
+         fraction of the decrease in the function value from that iteration of
+         the inner loop.
 
     Relevant `options` are: `xtol`, `ftol`, `maxit`, `maxfev`, `disp`.
 
@@ -184,6 +186,7 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
     .. [5] Press W., Teukolsky S.A., Vetterling W.T., and Flannery B.P.:
        Numerical Recipes (any edition), Cambridge University Press
     .. [6] Wright & Nocedal, 'Numerical Optimization', 1999.
+
     """
     if method.lower() == 'nelder-mead':
         return _minimize_neldermead(fun, x0, args, options, full_output,

--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -15,7 +15,8 @@ from warnings import warn
 from numpy import Inf
 from optimize import _epsilon
 # unconstrained minimization
-from optimize import fmin, fmin_powell, fmin_cg, fmin_bfgs, fmin_ncg
+from optimize import _minimize_neldermead, _minimize_powell, \
+        _minimize_cg, _minimize_bfgs, _minimize_ncg
 
 def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
              hessp=None, options=dict(), full_output=False, callback=None,
@@ -184,16 +185,8 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
         warn('retall is ignored since full_output=False.', RuntimeWarning)
 
     if method.lower() == 'nelder-mead':
-        # set default options and update using input values
-        opts = {'xtol': 1e-4,
-                'ftol': 1e-4,
-                'disp': 1}
-        opts.update(**options)
-
-        out = fmin(fun, x0, args=args, xtol=opts.get('xtol'),
-                   ftol=opts.get('ftol'), maxiter=opts.get('maxit'),
-                   maxfun=opts.get('maxfev'), full_output=full_output,
-                   disp=opts.get('disp'), retall=retall, callback=callback)
+        out = _minimize_neldermead(fun, x0, args, options, full_output,
+                                   retall, callback)
 
         if full_output:
             x, info['fun'], info['nit'], info['nfev'], info['status'] = \
@@ -207,16 +200,8 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
                 x = out
 
     elif method.lower() == 'powell':
-        # set default options and update using input values
-        opts = {'xtol': 1e-4,
-                'ftol': 1e-4,
-                'disp': 1}
-        opts.update(**options)
-        out = fmin_powell(fun, x0, args=args, xtol=opts.get('xtol'),
-                          ftol=opts.get('ftol'), maxiter=opts.get('maxit'),
-                          maxfun=opts.get('maxfev'),
-                          full_output=full_output, disp=opts.get('disp'),
-                          retall=retall, callback=callback)
+        out = _minimize_powell(fun, x0, args, options, full_output, retall,
+                               callback)
 
         if full_output:
             x, info['fun'], info['direc'], info['nit'], info['nfev'], \
@@ -230,17 +215,8 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
                 x = out
 
     elif method.lower() == 'cg':
-        # set default options and update using input values
-        opts = {'gtol': 1e-5,
-                'norm': Inf,
-                'eps': _epsilon,
-                'disp': 1}
-        opts.update(**options)
-        out = fmin_cg(fun, x0, fprime=jac, args=args,
-                      gtol=opts.get('gtol'), norm=opts.get('norm'),
-                      epsilon=opts.get('eps'), maxiter=opts.get('maxit'),
-                      full_output=full_output, disp=opts.get('disp'),
-                      retall=retall, callback=callback)
+        out = _minimize_cg(fun, x0, args, jac, options, full_output,
+                           retall, callback)
 
         if full_output:
             x, info['fun'], info['nfev'], info['njev'], info['status'] = \
@@ -254,17 +230,8 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
                 x = out
 
     elif method.lower() == 'bfgs':
-        # set default options and update using input values
-        opts = {'gtol': 1e-5,
-                'norm': Inf,
-                'eps': _epsilon,
-                'disp': 1}
-        opts.update(**options)
-        out = fmin_bfgs(fun, x0, fprime=jac, args=args,
-                        gtol=opts.get('gtol'), norm=opts.get('norm'),
-                        epsilon=opts.get('eps'), maxiter=opts.get('maxit'),
-                        full_output=full_output, disp=opts.get('disp'),
-                        retall=retall, callback=callback)
+        out = _minimize_bfgs(fun, x0, args, jac, options, full_output,
+                             retall, callback)
 
         if full_output:
             x, info['fun'], info['jac'], info['hess'], info['nfev'], \
@@ -280,16 +247,8 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
     elif method.lower() == 'newton-cg':
         if jac == None:
             raise ValueError('Jacobian is required for Newton-CG method')
-        # set default options and update using input values
-        opts = {'xtol': 1e-5,
-                'eps': _epsilon,
-                'disp': 1}
-        opts.update(**options)
-        out = fmin_ncg(fun, x0, jac, fhess_p=hessp, fhess=hess, args=args,
-                       avextol=opts.get('xtol'), epsilon=opts.get('eps'),
-                       maxiter=opts.get('maxit'), full_output=full_output,
-                       disp=opts.get('disp'), retall=retall,
-                       callback=callback)
+        out = _minimize_ncg(fun, x0, args, jac, hess, hessp, options,
+                            full_output, retall, callback)
 
         if full_output:
             x, info['fun'], info['nfev'], info['njev'], info['nhev'], \

--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -85,11 +85,17 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
         The solution.
     info : dict
         A dictionary of optional outputs with the keys:
+            solution : array
+                The solution (same as `x`).
+            success : bool
+                Boolean flag indicating if a solution was found.
             status : int
-                An integer flag. Set to 0 if a solution was found,
-                otherwise refer to message for more information.
+                An integer flag indicating the type of termination. Its
+                value depends on the underlying solver. Refer to message
+                for more information.
             message : str
-                If no solution is found, message details the cause of failure.
+                A string message giving information about the cause of the
+                termination.
             fun, jac, hess : ndarray
                 Values of objective function, Jacobian and Hessian (if
                 available).

--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -1,23 +1,22 @@
 """
-Interface to minimization algorithms
+Interfaces to minimization algorithms.
 
 Functions
 ---------
 - minimize : unconstrained minimization of a function of several variables.
-- con_minimize : constrained minimization of a function of several variables.
-- minimize_scalar: minimization of a scalar function.
-
 """
 
 
-__all__ = ['minimize']
+__all__ = ['minimize', '_minimize_neldermead', '_minimize_powell',
+           '_minimize_cg', '_minimize_bfgs', '_minimize_newtoncg',
+           '_minimize_anneal']
 
 
 from warnings import warn
 
 # unconstrained minimization
 from optimize import _minimize_neldermead, _minimize_powell, \
-        _minimize_cg, _minimize_bfgs, _minimize_ncg
+        _minimize_cg, _minimize_bfgs, _minimize_newtoncg
 from anneal import _minimize_anneal
 
 
@@ -38,7 +37,7 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
         derivatives (Jacobian, Hessian).
     method : str, optional
         Type of solver.  Should be one of:
-            {'Nelder-Mead', 'Powell', 'CG', 'BFGS', 'Newton-CG'}.
+            {'Nelder-Mead', 'Powell', 'CG', 'BFGS', 'Newton-CG', 'Anneal'}.
     jac : callable, optional
         Jacobian of objective function (if None, Jacobian will be
         estimated numerically). Only for CG, BFGS, Newton-CG.
@@ -52,51 +51,16 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
         times an arbitrary vector.  If it is not given, finite-differences
         on `jac` are used to compute it.
     options : dict, optional
-        A dictionary of solver options with the keys:
-            disp : bool
-                Set to True to print convergence messages.
-            xtol : float
-                Relative error in solution `xopt` acceptable for convergence.
-            ftol : float
-                Relative error in ``fun(xopt)`` acceptable for convergence.
+        A dictionary of solver options. All methods accept the following
+        generic options:
             maxiter : int
                 Maximum number of iterations to perform.
-            maxfev : int
-                Maximum number of function evaluations to make.
-            gtol : float
-                Gradient norm must be less than `gtol` before successful
-                termination.
-            norm : float
-                Order of norm (Inf is max, -Inf is min).
-            eps : int or ndarray
-                If `jac` is approximated, use this value for the step size.
-            direc : ndarray
-                Initial set of direction vectors for the Powell method.
-            schedule : str
-                Annealing schedule to use. One of: 'fast', 'cauchy' or
-                'boltzmann'.
-            T0 : float
-                Initial Temperature for simulated annealing (estimated as
-                1.2 times the largest cost-function deviation over random
-                points in the range).
-            Tf : float
-                Final goal temperature for simulated annealing.
-            maxaccept : int
-                Maximum changes to accept for simulated annealing.
-            learn_rate : float
-                Scale constant for adjusting guesses for simulated
-                annealing.
-            boltzmann : float
-                Boltzmann constant in acceptance test for simulated
-                annealing (increase for less stringent test at each
-                temperature).
-            quench, m, n : float
-                Parameters to alter fast_sa schedule.
-            lower, upper : float or ndarray
-                Lower and upper bounds on `x`.
-            dwell : int
-                The number of times to search the space at each temperature.
-
+            disp : bool
+                Set to True to print convergence messages.
+        For method-specific options, refer to the documentation of
+        respective underlying functions `_minimize_METHOD` (where METHOD is
+        one of 'neldermead', 'powell', 'cg', 'bfgs', 'newtoncg' or
+        'anneal').
     full_output : bool, optional
         If True, return optional outputs.  Default is False.
     callback : callable, optional
@@ -111,7 +75,8 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
     xopt : ndarray
         The solution.
     info : dict
-        A dictionary of optional outputs with the keys:
+        A dictionary of optional outputs (depending on the chosen method)
+        with the keys:
             solution : ndarray
                 The solution (same as `xopt`).
             success : bool
@@ -261,8 +226,8 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
         return _minimize_bfgs(fun, x0, args, jac, options, full_output,
                               retall, callback)
     elif method.lower() == 'newton-cg':
-        return _minimize_ncg(fun, x0, args, jac, hess, hessp, options,
-                             full_output, retall, callback)
+        return _minimize_newtoncg(fun, x0, args, jac, hess, hessp, options,
+                                  full_output, retall, callback)
     elif method.lower() == 'anneal':
         if callback:
             warn("Method 'Anneal' does not support callback.",

--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -1,0 +1,311 @@
+"""
+Interface to minimization algorithms
+
+Functions
+---------
+- minimize : unconstrained minimization of a function of several variables.
+- con_minimize : constrained minimization of a function of several variables.
+- minimize1d: minimization of a scalar function.
+
+"""
+
+__all__ = ['minimize']
+
+from warnings import warn
+from numpy import Inf
+from optimize import _epsilon
+# unconstrained minimization
+from optimize import fmin, fmin_powell, fmin_cg, fmin_bfgs, fmin_ncg
+
+def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
+             hessp=None, options=dict(), full_output=False, callback=None,
+             retall=False):
+    """
+    Minimization of scalar function of several variables.
+
+    Parameters
+    ----------
+    fun : callable
+        Objective function.
+    x0 : ndarray
+        Initial guess.
+    args : tuple
+        Extra arguments passed to the objective function and its
+        derivatives (Jacobian, Hessian).
+    method : str
+        Type of solver amongst:
+            'Nelder-Mead', 'Powell', 'CG', 'BFGS', 'Newton-CG'.
+    jac : callable
+        Jacobian of objective function (if None, Jacobian will be
+        estimate numerically). Only for CG, BFGS, Newton-CG.
+    hess, hessp : callable
+        Hessian of objective function or Hessian of objective function
+        times and arbitrary vector p. Only for Newton-CG.
+        Only one of `hessp` or `hess` need to be given.  If `hess` is
+        provided, then `hessp` will be ignored.  If neither `hess` nor
+        `hessp` is provided, then the hessian product will be approximated
+        using finite differences on `jac`. `hessp` must compute the hessian
+        times an arbitrary vector. If it is not given, finite-differences
+        on `jac` are used to compute it.
+    options : dict
+        A dictionary of solver options with the keys:
+            disp : int
+                If positive, information on the progress of the
+                optimization is displayed. Different level of details are
+                available depending on the solver. Most solvers consider
+                either 0 or 1 (i.e. Boolean) values for `disp`.
+            xtol : float
+                Relative error in xopt acceptable for convergence.
+            ftol : float
+                Relative error in fun(xopt) acceptable for convergence.
+            maxit : int
+                Maximum number of iterations to perform.
+            maxfev : int
+                Maximum number of function evaluations to make.
+            gtol : float
+                Gradient norm must be less than gtol before successful
+                termination.
+            norm : float
+                Order of norm (Inf is max, -Inf is min)
+            eps : int or ndarray
+                If `jac` is approximated, use this value for the step size.
+    full_output : bool
+        If True, return optional outputs.
+    callback : callable
+        Called after each iteration, as callback(xk), where xk is the
+        current parameter vector.
+    retall : bool
+        If True, return a list of the solution at each iteration. (Implies
+        full_output=True, ignored otherwise.)
+
+    Returns
+    -------
+    x : ndarray
+        The solution.
+    info : dict
+        A dictionary of optional outputs with the keys:
+            status : int
+                An integer flag. Set to 0 if a solution was found,
+                otherwise refer to message for more information.
+            message : str
+                If no solution is found, message details the cause of failure.
+            fun, jac, hess : ndarray
+                Values of objective function, Jacobian and Hessian (if
+                available).
+            nfev, njev, nhev: int
+                Number of evaluations of the objective functions and of its
+                jacobian and hessian.
+            nit: int
+                Number of iterations.
+            direc: array
+                Current direction set.
+            allvecs : list
+                Solution at each iteration (if retall==True).
+
+    Notes
+    -----
+    This section describes the available solver to be selected by the
+    'method' parameter. Respective solver options are also listed here.
+
+    By default, this function uses the *Nelder-Mead* simplex algorithm
+    [1]_,[2]_,[3]_ to find the a minimum of function of one or more
+    variables. This algorithm has a long history of successful use in
+    applications. But it will usually be slower than an algorithm that uses
+    first or second derivative information. In practice it can have poor
+    performance in high-dimensional problems and is not robust to
+    minimizing complicated functions. Additionally, there currently is no
+    complete theory describing when the algorithm will successfully
+    converge to the minimum, or how fast it will if it does.
+
+    Relevant `options` are: `xtol`, `ftol`, `maxit`, `maxfev`, `disp`.
+
+
+    Method *Powell* is a modification of Powell's method [4]_, [5]_ to find
+    the minimum of a function of N variables. Powell's method is a
+    conjugate direction method.
+
+    The algorithm has two loops. The outer loop merely iterates over the
+    inner loop. The inner loop minimizes over each current direction in the
+    direction set. At the end of the inner loop, if certain conditions are
+    met, the direction that gave the largest decrease is dropped and
+    replaced with the difference between the current estiamted x and the
+    estimated x from the beginning of the inner-loop.
+
+    The technical conditions for replacing the direction of greatest
+    increase amount to checking that
+
+    1. No further gain can be made along the direction of greatest increase
+       from that iteration.
+    2. The direction of greatest increase accounted for a large sufficient
+       fraction of the decrease in the function value from that iteration of
+       the inner loop.
+
+    Relevant `options` are: `xtol`, `ftol`, `maxit`, `maxfev`, `disp`.
+
+
+    Method *CG* uses a nonlinear conjugate gradient algorithm by Polak and
+    Ribiere as described in [6]_ pp. 120-122.
+
+    Relevant `options` are: `gtol`, `norm`, `maxit`, `eps`, `disp`.
+
+
+    Method *BFGS* uses the quasi-Newton method of Broyden, Fletcher,
+    Goldfarb, and Shanno (BFGS) [6]_ pp. 198
+
+    Relevant `options` are: `gtol`, `norm`, `maxit`, `eps`, `disp`.
+
+
+    Method *Newton-CG* uses a Newton-CG algorithm [6]_ pp.140. Newton-CG
+    methods are also called truncated Newton methods. See also `fmincon`
+    with method='TNC' for a box-constrained minimization with a similar
+    algorithm.
+
+    Relevant `options` are: `xtol`, `maxit`, `eps`, `disp`.
+
+    References
+    ----------
+    .. [1] Nelder, J.A. and Mead, R. (1965), "A simplex method for function
+       minimization", The Computer Journal, 7, pp. 308-313
+    .. [2] Wright, M.H. (1996), "Direct Search Methods: Once Scorned, Now
+       Respectable", in Numerical Analysis 1995, Proceedings of the
+       1995 Dundee Biennial Conference in Numerical Analysis, D.F.
+    .. [3] Griffiths and G.A. Watson (Eds.), Addison Wesley Longman,
+       Harlow, UK, pp. 191-208.
+    .. [4] Powell M.J.D. (1964) An efficient method for finding the minimum of a
+       function of several variables without calculating derivatives,
+       Computer Journal, 7 (2):155-162.
+    .. [5] Press W., Teukolsky S.A., Vetterling W.T., and Flannery B.P.:
+       Numerical Recipes (any edition), Cambridge University Press
+    .. [6] Wright & Nocedal, 'Numerical Optimization', 1999.
+    """
+    if full_output:
+        info = dict()
+    elif retall: # retall implies full_output, issue a warning otherwise
+        warn('retall is ignored since full_output=False.', RuntimeWarning)
+
+    if method.lower() == 'nelder-mead':
+        # set default options and update using input values
+        opts = {'xtol': 1e-4,
+                'ftol': 1e-4,
+                'disp': 1}
+        opts.update(**options)
+
+        out = fmin(fun, x0, args=args, xtol=opts.get('xtol'),
+                   ftol=opts.get('ftol'), maxiter=opts.get('maxit'),
+                   maxfun=opts.get('maxfev'), full_output=full_output,
+                   disp=opts.get('disp'), retall=retall, callback=callback)
+
+        if full_output:
+            x, info['fun'], info['nit'], info['nfev'], info['status'] = \
+                    out[:5]
+            if retall:
+                info['allvecs'] = out[5]
+        else:
+            if retall:
+                x = out[0]
+            else:
+                x = out
+
+    elif method.lower() == 'powell':
+        # set default options and update using input values
+        opts = {'xtol': 1e-4,
+                'ftol': 1e-4,
+                'disp': 1}
+        opts.update(**options)
+        out = fmin_powell(fun, x0, args=args, xtol=opts.get('xtol'),
+                          ftol=opts.get('ftol'), maxiter=opts.get('maxit'),
+                          maxfun=opts.get('maxfev'),
+                          full_output=full_output, disp=opts.get('disp'),
+                          retall=retall, callback=callback)
+
+        if full_output:
+            x, info['fun'], info['direc'], info['nit'], info['nfev'], \
+                    info['status'] = out[:6]
+            if retall:
+                info['allvecs'] = out[6]
+        else:
+            if retall:
+                x = out[0]
+            else:
+                x = out
+
+    elif method.lower() == 'cg':
+        # set default options and update using input values
+        opts = {'gtol': 1e-5,
+                'norm': Inf,
+                'eps': _epsilon,
+                'disp': 1}
+        opts.update(**options)
+        out = fmin_cg(fun, x0, fprime=jac, args=args,
+                      gtol=opts.get('gtol'), norm=opts.get('norm'),
+                      epsilon=opts.get('eps'), maxiter=opts.get('maxit'),
+                      full_output=full_output, disp=opts.get('disp'),
+                      retall=retall, callback=callback)
+
+        if full_output:
+            x, info['fun'], info['nfev'], info['njev'], info['status'] = \
+                    out[:5]
+            if retall:
+                info['allvecs'] = out[5]
+        else:
+            if retall:
+                x = out[0]
+            else:
+                x = out
+
+    elif method.lower() == 'bfgs':
+        # set default options and update using input values
+        opts = {'gtol': 1e-5,
+                'norm': Inf,
+                'eps': _epsilon,
+                'disp': 1}
+        opts.update(**options)
+        out = fmin_bfgs(fun, x0, fprime=jac, args=args,
+                        gtol=opts.get('gtol'), norm=opts.get('norm'),
+                        epsilon=opts.get('eps'), maxiter=opts.get('maxit'),
+                        full_output=full_output, disp=opts.get('disp'),
+                        retall=retall, callback=callback)
+
+        if full_output:
+            x, info['fun'], info['jac'], info['hess'], info['nfev'], \
+                    info['njev'], info['status'] = out[:7]
+            if retall:
+                info['allvecs'] = out[7]
+        else:
+            if retall:
+                x = out[0]
+            else:
+                x = out
+
+    elif method.lower() == 'newton-cg':
+        if jac == None:
+            raise ValueError('Jacobian is required for Newton-CG method')
+        # set default options and update using input values
+        opts = {'xtol': 1e-5,
+                'eps': _epsilon,
+                'disp': 1}
+        opts.update(**options)
+        out = fmin_ncg(fun, x0, jac, fhess_p=hessp, fhess=hess, args=args,
+                       avextol=opts.get('xtol'), epsilon=opts.get('eps'),
+                       maxiter=opts.get('maxit'), full_output=full_output,
+                       disp=opts.get('disp'), retall=retall,
+                       callback=callback)
+
+        if full_output:
+            x, info['fun'], info['nfev'], info['njev'], info['nhev'], \
+                    info['status'] = out[:6]
+            if retall:
+                info['allvecs'] = out[6]
+        else:
+            if retall:
+                x = out[0]
+            else:
+                x = out
+
+    else:
+        raise ValueError('Unknown solver %s' % method)
+
+    if full_output:
+        return x, info
+    else:
+        return x

--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -211,7 +211,42 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
     .. [5] Nocedal, J, and S J Wright. 2006. Numerical Optimization.
        Springer New York.
 
+    Examples
+    --------
+    Let us consider the problem of minimizing the Rosenbrock function. This
+    function (and its respective derivatives) is implemented in `rosen`
+    (resp. `rosen_der`, `rosen_hess`) in the `scipy.optimize`.
 
+    >>> from scipy.optimize import minimize, rosen, rosen_der
+
+    A simple application of the *Nelder-Mead* method is:
+
+    >>> x0 = [1.3, 0.7, 0.8, 1.9, 1.2]
+    >>> xopt = minimize(rosen, x0, method='Nelder-Mead')
+    Optimization terminated successfully.
+         Current function value: 0.000066
+         Iterations: 141
+         Function evaluations: 243
+    >>> print xopt
+    [ 1.  1.  1.  1.  1.]
+
+    Now using the *BFGS* algorithm, using the first derivative and a few
+    options:
+
+    >>> xopt, info = minimize(rosen, x0, method='BFGS', jac=rosen_der,
+    ...                       options={'gtol': 1e-6, 'disp': False},
+    ...                       full_output=True)
+
+    >>> print info['message']
+    Optimization terminated successfully.
+    >>> print info['solution']
+    [ 1.  1.  1.  1.  1.]
+    >>> print info['hess']
+    [[ 0.00749589  0.01255155  0.02396251  0.04750988  0.09495377]
+     [ 0.01255155  0.02510441  0.04794055  0.09502834  0.18996269]
+     [ 0.02396251  0.04794055  0.09631614  0.19092151  0.38165151]
+     [ 0.04750988  0.09502834  0.19092151  0.38341252  0.7664427 ]
+     [ 0.09495377  0.18996269  0.38165151  0.7664427   1.53713523]]
     """
     if method.lower() == 'nelder-mead':
         return _minimize_neldermead(fun, x0, args, options, full_output,

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -35,7 +35,7 @@ from linesearch import \
 _status_message = {'success': 'Optimization terminated successfully.',
                    'maxfev' : 'Maximum number of function evaluations has '
                               'been exceeded.',
-                   'maxit'  : 'Maximum number of iterations has been '
+                   'maxiter': 'Maximum number of iterations has been '
                               'exceeded.',
                    'pr_loss': 'Desired error not necessarily achieved due '
                               'to precision loss.'}
@@ -415,7 +415,7 @@ def _minimize_neldermead(func, x0, args=(), options={}, full_output=0,
             print 'Warning: ' + msg
     elif iterations >= maxiter:
         warnflag = 2
-        msg = _status_message['maxit']
+        msg = _status_message['maxiter']
         if disp:
             print 'Warning: ' + msg
     else:
@@ -685,7 +685,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, options={}, full_output=0,
 
     elif k >= maxiter:
         warnflag = 1
-        msg = _status_message['maxit']
+        msg = _status_message['maxiter']
         if disp:
             print "Warning: " + msg
             print "         Current function value: %f" % fval
@@ -889,7 +889,7 @@ def _minimize_cg(fun, x0, args=(), jac=None, options={}, full_output=0,
 
     elif k >= maxiter:
         warnflag = 1
-        msg = _status_message['maxit']
+        msg = _status_message['maxiter']
         if disp:
             print "Warning: " + msg
             print "         Current function value: %f" % fval
@@ -1128,7 +1128,7 @@ def _minimize_ncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
         fval = old_fval
     if k >= maxiter:
         warnflag = 1
-        msg = _status_message['maxit']
+        msg = _status_message['maxiter']
         if disp:
             print "Warning: " + msg
             print "         Current function value: %f" % fval
@@ -1898,7 +1898,7 @@ def _minimize_powell(func, x0, args=(), options={}, full_output=0,
             print "Warning: " + msg
     elif iter >= maxiter:
         warnflag = 2
-        msg = _status_message['maxit']
+        msg = _status_message['maxiter']
         if disp:
             print "Warning: " + msg
     else:

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -253,6 +253,25 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
     Harlow, UK, pp. 191-208.
 
     """
+    opts = {'xtol': xtol,
+            'ftol': ftol,
+            'maxiter': maxiter,
+            'maxfev': maxfun,
+            'disp': disp}
+
+    return _minimize_neldermead(func, x0, args, opts, full_output, retall,
+                                callback)
+
+def _minimize_neldermead(func, x0, args=(), options={}, full_output=0,
+                         retall=0, callback=None):
+    """minimize: Nelder-Mead method"""
+    # retrieve useful options
+    xtol    = options.get('xtol', 1e-4)
+    ftol    = options.get('ftol', 1e-4)
+    maxiter = options.get('maxiter')
+    maxfun  = options.get('maxfev')
+    disp    = options.get('disp', 1)
+
     fcalls, func = wrap_function(func, args)
     x0 = asfarray(x0).flatten()
     N = len(x0)
@@ -505,6 +524,27 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
     Wright, and Nocedal 'Numerical Optimization', 1999, pg. 198.
 
     """
+    opts = {'gtol': gtol,
+            'norm': norm,
+            'eps': epsilon,
+            'disp': disp,
+            'maxiter': maxiter}
+
+    return _minimize_bfgs(f, x0, args, fprime, opts, full_output, retall,
+                          callback)
+
+def _minimize_bfgs(fun, x0, args=(), jac=None, options={}, full_output=0,
+                   retall=0, callback=None):
+    """minimize: BFGS method"""
+    f = fun
+    fprime = jac
+    # retrieve useful options
+    gtol    = options.get('gtol', 1e-5)
+    norm    = options.get('norm', Inf)
+    epsilon = options.get('eps', _epsilon)
+    maxiter = options.get('maxiter')
+    disp    = options.get('disp', 1)
+
     x0 = asarray(x0).flatten()
     if x0.ndim == 0:
         x0.shape = (1,)
@@ -683,6 +723,27 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
     1999, pg. 120-122.
 
     """
+    opts = {'gtol': gtol,
+            'norm': norm,
+            'eps': epsilon,
+            'disp': disp,
+            'maxiter': maxiter}
+
+    return _minimize_cg(f, x0, args, fprime, opts, full_output, retall,
+                        callback)
+
+def _minimize_cg(fun, x0, args=(), jac=None, options={}, full_output=0,
+                 retall=0, callback=None):
+    """minimize: conjugate gradient method"""
+    f = fun
+    fprime = jac
+    # retrieve useful options
+    gtol    = options.get('gtol', 1e-5)
+    norm    = options.get('norm', Inf)
+    epsilon = options.get('eps', _epsilon)
+    maxiter = options.get('maxiter')
+    disp    = options.get('disp', 1)
+
     x0 = asarray(x0).flatten()
     if maxiter is None:
         maxiter = len(x0)*200
@@ -862,6 +923,29 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
     Wright & Nocedal, 'Numerical Optimization', 1999, pg. 140.
 
     """
+    opts = {'xtol': avextol,
+            'epsilon': epsilon,
+            'maxiter': maxiter,
+            'disp': disp}
+
+    return _minimize_ncg(f, x0, args, fprime, fhess, fhess_p, opts,
+                         full_output, retall, callback)
+
+def _minimize_ncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
+                  options={}, full_output=0, retall=0, callback=None):
+    """minimize: Newton-CG method"""
+    if jac == None:
+        raise ValueError('Jacobian is required for Newton-CG method')
+    f = fun
+    fprime = jac
+    fhess_p = hessp
+    fhess = hess
+    # retrieve useful options
+    avextol = options.get('xtol', 1e-5)
+    epsilon = options.get('eps', _epsilon)
+    maxiter = options.get('maxiter')
+    disp    = options.get('disp', 1)
+
     x0 = asarray(x0).flatten()
     fcalls, f = wrap_function(f, args)
     gcalls, fprime = wrap_function(fprime, args)
@@ -1593,6 +1677,25 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
     Numerical Recipes (any edition), Cambridge University Press
 
     """
+    opts = {'xtol': xtol,
+            'ftol': ftol,
+            'maxiter': maxiter,
+            'maxfev': maxfun,
+            'disp': disp}
+
+    return _minimize_powell(func, x0, args, opts, full_output, retall,
+                            callback)
+
+def _minimize_powell(func, x0, args=(), options={}, full_output=0,
+                     retall=0, callback=None):
+    """minimize: (modified) Powell method"""
+    # retrieve useful options
+    xtol    = options.get('xtol', 1e-4)
+    ftol    = options.get('ftol', 1e-4)
+    maxiter = options.get('maxiter')
+    maxfun  = options.get('maxfev')
+    disp    = options.get('disp', 1)
+    direc   = options.get('direc')
     # we need to use a mutable object here that we can update in the
     # wrapper function
     fcalls, func = wrap_function(func, args)

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -30,6 +30,16 @@ from linesearch import \
      line_search_BFGS, line_search_wolfe1, line_search_wolfe2, \
      line_search_wolfe2 as line_search
 
+
+# standard status messages of optimizers
+_status_message = {'success': 'Optimization terminated successfully.',
+                   'maxfev' : 'Maximum number of function evaluations has '
+                              'been exceeded.',
+                   'maxit'  : 'Maximum number of iterations has been '
+                              'exceeded.',
+                   'pr_loss': 'Desired error not necessarily achieved due '
+                              'to precision loss.'}
+
 # These have been copied from Numeric's MLab.py
 # I don't think they made the transition to scipy_core
 def max(m, axis=0):
@@ -393,16 +403,18 @@ def _minimize_neldermead(func, x0, args=(), options={}, full_output=0,
 
     if fcalls[0] >= maxfun:
         warnflag = 1
+        msg = _status_message['maxfev']
         if disp:
-            print "Warning: Maximum number of function evaluations has "\
-                  "been exceeded."
+            print 'Warning: ' + msg
     elif iterations >= maxiter:
         warnflag = 2
+        msg = _status_message['maxit']
         if disp:
-            print "Warning: Maximum number of iterations has been exceeded"
+            print 'Warning: ' + msg
     else:
+        msg = _status_message['success']
         if disp:
-            print "Optimization terminated successfully."
+            print msg
             print "         Current function value: %f" % fval
             print "         Iterations: %d" % iterations
             print "         Function evaluations: %d" % fcalls[0]
@@ -412,7 +424,8 @@ def _minimize_neldermead(func, x0, args=(), options={}, full_output=0,
         info = {'fun': fval,
                 'nit': iterations,
                 'nfev': fcalls[0],
-                'status': warnflag}
+                'status': warnflag,
+                'message': msg}
         if retall:
             info['allvecs'] = allvecs
         return x, info
@@ -645,9 +658,9 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, options={}, full_output=0,
     if disp or full_output:
         fval = old_fval
     if warnflag == 2:
+        msg = _status_message['pr_loss']
         if disp:
-            print "Warning: Desired error not necessarily achieved" \
-                  "due to precision loss"
+            print "Warning: " + msg
             print "         Current function value: %f" % fval
             print "         Iterations: %d" % k
             print "         Function evaluations: %d" % func_calls[0]
@@ -655,15 +668,17 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, options={}, full_output=0,
 
     elif k >= maxiter:
         warnflag = 1
+        msg = _status_message['maxit']
         if disp:
-            print "Warning: Maximum number of iterations has been exceeded"
+            print "Warning: " + msg
             print "         Current function value: %f" % fval
             print "         Iterations: %d" % k
             print "         Function evaluations: %d" % func_calls[0]
             print "         Gradient evaluations: %d" % grad_calls[0]
     else:
+        msg = _status_message['success']
         if disp:
-            print "Optimization terminated successfully."
+            print msg
             print "         Current function value: %f" % fval
             print "         Iterations: %d" % k
             print "         Function evaluations: %d" % func_calls[0]
@@ -675,7 +690,8 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, options={}, full_output=0,
                 'hess': Hk,
                 'nfev': func_calls[0],
                 'njev': grad_calls[0],
-                'status': warnflag}
+                'status': warnflag,
+                'message': msg}
         if retall:
             info['allvecs'] = allvecs
         if retall:
@@ -836,8 +852,9 @@ def _minimize_cg(fun, x0, args=(), jac=None, options={}, full_output=0,
     if disp or full_output:
         fval = old_fval
     if warnflag == 2:
+        msg = _status_message['pr_loss']
         if disp:
-            print "Warning: Desired error not necessarily achieved due to precision loss"
+            print "Warning: " + msg
             print "         Current function value: %f" % fval
             print "         Iterations: %d" % k
             print "         Function evaluations: %d" % func_calls[0]
@@ -845,15 +862,17 @@ def _minimize_cg(fun, x0, args=(), jac=None, options={}, full_output=0,
 
     elif k >= maxiter:
         warnflag = 1
+        msg = _status_message['maxit']
         if disp:
-            print "Warning: Maximum number of iterations has been exceeded"
+            print "Warning: " + msg
             print "         Current function value: %f" % fval
             print "         Iterations: %d" % k
             print "         Function evaluations: %d" % func_calls[0]
             print "         Gradient evaluations: %d" % grad_calls[0]
     else:
+        msg = _status_message['success']
         if disp:
-            print "Optimization terminated successfully."
+            print msg
             print "         Current function value: %f" % fval
             print "         Iterations: %d" % k
             print "         Function evaluations: %d" % func_calls[0]
@@ -864,7 +883,8 @@ def _minimize_cg(fun, x0, args=(), jac=None, options={}, full_output=0,
         info = {'fun': fval,
                 'nfev': func_calls[0],
                 'njev': grad_calls[0],
-                'status': warnflag}
+                'status': warnflag,
+                'message': msg}
         if retall:
             info['allvecs'] = allvecs
         return xk, info
@@ -1069,8 +1089,9 @@ def _minimize_ncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
         fval = old_fval
     if k >= maxiter:
         warnflag = 1
+        msg = _status_message['maxit']
         if disp:
-            print "Warning: Maximum number of iterations has been exceeded"
+            print "Warning: " + msg
             print "         Current function value: %f" % fval
             print "         Iterations: %d" % k
             print "         Function evaluations: %d" % fcalls[0]
@@ -1078,8 +1099,9 @@ def _minimize_ncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
             print "         Hessian evaluations: %d" % hcalls
     else:
         warnflag = 0
+        msg = _status_message['success']
         if disp:
-            print "Optimization terminated successfully."
+            print msg
             print "         Current function value: %f" % fval
             print "         Iterations: %d" % k
             print "         Function evaluations: %d" % fcalls[0]
@@ -1091,7 +1113,8 @@ def _minimize_ncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
                 'nfev': fcalls[0],
                 'njev': gcalls[0],
                 'nhev': hcalls,
-                'status': warnflag}
+                'status': warnflag,
+                'message': msg}
         if retall:
             info['allvecs'] = allvecs
         return xk, info
@@ -1821,16 +1844,18 @@ def _minimize_powell(func, x0, args=(), options={}, full_output=0,
     warnflag = 0
     if fcalls[0] >= maxfun:
         warnflag = 1
+        msg = _status_message['maxfev']
         if disp:
-            print "Warning: Maximum number of function evaluations has "\
-                  "been exceeded."
+            print "Warning: " + msg
     elif iter >= maxiter:
         warnflag = 2
+        msg = _status_message['maxit']
         if disp:
-            print "Warning: Maximum number of iterations has been exceeded"
+            print "Warning: " + msg
     else:
+        msg = _status_message['success']
         if disp:
-            print "Optimization terminated successfully."
+            print msg
             print "         Current function value: %f" % fval
             print "         Iterations: %d" % iter
             print "         Function evaluations: %d" % fcalls[0]
@@ -1842,7 +1867,8 @@ def _minimize_powell(func, x0, args=(), options={}, full_output=0,
                 'direc': direc,
                 'nit': iter,
                 'nfev': fcalls[0],
-                'status': warnflag}
+                'status': warnflag,
+                'message': msg}
         if retall:
             info['allvecs'] = allvecs
         return x, info

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -283,7 +283,7 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
         x, info = out
         retlist = x, info['fun'], info['nit'], info['nfev'], info['status']
         if retall:
-            retlist += info['allvecs']
+            retlist += (info['allvecs'], )
         return retlist
     else:
         return out
@@ -577,7 +577,7 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
         retlist = x, info['fun'], info['jac'], info['hess'], \
                 info['nfev'], info['njev'], info['status']
         if retall:
-            retlist += info['allvecs']
+            retlist += (info['allvecs'], )
         return retlist
     else:
         return out
@@ -801,7 +801,7 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
         x, info = out
         retlist = x, info['fun'], info['nfev'], info['njev'], info['status']
         if retall:
-            retlist += info['allvecs']
+            retlist += (info['allvecs'], )
         return retlist
     else:
         return out
@@ -1026,7 +1026,7 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
         retlist = x, info['fun'], info['nfev'], info['njev'], \
                 info['nhev'], info['status']
         if retall:
-            retlist += info['allvecs']
+            retlist += (info['allvecs'], )
         return retlist
     else:
         return out
@@ -1804,7 +1804,7 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
         retlist = x, info['fun'], info['direc'], info['nit'], \
                 info['nfev'], info['status']
         if retall:
-            retlist += info['allvecs']
+            retlist += (info['allvecs'], )
         return retlist
     else:
         return out

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -297,7 +297,25 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
 
 def _minimize_neldermead(func, x0, args=(), options={}, full_output=0,
                          retall=0, callback=None):
-    """minimize: Nelder-Mead method"""
+    """
+    Minimization of scalar function of one or more variables using the
+    Nelder-Mead algorithm.
+
+    Options for the Nelder-Mead algorithm are:
+        disp : bool
+            Set to True to print convergence messages.
+        xtol : float
+            Relative error in solution `xopt` acceptable for convergence.
+        ftol : float
+            Relative error in ``fun(xopt)`` acceptable for convergence.
+        maxiter : int
+            Maximum number of iterations to perform.
+        maxfev : int
+            Maximum number of function evaluations to make.
+
+    This function is called by the `minimize` function with
+    `method=Nelder-Mead`. It is not supposed to be called directly.
+    """
     # retrieve useful options
     xtol    = options.get('xtol', 1e-4)
     ftol    = options.get('ftol', 1e-4)
@@ -598,7 +616,26 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
 
 def _minimize_bfgs(fun, x0, args=(), jac=None, options={}, full_output=0,
                    retall=0, callback=None):
-    """minimize: BFGS method"""
+    """
+    Minimization of scalar function of one or more variables using the
+    BFGS algorithm.
+
+    Options for the BFGS algorithm are:
+        disp : bool
+            Set to True to print convergence messages.
+        maxiter : int
+            Maximum number of iterations to perform.
+        gtol : float
+            Gradient norm must be less than `gtol` before successful
+            termination.
+        norm : float
+            Order of norm (Inf is max, -Inf is min).
+        eps : float or ndarray
+            If `jac` is approximated, use this value for the step size.
+
+    This function is called by the `minimize` function with `method=BFGS`.
+    It is not supposed to be called directly.
+    """
     f = fun
     fprime = jac
     # retrieve useful options
@@ -827,7 +864,26 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
 
 def _minimize_cg(fun, x0, args=(), jac=None, options={}, full_output=0,
                  retall=0, callback=None):
-    """minimize: conjugate gradient method"""
+    """
+    Minimization of scalar function of one or more variables using the
+    conjugate gradient algorithm.
+
+    Options for the conjugate gradient algorithm are:
+        disp : bool
+            Set to True to print convergence messages.
+        maxiter : int
+            Maximum number of iterations to perform.
+        gtol : float
+            Gradient norm must be less than `gtol` before successful
+            termination.
+        norm : float
+            Order of norm (Inf is max, -Inf is min).
+        eps : float or ndarray
+            If `jac` is approximated, use this value for the step size.
+
+    This function is called by the `minimize` function with `method=CG`. It
+    is not supposed to be called directly.
+    """
     f = fun
     fprime = jac
     # retrieve useful options
@@ -1036,12 +1092,12 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
 
     # force full_output if retall=True to preserve backwards compatibility
     if retall and not full_output:
-        out = _minimize_ncg(f, x0, args, fprime, fhess, fhess_p, opts,
-                            full_output=True, retall=retall,
-                            callback=callback)
+        out = _minimize_newtoncg(f, x0, args, fprime, fhess, fhess_p, opts,
+                                 full_output=True, retall=retall,
+                                 callback=callback)
     else:
-        out = _minimize_ncg(f, x0, args, fprime, fhess, fhess_p, opts,
-                            full_output, retall, callback)
+        out = _minimize_newtoncg(f, x0, args, fprime, fhess, fhess_p, opts,
+                                 full_output, retall, callback)
 
     if full_output:
         x, info = out
@@ -1057,9 +1113,28 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
         else:
             return out
 
-def _minimize_ncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
-                  options={}, full_output=0, retall=0, callback=None):
-    """minimize: Newton-CG method"""
+def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
+                       options={}, full_output=0, retall=0, callback=None):
+    """
+    Minimization of scalar function of one or more variables using the
+    Newton-CG algorithm.
+
+    Options for the Newton-CG algorithm are:
+        disp : bool
+            Set to True to print convergence messages.
+        xtol : float
+            Average relative error in solution `xopt` acceptable for
+            convergence.
+        maxiter : int
+            Maximum number of iterations to perform.
+        eps : float or ndarray
+            If `jac` is approximated, use this value for the step size.
+
+    This function is called by the `minimize` function with
+    `method=Newton-CG`. It is not supposed to be called directly.
+
+    Also note that the `jac` parameter (Jacobian) is required.
+    """
     if jac == None:
         raise ValueError('Jacobian is required for Newton-CG method')
     f = fun
@@ -1845,7 +1920,27 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
 
 def _minimize_powell(func, x0, args=(), options={}, full_output=0,
                      retall=0, callback=None):
-    """minimize: (modified) Powell method"""
+    """
+    Minimization of scalar function of one or more variables using the
+    modified Powell algorithm.
+
+    Options for the Powell algorithm are:
+        disp : bool
+            Set to True to print convergence messages.
+        xtol : float
+            Relative error in solution `xopt` acceptable for convergence.
+        ftol : float
+            Relative error in ``fun(xopt)`` acceptable for convergence.
+        maxiter : int
+            Maximum number of iterations to perform.
+        maxfev : int
+            Maximum number of function evaluations to make.
+        direc : ndarray
+            Initial set of direction vectors for the Powell method.
+
+    This function is called by the `minimize` function with
+    `method=Powell`. It is not supposed to be called directly.
+    """
     # retrieve useful options
     xtol    = options.get('xtol', 1e-4)
     ftol    = options.get('ftol', 1e-4)

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -187,9 +187,16 @@ def wrap_function(function, args):
         return function(x, *args)
     return ncalls, function_wrapper
 
+@numpy.deprecate
 def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
          full_output=0, disp=1, retall=0, callback=None):
     """
+    This function is deprecated, use
+
+        scipy.optimize.minimize(..., method='Nelder-Mead', ...)
+
+    instead.
+
     Minimize a function using the downhill simplex algorithm.
 
     This algorithm only uses function values, not derivatives or second
@@ -479,10 +486,18 @@ def approx_fhess_p(x0, p, fprime, epsilon, *args):
     return (f2 - f1) / epsilon
 
 
+@numpy.deprecate
 def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
               epsilon=_epsilon, maxiter=None, full_output=0, disp=1,
               retall=0, callback=None):
-    """Minimize a function using the BFGS algorithm.
+    """
+    This function is deprecated, use
+
+        scipy.optimize.minimize(..., method='BFGS', ...)
+
+    instead.
+
+    Minimize a function using the BFGS algorithm.
 
     Parameters
     ----------
@@ -703,9 +718,17 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, options={}, full_output=0,
         return xk
 
 
+@numpy.deprecate
 def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
               maxiter=None, full_output=0, disp=1, retall=0, callback=None):
-    """Minimize a function using a nonlinear conjugate gradient algorithm.
+    """
+    This function is deprecated, use
+
+        scipy.optimize.minimize(..., method='CG', ...)
+
+    instead.
+
+    Minimize a function using a nonlinear conjugate gradient algorithm.
 
     Parameters
     ----------
@@ -893,10 +916,19 @@ def _minimize_cg(fun, x0, args=(), jac=None, options={}, full_output=0,
             warn('retall is ignored since full_output=False.', RuntimeWarning)
         return xk
 
+
+@numpy.deprecate
 def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
              epsilon=_epsilon, maxiter=None, full_output=0, disp=1, retall=0,
              callback=None):
-    """Unconstrained minimization of a function using the Newton-CG method.
+    """
+    This function is deprecated, use
+
+        scipy.optimize.minimize(..., method='Newton-CG', ...)
+
+    instead.
+
+    Unconstrained minimization of a function using the Newton-CG method.
 
 
     Parameters
@@ -1657,10 +1689,17 @@ def _linesearch_powell(func, p, xi, tol=1e-3):
     return squeeze(fret), p + xi, xi
 
 
+@numpy.deprecate
 def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
                 maxfun=None, full_output=0, disp=1, retall=0, callback=None,
                 direc=None):
     """
+    This function is deprecated, use
+
+        scipy.optimize.minimize(..., method='Powell', ...)
+
+    instead.
+
     Minimize a function using modified Powell's method. This method
     only uses function values, not derivatives.
 

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -186,16 +186,9 @@ def wrap_function(function, args):
         return function(x, *args)
     return ncalls, function_wrapper
 
-@numpy.deprecate
 def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
          full_output=0, disp=1, retall=0, callback=None):
     """
-    This function is deprecated, use
-
-        scipy.optimize.minimize(..., method='Nelder-Mead', ...)
-
-    instead.
-
     Minimize a function using the downhill simplex algorithm.
 
     This algorithm only uses function values, not derivatives or second
@@ -245,6 +238,12 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
         Set to True to print convergence messages.
     retall : bool
         Set to True to return list of solutions at each iteration.
+
+    See also
+    --------
+    minimize: Interface to unconstrained minimization algorithms for
+        multivariate functions. See the 'Nelder-Mead' `method` in
+        particular.
 
     Notes
     -----
@@ -494,17 +493,10 @@ def approx_fhess_p(x0, p, fprime, epsilon, *args):
     return (f2 - f1) / epsilon
 
 
-@numpy.deprecate
 def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
               epsilon=_epsilon, maxiter=None, full_output=0, disp=1,
               retall=0, callback=None):
     """
-    This function is deprecated, use
-
-        scipy.optimize.minimize(..., method='BFGS', ...)
-
-    instead.
-
     Minimize a function using the BFGS algorithm.
 
     Parameters
@@ -559,6 +551,11 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
         Print convergence message if True.
     retall : bool
         Return a list of results at each iteration if True.
+
+    See also
+    --------
+    minimize: Interface to unconstrained minimization algorithms for
+        multivariate functions. See the 'BFGS' `method` in particular.
 
     Notes
     -----
@@ -733,16 +730,9 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, options={}, full_output=0,
         return xk
 
 
-@numpy.deprecate
 def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
               maxiter=None, full_output=0, disp=1, retall=0, callback=None):
     """
-    This function is deprecated, use
-
-        scipy.optimize.minimize(..., method='CG', ...)
-
-    instead.
-
     Minimize a function using a nonlinear conjugate gradient algorithm.
 
     Parameters
@@ -795,6 +785,11 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
         Print convergence message if True.
     retall : bool
         Return a list of results at each iteration if True.
+
+    See also
+    --------
+    minimize: Interface to unconstrained minimization algorithms for
+        multivariate functions. See the 'CG' `method` in particular.
 
     Notes
     -----
@@ -941,18 +936,10 @@ def _minimize_cg(fun, x0, args=(), jac=None, options={}, full_output=0,
     else:
         return xk
 
-
-@numpy.deprecate
 def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
              epsilon=_epsilon, maxiter=None, full_output=0, disp=1, retall=0,
              callback=None):
     """
-    This function is deprecated, use
-
-        scipy.optimize.minimize(..., method='Newton-CG', ...)
-
-    instead.
-
     Unconstrained minimization of a function using the Newton-CG method.
 
 
@@ -1011,6 +998,11 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
         If True, print convergence message.
     retall : bool
         If True, return a list of results at each iteration.
+
+    See also
+    --------
+    minimize: Interface to unconstrained minimization algorithms for
+        multivariate functions. See the 'Newton-CG' `method` in particular.
 
     Notes
     -----
@@ -1725,17 +1717,10 @@ def _linesearch_powell(func, p, xi, tol=1e-3):
     return squeeze(fret), p + xi, xi
 
 
-@numpy.deprecate
 def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
                 maxfun=None, full_output=0, disp=1, retall=0, callback=None,
                 direc=None):
     """
-    This function is deprecated, use
-
-        scipy.optimize.minimize(..., method='Powell', ...)
-
-    instead.
-
     Minimize a function using modified Powell's method. This method
     only uses function values, not derivatives.
 
@@ -1790,6 +1775,11 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
         If True, print convergence messages.
     retall : bool
         If True, return a list of the solution at each iteration.
+
+    See also
+    --------
+    minimize: Interface to unconstrained minimization algorithms for
+        multivariate functions. See the 'Powell' `method` in particular.
 
     Notes
     -----

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -713,8 +713,6 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, options={}, full_output=0,
                 'solution': xk}
         if retall:
             info['allvecs'] = allvecs
-        if retall:
-            retlist += (allvecs,)
         return xk, info
     else:
         if retall:

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -296,7 +296,7 @@ def _minimize_neldermead(func, x0, args=(), options={}, full_output=0,
     ftol    = options.get('ftol', 1e-4)
     maxiter = options.get('maxiter')
     maxfun  = options.get('maxfev')
-    disp    = options.get('disp', 1)
+    disp    = options.get('disp', True)
 
     fcalls, func = wrap_function(func, args)
     x0 = asfarray(x0).flatten()
@@ -594,7 +594,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, options={}, full_output=0,
     norm    = options.get('norm', Inf)
     epsilon = options.get('eps', _epsilon)
     maxiter = options.get('maxiter')
-    disp    = options.get('disp', 1)
+    disp    = options.get('disp', True)
 
     x0 = asarray(x0).flatten()
     if x0.ndim == 0:
@@ -820,7 +820,7 @@ def _minimize_cg(fun, x0, args=(), jac=None, options={}, full_output=0,
     norm    = options.get('norm', Inf)
     epsilon = options.get('eps', _epsilon)
     maxiter = options.get('maxiter')
-    disp    = options.get('disp', 1)
+    disp    = options.get('disp', True)
 
     x0 = asarray(x0).flatten()
     if maxiter is None:
@@ -1050,7 +1050,7 @@ def _minimize_ncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
     avextol = options.get('xtol', 1e-5)
     epsilon = options.get('eps', _epsilon)
     maxiter = options.get('maxiter')
-    disp    = options.get('disp', 1)
+    disp    = options.get('disp', True)
 
     x0 = asarray(x0).flatten()
     fcalls, f = wrap_function(f, args)
@@ -1825,7 +1825,7 @@ def _minimize_powell(func, x0, args=(), options={}, full_output=0,
     ftol    = options.get('ftol', 1e-4)
     maxiter = options.get('maxiter')
     maxfun  = options.get('maxfev')
-    disp    = options.get('disp', 1)
+    disp    = options.get('disp', True)
     direc   = options.get('direc')
     # we need to use a mutable object here that we can update in the
     # wrapper function

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -22,7 +22,6 @@ __all__ = ['fmin', 'fmin_powell', 'fmin_bfgs', 'fmin_ncg', 'fmin_cg',
 
 __docformat__ = "restructuredtext en"
 
-from warnings import warn
 import numpy
 from numpy import atleast_1d, eye, mgrid, argmin, zeros, shape, \
      squeeze, vectorize, asarray, absolute, sqrt, Inf, asfarray, isinf
@@ -277,8 +276,13 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
             'maxfev': maxfun,
             'disp': disp}
 
-    out = _minimize_neldermead(func, x0, args, opts, full_output, retall,
-                               callback)
+    # force full_output if retall=True to preserve backwards compatibility
+    if retall and not full_output:
+        out = _minimize_neldermead(func, x0, args, opts, full_output=True,
+                                   retall=retall, callback=callback)
+    else:
+        out = _minimize_neldermead(func, x0, args, opts, full_output,
+                                   retall, callback)
     if full_output:
         x, info = out
         retlist = x, info['fun'], info['nit'], info['nfev'], info['status']
@@ -286,7 +290,11 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
             retlist += (info['allvecs'], )
         return retlist
     else:
-        return out
+        if retall:
+            x, info = out
+            return x, info['allvecs']
+        else:
+            return out
 
 def _minimize_neldermead(func, x0, args=(), options={}, full_output=0,
                          retall=0, callback=None):
@@ -439,8 +447,6 @@ def _minimize_neldermead(func, x0, args=(), options={}, full_output=0,
             info['allvecs'] = allvecs
         return x, info
     else:
-        if retall:
-            warn('retall is ignored since full_output=False.', RuntimeWarning)
         return x
 
 
@@ -571,8 +577,13 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
             'disp': disp,
             'maxiter': maxiter}
 
-    out = _minimize_bfgs(f, x0, args, fprime, opts, full_output, retall,
-                         callback)
+    # force full_output if retall=True to preserve backwards compatibility
+    if retall and not full_output:
+        out = _minimize_bfgs(f, x0, args, fprime, opts, full_output=True,
+                             retall=retall, callback=callback)
+    else:
+        out = _minimize_bfgs(f, x0, args, fprime, opts, full_output,
+                             retall, callback)
 
     if full_output:
         x, info = out
@@ -582,7 +593,11 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
             retlist += (info['allvecs'], )
         return retlist
     else:
-        return out
+        if retall:
+            x, info = out
+            return x, info['allvecs']
+        else:
+            return out
 
 def _minimize_bfgs(fun, x0, args=(), jac=None, options={}, full_output=0,
                    retall=0, callback=None):
@@ -715,8 +730,6 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, options={}, full_output=0,
             info['allvecs'] = allvecs
         return xk, info
     else:
-        if retall:
-            warn('retall is ignored since full_output=False.', RuntimeWarning)
         return xk
 
 
@@ -797,8 +810,13 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
             'disp': disp,
             'maxiter': maxiter}
 
-    out = _minimize_cg(f, x0, args, fprime, opts, full_output, retall,
-                       callback)
+    # force full_output if retall=True to preserve backwards compatibility
+    if retall and not full_output:
+        out = _minimize_cg(f, x0, args, fprime, opts, full_output=True,
+                           retall=retall, callback=callback)
+    else:
+        out = _minimize_cg(f, x0, args, fprime, opts, full_output, retall,
+                           callback)
     if full_output:
         x, info = out
         retlist = x, info['fun'], info['nfev'], info['njev'], info['status']
@@ -806,7 +824,11 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
             retlist += (info['allvecs'], )
         return retlist
     else:
-        return out
+        if retall:
+            x, info = out
+            return x, info['allvecs']
+        else:
+            return out
 
 def _minimize_cg(fun, x0, args=(), jac=None, options={}, full_output=0,
                  retall=0, callback=None):
@@ -917,8 +939,6 @@ def _minimize_cg(fun, x0, args=(), jac=None, options={}, full_output=0,
             info['allvecs'] = allvecs
         return xk, info
     else:
-        if retall:
-            warn('retall is ignored since full_output=False.', RuntimeWarning)
         return xk
 
 
@@ -1022,8 +1042,14 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
             'maxiter': maxiter,
             'disp': disp}
 
-    out = _minimize_ncg(f, x0, args, fprime, fhess, fhess_p, opts,
-                        full_output, retall, callback)
+    # force full_output if retall=True to preserve backwards compatibility
+    if retall and not full_output:
+        out = _minimize_ncg(f, x0, args, fprime, fhess, fhess_p, opts,
+                            full_output=True, retall=retall,
+                            callback=callback)
+    else:
+        out = _minimize_ncg(f, x0, args, fprime, fhess, fhess_p, opts,
+                            full_output, retall, callback)
 
     if full_output:
         x, info = out
@@ -1033,7 +1059,11 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
             retlist += (info['allvecs'], )
         return retlist
     else:
-        return out
+        if retall:
+            x, info = out
+            return x, info['allvecs']
+        else:
+            return out
 
 def _minimize_ncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
                   options={}, full_output=0, retall=0, callback=None):
@@ -1159,8 +1189,6 @@ def _minimize_ncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
             info['allvecs'] = allvecs
         return xk, info
     else:
-        if retall:
-            warn('retall is ignored since full_output=False.', RuntimeWarning)
         return xk
 
 
@@ -1804,8 +1832,13 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
             'disp': disp,
             'direc': direc}
 
-    out = _minimize_powell(func, x0, args, opts, full_output, retall,
-                            callback)
+    # force full_output if retall=True to preserve backwards compatibility
+    if retall and not full_output:
+        out = _minimize_powell(func, x0, args, opts, full_output=True,
+                               retall=retall, callback=callback)
+    else:
+        out = _minimize_powell(func, x0, args, opts, full_output, retall,
+                               callback)
     if full_output:
         x, info = out
         retlist = x, info['fun'], info['direc'], info['nit'], \
@@ -1814,7 +1847,11 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
             retlist += (info['allvecs'], )
         return retlist
     else:
-        return out
+        if retall:
+            x, info = out
+            return x, info['allvecs']
+        else:
+            return out
 
 def _minimize_powell(func, x0, args=(), options={}, full_output=0,
                      retall=0, callback=None):
@@ -1923,8 +1960,6 @@ def _minimize_powell(func, x0, args=(), options={}, full_output=0,
             info['allvecs'] = allvecs
         return x, info
     else:
-        if retall:
-            warn('retall is ignored since full_output=False.', RuntimeWarning)
         return x
 
 

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -904,6 +904,7 @@ def _minimize_cg(fun, x0, args=(), jac=None, options={}, full_output=0,
 
     if full_output:
         info = {'fun': fval,
+                'jac': gfk,
                 'nfev': func_calls[0],
                 'njev': grad_calls[0],
                 'status': warnflag,
@@ -1142,6 +1143,7 @@ def _minimize_ncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
 
     if full_output:
         info = {'fun': fval,
+                'jac': gfk,
                 'nfev': fcalls[0],
                 'njev': gcalls[0],
                 'nhev': hcalls,

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -432,7 +432,9 @@ def _minimize_neldermead(func, x0, args=(), options={}, full_output=0,
                 'nit': iterations,
                 'nfev': fcalls[0],
                 'status': warnflag,
-                'message': msg}
+                'success': warnflag == 0,
+                'message': msg,
+                'solution': x}
         if retall:
             info['allvecs'] = allvecs
         return x, info
@@ -706,7 +708,9 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, options={}, full_output=0,
                 'nfev': func_calls[0],
                 'njev': grad_calls[0],
                 'status': warnflag,
-                'message': msg}
+                'success': warnflag == 0,
+                'message': msg,
+                'solution': xk}
         if retall:
             info['allvecs'] = allvecs
         if retall:
@@ -908,7 +912,9 @@ def _minimize_cg(fun, x0, args=(), jac=None, options={}, full_output=0,
                 'nfev': func_calls[0],
                 'njev': grad_calls[0],
                 'status': warnflag,
-                'message': msg}
+                'success': warnflag == 0,
+                'message': msg,
+                'solution': xk}
         if retall:
             info['allvecs'] = allvecs
         return xk, info
@@ -1148,7 +1154,9 @@ def _minimize_ncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
                 'njev': gcalls[0],
                 'nhev': hcalls,
                 'status': warnflag,
-                'message': msg}
+                'success': warnflag == 0,
+                'message': msg,
+                'solution': xk}
         if retall:
             info['allvecs'] = allvecs
         return xk, info
@@ -1909,7 +1917,9 @@ def _minimize_powell(func, x0, args=(), options={}, full_output=0,
                 'nit': iter,
                 'nfev': fcalls[0],
                 'status': warnflag,
-                'message': msg}
+                'success': warnflag == 0,
+                'message': msg,
+                'solution': x}
         if retall:
             info['allvecs'] = allvecs
         return x, info

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -1803,7 +1803,8 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
             'ftol': ftol,
             'maxiter': maxiter,
             'maxfev': maxfun,
-            'disp': disp}
+            'disp': disp,
+            'direc': direc}
 
     out = _minimize_powell(func, x0, args, opts, full_output, retall,
                             callback)

--- a/scipy/optimize/tests/test_anneal.py
+++ b/scipy/optimize/tests/test_anneal.py
@@ -25,25 +25,35 @@ class TestAnneal(TestCase):
         self.upper = (3., [3., 3.])
         self.lower = (-3., [-3., -3.])
 
+        # 'fast' and 'cauchy' succeed with maxiter=1000 but 'boltzmann'
+        # exits with status=3 until very high values. Keep this value
+        # reasonable though.
+        self.maxiter = 1000
+
     def anneal_schedule(self, schedule='fast'):
         """ Call anneal algorithm using specified schedule """
         n = 0 # index of test function
-        out = anneal(self.fun[n], self.x0[n], full_output=True,
-                     upper=self.upper[n], lower=self.lower[n], feps=1e-3,
-                     maxiter=2000, schedule=schedule, disp=False)
-        assert_almost_equal(out[0], self.sol[n], 2)
+        x, retval = anneal(self.fun[n], self.x0[n], full_output=False,
+                           upper=self.upper[n], lower=self.lower[n],
+                           feps=1e-3, maxiter=self.maxiter, schedule=schedule,
+                           disp=False)
+        assert_almost_equal(x, self.sol[n], 2)
+        return retval
 
     def test_fast(self):
         """ Anneal: test for fast schedule """
-        self.anneal_schedule('fast')
+        retval = self.anneal_schedule('fast')
+        self.assertEqual(retval, 0)
 
     def test_boltzmann(self):
         """ Anneal: test for Boltzmann schedule """
-        self.anneal_schedule('boltzmann')
+        retval = self.anneal_schedule('boltzmann')
+        self.assertLessEqual(retval, 3) # usually 3
 
     def test_cauchy(self):
         """ Anneal: test for Cauchy schedule """
-        self.anneal_schedule('cauchy')
+        retval = self.anneal_schedule('cauchy')
+        self.assertEqual(retval, 0)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/optimize/tests/test_anneal.py
+++ b/scipy/optimize/tests/test_anneal.py
@@ -3,7 +3,7 @@ Unit tests for the simulated annealing minimization algorithm.
 """
 
 from numpy.testing import TestCase, run_module_suite, \
-    assert_almost_equal, assert_
+    assert_almost_equal, assert_, dec
 
 import numpy as np
 
@@ -53,21 +53,25 @@ class TestAnneal(TestCase):
         assert_almost_equal(x, self.sol[n], 2)
         return retval
 
+    @dec.slow
     def test_fast(self, use_wrapper=False):
         """ Anneal: test for fast schedule """
         retval = self.anneal_schedule('fast', use_wrapper)
         self.assertEqual(retval, 0)
 
+    @dec.slow
     def test_boltzmann(self, use_wrapper=False):
         """ Anneal: test for Boltzmann schedule """
         retval = self.anneal_schedule('boltzmann', use_wrapper)
         assert_(retval <= 3)  # usually 3
 
+    @dec.slow
     def test_cauchy(self, use_wrapper=False):
         """ Anneal: test for Cauchy schedule """
         retval = self.anneal_schedule('cauchy', use_wrapper)
         self.assertEqual(retval, 0)
 
+    @dec.slow
     def test_minimize(self):
         """ minimize with 'anneal' method """
         self.test_fast(True)

--- a/scipy/optimize/tests/test_anneal.py
+++ b/scipy/optimize/tests/test_anneal.py
@@ -2,7 +2,8 @@
 Unit tests for the simulated annealing minimization algorithm.
 """
 
-from numpy.testing import TestCase, run_module_suite, assert_almost_equal
+from numpy.testing import TestCase, run_module_suite, \
+    assert_almost_equal, assert_
 
 import numpy as np
 
@@ -60,7 +61,7 @@ class TestAnneal(TestCase):
     def test_boltzmann(self, use_wrapper=False):
         """ Anneal: test for Boltzmann schedule """
         retval = self.anneal_schedule('boltzmann', use_wrapper)
-        self.assertLessEqual(retval, 3) # usually 3
+        assert_(retval <= 3)  # usually 3
 
     def test_cauchy(self, use_wrapper=False):
         """ Anneal: test for Cauchy schedule """

--- a/scipy/optimize/tests/test_anneal.py
+++ b/scipy/optimize/tests/test_anneal.py
@@ -1,0 +1,49 @@
+"""
+Unit tests for the simulated annealing minimization algorithm.
+"""
+
+from numpy.testing import TestCase, run_module_suite, assert_almost_equal
+
+import numpy as np
+
+from scipy.optimize import anneal
+
+class TestAnneal(TestCase):
+    """ Tests for anneal """
+    def setUp(self):
+        """ Tests setup.
+
+        Define two tests, based on the example in anneal's source. Only the
+        first one is used since the second fails for the 'fast' schedule at
+        least.
+        """
+        self.fun = (lambda x: np.cos(14.5 * x - 0.3)  +  (x + 0.2) * x,
+                    lambda x: np.cos(14.5 * x[0] - 0.3)  +  \
+                             (x[1] + 0.2) * x[1] + (x[0] + 0.2) * x[0])
+        self.x0 = (1.0, [1.0, 1.0])
+        self.sol = (-0.195, np.array([-0.195, -0.1]))
+        self.upper = (3., [3., 3.])
+        self.lower = (-3., [-3., -3.])
+
+    def anneal_schedule(self, schedule='fast'):
+        """ Call anneal algorithm using specified schedule """
+        n = 0 # index of test function
+        out = anneal(self.fun[n], self.x0[n], full_output=True,
+                     upper=self.upper[n], lower=self.lower[n], feps=1e-3,
+                     maxiter=2000, schedule=schedule)
+        assert_almost_equal(out[0], self.sol[n], 2)
+
+    def test_fast(self):
+        """ Anneal: test for fast schedule """
+        self.anneal_schedule('fast')
+
+    def test_boltzmann(self):
+        """ Anneal: test for Boltzmann schedule """
+        self.anneal_schedule('boltzmann')
+
+    def test_cauchy(self):
+        """ Anneal: test for Cauchy schedule """
+        self.anneal_schedule('cauchy')
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/scipy/optimize/tests/test_anneal.py
+++ b/scipy/optimize/tests/test_anneal.py
@@ -30,7 +30,7 @@ class TestAnneal(TestCase):
         n = 0 # index of test function
         out = anneal(self.fun[n], self.x0[n], full_output=True,
                      upper=self.upper[n], lower=self.lower[n], feps=1e-3,
-                     maxiter=2000, schedule=schedule)
+                     maxiter=2000, schedule=schedule, disp=False)
         assert_almost_equal(out[0], self.sol[n], 2)
 
     def test_fast(self):


### PR DESCRIPTION
This is the first step of my [enhancement plan](https://github.com/dlaxalde/scipy/wiki/Improvements-to-optimize-package) for the optimization module. It concerns unconstrained minimization of multivariate functions.

Summary of changes:
- `minimize`: new wrapper called to replace `fmin`, `fmin_powell`, `fmin_bfgs`, `fmin_cg` and `fmin_ncg`;
- `_minimize_{neldermead,powell,cg,ncg,bfgs}` functions: internal clones of the latter functions with standardized signature;
- tests updated to cover both the new and old implementation;
- deprecation of old functions.
