### PR TITLE
BUG: Return gracefully if ctypes not available.

### DIFF
--- a/scipy/integrate/__quadpack.h
+++ b/scipy/integrate/__quadpack.h
@@ -87,8 +87,11 @@ get_func_type(PyObject *func) {
     PyErr_SetString(quadpack_error, "quad: first argument is not callable");
     return Not_Callable;
   }
+
   ctypes_module = PyImport_ImportModule("ctypes");
-  if (ctypes_module == NULL) return Error;
+  if (ctypes_module == NULL) { /* We don't have ctypes... just return Callable */
+      return Callable;
+  }
   CFuncPtr = PyObject_GetAttrString(ctypes_module, "_CFuncPtr");
   if (CFuncPtr == NULL) {
     Py_DECREF(ctypes_module);


### PR DESCRIPTION
Fix up PR #190 to work even if ctypes is not available (Python 2.4)
