### PR TITLE
BUG: fix segfault in fftpack on OS X >=10.7 when compiling with llvm-gcc...

### DIFF
--- a/scipy/fftpack/src/zfft.c
+++ b/scipy/fftpack/src/zfft.c
@@ -57,8 +57,9 @@ void zfft(complex_double * inout, int n, int direction, int howmany,
 	if (normalize) {
 		ptr = inout;
 		for (i = n * howmany - 1; i >= 0; --i) {
-			*((double *) (ptr)) /= n;
-			*((double *) (ptr++) + 1) /= n;
+                        ptr->r /= n;
+                        ptr->i /= n;
+                        ptr++;
 		}
 	}
 }
@@ -92,8 +93,9 @@ void cfft(complex_float * inout, int n, int direction, int howmany,
 	if (normalize) {
 		ptr = inout;
 		for (i = n * howmany - 1; i >= 0; --i) {
-			*((float *) (ptr)) /= n;
-			*((float *) (ptr++) + 1) /= n;
+                        ptr->r /= n;
+                        ptr->i /= n;
+                        ptr++;
 		}
 	}
 }


### PR DESCRIPTION
....

See ticket 1737.  Thanks to Alex Leach for help in debugging this issue.

Tested by Alex to confirm it fixes the segfault, works fine on Ubuntu 12.04 too. Ticket shouldn't be closed yet.
