### PR TITLE
Corrected wrong docstring in helper function ss

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3858,7 +3858,7 @@ def f_value_multivariate(ER, EF, dfnum, dfden):
 
 def ss(a, axis=0):
     """
-    Squares each element of the input array, and returns the square(s) of that.
+    Squares each element of the input array, and returns the sum(s) of that.
 
     Parameters
     ----------


### PR DESCRIPTION
I accidentally found a wron docstring in stats.py.

Nothing serious, though.
