### PR TITLE
formula used for the circular standard deviation is incorrect

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1395,7 +1395,7 @@ def circstd(samples, high=2*pi, low=0):
     ang = (samples - low)*2*pi / (high-low)
     res = np.mean(exp(1j*ang), axis=0)
     V = 1-abs(res)
-    return ((high-low)/2.0/pi) * sqrt(V)
+    return ((high-low)/2.0/pi) * sqrt(-2 * log(1 - V))
 
 
 


### PR DESCRIPTION
the current implementation of scipy.stats.morestats.circstd uses this formula:
  circular_standard_deviation = sqrt(circular_variance)
I think this formula is the one for the standard deviation, and not the circular standard deviation, after looking at wikipedia (http://en.wikipedia.org/wiki/Directional_statistics) and in the help of oriana (http://www.kovcomp.co.uk/oriana/), the expected formula to use looks more like:
  circular_standard_deviation = sqrt(-2 \* log(1 - circular_variance))

note: I tryed to fill a bug in the scipy trac but there is some issue with the database
