### PR TITLE
Add t-test with unequal variances, bug fix for edge case on all tests 

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2929,7 +2929,7 @@ def ttest_ind(a, b, axis=0, equal_var = True):
     """Calculates the T-test for the means of TWO INDEPENDENT samples of scores
 
     This is a two-sided test for the null hypothesis that 2 independent samples
-    with have identical average (expected) values.
+    have identical average (expected) values.
 
     Parameters
     ----------
@@ -2939,8 +2939,8 @@ def ttest_ind(a, b, axis=0, equal_var = True):
     axis : int, optional
         Axis can equal None (ravel array first), or an integer (the axis
         over which to operate on a and b).
-    equal_var : boolean, optional
-        The default is True, which performs a standard indepentent 2 sample test
+    equal_var : bool, optional
+        The default is True, which performs a standard independent 2 sample test
         that assumes equal population variances. If False, Welch's t-test, which
         does not assume equal population variance, is performed.
 
@@ -3102,7 +3102,7 @@ def ttest_rel(a,b,axis=0):
     n = a.shape[axis]
     df = float(n - 1)
 
-    d = (a - b).astype('d')
+    d = (a - b).astype(np.float64)
     v = np.var(d, axis, ddof=1)
     dm = np.mean(d, axis)
     denom = np.sqrt(v / float(n))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -85,6 +85,7 @@ CORRELATION FCNS:  paired
 
 INFERENTIAL STATS:  ttest_1samp
                     ttest_ind
+                    ttest_ind_uneq_var
                     ttest_rel
                     chisquare
                     ks_2samp
@@ -211,7 +212,7 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'cmedian', 'mode',
            'threshold', 'sigmaclip', 'trimboth', 'trim1', 'trim_mean',
            'f_oneway', 'pearsonr', 'fisher_exact',
            'spearmanr', 'pointbiserialr', 'kendalltau', 'linregress',
-           'ttest_1samp', 'ttest_ind', 'ttest_rel',
+           'ttest_1samp', 'ttest_ind', 'ttest_ind_uneq_var', 'ttest_rel',
            'kstest', 'chisquare', 'ks_2samp', 'mannwhitneyu',
            'tiecorrect', 'ranksums', 'kruskal', 'friedmanchisquare',
            'zprob', 'chisqprob', 'ksprob', 'fprob', 'betai',
@@ -2913,23 +2914,115 @@ def ttest_1samp(a, popmean, axis=0):
     v = np.var(a, axis, ddof=1)
 
     t = d / np.sqrt(v/float(n))
-    t = np.where((d==0)*(v==0), 1.0, t) #define t=0/0 = 1, identical mean, var
-    prob = distributions.t.sf(np.abs(t),df)*2  #use np.abs to get upper tail
-    #distributions.t.sf currently does not propagate nans
-    #this can be dropped, if distributions.t.sf propagates nans
-    #if this is removed, then prob = prob[()] needs to be removed
-    prob = np.where(np.isnan(t), np.nan, prob)
-
-    if t.ndim == 0:
-        t = t[()]
-        prob = prob[()]
+    t = np.where((d==0), 0.0, t) # handles case where d = v = 0
+    
+    t, prob = _ttest_finish(df, t)
+        
     return t,prob
 
 
 def ttest_ind(a, b, axis=0):
-    """Calculates the T-test for the means of TWO INDEPENDENT samples of scores.
+    """Calculates the T-test for the means of TWO INDEPENDENT samples of scores with equal variances.
 
-    This is a two-sided test for the null hypothesis that 2 independent samples
+    This is a two-sided test for the null hypothesis that 2 independent samples with equal variances
+    have identical average (expected) values.
+
+    Parameters
+    ----------
+    a, b : sequence of ndarrays
+        The arrays must have the same shape, except in the dimension
+        corresponding to `axis` (the first, by default).
+    axis : int, optional
+        Axis can equal None (ravel array first), or an integer (the axis
+        over which to operate on a and b).
+
+    Returns
+    -------
+    t : float or array
+        t-statistic
+    prob : float or array
+        two-tailed p-value
+
+
+    Notes
+    -----
+
+    We can use this test, if we observe two independent samples with equal variances from
+    the same or different population, e.g. exam scores of boys and
+    girls or of two ethnic groups. The test measures whether the
+    average (expected) value differs significantly across samples. If
+    we observe a large p-value, for example larger than 0.05 or 0.1,
+    then we cannot reject the null hypothesis of identical average scores.
+    If the p-value is smaller than the threshold, e.g. 1%, 5% or 10%,
+    then we reject the null hypothesis of equal averages.
+
+    References
+    ----------
+
+       http://en.wikipedia.org/wiki/T-test#Independent_two-sample_t-test
+
+
+    Examples
+    --------
+
+    >>> from scipy import stats
+    >>> import numpy as np
+
+    >>> #fix seed to get the same result
+    >>> np.random.seed(12345678)
+
+    test with sample with identical means
+
+    >>> rvs1 = stats.norm.rvs(loc=5,scale=10,size=500)
+    >>> rvs2 = stats.norm.rvs(loc=5,scale=10,size=500)
+    >>> stats.ttest_ind(rvs1,rvs2)
+    (0.26833823296239279, 0.78849443369564765)
+
+
+    test with sample with different means
+
+    >>> rvs3 = stats.norm.rvs(loc=8,scale=10,size=500)
+    >>> stats.ttest_ind(rvs1,rvs3)
+    (-5.0434013458585092, 5.4302979468623391e-007)
+
+    """
+    v1, n1, v2, n2, a, axis, b = _ttest_ind_setup(a, b, axis)
+    df = n1+n2-2
+
+    d = np.mean(a,axis) - np.mean(b,axis)
+    svar = ((n1-1)*v1+(n2-1)*v2) / float(df)
+
+    t = d/np.sqrt(svar*(1.0/n1 + 1.0/n2))
+    t = np.where((d==0), 0.0, t) #handles case where d = v1 = v2 = 0
+    
+    t, prob = _ttest_finish(df, t)
+
+    return t, prob
+
+def _ttest_ind_setup(a, b, axis):
+    a, b, axis = _chk2_asarray(a, b, axis)
+    v1 = np.var(a, axis, ddof=1)
+    v2 = np.var(b, axis, ddof=1)
+    n1 = a.shape[axis]
+    n2 = b.shape[axis]
+    return v1, n1, v2, n2, a, axis, b
+
+def _ttest_finish(df,t):
+    prob = distributions.t.sf(np.abs(t), df) * 2 #use np.abs to get upper tail
+    #distributions.t.sf currently does not propagate nans
+    #this can be dropped, if distributions.t.sf propagates nans
+    #if this is removed, then prob = prob[()] needs to be removed
+    prob = np.where(np.isnan(t), np.nan, prob)
+    if t.ndim == 0:
+        t = t[()]
+        prob = prob[()]
+    return t, prob
+
+def ttest_ind_uneq_var(a, b, axis=0):
+    """Calculates the T-test for the means of TWO INDEPENDENT samples of scores with 
+    unequal variances (or situations where it is unknown if the variances are equal).
+
+    This is a two-sided test for the null hypothesis that 2 independent samples with unequal variances
     have identical average (expected) values.
 
     Parameters
@@ -2981,42 +3074,61 @@ def ttest_ind(a, b, axis=0):
     >>> rvs1 = stats.norm.rvs(loc=5,scale=10,size=500)
     >>> rvs2 = stats.norm.rvs(loc=5,scale=10,size=500)
     >>> stats.ttest_ind(rvs1,rvs2)
-    (0.26833823296239279, 0.78849443369564765)
+    (0.26833823296239279, 0.78849443369564776)
+    >>> stats.ttest_ind(rvs1,rvs2)
+    (0.26833823296239279, 0.78849452749500748)
+    
+    ttest_ind underestimates p for unequal variances
+    
+    >>> rvs3 = stats.norm.rvs(loc=5, scale=20, size=500)
+    >>> stats.ttest_ind(rvs1, rvs3)
+    (-0.46580283298287162, 0.64145827413436174)
+    >>> stats.ttest_ind_uneq_var(rvs1, rvs3)
+    (-0.46580283298287162, 0.64149646246569292)
 
+    >>> rvs4 = stats.norm.rvs(loc=5, scale=20, size=100)
+    >>> stats.ttest_ind(rvs1, rvs4)
+    (-0.99882539442782481, 0.3182832709103896)
+    >>> stats.ttest_ind_uneq_var(rvs1, rvs4)
+    (-0.69712570584654099, 0.48716927725402048)
 
     test with sample with different means
 
-    >>> rvs3 = stats.norm.rvs(loc=8,scale=10,size=500)
-    >>> stats.ttest_ind(rvs1,rvs3)
-    (-5.0434013458585092, 5.4302979468623391e-007)
+    >>> rvs5 = stats.norm.rvs(loc=8, scale=10, size=500)
+    >>> stats.ttest_ind(rvs1, rvs5)
+    (-3.6578361690197507, 0.00026764922615141298)
+    >>> stats.ttest_ind_uneq_var(rvs1, rvs5)
+    (-3.6578361690197512, 0.00026764941377692148)
+    
+    >>> rvs6 = stats.norm.rvs(loc=8, scale=20, size=500)
+    >>> stats.ttest_ind(rvs1, rvs6)
+    (-3.3134712196511447, 0.00095456933477067706)
+    >>> stats.ttest_ind_uneq_var(rvs1, rvs6)
+    (-3.3134712196511447, 0.00096749377255367309)
 
+    >>> rvs7 = stats.norm.rvs(loc=8, scale=20, size=100)
+    >>> stats.ttest_ind(rvs1, rvs7)
+    (-0.28592251716234818, 0.77503648327796393)
+    >>> stats.ttest_ind_uneq_var(rvs1, rvs7)
+    (-0.18159713446343606, 0.85623941474785026)
     """
-    a, b, axis = _chk2_asarray(a, b, axis)
+    
+    v1, n1, v2, n2, a, axis, b = _ttest_ind_setup(a, b, axis)
+    vn1 = v1 / n1
+    vn2 = v2 / n2
+    df = ((vn1 + vn2)**2) / ((vn1**2) / (n1 - 1) + (vn2**2) / (n2 - 1))
+    
+    df = np.where(np.isnan(df), 1, df) # if df is undefined, variances are zero (assumes n1 > 0 & n2 > 0). 
+                                      # Hence doesn't matter what df is as long as it's not NaN.
+    d = np.mean(a, axis) - np.mean(b, axis)
 
-    v1 = np.var(a,axis,ddof = 1)
-    v2 = np.var(b,axis,ddof = 1)
-    n1 = a.shape[axis]
-    n2 = b.shape[axis]
-    df = n1+n2-2
+    t = d / np.sqrt(vn1 + vn2)
 
-    d = np.mean(a,axis) - np.mean(b,axis)
-    svar = ((n1-1)*v1+(n2-1)*v2) / float(df)
-
-    t = d/np.sqrt(svar*(1.0/n1 + 1.0/n2))
-    t = np.where((d==0)*(svar==0), 1.0, t) #define t=0/0 = 0, identical means
-    prob = distributions.t.sf(np.abs(t),df)*2#use np.abs to get upper tail
-
-    #distributions.t.sf currently does not propagate nans
-    #this can be dropped, if distributions.t.sf propagates nans
-    #if this is removed, then prob = prob[()] needs to be removed
-    prob = np.where(np.isnan(t), np.nan, prob)
-
-    if t.ndim == 0:
-        t = t[()]
-        prob = prob[()]
-
+    t = np.where((d==0), 0.0, t) #handles case where d = v1 = v2 = 0
+    
+    t, prob = _ttest_finish(df, t)
+    
     return t, prob
-
 
 def ttest_rel(a,b,axis=0):
     """
@@ -3084,20 +3196,9 @@ def ttest_rel(a,b,axis=0):
     dm = np.mean(d, axis)
 
     t = dm / np.sqrt(v/float(n))
-    t = np.where((dm==0)*(v==0), 1.0, t) #define t=0/0 = 1, zero mean and var
-    prob = distributions.t.sf(np.abs(t),df)*2 #use np.abs to get upper tail
-    #distributions.t.sf currently does not propagate nans
-    #this can be dropped, if distributions.t.sf propagates nans
-    #if this is removed, then prob = prob[()] needs to be removed
-    prob = np.where(np.isnan(t), np.nan, prob)
-
-##    if not np.isscalar(t):
-##        probs = np.reshape(probs, t.shape) # this should be redundant
-##    if not np.isscalar(prob) and len(prob) == 1:
-##        prob = prob[0]
-    if t.ndim == 0:
-        t = t[()]
-        prob = prob[()]
+    t = np.where((dm==0), 0.0, t) #handle case where both dm and v are 0
+    
+    t, prob = _ttest_finish(df, t)
 
     return t, prob
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -85,7 +85,6 @@ CORRELATION FCNS:  paired
 
 INFERENTIAL STATS:  ttest_1samp
                     ttest_ind
-                    ttest_ind_uneq_var
                     ttest_rel
                     chisquare
                     ks_2samp
@@ -212,7 +211,7 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'cmedian', 'mode',
            'threshold', 'sigmaclip', 'trimboth', 'trim1', 'trim_mean',
            'f_oneway', 'pearsonr', 'fisher_exact',
            'spearmanr', 'pointbiserialr', 'kendalltau', 'linregress',
-           'ttest_1samp', 'ttest_ind', 'ttest_ind_uneq_var', 'ttest_rel',
+           'ttest_1samp', 'ttest_ind', 'ttest_rel',
            'kstest', 'chisquare', 'ks_2samp', 'mannwhitneyu',
            'tiecorrect', 'ranksums', 'kruskal', 'friedmanchisquare',
            'zprob', 'chisqprob', 'ksprob', 'fprob', 'betai',
@@ -2877,7 +2876,6 @@ def ttest_1samp(a, popmean, axis=0):
     --------
 
     >>> from scipy import stats
-    >>> import numpy as np
 
     >>> #fix seed to get the same result
     >>> np.random.seed(7654567)
@@ -2908,131 +2906,43 @@ def ttest_1samp(a, popmean, axis=0):
 
     a, axis = _chk_asarray(a, axis)
     n = a.shape[axis]
-    df=n-1
+    df= n - 1
 
-    d = np.mean(a,axis) - popmean
+    d = np.mean(a, axis) - popmean
     v = np.var(a, axis, ddof=1)
+    denom = np.sqrt(v / float(n))
 
-    t = d / np.sqrt(v/float(n))
-    t = np.where((d==0), 0.0, t) # handles case where d = v = 0
+    t = d / denom
+    t = np.where((d == 0) * (denom == 0), np.nan, t) # handles case where d = v = 0
     
     t, prob = _ttest_finish(df, t)
         
     return t,prob
 
-
-def ttest_ind(a, b, axis=0):
-    """Calculates the T-test for the means of TWO INDEPENDENT samples of scores with equal variances.
-
-    This is a two-sided test for the null hypothesis that 2 independent samples with equal variances
-    have identical average (expected) values.
-
-    Parameters
-    ----------
-    a, b : sequence of ndarrays
-        The arrays must have the same shape, except in the dimension
-        corresponding to `axis` (the first, by default).
-    axis : int, optional
-        Axis can equal None (ravel array first), or an integer (the axis
-        over which to operate on a and b).
-
-    Returns
-    -------
-    t : float or array
-        t-statistic
-    prob : float or array
-        two-tailed p-value
-
-
-    Notes
-    -----
-
-    We can use this test, if we observe two independent samples with equal variances from
-    the same or different population, e.g. exam scores of boys and
-    girls or of two ethnic groups. The test measures whether the
-    average (expected) value differs significantly across samples. If
-    we observe a large p-value, for example larger than 0.05 or 0.1,
-    then we cannot reject the null hypothesis of identical average scores.
-    If the p-value is smaller than the threshold, e.g. 1%, 5% or 10%,
-    then we reject the null hypothesis of equal averages.
-
-    References
-    ----------
-
-       http://en.wikipedia.org/wiki/T-test#Independent_two-sample_t-test
-
-
-    Examples
-    --------
-
-    >>> from scipy import stats
-    >>> import numpy as np
-
-    >>> #fix seed to get the same result
-    >>> np.random.seed(12345678)
-
-    test with sample with identical means
-
-    >>> rvs1 = stats.norm.rvs(loc=5,scale=10,size=500)
-    >>> rvs2 = stats.norm.rvs(loc=5,scale=10,size=500)
-    >>> stats.ttest_ind(rvs1,rvs2)
-    (0.26833823296239279, 0.78849443369564765)
-
-
-    test with sample with different means
-
-    >>> rvs3 = stats.norm.rvs(loc=8,scale=10,size=500)
-    >>> stats.ttest_ind(rvs1,rvs3)
-    (-5.0434013458585092, 5.4302979468623391e-007)
-
-    """
-    v1, n1, v2, n2, a, axis, b = _ttest_ind_setup(a, b, axis)
-    df = n1+n2-2
-
-    d = np.mean(a,axis) - np.mean(b,axis)
-    svar = ((n1-1)*v1+(n2-1)*v2) / float(df)
-
-    t = d/np.sqrt(svar*(1.0/n1 + 1.0/n2))
-    t = np.where((d==0), 0.0, t) #handles case where d = v1 = v2 = 0
-    
-    t, prob = _ttest_finish(df, t)
-
-    return t, prob
-
-def _ttest_ind_setup(a, b, axis):
-    a, b, axis = _chk2_asarray(a, b, axis)
-    v1 = np.var(a, axis, ddof=1)
-    v2 = np.var(b, axis, ddof=1)
-    n1 = a.shape[axis]
-    n2 = b.shape[axis]
-    return v1, n1, v2, n2, a, axis, b
-
 def _ttest_finish(df,t):
     prob = distributions.t.sf(np.abs(t), df) * 2 #use np.abs to get upper tail
-    #distributions.t.sf currently does not propagate nans
-    #this can be dropped, if distributions.t.sf propagates nans
-    #if this is removed, then prob = prob[()] needs to be removed
-    prob = np.where(np.isnan(t), np.nan, prob)
     if t.ndim == 0:
         t = t[()]
-        prob = prob[()]
     return t, prob
 
-def ttest_ind_uneq_var(a, b, axis=0):
-    """Calculates the T-test for the means of TWO INDEPENDENT samples of scores with 
-    unequal variances (or situations where it is unknown if the variances are equal).
+def ttest_ind(a, b, axis=0, equal_var = True):
+    """Calculates the T-test for the means of TWO INDEPENDENT samples of scores
 
-    This is a two-sided test for the null hypothesis that 2 independent samples with unequal variances
-    have identical average (expected) values.
+    This is a two-sided test for the null hypothesis that 2 independent samples
+    with have identical average (expected) values.
 
     Parameters
     ----------
-    a, b : sequence of ndarrays
+    a, b : array_like
         The arrays must have the same shape, except in the dimension
         corresponding to `axis` (the first, by default).
     axis : int, optional
         Axis can equal None (ravel array first), or an integer (the axis
         over which to operate on a and b).
+    equal_var : boolean, optional
+        The default is True, which performs a standard indepentent 2 sample test
+        that assumes equal population variances. If False, Welch's t-test, which
+        does not assume equal population variance, is performed.
 
     Returns
     -------
@@ -3064,7 +2974,6 @@ def ttest_ind_uneq_var(a, b, axis=0):
     --------
 
     >>> from scipy import stats
-    >>> import numpy as np
 
     >>> #fix seed to get the same result
     >>> np.random.seed(12345678)
@@ -3075,7 +2984,7 @@ def ttest_ind_uneq_var(a, b, axis=0):
     >>> rvs2 = stats.norm.rvs(loc=5,scale=10,size=500)
     >>> stats.ttest_ind(rvs1,rvs2)
     (0.26833823296239279, 0.78849443369564776)
-    >>> stats.ttest_ind(rvs1,rvs2)
+    >>> stats.ttest_ind(rvs1,rvs2, equal_var = False)
     (0.26833823296239279, 0.78849452749500748)
     
     ttest_ind underestimates p for unequal variances
@@ -3083,49 +2992,51 @@ def ttest_ind_uneq_var(a, b, axis=0):
     >>> rvs3 = stats.norm.rvs(loc=5, scale=20, size=500)
     >>> stats.ttest_ind(rvs1, rvs3)
     (-0.46580283298287162, 0.64145827413436174)
-    >>> stats.ttest_ind_uneq_var(rvs1, rvs3)
+    >>> stats.ttest_ind(rvs1, rvs3, equal_var = False)
     (-0.46580283298287162, 0.64149646246569292)
+
+    When n1 != n2, the equal means t-statistic is no longer equal to the
+    unequal means t-statistic
 
     >>> rvs4 = stats.norm.rvs(loc=5, scale=20, size=100)
     >>> stats.ttest_ind(rvs1, rvs4)
     (-0.99882539442782481, 0.3182832709103896)
-    >>> stats.ttest_ind_uneq_var(rvs1, rvs4)
+    >>> stats.ttest_ind(rvs1, rvs4, equal_var = False)
     (-0.69712570584654099, 0.48716927725402048)
 
-    test with sample with different means
+    T-test with different means, variance, and n
 
-    >>> rvs5 = stats.norm.rvs(loc=8, scale=10, size=500)
+    >>> rvs5 = stats.norm.rvs(loc=8, scale=20, size=100)
     >>> stats.ttest_ind(rvs1, rvs5)
-    (-3.6578361690197507, 0.00026764922615141298)
-    >>> stats.ttest_ind_uneq_var(rvs1, rvs5)
-    (-3.6578361690197512, 0.00026764941377692148)
-    
-    >>> rvs6 = stats.norm.rvs(loc=8, scale=20, size=500)
-    >>> stats.ttest_ind(rvs1, rvs6)
-    (-3.3134712196511447, 0.00095456933477067706)
-    >>> stats.ttest_ind_uneq_var(rvs1, rvs6)
-    (-3.3134712196511447, 0.00096749377255367309)
+    (-1.4679669854490653, 0.14263895620529152)
+    >>> stats.ttest_ind(rvs1, rvs5, equal_var = False)
+    (-0.94365973617132992, 0.34744170334794122)
 
-    >>> rvs7 = stats.norm.rvs(loc=8, scale=20, size=100)
-    >>> stats.ttest_ind(rvs1, rvs7)
-    (-0.28592251716234818, 0.77503648327796393)
-    >>> stats.ttest_ind_uneq_var(rvs1, rvs7)
-    (-0.18159713446343606, 0.85623941474785026)
     """
     
-    v1, n1, v2, n2, a, axis, b = _ttest_ind_setup(a, b, axis)
-    vn1 = v1 / n1
-    vn2 = v2 / n2
-    df = ((vn1 + vn2)**2) / ((vn1**2) / (n1 - 1) + (vn2**2) / (n2 - 1))
+    a, b, axis = _chk2_asarray(a, b, axis)
+    v1 = np.var(a, axis, ddof=1)
+    v2 = np.var(b, axis, ddof=1)
+    n1 = a.shape[axis]
+    n2 = b.shape[axis]
     
-    df = np.where(np.isnan(df), 1, df) # if df is undefined, variances are zero (assumes n1 > 0 & n2 > 0). 
-                                      # Hence doesn't matter what df is as long as it's not NaN.
+    if (equal_var):
+        df = n1 + n2 - 2
+        svar = ((n1 - 1) * v1 + (n2 - 1) * v2) / float(df)
+        denom = np.sqrt(svar * (1.0 / n1 + 1.0 / n2))
+    else:
+        vn1 = v1 / n1
+        vn2 = v2 / n2
+        df = ((vn1 + vn2)**2) / ((vn1**2) / (n1 - 1) + (vn2**2) / (n2 - 1))
+    
+        df = np.where(np.isnan(df), 1, df) # if df is undefined, variances are 
+            #zero (assumes n1 > 0 & n2 > 0). Hence doesn't matter what df is as 
+            #long as it's not NaN.
+        denom = np.sqrt(vn1 + vn2) 
+    
     d = np.mean(a, axis) - np.mean(b, axis)
-
-    t = d / np.sqrt(vn1 + vn2)
-
-    t = np.where((d==0), 0.0, t) #handles case where d = v1 = v2 = 0
-    
+    t = d / denom
+    t = np.where((d == 0) * (denom == 0), np.nan, t) #handles case where d = v1 = v2 = 0
     t, prob = _ttest_finish(df, t)
     
     return t, prob
@@ -3139,7 +3050,7 @@ def ttest_rel(a,b,axis=0):
 
     Parameters
     ----------
-    a, b : sequence of ndarrays
+    a, b : array_like
         The arrays must have the same shape.
     axis : int, optional, (default axis=0)
         Axis can equal None (ravel array first), or an integer (the axis
@@ -3189,14 +3100,15 @@ def ttest_rel(a,b,axis=0):
     if a.shape[axis] != b.shape[axis]:
         raise ValueError('unequal length arrays')
     n = a.shape[axis]
-    df = float(n-1)
+    df = float(n - 1)
 
-    d = (a-b).astype('d')
-    v = np.var(d,axis,ddof=1)
+    d = (a - b).astype('d')
+    v = np.var(d, axis, ddof=1)
     dm = np.mean(d, axis)
+    denom = np.sqrt(v / float(n))
 
-    t = dm / np.sqrt(v/float(n))
-    t = np.where((dm==0), 0.0, t) #handle case where both dm and v are 0
+    t = dm / denom
+    t = np.where((dm == 0) * (denom == 0), np.nan, t) #handle case where both dm and v are 0
     
     t, prob = _ttest_finish(df, t)
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2912,9 +2912,7 @@ def ttest_1samp(a, popmean, axis=0):
     v = np.var(a, axis, ddof=1)
     denom = np.sqrt(v / float(n))
 
-    t = d / denom
-    t = np.where((d == 0) * (denom == 0), np.nan, t) # handles case where d = v = 0
-    
+    t = np.divide(d, denom)
     t, prob = _ttest_finish(df, t)
         
     return t,prob
@@ -2968,6 +2966,7 @@ def ttest_ind(a, b, axis=0, equal_var = True):
     ----------
 
        http://en.wikipedia.org/wiki/T-test#Independent_two-sample_t-test
+       http://en.wikipedia.org/wiki/Welch%27s_t_test
 
 
     Examples
@@ -2995,8 +2994,8 @@ def ttest_ind(a, b, axis=0, equal_var = True):
     >>> stats.ttest_ind(rvs1, rvs3, equal_var = False)
     (-0.46580283298287162, 0.64149646246569292)
 
-    When n1 != n2, the equal means t-statistic is no longer equal to the
-    unequal means t-statistic
+    When n1 != n2, the equal variance t-statistic is no longer equal to the
+    unequal variance t-statistic
 
     >>> rvs4 = stats.norm.rvs(loc=5, scale=20, size=100)
     >>> stats.ttest_ind(rvs1, rvs4)
@@ -3035,8 +3034,7 @@ def ttest_ind(a, b, axis=0, equal_var = True):
         denom = np.sqrt(vn1 + vn2) 
     
     d = np.mean(a, axis) - np.mean(b, axis)
-    t = d / denom
-    t = np.where((d == 0) * (denom == 0), np.nan, t) #handles case where d = v1 = v2 = 0
+    t = np.divide(d, denom)
     t, prob = _ttest_finish(df, t)
     
     return t, prob
@@ -3107,9 +3105,7 @@ def ttest_rel(a,b,axis=0):
     dm = np.mean(d, axis)
     denom = np.sqrt(v / float(n))
 
-    t = dm / denom
-    t = np.where((dm == 0) * (denom == 0), np.nan, t) #handle case where both dm and v are 0
-    
+    t = np.divide(dm, denom)
     t, prob = _ttest_finish(df, t)
 
     return t, prob

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1531,7 +1531,7 @@ def test_ttest_rel():
         #test zero division problem
         t,p = stats.ttest_rel([0,0,0],[1,1,1])
         assert_equal((np.abs(t),p), (np.inf, 0))
-        assert_equal(stats.ttest_rel([0,0,0], [0,0,0]), (0.0, 1.0))
+        assert_equal(stats.ttest_rel([0,0,0], [0,0,0]), (np.nan, np.nan))
 
         #check that nan in input array result in nan output
         anan = np.array([[1,np.nan],[-1,1]])
@@ -1576,7 +1576,7 @@ def test_ttest_ind():
         #test zero division problem
         t,p = stats.ttest_ind([0,0,0],[1,1,1])
         assert_equal((np.abs(t),p), (np.inf, 0))
-        assert_equal(stats.ttest_ind([0,0,0], [0,0,0]), (0.0, 1.0))
+        assert_equal(stats.ttest_ind([0,0,0], [0,0,0]), (np.nan, np.nan))
 
         #check that nan in input array result in nan output
         anan = np.array([[1,np.nan],[-1,1]])
@@ -1584,20 +1584,20 @@ def test_ttest_ind():
     finally:
         np.seterr(**olderr)
 
-def test_ttest_ind_uneq_var():
+def test_ttest_ind_with_uneq_var():
       
     # check vs. R
     a = (1, 2, 3)
     b = (1.1, 2.9, 4.2)
     pr = 0.53619490753126731
     tr = -0.68649512735572582
-    t, p = stats.ttest_ind_uneq_var(a, b)
+    t, p = stats.ttest_ind(a, b, equal_var = False)
     assert_array_almost_equal([t,p], [tr, pr])
     
     a = (1, 2, 3, 4)
     pr = 0.84354139131608286
     tr = -0.2108663315950719
-    t, p = stats.ttest_ind_uneq_var(a, b)
+    t, p = stats.ttest_ind(a, b, equal_var = False)
     assert_array_almost_equal([t,p], [tr, pr])
 
     #regression test
@@ -1613,24 +1613,25 @@ def test_ttest_ind_uneq_var():
     rvs1_2D = np.array([rvs1, rvs2])
     rvs2_2D = np.array([rvs2, rvs1])
 
-    t,p = stats.ttest_ind_uneq_var(rvs1, rvs2, axis=0)
+    t,p = stats.ttest_ind(rvs1, rvs2, axis=0, equal_var = False)
     assert_array_almost_equal([t,p],(tr,pr))
-    t,p = stats.ttest_ind_uneq_var(rvs1, rvs3, axis =0)
+    t,p = stats.ttest_ind(rvs1, rvs3, axis =0, equal_var = False)
     assert_array_almost_equal([t,p], (tr_uneq_n, pr_uneq_n))
-    t,p = stats.ttest_ind_uneq_var(rvs1_2D.T, rvs2_2D.T, axis=0)
+    t,p = stats.ttest_ind(rvs1_2D.T, rvs2_2D.T, axis=0, equal_var = False)
     assert_array_almost_equal([t,p],tpr)
-    t,p = stats.ttest_ind_uneq_var(rvs1_2D, rvs2_2D, axis=1)
+    t,p = stats.ttest_ind(rvs1_2D, rvs2_2D, axis=1, equal_var = False)
     assert_array_almost_equal([t,p],tpr)
 
     #test on 3 dimensions
     rvs1_3D = np.dstack([rvs1_2D,rvs1_2D,rvs1_2D])
     rvs2_3D = np.dstack([rvs2_2D,rvs2_2D,rvs2_2D])
-    t,p = stats.ttest_ind_uneq_var(rvs1_3D, rvs2_3D, axis=1)
+    t,p = stats.ttest_ind(rvs1_3D, rvs2_3D, axis=1, equal_var = False)
     assert_almost_equal(np.abs(t), np.abs(tr))
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (2, 3))
 
-    t,p = stats.ttest_ind_uneq_var(np.rollaxis(rvs1_3D,2), np.rollaxis(rvs2_3D,2), axis=2)
+    t,p = stats.ttest_ind(np.rollaxis(rvs1_3D,2), np.rollaxis(rvs2_3D,2), 
+                                   axis=2, equal_var = False)
     assert_array_almost_equal(np.abs(t), np.abs(tr))
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (3, 2))
@@ -1638,13 +1639,14 @@ def test_ttest_ind_uneq_var():
     olderr = np.seterr(all='ignore')
     try:
         #test zero division problem
-        t,p = stats.ttest_ind_uneq_var([0,0,0],[1,1,1])
+        t,p = stats.ttest_ind([0,0,0],[1,1,1], equal_var = False)
         assert_equal((np.abs(t),p), (np.inf, 0))
-        assert_equal(stats.ttest_ind_uneq_var([0,0,0], [0,0,0]), (0.0, 1.0))
+        assert_equal(stats.ttest_ind([0,0,0], [0,0,0], equal_var = False), (np.nan, np.nan))
 
         #check that nan in input array result in nan output
         anan = np.array([[1,np.nan],[-1,1]])
-        assert_equal(stats.ttest_ind_uneq_var(anan, np.zeros((2,2))),([0, np.nan], [1,np.nan]))
+        assert_equal(stats.ttest_ind(anan, np.zeros((2,2)), equal_var = False),
+                     ([0, np.nan], [1,np.nan]))
     finally:
         np.seterr(**olderr)
 
@@ -1680,7 +1682,7 @@ def test_ttest_1samp_new():
         #test zero division problem
         t,p = stats.ttest_1samp([0,0,0], 1)
         assert_equal((np.abs(t),p), (np.inf, 0))
-        assert_equal(stats.ttest_1samp([0,0,0], 0), (0.0, 1.0))
+        assert_equal(stats.ttest_1samp([0,0,0], 0), (np.nan, np.nan))
 
         #check that nan in input array result in nan output
         anan = np.array([[1,np.nan],[-1,1]])

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1531,7 +1531,7 @@ def test_ttest_rel():
         #test zero division problem
         t,p = stats.ttest_rel([0,0,0],[1,1,1])
         assert_equal((np.abs(t),p), (np.inf, 0))
-        assert_almost_equal(stats.ttest_rel([0,0,0], [0,0,0]), (1.0, 0.42264973081037421))
+        assert_equal(stats.ttest_rel([0,0,0], [0,0,0]), (0.0, 1.0))
 
         #check that nan in input array result in nan output
         anan = np.array([[1,np.nan],[-1,1]])
@@ -1576,7 +1576,7 @@ def test_ttest_ind():
         #test zero division problem
         t,p = stats.ttest_ind([0,0,0],[1,1,1])
         assert_equal((np.abs(t),p), (np.inf, 0))
-        assert_almost_equal(stats.ttest_ind([0,0,0], [0,0,0]), (1.0, 0.37390096630005898))
+        assert_equal(stats.ttest_ind([0,0,0], [0,0,0]), (0.0, 1.0))
 
         #check that nan in input array result in nan output
         anan = np.array([[1,np.nan],[-1,1]])
@@ -1584,6 +1584,69 @@ def test_ttest_ind():
     finally:
         np.seterr(**olderr)
 
+def test_ttest_ind_uneq_var():
+      
+    # check vs. R
+    a = (1, 2, 3)
+    b = (1.1, 2.9, 4.2)
+    pr = 0.53619490753126731
+    tr = -0.68649512735572582
+    t, p = stats.ttest_ind_uneq_var(a, b)
+    assert_array_almost_equal([t,p], [tr, pr])
+    
+    a = (1, 2, 3, 4)
+    pr = 0.84354139131608286
+    tr = -0.2108663315950719
+    t, p = stats.ttest_ind_uneq_var(a, b)
+    assert_array_almost_equal([t,p], [tr, pr])
+
+    #regression test
+    tr = 1.0912746897927283
+    tr_uneq_n = 0.66745638708050492
+    pr = 0.27647831993021388
+    pr_uneq_n = 0.50873585065616544
+    tpr = ([tr,-tr],[pr,pr])
+
+    rvs3 = np.linspace(1,100, 25)
+    rvs2 = np.linspace(1,100,100)
+    rvs1 = np.linspace(5,105,100)
+    rvs1_2D = np.array([rvs1, rvs2])
+    rvs2_2D = np.array([rvs2, rvs1])
+
+    t,p = stats.ttest_ind_uneq_var(rvs1, rvs2, axis=0)
+    assert_array_almost_equal([t,p],(tr,pr))
+    t,p = stats.ttest_ind_uneq_var(rvs1, rvs3, axis =0)
+    assert_array_almost_equal([t,p], (tr_uneq_n, pr_uneq_n))
+    t,p = stats.ttest_ind_uneq_var(rvs1_2D.T, rvs2_2D.T, axis=0)
+    assert_array_almost_equal([t,p],tpr)
+    t,p = stats.ttest_ind_uneq_var(rvs1_2D, rvs2_2D, axis=1)
+    assert_array_almost_equal([t,p],tpr)
+
+    #test on 3 dimensions
+    rvs1_3D = np.dstack([rvs1_2D,rvs1_2D,rvs1_2D])
+    rvs2_3D = np.dstack([rvs2_2D,rvs2_2D,rvs2_2D])
+    t,p = stats.ttest_ind_uneq_var(rvs1_3D, rvs2_3D, axis=1)
+    assert_almost_equal(np.abs(t), np.abs(tr))
+    assert_array_almost_equal(np.abs(p), pr)
+    assert_equal(t.shape, (2, 3))
+
+    t,p = stats.ttest_ind_uneq_var(np.rollaxis(rvs1_3D,2), np.rollaxis(rvs2_3D,2), axis=2)
+    assert_array_almost_equal(np.abs(t), np.abs(tr))
+    assert_array_almost_equal(np.abs(p), pr)
+    assert_equal(t.shape, (3, 2))
+
+    olderr = np.seterr(all='ignore')
+    try:
+        #test zero division problem
+        t,p = stats.ttest_ind_uneq_var([0,0,0],[1,1,1])
+        assert_equal((np.abs(t),p), (np.inf, 0))
+        assert_equal(stats.ttest_ind_uneq_var([0,0,0], [0,0,0]), (0.0, 1.0))
+
+        #check that nan in input array result in nan output
+        anan = np.array([[1,np.nan],[-1,1]])
+        assert_equal(stats.ttest_ind_uneq_var(anan, np.zeros((2,2))),([0, np.nan], [1,np.nan]))
+    finally:
+        np.seterr(**olderr)
 
 def test_ttest_1samp_new():
     n1, n2, n3 = (10,15,20)
@@ -1617,7 +1680,7 @@ def test_ttest_1samp_new():
         #test zero division problem
         t,p = stats.ttest_1samp([0,0,0], 1)
         assert_equal((np.abs(t),p), (np.inf, 0))
-        assert_almost_equal(stats.ttest_1samp([0,0,0], 0), (1.0, 0.42264973081037421))
+        assert_equal(stats.ttest_1samp([0,0,0], 0), (0.0, 1.0))
 
         #check that nan in input array result in nan output
         anan = np.array([[1,np.nan],[-1,1]])


### PR DESCRIPTION
Added method for t-test with unequal variances. ttest_ind assumes 
population variances are equal.

Refactor common code in all 4 t-test methods to _ttest_ind_setup and
_ttest_finish.

Fix bug in all 4 methods. Previous implementation would, if the
difference in means and the denominator of the t-statistic were zero,
set the t-statistic equal to 1. If the difference in means is zero, the
t-statistic should always be zero. Code and respective tests changed to
reflect this.

Added regression tests and tests that compare output to results of R
t.test() calls.
