### PR TITLE
BUG: Some macros require trailing semicolons for Numpy 1.7.

### DIFF
--- a/scipy/special/_cephesmodule.c
+++ b/scipy/special/_cephesmodule.c
@@ -1051,7 +1051,7 @@ static PyObject *scipy_special_SpecialFunctionWarning = NULL;
 
 void scipy_special_raise_warning(char *fmt, ...)
 {
-    NPY_ALLOW_C_API_DEF
+    NPY_ALLOW_C_API_DEF;
     char msg[1024];
     va_list ap;
 
@@ -1059,9 +1059,9 @@ void scipy_special_raise_warning(char *fmt, ...)
     PyOS_vsnprintf(msg, 1024, fmt, ap);
     va_end(ap);
 
-    NPY_ALLOW_C_API
+    NPY_ALLOW_C_API;
     PyErr_Warn(scipy_special_SpecialFunctionWarning, msg);
-    NPY_DISABLE_C_API
+    NPY_DISABLE_C_API;
 }
 
 static char errprint_doc[] = \


### PR DESCRIPTION
In Numpy 1.7 some macros have had their trailing semicolons removed
in the include file, hence require them in the source.
