### PR TITLE
NF: allow OrderedDict as input to savemat

### DIFF
--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -438,12 +438,15 @@ def to_writeable(source):
         return source
     if source is None:
         return None
-    # Objects that have dicts
-    if hasattr(source, '__dict__'):
+    # Objects that implement mappings
+    is_mapping = (hasattr(source, 'keys') and hasattr(source, 'values') and
+                  hasattr(source, 'items'))
+    # Objects that don't implement mappings, but do have dicts
+    if not is_mapping and hasattr(source, '__dict__'):
         source = dict((key, value) for key, value in source.__dict__.items()
                       if not key.startswith('_'))
-    # Mappings or object dicts
-    if hasattr(source, 'keys'):
+        is_mapping = True
+    if is_mapping:
         dtype = []
         values = []
         for field, value in source.items():
@@ -452,7 +455,7 @@ def to_writeable(source):
                 dtype.append((field,object))
                 values.append(value)
         if dtype:
-            return np.array( [tuple(values)] ,dtype)
+            return np.array([tuple(values)] ,dtype)
         else:
             return None
     # Next try and convert to an array

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -516,11 +516,23 @@ def test_use_small_element():
 
 def test_save_dict():
     # Test that dict can be saved (as recarray), loaded as matstruct
-    d = {'a':1, 'b':2}
-    stream = BytesIO()
-    savemat_future(stream, {'dict':d})
-    stream.seek(0)
-    vals = loadmat(stream)
+    dict_types = (dict,)
+    try:
+        from collections import OrderedDict
+    except ImportError:
+        pass
+    else:
+        dict_types += (OrderedDict,)
+    exp_arr = np.zeros((1, 1), dtype = [('a', object), ('b', object)])
+    exp_arr['a'] = 1
+    exp_arr['b'] = 2
+    for dict_type in dict_types:
+        d = dict_type(a=1, b=2)
+        stream = BytesIO()
+        savemat_future(stream, {'dict': d})
+        stream.seek(0)
+        vals = loadmat(stream)
+        assert_array_equal(vals['dict'], exp_arr)
 
 
 def test_1d_shape():


### PR DESCRIPTION
Thanks to ali-ebrahim for pointing out this problem.

Closes http://projects.scipy.org/scipy/ticket/1566

The commit changes the savemat behavior in that, an object that
implements 'keys', 'values' and 'items' would previously have been been
saved by considering the object as an object, and saving all fields in
the object's **dict** attribute.  This patch identifies this object as a
mapping and saves all key, value pairs like a dict. This will cause a
change in behavior only for objects implementing all of 'keys',
'values', 'items'.
