### PR TITLE
ENH: Changes to `convolve`, `fftconvolve`, ...

### DIFF
--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -307,7 +307,7 @@ def rfft(x, n=None, axis=-1, overwrite_x=0):
     Parameters
     ----------
     x : array_like, real-valued
-        The data to tranform.
+        The data to transform.
     n : int, optional
         Defines the length of the Fourier transform.  If `n` is not specified
         (the default) then ``n = x.shape[axis]``.  If ``n < x.shape[axis]``,

--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -428,6 +428,10 @@ def _raw_fftnd(x, s, axes, direction, overwrite_x, work_function):
         raise ValueError("when given, axes and shape arguments "\
                          "have to be of the same length")
 
+    for dim in s:
+        if dim < 1:
+            raise ValueError("Invalid number of FFT data points (%d) specified." % s)
+
     # No need to swap axes, array is in C order
     if noaxes:
         for i in axes:

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -70,9 +70,9 @@ def correlate(in1, in2, mode='full'):
 
     Parameters
     ----------
-    in1 : array
+    in1 : array_like
         First input.
-    in2 : array
+    in2 : array_like
         Second input. Should have the same number of dimensions as `in1`.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
@@ -156,9 +156,9 @@ def fftconvolve(in1, in2, mode="full"):
 
     Parameters
     ----------
-    in1 : array
+    in1 : array_like
         First input.
-    in2 : array
+    in2 : array_like
         Second input. Should have the same number of dimensions as `in1`.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
@@ -180,6 +180,9 @@ def fftconvolve(in1, in2, mode="full"):
         convolution of `in1` with `in2`.
 
     """
+    in1 = asarray(in1)
+    in2 = asarray(in2)
+
     s1 = array(in1.shape)
     s2 = array(in2.shape)
     complex_result = (np.issubdtype(in1.dtype, np.complex) or
@@ -216,9 +219,9 @@ def convolve(in1, in2, mode='full'):
 
     Parameters
     ----------
-    in1 : array
+    in1 : array_like
         First input.
-    in2 : array
+    in2 : array_like
         Second input. Should have the same number of dimensions as `in1`.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
@@ -416,7 +419,7 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
 
     Parameters
     ----------
-    in1, in2 : ndarray
+    in1, in2 : array_like
         Two-dimensional input arrays to be convolved.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
@@ -451,6 +454,9 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
         convolution of `in1` with `in2`.
 
     """
+    in1 = asarray(in1)
+    in2 = asarray(in2)
+
     if mode == 'valid':
         _check_valid_mode_shapes(in1.shape, in2.shape)
 
@@ -468,7 +474,7 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
 
     Parameters
     ----------
-    in1, in2 : ndarray
+    in1, in2 : array_like
         Two-dimensional input arrays to be convolved.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
@@ -503,6 +509,9 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
         cross-correlation of `in1` with `in2`.
 
     """
+    in1 = asarray(in1)
+    in2 = asarray(in2)
+
     if mode == 'valid':
         _check_valid_mode_shapes(in1.shape, in2.shape)
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -183,6 +183,11 @@ def fftconvolve(in1, in2, mode="full"):
     in1 = asarray(in1)
     in2 = asarray(in2)
 
+    if rank(in1) == rank(in2) == 0:
+        return in1 * in2
+    elif not in1.ndim == in2.ndim:
+        raise ValueError("in1 and in2 should have the same rank")
+    
     s1 = array(in1.shape)
     s2 = array(in2.shape)
     complex_result = (np.issubdtype(in1.dtype, np.complex) or

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -99,9 +99,9 @@ def correlate(in1, in2, mode='full'):
         out = np.empty(ps, in1.dtype)
         for i in range(len(ps)):
             if ps[i] <= 0:
-                raise ValueError("Dimension of x(%d) < y(%d) " \
-                                 "not compatible with valid mode" % \
-                                 (in1.shape[i], in2.shape[i]))
+                raise ValueError(
+                    "in1 should have at least as many items as in2 in "
+                    "every dimension for 'valid' mode.")
 
         z = sigtools._correlateND(in1, in2, out, val)
     else:
@@ -211,8 +211,9 @@ def convolve(in1, in2, mode='full'):
         for d1, d2 in zip(volume.shape, kernel.shape):
             if not d1 >= d2:
                 raise ValueError(
-                    "in1 should have at least as many items as in2 in " \
-                    "every dimension for valid mode.")
+                    "in1 should have at least as many items as in2 in "
+                    "every dimension for 'valid' mode.")
+
     if np.iscomplexobj(kernel):
         return correlate(volume, kernel[slice_obj].conj(), mode)
     else:
@@ -420,8 +421,8 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
         for d1, d2 in zip(np.shape(in1), np.shape(in2)):
             if not d1 >= d2:
                 raise ValueError(
-                    "in1 should have at least as many items as in2 in " \
-                    "every dimension for valid mode.")
+                    "in1 should have at least as many items as in2 in "
+                    "every dimension for 'valid' mode.")
 
     val = _valfrommode(mode)
     bval = _bvalfromboundary(boundary)
@@ -472,6 +473,13 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
         cross-correlation of `in1` with `in2`.
 
     """
+    if mode == 'valid':
+        for d1, d2 in zip(np.shape(in1), np.shape(in2)):
+            if not d1 >= d2:
+                raise ValueError(
+                    "in1 should have at least as many items as in2 in "
+                    "every dimension for 'valid' mode.")
+
     val = _valfrommode(mode)
     bval = _bvalfromboundary(boundary)
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -68,16 +68,16 @@ def correlate(in1, in2, mode='full'):
         Second input. Should have the same number of dimensions as `in1`.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
-    
+
+        ``full``
+           The output is the full discrete linear cross-correlation
+           of the inputs. (Default)
         ``valid``
            The output consists only of those elements that do not
            rely on the zero-padding.
         ``same``
            The output is the same size as `in1`, centered
            with respect to the 'full' output.
-        ``full``
-           The output is the full discrete linear cross-correlation
-           of the inputs. (Default)
 
     Returns
     -------
@@ -185,16 +185,16 @@ def convolve(in1, in2, mode='full'):
         Second input. Should have the same number of dimensions as `in1`.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
-    
+
+        ``full``
+           The output is the full discrete linear convolution
+           of the inputs. (Default)
         ``valid``
            The output consists only of those elements that do not
            rely on the zero-padding.
         ``same``
            The output is the same size as `in1`, centered
            with respect to the 'full' output.
-        ``full``
-           The output is the full discrete linear convolution
-           of the inputs. (Default)
 
     Returns
     -------
@@ -392,20 +392,20 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
         Two-dimensional input arrays to be convolved.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
-    
+
+        ``full``
+           The output is the full discrete linear convolution
+           of the inputs. (Default)
         ``valid``
            The output consists only of those elements that do not
            rely on the zero-padding.
         ``same``
            The output is the same size as `in1`, centered
            with respect to the 'full' output.
-        ``full``
-           The output is the full discrete linear convolution
-           of the inputs. (Default)
 
     boundary : str {'fill', 'wrap', 'symm'}, optional
         A flag indicating how to handle boundaries:
-    
+
         ``fill``
            pad input arrays with fillvalue. (default)
         ``wrap``
@@ -448,20 +448,20 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
         Two-dimensional input arrays to be convolved.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
-    
+
+        ``full``
+           The output is the full discrete linear cross-correlation
+           of the inputs. (Default)
         ``valid``
            The output consists only of those elements that do not
            rely on the zero-padding.
         ``same``
            The output is the same size as `in1`, centered
            with respect to the 'full' output.
-        ``full``
-           The output is the full discrete linear cross-correlation
-           of the inputs. (Default)
 
     boundary : str {'fill', 'wrap', 'symm'}, optional
         A flag indicating how to handle boundaries:
-    
+
         ``fill``
            pad input arrays with fillvalue. (default)
         ``wrap``

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -145,7 +145,39 @@ def _centered(arr, newsize):
 
 
 def fftconvolve(in1, in2, mode="full"):
-    """Convolve two N-dimensional arrays using FFT. See `convolve`.
+    """Convolve two N-dimensional arrays using FFT.
+
+    Convolve `in1` and `in2` using the fast Fourier transform method, with 
+    the output size determined by the `mode` argument.
+
+    This is generally much faster than `convolve` for large arrays (n > ~500), 
+    but can be slower when only a few output values are needed, and can only 
+    output float arrays (int or object array inputs will be cast to float).
+
+    Parameters
+    ----------
+    in1 : array
+        First input.
+    in2 : array
+        Second input. Should have the same number of dimensions as `in1`.
+    mode : str {'full', 'valid', 'same'}, optional
+        A string indicating the size of the output:
+
+        ``full``
+           The output is the full discrete linear convolution
+           of the inputs. (Default)
+        ``valid``
+           The output consists only of those elements that do not
+           rely on the zero-padding.
+        ``same``
+           The output is the same size as `in1`, centered
+           with respect to the 'full' output.
+
+    Returns
+    -------
+    out : array
+        An N-dimensional array containing a subset of the discrete linear
+        convolution of `in1` with `in2`.
 
     """
     s1 = array(in1.shape)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -56,29 +56,32 @@ def correlate(in1, in2, mode='full'):
     """
     Cross-correlate two N-dimensional arrays.
 
-    Cross-correlate `in1` and `in2` with the output size determined by the 
+    Cross-correlate `in1` and `in2`, with the output size determined by the 
     `mode` argument.
 
     Parameters
     ----------
     in1 : array
-        first input.
+        First input.
     in2 : array
-        second input. Should have the same number of dimensions as `in1`.
-    mode : str {'valid', 'same', 'full'}, optional
+        Second input. Should have the same number of dimensions as `in1`.
+    mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
-
-            - 'valid': the output consists only of those elements that do not
-              rely on the zero-padding.
-            - 'same': the output is the same size as `in1` centered
-              with respect to the 'full' output.
-            - 'full': the output is the full discrete linear cross-correlation
-              of the inputs (default).
+    
+        ``valid``
+           The output consists only of those elements that do not
+           rely on the zero-padding.
+        ``same``
+           The output is the same size as `in1`, centered
+           with respect to the 'full' output.
+        ``full``
+           The output is the full discrete linear cross-correlation
+           of the inputs. (Default)
 
     Returns
     -------
     out : array
-        an N-dimensional array containing a subset of the discrete linear
+        An N-dimensional array containing a subset of the discrete linear
         cross-correlation of `in1` with `in2`.
 
     Notes
@@ -113,10 +116,9 @@ def correlate(in1, in2, mode='full'):
             z = sigtools._correlateND(in1zpadded, in2, out, val)
         elif mode == 'same':
             out = np.empty(in1.shape, in1.dtype)
-
             z = sigtools._correlateND(in1zpadded, in2, out, val)
         else:
-            raise ValueError("Uknown mode %s" % mode)
+            raise ValueError("Unknown mode %s" % mode)
 
     return z
 
@@ -166,32 +168,33 @@ def convolve(in1, in2, mode='full'):
     """
     Convolve two N-dimensional arrays.
 
-    Convolve `in1` and `in2` with output size determined by `mode`.
+    Convolve `in1` and `in2`, with the output size determined by the 
+    `mode` argument.
 
     Parameters
     ----------
     in1 : array
-        first input.
+        First input.
     in2 : array
-        second input. Should have the same number of dimensions as `in1`.
-    mode : str {'valid', 'same', 'full'}
-        a string indicating the size of the output:
-
-        ``valid`` : the output consists only of those elements that do not
+        Second input. Should have the same number of dimensions as `in1`.
+    mode : str {'full', 'valid', 'same'}, optional
+        A string indicating the size of the output:
+    
+        ``valid``
+           The output consists only of those elements that do not
            rely on the zero-padding.
-
-        ``same`` : the output is the same size as `in1` centered
+        ``same``
+           The output is the same size as `in1`, centered
            with respect to the 'full' output.
-
-        ``full`` : the output is the full discrete linear cross-correlation
+        ``full``
+           The output is the full discrete linear convolution
            of the inputs. (Default)
-
 
     Returns
     -------
     out : array
-        an N-dimensional array containing a subset of the discrete linear
-        cross-correlation of `in1` with `in2`.
+        An N-dimensional array containing a subset of the discrete linear
+        convolution of `in1` with `in2`.
 
     """
     volume = asarray(in1)
@@ -373,31 +376,35 @@ def wiener(im, mysize=None, noise=None):
 def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
     """Convolve two 2-dimensional arrays.
 
-    Convolve `in1` and `in2` with output size determined by `mode` and boundary
-    conditions determined by `boundary` and `fillvalue`.
+    Convolve `in1` and `in2` with output size determined by `mode`, and 
+    boundary conditions determined by `boundary` and `fillvalue`.
 
     Parameters
     ----------
     in1, in2 : ndarray
         Two-dimensional input arrays to be convolved.
-    mode : str, optional
+    mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
-
-        ``valid`` : the output consists only of those elements that do not
+    
+        ``valid``
+           The output consists only of those elements that do not
            rely on the zero-padding.
-
-        ``same`` : the output is the same size as `in1` centered
+        ``same``
+           The output is the same size as `in1`, centered
            with respect to the 'full' output.
-
-        ``full`` : the output is the full discrete linear cross-correlation
+        ``full``
+           The output is the full discrete linear convolution
            of the inputs. (Default)
 
-    boundary : str, optional
+    boundary : str {'fill', 'wrap', 'symm'}, optional
         A flag indicating how to handle boundaries:
-
-          - 'fill' : pad input arrays with fillvalue. (default)
-          - 'wrap' : circular boundary conditions.
-          - 'symm' : symmetrical boundary conditions.
+    
+        ``fill``
+           pad input arrays with fillvalue. (default)
+        ``wrap``
+           circular boundary conditions.
+        ``symm``
+           symmetrical boundary conditions.
 
     fillvalue : scalar, optional
         Value to fill pad input arrays with. Default is 0.
@@ -425,31 +432,35 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
 def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
     """Cross-correlate two 2-dimensional arrays.
 
-    Cross correlate `in1` and `in2` with output size determined by `mode` and
+    Cross correlate `in1` and `in2` with output size determined by `mode`, and
     boundary conditions determined by `boundary` and `fillvalue`.
 
     Parameters
     ----------
     in1, in2 : ndarray
         Two-dimensional input arrays to be convolved.
-    mode : str, optional
+    mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
-
-        ``valid`` : the output consists only of those elements that do not
+    
+        ``valid``
+           The output consists only of those elements that do not
            rely on the zero-padding.
-
-        ``same`` : the output is the same size as `in1` centered
+        ``same``
+           The output is the same size as `in1`, centered
            with respect to the 'full' output.
-
-        ``full`` : the output is the full discrete linear cross-correlation
+        ``full``
+           The output is the full discrete linear cross-correlation
            of the inputs. (Default)
 
-    boundary : str, optional
+    boundary : str {'fill', 'wrap', 'symm'}, optional
         A flag indicating how to handle boundaries:
-
-          - 'fill' : pad input arrays with fillvalue. (default)
-          - 'wrap' : circular boundary conditions.
-          - 'symm' : symmetrical boundary conditions.
+    
+        ``fill``
+           pad input arrays with fillvalue. (default)
+        ``wrap``
+           circular boundary conditions.
+        ``symm``
+           symmetrical boundary conditions.
 
     fillvalue : scalar, optional
         Value to fill pad input arrays with. Default is 0.

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -101,7 +101,15 @@ def correlate(in1, in2, mode='full'):
             x[..., i_l,...] * conj(y[..., i_l + k,...])
 
     """
+    in1 = asarray(in1)
+    in2 = asarray(in2)
+
     val = _valfrommode(mode)
+
+    if rank(in1) == rank(in2) == 0:
+        return in1 * in2
+    elif not in1.ndim == in2.ndim:
+        raise ValueError("in1 and in2 should have the same rank")
 
     if mode == 'valid':
         _check_valid_mode_shapes(in1.shape, in2.shape)
@@ -118,12 +126,10 @@ def correlate(in1, in2, mode='full'):
 
         if mode == 'full':
             out = np.empty(ps, in1.dtype)
-            z = sigtools._correlateND(in1zpadded, in2, out, val)
         elif mode == 'same':
             out = np.empty(in1.shape, in1.dtype)
-            z = sigtools._correlateND(in1zpadded, in2, out, val)
-        else:
-            raise ValueError("Unknown mode %s" % mode)
+
+        z = sigtools._correlateND(in1zpadded, in2, out, val)
 
     return z
 
@@ -155,15 +161,10 @@ def fftconvolve(in1, in2, mode="full"):
     fsize = 2 ** np.ceil(np.log2(size)).astype(int)
     fslice = tuple([slice(0, int(sz)) for sz in size])
     if not complex_result:
-        IN1 = rfftn(in1, fsize)
-        IN1 *= rfftn(in2, fsize)        
-        ret = irfftn(IN1)[fslice].copy()
+        ret = irfftn(rfftn(in1, fsize) * rfftn(in2, fsize))[fslice].copy()
         ret = ret.real
     else:
-        IN1 = fftn(in1, fsize)
-        IN1 *= fftn(in2, fsize)
-        ret = ifftn(IN1)[fslice].copy()
-    del IN1
+        ret = ifftn(fftn(in1, fsize) * fftn(in2, fsize))[fslice].copy()
 
     if mode == "full":
         return ret
@@ -211,8 +212,6 @@ def convolve(in1, in2, mode='full'):
 
     if rank(volume) == rank(kernel) == 0:
         return volume * kernel
-    elif not volume.ndim == kernel.ndim:
-        raise ValueError("in1 and in2 should have the same rank")
 
     slice_obj = [slice(None, None, -1)] * len(kernel.shape)
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -53,6 +53,14 @@ def _bvalfromboundary(boundary):
     return val
 
 
+def _check_valid_mode_shapes(shape1, shape2):
+    for d1, d2 in zip(shape1, shape2):
+        if not d1 >= d2:
+            raise ValueError(
+                "in1 should have at least as many items as in2 in "
+                "every dimension for 'valid' mode.")    
+
+
 def correlate(in1, in2, mode='full'):
     """
     Cross-correlate two N-dimensional arrays.
@@ -96,13 +104,9 @@ def correlate(in1, in2, mode='full'):
     val = _valfrommode(mode)
 
     if mode == 'valid':
+        _check_valid_mode_shapes(in1.shape, in2.shape)
         ps = [i - j + 1 for i, j in zip(in1.shape, in2.shape)]
         out = np.empty(ps, in1.dtype)
-        for i in range(len(ps)):
-            if ps[i] <= 0:
-                raise ValueError(
-                    "in1 should have at least as many items as in2 in "
-                    "every dimension for 'valid' mode.")
 
         z = sigtools._correlateND(in1, in2, out, val)
     else:
@@ -144,6 +148,9 @@ def fftconvolve(in1, in2, mode="full"):
                       np.issubdtype(in2.dtype, np.complex))
     size = s1 + s2 - 1
 
+    if mode == "valid":
+        _check_valid_mode_shapes(s1, s2)
+    
     # Always use 2**n-sized FFT
     fsize = 2 ** np.ceil(np.log2(size)).astype(int)
     fslice = tuple([slice(0, int(sz)) for sz in size])
@@ -163,11 +170,6 @@ def fftconvolve(in1, in2, mode="full"):
     elif mode == "same":
         return _centered(ret, s1)
     elif mode == "valid":
-        for d1, d2 in zip(in1.shape, in2.shape):
-            if not d1 >= d2:
-                raise ValueError(
-                    "in1 should have at least as many items as in2 in "
-                    "every dimension for 'valid' mode.")
         return _centered(ret, s1 - s2 + 1)
 
 
@@ -213,13 +215,6 @@ def convolve(in1, in2, mode='full'):
         raise ValueError("in1 and in2 should have the same rank")
 
     slice_obj = [slice(None, None, -1)] * len(kernel.shape)
-
-    if mode == 'valid':
-        for d1, d2 in zip(volume.shape, kernel.shape):
-            if not d1 >= d2:
-                raise ValueError(
-                    "in1 should have at least as many items as in2 in "
-                    "every dimension for 'valid' mode.")
 
     if np.iscomplexobj(kernel):
         return correlate(volume, kernel[slice_obj].conj(), mode)
@@ -425,11 +420,7 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
 
     """
     if mode == 'valid':
-        for d1, d2 in zip(np.shape(in1), np.shape(in2)):
-            if not d1 >= d2:
-                raise ValueError(
-                    "in1 should have at least as many items as in2 in "
-                    "every dimension for 'valid' mode.")
+        _check_valid_mode_shapes(in1.shape, in2.shape)
 
     val = _valfrommode(mode)
     bval = _bvalfromboundary(boundary)
@@ -481,11 +472,7 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
 
     """
     if mode == 'valid':
-        for d1, d2 in zip(np.shape(in1), np.shape(in2)):
-            if not d1 >= d2:
-                raise ValueError(
-                    "in1 should have at least as many items as in2 in "
-                    "every dimension for 'valid' mode.")
+        _check_valid_mode_shapes(in1.shape, in2.shape)
 
     val = _valfrommode(mode)
     bval = _bvalfromboundary(boundary)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -161,13 +161,14 @@ def fftconvolve(in1, in2, mode="full"):
     if mode == "full":
         return ret
     elif mode == "same":
-        if product(s1, axis=0) > product(s2, axis=0):
-            osize = s1
-        else:
-            osize = s2
-        return _centered(ret, osize)
+        return _centered(ret, s1)
     elif mode == "valid":
-        return _centered(ret, abs(s2 - s1) + 1)
+        for d1, d2 in zip(in1.shape, in2.shape):
+            if not d1 >= d2:
+                raise ValueError(
+                    "in1 should have at least as many items as in2 in "
+                    "every dimension for 'valid' mode.")
+        return _centered(ret, s1 - s2 + 1)
 
 
 def convolve(in1, in2, mode='full'):

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -193,7 +193,8 @@ def fftconvolve(in1, in2, mode="full"):
     fsize = 2 ** np.ceil(np.log2(size)).astype(int)
     fslice = tuple([slice(0, int(sz)) for sz in size])
     if not complex_result:
-        ret = irfftn(rfftn(in1, fsize) * rfftn(in2, fsize))[fslice].copy()
+        ret = irfftn(rfftn(in1, fsize) * 
+                     rfftn(in2, fsize), fsize)[fslice].copy()
         ret = ret.real
     else:
         ret = ifftn(fftn(in1, fsize) * fftn(in2, fsize))[fslice].copy()

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -6,6 +6,7 @@ import sigtools
 from scipy import linalg
 from scipy.fftpack import fft, ifft, ifftshift, fft2, ifft2, fftn, \
         ifftn, fftfreq
+from numpy.fft import rfftn, irfftn
 from numpy import polyadd, polymul, polydiv, polysub, roots, \
         poly, polyval, polyder, cast, asarray, isscalar, atleast_1d, \
         ones, real_if_close, zeros, array, arange, where, rank, \
@@ -144,14 +145,19 @@ def fftconvolve(in1, in2, mode="full"):
     size = s1 + s2 - 1
 
     # Always use 2**n-sized FFT
-    fsize = 2 ** np.ceil(np.log2(size))
-    IN1 = fftn(in1, fsize)
-    IN1 *= fftn(in2, fsize)
+    fsize = 2 ** np.ceil(np.log2(size)).astype(int)
     fslice = tuple([slice(0, int(sz)) for sz in size])
-    ret = ifftn(IN1)[fslice].copy()
-    del IN1
     if not complex_result:
+        IN1 = rfftn(in1, fsize)
+        IN1 *= rfftn(in2, fsize)        
+        ret = irfftn(IN1)[fslice].copy()
         ret = ret.real
+    else:
+        IN1 = fftn(in1, fsize)
+        IN1 *= fftn(in2, fsize)
+        ret = ifftn(IN1)[fslice].copy()
+    del IN1
+
     if mode == "full":
         return ret
     elif mode == "same":

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1,4 +1,3 @@
-
 from decimal import Decimal
 
 from numpy.testing import TestCase, run_module_suite, assert_equal, \
@@ -6,7 +5,7 @@ from numpy.testing import TestCase, run_module_suite, assert_equal, \
     assert_raises, assert_
 
 import scipy.signal as signal
-from scipy.signal import correlate, convolve, convolve2d, \
+from scipy.signal import correlate, convolve, convolve2d, fftconvolve, \
      hilbert, hilbert2, lfilter, lfilter_zi, filtfilt, butter, tf2zpk
 
 
@@ -27,11 +26,17 @@ class _TestConvolve(TestCase):
         z = convolve(x, y)
         assert_array_equal(z, array([2j, 2+6j, 5+8j, 5+5j]))
 
-    def test_zero_order(self):
+    def test_zero_rank(self):
         a = 1289
         b = 4567
         c = convolve(a,b)
-        assert_array_equal(c,a*b)
+        assert_equal(c,a*b)
+
+    def test_single_element(self):
+        a = array([4967])
+        b = array([3920])
+        c = convolve(a,b)
+        assert_equal(c,a*b)
 
     def test_2d_arrays(self):
         a = [[1,2,3],[3,4,5]]
@@ -148,7 +153,7 @@ class TestFFTConvolve(TestCase):
 
     def test_2d_complex_same(self):
         a = array([[1+2j,3+4j,5+6j],[2+1j,4+3j,6+5j]])
-        c = signal.fftconvolve(a,a)
+        c = fftconvolve(a,a)
         d = array([[-3+4j,-10+20j,-21+56j,-18+76j,-11+60j],\
                    [10j,44j,118j,156j,122j],\
                    [3+4j,10+20j,21+56j,18+76j,11+60j]])
@@ -157,29 +162,56 @@ class TestFFTConvolve(TestCase):
     def test_real_same_mode(self):
         a = array([1,2,3])
         b = array([3,3,5,6,8,7,9,0,1])
-        c = signal.fftconvolve(a,b,'same')
+        c = fftconvolve(a,b,'same')
+        d = array([ 35.,  41.,  47.])
+        assert_array_almost_equal(c,d)
+
+    def test_real_same_mode2(self):
+        a = array([3,3,5,6,8,7,9,0,1])
+        b = array([1,2,3])
+        c = fftconvolve(a,b,'same')
         d = array([9.,20.,25.,35.,41.,47.,39.,28.,2.])
         assert_array_almost_equal(c,d)
 
     def test_real_valid_mode(self):
         a = array([3,2,1])
         b = array([3,3,5,6,8,7,9,0,1])
-        c = signal.fftconvolve(a,b,'valid')
+        def _test():
+            fftconvolve(a,b,'valid')
+        self.assertRaises(ValueError, _test)
+
+    def test_real_valid_mode2(self):
+        a = array([3,3,5,6,8,7,9,0,1])
+        b = array([3,2,1])
+        c = fftconvolve(a,b,'valid')
         d = array([24.,31.,41.,43.,49.,25.,12.])
         assert_array_almost_equal(c,d)
 
-    def test_zero_order(self):
+    def test_empty(self):
+        """Regression test for #1745: crashes with 0-length input"""
+        a = array([5])
+        b = array([])
+        def _test():
+            fftconvolve(a,b)
+        self.assertRaises(ValueError, _test)
+
+    def test_zero_rank(self):
+        a = array(4967)
+        b = array(3920)
+        c = fftconvolve(a,b)
+        assert_equal(c,a*b)
+
+    def test_single_element(self):
         a = array([4967])
         b = array([3920])
-        c = signal.fftconvolve(a,b)
-        d = a*b
-        assert_equal(c,d)
+        c = fftconvolve(a,b)
+        assert_equal(c,a*b)
 
     def test_random_data(self):
         np.random.seed(1234)
         a = np.random.rand(1233) + 1j*np.random.rand(1233)
         b = np.random.rand(1321) + 1j*np.random.rand(1321)
-        c = signal.fftconvolve(a, b, 'full')
+        c = fftconvolve(a, b, 'full')
         d = np.convolve(a, b, 'full')
         assert_(np.allclose(c, d, rtol=1e-10))
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -117,22 +117,22 @@ class _TestConvolve2d(TestCase):
         assert_array_equal(c,d)
 
 
-#class TestConvolve2d(_TestConvolve2d):
-#    def test_same_mode(self):
-#        e = [[1,2,3],[3,4,5]]
-#        f = [[2,3,4,5,6,7,8],[4,5,6,7,8,9,10]]
-#        g = convolve2d(e,f,'same')
-#        h = array([[80,98,116],\
-#                   [70,82,94]])
-#        assert_array_equal(g,h)
-#
-#    def test_valid_mode2(self):
-#        # Test when in2.size > in1.size
-#        e = [[1,2,3],[3,4,5]]
-#        f = [[2,3,4,5,6,7,8],[4,5,6,7,8,9,10]]
-#        def _test():
-#            convolve2d(e,f,'valid')
-#        self.assertRaises(ValueError, _test)
+class TestConvolve2d(_TestConvolve2d):
+    def test_same_mode(self):
+        e = [[1,2,3],[3,4,5]]
+        f = [[2,3,4,5,6,7,8],[4,5,6,7,8,9,10]]
+        g = convolve2d(e,f,'same')
+        h = array([[22,28,34],\
+                   [80,98,116]])
+        assert_array_equal(g,h)
+
+    def test_valid_mode2(self):
+        # Test when in2.size > in1.size
+        e = [[1,2,3],[3,4,5]]
+        f = [[2,3,4,5,6,7,8],[4,5,6,7,8,9,10]]
+        def _test():
+            convolve2d(e,f,'valid')
+        self.assertRaises(ValueError, _test)
 
 class TestFFTConvolve(TestCase):
     def test_real(self):


### PR DESCRIPTION
1. Made the error messages for invalid sizes consistent
2. convolve2d had the check for 'valid' mode size but correlate2d didn't (just output an empty array), so I added it.
3. The same check should be added to fftconvolve, I think.  Currently it uses whichever array is bigger, which I think is the "old behavior" [that was removed from the other functions here](https://github.com/scipy/scipy/commit/6b32937aafcbbb3e4758ddf67da8d573b88b1682).
4. Used `rfftn` for real-input fftconvolve to double the speed, as [I suggested on the numpy trac](http://projects.scipy.org/numpy/ticket/1260#comment:7) ([now here](https://github.com/numpy/numpy/issues/1858#issuecomment-9688656)).  (I hope I did this right and it doesn't break in weird cases)
5. docstring cleanup, typos, etc.
6. fftconvolve [dies with zero-size inputs](http://projects.scipy.org/scipy/ticket/1745), so maybe should add some checks to reject those?  Should probably be fixed [at the fftn level](http://projects.scipy.org/scipy/ticket/1745#comment:2), too, though.
7. Added docstring to fftconvolve (though I think the functionality of fftconvolve should be folded into convolve/correlate/convolve2d/correlate2d and enabled with an option like `fft={True, False, 'auto'}` or `method={'naive', 'fft', 'heuristic'}` and then fftconvolve gets deprecated, as in the numpy feature request, but that requires more extensive discussion)
