### PR TITLE
Fix build for py3k and pip inside a virtualenv.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,20 @@ def setup_package():
         if os.path.isfile(site_cfg):
             shutil.copy(site_cfg, src_path)
 
+        # Ugly hack to make pip work with Python 3
+        # Explanation: pip messes with __file__ which interacts badly with the
+        # change in directory due to the 2to3 conversion.  Therefore we restore
+        # __file__ to what it would have been otherwise.
+
+        global __file__
+        __file__ = os.path.join(os.curdir, os.path.basename(__file__))
+        if '--egg-base' in sys.argv:
+            # Change pip-egg-info entry to absolute path, so pip can find it
+            # after changing directory.
+            idx = sys.argv.index('--egg-base')
+            if sys.argv[idx + 1] == 'pip-egg-info':
+                sys.argv[idx + 1] = os.path.join(local_path, 'pip-egg-info')
+
     os.chdir(local_path)
     sys.path.insert(0, local_path)
     sys.path.insert(0, os.path.join(local_path, 'scipy'))  # to retrieve version


### PR DESCRIPTION
pip installing SciPy within a virtualenv with Python 3.2 fails with the following error:
`ValueError: 'build/py3k/scipy' is not a directory`

Earlier versions of Python 3k are probably affected, though I didn't test.

This patch is really just a port of the numpy patch, since numpy suffered from the same issue: https://github.com/numpy/numpy/commit/dba98cc1.
