### PR TITLE
BUG: Duplicate SWIG-related symbols when linking static extension.

### DIFF
--- a/scipy/sparse/sparsetools/bsr_wrap.cxx
+++ b/scipy/sparse/sparsetools/bsr_wrap.cxx
@@ -2854,7 +2854,7 @@ namespace swig {
 
 /* Given a PyObject, return a string describing its type.
  */
-const char* pytype_string(PyObject* py_obj) {
+static const char* pytype_string(PyObject* py_obj) {
   if (py_obj == NULL          ) return "C NULL value";
   if (py_obj == Py_None       ) return "Python None" ;
   if (PyCallable_Check(py_obj)) return "callable"    ;
@@ -2873,7 +2873,7 @@ const char* pytype_string(PyObject* py_obj) {
 
 /* Given a NumPy typecode, return a string describing the type.
  */
-const char* typecode_string(int typecode) {
+static const char* typecode_string(int typecode) {
   static const char* type_names[25] = {"bool", "byte", "unsigned byte",
 				 "short", "unsigned short", "int",
 				 "unsigned int", "long", "unsigned long",
@@ -2890,7 +2890,7 @@ const char* typecode_string(int typecode) {
  * to match.  Also allow int and long to match.  This is deprecated.
  * You should use PyArray_EquivTypenums() instead.
  */
-int type_match(int actual_type, int desired_type) {
+static int type_match(int actual_type, int desired_type) {
   return PyArray_EquivTypenums(actual_type, desired_type);
 }
 
@@ -2898,7 +2898,7 @@ int type_match(int actual_type, int desired_type) {
  * legal.  If not, set the python error string appropriately and
  * return NULL.
  */
-PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
+static PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
   PyArrayObject* ary = NULL;
   if (is_array(input) && (typecode == NPY_NOTYPE ||
 			  PyArray_EquivTypenums(array_type(input), typecode))) {
@@ -2928,7 +2928,7 @@ PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
  * correct type.  On failure, the python error string will be set and
  * the routine returns NULL.
  */
-PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
+static PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
                                              int* is_new_object) {
   PyArrayObject* ary = NULL;
   PyObject* py_obj;
@@ -2951,7 +2951,7 @@ PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
  * not contiguous, create a new PyArrayObject using the original data,
  * flag it as a new object and return the pointer.
  */
-PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
+static PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
                                int min_dims, int max_dims) {
   PyArrayObject* result;
   if (array_is_contiguous(ary)) {
@@ -2973,7 +2973,7 @@ PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
  * PyArrayObject, a new one will be created and the new object flag
  * will be set.
  */
-PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
+static PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
                                                         int typecode,
                                                         int* is_new_object) {
   int is_new1 = 0;
@@ -2995,7 +2995,7 @@ PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
  * contiguous, return 1.  Otherwise, set the python error string and
  * return 0.
  */
-int require_contiguous(PyArrayObject* ary) {
+static int require_contiguous(PyArrayObject* ary) {
   int contiguous = 1;
   if (!array_is_contiguous(ary)) {
     PyErr_SetString(PyExc_TypeError,
@@ -3009,7 +3009,7 @@ int require_contiguous(PyArrayObject* ary) {
  * not byte-swapped, return 1.  Otherwise, set the python error string
  * and return 0.
  */
-int require_native(PyArrayObject* ary) {
+static int require_native(PyArrayObject* ary) {
   int native = 1;
   if (!array_is_native(ary)) {
     PyErr_SetString(PyExc_TypeError,
@@ -3023,7 +3023,7 @@ int require_native(PyArrayObject* ary) {
  * dimensions.  If the array has the specified number of dimensions,
  * return 1.  Otherwise, set the python error string and return 0.
  */
-int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
+static int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
   int success = 1;
   if (array_numdims(ary) != exact_dimensions) {
     PyErr_Format(PyExc_TypeError, 
@@ -3039,7 +3039,7 @@ int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
  * of dimensions, return 1.  Otherwise, set the python error string
  * and return 0.
  */
-int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
+static int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
   int success = 0;
   int i;
   char dims_str[255] = "";
@@ -3067,7 +3067,7 @@ int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
  * array has the specified shape, return 1.  Otherwise, set the python
  * error string and return 0.
  */
-int require_size(PyArrayObject* ary, npy_intp* size, int n) {
+static int require_size(PyArrayObject* ary, npy_intp* size, int n) {
   int i;
   int success = 1;
   int len;
@@ -3117,7 +3117,7 @@ int require_size(PyArrayObject* ary, npy_intp* size, int n) {
   @par Revision history:
   - 17.02.2005, c
 */
-PyObject *helper_appendToTuple( PyObject *where, PyObject *what ) {
+static PyObject *helper_appendToTuple( PyObject *where, PyObject *what ) {
   PyObject *o2, *o3;
 
   if ((!where) || (where == Py_None)) {

--- a/scipy/sparse/sparsetools/coo_wrap.cxx
+++ b/scipy/sparse/sparsetools/coo_wrap.cxx
@@ -3074,7 +3074,7 @@ namespace swig {
 
 /* Given a PyObject, return a string describing its type.
  */
-const char* pytype_string(PyObject* py_obj) {
+static const char* pytype_string(PyObject* py_obj) {
   if (py_obj == NULL          ) return "C NULL value";
   if (py_obj == Py_None       ) return "Python None" ;
   if (PyCallable_Check(py_obj)) return "callable"    ;
@@ -3093,7 +3093,7 @@ const char* pytype_string(PyObject* py_obj) {
 
 /* Given a NumPy typecode, return a string describing the type.
  */
-const char* typecode_string(int typecode) {
+static const char* typecode_string(int typecode) {
   static const char* type_names[25] = {"bool", "byte", "unsigned byte",
 				 "short", "unsigned short", "int",
 				 "unsigned int", "long", "unsigned long",
@@ -3110,7 +3110,7 @@ const char* typecode_string(int typecode) {
  * to match.  Also allow int and long to match.  This is deprecated.
  * You should use PyArray_EquivTypenums() instead.
  */
-int type_match(int actual_type, int desired_type) {
+static int type_match(int actual_type, int desired_type) {
   return PyArray_EquivTypenums(actual_type, desired_type);
 }
 
@@ -3118,7 +3118,7 @@ int type_match(int actual_type, int desired_type) {
  * legal.  If not, set the python error string appropriately and
  * return NULL.
  */
-PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
+static PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
   PyArrayObject* ary = NULL;
   if (is_array(input) && (typecode == NPY_NOTYPE ||
 			  PyArray_EquivTypenums(array_type(input), typecode))) {
@@ -3148,7 +3148,7 @@ PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
  * correct type.  On failure, the python error string will be set and
  * the routine returns NULL.
  */
-PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
+static PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
                                              int* is_new_object) {
   PyArrayObject* ary = NULL;
   PyObject* py_obj;
@@ -3171,7 +3171,7 @@ PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
  * not contiguous, create a new PyArrayObject using the original data,
  * flag it as a new object and return the pointer.
  */
-PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
+static PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
                                int min_dims, int max_dims) {
   PyArrayObject* result;
   if (array_is_contiguous(ary)) {
@@ -3193,7 +3193,7 @@ PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
  * PyArrayObject, a new one will be created and the new object flag
  * will be set.
  */
-PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
+static PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
                                                         int typecode,
                                                         int* is_new_object) {
   int is_new1 = 0;
@@ -3215,7 +3215,7 @@ PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
  * contiguous, return 1.  Otherwise, set the python error string and
  * return 0.
  */
-int require_contiguous(PyArrayObject* ary) {
+static int require_contiguous(PyArrayObject* ary) {
   int contiguous = 1;
   if (!array_is_contiguous(ary)) {
     PyErr_SetString(PyExc_TypeError,
@@ -3229,7 +3229,7 @@ int require_contiguous(PyArrayObject* ary) {
  * not byte-swapped, return 1.  Otherwise, set the python error string
  * and return 0.
  */
-int require_native(PyArrayObject* ary) {
+static int require_native(PyArrayObject* ary) {
   int native = 1;
   if (!array_is_native(ary)) {
     PyErr_SetString(PyExc_TypeError,
@@ -3243,7 +3243,7 @@ int require_native(PyArrayObject* ary) {
  * dimensions.  If the array has the specified number of dimensions,
  * return 1.  Otherwise, set the python error string and return 0.
  */
-int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
+static int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
   int success = 1;
   if (array_numdims(ary) != exact_dimensions) {
     PyErr_Format(PyExc_TypeError, 
@@ -3259,7 +3259,7 @@ int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
  * of dimensions, return 1.  Otherwise, set the python error string
  * and return 0.
  */
-int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
+static int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
   int success = 0;
   int i;
   char dims_str[255] = "";
@@ -3287,7 +3287,7 @@ int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
  * array has the specified shape, return 1.  Otherwise, set the python
  * error string and return 0.
  */
-int require_size(PyArrayObject* ary, npy_intp* size, int n) {
+static int require_size(PyArrayObject* ary, npy_intp* size, int n) {
   int i;
   int success = 1;
   int len;
@@ -3337,7 +3337,7 @@ int require_size(PyArrayObject* ary, npy_intp* size, int n) {
   @par Revision history:
   - 17.02.2005, c
 */
-PyObject *helper_appendToTuple( PyObject *where, PyObject *what ) {
+static PyObject *helper_appendToTuple( PyObject *where, PyObject *what ) {
   PyObject *o2, *o3;
 
   if ((!where) || (where == Py_None)) {

--- a/scipy/sparse/sparsetools/csc_wrap.cxx
+++ b/scipy/sparse/sparsetools/csc_wrap.cxx
@@ -2854,7 +2854,7 @@ namespace swig {
 
 /* Given a PyObject, return a string describing its type.
  */
-const char* pytype_string(PyObject* py_obj) {
+static const char* pytype_string(PyObject* py_obj) {
   if (py_obj == NULL          ) return "C NULL value";
   if (py_obj == Py_None       ) return "Python None" ;
   if (PyCallable_Check(py_obj)) return "callable"    ;
@@ -2873,7 +2873,7 @@ const char* pytype_string(PyObject* py_obj) {
 
 /* Given a NumPy typecode, return a string describing the type.
  */
-const char* typecode_string(int typecode) {
+static const char* typecode_string(int typecode) {
   static const char* type_names[25] = {"bool", "byte", "unsigned byte",
 				 "short", "unsigned short", "int",
 				 "unsigned int", "long", "unsigned long",
@@ -2890,7 +2890,7 @@ const char* typecode_string(int typecode) {
  * to match.  Also allow int and long to match.  This is deprecated.
  * You should use PyArray_EquivTypenums() instead.
  */
-int type_match(int actual_type, int desired_type) {
+static int type_match(int actual_type, int desired_type) {
   return PyArray_EquivTypenums(actual_type, desired_type);
 }
 
@@ -2898,7 +2898,7 @@ int type_match(int actual_type, int desired_type) {
  * legal.  If not, set the python error string appropriately and
  * return NULL.
  */
-PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
+static PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
   PyArrayObject* ary = NULL;
   if (is_array(input) && (typecode == NPY_NOTYPE ||
 			  PyArray_EquivTypenums(array_type(input), typecode))) {
@@ -2928,7 +2928,7 @@ PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
  * correct type.  On failure, the python error string will be set and
  * the routine returns NULL.
  */
-PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
+static PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
                                              int* is_new_object) {
   PyArrayObject* ary = NULL;
   PyObject* py_obj;
@@ -2951,7 +2951,7 @@ PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
  * not contiguous, create a new PyArrayObject using the original data,
  * flag it as a new object and return the pointer.
  */
-PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
+static PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
                                int min_dims, int max_dims) {
   PyArrayObject* result;
   if (array_is_contiguous(ary)) {
@@ -2973,7 +2973,7 @@ PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
  * PyArrayObject, a new one will be created and the new object flag
  * will be set.
  */
-PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
+static PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
                                                         int typecode,
                                                         int* is_new_object) {
   int is_new1 = 0;
@@ -2995,7 +2995,7 @@ PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
  * contiguous, return 1.  Otherwise, set the python error string and
  * return 0.
  */
-int require_contiguous(PyArrayObject* ary) {
+static int require_contiguous(PyArrayObject* ary) {
   int contiguous = 1;
   if (!array_is_contiguous(ary)) {
     PyErr_SetString(PyExc_TypeError,
@@ -3009,7 +3009,7 @@ int require_contiguous(PyArrayObject* ary) {
  * not byte-swapped, return 1.  Otherwise, set the python error string
  * and return 0.
  */
-int require_native(PyArrayObject* ary) {
+static int require_native(PyArrayObject* ary) {
   int native = 1;
   if (!array_is_native(ary)) {
     PyErr_SetString(PyExc_TypeError,
@@ -3023,7 +3023,7 @@ int require_native(PyArrayObject* ary) {
  * dimensions.  If the array has the specified number of dimensions,
  * return 1.  Otherwise, set the python error string and return 0.
  */
-int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
+static int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
   int success = 1;
   if (array_numdims(ary) != exact_dimensions) {
     PyErr_Format(PyExc_TypeError, 
@@ -3039,7 +3039,7 @@ int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
  * of dimensions, return 1.  Otherwise, set the python error string
  * and return 0.
  */
-int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
+static int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
   int success = 0;
   int i;
   char dims_str[255] = "";
@@ -3067,7 +3067,7 @@ int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
  * array has the specified shape, return 1.  Otherwise, set the python
  * error string and return 0.
  */
-int require_size(PyArrayObject* ary, npy_intp* size, int n) {
+static int require_size(PyArrayObject* ary, npy_intp* size, int n) {
   int i;
   int success = 1;
   int len;
@@ -3117,7 +3117,7 @@ int require_size(PyArrayObject* ary, npy_intp* size, int n) {
   @par Revision history:
   - 17.02.2005, c
 */
-PyObject *helper_appendToTuple( PyObject *where, PyObject *what ) {
+static PyObject *helper_appendToTuple( PyObject *where, PyObject *what ) {
   PyObject *o2, *o3;
 
   if ((!where) || (where == Py_None)) {

--- a/scipy/sparse/sparsetools/csgraph_wrap.cxx
+++ b/scipy/sparse/sparsetools/csgraph_wrap.cxx
@@ -2854,7 +2854,7 @@ namespace swig {
 
 /* Given a PyObject, return a string describing its type.
  */
-const char* pytype_string(PyObject* py_obj) {
+static const char* pytype_string(PyObject* py_obj) {
   if (py_obj == NULL          ) return "C NULL value";
   if (py_obj == Py_None       ) return "Python None" ;
   if (PyCallable_Check(py_obj)) return "callable"    ;
@@ -2873,7 +2873,7 @@ const char* pytype_string(PyObject* py_obj) {
 
 /* Given a NumPy typecode, return a string describing the type.
  */
-const char* typecode_string(int typecode) {
+static const char* typecode_string(int typecode) {
   static const char* type_names[25] = {"bool", "byte", "unsigned byte",
 				 "short", "unsigned short", "int",
 				 "unsigned int", "long", "unsigned long",
@@ -2890,7 +2890,7 @@ const char* typecode_string(int typecode) {
  * to match.  Also allow int and long to match.  This is deprecated.
  * You should use PyArray_EquivTypenums() instead.
  */
-int type_match(int actual_type, int desired_type) {
+static int type_match(int actual_type, int desired_type) {
   return PyArray_EquivTypenums(actual_type, desired_type);
 }
 
@@ -2898,7 +2898,7 @@ int type_match(int actual_type, int desired_type) {
  * legal.  If not, set the python error string appropriately and
  * return NULL.
  */
-PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
+static PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
   PyArrayObject* ary = NULL;
   if (is_array(input) && (typecode == NPY_NOTYPE ||
 			  PyArray_EquivTypenums(array_type(input), typecode))) {
@@ -2928,7 +2928,7 @@ PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
  * correct type.  On failure, the python error string will be set and
  * the routine returns NULL.
  */
-PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
+static PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
                                              int* is_new_object) {
   PyArrayObject* ary = NULL;
   PyObject* py_obj;
@@ -2951,7 +2951,7 @@ PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
  * not contiguous, create a new PyArrayObject using the original data,
  * flag it as a new object and return the pointer.
  */
-PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
+static PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
                                int min_dims, int max_dims) {
   PyArrayObject* result;
   if (array_is_contiguous(ary)) {
@@ -2973,7 +2973,7 @@ PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
  * PyArrayObject, a new one will be created and the new object flag
  * will be set.
  */
-PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
+static PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
                                                         int typecode,
                                                         int* is_new_object) {
   int is_new1 = 0;
@@ -2995,7 +2995,7 @@ PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
  * contiguous, return 1.  Otherwise, set the python error string and
  * return 0.
  */
-int require_contiguous(PyArrayObject* ary) {
+static int require_contiguous(PyArrayObject* ary) {
   int contiguous = 1;
   if (!array_is_contiguous(ary)) {
     PyErr_SetString(PyExc_TypeError,
@@ -3009,7 +3009,7 @@ int require_contiguous(PyArrayObject* ary) {
  * not byte-swapped, return 1.  Otherwise, set the python error string
  * and return 0.
  */
-int require_native(PyArrayObject* ary) {
+static int require_native(PyArrayObject* ary) {
   int native = 1;
   if (!array_is_native(ary)) {
     PyErr_SetString(PyExc_TypeError,
@@ -3023,7 +3023,7 @@ int require_native(PyArrayObject* ary) {
  * dimensions.  If the array has the specified number of dimensions,
  * return 1.  Otherwise, set the python error string and return 0.
  */
-int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
+static int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
   int success = 1;
   if (array_numdims(ary) != exact_dimensions) {
     PyErr_Format(PyExc_TypeError, 
@@ -3039,7 +3039,7 @@ int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
  * of dimensions, return 1.  Otherwise, set the python error string
  * and return 0.
  */
-int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
+static int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
   int success = 0;
   int i;
   char dims_str[255] = "";
@@ -3067,7 +3067,7 @@ int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
  * array has the specified shape, return 1.  Otherwise, set the python
  * error string and return 0.
  */
-int require_size(PyArrayObject* ary, npy_intp* size, int n) {
+static int require_size(PyArrayObject* ary, npy_intp* size, int n) {
   int i;
   int success = 1;
   int len;
@@ -3117,7 +3117,7 @@ int require_size(PyArrayObject* ary, npy_intp* size, int n) {
   @par Revision history:
   - 17.02.2005, c
 */
-PyObject *helper_appendToTuple( PyObject *where, PyObject *what ) {
+static PyObject *helper_appendToTuple( PyObject *where, PyObject *what ) {
   PyObject *o2, *o3;
 
   if ((!where) || (where == Py_None)) {

--- a/scipy/sparse/sparsetools/csr_wrap.cxx
+++ b/scipy/sparse/sparsetools/csr_wrap.cxx
@@ -2868,7 +2868,7 @@ namespace swig {
 
 /* Given a PyObject, return a string describing its type.
  */
-const char* pytype_string(PyObject* py_obj) {
+static const char* pytype_string(PyObject* py_obj) {
   if (py_obj == NULL          ) return "C NULL value";
   if (py_obj == Py_None       ) return "Python None" ;
   if (PyCallable_Check(py_obj)) return "callable"    ;
@@ -2887,7 +2887,7 @@ const char* pytype_string(PyObject* py_obj) {
 
 /* Given a NumPy typecode, return a string describing the type.
  */
-const char* typecode_string(int typecode) {
+static const char* typecode_string(int typecode) {
   static const char* type_names[25] = {"bool", "byte", "unsigned byte",
 				 "short", "unsigned short", "int",
 				 "unsigned int", "long", "unsigned long",
@@ -2904,7 +2904,7 @@ const char* typecode_string(int typecode) {
  * to match.  Also allow int and long to match.  This is deprecated.
  * You should use PyArray_EquivTypenums() instead.
  */
-int type_match(int actual_type, int desired_type) {
+static int type_match(int actual_type, int desired_type) {
   return PyArray_EquivTypenums(actual_type, desired_type);
 }
 
@@ -2912,7 +2912,7 @@ int type_match(int actual_type, int desired_type) {
  * legal.  If not, set the python error string appropriately and
  * return NULL.
  */
-PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
+static PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
   PyArrayObject* ary = NULL;
   if (is_array(input) && (typecode == NPY_NOTYPE ||
 			  PyArray_EquivTypenums(array_type(input), typecode))) {
@@ -2942,7 +2942,7 @@ PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
  * correct type.  On failure, the python error string will be set and
  * the routine returns NULL.
  */
-PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
+static PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
                                              int* is_new_object) {
   PyArrayObject* ary = NULL;
   PyObject* py_obj;
@@ -2965,7 +2965,7 @@ PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
  * not contiguous, create a new PyArrayObject using the original data,
  * flag it as a new object and return the pointer.
  */
-PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
+static PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
                                int min_dims, int max_dims) {
   PyArrayObject* result;
   if (array_is_contiguous(ary)) {
@@ -2987,7 +2987,7 @@ PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
  * PyArrayObject, a new one will be created and the new object flag
  * will be set.
  */
-PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
+static PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
                                                         int typecode,
                                                         int* is_new_object) {
   int is_new1 = 0;
@@ -3009,7 +3009,7 @@ PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
  * contiguous, return 1.  Otherwise, set the python error string and
  * return 0.
  */
-int require_contiguous(PyArrayObject* ary) {
+static int require_contiguous(PyArrayObject* ary) {
   int contiguous = 1;
   if (!array_is_contiguous(ary)) {
     PyErr_SetString(PyExc_TypeError,
@@ -3023,7 +3023,7 @@ int require_contiguous(PyArrayObject* ary) {
  * not byte-swapped, return 1.  Otherwise, set the python error string
  * and return 0.
  */
-int require_native(PyArrayObject* ary) {
+static int require_native(PyArrayObject* ary) {
   int native = 1;
   if (!array_is_native(ary)) {
     PyErr_SetString(PyExc_TypeError,
@@ -3037,7 +3037,7 @@ int require_native(PyArrayObject* ary) {
  * dimensions.  If the array has the specified number of dimensions,
  * return 1.  Otherwise, set the python error string and return 0.
  */
-int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
+static int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
   int success = 1;
   if (array_numdims(ary) != exact_dimensions) {
     PyErr_Format(PyExc_TypeError, 
@@ -3053,7 +3053,7 @@ int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
  * of dimensions, return 1.  Otherwise, set the python error string
  * and return 0.
  */
-int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
+static int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
   int success = 0;
   int i;
   char dims_str[255] = "";
@@ -3081,7 +3081,7 @@ int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
  * array has the specified shape, return 1.  Otherwise, set the python
  * error string and return 0.
  */
-int require_size(PyArrayObject* ary, npy_intp* size, int n) {
+static int require_size(PyArrayObject* ary, npy_intp* size, int n) {
   int i;
   int success = 1;
   int len;
@@ -3131,7 +3131,7 @@ int require_size(PyArrayObject* ary, npy_intp* size, int n) {
   @par Revision history:
   - 17.02.2005, c
 */
-PyObject *helper_appendToTuple( PyObject *where, PyObject *what ) {
+static PyObject *helper_appendToTuple( PyObject *where, PyObject *what ) {
   PyObject *o2, *o3;
 
   if ((!where) || (where == Py_None)) {

--- a/scipy/sparse/sparsetools/dia_wrap.cxx
+++ b/scipy/sparse/sparsetools/dia_wrap.cxx
@@ -2854,7 +2854,7 @@ namespace swig {
 
 /* Given a PyObject, return a string describing its type.
  */
-const char* pytype_string(PyObject* py_obj) {
+static const char* pytype_string(PyObject* py_obj) {
   if (py_obj == NULL          ) return "C NULL value";
   if (py_obj == Py_None       ) return "Python None" ;
   if (PyCallable_Check(py_obj)) return "callable"    ;
@@ -2873,7 +2873,7 @@ const char* pytype_string(PyObject* py_obj) {
 
 /* Given a NumPy typecode, return a string describing the type.
  */
-const char* typecode_string(int typecode) {
+static const char* typecode_string(int typecode) {
   static const char* type_names[25] = {"bool", "byte", "unsigned byte",
 				 "short", "unsigned short", "int",
 				 "unsigned int", "long", "unsigned long",
@@ -2890,7 +2890,7 @@ const char* typecode_string(int typecode) {
  * to match.  Also allow int and long to match.  This is deprecated.
  * You should use PyArray_EquivTypenums() instead.
  */
-int type_match(int actual_type, int desired_type) {
+static int type_match(int actual_type, int desired_type) {
   return PyArray_EquivTypenums(actual_type, desired_type);
 }
 
@@ -2898,7 +2898,7 @@ int type_match(int actual_type, int desired_type) {
  * legal.  If not, set the python error string appropriately and
  * return NULL.
  */
-PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
+static PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
   PyArrayObject* ary = NULL;
   if (is_array(input) && (typecode == NPY_NOTYPE ||
 			  PyArray_EquivTypenums(array_type(input), typecode))) {
@@ -2928,7 +2928,7 @@ PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
  * correct type.  On failure, the python error string will be set and
  * the routine returns NULL.
  */
-PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
+static PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
                                              int* is_new_object) {
   PyArrayObject* ary = NULL;
   PyObject* py_obj;
@@ -2951,7 +2951,7 @@ PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
  * not contiguous, create a new PyArrayObject using the original data,
  * flag it as a new object and return the pointer.
  */
-PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
+static PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
                                int min_dims, int max_dims) {
   PyArrayObject* result;
   if (array_is_contiguous(ary)) {
@@ -2973,7 +2973,7 @@ PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
  * PyArrayObject, a new one will be created and the new object flag
  * will be set.
  */
-PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
+static PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
                                                         int typecode,
                                                         int* is_new_object) {
   int is_new1 = 0;
@@ -2995,7 +2995,7 @@ PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
  * contiguous, return 1.  Otherwise, set the python error string and
  * return 0.
  */
-int require_contiguous(PyArrayObject* ary) {
+static int require_contiguous(PyArrayObject* ary) {
   int contiguous = 1;
   if (!array_is_contiguous(ary)) {
     PyErr_SetString(PyExc_TypeError,
@@ -3009,7 +3009,7 @@ int require_contiguous(PyArrayObject* ary) {
  * not byte-swapped, return 1.  Otherwise, set the python error string
  * and return 0.
  */
-int require_native(PyArrayObject* ary) {
+static int require_native(PyArrayObject* ary) {
   int native = 1;
   if (!array_is_native(ary)) {
     PyErr_SetString(PyExc_TypeError,
@@ -3023,7 +3023,7 @@ int require_native(PyArrayObject* ary) {
  * dimensions.  If the array has the specified number of dimensions,
  * return 1.  Otherwise, set the python error string and return 0.
  */
-int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
+static int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
   int success = 1;
   if (array_numdims(ary) != exact_dimensions) {
     PyErr_Format(PyExc_TypeError, 
@@ -3039,7 +3039,7 @@ int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
  * of dimensions, return 1.  Otherwise, set the python error string
  * and return 0.
  */
-int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
+static int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
   int success = 0;
   int i;
   char dims_str[255] = "";
@@ -3067,7 +3067,7 @@ int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
  * array has the specified shape, return 1.  Otherwise, set the python
  * error string and return 0.
  */
-int require_size(PyArrayObject* ary, npy_intp* size, int n) {
+static int require_size(PyArrayObject* ary, npy_intp* size, int n) {
   int i;
   int success = 1;
   int len;
@@ -3117,7 +3117,7 @@ int require_size(PyArrayObject* ary, npy_intp* size, int n) {
   @par Revision history:
   - 17.02.2005, c
 */
-PyObject *helper_appendToTuple( PyObject *where, PyObject *what ) {
+static PyObject *helper_appendToTuple( PyObject *where, PyObject *what ) {
   PyObject *o2, *o3;
 
   if ((!where) || (where == Py_None)) {

--- a/scipy/sparse/sparsetools/numpy.i
+++ b/scipy/sparse/sparsetools/numpy.i
@@ -28,7 +28,7 @@
 
 /* Given a PyObject, return a string describing its type.
  */
-const char* pytype_string(PyObject* py_obj) {
+static const char* pytype_string(PyObject* py_obj) {
   if (py_obj == NULL          ) return "C NULL value";
   if (py_obj == Py_None       ) return "Python None" ;
   if (PyCallable_Check(py_obj)) return "callable"    ;
@@ -47,7 +47,7 @@ const char* pytype_string(PyObject* py_obj) {
 
 /* Given a NumPy typecode, return a string describing the type.
  */
-const char* typecode_string(int typecode) {
+static const char* typecode_string(int typecode) {
   static const char* type_names[25] = {"bool", "byte", "unsigned byte",
 				 "short", "unsigned short", "int",
 				 "unsigned int", "long", "unsigned long",
@@ -64,7 +64,7 @@ const char* typecode_string(int typecode) {
  * to match.  Also allow int and long to match.  This is deprecated.
  * You should use PyArray_EquivTypenums() instead.
  */
-int type_match(int actual_type, int desired_type) {
+static int type_match(int actual_type, int desired_type) {
   return PyArray_EquivTypenums(actual_type, desired_type);
 }
 
@@ -72,7 +72,7 @@ int type_match(int actual_type, int desired_type) {
  * legal.  If not, set the python error string appropriately and
  * return NULL.
  */
-PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
+static PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
   PyArrayObject* ary = NULL;
   if (is_array(input) && (typecode == NPY_NOTYPE ||
 			  PyArray_EquivTypenums(array_type(input), typecode))) {
@@ -102,7 +102,7 @@ PyArrayObject* obj_to_array_no_conversion(PyObject* input, int typecode) {
  * correct type.  On failure, the python error string will be set and
  * the routine returns NULL.
  */
-PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
+static PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
                                              int* is_new_object) {
   PyArrayObject* ary = NULL;
   PyObject* py_obj;
@@ -125,7 +125,7 @@ PyArrayObject* obj_to_array_allow_conversion(PyObject* input, int typecode,
  * not contiguous, create a new PyArrayObject using the original data,
  * flag it as a new object and return the pointer.
  */
-PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
+static PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
                                int min_dims, int max_dims) {
   PyArrayObject* result;
   if (array_is_contiguous(ary)) {
@@ -147,7 +147,7 @@ PyArrayObject* make_contiguous(PyArrayObject* ary, int* is_new_object,
  * PyArrayObject, a new one will be created and the new object flag
  * will be set.
  */
-PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
+static PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
                                                         int typecode,
                                                         int* is_new_object) {
   int is_new1 = 0;
@@ -169,7 +169,7 @@ PyArrayObject* obj_to_array_contiguous_allow_conversion(PyObject* input,
  * contiguous, return 1.  Otherwise, set the python error string and
  * return 0.
  */
-int require_contiguous(PyArrayObject* ary) {
+static int require_contiguous(PyArrayObject* ary) {
   int contiguous = 1;
   if (!array_is_contiguous(ary)) {
     PyErr_SetString(PyExc_TypeError,
@@ -183,7 +183,7 @@ int require_contiguous(PyArrayObject* ary) {
  * not byte-swapped, return 1.  Otherwise, set the python error string
  * and return 0.
  */
-int require_native(PyArrayObject* ary) {
+static int require_native(PyArrayObject* ary) {
   int native = 1;
   if (!array_is_native(ary)) {
     PyErr_SetString(PyExc_TypeError,
@@ -197,7 +197,7 @@ int require_native(PyArrayObject* ary) {
  * dimensions.  If the array has the specified number of dimensions,
  * return 1.  Otherwise, set the python error string and return 0.
  */
-int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
+static int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
   int success = 1;
   if (array_numdims(ary) != exact_dimensions) {
     PyErr_Format(PyExc_TypeError, 
@@ -213,7 +213,7 @@ int require_dimensions(PyArrayObject* ary, int exact_dimensions) {
  * of dimensions, return 1.  Otherwise, set the python error string
  * and return 0.
  */
-int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
+static int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
   int success = 0;
   int i;
   char dims_str[255] = "";
@@ -241,7 +241,7 @@ int require_dimensions_n(PyArrayObject* ary, int* exact_dimensions, int n) {
  * array has the specified shape, return 1.  Otherwise, set the python
  * error string and return 0.
  */
-int require_size(PyArrayObject* ary, npy_intp* size, int n) {
+static int require_size(PyArrayObject* ary, npy_intp* size, int n) {
   int i;
   int success = 1;
   int len;
@@ -291,7 +291,7 @@ int require_size(PyArrayObject* ary, npy_intp* size, int n) {
   @par Revision history:
   - 17.02.2005, c
 */
-PyObject *helper_appendToTuple( PyObject *where, PyObject *what ) {
+static PyObject *helper_appendToTuple( PyObject *where, PyObject *what ) {
   PyObject *o2, *o3;
 
   if ((!where) || (where == Py_None)) {


### PR DESCRIPTION
None of these symbols need to be exported.

Generated using the following `sed` rules, and manually inspected
for correctness:

```
s/^const char\* pytype_string/static &/
s/^const char\* typecode_string/static &/
s/^int type_match/static &/
s/^PyArrayObject\* obj_to_array_no_conversion/static &/
s/^PyArrayObject\* obj_to_array_allow_conversion/static &/
s/^PyArrayObject\* make_contiguous/static &/
s/^PyArrayObject\* obj_to_array_contiguous_allow_conversion/static &/
s/^int require_contiguous/static &/
s/^int require_native/static &/
s/^int require_dimensions/static &/
s/^int require_dimensions_n/static &/
s/^int require_size/static &/
s/^PyObject \*helper_appendToTuple/static &/
```
