### PR TITLE
Unset passed in FFLAGS environment variable in fftpack

### DIFF
--- a/scipy/fftpack/setup.py
+++ b/scipy/fftpack/setup.py
@@ -2,9 +2,15 @@
 # Created by Pearu Peterson, August 2002
 
 from os.path import join
+import os
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
+
+    try:
+        toss = os.environ.pop('FFLAGS')
+    except KeyError:
+        pass
 
     config = Configuration('fftpack',parent_package, top_path)
 


### PR DESCRIPTION
Setting the FFLAGS environment variable would prevent scipy from compiling by making
libdfftpack.a non-relocatable on 64-bit machines.

Suspect that the FFLAGS that should be used contains '-fPIC' and is replaced by the FFLAGS environment setting.

The actual location where FFLAGS in the environment replaces what should be used is deep inside Scons - I think.

This small change unsets FFLAGS is in the setup.py rather than in Scons.

See http://projects.scipy.org/scipy/ticket/485 for more information.
