### PR TITLE
TST: fix py3k failure in interpolate test.

### DIFF
--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -25,11 +25,10 @@ def f2(x,y=0,dx=0,dy=0):
     if d%4 == 2: return -sin(x+y)
     if d%4 == 3: return -cos(x+y)
 
-def makepairs(x,y):
-    x,y=map(asarray,[x,y])
-    xy=array(map(lambda x,y:map(None,len(y)*[x],y),x,len(x)*[y]))
-    sh=xy.shape
-    xy.shape=sh[0]*sh[1],sh[2]
+def makepairs(x, y):
+    """Helper function to create an array of pairs of x and y."""
+    # Or itertools.product (>= python 2.6)
+    xy = array([[a, b] for a in asarray(x) for b in asarray(y)])
     return xy.T
 
 def put(*a):


### PR DESCRIPTION
The syntax map(None, x, y) is no longer available, hence the failure.  Rewrite
in a simpler way.

Failure was introduced recently, no ticket opened. Failure:

```
======================================================================
ERROR: test_smoke_bisplrep_bisplev (test_fitpack.TestSmokeTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File
"X:\Python32-x32\lib\site-packages\scipy\interpolate\tests\test_fitpack.py",
line 219, in test_smoke_bisplrep_bisplev
    self.check_5()
  File
"X:\Python32-x32\lib\site-packages\scipy\interpolate\tests\test_fitpack.py",
line 180, in check_5
    xy=makepairs(x,y)
  File
"X:\Python32-x32\lib\site-packages\scipy\interpolate\tests\test_fitpack.py",
line 32, in makepairs
    xy.shape=sh[0]*sh[1],sh[2]
IndexError: tuple index out of range
```

Should be backported to 0.11.x
