### PR TITLE
ENH: speed up csr._get_rowslice and allow striding

### DIFF
--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -167,6 +167,19 @@ class csc_matrix(_cs_matrix):
         else:
             return self.T[:,key].T                              #[[1,2]]
 
+    def getrow(self, i):
+        """Returns a copy of row i of the matrix, as a (1 x n) sparse
+        matrix (row vector).
+        """
+        # transpose to use CSR code
+        return self.T.getcol(i).T
+
+    def getcol(self, i):
+        """Returns a copy of column i of the matrix, as a (1 x n) sparse
+        matrix (row vector).
+        """
+        # transpose to use CSR code
+        return self.T.getrow(i).T
 
     # these functions are used by the parent class (_cs_matrix)
     # to remove redudancy between csc_matrix and csr_matrix

--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -168,15 +168,17 @@ class csc_matrix(_cs_matrix):
             return self.T[:,key].T                              #[[1,2]]
 
     def getrow(self, i):
-        """Returns a copy of row i of the matrix, as a (1 x n) sparse
-        matrix (row vector).
+        """Returns a copy of row i of the matrix, as a (1 x n)
+        CSR matrix (row vector).
         """
         # transpose to use CSR code
-        return self.T.getcol(i).T
+        # we convert to CSR to maintain compatibility with old impl.
+        # in spmatrix.getrow()
+        return self.T.getcol(i).T.tocsr()
 
     def getcol(self, i):
-        """Returns a copy of column i of the matrix, as a (1 x n) sparse
-        matrix (row vector).
+        """Returns a copy of column i of the matrix, as a (m x 1)
+        CSC matrix (column vector).
         """
         # transpose to use CSR code
         return self.T.getrow(i).T

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -311,14 +311,14 @@ class csr_matrix(_cs_matrix):
             raise ValueError('nonzero entry (%d,%d) occurs more than once' % (row,col) )
 
     def getrow(self, i):
-        """Returns a copy of row i of the matrix, as a (1 x n) sparse
-        matrix (row vector).
+        """Returns a copy of row i of the matrix, as a (1 x n)
+        CSR matrix (row vector).
         """
         return self._get_submatrix(i, slice(None))
 
     def getcol(self, i):
-        """Returns a copy of column i of the matrix, as a (1 x n) sparse
-        matrix (row vector).
+        """Returns a copy of column i of the matrix, as a (m x 1)
+        CSR matrix (column vector).
         """
         return self._get_submatrix(slice(None), i)
 

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -310,6 +310,18 @@ class csr_matrix(_cs_matrix):
         else:
             raise ValueError('nonzero entry (%d,%d) occurs more than once' % (row,col) )
 
+    def getrow(self, i):
+        """Returns a copy of row i of the matrix, as a (1 x n) sparse
+        matrix (row vector).
+        """
+        return self._get_submatrix(i, slice(None))
+
+    def getcol(self, i):
+        """Returns a copy of column i of the matrix, as a (1 x n) sparse
+        matrix (row vector).
+        """
+        return self._get_submatrix(slice(None), i)
+
     def _get_row_slice(self, i, cslice):
         """Returns a copy of row self[i, cslice]
         """

--- a/scipy/sparse/tests/test_csc.py
+++ b/scipy/sparse/tests/test_csc.py
@@ -1,6 +1,22 @@
 import numpy as np
 from numpy.testing import assert_array_almost_equal, run_module_suite
-from scipy.sparse import csc_matrix
+from scipy.sparse import csr_matrix, csc_matrix
+
+
+def _check_csc_getrow(i, X, Xcsc):
+    arr_row = X[i:i + 1, :]
+    csc_row = Xcsc.getrow(i)
+
+    assert_array_almost_equal(arr_row, csc_row.toarray())
+    assert type(csc_row) is csr_matrix
+
+
+def _check_csc_getcol(i, X, Xcsc):
+    arr_col = X[:, i:i + 1]
+    csc_col = Xcsc.getcol(i)
+
+    assert_array_almost_equal(arr_col, csc_col.toarray())
+    assert type(csc_col) is csc_matrix
 
 
 def test_csc_getrow_getcol():
@@ -8,15 +24,11 @@ def test_csc_getrow_getcol():
     np.random.seed(0)
     X = np.random.random((N, N))
     X[X > 0.7] = 0
-    Xcsr = csc_matrix(X)
-    
+    Xcsc = csc_matrix(X)
+
     for i in range(N):
-        # check getrow()
-        yield (assert_array_almost_equal,
-               X[i:i + 1, :], Xcsr.getrow(i).toarray())
-        # check getcol()
-        yield (assert_array_almost_equal,
-               X[:, i:i + 1], Xcsr.getcol(i).toarray())
+        yield _check_csc_getrow, i, X, Xcsc
+        yield _check_csc_getcol, i, X, Xcsc
 
 
 if __name__ == "__main__":

--- a/scipy/sparse/tests/test_csc.py
+++ b/scipy/sparse/tests/test_csc.py
@@ -1,25 +1,9 @@
 import numpy as np
-from numpy.testing import assert_array_almost_equal, run_module_suite
+from numpy.testing import assert_array_almost_equal, run_module_suite, assert_
 from scipy.sparse import csr_matrix, csc_matrix
 
 
-def _check_csc_getrow(i, X, Xcsc):
-    arr_row = X[i:i + 1, :]
-    csc_row = Xcsc.getrow(i)
-
-    assert_array_almost_equal(arr_row, csc_row.toarray())
-    assert type(csc_row) is csr_matrix
-
-
-def _check_csc_getcol(i, X, Xcsc):
-    arr_col = X[:, i:i + 1]
-    csc_col = Xcsc.getcol(i)
-
-    assert_array_almost_equal(arr_col, csc_col.toarray())
-    assert type(csc_col) is csc_matrix
-
-
-def test_csc_getrow_getcol():
+def test_csc_getrow():
     N = 10
     np.random.seed(0)
     X = np.random.random((N, N))
@@ -27,8 +11,26 @@ def test_csc_getrow_getcol():
     Xcsc = csc_matrix(X)
 
     for i in range(N):
-        yield _check_csc_getrow, i, X, Xcsc
-        yield _check_csc_getcol, i, X, Xcsc
+        arr_row = X[i:i + 1, :]
+        csc_row = Xcsc.getrow(i)
+
+        assert_array_almost_equal(arr_row, csc_row.toarray())
+        assert_(type(csc_row) is csr_matrix)
+
+
+def test_csc_getcol():
+    N = 10
+    np.random.seed(0)
+    X = np.random.random((N, N))
+    X[X > 0.7] = 0
+    Xcsc = csc_matrix(X)
+
+    for i in range(N):
+        arr_col = X[:, i:i + 1]
+        csc_col = Xcsc.getcol(i)
+
+        assert_array_almost_equal(arr_col, csc_col.toarray())
+        assert_(type(csc_col) is csc_matrix)
 
 
 if __name__ == "__main__":

--- a/scipy/sparse/tests/test_csc.py
+++ b/scipy/sparse/tests/test_csc.py
@@ -1,0 +1,23 @@
+import numpy as np
+from numpy.testing import assert_array_almost_equal, run_module_suite
+from scipy.sparse import csc_matrix
+
+
+def test_csc_getrow_getcol():
+    N = 10
+    np.random.seed(0)
+    X = np.random.random((N, N))
+    X[X > 0.7] = 0
+    Xcsr = csc_matrix(X)
+    
+    for i in range(N):
+        # check getrow()
+        yield (assert_array_almost_equal,
+               X[i:i + 1, :], Xcsr.getrow(i).toarray())
+        # check getcol()
+        yield (assert_array_almost_equal,
+               X[:, i:i + 1], Xcsr.getcol(i).toarray())
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_array_almost_equal, run_module_suite
+from numpy.testing import assert_array_almost_equal, run_module_suite, assert_
 from scipy.sparse import csr_matrix
 
 
@@ -7,7 +7,7 @@ def _check_csr_rowslice(i, sl, X, Xcsr):
     np_slice = X[i, sl]
     csr_slice = Xcsr[i, sl]
     assert_array_almost_equal(np_slice, csr_slice.toarray()[0])
-    assert type(csr_slice) is csr_matrix
+    assert_(type(csr_slice) is csr_matrix)
 
 
 def test_csr_rowslice():
@@ -27,23 +27,7 @@ def test_csr_rowslice():
             yield _check_csr_rowslice, i, sl, X, Xcsr
 
 
-def _check_csr_getrow(i, X, Xcsr):
-    arr_row = X[i:i + 1, :]
-    csr_row = Xcsr.getrow(i)
-
-    assert_array_almost_equal(arr_row, csr_row.toarray())
-    assert type(csr_row) is csr_matrix
-
-
-def _check_csr_getcol(i, X, Xcsr):
-    arr_col = X[:, i:i + 1]
-    csr_col = Xcsr.getcol(i)
-
-    assert_array_almost_equal(arr_col, csr_col.toarray())
-    assert type(csr_col) is csr_matrix
-
-
-def test_csr_getrow_getcol():
+def test_csr_getrow():
     N = 10
     np.random.seed(0)
     X = np.random.random((N, N))
@@ -51,8 +35,27 @@ def test_csr_getrow_getcol():
     Xcsr = csr_matrix(X)
 
     for i in range(N):
-        yield _check_csr_getrow, i, X, Xcsr
-        yield _check_csr_getcol, i, X, Xcsr
+        arr_row = X[i:i + 1, :]
+        csr_row = Xcsr.getrow(i)
+
+        assert_array_almost_equal(arr_row, csr_row.toarray())
+        assert_(type(csr_row) is csr_matrix)
+
+
+def test_csr_getcol():
+    N = 10
+    np.random.seed(0)
+    X = np.random.random((N, N))
+    X[X > 0.7] = 0
+    Xcsr = csr_matrix(X)
+
+    for i in range(N):
+        arr_col = X[:, i:i + 1]
+        csr_col = Xcsr.getcol(i)
+
+        assert_array_almost_equal(arr_col, csr_col.toarray())
+        assert_(type(csr_col) is csr_matrix)
+
 
 
 if __name__ == "__main__":

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -25,5 +25,22 @@ def test_csr_rowslice():
         for sl in slices:
             yield (check_csr_rowslice, X, Xcsr, i, sl)
 
+
+def test_csr_getrow_getcol():
+    N = 10
+    np.random.seed(0)
+    X = np.random.random((N, N))
+    X[X > 0.7] = 0
+    Xcsr = csr_matrix(X)
+    
+    for i in range(N):
+        # check getrow()
+        yield (assert_array_almost_equal,
+               X[i:i + 1, :], Xcsr.getrow(i).toarray())
+        # check getcol()
+        yield (assert_array_almost_equal,
+               X[:, i:i + 1], Xcsr.getcol(i).toarray())
+
+
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -1,0 +1,26 @@
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+from scipy.sparse import csr_matrix
+
+
+def check_csr_rowslice(X, Xcsr, i, sl):
+    np_slice = X[i, sl]
+    csr_slice = Xcsr[i, sl]
+    assert_array_almost_equal(np_slice, csr_slice.toarray()[0])
+    
+
+def test_csr_rowslice():
+    N = 10
+    np.random.seed(0)
+    X = np.random.random((N, N))
+    X[X > 0.7] = 0
+    Xcsr = csr_matrix(X)
+
+    slices = [slice(None, None, None),
+              slice(None, None, -1),
+              slice(1, -2, 2),
+              slice(-2, 1, -2)]
+
+    for i in range(N):
+        for sl in slices:
+            yield (check_csr_rowslice, X, Xcsr, i, sl)

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -3,11 +3,12 @@ from numpy.testing import assert_array_almost_equal, run_module_suite
 from scipy.sparse import csr_matrix
 
 
-def check_csr_rowslice(i, sl, X, Xcsr):
+def _check_csr_rowslice(i, sl, X, Xcsr):
     np_slice = X[i, sl]
     csr_slice = Xcsr[i, sl]
     assert_array_almost_equal(np_slice, csr_slice.toarray()[0])
-    
+    assert type(csr_slice) is csr_matrix
+
 
 def test_csr_rowslice():
     N = 10
@@ -23,7 +24,23 @@ def test_csr_rowslice():
 
     for i in range(N):
         for sl in slices:
-            yield (check_csr_rowslice, i, sl, X, Xcsr)
+            yield _check_csr_rowslice, i, sl, X, Xcsr
+
+
+def _check_csr_getrow(i, X, Xcsr):
+    arr_row = X[i:i + 1, :]
+    csr_row = Xcsr.getrow(i)
+
+    assert_array_almost_equal(arr_row, csr_row.toarray())
+    assert type(csr_row) is csr_matrix
+
+
+def _check_csr_getcol(i, X, Xcsr):
+    arr_col = X[:, i:i + 1]
+    csr_col = Xcsr.getcol(i)
+
+    assert_array_almost_equal(arr_col, csr_col.toarray())
+    assert type(csr_col) is csr_matrix
 
 
 def test_csr_getrow_getcol():
@@ -32,14 +49,10 @@ def test_csr_getrow_getcol():
     X = np.random.random((N, N))
     X[X > 0.7] = 0
     Xcsr = csr_matrix(X)
-    
+
     for i in range(N):
-        # check getrow()
-        yield (assert_array_almost_equal,
-               X[i:i + 1, :], Xcsr.getrow(i).toarray())
-        # check getcol()
-        yield (assert_array_almost_equal,
-               X[:, i:i + 1], Xcsr.getcol(i).toarray())
+        yield _check_csr_getrow, i, X, Xcsr
+        yield _check_csr_getcol, i, X, Xcsr
 
 
 if __name__ == "__main__":

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, run_module_suite
 from scipy.sparse import csr_matrix
 
 
@@ -24,3 +24,6 @@ def test_csr_rowslice():
     for i in range(N):
         for sl in slices:
             yield (check_csr_rowslice, X, Xcsr, i, sl)
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -3,7 +3,7 @@ from numpy.testing import assert_array_almost_equal, run_module_suite
 from scipy.sparse import csr_matrix
 
 
-def check_csr_rowslice(X, Xcsr, i, sl):
+def check_csr_rowslice(i, sl, X, Xcsr):
     np_slice = X[i, sl]
     csr_slice = Xcsr[i, sl]
     assert_array_almost_equal(np_slice, csr_slice.toarray()[0])
@@ -23,7 +23,7 @@ def test_csr_rowslice():
 
     for i in range(N):
         for sl in slices:
-            yield (check_csr_rowslice, X, Xcsr, i, sl)
+            yield (check_csr_rowslice, i, sl, X, Xcsr)
 
 
 def test_csr_getrow_getcol():


### PR DESCRIPTION
This is in response to PR #307

I've improved the csr_matrix code for getting slices of single rows.  It's now much faster than before, and correctly handles slices with arbitrary strides.  Here's a benchmark similar to that mentioned in #307:

``` python
import numpy as np
import scipy.sparse as sp
import time
import random

a = sp.csr_matrix(np.mat(np.random.rand(500,500)))

no_samples = 500
idx = range(no_samples)
random.shuffle(idx)

for thr in [0.2, 0.6]:
    a.data[a.data < thr] = 0
    a.eliminate_zeros()
    print
    print "Shape and nnz/size", a.shape, a.nnz/float(a.shape[0]*a.shape[1])

    st = time.time()
    for i in idx:
        b = a[i]
    print "a[i]", (time.time() - st)/no_samples

    st = time.time()
    for i in idx:
        b = a.getrow(i)
    print "getrow(i)", (time.time() - st)/no_samples

    st = time.time()
    for i in idx:
        b = a[i:i+1]
    print "a[i:i+1]", (time.time() - st)/no_samples
```

These are the results on my machine:

```
Shape and nnz/size (500, 500) 0.799424
a[i] 0.000124758243561
getrow(i) 0.000647622108459
a[i:i+1] 0.000129615783691

Shape and nnz/size (500, 500) 0.399712
a[i] 0.000122797966003
getrow(i) 0.000641570091248
a[i:i+1] 0.000126832008362
```

In addition, tests pass for arbitrary positive and negative strides.
