### PR TITLE
TST: add a test for special.stdtr().

### DIFF
--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -439,6 +439,8 @@ class TestCephes(TestCase):
         assert_equal(cephes.spence(1),0.0)
     def test_stdtr(self):
         assert_equal(cephes.stdtr(1,0),0.5)
+        assert_almost_equal(cephes.stdtr(1,1), 0.75)
+        assert_almost_equal(cephes.stdtr(1,2), 0.852416382349)
     def test_stdtridf(self):
         cephes.stdtridf(0.7,1)
     def test_stdtrit(self):


### PR DESCRIPTION
See ticket 1734.  This may fail on OS X 10.8, which would show the issue more
clearly that the current failures in stats.ttest_ind/ttest_ind_unequal_var.
