### PR TITLE
Stats doc cleanup

### DIFF
--- a/doc/source/tutorial/stats/continuous.lyx
+++ b/doc/source/tutorial/stats/continuous.lyx
@@ -1,11 +1,17 @@
-#LyX 1.6.6.1 created this file. For more info see http://www.lyx.org/
-\lyxformat 345
+#LyX file created by tex2lyx 2.0.2
+\lyxformat 413
 \begin_document
 \begin_header
 \textclass article
+\begin_preamble
+\usepackage{babel}
+
+\end_preamble
 \use_default_options false
 \language english
-\inputencoding auto
+\language_package default
+\inputencoding latin9
+\fontencoding T1
 \font_roman default
 \font_sans default
 \font_typewriter default
@@ -14,18 +20,21 @@
 \font_osf false
 \font_sf_scale 100
 \font_tt_scale 100
-
 \graphics default
 \paperfontsize default
 \spacing single
-\use_hyperref false
+\use_hyperref 0
 \papersize default
 \use_geometry true
 \use_amsmath 2
-\use_esint 0
+\use_esint 1
+\use_mhchem 0
+\use_mathdots 0
 \cite_engine basic
 \use_bibtopic false
 \paperorientation portrait
+\suppress_date false
+\use_refstyle 0
 \leftmargin 1in
 \topmargin 1in
 \rightmargin 1in
@@ -33,32 +42,33 @@
 \secnumdepth 3
 \tocdepth 3
 \paragraph_separation indent
-\defskip medskip
+\paragraph_indentation default
 \quotes_language english
 \papercolumns 1
 \papersides 1
 \paperpagestyle default
 \tracking_changes false
 \output_changes false
-\author "" 
-\author "" 
+\html_math_output 0
+\html_css_as_file 0
+\html_be_strict false
 \end_header
 
 \begin_body
 
 \begin_layout Title
+
 Continuous Statistical Distributions
 \end_layout
 
 \begin_layout Section
+
 Overview
 \end_layout
 
 \begin_layout Standard
-All distributions will have location (L) and Scale (S) parameters along
- with any shape parameters needed, the names for the shape parameters will
- vary.
- Standard form for the distributions will be given where 
+
+All distributions will have location (L) and Scale (S) parameters along with any shape parameters needed, the names for the shape parameters will vary. Standard form for the distributions will be given where 
 \begin_inset Formula $L=0.0$
 \end_inset
 
@@ -66,48 +76,53 @@ All distributions will have location (L) and Scale (S) parameters along
 \begin_inset Formula $S=1.0.$
 \end_inset
 
- The nonstandard forms can be obtained for the various functions using (note
- 
+ The nonstandard forms can be obtained for the various functions using (note 
 \begin_inset Formula $U$
 \end_inset
 
  is a standard uniform random variate).
- 
 \end_layout
 
 \begin_layout Standard
 \align center
 
+
 \size small
-\begin_inset Tabular
+
+\size default
+
+\begin_inset Tabular 
 <lyxtabular version="3" rows="16" columns="3">
-<features>
-<column alignment="center" valignment="top" width="0pt">
-<column alignment="center" valignment="top" width="0pt">
-<column alignment="center" valignment="top" width="0pt">
+<features tabularvalignment="middle">
+<column alignment="center" valignment="top">
+<column alignment="center" valignment="top">
+<column alignment="center" valignment="top">
 <row>
-<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-Function Name
-\end_layout
-
-\end_inset
-</cell>
-<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-Standard Function
-\end_layout
-
-\end_inset
-</cell>
 <cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+Function Name 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+Standard Function 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
 Transformation
 \end_layout
 
@@ -115,31 +130,36 @@ Transformation
 </cell>
 </row>
 <row>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-Cumulative Distribution Function (CDF)
-\end_layout
-
-\end_inset
-</cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-\begin_inset Formula $F\left(x\right)$
-\end_inset
-
-
-\end_layout
-
-\end_inset
-</cell>
 <cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+Cumulative Distribution Function (CDF) 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
+\begin_inset Formula $F\left(x\right)$
+\end_inset
+
+ 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
 \begin_inset Formula $F\left(x;L,S\right)=F\left(\frac{\left(x-L\right)}{S}\right)$
 \end_inset
 
@@ -150,31 +170,36 @@ Cumulative Distribution Function (CDF)
 </cell>
 </row>
 <row>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-Probability Density Function (PDF)
-\end_layout
-
-\end_inset
-</cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-\begin_inset Formula $f\left(x\right)=F^{\prime}\left(x\right)$
-\end_inset
-
-
-\end_layout
-
-\end_inset
-</cell>
 <cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+Probability Density Function (PDF) 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
+\begin_inset Formula $f\left(x\right)=F^{\prime}\left(x\right)$
+\end_inset
+
+ 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
 \begin_inset Formula $f\left(x;L,S\right)=\frac{1}{S}f\left(\frac{\left(x-L\right)}{S}\right)$
 \end_inset
 
@@ -185,31 +210,36 @@ Probability Density Function (PDF)
 </cell>
 </row>
 <row>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-Percent Point Function (PPF)
-\end_layout
-
-\end_inset
-</cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-\begin_inset Formula $G\left(q\right)=F^{-1}\left(q\right)$
-\end_inset
-
-
-\end_layout
-
-\end_inset
-</cell>
 <cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+Percent Point Function (PPF) 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
+\begin_inset Formula $G\left(q\right)=F^{-1}\left(q\right)$
+\end_inset
+
+ 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
 \begin_inset Formula $G\left(q;L,S\right)=L+SG\left(q\right)$
 \end_inset
 
@@ -220,19 +250,22 @@ Percent Point Function (PPF)
 </cell>
 </row>
 <row>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
-Probability Sparsity Function (PSF)
+\begin_layout Standard
+
+Probability Sparsity Function (PSF) 
 \end_layout
 
 \end_inset
 </cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+
 \begin_inset Formula $g\left(q\right)=G^{\prime}\left(q\right)$
 \end_inset
 
@@ -241,10 +274,12 @@ Probability Sparsity Function (PSF)
 
 \end_inset
 </cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+
 \begin_inset Formula $g\left(q;L,S\right)=Sg\left(q\right)$
 \end_inset
 
@@ -255,31 +290,36 @@ Probability Sparsity Function (PSF)
 </cell>
 </row>
 <row>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-Hazard Function (HF)
-\end_layout
-
-\end_inset
-</cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-\begin_inset Formula $h_{a}\left(x\right)=\frac{f\left(x\right)}{1-F\left(x\right)}$
-\end_inset
-
-
-\end_layout
-
-\end_inset
-</cell>
 <cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+Hazard Function (HF) 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
+\begin_inset Formula $h_{a}\left(x\right)=\frac{f\left(x\right)}{1-F\left(x\right)}$
+\end_inset
+
+ 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
 \begin_inset Formula $h_{a}\left(x;L,S\right)=\frac{1}{S}h_{a}\left(\frac{\left(x-L\right)}{S}\right)$
 \end_inset
 
@@ -290,19 +330,22 @@ Hazard Function (HF)
 </cell>
 </row>
 <row>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
-Cumulative Hazard Functon (CHF)
+\begin_layout Standard
+
+Cumulative Hazard Functon (CHF) 
 \end_layout
 
 \end_inset
 </cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+
 \begin_inset Formula $H_{a}\left(x\right)=$
 \end_inset
 
@@ -310,15 +353,17 @@ Cumulative Hazard Functon (CHF)
 \begin_inset Formula $\log\frac{1}{1-F\left(x\right)}$
 \end_inset
 
-
+ 
 \end_layout
 
 \end_inset
 </cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+
 \begin_inset Formula $H_{a}\left(x;L,S\right)=H_{a}\left(\frac{\left(x-L\right)}{S}\right)$
 \end_inset
 
@@ -329,31 +374,36 @@ Cumulative Hazard Functon (CHF)
 </cell>
 </row>
 <row>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-Survival Function (SF)
-\end_layout
-
-\end_inset
-</cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-\begin_inset Formula $S\left(x\right)=1-F\left(x\right)$
-\end_inset
-
-
-\end_layout
-
-\end_inset
-</cell>
 <cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+Survival Function (SF) 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
+\begin_inset Formula $S\left(x\right)=1-F\left(x\right)$
+\end_inset
+
+ 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
 \begin_inset Formula $S\left(x;L,S\right)=S\left(\frac{\left(x-L\right)}{S}\right)$
 \end_inset
 
@@ -364,31 +414,36 @@ Survival Function (SF)
 </cell>
 </row>
 <row>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-Inverse Survival Function (ISF)
-\end_layout
-
-\end_inset
-</cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-\begin_inset Formula $Z\left(\alpha\right)=S^{-1}\left(\alpha\right)=G\left(1-\alpha\right)$
-\end_inset
-
-
-\end_layout
-
-\end_inset
-</cell>
 <cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+Inverse Survival Function (ISF) 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
+\begin_inset Formula $Z\left(\alpha\right)=S^{-1}\left(\alpha\right)=G\left(1-\alpha\right)$
+\end_inset
+
+ 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
 \begin_inset Formula $Z\left(\alpha;L,S\right)=L+SZ\left(\alpha\right)$
 \end_inset
 
@@ -399,31 +454,36 @@ Inverse Survival Function (ISF)
 </cell>
 </row>
 <row>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
 Moment Generating Function (MGF) 
 \end_layout
 
 \end_inset
 </cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+
 \begin_inset Formula $M_{Y}\left(t\right)=E\left[e^{Yt}\right]$
 \end_inset
 
-
+ 
 \end_layout
 
 \end_inset
 </cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+
 \begin_inset Formula $M_{X}\left(t\right)=e^{Lt}M_{Y}\left(St\right)$
 \end_inset
 
@@ -434,31 +494,36 @@ Moment Generating Function (MGF)
 </cell>
 </row>
 <row>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-Random Variates
-\end_layout
-
-\end_inset
-</cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-\begin_inset Formula $Y=G\left(U\right)$
-\end_inset
-
-
-\end_layout
-
-\end_inset
-</cell>
 <cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+Random Variates 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
+\begin_inset Formula $Y=G\left(U\right)$
+\end_inset
+
+ 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
 \begin_inset Formula $X=L+SY$
 \end_inset
 
@@ -469,31 +534,36 @@ Random Variates
 </cell>
 </row>
 <row>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-(Differential) Entropy
-\end_layout
-
-\end_inset
-</cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-\begin_inset Formula $h\left[Y\right]=-\int f\left(y\right)\log f\left(y\right)dy$
-\end_inset
-
-
-\end_layout
-
-\end_inset
-</cell>
 <cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+(Differential) Entropy 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
+\begin_inset Formula $h\left[Y\right]=-\int f\left(y\right)\log f\left(y\right)dy$
+\end_inset
+
+ 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
 \begin_inset Formula $h\left[X\right]=h\left[Y\right]+\log S$
 \end_inset
 
@@ -504,34 +574,40 @@ Random Variates
 </cell>
 </row>
 <row>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-(Non-central) Moments
-\end_layout
-
-\end_inset
-</cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-\begin_inset Formula $\mu_{n}^{\prime}=E\left[Y^{n}\right]$
-\end_inset
-
-
-\end_layout
-
-\end_inset
-</cell>
 <cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+(Non-central) Moments 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
+\begin_inset Formula $\mu_{n}^{\prime}=E\left[Y^{n}\right]$
+\end_inset
+
+ 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
 \begin_inset Formula $E\left[X^{n}\right]=L^{n}\sum_{k=0}^{N}\left(\begin{array}{c}
 n\\
-k\end{array}\right)\left(\frac{S}{L}\right)^{k}\mu_{k}^{\prime}$
+k
+\end{array}\right)\left(\frac{S}{L}\right)^{k}\mu_{k}^{\prime}$
 \end_inset
 
 
@@ -541,31 +617,36 @@ k\end{array}\right)\left(\frac{S}{L}\right)^{k}\mu_{k}^{\prime}$
 </cell>
 </row>
 <row>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
 Central Moments 
 \end_layout
 
 \end_inset
 </cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+
 \begin_inset Formula $\mu_{Y^{n}}=E\left[\left(Y-\mu_{Y}\right)^{n}\right]$
 \end_inset
 
-
+ 
 \end_layout
 
 \end_inset
 </cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+
 \begin_inset Formula $E\left[\left(X-\mu_{X}\right)^{n}\right]=S^{n}\mu_{X^{n}}=S^{n}\mu_{n}$
 \end_inset
 
@@ -576,31 +657,36 @@ Central Moments
 </cell>
 </row>
 <row>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-mean (mode, median), var
-\end_layout
-
-\end_inset
-</cell>
-<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
-\begin_inset Text
-
-\begin_layout Plain Layout
-\begin_inset Formula $\mu_{Y},\,\mu_{Y^{2}}$
-\end_inset
-
-
-\end_layout
-
-\end_inset
-</cell>
 <cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+mean (mode, median), var 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
+\begin_inset Formula $\mu_{Y},\,\mu_{Y^{2}}$
+\end_inset
+
+ 
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Standard
+
+
 \begin_inset Formula $L+S\mu,\, S^{2}\mu_{2}$
 \end_inset
 
@@ -611,19 +697,22 @@ mean (mode, median), var
 </cell>
 </row>
 <row>
-<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
-skewness, kurtosis
+\begin_layout Standard
+
+skewness, kurtosis 
 \end_layout
 
 \end_inset
 </cell>
-<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+<cell alignment="center" valignment="top" topline="true" bottomline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+
 \begin_inset Formula $\gamma_{1}=\frac{\mu_{3}}{\left(\mu_{2}\right)^{3/2}},\,$
 \end_inset
 
@@ -636,10 +725,12 @@ skewness, kurtosis
 
 \end_inset
 </cell>
-<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+<cell alignment="center" valignment="top" topline="true" bottomline="true" rightline="true" usebox="none">
 \begin_inset Text
 
-\begin_layout Plain Layout
+\begin_layout Standard
+
+
 \begin_inset Formula $\gamma_{1},\,\gamma_{2}$
 \end_inset
 
@@ -657,36 +748,46 @@ skewness, kurtosis
 \end_layout
 
 \begin_layout Standard
+
+
+\size small
+
+\end_layout
+
+\begin_layout Standard
+
+
 \begin_inset space ~
+
 \end_inset
 
 
 \end_layout
 
 \begin_layout Subsection
+
 Moments
 \end_layout
 
 \begin_layout Standard
+
 Non-central moments are defined using the PDF 
 \begin_inset Formula \[
-\mu_{n}^{\prime}=\int_{-\infty}^{\infty}x^{n}f\left(x\right)dx.\]
-
+\mu_{n}^{\prime}=\int_{-\infty}^{\infty}x^{n}f\left(x\right)dx.
+\]
 \end_inset
 
- Note, that these can always be computed using the PPF.
- Substitute 
+ Note, that these can always be computed using the PPF. Substitute 
 \begin_inset Formula $x=G\left(q\right)$
 \end_inset
 
  in the above equation and get 
 \begin_inset Formula \[
-\mu_{n}^{\prime}=\int_{0}^{1}G^{n}\left(q\right)dq\]
-
+\mu_{n}^{\prime}=\int_{0}^{1}G^{n}\left(q\right)dq
+\]
 \end_inset
 
- which may be easier to compute numerically.
- Note that 
+ which may be easier to compute numerically. Note that 
 \begin_inset Formula $q=F\left(x\right)$
 \end_inset
 
@@ -698,14 +799,15 @@ Non-central moments are defined using the PDF
 \begin_inset Formula $\mu=\mu_{1}^{\prime}$
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 \mu_{n} & = & \int_{-\infty}^{\infty}\left(x-\mu\right)^{n}f\left(x\right)dx\\
  & = & \int_{0}^{1}\left(G\left(q\right)-\mu\right)^{n}dq\\
  & = & \sum_{k=0}^{n}\left(\begin{array}{c}
 n\\
-k\end{array}\right)\left(-\mu\right)^{k}\mu_{n-k}^{\prime}\end{eqnarray*}
-
+k
+\end{array}\right)\left(-\mu\right)^{k}\mu_{n-k}^{\prime}
+\end{eqnarray*}
 \end_inset
 
  In particular 
@@ -713,75 +815,71 @@ k\end{array}\right)\left(-\mu\right)^{k}\mu_{n-k}^{\prime}\end{eqnarray*}
 \mu_{3} & = & \mu_{3}^{\prime}-3\mu\mu_{2}^{\prime}+2\mu^{3}\\
  & = & \mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}\\
 \mu_{4} & = & \mu_{4}^{\prime}-4\mu\mu_{3}^{\prime}+6\mu^{2}\mu_{2}^{\prime}-3\mu^{4}\\
- & = & \mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}\end{eqnarray*}
-
+ & = & \mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}
+\end{eqnarray*}
 \end_inset
 
  Skewness is defined as 
 \begin_inset Formula \[
-\gamma_{1}=\sqrt{\beta_{1}}=\frac{\mu_{3}}{\mu_{2}^{3/2}}\]
-
+\gamma_{1}=\sqrt{\beta_{1}}=\frac{\mu_{3}}{\mu_{2}^{3/2}}
+\]
 \end_inset
 
  while (Fisher) kurtosis is 
 \begin_inset Formula \[
-\gamma_{2}=\frac{\mu_{4}}{\mu_{2}^{2}}-3,\]
-
+\gamma_{2}=\frac{\mu_{4}}{\mu_{2}^{2}}-3,
+\]
 \end_inset
 
  so that a normal distribution has a kurtosis of zero.
- 
 \end_layout
 
 \begin_layout Subsection
+
 Median and mode
 \end_layout
 
 \begin_layout Standard
+
 The median, 
 \begin_inset Formula $m_{n}$
 \end_inset
 
- is defined as the point at which half of the density is on one side and
- half on the other.
- In other words, 
+ is defined as the point at which half of the density is on one side and half on the other. In other words, 
 \begin_inset Formula $F\left(m_{n}\right)=\frac{1}{2}$
 \end_inset
 
  so that 
 \begin_inset Formula \[
-m_{n}=G\left(\frac{1}{2}\right).\]
-
+m_{n}=G\left(\frac{1}{2}\right).
+\]
 \end_inset
 
  In addition, the mode, 
 \begin_inset Formula $m_{d}$
 \end_inset
 
-, is defined as the value for which the probability density function reaches
- it's peak 
+, is defined as the value for which the probability density function reaches it's peak 
 \begin_inset Formula \[
-m_{d}=\arg\max_{x}f\left(x\right).\]
-
+m_{d}=\arg\max_{x}f\left(x\right).
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Subsection
+
 Fitting data
 \end_layout
 
 \begin_layout Standard
-To fit data to a distribution, maximizing the likelihood function is common.
- Alternatively, some distributions have well-known minimum variance unbiased
- estimators.
- These will be chosen by default, but the likelihood function will always
- be available for minimizing.
- 
+
+To fit data to a distribution, maximizing the likelihood function is common. Alternatively, some distributions have well-known minimum variance unbiased estimators. These will be chosen by default, but the likelihood function will always be available for minimizing.
 \end_layout
 
 \begin_layout Standard
+
 If 
 \begin_inset Formula $f\left(x;\boldsymbol{\theta}\right)$
 \end_inset
@@ -792,8 +890,7 @@ If
 
  is a vector of parameters (
 \emph on
-e.g.
- 
+e.g. 
 \begin_inset Formula $L$
 \end_inset
 
@@ -807,15 +904,14 @@ e.g.
 \begin_inset Formula $N$
 \end_inset
 
- independent samples from this distribution, the joint distribution the
- random vector 
+ independent samples from this distribution, the joint distribution the random vector 
 \begin_inset Formula $\mathbf{x}$
 \end_inset
 
  is 
 \begin_inset Formula \[
-f\left(\mathbf{x};\boldsymbol{\theta}\right)=\prod_{i=1}^{N}f\left(x_{i};\boldsymbol{\theta}\right).\]
-
+f\left(\mathbf{x};\boldsymbol{\theta}\right)=\prod_{i=1}^{N}f\left(x_{i};\boldsymbol{\theta}\right).
+\]
 \end_inset
 
  The maximum likelihood estimate of the parameters 
@@ -829,23 +925,22 @@ f\left(\mathbf{x};\boldsymbol{\theta}\right)=\prod_{i=1}^{N}f\left(x_{i};\boldsy
  fixed and given by the data: 
 \begin_inset Formula \begin{eqnarray*}
 \boldsymbol{\theta}_{es} & = & \arg\max_{\boldsymbol{\theta}}f\left(\mathbf{x};\boldsymbol{\theta}\right)\\
- & = & \arg\min_{\boldsymbol{\theta}}l_{\mathbf{x}}\left(\boldsymbol{\theta}\right).\end{eqnarray*}
-
+ & = & \arg\min_{\boldsymbol{\theta}}l_{\mathbf{x}}\left(\boldsymbol{\theta}\right).
+\end{eqnarray*}
 \end_inset
 
  Where 
 \begin_inset Formula \begin{eqnarray*}
 l_{\mathbf{x}}\left(\boldsymbol{\theta}\right) & = & -\sum_{i=1}^{N}\log f\left(x_{i};\boldsymbol{\theta}\right)\\
- & = & -N\overline{\log f\left(x_{i};\boldsymbol{\theta}\right)}\end{eqnarray*}
-
+ & = & -N\overline{\log f\left(x_{i};\boldsymbol{\theta}\right)}
+\end{eqnarray*}
 \end_inset
 
  Note that if 
 \begin_inset Formula $\boldsymbol{\theta}$
 \end_inset
 
- includes only shape parameters, the location and scale-parameters can be
- fit by replacing 
+ includes only shape parameters, the location and scale-parameters can be fit by replacing 
 \begin_inset Formula $x_{i}$
 \end_inset
 
@@ -860,31 +955,30 @@ l_{\mathbf{x}}\left(\boldsymbol{\theta}\right) & = & -\sum_{i=1}^{N}\log f\left(
  and minimizing, thus 
 \begin_inset Formula \begin{eqnarray*}
 l_{\mathbf{x}}\left(L,S;\boldsymbol{\theta}\right) & = & N\log S-\sum_{i=1}^{N}\log f\left(\frac{x_{i}-L}{S};\boldsymbol{\theta}\right)\\
- & = & N\log S+l_{\frac{\mathbf{x}-S}{L}}\left(\boldsymbol{\theta}\right)\end{eqnarray*}
-
+ & = & N\log S+l_{\frac{\mathbf{x}-S}{L}}\left(\boldsymbol{\theta}\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Subsection
+
 Method of Moments
 \end_layout
 
 \begin_layout Standard
-Another approach to finding parameters of a distribution that explain a
- collection of data is to match the expected moments of the distribution
- with the computed moments and the relevant equations solved for the parameters
- of the distribution.
- In particular, for a distribution with no shape parameters, the following
- equations can be solved for location and scale
+
+Another approach to finding parameters of a distribution that explain a collection of data is to match the expected moments of the distribution with the computed moments and the relevant equations solved for the parameters of the distribution. In particular, for a distribution with no shape parameters, the following equations can be solved for location and scale
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{align*}
 \mu_{Y} & =S\mu+L\\
-\mu_{Y^{2}} & =S^{2}\mu_{2}.\end{align*}
-
+\mu_{Y^{2}} & =S^{2}\mu_{2}.
+\end{align*}
 \end_inset
 
  Estimating 
@@ -907,10 +1001,12 @@ Another approach to finding parameters of a distribution that explain a
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 \hat{S} & = & \sqrt{\frac{\hat{\mu}_{2}}{\mu_{2}}}\\
-\hat{L} & = & \hat{\mu}-\hat{S}\mu\end{eqnarray*}
-
+\hat{L} & = & \hat{\mu}-\hat{S}\mu
+\end{eqnarray*}
 \end_inset
 
  where 
@@ -936,32 +1032,29 @@ untransformed
 ) and 
 \begin_inset Formula \begin{eqnarray*}
 \hat{\mu} & = & \frac{1}{N}\sum_{i=1}^{N}x_{i}=\bar{\mathbf{x}}\\
-\hat{\mu}_{2} & = & \frac{1}{N}\sum_{i=1}^{N}\left(x_{i}-\hat{\mu}\right)^{2}=\overline{\left(\mathbf{x}-\bar{\mathbf{x}}\right)^{2}}.\end{eqnarray*}
-
+\hat{\mu}_{2} & = & \frac{1}{N}\sum_{i=1}^{N}\left(x_{i}-\hat{\mu}\right)^{2}=\overline{\left(\mathbf{x}-\bar{\mathbf{x}}\right)^{2}}.
+\end{eqnarray*}
 \end_inset
 
-In general, if the distribution has 
+ In general, if the distribution has 
 \begin_inset Formula $M$
 \end_inset
 
- shape parameters, then to find the parameters of the distribution, we need
- to add 
+ shape parameters, then to find the parameters of the distribution, we need to add 
 \begin_inset Formula $M$
 \end_inset
 
- additional equations.
- It is straightforward to add the central moment equations: 
+ additional equations. It is straightforward to add the central moment equations: 
 \begin_inset Formula \[
-\mu_{Y^{n}}=S^{n}\mu_{n}\left(\boldsymbol{\theta}\right)\]
-
+\mu_{Y^{n}}=S^{n}\mu_{n}\left(\boldsymbol{\theta}\right)
+\]
 \end_inset
 
-for 
+ for 
 \begin_inset Formula $n=2\ldots M+2$
 \end_inset
 
-.
- If we can estimate the 
+. If we can estimate the 
 \begin_inset Formula $n^{\mbox{th}}$
 \end_inset
 
@@ -971,11 +1064,11 @@ for
 
  as 
 \begin_inset Formula \[
-\hat{\mu}_{n}=\frac{1}{N}\sum_{i=1}^{N}\left(x_{i}-\hat{\mu}\right)^{n}=\overline{\left(\mathbf{x}-\bar{\mathbf{x}}\right)^{n}},\]
-
+\hat{\mu}_{n}=\frac{1}{N}\sum_{i=1}^{N}\left(x_{i}-\hat{\mu}\right)^{n}=\overline{\left(\mathbf{x}-\bar{\mathbf{x}}\right)^{n}},
+\]
 \end_inset
 
-then these data-computed statistics can be used to estimate 
+ then these data-computed statistics can be used to estimate 
 \begin_inset Formula $S$
 \end_inset
 
@@ -983,8 +1076,7 @@ then these data-computed statistics can be used to estimate
 \begin_inset Formula $\boldsymbol{\theta}$
 \end_inset
 
- by solving this set of potentially non-linear equations.
- Then, the location parameter can be found by solving the equation 
+ by solving this set of potentially non-linear equations. Then, the location parameter can be found by solving the equation 
 \begin_inset Formula $\mu_{Y}=S\mu\left(\boldsymbol{\theta}\right)+L$
 \end_inset
 
@@ -993,18 +1085,19 @@ then these data-computed statistics can be used to estimate
 \end_inset
 
 .
- 
 \end_layout
 
 \begin_layout Subsection
+
 Standard notation for mean
 \end_layout
 
 \begin_layout Standard
+
 We will use 
 \begin_inset Formula \[
-\overline{y\left(\mathbf{x}\right)}=\frac{1}{N}\sum_{i=1}^{N}y\left(x_{i}\right)\]
-
+\overline{y\left(\mathbf{x}\right)}=\frac{1}{N}\sum_{i=1}^{N}y\left(x_{i}\right)
+\]
 \end_inset
 
  where 
@@ -1016,14 +1109,61 @@ We will use
 \end_inset
 
 .
- 
+\end_layout
+
+\begin_layout Subsection
+
+References
+\end_layout
+
+\begin_layout Standard
+
+
+\begin_inset CommandInset label
+LatexCommand label
+name "sec:references"
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Itemize
+
+Documentation for ranlib, rv2, cdflib 
+\end_layout
+
+\begin_layout Itemize
+
+Eric Weisstein's world of mathematics http://mathworld.wolfram.com/, 
+\begin_inset Newline newline
+\end_inset
+
+http://mathworld.wolfram.com/topics/StatisticalDistributions.html 
+\end_layout
+
+\begin_layout Itemize
+
+Documentation to Regress+ by Michael McLaughlin item Engineering and Statistics Handbook (NIST), http://www.itl.nist.gov/div898/handbook/index.htm 
+\end_layout
+
+\begin_layout Itemize
+
+Documentation for DATAPLOT from NIST, http://www.itl.nist.gov/div898/software/dataplot/distribu.htm 
+\end_layout
+
+\begin_layout Itemize
+
+Norman Johnson, Samuel Kotz, and N. Balakrishnan "Continuous Univariate Distributions", second edition, Volumes I and II, Wiley & Sons, 1994. 
 \end_layout
 
 \begin_layout Section
+
 Alpha 
 \end_layout
 
 \begin_layout Standard
+
 One shape parameters 
 \begin_inset Formula $\alpha>0$
 \end_inset
@@ -1032,8 +1172,7 @@ One shape parameters
 \begin_inset Formula $\beta$
 \end_inset
 
- in DATAPLOT is a scale-parameter).
- Standard form is 
+ in DATAPLOT is a scale-parameter). Standard form is 
 \begin_inset Formula $x>0:$
 \end_inset
 
@@ -1041,40 +1180,47 @@ One shape parameters
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\alpha\right) & = & \frac{1}{x^{2}\Phi\left(\alpha\right)\sqrt{2\pi}}\exp\left(-\frac{1}{2}\left(\alpha-\frac{1}{x}\right)^{2}\right)\\
 F\left(x;\alpha\right) & = & \frac{\Phi\left(\alpha-\frac{1}{x}\right)}{\Phi\left(\alpha\right)}\\
-G\left(q;\alpha\right) & = & \left[\alpha-\Phi^{-1}\left(q\Phi\left(\alpha\right)\right)\right]^{-1}\end{eqnarray*}
-
+G\left(q;\alpha\right) & = & \left[\alpha-\Phi^{-1}\left(q\Phi\left(\alpha\right)\right)\right]^{-1}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-M\left(t\right)=\frac{1}{\Phi\left(a\right)\sqrt{2\pi}}\int_{0}^{\infty}\frac{e^{xt}}{x^{2}}\exp\left(-\frac{1}{2}\left(\alpha-\frac{1}{x}\right)^{2}\right)dx\]
 
+
+\begin_inset Formula \[
+M\left(t\right)=\frac{1}{\Phi\left(a\right)\sqrt{2\pi}}\int_{0}^{\infty}\frac{e^{xt}}{x^{2}}\exp\left(-\frac{1}{2}\left(\alpha-\frac{1}{x}\right)^{2}\right)dx
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-No moments?
-\begin_inset Formula \[
-l_{\mathbf{x}}\left(\alpha\right)=N\log\left[\Phi\left(\alpha\right)\sqrt{2\pi}\right]+2N\overline{\log\mathbf{x}}+\frac{N}{2}\alpha^{2}-\alpha\overline{\mathbf{x}^{-1}}+\frac{1}{2}\overline{\mathbf{x}^{-2}}\]
 
+No moments? 
+\begin_inset Formula \[
+l_{\mathbf{x}}\left(\alpha\right)=N\log\left[\Phi\left(\alpha\right)\sqrt{2\pi}\right]+2N\overline{\log\mathbf{x}}+\frac{N}{2}\alpha^{2}-\alpha\overline{\mathbf{x}^{-1}}+\frac{1}{2}\overline{\mathbf{x}^{-2}}
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Anglit
 \end_layout
 
 \begin_layout Standard
+
 Defined over 
 \begin_inset Formula $x\in\left[-\frac{\pi}{4},\frac{\pi}{4}\right]$
 \end_inset
@@ -1083,70 +1229,78 @@ Defined over
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \sin\left(2x+\frac{\pi}{2}\right)=\cos\left(2x\right)\\
 F\left(x\right) & = & \sin^{2}\left(x+\frac{\pi}{4}\right)\\
-G\left(q\right) & = & \arcsin\left(\sqrt{q}\right)-\frac{\pi}{4}\end{eqnarray*}
-
+G\left(q\right) & = & \arcsin\left(\sqrt{q}\right)-\frac{\pi}{4}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & 0\\
 \mu_{2} & = & \frac{\pi^{2}}{16}-\frac{1}{2}\\
 \gamma_{1} & = & 0\\
-\gamma_{2} & = & -2\frac{\pi^{4}-96}{\left(\pi^{2}-8\right)^{2}}\end{eqnarray*}
-
+\gamma_{2} & = & -2\frac{\pi^{4}-96}{\left(\pi^{2}-8\right)^{2}}
+\end{eqnarray*}
 \end_inset
 
  
 \begin_inset Formula \begin{eqnarray*}
 h\left[X\right] & = & 1-\log2\\
- & \approx & 0.30685281944005469058\end{eqnarray*}
-
+ & \approx & 0.30685281944005469058
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 M\left(t\right) & = & \int_{-\frac{\pi}{4}}^{\frac{\pi}{4}}\cos\left(2x\right)e^{xt}dx\\
- & = & \frac{4\cosh\left(\frac{\pi t}{4}\right)}{t^{2}+4}\end{eqnarray*}
-
+ & = & \frac{4\cosh\left(\frac{\pi t}{4}\right)}{t^{2}+4}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-l_{\mathbf{x}}\left(\cdot\right)=-N\overline{\log\left[\cos\left(2\mathbf{x}\right)\right]}\]
 
+
+\begin_inset Formula \[
+l_{\mathbf{x}}\left(\cdot\right)=-N\overline{\log\left[\cos\left(2\mathbf{x}\right)\right]}
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Arcsine 
 \end_layout
 
 \begin_layout Standard
+
 Defined over 
 \begin_inset Formula $x\in\left(0,1\right)$
 \end_inset
 
-.
- To get the JKB definition put 
+. To get the JKB definition put 
 \begin_inset Formula $x=\frac{u+1}{2}.$
 \end_inset
 
- i.e.
- 
+ i.e. 
 \begin_inset Formula $L=-1$
 \end_inset
 
@@ -1158,21 +1312,21 @@ Defined over
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \frac{1}{\pi\sqrt{x\left(1-x\right)}}\\
 F\left(x\right) & = & \frac{2}{\pi}\arcsin\left(\sqrt{x}\right)\\
-G\left(q\right) & = & \sin^{2}\left(\frac{\pi}{2}q\right)\end{eqnarray*}
-
+G\left(q\right) & = & \sin^{2}\left(\frac{\pi}{2}q\right)
+\end{eqnarray*}
 \end_inset
 
  
 \begin_inset Formula \[
-M\left(t\right)=E^{t/2}I_{0}\left(\frac{t}{2}\right)\]
-
+M\left(t\right)=E^{t/2}I_{0}\left(\frac{t}{2}\right)
+\]
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 \mu_{n}^{\prime} & = & \frac{1}{\pi}\int_{0}^{1}dx\, x^{n-1/2}\left(1-x\right)^{-1/2}\\
- & = & \frac{1}{\pi}B\left(\frac{1}{2},n+\frac{1}{2}\right)=\frac{\left(2n-1\right)!!}{2^{n}n!}\end{eqnarray*}
-
+ & = & \frac{1}{\pi}B\left(\frac{1}{2},n+\frac{1}{2}\right)=\frac{\left(2n-1\right)!!}{2^{n}n!}
+\end{eqnarray*}
 \end_inset
 
  
@@ -1180,49 +1334,59 @@ M\left(t\right)=E^{t/2}I_{0}\left(\frac{t}{2}\right)\]
 \mu & = & \frac{1}{2}\\
 \mu_{2} & = & \frac{1}{8}\\
 \gamma_{1} & = & 0\\
-\gamma_{2} & = & -\frac{3}{2}\end{eqnarray*}
-
+\gamma_{2} & = & -\frac{3}{2}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]\approx-0.24156447527049044468\]
 
+
+\begin_inset Formula \[
+h\left[X\right]\approx-0.24156447527049044468
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-l_{\mathbf{x}}\left(\cdot\right)=N\log\pi+\frac{N}{2}\overline{\log\mathbf{x}}+\frac{N}{2}\overline{\log\left(1-\mathbf{x}\right)}\]
 
+
+\begin_inset Formula \[
+l_{\mathbf{x}}\left(\cdot\right)=N\log\pi+\frac{N}{2}\overline{\log\mathbf{x}}+\frac{N}{2}\overline{\log\left(1-\mathbf{x}\right)}
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Beta 
 \end_layout
 
 \begin_layout Standard
+
 Two shape parameters
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-a,b>0\]
 
+
+\begin_inset Formula \[
+a,b>0
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;a,b\right) & = & \frac{\Gamma\left(a+b\right)}{\Gamma\left(a\right)\Gamma\left(b\right)}x^{a-1}\left(1-x\right)^{b-1}I_{\left(0,1\right)}\left(x\right)\\
 F\left(x;a,b\right) & = & \int_{0}^{x}f\left(y;a,b\right)dy=I\left(x,a,b\right)\\
@@ -1232,14 +1396,16 @@ M\left(t\right) & = & \frac{\Gamma\left(a\right)\Gamma\left(b\right)}{\Gamma\lef
 \mu_{2} & = & \frac{ab\left(a+b+1\right)}{\left(a+b\right)^{2}}\\
 \gamma_{1} & = & 2\frac{b-a}{a+b+2}\sqrt{\frac{a+b+1}{ab}}\\
 \gamma_{2} & = & \frac{6\left(a^{3}+a^{2}\left(1-2b\right)+b^{2}\left(b+1\right)-2ab\left(b+2\right)\right)}{ab\left(a+b+2\right)\left(a+b+3\right)}\\
-m_{d} & = & \frac{\left(a-1\right)}{\left(a+b-2\right)}\, a+b\neq2\end{eqnarray*}
-
+m_{d} & = & \frac{\left(a-1\right)}{\left(a+b-2\right)}\, a+b\neq2
+\end{eqnarray*}
 \end_inset
 
- 
+
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula $f\left(x;a,1\right)$
 \end_inset
 
@@ -1247,9 +1413,11 @@ m_{d} & = & \frac{\left(a-1\right)}{\left(a+b-2\right)}\, a+b\neq2\end{eqnarray*
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-l_{\mathbf{x}}\left(a,b\right)=-N\log\Gamma\left(a+b\right)+N\log\Gamma\left(a\right)+N\log\Gamma\left(b\right)-N\left(a-1\right)\overline{\log\mathbf{x}}-N\left(b-1\right)\overline{\log\left(1-\mathbf{x}\right)}\]
 
+
+\begin_inset Formula \[
+l_{\mathbf{x}}\left(a,b\right)=-N\log\Gamma\left(a+b\right)+N\log\Gamma\left(a\right)+N\log\Gamma\left(b\right)-N\left(a-1\right)\overline{\log\mathbf{x}}-N\left(b-1\right)\overline{\log\left(1-\mathbf{x}\right)}
+\]
 \end_inset
 
  All of the 
@@ -1260,10 +1428,12 @@ l_{\mathbf{x}}\left(a,b\right)=-N\log\Gamma\left(a+b\right)+N\log\Gamma\left(a\r
 \end_layout
 
 \begin_layout Section
+
 Beta Prime
 \end_layout
 
 \begin_layout Standard
+
 Defined over 
 \begin_inset Formula $0<x<\infty.$
 \end_inset
@@ -1272,29 +1442,31 @@ Defined over
 \begin_inset Formula $\alpha,\beta>0.$
 \end_inset
 
- (Note the CDF evaluation uses Eq.
- 3.194.1 on pg.
- 313 of Gradshteyn & Ryzhik (sixth edition).
- 
+ (Note the CDF evaluation uses Eq. 3.194.1 on pg. 313 of Gradshteyn & Ryzhik (sixth edition).
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\alpha,\beta\right) & = & \frac{\Gamma\left(\alpha+\beta\right)}{\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}x^{\alpha-1}\left(1+x\right)^{-\alpha-\beta}\\
 F\left(x;\alpha,\beta\right) & = & \frac{\Gamma\left(\alpha+\beta\right)}{\alpha\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}x^{\alpha}\,_{2}F_{1}\left(\alpha+\beta,\alpha;1+\alpha;-x\right)\\
-G\left(q;\alpha,\beta\right) & = & F^{-1}\left(x;\alpha,\beta\right)\end{eqnarray*}
-
+G\left(q;\alpha,\beta\right) & = & F^{-1}\left(x;\alpha,\beta\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \[
 \mu_{n}^{\prime}=\left\{ \begin{array}{ccc}
 \frac{\Gamma\left(n+\alpha\right)\Gamma\left(\beta-n\right)}{\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}=\frac{\left(\alpha\right)_{n}}{\left(\beta-n\right)_{n}} &  & \beta>n\\
-\infty &  & \textrm{otherwise}\end{array}\right.\]
-
+\infty &  & \textrm{otherwise}
+\end{array}\right.
+\]
 \end_inset
 
  Therefore, 
@@ -1303,22 +1475,25 @@ G\left(q;\alpha,\beta\right) & = & F^{-1}\left(x;\alpha,\beta\right)\end{eqnarra
 \mu_{2} & = & \frac{\alpha\left(\alpha+1\right)}{\left(\beta-2\right)\left(\beta-1\right)}-\frac{\alpha^{2}}{\left(\beta-1\right)^{2}}\quad\beta>2\\
 \gamma_{1} & = & \frac{\frac{\alpha\left(\alpha+1\right)\left(\alpha+2\right)}{\left(\beta-3\right)\left(\beta-2\right)\left(\beta-1\right)}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\quad\beta>3\\
 \gamma_{2} & = & \frac{\mu_{4}}{\mu_{2}^{2}}-3\\
-\mu_{4} & = & \frac{\alpha\left(\alpha+1\right)\left(\alpha+2\right)\left(\alpha+3\right)}{\left(\beta-4\right)\left(\beta-3\right)\left(\beta-2\right)\left(\beta-1\right)}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}\quad\beta>4\end{eqnarray*}
-
+\mu_{4} & = & \frac{\alpha\left(\alpha+1\right)\left(\alpha+2\right)\left(\alpha+3\right)}{\left(\beta-4\right)\left(\beta-3\right)\left(\beta-2\right)\left(\beta-1\right)}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}\quad\beta>4
+\end{eqnarray*}
 \end_inset
 
- 
+
 \end_layout
 
 \begin_layout Section
+
 Bradford
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 c & > & 0\\
-k & = & \log\left(1+c\right)\end{eqnarray*}
-
+k & = & \log\left(1+c\right)
+\end{eqnarray*}
 \end_inset
 
  
@@ -1332,40 +1507,44 @@ M\left(t\right) & = & \frac{1}{k}e^{-t/c}\left[\textrm{Ei}\left(t+\frac{t}{c}\ri
 \gamma_{1} & = & \frac{\sqrt{2}\left(12c^{2}-9kc\left(c+2\right)+2k^{2}\left(c\left(c+3\right)+3\right)\right)}{\sqrt{c\left(c\left(k-2\right)+2k\right)}\left(3c\left(k-2\right)+6k\right)}\\
 \gamma_{2} & = & \frac{c^{3}\left(k-3\right)\left(k\left(3k-16\right)+24\right)+12kc^{2}\left(k-4\right)\left(k-3\right)+6ck^{2}\left(3k-14\right)+12k^{3}}{3c\left(c\left(k-2\right)+2k\right)^{2}}\\
 m_{d} & = & 0\\
-m_{n} & = & \sqrt{1+c}-1\end{eqnarray*}
-
+m_{n} & = & \sqrt{1+c}-1
+\end{eqnarray*}
 \end_inset
 
  where 
 \begin_inset Formula $\textrm{Ei}\left(\textrm{z}\right)$
 \end_inset
 
- is the exponential integral function.
- Also 
+ is the exponential integral function. Also 
 \begin_inset Formula \[
-h\left[X\right]=\frac{1}{2}\log\left(1+c\right)-\log\left(\frac{c}{\log\left(1+c\right)}\right)\]
-
+h\left[X\right]=\frac{1}{2}\log\left(1+c\right)-\log\left(\frac{c}{\log\left(1+c\right)}\right)
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Burr
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 c & > & 0\\
 d & > & 0\\
-k & = & \Gamma\left(d\right)\Gamma\left(1-\frac{2}{c}\right)\Gamma\left(\frac{2}{c}+d\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+d\right)\end{eqnarray*}
-
+k & = & \Gamma\left(d\right)\Gamma\left(1-\frac{2}{c}\right)\Gamma\left(\frac{2}{c}+d\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+d\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c,d\right) & = & \frac{cd}{x^{c+1}\left(1+x^{-c}\right)^{d+1}}I_{\left(0,\infty\right)}\left(x\right)\\
 F\left(x;c,d\right) & = & \left(1+x^{-c}\right)^{-d}\\
@@ -1378,83 +1557,92 @@ G\left(\alpha;c,d\right) & = & \left(\alpha^{-1/d}-1\right)^{-1/c}\\
  &  & -3\Gamma^{4}\left(1-\frac{1}{c}\right)\Gamma^{4}\left(\frac{1}{c}+d\right)+\Gamma^{3}\left(d\right)\Gamma\left(1-\frac{4}{c}\right)\Gamma\left(\frac{4}{c}+d\right)\\
  &  & \left.-4\Gamma^{2}\left(d\right)\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+d\right)\Gamma\left(\frac{3}{c}+d\right)\right]\\
 m_{d} & = & \left(\frac{cd-1}{c+1}\right)^{1/c}\,\textrm{if }cd>1\,\textrm{otherwise }0\\
-m_{n} & = & \left(2^{1/d}-1\right)^{-1/c}\end{eqnarray*}
-
+m_{n} & = & \left(2^{1/d}-1\right)^{-1/c}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Cauchy
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \frac{1}{\pi\left(1+x^{2}\right)}\\
 F\left(x\right) & = & \frac{1}{2}+\frac{1}{\pi}\tan^{-1}x\\
 G\left(\alpha\right) & = & \tan\left(\pi\alpha-\frac{\pi}{2}\right)\\
 m_{d} & = & 0\\
-m_{n} & = & 0\end{eqnarray*}
-
+m_{n} & = & 0
+\end{eqnarray*}
 \end_inset
 
-No finite moments.
- This is the t distribution with one degree of freedom.
- 
+ No finite moments. This is the t distribution with one degree of freedom. 
 \begin_inset Formula \begin{eqnarray*}
 h\left[X\right] & = & \log\left(4\pi\right)\\
- & \approx & 2.5310242469692907930.\end{eqnarray*}
-
+ & \approx & 2.5310242469692907930.
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Chi
 \end_layout
 
 \begin_layout Standard
+
 Generated by taking the (positive) square-root of chi-squared variates.
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\nu\right) & = & \frac{x^{\nu-1}e^{-x^{2}/2}}{2^{\nu/2-1}\Gamma\left(\frac{\nu}{2}\right)}I_{\left(0,\infty\right)}\left(x\right)\\
 F\left(x;\nu\right) & = & \Gamma\left(\frac{\nu}{2},\frac{x^{2}}{2}\right)\\
-G\left(\alpha;\nu\right) & = & \sqrt{2\Gamma^{-1}\left(\frac{\nu}{2},\alpha\right)}\end{eqnarray*}
-
+G\left(\alpha;\nu\right) & = & \sqrt{2\Gamma^{-1}\left(\frac{\nu}{2},\alpha\right)}
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-M\left(t\right)=\Gamma\left(\frac{v}{2}\right)\,_{1}F_{1}\left(\frac{v}{2};\frac{1}{2};\frac{t^{2}}{2}\right)+\frac{t}{\sqrt{2}}\Gamma\left(\frac{1+\nu}{2}\right)\,_{1}F_{1}\left(\frac{1+\nu}{2};\frac{3}{2};\frac{t^{2}}{2}\right)\]
-
+M\left(t\right)=\Gamma\left(\frac{v}{2}\right)\,_{1}F_{1}\left(\frac{v}{2};\frac{1}{2};\frac{t^{2}}{2}\right)+\frac{t}{\sqrt{2}}\Gamma\left(\frac{1+\nu}{2}\right)\,_{1}F_{1}\left(\frac{1+\nu}{2};\frac{3}{2};\frac{t^{2}}{2}\right)
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \frac{\sqrt{2}\Gamma\left(\frac{\nu+1}{2}\right)}{\Gamma\left(\frac{\nu}{2}\right)}\\
 \mu_{2} & = & \nu-\mu^{2}\\
 \gamma_{1} & = & \frac{2\mu^{3}+\mu\left(1-2\nu\right)}{\mu_{2}^{3/2}}\\
 \gamma_{2} & = & \frac{2\nu\left(1-\nu\right)-6\mu^{4}+4\mu^{2}\left(2\nu-1\right)}{\mu_{2}^{2}}\\
 m_{d} & = & \sqrt{\nu-1}\quad\nu\geq1\\
-m_{n} & = & \sqrt{2\Gamma^{-1}\left(\frac{\nu}{2},\frac{1}{2}\right)}\end{eqnarray*}
-
+m_{n} & = & \sqrt{2\Gamma^{-1}\left(\frac{\nu}{2},\frac{1}{2}\right)}
+\end{eqnarray*}
 \end_inset
 
- 
+
 \end_layout
 
 \begin_layout Section
+
 Chi-squared
 \end_layout
 
 \begin_layout Standard
+
 This is the gamma distribution with 
 \begin_inset Formula $L=0.0$
 \end_inset
@@ -1471,8 +1659,7 @@ This is the gamma distribution with
 \begin_inset Formula $\nu$
 \end_inset
 
- is called the degrees of freedom.
- If 
+ is called the degrees of freedom. If 
 \begin_inset Formula $Z_{1}\ldots Z_{\nu}$
 \end_inset
 
@@ -1485,26 +1672,26 @@ This is the gamma distribution with
 \end_inset
 
  degrees of freedom.
- 
 \end_layout
 
 \begin_layout Standard
+
 The standard form (most often used in standard form only) is 
 \begin_inset Formula $x>0$
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\alpha\right) & = & \frac{1}{2\Gamma\left(\frac{\nu}{2}\right)}\left(\frac{x}{2}\right)^{\nu/2-1}e^{-x/2}\\
 F\left(x;\alpha\right) & = & \Gamma\left(\frac{\nu}{2},\frac{x}{2}\right)\\
-G\left(q;\alpha\right) & = & 2\Gamma^{-1}\left(\frac{\nu}{2},q\right)\end{eqnarray*}
-
+G\left(q;\alpha\right) & = & 2\Gamma^{-1}\left(\frac{\nu}{2},q\right)
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-M\left(t\right)=\frac{\Gamma\left(\frac{\nu}{2}\right)}{\left(\frac{1}{2}-t\right)^{\nu/2}}\]
-
+M\left(t\right)=\frac{\Gamma\left(\frac{\nu}{2}\right)}{\left(\frac{1}{2}-t\right)^{\nu/2}}
+\]
 \end_inset
 
  
@@ -1513,23 +1700,26 @@ M\left(t\right)=\frac{\Gamma\left(\frac{\nu}{2}\right)}{\left(\frac{1}{2}-t\righ
 \mu_{2} & = & 2\nu\\
 \gamma_{1} & = & \frac{2\sqrt{2}}{\sqrt{\nu}}\\
 \gamma_{2} & = & \frac{12}{\nu}\\
-m_{d} & = & \frac{\nu}{2}-1\end{eqnarray*}
-
+m_{d} & = & \frac{\nu}{2}-1
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Cosine
 \end_layout
 
 \begin_layout Standard
+
 Approximation to the normal distribution.
- 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \frac{1}{2\pi}\left[1+\cos x\right]I_{\left[-\pi,\pi\right]}\left(x\right)\\
 F\left(x\right) & = & \frac{1}{2\pi}\left[\pi+x+\sin x\right]I_{\left[-\pi,\pi\right]}\left(x\right)+I_{\left(\pi,\infty\right)}\left(x\right)\\
@@ -1538,30 +1728,33 @@ M\left(t\right) & = & \frac{\sinh\left(\pi t\right)}{\pi t\left(1+t^{2}\right)}\
 \mu=m_{d}=m_{n} & = & 0\\
 \mu_{2} & = & \frac{\pi^{2}}{3}-2\\
 \gamma_{1} & = & 0\\
-\gamma_{2} & = & \frac{-6\left(\pi^{4}-90\right)}{5\left(\pi^{2}-6\right)^{2}}\end{eqnarray*}
-
+\gamma_{2} & = & \frac{-6\left(\pi^{4}-90\right)}{5\left(\pi^{2}-6\right)^{2}}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 h\left[X\right] & = & \log\left(4\pi\right)-1\\
- & \approx & 1.5310242469692907930.\end{eqnarray*}
-
+ & \approx & 1.5310242469692907930.
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Double Gamma
 \end_layout
 
 \begin_layout Standard
-The double gamma is the signed version of the Gamma distribution.
- For 
+
+The double gamma is the signed version of the Gamma distribution. For 
 \begin_inset Formula $\alpha>0:$
 \end_inset
 
@@ -1569,76 +1762,93 @@ The double gamma is the signed version of the Gamma distribution.
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\alpha\right) & = & \frac{1}{2\Gamma\left(\alpha\right)}\left|x\right|^{\alpha-1}e^{-\left|x\right|}\\
 F\left(x;\alpha\right) & = & \left\{ \begin{array}{ccc}
 \frac{1}{2}-\frac{1}{2}\Gamma\left(\alpha,\left|x\right|\right) &  & x\leq0\\
-\frac{1}{2}+\frac{1}{2}\Gamma\left(\alpha,\left|x\right|\right) &  & x>0\end{array}\right.\\
+\frac{1}{2}+\frac{1}{2}\Gamma\left(\alpha,\left|x\right|\right) &  & x>0
+\end{array}\right.\\
 G\left(q;\alpha\right) & = & \left\{ \begin{array}{ccc}
 -\Gamma^{-1}\left(\alpha,\left|2q-1\right|\right) &  & q\leq\frac{1}{2}\\
-\Gamma^{-1}\left(\alpha,\left|2q-1\right|\right) &  & q>\frac{1}{2}\end{array}\right.\end{eqnarray*}
-
+\Gamma^{-1}\left(\alpha,\left|2q-1\right|\right) &  & q>\frac{1}{2}
+\end{array}\right.
+\end{eqnarray*}
 \end_inset
 
- 
+
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \[
-M\left(t\right)=\frac{1}{2\left(1-t\right)^{a}}+\frac{1}{2\left(1+t\right)^{a}}\]
-
+M\left(t\right)=\frac{1}{2\left(1-t\right)^{a}}+\frac{1}{2\left(1+t\right)^{a}}
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 \mu=m_{n} & = & 0\\
 \mu_{2} & = & \alpha\left(\alpha+1\right)\\
 \gamma_{1} & = & 0\\
 \gamma_{2} & = & \frac{\left(\alpha+2\right)\left(\alpha+3\right)}{\alpha\left(\alpha+1\right)}-3\\
-m_{d} & = & \textrm{NA}\end{eqnarray*}
-
+m_{d} & = & \textrm{NA}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Doubly Non-central F*
 \end_layout
 
 \begin_layout Section
+
 Doubly Non-central t*
 \end_layout
 
 \begin_layout Section
+
 Double Weibull
 \end_layout
 
 \begin_layout Standard
+
 This is a signed form of the Weibull distribution.
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & \frac{c}{2}\left|x\right|^{c-1}\exp\left(-\left|x\right|^{c}\right)\\
 F\left(x;c\right) & = & \left\{ \begin{array}{ccc}
 \frac{1}{2}\exp\left(-\left|x\right|^{c}\right) &  & x\leq0\\
-1-\frac{1}{2}\exp\left(-\left|x\right|^{c}\right) &  & x>0\end{array}\right.\\
+1-\frac{1}{2}\exp\left(-\left|x\right|^{c}\right) &  & x>0
+\end{array}\right.\\
 G\left(q;c\right) & = & \left\{ \begin{array}{ccc}
 -\log^{1/c}\left(\frac{1}{2q}\right) &  & q\leq\frac{1}{2}\\
-\log^{1/c}\left(\frac{1}{2q-1}\right) &  & q>\frac{1}{2}\end{array}\right.\end{eqnarray*}
-
+\log^{1/c}\left(\frac{1}{2q-1}\right) &  & q>\frac{1}{2}
+\end{array}\right.
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
 \mu_{n}^{\prime}=\mu_{n}=\begin{cases}
 \Gamma\left(1+\frac{n}{c}\right) & n\textrm{ even}\\
-0 & n\textrm{ odd}\end{cases}\]
-
+0 & n\textrm{ odd}
+\end{cases}
+\]
 \end_inset
 
  
@@ -1647,38 +1857,39 @@ m_{d}=\mu & = & 0\\
 \mu_{2} & = & \Gamma\left(\frac{c+2}{c}\right)\\
 \gamma_{1} & = & 0\\
 \gamma_{2} & = & \frac{\Gamma\left(1+\frac{4}{c}\right)}{\Gamma^{2}\left(1+\frac{2}{c}\right)}\\
-m_{d} & = & \textrm{NA bimodal}\end{eqnarray*}
-
+m_{d} & = & \textrm{NA bimodal}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Erlang
 \end_layout
 
 \begin_layout Standard
+
 This is just the Gamma distribution with shape parameter 
 \begin_inset Formula $\alpha=n$
 \end_inset
 
  an integer.
- 
 \end_layout
 
 \begin_layout Section
+
 Exponential
 \end_layout
 
 \begin_layout Standard
-This is a special case of the Gamma (and Erlang) distributions with shape
- parameter 
+
+This is a special case of the Gamma (and Erlang) distributions with shape parameter 
 \begin_inset Formula $\left(\alpha=1\right)$
 \end_inset
 
- and the same location and scale parameters.
- The standard form is therefore (
+ and the same location and scale parameters. The standard form is therefore (
 \begin_inset Formula $x\geq0$
 \end_inset
 
@@ -1686,52 +1897,58 @@ This is a special case of the Gamma (and Erlang) distributions with shape
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & e^{-x}\\
 F\left(x\right) & = & \Gamma\left(1,x\right)=1-e^{-x}\\
-G\left(q\right) & = & -\log\left(1-q\right)\end{eqnarray*}
-
+G\left(q\right) & = & -\log\left(1-q\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-\mu_{n}^{\prime}=n!\]
 
+
+\begin_inset Formula \[
+\mu_{n}^{\prime}=n!
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-M\left(t\right)=\frac{1}{1-t}\]
 
+
+\begin_inset Formula \[
+M\left(t\right)=\frac{1}{1-t}
+\]
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & 1\\
 \mu_{2} & = & 1\\
 \gamma_{1} & = & 2\\
 \gamma_{2} & = & 6\\
-m_{d} & = & 0\end{eqnarray*}
-
+m_{d} & = & 0
+\end{eqnarray*}
 \end_inset
 
  
 \begin_inset Formula \[
-h\left[X\right]=1.\]
-
+h\left[X\right]=1.
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Exponentiated Weibull
 \end_layout
 
 \begin_layout Standard
+
 Two positive shape parameters 
 \begin_inset Formula $a$
 \end_inset
@@ -1748,24 +1965,25 @@ Two positive shape parameters
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;a,c\right) & = & ac\left[1-\exp\left(-x^{c}\right)\right]^{a-1}\exp\left(-x^{c}\right)x^{c-1}\\
 F\left(x;a,c\right) & = & \left[1-\exp\left(-x^{c}\right)\right]^{a}\\
-G\left(q;a,c\right) & = & \left[-\log\left(1-q^{1/a}\right)\right]^{1/c}\end{eqnarray*}
-
+G\left(q;a,c\right) & = & \left[-\log\left(1-q^{1/a}\right)\right]^{1/c}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Exponential Power
 \end_layout
 
 \begin_layout Standard
+
 One positive shape parameter 
 \begin_inset Formula $b$
 \end_inset
 
-.
- Defined for 
+. Defined for 
 \begin_inset Formula $x\geq0.$
 \end_inset
 
@@ -1773,18 +1991,20 @@ One positive shape parameter
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;b\right) & = & ebx^{b-1}\exp\left[x^{b}-e^{x^{b}}\right]\\
 F\left(x;b\right) & = & 1-\exp\left[1-e^{x^{b}}\right]\\
-G\left(q;b\right) & = & \log^{1/b}\left[1-\log\left(1-q\right)\right]\end{eqnarray*}
-
+G\left(q;b\right) & = & \log^{1/b}\left[1-\log\left(1-q\right)\right]
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Fatigue Life (Birnbaum-Sanders)
 \end_layout
 
 \begin_layout Standard
+
 This distribution's pdf is the average of the inverse-Gaussian 
 \begin_inset Formula $\left(\mu=1\right)$
 \end_inset
@@ -1793,8 +2013,7 @@ This distribution's pdf is the average of the inverse-Gaussian
 \begin_inset Formula $\left(\mu=1\right)$
 \end_inset
 
-.
- We follow the notation of JKB here with 
+. We follow the notation of JKB here with 
 \begin_inset Formula $\beta=S.$
 \end_inset
 
@@ -1806,39 +2025,45 @@ This distribution's pdf is the average of the inverse-Gaussian
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & \frac{x+1}{2c\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-1\right)^{2}}{2xc^{2}}\right)\\
 F\left(x;c\right) & = & \Phi\left(\frac{1}{c}\left(\sqrt{x}-\frac{1}{\sqrt{x}}\right)\right)\\
-G\left(q;c\right) & = & \frac{1}{4}\left[c\Phi^{-1}\left(q\right)+\sqrt{c^{2}\left(\Phi^{-1}\left(q\right)\right)^{2}+4}\right]^{2}\end{eqnarray*}
-
-\end_inset
-
-
-\begin_inset Formula \[
-M\left(t\right)=c\sqrt{2\pi}\exp\left[\frac{1}{c^{2}}\left(1-\sqrt{1-2c^{2}t}\right)\right]\left(1+\frac{1}{\sqrt{1-2c^{2}t}}\right)\]
-
+G\left(q;c\right) & = & \frac{1}{4}\left[c\Phi^{-1}\left(q\right)+\sqrt{c^{2}\left(\Phi^{-1}\left(q\right)\right)^{2}+4}\right]^{2}
+\end{eqnarray*}
 \end_inset
 
  
+\begin_inset Formula \[
+M\left(t\right)=c\sqrt{2\pi}\exp\left[\frac{1}{c^{2}}\left(1-\sqrt{1-2c^{2}t}\right)\right]\left(1+\frac{1}{\sqrt{1-2c^{2}t}}\right)
+\]
+\end_inset
+
+
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \frac{c^{2}}{2}+1\\
 \mu_{2} & = & c^{2}\left(\frac{5}{4}c^{2}+1\right)\\
 \gamma_{1} & = & \frac{4c\sqrt{11c^{2}+6}}{\left(5c^{2}+4\right)^{3/2}}\\
-\gamma_{2} & = & \frac{6c^{2}\left(93c^{2}+41\right)}{\left(5c^{2}+4\right)^{2}}\end{eqnarray*}
-
+\gamma_{2} & = & \frac{6c^{2}\left(93c^{2}+41\right)}{\left(5c^{2}+4\right)^{2}}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Fisk (Log Logistic)
 \end_layout
 
 \begin_layout Standard
+
 Special case of the Burr distribution with 
 \begin_inset Formula $d=1$
 \end_inset
@@ -1847,16 +2072,20 @@ Special case of the Burr distribution with
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 c & > & 0\\
-k & = & \Gamma\left(1-\frac{2}{c}\right)\Gamma\left(\frac{2}{c}+1\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+1\right)\end{eqnarray*}
-
+k & = & \Gamma\left(1-\frac{2}{c}\right)\Gamma\left(\frac{2}{c}+1\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+1\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c,d\right) & = & \frac{cx^{c-1}}{\left(1+x^{c}\right)^{2}}I_{\left(0,\infty\right)}\left(x\right)\\
 F\left(x;c,d\right) & = & \left(1+x^{-c}\right)^{-1}\\
@@ -1869,29 +2098,32 @@ G\left(\alpha;c,d\right) & = & \left(\alpha^{-1}-1\right)^{-1/c}\\
  &  & -3\Gamma^{4}\left(1-\frac{1}{c}\right)\Gamma^{4}\left(\frac{1}{c}+1\right)+\Gamma\left(1-\frac{4}{c}\right)\Gamma\left(\frac{4}{c}+1\right)\\
  &  & \left.-4\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+1\right)\Gamma\left(\frac{3}{c}+1\right)\right]\\
 m_{d} & = & \left(\frac{c-1}{c+1}\right)^{1/c}\,\textrm{if }c>1\,\textrm{otherwise }0\\
-m_{n} & = & 1\end{eqnarray*}
-
+m_{n} & = & 1
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]=2-\log c.\]
 
+
+\begin_inset Formula \[
+h\left[X\right]=2-\log c.
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Folded Cauchy
 \end_layout
 
 \begin_layout Standard
-This formula can be expressed in terms of the standard formulas for the
- Cauchy distribution (call the cdf 
+
+This formula can be expressed in terms of the standard formulas for the Cauchy distribution (call the cdf 
 \begin_inset Formula $C\left(x\right)$
 \end_inset
 
@@ -1899,8 +2131,7 @@ This formula can be expressed in terms of the standard formulas for the
 \begin_inset Formula $d\left(x\right)$
 \end_inset
 
-).
- if 
+). if 
 \begin_inset Formula $Y$
 \end_inset
 
@@ -1908,8 +2139,7 @@ This formula can be expressed in terms of the standard formulas for the
 \begin_inset Formula $\left|Y\right|$
 \end_inset
 
- is folded cauchy.
- Note that 
+ is folded cauchy. Note that 
 \begin_inset Formula $x\geq0.$
 \end_inset
 
@@ -1917,22 +2147,25 @@ This formula can be expressed in terms of the standard formulas for the
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & \frac{1}{\pi\left(1+\left(x-c\right)^{2}\right)}+\frac{1}{\pi\left(1+\left(x+c\right)^{2}\right)}\\
 F\left(x;c\right) & = & \frac{1}{\pi}\tan^{-1}\left(x-c\right)+\frac{1}{\pi}\tan^{-1}\left(x+c\right)\\
-G\left(q;c\right) & = & F^{-1}\left(x;c\right)\end{eqnarray*}
-
+G\left(q;c\right) & = & F^{-1}\left(x;c\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
 No moments
 \end_layout
 
 \begin_layout Section
+
 Folded Normal
 \end_layout
 
 \begin_layout Standard
+
 If 
 \begin_inset Formula $Z$
 \end_inset
@@ -1961,9 +2194,7 @@ If
 \begin_inset Formula $S$
 \end_inset
 
-.
- This is a special case of the non-central chi distribution with one-degree
- of freedom and non-centrality parameter 
+. This is a special case of the non-central chi distribution with one-degree of freedom and non-centrality parameter 
 \begin_inset Formula $c^{2}.$
 \end_inset
 
@@ -1971,46 +2202,46 @@ If
 \begin_inset Formula $c\geq0$
 \end_inset
 
-.
- The standard form of the folded normal is 
+. The standard form of the folded normal is 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & \sqrt{\frac{2}{\pi}}\cosh\left(cx\right)\exp\left(-\frac{x^{2}+c^{2}}{2}\right)\\
 F\left(x;c\right) & = & \Phi\left(x-c\right)-\Phi\left(-x-c\right)=\Phi\left(x-c\right)+\Phi\left(x+c\right)-1\\
-G\left(\alpha;c\right) & = & F^{-1}\left(x;c\right)\end{eqnarray*}
-
+G\left(\alpha;c\right) & = & F^{-1}\left(x;c\right)
+\end{eqnarray*}
 \end_inset
 
  
 \begin_inset Formula \[
-M\left(t\right)=\exp\left[\frac{t}{2}\left(t-2c\right)\right]\left(1+e^{2ct}\right)\]
-
+M\left(t\right)=\exp\left[\frac{t}{2}\left(t-2c\right)\right]\left(1+e^{2ct}\right)
+\]
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 k & = & \textrm{erf}\left(\frac{c}{\sqrt{2}}\right)\\
 p & = & \exp\left(-\frac{c^{2}}{2}\right)\\
 \mu & = & \sqrt{\frac{2}{\pi}}p+ck\\
 \mu_{2} & = & c^{2}+1-\mu^{2}\\
 \gamma_{1} & = & \frac{\sqrt{\frac{2}{\pi}}p^{3}\left(4-\frac{\pi}{p^{2}}\left(2c^{2}+1\right)\right)+2ck\left(6p^{2}+3cpk\sqrt{2\pi}+\pi c\left(k^{2}-1\right)\right)}{\pi\mu_{2}^{3/2}}\\
-\gamma_{2} & = & \frac{c^{4}+6c^{2}+3+6\left(c^{2}+1\right)\mu^{2}-3\mu^{4}-4p\mu\left(\sqrt{\frac{2}{\pi}}\left(c^{2}+2\right)+\frac{ck}{p}\left(c^{2}+3\right)\right)}{\mu_{2}^{2}}\end{eqnarray*}
-
+\gamma_{2} & = & \frac{c^{4}+6c^{2}+3+6\left(c^{2}+1\right)\mu^{2}-3\mu^{4}-4p\mu\left(\sqrt{\frac{2}{\pi}}\left(c^{2}+2\right)+\frac{ck}{p}\left(c^{2}+3\right)\right)}{\mu_{2}^{2}}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Fratio (or F)
 \end_layout
 
 \begin_layout Standard
+
 Defined for 
 \begin_inset Formula $x>0$
 \end_inset
 
-.
- The distribution of 
+. The distribution of 
 \begin_inset Formula $\left(X_{1}/X_{2}\right)\left(\nu_{2}/\nu_{1}\right)$
 \end_inset
 
@@ -2030,34 +2261,34 @@ Defined for
 \begin_inset Formula $v_{2}$
 \end_inset
 
- degrees of freedom.
- 
+ degrees of freedom. 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\nu_{1},\nu_{2}\right) & = & \frac{\nu_{2}^{\nu_{2}/2}\nu_{1}^{\nu_{1}/2}x^{\nu_{1}/2-1}}{\left(\nu_{2}+\nu_{1}x\right)^{\left(\nu_{1}+\nu_{2}\right)/2}B\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2}\right)}\\
 F\left(x;v_{1},v_{2}\right) & = & I\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2},\frac{\nu_{2}x}{\nu_{2}+\nu_{1}x}\right)\\
-G\left(q;\nu_{1},\nu_{2}\right) & = & \left[\frac{\nu_{2}}{I^{-1}\left(\nu_{1}/2,\nu_{2}/2,q\right)}-\frac{\nu_{1}}{\nu_{2}}\right]^{-1}.\end{eqnarray*}
-
+G\left(q;\nu_{1},\nu_{2}\right) & = & \left[\frac{\nu_{2}}{I^{-1}\left(\nu_{1}/2,\nu_{2}/2,q\right)}-\frac{\nu_{1}}{\nu_{2}}\right]^{-1}.
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \frac{\nu_{2}}{\nu_{2}-2}\quad\nu_{2}>2\\
 \mu_{2} & = & \frac{2\nu_{2}^{2}\left(\nu_{1}+\nu_{2}-2\right)}{\nu_{1}\left(\nu_{2}-2\right)^{2}\left(\nu_{2}-4\right)}\quad v_{2}>4\\
 \gamma_{1} & = & \frac{2\left(2\nu_{1}+\nu_{2}-2\right)}{\nu_{2}-6}\sqrt{\frac{2\left(\nu_{2}-4\right)}{\nu_{1}\left(\nu_{1}+\nu_{2}-2\right)}}\quad\nu_{2}>6\\
-\gamma_{2} & = & \frac{3\left[8+\left(\nu_{2}-6\right)\gamma_{1}^{2}\right]}{2\nu-16}\quad\nu_{2}>8\end{eqnarray*}
-
+\gamma_{2} & = & \frac{3\left[8+\left(\nu_{2}-6\right)\gamma_{1}^{2}\right]}{2\nu-16}\quad\nu_{2}>8
+\end{eqnarray*}
 \end_inset
 
- 
+
 \end_layout
 
 \begin_layout Section
+
 Fréchet (ExtremeLB, Extreme Value II, Weibull minimum)
 \end_layout
 
 \begin_layout Standard
-A type of extreme-value distribution with a lower bound.
- Defined for 
+
+A type of extreme-value distribution with a lower bound. Defined for 
 \begin_inset Formula $x>0$
 \end_inset
 
@@ -2069,31 +2300,31 @@ A type of extreme-value distribution with a lower bound.
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & cx^{c-1}\exp\left(-x^{c}\right)\\
 F\left(x;c\right) & = & 1-\exp\left(-x^{c}\right)\\
-G\left(q;c\right) & = & \left[-\log\left(1-q\right)\right]^{1/c}\end{eqnarray*}
-
+G\left(q;c\right) & = & \left[-\log\left(1-q\right)\right]^{1/c}
+\end{eqnarray*}
 \end_inset
 
  
 \begin_inset Formula \[
-\mu_{n}^{\prime}=\Gamma\left(1+\frac{n}{c}\right)\]
-
+\mu_{n}^{\prime}=\Gamma\left(1+\frac{n}{c}\right)
+\]
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \Gamma\left(1+\frac{1}{c}\right)\\
 \mu_{2} & = & \Gamma\left(1+\frac{2}{c}\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\\
 \gamma_{1} & = & \frac{\Gamma\left(1+\frac{3}{c}\right)-3\Gamma\left(1+\frac{2}{c}\right)\Gamma\left(1+\frac{1}{c}\right)+2\Gamma^{3}\left(1+\frac{1}{c}\right)}{\mu_{2}^{3/2}}\\
 \gamma_{2} & = & \frac{\Gamma\left(1+\frac{4}{c}\right)-4\Gamma\left(1+\frac{1}{c}\right)\Gamma\left(1+\frac{3}{c}\right)+6\Gamma^{2}\left(1+\frac{1}{c}\right)\Gamma\left(1+\frac{2}{c}\right)-\Gamma^{4}\left(1+\frac{1}{c}\right)}{\mu_{2}^{2}}-3\\
 m_{d} & = & \left(\frac{c}{1+c}\right)^{1/c}\\
-m_{n} & = & G\left(\frac{1}{2};c\right)\end{eqnarray*}
-
+m_{n} & = & G\left(\frac{1}{2};c\right)
+\end{eqnarray*}
 \end_inset
 
  
 \begin_inset Formula \[
-h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1\]
-
+h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1
+\]
 \end_inset
 
  where 
@@ -2102,18 +2333,20 @@ h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1\]
 
  is Euler's constant and equal to 
 \begin_inset Formula \[
-\gamma\approx0.57721566490153286061.\]
-
+\gamma\approx0.57721566490153286061.
+\]
 \end_inset
 
- 
+
 \end_layout
 
 \begin_layout Section
+
 Fréchet (left-skewed, Extreme Value Type III, Weibull maximum)
 \end_layout
 
 \begin_layout Standard
+
 Defined for 
 \begin_inset Formula $x<0$
 \end_inset
@@ -2122,36 +2355,39 @@ Defined for
 \begin_inset Formula $c>0$
 \end_inset
 
-.
- 
+. 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & c\left(-x\right)^{c-1}\exp\left(-\left(-x\right)^{c}\right)\\
 F\left(x;c\right) & = & \exp\left(-\left(-x\right)^{c}\right)\\
-G\left(q;c\right) & = & -\left(-\log q\right)^{1/c}\end{eqnarray*}
-
+G\left(q;c\right) & = & -\left(-\log q\right)^{1/c}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-The mean is the negative of the right-skewed Frechet distribution given
- above, and the other statistical parameters can be computed from
+
+The mean is the negative of the right-skewed Frechet distribution given above, and the other statistical parameters can be computed from
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-\mu_{n}^{\prime}=\left(-1\right)^{n}\Gamma\left(1+\frac{n}{c}\right).\]
 
+
+\begin_inset Formula \[
+\mu_{n}^{\prime}=\left(-1\right)^{n}\Gamma\left(1+\frac{n}{c}\right).
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1\]
 
+
+\begin_inset Formula \[
+h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1
+\]
 \end_inset
 
  where 
@@ -2160,18 +2396,20 @@ h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1\]
 
  is Euler's constant and equal to 
 \begin_inset Formula \[
-\gamma\approx0.57721566490153286061.\]
-
+\gamma\approx0.57721566490153286061.
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Gamma
 \end_layout
 
 \begin_layout Standard
+
 The standard form for the gamma distribution is 
 \begin_inset Formula $\left(\alpha>0\right)$
 \end_inset
@@ -2180,18 +2418,18 @@ The standard form for the gamma distribution is
 \begin_inset Formula $x\geq0$
 \end_inset
 
-.
+. 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\alpha\right) & = & \frac{1}{\Gamma\left(\alpha\right)}x^{\alpha-1}e^{-x}\\
 F\left(x;\alpha\right) & = & \Gamma\left(\alpha,x\right)\\
-G\left(q;\alpha\right) & = & \Gamma^{-1}\left(\alpha,q\right)\end{eqnarray*}
-
+G\left(q;\alpha\right) & = & \Gamma^{-1}\left(\alpha,q\right)
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-M\left(t\right)=\frac{1}{\left(1-t\right)^{\alpha}}\]
-
+M\left(t\right)=\frac{1}{\left(1-t\right)^{\alpha}}
+\]
 \end_inset
 
  
@@ -2200,35 +2438,38 @@ M\left(t\right)=\frac{1}{\left(1-t\right)^{\alpha}}\]
 \mu_{2} & = & \alpha\\
 \gamma_{1} & = & \frac{2}{\sqrt{\alpha}}\\
 \gamma_{2} & = & \frac{6}{\alpha}\\
-m_{d} & = & \alpha-1\end{eqnarray*}
-
+m_{d} & = & \alpha-1
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]=\Psi\left(a\right)\left[1-a\right]+a+\log\Gamma\left(a\right)\]
 
+
+\begin_inset Formula \[
+h\left[X\right]=\Psi\left(a\right)\left[1-a\right]+a+\log\Gamma\left(a\right)
+\]
 \end_inset
 
  where 
 \begin_inset Formula \[
-\Psi\left(a\right)=\frac{\Gamma^{\prime}\left(a\right)}{\Gamma\left(a\right)}.\]
-
+\Psi\left(a\right)=\frac{\Gamma^{\prime}\left(a\right)}{\Gamma\left(a\right)}.
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Generalized Logistic
 \end_layout
 
 \begin_layout Standard
-Has been used in the analysis of extreme values.
- Has one shape parameter 
+
+Has been used in the analysis of extreme values. Has one shape parameter 
 \begin_inset Formula $c>0.$
 \end_inset
 
@@ -2240,50 +2481,55 @@ Has been used in the analysis of extreme values.
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & \frac{c\exp\left(-x\right)}{\left[1+\exp\left(-x\right)\right]^{c+1}}\\
 F\left(x;c\right) & = & \frac{1}{\left[1+\exp\left(-x\right)\right]^{c}}\\
-G\left(q;c\right) & = & -\log\left(q^{-1/c}-1\right)\end{eqnarray*}
-
+G\left(q;c\right) & = & -\log\left(q^{-1/c}-1\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \[
-M\left(t\right)=\frac{c}{1-t}\,_{2}F_{1}\left(1+c,\,1-t\,;\,2-t\,;-1\right)\]
-
+M\left(t\right)=\frac{c}{1-t}\,_{2}F_{1}\left(1+c,\,1-t\,;\,2-t\,;-1\right)
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \gamma+\psi_{0}\left(c\right)\\
 \mu_{2} & = & \frac{\pi^{2}}{6}+\psi_{1}\left(c\right)\\
 \gamma_{1} & = & \frac{\psi_{2}\left(c\right)+2\zeta\left(3\right)}{\mu_{2}^{3/2}}\\
 \gamma_{2} & = & \frac{\left(\frac{\pi^{4}}{15}+\psi_{3}\left(c\right)\right)}{\mu_{2}^{2}}\\
 m_{d} & = & \log c\\
-m_{n} & = & -\log\left(2^{1/c}-1\right)\end{eqnarray*}
-
+m_{n} & = & -\log\left(2^{1/c}-1\right)
+\end{eqnarray*}
 \end_inset
 
  Note that the polygamma function is 
 \begin_inset Formula \begin{eqnarray*}
 \psi_{n}\left(z\right) & = & \frac{d^{n+1}}{dz^{n+1}}\log\Gamma\left(z\right)\\
  & = & \left(-1\right)^{n+1}n!\sum_{k=0}^{\infty}\frac{1}{\left(z+k\right)^{n+1}}\\
- & = & \left(-1\right)^{n+1}n!\zeta\left(n+1,z\right)\end{eqnarray*}
-
+ & = & \left(-1\right)^{n+1}n!\zeta\left(n+1,z\right)
+\end{eqnarray*}
 \end_inset
 
  where 
 \begin_inset Formula $\zeta\left(k,x\right)$
 \end_inset
 
- is a generalization of the Riemann zeta function called the Hurwitz zeta
- function Note that 
+ is a generalization of the Riemann zeta function called the Hurwitz zeta function Note that 
 \begin_inset Formula $\zeta\left(n\right)\equiv\zeta\left(n,1\right)$
 \end_inset
 
@@ -2291,10 +2537,12 @@ m_{n} & = & -\log\left(2^{1/c}-1\right)\end{eqnarray*}
 \end_layout
 
 \begin_layout Section
+
 Generalized Pareto
 \end_layout
 
 \begin_layout Standard
+
 Shape parameter 
 \begin_inset Formula $c\neq0$
 \end_inset
@@ -2315,35 +2563,40 @@ Shape parameter
 \begin_inset Formula $c$
 \end_inset
 
- is negative.
- 
+ is negative. 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & \left(1+cx\right)^{-1-\frac{1}{c}}\\
 F\left(x;c\right) & = & 1-\frac{1}{\left(1+cx\right)^{1/c}}\\
-G\left(q;c\right) & = & \frac{1}{c}\left[\left(\frac{1}{1-q}\right)^{c}-1\right]\end{eqnarray*}
-
+G\left(q;c\right) & = & \frac{1}{c}\left[\left(\frac{1}{1-q}\right)^{c}-1\right]
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \[
 M\left(t\right)=\left\{ \begin{array}{cc}
 \left(-\frac{t}{c}\right)^{\frac{1}{c}}e^{-\frac{t}{c}}\left[\Gamma\left(1-\frac{1}{c}\right)+\Gamma\left(-\frac{1}{c},-\frac{t}{c}\right)-\pi\csc\left(\frac{\pi}{c}\right)/\Gamma\left(\frac{1}{c}\right)\right] & c>0\\
-\left(\frac{\left|c\right|}{t}\right)^{1/\left|c\right|}\Gamma\left[\frac{1}{\left|c\right|},\frac{t}{\left|c\right|}\right] & c<0\end{array}\right.\]
-
+\left(\frac{\left|c\right|}{t}\right)^{1/\left|c\right|}\Gamma\left[\frac{1}{\left|c\right|},\frac{t}{\left|c\right|}\right] & c<0
+\end{array}\right.
+\]
 \end_inset
 
- 
+
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \[
 \mu_{n}^{\prime}=\frac{\left(-1\right)^{n}}{c^{n}}\sum_{k=0}^{n}\left(\begin{array}{c}
 n\\
-k\end{array}\right)\frac{\left(-1\right)^{k}}{1-ck}\quad cn<1\]
-
+k
+\end{array}\right)\frac{\left(-1\right)^{k}}{1-ck}\quad cn<1
+\]
 \end_inset
 
  
@@ -2351,36 +2604,40 @@ k\end{array}\right)\frac{\left(-1\right)^{k}}{1-ck}\quad cn<1\]
 \mu_{1}^{\prime} & = & \frac{1}{1-c}\quad c<1\\
 \mu_{2}^{\prime} & = & \frac{2}{\left(1-2c\right)\left(1-c\right)}\quad c<\frac{1}{2}\\
 \mu_{3}^{\prime} & = & \frac{6}{\left(1-c\right)\left(1-2c\right)\left(1-3c\right)}\quad c<\frac{1}{3}\\
-\mu_{4}^{\prime} & = & \frac{24}{\left(1-c\right)\left(1-2c\right)\left(1-3c\right)\left(1-4c\right)}\quad c<\frac{1}{4}\end{eqnarray*}
-
+\mu_{4}^{\prime} & = & \frac{24}{\left(1-c\right)\left(1-2c\right)\left(1-3c\right)\left(1-4c\right)}\quad c<\frac{1}{4}
+\end{eqnarray*}
 \end_inset
 
- Thus,
+ Thus, 
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \mu_{1}^{\prime}\\
 \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\
 \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
-\gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{eqnarray*}
-
+\gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]=1+c\quad c>0\]
 
+
+\begin_inset Formula \[
+h\left[X\right]=1+c\quad c>0
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Generalized Exponential
 \end_layout
 
 \begin_layout Standard
+
 Three positive shape parameters for 
 \begin_inset Formula $x\geq0.$
 \end_inset
@@ -2401,27 +2658,29 @@ Three positive shape parameters for
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;a,b,c\right) & = & \left(a+b\left(1-e^{-cx}\right)\right)\exp\left[ax-bx+\frac{b}{c}\left(1-e^{-cx}\right)\right]\\
 F\left(x;a,b,c\right) & = & 1-\exp\left[ax-bx+\frac{b}{c}\left(1-e^{-cx}\right)\right]\\
-G\left(q;a,b,c\right) & = & F^{-1}\end{eqnarray*}
-
+G\left(q;a,b,c\right) & = & F^{-1}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Generalized Extreme Value
 \end_layout
 
 \begin_layout Standard
+
 Extreme value distributions with shape parameter 
 \begin_inset Formula $c$
 \end_inset
 
 .
- 
 \end_layout
 
 \begin_layout Standard
+
 For 
 \begin_inset Formula $c>0$
 \end_inset
@@ -2434,25 +2693,26 @@ For
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & \exp\left[-\left(1-cx\right)^{1/c}\right]\left(1-cx\right)^{1/c-1}\\
 F\left(x;c\right) & = & \exp\left[-\left(1-cx\right)^{1/c}\right]\\
-G\left(q;c\right) & = & \frac{1}{c}\left[1-\left(-\log q\right)^{c}\right]\end{eqnarray*}
-
+G\left(q;c\right) & = & \frac{1}{c}\left[1-\left(-\log q\right)^{c}\right]
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
 \mu_{n}^{\prime}=\frac{1}{c^{n}}\sum_{k=0}^{n}\left(\begin{array}{c}
 n\\
-k\end{array}\right)\left(-1\right)^{k}\Gamma\left(ck+1\right)\quad cn>-1\]
-
+k
+\end{array}\right)\left(-1\right)^{k}\Gamma\left(ck+1\right)\quad cn>-1
+\]
 \end_inset
 
- So,
+ So, 
 \begin_inset Formula \begin{eqnarray*}
 \mu_{1}^{\prime} & = & \frac{1}{c}\left(1-\Gamma\left(1+c\right)\right)\quad c>-1\\
 \mu_{2}^{\prime} & = & \frac{1}{c^{2}}\left(1-2\Gamma\left(1+c\right)+\Gamma\left(1+2c\right)\right)\quad c>-\frac{1}{2}\\
 \mu_{3}^{\prime} & = & \frac{1}{c^{3}}\left(1-3\Gamma\left(1+c\right)+3\Gamma\left(1+2c\right)-\Gamma\left(1+3c\right)\right)\quad c>-\frac{1}{3}\\
-\mu_{4}^{\prime} & = & \frac{1}{c^{4}}\left(1-4\Gamma\left(1+c\right)+6\Gamma\left(1+2c\right)-4\Gamma\left(1+3c\right)+\Gamma\left(1+4c\right)\right)\quad c>-\frac{1}{4}\end{eqnarray*}
-
+\mu_{4}^{\prime} & = & \frac{1}{c^{4}}\left(1-4\Gamma\left(1+c\right)+6\Gamma\left(1+2c\right)-4\Gamma\left(1+3c\right)+\Gamma\left(1+4c\right)\right)\quad c>-\frac{1}{4}
+\end{eqnarray*}
 \end_inset
 
  For 
@@ -2471,28 +2731,29 @@ k\end{array}\right)\left(-1\right)^{k}\Gamma\left(ck+1\right)\quad cn>-1\]
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;0\right) & = & \exp\left[-e^{-x}\right]e^{-x}\\
 F\left(x;0\right) & = & \exp\left[-e^{-x}\right]\\
-G\left(q;0\right) & = & -\log\left(-\log q\right)\end{eqnarray*}
-
+G\left(q;0\right) & = & -\log\left(-\log q\right)
+\end{eqnarray*}
 \end_inset
 
- This is just the (left-skewed) Gumbel distribution for c=0.
- 
+ This is just the (left-skewed) Gumbel distribution for c=0. 
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \gamma=-\psi_{0}\left(1\right)\\
 \mu_{2} & = & \frac{\pi^{2}}{6}\\
 \gamma_{1} & = & \frac{12\sqrt{6}}{\pi^{3}}\zeta\left(3\right)\\
-\gamma_{2} & = & \frac{12}{5}\end{eqnarray*}
-
+\gamma_{2} & = & \frac{12}{5}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Generalized Gamma
 \end_layout
 
 \begin_layout Standard
+
 A general probability form that reduces to many common distributions: 
 \begin_inset Formula $x>0$
 \end_inset
@@ -2505,24 +2766,27 @@ A general probability form that reduces to many common distributions:
 \begin_inset Formula $c\neq0.$
 \end_inset
 
- 
+
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;a,c\right) & = & \frac{\left|c\right|x^{ca-1}}{\Gamma\left(a\right)}\exp\left(-x^{c}\right)\\
 F\left(x;a,c\right) & = & \begin{array}{cc}
 \frac{\Gamma\left(a,x^{c}\right)}{\Gamma\left(a\right)} & c>0\\
-1-\frac{\Gamma\left(a,x^{c}\right)}{\Gamma\left(a\right)} & c<0\end{array}\\
+1-\frac{\Gamma\left(a,x^{c}\right)}{\Gamma\left(a\right)} & c<0
+\end{array}\\
 G\left(q;a,c\right) & = & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)q\right]\right\} ^{1/c}\quad c>0\\
- &  & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)\left(1-q\right)\right]\right\} ^{1/c}\quad c<0\end{eqnarray*}
-
+ &  & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)\left(1-q\right)\right]\right\} ^{1/c}\quad c<0
+\end{eqnarray*}
 \end_inset
 
  
 \begin_inset Formula \[
-\mu_{n}^{\prime}=\frac{\Gamma\left(a+\frac{n}{c}\right)}{\Gamma\left(a\right)}\]
-
+\mu_{n}^{\prime}=\frac{\Gamma\left(a+\frac{n}{c}\right)}{\Gamma\left(a\right)}
+\]
 \end_inset
 
  
@@ -2531,8 +2795,8 @@ G\left(q;a,c\right) & = & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)q\right
 \mu_{2} & = & \frac{\Gamma\left(a+\frac{2}{c}\right)}{\Gamma\left(a\right)}-\mu^{2}\\
 \gamma_{1} & = & \frac{\Gamma\left(a+\frac{3}{c}\right)/\Gamma\left(a\right)-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
 \gamma_{2} & = & \frac{\Gamma\left(a+\frac{4}{c}\right)/\Gamma\left(a\right)-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\\
-m_{d} & = & \left(\frac{ac-1}{c}\right)^{1/c}.\end{eqnarray*}
-
+m_{d} & = & \left(\frac{ac-1}{c}\right)^{1/c}.
+\end{eqnarray*}
 \end_inset
 
  Special cases are Weibull 
@@ -2552,23 +2816,26 @@ m_{d} & = & \left(\frac{ac-1}{c}\right)^{1/c}.\end{eqnarray*}
 \end_inset
 
  then it is the inverted gamma distribution.
- 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]=a-a\Psi\left(a\right)+\frac{1}{c}\Psi\left(a\right)+\log\Gamma\left(a\right)-\log\left|c\right|.\]
 
+
+\begin_inset Formula \[
+h\left[X\right]=a-a\Psi\left(a\right)+\frac{1}{c}\Psi\left(a\right)+\log\Gamma\left(a\right)-\log\left|c\right|.
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Generalized Half-Logistic
 \end_layout
 
 \begin_layout Standard
+
 For 
 \begin_inset Formula $x\in\left[0,1/c\right]$
 \end_inset
@@ -2581,27 +2848,31 @@ For
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & \frac{2\left(1-cx\right)^{\frac{1}{c}-1}}{\left(1+\left(1-cx\right)^{1/c}\right)^{2}}\\
 F\left(x;c\right) & = & \frac{1-\left(1-cx\right)^{1/c}}{1+\left(1-cx\right)^{1/c}}\\
-G\left(q;c\right) & = & \frac{1}{c}\left[1-\left(\frac{1-q}{1+q}\right)^{c}\right]\end{eqnarray*}
-
+G\left(q;c\right) & = & \frac{1}{c}\left[1-\left(\frac{1-q}{1+q}\right)^{c}\right]
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \begin{eqnarray*}
-h\left[X\right] & = & 2-\left(2c+1\right)\log2.\end{eqnarray*}
 
+
+\begin_inset Formula \begin{eqnarray*}
+h\left[X\right] & = & 2-\left(2c+1\right)\log2.
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Gilbrat
 \end_layout
 
 \begin_layout Standard
+
 Special case of the log-normal with 
 \begin_inset Formula $\sigma=1$
 \end_inset
@@ -2618,8 +2889,8 @@ Special case of the log-normal with
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\sigma\right) & = & \frac{1}{x\sqrt{2\pi}}\exp\left[-\frac{1}{2}\left(\log x\right)^{2}\right]\\
 F\left(x;\sigma\right) & = & \Phi\left(\log x\right)=\frac{1}{2}\left[1+\textrm{erf}\left(\frac{\log x}{\sqrt{2}}\right)\right]\\
-G\left(q;\sigma\right) & = & \exp\left\{ \Phi^{-1}\left(q\right)\right\} \end{eqnarray*}
-
+G\left(q;\sigma\right) & = & \exp\left\{ \Phi^{-1}\left(q\right)\right\} 
+\end{eqnarray*}
 \end_inset
 
  
@@ -2627,28 +2898,32 @@ G\left(q;\sigma\right) & = & \exp\left\{ \Phi^{-1}\left(q\right)\right\} \end{eq
 \mu & = & \sqrt{e}\\
 \mu_{2} & = & e\left[e-1\right]\\
 \gamma_{1} & = & \sqrt{e-1}\left(2+e\right)\\
-\gamma_{2} & = & e^{4}+2e^{3}+3e^{2}-6\end{eqnarray*}
-
+\gamma_{2} & = & e^{4}+2e^{3}+3e^{2}-6
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 h\left[X\right] & = & \log\left(\sqrt{2\pi e}\right)\\
- & \approx & 1.4189385332046727418\end{eqnarray*}
-
+ & \approx & 1.4189385332046727418
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Gompertz (Truncated Gumbel)
 \end_layout
 
 \begin_layout Standard
+
 For 
 \begin_inset Formula $x\geq0$
 \end_inset
@@ -2657,8 +2932,7 @@ For
 \begin_inset Formula $c>0$
 \end_inset
 
-.
- In JKB the two shape parameters 
+. In JKB the two shape parameters 
 \begin_inset Formula $b,a$
 \end_inset
 
@@ -2666,8 +2940,7 @@ For
 \begin_inset Formula $c=b/a$
 \end_inset
 
-.
- As 
+. As 
 \begin_inset Formula $a$
 \end_inset
 
@@ -2675,8 +2948,7 @@ For
 \begin_inset Formula $a\neq0$
 \end_inset
 
-.
- If 
+. If 
 \begin_inset Formula $a=0,$
 \end_inset
 
@@ -2688,48 +2960,54 @@ For
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & ce^{x}\exp\left[-c\left(e^{x}-1\right)\right]\\
 F\left(x;c\right) & = & 1-\exp\left[-c\left(e^{x}-1\right)\right]\\
-G\left(q;c\right) & = & \log\left[1-\frac{1}{c}\log\left(1-q\right)\right]\end{eqnarray*}
-
+G\left(q;c\right) & = & \log\left[1-\frac{1}{c}\log\left(1-q\right)\right]
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]=1-\log\left(c\right)-e^{c}\textrm{Ei}\left(1,c\right),\]
 
+
+\begin_inset Formula \[
+h\left[X\right]=1-\log\left(c\right)-e^{c}\textrm{Ei}\left(1,c\right),
+\]
 \end_inset
 
-where 
+ where 
 \begin_inset Formula \[
-\textrm{Ei}\left(n,x\right)=\int_{1}^{\infty}t^{-n}\exp\left(-xt\right)dt\]
-
+\textrm{Ei}\left(n,x\right)=\int_{1}^{\infty}t^{-n}\exp\left(-xt\right)dt
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Gumbel (LogWeibull, Fisher-Tippetts, Type I Extreme Value)
 \end_layout
 
 \begin_layout Standard
+
 One of a clase of extreme value distributions (right-skewed).
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \exp\left(-\left(x+e^{-x}\right)\right)\\
 F\left(x\right) & = & \exp\left(-e^{-x}\right)\\
-G\left(q\right) & = & -\log\left(-\log\left(q\right)\right)\end{eqnarray*}
-
+G\left(q\right) & = & -\log\left(-\log\left(q\right)\right)
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-M\left(t\right)=\Gamma\left(1-t\right)\]
-
+M\left(t\right)=\Gamma\left(1-t\right)
+\]
 \end_inset
 
  
@@ -2739,64 +3017,70 @@ M\left(t\right)=\Gamma\left(1-t\right)\]
 \gamma_{1} & = & \frac{12\sqrt{6}}{\pi^{3}}\zeta\left(3\right)\\
 \gamma_{2} & = & \frac{12}{5}\\
 m_{d} & = & 0\\
-m_{n} & = & -\log\left(\log2\right)\end{eqnarray*}
-
+m_{n} & = & -\log\left(\log2\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]\approx1.0608407169541684911\]
 
+
+\begin_inset Formula \[
+h\left[X\right]\approx1.0608407169541684911
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Gumbel Left-skewed (for minimum order statistic)
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \exp\left(x-e^{x}\right)\\
 F\left(x\right) & = & 1-\exp\left(-e^{x}\right)\\
-G\left(q\right) & = & \log\left(-\log\left(1-q\right)\right)\end{eqnarray*}
-
+G\left(q\right) & = & \log\left(-\log\left(1-q\right)\right)
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-M\left(t\right)=\Gamma\left(1+t\right)\]
-
+M\left(t\right)=\Gamma\left(1+t\right)
+\]
 \end_inset
 
  Note, that 
 \begin_inset Formula $\mu$
 \end_inset
 
- is negative the mean for the right-skewed distribution.
- Similar for median and mode.
- All other moments are the same.
- 
+ is negative the mean for the right-skewed distribution. Similar for median and mode. All other moments are the same.
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]\approx1.0608407169541684911.\]
 
+
+\begin_inset Formula \[
+h\left[X\right]\approx1.0608407169541684911.
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 HalfCauchy
 \end_layout
 
 \begin_layout Standard
+
 If 
 \begin_inset Formula $Z$
 \end_inset
@@ -2805,8 +3089,7 @@ If
 \begin_inset Formula $e^{Z}$
 \end_inset
 
- is Half-Cauchy distributed.
- Also, if 
+ is Half-Cauchy distributed. Also, if 
 \begin_inset Formula $W$
 \end_inset
 
@@ -2814,8 +3097,7 @@ If
 \begin_inset Formula $\left|W\right|$
 \end_inset
 
- is Half-Cauchy distributed.
- Special case of the Folded Cauchy distribution with 
+ is Half-Cauchy distributed. Special case of the Folded Cauchy distribution with 
 \begin_inset Formula $c=0.$
 \end_inset
 
@@ -2823,45 +3105,50 @@ If
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \frac{2}{\pi\left(1+x^{2}\right)}I_{[0,\infty)}\left(x\right)\\
 F\left(x\right) & = & \frac{2}{\pi}\arctan\left(x\right)I_{\left[0,\infty\right]}\left(x\right)\\
-G\left(q\right) & = & \tan\left(\frac{\pi}{2}q\right)\end{eqnarray*}
-
+G\left(q\right) & = & \tan\left(\frac{\pi}{2}q\right)
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-M\left(t\right)=\cos t+\frac{2}{\pi}\left[\textrm{Si}\left(t\right)\cos t-\textrm{Ci}\left(\textrm{-}t\right)\sin t\right]\]
-
+M\left(t\right)=\cos t+\frac{2}{\pi}\left[\textrm{Si}\left(t\right)\cos t-\textrm{Ci}\left(\textrm{-}t\right)\sin t\right]
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 m_{d} & = & 0\\
-m_{n} & = & \tan\left(\frac{\pi}{4}\right)\end{eqnarray*}
-
+m_{n} & = & \tan\left(\frac{\pi}{4}\right)
+\end{eqnarray*}
 \end_inset
 
  No moments, as the integrals diverge.
- 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 h\left[X\right] & = & \log\left(2\pi\right)\\
- & \approx & 1.8378770664093454836.\end{eqnarray*}
-
+ & \approx & 1.8378770664093454836.
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 HalfNormal
 \end_layout
 
 \begin_layout Standard
+
 This is a special case of the chi distribution with 
 \begin_inset Formula $L=a$
 \end_inset
@@ -2890,59 +3177,63 @@ This is a special case of the chi distribution with
 \begin_inset Formula $\left|Z\right|$
 \end_inset
 
- is half-normal.
- The standard form is 
+ is half-normal. The standard form is 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \sqrt{\frac{2}{\pi}}e^{-x^{2}/2}I_{\left(0,\infty\right)}\left(x\right)\\
 F\left(x\right) & = & 2\Phi\left(x\right)-1\\
-G\left(q\right) & = & \Phi^{-1}\left(\frac{1+q}{2}\right)\end{eqnarray*}
-
+G\left(q\right) & = & \Phi^{-1}\left(\frac{1+q}{2}\right)
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-M\left(t\right)=\sqrt{2\pi}e^{t^{2}/2}\Phi\left(t\right)\]
-
+M\left(t\right)=\sqrt{2\pi}e^{t^{2}/2}\Phi\left(t\right)
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \sqrt{\frac{2}{\pi}}\\
 \mu_{2} & = & 1-\frac{2}{\pi}\\
 \gamma_{1} & = & \frac{\sqrt{2}\left(4-\pi\right)}{\left(\pi-2\right)^{3/2}}\\
 \gamma_{2} & = & \frac{8\left(\pi-3\right)}{\left(\pi-2\right)^{2}}\\
 m_{d} & = & 0\\
-m_{n} & = & \Phi^{-1}\left(\frac{3}{4}\right)\end{eqnarray*}
-
+m_{n} & = & \Phi^{-1}\left(\frac{3}{4}\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 h\left[X\right] & = & \log\left(\sqrt{\frac{\pi e}{2}}\right)\\
- & \approx & 0.72579135264472743239.\end{eqnarray*}
-
+ & \approx & 0.72579135264472743239.
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Half-Logistic 
 \end_layout
 
 \begin_layout Standard
+
 In the limit as 
 \begin_inset Formula $c\rightarrow\infty$
 \end_inset
 
- for the generalized half-logistic we have the half-logistic defined over
- 
+ for the generalized half-logistic we have the half-logistic defined over 
 \begin_inset Formula $x\geq0.$
 \end_inset
 
@@ -2954,28 +3245,29 @@ In the limit as
 \begin_inset Formula $X$
 \end_inset
 
- has logistic distribtution.
- 
+ has logistic distribtution. 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \frac{2e^{-x}}{\left(1+e^{-x}\right)^{2}}=\frac{1}{2}\textrm{sech}^{2}\left(\frac{x}{2}\right)\\
 F\left(x\right) & = & \frac{1-e^{-x}}{1+e^{-x}}=\tanh\left(\frac{x}{2}\right)\\
-G\left(q\right) & = & \log\left(\frac{1+q}{1-q}\right)=2\textrm{arctanh}\left(q\right)\end{eqnarray*}
-
+G\left(q\right) & = & \log\left(\frac{1+q}{1-q}\right)=2\textrm{arctanh}\left(q\right)
+\end{eqnarray*}
 \end_inset
 
- 
+
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-M\left(t\right)=1-t\psi_{0}\left(\frac{1}{2}-\frac{t}{2}\right)+t\psi_{0}\left(1-\frac{t}{2}\right)\]
 
+
+\begin_inset Formula \[
+M\left(t\right)=1-t\psi_{0}\left(\frac{1}{2}-\frac{t}{2}\right)+t\psi_{0}\left(1-\frac{t}{2}\right)
+\]
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-\mu_{n}^{\prime}=2\left(1-2^{1-n}\right)n!\zeta\left(n\right)\quad n\neq1\]
-
+\mu_{n}^{\prime}=2\left(1-2^{1-n}\right)n!\zeta\left(n\right)\quad n\neq1
+\]
 \end_inset
 
  
@@ -2983,54 +3275,58 @@ M\left(t\right)=1-t\psi_{0}\left(\frac{1}{2}-\frac{t}{2}\right)+t\psi_{0}\left(1
 \mu_{1}^{\prime} & = & 2\log\left(2\right)\\
 \mu_{2}^{\prime} & = & 2\zeta\left(2\right)=\frac{\pi^{2}}{3}\\
 \mu_{3}^{\prime} & = & 9\zeta\left(3\right)\\
-\mu_{4}^{\prime} & = & 42\zeta\left(4\right)=\frac{7\pi^{4}}{15}\end{eqnarray*}
-
+\mu_{4}^{\prime} & = & 42\zeta\left(4\right)=\frac{7\pi^{4}}{15}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 h\left[X\right] & = & 2-\log\left(2\right)\\
- & \approx & 1.3068528194400546906.\end{eqnarray*}
-
+ & \approx & 1.3068528194400546906.
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Hyperbolic Secant
 \end_layout
 
 \begin_layout Standard
-Related to the logistic distribution and used in lifetime analysis.
- Standard form is (defined over all 
+
+Related to the logistic distribution and used in lifetime analysis. Standard form is (defined over all 
 \begin_inset Formula $x$
 \end_inset
 
-)
+) 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \frac{1}{\pi}\textrm{sech}\left(x\right)\\
 F\left(x\right) & = & \frac{2}{\pi}\arctan\left(e^{x}\right)\\
-G\left(q\right) & = & \log\left(\tan\left(\frac{\pi}{2}q\right)\right)\end{eqnarray*}
-
+G\left(q\right) & = & \log\left(\tan\left(\frac{\pi}{2}q\right)\right)
+\end{eqnarray*}
 \end_inset
 
  
 \begin_inset Formula \[
-M\left(t\right)=\sec\left(\frac{\pi}{2}t\right)\]
-
+M\left(t\right)=\sec\left(\frac{\pi}{2}t\right)
+\]
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 \mu_{n}^{\prime} & = & \frac{1+\left(-1\right)^{n}}{2\pi2^{2n}}n!\left[\zeta\left(n+1,\frac{1}{4}\right)-\zeta\left(n+1,\frac{3}{4}\right)\right]\\
  & = & \left\{ \begin{array}{cc}
 0 & n\textrm{ odd}\\
-C_{n/2}\frac{\pi^{n}}{2^{n}} & n\textrm{ even}\end{array}\right.\end{eqnarray*}
-
+C_{n/2}\frac{\pi^{n}}{2^{n}} & n\textrm{ even}
+\end{array}\right.
+\end{eqnarray*}
 \end_inset
 
  where 
@@ -3040,11 +3336,11 @@ C_{n/2}\frac{\pi^{n}}{2^{n}} & n\textrm{ even}\end{array}\right.\end{eqnarray*}
  is an integer given by 
 \begin_inset Formula \begin{eqnarray*}
 C_{m} & = & \frac{\left(2m\right)!\left[\zeta\left(2m+1,\frac{1}{4}\right)-\zeta\left(2m+1,\frac{3}{4}\right)\right]}{\pi^{2m+1}2^{2m}}\\
- & = & 4\left(-1\right)^{m-1}\frac{16^{m}}{2m+1}B_{2m+1}\left(\frac{1}{4}\right)\end{eqnarray*}
-
+ & = & 4\left(-1\right)^{m-1}\frac{16^{m}}{2m+1}B_{2m+1}\left(\frac{1}{4}\right)
+\end{eqnarray*}
 \end_inset
 
-where 
+ where 
 \begin_inset Formula $B_{2m+1}\left(\frac{1}{4}\right)$
 \end_inset
 
@@ -3060,39 +3356,47 @@ where
 \begin_inset Formula \[
 \mu_{n}^{\prime}=\left\{ \begin{array}{cc}
 0 & n\textrm{ odd}\\
-4\left(-1\right)^{n/2-1}\frac{\left(2\pi\right)^{n}}{n+1}B_{n+1}\left(\frac{1}{4}\right) & n\textrm{ even}\end{array}\right.\]
-
+4\left(-1\right)^{n/2-1}\frac{\left(2\pi\right)^{n}}{n+1}B_{n+1}\left(\frac{1}{4}\right) & n\textrm{ even}
+\end{array}\right.
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 m_{d}=m_{n}=\mu & = & 0\\
 \mu_{2} & = & \frac{\pi^{2}}{4}\\
 \gamma_{1} & = & 0\\
-\gamma_{2} & = & 2\end{eqnarray*}
-
+\gamma_{2} & = & 2
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]=\log\left(2\pi\right).\]
 
+
+\begin_inset Formula \[
+h\left[X\right]=\log\left(2\pi\right).
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Gauss Hypergeometric 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula $x\in\left[0,1\right]$
 \end_inset
 
@@ -3100,27 +3404,29 @@ Gauss Hypergeometric
 \begin_inset Formula $\alpha>0,\,\beta>0$
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-C^{-1}=B\left(\alpha,\beta\right)\,_{2}F_{1}\left(\gamma,\alpha;\alpha+\beta;-z\right)\]
-
+C^{-1}=B\left(\alpha,\beta\right)\,_{2}F_{1}\left(\gamma,\alpha;\alpha+\beta;-z\right)
+\]
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\alpha,\beta,\gamma,z\right) & = & Cx^{\alpha-1}\frac{\left(1-x\right)^{\beta-1}}{\left(1+zx\right)^{\gamma}}\\
-\mu_{n}^{\prime} & = & \frac{B\left(n+\alpha,\beta\right)}{B\left(\alpha,\beta\right)}\frac{\,_{2}F_{1}\left(\gamma,\alpha+n;\alpha+\beta+n;-z\right)}{\,_{2}F_{1}\left(\gamma,\alpha;\alpha+\beta;-z\right)}\end{eqnarray*}
-
+\mu_{n}^{\prime} & = & \frac{B\left(n+\alpha,\beta\right)}{B\left(\alpha,\beta\right)}\frac{\,_{2}F_{1}\left(\gamma,\alpha+n;\alpha+\beta+n;-z\right)}{\,_{2}F_{1}\left(\gamma,\alpha;\alpha+\beta;-z\right)}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Inverted Gamma
 \end_layout
 
 \begin_layout Standard
+
 Special case of the generalized Gamma distribution with 
 \begin_inset Formula $c=-1$
 \end_inset
@@ -3133,21 +3439,23 @@ Special case of the generalized Gamma distribution with
 \begin_inset Formula $x>0$
 \end_inset
 
- 
+
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;a\right) & = & \frac{x^{-a-1}}{\Gamma\left(a\right)}\exp\left(-\frac{1}{x}\right)\\
 F\left(x;a\right) & = & \frac{\Gamma\left(a,\frac{1}{x}\right)}{\Gamma\left(a\right)}\\
-G\left(q;a\right) & = & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)q\right]\right\} ^{-1}\end{eqnarray*}
-
+G\left(q;a\right) & = & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)q\right]\right\} ^{-1}
+\end{eqnarray*}
 \end_inset
 
  
 \begin_inset Formula \[
-\mu_{n}^{\prime}=\frac{\Gamma\left(a-n\right)}{\Gamma\left(a\right)}\quad a>n\]
-
+\mu_{n}^{\prime}=\frac{\Gamma\left(a-n\right)}{\Gamma\left(a\right)}\quad a>n
+\]
 \end_inset
 
  
@@ -3155,33 +3463,37 @@ G\left(q;a\right) & = & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)q\right]\
 \mu & = & \frac{1}{a-1}\quad a>1\\
 \mu_{2} & = & \frac{1}{\left(a-2\right)\left(a-1\right)}-\mu^{2}\quad a>2\\
 \gamma_{1} & = & \frac{\frac{1}{\left(a-3\right)\left(a-2\right)\left(a-1\right)}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
-\gamma_{2} & = & \frac{\frac{1}{\left(a-4\right)\left(a-3\right)\left(a-2\right)\left(a-1\right)}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{eqnarray*}
-
+\gamma_{2} & = & \frac{\frac{1}{\left(a-4\right)\left(a-3\right)\left(a-2\right)\left(a-1\right)}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-m_{d}=\frac{1}{a+1}\]
-
+m_{d}=\frac{1}{a+1}
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]=a-\left(a+1\right)\Psi\left(a\right)+\log\Gamma\left(a\right).\]
 
+
+\begin_inset Formula \[
+h\left[X\right]=a-\left(a+1\right)\Psi\left(a\right)+\log\Gamma\left(a\right).
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Inverse Normal (Inverse Gaussian)
 \end_layout
 
 \begin_layout Standard
+
 The standard form involves the shape parameter 
 \begin_inset Formula $\mu$
 \end_inset
@@ -3190,8 +3502,7 @@ The standard form involves the shape parameter
 \begin_inset Formula $L=0.0$
 \end_inset
 
- is used).
- (In terms of the regress documentation 
+ is used). (In terms of the regress documentation 
 \begin_inset Formula $\mu=A/B$
 \end_inset
 
@@ -3203,8 +3514,7 @@ The standard form involves the shape parameter
 \begin_inset Formula $L$
 \end_inset
 
- is not a parameter in that distribution.
- A standard form is 
+ is not a parameter in that distribution. A standard form is 
 \begin_inset Formula $x>0$
 \end_inset
 
@@ -3212,27 +3522,30 @@ The standard form involves the shape parameter
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\mu\right) & = & \frac{1}{\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-\mu\right)^{2}}{2x\mu^{2}}\right).\\
 F\left(x;\mu\right) & = & \Phi\left(\frac{1}{\sqrt{x}}\frac{x-\mu}{\mu}\right)+\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{x+\mu}{\mu}\right)\\
-G\left(q;\mu\right) & = & F^{-1}\left(q;\mu\right)\end{eqnarray*}
-
+G\left(q;\mu\right) & = & F^{-1}\left(q;\mu\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \mu\\
 \mu_{2} & = & \mu^{3}\\
 \gamma_{1} & = & 3\sqrt{\mu}\\
 \gamma_{2} & = & 15\mu\\
-m_{d} & = & \frac{\mu}{2}\left(\sqrt{9\mu^{2}+4}-3\mu\right)\end{eqnarray*}
-
+m_{d} & = & \frac{\mu}{2}\left(\sqrt{9\mu^{2}+4}-3\mu\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
 This is related to the canonical form or JKB 
 \begin_inset Quotes eld
 \end_inset
@@ -3269,9 +3582,7 @@ two-parameter
 \begin_inset Formula $\mu_{2}$
 \end_inset
 
- is the parameter used by JKB.
- We prefer this form because of it's consistent use of the scale parameter.
- Notice that in JKB the skew 
+ is the parameter used by JKB. We prefer this form because of it's consistent use of the scale parameter. Notice that in JKB the skew 
 \begin_inset Formula $\left(\sqrt{\beta_{1}}\right)$
 \end_inset
 
@@ -3283,16 +3594,16 @@ two-parameter
 \begin_inset Formula $\mu_{2}/\lambda=\mu S/S=\mu$
 \end_inset
 
- as shown here, while the variance and mean of the standard form here are
- transformed appropriately.
- 
+ as shown here, while the variance and mean of the standard form here are transformed appropriately.
 \end_layout
 
 \begin_layout Section
+
 Inverted Weibull
 \end_layout
 
 \begin_layout Standard
+
 Shape parameter 
 \begin_inset Formula $c>0$
 \end_inset
@@ -3301,19 +3612,18 @@ Shape parameter
 \begin_inset Formula $x>0$
 \end_inset
 
-.
- Then 
+. Then 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & cx^{-c-1}\exp\left(-x^{-c}\right)\\
 F\left(x;c\right) & = & \exp\left(-x^{-c}\right)\\
-G\left(q;c\right) & = & \left(-\log q\right)^{-1/c}\end{eqnarray*}
-
+G\left(q;c\right) & = & \left(-\log q\right)^{-1/c}
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-h\left[X\right]=1+\gamma+\frac{\gamma}{c}-\log\left(c\right)\]
-
+h\left[X\right]=1+\gamma+\frac{\gamma}{c}-\log\left(c\right)
+\]
 \end_inset
 
  where 
@@ -3324,10 +3634,12 @@ h\left[X\right]=1+\gamma+\frac{\gamma}{c}-\log\left(c\right)\]
 \end_layout
 
 \begin_layout Section
+
 Johnson SB
 \end_layout
 
 \begin_layout Standard
+
 Defined for 
 \begin_inset Formula $x\in\left(0,1\right)$
 \end_inset
@@ -3344,18 +3656,20 @@ Defined for
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;a,b\right) & = & \frac{b}{x\left(1-x\right)}\phi\left(a+b\log\frac{x}{1-x}\right)\\
 F\left(x;a,b\right) & = & \Phi\left(a+b\log\frac{x}{1-x}\right)\\
-G\left(q;a,b\right) & = & \frac{1}{1+\exp\left[-\frac{1}{b}\left(\Phi^{-1}\left(q\right)-a\right)\right]}\end{eqnarray*}
-
+G\left(q;a,b\right) & = & \frac{1}{1+\exp\left[-\frac{1}{b}\left(\Phi^{-1}\left(q\right)-a\right)\right]}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Johnson SU
 \end_layout
 
 \begin_layout Standard
+
 Defined for all 
 \begin_inset Formula $x$
 \end_inset
@@ -3368,40 +3682,46 @@ Defined for all
 \begin_inset Formula $b>0$
 \end_inset
 
-.
- 
+. 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;a,b\right) & = & \frac{b}{\sqrt{x^{2}+1}}\phi\left(a+b\log\left(x+\sqrt{x^{2}+1}\right)\right)\\
 F\left(x;a,b\right) & = & \Phi\left(a+b\log\left(x+\sqrt{x^{2}+1}\right)\right)\\
-G\left(q;a,b\right) & = & \sinh\left[\frac{\Phi^{-1}\left(q\right)-a}{b}\right]\end{eqnarray*}
-
+G\left(q;a,b\right) & = & \sinh\left[\frac{\Phi^{-1}\left(q\right)-a}{b}\right]
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 KSone
 \end_layout
 
 \begin_layout Section
+
 KStwo
 \end_layout
 
 \begin_layout Section
+
 Laplace (Double Exponential, Bilateral Expoooonential)
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \frac{1}{2}e^{-\left|x\right|}\\
 F\left(x\right) & = & \left\{ \begin{array}{ccc}
 \frac{1}{2}e^{x} &  & x\leq0\\
-1-\frac{1}{2}e^{-x} &  & x>0\end{array}\right.\\
+1-\frac{1}{2}e^{-x} &  & x>0
+\end{array}\right.\\
 G\left(q\right) & = & \left\{ \begin{array}{ccc}
 \log\left(2q\right) &  & q\leq\frac{1}{2}\\
--\log\left(2-2q\right) &  & q>\frac{1}{2}\end{array}\right.\end{eqnarray*}
-
+-\log\left(2-2q\right) &  & q>\frac{1}{2}
+\end{array}\right.
+\end{eqnarray*}
 \end_inset
 
  
@@ -3409,18 +3729,19 @@ G\left(q\right) & = & \left\{ \begin{array}{ccc}
 m_{d}=m_{n}=\mu & = & 0\\
 \mu_{2} & = & 2\\
 \gamma_{1} & = & 0\\
-\gamma_{2} & = & 3\end{eqnarray*}
-
+\gamma_{2} & = & 3
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
 The ML estimator of the location parameter is 
 \begin_inset Formula \[
-\hat{L}=\textrm{median}\left(X_{i}\right)\]
-
+\hat{L}=\textrm{median}\left(X_{i}\right)
+\]
 \end_inset
 
  where 
@@ -3431,8 +3752,7 @@ The ML estimator of the location parameter is
 \begin_inset Formula $N$
 \end_inset
 
- mutually independent Laplace RV's and the median is some number between
- the 
+ mutually independent Laplace RV's and the median is some number between the 
 \begin_inset Formula $\frac{1}{2}N\textrm{th}$
 \end_inset
 
@@ -3443,17 +3763,15 @@ The ML estimator of the location parameter is
  order statistic (
 \emph on
 e.g.
-
 \emph default
  take the average of these two) when 
 \begin_inset Formula $N$
 \end_inset
 
- is even.
- Also, 
+ is even. Also, 
 \begin_inset Formula \[
-\hat{S}=\frac{1}{N}\sum_{j=1}^{N}\left|X_{j}-\hat{L}\right|.\]
-
+\hat{S}=\frac{1}{N}\sum_{j=1}^{N}\left|X_{j}-\hat{L}\right|.
+\]
 \end_inset
 
  Replace 
@@ -3464,8 +3782,7 @@ e.g.
 \begin_inset Formula $L$
 \end_inset
 
- if it is known.
- If 
+ if it is known. If 
 \begin_inset Formula $L$
 \end_inset
 
@@ -3474,24 +3791,27 @@ e.g.
 \end_inset
 
 .
- 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 h\left[X\right] & = & \log\left(2e\right)\\
- & \approx & 1.6931471805599453094.\end{eqnarray*}
-
+ & \approx & 1.6931471805599453094.
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Left-skewed Lévy
 \end_layout
 
 \begin_layout Standard
+
 Special case of Lévy-stable distribution with 
 \begin_inset Formula $\alpha=\frac{1}{2}$
 \end_inset
@@ -3504,23 +3824,24 @@ Special case of Lévy-stable distribution with
 \begin_inset Formula $x<0$
 \end_inset
 
-.
- In standard form
+. In standard form 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \frac{1}{\left|x\right|\sqrt{2\pi\left|x\right|}}\exp\left(-\frac{1}{2\left|x\right|}\right)\\
 F\left(x\right) & = & 2\Phi\left(\frac{1}{\sqrt{\left|x\right|}}\right)-1\\
-G\left(q\right) & = & -\left[\Phi^{-1}\left(\frac{q+1}{2}\right)\right]^{-2}.\end{eqnarray*}
-
+G\left(q\right) & = & -\left[\Phi^{-1}\left(\frac{q+1}{2}\right)\right]^{-2}.
+\end{eqnarray*}
 \end_inset
 
-No moments.
+ No moments.
 \end_layout
 
 \begin_layout Section
+
 Lévy
 \end_layout
 
 \begin_layout Standard
+
 A special case of Lévy-stable distributions with 
 \begin_inset Formula $\alpha=\frac{1}{2}$
 \end_inset
@@ -3529,8 +3850,7 @@ A special case of Lévy-stable distributions with
 \begin_inset Formula $\beta=1$
 \end_inset
 
-.
- In standard form it is defined for 
+. In standard form it is defined for 
 \begin_inset Formula $x>0$
 \end_inset
 
@@ -3538,18 +3858,20 @@ A special case of Lévy-stable distributions with
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \frac{1}{x\sqrt{2\pi x}}\exp\left(-\frac{1}{2x}\right)\\
 F\left(x\right) & = & 2\left[1-\Phi\left(\frac{1}{\sqrt{x}}\right)\right]\\
-G\left(q\right) & = & \left[\Phi^{-1}\left(1-\frac{q}{2}\right)\right]^{-2}.\end{eqnarray*}
-
+G\left(q\right) & = & \left[\Phi^{-1}\left(1-\frac{q}{2}\right)\right]^{-2}.
+\end{eqnarray*}
 \end_inset
 
  It has no finite moments.
 \end_layout
 
 \begin_layout Section
+
 Logistic (Sech-squared)
 \end_layout
 
 \begin_layout Standard
+
 A special case of the Generalized Logistic distribution with 
 \begin_inset Formula $c=1.$
 \end_inset
@@ -3562,44 +3884,52 @@ A special case of the Generalized Logistic distribution with
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \frac{\exp\left(-x\right)}{\left[1+\exp\left(-x\right)\right]^{2}}\\
 F\left(x\right) & = & \frac{1}{1+\exp\left(-x\right)}\\
-G\left(q\right) & = & -\log\left(1/q-1\right)\end{eqnarray*}
-
+G\left(q\right) & = & -\log\left(1/q-1\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \gamma+\psi_{0}\left(1\right)=0\\
 \mu_{2} & = & \frac{\pi^{2}}{6}+\psi_{1}\left(1\right)=\frac{\pi^{2}}{3}\\
 \gamma_{1} & = & \frac{\psi_{2}\left(c\right)+2\zeta\left(3\right)}{\mu_{2}^{3/2}}=0\\
 \gamma_{2} & = & \frac{\left(\frac{\pi^{4}}{15}+\psi_{3}\left(c\right)\right)}{\mu_{2}^{2}}=\frac{6}{5}\\
 m_{d} & = & \log1=0\\
-m_{n} & = & -\log\left(2-1\right)=0\end{eqnarray*}
-
+m_{n} & = & -\log\left(2-1\right)=0
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]=1.\]
 
+
+\begin_inset Formula \[
+h\left[X\right]=1.
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Log Double Exponential (Log-Laplace)
 \end_layout
 
 \begin_layout Standard
+
 Defined over 
 \begin_inset Formula $x>0$
 \end_inset
@@ -3612,33 +3942,40 @@ Defined over
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & \left\{ \begin{array}{ccc}
 \frac{c}{2}x^{c-1} &  & 0<x<1\\
-\frac{c}{2}x^{-c-1} &  & x\geq1\end{array}\right.\\
+\frac{c}{2}x^{-c-1} &  & x\geq1
+\end{array}\right.\\
 F\left(x;c\right) & = & \left\{ \begin{array}{ccc}
 \frac{1}{2}x^{c} &  & 0<x<1\\
-1-\frac{1}{2}x^{-c} &  & x\geq1\end{array}\right.\\
+1-\frac{1}{2}x^{-c} &  & x\geq1
+\end{array}\right.\\
 G\left(q;c\right) & = & \left\{ \begin{array}{ccc}
 \left(2q\right)^{1/c} &  & 0\leq q<\frac{1}{2}\\
-\left(2-2q\right)^{-1/c} &  & \frac{1}{2}\leq q\leq1\end{array}\right.\end{eqnarray*}
-
+\left(2-2q\right)^{-1/c} &  & \frac{1}{2}\leq q\leq1
+\end{array}\right.
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]=\log\left(\frac{2e}{c}\right)\]
 
+
+\begin_inset Formula \[
+h\left[X\right]=\log\left(\frac{2e}{c}\right)
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Log Gamma
 \end_layout
 
 \begin_layout Standard
+
 A single shape parameter 
 \begin_inset Formula $c>0$
 \end_inset
@@ -3651,39 +3988,40 @@ A single shape parameter
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & \frac{\exp\left(cx-e^{x}\right)}{\Gamma\left(c\right)}\\
 F\left(x;c\right) & = & \frac{\Gamma\left(c,e^{x}\right)}{\Gamma\left(c\right)}\\
-G\left(q;c\right) & = & \log\left[\Gamma^{-1}\left[c,q\Gamma\left(c\right)\right]\right]\end{eqnarray*}
-
+G\left(q;c\right) & = & \log\left[\Gamma^{-1}\left[c,q\Gamma\left(c\right)\right]\right]
+\end{eqnarray*}
 \end_inset
 
  
 \begin_inset Formula \[
-\mu_{n}^{\prime}=\int_{0}^{\infty}\left[\log y\right]^{n}y^{c-1}\exp\left(-y\right)dy.\]
-
+\mu_{n}^{\prime}=\int_{0}^{\infty}\left[\log y\right]^{n}y^{c-1}\exp\left(-y\right)dy.
+\]
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \mu_{1}^{\prime}\\
 \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\
 \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
-\gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{eqnarray*}
-
+\gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Log Normal (Cobb-Douglass)
 \end_layout
 
 \begin_layout Standard
+
 Has one shape parameter 
 \begin_inset Formula $\sigma$
 \end_inset
 
->0.
- (Notice that the 
+>0. (Notice that the 
 \begin_inset Quotes eld
 \end_inset
 
@@ -3703,17 +4041,16 @@ Regress
 \begin_inset Formula $A$
 \end_inset
 
- is the mean of the underlying normal distribution).
- The standard form is 
+ is the mean of the underlying normal distribution). The standard form is 
 \begin_inset Formula $x>0$
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\sigma\right) & = & \frac{1}{\sigma x\sqrt{2\pi}}\exp\left[-\frac{1}{2}\left(\frac{\log x}{\sigma}\right)^{2}\right]\\
 F\left(x;\sigma\right) & = & \Phi\left(\frac{\log x}{\sigma}\right)\\
-G\left(q;\sigma\right) & = & \exp\left\{ \sigma\Phi^{-1}\left(q\right)\right\} \end{eqnarray*}
-
+G\left(q;\sigma\right) & = & \exp\left\{ \sigma\Phi^{-1}\left(q\right)\right\} 
+\end{eqnarray*}
 \end_inset
 
  
@@ -3721,14 +4058,15 @@ G\left(q;\sigma\right) & = & \exp\left\{ \sigma\Phi^{-1}\left(q\right)\right\} \
 \mu & = & \exp\left(\sigma^{2}/2\right)\\
 \mu_{2} & = & \exp\left(\sigma^{2}\right)\left[\exp\left(\sigma^{2}\right)-1\right]\\
 \gamma_{1} & = & \sqrt{p-1}\left(2+p\right)\\
-\gamma_{2} & = & p^{4}+2p^{3}+3p^{2}-6\quad\quad p=e^{\sigma^{2}}\end{eqnarray*}
-
+\gamma_{2} & = & p^{4}+2p^{3}+3p^{2}-6\quad\quad p=e^{\sigma^{2}}
+\end{eqnarray*}
 \end_inset
 
-  
+
 \end_layout
 
 \begin_layout Standard
+
 Notice that using JKB notation we have 
 \begin_inset Formula $\theta=L,$
 \end_inset
@@ -3737,22 +4075,22 @@ Notice that using JKB notation we have
 \begin_inset Formula $\zeta=\log S$
 \end_inset
 
- and we have given the so-called antilognormal form of the distribution.
- This is more consistent with the location, scale parameter description
- of general probability distributions.
- 
+ and we have given the so-called antilognormal form of the distribution. This is more consistent with the location, scale parameter description of general probability distributions.
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]=\frac{1}{2}\left[1+\log\left(2\pi\right)+2\log\left(\sigma\right)\right].\]
 
+
+\begin_inset Formula \[
+h\left[X\right]=\frac{1}{2}\left[1+\log\left(2\pi\right)+2\log\left(\sigma\right)\right].
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
 Also, note that if 
 \begin_inset Formula $X$
 \end_inset
@@ -3785,12 +4123,13 @@ Also, note that if
 \end_layout
 
 \begin_layout Section
+
 Nakagami
 \end_layout
 
 \begin_layout Standard
-Generalization of the chi distribution.
- Shape parameter is 
+
+Generalization of the chi distribution. Shape parameter is 
 \begin_inset Formula $\nu>0.$
 \end_inset
 
@@ -3802,8 +4141,8 @@ Generalization of the chi distribution.
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\nu\right) & = & \frac{2\nu^{\nu}}{\Gamma\left(\nu\right)}x^{2\nu-1}\exp\left(-\nu x^{2}\right)\\
 F\left(x;\nu\right) & = & \Gamma\left(\nu,\nu x^{2}\right)\\
-G\left(q;\nu\right) & = & \sqrt{\frac{1}{\nu}\Gamma^{-1}\left(v,q\right)}\end{eqnarray*}
-
+G\left(q;\nu\right) & = & \sqrt{\frac{1}{\nu}\Gamma^{-1}\left(v,q\right)}
+\end{eqnarray*}
 \end_inset
 
  
@@ -3811,18 +4150,20 @@ G\left(q;\nu\right) & = & \sqrt{\frac{1}{\nu}\Gamma^{-1}\left(v,q\right)}\end{eq
 \mu & = & \frac{\Gamma\left(\nu+\frac{1}{2}\right)}{\sqrt{\nu}\Gamma\left(\nu\right)}\\
 \mu_{2} & = & \left[1-\mu^{2}\right]\\
 \gamma_{1} & = & \frac{\mu\left(1-4v\mu_{2}\right)}{2\nu\mu_{2}^{3/2}}\\
-\gamma_{2} & = & \frac{-6\mu^{4}\nu+\left(8\nu-2\right)\mu^{2}-2\nu+1}{\nu\mu_{2}^{2}}\end{eqnarray*}
-
+\gamma_{2} & = & \frac{-6\mu^{4}\nu+\left(8\nu-2\right)\mu^{2}-2\nu+1}{\nu\mu_{2}^{2}}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Noncentral beta*
 \end_layout
 
 \begin_layout Standard
+
 Defined over 
 \begin_inset Formula $x\in\left[0,1\right]$
 \end_inset
@@ -3843,23 +4184,28 @@ Defined over
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-F\left(x;a,b,c\right)=\sum_{j=0}^{\infty}\frac{e^{-c/2}\left(\frac{c}{2}\right)^{j}}{j!}I_{B}\left(a+j,b;0\right)\]
 
+
+\begin_inset Formula \[
+F\left(x;a,b,c\right)=\sum_{j=0}^{\infty}\frac{e^{-c/2}\left(\frac{c}{2}\right)^{j}}{j!}I_{B}\left(a+j,b;0\right)
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Noncentral chi*
 \end_layout
 
 \begin_layout Section
+
 Noncentral chi-squared
 \end_layout
 
 \begin_layout Standard
+
 The distribution of 
 \begin_inset Formula $\sum_{i=1}^{\nu}\left(Z_{i}+\delta_{i}\right)^{2}$
 \end_inset
@@ -3872,14 +4218,11 @@ The distribution of
 \begin_inset Formula $\delta_{i}$
 \end_inset
 
- are constants.
- 
+ are constants. 
 \begin_inset Formula $\lambda=\sum_{i=1}^{\nu}\delta_{i}^{2}>0.$
 \end_inset
 
- (In communications it is called the Marcum-Q function).
- Can be thought of as a Generalized Rayleigh-Rice distribution.
- For 
+ (In communications it is called the Marcum-Q function). Can be thought of as a Generalized Rayleigh-Rice distribution. For 
 \begin_inset Formula $x>0$
 \end_inset
 
@@ -3887,27 +4230,29 @@ The distribution of
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\nu,\lambda\right) & = & e^{-\left(\lambda+x\right)/2}\frac{1}{2}\left(\frac{x}{\lambda}\right)^{\left(\nu-2\right)/4}I_{\left(\nu-2\right)/2}\left(\sqrt{\lambda x}\right)\\
 F\left(x;\nu,\lambda\right) & = & \sum_{j=0}^{\infty}\left\{ \frac{\left(\lambda/2\right)^{j}}{j!}e^{-\lambda/2}\right\} \textrm{Pr}\left[\chi_{\nu+2j}^{2}\leq x\right]\\
-G\left(q;\nu,\lambda\right) & = & F^{-1}\left(x;\nu,\lambda\right)\end{eqnarray*}
-
+G\left(q;\nu,\lambda\right) & = & F^{-1}\left(x;\nu,\lambda\right)
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \nu+\lambda\\
 \mu_{2} & = & 2\left(\nu+2\lambda\right)\\
 \gamma_{1} & = & \frac{\sqrt{8}\left(\nu+3\lambda\right)}{\left(\nu+2\lambda\right)^{3/2}}\\
-\gamma_{2} & = & \frac{12\left(\nu+4\lambda\right)}{\left(\nu+2\lambda\right)^{2}}\end{eqnarray*}
-
+\gamma_{2} & = & \frac{12\left(\nu+4\lambda\right)}{\left(\nu+2\lambda\right)^{2}}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Noncentral F
 \end_layout
 
 \begin_layout Standard
+
 Let 
 \begin_inset Formula $\lambda>0$
 \end_inset
@@ -3920,28 +4265,32 @@ Let
 \begin_inset Formula $\nu_{2}>0.$
 \end_inset
 
- 
+
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\lambda,\nu_{1},\nu_{2}\right) & = & \exp\left[\frac{\lambda}{2}+\frac{\left(\lambda\nu_{1}x\right)}{2\left(\nu_{1}x+\nu_{2}\right)}\right]\nu_{1}^{\nu_{1}/2}\nu_{2}^{\nu_{2}/2}x^{\nu_{1}/2-1}\\
- &  & \times\left(\nu_{2}+\nu_{1}x\right)^{-\left(\nu_{1}+\nu_{2}\right)/2}\frac{\Gamma\left(\frac{\nu_{1}}{2}\right)\Gamma\left(1+\frac{\nu_{2}}{2}\right)L_{\nu_{2}/2}^{\nu_{1}/2-1}\left(-\frac{\lambda\nu_{1}x}{2\left(\nu_{1}x+\nu_{2}\right)}\right)}{B\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2}\right)\Gamma\left(\frac{\nu_{1}+\nu_{2}}{2}\right)}\end{eqnarray*}
-
+ &  & \times\left(\nu_{2}+\nu_{1}x\right)^{-\left(\nu_{1}+\nu_{2}\right)/2}\frac{\Gamma\left(\frac{\nu_{1}}{2}\right)\Gamma\left(1+\frac{\nu_{2}}{2}\right)L_{\nu_{2}/2}^{\nu_{1}/2-1}\left(-\frac{\lambda\nu_{1}x}{2\left(\nu_{1}x+\nu_{2}\right)}\right)}{B\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2}\right)\Gamma\left(\frac{\nu_{1}+\nu_{2}}{2}\right)}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Noncentral t
 \end_layout
 
 \begin_layout Standard
+
 The distribution of the ratio 
 \begin_inset Formula \[
-\frac{U+\lambda}{\chi_{\nu}/\sqrt{\nu}}\]
-
+\frac{U+\lambda}{\chi_{\nu}/\sqrt{\nu}}
+\]
 \end_inset
 
  where 
@@ -3956,8 +4305,7 @@ The distribution of the ratio
 \begin_inset Formula $\nu$
 \end_inset
 
- degrees of freedom.
- Note 
+ degrees of freedom. Note 
 \begin_inset Formula $\lambda>0$
 \end_inset
 
@@ -3965,31 +4313,33 @@ The distribution of the ratio
 \begin_inset Formula $\nu>0$
 \end_inset
 
-.
- 
+. 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\lambda,\nu\right) & = & \frac{\nu^{\nu/2}\Gamma\left(\nu+1\right)}{2^{\nu}e^{\lambda^{2}/2}\left(\nu+x^{2}\right)^{\nu/2}\Gamma\left(\nu/2\right)}\\
  &  & \times\left\{ \frac{\sqrt{2}\lambda x\,_{1}F_{1}\left(\frac{\nu}{2}+1;\frac{3}{2};\frac{\lambda^{2}x^{2}}{2\left(\nu+x^{2}\right)}\right)}{\left(\nu+x^{2}\right)\Gamma\left(\frac{\nu+1}{2}\right)}\right.\\
  &  & -\left.\frac{\,_{1}F_{1}\left(\frac{\nu+1}{2};\frac{1}{2};\frac{\lambda^{2}x^{2}}{2\left(\nu+x^{2}\right)}\right)}{\sqrt{\nu+x^{2}}\Gamma\left(\frac{\nu}{2}+1\right)}\right\} \\
  & = & \frac{\Gamma\left(\nu+1\right)}{2^{\left(\nu-1\right)/2}\sqrt{\pi\nu}\Gamma\left(\nu/2\right)}\exp\left[-\frac{\nu\lambda^{2}}{\nu+x^{2}}\right]\\
  &  & \times\left(\frac{\nu}{\nu+x^{2}}\right)^{\left(\nu-1\right)/2}Hh_{\nu}\left(-\frac{\lambda x}{\sqrt{\nu+x^{2}}}\right)\\
-F\left(x;\lambda,\nu\right) & =\end{eqnarray*}
-
+F\left(x;\lambda,\nu\right) & =
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Normal
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \frac{e^{-x^{2}/2}}{\sqrt{2\pi}}\\
 F\left(x\right) & = & \Phi\left(x\right)=\frac{1}{2}+\frac{1}{2}\textrm{erf}\left(\frac{\textrm{x}}{\sqrt{2}}\right)\\
-G\left(q\right) & = & \Phi^{-1}\left(q\right)\end{eqnarray*}
-
+G\left(q\right) & = & \Phi^{-1}\left(q\right)
+\end{eqnarray*}
 \end_inset
 
 
@@ -3997,32 +4347,38 @@ G\left(q\right) & = & \Phi^{-1}\left(q\right)\end{eqnarray*}
 
 \begin_layout Standard
 \align center
+
+
 \begin_inset Formula \begin{eqnarray*}
 m_{d}=m_{n}=\mu & = & 0\\
 \mu_{2} & = & 1\\
 \gamma_{1} & = & 0\\
-\gamma_{2} & = & 0\end{eqnarray*}
-
+\gamma_{2} & = & 0
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 h\left[X\right] & = & \log\left(\sqrt{2\pi e}\right)\\
- & \approx & 1.4189385332046727418\end{eqnarray*}
-
+ & \approx & 1.4189385332046727418
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Maxwell
 \end_layout
 
 \begin_layout Standard
+
 This is a special case of the Chi distribution with 
 \begin_inset Formula $L=0$
 \end_inset
@@ -4035,47 +4391,52 @@ This is a special case of the Chi distribution with
 \begin_inset Formula $\nu=3.$
 \end_inset
 
- 
+
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \sqrt{\frac{2}{\pi}}x^{2}e^{-x^{2}/2}I_{\left(0,\infty\right)}\left(x\right)\\
 F\left(x\right) & = & \Gamma\left(\frac{3}{2},\frac{x^{2}}{2}\right)\\
-G\left(\alpha\right) & = & \sqrt{2\Gamma^{-1}\left(\frac{3}{2},\alpha\right)}\end{eqnarray*}
-
+G\left(\alpha\right) & = & \sqrt{2\Gamma^{-1}\left(\frac{3}{2},\alpha\right)}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & 2\sqrt{\frac{2}{\pi}}\\
 \mu_{2} & = & 3-\frac{8}{\pi}\\
 \gamma_{1} & = & \sqrt{2}\frac{32-10\pi}{\left(3\pi-8\right)^{3/2}}\\
 \gamma_{2} & = & \frac{-12\pi^{2}+160\pi-384}{\left(3\pi-8\right)^{2}}\\
 m_{d} & = & \sqrt{2}\\
-m_{n} & = & \sqrt{2\Gamma^{-1}\left(\frac{3}{2},\frac{1}{2}\right)}\end{eqnarray*}
-
+m_{n} & = & \sqrt{2\Gamma^{-1}\left(\frac{3}{2},\frac{1}{2}\right)}
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-h\left[X\right]=\log\left(\sqrt{\frac{2\pi}{e}}\right)+\gamma.\]
-
+h\left[X\right]=\log\left(\sqrt{\frac{2\pi}{e}}\right)+\gamma.
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Mielke's Beta-Kappa
 \end_layout
 
 \begin_layout Standard
-A generalized F distribution.
- Two shape parameters 
+
+A generalized F distribution. Two shape parameters 
 \begin_inset Formula $\kappa$
 \end_inset
 
@@ -4087,27 +4448,28 @@ A generalized F distribution.
 \begin_inset Formula $x>0$
 \end_inset
 
-.
- The 
+. The 
 \begin_inset Formula $\beta$
 \end_inset
 
- in the DATAPLOT reference is a scale parameter.
+ in the DATAPLOT reference is a scale parameter. 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\kappa,\theta\right) & = & \frac{\kappa x^{\kappa-1}}{\left(1+x^{\theta}\right)^{1+\frac{\kappa}{\theta}}}\\
 F\left(x;\kappa,\theta\right) & = & \frac{x^{\kappa}}{\left(1+x^{\theta}\right)^{\kappa/\theta}}\\
-G\left(q;\kappa,\theta\right) & = & \left(\frac{q^{\theta/\kappa}}{1-q^{\theta/\kappa}}\right)^{1/\theta}\end{eqnarray*}
-
+G\left(q;\kappa,\theta\right) & = & \left(\frac{q^{\theta/\kappa}}{1-q^{\theta/\kappa}}\right)^{1/\theta}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Pareto
 \end_layout
 
 \begin_layout Standard
+
 For 
 \begin_inset Formula $x\geq1$
 \end_inset
@@ -4116,47 +4478,55 @@ For
 \begin_inset Formula $b>0$
 \end_inset
 
-.
- Standard form is 
+. Standard form is
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;b\right) & = & \frac{b}{x^{b+1}}\\
 F\left(x;b\right) & = & 1-\frac{1}{x^{b}}\\
-G\left(q;b\right) & = & \left(1-q\right)^{-1/b}\end{eqnarray*}
-
+G\left(q;b\right) & = & \left(1-q\right)^{-1/b}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \frac{b}{b-1}\quad b>1\\
 \mu_{2} & = & \frac{b}{\left(b-2\right)\left(b-1\right)^{2}}\quad b>2\\
 \gamma_{1} & = & \frac{2\left(b+1\right)\sqrt{b-2}}{\left(b-3\right)\sqrt{b}}\quad b>3\\
-\gamma_{2} & = & \frac{6\left(b^{3}+b^{2}-6b-2\right)}{b\left(b^{2}-7b+12\right)}\quad b>4\end{eqnarray*}
-
+\gamma_{2} & = & \frac{6\left(b^{3}+b^{2}-6b-2\right)}{b\left(b^{2}-7b+12\right)}\quad b>4
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left(X\right)=\frac{1}{c}+1-\log\left(c\right)\]
 
+
+\begin_inset Formula \[
+h\left(X\right)=\frac{1}{c}+1-\log\left(c\right)
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Pareto Second Kind (Lomax)
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula $c>0.$
 \end_inset
 
@@ -4172,27 +4542,31 @@ Pareto Second Kind (Lomax)
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & \frac{c}{\left(1+x\right)^{c+1}}\\
 F\left(x;c\right) & = & 1-\frac{1}{\left(1+x\right)^{c}}\\
-G\left(q;c\right) & = & \left(1-q\right)^{-1/c}-1\end{eqnarray*}
-
+G\left(q;c\right) & = & \left(1-q\right)^{-1/c}-1
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-h\left[X\right]=\frac{1}{c}+1-\log\left(c\right).\]
-
+h\left[X\right]=\frac{1}{c}+1-\log\left(c\right).
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Power Log Normal
 \end_layout
 
 \begin_layout Standard
+
 A generalization of the log-normal distribution 
 \begin_inset Formula $\sigma>0$
 \end_inset
@@ -4209,37 +4583,39 @@ A generalization of the log-normal distribution
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\sigma,c\right) & = & \frac{c}{x\sigma}\phi\left(\frac{\log x}{\sigma}\right)\left(\Phi\left(-\frac{\log x}{\sigma}\right)\right)^{c-1}\\
 F\left(x;\sigma,c\right) & = & 1-\left(\Phi\left(-\frac{\log x}{\sigma}\right)\right)^{c}\\
-G\left(q;\sigma,c\right) & = & \exp\left[-\sigma\Phi^{-1}\left[\left(1-q\right)^{1/c}\right]\right]\end{eqnarray*}
-
+G\left(q;\sigma,c\right) & = & \exp\left[-\sigma\Phi^{-1}\left[\left(1-q\right)^{1/c}\right]\right]
+\end{eqnarray*}
 \end_inset
 
  
 \begin_inset Formula \[
-\mu_{n}^{\prime}=\int_{0}^{1}\exp\left[-n\sigma\Phi^{-1}\left(y^{1/c}\right)\right]dy\]
-
+\mu_{n}^{\prime}=\int_{0}^{1}\exp\left[-n\sigma\Phi^{-1}\left(y^{1/c}\right)\right]dy
+\]
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \mu_{1}^{\prime}\\
 \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\
 \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
-\gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{eqnarray*}
-
+\gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3
+\end{eqnarray*}
 \end_inset
 
  This distribution reduces to the log-normal distribution when 
 \begin_inset Formula $c=1.$
 \end_inset
 
- 
+
 \end_layout
 
 \begin_layout Section
+
 Power Normal
 \end_layout
 
 \begin_layout Standard
+
 A generalization of the normal distribution, 
 \begin_inset Formula $c>0$
 \end_inset
@@ -4248,14 +4624,14 @@ A generalization of the normal distribution,
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & c\phi\left(x\right)\left(\Phi\left(-x\right)\right)^{c-1}\\
 F\left(x;c\right) & = & 1-\left(\Phi\left(-x\right)\right)^{c}\\
-G\left(q;c\right) & = & -\Phi^{-1}\left[\left(1-q\right)^{1/c}\right]\end{eqnarray*}
-
+G\left(q;c\right) & = & -\Phi^{-1}\left[\left(1-q\right)^{1/c}\right]
+\end{eqnarray*}
 \end_inset
 
  
 \begin_inset Formula \[
-\mu_{n}^{\prime}=\left(-1\right)^{n}\int_{0}^{1}\left[\Phi^{-1}\left(y^{1/c}\right)\right]^{n}dy\]
-
+\mu_{n}^{\prime}=\left(-1\right)^{n}\int_{0}^{1}\left[\Phi^{-1}\left(y^{1/c}\right)\right]^{n}dy
+\]
 \end_inset
 
  
@@ -4263,23 +4639,24 @@ G\left(q;c\right) & = & -\Phi^{-1}\left[\left(1-q\right)^{1/c}\right]\end{eqnarr
 \mu & = & \mu_{1}^{\prime}\\
 \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\
 \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
-\gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{eqnarray*}
-
+\gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3
+\end{eqnarray*}
 \end_inset
 
-For 
+ For 
 \begin_inset Formula $c=1$
 \end_inset
 
  this reduces to the normal distribution.
- 
 \end_layout
 
 \begin_layout Section
+
 Power-function 
 \end_layout
 
 \begin_layout Standard
+
 A special case of the beta distribution with 
 \begin_inset Formula $b=1$
 \end_inset
@@ -4292,15 +4669,19 @@ A special case of the beta distribution with
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-a>0\]
 
+
+\begin_inset Formula \[
+a>0
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;a\right) & = & ax^{a-1}\\
 F\left(x;a\right) & = & x^{a}\\
@@ -4309,24 +4690,26 @@ G\left(q;a\right) & = & q^{1/a}\\
 \mu_{2} & = & \frac{a\left(a+2\right)}{\left(a+1\right)^{2}}\\
 \gamma_{1} & = & 2\left(1-a\right)\sqrt{\frac{a+2}{a\left(a+3\right)}}\\
 \gamma_{2} & = & \frac{6\left(a^{3}-a^{2}-6a+2\right)}{a\left(a+3\right)\left(a+4\right)}\\
-m_{d} & = & 1\end{eqnarray*}
-
+m_{d} & = & 1
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-h\left[X\right]=1-\frac{1}{a}-\log\left(a\right)\]
-
+h\left[X\right]=1-\frac{1}{a}-\log\left(a\right)
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 R-distribution
 \end_layout
 
 \begin_layout Standard
+
 A general-purpose distribution with a variety of shapes controlled by 
 \begin_inset Formula $c>0.$
 \end_inset
@@ -4335,25 +4718,24 @@ A general-purpose distribution with a variety of shapes controlled by
 \begin_inset Formula $x\in\left[-1,1\right]$
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & \frac{\left(1-x^{2}\right)^{c/2-1}}{B\left(\frac{1}{2},\frac{c}{2}\right)}\\
-F\left(x;c\right) & = & \frac{1}{2}+\frac{x}{B\left(\frac{1}{2},\frac{c}{2}\right)}\,_{2}F_{1}\left(\frac{1}{2},1-\frac{c}{2};\frac{3}{2};x^{2}\right)\end{eqnarray*}
-
+F\left(x;c\right) & = & \frac{1}{2}+\frac{x}{B\left(\frac{1}{2},\frac{c}{2}\right)}\,_{2}F_{1}\left(\frac{1}{2},1-\frac{c}{2};\frac{3}{2};x^{2}\right)
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-\mu_{n}^{\prime}=\frac{\left(1+\left(-1\right)^{n}\right)}{2}B\left(\frac{n+1}{2},\frac{c}{2}\right)\]
-
+\mu_{n}^{\prime}=\frac{\left(1+\left(-1\right)^{n}\right)}{2}B\left(\frac{n+1}{2},\frac{c}{2}\right)
+\]
 \end_inset
 
  The R-distribution with parameter 
 \begin_inset Formula $n$
 \end_inset
 
- is the distribution of the correlation coefficient of a random sample of
- size 
+ is the distribution of the correlation coefficient of a random sample of size 
 \begin_inset Formula $n$
 \end_inset
 
@@ -4361,17 +4743,16 @@ F\left(x;c\right) & = & \frac{1}{2}+\frac{x}{B\left(\frac{1}{2},\frac{c}{2}\righ
 \begin_inset Formula $\rho=0.$
 \end_inset
 
- The mean of the standard distribution is always zero and as the sample
- size grows, the distribution's mass concentrates more closely about this
- mean.
- 
+ The mean of the standard distribution is always zero and as the sample size grows, the distribution's mass concentrates more closely about this mean.
 \end_layout
 
 \begin_layout Section
+
 Rayleigh 
 \end_layout
 
 \begin_layout Standard
+
 This is Chi distribution with 
 \begin_inset Formula $L=0.0$
 \end_inset
@@ -4384,8 +4765,7 @@ This is Chi distribution with
 \begin_inset Formula $S=S$
 \end_inset
 
- (no location parameter is generally used), the mode of the distribution
- is 
+ (no location parameter is generally used), the mode of the distribution is 
 \begin_inset Formula $S.$
 \end_inset
 
@@ -4393,8 +4773,8 @@ This is Chi distribution with
 \begin_inset Formula \begin{eqnarray*}
 f\left(r\right) & = & re^{-r^{2}/2}I_{[0,\infty)}\left(x\right)\\
 F\left(r\right) & = & 1-e^{-r^{2}/2}I_{[0,\infty)}\left(x\right)\\
-G\left(q\right) & = & \sqrt{-2\log\left(1-q\right)}\end{eqnarray*}
-
+G\left(q\right) & = & \sqrt{-2\log\left(1-q\right)}
+\end{eqnarray*}
 \end_inset
 
  
@@ -4404,33 +4784,37 @@ G\left(q\right) & = & \sqrt{-2\log\left(1-q\right)}\end{eqnarray*}
 \gamma_{1} & = & \frac{2\left(\pi-3\right)\sqrt{\pi}}{\left(4-\pi\right)^{3/2}}\\
 \gamma_{2} & = & \frac{24\pi-6\pi^{2}-16}{\left(4-\pi\right)^{2}}\\
 m_{d} & = & 1\\
-m_{n} & = & \sqrt{2\log\left(2\right)}\end{eqnarray*}
-
+m_{n} & = & \sqrt{2\log\left(2\right)}
+\end{eqnarray*}
 \end_inset
 
  
 \begin_inset Formula \[
-h\left[X\right]=\frac{\gamma}{2}+\log\left(\frac{e}{\sqrt{2}}\right).\]
-
+h\left[X\right]=\frac{\gamma}{2}+\log\left(\frac{e}{\sqrt{2}}\right).
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-\mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(\frac{n}{2}+1\right)\]
 
+
+\begin_inset Formula \[
+\mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(\frac{n}{2}+1\right)
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Rice*
 \end_layout
 
 \begin_layout Standard
+
 Defined for 
 \begin_inset Formula $x>0$
 \end_inset
@@ -4443,29 +4827,35 @@ Defined for
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;b\right) & = & x\exp\left(-\frac{x^{2}+b^{2}}{2}\right)I_{0}\left(xb\right)\\
-F\left(x;b\right) & = & \int_{0}^{x}\alpha\exp\left(-\frac{\alpha^{2}+b^{2}}{2}\right)I_{0}\left(\alpha b\right)d\alpha\end{eqnarray*}
-
+F\left(x;b\right) & = & \int_{0}^{x}\alpha\exp\left(-\frac{\alpha^{2}+b^{2}}{2}\right)I_{0}\left(\alpha b\right)d\alpha
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-\mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(1+\frac{n}{2}\right)\,_{1}F_{1}\left(-\frac{n}{2};1;-\frac{b^{2}}{2}\right)\]
 
+
+\begin_inset Formula \[
+\mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(1+\frac{n}{2}\right)\,_{1}F_{1}\left(-\frac{n}{2};1;-\frac{b^{2}}{2}\right)
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Reciprocal
 \end_layout
 
 \begin_layout Standard
+
 Shape parameters 
 \begin_inset Formula $a,b>0$
 \end_inset
@@ -4478,8 +4868,8 @@ Shape parameters
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;a,b\right) & = & \frac{1}{x\log\left(b/a\right)}\\
 F\left(x;a,b\right) & = & \frac{\log\left(x/a\right)}{\log\left(b/a\right)}\\
-G\left(q;a,b\right) & = & a\exp\left(q\log\left(b/a\right)\right)=a\left(\frac{b}{a}\right)^{q}\end{eqnarray*}
-
+G\left(q;a,b\right) & = & a\exp\left(q\log\left(b/a\right)\right)=a\left(\frac{b}{a}\right)^{q}
+\end{eqnarray*}
 \end_inset
 
  
@@ -4490,24 +4880,26 @@ d & = & \log\left(a/b\right)\\
 \gamma_{1} & = & \frac{\sqrt{2}\left[12d\left(a-b\right)^{2}+d^{2}\left(a^{2}\left(2d-9\right)+2abd+b^{2}\left(2d+9\right)\right)\right]}{3d\sqrt{a-b}\left[a\left(d-2\right)+b\left(d+2\right)\right]^{3/2}}\\
 \gamma_{2} & = & \frac{-36\left(a-b\right)^{3}+36d\left(a-b\right)^{2}\left(a+b\right)-16d^{2}\left(a^{3}-b^{3}\right)+3d^{3}\left(a^{2}+b^{2}\right)\left(a+b\right)}{3\left(a-b\right)\left[a\left(d-2\right)+b\left(d+2\right)\right]^{2}}-3\\
 m_{d} & = & a\\
-m_{n} & = & \sqrt{ab}\end{eqnarray*}
-
+m_{n} & = & \sqrt{ab}
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-h\left[X\right]=\frac{1}{2}\log\left(ab\right)+\log\left[\log\left(\frac{b}{a}\right)\right].\]
-
+h\left[X\right]=\frac{1}{2}\log\left(ab\right)+\log\left[\log\left(\frac{b}{a}\right)\right].
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Reciprocal Inverse Gaussian 
 \end_layout
 
 \begin_layout Standard
+
 The pdf is found from the inverse gaussian (IG), 
 \begin_inset Formula $f_{RIG}\left(x;\mu\right)=\frac{1}{x^{2}}f_{IG}\left(\frac{1}{x};\mu\right)$
 \end_inset
@@ -4516,45 +4908,51 @@ The pdf is found from the inverse gaussian (IG),
 \begin_inset Formula $x\geq0$
 \end_inset
 
- as 
+ as
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f_{IG}\left(x;\mu\right) & = & \frac{1}{\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-\mu\right)^{2}}{2x\mu^{2}}\right).\\
-F_{IG}\left(x;\mu\right) & = & \Phi\left(\frac{1}{\sqrt{x}}\frac{x-\mu}{\mu}\right)+\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{x+\mu}{\mu}\right)\end{eqnarray*}
-
+F_{IG}\left(x;\mu\right) & = & \Phi\left(\frac{1}{\sqrt{x}}\frac{x-\mu}{\mu}\right)+\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{x+\mu}{\mu}\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f_{RIG}\left(x;\mu\right) & = & \frac{1}{\sqrt{2\pi x}}\exp\left(-\frac{\left(1-\mu x\right)^{2}}{2x\mu^{2}}\right)\\
 F_{RIG}\left(x;\mu\right) & = & 1-F_{IG}\left(\frac{1}{x},\mu\right)\\
- & = & 1-\Phi\left(\frac{1}{\sqrt{x}}\frac{1-\mu x}{\mu}\right)-\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{1+\mu x}{\mu}\right)\end{eqnarray*}
-
+ & = & 1-\Phi\left(\frac{1}{\sqrt{x}}\frac{1-\mu x}{\mu}\right)-\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{1+\mu x}{\mu}\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Semicircular
 \end_layout
 
 \begin_layout Standard
+
 Defined on 
 \begin_inset Formula $x\in\left[-1,1\right]$
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \frac{2}{\pi}\sqrt{1-x^{2}}\\
 F\left(x\right) & = & \frac{1}{2}+\frac{1}{\pi}\left[x\sqrt{1-x^{2}}+\arcsin x\right]\\
-G\left(q\right) & = & F^{-1}\left(q\right)\end{eqnarray*}
-
+G\left(q\right) & = & F^{-1}\left(q\right)
+\end{eqnarray*}
 \end_inset
 
  
@@ -4562,28 +4960,31 @@ G\left(q\right) & = & F^{-1}\left(q\right)\end{eqnarray*}
 m_{d}=m_{n}=\mu & = & 0\\
 \mu_{2} & = & \frac{1}{4}\\
 \gamma_{1} & = & 0\\
-\gamma_{2} & = & -1\end{eqnarray*}
-
+\gamma_{2} & = & -1
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-h\left[X\right]=0.64472988584940017414.\]
-
+h\left[X\right]=0.64472988584940017414.
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Studentized Range*
 \end_layout
 
 \begin_layout Section
+
 Student t
 \end_layout
 
 \begin_layout Standard
+
 Shape parameter 
 \begin_inset Formula $\nu>0.$
 \end_inset
@@ -4596,31 +4997,37 @@ Shape parameter
 \begin_inset Formula $I^{-1}\left(a,b,I\left(a,b,x\right)\right)=x$
 \end_inset
 
- 
+
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\nu\right) & = & \frac{\Gamma\left(\frac{\nu+1}{2}\right)}{\sqrt{\pi\nu}\Gamma\left(\frac{\nu}{2}\right)\left[1+\frac{x^{2}}{\nu}\right]^{\frac{\nu+1}{2}}}\\
 F\left(x;\nu\right) & = & \left\{ \begin{array}{ccc}
 \frac{1}{2}I\left(\frac{\nu}{2},\frac{1}{2},\frac{\nu}{\nu+x^{2}}\right) &  & x\leq0\\
-1-\frac{1}{2}I\left(\frac{\nu}{2},\frac{1}{2},\frac{\nu}{\nu+x^{2}}\right) &  & x\geq0\end{array}\right.\\
+1-\frac{1}{2}I\left(\frac{\nu}{2},\frac{1}{2},\frac{\nu}{\nu+x^{2}}\right) &  & x\geq0
+\end{array}\right.\\
 G\left(q;\nu\right) & = & \left\{ \begin{array}{ccc}
 -\sqrt{\frac{\nu}{I^{-1}\left(\frac{\nu}{2},\frac{1}{2},2q\right)}-\nu} &  & q\leq\frac{1}{2}\\
-\sqrt{\frac{\nu}{I^{-1}\left(\frac{\nu}{2},\frac{1}{2},2-2q\right)}-\nu} &  & q\geq\frac{1}{2}\end{array}\right.\end{eqnarray*}
-
+\sqrt{\frac{\nu}{I^{-1}\left(\frac{\nu}{2},\frac{1}{2},2-2q\right)}-\nu} &  & q\geq\frac{1}{2}
+\end{array}\right.
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 m_{n}=m_{d}=\mu & = & 0\\
 \mu_{2} & = & \frac{\nu}{\nu-2}\quad\nu>2\\
 \gamma_{1} & = & 0\quad\nu>3\\
-\gamma_{2} & = & \frac{6}{\nu-4}\quad\nu>4\end{eqnarray*}
-
+\gamma_{2} & = & \frac{6}{\nu-4}\quad\nu>4
+\end{eqnarray*}
 \end_inset
 
  As 
@@ -4628,80 +5035,82 @@ m_{n}=m_{d}=\mu & = & 0\\
 \end_inset
 
  this distribution approaches the standard normal distribution.
- 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]=\frac{1}{4}\log\left(\frac{\pi c\Gamma^{2}\left(\frac{c}{2}\right)}{\Gamma^{2}\left(\frac{c+1}{2}\right)}\right)-\frac{\left(c+1\right)}{4}\left[\Psi\left(\frac{c}{2}\right)-cZ\left(c\right)+\pi\tan\left(\frac{\pi c}{2}\right)+\gamma+2\log2\right]\]
 
+
+\begin_inset Formula \[
+h\left[X\right]=\frac{1}{4}\log\left(\frac{\pi c\Gamma^{2}\left(\frac{c}{2}\right)}{\Gamma^{2}\left(\frac{c+1}{2}\right)}\right)-\frac{\left(c+1\right)}{4}\left[\Psi\left(\frac{c}{2}\right)-cZ\left(c\right)+\pi\tan\left(\frac{\pi c}{2}\right)+\gamma+2\log2\right]
+\]
 \end_inset
 
-where 
+ where 
 \begin_inset Formula \[
-Z\left(c\right)=\,_{3}F_{2}\left(1,1,1+\frac{c}{2};\frac{3}{2},2;1\right)=\sum_{k=0}^{\infty}\frac{k!}{k+1}\frac{\Gamma\left(\frac{c}{2}+1+k\right)}{\Gamma\left(\frac{c}{2}+1\right)}\frac{\Gamma\left(\frac{3}{2}\right)}{\Gamma\left(\frac{3}{2}+k\right)}\]
-
+Z\left(c\right)=\,_{3}F_{2}\left(1,1,1+\frac{c}{2};\frac{3}{2},2;1\right)=\sum_{k=0}^{\infty}\frac{k!}{k+1}\frac{\Gamma\left(\frac{c}{2}+1+k\right)}{\Gamma\left(\frac{c}{2}+1\right)}\frac{\Gamma\left(\frac{3}{2}\right)}{\Gamma\left(\frac{3}{2}+k\right)}
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Student Z
 \end_layout
 
 \begin_layout Standard
-The student Z distriubtion is defined over all space with one shape parameter
- 
+
+The student Z distriubtion is defined over all space with one shape parameter 
 \begin_inset Formula $\nu>0$
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\nu\right) & = & \frac{\Gamma\left(\frac{\nu}{2}\right)}{\sqrt{\pi}\Gamma\left(\frac{\nu-1}{2}\right)}\left(1+x^{2}\right)^{-\nu/2}\\
 F\left(x;\nu\right) & = & \left\{ \begin{array}{ccc}
 Q\left(x;\nu\right) &  & x\leq0\\
-1-Q\left(x;\nu\right) &  & x\geq0\end{array}\right.\\
-Q\left(x;\nu\right) & = & \frac{\left|x\right|^{1-n}\Gamma\left(\frac{n}{2}\right)\,_{2}F_{1}\left(\frac{n-1}{2},\frac{n}{2};\frac{n+1}{2};-\frac{1}{x^{2}}\right)}{2\sqrt{\pi}\Gamma\left(\frac{n+1}{2}\right)}\end{eqnarray*}
-
+1-Q\left(x;\nu\right) &  & x\geq0
+\end{array}\right.\\
+Q\left(x;\nu\right) & = & \frac{\left|x\right|^{1-n}\Gamma\left(\frac{n}{2}\right)\,_{2}F_{1}\left(\frac{n-1}{2},\frac{n}{2};\frac{n+1}{2};-\frac{1}{x^{2}}\right)}{2\sqrt{\pi}\Gamma\left(\frac{n+1}{2}\right)}
+\end{eqnarray*}
 \end_inset
 
-Interesting moments are 
+ Interesting moments are 
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & 0\\
 \sigma^{2} & = & \frac{1}{\nu-3}\\
 \gamma_{1} & = & 0\\
-\gamma_{2} & = & \frac{6}{\nu-5}.\end{eqnarray*}
-
+\gamma_{2} & = & \frac{6}{\nu-5}.
+\end{eqnarray*}
 \end_inset
 
  The moment generating function is 
 \begin_inset Formula \[
-\theta\left(t\right)=2\sqrt{\left|\frac{t}{2}\right|^{\nu-1}}\frac{K_{\left(n-1\right)/2}\left(\left|t\right|\right)}{\Gamma\left(\frac{\nu-1}{2}\right)}.\]
-
+\theta\left(t\right)=2\sqrt{\left|\frac{t}{2}\right|^{\nu-1}}\frac{K_{\left(n-1\right)/2}\left(\left|t\right|\right)}{\Gamma\left(\frac{\nu-1}{2}\right)}.
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Symmetric Power*
 \end_layout
 
 \begin_layout Section
+
 Triangular
 \end_layout
 
 \begin_layout Standard
+
 One shape parameter 
 \begin_inset Formula $c\in[0,1]$
 \end_inset
 
- giving the distance to the peak as a percentage of the total extent of
- the non-zero portion.
- The location parameter is the start of the non-zero portion, and the scale-para
-meter is the width of the non-zero portion.
- In standard form we have 
+ giving the distance to the peak as a percentage of the total extent of the non-zero portion. The location parameter is the start of the non-zero portion, and the scale-parameter is the width of the non-zero portion. In standard form we have 
 \begin_inset Formula $x\in\left[0,1\right].$
 \end_inset
 
@@ -4709,78 +5118,85 @@ meter is the width of the non-zero portion.
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;c\right) & = & \left\{ \begin{array}{ccc}
 2\frac{x}{c} &  & x<c\\
-2\frac{1-x}{1-c} &  & x\geq c\end{array}\right.\\
+2\frac{1-x}{1-c} &  & x\geq c
+\end{array}\right.\\
 F\left(x;c\right) & = & \left\{ \begin{array}{ccc}
 \frac{x^{2}}{c} &  & x<c\\
-\frac{x^{2}-2x+c}{c-1} &  & x\geq c\end{array}\right.\\
+\frac{x^{2}-2x+c}{c-1} &  & x\geq c
+\end{array}\right.\\
 G\left(q;c\right) & = & \left\{ \begin{array}{ccc}
 \sqrt{cq} &  & q<c\\
-1-\sqrt{\left(1-c\right)\left(1-q\right)} &  & q\geq c\end{array}\right.\end{eqnarray*}
-
+1-\sqrt{\left(1-c\right)\left(1-q\right)} &  & q\geq c
+\end{array}\right.
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \frac{c}{3}+\frac{1}{3}\\
 \mu_{2} & = & \frac{1-c+c^{2}}{18}\\
 \gamma_{1} & = & \frac{\sqrt{2}\left(2c-1\right)\left(c+1\right)\left(c-2\right)}{5\left(1-c+c^{2}\right)^{3/2}}\\
-\gamma_{2} & = & -\frac{3}{5}\end{eqnarray*}
-
+\gamma_{2} & = & -\frac{3}{5}
+\end{eqnarray*}
 \end_inset
 
  
 \begin_inset Formula \begin{eqnarray*}
 h\left(X\right) & = & \log\left(\frac{1}{2}\sqrt{e}\right)\\
- & \approx & -0.19314718055994530942.\end{eqnarray*}
-
+ & \approx & -0.19314718055994530942.
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Truncated Exponential
 \end_layout
 
 \begin_layout Standard
+
 This is an exponential distribution defined only over a certain region 
 \begin_inset Formula $0<x<B$
 \end_inset
 
-.
- In standard form this is 
+. In standard form this is 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;B\right) & = & \frac{e^{-x}}{1-e^{-B}}\\
 F\left(x;B\right) & = & \frac{1-e^{-x}}{1-e^{-B}}\\
-G\left(q;B\right) & = & -\log\left(1-q+qe^{-B}\right)\end{eqnarray*}
-
+G\left(q;B\right) & = & -\log\left(1-q+qe^{-B}\right)
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-\mu_{n}^{\prime}=\Gamma\left(1+n\right)-\Gamma\left(1+n,B\right)\]
-
+\mu_{n}^{\prime}=\Gamma\left(1+n\right)-\Gamma\left(1+n,B\right)
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
-\begin_inset Formula \[
-h\left[X\right]=\log\left(e^{B}-1\right)+\frac{1+e^{B}\left(B-1\right)}{1-e^{B}}.\]
 
+
+\begin_inset Formula \[
+h\left[X\right]=\log\left(e^{B}-1\right)+\frac{1+e^{B}\left(B-1\right)}{1-e^{B}}.
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Truncated Normal
 \end_layout
 
 \begin_layout Standard
-A normal distribution restricted to lie within a certain range given by
- two parameters 
+
+A normal distribution restricted to lie within a certain range given by two parameters 
 \begin_inset Formula $A$
 \end_inset
 
@@ -4788,8 +5204,7 @@ A normal distribution restricted to lie within a certain range given by
 \begin_inset Formula $B$
 \end_inset
 
-.
- Notice that this 
+. Notice that this 
 \begin_inset Formula $A$
 \end_inset
 
@@ -4801,8 +5216,7 @@ A normal distribution restricted to lie within a certain range given by
 \begin_inset Formula $x$
 \end_inset
 
- in standard form.
- For 
+ in standard form. For 
 \begin_inset Formula $x\in\left[A,B\right]$
 \end_inset
 
@@ -4810,37 +5224,40 @@ A normal distribution restricted to lie within a certain range given by
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;A,B\right) & = & \frac{\phi\left(x\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\\
 F\left(x;A,B\right) & = & \frac{\Phi\left(x\right)-\Phi\left(A\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\\
-G\left(q;A,B\right) & = & \Phi^{-1}\left[q\Phi\left(B\right)+\Phi\left(A\right)\left(1-q\right)\right]\end{eqnarray*}
-
+G\left(q;A,B\right) & = & \Phi^{-1}\left[q\Phi\left(B\right)+\Phi\left(A\right)\left(1-q\right)\right]
+\end{eqnarray*}
 \end_inset
 
  where 
 \begin_inset Formula \begin{eqnarray*}
 \phi\left(x\right) & = & \frac{1}{\sqrt{2\pi}}e^{-x^{2}/2}\\
-\Phi\left(x\right) & = & \int_{-\infty}^{x}\phi\left(u\right)du.\end{eqnarray*}
-
+\Phi\left(x\right) & = & \int_{-\infty}^{x}\phi\left(u\right)du.
+\end{eqnarray*}
 \end_inset
 
  
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \frac{\phi\left(A\right)-\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\\
-\mu_{2} & = & 1+\frac{A\phi\left(A\right)-B\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}-\left(\frac{\phi\left(A\right)-\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\right)^{2}\end{eqnarray*}
-
+\mu_{2} & = & 1+\frac{A\phi\left(A\right)-B\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}-\left(\frac{\phi\left(A\right)-\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\right)^{2}
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Tukey-Lambda
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;\lambda\right) & = & F^{\prime}\left(x;\lambda\right)=\frac{1}{G^{\prime}\left(F\left(x;\lambda\right);\lambda\right)}=\frac{1}{F^{\lambda-1}\left(x;\lambda\right)+\left[1-F\left(x;\lambda\right)\right]^{\lambda-1}}\\
 F\left(x;\lambda\right) & = & G^{-1}\left(x;\lambda\right)\\
-G\left(p;\lambda\right) & = & \frac{p^{\lambda}-\left(1-p\right)^{\lambda}}{\lambda}\end{eqnarray*}
-
+G\left(p;\lambda\right) & = & \frac{p^{\lambda}-\left(1-p\right)^{\lambda}}{\lambda}
+\end{eqnarray*}
 \end_inset
 
  
@@ -4851,8 +5268,8 @@ G\left(p;\lambda\right) & = & \frac{p^{\lambda}-\left(1-p\right)^{\lambda}}{\lam
 \gamma_{1} & = & 0\\
 \gamma_{2} & = & \frac{\mu_{4}}{\mu_{2}^{2}}-3\\
 \mu_{4} & = & \frac{3\Gamma\left(\lambda\right)\Gamma\left(\lambda+\frac{1}{2}\right)2^{-2\lambda}}{\lambda^{3}\Gamma\left(2\lambda+\frac{3}{2}\right)}+\frac{2}{\lambda^{4}\left(1+4\lambda\right)}\\
- &  & -\frac{2\sqrt{3}\Gamma\left(\lambda\right)2^{-6\lambda}3^{3\lambda}\Gamma\left(\lambda+\frac{1}{3}\right)\Gamma\left(\lambda+\frac{2}{3}\right)}{\lambda^{3}\Gamma\left(2\lambda+\frac{3}{2}\right)\Gamma\left(\lambda+\frac{1}{2}\right)}.\end{eqnarray*}
-
+ &  & -\frac{2\sqrt{3}\Gamma\left(\lambda\right)2^{-6\lambda}3^{3\lambda}\Gamma\left(\lambda+\frac{1}{3}\right)\Gamma\left(\lambda+\frac{2}{3}\right)}{\lambda^{3}\Gamma\left(2\lambda+\frac{3}{2}\right)\Gamma\left(\lambda+\frac{1}{2}\right)}.
+\end{eqnarray*}
 \end_inset
 
  Notice that the 
@@ -4863,20 +5280,24 @@ G\left(p;\lambda\right) & = & \frac{p^{\lambda}-\left(1-p\right)^{\lambda}}{\lam
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 h\left[X\right] & = & \int_{0}^{1}\log\left[G^{\prime}\left(p\right)\right]dp\\
- & = & \int_{0}^{1}\log\left[p^{\lambda-1}+\left(1-p\right)^{\lambda-1}\right]dp.\end{eqnarray*}
-
+ & = & \int_{0}^{1}\log\left[p^{\lambda-1}+\left(1-p\right)^{\lambda-1}\right]dp.
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Uniform
 \end_layout
 
 \begin_layout Standard
+
 Standard form 
 \begin_inset Formula $x\in\left(0,1\right).$
 \end_inset
@@ -4893,36 +5314,40 @@ Standard form
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & 1\\
 F\left(x\right) & = & x\\
-G\left(q\right) & = & q\end{eqnarray*}
-
+G\left(q\right) & = & q
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & \frac{1}{2}\\
 \mu_{2} & = & \frac{1}{12}\\
 \gamma_{1} & = & 0\\
-\gamma_{2} & = & -\frac{6}{5}\end{eqnarray*}
-
+\gamma_{2} & = & -\frac{6}{5}
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-h\left[X\right]=0\]
-
+h\left[X\right]=0
+\]
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Von Mises
 \end_layout
 
 \begin_layout Standard
+
 Defined for 
 \begin_inset Formula $x\in\left[-\pi,\pi\right]$
 \end_inset
@@ -4931,60 +5356,55 @@ Defined for
 \begin_inset Formula $b>0$
 \end_inset
 
-.
- Note, the PDF and CDF functions are periodic and are always defined over
- 
+. Note, the PDF and CDF functions are periodic and are always defined over 
 \begin_inset Formula $x\in\left[-\pi,\pi\right]$
 \end_inset
 
- regardless of the location parameter.
- Thus, if an input beyond this range is given, it is converted to the equivalent
- angle in this range.
- For values of 
+ regardless of the location parameter. Thus, if an input beyond this range is given, it is converted to the equivalent angle in this range. For values of 
 \begin_inset Formula $b<100$
 \end_inset
 
- the PDF and CDF formulas below are used.
- Otherwise, a normal approximation with variance 
+ the PDF and CDF formulas below are used. Otherwise, a normal approximation with variance 
 \begin_inset Formula $1/b$
 \end_inset
 
- is used.
- 
+ is used. 
 \begin_inset Formula \begin{eqnarray*}
 f\left(x;b\right) & = & \frac{e^{b\cos x}}{2\pi I_{0}\left(b\right)}\\
 F\left(x;b\right) & = & \frac{1}{2}+\frac{x}{2\pi}+\sum_{k=1}^{\infty}\frac{I_{k}\left(b\right)\sin\left(kx\right)}{I_{0}\left(b\right)\pi k}\\
-G\left(q;b\right) & = & F^{-1}\left(x;b\right)\end{eqnarray*}
-
+G\left(q;b\right) & = & F^{-1}\left(x;b\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & 0\\
 \mu_{2} & = & \int_{-\pi}^{\pi}x^{2}f\left(x;b\right)dx\\
 \gamma_{1} & = & 0\\
-\gamma_{2} & = & \frac{\int_{-\pi}^{\pi}x^{4}f\left(x;b\right)dx}{\mu_{2}^{2}}-3\end{eqnarray*}
-
+\gamma_{2} & = & \frac{\int_{-\pi}^{\pi}x^{4}f\left(x;b\right)dx}{\mu_{2}^{2}}-3
+\end{eqnarray*}
 \end_inset
 
  This can be used for defining circular variance.
- 
 \end_layout
 
 \begin_layout Section
+
 Wald 
 \end_layout
 
 \begin_layout Standard
+
 Special case of the Inverse Normal with shape parameter set to 
 \begin_inset Formula $1.0$
 \end_inset
 
-.
- Defined for 
+. Defined for 
 \begin_inset Formula $x>0$
 \end_inset
 
@@ -4992,38 +5412,45 @@ Special case of the Inverse Normal with shape parameter set to
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 f\left(x\right) & = & \frac{1}{\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-1\right)^{2}}{2x}\right).\\
 F\left(x\right) & = & \Phi\left(\frac{x-1}{\sqrt{x}}\right)+\exp\left(2\right)\Phi\left(-\frac{x+1}{\sqrt{x}}\right)\\
-G\left(q;\mu\right) & = & F^{-1}\left(q;\mu\right)\end{eqnarray*}
-
+G\left(q;\mu\right) & = & F^{-1}\left(q;\mu\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Standard
+
+
 \begin_inset Formula \begin{eqnarray*}
 \mu & = & 1\\
 \mu_{2} & = & 1\\
 \gamma_{1} & = & 3\\
 \gamma_{2} & = & 15\\
-m_{d} & = & \frac{1}{2}\left(\sqrt{13}-3\right)\end{eqnarray*}
-
+m_{d} & = & \frac{1}{2}\left(\sqrt{13}-3\right)
+\end{eqnarray*}
 \end_inset
 
 
 \end_layout
 
 \begin_layout Section
+
 Wishart*
 \end_layout
 
 \begin_layout Section
+
 Wrapped Cauchy
 \end_layout
 
 \begin_layout Standard
+
 For 
 \begin_inset Formula $x\in\left[0,2\pi\right]$
 \end_inset
@@ -5039,23 +5466,24 @@ g_{c}\left(x\right) & = & \frac{1}{\pi}\arctan\left[\frac{1+c}{1-c}\tan\left(\fr
 r_{c}\left(q\right) & = & 2\arctan\left[\frac{1-c}{1+c}\tan\left(\pi q\right)\right]\\
 F\left(x;c\right) & = & \left\{ \begin{array}{ccc}
 g_{c}\left(x\right) &  & 0\leq x<\pi\\
-1-g_{c}\left(2\pi-x\right) &  & \pi\leq x\leq2\pi\end{array}\right.\\
+1-g_{c}\left(2\pi-x\right) &  & \pi\leq x\leq2\pi
+\end{array}\right.\\
 G\left(q;c\right) & = & \left\{ \begin{array}{ccc}
 r_{c}\left(q\right) &  & 0\leq q<\frac{1}{2}\\
-2\pi-r_{c}\left(1-q\right) &  & \frac{1}{2}\leq q\leq1\end{array}\right.\end{eqnarray*}
-
+2\pi-r_{c}\left(1-q\right) &  & \frac{1}{2}\leq q\leq1
+\end{array}\right.
+\end{eqnarray*}
 \end_inset
 
-
+ 
 \begin_inset Formula \[
 \]
-
 \end_inset
 
-
+ 
 \begin_inset Formula \[
-h\left[X\right]=\log\left(2\pi\left(1-c^{2}\right)\right).\]
-
+h\left[X\right]=\log\left(2\pi\left(1-c^{2}\right)\right).
+\]
 \end_inset
 
  

--- a/doc/source/tutorial/stats/continuous.rst
+++ b/doc/source/tutorial/stats/continuous.rst
@@ -1,114 +1,113 @@
+.. _continuous-random-variables:
+
+====================================
+Continuous Statistical Distributions
+====================================
+
 Overview
 ========
 
-All distributions will have location (L) and Scale (S) parameters along
-with any shape parameters needed, the names for the shape parameters
-will vary. Standard form for the distributions will be given where
-:math:`L=0.0` and :math:`S=1.0.` The nonstandard forms can be obtained
-for the various functions using (note :math:`U` is a standard uniform
-random variate).
+All distributions will have location (L) and Scale (S) parameters
+along with any shape parameters needed, the names for the shape
+parameters will vary. Standard form for the distributions will be
+given where :math:`L=0.0` and :math:`S=1.0.` The nonstandard forms can be obtained for the various functions using
+(note :math:`U` is a standard uniform random variate).
 
-\|c\|c\|c\|
 
-Function Name & Standard Function & TransformationCumulative
-Distribution Function (CDF) & :math:`F\left(x\right)` &
-:math:`F\left(x;L,S\right)=F\left(\frac{\left(x-L\right)}{S}\right)`\ Probability
-Density Function (PDF) &
-:math:`f\left(x\right)=F^{\prime}\left(x\right)` &
-:math:`f\left(x;L,S\right)=\frac{1}{S}f\left(\frac{\left(x-L\right)}{S}\right)`\ Percent
-Point Function (PPF) & :math:`G\left(q\right)=F^{-1}\left(q\right)` &
-:math:`G\left(q;L,S\right)=L+SG\left(q\right)`\ Probability Sparsity
-Function (PSF) & :math:`g\left(q\right)=G^{\prime}\left(q\right)` &
-:math:`g\left(q;L,S\right)=Sg\left(q\right)`\ Hazard Function (HF) &
-:math:`h_{a}\left(x\right)=\frac{f\left(x\right)}{1-F\left(x\right)}` &
-:math:`h_{a}\left(x;L,S\right)=\frac{1}{S}h_{a}\left(\frac{\left(x-L\right)}{S}\right)`\ Cumulative
-Hazard Functon (CHF) & :math:`H_{a}\left(x\right)=`\ :math:`\log\frac{1}{1-F\left(x\right)}`
-&
-:math:`H_{a}\left(x;L,S\right)=H_{a}\left(\frac{\left(x-L\right)}{S}\right)`\ Survival
-Function (SF) & :math:`S\left(x\right)=1-F\left(x\right)` &
-:math:`S\left(x;L,S\right)=S\left(\frac{\left(x-L\right)}{S}\right)`\ Inverse
-Survival Function (ISF) &
-:math:`Z\left(\alpha\right)=S^{-1}\left(\alpha\right)=G\left(1-\alpha\right)`
-& :math:`Z\left(\alpha;L,S\right)=L+SZ\left(\alpha\right)`\ Moment
-Generating Function (MGF) &
-:math:`M_{Y}\left(t\right)=E\left[e^{Yt}\right]` &
-:math:`M_{X}\left(t\right)=e^{Lt}M_{Y}\left(St\right)`\ Random Variates
-& :math:`Y=G\left(U\right)` & :math:`X=L+SY`\ (Differential) Entropy &
-:math:`h\left[Y\right]=-\int f\left(y\right)\log f\left(y\right)dy` &
-:math:`h\left[X\right]=h\left[Y\right]+\log S`\ (Non-central) Moments &
-:math:`\mu_{n}^{\prime}=E\left[Y^{n}\right]` &
-:math:`E\left[X^{n}\right]=L^{n}\sum_{k=0}^{N}\left(\begin{array}{c}
-n\\
-k
-\end{array}\right)\left(\frac{S}{L}\right)^{k}\mu_{k}^{\prime}`\ Central
-Moments & :math:`\mu_{Y^{n}}=E\left[\left(Y-\mu_{Y}\right)^{n}\right]` &
-:math:`E\left[\left(X-\mu_{X}\right)^{n}\right]=S^{n}\mu_{X^{n}}=S^{n}\mu_{n}`\ mean
-(mode, median), var & :math:`\mu_{Y},\,\mu_{Y^{2}}` &
-:math:`L+S\mu,\, S^{2}\mu_{2}` skewness, kurtosis &
-:math:`\gamma_{1}=\frac{\mu_{3}}{\left(\mu_{2}\right)^{3/2}},\,`\ :math:`\gamma_{2}=\frac{\mu_{4}}{\left(\mu_{2}\right)^{2}}-3`
-& :math:`\gamma_{1},\,\gamma_{2}`
+======================================  ==============================================================================================================================  =========================================================================================================================================
+Function Name                           Standard Function                                                                                                               Transformation
+======================================  ==============================================================================================================================  =========================================================================================================================================
+Cumulative Distribution Function (CDF)  :math:`F\left(x\right)`                                                                                                         :math:`F\left(x;L,S\right)=F\left(\frac{\left(x-L\right)}{S}\right)`
+Probability Density Function (PDF)      :math:`f\left(x\right)=F^{\prime}\left(x\right)`                                                                                :math:`f\left(x;L,S\right)=\frac{1}{S}f\left(\frac{\left(x-L\right)}{S}\right)`
+Percent Point Function (PPF)            :math:`G\left(q\right)=F^{-1}\left(q\right)`                                                                                    :math:`G\left(q;L,S\right)=L+SG\left(q\right)`
+Probability Sparsity Function (PSF)     :math:`g\left(q\right)=G^{\prime}\left(q\right)`                                                                                :math:`g\left(q;L,S\right)=Sg\left(q\right)`
+Hazard Function (HF)                    :math:`h_{a}\left(x\right)=\frac{f\left(x\right)}{1-F\left(x\right)}`                                                           :math:`h_{a}\left(x;L,S\right)=\frac{1}{S}h_{a}\left(\frac{\left(x-L\right)}{S}\right)`
+Cumulative Hazard Functon (CHF)         :math:`H_{a}\left(x\right)=` :math:`\log\frac{1}{1-F\left(x\right)}`                                                            :math:`H_{a}\left(x;L,S\right)=H_{a}\left(\frac{\left(x-L\right)}{S}\right)`
+Survival Function (SF)                  :math:`S\left(x\right)=1-F\left(x\right)`                                                                                       :math:`S\left(x;L,S\right)=S\left(\frac{\left(x-L\right)}{S}\right)`
+Inverse Survival Function (ISF)         :math:`Z\left(\alpha\right)=S^{-1}\left(\alpha\right)=G\left(1-\alpha\right)`                                                   :math:`Z\left(\alpha;L,S\right)=L+SZ\left(\alpha\right)`
+Moment Generating Function (MGF)        :math:`M_{Y}\left(t\right)=E\left[e^{Yt}\right]`                                                                                :math:`M_{X}\left(t\right)=e^{Lt}M_{Y}\left(St\right)`
+Random Variates                         :math:`Y=G\left(U\right)`                                                                                                       :math:`X=L+SY`
+(Differential) Entropy                  :math:`h\left[Y\right]=-\int f\left(y\right)\log f\left(y\right)dy`                                                             :math:`h\left[X\right]=h\left[Y\right]+\log S`
+(Non-central) Moments                   :math:`\mu_{n}^{\prime}=E\left[Y^{n}\right]`                                                                                    :math:`E\left[X^{n}\right]=L^{n}\sum_{k=0}^{N}\left(\begin{array}{c} n\\ k\end{array}\right)\left(\frac{S}{L}\right)^{k}\mu_{k}^{\prime}`
+Central Moments                         :math:`\mu_{n}=E\left[\left(Y-\mu\right)^{n}\right]`                                                                            :math:`E\left[\left(X-\mu_{X}\right)^{n}\right]=S^{n}\mu_{n}`
+mean (mode, median), var                :math:`\mu,\,\mu_{2}`                                                                                                           :math:`L+S\mu,\, S^{2}\mu_{2}`
+skewness, kurtosis                      :math:`\gamma_{1}=\frac{\mu_{3}}{\left(\mu_{2}\right)^{3/2}},\,` :math:`\gamma_{2}=\frac{\mu_{4}}{\left(\mu_{2}\right)^{2}}-3`  :math:`\gamma_{1},\,\gamma_{2}`
+======================================  ==============================================================================================================================  =========================================================================================================================================
 
- 
+
+
+
+
 
 Moments
 -------
 
 Non-central moments are defined using the PDF
 
-.. math:: \mu_{n}^{\prime}=\int_{-\infty}^{\infty}x^{n}f\left(x\right)dx.
+.. math::
+   :nowrap:
 
- Note, that these can always be computed using the PPF. Substitute
-:math:`x=G\left(q\right)` in the above equation and get
+    \[ \mu_{n}^{\prime}=\int_{-\infty}^{\infty}x^{n}f\left(x\right)dx.\]
 
-.. math:: \mu_{n}^{\prime}=\int_{0}^{1}G^{n}\left(q\right)dq
-
- which may be easier to compute numerically. Note that
-:math:`q=F\left(x\right)` so that :math:`dq=f\left(x\right)dx.` Central
-moments are computed similarly :math:`\mu=\mu_{1}^{\prime}`
+Note, that these can always be computed using the PPF. Substitute :math:`x=G\left(q\right)` in the above equation and get
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu_{n} & = & \int_{-\infty}^{\infty}\left(x-\mu\right)^{n}f\left(x\right)dx\\
-    & = & \int_{0}^{1}\left(G\left(q\right)-\mu\right)^{n}dq\\
-    & = & \sum_{k=0}^{n}\left(\begin{array}{c}
-   n\\
-   k
-   \end{array}\right)\left(-\mu\right)^{k}\mu_{n-k}^{\prime}\end{aligned*}
+    \[ \mu_{n}^{\prime}=\int_{0}^{1}G^{n}\left(q\right)dq\]
+
+which may be easier to compute numerically. Note that :math:`q=F\left(x\right)` so that :math:`dq=f\left(x\right)dx.` Central moments are computed similarly :math:`\mu=\mu_{1}^{\prime}`
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu_{n} & = & \int_{-\infty}^{\infty}\left(x-\mu\right)^{n}f\left(x\right)dx\\  & = & \int_{0}^{1}\left(G\left(q\right)-\mu\right)^{n}dq\\  & = & \sum_{k=0}^{n}\left(\begin{array}{c} n\\ k\end{array}\right)\left(-\mu\right)^{k}\mu_{n-k}^{\prime}\end{eqnarray*}
 
 In particular
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu_{3} & = & \mu_{3}^{\prime}-3\mu\mu_{2}^{\prime}+2\mu^{3}\\
-    & = & \mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}\\
-   \mu_{4} & = & \mu_{4}^{\prime}-4\mu\mu_{3}^{\prime}+6\mu^{2}\mu_{2}^{\prime}-3\mu^{4}\\
-    & = & \mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}\end{aligned*}
+    \begin{eqnarray*} \mu_{3} & = & \mu_{3}^{\prime}-3\mu\mu_{2}^{\prime}+2\mu^{3}\\  & = & \mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}\\ \mu_{4} & = & \mu_{4}^{\prime}-4\mu\mu_{3}^{\prime}+6\mu^{2}\mu_{2}^{\prime}-3\mu^{4}\\  & = & \mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}\end{eqnarray*}
 
 Skewness is defined as
 
-.. math:: \gamma_{1}=\sqrt{\beta_{1}}=\frac{\mu_{3}}{\mu_{2}^{3/2}}
+.. math::
+   :nowrap:
 
- while (Fisher) kurtosis is
+    \[ \gamma_{1}=\sqrt{\beta_{1}}=\frac{\mu_{3}}{\mu_{2}^{3/2}}\]
 
-.. math:: \gamma_{2}=\frac{\mu_{4}}{\mu_{2}^{2}}-3,
+while (Fisher) kurtosis is
 
- so that a normal distribution has a kurtosis of zero.
+.. math::
+   :nowrap:
+
+    \[ \gamma_{2}=\frac{\mu_{4}}{\mu_{2}^{2}}-3,\]
+
+so that a normal distribution has a kurtosis of zero.
+
 
 Median and mode
 ---------------
 
-The median, :math:`m_{n}` is defined as the point at which half of the
-density is on one side and half on the other. In other words,
-:math:`F\left(m_{n}\right)=\frac{1}{2}` so that
+The median, :math:`m_{n}` is defined as the point at which half of the density is on one side
+and half on the other. In other words, :math:`F\left(m_{n}\right)=\frac{1}{2}` so that
 
-.. math:: m_{n}=G\left(\frac{1}{2}\right).
+.. math::
+   :nowrap:
 
- In addition, the mode, :math:`m_{d}`\ , is defined as the value for
-which the probability density function reaches it’s peak
+    \[ m_{n}=G\left(\frac{1}{2}\right).\]
 
-.. math:: m_{d}=\arg\max_{x}f\left(x\right).
+In addition, the mode, :math:`m_{d}` , is defined as the value for which the probability density function
+reaches it's peak
+
+.. math::
+   :nowrap:
+
+    \[ m_{d}=\arg\max_{x}f\left(x\right).\]
+
+
+
 
 Fitting data
 ------------
@@ -118,944 +117,1014 @@ common. Alternatively, some distributions have well-known minimum
 variance unbiased estimators. These will be chosen by default, but the
 likelihood function will always be available for minimizing.
 
-If :math:`f\left(x;\boldsymbol{\theta}\right)` is the PDF of a
-random-variable where :math:`\boldsymbol{\theta}` is a vector of
-parameters (*e.g. :math:`L`\ * and :math:`S`\ ), then for a collection
-of :math:`N` independent samples from this distribution, the joint
-distribution the random vector :math:`\mathbf{x}` is
-
-.. math:: f\left(\mathbf{x};\boldsymbol{\theta}\right)=\prod_{i=1}^{N}f\left(x_{i};\boldsymbol{\theta}\right).
-
- The maximum likelihood estimate of the parameters
-:math:`\boldsymbol{\theta}` are the parameters which maximize this
-function with :math:`\mathbf{x}` fixed and given by the data:
+If :math:`f\left(x;\boldsymbol{\theta}\right)` is the PDF of a random-variable where :math:`\boldsymbol{\theta}` is a vector of parameters ( *e.g.* :math:`L` and :math:`S` ), then for a collection of :math:`N` independent samples from this distribution, the joint distribution the
+random vector :math:`\mathbf{x}` is
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \boldsymbol{\theta}_{es} & = & \arg\max_{\boldsymbol{\theta}}f\left(\mathbf{x};\boldsymbol{\theta}\right)\\
-    & = & \arg\min_{\boldsymbol{\theta}}l_{\mathbf{x}}\left(\boldsymbol{\theta}\right).\end{aligned*}
+    \[ f\left(\mathbf{x};\boldsymbol{\theta}\right)=\prod_{i=1}^{N}f\left(x_{i};\boldsymbol{\theta}\right).\]
+
+The maximum likelihood estimate of the parameters :math:`\boldsymbol{\theta}` are the parameters which maximize this function with :math:`\mathbf{x}` fixed and given by the data:
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \boldsymbol{\theta}_{es} & = & \arg\max_{\boldsymbol{\theta}}f\left(\mathbf{x};\boldsymbol{\theta}\right)\\  & = & \arg\min_{\boldsymbol{\theta}}l_{\mathbf{x}}\left(\boldsymbol{\theta}\right).\end{eqnarray*}
 
 Where
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   l_{\mathbf{x}}\left(\boldsymbol{\theta}\right) & = & -\sum_{i=1}^{N}\log f\left(x_{i};\boldsymbol{\theta}\right)\\
-    & = & -N\overline{\log f\left(x_{i};\boldsymbol{\theta}\right)}\end{aligned*}
+    \begin{eqnarray*} l_{\mathbf{x}}\left(\boldsymbol{\theta}\right) & = & -\sum_{i=1}^{N}\log f\left(x_{i};\boldsymbol{\theta}\right)\\  & = & -N\overline{\log f\left(x_{i};\boldsymbol{\theta}\right)}\end{eqnarray*}
 
-Note that if :math:`\boldsymbol{\theta}` includes only shape parameters,
-the location and scale-parameters can be fit by replacing :math:`x_{i}`
-with :math:`\left(x_{i}-L\right)/S` in the log-likelihood function
-adding :math:`N\log S` and minimizing, thus
+Note that if :math:`\boldsymbol{\theta}` includes only shape parameters, the location and scale-parameters can
+be fit by replacing :math:`x_{i}` with :math:`\left(x_{i}-L\right)/S` in the log-likelihood function adding :math:`N\log S` and minimizing, thus
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   l_{\mathbf{x}}\left(L,S;\boldsymbol{\theta}\right) & = & N\log S-\sum_{i=1}^{N}\log f\left(\frac{x_{i}-L}{S};\boldsymbol{\theta}\right)\\
-    & = & N\log S+l_{\frac{\mathbf{x}-S}{L}}\left(\boldsymbol{\theta}\right)\end{aligned*}
+    \begin{eqnarray*} l_{\mathbf{x}}\left(L,S;\boldsymbol{\theta}\right) & = & N\log S-\sum_{i=1}^{N}\log f\left(\frac{x_{i}-L}{S};\boldsymbol{\theta}\right)\\  & = & N\log S+l_{\frac{\mathbf{x}-S}{L}}\left(\boldsymbol{\theta}\right)\end{eqnarray*}
 
-Method of Moments
------------------
-
-Another approach to finding parameters of a distribution that explain a
-collection of data is to match the expected moments of the distribution
-with the computed moments and the relevant equations solved for the
-parameters of the distribution. In particular, for a distribution with
-no shape parameters, the following equations can be solved for location
-and scale
+If desired, sample estimates for :math:`L` and :math:`S` (not necessarily maximum likelihood estimates) can be obtained from
+samples estimates of the mean and variance using
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu_{Y} & =S\mu+L\\
-   \mu_{Y^{2}} & =S^{2}\mu_{2}.\end{aligned*}
+    \begin{eqnarray*} \hat{S} & = & \sqrt{\frac{\hat{\mu}_{2}}{\mu_{2}}}\\ \hat{L} & = & \hat{\mu}-\hat{S}\mu\end{eqnarray*}
 
-Estimating :math:`\mu_{Y}` as :math:`\hat{\mu}` and :math:`\mu_{Y^{2}}`
-as :math:`\hat{\mu}_{2}` gives the estimates
+where :math:`\mu` and :math:`\mu_{2}` are assumed known as the mean and variance of the **untransformed** distribution (when :math:`L=0` and :math:`S=1` ) and
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \hat{S} & = & \sqrt{\frac{\hat{\mu}_{2}}{\mu_{2}}}\\
-   \hat{L} & = & \hat{\mu}-\hat{S}\mu\end{aligned*}
+    \begin{eqnarray*} \hat{\mu} & = & \frac{1}{N}\sum_{i=1}^{N}x_{i}=\bar{\mathbf{x}}\\ \hat{\mu}_{2} & = & \frac{1}{N-1}\sum_{i=1}^{N}\left(x_{i}-\hat{\mu}\right)^{2}=\frac{N}{N-1}\overline{\left(\mathbf{x}-\bar{\mathbf{x}}\right)^{2}}\end{eqnarray*}
 
-where :math:`\mu` and :math:`\mu_{2}` are assumed known as the mean and
-variance of the **untransformed** distribution (when :math:`L=0` and
-:math:`S=1`\ ) and
 
-.. math::
 
-   \begin{aligned*}
-   \hat{\mu} & = & \frac{1}{N}\sum_{i=1}^{N}x_{i}=\bar{\mathbf{x}}\\
-   \hat{\mu}_{2} & = & \frac{1}{N}\sum_{i=1}^{N}\left(x_{i}-\hat{\mu}\right)^{2}=\overline{\left(\mathbf{x}-\bar{\mathbf{x}}\right)^{2}}.\end{aligned*}
-
-In general, if the distribution has :math:`M` shape parameters, then to
-find the parameters of the distribution, we need to add :math:`M`
-additional equations. It is straightforward to add the central moment
-equations:
-
-.. math:: \mu_{Y^{n}}=S^{n}\mu_{n}\left(\boldsymbol{\theta}\right)
-
- for :math:`n=2\ldots M+2`\ . If we can estimate the
-:math:`n^{\mbox{th}}` central moment of :math:`Y` as
-
-.. math:: \hat{\mu}_{n}=\frac{1}{N}\sum_{i=1}^{N}\left(x_{i}-\hat{\mu}\right)^{n}=\overline{\left(\mathbf{x}-\bar{\mathbf{x}}\right)^{n}},
-
- then these data-computed statistics can be used to estimate :math:`S`
-and the parameter vector :math:`\boldsymbol{\theta}` by solving this set
-of potentially non-linear equations. Then, the location parameter can be
-found by solving the equation
-:math:`\mu_{Y}=S\mu\left(\boldsymbol{\theta}\right)+L`\ , for :math:`L`\ .
 
 Standard notation for mean
 --------------------------
 
 We will use
 
-.. math:: \overline{y\left(\mathbf{x}\right)}=\frac{1}{N}\sum_{i=1}^{N}y\left(x_{i}\right)
+.. math::
+   :nowrap:
 
- where :math:`N` should be clear from context as the number of samples
-:math:`x_{i}`\ .
+    \[ \overline{y\left(\mathbf{x}\right)}=\frac{1}{N}\sum_{i=1}^{N}y\left(x_{i}\right)\]
 
-References
-----------
+where :math:`N` should be clear from context as the number of samples :math:`x_{i}`
 
-[sec:references]
 
--  Documentation for ranlib, rv2, cdflib
+Alpha
+=====
 
--  Eric Weisstein’s world of mathematics http://mathworld.wolfram.com/,
-   http://mathworld.wolfram.com/topics/StatisticalDistributions.html
+One shape parameters :math:`\alpha>0` (paramter :math:`\beta` in DATAPLOT is a scale-parameter). Standard form is :math:`x>0:`
 
--  Documentation to Regress+ by Michael McLaughlin item Engineering and
-   Statistics Handbook (NIST),
-   http://www.itl.nist.gov/div898/handbook/index.htm
 
--  Documentation for DATAPLOT from NIST,
-   http://www.itl.nist.gov/div898/software/dataplot/distribu.htm
-
--  Norman Johnson, Samuel Kotz, and N. Balakrishnan Continuous
-   Univariate Distributions, second edition, Volumes I and II, Wiley &
-   Sons, 1994.
-
-Alpha 
-======
-
-One shape parameters :math:`\alpha>0` (paramter :math:`\beta` in
-DATAPLOT is a scale-parameter). Standard form is :math:`x>0:`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\alpha\right) & = & \frac{1}{x^{2}\Phi\left(\alpha\right)\sqrt{2\pi}}\exp\left(-\frac{1}{2}\left(\alpha-\frac{1}{x}\right)^{2}\right)\\
-   F\left(x;\alpha\right) & = & \frac{\Phi\left(\alpha-\frac{1}{x}\right)}{\Phi\left(\alpha\right)}\\
-   G\left(q;\alpha\right) & = & \left[\alpha-\Phi^{-1}\left(q\Phi\left(\alpha\right)\right)\right]^{-1}\end{aligned*}
+    \begin{eqnarray*} f\left(x;\alpha\right) & = & \frac{1}{x^{2}\Phi\left(\alpha\right)\sqrt{2\pi}}\exp\left(-\frac{1}{2}\left(\alpha-\frac{1}{x}\right)^{2}\right)\\ F\left(x;\alpha\right) & = & \frac{\Phi\left(\alpha-\frac{1}{x}\right)}{\Phi\left(\alpha\right)}\\ G\left(q;\alpha\right) & = & \left[\alpha-\Phi^{-1}\left(q\Phi\left(\alpha\right)\right)\right]^{-1}\end{eqnarray*}
 
-.. math:: M\left(t\right)=\frac{1}{\Phi\left(a\right)\sqrt{2\pi}}\int_{0}^{\infty}\frac{e^{xt}}{x^{2}}\exp\left(-\frac{1}{2}\left(\alpha-\frac{1}{x}\right)^{2}\right)dx
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ M\left(t\right)=\frac{1}{\Phi\left(a\right)\sqrt{2\pi}}\int_{0}^{\infty}\frac{e^{xt}}{x^{2}}\exp\left(-\frac{1}{2}\left(\alpha-\frac{1}{x}\right)^{2}\right)dx\]
+
+
 
 No moments?
 
-.. math:: l_{\mathbf{x}}\left(\alpha\right)=N\log\left[\Phi\left(\alpha\right)\sqrt{2\pi}\right]+2N\overline{\log\mathbf{x}}+\frac{N}{2}\alpha^{2}-\alpha\overline{\mathbf{x}^{-1}}+\frac{1}{2}\overline{\mathbf{x}^{-2}}
+.. math::
+   :nowrap:
+
+    \[ l_{\mathbf{x}}\left(\alpha\right)=N\log\left[\Phi\left(\alpha\right)\sqrt{2\pi}\right]+2N\overline{\log\mathbf{x}}+\frac{N}{2}\alpha^{2}-\alpha\overline{\mathbf{x}^{-1}}+\frac{1}{2}\overline{\mathbf{x}^{-2}}\]
+
+
+
 
 Anglit
 ======
 
 Defined over :math:`x\in\left[-\frac{\pi}{4},\frac{\pi}{4}\right]`
 
-.. math::
 
-   \begin{aligned*}
-   f\left(x\right) & = & \sin\left(2x+\frac{\pi}{2}\right)=\cos\left(2x\right)\\
-   F\left(x\right) & = & \sin^{2}\left(x+\frac{\pi}{4}\right)\\
-   G\left(q\right) & = & \arcsin\left(\sqrt{q}\right)-\frac{\pi}{4}\end{aligned*}
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & 0\\
-   \mu_{2} & = & \frac{\pi^{2}}{16}-\frac{1}{2}\\
-   \gamma_{1} & = & 0\\
-   \gamma_{2} & = & -2\frac{\pi^{4}-96}{\left(\pi^{2}-8\right)^{2}}\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \sin\left(2x+\frac{\pi}{2}\right)=\cos\left(2x\right)\\ F\left(x\right) & = & \sin^{2}\left(x+\frac{\pi}{4}\right)\\ G\left(q\right) & = & \arcsin\left(\sqrt{q}\right)-\frac{\pi}{4}\end{eqnarray*}
 
-.. math::
 
-   \begin{aligned*}
-   h\left[X\right] & = & 1-\log2\\
-    & \approx & 0.30685281944005469058\end{aligned*}
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   M\left(t\right) & = & \int_{-\frac{\pi}{4}}^{\frac{\pi}{4}}\cos\left(2x\right)e^{xt}dx\\
-    & = & \frac{4\cosh\left(\frac{\pi t}{4}\right)}{t^{2}+4}\end{aligned*}
+    \begin{eqnarray*} \mu & = & 0\\ \mu_{2} & = & \frac{\pi^{2}}{16}-\frac{1}{2}\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & -2\frac{\pi^{4}-96}{\left(\pi^{2}-8\right)^{2}}\end{eqnarray*}
 
-.. math:: l_{\mathbf{x}}\left(\cdot\right)=-N\overline{\log\left[\cos\left(2\mathbf{x}\right)\right]}
 
-Arcsine 
-========
-
-Defined over :math:`x\in\left(0,1\right)`\ . To get the JKB definition
-put :math:`x=\frac{u+1}{2}.` i.e. :math:`L=-1` and :math:`S=2.`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x\right) & = & \frac{1}{\pi\sqrt{x\left(1-x\right)}}\\
-   F\left(x\right) & = & \frac{2}{\pi}\arcsin\left(\sqrt{x}\right)\\
-   G\left(q\right) & = & \sin^{2}\left(\frac{\pi}{2}q\right)\end{aligned*}
+    \begin{eqnarray*} h\left[X\right] & = & 1-\log2\\  & \approx & 0.30685281944005469058\end{eqnarray*}
 
-.. math:: M\left(t\right)=E^{t/2}I_{0}\left(\frac{t}{2}\right)
 
-.. math::
 
-   \begin{aligned*}
-   \mu_{n}^{\prime} & = & \frac{1}{\pi}\int_{0}^{1}dx\, x^{n-1/2}\left(1-x\right)^{-1/2}\\
-    & = & \frac{1}{\pi}B\left(\frac{1}{2},n+\frac{1}{2}\right)=\frac{\left(2n-1\right)!!}{2^{n}n!}\end{aligned*}
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \frac{1}{2}\\
-   \mu_{2} & = & \frac{1}{8}\\
-   \gamma_{1} & = & 0\\
-   \gamma_{2} & = & -\frac{3}{2}\end{aligned*}
+    \begin{eqnarray*} M\left(t\right) & = & \int_{-\frac{\pi}{4}}^{\frac{\pi}{4}}\cos\left(2x\right)e^{xt}dx\\  & = & \frac{4\cosh\left(\frac{\pi t}{4}\right)}{t^{2}+4}\end{eqnarray*}
 
-.. math:: h\left[X\right]\approx-0.24156447527049044468
 
-.. math:: l_{\mathbf{x}}\left(\cdot\right)=N\log\pi+\frac{N}{2}\overline{\log\mathbf{x}}+\frac{N}{2}\overline{\log\left(1-\mathbf{x}\right)}
 
-Beta 
-=====
+
+
+.. math::
+   :nowrap:
+
+    \[ l_{\mathbf{x}}\left(\cdot\right)=-N\overline{\log\left[\cos\left(2\mathbf{x}\right)\right]}\]
+
+
+
+
+Arcsine
+=======
+
+Defined over :math:`x\in\left(0,1\right)` . To get the JKB definition put :math:`x=\frac{u+1}{2}.` i.e. :math:`L=-1` and :math:`S=2.`
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{\pi\sqrt{x\left(1-x\right)}}\\ F\left(x\right) & = & \frac{2}{\pi}\arcsin\left(\sqrt{x}\right)\\ G\left(q\right) & = & \sin^{2}\left(\frac{\pi}{2}q\right)\end{eqnarray*}
+
+
+
+.. math::
+   :nowrap:
+
+    \[ M\left(t\right)=E^{t/2}I_{0}\left(\frac{t}{2}\right)\]
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu_{n}^{\prime} & = & \frac{1}{\pi}\int_{0}^{1}dx\, x^{n-1/2}\left(1-x\right)^{-1/2}\\  & = & \frac{1}{\pi}B\left(\frac{1}{2},n+\frac{1}{2}\right)=\frac{\left(2n-1\right)!!}{2^{n}n!}\end{eqnarray*}
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & \frac{1}{2}\\ \mu_{2} & = & \frac{1}{8}\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & -\frac{3}{2}\end{eqnarray*}
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]\approx-0.24156447527049044468\]
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ l_{\mathbf{x}}\left(\cdot\right)=N\log\pi+\frac{N}{2}\overline{\log\mathbf{x}}+\frac{N}{2}\overline{\log\left(1-\mathbf{x}\right)}\]
+
+
+
+
+Beta
+====
 
 Two shape parameters
 
-.. math:: a,b>0
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;a,b\right) & = & \frac{\Gamma\left(a+b\right)}{\Gamma\left(a\right)\Gamma\left(b\right)}x^{a-1}\left(1-x\right)^{b-1}I_{\left(0,1\right)}\left(x\right)\\
-   F\left(x;a,b\right) & = & \int_{0}^{x}f\left(y;a,b\right)dy=I\left(x,a,b\right)\\
-   G\left(\alpha;a,b\right) & = & I^{-1}\left(\alpha;a,b\right)\\
-   M\left(t\right) & = & \frac{\Gamma\left(a\right)\Gamma\left(b\right)}{\Gamma\left(a+b\right)}\,_{1}F_{1}\left(a;a+b;t\right)\\
-   \mu & = & \frac{a}{a+b}\\
-   \mu_{2} & = & \frac{ab\left(a+b+1\right)}{\left(a+b\right)^{2}}\\
-   \gamma_{1} & = & 2\frac{b-a}{a+b+2}\sqrt{\frac{a+b+1}{ab}}\\
-   \gamma_{2} & = & \frac{6\left(a^{3}+a^{2}\left(1-2b\right)+b^{2}\left(b+1\right)-2ab\left(b+2\right)\right)}{ab\left(a+b+2\right)\left(a+b+3\right)}\\
-   m_{d} & = & \frac{\left(a-1\right)}{\left(a+b-2\right)}\, a+b\neq2\end{aligned*}
+    \[ a,b>0\]
 
-:math:`f\left(x;a,1\right)` is also called the Power-function
-distribution.
 
-.. math:: l_{\mathbf{x}}\left(a,b\right)=-N\log\Gamma\left(a+b\right)+N\log\Gamma\left(a\right)+N\log\Gamma\left(b\right)-N\left(a-1\right)\overline{\log\mathbf{x}}-N\left(b-1\right)\overline{\log\left(1-\mathbf{x}\right)}
 
- All of the :math:`x_{i}\in\left[0,1\right]`
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} f\left(x;a,b\right) & = & \frac{\Gamma\left(a+b\right)}{\Gamma\left(a\right)\Gamma\left(b\right)}x^{a-1}\left(1-x\right)^{b-1}I_{\left(0,1\right)}\left(x\right)\\ F\left(x;a,b\right) & = & \int_{0}^{x}f\left(y;a,b\right)dy=I\left(x,a,b\right)\\ G\left(\alpha;a,b\right) & = & I^{-1}\left(\alpha;a,b\right)\\ M\left(t\right) & = & \frac{\Gamma\left(a\right)\Gamma\left(b\right)}{\Gamma\left(a+b\right)}\,_{1}F_{1}\left(a;a+b;t\right)\\ \mu & = & \frac{a}{a+b}\\ \mu_{2} & = & \frac{ab\left(a+b+1\right)}{\left(a+b\right)^{2}}\\ \gamma_{1} & = & 2\frac{b-a}{a+b+2}\sqrt{\frac{a+b+1}{ab}}\\ \gamma_{2} & = & \frac{6\left(a^{3}+a^{2}\left(1-2b\right)+b^{2}\left(b+1\right)-2ab\left(b+2\right)\right)}{ab\left(a+b+2\right)\left(a+b+3\right)}\\ m_{d} & = & \frac{\left(a-1\right)}{\left(a+b-2\right)}\, a+b\neq2\end{eqnarray*}
+
+
+
+:math:`f\left(x;a,1\right)` is also called the Power-function distribution.
+
+
+
+.. math::
+   :nowrap:
+
+    \[ l_{\mathbf{x}}\left(a,b\right)=-N\log\Gamma\left(a+b\right)+N\log\Gamma\left(a\right)+N\log\Gamma\left(b\right)-N\left(a-1\right)\overline{\log\mathbf{x}}-N\left(b-1\right)\overline{\log\left(1-\mathbf{x}\right)}\]
+
+All of the :math:`x_{i}\in\left[0,1\right]`
+
 
 Beta Prime
 ==========
 
-Defined over :math:`0<x<\infty.` :math:`\alpha,\beta>0.` (Note the CDF
-evaluation uses Eq. 3.194.1 on pg. 313 of Gradshteyn & Ryzhik (sixth
-edition).
+Defined over :math:`0<x<\infty.` :math:`\alpha,\beta>0.` (Note the CDF evaluation uses Eq. 3.194.1 on pg. 313 of Gradshteyn &
+Ryzhik (sixth edition).
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\alpha,\beta\right) & = & \frac{\Gamma\left(\alpha+\beta\right)}{\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}x^{\alpha-1}\left(1+x\right)^{-\alpha-\beta}\\
-   F\left(x;\alpha,\beta\right) & = & \frac{\Gamma\left(\alpha+\beta\right)}{\alpha\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}x^{\alpha}\,_{2}F_{1}\left(\alpha+\beta,\alpha;1+\alpha;-x\right)\\
-   G\left(q;\alpha,\beta\right) & = & F^{-1}\left(x;\alpha,\beta\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x;\alpha,\beta\right) & = & \frac{\Gamma\left(\alpha+\beta\right)}{\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}x^{\alpha-1}\left(1+x\right)^{-\alpha-\beta}\\ F\left(x;\alpha,\beta\right) & = & \frac{\Gamma\left(\alpha+\beta\right)}{\alpha\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}x^{\alpha}\,_{2}F_{1}\left(\alpha+\beta,\alpha;1+\alpha;-x\right)\\ G\left(q;\alpha,\beta\right) & = & F^{-1}\left(x;\alpha,\beta\right)\end{eqnarray*}
 
-.. math::
 
-   \mu_{n}^{\prime}=\left\{ \begin{array}{ccc}
-   \frac{\Gamma\left(n+\alpha\right)\Gamma\left(\beta-n\right)}{\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}=\frac{\left(\alpha\right)_{n}}{\left(\beta-n\right)_{n}} &  & \beta>n\\
-   \infty &  & \textrm{otherwise}
-   \end{array}\right.
 
- Therefore,
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \frac{\alpha}{\beta-1}\quad\beta>1\\
-   \mu_{2} & = & \frac{\alpha\left(\alpha+1\right)}{\left(\beta-2\right)\left(\beta-1\right)}-\frac{\alpha^{2}}{\left(\beta-1\right)^{2}}\quad\beta>2\\
-   \gamma_{1} & = & \frac{\frac{\alpha\left(\alpha+1\right)\left(\alpha+2\right)}{\left(\beta-3\right)\left(\beta-2\right)\left(\beta-1\right)}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\quad\beta>3\\
-   \gamma_{2} & = & \frac{\mu_{4}}{\mu_{2}^{2}}-3\\
-   \mu_{4} & = & \frac{\alpha\left(\alpha+1\right)\left(\alpha+2\right)\left(\alpha+3\right)}{\left(\beta-4\right)\left(\beta-3\right)\left(\beta-2\right)\left(\beta-1\right)}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}\quad\beta>4\end{aligned*}
+    \[ \mu_{n}^{\prime}=\left\{ \begin{array}{ccc} \frac{\Gamma\left(n+\alpha\right)\Gamma\left(\beta-n\right)}{\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}=\frac{\left(\alpha\right)_{n}}{\left(\beta-n\right)_{n}} &  & \beta>n\\ \infty &  & \textrm{otherwise}\end{array}\right.\]
+
+Therefore,
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & \frac{\alpha}{\beta-1}\quad\beta>1\\ \mu_{2} & = & \frac{\alpha\left(\alpha+1\right)}{\left(\beta-2\right)\left(\beta-1\right)}-\frac{\alpha^{2}}{\left(\beta-1\right)^{2}}\quad\beta>2\\ \gamma_{1} & = & \frac{\frac{\alpha\left(\alpha+1\right)\left(\alpha+2\right)}{\left(\beta-3\right)\left(\beta-2\right)\left(\beta-1\right)}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\quad\beta>3\\ \gamma_{2} & = & \frac{\mu_{4}}{\mu_{2}^{2}}-3\\ \mu_{4} & = & \frac{\alpha\left(\alpha+1\right)\left(\alpha+2\right)\left(\alpha+3\right)}{\left(\beta-4\right)\left(\beta-3\right)\left(\beta-2\right)\left(\beta-1\right)}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}\quad\beta>4\end{eqnarray*}
+
+
+
 
 Bradford
 ========
 
-.. math::
 
-   \begin{aligned*}
-   c & > & 0\\
-   k & = & \log\left(1+c\right)\end{aligned*}
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & \frac{c}{k\left(1+cx\right)}I_{\left(0,1\right)}\left(x\right)\\
-   F\left(x;c\right) & = & \frac{\log\left(1+cx\right)}{k}\\
-   G\left(\alpha\; c\right) & = & \frac{\left(1+c\right)^{\alpha}-1}{c}\\
-   M\left(t\right) & = & \frac{1}{k}e^{-t/c}\left[\textrm{Ei}\left(t+\frac{t}{c}\right)-\textrm{Ei}\left(\frac{t}{c}\right)\right]\\
-   \mu & = & \frac{c-k}{ck}\\
-   \mu_{2} & = & \frac{\left(c+2\right)k-2c}{2ck^{2}}\\
-   \gamma_{1} & = & \frac{\sqrt{2}\left(12c^{2}-9kc\left(c+2\right)+2k^{2}\left(c\left(c+3\right)+3\right)\right)}{\sqrt{c\left(c\left(k-2\right)+2k\right)}\left(3c\left(k-2\right)+6k\right)}\\
-   \gamma_{2} & = & \frac{c^{3}\left(k-3\right)\left(k\left(3k-16\right)+24\right)+12kc^{2}\left(k-4\right)\left(k-3\right)+6ck^{2}\left(3k-14\right)+12k^{3}}{3c\left(c\left(k-2\right)+2k\right)^{2}}\\
-   m_{d} & = & 0\\
-   m_{n} & = & \sqrt{1+c}-1\end{aligned*}
+    \begin{eqnarray*} c & > & 0\\ k & = & \log\left(1+c\right)\end{eqnarray*}
 
-where :math:`\textrm{Ei}\left(\textrm{z}\right)` is the exponential
-integral function. Also
 
-.. math:: h\left[X\right]=\frac{1}{2}\log\left(1+c\right)-\log\left(\frac{c}{\log\left(1+c\right)}\right)
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} f\left(x;c\right) & = & \frac{c}{k\left(1+cx\right)}I_{\left(0,1\right)}\left(x\right)\\ F\left(x;c\right) & = & \frac{\log\left(1+cx\right)}{k}\\ G\left(\alpha\; c\right) & = & \frac{\left(1+c\right)^{\alpha}-1}{c}\\ M\left(t\right) & = & \frac{1}{k}e^{-t/c}\left[\textrm{Ei}\left(t+\frac{t}{c}\right)-\textrm{Ei}\left(\frac{t}{c}\right)\right]\\ \mu & = & \frac{c-k}{ck}\\ \mu_{2} & = & \frac{\left(c+2\right)k-2c}{2ck^{2}}\\ \gamma_{1} & = & \frac{\sqrt{2}\left(12c^{2}-9kc\left(c+2\right)+2k^{2}\left(c\left(c+3\right)+3\right)\right)}{\sqrt{c\left(c\left(k-2\right)+2k\right)}\left(3c\left(k-2\right)+6k\right)}\\ \gamma_{2} & = & \frac{c^{3}\left(k-3\right)\left(k\left(3k-16\right)+24\right)+12kc^{2}\left(k-4\right)\left(k-3\right)+6ck^{2}\left(3k-14\right)+12k^{3}}{3c\left(c\left(k-2\right)+2k\right)^{2}}\\ m_{d} & = & 0\\ m_{n} & = & \sqrt{1+c}-1\end{eqnarray*}
+
+where :math:`\textrm{Ei}\left(\textrm{z}\right)` is the exponential integral function. Also
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=\frac{1}{2}\log\left(1+c\right)-\log\left(\frac{c}{\log\left(1+c\right)}\right)\]
+
+
+
 
 Burr
 ====
 
-.. math::
 
-   \begin{aligned*}
-   c & > & 0\\
-   d & > & 0\\
-   k & = & \Gamma\left(d\right)\Gamma\left(1-\frac{2}{c}\right)\Gamma\left(\frac{2}{c}+d\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+d\right)\end{aligned*}
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c,d\right) & = & \frac{cd}{x^{c+1}\left(1+x^{-c}\right)^{d+1}}I_{\left(0,\infty\right)}\left(x\right)\\
-   F\left(x;c,d\right) & = & \left(1+x^{-c}\right)^{-d}\\
-   G\left(\alpha;c,d\right) & = & \left(\alpha^{-1/d}-1\right)^{-1/c}\\
-   \mu & = & \frac{\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+d\right)}{\Gamma\left(d\right)}\\
-   \mu_{2} & = & \frac{k}{\Gamma^{2}\left(d\right)}\\
-   \gamma_{1} & = & \frac{1}{\sqrt{k^{3}}}\left[2\Gamma^{3}\left(1-\frac{1}{c}\right)\Gamma^{3}\left(\frac{1}{c}+d\right)+\Gamma^{2}\left(d\right)\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(\frac{3}{c}+d\right)\right.\\
-    &  & \left.-3\Gamma\left(d\right)\Gamma\left(1-\frac{2}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+d\right)\Gamma\left(\frac{2}{c}+d\right)\right]\\
-   \gamma_{2} & = & -3+\frac{1}{k^{2}}\left[6\Gamma\left(d\right)\Gamma\left(1-\frac{2}{c}\right)\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+d\right)\Gamma\left(\frac{2}{c}+d\right)\right.\\
-    &  & -3\Gamma^{4}\left(1-\frac{1}{c}\right)\Gamma^{4}\left(\frac{1}{c}+d\right)+\Gamma^{3}\left(d\right)\Gamma\left(1-\frac{4}{c}\right)\Gamma\left(\frac{4}{c}+d\right)\\
-    &  & \left.-4\Gamma^{2}\left(d\right)\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+d\right)\Gamma\left(\frac{3}{c}+d\right)\right]\\
-   m_{d} & = & \left(\frac{cd-1}{c+1}\right)^{1/c}\,\textrm{if }cd>1\,\textrm{otherwise }0\\
-   m_{n} & = & \left(2^{1/d}-1\right)^{-1/c}\end{aligned*}
+    \begin{eqnarray*} c & > & 0\\ d & > & 0\\ k & = & \Gamma\left(d\right)\Gamma\left(1-\frac{2}{c}\right)\Gamma\left(\frac{2}{c}+d\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+d\right)\end{eqnarray*}
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} f\left(x;c,d\right) & = & \frac{cd}{x^{c+1}\left(1+x^{-c}\right)^{d+1}}I_{\left(0,\infty\right)}\left(x\right)\\ F\left(x;c,d\right) & = & \left(1+x^{-c}\right)^{-d}\\ G\left(\alpha;c,d\right) & = & \left(\alpha^{-1/d}-1\right)^{-1/c}\\ \mu & = & \frac{\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+d\right)}{\Gamma\left(d\right)}\\ \mu_{2} & = & \frac{k}{\Gamma^{2}\left(d\right)}\\ \gamma_{1} & = & \frac{1}{\sqrt{k^{3}}}\left[2\Gamma^{3}\left(1-\frac{1}{c}\right)\Gamma^{3}\left(\frac{1}{c}+d\right)+\Gamma^{2}\left(d\right)\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(\frac{3}{c}+d\right)\right.\\  &  & \left.-3\Gamma\left(d\right)\Gamma\left(1-\frac{2}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+d\right)\Gamma\left(\frac{2}{c}+d\right)\right]\\ \gamma_{2} & = & -3+\frac{1}{k^{2}}\left[6\Gamma\left(d\right)\Gamma\left(1-\frac{2}{c}\right)\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+d\right)\Gamma\left(\frac{2}{c}+d\right)\right.\\  &  & -3\Gamma^{4}\left(1-\frac{1}{c}\right)\Gamma^{4}\left(\frac{1}{c}+d\right)+\Gamma^{3}\left(d\right)\Gamma\left(1-\frac{4}{c}\right)\Gamma\left(\frac{4}{c}+d\right)\\  &  & \left.-4\Gamma^{2}\left(d\right)\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+d\right)\Gamma\left(\frac{3}{c}+d\right)\right]\\ m_{d} & = & \left(\frac{cd-1}{c+1}\right)^{1/c}\,\textrm{if }cd>1\,\textrm{otherwise }0\\ m_{n} & = & \left(2^{1/d}-1\right)^{-1/c}\end{eqnarray*}
+
+
+
 
 Cauchy
 ======
 
-.. math::
 
-   \begin{aligned*}
-   f\left(x\right) & = & \frac{1}{\pi\left(1+x^{2}\right)}\\
-   F\left(x\right) & = & \frac{1}{2}+\frac{1}{\pi}\tan^{-1}x\\
-   G\left(\alpha\right) & = & \tan\left(\pi\alpha-\frac{\pi}{2}\right)\\
-   m_{d} & = & 0\\
-   m_{n} & = & 0\end{aligned*}
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{\pi\left(1+x^{2}\right)}\\ F\left(x\right) & = & \frac{1}{2}+\frac{1}{\pi}\tan^{-1}x\\ G\left(\alpha\right) & = & \tan\left(\pi\alpha-\frac{\pi}{2}\right)\\ m_{d} & = & 0\\ m_{n} & = & 0\end{eqnarray*}
 
 No finite moments. This is the t distribution with one degree of
 freedom.
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   h\left[X\right] & = & \log\left(4\pi\right)\\
-    & \approx & 2.5310242469692907930.\end{aligned*}
+    \begin{eqnarray*} h\left[X\right] & = & \log\left(4\pi\right)\\  & \approx & 2.5310242469692907930.\end{eqnarray*}
+
+
+
 
 Chi
 ===
 
-Generated by taking the (positive) square-root of chi-squared variates.
+Generated by taking the (positive) square-root of chi-squared
+variates.
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\nu\right) & = & \frac{x^{\nu-1}e^{-x^{2}/2}}{2^{\nu/2-1}\Gamma\left(\frac{\nu}{2}\right)}I_{\left(0,\infty\right)}\left(x\right)\\
-   F\left(x;\nu\right) & = & \Gamma\left(\frac{\nu}{2},\frac{x^{2}}{2}\right)\\
-   G\left(\alpha;\nu\right) & = & \sqrt{2\Gamma^{-1}\left(\frac{\nu}{2},\alpha\right)}\end{aligned*}
+    \begin{eqnarray*} f\left(x;\nu\right) & = & \frac{x^{\nu-1}e^{-x^{2}/2}}{2^{\nu/2-1}\Gamma\left(\frac{\nu}{2}\right)}I_{\left(0,\infty\right)}\left(x\right)\\ F\left(x;\nu\right) & = & \Gamma\left(\frac{\nu}{2},\frac{x^{2}}{2}\right)\\ G\left(\alpha;\nu\right) & = & \sqrt{2\Gamma^{-1}\left(\frac{\nu}{2},\alpha\right)}\end{eqnarray*}
 
-.. math:: M\left(t\right)=\Gamma\left(\frac{v}{2}\right)\,_{1}F_{1}\left(\frac{v}{2};\frac{1}{2};\frac{t^{2}}{2}\right)+\frac{t}{\sqrt{2}}\Gamma\left(\frac{1+\nu}{2}\right)\,_{1}F_{1}\left(\frac{1+\nu}{2};\frac{3}{2};\frac{t^{2}}{2}\right)
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \frac{\sqrt{2}\Gamma\left(\frac{\nu+1}{2}\right)}{\Gamma\left(\frac{\nu}{2}\right)}\\
-   \mu_{2} & = & \nu-\mu^{2}\\
-   \gamma_{1} & = & \frac{2\mu^{3}+\mu\left(1-2\nu\right)}{\mu_{2}^{3/2}}\\
-   \gamma_{2} & = & \frac{2\nu\left(1-\nu\right)-6\mu^{4}+4\mu^{2}\left(2\nu-1\right)}{\mu_{2}^{2}}\\
-   m_{d} & = & \sqrt{\nu-1}\quad\nu\geq1\\
-   m_{n} & = & \sqrt{2\Gamma^{-1}\left(\frac{\nu}{2},\frac{1}{2}\right)}\end{aligned*}
+    \[ M\left(t\right)=\Gamma\left(\frac{v}{2}\right)\,_{1}F_{1}\left(\frac{v}{2};\frac{1}{2};\frac{t^{2}}{2}\right)+\frac{t}{\sqrt{2}}\Gamma\left(\frac{1+\nu}{2}\right)\,_{1}F_{1}\left(\frac{1+\nu}{2};\frac{3}{2};\frac{t^{2}}{2}\right)\]
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & \frac{\sqrt{2}\Gamma\left(\frac{\nu+1}{2}\right)}{\Gamma\left(\frac{\nu}{2}\right)}\\ \mu_{2} & = & \nu-\mu^{2}\\ \gamma_{1} & = & \frac{2\mu^{3}+\mu\left(1-2\nu\right)}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{2\nu\left(1-\nu\right)-6\mu^{4}+4\mu^{2}\left(2\nu-1\right)}{\mu_{2}^{2}}\\ m_{d} & = & \sqrt{\nu-1}\quad\nu\geq1\\ m_{n} & = & \sqrt{2\Gamma^{-1}\left(\frac{\nu}{2},\frac{1}{2}\right)}\end{eqnarray*}
+
+
+
 
 Chi-squared
 ===========
 
-This is the gamma distribution with :math:`L=0.0` and :math:`S=2.0` and
-:math:`\alpha=\nu/2` where :math:`\nu` is called the degrees of freedom.
-If :math:`Z_{1}\ldots Z_{\nu}` are all standard normal distributions,
-then :math:`W=\sum_{k}Z_{k}^{2}` has (standard) chi-square distribution
-with :math:`\nu` degrees of freedom.
+This is the gamma distribution with :math:`L=0.0` and :math:`S=2.0` and :math:`\alpha=\nu/2` where :math:`\nu` is called the degrees of freedom. If :math:`Z_{1}\ldots Z_{\nu}` are all standard normal distributions, then :math:`W=\sum_{k}Z_{k}^{2}` has (standard) chi-square distribution with :math:`\nu` degrees of freedom.
 
 The standard form (most often used in standard form only) is :math:`x>0`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\alpha\right) & = & \frac{1}{2\Gamma\left(\frac{\nu}{2}\right)}\left(\frac{x}{2}\right)^{\nu/2-1}e^{-x/2}\\
-   F\left(x;\alpha\right) & = & \Gamma\left(\frac{\nu}{2},\frac{x}{2}\right)\\
-   G\left(q;\alpha\right) & = & 2\Gamma^{-1}\left(\frac{\nu}{2},q\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x;\alpha\right) & = & \frac{1}{2\Gamma\left(\frac{\nu}{2}\right)}\left(\frac{x}{2}\right)^{\nu/2-1}e^{-x/2}\\ F\left(x;\alpha\right) & = & \Gamma\left(\frac{\nu}{2},\frac{x}{2}\right)\\ G\left(q;\alpha\right) & = & 2\Gamma^{-1}\left(\frac{\nu}{2},q\right)\end{eqnarray*}
 
-.. math:: M\left(t\right)=\frac{\Gamma\left(\frac{\nu}{2}\right)}{\left(\frac{1}{2}-t\right)^{\nu/2}}
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \nu\\
-   \mu_{2} & = & 2\nu\\
-   \gamma_{1} & = & \frac{2\sqrt{2}}{\sqrt{\nu}}\\
-   \gamma_{2} & = & \frac{12}{\nu}\\
-   m_{d} & = & \frac{\nu}{2}-1\end{aligned*}
+    \[ M\left(t\right)=\frac{\Gamma\left(\frac{\nu}{2}\right)}{\left(\frac{1}{2}-t\right)^{\nu/2}}\]
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & \nu\\ \mu_{2} & = & 2\nu\\ \gamma_{1} & = & \frac{2\sqrt{2}}{\sqrt{\nu}}\\ \gamma_{2} & = & \frac{12}{\nu}\\ m_{d} & = & \frac{\nu}{2}-1\end{eqnarray*}
+
+
+
 
 Cosine
 ======
 
 Approximation to the normal distribution.
 
-.. math::
 
-   \begin{aligned*}
-   f\left(x\right) & = & \frac{1}{2\pi}\left[1+\cos x\right]I_{\left[-\pi,\pi\right]}\left(x\right)\\
-   F\left(x\right) & = & \frac{1}{2\pi}\left[\pi+x+\sin x\right]I_{\left[-\pi,\pi\right]}\left(x\right)+I_{\left(\pi,\infty\right)}\left(x\right)\\
-   G\left(\alpha\right) & = & F^{-1}\left(\alpha\right)\\
-   M\left(t\right) & = & \frac{\sinh\left(\pi t\right)}{\pi t\left(1+t^{2}\right)}\\
-   \mu=m_{d}=m_{n} & = & 0\\
-   \mu_{2} & = & \frac{\pi^{2}}{3}-2\\
-   \gamma_{1} & = & 0\\
-   \gamma_{2} & = & \frac{-6\left(\pi^{4}-90\right)}{5\left(\pi^{2}-6\right)^{2}}\end{aligned*}
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   h\left[X\right] & = & \log\left(4\pi\right)-1\\
-    & \approx & 1.5310242469692907930.\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{2\pi}\left[1+\cos x\right]I_{\left[-\pi,\pi\right]}\left(x\right)\\ F\left(x\right) & = & \frac{1}{2\pi}\left[\pi+x+\sin x\right]I_{\left[-\pi,\pi\right]}\left(x\right)+I_{\left(\pi,\infty\right)}\left(x\right)\\ G\left(\alpha\right) & = & F^{-1}\left(\alpha\right)\\ M\left(t\right) & = & \frac{\sinh\left(\pi t\right)}{\pi t\left(1+t^{2}\right)}\\ \mu=m_{d}=m_{n} & = & 0\\ \mu_{2} & = & \frac{\pi^{2}}{3}-2\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & \frac{-6\left(\pi^{4}-90\right)}{5\left(\pi^{2}-6\right)^{2}}\end{eqnarray*}
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} h\left[X\right] & = & \log\left(4\pi\right)-1\\  & \approx & 1.5310242469692907930.\end{eqnarray*}
+
+
+
 
 Double Gamma
 ============
 
-The double gamma is the signed version of the Gamma distribution. For
-:math:`\alpha>0:`
+The double gamma is the signed version of the Gamma distribution. For :math:`\alpha>0:`
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\alpha\right) & = & \frac{1}{2\Gamma\left(\alpha\right)}\left|x\right|^{\alpha-1}e^{-\left|x\right|}\\
-   F\left(x;\alpha\right) & = & \left\{ \begin{array}{ccc}
-   \frac{1}{2}-\frac{1}{2}\Gamma\left(\alpha,\left|x\right|\right) &  & x\leq0\\
-   \frac{1}{2}+\frac{1}{2}\Gamma\left(\alpha,\left|x\right|\right) &  & x>0
-   \end{array}\right.\\
-   G\left(q;\alpha\right) & = & \left\{ \begin{array}{ccc}
-   -\Gamma^{-1}\left(\alpha,\left|2q-1\right|\right) &  & q\leq\frac{1}{2}\\
-   \Gamma^{-1}\left(\alpha,\left|2q-1\right|\right) &  & q>\frac{1}{2}
-   \end{array}\right.\end{aligned*}
+    \begin{eqnarray*} f\left(x;\alpha\right) & = & \frac{1}{2\Gamma\left(\alpha\right)}\left|x\right|^{\alpha-1}e^{-\left|x\right|}\\ F\left(x;\alpha\right) & = & \left\{ \begin{array}{ccc} \frac{1}{2}-\frac{1}{2}\Gamma\left(\alpha,\left|x\right|\right) &  & x\leq0\\ \frac{1}{2}+\frac{1}{2}\Gamma\left(\alpha,\left|x\right|\right) &  & x>0\end{array}\right.\\ G\left(q;\alpha\right) & = & \left\{ \begin{array}{ccc} -\Gamma^{-1}\left(\alpha,\left|2q-1\right|\right) &  & q\leq\frac{1}{2}\\ \Gamma^{-1}\left(\alpha,\left|2q-1\right|\right) &  & q>\frac{1}{2}\end{array}\right.\end{eqnarray*}
 
-.. math:: M\left(t\right)=\frac{1}{2\left(1-t\right)^{a}}+\frac{1}{2\left(1+t\right)^{a}}
+
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu=m_{n} & = & 0\\
-   \mu_{2} & = & \alpha\left(\alpha+1\right)\\
-   \gamma_{1} & = & 0\\
-   \gamma_{2} & = & \frac{\left(\alpha+2\right)\left(\alpha+3\right)}{\alpha\left(\alpha+1\right)}-3\\
-   m_{d} & = & \textrm{NA}\end{aligned*}
+    \[ M\left(t\right)=\frac{1}{2\left(1-t\right)^{a}}+\frac{1}{2\left(1+t\right)^{a}}\]
 
-Doubly Non-central F\*
-======================
 
-Doubly Non-central t\*
-======================
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu=m_{n} & = & 0\\ \mu_{2} & = & \alpha\left(\alpha+1\right)\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & \frac{\left(\alpha+2\right)\left(\alpha+3\right)}{\alpha\left(\alpha+1\right)}-3\\ m_{d} & = & \textrm{NA}\end{eqnarray*}
+
+
+
+
+Doubly Non-central F*
+=====================
+
+
+Doubly Non-central t*
+=====================
+
 
 Double Weibull
 ==============
 
 This is a signed form of the Weibull distribution.
 
-.. math::
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & \frac{c}{2}\left|x\right|^{c-1}\exp\left(-\left|x\right|^{c}\right)\\
-   F\left(x;c\right) & = & \left\{ \begin{array}{ccc}
-   \frac{1}{2}\exp\left(-\left|x\right|^{c}\right) &  & x\leq0\\
-   1-\frac{1}{2}\exp\left(-\left|x\right|^{c}\right) &  & x>0
-   \end{array}\right.\\
-   G\left(q;c\right) & = & \left\{ \begin{array}{ccc}
-   -\log^{1/c}\left(\frac{1}{2q}\right) &  & q\leq\frac{1}{2}\\
-   \log^{1/c}\left(\frac{1}{2q-1}\right) &  & q>\frac{1}{2}
-   \end{array}\right.\end{aligned*}
 
 .. math::
+   :nowrap:
 
-   \mu_{n}^{\prime}=\mu_{n}=\begin{cases}
-   \Gamma\left(1+\frac{n}{c}\right) & n\textrm{ even}\\
-   0 & n\textrm{ odd}
-   \end{cases}
+    \begin{eqnarray*} f\left(x;c\right) & = & \frac{c}{2}\left|x\right|^{c-1}\exp\left(-\left|x\right|^{c}\right)\\ F\left(x;c\right) & = & \left\{ \begin{array}{ccc} \frac{1}{2}\exp\left(-\left|x\right|^{c}\right) &  & x\leq0\\ 1-\frac{1}{2}\exp\left(-\left|x\right|^{c}\right) &  & x>0\end{array}\right.\\ G\left(q;c\right) & = & \left\{ \begin{array}{ccc} -\log^{1/c}\left(\frac{1}{2q}\right) &  & q\leq\frac{1}{2}\\ \log^{1/c}\left(\frac{1}{2q-1}\right) &  & q>\frac{1}{2}\end{array}\right.\end{eqnarray*}
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   m_{d}=\mu & = & 0\\
-   \mu_{2} & = & \Gamma\left(\frac{c+2}{c}\right)\\
-   \gamma_{1} & = & 0\\
-   \gamma_{2} & = & \frac{\Gamma\left(1+\frac{4}{c}\right)}{\Gamma^{2}\left(1+\frac{2}{c}\right)}\\
-   m_{d} & = & \textrm{NA bimodal}\end{aligned*}
+    \[ \mu_{n}^{\prime}=\mu_{n}=\begin{cases} \Gamma\left(1+\frac{n}{c}\right) & n\textrm{ even}\\ 0 & n\textrm{ odd}\end{cases}\]
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} m_{d}=\mu & = & 0\\ \mu_{2} & = & \Gamma\left(\frac{c+2}{c}\right)\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & \frac{\Gamma\left(1+\frac{4}{c}\right)}{\Gamma^{2}\left(1+\frac{2}{c}\right)}\\ m_{d} & = & \textrm{NA bimodal}\end{eqnarray*}
+
+
+
 
 Erlang
 ======
 
-This is just the Gamma distribution with shape parameter
-:math:`\alpha=n` an integer.
+This is just the Gamma distribution with shape parameter :math:`\alpha=n` an integer.
+
 
 Exponential
 ===========
 
 This is a special case of the Gamma (and Erlang) distributions with
-shape parameter :math:`\left(\alpha=1\right)` and the same location and
-scale parameters. The standard form is therefore (:math:`x\geq0`\ )
+shape parameter :math:`\left(\alpha=1\right)` and the same location and scale parameters. The standard form is
+therefore ( :math:`x\geq0` )
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x\right) & = & e^{-x}\\
-   F\left(x\right) & = & \Gamma\left(1,x\right)=1-e^{-x}\\
-   G\left(q\right) & = & -\log\left(1-q\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & e^{-x}\\ F\left(x\right) & = & \Gamma\left(1,x\right)=1-e^{-x}\\ G\left(q\right) & = & -\log\left(1-q\right)\end{eqnarray*}
 
-.. math:: \mu_{n}^{\prime}=n!
 
-.. math:: M\left(t\right)=\frac{1}{1-t}
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & 1\\
-   \mu_{2} & = & 1\\
-   \gamma_{1} & = & 2\\
-   \gamma_{2} & = & 6\\
-   m_{d} & = & 0\end{aligned*}
+    \[ \mu_{n}^{\prime}=n!\]
 
-.. math:: h\left[X\right]=1.
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ M\left(t\right)=\frac{1}{1-t}\]
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & 1\\ \mu_{2} & = & 1\\ \gamma_{1} & = & 2\\ \gamma_{2} & = & 6\\ m_{d} & = & 0\end{eqnarray*}
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=1.\]
+
+
+
 
 Exponentiated Weibull
 =====================
 
-Two positive shape parameters :math:`a` and :math:`c` and
-:math:`x\in\left(0,\infty\right)`
+Two positive shape parameters :math:`a` and :math:`c` and :math:`x\in\left(0,\infty\right)`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;a,c\right) & = & ac\left[1-\exp\left(-x^{c}\right)\right]^{a-1}\exp\left(-x^{c}\right)x^{c-1}\\
-   F\left(x;a,c\right) & = & \left[1-\exp\left(-x^{c}\right)\right]^{a}\\
-   G\left(q;a,c\right) & = & \left[-\log\left(1-q^{1/a}\right)\right]^{1/c}\end{aligned*}
+    \begin{eqnarray*} f\left(x;a,c\right) & = & ac\left[1-\exp\left(-x^{c}\right)\right]^{a-1}\exp\left(-x^{c}\right)x^{c-1}\\ F\left(x;a,c\right) & = & \left[1-\exp\left(-x^{c}\right)\right]^{a}\\ G\left(q;a,c\right) & = & \left[-\log\left(1-q^{1/a}\right)\right]^{1/c}\end{eqnarray*}
+
+
+
 
 Exponential Power
 =================
 
-One positive shape parameter :math:`b`\ . Defined for :math:`x\geq0.`
+One positive shape parameter :math:`b` . Defined for :math:`x\geq0.`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;b\right) & = & ebx^{b-1}\exp\left[x^{b}-e^{x^{b}}\right]\\
-   F\left(x;b\right) & = & 1-\exp\left[1-e^{x^{b}}\right]\\
-   G\left(q;b\right) & = & \log^{1/b}\left[1-\log\left(1-q\right)\right]\end{aligned*}
+    \begin{eqnarray*} f\left(x;b\right) & = & ebx^{b-1}\exp\left[x^{b}-e^{x^{b}}\right]\\ F\left(x;b\right) & = & 1-\exp\left[1-e^{x^{b}}\right]\\ G\left(q;b\right) & = & \log^{1/b}\left[1-\log\left(1-q\right)\right]\end{eqnarray*}
+
+
+
 
 Fatigue Life (Birnbaum-Sanders)
 ===============================
 
-This distribution’s pdf is the average of the inverse-Gaussian
-:math:`\left(\mu=1\right)` and reciprocal inverse-Gaussian pdf
-:math:`\left(\mu=1\right)`\ . We follow the notation of JKB here with
-:math:`\beta=S.` for :math:`x>0`
+This distribution's pdf is the average of the inverse-Gaussian :math:`\left(\mu=1\right)` and reciprocal inverse-Gaussian pdf :math:`\left(\mu=1\right)` . We follow the notation of JKB here with :math:`\beta=S.` for :math:`x>0`
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & \frac{x+1}{2c\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-1\right)^{2}}{2xc^{2}}\right)\\
-   F\left(x;c\right) & = & \Phi\left(\frac{1}{c}\left(\sqrt{x}-\frac{1}{\sqrt{x}}\right)\right)\\
-   G\left(q;c\right) & = & \frac{1}{4}\left[c\Phi^{-1}\left(q\right)+\sqrt{c^{2}\left(\Phi^{-1}\left(q\right)\right)^{2}+4}\right]^{2}\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & \frac{x+1}{2c\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-1\right)^{2}}{2xc^{2}}\right)\\ F\left(x;c\right) & = & \Phi\left(\frac{1}{c}\left(\sqrt{x}-\frac{1}{\sqrt{x}}\right)\right)\\ G\left(q;c\right) & = & \frac{1}{4}\left[c\Phi^{-1}\left(q\right)+\sqrt{c^{2}\left(\Phi^{-1}\left(q\right)\right)^{2}+4}\right]^{2}\end{eqnarray*}
 
-.. math:: M\left(t\right)=c\sqrt{2\pi}\exp\left[\frac{1}{c^{2}}\left(1-\sqrt{1-2c^{2}t}\right)\right]\left(1+\frac{1}{\sqrt{1-2c^{2}t}}\right)
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \frac{c^{2}}{2}+1\\
-   \mu_{2} & = & c^{2}\left(\frac{5}{4}c^{2}+1\right)\\
-   \gamma_{1} & = & \frac{4c\sqrt{11c^{2}+6}}{\left(5c^{2}+4\right)^{3/2}}\\
-   \gamma_{2} & = & \frac{6c^{2}\left(93c^{2}+41\right)}{\left(5c^{2}+4\right)^{2}}\end{aligned*}
+    \[ M\left(t\right)=c\sqrt{2\pi}\exp\left[\frac{1}{c^{2}}\left(1-\sqrt{1-2c^{2}t}\right)\right]\left(1+\frac{1}{\sqrt{1-2c^{2}t}}\right)\]
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & \frac{c^{2}}{2}+1\\ \mu_{2} & = & c^{2}\left(\frac{5}{4}c^{2}+1\right)\\ \gamma_{1} & = & \frac{4c\sqrt{11c^{2}+6}}{\left(5c^{2}+4\right)^{3/2}}\\ \gamma_{2} & = & \frac{6c^{2}\left(93c^{2}+41\right)}{\left(5c^{2}+4\right)^{2}}\end{eqnarray*}
+
+
+
 
 Fisk (Log Logistic)
 ===================
 
 Special case of the Burr distribution with :math:`d=1`
 
-.. math::
 
-   \begin{aligned*}
-   c & > & 0\\
-   k & = & \Gamma\left(1-\frac{2}{c}\right)\Gamma\left(\frac{2}{c}+1\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+1\right)\end{aligned*}
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c,d\right) & = & \frac{cx^{c-1}}{\left(1+x^{c}\right)^{2}}I_{\left(0,\infty\right)}\left(x\right)\\
-   F\left(x;c,d\right) & = & \left(1+x^{-c}\right)^{-1}\\
-   G\left(\alpha;c,d\right) & = & \left(\alpha^{-1}-1\right)^{-1/c}\\
-   \mu & = & \Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+1\right)\\
-   \mu_{2} & = & k\\
-   \gamma_{1} & = & \frac{1}{\sqrt{k^{3}}}\left[2\Gamma^{3}\left(1-\frac{1}{c}\right)\Gamma^{3}\left(\frac{1}{c}+1\right)+\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(\frac{3}{c}+1\right)\right.\\
-    &  & \left.-3\Gamma\left(1-\frac{2}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+1\right)\Gamma\left(\frac{2}{c}+1\right)\right]\\
-   \gamma_{2} & = & -3+\frac{1}{k^{2}}\left[6\Gamma\left(1-\frac{2}{c}\right)\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+1\right)\Gamma\left(\frac{2}{c}+1\right)\right.\\
-    &  & -3\Gamma^{4}\left(1-\frac{1}{c}\right)\Gamma^{4}\left(\frac{1}{c}+1\right)+\Gamma\left(1-\frac{4}{c}\right)\Gamma\left(\frac{4}{c}+1\right)\\
-    &  & \left.-4\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+1\right)\Gamma\left(\frac{3}{c}+1\right)\right]\\
-   m_{d} & = & \left(\frac{c-1}{c+1}\right)^{1/c}\,\textrm{if }c>1\,\textrm{otherwise }0\\
-   m_{n} & = & 1\end{aligned*}
+    \begin{eqnarray*} c & > & 0\\ k & = & \Gamma\left(1-\frac{2}{c}\right)\Gamma\left(\frac{2}{c}+1\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+1\right)\end{eqnarray*}
 
-.. math:: h\left[X\right]=2-\log c.
+
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} f\left(x;c,d\right) & = & \frac{cx^{c-1}}{\left(1+x^{c}\right)^{2}}I_{\left(0,\infty\right)}\left(x\right)\\ F\left(x;c,d\right) & = & \left(1+x^{-c}\right)^{-1}\\ G\left(\alpha;c,d\right) & = & \left(\alpha^{-1}-1\right)^{-1/c}\\ \mu & = & \Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+1\right)\\ \mu_{2} & = & k\\ \gamma_{1} & = & \frac{1}{\sqrt{k^{3}}}\left[2\Gamma^{3}\left(1-\frac{1}{c}\right)\Gamma^{3}\left(\frac{1}{c}+1\right)+\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(\frac{3}{c}+1\right)\right.\\  &  & \left.-3\Gamma\left(1-\frac{2}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+1\right)\Gamma\left(\frac{2}{c}+1\right)\right]\\ \gamma_{2} & = & -3+\frac{1}{k^{2}}\left[6\Gamma\left(1-\frac{2}{c}\right)\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+1\right)\Gamma\left(\frac{2}{c}+1\right)\right.\\  &  & -3\Gamma^{4}\left(1-\frac{1}{c}\right)\Gamma^{4}\left(\frac{1}{c}+1\right)+\Gamma\left(1-\frac{4}{c}\right)\Gamma\left(\frac{4}{c}+1\right)\\  &  & \left.-4\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+1\right)\Gamma\left(\frac{3}{c}+1\right)\right]\\ m_{d} & = & \left(\frac{c-1}{c+1}\right)^{1/c}\,\textrm{if }c>1\,\textrm{otherwise }0\\ m_{n} & = & 1\end{eqnarray*}
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=2-\log c.\]
+
+
+
 
 Folded Cauchy
 =============
 
-This formula can be expressed in terms of the standard formulas for the
-Cauchy distribution (call the cdf :math:`C\left(x\right)` and the pdf
-:math:`d\left(x\right)`\ ). if :math:`Y` is cauchy then
-:math:`\left|Y\right|` is folded cauchy. Note that :math:`x\geq0.`
+This formula can be expressed in terms of the standard formulas for
+the Cauchy distribution (call the cdf :math:`C\left(x\right)` and the pdf :math:`d\left(x\right)` ). if :math:`Y` is cauchy then :math:`\left|Y\right|` is folded cauchy. Note that :math:`x\geq0.`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & \frac{1}{\pi\left(1+\left(x-c\right)^{2}\right)}+\frac{1}{\pi\left(1+\left(x+c\right)^{2}\right)}\\
-   F\left(x;c\right) & = & \frac{1}{\pi}\tan^{-1}\left(x-c\right)+\frac{1}{\pi}\tan^{-1}\left(x+c\right)\\
-   G\left(q;c\right) & = & F^{-1}\left(x;c\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & \frac{1}{\pi\left(1+\left(x-c\right)^{2}\right)}+\frac{1}{\pi\left(1+\left(x+c\right)^{2}\right)}\\ F\left(x;c\right) & = & \frac{1}{\pi}\tan^{-1}\left(x-c\right)+\frac{1}{\pi}\tan^{-1}\left(x+c\right)\\ G\left(q;c\right) & = & F^{-1}\left(x;c\right)\end{eqnarray*}
+
+
 
 No moments
+
 
 Folded Normal
 =============
 
-If :math:`Z` is Normal with mean :math:`L` and :math:`\sigma=S`\ , then
-:math:`\left|Z\right|` is a folded normal with shape parameter
-:math:`c=\left|L\right|/S`\ , location parameter :math:`0` and scale
-parameter :math:`S`\ . This is a special case of the non-central chi
-distribution with one-degree of freedom and non-centrality parameter
-:math:`c^{2}.` Note that :math:`c\geq0`\ . The standard form of the
-folded normal is
+If :math:`Z` is Normal with mean :math:`L` and :math:`\sigma=S` , then :math:`\left|Z\right|` is a folded normal with shape parameter :math:`c=\left|L\right|/S` , location parameter :math:`0` and scale parameter :math:`S` . This is a special case of the non-central chi distribution with one-
+degree of freedom and non-centrality parameter :math:`c^{2}.` Note that :math:`c\geq0` . The standard form of the folded normal is
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & \sqrt{\frac{2}{\pi}}\cosh\left(cx\right)\exp\left(-\frac{x^{2}+c^{2}}{2}\right)\\
-   F\left(x;c\right) & = & \Phi\left(x-c\right)-\Phi\left(-x-c\right)=\Phi\left(x-c\right)+\Phi\left(x+c\right)-1\\
-   G\left(\alpha;c\right) & = & F^{-1}\left(x;c\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & \sqrt{\frac{2}{\pi}}\cosh\left(cx\right)\exp\left(-\frac{x^{2}+c^{2}}{2}\right)\\ F\left(x;c\right) & = & \Phi\left(x-c\right)-\Phi\left(-x-c\right)=\Phi\left(x-c\right)+\Phi\left(x+c\right)-1\\ G\left(\alpha;c\right) & = & F^{-1}\left(x;c\right)\end{eqnarray*}
 
-.. math:: M\left(t\right)=\exp\left[\frac{t}{2}\left(t-2c\right)\right]\left(1+e^{2ct}\right)
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   k & = & \textrm{erf}\left(\frac{c}{\sqrt{2}}\right)\\
-   p & = & \exp\left(-\frac{c^{2}}{2}\right)\\
-   \mu & = & \sqrt{\frac{2}{\pi}}p+ck\\
-   \mu_{2} & = & c^{2}+1-\mu^{2}\\
-   \gamma_{1} & = & \frac{\sqrt{\frac{2}{\pi}}p^{3}\left(4-\frac{\pi}{p^{2}}\left(2c^{2}+1\right)\right)+2ck\left(6p^{2}+3cpk\sqrt{2\pi}+\pi c\left(k^{2}-1\right)\right)}{\pi\mu_{2}^{3/2}}\\
-   \gamma_{2} & = & \frac{c^{4}+6c^{2}+3+6\left(c^{2}+1\right)\mu^{2}-3\mu^{4}-4p\mu\left(\sqrt{\frac{2}{\pi}}\left(c^{2}+2\right)+\frac{ck}{p}\left(c^{2}+3\right)\right)}{\mu_{2}^{2}}\end{aligned*}
+    \[ M\left(t\right)=\exp\left[\frac{t}{2}\left(t-2c\right)\right]\left(1+e^{2ct}\right)\]
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} k & = & \textrm{erf}\left(\frac{c}{\sqrt{2}}\right)\\ p & = & \exp\left(-\frac{c^{2}}{2}\right)\\ \mu & = & \sqrt{\frac{2}{\pi}}p+ck\\ \mu_{2} & = & c^{2}+1-\mu^{2}\\ \gamma_{1} & = & \frac{\sqrt{\frac{2}{\pi}}p^{3}\left(4-\frac{\pi}{p^{2}}\left(2c^{2}+1\right)\right)+2ck\left(6p^{2}+3cpk\sqrt{2\pi}+\pi c\left(k^{2}-1\right)\right)}{\pi\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{c^{4}+6c^{2}+3+6\left(c^{2}+1\right)\mu^{2}-3\mu^{4}-4p\mu\left(\sqrt{\frac{2}{\pi}}\left(c^{2}+2\right)+\frac{ck}{p}\left(c^{2}+3\right)\right)}{\mu_{2}^{2}}\end{eqnarray*}
+
+
+
 
 Fratio (or F)
 =============
 
-Defined for :math:`x>0`\ . The distribution of
-:math:`\left(X_{1}/X_{2}\right)\left(\nu_{2}/\nu_{1}\right)` if
-:math:`X_{1}` is chi-squared with :math:`v_{1}` degrees of freedom and
-:math:`X_{2}` is chi-squared with :math:`v_{2}` degrees of freedom.
+Defined for :math:`x>0` . The distribution of :math:`\left(X_{1}/X_{2}\right)\left(\nu_{2}/\nu_{1}\right)` if :math:`X_{1}` is chi-squared with :math:`v_{1}` degrees of freedom and :math:`X_{2}` is chi-squared with :math:`v_{2}` degrees of freedom.
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\nu_{1},\nu_{2}\right) & = & \frac{\nu_{2}^{\nu_{2}/2}\nu_{1}^{\nu_{1}/2}x^{\nu_{1}/2-1}}{\left(\nu_{2}+\nu_{1}x\right)^{\left(\nu_{1}+\nu_{2}\right)/2}B\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2}\right)}\\
-   F\left(x;v_{1},v_{2}\right) & = & I\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2},\frac{\nu_{2}x}{\nu_{2}+\nu_{1}x}\right)\\
-   G\left(q;\nu_{1},\nu_{2}\right) & = & \left[\frac{\nu_{2}}{I^{-1}\left(\nu_{1}/2,\nu_{2}/2,q\right)}-\frac{\nu_{1}}{\nu_{2}}\right]^{-1}.\end{aligned*}
+    \begin{eqnarray*} f\left(x;\nu_{1},\nu_{2}\right) & = & \frac{\nu_{2}^{\nu_{2}/2}\nu_{1}^{\nu_{1}/2}x^{\nu_{1}/2-1}}{\left(\nu_{2}+\nu_{1}x\right)^{\left(\nu_{1}+\nu_{2}\right)/2}B\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2}\right)}\\ F\left(x;v_{1},v_{2}\right) & = & I\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2},\frac{\nu_{2}x}{\nu_{2}+\nu_{1}x}\right)\\ G\left(q;\nu_{1},\nu_{2}\right) & = & \left[\frac{\nu_{2}}{I^{-1}\left(\nu_{1}/2,\nu_{2}/2,q\right)}-\frac{\nu_{1}}{\nu_{2}}\right]^{-1}.\end{eqnarray*}
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \frac{\nu_{2}}{\nu_{2}-2}\quad\nu_{2}>2\\
-   \mu_{2} & = & \frac{2\nu_{2}^{2}\left(\nu_{1}+\nu_{2}-2\right)}{\nu_{1}\left(\nu_{2}-2\right)^{2}\left(\nu_{2}-4\right)}\quad v_{2}>4\\
-   \gamma_{1} & = & \frac{2\left(2\nu_{1}+\nu_{2}-2\right)}{\nu_{2}-6}\sqrt{\frac{2\left(\nu_{2}-4\right)}{\nu_{1}\left(\nu_{1}+\nu_{2}-2\right)}}\quad\nu_{2}>6\\
-   \gamma_{2} & = & \frac{3\left[8+\left(\nu_{2}-6\right)\gamma_{1}^{2}\right]}{2\nu-16}\quad\nu_{2}>8\end{aligned*}
+    \begin{eqnarray*} \mu & = & \frac{\nu_{2}}{\nu_{2}-2}\quad\nu_{2}>2\\ \mu_{2} & = & \frac{2\nu_{2}^{2}\left(\nu_{1}+\nu_{2}-2\right)}{\nu_{1}\left(\nu_{2}-2\right)^{2}\left(\nu_{2}-4\right)}\quad v_{2}>4\\ \gamma_{1} & = & \frac{2\left(2\nu_{1}+\nu_{2}-2\right)}{\nu_{2}-6}\sqrt{\frac{2\left(\nu_{2}-4\right)}{\nu_{1}\left(\nu_{1}+\nu_{2}-2\right)}}\quad\nu_{2}>6\\ \gamma_{2} & = & \frac{3\left[8+\left(\nu_{2}-6\right)\gamma_{1}^{2}\right]}{2\nu-16}\quad\nu_{2}>8\end{eqnarray*}
+
+
+
 
 Fréchet (ExtremeLB, Extreme Value II, Weibull minimum)
-======================================================
+=======================================================
 
-A type of extreme-value distribution with a lower bound. Defined for
-:math:`x>0` and :math:`c>0`
-
-.. math::
-
-   \begin{aligned*}
-   f\left(x;c\right) & = & cx^{c-1}\exp\left(-x^{c}\right)\\
-   F\left(x;c\right) & = & 1-\exp\left(-x^{c}\right)\\
-   G\left(q;c\right) & = & \left[-\log\left(1-q\right)\right]^{1/c}\end{aligned*}
-
-.. math:: \mu_{n}^{\prime}=\Gamma\left(1+\frac{n}{c}\right)
+A type of extreme-value distribution with a lower bound. Defined for :math:`x>0` and :math:`c>0`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \Gamma\left(1+\frac{1}{c}\right)\\
-   \mu_{2} & = & \Gamma\left(1+\frac{2}{c}\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\\
-   \gamma_{1} & = & \frac{\Gamma\left(1+\frac{3}{c}\right)-3\Gamma\left(1+\frac{2}{c}\right)\Gamma\left(1+\frac{1}{c}\right)+2\Gamma^{3}\left(1+\frac{1}{c}\right)}{\mu_{2}^{3/2}}\\
-   \gamma_{2} & = & \frac{\Gamma\left(1+\frac{4}{c}\right)-4\Gamma\left(1+\frac{1}{c}\right)\Gamma\left(1+\frac{3}{c}\right)+6\Gamma^{2}\left(1+\frac{1}{c}\right)\Gamma\left(1+\frac{2}{c}\right)-\Gamma^{4}\left(1+\frac{1}{c}\right)}{\mu_{2}^{2}}-3\\
-   m_{d} & = & \left(\frac{c}{1+c}\right)^{1/c}\\
-   m_{n} & = & G\left(\frac{1}{2};c\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & cx^{c-1}\exp\left(-x^{c}\right)\\ F\left(x;c\right) & = & 1-\exp\left(-x^{c}\right)\\ G\left(q;c\right) & = & \left[-\log\left(1-q\right)\right]^{1/c}\end{eqnarray*}
 
-.. math:: h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1
 
- where :math:`\gamma` is Euler’s constant and equal to
 
-.. math:: \gamma\approx0.57721566490153286061.
+.. math::
+   :nowrap:
+
+    \[ \mu_{n}^{\prime}=\Gamma\left(1+\frac{n}{c}\right)\]
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & \Gamma\left(1+\frac{1}{c}\right)\\ \mu_{2} & = & \Gamma\left(1+\frac{2}{c}\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\\ \gamma_{1} & = & \frac{\Gamma\left(1+\frac{3}{c}\right)-3\Gamma\left(1+\frac{2}{c}\right)\Gamma\left(1+\frac{1}{c}\right)+2\Gamma^{3}\left(1+\frac{1}{c}\right)}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\Gamma\left(1+\frac{4}{c}\right)-4\Gamma\left(1+\frac{1}{c}\right)\Gamma\left(1+\frac{3}{c}\right)+6\Gamma^{2}\left(1+\frac{1}{c}\right)\Gamma\left(1+\frac{2}{c}\right)-\Gamma^{4}\left(1+\frac{1}{c}\right)}{\mu_{2}^{2}}-3\\ m_{d} & = & \left(\frac{c}{1+c}\right)^{1/c}\\ m_{n} & = & G\left(\frac{1}{2};c\right)\end{eqnarray*}
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1\]
+
+where :math:`\gamma` is Euler's constant and equal to
+
+.. math::
+   :nowrap:
+
+    \[ \gamma\approx0.57721566490153286061.\]
+
+
+
 
 Fréchet (left-skewed, Extreme Value Type III, Weibull maximum)
-==============================================================
+===============================================================
 
-Defined for :math:`x<0` and :math:`c>0`\ .
+Defined for :math:`x<0` and :math:`c>0` .
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & c\left(-x\right)^{c-1}\exp\left(-\left(-x\right)^{c}\right)\\
-   F\left(x;c\right) & = & \exp\left(-\left(-x\right)^{c}\right)\\
-   G\left(q;c\right) & = & -\left(-\log q\right)^{1/c}\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & c\left(-x\right)^{c-1}\exp\left(-\left(-x\right)^{c}\right)\\ F\left(x;c\right) & = & \exp\left(-\left(-x\right)^{c}\right)\\ G\left(q;c\right) & = & -\left(-\log q\right)^{1/c}\end{eqnarray*}
 
-The mean is the negative of the right-skewed Frechet distribution given
-above, and the other statistical parameters can be computed from
 
-.. math:: \mu_{n}^{\prime}=\left(-1\right)^{n}\Gamma\left(1+\frac{n}{c}\right).
 
-.. math:: h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1
+The mean is the negative of the right-skewed Frechet distribution
+given above, and the other statistical parameters can be computed from
 
- where :math:`\gamma` is Euler’s constant and equal to
 
-.. math:: \gamma\approx0.57721566490153286061.
+
+.. math::
+   :nowrap:
+
+    \[ \mu_{n}^{\prime}=\left(-1\right)^{n}\Gamma\left(1+\frac{n}{c}\right).\]
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1\]
+
+where :math:`\gamma` is Euler's constant and equal to
+
+.. math::
+   :nowrap:
+
+    \[ \gamma\approx0.57721566490153286061.\]
+
+
+
 
 Gamma
 =====
 
-The standard form for the gamma distribution is
-:math:`\left(\alpha>0\right)` valid for :math:`x\geq0`\ .
+The standard form for the gamma distribution is :math:`\left(\alpha>0\right)` valid for :math:`x\geq0` .
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\alpha\right) & = & \frac{1}{\Gamma\left(\alpha\right)}x^{\alpha-1}e^{-x}\\
-   F\left(x;\alpha\right) & = & \Gamma\left(\alpha,x\right)\\
-   G\left(q;\alpha\right) & = & \Gamma^{-1}\left(\alpha,q\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x;\alpha\right) & = & \frac{1}{\Gamma\left(\alpha\right)}x^{\alpha-1}e^{-x}\\ F\left(x;\alpha\right) & = & \Gamma\left(\alpha,x\right)\\ G\left(q;\alpha\right) & = & \Gamma^{-1}\left(\alpha,q\right)\end{eqnarray*}
 
-.. math:: M\left(t\right)=\frac{1}{\left(1-t\right)^{\alpha}}
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \alpha\\
-   \mu_{2} & = & \alpha\\
-   \gamma_{1} & = & \frac{2}{\sqrt{\alpha}}\\
-   \gamma_{2} & = & \frac{6}{\alpha}\\
-   m_{d} & = & \alpha-1\end{aligned*}
+    \[ M\left(t\right)=\frac{1}{\left(1-t\right)^{\alpha}}\]
 
-.. math:: h\left[X\right]=\Psi\left(a\right)\left[1-a\right]+a+\log\Gamma\left(a\right)
 
- where
 
-.. math:: \Psi\left(a\right)=\frac{\Gamma^{\prime}\left(a\right)}{\Gamma\left(a\right)}.
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & \alpha\\ \mu_{2} & = & \alpha\\ \gamma_{1} & = & \frac{2}{\sqrt{\alpha}}\\ \gamma_{2} & = & \frac{6}{\alpha}\\ m_{d} & = & \alpha-1\end{eqnarray*}
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=\Psi\left(a\right)\left[1-a\right]+a+\log\Gamma\left(a\right)\]
+
+where
+
+.. math::
+   :nowrap:
+
+    \[ \Psi\left(a\right)=\frac{\Gamma^{\prime}\left(a\right)}{\Gamma\left(a\right)}.\]
+
+
+
 
 Generalized Logistic
 ====================
 
-Has been used in the analysis of extreme values. Has one shape parameter
-:math:`c>0.` And :math:`x>0`
+Has been used in the analysis of extreme values. Has one shape
+parameter :math:`c>0.` And :math:`x>0`
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & \frac{c\exp\left(-x\right)}{\left[1+\exp\left(-x\right)\right]^{c+1}}\\
-   F\left(x;c\right) & = & \frac{1}{\left[1+\exp\left(-x\right)\right]^{c}}\\
-   G\left(q;c\right) & = & -\log\left(q^{-1/c}-1\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & \frac{c\exp\left(-x\right)}{\left[1+\exp\left(-x\right)\right]^{c+1}}\\ F\left(x;c\right) & = & \frac{1}{\left[1+\exp\left(-x\right)\right]^{c}}\\ G\left(q;c\right) & = & -\log\left(q^{-1/c}-1\right)\end{eqnarray*}
 
-.. math:: M\left(t\right)=\frac{c}{1-t}\,_{2}F_{1}\left(1+c,\,1-t\,;\,2-t\,;-1\right)
+
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \gamma+\psi_{0}\left(c\right)\\
-   \mu_{2} & = & \frac{\pi^{2}}{6}+\psi_{1}\left(c\right)\\
-   \gamma_{1} & = & \frac{\psi_{2}\left(c\right)+2\zeta\left(3\right)}{\mu_{2}^{3/2}}\\
-   \gamma_{2} & = & \frac{\left(\frac{\pi^{4}}{15}+\psi_{3}\left(c\right)\right)}{\mu_{2}^{2}}\\
-   m_{d} & = & \log c\\
-   m_{n} & = & -\log\left(2^{1/c}-1\right)\end{aligned*}
+    \[ M\left(t\right)=\frac{c}{1-t}\,_{2}F_{1}\left(1+c,\,1-t\,;\,2-t\,;-1\right)\]
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & \gamma+\psi_{0}\left(c\right)\\ \mu_{2} & = & \frac{\pi^{2}}{6}+\psi_{1}\left(c\right)\\ \gamma_{1} & = & \frac{\psi_{2}\left(c\right)+2\zeta\left(3\right)}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\left(\frac{\pi^{4}}{15}+\psi_{3}\left(c\right)\right)}{\mu_{2}^{2}}\\ m_{d} & = & \log c\\ m_{n} & = & -\log\left(2^{1/c}-1\right)\end{eqnarray*}
 
 Note that the polygamma function is
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \psi_{n}\left(z\right) & = & \frac{d^{n+1}}{dz^{n+1}}\log\Gamma\left(z\right)\\
-    & = & \left(-1\right)^{n+1}n!\sum_{k=0}^{\infty}\frac{1}{\left(z+k\right)^{n+1}}\\
-    & = & \left(-1\right)^{n+1}n!\zeta\left(n+1,z\right)\end{aligned*}
+    \begin{eqnarray*} \psi_{n}\left(z\right) & = & \frac{d^{n+1}}{dz^{n+1}}\log\Gamma\left(z\right)\\  & = & \left(-1\right)^{n+1}n!\sum_{k=0}^{\infty}\frac{1}{\left(z+k\right)^{n+1}}\\  & = & \left(-1\right)^{n+1}n!\zeta\left(n+1,z\right)\end{eqnarray*}
 
-where :math:`\zeta\left(k,x\right)` is a generalization of the Riemann
-zeta function called the Hurwitz zeta function Note that
-:math:`\zeta\left(n\right)\equiv\zeta\left(n,1\right)`
+where :math:`\zeta\left(k,x\right)` is a generalization of the Riemann zeta function called the Hurwitz
+zeta function Note that :math:`\zeta\left(n\right)\equiv\zeta\left(n,1\right)`
+
 
 Generalized Pareto
 ==================
 
-Shape parameter :math:`c\neq0` and defined for :math:`x\geq0` for all
-:math:`c` and :math:`x<\frac{1}{\left|c\right|}` if :math:`c` is
-negative.
+Shape parameter :math:`c\neq0` and defined for :math:`x\geq0` for all :math:`c` and :math:`x<\frac{1}{\left|c\right|}` if :math:`c` is negative.
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & \left(1+cx\right)^{-1-\frac{1}{c}}\\
-   F\left(x;c\right) & = & 1-\frac{1}{\left(1+cx\right)^{1/c}}\\
-   G\left(q;c\right) & = & \frac{1}{c}\left[\left(\frac{1}{1-q}\right)^{c}-1\right]\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & \left(1+cx\right)^{-1-\frac{1}{c}}\\ F\left(x;c\right) & = & 1-\frac{1}{\left(1+cx\right)^{1/c}}\\ G\left(q;c\right) & = & \frac{1}{c}\left[\left(\frac{1}{1-q}\right)^{c}-1\right]\end{eqnarray*}
 
-.. math::
 
-   M\left(t\right)=\left\{ \begin{array}{cc}
-   \left(-\frac{t}{c}\right)^{\frac{1}{c}}e^{-\frac{t}{c}}\left[\Gamma\left(1-\frac{1}{c}\right)+\Gamma\left(-\frac{1}{c},-\frac{t}{c}\right)-\pi\csc\left(\frac{\pi}{c}\right)/\Gamma\left(\frac{1}{c}\right)\right] & c>0\\
-   \left(\frac{\left|c\right|}{t}\right)^{1/\left|c\right|}\Gamma\left[\frac{1}{\left|c\right|},\frac{t}{\left|c\right|}\right] & c<0
-   \end{array}\right.
+
+
 
 .. math::
+   :nowrap:
 
-   \mu_{n}^{\prime}=\frac{\left(-1\right)^{n}}{c^{n}}\sum_{k=0}^{n}\left(\begin{array}{c}
-   n\\
-   k
-   \end{array}\right)\frac{\left(-1\right)^{k}}{1-ck}\quad cn<1
+    \[ M\left(t\right)=\left\{ \begin{array}{cc} \left(-\frac{t}{c}\right)^{\frac{1}{c}}e^{-\frac{t}{c}}\left[\Gamma\left(1-\frac{1}{c}\right)+\Gamma\left(-\frac{1}{c},-\frac{t}{c}\right)-\pi\csc\left(\frac{\pi}{c}\right)/\Gamma\left(\frac{1}{c}\right)\right] & c>0\\ \left(\frac{\left|c\right|}{t}\right)^{1/\left|c\right|}\Gamma\left[\frac{1}{\left|c\right|},\frac{t}{\left|c\right|}\right] & c<0\end{array}\right.\]
+
+
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu_{1}^{\prime} & = & \frac{1}{1-c}\quad c<1\\
-   \mu_{2}^{\prime} & = & \frac{2}{\left(1-2c\right)\left(1-c\right)}\quad c<\frac{1}{2}\\
-   \mu_{3}^{\prime} & = & \frac{6}{\left(1-c\right)\left(1-2c\right)\left(1-3c\right)}\quad c<\frac{1}{3}\\
-   \mu_{4}^{\prime} & = & \frac{24}{\left(1-c\right)\left(1-2c\right)\left(1-3c\right)\left(1-4c\right)}\quad c<\frac{1}{4}\end{aligned*}
+    \[ \mu_{n}^{\prime}=\frac{\left(-1\right)^{n}}{c^{n}}\sum_{k=0}^{n}\left(\begin{array}{c} n\\ k\end{array}\right)\frac{\left(-1\right)^{k}}{1-ck}\quad cn<1\]
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu_{1}^{\prime} & = & \frac{1}{1-c}\quad c<1\\ \mu_{2}^{\prime} & = & \frac{2}{\left(1-2c\right)\left(1-c\right)}\quad c<\frac{1}{2}\\ \mu_{3}^{\prime} & = & \frac{6}{\left(1-c\right)\left(1-2c\right)\left(1-3c\right)}\quad c<\frac{1}{3}\\ \mu_{4}^{\prime} & = & \frac{24}{\left(1-c\right)\left(1-2c\right)\left(1-3c\right)\left(1-4c\right)}\quad c<\frac{1}{4}\end{eqnarray*}
 
 Thus,
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \mu_{1}^{\prime}\\
-   \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\
-   \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
-   \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{aligned*}
+    \begin{eqnarray*} \mu & = & \mu_{1}^{\prime}\\ \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\ \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{eqnarray*}
 
-.. math:: h\left[X\right]=1+c\quad c>0
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=1+c\quad c>0\]
+
+
+
 
 Generalized Exponential
 =======================
 
-Three positive shape parameters for :math:`x\geq0.` Note that
-:math:`a,b,` and :math:`c` are all :math:`>0.`
+Three positive shape parameters for :math:`x\geq0.` Note that :math:`a,b,` and :math:`c` are all :math:`>0.`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;a,b,c\right) & = & \left(a+b\left(1-e^{-cx}\right)\right)\exp\left[ax-bx+\frac{b}{c}\left(1-e^{-cx}\right)\right]\\
-   F\left(x;a,b,c\right) & = & 1-\exp\left[ax-bx+\frac{b}{c}\left(1-e^{-cx}\right)\right]\\
-   G\left(q;a,b,c\right) & = & F^{-1}\end{aligned*}
+    \begin{eqnarray*} f\left(x;a,b,c\right) & = & \left(a+b\left(1-e^{-cx}\right)\right)\exp\left[ax-bx+\frac{b}{c}\left(1-e^{-cx}\right)\right]\\ F\left(x;a,b,c\right) & = & 1-\exp\left[ax-bx+\frac{b}{c}\left(1-e^{-cx}\right)\right]\\ G\left(q;a,b,c\right) & = & F^{-1}\end{eqnarray*}
+
+
+
 
 Generalized Extreme Value
 =========================
 
-Extreme value distributions with shape parameter :math:`c`\ .
+Extreme value distributions with shape parameter :math:`c` .
 
 For :math:`c>0` defined on :math:`-\infty<x\leq1/c.`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & \exp\left[-\left(1-cx\right)^{1/c}\right]\left(1-cx\right)^{1/c-1}\\
-   F\left(x;c\right) & = & \exp\left[-\left(1-cx\right)^{1/c}\right]\\
-   G\left(q;c\right) & = & \frac{1}{c}\left[1-\left(-\log q\right)^{c}\right]\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & \exp\left[-\left(1-cx\right)^{1/c}\right]\left(1-cx\right)^{1/c-1}\\ F\left(x;c\right) & = & \exp\left[-\left(1-cx\right)^{1/c}\right]\\ G\left(q;c\right) & = & \frac{1}{c}\left[1-\left(-\log q\right)^{c}\right]\end{eqnarray*}
 
-.. math::
 
-   \mu_{n}^{\prime}=\frac{1}{c^{n}}\sum_{k=0}^{n}\left(\begin{array}{c}
-   n\\
-   k
-   \end{array}\right)\left(-1\right)^{k}\Gamma\left(ck+1\right)\quad cn>-1
-
- So,
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu_{1}^{\prime} & = & \frac{1}{c}\left(1-\Gamma\left(1+c\right)\right)\quad c>-1\\
-   \mu_{2}^{\prime} & = & \frac{1}{c^{2}}\left(1-2\Gamma\left(1+c\right)+\Gamma\left(1+2c\right)\right)\quad c>-\frac{1}{2}\\
-   \mu_{3}^{\prime} & = & \frac{1}{c^{3}}\left(1-3\Gamma\left(1+c\right)+3\Gamma\left(1+2c\right)-\Gamma\left(1+3c\right)\right)\quad c>-\frac{1}{3}\\
-   \mu_{4}^{\prime} & = & \frac{1}{c^{4}}\left(1-4\Gamma\left(1+c\right)+6\Gamma\left(1+2c\right)-4\Gamma\left(1+3c\right)+\Gamma\left(1+4c\right)\right)\quad c>-\frac{1}{4}\end{aligned*}
+    \[ \mu_{n}^{\prime}=\frac{1}{c^{n}}\sum_{k=0}^{n}\left(\begin{array}{c} n\\ k\end{array}\right)\left(-1\right)^{k}\Gamma\left(ck+1\right)\quad cn>-1\]
 
-For :math:`c<0` defined on :math:`\frac{1}{c}\leq x<\infty.` For
-:math:`c=0` defined over all space
+So,
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;0\right) & = & \exp\left[-e^{-x}\right]e^{-x}\\
-   F\left(x;0\right) & = & \exp\left[-e^{-x}\right]\\
-   G\left(q;0\right) & = & -\log\left(-\log q\right)\end{aligned*}
+    \begin{eqnarray*} \mu_{1}^{\prime} & = & \frac{1}{c}\left(1-\Gamma\left(1+c\right)\right)\quad c>-1\\ \mu_{2}^{\prime} & = & \frac{1}{c^{2}}\left(1-2\Gamma\left(1+c\right)+\Gamma\left(1+2c\right)\right)\quad c>-\frac{1}{2}\\ \mu_{3}^{\prime} & = & \frac{1}{c^{3}}\left(1-3\Gamma\left(1+c\right)+3\Gamma\left(1+2c\right)-\Gamma\left(1+3c\right)\right)\quad c>-\frac{1}{3}\\ \mu_{4}^{\prime} & = & \frac{1}{c^{4}}\left(1-4\Gamma\left(1+c\right)+6\Gamma\left(1+2c\right)-4\Gamma\left(1+3c\right)+\Gamma\left(1+4c\right)\right)\quad c>-\frac{1}{4}\end{eqnarray*}
+
+For :math:`c<0` defined on :math:`\frac{1}{c}\leq x<\infty.` For :math:`c=0` defined over all space
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} f\left(x;0\right) & = & \exp\left[-e^{-x}\right]e^{-x}\\ F\left(x;0\right) & = & \exp\left[-e^{-x}\right]\\ G\left(q;0\right) & = & -\log\left(-\log q\right)\end{eqnarray*}
 
 This is just the (left-skewed) Gumbel distribution for c=0.
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \gamma=-\psi_{0}\left(1\right)\\
-   \mu_{2} & = & \frac{\pi^{2}}{6}\\
-   \gamma_{1} & = & \frac{12\sqrt{6}}{\pi^{3}}\zeta\left(3\right)\\
-   \gamma_{2} & = & \frac{12}{5}\end{aligned*}
+    \begin{eqnarray*} \mu & = & \gamma=-\psi_{0}\left(1\right)\\ \mu_{2} & = & \frac{\pi^{2}}{6}\\ \gamma_{1} & = & \frac{12\sqrt{6}}{\pi^{3}}\zeta\left(3\right)\\ \gamma_{2} & = & \frac{12}{5}\end{eqnarray*}
+
+
+
 
 Generalized Gamma
 =================
 
-A general probability form that reduces to many common distributions:
-:math:`x>0` :math:`a>0` and :math:`c\neq0.`
+A general probability form that reduces to many common distributions: :math:`x>0` :math:`a>0` and :math:`c\neq0.`
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;a,c\right) & = & \frac{\left|c\right|x^{ca-1}}{\Gamma\left(a\right)}\exp\left(-x^{c}\right)\\
-   F\left(x;a,c\right) & = & \begin{array}{cc}
-   \frac{\Gamma\left(a,x^{c}\right)}{\Gamma\left(a\right)} & c>0\\
-   1-\frac{\Gamma\left(a,x^{c}\right)}{\Gamma\left(a\right)} & c<0
-   \end{array}\\
-   G\left(q;a,c\right) & = & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)q\right]\right\} ^{1/c}\quad c>0\\
-    &  & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)\left(1-q\right)\right]\right\} ^{1/c}\quad c<0\end{aligned*}
+    \begin{eqnarray*} f\left(x;a,c\right) & = & \frac{\left|c\right|x^{ca-1}}{\Gamma\left(a\right)}\exp\left(-x^{c}\right)\\ F\left(x;a,c\right) & = & \begin{array}{cc} \frac{\Gamma\left(a,x^{c}\right)}{\Gamma\left(a\right)} & c>0\\ 1-\frac{\Gamma\left(a,x^{c}\right)}{\Gamma\left(a\right)} & c<0\end{array}\\ G\left(q;a,c\right) & = & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)q\right]\right\} ^{1/c}\quad c>0\\  &  & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)\left(1-q\right)\right]\right\} ^{1/c}\quad c<0\end{eqnarray*}
 
-.. math:: \mu_{n}^{\prime}=\frac{\Gamma\left(a+\frac{n}{c}\right)}{\Gamma\left(a\right)}
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \frac{\Gamma\left(a+\frac{1}{c}\right)}{\Gamma\left(a\right)}\\
-   \mu_{2} & = & \frac{\Gamma\left(a+\frac{2}{c}\right)}{\Gamma\left(a\right)}-\mu^{2}\\
-   \gamma_{1} & = & \frac{\Gamma\left(a+\frac{3}{c}\right)/\Gamma\left(a\right)-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
-   \gamma_{2} & = & \frac{\Gamma\left(a+\frac{4}{c}\right)/\Gamma\left(a\right)-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\\
-   m_{d} & = & \left(\frac{ac-1}{c}\right)^{1/c}.\end{aligned*}
+    \[ \mu_{n}^{\prime}=\frac{\Gamma\left(a+\frac{n}{c}\right)}{\Gamma\left(a\right)}\]
 
-Special cases are Weibull :math:`\left(a=1\right)`\ , half-normal
-:math:`\left(a=1/2,c=2\right)` and ordinary gamma distributions
-:math:`c=1.` If :math:`c=-1` then it is the inverted gamma distribution.
 
-.. math:: h\left[X\right]=a-a\Psi\left(a\right)+\frac{1}{c}\Psi\left(a\right)+\log\Gamma\left(a\right)-\log\left|c\right|.
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & \frac{\Gamma\left(a+\frac{1}{c}\right)}{\Gamma\left(a\right)}\\ \mu_{2} & = & \frac{\Gamma\left(a+\frac{2}{c}\right)}{\Gamma\left(a\right)}-\mu^{2}\\ \gamma_{1} & = & \frac{\Gamma\left(a+\frac{3}{c}\right)/\Gamma\left(a\right)-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\Gamma\left(a+\frac{4}{c}\right)/\Gamma\left(a\right)-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\\ m_{d} & = & \left(\frac{ac-1}{c}\right)^{1/c}.\end{eqnarray*}
+
+Special cases are Weibull :math:`\left(a=1\right)` , half-normal :math:`\left(a=1/2,c=2\right)` and ordinary gamma distributions :math:`c=1.` If :math:`c=-1` then it is the inverted gamma distribution.
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=a-a\Psi\left(a\right)+\frac{1}{c}\Psi\left(a\right)+\log\Gamma\left(a\right)-\log\left|c\right|.\]
+
+
+
 
 Generalized Half-Logistic
 =========================
@@ -1063,485 +1132,580 @@ Generalized Half-Logistic
 For :math:`x\in\left[0,1/c\right]` and :math:`c>0` we have
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & \frac{2\left(1-cx\right)^{\frac{1}{c}-1}}{\left(1+\left(1-cx\right)^{1/c}\right)^{2}}\\
-   F\left(x;c\right) & = & \frac{1-\left(1-cx\right)^{1/c}}{1+\left(1-cx\right)^{1/c}}\\
-   G\left(q;c\right) & = & \frac{1}{c}\left[1-\left(\frac{1-q}{1+q}\right)^{c}\right]\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & \frac{2\left(1-cx\right)^{\frac{1}{c}-1}}{\left(1+\left(1-cx\right)^{1/c}\right)^{2}}\\ F\left(x;c\right) & = & \frac{1-\left(1-cx\right)^{1/c}}{1+\left(1-cx\right)^{1/c}}\\ G\left(q;c\right) & = & \frac{1}{c}\left[1-\left(\frac{1-q}{1+q}\right)^{c}\right]\end{eqnarray*}
+
+
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   h\left[X\right] & = & 2-\left(2c+1\right)\log2.\end{aligned*}
+    \begin{eqnarray*} h\left[X\right] & = & 2-\left(2c+1\right)\log2.\end{eqnarray*}
+
+
+
 
 Gilbrat
 =======
 
-Special case of the log-normal with :math:`\sigma=1` and :math:`S=1.0`
-(typically also :math:`L=0.0`\ )
+Special case of the log-normal with :math:`\sigma=1` and :math:`S=1.0` (typically also :math:`L=0.0` )
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\sigma\right) & = & \frac{1}{x\sqrt{2\pi}}\exp\left[-\frac{1}{2}\left(\log x\right)^{2}\right]\\
-   F\left(x;\sigma\right) & = & \Phi\left(\log x\right)=\frac{1}{2}\left[1+\textrm{erf}\left(\frac{\log x}{\sqrt{2}}\right)\right]\\
-   G\left(q;\sigma\right) & = & \exp\left\{ \Phi^{-1}\left(q\right)\right\} \end{aligned*}
+    \begin{eqnarray*} f\left(x;\sigma\right) & = & \frac{1}{x\sqrt{2\pi}}\exp\left[-\frac{1}{2}\left(\log x\right)^{2}\right]\\ F\left(x;\sigma\right) & = & \Phi\left(\log x\right)=\frac{1}{2}\left[1+\textrm{erf}\left(\frac{\log x}{\sqrt{2}}\right)\right]\\ G\left(q;\sigma\right) & = & \exp\left\{ \Phi^{-1}\left(q\right)\right\} \end{eqnarray*}
 
-.. math::
 
-   \begin{aligned*}
-   \mu & = & \sqrt{e}\\
-   \mu_{2} & = & e\left[e-1\right]\\
-   \gamma_{1} & = & \sqrt{e-1}\left(2+e\right)\\
-   \gamma_{2} & = & e^{4}+2e^{3}+3e^{2}-6\end{aligned*}
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   h\left[X\right] & = & \log\left(\sqrt{2\pi e}\right)\\
-    & \approx & 1.4189385332046727418\end{aligned*}
+    \begin{eqnarray*} \mu & = & \sqrt{e}\\ \mu_{2} & = & e\left[e-1\right]\\ \gamma_{1} & = & \sqrt{e-1}\left(2+e\right)\\ \gamma_{2} & = & e^{4}+2e^{3}+3e^{2}-6\end{eqnarray*}
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} h\left[X\right] & = & \log\left(\sqrt{2\pi e}\right)\\  & \approx & 1.4189385332046727418\end{eqnarray*}
+
+
+
 
 Gompertz (Truncated Gumbel)
 ===========================
 
-For :math:`x\geq0` and :math:`c>0`\ . In JKB the two shape parameters
-:math:`b,a` are reduced to the single shape-parameter :math:`c=b/a`\ .
-As :math:`a` is just a scale parameter when :math:`a\neq0`\ . If
-:math:`a=0,` the distribution reduces to the exponential distribution
-scaled by :math:`1/b.` Thus, the standard form is given as
+For :math:`x\geq0` and :math:`c>0` . In JKB the two shape parameters :math:`b,a` are reduced to the single shape-parameter :math:`c=b/a` . As :math:`a` is just a scale parameter when :math:`a\neq0` . If :math:`a=0,` the distribution reduces to the exponential distribution scaled by :math:`1/b.` Thus, the standard form is given as
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & ce^{x}\exp\left[-c\left(e^{x}-1\right)\right]\\
-   F\left(x;c\right) & = & 1-\exp\left[-c\left(e^{x}-1\right)\right]\\
-   G\left(q;c\right) & = & \log\left[1-\frac{1}{c}\log\left(1-q\right)\right]\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & ce^{x}\exp\left[-c\left(e^{x}-1\right)\right]\\ F\left(x;c\right) & = & 1-\exp\left[-c\left(e^{x}-1\right)\right]\\ G\left(q;c\right) & = & \log\left[1-\frac{1}{c}\log\left(1-q\right)\right]\end{eqnarray*}
 
-.. math:: h\left[X\right]=1-\log\left(c\right)-e^{c}\textrm{Ei}\left(1,c\right),
 
- where
 
-.. math:: \textrm{Ei}\left(n,x\right)=\int_{1}^{\infty}t^{-n}\exp\left(-xt\right)dt
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=1-\log\left(c\right)-e^{c}\textrm{Ei}\left(1,c\right),\]
+
+where
+
+.. math::
+   :nowrap:
+
+    \[ \textrm{Ei}\left(n,x\right)=\int_{1}^{\infty}t^{-n}\exp\left(-xt\right)dt\]
+
+
+
 
 Gumbel (LogWeibull, Fisher-Tippetts, Type I Extreme Value)
 ==========================================================
 
 One of a clase of extreme value distributions (right-skewed).
 
-.. math::
 
-   \begin{aligned*}
-   f\left(x\right) & = & \exp\left(-\left(x+e^{-x}\right)\right)\\
-   F\left(x\right) & = & \exp\left(-e^{-x}\right)\\
-   G\left(q\right) & = & -\log\left(-\log\left(q\right)\right)\end{aligned*}
-
-.. math:: M\left(t\right)=\Gamma\left(1-t\right)
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \gamma=-\psi_{0}\left(1\right)\\
-   \mu_{2} & = & \frac{\pi^{2}}{6}\\
-   \gamma_{1} & = & \frac{12\sqrt{6}}{\pi^{3}}\zeta\left(3\right)\\
-   \gamma_{2} & = & \frac{12}{5}\\
-   m_{d} & = & 0\\
-   m_{n} & = & -\log\left(\log2\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \exp\left(-\left(x+e^{-x}\right)\right)\\ F\left(x\right) & = & \exp\left(-e^{-x}\right)\\ G\left(q\right) & = & -\log\left(-\log\left(q\right)\right)\end{eqnarray*}
 
-.. math:: h\left[X\right]\approx1.0608407169541684911
+
+
+.. math::
+   :nowrap:
+
+    \[ M\left(t\right)=\Gamma\left(1-t\right)\]
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & \gamma=-\psi_{0}\left(1\right)\\ \mu_{2} & = & \frac{\pi^{2}}{6}\\ \gamma_{1} & = & \frac{12\sqrt{6}}{\pi^{3}}\zeta\left(3\right)\\ \gamma_{2} & = & \frac{12}{5}\\ m_{d} & = & 0\\ m_{n} & = & -\log\left(\log2\right)\end{eqnarray*}
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]\approx1.0608407169541684911\]
+
+
+
 
 Gumbel Left-skewed (for minimum order statistic)
 ================================================
 
+
+
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x\right) & = & \exp\left(x-e^{x}\right)\\
-   F\left(x\right) & = & 1-\exp\left(-e^{x}\right)\\
-   G\left(q\right) & = & \log\left(-\log\left(1-q\right)\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \exp\left(x-e^{x}\right)\\ F\left(x\right) & = & 1-\exp\left(-e^{x}\right)\\ G\left(q\right) & = & \log\left(-\log\left(1-q\right)\right)\end{eqnarray*}
 
-.. math:: M\left(t\right)=\Gamma\left(1+t\right)
 
- Note, that :math:`\mu` is negative the mean for the right-skewed
-distribution. Similar for median and mode. All other moments are the
-same.
 
-.. math:: h\left[X\right]\approx1.0608407169541684911.
+.. math::
+   :nowrap:
+
+    \[ M\left(t\right)=\Gamma\left(1+t\right)\]
+
+Note, that :math:`\mu` is negative the mean for the right-skewed distribution. Similar for
+median and mode. All other moments are the same.
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]\approx1.0608407169541684911.\]
+
+
+
 
 HalfCauchy
 ==========
 
-If :math:`Z` is Hyperbolic Secant distributed then :math:`e^{Z}` is
-Half-Cauchy distributed. Also, if :math:`W` is (standard) Cauchy
-distributed, then :math:`\left|W\right|` is Half-Cauchy distributed.
-Special case of the Folded Cauchy distribution with :math:`c=0.` The
-standard form is
+If :math:`Z` is Hyperbolic Secant distributed then :math:`e^{Z}` is Half-Cauchy distributed. Also, if :math:`W` is (standard) Cauchy distributed, then :math:`\left|W\right|` is Half-Cauchy distributed. Special case of the Folded Cauchy
+distribution with :math:`c=0.` The standard form is
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x\right) & = & \frac{2}{\pi\left(1+x^{2}\right)}I_{[0,\infty)}\left(x\right)\\
-   F\left(x\right) & = & \frac{2}{\pi}\arctan\left(x\right)I_{\left[0,\infty\right]}\left(x\right)\\
-   G\left(q\right) & = & \tan\left(\frac{\pi}{2}q\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \frac{2}{\pi\left(1+x^{2}\right)}I_{[0,\infty)}\left(x\right)\\ F\left(x\right) & = & \frac{2}{\pi}\arctan\left(x\right)I_{\left[0,\infty\right]}\left(x\right)\\ G\left(q\right) & = & \tan\left(\frac{\pi}{2}q\right)\end{eqnarray*}
 
-.. math:: M\left(t\right)=\cos t+\frac{2}{\pi}\left[\textrm{Si}\left(t\right)\cos t-\textrm{Ci}\left(\textrm{-}t\right)\sin t\right]
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   m_{d} & = & 0\\
-   m_{n} & = & \tan\left(\frac{\pi}{4}\right)\end{aligned*}
+    \[ M\left(t\right)=\cos t+\frac{2}{\pi}\left[\textrm{Si}\left(t\right)\cos t-\textrm{Ci}\left(\textrm{-}t\right)\sin t\right]\]
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} m_{d} & = & 0\\ m_{n} & = & \tan\left(\frac{\pi}{4}\right)\end{eqnarray*}
 
 No moments, as the integrals diverge.
 
-.. math::
 
-   \begin{aligned*}
-   h\left[X\right] & = & \log\left(2\pi\right)\\
-    & \approx & 1.8378770664093454836.\end{aligned*}
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} h\left[X\right] & = & \log\left(2\pi\right)\\  & \approx & 1.8378770664093454836.\end{eqnarray*}
+
+
+
 
 HalfNormal
 ==========
 
-This is a special case of the chi distribution with :math:`L=a` and
-:math:`S=b` and :math:`\nu=1.` This is also a special case of the folded
-normal with shape parameter :math:`c=0` and :math:`S=S.` If :math:`Z` is
-(standard) normally distributed then, :math:`\left|Z\right|` is
-half-normal. The standard form is
+This is a special case of the chi distribution with :math:`L=a` and :math:`S=b` and :math:`\nu=1.` This is also a special case of the folded normal with shape parameter :math:`c=0` and :math:`S=S.` If :math:`Z` is (standard) normally distributed then, :math:`\left|Z\right|` is half-normal. The standard form is
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x\right) & = & \sqrt{\frac{2}{\pi}}e^{-x^{2}/2}I_{\left(0,\infty\right)}\left(x\right)\\
-   F\left(x\right) & = & 2\Phi\left(x\right)-1\\
-   G\left(q\right) & = & \Phi^{-1}\left(\frac{1+q}{2}\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \sqrt{\frac{2}{\pi}}e^{-x^{2}/2}I_{\left(0,\infty\right)}\left(x\right)\\ F\left(x\right) & = & 2\Phi\left(x\right)-1\\ G\left(q\right) & = & \Phi^{-1}\left(\frac{1+q}{2}\right)\end{eqnarray*}
 
-.. math:: M\left(t\right)=\sqrt{2\pi}e^{t^{2}/2}\Phi\left(t\right)
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \sqrt{\frac{2}{\pi}}\\
-   \mu_{2} & = & 1-\frac{2}{\pi}\\
-   \gamma_{1} & = & \frac{\sqrt{2}\left(4-\pi\right)}{\left(\pi-2\right)^{3/2}}\\
-   \gamma_{2} & = & \frac{8\left(\pi-3\right)}{\left(\pi-2\right)^{2}}\\
-   m_{d} & = & 0\\
-   m_{n} & = & \Phi^{-1}\left(\frac{3}{4}\right)\end{aligned*}
+    \[ M\left(t\right)=\sqrt{2\pi}e^{t^{2}/2}\Phi\left(t\right)\]
 
-.. math::
 
-   \begin{aligned*}
-   h\left[X\right] & = & \log\left(\sqrt{\frac{\pi e}{2}}\right)\\
-    & \approx & 0.72579135264472743239.\end{aligned*}
 
-Half-Logistic 
-==============
 
-In the limit as :math:`c\rightarrow\infty` for the generalized
-half-logistic we have the half-logistic defined over :math:`x\geq0.`
-Also, the distribution of :math:`\left|X\right|` where :math:`X` has
-logistic distribtution.
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x\right) & = & \frac{2e^{-x}}{\left(1+e^{-x}\right)^{2}}=\frac{1}{2}\textrm{sech}^{2}\left(\frac{x}{2}\right)\\
-   F\left(x\right) & = & \frac{1-e^{-x}}{1+e^{-x}}=\tanh\left(\frac{x}{2}\right)\\
-   G\left(q\right) & = & \log\left(\frac{1+q}{1-q}\right)=2\textrm{arctanh}\left(q\right)\end{aligned*}
+    \begin{eqnarray*} \mu & = & \sqrt{\frac{2}{\pi}}\\ \mu_{2} & = & 1-\frac{2}{\pi}\\ \gamma_{1} & = & \frac{\sqrt{2}\left(4-\pi\right)}{\left(\pi-2\right)^{3/2}}\\ \gamma_{2} & = & \frac{8\left(\pi-3\right)}{\left(\pi-2\right)^{2}}\\ m_{d} & = & 0\\ m_{n} & = & \Phi^{-1}\left(\frac{3}{4}\right)\end{eqnarray*}
 
-.. math:: M\left(t\right)=1-t\psi_{0}\left(\frac{1}{2}-\frac{t}{2}\right)+t\psi_{0}\left(1-\frac{t}{2}\right)
 
-.. math:: \mu_{n}^{\prime}=2\left(1-2^{1-n}\right)n!\zeta\left(n\right)\quad n\neq1
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu_{1}^{\prime} & = & 2\log\left(2\right)\\
-   \mu_{2}^{\prime} & = & 2\zeta\left(2\right)=\frac{\pi^{2}}{3}\\
-   \mu_{3}^{\prime} & = & 9\zeta\left(3\right)\\
-   \mu_{4}^{\prime} & = & 42\zeta\left(4\right)=\frac{7\pi^{4}}{15}\end{aligned*}
+    \begin{eqnarray*} h\left[X\right] & = & \log\left(\sqrt{\frac{\pi e}{2}}\right)\\  & \approx & 0.72579135264472743239.\end{eqnarray*}
+
+
+
+
+Half-Logistic
+=============
+
+In the limit as :math:`c\rightarrow\infty` for the generalized half-logistic we have the half-logistic defined
+over :math:`x\geq0.` Also, the distribution of :math:`\left|X\right|` where :math:`X` has logistic distribtution.
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   h\left[X\right] & = & 2-\log\left(2\right)\\
-    & \approx & 1.3068528194400546906.\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \frac{2e^{-x}}{\left(1+e^{-x}\right)^{2}}=\frac{1}{2}\textrm{sech}^{2}\left(\frac{x}{2}\right)\\ F\left(x\right) & = & \frac{1-e^{-x}}{1+e^{-x}}=\tanh\left(\frac{x}{2}\right)\\ G\left(q\right) & = & \log\left(\frac{1+q}{1-q}\right)=2\textrm{arctanh}\left(q\right)\end{eqnarray*}
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ M\left(t\right)=1-t\psi_{0}\left(\frac{1}{2}-\frac{t}{2}\right)+t\psi_{0}\left(1-\frac{t}{2}\right)\]
+
+
+
+.. math::
+   :nowrap:
+
+    \[ \mu_{n}^{\prime}=2\left(1-2^{1-n}\right)n!\zeta\left(n\right)\quad n\neq1\]
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu_{1}^{\prime} & = & 2\log\left(2\right)\\ \mu_{2}^{\prime} & = & 2\zeta\left(2\right)=\frac{\pi^{2}}{3}\\ \mu_{3}^{\prime} & = & 9\zeta\left(3\right)\\ \mu_{4}^{\prime} & = & 42\zeta\left(4\right)=\frac{7\pi^{4}}{15}\end{eqnarray*}
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} h\left[X\right] & = & 2-\log\left(2\right)\\  & \approx & 1.3068528194400546906.\end{eqnarray*}
+
+
+
 
 Hyperbolic Secant
 =================
 
 Related to the logistic distribution and used in lifetime analysis.
-Standard form is (defined over all :math:`x`\ )
+Standard form is (defined over all :math:`x` )
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x\right) & = & \frac{1}{\pi}\textrm{sech}\left(x\right)\\
-   F\left(x\right) & = & \frac{2}{\pi}\arctan\left(e^{x}\right)\\
-   G\left(q\right) & = & \log\left(\tan\left(\frac{\pi}{2}q\right)\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{\pi}\textrm{sech}\left(x\right)\\ F\left(x\right) & = & \frac{2}{\pi}\arctan\left(e^{x}\right)\\ G\left(q\right) & = & \log\left(\tan\left(\frac{\pi}{2}q\right)\right)\end{eqnarray*}
 
-.. math:: M\left(t\right)=\sec\left(\frac{\pi}{2}t\right)
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu_{n}^{\prime} & = & \frac{1+\left(-1\right)^{n}}{2\pi2^{2n}}n!\left[\zeta\left(n+1,\frac{1}{4}\right)-\zeta\left(n+1,\frac{3}{4}\right)\right]\\
-    & = & \left\{ \begin{array}{cc}
-   0 & n\textrm{ odd}\\
-   C_{n/2}\frac{\pi^{n}}{2^{n}} & n\textrm{ even}
-   \end{array}\right.\end{aligned*}
+    \[ M\left(t\right)=\sec\left(\frac{\pi}{2}t\right)\]
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu_{n}^{\prime} & = & \frac{1+\left(-1\right)^{n}}{2\pi2^{2n}}n!\left[\zeta\left(n+1,\frac{1}{4}\right)-\zeta\left(n+1,\frac{3}{4}\right)\right]\\  & = & \left\{ \begin{array}{cc} 0 & n\textrm{ odd}\\ C_{n/2}\frac{\pi^{n}}{2^{n}} & n\textrm{ even}\end{array}\right.\end{eqnarray*}
 
 where :math:`C_{m}` is an integer given by
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   C_{m} & = & \frac{\left(2m\right)!\left[\zeta\left(2m+1,\frac{1}{4}\right)-\zeta\left(2m+1,\frac{3}{4}\right)\right]}{\pi^{2m+1}2^{2m}}\\
-    & = & 4\left(-1\right)^{m-1}\frac{16^{m}}{2m+1}B_{2m+1}\left(\frac{1}{4}\right)\end{aligned*}
+    \begin{eqnarray*} C_{m} & = & \frac{\left(2m\right)!\left[\zeta\left(2m+1,\frac{1}{4}\right)-\zeta\left(2m+1,\frac{3}{4}\right)\right]}{\pi^{2m+1}2^{2m}}\\  & = & 4\left(-1\right)^{m-1}\frac{16^{m}}{2m+1}B_{2m+1}\left(\frac{1}{4}\right)\end{eqnarray*}
 
-where :math:`B_{2m+1}\left(\frac{1}{4}\right)` is the Bernoulli
-polynomial of order :math:`2m+1` evaluated at :math:`1/4.` Thus
+where :math:`B_{2m+1}\left(\frac{1}{4}\right)` is the Bernoulli polynomial of order :math:`2m+1` evaluated at :math:`1/4.` Thus
 
 .. math::
+   :nowrap:
 
-   \mu_{n}^{\prime}=\left\{ \begin{array}{cc}
-   0 & n\textrm{ odd}\\
-   4\left(-1\right)^{n/2-1}\frac{\left(2\pi\right)^{n}}{n+1}B_{n+1}\left(\frac{1}{4}\right) & n\textrm{ even}
-   \end{array}\right.
+    \[ \mu_{n}^{\prime}=\left\{ \begin{array}{cc} 0 & n\textrm{ odd}\\ 4\left(-1\right)^{n/2-1}\frac{\left(2\pi\right)^{n}}{n+1}B_{n+1}\left(\frac{1}{4}\right) & n\textrm{ even}\end{array}\right.\]
 
-.. math::
 
-   \begin{aligned*}
-   m_{d}=m_{n}=\mu & = & 0\\
-   \mu_{2} & = & \frac{\pi^{2}}{4}\\
-   \gamma_{1} & = & 0\\
-   \gamma_{2} & = & 2\end{aligned*}
 
-.. math:: h\left[X\right]=\log\left(2\pi\right).
 
-Gauss Hypergeometric 
-=====================
-
-:math:`x\in\left[0,1\right]`\ , :math:`\alpha>0,\,\beta>0`
-
-.. math:: C^{-1}=B\left(\alpha,\beta\right)\,_{2}F_{1}\left(\gamma,\alpha;\alpha+\beta;-z\right)
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\alpha,\beta,\gamma,z\right) & = & Cx^{\alpha-1}\frac{\left(1-x\right)^{\beta-1}}{\left(1+zx\right)^{\gamma}}\\
-   \mu_{n}^{\prime} & = & \frac{B\left(n+\alpha,\beta\right)}{B\left(\alpha,\beta\right)}\frac{\,_{2}F_{1}\left(\gamma,\alpha+n;\alpha+\beta+n;-z\right)}{\,_{2}F_{1}\left(\gamma,\alpha;\alpha+\beta;-z\right)}\end{aligned*}
+    \begin{eqnarray*} m_{d}=m_{n}=\mu & = & 0\\ \mu_{2} & = & \frac{\pi^{2}}{4}\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & 2\end{eqnarray*}
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=\log\left(2\pi\right).\]
+
+
+
+
+Gauss Hypergeometric
+====================
+
+:math:`x\in\left[0,1\right]` , :math:`\alpha>0,\,\beta>0`
+
+.. math::
+   :nowrap:
+
+    \[ C^{-1}=B\left(\alpha,\beta\right)\,_{2}F_{1}\left(\gamma,\alpha;\alpha+\beta;-z\right)\]
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} f\left(x;\alpha,\beta,\gamma,z\right) & = & Cx^{\alpha-1}\frac{\left(1-x\right)^{\beta-1}}{\left(1+zx\right)^{\gamma}}\\ \mu_{n}^{\prime} & = & \frac{B\left(n+\alpha,\beta\right)}{B\left(\alpha,\beta\right)}\frac{\,_{2}F_{1}\left(\gamma,\alpha+n;\alpha+\beta+n;-z\right)}{\,_{2}F_{1}\left(\gamma,\alpha;\alpha+\beta;-z\right)}\end{eqnarray*}
+
+
+
 
 Inverted Gamma
 ==============
 
-Special case of the generalized Gamma distribution with :math:`c=-1` and
-:math:`a>0`\ , :math:`x>0`
+Special case of the generalized Gamma distribution with :math:`c=-1` and :math:`a>0` , :math:`x>0`
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;a\right) & = & \frac{x^{-a-1}}{\Gamma\left(a\right)}\exp\left(-\frac{1}{x}\right)\\
-   F\left(x;a\right) & = & \frac{\Gamma\left(a,\frac{1}{x}\right)}{\Gamma\left(a\right)}\\
-   G\left(q;a\right) & = & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)q\right]\right\} ^{-1}\end{aligned*}
+    \begin{eqnarray*} f\left(x;a\right) & = & \frac{x^{-a-1}}{\Gamma\left(a\right)}\exp\left(-\frac{1}{x}\right)\\ F\left(x;a\right) & = & \frac{\Gamma\left(a,\frac{1}{x}\right)}{\Gamma\left(a\right)}\\ G\left(q;a\right) & = & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)q\right]\right\} ^{-1}\end{eqnarray*}
 
-.. math:: \mu_{n}^{\prime}=\frac{\Gamma\left(a-n\right)}{\Gamma\left(a\right)}\quad a>n
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \frac{1}{a-1}\quad a>1\\
-   \mu_{2} & = & \frac{1}{\left(a-2\right)\left(a-1\right)}-\mu^{2}\quad a>2\\
-   \gamma_{1} & = & \frac{\frac{1}{\left(a-3\right)\left(a-2\right)\left(a-1\right)}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
-   \gamma_{2} & = & \frac{\frac{1}{\left(a-4\right)\left(a-3\right)\left(a-2\right)\left(a-1\right)}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{aligned*}
+    \[ \mu_{n}^{\prime}=\frac{\Gamma\left(a-n\right)}{\Gamma\left(a\right)}\quad a>n\]
 
-.. math:: m_{d}=\frac{1}{a+1}
 
-.. math:: h\left[X\right]=a-\left(a+1\right)\Psi\left(a\right)+\log\Gamma\left(a\right).
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & \frac{1}{a-1}\quad a>1\\ \mu_{2} & = & \frac{1}{\left(a-2\right)\left(a-1\right)}-\mu^{2}\quad a>2\\ \gamma_{1} & = & \frac{\frac{1}{\left(a-3\right)\left(a-2\right)\left(a-1\right)}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\frac{1}{\left(a-4\right)\left(a-3\right)\left(a-2\right)\left(a-1\right)}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{eqnarray*}
+
+
+
+.. math::
+   :nowrap:
+
+    \[ m_{d}=\frac{1}{a+1}\]
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=a-\left(a+1\right)\Psi\left(a\right)+\log\Gamma\left(a\right).\]
+
+
+
 
 Inverse Normal (Inverse Gaussian)
 =================================
 
-The standard form involves the shape parameter :math:`\mu` (in most
-definitions, :math:`L=0.0` is used). (In terms of the regress
-documentation :math:`\mu=A/B`\ ) and :math:`B=S` and :math:`L` is not a
-parameter in that distribution. A standard form is :math:`x>0`
+The standard form involves the shape parameter :math:`\mu` (in most definitions, :math:`L=0.0` is used). (In terms of the regress documentation :math:`\mu=A/B` ) and :math:`B=S` and :math:`L` is not a parameter in that distribution. A standard form is :math:`x>0`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\mu\right) & = & \frac{1}{\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-\mu\right)^{2}}{2x\mu^{2}}\right).\\
-   F\left(x;\mu\right) & = & \Phi\left(\frac{1}{\sqrt{x}}\frac{x-\mu}{\mu}\right)+\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{x+\mu}{\mu}\right)\\
-   G\left(q;\mu\right) & = & F^{-1}\left(q;\mu\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x;\mu\right) & = & \frac{1}{\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-\mu\right)^{2}}{2x\mu^{2}}\right).\\ F\left(x;\mu\right) & = & \Phi\left(\frac{1}{\sqrt{x}}\frac{x-\mu}{\mu}\right)+\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{x+\mu}{\mu}\right)\\ G\left(q;\mu\right) & = & F^{-1}\left(q;\mu\right)\end{eqnarray*}
+
+
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \mu\\
-   \mu_{2} & = & \mu^{3}\\
-   \gamma_{1} & = & 3\sqrt{\mu}\\
-   \gamma_{2} & = & 15\mu\\
-   m_{d} & = & \frac{\mu}{2}\left(\sqrt{9\mu^{2}+4}-3\mu\right)\end{aligned*}
+    \begin{eqnarray*} \mu & = & \mu\\ \mu_{2} & = & \mu^{3}\\ \gamma_{1} & = & 3\sqrt{\mu}\\ \gamma_{2} & = & 15\mu\\ m_{d} & = & \frac{\mu}{2}\left(\sqrt{9\mu^{2}+4}-3\mu\right)\end{eqnarray*}
 
-This is related to the canonical form or JKB “two-parameter” inverse
-Gaussian when written in it’s full form with scale parameter :math:`S`
-and location parameter :math:`L` by taking :math:`L=0` and
-:math:`S\equiv\lambda,` then :math:`\mu S` is equal to :math:`\mu_{2}`
-where :math:`\mu_{2}` is the parameter used by JKB. We prefer this form
-because of it’s consistent use of the scale parameter. Notice that in
-JKB the skew :math:`\left(\sqrt{\beta_{1}}\right)` and the kurtosis
-(:math:`\beta_{2}-3`\ ) are both functions only of
-:math:`\mu_{2}/\lambda=\mu S/S=\mu` as shown here, while the variance
-and mean of the standard form here are transformed appropriately.
+
+
+This is related to the canonical form or JKB "two-parameter "inverse Gaussian when written in it's full form with scale parameter :math:`S` and location parameter :math:`L` by taking :math:`L=0` and :math:`S\equiv\lambda,` then :math:`\mu S` is equal to :math:`\mu_{2}` where :math:`\mu_{2}` is the parameter used by JKB. We prefer this form because of it's
+consistent use of the scale parameter. Notice that in JKB the skew :math:`\left(\sqrt{\beta_{1}}\right)` and the kurtosis ( :math:`\beta_{2}-3` ) are both functions only of :math:`\mu_{2}/\lambda=\mu S/S=\mu` as shown here, while the variance and mean of the standard form here
+are transformed appropriately.
+
 
 Inverted Weibull
 ================
 
-Shape parameter :math:`c>0` and :math:`x>0`\ . Then
+Shape parameter :math:`c>0` and :math:`x>0` . Then
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & cx^{-c-1}\exp\left(-x^{-c}\right)\\
-   F\left(x;c\right) & = & \exp\left(-x^{-c}\right)\\
-   G\left(q;c\right) & = & \left(-\log q\right)^{-1/c}\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & cx^{-c-1}\exp\left(-x^{-c}\right)\\ F\left(x;c\right) & = & \exp\left(-x^{-c}\right)\\ G\left(q;c\right) & = & \left(-\log q\right)^{-1/c}\end{eqnarray*}
 
-.. math:: h\left[X\right]=1+\gamma+\frac{\gamma}{c}-\log\left(c\right)
 
- where :math:`\gamma` is Euler’s constant.
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=1+\gamma+\frac{\gamma}{c}-\log\left(c\right)\]
+
+where :math:`\gamma` is Euler's constant.
+
 
 Johnson SB
 ==========
 
-Defined for :math:`x\in\left(0,1\right)` with two shape parameters
-:math:`a` and :math:`b>0.`
+Defined for :math:`x\in\left(0,1\right)` with two shape parameters :math:`a` and :math:`b>0.`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;a,b\right) & = & \frac{b}{x\left(1-x\right)}\phi\left(a+b\log\frac{x}{1-x}\right)\\
-   F\left(x;a,b\right) & = & \Phi\left(a+b\log\frac{x}{1-x}\right)\\
-   G\left(q;a,b\right) & = & \frac{1}{1+\exp\left[-\frac{1}{b}\left(\Phi^{-1}\left(q\right)-a\right)\right]}\end{aligned*}
+    \begin{eqnarray*} f\left(x;a,b\right) & = & \frac{b}{x\left(1-x\right)}\phi\left(a+b\log\frac{x}{1-x}\right)\\ F\left(x;a,b\right) & = & \Phi\left(a+b\log\frac{x}{1-x}\right)\\ G\left(q;a,b\right) & = & \frac{1}{1+\exp\left[-\frac{1}{b}\left(\Phi^{-1}\left(q\right)-a\right)\right]}\end{eqnarray*}
+
+
+
 
 Johnson SU
 ==========
 
-Defined for all :math:`x` with two shape parameters :math:`a` and
-:math:`b>0`\ .
+Defined for all :math:`x` with two shape parameters :math:`a` and :math:`b>0` .
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;a,b\right) & = & \frac{b}{\sqrt{x^{2}+1}}\phi\left(a+b\log\left(x+\sqrt{x^{2}+1}\right)\right)\\
-   F\left(x;a,b\right) & = & \Phi\left(a+b\log\left(x+\sqrt{x^{2}+1}\right)\right)\\
-   G\left(q;a,b\right) & = & \sinh\left[\frac{\Phi^{-1}\left(q\right)-a}{b}\right]\end{aligned*}
+    \begin{eqnarray*} f\left(x;a,b\right) & = & \frac{b}{\sqrt{x^{2}+1}}\phi\left(a+b\log\left(x+\sqrt{x^{2}+1}\right)\right)\\ F\left(x;a,b\right) & = & \Phi\left(a+b\log\left(x+\sqrt{x^{2}+1}\right)\right)\\ G\left(q;a,b\right) & = & \sinh\left[\frac{\Phi^{-1}\left(q\right)-a}{b}\right]\end{eqnarray*}
+
+
+
 
 KSone
 =====
 
+
 KStwo
 =====
+
 
 Laplace (Double Exponential, Bilateral Expoooonential)
 ======================================================
 
-.. math::
 
-   \begin{aligned*}
-   f\left(x\right) & = & \frac{1}{2}e^{-\left|x\right|}\\
-   F\left(x\right) & = & \left\{ \begin{array}{ccc}
-   \frac{1}{2}e^{x} &  & x\leq0\\
-   1-\frac{1}{2}e^{-x} &  & x>0
-   \end{array}\right.\\
-   G\left(q\right) & = & \left\{ \begin{array}{ccc}
-   \log\left(2q\right) &  & q\leq\frac{1}{2}\\
-   -\log\left(2-2q\right) &  & q>\frac{1}{2}
-   \end{array}\right.\end{aligned*}
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   m_{d}=m_{n}=\mu & = & 0\\
-   \mu_{2} & = & 2\\
-   \gamma_{1} & = & 0\\
-   \gamma_{2} & = & 3\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{2}e^{-\left|x\right|}\\ F\left(x\right) & = & \left\{ \begin{array}{ccc} \frac{1}{2}e^{x} &  & x\leq0\\ 1-\frac{1}{2}e^{-x} &  & x>0\end{array}\right.\\ G\left(q\right) & = & \left\{ \begin{array}{ccc} \log\left(2q\right) &  & q\leq\frac{1}{2}\\ -\log\left(2-2q\right) &  & q>\frac{1}{2}\end{array}\right.\end{eqnarray*}
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} m_{d}=m_{n}=\mu & = & 0\\ \mu_{2} & = & 2\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & 3\end{eqnarray*}
+
+
 
 The ML estimator of the location parameter is
 
-.. math:: \hat{L}=\textrm{median}\left(X_{i}\right)
+.. math::
+   :nowrap:
 
- where :math:`X_{i}` is a sequence of :math:`N` mutually independent
-Laplace RV’s and the median is some number between the
-:math:`\frac{1}{2}N\textrm{th}` and the :math:`(N/2+1)\textrm{th}` order
-statistic (*e.g.* take the average of these two) when :math:`N` is even.
-Also,
+    \[ \hat{L}=\textrm{median}\left(X_{i}\right)\]
 
-.. math:: \hat{S}=\frac{1}{N}\sum_{j=1}^{N}\left|X_{j}-\hat{L}\right|.
-
- Replace :math:`\hat{L}` with :math:`L` if it is known. If :math:`L` is
-known then this estimator is distributed as
-:math:`\left(2N\right)^{-1}S\cdot\chi_{2N}^{2}`\ .
+where :math:`X_{i}` is a sequence of :math:`N` mutually independent Laplace RV's and the median is some number
+between the :math:`\frac{1}{2}N\textrm{th}` and the :math:`(N/2+1)\textrm{th}` order statistic ( *e.g.* take the average of these two) when :math:`N` is even. Also,
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   h\left[X\right] & = & \log\left(2e\right)\\
-    & \approx & 1.6931471805599453094.\end{aligned*}
+    \[ \hat{S}=\frac{1}{N}\sum_{j=1}^{N}\left|X_{j}-\hat{L}\right|.\]
+
+Replace :math:`\hat{L}` with :math:`L` if it is known. If :math:`L` is known then this estimator is distributed as :math:`\left(2N\right)^{-1}S\cdot\chi_{2N}^{2}` .
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} h\left[X\right] & = & \log\left(2e\right)\\  & \approx & 1.6931471805599453094.\end{eqnarray*}
+
+
+
 
 Left-skewed Lévy
-================
+=================
 
-Special case of Lévy-stable distribution with :math:`\alpha=\frac{1}{2}`
-and :math:`\beta=-1` the support is :math:`x<0`\ . In standard form
+Special case of Lévy-stable distribution with :math:`\alpha=\frac{1}{2}` and :math:`\beta=-1` the support is :math:`x<0` . In standard form
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x\right) & = & \frac{1}{\left|x\right|\sqrt{2\pi\left|x\right|}}\exp\left(-\frac{1}{2\left|x\right|}\right)\\
-   F\left(x\right) & = & 2\Phi\left(\frac{1}{\sqrt{\left|x\right|}}\right)-1\\
-   G\left(q\right) & = & -\left[\Phi^{-1}\left(\frac{q+1}{2}\right)\right]^{-2}.\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{\left|x\right|\sqrt{2\pi\left|x\right|}}\exp\left(-\frac{1}{2\left|x\right|}\right)\\ F\left(x\right) & = & 2\Phi\left(\frac{1}{\sqrt{\left|x\right|}}\right)-1\\ G\left(q\right) & = & -\left[\Phi^{-1}\left(\frac{q+1}{2}\right)\right]^{-2}.\end{eqnarray*}
 
 No moments.
 
-Lévy
-====
 
-A special case of Lévy-stable distributions with
-:math:`\alpha=\frac{1}{2}` and :math:`\beta=1`\ . In standard form it is
-defined for :math:`x>0` as
+Lévy
+=====
+
+A special case of Lévy-stable distributions with :math:`\alpha=\frac{1}{2}` and :math:`\beta=1` . In standard form it is defined for :math:`x>0` as
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x\right) & = & \frac{1}{x\sqrt{2\pi x}}\exp\left(-\frac{1}{2x}\right)\\
-   F\left(x\right) & = & 2\left[1-\Phi\left(\frac{1}{\sqrt{x}}\right)\right]\\
-   G\left(q\right) & = & \left[\Phi^{-1}\left(1-\frac{q}{2}\right)\right]^{-2}.\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{x\sqrt{2\pi x}}\exp\left(-\frac{1}{2x}\right)\\ F\left(x\right) & = & 2\left[1-\Phi\left(\frac{1}{\sqrt{x}}\right)\right]\\ G\left(q\right) & = & \left[\Phi^{-1}\left(1-\frac{q}{2}\right)\right]^{-2}.\end{eqnarray*}
 
 It has no finite moments.
+
 
 Logistic (Sech-squared)
 =======================
 
-A special case of the Generalized Logistic distribution with
-:math:`c=1.` Defined for :math:`x>0`
+A special case of the Generalized Logistic distribution with :math:`c=1.` Defined for :math:`x>0`
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x\right) & = & \frac{\exp\left(-x\right)}{\left[1+\exp\left(-x\right)\right]^{2}}\\
-   F\left(x\right) & = & \frac{1}{1+\exp\left(-x\right)}\\
-   G\left(q\right) & = & -\log\left(1/q-1\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \frac{\exp\left(-x\right)}{\left[1+\exp\left(-x\right)\right]^{2}}\\ F\left(x\right) & = & \frac{1}{1+\exp\left(-x\right)}\\ G\left(q\right) & = & -\log\left(1/q-1\right)\end{eqnarray*}
+
+
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \gamma+\psi_{0}\left(1\right)=0\\
-   \mu_{2} & = & \frac{\pi^{2}}{6}+\psi_{1}\left(1\right)=\frac{\pi^{2}}{3}\\
-   \gamma_{1} & = & \frac{\psi_{2}\left(c\right)+2\zeta\left(3\right)}{\mu_{2}^{3/2}}=0\\
-   \gamma_{2} & = & \frac{\left(\frac{\pi^{4}}{15}+\psi_{3}\left(c\right)\right)}{\mu_{2}^{2}}=\frac{6}{5}\\
-   m_{d} & = & \log1=0\\
-   m_{n} & = & -\log\left(2-1\right)=0\end{aligned*}
+    \begin{eqnarray*} \mu & = & \gamma+\psi_{0}\left(1\right)=0\\ \mu_{2} & = & \frac{\pi^{2}}{6}+\psi_{1}\left(1\right)=\frac{\pi^{2}}{3}\\ \gamma_{1} & = & \frac{\psi_{2}\left(c\right)+2\zeta\left(3\right)}{\mu_{2}^{3/2}}=0\\ \gamma_{2} & = & \frac{\left(\frac{\pi^{4}}{15}+\psi_{3}\left(c\right)\right)}{\mu_{2}^{2}}=\frac{6}{5}\\ m_{d} & = & \log1=0\\ m_{n} & = & -\log\left(2-1\right)=0\end{eqnarray*}
 
-.. math:: h\left[X\right]=1.
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=1.\]
+
+
+
 
 Log Double Exponential (Log-Laplace)
 ====================================
@@ -1549,295 +1713,336 @@ Log Double Exponential (Log-Laplace)
 Defined over :math:`x>0` with :math:`c>0`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & \left\{ \begin{array}{ccc}
-   \frac{c}{2}x^{c-1} &  & 0<x<1\\
-   \frac{c}{2}x^{-c-1} &  & x\geq1
-   \end{array}\right.\\
-   F\left(x;c\right) & = & \left\{ \begin{array}{ccc}
-   \frac{1}{2}x^{c} &  & 0<x<1\\
-   1-\frac{1}{2}x^{-c} &  & x\geq1
-   \end{array}\right.\\
-   G\left(q;c\right) & = & \left\{ \begin{array}{ccc}
-   \left(2q\right)^{1/c} &  & 0\leq q<\frac{1}{2}\\
-   \left(2-2q\right)^{-1/c} &  & \frac{1}{2}\leq q\leq1
-   \end{array}\right.\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & \left\{ \begin{array}{ccc} \frac{c}{2}x^{c-1} &  & 0<x<1\\ \frac{c}{2}x^{-c-1} &  & x\geq1\end{array}\right.\\ F\left(x;c\right) & = & \left\{ \begin{array}{ccc} \frac{1}{2}x^{c} &  & 0<x<1\\ 1-\frac{1}{2}x^{-c} &  & x\geq1\end{array}\right.\\ G\left(q;c\right) & = & \left\{ \begin{array}{ccc} \left(2q\right)^{1/c} &  & 0\leq q<\frac{1}{2}\\ \left(2-2q\right)^{-1/c} &  & \frac{1}{2}\leq q\leq1\end{array}\right.\end{eqnarray*}
 
-.. math:: h\left[X\right]=\log\left(\frac{2e}{c}\right)
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=\log\left(\frac{2e}{c}\right)\]
+
+
+
 
 Log Gamma
 =========
 
-A single shape parameter :math:`c>0` (Defined for all :math:`x`\ )
+A single shape parameter :math:`c>0` (Defined for all :math:`x` )
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & \frac{\exp\left(cx-e^{x}\right)}{\Gamma\left(c\right)}\\
-   F\left(x;c\right) & = & \frac{\Gamma\left(c,e^{x}\right)}{\Gamma\left(c\right)}\\
-   G\left(q;c\right) & = & \log\left[\Gamma^{-1}\left[c,q\Gamma\left(c\right)\right]\right]\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & \frac{\exp\left(cx-e^{x}\right)}{\Gamma\left(c\right)}\\ F\left(x;c\right) & = & \frac{\Gamma\left(c,e^{x}\right)}{\Gamma\left(c\right)}\\ G\left(q;c\right) & = & \log\left[\Gamma^{-1}\left[c,q\Gamma\left(c\right)\right]\right]\end{eqnarray*}
 
-.. math:: \mu_{n}^{\prime}=\int_{0}^{\infty}\left[\log y\right]^{n}y^{c-1}\exp\left(-y\right)dy.
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \mu_{1}^{\prime}\\
-   \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\
-   \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
-   \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{aligned*}
+    \[ \mu_{n}^{\prime}=\int_{0}^{\infty}\left[\log y\right]^{n}y^{c-1}\exp\left(-y\right)dy.\]
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & \mu_{1}^{\prime}\\ \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\ \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{eqnarray*}
+
+
+
 
 Log Normal (Cobb-Douglass)
 ==========================
 
-Has one shape parameter :math:`\sigma`\ >0. (Notice that the “Regress”
-:math:`A=\log S` where :math:`S` is the scale parameter and :math:`A` is
-the mean of the underlying normal distribution). The standard form is
-:math:`x>0`
+Has one shape parameter :math:`\sigma` >0. (Notice that the "Regress ":math:`A=\log S` where :math:`S` is the scale parameter and :math:`A` is the mean of the underlying normal distribution). The standard form
+is :math:`x>0`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\sigma\right) & = & \frac{1}{\sigma x\sqrt{2\pi}}\exp\left[-\frac{1}{2}\left(\frac{\log x}{\sigma}\right)^{2}\right]\\
-   F\left(x;\sigma\right) & = & \Phi\left(\frac{\log x}{\sigma}\right)\\
-   G\left(q;\sigma\right) & = & \exp\left\{ \sigma\Phi^{-1}\left(q\right)\right\} \end{aligned*}
+    \begin{eqnarray*} f\left(x;\sigma\right) & = & \frac{1}{\sigma x\sqrt{2\pi}}\exp\left[-\frac{1}{2}\left(\frac{\log x}{\sigma}\right)^{2}\right]\\ F\left(x;\sigma\right) & = & \Phi\left(\frac{\log x}{\sigma}\right)\\ G\left(q;\sigma\right) & = & \exp\left\{ \sigma\Phi^{-1}\left(q\right)\right\} \end{eqnarray*}
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \exp\left(\sigma^{2}/2\right)\\
-   \mu_{2} & = & \exp\left(\sigma^{2}\right)\left[\exp\left(\sigma^{2}\right)-1\right]\\
-   \gamma_{1} & = & \sqrt{p-1}\left(2+p\right)\\
-   \gamma_{2} & = & p^{4}+2p^{3}+3p^{2}-6\quad\quad p=e^{\sigma^{2}}\end{aligned*}
+    \begin{eqnarray*} \mu & = & \exp\left(\sigma^{2}/2\right)\\ \mu_{2} & = & \exp\left(\sigma^{2}\right)\left[\exp\left(\sigma^{2}\right)-1\right]\\ \gamma_{1} & = & \sqrt{p-1}\left(2+p\right)\\ \gamma_{2} & = & p^{4}+2p^{3}+3p^{2}-6\quad\quad p=e^{\sigma^{2}}\end{eqnarray*}
 
-Notice that using JKB notation we have :math:`\theta=L,`
-:math:`\zeta=\log S` and we have given the so-called antilognormal form
-of the distribution. This is more consistent with the location, scale
+
+
+Notice that using JKB notation we have :math:`\theta=L,` :math:`\zeta=\log S` and we have given the so-called antilognormal form of the
+distribution. This is more consistent with the location, scale
 parameter description of general probability distributions.
 
-.. math:: h\left[X\right]=\frac{1}{2}\left[1+\log\left(2\pi\right)+2\log\left(\sigma\right)\right].
 
-Also, note that if :math:`X` is a log-normally distributed
-random-variable with :math:`L=0` and :math:`S` and shape parameter
-:math:`\sigma.` Then, :math:`\log X` is normally distributed with
-variance :math:`\sigma^{2}` and mean :math:`\log S.`
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=\frac{1}{2}\left[1+\log\left(2\pi\right)+2\log\left(\sigma\right)\right].\]
+
+
+
+Also, note that if :math:`X` is a log-normally distributed random-variable with :math:`L=0` and :math:`S` and shape parameter :math:`\sigma.` Then, :math:`\log X` is normally distributed with variance :math:`\sigma^{2}` and mean :math:`\log S.`
+
 
 Nakagami
 ========
 
-Generalization of the chi distribution. Shape parameter is
-:math:`\nu>0.` Defined for :math:`x>0.`
+Generalization of the chi distribution. Shape parameter is :math:`\nu>0.` Defined for :math:`x>0.`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\nu\right) & = & \frac{2\nu^{\nu}}{\Gamma\left(\nu\right)}x^{2\nu-1}\exp\left(-\nu x^{2}\right)\\
-   F\left(x;\nu\right) & = & \Gamma\left(\nu,\nu x^{2}\right)\\
-   G\left(q;\nu\right) & = & \sqrt{\frac{1}{\nu}\Gamma^{-1}\left(v,q\right)}\end{aligned*}
+    \begin{eqnarray*} f\left(x;\nu\right) & = & \frac{2\nu^{\nu}}{\Gamma\left(\nu\right)}x^{2\nu-1}\exp\left(-\nu x^{2}\right)\\ F\left(x;\nu\right) & = & \Gamma\left(\nu,\nu x^{2}\right)\\ G\left(q;\nu\right) & = & \sqrt{\frac{1}{\nu}\Gamma^{-1}\left(v,q\right)}\end{eqnarray*}
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \frac{\Gamma\left(\nu+\frac{1}{2}\right)}{\sqrt{\nu}\Gamma\left(\nu\right)}\\
-   \mu_{2} & = & \left[1-\mu^{2}\right]\\
-   \gamma_{1} & = & \frac{\mu\left(1-4v\mu_{2}\right)}{2\nu\mu_{2}^{3/2}}\\
-   \gamma_{2} & = & \frac{-6\mu^{4}\nu+\left(8\nu-2\right)\mu^{2}-2\nu+1}{\nu\mu_{2}^{2}}\end{aligned*}
+    \begin{eqnarray*} \mu & = & \frac{\Gamma\left(\nu+\frac{1}{2}\right)}{\sqrt{\nu}\Gamma\left(\nu\right)}\\ \mu_{2} & = & \left[1-\mu^{2}\right]\\ \gamma_{1} & = & \frac{\mu\left(1-4v\mu_{2}\right)}{2\nu\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{-6\mu^{4}\nu+\left(8\nu-2\right)\mu^{2}-2\nu+1}{\nu\mu_{2}^{2}}\end{eqnarray*}
 
-Noncentral beta\*
-=================
 
-Defined over :math:`x\in\left[0,1\right]` with :math:`a>0` and
-:math:`b>0` and :math:`c\geq0`
 
-.. math:: F\left(x;a,b,c\right)=\sum_{j=0}^{\infty}\frac{e^{-c/2}\left(\frac{c}{2}\right)^{j}}{j!}I_{B}\left(a+j,b;0\right)
 
-Noncentral chi\*
+Noncentral beta*
 ================
+
+Defined over :math:`x\in\left[0,1\right]` with :math:`a>0` and :math:`b>0` and :math:`c\geq0`
+
+
+
+.. math::
+   :nowrap:
+
+    \[ F\left(x;a,b,c\right)=\sum_{j=0}^{\infty}\frac{e^{-c/2}\left(\frac{c}{2}\right)^{j}}{j!}I_{B}\left(a+j,b;0\right)\]
+
+
+
+
+Noncentral chi*
+===============
+
 
 Noncentral chi-squared
 ======================
 
-The distribution of
-:math:`\sum_{i=1}^{\nu}\left(Z_{i}+\delta_{i}\right)^{2}` where
-:math:`Z_{i}` are independent standard normal variables and
-:math:`\delta_{i}` are constants.
-:math:`\lambda=\sum_{i=1}^{\nu}\delta_{i}^{2}>0.` (In communications it
-is called the Marcum-Q function). Can be thought of as a Generalized
-Rayleigh-Rice distribution. For :math:`x>0`
+The distribution of :math:`\sum_{i=1}^{\nu}\left(Z_{i}+\delta_{i}\right)^{2}` where :math:`Z_{i}` are independent standard normal variables and :math:`\delta_{i}` are constants. :math:`\lambda=\sum_{i=1}^{\nu}\delta_{i}^{2}>0.` (In communications it is called the Marcum-Q function). Can be thought
+of as a Generalized Rayleigh-Rice distribution. For :math:`x>0`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\nu,\lambda\right) & = & e^{-\left(\lambda+x\right)/2}\frac{1}{2}\left(\frac{x}{\lambda}\right)^{\left(\nu-2\right)/4}I_{\left(\nu-2\right)/2}\left(\sqrt{\lambda x}\right)\\
-   F\left(x;\nu,\lambda\right) & = & \sum_{j=0}^{\infty}\left\{ \frac{\left(\lambda/2\right)^{j}}{j!}e^{-\lambda/2}\right\} \textrm{Pr}\left[\chi_{\nu+2j}^{2}\leq x\right]\\
-   G\left(q;\nu,\lambda\right) & = & F^{-1}\left(x;\nu,\lambda\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x;\nu,\lambda\right) & = & e^{-\left(\lambda+x\right)/2}\frac{1}{2}\left(\frac{x}{\lambda}\right)^{\left(\nu-2\right)/4}I_{\left(\nu-2\right)/2}\left(\sqrt{\lambda x}\right)\\ F\left(x;\nu,\lambda\right) & = & \sum_{j=0}^{\infty}\left\{ \frac{\left(\lambda/2\right)^{j}}{j!}e^{-\lambda/2}\right\} \textrm{Pr}\left[\chi_{\nu+2j}^{2}\leq x\right]\\ G\left(q;\nu,\lambda\right) & = & F^{-1}\left(x;\nu,\lambda\right)\end{eqnarray*}
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \nu+\lambda\\
-   \mu_{2} & = & 2\left(\nu+2\lambda\right)\\
-   \gamma_{1} & = & \frac{\sqrt{8}\left(\nu+3\lambda\right)}{\left(\nu+2\lambda\right)^{3/2}}\\
-   \gamma_{2} & = & \frac{12\left(\nu+4\lambda\right)}{\left(\nu+2\lambda\right)^{2}}\end{aligned*}
+    \begin{eqnarray*} \mu & = & \nu+\lambda\\ \mu_{2} & = & 2\left(\nu+2\lambda\right)\\ \gamma_{1} & = & \frac{\sqrt{8}\left(\nu+3\lambda\right)}{\left(\nu+2\lambda\right)^{3/2}}\\ \gamma_{2} & = & \frac{12\left(\nu+4\lambda\right)}{\left(\nu+2\lambda\right)^{2}}\end{eqnarray*}
+
+
+
 
 Noncentral F
 ============
 
 Let :math:`\lambda>0` and :math:`\nu_{1}>0` and :math:`\nu_{2}>0.`
 
-.. math::
 
-   \begin{aligned*}
-   f\left(x;\lambda,\nu_{1},\nu_{2}\right) & = & \exp\left[\frac{\lambda}{2}+\frac{\left(\lambda\nu_{1}x\right)}{2\left(\nu_{1}x+\nu_{2}\right)}\right]\nu_{1}^{\nu_{1}/2}\nu_{2}^{\nu_{2}/2}x^{\nu_{1}/2-1}\\
-    &  & \times\left(\nu_{2}+\nu_{1}x\right)^{-\left(\nu_{1}+\nu_{2}\right)/2}\frac{\Gamma\left(\frac{\nu_{1}}{2}\right)\Gamma\left(1+\frac{\nu_{2}}{2}\right)L_{\nu_{2}/2}^{\nu_{1}/2-1}\left(-\frac{\lambda\nu_{1}x}{2\left(\nu_{1}x+\nu_{2}\right)}\right)}{B\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2}\right)\Gamma\left(\frac{\nu_{1}+\nu_{2}}{2}\right)}\end{aligned*}
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} f\left(x;\lambda,\nu_{1},\nu_{2}\right) & = & \exp\left[\frac{\lambda}{2}+\frac{\left(\lambda\nu_{1}x\right)}{2\left(\nu_{1}x+\nu_{2}\right)}\right]\nu_{1}^{\nu_{1}/2}\nu_{2}^{\nu_{2}/2}x^{\nu_{1}/2-1}\\  &  & \times\left(\nu_{2}+\nu_{1}x\right)^{-\left(\nu_{1}+\nu_{2}\right)/2}\frac{\Gamma\left(\frac{\nu_{1}}{2}\right)\Gamma\left(1+\frac{\nu_{2}}{2}\right)L_{\nu_{2}/2}^{\nu_{1}/2-1}\left(-\frac{\lambda\nu_{1}x}{2\left(\nu_{1}x+\nu_{2}\right)}\right)}{B\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2}\right)\Gamma\left(\frac{\nu_{1}+\nu_{2}}{2}\right)}\end{eqnarray*}
+
+
+
 
 Noncentral t
 ============
 
 The distribution of the ratio
 
-.. math:: \frac{U+\lambda}{\chi_{\nu}/\sqrt{\nu}}
+.. math::
+   :nowrap:
 
- where :math:`U` and :math:`\chi_{\nu}` are independent and distributed
-as a standard normal and chi with :math:`\nu` degrees of freedom. Note
-:math:`\lambda>0` and :math:`\nu>0`\ .
+    \[ \frac{U+\lambda}{\chi_{\nu}/\sqrt{\nu}}\]
+
+where :math:`U` and :math:`\chi_{\nu}` are independent and distributed as a standard normal and chi with :math:`\nu` degrees of freedom. Note :math:`\lambda>0` and :math:`\nu>0` .
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\lambda,\nu\right) & = & \frac{\nu^{\nu/2}\Gamma\left(\nu+1\right)}{2^{\nu}e^{\lambda^{2}/2}\left(\nu+x^{2}\right)^{\nu/2}\Gamma\left(\nu/2\right)}\\
-    &  & \times\left\{ \frac{\sqrt{2}\lambda x\,_{1}F_{1}\left(\frac{\nu}{2}+1;\frac{3}{2};\frac{\lambda^{2}x^{2}}{2\left(\nu+x^{2}\right)}\right)}{\left(\nu+x^{2}\right)\Gamma\left(\frac{\nu+1}{2}\right)}\right.\\
-    &  & -\left.\frac{\,_{1}F_{1}\left(\frac{\nu+1}{2};\frac{1}{2};\frac{\lambda^{2}x^{2}}{2\left(\nu+x^{2}\right)}\right)}{\sqrt{\nu+x^{2}}\Gamma\left(\frac{\nu}{2}+1\right)}\right\} \\
-    & = & \frac{\Gamma\left(\nu+1\right)}{2^{\left(\nu-1\right)/2}\sqrt{\pi\nu}\Gamma\left(\nu/2\right)}\exp\left[-\frac{\nu\lambda^{2}}{\nu+x^{2}}\right]\\
-    &  & \times\left(\frac{\nu}{\nu+x^{2}}\right)^{\left(\nu-1\right)/2}Hh_{\nu}\left(-\frac{\lambda x}{\sqrt{\nu+x^{2}}}\right)\\
-   F\left(x;\lambda,\nu\right) & =\end{aligned*}
+    \begin{eqnarray*} f\left(x;\lambda,\nu\right) & = & \frac{\nu^{\nu/2}\Gamma\left(\nu+1\right)}{2^{\nu}e^{\lambda^{2}/2}\left(\nu+x^{2}\right)^{\nu/2}\Gamma\left(\nu/2\right)}\\  &  & \times\left\{ \frac{\sqrt{2}\lambda x\,_{1}F_{1}\left(\frac{\nu}{2}+1;\frac{3}{2};\frac{\lambda^{2}x^{2}}{2\left(\nu+x^{2}\right)}\right)}{\left(\nu+x^{2}\right)\Gamma\left(\frac{\nu+1}{2}\right)}\right.\\  &  & -\left.\frac{\,_{1}F_{1}\left(\frac{\nu+1}{2};\frac{1}{2};\frac{\lambda^{2}x^{2}}{2\left(\nu+x^{2}\right)}\right)}{\sqrt{\nu+x^{2}}\Gamma\left(\frac{\nu}{2}+1\right)}\right\} \\  & = & \frac{\Gamma\left(\nu+1\right)}{2^{\left(\nu-1\right)/2}\sqrt{\pi\nu}\Gamma\left(\nu/2\right)}\exp\left[-\frac{\nu\lambda^{2}}{\nu+x^{2}}\right]\\  &  & \times\left(\frac{\nu}{\nu+x^{2}}\right)^{\left(\nu-1\right)/2}Hh_{\nu}\left(-\frac{\lambda x}{\sqrt{\nu+x^{2}}}\right)\\ F\left(x;\lambda,\nu\right) & =\end{eqnarray*}
+
+
+
 
 Normal
 ======
 
-.. math::
 
-   \begin{aligned*}
-   f\left(x\right) & = & \frac{e^{-x^{2}/2}}{\sqrt{2\pi}}\\
-   F\left(x\right) & = & \Phi\left(x\right)=\frac{1}{2}+\frac{1}{2}\textrm{erf}\left(\frac{\textrm{x}}{\sqrt{2}}\right)\\
-   G\left(q\right) & = & \Phi^{-1}\left(q\right)\end{aligned*}
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   m_{d}=m_{n}=\mu & = & 0\\
-   \mu_{2} & = & 1\\
-   \gamma_{1} & = & 0\\
-   \gamma_{2} & = & 0\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \frac{e^{-x^{2}/2}}{\sqrt{2\pi}}\\ F\left(x\right) & = & \Phi\left(x\right)=\frac{1}{2}+\frac{1}{2}\textrm{erf}\left(\frac{\textrm{x}}{\sqrt{2}}\right)\\ G\left(q\right) & = & \Phi^{-1}\left(q\right)\end{eqnarray*}
+
+
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   h\left[X\right] & = & \log\left(\sqrt{2\pi e}\right)\\
-    & \approx & 1.4189385332046727418\end{aligned*}
+    \begin{eqnarray*} m_{d}=m_{n}=\mu & = & 0\\ \mu_{2} & = & 1\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & 0\end{eqnarray*}
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} h\left[X\right] & = & \log\left(\sqrt{2\pi e}\right)\\  & \approx & 1.4189385332046727418\end{eqnarray*}
+
+
+
 
 Maxwell
 =======
 
-This is a special case of the Chi distribution with :math:`L=0` and
-:math:`S=S=\frac{1}{\sqrt{a}}` and :math:`\nu=3.`
+This is a special case of the Chi distribution with :math:`L=0` and :math:`S=S=\frac{1}{\sqrt{a}}` and :math:`\nu=3.`
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x\right) & = & \sqrt{\frac{2}{\pi}}x^{2}e^{-x^{2}/2}I_{\left(0,\infty\right)}\left(x\right)\\
-   F\left(x\right) & = & \Gamma\left(\frac{3}{2},\frac{x^{2}}{2}\right)\\
-   G\left(\alpha\right) & = & \sqrt{2\Gamma^{-1}\left(\frac{3}{2},\alpha\right)}\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \sqrt{\frac{2}{\pi}}x^{2}e^{-x^{2}/2}I_{\left(0,\infty\right)}\left(x\right)\\ F\left(x\right) & = & \Gamma\left(\frac{3}{2},\frac{x^{2}}{2}\right)\\ G\left(\alpha\right) & = & \sqrt{2\Gamma^{-1}\left(\frac{3}{2},\alpha\right)}\end{eqnarray*}
+
+
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & 2\sqrt{\frac{2}{\pi}}\\
-   \mu_{2} & = & 3-\frac{8}{\pi}\\
-   \gamma_{1} & = & \sqrt{2}\frac{32-10\pi}{\left(3\pi-8\right)^{3/2}}\\
-   \gamma_{2} & = & \frac{-12\pi^{2}+160\pi-384}{\left(3\pi-8\right)^{2}}\\
-   m_{d} & = & \sqrt{2}\\
-   m_{n} & = & \sqrt{2\Gamma^{-1}\left(\frac{3}{2},\frac{1}{2}\right)}\end{aligned*}
+    \begin{eqnarray*} \mu & = & 2\sqrt{\frac{2}{\pi}}\\ \mu_{2} & = & 3-\frac{8}{\pi}\\ \gamma_{1} & = & \sqrt{2}\frac{32-10\pi}{\left(3\pi-8\right)^{3/2}}\\ \gamma_{2} & = & \frac{-12\pi^{2}+160\pi-384}{\left(3\pi-8\right)^{2}}\\ m_{d} & = & \sqrt{2}\\ m_{n} & = & \sqrt{2\Gamma^{-1}\left(\frac{3}{2},\frac{1}{2}\right)}\end{eqnarray*}
 
-.. math:: h\left[X\right]=\log\left(\sqrt{\frac{2\pi}{e}}\right)+\gamma.
 
-Mielke’s Beta-Kappa
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=\log\left(\sqrt{\frac{2\pi}{e}}\right)+\gamma.\]
+
+
+
+
+Mielke's Beta-Kappa
 ===================
 
-A generalized F distribution. Two shape parameters :math:`\kappa` and
-:math:`\theta`\ , and :math:`x>0`\ . The :math:`\beta` in the DATAPLOT
-reference is a scale parameter.
+A generalized F distribution. Two shape parameters :math:`\kappa` and :math:`\theta` , and :math:`x>0` . The :math:`\beta` in the DATAPLOT reference is a scale parameter.
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\kappa,\theta\right) & = & \frac{\kappa x^{\kappa-1}}{\left(1+x^{\theta}\right)^{1+\frac{\kappa}{\theta}}}\\
-   F\left(x;\kappa,\theta\right) & = & \frac{x^{\kappa}}{\left(1+x^{\theta}\right)^{\kappa/\theta}}\\
-   G\left(q;\kappa,\theta\right) & = & \left(\frac{q^{\theta/\kappa}}{1-q^{\theta/\kappa}}\right)^{1/\theta}\end{aligned*}
+    \begin{eqnarray*} f\left(x;\kappa,\theta\right) & = & \frac{\kappa x^{\kappa-1}}{\left(1+x^{\theta}\right)^{1+\frac{\kappa}{\theta}}}\\ F\left(x;\kappa,\theta\right) & = & \frac{x^{\kappa}}{\left(1+x^{\theta}\right)^{\kappa/\theta}}\\ G\left(q;\kappa,\theta\right) & = & \left(\frac{q^{\theta/\kappa}}{1-q^{\theta/\kappa}}\right)^{1/\theta}\end{eqnarray*}
+
+
+
 
 Pareto
 ======
 
-For :math:`x\geq1` and :math:`b>0`\ . Standard form is
+For :math:`x\geq1` and :math:`b>0` . Standard form is
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;b\right) & = & \frac{b}{x^{b+1}}\\
-   F\left(x;b\right) & = & 1-\frac{1}{x^{b}}\\
-   G\left(q;b\right) & = & \left(1-q\right)^{-1/b}\end{aligned*}
+    \begin{eqnarray*} f\left(x;b\right) & = & \frac{b}{x^{b+1}}\\ F\left(x;b\right) & = & 1-\frac{1}{x^{b}}\\ G\left(q;b\right) & = & \left(1-q\right)^{-1/b}\end{eqnarray*}
+
+
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \frac{b}{b-1}\quad b>1\\
-   \mu_{2} & = & \frac{b}{\left(b-2\right)\left(b-1\right)^{2}}\quad b>2\\
-   \gamma_{1} & = & \frac{2\left(b+1\right)\sqrt{b-2}}{\left(b-3\right)\sqrt{b}}\quad b>3\\
-   \gamma_{2} & = & \frac{6\left(b^{3}+b^{2}-6b-2\right)}{b\left(b^{2}-7b+12\right)}\quad b>4\end{aligned*}
+    \begin{eqnarray*} \mu & = & \frac{b}{b-1}\quad b>1\\ \mu_{2} & = & \frac{b}{\left(b-2\right)\left(b-1\right)^{2}}\quad b>2\\ \gamma_{1} & = & \frac{2\left(b+1\right)\sqrt{b-2}}{\left(b-3\right)\sqrt{b}}\quad b>3\\ \gamma_{2} & = & \frac{6\left(b^{3}+b^{2}-6b-2\right)}{b\left(b^{2}-7b+12\right)}\quad b>4\end{eqnarray*}
 
-.. math:: h\left(X\right)=\frac{1}{c}+1-\log\left(c\right)
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left(X\right)=\frac{1}{c}+1-\log\left(c\right)\]
+
+
+
 
 Pareto Second Kind (Lomax)
 ==========================
 
-:math:`c>0.` This is Pareto of the first kind with :math:`L=-1.0` so
-:math:`x\geq0`
+:math:`c>0.` This is Pareto of the first kind with :math:`L=-1.0` so :math:`x\geq0`
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & \frac{c}{\left(1+x\right)^{c+1}}\\
-   F\left(x;c\right) & = & 1-\frac{1}{\left(1+x\right)^{c}}\\
-   G\left(q;c\right) & = & \left(1-q\right)^{-1/c}-1\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & \frac{c}{\left(1+x\right)^{c+1}}\\ F\left(x;c\right) & = & 1-\frac{1}{\left(1+x\right)^{c}}\\ G\left(q;c\right) & = & \left(1-q\right)^{-1/c}-1\end{eqnarray*}
 
-.. math:: h\left[X\right]=\frac{1}{c}+1-\log\left(c\right).
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=\frac{1}{c}+1-\log\left(c\right).\]
+
+
+
 
 Power Log Normal
 ================
 
-A generalization of the log-normal distribution :math:`\sigma>0` and
-:math:`c>0` and :math:`x>0`
+A generalization of the log-normal distribution :math:`\sigma>0` and :math:`c>0` and :math:`x>0`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\sigma,c\right) & = & \frac{c}{x\sigma}\phi\left(\frac{\log x}{\sigma}\right)\left(\Phi\left(-\frac{\log x}{\sigma}\right)\right)^{c-1}\\
-   F\left(x;\sigma,c\right) & = & 1-\left(\Phi\left(-\frac{\log x}{\sigma}\right)\right)^{c}\\
-   G\left(q;\sigma,c\right) & = & \exp\left[-\sigma\Phi^{-1}\left[\left(1-q\right)^{1/c}\right]\right]\end{aligned*}
+    \begin{eqnarray*} f\left(x;\sigma,c\right) & = & \frac{c}{x\sigma}\phi\left(\frac{\log x}{\sigma}\right)\left(\Phi\left(-\frac{\log x}{\sigma}\right)\right)^{c-1}\\ F\left(x;\sigma,c\right) & = & 1-\left(\Phi\left(-\frac{\log x}{\sigma}\right)\right)^{c}\\ G\left(q;\sigma,c\right) & = & \exp\left[-\sigma\Phi^{-1}\left[\left(1-q\right)^{1/c}\right]\right]\end{eqnarray*}
 
-.. math:: \mu_{n}^{\prime}=\int_{0}^{1}\exp\left[-n\sigma\Phi^{-1}\left(y^{1/c}\right)\right]dy
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \mu_{1}^{\prime}\\
-   \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\
-   \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
-   \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{aligned*}
+    \[ \mu_{n}^{\prime}=\int_{0}^{1}\exp\left[-n\sigma\Phi^{-1}\left(y^{1/c}\right)\right]dy\]
 
-This distribution reduces to the log-normal distribution when
-:math:`c=1.`
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & \mu_{1}^{\prime}\\ \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\ \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{eqnarray*}
+
+This distribution reduces to the log-normal distribution when :math:`c=1.`
+
 
 Power Normal
 ============
@@ -1845,107 +2050,141 @@ Power Normal
 A generalization of the normal distribution, :math:`c>0` for
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & c\phi\left(x\right)\left(\Phi\left(-x\right)\right)^{c-1}\\
-   F\left(x;c\right) & = & 1-\left(\Phi\left(-x\right)\right)^{c}\\
-   G\left(q;c\right) & = & -\Phi^{-1}\left[\left(1-q\right)^{1/c}\right]\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & c\phi\left(x\right)\left(\Phi\left(-x\right)\right)^{c-1}\\ F\left(x;c\right) & = & 1-\left(\Phi\left(-x\right)\right)^{c}\\ G\left(q;c\right) & = & -\Phi^{-1}\left[\left(1-q\right)^{1/c}\right]\end{eqnarray*}
 
-.. math:: \mu_{n}^{\prime}=\left(-1\right)^{n}\int_{0}^{1}\left[\Phi^{-1}\left(y^{1/c}\right)\right]^{n}dy
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \mu_{1}^{\prime}\\
-   \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\
-   \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
-   \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{aligned*}
+    \[ \mu_{n}^{\prime}=\left(-1\right)^{n}\int_{0}^{1}\left[\Phi^{-1}\left(y^{1/c}\right)\right]^{n}dy\]
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & \mu_{1}^{\prime}\\ \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\ \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{eqnarray*}
 
 For :math:`c=1` this reduces to the normal distribution.
 
-Power-function 
-===============
 
-A special case of the beta distribution with :math:`b=1`\ : defined for
-:math:`x\in\left[0,1\right]`
+Power-function
+==============
 
-.. math:: a>0
+A special case of the beta distribution with :math:`b=1` : defined for :math:`x\in\left[0,1\right]`
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;a\right) & = & ax^{a-1}\\
-   F\left(x;a\right) & = & x^{a}\\
-   G\left(q;a\right) & = & q^{1/a}\\
-   \mu & = & \frac{a}{a+1}\\
-   \mu_{2} & = & \frac{a\left(a+2\right)}{\left(a+1\right)^{2}}\\
-   \gamma_{1} & = & 2\left(1-a\right)\sqrt{\frac{a+2}{a\left(a+3\right)}}\\
-   \gamma_{2} & = & \frac{6\left(a^{3}-a^{2}-6a+2\right)}{a\left(a+3\right)\left(a+4\right)}\\
-   m_{d} & = & 1\end{aligned*}
+    \[ a>0\]
 
-.. math:: h\left[X\right]=1-\frac{1}{a}-\log\left(a\right)
+
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} f\left(x;a\right) & = & ax^{a-1}\\ F\left(x;a\right) & = & x^{a}\\ G\left(q;a\right) & = & q^{1/a}\\ \mu & = & \frac{a}{a+1}\\ \mu_{2} & = & \frac{a\left(a+2\right)}{\left(a+1\right)^{2}}\\ \gamma_{1} & = & 2\left(1-a\right)\sqrt{\frac{a+2}{a\left(a+3\right)}}\\ \gamma_{2} & = & \frac{6\left(a^{3}-a^{2}-6a+2\right)}{a\left(a+3\right)\left(a+4\right)}\\ m_{d} & = & 1\end{eqnarray*}
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=1-\frac{1}{a}-\log\left(a\right)\]
+
+
+
 
 R-distribution
 ==============
 
-A general-purpose distribution with a variety of shapes controlled by
-:math:`c>0.` Range of standard distribution is
-:math:`x\in\left[-1,1\right]`
+A general-purpose distribution with a variety of shapes controlled by :math:`c>0.` Range of standard distribution is :math:`x\in\left[-1,1\right]`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & \frac{\left(1-x^{2}\right)^{c/2-1}}{B\left(\frac{1}{2},\frac{c}{2}\right)}\\
-   F\left(x;c\right) & = & \frac{1}{2}+\frac{x}{B\left(\frac{1}{2},\frac{c}{2}\right)}\,_{2}F_{1}\left(\frac{1}{2},1-\frac{c}{2};\frac{3}{2};x^{2}\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & \frac{\left(1-x^{2}\right)^{c/2-1}}{B\left(\frac{1}{2},\frac{c}{2}\right)}\\ F\left(x;c\right) & = & \frac{1}{2}+\frac{x}{B\left(\frac{1}{2},\frac{c}{2}\right)}\,_{2}F_{1}\left(\frac{1}{2},1-\frac{c}{2};\frac{3}{2};x^{2}\right)\end{eqnarray*}
 
-.. math:: \mu_{n}^{\prime}=\frac{\left(1+\left(-1\right)^{n}\right)}{2}B\left(\frac{n+1}{2},\frac{c}{2}\right)
 
- The R-distribution with parameter :math:`n` is the distribution of the
-correlation coefficient of a random sample of size :math:`n` drawn from
-a bivariate normal distribution with :math:`\rho=0.` The mean of the
-standard distribution is always zero and as the sample size grows, the
-distribution’s mass concentrates more closely about this mean.
 
-Rayleigh 
-=========
+.. math::
+   :nowrap:
 
-This is Chi distribution with :math:`L=0.0` and :math:`\nu=2` and
-:math:`S=S` (no location parameter is generally used), the mode of the
+    \[ \mu_{n}^{\prime}=\frac{\left(1+\left(-1\right)^{n}\right)}{2}B\left(\frac{n+1}{2},\frac{c}{2}\right)\]
+
+The R-distribution with parameter :math:`n` is the distribution of the correlation coefficient of a random sample
+of size :math:`n` drawn from a bivariate normal distribution with :math:`\rho=0.` The mean of the standard distribution is always zero and as the sample
+size grows, the distribution's mass concentrates more closely about
+this mean.
+
+
+Rayleigh
+========
+
+This is Chi distribution with :math:`L=0.0` and :math:`\nu=2` and :math:`S=S` (no location parameter is generally used), the mode of the
 distribution is :math:`S.`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(r\right) & = & re^{-r^{2}/2}I_{[0,\infty)}\left(x\right)\\
-   F\left(r\right) & = & 1-e^{-r^{2}/2}I_{[0,\infty)}\left(x\right)\\
-   G\left(q\right) & = & \sqrt{-2\log\left(1-q\right)}\end{aligned*}
+    \begin{eqnarray*} f\left(r\right) & = & re^{-r^{2}/2}I_{[0,\infty)}\left(x\right)\\ F\left(r\right) & = & 1-e^{-r^{2}/2}I_{[0,\infty)}\left(x\right)\\ G\left(q\right) & = & \sqrt{-2\log\left(1-q\right)}\end{eqnarray*}
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \sqrt{\frac{\pi}{2}}\\
-   \mu_{2} & = & \frac{4-\pi}{2}\\
-   \gamma_{1} & = & \frac{2\left(\pi-3\right)\sqrt{\pi}}{\left(4-\pi\right)^{3/2}}\\
-   \gamma_{2} & = & \frac{24\pi-6\pi^{2}-16}{\left(4-\pi\right)^{2}}\\
-   m_{d} & = & 1\\
-   m_{n} & = & \sqrt{2\log\left(2\right)}\end{aligned*}
+    \begin{eqnarray*} \mu & = & \sqrt{\frac{\pi}{2}}\\ \mu_{2} & = & \frac{4-\pi}{2}\\ \gamma_{1} & = & \frac{2\left(\pi-3\right)\sqrt{\pi}}{\left(4-\pi\right)^{3/2}}\\ \gamma_{2} & = & \frac{24\pi-6\pi^{2}-16}{\left(4-\pi\right)^{2}}\\ m_{d} & = & 1\\ m_{n} & = & \sqrt{2\log\left(2\right)}\end{eqnarray*}
 
-.. math:: h\left[X\right]=\frac{\gamma}{2}+\log\left(\frac{e}{\sqrt{2}}\right).
 
-.. math:: \mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(\frac{n}{2}+1\right)
 
-Rice\*
-======
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=\frac{\gamma}{2}+\log\left(\frac{e}{\sqrt{2}}\right).\]
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ \mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(\frac{n}{2}+1\right)\]
+
+
+
+
+Rice*
+=====
 
 Defined for :math:`x>0` and :math:`b>0`
 
+
+
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;b\right) & = & x\exp\left(-\frac{x^{2}+b^{2}}{2}\right)I_{0}\left(xb\right)\\
-   F\left(x;b\right) & = & \int_{0}^{x}\alpha\exp\left(-\frac{\alpha^{2}+b^{2}}{2}\right)I_{0}\left(\alpha b\right)d\alpha\end{aligned*}
+    \begin{eqnarray*} f\left(x;b\right) & = & x\exp\left(-\frac{x^{2}+b^{2}}{2}\right)I_{0}\left(xb\right)\\ F\left(x;b\right) & = & \int_{0}^{x}\alpha\exp\left(-\frac{\alpha^{2}+b^{2}}{2}\right)I_{0}\left(\alpha b\right)d\alpha\end{eqnarray*}
 
-.. math:: \mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(1+\frac{n}{2}\right)\,_{1}F_{1}\left(-\frac{n}{2};1;-\frac{b^{2}}{2}\right)
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ \mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(1+\frac{n}{2}\right)\,_{1}F_{1}\left(-\frac{n}{2};1;-\frac{b^{2}}{2}\right)\]
+
+
+
 
 Reciprocal
 ==========
@@ -1953,44 +2192,50 @@ Reciprocal
 Shape parameters :math:`a,b>0` :math:`x\in\left[a,b\right]`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;a,b\right) & = & \frac{1}{x\log\left(b/a\right)}\\
-   F\left(x;a,b\right) & = & \frac{\log\left(x/a\right)}{\log\left(b/a\right)}\\
-   G\left(q;a,b\right) & = & a\exp\left(q\log\left(b/a\right)\right)=a\left(\frac{b}{a}\right)^{q}\end{aligned*}
+    \begin{eqnarray*} f\left(x;a,b\right) & = & \frac{1}{x\log\left(b/a\right)}\\ F\left(x;a,b\right) & = & \frac{\log\left(x/a\right)}{\log\left(b/a\right)}\\ G\left(q;a,b\right) & = & a\exp\left(q\log\left(b/a\right)\right)=a\left(\frac{b}{a}\right)^{q}\end{eqnarray*}
 
-.. math::
 
-   \begin{aligned*}
-   d & = & \log\left(a/b\right)\\
-   \mu & = & \frac{a-b}{d}\\
-   \mu_{2} & = & \mu\frac{a+b}{2}-\mu^{2}=\frac{\left(a-b\right)\left[a\left(d-2\right)+b\left(d+2\right)\right]}{2d^{2}}\\
-   \gamma_{1} & = & \frac{\sqrt{2}\left[12d\left(a-b\right)^{2}+d^{2}\left(a^{2}\left(2d-9\right)+2abd+b^{2}\left(2d+9\right)\right)\right]}{3d\sqrt{a-b}\left[a\left(d-2\right)+b\left(d+2\right)\right]^{3/2}}\\
-   \gamma_{2} & = & \frac{-36\left(a-b\right)^{3}+36d\left(a-b\right)^{2}\left(a+b\right)-16d^{2}\left(a^{3}-b^{3}\right)+3d^{3}\left(a^{2}+b^{2}\right)\left(a+b\right)}{3\left(a-b\right)\left[a\left(d-2\right)+b\left(d+2\right)\right]^{2}}-3\\
-   m_{d} & = & a\\
-   m_{n} & = & \sqrt{ab}\end{aligned*}
-
-.. math:: h\left[X\right]=\frac{1}{2}\log\left(ab\right)+\log\left[\log\left(\frac{b}{a}\right)\right].
-
-Reciprocal Inverse Gaussian 
-============================
-
-The pdf is found from the inverse gaussian (IG),
-:math:`f_{RIG}\left(x;\mu\right)=\frac{1}{x^{2}}f_{IG}\left(\frac{1}{x};\mu\right)`
-defined for :math:`x\geq0` as
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f_{IG}\left(x;\mu\right) & = & \frac{1}{\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-\mu\right)^{2}}{2x\mu^{2}}\right).\\
-   F_{IG}\left(x;\mu\right) & = & \Phi\left(\frac{1}{\sqrt{x}}\frac{x-\mu}{\mu}\right)+\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{x+\mu}{\mu}\right)\end{aligned*}
+    \begin{eqnarray*} d & = & \log\left(a/b\right)\\ \mu & = & \frac{a-b}{d}\\ \mu_{2} & = & \mu\frac{a+b}{2}-\mu^{2}=\frac{\left(a-b\right)\left[a\left(d-2\right)+b\left(d+2\right)\right]}{2d^{2}}\\ \gamma_{1} & = & \frac{\sqrt{2}\left[12d\left(a-b\right)^{2}+d^{2}\left(a^{2}\left(2d-9\right)+2abd+b^{2}\left(2d+9\right)\right)\right]}{3d\sqrt{a-b}\left[a\left(d-2\right)+b\left(d+2\right)\right]^{3/2}}\\ \gamma_{2} & = & \frac{-36\left(a-b\right)^{3}+36d\left(a-b\right)^{2}\left(a+b\right)-16d^{2}\left(a^{3}-b^{3}\right)+3d^{3}\left(a^{2}+b^{2}\right)\left(a+b\right)}{3\left(a-b\right)\left[a\left(d-2\right)+b\left(d+2\right)\right]^{2}}-3\\ m_{d} & = & a\\ m_{n} & = & \sqrt{ab}\end{eqnarray*}
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f_{RIG}\left(x;\mu\right) & = & \frac{1}{\sqrt{2\pi x}}\exp\left(-\frac{\left(1-\mu x\right)^{2}}{2x\mu^{2}}\right)\\
-   F_{RIG}\left(x;\mu\right) & = & 1-F_{IG}\left(\frac{1}{x},\mu\right)\\
-    & = & 1-\Phi\left(\frac{1}{\sqrt{x}}\frac{1-\mu x}{\mu}\right)-\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{1+\mu x}{\mu}\right)\end{aligned*}
+    \[ h\left[X\right]=\frac{1}{2}\log\left(ab\right)+\log\left[\log\left(\frac{b}{a}\right)\right].\]
+
+
+
+
+Reciprocal Inverse Gaussian
+===========================
+
+The pdf is found from the inverse gaussian (IG), :math:`f_{RIG}\left(x;\mu\right)=\frac{1}{x^{2}}f_{IG}\left(\frac{1}{x};\mu\right)` defined for :math:`x\geq0` as
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} f_{IG}\left(x;\mu\right) & = & \frac{1}{\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-\mu\right)^{2}}{2x\mu^{2}}\right).\\ F_{IG}\left(x;\mu\right) & = & \Phi\left(\frac{1}{\sqrt{x}}\frac{x-\mu}{\mu}\right)+\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{x+\mu}{\mu}\right)\end{eqnarray*}
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} f_{RIG}\left(x;\mu\right) & = & \frac{1}{\sqrt{2\pi x}}\exp\left(-\frac{\left(1-\mu x\right)^{2}}{2x\mu^{2}}\right)\\ F_{RIG}\left(x;\mu\right) & = & 1-F_{IG}\left(\frac{1}{x},\mu\right)\\  & = & 1-\Phi\left(\frac{1}{\sqrt{x}}\frac{1-\mu x}{\mu}\right)-\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{1+\mu x}{\mu}\right)\end{eqnarray*}
+
+
+
 
 Semicircular
 ============
@@ -1998,61 +2243,70 @@ Semicircular
 Defined on :math:`x\in\left[-1,1\right]`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x\right) & = & \frac{2}{\pi}\sqrt{1-x^{2}}\\
-   F\left(x\right) & = & \frac{1}{2}+\frac{1}{\pi}\left[x\sqrt{1-x^{2}}+\arcsin x\right]\\
-   G\left(q\right) & = & F^{-1}\left(q\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \frac{2}{\pi}\sqrt{1-x^{2}}\\ F\left(x\right) & = & \frac{1}{2}+\frac{1}{\pi}\left[x\sqrt{1-x^{2}}+\arcsin x\right]\\ G\left(q\right) & = & F^{-1}\left(q\right)\end{eqnarray*}
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   m_{d}=m_{n}=\mu & = & 0\\
-   \mu_{2} & = & \frac{1}{4}\\
-   \gamma_{1} & = & 0\\
-   \gamma_{2} & = & -1\end{aligned*}
+    \begin{eqnarray*} m_{d}=m_{n}=\mu & = & 0\\ \mu_{2} & = & \frac{1}{4}\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & -1\end{eqnarray*}
 
-.. math:: h\left[X\right]=0.64472988584940017414.
 
-Studentized Range\*
-===================
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=0.64472988584940017414.\]
+
+
+
+
+Studentized Range*
+==================
+
 
 Student t
 =========
 
-Shape parameter :math:`\nu>0.` :math:`I\left(a,b,x\right)` is the
-incomplete beta integral and
-:math:`I^{-1}\left(a,b,I\left(a,b,x\right)\right)=x`
+Shape parameter :math:`\nu>0.` :math:`I\left(a,b,x\right)` is the incomplete beta integral and :math:`I^{-1}\left(a,b,I\left(a,b,x\right)\right)=x`
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\nu\right) & = & \frac{\Gamma\left(\frac{\nu+1}{2}\right)}{\sqrt{\pi\nu}\Gamma\left(\frac{\nu}{2}\right)\left[1+\frac{x^{2}}{\nu}\right]^{\frac{\nu+1}{2}}}\\
-   F\left(x;\nu\right) & = & \left\{ \begin{array}{ccc}
-   \frac{1}{2}I\left(\frac{\nu}{2},\frac{1}{2},\frac{\nu}{\nu+x^{2}}\right) &  & x\leq0\\
-   1-\frac{1}{2}I\left(\frac{\nu}{2},\frac{1}{2},\frac{\nu}{\nu+x^{2}}\right) &  & x\geq0
-   \end{array}\right.\\
-   G\left(q;\nu\right) & = & \left\{ \begin{array}{ccc}
-   -\sqrt{\frac{\nu}{I^{-1}\left(\frac{\nu}{2},\frac{1}{2},2q\right)}-\nu} &  & q\leq\frac{1}{2}\\
-   \sqrt{\frac{\nu}{I^{-1}\left(\frac{\nu}{2},\frac{1}{2},2-2q\right)}-\nu} &  & q\geq\frac{1}{2}
-   \end{array}\right.\end{aligned*}
+    \begin{eqnarray*} f\left(x;\nu\right) & = & \frac{\Gamma\left(\frac{\nu+1}{2}\right)}{\sqrt{\pi\nu}\Gamma\left(\frac{\nu}{2}\right)\left[1+\frac{x^{2}}{\nu}\right]^{\frac{\nu+1}{2}}}\\ F\left(x;\nu\right) & = & \left\{ \begin{array}{ccc} \frac{1}{2}I\left(\frac{\nu}{2},\frac{1}{2},\frac{\nu}{\nu+x^{2}}\right) &  & x\leq0\\ 1-\frac{1}{2}I\left(\frac{\nu}{2},\frac{1}{2},\frac{\nu}{\nu+x^{2}}\right) &  & x\geq0\end{array}\right.\\ G\left(q;\nu\right) & = & \left\{ \begin{array}{ccc} -\sqrt{\frac{\nu}{I^{-1}\left(\frac{\nu}{2},\frac{1}{2},2q\right)}-\nu} &  & q\leq\frac{1}{2}\\ \sqrt{\frac{\nu}{I^{-1}\left(\frac{\nu}{2},\frac{1}{2},2-2q\right)}-\nu} &  & q\geq\frac{1}{2}\end{array}\right.\end{eqnarray*}
+
+
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   m_{n}=m_{d}=\mu & = & 0\\
-   \mu_{2} & = & \frac{\nu}{\nu-2}\quad\nu>2\\
-   \gamma_{1} & = & 0\quad\nu>3\\
-   \gamma_{2} & = & \frac{6}{\nu-4}\quad\nu>4\end{aligned*}
+    \begin{eqnarray*} m_{n}=m_{d}=\mu & = & 0\\ \mu_{2} & = & \frac{\nu}{\nu-2}\quad\nu>2\\ \gamma_{1} & = & 0\quad\nu>3\\ \gamma_{2} & = & \frac{6}{\nu-4}\quad\nu>4\end{eqnarray*}
 
-As :math:`\nu\rightarrow\infty,` this distribution approaches the
-standard normal distribution.
+As :math:`\nu\rightarrow\infty,` this distribution approaches the standard normal distribution.
 
-.. math:: h\left[X\right]=\frac{1}{4}\log\left(\frac{\pi c\Gamma^{2}\left(\frac{c}{2}\right)}{\Gamma^{2}\left(\frac{c+1}{2}\right)}\right)-\frac{\left(c+1\right)}{4}\left[\Psi\left(\frac{c}{2}\right)-cZ\left(c\right)+\pi\tan\left(\frac{\pi c}{2}\right)+\gamma+2\log2\right]
 
- where
 
-.. math:: Z\left(c\right)=\,_{3}F_{2}\left(1,1,1+\frac{c}{2};\frac{3}{2},2;1\right)=\sum_{k=0}^{\infty}\frac{k!}{k+1}\frac{\Gamma\left(\frac{c}{2}+1+k\right)}{\Gamma\left(\frac{c}{2}+1\right)}\frac{\Gamma\left(\frac{3}{2}\right)}{\Gamma\left(\frac{3}{2}+k\right)}
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=\frac{1}{4}\log\left(\frac{\pi c\Gamma^{2}\left(\frac{c}{2}\right)}{\Gamma^{2}\left(\frac{c+1}{2}\right)}\right)-\frac{\left(c+1\right)}{4}\left[\Psi\left(\frac{c}{2}\right)-cZ\left(c\right)+\pi\tan\left(\frac{\pi c}{2}\right)+\gamma+2\log2\right]\]
+
+where
+
+.. math::
+   :nowrap:
+
+    \[ Z\left(c\right)=\,_{3}F_{2}\left(1,1,1+\frac{c}{2};\frac{3}{2},2;1\right)=\sum_{k=0}^{\infty}\frac{k!}{k+1}\frac{\Gamma\left(\frac{c}{2}+1+k\right)}{\Gamma\left(\frac{c}{2}+1\right)}\frac{\Gamma\left(\frac{3}{2}\right)}{\Gamma\left(\frac{3}{2}+k\right)}\]
+
+
+
 
 Student Z
 =========
@@ -2061,222 +2315,229 @@ The student Z distriubtion is defined over all space with one shape
 parameter :math:`\nu>0`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;\nu\right) & = & \frac{\Gamma\left(\frac{\nu}{2}\right)}{\sqrt{\pi}\Gamma\left(\frac{\nu-1}{2}\right)}\left(1+x^{2}\right)^{-\nu/2}\\
-   F\left(x;\nu\right) & = & \left\{ \begin{array}{ccc}
-   Q\left(x;\nu\right) &  & x\leq0\\
-   1-Q\left(x;\nu\right) &  & x\geq0
-   \end{array}\right.\\
-   Q\left(x;\nu\right) & = & \frac{\left|x\right|^{1-n}\Gamma\left(\frac{n}{2}\right)\,_{2}F_{1}\left(\frac{n-1}{2},\frac{n}{2};\frac{n+1}{2};-\frac{1}{x^{2}}\right)}{2\sqrt{\pi}\Gamma\left(\frac{n+1}{2}\right)}\end{aligned*}
+    \begin{eqnarray*} f\left(x;\nu\right) & = & \frac{\Gamma\left(\frac{\nu}{2}\right)}{\sqrt{\pi}\Gamma\left(\frac{\nu-1}{2}\right)}\left(1+x^{2}\right)^{-\nu/2}\\ F\left(x;\nu\right) & = & \left\{ \begin{array}{ccc} Q\left(x;\nu\right) &  & x\leq0\\ 1-Q\left(x;\nu\right) &  & x\geq0\end{array}\right.\\ Q\left(x;\nu\right) & = & \frac{\left|x\right|^{1-n}\Gamma\left(\frac{n}{2}\right)\,_{2}F_{1}\left(\frac{n-1}{2},\frac{n}{2};\frac{n+1}{2};-\frac{1}{x^{2}}\right)}{2\sqrt{\pi}\Gamma\left(\frac{n+1}{2}\right)}\end{eqnarray*}
 
 Interesting moments are
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & 0\\
-   \sigma^{2} & = & \frac{1}{\nu-3}\\
-   \gamma_{1} & = & 0\\
-   \gamma_{2} & = & \frac{6}{\nu-5}.\end{aligned*}
+    \begin{eqnarray*} \mu & = & 0\\ \sigma^{2} & = & \frac{1}{\nu-3}\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & \frac{6}{\nu-5}.\end{eqnarray*}
 
 The moment generating function is
 
-.. math:: \theta\left(t\right)=2\sqrt{\left|\frac{t}{2}\right|^{\nu-1}}\frac{K_{\left(n-1\right)/2}\left(\left|t\right|\right)}{\Gamma\left(\frac{\nu-1}{2}\right)}.
+.. math::
+   :nowrap:
 
-Symmetric Power\*
-=================
+    \[ \theta\left(t\right)=2\sqrt{\left|\frac{t}{2}\right|^{\nu-1}}\frac{K_{\left(n-1\right)/2}\left(\left|t\right|\right)}{\Gamma\left(\frac{\nu-1}{2}\right)}.\]
+
+
+
+
+Symmetric Power*
+================
+
 
 Triangular
 ==========
 
-One shape parameter :math:`c\in[0,1]` giving the distance to the peak as
-a percentage of the total extent of the non-zero portion. The location
-parameter is the start of the non-zero portion, and the scale-parameter
-is the width of the non-zero portion. In standard form we have
-:math:`x\in\left[0,1\right].`
+One shape parameter :math:`c\in[0,1]` giving the distance to the peak as a percentage of the total extent of
+the non-zero portion. The location parameter is the start of the non-
+zero portion, and the scale-parameter is the width of the non-zero
+portion. In standard form we have :math:`x\in\left[0,1\right].`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & \left\{ \begin{array}{ccc}
-   2\frac{x}{c} &  & x<c\\
-   2\frac{1-x}{1-c} &  & x\geq c
-   \end{array}\right.\\
-   F\left(x;c\right) & = & \left\{ \begin{array}{ccc}
-   \frac{x^{2}}{c} &  & x<c\\
-   \frac{x^{2}-2x+c}{c-1} &  & x\geq c
-   \end{array}\right.\\
-   G\left(q;c\right) & = & \left\{ \begin{array}{ccc}
-   \sqrt{cq} &  & q<c\\
-   1-\sqrt{\left(1-c\right)\left(1-q\right)} &  & q\geq c
-   \end{array}\right.\end{aligned*}
+    \begin{eqnarray*} f\left(x;c\right) & = & \left\{ \begin{array}{ccc} 2\frac{x}{c} &  & x<c\\ 2\frac{1-x}{1-c} &  & x\geq c\end{array}\right.\\ F\left(x;c\right) & = & \left\{ \begin{array}{ccc} \frac{x^{2}}{c} &  & x<c\\ \frac{x^{2}-2x+c}{c-1} &  & x\geq c\end{array}\right.\\ G\left(q;c\right) & = & \left\{ \begin{array}{ccc} \sqrt{cq} &  & q<c\\ 1-\sqrt{\left(1-c\right)\left(1-q\right)} &  & q\geq c\end{array}\right.\end{eqnarray*}
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \frac{c}{3}+\frac{1}{3}\\
-   \mu_{2} & = & \frac{1-c+c^{2}}{18}\\
-   \gamma_{1} & = & \frac{\sqrt{2}\left(2c-1\right)\left(c+1\right)\left(c-2\right)}{5\left(1-c+c^{2}\right)^{3/2}}\\
-   \gamma_{2} & = & -\frac{3}{5}\end{aligned*}
+    \begin{eqnarray*} \mu & = & \frac{c}{3}+\frac{1}{3}\\ \mu_{2} & = & \frac{1-c+c^{2}}{18}\\ \gamma_{1} & = & \frac{\sqrt{2}\left(2c-1\right)\left(c+1\right)\left(c-2\right)}{5\left(1-c+c^{2}\right)^{3/2}}\\ \gamma_{2} & = & -\frac{3}{5}\end{eqnarray*}
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   h\left(X\right) & = & \log\left(\frac{1}{2}\sqrt{e}\right)\\
-    & \approx & -0.19314718055994530942.\end{aligned*}
+    \begin{eqnarray*} h\left(X\right) & = & \log\left(\frac{1}{2}\sqrt{e}\right)\\  & \approx & -0.19314718055994530942.\end{eqnarray*}
+
+
+
 
 Truncated Exponential
 =====================
 
-This is an exponential distribution defined only over a certain region
-:math:`0<x<B`\ . In standard form this is
+This is an exponential distribution defined only over a certain region :math:`0<x<B` . In standard form this is
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;B\right) & = & \frac{e^{-x}}{1-e^{-B}}\\
-   F\left(x;B\right) & = & \frac{1-e^{-x}}{1-e^{-B}}\\
-   G\left(q;B\right) & = & -\log\left(1-q+qe^{-B}\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x;B\right) & = & \frac{e^{-x}}{1-e^{-B}}\\ F\left(x;B\right) & = & \frac{1-e^{-x}}{1-e^{-B}}\\ G\left(q;B\right) & = & -\log\left(1-q+qe^{-B}\right)\end{eqnarray*}
 
-.. math:: \mu_{n}^{\prime}=\Gamma\left(1+n\right)-\Gamma\left(1+n,B\right)
 
-.. math:: h\left[X\right]=\log\left(e^{B}-1\right)+\frac{1+e^{B}\left(B-1\right)}{1-e^{B}}.
+
+.. math::
+   :nowrap:
+
+    \[ \mu_{n}^{\prime}=\Gamma\left(1+n\right)-\Gamma\left(1+n,B\right)\]
+
+
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=\log\left(e^{B}-1\right)+\frac{1+e^{B}\left(B-1\right)}{1-e^{B}}.\]
+
+
+
 
 Truncated Normal
 ================
 
-A normal distribution restricted to lie within a certain range given by
-two parameters :math:`A` and :math:`B`\ . Notice that this :math:`A` and
-:math:`B` correspond to the bounds on :math:`x` in standard form. For
-:math:`x\in\left[A,B\right]` we get
+A normal distribution restricted to lie within a certain range given
+by two parameters :math:`A` and :math:`B` . Notice that this :math:`A` and :math:`B` correspond to the bounds on :math:`x` in standard form. For :math:`x\in\left[A,B\right]` we get
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;A,B\right) & = & \frac{\phi\left(x\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\\
-   F\left(x;A,B\right) & = & \frac{\Phi\left(x\right)-\Phi\left(A\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\\
-   G\left(q;A,B\right) & = & \Phi^{-1}\left[q\Phi\left(B\right)+\Phi\left(A\right)\left(1-q\right)\right]\end{aligned*}
+    \begin{eqnarray*} f\left(x;A,B\right) & = & \frac{\phi\left(x\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\\ F\left(x;A,B\right) & = & \frac{\Phi\left(x\right)-\Phi\left(A\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\\ G\left(q;A,B\right) & = & \Phi^{-1}\left[q\Phi\left(B\right)+\Phi\left(A\right)\left(1-q\right)\right]\end{eqnarray*}
 
 where
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \phi\left(x\right) & = & \frac{1}{\sqrt{2\pi}}e^{-x^{2}/2}\\
-   \Phi\left(x\right) & = & \int_{-\infty}^{x}\phi\left(u\right)du.\end{aligned*}
+    \begin{eqnarray*} \phi\left(x\right) & = & \frac{1}{\sqrt{2\pi}}e^{-x^{2}/2}\\ \Phi\left(x\right) & = & \int_{-\infty}^{x}\phi\left(u\right)du.\end{eqnarray*}
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \frac{\phi\left(A\right)-\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\\
-   \mu_{2} & = & 1+\frac{A\phi\left(A\right)-B\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}-\left(\frac{\phi\left(A\right)-\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\right)^{2}\end{aligned*}
+    \begin{eqnarray*} \mu & = & \frac{\phi\left(A\right)-\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\\ \mu_{2} & = & 1+\frac{A\phi\left(A\right)-B\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}-\left(\frac{\phi\left(A\right)-\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\right)^{2}\end{eqnarray*}
+
+
+
 
 Tukey-Lambda
 ============
 
-.. math::
 
-   \begin{aligned*}
-   f\left(x;\lambda\right) & = & F^{\prime}\left(x;\lambda\right)=\frac{1}{G^{\prime}\left(F\left(x;\lambda\right);\lambda\right)}=\frac{1}{F^{\lambda-1}\left(x;\lambda\right)+\left[1-F\left(x;\lambda\right)\right]^{\lambda-1}}\\
-   F\left(x;\lambda\right) & = & G^{-1}\left(x;\lambda\right)\\
-   G\left(p;\lambda\right) & = & \frac{p^{\lambda}-\left(1-p\right)^{\lambda}}{\lambda}\end{aligned*}
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & 0\\
-   \mu_{2} & = & \int_{0}^{1}G^{2}\left(p;\lambda\right)dp\\
-    & = & \frac{2\Gamma\left(\lambda+\frac{3}{2}\right)-\lambda4^{-\lambda}\sqrt{\pi}\Gamma\left(\lambda\right)\left(1-2\lambda\right)}{\lambda^{2}\left(1+2\lambda\right)\Gamma\left(\lambda+\frac{3}{2}\right)}\\
-   \gamma_{1} & = & 0\\
-   \gamma_{2} & = & \frac{\mu_{4}}{\mu_{2}^{2}}-3\\
-   \mu_{4} & = & \frac{3\Gamma\left(\lambda\right)\Gamma\left(\lambda+\frac{1}{2}\right)2^{-2\lambda}}{\lambda^{3}\Gamma\left(2\lambda+\frac{3}{2}\right)}+\frac{2}{\lambda^{4}\left(1+4\lambda\right)}\\
-    &  & -\frac{2\sqrt{3}\Gamma\left(\lambda\right)2^{-6\lambda}3^{3\lambda}\Gamma\left(\lambda+\frac{1}{3}\right)\Gamma\left(\lambda+\frac{2}{3}\right)}{\lambda^{3}\Gamma\left(2\lambda+\frac{3}{2}\right)\Gamma\left(\lambda+\frac{1}{2}\right)}.\end{aligned*}
+    \begin{eqnarray*} f\left(x;\lambda\right) & = & F^{\prime}\left(x;\lambda\right)=\frac{1}{G^{\prime}\left(F\left(x;\lambda\right);\lambda\right)}=\frac{1}{F^{\lambda-1}\left(x;\lambda\right)+\left[1-F\left(x;\lambda\right)\right]^{\lambda-1}}\\ F\left(x;\lambda\right) & = & G^{-1}\left(x;\lambda\right)\\ G\left(p;\lambda\right) & = & \frac{p^{\lambda}-\left(1-p\right)^{\lambda}}{\lambda}\end{eqnarray*}
 
-Notice that the
-:math:`\lim_{\lambda\rightarrow0}G\left(p;\lambda\right)=\log\left(p/\left(1-p\right)\right)`
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   h\left[X\right] & = & \int_{0}^{1}\log\left[G^{\prime}\left(p\right)\right]dp\\
-    & = & \int_{0}^{1}\log\left[p^{\lambda-1}+\left(1-p\right)^{\lambda-1}\right]dp.\end{aligned*}
+    \begin{eqnarray*} \mu & = & 0\\ \mu_{2} & = & \int_{0}^{1}G^{2}\left(p;\lambda\right)dp\\  & = & \frac{2\Gamma\left(\lambda+\frac{3}{2}\right)-\lambda4^{-\lambda}\sqrt{\pi}\Gamma\left(\lambda\right)\left(1-2\lambda\right)}{\lambda^{2}\left(1+2\lambda\right)\Gamma\left(\lambda+\frac{3}{2}\right)}\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & \frac{\mu_{4}}{\mu_{2}^{2}}-3\\ \mu_{4} & = & \frac{3\Gamma\left(\lambda\right)\Gamma\left(\lambda+\frac{1}{2}\right)2^{-2\lambda}}{\lambda^{3}\Gamma\left(2\lambda+\frac{3}{2}\right)}+\frac{2}{\lambda^{4}\left(1+4\lambda\right)}\\  &  & -\frac{2\sqrt{3}\Gamma\left(\lambda\right)2^{-6\lambda}3^{3\lambda}\Gamma\left(\lambda+\frac{1}{3}\right)\Gamma\left(\lambda+\frac{2}{3}\right)}{\lambda^{3}\Gamma\left(2\lambda+\frac{3}{2}\right)\Gamma\left(\lambda+\frac{1}{2}\right)}.\end{eqnarray*}
+
+Notice that the :math:`\lim_{\lambda\rightarrow0}G\left(p;\lambda\right)=\log\left(p/\left(1-p\right)\right)`
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} h\left[X\right] & = & \int_{0}^{1}\log\left[G^{\prime}\left(p\right)\right]dp\\  & = & \int_{0}^{1}\log\left[p^{\lambda-1}+\left(1-p\right)^{\lambda-1}\right]dp.\end{eqnarray*}
+
+
+
 
 Uniform
 =======
 
-Standard form :math:`x\in\left(0,1\right).` In general form, the lower
-limit is :math:`L,` the upper limit is :math:`S+L.`
+Standard form :math:`x\in\left(0,1\right).` In general form, the lower limit is :math:`L,` the upper limit is :math:`S+L.`
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x\right) & = & 1\\
-   F\left(x\right) & = & x\\
-   G\left(q\right) & = & q\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & 1\\ F\left(x\right) & = & x\\ G\left(q\right) & = & q\end{eqnarray*}
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & \frac{1}{2}\\
-   \mu_{2} & = & \frac{1}{12}\\
-   \gamma_{1} & = & 0\\
-   \gamma_{2} & = & -\frac{6}{5}\end{aligned*}
+    \begin{eqnarray*} \mu & = & \frac{1}{2}\\ \mu_{2} & = & \frac{1}{12}\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & -\frac{6}{5}\end{eqnarray*}
 
-.. math:: h\left[X\right]=0
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=0\]
+
+
+
 
 Von Mises
 =========
 
-Defined for :math:`x\in\left[-\pi,\pi\right]` with shape parameter
-:math:`b>0`\ . Note, the PDF and CDF functions are periodic and are
-always defined over :math:`x\in\left[-\pi,\pi\right]` regardless of the
-location parameter. Thus, if an input beyond this range is given, it is
-converted to the equivalent angle in this range. For values of
-:math:`b<100` the PDF and CDF formulas below are used. Otherwise, a
-normal approximation with variance :math:`1/b` is used.
+Defined for :math:`x\in\left[-\pi,\pi\right]` with shape parameter :math:`b>0` . Note, the PDF and CDF functions are periodic and are always defined
+over :math:`x\in\left[-\pi,\pi\right]` regardless of the location parameter. Thus, if an input beyond this
+range is given, it is converted to the equivalent angle in this range.
+For values of :math:`b<100` the PDF and CDF formulas below are used. Otherwise, a normal
+approximation with variance :math:`1/b` is used.
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;b\right) & = & \frac{e^{b\cos x}}{2\pi I_{0}\left(b\right)}\\
-   F\left(x;b\right) & = & \frac{1}{2}+\frac{x}{2\pi}+\sum_{k=1}^{\infty}\frac{I_{k}\left(b\right)\sin\left(kx\right)}{I_{0}\left(b\right)\pi k}\\
-   G\left(q;b\right) & = & F^{-1}\left(x;b\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x;b\right) & = & \frac{e^{b\cos x}}{2\pi I_{0}\left(b\right)}\\ F\left(x;b\right) & = & \frac{1}{2}+\frac{x}{2\pi}+\sum_{k=1}^{\infty}\frac{I_{k}\left(b\right)\sin\left(kx\right)}{I_{0}\left(b\right)\pi k}\\ G\left(q;b\right) & = & F^{-1}\left(x;b\right)\end{eqnarray*}
+
+
+
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & 0\\
-   \mu_{2} & = & \int_{-\pi}^{\pi}x^{2}f\left(x;b\right)dx\\
-   \gamma_{1} & = & 0\\
-   \gamma_{2} & = & \frac{\int_{-\pi}^{\pi}x^{4}f\left(x;b\right)dx}{\mu_{2}^{2}}-3\end{aligned*}
+    \begin{eqnarray*} \mu & = & 0\\ \mu_{2} & = & \int_{-\pi}^{\pi}x^{2}f\left(x;b\right)dx\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & \frac{\int_{-\pi}^{\pi}x^{4}f\left(x;b\right)dx}{\mu_{2}^{2}}-3\end{eqnarray*}
 
 This can be used for defining circular variance.
 
-Wald 
-=====
 
-Special case of the Inverse Normal with shape parameter set to
-:math:`1.0`\ . Defined for :math:`x>0`\ .
+Wald
+====
 
-.. math::
+Special case of the Inverse Normal with shape parameter set to :math:`1.0` . Defined for :math:`x>0` .
 
-   \begin{aligned*}
-   f\left(x\right) & = & \frac{1}{\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-1\right)^{2}}{2x}\right).\\
-   F\left(x\right) & = & \Phi\left(\frac{x-1}{\sqrt{x}}\right)+\exp\left(2\right)\Phi\left(-\frac{x+1}{\sqrt{x}}\right)\\
-   G\left(q;\mu\right) & = & F^{-1}\left(q;\mu\right)\end{aligned*}
+
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   \mu & = & 1\\
-   \mu_{2} & = & 1\\
-   \gamma_{1} & = & 3\\
-   \gamma_{2} & = & 15\\
-   m_{d} & = & \frac{1}{2}\left(\sqrt{13}-3\right)\end{aligned*}
+    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-1\right)^{2}}{2x}\right).\\ F\left(x\right) & = & \Phi\left(\frac{x-1}{\sqrt{x}}\right)+\exp\left(2\right)\Phi\left(-\frac{x+1}{\sqrt{x}}\right)\\ G\left(q;\mu\right) & = & F^{-1}\left(q;\mu\right)\end{eqnarray*}
 
-Wishart\*
-=========
+
+
+
+
+.. math::
+   :nowrap:
+
+    \begin{eqnarray*} \mu & = & 1\\ \mu_{2} & = & 1\\ \gamma_{1} & = & 3\\ \gamma_{2} & = & 15\\ m_{d} & = & \frac{1}{2}\left(\sqrt{13}-3\right)\end{eqnarray*}
+
+
+
+
+Wishart*
+========
+
 
 Wrapped Cauchy
 ==============
@@ -2284,22 +2545,20 @@ Wrapped Cauchy
 For :math:`x\in\left[0,2\pi\right]` :math:`c\in\left(0,1\right)`
 
 .. math::
+   :nowrap:
 
-   \begin{aligned*}
-   f\left(x;c\right) & = & \frac{1-c^{2}}{2\pi\left(1+c^{2}-2c\cos x\right)}\\
-   g_{c}\left(x\right) & = & \frac{1}{\pi}\arctan\left[\frac{1+c}{1-c}\tan\left(\frac{x}{2}\right)\right]\\
-   r_{c}\left(q\right) & = & 2\arctan\left[\frac{1-c}{1+c}\tan\left(\pi q\right)\right]\\
-   F\left(x;c\right) & = & \left\{ \begin{array}{ccc}
-   g_{c}\left(x\right) &  & 0\leq x<\pi\\
-   1-g_{c}\left(2\pi-x\right) &  & \pi\leq x\leq2\pi
-   \end{array}\right.\\
-   G\left(q;c\right) & = & \left\{ \begin{array}{ccc}
-   r_{c}\left(q\right) &  & 0\leq q<\frac{1}{2}\\
-   2\pi-r_{c}\left(1-q\right) &  & \frac{1}{2}\leq q\leq1
-   \end{array}\right.\end{aligned*}
-
-.. math:: 
-
-.. math:: h\left[X\right]=\log\left(2\pi\left(1-c^{2}\right)\right).
+    \begin{eqnarray*} f\left(x;c\right) & = & \frac{1-c^{2}}{2\pi\left(1+c^{2}-2c\cos x\right)}\\ g_{c}\left(x\right) & = & \frac{1}{\pi}\arctan\left[\frac{1+c}{1-c}\tan\left(\frac{x}{2}\right)\right]\\ r_{c}\left(q\right) & = & 2\arctan\left[\frac{1-c}{1+c}\tan\left(\pi q\right)\right]\\ F\left(x;c\right) & = & \left\{ \begin{array}{ccc} g_{c}\left(x\right) &  & 0\leq x<\pi\\ 1-g_{c}\left(2\pi-x\right) &  & \pi\leq x\leq2\pi\end{array}\right.\\ G\left(q;c\right) & = & \left\{ \begin{array}{ccc} r_{c}\left(q\right) &  & 0\leq q<\frac{1}{2}\\ 2\pi-r_{c}\left(1-q\right) &  & \frac{1}{2}\leq q\leq1\end{array}\right.\end{eqnarray*}
 
 
+
+.. math::
+   :nowrap:
+
+    \[ \]
+
+
+
+.. math::
+   :nowrap:
+
+    \[ h\left[X\right]=\log\left(2\pi\left(1-c^{2}\right)\right).\]

--- a/doc/source/tutorial/stats/continuous.rst
+++ b/doc/source/tutorial/stats/continuous.rst
@@ -1,113 +1,114 @@
-.. _continuous-random-variables:
-
-====================================
-Continuous Statistical Distributions
-====================================
-
 Overview
 ========
 
-All distributions will have location (L) and Scale (S) parameters
-along with any shape parameters needed, the names for the shape
-parameters will vary. Standard form for the distributions will be
-given where :math:`L=0.0` and :math:`S=1.0.` The nonstandard forms can be obtained for the various functions using
-(note :math:`U` is a standard uniform random variate).
+All distributions will have location (L) and Scale (S) parameters along
+with any shape parameters needed, the names for the shape parameters
+will vary. Standard form for the distributions will be given where
+:math:`L=0.0` and :math:`S=1.0.` The nonstandard forms can be obtained
+for the various functions using (note :math:`U` is a standard uniform
+random variate).
 
+\|c\|c\|c\|
 
-======================================  ==============================================================================================================================  =========================================================================================================================================
-Function Name                           Standard Function                                                                                                               Transformation
-======================================  ==============================================================================================================================  =========================================================================================================================================
-Cumulative Distribution Function (CDF)  :math:`F\left(x\right)`                                                                                                         :math:`F\left(x;L,S\right)=F\left(\frac{\left(x-L\right)}{S}\right)`
-Probability Density Function (PDF)      :math:`f\left(x\right)=F^{\prime}\left(x\right)`                                                                                :math:`f\left(x;L,S\right)=\frac{1}{S}f\left(\frac{\left(x-L\right)}{S}\right)`
-Percent Point Function (PPF)            :math:`G\left(q\right)=F^{-1}\left(q\right)`                                                                                    :math:`G\left(q;L,S\right)=L+SG\left(q\right)`
-Probability Sparsity Function (PSF)     :math:`g\left(q\right)=G^{\prime}\left(q\right)`                                                                                :math:`g\left(q;L,S\right)=Sg\left(q\right)`
-Hazard Function (HF)                    :math:`h_{a}\left(x\right)=\frac{f\left(x\right)}{1-F\left(x\right)}`                                                           :math:`h_{a}\left(x;L,S\right)=\frac{1}{S}h_{a}\left(\frac{\left(x-L\right)}{S}\right)`
-Cumulative Hazard Functon (CHF)         :math:`H_{a}\left(x\right)=` :math:`\log\frac{1}{1-F\left(x\right)}`                                                            :math:`H_{a}\left(x;L,S\right)=H_{a}\left(\frac{\left(x-L\right)}{S}\right)`
-Survival Function (SF)                  :math:`S\left(x\right)=1-F\left(x\right)`                                                                                       :math:`S\left(x;L,S\right)=S\left(\frac{\left(x-L\right)}{S}\right)`
-Inverse Survival Function (ISF)         :math:`Z\left(\alpha\right)=S^{-1}\left(\alpha\right)=G\left(1-\alpha\right)`                                                   :math:`Z\left(\alpha;L,S\right)=L+SZ\left(\alpha\right)`
-Moment Generating Function (MGF)        :math:`M_{Y}\left(t\right)=E\left[e^{Yt}\right]`                                                                                :math:`M_{X}\left(t\right)=e^{Lt}M_{Y}\left(St\right)`
-Random Variates                         :math:`Y=G\left(U\right)`                                                                                                       :math:`X=L+SY`
-(Differential) Entropy                  :math:`h\left[Y\right]=-\int f\left(y\right)\log f\left(y\right)dy`                                                             :math:`h\left[X\right]=h\left[Y\right]+\log S`
-(Non-central) Moments                   :math:`\mu_{n}^{\prime}=E\left[Y^{n}\right]`                                                                                    :math:`E\left[X^{n}\right]=L^{n}\sum_{k=0}^{N}\left(\begin{array}{c} n\\ k\end{array}\right)\left(\frac{S}{L}\right)^{k}\mu_{k}^{\prime}`
-Central Moments                         :math:`\mu_{n}=E\left[\left(Y-\mu\right)^{n}\right]`                                                                            :math:`E\left[\left(X-\mu_{X}\right)^{n}\right]=S^{n}\mu_{n}`
-mean (mode, median), var                :math:`\mu,\,\mu_{2}`                                                                                                           :math:`L+S\mu,\, S^{2}\mu_{2}`
-skewness, kurtosis                      :math:`\gamma_{1}=\frac{\mu_{3}}{\left(\mu_{2}\right)^{3/2}},\,` :math:`\gamma_{2}=\frac{\mu_{4}}{\left(\mu_{2}\right)^{2}}-3`  :math:`\gamma_{1},\,\gamma_{2}`
-======================================  ==============================================================================================================================  =========================================================================================================================================
+Function Name & Standard Function & TransformationCumulative
+Distribution Function (CDF) & :math:`F\left(x\right)` &
+:math:`F\left(x;L,S\right)=F\left(\frac{\left(x-L\right)}{S}\right)`\ Probability
+Density Function (PDF) &
+:math:`f\left(x\right)=F^{\prime}\left(x\right)` &
+:math:`f\left(x;L,S\right)=\frac{1}{S}f\left(\frac{\left(x-L\right)}{S}\right)`\ Percent
+Point Function (PPF) & :math:`G\left(q\right)=F^{-1}\left(q\right)` &
+:math:`G\left(q;L,S\right)=L+SG\left(q\right)`\ Probability Sparsity
+Function (PSF) & :math:`g\left(q\right)=G^{\prime}\left(q\right)` &
+:math:`g\left(q;L,S\right)=Sg\left(q\right)`\ Hazard Function (HF) &
+:math:`h_{a}\left(x\right)=\frac{f\left(x\right)}{1-F\left(x\right)}` &
+:math:`h_{a}\left(x;L,S\right)=\frac{1}{S}h_{a}\left(\frac{\left(x-L\right)}{S}\right)`\ Cumulative
+Hazard Functon (CHF) & :math:`H_{a}\left(x\right)=`\ :math:`\log\frac{1}{1-F\left(x\right)}`
+&
+:math:`H_{a}\left(x;L,S\right)=H_{a}\left(\frac{\left(x-L\right)}{S}\right)`\ Survival
+Function (SF) & :math:`S\left(x\right)=1-F\left(x\right)` &
+:math:`S\left(x;L,S\right)=S\left(\frac{\left(x-L\right)}{S}\right)`\ Inverse
+Survival Function (ISF) &
+:math:`Z\left(\alpha\right)=S^{-1}\left(\alpha\right)=G\left(1-\alpha\right)`
+& :math:`Z\left(\alpha;L,S\right)=L+SZ\left(\alpha\right)`\ Moment
+Generating Function (MGF) &
+:math:`M_{Y}\left(t\right)=E\left[e^{Yt}\right]` &
+:math:`M_{X}\left(t\right)=e^{Lt}M_{Y}\left(St\right)`\ Random Variates
+& :math:`Y=G\left(U\right)` & :math:`X=L+SY`\ (Differential) Entropy &
+:math:`h\left[Y\right]=-\int f\left(y\right)\log f\left(y\right)dy` &
+:math:`h\left[X\right]=h\left[Y\right]+\log S`\ (Non-central) Moments &
+:math:`\mu_{n}^{\prime}=E\left[Y^{n}\right]` &
+:math:`E\left[X^{n}\right]=L^{n}\sum_{k=0}^{N}\left(\begin{array}{c}
+n\\
+k
+\end{array}\right)\left(\frac{S}{L}\right)^{k}\mu_{k}^{\prime}`\ Central
+Moments & :math:`\mu_{Y^{n}}=E\left[\left(Y-\mu_{Y}\right)^{n}\right]` &
+:math:`E\left[\left(X-\mu_{X}\right)^{n}\right]=S^{n}\mu_{X^{n}}=S^{n}\mu_{n}`\ mean
+(mode, median), var & :math:`\mu_{Y},\,\mu_{Y^{2}}` &
+:math:`L+S\mu,\, S^{2}\mu_{2}` skewness, kurtosis &
+:math:`\gamma_{1}=\frac{\mu_{3}}{\left(\mu_{2}\right)^{3/2}},\,`\ :math:`\gamma_{2}=\frac{\mu_{4}}{\left(\mu_{2}\right)^{2}}-3`
+& :math:`\gamma_{1},\,\gamma_{2}`
 
-
-
-
-
+ 
 
 Moments
 -------
 
 Non-central moments are defined using the PDF
 
-.. math::
-   :nowrap:
+.. math:: \mu_{n}^{\prime}=\int_{-\infty}^{\infty}x^{n}f\left(x\right)dx.
 
-    \[ \mu_{n}^{\prime}=\int_{-\infty}^{\infty}x^{n}f\left(x\right)dx.\]
+ Note, that these can always be computed using the PPF. Substitute
+:math:`x=G\left(q\right)` in the above equation and get
 
-Note, that these can always be computed using the PPF. Substitute :math:`x=G\left(q\right)` in the above equation and get
+.. math:: \mu_{n}^{\prime}=\int_{0}^{1}G^{n}\left(q\right)dq
 
-.. math::
-   :nowrap:
-
-    \[ \mu_{n}^{\prime}=\int_{0}^{1}G^{n}\left(q\right)dq\]
-
-which may be easier to compute numerically. Note that :math:`q=F\left(x\right)` so that :math:`dq=f\left(x\right)dx.` Central moments are computed similarly :math:`\mu=\mu_{1}^{\prime}`
+ which may be easier to compute numerically. Note that
+:math:`q=F\left(x\right)` so that :math:`dq=f\left(x\right)dx.` Central
+moments are computed similarly :math:`\mu=\mu_{1}^{\prime}`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu_{n} & = & \int_{-\infty}^{\infty}\left(x-\mu\right)^{n}f\left(x\right)dx\\  & = & \int_{0}^{1}\left(G\left(q\right)-\mu\right)^{n}dq\\  & = & \sum_{k=0}^{n}\left(\begin{array}{c} n\\ k\end{array}\right)\left(-\mu\right)^{k}\mu_{n-k}^{\prime}\end{eqnarray*}
+   \begin{aligned*}
+   \mu_{n} & = & \int_{-\infty}^{\infty}\left(x-\mu\right)^{n}f\left(x\right)dx\\
+    & = & \int_{0}^{1}\left(G\left(q\right)-\mu\right)^{n}dq\\
+    & = & \sum_{k=0}^{n}\left(\begin{array}{c}
+   n\\
+   k
+   \end{array}\right)\left(-\mu\right)^{k}\mu_{n-k}^{\prime}\end{aligned*}
 
 In particular
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu_{3} & = & \mu_{3}^{\prime}-3\mu\mu_{2}^{\prime}+2\mu^{3}\\  & = & \mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}\\ \mu_{4} & = & \mu_{4}^{\prime}-4\mu\mu_{3}^{\prime}+6\mu^{2}\mu_{2}^{\prime}-3\mu^{4}\\  & = & \mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}\end{eqnarray*}
+   \begin{aligned*}
+   \mu_{3} & = & \mu_{3}^{\prime}-3\mu\mu_{2}^{\prime}+2\mu^{3}\\
+    & = & \mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}\\
+   \mu_{4} & = & \mu_{4}^{\prime}-4\mu\mu_{3}^{\prime}+6\mu^{2}\mu_{2}^{\prime}-3\mu^{4}\\
+    & = & \mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}\end{aligned*}
 
 Skewness is defined as
 
-.. math::
-   :nowrap:
+.. math:: \gamma_{1}=\sqrt{\beta_{1}}=\frac{\mu_{3}}{\mu_{2}^{3/2}}
 
-    \[ \gamma_{1}=\sqrt{\beta_{1}}=\frac{\mu_{3}}{\mu_{2}^{3/2}}\]
+ while (Fisher) kurtosis is
 
-while (Fisher) kurtosis is
+.. math:: \gamma_{2}=\frac{\mu_{4}}{\mu_{2}^{2}}-3,
 
-.. math::
-   :nowrap:
-
-    \[ \gamma_{2}=\frac{\mu_{4}}{\mu_{2}^{2}}-3,\]
-
-so that a normal distribution has a kurtosis of zero.
-
+ so that a normal distribution has a kurtosis of zero.
 
 Median and mode
 ---------------
 
-The median, :math:`m_{n}` is defined as the point at which half of the density is on one side
-and half on the other. In other words, :math:`F\left(m_{n}\right)=\frac{1}{2}` so that
+The median, :math:`m_{n}` is defined as the point at which half of the
+density is on one side and half on the other. In other words,
+:math:`F\left(m_{n}\right)=\frac{1}{2}` so that
 
-.. math::
-   :nowrap:
+.. math:: m_{n}=G\left(\frac{1}{2}\right).
 
-    \[ m_{n}=G\left(\frac{1}{2}\right).\]
+ In addition, the mode, :math:`m_{d}`\ , is defined as the value for
+which the probability density function reaches it’s peak
 
-In addition, the mode, :math:`m_{d}` , is defined as the value for which the probability density function
-reaches it's peak
-
-.. math::
-   :nowrap:
-
-    \[ m_{d}=\arg\max_{x}f\left(x\right).\]
-
-
-
+.. math:: m_{d}=\arg\max_{x}f\left(x\right).
 
 Fitting data
 ------------
@@ -117,1014 +118,944 @@ common. Alternatively, some distributions have well-known minimum
 variance unbiased estimators. These will be chosen by default, but the
 likelihood function will always be available for minimizing.
 
-If :math:`f\left(x;\boldsymbol{\theta}\right)` is the PDF of a random-variable where :math:`\boldsymbol{\theta}` is a vector of parameters ( *e.g.* :math:`L` and :math:`S` ), then for a collection of :math:`N` independent samples from this distribution, the joint distribution the
-random vector :math:`\mathbf{x}` is
+If :math:`f\left(x;\boldsymbol{\theta}\right)` is the PDF of a
+random-variable where :math:`\boldsymbol{\theta}` is a vector of
+parameters (*e.g. :math:`L`\ * and :math:`S`\ ), then for a collection
+of :math:`N` independent samples from this distribution, the joint
+distribution the random vector :math:`\mathbf{x}` is
+
+.. math:: f\left(\mathbf{x};\boldsymbol{\theta}\right)=\prod_{i=1}^{N}f\left(x_{i};\boldsymbol{\theta}\right).
+
+ The maximum likelihood estimate of the parameters
+:math:`\boldsymbol{\theta}` are the parameters which maximize this
+function with :math:`\mathbf{x}` fixed and given by the data:
 
 .. math::
-   :nowrap:
 
-    \[ f\left(\mathbf{x};\boldsymbol{\theta}\right)=\prod_{i=1}^{N}f\left(x_{i};\boldsymbol{\theta}\right).\]
-
-The maximum likelihood estimate of the parameters :math:`\boldsymbol{\theta}` are the parameters which maximize this function with :math:`\mathbf{x}` fixed and given by the data:
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} \boldsymbol{\theta}_{es} & = & \arg\max_{\boldsymbol{\theta}}f\left(\mathbf{x};\boldsymbol{\theta}\right)\\  & = & \arg\min_{\boldsymbol{\theta}}l_{\mathbf{x}}\left(\boldsymbol{\theta}\right).\end{eqnarray*}
+   \begin{aligned*}
+   \boldsymbol{\theta}_{es} & = & \arg\max_{\boldsymbol{\theta}}f\left(\mathbf{x};\boldsymbol{\theta}\right)\\
+    & = & \arg\min_{\boldsymbol{\theta}}l_{\mathbf{x}}\left(\boldsymbol{\theta}\right).\end{aligned*}
 
 Where
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} l_{\mathbf{x}}\left(\boldsymbol{\theta}\right) & = & -\sum_{i=1}^{N}\log f\left(x_{i};\boldsymbol{\theta}\right)\\  & = & -N\overline{\log f\left(x_{i};\boldsymbol{\theta}\right)}\end{eqnarray*}
+   \begin{aligned*}
+   l_{\mathbf{x}}\left(\boldsymbol{\theta}\right) & = & -\sum_{i=1}^{N}\log f\left(x_{i};\boldsymbol{\theta}\right)\\
+    & = & -N\overline{\log f\left(x_{i};\boldsymbol{\theta}\right)}\end{aligned*}
 
-Note that if :math:`\boldsymbol{\theta}` includes only shape parameters, the location and scale-parameters can
-be fit by replacing :math:`x_{i}` with :math:`\left(x_{i}-L\right)/S` in the log-likelihood function adding :math:`N\log S` and minimizing, thus
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} l_{\mathbf{x}}\left(L,S;\boldsymbol{\theta}\right) & = & N\log S-\sum_{i=1}^{N}\log f\left(\frac{x_{i}-L}{S};\boldsymbol{\theta}\right)\\  & = & N\log S+l_{\frac{\mathbf{x}-S}{L}}\left(\boldsymbol{\theta}\right)\end{eqnarray*}
-
-If desired, sample estimates for :math:`L` and :math:`S` (not necessarily maximum likelihood estimates) can be obtained from
-samples estimates of the mean and variance using
+Note that if :math:`\boldsymbol{\theta}` includes only shape parameters,
+the location and scale-parameters can be fit by replacing :math:`x_{i}`
+with :math:`\left(x_{i}-L\right)/S` in the log-likelihood function
+adding :math:`N\log S` and minimizing, thus
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \hat{S} & = & \sqrt{\frac{\hat{\mu}_{2}}{\mu_{2}}}\\ \hat{L} & = & \hat{\mu}-\hat{S}\mu\end{eqnarray*}
+   \begin{aligned*}
+   l_{\mathbf{x}}\left(L,S;\boldsymbol{\theta}\right) & = & N\log S-\sum_{i=1}^{N}\log f\left(\frac{x_{i}-L}{S};\boldsymbol{\theta}\right)\\
+    & = & N\log S+l_{\frac{\mathbf{x}-S}{L}}\left(\boldsymbol{\theta}\right)\end{aligned*}
 
-where :math:`\mu` and :math:`\mu_{2}` are assumed known as the mean and variance of the **untransformed** distribution (when :math:`L=0` and :math:`S=1` ) and
+Method of Moments
+-----------------
+
+Another approach to finding parameters of a distribution that explain a
+collection of data is to match the expected moments of the distribution
+with the computed moments and the relevant equations solved for the
+parameters of the distribution. In particular, for a distribution with
+no shape parameters, the following equations can be solved for location
+and scale
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \hat{\mu} & = & \frac{1}{N}\sum_{i=1}^{N}x_{i}=\bar{\mathbf{x}}\\ \hat{\mu}_{2} & = & \frac{1}{N-1}\sum_{i=1}^{N}\left(x_{i}-\hat{\mu}\right)^{2}=\frac{N}{N-1}\overline{\left(\mathbf{x}-\bar{\mathbf{x}}\right)^{2}}\end{eqnarray*}
+   \begin{aligned*}
+   \mu_{Y} & =S\mu+L\\
+   \mu_{Y^{2}} & =S^{2}\mu_{2}.\end{aligned*}
 
+Estimating :math:`\mu_{Y}` as :math:`\hat{\mu}` and :math:`\mu_{Y^{2}}`
+as :math:`\hat{\mu}_{2}` gives the estimates
 
+.. math::
 
+   \begin{aligned*}
+   \hat{S} & = & \sqrt{\frac{\hat{\mu}_{2}}{\mu_{2}}}\\
+   \hat{L} & = & \hat{\mu}-\hat{S}\mu\end{aligned*}
+
+where :math:`\mu` and :math:`\mu_{2}` are assumed known as the mean and
+variance of the **untransformed** distribution (when :math:`L=0` and
+:math:`S=1`\ ) and
+
+.. math::
+
+   \begin{aligned*}
+   \hat{\mu} & = & \frac{1}{N}\sum_{i=1}^{N}x_{i}=\bar{\mathbf{x}}\\
+   \hat{\mu}_{2} & = & \frac{1}{N}\sum_{i=1}^{N}\left(x_{i}-\hat{\mu}\right)^{2}=\overline{\left(\mathbf{x}-\bar{\mathbf{x}}\right)^{2}}.\end{aligned*}
+
+In general, if the distribution has :math:`M` shape parameters, then to
+find the parameters of the distribution, we need to add :math:`M`
+additional equations. It is straightforward to add the central moment
+equations:
+
+.. math:: \mu_{Y^{n}}=S^{n}\mu_{n}\left(\boldsymbol{\theta}\right)
+
+ for :math:`n=2\ldots M+2`\ . If we can estimate the
+:math:`n^{\mbox{th}}` central moment of :math:`Y` as
+
+.. math:: \hat{\mu}_{n}=\frac{1}{N}\sum_{i=1}^{N}\left(x_{i}-\hat{\mu}\right)^{n}=\overline{\left(\mathbf{x}-\bar{\mathbf{x}}\right)^{n}},
+
+ then these data-computed statistics can be used to estimate :math:`S`
+and the parameter vector :math:`\boldsymbol{\theta}` by solving this set
+of potentially non-linear equations. Then, the location parameter can be
+found by solving the equation
+:math:`\mu_{Y}=S\mu\left(\boldsymbol{\theta}\right)+L`\ , for :math:`L`\ .
 
 Standard notation for mean
 --------------------------
 
 We will use
 
+.. math:: \overline{y\left(\mathbf{x}\right)}=\frac{1}{N}\sum_{i=1}^{N}y\left(x_{i}\right)
+
+ where :math:`N` should be clear from context as the number of samples
+:math:`x_{i}`\ .
+
+References
+----------
+
+[sec:references]
+
+-  Documentation for ranlib, rv2, cdflib
+
+-  Eric Weisstein’s world of mathematics http://mathworld.wolfram.com/,
+   http://mathworld.wolfram.com/topics/StatisticalDistributions.html
+
+-  Documentation to Regress+ by Michael McLaughlin item Engineering and
+   Statistics Handbook (NIST),
+   http://www.itl.nist.gov/div898/handbook/index.htm
+
+-  Documentation for DATAPLOT from NIST,
+   http://www.itl.nist.gov/div898/software/dataplot/distribu.htm
+
+-  Norman Johnson, Samuel Kotz, and N. Balakrishnan Continuous
+   Univariate Distributions, second edition, Volumes I and II, Wiley &
+   Sons, 1994.
+
+Alpha 
+======
+
+One shape parameters :math:`\alpha>0` (paramter :math:`\beta` in
+DATAPLOT is a scale-parameter). Standard form is :math:`x>0:`
+
 .. math::
-   :nowrap:
 
-    \[ \overline{y\left(\mathbf{x}\right)}=\frac{1}{N}\sum_{i=1}^{N}y\left(x_{i}\right)\]
+   \begin{aligned*}
+   f\left(x;\alpha\right) & = & \frac{1}{x^{2}\Phi\left(\alpha\right)\sqrt{2\pi}}\exp\left(-\frac{1}{2}\left(\alpha-\frac{1}{x}\right)^{2}\right)\\
+   F\left(x;\alpha\right) & = & \frac{\Phi\left(\alpha-\frac{1}{x}\right)}{\Phi\left(\alpha\right)}\\
+   G\left(q;\alpha\right) & = & \left[\alpha-\Phi^{-1}\left(q\Phi\left(\alpha\right)\right)\right]^{-1}\end{aligned*}
 
-where :math:`N` should be clear from context as the number of samples :math:`x_{i}`
-
-
-Alpha
-=====
-
-One shape parameters :math:`\alpha>0` (paramter :math:`\beta` in DATAPLOT is a scale-parameter). Standard form is :math:`x>0:`
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x;\alpha\right) & = & \frac{1}{x^{2}\Phi\left(\alpha\right)\sqrt{2\pi}}\exp\left(-\frac{1}{2}\left(\alpha-\frac{1}{x}\right)^{2}\right)\\ F\left(x;\alpha\right) & = & \frac{\Phi\left(\alpha-\frac{1}{x}\right)}{\Phi\left(\alpha\right)}\\ G\left(q;\alpha\right) & = & \left[\alpha-\Phi^{-1}\left(q\Phi\left(\alpha\right)\right)\right]^{-1}\end{eqnarray*}
-
-
-
-
-
-.. math::
-   :nowrap:
-
-    \[ M\left(t\right)=\frac{1}{\Phi\left(a\right)\sqrt{2\pi}}\int_{0}^{\infty}\frac{e^{xt}}{x^{2}}\exp\left(-\frac{1}{2}\left(\alpha-\frac{1}{x}\right)^{2}\right)dx\]
-
-
+.. math:: M\left(t\right)=\frac{1}{\Phi\left(a\right)\sqrt{2\pi}}\int_{0}^{\infty}\frac{e^{xt}}{x^{2}}\exp\left(-\frac{1}{2}\left(\alpha-\frac{1}{x}\right)^{2}\right)dx
 
 No moments?
 
-.. math::
-   :nowrap:
-
-    \[ l_{\mathbf{x}}\left(\alpha\right)=N\log\left[\Phi\left(\alpha\right)\sqrt{2\pi}\right]+2N\overline{\log\mathbf{x}}+\frac{N}{2}\alpha^{2}-\alpha\overline{\mathbf{x}^{-1}}+\frac{1}{2}\overline{\mathbf{x}^{-2}}\]
-
-
-
+.. math:: l_{\mathbf{x}}\left(\alpha\right)=N\log\left[\Phi\left(\alpha\right)\sqrt{2\pi}\right]+2N\overline{\log\mathbf{x}}+\frac{N}{2}\alpha^{2}-\alpha\overline{\mathbf{x}^{-1}}+\frac{1}{2}\overline{\mathbf{x}^{-2}}
 
 Anglit
 ======
 
 Defined over :math:`x\in\left[-\frac{\pi}{4},\frac{\pi}{4}\right]`
 
+.. math::
 
+   \begin{aligned*}
+   f\left(x\right) & = & \sin\left(2x+\frac{\pi}{2}\right)=\cos\left(2x\right)\\
+   F\left(x\right) & = & \sin^{2}\left(x+\frac{\pi}{4}\right)\\
+   G\left(q\right) & = & \arcsin\left(\sqrt{q}\right)-\frac{\pi}{4}\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \sin\left(2x+\frac{\pi}{2}\right)=\cos\left(2x\right)\\ F\left(x\right) & = & \sin^{2}\left(x+\frac{\pi}{4}\right)\\ G\left(q\right) & = & \arcsin\left(\sqrt{q}\right)-\frac{\pi}{4}\end{eqnarray*}
-
-
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} \mu & = & 0\\ \mu_{2} & = & \frac{\pi^{2}}{16}-\frac{1}{2}\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & -2\frac{\pi^{4}-96}{\left(\pi^{2}-8\right)^{2}}\end{eqnarray*}
-
-
+   \begin{aligned*}
+   \mu & = & 0\\
+   \mu_{2} & = & \frac{\pi^{2}}{16}-\frac{1}{2}\\
+   \gamma_{1} & = & 0\\
+   \gamma_{2} & = & -2\frac{\pi^{4}-96}{\left(\pi^{2}-8\right)^{2}}\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} h\left[X\right] & = & 1-\log2\\  & \approx & 0.30685281944005469058\end{eqnarray*}
-
-
-
-
+   \begin{aligned*}
+   h\left[X\right] & = & 1-\log2\\
+    & \approx & 0.30685281944005469058\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} M\left(t\right) & = & \int_{-\frac{\pi}{4}}^{\frac{\pi}{4}}\cos\left(2x\right)e^{xt}dx\\  & = & \frac{4\cosh\left(\frac{\pi t}{4}\right)}{t^{2}+4}\end{eqnarray*}
+   \begin{aligned*}
+   M\left(t\right) & = & \int_{-\frac{\pi}{4}}^{\frac{\pi}{4}}\cos\left(2x\right)e^{xt}dx\\
+    & = & \frac{4\cosh\left(\frac{\pi t}{4}\right)}{t^{2}+4}\end{aligned*}
 
+.. math:: l_{\mathbf{x}}\left(\cdot\right)=-N\overline{\log\left[\cos\left(2\mathbf{x}\right)\right]}
 
+Arcsine 
+========
 
-
-
-.. math::
-   :nowrap:
-
-    \[ l_{\mathbf{x}}\left(\cdot\right)=-N\overline{\log\left[\cos\left(2\mathbf{x}\right)\right]}\]
-
-
-
-
-Arcsine
-=======
-
-Defined over :math:`x\in\left(0,1\right)` . To get the JKB definition put :math:`x=\frac{u+1}{2}.` i.e. :math:`L=-1` and :math:`S=2.`
+Defined over :math:`x\in\left(0,1\right)`\ . To get the JKB definition
+put :math:`x=\frac{u+1}{2}.` i.e. :math:`L=-1` and :math:`S=2.`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{\pi\sqrt{x\left(1-x\right)}}\\ F\left(x\right) & = & \frac{2}{\pi}\arcsin\left(\sqrt{x}\right)\\ G\left(q\right) & = & \sin^{2}\left(\frac{\pi}{2}q\right)\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x\right) & = & \frac{1}{\pi\sqrt{x\left(1-x\right)}}\\
+   F\left(x\right) & = & \frac{2}{\pi}\arcsin\left(\sqrt{x}\right)\\
+   G\left(q\right) & = & \sin^{2}\left(\frac{\pi}{2}q\right)\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \[ M\left(t\right)=E^{t/2}I_{0}\left(\frac{t}{2}\right)\]
-
-
+.. math:: M\left(t\right)=E^{t/2}I_{0}\left(\frac{t}{2}\right)
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu_{n}^{\prime} & = & \frac{1}{\pi}\int_{0}^{1}dx\, x^{n-1/2}\left(1-x\right)^{-1/2}\\  & = & \frac{1}{\pi}B\left(\frac{1}{2},n+\frac{1}{2}\right)=\frac{\left(2n-1\right)!!}{2^{n}n!}\end{eqnarray*}
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} \mu & = & \frac{1}{2}\\ \mu_{2} & = & \frac{1}{8}\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & -\frac{3}{2}\end{eqnarray*}
-
-
-
-
+   \begin{aligned*}
+   \mu_{n}^{\prime} & = & \frac{1}{\pi}\int_{0}^{1}dx\, x^{n-1/2}\left(1-x\right)^{-1/2}\\
+    & = & \frac{1}{\pi}B\left(\frac{1}{2},n+\frac{1}{2}\right)=\frac{\left(2n-1\right)!!}{2^{n}n!}\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \[ h\left[X\right]\approx-0.24156447527049044468\]
+   \begin{aligned*}
+   \mu & = & \frac{1}{2}\\
+   \mu_{2} & = & \frac{1}{8}\\
+   \gamma_{1} & = & 0\\
+   \gamma_{2} & = & -\frac{3}{2}\end{aligned*}
 
+.. math:: h\left[X\right]\approx-0.24156447527049044468
 
+.. math:: l_{\mathbf{x}}\left(\cdot\right)=N\log\pi+\frac{N}{2}\overline{\log\mathbf{x}}+\frac{N}{2}\overline{\log\left(1-\mathbf{x}\right)}
 
-
-
-.. math::
-   :nowrap:
-
-    \[ l_{\mathbf{x}}\left(\cdot\right)=N\log\pi+\frac{N}{2}\overline{\log\mathbf{x}}+\frac{N}{2}\overline{\log\left(1-\mathbf{x}\right)}\]
-
-
-
-
-Beta
-====
+Beta 
+=====
 
 Two shape parameters
 
-
-
-.. math::
-   :nowrap:
-
-    \[ a,b>0\]
-
-
-
-
+.. math:: a,b>0
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;a,b\right) & = & \frac{\Gamma\left(a+b\right)}{\Gamma\left(a\right)\Gamma\left(b\right)}x^{a-1}\left(1-x\right)^{b-1}I_{\left(0,1\right)}\left(x\right)\\ F\left(x;a,b\right) & = & \int_{0}^{x}f\left(y;a,b\right)dy=I\left(x,a,b\right)\\ G\left(\alpha;a,b\right) & = & I^{-1}\left(\alpha;a,b\right)\\ M\left(t\right) & = & \frac{\Gamma\left(a\right)\Gamma\left(b\right)}{\Gamma\left(a+b\right)}\,_{1}F_{1}\left(a;a+b;t\right)\\ \mu & = & \frac{a}{a+b}\\ \mu_{2} & = & \frac{ab\left(a+b+1\right)}{\left(a+b\right)^{2}}\\ \gamma_{1} & = & 2\frac{b-a}{a+b+2}\sqrt{\frac{a+b+1}{ab}}\\ \gamma_{2} & = & \frac{6\left(a^{3}+a^{2}\left(1-2b\right)+b^{2}\left(b+1\right)-2ab\left(b+2\right)\right)}{ab\left(a+b+2\right)\left(a+b+3\right)}\\ m_{d} & = & \frac{\left(a-1\right)}{\left(a+b-2\right)}\, a+b\neq2\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;a,b\right) & = & \frac{\Gamma\left(a+b\right)}{\Gamma\left(a\right)\Gamma\left(b\right)}x^{a-1}\left(1-x\right)^{b-1}I_{\left(0,1\right)}\left(x\right)\\
+   F\left(x;a,b\right) & = & \int_{0}^{x}f\left(y;a,b\right)dy=I\left(x,a,b\right)\\
+   G\left(\alpha;a,b\right) & = & I^{-1}\left(\alpha;a,b\right)\\
+   M\left(t\right) & = & \frac{\Gamma\left(a\right)\Gamma\left(b\right)}{\Gamma\left(a+b\right)}\,_{1}F_{1}\left(a;a+b;t\right)\\
+   \mu & = & \frac{a}{a+b}\\
+   \mu_{2} & = & \frac{ab\left(a+b+1\right)}{\left(a+b\right)^{2}}\\
+   \gamma_{1} & = & 2\frac{b-a}{a+b+2}\sqrt{\frac{a+b+1}{ab}}\\
+   \gamma_{2} & = & \frac{6\left(a^{3}+a^{2}\left(1-2b\right)+b^{2}\left(b+1\right)-2ab\left(b+2\right)\right)}{ab\left(a+b+2\right)\left(a+b+3\right)}\\
+   m_{d} & = & \frac{\left(a-1\right)}{\left(a+b-2\right)}\, a+b\neq2\end{aligned*}
 
+:math:`f\left(x;a,1\right)` is also called the Power-function
+distribution.
 
+.. math:: l_{\mathbf{x}}\left(a,b\right)=-N\log\Gamma\left(a+b\right)+N\log\Gamma\left(a\right)+N\log\Gamma\left(b\right)-N\left(a-1\right)\overline{\log\mathbf{x}}-N\left(b-1\right)\overline{\log\left(1-\mathbf{x}\right)}
 
-:math:`f\left(x;a,1\right)` is also called the Power-function distribution.
-
-
-
-.. math::
-   :nowrap:
-
-    \[ l_{\mathbf{x}}\left(a,b\right)=-N\log\Gamma\left(a+b\right)+N\log\Gamma\left(a\right)+N\log\Gamma\left(b\right)-N\left(a-1\right)\overline{\log\mathbf{x}}-N\left(b-1\right)\overline{\log\left(1-\mathbf{x}\right)}\]
-
-All of the :math:`x_{i}\in\left[0,1\right]`
-
+ All of the :math:`x_{i}\in\left[0,1\right]`
 
 Beta Prime
 ==========
 
-Defined over :math:`0<x<\infty.` :math:`\alpha,\beta>0.` (Note the CDF evaluation uses Eq. 3.194.1 on pg. 313 of Gradshteyn &
-Ryzhik (sixth edition).
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x;\alpha,\beta\right) & = & \frac{\Gamma\left(\alpha+\beta\right)}{\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}x^{\alpha-1}\left(1+x\right)^{-\alpha-\beta}\\ F\left(x;\alpha,\beta\right) & = & \frac{\Gamma\left(\alpha+\beta\right)}{\alpha\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}x^{\alpha}\,_{2}F_{1}\left(\alpha+\beta,\alpha;1+\alpha;-x\right)\\ G\left(q;\alpha,\beta\right) & = & F^{-1}\left(x;\alpha,\beta\right)\end{eqnarray*}
-
-
-
-
+Defined over :math:`0<x<\infty.` :math:`\alpha,\beta>0.` (Note the CDF
+evaluation uses Eq. 3.194.1 on pg. 313 of Gradshteyn & Ryzhik (sixth
+edition).
 
 .. math::
-   :nowrap:
 
-    \[ \mu_{n}^{\prime}=\left\{ \begin{array}{ccc} \frac{\Gamma\left(n+\alpha\right)\Gamma\left(\beta-n\right)}{\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}=\frac{\left(\alpha\right)_{n}}{\left(\beta-n\right)_{n}} &  & \beta>n\\ \infty &  & \textrm{otherwise}\end{array}\right.\]
-
-Therefore,
+   \begin{aligned*}
+   f\left(x;\alpha,\beta\right) & = & \frac{\Gamma\left(\alpha+\beta\right)}{\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}x^{\alpha-1}\left(1+x\right)^{-\alpha-\beta}\\
+   F\left(x;\alpha,\beta\right) & = & \frac{\Gamma\left(\alpha+\beta\right)}{\alpha\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}x^{\alpha}\,_{2}F_{1}\left(\alpha+\beta,\alpha;1+\alpha;-x\right)\\
+   G\left(q;\alpha,\beta\right) & = & F^{-1}\left(x;\alpha,\beta\right)\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \frac{\alpha}{\beta-1}\quad\beta>1\\ \mu_{2} & = & \frac{\alpha\left(\alpha+1\right)}{\left(\beta-2\right)\left(\beta-1\right)}-\frac{\alpha^{2}}{\left(\beta-1\right)^{2}}\quad\beta>2\\ \gamma_{1} & = & \frac{\frac{\alpha\left(\alpha+1\right)\left(\alpha+2\right)}{\left(\beta-3\right)\left(\beta-2\right)\left(\beta-1\right)}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\quad\beta>3\\ \gamma_{2} & = & \frac{\mu_{4}}{\mu_{2}^{2}}-3\\ \mu_{4} & = & \frac{\alpha\left(\alpha+1\right)\left(\alpha+2\right)\left(\alpha+3\right)}{\left(\beta-4\right)\left(\beta-3\right)\left(\beta-2\right)\left(\beta-1\right)}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}\quad\beta>4\end{eqnarray*}
+   \mu_{n}^{\prime}=\left\{ \begin{array}{ccc}
+   \frac{\Gamma\left(n+\alpha\right)\Gamma\left(\beta-n\right)}{\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}=\frac{\left(\alpha\right)_{n}}{\left(\beta-n\right)_{n}} &  & \beta>n\\
+   \infty &  & \textrm{otherwise}
+   \end{array}\right.
 
+ Therefore,
 
+.. math::
 
+   \begin{aligned*}
+   \mu & = & \frac{\alpha}{\beta-1}\quad\beta>1\\
+   \mu_{2} & = & \frac{\alpha\left(\alpha+1\right)}{\left(\beta-2\right)\left(\beta-1\right)}-\frac{\alpha^{2}}{\left(\beta-1\right)^{2}}\quad\beta>2\\
+   \gamma_{1} & = & \frac{\frac{\alpha\left(\alpha+1\right)\left(\alpha+2\right)}{\left(\beta-3\right)\left(\beta-2\right)\left(\beta-1\right)}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\quad\beta>3\\
+   \gamma_{2} & = & \frac{\mu_{4}}{\mu_{2}^{2}}-3\\
+   \mu_{4} & = & \frac{\alpha\left(\alpha+1\right)\left(\alpha+2\right)\left(\alpha+3\right)}{\left(\beta-4\right)\left(\beta-3\right)\left(\beta-2\right)\left(\beta-1\right)}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}\quad\beta>4\end{aligned*}
 
 Bradford
 ========
 
+.. math::
 
+   \begin{aligned*}
+   c & > & 0\\
+   k & = & \log\left(1+c\right)\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} c & > & 0\\ k & = & \log\left(1+c\right)\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;c\right) & = & \frac{c}{k\left(1+cx\right)}I_{\left(0,1\right)}\left(x\right)\\
+   F\left(x;c\right) & = & \frac{\log\left(1+cx\right)}{k}\\
+   G\left(\alpha\; c\right) & = & \frac{\left(1+c\right)^{\alpha}-1}{c}\\
+   M\left(t\right) & = & \frac{1}{k}e^{-t/c}\left[\textrm{Ei}\left(t+\frac{t}{c}\right)-\textrm{Ei}\left(\frac{t}{c}\right)\right]\\
+   \mu & = & \frac{c-k}{ck}\\
+   \mu_{2} & = & \frac{\left(c+2\right)k-2c}{2ck^{2}}\\
+   \gamma_{1} & = & \frac{\sqrt{2}\left(12c^{2}-9kc\left(c+2\right)+2k^{2}\left(c\left(c+3\right)+3\right)\right)}{\sqrt{c\left(c\left(k-2\right)+2k\right)}\left(3c\left(k-2\right)+6k\right)}\\
+   \gamma_{2} & = & \frac{c^{3}\left(k-3\right)\left(k\left(3k-16\right)+24\right)+12kc^{2}\left(k-4\right)\left(k-3\right)+6ck^{2}\left(3k-14\right)+12k^{3}}{3c\left(c\left(k-2\right)+2k\right)^{2}}\\
+   m_{d} & = & 0\\
+   m_{n} & = & \sqrt{1+c}-1\end{aligned*}
 
+where :math:`\textrm{Ei}\left(\textrm{z}\right)` is the exponential
+integral function. Also
 
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x;c\right) & = & \frac{c}{k\left(1+cx\right)}I_{\left(0,1\right)}\left(x\right)\\ F\left(x;c\right) & = & \frac{\log\left(1+cx\right)}{k}\\ G\left(\alpha\; c\right) & = & \frac{\left(1+c\right)^{\alpha}-1}{c}\\ M\left(t\right) & = & \frac{1}{k}e^{-t/c}\left[\textrm{Ei}\left(t+\frac{t}{c}\right)-\textrm{Ei}\left(\frac{t}{c}\right)\right]\\ \mu & = & \frac{c-k}{ck}\\ \mu_{2} & = & \frac{\left(c+2\right)k-2c}{2ck^{2}}\\ \gamma_{1} & = & \frac{\sqrt{2}\left(12c^{2}-9kc\left(c+2\right)+2k^{2}\left(c\left(c+3\right)+3\right)\right)}{\sqrt{c\left(c\left(k-2\right)+2k\right)}\left(3c\left(k-2\right)+6k\right)}\\ \gamma_{2} & = & \frac{c^{3}\left(k-3\right)\left(k\left(3k-16\right)+24\right)+12kc^{2}\left(k-4\right)\left(k-3\right)+6ck^{2}\left(3k-14\right)+12k^{3}}{3c\left(c\left(k-2\right)+2k\right)^{2}}\\ m_{d} & = & 0\\ m_{n} & = & \sqrt{1+c}-1\end{eqnarray*}
-
-where :math:`\textrm{Ei}\left(\textrm{z}\right)` is the exponential integral function. Also
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]=\frac{1}{2}\log\left(1+c\right)-\log\left(\frac{c}{\log\left(1+c\right)}\right)\]
-
-
-
+.. math:: h\left[X\right]=\frac{1}{2}\log\left(1+c\right)-\log\left(\frac{c}{\log\left(1+c\right)}\right)
 
 Burr
 ====
 
+.. math::
 
+   \begin{aligned*}
+   c & > & 0\\
+   d & > & 0\\
+   k & = & \Gamma\left(d\right)\Gamma\left(1-\frac{2}{c}\right)\Gamma\left(\frac{2}{c}+d\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+d\right)\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} c & > & 0\\ d & > & 0\\ k & = & \Gamma\left(d\right)\Gamma\left(1-\frac{2}{c}\right)\Gamma\left(\frac{2}{c}+d\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+d\right)\end{eqnarray*}
-
-
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x;c,d\right) & = & \frac{cd}{x^{c+1}\left(1+x^{-c}\right)^{d+1}}I_{\left(0,\infty\right)}\left(x\right)\\ F\left(x;c,d\right) & = & \left(1+x^{-c}\right)^{-d}\\ G\left(\alpha;c,d\right) & = & \left(\alpha^{-1/d}-1\right)^{-1/c}\\ \mu & = & \frac{\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+d\right)}{\Gamma\left(d\right)}\\ \mu_{2} & = & \frac{k}{\Gamma^{2}\left(d\right)}\\ \gamma_{1} & = & \frac{1}{\sqrt{k^{3}}}\left[2\Gamma^{3}\left(1-\frac{1}{c}\right)\Gamma^{3}\left(\frac{1}{c}+d\right)+\Gamma^{2}\left(d\right)\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(\frac{3}{c}+d\right)\right.\\  &  & \left.-3\Gamma\left(d\right)\Gamma\left(1-\frac{2}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+d\right)\Gamma\left(\frac{2}{c}+d\right)\right]\\ \gamma_{2} & = & -3+\frac{1}{k^{2}}\left[6\Gamma\left(d\right)\Gamma\left(1-\frac{2}{c}\right)\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+d\right)\Gamma\left(\frac{2}{c}+d\right)\right.\\  &  & -3\Gamma^{4}\left(1-\frac{1}{c}\right)\Gamma^{4}\left(\frac{1}{c}+d\right)+\Gamma^{3}\left(d\right)\Gamma\left(1-\frac{4}{c}\right)\Gamma\left(\frac{4}{c}+d\right)\\  &  & \left.-4\Gamma^{2}\left(d\right)\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+d\right)\Gamma\left(\frac{3}{c}+d\right)\right]\\ m_{d} & = & \left(\frac{cd-1}{c+1}\right)^{1/c}\,\textrm{if }cd>1\,\textrm{otherwise }0\\ m_{n} & = & \left(2^{1/d}-1\right)^{-1/c}\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   f\left(x;c,d\right) & = & \frac{cd}{x^{c+1}\left(1+x^{-c}\right)^{d+1}}I_{\left(0,\infty\right)}\left(x\right)\\
+   F\left(x;c,d\right) & = & \left(1+x^{-c}\right)^{-d}\\
+   G\left(\alpha;c,d\right) & = & \left(\alpha^{-1/d}-1\right)^{-1/c}\\
+   \mu & = & \frac{\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+d\right)}{\Gamma\left(d\right)}\\
+   \mu_{2} & = & \frac{k}{\Gamma^{2}\left(d\right)}\\
+   \gamma_{1} & = & \frac{1}{\sqrt{k^{3}}}\left[2\Gamma^{3}\left(1-\frac{1}{c}\right)\Gamma^{3}\left(\frac{1}{c}+d\right)+\Gamma^{2}\left(d\right)\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(\frac{3}{c}+d\right)\right.\\
+    &  & \left.-3\Gamma\left(d\right)\Gamma\left(1-\frac{2}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+d\right)\Gamma\left(\frac{2}{c}+d\right)\right]\\
+   \gamma_{2} & = & -3+\frac{1}{k^{2}}\left[6\Gamma\left(d\right)\Gamma\left(1-\frac{2}{c}\right)\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+d\right)\Gamma\left(\frac{2}{c}+d\right)\right.\\
+    &  & -3\Gamma^{4}\left(1-\frac{1}{c}\right)\Gamma^{4}\left(\frac{1}{c}+d\right)+\Gamma^{3}\left(d\right)\Gamma\left(1-\frac{4}{c}\right)\Gamma\left(\frac{4}{c}+d\right)\\
+    &  & \left.-4\Gamma^{2}\left(d\right)\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+d\right)\Gamma\left(\frac{3}{c}+d\right)\right]\\
+   m_{d} & = & \left(\frac{cd-1}{c+1}\right)^{1/c}\,\textrm{if }cd>1\,\textrm{otherwise }0\\
+   m_{n} & = & \left(2^{1/d}-1\right)^{-1/c}\end{aligned*}
 
 Cauchy
 ======
 
-
-
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{\pi\left(1+x^{2}\right)}\\ F\left(x\right) & = & \frac{1}{2}+\frac{1}{\pi}\tan^{-1}x\\ G\left(\alpha\right) & = & \tan\left(\pi\alpha-\frac{\pi}{2}\right)\\ m_{d} & = & 0\\ m_{n} & = & 0\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x\right) & = & \frac{1}{\pi\left(1+x^{2}\right)}\\
+   F\left(x\right) & = & \frac{1}{2}+\frac{1}{\pi}\tan^{-1}x\\
+   G\left(\alpha\right) & = & \tan\left(\pi\alpha-\frac{\pi}{2}\right)\\
+   m_{d} & = & 0\\
+   m_{n} & = & 0\end{aligned*}
 
 No finite moments. This is the t distribution with one degree of
 freedom.
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} h\left[X\right] & = & \log\left(4\pi\right)\\  & \approx & 2.5310242469692907930.\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   h\left[X\right] & = & \log\left(4\pi\right)\\
+    & \approx & 2.5310242469692907930.\end{aligned*}
 
 Chi
 ===
 
-Generated by taking the (positive) square-root of chi-squared
-variates.
-
-
+Generated by taking the (positive) square-root of chi-squared variates.
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;\nu\right) & = & \frac{x^{\nu-1}e^{-x^{2}/2}}{2^{\nu/2-1}\Gamma\left(\frac{\nu}{2}\right)}I_{\left(0,\infty\right)}\left(x\right)\\ F\left(x;\nu\right) & = & \Gamma\left(\frac{\nu}{2},\frac{x^{2}}{2}\right)\\ G\left(\alpha;\nu\right) & = & \sqrt{2\Gamma^{-1}\left(\frac{\nu}{2},\alpha\right)}\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;\nu\right) & = & \frac{x^{\nu-1}e^{-x^{2}/2}}{2^{\nu/2-1}\Gamma\left(\frac{\nu}{2}\right)}I_{\left(0,\infty\right)}\left(x\right)\\
+   F\left(x;\nu\right) & = & \Gamma\left(\frac{\nu}{2},\frac{x^{2}}{2}\right)\\
+   G\left(\alpha;\nu\right) & = & \sqrt{2\Gamma^{-1}\left(\frac{\nu}{2},\alpha\right)}\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \[ M\left(t\right)=\Gamma\left(\frac{v}{2}\right)\,_{1}F_{1}\left(\frac{v}{2};\frac{1}{2};\frac{t^{2}}{2}\right)+\frac{t}{\sqrt{2}}\Gamma\left(\frac{1+\nu}{2}\right)\,_{1}F_{1}\left(\frac{1+\nu}{2};\frac{3}{2};\frac{t^{2}}{2}\right)\]
-
-
-
-
+.. math:: M\left(t\right)=\Gamma\left(\frac{v}{2}\right)\,_{1}F_{1}\left(\frac{v}{2};\frac{1}{2};\frac{t^{2}}{2}\right)+\frac{t}{\sqrt{2}}\Gamma\left(\frac{1+\nu}{2}\right)\,_{1}F_{1}\left(\frac{1+\nu}{2};\frac{3}{2};\frac{t^{2}}{2}\right)
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \frac{\sqrt{2}\Gamma\left(\frac{\nu+1}{2}\right)}{\Gamma\left(\frac{\nu}{2}\right)}\\ \mu_{2} & = & \nu-\mu^{2}\\ \gamma_{1} & = & \frac{2\mu^{3}+\mu\left(1-2\nu\right)}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{2\nu\left(1-\nu\right)-6\mu^{4}+4\mu^{2}\left(2\nu-1\right)}{\mu_{2}^{2}}\\ m_{d} & = & \sqrt{\nu-1}\quad\nu\geq1\\ m_{n} & = & \sqrt{2\Gamma^{-1}\left(\frac{\nu}{2},\frac{1}{2}\right)}\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   \mu & = & \frac{\sqrt{2}\Gamma\left(\frac{\nu+1}{2}\right)}{\Gamma\left(\frac{\nu}{2}\right)}\\
+   \mu_{2} & = & \nu-\mu^{2}\\
+   \gamma_{1} & = & \frac{2\mu^{3}+\mu\left(1-2\nu\right)}{\mu_{2}^{3/2}}\\
+   \gamma_{2} & = & \frac{2\nu\left(1-\nu\right)-6\mu^{4}+4\mu^{2}\left(2\nu-1\right)}{\mu_{2}^{2}}\\
+   m_{d} & = & \sqrt{\nu-1}\quad\nu\geq1\\
+   m_{n} & = & \sqrt{2\Gamma^{-1}\left(\frac{\nu}{2},\frac{1}{2}\right)}\end{aligned*}
 
 Chi-squared
 ===========
 
-This is the gamma distribution with :math:`L=0.0` and :math:`S=2.0` and :math:`\alpha=\nu/2` where :math:`\nu` is called the degrees of freedom. If :math:`Z_{1}\ldots Z_{\nu}` are all standard normal distributions, then :math:`W=\sum_{k}Z_{k}^{2}` has (standard) chi-square distribution with :math:`\nu` degrees of freedom.
+This is the gamma distribution with :math:`L=0.0` and :math:`S=2.0` and
+:math:`\alpha=\nu/2` where :math:`\nu` is called the degrees of freedom.
+If :math:`Z_{1}\ldots Z_{\nu}` are all standard normal distributions,
+then :math:`W=\sum_{k}Z_{k}^{2}` has (standard) chi-square distribution
+with :math:`\nu` degrees of freedom.
 
 The standard form (most often used in standard form only) is :math:`x>0`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;\alpha\right) & = & \frac{1}{2\Gamma\left(\frac{\nu}{2}\right)}\left(\frac{x}{2}\right)^{\nu/2-1}e^{-x/2}\\ F\left(x;\alpha\right) & = & \Gamma\left(\frac{\nu}{2},\frac{x}{2}\right)\\ G\left(q;\alpha\right) & = & 2\Gamma^{-1}\left(\frac{\nu}{2},q\right)\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;\alpha\right) & = & \frac{1}{2\Gamma\left(\frac{\nu}{2}\right)}\left(\frac{x}{2}\right)^{\nu/2-1}e^{-x/2}\\
+   F\left(x;\alpha\right) & = & \Gamma\left(\frac{\nu}{2},\frac{x}{2}\right)\\
+   G\left(q;\alpha\right) & = & 2\Gamma^{-1}\left(\frac{\nu}{2},q\right)\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \[ M\left(t\right)=\frac{\Gamma\left(\frac{\nu}{2}\right)}{\left(\frac{1}{2}-t\right)^{\nu/2}}\]
-
-
+.. math:: M\left(t\right)=\frac{\Gamma\left(\frac{\nu}{2}\right)}{\left(\frac{1}{2}-t\right)^{\nu/2}}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \nu\\ \mu_{2} & = & 2\nu\\ \gamma_{1} & = & \frac{2\sqrt{2}}{\sqrt{\nu}}\\ \gamma_{2} & = & \frac{12}{\nu}\\ m_{d} & = & \frac{\nu}{2}-1\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   \mu & = & \nu\\
+   \mu_{2} & = & 2\nu\\
+   \gamma_{1} & = & \frac{2\sqrt{2}}{\sqrt{\nu}}\\
+   \gamma_{2} & = & \frac{12}{\nu}\\
+   m_{d} & = & \frac{\nu}{2}-1\end{aligned*}
 
 Cosine
 ======
 
 Approximation to the normal distribution.
 
+.. math::
 
+   \begin{aligned*}
+   f\left(x\right) & = & \frac{1}{2\pi}\left[1+\cos x\right]I_{\left[-\pi,\pi\right]}\left(x\right)\\
+   F\left(x\right) & = & \frac{1}{2\pi}\left[\pi+x+\sin x\right]I_{\left[-\pi,\pi\right]}\left(x\right)+I_{\left(\pi,\infty\right)}\left(x\right)\\
+   G\left(\alpha\right) & = & F^{-1}\left(\alpha\right)\\
+   M\left(t\right) & = & \frac{\sinh\left(\pi t\right)}{\pi t\left(1+t^{2}\right)}\\
+   \mu=m_{d}=m_{n} & = & 0\\
+   \mu_{2} & = & \frac{\pi^{2}}{3}-2\\
+   \gamma_{1} & = & 0\\
+   \gamma_{2} & = & \frac{-6\left(\pi^{4}-90\right)}{5\left(\pi^{2}-6\right)^{2}}\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{2\pi}\left[1+\cos x\right]I_{\left[-\pi,\pi\right]}\left(x\right)\\ F\left(x\right) & = & \frac{1}{2\pi}\left[\pi+x+\sin x\right]I_{\left[-\pi,\pi\right]}\left(x\right)+I_{\left(\pi,\infty\right)}\left(x\right)\\ G\left(\alpha\right) & = & F^{-1}\left(\alpha\right)\\ M\left(t\right) & = & \frac{\sinh\left(\pi t\right)}{\pi t\left(1+t^{2}\right)}\\ \mu=m_{d}=m_{n} & = & 0\\ \mu_{2} & = & \frac{\pi^{2}}{3}-2\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & \frac{-6\left(\pi^{4}-90\right)}{5\left(\pi^{2}-6\right)^{2}}\end{eqnarray*}
-
-
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} h\left[X\right] & = & \log\left(4\pi\right)-1\\  & \approx & 1.5310242469692907930.\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   h\left[X\right] & = & \log\left(4\pi\right)-1\\
+    & \approx & 1.5310242469692907930.\end{aligned*}
 
 Double Gamma
 ============
 
-The double gamma is the signed version of the Gamma distribution. For :math:`\alpha>0:`
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x;\alpha\right) & = & \frac{1}{2\Gamma\left(\alpha\right)}\left|x\right|^{\alpha-1}e^{-\left|x\right|}\\ F\left(x;\alpha\right) & = & \left\{ \begin{array}{ccc} \frac{1}{2}-\frac{1}{2}\Gamma\left(\alpha,\left|x\right|\right) &  & x\leq0\\ \frac{1}{2}+\frac{1}{2}\Gamma\left(\alpha,\left|x\right|\right) &  & x>0\end{array}\right.\\ G\left(q;\alpha\right) & = & \left\{ \begin{array}{ccc} -\Gamma^{-1}\left(\alpha,\left|2q-1\right|\right) &  & q\leq\frac{1}{2}\\ \Gamma^{-1}\left(\alpha,\left|2q-1\right|\right) &  & q>\frac{1}{2}\end{array}\right.\end{eqnarray*}
-
-
-
-
+The double gamma is the signed version of the Gamma distribution. For
+:math:`\alpha>0:`
 
 .. math::
-   :nowrap:
 
-    \[ M\left(t\right)=\frac{1}{2\left(1-t\right)^{a}}+\frac{1}{2\left(1+t\right)^{a}}\]
+   \begin{aligned*}
+   f\left(x;\alpha\right) & = & \frac{1}{2\Gamma\left(\alpha\right)}\left|x\right|^{\alpha-1}e^{-\left|x\right|}\\
+   F\left(x;\alpha\right) & = & \left\{ \begin{array}{ccc}
+   \frac{1}{2}-\frac{1}{2}\Gamma\left(\alpha,\left|x\right|\right) &  & x\leq0\\
+   \frac{1}{2}+\frac{1}{2}\Gamma\left(\alpha,\left|x\right|\right) &  & x>0
+   \end{array}\right.\\
+   G\left(q;\alpha\right) & = & \left\{ \begin{array}{ccc}
+   -\Gamma^{-1}\left(\alpha,\left|2q-1\right|\right) &  & q\leq\frac{1}{2}\\
+   \Gamma^{-1}\left(\alpha,\left|2q-1\right|\right) &  & q>\frac{1}{2}
+   \end{array}\right.\end{aligned*}
 
-
-
-
+.. math:: M\left(t\right)=\frac{1}{2\left(1-t\right)^{a}}+\frac{1}{2\left(1+t\right)^{a}}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu=m_{n} & = & 0\\ \mu_{2} & = & \alpha\left(\alpha+1\right)\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & \frac{\left(\alpha+2\right)\left(\alpha+3\right)}{\alpha\left(\alpha+1\right)}-3\\ m_{d} & = & \textrm{NA}\end{eqnarray*}
+   \begin{aligned*}
+   \mu=m_{n} & = & 0\\
+   \mu_{2} & = & \alpha\left(\alpha+1\right)\\
+   \gamma_{1} & = & 0\\
+   \gamma_{2} & = & \frac{\left(\alpha+2\right)\left(\alpha+3\right)}{\alpha\left(\alpha+1\right)}-3\\
+   m_{d} & = & \textrm{NA}\end{aligned*}
 
+Doubly Non-central F\*
+======================
 
-
-
-Doubly Non-central F*
-=====================
-
-
-Doubly Non-central t*
-=====================
-
+Doubly Non-central t\*
+======================
 
 Double Weibull
 ==============
 
 This is a signed form of the Weibull distribution.
 
+.. math::
 
+   \begin{aligned*}
+   f\left(x;c\right) & = & \frac{c}{2}\left|x\right|^{c-1}\exp\left(-\left|x\right|^{c}\right)\\
+   F\left(x;c\right) & = & \left\{ \begin{array}{ccc}
+   \frac{1}{2}\exp\left(-\left|x\right|^{c}\right) &  & x\leq0\\
+   1-\frac{1}{2}\exp\left(-\left|x\right|^{c}\right) &  & x>0
+   \end{array}\right.\\
+   G\left(q;c\right) & = & \left\{ \begin{array}{ccc}
+   -\log^{1/c}\left(\frac{1}{2q}\right) &  & q\leq\frac{1}{2}\\
+   \log^{1/c}\left(\frac{1}{2q-1}\right) &  & q>\frac{1}{2}
+   \end{array}\right.\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & \frac{c}{2}\left|x\right|^{c-1}\exp\left(-\left|x\right|^{c}\right)\\ F\left(x;c\right) & = & \left\{ \begin{array}{ccc} \frac{1}{2}\exp\left(-\left|x\right|^{c}\right) &  & x\leq0\\ 1-\frac{1}{2}\exp\left(-\left|x\right|^{c}\right) &  & x>0\end{array}\right.\\ G\left(q;c\right) & = & \left\{ \begin{array}{ccc} -\log^{1/c}\left(\frac{1}{2q}\right) &  & q\leq\frac{1}{2}\\ \log^{1/c}\left(\frac{1}{2q-1}\right) &  & q>\frac{1}{2}\end{array}\right.\end{eqnarray*}
-
-
-
-.. math::
-   :nowrap:
-
-    \[ \mu_{n}^{\prime}=\mu_{n}=\begin{cases} \Gamma\left(1+\frac{n}{c}\right) & n\textrm{ even}\\ 0 & n\textrm{ odd}\end{cases}\]
-
-
+   \mu_{n}^{\prime}=\mu_{n}=\begin{cases}
+   \Gamma\left(1+\frac{n}{c}\right) & n\textrm{ even}\\
+   0 & n\textrm{ odd}
+   \end{cases}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} m_{d}=\mu & = & 0\\ \mu_{2} & = & \Gamma\left(\frac{c+2}{c}\right)\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & \frac{\Gamma\left(1+\frac{4}{c}\right)}{\Gamma^{2}\left(1+\frac{2}{c}\right)}\\ m_{d} & = & \textrm{NA bimodal}\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   m_{d}=\mu & = & 0\\
+   \mu_{2} & = & \Gamma\left(\frac{c+2}{c}\right)\\
+   \gamma_{1} & = & 0\\
+   \gamma_{2} & = & \frac{\Gamma\left(1+\frac{4}{c}\right)}{\Gamma^{2}\left(1+\frac{2}{c}\right)}\\
+   m_{d} & = & \textrm{NA bimodal}\end{aligned*}
 
 Erlang
 ======
 
-This is just the Gamma distribution with shape parameter :math:`\alpha=n` an integer.
-
+This is just the Gamma distribution with shape parameter
+:math:`\alpha=n` an integer.
 
 Exponential
 ===========
 
 This is a special case of the Gamma (and Erlang) distributions with
-shape parameter :math:`\left(\alpha=1\right)` and the same location and scale parameters. The standard form is
-therefore ( :math:`x\geq0` )
+shape parameter :math:`\left(\alpha=1\right)` and the same location and
+scale parameters. The standard form is therefore (:math:`x\geq0`\ )
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & e^{-x}\\ F\left(x\right) & = & \Gamma\left(1,x\right)=1-e^{-x}\\ G\left(q\right) & = & -\log\left(1-q\right)\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x\right) & = & e^{-x}\\
+   F\left(x\right) & = & \Gamma\left(1,x\right)=1-e^{-x}\\
+   G\left(q\right) & = & -\log\left(1-q\right)\end{aligned*}
 
+.. math:: \mu_{n}^{\prime}=n!
 
-
-
-
-.. math::
-   :nowrap:
-
-    \[ \mu_{n}^{\prime}=n!\]
-
-
-
-
+.. math:: M\left(t\right)=\frac{1}{1-t}
 
 .. math::
-   :nowrap:
 
-    \[ M\left(t\right)=\frac{1}{1-t}\]
+   \begin{aligned*}
+   \mu & = & 1\\
+   \mu_{2} & = & 1\\
+   \gamma_{1} & = & 2\\
+   \gamma_{2} & = & 6\\
+   m_{d} & = & 0\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} \mu & = & 1\\ \mu_{2} & = & 1\\ \gamma_{1} & = & 2\\ \gamma_{2} & = & 6\\ m_{d} & = & 0\end{eqnarray*}
-
-
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]=1.\]
-
-
-
+.. math:: h\left[X\right]=1.
 
 Exponentiated Weibull
 =====================
 
-Two positive shape parameters :math:`a` and :math:`c` and :math:`x\in\left(0,\infty\right)`
+Two positive shape parameters :math:`a` and :math:`c` and
+:math:`x\in\left(0,\infty\right)`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;a,c\right) & = & ac\left[1-\exp\left(-x^{c}\right)\right]^{a-1}\exp\left(-x^{c}\right)x^{c-1}\\ F\left(x;a,c\right) & = & \left[1-\exp\left(-x^{c}\right)\right]^{a}\\ G\left(q;a,c\right) & = & \left[-\log\left(1-q^{1/a}\right)\right]^{1/c}\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   f\left(x;a,c\right) & = & ac\left[1-\exp\left(-x^{c}\right)\right]^{a-1}\exp\left(-x^{c}\right)x^{c-1}\\
+   F\left(x;a,c\right) & = & \left[1-\exp\left(-x^{c}\right)\right]^{a}\\
+   G\left(q;a,c\right) & = & \left[-\log\left(1-q^{1/a}\right)\right]^{1/c}\end{aligned*}
 
 Exponential Power
 =================
 
-One positive shape parameter :math:`b` . Defined for :math:`x\geq0.`
+One positive shape parameter :math:`b`\ . Defined for :math:`x\geq0.`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;b\right) & = & ebx^{b-1}\exp\left[x^{b}-e^{x^{b}}\right]\\ F\left(x;b\right) & = & 1-\exp\left[1-e^{x^{b}}\right]\\ G\left(q;b\right) & = & \log^{1/b}\left[1-\log\left(1-q\right)\right]\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   f\left(x;b\right) & = & ebx^{b-1}\exp\left[x^{b}-e^{x^{b}}\right]\\
+   F\left(x;b\right) & = & 1-\exp\left[1-e^{x^{b}}\right]\\
+   G\left(q;b\right) & = & \log^{1/b}\left[1-\log\left(1-q\right)\right]\end{aligned*}
 
 Fatigue Life (Birnbaum-Sanders)
 ===============================
 
-This distribution's pdf is the average of the inverse-Gaussian :math:`\left(\mu=1\right)` and reciprocal inverse-Gaussian pdf :math:`\left(\mu=1\right)` . We follow the notation of JKB here with :math:`\beta=S.` for :math:`x>0`
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x;c\right) & = & \frac{x+1}{2c\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-1\right)^{2}}{2xc^{2}}\right)\\ F\left(x;c\right) & = & \Phi\left(\frac{1}{c}\left(\sqrt{x}-\frac{1}{\sqrt{x}}\right)\right)\\ G\left(q;c\right) & = & \frac{1}{4}\left[c\Phi^{-1}\left(q\right)+\sqrt{c^{2}\left(\Phi^{-1}\left(q\right)\right)^{2}+4}\right]^{2}\end{eqnarray*}
-
-
+This distribution’s pdf is the average of the inverse-Gaussian
+:math:`\left(\mu=1\right)` and reciprocal inverse-Gaussian pdf
+:math:`\left(\mu=1\right)`\ . We follow the notation of JKB here with
+:math:`\beta=S.` for :math:`x>0`
 
 .. math::
-   :nowrap:
 
-    \[ M\left(t\right)=c\sqrt{2\pi}\exp\left[\frac{1}{c^{2}}\left(1-\sqrt{1-2c^{2}t}\right)\right]\left(1+\frac{1}{\sqrt{1-2c^{2}t}}\right)\]
+   \begin{aligned*}
+   f\left(x;c\right) & = & \frac{x+1}{2c\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-1\right)^{2}}{2xc^{2}}\right)\\
+   F\left(x;c\right) & = & \Phi\left(\frac{1}{c}\left(\sqrt{x}-\frac{1}{\sqrt{x}}\right)\right)\\
+   G\left(q;c\right) & = & \frac{1}{4}\left[c\Phi^{-1}\left(q\right)+\sqrt{c^{2}\left(\Phi^{-1}\left(q\right)\right)^{2}+4}\right]^{2}\end{aligned*}
 
-
-
-
+.. math:: M\left(t\right)=c\sqrt{2\pi}\exp\left[\frac{1}{c^{2}}\left(1-\sqrt{1-2c^{2}t}\right)\right]\left(1+\frac{1}{\sqrt{1-2c^{2}t}}\right)
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \frac{c^{2}}{2}+1\\ \mu_{2} & = & c^{2}\left(\frac{5}{4}c^{2}+1\right)\\ \gamma_{1} & = & \frac{4c\sqrt{11c^{2}+6}}{\left(5c^{2}+4\right)^{3/2}}\\ \gamma_{2} & = & \frac{6c^{2}\left(93c^{2}+41\right)}{\left(5c^{2}+4\right)^{2}}\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   \mu & = & \frac{c^{2}}{2}+1\\
+   \mu_{2} & = & c^{2}\left(\frac{5}{4}c^{2}+1\right)\\
+   \gamma_{1} & = & \frac{4c\sqrt{11c^{2}+6}}{\left(5c^{2}+4\right)^{3/2}}\\
+   \gamma_{2} & = & \frac{6c^{2}\left(93c^{2}+41\right)}{\left(5c^{2}+4\right)^{2}}\end{aligned*}
 
 Fisk (Log Logistic)
 ===================
 
 Special case of the Burr distribution with :math:`d=1`
 
+.. math::
 
+   \begin{aligned*}
+   c & > & 0\\
+   k & = & \Gamma\left(1-\frac{2}{c}\right)\Gamma\left(\frac{2}{c}+1\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+1\right)\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} c & > & 0\\ k & = & \Gamma\left(1-\frac{2}{c}\right)\Gamma\left(\frac{2}{c}+1\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+1\right)\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;c,d\right) & = & \frac{cx^{c-1}}{\left(1+x^{c}\right)^{2}}I_{\left(0,\infty\right)}\left(x\right)\\
+   F\left(x;c,d\right) & = & \left(1+x^{-c}\right)^{-1}\\
+   G\left(\alpha;c,d\right) & = & \left(\alpha^{-1}-1\right)^{-1/c}\\
+   \mu & = & \Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+1\right)\\
+   \mu_{2} & = & k\\
+   \gamma_{1} & = & \frac{1}{\sqrt{k^{3}}}\left[2\Gamma^{3}\left(1-\frac{1}{c}\right)\Gamma^{3}\left(\frac{1}{c}+1\right)+\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(\frac{3}{c}+1\right)\right.\\
+    &  & \left.-3\Gamma\left(1-\frac{2}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+1\right)\Gamma\left(\frac{2}{c}+1\right)\right]\\
+   \gamma_{2} & = & -3+\frac{1}{k^{2}}\left[6\Gamma\left(1-\frac{2}{c}\right)\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+1\right)\Gamma\left(\frac{2}{c}+1\right)\right.\\
+    &  & -3\Gamma^{4}\left(1-\frac{1}{c}\right)\Gamma^{4}\left(\frac{1}{c}+1\right)+\Gamma\left(1-\frac{4}{c}\right)\Gamma\left(\frac{4}{c}+1\right)\\
+    &  & \left.-4\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+1\right)\Gamma\left(\frac{3}{c}+1\right)\right]\\
+   m_{d} & = & \left(\frac{c-1}{c+1}\right)^{1/c}\,\textrm{if }c>1\,\textrm{otherwise }0\\
+   m_{n} & = & 1\end{aligned*}
 
-
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x;c,d\right) & = & \frac{cx^{c-1}}{\left(1+x^{c}\right)^{2}}I_{\left(0,\infty\right)}\left(x\right)\\ F\left(x;c,d\right) & = & \left(1+x^{-c}\right)^{-1}\\ G\left(\alpha;c,d\right) & = & \left(\alpha^{-1}-1\right)^{-1/c}\\ \mu & = & \Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+1\right)\\ \mu_{2} & = & k\\ \gamma_{1} & = & \frac{1}{\sqrt{k^{3}}}\left[2\Gamma^{3}\left(1-\frac{1}{c}\right)\Gamma^{3}\left(\frac{1}{c}+1\right)+\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(\frac{3}{c}+1\right)\right.\\  &  & \left.-3\Gamma\left(1-\frac{2}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+1\right)\Gamma\left(\frac{2}{c}+1\right)\right]\\ \gamma_{2} & = & -3+\frac{1}{k^{2}}\left[6\Gamma\left(1-\frac{2}{c}\right)\Gamma^{2}\left(1-\frac{1}{c}\right)\Gamma^{2}\left(\frac{1}{c}+1\right)\Gamma\left(\frac{2}{c}+1\right)\right.\\  &  & -3\Gamma^{4}\left(1-\frac{1}{c}\right)\Gamma^{4}\left(\frac{1}{c}+1\right)+\Gamma\left(1-\frac{4}{c}\right)\Gamma\left(\frac{4}{c}+1\right)\\  &  & \left.-4\Gamma\left(1-\frac{3}{c}\right)\Gamma\left(1-\frac{1}{c}\right)\Gamma\left(\frac{1}{c}+1\right)\Gamma\left(\frac{3}{c}+1\right)\right]\\ m_{d} & = & \left(\frac{c-1}{c+1}\right)^{1/c}\,\textrm{if }c>1\,\textrm{otherwise }0\\ m_{n} & = & 1\end{eqnarray*}
-
-
-
-
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]=2-\log c.\]
-
-
-
+.. math:: h\left[X\right]=2-\log c.
 
 Folded Cauchy
 =============
 
-This formula can be expressed in terms of the standard formulas for
-the Cauchy distribution (call the cdf :math:`C\left(x\right)` and the pdf :math:`d\left(x\right)` ). if :math:`Y` is cauchy then :math:`\left|Y\right|` is folded cauchy. Note that :math:`x\geq0.`
+This formula can be expressed in terms of the standard formulas for the
+Cauchy distribution (call the cdf :math:`C\left(x\right)` and the pdf
+:math:`d\left(x\right)`\ ). if :math:`Y` is cauchy then
+:math:`\left|Y\right|` is folded cauchy. Note that :math:`x\geq0.`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & \frac{1}{\pi\left(1+\left(x-c\right)^{2}\right)}+\frac{1}{\pi\left(1+\left(x+c\right)^{2}\right)}\\ F\left(x;c\right) & = & \frac{1}{\pi}\tan^{-1}\left(x-c\right)+\frac{1}{\pi}\tan^{-1}\left(x+c\right)\\ G\left(q;c\right) & = & F^{-1}\left(x;c\right)\end{eqnarray*}
-
-
+   \begin{aligned*}
+   f\left(x;c\right) & = & \frac{1}{\pi\left(1+\left(x-c\right)^{2}\right)}+\frac{1}{\pi\left(1+\left(x+c\right)^{2}\right)}\\
+   F\left(x;c\right) & = & \frac{1}{\pi}\tan^{-1}\left(x-c\right)+\frac{1}{\pi}\tan^{-1}\left(x+c\right)\\
+   G\left(q;c\right) & = & F^{-1}\left(x;c\right)\end{aligned*}
 
 No moments
-
 
 Folded Normal
 =============
 
-If :math:`Z` is Normal with mean :math:`L` and :math:`\sigma=S` , then :math:`\left|Z\right|` is a folded normal with shape parameter :math:`c=\left|L\right|/S` , location parameter :math:`0` and scale parameter :math:`S` . This is a special case of the non-central chi distribution with one-
-degree of freedom and non-centrality parameter :math:`c^{2}.` Note that :math:`c\geq0` . The standard form of the folded normal is
+If :math:`Z` is Normal with mean :math:`L` and :math:`\sigma=S`\ , then
+:math:`\left|Z\right|` is a folded normal with shape parameter
+:math:`c=\left|L\right|/S`\ , location parameter :math:`0` and scale
+parameter :math:`S`\ . This is a special case of the non-central chi
+distribution with one-degree of freedom and non-centrality parameter
+:math:`c^{2}.` Note that :math:`c\geq0`\ . The standard form of the
+folded normal is
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & \sqrt{\frac{2}{\pi}}\cosh\left(cx\right)\exp\left(-\frac{x^{2}+c^{2}}{2}\right)\\ F\left(x;c\right) & = & \Phi\left(x-c\right)-\Phi\left(-x-c\right)=\Phi\left(x-c\right)+\Phi\left(x+c\right)-1\\ G\left(\alpha;c\right) & = & F^{-1}\left(x;c\right)\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;c\right) & = & \sqrt{\frac{2}{\pi}}\cosh\left(cx\right)\exp\left(-\frac{x^{2}+c^{2}}{2}\right)\\
+   F\left(x;c\right) & = & \Phi\left(x-c\right)-\Phi\left(-x-c\right)=\Phi\left(x-c\right)+\Phi\left(x+c\right)-1\\
+   G\left(\alpha;c\right) & = & F^{-1}\left(x;c\right)\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \[ M\left(t\right)=\exp\left[\frac{t}{2}\left(t-2c\right)\right]\left(1+e^{2ct}\right)\]
-
-
+.. math:: M\left(t\right)=\exp\left[\frac{t}{2}\left(t-2c\right)\right]\left(1+e^{2ct}\right)
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} k & = & \textrm{erf}\left(\frac{c}{\sqrt{2}}\right)\\ p & = & \exp\left(-\frac{c^{2}}{2}\right)\\ \mu & = & \sqrt{\frac{2}{\pi}}p+ck\\ \mu_{2} & = & c^{2}+1-\mu^{2}\\ \gamma_{1} & = & \frac{\sqrt{\frac{2}{\pi}}p^{3}\left(4-\frac{\pi}{p^{2}}\left(2c^{2}+1\right)\right)+2ck\left(6p^{2}+3cpk\sqrt{2\pi}+\pi c\left(k^{2}-1\right)\right)}{\pi\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{c^{4}+6c^{2}+3+6\left(c^{2}+1\right)\mu^{2}-3\mu^{4}-4p\mu\left(\sqrt{\frac{2}{\pi}}\left(c^{2}+2\right)+\frac{ck}{p}\left(c^{2}+3\right)\right)}{\mu_{2}^{2}}\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   k & = & \textrm{erf}\left(\frac{c}{\sqrt{2}}\right)\\
+   p & = & \exp\left(-\frac{c^{2}}{2}\right)\\
+   \mu & = & \sqrt{\frac{2}{\pi}}p+ck\\
+   \mu_{2} & = & c^{2}+1-\mu^{2}\\
+   \gamma_{1} & = & \frac{\sqrt{\frac{2}{\pi}}p^{3}\left(4-\frac{\pi}{p^{2}}\left(2c^{2}+1\right)\right)+2ck\left(6p^{2}+3cpk\sqrt{2\pi}+\pi c\left(k^{2}-1\right)\right)}{\pi\mu_{2}^{3/2}}\\
+   \gamma_{2} & = & \frac{c^{4}+6c^{2}+3+6\left(c^{2}+1\right)\mu^{2}-3\mu^{4}-4p\mu\left(\sqrt{\frac{2}{\pi}}\left(c^{2}+2\right)+\frac{ck}{p}\left(c^{2}+3\right)\right)}{\mu_{2}^{2}}\end{aligned*}
 
 Fratio (or F)
 =============
 
-Defined for :math:`x>0` . The distribution of :math:`\left(X_{1}/X_{2}\right)\left(\nu_{2}/\nu_{1}\right)` if :math:`X_{1}` is chi-squared with :math:`v_{1}` degrees of freedom and :math:`X_{2}` is chi-squared with :math:`v_{2}` degrees of freedom.
+Defined for :math:`x>0`\ . The distribution of
+:math:`\left(X_{1}/X_{2}\right)\left(\nu_{2}/\nu_{1}\right)` if
+:math:`X_{1}` is chi-squared with :math:`v_{1}` degrees of freedom and
+:math:`X_{2}` is chi-squared with :math:`v_{2}` degrees of freedom.
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;\nu_{1},\nu_{2}\right) & = & \frac{\nu_{2}^{\nu_{2}/2}\nu_{1}^{\nu_{1}/2}x^{\nu_{1}/2-1}}{\left(\nu_{2}+\nu_{1}x\right)^{\left(\nu_{1}+\nu_{2}\right)/2}B\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2}\right)}\\ F\left(x;v_{1},v_{2}\right) & = & I\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2},\frac{\nu_{2}x}{\nu_{2}+\nu_{1}x}\right)\\ G\left(q;\nu_{1},\nu_{2}\right) & = & \left[\frac{\nu_{2}}{I^{-1}\left(\nu_{1}/2,\nu_{2}/2,q\right)}-\frac{\nu_{1}}{\nu_{2}}\right]^{-1}.\end{eqnarray*}
-
-
+   \begin{aligned*}
+   f\left(x;\nu_{1},\nu_{2}\right) & = & \frac{\nu_{2}^{\nu_{2}/2}\nu_{1}^{\nu_{1}/2}x^{\nu_{1}/2-1}}{\left(\nu_{2}+\nu_{1}x\right)^{\left(\nu_{1}+\nu_{2}\right)/2}B\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2}\right)}\\
+   F\left(x;v_{1},v_{2}\right) & = & I\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2},\frac{\nu_{2}x}{\nu_{2}+\nu_{1}x}\right)\\
+   G\left(q;\nu_{1},\nu_{2}\right) & = & \left[\frac{\nu_{2}}{I^{-1}\left(\nu_{1}/2,\nu_{2}/2,q\right)}-\frac{\nu_{1}}{\nu_{2}}\right]^{-1}.\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \frac{\nu_{2}}{\nu_{2}-2}\quad\nu_{2}>2\\ \mu_{2} & = & \frac{2\nu_{2}^{2}\left(\nu_{1}+\nu_{2}-2\right)}{\nu_{1}\left(\nu_{2}-2\right)^{2}\left(\nu_{2}-4\right)}\quad v_{2}>4\\ \gamma_{1} & = & \frac{2\left(2\nu_{1}+\nu_{2}-2\right)}{\nu_{2}-6}\sqrt{\frac{2\left(\nu_{2}-4\right)}{\nu_{1}\left(\nu_{1}+\nu_{2}-2\right)}}\quad\nu_{2}>6\\ \gamma_{2} & = & \frac{3\left[8+\left(\nu_{2}-6\right)\gamma_{1}^{2}\right]}{2\nu-16}\quad\nu_{2}>8\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   \mu & = & \frac{\nu_{2}}{\nu_{2}-2}\quad\nu_{2}>2\\
+   \mu_{2} & = & \frac{2\nu_{2}^{2}\left(\nu_{1}+\nu_{2}-2\right)}{\nu_{1}\left(\nu_{2}-2\right)^{2}\left(\nu_{2}-4\right)}\quad v_{2}>4\\
+   \gamma_{1} & = & \frac{2\left(2\nu_{1}+\nu_{2}-2\right)}{\nu_{2}-6}\sqrt{\frac{2\left(\nu_{2}-4\right)}{\nu_{1}\left(\nu_{1}+\nu_{2}-2\right)}}\quad\nu_{2}>6\\
+   \gamma_{2} & = & \frac{3\left[8+\left(\nu_{2}-6\right)\gamma_{1}^{2}\right]}{2\nu-16}\quad\nu_{2}>8\end{aligned*}
 
 Fréchet (ExtremeLB, Extreme Value II, Weibull minimum)
-=======================================================
+======================================================
 
-A type of extreme-value distribution with a lower bound. Defined for :math:`x>0` and :math:`c>0`
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x;c\right) & = & cx^{c-1}\exp\left(-x^{c}\right)\\ F\left(x;c\right) & = & 1-\exp\left(-x^{c}\right)\\ G\left(q;c\right) & = & \left[-\log\left(1-q\right)\right]^{1/c}\end{eqnarray*}
-
-
+A type of extreme-value distribution with a lower bound. Defined for
+:math:`x>0` and :math:`c>0`
 
 .. math::
-   :nowrap:
 
-    \[ \mu_{n}^{\prime}=\Gamma\left(1+\frac{n}{c}\right)\]
+   \begin{aligned*}
+   f\left(x;c\right) & = & cx^{c-1}\exp\left(-x^{c}\right)\\
+   F\left(x;c\right) & = & 1-\exp\left(-x^{c}\right)\\
+   G\left(q;c\right) & = & \left[-\log\left(1-q\right)\right]^{1/c}\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} \mu & = & \Gamma\left(1+\frac{1}{c}\right)\\ \mu_{2} & = & \Gamma\left(1+\frac{2}{c}\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\\ \gamma_{1} & = & \frac{\Gamma\left(1+\frac{3}{c}\right)-3\Gamma\left(1+\frac{2}{c}\right)\Gamma\left(1+\frac{1}{c}\right)+2\Gamma^{3}\left(1+\frac{1}{c}\right)}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\Gamma\left(1+\frac{4}{c}\right)-4\Gamma\left(1+\frac{1}{c}\right)\Gamma\left(1+\frac{3}{c}\right)+6\Gamma^{2}\left(1+\frac{1}{c}\right)\Gamma\left(1+\frac{2}{c}\right)-\Gamma^{4}\left(1+\frac{1}{c}\right)}{\mu_{2}^{2}}-3\\ m_{d} & = & \left(\frac{c}{1+c}\right)^{1/c}\\ m_{n} & = & G\left(\frac{1}{2};c\right)\end{eqnarray*}
-
-
+.. math:: \mu_{n}^{\prime}=\Gamma\left(1+\frac{n}{c}\right)
 
 .. math::
-   :nowrap:
 
-    \[ h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1\]
+   \begin{aligned*}
+   \mu & = & \Gamma\left(1+\frac{1}{c}\right)\\
+   \mu_{2} & = & \Gamma\left(1+\frac{2}{c}\right)-\Gamma^{2}\left(1-\frac{1}{c}\right)\\
+   \gamma_{1} & = & \frac{\Gamma\left(1+\frac{3}{c}\right)-3\Gamma\left(1+\frac{2}{c}\right)\Gamma\left(1+\frac{1}{c}\right)+2\Gamma^{3}\left(1+\frac{1}{c}\right)}{\mu_{2}^{3/2}}\\
+   \gamma_{2} & = & \frac{\Gamma\left(1+\frac{4}{c}\right)-4\Gamma\left(1+\frac{1}{c}\right)\Gamma\left(1+\frac{3}{c}\right)+6\Gamma^{2}\left(1+\frac{1}{c}\right)\Gamma\left(1+\frac{2}{c}\right)-\Gamma^{4}\left(1+\frac{1}{c}\right)}{\mu_{2}^{2}}-3\\
+   m_{d} & = & \left(\frac{c}{1+c}\right)^{1/c}\\
+   m_{n} & = & G\left(\frac{1}{2};c\right)\end{aligned*}
 
-where :math:`\gamma` is Euler's constant and equal to
+.. math:: h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1
 
-.. math::
-   :nowrap:
+ where :math:`\gamma` is Euler’s constant and equal to
 
-    \[ \gamma\approx0.57721566490153286061.\]
-
-
-
+.. math:: \gamma\approx0.57721566490153286061.
 
 Fréchet (left-skewed, Extreme Value Type III, Weibull maximum)
-===============================================================
+==============================================================
 
-Defined for :math:`x<0` and :math:`c>0` .
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x;c\right) & = & c\left(-x\right)^{c-1}\exp\left(-\left(-x\right)^{c}\right)\\ F\left(x;c\right) & = & \exp\left(-\left(-x\right)^{c}\right)\\ G\left(q;c\right) & = & -\left(-\log q\right)^{1/c}\end{eqnarray*}
-
-
-
-The mean is the negative of the right-skewed Frechet distribution
-given above, and the other statistical parameters can be computed from
-
-
+Defined for :math:`x<0` and :math:`c>0`\ .
 
 .. math::
-   :nowrap:
 
-    \[ \mu_{n}^{\prime}=\left(-1\right)^{n}\Gamma\left(1+\frac{n}{c}\right).\]
+   \begin{aligned*}
+   f\left(x;c\right) & = & c\left(-x\right)^{c-1}\exp\left(-\left(-x\right)^{c}\right)\\
+   F\left(x;c\right) & = & \exp\left(-\left(-x\right)^{c}\right)\\
+   G\left(q;c\right) & = & -\left(-\log q\right)^{1/c}\end{aligned*}
 
+The mean is the negative of the right-skewed Frechet distribution given
+above, and the other statistical parameters can be computed from
 
+.. math:: \mu_{n}^{\prime}=\left(-1\right)^{n}\Gamma\left(1+\frac{n}{c}\right).
 
+.. math:: h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1
 
+ where :math:`\gamma` is Euler’s constant and equal to
 
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1\]
-
-where :math:`\gamma` is Euler's constant and equal to
-
-.. math::
-   :nowrap:
-
-    \[ \gamma\approx0.57721566490153286061.\]
-
-
-
+.. math:: \gamma\approx0.57721566490153286061.
 
 Gamma
 =====
 
-The standard form for the gamma distribution is :math:`\left(\alpha>0\right)` valid for :math:`x\geq0` .
+The standard form for the gamma distribution is
+:math:`\left(\alpha>0\right)` valid for :math:`x\geq0`\ .
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;\alpha\right) & = & \frac{1}{\Gamma\left(\alpha\right)}x^{\alpha-1}e^{-x}\\ F\left(x;\alpha\right) & = & \Gamma\left(\alpha,x\right)\\ G\left(q;\alpha\right) & = & \Gamma^{-1}\left(\alpha,q\right)\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;\alpha\right) & = & \frac{1}{\Gamma\left(\alpha\right)}x^{\alpha-1}e^{-x}\\
+   F\left(x;\alpha\right) & = & \Gamma\left(\alpha,x\right)\\
+   G\left(q;\alpha\right) & = & \Gamma^{-1}\left(\alpha,q\right)\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \[ M\left(t\right)=\frac{1}{\left(1-t\right)^{\alpha}}\]
-
-
+.. math:: M\left(t\right)=\frac{1}{\left(1-t\right)^{\alpha}}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \alpha\\ \mu_{2} & = & \alpha\\ \gamma_{1} & = & \frac{2}{\sqrt{\alpha}}\\ \gamma_{2} & = & \frac{6}{\alpha}\\ m_{d} & = & \alpha-1\end{eqnarray*}
+   \begin{aligned*}
+   \mu & = & \alpha\\
+   \mu_{2} & = & \alpha\\
+   \gamma_{1} & = & \frac{2}{\sqrt{\alpha}}\\
+   \gamma_{2} & = & \frac{6}{\alpha}\\
+   m_{d} & = & \alpha-1\end{aligned*}
 
+.. math:: h\left[X\right]=\Psi\left(a\right)\left[1-a\right]+a+\log\Gamma\left(a\right)
 
+ where
 
-
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]=\Psi\left(a\right)\left[1-a\right]+a+\log\Gamma\left(a\right)\]
-
-where
-
-.. math::
-   :nowrap:
-
-    \[ \Psi\left(a\right)=\frac{\Gamma^{\prime}\left(a\right)}{\Gamma\left(a\right)}.\]
-
-
-
+.. math:: \Psi\left(a\right)=\frac{\Gamma^{\prime}\left(a\right)}{\Gamma\left(a\right)}.
 
 Generalized Logistic
 ====================
 
-Has been used in the analysis of extreme values. Has one shape
-parameter :math:`c>0.` And :math:`x>0`
-
-
+Has been used in the analysis of extreme values. Has one shape parameter
+:math:`c>0.` And :math:`x>0`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & \frac{c\exp\left(-x\right)}{\left[1+\exp\left(-x\right)\right]^{c+1}}\\ F\left(x;c\right) & = & \frac{1}{\left[1+\exp\left(-x\right)\right]^{c}}\\ G\left(q;c\right) & = & -\log\left(q^{-1/c}-1\right)\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;c\right) & = & \frac{c\exp\left(-x\right)}{\left[1+\exp\left(-x\right)\right]^{c+1}}\\
+   F\left(x;c\right) & = & \frac{1}{\left[1+\exp\left(-x\right)\right]^{c}}\\
+   G\left(q;c\right) & = & -\log\left(q^{-1/c}-1\right)\end{aligned*}
 
-
-
-
-
-.. math::
-   :nowrap:
-
-    \[ M\left(t\right)=\frac{c}{1-t}\,_{2}F_{1}\left(1+c,\,1-t\,;\,2-t\,;-1\right)\]
-
-
-
-
+.. math:: M\left(t\right)=\frac{c}{1-t}\,_{2}F_{1}\left(1+c,\,1-t\,;\,2-t\,;-1\right)
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \gamma+\psi_{0}\left(c\right)\\ \mu_{2} & = & \frac{\pi^{2}}{6}+\psi_{1}\left(c\right)\\ \gamma_{1} & = & \frac{\psi_{2}\left(c\right)+2\zeta\left(3\right)}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\left(\frac{\pi^{4}}{15}+\psi_{3}\left(c\right)\right)}{\mu_{2}^{2}}\\ m_{d} & = & \log c\\ m_{n} & = & -\log\left(2^{1/c}-1\right)\end{eqnarray*}
+   \begin{aligned*}
+   \mu & = & \gamma+\psi_{0}\left(c\right)\\
+   \mu_{2} & = & \frac{\pi^{2}}{6}+\psi_{1}\left(c\right)\\
+   \gamma_{1} & = & \frac{\psi_{2}\left(c\right)+2\zeta\left(3\right)}{\mu_{2}^{3/2}}\\
+   \gamma_{2} & = & \frac{\left(\frac{\pi^{4}}{15}+\psi_{3}\left(c\right)\right)}{\mu_{2}^{2}}\\
+   m_{d} & = & \log c\\
+   m_{n} & = & -\log\left(2^{1/c}-1\right)\end{aligned*}
 
 Note that the polygamma function is
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \psi_{n}\left(z\right) & = & \frac{d^{n+1}}{dz^{n+1}}\log\Gamma\left(z\right)\\  & = & \left(-1\right)^{n+1}n!\sum_{k=0}^{\infty}\frac{1}{\left(z+k\right)^{n+1}}\\  & = & \left(-1\right)^{n+1}n!\zeta\left(n+1,z\right)\end{eqnarray*}
+   \begin{aligned*}
+   \psi_{n}\left(z\right) & = & \frac{d^{n+1}}{dz^{n+1}}\log\Gamma\left(z\right)\\
+    & = & \left(-1\right)^{n+1}n!\sum_{k=0}^{\infty}\frac{1}{\left(z+k\right)^{n+1}}\\
+    & = & \left(-1\right)^{n+1}n!\zeta\left(n+1,z\right)\end{aligned*}
 
-where :math:`\zeta\left(k,x\right)` is a generalization of the Riemann zeta function called the Hurwitz
-zeta function Note that :math:`\zeta\left(n\right)\equiv\zeta\left(n,1\right)`
-
+where :math:`\zeta\left(k,x\right)` is a generalization of the Riemann
+zeta function called the Hurwitz zeta function Note that
+:math:`\zeta\left(n\right)\equiv\zeta\left(n,1\right)`
 
 Generalized Pareto
 ==================
 
-Shape parameter :math:`c\neq0` and defined for :math:`x\geq0` for all :math:`c` and :math:`x<\frac{1}{\left|c\right|}` if :math:`c` is negative.
+Shape parameter :math:`c\neq0` and defined for :math:`x\geq0` for all
+:math:`c` and :math:`x<\frac{1}{\left|c\right|}` if :math:`c` is
+negative.
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & \left(1+cx\right)^{-1-\frac{1}{c}}\\ F\left(x;c\right) & = & 1-\frac{1}{\left(1+cx\right)^{1/c}}\\ G\left(q;c\right) & = & \frac{1}{c}\left[\left(\frac{1}{1-q}\right)^{c}-1\right]\end{eqnarray*}
-
-
-
-
+   \begin{aligned*}
+   f\left(x;c\right) & = & \left(1+cx\right)^{-1-\frac{1}{c}}\\
+   F\left(x;c\right) & = & 1-\frac{1}{\left(1+cx\right)^{1/c}}\\
+   G\left(q;c\right) & = & \frac{1}{c}\left[\left(\frac{1}{1-q}\right)^{c}-1\right]\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \[ M\left(t\right)=\left\{ \begin{array}{cc} \left(-\frac{t}{c}\right)^{\frac{1}{c}}e^{-\frac{t}{c}}\left[\Gamma\left(1-\frac{1}{c}\right)+\Gamma\left(-\frac{1}{c},-\frac{t}{c}\right)-\pi\csc\left(\frac{\pi}{c}\right)/\Gamma\left(\frac{1}{c}\right)\right] & c>0\\ \left(\frac{\left|c\right|}{t}\right)^{1/\left|c\right|}\Gamma\left[\frac{1}{\left|c\right|},\frac{t}{\left|c\right|}\right] & c<0\end{array}\right.\]
-
-
-
-
+   M\left(t\right)=\left\{ \begin{array}{cc}
+   \left(-\frac{t}{c}\right)^{\frac{1}{c}}e^{-\frac{t}{c}}\left[\Gamma\left(1-\frac{1}{c}\right)+\Gamma\left(-\frac{1}{c},-\frac{t}{c}\right)-\pi\csc\left(\frac{\pi}{c}\right)/\Gamma\left(\frac{1}{c}\right)\right] & c>0\\
+   \left(\frac{\left|c\right|}{t}\right)^{1/\left|c\right|}\Gamma\left[\frac{1}{\left|c\right|},\frac{t}{\left|c\right|}\right] & c<0
+   \end{array}\right.
 
 .. math::
-   :nowrap:
 
-    \[ \mu_{n}^{\prime}=\frac{\left(-1\right)^{n}}{c^{n}}\sum_{k=0}^{n}\left(\begin{array}{c} n\\ k\end{array}\right)\frac{\left(-1\right)^{k}}{1-ck}\quad cn<1\]
-
-
+   \mu_{n}^{\prime}=\frac{\left(-1\right)^{n}}{c^{n}}\sum_{k=0}^{n}\left(\begin{array}{c}
+   n\\
+   k
+   \end{array}\right)\frac{\left(-1\right)^{k}}{1-ck}\quad cn<1
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu_{1}^{\prime} & = & \frac{1}{1-c}\quad c<1\\ \mu_{2}^{\prime} & = & \frac{2}{\left(1-2c\right)\left(1-c\right)}\quad c<\frac{1}{2}\\ \mu_{3}^{\prime} & = & \frac{6}{\left(1-c\right)\left(1-2c\right)\left(1-3c\right)}\quad c<\frac{1}{3}\\ \mu_{4}^{\prime} & = & \frac{24}{\left(1-c\right)\left(1-2c\right)\left(1-3c\right)\left(1-4c\right)}\quad c<\frac{1}{4}\end{eqnarray*}
+   \begin{aligned*}
+   \mu_{1}^{\prime} & = & \frac{1}{1-c}\quad c<1\\
+   \mu_{2}^{\prime} & = & \frac{2}{\left(1-2c\right)\left(1-c\right)}\quad c<\frac{1}{2}\\
+   \mu_{3}^{\prime} & = & \frac{6}{\left(1-c\right)\left(1-2c\right)\left(1-3c\right)}\quad c<\frac{1}{3}\\
+   \mu_{4}^{\prime} & = & \frac{24}{\left(1-c\right)\left(1-2c\right)\left(1-3c\right)\left(1-4c\right)}\quad c<\frac{1}{4}\end{aligned*}
 
 Thus,
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \mu_{1}^{\prime}\\ \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\ \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{eqnarray*}
+   \begin{aligned*}
+   \mu & = & \mu_{1}^{\prime}\\
+   \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\
+   \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
+   \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{aligned*}
 
-
-
-
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]=1+c\quad c>0\]
-
-
-
+.. math:: h\left[X\right]=1+c\quad c>0
 
 Generalized Exponential
 =======================
 
-Three positive shape parameters for :math:`x\geq0.` Note that :math:`a,b,` and :math:`c` are all :math:`>0.`
+Three positive shape parameters for :math:`x\geq0.` Note that
+:math:`a,b,` and :math:`c` are all :math:`>0.`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;a,b,c\right) & = & \left(a+b\left(1-e^{-cx}\right)\right)\exp\left[ax-bx+\frac{b}{c}\left(1-e^{-cx}\right)\right]\\ F\left(x;a,b,c\right) & = & 1-\exp\left[ax-bx+\frac{b}{c}\left(1-e^{-cx}\right)\right]\\ G\left(q;a,b,c\right) & = & F^{-1}\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   f\left(x;a,b,c\right) & = & \left(a+b\left(1-e^{-cx}\right)\right)\exp\left[ax-bx+\frac{b}{c}\left(1-e^{-cx}\right)\right]\\
+   F\left(x;a,b,c\right) & = & 1-\exp\left[ax-bx+\frac{b}{c}\left(1-e^{-cx}\right)\right]\\
+   G\left(q;a,b,c\right) & = & F^{-1}\end{aligned*}
 
 Generalized Extreme Value
 =========================
 
-Extreme value distributions with shape parameter :math:`c` .
+Extreme value distributions with shape parameter :math:`c`\ .
 
 For :math:`c>0` defined on :math:`-\infty<x\leq1/c.`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & \exp\left[-\left(1-cx\right)^{1/c}\right]\left(1-cx\right)^{1/c-1}\\ F\left(x;c\right) & = & \exp\left[-\left(1-cx\right)^{1/c}\right]\\ G\left(q;c\right) & = & \frac{1}{c}\left[1-\left(-\log q\right)^{c}\right]\end{eqnarray*}
-
-
-
-.. math::
-   :nowrap:
-
-    \[ \mu_{n}^{\prime}=\frac{1}{c^{n}}\sum_{k=0}^{n}\left(\begin{array}{c} n\\ k\end{array}\right)\left(-1\right)^{k}\Gamma\left(ck+1\right)\quad cn>-1\]
-
-So,
+   \begin{aligned*}
+   f\left(x;c\right) & = & \exp\left[-\left(1-cx\right)^{1/c}\right]\left(1-cx\right)^{1/c-1}\\
+   F\left(x;c\right) & = & \exp\left[-\left(1-cx\right)^{1/c}\right]\\
+   G\left(q;c\right) & = & \frac{1}{c}\left[1-\left(-\log q\right)^{c}\right]\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu_{1}^{\prime} & = & \frac{1}{c}\left(1-\Gamma\left(1+c\right)\right)\quad c>-1\\ \mu_{2}^{\prime} & = & \frac{1}{c^{2}}\left(1-2\Gamma\left(1+c\right)+\Gamma\left(1+2c\right)\right)\quad c>-\frac{1}{2}\\ \mu_{3}^{\prime} & = & \frac{1}{c^{3}}\left(1-3\Gamma\left(1+c\right)+3\Gamma\left(1+2c\right)-\Gamma\left(1+3c\right)\right)\quad c>-\frac{1}{3}\\ \mu_{4}^{\prime} & = & \frac{1}{c^{4}}\left(1-4\Gamma\left(1+c\right)+6\Gamma\left(1+2c\right)-4\Gamma\left(1+3c\right)+\Gamma\left(1+4c\right)\right)\quad c>-\frac{1}{4}\end{eqnarray*}
+   \mu_{n}^{\prime}=\frac{1}{c^{n}}\sum_{k=0}^{n}\left(\begin{array}{c}
+   n\\
+   k
+   \end{array}\right)\left(-1\right)^{k}\Gamma\left(ck+1\right)\quad cn>-1
 
-For :math:`c<0` defined on :math:`\frac{1}{c}\leq x<\infty.` For :math:`c=0` defined over all space
+ So,
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;0\right) & = & \exp\left[-e^{-x}\right]e^{-x}\\ F\left(x;0\right) & = & \exp\left[-e^{-x}\right]\\ G\left(q;0\right) & = & -\log\left(-\log q\right)\end{eqnarray*}
+   \begin{aligned*}
+   \mu_{1}^{\prime} & = & \frac{1}{c}\left(1-\Gamma\left(1+c\right)\right)\quad c>-1\\
+   \mu_{2}^{\prime} & = & \frac{1}{c^{2}}\left(1-2\Gamma\left(1+c\right)+\Gamma\left(1+2c\right)\right)\quad c>-\frac{1}{2}\\
+   \mu_{3}^{\prime} & = & \frac{1}{c^{3}}\left(1-3\Gamma\left(1+c\right)+3\Gamma\left(1+2c\right)-\Gamma\left(1+3c\right)\right)\quad c>-\frac{1}{3}\\
+   \mu_{4}^{\prime} & = & \frac{1}{c^{4}}\left(1-4\Gamma\left(1+c\right)+6\Gamma\left(1+2c\right)-4\Gamma\left(1+3c\right)+\Gamma\left(1+4c\right)\right)\quad c>-\frac{1}{4}\end{aligned*}
+
+For :math:`c<0` defined on :math:`\frac{1}{c}\leq x<\infty.` For
+:math:`c=0` defined over all space
+
+.. math::
+
+   \begin{aligned*}
+   f\left(x;0\right) & = & \exp\left[-e^{-x}\right]e^{-x}\\
+   F\left(x;0\right) & = & \exp\left[-e^{-x}\right]\\
+   G\left(q;0\right) & = & -\log\left(-\log q\right)\end{aligned*}
 
 This is just the (left-skewed) Gumbel distribution for c=0.
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \gamma=-\psi_{0}\left(1\right)\\ \mu_{2} & = & \frac{\pi^{2}}{6}\\ \gamma_{1} & = & \frac{12\sqrt{6}}{\pi^{3}}\zeta\left(3\right)\\ \gamma_{2} & = & \frac{12}{5}\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   \mu & = & \gamma=-\psi_{0}\left(1\right)\\
+   \mu_{2} & = & \frac{\pi^{2}}{6}\\
+   \gamma_{1} & = & \frac{12\sqrt{6}}{\pi^{3}}\zeta\left(3\right)\\
+   \gamma_{2} & = & \frac{12}{5}\end{aligned*}
 
 Generalized Gamma
 =================
 
-A general probability form that reduces to many common distributions: :math:`x>0` :math:`a>0` and :math:`c\neq0.`
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x;a,c\right) & = & \frac{\left|c\right|x^{ca-1}}{\Gamma\left(a\right)}\exp\left(-x^{c}\right)\\ F\left(x;a,c\right) & = & \begin{array}{cc} \frac{\Gamma\left(a,x^{c}\right)}{\Gamma\left(a\right)} & c>0\\ 1-\frac{\Gamma\left(a,x^{c}\right)}{\Gamma\left(a\right)} & c<0\end{array}\\ G\left(q;a,c\right) & = & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)q\right]\right\} ^{1/c}\quad c>0\\  &  & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)\left(1-q\right)\right]\right\} ^{1/c}\quad c<0\end{eqnarray*}
-
-
+A general probability form that reduces to many common distributions:
+:math:`x>0` :math:`a>0` and :math:`c\neq0.`
 
 .. math::
-   :nowrap:
 
-    \[ \mu_{n}^{\prime}=\frac{\Gamma\left(a+\frac{n}{c}\right)}{\Gamma\left(a\right)}\]
+   \begin{aligned*}
+   f\left(x;a,c\right) & = & \frac{\left|c\right|x^{ca-1}}{\Gamma\left(a\right)}\exp\left(-x^{c}\right)\\
+   F\left(x;a,c\right) & = & \begin{array}{cc}
+   \frac{\Gamma\left(a,x^{c}\right)}{\Gamma\left(a\right)} & c>0\\
+   1-\frac{\Gamma\left(a,x^{c}\right)}{\Gamma\left(a\right)} & c<0
+   \end{array}\\
+   G\left(q;a,c\right) & = & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)q\right]\right\} ^{1/c}\quad c>0\\
+    &  & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)\left(1-q\right)\right]\right\} ^{1/c}\quad c<0\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} \mu & = & \frac{\Gamma\left(a+\frac{1}{c}\right)}{\Gamma\left(a\right)}\\ \mu_{2} & = & \frac{\Gamma\left(a+\frac{2}{c}\right)}{\Gamma\left(a\right)}-\mu^{2}\\ \gamma_{1} & = & \frac{\Gamma\left(a+\frac{3}{c}\right)/\Gamma\left(a\right)-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\Gamma\left(a+\frac{4}{c}\right)/\Gamma\left(a\right)-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\\ m_{d} & = & \left(\frac{ac-1}{c}\right)^{1/c}.\end{eqnarray*}
-
-Special cases are Weibull :math:`\left(a=1\right)` , half-normal :math:`\left(a=1/2,c=2\right)` and ordinary gamma distributions :math:`c=1.` If :math:`c=-1` then it is the inverted gamma distribution.
-
-
+.. math:: \mu_{n}^{\prime}=\frac{\Gamma\left(a+\frac{n}{c}\right)}{\Gamma\left(a\right)}
 
 .. math::
-   :nowrap:
 
-    \[ h\left[X\right]=a-a\Psi\left(a\right)+\frac{1}{c}\Psi\left(a\right)+\log\Gamma\left(a\right)-\log\left|c\right|.\]
+   \begin{aligned*}
+   \mu & = & \frac{\Gamma\left(a+\frac{1}{c}\right)}{\Gamma\left(a\right)}\\
+   \mu_{2} & = & \frac{\Gamma\left(a+\frac{2}{c}\right)}{\Gamma\left(a\right)}-\mu^{2}\\
+   \gamma_{1} & = & \frac{\Gamma\left(a+\frac{3}{c}\right)/\Gamma\left(a\right)-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
+   \gamma_{2} & = & \frac{\Gamma\left(a+\frac{4}{c}\right)/\Gamma\left(a\right)-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\\
+   m_{d} & = & \left(\frac{ac-1}{c}\right)^{1/c}.\end{aligned*}
 
+Special cases are Weibull :math:`\left(a=1\right)`\ , half-normal
+:math:`\left(a=1/2,c=2\right)` and ordinary gamma distributions
+:math:`c=1.` If :math:`c=-1` then it is the inverted gamma distribution.
 
-
+.. math:: h\left[X\right]=a-a\Psi\left(a\right)+\frac{1}{c}\Psi\left(a\right)+\log\Gamma\left(a\right)-\log\left|c\right|.
 
 Generalized Half-Logistic
 =========================
@@ -1132,580 +1063,485 @@ Generalized Half-Logistic
 For :math:`x\in\left[0,1/c\right]` and :math:`c>0` we have
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & \frac{2\left(1-cx\right)^{\frac{1}{c}-1}}{\left(1+\left(1-cx\right)^{1/c}\right)^{2}}\\ F\left(x;c\right) & = & \frac{1-\left(1-cx\right)^{1/c}}{1+\left(1-cx\right)^{1/c}}\\ G\left(q;c\right) & = & \frac{1}{c}\left[1-\left(\frac{1-q}{1+q}\right)^{c}\right]\end{eqnarray*}
-
-
-
-
+   \begin{aligned*}
+   f\left(x;c\right) & = & \frac{2\left(1-cx\right)^{\frac{1}{c}-1}}{\left(1+\left(1-cx\right)^{1/c}\right)^{2}}\\
+   F\left(x;c\right) & = & \frac{1-\left(1-cx\right)^{1/c}}{1+\left(1-cx\right)^{1/c}}\\
+   G\left(q;c\right) & = & \frac{1}{c}\left[1-\left(\frac{1-q}{1+q}\right)^{c}\right]\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} h\left[X\right] & = & 2-\left(2c+1\right)\log2.\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   h\left[X\right] & = & 2-\left(2c+1\right)\log2.\end{aligned*}
 
 Gilbrat
 =======
 
-Special case of the log-normal with :math:`\sigma=1` and :math:`S=1.0` (typically also :math:`L=0.0` )
+Special case of the log-normal with :math:`\sigma=1` and :math:`S=1.0`
+(typically also :math:`L=0.0`\ )
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;\sigma\right) & = & \frac{1}{x\sqrt{2\pi}}\exp\left[-\frac{1}{2}\left(\log x\right)^{2}\right]\\ F\left(x;\sigma\right) & = & \Phi\left(\log x\right)=\frac{1}{2}\left[1+\textrm{erf}\left(\frac{\log x}{\sqrt{2}}\right)\right]\\ G\left(q;\sigma\right) & = & \exp\left\{ \Phi^{-1}\left(q\right)\right\} \end{eqnarray*}
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} \mu & = & \sqrt{e}\\ \mu_{2} & = & e\left[e-1\right]\\ \gamma_{1} & = & \sqrt{e-1}\left(2+e\right)\\ \gamma_{2} & = & e^{4}+2e^{3}+3e^{2}-6\end{eqnarray*}
-
-
-
-
+   \begin{aligned*}
+   f\left(x;\sigma\right) & = & \frac{1}{x\sqrt{2\pi}}\exp\left[-\frac{1}{2}\left(\log x\right)^{2}\right]\\
+   F\left(x;\sigma\right) & = & \Phi\left(\log x\right)=\frac{1}{2}\left[1+\textrm{erf}\left(\frac{\log x}{\sqrt{2}}\right)\right]\\
+   G\left(q;\sigma\right) & = & \exp\left\{ \Phi^{-1}\left(q\right)\right\} \end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} h\left[X\right] & = & \log\left(\sqrt{2\pi e}\right)\\  & \approx & 1.4189385332046727418\end{eqnarray*}
+   \begin{aligned*}
+   \mu & = & \sqrt{e}\\
+   \mu_{2} & = & e\left[e-1\right]\\
+   \gamma_{1} & = & \sqrt{e-1}\left(2+e\right)\\
+   \gamma_{2} & = & e^{4}+2e^{3}+3e^{2}-6\end{aligned*}
 
+.. math::
 
-
+   \begin{aligned*}
+   h\left[X\right] & = & \log\left(\sqrt{2\pi e}\right)\\
+    & \approx & 1.4189385332046727418\end{aligned*}
 
 Gompertz (Truncated Gumbel)
 ===========================
 
-For :math:`x\geq0` and :math:`c>0` . In JKB the two shape parameters :math:`b,a` are reduced to the single shape-parameter :math:`c=b/a` . As :math:`a` is just a scale parameter when :math:`a\neq0` . If :math:`a=0,` the distribution reduces to the exponential distribution scaled by :math:`1/b.` Thus, the standard form is given as
+For :math:`x\geq0` and :math:`c>0`\ . In JKB the two shape parameters
+:math:`b,a` are reduced to the single shape-parameter :math:`c=b/a`\ .
+As :math:`a` is just a scale parameter when :math:`a\neq0`\ . If
+:math:`a=0,` the distribution reduces to the exponential distribution
+scaled by :math:`1/b.` Thus, the standard form is given as
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & ce^{x}\exp\left[-c\left(e^{x}-1\right)\right]\\ F\left(x;c\right) & = & 1-\exp\left[-c\left(e^{x}-1\right)\right]\\ G\left(q;c\right) & = & \log\left[1-\frac{1}{c}\log\left(1-q\right)\right]\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;c\right) & = & ce^{x}\exp\left[-c\left(e^{x}-1\right)\right]\\
+   F\left(x;c\right) & = & 1-\exp\left[-c\left(e^{x}-1\right)\right]\\
+   G\left(q;c\right) & = & \log\left[1-\frac{1}{c}\log\left(1-q\right)\right]\end{aligned*}
 
+.. math:: h\left[X\right]=1-\log\left(c\right)-e^{c}\textrm{Ei}\left(1,c\right),
 
+ where
 
-
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]=1-\log\left(c\right)-e^{c}\textrm{Ei}\left(1,c\right),\]
-
-where
-
-.. math::
-   :nowrap:
-
-    \[ \textrm{Ei}\left(n,x\right)=\int_{1}^{\infty}t^{-n}\exp\left(-xt\right)dt\]
-
-
-
+.. math:: \textrm{Ei}\left(n,x\right)=\int_{1}^{\infty}t^{-n}\exp\left(-xt\right)dt
 
 Gumbel (LogWeibull, Fisher-Tippetts, Type I Extreme Value)
 ==========================================================
 
 One of a clase of extreme value distributions (right-skewed).
 
+.. math::
 
+   \begin{aligned*}
+   f\left(x\right) & = & \exp\left(-\left(x+e^{-x}\right)\right)\\
+   F\left(x\right) & = & \exp\left(-e^{-x}\right)\\
+   G\left(q\right) & = & -\log\left(-\log\left(q\right)\right)\end{aligned*}
+
+.. math:: M\left(t\right)=\Gamma\left(1-t\right)
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \exp\left(-\left(x+e^{-x}\right)\right)\\ F\left(x\right) & = & \exp\left(-e^{-x}\right)\\ G\left(q\right) & = & -\log\left(-\log\left(q\right)\right)\end{eqnarray*}
+   \begin{aligned*}
+   \mu & = & \gamma=-\psi_{0}\left(1\right)\\
+   \mu_{2} & = & \frac{\pi^{2}}{6}\\
+   \gamma_{1} & = & \frac{12\sqrt{6}}{\pi^{3}}\zeta\left(3\right)\\
+   \gamma_{2} & = & \frac{12}{5}\\
+   m_{d} & = & 0\\
+   m_{n} & = & -\log\left(\log2\right)\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \[ M\left(t\right)=\Gamma\left(1-t\right)\]
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} \mu & = & \gamma=-\psi_{0}\left(1\right)\\ \mu_{2} & = & \frac{\pi^{2}}{6}\\ \gamma_{1} & = & \frac{12\sqrt{6}}{\pi^{3}}\zeta\left(3\right)\\ \gamma_{2} & = & \frac{12}{5}\\ m_{d} & = & 0\\ m_{n} & = & -\log\left(\log2\right)\end{eqnarray*}
-
-
-
-
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]\approx1.0608407169541684911\]
-
-
-
+.. math:: h\left[X\right]\approx1.0608407169541684911
 
 Gumbel Left-skewed (for minimum order statistic)
 ================================================
 
-
-
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \exp\left(x-e^{x}\right)\\ F\left(x\right) & = & 1-\exp\left(-e^{x}\right)\\ G\left(q\right) & = & \log\left(-\log\left(1-q\right)\right)\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x\right) & = & \exp\left(x-e^{x}\right)\\
+   F\left(x\right) & = & 1-\exp\left(-e^{x}\right)\\
+   G\left(q\right) & = & \log\left(-\log\left(1-q\right)\right)\end{aligned*}
 
+.. math:: M\left(t\right)=\Gamma\left(1+t\right)
 
+ Note, that :math:`\mu` is negative the mean for the right-skewed
+distribution. Similar for median and mode. All other moments are the
+same.
 
-.. math::
-   :nowrap:
-
-    \[ M\left(t\right)=\Gamma\left(1+t\right)\]
-
-Note, that :math:`\mu` is negative the mean for the right-skewed distribution. Similar for
-median and mode. All other moments are the same.
-
-
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]\approx1.0608407169541684911.\]
-
-
-
+.. math:: h\left[X\right]\approx1.0608407169541684911.
 
 HalfCauchy
 ==========
 
-If :math:`Z` is Hyperbolic Secant distributed then :math:`e^{Z}` is Half-Cauchy distributed. Also, if :math:`W` is (standard) Cauchy distributed, then :math:`\left|W\right|` is Half-Cauchy distributed. Special case of the Folded Cauchy
-distribution with :math:`c=0.` The standard form is
+If :math:`Z` is Hyperbolic Secant distributed then :math:`e^{Z}` is
+Half-Cauchy distributed. Also, if :math:`W` is (standard) Cauchy
+distributed, then :math:`\left|W\right|` is Half-Cauchy distributed.
+Special case of the Folded Cauchy distribution with :math:`c=0.` The
+standard form is
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \frac{2}{\pi\left(1+x^{2}\right)}I_{[0,\infty)}\left(x\right)\\ F\left(x\right) & = & \frac{2}{\pi}\arctan\left(x\right)I_{\left[0,\infty\right]}\left(x\right)\\ G\left(q\right) & = & \tan\left(\frac{\pi}{2}q\right)\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x\right) & = & \frac{2}{\pi\left(1+x^{2}\right)}I_{[0,\infty)}\left(x\right)\\
+   F\left(x\right) & = & \frac{2}{\pi}\arctan\left(x\right)I_{\left[0,\infty\right]}\left(x\right)\\
+   G\left(q\right) & = & \tan\left(\frac{\pi}{2}q\right)\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \[ M\left(t\right)=\cos t+\frac{2}{\pi}\left[\textrm{Si}\left(t\right)\cos t-\textrm{Ci}\left(\textrm{-}t\right)\sin t\right]\]
-
-
-
-
+.. math:: M\left(t\right)=\cos t+\frac{2}{\pi}\left[\textrm{Si}\left(t\right)\cos t-\textrm{Ci}\left(\textrm{-}t\right)\sin t\right]
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} m_{d} & = & 0\\ m_{n} & = & \tan\left(\frac{\pi}{4}\right)\end{eqnarray*}
+   \begin{aligned*}
+   m_{d} & = & 0\\
+   m_{n} & = & \tan\left(\frac{\pi}{4}\right)\end{aligned*}
 
 No moments, as the integrals diverge.
 
-
-
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} h\left[X\right] & = & \log\left(2\pi\right)\\  & \approx & 1.8378770664093454836.\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   h\left[X\right] & = & \log\left(2\pi\right)\\
+    & \approx & 1.8378770664093454836.\end{aligned*}
 
 HalfNormal
 ==========
 
-This is a special case of the chi distribution with :math:`L=a` and :math:`S=b` and :math:`\nu=1.` This is also a special case of the folded normal with shape parameter :math:`c=0` and :math:`S=S.` If :math:`Z` is (standard) normally distributed then, :math:`\left|Z\right|` is half-normal. The standard form is
+This is a special case of the chi distribution with :math:`L=a` and
+:math:`S=b` and :math:`\nu=1.` This is also a special case of the folded
+normal with shape parameter :math:`c=0` and :math:`S=S.` If :math:`Z` is
+(standard) normally distributed then, :math:`\left|Z\right|` is
+half-normal. The standard form is
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \sqrt{\frac{2}{\pi}}e^{-x^{2}/2}I_{\left(0,\infty\right)}\left(x\right)\\ F\left(x\right) & = & 2\Phi\left(x\right)-1\\ G\left(q\right) & = & \Phi^{-1}\left(\frac{1+q}{2}\right)\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x\right) & = & \sqrt{\frac{2}{\pi}}e^{-x^{2}/2}I_{\left(0,\infty\right)}\left(x\right)\\
+   F\left(x\right) & = & 2\Phi\left(x\right)-1\\
+   G\left(q\right) & = & \Phi^{-1}\left(\frac{1+q}{2}\right)\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \[ M\left(t\right)=\sqrt{2\pi}e^{t^{2}/2}\Phi\left(t\right)\]
-
-
-
-
+.. math:: M\left(t\right)=\sqrt{2\pi}e^{t^{2}/2}\Phi\left(t\right)
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \sqrt{\frac{2}{\pi}}\\ \mu_{2} & = & 1-\frac{2}{\pi}\\ \gamma_{1} & = & \frac{\sqrt{2}\left(4-\pi\right)}{\left(\pi-2\right)^{3/2}}\\ \gamma_{2} & = & \frac{8\left(\pi-3\right)}{\left(\pi-2\right)^{2}}\\ m_{d} & = & 0\\ m_{n} & = & \Phi^{-1}\left(\frac{3}{4}\right)\end{eqnarray*}
-
-
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} h\left[X\right] & = & \log\left(\sqrt{\frac{\pi e}{2}}\right)\\  & \approx & 0.72579135264472743239.\end{eqnarray*}
-
-
-
-
-Half-Logistic
-=============
-
-In the limit as :math:`c\rightarrow\infty` for the generalized half-logistic we have the half-logistic defined
-over :math:`x\geq0.` Also, the distribution of :math:`\left|X\right|` where :math:`X` has logistic distribtution.
+   \begin{aligned*}
+   \mu & = & \sqrt{\frac{2}{\pi}}\\
+   \mu_{2} & = & 1-\frac{2}{\pi}\\
+   \gamma_{1} & = & \frac{\sqrt{2}\left(4-\pi\right)}{\left(\pi-2\right)^{3/2}}\\
+   \gamma_{2} & = & \frac{8\left(\pi-3\right)}{\left(\pi-2\right)^{2}}\\
+   m_{d} & = & 0\\
+   m_{n} & = & \Phi^{-1}\left(\frac{3}{4}\right)\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \frac{2e^{-x}}{\left(1+e^{-x}\right)^{2}}=\frac{1}{2}\textrm{sech}^{2}\left(\frac{x}{2}\right)\\ F\left(x\right) & = & \frac{1-e^{-x}}{1+e^{-x}}=\tanh\left(\frac{x}{2}\right)\\ G\left(q\right) & = & \log\left(\frac{1+q}{1-q}\right)=2\textrm{arctanh}\left(q\right)\end{eqnarray*}
+   \begin{aligned*}
+   h\left[X\right] & = & \log\left(\sqrt{\frac{\pi e}{2}}\right)\\
+    & \approx & 0.72579135264472743239.\end{aligned*}
 
+Half-Logistic 
+==============
 
-
-
-
-.. math::
-   :nowrap:
-
-    \[ M\left(t\right)=1-t\psi_{0}\left(\frac{1}{2}-\frac{t}{2}\right)+t\psi_{0}\left(1-\frac{t}{2}\right)\]
-
-
+In the limit as :math:`c\rightarrow\infty` for the generalized
+half-logistic we have the half-logistic defined over :math:`x\geq0.`
+Also, the distribution of :math:`\left|X\right|` where :math:`X` has
+logistic distribtution.
 
 .. math::
-   :nowrap:
 
-    \[ \mu_{n}^{\prime}=2\left(1-2^{1-n}\right)n!\zeta\left(n\right)\quad n\neq1\]
+   \begin{aligned*}
+   f\left(x\right) & = & \frac{2e^{-x}}{\left(1+e^{-x}\right)^{2}}=\frac{1}{2}\textrm{sech}^{2}\left(\frac{x}{2}\right)\\
+   F\left(x\right) & = & \frac{1-e^{-x}}{1+e^{-x}}=\tanh\left(\frac{x}{2}\right)\\
+   G\left(q\right) & = & \log\left(\frac{1+q}{1-q}\right)=2\textrm{arctanh}\left(q\right)\end{aligned*}
 
+.. math:: M\left(t\right)=1-t\psi_{0}\left(\frac{1}{2}-\frac{t}{2}\right)+t\psi_{0}\left(1-\frac{t}{2}\right)
 
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} \mu_{1}^{\prime} & = & 2\log\left(2\right)\\ \mu_{2}^{\prime} & = & 2\zeta\left(2\right)=\frac{\pi^{2}}{3}\\ \mu_{3}^{\prime} & = & 9\zeta\left(3\right)\\ \mu_{4}^{\prime} & = & 42\zeta\left(4\right)=\frac{7\pi^{4}}{15}\end{eqnarray*}
-
-
-
-
+.. math:: \mu_{n}^{\prime}=2\left(1-2^{1-n}\right)n!\zeta\left(n\right)\quad n\neq1
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} h\left[X\right] & = & 2-\log\left(2\right)\\  & \approx & 1.3068528194400546906.\end{eqnarray*}
+   \begin{aligned*}
+   \mu_{1}^{\prime} & = & 2\log\left(2\right)\\
+   \mu_{2}^{\prime} & = & 2\zeta\left(2\right)=\frac{\pi^{2}}{3}\\
+   \mu_{3}^{\prime} & = & 9\zeta\left(3\right)\\
+   \mu_{4}^{\prime} & = & 42\zeta\left(4\right)=\frac{7\pi^{4}}{15}\end{aligned*}
 
+.. math::
 
-
+   \begin{aligned*}
+   h\left[X\right] & = & 2-\log\left(2\right)\\
+    & \approx & 1.3068528194400546906.\end{aligned*}
 
 Hyperbolic Secant
 =================
 
 Related to the logistic distribution and used in lifetime analysis.
-Standard form is (defined over all :math:`x` )
+Standard form is (defined over all :math:`x`\ )
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{\pi}\textrm{sech}\left(x\right)\\ F\left(x\right) & = & \frac{2}{\pi}\arctan\left(e^{x}\right)\\ G\left(q\right) & = & \log\left(\tan\left(\frac{\pi}{2}q\right)\right)\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x\right) & = & \frac{1}{\pi}\textrm{sech}\left(x\right)\\
+   F\left(x\right) & = & \frac{2}{\pi}\arctan\left(e^{x}\right)\\
+   G\left(q\right) & = & \log\left(\tan\left(\frac{\pi}{2}q\right)\right)\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \[ M\left(t\right)=\sec\left(\frac{\pi}{2}t\right)\]
-
-
+.. math:: M\left(t\right)=\sec\left(\frac{\pi}{2}t\right)
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu_{n}^{\prime} & = & \frac{1+\left(-1\right)^{n}}{2\pi2^{2n}}n!\left[\zeta\left(n+1,\frac{1}{4}\right)-\zeta\left(n+1,\frac{3}{4}\right)\right]\\  & = & \left\{ \begin{array}{cc} 0 & n\textrm{ odd}\\ C_{n/2}\frac{\pi^{n}}{2^{n}} & n\textrm{ even}\end{array}\right.\end{eqnarray*}
+   \begin{aligned*}
+   \mu_{n}^{\prime} & = & \frac{1+\left(-1\right)^{n}}{2\pi2^{2n}}n!\left[\zeta\left(n+1,\frac{1}{4}\right)-\zeta\left(n+1,\frac{3}{4}\right)\right]\\
+    & = & \left\{ \begin{array}{cc}
+   0 & n\textrm{ odd}\\
+   C_{n/2}\frac{\pi^{n}}{2^{n}} & n\textrm{ even}
+   \end{array}\right.\end{aligned*}
 
 where :math:`C_{m}` is an integer given by
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} C_{m} & = & \frac{\left(2m\right)!\left[\zeta\left(2m+1,\frac{1}{4}\right)-\zeta\left(2m+1,\frac{3}{4}\right)\right]}{\pi^{2m+1}2^{2m}}\\  & = & 4\left(-1\right)^{m-1}\frac{16^{m}}{2m+1}B_{2m+1}\left(\frac{1}{4}\right)\end{eqnarray*}
+   \begin{aligned*}
+   C_{m} & = & \frac{\left(2m\right)!\left[\zeta\left(2m+1,\frac{1}{4}\right)-\zeta\left(2m+1,\frac{3}{4}\right)\right]}{\pi^{2m+1}2^{2m}}\\
+    & = & 4\left(-1\right)^{m-1}\frac{16^{m}}{2m+1}B_{2m+1}\left(\frac{1}{4}\right)\end{aligned*}
 
-where :math:`B_{2m+1}\left(\frac{1}{4}\right)` is the Bernoulli polynomial of order :math:`2m+1` evaluated at :math:`1/4.` Thus
-
-.. math::
-   :nowrap:
-
-    \[ \mu_{n}^{\prime}=\left\{ \begin{array}{cc} 0 & n\textrm{ odd}\\ 4\left(-1\right)^{n/2-1}\frac{\left(2\pi\right)^{n}}{n+1}B_{n+1}\left(\frac{1}{4}\right) & n\textrm{ even}\end{array}\right.\]
-
-
-
-
+where :math:`B_{2m+1}\left(\frac{1}{4}\right)` is the Bernoulli
+polynomial of order :math:`2m+1` evaluated at :math:`1/4.` Thus
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} m_{d}=m_{n}=\mu & = & 0\\ \mu_{2} & = & \frac{\pi^{2}}{4}\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & 2\end{eqnarray*}
-
-
-
-
+   \mu_{n}^{\prime}=\left\{ \begin{array}{cc}
+   0 & n\textrm{ odd}\\
+   4\left(-1\right)^{n/2-1}\frac{\left(2\pi\right)^{n}}{n+1}B_{n+1}\left(\frac{1}{4}\right) & n\textrm{ even}
+   \end{array}\right.
 
 .. math::
-   :nowrap:
 
-    \[ h\left[X\right]=\log\left(2\pi\right).\]
+   \begin{aligned*}
+   m_{d}=m_{n}=\mu & = & 0\\
+   \mu_{2} & = & \frac{\pi^{2}}{4}\\
+   \gamma_{1} & = & 0\\
+   \gamma_{2} & = & 2\end{aligned*}
 
+.. math:: h\left[X\right]=\log\left(2\pi\right).
 
+Gauss Hypergeometric 
+=====================
 
+:math:`x\in\left[0,1\right]`\ , :math:`\alpha>0,\,\beta>0`
 
-Gauss Hypergeometric
-====================
-
-:math:`x\in\left[0,1\right]` , :math:`\alpha>0,\,\beta>0`
-
-.. math::
-   :nowrap:
-
-    \[ C^{-1}=B\left(\alpha,\beta\right)\,_{2}F_{1}\left(\gamma,\alpha;\alpha+\beta;-z\right)\]
-
-
+.. math:: C^{-1}=B\left(\alpha,\beta\right)\,_{2}F_{1}\left(\gamma,\alpha;\alpha+\beta;-z\right)
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;\alpha,\beta,\gamma,z\right) & = & Cx^{\alpha-1}\frac{\left(1-x\right)^{\beta-1}}{\left(1+zx\right)^{\gamma}}\\ \mu_{n}^{\prime} & = & \frac{B\left(n+\alpha,\beta\right)}{B\left(\alpha,\beta\right)}\frac{\,_{2}F_{1}\left(\gamma,\alpha+n;\alpha+\beta+n;-z\right)}{\,_{2}F_{1}\left(\gamma,\alpha;\alpha+\beta;-z\right)}\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   f\left(x;\alpha,\beta,\gamma,z\right) & = & Cx^{\alpha-1}\frac{\left(1-x\right)^{\beta-1}}{\left(1+zx\right)^{\gamma}}\\
+   \mu_{n}^{\prime} & = & \frac{B\left(n+\alpha,\beta\right)}{B\left(\alpha,\beta\right)}\frac{\,_{2}F_{1}\left(\gamma,\alpha+n;\alpha+\beta+n;-z\right)}{\,_{2}F_{1}\left(\gamma,\alpha;\alpha+\beta;-z\right)}\end{aligned*}
 
 Inverted Gamma
 ==============
 
-Special case of the generalized Gamma distribution with :math:`c=-1` and :math:`a>0` , :math:`x>0`
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x;a\right) & = & \frac{x^{-a-1}}{\Gamma\left(a\right)}\exp\left(-\frac{1}{x}\right)\\ F\left(x;a\right) & = & \frac{\Gamma\left(a,\frac{1}{x}\right)}{\Gamma\left(a\right)}\\ G\left(q;a\right) & = & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)q\right]\right\} ^{-1}\end{eqnarray*}
-
-
+Special case of the generalized Gamma distribution with :math:`c=-1` and
+:math:`a>0`\ , :math:`x>0`
 
 .. math::
-   :nowrap:
 
-    \[ \mu_{n}^{\prime}=\frac{\Gamma\left(a-n\right)}{\Gamma\left(a\right)}\quad a>n\]
+   \begin{aligned*}
+   f\left(x;a\right) & = & \frac{x^{-a-1}}{\Gamma\left(a\right)}\exp\left(-\frac{1}{x}\right)\\
+   F\left(x;a\right) & = & \frac{\Gamma\left(a,\frac{1}{x}\right)}{\Gamma\left(a\right)}\\
+   G\left(q;a\right) & = & \left\{ \Gamma^{-1}\left[a,\Gamma\left(a\right)q\right]\right\} ^{-1}\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} \mu & = & \frac{1}{a-1}\quad a>1\\ \mu_{2} & = & \frac{1}{\left(a-2\right)\left(a-1\right)}-\mu^{2}\quad a>2\\ \gamma_{1} & = & \frac{\frac{1}{\left(a-3\right)\left(a-2\right)\left(a-1\right)}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\frac{1}{\left(a-4\right)\left(a-3\right)\left(a-2\right)\left(a-1\right)}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{eqnarray*}
-
-
+.. math:: \mu_{n}^{\prime}=\frac{\Gamma\left(a-n\right)}{\Gamma\left(a\right)}\quad a>n
 
 .. math::
-   :nowrap:
 
-    \[ m_{d}=\frac{1}{a+1}\]
+   \begin{aligned*}
+   \mu & = & \frac{1}{a-1}\quad a>1\\
+   \mu_{2} & = & \frac{1}{\left(a-2\right)\left(a-1\right)}-\mu^{2}\quad a>2\\
+   \gamma_{1} & = & \frac{\frac{1}{\left(a-3\right)\left(a-2\right)\left(a-1\right)}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
+   \gamma_{2} & = & \frac{\frac{1}{\left(a-4\right)\left(a-3\right)\left(a-2\right)\left(a-1\right)}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{aligned*}
 
+.. math:: m_{d}=\frac{1}{a+1}
 
-
-
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]=a-\left(a+1\right)\Psi\left(a\right)+\log\Gamma\left(a\right).\]
-
-
-
+.. math:: h\left[X\right]=a-\left(a+1\right)\Psi\left(a\right)+\log\Gamma\left(a\right).
 
 Inverse Normal (Inverse Gaussian)
 =================================
 
-The standard form involves the shape parameter :math:`\mu` (in most definitions, :math:`L=0.0` is used). (In terms of the regress documentation :math:`\mu=A/B` ) and :math:`B=S` and :math:`L` is not a parameter in that distribution. A standard form is :math:`x>0`
+The standard form involves the shape parameter :math:`\mu` (in most
+definitions, :math:`L=0.0` is used). (In terms of the regress
+documentation :math:`\mu=A/B`\ ) and :math:`B=S` and :math:`L` is not a
+parameter in that distribution. A standard form is :math:`x>0`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;\mu\right) & = & \frac{1}{\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-\mu\right)^{2}}{2x\mu^{2}}\right).\\ F\left(x;\mu\right) & = & \Phi\left(\frac{1}{\sqrt{x}}\frac{x-\mu}{\mu}\right)+\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{x+\mu}{\mu}\right)\\ G\left(q;\mu\right) & = & F^{-1}\left(q;\mu\right)\end{eqnarray*}
-
-
-
-
+   \begin{aligned*}
+   f\left(x;\mu\right) & = & \frac{1}{\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-\mu\right)^{2}}{2x\mu^{2}}\right).\\
+   F\left(x;\mu\right) & = & \Phi\left(\frac{1}{\sqrt{x}}\frac{x-\mu}{\mu}\right)+\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{x+\mu}{\mu}\right)\\
+   G\left(q;\mu\right) & = & F^{-1}\left(q;\mu\right)\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \mu\\ \mu_{2} & = & \mu^{3}\\ \gamma_{1} & = & 3\sqrt{\mu}\\ \gamma_{2} & = & 15\mu\\ m_{d} & = & \frac{\mu}{2}\left(\sqrt{9\mu^{2}+4}-3\mu\right)\end{eqnarray*}
+   \begin{aligned*}
+   \mu & = & \mu\\
+   \mu_{2} & = & \mu^{3}\\
+   \gamma_{1} & = & 3\sqrt{\mu}\\
+   \gamma_{2} & = & 15\mu\\
+   m_{d} & = & \frac{\mu}{2}\left(\sqrt{9\mu^{2}+4}-3\mu\right)\end{aligned*}
 
-
-
-This is related to the canonical form or JKB "two-parameter "inverse Gaussian when written in it's full form with scale parameter :math:`S` and location parameter :math:`L` by taking :math:`L=0` and :math:`S\equiv\lambda,` then :math:`\mu S` is equal to :math:`\mu_{2}` where :math:`\mu_{2}` is the parameter used by JKB. We prefer this form because of it's
-consistent use of the scale parameter. Notice that in JKB the skew :math:`\left(\sqrt{\beta_{1}}\right)` and the kurtosis ( :math:`\beta_{2}-3` ) are both functions only of :math:`\mu_{2}/\lambda=\mu S/S=\mu` as shown here, while the variance and mean of the standard form here
-are transformed appropriately.
-
+This is related to the canonical form or JKB “two-parameter” inverse
+Gaussian when written in it’s full form with scale parameter :math:`S`
+and location parameter :math:`L` by taking :math:`L=0` and
+:math:`S\equiv\lambda,` then :math:`\mu S` is equal to :math:`\mu_{2}`
+where :math:`\mu_{2}` is the parameter used by JKB. We prefer this form
+because of it’s consistent use of the scale parameter. Notice that in
+JKB the skew :math:`\left(\sqrt{\beta_{1}}\right)` and the kurtosis
+(:math:`\beta_{2}-3`\ ) are both functions only of
+:math:`\mu_{2}/\lambda=\mu S/S=\mu` as shown here, while the variance
+and mean of the standard form here are transformed appropriately.
 
 Inverted Weibull
 ================
 
-Shape parameter :math:`c>0` and :math:`x>0` . Then
+Shape parameter :math:`c>0` and :math:`x>0`\ . Then
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & cx^{-c-1}\exp\left(-x^{-c}\right)\\ F\left(x;c\right) & = & \exp\left(-x^{-c}\right)\\ G\left(q;c\right) & = & \left(-\log q\right)^{-1/c}\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;c\right) & = & cx^{-c-1}\exp\left(-x^{-c}\right)\\
+   F\left(x;c\right) & = & \exp\left(-x^{-c}\right)\\
+   G\left(q;c\right) & = & \left(-\log q\right)^{-1/c}\end{aligned*}
 
+.. math:: h\left[X\right]=1+\gamma+\frac{\gamma}{c}-\log\left(c\right)
 
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]=1+\gamma+\frac{\gamma}{c}-\log\left(c\right)\]
-
-where :math:`\gamma` is Euler's constant.
-
+ where :math:`\gamma` is Euler’s constant.
 
 Johnson SB
 ==========
 
-Defined for :math:`x\in\left(0,1\right)` with two shape parameters :math:`a` and :math:`b>0.`
+Defined for :math:`x\in\left(0,1\right)` with two shape parameters
+:math:`a` and :math:`b>0.`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;a,b\right) & = & \frac{b}{x\left(1-x\right)}\phi\left(a+b\log\frac{x}{1-x}\right)\\ F\left(x;a,b\right) & = & \Phi\left(a+b\log\frac{x}{1-x}\right)\\ G\left(q;a,b\right) & = & \frac{1}{1+\exp\left[-\frac{1}{b}\left(\Phi^{-1}\left(q\right)-a\right)\right]}\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   f\left(x;a,b\right) & = & \frac{b}{x\left(1-x\right)}\phi\left(a+b\log\frac{x}{1-x}\right)\\
+   F\left(x;a,b\right) & = & \Phi\left(a+b\log\frac{x}{1-x}\right)\\
+   G\left(q;a,b\right) & = & \frac{1}{1+\exp\left[-\frac{1}{b}\left(\Phi^{-1}\left(q\right)-a\right)\right]}\end{aligned*}
 
 Johnson SU
 ==========
 
-Defined for all :math:`x` with two shape parameters :math:`a` and :math:`b>0` .
+Defined for all :math:`x` with two shape parameters :math:`a` and
+:math:`b>0`\ .
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;a,b\right) & = & \frac{b}{\sqrt{x^{2}+1}}\phi\left(a+b\log\left(x+\sqrt{x^{2}+1}\right)\right)\\ F\left(x;a,b\right) & = & \Phi\left(a+b\log\left(x+\sqrt{x^{2}+1}\right)\right)\\ G\left(q;a,b\right) & = & \sinh\left[\frac{\Phi^{-1}\left(q\right)-a}{b}\right]\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   f\left(x;a,b\right) & = & \frac{b}{\sqrt{x^{2}+1}}\phi\left(a+b\log\left(x+\sqrt{x^{2}+1}\right)\right)\\
+   F\left(x;a,b\right) & = & \Phi\left(a+b\log\left(x+\sqrt{x^{2}+1}\right)\right)\\
+   G\left(q;a,b\right) & = & \sinh\left[\frac{\Phi^{-1}\left(q\right)-a}{b}\right]\end{aligned*}
 
 KSone
 =====
 
-
 KStwo
 =====
-
 
 Laplace (Double Exponential, Bilateral Expoooonential)
 ======================================================
 
+.. math::
 
+   \begin{aligned*}
+   f\left(x\right) & = & \frac{1}{2}e^{-\left|x\right|}\\
+   F\left(x\right) & = & \left\{ \begin{array}{ccc}
+   \frac{1}{2}e^{x} &  & x\leq0\\
+   1-\frac{1}{2}e^{-x} &  & x>0
+   \end{array}\right.\\
+   G\left(q\right) & = & \left\{ \begin{array}{ccc}
+   \log\left(2q\right) &  & q\leq\frac{1}{2}\\
+   -\log\left(2-2q\right) &  & q>\frac{1}{2}
+   \end{array}\right.\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{2}e^{-\left|x\right|}\\ F\left(x\right) & = & \left\{ \begin{array}{ccc} \frac{1}{2}e^{x} &  & x\leq0\\ 1-\frac{1}{2}e^{-x} &  & x>0\end{array}\right.\\ G\left(q\right) & = & \left\{ \begin{array}{ccc} \log\left(2q\right) &  & q\leq\frac{1}{2}\\ -\log\left(2-2q\right) &  & q>\frac{1}{2}\end{array}\right.\end{eqnarray*}
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} m_{d}=m_{n}=\mu & = & 0\\ \mu_{2} & = & 2\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & 3\end{eqnarray*}
-
-
+   \begin{aligned*}
+   m_{d}=m_{n}=\mu & = & 0\\
+   \mu_{2} & = & 2\\
+   \gamma_{1} & = & 0\\
+   \gamma_{2} & = & 3\end{aligned*}
 
 The ML estimator of the location parameter is
 
-.. math::
-   :nowrap:
+.. math:: \hat{L}=\textrm{median}\left(X_{i}\right)
 
-    \[ \hat{L}=\textrm{median}\left(X_{i}\right)\]
+ where :math:`X_{i}` is a sequence of :math:`N` mutually independent
+Laplace RV’s and the median is some number between the
+:math:`\frac{1}{2}N\textrm{th}` and the :math:`(N/2+1)\textrm{th}` order
+statistic (*e.g.* take the average of these two) when :math:`N` is even.
+Also,
 
-where :math:`X_{i}` is a sequence of :math:`N` mutually independent Laplace RV's and the median is some number
-between the :math:`\frac{1}{2}N\textrm{th}` and the :math:`(N/2+1)\textrm{th}` order statistic ( *e.g.* take the average of these two) when :math:`N` is even. Also,
+.. math:: \hat{S}=\frac{1}{N}\sum_{j=1}^{N}\left|X_{j}-\hat{L}\right|.
 
-.. math::
-   :nowrap:
-
-    \[ \hat{S}=\frac{1}{N}\sum_{j=1}^{N}\left|X_{j}-\hat{L}\right|.\]
-
-Replace :math:`\hat{L}` with :math:`L` if it is known. If :math:`L` is known then this estimator is distributed as :math:`\left(2N\right)^{-1}S\cdot\chi_{2N}^{2}` .
-
-
+ Replace :math:`\hat{L}` with :math:`L` if it is known. If :math:`L` is
+known then this estimator is distributed as
+:math:`\left(2N\right)^{-1}S\cdot\chi_{2N}^{2}`\ .
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} h\left[X\right] & = & \log\left(2e\right)\\  & \approx & 1.6931471805599453094.\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   h\left[X\right] & = & \log\left(2e\right)\\
+    & \approx & 1.6931471805599453094.\end{aligned*}
 
 Left-skewed Lévy
-=================
+================
 
-Special case of Lévy-stable distribution with :math:`\alpha=\frac{1}{2}` and :math:`\beta=-1` the support is :math:`x<0` . In standard form
+Special case of Lévy-stable distribution with :math:`\alpha=\frac{1}{2}`
+and :math:`\beta=-1` the support is :math:`x<0`\ . In standard form
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{\left|x\right|\sqrt{2\pi\left|x\right|}}\exp\left(-\frac{1}{2\left|x\right|}\right)\\ F\left(x\right) & = & 2\Phi\left(\frac{1}{\sqrt{\left|x\right|}}\right)-1\\ G\left(q\right) & = & -\left[\Phi^{-1}\left(\frac{q+1}{2}\right)\right]^{-2}.\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x\right) & = & \frac{1}{\left|x\right|\sqrt{2\pi\left|x\right|}}\exp\left(-\frac{1}{2\left|x\right|}\right)\\
+   F\left(x\right) & = & 2\Phi\left(\frac{1}{\sqrt{\left|x\right|}}\right)-1\\
+   G\left(q\right) & = & -\left[\Phi^{-1}\left(\frac{q+1}{2}\right)\right]^{-2}.\end{aligned*}
 
 No moments.
 
-
 Lévy
-=====
+====
 
-A special case of Lévy-stable distributions with :math:`\alpha=\frac{1}{2}` and :math:`\beta=1` . In standard form it is defined for :math:`x>0` as
+A special case of Lévy-stable distributions with
+:math:`\alpha=\frac{1}{2}` and :math:`\beta=1`\ . In standard form it is
+defined for :math:`x>0` as
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{x\sqrt{2\pi x}}\exp\left(-\frac{1}{2x}\right)\\ F\left(x\right) & = & 2\left[1-\Phi\left(\frac{1}{\sqrt{x}}\right)\right]\\ G\left(q\right) & = & \left[\Phi^{-1}\left(1-\frac{q}{2}\right)\right]^{-2}.\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x\right) & = & \frac{1}{x\sqrt{2\pi x}}\exp\left(-\frac{1}{2x}\right)\\
+   F\left(x\right) & = & 2\left[1-\Phi\left(\frac{1}{\sqrt{x}}\right)\right]\\
+   G\left(q\right) & = & \left[\Phi^{-1}\left(1-\frac{q}{2}\right)\right]^{-2}.\end{aligned*}
 
 It has no finite moments.
-
 
 Logistic (Sech-squared)
 =======================
 
-A special case of the Generalized Logistic distribution with :math:`c=1.` Defined for :math:`x>0`
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x\right) & = & \frac{\exp\left(-x\right)}{\left[1+\exp\left(-x\right)\right]^{2}}\\ F\left(x\right) & = & \frac{1}{1+\exp\left(-x\right)}\\ G\left(q\right) & = & -\log\left(1/q-1\right)\end{eqnarray*}
-
-
-
-
+A special case of the Generalized Logistic distribution with
+:math:`c=1.` Defined for :math:`x>0`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \gamma+\psi_{0}\left(1\right)=0\\ \mu_{2} & = & \frac{\pi^{2}}{6}+\psi_{1}\left(1\right)=\frac{\pi^{2}}{3}\\ \gamma_{1} & = & \frac{\psi_{2}\left(c\right)+2\zeta\left(3\right)}{\mu_{2}^{3/2}}=0\\ \gamma_{2} & = & \frac{\left(\frac{\pi^{4}}{15}+\psi_{3}\left(c\right)\right)}{\mu_{2}^{2}}=\frac{6}{5}\\ m_{d} & = & \log1=0\\ m_{n} & = & -\log\left(2-1\right)=0\end{eqnarray*}
-
-
-
-
+   \begin{aligned*}
+   f\left(x\right) & = & \frac{\exp\left(-x\right)}{\left[1+\exp\left(-x\right)\right]^{2}}\\
+   F\left(x\right) & = & \frac{1}{1+\exp\left(-x\right)}\\
+   G\left(q\right) & = & -\log\left(1/q-1\right)\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \[ h\left[X\right]=1.\]
+   \begin{aligned*}
+   \mu & = & \gamma+\psi_{0}\left(1\right)=0\\
+   \mu_{2} & = & \frac{\pi^{2}}{6}+\psi_{1}\left(1\right)=\frac{\pi^{2}}{3}\\
+   \gamma_{1} & = & \frac{\psi_{2}\left(c\right)+2\zeta\left(3\right)}{\mu_{2}^{3/2}}=0\\
+   \gamma_{2} & = & \frac{\left(\frac{\pi^{4}}{15}+\psi_{3}\left(c\right)\right)}{\mu_{2}^{2}}=\frac{6}{5}\\
+   m_{d} & = & \log1=0\\
+   m_{n} & = & -\log\left(2-1\right)=0\end{aligned*}
 
-
-
+.. math:: h\left[X\right]=1.
 
 Log Double Exponential (Log-Laplace)
 ====================================
@@ -1713,336 +1549,295 @@ Log Double Exponential (Log-Laplace)
 Defined over :math:`x>0` with :math:`c>0`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & \left\{ \begin{array}{ccc} \frac{c}{2}x^{c-1} &  & 0<x<1\\ \frac{c}{2}x^{-c-1} &  & x\geq1\end{array}\right.\\ F\left(x;c\right) & = & \left\{ \begin{array}{ccc} \frac{1}{2}x^{c} &  & 0<x<1\\ 1-\frac{1}{2}x^{-c} &  & x\geq1\end{array}\right.\\ G\left(q;c\right) & = & \left\{ \begin{array}{ccc} \left(2q\right)^{1/c} &  & 0\leq q<\frac{1}{2}\\ \left(2-2q\right)^{-1/c} &  & \frac{1}{2}\leq q\leq1\end{array}\right.\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;c\right) & = & \left\{ \begin{array}{ccc}
+   \frac{c}{2}x^{c-1} &  & 0<x<1\\
+   \frac{c}{2}x^{-c-1} &  & x\geq1
+   \end{array}\right.\\
+   F\left(x;c\right) & = & \left\{ \begin{array}{ccc}
+   \frac{1}{2}x^{c} &  & 0<x<1\\
+   1-\frac{1}{2}x^{-c} &  & x\geq1
+   \end{array}\right.\\
+   G\left(q;c\right) & = & \left\{ \begin{array}{ccc}
+   \left(2q\right)^{1/c} &  & 0\leq q<\frac{1}{2}\\
+   \left(2-2q\right)^{-1/c} &  & \frac{1}{2}\leq q\leq1
+   \end{array}\right.\end{aligned*}
 
-
-
-
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]=\log\left(\frac{2e}{c}\right)\]
-
-
-
+.. math:: h\left[X\right]=\log\left(\frac{2e}{c}\right)
 
 Log Gamma
 =========
 
-A single shape parameter :math:`c>0` (Defined for all :math:`x` )
+A single shape parameter :math:`c>0` (Defined for all :math:`x`\ )
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & \frac{\exp\left(cx-e^{x}\right)}{\Gamma\left(c\right)}\\ F\left(x;c\right) & = & \frac{\Gamma\left(c,e^{x}\right)}{\Gamma\left(c\right)}\\ G\left(q;c\right) & = & \log\left[\Gamma^{-1}\left[c,q\Gamma\left(c\right)\right]\right]\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;c\right) & = & \frac{\exp\left(cx-e^{x}\right)}{\Gamma\left(c\right)}\\
+   F\left(x;c\right) & = & \frac{\Gamma\left(c,e^{x}\right)}{\Gamma\left(c\right)}\\
+   G\left(q;c\right) & = & \log\left[\Gamma^{-1}\left[c,q\Gamma\left(c\right)\right]\right]\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \[ \mu_{n}^{\prime}=\int_{0}^{\infty}\left[\log y\right]^{n}y^{c-1}\exp\left(-y\right)dy.\]
-
-
+.. math:: \mu_{n}^{\prime}=\int_{0}^{\infty}\left[\log y\right]^{n}y^{c-1}\exp\left(-y\right)dy.
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \mu_{1}^{\prime}\\ \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\ \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   \mu & = & \mu_{1}^{\prime}\\
+   \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\
+   \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
+   \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{aligned*}
 
 Log Normal (Cobb-Douglass)
 ==========================
 
-Has one shape parameter :math:`\sigma` >0. (Notice that the "Regress ":math:`A=\log S` where :math:`S` is the scale parameter and :math:`A` is the mean of the underlying normal distribution). The standard form
-is :math:`x>0`
+Has one shape parameter :math:`\sigma`\ >0. (Notice that the “Regress”
+:math:`A=\log S` where :math:`S` is the scale parameter and :math:`A` is
+the mean of the underlying normal distribution). The standard form is
+:math:`x>0`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;\sigma\right) & = & \frac{1}{\sigma x\sqrt{2\pi}}\exp\left[-\frac{1}{2}\left(\frac{\log x}{\sigma}\right)^{2}\right]\\ F\left(x;\sigma\right) & = & \Phi\left(\frac{\log x}{\sigma}\right)\\ G\left(q;\sigma\right) & = & \exp\left\{ \sigma\Phi^{-1}\left(q\right)\right\} \end{eqnarray*}
-
-
+   \begin{aligned*}
+   f\left(x;\sigma\right) & = & \frac{1}{\sigma x\sqrt{2\pi}}\exp\left[-\frac{1}{2}\left(\frac{\log x}{\sigma}\right)^{2}\right]\\
+   F\left(x;\sigma\right) & = & \Phi\left(\frac{\log x}{\sigma}\right)\\
+   G\left(q;\sigma\right) & = & \exp\left\{ \sigma\Phi^{-1}\left(q\right)\right\} \end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \exp\left(\sigma^{2}/2\right)\\ \mu_{2} & = & \exp\left(\sigma^{2}\right)\left[\exp\left(\sigma^{2}\right)-1\right]\\ \gamma_{1} & = & \sqrt{p-1}\left(2+p\right)\\ \gamma_{2} & = & p^{4}+2p^{3}+3p^{2}-6\quad\quad p=e^{\sigma^{2}}\end{eqnarray*}
+   \begin{aligned*}
+   \mu & = & \exp\left(\sigma^{2}/2\right)\\
+   \mu_{2} & = & \exp\left(\sigma^{2}\right)\left[\exp\left(\sigma^{2}\right)-1\right]\\
+   \gamma_{1} & = & \sqrt{p-1}\left(2+p\right)\\
+   \gamma_{2} & = & p^{4}+2p^{3}+3p^{2}-6\quad\quad p=e^{\sigma^{2}}\end{aligned*}
 
-
-
-Notice that using JKB notation we have :math:`\theta=L,` :math:`\zeta=\log S` and we have given the so-called antilognormal form of the
-distribution. This is more consistent with the location, scale
+Notice that using JKB notation we have :math:`\theta=L,`
+:math:`\zeta=\log S` and we have given the so-called antilognormal form
+of the distribution. This is more consistent with the location, scale
 parameter description of general probability distributions.
 
+.. math:: h\left[X\right]=\frac{1}{2}\left[1+\log\left(2\pi\right)+2\log\left(\sigma\right)\right].
 
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]=\frac{1}{2}\left[1+\log\left(2\pi\right)+2\log\left(\sigma\right)\right].\]
-
-
-
-Also, note that if :math:`X` is a log-normally distributed random-variable with :math:`L=0` and :math:`S` and shape parameter :math:`\sigma.` Then, :math:`\log X` is normally distributed with variance :math:`\sigma^{2}` and mean :math:`\log S.`
-
+Also, note that if :math:`X` is a log-normally distributed
+random-variable with :math:`L=0` and :math:`S` and shape parameter
+:math:`\sigma.` Then, :math:`\log X` is normally distributed with
+variance :math:`\sigma^{2}` and mean :math:`\log S.`
 
 Nakagami
 ========
 
-Generalization of the chi distribution. Shape parameter is :math:`\nu>0.` Defined for :math:`x>0.`
+Generalization of the chi distribution. Shape parameter is
+:math:`\nu>0.` Defined for :math:`x>0.`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;\nu\right) & = & \frac{2\nu^{\nu}}{\Gamma\left(\nu\right)}x^{2\nu-1}\exp\left(-\nu x^{2}\right)\\ F\left(x;\nu\right) & = & \Gamma\left(\nu,\nu x^{2}\right)\\ G\left(q;\nu\right) & = & \sqrt{\frac{1}{\nu}\Gamma^{-1}\left(v,q\right)}\end{eqnarray*}
-
-
+   \begin{aligned*}
+   f\left(x;\nu\right) & = & \frac{2\nu^{\nu}}{\Gamma\left(\nu\right)}x^{2\nu-1}\exp\left(-\nu x^{2}\right)\\
+   F\left(x;\nu\right) & = & \Gamma\left(\nu,\nu x^{2}\right)\\
+   G\left(q;\nu\right) & = & \sqrt{\frac{1}{\nu}\Gamma^{-1}\left(v,q\right)}\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \frac{\Gamma\left(\nu+\frac{1}{2}\right)}{\sqrt{\nu}\Gamma\left(\nu\right)}\\ \mu_{2} & = & \left[1-\mu^{2}\right]\\ \gamma_{1} & = & \frac{\mu\left(1-4v\mu_{2}\right)}{2\nu\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{-6\mu^{4}\nu+\left(8\nu-2\right)\mu^{2}-2\nu+1}{\nu\mu_{2}^{2}}\end{eqnarray*}
+   \begin{aligned*}
+   \mu & = & \frac{\Gamma\left(\nu+\frac{1}{2}\right)}{\sqrt{\nu}\Gamma\left(\nu\right)}\\
+   \mu_{2} & = & \left[1-\mu^{2}\right]\\
+   \gamma_{1} & = & \frac{\mu\left(1-4v\mu_{2}\right)}{2\nu\mu_{2}^{3/2}}\\
+   \gamma_{2} & = & \frac{-6\mu^{4}\nu+\left(8\nu-2\right)\mu^{2}-2\nu+1}{\nu\mu_{2}^{2}}\end{aligned*}
 
+Noncentral beta\*
+=================
 
+Defined over :math:`x\in\left[0,1\right]` with :math:`a>0` and
+:math:`b>0` and :math:`c\geq0`
 
+.. math:: F\left(x;a,b,c\right)=\sum_{j=0}^{\infty}\frac{e^{-c/2}\left(\frac{c}{2}\right)^{j}}{j!}I_{B}\left(a+j,b;0\right)
 
-Noncentral beta*
+Noncentral chi\*
 ================
-
-Defined over :math:`x\in\left[0,1\right]` with :math:`a>0` and :math:`b>0` and :math:`c\geq0`
-
-
-
-.. math::
-   :nowrap:
-
-    \[ F\left(x;a,b,c\right)=\sum_{j=0}^{\infty}\frac{e^{-c/2}\left(\frac{c}{2}\right)^{j}}{j!}I_{B}\left(a+j,b;0\right)\]
-
-
-
-
-Noncentral chi*
-===============
-
 
 Noncentral chi-squared
 ======================
 
-The distribution of :math:`\sum_{i=1}^{\nu}\left(Z_{i}+\delta_{i}\right)^{2}` where :math:`Z_{i}` are independent standard normal variables and :math:`\delta_{i}` are constants. :math:`\lambda=\sum_{i=1}^{\nu}\delta_{i}^{2}>0.` (In communications it is called the Marcum-Q function). Can be thought
-of as a Generalized Rayleigh-Rice distribution. For :math:`x>0`
+The distribution of
+:math:`\sum_{i=1}^{\nu}\left(Z_{i}+\delta_{i}\right)^{2}` where
+:math:`Z_{i}` are independent standard normal variables and
+:math:`\delta_{i}` are constants.
+:math:`\lambda=\sum_{i=1}^{\nu}\delta_{i}^{2}>0.` (In communications it
+is called the Marcum-Q function). Can be thought of as a Generalized
+Rayleigh-Rice distribution. For :math:`x>0`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;\nu,\lambda\right) & = & e^{-\left(\lambda+x\right)/2}\frac{1}{2}\left(\frac{x}{\lambda}\right)^{\left(\nu-2\right)/4}I_{\left(\nu-2\right)/2}\left(\sqrt{\lambda x}\right)\\ F\left(x;\nu,\lambda\right) & = & \sum_{j=0}^{\infty}\left\{ \frac{\left(\lambda/2\right)^{j}}{j!}e^{-\lambda/2}\right\} \textrm{Pr}\left[\chi_{\nu+2j}^{2}\leq x\right]\\ G\left(q;\nu,\lambda\right) & = & F^{-1}\left(x;\nu,\lambda\right)\end{eqnarray*}
-
-
+   \begin{aligned*}
+   f\left(x;\nu,\lambda\right) & = & e^{-\left(\lambda+x\right)/2}\frac{1}{2}\left(\frac{x}{\lambda}\right)^{\left(\nu-2\right)/4}I_{\left(\nu-2\right)/2}\left(\sqrt{\lambda x}\right)\\
+   F\left(x;\nu,\lambda\right) & = & \sum_{j=0}^{\infty}\left\{ \frac{\left(\lambda/2\right)^{j}}{j!}e^{-\lambda/2}\right\} \textrm{Pr}\left[\chi_{\nu+2j}^{2}\leq x\right]\\
+   G\left(q;\nu,\lambda\right) & = & F^{-1}\left(x;\nu,\lambda\right)\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \nu+\lambda\\ \mu_{2} & = & 2\left(\nu+2\lambda\right)\\ \gamma_{1} & = & \frac{\sqrt{8}\left(\nu+3\lambda\right)}{\left(\nu+2\lambda\right)^{3/2}}\\ \gamma_{2} & = & \frac{12\left(\nu+4\lambda\right)}{\left(\nu+2\lambda\right)^{2}}\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   \mu & = & \nu+\lambda\\
+   \mu_{2} & = & 2\left(\nu+2\lambda\right)\\
+   \gamma_{1} & = & \frac{\sqrt{8}\left(\nu+3\lambda\right)}{\left(\nu+2\lambda\right)^{3/2}}\\
+   \gamma_{2} & = & \frac{12\left(\nu+4\lambda\right)}{\left(\nu+2\lambda\right)^{2}}\end{aligned*}
 
 Noncentral F
 ============
 
 Let :math:`\lambda>0` and :math:`\nu_{1}>0` and :math:`\nu_{2}>0.`
 
-
-
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;\lambda,\nu_{1},\nu_{2}\right) & = & \exp\left[\frac{\lambda}{2}+\frac{\left(\lambda\nu_{1}x\right)}{2\left(\nu_{1}x+\nu_{2}\right)}\right]\nu_{1}^{\nu_{1}/2}\nu_{2}^{\nu_{2}/2}x^{\nu_{1}/2-1}\\  &  & \times\left(\nu_{2}+\nu_{1}x\right)^{-\left(\nu_{1}+\nu_{2}\right)/2}\frac{\Gamma\left(\frac{\nu_{1}}{2}\right)\Gamma\left(1+\frac{\nu_{2}}{2}\right)L_{\nu_{2}/2}^{\nu_{1}/2-1}\left(-\frac{\lambda\nu_{1}x}{2\left(\nu_{1}x+\nu_{2}\right)}\right)}{B\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2}\right)\Gamma\left(\frac{\nu_{1}+\nu_{2}}{2}\right)}\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   f\left(x;\lambda,\nu_{1},\nu_{2}\right) & = & \exp\left[\frac{\lambda}{2}+\frac{\left(\lambda\nu_{1}x\right)}{2\left(\nu_{1}x+\nu_{2}\right)}\right]\nu_{1}^{\nu_{1}/2}\nu_{2}^{\nu_{2}/2}x^{\nu_{1}/2-1}\\
+    &  & \times\left(\nu_{2}+\nu_{1}x\right)^{-\left(\nu_{1}+\nu_{2}\right)/2}\frac{\Gamma\left(\frac{\nu_{1}}{2}\right)\Gamma\left(1+\frac{\nu_{2}}{2}\right)L_{\nu_{2}/2}^{\nu_{1}/2-1}\left(-\frac{\lambda\nu_{1}x}{2\left(\nu_{1}x+\nu_{2}\right)}\right)}{B\left(\frac{\nu_{1}}{2},\frac{\nu_{2}}{2}\right)\Gamma\left(\frac{\nu_{1}+\nu_{2}}{2}\right)}\end{aligned*}
 
 Noncentral t
 ============
 
 The distribution of the ratio
 
+.. math:: \frac{U+\lambda}{\chi_{\nu}/\sqrt{\nu}}
+
+ where :math:`U` and :math:`\chi_{\nu}` are independent and distributed
+as a standard normal and chi with :math:`\nu` degrees of freedom. Note
+:math:`\lambda>0` and :math:`\nu>0`\ .
+
 .. math::
-   :nowrap:
 
-    \[ \frac{U+\lambda}{\chi_{\nu}/\sqrt{\nu}}\]
-
-where :math:`U` and :math:`\chi_{\nu}` are independent and distributed as a standard normal and chi with :math:`\nu` degrees of freedom. Note :math:`\lambda>0` and :math:`\nu>0` .
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x;\lambda,\nu\right) & = & \frac{\nu^{\nu/2}\Gamma\left(\nu+1\right)}{2^{\nu}e^{\lambda^{2}/2}\left(\nu+x^{2}\right)^{\nu/2}\Gamma\left(\nu/2\right)}\\  &  & \times\left\{ \frac{\sqrt{2}\lambda x\,_{1}F_{1}\left(\frac{\nu}{2}+1;\frac{3}{2};\frac{\lambda^{2}x^{2}}{2\left(\nu+x^{2}\right)}\right)}{\left(\nu+x^{2}\right)\Gamma\left(\frac{\nu+1}{2}\right)}\right.\\  &  & -\left.\frac{\,_{1}F_{1}\left(\frac{\nu+1}{2};\frac{1}{2};\frac{\lambda^{2}x^{2}}{2\left(\nu+x^{2}\right)}\right)}{\sqrt{\nu+x^{2}}\Gamma\left(\frac{\nu}{2}+1\right)}\right\} \\  & = & \frac{\Gamma\left(\nu+1\right)}{2^{\left(\nu-1\right)/2}\sqrt{\pi\nu}\Gamma\left(\nu/2\right)}\exp\left[-\frac{\nu\lambda^{2}}{\nu+x^{2}}\right]\\  &  & \times\left(\frac{\nu}{\nu+x^{2}}\right)^{\left(\nu-1\right)/2}Hh_{\nu}\left(-\frac{\lambda x}{\sqrt{\nu+x^{2}}}\right)\\ F\left(x;\lambda,\nu\right) & =\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   f\left(x;\lambda,\nu\right) & = & \frac{\nu^{\nu/2}\Gamma\left(\nu+1\right)}{2^{\nu}e^{\lambda^{2}/2}\left(\nu+x^{2}\right)^{\nu/2}\Gamma\left(\nu/2\right)}\\
+    &  & \times\left\{ \frac{\sqrt{2}\lambda x\,_{1}F_{1}\left(\frac{\nu}{2}+1;\frac{3}{2};\frac{\lambda^{2}x^{2}}{2\left(\nu+x^{2}\right)}\right)}{\left(\nu+x^{2}\right)\Gamma\left(\frac{\nu+1}{2}\right)}\right.\\
+    &  & -\left.\frac{\,_{1}F_{1}\left(\frac{\nu+1}{2};\frac{1}{2};\frac{\lambda^{2}x^{2}}{2\left(\nu+x^{2}\right)}\right)}{\sqrt{\nu+x^{2}}\Gamma\left(\frac{\nu}{2}+1\right)}\right\} \\
+    & = & \frac{\Gamma\left(\nu+1\right)}{2^{\left(\nu-1\right)/2}\sqrt{\pi\nu}\Gamma\left(\nu/2\right)}\exp\left[-\frac{\nu\lambda^{2}}{\nu+x^{2}}\right]\\
+    &  & \times\left(\frac{\nu}{\nu+x^{2}}\right)^{\left(\nu-1\right)/2}Hh_{\nu}\left(-\frac{\lambda x}{\sqrt{\nu+x^{2}}}\right)\\
+   F\left(x;\lambda,\nu\right) & =\end{aligned*}
 
 Normal
 ======
 
+.. math::
 
+   \begin{aligned*}
+   f\left(x\right) & = & \frac{e^{-x^{2}/2}}{\sqrt{2\pi}}\\
+   F\left(x\right) & = & \Phi\left(x\right)=\frac{1}{2}+\frac{1}{2}\textrm{erf}\left(\frac{\textrm{x}}{\sqrt{2}}\right)\\
+   G\left(q\right) & = & \Phi^{-1}\left(q\right)\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \frac{e^{-x^{2}/2}}{\sqrt{2\pi}}\\ F\left(x\right) & = & \Phi\left(x\right)=\frac{1}{2}+\frac{1}{2}\textrm{erf}\left(\frac{\textrm{x}}{\sqrt{2}}\right)\\ G\left(q\right) & = & \Phi^{-1}\left(q\right)\end{eqnarray*}
-
-
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} m_{d}=m_{n}=\mu & = & 0\\ \mu_{2} & = & 1\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & 0\end{eqnarray*}
-
-
-
-
+   \begin{aligned*}
+   m_{d}=m_{n}=\mu & = & 0\\
+   \mu_{2} & = & 1\\
+   \gamma_{1} & = & 0\\
+   \gamma_{2} & = & 0\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} h\left[X\right] & = & \log\left(\sqrt{2\pi e}\right)\\  & \approx & 1.4189385332046727418\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   h\left[X\right] & = & \log\left(\sqrt{2\pi e}\right)\\
+    & \approx & 1.4189385332046727418\end{aligned*}
 
 Maxwell
 =======
 
-This is a special case of the Chi distribution with :math:`L=0` and :math:`S=S=\frac{1}{\sqrt{a}}` and :math:`\nu=3.`
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x\right) & = & \sqrt{\frac{2}{\pi}}x^{2}e^{-x^{2}/2}I_{\left(0,\infty\right)}\left(x\right)\\ F\left(x\right) & = & \Gamma\left(\frac{3}{2},\frac{x^{2}}{2}\right)\\ G\left(\alpha\right) & = & \sqrt{2\Gamma^{-1}\left(\frac{3}{2},\alpha\right)}\end{eqnarray*}
-
-
-
-
+This is a special case of the Chi distribution with :math:`L=0` and
+:math:`S=S=\frac{1}{\sqrt{a}}` and :math:`\nu=3.`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & 2\sqrt{\frac{2}{\pi}}\\ \mu_{2} & = & 3-\frac{8}{\pi}\\ \gamma_{1} & = & \sqrt{2}\frac{32-10\pi}{\left(3\pi-8\right)^{3/2}}\\ \gamma_{2} & = & \frac{-12\pi^{2}+160\pi-384}{\left(3\pi-8\right)^{2}}\\ m_{d} & = & \sqrt{2}\\ m_{n} & = & \sqrt{2\Gamma^{-1}\left(\frac{3}{2},\frac{1}{2}\right)}\end{eqnarray*}
-
-
+   \begin{aligned*}
+   f\left(x\right) & = & \sqrt{\frac{2}{\pi}}x^{2}e^{-x^{2}/2}I_{\left(0,\infty\right)}\left(x\right)\\
+   F\left(x\right) & = & \Gamma\left(\frac{3}{2},\frac{x^{2}}{2}\right)\\
+   G\left(\alpha\right) & = & \sqrt{2\Gamma^{-1}\left(\frac{3}{2},\alpha\right)}\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \[ h\left[X\right]=\log\left(\sqrt{\frac{2\pi}{e}}\right)+\gamma.\]
+   \begin{aligned*}
+   \mu & = & 2\sqrt{\frac{2}{\pi}}\\
+   \mu_{2} & = & 3-\frac{8}{\pi}\\
+   \gamma_{1} & = & \sqrt{2}\frac{32-10\pi}{\left(3\pi-8\right)^{3/2}}\\
+   \gamma_{2} & = & \frac{-12\pi^{2}+160\pi-384}{\left(3\pi-8\right)^{2}}\\
+   m_{d} & = & \sqrt{2}\\
+   m_{n} & = & \sqrt{2\Gamma^{-1}\left(\frac{3}{2},\frac{1}{2}\right)}\end{aligned*}
 
+.. math:: h\left[X\right]=\log\left(\sqrt{\frac{2\pi}{e}}\right)+\gamma.
 
-
-
-Mielke's Beta-Kappa
+Mielke’s Beta-Kappa
 ===================
 
-A generalized F distribution. Two shape parameters :math:`\kappa` and :math:`\theta` , and :math:`x>0` . The :math:`\beta` in the DATAPLOT reference is a scale parameter.
+A generalized F distribution. Two shape parameters :math:`\kappa` and
+:math:`\theta`\ , and :math:`x>0`\ . The :math:`\beta` in the DATAPLOT
+reference is a scale parameter.
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;\kappa,\theta\right) & = & \frac{\kappa x^{\kappa-1}}{\left(1+x^{\theta}\right)^{1+\frac{\kappa}{\theta}}}\\ F\left(x;\kappa,\theta\right) & = & \frac{x^{\kappa}}{\left(1+x^{\theta}\right)^{\kappa/\theta}}\\ G\left(q;\kappa,\theta\right) & = & \left(\frac{q^{\theta/\kappa}}{1-q^{\theta/\kappa}}\right)^{1/\theta}\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   f\left(x;\kappa,\theta\right) & = & \frac{\kappa x^{\kappa-1}}{\left(1+x^{\theta}\right)^{1+\frac{\kappa}{\theta}}}\\
+   F\left(x;\kappa,\theta\right) & = & \frac{x^{\kappa}}{\left(1+x^{\theta}\right)^{\kappa/\theta}}\\
+   G\left(q;\kappa,\theta\right) & = & \left(\frac{q^{\theta/\kappa}}{1-q^{\theta/\kappa}}\right)^{1/\theta}\end{aligned*}
 
 Pareto
 ======
 
-For :math:`x\geq1` and :math:`b>0` . Standard form is
-
-
+For :math:`x\geq1` and :math:`b>0`\ . Standard form is
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;b\right) & = & \frac{b}{x^{b+1}}\\ F\left(x;b\right) & = & 1-\frac{1}{x^{b}}\\ G\left(q;b\right) & = & \left(1-q\right)^{-1/b}\end{eqnarray*}
-
-
-
-
+   \begin{aligned*}
+   f\left(x;b\right) & = & \frac{b}{x^{b+1}}\\
+   F\left(x;b\right) & = & 1-\frac{1}{x^{b}}\\
+   G\left(q;b\right) & = & \left(1-q\right)^{-1/b}\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \frac{b}{b-1}\quad b>1\\ \mu_{2} & = & \frac{b}{\left(b-2\right)\left(b-1\right)^{2}}\quad b>2\\ \gamma_{1} & = & \frac{2\left(b+1\right)\sqrt{b-2}}{\left(b-3\right)\sqrt{b}}\quad b>3\\ \gamma_{2} & = & \frac{6\left(b^{3}+b^{2}-6b-2\right)}{b\left(b^{2}-7b+12\right)}\quad b>4\end{eqnarray*}
+   \begin{aligned*}
+   \mu & = & \frac{b}{b-1}\quad b>1\\
+   \mu_{2} & = & \frac{b}{\left(b-2\right)\left(b-1\right)^{2}}\quad b>2\\
+   \gamma_{1} & = & \frac{2\left(b+1\right)\sqrt{b-2}}{\left(b-3\right)\sqrt{b}}\quad b>3\\
+   \gamma_{2} & = & \frac{6\left(b^{3}+b^{2}-6b-2\right)}{b\left(b^{2}-7b+12\right)}\quad b>4\end{aligned*}
 
-
-
-
-
-.. math::
-   :nowrap:
-
-    \[ h\left(X\right)=\frac{1}{c}+1-\log\left(c\right)\]
-
-
-
+.. math:: h\left(X\right)=\frac{1}{c}+1-\log\left(c\right)
 
 Pareto Second Kind (Lomax)
 ==========================
 
-:math:`c>0.` This is Pareto of the first kind with :math:`L=-1.0` so :math:`x\geq0`
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x;c\right) & = & \frac{c}{\left(1+x\right)^{c+1}}\\ F\left(x;c\right) & = & 1-\frac{1}{\left(1+x\right)^{c}}\\ G\left(q;c\right) & = & \left(1-q\right)^{-1/c}-1\end{eqnarray*}
-
-
+:math:`c>0.` This is Pareto of the first kind with :math:`L=-1.0` so
+:math:`x\geq0`
 
 .. math::
-   :nowrap:
 
-    \[ h\left[X\right]=\frac{1}{c}+1-\log\left(c\right).\]
+   \begin{aligned*}
+   f\left(x;c\right) & = & \frac{c}{\left(1+x\right)^{c+1}}\\
+   F\left(x;c\right) & = & 1-\frac{1}{\left(1+x\right)^{c}}\\
+   G\left(q;c\right) & = & \left(1-q\right)^{-1/c}-1\end{aligned*}
 
-
-
+.. math:: h\left[X\right]=\frac{1}{c}+1-\log\left(c\right).
 
 Power Log Normal
 ================
 
-A generalization of the log-normal distribution :math:`\sigma>0` and :math:`c>0` and :math:`x>0`
+A generalization of the log-normal distribution :math:`\sigma>0` and
+:math:`c>0` and :math:`x>0`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;\sigma,c\right) & = & \frac{c}{x\sigma}\phi\left(\frac{\log x}{\sigma}\right)\left(\Phi\left(-\frac{\log x}{\sigma}\right)\right)^{c-1}\\ F\left(x;\sigma,c\right) & = & 1-\left(\Phi\left(-\frac{\log x}{\sigma}\right)\right)^{c}\\ G\left(q;\sigma,c\right) & = & \exp\left[-\sigma\Phi^{-1}\left[\left(1-q\right)^{1/c}\right]\right]\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;\sigma,c\right) & = & \frac{c}{x\sigma}\phi\left(\frac{\log x}{\sigma}\right)\left(\Phi\left(-\frac{\log x}{\sigma}\right)\right)^{c-1}\\
+   F\left(x;\sigma,c\right) & = & 1-\left(\Phi\left(-\frac{\log x}{\sigma}\right)\right)^{c}\\
+   G\left(q;\sigma,c\right) & = & \exp\left[-\sigma\Phi^{-1}\left[\left(1-q\right)^{1/c}\right]\right]\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \[ \mu_{n}^{\prime}=\int_{0}^{1}\exp\left[-n\sigma\Phi^{-1}\left(y^{1/c}\right)\right]dy\]
-
-
+.. math:: \mu_{n}^{\prime}=\int_{0}^{1}\exp\left[-n\sigma\Phi^{-1}\left(y^{1/c}\right)\right]dy
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \mu_{1}^{\prime}\\ \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\ \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{eqnarray*}
+   \begin{aligned*}
+   \mu & = & \mu_{1}^{\prime}\\
+   \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\
+   \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
+   \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{aligned*}
 
-This distribution reduces to the log-normal distribution when :math:`c=1.`
-
+This distribution reduces to the log-normal distribution when
+:math:`c=1.`
 
 Power Normal
 ============
@@ -2050,141 +1845,107 @@ Power Normal
 A generalization of the normal distribution, :math:`c>0` for
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & c\phi\left(x\right)\left(\Phi\left(-x\right)\right)^{c-1}\\ F\left(x;c\right) & = & 1-\left(\Phi\left(-x\right)\right)^{c}\\ G\left(q;c\right) & = & -\Phi^{-1}\left[\left(1-q\right)^{1/c}\right]\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;c\right) & = & c\phi\left(x\right)\left(\Phi\left(-x\right)\right)^{c-1}\\
+   F\left(x;c\right) & = & 1-\left(\Phi\left(-x\right)\right)^{c}\\
+   G\left(q;c\right) & = & -\Phi^{-1}\left[\left(1-q\right)^{1/c}\right]\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \[ \mu_{n}^{\prime}=\left(-1\right)^{n}\int_{0}^{1}\left[\Phi^{-1}\left(y^{1/c}\right)\right]^{n}dy\]
-
-
+.. math:: \mu_{n}^{\prime}=\left(-1\right)^{n}\int_{0}^{1}\left[\Phi^{-1}\left(y^{1/c}\right)\right]^{n}dy
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \mu_{1}^{\prime}\\ \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\ \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\ \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{eqnarray*}
+   \begin{aligned*}
+   \mu & = & \mu_{1}^{\prime}\\
+   \mu_{2} & = & \mu_{2}^{\prime}-\mu^{2}\\
+   \gamma_{1} & = & \frac{\mu_{3}^{\prime}-3\mu\mu_{2}-\mu^{3}}{\mu_{2}^{3/2}}\\
+   \gamma_{2} & = & \frac{\mu_{4}^{\prime}-4\mu\mu_{3}-6\mu^{2}\mu_{2}-\mu^{4}}{\mu_{2}^{2}}-3\end{aligned*}
 
 For :math:`c=1` this reduces to the normal distribution.
 
+Power-function 
+===============
 
-Power-function
-==============
+A special case of the beta distribution with :math:`b=1`\ : defined for
+:math:`x\in\left[0,1\right]`
 
-A special case of the beta distribution with :math:`b=1` : defined for :math:`x\in\left[0,1\right]`
-
-
-
-.. math::
-   :nowrap:
-
-    \[ a>0\]
-
-
-
-
+.. math:: a>0
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;a\right) & = & ax^{a-1}\\ F\left(x;a\right) & = & x^{a}\\ G\left(q;a\right) & = & q^{1/a}\\ \mu & = & \frac{a}{a+1}\\ \mu_{2} & = & \frac{a\left(a+2\right)}{\left(a+1\right)^{2}}\\ \gamma_{1} & = & 2\left(1-a\right)\sqrt{\frac{a+2}{a\left(a+3\right)}}\\ \gamma_{2} & = & \frac{6\left(a^{3}-a^{2}-6a+2\right)}{a\left(a+3\right)\left(a+4\right)}\\ m_{d} & = & 1\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;a\right) & = & ax^{a-1}\\
+   F\left(x;a\right) & = & x^{a}\\
+   G\left(q;a\right) & = & q^{1/a}\\
+   \mu & = & \frac{a}{a+1}\\
+   \mu_{2} & = & \frac{a\left(a+2\right)}{\left(a+1\right)^{2}}\\
+   \gamma_{1} & = & 2\left(1-a\right)\sqrt{\frac{a+2}{a\left(a+3\right)}}\\
+   \gamma_{2} & = & \frac{6\left(a^{3}-a^{2}-6a+2\right)}{a\left(a+3\right)\left(a+4\right)}\\
+   m_{d} & = & 1\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]=1-\frac{1}{a}-\log\left(a\right)\]
-
-
-
+.. math:: h\left[X\right]=1-\frac{1}{a}-\log\left(a\right)
 
 R-distribution
 ==============
 
-A general-purpose distribution with a variety of shapes controlled by :math:`c>0.` Range of standard distribution is :math:`x\in\left[-1,1\right]`
+A general-purpose distribution with a variety of shapes controlled by
+:math:`c>0.` Range of standard distribution is
+:math:`x\in\left[-1,1\right]`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & \frac{\left(1-x^{2}\right)^{c/2-1}}{B\left(\frac{1}{2},\frac{c}{2}\right)}\\ F\left(x;c\right) & = & \frac{1}{2}+\frac{x}{B\left(\frac{1}{2},\frac{c}{2}\right)}\,_{2}F_{1}\left(\frac{1}{2},1-\frac{c}{2};\frac{3}{2};x^{2}\right)\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;c\right) & = & \frac{\left(1-x^{2}\right)^{c/2-1}}{B\left(\frac{1}{2},\frac{c}{2}\right)}\\
+   F\left(x;c\right) & = & \frac{1}{2}+\frac{x}{B\left(\frac{1}{2},\frac{c}{2}\right)}\,_{2}F_{1}\left(\frac{1}{2},1-\frac{c}{2};\frac{3}{2};x^{2}\right)\end{aligned*}
 
+.. math:: \mu_{n}^{\prime}=\frac{\left(1+\left(-1\right)^{n}\right)}{2}B\left(\frac{n+1}{2},\frac{c}{2}\right)
 
+ The R-distribution with parameter :math:`n` is the distribution of the
+correlation coefficient of a random sample of size :math:`n` drawn from
+a bivariate normal distribution with :math:`\rho=0.` The mean of the
+standard distribution is always zero and as the sample size grows, the
+distribution’s mass concentrates more closely about this mean.
 
-.. math::
-   :nowrap:
+Rayleigh 
+=========
 
-    \[ \mu_{n}^{\prime}=\frac{\left(1+\left(-1\right)^{n}\right)}{2}B\left(\frac{n+1}{2},\frac{c}{2}\right)\]
-
-The R-distribution with parameter :math:`n` is the distribution of the correlation coefficient of a random sample
-of size :math:`n` drawn from a bivariate normal distribution with :math:`\rho=0.` The mean of the standard distribution is always zero and as the sample
-size grows, the distribution's mass concentrates more closely about
-this mean.
-
-
-Rayleigh
-========
-
-This is Chi distribution with :math:`L=0.0` and :math:`\nu=2` and :math:`S=S` (no location parameter is generally used), the mode of the
+This is Chi distribution with :math:`L=0.0` and :math:`\nu=2` and
+:math:`S=S` (no location parameter is generally used), the mode of the
 distribution is :math:`S.`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(r\right) & = & re^{-r^{2}/2}I_{[0,\infty)}\left(x\right)\\ F\left(r\right) & = & 1-e^{-r^{2}/2}I_{[0,\infty)}\left(x\right)\\ G\left(q\right) & = & \sqrt{-2\log\left(1-q\right)}\end{eqnarray*}
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} \mu & = & \sqrt{\frac{\pi}{2}}\\ \mu_{2} & = & \frac{4-\pi}{2}\\ \gamma_{1} & = & \frac{2\left(\pi-3\right)\sqrt{\pi}}{\left(4-\pi\right)^{3/2}}\\ \gamma_{2} & = & \frac{24\pi-6\pi^{2}-16}{\left(4-\pi\right)^{2}}\\ m_{d} & = & 1\\ m_{n} & = & \sqrt{2\log\left(2\right)}\end{eqnarray*}
-
-
+   \begin{aligned*}
+   f\left(r\right) & = & re^{-r^{2}/2}I_{[0,\infty)}\left(x\right)\\
+   F\left(r\right) & = & 1-e^{-r^{2}/2}I_{[0,\infty)}\left(x\right)\\
+   G\left(q\right) & = & \sqrt{-2\log\left(1-q\right)}\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \[ h\left[X\right]=\frac{\gamma}{2}+\log\left(\frac{e}{\sqrt{2}}\right).\]
+   \begin{aligned*}
+   \mu & = & \sqrt{\frac{\pi}{2}}\\
+   \mu_{2} & = & \frac{4-\pi}{2}\\
+   \gamma_{1} & = & \frac{2\left(\pi-3\right)\sqrt{\pi}}{\left(4-\pi\right)^{3/2}}\\
+   \gamma_{2} & = & \frac{24\pi-6\pi^{2}-16}{\left(4-\pi\right)^{2}}\\
+   m_{d} & = & 1\\
+   m_{n} & = & \sqrt{2\log\left(2\right)}\end{aligned*}
 
+.. math:: h\left[X\right]=\frac{\gamma}{2}+\log\left(\frac{e}{\sqrt{2}}\right).
 
+.. math:: \mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(\frac{n}{2}+1\right)
 
-
-
-.. math::
-   :nowrap:
-
-    \[ \mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(\frac{n}{2}+1\right)\]
-
-
-
-
-Rice*
-=====
+Rice\*
+======
 
 Defined for :math:`x>0` and :math:`b>0`
 
-
-
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;b\right) & = & x\exp\left(-\frac{x^{2}+b^{2}}{2}\right)I_{0}\left(xb\right)\\ F\left(x;b\right) & = & \int_{0}^{x}\alpha\exp\left(-\frac{\alpha^{2}+b^{2}}{2}\right)I_{0}\left(\alpha b\right)d\alpha\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;b\right) & = & x\exp\left(-\frac{x^{2}+b^{2}}{2}\right)I_{0}\left(xb\right)\\
+   F\left(x;b\right) & = & \int_{0}^{x}\alpha\exp\left(-\frac{\alpha^{2}+b^{2}}{2}\right)I_{0}\left(\alpha b\right)d\alpha\end{aligned*}
 
-
-
-
-
-.. math::
-   :nowrap:
-
-    \[ \mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(1+\frac{n}{2}\right)\,_{1}F_{1}\left(-\frac{n}{2};1;-\frac{b^{2}}{2}\right)\]
-
-
-
+.. math:: \mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(1+\frac{n}{2}\right)\,_{1}F_{1}\left(-\frac{n}{2};1;-\frac{b^{2}}{2}\right)
 
 Reciprocal
 ==========
@@ -2192,50 +1953,44 @@ Reciprocal
 Shape parameters :math:`a,b>0` :math:`x\in\left[a,b\right]`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;a,b\right) & = & \frac{1}{x\log\left(b/a\right)}\\ F\left(x;a,b\right) & = & \frac{\log\left(x/a\right)}{\log\left(b/a\right)}\\ G\left(q;a,b\right) & = & a\exp\left(q\log\left(b/a\right)\right)=a\left(\frac{b}{a}\right)^{q}\end{eqnarray*}
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} d & = & \log\left(a/b\right)\\ \mu & = & \frac{a-b}{d}\\ \mu_{2} & = & \mu\frac{a+b}{2}-\mu^{2}=\frac{\left(a-b\right)\left[a\left(d-2\right)+b\left(d+2\right)\right]}{2d^{2}}\\ \gamma_{1} & = & \frac{\sqrt{2}\left[12d\left(a-b\right)^{2}+d^{2}\left(a^{2}\left(2d-9\right)+2abd+b^{2}\left(2d+9\right)\right)\right]}{3d\sqrt{a-b}\left[a\left(d-2\right)+b\left(d+2\right)\right]^{3/2}}\\ \gamma_{2} & = & \frac{-36\left(a-b\right)^{3}+36d\left(a-b\right)^{2}\left(a+b\right)-16d^{2}\left(a^{3}-b^{3}\right)+3d^{3}\left(a^{2}+b^{2}\right)\left(a+b\right)}{3\left(a-b\right)\left[a\left(d-2\right)+b\left(d+2\right)\right]^{2}}-3\\ m_{d} & = & a\\ m_{n} & = & \sqrt{ab}\end{eqnarray*}
-
-
+   \begin{aligned*}
+   f\left(x;a,b\right) & = & \frac{1}{x\log\left(b/a\right)}\\
+   F\left(x;a,b\right) & = & \frac{\log\left(x/a\right)}{\log\left(b/a\right)}\\
+   G\left(q;a,b\right) & = & a\exp\left(q\log\left(b/a\right)\right)=a\left(\frac{b}{a}\right)^{q}\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \[ h\left[X\right]=\frac{1}{2}\log\left(ab\right)+\log\left[\log\left(\frac{b}{a}\right)\right].\]
+   \begin{aligned*}
+   d & = & \log\left(a/b\right)\\
+   \mu & = & \frac{a-b}{d}\\
+   \mu_{2} & = & \mu\frac{a+b}{2}-\mu^{2}=\frac{\left(a-b\right)\left[a\left(d-2\right)+b\left(d+2\right)\right]}{2d^{2}}\\
+   \gamma_{1} & = & \frac{\sqrt{2}\left[12d\left(a-b\right)^{2}+d^{2}\left(a^{2}\left(2d-9\right)+2abd+b^{2}\left(2d+9\right)\right)\right]}{3d\sqrt{a-b}\left[a\left(d-2\right)+b\left(d+2\right)\right]^{3/2}}\\
+   \gamma_{2} & = & \frac{-36\left(a-b\right)^{3}+36d\left(a-b\right)^{2}\left(a+b\right)-16d^{2}\left(a^{3}-b^{3}\right)+3d^{3}\left(a^{2}+b^{2}\right)\left(a+b\right)}{3\left(a-b\right)\left[a\left(d-2\right)+b\left(d+2\right)\right]^{2}}-3\\
+   m_{d} & = & a\\
+   m_{n} & = & \sqrt{ab}\end{aligned*}
 
+.. math:: h\left[X\right]=\frac{1}{2}\log\left(ab\right)+\log\left[\log\left(\frac{b}{a}\right)\right].
 
+Reciprocal Inverse Gaussian 
+============================
 
-
-Reciprocal Inverse Gaussian
-===========================
-
-The pdf is found from the inverse gaussian (IG), :math:`f_{RIG}\left(x;\mu\right)=\frac{1}{x^{2}}f_{IG}\left(\frac{1}{x};\mu\right)` defined for :math:`x\geq0` as
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f_{IG}\left(x;\mu\right) & = & \frac{1}{\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-\mu\right)^{2}}{2x\mu^{2}}\right).\\ F_{IG}\left(x;\mu\right) & = & \Phi\left(\frac{1}{\sqrt{x}}\frac{x-\mu}{\mu}\right)+\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{x+\mu}{\mu}\right)\end{eqnarray*}
-
-
-
-
+The pdf is found from the inverse gaussian (IG),
+:math:`f_{RIG}\left(x;\mu\right)=\frac{1}{x^{2}}f_{IG}\left(\frac{1}{x};\mu\right)`
+defined for :math:`x\geq0` as
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f_{RIG}\left(x;\mu\right) & = & \frac{1}{\sqrt{2\pi x}}\exp\left(-\frac{\left(1-\mu x\right)^{2}}{2x\mu^{2}}\right)\\ F_{RIG}\left(x;\mu\right) & = & 1-F_{IG}\left(\frac{1}{x},\mu\right)\\  & = & 1-\Phi\left(\frac{1}{\sqrt{x}}\frac{1-\mu x}{\mu}\right)-\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{1+\mu x}{\mu}\right)\end{eqnarray*}
+   \begin{aligned*}
+   f_{IG}\left(x;\mu\right) & = & \frac{1}{\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-\mu\right)^{2}}{2x\mu^{2}}\right).\\
+   F_{IG}\left(x;\mu\right) & = & \Phi\left(\frac{1}{\sqrt{x}}\frac{x-\mu}{\mu}\right)+\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{x+\mu}{\mu}\right)\end{aligned*}
 
+.. math::
 
-
+   \begin{aligned*}
+   f_{RIG}\left(x;\mu\right) & = & \frac{1}{\sqrt{2\pi x}}\exp\left(-\frac{\left(1-\mu x\right)^{2}}{2x\mu^{2}}\right)\\
+   F_{RIG}\left(x;\mu\right) & = & 1-F_{IG}\left(\frac{1}{x},\mu\right)\\
+    & = & 1-\Phi\left(\frac{1}{\sqrt{x}}\frac{1-\mu x}{\mu}\right)-\exp\left(\frac{2}{\mu}\right)\Phi\left(-\frac{1}{\sqrt{x}}\frac{1+\mu x}{\mu}\right)\end{aligned*}
 
 Semicircular
 ============
@@ -2243,70 +1998,61 @@ Semicircular
 Defined on :math:`x\in\left[-1,1\right]`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \frac{2}{\pi}\sqrt{1-x^{2}}\\ F\left(x\right) & = & \frac{1}{2}+\frac{1}{\pi}\left[x\sqrt{1-x^{2}}+\arcsin x\right]\\ G\left(q\right) & = & F^{-1}\left(q\right)\end{eqnarray*}
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} m_{d}=m_{n}=\mu & = & 0\\ \mu_{2} & = & \frac{1}{4}\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & -1\end{eqnarray*}
-
-
+   \begin{aligned*}
+   f\left(x\right) & = & \frac{2}{\pi}\sqrt{1-x^{2}}\\
+   F\left(x\right) & = & \frac{1}{2}+\frac{1}{\pi}\left[x\sqrt{1-x^{2}}+\arcsin x\right]\\
+   G\left(q\right) & = & F^{-1}\left(q\right)\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \[ h\left[X\right]=0.64472988584940017414.\]
+   \begin{aligned*}
+   m_{d}=m_{n}=\mu & = & 0\\
+   \mu_{2} & = & \frac{1}{4}\\
+   \gamma_{1} & = & 0\\
+   \gamma_{2} & = & -1\end{aligned*}
 
+.. math:: h\left[X\right]=0.64472988584940017414.
 
-
-
-Studentized Range*
-==================
-
+Studentized Range\*
+===================
 
 Student t
 =========
 
-Shape parameter :math:`\nu>0.` :math:`I\left(a,b,x\right)` is the incomplete beta integral and :math:`I^{-1}\left(a,b,I\left(a,b,x\right)\right)=x`
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x;\nu\right) & = & \frac{\Gamma\left(\frac{\nu+1}{2}\right)}{\sqrt{\pi\nu}\Gamma\left(\frac{\nu}{2}\right)\left[1+\frac{x^{2}}{\nu}\right]^{\frac{\nu+1}{2}}}\\ F\left(x;\nu\right) & = & \left\{ \begin{array}{ccc} \frac{1}{2}I\left(\frac{\nu}{2},\frac{1}{2},\frac{\nu}{\nu+x^{2}}\right) &  & x\leq0\\ 1-\frac{1}{2}I\left(\frac{\nu}{2},\frac{1}{2},\frac{\nu}{\nu+x^{2}}\right) &  & x\geq0\end{array}\right.\\ G\left(q;\nu\right) & = & \left\{ \begin{array}{ccc} -\sqrt{\frac{\nu}{I^{-1}\left(\frac{\nu}{2},\frac{1}{2},2q\right)}-\nu} &  & q\leq\frac{1}{2}\\ \sqrt{\frac{\nu}{I^{-1}\left(\frac{\nu}{2},\frac{1}{2},2-2q\right)}-\nu} &  & q\geq\frac{1}{2}\end{array}\right.\end{eqnarray*}
-
-
-
-
+Shape parameter :math:`\nu>0.` :math:`I\left(a,b,x\right)` is the
+incomplete beta integral and
+:math:`I^{-1}\left(a,b,I\left(a,b,x\right)\right)=x`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} m_{n}=m_{d}=\mu & = & 0\\ \mu_{2} & = & \frac{\nu}{\nu-2}\quad\nu>2\\ \gamma_{1} & = & 0\quad\nu>3\\ \gamma_{2} & = & \frac{6}{\nu-4}\quad\nu>4\end{eqnarray*}
-
-As :math:`\nu\rightarrow\infty,` this distribution approaches the standard normal distribution.
-
-
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]=\frac{1}{4}\log\left(\frac{\pi c\Gamma^{2}\left(\frac{c}{2}\right)}{\Gamma^{2}\left(\frac{c+1}{2}\right)}\right)-\frac{\left(c+1\right)}{4}\left[\Psi\left(\frac{c}{2}\right)-cZ\left(c\right)+\pi\tan\left(\frac{\pi c}{2}\right)+\gamma+2\log2\right]\]
-
-where
+   \begin{aligned*}
+   f\left(x;\nu\right) & = & \frac{\Gamma\left(\frac{\nu+1}{2}\right)}{\sqrt{\pi\nu}\Gamma\left(\frac{\nu}{2}\right)\left[1+\frac{x^{2}}{\nu}\right]^{\frac{\nu+1}{2}}}\\
+   F\left(x;\nu\right) & = & \left\{ \begin{array}{ccc}
+   \frac{1}{2}I\left(\frac{\nu}{2},\frac{1}{2},\frac{\nu}{\nu+x^{2}}\right) &  & x\leq0\\
+   1-\frac{1}{2}I\left(\frac{\nu}{2},\frac{1}{2},\frac{\nu}{\nu+x^{2}}\right) &  & x\geq0
+   \end{array}\right.\\
+   G\left(q;\nu\right) & = & \left\{ \begin{array}{ccc}
+   -\sqrt{\frac{\nu}{I^{-1}\left(\frac{\nu}{2},\frac{1}{2},2q\right)}-\nu} &  & q\leq\frac{1}{2}\\
+   \sqrt{\frac{\nu}{I^{-1}\left(\frac{\nu}{2},\frac{1}{2},2-2q\right)}-\nu} &  & q\geq\frac{1}{2}
+   \end{array}\right.\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \[ Z\left(c\right)=\,_{3}F_{2}\left(1,1,1+\frac{c}{2};\frac{3}{2},2;1\right)=\sum_{k=0}^{\infty}\frac{k!}{k+1}\frac{\Gamma\left(\frac{c}{2}+1+k\right)}{\Gamma\left(\frac{c}{2}+1\right)}\frac{\Gamma\left(\frac{3}{2}\right)}{\Gamma\left(\frac{3}{2}+k\right)}\]
+   \begin{aligned*}
+   m_{n}=m_{d}=\mu & = & 0\\
+   \mu_{2} & = & \frac{\nu}{\nu-2}\quad\nu>2\\
+   \gamma_{1} & = & 0\quad\nu>3\\
+   \gamma_{2} & = & \frac{6}{\nu-4}\quad\nu>4\end{aligned*}
 
+As :math:`\nu\rightarrow\infty,` this distribution approaches the
+standard normal distribution.
 
+.. math:: h\left[X\right]=\frac{1}{4}\log\left(\frac{\pi c\Gamma^{2}\left(\frac{c}{2}\right)}{\Gamma^{2}\left(\frac{c+1}{2}\right)}\right)-\frac{\left(c+1\right)}{4}\left[\Psi\left(\frac{c}{2}\right)-cZ\left(c\right)+\pi\tan\left(\frac{\pi c}{2}\right)+\gamma+2\log2\right]
 
+ where
+
+.. math:: Z\left(c\right)=\,_{3}F_{2}\left(1,1,1+\frac{c}{2};\frac{3}{2},2;1\right)=\sum_{k=0}^{\infty}\frac{k!}{k+1}\frac{\Gamma\left(\frac{c}{2}+1+k\right)}{\Gamma\left(\frac{c}{2}+1\right)}\frac{\Gamma\left(\frac{3}{2}\right)}{\Gamma\left(\frac{3}{2}+k\right)}
 
 Student Z
 =========
@@ -2315,229 +2061,222 @@ The student Z distriubtion is defined over all space with one shape
 parameter :math:`\nu>0`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;\nu\right) & = & \frac{\Gamma\left(\frac{\nu}{2}\right)}{\sqrt{\pi}\Gamma\left(\frac{\nu-1}{2}\right)}\left(1+x^{2}\right)^{-\nu/2}\\ F\left(x;\nu\right) & = & \left\{ \begin{array}{ccc} Q\left(x;\nu\right) &  & x\leq0\\ 1-Q\left(x;\nu\right) &  & x\geq0\end{array}\right.\\ Q\left(x;\nu\right) & = & \frac{\left|x\right|^{1-n}\Gamma\left(\frac{n}{2}\right)\,_{2}F_{1}\left(\frac{n-1}{2},\frac{n}{2};\frac{n+1}{2};-\frac{1}{x^{2}}\right)}{2\sqrt{\pi}\Gamma\left(\frac{n+1}{2}\right)}\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;\nu\right) & = & \frac{\Gamma\left(\frac{\nu}{2}\right)}{\sqrt{\pi}\Gamma\left(\frac{\nu-1}{2}\right)}\left(1+x^{2}\right)^{-\nu/2}\\
+   F\left(x;\nu\right) & = & \left\{ \begin{array}{ccc}
+   Q\left(x;\nu\right) &  & x\leq0\\
+   1-Q\left(x;\nu\right) &  & x\geq0
+   \end{array}\right.\\
+   Q\left(x;\nu\right) & = & \frac{\left|x\right|^{1-n}\Gamma\left(\frac{n}{2}\right)\,_{2}F_{1}\left(\frac{n-1}{2},\frac{n}{2};\frac{n+1}{2};-\frac{1}{x^{2}}\right)}{2\sqrt{\pi}\Gamma\left(\frac{n+1}{2}\right)}\end{aligned*}
 
 Interesting moments are
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & 0\\ \sigma^{2} & = & \frac{1}{\nu-3}\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & \frac{6}{\nu-5}.\end{eqnarray*}
+   \begin{aligned*}
+   \mu & = & 0\\
+   \sigma^{2} & = & \frac{1}{\nu-3}\\
+   \gamma_{1} & = & 0\\
+   \gamma_{2} & = & \frac{6}{\nu-5}.\end{aligned*}
 
 The moment generating function is
 
-.. math::
-   :nowrap:
+.. math:: \theta\left(t\right)=2\sqrt{\left|\frac{t}{2}\right|^{\nu-1}}\frac{K_{\left(n-1\right)/2}\left(\left|t\right|\right)}{\Gamma\left(\frac{\nu-1}{2}\right)}.
 
-    \[ \theta\left(t\right)=2\sqrt{\left|\frac{t}{2}\right|^{\nu-1}}\frac{K_{\left(n-1\right)/2}\left(\left|t\right|\right)}{\Gamma\left(\frac{\nu-1}{2}\right)}.\]
-
-
-
-
-Symmetric Power*
-================
-
+Symmetric Power\*
+=================
 
 Triangular
 ==========
 
-One shape parameter :math:`c\in[0,1]` giving the distance to the peak as a percentage of the total extent of
-the non-zero portion. The location parameter is the start of the non-
-zero portion, and the scale-parameter is the width of the non-zero
-portion. In standard form we have :math:`x\in\left[0,1\right].`
+One shape parameter :math:`c\in[0,1]` giving the distance to the peak as
+a percentage of the total extent of the non-zero portion. The location
+parameter is the start of the non-zero portion, and the scale-parameter
+is the width of the non-zero portion. In standard form we have
+:math:`x\in\left[0,1\right].`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & \left\{ \begin{array}{ccc} 2\frac{x}{c} &  & x<c\\ 2\frac{1-x}{1-c} &  & x\geq c\end{array}\right.\\ F\left(x;c\right) & = & \left\{ \begin{array}{ccc} \frac{x^{2}}{c} &  & x<c\\ \frac{x^{2}-2x+c}{c-1} &  & x\geq c\end{array}\right.\\ G\left(q;c\right) & = & \left\{ \begin{array}{ccc} \sqrt{cq} &  & q<c\\ 1-\sqrt{\left(1-c\right)\left(1-q\right)} &  & q\geq c\end{array}\right.\end{eqnarray*}
-
-
+   \begin{aligned*}
+   f\left(x;c\right) & = & \left\{ \begin{array}{ccc}
+   2\frac{x}{c} &  & x<c\\
+   2\frac{1-x}{1-c} &  & x\geq c
+   \end{array}\right.\\
+   F\left(x;c\right) & = & \left\{ \begin{array}{ccc}
+   \frac{x^{2}}{c} &  & x<c\\
+   \frac{x^{2}-2x+c}{c-1} &  & x\geq c
+   \end{array}\right.\\
+   G\left(q;c\right) & = & \left\{ \begin{array}{ccc}
+   \sqrt{cq} &  & q<c\\
+   1-\sqrt{\left(1-c\right)\left(1-q\right)} &  & q\geq c
+   \end{array}\right.\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \frac{c}{3}+\frac{1}{3}\\ \mu_{2} & = & \frac{1-c+c^{2}}{18}\\ \gamma_{1} & = & \frac{\sqrt{2}\left(2c-1\right)\left(c+1\right)\left(c-2\right)}{5\left(1-c+c^{2}\right)^{3/2}}\\ \gamma_{2} & = & -\frac{3}{5}\end{eqnarray*}
-
-
+   \begin{aligned*}
+   \mu & = & \frac{c}{3}+\frac{1}{3}\\
+   \mu_{2} & = & \frac{1-c+c^{2}}{18}\\
+   \gamma_{1} & = & \frac{\sqrt{2}\left(2c-1\right)\left(c+1\right)\left(c-2\right)}{5\left(1-c+c^{2}\right)^{3/2}}\\
+   \gamma_{2} & = & -\frac{3}{5}\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} h\left(X\right) & = & \log\left(\frac{1}{2}\sqrt{e}\right)\\  & \approx & -0.19314718055994530942.\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   h\left(X\right) & = & \log\left(\frac{1}{2}\sqrt{e}\right)\\
+    & \approx & -0.19314718055994530942.\end{aligned*}
 
 Truncated Exponential
 =====================
 
-This is an exponential distribution defined only over a certain region :math:`0<x<B` . In standard form this is
+This is an exponential distribution defined only over a certain region
+:math:`0<x<B`\ . In standard form this is
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;B\right) & = & \frac{e^{-x}}{1-e^{-B}}\\ F\left(x;B\right) & = & \frac{1-e^{-x}}{1-e^{-B}}\\ G\left(q;B\right) & = & -\log\left(1-q+qe^{-B}\right)\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;B\right) & = & \frac{e^{-x}}{1-e^{-B}}\\
+   F\left(x;B\right) & = & \frac{1-e^{-x}}{1-e^{-B}}\\
+   G\left(q;B\right) & = & -\log\left(1-q+qe^{-B}\right)\end{aligned*}
 
+.. math:: \mu_{n}^{\prime}=\Gamma\left(1+n\right)-\Gamma\left(1+n,B\right)
 
-
-.. math::
-   :nowrap:
-
-    \[ \mu_{n}^{\prime}=\Gamma\left(1+n\right)-\Gamma\left(1+n,B\right)\]
-
-
-
-
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]=\log\left(e^{B}-1\right)+\frac{1+e^{B}\left(B-1\right)}{1-e^{B}}.\]
-
-
-
+.. math:: h\left[X\right]=\log\left(e^{B}-1\right)+\frac{1+e^{B}\left(B-1\right)}{1-e^{B}}.
 
 Truncated Normal
 ================
 
-A normal distribution restricted to lie within a certain range given
-by two parameters :math:`A` and :math:`B` . Notice that this :math:`A` and :math:`B` correspond to the bounds on :math:`x` in standard form. For :math:`x\in\left[A,B\right]` we get
+A normal distribution restricted to lie within a certain range given by
+two parameters :math:`A` and :math:`B`\ . Notice that this :math:`A` and
+:math:`B` correspond to the bounds on :math:`x` in standard form. For
+:math:`x\in\left[A,B\right]` we get
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;A,B\right) & = & \frac{\phi\left(x\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\\ F\left(x;A,B\right) & = & \frac{\Phi\left(x\right)-\Phi\left(A\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\\ G\left(q;A,B\right) & = & \Phi^{-1}\left[q\Phi\left(B\right)+\Phi\left(A\right)\left(1-q\right)\right]\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;A,B\right) & = & \frac{\phi\left(x\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\\
+   F\left(x;A,B\right) & = & \frac{\Phi\left(x\right)-\Phi\left(A\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\\
+   G\left(q;A,B\right) & = & \Phi^{-1}\left[q\Phi\left(B\right)+\Phi\left(A\right)\left(1-q\right)\right]\end{aligned*}
 
 where
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \phi\left(x\right) & = & \frac{1}{\sqrt{2\pi}}e^{-x^{2}/2}\\ \Phi\left(x\right) & = & \int_{-\infty}^{x}\phi\left(u\right)du.\end{eqnarray*}
-
-
+   \begin{aligned*}
+   \phi\left(x\right) & = & \frac{1}{\sqrt{2\pi}}e^{-x^{2}/2}\\
+   \Phi\left(x\right) & = & \int_{-\infty}^{x}\phi\left(u\right)du.\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \frac{\phi\left(A\right)-\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\\ \mu_{2} & = & 1+\frac{A\phi\left(A\right)-B\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}-\left(\frac{\phi\left(A\right)-\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\right)^{2}\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   \mu & = & \frac{\phi\left(A\right)-\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\\
+   \mu_{2} & = & 1+\frac{A\phi\left(A\right)-B\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}-\left(\frac{\phi\left(A\right)-\phi\left(B\right)}{\Phi\left(B\right)-\Phi\left(A\right)}\right)^{2}\end{aligned*}
 
 Tukey-Lambda
 ============
 
+.. math::
 
+   \begin{aligned*}
+   f\left(x;\lambda\right) & = & F^{\prime}\left(x;\lambda\right)=\frac{1}{G^{\prime}\left(F\left(x;\lambda\right);\lambda\right)}=\frac{1}{F^{\lambda-1}\left(x;\lambda\right)+\left[1-F\left(x;\lambda\right)\right]^{\lambda-1}}\\
+   F\left(x;\lambda\right) & = & G^{-1}\left(x;\lambda\right)\\
+   G\left(p;\lambda\right) & = & \frac{p^{\lambda}-\left(1-p\right)^{\lambda}}{\lambda}\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;\lambda\right) & = & F^{\prime}\left(x;\lambda\right)=\frac{1}{G^{\prime}\left(F\left(x;\lambda\right);\lambda\right)}=\frac{1}{F^{\lambda-1}\left(x;\lambda\right)+\left[1-F\left(x;\lambda\right)\right]^{\lambda-1}}\\ F\left(x;\lambda\right) & = & G^{-1}\left(x;\lambda\right)\\ G\left(p;\lambda\right) & = & \frac{p^{\lambda}-\left(1-p\right)^{\lambda}}{\lambda}\end{eqnarray*}
+   \begin{aligned*}
+   \mu & = & 0\\
+   \mu_{2} & = & \int_{0}^{1}G^{2}\left(p;\lambda\right)dp\\
+    & = & \frac{2\Gamma\left(\lambda+\frac{3}{2}\right)-\lambda4^{-\lambda}\sqrt{\pi}\Gamma\left(\lambda\right)\left(1-2\lambda\right)}{\lambda^{2}\left(1+2\lambda\right)\Gamma\left(\lambda+\frac{3}{2}\right)}\\
+   \gamma_{1} & = & 0\\
+   \gamma_{2} & = & \frac{\mu_{4}}{\mu_{2}^{2}}-3\\
+   \mu_{4} & = & \frac{3\Gamma\left(\lambda\right)\Gamma\left(\lambda+\frac{1}{2}\right)2^{-2\lambda}}{\lambda^{3}\Gamma\left(2\lambda+\frac{3}{2}\right)}+\frac{2}{\lambda^{4}\left(1+4\lambda\right)}\\
+    &  & -\frac{2\sqrt{3}\Gamma\left(\lambda\right)2^{-6\lambda}3^{3\lambda}\Gamma\left(\lambda+\frac{1}{3}\right)\Gamma\left(\lambda+\frac{2}{3}\right)}{\lambda^{3}\Gamma\left(2\lambda+\frac{3}{2}\right)\Gamma\left(\lambda+\frac{1}{2}\right)}.\end{aligned*}
 
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} \mu & = & 0\\ \mu_{2} & = & \int_{0}^{1}G^{2}\left(p;\lambda\right)dp\\  & = & \frac{2\Gamma\left(\lambda+\frac{3}{2}\right)-\lambda4^{-\lambda}\sqrt{\pi}\Gamma\left(\lambda\right)\left(1-2\lambda\right)}{\lambda^{2}\left(1+2\lambda\right)\Gamma\left(\lambda+\frac{3}{2}\right)}\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & \frac{\mu_{4}}{\mu_{2}^{2}}-3\\ \mu_{4} & = & \frac{3\Gamma\left(\lambda\right)\Gamma\left(\lambda+\frac{1}{2}\right)2^{-2\lambda}}{\lambda^{3}\Gamma\left(2\lambda+\frac{3}{2}\right)}+\frac{2}{\lambda^{4}\left(1+4\lambda\right)}\\  &  & -\frac{2\sqrt{3}\Gamma\left(\lambda\right)2^{-6\lambda}3^{3\lambda}\Gamma\left(\lambda+\frac{1}{3}\right)\Gamma\left(\lambda+\frac{2}{3}\right)}{\lambda^{3}\Gamma\left(2\lambda+\frac{3}{2}\right)\Gamma\left(\lambda+\frac{1}{2}\right)}.\end{eqnarray*}
-
-Notice that the :math:`\lim_{\lambda\rightarrow0}G\left(p;\lambda\right)=\log\left(p/\left(1-p\right)\right)`
-
-
+Notice that the
+:math:`\lim_{\lambda\rightarrow0}G\left(p;\lambda\right)=\log\left(p/\left(1-p\right)\right)`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} h\left[X\right] & = & \int_{0}^{1}\log\left[G^{\prime}\left(p\right)\right]dp\\  & = & \int_{0}^{1}\log\left[p^{\lambda-1}+\left(1-p\right)^{\lambda-1}\right]dp.\end{eqnarray*}
-
-
-
+   \begin{aligned*}
+   h\left[X\right] & = & \int_{0}^{1}\log\left[G^{\prime}\left(p\right)\right]dp\\
+    & = & \int_{0}^{1}\log\left[p^{\lambda-1}+\left(1-p\right)^{\lambda-1}\right]dp.\end{aligned*}
 
 Uniform
 =======
 
-Standard form :math:`x\in\left(0,1\right).` In general form, the lower limit is :math:`L,` the upper limit is :math:`S+L.`
-
-
-
-.. math::
-   :nowrap:
-
-    \begin{eqnarray*} f\left(x\right) & = & 1\\ F\left(x\right) & = & x\\ G\left(q\right) & = & q\end{eqnarray*}
-
-
+Standard form :math:`x\in\left(0,1\right).` In general form, the lower
+limit is :math:`L,` the upper limit is :math:`S+L.`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & \frac{1}{2}\\ \mu_{2} & = & \frac{1}{12}\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & -\frac{6}{5}\end{eqnarray*}
-
-
+   \begin{aligned*}
+   f\left(x\right) & = & 1\\
+   F\left(x\right) & = & x\\
+   G\left(q\right) & = & q\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \[ h\left[X\right]=0\]
+   \begin{aligned*}
+   \mu & = & \frac{1}{2}\\
+   \mu_{2} & = & \frac{1}{12}\\
+   \gamma_{1} & = & 0\\
+   \gamma_{2} & = & -\frac{6}{5}\end{aligned*}
 
-
-
+.. math:: h\left[X\right]=0
 
 Von Mises
 =========
 
-Defined for :math:`x\in\left[-\pi,\pi\right]` with shape parameter :math:`b>0` . Note, the PDF and CDF functions are periodic and are always defined
-over :math:`x\in\left[-\pi,\pi\right]` regardless of the location parameter. Thus, if an input beyond this
-range is given, it is converted to the equivalent angle in this range.
-For values of :math:`b<100` the PDF and CDF formulas below are used. Otherwise, a normal
-approximation with variance :math:`1/b` is used.
+Defined for :math:`x\in\left[-\pi,\pi\right]` with shape parameter
+:math:`b>0`\ . Note, the PDF and CDF functions are periodic and are
+always defined over :math:`x\in\left[-\pi,\pi\right]` regardless of the
+location parameter. Thus, if an input beyond this range is given, it is
+converted to the equivalent angle in this range. For values of
+:math:`b<100` the PDF and CDF formulas below are used. Otherwise, a
+normal approximation with variance :math:`1/b` is used.
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;b\right) & = & \frac{e^{b\cos x}}{2\pi I_{0}\left(b\right)}\\ F\left(x;b\right) & = & \frac{1}{2}+\frac{x}{2\pi}+\sum_{k=1}^{\infty}\frac{I_{k}\left(b\right)\sin\left(kx\right)}{I_{0}\left(b\right)\pi k}\\ G\left(q;b\right) & = & F^{-1}\left(x;b\right)\end{eqnarray*}
-
-
-
-
+   \begin{aligned*}
+   f\left(x;b\right) & = & \frac{e^{b\cos x}}{2\pi I_{0}\left(b\right)}\\
+   F\left(x;b\right) & = & \frac{1}{2}+\frac{x}{2\pi}+\sum_{k=1}^{\infty}\frac{I_{k}\left(b\right)\sin\left(kx\right)}{I_{0}\left(b\right)\pi k}\\
+   G\left(q;b\right) & = & F^{-1}\left(x;b\right)\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & 0\\ \mu_{2} & = & \int_{-\pi}^{\pi}x^{2}f\left(x;b\right)dx\\ \gamma_{1} & = & 0\\ \gamma_{2} & = & \frac{\int_{-\pi}^{\pi}x^{4}f\left(x;b\right)dx}{\mu_{2}^{2}}-3\end{eqnarray*}
+   \begin{aligned*}
+   \mu & = & 0\\
+   \mu_{2} & = & \int_{-\pi}^{\pi}x^{2}f\left(x;b\right)dx\\
+   \gamma_{1} & = & 0\\
+   \gamma_{2} & = & \frac{\int_{-\pi}^{\pi}x^{4}f\left(x;b\right)dx}{\mu_{2}^{2}}-3\end{aligned*}
 
 This can be used for defining circular variance.
 
+Wald 
+=====
 
-Wald
-====
-
-Special case of the Inverse Normal with shape parameter set to :math:`1.0` . Defined for :math:`x>0` .
-
-
+Special case of the Inverse Normal with shape parameter set to
+:math:`1.0`\ . Defined for :math:`x>0`\ .
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x\right) & = & \frac{1}{\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-1\right)^{2}}{2x}\right).\\ F\left(x\right) & = & \Phi\left(\frac{x-1}{\sqrt{x}}\right)+\exp\left(2\right)\Phi\left(-\frac{x+1}{\sqrt{x}}\right)\\ G\left(q;\mu\right) & = & F^{-1}\left(q;\mu\right)\end{eqnarray*}
-
-
-
-
+   \begin{aligned*}
+   f\left(x\right) & = & \frac{1}{\sqrt{2\pi x^{3}}}\exp\left(-\frac{\left(x-1\right)^{2}}{2x}\right).\\
+   F\left(x\right) & = & \Phi\left(\frac{x-1}{\sqrt{x}}\right)+\exp\left(2\right)\Phi\left(-\frac{x+1}{\sqrt{x}}\right)\\
+   G\left(q;\mu\right) & = & F^{-1}\left(q;\mu\right)\end{aligned*}
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} \mu & = & 1\\ \mu_{2} & = & 1\\ \gamma_{1} & = & 3\\ \gamma_{2} & = & 15\\ m_{d} & = & \frac{1}{2}\left(\sqrt{13}-3\right)\end{eqnarray*}
+   \begin{aligned*}
+   \mu & = & 1\\
+   \mu_{2} & = & 1\\
+   \gamma_{1} & = & 3\\
+   \gamma_{2} & = & 15\\
+   m_{d} & = & \frac{1}{2}\left(\sqrt{13}-3\right)\end{aligned*}
 
-
-
-
-Wishart*
-========
-
+Wishart\*
+=========
 
 Wrapped Cauchy
 ==============
@@ -2545,20 +2284,22 @@ Wrapped Cauchy
 For :math:`x\in\left[0,2\pi\right]` :math:`c\in\left(0,1\right)`
 
 .. math::
-   :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & \frac{1-c^{2}}{2\pi\left(1+c^{2}-2c\cos x\right)}\\ g_{c}\left(x\right) & = & \frac{1}{\pi}\arctan\left[\frac{1+c}{1-c}\tan\left(\frac{x}{2}\right)\right]\\ r_{c}\left(q\right) & = & 2\arctan\left[\frac{1-c}{1+c}\tan\left(\pi q\right)\right]\\ F\left(x;c\right) & = & \left\{ \begin{array}{ccc} g_{c}\left(x\right) &  & 0\leq x<\pi\\ 1-g_{c}\left(2\pi-x\right) &  & \pi\leq x\leq2\pi\end{array}\right.\\ G\left(q;c\right) & = & \left\{ \begin{array}{ccc} r_{c}\left(q\right) &  & 0\leq q<\frac{1}{2}\\ 2\pi-r_{c}\left(1-q\right) &  & \frac{1}{2}\leq q\leq1\end{array}\right.\end{eqnarray*}
+   \begin{aligned*}
+   f\left(x;c\right) & = & \frac{1-c^{2}}{2\pi\left(1+c^{2}-2c\cos x\right)}\\
+   g_{c}\left(x\right) & = & \frac{1}{\pi}\arctan\left[\frac{1+c}{1-c}\tan\left(\frac{x}{2}\right)\right]\\
+   r_{c}\left(q\right) & = & 2\arctan\left[\frac{1-c}{1+c}\tan\left(\pi q\right)\right]\\
+   F\left(x;c\right) & = & \left\{ \begin{array}{ccc}
+   g_{c}\left(x\right) &  & 0\leq x<\pi\\
+   1-g_{c}\left(2\pi-x\right) &  & \pi\leq x\leq2\pi
+   \end{array}\right.\\
+   G\left(q;c\right) & = & \left\{ \begin{array}{ccc}
+   r_{c}\left(q\right) &  & 0\leq q<\frac{1}{2}\\
+   2\pi-r_{c}\left(1-q\right) &  & \frac{1}{2}\leq q\leq1
+   \end{array}\right.\end{aligned*}
+
+.. math:: 
+
+.. math:: h\left[X\right]=\log\left(2\pi\left(1-c^{2}\right)\right).
 
 
-
-.. math::
-   :nowrap:
-
-    \[ \]
-
-
-
-.. math::
-   :nowrap:
-
-    \[ h\left[X\right]=\log\left(2\pi\left(1-c^{2}\right)\right).\]

--- a/doc/source/tutorial/stats/continuous.rst
+++ b/doc/source/tutorial/stats/continuous.rst
@@ -47,14 +47,14 @@ Non-central moments are defined using the PDF
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\int_{-\infty}^{\infty}x^{n}f\left(x\right)dx.\]
+     \mu_{n}^{\prime}=\int_{-\infty}^{\infty}x^{n}f\left(x\right)dx.
 
 Note, that these can always be computed using the PPF. Substitute :math:`x=G\left(q\right)` in the above equation and get
 
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\int_{0}^{1}G^{n}\left(q\right)dq\]
+     \mu_{n}^{\prime}=\int_{0}^{1}G^{n}\left(q\right)dq
 
 which may be easier to compute numerically. Note that :math:`q=F\left(x\right)` so that :math:`dq=f\left(x\right)dx.` Central moments are computed similarly :math:`\mu=\mu_{1}^{\prime}`
 
@@ -75,14 +75,14 @@ Skewness is defined as
 .. math::
    :nowrap:
 
-    \[ \gamma_{1}=\sqrt{\beta_{1}}=\frac{\mu_{3}}{\mu_{2}^{3/2}}\]
+     \gamma_{1}=\sqrt{\beta_{1}}=\frac{\mu_{3}}{\mu_{2}^{3/2}}
 
 while (Fisher) kurtosis is
 
 .. math::
    :nowrap:
 
-    \[ \gamma_{2}=\frac{\mu_{4}}{\mu_{2}^{2}}-3,\]
+     \gamma_{2}=\frac{\mu_{4}}{\mu_{2}^{2}}-3,
 
 so that a normal distribution has a kurtosis of zero.
 
@@ -96,7 +96,7 @@ and half on the other. In other words, :math:`F\left(m_{n}\right)=\frac{1}{2}` s
 .. math::
    :nowrap:
 
-    \[ m_{n}=G\left(\frac{1}{2}\right).\]
+     m_{n}=G\left(\frac{1}{2}\right).
 
 In addition, the mode, :math:`m_{d}` , is defined as the value for which the probability density function
 reaches it's peak
@@ -104,7 +104,7 @@ reaches it's peak
 .. math::
    :nowrap:
 
-    \[ m_{d}=\arg\max_{x}f\left(x\right).\]
+     m_{d}=\arg\max_{x}f\left(x\right).
 
 
 
@@ -123,7 +123,7 @@ random vector :math:`\mathbf{x}` is
 .. math::
    :nowrap:
 
-    \[ f\left(\mathbf{x};\boldsymbol{\theta}\right)=\prod_{i=1}^{N}f\left(x_{i};\boldsymbol{\theta}\right).\]
+     f\left(\mathbf{x};\boldsymbol{\theta}\right)=\prod_{i=1}^{N}f\left(x_{i};\boldsymbol{\theta}\right).
 
 The maximum likelihood estimate of the parameters :math:`\boldsymbol{\theta}` are the parameters which maximize this function with :math:`\mathbf{x}` fixed and given by the data:
 
@@ -173,9 +173,28 @@ We will use
 .. math::
    :nowrap:
 
-    \[ \overline{y\left(\mathbf{x}\right)}=\frac{1}{N}\sum_{i=1}^{N}y\left(x_{i}\right)\]
+    \overline{y\left(\mathbf{x}\right)}=\frac{1}{N}\sum_{i=1}^{N}y\left(x_{i}\right)
 
 where :math:`N` should be clear from context as the number of samples :math:`x_{i}`
+
+References
+----------
+
+-  Documentation for ranlib, rv2, cdflib
+
+-  Eric Weisstein~s world of mathematics http://mathworld.wolfram.com/,
+   http://mathworld.wolfram.com/topics/StatisticalDistributions.html
+
+-  Documentation to Regress+ by Michael McLaughlin item Engineering and
+   Statistics Handbook (NIST),
+   http://www.itl.nist.gov/div898/handbook/index.htm
+
+-  Documentation for DATAPLOT from NIST,
+   http://www.itl.nist.gov/div898/software/dataplot/distribu.htm
+
+-  Norman Johnson, Samuel Kotz, and N. Balakrishnan Continuous
+   Univariate Distributions, second edition, Volumes I and II, Wiley &
+   Sons, 1994.
 
 
 Alpha
@@ -197,7 +216,7 @@ One shape parameters :math:`\alpha>0` (paramter :math:`\beta` in DATAPLOT is a s
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=\frac{1}{\Phi\left(a\right)\sqrt{2\pi}}\int_{0}^{\infty}\frac{e^{xt}}{x^{2}}\exp\left(-\frac{1}{2}\left(\alpha-\frac{1}{x}\right)^{2}\right)dx\]
+     M\left(t\right)=\frac{1}{\Phi\left(a\right)\sqrt{2\pi}}\int_{0}^{\infty}\frac{e^{xt}}{x^{2}}\exp\left(-\frac{1}{2}\left(\alpha-\frac{1}{x}\right)^{2}\right)dx
 
 
 
@@ -206,7 +225,7 @@ No moments?
 .. math::
    :nowrap:
 
-    \[ l_{\mathbf{x}}\left(\alpha\right)=N\log\left[\Phi\left(\alpha\right)\sqrt{2\pi}\right]+2N\overline{\log\mathbf{x}}+\frac{N}{2}\alpha^{2}-\alpha\overline{\mathbf{x}^{-1}}+\frac{1}{2}\overline{\mathbf{x}^{-2}}\]
+     l_{\mathbf{x}}\left(\alpha\right)=N\log\left[\Phi\left(\alpha\right)\sqrt{2\pi}\right]+2N\overline{\log\mathbf{x}}+\frac{N}{2}\alpha^{2}-\alpha\overline{\mathbf{x}^{-1}}+\frac{1}{2}\overline{\mathbf{x}^{-2}}
 
 
 
@@ -255,7 +274,7 @@ Defined over :math:`x\in\left[-\frac{\pi}{4},\frac{\pi}{4}\right]`
 .. math::
    :nowrap:
 
-    \[ l_{\mathbf{x}}\left(\cdot\right)=-N\overline{\log\left[\cos\left(2\mathbf{x}\right)\right]}\]
+     l_{\mathbf{x}}\left(\cdot\right)=-N\overline{\log\left[\cos\left(2\mathbf{x}\right)\right]}
 
 
 
@@ -275,7 +294,7 @@ Defined over :math:`x\in\left(0,1\right)` . To get the JKB definition put :math:
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=E^{t/2}I_{0}\left(\frac{t}{2}\right)\]
+     M\left(t\right)=E^{t/2}I_{0}\left(\frac{t}{2}\right)
 
 
 
@@ -298,7 +317,7 @@ Defined over :math:`x\in\left(0,1\right)` . To get the JKB definition put :math:
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]\approx-0.24156447527049044468\]
+     h\left[X\right]\approx-0.24156447527049044468
 
 
 
@@ -307,7 +326,7 @@ Defined over :math:`x\in\left(0,1\right)` . To get the JKB definition put :math:
 .. math::
    :nowrap:
 
-    \[ l_{\mathbf{x}}\left(\cdot\right)=N\log\pi+\frac{N}{2}\overline{\log\mathbf{x}}+\frac{N}{2}\overline{\log\left(1-\mathbf{x}\right)}\]
+     l_{\mathbf{x}}\left(\cdot\right)=N\log\pi+\frac{N}{2}\overline{\log\mathbf{x}}+\frac{N}{2}\overline{\log\left(1-\mathbf{x}\right)}
 
 
 
@@ -322,7 +341,7 @@ Two shape parameters
 .. math::
    :nowrap:
 
-    \[ a,b>0\]
+     a,b>0
 
 
 
@@ -342,7 +361,7 @@ Two shape parameters
 .. math::
    :nowrap:
 
-    \[ l_{\mathbf{x}}\left(a,b\right)=-N\log\Gamma\left(a+b\right)+N\log\Gamma\left(a\right)+N\log\Gamma\left(b\right)-N\left(a-1\right)\overline{\log\mathbf{x}}-N\left(b-1\right)\overline{\log\left(1-\mathbf{x}\right)}\]
+     l_{\mathbf{x}}\left(a,b\right)=-N\log\Gamma\left(a+b\right)+N\log\Gamma\left(a\right)+N\log\Gamma\left(b\right)-N\left(a-1\right)\overline{\log\mathbf{x}}-N\left(b-1\right)\overline{\log\left(1-\mathbf{x}\right)}
 
 All of the :math:`x_{i}\in\left[0,1\right]`
 
@@ -367,7 +386,7 @@ Ryzhik (sixth edition).
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\left\{ \begin{array}{ccc} \frac{\Gamma\left(n+\alpha\right)\Gamma\left(\beta-n\right)}{\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}=\frac{\left(\alpha\right)_{n}}{\left(\beta-n\right)_{n}} &  & \beta>n\\ \infty &  & \textrm{otherwise}\end{array}\right.\]
+     \mu_{n}^{\prime}=\left\{ \begin{array}{ccc} \frac{\Gamma\left(n+\alpha\right)\Gamma\left(\beta-n\right)}{\Gamma\left(\alpha\right)\Gamma\left(\beta\right)}=\frac{\left(\alpha\right)_{n}}{\left(\beta-n\right)_{n}} &  & \beta>n\\ \infty &  & \textrm{otherwise}\end{array}\right.
 
 Therefore,
 
@@ -401,7 +420,7 @@ where :math:`\textrm{Ei}\left(\textrm{z}\right)` is the exponential integral fun
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=\frac{1}{2}\log\left(1+c\right)-\log\left(\frac{c}{\log\left(1+c\right)}\right)\]
+     h\left[X\right]=\frac{1}{2}\log\left(1+c\right)-\log\left(\frac{c}{\log\left(1+c\right)}\right)
 
 
 
@@ -467,7 +486,7 @@ variates.
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=\Gamma\left(\frac{v}{2}\right)\,_{1}F_{1}\left(\frac{v}{2};\frac{1}{2};\frac{t^{2}}{2}\right)+\frac{t}{\sqrt{2}}\Gamma\left(\frac{1+\nu}{2}\right)\,_{1}F_{1}\left(\frac{1+\nu}{2};\frac{3}{2};\frac{t^{2}}{2}\right)\]
+     M\left(t\right)=\Gamma\left(\frac{v}{2}\right)\,_{1}F_{1}\left(\frac{v}{2};\frac{1}{2};\frac{t^{2}}{2}\right)+\frac{t}{\sqrt{2}}\Gamma\left(\frac{1+\nu}{2}\right)\,_{1}F_{1}\left(\frac{1+\nu}{2};\frac{3}{2};\frac{t^{2}}{2}\right)
 
 
 
@@ -498,7 +517,7 @@ The standard form (most often used in standard form only) is :math:`x>0`
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=\frac{\Gamma\left(\frac{\nu}{2}\right)}{\left(\frac{1}{2}-t\right)^{\nu/2}}\]
+     M\left(t\right)=\frac{\Gamma\left(\frac{\nu}{2}\right)}{\left(\frac{1}{2}-t\right)^{\nu/2}}
 
 
 
@@ -553,7 +572,7 @@ The double gamma is the signed version of the Gamma distribution. For :math:`\al
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=\frac{1}{2\left(1-t\right)^{a}}+\frac{1}{2\left(1+t\right)^{a}}\]
+     M\left(t\right)=\frac{1}{2\left(1-t\right)^{a}}+\frac{1}{2\left(1+t\right)^{a}}
 
 
 
@@ -592,7 +611,7 @@ This is a signed form of the Weibull distribution.
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\mu_{n}=\begin{cases} \Gamma\left(1+\frac{n}{c}\right) & n\textrm{ even}\\ 0 & n\textrm{ odd}\end{cases}\]
+     \mu_{n}^{\prime}=\mu_{n}=\begin{cases} \Gamma\left(1+\frac{n}{c}\right) & n\textrm{ even}\\ 0 & n\textrm{ odd}\end{cases}
 
 
 
@@ -629,7 +648,7 @@ therefore ( :math:`x\geq0` )
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=n!\]
+     \mu_{n}^{\prime}=n!
 
 
 
@@ -638,7 +657,7 @@ therefore ( :math:`x\geq0` )
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=\frac{1}{1-t}\]
+     M\left(t\right)=\frac{1}{1-t}
 
 
 
@@ -652,7 +671,7 @@ therefore ( :math:`x\geq0` )
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=1.\]
+     h\left[X\right]=1.
 
 
 
@@ -700,7 +719,7 @@ This distribution's pdf is the average of the inverse-Gaussian :math:`\left(\mu=
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=c\sqrt{2\pi}\exp\left[\frac{1}{c^{2}}\left(1-\sqrt{1-2c^{2}t}\right)\right]\left(1+\frac{1}{\sqrt{1-2c^{2}t}}\right)\]
+     M\left(t\right)=c\sqrt{2\pi}\exp\left[\frac{1}{c^{2}}\left(1-\sqrt{1-2c^{2}t}\right)\right]\left(1+\frac{1}{\sqrt{1-2c^{2}t}}\right)
 
 
 
@@ -742,7 +761,7 @@ Special case of the Burr distribution with :math:`d=1`
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=2-\log c.\]
+     h\left[X\right]=2-\log c.
 
 
 
@@ -779,7 +798,7 @@ degree of freedom and non-centrality parameter :math:`c^{2}.` Note that :math:`c
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=\exp\left[\frac{t}{2}\left(t-2c\right)\right]\left(1+e^{2ct}\right)\]
+     M\left(t\right)=\exp\left[\frac{t}{2}\left(t-2c\right)\right]\left(1+e^{2ct}\right)
 
 
 
@@ -826,7 +845,7 @@ A type of extreme-value distribution with a lower bound. Defined for :math:`x>0`
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\Gamma\left(1+\frac{n}{c}\right)\]
+     \mu_{n}^{\prime}=\Gamma\left(1+\frac{n}{c}\right)
 
 
 
@@ -840,14 +859,14 @@ A type of extreme-value distribution with a lower bound. Defined for :math:`x>0`
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1\]
+     h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1
 
 where :math:`\gamma` is Euler's constant and equal to
 
 .. math::
    :nowrap:
 
-    \[ \gamma\approx0.57721566490153286061.\]
+     \gamma\approx0.57721566490153286061.
 
 
 
@@ -872,7 +891,7 @@ given above, and the other statistical parameters can be computed from
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\left(-1\right)^{n}\Gamma\left(1+\frac{n}{c}\right).\]
+     \mu_{n}^{\prime}=\left(-1\right)^{n}\Gamma\left(1+\frac{n}{c}\right).
 
 
 
@@ -881,14 +900,14 @@ given above, and the other statistical parameters can be computed from
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1\]
+     h\left[X\right]=-\frac{\gamma}{c}-\log\left(c\right)+\gamma+1
 
 where :math:`\gamma` is Euler's constant and equal to
 
 .. math::
    :nowrap:
 
-    \[ \gamma\approx0.57721566490153286061.\]
+     \gamma\approx0.57721566490153286061.
 
 
 
@@ -908,7 +927,7 @@ The standard form for the gamma distribution is :math:`\left(\alpha>0\right)` va
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=\frac{1}{\left(1-t\right)^{\alpha}}\]
+     M\left(t\right)=\frac{1}{\left(1-t\right)^{\alpha}}
 
 
 
@@ -924,14 +943,14 @@ The standard form for the gamma distribution is :math:`\left(\alpha>0\right)` va
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=\Psi\left(a\right)\left[1-a\right]+a+\log\Gamma\left(a\right)\]
+     h\left[X\right]=\Psi\left(a\right)\left[1-a\right]+a+\log\Gamma\left(a\right)
 
 where
 
 .. math::
    :nowrap:
 
-    \[ \Psi\left(a\right)=\frac{\Gamma^{\prime}\left(a\right)}{\Gamma\left(a\right)}.\]
+     \Psi\left(a\right)=\frac{\Gamma^{\prime}\left(a\right)}{\Gamma\left(a\right)}.
 
 
 
@@ -956,7 +975,7 @@ parameter :math:`c>0.` And :math:`x>0`
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=\frac{c}{1-t}\,_{2}F_{1}\left(1+c,\,1-t\,;\,2-t\,;-1\right)\]
+     M\left(t\right)=\frac{c}{1-t}\,_{2}F_{1}\left(1+c,\,1-t\,;\,2-t\,;-1\right)
 
 
 
@@ -995,7 +1014,7 @@ Shape parameter :math:`c\neq0` and defined for :math:`x\geq0` for all :math:`c` 
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=\left\{ \begin{array}{cc} \left(-\frac{t}{c}\right)^{\frac{1}{c}}e^{-\frac{t}{c}}\left[\Gamma\left(1-\frac{1}{c}\right)+\Gamma\left(-\frac{1}{c},-\frac{t}{c}\right)-\pi\csc\left(\frac{\pi}{c}\right)/\Gamma\left(\frac{1}{c}\right)\right] & c>0\\ \left(\frac{\left|c\right|}{t}\right)^{1/\left|c\right|}\Gamma\left[\frac{1}{\left|c\right|},\frac{t}{\left|c\right|}\right] & c<0\end{array}\right.\]
+     M\left(t\right)=\left\{ \begin{array}{cc} \left(-\frac{t}{c}\right)^{\frac{1}{c}}e^{-\frac{t}{c}}\left[\Gamma\left(1-\frac{1}{c}\right)+\Gamma\left(-\frac{1}{c},-\frac{t}{c}\right)-\pi\csc\left(\frac{\pi}{c}\right)/\Gamma\left(\frac{1}{c}\right)\right] & c>0\\ \left(\frac{\left|c\right|}{t}\right)^{1/\left|c\right|}\Gamma\left[\frac{1}{\left|c\right|},\frac{t}{\left|c\right|}\right] & c<0\end{array}\right.
 
 
 
@@ -1004,7 +1023,7 @@ Shape parameter :math:`c\neq0` and defined for :math:`x\geq0` for all :math:`c` 
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\frac{\left(-1\right)^{n}}{c^{n}}\sum_{k=0}^{n}\left(\begin{array}{c} n\\ k\end{array}\right)\frac{\left(-1\right)^{k}}{1-ck}\quad cn<1\]
+     \mu_{n}^{\prime}=\frac{\left(-1\right)^{n}}{c^{n}}\sum_{k=0}^{n}\left(\begin{array}{c} n\\ k\end{array}\right)\frac{\left(-1\right)^{k}}{1-ck}\quad cn<1
 
 
 
@@ -1027,7 +1046,7 @@ Thus,
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=1+c\quad c>0\]
+     h\left[X\right]=1+c\quad c>0
 
 
 
@@ -1062,7 +1081,7 @@ For :math:`c>0` defined on :math:`-\infty<x\leq1/c.`
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\frac{1}{c^{n}}\sum_{k=0}^{n}\left(\begin{array}{c} n\\ k\end{array}\right)\left(-1\right)^{k}\Gamma\left(ck+1\right)\quad cn>-1\]
+     \mu_{n}^{\prime}=\frac{1}{c^{n}}\sum_{k=0}^{n}\left(\begin{array}{c} n\\ k\end{array}\right)\left(-1\right)^{k}\Gamma\left(ck+1\right)\quad cn>-1
 
 So,
 
@@ -1105,7 +1124,7 @@ A general probability form that reduces to many common distributions: :math:`x>0
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\frac{\Gamma\left(a+\frac{n}{c}\right)}{\Gamma\left(a\right)}\]
+     \mu_{n}^{\prime}=\frac{\Gamma\left(a+\frac{n}{c}\right)}{\Gamma\left(a\right)}
 
 
 
@@ -1121,7 +1140,7 @@ Special cases are Weibull :math:`\left(a=1\right)` , half-normal :math:`\left(a=
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=a-a\Psi\left(a\right)+\frac{1}{c}\Psi\left(a\right)+\log\Gamma\left(a\right)-\log\left|c\right|.\]
+     h\left[X\right]=a-a\Psi\left(a\right)+\frac{1}{c}\Psi\left(a\right)+\log\Gamma\left(a\right)-\log\left|c\right|.
 
 
 
@@ -1194,14 +1213,14 @@ For :math:`x\geq0` and :math:`c>0` . In JKB the two shape parameters :math:`b,a`
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=1-\log\left(c\right)-e^{c}\textrm{Ei}\left(1,c\right),\]
+     h\left[X\right]=1-\log\left(c\right)-e^{c}\textrm{Ei}\left(1,c\right),
 
 where
 
 .. math::
    :nowrap:
 
-    \[ \textrm{Ei}\left(n,x\right)=\int_{1}^{\infty}t^{-n}\exp\left(-xt\right)dt\]
+     \textrm{Ei}\left(n,x\right)=\int_{1}^{\infty}t^{-n}\exp\left(-xt\right)dt
 
 
 
@@ -1223,7 +1242,7 @@ One of a clase of extreme value distributions (right-skewed).
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=\Gamma\left(1-t\right)\]
+     M\left(t\right)=\Gamma\left(1-t\right)
 
 
 
@@ -1239,7 +1258,7 @@ One of a clase of extreme value distributions (right-skewed).
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]\approx1.0608407169541684911\]
+     h\left[X\right]\approx1.0608407169541684911
 
 
 
@@ -1259,7 +1278,7 @@ Gumbel Left-skewed (for minimum order statistic)
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=\Gamma\left(1+t\right)\]
+     M\left(t\right)=\Gamma\left(1+t\right)
 
 Note, that :math:`\mu` is negative the mean for the right-skewed distribution. Similar for
 median and mode. All other moments are the same.
@@ -1269,7 +1288,7 @@ median and mode. All other moments are the same.
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]\approx1.0608407169541684911.\]
+     h\left[X\right]\approx1.0608407169541684911.
 
 
 
@@ -1290,7 +1309,7 @@ distribution with :math:`c=0.` The standard form is
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=\cos t+\frac{2}{\pi}\left[\textrm{Si}\left(t\right)\cos t-\textrm{Ci}\left(\textrm{-}t\right)\sin t\right]\]
+     M\left(t\right)=\cos t+\frac{2}{\pi}\left[\textrm{Si}\left(t\right)\cos t-\textrm{Ci}\left(\textrm{-}t\right)\sin t\right]
 
 
 
@@ -1328,7 +1347,7 @@ This is a special case of the chi distribution with :math:`L=a` and :math:`S=b` 
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=\sqrt{2\pi}e^{t^{2}/2}\Phi\left(t\right)\]
+     M\left(t\right)=\sqrt{2\pi}e^{t^{2}/2}\Phi\left(t\right)
 
 
 
@@ -1369,14 +1388,14 @@ over :math:`x\geq0.` Also, the distribution of :math:`\left|X\right|` where :mat
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=1-t\psi_{0}\left(\frac{1}{2}-\frac{t}{2}\right)+t\psi_{0}\left(1-\frac{t}{2}\right)\]
+     M\left(t\right)=1-t\psi_{0}\left(\frac{1}{2}-\frac{t}{2}\right)+t\psi_{0}\left(1-\frac{t}{2}\right)
 
 
 
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=2\left(1-2^{1-n}\right)n!\zeta\left(n\right)\quad n\neq1\]
+     \mu_{n}^{\prime}=2\left(1-2^{1-n}\right)n!\zeta\left(n\right)\quad n\neq1
 
 
 
@@ -1413,7 +1432,7 @@ Standard form is (defined over all :math:`x` )
 .. math::
    :nowrap:
 
-    \[ M\left(t\right)=\sec\left(\frac{\pi}{2}t\right)\]
+     M\left(t\right)=\sec\left(\frac{\pi}{2}t\right)
 
 
 
@@ -1434,7 +1453,7 @@ where :math:`B_{2m+1}\left(\frac{1}{4}\right)` is the Bernoulli polynomial of or
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\left\{ \begin{array}{cc} 0 & n\textrm{ odd}\\ 4\left(-1\right)^{n/2-1}\frac{\left(2\pi\right)^{n}}{n+1}B_{n+1}\left(\frac{1}{4}\right) & n\textrm{ even}\end{array}\right.\]
+     \mu_{n}^{\prime}=\left\{ \begin{array}{cc} 0 & n\textrm{ odd}\\ 4\left(-1\right)^{n/2-1}\frac{\left(2\pi\right)^{n}}{n+1}B_{n+1}\left(\frac{1}{4}\right) & n\textrm{ even}\end{array}\right.
 
 
 
@@ -1452,7 +1471,7 @@ where :math:`B_{2m+1}\left(\frac{1}{4}\right)` is the Bernoulli polynomial of or
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=\log\left(2\pi\right).\]
+     h\left[X\right]=\log\left(2\pi\right).
 
 
 
@@ -1465,7 +1484,7 @@ Gauss Hypergeometric
 .. math::
    :nowrap:
 
-    \[ C^{-1}=B\left(\alpha,\beta\right)\,_{2}F_{1}\left(\gamma,\alpha;\alpha+\beta;-z\right)\]
+     C^{-1}=B\left(\alpha,\beta\right)\,_{2}F_{1}\left(\gamma,\alpha;\alpha+\beta;-z\right)
 
 
 
@@ -1494,7 +1513,7 @@ Special case of the generalized Gamma distribution with :math:`c=-1` and :math:`
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\frac{\Gamma\left(a-n\right)}{\Gamma\left(a\right)}\quad a>n\]
+     \mu_{n}^{\prime}=\frac{\Gamma\left(a-n\right)}{\Gamma\left(a\right)}\quad a>n
 
 
 
@@ -1508,7 +1527,7 @@ Special case of the generalized Gamma distribution with :math:`c=-1` and :math:`
 .. math::
    :nowrap:
 
-    \[ m_{d}=\frac{1}{a+1}\]
+     m_{d}=\frac{1}{a+1}
 
 
 
@@ -1517,7 +1536,7 @@ Special case of the generalized Gamma distribution with :math:`c=-1` and :math:`
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=a-\left(a+1\right)\Psi\left(a\right)+\log\Gamma\left(a\right).\]
+     h\left[X\right]=a-\left(a+1\right)\Psi\left(a\right)+\log\Gamma\left(a\right).
 
 
 
@@ -1563,7 +1582,7 @@ Shape parameter :math:`c>0` and :math:`x>0` . Then
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=1+\gamma+\frac{\gamma}{c}-\log\left(c\right)\]
+     h\left[X\right]=1+\gamma+\frac{\gamma}{c}-\log\left(c\right)
 
 where :math:`\gamma` is Euler's constant.
 
@@ -1626,7 +1645,7 @@ The ML estimator of the location parameter is
 .. math::
    :nowrap:
 
-    \[ \hat{L}=\textrm{median}\left(X_{i}\right)\]
+     \hat{L}=\textrm{median}\left(X_{i}\right)
 
 where :math:`X_{i}` is a sequence of :math:`N` mutually independent Laplace RV's and the median is some number
 between the :math:`\frac{1}{2}N\textrm{th}` and the :math:`(N/2+1)\textrm{th}` order statistic ( *e.g.* take the average of these two) when :math:`N` is even. Also,
@@ -1634,7 +1653,7 @@ between the :math:`\frac{1}{2}N\textrm{th}` and the :math:`(N/2+1)\textrm{th}` o
 .. math::
    :nowrap:
 
-    \[ \hat{S}=\frac{1}{N}\sum_{j=1}^{N}\left|X_{j}-\hat{L}\right|.\]
+     \hat{S}=\frac{1}{N}\sum_{j=1}^{N}\left|X_{j}-\hat{L}\right|.
 
 Replace :math:`\hat{L}` with :math:`L` if it is known. If :math:`L` is known then this estimator is distributed as :math:`\left(2N\right)^{-1}S\cdot\chi_{2N}^{2}` .
 
@@ -1702,7 +1721,7 @@ A special case of the Generalized Logistic distribution with :math:`c=1.` Define
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=1.\]
+     h\left[X\right]=1.
 
 
 
@@ -1724,7 +1743,7 @@ Defined over :math:`x>0` with :math:`c>0`
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=\log\left(\frac{2e}{c}\right)\]
+     h\left[X\right]=\log\left(\frac{2e}{c}\right)
 
 
 
@@ -1744,7 +1763,7 @@ A single shape parameter :math:`c>0` (Defined for all :math:`x` )
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\int_{0}^{\infty}\left[\log y\right]^{n}y^{c-1}\exp\left(-y\right)dy.\]
+     \mu_{n}^{\prime}=\int_{0}^{\infty}\left[\log y\right]^{n}y^{c-1}\exp\left(-y\right)dy.
 
 
 
@@ -1785,7 +1804,7 @@ parameter description of general probability distributions.
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=\frac{1}{2}\left[1+\log\left(2\pi\right)+2\log\left(\sigma\right)\right].\]
+     h\left[X\right]=\frac{1}{2}\left[1+\log\left(2\pi\right)+2\log\left(\sigma\right)\right].
 
 
 
@@ -1822,7 +1841,7 @@ Defined over :math:`x\in\left[0,1\right]` with :math:`a>0` and :math:`b>0` and :
 .. math::
    :nowrap:
 
-    \[ F\left(x;a,b,c\right)=\sum_{j=0}^{\infty}\frac{e^{-c/2}\left(\frac{c}{2}\right)^{j}}{j!}I_{B}\left(a+j,b;0\right)\]
+     F\left(x;a,b,c\right)=\sum_{j=0}^{\infty}\frac{e^{-c/2}\left(\frac{c}{2}\right)^{j}}{j!}I_{B}\left(a+j,b;0\right)
 
 
 
@@ -1875,7 +1894,7 @@ The distribution of the ratio
 .. math::
    :nowrap:
 
-    \[ \frac{U+\lambda}{\chi_{\nu}/\sqrt{\nu}}\]
+     \frac{U+\lambda}{\chi_{\nu}/\sqrt{\nu}}
 
 where :math:`U` and :math:`\chi_{\nu}` are independent and distributed as a standard normal and chi with :math:`\nu` degrees of freedom. Note :math:`\lambda>0` and :math:`\nu>0` .
 
@@ -1944,7 +1963,7 @@ This is a special case of the Chi distribution with :math:`L=0` and :math:`S=S=\
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=\log\left(\sqrt{\frac{2\pi}{e}}\right)+\gamma.\]
+     h\left[X\right]=\log\left(\sqrt{\frac{2\pi}{e}}\right)+\gamma.
 
 
 
@@ -1990,7 +2009,7 @@ For :math:`x\geq1` and :math:`b>0` . Standard form is
 .. math::
    :nowrap:
 
-    \[ h\left(X\right)=\frac{1}{c}+1-\log\left(c\right)\]
+     h\left(X\right)=\frac{1}{c}+1-\log\left(c\right)
 
 
 
@@ -2012,7 +2031,7 @@ Pareto Second Kind (Lomax)
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=\frac{1}{c}+1-\log\left(c\right).\]
+     h\left[X\right]=\frac{1}{c}+1-\log\left(c\right).
 
 
 
@@ -2032,7 +2051,7 @@ A generalization of the log-normal distribution :math:`\sigma>0` and :math:`c>0`
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\int_{0}^{1}\exp\left[-n\sigma\Phi^{-1}\left(y^{1/c}\right)\right]dy\]
+     \mu_{n}^{\prime}=\int_{0}^{1}\exp\left[-n\sigma\Phi^{-1}\left(y^{1/c}\right)\right]dy
 
 
 
@@ -2059,7 +2078,7 @@ A generalization of the normal distribution, :math:`c>0` for
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\left(-1\right)^{n}\int_{0}^{1}\left[\Phi^{-1}\left(y^{1/c}\right)\right]^{n}dy\]
+     \mu_{n}^{\prime}=\left(-1\right)^{n}\int_{0}^{1}\left[\Phi^{-1}\left(y^{1/c}\right)\right]^{n}dy
 
 
 
@@ -2081,7 +2100,7 @@ A special case of the beta distribution with :math:`b=1` : defined for :math:`x\
 .. math::
    :nowrap:
 
-    \[ a>0\]
+     a>0
 
 
 
@@ -2097,7 +2116,7 @@ A special case of the beta distribution with :math:`b=1` : defined for :math:`x\
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=1-\frac{1}{a}-\log\left(a\right)\]
+     h\left[X\right]=1-\frac{1}{a}-\log\left(a\right)
 
 
 
@@ -2117,7 +2136,7 @@ A general-purpose distribution with a variety of shapes controlled by :math:`c>0
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\frac{\left(1+\left(-1\right)^{n}\right)}{2}B\left(\frac{n+1}{2},\frac{c}{2}\right)\]
+     \mu_{n}^{\prime}=\frac{\left(1+\left(-1\right)^{n}\right)}{2}B\left(\frac{n+1}{2},\frac{c}{2}\right)
 
 The R-distribution with parameter :math:`n` is the distribution of the correlation coefficient of a random sample
 of size :math:`n` drawn from a bivariate normal distribution with :math:`\rho=0.` The mean of the standard distribution is always zero and as the sample
@@ -2148,7 +2167,7 @@ distribution is :math:`S.`
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=\frac{\gamma}{2}+\log\left(\frac{e}{\sqrt{2}}\right).\]
+     h\left[X\right]=\frac{\gamma}{2}+\log\left(\frac{e}{\sqrt{2}}\right).
 
 
 
@@ -2157,7 +2176,7 @@ distribution is :math:`S.`
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(\frac{n}{2}+1\right)\]
+     \mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(\frac{n}{2}+1\right)
 
 
 
@@ -2181,7 +2200,7 @@ Defined for :math:`x>0` and :math:`b>0`
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(1+\frac{n}{2}\right)\,_{1}F_{1}\left(-\frac{n}{2};1;-\frac{b^{2}}{2}\right)\]
+     \mu_{n}^{\prime}=\sqrt{2^{n}}\Gamma\left(1+\frac{n}{2}\right)\,_{1}F_{1}\left(-\frac{n}{2};1;-\frac{b^{2}}{2}\right)
 
 
 
@@ -2208,7 +2227,7 @@ Shape parameters :math:`a,b>0` :math:`x\in\left[a,b\right]`
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=\frac{1}{2}\log\left(ab\right)+\log\left[\log\left(\frac{b}{a}\right)\right].\]
+     h\left[X\right]=\frac{1}{2}\log\left(ab\right)+\log\left[\log\left(\frac{b}{a}\right)\right].
 
 
 
@@ -2259,7 +2278,7 @@ Defined on :math:`x\in\left[-1,1\right]`
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=0.64472988584940017414.\]
+     h\left[X\right]=0.64472988584940017414.
 
 
 
@@ -2296,14 +2315,14 @@ As :math:`\nu\rightarrow\infty,` this distribution approaches the standard norma
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=\frac{1}{4}\log\left(\frac{\pi c\Gamma^{2}\left(\frac{c}{2}\right)}{\Gamma^{2}\left(\frac{c+1}{2}\right)}\right)-\frac{\left(c+1\right)}{4}\left[\Psi\left(\frac{c}{2}\right)-cZ\left(c\right)+\pi\tan\left(\frac{\pi c}{2}\right)+\gamma+2\log2\right]\]
+     h\left[X\right]=\frac{1}{4}\log\left(\frac{\pi c\Gamma^{2}\left(\frac{c}{2}\right)}{\Gamma^{2}\left(\frac{c+1}{2}\right)}\right)-\frac{\left(c+1\right)}{4}\left[\Psi\left(\frac{c}{2}\right)-cZ\left(c\right)+\pi\tan\left(\frac{\pi c}{2}\right)+\gamma+2\log2\right]
 
 where
 
 .. math::
    :nowrap:
 
-    \[ Z\left(c\right)=\,_{3}F_{2}\left(1,1,1+\frac{c}{2};\frac{3}{2},2;1\right)=\sum_{k=0}^{\infty}\frac{k!}{k+1}\frac{\Gamma\left(\frac{c}{2}+1+k\right)}{\Gamma\left(\frac{c}{2}+1\right)}\frac{\Gamma\left(\frac{3}{2}\right)}{\Gamma\left(\frac{3}{2}+k\right)}\]
+     Z\left(c\right)=\,_{3}F_{2}\left(1,1,1+\frac{c}{2};\frac{3}{2},2;1\right)=\sum_{k=0}^{\infty}\frac{k!}{k+1}\frac{\Gamma\left(\frac{c}{2}+1+k\right)}{\Gamma\left(\frac{c}{2}+1\right)}\frac{\Gamma\left(\frac{3}{2}\right)}{\Gamma\left(\frac{3}{2}+k\right)}
 
 
 
@@ -2331,7 +2350,7 @@ The moment generating function is
 .. math::
    :nowrap:
 
-    \[ \theta\left(t\right)=2\sqrt{\left|\frac{t}{2}\right|^{\nu-1}}\frac{K_{\left(n-1\right)/2}\left(\left|t\right|\right)}{\Gamma\left(\frac{\nu-1}{2}\right)}.\]
+     \theta\left(t\right)=2\sqrt{\left|\frac{t}{2}\right|^{\nu-1}}\frac{K_{\left(n-1\right)/2}\left(\left|t\right|\right)}{\Gamma\left(\frac{\nu-1}{2}\right)}.
 
 
 
@@ -2385,7 +2404,7 @@ This is an exponential distribution defined only over a certain region :math:`0<
 .. math::
    :nowrap:
 
-    \[ \mu_{n}^{\prime}=\Gamma\left(1+n\right)-\Gamma\left(1+n,B\right)\]
+     \mu_{n}^{\prime}=\Gamma\left(1+n\right)-\Gamma\left(1+n,B\right)
 
 
 
@@ -2394,7 +2413,7 @@ This is an exponential distribution defined only over a certain region :math:`0<
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=\log\left(e^{B}-1\right)+\frac{1+e^{B}\left(B-1\right)}{1-e^{B}}.\]
+     h\left[X\right]=\log\left(e^{B}-1\right)+\frac{1+e^{B}\left(B-1\right)}{1-e^{B}}.
 
 
 
@@ -2480,7 +2499,7 @@ Standard form :math:`x\in\left(0,1\right).` In general form, the lower limit is 
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=0\]
+     h\left[X\right]=0
 
 
 
@@ -2554,11 +2573,11 @@ For :math:`x\in\left[0,2\pi\right]` :math:`c\in\left(0,1\right)`
 .. math::
    :nowrap:
 
-    \[ \]
+     
 
 
 
 .. math::
    :nowrap:
 
-    \[ h\left[X\right]=\log\left(2\pi\left(1-c^{2}\right)\right).\]
+     h\left[X\right]=\log\left(2\pi\left(1-c^{2}\right)\right).

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -397,6 +397,9 @@ def _moment_from_stats(n, mu, mu2, g1, g2, moment_func, args):
 
 
 def _skew(data):
+    """
+    skew is third central moment / variance**(1.5)
+    """
     data = np.ravel(data)
     mu = data.mean()
     m2 = ((data - mu)**2).mean()
@@ -404,6 +407,9 @@ def _skew(data):
     return m3 / m2**1.5
 
 def _kurtosis(data):
+    """
+    kurtosis is fourth central moment / variance**2 - 3
+    """
     data = np.ravel(data)
     mu = data.mean()
     m2 = ((data - mu)**2).mean()
@@ -487,97 +493,6 @@ class rv_frozen(object):
         return self.dist.interval(alpha, *self.args, **self.kwds)
 
 
-
-##  NANs are returned for unsupported parameters.
-##    location and scale parameters are optional for each distribution.
-##    The shape parameters are generally required
-##
-##    The loc and scale parameters must be given as keyword parameters.
-##    These are related to the common symbols in the .lyx file
-
-##  skew is third central moment / variance**(1.5)
-##  kurtosis is fourth central moment / variance**2 - 3
-
-
-## References::
-
-##  Documentation for ranlib, rv2, cdflib and
-##
-##  Eric Weisstein's world of mathematics http://mathworld.wolfram.com/
-##      http://mathworld.wolfram.com/topics/StatisticalDistributions.html
-##
-##  Documentation to Regress+ by Michael McLaughlin
-##
-##  Engineering and Statistics Handbook (NIST)
-##      http://www.itl.nist.gov/div898/handbook/index.htm
-##
-##  Documentation for DATAPLOT from NIST
-##      http://www.itl.nist.gov/div898/software/dataplot/distribu.htm
-##
-##  Norman Johnson, Samuel Kotz, and N. Balakrishnan "Continuous
-##      Univariate Distributions", second edition,
-##      Volumes I and II, Wiley & Sons, 1994.
-
-
-## Each continuous random variable as the following methods
-##
-## rvs -- Random Variates (alternatively calling the class could produce these)
-## pdf -- PDF
-## logpdf -- log PDF (more  numerically accurate if possible)
-## cdf -- CDF
-## logcdf -- log of CDF
-## sf  -- Survival Function (1-CDF)
-## logsf --- log of SF
-## ppf -- Percent Point Function (Inverse of CDF)
-## isf -- Inverse Survival Function (Inverse of SF)
-## stats -- Return mean, variance, (Fisher's) skew, or (Fisher's) kurtosis
-## nnlf  -- negative log likelihood function (to minimize)
-## fit   -- Model-fitting
-##
-##  Maybe Later
-##
-##  hf  --- Hazard Function (PDF / SF)
-##  chf  --- Cumulative hazard function (-log(SF))
-##  psf --- Probability sparsity function (reciprocal of the pdf) in
-##                units of percent-point-function (as a function of q).
-##                Also, the derivative of the percent-point function.
-
-## To define a new random variable you subclass the rv_continuous class
-##   and re-define the
-##
-##   _pdf method which will be given clean arguments (in between a and b)
-##        and passing the argument check method
-##
-##      If postive argument checking is not correct for your RV
-##      then you will also need to re-define
-##   _argcheck
-
-##   Correct, but potentially slow defaults exist for the remaining
-##       methods but for speed and/or accuracy you can over-ride
-##
-##     _cdf, _ppf, _rvs, _isf, _sf
-##
-##   Rarely would you override _isf  and _sf but you could for numerical precision.
-##
-##   Statistics are computed using numerical integration by default.
-##     For speed you can redefine this using
-##
-##    _stats  --- take shape parameters and return mu, mu2, g1, g2
-##            --- If you can't compute one of these return it as None
-##
-##            --- Can also be defined with a keyword argument moments=<str>
-##                  where <str> is a string composed of 'm', 'v', 's',
-##                  and/or 'k'.  Only the components appearing in string
-##                 should be computed and returned in the order 'm', 'v',
-##                  's', or 'k'  with missing values returned as None
-##
-##    OR
-##
-##  You can override
-##
-##    _munp    -- takes n and shape parameters and returns
-##             --  then nth non-central moment of the distribution.
-##
 
 def valarray(shape,value=nan,typecode=None):
     """Return an array of all value.
@@ -827,6 +742,14 @@ class rv_generic(object):
         b = self.ppf(q2, *args, **kwds)
         return a, b
 
+
+##  continuous random variables: implement maybe later
+##
+##  hf  --- Hazard Function (PDF / SF)
+##  chf  --- Cumulative hazard function (-log(SF))
+##  psf --- Probability sparsity function (reciprocal of the pdf) in
+##                units of percent-point-function (as a function of q).
+##                Also, the derivative of the percent-point function.
 
 class rv_continuous(rv_generic):
     """


### PR DESCRIPTION
in distributions.py I removed some ## parts of documentation. Part of it is (nearly) identical to the docstring of rv_continuous. I moved the http links to the references to continuous.rst and continuous.lyx as these docs contain the mathematical description of the distributions. 

In continous.rst I removed the [ and ]. These remnants of latex mark up lead to ugly html, hence have to be removed. 
