### PR TITLE
Added a Sylvester equation solver to scipy.linalg

### DIFF
--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -25,6 +25,7 @@ Basics
    solve - Solve a linear system of equations
    solve_banded - Solve a banded linear system
    solveh_banded - Solve a Hermitian or symmetric banded system
+   solve_sylvester - Solve the Sylvester matrix equation
    solve_triangular - Solve a triangular matrix
    det - Find the determinant of a square matrix
    norm - Matrix and vector norm

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -29,7 +29,7 @@ from numpy.testing import TestCase, rand, run_module_suite, assert_raises, \
     assert_allclose
 
 from scipy.linalg import solve, inv, det, lstsq, pinv, pinv2, norm,\
-        solve_banded, solveh_banded, solve_triangular
+        solve_banded, solveh_banded, solve_triangular, solve_sylvester
 
 from scipy.linalg._testutils import assert_no_overwrite
 
@@ -558,6 +558,31 @@ class TestPinv(TestCase):
         a_pinv2 = pinv2(a)
         assert_array_almost_equal(a_pinv,a_pinv2)
 
+class TestSolveSylvester(TestCase):
+
+    def test_simple(self):
+        a = np.array([[1, 2], [0, 4]])
+        b = np.array([[5, 6], [0, 8]])
+        c = np.array([[9, 10], [11, 12]])
+
+        x = solve_sylvester(a, b, c)
+        assert_array_almost_equal(np.dot(a, x) + np.dot(x, b), c)
+
+        # Test with a complex form, but effectively same matrices
+        ac = complex(0, 1)*a
+        bc = complex(0, 1)*b
+        cc = complex(0, 1)*c
+
+        x = solve_sylvester(a, b, c)
+        assert_array_almost_equal(np.dot(ac, x) + np.dot(x, bc), cc)
+
+    def test_nonsquare(self):
+        a = np.array([[8, 1, 6], [3, 5, 7], [4, 9, 2]])
+        b = np.array([[2, 3], [4, 5]])
+        c = np.array([[1, 2], [3, 4], [5, 6]])
+
+        x = solve_sylvester(a, b, c)
+        assert_array_almost_equal(np.dot(a, x) + np.dot(x, b), c)
 
 class TestNorm(object):
 


### PR DESCRIPTION
I've added a function to provide a solution to the Sylvester equation (AX + XB = Q) to the linear algebra module.  The code is currently grouped with "basic" linear algebra routines as this seems to be the only  applicable place to include such a solver.  The routine relies on some Schur decomposition calls and a LAPACK call.  If including the code in this location is sub-optimal, maybe another location in SciPy could be suggested.
