### PR TITLE
BUG: use newer cinit syntax for cython 0.15

### DIFF
--- a/scipy/io/matlab/mio5_utils.pyx
+++ b/scipy/io/matlab/mio5_utils.pyx
@@ -169,7 +169,7 @@ cdef class VarReader5:
     * mat_dtype (bool)
     * squeeze_me (bool)
     """
-    def __new__(self, preader):
+    def __cinit__(self, preader):
         byte_order = preader.byte_order
         self.is_swapped = byte_order == swapped_code
         if self.is_swapped:


### PR DESCRIPTION
Was raising an error when cythonizing with cython 0.15.  Tested as still
working on cython 0.13 with this change.
