### PR TITLE
Two bugfixes for scipy.spatial.kdtree

### DIFF
--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -423,7 +423,7 @@ class KDTree(object):
             else:
                 raise ValueError("Requested %s nearest neighbors; acceptable numbers are integers greater than or equal to one, or None")
             for c in np.ndindex(retshape):
-                hits = self.__query(x[c], k=k, p=p, distance_upper_bound=distance_upper_bound)
+                hits = self.__query(x[c], k=k, eps=eps, p=p, distance_upper_bound=distance_upper_bound)
                 if k is None:
                     dd[c] = [d for (d,i) in hits]
                     ii[c] = [i for (d,i) in hits]
@@ -438,7 +438,7 @@ class KDTree(object):
                         ii[c] = self.n
             return dd, ii
         else:
-            hits = self.__query(x, k=k, p=p, distance_upper_bound=distance_upper_bound)
+            hits = self.__query(x, k=k, eps=eps, p=p, distance_upper_bound=distance_upper_bound)
             if k is None:
                 return [d for (d,i) in hits], [i for (d,i) in hits]
             elif k==1:

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -477,10 +477,12 @@ def test_ball_point_ints():
     x, y = np.mgrid[0:4, 0:4]
     points = zip(x.ravel(), y.ravel())
     tree = KDTree(points)
-    assert_equal([4, 8, 9, 12], tree.query_ball_point((2, 0), 1))
+    assert_equal(sorted([4, 8, 9, 12]),
+                 sorted(tree.query_ball_point((2, 0), 1)))
     points = np.asarray(points, dtype=np.float)
     tree = KDTree(points)
-    assert_equal([4, 8, 9, 12], tree.query_ball_point((2, 0), 1))
+    assert_equal(sorted([4, 8, 9, 12]),
+                 sorted(tree.query_ball_point((2, 0), 1)))
 
 
 if __name__=="__main__":


### PR DESCRIPTION
1. eps parameter to query now forwarded to internal workhorse, __query
2. in tests/test_kdtree.py function test_ball_points_int(), sort actual and
   expected results to make test case independent of (arbitrary) order of
   returned items in list.  I ran into this glitch while programming a cover
   tree class with identical API.
