### PR TITLE
BUG: cluster: linkage C function did not check the return value of mallo...

### DIFF
--- a/scipy/cluster/src/hierarchy.c
+++ b/scipy/cluster/src/hierarchy.c
@@ -69,8 +69,6 @@
 
 #include "hierarchy.h"
 
-#define safefree(p) if (p != NULL) {free(p); p = NULL;}
-
 
 static NPY_INLINE double euclidean_distance(const double *u, const double *v, int n) {
   int i = 0;
@@ -623,16 +621,16 @@ int linkage(double *dm, double *Z, double *X,
   result = 0;
   
 finished:
-  safefree(lists);
-  safefree(lnodes);
-  safefree(nodes);
-  safefree(ind);
-  safefree(dmt);
-  safefree(buf);
-  safefree(rows);
-  safefree(rowsize);
-  safefree(centroidsData);
-  safefree(centroids);
+  free(lists);
+  free(lnodes);
+  free(nodes);
+  free(ind);
+  free(dmt);
+  free(buf);
+  free(rows);
+  free(rowsize);
+  free(centroidsData);
+  free(centroids);
   return result;
 }
 

--- a/scipy/cluster/src/hierarchy.c
+++ b/scipy/cluster/src/hierarchy.c
@@ -69,6 +69,9 @@
 
 #include "hierarchy.h"
 
+#define safefree(p) if (p != NULL) {free(p); p = NULL;}
+
+
 static NPY_INLINE double euclidean_distance(const double *u, const double *v, int n) {
   int i = 0;
   double s = 0.0, d;
@@ -349,6 +352,7 @@ void print_vec(const double *d, int n) {
   CPY_DEBUG_MSG("]");
 }
 
+
 /**
  * notes to self:
  * dm:    The distance matrix.
@@ -358,34 +362,42 @@ void print_vec(const double *d, int n) {
  * ml:    A boolean indicating whether a list of objects in the forest
  *        clusters should be maintained.
  * kc:    Keep track of the centroids.
+ *
+ * Return values:
+ * 0:  success
+ * -1: out of memory--malloc() failed.
  */
-void linkage(double *dm, double *Z, double *X,
+int linkage(double *dm, double *Z, double *X,
 	     int m, int n, int ml, int kc, distfunc dfunc,
 	     int method) {
   int i, j, k, t, np, nid, mini, minj, npc2;
   double min, ln, rn, qn;
-  int *ind;
+  int *ind = NULL;
   /** An iterator through the distance matrix. */
-  double *dmit, *buf;
+  double *dmit, *buf = NULL;
 
-  int *rowsize;
+  int *rowsize = NULL;
 
   /** Temporary array to store modified distance matrix. */
-  double *dmt, **rows, *Zrow;
-  double *centroidsData;
-  double **centroids;
+  double *dmt = NULL, **rows = NULL, *Zrow;
+  double *centroidsData = NULL;
+  double **centroids = NULL;
   const double *centroidL, *centroidR;
   double *centroid;
-  clist *lists, *listL, *listR, *listC;
-  clnode *lnodes;
-  cnode *nodes, *node;
+  clist *lists = NULL, *listL, *listR, *listC;
+  clnode *lnodes = NULL;
+  cnode *nodes = NULL, *node;
 
   cinfo info;
+
+  int result = -1;
 
   /** The next two are only necessary for euclidean distance methods. */
   if (ml) {
     lists = (clist*)malloc(sizeof(clist) * (n-1));
+    if (!lists) goto finished;
     lnodes = (clnode*)malloc(sizeof(clnode) * n);
+    if (!lnodes) goto finished;
   }
   else {
     lists = 0;
@@ -393,7 +405,9 @@ void linkage(double *dm, double *Z, double *X,
   }
   if (kc) {
     centroids = (double**)malloc(sizeof(double*) * (2 * n));
+    if (!centroids) goto finished;
     centroidsData = (double*)malloc(sizeof(double) * n * m);
+    if (!centroidsData) goto finished;
     for (i = 0; i < n; i++) {
       centroids[i] = X + i * m;
     }
@@ -407,11 +421,17 @@ void linkage(double *dm, double *Z, double *X,
   }
 
   nodes = (cnode*)malloc(sizeof(cnode) * (n * 2) - 1);
+  if (!nodes) goto finished;
   ind = (int*)malloc(sizeof(int) * n);
+  if (!ind) goto finished;
   dmt = (double*)malloc(sizeof(double) * NCHOOSE2(n));
+  if (!dmt) goto finished;
   buf = (double*)malloc(sizeof(double) * n);
+  if (!buf) goto finished;
   rows = (double**)malloc(sizeof(double*) * n);
+  if (!rows) goto finished;
   rowsize = (int*)malloc(sizeof(int) * n);
+  if (!rowsize) goto finished;
   memcpy(dmt, dm, sizeof(double) * NCHOOSE2(n));
 
   info.X = X;
@@ -600,21 +620,29 @@ void linkage(double *dm, double *Z, double *X,
     ind[np - 2] = nid;
     /**    print_ind(ind, np - 1);**/
   }
-  free(lists);
-  free(lnodes);
-  free(nodes);
-  free(ind);
-  free(dmt);
-  free(buf);
-  free(rows);
-  free(rowsize);
-  free(centroidsData);
-  free(centroids);
+  result = 0;
+  
+finished:
+  safefree(lists);
+  safefree(lnodes);
+  safefree(nodes);
+  safefree(ind);
+  safefree(dmt);
+  safefree(buf);
+  safefree(rows);
+  safefree(rowsize);
+  safefree(centroidsData);
+  safefree(centroids);
+  return result;
 }
 
 /** Trying to reimplement so that output is consistent with MATLAB's in
     cases where there are is than one correct choice to make at each
-    iteration of the algorithm. This implementation is not active. */
+    iteration of the algorithm. This implementation is not active.
+
+    XXX linkage_alt is not used.  If it ever does get used, it needs to
+    be updated to check the results of any calls to malloc().
+*/
 
 void linkage_alt(double *dm, double *Z, double *X,
 	     int m, int n, int ml, int kc, distfunc dfunc,

--- a/scipy/cluster/src/hierarchy.h
+++ b/scipy/cluster/src/hierarchy.h
@@ -102,7 +102,7 @@ void dist_weighted(cinfo *info, int mini, int minj, int np, int n);
 
 int leaders(const double *Z, const int *T, int *L, int *M, int kk, int n);
 
-void linkage(double *dm, double *Z, double *X, int m, int n, int ml, int kc, distfunc dfunc, int method);
+int linkage(double *dm, double *Z, double *X, int m, int n, int ml, int kc, distfunc dfunc, int method);
 void linkage_alt(double *dm, double *Z, double *X, int m, int n, int ml, int kc, distfunc dfunc, int method);
 
 void cophenetic_distances(const double *Z, double *d, int n);

--- a/scipy/cluster/src/hierarchy_wrap.c
+++ b/scipy/cluster/src/hierarchy_wrap.c
@@ -69,8 +69,10 @@ extern PyObject *linkage_wrap(PyObject *self, PyObject *args) {
       df = 0;
       break;
     }
-    if (linkage((double*)dm->data, (double*)Z->data, 0, 0, n, 0, 0, df, method) == -1) {
-      PyErr_SetString(PyExc_MemoryError, "out of memory while computing linkage");
+    if (linkage((double*)dm->data, (double*)Z->data,
+                0, 0, n, 0, 0, df, method) == -1) {
+      PyErr_SetString(PyExc_MemoryError,
+                      "out of memory while computing linkage");
       return NULL;
     }
   }
@@ -110,8 +112,9 @@ extern PyObject *linkage_euclid_wrap(PyObject *self, PyObject *args) {
       break;
     }
     if (linkage((double*)dm->data, (double*)Z->data, (double*)X->data,
-	    m, n, 1, 1, df, method) == -1) {
-      PyErr_SetString(PyExc_MemoryError, "out of memory while computing linkage");
+	              m, n, 1, 1, df, method) == -1) {
+      PyErr_SetString(PyExc_MemoryError,
+                      "out of memory while computing linkage");
       return NULL;
     }
   }

--- a/scipy/cluster/src/hierarchy_wrap.c
+++ b/scipy/cluster/src/hierarchy_wrap.c
@@ -48,7 +48,7 @@ extern PyObject *linkage_wrap(PyObject *self, PyObject *args) {
 			&PyArray_Type, &Z,
 			&n,
 			&method)) {
-    return 0;
+    return NULL;
   }
   else {
     switch (method) {
@@ -69,7 +69,10 @@ extern PyObject *linkage_wrap(PyObject *self, PyObject *args) {
       df = 0;
       break;
     }
-    linkage((double*)dm->data, (double*)Z->data, 0, 0, n, 0, 0, df, method);
+    if (linkage((double*)dm->data, (double*)Z->data, 0, 0, n, 0, 0, df, method) == -1) {
+      PyErr_SetString(PyExc_MemoryError, "out of memory while computing linkage");
+      return NULL;
+    }
   }
   return Py_BuildValue("d", 0.0);
 }
@@ -85,7 +88,7 @@ extern PyObject *linkage_euclid_wrap(PyObject *self, PyObject *args) {
 			&m,
 			&n,
 			&method)) {
-    return 0;
+    return NULL;
   }
   else {
     ml = 0;
@@ -106,8 +109,11 @@ extern PyObject *linkage_euclid_wrap(PyObject *self, PyObject *args) {
       df = 0;
       break;
     }
-    linkage((double*)dm->data, (double*)Z->data, (double*)X->data,
-	    m, n, 1, 1, df, method);
+    if (linkage((double*)dm->data, (double*)Z->data, (double*)X->data,
+	    m, n, 1, 1, df, method) == -1) {
+      PyErr_SetString(PyExc_MemoryError, "out of memory while computing linkage");
+      return NULL;
+    }
   }
   return Py_BuildValue("d", 0.0);
 }


### PR DESCRIPTION
...c, which could lead to seg faults (ticket #1562)

See http://projects.scipy.org/scipy/ticket/1562 and http://projects.scipy.org/scipy/ticket/967

I didn't add any unit tests.  Any suggestions for a reliable way to test this?

Here's a before and after demonstration:
#### Before...

<pre>
In [1]: from scipy.misc import comb

In [2]: from scipy.cluster.hierarchy import linkage

In [3]: comb(20000, 2, exact=True)
Out[3]: 199990000L

In [4]: y = np.random.randn(_)

In [5]: r = linkage(y)
Python(29642,0xa0498540) malloc: *** mmap(size=1599922176) failed (error code=12)
*** error: can't allocate region
*** set a breakpoint in malloc_error_break to debug
Bus error
</pre>

#### After...

<pre>
In [1]: from scipy.cluster.hierarchy import linkage

In [2]: from scipy.misc import comb

In [3]: n = comb(20000, 2, exact=True)

In [4]: y = np.random.randn(n)

In [5]: r = linkage(y)
Python(38734,0xa0498540) malloc: *** mmap(size=1599922176) failed (error code=12)
*** error: can't allocate region
*** set a breakpoint in malloc_error_break to debug
---------------------------------------------------------------------------
MemoryError                               Traceback (most recent call last)
/Users/warren/<ipython-input-5-dcbc3357f18b> in <module>()
----> 1 r = linkage(y)

/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/cluster/hierarchy.pyc in linkage(y, method, metric)
    629         Z = np.zeros((d - 1, 4))
    630         _hierarchy_wrap.linkage_wrap(y, Z, int(d), \
--> 631                                    int(_cpy_non_euclid_methods[method]))
    632     elif len(s) == 2:
    633         X = y

MemoryError: out of memory while computing linkage

In [6]:
</pre>
