### PR TITLE
BUG: stats: zscore and zmap did not handle the axis keyword correctly

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1830,19 +1830,18 @@ def zscore(a, axis=0, ddof=0):
                       [ 0.5918,  0.6948,  0.904 ,  0.3721],
                       [ 0.0921,  0.2481,  0.1188,  0.1366]])
     >>> stats.zscore(b, axis=1, ddof=1)
-    array([[-1.1649, -1.4319, -0.8554, -1.0189],
-           [-0.8661, -1.5035, -0.9737, -0.6154],
-           [-0.888 , -1.3817, -0.5461, -1.1156],
-           [-2.3043, -2.2014, -1.9921, -2.5241],
-           [-2.0773, -1.9212, -2.0506, -2.0328]])
-
+    array([[-0.19264823, -1.28415119,  1.07259584,  0.40420358],
+           [ 0.33048416, -1.37380874,  0.04251374,  1.00081084],
+           [ 0.26796377, -1.12598418,  1.23283094, -0.37481053],
+           [-0.22095197,  0.24468594,  1.19042819, -1.21416216],
+           [-0.82780366,  1.4457416 , -0.43867764, -0.1792603 ]])
     """
     a = np.asanyarray(a)
     mns = a.mean(axis=axis)
     sstd = a.std(axis=axis, ddof=ddof)
     if axis and mns.ndim < a.ndim:
-        return ((a - np.expand_dims(mns, axis=axis) /
-                 np.expand_dims(sstd,axis=axis)))
+        return ((a - np.expand_dims(mns, axis=axis)) /
+                 np.expand_dims(sstd,axis=axis))
     else:
         return (a - mns) / sstd
 
@@ -1881,17 +1880,21 @@ def zmap(scores, compare, axis=0, ddof=0):
     matrices and masked arrays (it uses `asanyarray` instead of `asarray`
     for parameters).
 
+    Examples
+    --------
+    >>> a = [0.5, 2.0, 2.5, 3]
+    >>> b = [0, 1, 2, 3, 4]
+    >>> zmap(a, b)
+    array([-1.06066017,  0.        ,  0.35355339,  0.70710678])
     """
     scores, compare = map(np.asanyarray, [scores, compare])
     mns = compare.mean(axis=axis)
     sstd = compare.std(axis=axis, ddof=ddof)
     if axis and mns.ndim < compare.ndim:
-        return ((scores - np.expand_dims(mns, axis=axis) /
-                 np.expand_dims(sstd,axis=axis)))
+        return ((scores - np.expand_dims(mns, axis=axis)) /
+                 np.expand_dims(sstd,axis=axis))
     else:
         return (scores - mns) / sstd
-
-
 
 
 #####################################

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1028,9 +1028,7 @@ class TestMode(TestCase):
 
 
 class TestVariability(TestCase):
-    """  Comparison numbers are found using R v.1.5.1
-         note that length(testcase) = 4
-    """
+
     testcase = [1,2,3,4]
 
     def test_signaltonoise(self):
@@ -1061,6 +1059,45 @@ class TestVariability(TestCase):
         desired = ([-1.3416407864999, -0.44721359549996 , 0.44721359549996 , 1.3416407864999])
         assert_array_almost_equal(desired,y,decimal=12)
 
+    def test_zmap_axis(self):
+        """Test use of 'axis' keyword in zmap."""        
+        x = np.array([[0.0, 0.0, 1.0, 1.0],
+                      [1.0, 1.0, 1.0, 2.0],
+                      [2.0, 0.0, 2.0, 0.0]])
+
+        t1 = 1.0/np.sqrt(2.0/3)
+        t2 = np.sqrt(3.)/3
+        t3 = np.sqrt(2.)
+
+        z0 = stats.zmap(x, x, axis=0)
+        z1 = stats.zmap(x, x, axis=1)
+
+        z0_expected = [[-t1, -t3/2, -t3/2, 0.0],
+                       [0.0,  t3,   -t3/2,  t1],
+                       [t1,  -t3/2,  t3,   -t1]]
+        z1_expected = [[-1.0, -1.0, 1.0, 1.0],
+                       [-t2, -t2, -t2, np.sqrt(3.)],
+                       [1.0, -1.0, 1.0, -1.0]]
+
+        assert_array_almost_equal(z0, z0_expected)
+        assert_array_almost_equal(z1, z1_expected)        
+
+    def test_zmap_ddof(self):
+        """Test use of 'ddof' keyword in zmap."""
+        x = np.array([[0.0, 0.0, 1.0, 1.0],
+                      [0.0, 1.0, 2.0, 3.0]])
+
+        t1 = 1.0/np.sqrt(2.0/3)
+        t2 = np.sqrt(3.)/3
+        t3 = np.sqrt(2.)
+
+        z = stats.zmap(x, x, axis=1, ddof=1)
+
+        z0_expected = np.array([-0.5, -0.5, 0.5, 0.5])/(1.0/np.sqrt(3))
+        z1_expected = np.array([-1.5, -0.5, 0.5, 1.5])/(np.sqrt(5./3))
+        assert_array_almost_equal(z[0], z0_expected)
+        assert_array_almost_equal(z[1], z1_expected)
+
     def test_zscore(self):
         """
         not in R, so tested by using
@@ -1069,6 +1106,46 @@ class TestVariability(TestCase):
         y = stats.zscore(self.testcase)
         desired = ([-1.3416407864999, -0.44721359549996 , 0.44721359549996 , 1.3416407864999])
         assert_array_almost_equal(desired,y,decimal=12)
+
+    def test_zscore_axis(self):
+        """Test use of 'axis' keyword in zscore."""
+        x = np.array([[0.0, 0.0, 1.0, 1.0],
+                      [1.0, 1.0, 1.0, 2.0],
+                      [2.0, 0.0, 2.0, 0.0]])
+
+        t1 = 1.0/np.sqrt(2.0/3)
+        t2 = np.sqrt(3.)/3
+        t3 = np.sqrt(2.)
+
+        z0 = stats.zscore(x, axis=0)
+        z1 = stats.zscore(x, axis=1)
+
+        z0_expected = [[-t1, -t3/2, -t3/2, 0.0],
+                       [0.0,  t3,   -t3/2,  t1],
+                       [t1,  -t3/2,  t3,   -t1]]
+        z1_expected = [[-1.0, -1.0, 1.0, 1.0],
+                       [-t2, -t2, -t2, np.sqrt(3.)],
+                       [1.0, -1.0, 1.0, -1.0]]
+
+        assert_array_almost_equal(z0, z0_expected)
+        assert_array_almost_equal(z1, z1_expected)
+
+    def test_zscore_ddof(self):
+        """Test use of 'ddof' keyword in zscore."""
+        x = np.array([[0.0, 0.0, 1.0, 1.0],
+                      [0.0, 1.0, 2.0, 3.0]])
+
+        t1 = 1.0/np.sqrt(2.0/3)
+        t2 = np.sqrt(3.)/3
+        t3 = np.sqrt(2.)
+
+        z = stats.zscore(x, axis=1, ddof=1)
+
+        z0_expected = np.array([-0.5, -0.5, 0.5, 0.5])/(1.0/np.sqrt(3))
+        z1_expected = np.array([-1.5, -0.5, 0.5, 1.5])/(np.sqrt(5./3))
+        assert_array_almost_equal(z[0], z0_expected)
+        assert_array_almost_equal(z[1], z1_expected)
+
 
 class TestMoments(TestCase):
     """


### PR DESCRIPTION
This fixes ticket 1575 (http://projects.scipy.org/scipy/ticket/1575).
