### PR TITLE
Fix edge case in lstsq function

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -468,11 +468,15 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False):
     if n > m:
         # need to extend b matrix as it will be filled with
         # a larger solution matrix
-        b2 = np.zeros((n, nrhs), dtype=gelss.dtype)
+        if len(b1.shape) == 2:
+            b2 = np.zeros((n, nrhs), dtype=gelss.dtype)
+        else:
+            b2 = np.zeros(n, dtype=gelss.dtype)
+
         if len(b1.shape) == 2:
             b2[:m,:] = b1
         else:
-            b2[:m,0] = b1
+            b2[:m] = b1
         b1 = b2
     overwrite_a = overwrite_a or _datacopied(a1, a)
     overwrite_b = overwrite_b or _datacopied(b1, b)

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -470,14 +470,12 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False):
         # a larger solution matrix
         if len(b1.shape) == 2:
             b2 = np.zeros((n, nrhs), dtype=gelss.dtype)
-        else:
-            b2 = np.zeros(n, dtype=gelss.dtype)
-
-        if len(b1.shape) == 2:
             b2[:m,:] = b1
         else:
+            b2 = np.zeros(n, dtype=gelss.dtype)
             b2[:m] = b1
         b1 = b2
+
     overwrite_a = overwrite_a or _datacopied(a1, a)
     overwrite_b = overwrite_b or _datacopied(b1, b)
     if gelss.module_name[:7] == 'flapack':

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -484,8 +484,7 @@ class TestLstsq(TestCase):
         b = [1,2]
         x,res,r,s = lstsq(a,b)
         #XXX: need independent check
-        assert_array_almost_equal(x,[[-0.05555556],
-                                     [0.11111111],[0.27777778]])
+        assert_array_almost_equal(x,[-0.05555556, 0.11111111, 0.27777778])
 
     def test_random_exact(self):
 


### PR DESCRIPTION
Looking at http://stackoverflow.com/questions/11549486/linearregression-returns-list-within-list-sklearn/ and digging through the code I found that the lstsq function wasn't behaving correctly. It's doc says that:

```
Returns
-------
x : array, shape (N,) or (N, K) depending on shape of b
    Least-squares solution.
```

for

```
a : array, shape (M, N)
    Left hand side matrix (2-D array).
b : array, shape (M,) or (M, K)
    Right hand side matrix or vector (1-D or 2-D array).
```

But for the case `a.shape==(2,6)` and `b.shape==(2,)` we get `x.shape==(6,1)` instead of `(6,)`.

I've tried to patch the code to work correctly for that case.
