### PR TITLE
BUG: integrate: fix complex_ode y attribute

### DIFF
--- a/doc/release/0.11.0-notes.rst
+++ b/doc/release/0.11.0-notes.rst
@@ -197,6 +197,19 @@ Removal of ``scipy.maxentropy``
 The ``scipy.maxentropy`` module, which was deprecated in the 0.10.0 release,
 has been removed.  Logistic regression in scikits.learn is a good and modern
 alternative for this functionality.
+alternative for this functionality.  
+
+Behavior of ``scipy.integrate.complex_ode``
+-------------------------------------------
+
+The behavior of the ``y`` attribute of ``complex_ode`` is changed.
+Previously, it expressed the complex-valued solution in the form::
+
+    z = ode.y[::2] + 1j * ode.y[1::2]
+
+Now, it is directly the complex-valued solution::
+
+    z = ode.y
 
 
 Other changes

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -8,7 +8,8 @@ from numpy import arange, zeros, array, dot, sqrt, cos, sin, eye, pi, exp, \
                   allclose
 
 from numpy.testing import assert_, TestCase, run_module_suite, \
-        assert_array_almost_equal, assert_raises, assert_allclose
+        assert_array_almost_equal, assert_raises, assert_allclose, \
+        assert_array_equal
 from scipy.integrate import odeint, ode, complex_ode
 
 #------------------------------------------------------------------------------
@@ -155,7 +156,9 @@ class TestComplexOde(TestCase):
                           method=method)
         ig.set_initial_value(problem.z0, t=0.0)
         z = ig.integrate(problem.stop_t)
+        z2 = ig.y
 
+        assert_array_equal(z, z2)
         assert_(ig.successful(), (problem, method))
         assert_(problem.verify(array([z]), problem.stop_t), (problem, method))
 


### PR DESCRIPTION
From ticket http://projects.scipy.org/scipy/ticket/1623

Thanks to borishim for the patch.

IMHO, it's probable that nobody is relying on the old behavior, as the contents of the `y` variable were misleadingly documented. Anyway, I'm thinking that just mentioning this in the release notes is enough for the transition... Thoughts?

---

scipy.integrate.complex_ode solves a complex valued problem by converting the problem to an equivalent real valued one. However, the member variable y of the class instance is a not a complex array but a float array filled with alternating real and imaginary parts. This behavior is not documented clearly. I changed the name of the member variable self.y to self._y and added a getter using property decorator. This patch should be backward compatible for existing real valued problems and more convenient for complex valued problems.
