### PR TITLE
Fix msvc9 compile error

### DIFF
--- a/scipy/special/_cephesmodule.c
+++ b/scipy/special/_cephesmodule.c
@@ -1051,9 +1051,9 @@ static PyObject *scipy_special_SpecialFunctionWarning = NULL;
 
 void scipy_special_raise_warning(char *fmt, ...)
 {
-    NPY_ALLOW_C_API_DEF;
     char msg[1024];
     va_list ap;
+    NPY_ALLOW_C_API_DEF;
 
     va_start(ap, fmt);
     PyOS_vsnprintf(msg, 1024, fmt, ap);


### PR DESCRIPTION
Apparently msvc9, and possibly other c89/ansi C compilers, do not allow a extra semicolon (empty statement) before variable declarations.
