### PR TITLE
Fix typos in interval method documentation

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -826,8 +826,8 @@ class rv_generic(object):
         arg1, arg2, ... : array_like
             The shape parameter(s) for the distribution (see docstring of the instance
             object for more information)
-        loc: array_like, optioal
-            location parameter (deafult = 0)
+        loc: array_like, optional
+            location parameter (default = 0)
         scale : array_like, optional
             scale paramter (default = 1)
 


### PR DESCRIPTION
The words "default" and "optional" were misspelled. These shows up in the reference guide for rv_discrete and rv_continous.
