### PR TITLE
Revert "ENH: optimize/minimize: combine hess and hessp parameters" (#161...

### DIFF
--- a/scipy/optimize/minimize.py
+++ b/scipy/optimize/minimize.py
@@ -24,7 +24,7 @@ from cobyla import _minimize_cobyla
 from slsqp import _minimize_slsqp
 
 def minimize(fun, x0, args=(), method='BFGS', jac=None, hess=None,
-             bounds=None, constraints=(),
+             hessp=None, bounds=None, constraints=(),
              options=dict(), full_output=False, callback=None,
              retall=False):
     """
@@ -46,13 +46,14 @@ def minimize(fun, x0, args=(), method='BFGS', jac=None, hess=None,
     jac : callable, optional
         Jacobian of objective function (if None, Jacobian will be
         estimated numerically). Only for CG, BFGS, Newton-CG.
-    hess : callable, optional
-        Hessian of objective function. Only for Newton-CG.
-        The function `hess` can either return the Hessian matrix of `fun`
-        or the Hessian matrix times an arbitrary vector, in which case
-        it accepts an extra argument `p` as `hess(x, p, *args)`.
-        If `hess` is None, the Hessian will be approximated using finite
-        differences on `jac`.
+    hess, hessp : callable, optional
+        Hessian of objective function or Hessian of objective function
+        times an arbitrary vector p.  Only for Newton-CG.
+        Only one of `hessp` or `hess` needs to be given.  If `hess` is
+        provided, then `hessp` will be ignored.  If neither `hess` nor
+        `hessp` is provided, then the hessian product will be approximated
+        using finite differences on `jac`. `hessp` must compute the Hessian
+        times an arbitrary vector.
     bounds : sequence, optional
         Bounds for variables (only for L-BFGS-B, TNC, COBYLA and SLSQP).
         ``(min, max)`` pairs for each element in ``x``, defining
@@ -327,7 +328,7 @@ def minimize(fun, x0, args=(), method='BFGS', jac=None, hess=None,
         return _minimize_bfgs(fun, x0, args, jac, options, full_output,
                               retall, callback)
     elif meth == 'newton-cg':
-        return _minimize_newtoncg(fun, x0, args, jac, hess, options,
+        return _minimize_newtoncg(fun, x0, args, jac, hess, hessp, options,
                                   full_output, retall, callback)
     elif meth == 'anneal':
         return _minimize_anneal(fun, x0, args, options, full_output)

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -28,7 +28,6 @@ from numpy import atleast_1d, eye, mgrid, argmin, zeros, shape, \
 from linesearch import \
      line_search_BFGS, line_search_wolfe1, line_search_wolfe2, \
      line_search_wolfe2 as line_search
-import inspect
 
 
 # standard status messages of optimizers
@@ -1149,20 +1148,13 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
             'maxiter': maxiter,
             'disp': disp}
 
-    if fhess is not None:
-        hess = fhess
-    elif fhess_p is not None:
-        hess = fhess_p
-    else:
-        hess = None
-
     # force full_output if retall=True to preserve backwards compatibility
     if retall and not full_output:
-        out = _minimize_newtoncg(f, x0, args, fprime, hess, opts,
+        out = _minimize_newtoncg(f, x0, args, fprime, fhess, fhess_p, opts,
                                  full_output=True, retall=retall,
                                  callback=callback)
     else:
-        out = _minimize_newtoncg(f, x0, args, fprime, hess, opts,
+        out = _minimize_newtoncg(f, x0, args, fprime, fhess, fhess_p, opts,
                                  full_output, retall, callback)
 
     if full_output:
@@ -1179,7 +1171,7 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
         else:
             return out
 
-def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None,
+def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
                        options={}, full_output=0, retall=0, callback=None):
     """
     Minimization of scalar function of one or more variables using the
@@ -1205,23 +1197,8 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None,
         raise ValueError('Jacobian is required for Newton-CG method')
     f = fun
     fprime = jac
-    if hess is None:
-        fhess = None
-        fhess_p = None
-    else:
-        # check hessian type based on the number of arguments
-        fun_args = inspect.getargspec(fun)[0]
-        hess_args = inspect.getargspec(hess)[0]
-        if len(hess_args) == len(fun_args):
-            fhess = hess
-            fhess_p = None
-        elif len(hess_args) == len(fun_args) + 1:
-            fhess = None
-            fhess_p = hess
-        else:
-            raise ValueError('The number of arguments of the Hessian '
-                             'function does not agree with that of the '
-                             'objective function.')
+    fhess_p = hessp
+    fhess = hess
     # retrieve useful options
     avextol = options.get('xtol', 1e-5)
     epsilon = options.get('eps', _epsilon)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -324,7 +324,7 @@ class TestOptimize(TestCase):
             opts = {'maxit': self.maxiter, 'disp': False}
             retval = optimize.minimize(self.func, self.startparams,
                                        method='Newton-CG', jac=self.grad,
-                                       hess = self.hessp,
+                                       hessp = self.hessp,
                                        args=(), options=opts,
                                        full_output=False, retall=False)
         else:


### PR DESCRIPTION
...7)

This reverts commit c5f12acf3910068c94d8caa5360e041bbcb47912.

Conflicts:

```
scipy/optimize/minimize.py
```
