### PR TITLE
ENH: add a callback mechanism to L-BFGS-B (ticket #923)

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -303,7 +303,7 @@ def minimize(fun, x0, args=(), method='BFGS', jac=None, hess=None,
         warn('Method %s cannot handle bounds.' % method,
              RuntimeWarning)
     # - callback
-    if (meth in ['anneal', 'l-bfgs-b', 'tnc', 'cobyla', 'slsqp'] and
+    if (meth in ['anneal', 'tnc', 'cobyla', 'slsqp'] and
         callback is not None):
         warn('Method %s does not support callback.' % method,
              RuntimeWarning)


### PR DESCRIPTION
As suggested in [ticket #923](http://projects.scipy.org/scipy/ticket/923), this PR adds a callback mechanism to L-BFGS-B minimization algorithm. It is not the same as suggested in the ticket but it conforms with other callback behavior in the optimize module.
