### PR TITLE
Fix incorrect output shape of UnivariateSpline

### DIFF
--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -545,15 +545,15 @@ def splev(x, tck, der=0, ext=0):
 
         x = myasarray(x)
         y, ier =_fitpack._spl_(x, der, t, c, k, ext)
+        
         if ier == 10:
             raise ValueError("Invalid input data")
         if ier == 1:
             raise ValueError("Found x value not in the domain")
         if ier:
             raise TypeError("An error occurred")
-        if len(y) > 1:
-            return y
-        return y[0]
+        
+        return y
 
 def splint(a,b,tck,full_output=0):
     """


### PR DESCRIPTION
The shape of the output of UnivariateSpline.__call__ does not match the shape of the input when the input is a one-item array. The behavior is unexpected and leads to bugs.

```
In [1]: import scipy.interpolate
In [2]: f = scipy.interpolate.UnivariateSpline([1,2,3,4], [1,2,3,4])

In [3]: f(1)
Out[3]: 0.99999999999999956

In [4]: f([1])
Out[4]: 0.9999999999999995

In [5]: f([1, 2])
Out[5]: array([ 1.,  2.])
```

The consistent bahavior would be f([1]) -> [1.0] rather than the current f([1]) -> 1.0 

See http://projects.scipy.org/scipy/ticket/1534
