### PR TITLE
MAINT: filter unhelpful Cython warnings for numpy dtype/ufunc size chang...

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -117,3 +117,8 @@ else:
     from numpy.testing import Tester
     test = Tester().test
     bench = Tester().bench
+
+    # Filter annoying Cython warnings that serve no good purpose.
+    import warnings
+    warnings.filterwarnings("ignore", message="numpy.dtype size changed")
+    warnings.filterwarnings("ignore", message="numpy.ufunc size changed")

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -176,6 +176,11 @@ sorted indices are required (e.g. when passing data to other libraries).
 # Modified and extended by Ed Schofield, Robert Cimrman,
 # Nathan Bell, and Jake Vanderplas.
 
+# Filter annoying Cython warnings that serve no good purpose.
+import warnings
+warnings.filterwarnings("ignore", message="numpy.dtype size changed")
+warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
+
 from base import *
 from csr import *
 from csc import *
@@ -196,3 +201,4 @@ __all__ = filter(lambda s:not s.startswith('_'),dir())
 from numpy.testing import Tester
 test = Tester().test
 bench = Tester().bench
+


### PR DESCRIPTION
...es.

Without this `scipy.test` gives a large amount of errors when using numpy master with scipy compiled against numpy 1.6.x.
