### PR TITLE
ENH implement unary functions on CSR/CSC matrices that don't change the sparsity

### DIFF
--- a/doc/release/0.11.0-notes.rst
+++ b/doc/release/0.11.0-notes.rst
@@ -61,6 +61,18 @@ added to easily construct diagonal and block-diagonal sparse matrices
 respectively.
 
 
+New operations on sparse matrices
+---------------------------------
+
+``scipy.sparse.csc_matrix`` and ``csr_matrix`` now support the operations
+``sin``, ``tan``, ``arcsin``, ``arctan``, ``sinh``, ``tanh``, ``arcsinh``,
+``arctanh``, ``rint``, ``sign``, ``expm1``, ``log1p``, ``deg2rad``, ``rad2deg``,
+``floor``, ``ceil`` and ``trunc``.
+
+Previously, these operations had to be performed by operating on the matrices'
+``data`` attribute.
+
+
 LSMR iterative solver
 ---------------------
 

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -8,7 +8,6 @@
 
 __all__ = []
 
-import types
 import numpy as np
 
 from base import spmatrix
@@ -20,26 +19,6 @@ from sputils import isscalarlike
 class _data_matrix(spmatrix):
     def __init__(self):
         spmatrix.__init__(self)
-
-        # Add the numpy unary ufuncs for which func(0) = 0
-        # to this class.
-        for npfunc in [np.sin, np.tan, np.arcsin, np.arctan,
-                       np.sinh, np.tanh, np.arcsinh, np.arctanh,
-                       np.rint, np.sign, np.expm1, np.log1p,
-                       np.deg2rad, np.rad2deg, np.floor, np.ceil,
-                       np.trunc]:
-            name = npfunc.__name__
-
-            def create_func(op):
-                def func(self):
-                    result = op(self.data)
-                    x = self._with_data(result, copy=True)
-                    return x
-                func.__doc__ = ("Element-wise %s\n\nSee numpy.%s "
-                                "for more information." % (name, name))
-                return func
-            setattr(self, name, types.MethodType(create_func(npfunc),
-                                                 self, self.__class__))
 
     def _get_dtype(self):
         return self.data.dtype
@@ -90,3 +69,24 @@ class _data_matrix(spmatrix):
 
     def _mul_scalar(self, other):
         return self._with_data(self.data * other)
+
+
+# Add the numpy unary ufuncs for which func(0) = 0 to _data_matrix.
+for npfunc in [np.sin, np.tan, np.arcsin, np.arctan, np.sinh, np.tanh,
+               np.arcsinh, np.arctanh, np.rint, np.sign, np.expm1, np.log1p,
+               np.deg2rad, np.rad2deg, np.floor, np.ceil, np.trunc]:
+    name = npfunc.__name__
+
+    def create_method(op):
+        def method(self):
+            result = op(self.data)
+            x = self._with_data(result, copy=True)
+            return x
+
+        method.__doc__ = ("Element-wise %s.\n\n"
+                          "See numpy.%s for more information." % (name, name))
+        method.__name__ = name
+
+        return method
+
+    setattr(_data_matrix, name, create_method(npfunc))

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -77,7 +77,7 @@ for npfunc in [np.sin, np.tan, np.arcsin, np.arctan, np.sinh, np.tanh,
                np.deg2rad, np.rad2deg, np.floor, np.ceil, np.trunc]:
     name = npfunc.__name__
 
-    def create_method(op):
+    def _create_method(op):
         def method(self):
             result = op(self.data)
             x = self._with_data(result, copy=True)
@@ -89,4 +89,4 @@ for npfunc in [np.sin, np.tan, np.arcsin, np.arctan, np.sinh, np.tanh,
 
         return method
 
-    setattr(_data_matrix, name, create_method(npfunc))
+    setattr(_data_matrix, name, _create_method(npfunc))

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1091,6 +1091,18 @@ class TestCSR(_TestCommon, _TestGetSet, _TestSolve,
         assert_array_equal(asp.data,[1, 2, 3])
         assert_array_equal(asp.todense(),bsp.todense())
 
+    def test_ufuncs(self):
+        X = csr_matrix(np.arange(20).reshape(4, 5) / 20.)
+        for f in ["sin", "tan", "arcsin", "arctan", "sinh", "tanh",
+                  "arcsinh", "arctanh", "rint", "sign", "expm1", "log1p",
+                  "deg2rad", "rad2deg", "floor", "ceil", "trunc"]:
+            assert_equal(hasattr(csr_matrix, f), True)
+            X2 = getattr(X, f)()
+            assert_equal(X.shape, X2.shape)
+            assert_array_equal(X.indices, X2.indices)
+            assert_array_equal(X.indptr, X2.indptr)
+            assert_array_equal(X2.toarray(), getattr(np, f)(X.toarray()))
+
     def test_unsorted_arithmetic(self):
         data    = arange( 5 )
         indices = array( [7, 2, 1, 5, 4] )
@@ -1178,6 +1190,18 @@ class TestCSC(_TestCommon, _TestGetSet, _TestSolve,
         asp.sort_indices()
         assert_array_equal(asp.indices,[1, 2, 7, 4, 5])
         assert_array_equal(asp.todense(),bsp.todense())
+
+    def test_ufuncs(self):
+        X = csc_matrix(np.arange(21).reshape(7, 3) / 21.)
+        for f in ["sin", "tan", "arcsin", "arctan", "sinh", "tanh",
+                  "arcsinh", "arctanh", "rint", "sign", "expm1", "log1p",
+                  "deg2rad", "rad2deg", "floor", "ceil", "trunc"]:
+            assert_equal(hasattr(csr_matrix, f), True)
+            X2 = getattr(X, f)()
+            assert_equal(X.shape, X2.shape)
+            assert_array_equal(X.indices, X2.indices)
+            assert_array_equal(X.indptr, X2.indptr)
+            assert_array_equal(X2.toarray(), getattr(np, f)(X.toarray()))
 
     def test_unsorted_arithmetic(self):
         data    = arange( 5 )


### PR DESCRIPTION
This PR adds `sin`, `tan`, `arcsin`, `arctan`, `sinh`, `tanh`, `arcsinh`, `arctanh`, `rint`, `sign`, `expm1`, `log1p`, `deg2rad`, `rad2deg`, `floor`, `ceil` and `trunc` members to CSR and CSC matrices. It replaces PR #183 and reuses @WarrenWeckesser's code for adding these methods.
