### PR TITLE
ENH: Jacobian memoization for multivariate minimization

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -40,6 +40,27 @@ _status_message = {'success': 'Optimization terminated successfully.',
                    'pr_loss': 'Desired error not necessarily achieved due '
                               'to precision loss.'}
 
+class MemoizeJac(object):
+    """ Decorator that caches the value gradient of function each time it
+    is called. """
+    def __init__(self, fun):
+        self.fun = fun
+        self.jac = None
+        self.x = None
+
+    def __call__(self, x, *args):
+        self.x = numpy.asarray(x).copy()
+        fg = self.fun(x, *args)
+        self.jac = fg[1]
+        return fg[0]
+
+    def derivative(self, x, *args):
+        if all(x == self.x) and self.jac is not None:
+            return self.jac
+        else:
+            self(x, *args)
+            return self.jac
+
 # These have been copied from Numeric's MLab.py
 # I don't think they made the transition to scipy_core
 def max(m, axis=0):

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -622,6 +622,15 @@ class TestTnc(TestCase):
                               bounds=bnds, options=self.opts)
         assert_allclose(self.f1(x), self.f1(xopt), atol=1e-4)
 
+    def test_minimize_tnc1c(self):
+        """Minimize, method=TNC, 1c (combined function and gradient)"""
+        x0, bnds = [-2, 1], ([-np.inf, None],[-1.5, None])
+        xopt = [1, 1]
+        x = optimize.minimize(self.fg1, x0, method='TNC',
+                              jac=self.fg1, bounds=bnds,
+                              options=self.opts)
+        assert_allclose(self.f1(x), self.f1(xopt), atol=1e-8)
+
     def test_minimize_tnc2(self):
         """Minimize, method=TNC, 2"""
         x0, bnds = [-2, 1], ([-np.inf, None], [1.5, None])

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -627,7 +627,7 @@ class TestTnc(TestCase):
         x0, bnds = [-2, 1], ([-np.inf, None],[-1.5, None])
         xopt = [1, 1]
         x = optimize.minimize(self.fg1, x0, method='TNC',
-                              jac=self.fg1, bounds=bnds,
+                              jac=True, bounds=bnds,
                               options=self.opts)
         assert_allclose(self.f1(x), self.f1(xopt), atol=1e-8)
 

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -96,7 +96,7 @@ class TestSLSQP(TestCase):
         Minimize, method='SLSQP': unbounded, combined function and jacobian.
         """
         x, info = minimize(self.fun_and_jac, [-1.0, 1.0], args = (-1.0, ),
-                           jac=self.fun_and_jac, method='SLSQP',
+                           jac=True, method='SLSQP',
                            options=self.opts, full_output=True)
         assert_(info['success'], info['message'])
         assert_allclose(x, [2, 1])

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -46,6 +46,9 @@ class TestSLSQP(TestCase):
         dfdy = sign*(2*x - 4*y)
         return np.array([dfdx, dfdy], float)
 
+    def fun_and_jac(self, d, sign=1.0):
+        return self.fun(d, sign), self.jac(d, sign)
+
     def f_eqcon(self, x, sign=1.0):
         """ Equality constraint """
         return np.array([x[0] - x[1]])
@@ -85,6 +88,16 @@ class TestSLSQP(TestCase):
         x, info = minimize(self.fun, [-1.0, 1.0], args = (-1.0, ),
                            jac=self.jac, method='SLSQP', options=self.opts,
                            full_output=True)
+        assert_(info['success'], info['message'])
+        assert_allclose(x, [2, 1])
+
+    def test_minimize_unbounded_combined(self):
+        """ \
+        Minimize, method='SLSQP': unbounded, combined function and jacobian.
+        """
+        x, info = minimize(self.fun_and_jac, [-1.0, 1.0], args = (-1.0, ),
+                           jac=self.fun_and_jac, method='SLSQP',
+                           options=self.opts, full_output=True)
         assert_(info['success'], info['message'])
         assert_allclose(x, [2, 1])
 

--- a/scipy/optimize/tnc.py
+++ b/scipy/optimize/tnc.py
@@ -32,6 +32,7 @@ value of the function, and whose second argument is the gradient of the function
 (as a list of values); or None, to abort the minimization.
 """
 from scipy.optimize import moduleTNC, approx_fprime
+from optimize import MemoizeJac
 from numpy import asarray, inf, array
 
 __all__ = ['fmin_tnc']
@@ -220,10 +221,8 @@ def fmin_tnc(func, x0, fprime=None, args=(), approx_grad=0,
         fun = func
         jac = None
     elif fprime is None:
-        def fun(x):
-            return func(x, *args)[0]
-        def jac(x):
-            return func(x, *args)[1]
+        fun = MemoizeJac(func)
+        jac = fun.derivative
     else:
         fun = func
         jac = fprime

--- a/scipy/optimize/tnc.py
+++ b/scipy/optimize/tnc.py
@@ -31,7 +31,7 @@ evaluate the function; and it must return either a tuple, whose first element is
 value of the function, and whose second argument is the gradient of the function
 (as a list of values); or None, to abort the minimization.
 """
-from scipy.optimize import moduleTNC
+from scipy.optimize import moduleTNC, approx_fprime
 from numpy import asarray, inf, array
 
 __all__ = ['fmin_tnc']
@@ -77,9 +77,6 @@ RCSTRINGS = {
 
 # Changes to interface made by Travis Oliphant, Apr. 2004 for inclusion in
 #  SciPy
-
-import optimize
-approx_fprime = optimize.approx_fprime
 
 def fmin_tnc(func, x0, fprime=None, args=(), approx_grad=0,
              bounds=None, epsilon=1e-8, scale=None, offset=None,


### PR DESCRIPTION
- The second commit fixes the current situation in which the objective function is evaluated twice when it also returns the jacobian in TNC and L-BFGS-B. See this [discussion](https://github.com/scipy/scipy/commit/2570a3b685fdc45e0bc5d00f27e71ba78993efad#commitcomment-1021489).
- The last one introduces support for this behavior (i.e. `fun(x, *args) -> f, fprime`) in `minimize` thus making it available for all solvers.

I'm quite new to these _memoization_ techniques so any comment very welcome.
