### PR TITLE
DOC: Docstring regexps

### DIFF
--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -732,7 +732,7 @@ def newton_cotes(rn, equal=0):
         The integer order for equally-spaced data or the relative positions of
         the samples with the first sample at 0 and the last at N, where N+1 is
         the length of `rn`.  N is the order of the Newton-Cotes integration.
-    equal: int, optional
+    equal : int, optional
         Set to 1 to enforce equally spaced data.
 
     Returns

--- a/scipy/io/harwell_boeing/_fortran_format_parser.py
+++ b/scipy/io/harwell_boeing/_fortran_format_parser.py
@@ -42,14 +42,14 @@ class IntFormat(object):
 
         Parameters
         ----------
-        n: int
+        n : int
             max number one wants to be able to represent
-        min: int
+        min : int
             minimum number of characters to use for the format
 
         Returns
         -------
-        res: IntFormat
+        res : IntFormat
             IntFormat instance with reasonable (see Notes) computed width
 
         Notes
@@ -102,14 +102,14 @@ class ExpFormat(object):
 
         Parameters
         ----------
-        n: float
+        n : float
             max number one wants to be able to represent
-        min: int
+        min : int
             minimum number of characters to use for the format
 
         Returns
         -------
-        res: ExpFormat
+        res : ExpFormat
             ExpFormat instance with reasonable (see Notes) computed width
 
         Notes
@@ -135,7 +135,7 @@ class ExpFormat(object):
         """\
         Parameters
         ----------
-        width: int
+        width : int
             number of characters taken by the string (includes space).
         """
         self.width = width

--- a/scipy/io/harwell_boeing/hb.py
+++ b/scipy/io/harwell_boeing/hb.py
@@ -51,20 +51,20 @@ class HBInfo(object):
 
         Parameters
         ----------
-        m: sparse matrix
+        m : sparse matrix
             the HBInfo instance will derive its parameters from m
-        title: str
+        title : str
             Title to put in the HB header
-        key: str
+        key : str
             Key
-        mxtype: HBMatrixType
+        mxtype : HBMatrixType
             type of the input matrix
-        fmt: dict
+        fmt : dict
             not implemented
 
         Returns
         -------
-        hb_info: HBInfo instance
+        hb_info : HBInfo instance
         """
         pointer = m.indptr
         indices = m.indices
@@ -127,12 +127,12 @@ class HBInfo(object):
 
         Parameters
         ----------
-        fid: file-like matrix
+        fid : file-like matrix
             File or file-like object containing a matrix in the HB format.
 
         Returns
         -------
-        hb_info: HBInfo instance
+        hb_info : HBInfo instance
         """
         # First line
         line = fid.readline().strip("\n")
@@ -424,9 +424,9 @@ class HBFile(object):
 
         Parameters
         ----------
-        file: file-object
+        file : file-object
             StringIO work as well
-        hb_info: HBInfo
+        hb_info : HBInfo
             Should be given as an argument for writing, in which case the file
             should be writable.
         """
@@ -470,7 +470,7 @@ def hb_read(file):
 
     Parameters
     ----------
-    file: str-like or file-like
+    file : str-like or file-like
         If a string-like object, file is the name of the file to read. If a
         file-like object, the data are read from it.
 
@@ -508,12 +508,12 @@ def hb_write(file, m, hb_info=None):
 
     Parameters
     ----------
-    file: str-like or file-like
+    file : str-like or file-like
         if a string-like object, file is the name of the file to read. If a
         file-like object, the data are read from it.
-    m: sparse-matrix
+    m : sparse-matrix
         the sparse matrix to write
-    hb_info: HBInfo
+    hb_info : HBInfo
         contains the meta-data for write
 
     Returns

--- a/scipy/io/idl.py
+++ b/scipy/io/idl.py
@@ -677,7 +677,7 @@ def readsav(file_name, idict=None, python_dict=False,
         Name of the IDL save file.
     idict : dict, optional
         Dictionary in which to insert .sav file variables
-    python_dict: bool, optional
+    python_dict : bool, optional
         By default, the object return is not a Python dictionary, but a
         case-insensitive dictionary with item, attribute, and call access
         to variables. To get a standard Python dictionary, set this option

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -584,7 +584,7 @@ class VarWriter5(object):
         name : str, optional
             name as it will appear in matlab workspace
             default is empty string
-        is_global : {False, True} optional
+        is_global : {False, True}, optional
             whether variable will be global on load into matlab
         """
         # these are set before the top-level header write, and unset at

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -228,7 +228,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
         Indexes of the smallest and largest (in ascending order) eigenvalues
         and corresponding eigenvectors to be returned: 0 <= lo < hi <= M-1.
         If omitted, all eigenvalues and eigenvectors are returned.
-    type: integer
+    type : integer
         Specifies the problem type to be solved:
            type = 1: a   v[:,i] = w[i] b v[:,i]
            type = 2: a b v[:,i] = w[i]   v[:,i]
@@ -425,7 +425,7 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
         (Default: calculate also eigenvectors)
     overwrite_a_band:
         Discard data in a_band (may enhance performance)
-    select: {'a', 'v', 'i'}
+    select : {'a', 'v', 'i'}
         Which eigenvalues to calculate
 
         ======  ========================================
@@ -604,7 +604,7 @@ def eigvalsh(a, b=None, lower=True, overwrite_a=False,
         Indexes of the smallest and largest (in ascending order) eigenvalues
         and corresponding eigenvectors to be returned: 0 <= lo < hi <= M-1.
         If omitted, all eigenvalues and eigenvectors are returned.
-    type: integer
+    type : integer
         Specifies the problem type to be solved:
            type = 1: a   v[:,i] = w[i] b v[:,i]
            type = 2: a b v[:,i] = w[i]   v[:,i]
@@ -675,7 +675,7 @@ def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
         Is the matrix in the lower form. (Default is upper form)
     overwrite_a_band:
         Discard data in a_band (may enhance performance)
-    select: {'a', 'v', 'i'}
+    select : {'a', 'v', 'i'}
         Which eigenvalues to calculate
 
         ======  ========================================

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -195,7 +195,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
         than explicit conjugation.
     overwrite_a : bool, optional
         Whether data in a is overwritten (may improve performance)
-    overwrite_c: bool, optional
+    overwrite_c : bool, optional
         Whether data in c is overwritten (may improve performance).
         If this is used, c must be big enough to keep the result,
         i.e. c.shape[0] = a.shape[0] if mode is 'left'.

--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -414,21 +414,21 @@ def _stats(input, labels=None, index=None, centered=False):
         compatible with `input`; typically it is the same shape as `input`.
         If `labels` is None, all nonzero values in `input` are treated as
         the single labeled group.
-    index: label or sequence of labels, optional
+    index : label or sequence of labels, optional
         These are the labels of the groups for which the stats are computed.
         If `index` is None, the stats are computed for the single group where
         `labels` is greater than 0.
-    centered: bool, optional
+    centered : bool, optional
         If True, the centered sum of squares for each labeled group is
         also returned.  Default is False.
 
     Returns
     -------
-    counts: int or ndarray of ints
+    counts : int or ndarray of ints
         The number of elements in each labeled group.
-    sums: scalar or ndarray of scalars
+    sums : scalar or ndarray of scalars
         The sums of the values in each labeled group.
-    sums_c: scalar or ndarray of scalars, optional
+    sums_c : scalar or ndarray of scalars, optional
         The sums of mean-centered squares of the values in each labeled group.
         This is only returned if `centered` is True.
 
@@ -818,15 +818,15 @@ def minimum(input, labels=None, index=None):
 
     Parameters
     ----------
-    input: array_like
+    input : array_like
         Array_like of values. For each region specified by `labels`, the
         minimal values of `input` over the region is computed.
-    labels: array_like, optional
+    labels : array_like, optional
         An array_like of integers marking different regions over which the
         minimum value of `input` is to be computed. `labels` must have the
         same shape as `input`. If `labels` is not specified, the minimum
         over the whole array is returned.
-    index: array_like, optional
+    index : array_like, optional
         A list of region labels that are taken into account for computing the
         minima. If index is None, the minimum over all elements where `labels`
         is non-zero is returned.
@@ -956,15 +956,15 @@ def median(input, labels=None, index=None):
 
     Parameters
     ----------
-    input: array_like
+    input : array_like
         Array_like of values. For each region specified by `labels`, the
         median value of `input` over the region is computed.
-    labels: array_like, optional
+    labels : array_like, optional
         An array_like of integers marking different regions over which the
         median value of `input` is to be computed. `labels` must have the
         same shape as `input`. If `labels` is not specified, the median
         over the whole array is returned.
-    index: array_like, optional
+    index : array_like, optional
         A list of region labels that are taken into account for computing the
         medians. If index is None, the minimum over all elements where `labels`
         is non-zero is returned.

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -71,7 +71,7 @@ def iterate_structure(structure, iterations, origin = None):
     Returns
     -------
 
-    output: ndarray of bools
+    output : ndarray of bools
         A new structuring element obtained by dilating `structure`
         (`iterations` - 1) times with itself.
 
@@ -330,17 +330,17 @@ def binary_erosion(input, structure = None, iterations = 1, mask = None,
         Array of the same shape as input, into which the output is placed.
         By default, a new array is created.
 
-    origin: int or tuple of ints, optional
+    origin : int or tuple of ints, optional
         Placement of the filter, by default 0.
 
-    border_value: int (cast to 0 or 1)
+    border_value : int (cast to 0 or 1)
         Value at the border in the output array.
 
 
     Returns
     -------
 
-    out: ndarray of bools
+    out : ndarray of bools
         Erosion of the input by the structuring element.
 
 
@@ -1063,27 +1063,27 @@ def binary_fill_holes(input, structure = None, output = None, origin = 0):
     Parameters
     ----------
 
-    input: array_like
+    input : array_like
         n-dimensional binary array with holes to be filled
 
-    structure: array_like, optional
+    structure : array_like, optional
         Structuring element used in the computation; large-size elements
         make computations faster but may miss holes separated from the
         background by thin regions. The default element (with a square
         connectivity equal to one) yields the intuitive result where all
         holes in the input have been filled.
 
-    output: ndarray, optional
+    output : ndarray, optional
         Array of the same shape as input, into which the output is placed.
         By default, a new array is created.
 
-    origin: int, tuple of ints, optional
+    origin : int, tuple of ints, optional
         Position of the structuring element.
 
     Returns
     -------
 
-    out: ndarray
+    out : ndarray
         Transformation of the initial image `input` where holes have been
         filled.
 

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -81,13 +81,13 @@ def minimize(fun, x0, args=(), method='BFGS', jac=None, hess=None,
     constraints : dict or sequence of dict, optional
         Constraints definition (only for COBYLA and SLSQP).
         Each constraint is defined in a dictionary with fields:
-            type: str
+            type : str
                 Constraint type: 'eq' for equality, 'ineq' for inequality.
-            fun: callable
+            fun : callable
                 The function defining the constraint.
-            jac: callable, optional
+            jac : callable, optional
                 The Jacobian of `fun` (only for SLSQP).
-            args: sequence, optional
+            args : sequence, optional
                 Extra arguments to be passed to the function and Jacobian.
         Equality constraint means that the constraint function result is to
         be zero whereas inequality means that it is to be non-negative.

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -78,10 +78,10 @@ class Result(dict):
         Description of the cause of the termination.
     fun, jac, hess : ndarray
         Values of objective function, Jacobian and Hessian (if available).
-    nfev, njev, nhev: int
+    nfev, njev, nhev : int
         Number of evaluations of the objective functions and of its
         Jacobian and Hessian.
-    nit: int
+    nit : int
         Number of iterations performed by the optimizer.
     maxcv : float
         The maximum constraint violation.
@@ -605,19 +605,19 @@ def check_grad(func, grad, x0, *args):
 
     Parameters
     ----------
-    func: callable func(x0,*args)
+    func : callable func(x0,*args)
         Function whose derivative is to be checked.
-    grad: callable grad(x0, *args)
+    grad : callable grad(x0, *args)
         Gradient of `func`.
-    x0: ndarray
+    x0 : ndarray
         Points to check `grad` against forward difference approximation of grad
         using `func`.
-    args: \*args, optional
+    args : \*args, optional
         Extra arguments passed to `func` and `grad`.
 
     Returns
     -------
-    err: float
+    err : float
         The square root of the sum of squares (i.e. the 2-norm) of the
         difference between ``grad(x0, *args)`` and the finite difference
         approximation of `grad` using func at the points `x0`.

--- a/scipy/optimize/tnc.py
+++ b/scipy/optimize/tnc.py
@@ -115,7 +115,7 @@ def fmin_tnc(func, x0, fprime=None, args=(), approx_grad=0,
         (min, max) pairs for each element in x0, defining the
         bounds on that parameter. Use None or +/-inf for one of
         min or max when there is no bound in that direction.
-    epsilon: float
+    epsilon : float
         Used if approx_grad is True. The stepsize in a finite
         difference approximation for fprime.
     scale : list of floats
@@ -268,7 +268,7 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
     Newton (TNC) algorithm.
 
     Options for the TNC algorithm are:
-        eps: float
+        eps : float
             Step size used for numerical approximation of the jacobian.
         scale : list of floats
             Scaling factors to apply to each variable.  If None, the

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -18,16 +18,16 @@ def _boolrelextrema(data, comparator,
 
     Parameters
     ----------
-    data: ndarray
-    comparator: function
+    data : ndarray
+    comparator : function
         function to use to compare two data points.
         Should take 2 numbers as arguments
-    axis: int, optional
+    axis : int, optional
         axis over which to select from `data`
-    order: int, optional
+    order : int, optional
         How many points on each side to require
         a `comparator`(n,n+x) = True.
-    mode: string, optional
+    mode : string, optional
         How the edges of the vector are treated.
         'wrap' (wrap around) or 'clip' (treat overflow
         as the same as the last (or first) element).
@@ -35,7 +35,7 @@ def _boolrelextrema(data, comparator,
 
     Returns
     -------
-    extrema: ndarray
+    extrema : ndarray
         Indices of the extrema, as boolean array
         of same shape as data. True for an extrema,
         False else.
@@ -98,7 +98,7 @@ def argrelextrema(data, comparator,
 
     Returns
     -------
-    extrema: ndarray
+    extrema : ndarray
         Indices of the extrema, as an array
         of integers (same format as argmin, argmax
 
@@ -122,13 +122,13 @@ def _identify_ridge_lines(matr, max_distances, gap_thresh):
 
     Parameters
     ----------
-    matr: 2-D ndarray
+    matr : 2-D ndarray
         Matrix in which to identify ridge lines.
-    max_distances: 1-D sequence
+    max_distances : 1-D sequence
         At each row, a ridge line is only connected
         if the relative max at row[n] is within
         `max_distances`[n] from the relative max at row[n+1].
-    gap_thresh: int
+    gap_thresh : int
         If a relative maximum is not found within `max_distances`,
         there will be a gap. A ridge line is discontinued if
         there are more than `gap_thresh` points without connecting
@@ -136,7 +136,7 @@ def _identify_ridge_lines(matr, max_distances, gap_thresh):
 
     Returns
     -------
-    ridge_lines: tuple
+    ridge_lines : tuple
         tuple of 2 1-D sequences. `ridge_lines`[ii][0] are the rows of the ii-th
         ridge-line, `ridge_lines`[ii][1] are the columns. Empty if none found.
         Each ridge-line will be sorted by row (increasing), but the order
@@ -245,21 +245,21 @@ def _filter_ridge_lines(cwt, ridge_lines, window_size=None, min_length=None,
     cwt : 2-D ndarray
         Continuous wavelet transform from which
         the ridge_lines were defined
-    ridge_lines: 1-D sequence
+    ridge_lines : 1-D sequence
         Each element should contain 2 sequences, the rows and columns
         of the ridge line (respectively)
-    window_size: int, optional
+    window_size : int, optional
         Size of window to use to calculate noise floor.
         Default is `cwt`.shape[1]/20
-    min_length: int, optional
+    min_length : int, optional
         Minimum length a ridge line needs to be acceptable.
         Default is `cwt`.shape[0]/4, ie 1/4th the number of widths.
-    min_snr: float, optional
+    min_snr : float, optional
         Minimum SNR ratio. Default 1. The signal is the value of
         the cwt matrix at the shortest length scale (`cwt`[0,loc]), the noise is
         the `noise_perc`th percentile of datapoints contained within
         a window of `window_size` around `cwt`[0,loc]
-    noise_perc: float,optional
+    noise_perc : float, optional
         When calculating the noise floor, percentile of data points
         examined below which to consider noise. Calculated using
         scipy.stats.scoreatpercentile.
@@ -307,23 +307,23 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None, gap_thresh=
 
     Parameters
     ----------
-    vector: 1-D ndarray
-    widths: 1-D sequence
+    vector : 1-D ndarray
+    widths : 1-D sequence
         Widths to use for calculating the CWT matrix. In general,
         this range should cover the expected width of peaks of interest.
-    wavelet: function
+    wavelet : function
         Should take a single variable and return a 1d array to convolve
         with `vector`. Should be normalized to unit area. Default
         is the ricker wavelet
-    max_distances: 1-D ndarray,optional
+    max_distances : 1-D ndarray, optional
         Default `widths`/4. See identify_ridge_lines
-    gap_thresh: float, optional
+    gap_thresh : float, optional
         Default 2. See identify_ridge_lines
-    min_length: int, optional
+    min_length : int, optional
         Default None. See filter_ridge_lines
-    min_snr: float, optional
+    min_snr : float, optional
         Default 1. See filter_ridge_lines
-    noise_perc: float, optional
+    noise_perc : float, optional
         Default 10. See filter_ridge_lines
 
     Notes

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -402,10 +402,10 @@ def lsim2(system, U=None, T=None, X0=None, **kwargs):
 
     Notes
     -----
-    This function uses :func:`scipy.integrate.odeint` to solve the
+    This function uses `scipy.integrate.odeint` to solve the
     system's differential equations.  Additional keyword arguments
     given to `lsim2` are passed on to `odeint`.  See the documentation
-    for :func:`scipy.integrate.odeint` for the full list of arguments.
+    for `scipy.integrate.odeint` for the full list of arguments.
 
     """
     if isinstance(system, lti):

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -56,30 +56,30 @@ def correlate(in1, in2, mode='full'):
     """
     Cross-correlate two N-dimensional arrays.
 
-    Cross-correlate in1 and in2 with the output size determined by the mode
+    Cross-correlate `in1` and `in2` with the output size determined by the mode
     argument.
 
     Parameters
     ----------
-    in1: array
+    in1 : array
         first input.
-    in2: array
-        second input. Should have the same number of dimensions as in1.
-    mode: str {'valid', 'same', 'full'}, optional
+    in2 : array
+        second input. Should have the same number of dimensions as `in1`.
+    mode : str {'valid', 'same', 'full'}, optional
         A string indicating the size of the output:
 
             - 'valid': the output consists only of those elements that do not
               rely on the zero-padding.
-            - 'same': the output is the same size as ``in1`` centered
+            - 'same': the output is the same size as `in1` centered
               with respect to the 'full' output.
             - 'full': the output is the full discrete linear cross-correlation
               of the inputs (default).
 
     Returns
     -------
-    out: array
+    out : array
         an N-dimensional array containing a subset of the discrete linear
-        cross-correlation of in1 with in2.
+        cross-correlation of `in1` with `in2`.
 
     Notes
     -----
@@ -132,7 +132,7 @@ def _centered(arr, newsize):
 
 
 def fftconvolve(in1, in2, mode="full"):
-    """Convolve two N-dimensional arrays using FFT. See convolve.
+    """Convolve two N-dimensional arrays using FFT. See :func:`convolve`.
 
     """
     s1 = array(in1.shape)
@@ -166,21 +166,21 @@ def convolve(in1, in2, mode='full'):
     """
     Convolve two N-dimensional arrays.
 
-    Convolve in1 and in2 with output size determined by mode.
+    Convolve `in1` and `in2` with output size determined by mode.
 
     Parameters
     ----------
-    in1: array
+    in1 : array
         first input.
-    in2: array
-        second input. Should have the same number of dimensions as in1.
-    mode: str {'valid', 'same', 'full'}
+    in2 : array
+        second input. Should have the same number of dimensions as `in1`.
+    mode : str {'valid', 'same', 'full'}
         a string indicating the size of the output:
 
         ``valid`` : the output consists only of those elements that do not
            rely on the zero-padding.
 
-        ``same`` : the output is the same size as ``in1`` centered
+        ``same`` : the output is the same size as `in1` centered
            with respect to the 'full' output.
 
         ``full`` : the output is the full discrete linear cross-correlation
@@ -189,9 +189,9 @@ def convolve(in1, in2, mode='full'):
 
     Returns
     -------
-    out: array
+    out : array
         an N-dimensional array containing a subset of the discrete linear
-        cross-correlation of in1 with in2.
+        cross-correlation of `in1` with `in2`.
 
     """
     volume = asarray(in1)
@@ -380,7 +380,7 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
     ----------
     in1, in2 : ndarray
         Two-dimensional input arrays to be convolved.
-    mode: str, optional
+    mode : str, optional
         A string indicating the size of the output:
 
         ``valid`` : the output consists only of those elements that do not
@@ -432,7 +432,7 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
     ----------
     in1, in2 : ndarray
         Two-dimensional input arrays to be convolved.
-    mode: str, optional
+    mode : str, optional
         A string indicating the size of the output:
 
         ``valid`` : the output consists only of those elements that do not

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -56,8 +56,8 @@ def correlate(in1, in2, mode='full'):
     """
     Cross-correlate two N-dimensional arrays.
 
-    Cross-correlate `in1` and `in2` with the output size determined by the mode
-    argument.
+    Cross-correlate `in1` and `in2` with the output size determined by the 
+    `mode` argument.
 
     Parameters
     ----------
@@ -132,7 +132,7 @@ def _centered(arr, newsize):
 
 
 def fftconvolve(in1, in2, mode="full"):
-    """Convolve two N-dimensional arrays using FFT. See :func:`convolve`.
+    """Convolve two N-dimensional arrays using FFT. See `convolve`.
 
     """
     s1 = array(in1.shape)
@@ -166,7 +166,7 @@ def convolve(in1, in2, mode='full'):
     """
     Convolve two N-dimensional arrays.
 
-    Convolve `in1` and `in2` with output size determined by mode.
+    Convolve `in1` and `in2` with output size determined by `mode`.
 
     Parameters
     ----------
@@ -283,7 +283,7 @@ def medfilt(volume, kernel_size=None):
     Perform a median filter on an N-dimensional array.
 
     Apply a median filter to the input array using a local window-size
-    given by kernel_size.
+    given by `kernel_size`.
 
     Parameters
     ----------
@@ -373,7 +373,7 @@ def wiener(im, mysize=None, noise=None):
 def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
     """Convolve two 2-dimensional arrays.
 
-    Convolve `in1` and `in2` with output size determined by mode and boundary
+    Convolve `in1` and `in2` with output size determined by `mode` and boundary
     conditions determined by `boundary` and `fillvalue`.
 
     Parameters
@@ -386,7 +386,7 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
         ``valid`` : the output consists only of those elements that do not
            rely on the zero-padding.
 
-        ``same`` : the output is the same size as ``in1`` centered
+        ``same`` : the output is the same size as `in1` centered
            with respect to the 'full' output.
 
         ``full`` : the output is the full discrete linear cross-correlation
@@ -425,7 +425,7 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
 def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
     """Cross-correlate two 2-dimensional arrays.
 
-    Cross correlate in1 and in2 with output size determined by mode and
+    Cross correlate `in1` and `in2` with output size determined by `mode` and
     boundary conditions determined by `boundary` and `fillvalue`.
 
     Parameters
@@ -438,7 +438,7 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
         ``valid`` : the output consists only of those elements that do not
            rely on the zero-padding.
 
-        ``same`` : the output is the same size as ``in1`` centered
+        ``same`` : the output is the same size as `in1` centered
            with respect to the 'full' output.
 
         ``full`` : the output is the full discrete linear cross-correlation
@@ -471,7 +471,7 @@ def medfilt2d(input, kernel_size=3):
     """
     Median filter a 2-dimensional array.
 
-    Apply a median filter to the input array using a local window-size
+    Apply a median filter to the `input` array using a local window-size
     given by `kernel_size` (must be odd).
 
     Parameters
@@ -646,7 +646,7 @@ def lfiltic(b, a, y, x=None):
 
 
 def deconvolve(signal, divisor):
-    """Deconvolves divisor out of signal.
+    """Deconvolves `divisor` out of `signal`.
 
     """
     num = atleast_1d(signal)
@@ -1306,7 +1306,7 @@ def lfilter_zi(b, a):
     Parameters
     ----------
     b, a : array_like (1-D)
-        The IIR filter coefficients. See `scipy.signal.lfilter` for more
+        The IIR filter coefficients. See `lfilter` for more
         information.
 
     Returns
@@ -1435,7 +1435,7 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None):
     and even extensions have the corresponding symmetry about the end point
     of the data.  The constant extension extends the data with the values
     at end points.  On both the forward and backwards passes, the
-    initial condition of the filter is found by using lfilter_zi and
+    initial condition of the filter is found by using `lfilter_zi` and
     scaling it by the end point of the extended data.
 
     Parameters
@@ -1569,10 +1569,11 @@ from scipy.signal.fir_filter_design import firwin
 
 
 def decimate(x, q, n=None, ftype='iir', axis=-1):
-    """Downsample the signal x by an integer factor q, using an order n filter.
+    """Downsample the signal `x` by an integer factor `q`, using an order `n` 
+    filter.
 
-    By default an order 8 Chebyshev type I filter is used.  A 30 point FIR
-    filter with hamming window is used if ftype is 'fir'.
+    By default, an order 8 Chebyshev type I filter is used.  A 30 point FIR
+    filter with hamming window is used if `ftype` is 'fir'.
 
     Parameters
     ----------

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -326,8 +326,8 @@ def cwt(data, wavelet, widths):
         The first argument is the number of points that the returned vector
         will have (len(wavelet(width,length)) == length).
         The second is a width parameter, defining the size of the wavelet
-        (e.g. standard deviation of a gaussian). See
-        :func:`scipy.signal.ricker`, which satisfies these requirements.
+        (e.g. standard deviation of a gaussian). See `ricker`, which 
+        satisfies these requirements.
     widths : sequence
         Widths to use for transform.
 

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -1032,7 +1032,7 @@ def general_gaussian(M, p, sig, sym=True):
         Number of points in the output window. If zero or less, an empty
         array is returned.
     p : float
-        Shape parameter.  p = 1 is identical to :func:`~gaussian`, p = 0.5 is
+        Shape parameter.  p = 1 is identical to `gaussian`, p = 0.5 is
         the same shape as the Laplace distribution.
     sig : float
         The standard deviation, sigma.

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -582,14 +582,14 @@ def rand(m, n, density=0.01, format="coo", dtype=None):
 
     Parameters
     ----------
-    m, n: int
+    m, n : int
         shape of the matrix
-    density: real
+    density : real
         density of the generated matrix: density equal to one means a full
         matrix, density of 0 means a matrix with no non-zero items.
-    format: str
+    format : str
         sparse matrix format.
-    dtype: dtype
+    dtype : dtype
         type of the returned matrix values.
 
     Notes

--- a/scipy/sparse/csgraph/_components.py
+++ b/scipy/sparse/csgraph/_components.py
@@ -21,15 +21,15 @@ def cs_graph_components(x):
 
     Parameters
     -----------
-    x: array_like or sparse matrix, 2 dimensions
+    x : array_like or sparse matrix, 2 dimensions
         The adjacency matrix of the graph. Only the upper triangular part
         is used.
 
     Returns
     --------
-    n_comp: int
+    n_comp : int
         The number of connected components.
-    label: ndarray (ints, 1 dimension):
+    label : ndarray (ints, 1 dimension):
         The label array of each connected component (-2 is used to
         indicate empty rows in the matrix: 0 everywhere, including
         diagonal). This array has the length of the number of nodes,

--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -20,18 +20,18 @@ def laplacian(csgraph, normed=False, return_diag=False):
 
     Parameters
     ----------
-    csgraph: array_like or sparse matrix, 2 dimensions
+    csgraph : array_like or sparse matrix, 2 dimensions
         compressed-sparse graph, with shape (N, N).
-    normed: bool, optional
+    normed : bool, optional
         If True, then compute normalized Laplacian.
-    return_diag: bool, optional
+    return_diag : bool, optional
         If True, then return diagonal as well as laplacian.
 
     Returns
     -------
-    lap: ndarray
+    lap : ndarray
         The N x N laplacian matrix of graph.
-    diag: ndarray
+    diag : ndarray
         The length-N diagonal of the laplacian matrix.
         diag is returned only if return_diag is True.
 

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -189,7 +189,7 @@ def lobpcg( A, X,
     tol : scalar, optional
         Solver tolerance (stopping criterion)
         by default: tol=n*sqrt(eps)
-    maxiter: integer, optional
+    maxiter : integer, optional
         maximum number of iterations
         by default: maxiter=min(n,20)
     largest : boolean, optional

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -716,14 +716,14 @@ class rv_generic(object):
         arg1, arg2, ... : array_like
             The shape parameter(s) for the distribution (see docstring of the instance
             object for more information)
-        loc: array_like, optional
+        loc : array_like, optional
             location parameter (default = 0)
         scale : array_like, optional
             scale paramter (default = 1)
 
         Returns
         -------
-        a, b: array_like (float)
+        a, b : array_like (float)
             end-points of range that contain alpha % of the rvs
         """
         alpha = asarray(alpha)
@@ -1612,7 +1612,7 @@ class rv_continuous(rv_generic):
 
         Parameters
         ----------
-        n: int, n>=1
+        n : int, n>=1
             Order of moment.
         arg1, arg2, arg3,... : float
             The shape parameter(s) for the distribution (see docstring of the
@@ -6015,7 +6015,7 @@ class rv_discrete(rv_generic):
             instance object for more information).
         loc : array_like, optional
             Location parameter (default=0).
-        scale: array_like, optional
+        scale : array_like, optional
             Scale parameter (default=1).
 
         Returns
@@ -6214,7 +6214,7 @@ class rv_discrete(rv_generic):
 
         Parameters
         ----------
-        n: int, n>=1
+        n : int, n>=1
             order of moment
         arg1, arg2, arg3,...: float
             The shape parameter(s) for the distribution (see docstring of the

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -198,11 +198,11 @@ def rankdata(data, axis=None, use_missing=False):
     ----------
         data : sequence
             Input data. The data is transformed to a masked array
-        axis : {None,int} optional
+        axis : {None,int}, optional
             Axis along which to perform the ranking.
             If None, the array is first flattened. An exception is raised if
             the axis is specified for arrays with a dimension larger than 2
-        use_missing : {boolean} optional
+        use_missing : {boolean}, optional
             Whether the masked values have a rank of 0 (False) or equal to the
             average rank of the unmasked values (True).
     """
@@ -388,7 +388,7 @@ Parameters
     x : 1D array
     y : 1D array the same length as x
         The lengths of both arrays must be > 2.
-    use_ties : {True, False} optional
+    use_ties : {True, False}, optional
         Whether the correction for ties should be computed.
 
 Returns
@@ -443,13 +443,13 @@ def kendalltau(x, y, use_ties=True, use_missing=False):
 
     Parameters
     ----------
-    xdata: sequence
+    xdata : sequence
         First data list (for example, time).
-    ydata: sequence
+    ydata : sequence
         Second data list.
-    use_ties: {True, False} optional
+    use_ties : {True, False}, optional
         Whether ties correction should be performed.
-    use_missing: {False, True} optional
+    use_missing : {False, True}, optional
         Whether missing data should be allocated a rank of 0 (False) or the
         average rank (True)
 
@@ -656,7 +656,7 @@ def theilslopes(y, x=None, alpha=0.05):
     ----------
         y : sequence
             Dependent variable.
-        x : {None, sequence} optional
+        x : {None, sequence}, optional
             Independent variable. If None, use arange(len(y)) instead.
         alpha : float
             Confidence degree.
@@ -788,7 +788,7 @@ def mannwhitneyu(x,y, use_continuity=True):
     ----------
         x : sequence
         y : sequence
-        use_continuity : {True, False} optional
+        use_continuity : {True, False}, optional
             Whether a continuity correction (1/2.) should be taken into account.
 
     Returns
@@ -867,7 +867,7 @@ def ks_twosamp(data1, data2, alternative="two-sided"):
             First data set
         data2 : sequence
             Second data set
-        alternative : {'two-sided', 'less', 'greater'} optional
+        alternative : {'two-sided', 'less', 'greater'}, optional
             Indicates the alternative hypothesis.
 
     Returns
@@ -932,11 +932,11 @@ def threshold(a, threshmin=None, threshmax=None, newval=0):
     ----------
     a : ndarray
         Input data
-    threshmin : {None, float} optional
+    threshmin : {None, float}, optional
         Lower threshold. If None, set to the minimum value.
-    threshmax : {None, float} optional
+    threshmax : {None, float}, optional
         Upper threshold. If None, set to the maximum value.
-    newval : {0, float} optional
+    newval : {0, float}, optional
         Value outside the thresholds.
 
     Returns
@@ -962,11 +962,11 @@ def trima(a, limits=None, inclusive=(True,True)):
     ----------
     a : sequence
         Input array.
-    limits : {None, tuple} optional
+    limits : {None, tuple}, optional
         Tuple of (lower limit, upper limit) in absolute values.
         Values of the input array lower (greater) than the lower (upper) limit
         will be masked. A limit is None indicates an open interval.
-    inclusive : {(True,True) tuple} optional
+    inclusive : {(True,True) tuple}, optional
         Tuple of (lower flag, upper flag), indicating whether values exactly
         equal to the lower (upper) limit are allowed.
 
@@ -1000,17 +1000,17 @@ def trimr(a, limits=None, inclusive=(True, True), axis=None):
     ----------
     a : sequence
         Input array.
-    limits : {None, tuple} optional
+    limits : {None, tuple}, optional
         Tuple of the percentages to cut on each side of the array, with respect
         to the number of unmasked data, as floats between 0. and 1.
         Noting n the number of unmasked data before trimming, the (n*limits[0])th
         smallest data and the (n*limits[1])th largest data are masked, and the
         total number of unmasked data after trimming is n*(1.-sum(limits))
         The value of one limit can be set to None to indicate an open interval.
-    inclusive : {(True,True) tuple} optional
+    inclusive : {(True,True) tuple}, optional
         Tuple of flags indicating whether the number of data being masked on the
         left (right) end should be truncated (True) or rounded (False) to integers.
-    axis : {None,int} optional
+    axis : {None,int}, optional
         Axis along which to trim. If None, the whole array is trimmed, but its
         shape is maintained.
 
@@ -1059,7 +1059,7 @@ trimdoc = """
     ----------
     a : sequence
         Input array
-    limits : {None, tuple} optional
+    limits : {None, tuple}, optional
         If relative == False, tuple (lower limit, upper limit) in absolute values.
         Values of the input array lower (greater) than the lower (upper) limit are
         masked.
@@ -1071,12 +1071,12 @@ trimdoc = """
         In each case, the value of one limit can be set to None to indicate an
         open interval.
         If limits is None, no trimming is performed
-    inclusive : {(True, True) tuple} optional
+    inclusive : {(True, True) tuple}, optional
         If relative==False, tuple indicating whether values exactly equal to the
         absolute limits are allowed.
         If relative==True, tuple indicating whether the number of data being masked
         on each side should be rounded (True) or truncated (False).
-    relative : {False, True} optional
+    relative : {False, True}, optional
         Whether to consider the limits as absolute values (False) or proportions
         to cut (True).
     axis : {None, integer}, optional
@@ -1118,12 +1118,12 @@ Parameters
 ----------
     data : ndarray
         Data to trim.
-    proportiontocut : {0.2, float} optional
+    proportiontocut : {0.2, float}, optional
         Percentage of trimming (as a float between 0 and 1).
         If n is the number of unmasked values before trimming, the number of
         values after trimming is:
             (1-2*proportiontocut)*n.
-    inclusive : {(True, True) tuple} optional
+    inclusive : {(True, True) tuple}, optional
         Tuple indicating whether the number of data being masked on each side
         should be rounded (True) or truncated (False).
     axis : {None, integer}, optional
@@ -1144,14 +1144,14 @@ Parameters
 ----------
     data : {ndarray}
         Data to trim.
-    proportiontocut : {0.2, float} optional
+    proportiontocut : {0.2, float}, optional
         Percentage of trimming. If n is the number of unmasked values
         before trimming, the number of values after trimming is
         (1-proportiontocut)*n.
-    tail : {'left','right'} optional
+    tail : {'left','right'}, optional
         If left (right), the ``proportiontocut`` lowest (greatest) values will
         be masked.
-    inclusive : {(True, True) tuple} optional
+    inclusive : {(True, True) tuple}, optional
         Tuple indicating whether the number of data being masked on each side
         should be rounded (True) or truncated (False).
     axis : {None, integer}, optional
@@ -1232,7 +1232,7 @@ def trimmed_stde(a, limits=(0.1,0.1), inclusive=(1,1), axis=None):
     ----------
     a : sequence
         Input array
-    limits : {(0.1,0.1), tuple of float} optional
+    limits : {(0.1,0.1), tuple of float}, optional
         tuple (lower percentage, upper percentage) to cut  on each side of the
         array, with respect to the number of unmasked data.
         Noting n the number of unmasked data before trimming, the (n*limits[0])th
@@ -1241,7 +1241,7 @@ def trimmed_stde(a, limits=(0.1,0.1), inclusive=(1,1), axis=None):
         In each case, the value of one limit can be set to None to indicate an
         open interval.
         If limits is None, no trimming is performed
-    inclusive : {(True, True) tuple} optional
+    inclusive : {(True, True) tuple}, optional
         Tuple indicating whether the number of data being masked on each side
         should be rounded (True) or truncated (False).
     axis : {None, integer}, optional
@@ -1341,19 +1341,19 @@ def winsorize(a, limits=None, inclusive=(True,True), inplace=False, axis=None):
     ----------
     a : sequence
         Input array.
-    limits : {None, tuple of float} optional
+    limits : {None, tuple of float}, optional
         Tuple of the percentages to cut on each side of the array, with respect
         to the number of unmasked data, as floats between 0. and 1.
         Noting n the number of unmasked data before trimming, the (n*limits[0])th
         smallest data and the (n*limits[1])th largest data are masked, and the
         total number of unmasked data after trimming is n*(1.-sum(limits))
         The value of one limit can be set to None to indicate an open interval.
-    inclusive : {(True, True) tuple} optional
+    inclusive : {(True, True) tuple}, optional
         Tuple indicating whether the number of data being masked on each side
         should be rounded (True) or truncated (False).
-    inplace : {False, True} optional
+    inplace : {False, True}, optional
         Whether to winsorize in place (True) or to use a copy (False)
-    axis : {None, int} optional
+    axis : {None, int}, optional
         Axis along which to trim. If None, the whole array is trimmed, but its
         shape is maintained.
 
@@ -1524,7 +1524,7 @@ median along the given axis. masked values are discarded.
     ----------
         data : ndarray
             Data to trim.
-        axis : {None,int} optional
+        axis : {None,int}, optional
             Axis along which to perform the trimming.
             If None, the input array is first flattened.
 
@@ -1880,7 +1880,7 @@ def signaltonoise(data, axis=0):
     ----------
         data : sequence
             Input data
-        axis : {0, int} optional
+        axis : {0, int}, optional
             Axis along which to compute. If None, the computation is performed
             on a flat version of the array.
 """

--- a/scipy/stats/mstats_extras.py
+++ b/scipy/stats/mstats_extras.py
@@ -37,9 +37,9 @@ are calculated as a weighted linear combination of order statistics.
 
 Parameters
 ----------
-    data: ndarray
+    data : ndarray
         Data array.
-    prob: sequence
+    prob : sequence
         Sequence of quantiles to compute.
     axis : int
         Axis along which to compute the quantiles. If None, use a flattened array.
@@ -104,7 +104,7 @@ def hdmedian(data, axis=-1, var=False):
 
 Parameters
 ----------
-    data: ndarray
+    data : ndarray
         Data array.
     axis : int
         Axis along which to compute the quantiles. If None, use a flattened array.
@@ -123,9 +123,9 @@ def hdquantiles_sd(data, prob=list([.25,.5,.75]), axis=None):
 
 Parameters
 ----------
-    data: ndarray
+    data : ndarray
         Data array.
-    prob: sequence
+    prob : sequence
         Sequence of quantiles to compute.
     axis : int
         Axis along which to compute the quantiles. If None, use a flattened array.
@@ -212,9 +212,9 @@ experimental quantiles of the data.
 
 Parameters
 -----------
-    data: ndarray
+    data : ndarray
         Data array.
-    prob: sequence
+    prob : sequence
         Sequence of quantiles to compute.
     axis : int
         Axis along which to compute the quantiles. If None, use a flattened array.
@@ -255,9 +255,9 @@ def mquantiles_cimj(data, prob=[0.25,0.50,0.75], alpha=0.05, axis=None):
 
     Parameters
     ----------
-    data: ndarray
+    data : ndarray
         Data array.
-    prob: sequence
+    prob : sequence
         Sequence of quantiles to compute.
     alpha : float
         Confidence level of the intervals.

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -461,14 +461,14 @@ def gmean(a, axis=0, dtype=None):
 
     Returns
     -------
-    gmean : ndarray,
+    gmean : ndarray
         see dtype parameter above
 
     See Also
     --------
     numpy.mean : Arithmetic average
     numpy.average : Weighted average
-    hmean: Harmonic mean
+    hmean : Harmonic mean
 
     Notes
     -----
@@ -513,14 +513,14 @@ def hmean(a, axis=0, dtype=None):
 
     Returns
     -------
-    hmean : ndarray,
+    hmean : ndarray
         see `dtype` parameter above
 
     See Also
     --------
     numpy.mean : Arithmetic average
     numpy.average : Weighted average
-    gmean: Geometric mean
+    gmean : Geometric mean
 
     Notes
     -----
@@ -805,7 +805,7 @@ def tmin(a, lowerlimit=None, axis=0, inclusive=True):
 
     Returns
     -------
-    tmin: float
+    tmin : float
 
     """
     a, axis = _chk_asarray(a, axis)
@@ -1439,11 +1439,11 @@ def percentileofscore(a, score, kind='rank'):
 
     Parameters
     ----------
-    a: array like
+    a : array like
         Array of scores to which `score` is compared.
-    score: int or float
+    score : int or float
         Score that is compared to the elements in `a`.
-    kind: {'rank', 'weak', 'strict', 'mean'}, optional
+    kind : {'rank', 'weak', 'strict', 'mean'}, optional
         This optional parameter specifies the interpretation of the
         resulting score:
 
@@ -1559,31 +1559,31 @@ def histogram(a, numbins=10, defaultlimits=None, weights=None, printextras=False
 
     Parameters
     ----------
-    a: array_like
+    a : array_like
         Array of scores which will be put into bins.
-    numbins: int, optional
+    numbins : int, optional
         The number of bins to use for the histogram. Default is 10.
-    defaultlimits: tuple (lower, upper), optional
+    defaultlimits : tuple (lower, upper), optional
         The lower and upper values for the range of the histogram.
         If no value is given, a range slightly larger then the range of the
         values in a is used. Specifically ``(a.min() - s, a.max() + s)``,
             where ``s = (1/2)(a.max() - a.min()) / (numbins - 1)``.
-    weights: array_like, optional
+    weights : array_like, optional
         The weights for each value in `a`. Default is None, which gives each
         value a weight of 1.0
-    printextras: bool, optional
+    printextras : bool, optional
         If True, the number of extra points is printed to standard output.
         Default is False.
 
     Returns
     -------
-    histogram: ndarray
+    histogram : ndarray
         Number of points (or sum of weights) in each bin.
-    low_range: float
+    low_range : float
         Lowest value of histogram, the lower limit of the first bin.
-    binsize: float
+    binsize : float
         The size of the bins (all bins have the same size).
-    extrapoints: int
+    extrapoints : int
         The number of points outside the range of the histogram.
 
     See Also
@@ -1624,14 +1624,14 @@ def cumfreq(a, numbins=10, defaultreallimits=None, weights=None):
     ----------
     a : array_like
         Input array.
-    numbins: int, optional
+    numbins : int, optional
         The number of bins to use for the histogram. Default is 10.
-    defaultlimits: tuple (lower, upper), optional
+    defaultlimits : tuple (lower, upper), optional
         The lower and upper values for the range of the histogram.
         If no value is given, a range slightly larger then the range of the
         values in a is used. Specifically ``(a.min() - s, a.max() + s)``,
             where ``s = (1/2)(a.max() - a.min()) / (numbins - 1)``.
-    weights: array_like, optional
+    weights : array_like, optional
         The weights for each value in `a`. Default is None, which gives each
         value a weight of 1.0
 
@@ -1673,14 +1673,14 @@ def relfreq(a, numbins=10, defaultreallimits=None, weights=None):
     ----------
     a : array_like
         Input array.
-    numbins: int, optional
+    numbins : int, optional
         The number of bins to use for the histogram. Default is 10.
-    defaultreallimits: tuple (lower, upper), optional
+    defaultreallimits : tuple (lower, upper), optional
         The lower and upper values for the range of the histogram.
         If no value is given, a range slightly larger then the range of the
         values in a is used. Specifically ``(a.min() - s, a.max() + s)``,
             where ``s = (1/2)(a.max() - a.min()) / (numbins - 1)``.
-    weights: array_like, optional
+    weights : array_like, optional
         The weights for each value in `a`. Default is None, which gives each
         value a weight of 1.0
 
@@ -1770,9 +1770,9 @@ def signaltonoise(a, axis=0, ddof=0):
 
     Parameters
     ----------
-    a: array_like
+    a : array_like
         An array_like object containing the sample data.
-    axis: int or None, optional
+    axis : int or None, optional
         If axis is equal to None, the array is first ravel'd. If axis is an
         integer, this is the axis over which to operate. Default is 0.
     ddof : int, optional
@@ -2477,7 +2477,7 @@ def spearmanr(a, b=None, axis=0):
 
     Returns
     -------
-    rho: float or ndarray (2-D square)
+    rho : float or ndarray (2-D square)
         Spearman correlation matrix or correlation coefficient (if only 2
         variables are given as parameters. Correlation matrix is square with
         length equal to total number of variables (columns or rows) in a and b

--- a/scipy/weave/catalog.py
+++ b/scipy/weave/catalog.py
@@ -133,7 +133,7 @@ def is_writable(dir):
 
     Parameters
     ----------
-    dir: str
+    dir : str
         A string represeting a path to a directory on the filesystem.
 
     Returns


### PR DESCRIPTION
DOC: Cleanup formating of convolution functions, highlight variables, link to convolve(), spaces before colons

DOC: Regexp-assisted fix of lots of colons without spaces before them, which results in wrong bolding and colon on web documentation, and some commas and spaces
