### PR TITLE
ENH: binned statistics

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -322,6 +322,7 @@ from stats import *
 from distributions import *
 from rv import *
 from morestats import *
+from _binned_statistic import *
 from kde import gaussian_kde
 import mstats
 from contingency import chi2_contingency

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -1,0 +1,360 @@
+import numpy as np
+
+
+def binned_statistic(x, values, statistic='mean',
+                     bins=10, range=None):
+    """
+    Compute a binned statistic for a set of data.
+
+    This is a generalization of a histogram function.  A histogram divides
+    the space into bins, and returns the count of the number of points in
+    each bin.  This function allows the computation of the sum, mean, median,
+    or other statistic of the values within each bin.
+
+    Parameters
+    ----------
+    x : array_like
+        A sequence of values to be binned.
+    values : array_like
+        The values on which the statistic will be computed.  This must be
+        the same shape as x.
+    statistic : string or callable, optional
+        The statistic to compute (default is 'mean').
+        The following statistics are available:
+
+          * 'mean' : compute the mean of values for points within each bin.
+            Empty bins will be represented by NaN.
+          * 'median' : compute the median of values for points within each
+            bin. Empty bins will be represented by NaN.
+          * 'count' : compute the count of points within each bin.  This is
+            identical to an unweighted histogram.  `values` array is not
+            referenced.
+          * 'sum' : compute the sum of values for points within each bin.
+            This is identical to a weighted histogram.
+          * function : a user-defined function which takes a 1D array of
+            values, and outputs a single numerical statistic. This function
+            will be called on the values in each bin.  Empty bins will be
+            represented by function([]), or NaN if this returns an error.
+
+    bins : int or sequence of scalars, optional
+        If `bins` is an int, it defines the number of equal-width
+        bins in the given range (10, by default). If `bins` is a sequence,
+        it defines the bin edges, including the rightmost edge, allowing
+        for non-uniform bin widths.
+    range : (float, float), optional
+        The lower and upper range of the bins.  If not provided, range
+        is simply ``(x.min(), x.max())``.  Values outside the range are
+        ignored.
+
+    Returns
+    -------
+    statistic : array
+        The values of the selected statistic in each bin.
+    bin_edges : array of dtype float
+        Return the bin edges ``(length(statistic)+1)``.
+
+    Notes
+    -----
+    All but the last (righthand-most) bin is half-open.  In other words, if
+    `bins` is::
+
+      [1, 2, 3, 4]
+
+    then the first bin is ``[1, 2)`` (including 1, but excluding 2) and the
+    second ``[2, 3)``.  The last bin, however, is ``[3, 4]``, which *includes*
+    4.
+
+    Examples
+    --------
+    >>> binned_statistic([1,2,1], bins=[0,1,2,3], 'count')
+    (array([0, 2, 1]), array([0, 1, 2, 3]))\
+
+    See Also
+    --------
+    np.histogram, binned_statistic_2d, binned_statistic_dd
+    """
+    try:
+        N = len(bins)
+    except TypeError:
+        N = 1
+
+    if N != 1:
+        bins = [np.asarray(bins, float)]
+
+    medians, edges = binned_statistic_dd([x], values, statistic,
+                                         bins, range)
+
+    return medians, edges[0]
+
+
+def binned_statistic_2d(x, y, values, statistic='mean',
+                        bins=10, range=None):
+    """
+    Compute a bidimensional binned statistic for a set of data.
+
+    This is a generalization of a histogram2d function.  A histogram divides
+    the space into bins, and returns the count of the number of points in
+    each bin.  This function allows the computation of the sum, mean, median,
+    or other statistic of the values within each bin.
+
+    Parameters
+    ----------
+    x : array_like
+        A sequence of values to be binned along the first dimension.
+    y : array_like
+        A sequence of values to be binned along the second dimension.
+    values : array_like
+        The values on which the statistic will be computed.  This must be
+        the same shape as x.
+    statistic : string or callable, optional
+        The statistic to compute (default is 'mean').
+        The following statistics are available:
+
+          * 'mean' : compute the mean of values for points within each bin.
+            Empty bins will be represented by NaN.
+          * 'median' : compute the median of values for points within each
+            bin. Empty bins will be represented by NaN.
+          * 'count' : compute the count of points within each bin.  This is
+            identical to an unweighted histogram.  `values` array is not
+            referenced.
+          * 'sum' : compute the sum of values for points within each bin.
+            This is identical to a weighted histogram.
+          * function : a user-defined function which takes a 1D array of
+            values, and outputs a single numerical statistic. This function
+            will be called on the values in each bin.  Empty bins will be
+            represented by function([]), or NaN if this returns an error.
+
+    bins : int or [int, int] or array-like or [array, array], optional
+        The bin specification:
+
+          * the number of bins for the two dimensions (nx=ny=bins),
+          * the number of bins in each dimension (nx, ny = bins),
+          * the bin edges for the two dimensions (x_edges=y_edges=bins),
+          * the bin edges in each dimension (x_edges, y_edges = bins).
+
+    range : array_like, shape(2,2), optional
+        The leftmost and rightmost edges of the bins along each dimension
+        (if not specified explicitly in the `bins` parameters):
+        [[xmin, xmax], [ymin, ymax]]. All values outside of this range will be
+        considered outliers and not tallied in the histogram.
+
+    Returns
+    -------
+    statistic : ndarray, shape(nx, ny)
+        The values of the selected statistic in each two-dimensional bin
+    xedges : ndarray, shape(nx + 1,)
+      The bin edges along the first dimension.
+    yedges : ndarray, shape(ny + 1,)
+      The bin edges along the second dimension.
+
+    See Also
+    --------
+    np.histogram2d, binned_statistic, binned_statistic_dd
+    """
+
+    # This code is based on np.histogram2d
+    try:
+        N = len(bins)
+    except TypeError:
+        N = 1
+
+    if N != 1 and N != 2:
+        xedges = yedges = np.asarray(bins, float)
+        bins = [xedges, yedges]
+
+    medians, edges = binned_statistic_dd([x, y], values, statistic,
+                                         bins, range)
+
+    return medians, edges[0], edges[1]
+
+
+def binned_statistic_dd(sample, values, statistic='mean',
+                        bins=10, range=None):
+    """
+    Compute a multidimensional binned statistic for a set of data.
+
+    This is a generalization of a histogramdd function.  A histogram divides
+    the space into bins, and returns the count of the number of points in
+    each bin.  This function allows the computation of the sum, mean, median,
+    or other statistic of the values within each bin.
+
+    Parameters
+    ----------
+    sample : array_like
+        Data to histogram passed as a sequence of D arrays of length N, or
+        as an (N,D) array.
+    values : array_like
+        The values on which the statistic will be computed.  This must be
+        the same shape as x.
+    statistic : string or callable, optional
+        The statistic to compute (default is 'mean').
+        The following statistics are available:
+
+          * 'mean' : compute the mean of values for points within each bin.
+            Empty bins will be represented by NaN.
+          * 'median' : compute the median of values for points within each
+            bin. Empty bins will be represented by NaN.
+          * 'count' : compute the count of points within each bin.  This is
+            identical to an unweighted histogram.  `values` array is not
+            referenced.
+          * 'sum' : compute the sum of values for points within each bin.
+            This is identical to a weighted histogram.
+          * function : a user-defined function which takes a 1D array of
+            values, and outputs a single numerical statistic. This function
+            will be called on the values in each bin.  Empty bins will be
+            represented by function([]), or NaN if this returns an error.
+
+    bins : sequence or int, optional
+        The bin specification:
+
+          * A sequence of arrays describing the bin edges along each dimension.
+          * The number of bins for each dimension (nx, ny, ... =bins)
+          * The number of bins for all dimensions (nx=ny=...=bins).
+
+    range : sequence, optional
+        A sequence of lower and upper bin edges to be used if the edges are
+        not given explicitely in `bins`. Defaults to the minimum and maximum
+        values along each dimension.
+
+    Returns
+    -------
+    statistic : ndarray, shape(nx1, nx2, nx3,...)
+        The values of the selected statistic in each two-dimensional bin
+    edges : list of ndarrays
+        A list of D arrays describing the (nxi + 1) bin edges for each
+        dimension
+
+    See Also
+    --------
+    np.histogramdd, binned_statistic, binned_statistic_2d
+    """
+    if type(statistic) == str:
+        if statistic not in ['mean', 'median', 'count', 'sum']:
+            raise ValueError('unrecognized statistic "%s"' % statistic)
+    elif callable(statistic):
+        pass
+    else:
+        raise ValueError("statistic not understood")
+
+    # This code is based on np.histogramdd
+    try:
+        # Sample is an ND-array.
+        N, D = sample.shape
+    except (AttributeError, ValueError):
+        # Sample is a sequence of 1D arrays.
+        sample = np.atleast_2d(sample).T
+        N, D = sample.shape
+
+    nbin = np.empty(D, int)
+    edges = D * [None]
+    dedges = D * [None]
+
+    try:
+        M = len(bins)
+        if M != D:
+            raise AttributeError('The dimension of bins must be equal '
+                                 'to the dimension of the sample x.')
+    except TypeError:
+        bins = D * [bins]
+
+    # Select range for each dimension
+    # Used only if number of bins is given.
+    if range is None:
+        smin = np.atleast_1d(np.array(sample.min(0), float))
+        smax = np.atleast_1d(np.array(sample.max(0), float))
+    else:
+        smin = np.zeros(D)
+        smax = np.zeros(D)
+        for i in np.arange(D):
+            smin[i], smax[i] = range[i]
+
+    # Make sure the bins have a finite width.
+    for i in np.arange(len(smin)):
+        if smin[i] == smax[i]:
+            smin[i] = smin[i] - .5
+            smax[i] = smax[i] + .5
+
+    # Create edge arrays
+    for i in np.arange(D):
+        if np.isscalar(bins[i]):
+            nbin[i] = bins[i] + 2  # +2 for outlier bins
+            edges[i] = np.linspace(smin[i], smax[i], nbin[i] - 1)
+        else:
+            edges[i] = np.asarray(bins[i], float)
+            nbin[i] = len(edges[i]) + 1  # +1 for outlier bins
+        dedges[i] = np.diff(edges[i])
+
+    nbin = np.asarray(nbin)
+
+    # Compute the bin number each sample falls into.
+    Ncount = {}
+    for i in np.arange(D):
+        Ncount[i] = np.digitize(sample[:, i], edges[i])
+
+    # Using digitize, values that fall on an edge are put in the right bin.
+    # For the rightmost bin, we want values equal to the right
+    # edge to be counted in the last bin, and not as an outlier.
+    outliers = np.zeros(N, int)
+    for i in np.arange(D):
+        # Rounding precision
+        decimal = int(-np.log10(dedges[i].min())) + 6
+        # Find which points are on the rightmost edge.
+        on_edge = np.where(np.around(sample[:, i], decimal)
+                           == np.around(edges[i][-1], decimal))[0]
+        # Shift these points one bin to the left.
+        Ncount[i][on_edge] -= 1
+
+    # Compute the sample indices in the flattened statistic matrix.
+    ni = nbin.argsort()
+    shape = []
+    xy = np.zeros(N, int)
+    for i in np.arange(0, D - 1):
+        xy += Ncount[ni[i]] * nbin[ni[i + 1:]].prod()
+    xy += Ncount[ni[-1]]
+
+    result = np.empty(nbin.prod(), float)
+
+    if statistic == 'mean':
+        result.fill(np.nan)
+        flatcount = np.bincount(xy, None)
+        flatsum = np.bincount(xy, values)
+        a = np.arange(len(flatcount))
+        result[a] = flatsum
+        result[a] /= flatcount
+    elif statistic == 'count':
+        result.fill(0)
+        flatcount = np.bincount(xy, None)
+        a = np.arange(len(flatcount))
+        result[a] = flatcount
+    elif statistic == 'sum':
+        result.fill(0)
+        flatsum = np.bincount(xy, values)
+        a = np.arange(len(flatsum))
+        result[a] = flatsum
+    elif statistic == 'median':
+        result.fill(np.nan)
+        for i in np.unique(xy):
+            result[i] = np.median(values[xy == i])
+    elif callable(statistic):
+        try:
+            null = statistic([])
+        except:
+            null = np.nan
+        result.fill(null)
+        for i in np.unique(xy):
+            result[i] = statistic(values[xy == i])
+
+    # Shape into a proper matrix
+    result = result.reshape(np.sort(nbin))
+    for i in np.arange(nbin.size):
+        j = ni.argsort()[i]
+        result = result.swapaxes(i, j)
+        ni[i], ni[j] = ni[j], ni[i]
+
+    # Remove outliers (indices 0 and -1 for each dimension).
+    core = D * [slice(1, -1)]
+    result = result[core]
+
+    if (result.shape != nbin - 2).any():
+        raise RuntimeError('Internal Shape Error')
+    return result, edges

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -343,10 +343,12 @@ def binned_statistic_dd(sample, values, statistic='mean',
         for i in np.unique(xy):
             result[i] = np.median(values[xy == i])
     elif callable(statistic):
+        old = np.seterr(invalid='ignore')
         try:
             null = statistic([])
         except:
             null = np.nan
+        np.seterr(**old)
         result.fill(null)
         for i in np.unique(xy):
             result[i] = statistic(values[xy == i])

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -229,7 +229,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
     np.histogramdd, binned_statistic, binned_statistic_2d
     """
     if type(statistic) == str:
-        if statistic not in ['mean', 'median', 'count', 'sum']:
+        if statistic not in ['mean', 'median', 'count', 'sum', 'std']:
             raise ValueError('unrecognized statistic "%s"' % statistic)
     elif callable(statistic):
         pass
@@ -318,9 +318,16 @@ def binned_statistic_dd(sample, values, statistic='mean',
         result.fill(np.nan)
         flatcount = np.bincount(xy, None)
         flatsum = np.bincount(xy, values)
-        a = np.arange(len(flatcount))
-        result[a] = flatsum
-        result[a] /= flatcount
+        a = (flatcount > 0)
+        result[a] = flatsum[a] / flatcount[a]
+    elif statistic == 'std':
+        result.fill(0)
+        flatcount = np.bincount(xy, None)
+        flatsum = np.bincount(xy, values)
+        flatsum2 = np.bincount(xy, values ** 2)
+        a = (flatcount > 0)
+        result[a] = np.sqrt(flatsum2[a] / flatcount[a]
+                            - (flatsum[a] / flatcount[a]) ** 2)
     elif statistic == 'count':
         result.fill(0)
         flatcount = np.bincount(xy, None)

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -1,0 +1,144 @@
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+from scipy.stats import \
+    binned_statistic, binned_statistic_2d, binned_statistic_dd
+
+
+def test_1d_count():
+    x = np.random.random(100)
+    v = np.random.random(100)
+
+    count1, edges1 = binned_statistic(x, v, 'count', bins=10)
+    count2, edges2 = np.histogram(x, bins=10)
+
+    assert_array_almost_equal(count1, count2)
+    assert_array_almost_equal(edges1, edges2)
+
+
+def test_1d_sum():
+    x = np.random.random(100)
+    v = np.random.random(100)
+
+    sum1, edges1 = binned_statistic(x, v, 'sum', bins=10)
+    sum2, edges2 = np.histogram(x, bins=10, weights=v)
+
+    assert_array_almost_equal(sum1, sum2)
+    assert_array_almost_equal(edges1, edges2)
+
+
+def test_1d_mean():
+    x = np.random.random(100)
+    v = np.random.random(100)
+
+    stat1, edges1 = binned_statistic(x, v, 'mean', bins=10)
+    stat2, edges2 = binned_statistic(x, v, np.mean, bins=10)
+
+    assert_array_almost_equal(stat1, stat2)
+    assert_array_almost_equal(edges1, edges2)
+
+
+def test_1d_median():
+    x = np.random.random(100)
+    v = np.random.random(100)
+
+    stat1, edges1 = binned_statistic(x, v, 'median', bins=10)
+    stat2, edges2 = binned_statistic(x, v, np.median, bins=10)
+
+    assert_array_almost_equal(stat1, stat2)
+    assert_array_almost_equal(edges1, edges2)
+
+
+def test_2d_count():
+    x = np.random.random(100)
+    y = np.random.random(100)
+    v = np.random.random(100)
+
+    count1, binx1, biny1 = binned_statistic_2d(x, y, v, 'count', bins=5)
+    count2, binx2, biny2 = np.histogram2d(x, y, bins=5)
+
+    assert_array_almost_equal(count1, count2)
+    assert_array_almost_equal(binx1, binx2)
+    assert_array_almost_equal(biny1, biny2)
+
+
+def test_2d_sum():
+    x = np.random.random(100)
+    y = np.random.random(100)
+    v = np.random.random(100)
+
+    sum1, binx1, biny1 = binned_statistic_2d(x, y, v, 'sum', bins=5)
+    sum2, binx2, biny2 = np.histogram2d(x, y, bins=5, weights=v)
+
+    assert_array_almost_equal(sum1, sum2)
+    assert_array_almost_equal(binx1, binx2)
+    assert_array_almost_equal(biny1, biny2)
+
+
+def test_2d_mean():
+    x = np.random.random(100)
+    y = np.random.random(100)
+    v = np.random.random(100)
+
+    stat1, binx1, biny1 = binned_statistic_2d(x, y, v, 'mean', bins=5)
+    stat2, binx2, biny2 = binned_statistic_2d(x, y, v, np.mean, bins=5)
+
+    assert_array_almost_equal(stat1, stat2)
+    assert_array_almost_equal(binx1, binx2)
+    assert_array_almost_equal(biny1, biny2)
+
+
+def test_2d_median():
+    x = np.random.random(100)
+    y = np.random.random(100)
+    v = np.random.random(100)
+
+    stat1, binx1, biny1 = binned_statistic_2d(x, y, v, 'median', bins=5)
+    stat2, binx2, biny2 = binned_statistic_2d(x, y, v, np.median, bins=5)
+
+    assert_array_almost_equal(stat1, stat2)
+    assert_array_almost_equal(binx1, binx2)
+    assert_array_almost_equal(biny1, biny2)
+
+
+def test_dd_count():
+    X = np.random.random((100, 3))
+    v = np.random.random(100)
+
+    count1, edges1 = binned_statistic_dd(X, v, 'count', bins=3)
+    count2, edges2 = np.histogramdd(X, bins=3)
+
+    assert_array_almost_equal(count1, count2)
+    assert_array_almost_equal(edges1, edges2)
+
+
+def test_dd_sum():
+    X = np.random.random((100, 3))
+    v = np.random.random(100)
+
+    sum1, edges1 = binned_statistic_dd(X, v, 'sum', bins=3)
+    sum2, edges2 = np.histogramdd(X, bins=3, weights=v)
+
+    assert_array_almost_equal(sum1, sum2)
+    assert_array_almost_equal(edges1, edges2)
+
+
+def test_dd_mean():
+    X = np.random.random((100, 3))
+    v = np.random.random(100)
+
+    stat1, edges1 = binned_statistic_dd(X, v, 'mean', bins=3)
+    stat2, edges2 = binned_statistic_dd(X, v, np.mean, bins=3)
+
+    assert_array_almost_equal(stat1, stat2)
+    assert_array_almost_equal(edges1, edges2)
+
+
+def test_dd_median():
+    X = np.random.random((100, 3))
+    v = np.random.random(100)
+
+    stat1, edges1 = binned_statistic_dd(X, v, 'median', bins=3)
+    stat2, edges2 = binned_statistic_dd(X, v, np.median, bins=3)
+
+    assert_array_almost_equal(stat1, stat2)
+    assert_array_almost_equal(edges1, edges2)

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -46,6 +46,17 @@ class TestBinnedStatistic(object):
         assert_array_almost_equal(edges1, edges2)
 
 
+    def test_1d_std(self):
+        x = self.x
+        v = self.v
+
+        stat1, edges1 = binned_statistic(x, v, 'std', bins=10)
+        stat2, edges2 = binned_statistic(x, v, np.std, bins=10)
+
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(edges1, edges2)
+
+
     def test_1d_median(self):
         x = self.x
         v = self.v
@@ -96,6 +107,19 @@ class TestBinnedStatistic(object):
         assert_array_almost_equal(biny1, biny2)
 
 
+    def test_2d_std(self):
+        x = self.x
+        y = self.y
+        v = self.v
+
+        stat1, binx1, biny1 = binned_statistic_2d(x, y, v, 'std', bins=5)
+        stat2, binx2, biny2 = binned_statistic_2d(x, y, v, np.std, bins=5)
+
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(binx1, binx2)
+        assert_array_almost_equal(biny1, biny2)
+
+
     def test_2d_median(self):
         x = self.x
         y = self.y
@@ -138,6 +162,17 @@ class TestBinnedStatistic(object):
 
         stat1, edges1 = binned_statistic_dd(X, v, 'mean', bins=3)
         stat2, edges2 = binned_statistic_dd(X, v, np.mean, bins=3)
+
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(edges1, edges2)
+
+
+    def test_dd_std(self):
+        X = self.X
+        v = self.v
+
+        stat1, edges1 = binned_statistic_dd(X, v, 'std', bins=3)
+        stat2, edges2 = binned_statistic_dd(X, v, np.std, bins=3)
 
         assert_array_almost_equal(stat1, stat2)
         assert_array_almost_equal(edges1, edges2)

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -3,142 +3,152 @@ from numpy.testing import assert_array_almost_equal
 from scipy.stats import \
     binned_statistic, binned_statistic_2d, binned_statistic_dd
 
+class TestBinnedStatistic(object):
 
-def test_1d_count():
-    x = np.random.random(100)
-    v = np.random.random(100)
+    @classmethod
+    def setup_class(cls):
+        np.random.seed(9865)
+        cls.x = np.random.random(100)
+        cls.y = np.random.random(100)
+        cls.v = np.random.random(100)
+        cls.X = np.random.random((100, 3))
 
-    count1, edges1 = binned_statistic(x, v, 'count', bins=10)
-    count2, edges2 = np.histogram(x, bins=10)
+    def test_1d_count(self):
+        x = self.x
+        v = self.v
 
-    assert_array_almost_equal(count1, count2)
-    assert_array_almost_equal(edges1, edges2)
+        count1, edges1 = binned_statistic(x, v, 'count', bins=10)
+        count2, edges2 = np.histogram(x, bins=10)
 
-
-def test_1d_sum():
-    x = np.random.random(100)
-    v = np.random.random(100)
-
-    sum1, edges1 = binned_statistic(x, v, 'sum', bins=10)
-    sum2, edges2 = np.histogram(x, bins=10, weights=v)
-
-    assert_array_almost_equal(sum1, sum2)
-    assert_array_almost_equal(edges1, edges2)
+        assert_array_almost_equal(count1, count2)
+        assert_array_almost_equal(edges1, edges2)
 
 
-def test_1d_mean():
-    x = np.random.random(100)
-    v = np.random.random(100)
+    def test_1d_sum(self):
+        x = self.x
+        v = self.v
 
-    stat1, edges1 = binned_statistic(x, v, 'mean', bins=10)
-    stat2, edges2 = binned_statistic(x, v, np.mean, bins=10)
+        sum1, edges1 = binned_statistic(x, v, 'sum', bins=10)
+        sum2, edges2 = np.histogram(x, bins=10, weights=v)
 
-    assert_array_almost_equal(stat1, stat2)
-    assert_array_almost_equal(edges1, edges2)
-
-
-def test_1d_median():
-    x = np.random.random(100)
-    v = np.random.random(100)
-
-    stat1, edges1 = binned_statistic(x, v, 'median', bins=10)
-    stat2, edges2 = binned_statistic(x, v, np.median, bins=10)
-
-    assert_array_almost_equal(stat1, stat2)
-    assert_array_almost_equal(edges1, edges2)
+        assert_array_almost_equal(sum1, sum2)
+        assert_array_almost_equal(edges1, edges2)
 
 
-def test_2d_count():
-    x = np.random.random(100)
-    y = np.random.random(100)
-    v = np.random.random(100)
+    def test_1d_mean(self):
+        x = self.x
+        v = self.v
 
-    count1, binx1, biny1 = binned_statistic_2d(x, y, v, 'count', bins=5)
-    count2, binx2, biny2 = np.histogram2d(x, y, bins=5)
+        stat1, edges1 = binned_statistic(x, v, 'mean', bins=10)
+        stat2, edges2 = binned_statistic(x, v, np.mean, bins=10)
 
-    assert_array_almost_equal(count1, count2)
-    assert_array_almost_equal(binx1, binx2)
-    assert_array_almost_equal(biny1, biny2)
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(edges1, edges2)
 
 
-def test_2d_sum():
-    x = np.random.random(100)
-    y = np.random.random(100)
-    v = np.random.random(100)
+    def test_1d_median(self):
+        x = self.x
+        v = self.v
 
-    sum1, binx1, biny1 = binned_statistic_2d(x, y, v, 'sum', bins=5)
-    sum2, binx2, biny2 = np.histogram2d(x, y, bins=5, weights=v)
+        stat1, edges1 = binned_statistic(x, v, 'median', bins=10)
+        stat2, edges2 = binned_statistic(x, v, np.median, bins=10)
 
-    assert_array_almost_equal(sum1, sum2)
-    assert_array_almost_equal(binx1, binx2)
-    assert_array_almost_equal(biny1, biny2)
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(edges1, edges2)
 
 
-def test_2d_mean():
-    x = np.random.random(100)
-    y = np.random.random(100)
-    v = np.random.random(100)
+    def test_2d_count(self):
+        x = self.x
+        y = self.y
+        v = self.v
 
-    stat1, binx1, biny1 = binned_statistic_2d(x, y, v, 'mean', bins=5)
-    stat2, binx2, biny2 = binned_statistic_2d(x, y, v, np.mean, bins=5)
+        count1, binx1, biny1 = binned_statistic_2d(x, y, v, 'count', bins=5)
+        count2, binx2, biny2 = np.histogram2d(x, y, bins=5)
 
-    assert_array_almost_equal(stat1, stat2)
-    assert_array_almost_equal(binx1, binx2)
-    assert_array_almost_equal(biny1, biny2)
-
-
-def test_2d_median():
-    x = np.random.random(100)
-    y = np.random.random(100)
-    v = np.random.random(100)
-
-    stat1, binx1, biny1 = binned_statistic_2d(x, y, v, 'median', bins=5)
-    stat2, binx2, biny2 = binned_statistic_2d(x, y, v, np.median, bins=5)
-
-    assert_array_almost_equal(stat1, stat2)
-    assert_array_almost_equal(binx1, binx2)
-    assert_array_almost_equal(biny1, biny2)
+        assert_array_almost_equal(count1, count2)
+        assert_array_almost_equal(binx1, binx2)
+        assert_array_almost_equal(biny1, biny2)
 
 
-def test_dd_count():
-    X = np.random.random((100, 3))
-    v = np.random.random(100)
+    def test_2d_sum(self):
+        x = self.x
+        y = self.y
+        v = self.v
 
-    count1, edges1 = binned_statistic_dd(X, v, 'count', bins=3)
-    count2, edges2 = np.histogramdd(X, bins=3)
+        sum1, binx1, biny1 = binned_statistic_2d(x, y, v, 'sum', bins=5)
+        sum2, binx2, biny2 = np.histogram2d(x, y, bins=5, weights=v)
 
-    assert_array_almost_equal(count1, count2)
-    assert_array_almost_equal(edges1, edges2)
-
-
-def test_dd_sum():
-    X = np.random.random((100, 3))
-    v = np.random.random(100)
-
-    sum1, edges1 = binned_statistic_dd(X, v, 'sum', bins=3)
-    sum2, edges2 = np.histogramdd(X, bins=3, weights=v)
-
-    assert_array_almost_equal(sum1, sum2)
-    assert_array_almost_equal(edges1, edges2)
+        assert_array_almost_equal(sum1, sum2)
+        assert_array_almost_equal(binx1, binx2)
+        assert_array_almost_equal(biny1, biny2)
 
 
-def test_dd_mean():
-    X = np.random.random((100, 3))
-    v = np.random.random(100)
+    def test_2d_mean(self):
+        x = self.x
+        y = self.y
+        v = self.v
 
-    stat1, edges1 = binned_statistic_dd(X, v, 'mean', bins=3)
-    stat2, edges2 = binned_statistic_dd(X, v, np.mean, bins=3)
+        stat1, binx1, biny1 = binned_statistic_2d(x, y, v, 'mean', bins=5)
+        stat2, binx2, biny2 = binned_statistic_2d(x, y, v, np.mean, bins=5)
 
-    assert_array_almost_equal(stat1, stat2)
-    assert_array_almost_equal(edges1, edges2)
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(binx1, binx2)
+        assert_array_almost_equal(biny1, biny2)
 
 
-def test_dd_median():
-    X = np.random.random((100, 3))
-    v = np.random.random(100)
+    def test_2d_median(self):
+        x = self.x
+        y = self.y
+        v = self.v
 
-    stat1, edges1 = binned_statistic_dd(X, v, 'median', bins=3)
-    stat2, edges2 = binned_statistic_dd(X, v, np.median, bins=3)
+        stat1, binx1, biny1 = binned_statistic_2d(x, y, v, 'median', bins=5)
+        stat2, binx2, biny2 = binned_statistic_2d(x, y, v, np.median, bins=5)
 
-    assert_array_almost_equal(stat1, stat2)
-    assert_array_almost_equal(edges1, edges2)
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(binx1, binx2)
+        assert_array_almost_equal(biny1, biny2)
+
+
+    def test_dd_count(self):
+        X = self.X
+        v = self.v
+
+        count1, edges1 = binned_statistic_dd(X, v, 'count', bins=3)
+        count2, edges2 = np.histogramdd(X, bins=3)
+
+        assert_array_almost_equal(count1, count2)
+        assert_array_almost_equal(edges1, edges2)
+
+
+    def test_dd_sum(self):
+        print "dd_sum"
+        X = self.X
+        v = self.v
+
+        sum1, edges1 = binned_statistic_dd(X, v, 'sum', bins=3)
+        sum2, edges2 = np.histogramdd(X, bins=3, weights=v)
+
+        assert_array_almost_equal(sum1, sum2)
+        assert_array_almost_equal(edges1, edges2)
+
+
+    def test_dd_mean(self):
+        X = self.X
+        v = self.v
+
+        stat1, edges1 = binned_statistic_dd(X, v, 'mean', bins=3)
+        stat2, edges2 = binned_statistic_dd(X, v, np.mean, bins=3)
+
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(edges1, edges2)
+
+
+    def test_dd_median(self):
+        X = self.X
+        v = self.v
+
+        stat1, edges1 = binned_statistic_dd(X, v, 'median', bins=3)
+        stat2, edges2 = binned_statistic_dd(X, v, np.median, bins=3)
+
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(edges1, edges2)


### PR DESCRIPTION
This PR adds some functions to the stats module to perform binned statistics: essentially a generalization of the histogram functions.  Where `np.histogram` bins the data and counts the points per bin, `binned_statistic` bins the data and computes the sum, mean, median, or user-defined statistic of the values of points within each bin.

I developed this code for an astronomy datamining package I'm working on.  I thought it might be useful to include in scipy.
