### PR TITLE
DOCSTRING: moved from top to class (netcdf)

### DIFF
--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -6,78 +6,6 @@ accessed through the `netcdf_file` object. Data written to and from NetCDF
 files are contained in `netcdf_variable` objects. Attributes are given
 as member variables of the `netcdf_file` and `netcdf_variable` objects.
 
-Notes
------
-NetCDF files are a self-describing binary data format. The file contains
-metadata that describes the dimensions and variables in the file. More
-details about NetCDF files can be found `here
-<http://www.unidata.ucar.edu/software/netcdf/docs/netcdf.html>`_. There
-are three main sections to a NetCDF data structure:
-
-1. Dimensions
-2. Variables
-3. Attributes
-
-The dimensions section records the name and length of each dimension used
-by the variables. The variables would then indicate which dimensions it
-uses and any attributes such as data units, along with containing the data
-values for the variable. It is good practice to include a
-variable that is the same name as a dimension to provide the values for
-that axes. Lastly, the attributes section would contain additional
-information such as the name of the file creator or the instrument used to
-collect the data.
-
-When writing data to a NetCDF file, there is often the need to indicate the
-'record dimension'. A record dimension is the unbounded dimension for a
-variable. For example, a temperature variable may have dimensions of
-latitude, longitude and time. If one wants to add more temperature data to
-the NetCDF file as time progresses, then the temperature variable should
-have the time dimension flagged as the record dimension.
-
-This module implements the Scientific.IO.NetCDF API to read and create
-NetCDF files. The same API is also used in the PyNIO and pynetcdf
-modules, allowing these modules to be used interchangeably when working
-with NetCDF files. The major advantage of this module over other
-modules is that it doesn't require the code to be linked to the NetCDF
-libraries.
-
-In addition, the NetCDF file header contains the position of the data in
-the file, so access can be done in an efficient manner without loading
-unnecessary data into memory. It uses the ``mmap`` module to create
-Numpy arrays mapped to the data on disk, for the same purpose.
-
-Examples
---------
-To create a NetCDF file:
-
-    >>> from scipy.io import netcdf
-    >>> f = netcdf.netcdf_file('simple.nc', 'w')
-    >>> f.history = 'Created for a test'
-    >>> f.createDimension('time', 10)
-    >>> time = f.createVariable('time', 'i', ('time',))
-    >>> time[:] = range(10)
-    >>> time.units = 'days since 2008-01-01'
-    >>> f.close()
-
-Note the assignment of ``range(10)`` to ``time[:]``.  Exposing the slice
-of the time variable allows for the data to be set in the object, rather
-than letting ``range(10)`` overwrite the ``time`` variable.
-
-To read the NetCDF file we just created:
-
-    >>> from scipy.io import netcdf
-    >>> f = netcdf.netcdf_file('simple.nc', 'r')
-    >>> print f.history
-    Created for a test
-    >>> time = f.variables['time']
-    >>> print time.units
-    days since 2008-01-01
-    >>> print time.shape
-    (10,)
-    >>> print time[-1]
-    9
-    >>> f.close()
-
 """
 
 #TODO:
@@ -171,6 +99,77 @@ class netcdf_file(object):
         `here <http://www.unidata.ucar.edu/software/netcdf/docs/netcdf/Which-Format.html>`_
         for more info.
 
+    Notes
+    -----
+    NetCDF files are a self-describing binary data format. The file contains
+    metadata that describes the dimensions and variables in the file. More
+    details about NetCDF files can be found `here
+    <http://www.unidata.ucar.edu/software/netcdf/docs/netcdf.html>`_. There
+    are three main sections to a NetCDF data structure:
+    
+    1. Dimensions
+    2. Variables
+    3. Attributes
+    
+    The dimensions section records the name and length of each dimension used
+    by the variables. The variables would then indicate which dimensions it
+    uses and any attributes such as data units, along with containing the data
+    values for the variable. It is good practice to include a
+    variable that is the same name as a dimension to provide the values for
+    that axes. Lastly, the attributes section would contain additional
+    information such as the name of the file creator or the instrument used to
+    collect the data.
+    
+    When writing data to a NetCDF file, there is often the need to indicate the
+    'record dimension'. A record dimension is the unbounded dimension for a
+    variable. For example, a temperature variable may have dimensions of
+    latitude, longitude and time. If one wants to add more temperature data to
+    the NetCDF file as time progresses, then the temperature variable should
+    have the time dimension flagged as the record dimension.
+    
+    This module implements the Scientific.IO.NetCDF API to read and create
+    NetCDF files. The same API is also used in the PyNIO and pynetcdf
+    modules, allowing these modules to be used interchangeably when working
+    with NetCDF files. The major advantage of this module over other
+    modules is that it doesn't require the code to be linked to the NetCDF
+    libraries.
+    
+    In addition, the NetCDF file header contains the position of the data in
+    the file, so access can be done in an efficient manner without loading
+    unnecessary data into memory. It uses the ``mmap`` module to create
+    Numpy arrays mapped to the data on disk, for the same purpose.
+    
+    Examples
+    --------
+    To create a NetCDF file:
+    
+        >>> from scipy.io import netcdf
+        >>> f = netcdf.netcdf_file('simple.nc', 'w')
+        >>> f.history = 'Created for a test'
+        >>> f.createDimension('time', 10)
+        >>> time = f.createVariable('time', 'i', ('time',))
+        >>> time[:] = range(10)
+        >>> time.units = 'days since 2008-01-01'
+        >>> f.close()
+    
+    Note the assignment of ``range(10)`` to ``time[:]``.  Exposing the slice
+    of the time variable allows for the data to be set in the object, rather
+    than letting ``range(10)`` overwrite the ``time`` variable.
+    
+    To read the NetCDF file we just created:
+    
+        >>> from scipy.io import netcdf
+        >>> f = netcdf.netcdf_file('simple.nc', 'r')
+        >>> print f.history
+        Created for a test
+        >>> time = f.variables['time']
+        >>> print time.units
+        days since 2008-01-01
+        >>> print time.shape
+        (10,)
+        >>> print time[-1]
+        9
+        >>> f.close()
     """
     def __init__(self, filename, mode='r', mmap=None, version=1):
         """Initialize netcdf_file from fileobj (str or file-like)."""

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -6,6 +6,10 @@ accessed through the `netcdf_file` object. Data written to and from NetCDF
 files are contained in `netcdf_variable` objects. Attributes are given
 as member variables of the `netcdf_file` and `netcdf_variable` objects.
 
+This module implements the Scientific.IO.NetCDF API to read and create
+NetCDF files. The same API is also used in the PyNIO and pynetcdf
+modules, allowing these modules to be used interchangeably when working
+with NetCDF files. 
 """
 
 #TODO:
@@ -101,6 +105,10 @@ class netcdf_file(object):
 
     Notes
     -----
+    The major advantage of this module over other modules is that it doesn't 
+    require the code to be linked to the NetCDF libraries. This module is
+    derived from `pupynere <https://bitbucket.org/robertodealmeida/pupynere/>`_.
+
     NetCDF files are a self-describing binary data format. The file contains
     metadata that describes the dimensions and variables in the file. More
     details about NetCDF files can be found `here
@@ -127,13 +135,6 @@ class netcdf_file(object):
     the NetCDF file as time progresses, then the temperature variable should
     have the time dimension flagged as the record dimension.
     
-    This module implements the Scientific.IO.NetCDF API to read and create
-    NetCDF files. The same API is also used in the PyNIO and pynetcdf
-    modules, allowing these modules to be used interchangeably when working
-    with NetCDF files. The major advantage of this module over other
-    modules is that it doesn't require the code to be linked to the NetCDF
-    libraries.
-    
     In addition, the NetCDF file header contains the position of the data in
     the file, so access can be done in an efficient manner without loading
     unnecessary data into memory. It uses the ``mmap`` module to create
@@ -148,7 +149,7 @@ class netcdf_file(object):
         >>> f.history = 'Created for a test'
         >>> f.createDimension('time', 10)
         >>> time = f.createVariable('time', 'i', ('time',))
-        >>> time[:] = range(10)
+        >>> time[:] = np.arange(10)
         >>> time.units = 'days since 2008-01-01'
         >>> f.close()
     


### PR DESCRIPTION
Hi,

As far I understand, the docstrings at the top of files are not included in the documentation.
For instance, the netcdf.py (in scipy.io) contains Notes and examples which are not in the doc
(I checked there: http://docs.scipy.org/doc/scipy/reference/tutorial/io.html?highlight=netcdf#module-scipy.io.netcdf and http://docs.scipy.org/doc/scipy/reference/generated/scipy.io.netcdf.netcdf_file.html#scipy.io.netcdf.netcdf_file)

Since notes and examples document the usage of netcdf_file, I moved these sections in the docstring of this class.

Please, correct me if I'm wrong.
