### PR TITLE
DOC: Correction to integrate.quad docstring

### DIFF
--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -153,9 +153,9 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     func : function
         A Python function or method to integrate.
     a : float
-        Lower limit of integration (use -scipy.integrate.Inf for -infinity).
+        Lower limit of integration (use -numpy.inf for -infinity).
     b : float
-        Upper limit of integration (use scipy.integrate.Inf for +infinity).
+        Upper limit of integration (use numpy.inf for +infinity).
     args : tuple, optional
         extra arguments to pass to func
     full_output : int


### PR DESCRIPTION
As reported on mailing list by Mark Bakker http://mail.scipy.org/pipermail/scipy-user/2012-January/031286.html
