### PR TITLE
Fix msvc compile errors in scipy/special/Faddeeva.cc

### DIFF
--- a/scipy/special/Faddeeva.cc
+++ b/scipy/special/Faddeeva.cc
@@ -117,6 +117,9 @@
 		       file Faddeeva.hh.
 */
 
+#include "Python.h"
+#include "numpy/npy_math.h"
+
 #include <cfloat>
 #include <cmath>
 
@@ -124,13 +127,15 @@ using namespace std;
 
 /////////////////////////////////////////////////////////////////////////
 
-// define my own isnan & isinf, since std:: versions only available in C++11
-static inline bool my_isnan(double x) { return x != x; }
-#define isnan my_isnan
-static inline bool my_isinf(double x) { return 1/x == 0.; }
-#define isinf my_isinf
-#define Inf (1./0.) // infinity
-#define NaN (0./0.) // NaN
+// use numpy's isnan & isinf, since std:: versions only available in C++11
+#define isnan npy_isnan
+#define isinf npy_isinf
+#define Inf NPY_INFINITY // infinity
+#define NaN NPY_NAN // NaN
+
+#ifdef _MSC_VER
+#define copysign _copysign
+#endif
 
 /////////////////////////////////////////////////////////////////////////
 // Auxiliary routines to compute other special functions based on w(z)

--- a/scipy/special/Faddeeva.cc
+++ b/scipy/special/Faddeeva.cc
@@ -118,7 +118,9 @@
 */
 
 #include "Python.h"
+extern "C" {
 #include "numpy/npy_math.h"
+}
 
 #include <cfloat>
 #include <cmath>


### PR DESCRIPTION
Building scipy from the master branch fails when using msvc10 (and probably also msvc9) compilers because `copysign` is unknown and `#define Inf (1./0.)` raises a division by zero error in scipy/special/Faddeeva.cc. 
