### PR TITLE
List matlab files variables (scipy.io.matlab)

### DIFF
--- a/scipy/io/__init__.py
+++ b/scipy/io/__init__.py
@@ -80,7 +80,7 @@ Netcdf (:mod:`scipy.io.netcdf`)
 
 """
 # matfile read and write
-from matlab import loadmat, savemat, byteordercodes
+from matlab import loadmat, savemat, whosmat, byteordercodes
 
 # netCDF file support
 from netcdf import netcdf_file, netcdf_variable

--- a/scipy/io/matlab/__init__.py
+++ b/scipy/io/matlab/__init__.py
@@ -8,10 +8,10 @@ Drive, Natick, MA 01760-2098, USA.
 
 """
 # Matlab file read and write utilities
-from mio import loadmat, savemat
+from mio import loadmat, savemat, whosmat
 import byteordercodes
 
-__all__ = ['loadmat', 'savemat', 'byteordercodes']
+__all__ = ['loadmat', 'savemat', 'whosmat', 'byteordercodes']
 
 from numpy.testing import Tester
 test = Tester().test

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -15,7 +15,7 @@ from miobase import get_matfile_version, docfiller
 from mio4 import MatFile4Reader, MatFile4Writer
 from mio5 import MatFile5Reader, MatFile5Writer
 
-__all__ = ['find_mat_file', 'mat_reader_factory', 'loadmat', 'savemat']
+__all__ = ['find_mat_file', 'mat_reader_factory', 'loadmat', 'savemat','whosmat']
 
 @docfiller
 def find_mat_file(file_name, appendmat=True):
@@ -269,3 +269,33 @@ def savemat(file_name, mdict,
     MW.put_variables(mdict)
     if file_is_string:
         file_stream.close()
+@docfiller
+def whosmat(file_name, appendmat=True, **kwargs):
+    """
+    List variables inside a MATLAB file
+
+    Parameters
+    ----------
+    %(file_arg)s
+    %(append_arg)s
+
+    Returns
+    -------
+    variables : list
+       list with variable names
+
+    Notes
+    -----
+    v4 (Level 1.0), v6 and v7 to 7.2 matfiles are supported.
+
+    You will need an HDF5 python library to read matlab 7.3 format mat
+    files.  Because scipy does not supply one, we do not implement the
+    HDF5 / 7.3 interface here.
+
+    """
+    ML = mat_reader_factory(file_name,**kwargs)
+    variables = ML.list_variables()
+    if isinstance(file_name, basestring):
+        ML.mat_stream.close()
+    return variables
+

--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -307,6 +307,25 @@ class MatFile4Reader(MatFileReader):
                 if len(variable_names) == 0:
                     break
         return mdict
+    def list_variables(self):
+        ''' list variables from stream '''
+        self.mat_stream.seek(0)
+        # set up variable reader
+        self.initialize_read()
+        var_names = []
+        var_shape = []
+        # var_types = []
+        # var_bytesize = []
+        while not self.end_of_stream():
+            hdr, next_position = self.read_var_header()
+            name = asstr(hdr.name)
+            var_names.append(name)
+            var_shape.append(map(int,hdr.dims))
+            # var_types.append(hdr.mclass)
+            # var_bytesize.append(next_position-self.mat_stream.tell())
+            self.mat_stream.seek(next_position)
+        # return zip(var_names,var_shape,var_types,var_bytesize)
+        return zip(var_names,var_shape)
 
 
 def arr_to_2d(arr, oned_as='row'):

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -100,7 +100,7 @@ from mio5_params import MatlabObject, MatlabFunction, \
         MDTYPES, NP_TO_MTYPES, NP_TO_MXTYPES, \
         miCOMPRESSED, miMATRIX, miINT8, miUTF8, miUINT32, \
         mxCELL_CLASS, mxSTRUCT_CLASS, mxOBJECT_CLASS, mxCHAR_CLASS, \
-        mxSPARSE_CLASS, mxDOUBLE_CLASS
+        mxSPARSE_CLASS, mxDOUBLE_CLASS,mclass_dtypes_template
 
 
 class MatFile5Reader(MatFileReader):
@@ -306,6 +306,35 @@ class MatFile5Reader(MatFileReader):
                     break
         return mdict
 
+    def list_variables(self):
+        ''' list variables from stream '''
+        self.mat_stream.seek(0)
+        # Here we pass all the parameters in self to the reading objects
+        self.initialize_read()
+        self.read_file_header()
+        var_names = []
+        var_shape = []
+        # var_types = []
+        # var_bytesize = []
+        while not self.end_of_stream():
+            start_position = self.mat_stream.tell()+8 # 8-byte header
+            hdr, next_position = self.read_var_header()
+            name = asstr(hdr.name)
+            if name == '':
+                # can only be a matlab 7 function workspace
+                name = '__function_workspace__'
+                # We want to keep this raw because mat_dtype processing
+                # will break the format (uint8 as mxDOUBLE_CLASS)
+                process = False
+            else:
+                process = True
+            var_names.append(name)
+            var_shape.append(hdr.dims)
+            # var_types.append(hdr.mclass)
+            # var_bytesize.append(np.dtype(mclass_dtypes_template[hdr.mclass]).itemsize*np.prod(hdr.dims))
+            self.mat_stream.seek(next_position)
+        #return zip(var_names,var_shape,var_types,var_bytesize)
+        return zip(var_names,var_shape)
 
 def varmats_from_mat(file_obj):
     """ Pull variables out of mat 5 file as a sequence of mat file objects

--- a/scipy/io/matlab/mio5_params.py
+++ b/scipy/io/matlab/mio5_params.py
@@ -90,6 +90,7 @@ mclass_dtypes_template = {
     mxUINT64_CLASS: 'u8',
     mxSINGLE_CLASS: 'f4',
     mxDOUBLE_CLASS: 'f8',
+    mxCHAR_CLASS:	'S1',
     }
 
 


### PR DESCRIPTION
The new function whosmat tries to resemble the matlab 'whos' command. At the moment it gives a list of (name,shape) tuples.

I thought of writing this, to avoid loading the whole .mat file to know the names of variables, sometimes the .mat files can be really huge.

Regards!
