### PR TITLE
BUG: Fix Python 3 test failures.

### DIFF
--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -244,18 +244,18 @@ class _TestIFFTBase(TestCase):
             np.random.seed(1234)
             x = np.random.rand(size).astype(self.rdt)
             y = ifft(fft(x))
-            self.failUnless(np.linalg.norm(x - y) < rtol*np.linalg.norm(x),
+            self.assertTrue(np.linalg.norm(x - y) < rtol*np.linalg.norm(x),
                             (size, self.rdt))
             y = fft(ifft(x))
-            self.failUnless(np.linalg.norm(x - y) < rtol*np.linalg.norm(x),
+            self.assertTrue(np.linalg.norm(x - y) < rtol*np.linalg.norm(x),
                             (size, self.rdt))
 
             x = (x + 1j*np.random.rand(size)).astype(self.cdt)
             y = ifft(fft(x))
-            self.failUnless(np.linalg.norm(x - y) < rtol*np.linalg.norm(x),
+            self.assertTrue(np.linalg.norm(x - y) < rtol*np.linalg.norm(x),
                             (size, self.rdt))
             y = fft(ifft(x))
-            self.failUnless(np.linalg.norm(x - y) < rtol*np.linalg.norm(x),
+            self.assertTrue(np.linalg.norm(x - y) < rtol*np.linalg.norm(x),
                             (size, self.rdt))
 
 class TestDoubleIFFT(_TestIFFTBase):
@@ -367,10 +367,10 @@ class _TestIRFFTBase(TestCase):
             np.random.seed(1234)
             x = np.random.rand(size).astype(self.rdt)
             y = irfft(rfft(x))
-            self.failUnless(np.linalg.norm(x - y) < rtol*np.linalg.norm(x),
+            self.assertTrue(np.linalg.norm(x - y) < rtol*np.linalg.norm(x),
                             (size, self.rdt))
             y = rfft(irfft(x))
-            self.failUnless(np.linalg.norm(x - y) < rtol*np.linalg.norm(x),
+            self.assertTrue(np.linalg.norm(x - y) < rtol*np.linalg.norm(x),
                             (size, self.rdt))
 
 # self.ndec is bogus; we should have a assert_array_approx_equal for number of
@@ -420,7 +420,7 @@ class TestFftnSingle(TestCase):
             y1 = fftn(x.real.astype(np.float32))
             y2 = fftn(x.real.astype(np.float64)).astype(np.complex64)
 
-            self.failUnless(y1.dtype == np.complex64)
+            self.assertTrue(y1.dtype == np.complex64)
             assert_array_almost_equal_nulp(y1, y2, 2000)
 
         for size in LARGE_COMPOSITE_SIZES + LARGE_PRIME_SIZES:
@@ -429,7 +429,7 @@ class TestFftnSingle(TestCase):
             y1 = fftn(x.real.astype(np.float32))
             y2 = fftn(x.real.astype(np.float64)).astype(np.complex64)
 
-            self.failUnless(y1.dtype == np.complex64)
+            self.assertTrue(y1.dtype == np.complex64)
             assert_array_almost_equal_nulp(y1, y2, 2000)
 
 class TestFftn(TestCase):

--- a/scipy/interpolate/tests/test_interpolate_wrapper.py
+++ b/scipy/interpolate/tests/test_interpolate_wrapper.py
@@ -15,7 +15,7 @@ class Test(unittest.TestCase):
 
     def assertAllclose(self, x, y, rtol=1.0e-5):
         for i, xi in enumerate(x):
-            self.assert_(allclose(xi, y[i], rtol) or (isnan(xi) and isnan(y[i])))
+            self.assertTrue(allclose(xi, y[i], rtol) or (isnan(xi) and isnan(y[i])))
 
     def test_nearest(self):
         N = 5

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -27,6 +27,7 @@
 # WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from __future__ import division
 
 import math
 import numpy
@@ -46,10 +47,13 @@ class TestNdimage:
 
     def setUp(self):
         # list of numarray data types
-        self.types = [numpy.int8, numpy.uint8, numpy.int16,
-                      numpy.uint16, numpy.int32, numpy.uint32,
-                      numpy.int64, numpy.uint64,
-                      numpy.float32, numpy.float64]
+        self.integer_types = [numpy.int8, numpy.uint8, numpy.int16,
+                numpy.uint16, numpy.int32, numpy.uint32,
+                numpy.int64, numpy.uint64]
+
+        self.float_types = [numpy.float32, numpy.float64]
+
+        self.types = self.integer_types + self.float_types
 
         # list of boundary modes:
         self.modes = ['nearest', 'wrap', 'reflect', 'mirror', 'constant']
@@ -1144,7 +1148,10 @@ class TestNdimage:
             a = numpy.arange(12, dtype=type)
             a.shape = (3,4)
             r1 = ndimage.correlate(a, filter_ * footprint)
-            r1 /= 5
+            if type in self.float_types:
+                r1 /= 5
+            else:
+                r1 //= 5
             r2 = ndimage.generic_filter(a, _filter_func,
                             footprint=footprint, extra_arguments=(cf,),
                             extra_keywords={'total': cf.sum()})

--- a/scipy/signal/tests/test_wavelets.py
+++ b/scipy/signal/tests/test_wavelets.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 from numpy.testing import TestCase, run_module_suite, assert_equal, \
     assert_array_equal, assert_array_almost_equal, assert_array_less, assert_
@@ -86,11 +88,11 @@ class TestWavelets(TestCase):
             w = wavelets.ricker(length, 1.0)
             assert_(len(w) == length)
             max_loc = np.argmax(w)
-            assert_(max_loc == (length / 2))
+            assert_(max_loc == (length // 2))
 
         points = 100
         w = wavelets.ricker(points, 2.0)
-        half_vec = np.arange(0, points / 2)
+        half_vec = np.arange(0, points // 2)
         #Wavelet should be symmetric
         assert_array_almost_equal(w[half_vec], w[-(half_vec + 1)])
 


### PR DESCRIPTION
Some of these are due to the deprecated test functions self.assertEquals,
self.assert_, and some are due to the reinterpretion of '/'. Probably all
test modules should have

from **future** import division

at the top.
