### PR TITLE
0.11.0 final release

### DIFF
--- a/doc/release/0.11.0-notes.rst
+++ b/doc/release/0.11.0-notes.rst
@@ -2,8 +2,6 @@
 SciPy 0.11.0 Release Notes
 ==========================
 
-.. note:: Scipy 0.11.0 is not released yet!
-
 .. contents::
 
 SciPy 0.11.0 is the culmination of 8 months of hard work. It contains

--- a/pavement.py
+++ b/pavement.py
@@ -116,7 +116,7 @@ RELEASE = 'doc/release/0.11.0-notes.rst'
 
 # Start/end of the log (from git)
 LOG_START = 'v0.10.0'
-LOG_END = 'v0.11.0rc2'
+LOG_END = 'v0.11.0'
 
 
 #-------------------------------------------------------

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -10,6 +10,8 @@ Run tests if linalg is not installed:
   python tests/test_decomp.py
 """
 
+import sys
+
 import numpy as np
 from numpy.testing import TestCase, assert_equal, assert_array_almost_equal, \
         assert_array_equal, assert_raises, assert_, run_module_suite, dec
@@ -187,6 +189,7 @@ class TestEig(object):
         assert_array_almost_equal(sort(w[isfinite(w)]), sort(wt[isfinite(wt)]),
                                   err_msg=msg)
 
+    @dec.knownfailureif(sys.platform == "win32", "See ticket #1735")
     def test_singular(self):
         """Test singular pair"""
         # Example taken from

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ MAJOR               = 0
 MINOR               = 11
 MICRO               = 0
 ISRELEASED          = True
-VERSION             = '%d.%d.%drc2' % (MAJOR, MINOR, MICRO)
+VERSION             = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
 # Return the git revision as a string


### PR DESCRIPTION
Here's one more commit marking the TestEig.test_singular test as knownfail on Windows (see http://projects.scipy.org/scipy/ticket/1735), plus the final release.

I propose to do the release like this, it's already taken too long. I consider all the random OS X issues out of scope for now. If someone wants to have a go at them, great -- but I don't consider them blocking for this release. Opinions?
