### PR TITLE
ENH add axis kwarg to misc.logsumexp

### DIFF
--- a/doc/release/0.11.0-notes.rst
+++ b/doc/release/0.11.0-notes.rst
@@ -21,6 +21,8 @@ This release requires Python 2.4-2.7 or 3.1- and NumPy 1.X.X or greater.
 New features
 ============
 
+* ``misc.logsumexp`` now takes an optional ``axis`` keyword argument.
+
 
 Deprecated features
 ===================

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -44,8 +44,8 @@ def logsumexp(a, axis=0):
     Notes
     -----
     Numpy has a logaddexp function which is very similar to `logsumexp`, but
-    only handles two arguments. `logsumexp.reduce` is similar to this
-    function, but less stable.
+    only handles two arguments. `logaddexp.reduce` is similar to this
+    function, but may be less stable.
 
     """
     a = asarray(a)

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -30,7 +30,7 @@ def logsumexp(a, axis=None):
         The result, ``np.log(np.sum(np.exp(a)))`` calculated in a numerically
         more stable way.
 
-    See also
+    See Also
     --------
     numpy.logaddexp, numpy.logaddexp2
 

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -13,13 +13,16 @@ __all__ = ['logsumexp', 'factorial','factorial2','factorialk','comb',
 # XXX: the factorial functions could move to scipy.special, and the others
 # to numpy perhaps?
 
-def logsumexp(a, axis=0):
+def logsumexp(a, axis=None):
     """Compute the log of the sum of exponentials of input elements.
 
     Parameters
     ----------
     a : array_like
         Input array.
+    axis : int, optional
+        Axis over which the sum is taken. By default `axis` is None,
+        and all elements are summed.
 
     Returns
     -------
@@ -49,7 +52,10 @@ def logsumexp(a, axis=0):
 
     """
     a = asarray(a)
-    a = rollaxis(a, axis)
+    if axis is None:
+        a = a.ravel()
+    else:
+        a = rollaxis(a, axis)
     a_max = a.max(axis=0)
     out = log(sum(exp(a - a_max), axis=0))
     out += a_max

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -4,7 +4,8 @@ Functions which are common and require SciPy Base and Level 1 SciPy
 """
 
 from numpy import exp, log, asarray, arange, newaxis, hstack, product, array, \
-                  where, zeros, extract, place, pi, sqrt, eye, poly1d, dot, r_
+                  where, zeros, extract, place, pi, sqrt, eye, poly1d, dot, \
+                  r_, rollaxis, sum
 
 __all__ = ['logsumexp', 'factorial','factorial2','factorialk','comb',
            'central_diff_weights', 'derivative', 'pade', 'lena']
@@ -12,7 +13,7 @@ __all__ = ['logsumexp', 'factorial','factorial2','factorialk','comb',
 # XXX: the factorial functions could move to scipy.special, and the others
 # to numpy perhaps?
 
-def logsumexp(a):
+def logsumexp(a, axis=0):
     """Compute the log of the sum of exponentials of input elements.
 
     Parameters
@@ -26,18 +27,33 @@ def logsumexp(a):
         The result, ``np.log(np.sum(np.exp(a)))`` calculated in a numerically
         more stable way.
 
-    See Also
+    See also
     --------
     numpy.logaddexp, numpy.logaddexp2
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.misc import logsumexp
+    >>> a = np.arange(10)
+    >>> np.log(np.sum(np.exp(a)))
+    9.4586297444267107
+    >>> logsumexp(a)
+    9.4586297444267107
+
     Notes
     -----
-    Numpy has a logaddexp function which is very similar to `logsumexp`.
+    Numpy has a logaddexp function which is very similar to `logsumexp`, but
+    only handles two arguments. `logsumexp.reduce` is similar to this
+    function, but less stable.
 
     """
     a = asarray(a)
-    a_max = a.max()
-    return a_max + log((exp(a-a_max)).sum())
+    a = rollaxis(a, axis)
+    a_max = a.max(axis=0)
+    out = log(sum(exp(a - a_max), axis=0))
+    out += a_max
+    return out
 
 def factorial(n,exact=0):
     """

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -52,5 +52,6 @@ def test_logsumexp():
 
     X = np.vstack([x, x])
     logX = np.vstack([logx, logx])
+    assert_array_almost_equal(np.exp(logsumexp(logX)), X.sum())
     assert_array_almost_equal(np.exp(logsumexp(logX, axis=0)), X.sum(axis=0))
     assert_array_almost_equal(np.exp(logsumexp(logX, axis=1)), X.sum(axis=1))

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -38,11 +38,19 @@ def test_logsumexp():
     assert_almost_equal(logsumexp(a), desired)
 
     # Now test with large numbers
-    b = [1000,1000]
+    b = [1000, 1000]
     desired = 1000.0 + np.log(2.0)
     assert_almost_equal(logsumexp(b), desired)
 
     n = 1000
-    b = np.ones(n)*10000
+    b = np.ones(n) * 10000
     desired = 10000.0 + np.log(n)
     assert_almost_equal(logsumexp(b), desired)
+
+    x = np.array([1e-40] * 1000000)
+    logx = np.log(x)
+
+    X = np.vstack([x, x])
+    logX = np.vstack([logx, logx])
+    assert_array_almost_equal(np.exp(logsumexp(logX, axis=0)), X.sum(axis=0))
+    assert_array_almost_equal(np.exp(logsumexp(logX, axis=1)), X.sum(axis=1))


### PR DESCRIPTION
Replaced the implementation, from `maxentropy` by Ed Schofield, with the one from scikit-learn by Gaël Varoquaux. Merged the docstrings.

There was no authors section in `scipy/misc/common.py`, so I decided to put the authors in the commit message.
