### PR TITLE
BUG: smirnov -- make comparison robust to handle NaNs

### DIFF
--- a/scipy/special/cephes/kolmogorov.c
+++ b/scipy/special/cephes/kolmogorov.c
@@ -35,7 +35,9 @@ smirnov (n, e)
   int v, nn;
   double evn, omevn, p, t, c, lgamnp1;
 
-  if (n <= 0 || e < 0.0 || e > 1.0)
+  /* This comparison should assure returning NaN whenever
+     e is NaN itself.  In original || form it would proceed */
+  if (!(n > 0 && e >= 0.0 && e <= 1.0))
     return (NPY_NAN);
   if (e == 0.0) return 1.0;
   nn = (int) (floor ((double) n * (1.0 - e)));

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -12,6 +12,7 @@ import numpy as np
 from numpy import typecodes, array
 import scipy.stats as stats
 from scipy.stats.distributions import argsreduce
+import warnings
 
 def kolmogorov_check(diststr, args=(), N=20, significance=0.01):
     qtest = stats.ksoneisf(significance, N)
@@ -862,6 +863,27 @@ def test_powerlaw_stats():
         mvsk = stats.powerlaw.stats(a, moments="mvsk")
         assert_array_almost_equal(mvsk, exact_mvsk)
 
+def test_ksone_fit_freeze():
+    """Regression test for ticket #1638.
+
+    """
+    d = np.array(
+        [-0.18879233,  0.15734249,  0.18695107,  0.27908787, -0.248649,
+         -0.2171497 ,  0.12233512,  0.15126419,  0.03119282,  0.4365294 ,
+          0.08930393, -0.23509903,  0.28231224, -0.09974875, -0.25196048,
+          0.11102028,  0.1427649 ,  0.10176452,  0.18754054,  0.25826724,
+          0.05988819,  0.0531668 ,  0.21906056,  0.32106729,  0.2117662 ,
+          0.10886442,  0.09375789,  0.24583286, -0.22968366, -0.07842391,
+         -0.31195432, -0.21271196,  0.1114243 , -0.13293002,  0.01331725,
+         -0.04330977, -0.09485776, -0.28434547,  0.22245721, -0.18518199,
+         -0.10943985, -0.35243174,  0.06897665, -0.03553363, -0.0701746 ,
+         -0.06037974,  0.37670779, -0.21684405])
+
+    warnings.simplefilter('ignore', UserWarning)
+    try:
+        stats.ksone.fit(d)
+    finally:
+        warnings.simplefilter('default', UserWarning)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
any comparison (< or >=) with NaN is False, so check to belong to the range
[x,y] must be done with (>=x)&&(<=y) and not !((<x)||(>y))

This issue happens to be critical especially for big-endian architectures
leading to stalling in smirnov due to excessive looping later in the code.

References:
  http://bugs.debian.org/cgi-bin/bugreport.cgi\?bug\=653948
  http://mail.scipy.org/pipermail/scipy-dev/2012-March/017298.html
