### PR TITLE
BLD: fixes build on MacOSX Lion with XCode 4.4 + CLT installed

### DIFF
--- a/scipy/sparse/linalg/dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/dsolve/_superlumodule.c
@@ -265,7 +265,7 @@ PyObject *PyInit__superlu(void)
     import_array();
 
     if (PyType_Ready(&SciPySuperLUType) < 0) {
-        return;
+        return NULL;
     }
 
     m = PyModule_Create(&moduledef);


### PR DESCRIPTION
Specific compiler is i686-apple-darwin11-llvm-gcc-4.2
