### PR TITLE
ENH: Optimize sparse csr A[i,:] and A[i].

### DIFF
--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -16,6 +16,8 @@ from sputils import upcast, isintlike
 
 from compressed import _cs_matrix
 
+_slice_all = slice(None, None, None)
+
 class csr_matrix(_cs_matrix):
     """
     Compressed Sparse Row matrix
@@ -230,6 +232,8 @@ class csr_matrix(_cs_matrix):
                 if isintlike(col):
                     return self._get_single_element(row, col) #[i,j]
                 elif isinstance(col, slice):
+                    if col == _slice_all:                     #[i,:]
+                        return self.getrow(row)
                     return self._get_row_slice(row, col)      #[i,1:2]
                 else:
                     P = extractor(col,self.shape[1]).T        #[i,[1,2]]


### PR DESCRIPTION
Georgiana Dinu provided me with a benchmark showing that row slicing into a sparse csr matrix is rather slow.  This patch provides a shortcut for that specific use case, yielding a 10x speed improvement.

``` python
import numpy as np
import scipy.sparse as sp
import time
import random

a = sp.csr_matrix(np.mat(np.random.rand(500,500)))

no_samples = 500
idx = range(no_samples)
random.shuffle(idx)

for thr in [0.2, 0.6]:

        a.data[a.data < thr] = 0
        a.eliminate_zeros()
        print "Shape and nnz/size", a.shape, a.nnz/float(a.shape[0]*a.shape[1])

        st = time.time()
        for i in idx:
                b = a[i]

        print "a[i]", (time.time() - st)/no_samples

        st = time.time()
        for i in idx:
                b = a[i, :]

        print "a[i,:]", (time.time() - st)/no_samples

        st = time.time()
        for i in idx:
                b = a.getrow(i)

        print "getrow(i)", (time.time() - st)/no_samples
```
