### PR TITLE
DOC: More changes to waveform docstrings

### DIFF
--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -19,6 +19,10 @@ def sawtooth(t, width=1):
     interval 0 to ``width*2*pi``, then drops from 1 to -1 on the interval
     ``width*2*pi`` to ``2*pi``. `width` must be in the interval [0, 1].
 
+    Note that this is not band-limited.  It produces an infinite number 
+    of harmonics, which are aliased back and forth across the frequency 
+    spectrum.
+
     Parameters
     ----------
     t : array_like
@@ -83,6 +87,10 @@ def square(t, duty=0.5):
     The square wave has a period ``2*pi``, has value +1 from 0 to
     ``2*pi*duty`` and -1 from ``2*pi*duty`` to ``2*pi``. `duty` must be in
     the interval [0,1].
+
+    Note that this is not band-limited.  It produces an infinite number 
+    of harmonics, which are aliased back and forth across the frequency 
+    spectrum.
 
     Parameters
     ----------

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -117,6 +117,16 @@ def square(t, duty=0.5):
     >>> plt.plot(t, scipy.signal.square(2 * np.pi * 5 * t))
     >>> plt.ylim(-2, 2)
 
+    A pulse-width modulated sine wave:
+
+    >>> sig = np.sin(2 * np.pi * t)
+    >>> pwm = scipy.signal.square(2 * np.pi * 30 * t, duty=(sig + 1)/2)
+    >>> plt.subplot(2, 1, 1)
+    >>> plt.plot(t, sig)
+    >>> plt.subplot(2, 1, 2)
+    >>> plt.plot(t, pwm)
+    >>> plt.ylim(-1.5, 1.5)
+
     """
     t, w = asarray(t), asarray(duty)
     w = asarray(w + (t - t))

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -27,10 +27,12 @@ def sawtooth(t, width=1):
     ----------
     t : array_like
         Time.
-    width : float, optional
+    width : float or array_like, optional
         Width of the rising ramp as a proportion of the total cycle.
         Default is 1, producing a rising ramp, while 0 produces a falling
         ramp.  `t` = 0.5 produces a triangle wave.
+        If an array, must be the same length as t, causes wave shape to change 
+        over time.
 
     Returns
     -------
@@ -96,8 +98,10 @@ def square(t, duty=0.5):
     ----------
     t : array_like
         The input time array.
-    duty : float, optional
+    duty : float or array_like, optional
         Duty cycle.  Default is 0.5 (50% duty cycle)
+        If an array, must be the same length as t, causes wave shape to change 
+        over time.
 
     Returns
     -------


### PR DESCRIPTION
1: Add note that waveforms are not band-limited

see for example:
http://www.music.mcgill.ca/~gary/307/week5/bandlimited.html

http://projects.scipy.org/scipy/ticket/980

https://gist.github.com/407991

Feel free to completely change the wording.  I just think it should be mentioned in some way.

2: Add note that `duty` and `width` can be arrays, show an example of pulse-width modulation.
