### PR TITLE
Bug in scipy.io.netcdf

### DIFF
--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -305,6 +305,7 @@ class netcdf_file(object):
     sync = flush
 
     def _write(self):
+        self.fp.seek(0)
         self.fp.write(asbytes('CDF'))
         self.fp.write(array(self.version_byte, '>b').tostring())
 


### PR DESCRIPTION
Hi, 

There is a bug in scipy.io.netcdf when calling sync() or flush(). When writing to disk, the whole Netcdf structure is written, but the file is not rewound. Therefore, the second call to _write() (which can happen when closing the file) just append a second version of the structure after the first one.

This patch just adds a seek(0) before any writing operation.
