### PR TITLE
ENH implement sin, sqrt and tan on CSR and CSC matrices

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -243,6 +243,27 @@ class _cs_matrix(_data_matrix):
             return self._binopt(other,'_elmul_')
 
 
+    def sin(self):
+        """Element-wise sine."""
+        return self._apply_arith(np.sin)
+
+
+    def sqrt(self):
+        """Element-wise square root."""
+        return self._apply_arith(np.sqrt)
+
+
+    def tan(self):
+        """Element-wise tangent."""
+        return self._apply_arith(np.tan)
+
+
+    def _apply_arith(self, op):
+        X = self.copy()
+        op(X.data, X.data)  # out keyword not supported by older Numpy
+        return X
+
+
     ###########################
     # Multiplication handlers #
     ###########################

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1075,6 +1075,11 @@ class TestCSR(_TestCommon, _TestGetSet, _TestSolve,
         assert_array_equal(asp.data,[1, 2, 3])
         assert_array_equal(asp.todense(),bsp.todense())
 
+    def test_sqrt(self):
+        X = csr_matrix([[0., 1.], [2., 4.]])
+        assert_array_equal(np.sqrt(X).A,
+                           [[0., 1.], [1.4142135623730951, 2.]])
+
     def test_unsorted_arithmetic(self):
         data    = arange( 5 )
         indices = array( [7, 2, 1, 5, 4] )
@@ -1154,6 +1159,12 @@ class TestCSC(_TestCommon, _TestGetSet, _TestSolve,
         assert_array_equal(asp.nnz, 3)
         assert_array_equal(asp.data,[1, 2, 3])
         assert_array_equal(asp.todense(),bsp.todense())
+
+    def test_sin(self):
+        X = csc_matrix([0., 1.], [2., 3.])
+        assert_array_equal(np.sin(X).A,
+                           [[0.,                  0.8414709848078965 ],
+                            [0.90929742682568171, 0.14112000805986721]])
 
     def test_sort_indices(self):
         data = arange( 5 )


### PR DESCRIPTION
I implemented a few more arithmetic operations on sparse matrices, so that

```
 np.sin(X)
 np.sqrt(X)
```

and

```
np.tan(X)
```

work when `X` is CSR or CSC.
