### PR TITLE
DOC: Document butter() parameters and returns

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -636,6 +636,31 @@ def butter(N, Wn, btype='low', analog=0, output='ba'):
     Design an Nth order lowpass digital or analog Butterworth filter and return
     the filter coefficients in (B,A) or (Z,P,K) form.
 
+    Parameters
+    ----------
+    N : int
+        The order of the filter.
+    Wn : array_like
+        A scalar or length-2 sequence giving the critical frequencies.
+    btype : str, optional
+        The type of filter (lowpass, highpass, bandpass, bandstop).
+        Default is bandpass.
+    analog : int, optional
+        Non-zero to return an analog filter, otherwise a digital filter is
+        returned.
+    output : ['ba', 'zpk'], optional
+        Type of output:  numerator/denominator ('ba') or pole-zero ('zpk').
+        Default is 'ba'.
+       
+    Returns
+    -------
+    b, a : ndarray, ndarray
+        Numerator (b) and denominator (a) polynomials of the IIR filter. 
+        Only returned if ``output='ba'``.
+    z, p, k : ndarray, ndarray, float
+        Zeros, poles, and system gain of the IIR filter transfer 
+        function.  Only returned if ``output='zpk'``.
+    
     See also
     --------
     buttord.

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -648,7 +648,7 @@ def butter(N, Wn, btype='low', analog=0, output='ba'):
     analog : int, optional
         Non-zero to return an analog filter, otherwise a digital filter is
         returned.
-    output : ['ba', 'zpk'], optional
+    output : {'ba', 'zpk'}, optional
         Type of output:  numerator/denominator ('ba') or pole-zero ('zpk').
         Default is 'ba'.
        


### PR DESCRIPTION
Adapted from `iirfilter()` and `iirdesign()` docstrings

If this is an accepted change, I can add them for the other types too.
