### PR TITLE
BUG: io: add work-around in netcdf.py for the bug in numpy that is the c...

### DIFF
--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -801,6 +801,14 @@ class netcdf_variable(object):
             netcdf variable.
 
         """
+        if not self.data.flags.writeable:
+            # Work-around for a bug in NumPy.  Calling itemset() on a read-only
+            # memory-mapped array causes a seg. fault.
+            # See NumPy ticket #1622, and SciPy ticket #1202.
+            # This check for `writeable` can be removed when the oldest version
+            # of numpy still supported by scipy contains the fix for #1622.
+            raise RuntimeError("variable is not writeable")
+
         self.data.itemset(value)
 
     def typecode(self):

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -124,6 +124,14 @@ def test_read_example_data():
         f = netcdf_file(fname, 'r')
         f = netcdf_file(fname, 'r', mmap=False)
 
+def test_itemset_no_segfault_on_readonly():
+    # Regression test for ticket #1202.
+    # Open the test file in read-only mode.
+    filename = pjoin(TEST_DATA_PATH, 'example_1.nc')
+    f = netcdf_file(filename, 'r')
+    time_var = f.variables['time']
+    # time_var.assignValue(42) should raise a RuntimeError--not seg. fault!
+    assert_raises(RuntimeError, time_var.assignValue, 42)
 
 def test_write_invalid_dtype():
     dtypes = ['int64', 'uint64']


### PR DESCRIPTION
...ause of the problem reported in ticket #1202

This change avoids the problem reported in ticket #1202 by checking the `writeable` flag of the data array before attempting to call assignValue() on the netcdf variable.

A pull request to fix the underlying problem has been submitted to numpy.  Even after numpy is fixed, however,  we'll need to support older versions of numpy, so the work-around provided by this pull request is necessary.
