### PR TITLE
ENH: ltisys: make lti zpk initialization work with plain lists

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -254,6 +254,9 @@ class lti(object):
             self.__dict__['A'], self.__dict__['B'], \
                                 self.__dict__['C'], \
                                 self.__dict__['D'] = zpk2ss(*args)
+            # make sure we have numpy.arrays
+            self.zeros = numpy.array(self.zeros)
+            self.poles = numpy.array(self.poles)
             self.inputs = 1
             if len(self.zeros.shape) > 1:
                 self.outputs = self.zeros.shape[0]


### PR DESCRIPTION
lti objects can be created from a 3-tuple of zero-pole-gain (zpk) values.
However, the current code only accepts numpy.array arguments, not plain lists.

This is OK:

> > > s = lti(array([]), array([-1]), 1)

This is not:

> > > s = lti([], [-1], 1)
> > >   [...]
> > >   AttributeError: 'list' object has no attribute 'shape'

Using plain Python lists is intuitive and user friendly, so make that work as
well.
