### PR TITLE
ENH: integrate: add 'initial' kw to cumtrapz, which makes len(out) == le...

### DIFF
--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -226,22 +226,23 @@ def cumtrapz(y, x=None, dx=1.0, axis=-1, initial=None):
 
     """
     y = asarray(y)
-    x = asarray(x)
     if x is None:
         d = dx
     else:
         d = diff(x, axis=axis)
+
     nd = len(y.shape)
     slice1 = tupleset((slice(None),)*nd, axis, slice(1, None))
     slice2 = tupleset((slice(None),)*nd, axis, slice(None, -1))
     res = add.accumulate(d * (y[slice1] + y[slice2]) / 2.0, axis)
+
     if initial is not None:
         if not np.isscalar(initial):
             raise ValueError("`initial` parameter should be a scalar.")
 
         shape = list(res.shape)
         shape[axis] = 1
-        res = np.concatenate([np.zeros(shape, dtype=res.dtype), res],
+        res = np.concatenate([np.ones(shape, dtype=res.dtype) * initial, res],
                              axis=axis)
 
     return res

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -198,7 +198,7 @@ def cumtrapz(y, x=None, dx=1.0, axis=-1, initial=None):
     res : ndarray
         The result of cumulative integration of `y` along `axis`.
         If `initial` is None, the shape is such that the axis of integration
-        has one less value then `y`.  If `initial` is given, the shape is equal
+        has one less value than `y`.  If `initial` is given, the shape is equal
         to that of `y`.
 
     See Also

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -123,6 +123,25 @@ class TestCumtrapz(TestCase):
             y_int = cumtrapz(y, x, initial=None, axis=axis)
             assert_equal(y_int.shape, shape)
 
+    def test_x_none(self):
+        y = np.linspace(-2, 2, num=5)
+
+        y_int = cumtrapz(y)
+        y_expected = [-1.5, -2., -1.5, 0.]
+        assert_allclose(y_int, y_expected)
+
+        y_int = cumtrapz(y, initial=1.23)
+        y_expected = [1.23, -1.5, -2., -1.5, 0.]
+        assert_allclose(y_int, y_expected)
+
+        y_int = cumtrapz(y, dx=3)
+        y_expected = [-4.5, -6., -4.5, 0.]
+        assert_allclose(y_int, y_expected)
+
+        y_int = cumtrapz(y, dx=3, initial=1.23)
+        y_expected = [1.23, -4.5, -6., -4.5, 0.]
+        assert_allclose(y_int, y_expected)
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -1,9 +1,10 @@
-import numpy
+import numpy as np
 from numpy import cos, sin, pi
 from numpy.testing import TestCase, run_module_suite, assert_equal, \
     assert_almost_equal, assert_allclose
 
-from scipy.integrate import quadrature, romberg, romb, newton_cotes
+from scipy.integrate import quadrature, romberg, romb, newton_cotes, cumtrapz
+
 
 class TestQuadrature(TestCase):
     def quad(self, x, a, b, args):
@@ -41,7 +42,7 @@ class TestQuadrature(TestCase):
         assert_allclose(val, table_val, rtol=1e-10)
 
     def test_romb(self):
-        assert_equal(romb(numpy.arange(17)),128)
+        assert_equal(romb(np.arange(17)),128)
 
     def test_non_dtype(self):
         # Check that we work fine with functions returning float
@@ -54,40 +55,73 @@ class TestQuadrature(TestCase):
         """Test the first few degrees, for evenly spaced points."""
         n = 1
         wts, errcoff = newton_cotes(n, 1)
-        assert_equal(wts, n*numpy.array([0.5, 0.5]))
+        assert_equal(wts, n*np.array([0.5, 0.5]))
         assert_almost_equal(errcoff, -n**3/12.0)
 
         n = 2
         wts, errcoff = newton_cotes(n, 1)
-        assert_almost_equal(wts, n*numpy.array([1.0, 4.0, 1.0])/6.0)
+        assert_almost_equal(wts, n*np.array([1.0, 4.0, 1.0])/6.0)
         assert_almost_equal(errcoff, -n**5/2880.0)
 
         n = 3
         wts, errcoff = newton_cotes(n, 1)
-        assert_almost_equal(wts, n*numpy.array([1.0, 3.0, 3.0, 1.0])/8.0)
+        assert_almost_equal(wts, n*np.array([1.0, 3.0, 3.0, 1.0])/8.0)
         assert_almost_equal(errcoff, -n**5/6480.0)
 
         n = 4
         wts, errcoff = newton_cotes(n, 1)
-        assert_almost_equal(wts, n*numpy.array([7.0, 32.0, 12.0, 32.0, 7.0])/90.0)
+        assert_almost_equal(wts, n*np.array([7.0, 32.0, 12.0, 32.0, 7.0])/90.0)
         assert_almost_equal(errcoff, -n**7/1935360.0)
 
     def test_newton_cotes2(self):
         """Test newton_cotes with points that are not evenly spaced."""
 
-        x = numpy.array([0.0, 1.5, 2.0])
+        x = np.array([0.0, 1.5, 2.0])
         y = x**2
         wts, errcoff = newton_cotes(x)
         exact_integral = 8.0/3
-        numeric_integral = numpy.dot(wts, y)
+        numeric_integral = np.dot(wts, y)
         assert_almost_equal(numeric_integral, exact_integral)
 
-        x = numpy.array([0.0, 1.4, 2.1, 3.0])
+        x = np.array([0.0, 1.4, 2.1, 3.0])
         y = x**2
         wts, errcoff = newton_cotes(x)
         exact_integral = 9.0
-        numeric_integral = numpy.dot(wts, y)
+        numeric_integral = np.dot(wts, y)
         assert_almost_equal(numeric_integral, exact_integral)
+
+
+class TestCumtrapz(TestCase):
+    def test_1d(self):
+        x = np.linspace(-2, 2, num=5)
+        y = x
+        y_int = cumtrapz(y, x, initial=0)
+        y_expected = [0., -1.5, -2., -1.5, 0.]
+        assert_allclose(y_int, y_expected)
+
+        y_int = cumtrapz(y, x, initial=None)
+        assert_allclose(y_int, y_expected[1:])
+
+    def test_nd(self):
+        x = np.arange(3 * 2 * 4).reshape(3, 2, 4)
+        y = x
+        y_int = cumtrapz(y, x, initial=0)
+        y_expected = np.array([[[  0. ,   0.5,   2. ,   4.5],
+                                [  0. ,   4.5,  10. ,  16.5]],
+                               [[  0. ,   8.5,  18. ,  28.5],
+                                [  0. ,  12.5,  26. ,  40.5]],
+                               [[  0. ,  16.5,  34. ,  52.5],
+                                [  0. ,  20.5,  42. ,  64.5]]])
+
+        assert_allclose(y_int, y_expected)
+
+        # Try with all axes
+        shapes = [(2, 2, 4), (3, 1, 4), (3, 2, 3)]
+        for axis, shape in zip([0, 1, 2], shapes):
+            y_int = cumtrapz(y, x, initial=3.45, axis=axis)
+            assert_equal(y_int.shape, (3, 2, 4))
+            y_int = cumtrapz(y, x, initial=None, axis=axis)
+            assert_equal(y_int.shape, shape)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
...n(in).

Default is initial=None, to be backwards compatible
(meaning len(out) == len(in - 1) along axis of integration.

Also add tests and a decent docstring.

Trac ticket is http://projects.scipy.org/scipy/ticket/1574
