### PR TITLE
TST: fix one Python 2.4 issue and skip some tests with numpy < 1.6 in cs...

### DIFF
--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -14,6 +14,7 @@ from glob import glob
 
 import numpy as np
 from numpy.compat import asbytes
+from numpy.testing import dec
 
 from scipy.io.netcdf import netcdf_file
 
@@ -87,6 +88,7 @@ def test_read_write_files():
     shutil.rmtree(tmpdir)
 
 
+@dec.skipif(sys.version[:3] < '2.5', "Random StringIO issue on 2.4")
 def test_read_write_sio():
     eg_sio1 = BytesIO()
     f1 = make_simple(eg_sio1, 'w')

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -238,7 +238,7 @@ class coo_matrix(_data_matrix):
             raise ValueError("Output array must be C or F contiguous")
         M,N = self.shape
         coo_todense(M, N, self.nnz, self.row, self.col, self.data,
-                    B.ravel(order='A'), fortran)
+                    B.ravel('A'), fortran)
         return B
 
     def tocsc(self):

--- a/scipy/sparse/csgraph/tests/test_conversions.py
+++ b/scipy/sparse/csgraph/tests/test_conversions.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, dec
 from scipy.sparse import csr_matrix
 from scipy.sparse.csgraph import csgraph_from_dense, csgraph_to_dense
 
@@ -23,11 +23,12 @@ def test_csgraph_from_dense():
         assert_array_almost_equal(G, G_csr.toarray())
 
 
+@dec.skipif(np.version.short_version < '1.6', "Can't test arrays with infs.")
 def test_csgraph_to_dense():
     G = np.random.random((10, 10))
     nulls = (G < 0.8)
     G[nulls] = np.inf
-    
+
     G_csr = csgraph_from_dense(G)
 
     for null_value in [0, 10, -np.inf, np.inf]:

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -1,5 +1,6 @@
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_raises, TestCase
+from numpy.testing import \
+    assert_array_almost_equal, assert_raises, TestCase, dec
 from scipy.sparse.csgraph import \
     shortest_path, dijkstra, floyd_warshall, johnson,\
     bellman_ford, construct_dist_matrix, NegativeCycleError
@@ -46,6 +47,7 @@ undirected_pred = np.array([[-9999,     0,     0,     0,     0],
 
 methods = ['auto', 'FW', 'D', 'BF', 'J']
 
+@dec.skipif(np.version.short_version < '1.6', "Can't test arrays with infs.")
 def test_directed():
     for method in methods:
         SP = shortest_path(directed_G, method=method, directed=True,
@@ -72,12 +74,13 @@ def test_shortest_path_indices():
             yield (assert_array_almost_equal, SP,
                    undirected_SP[indices].reshape(outshape))
 
+@dec.skipif(np.version.short_version < '1.6', "Can't test arrays with infs.")
 def test_predecessors():
     SP_res = {True: directed_SP,
               False: undirected_SP}
     pred_res = {True: directed_pred,
                 False: undirected_pred}
-    
+
     for method in methods:
         for directed in True, False:
             SP, pred = shortest_path(directed_G, method, directed=directed,
@@ -89,6 +92,7 @@ def test_predecessors():
             yield (assert_array_almost_equal,
                    pred, pred_res[directed])
 
+@dec.skipif(np.version.short_version < '1.6', "Can't test arrays with infs.")
 def test_construct_shortest_path():
     SP_res = {True: directed_SP,
               False: undirected_SP}
@@ -102,6 +106,7 @@ def test_construct_shortest_path():
 
             yield (assert_array_almost_equal, SP1, SP2)
 
+@dec.skipif(np.version.short_version < '1.6', "Can't test arrays with infs.")
 def test_unweighted_path():
     for method in methods:
         for directed in (True, False):
@@ -113,7 +118,7 @@ def test_unweighted_path():
                                 directed=directed,
                                 overwrite=False,
                                 unweighted=False)
-    
+
             yield (assert_array_almost_equal, SP1, SP2)
 
 
@@ -127,13 +132,14 @@ def test_negative_cycles():
             yield (assert_raises, NegativeCycleError, shortest_path,
                    graph, method, directed)
 
+@dec.skipif(np.version.short_version < '1.6', "Can't test arrays with infs.")
 def test_masked_input():
     G = np.ma.masked_equal(directed_G, 0)
     for method in methods:
         SP = shortest_path(directed_G, method=method, directed=True,
                            overwrite=False)
         yield (assert_array_almost_equal, SP, directed_SP)
-    
+
 
 if __name__ == '__main__':
     import nose

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -119,6 +119,7 @@ class TestUtilities(object):
             ok = (j != -1) | at_boundary
             assert_(ok.all(), "%s %s" % (err_msg, np.where(~ok)))
 
+    @dec.skipif(np.version.short_version < '1.6', "No einsum in numpy 1.5.x")
     def test_degenerate_barycentric_transforms(self):
         # The triangulation should not produce invalid barycentric
         # transforms that stump the simplex finding
@@ -137,6 +138,7 @@ class TestUtilities(object):
         self._check_barycentric_transforms(tri)
 
     @dec.slow
+    @dec.skipif(np.version.short_version < '1.6', "No einsum in numpy 1.5.x")
     def test_more_barycentric_transforms(self):
         # Triangulate some "nasty" grids
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -606,6 +606,7 @@ class TestCorrSpearmanrTies(TestCase):
 ### I need to figure out how to do this one.
 
 
+@dec.knownfailureif(sys.version[:3] < '2.5', "Can't index array with np.int64")
 def test_kendalltau():
     """Some tests for kendalltau."""
 


### PR DESCRIPTION
...graph.

See ticket 1669 for details.

Also skip some other tests where needed (Python 2.4, NumPy 1.5.x).

This takes care of all failures under Python 2.4 besides those reported in http://projects.scipy.org/scipy/ticket/1670.
