### PR TITLE
DOC: raise minimum NumPy version to 1.5.0

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -23,7 +23,7 @@ SciPy requires the following software installed for your platform:
 
 __ http://www.python.org
 
-2) NumPy__ 1.4.1 or newer (note: SciPy trunk at times requires latest NumPy
+2) NumPy__ 1.5.0 or newer (note: SciPy trunk at times requires latest NumPy
    trunk).
 
 __ http://www.numpy.org/


### PR DESCRIPTION
SciPy does not build anymore with NumPy 1.4.1.
The first error occuring is:

```
scipy/spatial/qhull/src/mem.h:23:32: error: numpy/ndarraytypes.h: No such file or directory 
```
