### PR TITLE
BUG: stats: fisher_exact() returned an incorrect result for alternative=...

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2349,11 +2349,8 @@ def fisher_exact(table, alternative='two-sided'):
     if alternative == 'less':
         pvalue = hypergeom.cdf(c[0,0], n1 + n2, n1, n)
     elif alternative == 'greater':
-        if c[0, 0]:
-            x = c[0, 0] - 1
-        else:
-            x = c[0, 0]
-        pvalue = hypergeom.sf(x, n1 + n2, n1, n)
+        # Same formula as the 'less' case, but with the second column.
+        pvalue = hypergeom.cdf(c[0,1], n1 + n2, n1, c[0,1] + c[1,1])
     elif alternative == 'two-sided':
         mode = int(float((n + 1) * (n1 + 1)) / (n1 + n2 + 2))
         pexact = hypergeom.pmf(c[0,0], n1 + n2, n1, n)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -432,15 +432,33 @@ class TestFisherExact(TestCase):
             assert_equal(oddsratio, np.nan)
 
     def test_less_greater(self):
-        tables = ([[2, 7], [8, 2]],
-                  [[200, 7], [8, 300]],
-                  [[28, 21], [6, 1957]],
-                  [[190, 800], [200, 900]])
-        # from R
-        pvals = ([0.018521725952066501, 0.9990149169715733],
-                 [1.0, 2.0056578803889148e-122],
-                 [1.0, 5.7284374608319831e-44],
-                 [0.7416227, 0.2959826])
+        tables = (
+            # Some tables to compare with R:
+            [[2, 7], [8, 2]],
+            [[200, 7], [8, 300]],
+            [[28, 21], [6, 1957]],
+            [[190, 800], [200, 900]],
+            # Some tables with simple exact values
+            # (includes regression test for ticket #1568):
+            [[0, 2], [3, 0]],
+            [[1, 1], [2, 1]],
+            [[2, 0], [1, 2]],
+            [[0, 1], [2, 3]],
+            [[1, 0], [1, 4]],
+            )
+        pvals = (
+            # from R:
+            [0.018521725952066501, 0.9990149169715733],
+            [1.0, 2.0056578803889148e-122],
+            [1.0, 5.7284374608319831e-44],
+            [0.7416227, 0.2959826],
+            # Exact:
+            [0.1, 1.0],
+            [0.7, 0.9],
+            [1.0, 0.3],
+            [2./3, 1.0],
+            [1.0, 1./3],
+            )
         for table, pval in zip(tables, pvals):
             res = []
             res.append(stats.fisher_exact(table, alternative="less")[1])


### PR DESCRIPTION
...'greater' when the upper-left entry of the coontingency table was 0 (ticket #1568)

See http://projects.scipy.org/scipy/ticket/1568

I removed the incorrect "correction" in the code.  In fact, I replaced the use of hypergeom.sf() with hypergeom.cdf(), by taking advantage of the symmetry of the 'less' and 'greater' alternatives.  This has the advantage of consistently giving the exact value 1 when the upper-left entry is 0 (instead of, e.g. 0.9999999999932).
