### PR TITLE
Bode fix

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -616,8 +616,16 @@ def _default_response_frequencies(A, n):
         the response is to be computed.
     """
     vals = linalg.eigvals(A)
-    minpole = min(abs(real(vals)))
-    maxpole = max(abs(real(vals)))
+    # Remove poles at 0 because they don't help us determine an interesting
+    # frequency range. (And if we pass a 0 to log10() below we will crash.)
+    poles = [pole for pole in vals if pole != 0]
+    # If there are no non-zero poles, just hardcode something.
+    if len(poles) == 0:
+        minpole = 1
+        maxpole = 1
+    else:
+        minpole = min(abs(real(poles)))
+        maxpole = max(abs(real(poles)))
     # A reasonable frequency range is two orders of magnitude before the
     # minimum pole (slowest) and two orders of magnitude after the maximum pole
     # (fastest).

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -299,6 +299,12 @@ class Test_bode(object):
         w, mag, phase = bode(system, n=n)
         assert_almost_equal(w, expected_w)
 
+    def test_06(self):
+        """Test that bode() doesn't fail on a system with a pole at 0."""
+        # integrator, pole at zero: H(s) = 1 / s
+        system = lti([1], [1, 0])
+        w, mag, phase = bode(system, n=2)
+        assert_equal(w[0], 0.01)  # a fail would give not-a-number
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Hi, I discovered a bug in signal.bode() that makes it crash if the system has a pole at 0, like this: bode(([], [0], 1))

Please merge this fix.
