### PR TITLE
Docstrings: improvement rv_discrete

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -5528,7 +5528,7 @@ class rv_discrete(rv_generic):
             - frozen RV object with the same methods but holding the given
               shape and location fixed.
 
-    You can construct an aribtrary discrete rv where ``P{X=xk} = pk``
+    You can construct an arbitrary discrete rv where ``P{X=xk} = pk``
     by passing to the rv_discrete initialization method (through the
     values=keyword) a tuple of sequences (xk, pk) which describes only those
     values of X (xk) that occur with nonzero probability (pk).

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -5554,9 +5554,10 @@ class rv_discrete(rv_generic):
     Custom made discrete distribution:
 
     >>> import matplotlib.pyplot as plt
-    >>> xk = arange(7)
+    >>> from scipy import stats
+    >>> xk = np.arange(7)
     >>> pk = (0.1, 0.2, 0.3, 0.1, 0.1, 0.1, 0.1)
-    >>> custm = rv_discrete(name='custm', values=(xk, pk))
+    >>> custm = stats.rv_discrete(name='custm', values=(xk, pk))
     >>> h = plt.plot(xk, custm.pmf(xk))
 
     Random number generation:

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -5572,9 +5572,10 @@ class rv_discrete(rv_generic):
 
     Custom made discrete distribution:
 
-    >>> vals = [arange(7), (0.1, 0.2, 0.3, 0.1, 0.1, 0.1, 0.1)]
-    >>> custm = rv_discrete(name='custm', values=vals)
-    >>> h = plt.plot(vals[0], custm.pmf(vals[0]))
+    >>> xk = arange(7)
+    >>> pk = (0.1, 0.2, 0.3, 0.1, 0.1, 0.1, 0.1)
+    >>> custm = rv_discrete(name='custm', values=(xk, pk))
+    >>> h = plt.plot(xk, custm.pmf(xk))
 
     """
 

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -5521,12 +5521,6 @@ class rv_discrete(rv_generic):
 
     Notes
     -----
-    Alternatively, the object may be called (as a function) to fix the shape
-    and location parameters returning a "frozen" discrete RV object::
-
-        myrv = generic(<shape(s)>, loc=0)
-            - frozen RV object with the same methods but holding the given
-              shape and location fixed.
 
     You can construct an arbitrary discrete rv where ``P{X=xk} = pk``
     by passing to the rv_discrete initialization method (through the
@@ -5547,14 +5541,32 @@ class rv_discrete(rv_generic):
 
     The docstring can be created from a template.
 
+    Alternatively, the object may be called (as a function) to fix the shape
+    and location parameters returning a "frozen" discrete RV object::
+
+        myrv = generic(<shape(s)>, loc=0)
+            - frozen RV object with the same methods but holding the given
+              shape and location fixed.
+
     Examples
     --------
+
+    Custom made discrete distribution:
+
     >>> import matplotlib.pyplot as plt
-    >>> numargs = generic.numargs
-    >>> [ <shape(s)> ] = ['Replace with resonable value', ]*numargs
+    >>> xk = arange(7)
+    >>> pk = (0.1, 0.2, 0.3, 0.1, 0.1, 0.1, 0.1)
+    >>> custm = rv_discrete(name='custm', values=(xk, pk))
+    >>> h = plt.plot(xk, custm.pmf(xk))
+
+    Random number generation:
+
+    >>> R = custm.rvs(size=100)
 
     Display frozen pmf:
 
+    >>> numargs = generic.numargs
+    >>> [ <shape(s)> ] = ['Replace with resonable value', ]*numargs
     >>> rv = generic(<shape(s)>)
     >>> x = np.arange(0, np.min(rv.dist.b, 3)+1)
     >>> h = plt.plot(x, rv.pmf(x))
@@ -5565,17 +5577,6 @@ class rv_discrete(rv_generic):
 
     >>> prb = generic.cdf(x, <shape(s)>)
     >>> h = plt.semilogy(np.abs(x-generic.ppf(prb, <shape(s)>))+1e-20)
-
-    Random number generation:
-
-    >>> R = generic.rvs(<shape(s)>, size=100)
-
-    Custom made discrete distribution:
-
-    >>> xk = arange(7)
-    >>> pk = (0.1, 0.2, 0.3, 0.1, 0.1, 0.1, 0.1)
-    >>> custm = rv_discrete(name='custm', values=(xk, pk))
-    >>> h = plt.plot(xk, custm.pmf(xk))
 
     """
 


### PR DESCRIPTION
Hi,

From my point of view, the docstring of class rv_discrete() was poorly understandable. 

The problem was:
Most of examples were not directly executable and mostly illustrated the ' Alternatively' section in notes.

In the new version, 
- It starts with a distribution from a list.
- I use the notation xk, pk, easily understandable and already used previously in the doc. 
- The 'alternatively' section is now at the end of the Notes (it's an alternative ;) )
- A typo fixed :)

I have not fully understood yet examples using <shape(s)>. But I think we must avoid examples that could not be executed "out of the box". For the moment, still there... 

François.
