### PR TITLE
ENH: sparse: new block_diag function added to construct

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -42,6 +42,7 @@ Building sparse matrices:
    bmat - Build a sparse matrix from sparse sub-blocks
    hstack - Stack sparse matrices horizontally (column wise)
    vstack - Stack sparse matrices vertically (row wise)
+   block_diag - Build a block diagonal sparse matrix
    rand - Random values in a given shape
 
 Identifying sparse matrices:

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -4,7 +4,7 @@
 __docformat__ = "restructuredtext en"
 
 __all__ = [ 'spdiags', 'eye', 'identity', 'kron', 'kronsum',
-            'hstack', 'vstack', 'bmat', 'rand']
+            'hstack', 'vstack', 'bmat', 'block_diag', 'rand']
 
 
 from warnings import warn
@@ -388,6 +388,38 @@ def bmat(blocks, format=None, dtype=None):
 
     shape = (np.sum(brow_lengths), np.sum(bcol_lengths))
     return coo_matrix((data, (row, col)), shape=shape).asformat(format)
+
+def block_diag(mats, format=None, dtype=None):
+    """
+    Build a block diagonal sparse matrix from provided matrices.
+
+    Parameters
+    ----------
+    A, B, ... : sequence of matrices
+        Input matrices.
+    format : sparse format of the result (e.g. "csr")
+        by default an appropriate sparse matrix format is returned.
+        This choice is subject to change.
+
+    Examples
+    --------
+    >>> A = coo_matrix([[1, 2], [3, 4]])
+    >>> B = coo_matrix([[5], [6]])
+    >>> C = coo_matrix([[7]])
+    >>> block_diag((A, B, C)).todense()
+    matrix([[1, 2, 0, 0],
+            [3, 4, 0, 0],
+            [0, 0, 5, 0],
+            [0, 0, 6, 0],
+            [0, 0, 0, 7]])
+    """
+    nmat = len(mats)
+    rows = []
+    for ia, a in enumerate(mats):
+        row = [None]*nmat
+        row[ia] = a
+        rows.append(row)
+    return bmat(rows, format=format, dtype=dtype)
 
 def rand(m, n, density=0.01, format="coo", dtype=None):
     """Generate a sparse matrix of the given shape and density with uniformely

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -175,6 +175,19 @@ class TestConstructUtils(TestCase):
 
         #TODO test failure cases
 
+    def test_block_diag(self):
+        A = coo_matrix([[1,2],[3,4]])
+        B = coo_matrix([[5],[6]])
+        C = coo_matrix([[7]])
+
+        expected = matrix([[1, 2, 0, 0],
+                           [3, 4, 0, 0],
+                           [0, 0, 5, 0],
+                           [0, 0, 6, 0],
+                           [0, 0, 0, 7]])
+
+        assert_equal(construct.block_diag((A, B, C)).todense(), expected)
+
     def test_rand(self):
         # Simple sanity checks for sparse.rand
         for t in [np.float32, np.float64, np.longdouble]:


### PR DESCRIPTION
This function makes it possible to build a sparse block-diagonal matrix from a sequence of (sparse or dense) matrices. This is the counterpart of `block_diag` for dense matrices (in `linalg / special_matrices`). As most other functions in `construct`, it makes use of `bmat` to actually build the matrix. Test included.
