### PR TITLE
BUG: sparse: cs{r,c}_matrix slicing with step > 1

### DIFF
--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -347,6 +347,8 @@ class csr_matrix(_cs_matrix):
 
         def process_slice( sl, num ):
             if isinstance( sl, slice ):
+                if sl.step not in (1, None):
+                    raise ValueError('slicing with step != 1 not supported')
                 i0, i1 = sl.start, sl.stop
                 if i0 is None:
                     i0 = 0

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -975,11 +975,20 @@ class _TestArithmetic:
                 assert_equal(S1.dtype,D1.dtype)
 
 
+class _Test2DSlicingRegression:
+    def test_non_unit_stride_2d_indexing_raises_exception(self):
+        # Regression test -- used to silently ignore the stride.
+        try:
+            self.spmatrix((500, 500))[0:100:2, 0:100:2]
+        except ValueError:
+            return
+        assert False  # Should not happen.
+
 
 class TestCSR(_TestCommon, _TestGetSet, _TestSolve,
         _TestInplaceArithmetic, _TestArithmetic,
         _TestHorizSlicing, _TestVertSlicing, _TestBothSlicing,
-        _TestFancyIndexing, TestCase):
+        _TestFancyIndexing, _Test2DSlicingRegression, TestCase):
     spmatrix = csr_matrix
 
     @dec.knownfailureif(True, "Fancy indexing is known to be broken for CSR" \
@@ -1092,7 +1101,7 @@ class TestCSR(_TestCommon, _TestGetSet, _TestSolve,
 class TestCSC(_TestCommon, _TestGetSet, _TestSolve,
         _TestInplaceArithmetic, _TestArithmetic,
         _TestHorizSlicing, _TestVertSlicing, _TestBothSlicing,
-        _TestFancyIndexing, TestCase):
+        _TestFancyIndexing, _Test2DSlicingRegression, TestCase):
     spmatrix = csc_matrix
 
     @dec.knownfailureif(True, "Fancy indexing is known to be broken for CSC" \


### PR DESCRIPTION
Previously, csr_matrix/csc_matrix would silently ignore strided slices,
except in the case of scalar-slice or slice-scalar combinations for
csr_matrix and csc_matrix, respectively. This adds an exception in an
alternate location with the same message as the correctly handled case,
as well as regression tests.

```
>>> import scipy.sparse
>>> a = scipy.sparse.csr_matrix((500, 500))
>>> a[:100:2, :100:2]  # Should fail, but instead produces 100x100
<100x100 sparse matrix of type '<type 'numpy.float64'>'
    with 0 stored elements in Compressed Sparse Row format>
>>> a[:, :100:2]  # Should fail, but instead produces 500x100
<500x100 sparse matrix of type '<type 'numpy.float64'>'
    with 0 stored elements in Compressed Sparse Row format>
>>> a[:100:2, 2]  # Should fail, but instead produces 100x1
<100x1 sparse matrix of type '<type 'numpy.float64'>'
    with 0 stored elements in Compressed Sparse Row format>
>>> a[2, :100:2]  # Fails, correctly
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/lisa/os/epd-7.1.2/lib/python2.7/site-packages/scipy/sparse/csr.py", line 210, in __getitem__
    return self._get_row_slice(row, col)      #[i,1:2]
  File "/opt/lisa/os/epd-7.1.2/lib/python2.7/site-packages/scipy/sparse/csr.py", line 302, in _get_row_slice
    raise ValueError("slicing with step != 1 not supported")
ValueError: slicing with step != 1 not supported
```
