### PR TITLE
Make Umfpack free its data (#1597)

### DIFF
--- a/scipy/sparse/linalg/dsolve/umfpack/tests/test_umfpack.py
+++ b/scipy/sparse/linalg/dsolve/umfpack/tests/test_umfpack.py
@@ -7,8 +7,10 @@
 
 import warnings
 import random
+
 from numpy.testing import TestCase, assert_array_almost_equal, dec, \
         decorate_methods
+from numpy.testing.utils import WarningManager
 
 from scipy import rand, matrix, diag, eye
 from scipy.sparse import csc_matrix, spdiags, SparseEfficiencyWarning
@@ -29,7 +31,17 @@ else:
 _umfpack_skip = dec.skipif(not _have_umfpack,
                            'UMFPACK appears not to be compiled')
 
-class TestSolvers(TestCase):
+class _DeprecationAccept:
+    def setUp(self):
+        self.mgr = WarningManager()
+        self.mgr.__enter__()
+        warnings.simplefilter("ignore", DeprecationWarning)
+
+    def tearDown(self):
+        self.mgr.__exit__()
+
+
+class TestSolvers(TestCase, _DeprecationAccept):
     """Tests inverting a sparse linear system"""
 
     def test_solve_complex_without_umfpack(self):
@@ -113,9 +125,9 @@ class TestSolvers(TestCase):
         self.b = np.array([1, 2, 3, 4, 5])
         self.b2 = np.array([5, 4, 3, 2, 1])
 
+        _DeprecationAccept.setUp(self)
 
-
-class TestFactorization(TestCase):
+class TestFactorization(TestCase, _DeprecationAccept):
     """Tests factorizing a sparse linear system"""
 
     def test_complex_lu(self):
@@ -174,6 +186,8 @@ class TestFactorization(TestCase):
                 in self.real_matrices]
         self.complex_matrices = [x.astype(np.complex128)
                                  for x in self.real_matrices]
+
+        _DeprecationAccept.setUp(self)
 
 # Skip methods if umfpack not present
 for cls in [TestSolvers, TestFactorization]:

--- a/scipy/sparse/linalg/dsolve/umfpack/umfpack.py
+++ b/scipy/sparse/linalg/dsolve/umfpack/umfpack.py
@@ -296,6 +296,9 @@ class UmfpackContext( Struct ):
         self.funs.defaults( self.control )
         self.control[UMFPACK_PRL] = 3
 
+    def __del__(self):
+        self.free()
+
     ##
     # 30.11.2005, c
     def strControl( self ):


### PR DESCRIPTION
Fixes this: http://projects.scipy.org/scipy/ticket/1597
Can't really add an unit test for this, since the data is held on C level.

@rc: do you concur?

The WarningManager stuff is for present Numpy.
