### PR TITLE
BLD: Fix Bento build of source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,12 @@ include setup.py
 include scipy/*.py
 # Adding scons build related files not found by distutils
 recursive-include scipy SConstruct SConscript
+# Add files to allow Bento build
+include f2py.py
+include interface_gen.py
+include bscript bento.info
+recursive-include scipy bscript bento.info
+include scipy/special/tests/*.dat
 # Add py3tool
 include tools/py3tool.py
 # Add documentation: we don't use add_data_dir since we do not want to include

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,7 +15,6 @@ include f2py.py
 include interface_gen.py
 include bscript bento.info
 recursive-include scipy bscript bento.info
-include scipy/special/tests/*.dat
 # Add py3tool
 include tools/py3tool.py
 # Add documentation: we don't use add_data_dir since we do not want to include

--- a/bento.info
+++ b/bento.info
@@ -70,7 +70,6 @@ DataFiles: tests
         spatial/tests/*.py,
         spatial/tests/*.txt,
         special/tests/*.py,
-        special/tests/*.dat,
         special/tests/data/*.npz,
         stats/tests/*.py
 


### PR DESCRIPTION
- Several files required to build Scipy using Bento are not included
  in source distributions created using `python setup.py sdist`.
