### PR TITLE
ENH: sparse.diags accepts one diagonal

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -122,7 +122,13 @@ def diags(diagonals, offsets, shape=None, format=None, dtype=None):
     try:
         iter(offsets)
     except TypeError:
-        diagonals = [np.atleast_1d(diagonals)]
+        # now check that there's actually only one diagonal
+        try:
+            iter(diagonals[0])
+        except TypeError:
+            diagonals = [np.atleast_1d(diagonals)]
+        else:
+            raise ValueError("Different number of diagonals and offsets.")
     else:
         diagonals = map(np.atleast_1d, diagonals)
     offsets = np.atleast_1d(offsets)

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -117,6 +117,15 @@ def diags(diagonals, offsets, shape=None, format=None, dtype=None):
             [ 0.,  1., -2.,  1.],
             [ 0.,  0.,  1., -2.]])
 
+
+    If only one diagonal is wanted (as in `numpy.diag`), the following
+    works as well:
+
+    >>> diags([1, 2, 3], 1).todense()
+    matrix([[ 0.,  1.,  0.,  0.],
+            [ 0.,  0.,  2.,  0.],
+            [ 0.,  0.,  0.,  3.],
+            [ 0.,  0.,  0.,  0.]])
     """
     # if offsets is not a sequence, assume that there's only one diagonal
     try:

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -118,8 +118,14 @@ def diags(diagonals, offsets, shape=None, format=None, dtype=None):
             [ 0.,  0.,  1., -2.]])
 
     """
+    # if offsets is not a sequence, assume that there's only one diagonal
+    try:
+        iter(offsets)
+    except TypeError:
+        diagonals = [np.atleast_1d(diagonals)]
+    else:
+        diagonals = map(np.atleast_1d, diagonals)
     offsets = np.atleast_1d(offsets)
-    diagonals = map(np.atleast_1d, diagonals)
 
     # Basic check
     if len(diagonals) != len(offsets):

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -170,6 +170,11 @@ class TestConstructUtils(TestCase):
         assert_equal(x.dtype, int)
         assert_equal(x.todense(), [[2, 0], [0, 2]])
 
+    def test_diags_one_diagonal(self):
+        d = np.random.rand(4)
+        k = np.random.randint(-5, 5)
+        assert_equal(construct.diags(d, k).toarray(), np.diag(d, k))
+
     def test_identity(self):
         assert_equal(construct.identity(1).toarray(), [[1]])
         assert_equal(construct.identity(2).toarray(), [[1,0],[0,1]])

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -69,7 +69,6 @@ class TestConstructUtils(TestCase):
         c = array([11, 12, 13, 14, 15])
 
         cases = []
-        cases.append( ([a[:1]],  0,  (1, 1), [[1]]) )
         cases.append( ([a[:1]], [0], (1, 1), [[1]]) )
         cases.append( ([a[:1]], [0], (2, 1), [[1],[0]]) )
         cases.append( ([a[:1]], [0], (1, 2), [[1,0]]) )

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -133,6 +133,7 @@ class TestConstructUtils(TestCase):
         cases.append( ([], [-4,2,-1], None) )
         cases.append( ([1], [-4], (4, 4)) )
         cases.append( ([a[:0]], [-1], (1, 2)) )
+        cases.append( ([a], 0, None))
 
         for d, o, shape in cases:
             try:
@@ -171,9 +172,10 @@ class TestConstructUtils(TestCase):
         assert_equal(x.todense(), [[2, 0], [0, 2]])
 
     def test_diags_one_diagonal(self):
-        d = np.random.rand(4)
-        k = np.random.randint(-5, 5)
-        assert_equal(construct.diags(d, k).toarray(), np.diag(d, k))
+        d = range(5)
+        for k in range(-5, 6):
+            assert_equal(construct.diags(d, k).toarray(),
+                         construct.diags([d], [k]).toarray())
 
     def test_identity(self):
         assert_equal(construct.identity(1).toarray(), [[1]])


### PR DESCRIPTION
This allows single diagonal matrices to be constructed as
`diags([1, 2], 3)` instead of `diags([[1, 2]], [3])` or
`diags([[1, 2]], 3)` (which still work though).
This is also more consistent with numpy.diag.
