### PR TITLE
Add t-test with unequal variances, bug fix for edge case on all tests 

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1531,7 +1531,7 @@ def test_ttest_rel():
         #test zero division problem
         t,p = stats.ttest_rel([0,0,0],[1,1,1])
         assert_equal((np.abs(t),p), (np.inf, 0))
-        assert_almost_equal(stats.ttest_rel([0,0,0], [0,0,0]), (1.0, 0.42264973081037421))
+        assert_equal(stats.ttest_rel([0,0,0], [0,0,0]), (0.0, 1.0))
 
         #check that nan in input array result in nan output
         anan = np.array([[1,np.nan],[-1,1]])
@@ -1576,7 +1576,7 @@ def test_ttest_ind():
         #test zero division problem
         t,p = stats.ttest_ind([0,0,0],[1,1,1])
         assert_equal((np.abs(t),p), (np.inf, 0))
-        assert_almost_equal(stats.ttest_ind([0,0,0], [0,0,0]), (1.0, 0.37390096630005898))
+        assert_equal(stats.ttest_ind([0,0,0], [0,0,0]), (0.0, 1.0))
 
         #check that nan in input array result in nan output
         anan = np.array([[1,np.nan],[-1,1]])
@@ -1584,6 +1584,54 @@ def test_ttest_ind():
     finally:
         np.seterr(**olderr)
 
+def test_ttest_ind_uneq_var():
+    #regression test
+    tr = 1.0912746897927283
+    tr_uneq_n = 1.0664718080065985
+    pr = 0.27646507583618757
+    pr_uneq_n = 0.28953005946069343
+    tpr = ([tr,-tr],[pr,pr])
+
+    rvs3 = np.linspace(1,100, 25)
+    rvs2 = np.linspace(1,100,100)
+    rvs1 = np.linspace(5,105,100)
+    rvs1_2D = np.array([rvs1, rvs2])
+    rvs2_2D = np.array([rvs2, rvs1])
+
+    t,p = stats.ttest_ind_uneq_var(rvs1, rvs2, axis=0)
+    assert_array_almost_equal([t,p],(tr,pr))
+    t,p = stats.ttest_ind_uneq_var(rvs1, rvs3, axis =0)
+    assert_array_almost_equal([t,p], (tr_uneq_n, pr_uneq_n))
+    t,p = stats.ttest_ind_uneq_var(rvs1_2D.T, rvs2_2D.T, axis=0)
+    assert_array_almost_equal([t,p],tpr)
+    t,p = stats.ttest_ind_uneq_var(rvs1_2D, rvs2_2D, axis=1)
+    assert_array_almost_equal([t,p],tpr)
+
+    #test on 3 dimensions
+    rvs1_3D = np.dstack([rvs1_2D,rvs1_2D,rvs1_2D])
+    rvs2_3D = np.dstack([rvs2_2D,rvs2_2D,rvs2_2D])
+    t,p = stats.ttest_ind_uneq_var(rvs1_3D, rvs2_3D, axis=1)
+    assert_almost_equal(np.abs(t), np.abs(tr))
+    assert_array_almost_equal(np.abs(p), pr)
+    assert_equal(t.shape, (2, 3))
+
+    t,p = stats.ttest_ind_uneq_var(np.rollaxis(rvs1_3D,2), np.rollaxis(rvs2_3D,2), axis=2)
+    assert_array_almost_equal(np.abs(t), np.abs(tr))
+    assert_array_almost_equal(np.abs(p), pr)
+    assert_equal(t.shape, (3, 2))
+
+    olderr = np.seterr(all='ignore')
+    try:
+        #test zero division problem
+        t,p = stats.ttest_ind_uneq_var([0,0,0],[1,1,1])
+        assert_equal((np.abs(t),p), (np.inf, 0))
+        assert_equal(stats.ttest_ind_uneq_var([0,0,0], [0,0,0]), (0.0, 1.0))
+
+        #check that nan in input array result in nan output
+        anan = np.array([[1,np.nan],[-1,1]])
+        assert_equal(stats.ttest_ind_uneq_var(anan, np.zeros((2,2))),([0, np.nan], [1,np.nan]))
+    finally:
+        np.seterr(**olderr)
 
 def test_ttest_1samp_new():
     n1, n2, n3 = (10,15,20)
@@ -1617,7 +1665,7 @@ def test_ttest_1samp_new():
         #test zero division problem
         t,p = stats.ttest_1samp([0,0,0], 1)
         assert_equal((np.abs(t),p), (np.inf, 0))
-        assert_almost_equal(stats.ttest_1samp([0,0,0], 0), (1.0, 0.42264973081037421))
+        assert_equal(stats.ttest_1samp([0,0,0], 0), (0.0, 1.0))
 
         #check that nan in input array result in nan output
         anan = np.array([[1,np.nan],[-1,1]])


### PR DESCRIPTION
Added method for t-test with unequal variances. ttest_ind assumes
population variances are equal.

Refactor common code in all 4 t-test methods to _ttest_ind_setup and
_ttest_finish.

Fix bug in all 4 methods. Previous implementation would, if the
difference in means and the denominator of the t-statistic were zero,
set the t-statistic equal to 1. If the difference in means is zero, the
t-statistic should always be zero. Code and respective tests changed to
reflect this.
