### PR TITLE
BUG: fix dtype comparison on big-endian machines.  Closes ticket 1680.

### DIFF
--- a/scipy/sparse/linalg/dsolve/umfpack/umfpack.py
+++ b/scipy/sparse/linalg/dsolve/umfpack/umfpack.py
@@ -345,10 +345,10 @@ class UmfpackContext( Struct ):
                 raise ValueError('matrix must have long indices')
 
         if self.isReal:
-            if mtx.data.dtype != np.dtype('<f8'):
+            if mtx.data.dtype != np.dtype('f8'):
                 raise ValueError('matrix must have float64 values')
         else:
-            if mtx.data.dtype != np.dtype('<c16'):
+            if mtx.data.dtype != np.dtype('c16'):
                 raise ValueError('matrix must have complex128 values')
 
         return indx


### PR DESCRIPTION
Note that while this seems correct, I don't have umfpack installed and therefore can't test this.
