### PR TITLE
BUG: make sparse.block_diag work with only one matrix

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -20,6 +20,8 @@ from coo import coo_matrix
 from lil import lil_matrix
 from dia import dia_matrix
 
+from base import issparse
+
 def spdiags(data, diags, m, n, format=None):
     """
     Return a sparse matrix from diagonals.
@@ -563,14 +565,11 @@ def block_diag(mats, format=None, dtype=None):
 
     """
     nmat = len(mats)
-    if nmat == 1:
-        rows = mats
-    else:
-        rows = []
-        for ia, a in enumerate(mats):
-            row = [None]*nmat
-            row[ia] = a
-            rows.append(row)
+    rows = []
+    for ia, a in enumerate(mats):
+        row = [None]*nmat
+        row[ia] = a if issparse(a) else coo_matrix(a)
+        rows.append(row)
     return bmat(rows, format=format, dtype=dtype)
 
 def rand(m, n, density=0.01, format="coo", dtype=None):

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -563,11 +563,14 @@ def block_diag(mats, format=None, dtype=None):
 
     """
     nmat = len(mats)
-    rows = []
-    for ia, a in enumerate(mats):
-        row = [None]*nmat
-        row[ia] = a
-        rows.append(row)
+    if nmat == 1:
+        rows = mats
+    else:
+        rows = []
+        for ia, a in enumerate(mats):
+            row = [None]*nmat
+            row[ia] = a
+            rows.append(row)
     return bmat(rows, format=format, dtype=dtype)
 
 def rand(m, n, density=0.01, format="coo", dtype=None):

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -306,6 +306,11 @@ class TestConstructUtils(TestCase):
 
         assert_equal(construct.block_diag((A, B, C)).todense(), expected)
 
+    def test_block_diag_1(self):
+        """ block_diag with one matrix """
+        assert_equal(construct.block_diag([[1, 0]]).todense(),
+                     matrix([[1, 0]]))
+
     def test_rand(self):
         # Simple sanity checks for sparse.rand
         for t in [np.float32, np.float64, np.longdouble]:

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -293,7 +293,8 @@ class TestConstructUtils(TestCase):
 
         #TODO test failure cases
 
-    def test_block_diag(self):
+    def test_block_diag_basic(self):
+        """ basic test for block_diag """
         A = coo_matrix([[1,2],[3,4]])
         B = coo_matrix([[5],[6]])
         C = coo_matrix([[7]])
@@ -306,10 +307,24 @@ class TestConstructUtils(TestCase):
 
         assert_equal(construct.block_diag((A, B, C)).todense(), expected)
 
+    def test_block_diag_scalar_1d_args(self):
+        """ block_diag with scalar and 1d arguments """
+        # one 1d matrix and a scalar
+        assert_array_equal(construct.block_diag([[2,3], 4]).toarray(),
+                           [[2, 3, 0], [0, 0, 4]])
+
     def test_block_diag_1(self):
         """ block_diag with one matrix """
         assert_equal(construct.block_diag([[1, 0]]).todense(),
                      matrix([[1, 0]]))
+        assert_equal(construct.block_diag([[[1, 0]]]).todense(),
+                     matrix([[1, 0]]))
+        assert_equal(construct.block_diag([[[1], [0]]]).todense(),
+                     matrix([[1], [0]]))
+        # just on scalar
+        assert_equal(construct.block_diag([1]).todense(),
+                     matrix([[1]]))
+
 
     def test_rand(self):
         # Simple sanity checks for sparse.rand


### PR DESCRIPTION
Currenlty `sparse.block_diag([[1, 0]])` raises `ValueError: blocks must have rank 2`.
With this patch, it returns a 1x2 sparse matrix as expected.
