### PR TITLE
DOC: Add docstrings to all the window functions

### DIFF
--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -165,10 +165,6 @@ def blackman(M, sym=True):
     w : ndarray
         The window, with the maximum value normalized to 1 (though the value 1 
         does not appear if the number of samples is even and sym is True).
-        
-    See Also
-    --------
-    bartlett, hamming, hann, kaiser
 
     Notes
     -----
@@ -381,10 +377,6 @@ def bartlett(M, sym=True):
         does not appear if the number of samples is even and sym is True), with the first
         and last samples equal to zero.
 
-    See Also
-    --------
-    blackman, hamming, hann, kaiser
-
     Notes
     -----
     The Bartlett window is defined as
@@ -493,10 +485,6 @@ def hann(M, sym=True):
     w : ndarray
         The window, with the maximum value normalized to 1 (though the value 1 
         does not appear if `M` is even and `sym` is True).
-
-    See Also
-    --------
-    bartlett, blackman, hamming, kaiser
 
     Notes
     -----
@@ -640,10 +628,6 @@ def hamming(M, sym=True):
         The window, with the maximum value normalized to 1 (though the value 1 
         does not appear if the number of samples is even and sym is True).
 
-    See Also
-    --------
-    bartlett, blackman, hann, kaiser
-
     Notes
     -----
     The Hamming window is defined as
@@ -749,10 +733,6 @@ def kaiser(M, beta, sym=True):
     w : ndarray
         The window, with the maximum value normalized to 1 (though the value 1 
         does not appear if the number of samples is even and sym is True).
-    
-    See Also
-    --------
-    bartlett, blackman, hamming, hann
 
     Notes
     -----

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -11,15 +11,16 @@ __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
 
 
 def boxcar(M, sym=True):
-    """The M-point boxcar or rectangular window.
+    """Return a boxcar or rectangular window.
     
     Included for completeness, this is equivalent to no window at all.
 
     Parameters
     ----------
     M : int
-        Window size.
-    sym : bool
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
+    sym : bool, optional
         Whether the window is symmetric. (Has no effect for boxcar.)
 
     Returns
@@ -32,13 +33,14 @@ def boxcar(M, sym=True):
 
 
 def triang(M, sym=True):
-    """The M-point triangular window.
+    """Return a triangular window.
 
     Parameters
     ----------
     M : int
-        Window size.
-    sym : bool
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
+    sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
 
@@ -70,13 +72,14 @@ def triang(M, sym=True):
 
 
 def parzen(M, sym=True):
-    """The M-point Parzen window.
+    """Return a Parzen window.
 
     Parameters
     ----------
     M : int
-        Window size.
-    sym : bool
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
+    sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
 
@@ -107,13 +110,14 @@ def parzen(M, sym=True):
 
 
 def bohman(M, sym=True):
-    """The M-point Bohman window.
+    """Return a Bohman window.
 
     Parameters
     ----------
     M : int
-        Window size.
-    sym : bool
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
+    sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
 
@@ -140,13 +144,14 @@ def bohman(M, sym=True):
 
 
 def blackman(M, sym=True):
-    """The M-point Blackman window.
+    """Return a Blackman window.
 
     Parameters
     ----------
     M : int
-        Window size.
-    sym : bool
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
+    sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
 
@@ -173,13 +178,14 @@ def blackman(M, sym=True):
 
 
 def nuttall(M, sym=True):
-    """A minimum 4-term Blackman-Harris window according to Nuttall.
+    """Return a minimum 4-term Blackman-Harris window according to Nuttall.
 
     Parameters
     ----------
     M : int
-        Window size.
-    sym : bool
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
+    sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
 
@@ -208,13 +214,14 @@ def nuttall(M, sym=True):
 
 
 def blackmanharris(M, sym=True):
-    """The M-point minimum 4-term Blackman-Harris window.
+    """Return a minimum 4-term Blackman-Harris window.
 
     Parameters
     ----------
     M : int
-        Window size.
-    sym : bool
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
+    sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
 
@@ -243,13 +250,14 @@ def blackmanharris(M, sym=True):
 
 
 def flattop(M, sym=True):
-    """The M-point flat top window.
+    """Return a flat top window.
 
     Parameters
     ----------
     M : int
-        Window size.
-    sym : bool
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
+    sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
 
@@ -278,15 +286,16 @@ def flattop(M, sym=True):
 
 
 def bartlett(M, sym=True):
-    """The M-point Bartlett window.
+    """Return a Bartlett window.
 
     Similar to the triangular window, but with zero endpoints.
     
     Parameters
     ----------
     M : int
-        Window size.
-    sym : bool
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
+    sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
 
@@ -313,7 +322,7 @@ def bartlett(M, sym=True):
 
 
 def hann(M, sym=True):
-    """The M-point Hann window.
+    """Return a Hann window.
 
     Raised cosine or sine squared window with ends that touch zero. (Sometimes 
     erroneously referred to as the "Hanning" window, from confusion with 
@@ -322,8 +331,9 @@ def hann(M, sym=True):
     Parameters
     ----------
     M : int
-        Window size.  If zero or less, an empty array is returned.
-    sym : bool
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
+    sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
 
@@ -385,7 +395,7 @@ def barthann(M, sym=True):
 
 
 def hamming(M, sym=True):
-    """The M-point Hamming window.
+    """Return a Hamming window.
 
     Raised cosine window with non-zero endpoints, optimized to minimize the 
     nearest side lobe.
@@ -393,8 +403,9 @@ def hamming(M, sym=True):
     Parameters
     ----------
     M : int
-        Window size.
-    sym : bool
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
+    sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
 
@@ -425,11 +436,12 @@ def kaiser(M, beta, sym=True):
     Parameters
     ----------
     M : int
-        Window size.
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
     beta : float
         Shape parameter, determines trade-off between main-lobe width and 
         side lobe level
-    sym : bool
+    sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
 
@@ -462,17 +474,25 @@ def gaussian(M, std, sym=True):
     Parameters
     ----------
     M : int
-        Window size.
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
     std : float
         Standard deviation.
-    sym : bool
+    sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
 
     Returns
     -------
     w : ndarray
-        The window function
+        The window, with the maximum value normalized to 1 (though the value 1 
+        does not appear if the number of samples is even and sym is True).
+
+    Notes
+    -----
+    The Gaussian window is defined as
+
+    .. math::  w(n) = e^{ -\\frac{1}{2}\\left(\\frac{n}{\\sigma}\\right)^2 }
 
     """
     if M < 1:
@@ -515,15 +535,16 @@ def general_gaussian(M, p, sig, sym=True):
 # `chebwin` contributed by Kumar Appaiah.
 
 def chebwin(M, at, sym=True):
-    """Dolph-Chebyshev window.
+    """Return a Dolph-Chebyshev window.
 
     Parameters
     ----------
     M : int
-        Window size.
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
     at : float
         Attenuation (in dB).
-    sym : bool
+    sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
 

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -335,7 +335,8 @@ def flattop(M, sym=True):
     Returns
     -------
     w : ndarray
-        The window function
+        The window, with the maximum value normalized to 1 (though the value 1 
+        does not appear if the number of samples is even and sym is True).
 
     """
     if M < 1:
@@ -873,7 +874,7 @@ def gaussian(M, std, sym=True):
         Number of points in the output window. If zero or less, an empty
         array is returned.
     std : float
-        Standard deviation.
+        The standard deviation, sigma.
     sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
@@ -907,13 +908,39 @@ def gaussian(M, std, sym=True):
 
 
 def general_gaussian(M, p, sig, sym=True):
-    """Return a window with a generalized Gaussian shape.
+    r"""Return a window with a generalized Gaussian shape.
 
-    The Gaussian shape is defined as ``exp(-0.5*(x/sig)**(2*p))``, the
-    half-power point is at ``(2*log(2)))**(1/(2*p)) * sig``.
+    Parameters
+    ----------
+    M : int
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
+    p : float
+        Shape parameter.  p = 1 is identical to :func:`~gaussian`, p = 0.5 is
+        the same shape as the Laplace distribution.
+    sig : float
+        The standard deviation, sigma.
+    sym : bool, optional
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
 
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1 (though the value 1 
+        does not appear if the number of samples is even and sym is True).
+
+    Notes
+    -----
+    The generalized Gaussian window is defined as
+
+    .. math::  w(n) = e^{ -\frac{1}{2}\left|\frac{n}{\sigma}\right|^{2p} }
+    
+    the half-power point is at
+    
+    .. math::  (2 \log(2))^{1/(2 p)} \sigma
+        
     """
-    # FIXME: What are p and sig called in English?  Improve docstring
     if M < 1:
         return np.array([])
     if M == 1:
@@ -922,7 +949,7 @@ def general_gaussian(M, p, sig, sym=True):
     if not sym and not odd:
         M = M + 1
     n = np.arange(0, M) - (M - 1.0) / 2.0
-    w = np.exp(-0.5 * (n / sig) ** (2 * p))
+    w = np.exp(-0.5 * np.abs(n / sig) ** (2 * p))
     if not sym and not odd:
         w = w[:-1]
     return w
@@ -947,7 +974,7 @@ def chebwin(M, at, sym=True):
     Returns
     -------
     w : ndarray
-        The window function
+        The window, with the maximum value always normalized to 1
     
     """
     if M < 1:
@@ -991,14 +1018,28 @@ def chebwin(M, at, sym=True):
 
 
 def slepian(M, width, sym=True):
-    """Return the M-point Slepian window.
+    """Return a digital Slepian window.
     
     Used to maximize the energy concentration in the main lobe.  Also called 
     the digital prolate spheroidal sequence (DPSS).
 
-    """
-    # FIXME: Improve docstring, explain what "width" does
+    Parameters
+    ----------
+    M : int
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
+    width : float
+        Bandwidth
+    sym : bool, optional
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value always normalized to 1
     
+    """
     if (M * width > 27.38):
         raise ValueError("Cannot reliably obtain slepian sequences for"
               " M*width > 27.38.")

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -189,11 +189,6 @@ def blackman(M, sym=True):
 
     Examples
     --------
-    >>> scipy.signal.blackman(12)
-    array([-0.        ,  0.03260643,  0.15990363,  0.41439798,  0.73604518,
-            0.96704677,  0.96704677,  0.73604518,  0.41439798,  0.15990363,
-            0.03260643, -0.        ])
-
     Plot the window and the frequency response:
 
     >>> from numpy.fft import fft, fftshift
@@ -410,11 +405,6 @@ def bartlett(M, sym=True):
 
     Examples
     --------
-    >>> scipy.signal.bartlett(12)
-    array([ 0.        ,  0.18181818,  0.36363636,  0.54545455,  0.72727273,
-            0.90909091,  0.90909091,  0.72727273,  0.54545455,  0.36363636,
-            0.18181818,  0.        ])
-
     Plot the window and its frequency response (requires matplotlib):
 
     >>> from numpy.fft import fft, fftshift
@@ -517,11 +507,6 @@ def hann(M, sym=True):
 
     Examples
     --------
-    >>> scipy.signal.hann(12)
-    array([ 0.        ,  0.07937323,  0.29229249,  0.57115742,  0.82743037,
-            0.97974649,  0.97974649,  0.82743037,  0.57115742,  0.29229249,
-            0.07937323,  0.        ])
-
     Plot the window and its frequency response:
 
     >>> from numpy.fft import fft, fftshift
@@ -657,11 +642,6 @@ def hamming(M, sym=True):
 
     Examples
     --------
-    >>> scipy.signal.hamming(12)
-    array([ 0.08      ,  0.15302337,  0.34890909,  0.60546483,  0.84123594,
-            0.98136677,  0.98136677,  0.84123594,  0.60546483,  0.34890909,
-            0.15302337,  0.08      ])
-
     Plot the window and the frequency response:
 
     >>> from numpy.fft import fft, fftshift
@@ -789,11 +769,6 @@ def kaiser(M, beta, sym=True):
 
     Examples
     --------
-    >>> scipy.signal.kaiser(12, 14)
-    array([ 0.00000773,  0.00346009,  0.04652002,  0.22973712,  0.59988532,
-            0.9456749 ,  0.9456749 ,  0.59988532,  0.22973712,  0.04652002,
-            0.00346009,  0.00000773])
-
     Plot the window and the frequency response:
 
     >>> from numpy.fft import fft, fftshift

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -708,9 +708,9 @@ def get_window(window, Nx, fftbins=True):
         elif winstr in ['general gaussian', 'general_gaussian',
                         'general gauss', 'general_gauss', 'ggs']:
             winfunc = general_gaussian
-        elif winstr in ['boxcar', 'box', 'ones']:
+        elif winstr in ['boxcar', 'box', 'ones', 'rect', 'rectangular']:
             winfunc = boxcar
-        elif winstr in ['slepian', 'slep', 'optimal', 'dss']:
+        elif winstr in ['slepian', 'slep', 'optimal', 'dpss', 'dss']:
             winfunc = slepian
         elif winstr in ['chebwin', 'cheb']:
             winfunc = chebwin

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -351,13 +351,14 @@ hanning = hann
 
 
 def barthann(M, sym=True):
-    """Return the M-point modified Bartlett-Hann window.
+    """Return a modified Bartlett-Hann window.
 
     Parameters
     ----------
     M : int
-        Window size.
-    sym : bool
+        Number of points in the output window. If zero or less, an empty
+        array is returned.
+    sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
 

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -626,7 +626,7 @@ def get_window(window, Nx, fftbins=True):
     -----
     Window types:
 
-        boxcar, triang, blackman, hamming, hanning, bartlett,
+        boxcar, triang, blackman, hamming, hann, bartlett, flattop, 
         parzen, bohman, blackmanharris, nuttall, barthann,
         kaiser (needs beta), gaussian (needs std),
         general_gaussian (needs power, width),
@@ -688,7 +688,7 @@ def get_window(window, Nx, fftbins=True):
         elif winstr in ['bartlett', 'bart', 'brt']:
             winfunc = bartlett
         elif winstr in ['hanning', 'hann', 'han']:
-            winfunc = hanning
+            winfunc = hann
         elif winstr in ['blackmanharris', 'blackharr', 'bkh']:
             winfunc = blackmanharris
         elif winstr in ['parzen', 'parz', 'par']:

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -144,7 +144,7 @@ def bohman(M, sym=True):
 
 
 def blackman(M, sym=True):
-    """Return a Blackman window.
+    r"""Return a Blackman window.
 
     The Blackman window is a taper formed by using the the first three
     terms of a summation of cosines. It was designed to have close to the
@@ -170,7 +170,7 @@ def blackman(M, sym=True):
     -----
     The Blackman window is defined as
 
-    .. math::  w(n) = 0.42 - 0.5 \\cos(2\\pi n/M) + 0.08 \\cos(4\\pi n/M)
+    .. math::  w(n) = 0.42 - 0.5 \cos(2\pi n/M) + 0.08 \cos(4\pi n/M)
 
     Most references to the Blackman window come from the signal processing
     literature, where it is used as one of many windowing functions for
@@ -354,7 +354,7 @@ def flattop(M, sym=True):
 
 
 def bartlett(M, sym=True):
-    """Return a Bartlett window.
+    r"""Return a Bartlett window.
 
     The Bartlett window is very similar to a triangular window, except
     that the end points are at zero.  It is often used in signal
@@ -381,9 +381,9 @@ def bartlett(M, sym=True):
     -----
     The Bartlett window is defined as
 
-    .. math:: w(n) = \\frac{2}{M-1} \\left(
-              \\frac{M-1}{2} - \\left|n - \\frac{M-1}{2}\\right|
-              \\right)
+    .. math:: w(n) = \frac{2}{M-1} \left(
+              \frac{M-1}{2} - \left|n - \frac{M-1}{2}\right|
+              \right)
 
     Most references to the Bartlett window come from the signal
     processing literature, where it is used as one of many windowing
@@ -466,7 +466,7 @@ def bartlett(M, sym=True):
 
 
 def hann(M, sym=True):
-    """Return a Hann window.
+    r"""Return a Hann window.
 
     The Hann window is a taper formed by using a raised cosine or sine-squared 
     with ends that touch zero.
@@ -490,8 +490,8 @@ def hann(M, sym=True):
     -----
     The Hann window is defined as
 
-    .. math::  w(n) = 0.5 - 0.5cos\\left(\\frac{2\\pi{n}}{M-1}\\right)
-               \\qquad 0 \\leq n \\leq M-1
+    .. math::  w(n) = 0.5 - 0.5cos\left(\frac{2\pi{n}}{M-1}\right)
+               \qquad 0 \leq n \leq M-1
 
     The window was named for Julius van Hann, an Austrian meterologist. It is
     also known as the Cosine Bell. It is sometimes erroneously referred to as the 
@@ -608,7 +608,7 @@ def barthann(M, sym=True):
 
 
 def hamming(M, sym=True):
-    """Return a Hamming window.
+    r"""Return a Hamming window.
 
     The Hamming window is a taper formed by using a raised cosine with 
     non-zero endpoints, optimized to minimize the nearest side lobe.
@@ -632,8 +632,8 @@ def hamming(M, sym=True):
     -----
     The Hamming window is defined as
 
-    .. math::  w(n) = 0.54 - 0.46cos\\left(\\frac{2\\pi{n}}{M-1}\\right)
-               \\qquad 0 \\leq n \\leq M-1
+    .. math::  w(n) = 0.54 - 0.46cos\left(\frac{2\pi{n}}{M-1}\right)
+               \qquad 0 \leq n \leq M-1
 
     The Hamming was named for R. W. Hamming, an associate of J. W. Tukey and
     is described in Blackman and Tukey. It was recommended for smoothing the
@@ -712,7 +712,7 @@ def hamming(M, sym=True):
 
 
 def kaiser(M, beta, sym=True):
-    """Return a Kaiser window.
+    r"""Return a Kaiser window.
 
     The Kaiser window is a taper formed by using a Bessel function.
 
@@ -738,12 +738,12 @@ def kaiser(M, beta, sym=True):
     -----
     The Kaiser window is defined as
 
-    .. math::  w(n) = I_0\\left( \\beta \\sqrt{1-\\frac{4n^2}{(M-1)^2}}
-               \\right)/I_0(\\beta)
+    .. math::  w(n) = I_0\left( \beta \sqrt{1-\frac{4n^2}{(M-1)^2}}
+               \right)/I_0(\beta)
 
     with
 
-    .. math:: \\quad -\\frac{M-1}{2} \\leq n \\leq \\frac{M-1}{2},
+    .. math:: \quad -\frac{M-1}{2} \leq n \leq \frac{M-1}{2},
 
     where :math:`I_0` is the modified zeroth-order Bessel function.
 
@@ -846,7 +846,7 @@ def kaiser(M, beta, sym=True):
 
 
 def gaussian(M, std, sym=True):
-    """Return a Gaussian window.
+    r"""Return a Gaussian window.
 
     Parameters
     ----------
@@ -869,7 +869,7 @@ def gaussian(M, std, sym=True):
     -----
     The Gaussian window is defined as
 
-    .. math::  w(n) = e^{ -\\frac{1}{2}\\left(\\frac{n}{\\sigma}\\right)^2 }
+    .. math::  w(n) = e^{ -\frac{1}{2}\left(\frac{n}{\sigma}\right)^2 }
 
     """
     if M < 1:

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -146,6 +146,11 @@ def bohman(M, sym=True):
 def blackman(M, sym=True):
     """Return a Blackman window.
 
+    The Blackman window is a taper formed by using the the first three
+    terms of a summation of cosines. It was designed to have close to the
+    minimal leakage possible.  It is close to optimal, only slightly worse
+    than a Kaiser window.
+
     Parameters
     ----------
     M : int
@@ -154,14 +159,80 @@ def blackman(M, sym=True):
     sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
-
+        
     Returns
     -------
     w : ndarray
         The window, with the maximum value normalized to 1 (though the value 1 
         does not appear if the number of samples is even and sym is True).
+        
+    See Also
+    --------
+    bartlett, hamming, hann, kaiser
+
+    Notes
+    -----
+    The Blackman window is defined as
+
+    .. math::  w(n) = 0.42 - 0.5 \\cos(2\\pi n/M) + 0.08 \\cos(4\\pi n/M)
+
+    Most references to the Blackman window come from the signal processing
+    literature, where it is used as one of many windowing functions for
+    smoothing values.  It is also known as an apodization (which means
+    "removing the foot", i.e. smoothing discontinuities at the beginning
+    and end of the sampled signal) or tapering function. It is known as a
+    "near optimal" tapering function, almost as good (by some measures)
+    as the Kaiser window.
+
+    References
+    ----------
+    .. [1] Blackman, R.B. and Tukey, J.W., (1958) The measurement of power spectra,
+           Dover Publications, New York.
+    .. [2] Oppenheim, A.V., and R.W. Schafer. Discrete-Time Signal Processing.
+           Upper Saddle River, NJ: Prentice-Hall, 1999, pp. 468-471.
+
+    Examples
+    --------
+    >>> scipy.signal.blackman(12)
+    array([-0.        ,  0.03260643,  0.15990363,  0.41439798,  0.73604518,
+            0.96704677,  0.96704677,  0.73604518,  0.41439798,  0.15990363,
+            0.03260643, -0.        ])
+
+    Plot the window and the frequency response:
+
+    >>> from numpy.fft import fft, fftshift
+    >>> window = scipy.signal.blackman(51)
+    >>> plt.plot(window)
+    [<matplotlib.lines.Line2D object at 0x...>]
+    >>> plt.title("Blackman window")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.ylabel("Amplitude")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.xlabel("Sample")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.show()
+
+    >>> plt.figure()
+    <matplotlib.figure.Figure object at 0x...>
+    >>> A = fft(window, 2048) / 25.5
+    >>> mag = np.abs(fftshift(A))
+    >>> freq = np.linspace(-0.5, 0.5, len(A))
+    >>> response = 20 * np.log10(mag)
+    >>> response = np.clip(response, -100, 100)
+    >>> plt.plot(freq, response)
+    [<matplotlib.lines.Line2D object at 0x...>]
+    >>> plt.title("Frequency response of Blackman window")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.ylabel("Magnitude [dB]")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.xlabel("Normalized frequency [cycles per sample]")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.axis('tight')
+    (-0.5, 0.5, -100.0, ...)
+    >>> plt.show()
 
     """
+    # Docstring adapted from NumPy's blackman function
     if M < 1:
         return np.array([])
     if M == 1:
@@ -288,7 +359,10 @@ def flattop(M, sym=True):
 def bartlett(M, sym=True):
     """Return a Bartlett window.
 
-    Similar to the triangular window, but with zero endpoints.
+    The Bartlett window is very similar to a triangular window, except
+    that the end points are at zero.  It is often used in signal
+    processing for tapering a signal, without generating too much
+    ripple in the frequency domain.
     
     Parameters
     ----------
@@ -302,10 +376,87 @@ def bartlett(M, sym=True):
     Returns
     -------
     w : ndarray
-        The window, with the maximum value normalized to 1 (though the value 1 
-        does not appear if the number of samples is even and sym is True).
+        The triangular window, with the maximum value normalized to 1 (though the value 1 
+        does not appear if the number of samples is even and sym is True), with the first
+        and last samples equal to zero.
+
+    See Also
+    --------
+    blackman, hamming, hann, kaiser
+
+    Notes
+    -----
+    The Bartlett window is defined as
+
+    .. math:: w(n) = \\frac{2}{M-1} \\left(
+              \\frac{M-1}{2} - \\left|n - \\frac{M-1}{2}\\right|
+              \\right)
+
+    Most references to the Bartlett window come from the signal
+    processing literature, where it is used as one of many windowing
+    functions for smoothing values.  Note that convolution with this
+    window produces linear interpolation.  It is also known as an
+    apodization (which means"removing the foot", i.e. smoothing
+    discontinuities at the beginning and end of the sampled signal) or
+    tapering function. The fourier transform of the Bartlett is the product
+    of two sinc functions.
+    Note the excellent discussion in Kanasewich.
+
+    References
+    ----------
+    .. [1] M.S. Bartlett, "Periodogram Analysis and Continuous Spectra",
+           Biometrika 37, 1-16, 1950.
+    .. [2] E.R. Kanasewich, "Time Sequence Analysis in Geophysics",
+           The University of Alberta Press, 1975, pp. 109-110.
+    .. [3] A.V. Oppenheim and R.W. Schafer, "Discrete-Time Signal
+           Processing", Prentice-Hall, 1999, pp. 468-471.
+    .. [4] Wikipedia, "Window function",
+           http://en.wikipedia.org/wiki/Window_function
+    .. [5] W.H. Press,  B.P. Flannery, S.A. Teukolsky, and W.T. Vetterling,
+           "Numerical Recipes", Cambridge University Press, 1986, page 429.
+
+    Examples
+    --------
+    >>> scipy.signal.bartlett(12)
+    array([ 0.        ,  0.18181818,  0.36363636,  0.54545455,  0.72727273,
+            0.90909091,  0.90909091,  0.72727273,  0.54545455,  0.36363636,
+            0.18181818,  0.        ])
+
+    Plot the window and its frequency response (requires matplotlib):
+
+    >>> from numpy.fft import fft, fftshift
+    >>> window = scipy.signal.bartlett(51)
+    >>> plt.plot(window)
+    [<matplotlib.lines.Line2D object at 0x...>]
+    >>> plt.title("Bartlett window")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.ylabel("Amplitude")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.xlabel("Sample")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.show()
+
+    >>> plt.figure()
+    <matplotlib.figure.Figure object at 0x...>
+    >>> A = fft(window, 2048) / 25.5
+    >>> mag = np.abs(fftshift(A))
+    >>> freq = np.linspace(-0.5, 0.5, len(A))
+    >>> response = 20 * np.log10(mag)
+    >>> response = np.clip(response, -100, 100)
+    >>> plt.plot(freq, response)
+    [<matplotlib.lines.Line2D object at 0x...>]
+    >>> plt.title("Frequency response of Bartlett window")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.ylabel("Magnitude [dB]")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.xlabel("Normalized frequency [cycles per sample]")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.axis('tight')
+    (-0.5, 0.5, -100.0, ...)
+    >>> plt.show()
 
     """
+    # Docstring adapted from NumPy's bartlett function
     if M < 1:
         return np.array([])
     if M == 1:
@@ -324,9 +475,8 @@ def bartlett(M, sym=True):
 def hann(M, sym=True):
     """Return a Hann window.
 
-    Raised cosine or sine squared window with ends that touch zero. (Sometimes 
-    erroneously referred to as the "Hanning" window, from confusion with 
-    Hamming.)
+    The Hann window is a taper formed by using a raised cosine or sine-squared 
+    with ends that touch zero.
 
     Parameters
     ----------
@@ -343,7 +493,81 @@ def hann(M, sym=True):
         The window, with the maximum value normalized to 1 (though the value 1 
         does not appear if `M` is even and `sym` is True).
 
+    See Also
+    --------
+    bartlett, blackman, hamming, kaiser
+
+    Notes
+    -----
+    The Hann window is defined as
+
+    .. math::  w(n) = 0.5 - 0.5cos\\left(\\frac{2\\pi{n}}{M-1}\\right)
+               \\qquad 0 \\leq n \\leq M-1
+
+    The window was named for Julius van Hann, an Austrian meterologist. It is
+    also known as the Cosine Bell. It is sometimes erroneously referred to as the 
+    "Hanning" window, from the use of "hann" as a verb in the original paper and 
+    confusion with the very similar Hamming window.
+
+    Most references to the Hann window come from the signal processing
+    literature, where it is used as one of many windowing functions for
+    smoothing values.  It is also known as an apodization (which means
+    "removing the foot", i.e. smoothing discontinuities at the beginning
+    and end of the sampled signal) or tapering function.
+
+    References
+    ----------
+    .. [1] Blackman, R.B. and Tukey, J.W., (1958) The measurement of power
+           spectra, Dover Publications, New York.
+    .. [2] E.R. Kanasewich, "Time Sequence Analysis in Geophysics",
+           The University of Alberta Press, 1975, pp. 106-108.
+    .. [3] Wikipedia, "Window function",
+           http://en.wikipedia.org/wiki/Window_function
+    .. [4] W.H. Press,  B.P. Flannery, S.A. Teukolsky, and W.T. Vetterling,
+           "Numerical Recipes", Cambridge University Press, 1986, page 425.
+
+    Examples
+    --------
+    >>> scipy.signal.hann(12)
+    array([ 0.        ,  0.07937323,  0.29229249,  0.57115742,  0.82743037,
+            0.97974649,  0.97974649,  0.82743037,  0.57115742,  0.29229249,
+            0.07937323,  0.        ])
+
+    Plot the window and its frequency response:
+
+    >>> from numpy.fft import fft, fftshift
+    >>> window = scipy.signal.hann(51)
+    >>> plt.plot(window)
+    [<matplotlib.lines.Line2D object at 0x...>]
+    >>> plt.title("Hann window")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.ylabel("Amplitude")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.xlabel("Sample")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.show()
+
+    >>> plt.figure()
+    <matplotlib.figure.Figure object at 0x...>
+    >>> A = fft(window, 2048) / 25.5
+    >>> mag = np.abs(fftshift(A))
+    >>> freq = np.linspace(-0.5, 0.5, len(A))
+    >>> response = 20 * np.log10(mag)
+    >>> response = np.clip(response, -100, 100)
+    >>> plt.plot(freq, response)
+    [<matplotlib.lines.Line2D object at 0x...>]
+    >>> plt.title("Frequency response of the Hann window")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.ylabel("Magnitude [dB]")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.xlabel("Normalized frequency [cycles per sample]")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.axis('tight')
+    (-0.5, 0.5, -100.0, ...)
+    >>> plt.show()
+
     """
+    # Docstring adapted from NumPy's hanning function
     if M < 1:
         return np.array([])
     if M == 1:
@@ -397,8 +621,8 @@ def barthann(M, sym=True):
 def hamming(M, sym=True):
     """Return a Hamming window.
 
-    Raised cosine window with non-zero endpoints, optimized to minimize the 
-    nearest side lobe.
+    The Hamming window is a taper formed by using a raised cosine with 
+    non-zero endpoints, optimized to minimize the nearest side lobe.
     
     Parameters
     ----------
@@ -415,7 +639,79 @@ def hamming(M, sym=True):
         The window, with the maximum value normalized to 1 (though the value 1 
         does not appear if the number of samples is even and sym is True).
 
+    See Also
+    --------
+    bartlett, blackman, hann, kaiser
+
+    Notes
+    -----
+    The Hamming window is defined as
+
+    .. math::  w(n) = 0.54 - 0.46cos\\left(\\frac{2\\pi{n}}{M-1}\\right)
+               \\qquad 0 \\leq n \\leq M-1
+
+    The Hamming was named for R. W. Hamming, an associate of J. W. Tukey and
+    is described in Blackman and Tukey. It was recommended for smoothing the
+    truncated autocovariance function in the time domain.
+    Most references to the Hamming window come from the signal processing
+    literature, where it is used as one of many windowing functions for
+    smoothing values.  It is also known as an apodization (which means
+    "removing the foot", i.e. smoothing discontinuities at the beginning
+    and end of the sampled signal) or tapering function.
+
+    References
+    ----------
+    .. [1] Blackman, R.B. and Tukey, J.W., (1958) The measurement of power
+           spectra, Dover Publications, New York.
+    .. [2] E.R. Kanasewich, "Time Sequence Analysis in Geophysics", The
+           University of Alberta Press, 1975, pp. 109-110.
+    .. [3] Wikipedia, "Window function",
+           http://en.wikipedia.org/wiki/Window_function
+    .. [4] W.H. Press,  B.P. Flannery, S.A. Teukolsky, and W.T. Vetterling,
+           "Numerical Recipes", Cambridge University Press, 1986, page 425.
+
+    Examples
+    --------
+    >>> scipy.signal.hamming(12)
+    array([ 0.08      ,  0.15302337,  0.34890909,  0.60546483,  0.84123594,
+            0.98136677,  0.98136677,  0.84123594,  0.60546483,  0.34890909,
+            0.15302337,  0.08      ])
+
+    Plot the window and the frequency response:
+
+    >>> from numpy.fft import fft, fftshift
+    >>> window = scipy.signal.hamming(51)
+    >>> plt.plot(window)
+    [<matplotlib.lines.Line2D object at 0x...>]
+    >>> plt.title("Hamming window")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.ylabel("Amplitude")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.xlabel("Sample")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.show()
+
+    >>> plt.figure()
+    <matplotlib.figure.Figure object at 0x...>
+    >>> A = fft(window, 2048) / 25.5
+    >>> mag = np.abs(fftshift(A))
+    >>> freq = np.linspace(-0.5, 0.5, len(A))
+    >>> response = 20 * np.log10(mag)
+    >>> response = np.clip(response, -100, 100)
+    >>> plt.plot(freq, response)
+    [<matplotlib.lines.Line2D object at 0x...>]
+    >>> plt.title("Frequency response of Hamming window")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.ylabel("Magnitude [dB]")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.xlabel("Normalized frequency [cycles per sample]")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.axis('tight')
+    (-0.5, 0.5, -100.0, ...)
+    >>> plt.show()
+
     """
+    # Docstring adapted from NumPy's hamming function
     if M < 1:
         return np.array([])
     if M == 1:
@@ -433,6 +729,8 @@ def hamming(M, sym=True):
 def kaiser(M, beta, sym=True):
     """Return a Kaiser window.
 
+    The Kaiser window is a taper formed by using a Bessel function.
+
     Parameters
     ----------
     M : int
@@ -440,18 +738,116 @@ def kaiser(M, beta, sym=True):
         array is returned.
     beta : float
         Shape parameter, determines trade-off between main-lobe width and 
-        side lobe level
+        side lobe level. As beta gets large, the window narrows.
     sym : bool, optional
         When True, generates a symmetric window, for use in filter design. 
         When False, generates a periodic window, for use in spectral analysis.
-
+        
     Returns
     -------
     w : ndarray
         The window, with the maximum value normalized to 1 (though the value 1 
         does not appear if the number of samples is even and sym is True).
+    
+    See Also
+    --------
+    bartlett, blackman, hamming, hann
+
+    Notes
+    -----
+    The Kaiser window is defined as
+
+    .. math::  w(n) = I_0\\left( \\beta \\sqrt{1-\\frac{4n^2}{(M-1)^2}}
+               \\right)/I_0(\\beta)
+
+    with
+
+    .. math:: \\quad -\\frac{M-1}{2} \\leq n \\leq \\frac{M-1}{2},
+
+    where :math:`I_0` is the modified zeroth-order Bessel function.
+
+    The Kaiser was named for Jim Kaiser, who discovered a simple approximation
+    to the DPSS window based on Bessel functions.
+    The Kaiser window is a very good approximation to the Digital Prolate
+    Spheroidal Sequence, or Slepian window, which is the transform which
+    maximizes the energy in the main lobe of the window relative to total
+    energy.
+
+    The Kaiser can approximate many other windows by varying the beta
+    parameter.
+
+    ====  =======================
+    beta  Window shape
+    ====  =======================
+    0     Rectangular
+    5     Similar to a Hamming
+    6     Similar to a Hann
+    8.6   Similar to a Blackman
+    ====  =======================
+
+    A beta value of 14 is probably a good starting point. Note that as beta
+    gets large, the window narrows, and so the number of samples needs to be
+    large enough to sample the increasingly narrow spike, otherwise nans will
+    get returned.
+
+    Most references to the Kaiser window come from the signal processing
+    literature, where it is used as one of many windowing functions for
+    smoothing values.  It is also known as an apodization (which means
+    "removing the foot", i.e. smoothing discontinuities at the beginning
+    and end of the sampled signal) or tapering function.
+
+    References
+    ----------
+    .. [1] J. F. Kaiser, "Digital Filters" - Ch 7 in "Systems analysis by
+           digital computer", Editors: F.F. Kuo and J.F. Kaiser, p 218-285.
+           John Wiley and Sons, New York, (1966).
+    .. [2] E.R. Kanasewich, "Time Sequence Analysis in Geophysics", The
+           University of Alberta Press, 1975, pp. 177-178.
+    .. [3] Wikipedia, "Window function",
+           http://en.wikipedia.org/wiki/Window_function
+
+    Examples
+    --------
+    >>> scipy.signal.kaiser(12, 14)
+    array([ 0.00000773,  0.00346009,  0.04652002,  0.22973712,  0.59988532,
+            0.9456749 ,  0.9456749 ,  0.59988532,  0.22973712,  0.04652002,
+            0.00346009,  0.00000773])
+
+    Plot the window and the frequency response:
+
+    >>> from numpy.fft import fft, fftshift
+    >>> window = scipy.signal.kaiser(51, 14)
+    >>> plt.plot(window)
+    [<matplotlib.lines.Line2D object at 0x...>]
+    >>> plt.title("Kaiser window")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.ylabel("Amplitude")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.xlabel("Sample")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.show()
+
+    >>> plt.figure()
+    <matplotlib.figure.Figure object at 0x...>
+    >>> A = fft(window, 2048) / 25.5
+    >>> mag = np.abs(fftshift(A))
+    >>> freq = np.linspace(-0.5, 0.5, len(A))
+    >>> response = 20 * np.log10(mag)
+    >>> response = np.clip(response, -100, 100)
+    >>> plt.plot(freq, response)
+    [<matplotlib.lines.Line2D object at 0x...>]
+    >>> plt.title("Frequency response of Kaiser window")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.ylabel("Magnitude [dB]")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.xlabel("Normalized frequency [cycles per sample]")
+    <matplotlib.text.Text object at 0x...>
+    >>> plt.axis('tight')
+    (-0.5, 0.5, -100.0, ...)
+    >>> plt.show()
 
     """
+    # Docstring adapted from NumPy's kaiser function
     if M < 1:
         return np.array([])
     if M == 1:

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -185,8 +185,8 @@ def bartlett(M, sym=True):
     return w
 
 
-def hanning(M, sym=True):
-    """The M-point Hanning window.
+def hann(M, sym=True):
+    """The M-point Hann window.
 
     """
     if M < 1:
@@ -202,7 +202,7 @@ def hanning(M, sym=True):
         w = w[:-1]
     return w
 
-hann = hanning
+hanning = hann
 
 
 def barthann(M, sym=True):

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -11,7 +11,21 @@ __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
 
 
 def boxcar(M, sym=True):
-    """The M-point boxcar window.
+    """The M-point boxcar or rectangular window.
+    
+    Included for completeness, this is equivalent to no window at all.
+
+    Parameters
+    ----------
+    M : int
+        Window size.
+    sym : bool
+        Whether the window is symmetric. (Has no effect for boxcar.)
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1
 
     """
     return np.ones(M, float)
@@ -19,6 +33,20 @@ def boxcar(M, sym=True):
 
 def triang(M, sym=True):
     """The M-point triangular window.
+
+    Parameters
+    ----------
+    M : int
+        Window size.
+    sym : bool
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1 (though the value 1 
+        does not appear if the number of samples is even and sym is True).
 
     """
     if M < 1:
@@ -44,6 +72,20 @@ def triang(M, sym=True):
 def parzen(M, sym=True):
     """The M-point Parzen window.
 
+    Parameters
+    ----------
+    M : int
+        Window size.
+    sym : bool
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1 (though the value 1 
+        does not appear if the number of samples is even and sym is True).
+
     """
     if M < 1:
         return np.array([])
@@ -67,6 +109,20 @@ def parzen(M, sym=True):
 def bohman(M, sym=True):
     """The M-point Bohman window.
 
+    Parameters
+    ----------
+    M : int
+        Window size.
+    sym : bool
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1 (though the value 1 
+        does not appear if the number of samples is even and sym is True).
+
     """
     if M < 1:
         return np.array([])
@@ -86,6 +142,20 @@ def bohman(M, sym=True):
 def blackman(M, sym=True):
     """The M-point Blackman window.
 
+    Parameters
+    ----------
+    M : int
+        Window size.
+    sym : bool
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1 (though the value 1 
+        does not appear if the number of samples is even and sym is True).
+
     """
     if M < 1:
         return np.array([])
@@ -104,6 +174,20 @@ def blackman(M, sym=True):
 
 def nuttall(M, sym=True):
     """A minimum 4-term Blackman-Harris window according to Nuttall.
+
+    Parameters
+    ----------
+    M : int
+        Window size.
+    sym : bool
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1 (though the value 1 
+        does not appear if the number of samples is even and sym is True).
 
     """
     if M < 1:
@@ -126,6 +210,20 @@ def nuttall(M, sym=True):
 def blackmanharris(M, sym=True):
     """The M-point minimum 4-term Blackman-Harris window.
 
+    Parameters
+    ----------
+    M : int
+        Window size.
+    sym : bool
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1 (though the value 1 
+        does not appear if the number of samples is even and sym is True).
+
     """
     if M < 1:
         return np.array([])
@@ -145,7 +243,20 @@ def blackmanharris(M, sym=True):
 
 
 def flattop(M, sym=True):
-    """The M-point Flat top window.
+    """The M-point flat top window.
+
+    Parameters
+    ----------
+    M : int
+        Window size.
+    sym : bool
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window function
 
     """
     if M < 1:
@@ -169,6 +280,22 @@ def flattop(M, sym=True):
 def bartlett(M, sym=True):
     """The M-point Bartlett window.
 
+    Similar to the triangular window, but with zero endpoints.
+    
+    Parameters
+    ----------
+    M : int
+        Window size.
+    sym : bool
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1 (though the value 1 
+        does not appear if the number of samples is even and sym is True).
+
     """
     if M < 1:
         return np.array([])
@@ -187,6 +314,24 @@ def bartlett(M, sym=True):
 
 def hann(M, sym=True):
     """The M-point Hann window.
+
+    Raised cosine or sine squared window with ends that touch zero. (Sometimes 
+    erroneously referred to as the "Hanning" window, from confusion with 
+    Hamming.)
+
+    Parameters
+    ----------
+    M : int
+        Window size.  If zero or less, an empty array is returned.
+    sym : bool
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1 (though the value 1 
+        does not appear if `M` is even and `sym` is True).
 
     """
     if M < 1:
@@ -208,6 +353,20 @@ hanning = hann
 def barthann(M, sym=True):
     """Return the M-point modified Bartlett-Hann window.
 
+    Parameters
+    ----------
+    M : int
+        Window size.
+    sym : bool
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1 (though the value 1 
+        does not appear if the number of samples is even and sym is True).
+
     """
     if M < 1:
         return np.array([])
@@ -227,6 +386,23 @@ def barthann(M, sym=True):
 def hamming(M, sym=True):
     """The M-point Hamming window.
 
+    Raised cosine window with non-zero endpoints, optimized to minimize the 
+    nearest side lobe.
+    
+    Parameters
+    ----------
+    M : int
+        Window size.
+    sym : bool
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1 (though the value 1 
+        does not appear if the number of samples is even and sym is True).
+
     """
     if M < 1:
         return np.array([])
@@ -243,7 +419,24 @@ def hamming(M, sym=True):
 
 
 def kaiser(M, beta, sym=True):
-    """Return a Kaiser window of length M with shape parameter beta.
+    """Return a Kaiser window.
+
+    Parameters
+    ----------
+    M : int
+        Window size.
+    beta : float
+        Shape parameter, determines trade-off between main-lobe width and 
+        side lobe level
+    sym : bool
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1 (though the value 1 
+        does not appear if the number of samples is even and sym is True).
 
     """
     if M < 1:
@@ -263,7 +456,22 @@ def kaiser(M, beta, sym=True):
 
 
 def gaussian(M, std, sym=True):
-    """Return a Gaussian window of length M with standard-deviation std.
+    """Return a Gaussian window.
+
+    Parameters
+    ----------
+    M : int
+        Window size.
+    std : float
+        Standard deviation.
+    sym : bool
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window function
 
     """
     if M < 1:
@@ -288,6 +496,7 @@ def general_gaussian(M, p, sig, sym=True):
     half-power point is at ``(2*log(2)))**(1/(2*p)) * sig``.
 
     """
+    # FIXME: What are p and sig called in English?  Improve docstring
     if M < 1:
         return np.array([])
     if M == 1:
@@ -314,8 +523,14 @@ def chebwin(M, at, sym=True):
     at : float
         Attenuation (in dB).
     sym : bool
-        Generates symmetric window if True.
+        When True, generates a symmetric window, for use in filter design. 
+        When False, generates a periodic window, for use in spectral analysis.
 
+    Returns
+    -------
+    w : ndarray
+        The window function
+    
     """
     if M < 1:
         return np.array([])
@@ -358,9 +573,14 @@ def chebwin(M, at, sym=True):
 
 
 def slepian(M, width, sym=True):
-    """Return the M-point slepian window.
+    """Return the M-point Slepian window.
+    
+    Used to maximize the energy concentration in the main lobe.  Also called 
+    the digital prolate spheroidal sequence (DPSS).
 
     """
+    # FIXME: Improve docstring, explain what "width" does
+    
     if (M * width > 27.38):
         raise ValueError("Cannot reliably obtain slepian sequences for"
               " M*width > 27.38.")


### PR DESCRIPTION
Added docstrings for all the window functions (because I couldn't figure out what "sym" was for).  

5 of these are copied from NumPy's functions, with modifications.  I double-checked that they produce identical output.

Not sure about:
1. Are the numpy examples good? Do we want that for all of them?  There should probably be graphs of each in the web documentation?
2. Not sure what to do about the See also section.  Include all 17 other window functions?  Or remove it altogether?
3. Not sure about official definitions for shape parameter for generalized Gaussian or bandwidth for Slepian, so I was vague.
4. generalized Gaussian half-power point equation had an extra parenthesis before I converted it to TeX, not sure if it was right.
5. Some of these are normalized to 1 even with an even number of samples, so I made the docstring match the behavior, but the behavior might be wrong.
