### PR TITLE
BUG: Change __Pyx_zeros and __Pyx_minusones scope to static.

### DIFF
--- a/scipy/io/matlab/mio5_utils.c
+++ b/scipy/io/matlab/mio5_utils.c
@@ -1054,8 +1054,8 @@ static void __Pyx_ReleaseBuffer(Py_buffer *view);
 #define __Pyx_ReleaseBuffer PyBuffer_Release
 #endif
 
-Py_ssize_t __Pyx_zeros[] = {0};
-Py_ssize_t __Pyx_minusones[] = {-1};
+static Py_ssize_t __Pyx_zeros[] = {0};
+static Py_ssize_t __Pyx_minusones[] = {-1};
 
 static PyObject *__Pyx_Import(PyObject *name, PyObject *from_list, long level); /*proto*/
 

--- a/scipy/stats/vonmises_cython.c
+++ b/scipy/stats/vonmises_cython.c
@@ -770,8 +770,8 @@ static void __Pyx_ReleaseBuffer(Py_buffer *view);
 #define __Pyx_ReleaseBuffer PyBuffer_Release
 #endif
 
-Py_ssize_t __Pyx_zeros[] = {0};
-Py_ssize_t __Pyx_minusones[] = {-1};
+static Py_ssize_t __Pyx_zeros[] = {0};
+static Py_ssize_t __Pyx_minusones[] = {-1};
 
 static PyObject *__Pyx_Import(PyObject *name, PyObject *from_list, long level); /*proto*/
 


### PR DESCRIPTION
Manually apply the fix from cython/cython#87, rather than regenerate the
entire cython file.

Having multiple definitions of these symbols prevents liking SciPy into a
static Python binary.
