### PR TITLE
Disable qz sort keyword

### DIFF
--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -52,36 +52,37 @@ def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
     QZ decompostion for generalized eigenvalues of a pair of matrices.
 
     The QZ, or generalized Schur, decomposition for a pair of N x N
-    nonsymmetric matrices (A,B) is
+    nonsymmetric matrices (A,B) is::
 
         (A,B) = (Q*AA*Z', Q*BB*Z')
 
     where AA, BB is in generalized Schur form if BB is upper-triangular
     with non-negative diagonal and AA is upper-triangular, or for real QZ
-    decomposition (output='real') block upper triangular with 1x1
-    and 2x2 blocks. In this case, the 1x1 blocks correpsond to real
+    decomposition (``output='real'``) block upper triangular with 1x1
+    and 2x2 blocks.  In this case, the 1x1 blocks correspond to real
     generalized eigenvalues and 2x2 blocks are 'standardized' by making
-    the correpsonding elements of BB have the form::
+    the corresponding elements of BB have the form::
 
         [ a 0 ]
         [ 0 b ]
 
-    and the pair of correpsonding 2x2 blocks in AA and BB will have a complex
-    conjugate pair of generalized eigenvalues. If (output='complex') or A
-    and B are complex matrices, Z' denotes the conjugate-transpose of Z.
+    and the pair of corresponding 2x2 blocks in AA and BB will have a complex
+    conjugate pair of generalized eigenvalues.  If (``output='complex'``) or
+    A and B are complex matrices, Z' denotes the conjugate-transpose of Z.
     Q and Z are unitary matrices.
 
     Parameters
     ----------
     A : array_like, shape (N,N)
-        2d array to decompose
+        2-D array to decompose.
     B : array_like, shape (N,N)
-        2d array to decompose
-    output : str {'real','complex'}
+        2-D array to decompose.
+    output : {'real','complex'}, optional
         Construct the real or complex QZ decomposition for real matrices.
-    lwork : integer, optional
-        Work array size. If None or -1, it is automatically computed.
-    sort : {None, callable, 'lhp', 'rhp', 'iuc', 'ouc'}
+        Default is 'real'.
+    lwork : int, optional
+        Work array size.  If None or -1, it is automatically computed.
+    sort : {None, callable, 'lhp', 'rhp', 'iuc', 'ouc'}, optional
         Specifies whether the upper eigenvalues should be sorted.  A callable
         may be passed that, given a eigenvalue, returns a boolean denoting
         whether the eigenvalue should be sorted to the top-left (True). For
@@ -91,10 +92,12 @@ def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
         takes two complex arguments (alpha, beta). The eigenvalue
         x = (alpha/beta).
         Alternatively, string parameters may be used:
-            'lhp'   Left-hand plane (x.real < 0.0)
-            'rhp'   Right-hand plane (x.real > 0.0)
-            'iuc'   Inside the unit circle (x*x.conjugate() <= 1.0)
-            'ouc'   Outside the unit circle (x*x.conjugate() > 1.0)
+
+            - 'lhp'   Left-hand plane (x.real < 0.0)
+            - 'rhp'   Right-hand plane (x.real > 0.0)
+            - 'iuc'   Inside the unit circle (x*x.conjugate() <= 1.0)
+            - 'ouc'   Outside the unit circle (x*x.conjugate() > 1.0)
+
         Defaults to None (no sorting).
 
     Returns
@@ -107,7 +110,7 @@ def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
         The left Schur vectors.
     Z : ndarray, shape (N,N)
         The right Schur vectors.
-    sdim : int
+    sdim : int, optional
         If sorting was requested, a fifth return value will contain the
         number of eigenvalues for which the sort condition was True.
 
@@ -116,6 +119,31 @@ def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
     Q is transposed versus the equivalent function in Matlab.
 
     .. versionadded:: 0.11.0
+
+    Examples
+    --------
+    >>> from scipy import linalg
+    >>> np.random.seed(1234)
+    >>> A = np.arange(9).reshape((3, 3))
+    >>> B = np.random.randn(3, 3)
+
+    >>> AA, BB, Q, Z = linalg.qz(A, B)
+    >>> AA
+    array([[-13.40928183,  -4.62471562,   1.09215523],
+           [  0.        ,   0.        ,   1.22805978],
+           [  0.        ,   0.        ,   0.31973817]])
+    >>> BB
+    array([[ 0.33362547, -1.37393632,  0.02179805],
+           [ 0.        ,  1.68144922,  0.74683866],
+           [ 0.        ,  0.        ,  0.9258294 ]])
+    >>> Q
+    array([[ 0.14134727, -0.97562773,  0.16784365],
+           [ 0.49835904, -0.07636948, -0.86360059],
+           [ 0.85537081,  0.20571399,  0.47541828]])
+    >>> Z
+    array([[-0.24900855, -0.51772687,  0.81850696],
+           [-0.79813178,  0.58842606,  0.12938478],
+           [-0.54861681, -0.6210585 , -0.55973739]])
 
     """
     if not output in ['real','complex','r','c']:

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -83,6 +83,8 @@ def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
     lwork : int, optional
         Work array size.  If None or -1, it is automatically computed.
     sort : {None, callable, 'lhp', 'rhp', 'iuc', 'ouc'}, optional
+        NOTE: THIS INPUT IS DISABLED FOR NOW, IT DOESN'T WORK WELL ON WINDOWS.
+
         Specifies whether the upper eigenvalues should be sorted.  A callable
         may be passed that, given a eigenvalue, returns a boolean denoting
         whether the eigenvalue should be sorted to the top-left (True). For
@@ -146,6 +148,11 @@ def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
            [-0.54861681, -0.6210585 , -0.55973739]])
 
     """
+    if sort is not None:
+        # Disabled due to segfaults on win32, see ticket 1717.
+        raise ValueError("The 'sort' input of qz() has to be None (will "
+                 " change when this functionality is made more robust).")
+
     if not output in ['real','complex','r','c']:
         raise ValueError("argument must be 'real', or 'complex'")
 
@@ -201,14 +208,14 @@ def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
         raise ValueError("Illegal value in argument %d of gges" % -info)
     elif info > 0 and info <= a_n:
         warnings.warn("The QZ iteration failed. (a,b) are not in Schur "
-                "form, but ALPHAR(j), ALPHAI(j), and BETA(j) should be correct"
+                "form, but ALPHAR(j), ALPHAI(j), and BETA(j) should be correct "
                 "for J=%d,...,N" % info-1, UserWarning)
     elif info == a_n+1:
         raise LinAlgError("Something other than QZ iteration failed")
     elif info == a_n+2:
-        raise LinAlgError("After reordering, roundoff changed values of some"
-                "complex eigenvalues so that leading eigenvalues in the"
-                "Generalized Schur form no longer satisfy sort=True."
+        raise LinAlgError("After reordering, roundoff changed values of some "
+                "complex eigenvalues so that leading eigenvalues in the "
+                "Generalized Schur form no longer satisfy sort=True. "
                 "This could also be caused due to scaling.")
     elif info == a_n+3:
         raise LinAlgError("Reordering failed in <s,d,c,z>tgsen")

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1715,34 +1715,36 @@ class TestQZ(TestCase):
 
         sort = lambda ar,ai,beta : ai == 0
 
-        AA,BB,Q,Z,sdim = qz(A,B,sort=sort)
-        #assert_(sdim == 2)
-        assert_(sdim == 4)
-        assert_array_almost_equal(dot(dot(Q,AA),Z.T), A)
-        assert_array_almost_equal(dot(dot(Q,BB),Z.T), B)
+        assert_raises(ValueError, qz, A, B, sort=sort)
+        if False:
+            AA,BB,Q,Z,sdim = qz(A,B,sort=sort)
+            #assert_(sdim == 2)
+            assert_(sdim == 4)
+            assert_array_almost_equal(dot(dot(Q,AA),Z.T), A)
+            assert_array_almost_equal(dot(dot(Q,BB),Z.T), B)
 
-        # test absolute values bc the sign is ambiguous and might be platform
-        # dependent
-        assert_array_almost_equal(np.abs(AA), np.abs(np.array(
-                        [[ 35.7864, -80.9061, -12.0629,  -9.498 ],
-                         [  0.    ,   2.7638,  -2.3505,   7.3256],
-                         [  0.    ,   0.    ,   0.6258,  -0.0398],
-                         [  0.    ,   0.    ,   0.    , -12.8217]])), 4)
-        assert_array_almost_equal(np.abs(BB), np.abs(np.array(
-                        [[ 4.5324, -8.7878,  3.2357, -3.5526],
-                         [ 0.    ,  1.4314, -2.1894,  0.9709],
-                         [ 0.    ,  0.    ,  1.3126, -0.3468],
-                         [ 0.    ,  0.    ,  0.    ,  0.559 ]])), 4)
-        assert_array_almost_equal(np.abs(Q), np.abs(np.array(
-                        [[-0.4193, -0.605 , -0.1894, -0.6498],
-                         [-0.5495,  0.6987,  0.2654, -0.3734],
-                         [-0.4973, -0.3682,  0.6194,  0.4832],
-                         [-0.5243,  0.1008, -0.7142,  0.4526]])), 4)
-        assert_array_almost_equal(np.abs(Z), np.abs(np.array(
-                        [[-0.9471, -0.2971, -0.1217,  0.0055],
-                         [-0.0367,  0.1209,  0.0358,  0.9913],
-                         [ 0.3171, -0.9041, -0.2547,  0.1312],
-                         [ 0.0346,  0.2824, -0.9587,  0.0014]])), 4)
+            # test absolute values bc the sign is ambiguous and might be platform
+            # dependent
+            assert_array_almost_equal(np.abs(AA), np.abs(np.array(
+                            [[ 35.7864, -80.9061, -12.0629,  -9.498 ],
+                             [  0.    ,   2.7638,  -2.3505,   7.3256],
+                             [  0.    ,   0.    ,   0.6258,  -0.0398],
+                             [  0.    ,   0.    ,   0.    , -12.8217]])), 4)
+            assert_array_almost_equal(np.abs(BB), np.abs(np.array(
+                            [[ 4.5324, -8.7878,  3.2357, -3.5526],
+                             [ 0.    ,  1.4314, -2.1894,  0.9709],
+                             [ 0.    ,  0.    ,  1.3126, -0.3468],
+                             [ 0.    ,  0.    ,  0.    ,  0.559 ]])), 4)
+            assert_array_almost_equal(np.abs(Q), np.abs(np.array(
+                            [[-0.4193, -0.605 , -0.1894, -0.6498],
+                             [-0.5495,  0.6987,  0.2654, -0.3734],
+                             [-0.4973, -0.3682,  0.6194,  0.4832],
+                             [-0.5243,  0.1008, -0.7142,  0.4526]])), 4)
+            assert_array_almost_equal(np.abs(Z), np.abs(np.array(
+                            [[-0.9471, -0.2971, -0.1217,  0.0055],
+                             [-0.0367,  0.1209,  0.0358,  0.9913],
+                             [ 0.3171, -0.9041, -0.2547,  0.1312],
+                             [ 0.0346,  0.2824, -0.9587,  0.0014]])), 4)
 
         # test absolute values bc the sign is ambiguous and might be platform
         # dependent
@@ -1769,24 +1771,25 @@ class TestQZ(TestCase):
         #                [0.0626, -0.6934, -0.7114,  0.0956]])), 4)
         #assert_array_almost_equal(dot(Z,Z.T), eye(4))
 
-    def test_qz_complex_sort(self):
-        cA = np.array([
-       [-21.10+22.50*1j, 53.50+-50.50*1j, -34.50+127.50*1j, 7.50+  0.50*1j],
-       [-0.46+ -7.78*1j, -3.50+-37.50*1j, -15.50+ 58.50*1j,-10.50+ -1.50*1j],
-       [ 4.30+ -5.50*1j, 39.70+-17.10*1j, -68.50+ 12.50*1j, -7.50+ -3.50*1j],
-       [ 5.50+  4.40*1j, 14.40+ 43.30*1j, -32.50+-46.00*1j,-19.00+-32.50*1j]])
+    #def test_qz_complex_sort(self):
+    #    cA = np.array([
+    #   [-21.10+22.50*1j, 53.50+-50.50*1j, -34.50+127.50*1j, 7.50+  0.50*1j],
+    #   [-0.46+ -7.78*1j, -3.50+-37.50*1j, -15.50+ 58.50*1j,-10.50+ -1.50*1j],
+    #   [ 4.30+ -5.50*1j, 39.70+-17.10*1j, -68.50+ 12.50*1j, -7.50+ -3.50*1j],
+    #   [ 5.50+  4.40*1j, 14.40+ 43.30*1j, -32.50+-46.00*1j,-19.00+-32.50*1j]])
 
-        cB =  np.array([
-       [1.00+ -5.00*1j, 1.60+  1.20*1j,-3.00+  0.00*1j, 0.00+ -1.00*1j],
-       [0.80+ -0.60*1j, 3.00+ -5.00*1j,-4.00+  3.00*1j,-2.40+ -3.20*1j],
-       [1.00+  0.00*1j, 2.40+  1.80*1j,-4.00+ -5.00*1j, 0.00+ -3.00*1j],
-       [0.00+  1.00*1j,-1.80+  2.40*1j, 0.00+ -4.00*1j, 4.00+ -5.00*1j]])
+    #    cB =  np.array([
+    #   [1.00+ -5.00*1j, 1.60+  1.20*1j,-3.00+  0.00*1j, 0.00+ -1.00*1j],
+    #   [0.80+ -0.60*1j, 3.00+ -5.00*1j,-4.00+  3.00*1j,-2.40+ -3.20*1j],
+    #   [1.00+  0.00*1j, 2.40+  1.80*1j,-4.00+ -5.00*1j, 0.00+ -3.00*1j],
+    #   [0.00+  1.00*1j,-1.80+  2.40*1j, 0.00+ -4.00*1j, 4.00+ -5.00*1j]])
 
-        AAS,BBS,QS,ZS,sdim = qz(cA,cB,sort='lhp')
+    #    AAS,BBS,QS,ZS,sdim = qz(cA,cB,sort='lhp')
 
-        eigenvalues = diag(AAS)/diag(BBS)
-        assert_(all(np.real(eigenvalues[:sdim] < 0)))
-        assert_(all(np.real(eigenvalues[sdim:] > 0)))
+    #    eigenvalues = diag(AAS)/diag(BBS)
+    #    assert_(all(np.real(eigenvalues[:sdim] < 0)))
+    #    assert_(all(np.real(eigenvalues[sdim:] > 0)))
+
 
 class TestDatacopied(TestCase):
 


### PR DESCRIPTION
See ticket 1717 (http://projects.scipy.org/scipy/ticket/1717) for details. Since I haven't been able to find the issue yet and can't spend more time on this, disabling the sort kw is the most reasonable option imho. This function is new in 0.11.0, so backwards compatibility is not an issue.

This PR also includes some docstring fixes and adds an example.
