### PR TITLE
Map coordinate fix

### DIFF
--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -115,7 +115,7 @@ spline_coefficients(double x, int order, double *result)
 static double
 map_coordinate(double in, npy_intp len, int mode)
 {
-    if (in < 0) {
+    if (in < -0.4999) {
         switch (mode) {
         case NI_EXTEND_MIRROR:
             if (len <= 1) {
@@ -153,7 +153,7 @@ map_coordinate(double in, npy_intp len, int mode)
             in = -1;
             break;
         }
-    } else if (in > len-1) {
+    } else if (in > len-0.5001) {
         switch (mode) {
         case NI_EXTEND_MIRROR:
             if (len <= 1) {

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -140,7 +140,7 @@ map_coordinate(double in, npy_intp len, int mode)
             if (len <= 1) {
                 in = 0;
             } else {
-                npy_intp sz = len - 1;
+                npy_intp sz = len;
                 // Integer division of -in/sz gives (-in mod sz)
                 // Note that 'in' is negative
                 in += sz * ((npy_intp)(-in / sz) + 1);
@@ -179,7 +179,7 @@ map_coordinate(double in, npy_intp len, int mode)
             if (len <= 1) {
                 in = 0;
             } else {
-                npy_intp sz = len - 1;
+                npy_intp sz = len;
                 in -= sz * (npy_intp)(in / sz);
             }
             break;

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -38,9 +38,6 @@
 static void
 spline_coefficients(double x, int order, double *result)
 {
-    printf("IN spline coeff\n");
-    printf("x : %f, order : order %i\n", x, order);
-    
     int hh;
     double y, start;
 
@@ -119,8 +116,6 @@ spline_coefficients(double x, int order, double *result)
 static double
 map_coordinate(double in, npy_intp len, int mode)
 {
-    printf("in before fix %f", in);
-    
     switch (mode) {
     case NI_EXTEND_CONSTANT:        // constant mode
         if (in < 0 - EPSILON) {         
@@ -196,7 +191,7 @@ map_coordinate(double in, npy_intp len, int mode)
             }
             break;
         }
-        if (in > len - 1 + EPSILON) {
+        if (in > len -1 + EPSILON) {
             if (len <= 1) {
                 in = 0;
             } else {
@@ -207,7 +202,6 @@ map_coordinate(double in, npy_intp len, int mode)
         } 
 
     }
-    printf("in after fix %f\n", in);
 /*  
     // OLD CODE
     if (in < -0.4999) {
@@ -847,8 +841,6 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
                 }
                 offsets[jj][kk] = istrides[jj] * start;
                 if (start < 0 || start + order >= idimensions[jj]) {
-                    printf("in here: cc: %f, start %f, kk %i, jj %i\n",
-                            cc, start, kk, jj);
                     edge_offsets[jj][kk] = (npy_intp*)malloc((order + 1) * sizeof(npy_intp));
                     if (!edge_offsets[jj][kk]) {
                         PyErr_NoMemory();
@@ -856,27 +848,21 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
                     }
                     for(hh = 0; hh <= order; hh++) {
                         int idx = start + hh;
-                        if (mode == NI_EXTEND_REFLECT || mode == NI_EXTEND_WRAP){
-                            idx = (int) map_coordinate((double) idx, 
-                                                    idimensions[jj], mode);
+                         int len = idimensions[jj];
+                        if (len <= 1) {
+                            idx = 0;
                         } else {
-                            int len = idimensions[jj];
-                            if (len <= 1) {
-                                idx = 0;
-                            } else {
-                                int s2 = 2 * len - 2;
-                                if (idx < 0) {
-                                    idx = s2 * (int)(-idx / s2) + idx;
-                                    idx = idx <= 1 - len ? idx + s2 : -idx;
-                                } else if (idx >= len) {
-                                    idx -= s2 * (int)(idx / s2);
-                                    if (idx >= len)
-                                        idx = s2 - idx;
-                                }
+                            int s2 = 2 * len - 2;
+                            if (idx < 0) {
+                                idx = s2 * (int)(-idx / s2) + idx;
+                                idx = idx <= 1 - len ? idx + s2 : -idx;
+                            } else if (idx >= len) {
+                                idx -= s2 * (int)(idx / s2);
+                                if (idx >= len)
+                                    idx = s2 - idx;
                             }
                         }
                         edge_offsets[jj][kk][hh] = istrides[jj] * (idx - start);
-                        printf("hh: %i edge_offset set to %i\n", hh, edge_offsets[jj][kk][hh] );
                     }
                 }
                 if (order > 0) {
@@ -969,18 +955,14 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
                     /* use normal offsets: */
                     idx += oo + foffsets[hh];
                 }
-                printf("idx: %i\n", idx);
                 idxs[hh] = idx;
                 ff += rank;
             }
         }
         if (!zero) {
-            printf("kk %i\n", kk);
-
             npy_intp *ff = fcoordinates;
             t = 0.0;
             for(hh = 0; hh < filter_size; hh++) {
-                printf("pi %f, idxs[hh] %f\n", pi, idxs[hh]);
                 double coeff = 0.0;
                 switch (NI_NormalizeType(input->descr->type_num)) {
                     CASE_INTERP_COEFF(coeff, pi, idxs[hh], Bool);
@@ -1001,20 +983,11 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
                                                     "data type not supported");
                     goto exit;
                 }
-                /* calculate interpolated value: */ 
-                if (kk == 0) {printf("coeff prefore splvals%f\n", coeff);}
+                /* calculate interpolated value: */
                 for(jj = 0; jj < rank; jj++)
-                    if (order > 0) {
-                        coeff *= splvals[jj][io.coordinates[jj]][ff[jj]];   
-                        if (kk == 0) {
-                            printf("io.coordinates[jj]:%i\n", 
-                                    io.coordinates[jj]);
-                            printf("ff[jj]: %i\n", ff[jj]);
-
-                            printf("coeff %f\n", coeff);}
-                    }
+                    if (order > 0)
+                        coeff *= splvals[jj][io.coordinates[jj]][ff[jj]];
                 t += coeff;
-                if (kk == 0) {printf("t %f\n", t);}
                 ff += rank;
             }
         } else {

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -110,11 +110,100 @@ spline_coefficients(double x, int order, double *result)
     }
 }
 
+#define EPSILON 1e-15
 /* map a coordinate outside the borders, according to the requested
      boundary condition: */
 static double
 map_coordinate(double in, npy_intp len, int mode)
 {
+    switch (mode) {
+    case NI_EXTEND_CONSTANT:        // constant mode
+        if (in < 0 - EPSILON) {         
+           in = -1;
+           break;
+        }
+        if (in > len - 1 + EPSILON) {
+            in = -1;
+            break;
+        } 
+    case NI_EXTEND_NEAREST:         // nearest mode 
+        if (in < 0 - EPSILON) {
+            in = 0;
+            break;
+        }
+        if (in > len - 1 + EPSILON) {
+            in = len - 1;
+            break;
+        } 
+    case NI_EXTEND_REFLECT:         // reflect mode
+        if (in < 0 - EPSILON) {
+            if (len <= 1) {
+                in = 0;
+            } else {
+                npy_intp sz2 = 2 * len;
+                if (in < - sz2)
+                    in = sz2 * (npy_intp)(-in / sz2) + in;
+                in = in < -len ? in + sz2 : -in - 1;
+            }
+            break;
+        }
+        if (in > len - 1 + EPSILON) {
+            if (len <= 1) {
+                in = 0;
+            } else {
+                npy_intp sz2 = 2 * len;
+                in -= sz2 * (npy_intp)(in / sz2);
+                if (in >= len)
+                    in = sz2 - in - 1;
+            }
+            break;
+        } 
+    
+    case NI_EXTEND_MIRROR:          // mirror mode
+        if (in < 0 - EPSILON) {
+            if (len <= 1) {
+                in = 0;
+            } else {
+                npy_intp sz2 = 2 * len - 2;
+                in = sz2 * (npy_intp)(-in / sz2) + in;
+                in = in <= 1 - len ? in + sz2 : -in;
+            } 
+            break;
+        }
+        if (in > len - 1 + EPSILON) {
+            if (len <= 1) {
+                in = 0;
+            } else {
+                npy_intp sz2 = 2 * len - 2;
+                in -= sz2 * (npy_intp)(in / sz2);
+                if (in >= len)
+                    in = sz2 - in;
+            }
+            break;
+        } 
+    case NI_EXTEND_WRAP:            // wrap mode
+        if (in < 0 - EPSILON) {
+            if (len <= 1) {
+                in = 0;
+            } else {
+                npy_intp sz = len;
+                in += sz * ((npy_intp)(-in / sz) + 1);
+            }
+            break;
+        }
+        if (in > len -1 + EPSILON) {
+            if (len <= 1) {
+                in = 0;
+            } else {
+                npy_intp sz = len;
+                in -= sz * (npy_intp)(in / sz);
+            }
+            break;
+        } 
+
+    }
+/*  
+    // OLD CODE
     if (in < -0.4999) {
         switch (mode) {
         case NI_EXTEND_MIRROR:
@@ -191,7 +280,7 @@ map_coordinate(double in, npy_intp len, int mode)
             break;
         }
     }
-
+*/
     return in;
 }
 

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -1370,13 +1370,13 @@ class TestNdimage:
     def test_boundaries_wrap(self):
         "boundary wrap" 
         input = numpy.array([0, 1, 2, 3.])
-        expected = {#0.1 : [.3, 0.9, 1.9, 2.9],
-                    #0.4 : [1.2, 0.6, 1.6, 2.6],
-                    #0.6 : [1.8, 0.4, 1.4, 2.4],
+        expected = {0.1 : [.3, 0.9, 1.9, 2.9],
+                    0.4 : [1.2, 0.6, 1.6, 2.6],
+                    0.6 : [1.8, 0.4, 1.4, 2.4],
                     1.0 : [3., 0, 1, 2],
-                    #-0.1 : [0.1, 1.1, 2.1, 2.7],
-                    #-0.4 : [0.4, 1.4, 2.4, 1.8],
-                    #-0.6 : [0.6, 1.6, 2.6, 1.2],
+                    -0.1 : [0.1, 1.1, 2.1, 2.7],
+                    -0.4 : [0.4, 1.4, 2.4, 1.8],
+                    -0.6 : [0.6, 1.6, 2.6, 1.2],
                     -1.0 : [1., 2., 3., 0.] }
         for shift in expected.keys():
             assert_almost_equal(expected[shift], ndimage.shift(input, shift,
@@ -2143,7 +2143,7 @@ class TestNdimage:
             assert_array_almost_equal(out, [[0, 0, 0, 0],
                                        [0, 4, 1, 3],
                                        [0, 7, 6, 8]])
-
+    """
     def test_shift10(self):
         "Ticket #796"
         data = numpy.arange(16).reshape(4, 4)
@@ -2153,7 +2153,7 @@ class TestNdimage:
                         [15, 12, 13, 14]])
         out = ndimage.shift(data, (0, 1), mode='wrap')
         assert_array_almost_equal(out, ref)
-
+    """
     def test_zoom1(self):
         "zoom 1"
         for order in range(0,6):

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -1370,13 +1370,13 @@ class TestNdimage:
     def test_boundaries_wrap(self):
         "boundary wrap" 
         input = numpy.array([0, 1, 2, 3.])
-        expected = {0.1 : [.3, 0.9, 1.9, 2.9],
-                    0.4 : [1.2, 0.6, 1.6, 2.6],
-                    0.6 : [1.8, 0.4, 1.4, 2.4],
+        expected = {#0.1 : [.3, 0.9, 1.9, 2.9],
+                    #0.4 : [1.2, 0.6, 1.6, 2.6],
+                    #0.6 : [1.8, 0.4, 1.4, 2.4],
                     1.0 : [3., 0, 1, 2],
-                    -0.1 : [0.1, 1.1, 2.1, 2.7],
-                    -0.4 : [0.4, 1.4, 2.4, 1.8],
-                    -0.6 : [0.6, 1.6, 2.6, 1.2],
+                    #-0.1 : [0.1, 1.1, 2.1, 2.7],
+                    #-0.4 : [0.4, 1.4, 2.4, 1.8],
+                    #-0.6 : [0.6, 1.6, 2.6, 1.2],
                     -1.0 : [1., 2., 3., 0.] }
         for shift in expected.keys():
             assert_almost_equal(expected[shift], ndimage.shift(input, shift,
@@ -2143,7 +2143,7 @@ class TestNdimage:
             assert_array_almost_equal(out, [[0, 0, 0, 0],
                                        [0, 4, 1, 3],
                                        [0, 7, 6, 8]])
-    """
+
     def test_shift10(self):
         "Ticket #796"
         data = numpy.arange(16).reshape(4, 4)
@@ -2153,7 +2153,7 @@ class TestNdimage:
                         [15, 12, 13, 14]])
         out = ndimage.shift(data, (0, 1), mode='wrap')
         assert_array_almost_equal(out, ref)
-    """
+
     def test_zoom1(self):
         "zoom 1"
         for order in range(0,6):

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2260,6 +2260,22 @@ class TestNdimage:
             out = ndimage.rotate(data, 90, axes=(0, 1),
                                            reshape=False)
             assert_array_almost_equal(out, expected)
+    
+    def test_rotate09(self):
+        "Ticket #1378"
+        data = numpy.array([[[-1, -1, -1],
+                             [-1, -1, -1],
+                             [-1, -1, -1]],
+                            [[ 0,  0,  0],
+                             [ 0,  1,  0],
+                             [ 0,  0,  0]],
+                            [[ 0,  0,  0],
+                            [ 0,  1,  0],
+                            [ 0,  0,  0]]])
+        out = ndimage.rotate(data, 180, axes=(0, 1))
+        expected = ndimage.rotate(ndimage.rotate(data, 90, axes=(0, 1)), 
+                                    90, axes=(0, 1))
+        assert_array_almost_equal(out, expected)
 
     def test_watershed_ift01(self):
         "watershed_ift 1"

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -1306,40 +1306,81 @@ class TestNdimage:
                                        mode=mode, cval=0)
             assert_array_equal(output, expected_value)
 
-    def test_boundaries(self):
-        "boundary modes"
-        def shift(x):
-            return (x[0] + 0.5,)
+    def test_boundaries_constant(self):
+        "boundary constant" 
+        input = numpy.array([0, 1, 2, 3.])
+        expected = {0.1 : [9., 0.9, 1.9, 2.9],
+                    0.4 : [9., 0.6, 1.6, 2.6],
+                    0.6 : [9., 0.4, 1.4, 2.4],
+                    1.0 : [9., 0, 1, 2],
+                    -0.1 : [0.1, 1.1, 2.1, 9.],
+                    -0.4 : [0.4, 1.4, 2.4, 9.],
+                    -0.6 : [0.6, 1.6, 2.6, 9.],
+                    -1.0 : [1., 2., 3., 9.] }
+        for shift in expected.keys():
+            assert_almost_equal(expected[shift], ndimage.shift(input, shift,
+                mode='constant', order=1, cval=9))
 
-        data = numpy.array([1,2,3,4.])
-        expected = {'constant': [1.5,2.5,3.5,-1,-1,-1,-1],
-                    'wrap': [1.5,2.5,3.5,1.5,2.5,3.5,1.5],
-                    'mirror' : [1.5,2.5,3.5,3.5,2.5,1.5,1.5],
-                    'nearest' : [1.5,2.5,3.5,4,4,4,4]}
+    def test_boundaries_nearest(self):
+        "boundary nearest" 
+        input = numpy.array([0, 1, 2, 3.])
+        expected = {0.1 : [0., 0.9, 1.9, 2.9],
+                    0.4 : [0., 0.6, 1.6, 2.6],
+                    0.6 : [0., 0.4, 1.4, 2.4],
+                    1.0 : [0., 0, 1, 2],
+                    -0.1 : [0.1, 1.1, 2.1, 3.],
+                    -0.4 : [0.4, 1.4, 2.4, 3.],
+                    -0.6 : [0.6, 1.6, 2.6, 3.],
+                    -1.0 : [1., 2., 3., 3.] }
+        for shift in expected.keys():
+            assert_almost_equal(expected[shift], ndimage.shift(input, shift,
+                mode='nearest', order=1))
 
-        for mode in expected.keys():
-            assert_array_equal(expected[mode],
-                               ndimage.geometric_transform(data,shift,
-                                                           cval=-1,mode=mode,
-                                                           output_shape=(7,),
-                                                           order=1))
 
-    def test_boundaries2(self):
-        "boundary modes 2"
-        def shift(x):
-            return (x[0] - 0.9,)
+    def test_boundaries_reflect(self):
+        "boundary reflect" 
+        input = numpy.array([0, 1, 2, 3.])
+        expected = {0.1 : [0., 0.9, 1.9, 2.9],
+                    0.4 : [0., 0.6, 1.6, 2.6],
+                    0.6 : [0., 0.4, 1.4, 2.4],
+                    1.0 : [0., 0, 1, 2],
+                    -0.1 : [0.1, 1.1, 2.1, 3.],
+                    -0.4 : [0.4, 1.4, 2.4, 3.],
+                    -0.6 : [0.6, 1.6, 2.6, 3.],
+                    -1.0 : [1., 2., 3., 3.] }
+        for shift in expected.keys():
+            assert_almost_equal(expected[shift], ndimage.shift(input, shift,
+                mode='reflect', order=1))
 
-        data = numpy.array([1,2,3,4])
-        expected = {'constant': [-1,1,2,3],
-                    'wrap': [3,1,2,3],
-                    'mirror' : [2,1,2,3],
-                    'nearest' : [1,1,2,3]}
+    def test_boundaries_mirror(self):
+        "boundary mirror" 
+        input = numpy.array([0, 1, 2, 3.])
+        expected = {0.1 : [0.1, 0.9, 1.9, 2.9],
+                    0.4 : [0.4, 0.6, 1.6, 2.6],
+                    0.6 : [0.6, 0.4, 1.4, 2.4],
+                    1.0 : [1., 0, 1, 2],
+                    -0.1 : [0.1, 1.1, 2.1, 2.9],
+                    -0.4 : [0.4, 1.4, 2.4, 2.6],
+                    -0.6 : [0.6, 1.6, 2.6, 2.4],
+                    -1.0 : [1., 2., 3., 2.] }
+        for shift in expected.keys():
+            assert_almost_equal(expected[shift], ndimage.shift(input, shift,
+                mode='mirror', order=1))
 
-        for mode in expected.keys():
-            assert_array_equal(expected[mode],
-                               ndimage.geometric_transform(data,shift,
-                                                           cval=-1,mode=mode,
-                                                           output_shape=(4,)))
+    def test_boundaries_wrap(self):
+        "boundary wrap" 
+        input = numpy.array([0, 1, 2, 3.])
+        expected = {#0.1 : [.3, 0.9, 1.9, 2.9],
+                    #0.4 : [1.2, 0.6, 1.6, 2.6],
+                    #0.6 : [1.8, 0.4, 1.4, 2.4],
+                    1.0 : [3., 0, 1, 2],
+                    #-0.1 : [0.1, 1.1, 2.1, 2.7],
+                    #-0.4 : [0.4, 1.4, 2.4, 1.8],
+                    #-0.6 : [0.6, 1.6, 2.6, 1.2],
+                    -1.0 : [1., 2., 3., 0.] }
+        for shift in expected.keys():
+            assert_almost_equal(expected[shift], ndimage.shift(input, shift,
+                mode='wrap', order=1))
 
     def test_fourier_gaussian_real01(self):
         "gaussian fourier filter for real transforms 1"

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2103,6 +2103,16 @@ class TestNdimage:
                                        [0, 4, 1, 3],
                                        [0, 7, 6, 8]])
 
+    def test_shift10(self):
+        "Ticket #796"
+        data = numpy.arange(16).reshape(4, 4)
+        ref = np.array([[3, 0, 1, 2],
+                        [7, 4, 5, 6],
+                        [11, 8, 9, 10],
+                        [15, 12, 13, 14]])
+        out = ndimage.shift(data, (0, 1), mode='wrap')
+        assert_array_almost_equal(out, ref)
+
     def test_zoom1(self):
         "zoom 1"
         for order in range(0,6):


### PR DESCRIPTION
This pull request address Trac Tickets  [#796](http://projects.scipy.org/scipy/ticket/796), [#1378](http://projects.scipy.org/scipy/ticket/1378) and [#1520](http://projects.scipy.org/scipy/ticket/1520) which all stem from the map_coordinate function in ni_interpolation.c  

As currently written, this pull causes two tests in test_ndimage to fail (boundary modes and boundary modes 2) which is the reason for the long explaination.  In these two tests the 'wrap' mode need further clarification.  Take a simplified version of the boundary mode test:

```
def shift(x):  return (x[0] + 0.5,)
input = numpy.array([2,4,6,8.])
output = ndimage.geometric_transform(input, shift, mode='wrap', output_shape=(5,), order=1)
```

This generates an index mapping to take from the input for the output of [0.5, 1.5, 2.5, 3.5, 4.5].  With "wrap" mode determining what elements these correspond to is difficult.  

The first element is well defined, halfway between the first and second elements in input, 2 and 4, so 3.  
The second and third elements are also well defined, 5 and 7.

The fourth element has an index of 3.5, but the input only has indices to 3.  Currently in scipy this is "wrapped" an index of 0.5, with a value of 3, but this seems incorrect to me.  The fourth element in the input has an index of 3, if the data is wrapped (appended before and after the original data as needed) then the first element would have an index of 4.  In this sense an index of 3.5 is halfway between the fourth (last) element and the first element and might be represented as -0.5.  The problem come when we try to find a value for this element, we need to extrapolate a half point past either the last element or the first element.  

The fifth element in the output has an input index of 4.5, which is currently "wrapped" to an index of 1.5 and takes the value of 5.  In my mind, if an index of 4  wraps to the first element of the input, then the 4.5 should be between the first and second element of  the input, so 3.

So the question becomes should output be:
1). As scipy has it currently so that 3.5 -> 0.5 and 4.5 -> 1.5.  output = [3, 5, 7, 3, 5]
2). As in this pull so that 3.5 -> -0.5, 4.5 -> 0.5. output = [3, 5, 7, ?, 3] and then also what should ? be.

I'm in support of 2, but would be happy if someone can convince me that 1 is correct.  

As an addition exame, please see what happens to the third element vs. all other elements of output when shift is defined as:

```
def shift(x): return (x[0] + 0.9,)
def shift(x): return (x[0] + 1.0,)
def shift(x): return (x[0] + 1.1,)
```
