### PR TITLE
MAINT: make hann() the function and hanning the alias

### DIFF
--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -185,8 +185,8 @@ def bartlett(M, sym=True):
     return w
 
 
-def hanning(M, sym=True):
-    """The M-point Hanning window.
+def hann(M, sym=True):
+    """The M-point Hann window.
 
     """
     if M < 1:
@@ -202,7 +202,7 @@ def hanning(M, sym=True):
         w = w[:-1]
     return w
 
-hann = hanning
+hanning = hann
 
 
 def barthann(M, sym=True):


### PR DESCRIPTION
pedantic, but the window is named "Hann".  "Hanning" is erroneous, from being confused with Hamming.  Also, scipy.signal documentation lists "hann", not "hanning".  https://github.com/scipy/scipy/blob/4e4c8c98802698556d0b02aebab662f72f7cf19b/scipy/signal/info.py
