### PR TITLE
DOC: Clean up docstrings for waveforms and wavelets

### DIFF
--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -15,9 +15,9 @@ def sawtooth(t, width=1):
     """
     Return a periodic sawtooth or triangle waveform.
 
-    The sawtooth waveform has a period 2*pi, rises from -1 to 1 on the
-    interval 0 to width*2*pi, then drops from 1 to -1 on the interval
-    width*2*pi to 2*pi. `width` must be in the interval [0, 1].
+    The sawtooth waveform has a period ``2*pi``, rises from -1 to 1 on the
+    interval 0 to ``width*2*pi``, then drops from 1 to -1 on the interval
+    ``width*2*pi`` to ``2*pi``. `width` must be in the interval [0, 1].
 
     Parameters
     ----------
@@ -79,8 +79,9 @@ def square(t, duty=0.5):
     """
     Return a periodic square-wave waveform.
 
-    The square wave has a period 2*pi, has value +1 from 0 to 2*pi*duty
-    and -1 from 2*pi*duty to 2*pi. `duty` must be in the interval [0,1].
+    The square wave has a period ``2*pi``, has value +1 from 0 to 
+    ``2*pi*duty`` and -1 from ``2*pi*duty`` to ``2*pi``. `duty` must be in 
+    the interval [0,1].
 
     Parameters
     ----------
@@ -101,7 +102,7 @@ def square(t, duty=0.5):
     >>> import matplotlib.pyplot as plt
     >>> t = np.linspace(0, 1, 500, endpoint=False)
     >>> plt.plot(t, scipy.signal.square(2 * np.pi * 5 * t))
-    >>> ylim(-2, 2)
+    >>> plt.ylim(-2, 2)
 
     """
     t, w = asarray(t), asarray(duty)
@@ -140,7 +141,9 @@ def square(t, duty=0.5):
 def gausspulse(t, fc=1000, bw=0.5, bwr=-6, tpr=-60, retquad=False,
                retenv=False):
     """
-    Return a Gaussian modulated sinusoid: exp(-a t^2) exp(1j*2*pi*fc*t).
+    Return a Gaussian modulated sinusoid:
+        
+        ``exp(-a t^2) exp(1j*2*pi*fc*t).``
 
     If `retquad` is True, then return the real and imaginary parts
     (in-phase and quadrature).
@@ -184,13 +187,13 @@ def gausspulse(t, fc=1000, bw=0.5, bwr=-6, tpr=-60, retquad=False,
 
     Examples
     --------
-    Plot real, imaginary, and envelope for a 5 Hz pulse, sampled at 100 Hz 
-    for 2 seconds:
+    Plot real component, imaginary component, and envelope for a 5 Hz pulse, 
+    sampled at 100 Hz for 2 seconds:
     
     >>> import matplotlib.pyplot as plt
-    >>> t = linspace(-1, 1, 2 * 100, endpoint=False)
+    >>> t = np.linspace(-1, 1, 2 * 100, endpoint=False)
     >>> i, q, e = scipy.signal.gausspulse(t, fc=5, retquad=True, retenv=True)
-    >>> plot(t, i, t, q, t, e, '--')
+    >>> plt.plot(t, i, t, q, t, e, '--')
 
     """
     if fc < 0:
@@ -403,12 +406,8 @@ def sweep_poly(t, poly, phi=0):
     y : ndarray
         A numpy array containing the signal evaluated at `t` with the 
         requested time-varying frequency.  More precisely, the function 
-        returns:
-        
-            ``cos(phase + (pi/180)*phi)``
-        
-        where `phase` is the integral (from 0 to t) of ``2 * pi * f(t)``;
-        ``f(t)`` is defined above.
+        returns ``cos(phase + (pi/180)*phi)``, where `phase` is the integral 
+        (from 0 to t) of ``2 * pi * f(t)``; ``f(t)`` is defined above.
 
     See Also
     --------

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -266,12 +266,8 @@ def chirp(t, f0, t1, f1, method='linear', phi=0, vertex_zero=True):
     y : ndarray
         A numpy array containing the signal evaluated at `t` with the 
         requested time-varying frequency.  More precisely, the function 
-        returns:
-        
-            ``cos(phase + (pi/180)*phi)``
-        
-        where `phase` is the integral (from 0 to `t`) of ``2*pi*f(t)``.
-        ``f(t)`` is defined below.
+        returns ``cos(phase + (pi/180)*phi)`` where `phase` is the integral 
+        (from 0 to `t`) of ``2*pi*f(t)``. ``f(t)`` is defined below.
 
     See Also
     --------

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -13,7 +13,7 @@ __all__ = ['sawtooth', 'square', 'gausspulse', 'chirp', 'sweep_poly']
 
 def sawtooth(t, width=1):
     """
-    Return a periodic sawtooth waveform.
+    Return a periodic sawtooth or triangle waveform.
 
     The sawtooth waveform has a period 2*pi, rises from -1 to 1 on the
     interval 0 to width*2*pi and drops from 1 to -1 on the interval
@@ -24,7 +24,9 @@ def sawtooth(t, width=1):
     t : array_like
         Time.
     width : float, optional
-        Width of the waveform. Default is 1.
+        Width of the rising ramp as a proportion of the total cycle. 
+        Default is 1, producing a rising ramp, 0 produces a falling ramp.  
+        `t` = 0.5 produces a triangle wave.
 
     Returns
     -------
@@ -35,7 +37,7 @@ def sawtooth(t, width=1):
     --------
     >>> import matplotlib.pyplot as plt
     >>> x = np.linspace(0, 20*np.pi, 500)
-    >>> plt.plot(x, sp.signal.sawtooth(x))
+    >>> plt.plot(x, scipy.signal.sawtooth(x))
 
     """
     t, w = asarray(t), asarray(width)
@@ -88,7 +90,7 @@ def square(t, duty=0.5):
     Returns
     -------
     y : ndarray
-        The output square wave.
+        Output array containing the square waveform.
 
     """
     t, w = asarray(t), asarray(duty)
@@ -224,13 +226,15 @@ def chirp(t, f0, t1, f1, method='linear', phi=0, vertex_zero=True):
 
     Returns
     -------
-    A numpy array containing the signal evaluated at 't' with the requested
-    time-varying frequency.  More precisely, the function returns:
-
-        ``cos(phase + (pi/180)*phi)``
-
-    where `phase` is the integral (from 0 to t) of ``2*pi*f(t)``.
-    ``f(t)`` is defined below.
+    y : ndarray
+        A numpy array containing the signal evaluated at `t` with the 
+        requested time-varying frequency.  More precisely, the function 
+        returns:
+        
+            ``cos(phase + (pi/180)*phi)``
+        
+        where `phase` is the integral (from 0 to `t`) of ``2*pi*f(t)``.
+        ``f(t)`` is defined below.
 
     See Also
     --------
@@ -363,13 +367,15 @@ def sweep_poly(t, poly, phi=0):
 
     Returns
     -------
-    A numpy array containing the signal evaluated at 't' with the requested
-    time-varying frequency.  More precisely, the function returns
-
-        ``cos(phase + (pi/180)*phi)``
-
-    where `phase` is the integral (from 0 to t) of ``2 * pi * f(t)``;
-    ``f(t)`` is defined above.
+    y : ndarray
+        A numpy array containing the signal evaluated at `t` with the 
+        requested time-varying frequency.  More precisely, the function 
+        returns:
+        
+            ``cos(phase + (pi/180)*phi)``
+        
+        where `phase` is the integral (from 0 to t) of ``2 * pi * f(t)``;
+        ``f(t)`` is defined above.
 
     See Also
     --------

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -87,7 +87,7 @@ def square(t, duty=0.5):
 
     Returns
     -------
-    y : array_like
+    y : ndarray
         The output square wave.
 
     """

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -16,8 +16,8 @@ def sawtooth(t, width=1):
     Return a periodic sawtooth or triangle waveform.
 
     The sawtooth waveform has a period 2*pi, rises from -1 to 1 on the
-    interval 0 to width*2*pi and drops from 1 to -1 on the interval
-    width*2*pi to 2*pi. `width` must be in the interval [0,1].
+    interval 0 to width*2*pi, then drops from 1 to -1 on the interval
+    width*2*pi to 2*pi. `width` must be in the interval [0, 1].
 
     Parameters
     ----------
@@ -25,8 +25,8 @@ def sawtooth(t, width=1):
         Time.
     width : float, optional
         Width of the rising ramp as a proportion of the total cycle. 
-        Default is 1, producing a rising ramp, 0 produces a falling ramp.  
-        `t` = 0.5 produces a triangle wave.
+        Default is 1, producing a rising ramp, while 0 produces a falling 
+        ramp.  `t` = 0.5 produces a triangle wave.
 
     Returns
     -------
@@ -35,9 +35,11 @@ def sawtooth(t, width=1):
 
     Examples
     --------
+    A 5 Hz waveform sampled at 500 Hz for 1 second:
+    
     >>> import matplotlib.pyplot as plt
-    >>> x = np.linspace(0, 20*np.pi, 500)
-    >>> plt.plot(x, scipy.signal.sawtooth(x))
+    >>> t = np.linspace(0, 1, 500, endpoint=False)
+    >>> plt.plot(t, scipy.signal.sawtooth(2 * np.pi * 5 * t))
 
     """
     t, w = asarray(t), asarray(width)
@@ -85,12 +87,21 @@ def square(t, duty=0.5):
     t : array_like
         The input time array.
     duty : float, optional
-        Duty cycle.
+        Duty cycle.  Default is 0.5 (50% duty cycle)
 
     Returns
     -------
     y : ndarray
         Output array containing the square waveform.
+
+    Examples
+    --------
+    A 5 Hz waveform sampled at 500 Hz for 1 second:
+    
+    >>> import matplotlib.pyplot as plt
+    >>> t = np.linspace(0, 1, 500, endpoint=False)
+    >>> plt.plot(t, scipy.signal.square(2 * np.pi * 5 * t))
+    >>> ylim(-2, 2)
 
     """
     t, w = asarray(t), asarray(duty)

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -140,7 +140,7 @@ def square(t, duty=0.5):
 def gausspulse(t, fc=1000, bw=0.5, bwr=-6, tpr=-60, retquad=False,
                retenv=False):
     """
-    Return a gaussian modulated sinusoid: exp(-a t^2) exp(1j*2*pi*fc*t).
+    Return a Gaussian modulated sinusoid: exp(-a t^2) exp(1j*2*pi*fc*t).
 
     If `retquad` is True, then return the real and imaginary parts
     (in-phase and quadrature).
@@ -156,7 +156,7 @@ def gausspulse(t, fc=1000, bw=0.5, bwr=-6, tpr=-60, retquad=False,
     bw : float, optional
         Fractional bandwidth in frequency domain of pulse (Hz).
         Default is 0.5.
-    bwr: float, optional
+    bwr : float, optional
         Reference level at which fractional bandwidth is calculated (dB).
         Default is -6.
     tpr : float, optional
@@ -168,6 +168,29 @@ def gausspulse(t, fc=1000, bw=0.5, bwr=-6, tpr=-60, retquad=False,
         of the signal.  Default is False.
     retenv : bool, optional
         If True, return the envelope of the signal.  Default is False.
+
+    Returns
+    -------
+    yI : ndarray
+        Real part of signal.  Always returned.
+    yQ : ndarray
+        Imaginary part of signal.  Only returned if `retquad` is True.
+    yenv : ndarray
+        Envelope of signal.  Only returned if `retenv` is True.
+        
+    See Also
+    --------
+    scipy.signal.morlet
+
+    Examples
+    --------
+    Plot real, imaginary, and envelope for a 5 Hz pulse, sampled at 100 Hz 
+    for 2 seconds:
+    
+    >>> import matplotlib.pyplot as plt
+    >>> t = linspace(-1, 1, 2 * 100, endpoint=False)
+    >>> i, q, e = scipy.signal.gausspulse(t, fc=5, retquad=True, retenv=True)
+    >>> plot(t, i, t, q, t, e, '--')
 
     """
     if fc < 0:
@@ -295,7 +318,6 @@ def chirp(t, f0, t1, f1, method='linear', phi=0, vertex_zero=True):
         f1 must be positive, and f0 must be greater than f1.
 
     """
-
     # 'phase' is computed in _chirp_phase, to make testing easier.
     phase = _chirp_phase(t, f0, t1, f1, method, vertex_zero)
     # Convert  phi to radians.
@@ -395,6 +417,7 @@ def sweep_poly(t, poly, phi=0):
     Notes
     -----
     .. versionadded:: 0.8.0
+    
     """
     # 'phase' is computed in _sweep_poly_phase, to make testing easier.
     phase = _sweep_poly_phase(t, poly)

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -18,6 +18,10 @@ def daub(p):
     ----------
     p : int
         Order of the zero at f=1/2, can have values from 1 to 34.
+        
+    Returns
+    -------
+    q : ndarray
 
     """
     sqrt = np.sqrt
@@ -91,10 +95,10 @@ def cascade(hk, J=7):
 
     Parameters
     ----------
-    hk :
+    hk : array_like
         Coefficients of low-pass filter.
-    J : int. optional
-        Values will be computed at grid points ``K/2**J``.
+    J : int, optional
+        Values will be computed at grid points ``K/2**J``. Default is 7.
 
     Returns
     -------
@@ -125,7 +129,6 @@ def cascade(hk, J=7):
     end.
 
     """
-
     N = len(hk) - 1
 
     if (J > 30 - np.log2(N + 1)):
@@ -210,11 +213,15 @@ def morlet(M, w=5.0, s=1.0, complete=True):
     M : int
         Length of the wavelet.
     w : float
-        Omega0
+        Omega0. Default is 5
     s : float
-        Scaling factor, windowed from -s*2*pi to +s*2*pi.
+        Scaling factor, windowed from -s*2*pi to +s*2*pi.  Default is 1.
     complete : bool
         Whether to use the complete or the standard version.
+
+    Returns
+    -------
+    out : 1-D ndarray
 
     Notes
     -----
@@ -260,7 +267,7 @@ def ricker(points, a):
     """
     Also known as the "Mexican hat wavelet",
     models the function:
-    A ( 1 - x^2/a^2) exp(-t^2/a^2),
+    A (1 - x^2/a^2) exp(-t^2/a^2),
     where ``A = 2/sqrt(3a)pi^1/3``
 
     Parameters
@@ -274,7 +281,7 @@ def ricker(points, a):
     Returns
     -------
     vector : 1-D ndarray
-        array of length `points` in shape of ricker curve.
+        Array of length `points` in shape of ricker curve.
 
     Examples
     --------
@@ -326,8 +333,11 @@ def cwt(data, wavelet, widths):
 
     Notes
     ------
-    cwt[ii,:] = scipy.signal.convolve(data,wavelet(width[ii], length), mode='same')
-    where length = min(10 * width[ii], len(data)).
+    ``cwt[ii,:] = scipy.signal.convolve(data, wavelet(width[ii], length), mode='same')``
+    
+    where
+    
+    ``length = min(10 * width[ii], len(data))``.
 
     Examples
     --------

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -281,7 +281,7 @@ def ricker(points, a):
     Returns
     -------
     vector : 1-D ndarray
-        Array of length `points` in shape of ricker curve.
+        Array of length `points` in shape of Ricker curve.
 
     Examples
     --------

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -251,7 +251,7 @@ def morlet(M, w=5.0, s=1.0, complete=True):
 
 def ricker(points, a):
     """
-    Also known as the "mexican hat wavelet",
+    Also known as the "Mexican hat wavelet",
     models the function:
     A ( 1 - x^2/a^2) exp(-t^2/a^2),
     where ``A = 2/sqrt(3a)pi^1/3``
@@ -263,10 +263,12 @@ def ricker(points, a):
     points: int, optional
         Number of points in `vector`. Default is ``10*a``
         Will be centered around 0.
+
     Returns
-    -----------
+    -------
     vector: 1-D ndarray
         array of length `points` in shape of ricker curve.
+
     Examples
     --------
     >>> import matplotlib.pyplot as plt
@@ -277,8 +279,8 @@ def ricker(points, a):
     100
     >>> plt.plot(vec2)
     >>> plt.show()
-    """
 
+    """
     A = 2 / (np.sqrt(3 * a) * (np.pi**0.25))
     wsq = a**2
     vec = np.arange(0, points) - (points - 1.0) / 2

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -215,7 +215,7 @@ def morlet(M, w=5.0, s=1.0, complete=True):
     w : float
         Omega0. Default is 5
     s : float
-        Scaling factor, windowed from -s*2*pi to +s*2*pi.  Default is 1.
+        Scaling factor, windowed from ``-s*2*pi`` to ``+s*2*pi``. Default is 1.
     complete : bool
         Whether to use the complete or the standard version.
 
@@ -245,7 +245,7 @@ def morlet(M, w=5.0, s=1.0, complete=True):
     according to s.
 
     The fundamental frequency of this wavelet in Hz is given
-    by f = 2*s*w*r / M where r is the sampling rate.
+    by ``f = 2*s*w*r / M`` where r is the sampling rate.
 
     See Also
     --------
@@ -265,9 +265,11 @@ def morlet(M, w=5.0, s=1.0, complete=True):
 
 def ricker(points, a):
     """
-    Also known as the "Mexican hat wavelet",
+    Return a Ricker wavelet, also known as the "Mexican hat wavelet", which 
     models the function:
-    A (1 - x^2/a^2) exp(-t^2/a^2),
+    
+        ``A (1 - x^2/a^2) exp(-t^2/a^2)``,
+        
     where ``A = 2/sqrt(3a)pi^1/3``
 
     Parameters
@@ -288,7 +290,7 @@ def ricker(points, a):
     >>> import matplotlib.pyplot as plt
     >>> points = 100
     >>> a = 4.0
-    >>> vec2 = ricker(points, a)
+    >>> vec2 = signal.ricker(points, a)
     >>> print len(vec2)
     100
     >>> plt.plot(vec2)
@@ -342,9 +344,9 @@ def cwt(data, wavelet, widths):
     Examples
     --------
     >>> signal = np.random.rand(20) - 0.5
-    >>> wavelet = ricker
+    >>> wavelet = signal.ricker
     >>> widths = np.arange(1, 11)
-    >>> cwtmatr = cwt(signal, wavelet, widths)
+    >>> cwtmatr = signal.cwt(signal, wavelet, widths)
     """
 
     output = np.zeros([len(widths), len(data)])

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -265,11 +265,11 @@ def ricker(points, a):
 
     Parameters
     ----------
-    a : scalar
-        Width parameter of the wavelet.
     points : int, optional
         Number of points in `vector`. Default is ``10*a``
         Will be centered around 0.
+    a : scalar
+        Width parameter of the wavelet.
 
     Returns
     -------
@@ -281,7 +281,7 @@ def ricker(points, a):
     >>> import matplotlib.pyplot as plt
     >>> points = 100
     >>> a = 4.0
-    >>> vec2 = ricker(a,points)
+    >>> vec2 = ricker(points, a)
     >>> print len(vec2)
     100
     >>> plt.plot(vec2)

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -311,11 +311,11 @@ def cwt(data, wavelet, widths):
         data on which to perform the transform.
     wavelet : function
         Wavelet function, which should take 2 arguments.
-        The first argument is a width parameter, defining
-        the size of the wavelet (e.g. standard deviation of a gaussian).
-        The second is the number of points that the returned vector will have
-        (len(wavelet(width,length)) == length). See `ricker`, which
-        satisfies these requirements.
+        The first argument is the number of points that the returned vector 
+        will have (len(wavelet(width,length)) == length).
+        The second is a width parameter, defining the size of the wavelet 
+        (e.g. standard deviation of a gaussian). See 
+        :func:`scipy.signal.ricker`, which satisfies these requirements.
     widths : sequence
         Widths to use for transform.
 

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -73,6 +73,7 @@ def daub(p):
 
 def qmf(hk):
     """Return high-pass qmf filter from low-pass
+
     """
     N = len(hk) - 1
     asgn = [{0: 1, 1:-1}[k % 2] for k in range(N + 1)]
@@ -217,25 +218,31 @@ def morlet(M, w=5.0, s=1.0, complete=True):
 
     Notes
     -----
-    The standard version:
+    The standard version::
+
         pi**-0.25 * exp(1j*w*x) * exp(-0.5*(x**2))
 
-        This commonly used wavelet is often referred to simply as the
-        Morlet wavelet.  Note that, this simplified version can cause
-        admissibility problems at low values of w.
+    This commonly used wavelet is often referred to simply as the
+    Morlet wavelet.  Note that this simplified version can cause
+    admissibility problems at low values of w.
 
-    The complete version:
+    The complete version::
+
         pi**-0.25 * (exp(1j*w*x) - exp(-0.5*(w**2))) * exp(-0.5*(x**2))
 
-        The complete version of the Morlet wavelet, with a correction
-        term to improve admissibility. For w greater than 5, the
-        correction term is negligible.
+    The complete version of the Morlet wavelet, with a correction
+    term to improve admissibility. For w greater than 5, the
+    correction term is negligible.
 
     Note that the energy of the return wavelet is not normalised
     according to s.
 
     The fundamental frequency of this wavelet in Hz is given
     by f = 2*s*w*r / M where r is the sampling rate.
+
+    See Also
+    --------
+    scipy.signal.gausspulse
 
     """
     x = linspace(-s * 2 * pi, s * 2 * pi, M)
@@ -258,15 +265,15 @@ def ricker(points, a):
 
     Parameters
     ----------
-    a: scalar
+    a : scalar
         Width parameter of the wavelet.
-    points: int, optional
+    points : int, optional
         Number of points in `vector`. Default is ``10*a``
         Will be centered around 0.
 
     Returns
     -------
-    vector: 1-D ndarray
+    vector : 1-D ndarray
         array of length `points` in shape of ricker curve.
 
     Examples
@@ -294,7 +301,7 @@ def ricker(points, a):
 def cwt(data, wavelet, widths):
     """
     Performs a continuous wavelet transform on `data`,
-    using the wavelet function. A CWT performs a convolution
+    using the `wavelet` function. A CWT performs a convolution
     with `data` using the `wavelet` function, which is characterized
     by a width parameter and length parameter.
 
@@ -314,7 +321,7 @@ def cwt(data, wavelet, widths):
 
     Returns
     -------
-    cwt: 2-D ndarray
+    cwt : 2-D ndarray
         Will be len(widths) x len(data).
 
     Notes


### PR DESCRIPTION
- Fix docstrings that weren't rendering correctly
- Point out that sawtooth() can produce triangle waves
- Change examples for sawtooth and square to use realistic units
- Fix parameter order in cwt() and ricker() docstrings
- Add missing Returns sections, parameter descriptions, defaults, ...
