### PR TITLE
Fix ndimage.grey_dilation

### DIFF
--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -1420,6 +1420,10 @@ def grey_dilation(input,  size = None, footprint = None, structure = None,
         origin[ii] = -origin[ii]
         if footprint is not None:
             sz = footprint.shape[ii]
+        elif structure is not None:
+            sz = structure.shape[ii]
+        elif numpy.isscalar(size):
+            sz = size
         else:
             sz = size[ii]
         if not sz & 1:

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -1163,8 +1163,8 @@ def grey_erosion(input,  size = None, footprint = None, structure = None,
         Array over which the grayscale erosion is to be computed.
 
     size : tuple of ints
-        Shape of a flat and full structuring element used for the
-        grayscale erosion. Optional if `footprint` is provided.
+        Shape of a flat and full structuring element used for the grayscale
+        erosion. Optional if `footprint` or `structure` is provided.
 
     footprint : array of ints, optional
         Positions of non-infinite elements of a flat structuring element
@@ -1289,8 +1289,8 @@ def grey_dilation(input,  size = None, footprint = None, structure = None,
         Array over which the grayscale dilation is to be computed.
 
     size : tuple of ints
-        Shape of a flat and full structuring element used for the
-        grayscale dilation. Optional if `footprint` is provided.
+        Shape of a flat and full structuring element used for the grayscale
+        dilation. Optional if `footprint` or `structure` is provided.
 
     footprint : array of ints, optional
         Positions of non-infinite elements of a flat structuring element
@@ -1451,8 +1451,8 @@ def grey_opening(input, size = None, footprint = None, structure = None,
         Array over which the grayscale opening is to be computed.
 
     size : tuple of ints
-        Shape of a flat and full structuring element used for the
-        grayscale opening. Optional if `footprint` is provided.
+        Shape of a flat and full structuring element used for the grayscale
+        opening. Optional if `footprint` or `structure` is provided.
 
     footprint : array of ints, optional
         Positions of non-infinite elements of a flat structuring element
@@ -1546,8 +1546,8 @@ def grey_closing(input, size = None, footprint = None, structure = None,
         Array over which the grayscale closing is to be computed.
 
     size : tuple of ints
-        Shape of a flat and full structuring element used for the
-        grayscale closing. Optional if `footprint` is provided.
+        Shape of a flat and full structuring element used for the grayscale
+        closing. Optional if `footprint` or `structure` is provided.
 
     footprint : array of ints, optional
         Positions of non-infinite elements of a flat structuring element
@@ -1643,9 +1643,9 @@ def morphological_gradient(input, size = None, footprint = None,
         Array over which to compute the morphlogical gradient.
 
     size : tuple of ints
-        Shape of a flat and full structuring element used for the
-        mathematical morphology operations. Optional if `footprint`
-        is provided. A larger `size` yields a more blurred gradient.
+        Shape of a flat and full structuring element used for the mathematical
+        morphology operations. Optional if `footprint` or `structure` is
+        provided. A larger `size` yields a more blurred gradient.
 
     footprint : array of ints, optional
         Positions of non-infinite elements of a flat structuring element

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -1266,6 +1266,8 @@ def grey_erosion(input,  size = None, footprint = None, structure = None,
            [0, 0, 0, 0, 0, 0, 0]])
 
     """
+    if size is None and footprint is None and structure is None:
+        raise ValueError("size, footprint or structure must be specified")
     return filters._min_or_max_filter(input, size, footprint, structure,
                                       output, mode, cval, origin, 1)
 
@@ -1406,6 +1408,8 @@ def grey_dilation(input,  size = None, footprint = None, structure = None,
            [1, 1, 1, 1, 1, 1, 1]])
 
     """
+    if size is None and footprint is None and structure is None:
+        raise ValueError("size, footprint or structure must be specified")
     if structure is not None:
         structure = numpy.asarray(structure)
         structure = structure[tuple([slice(None, None, -1)] *

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -4662,6 +4662,30 @@ class TestNdimage:
             assert_array_almost_equal(expected, out)
 
 
+class TestDilateFix:
+
+    def setUp(self):
+        # dilation related setup
+        self.array = numpy.array([[0, 0, 0, 0, 0,],
+                                  [0, 0, 0, 0, 0,],
+                                  [0, 0, 0, 1, 0,],
+                                  [0, 0, 1, 1, 0,],
+                                  [0, 0, 0, 0, 0,]], dtype=numpy.uint8)
+
+        self.sq3x3 = numpy.ones((3, 3))
+        dilated3x3 = ndimage.binary_dilation(self.array, structure=self.sq3x3)
+        self.dilated3x3 = dilated3x3.view(numpy.uint8)
+
+    def test_dilation_square_structure(self):
+        result = ndimage.grey_dilation(self.array, structure=self.sq3x3)
+        # +1 accounts for difference between grey and binary dilation
+        assert_array_almost_equal(result, self.dilated3x3 + 1)
+
+    def test_dilation_scalar_size(self):
+        result = ndimage.grey_dilation(self.array, size=3)
+        assert_array_almost_equal(result, self.dilated3x3)
+
+
 #class NDImageTestResult(unittest.TestResult):
 #    separator1 = '=' * 70 + '\n'
 #    separator2 = '-' * 70 + '\n'


### PR DESCRIPTION
`grey_dilation` raises an error if given a scalar `size` or if `structure` is given but `size` and `footprint` aren't. Note that other morphology functions behave correctly for these cases. See [original post](http://mail.scipy.org/pipermail/scipy-user/2009-August/022423.html) and  [ticket #1135](http://projects.scipy.org/scipy/ticket/1135) for details.
