### PR TITLE
ENH: optimize: Return additional information from COBYLA

### DIFF
--- a/scipy/optimize/cobyla.py
+++ b/scipy/optimize/cobyla.py
@@ -8,9 +8,9 @@ fmin_coblya(func, x0, cons, args=(), consargs=None, rhobeg=1.0, rhoend=1e-4,
 
 """
 
+import numpy as np
 from scipy.optimize import _cobyla
 from optimize import Result
-from numpy import copy
 from warnings import warn
 
 __all__ = ['fmin_cobyla']
@@ -231,10 +231,16 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(), options=None):
             con[k] = c['fun'](x, *c['args'])
         return f
 
-    xopt = _cobyla.minimize(calcfc, m=m, x=copy(x0), rhobeg=rhobeg,
-                            rhoend=rhoend, iprint=iprint, maxfun=maxfun)
+    info = np.zeros(4, np.float64)
+    xopt, info = _cobyla.minimize(calcfc, m=m, x=np.copy(x0), rhobeg=rhobeg,
+                                  rhoend=rhoend, iprint=iprint, maxfun=maxfun,
+                                  dinfo=info)
 
-    return Result(x=xopt)
+    return Result(x=xopt,
+                  success=bool(info[0]),
+                  nfev=int(info[1]),
+                  fun=info[2],
+                  maxcv=info[3])
 
 if __name__ == '__main__':
 

--- a/scipy/optimize/cobyla/cobyla.pyf
+++ b/scipy/optimize/cobyla/cobyla.pyf
@@ -12,7 +12,7 @@ python module _cobyla__user__routines
 end python module _cobyla__user__routines
 python module _cobyla ! in 
     interface  ! in :__cobyla
-        subroutine minimize(calcfc,n,m,x,rhobeg,rhoend,iprint,maxfun,w,iact)
+        subroutine minimize(calcfc,n,m,x,rhobeg,rhoend,iprint,maxfun,w,iact,dinfo)
             fortranname cobyla
             use _cobyla__user__routines
             external calcfc
@@ -25,6 +25,7 @@ python module _cobyla ! in
             integer :: maxfun = 100
             double precision dimension(n*(3*n+2*m+11)+4*m+6), intent(cache,hide),depend(n,m) :: w
             integer dimension(m + 1),intent(cache,hide),depend(m) :: iact
+            double precision dimension(4), intent(in,out) :: dinfo
         end subroutine minimize
     end interface 
 end python module _cobyla

--- a/scipy/optimize/cobyla/cobyla2.f
+++ b/scipy/optimize/cobyla/cobyla2.f
@@ -1,10 +1,10 @@
 C------------------------------------------------------------------------ 
 C
       SUBROUTINE COBYLA (CALCFC, N,M,X,RHOBEG,RHOEND,IPRINT,MAXFUN,
-     & W,IACT)
+     & W,IACT, DINFO)
       IMPLICIT DOUBLE PRECISION (A-H,O-Z)
       EXTERNAL CALCFC
-      DIMENSION X(*),W(*),IACT(*)
+      DIMENSION X(*),W(*),IACT(*), DINFO(*)
 C
 C     This subroutine minimizes an objective function F(X) subject to M
 C     inequality constraints on X, where X is a vector of variables that has
@@ -74,15 +74,15 @@ C
       IWORK=IDX+N
       CALL COBYLB (CALCFC,N,M,MPP,X,RHOBEG,RHOEND,IPRINT,MAXFUN,W(ICON),
      1  W(ISIM),W(ISIMI),W(IDATM),W(IA),W(IVSIG),W(IVETA),W(ISIGB),
-     2  W(IDX),W(IWORK),IACT)
+     2  W(IDX),W(IWORK),IACT,DINFO)
       RETURN
       END
 C------------------------------------------------------------------------------
       SUBROUTINE COBYLB (CALCFC,N,M,MPP,X,RHOBEG,RHOEND,IPRINT,MAXFUN,
-     1  CON,SIM,SIMI,DATMAT,A,VSIG,VETA,SIGBAR,DX,W,IACT)
+     1  CON,SIM,SIMI,DATMAT,A,VSIG,VETA,SIGBAR,DX,W,IACT,DINFO)
       IMPLICIT DOUBLE PRECISION (A-H,O-Z)
       DIMENSION X(*),CON(*),SIM(N,*),SIMI(N,*),DATMAT(MPP,*),
-     1  A(N,*),VSIG(*),VETA(*),SIGBAR(*),DX(*),W(*),IACT(*)
+     1  A(N,*),VSIG(*),VETA(*),SIGBAR(*),DX(*),W(*),IACT(*),DINFO(*)
       EXTERNAL CALCFC
 C
 C     Set the initial values of some parameters. The last column of SIM holds
@@ -102,6 +102,9 @@ C
       DELTA=1.1d0
       RHO=RHOBEG
       PARMU=0.0d0
+C     Set the SUCCESS value of DINFO to 1.0 to start.
+C     IF an error occurs it will get set to 0.0
+      DINFO(1)=1.0d0
 
 C     Fix compiler warnings
       IFLAG=1
@@ -135,6 +138,7 @@ C
          IF (IPRINT .GE. 1) PRINT 50
    50      FORMAT (/3X,'Return from subroutine COBYLA because the ',
      1        'MAXFUN limit has been reached.')
+         DINFO(1)=0.0d0
          GOTO 600
       END IF
       NFVALS=NFVALS+1
@@ -248,6 +252,7 @@ C
           IF (IPRINT .GE. 1) PRINT 210
   210     FORMAT (/3X,'Return from subroutine COBYLA because ',
      1      'rounding errors are becoming damaging.')
+          DINFO(1)=0.0d0
           GOTO 600
       END IF
 C
@@ -551,5 +556,9 @@ C
           IF (IPTEM .LT. N) PRINT 80, (X(I),I=IPTEMP,N)
       END IF
       MAXFUN=NFVALS
+      DINFO(2)=DBLE(NFVALS)
+      DINFO(3)=DBLE(F)
+      DINFO(4)=DBLE(RESMAX)
       RETURN
       END
+

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -81,6 +81,8 @@ class Result(dict):
         Jacobian and Hessian.
     nit: int
         Number of iterations performed by the optimizer.
+    maxcv : float
+        The maximum constraint violation.
 
     Notes
     -----

--- a/scipy/optimize/tests/test_cobyla.py
+++ b/scipy/optimize/tests/test_cobyla.py
@@ -1,6 +1,7 @@
 import math
 
-from numpy.testing import assert_allclose, TestCase, run_module_suite
+from numpy.testing import assert_allclose, TestCase, run_module_suite, \
+     assert_
 
 from scipy.optimize import fmin_cobyla, minimize
 
@@ -30,9 +31,13 @@ class TestCobyla(TestCase):
         """ Minimize with method='COBYLA' """
         cons = ({'type': 'ineq', 'fun': self.con1},
                 {'type': 'ineq', 'fun': self.con2})
-        x = minimize(self.fun, self.x0, method='cobyla', constraints=cons,
-                     options=self.opts).x
-        assert_allclose(x, self.solution, atol=1e-4)
+        sol = minimize(self.fun, self.x0, method='cobyla', constraints=cons,
+                       options=self.opts)
+        assert_allclose(sol.x, self.solution, atol=1e-4)
+        assert_(sol.success, sol)
+        assert_(sol.maxcv < 1e-5, sol)
+        assert_(sol.nfev < 70, sol)
+        assert_(sol.fun < self.fun(self.solution) + 1e-3, sol)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Rescued and cleaned up from ticket http://projects.scipy.org/scipy/ticket/1350

Thanks to Darryl Wally for the patch. This looks mostly good to me.

---

Reported by: darrylwally

The standard outputs of fmin_cobyla that are printed to the screen, include: NFVALS, F, MAXCV and the function minimum.

These values could be useful to another program if they were captured and output as variables.

The attached patch affects the following files: cobyla.py, cobyla.f, and cobyla.pyf.

A new 4 element array variable is passed into the Fortran code which holds the information data (NFVALS, F, MaxCV and a new SUCCESS value) that is manipulated and returned. fmin_cobyla now returns the minimum, SUCCESS (True/False), NFVALS, F, and MAXCV.

This patch satisfies my requirements so I thought I would submit it to the community.
