### PR TITLE
BUG: use g77 ABI when linking against Accelerate/Veclib

### DIFF
--- a/scipy/lib/blas/setup.py
+++ b/scipy/lib/blas/setup.py
@@ -85,8 +85,8 @@ def configuration(parent_package='',top_path=None):
 
         # Veclib/Accelerate ABI is g77
         blas_opt = dict(blas_opt)
-        blas_opt.setdefault('extra_compile_f77_args', []).append('-ff2c')
-        blas_opt.setdefault('extra_compile_f90_args', []).append('-ff2c')
+        blas_opt.setdefault('extra_f77_compile_args', []).append('-ff2c')
+        blas_opt.setdefault('extra_f90_compile_args', []).append('-ff2c')
     else:
         sources = ['fblas.pyf.src','fblaswrap.f.src']
 

--- a/scipy/lib/blas/setup.py
+++ b/scipy/lib/blas/setup.py
@@ -82,8 +82,14 @@ def configuration(parent_package='',top_path=None):
     # fblas:
     if needs_cblas_wrapper(blas_opt):
         sources = ['fblas.pyf.src', 'fblaswrap_veclib_c.c.src'],
+
+        # Veclib/Accelerate ABI is g77
+        blas_opt = dict(blas_opt)
+        blas_opt.setdefault('extra_compile_f77_args', []).append('-ff2c')
+        blas_opt.setdefault('extra_compile_f90_args', []).append('-ff2c')
     else:
         sources = ['fblas.pyf.src','fblaswrap.f.src']
+
     config.add_extension('fblas',
                          sources = sources,
                          depends = depends,

--- a/scipy/lib/lapack/SConscript
+++ b/scipy/lib/lapack/SConscript
@@ -8,7 +8,7 @@ from numscons import GetNumpyEnvironment
 from numscons import CheckF77LAPACK,\
                                   CheckCLAPACK, \
                                   IsATLAS, GetATLASVersion, \
-                                  CheckF77Clib
+                                  CheckF77Clib, IsAccelerate, IsVeclib
 from numscons import write_info
 
 from scons_support import do_generate_fake_interface, \
@@ -41,6 +41,9 @@ if IsATLAS(env, 'lapack'):
     env.Append(CPPDEFINES = [('ATLAS_INFO', '"\\"%s"\\"' % version)])
 else:
     env.Append(CPPDEFINES = [('NO_ATLAS_INFO', 1)])
+
+if IsAccelerate(env, "lapack") or IsVeclib(env, "lapack"):
+    env.Append(F77FLAGS='-ff2c')
 
 if config.CheckCLAPACK():
     has_clapack = 1

--- a/scipy/lib/lapack/setup.py
+++ b/scipy/lib/lapack/setup.py
@@ -79,8 +79,8 @@ def configuration(parent_package='',top_path=None):
     if needs_cblas_wrapper(lapack_opt):
         # Veclib/Accelerate ABI is g77
         lapack_opt = dict(lapack_opt)
-        lapack_opt.setdefault('extra_compile_f77_args', []).append('-ff2c')
-        lapack_opt.setdefault('extra_compile_f90_args', []).append('-ff2c')
+        lapack_opt.setdefault('extra_f77_compile_args', []).append('-ff2c')
+        lapack_opt.setdefault('extra_f90_compile_args', []).append('-ff2c')
 
     # flapack:
     config.add_extension('flapack',

--- a/scipy/linalg/SConscript
+++ b/scipy/linalg/SConscript
@@ -101,6 +101,7 @@ fenv.FromFTemplate('fblas.pyf', 'fblas.pyf.src')
 source = ['fblas.pyf']
 if IsVeclib(fenv, 'blas') or IsAccelerate(fenv, 'blas'):
     source.append(pjoin('src', 'fblaswrap_veclib_c.c'))
+    fenv.Append(F77FLAGS='-ff2c')
 else:
     source.append(pjoin('src', 'fblaswrap.f'))
 fenv.NumpyPythonExtension('fblas', source)

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -115,8 +115,8 @@ def configuration(parent_package='',top_path=None):
 
         # Veclib/Accelerate ABI is g77
         lapack_opt = dict(lapack_opt)
-        lapack_opt.setdefault('extra_compile_f77_args', []).append('-ff2c')
-        lapack_opt.setdefault('extra_compile_f90_args', []).append('-ff2c')
+        lapack_opt.setdefault('extra_f77_compile_args', []).append('-ff2c')
+        lapack_opt.setdefault('extra_f90_compile_args', []).append('-ff2c')
     else:
         sources = ['fblas.pyf.src', join('src', 'fblaswrap.f')]
 

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -112,6 +112,11 @@ def configuration(parent_package='',top_path=None):
     # fblas:
     if needs_cblas_wrapper(lapack_opt):
         sources = ['fblas.pyf.src', join('src', 'fblaswrap_veclib_c.c')],
+
+        # Veclib/Accelerate ABI is g77
+        lapack_opt = dict(lapack_opt)
+        lapack_opt.setdefault('extra_compile_f77_args', []).append('-ff2c')
+        lapack_opt.setdefault('extra_compile_f90_args', []).append('-ff2c')
     else:
         sources = ['fblas.pyf.src', join('src', 'fblaswrap.f')]
 

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -43,8 +43,8 @@ def configuration(parent_package='',top_path=None):
     if needs_cblas_wrapper(lapack):
         # Veclib/Accelerate ABI is g77
         lapack = dict(lapack)
-        lapack.setdefault('extra_compile_f77_args', []).append('-ff2c')
-        lapack.setdefault('extra_compile_f90_args', []).append('-ff2c')
+        lapack.setdefault('extra_f77_compile_args', []).append('-ff2c')
+        lapack.setdefault('extra_f90_compile_args', []).append('-ff2c')
 
     sources=['lbfgsb.pyf', 'lbfgsb.f', 'linpack.f', 'timer.f']
     config.add_extension('_lbfgsb',

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -2,6 +2,23 @@
 
 from os.path import join
 
+def needs_cblas_wrapper(info):
+    """Returns true if needs c wrapper around cblas for calling from
+    fortran."""
+    import re
+    r_accel = re.compile("Accelerate")
+    r_vec = re.compile("vecLib")
+    res = False
+    try:
+        tmpstr = info['extra_link_args']
+        for i in tmpstr:
+            if r_accel.search(i) or r_vec.search(i):
+                res = True
+    except KeyError:
+        pass
+
+    return res
+
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     from numpy.distutils.system_info import get_info
@@ -22,6 +39,13 @@ def configuration(parent_package='',top_path=None):
                          libraries=['rootfind'])
 
     lapack = get_info('lapack_opt')
+
+    if needs_cblas_wrapper(lapack):
+        # Veclib/Accelerate ABI is g77
+        lapack = dict(lapack)
+        lapack.setdefault('extra_compile_f77_args', []).append('-ff2c')
+        lapack.setdefault('extra_compile_f90_args', []).append('-ff2c')
+
     sources=['lbfgsb.pyf', 'lbfgsb.f', 'linpack.f', 'timer.f']
     config.add_extension('_lbfgsb',
                          sources=[join('lbfgsb',x) for x in sources],

--- a/scipy/sparse/linalg/eigen/arpack/SConscript
+++ b/scipy/sparse/linalg/eigen/arpack/SConscript
@@ -47,6 +47,7 @@ arpack_src += [pjoin('ARPACK', 'UTIL', s) for s in [ "cmout.f", "cvout.f",
 if use_c_calling:
     arpack_src += [pjoin('ARPACK', 'FWRAPPERS', 'veclib_cabi_f.f'),
                    pjoin('ARPACK', 'FWRAPPERS', 'veclib_cabi_c.c')]
+    env.Append(F77FLAGS='-ff2c')
 else:
     arpack_src += [pjoin('ARPACK', 'FWRAPPERS', 'dummy.f')]
 arpack_src += [pjoin('ARPACK', 'LAPACK', s) for s in [ "clahqr.f", "dlahqr.f",

--- a/scipy/sparse/linalg/eigen/arpack/setup.py
+++ b/scipy/sparse/linalg/eigen/arpack/setup.py
@@ -38,6 +38,11 @@ def configuration(parent_package='',top_path=None):
     if needs_veclib_wrapper(lapack_opt):
         arpack_sources += [join('ARPACK', 'FWRAPPERS', 'veclib_cabi_f.f'),
                            join('ARPACK', 'FWRAPPERS', 'veclib_cabi_c.c')]
+
+        # Veclib/Accelerate ABI is g77
+        lapack_opt = dict(lapack_opt)
+        lapack_opt.setdefault('extra_compile_f77_args', []).append('-ff2c')
+        lapack_opt.setdefault('extra_compile_f90_args', []).append('-ff2c')
     else:
         arpack_sources += [join('ARPACK', 'FWRAPPERS', 'dummy.f')]
 

--- a/scipy/sparse/linalg/eigen/arpack/setup.py
+++ b/scipy/sparse/linalg/eigen/arpack/setup.py
@@ -41,8 +41,8 @@ def configuration(parent_package='',top_path=None):
 
         # Veclib/Accelerate ABI is g77
         lapack_opt = dict(lapack_opt)
-        lapack_opt.setdefault('extra_compile_f77_args', []).append('-ff2c')
-        lapack_opt.setdefault('extra_compile_f90_args', []).append('-ff2c')
+        lapack_opt.setdefault('extra_f77_compile_args', []).append('-ff2c')
+        lapack_opt.setdefault('extra_f90_compile_args', []).append('-ff2c')
     else:
         arpack_sources += [join('ARPACK', 'FWRAPPERS', 'dummy.f')]
 

--- a/scipy/sparse/linalg/isolve/SConscript
+++ b/scipy/sparse/linalg/isolve/SConscript
@@ -60,6 +60,7 @@ use_c_calling = IsAccelerate(env, "lapack") or IsVeclib(env, "lapack")
 
 if use_c_calling: 
     blas_wrapper = ['veclib_cabi_c.c', 'veclib_cabi_f.f'] 
+    env.Append(F77FLAGS='-ff2c')
 else: 
     blas_wrapper = ['dummy.f'] 
 

--- a/scipy/sparse/linalg/isolve/setup.py
+++ b/scipy/sparse/linalg/isolve/setup.py
@@ -55,8 +55,8 @@ def configuration(parent_package='',top_path=None):
 
         # Veclib/Accelerate ABI is g77
         lapack_opt = dict(lapack_opt)
-        lapack_opt.setdefault('extra_compile_f77_args', []).append('-ff2c')
-        lapack_opt.setdefault('extra_compile_f90_args', []).append('-ff2c')
+        lapack_opt.setdefault('extra_f77_compile_args', []).append('-ff2c')
+        lapack_opt.setdefault('extra_f90_compile_args', []).append('-ff2c')
     else:
         methods += [join('FWRAPPERS', 'dummy.f')]
 

--- a/scipy/sparse/linalg/isolve/setup.py
+++ b/scipy/sparse/linalg/isolve/setup.py
@@ -52,6 +52,11 @@ def configuration(parent_package='',top_path=None):
     if needs_veclib_wrapper(lapack_opt):
         methods += [join('FWRAPPERS', 'veclib_cabi_f.f'),
                     join('FWRAPPERS', 'veclib_cabi_c.c')]
+
+        # Veclib/Accelerate ABI is g77
+        lapack_opt = dict(lapack_opt)
+        lapack_opt.setdefault('extra_compile_f77_args', []).append('-ff2c')
+        lapack_opt.setdefault('extra_compile_f90_args', []).append('-ff2c')
     else:
         methods += [join('FWRAPPERS', 'dummy.f')]
 


### PR DESCRIPTION
As per the discussion on: http://projects.scipy.org/scipy/ticket/1618

The Fortran ABI in Veclib/Accelerate is that of g77, not that of gfortran, so let's tell the compiler to force it. (Using a wrong ABI causes bogus return values from FUNCTIONs.) A robust fix would be to avoid relying on the exact ABI at all, but the compiler flag should be good enough in practice. Veclib was rumored to have also some bugs with incorrect ABI for some functions, but even if that is true, it's better that most functions work than that none of them works.

I didn't actually test this, someone with OSX at hand is needed. This may also resolve ARPACK and QZ callback issues.
