### PR TITLE
Pinv enhancements

### DIFF
--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -31,6 +31,7 @@ Basics
    lstsq - Solve a linear least-squares problem
    pinv - Pseudo-inverse (Moore-Penrose) using lstsq
    pinv2 - Pseudo-inverse using svd
+   pinvh - Pseudo-inverse of hermitian matrix
    kron - Kronecker product of two arrays
    tril - Construct a lower-triangular matrix from a given matrix
    triu - Construct an upper-triangular matrix from a given matrix

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -4,7 +4,7 @@
 # w/ additions by Travis Oliphant, March 2002
 
 __all__ = ['solve', 'solve_triangular', 'solveh_banded', 'solve_banded',
-            'inv', 'det', 'lstsq', 'pinv', 'pinv2']
+            'inv', 'det', 'lstsq', 'pinv', 'pinv2', 'pinvh']
 
 import numpy as np
 
@@ -13,7 +13,7 @@ from lapack import get_lapack_funcs
 from misc import LinAlgError, _datacopied
 from scipy.linalg import calc_lwork
 from decomp_schur import schur
-import decomp_svd
+import decomp, decomp_svd
 
 
 # Linear equations
@@ -596,3 +596,58 @@ def pinv2(a, cond=None, rcond=None):
     psigma_diag[above_cutoff] = 1.0 / s[above_cutoff]
  
     return np.transpose(np.conjugate(np.dot(u * psigma_diag, vh)))
+
+
+def pinvh(a, cond=None, rcond=None):
+    """Compute the (Moore-Penrose) pseudo-inverse of a hermetian matrix.
+
+    Calculate a generalized inverse of a symmetric matrix using its
+    eigenvalue decomposition and including all 'large' eigenvalues.
+
+    Parameters
+    ----------
+    a : array, shape (N, N)
+        Real symmetric or complex hermetian matrix to be pseudo-inverted
+    cond, rcond : float or None
+        Cutoff for 'small' eigenvalues.
+        Singular values smaller than rcond * largest_eigenvalue are considered
+        zero.
+
+        If None or -1, suitable machine precision is used.
+
+    Returns
+    -------
+    B : array, shape (N, N)
+
+    Raises
+    ------
+    LinAlgError
+        If eigenvalue does not converge
+
+    Examples
+    --------
+    >>> from numpy import *
+    >>> a = random.randn(9, 6)
+    >>> a = np.dot(a, a.T)
+    >>> B = pinv_symmetric(a)
+    >>> allclose(a, dot(a, dot(B, a)))
+    True
+    >>> allclose(B, dot(B, dot(a, B)))
+    True
+
+    """
+    a = np.asarray_chkfinite(a)
+    s, u = decomp.eigh(a)
+    
+    if rcond is not None:
+        cond = rcond
+    if cond in [None, -1]:
+        t = u.dtype.char.lower()
+        factor = {'f': 1E3, 'd': 1E6}
+        cond = factor[t] * np.finfo(t).eps
+    
+    above_cutoff = (s > cond * np.max(s))
+    psigma_diag = np.zeros_like(s)
+    psigma_diag[above_cutoff] = 1.0 / s[above_cutoff]
+
+    return np.dot(u * psigma_diag, np.conjugate(u).T)

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -598,7 +598,7 @@ def pinv2(a, cond=None, rcond=None):
     return np.transpose(np.conjugate(np.dot(u * psigma_diag, vh)))
 
 
-def pinvh(a, cond=None, rcond=None):
+def pinvh(a, cond=None, rcond=None, lower=True):
     """Compute the (Moore-Penrose) pseudo-inverse of a hermetian matrix.
 
     Calculate a generalized inverse of a symmetric matrix using its
@@ -614,6 +614,9 @@ def pinvh(a, cond=None, rcond=None):
         zero.
 
         If None or -1, suitable machine precision is used.
+    lower : boolean
+        Whether the pertinent array data is taken from the lower or upper
+        triangle of a. (Default: lower)
 
     Returns
     -------
@@ -637,7 +640,7 @@ def pinvh(a, cond=None, rcond=None):
 
     """
     a = np.asarray_chkfinite(a)
-    s, u = decomp.eigh(a)
+    s, u = decomp.eigh(a, lower=lower)
     
     if rcond is not None:
         cond = rcond

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -646,7 +646,8 @@ def pinvh(a, cond=None, rcond=None):
         factor = {'f': 1E3, 'd': 1E6}
         cond = factor[t] * np.finfo(t).eps
     
-    above_cutoff = (s > cond * np.max(s))
+    # unlike svd case, eigh can lead to negative eigenvalues
+    above_cutoff = (abs(s) > cond * np.max(abs(s)))
     psigma_diag = np.zeros_like(s)
     psigma_diag[above_cutoff] = 1.0 / s[above_cutoff]
 

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -632,7 +632,7 @@ def pinvh(a, cond=None, rcond=None, lower=True):
     >>> from numpy import *
     >>> a = random.randn(9, 6)
     >>> a = np.dot(a, a.T)
-    >>> B = pinv_symmetric(a)
+    >>> B = pinvh(a)
     >>> allclose(a, dot(a, dot(B, a)))
     True
     >>> allclose(B, dot(B, dot(a, B)))

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -28,7 +28,7 @@ from numpy.testing import TestCase, rand, run_module_suite, assert_raises, \
     assert_equal, assert_almost_equal, assert_array_almost_equal, assert_, \
     assert_allclose
 
-from scipy.linalg import solve, inv, det, lstsq, pinv, pinv2, norm,\
+from scipy.linalg import solve, inv, det, lstsq, pinv, pinv2, pinvh, norm,\
         solve_banded, solveh_banded, solve_triangular
 
 from scipy.linalg._testutils import assert_no_overwrite
@@ -534,29 +534,55 @@ class TestLstsq(TestCase):
 
 class TestPinv(TestCase):
 
-    def test_simple(self):
-        a=array([[1,2,3],[4,5,6.],[7,8,10]])
+    def test_simple_real(self):
+        a = array([[1,2,3], [4,5,6.], [7,8,10]])
         a_pinv = pinv(a)
-        assert_array_almost_equal(dot(a,a_pinv),[[1,0,0],[0,1,0],[0,0,1]])
+        assert_array_almost_equal(dot(a,a_pinv), np.eye(3))
         a_pinv = pinv2(a)
-        assert_array_almost_equal(dot(a,a_pinv),[[1,0,0],[0,1,0],[0,0,1]])
-    def test_simple_0det(self):
-        a=array([[1,2,3],[4,5,6.],[7,8,9]])
+        assert_array_almost_equal(dot(a,a_pinv), np.eye(3))
+
+    def test_simple_complex(self):
+        a = (array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+             + 1j * array([[9, 8, 7], [6, 5, 4], [3, 2, 1]]))
+        a_pinv = pinv(a)
+        assert_array_almost_equal(dot(a, a_pinv), np.eye(3))
+        a_pinv = pinv2(a)
+        assert_array_almost_equal(dot(a, a_pinv), np.eye(3))
+
+    def test_simple_det(self):
+        a = array([[1,2,3],[4,5,6.],[7,8,9]])
         a_pinv = pinv(a)
         a_pinv2 = pinv2(a)
         assert_array_almost_equal(a_pinv,a_pinv2)
 
     def test_simple_cols(self):
-        a=array([[1,2,3],[4,5,6.]])
+        a = array([[1,2,3],[4,5,6.]])
         a_pinv = pinv(a)
         a_pinv2 = pinv2(a)
         assert_array_almost_equal(a_pinv,a_pinv2)
 
     def test_simple_rows(self):
-        a=array([[1,2],[3,4],[5,6]])
+        a = array([[1,2],[3,4],[5,6]])
         a_pinv = pinv(a)
         a_pinv2 = pinv2(a)
         assert_array_almost_equal(a_pinv,a_pinv2)
+
+
+class TestPinv(TestCase):
+
+    def test_simple_real(self):
+        a = array([[1,2,3], [4,5,6.], [7,8,10]])
+        a = np.dot(a, a.T)
+        a_pinv = pinvh(a)
+        assert_array_almost_equal(np.dot(a, a_pinv), np.eye(3))
+
+    def test_simple_complex(self):
+        a = (array([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
+             + 1j * array([[10, 8, 7], [6, 5, 4], [3, 2, 1]]))
+        a = np.dot(a, a.conj().T)
+        a_pinv = pinvh(a)
+        assert_array_almost_equal(np.dot(a, a_pinv), np.eye(3))
+
 
 class TestNorm(object):
 
@@ -608,6 +634,8 @@ class TestOverwrite(object):
         assert_no_overwrite(pinv, [(3,3)])
     def test_pinv2(self):
         assert_no_overwrite(pinv2, [(3,3)])
+    def test_pinvh(self):
+        assert_no_overwrite(pinvh, [(3,3)])
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -542,8 +542,8 @@ class TestPinv(TestCase):
         assert_array_almost_equal(dot(a,a_pinv), np.eye(3))
 
     def test_simple_complex(self):
-        a = (array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-             + 1j * array([[9, 8, 7], [6, 5, 4], [3, 2, 1]]))
+        a = (array([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
+             + 1j * array([[10, 8, 7], [6, 5, 4], [3, 2, 1]]))
         a_pinv = pinv(a)
         assert_array_almost_equal(dot(a, a_pinv), np.eye(3))
         a_pinv = pinv2(a)
@@ -568,13 +568,23 @@ class TestPinv(TestCase):
         assert_array_almost_equal(a_pinv,a_pinv2)
 
 
-class TestPinv(TestCase):
+class TestPinvSymmetric(TestCase):
 
     def test_simple_real(self):
         a = array([[1,2,3], [4,5,6.], [7,8,10]])
         a = np.dot(a, a.T)
         a_pinv = pinvh(a)
         assert_array_almost_equal(np.dot(a, a_pinv), np.eye(3))
+
+    def test_nonpositive(self):
+        a = array([[1,2,3], [4,5,6.], [7,8,9]])
+        a = np.dot(a, a.T)
+        u, s, vt = np.linalg.svd(a)
+        s[0] *= -1
+        a = np.dot(u * s, vt)  # a is now symmetric non-positive and singular
+        a_pinv = pinv2(a)
+        a_pinvh = pinvh(a)
+        assert_array_almost_equal(a_pinv, a_pinvh)
 
     def test_simple_complex(self):
         a = (array([[1, 2, 3], [4, 5, 6], [7, 8, 10]])

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -549,7 +549,7 @@ class TestPinv(TestCase):
         a_pinv = pinv2(a)
         assert_array_almost_equal(dot(a, a_pinv), np.eye(3))
 
-    def test_simple_det(self):
+    def test_simple_singular(self):
         a = array([[1,2,3],[4,5,6.],[7,8,9]])
         a_pinv = pinv(a)
         a_pinv2 = pinv2(a)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -535,34 +535,34 @@ class TestLstsq(TestCase):
 class TestPinv(TestCase):
 
     def test_simple_real(self):
-        a = array([[1,2,3], [4,5,6.], [7,8,10]])
+        a = array([[1, 2, 3], [4, 5, 6], [7, 8, 10]], dtype=float)
         a_pinv = pinv(a)
         assert_array_almost_equal(dot(a,a_pinv), np.eye(3))
         a_pinv = pinv2(a)
         assert_array_almost_equal(dot(a,a_pinv), np.eye(3))
 
     def test_simple_complex(self):
-        a = (array([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
-             + 1j * array([[10, 8, 7], [6, 5, 4], [3, 2, 1]]))
+        a = (array([[1, 2, 3], [4, 5, 6], [7, 8, 10]], dtype=float)
+             + 1j * array([[10, 8, 7], [6, 5, 4], [3, 2, 1]], dtype=float))
         a_pinv = pinv(a)
         assert_array_almost_equal(dot(a, a_pinv), np.eye(3))
         a_pinv = pinv2(a)
         assert_array_almost_equal(dot(a, a_pinv), np.eye(3))
 
     def test_simple_singular(self):
-        a = array([[1,2,3],[4,5,6.],[7,8,9]])
+        a = array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=float)
         a_pinv = pinv(a)
         a_pinv2 = pinv2(a)
         assert_array_almost_equal(a_pinv,a_pinv2)
 
     def test_simple_cols(self):
-        a = array([[1,2,3],[4,5,6.]])
+        a = array([[1, 2, 3], [4, 5, 6]], dtype=float)
         a_pinv = pinv(a)
         a_pinv2 = pinv2(a)
         assert_array_almost_equal(a_pinv,a_pinv2)
 
     def test_simple_rows(self):
-        a = array([[1,2],[3,4],[5,6]])
+        a = array([[1, 2], [3, 4], [5, 6]], dtype=float)
         a_pinv = pinv(a)
         a_pinv2 = pinv2(a)
         assert_array_almost_equal(a_pinv,a_pinv2)
@@ -571,13 +571,13 @@ class TestPinv(TestCase):
 class TestPinvSymmetric(TestCase):
 
     def test_simple_real(self):
-        a = array([[1,2,3], [4,5,6.], [7,8,10]])
+        a = array([[1, 2, 3], [4, 5, 6], [7, 8, 10]], dtype=float)
         a = np.dot(a, a.T)
         a_pinv = pinvh(a)
         assert_array_almost_equal(np.dot(a, a_pinv), np.eye(3))
 
     def test_nonpositive(self):
-        a = array([[1,2,3], [4,5,6.], [7,8,9]])
+        a = array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=float)
         a = np.dot(a, a.T)
         u, s, vt = np.linalg.svd(a)
         s[0] *= -1
@@ -587,8 +587,8 @@ class TestPinvSymmetric(TestCase):
         assert_array_almost_equal(a_pinv, a_pinvh)
 
     def test_simple_complex(self):
-        a = (array([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
-             + 1j * array([[10, 8, 7], [6, 5, 4], [3, 2, 1]]))
+        a = (array([[1, 2, 3], [4, 5, 6], [7, 8, 10]], dtype=float)
+             + 1j * array([[10, 8, 7], [6, 5, 4], [3, 2, 1]], dtype=float))
         a = np.dot(a, a.conj().T)
         a_pinv = pinvh(a)
         assert_array_almost_equal(np.dot(a, a_pinv), np.eye(3))


### PR DESCRIPTION
This is a PR based on some of @vene's work in scikit-learn: see https://github.com/scikit-learn/scikit-learn/pull/1015

There are two enhancements:
- `scipy.linalg.pinv2` is sped up by only computing necessary singular values, and not allocating the entire `psigma` matrix
- `scipy.linalg.pinvh` added: this uses `eigh` to significantly speed up the pseudo-inverse computation in the symmetric/hermitian case

Here are some simple benchmarks:

**old pinv2 vs new pinv2**

old version:

```
In [1]: import numpy as np
In [2]: from scipy.linalg import pinv2
In [3]: np.random.seed(0)
In [4]: X = np.random.random((500, 100))
In [5]: %timeit pinv2(X)
10 loops, best of 3: 172 ms per loop
```

new version:

```
...
In [5]: %timeit pinv2(X)
10 loops, best of 3: 38.1 ms per loop
```

**pinvh vs new pinv2:**

```
In [1]: import numpy as np
In [2]: from scipy.linalg import pinv2, pinvh
In [3]: np.random.seed(0)
In [4]: X = np.random.random((500, 400))
In [5]: X = np.dot(X, X.T) # make symmetric positive semi-definite
In [6]: %timeit pinv2(X)
1 loops, best of 3: 736 ms per loop
In [7]: %timeit pinvh(X)
1 loops, best of 3: 320 ms per loop
```
