### PR TITLE
ENH: removed superfluous asarray conversion in stats.distributions.py

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -6810,8 +6810,8 @@ class poisson_gen(rv_discrete):
     def _stats(self, mu):
         var = mu
         tmp = asarray(mu)
-        g1 = 1.0/asarray(tmp)
-        g2 = 1.0 / asarray(tmp)
+        g1 = 1.0 / tmp
+        g2 = 1.0 / tmp
         return mu, var, g1, g2
 poisson = poisson_gen(name="poisson", longname='A Poisson', shapes="mu")
 


### PR DESCRIPTION
I guess I forgot to remove the asarray around the tmp variable. 
