### PR TITLE
use root in optimize tutorial

### DIFF
--- a/doc/source/tutorial/examples/newton_krylov_preconditioning.py
+++ b/doc/source/tutorial/examples/newton_krylov_preconditioning.py
@@ -1,6 +1,6 @@
 import numpy as np
-from scipy.optimize import newton_krylov
-from scipy.sparse import spdiags, spkron
+from scipy.optimize import root
+from scipy.sparse import spdiags, kron
 from scipy.sparse.linalg import spilu, LinearOperator
 from numpy import cosh, zeros_like, mgrid, zeros, eye
 
@@ -25,7 +25,7 @@ def get_preconditioner():
     diags_y[2,:] = 1/hy/hy
     Ly = spdiags(diags_y, [-1,0,1], ny, ny)
 
-    J1 = spkron(Lx, eye(ny)) + spkron(eye(nx), Ly)
+    J1 = kron(Lx, eye(ny)) + kron(eye(nx), Ly)
 
     # Now we have the matrix `J_1`. We need to find its inverse `M` --
     # however, since an approximate inverse is enough, we can use
@@ -49,15 +49,15 @@ def solve(preconditioning=True):
 
         d2x = zeros_like(P)
         d2y = zeros_like(P)
-        
+
         d2x[1:-1] = (P[2:]   - 2*P[1:-1] + P[:-2])/hx/hx
         d2x[0]    = (P[1]    - 2*P[0]    + P_left)/hx/hx
         d2x[-1]   = (P_right - 2*P[-1]   + P[-2])/hx/hx
-        
+
         d2y[:,1:-1] = (P[:,2:] - 2*P[:,1:-1] + P[:,:-2])/hy/hy
         d2y[:,0]    = (P[:,1]  - 2*P[:,0]    + P_bottom)/hy/hy
         d2y[:,-1]   = (P_top   - 2*P[:,-1]   + P[:,-2])/hy/hy
-        
+
         return d2x + d2y + 5*cosh(P).mean()**2
 
     # preconditioner
@@ -69,11 +69,13 @@ def solve(preconditioning=True):
     # solve
     guess = zeros((nx, ny), float)
 
-    sol = newton_krylov(residual, guess, verbose=1, inner_M=M)
-    print 'Residual', abs(residual(sol)).max()
+    sol = root(residual, guess, method='krylov',
+               options={'disp': True,
+                        'jac_options': {'inner_M': M}})
+    print 'Residual', abs(residual(sol.x)).max()
     print 'Evaluations', count[0]
 
-    return sol
+    return sol.x
 
 def main():
     sol = solve(preconditioning=True)

--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -550,10 +550,12 @@ starting point.
 Sets of equations
 ^^^^^^^^^^^^^^^^^
 
-Find a root of a set of non-linear equations can be achieve using the
-function :func:`root`.
+Finding a root of a set of non-linear equations can be achieve using the
+:func:`root` function. Several methods are available, amongst which ``hybr``
+(the default) and ``lm`` which respectively use the hybrid method of Powell
+and the Levenberg-Marquardt method from MINPACK.
 
-The following example finds a root of the single-variable transcendental
+The following example considers the single-variable transcendental
 equation
 
 .. math::
@@ -561,21 +563,17 @@ equation
 
     \[ x+2\cos\left(x\right)=0,\]
 
-::
+a root of which can be found as follows::
 
     >>> import numpy as np
     >>> from scipy.optimize import root
     >>> def func(x):
     ...     return x + 2 * np.cos(x)
-
     >>> sol = root(func, 0.3)
     >>> sol.x
     array([-1.02986653])
     >>> sol.fun
     array([ -6.66133815e-16])
-
-Several methods are available through the :func:`root` interface, the
-default is `hybr` and uses the hybrid method of Powell from MINPACK.
 
 Consider now a set of non-linear equations
 
@@ -588,7 +586,7 @@ Consider now a set of non-linear equations
     \end{eqnarray*}
 
 We define the objective function so that it also returns the Jacobian and
-indicate this by setting the `jac` parameter to `True`. Also, the
+indicate this by setting the ``jac`` parameter to ``True``. Also, the
 Levenberg-Marquardt solver is used here.
 
 ::
@@ -599,7 +597,7 @@ Levenberg-Marquardt solver is used here.
     ...     df = np.array([[np.cos(x[1]), -x[0] * np.sin(x[1])],
     ...                    [x[1], x[0] - 1]])
     ...     return f, df
-    >>> sol = root(func2, [1, 1] jac=True, method='lm')
+    >>> sol = root(func2, [1, 1], jac=True, method='lm')
     >>> sol.x
     array([ 6.50409711,  0.90841421])
 
@@ -607,10 +605,10 @@ Levenberg-Marquardt solver is used here.
 Root finding for large problems
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Methods `hybr` and `lm` in :func:`root` function cannot deal with a very
-large number of variables (*N*), as they need to calculate and invert a
-dense *N x N* Jacobian matrix on every Newton step. This becomes rather
-inefficent when *N* grows.
+Methods ``hybr`` and ``lm`` in :func:`root` cannot deal with a very large
+number of variables (*N*), as they need to calculate and invert a dense *N
+x N* Jacobian matrix on every Newton step. This becomes rather inefficient
+when *N* grows.
 
 Consider for instance the following problem: we need to solve the
 following integrodifferential equation on the square
@@ -627,15 +625,15 @@ by approximating the continuous function *P* by its values on a grid,
 *h*. The derivatives and integrals can then be approximated; for
 instance :math:`\partial_x^2 P(x,y)\approx{}(P(x+h,y) - 2 P(x,y) +
 P(x-h,y))/h^2`. The problem is then equivalent to finding the root of
-some function *residual(P)*, where *P* is a vector of length
+some function ``residual(P)``, where ``P`` is a vector of length
 :math:`N_x N_y`.
 
-Now, because :math:`N_x N_y` can be large, methods `hybr` or `lm` in
-:func:`root` will take a long time to solve this problem. The solution
-can however be found using one of the large-scale solvers, for example
-`krylov`, `broyden2`, or `anderson`. These use what is known as the inexact
-Newton method, which instead of computing the Jacobian matrix exactly,
-forms an approximation for it.
+Now, because :math:`N_x N_y` can be large, methods ``hybr`` or ``lm`` in
+:func:`root` will take a long time to solve this problem. The solution can
+however be found using one of the large-scale solvers, for example
+``krylov``, ``broyden2``, or ``anderson``. These use what is known as the
+inexact Newton method, which instead of computing the Jacobian matrix
+exactly, forms an approximation for it.
 
 The problem we have can now be solved as follows:
 
@@ -685,7 +683,7 @@ Still too slow? Preconditioning.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When looking for the zero of the functions :math:`f_i({\bf x}) = 0`,
-*i = 1, 2, ..., N*, the `krylov` solver spends most of its
+*i = 1, 2, ..., N*, the ``krylov`` solver spends most of its
 time inverting the Jacobian matrix,
 
 .. math:: J_{ij} = \frac{\partial f_i}{\partial x_j} .
@@ -697,8 +695,8 @@ linear inversion problem. The idea is that instead of solving
 matrix :math:`MJ` is "closer" to the identity matrix than :math:`J`
 is, the equation should be easier for the Krylov method to deal with.
 
-The matrix *M* can be passed to :func:`root` with method `krylov` as an
-option *inner_M* in the `jac_options` field. It can be a (sparse) matrix
+The matrix *M* can be passed to :func:`root` with method ``krylov`` as an
+option ``options['jac_options']['inner_M']``. It can be a (sparse) matrix
 or a :obj:`scipy.sparse.linalg.LinearOperator` instance.
 
 For the problem in the previous section, we note that the function to
@@ -762,7 +760,7 @@ and then with preconditioning::
   Evaluations 77
 
 Using a preconditioner reduced the number of evaluations of the
-*residual* function by a factor of *4*. For problems where the
+``residual`` function by a factor of *4*. For problems where the
 residual is expensive to compute, good preconditioning can be crucial
 --- it can even decide whether the problem is solvable in practice or
 not.

--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -523,22 +523,37 @@ For example, to find the minimum of :math:`J_{1}\left( x \right)` near
 Root finding
 ------------
 
-
 Sets of equations
 ^^^^^^^^^^^^^^^^^
 
 To find the roots of a polynomial, the command :obj:`roots
 <scipy.roots>` is useful. To find a root of a set of non-linear
-equations, the command :obj:`fsolve` is needed. For example, the
-following example finds the roots of the single-variable
-transcendental equation
+equations, the function :func:`root` is needed.
+
+The following example finds a root of the single-variable transcendental
+equation
 
 .. math::
    :nowrap:
 
     \[ x+2\cos\left(x\right)=0,\]
 
-and the set of non-linear equations
+::
+
+    >>> def func(x):
+    ...     return x + 2 * np.cos(x)
+
+    >>> from scipy.optimize import root
+    >>> sol = root(func, 0.3)
+    >>> sol.x
+    array([-1.02986653])
+    >>> sol.fun
+    array([ -6.66133815e-16])
+
+Several methods are available through the :func:`root` interface, the
+default is `hybr` and uses the hybrid method of Powell from MINPACK.
+
+Consider now a set of non-linear equations
 
 .. math::
    :nowrap:
@@ -548,24 +563,21 @@ and the set of non-linear equations
     x_{0}x_{1}-x_{1} & = & 5.
     \end{eqnarray*}
 
-The results are :math:`x=-1.0299` and :math:`x_{0}=6.5041,\, x_{1}=0.9084` .
+We define the objective function so that it also returns the Jacobian and
+indicate this by setting the `jac` parameter to `True`. Also, the
+Levenberg-Marquardt solver is used here.
 
-    >>> def func(x):
-    ...     return x + 2*cos(x)
+::
 
     >>> def func2(x):
-    ...     out = [x[0]*cos(x[1]) - 4]
-    ...     out.append(x[1]*x[0] - x[1] - 5)
-    ...     return out
-
-    >>> from scipy.optimize import fsolve
-    >>> x0 = fsolve(func, 0.3)
-    >>> print x0
-    -1.02986652932
-
-    >>> x02 = fsolve(func2, [1, 1])
-    >>> print x02
-    [ 6.50409711  0.90841421]
+    ...     f = [x[0] * np.cos(x[1]) - 4,
+    ...          x[1]*x[0] - x[1] - 5]
+    ...     df = np.array([[np.cos(x[1]), -x[0] * np.sin(x[1])],
+    ...                    [x[1], x[0] - 1]])
+    ...     return f, df
+    >>> sol = root(func2, [1, 1] jac=True, method='lm')
+    >>> sol.x
+    array([ 6.50409711,  0.90841421])
 
 
 Scalar function root finding

--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -523,12 +523,35 @@ For example, to find the minimum of :math:`J_{1}\left( x \right)` near
 Root finding
 ------------
 
+Scalar functions
+^^^^^^^^^^^^^^^^
+
+If one has a single-variable equation, there are four different root
+finding algorithms that can be tried. Each of these algorithms requires the
+endpoints of an interval in which a root is expected (because the function
+changes signs). In general :obj:`brentq` is the best choice, but the other
+methods may be useful in certain circumstances or for academic purposes.
+
+
+Fixed-point solving
+^^^^^^^^^^^^^^^^^^^
+
+A problem closely related to finding the zeros of a function is the
+problem of finding a fixed-point of a function. A fixed point of a
+function is the point at which evaluation of the function returns the
+point: :math:`g\left(x\right)=x.` Clearly the fixed point of :math:`g`
+is the root of :math:`f\left(x\right)=g\left(x\right)-x.`
+Equivalently, the root of :math:`f` is the fixed_point of
+:math:`g\left(x\right)=f\left(x\right)+x.` The routine
+:obj:`fixed_point` provides a simple iterative method using Aitkens
+sequence acceleration to estimate the fixed point of :math:`g` given a
+starting point.
+
 Sets of equations
 ^^^^^^^^^^^^^^^^^
 
-To find the roots of a polynomial, the command :obj:`roots
-<scipy.roots>` is useful. To find a root of a set of non-linear
-equations, the function :func:`root` is needed.
+Find a root of a set of non-linear equations can be achieve using the
+function :func:`root`.
 
 The following example finds a root of the single-variable transcendental
 equation
@@ -540,10 +563,11 @@ equation
 
 ::
 
+    >>> import numpy as np
+    >>> from scipy.optimize import root
     >>> def func(x):
     ...     return x + 2 * np.cos(x)
 
-    >>> from scipy.optimize import root
     >>> sol = root(func, 0.3)
     >>> sol.x
     array([-1.02986653])
@@ -580,34 +604,8 @@ Levenberg-Marquardt solver is used here.
     array([ 6.50409711,  0.90841421])
 
 
-Scalar function root finding
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If one has a single-variable equation, there are four different root
-finder algorithms that can be tried. Each of these root finding
-algorithms requires the endpoints of an interval where a root is
-suspected (because the function changes signs). In general
-:obj:`brentq` is the best choice, but the other methods may be useful
-in certain circumstances or for academic purposes.
-
-
-Fixed-point solving
-^^^^^^^^^^^^^^^^^^^
-
-A problem closely related to finding the zeros of a function is the
-problem of finding a fixed-point of a function. A fixed point of a
-function is the point at which evaluation of the function returns the
-point: :math:`g\left(x\right)=x.` Clearly the fixed point of :math:`g`
-is the root of :math:`f\left(x\right)=g\left(x\right)-x.`
-Equivalently, the root of :math:`f` is the fixed_point of
-:math:`g\left(x\right)=f\left(x\right)+x.` The routine
-:obj:`fixed_point` provides a simple iterative method using Aitkens
-sequence acceleration to estimate the fixed point of :math:`g` given a
-starting point.
-
-
-Root finding: Large problems
-----------------------------
+Root finding for large problems
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Methods `hybr` and `lm` in :func:`root` function cannot deal with a very
 large number of variables (*N*), as they need to calculate and invert a


### PR DESCRIPTION
Replace `fsolve` and `nonlin` solvers by `root` in optimize tutorial.
I haven't checked if the doc builds yet.
