### PR TITLE
DOC: fix formulas in spatial.distance

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -599,8 +599,8 @@ def canberra(u, v):
 
     .. math::
 
-         \sum_u \frac{|u_i-v_i|}
-                     {(|u_i|+|v_i|)}.
+         d(u,v) = \frac{\sum_i|u_i-v_i|}
+                       {\sum_i(|u_i|+|v_i|)}.
 
     Parameters
     ----------
@@ -1016,8 +1016,8 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
 
        .. math::
 
-         d(u,v) = \sum_u \frac{|u_i-v_i|}
-                              {(|u_i|+|v_i|)}
+         d(u,v) = \frac{\sum_i|u_i-v_i|}
+                       {\sum_i(|u_i|+|v_i|)}.
 
 
     12. ``Y = pdist(X, 'braycurtis')``
@@ -1794,9 +1794,8 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
 
        .. math::
 
-         d(u,v) = \sum_u \frac{|u_i-v_i|}
-                              {(|u_i|+|v_i|)}
-
+         d(u,v) = \frac{\sum_i|u_i-v_i|}
+                       {\sum_i(|u_i|+|v_i|)}.
 
     12. ``Y = cdist(XA, XB, 'braycurtis')``
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1746,7 +1746,7 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
 
        .. math::
 
-          \frac{1 - uv^T}
+          1 - \frac{uv^T}
                {{|u|}_2 {|v|}_2}
 
        where :math:`|*|_2` is the 2-norm of its argument *.

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1757,12 +1757,10 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
 
        .. math::
 
-          \frac{1 - (u - n{|u|}_1){(v - n{|v|}_1)}^T}
-               {{|(u - n{|u|}_1)|}_2 {|(v - n{|v|}_1)|}^T}
+          1 - \frac{(u - \bar{u})(v - \bar{v})^T}
+                   {{|(u - \bar{u})|}{|(v - \bar{v})|}^T}
 
-       where :math:`|*|_1` is the Manhattan (or 1-norm) of its
-       argument, and :math:`n` is the common dimensionality of the
-       vectors.
+       where :math:`\bar{v}` is the mean of the elements of vector v.
 
     8. ``Y = cdist(XA, XB, 'hamming')``
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -599,8 +599,8 @@ def canberra(u, v):
 
     .. math::
 
-         d(u,v) = \frac{\sum_i|u_i-v_i|}
-                       {\sum_i(|u_i|+|v_i|)}.
+         d(u,v) = \sum_i \frac{|u_i-v_i|}
+                              {|u_i|+|v_i|}.
 
     Parameters
     ----------
@@ -1016,8 +1016,8 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
 
        .. math::
 
-         d(u,v) = \frac{\sum_i|u_i-v_i|}
-                       {\sum_i(|u_i|+|v_i|)}.
+         d(u,v) = \sum_i \frac{|u_i-v_i|}
+                              {|u_i|+|v_i|}.
 
 
     12. ``Y = pdist(X, 'braycurtis')``
@@ -1794,8 +1794,8 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
 
        .. math::
 
-         d(u,v) = \frac{\sum_i|u_i-v_i|}
-                       {\sum_i(|u_i|+|v_i|)}.
+         d(u,v) = \sum_i \frac{|u_i-v_i|}
+                              {|u_i|+|v_i|}.
 
     12. ``Y = cdist(XA, XB, 'braycurtis')``
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -321,8 +321,8 @@ def correlation(u, v):
 
     .. math::
 
-       1 - frac{(u - \bar{u}){(v - \bar{v})}^T}
-               {{||(u - \bar{u})||}_2 {||(v - \bar{v})||}_2^T}
+       1 - \frac{(u - \bar{u}){(v - \bar{v})}^T}
+               {{||(u - \bar{u})||}_2 {||(v - \bar{v})||}_2}
 
     where :math:`\bar{u}` is the mean of a vectors elements and ``n``
     is the common dimensionality of ``u`` and ``v``.
@@ -980,7 +980,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
        .. math::
 
           1 - \frac{(u - \bar{u})(v - \bar{v})^T}
-                   {{|(u - \bar{u})|}{|(v - \bar{v})|}^T}
+                   {{|(u - \bar{u})|}{|(v - \bar{v})|}}
 
        where :math:`\bar{v}` is the mean of the elements of vector v.
 
@@ -1758,7 +1758,7 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
        .. math::
 
           1 - \frac{(u - \bar{u})(v - \bar{v})^T}
-                   {{|(u - \bar{u})|}{|(v - \bar{v})|}^T}
+                   {{|(u - \bar{u})|}{|(v - \bar{v})|}}
 
        where :math:`\bar{v}` is the mean of the elements of vector v.
 


### PR DESCRIPTION
Fixes to documentation in `scipy.spatial.distance`
