### PR TITLE
Exposed LAPACK's TRSYL Sylvester Equation solver, including test.

### DIFF
--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -1086,21 +1086,34 @@ interface
 
    subroutine <prefix>trsyl(trana, tranb, isgn, m, n, a, lda, b, ldb, c, ldc, scale, info)
    
-     ! x,info = trsyl(trana=0, tranb=0, isgn, a, b, c, scale, info)
+     ! x,scale,info = trsyl(trana='N', tranb='N', isgn, a, b, c)
      !
      ! Solves the real Sylvester matrix equation:
      !
      !    op(A)*X + X*op(B) = scale*C or op(A)*X - X*op(B) = scale*C
      !
      ! where A and B are both quasi-triangular matrices.  A and B must be in 
-     ! Schur canonical form.
+     ! Schur canonical form.  op(A) and op(B) are specified via trana and tranb
+     ! respectively, and may take the forms 'N' (no transpose), 'T' (transpose),
+     ! or 'C' (conjugate transpose, where applicable) to indicate the operation
+     ! to be performed.  The value of isgn (1 or -1) specifies the sign of the 
+     ! X*op(B) term in the equation.
+     !
+     ! Upon exit, x contains the solution, scale represnets scale factor, set
+     ! <= 1 to avoid overflow in the solution, and info contains the exit
+     ! status:
+     !
+     !      0: success
+     !      < 0: if info = -i, the i-th argument had an illegal value
+     !      1: A and B have common or very close eigenvalues; perturbed values 
+     !         were used to solve the equation
      
-     callstatement (*f2py_func)((trana?"T":"N"),(tranb?"T":"N"),&isgn,&m,&n,a,&lda,b,&ldb,c,&ldc,&scale,&info)
+     callstatement (*f2py_func)(trana,tranb,&isgn,&m,&n,a,&lda,b,&ldb,c,&ldc,&scale,&info)
      callprotoargument char*,char*,int*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*
 
-     integer optional,intent(in),check(trana==0||trana==1) :: trana = 0
-     integer optional,intent(in),check(tranb==0||tranb==1) :: tranb = 0
-     
+     character optional,intent(in),check(*trana=='N'||*trana=='T'||*trana=='C'):: trana='N'
+     character optional,intent(in),check(*tranb=='N'||*tranb=='T'||*tranb=='C'):: tranb='N'
+
      integer optional,intent(in),check(isgn==1||isgn==-1)::isgn=1
      
      integer depend(a),intent(hide):: m = shape(a,0)
@@ -1117,7 +1130,7 @@ interface
      <ftype> dimension(m,n),intent(in,out,copy,out=x) :: c
      integer depend(c),intent(hide):: ldc = shape(c,0)
      
-     <ftype> optional, dimension(1), intent(in) :: scale = 1.0
+     <ftype> intent(out) :: scale
      
      integer intent(out) :: info
      

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -1084,6 +1084,44 @@ interface
      
    end subroutine <prefix>trtri
 
+   subroutine <prefix>trsyl(trana, tranb, isgn, m, n, a, lda, b, ldb, c, ldc, scale, info)
+   
+     ! x,info = trsyl(trana=0, tranb=0, isgn, a, b, c, scale, info)
+     !
+     ! Solves the real Sylvester matrix equation:
+     !
+     !    op(A)*X + X*op(B) = scale*C or op(A)*X - X*op(B) = scale*C
+     !
+     ! where A and B are both quasi-triangular matrices.  A and B must be in 
+     ! Schur canonical form.
+     
+     callstatement (*f2py_func)((trana?"T":"N"),(tranb?"T":"N"),&isgn,&m,&n,a,&lda,b,&ldb,c,&ldc,&scale,&info)
+     callprotoargument char*,char*,int*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*
+
+     integer optional,intent(in),check(trana==0||trana==1) :: trana = 0
+     integer optional,intent(in),check(tranb==0||tranb==1) :: tranb = 0
+     
+     integer optional,intent(in),check(isgn==1||isgn==-1)::isgn=1
+     
+     integer depend(a),intent(hide):: m = shape(a,0)
+     integer depend(b),intent(hide):: n = shape(b,0)
+     
+     <ftype> dimension(m,m),intent(in) :: a
+     check(shape(a,0)==shape(a,1)) :: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     
+     <ftype> dimension(n,n),intent(in) :: b
+     check(shape(b,0)==shape(b,1)) :: b
+     integer depend(b),intent(hide):: ldb = shape(b,0)
+     
+     <ftype> dimension(m,n),intent(in,out,copy,out=x) :: c
+     integer depend(c),intent(hide):: ldc = shape(c,0)
+     
+     <ftype> optional, dimension(1), intent(in) :: scale = 1.0
+     
+     integer intent(out) :: info
+     
+   end subroutine <prefix>trsyl
 
    subroutine <prefix>laswp(n,a,nrows,k1,k2,piv,off,inc,m)
 

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -5,7 +5,8 @@
 
 from numpy.testing import TestCase, run_module_suite, assert_equal, \
     assert_array_almost_equal, assert_
-from numpy import ones
+
+import numpy as np
 
 from scipy.linalg import flapack, clapack
 
@@ -25,7 +26,7 @@ class TestFlapackSimple(TestCase):
             assert_(not info,`info`)
             assert_array_almost_equal(ba,a)
             assert_equal((lo,hi),(0,len(a[0])-1))
-            assert_array_almost_equal(pivscale,ones(len(a)))
+            assert_array_almost_equal(pivscale, np.ones(len(a)))
 
             ba,lo,hi,pivscale,info = f(a1,permute=1,scale=1)
             assert_(not info,`info`)
@@ -43,16 +44,48 @@ class TestFlapackSimple(TestCase):
             assert_(not info,`info`)
             
     def test_trsyl(self):
-        a = [[1,2],[3,4]]
-        b = [[5,6],[7,8]]
-        c = [[9,10],[11,12]]
+        a = [[1, 2], [3, 4]]
+        b = [[5, 6], [7, 8]]
+        c = [[9, 10], [11, 12]]
+        
         x_expected = [[0.5, 0.66667],
                       [0.66667, 0.5]]
+                      
+        x_expected_t = [[0.5, 0.58333],
+                        [0.83333, 0.41667]]
+                        
+        x_expected_m = [[-1.125, -1.0],
+                        [-1.25, -1.875]]
+        
+        # Test single and double implementations, including most
+        # of the options
         for p in 'ds':
-            f = getattr(flapack,p+'trsyl',None)
-            if f is None: continue
-            x, info = f(a,b,c)
-            assert_array_almost_equal(x,x_expected, decimal=4)
+            f = getattr(flapack, p+'trsyl', None)
+                
+            x, scale, info = f(a, b, c)
+            assert_array_almost_equal(x, x_expected, decimal=4)
+            assert_equal(scale,1.0)
+            
+            x, scale, info = f(a, b, c, trana='T', tranb='T')
+            assert_array_almost_equal(x, x_expected_t, decimal=4)
+            
+            x, scale, info = f(a, b, c, isgn=-1)
+            assert_array_almost_equal(x, x_expected_m, decimal=4)
+        
+        # Test complex operation (a bit simpler...)
+        ac = [[0+2.j,],]
+        bc = [[0+4.j,],]
+        cc = [[0+12.j,],]
+        x_expected_c = [[2.0+0.j,],]
+        
+        for p in 'zc':
+            f = getattr(flapack, p+'trsyl', None)
+            
+            x, scale, info = f(ac, bc, cc)
+            assert_array_almost_equal(x, x_expected_c, decimal=4)
+            
+            x, scale, info = f(ac, bc, cc, trana='C', tranb='C')
+            assert_array_almost_equal(x, -1.0*np.asarray(x_expected_c), decimal=4)
 
 class TestLapack(TestCase):
 

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -41,6 +41,18 @@ class TestFlapackSimple(TestCase):
             if f is None: continue
             ht,tau,info = f(a)
             assert_(not info,`info`)
+            
+    def test_trsyl(self):
+        a = [[1,2],[3,4]]
+        b = [[5,6],[7,8]]
+        c = [[9,10],[11,12]]
+        x_expected = [[0.5, 0.66667],
+                      [0.66667, 0.5]]
+        for p in 'ds':
+            f = getattr(flapack,p+'trsyl',None)
+            if f is None: continue
+            x, info = f(a,b,c)
+            assert_array_almost_equal(x,x_expected, decimal=4)
 
 class TestLapack(TestCase):
 


### PR DESCRIPTION
This change exposes LAPACK's Sylvester equation solver, which is common in controls engineering and becomes useful when solving related equations such as the Lyapunov or Riccati equations.  A test was included to ensure the exposed LAPACK routine is working properly.
