### PR TITLE
Collection of fixes - #1528, #1385 and warnings

### DIFF
--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -101,9 +101,7 @@ def load_testing_files():
     for fn in _filenames:
         name = fn.replace(".txt", "").replace("-ml", "")
         fqfn = os.path.join(os.path.dirname(__file__), fn)
-        fp = open(fqfn)
-        eo[name] = np.loadtxt(fp)
-        fp.close()
+        eo[name] = np.loadtxt(fqfn)
 
 load_testing_files()
 

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -101,9 +101,9 @@ def load_testing_files():
     for fn in _filenames:
         name = fn.replace(".txt", "").replace("-ml", "")
         fqfn = os.path.join(os.path.dirname(__file__), fn)
-        eo[name] = np.loadtxt(open(fqfn))
-        #print "%s: %s   %s" % (name, str(eo[name].shape), str(eo[name].dtype))
-    #eo['pdist-boolean-inp'] = np.bool_(eo['pdist-boolean-inp'])
+        fp = open(fqfn)
+        eo[name] = np.loadtxt(fp)
+        fp.close()
 
 load_testing_files()
 

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -115,7 +115,9 @@ class TestKMean(TestCase):
 
     def test_kmeans_lost_cluster(self):
         """This will cause kmean to have a cluster with no points."""
-        data = np.fromfile(open(DATAFILE1), sep = ", ")
+        fp = open(DATAFILE1)
+        data = np.fromfile(fp, sep = ", ")
+        fp.close()
         data = data.reshape((200, 2))
         initk = np.array([[-1.8127404, -0.67128041],
                          [ 2.04621601, 0.07401111],
@@ -146,7 +148,9 @@ class TestKMean(TestCase):
 
     def test_kmeans2_rank1(self):
         """Testing simple call to kmeans2 with rank 1 data."""
-        data = np.fromfile(open(DATAFILE1), sep = ", ")
+        fp = open(DATAFILE1)
+        data = np.fromfile(fp, sep = ", ")
+        fp.close()
         data = data.reshape((200, 2))
         data1 = data[:, 0]
         data2 = data[:, 1]
@@ -158,7 +162,9 @@ class TestKMean(TestCase):
 
     def test_kmeans2_rank1_2(self):
         """Testing simple call to kmeans2 with rank 1 data."""
-        data = np.fromfile(open(DATAFILE1), sep = ", ")
+        fp = open(DATAFILE1)
+        data = np.fromfile(fp, sep = ", ")
+        fp.close()
         data = data.reshape((200, 2))
         data1 = data[:, 0]
 
@@ -166,7 +172,9 @@ class TestKMean(TestCase):
 
     def test_kmeans2_init(self):
         """Testing that kmeans2 init methods work."""
-        data = np.fromfile(open(DATAFILE1), sep = ", ")
+        fp = open(DATAFILE1)
+        data = np.fromfile(fp, sep = ", ")
+        fp.close()
         data = data.reshape((200, 2))
 
         kmeans2(data, 3, minit = 'random')

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -116,9 +116,7 @@ class TestKMean(TestCase):
 
     def test_kmeans_lost_cluster(self):
         """This will cause kmean to have a cluster with no points."""
-        fp = open(DATAFILE1)
-        data = np.fromfile(fp, sep = ", ")
-        fp.close()
+        data = np.fromfile(DATAFILE1, sep = ", ")
         data = data.reshape((200, 2))
         initk = np.array([[-1.8127404, -0.67128041],
                          [ 2.04621601, 0.07401111],
@@ -148,9 +146,7 @@ class TestKMean(TestCase):
 
     def test_kmeans2_rank1(self):
         """Testing simple call to kmeans2 with rank 1 data."""
-        fp = open(DATAFILE1)
-        data = np.fromfile(fp, sep = ", ")
-        fp.close()
+        data = np.fromfile(DATAFILE1, sep = ", ")
         data = data.reshape((200, 2))
         data1 = data[:, 0]
         data2 = data[:, 1]
@@ -162,9 +158,7 @@ class TestKMean(TestCase):
 
     def test_kmeans2_rank1_2(self):
         """Testing simple call to kmeans2 with rank 1 data."""
-        fp = open(DATAFILE1)
-        data = np.fromfile(fp, sep = ", ")
-        fp.close()
+        data = np.fromfile(DATAFILE1, sep = ", ")
         data = data.reshape((200, 2))
         data1 = data[:, 0]
 
@@ -172,9 +166,7 @@ class TestKMean(TestCase):
 
     def test_kmeans2_init(self):
         """Testing that kmeans2 init methods work."""
-        fp = open(DATAFILE1)
-        data = np.fromfile(fp, sep = ", ")
-        fp.close()
+        data = np.fromfile(DATAFILE1, sep = ", ")
         data = data.reshape((200, 2))
 
         kmeans2(data, 3, minit = 'random')

--- a/scipy/constants/tests/test_codata.py
+++ b/scipy/constants/tests/test_codata.py
@@ -3,28 +3,34 @@ import warnings
 from scipy.constants import constants, codata, find, value
 from numpy.testing import assert_equal, assert_, run_module_suite, \
                           assert_almost_equal
+from numpy.testing.utils import WarningManager
+
 
 def test_find():
+    warn_ctx = WarningManager()
+    warn_ctx.__enter__()
+    try:
+        warnings.simplefilter('ignore', DeprecationWarning)
 
-    warnings.simplefilter('ignore', DeprecationWarning)
+        keys = find('weak mixing', disp=False)
+        assert_equal(keys, ['weak mixing angle'])
 
-    keys = find('weak mixing', disp=False)
-    assert_equal(keys, ['weak mixing angle'])
+        keys = find('qwertyuiop', disp=False)
+        assert_equal(keys, [])
 
-    keys = find('qwertyuiop', disp=False)
-    assert_equal(keys, [])
-
-    keys = find('natural unit', disp=False)
-    assert_equal(keys, sorted(['natural unit of velocity',
-                                'natural unit of action',
-                                'natural unit of action in eV s',
-                                'natural unit of mass',
-                                'natural unit of energy',
-                                'natural unit of energy in MeV',
-                                'natural unit of mom.um',
-                                'natural unit of mom.um in MeV/c',
-                                'natural unit of length',
-                                'natural unit of time']))
+        keys = find('natural unit', disp=False)
+        assert_equal(keys, sorted(['natural unit of velocity',
+                                    'natural unit of action',
+                                    'natural unit of action in eV s',
+                                    'natural unit of mass',
+                                    'natural unit of energy',
+                                    'natural unit of energy in MeV',
+                                    'natural unit of mom.um',
+                                    'natural unit of mom.um in MeV/c',
+                                    'natural unit of length',
+                                    'natural unit of time']))
+    finally:
+        warn_ctx.__exit__()
 
 
 def test_basic_table_parse():

--- a/scipy/integrate/dop/dop853.f
+++ b/scipy/integrate/dop/dop853.f
@@ -867,6 +867,7 @@ C ----- COMPUTE PLACE OF II-TH COMPONENT
    5  CONTINUE
       IF (I.EQ.0) THEN
          WRITE (6,*) ' NO DENSE OUTPUT AVAILABLE FOR COMP.',II 
+         CONTD8=-1
          RETURN
       END IF  
       S=(X-XOLD)/H

--- a/scipy/integrate/dop/dopri5.f
+++ b/scipy/integrate/dop/dopri5.f
@@ -634,6 +634,7 @@ C ----- COMPUTE PLACE OF II-TH COMPONENT
    5  CONTINUE
       IF (I.EQ.0) THEN
          WRITE (6,*) ' NO DENSE OUTPUT AVAILABLE FOR COMP.',II 
+         CONTD5=-1
          RETURN
       END IF  
       THETA=(X-XOLD)/H

--- a/scipy/integrate/multipack.h
+++ b/scipy/integrate/multipack.h
@@ -175,7 +175,7 @@ static PyObject *call_python_function(PyObject *func, npy_intp n, double *x, PyO
    */
   if ((result = PyEval_CallObject(func, arglist))==NULL) {
     PyErr_Print();
-    tmpobj = PyObject_GetAttrString(func, "func_name");
+    tmpobj = PyObject_GetAttrString(func, "__name__");
     if (tmpobj == NULL) goto fail;
     str1 = PyString_FromString("Error occurred while calling the Python function named ");
     if (str1 == NULL) { Py_DECREF(tmpobj); goto fail;}

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -18,9 +18,8 @@ __all__ = [
     'RectBivariateSpline',
     'RectSphereBivariateSpline']
 
-from types import NoneType
-
 import warnings
+
 from numpy import zeros, concatenate, alltrue, ravel, all, diff, array
 import numpy as np
 
@@ -906,7 +905,7 @@ class RectSphereBivariateSpline(BivariateSpline):
                  pole_exact=False, pole_flat=False):
         iopt = np.array([0, 0, 0], dtype=int)
         ider = np.array([-1, 0, -1, 0], dtype=int)
-        if isinstance(pole_values, NoneType):
+        if pole_values is None:
             pole_values = (None, None)
         elif isinstance(pole_values, (float, np.float32, np.float64)):
             pole_values = (pole_values, pole_values)

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 # Created by Pearu Peterson, June 2003
+import warnings
 
 from numpy.testing import assert_equal, assert_almost_equal, assert_array_equal, \
         assert_array_almost_equal, assert_allclose, TestCase, run_module_suite
+from numpy.testing.utils import WarningManager
 from numpy import array, diff, shape, linspace, pi
 from scipy.interpolate.fitpack2 import UnivariateSpline, LSQBivariateSpline, \
     SmoothBivariateSpline, RectBivariateSpline, RectSphereBivariateSpline
@@ -91,7 +93,14 @@ class TestLSQBivariateSpline(TestCase):
         s = 0.1
         tx = [1+s,3-s]
         ty = [1+s,3-s]
-        lut = LSQBivariateSpline(x,y,z,tx,ty,kx=1,ky=1)
+        warn_ctx = WarningManager()
+        warn_ctx.__enter__()
+        try:
+            # This seems to fail (ier=1, see ticket 1642).
+            warnings.simplefilter('ignore', UserWarning)
+            lut = LSQBivariateSpline(x,y,z,tx,ty,kx=1,ky=1)
+        finally:
+            warn_ctx.__exit__()
 
         tx, ty = lut.get_knots()
 
@@ -163,7 +172,15 @@ class TestSmoothBivariateSpline(TestCase):
         y = [1,2,3,1,2,3,1,2,3]
         z = array([0,7,8,3,4,7,1,3,4])
 
-        lut = SmoothBivariateSpline(x,y,z,kx=1,ky=1,s=0)
+        warn_ctx = WarningManager()
+        warn_ctx.__enter__()
+        try:
+            # This seems to fail (ier=1, see ticket 1642).
+            warnings.simplefilter('ignore', UserWarning)
+            lut = SmoothBivariateSpline(x, y, z, kx=1, ky=1, s=0)
+        finally:
+            warn_ctx.__exit__()
+
         tx = [1,2,4]
         ty = [1,2,3]
 
@@ -172,7 +189,7 @@ class TestSmoothBivariateSpline(TestCase):
                     *(tz[:-1,:-1]+tz[1:,:-1]+tz[:-1,1:]+tz[1:,1:])).sum()
         assert_almost_equal(lut.integral(tx[0], tx[-1], ty[0], ty[-1]), trpz)
 
-        lut2 = SmoothBivariateSpline(x,y,z,kx=2,ky=2,s=0)
+        lut2 = SmoothBivariateSpline(x, y, z, kx=2, ky=2, s=0)
         assert_almost_equal(lut2.integral(tx[0], tx[-1], ty[0], ty[-1]), trpz,
                             decimal=0) # the quadratures give 23.75 and 23.85
 

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -49,9 +49,11 @@ class DataTest(TestCase):
     def test_filelike(self):
         """Test reading from file-like object (StringIO)"""
         f1 = open(test1)
-        f2 = StringIO(open(test1).read())
         data1, meta1 = loadarff(f1)
-        data2, meta2 = loadarff(f2)
+        f1.close()
+        f2 = open(test1)
+        data2, meta2 = loadarff(StringIO(f2.read()))
+        f2.close()
         assert_(data1 == data2)
         assert_(repr(meta1) == repr(meta2))
 
@@ -67,6 +69,7 @@ class HeaderTest(TestCase):
         """Test parsing type of attribute from their value."""
         ofile = open(test2)
         rel, attrs = read_header(ofile)
+        ofile.close()
 
         expected = ['numeric', 'numeric', 'numeric', 'numeric', 'numeric',
                     'numeric', 'string', 'string', 'nominal', 'nominal']
@@ -78,6 +81,7 @@ class HeaderTest(TestCase):
         """Test parsing wrong type of attribute from their value."""
         ofile = open(test3)
         rel, attrs = read_header(ofile)
+        ofile.close()
 
         for name, value in attrs:
             assert_raises(ParseArffError, parse_type, value)
@@ -86,6 +90,7 @@ class HeaderTest(TestCase):
         """Parsing trivial header with nothing."""
         ofile = open(test1)
         rel, attrs = read_header(ofile)
+        ofile.close()
 
         # Test relation
         assert_(rel == 'test1')

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -197,9 +197,9 @@ case_table5.append(
     {'name': 'object',
      'expected': {'testobject': MO}
      })
-u_str = open(
-    pjoin(test_data_path, 'japanese_utf8.txt'),
-    'rb').read().decode('utf-8')
+fp_u_str = open(pjoin(test_data_path, 'japanese_utf8.txt'), 'rb')
+u_str = fp_u_str.read().decode('utf-8')
+fp_u_str.close()
 case_table5.append(
     {'name': 'unicode',
     'expected': {'testunicode': array([u_str])}
@@ -383,10 +383,12 @@ def test_mat73():
         pjoin(test_data_path, 'testhdf5*.mat'))
     assert_true(len(filenames)>0)
     for filename in filenames:
+        fp = open(filename, 'rb')
         assert_raises(NotImplementedError,
                       loadmat,
-                      filename,
+                      fp,
                       struct_as_record=True)
+        fp.close()
 
 
 def test_warnings():
@@ -607,6 +609,7 @@ def test_skip_variable():
     #
     d = factory.get_variables('second')
     yield assert_true, d.has_key('second')
+    factory.mat_stream.close()
 
 
 def test_empty_struct():
@@ -710,8 +713,10 @@ def test_read_opts():
 def test_empty_string():
     # make sure reading empty string does not raise error
     estring_fname = pjoin(test_data_path, 'single_empty_string.mat')
-    rdr = MatFile5Reader_future(open(estring_fname, 'rb'))
+    fp = open(estring_fname, 'rb')
+    rdr = MatFile5Reader_future(fp)
     d = rdr.get_variables()
+    fp.close()
     assert_array_equal(d['a'], np.array([], dtype='U1'))
     # empty string round trip.  Matlab cannot distiguish
     # between a string array that is empty, and a string array
@@ -729,6 +734,7 @@ def test_empty_string():
     rdr = MatFile5Reader_future(stream)
     d = rdr.get_variables()
     assert_array_equal(d['a'], np.array([], dtype='U1'))
+    stream.close()
 
 
 def test_mat4_3d():
@@ -749,8 +755,10 @@ def test_mat4_3d():
 
 def test_func_read():
     func_eg = pjoin(test_data_path, 'testfunc_7.4_GLNX86.mat')
-    rdr = MatFile5Reader_future(open(func_eg, 'rb'))
+    fp = open(func_eg, 'rb')
+    rdr = MatFile5Reader_future(fp)
     d = rdr.get_variables()
+    fp.close()
     yield assert_true, isinstance(d['testfunc'], MatlabFunction)
     stream = BytesIO()
     wtr = MatFile5Writer(stream, oned_as='row')
@@ -759,11 +767,16 @@ def test_func_read():
 
 def test_mat_dtype():
     double_eg = pjoin(test_data_path, 'testmatrix_6.1_SOL2.mat')
-    rdr = MatFile5Reader_future(open(double_eg, 'rb'), mat_dtype=False)
+    fp = open(double_eg, 'rb')
+    rdr = MatFile5Reader_future(fp, mat_dtype=False)
     d = rdr.get_variables()
+    fp.close()
     yield assert_equal, d['testmatrix'].dtype.kind, 'u'
-    rdr = MatFile5Reader_future(open(double_eg, 'rb'), mat_dtype=True)
+
+    fp = open(double_eg, 'rb')
+    rdr = MatFile5Reader_future(fp, mat_dtype=True)
     d = rdr.get_variables()
+    fp.close()
     yield assert_equal, d['testmatrix'].dtype.kind, 'f'
 
 
@@ -878,8 +891,10 @@ def test_varmats_from_mat():
 def test_one_by_zero():
     ''' Test 1x0 chars get read correctly '''
     func_eg = pjoin(test_data_path, 'one_by_zero_char.mat')
-    rdr = MatFile5Reader_future(open(func_eg, 'rb'))
+    fp = open(func_eg, 'rb')
+    rdr = MatFile5Reader_future(fp)
     d = rdr.get_variables()
+    fp.close()
     assert_equal(d['var'].shape, (0,))
 
 

--- a/scipy/io/matlab/tests/test_mio_funcs.py
+++ b/scipy/io/matlab/tests/test_mio_funcs.py
@@ -45,8 +45,8 @@ def read_minimat_vars(rdr):
     return mdict
 
 def read_workspace_vars(fname):
-    rdr = MatFile5Reader(open(fname, 'rb'),
-                         struct_as_record=True)
+    fp = open(fname, 'rb')
+    rdr = MatFile5Reader(fp, struct_as_record=True)
     vars = rdr.get_variables()
     fws = vars['__function_workspace__']
     ws_bs = BytesIO(fws.tostring())
@@ -56,7 +56,9 @@ def read_workspace_vars(fname):
     mi = rdr.mat_stream.read(2)
     rdr.byte_order = mi == asbytes('IM') and '<' or '>'
     rdr.mat_stream.read(4) # presumably byte padding
-    return read_minimat_vars(rdr)
+    mdict = read_minimat_vars(rdr)
+    fp.close()
+    return mdict
 
 
 def test_jottings():

--- a/scipy/io/tests/test_idl.py
+++ b/scipy/io/tests/test_idl.py
@@ -6,12 +6,11 @@ DATA_PATH = path.join(path.dirname(__file__), 'data')
 import numpy as np
 from numpy.compat import asbytes_nested, asbytes
 from numpy.testing import assert_equal, assert_array_equal, run_module_suite
+from numpy.testing.utils import WarningManager
 from nose.tools import assert_true
 
 from scipy.io.idl import readsav
 
-warnings.filterwarnings('ignore', message="warning: multi-dimensional structures")
-warnings.filterwarnings('ignore', message="warning: empty strings")
 
 def object_array(*args):
     '''Constructs a numpy array of objects'''
@@ -118,7 +117,14 @@ class TestCompressed(TestScalars):
     '''Test that compressed .sav files can be read in'''
 
     def test_compressed(self):
-        s = readsav(path.join(DATA_PATH, 'various_compressed.sav'), verbose=False)
+        warn_ctx = WarningManager()
+        warn_ctx.__enter__()
+        try:
+            warnings.filterwarnings('ignore', message="warning: empty strings")
+            s = readsav(path.join(DATA_PATH, 'various_compressed.sav'), verbose=False)
+        finally:
+            warn_ctx.__exit__()
+
         assert_identical(s.i8u, np.uint8(234))
         assert_identical(s.f32, np.float32(-3.1234567e+37))
         assert_identical(s.c64, np.complex128(1.1987253647623157e+112-5.1987258887729157e+307j))
@@ -368,8 +374,13 @@ class TestPointerStructures:
             assert_true(np.all(vect_id(s.arrays_rep.h[i]) == id(s.arrays_rep.h[0][0])))
 
     def test_arrays_replicated_3d(self):
-
-        s = readsav(path.join(DATA_PATH, 'struct_pointer_arrays_replicated_3d.sav'), verbose=False)
+        warn_ctx = WarningManager()
+        warn_ctx.__enter__()
+        try:
+            warnings.filterwarnings('ignore', message="warning: multi-dimensional structures")
+            s = readsav(path.join(DATA_PATH, 'struct_pointer_arrays_replicated_3d.sav'), verbose=False)
+        finally:
+            warn_ctx.__exit__()
 
         # Check column types
         assert_true(s.arrays_rep.g.dtype.type is np.object_)

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -122,7 +122,9 @@ def test_read_example_data():
     # read any example data files
     for fname in glob(pjoin(TEST_DATA_PATH, '*.nc')):
         f = netcdf_file(fname, 'r')
+        f.close()
         f = netcdf_file(fname, 'r', mmap=False)
+        f.close()
 
 def test_itemset_no_segfault_on_readonly():
     # Regression test for ticket #1202.
@@ -130,6 +132,7 @@ def test_itemset_no_segfault_on_readonly():
     filename = pjoin(TEST_DATA_PATH, 'example_1.nc')
     f = netcdf_file(filename, 'r')
     time_var = f.variables['time']
+    f.close()
     # time_var.assignValue(42) should raise a RuntimeError--not seg. fault!
     assert_raises(RuntimeError, time_var.assignValue, 42)
 

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -1,15 +1,25 @@
 import os
 import tempfile
-import numpy as np
+import warnings
 
+import numpy as np
 from numpy.testing import assert_equal, assert_, assert_raises, assert_array_equal
+from numpy.testing.utils import WarningManager
 from scipy.io import wavfile
+
 
 def datafile(fn):
     return os.path.join(os.path.dirname(__file__), 'data', fn)
 
 def test_read_1():
-    rate, data = wavfile.read(datafile('test-44100-le-1ch-4bytes.wav'))
+    warn_ctx = WarningManager()
+    warn_ctx.__enter__()
+    try:
+        warnings.simplefilter('ignore', wavfile.WavFileWarning)
+        rate, data = wavfile.read(datafile('test-44100-le-1ch-4bytes.wav'))
+    finally:
+        warn_ctx.__exit__()
+
     assert_equal(rate, 44100)
     assert_(np.issubdtype(data.dtype, np.int32))
     assert_equal(data.shape, (4410,))

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -21,7 +21,9 @@ def test_read_2():
     assert_equal(data.shape, (800, 2))
 
 def test_read_fail():
-    assert_raises(ValueError, wavfile.read, datafile('example_1.nc'))
+    fp = open(datafile('example_1.nc'))
+    assert_raises(ValueError, wavfile.read, fp)
+    fp.close()
 
 def _check_roundtrip(rate, dtype, channels):
     fd, tmpfile = tempfile.mkstemp(suffix='.wav')

--- a/scipy/lib/blas/tests/test_blas.py
+++ b/scipy/lib/blas/tests/test_blas.py
@@ -11,10 +11,12 @@ Run tests if scipy is installed:
 """
 
 import math
+import warnings
 
 from numpy import array
 from numpy.testing import assert_equal, assert_almost_equal, \
         assert_array_almost_equal, TestCase, run_module_suite
+from numpy.testing.utils import WarningManager
 from scipy.lib.blas import fblas
 from scipy.lib.blas import cblas
 from scipy.lib.blas import get_blas_funcs
@@ -198,11 +200,13 @@ class TestBLAS(TestCase):
         b = array([[1],[1],[1]])
 
         # get_blas_funcs is deprecated, silence the warning
-        import warnings
-        warnings.simplefilter('ignore', DeprecationWarning)
-        gemm, = get_blas_funcs(('gemm',),(a,b))
-        # remove filter again
-        warnings.filters.pop(0)
+        warn_ctx = WarningManager()
+        warn_ctx.__enter__()
+        try:
+            warnings.simplefilter('ignore', DeprecationWarning)
+            gemm, = get_blas_funcs(('gemm',),(a,b))
+        finally:
+            warn_ctx.__exit__()
 
         assert_array_almost_equal(gemm(1,a,b),[[3]],15)
 

--- a/scipy/odr/__odrpack.c
+++ b/scipy/odr/__odrpack.c
@@ -110,7 +110,7 @@ void fcn_callback(int *n, int *m, int *np, int *nq, int *ldn, int *ldm,
             }
 
           PyErr_Print();
-          tmpobj = PyObject_GetAttrString(odr_global.fcn, "func_name");
+          tmpobj = PyObject_GetAttrString(odr_global.fcn, "__name__");
           if (tmpobj == NULL)
             goto fail;
 
@@ -165,7 +165,7 @@ void fcn_callback(int *n, int *m, int *np, int *nq, int *ldn, int *ldm,
             }
 
           PyErr_Print();
-          tmpobj = PyObject_GetAttrString(odr_global.fjacb, "func_name");
+          tmpobj = PyObject_GetAttrString(odr_global.fjacb, "__name__");
           if (tmpobj == NULL)
             goto fail;
 
@@ -243,7 +243,7 @@ void fcn_callback(int *n, int *m, int *np, int *nq, int *ldn, int *ldm,
             }
 
           PyErr_Print();
-          tmpobj = PyObject_GetAttrString(odr_global.fjacd, "func_name");
+          tmpobj = PyObject_GetAttrString(odr_global.fjacd, "__name__");
           if (tmpobj == NULL)
             goto fail;
 

--- a/scipy/optimize/minpack.h
+++ b/scipy/optimize/minpack.h
@@ -154,7 +154,7 @@ static PyObject *call_python_function(PyObject *func, npy_intp n, double *x, PyO
    */
   if ((result = PyEval_CallObject(func, arglist))==NULL) {
     PyErr_Print();
-    tmpobj = PyObject_GetAttrString(func, "func_name");
+    tmpobj = PyObject_GetAttrString(func, "__name__");
     if (tmpobj == NULL) goto fail;
     str1 = PyString_FromString("Error occurred while calling the Python function named ");
     if (str1 == NULL) { Py_DECREF(tmpobj); goto fail;}

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -18,7 +18,7 @@ def _check_func(checker, argname, thefunc, x0, args, numinputs, output_shape=Non
                     return shape(res)
             msg = "%s: there is a mismatch between the input and output " \
                   "shape of the '%s' argument" % (checker, argname)
-            func_name = getattr(thefunc, 'func_name', None)
+            func_name = getattr(thefunc, '__name__', None)
             if func_name:
                 msg += " '%s'." % func_name
             else:

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -12,7 +12,7 @@ from scipy.optimize.minpack import leastsq, curve_fit, fixed_point
 
 
 class ReturnShape(object):
-    """This class exists to create a callable that does not have a 'func_name' attribute.
+    """This class exists to create a callable that does not have a '__name__' attribute.
 
     __init__ takes the argument 'shape', which should be a tuple of ints.  When an instance
     it called with a single argument 'x', it returns numpy.ones(shape).
@@ -105,7 +105,7 @@ class TestFSolve(TestCase):
         assert_array_almost_equal(final_flows, np.ones(4))
 
     def test_wrong_shape_func_callable(self):
-        """The callable 'func' has no 'func_name' attribute."""
+        """The callable 'func' has no '__name__' attribute."""
         func = ReturnShape(1)
         # x0 is a list of two elements, but func will return an array with
         # length 1, so this should result in a TypeError.
@@ -119,7 +119,7 @@ class TestFSolve(TestCase):
         assert_raises(TypeError, optimize.fsolve, dummy_func, x0, args=((1,),))
 
     def test_wrong_shape_fprime_callable(self):
-        """The callables 'func' and 'deriv_func' have no 'func_name' attribute."""
+        """The callables 'func' and 'deriv_func' have no '__name__' attribute."""
         func = ReturnShape(1)
         deriv_func = ReturnShape((2,2))
         assert_raises(TypeError, optimize.fsolve, func, x0=[0,1], fprime=deriv_func)
@@ -172,7 +172,7 @@ class TestLeastSq(TestCase):
         assert_array_equal(p0, p0_copy)
 
     def test_wrong_shape_func_callable(self):
-        """The callable 'func' has no 'func_name' attribute."""
+        """The callable 'func' has no '__name__' attribute."""
         func = ReturnShape(1)
         # x0 is a list of two elements, but func will return an array with
         # length 1, so this should result in a TypeError.
@@ -186,7 +186,7 @@ class TestLeastSq(TestCase):
         assert_raises(TypeError, optimize.leastsq, dummy_func, x0, args=((1,),))
 
     def test_wrong_shape_Dfun_callable(self):
-        """The callables 'func' and 'deriv_func' have no 'func_name' attribute."""
+        """The callables 'func' and 'deriv_func' have no '__name__' attribute."""
         func = ReturnShape(1)
         deriv_func = ReturnShape((2,2))
         assert_raises(TypeError, optimize.leastsq, func, x0=[0,1], Dfun=deriv_func)

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -1708,4 +1708,3 @@ band_dict = {'band': 'bandpass',
              'h': 'highpass'
              }
 
-warnings.simplefilter("always", BadCoefficients)

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -181,13 +181,13 @@ class coo_matrix(_data_matrix):
 
                 if np.rank(M) != 2:
                     raise TypeError('expected rank <= 2 array or matrix')
+
                 self.shape = M.shape
-                self.row,self.col = (M != 0).nonzero()
-                self.data  = M[self.row,self.col]
+                self.row, self.col = M.nonzero()
+                self.data  = M[self.row, self.col]
 
         if dtype is not None:
             self.data = self.data.astype(dtype)
-
 
         self._check()
 

--- a/scipy/spatial/qhull/src/global.c
+++ b/scipy/spatial/qhull/src/global.c
@@ -614,7 +614,7 @@ void qh_initflags(char *command) {
   if (command <= &qh qhull_command[0] || command > &qh qhull_command[0] + sizeof(qh qhull_command)) {
     if (command != &qh qhull_command[0]) {
       *qh qhull_command= '\0';
-      strncat( qh qhull_command, command, sizeof( qh qhull_command));
+      strncat( qh qhull_command, command, sizeof( qh qhull_command)-strlen( qh qhull_command)-1);
     }
     while (*s && !isspace(*s))  /* skip program name */
       s++;

--- a/scipy/spatial/qhull/src/rboxlib.c
+++ b/scipy/spatial/qhull/src/rboxlib.c
@@ -124,7 +124,7 @@ int qh_rboxpoints(FILE* fout, FILE* ferr, char* rbox_command) {
   }
 
   *command= '\0';
-  strncat(command, rbox_command, sizeof(command));
+  strncat(command, rbox_command, sizeof(command)-strlen(command)-1);
 
   while (*s && !isspace(*s))  /* skip program name */
     s++;
@@ -347,7 +347,7 @@ int qh_rboxpoints(FILE* fout, FILE* ferr, char* rbox_command) {
   }else if (israndom) {
     seed= (int)time(&timedata);
     sprintf(seedbuf, " t%d", seed);  /* appends an extra t, not worth removing */
-    strncat(command, seedbuf, sizeof(command));
+    strncat(command, seedbuf, sizeof(command)-strlen(command)-1);
     t= strstr(command, " t ");
     if (t)
       strcpy(t+1, t+3); /* remove " t " */

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -8,6 +8,7 @@ import warnings
 from numpy.testing import TestCase, run_module_suite, assert_array_equal, \
     assert_almost_equal, assert_array_less, assert_array_almost_equal, \
     assert_raises, assert_, assert_allclose
+from numpy.testing.utils import WarningManager
 
 import scipy.stats as stats
 
@@ -89,7 +90,16 @@ class TestAnsari(TestCase):
                            101, 96, 97, 102, 107, 113, 116, 113, 110, 98))
         parekh = np.array((107, 108, 106, 98, 105, 103, 110, 105, 104,
                            100, 96, 108, 103, 104, 114, 114, 113, 108, 106, 99))
-        W, pval = stats.ansari(ramsay, parekh)
+
+        warn_ctx = WarningManager()
+        warn_ctx.__enter__()
+        try:
+            warnings.filterwarnings('ignore',
+                        message="Ties preclude use of exact statistic.")
+            W, pval = stats.ansari(ramsay, parekh)
+        finally:
+            warn_ctx.__exit__()
+
         assert_almost_equal(W,185.5,11)
         assert_almost_equal(pval,0.18145819972867083,11)
 
@@ -101,9 +111,6 @@ class TestAnsari(TestCase):
     def test_bad_arg(self):
         assert_raises(ValueError, stats.ansari, [], [1])
         assert_raises(ValueError, stats.ansari, [1], [])
-
-warnings.filterwarnings('ignore',
-                        message="Ties preclude use of exact statistic.")
 
 
 class TestBartlett(TestCase):
@@ -306,11 +313,11 @@ def test_circstats():
     M = stats.circmean(x, high=360)
     Mval = 0.167690146
     assert_allclose(M, Mval, rtol=1e-7)
-    
+
     V = stats.circvar(x, high=360)
     Vval = 42.51955609
     assert_allclose(V, Vval, rtol=1e-7)
-    
+
     S = stats.circstd(x, high=360)
     Sval = 6.520702116
     assert_allclose(S, Sval, rtol=1e-7)
@@ -335,7 +342,7 @@ def test_circvar_axis():
     x = np.array([[355,5,2,359,10,350],
                   [351,7,4,352,9,349],
                   [357,9,8,358,4,356]])
-    
+
     V1 = stats.circvar(x, high=360)
     V2 = stats.circvar(x.ravel(), high=360)
     assert_allclose(V1, V2, rtol=1e-11)
@@ -352,7 +359,7 @@ def test_circstd_axis():
     x = np.array([[355,5,2,359,10,350],
                   [351,7,4,352,9,349],
                   [357,9,8,358,4,356]])
-    
+
     S1 = stats.circstd(x, high=360)
     S2 = stats.circstd(x.ravel(), high=360)
     assert_allclose(S1, S2, rtol=1e-11)
@@ -364,7 +371,7 @@ def test_circstd_axis():
     S1 = stats.circstd(x, high=360, axis=0)
     S2 = [stats.circstd(x[:,i], high=360) for i in range(x.shape[1])]
     assert_allclose(S1, S2, rtol=1e-11)
-    
+
 
 def test_circstats_small():
     x = np.array([20,21,22,18,19,20.5,19.2])

--- a/scipy/weave/bytecodecompiler.py
+++ b/scipy/weave/bytecodecompiler.py
@@ -693,7 +693,8 @@ class CXXCoder(ByteCodeMeaning):
         assert_(inspect.isfunction(function))
         assert_(not function.func_defaults,
                 msg="Function cannot have default args (yet)")
-        if name is None: name = function.func_name
+        if name is None:
+            name = function.__name__
         self.name = name
         self.function = function
         self.signature = signature


### PR DESCRIPTION
Fixes:
- all ResourceWarnings under Python 3.2 (#1528)
- some build warnings that are a problem with the OpenSuse build service (#1358)
- filters all visible warnings when running tests
- fixes up existing warning filters with usage of WarningManager
- some cleanups in cluster.vq test file

This should all be fairly straightforward. Please pay attention to the two one-liner Fortran fixes for #1358; they look reasonable but I don't speak much Fortran. 
