### PR TITLE
BUG: avoid duplicate tol argument when calling lmgres in optimize.nonlin

### DIFF
--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -1418,6 +1418,7 @@ class KrylovJacobian(Jacobian):
         return r
 
     def solve(self, rhs, tol=0):
+        tol = self.method_kw.pop('tol', tol)
         sol, info = self.method(self.op, rhs, tol=tol, **self.method_kw)
         return sol
 


### PR DESCRIPTION
Reported in http://mail.scipy.org/pipermail/scipy-user/2012-August/032889.html.
