### PR TITLE
DOC--In interp1d, the y input is allowed to be complex -- fixed docstring

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1,5 +1,4 @@
 
-
 """ Classes for interpolating values.
 """
 
@@ -208,8 +207,8 @@ class interp1d(object):
     x : array_like
         A 1-D array of monotonically increasing real values.
     y : array_like
-        A N-D array of real values. The length of `y` along the interpolation
-        axis must be equal to the length of `x`.
+        A N-D array of real or complex values. The length of `y` along the
+        interpolation axis must be equal to the length of `x`.
     kind : str or int, optional
         Specifies the kind of interpolation as a string
         ('linear','nearest', 'zero', 'slinear', 'quadratic, 'cubic')


### PR DESCRIPTION
The dependent variable (y) of interp1d is allowed to be complex. In fact, the unit tests already check that complex y works properly. See test_interpolate.TestInterp1D.test_complex(). Therefore I edited the docstring to advertise that fact.
