### PR TITLE
BUG: vector constraints in optimize/slsqp

### DIFF
--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -283,8 +283,8 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
 
     # Set the parameters that SLSQP will need
     # meq, mieq: number of equality and inequality constraints
-    meq  = len(cons['eq'])
-    mieq = len(cons['ineq'])
+    meq = sum(map(len, [c['fun'](x, *c['args']) for c in cons['eq']]))
+    mieq = sum(map(len, [c['fun'](x, *c['args']) for c in cons['ineq']]))
     # m = The total number of constraints
     m = meq + mieq
     # la = The number of constraints, or 1 if there are no constraints

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -62,6 +62,15 @@ class TestSLSQP(TestCase):
         """ Inequality constraint, derivative """
         return np.array([[1, -1]])
 
+    def f_ieqcon2(self, x):
+        """ Vector inequality constraint """
+        return np.asarray(x)
+
+    def fprime_ieqcon2(self, x):
+        """ Vector inequality constraint, derivative """
+        return np.identity(x.shape[0])
+
+
     # minimize
     def test_minimize_unbounded_approximated(self):
         """ Minimize, method='SLSQP': unbounded, approximated jacobian. """
@@ -131,6 +140,19 @@ class TestSLSQP(TestCase):
                            options=self.opts, full_output=True)
         assert_(info['success'], info['message'])
         assert_allclose(x, [2, 1], atol=1e-3)
+
+    def test_minimize_inequality_given_vector_constraints(self):
+        """ \
+        Minimize with method='SLSQP': vector inequality constraint, given jacobian.
+        """
+        x, info = minimize(self.fun, [-1.0, 1.0], jac=self.jac,
+                           method='SLSQP', args=(-1.0,),
+                           constraints={'type': 'ineq',
+                                        'fun': self.f_ieqcon2,
+                                        'jac': self.fprime_ieqcon2},
+                           options=self.opts, full_output=True)
+        assert_(info['success'], info['message'])
+        assert_allclose(x, [2, 1])
 
     def test_minimize_bound_equality_given2(self):
         """ \


### PR DESCRIPTION
This adds a test with a vector constraint for SLSQP and a fix to correctly handle this. The bug was introduced in my earlier work on that function.
