### PR TITLE
ENH: wrapped FITPACK's sphere.f

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -98,7 +98,7 @@ Christoph Gohlke for many bug fixes and help with Windows specific issues.
 Jacob Silterra for cwt-based peak finding in scipy.signal.
 Denis Laxalde for the unified interface to minimizers in scipy.optimize.
 David Fong for the sparse LSMR solver.
-Andreas Hilboll for wrapping FITPACK's spgrid.f
+Andreas Hilboll for wrapping FITPACK's spgrid.f and sphere.f
 
 
 Institutions

--- a/doc/release/0.11.0-notes.rst
+++ b/doc/release/0.11.0-notes.rst
@@ -73,8 +73,8 @@ A function for creating Pascal matrices, ``scipy.linalg.pascal``, was added.
 
 For interpolation in spherical coordinates, the three classes
 ``scipy.interpolate.SmoothSpherBivariateSpline``, 
-``scipy.interpolate.RectBivariateSpline``, and 
-``scipy.interpolate.RectSpherBivariateSpline`` have been added.
+``scipy.interpolate.LSQSpherBivariateSpline``, and 
+``scipy.interpolate.RectSphereBivariateSpline`` have been added.
 
 
 Deprecated features

--- a/doc/release/0.11.0-notes.rst
+++ b/doc/release/0.11.0-notes.rst
@@ -68,6 +68,15 @@ A function for creating Pascal matrices, ``scipy.linalg.pascal``, was added.
 ``misc.logsumexp`` now takes an optional ``axis`` keyword argument.
 
 
+``scipy.interpolate`` improvements
+----------------------------------
+
+For interpolation in spherical coordinates, the three classes
+``scipy.interpolate.SmoothSpherBivariateSpline``, 
+``scipy.interpolate.RectBivariateSpline``, and 
+``scipy.interpolate.RectSpherBivariateSpline`` have been added.
+
+
 Deprecated features
 ===================
 

--- a/doc/release/0.11.0-notes.rst
+++ b/doc/release/0.11.0-notes.rst
@@ -72,8 +72,8 @@ A function for creating Pascal matrices, ``scipy.linalg.pascal``, was added.
 ----------------------------------
 
 For interpolation in spherical coordinates, the three classes
-``scipy.interpolate.SmoothSpherBivariateSpline``, 
-``scipy.interpolate.LSQSpherBivariateSpline``, and 
+``scipy.interpolate.SmoothSphereBivariateSpline``,
+``scipy.interpolate.LSQSphereBivariateSpline``, and
 ``scipy.interpolate.RectSphereBivariateSpline`` have been added.
 
 
@@ -92,8 +92,8 @@ Removal of ``scipy.maxentropy``
 
 The ``scipy.maxentropy`` module, which was deprecated in the 0.10.0 release,
 has been removed.  Logistic regression in scikits.learn is a good and modern
-alternative for this functionality.  
- 
+alternative for this functionality.
+
 
 Other changes
 =============

--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -100,7 +100,7 @@ For data on a grid:
    :toctree: generated/
 
    RectBivariateSpline
-   RectSpherBivariateSpline
+   RectSphereBivariateSpline
 
 For unstructured data:
 

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -706,8 +706,8 @@ ERROR. On entry, the input data are controlled on validity. The following
 _spherefit_messages[-3] = """
 WARNING. The coefficients of the spline returned have been computed as the
          minimal norm least-squares solution of a (numerically) rank
-         deficient system. (-ier) gives the rank. Especially if the rank
-         deficiency, which can be computed as 6+(nt-8)*(np-7)+ier, is large,
+         deficient system (deficiency=%i, rank=%i). Especially if the rank
+         deficiency, which is computed by 6+(nt-8)*(np-7)+ier, is large,
          the results may be inaccurate. They could also seriously depend on
          the value of eps."""
 
@@ -797,6 +797,20 @@ class SmoothSpherBivariateSpline(BivariateSpline):
         self.fp = fp
         self.tck = tt_[:nt_],tp_[:np_],c[:(nt_-4)*(np_-4)]
         self.degrees = (3, 3)
+
+    def __call__(self, theta, phi, mth='array'):
+        if min(theta) < 0. or max(theta) > np.pi:
+            raise ValueError("requested theta out of bounds.")
+        if min(phi) < 0. or max(phi) > 2. * np.pi:
+            raise ValueError("requested phi out of bounds.")
+        return super(SmoothSpherBivariateSpline, self).__call__(theta, phi,
+
+    def ev(self, theta, phi):
+        if min(theta) < 0. or max(theta) > np.pi:
+            raise ValueError("requested theta out of bounds.")
+        if min(phi) < 0. or max(phi) > 2. * np.pi:
+            raise ValueError("requested phi out of bounds.")
+        return super(SmoothSpherBivariateSpline, self).ev(theta, phi)
 
 class LSQSpherBivariateSpline(BivariateSpline):
     """ Weighted least-squares bivariate spline approximation in spherical
@@ -888,14 +902,27 @@ class LSQSpherBivariateSpline(BivariateSpline):
             pass
         elif ier < -2:
             deficiency = 6+(nt_-8)*(np_-7)+ier
-            message = _spherefit_messages.get(-3) % (deficiency)
+            message = _spherefit_messages.get(-3) % (deficiency, -ier)
         else:
             message = _spherefit_messages.get(ier,'ier=%s' % (ier))
             warnings.warn(message)
-
         self.fp = fp
         self.tck = tt_,tp_,c
         self.degrees = (3, 3)
+
+    def __call__(self, theta, phi, mth='array'):
+        if min(theta) < 0. or max(theta) > np.pi:
+            raise ValueError("requested theta out of bounds.")
+        if min(phi) < 0. or max(phi) > 2. * np.pi:
+            raise ValueError("requested phi out of bounds.")
+        return super(LSQSpherBivariateSpline, self).__call__(theta, phi, mth)
+
+    def ev(self, theta, phi):
+        if min(theta) < 0. or max(theta) > np.pi:
+            raise ValueError("requested theta out of bounds.")
+        if min(phi) < 0. or max(phi) > 2. * np.pi:
+            raise ValueError("requested phi out of bounds.")
+        return super(LSQSpherBivariateSpline, self).ev(theta, phi)
 
 class RectBivariateSpline(BivariateSpline):
     """ Bivariate spline approximation over a rectangular mesh.

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -18,7 +18,7 @@ __all__ = [
     'LSQSphereBivariateSpline',
     'SmoothSphereBivariateSpline',
     'RectBivariateSpline',
-    'RectSpherBivariateSpline']
+    'RectSphereBivariateSpline']
 
 from types import NoneType
 
@@ -1061,7 +1061,7 @@ ERROR: on entry, the input data are controlled on validity
        approximation returned."""
 
 
-class RectSpherBivariateSpline(BivariateSpline):
+class RectSphereBivariateSpline(BivariateSpline):
     """
     Bivariate spline approximation over a rectangular mesh on a sphere.
 
@@ -1136,10 +1136,10 @@ class RectSpherBivariateSpline(BivariateSpline):
 
     We need to set up the interpolator object
 
-    >>> from scipy.interpolate import RectSpherBivariateSpline
-    >>> lut = RectSpherBivariateSpline(lats, lons, data)
+    >>> from scipy.interpolate import RectSphereBivariateSpline
+    >>> lut = RectSphereBivariateSpline(lats, lons, data)
 
-    Finally we interpolate the data.  The `RectSpherBivariateSpline` object
+    Finally we interpolate the data.  The `RectSphereBivariateSpline` object
     only takes 1-D arrays as input, therefore we need to do some reshaping.
 
     >>> data_interp = lut.ev(new_lats.ravel(),
@@ -1180,7 +1180,7 @@ class RectSpherBivariateSpline(BivariateSpline):
     >>> fig2 = plt.figure()
     >>> s = [3e9, 2e9, 1e9, 1e8]
     >>> for ii in xrange(len(s)):
-    >>>     lut = RectSpherBivariateSpline(lats, lons, data, s=s[ii])
+    >>>     lut = RectSphereBivariateSpline(lats, lons, data, s=s[ii])
     >>>     data_interp = lut.ev(new_lats.ravel(),
     ...                          new_lons.ravel()).reshape((360, 180)).T
     >>>     ax = fig2.add_subplot(2, 2, ii+1)

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -711,7 +711,8 @@ class SmoothSpherBivariateSpline(BivariateSpline):
     def __init__(self, theta, phi, r, w=1., s=0., eps=1E-16):
         if isinstance(w, (float, np.float32, np.float64)):
             w = ones(len(theta)) * w
-        nt_,tt_,np_,tp_,c,fp,ier = dfitpack.spherfit_smth(theta,phi,r,w=w,s=s,eps=eps)
+        nt_,tt_,np_,tp_,c,fp,ier = dfitpack.spherfit_smth(theta,phi,r,w=w,s=s,
+                                                          eps=eps)
         if ier in [0,-1,-2]: # normal return
             pass
         else:
@@ -719,7 +720,7 @@ class SmoothSpherBivariateSpline(BivariateSpline):
             warnings.warn(message)
 
         self.fp = fp
-        self.tck = tt_[:nt_],tp_[:np_],c[:(ntest-4)*(npest-4)]
+        self.tck = tt_[:nt_],tp_[:np_],c[:(nt_-4)*(np_-4)]
         self.degrees = (3, 3)
 
 class RectBivariateSpline(BivariateSpline):

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -15,8 +15,8 @@ __all__ = [
     'BivariateSpline',
     'LSQBivariateSpline',
     'SmoothBivariateSpline',
-    'LSQSpherBivariateSpline',
-    'SmoothSpherBivariateSpline',
+    'LSQSphereBivariateSpline',
+    'SmoothSphereBivariateSpline',
     'RectBivariateSpline',
     'RectSpherBivariateSpline']
 
@@ -713,7 +713,7 @@ WARNING. The coefficients of the spline returned have been computed as the
          the value of eps."""
 
 
-class SmoothSpherBivariateSpline(BivariateSpline):
+class SmoothSphereBivariateSpline(BivariateSpline):
     """ Smooth bivariate spline approximation in spherical coordinates.
 
     Parameters
@@ -759,8 +759,8 @@ class SmoothSpherBivariateSpline(BivariateSpline):
     We need to set up the interpolator object
 
     >>> lats, lons = np.meshgrid(theta, phi)
-    >>> from scipy.interpolate import SmoothSpherBivariateSpline
-    >>> lut = SmoothSpherBivariateSpline(lats.ravel(), lons.ravel(),
+    >>> from scipy.interpolate import SmoothSphereBivariateSpline
+    >>> lut = SmoothSphereBivariateSpline(lats.ravel(), lons.ravel(),
                                          data.T.ravel(),s=3.5)
 
     As a first test, we'll see what the algorithm returns when run on the
@@ -808,7 +808,7 @@ class SmoothSpherBivariateSpline(BivariateSpline):
             raise ValueError("requested theta out of bounds.")
         if min(phi) < 0. or max(phi) > 2. * np.pi:
             raise ValueError("requested phi out of bounds.")
-        return super(SmoothSpherBivariateSpline, self).__call__(theta, phi,
+        return super(SmoothSphereBivariateSpline, self).__call__(theta, phi,
                                                                 mth)
 
     def ev(self, theta, phi):
@@ -816,10 +816,10 @@ class SmoothSpherBivariateSpline(BivariateSpline):
             raise ValueError("requested theta out of bounds.")
         if min(phi) < 0. or max(phi) > 2. * np.pi:
             raise ValueError("requested phi out of bounds.")
-        return super(SmoothSpherBivariateSpline, self).ev(theta, phi)
+        return super(SmoothSphereBivariateSpline, self).ev(theta, phi)
 
 
-class LSQSpherBivariateSpline(BivariateSpline):
+class LSQSphereBivariateSpline(BivariateSpline):
     """ Weighted least-squares bivariate spline approximation in spherical
     coordinates.
 
@@ -870,8 +870,8 @@ class LSQSpherBivariateSpline(BivariateSpline):
     >>> knotst[-1] -= .0001
     >>> knotsp[0] += .0001
     >>> knotsp[-1] -= .0001
-    >>> from scipy.interpolate import LSQSpherBivariateSpline
-    >>> lut = LSQSpherBivariateSpline(lats.ravel(), lons.ravel(),
+    >>> from scipy.interpolate import LSQSphereBivariateSpline
+    >>> lut = LSQSphereBivariateSpline(lats.ravel(), lons.ravel(),
                                       data.T.ravel(),knotst,knotsp)
 
     As a first test, we'll see what the algorithm returns when run on the
@@ -924,14 +924,14 @@ class LSQSpherBivariateSpline(BivariateSpline):
             raise ValueError("requested theta out of bounds.")
         if min(phi) < 0. or max(phi) > 2. * np.pi:
             raise ValueError("requested phi out of bounds.")
-        return super(LSQSpherBivariateSpline, self).__call__(theta, phi, mth)
+        return super(LSQSphereBivariateSpline, self).__call__(theta, phi, mth)
 
     def ev(self, theta, phi):
         if min(theta) < 0. or max(theta) > np.pi:
             raise ValueError("requested theta out of bounds.")
         if min(phi) < 0. or max(phi) > 2. * np.pi:
             raise ValueError("requested phi out of bounds.")
-        return super(LSQSpherBivariateSpline, self).ev(theta, phi)
+        return super(LSQSphereBivariateSpline, self).ev(theta, phi)
 
 
 class RectBivariateSpline(BivariateSpline):

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -688,6 +688,7 @@ class LSQBivariateSpline(BivariateSpline):
         self.tck = tx1,ty1,c
         self.degrees = kx,ky
 
+
 _spherefit_messages = _surfit_messages.copy()
 _spherefit_messages[10] = """
 ERROR. On entry, the input data are controlled on validity. The following
@@ -710,6 +711,7 @@ WARNING. The coefficients of the spline returned have been computed as the
          deficiency, which is computed by 6+(nt-8)*(np-7)+ier, is large,
          the results may be inaccurate. They could also seriously depend on
          the value of eps."""
+
 
 class SmoothSpherBivariateSpline(BivariateSpline):
     """ Smooth bivariate spline approximation in spherical coordinates.
@@ -747,8 +749,10 @@ class SmoothSpherBivariateSpline(BivariateSpline):
     >>> phi = np.linspace(0., 2*np.pi, 9)
     >>> data = np.empty((theta.shape[0], phi.shape[0]))
     >>> data[:,0], data[0,:], data[-1,:] = 0., 0., 0.
-    >>> data[1:-1,1], data[1:-1,-1], data[1,1:-1], data[-2,1:-1] = 1., 1., 1., 1.
-    >>> data[2:-2,2], data[2:-2,-2], data[2,2:-2], data[-3,2:-2] = 2., 2., 2., 2.
+    >>> data[1:-1,1], data[1:-1,-1] = 1., 1.
+    >>> data[1,1:-1], data[-2,1:-1] = 1., 1.
+    >>> data[2:-2,2], data[2:-2,-2] = 2., 2.
+    >>> data[2,2:-2], data[-3,2:-2] = 2., 2.
     >>> data[3,3:-2] = 3.
     >>> data = np.roll(data, 4, 1)
 
@@ -781,21 +785,22 @@ class SmoothSpherBivariateSpline(BivariateSpline):
     >>> ax3 = fig.add_subplot(133)
     >>> ax3.imshow(data_smth, interpolation='nearest')
     >>> plt.show()
-    """
 
+    """
     def __init__(self, theta, phi, r, w=None, s=0., eps=1E-16):
         if np.issubclass_(w, float):
             w = ones(len(theta)) * w
-        nt_,tt_,np_,tp_,c,fp,ier = dfitpack.spherfit_smth(theta,phi,r,w=w,s=s,
-                                                          eps=eps)
-        if ier in [0,-1,-2]: # normal return
+        nt_, tt_, np_, tp_, c, fp, ier = dfitpack.spherfit_smth(theta, phi,
+                                                                r, w=w, s=s,
+                                                                eps=eps)
+        if ier in [0, -1, -2]:  # normal return
             pass
         else:
-            message = _spherefit_messages.get(ier,'ier=%s' % (ier))
+            message = _spherefit_messages.get(ier, 'ier=%s' % (ier))
             warnings.warn(message)
 
         self.fp = fp
-        self.tck = tt_[:nt_],tp_[:np_],c[:(nt_-4)*(np_-4)]
+        self.tck = tt_[:nt_], tp_[:np_], c[:(nt_ - 4) * (np_ - 4)]
         self.degrees = (3, 3)
 
     def __call__(self, theta, phi, mth='array'):
@@ -812,6 +817,7 @@ class SmoothSpherBivariateSpline(BivariateSpline):
         if min(phi) < 0. or max(phi) > 2. * np.pi:
             raise ValueError("requested phi out of bounds.")
         return super(SmoothSpherBivariateSpline, self).ev(theta, phi)
+
 
 class LSQSpherBivariateSpline(BivariateSpline):
     """ Weighted least-squares bivariate spline approximation in spherical
@@ -848,8 +854,10 @@ class LSQSpherBivariateSpline(BivariateSpline):
     >>> phi = np.linspace(0., 2*np.pi, 9)
     >>> data = np.empty((theta.shape[0], phi.shape[0]))
     >>> data[:,0], data[0,:], data[-1,:] = 0., 0., 0.
-    >>> data[1:-1,1], data[1:-1,-1], data[1,1:-1], data[-2,1:-1] = 1., 1., 1., 1.
-    >>> data[2:-2,2], data[2:-2,-2], data[2,2:-2], data[-3,2:-2] = 2., 2., 2., 2.
+    >>> data[1:-1,1], data[1:-1,-1] = 1., 1.
+    >>> data[1,1:-1], data[-2,1:-1] = 1., 1.
+    >>> data[2:-2,2], data[2:-2,-2] = 2., 2.
+    >>> data[2,2:-2], data[-3,2:-2] = 2., 2.
     >>> data[3,3:-2] = 3.
     >>> data = np.roll(data, 4, 1)
 
@@ -896,19 +904,19 @@ class LSQSpherBivariateSpline(BivariateSpline):
         nt_, np_ = 8 + len(tt), 8 + len(tp)
         tt_, tp_ = zeros((nt_,), float), zeros((np_,), float)
         tt_[4:-4], tp_[4:-4] = tt, tp
-        tt_[-4:], tp_[-4:] = np.pi, 2*np.pi
-        tt_,tp_,c,fp,ier = dfitpack.spherfit_lsq(theta,phi,r,tt_,tp_,
-                                                 w=w,eps=eps)
-        if ier in [0,-1,-2]: # normal return
+        tt_[-4:], tp_[-4:] = np.pi, 2. * np.pi
+        tt_, tp_, c, fp, ier = dfitpack.spherfit_lsq(theta, phi, r, tt_, tp_,
+                                                     w=w, eps=eps)
+        if ier in [0, -1, -2]:  # normal return
             pass
         elif ier < -2:
-            deficiency = 6+(nt_-8)*(np_-7)+ier
+            deficiency = 6 + (nt_ - 8) * (np_ - 7) + ier
             message = _spherefit_messages.get(-3) % (deficiency, -ier)
         else:
-            message = _spherefit_messages.get(ier,'ier=%s' % (ier))
+            message = _spherefit_messages.get(ier, 'ier=%s' % (ier))
             warnings.warn(message)
         self.fp = fp
-        self.tck = tt_,tp_,c
+        self.tck = tt_, tp_, c
         self.degrees = (3, 3)
 
     def __call__(self, theta, phi, mth='array'):
@@ -924,6 +932,7 @@ class LSQSpherBivariateSpline(BivariateSpline):
         if min(phi) < 0. or max(phi) > 2. * np.pi:
             raise ValueError("requested phi out of bounds.")
         return super(LSQSpherBivariateSpline, self).ev(theta, phi)
+
 
 class RectBivariateSpline(BivariateSpline):
     """ Bivariate spline approximation over a rectangular mesh.

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1015,14 +1015,13 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
         tt_[-4:], tp_[-4:] = np.pi, 2. * np.pi
         tt_, tp_, c, fp, ier = dfitpack.spherfit_lsq(theta, phi, r, tt_, tp_,
                                                      w=w, eps=eps)
-        if ier in [0, -1, -2]:  # normal return
-            pass
-        elif ier < -2:
+        if ier < -2:
             deficiency = 6 + (nt_ - 8) * (np_ - 7) + ier
             message = _spherefit_messages.get(-3) % (deficiency, -ier)
-        else:
-            message = _spherefit_messages.get(ier, 'ier=%s' % (ier))
             warnings.warn(message)
+        elif not ier in [0, -1, -2]:
+            message = _spherefit_messages.get(ier, 'ier=%s' % (ier))
+            raise ValueError(message)
         self.fp = fp
         self.tck = tt_, tp_, c
         self.degrees = (3, 3)

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -439,7 +439,7 @@ class LSQUnivariateSpline(UnivariateSpline):
 
 ################ Bivariate spline ####################
 
-class BivariateSplineBase(object):
+class _BivariateSplineBase(object):
     """ Base class for Bivariate spline s(x,y) interpolation on the rectangle
     [xb,xe] x [yb, ye] calculated from a given set of data points
     (x,y,z).
@@ -514,7 +514,7 @@ inaccurate. Deficiency may strongly depend on the value of eps."""
                     }
 
 
-class BivariateSpline(BivariateSplineBase):
+class BivariateSpline(_BivariateSplineBase):
     """ Bivariate spline s(x,y) of degrees kx and ky on the rectangle
     [xb,xe] x [yb, ye] calculated from a given set of data points
     (x,y,z).
@@ -791,7 +791,7 @@ WARNING. The coefficients of the spline returned have been computed as the
          the value of eps."""
 
 
-class SphereBivariateSpline(BivariateSplineBase):
+class SphereBivariateSpline(_BivariateSplineBase):
     """ Bivariate spline s(x,y) of degrees 3 on a sphere, calculated from a
     given set of data points (theta,phi,r).
 

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -804,6 +804,7 @@ class SmoothSpherBivariateSpline(BivariateSpline):
         if min(phi) < 0. or max(phi) > 2. * np.pi:
             raise ValueError("requested phi out of bounds.")
         return super(SmoothSpherBivariateSpline, self).__call__(theta, phi,
+                                                                mth)
 
     def ev(self, theta, phi):
         if min(theta) < 0. or max(theta) > np.pi:

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -447,10 +447,10 @@ class BivariateSplineBase(object):
     See Also
     --------
     bisplrep, bisplev : an older wrapping of FITPACK
-    BivariateSpline : implementation of bivariate spline interpolation on a 
-        plane grid
-    SphereBivariateSpline : implementation of bivariate spline interpolation on
-        a spherical grid
+    BivariateSpline :
+        implementation of bivariate spline interpolation on a plane grid
+    SphereBivariateSpline :
+        implementation of bivariate spline interpolation on a spherical grid
     """
 
     def get_residual(self):
@@ -523,14 +523,17 @@ class BivariateSpline(BivariateSplineBase):
     --------
     bisplrep, bisplev : an older wrapping of FITPACK
     UnivariateSpline : a similar class for univariate spline interpolation
-    SmoothUnivariateSpline :
+    SmoothBivariateSpline :
         to create a BivariateSpline through the given points
-    LSQUnivariateSpline :
+    LSQBivariateSpline :
         to create a BivariateSpline using weighted least-squares fitting
+    SphereBivariateSpline :
+        bivariate spline interpolation in spherical cooridinates
     """
 
     def __call__(self, x, y, mth='array'):
-        """ Evaluate spline at positions x,y."""
+        """ Evaluate spline at the grid points defined by the coordinate arrays
+        x,y."""
         x = np.asarray(x)
         y = np.asarray(y)
         # empty input yields empty output
@@ -616,7 +619,7 @@ class SmoothBivariateSpline(BivariateSpline):
 
     """
 
-    def __init__(self, x, y, z, w=None, bbox = [None]*4, kx=3, ky=3, s=None,
+    def __init__(self, x, y, z, w=None, bbox=[None] * 4, kx=3, ky=3, s=None,
                  eps=None):
         xb,xe,yb,ye = bbox
         nx,tx,ny,ty,c,fp,wrk1,ier = dfitpack.surfit_smth(x,y,z,w,
@@ -789,9 +792,8 @@ WARNING. The coefficients of the spline returned have been computed as the
 
 
 class SphereBivariateSpline(BivariateSplineBase):
-    """ Bivariate spline s(x,y) of degrees kx and ky on the rectangle
-    [xb,xe] x [yb, ye] calculated from a given set of data points
-    (x,y,z).
+    """ Bivariate spline s(x,y) of degrees 3 on a sphere, calculated from a
+    given set of data points (theta,phi,r).
 
     See Also
     --------
@@ -804,6 +806,8 @@ class SphereBivariateSpline(BivariateSplineBase):
     """
 
     def __call__(self, theta, phi):
+        """ Evaluate the spline at the grid ponts defined by the coordinate
+        arrays theta, phi. """
         theta = np.asarray(theta)
         phi = np.asarray(phi)
         # empty input yields empty output
@@ -821,6 +825,9 @@ class SphereBivariateSpline(BivariateSplineBase):
         return z
 
     def ev(self, thetai, phii):
+        """ Evaluate the spline at the points (theta[i], phi[i]),
+        i=0,...,len(theta)-1
+        """
         thetai = np.asarray(thetai)
         phii = np.asarray(phii)
         # empty input yields empty output

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -16,7 +16,8 @@ __all__ = [
     'LSQBivariateSpline',
     'SmoothBivariateSpline',
     'RectBivariateSpline',
-    'RectSpherBivariateSpline']
+    'RectSpherBivariateSpline',
+    'SmoothSpherBivariateSpline']
 
 from types import NoneType
 
@@ -686,6 +687,38 @@ class LSQBivariateSpline(BivariateSpline):
         self.tck = tx1,ty1,c
         self.degrees = kx,ky
 
+class SmoothSpherBivariateSpline(BivariateSpline):
+    """ Smooth bivariate spline approximation in spherical coordinates.
+
+    Parameters
+    ----------
+    theta, phi, r : array_like
+        1-D sequences of data points (order is not important).
+    w : array_like, optional
+        Positive 1-D sequence of weights.
+    s : float, optional
+        Positive smoothing factor defined for estimation condition:
+        ``sum((w(i)*(r(i)-s(theta(i),phi(i))))**2,axis=0) <= s``
+        Default ``s=len(w)`` which should be a good value if 1/w[i] is an
+        estimate of the standard deviation of r[i].
+    eps : float, optional
+        A threshold for determining the effective rank of an over-determined
+        linear system of equations. `eps` should have a value between 0 and 1,
+        the default is 1e-16.
+
+    """
+
+    def __init__(self, theta, phi, r, w=None, s=None, eps=None):
+        nt,tt,np,tp,c,fp,ier = dfitpack.spherfit_smth(theta,phi,r,w,s=s,eps=eps)
+        if ier in [0,-1,-2]: # normal return
+            pass
+        else:
+            message = _surfit_messages.get(ier,'ier=%s' % (ier))
+            warnings.warn(message)
+
+        self.fp = fp
+        self.tck = tt[:nt],tp[:np],c[:(ntest-4)*(npest-4)]
+        self.degrees = (3, 3)
 
 class RectBivariateSpline(BivariateSpline):
     """ Bivariate spline approximation over a rectangular mesh.

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -697,11 +697,11 @@ class LSQBivariateSpline(BivariateSpline):
                 deficiency = (nx-kx-1)*(ny-ky-1)+ier
                 message = _surfit_messages.get(-3) % (deficiency)
             else:
-                message = _surfit_messages.get(ier,'ier=%s' % (ier))
+                message = _surfit_messages.get(ier, 'ier=%s' % (ier))
             warnings.warn(message)
         self.fp = fp
-        self.tck = tx1,ty1,c
-        self.degrees = kx,ky
+        self.tck = tx1, ty1, c
+        self.degrees = kx, ky
 
 
 class RectBivariateSpline(BivariateSpline):
@@ -733,8 +733,9 @@ class RectBivariateSpline(BivariateSpline):
     UnivariateSpline : a similar class for univariate spline interpolation
 
     """
-    def __init__(self, x, y, z, bbox = [None]*4, kx=3, ky=3, s=0):
-        x,y = ravel(x), ravel(y)
+
+    def __init__(self, x, y, z, bbox=[None] * 4, kx=3, ky=3, s=0):
+        x, y = ravel(x), ravel(y)
         if not all(diff(x) > 0.0):
             raise TypeError('x must be strictly increasing')
         if not all(diff(y) > 0.0):
@@ -750,18 +751,17 @@ class RectBivariateSpline(BivariateSpline):
             raise TypeError('y dimension of z must have same number of '
                             'elements as y')
         z = ravel(z)
-        xb,xe,yb,ye = bbox
-        nx,tx,ny,ty,c,fp,ier = dfitpack.regrid_smth(x,y,z,
-                                                    xb,xe,yb,ye,
-                                                    kx,ky,s)
+        xb, xe, yb, ye = bbox
+        nx, tx, ny, ty, c, fp, ier = dfitpack.regrid_smth(x, y, z, xb, xe, yb,
+                                                          ye, kx, ky, s)
 
-        if not ier in [0,-1,-2]:
+        if not ier in [0, -1, -2]:
             msg = _surfit_messages.get(ier, 'ier=%s' % (ier))
             raise ValueError(msg)
 
         self.fp = fp
-        self.tck = tx[:nx],ty[:ny],c[:(nx-kx-1)*(ny-ky-1)]
-        self.degrees = kx,ky
+        self.tck = tx[:nx], ty[:ny], c[:(nx - kx - 1) * (ny - ky - 1)]
+        self.degrees = kx, ky
 
 
 _spherefit_messages = _surfit_messages.copy()
@@ -813,9 +813,9 @@ class SphereBivariateSpline(BivariateSplineBase):
             raise ValueError("requested theta out of bounds.")
         if phi.min() < 0. or phi.max() > 2. * np.pi:
             raise ValueError("requested phi out of bounds.")
-        tx,ty,c = self.tck[:3]
-        kx,ky = self.degrees
-        z,ier = dfitpack.bispev(tx,ty,c,kx,ky,theta,phi)
+        tx, ty, c = self.tck[:3]
+        kx, ky = self.degrees
+        z, ier = dfitpack.bispev(tx, ty, c, kx, ky, theta, phi)
         if not ier == 0:
             raise ValueError("Error code returned by bispev: %s" % ier)
         return z
@@ -830,9 +830,9 @@ class SphereBivariateSpline(BivariateSplineBase):
             raise ValueError("requested thetai out of bounds.")
         if phii.min() < 0. or phii.max() > 2. * np.pi:
             raise ValueError("requested phii out of bounds.")
-        tx,ty,c = self.tck[:3]
-        kx,ky = self.degrees
-        zi,ier = dfitpack.bispeu(tx,ty,c,kx,ky,thetai,phii)
+        tx, ty, c = self.tck[:3]
+        kx, ky = self.degrees
+        zi, ier = dfitpack.bispeu(tx, ty, c, kx, ky, thetai, phii)
         if not ier == 0:
             raise ValueError("Error code returned by bispeu: %s" % ier)
         return zi
@@ -893,14 +893,12 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
     As a first test, we'll see what the algorithm returns when run on the
     input coordinates
 
-    >>> new_lats = theta.copy()
-    >>> new_lons = phi.copy()
-    >>> data_orig = lut(new_lats, new_lons)
+    >>> data_orig = lut(theta, phi)
 
     Finally we interpolate the data to a finer grid
 
     >>> fine_lats = np.linspace(0., np.pi, 70)
-    >>> fine_lons = np.linspace(0., 2*np.pi, 90)
+    >>> fine_lons = np.linspace(0., 2 * np.pi, 90)
 
     >>> data_smth = lut(fine_lats, fine_lons)
 
@@ -914,6 +912,7 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
     >>> plt.show()
 
     """
+
     def __init__(self, theta, phi, r, w=None, s=0., eps=1E-16):
         if np.issubclass_(w, float):
             w = ones(len(theta)) * w
@@ -983,14 +982,12 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
     >>> knotsp[-1] -= .0001
     >>> from scipy.interpolate import LSQSphereBivariateSpline
     >>> lut = LSQSphereBivariateSpline(lats.ravel(), lons.ravel(),
-                                      data.T.ravel(),knotst,knotsp)
+                                       data.T.ravel(),knotst,knotsp)
 
     As a first test, we'll see what the algorithm returns when run on the
     input coordinates
 
-    >>> new_lats = theta.copy()
-    >>> new_lons = phi.copy()
-    >>> data_orig = lut(new_lats, new_lons)
+    >>> data_orig = lut(theta, phi)
 
     Finally we interpolate the data to a finer grid
 
@@ -1099,7 +1096,8 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
 
     See Also
     --------
-    RectBivariateSpline : bivariate spline approximation over a rectangular mesh
+    RectBivariateSpline : bivariate spline approximation over a rectangular
+        mesh
 
     Notes
     -----
@@ -1187,6 +1185,7 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
     >>> plt.show()
 
     """
+
     def __init__(self, u, v, r, s=0., pole_continuity=False, pole_values=None,
                  pole_exact=False, pole_flat=False):
         iopt = np.array([0, 0, 0], dtype=int)
@@ -1230,19 +1229,20 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
                             'elements as v')
 
         if pole_continuity[1] is False and pole_flat[1] is True:
-            raise TypeError('if pole_continuity is False, so must be pole_flat')
+            raise TypeError('if pole_continuity is False, so must be '
+                            'pole_flat')
         if pole_continuity[0] is False and pole_flat[0] is True:
-            raise TypeError('if pole_continuity is False, so must be pole_flat')
+            raise TypeError('if pole_continuity is False, so must be '
+                            'pole_flat')
 
         r = np.ravel(r)
         nu, tu, nv, tv, c, fp, ier = dfitpack.regrid_smth_spher(iopt, ider,
-                                        u.copy(), v.copy(), r.copy(), r0, r1, s)
+                                       u.copy(), v.copy(), r.copy(), r0, r1, s)
 
-        if not ier in [0,-1,-2]:
+        if not ier in [0, -1, -2]:
             msg = _spfit_messages.get(ier, 'ier=%s' % (ier))
             raise ValueError(msg)
 
         self.fp = fp
         self.tck = tu[:nu], tv[:nv], c[:(nu - 4) * (nv-4)]
         self.degrees = (3, 3)
-

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -22,7 +22,7 @@ __all__ = [
 from types import NoneType
 
 import warnings
-from numpy import zeros, concatenate, alltrue, ravel, all, diff, array
+from numpy import zeros, concatenate, alltrue, ravel, all, diff, array, ones
 import numpy as np
 
 import fitpack
@@ -708,8 +708,10 @@ class SmoothSpherBivariateSpline(BivariateSpline):
 
     """
 
-    def __init__(self, theta, phi, r, w=None, s=None, eps=None):
-        nt,tt,np,tp,c,fp,ier = dfitpack.spherfit_smth(theta,phi,r,w,s=s,eps=eps)
+    def __init__(self, theta, phi, r, w=1., s=0., eps=1E-16):
+        if isinstance(w, (float, np.float32, np.float64)):
+            w = ones(len(theta)) * w
+        nt_,tt_,np_,tp_,c,fp,ier = dfitpack.spherfit_smth(theta,phi,r,w=w,s=s,eps=eps)
         if ier in [0,-1,-2]: # normal return
             pass
         else:
@@ -717,7 +719,7 @@ class SmoothSpherBivariateSpline(BivariateSpline):
             warnings.warn(message)
 
         self.fp = fp
-        self.tck = tt[:nt],tp[:np],c[:(ntest-4)*(npest-4)]
+        self.tck = tt_[:nt_],tp_[:np_],c[:(ntest-4)*(npest-4)]
         self.degrees = (3, 3)
 
 class RectBivariateSpline(BivariateSpline):

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -452,7 +452,7 @@ static int calc_regrid_lwrk(int mx, int my, int kx, int ky,
 
      subroutine spherfit_smth(iopt,m,teta,phi,r,w,s,ntest,npest,eps,nt,tt,np,&
           tp,c,fp,wrk1,lwrk1,wrk2,lwrk2,iwrk,kwrk,ier)
-       !  nt,tt,np,tp,c,fp,ier = spherfit_smth(teta,phi,r,[w,s,eps])
+       !  tt,tp,c,fp,ier = spherfit_smth(teta,phi,r,[w,s,eps])
 
        fortranname sphere
 
@@ -484,6 +484,40 @@ static int calc_regrid_lwrk(int mx, int my, int kx, int ky,
             :: kwrk=m+(ntest-7)*(npest-7)
        integer intent(out) :: ier
      end subroutine spherfit_smth
+
+     subroutine spherfit_lsq(iopt,m,teta,phi,r,w,s,ntest,npest,eps,nt,tt,np,&
+          tp,c,fp,wrk1,lwrk1,wrk2,lwrk2,iwrk,kwrk,ier)
+       !  tt,tp,c,fp,ier = spherfit_lsq(teta,phi,r,tt,tp,[w,eps])
+
+       fortranname sphere
+
+       integer intent(hide) :: iopt=-1
+       integer intent(hide),depend(teta),check(m>=2) :: m=len(teta)
+       real*8 dimension(m) :: teta
+       real*8 dimension(m),depend(m),check(len(phi)==m) :: phi
+       real*8 dimension(m),depend(m),check(len(r)==m) :: r
+       real*8 optional,dimension(m),depend(m),check(len(w)==m) :: w = 1.0
+       real*8 intent(hide) :: s = 0.0
+       integer intent(hide),depend(tt) :: ntest = len(tt)
+       integer intent(hide),depend(tp),check(npest>=9) :: npest = len(tp)
+       real*8 optional,check(0.0<eps && eps<1.0) :: eps = 1e-16
+       integer intent(hide),depend(ntest) :: nt = ntest
+       real*8 dimension(ntest),intent(in,out,overwrite) :: tt
+       integer intent(hide),depend(npest) :: np = npest
+       real*8 dimension(npest),intent(in,out,overwrite) :: tp
+       real*8 dimension((nt-4)*(np-4)),intent(out),depend(nt,np) :: c
+       real*8 intent(out) :: fp
+       real*8 dimension(lwrk1),intent(cache,hide),depend(lwrk1) :: wrk1
+       integer intent(hide),depend(m,ntest,npest) &
+            :: lwrk1=calc_spherfit_lwrk1(m,ntest,npest)
+       real*8 dimension(lwrk2),intent(cache,hide),depend(lwrk2) :: wrk2
+       integer intent(hide),depend(ntest,npest) &
+            :: lwrk2=calc_spherfit_lwrk2(ntest,npest)
+       integer dimension(kwrk),depend(kwrk),intent(cache,hide) :: iwrk
+       integer intent(hide),depend(m,ntest,npest) &
+            :: kwrk=m+(ntest-7)*(npest-7)
+       integer intent(out) :: ier
+     end subroutine spherfit_lsq
 
      subroutine regrid_smth(iopt,mx,x,my,y,z,xb,xe,yb,ye,kx,ky,s,&
         nxest,nyest,nx,tx,ny,ty,c,fp,wrk,lwrk,iwrk,kwrk,ier)

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -462,15 +462,15 @@ static int calc_regrid_lwrk(int mx, int my, int kx, int ky,
        real*8 dimension(m),depend(m),check(len(phi)==m) :: phi
        real*8 dimension(m),depend(m),check(len(r)==m) :: r
        real*8 optional,dimension(m),depend(m),check(len(w)==m) :: w = 1.0
-       real*8 optional,check(0.0<=s),depend(m) :: s = m
+       real*8 optional,check(0.0<=s) :: s = m
        integer intent(hide),depend(m),check(ntest>=8) :: ntest = 8+sqrt(m/2)
        integer intent(hide),depend(m),check(npest>=8) :: npest = 8+sqrt(m/2)
        real*8 optional,check(0.0<eps && eps<1.0) :: eps = 1e-16
        integer intent(out) :: nt
-       real*8 dimension(nt),intent(out) :: tt
+       real*8 dimension(ntest),intent(out),depend(ntest) :: tt
        integer intent(out) :: np
-       real*8 dimension(np),intent(out) :: tp
-       real*8 dimension((ntest-4)*(npest-4)), 
+       real*8 dimension(npest),intent(out),depend(npest) :: tp
+       real*8 dimension((ntest-4)*(npest-4)), &
             depend(ntest,npest),intent(out) :: c
        real*8 intent(out) :: fp
        real*8 dimension(lwrk1),intent(cache,hide),depend(lwrk1) :: wrk1

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -64,6 +64,17 @@ static int calc_surfit_lwrk2(int m, int kx, int ky, int nxest, int nyest) {
  return u*v*(b2+1)+b2;
 }
 
+static int calc_spherfit_lwrk1(int m, int ntest, int npest) {
+ int u = ntest-7;
+ int v = npest-7;
+ return 185+52*v+10*u+14*u*v+8*(u-1)*v*v+8*m;
+}
+static int calc_spherfit_lwrk2(int ntest, int npest) {
+ int u = ntest-7;
+ int v = npest-7;
+ return 48+21*v+7*u*v+4*(u-1)*v*v;
+}
+
 static int calc_regrid_lwrk(int mx, int my, int kx, int ky,
                             int nxest, int nyest) {
  int u = MAX(my, nxest);
@@ -438,6 +449,41 @@ static int calc_regrid_lwrk(int mx, int my, int kx, int ky,
             :: kwrk=m+(nx-2*kx-1)*(ny-2*ky-1)
        integer intent(out) :: ier
      end subroutine surfit_lsq
+
+     subroutine spherfit_smth(iopt,m,teta,phi,r,w,s,ntest,npest,eps,nt,tt,np,&
+          tp,c,fp,wrk1,lwrk1,wrk2,lwrk2,iwrk,kwrk,ier)
+       !  nt,tt,np,tp,c,fp,ier = spherfit_smth(teta,phi,r,[w,s,eps])
+
+       fortranname sphere
+
+       integer intent(hide) :: iopt=0
+       integer intent(hide),depend(teta),check(m>=2) :: m=len(teta)
+       real*8 dimension(m) :: teta
+       real*8 dimension(m),depend(m),check(len(phi)==m) :: phi
+       real*8 dimension(m),depend(m),check(len(r)==m) :: r
+       real*8 optional,dimension(m),depend(m),check(len(w)==m) :: w = 1.0
+       real*8 optional,check(0.0<=s),depend(m) :: s = m
+       integer intent(hide),depend(m),check(ntest>=8) :: ntest = 8+sqrt(m/2)
+       integer intent(hide),depend(m),check(npest>=8) :: npest = 8+sqrt(m/2)
+       real*8 optional,check(0.0<eps && eps<1.0) :: eps = 1e-16
+       integer intent(out) :: nt
+       real*8 dimension(nt),intent(out) :: tt
+       integer intent(out) :: np
+       real*8 dimension(np),intent(out) :: tp
+       real*8 dimension((ntest-4)*(npest-4)), 
+            depend(ntest,npest),intent(out) :: c
+       real*8 intent(out) :: fp
+       real*8 dimension(lwrk1),intent(cache,hide),depend(lwrk1) :: wrk1
+       integer intent(hide),depend(m,ntest,npest) &
+            :: lwrk1=calc_spherfit_lwrk1(m,ntest,npest)
+       real*8 dimension(lwrk2),intent(cache,hide),depend(lwrk2) :: wrk2
+       integer intent(hide),depend(ntest,npest) &
+            :: lwrk2=calc_spherfit_lwrk2(ntest,npest)
+       integer dimension(kwrk),depend(kwrk),intent(cache,hide) :: iwrk
+       integer intent(hide),depend(m,ntest,npest) &
+            :: kwrk=m+(ntest-7)*(npest-7)
+       integer intent(out) :: ier
+     end subroutine spherfit_smth
 
      subroutine regrid_smth(iopt,mx,x,my,y,z,xb,xe,yb,ye,kx,ky,s,&
         nxest,nyest,nx,tx,ny,ty,c,fp,wrk,lwrk,iwrk,kwrk,ier)

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -183,12 +183,12 @@ class TestSmoothBivariateSpline(TestCase):
 
 class TestSmoothSpherBivariateSpline(TestCase):
     def test_linear_constant(self):
-        theta = [.25*pi,.25*pi,.25*pi,.5*pi,.5*pi,.5*pi,.75*pi,.75*pi,.75*pi]
-        phi = [.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi]
-        r = [3,3,3,3,3,3,3,3,3]
+        theta = array([.25*pi,.25*pi,.25*pi,.5*pi,.5*pi,.5*pi,.75*pi,.75*pi,.75*pi])
+        phi = array([.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi])
+        r = array([3,3,3,3,3,3,3,3,3])
         lut = SmoothSpherBivariateSpline(theta,phi,r)
-        assert_array_almost_equal(lut.get_knots(),([.25*pi,.25*pi,.75*pi,.75*pi],[.25*pi,.25*pi,.75*pi,.75*pi]))
-        assert_array_almost_equal(lut.get_coeffs(),[3,3,3,3])
+#        assert_array_almost_equal(lut.get_knots(),([.25*pi,.25*pi,.75*pi,.75*pi],[.25*pi,.25*pi,.75*pi,.75*pi]))
+#        assert_array_almost_equal(lut.get_coeffs(),[3,3,3,3])
         assert_almost_equal(lut.get_residual(),0.0)
         assert_array_almost_equal(lut([1,1.5,2],[1,1.5]),[[3,3],[3,3],[3,3]])
 

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -3,9 +3,9 @@
 
 from numpy.testing import assert_equal, assert_almost_equal, assert_array_equal, \
         assert_array_almost_equal, assert_allclose, TestCase, run_module_suite
-from numpy import array, diff, shape
+from numpy import array, diff, pi, shape
 from scipy.interpolate.fitpack2 import UnivariateSpline, LSQBivariateSpline, \
-    SmoothBivariateSpline, RectBivariateSpline
+    SmoothBivariateSpline, SmoothSpherBivariateSpline, RectBivariateSpline
 
 class TestUnivariateSpline(TestCase):
     def test_linear_constant(self):
@@ -178,6 +178,50 @@ class TestSmoothBivariateSpline(TestCase):
         trpz = .25*(diff(tx[:-1])[:,None]*diff(ty[:-1])[None,:]
                     *(tz[:-1,:-1]+tz[1:,:-1]+tz[:-1,1:]+tz[1:,1:])).sum()
         assert_almost_equal(lut.integral(tx[0], tx[-2], ty[0], ty[-2]), trpz)
+
+class TestSmoothSpherBivariateSpline(TestCase):
+    def test_linear_constant(self):
+        theta = [.25*pi,.25*pi,.25*pi,.5*pi,.5*pi,.5*pi,.75*pi,.75*pi,.75*pi]
+        phi = [.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi]
+        r = [3,3,3,3,3,3,3,3,3]
+        lut = SmoothSpherBivariateSpline(theta,phi,r)
+        assert_array_almost_equal(lut.get_knots(),([.25*pi,.25*pi,.75*pi,.75*pi],[.25*pi,.25*pi,.75*pi,.75*pi]))
+        assert_array_almost_equal(lut.get_coeffs(),[3,3,3,3])
+        assert_almost_equal(lut.get_residual(),0.0)
+        assert_array_almost_equal(lut([1,1.5,2],[1,1.5]),[[3,3],[3,3],[3,3]])
+
+#    def test_linear_1d(self):
+#        x = [1,1,1,2,2,2,3,3,3]
+#        y = [1,2,3,1,2,3,1,2,3]
+#        z = [0,0,0,2,2,2,4,4,4]
+#        lut = SmoothSpherBivariateSpline(x,y,z,kx=1,ky=1)
+#        assert_array_almost_equal(lut.get_knots(),([1,1,3,3],[1,1,3,3]))
+#        assert_array_almost_equal(lut.get_coeffs(),[0,0,4,4])
+#        assert_almost_equal(lut.get_residual(),0.0)
+#        assert_array_almost_equal(lut([1,1.5,2],[1,1.5]),[[0,0],[1,1],[2,2]])
+
+#    def test_integral(self):
+#        x = [1,1,1,2,2,2,4,4,4]
+#        y = [1,2,3,1,2,3,1,2,3]
+#        z = array([0,7,8,3,4,7,1,3,4])
+#
+#        lut = SmoothBivariateSpline(x,y,z,kx=1,ky=1,s=0)
+#        tx = [1,2,4]
+#        ty = [1,2,3]
+#
+#        tz = lut(tx, ty)
+#        trpz = .25*(diff(tx)[:,None]*diff(ty)[None,:]
+#                    *(tz[:-1,:-1]+tz[1:,:-1]+tz[:-1,1:]+tz[1:,1:])).sum()
+#        assert_almost_equal(lut.integral(tx[0], tx[-1], ty[0], ty[-1]), trpz)
+#
+#        lut2 = SmoothBivariateSpline(x,y,z,kx=2,ky=2,s=0)
+#        assert_almost_equal(lut2.integral(tx[0], tx[-1], ty[0], ty[-1]), trpz,
+#                            decimal=0) # the quadratures give 23.75 and 23.85
+#
+#        tz = lut(tx[:-1], ty[:-1])
+#        trpz = .25*(diff(tx[:-1])[:,None]*diff(ty[:-1])[None,:]
+#                    *(tz[:-1,:-1]+tz[1:,:-1]+tz[:-1,1:]+tz[1:,1:])).sum()
+#        assert_almost_equal(lut.integral(tx[0], tx[-2], ty[0], ty[-2]), trpz)
 
 class TestRectBivariateSpline(TestCase):
     def test_defaults(self):

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -4,9 +4,10 @@
 from numpy.testing import assert_equal, assert_almost_equal, assert_array_equal, \
         assert_array_almost_equal, assert_allclose, TestCase, run_module_suite
 from numpy import array, diff, linspace, meshgrid, ones, pi, shape
-from scipy.interpolate.fitpack2 import UnivariateSpline, LSQBivariateSpline, \
-    SmoothBivariateSpline, RectBivariateSpline, RectSpherBivariateSpline, \
-    SmoothSphereBivariateSpline,LSQSphereBivariateSpline
+from scipy.interpolate.fitpack2 import UnivariateSpline, \
+    LSQBivariateSpline, SmoothBivariateSpline, RectBivariateSpline, \
+    LSQSphereBivariateSpline, SmoothSphereBivariateSpline, \
+    RectSphereBivariateSpline
 
 class TestUnivariateSpline(TestCase):
     def test_linear_constant(self):
@@ -242,14 +243,14 @@ class TestRectBivariateSpline(TestCase):
         assert_almost_equal(zi, zi2)
 
 
-class TestRectSpherBivariateSpline(TestCase):
+class TestRectSphereBivariateSpline(TestCase):
     def test_defaults(self):
         y = linspace(0.01, 2*pi-0.01, 7)
         x = linspace(0.01, pi-0.01, 7)
         z = array([[1,2,1,2,1,2,1],[1,2,1,2,1,2,1],[1,2,3,2,1,2,1],
                    [1,2,2,2,1,2,1],[1,2,1,2,1,2,1],[1,2,2,2,1,2,1],
                    [1,2,1,2,1,2,1]])
-        lut = RectSpherBivariateSpline(x,y,z)
+        lut = RectSphereBivariateSpline(x,y,z)
         assert_array_almost_equal(lut(x,y),z)
 
     def test_evaluate(self):
@@ -258,7 +259,7 @@ class TestRectSpherBivariateSpline(TestCase):
         z = array([[1,2,1,2,1,2,1],[1,2,1,2,1,2,1],[1,2,3,2,1,2,1],
                    [1,2,2,2,1,2,1],[1,2,1,2,1,2,1],[1,2,2,2,1,2,1],
                    [1,2,1,2,1,2,1]])
-        lut = RectSpherBivariateSpline(x,y,z)
+        lut = RectSphereBivariateSpline(x,y,z)
         yi = [0.2, 1, 2.3, 2.35, 3.0, 3.99, 5.25]
         xi = [1.5, 0.4, 1.1, 0.45, 0.2345, 1., 0.0001]
         zi = lut.ev(xi, yi)

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_equal, assert_almost_equal, assert_array_equal,
 from numpy import array, diff, linspace, meshgrid, ones, pi, shape
 from scipy.interpolate.fitpack2 import UnivariateSpline, LSQBivariateSpline, \
     SmoothBivariateSpline, RectBivariateSpline, RectSpherBivariateSpline, \
-    SmoothSpherBivariateSpline,LSQSpherBivariateSpline
+    SmoothSphereBivariateSpline,LSQSphereBivariateSpline
 
 class TestUnivariateSpline(TestCase):
     def test_linear_constant(self):
@@ -181,7 +181,7 @@ class TestSmoothBivariateSpline(TestCase):
                     *(tz[:-1,:-1]+tz[1:,:-1]+tz[:-1,1:]+tz[1:,1:])).sum()
         assert_almost_equal(lut.integral(tx[0], tx[-2], ty[0], ty[-2]), trpz)
 
-class TestLSQSpherBivariateSpline(TestCase):
+class TestLSQSphereBivariateSpline(TestCase):
     def test_linear_constant(self):
         # define the knots
         knotst, knotsp = linspace(0., pi, 7), linspace(0., 2.*pi, 9)
@@ -204,18 +204,18 @@ class TestLSQSpherBivariateSpline(TestCase):
         new_lons = lons.copy()
         lats, lons = meshgrid(lats, lons)
         # calculate spline coefficients
-        lut_lsq = LSQSpherBivariateSpline(lats.ravel(), lons.ravel(), data.T.ravel(),
+        lut_lsq = LSQSphereBivariateSpline(lats.ravel(), lons.ravel(), data.T.ravel(),
                                           knotst, knotsp)
         assert_almost_equal(lut_lsq.get_residual(),0.0)
         assert_array_almost_equal(lut_lsq(new_lats, new_lons),data)
 
 
-class TestSmoothSpherBivariateSpline(TestCase):
+class TestSmoothSphereBivariateSpline(TestCase):
     def test_linear_constant(self):
         theta = array([.25*pi,.25*pi,.25*pi,.5*pi,.5*pi,.5*pi,.75*pi,.75*pi,.75*pi])
         phi = array([.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi])
         r = array([3,3,3,3,3,3,3,3,3])
-        lut = SmoothSpherBivariateSpline(theta,phi,r,s=1E10)
+        lut = SmoothSphereBivariateSpline(theta,phi,r,s=1E10)
         assert_almost_equal(lut.get_residual(),0.0)
         assert_array_almost_equal(lut([1,1.5,2],[1,1.5]),[[3,3],[3,3],[3,3]])
 

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -3,10 +3,10 @@
 
 from numpy.testing import assert_equal, assert_almost_equal, assert_array_equal, \
         assert_array_almost_equal, assert_allclose, TestCase, run_module_suite
-from numpy import array, diff, shape, linspace, pi
+from numpy import array, diff, linspace, pi, shape
 from scipy.interpolate.fitpack2 import UnivariateSpline, LSQBivariateSpline, \
-    SmoothBivariateSpline, RectBivariateSpline, RectSpherBivariateSpline
-
+    SmoothBivariateSpline, RectBivariateSpline, RectSpherBivariateSpline, \
+    SmoothSpherBivariateSpline
 
 class TestUnivariateSpline(TestCase):
     def test_linear_constant(self):
@@ -181,6 +181,49 @@ class TestSmoothBivariateSpline(TestCase):
                     *(tz[:-1,:-1]+tz[1:,:-1]+tz[:-1,1:]+tz[1:,1:])).sum()
         assert_almost_equal(lut.integral(tx[0], tx[-2], ty[0], ty[-2]), trpz)
 
+class TestSmoothSpherBivariateSpline(TestCase):
+    def test_linear_constant(self):
+        theta = [.25*pi,.25*pi,.25*pi,.5*pi,.5*pi,.5*pi,.75*pi,.75*pi,.75*pi]
+        phi = [.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi]
+        r = [3,3,3,3,3,3,3,3,3]
+        lut = SmoothSpherBivariateSpline(theta,phi,r)
+        assert_array_almost_equal(lut.get_knots(),([.25*pi,.25*pi,.75*pi,.75*pi],[.25*pi,.25*pi,.75*pi,.75*pi]))
+        assert_array_almost_equal(lut.get_coeffs(),[3,3,3,3])
+        assert_almost_equal(lut.get_residual(),0.0)
+        assert_array_almost_equal(lut([1,1.5,2],[1,1.5]),[[3,3],[3,3],[3,3]])
+
+#    def test_linear_1d(self):
+#        x = [1,1,1,2,2,2,3,3,3]
+#        y = [1,2,3,1,2,3,1,2,3]
+#        z = [0,0,0,2,2,2,4,4,4]
+#        lut = SmoothSpherBivariateSpline(x,y,z,kx=1,ky=1)
+#        assert_array_almost_equal(lut.get_knots(),([1,1,3,3],[1,1,3,3]))
+#        assert_array_almost_equal(lut.get_coeffs(),[0,0,4,4])
+#        assert_almost_equal(lut.get_residual(),0.0)
+#        assert_array_almost_equal(lut([1,1.5,2],[1,1.5]),[[0,0],[1,1],[2,2]])
+
+#    def test_integral(self):
+#        x = [1,1,1,2,2,2,4,4,4]
+#        y = [1,2,3,1,2,3,1,2,3]
+#        z = array([0,7,8,3,4,7,1,3,4])
+#
+#        lut = SmoothBivariateSpline(x,y,z,kx=1,ky=1,s=0)
+#        tx = [1,2,4]
+#        ty = [1,2,3]
+#
+#        tz = lut(tx, ty)
+#        trpz = .25*(diff(tx)[:,None]*diff(ty)[None,:]
+#                    *(tz[:-1,:-1]+tz[1:,:-1]+tz[:-1,1:]+tz[1:,1:])).sum()
+#        assert_almost_equal(lut.integral(tx[0], tx[-1], ty[0], ty[-1]), trpz)
+#
+#        lut2 = SmoothBivariateSpline(x,y,z,kx=2,ky=2,s=0)
+#        assert_almost_equal(lut2.integral(tx[0], tx[-1], ty[0], ty[-1]), trpz,
+#                            decimal=0) # the quadratures give 23.75 and 23.85
+#
+#        tz = lut(tx[:-1], ty[:-1])
+#        trpz = .25*(diff(tx[:-1])[:,None]*diff(ty[:-1])[None,:]
+#                    *(tz[:-1,:-1]+tz[1:,:-1]+tz[:-1,1:]+tz[1:,1:])).sum()
+#        assert_almost_equal(lut.integral(tx[0], tx[-2], ty[0], ty[-2]), trpz)
 
 class TestRectBivariateSpline(TestCase):
     def test_defaults(self):

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -212,6 +212,34 @@ class TestLSQSphereBivariateSpline(TestCase):
         assert_array_almost_equal(lut_lsq(new_lats, new_lons), data)
 
 
+    def test_empty_input(self):
+        # define the knots
+        knotst, knotsp = linspace(0., pi, 7), linspace(0., 2.*pi, 9)
+        knotst[0] += .001
+        knotsp[0] += .001
+        knotsp[-1] -= .001
+        knotst[-1] -= .001
+        # define the input data and coordinates
+        lats, lons = linspace(0., pi, 7), linspace(0., 2*pi, 9)
+        data = ones((lons.shape[0], lats.shape[0]))
+        data[0,:], data[-1,:], data[:,0], data[:,-1] = 0., 0., 0., 0.
+        data[1,1:-1], data[-2,1:-1], data[1:-1,1], data[1:-1,-2] = 1., 1., 1., \
+                                                                   1.
+        data[2,2:-3], data[-3,2:-3], data[2:-3,2], data[2:-3,-3], data[2:-2,4] = 2., 2., 2., 2., 2.
+        data[3:6,3] = 3.
+        data = data.T
+        data = data[:,:-1]
+        lons = lons[:-1]
+        # define the coordinates we will test
+        new_lats = lats
+        new_lons = lons
+        lats, lons = meshgrid(lats, lons)
+        # calculate spline coefficients
+        lut_lsq = LSQSphereBivariateSpline(lats.ravel(), lons.ravel(),
+                                           data.T.ravel(), knotst, knotsp)
+        assert_array_almost_equal(lut_lsq([], []), array([]))
+
+
 class TestSmoothSphereBivariateSpline(TestCase):
     def test_linear_constant(self):
         theta = array([.25*pi,.25*pi,.25*pi,.5*pi,.5*pi,.5*pi,.75*pi,.75*pi,.75*pi])
@@ -220,6 +248,13 @@ class TestSmoothSphereBivariateSpline(TestCase):
         lut = SmoothSphereBivariateSpline(theta,phi,r,s=1E10)
         assert_almost_equal(lut.get_residual(),0.0)
         assert_array_almost_equal(lut([1,1.5,2],[1,1.5]),[[3,3],[3,3],[3,3]])
+
+    def test_empty_constant(self):
+        theta = array([.25*pi,.25*pi,.25*pi,.5*pi,.5*pi,.5*pi,.75*pi,.75*pi,.75*pi])
+        phi = array([.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi])
+        r = array([3,3,3,3,3,3,3,3,3])
+        lut = SmoothSphereBivariateSpline(theta,phi,r,s=1E10)
+        assert_array_almost_equal(lut([],[]), array([]))
 
 
 class TestRectBivariateSpline(TestCase):

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -3,10 +3,10 @@
 
 from numpy.testing import assert_equal, assert_almost_equal, assert_array_equal, \
         assert_array_almost_equal, assert_allclose, TestCase, run_module_suite
-from numpy import array, diff, linspace, pi, shape
+from numpy import array, diff, linspace, meshgrid, ones, pi, shape
 from scipy.interpolate.fitpack2 import UnivariateSpline, LSQBivariateSpline, \
     SmoothBivariateSpline, RectBivariateSpline, RectSpherBivariateSpline, \
-    SmoothSpherBivariateSpline
+    SmoothSpherBivariateSpline,LSQSpherBivariateSpline
 
 class TestUnivariateSpline(TestCase):
     def test_linear_constant(self):
@@ -181,49 +181,44 @@ class TestSmoothBivariateSpline(TestCase):
                     *(tz[:-1,:-1]+tz[1:,:-1]+tz[:-1,1:]+tz[1:,1:])).sum()
         assert_almost_equal(lut.integral(tx[0], tx[-2], ty[0], ty[-2]), trpz)
 
+class TestLSQSpherBivariateSpline(TestCase):
+    def test_linear_constant(self):
+        # define the knots
+        knotst, knotsp = linspace(0., pi, 7), linspace(0., 2.*pi, 9)
+        knotst[0] += .001
+        knotsp[0] += .001
+        knotsp[-1] -= .001
+        knotst[-1] -= .001
+        # define the input data and coordinates
+        lats, lons = linspace(0., pi, 7), linspace(0., 2*pi, 9)
+        data = ones((lons.shape[0], lats.shape[0]))
+        data[0,:], data[-1,:], data[:,0], data[:,-1] = 0., 0., 0., 0.
+        data[1,1:-1], data[-2,1:-1], data[1:-1,1], data[1:-1,-2] = 1., 1., 1., 1.
+        data[2,2:-3], data[-3,2:-3], data[2:-3,2], data[2:-3,-3], data[2:-2,4] = 2., 2., 2., 2., 2.
+        data[3:6,3] = 3.
+        data = data.T
+        data = data[:,:-1]
+        lons = lons[:-1]
+        # define the coordinates we will test
+        new_lats = lats.copy()
+        new_lons = lons.copy()
+        lats, lons = meshgrid(lats, lons)
+        # calculate spline coefficients
+        lut_lsq = LSQSpherBivariateSpline(lats.ravel(), lons.ravel(), data.T.ravel(),
+                                          knotst, knotsp)
+        assert_almost_equal(lut_lsq.get_residual(),0.0)
+        assert_array_almost_equal(lut_lsq(new_lats, new_lons),data)
+
+
 class TestSmoothSpherBivariateSpline(TestCase):
     def test_linear_constant(self):
         theta = array([.25*pi,.25*pi,.25*pi,.5*pi,.5*pi,.5*pi,.75*pi,.75*pi,.75*pi])
         phi = array([.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi])
         r = array([3,3,3,3,3,3,3,3,3])
-        lut = SmoothSpherBivariateSpline(theta,phi,r)
-#        assert_array_almost_equal(lut.get_knots(),([.25*pi,.25*pi,.75*pi,.75*pi],[.25*pi,.25*pi,.75*pi,.75*pi]))
-#        assert_array_almost_equal(lut.get_coeffs(),[3,3,3,3])
+        lut = SmoothSpherBivariateSpline(theta,phi,r,s=1E10)
         assert_almost_equal(lut.get_residual(),0.0)
         assert_array_almost_equal(lut([1,1.5,2],[1,1.5]),[[3,3],[3,3],[3,3]])
 
-#    def test_linear_1d(self):
-#        x = [1,1,1,2,2,2,3,3,3]
-#        y = [1,2,3,1,2,3,1,2,3]
-#        z = [0,0,0,2,2,2,4,4,4]
-#        lut = SmoothSpherBivariateSpline(x,y,z,kx=1,ky=1)
-#        assert_array_almost_equal(lut.get_knots(),([1,1,3,3],[1,1,3,3]))
-#        assert_array_almost_equal(lut.get_coeffs(),[0,0,4,4])
-#        assert_almost_equal(lut.get_residual(),0.0)
-#        assert_array_almost_equal(lut([1,1.5,2],[1,1.5]),[[0,0],[1,1],[2,2]])
-
-#    def test_integral(self):
-#        x = [1,1,1,2,2,2,4,4,4]
-#        y = [1,2,3,1,2,3,1,2,3]
-#        z = array([0,7,8,3,4,7,1,3,4])
-#
-#        lut = SmoothBivariateSpline(x,y,z,kx=1,ky=1,s=0)
-#        tx = [1,2,4]
-#        ty = [1,2,3]
-#
-#        tz = lut(tx, ty)
-#        trpz = .25*(diff(tx)[:,None]*diff(ty)[None,:]
-#                    *(tz[:-1,:-1]+tz[1:,:-1]+tz[:-1,1:]+tz[1:,1:])).sum()
-#        assert_almost_equal(lut.integral(tx[0], tx[-1], ty[0], ty[-1]), trpz)
-#
-#        lut2 = SmoothBivariateSpline(x,y,z,kx=2,ky=2,s=0)
-#        assert_almost_equal(lut2.integral(tx[0], tx[-1], ty[0], ty[-1]), trpz,
-#                            decimal=0) # the quadratures give 23.75 and 23.85
-#
-#        tz = lut(tx[:-1], ty[:-1])
-#        trpz = .25*(diff(tx[:-1])[:,None]*diff(ty[:-1])[None,:]
-#                    *(tz[:-1,:-1]+tz[1:,:-1]+tz[:-1,1:]+tz[1:,1:])).sum()
-#        assert_almost_equal(lut.integral(tx[0], tx[-2], ty[0], ty[-2]), trpz)
 
 class TestRectBivariateSpline(TestCase):
     def test_defaults(self):

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -3,7 +3,7 @@
 
 from numpy.testing import assert_equal, assert_almost_equal, assert_array_equal, \
         assert_array_almost_equal, assert_allclose, TestCase, run_module_suite
-from numpy import array, diff, linspace, meshgrid, ones, pi, shape
+from numpy import array, diff, linspace, meshgrid, ones, pi, roll, shape
 from scipy.interpolate.fitpack2 import UnivariateSpline, \
     LSQBivariateSpline, SmoothBivariateSpline, RectBivariateSpline, \
     LSQSphereBivariateSpline, SmoothSphereBivariateSpline, \
@@ -74,6 +74,7 @@ class TestUnivariateSpline(TestCase):
 
 
 class TestLSQBivariateSpline(TestCase):
+    # NOTE: The systems in this test class are rank-deficient
     def test_linear_constant(self):
         x = [1,1,1,2,2,2,3,3,3]
         y = [1,2,3,1,2,3,1,2,3]
@@ -160,6 +161,7 @@ class TestSmoothBivariateSpline(TestCase):
         assert_array_almost_equal(lut([1,1.5,2],[1,1.5]),[[0,0],[1,1],[2,2]])
 
     def test_integral(self):
+        # NOTE: This test raises a warning
         x = [1,1,1,2,2,2,4,4,4]
         y = [1,2,3,1,2,3,1,2,3]
         z = array([0,7,8,3,4,7,1,3,4])
@@ -183,78 +185,49 @@ class TestSmoothBivariateSpline(TestCase):
         assert_almost_equal(lut.integral(tx[0], tx[-2], ty[0], ty[-2]), trpz)
 
 class TestLSQSphereBivariateSpline(TestCase):
-    def test_linear_constant(self):
-        # define the knots
-        knotst, knotsp = linspace(0., pi, 7), linspace(0., 2.*pi, 9)
-        knotst[0] += .001
-        knotsp[0] += .001
-        knotsp[-1] -= .001
-        knotst[-1] -= .001
+    def setUp(self):
         # define the input data and coordinates
-        lats, lons = linspace(0., pi, 7), linspace(0., 2*pi, 9)
-        data = ones((lons.shape[0], lats.shape[0]))
-        data[0,:], data[-1,:], data[:,0], data[:,-1] = 0., 0., 0., 0.
-        data[1,1:-1], data[-2,1:-1], data[1:-1,1], data[1:-1,-2] = 1., 1., 1., \
-                                                                   1.
-        data[2,2:-3], data[-3,2:-3], data[2:-3,2], data[2:-3,-3], data[2:-2,4] = 2., 2., 2., 2., 2.
-        data[3:6,3] = 3.
-        data = data.T
-        data = data[:,:-1]
-        lons = lons[:-1]
-        # define the coordinates we will test
-        new_lats = lats
-        new_lons = lons
-        lats, lons = meshgrid(lats, lons)
+        ntheta, nphi = 70, 90
+        theta = linspace(0.5/(ntheta - 1), 1 - 0.5/(ntheta - 1), ntheta) * pi
+        phi = linspace(0.5/(nphi - 1), 1 - 0.5/(nphi - 1), nphi) * 2. * pi
+        data = ones((theta.shape[0], phi.shape[0]))
+        # define knots and extract data values at the knots
+        knotst = theta[::5]
+        knotsp = phi[::5]
+        knotdata = data[::5, ::5]
         # calculate spline coefficients
+        lats, lons = meshgrid(theta, phi)
         lut_lsq = LSQSphereBivariateSpline(lats.ravel(), lons.ravel(),
                                            data.T.ravel(), knotst, knotsp)
-        assert_almost_equal(lut_lsq.get_residual(), 0.0)
-        assert_array_almost_equal(lut_lsq(new_lats, new_lons), data)
+        self.lut_lsq = lut_lsq
+        self.data = knotdata
+        self.new_lons, self.new_lats = knotsp, knotst
 
+    def test_linear_constant(self):
+        assert_almost_equal(self.lut_lsq.get_residual(), 0.0)
+        assert_array_almost_equal(self.lut_lsq(self.new_lats, self.new_lons),
+                                  self.data)
 
     def test_empty_input(self):
-        # define the knots
-        knotst, knotsp = linspace(0., pi, 7), linspace(0., 2.*pi, 9)
-        knotst[0] += .001
-        knotsp[0] += .001
-        knotsp[-1] -= .001
-        knotst[-1] -= .001
-        # define the input data and coordinates
-        lats, lons = linspace(0., pi, 7), linspace(0., 2*pi, 9)
-        data = ones((lons.shape[0], lats.shape[0]))
-        data[0,:], data[-1,:], data[:,0], data[:,-1] = 0., 0., 0., 0.
-        data[1,1:-1], data[-2,1:-1], data[1:-1,1], data[1:-1,-2] = 1., 1., 1., \
-                                                                   1.
-        data[2,2:-3], data[-3,2:-3], data[2:-3,2], data[2:-3,-3], data[2:-2,4] = 2., 2., 2., 2., 2.
-        data[3:6,3] = 3.
-        data = data.T
-        data = data[:,:-1]
-        lons = lons[:-1]
-        # define the coordinates we will test
-        new_lats = lats
-        new_lons = lons
-        lats, lons = meshgrid(lats, lons)
-        # calculate spline coefficients
-        lut_lsq = LSQSphereBivariateSpline(lats.ravel(), lons.ravel(),
-                                           data.T.ravel(), knotst, knotsp)
-        assert_array_almost_equal(lut_lsq([], []), array([]))
+        assert_array_almost_equal(self.lut_lsq([], []), array([]))
 
 
 class TestSmoothSphereBivariateSpline(TestCase):
-    def test_linear_constant(self):
-        theta = array([.25*pi,.25*pi,.25*pi,.5*pi,.5*pi,.5*pi,.75*pi,.75*pi,.75*pi])
-        phi = array([.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi])
-        r = array([3,3,3,3,3,3,3,3,3])
-        lut = SmoothSphereBivariateSpline(theta,phi,r,s=1E10)
-        assert_almost_equal(lut.get_residual(),0.0)
-        assert_array_almost_equal(lut([1,1.5,2],[1,1.5]),[[3,3],[3,3],[3,3]])
+    def setUp(self):
+        theta = array([.25*pi, .25*pi, .25*pi, .5*pi, .5*pi, .5*pi, .75*pi,
+                       .75*pi, .75*pi])
+        phi = array([.5 * pi, pi, 1.5 * pi, .5 * pi, pi, 1.5 * pi, .5 * pi, pi,
+                     1.5 * pi])
+        r = array([3, 3, 3, 3, 3, 3, 3, 3, 3])
+        self.lut = SmoothSphereBivariateSpline(theta, phi, r, s=1E10)
 
-    def test_empty_constant(self):
-        theta = array([.25*pi,.25*pi,.25*pi,.5*pi,.5*pi,.5*pi,.75*pi,.75*pi,.75*pi])
-        phi = array([.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi,.5*pi,pi,1.5*pi])
-        r = array([3,3,3,3,3,3,3,3,3])
-        lut = SmoothSphereBivariateSpline(theta,phi,r,s=1E10)
-        assert_array_almost_equal(lut([],[]), array([]))
+    def test_linear_constant(self):
+        assert_almost_equal(self.lut.get_residual(), 0.)
+        assert_array_almost_equal(self.lut([1, 1.5, 2],[1, 1.5]),
+                                  [[3, 3], [3, 3], [3, 3]])
+
+    def test_empty_input(self):
+        assert_array_almost_equal(self.lut([], []), array([]))
 
 
 class TestRectBivariateSpline(TestCase):

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -194,21 +194,22 @@ class TestLSQSphereBivariateSpline(TestCase):
         lats, lons = linspace(0., pi, 7), linspace(0., 2*pi, 9)
         data = ones((lons.shape[0], lats.shape[0]))
         data[0,:], data[-1,:], data[:,0], data[:,-1] = 0., 0., 0., 0.
-        data[1,1:-1], data[-2,1:-1], data[1:-1,1], data[1:-1,-2] = 1., 1., 1., 1.
+        data[1,1:-1], data[-2,1:-1], data[1:-1,1], data[1:-1,-2] = 1., 1., 1., \
+                                                                   1.
         data[2,2:-3], data[-3,2:-3], data[2:-3,2], data[2:-3,-3], data[2:-2,4] = 2., 2., 2., 2., 2.
         data[3:6,3] = 3.
         data = data.T
         data = data[:,:-1]
         lons = lons[:-1]
         # define the coordinates we will test
-        new_lats = lats.copy()
-        new_lons = lons.copy()
+        new_lats = lats
+        new_lons = lons
         lats, lons = meshgrid(lats, lons)
         # calculate spline coefficients
-        lut_lsq = LSQSphereBivariateSpline(lats.ravel(), lons.ravel(), data.T.ravel(),
-                                          knotst, knotsp)
-        assert_almost_equal(lut_lsq.get_residual(),0.0)
-        assert_array_almost_equal(lut_lsq(new_lats, new_lons),data)
+        lut_lsq = LSQSphereBivariateSpline(lats.ravel(), lons.ravel(),
+                                           data.T.ravel(), knotst, knotsp)
+        assert_almost_equal(lut_lsq.get_residual(), 0.0)
+        assert_array_almost_equal(lut_lsq(new_lats, new_lons), data)
 
 
 class TestSmoothSphereBivariateSpline(TestCase):


### PR DESCRIPTION
I finally got around to wrap FITPACK's `sphere.f` for use in `scipy.interpolate`.

If I'm not mistaken, the `integrate()` methods won't return correct values in spherical coordinates. Therefore I'd like to disable them for `LSQSpherBivariateSpline` and `SmoothSpherBivariateSpline`. But I'm not sure how to best do this.
