### PR TITLE
DOC: Fix error in wilcoxon docstring.

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -105,6 +105,7 @@ Sebastian Werk for Halley's method in newton().
 Bjorn Forsman for contributing signal.bode().
 Tony S. Yu for ndimage improvements.
 Jonathan J. Helmus for work on ndimage.
+Alex Reinhart for documentation improvements.
 
 
 Institutions

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1226,8 +1226,9 @@ def wilcoxon(x,y=None):
     Calculate the Wilcoxon signed-rank test.
 
     The Wilcoxon signed-rank test tests the null hypothesis that two
-    related samples come from the same distribution. It is a a
-    non-parametric version of the paired T-test.
+    related paired samples come from the same distribution. In particular,
+    it tests whether the distribution of the differences x - y is symmetric
+    about zero. It is a non-parametric version of the paired T-test.
 
     Parameters
     ----------
@@ -1240,9 +1241,9 @@ def wilcoxon(x,y=None):
 
     Returns
     -------
-    z-statistic : float
-        The test statistic under the large-sample approximation that the
-        signed-rank statistic is normally distributed.
+    T : float
+        The sum of the ranks of the differences above or below zero, whichever
+        is smaller.
     p-value : float
         The two-sided p-value for the test.
 

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -737,6 +737,8 @@ def ansari(x,y):
 
     Returns
     -------
+    AB : float
+        The Ansari-Bradley test statistic
     p-value : float
         The p-value of the hypothesis test
 
@@ -1140,6 +1142,8 @@ def mood(x,y):
 
     Returns
     -------
+    z : float
+        The z-score for the hypothesis test.
     p-value : float
         The p-value for the hypothesis test.
 


### PR DESCRIPTION
This PR fixes issue #1413:

http://projects.scipy.org/scipy/ticket/1413

The stats.wilcoxon() docstring incorrectly described what the function actually returns. I fixed this, and also added further description to the docstring so users will actually understand what I mean by "the ranks of the differences". I think my description is accurate, but if anyone knows the Wilcoxon signed-ranks test better I'd appreciate a check.

Also, first SciPy contribution, woo.
