### PR TITLE
Fix detection of MKL usage on Windows

### DIFF
--- a/scipy/lib/lapack/setup.py
+++ b/scipy/lib/lapack/setup.py
@@ -96,7 +96,7 @@ def configuration(parent_package='',top_path=None):
                          )
 
     # atlas_version:
-    if os.name == 'nt' and 'FPATH' in os.environ:
+    if os.name == 'nt' and ('FPATH' in os.environ or 'MKLROOT' in os.environ):
         define_macros = [('NO_ATLAS_INFO', 1)]
     else:
         define_macros = []

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -162,7 +162,7 @@ def configuration(parent_package='',top_path=None):
                          )
 
     # atlas_version:
-    if os.name == 'nt' and 'FPATH' in os.environ:
+    if os.name == 'nt' and ('FPATH' in os.environ or 'MKLROOT' in os.environ):
         define_macros = [('NO_ATLAS_INFO', 1)]
     else:
         define_macros = []

--- a/scipy/sparse/linalg/dsolve/setup.py
+++ b/scipy/sparse/linalg/dsolve/setup.py
@@ -21,7 +21,7 @@ def configuration(parent_package='',top_path=None):
     superlu_src = join(dirname(__file__), 'SuperLU', 'SRC')
 
     sources = list(glob.glob(join(superlu_src, '*.c')))
-    if os.name == 'nt' and 'FPATH' in os.environ:
+    if os.name == 'nt' and ('FPATH' in os.environ or 'MKLROOT' in os.environ):
         # when using MSVC + MKL, lsame is already in MKL
         sources.remove(join(superlu_src, 'lsame.c'))
 


### PR DESCRIPTION
Building scipy on Windows with the Intel Composer XE 2013 compilers fails because the `FPATH` environment variable, which is currently used in setup.py to detect whether MKL is linked, is no longer set. This patch adds a check for the `MKLROOT` environment variable.
