### PR TITLE
Sparse solve(), expm(), and inv()

### DIFF
--- a/doc/release/0.12.0-notes.rst
+++ b/doc/release/0.12.0-notes.rst
@@ -21,6 +21,14 @@ This release requires Python 2.4-2.7 or 3.1- and NumPy 1.X.X or greater.
 New features
 ============
 
+``scipy.sparse.linalg`` features
+--------------------------------
+- In ``scipy.sparse.linalg.spsolve``, the ``b`` argument can now be either
+  a vector or a matrix.
+- ``scipy.sparse.linalg.expm`` was added.  This computes the exponential of
+  a sparse matrix using a similar algorithm to the existing dense array
+  implementation in ``scipy.linalg.expm``.
+
 
 Deprecated features
 ===================

--- a/doc/release/0.12.0-notes.rst
+++ b/doc/release/0.12.0-notes.rst
@@ -25,6 +25,8 @@ New features
 --------------------------------
 - In ``scipy.sparse.linalg.spsolve``, the ``b`` argument can now be either
   a vector or a matrix.
+- ``scipy.sparse.linalg.inv`` was added.  This uses ``spsolve`` to compute
+  a sparse matrix inverse.
 - ``scipy.sparse.linalg.expm`` was added.  This computes the exponential of
   a sparse matrix using a similar algorithm to the existing dense array
   implementation in ``scipy.linalg.expm``.
@@ -47,4 +49,5 @@ Other changes
 
 Authors
 =======
-
+- Anthony Scopatz (sparse linear algebra)
+- Jake Vanderplas (sparse linear algebra)

--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -874,6 +874,7 @@ is called a rug plot):
 .. plot::
 
     >>> from scipy import stats
+    >>> import matplotlib.pyplot as plt
 
     >>> x1 = np.array([-7, -5, 1, 4, 5], dtype=np.float)
     >>> kde1 = stats.gaussian_kde(x1)

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -945,12 +945,10 @@ def _find_derivatives(x, y):
 def pchip(x, y):
     """PCHIP 1-d monotonic cubic interpolation
 
-    Description
-    -----------
-    x and y are arrays of values used to approximate some function f:
-       y = f(x)
-    This class factory function returns a callable class whose __call__ method
-    uses monotonic cubic, interpolation to find the value of new points.
+    x and y are arrays of values used to approximate some function f, with
+    ``y = f(x)``.  This class factory function returns a callable class whose
+    ``__call__`` method uses monotonic cubic, interpolation to find the value
+    of new points.
 
     Parameters
     ----------
@@ -961,7 +959,13 @@ def pchip(x, y):
         A 1-D array of real values.  y's length along the interpolation
         axis must be equal to the length of x.
 
-    Assumes x is sorted in monotonic order (e.g. x[1] > x[0])
+    Assumes x is sorted in monotonic order (e.g. ``x[1] > x[0]``).
+
+    Returns
+    -------
+    pchip : PiecewisePolynomial instance
+        The result of the interpolation.
+
     """
     derivs = _find_derivatives(x,y)
     return PiecewisePolynomial(x, zip(y, derivs), orders=3, direction=None)

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -114,18 +114,6 @@ def _pade5(A):
     V = b[4]*A4 + b[2]*A2 + b[0]*ident
     return U,V
 
-def _pade5(A):
-    b = (30240., 15120., 3360., 420., 30., 1.)
-    if isspmatrix(A):
-        ident = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
-    else:
-        ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
-    U = A.dot(b[5]*A4 + b[3]*A2 + b[1]*ident)
-    V = b[4]*A4 + b[2]*A2 + b[0]*ident
-    return U,V
-
 def _pade7(A):
     b = (17297280., 8648640., 1995840., 277200., 25200., 1512., 56., 1.)
     if isspmatrix(A):

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -12,6 +12,9 @@ from numpy import asarray, Inf, dot, floor, eye, diag, exp, \
 from numpy import matrix as mat
 import numpy as np
 
+from scipy.sparse.base import isspmatrix
+from scipy.sparse.construct import eye as speye
+
 # Local imports
 from misc import norm
 from basic import solve, inv
@@ -87,43 +90,67 @@ def expm(A, q=False):
     return R
 
 # implementation of Pade approximations of various degree using the algorithm presented in [Higham 2005]
-
+# These should apply to both dense and sparse matricies.
 def _pade3(A):
     b = (120., 60., 12., 1.)
-    ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
-    A2 = dot(A,A)
-    U = dot(A , (b[3]*A2 + b[1]*ident))
+    if isspmatrix(A):
+        ident = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
+    else:
+        ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
+    A2 = A.dot(A)
+    U = A.dot(b[3]*A2 + b[1]*ident)
     V = b[2]*A2 + b[0]*ident
     return U,V
 
 def _pade5(A):
     b = (30240., 15120., 3360., 420., 30., 1.)
-    ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
-    A2 = dot(A,A)
-    A4 = dot(A2,A2)
-    U = dot(A, b[5]*A4 + b[3]*A2 + b[1]*ident)
+    if isspmatrix(A):
+        ident = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
+    else:
+        ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
+    A2 = A.dot(A)
+    A4 = A2.dot(A2)
+    U = A.dot(b[5]*A4 + b[3]*A2 + b[1]*ident)
+    V = b[4]*A4 + b[2]*A2 + b[0]*ident
+    return U,V
+
+def _pade5(A):
+    b = (30240., 15120., 3360., 420., 30., 1.)
+    if isspmatrix(A):
+        ident = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
+    else:
+        ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
+    A2 = A.dot(A)
+    A4 = A2.dot(A2)
+    U = A.dot(b[5]*A4 + b[3]*A2 + b[1]*ident)
     V = b[4]*A4 + b[2]*A2 + b[0]*ident
     return U,V
 
 def _pade7(A):
     b = (17297280., 8648640., 1995840., 277200., 25200., 1512., 56., 1.)
-    ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
-    A2 = dot(A,A)
-    A4 = dot(A2,A2)
-    A6 = dot(A4,A2)
-    U = dot(A, b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
+    if isspmatrix(A):
+        ident = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
+    else:
+        ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
+    A2 = A.dot(A)
+    A4 = A2.dot(A2)
+    A6 = A4.dot(A2)
+    U = A.dot(b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
     V = b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
     return U,V
 
 def _pade9(A):
     b = (17643225600., 8821612800., 2075673600., 302702400., 30270240.,
                 2162160., 110880., 3960., 90., 1.)
-    ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
-    A2 = dot(A,A)
-    A4 = dot(A2,A2)
-    A6 = dot(A4,A2)
-    A8 = dot(A6,A2)
-    U = dot(A, b[9]*A8 + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
+    if isspmatrix(A):
+        ident = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
+    else:
+        ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
+    A2 = A.dot(A)
+    A4 = A2.dot(A2)
+    A6 = A4.dot(A2)
+    A8 = A6.dot(A2)
+    U = A.dot(b[9]*A8 + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
     V = b[8]*A8 + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
     return U,V
 
@@ -131,12 +158,15 @@ def _pade13(A):
     b = (64764752532480000., 32382376266240000., 7771770303897600.,
     1187353796428800., 129060195264000., 10559470521600., 670442572800.,
     33522128640., 1323241920., 40840800., 960960., 16380., 182., 1.)
-    ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
-    A2 = dot(A,A)
-    A4 = dot(A2,A2)
-    A6 = dot(A4,A2)
-    U = dot(A,dot(A6, b[13]*A6 + b[11]*A4 + b[9]*A2) + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
-    V = dot(A6, b[12]*A6 + b[10]*A4 + b[8]*A2) + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
+    if isspmatrix(A):
+        ident = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
+    else:
+        ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
+    A2 = A.dot(A)
+    A4 = A2.dot(A2)
+    A6 = A4.dot(A2)
+    U = A.dot(A6.dot(b[13]*A6 + b[11]*A4 + b[9]*A2) + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
+    V = A6.dot(b[12]*A6 + b[10]*A4 + b[8]*A2) + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
     return U,V
 
 def expm2(A):

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -78,6 +78,7 @@ def expm(A, q=False):
 
     P = U + V  # p_m(A) : numerator
     Q = -U + V # q_m(A) : denominator
+
     R = solve(Q,P)
     # squaring step to undo scaling
     for i in range(n_squarings):

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -12,9 +12,6 @@ from numpy import asarray, Inf, dot, floor, eye, diag, exp, \
 from numpy import matrix as mat
 import numpy as np
 
-from scipy.sparse.base import isspmatrix
-from scipy.sparse.construct import eye as speye
-
 # Local imports
 from misc import norm
 from basic import solve, inv
@@ -27,7 +24,7 @@ import warnings
 eps = np.finfo(float).eps
 feps = np.finfo(single).eps
 
-def expm(A, q=False):
+def expm(A, q=None):
     """Compute the matrix exponential using Pade approximation.
 
     Parameters
@@ -47,126 +44,10 @@ def expm(A, q=False):
     SIAM. J. Matrix Anal. & Appl. 26, 1179 (2005).
 
     """
-    if q: warnings.warn("argument q=... in scipy.linalg.expm is deprecated.")
-    Aissparse = isspmatrix(A)
-
-    if Aissparse:
-        A_L1 = max(abs(A).sum(axis=0).flat)
-    else:
-        A = asarray(A)
-        A_L1 = norm(A,1)
-
-    n_squarings = 0
-
-    if A.dtype == 'float64' or A.dtype == 'complex128':
-        if A_L1 < 1.495585217958292e-002:
-            U,V = _pade3(A)
-        elif A_L1 < 2.539398330063230e-001:
-            U,V = _pade5(A)
-        elif A_L1 < 9.504178996162932e-001:
-            U,V = _pade7(A)
-        elif A_L1 < 2.097847961257068e+000:
-            U,V = _pade9(A)
-        else:
-            maxnorm = 5.371920351148152
-            n_squarings = max(0, int(ceil(log2(A_L1 / maxnorm))))
-            A = A / 2**n_squarings
-            U,V = _pade13(A)
-    elif A.dtype == 'float32' or A.dtype == 'complex64':
-        if A_L1 < 4.258730016922831e-001:
-            U,V = _pade3(A)
-        elif A_L1 < 1.880152677804762e+000:
-            U,V = _pade5(A)
-        else:
-            maxnorm = 3.925724783138660
-            n_squarings = max(0, int(ceil(log2(A_L1 / maxnorm))))
-            A = A / 2**n_squarings
-            U,V = _pade7(A)
-    else:
-        raise ValueError("invalid type: "+str(A.dtype))
-
-    P = U + V  # p_m(A) : numerator
-    Q = -U + V # q_m(A) : denominator
-
-    if Aissparse:
-        from scipy.sparse.linalg import spsolve
-        R = spsolve(Q, P)
-    else:
-        R = solve(Q,P)
-
-    # squaring step to undo scaling
-    for i in range(n_squarings):
-        R = R.dot(R)
-
-    return R
-
-# implementation of Pade approximations of various degree using the algorithm presented in [Higham 2005]
-# These should apply to both dense and sparse matricies.
-def _pade3(A):
-    b = (120., 60., 12., 1.)
-    if isspmatrix(A):
-        ident = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
-    else:
-        ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
-    A2 = A.dot(A)
-    U = A.dot(b[3]*A2 + b[1]*ident)
-    V = b[2]*A2 + b[0]*ident
-    return U,V
-
-def _pade5(A):
-    b = (30240., 15120., 3360., 420., 30., 1.)
-    if isspmatrix(A):
-        ident = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
-    else:
-        ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
-    U = A.dot(b[5]*A4 + b[3]*A2 + b[1]*ident)
-    V = b[4]*A4 + b[2]*A2 + b[0]*ident
-    return U,V
-
-def _pade7(A):
-    b = (17297280., 8648640., 1995840., 277200., 25200., 1512., 56., 1.)
-    if isspmatrix(A):
-        ident = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
-    else:
-        ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
-    A6 = A4.dot(A2)
-    U = A.dot(b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
-    V = b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
-    return U,V
-
-def _pade9(A):
-    b = (17643225600., 8821612800., 2075673600., 302702400., 30270240.,
-                2162160., 110880., 3960., 90., 1.)
-    if isspmatrix(A):
-        ident = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
-    else:
-        ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
-    A6 = A4.dot(A2)
-    A8 = A6.dot(A2)
-    U = A.dot(b[9]*A8 + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
-    V = b[8]*A8 + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
-    return U,V
-
-def _pade13(A):
-    b = (64764752532480000., 32382376266240000., 7771770303897600.,
-    1187353796428800., 129060195264000., 10559470521600., 670442572800.,
-    33522128640., 1323241920., 40840800., 960960., 16380., 182., 1.)
-    if isspmatrix(A):
-        ident = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
-    else:
-        ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
-    A6 = A4.dot(A2)
-    U = A.dot(A6.dot(b[13]*A6 + b[11]*A4 + b[9]*A2) + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
-    V = A6.dot(b[12]*A6 + b[10]*A4 + b[8]*A2) + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
-    return U,V
+    if q:
+        warnings.warn("argument q=... in scipy.linalg.expm is deprecated.")
+    import scipy.sparse.linalg
+    return scipy.sparse.linalg.expm(A)
 
 def expm2(A):
     """Compute the matrix exponential using eigenvalue decomposition.

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -1,11 +1,6 @@
 import numpy as np
-from numpy import eye
 from numpy.linalg import LinAlgError
 import fblas
-
-from scipy.sparse.base import isspmatrix
-from scipy.sparse.construct import eye as speye
-
 
 __all__ = ['LinAlgError', 'norm']
 

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -1,6 +1,11 @@
 import numpy as np
+from numpy import eye
 from numpy.linalg import LinAlgError
 import fblas
+
+from scipy.sparse.base import isspmatrix
+from scipy.sparse.construct import eye as speye
+
 
 __all__ = ['LinAlgError', 'norm']
 

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -104,24 +104,6 @@ class TestExpM(TestCase):
         assert_array_almost_equal(expm(a), expm2(a))
         assert_array_almost_equal(expm(a), expm3(a))
 
-    def test_padecases_dtype(self):
-        for dtype in [np.float32, np.float64, np.complex64, np.complex128]:
-            # test double-precision cases
-            for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
-                a = scale * identity(3, dtype=dtype)
-                e = exp(scale) * identity(3, dtype=dtype)
-                assert_array_almost_equal_nulp(expm(a), e, nulp=100)
-
-    def test_logm_consistency(self):
-        random.seed(1234)
-        for dtype in [np.float32, np.float64, np.complex64, np.complex128]:
-            for n in range(1, 10):
-                for scale in [1e-4, 1e-3, 1e-2, 1e-1, 1, 1e1, 1e2]:
-                    # make logm(a) be of a given scale
-                    a = (identity(n) + random.rand(n, n) * scale).astype(dtype)
-                    if np.iscomplexobj(a):
-                        a = a + 1j * random.rand(n, n) * scale
-                    assert_array_almost_equal(expm(logm(a)), a)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -342,8 +342,8 @@ class lti(object):
         Returns a 3-tuple containing arrays of frequencies [rad/s], magnitude
         [dB] and phase [deg]. See scipy.signal.bode for details.
 
-        Example
-        -------
+        Examples
+        --------
         >>> from scipy import signal
         >>> import matplotlib.pyplot as plt
 
@@ -728,10 +728,8 @@ def impulse2(system, X0=None, T=None, N=None, **kwargs):
 
     .. versionadded:: 0.8.0
 
-
     Examples
     --------
-
     Second order system with a repeated root: x''(t) + 2*x(t) + x(t) = u(t)
 
     >>> import scipy.signal
@@ -897,8 +895,8 @@ def bode(system, w=None, n=100):
     phase : 1D ndarray
         Phase array [deg]
 
-    Example
-    -------
+    Examples
+    --------
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
 

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -626,30 +626,6 @@ class spmatrix(object):
             return out
         else:
             return np.zeros(self.shape, dtype=self.dtype, order=order)
-
-    def expm(self):
-        """Compute the matrix exponential using Pade approximation.
-
-        Returns
-        -------
-        expA : array, shape(M,M)
-            Matrix exponential of A
-
-        See Also 
-        --------
-        scipy.sparse.linalg.expm
-        """
-        from scipy.sparse.linalg import expm as mfexpm
-        return mfexpm(self)
-
-    def inv(self):
-        """Computes the inverse of the sparse matrix.
-        """
-        from construct import eye
-        from linalg import spsolve
-        I = eye(self.shape[0], self.shape[1], dtype=self.dtype, format=self.format)
-        selfinv = spsolve(self, I)
-        return selfinv
         
 
 def isspmatrix(x):

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -639,6 +639,8 @@ class spmatrix(object):
         --------
         scipy.linalg.expm
         """
+        from scipy.linalg.matfuncs import _pade3, _pade5, _pade7, _pade9, _pade13
+
         A_L1 = max(abs(self).sum(axis=0).flat)
         n_squarings = 0
 
@@ -690,67 +692,6 @@ class spmatrix(object):
         selfinv = spsolve(self, I)
         return selfinv
         
-
-
-def _pade3(A):
-    from construct import eye
-    b = (120., 60., 12., 1.)
-    ident = eye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
-    A2 = A.dot(A)
-    U = A.dot(b[3]*A2 + b[1]*ident)
-    V = b[2]*A2 + b[0]*ident
-    return U,V
-
-def _pade5(A):
-    from construct import eye
-    b = (30240., 15120., 3360., 420., 30., 1.)
-    ident = eye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
-    U = A.dot(b[5]*A4 + b[3]*A2 + b[1]*ident)
-    V = b[4]*A4 + b[2]*A2 + b[0]*ident
-    return U,V
-
-def _pade7(A):
-    from construct import eye
-    b = (17297280., 8648640., 1995840., 277200., 25200., 1512., 56., 1.)
-    ident = eye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
-    A6 = A4.dot(A2)
-    U = A.dot(b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
-    V = b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
-    return U,V
-
-def _pade9(A):
-    from construct import eye
-    b = (17643225600., 8821612800., 2075673600., 302702400., 30270240.,
-                2162160., 110880., 3960., 90., 1.)
-    ident = eye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
-    A6 = A4.dot(A2)
-    A8 = A6.dot(A2)
-    U = A.dot(b[9]*A8 + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
-    V = b[8]*A8 + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
-    return U,V
-
-def _pade13(A):
-    from construct import eye
-    b = (64764752532480000., 32382376266240000., 7771770303897600.,
-    1187353796428800., 129060195264000., 10559470521600., 670442572800.,
-    33522128640., 1323241920., 40840800., 960960., 16380., 182., 1.)
-    ident = eye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
-    A6 = A4.dot(A2)
-    U = A.dot(A6.dot(b[13]*A6 + b[11]*A4 + b[9]*A2) + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
-    V = A6.dot(b[12]*A6 + b[10]*A4 + b[8]*A2) + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
-    return U,V
-
-
-
-
 
 def isspmatrix(x):
     return isinstance(x, spmatrix)

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -627,6 +627,122 @@ class spmatrix(object):
         else:
             return np.zeros(self.shape, dtype=self.dtype, order=order)
 
+    def expm(self):
+        """Compute the matrix exponential using Pade approximation.
+
+        Returns
+        -------
+        expA : array, shape(M,M)
+            Matrix exponential of A
+
+        See Also 
+        --------
+        scipy.linalg.expm
+        """
+        A_L1 = max(abs(self).sum(axis=0).flat)
+        n_squarings = 0
+
+        if self.dtype == 'float64' or self.dtype == 'complex128':
+            if A_L1 < 1.495585217958292e-002:
+                U,V = _pade3(self)
+            elif A_L1 < 2.539398330063230e-001:
+                U,V = _pade5(self)
+            elif A_L1 < 9.504178996162932e-001:
+                U,V = _pade7(self)
+            elif A_L1 < 2.097847961257068e+000:
+                U,V = _pade9(self)
+            else:
+                maxnorm = 5.371920351148152
+                n_squarings = max(0, int(np.ceil(np.log2(A_L1 / maxnorm))))
+                A = self / 2**n_squarings
+                U,V = _pade13(A)
+        elif self.dtype == 'float32' or self.dtype == 'complex64':
+            if A_L1 < 4.258730016922831e-001:
+                U,V = _pade3(self)
+            elif A_L1 < 1.880152677804762e+000:
+                U,V = _pade5(self)
+            else:
+                maxnorm = 3.925724783138660
+                n_squarings = max(0, int(np.ceil(np.log2(A_L1 / maxnorm))))
+                A = self / 2**n_squarings
+                U,V = _pade7(A)
+        else:
+            raise ValueError("invalid type: "+str(self.dtype))
+
+        from linalg import splu, factorized
+
+        P = U + V  # p_m(A) : numerator
+        Q = -U + V # q_m(A) : denominator
+        #R = spsolve(Q,P)
+        #R = factorized(Q,P)
+        R = factorized(Q)(np.array([0, 0, 1]))
+        print R
+        # squaring step to undo scaling
+        for i in range(n_squarings):
+            R = R.dot(R)
+
+        return R
+
+
+def _pade3(A):
+    from construct import eye
+    b = (120., 60., 12., 1.)
+    ident = eye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
+    A2 = A.dot(A)
+    U = A.dot(b[3]*A2 + b[1]*ident)
+    V = b[2]*A2 + b[0]*ident
+    return U,V
+
+def _pade5(A):
+    from construct import eye
+    b = (30240., 15120., 3360., 420., 30., 1.)
+    ident = eye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
+    A2 = A.dot(A)
+    A4 = A2.dot(A2)
+    U = A.dot(b[5]*A4 + b[3]*A2 + b[1]*ident)
+    V = b[4]*A4 + b[2]*A2 + b[0]*ident
+    return U,V
+
+def _pade7(A):
+    from construct import eye
+    b = (17297280., 8648640., 1995840., 277200., 25200., 1512., 56., 1.)
+    ident = eye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
+    A2 = A.dot(A)
+    A4 = A2.dot(A2)
+    A6 = A4.dot(A2)
+    U = A.dot(b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
+    V = b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
+    return U,V
+
+def _pade9(A):
+    from construct import eye
+    b = (17643225600., 8821612800., 2075673600., 302702400., 30270240.,
+                2162160., 110880., 3960., 90., 1.)
+    ident = eye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
+    A2 = A.dot(A)
+    A4 = A2.dot(A2)
+    A6 = A4.dot(A2)
+    A8 = A6.dot(A2)
+    U = A.dot(b[9]*A8 + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
+    V = b[8]*A8 + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
+    return U,V
+
+def _pade13(A):
+    from construct import eye
+    b = (64764752532480000., 32382376266240000., 7771770303897600.,
+    1187353796428800., 129060195264000., 10559470521600., 670442572800.,
+    33522128640., 1323241920., 40840800., 960960., 16380., 182., 1.)
+    ident = eye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
+    A2 = A.dot(A)
+    A4 = A2.dot(A2)
+    A6 = A4.dot(A2)
+    U = A.dot(A6.dot(b[13]*A6 + b[11]*A4 + b[9]*A2) + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
+    V = A6.dot(b[12]*A6 + b[10]*A4 + b[8]*A2) + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
+    return U,V
+
+
+
+
 
 def isspmatrix(x):
     return isinstance(x, spmatrix)

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -669,11 +669,11 @@ class spmatrix(object):
         else:
             raise ValueError("invalid type: "+str(self.dtype))
 
-        from linalg import solve
+        from linalg import spsolve
 
         P = U + V  # p_m(A) : numerator
         Q = -U + V # q_m(A) : denominator
-        R = solve(Q, P)
+        R = spsolve(Q, P)
 
         # squaring step to undo scaling
         for i in range(n_squarings):
@@ -685,9 +685,9 @@ class spmatrix(object):
         """Computes the inverse of the sparse matrix.
         """
         from construct import eye
-        from linalg import solve
+        from linalg import spsolve
         I = eye(self.shape[0], self.shape[1], dtype=self.dtype, format=self.format)
-        selfinv = solve(self, I)
+        selfinv = spsolve(self, I)
         return selfinv
         
 

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -639,49 +639,8 @@ class spmatrix(object):
         --------
         scipy.linalg.expm
         """
-        from scipy.linalg.matfuncs import _pade3, _pade5, _pade7, _pade9, _pade13
-
-        A_L1 = max(abs(self).sum(axis=0).flat)
-        n_squarings = 0
-
-        if self.dtype == 'float64' or self.dtype == 'complex128':
-            if A_L1 < 1.495585217958292e-002:
-                U,V = _pade3(self)
-            elif A_L1 < 2.539398330063230e-001:
-                U,V = _pade5(self)
-            elif A_L1 < 9.504178996162932e-001:
-                U,V = _pade7(self)
-            elif A_L1 < 2.097847961257068e+000:
-                U,V = _pade9(self)
-            else:
-                maxnorm = 5.371920351148152
-                n_squarings = max(0, int(np.ceil(np.log2(A_L1 / maxnorm))))
-                A = self / 2**n_squarings
-                U,V = _pade13(A)
-        elif self.dtype == 'float32' or self.dtype == 'complex64':
-            if A_L1 < 4.258730016922831e-001:
-                U,V = _pade3(self)
-            elif A_L1 < 1.880152677804762e+000:
-                U,V = _pade5(self)
-            else:
-                maxnorm = 3.925724783138660
-                n_squarings = max(0, int(np.ceil(np.log2(A_L1 / maxnorm))))
-                A = self / 2**n_squarings
-                U,V = _pade7(A)
-        else:
-            raise ValueError("invalid type: "+str(self.dtype))
-
-        from linalg import spsolve
-
-        P = U + V  # p_m(A) : numerator
-        Q = -U + V # q_m(A) : denominator
-        R = spsolve(Q, P)
-
-        # squaring step to undo scaling
-        for i in range(n_squarings):
-            R = R.dot(R)
-
-        return R
+        from scipy.linalg.matfuncs import expm as mfexpm
+        return mfexpm(self)
 
     def inv(self):
         """Computes the inverse of the sparse matrix.

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -637,9 +637,9 @@ class spmatrix(object):
 
         See Also 
         --------
-        scipy.linalg.expm
+        scipy.sparse.linalg.expm
         """
-        from scipy.linalg.matfuncs import expm as mfexpm
+        from scipy.sparse.linalg import expm as mfexpm
         return mfexpm(self)
 
     def inv(self):

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -669,27 +669,27 @@ class spmatrix(object):
         else:
             raise ValueError("invalid type: "+str(self.dtype))
 
-        from linalg import spsolve
-        from construct import eye
+        from linalg import solve
 
         P = U + V  # p_m(A) : numerator
         Q = -U + V # q_m(A) : denominator
-
-        shape0 = self.shape[0]
-        tempj = np.empty(shape0, dtype=int)
-        R = self.__class__(self.shape)
-        for j in range(shape0):
-            Rj = spsolve(Q, P[:,j])
-            w = np.where(Rj != 0.0)[0]
-            tempj.fill(j)
-            R = R + self.__class__((Rj[w],(w,tempj[:len(w)])), 
-                                    shape=self.shape, dtype=self.dtype)
+        R = solve(Q, P)
 
         # squaring step to undo scaling
         for i in range(n_squarings):
             R = R.dot(R)
 
         return R
+
+    def inv(self):
+        """Computes the inverse of the sparse matrix.
+        """
+        from construct import eye
+        from linalg import solve
+        I = eye(self.shape[0], self.shape[1], dtype=self.dtype, format=self.format)
+        selfinv = solve(self, I)
+        return selfinv
+        
 
 
 def _pade3(A):

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -669,14 +669,22 @@ class spmatrix(object):
         else:
             raise ValueError("invalid type: "+str(self.dtype))
 
-        from linalg import splu, factorized
+        from linalg import spsolve
+        from construct import eye
 
         P = U + V  # p_m(A) : numerator
         Q = -U + V # q_m(A) : denominator
-        #R = spsolve(Q,P)
-        #R = factorized(Q,P)
-        R = factorized(Q)(np.array([0, 0, 1]))
-        print R
+
+        shape0 = self.shape[0]
+        tempj = np.empty(shape0, dtype=int)
+        R = self.__class__(self.shape)
+        for j in range(shape0):
+            Rj = spsolve(Q, P[:,j])
+            w = np.where(Rj != 0.0)[0]
+            tempj.fill(j)
+            R = R + self.__class__((Rj[w],(w,tempj[:len(w)])), 
+                                    shape=self.shape, dtype=self.dtype)
+
         # squaring step to undo scaling
         for i in range(n_squarings):
             R = R.dot(R)

--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -92,7 +92,7 @@ from isolve import *
 from dsolve import *
 from interface import *
 from eigen import *
-
+from matfuncs import *
 
 __all__ = filter(lambda s:not s.startswith('_'),dir())
 from numpy.testing import Tester

--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -24,6 +24,7 @@ Direct methods for linear equation systems:
 
    spsolve -- Solve the sparse linear system Ax=b
    factorized -- Pre-factorize matrix to a function solving a linear system
+   solve -- Solve the sparse linear system Ax=B, where B may be a sparse matrix
 
 Iterative methods for linear equation systems:
 

--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -14,6 +14,15 @@ Abstract linear operators
    LinearOperator -- abstract representation of a linear operator
    aslinearoperator -- convert an object to an abstract linear operator
 
+Matrix Operations
+-----------------
+
+.. autosummary::
+   :toctree: generated/
+
+   inv -- compute the sparse matrix inverse
+   expm -- compute the sparse matrix exponential
+
 Solving linear problems
 -----------------------
 

--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -33,7 +33,6 @@ Direct methods for linear equation systems:
 
    spsolve -- Solve the sparse linear system Ax=b
    factorized -- Pre-factorize matrix to a function solving a linear system
-   solve -- Solve the sparse linear system Ax=B, where B may be a sparse matrix
 
 Iterative methods for linear equation systems:
 

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -53,9 +53,14 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
     b : ndarray or sparse matrix
         The matrix or vector representing the right hand side of the equation.
         If a vector, b.size must
-    permc_spec : (optional)
-        argument passed to ColPerm option in the superLU solver.  This is
-        only referenced if b is a vector and use_umfpack == False
+    permc_spec : str, optional
+        How to permute the columns of the matrix for sparsity preservation.
+        (default: 'COLAMD')
+
+        - ``NATURAL``: natural ordering.
+        - ``MMD_ATA``: minimum degree ordering on the structure of A^T A.
+        - ``MMD_AT_PLUS_A``: minimum degree ordering on the structure of A^T+A.
+        - ``COLAMD``: approximate minimum degree column ordering
     use_umfpack : bool (optional)
         if True (default) then use umfpack for the solution.  This is
         only referenced if b is a vector.

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -44,7 +44,37 @@ def use_solver( **kwargs ):
 
 
 def spsolve(A, b, permc_spec=None, use_umfpack=True):
-    """Solve the sparse linear system Ax=b, where b may be a vector or a matrix."""
+    """Solve the sparse linear system Ax=b, where b may be a vector or a matrix.
+
+    Parameters
+    ----------
+    A : ndarray or sparse matrix
+        The square matrix A will be converted into CSC or CSR form
+    b : ndarray or sparse matrix
+        The matrix or vector representing the right hand side of the equation.
+        If a vector, b.size must
+    permc_spec : (optional)
+        argument passed to ColPerm option in the superLU solver.  This is
+        only referenced if b is a vector and use_umfpack == False
+    use_umfpack : bool (optional)
+        if True (default) then use umfpack for the solution.  This is
+        only referenced if b is a vector.
+
+    Returns
+    -------
+    x : ndarray or sparse matrix
+        the solution of the sparse linear equation.
+        If b is a vector, then x is a vector of size A.shape[1]
+        If b is a matrix, then x is a matrix of size (A.shape[1], b.shape[1])
+
+    Notes
+    -----
+    For solving the matrix expression AX = B, this solver assumes the resulting
+    matrix X is sparse, as is often the case for very sparse inputs.  If the
+    resulting X is dense, the construction of this sparse result will be
+    relatively expensive.  In that case, consider converting A to a dense
+    matrix and using scipy.linalg.solve or its variants.
+    """
     if not (isspmatrix_csc(A) or isspmatrix_csr(A)):
         A = csc_matrix(A)
         warn('spsolve requires A be CSC or CSR matrix format', SparseEfficiencyWarning)

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -1,6 +1,6 @@
 from warnings import warn
 
-from numpy import asarray, empty, where, squeeze
+from numpy import asarray, empty, where, squeeze, prod
 from scipy.sparse import isspmatrix_csc, isspmatrix_csr, isspmatrix, \
         SparseEfficiencyWarning, csc_matrix
 
@@ -49,35 +49,38 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
         A = csc_matrix(A)
         warn('spsolve requires A be CSC or CSR matrix format', SparseEfficiencyWarning)
 
-    bisvector = (A.shape != b.shape)
+    # b.size gives a different answer for dense vs sparse:
+    # use prod(b.shape)
+    b_is_vector = (max(b.shape) == prod(b.shape))
 
-    if bisvector and isspmatrix( b ):
-        b = b.toarray()
+    if b_is_vector:
+        if isspmatrix(b):
+            b = b.toarray()
+        b = b.squeeze()
 
-        if b.ndim > 1:
-            if max( b.shape ) == b.size:
-                b = b.squeeze()
-            else:
-                msg = "rhs must be a vector (has shape %s) " % (b.shape,)
-                msg += "or matrix whose shape matches lhs (%s)" % (A.shape,)
-                raise ValueError(msg)
-    elif isspmatrix(b) and not (isspmatrix_csc(b) or isspmatrix_csr(b)):
-        b = csc_matrix(b)
-        warn('solve requires b be CSC or CSR matrix format', SparseEfficiencyWarning)
+    else:
+        if isspmatrix(b) and not (isspmatrix_csc(b) or isspmatrix_csr(b)):
+            b = csc_matrix(b)
+            warn('solve requires b be CSC or CSR matrix format',
+                 SparseEfficiencyWarning)
+        if b.ndim != 2:
+            raise ValueError("b must be either a vector or a matrix")
 
     A.sort_indices()
     A = A.asfptype()  # upcast to a floating point format
 
+    # validate input shapes
     M, N = A.shape
     if (M != N):
         raise ValueError("matrix must be square (has shape %s)" % ((M, N),))
-    if bisvector and M != b.size:
-        raise ValueError("matrix - rhs size mismatch (%s - %s)"
-              % (A.shape, b.size))
+
+    if M != b.shape[0]:
+        raise ValueError("matrix - rhs dimension mismatch (%s - %s)"
+                         % (A.shape, b.shape[0]))
 
     use_umfpack = use_umfpack and useUmfpack
 
-    if bisvector and isUmfpack and use_umfpack:
+    if b_is_vector and isUmfpack and use_umfpack:
         if noScikit:
             warn( 'scipy.sparse.linalg.dsolve.umfpack will be removed,'
                     ' install scikits.umfpack instead', DeprecationWarning )
@@ -88,11 +91,11 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
         b = asarray(b, dtype=A.dtype).reshape(-1)
 
         family = {'d' : 'di', 'D' : 'zi'}
-        umf = umfpack.UmfpackContext( family[A.dtype.char] )
-        return umf.linsolve( umfpack.UMFPACK_A, A, b,
-                             autoTranspose = True )
+        umf = umfpack.UmfpackContext(family[A.dtype.char])
+        x = umf.linsolve(umfpack.UMFPACK_A, A, b,
+                         autoTranspose = True )
 
-    elif bisvector:
+    elif b_is_vector:
         if isspmatrix_csc(A):
             flag = 1 # CSC format
         elif isspmatrix_csr(A):
@@ -103,20 +106,20 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
 
         b = asarray(b, dtype=A.dtype)
         options = dict(ColPerm=permc_spec)
-        return _superlu.gssv(N, A.nnz, A.data, A.indices, A.indptr, b, flag,
-                             options=options)[0]
+        x = _superlu.gssv(N, A.nnz, A.data, A.indices, A.indptr, b, flag,
+                          options=options)[0]
     else:
         # Cover the case where b is also a matrix
         Afactsolve = factorized(A)
         tempj = empty(M, dtype=int)
-        x = A.__class__(A.shape)
-        for j in range(M):
-            xj = Afactsolve(squeeze(b[:,j].toarray()))
+        x = A.__class__(b.shape)
+        for j in range(b.shape[1]):
+            xj = Afactsolve(squeeze(b[:, j].toarray()))
             w = where(xj != 0.0)[0]
             tempj.fill(j)
-            x = x + A.__class__((xj[w],(w,tempj[:len(w)])),
-                                shape=A.shape, dtype=A.dtype)
-        return x
+            x = x + A.__class__((xj[w], (w, tempj[:len(w)])),
+                                shape=b.shape, dtype=A.dtype)
+    return x
 
 
 def splu(A, permc_spec=None, diag_pivot_thresh=None,

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -1,6 +1,6 @@
 from warnings import warn
 
-from numpy import asarray, empty, where
+from numpy import asarray, empty, where, squeeze
 from scipy.sparse import isspmatrix_csc, isspmatrix_csr, isspmatrix, \
         SparseEfficiencyWarning, csc_matrix
 
@@ -18,7 +18,7 @@ isUmfpack = hasattr( umfpack, 'UMFPACK_OK' )
 useUmfpack = True
 
 
-__all__ = [ 'use_solver', 'spsolve', 'solve', 'splu', 'spilu', 'factorized' ]
+__all__ = [ 'use_solver', 'spsolve', 'splu', 'spilu', 'factorized' ]
 
 def use_solver( **kwargs ):
     """
@@ -44,33 +44,40 @@ def use_solver( **kwargs ):
 
 
 def spsolve(A, b, permc_spec=None, use_umfpack=True):
-    """Solve the sparse linear system Ax=b """
-    if isspmatrix( b ):
-        b = b.toarray()
-
-    if b.ndim > 1:
-        if max( b.shape ) == b.size:
-            b = b.squeeze()
-        else:
-            raise ValueError("rhs must be a vector (has shape %s)" % (b.shape,))
-
+    """Solve the sparse linear system Ax=b, where b may be a vector or a matrix."""
     if not (isspmatrix_csc(A) or isspmatrix_csr(A)):
         A = csc_matrix(A)
-        warn('spsolve requires CSC or CSR matrix format', SparseEfficiencyWarning)
+        warn('spsolve requires A be CSC or CSR matrix format', SparseEfficiencyWarning)
+
+    bisvector = (A.shape != b.shape)
+
+    if bisvector and isspmatrix( b ):
+        b = b.toarray()
+
+        if b.ndim > 1:
+            if max( b.shape ) == b.size:
+                b = b.squeeze()
+            else:
+                msg = "rhs must be a vector (has shape %s) " % (b.shape,)
+                msg += "or matrix whose shape matches lhs (%s)" % (A.shape,)
+                raise ValueError(msg)
+    elif isspmatrix(b) and not (isspmatrix_csc(b) or isspmatrix_csr(b)):
+        B = csc_matrix(b)
+        warn('solve requires b be CSC or CSR matrix format', SparseEfficiencyWarning)
 
     A.sort_indices()
-    A = A.asfptype()  #upcast to a floating point format
+    A = A.asfptype()  # upcast to a floating point format
 
     M, N = A.shape
     if (M != N):
         raise ValueError("matrix must be square (has shape %s)" % ((M, N),))
-    if M != b.size:
+    if bisvector and M != b.size:
         raise ValueError("matrix - rhs size mismatch (%s - %s)"
               % (A.shape, b.size))
 
     use_umfpack = use_umfpack and useUmfpack
 
-    if isUmfpack and use_umfpack:
+    if bisvector and isUmfpack and use_umfpack:
         if noScikit:
             warn( 'scipy.sparse.linalg.dsolve.umfpack will be removed,'
                     ' install scikits.umfpack instead', DeprecationWarning )
@@ -85,7 +92,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
         return umf.linsolve( umfpack.UMFPACK_A, A, b,
                              autoTranspose = True )
 
-    else:
+    elif bisvector:
         if isspmatrix_csc(A):
             flag = 1 # CSC format
         elif isspmatrix_csr(A):
@@ -98,30 +105,18 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
         options = dict(ColPerm=permc_spec)
         return _superlu.gssv(N, A.nnz, A.data, A.indices, A.indptr, b, flag,
                              options=options)[0]
-
-def solve(A, B, permc_spec=None, use_umfpack=True):
-    """Solve the sparse linear system Ax=B, where B may be a vector or a matrix."""
-    if not isspmatrix(B) or A.shape != B.shape:
-        return spsolve(A, B, permc_spec=permc_spec, use_umfpack=use_umfpack)
-
-    if not (isspmatrix_csc(A) or isspmatrix_csr(A)):
-        A = csc_matrix(A)
-        warn('solve requires CSC or CSR matrix format', SparseEfficiencyWarning)
-
-    if not (isspmatrix_csc(B) or isspmatrix_csr(B)):
-        B = csc_matrix(B)
-        warn('solve requires CSC or CSR matrix format', SparseEfficiencyWarning)
-
-    shape0 = A.shape[0]
-    tempj = empty(shape0, dtype=int)
-    X = A.__class__(A.shape)
-    for j in range(shape0):
-        Xj = spsolve(A, B[:,j])
-        w = where(Xj != 0.0)[0]
-        tempj.fill(j)
-        X = X + A.__class__((Xj[w],(w,tempj[:len(w)])),
-                            shape=A.shape, dtype=A.dtype)
-    return X
+    else:
+        # Cover the case where b is also a matrix
+        Afactsolve = factorized(A)
+        tempj = empty(M, dtype=int)
+        x = A.__class__(A.shape)
+        for j in range(M):
+            xj = Afactsolve(squeeze(b[:,j].toarray()))
+            w = where(xj != 0.0)[0]
+            tempj.fill(j)
+            x = x + A.__class__((xj[w],(w,tempj[:len(w)])),
+                                shape=A.shape, dtype=A.dtype)
+        return x
 
 
 def splu(A, permc_spec=None, diag_pivot_thresh=None,
@@ -268,10 +263,11 @@ def factorized( A ):
     """
     Return a fuction for solving a sparse linear system, with A pre-factorized.
 
-    Example:
-      solve = factorized( A ) # Makes LU decomposition.
-      x1 = solve( rhs1 ) # Uses the LU factors.
-      x2 = solve( rhs2 ) # Uses again the LU factors.
+    Examples
+    --------
+    solve = factorized( A ) # Makes LU decomposition.
+    x1 = solve( rhs1 ) # Uses the LU factors.
+    x2 = solve( rhs2 ) # Uses again the LU factors.
     """
     if isUmfpack and useUmfpack:
         if noScikit:

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -62,7 +62,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
                 msg += "or matrix whose shape matches lhs (%s)" % (A.shape,)
                 raise ValueError(msg)
     elif isspmatrix(b) and not (isspmatrix_csc(b) or isspmatrix_csr(b)):
-        B = csc_matrix(b)
+        b = csc_matrix(b)
         warn('solve requires b be CSC or CSR matrix format', SparseEfficiencyWarning)
 
     A.sort_indices()

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -104,6 +104,14 @@ def solve(A, B, permc_spec=None, use_umfpack=True):
     if not isspmatrix(B) or A.shape != B.shape:
         return spsolve(A, B, permc_spec=permc_spec, use_umfpack=use_umfpack)
 
+    if not (isspmatrix_csc(A) or isspmatrix_csr(A)):
+        A = csc_matrix(A)
+        warn('solve requires CSC or CSR matrix format', SparseEfficiencyWarning)
+
+    if not (isspmatrix_csc(B) or isspmatrix_csr(B)):
+        B = csc_matrix(B)
+        warn('solve requires CSC or CSR matrix format', SparseEfficiencyWarning)
+
     shape0 = A.shape[0]
     tempj = empty(shape0, dtype=int)
     X = A.__class__(A.shape)

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -58,7 +58,7 @@ class TestLinsolve(TestCase):
                          [ 0.,  0.,  1.]])
         As =  csc_matrix(Adense)
         random.seed(1234)
-        x = random.randn(3, 3)
+        x = random.randn(3, 4)
         Bdense = As.dot(x)
         Bs = csc_matrix(Bdense)
         x2 = spsolve(As, Bs)

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -8,7 +8,7 @@ from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal,
 import scipy.linalg 
 from scipy.linalg import norm, inv
 from scipy.sparse import spdiags, SparseEfficiencyWarning, csc_matrix, csr_matrix
-from scipy.sparse.linalg.dsolve import spsolve, solve, use_solver, splu, spilu
+from scipy.sparse.linalg.dsolve import spsolve, use_solver, splu, spilu
 
 warnings.simplefilter('ignore',SparseEfficiencyWarning)
 
@@ -40,7 +40,7 @@ class TestLinsolve(TestCase):
 
                 assert_( norm(b - Asp*x) < 10 * cond_A * eps )
 
-    def test_smoketest(self):
+    def test_bvector_smoketest(self):
         Adense = matrix([[ 0.,  1.,  1.],
                          [ 1.,  0.,  1.],
                          [ 0.,  0.,  1.]])
@@ -52,6 +52,18 @@ class TestLinsolve(TestCase):
 
         assert_array_almost_equal(x, x2)
 
+    def test_bmatrix_smoketest(self):
+        Adense = matrix([[ 0.,  1.,  1.],
+                         [ 1.,  0.,  1.],
+                         [ 0.,  0.,  1.]])
+        As =  csc_matrix(Adense)
+        random.seed(1234)
+        x = random.randn(3, 3)
+        Bdense = As.dot(x)
+        Bs = csc_matrix(Bdense)
+        x2 = spsolve(As, Bs)
+        assert_array_almost_equal(x, x2.todense())
+
     def test_non_square(self):
         # A is not square.
         A = ones((3, 4))
@@ -61,20 +73,6 @@ class TestLinsolve(TestCase):
         A2 = csc_matrix(eye(3))
         b2 = array([1.0, 2.0])
         assert_raises(ValueError, spsolve, A2, b2)
-
-
-class TestSolve(TestCase):
-    def test_solve_smoketest(self):
-        Adense = matrix([[ 0.,  1.,  1.],
-                         [ 1.,  0.,  1.],
-                         [ 0.,  0.,  1.]])
-        As =  csc_matrix(Adense)
-        random.seed(1234)
-        x = random.randn(3, 3)
-        Bdense = As.dot(x)
-        Bs = csc_matrix(Bdense)
-        x2 = solve(As, Bs)
-        assert_array_almost_equal(x, x2.todense())
 
     def test_example_comparison(self):
         row = array([0,0,1,2,2,2])
@@ -89,7 +87,7 @@ class TestSolve(TestCase):
         sN = csr_matrix((data, (row,col)), shape=(3,3), dtype=float)
         N = sN.todense()
 
-        sX = solve(sM, sN)
+        sX = spsolve(sM, sN)
         X = scipy.linalg.solve(M, N)
 
         assert_array_almost_equal(X, sX.todense())

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -5,9 +5,10 @@ import numpy.random as random
 from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal, \
     assert_raises, assert_almost_equal, assert_equal, assert_array_equal, assert_
 
+import scipy.linalg 
 from scipy.linalg import norm, inv
-from scipy.sparse import spdiags, SparseEfficiencyWarning, csc_matrix
-from scipy.sparse.linalg.dsolve import spsolve, use_solver, splu, spilu
+from scipy.sparse import spdiags, SparseEfficiencyWarning, csc_matrix, csr_matrix
+from scipy.sparse.linalg.dsolve import spsolve, solve, use_solver, splu, spilu
 
 warnings.simplefilter('ignore',SparseEfficiencyWarning)
 
@@ -60,6 +61,38 @@ class TestLinsolve(TestCase):
         A2 = csc_matrix(eye(3))
         b2 = array([1.0, 2.0])
         assert_raises(ValueError, spsolve, A2, b2)
+
+
+class TestSolve(TestCase):
+    def test_solve_smoketest(self):
+        Adense = matrix([[ 0.,  1.,  1.],
+                         [ 1.,  0.,  1.],
+                         [ 0.,  0.,  1.]])
+        As =  csc_matrix(Adense)
+        random.seed(1234)
+        x = random.randn(3, 3)
+        Bdense = As.dot(x)
+        Bs = csc_matrix(Bdense)
+        x2 = solve(As, Bs)
+        assert_array_almost_equal(x, x2.todense())
+
+    def test_example_comparison(self):
+        row = array([0,0,1,2,2,2])
+        col = array([0,2,2,0,1,2])
+        data = array([1,2,3,-4,5,6])
+        sM = csr_matrix((data,(row,col)), shape=(3,3), dtype=float)
+        M = sM.todense()
+
+        row  = array([0,0,1,1,0,0])
+        col  = array([0,2,1,1,0,0])
+        data = array([1,1,1,1,1,1])
+        sN = csr_matrix((data, (row,col)), shape=(3,3), dtype=float)
+        N = sN.todense()
+
+        sX = solve(sM, sN)
+        X = scipy.linalg.solve(M, N)
+
+        assert_array_almost_equal(X, sX.todense())
 
 class TestSplu(object):
     def setUp(self):

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -16,7 +16,7 @@ from scipy.sparse.base import isspmatrix
 from scipy.sparse.construct import eye as speye
 
 
-def expm(A, q=False):
+def expm(A):
     """Compute the matrix exponential using Pade approximation.
 
     Parameters

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -40,7 +40,6 @@ def expm(A):
     Aissparse = isspmatrix(A)
 
     if Aissparse:
-
         A_L1 = max(abs(A).sum(axis=0).flat)
         ident = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
     else:

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -3,7 +3,7 @@
 # Author: Anthony Scopatz, August 2012 (Sparse Updates)
 #
 
-__all__ = ['expm', ]
+__all__ = ['expm', 'inv']
 
 from numpy import asarray, dot, eye, ceil, log2
 from numpy import matrix as mat
@@ -14,7 +14,30 @@ from scipy.linalg.basic import solve, inv
 
 from scipy.sparse.base import isspmatrix
 from scipy.sparse.construct import eye as speye
+from scipy.sparse.linalg import spsolve
 
+
+def inv(A):
+    """Compute the inverse of a sparse matrix
+
+    Parameters
+    ----------
+    A : ndarray or sparse matrix
+        square matrix to be inverted
+    
+    Returns
+    -------
+    Ainv : inverse of A
+
+    Notes
+    -----
+    This computes the sparse inverse of A.  If the inverse of A is expected
+    to be non-sparse, it will likely be faster to convert A to dense and use
+    scipy.linalg.inv.
+    """
+    I = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
+    Ainv = spsolve(A, I)
+    return Ainv
 
 def expm(A):
     """Compute the matrix exponential using Pade approximation.

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -1,6 +1,11 @@
+"""
+Sparse matrix functions
+"""
+
 #
-# Author: Travis Oliphant, March 2002
-# Author: Anthony Scopatz, August 2012 (Sparse Updates)
+# Authors: Travis Oliphant, March 2002
+#          Anthony Scopatz, August 2012 (Sparse Updates)
+#          Jake Vanderplas, August 2012 (Sparse Updates)
 #
 
 __all__ = ['expm', 'inv']

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -1,0 +1,141 @@
+#
+# Author: Travis Oliphant, March 2002
+# Author: Anthony Scopatz, August 2012 (Sparse Updates)
+#
+
+__all__ = ['expm', ]
+
+from numpy import asarray, dot, eye, ceil, log2
+from numpy import matrix as mat
+import numpy as np
+
+from scipy.linalg.misc import norm
+from scipy.linalg.basic import solve, inv
+
+from scipy.sparse.base import isspmatrix
+from scipy.sparse.construct import eye as speye
+
+
+def expm(A, q=False):
+    """Compute the matrix exponential using Pade approximation.
+
+    Parameters
+    ----------
+    A : array or sparse matrix, shape(M,M)
+        2D Array or Matrix (sparse or dense) to be exponentiated
+
+    Returns
+    -------
+    expA : array, shape(M,M)
+        Matrix exponential of A
+
+    References
+    ----------
+    N. J. Higham,
+    "The Scaling and Squaring Method for the Matrix Exponential Revisited",
+    SIAM. J. Matrix Anal. & Appl. 26, 1179 (2005).
+
+    """
+    n_squarings = 0
+    Aissparse = isspmatrix(A)
+
+    if Aissparse:
+
+        A_L1 = max(abs(A).sum(axis=0).flat)
+        ident = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
+    else:
+        A = asarray(A)
+        A_L1 = norm(A,1)
+        ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
+
+    if A.dtype == 'float64' or A.dtype == 'complex128':
+        if A_L1 < 1.495585217958292e-002:
+            U,V = _pade3(A, ident)
+        elif A_L1 < 2.539398330063230e-001:
+            U,V = _pade5(A, ident)
+        elif A_L1 < 9.504178996162932e-001:
+            U,V = _pade7(A, ident)
+        elif A_L1 < 2.097847961257068e+000:
+            U,V = _pade9(A, ident)
+        else:
+            maxnorm = 5.371920351148152
+            n_squarings = max(0, int(ceil(log2(A_L1 / maxnorm))))
+            A = A / 2**n_squarings
+            U,V = _pade13(A, ident)
+    elif A.dtype == 'float32' or A.dtype == 'complex64':
+        if A_L1 < 4.258730016922831e-001:
+            U,V = _pade3(A, ident)
+        elif A_L1 < 1.880152677804762e+000:
+            U,V = _pade5(A, ident)
+        else:
+            maxnorm = 3.925724783138660
+            n_squarings = max(0, int(ceil(log2(A_L1 / maxnorm))))
+            A = A / 2**n_squarings
+            U,V = _pade7(A, ident)
+    else:
+        raise ValueError("invalid type: "+str(A.dtype))
+
+    P = U + V  # p_m(A) : numerator
+    Q = -U + V # q_m(A) : denominator
+
+    if Aissparse:
+        from scipy.sparse.linalg import spsolve
+        R = spsolve(Q, P)
+    else:
+        R = solve(Q,P)
+
+    # squaring step to undo scaling
+    for i in range(n_squarings):
+        R = R.dot(R)
+
+    return R
+
+# implementation of Pade approximations of various degree using the algorithm presented in [Higham 2005]
+# These should apply to both dense and sparse matricies.
+# ident is the identity matrix, which matches A in being sparse or dense.
+def _pade3(A, ident):
+    b = (120., 60., 12., 1.)
+    A2 = A.dot(A)
+    U = A.dot(b[3]*A2 + b[1]*ident)
+    V = b[2]*A2 + b[0]*ident
+    return U,V
+
+def _pade5(A, ident):
+    b = (30240., 15120., 3360., 420., 30., 1.)
+    A2 = A.dot(A)
+    A4 = A2.dot(A2)
+    U = A.dot(b[5]*A4 + b[3]*A2 + b[1]*ident)
+    V = b[4]*A4 + b[2]*A2 + b[0]*ident
+    return U,V
+
+def _pade7(A, ident):
+    b = (17297280., 8648640., 1995840., 277200., 25200., 1512., 56., 1.)
+    A2 = A.dot(A)
+    A4 = A2.dot(A2)
+    A6 = A4.dot(A2)
+    U = A.dot(b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
+    V = b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
+    return U,V
+
+def _pade9(A, ident):
+    b = (17643225600., 8821612800., 2075673600., 302702400., 30270240.,
+                2162160., 110880., 3960., 90., 1.)
+    A2 = A.dot(A)
+    A4 = A2.dot(A2)
+    A6 = A4.dot(A2)
+    A8 = A6.dot(A2)
+    U = A.dot(b[9]*A8 + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
+    V = b[8]*A8 + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
+    return U,V
+
+def _pade13(A, ident):
+    b = (64764752532480000., 32382376266240000., 7771770303897600.,
+    1187353796428800., 129060195264000., 10559470521600., 670442572800.,
+    33522128640., 1323241920., 40840800., 960960., 16380., 182., 1.)
+    A2 = A.dot(A)
+    A4 = A2.dot(A2)
+    A6 = A4.dot(A2)
+    U = A.dot(A6.dot(b[13]*A6 + b[11]*A4 + b[9]*A2) + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
+    V = A6.dot(b[12]*A6 + b[10]*A4 + b[8]*A2) + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
+    return U,V
+

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+#
+# Created by: Pearu Peterson, March 2002
+#
+""" Test functions for scipy.linalg.matfuncs module
+
+"""
+import numpy as np
+from numpy import array, identity, dot, sqrt, double, exp, random
+from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal, \
+     assert_array_almost_equal_nulp
+
+from scipy.sparse.linalg import expm
+from scipy.linalg import logm
+
+
+class TestExpM(TestCase):
+    def test_zero(self):
+        a = array([[0.,0],[0,0]])
+        assert_array_almost_equal(expm(a),[[1,0],[0,1]])
+
+    def test_padecases_dtype(self):
+        for dtype in [np.float32, np.float64, np.complex64, np.complex128]:
+            # test double-precision cases
+            for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
+                a = scale * identity(3, dtype=dtype)
+                e = exp(scale) * identity(3, dtype=dtype)
+                assert_array_almost_equal_nulp(expm(a), e, nulp=100)
+
+    def test_logm_consistency(self):
+        random.seed(1234)
+        for dtype in [np.float32, np.float64, np.complex64, np.complex128]:
+            for n in range(1, 10):
+                for scale in [1e-4, 1e-3, 1e-2, 1e-1, 1, 1e1, 1e2]:
+                    # make logm(a) be of a given scale
+                    a = (identity(n) + random.rand(n, n) * scale).astype(dtype)
+                    if np.iscomplexobj(a):
+                        a = a + 1j * random.rand(n, n) * scale
+                    assert_array_almost_equal(expm(logm(a)), a)
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -10,6 +10,8 @@ from numpy import array, identity, dot, sqrt, double, exp, random
 from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal, \
      assert_array_almost_equal_nulp
 
+from scipy.sparse import csc_matrix
+from scipy.sparse.construct import eye as speye
 from scipy.sparse.linalg import expm
 from scipy.linalg import logm
 
@@ -19,6 +21,10 @@ class TestExpM(TestCase):
         a = array([[0.,0],[0,0]])
         assert_array_almost_equal(expm(a),[[1,0],[0,1]])
 
+    def test_zero_sparse(self):
+        a = csc_matrix([[0.,0],[0,0]])
+        assert_array_almost_equal(expm(a).toarray(),[[1,0],[0,1]])
+
     def test_padecases_dtype(self):
         for dtype in [np.float32, np.float64, np.complex64, np.complex128]:
             # test double-precision cases
@@ -26,6 +32,15 @@ class TestExpM(TestCase):
                 a = scale * identity(3, dtype=dtype)
                 e = exp(scale) * identity(3, dtype=dtype)
                 assert_array_almost_equal_nulp(expm(a), e, nulp=100)
+
+    def test_padecases_dtype_sparse(self):
+        # float32 and complex64 lead to errors in spsolve/UMFpack
+        for dtype in [np.float64, np.complex128]:
+            # test double-precision cases
+            for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
+                a = scale * speye(3, 3, dtype=dtype, format='csc')
+                e = exp(scale) * identity(3, dtype=dtype)
+                assert_array_almost_equal_nulp(expm(a).toarray(), e, nulp=100)
 
     def test_logm_consistency(self):
         random.seed(1234)

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -15,7 +15,6 @@ from scipy.sparse.construct import eye as speye
 from scipy.sparse.linalg import expm
 from scipy.linalg import logm
 
-
 class TestExpM(TestCase):
     def test_zero(self):
         a = array([[0.,0],[0,0]])

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -33,7 +33,7 @@ from scipy.sparse import csc_matrix, csr_matrix, dok_matrix, \
         coo_matrix, lil_matrix, dia_matrix, bsr_matrix, \
         eye, isspmatrix, SparseEfficiencyWarning
 from scipy.sparse.sputils import supported_dtypes
-from scipy.sparse.linalg import splu
+from scipy.sparse.linalg import splu, expm, inv
 
 
 warnings.simplefilter('ignore', SparseEfficiencyWarning)
@@ -162,19 +162,19 @@ class _TestCommon:
         M = array([[1, 0, 2], [0, 0, 3], [-4, 5, 6]], float)
         sM = self.spmatrix(M, shape=(3,3), dtype=float)
         Mexp = scipy.linalg.expm(M)
-        sMexp = sM.expm().todense()
+        sMexp = expm(sM).todense()
         assert_array_almost_equal((sMexp - Mexp), zeros((3, 3)))
 
         N = array([[ 3.,  0., 1.], [ 0.,  2., 0.],  [ 0.,  0., 0.]])
         sN = self.spmatrix(N, shape=(3,3), dtype=float)
         Nexp = scipy.linalg.expm(N)
-        sNexp = sN.expm().todense()
+        sNexp = expm(sN).todense()
         assert_array_almost_equal((sNexp - Nexp), zeros((3, 3)))
 
     def test_inv(self):
         M = array([[1, 0, 2], [0, 0, 3], [-4, 5, 6]], float)
         sM = self.spmatrix(M, shape=(3,3), dtype=float)
-        sMinv = sM.inv()
+        sMinv = inv(sM)
         assert_array_almost_equal(sMinv.dot(sM).todense(), np.eye(3))
 
     def test_from_array(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -26,6 +26,8 @@ from numpy.testing import assert_raises, assert_equal, assert_array_equal, \
         assert_array_almost_equal, assert_almost_equal, assert_, \
         dec, TestCase, run_module_suite
 
+import scipy.linalg
+
 import scipy.sparse as sparse
 from scipy.sparse import csc_matrix, csr_matrix, dok_matrix, \
         coo_matrix, lil_matrix, dia_matrix, bsr_matrix, \
@@ -155,6 +157,25 @@ class _TestCommon:
         assert_array_equal(self.dat.mean(axis=None), self.datsp.mean(axis=None))
         assert_array_equal(self.dat.mean(axis=0), self.datsp.mean(axis=0))
         assert_array_equal(self.dat.mean(axis=1), self.datsp.mean(axis=1))
+
+    def test_expm(self):
+        M = array([[1, 0, 2], [0, 0, 3], [-4, 5, 6]], float)
+        sM = self.spmatrix(M, shape=(3,3), dtype=float)
+        Mexp = scipy.linalg.expm(M)
+        sMexp = sM.expm().todense()
+        assert_array_almost_equal((sMexp - Mexp), zeros((3, 3)))
+
+        N = array([[ 3.,  0., 1.], [ 0.,  2., 0.],  [ 0.,  0., 0.]])
+        sN = self.spmatrix(N, shape=(3,3), dtype=float)
+        Nexp = scipy.linalg.expm(N)
+        sNexp = sN.expm().todense()
+        assert_array_almost_equal((sNexp - Nexp), zeros((3, 3)))
+
+    def test_inv(self):
+        M = array([[1, 0, 2], [0, 0, 3], [-4, 5, 6]], float)
+        sM = self.spmatrix(M, shape=(3,3), dtype=float)
+        sMinv = sM.inv()
+        assert_array_almost_equal(sMinv.dot(sM).todense(), np.eye(3))
 
     def test_from_array(self):
         A = array([[1,0,0],[2,3,4],[0,5,0],[0,0,0]])


### PR DESCRIPTION
Some top level linear algebra functions, such as matrix exponentials, for sparse matrices are missing. For small & sparse systems such functions normally end up producing dense results.  However, for large & very sparse systems these functions are far more likely to have sparse results as well. It is this use case which is being addressed by this PR.

The goal of this PR was to add expm() - a Pade approximate exponential method - to sparse matrices.  However, this involved also writing the sparse equivalent of `scipy.linalg.solve()`, which solves `Ax=B` linear equations where B may be a vector or a matrix.  Currently, `scipy.sparse.linalg.spsolve()` only solves `Ax=b` type equations where b must be a vector.  

Incidentally, the inv() method comes along for free by noting that `A.inv() == solve(A, I)` where I is the identity matrix.

Tests and docs are included in this PR.
