### PR TITLE
MAINT: raise more informative error when importing weave under Python 3.x

### DIFF
--- a/scipy/weave/__init__.py
+++ b/scipy/weave/__init__.py
@@ -16,6 +16,12 @@ C/C++ integration
 
 """
 
+import sys
+
+if sys.version_info[0] >= 3:
+    raise ImportError("scipy.weave only supports Python 2.x")
+
+
 from weave_version import weave_version as __version__
 
 try:


### PR DESCRIPTION
Now the error (also when running the test suite) is confusing:

```
AttributeError: 'module' object has no attribute 'FileType'
```
