### PR TITLE
Ticket #954: ndimage.distance_transform_edt

### DIFF
--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -2160,7 +2160,7 @@ def distance_transform_edt(input, sampling = None,
     ft_inplace = isinstance(indices, numpy.ndarray)
     dt_inplace = isinstance(distances, numpy.ndarray)
     # calculate the feature transform
-    input = numpy.where(input, 1, 0).astype(numpy.int8)
+    input = numpy.atleast_1d(numpy.where(input, 1, 0).astype(numpy.int8))
     if sampling is not None:
         sampling = _ni_support._normalize_sequence(sampling, input.ndim)
         sampling = numpy.asarray(sampling, dtype = numpy.float64)

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2987,6 +2987,11 @@ class TestNdimage:
                                                        sampling=[2, 1])
         assert_array_almost_equal(ref, out)
 
+    def test_distance_transform_edt5(self):
+        "Ticket #954"
+        out = ndimage.distance_transform_edt(False) 
+        assert_array_almost_equal(out, [0.])
+
     def test_generate_structure01(self):
         "generation of a binary structure 1"
         struct = ndimage.generate_binary_structure(0, 1)


### PR DESCRIPTION
One line correction to ndimage.distance_transform_edt which fixed segmentation fault upon passing False as mentioned in Ticket 954.

This is my first pull request so please be kind if I have made a mistake.
