### PR TITLE
BUG: included Accelerate.h instead of deprecated vecLib

### DIFF
--- a/scipy/lib/blas/fblaswrap_veclib_c.c.src
+++ b/scipy/lib/blas/fblaswrap_veclib_c.c.src
@@ -1,5 +1,5 @@
 #include <complex.h>
-#include <vecLib/vecLib.h>
+#include <Accelerate/Accelerate.h>
 
 //#define WRAP_F77(a) wcblas_##a##_
 #define WRAP_F77(a) w##a##_

--- a/scipy/linalg/src/fblaswrap_veclib_c.c
+++ b/scipy/linalg/src/fblaswrap_veclib_c.c
@@ -1,5 +1,5 @@
 #include <complex.h>
-#include <vecLib/vecLib.h>
+#include <Accelerate/Accelerate.h>
 
 //#define WRAP_F77(a) wcblas_##a##_
 #define WRAP_F77(a) w##a##_

--- a/scipy/sparse/linalg/eigen/arpack/ARPACK/FWRAPPERS/veclib_cabi_c.c
+++ b/scipy/sparse/linalg/eigen/arpack/ARPACK/FWRAPPERS/veclib_cabi_c.c
@@ -1,5 +1,5 @@
 #include <complex.h>
-#include <vecLib/vecLib.h>
+#include <Accelerate/Accelerate.h>
 
 #define WRAP_F77(a) a##_
 void WRAP_F77(veclib_cdotc)(const int *N, const complex float *X, const int *incX,

--- a/scipy/sparse/linalg/isolve/iterative/FWRAPPERS/veclib_cabi_c.c
+++ b/scipy/sparse/linalg/isolve/iterative/FWRAPPERS/veclib_cabi_c.c
@@ -1,5 +1,5 @@
 #include <complex.h>
-#include <vecLib/vecLib.h>
+#include <Accelerate/Accelerate.h>
 
 #define WRAP_F77(a) a##_
 void WRAP_F77(veclib_cdotc)(const int *N, const complex float *X, const int *incX,


### PR DESCRIPTION
`#include <vecLib/vecLib.h>` fails with Xcode 4.4/OS X 10.8

This change lets scipy build on Xcode 4.4/OS X 10.8, System Python 2.7.2

I don't know what the actual implications of this might be, so a more informed developer should probably check this out before it goes in.

should fix #1710: http://projects.scipy.org/scipy/ticket/1710
