### PR TITLE
BUG: signal: lfilter would segfault on object arrays (ticket #1452)

### DIFF
--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -156,7 +156,6 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
     }
 
     /* Skip over leading zeros in vector representing denominator (a) */
-    /* XXX: handle this correctly */
     azero = PyArray_Zero(ara);
     if (azero == NULL) {
         goto fail;
@@ -352,6 +351,10 @@ RawFilter(const PyArrayObject * b, const PyArrayObject * a,
                     itx->dataptr, ity->dataptr, zfzfilled,
                     nfilt, PyArray_DIM(x, axis), itx->strides[axis],
                     ity->strides[axis]);
+	
+	if (PyErr_Occurred()) {
+	    goto clean_bzfilled; 
+	}
         PyArray_ITER_NEXT(itx);
         PyArray_ITER_NEXT(ity);
 
@@ -542,49 +545,69 @@ static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
             ptr_Z = ((PyObject **) Z);
             /* Calculate first delay (output) */
             tmp1 = PyNumber_Multiply(*ptr_b, *xn);
+	    if (tmp1 == NULL) return;
             tmp2 = PyNumber_Divide(tmp1, *a0);
+	    if (tmp2 == NULL) {
+		Py_DECREF(tmp1);
+		return;
+	    }
             tmp3 = PyNumber_Add(tmp2, *ptr_Z);
             Py_XDECREF(*yn);
-            *yn = tmp3;
+            *yn = tmp3; /* Steals the reference */
             Py_DECREF(tmp1);
             Py_DECREF(tmp2);
+	    if (tmp3 == NULL) return;
             ptr_b++;
             ptr_a++;
 
             /* Fill in middle delays */
             for (n = 0; n < len_b - 2; n++) {
                 tmp1 = PyNumber_Multiply(*xn, *ptr_b);
+		if (tmp1 == NULL) return;
                 tmp2 = PyNumber_Divide(tmp1, *a0);
+		if (tmp2 == NULL) {
+		    Py_DECREF(tmp1);
+		    return;
+		}
                 tmp3 = PyNumber_Add(tmp2, ptr_Z[1]);
                 Py_DECREF(tmp1);
                 Py_DECREF(tmp2);
                 tmp1 = PyNumber_Multiply(*yn, *ptr_a);
+		if (tmp1 == NULL || tmp3 == NULL) return;
                 tmp2 = PyNumber_Divide(tmp1, *a0);
                 Py_DECREF(tmp1);
+		if (tmp2 == NULL) return;
                 Py_XDECREF(*ptr_Z);
                 *ptr_Z = PyNumber_Subtract(tmp3, tmp2);
                 Py_DECREF(tmp2);
                 Py_DECREF(tmp3);
+		if (*ptr_Z == NULL) return;
                 ptr_b++;
                 ptr_a++;
                 ptr_Z++;
             }
             /* Calculate last delay */
             tmp1 = PyNumber_Multiply(*xn, *ptr_b);
+	    if (tmp1 == NULL) return;
             tmp3 = PyNumber_Divide(tmp1, *a0);
             Py_DECREF(tmp1);
+	    if (tmp3 == NULL) return;
             tmp1 = PyNumber_Multiply(*yn, *ptr_a);
+	    if (tmp1 == NULL) return;
             tmp2 = PyNumber_Divide(tmp1, *a0);
             Py_DECREF(tmp1);
+	    if (tmp2 == NULL) return;
             Py_XDECREF(*ptr_Z);
             *ptr_Z = PyNumber_Subtract(tmp3, tmp2);
             Py_DECREF(tmp2);
             Py_DECREF(tmp3);
         } else {
             tmp1 = PyNumber_Multiply(*xn, *ptr_b);
+	    if (tmp1 == NULL) return;
             Py_XDECREF(*yn);
             *yn = PyNumber_Divide(tmp1, *a0);
             Py_DECREF(tmp1);
+	    if (*yn == NULL) return;
         }
 
         ptr_y += stride_Y;      /* Move to next input/output point */

--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -346,9 +346,7 @@ RawFilter(const PyArrayObject * b, const PyArrayObject * a,
             }
             PyArray_ITER_NEXT(itzi);
         } else {
-            if (zfill(x, 0, zfzfilled, nfilt - 1) == -1) {
-		goto clean_zfzfilled;
-	    };
+            if (zfill(x, 0, zfzfilled, nfilt - 1) == -1) goto clean_zfzfilled;
         }
 
         filter_func(bzfilled, azfilled,

--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -351,10 +351,10 @@ RawFilter(const PyArrayObject * b, const PyArrayObject * a,
                     itx->dataptr, ity->dataptr, zfzfilled,
                     nfilt, PyArray_DIM(x, axis), itx->strides[axis],
                     ity->strides[axis]);
-	
-	if (PyErr_Occurred()) {
-	    goto clean_bzfilled; 
-	}
+    
+        if (PyErr_Occurred()) {
+            goto clean_bzfilled; 
+        }
         PyArray_ITER_NEXT(itx);
         PyArray_ITER_NEXT(ity);
 
@@ -545,35 +545,55 @@ static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
             ptr_Z = ((PyObject **) Z);
             /* Calculate first delay (output) */
             tmp1 = PyNumber_Multiply(*ptr_b, *xn);
-	    if (tmp1 == NULL) return;
-            tmp2 = PyNumber_Divide(tmp1, *a0);
-	    if (tmp2 == NULL) {
-			Py_DECREF(tmp1);
-			return;
-	    }
-		tmp3 = PyNumber_Add(tmp2, *ptr_Z);
-		Py_XDECREF(*yn);
-		*yn = tmp3; /* Steals the reference */
-		Py_DECREF(tmp1);
-		Py_DECREF(tmp2);
-	    if (tmp3 == NULL) return;
-		ptr_b++;
-	    ptr_a++;
-
-            /* Fill in middle delays */
-		for (n = 0; n < len_b - 2; n++) {
-			tmp1 = PyNumber_Multiply(*xn, *ptr_b);
 			if (tmp1 == NULL) return;
-			tmp2 = PyNumber_Divide(tmp1, *a0);
+            tmp2 = PyNumber_Divide(tmp1, *a0);
 			if (tmp2 == NULL) {
 				Py_DECREF(tmp1);
 				return;
 			}
-			tmp3 = PyNumber_Add(tmp2, ptr_Z[1]);
+			tmp3 = PyNumber_Add(tmp2, *ptr_Z);
+			Py_XDECREF(*yn);
+			*yn = tmp3; /* Steals the reference */
 			Py_DECREF(tmp1);
 			Py_DECREF(tmp2);
+			if (tmp3 == NULL) return;
+			ptr_b++;
+			ptr_a++;
+			
+            /* Fill in middle delays */
+			for (n = 0; n < len_b - 2; n++) {
+				tmp1 = PyNumber_Multiply(*xn, *ptr_b);
+				if (tmp1 == NULL) return;
+				tmp2 = PyNumber_Divide(tmp1, *a0);
+				if (tmp2 == NULL) {
+					Py_DECREF(tmp1);
+					return;
+				}
+				tmp3 = PyNumber_Add(tmp2, ptr_Z[1]);
+				Py_DECREF(tmp1);
+				Py_DECREF(tmp2);
+				tmp1 = PyNumber_Multiply(*yn, *ptr_a);
+				if (tmp1 == NULL || tmp3 == NULL) return;
+				tmp2 = PyNumber_Divide(tmp1, *a0);
+				Py_DECREF(tmp1);
+				if (tmp2 == NULL) return;
+				Py_XDECREF(*ptr_Z);
+				*ptr_Z = PyNumber_Subtract(tmp3, tmp2);
+				Py_DECREF(tmp2);
+				Py_DECREF(tmp3);
+				if (*ptr_Z == NULL) return;
+				ptr_b++;
+				ptr_a++;
+				ptr_Z++;
+			}
+			/* Calculate last delay */
+			tmp1 = PyNumber_Multiply(*xn, *ptr_b);
+			if (tmp1 == NULL) return;
+			tmp3 = PyNumber_Divide(tmp1, *a0);
+			Py_DECREF(tmp1);
+			if (tmp3 == NULL) return;
 			tmp1 = PyNumber_Multiply(*yn, *ptr_a);
-			if (tmp1 == NULL || tmp3 == NULL) return;
+			if (tmp1 == NULL) return;
 			tmp2 = PyNumber_Divide(tmp1, *a0);
 			Py_DECREF(tmp1);
 			if (tmp2 == NULL) return;
@@ -581,26 +601,6 @@ static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
 			*ptr_Z = PyNumber_Subtract(tmp3, tmp2);
 			Py_DECREF(tmp2);
 			Py_DECREF(tmp3);
-			if (*ptr_Z == NULL) return;
-			ptr_b++;
-			ptr_a++;
-			ptr_Z++;
-		}
-		/* Calculate last delay */
-		tmp1 = PyNumber_Multiply(*xn, *ptr_b);
-	    if (tmp1 == NULL) return;
-		tmp3 = PyNumber_Divide(tmp1, *a0);
-		Py_DECREF(tmp1);
-	    if (tmp3 == NULL) return;
-		tmp1 = PyNumber_Multiply(*yn, *ptr_a);
-	    if (tmp1 == NULL) return;
-		tmp2 = PyNumber_Divide(tmp1, *a0);
-		Py_DECREF(tmp1);
-	    if (tmp2 == NULL) return;
-		Py_XDECREF(*ptr_Z);
-		*ptr_Z = PyNumber_Subtract(tmp3, tmp2);
-		Py_DECREF(tmp2);
-		Py_DECREF(tmp3);
         } else {
             tmp1 = PyNumber_Multiply(*xn, *ptr_b);
 			if (tmp1 == NULL) return;

--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -162,12 +162,13 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
     }
     ara_ptr = ara->data;
     nal = PyArray_ITEMSIZE(ara);
-    if (memcmp(ara_ptr, azero, nal) == 0) {
+    st = memcmp(ara_ptr, azero, nal);
+    PyDataMem_FREE(azero);
+    if (st == 0) {
         PyErr_SetString(PyExc_ValueError,
                         "BUG: filter coefficient a[0] == 0 not supported yet");
         goto fail;
     }
-    PyDataMem_FREE(azero);
 
     na = PyArray_SIZE(ara);
     nb = PyArray_SIZE(arb);
@@ -221,6 +222,7 @@ zfill(const PyArrayObject * x, intp nx, char *xzfilled, intp nxzfilled)
 
     /* PyArray_Zero does not take const pointer, hence the cast */
     xzero = PyArray_Zero((PyArrayObject *) x);
+    if (xzero == NULL) return -1;
 
     if (nx > 0) {
         for (i = 0; i < nx; ++i) {
@@ -323,8 +325,8 @@ RawFilter(const PyArrayObject * b, const PyArrayObject * a,
     memset(bzfilled, 0, nbl * nfilt);
     memset(zfzfilled, 0, nxl * (nfilt - 1));
 
-    zfill(a, na, azfilled, nfilt);
-    zfill(b, nb, bzfilled, nfilt);
+    if (zfill(a, na, azfilled, nfilt) == -1) goto clean_zfzfilled;
+    if (zfill(b, nb, bzfilled, nfilt) == -1) goto clean_zfzfilled;
 
     /* XXX: Check that zf and zi have same type ? */
     if (zf != NULL) {
@@ -344,7 +346,9 @@ RawFilter(const PyArrayObject * b, const PyArrayObject * a,
             }
             PyArray_ITER_NEXT(itzi);
         } else {
-            zfill(x, 0, zfzfilled, nfilt - 1);
+            if (zfill(x, 0, zfzfilled, nfilt - 1) == -1) {
+		goto clean_zfzfilled;
+	    };
         }
 
         filter_func(bzfilled, azfilled,
@@ -353,7 +357,7 @@ RawFilter(const PyArrayObject * b, const PyArrayObject * a,
                     ity->strides[axis]);
     
         if (PyErr_Occurred()) {
-            goto clean_bzfilled; 
+            goto clean_zfzfilled; 
         }
         PyArray_ITER_NEXT(itx);
         PyArray_ITER_NEXT(ity);
@@ -383,6 +387,8 @@ RawFilter(const PyArrayObject * b, const PyArrayObject * a,
 
     return 0;
 
+clean_zfzfilled:
+    free(zfzfilled);
 clean_bzfilled:
     free(bzfilled);
 clean_azfilled:
@@ -609,7 +615,7 @@ static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
             Py_DECREF(tmp1);
             if (*yn == NULL) return;
         }
-        
+
         ptr_y += stride_Y;      /* Move to next input/output point */
         ptr_x += stride_X;
     }

--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -578,11 +578,18 @@ static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
                 tmp3 = PyNumber_Add(tmp2, ptr_Z[1]);
                 Py_DECREF(tmp1);
                 Py_DECREF(tmp2);
+		if (tmp3 == NULL) return;
                 tmp1 = PyNumber_Multiply(*yn, *ptr_a);
-                if (tmp1 == NULL || tmp3 == NULL) return;
+                if (tmp1 == NULL) {
+                    Py_DECREF(tmp3);
+                    return NULL;
+                }
                 tmp2 = PyNumber_Divide(tmp1, *a0);
                 Py_DECREF(tmp1);
-                if (tmp2 == NULL) return;
+                if (tmp2 == NULL) {
+                    Py_DECREF(tmp3);
+                    return;
+                }
                 Py_XDECREF(*ptr_Z);
                 *ptr_Z = PyNumber_Subtract(tmp3, tmp2);
                 Py_DECREF(tmp2);
@@ -599,10 +606,16 @@ static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
             Py_DECREF(tmp1);
             if (tmp3 == NULL) return;
             tmp1 = PyNumber_Multiply(*yn, *ptr_a);
-            if (tmp1 == NULL) return;
+            if (tmp1 == NULL) {
+                Py_DECREF(tmp3);
+                return;
+            }
             tmp2 = PyNumber_Divide(tmp1, *a0);
             Py_DECREF(tmp1);
-            if (tmp2 == NULL) return;
+            if (tmp2 == NULL) {
+                Py_DECREF(tmp3);
+                return;
+            }
             Py_XDECREF(*ptr_Z);
             *ptr_Z = PyNumber_Subtract(tmp3, tmp2);
             Py_DECREF(tmp2);

--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -545,71 +545,71 @@ static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
             ptr_Z = ((PyObject **) Z);
             /* Calculate first delay (output) */
             tmp1 = PyNumber_Multiply(*ptr_b, *xn);
-			if (tmp1 == NULL) return;
+            if (tmp1 == NULL) return;
             tmp2 = PyNumber_Divide(tmp1, *a0);
-			if (tmp2 == NULL) {
-				Py_DECREF(tmp1);
-				return;
-			}
-			tmp3 = PyNumber_Add(tmp2, *ptr_Z);
-			Py_XDECREF(*yn);
-			*yn = tmp3; /* Steals the reference */
-			Py_DECREF(tmp1);
-			Py_DECREF(tmp2);
-			if (tmp3 == NULL) return;
-			ptr_b++;
-			ptr_a++;
-			
+            if (tmp2 == NULL) {
+                Py_DECREF(tmp1);
+                return;
+            }
+            tmp3 = PyNumber_Add(tmp2, *ptr_Z);
+            Py_XDECREF(*yn);
+            *yn = tmp3; /* Steals the reference */
+            Py_DECREF(tmp1);
+            Py_DECREF(tmp2);
+            if (tmp3 == NULL) return;
+            ptr_b++;
+            ptr_a++;
+            
             /* Fill in middle delays */
-			for (n = 0; n < len_b - 2; n++) {
-				tmp1 = PyNumber_Multiply(*xn, *ptr_b);
-				if (tmp1 == NULL) return;
-				tmp2 = PyNumber_Divide(tmp1, *a0);
-				if (tmp2 == NULL) {
-					Py_DECREF(tmp1);
-					return;
-				}
-				tmp3 = PyNumber_Add(tmp2, ptr_Z[1]);
-				Py_DECREF(tmp1);
-				Py_DECREF(tmp2);
-				tmp1 = PyNumber_Multiply(*yn, *ptr_a);
-				if (tmp1 == NULL || tmp3 == NULL) return;
-				tmp2 = PyNumber_Divide(tmp1, *a0);
-				Py_DECREF(tmp1);
-				if (tmp2 == NULL) return;
-				Py_XDECREF(*ptr_Z);
-				*ptr_Z = PyNumber_Subtract(tmp3, tmp2);
-				Py_DECREF(tmp2);
-				Py_DECREF(tmp3);
-				if (*ptr_Z == NULL) return;
-				ptr_b++;
-				ptr_a++;
-				ptr_Z++;
-			}
-			/* Calculate last delay */
-			tmp1 = PyNumber_Multiply(*xn, *ptr_b);
-			if (tmp1 == NULL) return;
-			tmp3 = PyNumber_Divide(tmp1, *a0);
-			Py_DECREF(tmp1);
-			if (tmp3 == NULL) return;
-			tmp1 = PyNumber_Multiply(*yn, *ptr_a);
-			if (tmp1 == NULL) return;
-			tmp2 = PyNumber_Divide(tmp1, *a0);
-			Py_DECREF(tmp1);
-			if (tmp2 == NULL) return;
-			Py_XDECREF(*ptr_Z);
-			*ptr_Z = PyNumber_Subtract(tmp3, tmp2);
-			Py_DECREF(tmp2);
-			Py_DECREF(tmp3);
+            for (n = 0; n < len_b - 2; n++) {
+                tmp1 = PyNumber_Multiply(*xn, *ptr_b);
+                if (tmp1 == NULL) return;
+                tmp2 = PyNumber_Divide(tmp1, *a0);
+                if (tmp2 == NULL) {
+                    Py_DECREF(tmp1);
+                    return;
+                }
+                tmp3 = PyNumber_Add(tmp2, ptr_Z[1]);
+                Py_DECREF(tmp1);
+                Py_DECREF(tmp2);
+                tmp1 = PyNumber_Multiply(*yn, *ptr_a);
+                if (tmp1 == NULL || tmp3 == NULL) return;
+                tmp2 = PyNumber_Divide(tmp1, *a0);
+                Py_DECREF(tmp1);
+                if (tmp2 == NULL) return;
+                Py_XDECREF(*ptr_Z);
+                *ptr_Z = PyNumber_Subtract(tmp3, tmp2);
+                Py_DECREF(tmp2);
+                Py_DECREF(tmp3);
+                if (*ptr_Z == NULL) return;
+                ptr_b++;
+                ptr_a++;
+                ptr_Z++;
+            }
+            /* Calculate last delay */
+            tmp1 = PyNumber_Multiply(*xn, *ptr_b);
+            if (tmp1 == NULL) return;
+            tmp3 = PyNumber_Divide(tmp1, *a0);
+            Py_DECREF(tmp1);
+            if (tmp3 == NULL) return;
+            tmp1 = PyNumber_Multiply(*yn, *ptr_a);
+            if (tmp1 == NULL) return;
+            tmp2 = PyNumber_Divide(tmp1, *a0);
+            Py_DECREF(tmp1);
+            if (tmp2 == NULL) return;
+            Py_XDECREF(*ptr_Z);
+            *ptr_Z = PyNumber_Subtract(tmp3, tmp2);
+            Py_DECREF(tmp2);
+            Py_DECREF(tmp3);
         } else {
             tmp1 = PyNumber_Multiply(*xn, *ptr_b);
-			if (tmp1 == NULL) return;
+            if (tmp1 == NULL) return;
             Py_XDECREF(*yn);
             *yn = PyNumber_Divide(tmp1, *a0);
             Py_DECREF(tmp1);
-			if (*yn == NULL) return;
+            if (*yn == NULL) return;
         }
-		
+        
         ptr_y += stride_Y;      /* Move to next input/output point */
         ptr_x += stride_X;
     }

--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -127,6 +127,9 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
         arVf = (PyArrayObject *) PyArray_SimpleNew(arVi->nd,
                                                    arVi->dimensions,
                                                    typenum);
+        if (arVF == NULL) {
+            goto fail;
+        }
     }
 
     if (arX->descr->type_num < 256) {
@@ -576,7 +579,7 @@ static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
                 tmp3 = PyNumber_Add(tmp2, ptr_Z[1]);
                 Py_DECREF(tmp1);
                 Py_DECREF(tmp2);
-		if (tmp3 == NULL) return;
+                if (tmp3 == NULL) return;
                 tmp1 = PyNumber_Multiply(*yn, *ptr_a);
                 if (tmp1 == NULL) {
                     Py_DECREF(tmp3);

--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -158,6 +158,9 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
     /* Skip over leading zeros in vector representing denominator (a) */
     /* XXX: handle this correctly */
     azero = PyArray_Zero(ara);
+    if (azero == NULL) {
+        goto fail;
+    }
     ara_ptr = ara->data;
     nal = PyArray_ITEMSIZE(ara);
     if (memcmp(ara_ptr, azero, nal) == 0) {

--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -127,7 +127,7 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
         arVf = (PyArrayObject *) PyArray_SimpleNew(arVi->nd,
                                                    arVi->dimensions,
                                                    typenum);
-        if (arVF == NULL) {
+        if (arVf == NULL) {
             goto fail;
         }
     }

--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -548,68 +548,68 @@ static void OBJECT_filt(char *b, char *a, char *x, char *y, char *Z,
 	    if (tmp1 == NULL) return;
             tmp2 = PyNumber_Divide(tmp1, *a0);
 	    if (tmp2 == NULL) {
-		Py_DECREF(tmp1);
-		return;
+			Py_DECREF(tmp1);
+			return;
 	    }
-            tmp3 = PyNumber_Add(tmp2, *ptr_Z);
-            Py_XDECREF(*yn);
-            *yn = tmp3; /* Steals the reference */
-            Py_DECREF(tmp1);
-            Py_DECREF(tmp2);
+		tmp3 = PyNumber_Add(tmp2, *ptr_Z);
+		Py_XDECREF(*yn);
+		*yn = tmp3; /* Steals the reference */
+		Py_DECREF(tmp1);
+		Py_DECREF(tmp2);
 	    if (tmp3 == NULL) return;
-            ptr_b++;
-            ptr_a++;
+		ptr_b++;
+	    ptr_a++;
 
             /* Fill in middle delays */
-            for (n = 0; n < len_b - 2; n++) {
-                tmp1 = PyNumber_Multiply(*xn, *ptr_b);
-		if (tmp1 == NULL) return;
-                tmp2 = PyNumber_Divide(tmp1, *a0);
-		if (tmp2 == NULL) {
-		    Py_DECREF(tmp1);
-		    return;
+		for (n = 0; n < len_b - 2; n++) {
+			tmp1 = PyNumber_Multiply(*xn, *ptr_b);
+			if (tmp1 == NULL) return;
+			tmp2 = PyNumber_Divide(tmp1, *a0);
+			if (tmp2 == NULL) {
+				Py_DECREF(tmp1);
+				return;
+			}
+			tmp3 = PyNumber_Add(tmp2, ptr_Z[1]);
+			Py_DECREF(tmp1);
+			Py_DECREF(tmp2);
+			tmp1 = PyNumber_Multiply(*yn, *ptr_a);
+			if (tmp1 == NULL || tmp3 == NULL) return;
+			tmp2 = PyNumber_Divide(tmp1, *a0);
+			Py_DECREF(tmp1);
+			if (tmp2 == NULL) return;
+			Py_XDECREF(*ptr_Z);
+			*ptr_Z = PyNumber_Subtract(tmp3, tmp2);
+			Py_DECREF(tmp2);
+			Py_DECREF(tmp3);
+			if (*ptr_Z == NULL) return;
+			ptr_b++;
+			ptr_a++;
+			ptr_Z++;
 		}
-                tmp3 = PyNumber_Add(tmp2, ptr_Z[1]);
-                Py_DECREF(tmp1);
-                Py_DECREF(tmp2);
-                tmp1 = PyNumber_Multiply(*yn, *ptr_a);
-		if (tmp1 == NULL || tmp3 == NULL) return;
-                tmp2 = PyNumber_Divide(tmp1, *a0);
-                Py_DECREF(tmp1);
-		if (tmp2 == NULL) return;
-                Py_XDECREF(*ptr_Z);
-                *ptr_Z = PyNumber_Subtract(tmp3, tmp2);
-                Py_DECREF(tmp2);
-                Py_DECREF(tmp3);
-		if (*ptr_Z == NULL) return;
-                ptr_b++;
-                ptr_a++;
-                ptr_Z++;
-            }
-            /* Calculate last delay */
-            tmp1 = PyNumber_Multiply(*xn, *ptr_b);
+		/* Calculate last delay */
+		tmp1 = PyNumber_Multiply(*xn, *ptr_b);
 	    if (tmp1 == NULL) return;
-            tmp3 = PyNumber_Divide(tmp1, *a0);
-            Py_DECREF(tmp1);
+		tmp3 = PyNumber_Divide(tmp1, *a0);
+		Py_DECREF(tmp1);
 	    if (tmp3 == NULL) return;
-            tmp1 = PyNumber_Multiply(*yn, *ptr_a);
+		tmp1 = PyNumber_Multiply(*yn, *ptr_a);
 	    if (tmp1 == NULL) return;
-            tmp2 = PyNumber_Divide(tmp1, *a0);
-            Py_DECREF(tmp1);
+		tmp2 = PyNumber_Divide(tmp1, *a0);
+		Py_DECREF(tmp1);
 	    if (tmp2 == NULL) return;
-            Py_XDECREF(*ptr_Z);
-            *ptr_Z = PyNumber_Subtract(tmp3, tmp2);
-            Py_DECREF(tmp2);
-            Py_DECREF(tmp3);
+		Py_XDECREF(*ptr_Z);
+		*ptr_Z = PyNumber_Subtract(tmp3, tmp2);
+		Py_DECREF(tmp2);
+		Py_DECREF(tmp3);
         } else {
             tmp1 = PyNumber_Multiply(*xn, *ptr_b);
-	    if (tmp1 == NULL) return;
+			if (tmp1 == NULL) return;
             Py_XDECREF(*yn);
             *yn = PyNumber_Divide(tmp1, *a0);
             Py_DECREF(tmp1);
-	    if (*yn == NULL) return;
+			if (*yn == NULL) return;
         }
-
+		
         ptr_y += stride_Y;      /* Move to next input/output point */
         ptr_x += stride_X;
     }

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -379,6 +379,19 @@ class TestLinearFilterComplexxxiExtended28(_TestLinearFilter):
 class TestLinearFilterDecimal(_TestLinearFilter):
     dt = np.dtype(Decimal)
 
+class TestLinearFilterObject(_TestLinearFilter):
+    dt = np.object_
+
+
+def test_lfilter_bad_object():
+    """lfilter: object arrays with non-numeric objects raise ValueError.
+    
+    Regression test for ticket #1452.
+    """
+    assert_raises(ValueError, lfilter, [1.0], [1.0], [1.0, None, 2.0])
+    assert_raises(ValueError, lfilter, [1.0], [None], [1.0, 2.0, 3.0])
+    assert_raises(ValueError, lfilter, [None], [1.0], [1.0, 2.0, 3.0])
+
 
 class _TestCorrelateReal(TestCase):
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -384,13 +384,13 @@ class TestLinearFilterObject(_TestLinearFilter):
 
 
 def test_lfilter_bad_object():
-    """lfilter: object arrays with non-numeric objects raise ValueError.
+    """lfilter: object arrays with non-numeric objects raise TypeError.
     
     Regression test for ticket #1452.
     """
-    assert_raises(ValueError, lfilter, [1.0], [1.0], [1.0, None, 2.0])
-    assert_raises(ValueError, lfilter, [1.0], [None], [1.0, 2.0, 3.0])
-    assert_raises(ValueError, lfilter, [None], [1.0], [1.0, 2.0, 3.0])
+    assert_raises(TypeError, lfilter, [1.0], [1.0], [1.0, None, 2.0])
+    assert_raises(TypeError, lfilter, [1.0], [None], [1.0, 2.0, 3.0])
+    assert_raises(TypeError, lfilter, [None], [1.0], [1.0, 2.0, 3.0])
 
 
 class _TestCorrelateReal(TestCase):


### PR DESCRIPTION
This pull request replaces #112 by adding proper error handling in the C-extension module for the low-level Object filtering loop. 
