### PR TITLE
FIX: ndimage.zoom ticket #1122

### DIFF
--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -518,12 +518,10 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
 
     zoom_div = numpy.array(output_shape, float) - 1
     zoom = (numpy.array(input.shape) - 1) / zoom_div
-    zoom = numpy.where(numpy.array(input.shape) == numpy.array(output_shape),
-                       1.0, zoom)
-
-    # Zooming to infinity is unpredictable, so just choose
+    
+    # Zooming to non-finite values in unpredictable, so just choose
     # zoom factor 1 instead
-    zoom[numpy.isinf(zoom)] = 1
+    zoom[~numpy.isfinite(zoom)] = 1
 
     output, return_value = _ni_support._get_output(output, input,
                                                    shape=output_shape)

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -518,6 +518,8 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
 
     zoom_div = numpy.array(output_shape, float) - 1
     zoom = (numpy.array(input.shape) - 1) / zoom_div
+    zoom = numpy.where(numpy.array(input.shape) == numpy.array(output_shape),
+                       1.0, zoom)
 
     # Zooming to infinity is unpredictable, so just choose
     # zoom factor 1 instead

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2122,6 +2122,19 @@ class TestNdimage:
         out = ndimage.zoom(ndimage.zoom(arr,2),0.5)
         assert_array_equal(out,arr)
 
+    def test_zoom3(self):
+        "zoom 3"
+        err = numpy.seterr(invalid='ignore')    
+        arr = numpy.array([[1, 2]])
+        try:
+            out1 = ndimage.zoom(arr, (2, 1))
+            out2 = ndimage.zoom(arr, (1,2))
+        finally:
+            numpy.seterr(**err)
+
+        assert_array_almost_equal(out1, numpy.array([[1, 2], [1, 2]])) 
+        assert_array_almost_equal(out2, numpy.array([[1, 1, 2, 2]]))
+
     def test_zoom_affine01(self):
         "zoom by affine transformation 1"
         data = [[1, 2, 3, 4],

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2147,7 +2147,7 @@ class TestNdimage:
         arr = numpy.zeros((1, 5, 5))
         zoom = (1.0, 2.0, 2.0)
         
-        err = numpy.seterr(divide='ignore')
+        err = numpy.seterr(invalid='ignore')
         try:
             out = ndimage.zoom(arr, zoom, cval=7)
         finally:

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2146,7 +2146,12 @@ class TestNdimage:
         """Ticket #1122"""
         arr = numpy.zeros((1, 5, 5))
         zoom = (1.0, 2.0, 2.0)
-        out = ndimage.zoom(arr, zoom, cval=7)
+        
+        err = numpy.seterr(divide='ignore')
+        try:
+            out = ndimage.zoom(arr, zoom, cval=7)
+        finally:
+            numpy.seterr(**err)
         ref = numpy.zeros((1, 10, 10))
         assert_array_almost_equal(out, ref)
 

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2141,6 +2141,14 @@ class TestNdimage:
             ndimage.zoom(numpy.zeros((dim, dim)), 1./dim, mode='nearest')
         finally:
             numpy.seterr(**err)
+    
+    def test_zoom_zoomfactor_one(self):
+        """Ticket #1122"""
+        arr = numpy.zeros((1, 5, 5))
+        zoom = (1.0, 2.0, 2.0)
+        out = ndimage.zoom(arr, zoom, cval=7)
+        ref = numpy.zeros((1, 10, 10))
+        assert_array_almost_equal(out, ref)
 
     def test_rotate01(self):
         "rotate 1"


### PR DESCRIPTION
Using patch submitted by russel fixed Ticket #1122.  Added a unit test to catch error.  With my numpy error setup the test still raises a RuntimeWarning because of the division by zero but passes.
