### PR TITLE
ENH: optimize/minimize: combine hess and hessp parameters

### DIFF
--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -19,7 +19,7 @@ from anneal import _minimize_anneal
 
 
 def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
-             hessp=None, options=dict(), full_output=False, callback=None,
+             options=dict(), full_output=False, callback=None,
              retall=False):
     """
     Minimization of scalar function of one or more variables.
@@ -39,15 +39,13 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
     jac : callable, optional
         Jacobian of objective function (if None, Jacobian will be
         estimated numerically). Only for CG, BFGS, Newton-CG.
-    hess, hessp : callable, optional
-        Hessian of objective function or Hessian of objective function
-        times an arbitrary vector p.  Only for Newton-CG.
-        Only one of `hessp` or `hess` needs to be given.  If `hess` is
-        provided, then `hessp` will be ignored.  If neither `hess` nor
-        `hessp` is provided, then the hessian product will be approximated
-        using finite differences on `jac`.  `hessp` must compute the hessian
-        times an arbitrary vector.  If it is not given, finite-differences
-        on `jac` are used to compute it.
+    hess : callable, optional
+        Hessian of objective function. Only for Newton-CG.
+        The function `hess` can either return the Hessian matrix of `fun`
+        or the Hessian matrix times an arbitrary vector, in which case
+        it accepts an extra argument `p` as `hess(x, p, *args)`.
+        If `hess` is None, the Hessian will be approximated using finite
+        differences on `jac`.
     options : dict, optional
         A dictionary of solver options. All methods accept the following
         generic options:
@@ -203,7 +201,7 @@ def minimize(fun, x0, args=(), method='Nelder-Mead', jac=None, hess=None,
         return _minimize_bfgs(fun, x0, args, jac, options, full_output,
                               retall, callback)
     elif method.lower() == 'newton-cg':
-        return _minimize_newtoncg(fun, x0, args, jac, hess, hessp, options,
+        return _minimize_newtoncg(fun, x0, args, jac, hess, options,
                                   full_output, retall, callback)
     elif method.lower() == 'anneal':
         if callback:

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -14,10 +14,8 @@ from numpy.testing import assert_raises, assert_almost_equal, \
         assert_equal, assert_, TestCase, run_module_suite
 
 from scipy import optimize
-from numpy import array, zeros, float64, dot, log, exp, inf, sin, cos
 import numpy as np
 from scipy.optimize.tnc import RCSTRINGS, MSG_NONE
-import numpy.random
 from math import pow
 
 class TestOptimize(TestCase):
@@ -26,10 +24,10 @@ class TestOptimize(TestCase):
     Computational Linguistics, vol 22, num 1, pp 39--72, 1996.)
     """
     def setUp(self):
-        self.F = array([[1,1,1],[1,1,0],[1,0,1],[1,0,0],[1,0,0]])
-        self.K = array([1., 0.3, 0.5])
-        self.startparams = zeros(3, float64)
-        self.solution = array([0., -0.524869316, 0.487525860])
+        self.F = np.array([[1,1,1],[1,1,0],[1,0,1],[1,0,0],[1,0,0]])
+        self.K = np.array([1., 0.3, 0.5])
+        self.startparams = np.zeros(3, np.float64)
+        self.solution = np.array([0., -0.524869316, 0.487525860])
         self.maxiter = 1000
         self.funccalls = 0
         self.gradcalls = 0
@@ -40,19 +38,19 @@ class TestOptimize(TestCase):
         self.funccalls += 1
         if self.funccalls > 6000:
             raise RuntimeError("too many iterations in optimization routine")
-        log_pdot = dot(self.F, x)
-        logZ = log(sum(exp(log_pdot)))
-        f = logZ - dot(self.K, x)
+        log_pdot = np.dot(self.F, x)
+        logZ = np.log(sum(np.exp(log_pdot)))
+        f = logZ - np.dot(self.K, x)
         self.trace.append(x)
         return f
 
 
     def grad(self, x):
         self.gradcalls += 1
-        log_pdot = dot(self.F, x)
-        logZ = log(sum(exp(log_pdot)))
-        p = exp(log_pdot - logZ)
-        return dot(self.F.transpose(), p) - self.K
+        log_pdot = np.dot(self.F, x)
+        logZ = np.log(sum(np.exp(log_pdot)))
+        p = np.exp(log_pdot - logZ)
+        return np.dot(self.F.transpose(), p) - self.K
 
 
     def test_cg(self, use_wrapper=False):
@@ -351,7 +349,7 @@ class TestOptimize(TestCase):
         x = optimize.fminbound(lambda x: (x - 1.5)**2 - 0.8, 1, 5)
         assert_(abs(x - 1.5) < 1e-6)
         x = optimize.fminbound(lambda x: (x - 1.5)**2 - 0.8,
-                               numpy.array([1]), numpy.array([5]))
+                               np.array([1]), np.array([5]))
         assert_(abs(x - 1.5) < 1e-6)
         assert_raises(ValueError,
                 optimize.fminbound, lambda x: (x - 1.5)**2 - 0.8, 5, 1)
@@ -384,7 +382,7 @@ class TestTnc(TestCase):
             dif[1] = 200.0*(x[1]-pow(x[0],2))
             dif[0] = -2.0*(x[0]*(dif[1]-1.0)+1.0)
             return f, dif
-        self.tests.append((test1fg, [-2,1], ([-inf,None],[-1.5,None]),
+        self.tests.append((test1fg, [-2,1], ([-np.inf,None],[-1.5,None]),
                            [1,1]))
         def test2fg(x):
             f = 100.0*pow((x[1]-pow(x[0],2)),2)+pow(1.0-x[0],2)
@@ -392,7 +390,7 @@ class TestTnc(TestCase):
             dif[1] = 200.0*(x[1]-pow(x[0],2))
             dif[0] = -2.0*(x[0]*(dif[1]-1.0)+1.0)
             return f, dif
-        self.tests.append((test2fg, [-2,1], [(-inf,None),(1.5,None)],
+        self.tests.append((test2fg, [-2,1], [(-np.inf,None),(1.5,None)],
                            [-1.2210262419616387,1.5]))
 
         def test3fg(x):
@@ -401,7 +399,7 @@ class TestTnc(TestCase):
             dif[0] = -2.0*(x[1]-x[0])*1.0e-5
             dif[1] = 1.0-dif[0]
             return f, dif
-        self.tests.append((test3fg, [10,1], [(-inf,None),(0.0, None)],
+        self.tests.append((test3fg, [10,1], [(-np.inf,None),(0.0, None)],
                            [0,0]))
 
         def test4fg(x):
@@ -414,9 +412,9 @@ class TestTnc(TestCase):
                            [1,0]))
 
         def test5fg(x):
-            f = sin(x[0]+x[1])+pow(x[0]-x[1],2)-1.5*x[0]+2.5*x[1]+1.0
+            f = np.sin(x[0]+x[1])+pow(x[0]-x[1],2)-1.5*x[0]+2.5*x[1]+1.0
             dif = [0,0]
-            v1 = cos(x[0]+x[1])
+            v1 = np.cos(x[0]+x[1])
             v2 = 2.0*(x[0]-x[1])
 
             dif[0] = v1+v2-1.5
@@ -439,7 +437,7 @@ class TestTnc(TestCase):
             dif[3] = (180.0*(x[3]-pow(x[2],2))+20.2\
                       *(x[3]-1.0)+19.8*(x[1]-1.0))*1.0e-5
             return f, dif
-        self.tests.append((test38fg, array([-3,-1,-3,-1]), [(-10,10)]*4, [1]*4))
+        self.tests.append((test38fg, np.array([-3,-1,-3,-1]), [(-10,10)]*4, [1]*4))
 
         def test45fg(x):
             f = 2.0-x[0]*x[1]*x[2]*x[3]*x[4]/120.0
@@ -470,8 +468,8 @@ class TestRosen(TestCase):
 
     def test_hess(self):
         """Compare rosen_hess(x) times p with rosen_hess_prod(x,p) (ticket #1248)"""
-        x = array([3, 4, 5])
-        p = array([2, 2, 2])
+        x = np.array([3, 4, 5])
+        p = np.array([2, 2, 2])
         hp = optimize.rosen_hess_prod(x, p)
         dothp = np.dot(optimize.rosen_hess(x), p)
         assert_equal(hp, dothp)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -331,7 +331,7 @@ class TestOptimize(TestCase):
             opts = {'maxit': self.maxiter, 'disp': False}
             retval = optimize.minimize(self.func, self.startparams,
                                        method='Newton-CG', jac=self.grad,
-                                       hessp = self.hessp,
+                                       hess = self.hessp,
                                        args=(), options=opts,
                                        full_output=False, retall=False)
         else:


### PR DESCRIPTION
The Hessian parameter can have two forms (`hess` and `hessp`) but it's only used by the Newton-CG solver so having two distinct parameters somehow clutters up `minimize`'s signature. These parameters have been combined into a single `hess` parameter and the actual type of Hessian is checked internally.     

Besides, I've added new tests that cover the use of these parameters and the first commit cleans up multiple numpy imports in tests.
