### PR TITLE
MAINT: linalg: clean up LAPACK and BLAS wrappers + document them

### DIFF
--- a/doc/API.rst.txt
+++ b/doc/API.rst.txt
@@ -104,6 +104,9 @@ change is made.
 
 * scipy.linalg
 
+  - scipy.linalg.blas
+  - scipy.linalg.lapack
+
 * scipy.misc
 
 * scipy.ndimage

--- a/doc/release/0.12.0-notes.rst
+++ b/doc/release/0.12.0-notes.rst
@@ -43,7 +43,6 @@ exactly the same interface as KDTree, and can be used as a drop-in replacement.
 -------------------------------
 A callback mechanism was added to L-BFGS-B and TNC minimization solvers.
 
-
 Complex error functions in ``scipy.special``
 --------------------------------------------
 The computation of special functions related to the error function now uses a
@@ -57,9 +56,26 @@ Listing Matlab(R) file contents
 A new function ``whosmat`` is available in ``scipy.io`` for inspecting contents
 of MAT files without reading them to memory.
 
+Documented BLAS and LAPACK low-level interfaces
+-----------------------------------------------
+The modules `scipy.linalg.blas` and `scipy.linalg.lapack` can be used
+to access low-level BLAS and LAPACK functions.
+
 
 Deprecated features
 ===================
+
+`scipy.lib.lapack`
+------------------
+The module `scipy.lib.lapack` is deprecated. You can use
+`scipy.linalg.lapack` instead. The module `scipy.lib.blas` was
+deprecated earlier in Scipy 0.10.0.
+
+`fblas` and `cblas`
+-------------------
+Accessing the modules `scipy.linalg.fblas`, `cblas`, `flapack`,
+`clapack` is deprecated. Instead, use the modules
+`scipy.linalg.lapack` and `scipy.linalg.blas`.
 
 
 Backwards incompatible changes

--- a/doc/source/linalg.blas.rst
+++ b/doc/source/linalg.blas.rst
@@ -1,0 +1,1 @@
+.. automodule:: scipy.linalg.blas

--- a/doc/source/linalg.lapack.rst
+++ b/doc/source/linalg.lapack.rst
@@ -1,0 +1,1 @@
+.. automodule:: scipy.linalg.lapack

--- a/doc/source/linalg.rst
+++ b/doc/source/linalg.rst
@@ -1,1 +1,7 @@
 .. automodule:: scipy.linalg
+
+.. toctree::
+   :hidden:
+
+   linalg.blas
+   linalg.lapack

--- a/scipy/lib/blas/__init__.py
+++ b/scipy/lib/blas/__init__.py
@@ -2,6 +2,8 @@
 Wrappers to BLAS library
 ========================
 
+NOTE: this module is deprecated -- use scipy.linalg.blas instead!
+
 fblas -- wrappers for Fortran [*] BLAS routines
 cblas -- wrappers for ATLAS BLAS routines
 get_blas_funcs -- query for wrapper functions.
@@ -88,6 +90,15 @@ import cblas
 
 from numpy import deprecate
 
+@deprecate(old_name="scipy.lib.blas", new_name="scipy.linalg.blas")
+def _deprecated():
+    pass
+try:
+    _deprecated()
+except DeprecationWarning, e:
+    # don't fail import if DeprecationWarnings raise error -- works around
+    # the situation with Numpy's test framework
+    pass
 
 _use_force_cblas = 1
 if hasattr(cblas,'empty_module'):

--- a/scipy/lib/lapack/__init__.py
+++ b/scipy/lib/lapack/__init__.py
@@ -137,6 +137,7 @@ Optimal lwork is maxwrk. Default is minwrk.
 
 __all__ = ['get_lapack_funcs','calc_lwork','flapack','clapack']
 
+from numpy import deprecate
 
 import calc_lwork
 
@@ -146,7 +147,6 @@ import calc_lwork
 
 import flapack
 import clapack
-
 
 _use_force_clapack = 1
 if hasattr(clapack,'empty_module'):
@@ -159,7 +159,7 @@ elif hasattr(flapack,'empty_module'):
 _type_conv = {'f':'s', 'd':'d', 'F':'c', 'D':'z'} # 'd' will be default for 'i',..
 _inv_type_conv = {'s':'f','d':'d','c':'F','z':'D'}
 
-
+@deprecate
 def get_lapack_funcs(names,arrays=(),debug=0,force_clapack=1):
     """Return available LAPACK function objects with names.
     arrays are used to determine the optimal prefix of

--- a/scipy/lib/lapack/__init__.py
+++ b/scipy/lib/lapack/__init__.py
@@ -2,6 +2,8 @@
 Wrappers to LAPACK library
 ==========================
 
+NOTE: this module is deprecated -- use scipy.linalg.lapack instead!
+
   flapack -- wrappers for Fortran [*] LAPACK routines
   clapack -- wrappers for ATLAS LAPACK routines
   calc_lwork -- calculate optimal lwork parameters
@@ -144,6 +146,16 @@ import calc_lwork
 # The following ensures that possibly missing flavor (C or Fortran) is
 # replaced with the available one. If none is available, exception
 # is raised at the first attempt to use the resources.
+
+@deprecate(old_name="scipy.lib.lapack", new_name="scipy.linalg.lapack")
+def _deprecated():
+    pass
+try:
+    _deprecated()
+except DeprecationWarning, e:
+    # don't fail import if DeprecationWarnings raise error -- works around
+    # the situation with Numpy's test framework
+    pass
 
 import flapack
 import clapack

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -135,6 +135,8 @@ Low-level routines
    get_blas_funcs
    get_lapack_funcs
    find_best_blas_type
+   scipy.linalg.blas
+   scipy.linalg.lapack
 
 """
 
@@ -151,6 +153,7 @@ from decomp_svd import *
 from decomp_schur import *
 from matfuncs import *
 from blas import *
+from lapack import *
 from special_matrices import *
 from _solvers import *
 

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -126,6 +126,16 @@ Special Matrices
    toeplitz - Toeplitz matrix
    tri - Construct a matrix filled with ones at and below a given diagonal
 
+Low-level routines
+==================
+
+.. autosummary::
+   :toctree: generated/
+
+   get_blas_funcs
+   get_lapack_funcs
+   find_best_blas_type
+
 """
 
 from linalg_version import linalg_version as __version__

--- a/scipy/linalg/bento.info
+++ b/scipy/linalg/bento.info
@@ -1,17 +1,17 @@
 HookFile: bscript
 
 Library:
-    Extension: fblas
+    Extension: _fblas
         Sources:
             fblas.pyf.src,
             src/fblaswrap.f
-    Extension: cblas
+    Extension: _cblas
         Sources:
             generic_cblas.pyf
-    Extension: flapack
+    Extension: _flapack
         Sources:
             flapack.pyf.src
-    Extension: clapack
+    Extension: _clapack
         Sources:
             generic_clapack.pyf
     Extension: _flinalg

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -111,9 +111,9 @@ import numpy as _np
 # replaced with the available one. If none is available, exception
 # is raised at the first attempt to use the resources.
 
-from scipy.linalg import fblas as _fblas
+from scipy.linalg import _fblas
 try:
-    from scipy.linalg import cblas as _cblas
+    from scipy.linalg import _cblas
 except ImportError:
     _cblas = None
 if _cblas is None:
@@ -122,7 +122,9 @@ elif hasattr(_fblas, 'empty_module'):
     _fblas = _cblas
 
 # Expose all functions (only fblas --- cblas is an implementation detail)
-from scipy.linalg.fblas import *
+empty_module = None
+from scipy.linalg._fblas import *
+del empty_module
 
 # 'd' will be default for 'i',..
 _type_conv = {'f':'s', 'd':'d', 'F':'c', 'D':'z', 'G':'z'}
@@ -178,7 +180,8 @@ def find_best_blas_type(arrays=(), dtype=None):
     return prefix, dtype, prefer_fortran
 
 def _get_funcs(names, arrays, dtype,
-               lib_name, fmodule, cmodule, alias):
+               lib_name, fmodule, cmodule,
+               fmodule_name, cmodule_name, alias):
     """
     Return available BLAS/LAPACK functions.
 
@@ -188,8 +191,8 @@ def _get_funcs(names, arrays, dtype,
     funcs = []
     unpack = False
     dtype = _np.dtype(dtype)
-    module1 = (cmodule, cmodule.__name__.split('.')[-1])
-    module2 = (fmodule, fmodule.__name__.split('.')[-1])
+    module1 = (cmodule, cmodule_name)
+    module2 = (fmodule, fmodule_name)
 
     if isinstance(names, str):
         names = (names,)
@@ -260,4 +263,5 @@ def get_blas_funcs(names, arrays=(), dtype=None):
     of the returned functions.
     """
     return _get_funcs(names, arrays, dtype,
-                      "BLAS", _fblas, _cblas, _blas_alias)
+                      "BLAS", _fblas, _cblas, "fblas", "cblas",
+                      _blas_alias)

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -95,7 +95,7 @@ def _get_funcs(names, arrays, dtype,
 
     for i, name in enumerate(names):
         func_name = prefix + name
-        func_name = _blas_alias.get(func_name, func_name)
+        func_name = alias.get(func_name, func_name)
         func = getattr(module1[0], func_name, None)
         module_name = module1[1]
         if func is None:
@@ -105,6 +105,8 @@ def _get_funcs(names, arrays, dtype,
             raise ValueError(
                 '%s function %s could not be found' % (lib_name, func_name))
         func.module_name, func.typecode = module_name, prefix
+        func.dtype = dtype
+        func.prefix = prefix # Backward compatibility
         funcs.append(func)
 
     if unpack:
@@ -146,8 +148,9 @@ def get_blas_funcs(names, arrays=(), dtype=None):
     In BLAS, the naming convention is that all functions start with a
     type prefix, which depends on the type of the principal
     matrix. These can be one of {'s', 'd', 'c', 'z'} for the numpy
-    types {float32, float64, complex64, complex128} respectevely, and
-    are stored in attribute `typecode` of the returned functions.
+    types {float32, float64, complex64, complex128} respectively.
+    The code and the dtype are stored in attributes `typecode` and `dtype`
+    of the returned functions.
     """
     return _get_funcs(names, arrays, dtype,
                       "BLAS", fblas, cblas, _blas_alias)

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -1,3 +1,103 @@
+"""
+Low-level BLAS functions
+========================
+
+This module contains low-level functions from the BLAS library.
+
+
+.. warning::
+
+   These functions do little to no error checking.
+   It is possible to cause crashes by mis-using them,
+   so prefer using the higher-level routines in `scipy.linalg`.
+
+Finding functions
+=================
+
+.. autosummary::
+
+   get_blas_funcs
+   find_best_blas_type
+
+All functions
+=============
+
+.. autosummary::
+   :toctree: generated/
+
+   caxpy
+   ccopy
+   cdotc
+   cdotu
+   cgemm
+   cgemv
+   cgerc
+   cgeru
+   chemv
+   crotg
+   cscal
+   csrot
+   csscal
+   cswap
+   ctrmv
+   dasum
+   daxpy
+   dcopy
+   ddot
+   dgemm
+   dgemv
+   dger
+   dnrm2
+   drot
+   drotg
+   drotm
+   drotmg
+   dscal
+   dswap
+   dsymv
+   dtrmv
+   dzasum
+   dznrm2
+   icamax
+   idamax
+   isamax
+   izamax
+   sasum
+   saxpy
+   scasum
+   scnrm2
+   scopy
+   sdot
+   sgemm
+   sgemv
+   sger
+   snrm2
+   srot
+   srotg
+   srotm
+   srotmg
+   sscal
+   sswap
+   ssymv
+   strmv
+   zaxpy
+   zcopy
+   zdotc
+   zdotu
+   zdrot
+   zdscal
+   zgemm
+   zgemv
+   zgerc
+   zgeru
+   zhemv
+   zrotg
+   zscal
+   zswap
+   ztrmv
+
+
+"""
 #
 # Author: Pearu Peterson, March 2002
 #         refactoring by Fabian Pedregosa, March 2010
@@ -5,21 +105,24 @@
 
 __all__ = ['get_blas_funcs', 'find_best_blas_type']
 
-import numpy as np
+import numpy as _np
 
 # The following ensures that possibly missing flavor (C or Fortran) is
 # replaced with the available one. If none is available, exception
 # is raised at the first attempt to use the resources.
 
-from scipy.linalg import fblas
+from scipy.linalg import fblas as _fblas
 try:
-    from scipy.linalg import cblas
+    from scipy.linalg import cblas as _cblas
 except ImportError:
-    cblas = None
-if cblas is None:
-    cblas = fblas
-elif hasattr(fblas, 'empty_module'):
-    fblas = cblas
+    _cblas = None
+if _cblas is None:
+    _cblas = _fblas
+elif hasattr(_fblas, 'empty_module'):
+    _fblas = _cblas
+
+# Expose all functions (only fblas --- cblas is an implementation detail)
+from scipy.linalg.fblas import *
 
 # 'd' will be default for 'i',..
 _type_conv = {'f':'s', 'd':'d', 'F':'c', 'D':'z', 'G':'z'}
@@ -55,13 +158,13 @@ def find_best_blas_type(arrays=(), dtype=None):
         Whether to prefer Fortran order routines over C order.
 
     """
-    dtype = np.dtype(dtype)
+    dtype = _np.dtype(dtype)
     prefer_fortran = False
 
     if arrays:
         # use the most generic type in arrays
         dtypes = [ar.dtype for ar in arrays]
-        dtype = np.find_common_type(dtypes, ())
+        dtype = _np.find_common_type(dtypes, ())
         try:
             index = dtypes.index(dtype)
         except ValueError:
@@ -84,9 +187,9 @@ def _get_funcs(names, arrays, dtype,
 
     funcs = []
     unpack = False
-    dtype = np.dtype(dtype)
-    module1 = (cmodule, 'cblas')
-    module2 = (fmodule, 'fblas')
+    dtype = _np.dtype(dtype)
+    module1 = (cmodule, cmodule.__name__.split('.')[-1])
+    module2 = (fmodule, fmodule.__name__.split('.')[-1])
 
     if isinstance(names, str):
         names = (names,)
@@ -157,4 +260,4 @@ def get_blas_funcs(names, arrays=(), dtype=None):
     of the returned functions.
     """
     return _get_funcs(names, arrays, dtype,
-                      "BLAS", fblas, cblas, _blas_alias)
+                      "BLAS", _fblas, _cblas, _blas_alias)

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -4,6 +4,7 @@ Low-level BLAS functions
 
 This module contains low-level functions from the BLAS library.
 
+.. versionadded:: 0.12.0
 
 .. warning::
 

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -60,8 +60,12 @@ def find_best_blas_type(arrays=(), dtype=None):
 
     if arrays:
         # use the most generic type in arrays
-        dtype, index = max(
-            [(ar.dtype, i) for i, ar in enumerate(arrays)])
+        dtypes = [ar.dtype for ar in arrays]
+        dtype = np.find_common_type(dtypes, ())
+        try:
+            index = dtypes.index(dtype)
+        except ValueError:
+            index = 0
         if arrays[index].flags['FORTRAN']:
             # prefer Fortran for leading array with column major order
             prefer_fortran = True

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -107,19 +107,11 @@ __all__ = ['get_blas_funcs', 'find_best_blas_type']
 
 import numpy as _np
 
-# The following ensures that possibly missing flavor (C or Fortran) is
-# replaced with the available one. If none is available, exception
-# is raised at the first attempt to use the resources.
-
 from scipy.linalg import _fblas
 try:
     from scipy.linalg import _cblas
 except ImportError:
     _cblas = None
-if _cblas is None:
-    _cblas = _fblas
-elif hasattr(_fblas, 'empty_module'):
-    _fblas = _cblas
 
 # Expose all functions (only fblas --- cblas is an implementation detail)
 empty_module = None

--- a/scipy/linalg/bscript
+++ b/scipy/linalg/bscript
@@ -17,16 +17,16 @@ def pre_build(context):
                                features="c fc pyext bento cshlib f2py",
                                source=source,
                                use="FBLAS CLIB")
-    context.register_builder("fblas", fblas_builder)
+    context.register_builder("_fblas", fblas_builder)
 
     def cblas_builder(extension):
         if bld.env.HAS_CBLAS:
             return default_builder(extension,
                                    features="c fc pyext bento cshlib f2py",
                                    use="CBLAS")
-    context.register_builder("cblas", cblas_builder)
+    context.register_builder("_cblas", cblas_builder)
 
-    context.tweak_extension("flapack", features="c fc pyext bento cshlib f2py",
+    context.tweak_extension("_flapack", features="c fc pyext bento cshlib f2py",
                           use="FLAPACK CLIB")
 
     def builder(extension):
@@ -34,7 +34,7 @@ def pre_build(context):
             return default_builder(extension,
                                    features="c pyext bento cshlib f2py",
                                    use="CLAPACK")
-    context.register_builder("clapack", builder)
+    context.register_builder("_clapack", builder)
 
     context.tweak_extension("_flinalg", features="c fc pyext bento cshlib f2py f2py_fortran",
                           use="FLAPACK CLIB")

--- a/scipy/linalg/cblas.py
+++ b/scipy/linalg/cblas.py
@@ -1,0 +1,11 @@
+"""
+This module is deprecated -- use scipy.linalg.blas instead
+"""
+try:
+    from _cblas import *
+except ImportError:
+    empty_module = True
+import numpy as _np
+@_np.deprecate(old_name="scipy.linalg.cblas", new_name="scipy.linalg.blas")
+def _deprecate(): pass
+_deprecate()

--- a/scipy/linalg/cblas.pyf.src
+++ b/scipy/linalg/cblas.pyf.src
@@ -6,10 +6,10 @@
 ! $Revision$ $Date$
 ! 
 
-python module cblas
+python module _cblas
     interface
 
        include "cblas_l1.pyf.src"
 
     end interface
-end python module cblas
+end python module _cblas

--- a/scipy/linalg/clapack.py
+++ b/scipy/linalg/clapack.py
@@ -1,0 +1,11 @@
+"""
+This module is deprecated -- use scipy.linalg.lapack instead
+"""
+try:
+    from _clapack import *
+except ImportError:
+    empty_module = True
+import numpy as _np
+@_np.deprecate(old_name="scipy.linalg.clapack", new_name="scipy.linalg.lapack")
+def _deprecate(): pass
+_deprecate()

--- a/scipy/linalg/clapack.pyf.src
+++ b/scipy/linalg/clapack.pyf.src
@@ -12,7 +12,7 @@
 !  trtri
 !
 
-python module clapack
+python module _clapack
   interface
    
    function <prefix>gesv(n,nrhs,a,piv,b,info,rowmajor)
@@ -202,4 +202,4 @@ python module clapack
 
 
   end interface
-end python module clapack
+end python module _clapack

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -44,8 +44,6 @@ def _make_complex_eigvecs(w, vin, dtype):
 def _geneig(a1, b1, left, right, overwrite_a, overwrite_b):
     ggev, = get_lapack_funcs(('ggev',), (a1, b1))
     cvl, cvr = left, right
-    if ggev.module_name[:7] == 'clapack':
-        raise NotImplementedError('calling ggev from %s' % ggev.module_name)
     res = ggev(a1, b1, lwork=-1)
     lwork = res[-2][0].real.astype(numpy.int)
     if ggev.typecode in 'cz':
@@ -155,34 +153,22 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
         return _geneig(a1, b1, left, right, overwrite_a, overwrite_b)
     geev, = get_lapack_funcs(('geev',), (a1,))
     compute_vl, compute_vr = left, right
-    if geev.module_name[:7] == 'flapack':
-        lwork = calc_lwork.geev(geev.typecode, a1.shape[0],
-                                    compute_vl, compute_vr)[1]
-        if geev.typecode in 'cz':
-            w, vl, vr, info = geev(a1, lwork=lwork,
-                                        compute_vl=compute_vl,
-                                        compute_vr=compute_vr,
-                                        overwrite_a=overwrite_a)
-        else:
-            wr, wi, vl, vr, info = geev(a1, lwork=lwork,
-                                        compute_vl=compute_vl,
-                                        compute_vr=compute_vr,
-                                        overwrite_a=overwrite_a)
-            t = {'f':'F','d':'D'}[wr.dtype.char]
-            w = wr + _I * wi
-    else: # 'clapack'
-        if geev.typecode in 'cz':
-            w, vl, vr, info = geev(a1,
+
+    lwork = calc_lwork.geev(geev.typecode, a1.shape[0],
+                                compute_vl, compute_vr)[1]
+    if geev.typecode in 'cz':
+        w, vl, vr, info = geev(a1, lwork=lwork,
                                     compute_vl=compute_vl,
                                     compute_vr=compute_vr,
                                     overwrite_a=overwrite_a)
-        else:
-            wr, wi, vl, vr, info = geev(a1,
-                                        compute_vl=compute_vl,
-                                        compute_vr=compute_vr,
-                                        overwrite_a=overwrite_a)
-            t = {'f':'F','d':'D'}[wr.dtype.char]
-            w = wr + _I * wi
+    else:
+        wr, wi, vl, vr, info = geev(a1, lwork=lwork,
+                                    compute_vl=compute_vl,
+                                    compute_vr=compute_vr,
+                                    overwrite_a=overwrite_a)
+        t = {'f':'F','d':'D'}[wr.dtype.char]
+        w = wr + _I * wi
+
     if info < 0:
         raise ValueError('illegal value in %d-th argument of internal geev'
                                                                     % -info)

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -48,7 +48,7 @@ def _geneig(a1, b1, left, right, overwrite_a, overwrite_b):
         raise NotImplementedError('calling ggev from %s' % ggev.module_name)
     res = ggev(a1, b1, lwork=-1)
     lwork = res[-2][0].real.astype(numpy.int)
-    if ggev.prefix in 'cz':
+    if ggev.typecode in 'cz':
         alpha, beta, vl, vr, work, info = ggev(a1, b1, cvl, cvr, lwork,
                                                     overwrite_a, overwrite_b)
         w = alpha / beta
@@ -64,7 +64,7 @@ def _geneig(a1, b1, left, right, overwrite_a, overwrite_b):
                                                                     % info)
 
     only_real = numpy.logical_and.reduce(numpy.equal(w.imag, 0.0))
-    if not (ggev.prefix in 'cz' or only_real):
+    if not (ggev.typecode in 'cz' or only_real):
         t = w.dtype.char
         if left:
             vl = _make_complex_eigvecs(w, vl, t)
@@ -156,9 +156,9 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     geev, = get_lapack_funcs(('geev',), (a1,))
     compute_vl, compute_vr = left, right
     if geev.module_name[:7] == 'flapack':
-        lwork = calc_lwork.geev(geev.prefix, a1.shape[0],
+        lwork = calc_lwork.geev(geev.typecode, a1.shape[0],
                                     compute_vl, compute_vr)[1]
-        if geev.prefix in 'cz':
+        if geev.typecode in 'cz':
             w, vl, vr, info = geev(a1, lwork=lwork,
                                         compute_vl=compute_vl,
                                         compute_vr=compute_vr,
@@ -171,7 +171,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
             t = {'f':'F','d':'D'}[wr.dtype.char]
             w = wr + _I * wi
     else: # 'clapack'
-        if geev.prefix in 'cz':
+        if geev.typecode in 'cz':
             w, vl, vr, info = geev(a1,
                                     compute_vl=compute_vl,
                                     compute_vr=compute_vr,
@@ -191,7 +191,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
                             "with order >= %d have converged)" % info)
 
     only_real = numpy.logical_and.reduce(numpy.equal(w.imag, 0.0))
-    if not (geev.prefix in 'cz' or only_real):
+    if not (geev.typecode in 'cz' or only_real):
         t = w.dtype.char
         if left:
             vl = _make_complex_eigvecs(w, vl, t)
@@ -505,13 +505,13 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
             # FIXME: implement this somewhen, for now go with builtin values
             # FIXME: calc optimal lwork by calling ?hbevd(lwork=-1)
             #        or by using calc_lwork.f ???
-            # lwork = calc_lwork.hbevd(bevd.prefix, a1.shape[0], lower)
+            # lwork = calc_lwork.hbevd(bevd.typecode, a1.shape[0], lower)
             internal_name = 'hbevd'
         else: # a1.dtype.char in 'fd':
             bevd, = get_lapack_funcs(('sbevd',), (a1,))
             # FIXME: implement this somewhen, for now go with builtin values
             #         see above
-            # lwork = calc_lwork.sbevd(bevd.prefix, a1.shape[0], lower)
+            # lwork = calc_lwork.sbevd(bevd.typecode, a1.shape[0], lower)
             internal_name = 'sbevd'
         w,v,info = bevd(a1, compute_v=not eigvals_only,
                         lower=lower,
@@ -803,7 +803,7 @@ def hessenberg(a, calc_q=False, overwrite_a=False, check_finite=True):
         raise ValueError('illegal value in %d-th argument of internal gebal '
                                                     '(hessenberg)' % -info)
     n = len(a1)
-    lwork = calc_lwork.gehrd(gehrd.prefix, n, lo, hi)
+    lwork = calc_lwork.gehrd(gehrd.typecode, n, lo, hi)
     hq, tau, info = gehrd(ba, lo=lo, hi=hi, lwork=lwork, overwrite_a=1)
     if info < 0:
         raise ValueError('illegal value in %d-th argument of internal gehrd '

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -4,7 +4,7 @@ import numpy
 
 # Local imports
 from blas import get_blas_funcs
-from lapack import get_lapack_funcs, find_best_lapack_type
+from lapack import get_lapack_funcs
 from misc import _datacopied
 
 # XXX: what is qr_old, should it be kept?
@@ -154,10 +154,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
     elif mode == 'raw':
         return ((qr, tau),) + Rj
 
-    if find_best_lapack_type((a1,))[0] in ('s', 'd'):
-        gor_un_gqr, = get_lapack_funcs(('orgqr',), (qr,))
-    else:
-        gor_un_gqr, = get_lapack_funcs(('ungqr',), (qr,))
+    gor_un_gqr, = get_lapack_funcs(('orgqr',), (qr,))
 
     if M < N:
         Q, = safecall(gor_un_gqr, "gorgqr/gungqr", qr[:, :M], tau,
@@ -249,11 +246,10 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
     raw = qr(a, overwrite_a, None, "raw", pivoting)
     Q, tau = raw[0]
 
-    if find_best_lapack_type((Q,))[0] in ('s', 'd'):
-        gor_un_mqr, = get_lapack_funcs(('ormqr',), (Q,))
+    gor_un_mqr, = get_lapack_funcs(('ormqr',), (Q,))
+    if gor_un_mqr.typecode in ('s', 'd'):
         trans = "T"
     else:
-        gor_un_mqr, = get_lapack_funcs(('unmqr',), (Q,))
         trans = "C"
 
     Q = Q[:, :min(M, N)]
@@ -435,10 +431,7 @@ def rq(a, overwrite_a=False, lwork=None, mode='full', check_finite=True):
     if mode == 'r':
         return R
 
-    if find_best_lapack_type((a1,))[0] in ('s', 'd'):
-        gor_un_grq, = get_lapack_funcs(('orgrq',), (rq,))
-    else:
-        gor_un_grq, = get_lapack_funcs(('ungrq',), (rq,))
+    gor_un_grq, = get_lapack_funcs(('orgrq',), (rq,))
 
     if N < M:
         # get optimal work array

--- a/scipy/linalg/decomp_svd.py
+++ b/scipy/linalg/decomp_svd.py
@@ -93,12 +93,11 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     m,n = a1.shape
     overwrite_a = overwrite_a or (_datacopied(a1, a))
     gesdd, = get_lapack_funcs(('gesdd',), (a1,))
-    if gesdd.module_name[:7] == 'flapack':
-        lwork = calc_lwork.gesdd(gesdd.prefix, m, n, compute_uv)[1]
-        u,s,v,info = gesdd(a1,compute_uv = compute_uv, lwork = lwork,
-                           full_matrices=full_matrices, overwrite_a = overwrite_a)
-    else: # 'clapack'
-        raise NotImplementedError('calling gesdd from %s' % gesdd.module_name)
+
+    lwork = calc_lwork.gesdd(gesdd.typecode, m, n, compute_uv)[1]
+    u,s,v,info = gesdd(a1,compute_uv = compute_uv, lwork = lwork,
+                       full_matrices=full_matrices, overwrite_a = overwrite_a)
+
     if info > 0:
         raise LinAlgError("SVD did not converge")
     if info < 0:

--- a/scipy/linalg/fblas.py
+++ b/scipy/linalg/fblas.py
@@ -1,0 +1,8 @@
+"""
+This module is deprecated -- use scipy.linalg.blas instead
+"""
+from _fblas import *
+import numpy as _np
+@_np.deprecate(old_name="scipy.linalg.fblas", new_name="scipy.linalg.blas")
+def _deprecate(): pass
+_deprecate()

--- a/scipy/linalg/fblas.pyf.src
+++ b/scipy/linalg/fblas.pyf.src
@@ -7,7 +7,7 @@
 !
 
 
-python module fblas
+python module _fblas
     interface
 
        include 'fblas_l1.pyf.src'
@@ -15,4 +15,4 @@ python module fblas
        include 'fblas_l3.pyf.src'
 
     end interface
-end python module fblas
+end python module _fblas

--- a/scipy/linalg/flapack.py
+++ b/scipy/linalg/flapack.py
@@ -1,0 +1,8 @@
+"""
+This module is deprecated -- use scipy.linalg.lapack instead
+"""
+from _flapack import *
+import numpy as _np
+@_np.deprecate(old_name="scipy.linalg.flapack", new_name="scipy.linalg.lapack")
+def _deprecate(): pass
+_deprecate()

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -1004,6 +1004,73 @@ interface
      integer intent(out) :: info
    end subroutine <prefix2c>heev
 
+
+   subroutine <prefix2>syevd(compute_v,lower,n,w,a,work,lwork,iwork,liwork,info)
+   ! w,v,info = syevd(a,compute_v=1,lower=0,lwork=min_lwork,overwrite_a=0)
+   ! Compute all eigenvalues and, optionally, eigenvectors of a
+   ! real symmetric matrix A using D&C.
+   !
+   ! Performance tip:
+   !   If compute_v=0 then set also overwrite_a=1.
+
+     callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,a,&n,w,work,&lwork,iwork,&liwork,&info)
+     callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,int*,int*
+
+     integer optional,intent(in):: compute_v = 1
+     check(compute_v==1||compute_v==0) compute_v
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0   
+
+     integer intent(hide),depend(a):: n = shape(a,0)
+     <ftype2> dimension(n,n),check(shape(a,0)==shape(a,1)) :: a
+     intent(in,copy,out,out=v) :: a
+
+     <ftype2> dimension(n),intent(out),depend(n) :: w
+
+     integer optional,intent(in),depend(n,compute_v) :: lwork=(compute_v?1+6*n+2*n*n:2*n+1)
+     check(lwork>=(compute_v?1+6*n+2*n*n:2*n+1)) :: lwork
+     <ftype2> dimension(lwork),intent(hide,cache),depend(lwork) :: work
+
+     integer intent(hide),depend(n,compute_v) :: liwork = (compute_v?3+5*n:1)
+     integer dimension(liwork),intent(hide,cache),depend(liwork) :: iwork
+
+     integer intent(out) :: info
+   end subroutine <prefix2>syevd
+
+   subroutine <prefix2c>heevd(compute_v,lower,n,w,a,work,lwork,iwork,liwork,rwork,lrwork,info)
+   ! w,v,info = heevd(a,compute_v=1,lower=0,lwork=min_lwork,overwrite_a=0)
+   ! Compute all eigenvalues and, optionally, eigenvectors of a
+   ! complex Hermitian matrix A using D&C.
+   !
+   ! Warning:
+   !   If compute_v=0 and overwrite_a=1, the contents of a is destroyed.
+
+     callstatement (*f2py_func)((compute_v?"V":"N"),(lower?"L":"U"),&n,a,&n,w,work,&lwork,rwork,&lrwork,iwork,&liwork,&info)
+     callprotoargument char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
+
+     integer optional,intent(in):: compute_v = 1
+     check(compute_v==1||compute_v==0) compute_v
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0   
+
+     integer intent(hide),depend(a):: n = shape(a,0)
+     <ftype2c> dimension(n,n),check(shape(a,0)==shape(a,1)) :: a
+     intent(in,copy,out,out=v) :: a
+
+     <ftype2> dimension(n),intent(out),depend(n) :: w
+
+     integer optional,intent(in),depend(n,compute_v) :: lwork=(compute_v?2*n+n*n:n+1)
+     check(lwork>=(compute_v?2*n+n*n:n+1)) :: lwork
+     <ftype2c> dimension(lwork),intent(hide,cache),depend(lwork) :: work
+
+     integer intent(hide),depend(n,compute_v) :: liwork = (compute_v?3+5*n:1)
+     integer dimension(liwork),intent(hide,cache),depend(liwork) :: iwork
+
+     integer intent(hide),depend(n,compute_v) :: lrwork = (compute_v?1+5*n+2*n*n:n)
+     <ftype2> dimension(lrwork),intent(hide,cache),depend(n,lrwork) :: rwork
+
+     integer intent(out) :: info
+   end subroutine <prefix2c>heevd
+
+
    subroutine <prefix>posv(n,nrhs,a,b,info,lower)
 
    ! c,x,info = posv(a,b,lower=0,overwrite_a=0,overwrite_b=0)

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -11,7 +11,7 @@
 ! <prefix2=s,d> <ctype2=float,double> <ftype2=real,double precision>
 ! <prefix2c=c,z> <ftype2c=complex,double complex> <ctype2c=complex_float,complex_double>
 
-python module flapack
+python module _flapack
 interface
 
    include 'flapack_user.pyf.src'
@@ -2142,7 +2142,7 @@ end subroutine zhegvx
 
 end interface
 
-end python module flapack
+end python module _flapack
 
 ! This file was auto-generated with f2py (version:2.10.173).
 ! See http://cens.ioc.ee/projects/f2py2e/

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -48,6 +48,7 @@ All functions
    chbevd
    chbevx
    cheev
+   cheevd
    cheevr
    chegv
    chegvd
@@ -103,6 +104,7 @@ All functions
    dsbevd
    dsbevx
    dsyev
+   dsyevd
    dsyevr
    dsygv
    dsygvd
@@ -146,6 +148,7 @@ All functions
    ssbevd
    ssbevx
    ssyev
+   ssyevd
    ssyevr
    ssygv
    ssygvd
@@ -175,6 +178,7 @@ All functions
    zhbevd
    zhbevx
    zheev
+   zheevd
    zheevr
    zhegv
    zhegvd

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -7,9 +7,7 @@ __all__ = ['get_lapack_funcs']
 # The following ensures that possibly missing flavor (C or Fortran) is
 # replaced with the available one. If none is available, exception
 # is raised at the first attempt to use the resources.
-import types
-
-import numpy
+from blas import _get_funcs
 
 from scipy.linalg import flapack
 try:
@@ -24,96 +22,44 @@ if clapack is None:
 elif hasattr(flapack,'empty_module'):
     flapack = clapack
 
-def cast_to_lapack_prefix(t):
-    if issubclass(t, numpy.single):
-        prefix = 's'
-    elif issubclass(t, numpy.double):
-        prefix = 'd'
-    elif issubclass(t, numpy.longdouble):
-        prefix = 'd'
-    elif issubclass(t, numpy.csingle):
-        prefix = 'c'
-    elif issubclass(t, numpy.cdouble):
-        prefix = 'z'
-    elif issubclass(t, numpy.clongdouble):
-        prefix = 'z'
-    else:
-        prefix = 'd'
-    return prefix
+_lapack_alias = {}
 
-prefix_to_order = dict(s=3, d=2, c=1, z=0)
-order_to_prefix = ['s', 'd', 'c', 'z']
-prefix_to_dtype = dict(s=numpy.single, d=numpy.double,
-                       c=numpy.csingle, z=numpy.cdouble)
+def get_lapack_funcs(names, arrays=(), dtype=None):
+    """Return available LAPACK function objects from names.
 
-def find_best_lapack_type(arrays):
-    if not arrays:
-        return 'd', numpy.double, False
-    ordering = []
-    for i in range(len(arrays)):
-        t = arrays[i].dtype.type
-        prefix = cast_to_lapack_prefix(t)
-        order = prefix_to_order[prefix]
-        ordering.append((order, prefix, i))
-    ordering.sort()
-    _, required_prefix, lowest_array_index = ordering[0]
-    dtype = prefix_to_dtype[required_prefix]
-    isfortran = numpy.isfortran(arrays[lowest_array_index])
-    return required_prefix, dtype, isfortran
+    Arrays are used to determine the optimal prefix of LAPACK routines.
 
-def get_lapack_funcs(names, arrays=()):
-    """Return available LAPACK function objects with names.
-    arrays are used to determine the optimal prefix of
-    LAPACK routines.
+    Parameters
+    ----------
+    names : str or sequence of str
+        Name(s) of LAPACK functions withouth type prefix.
+
+    arrays : sequency of ndarrays, optional
+        Arrays can be given to determine optiomal prefix of LAPACK
+        routines. If not given, double-precision routines will be
+        used, otherwise the most generic type in arrays will be used.
+
+    dtype : str or dtype, optional
+        Data-type specifier. Not used if `arrays` is non-empty.
+
+
+    Returns
+    -------
+    funcs : list
+        List containing the found function(s).
+
+
+    Notes
+    -----
+    This routines automatically chooses between Fortran/C
+    interfaces. Fortran code is used whenever possible for arrays with
+    column major order. In all other cases, C code is preferred.
+
+    In LAPACK, the naming convention is that all functions start with a
+    type prefix, which depends on the type of the principal
+    matrix. These can be one of {'s', 'd', 'c', 'z'} for the numpy
+    types {float32, float64, complex64, complex128} respectevely, and
+    are stored in attribute `typecode` of the returned functions.
     """
-    #If force_clapack is True then available Atlas routine
-    #is returned for column major storaged arrays with
-    #rowmajor argument set to False.
-    force_clapack=False  #XXX: Don't set it true! The feature is unreliable
-                         #     and may cause incorrect results.
-                         #     See test_basic.test_solve.check_20Feb04_bug.
-
-    required_prefix, dtype, isfortran = find_best_lapack_type(arrays)
-    # Default lookup:
-    if isfortran:
-        # prefer Fortran code for leading array with column major order
-        m1, m2 = flapack, clapack
-    else:
-        # in all other cases, C code is preferred
-        m1, m2 = clapack, flapack
-    if not _use_force_clapack:
-        force_clapack = False
-    funcs = []
-    m1_name = m1.__name__.split('.')[-1]
-    m2_name = m2.__name__.split('.')[-1]
-    for name in names:
-        func_name = required_prefix + name
-        func = getattr(m1,func_name,None)
-        if func is None:
-            func = getattr(m2,func_name)
-            func.module_name = m2_name
-        else:
-            func.module_name = m1_name
-            if force_clapack and m1 is flapack:
-                func2 = getattr(m2,func_name,None)
-                if func2 is not None:
-                    exec _colmajor_func_template % {'func_name':func_name}
-                    func = types.FunctionType(func_code,
-                                              {'clapack_func':func2},
-                                              func_name)
-                    func.module_name = m2_name
-                    func.__doc__ = func2.__doc__
-        func.prefix = required_prefix
-        func.dtype = dtype
-        funcs.append(func)
-    return tuple(funcs)
-
-
-
-_colmajor_func_template = '''\
-def %(func_name)s(*args,**kws):
-    if "rowmajor" not in kws:
-        kws["rowmajor"] = 0
-    return clapack_func(*args,**kws)
-func_code = %(func_name)s.func_code
-'''
+    return _get_funcs(names, arrays, dtype,
+                      "LAPACK", flapack, clapack, _lapack_alias)

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -208,22 +208,20 @@ from blas import _get_funcs
 # Backward compatibility:
 from blas import find_best_blas_type as find_best_lapack_type
 
-from scipy.linalg import flapack as _flapack
+from scipy.linalg import _flapack
 try:
-    from scipy.linalg import clapack as _clapack
+    from scipy.linalg import _clapack
 except ImportError:
     _clapack = None
 
-_use_force_clapack = 1
 if _clapack is None:
     _clapack = _flapack
-    _use_force_clapack = 0
 elif hasattr(_flapack,'empty_module'):
     _flapack = _clapack
 
 # Expose all functions (only flapack --- clapack is an implementation detail)
 empty_module = None
-from scipy.linalg.flapack import *
+from scipy.linalg._flapack import *
 del empty_module
 
 # some convenience alias for complex functions
@@ -271,4 +269,5 @@ def get_lapack_funcs(names, arrays=(), dtype=None):
     are stored in attribute `typecode` of the returned functions.
     """
     return _get_funcs(names, arrays, dtype,
-                      "LAPACK", _flapack, _clapack, _lapack_alias)
+                      "LAPACK", _flapack, _clapack,
+                      "flapack", "clapack", _lapack_alias)

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -4,6 +4,8 @@ Low-level LAPACK functions
 
 This module contains low-level functions from the LAPACK library.
 
+.. versionadded:: 0.12.0
+
 .. warning::
 
    These functions do little to no error checking.

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -9,6 +9,9 @@ __all__ = ['get_lapack_funcs']
 # is raised at the first attempt to use the resources.
 from blas import _get_funcs
 
+# Backward compatibility:
+from blas import find_best_blas_type as find_best_lapack_type
+
 from scipy.linalg import flapack
 try:
     from scipy.linalg import clapack

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -1,3 +1,199 @@
+"""
+Low-level LAPACK functions
+==========================
+
+This module contains low-level functions from the LAPACK library.
+
+.. warning::
+
+   These functions do little to no error checking.
+   It is possible to cause crashes by mis-using them,
+   so prefer using the higher-level routines in `scipy.linalg`.
+
+Finding functions
+=================
+
+.. autosummary::
+
+   get_lapack_funcs
+   find_best_blas_type
+
+All functions
+=============
+
+.. autosummary::
+   :toctree: generated/
+
+   cgbsv
+   cgbtrf
+   cgbtrs
+   cgebal
+   cgees
+   cgeev
+   cgegv
+   cgehrd
+   cgelss
+   cgeqp3
+   cgeqrf
+   cgerqf
+   cgesdd
+   cgesv
+   cgetrf
+   cgetri
+   cgetrs
+   cgges
+   cggev
+   chbevd
+   chbevx
+   cheev
+   cheevr
+   chegv
+   chegvd
+   chegvx
+   claswp
+   clauum
+   cpbsv
+   cpbtrf
+   cpbtrs
+   cposv
+   cpotrf
+   cpotri
+   cpotrs
+   ctrsyl
+   ctrtri
+   ctrtrs
+   cungqr
+   cungrq
+   cunmqr
+   dgbsv
+   dgbtrf
+   dgbtrs
+   dgebal
+   dgees
+   dgeev
+   dgegv
+   dgehrd
+   dgelss
+   dgeqp3
+   dgeqrf
+   dgerqf
+   dgesdd
+   dgesv
+   dgetrf
+   dgetri
+   dgetrs
+   dgges
+   dggev
+   dlamch
+   dlaswp
+   dlauum
+   dorgqr
+   dorgrq
+   dormqr
+   dpbsv
+   dpbtrf
+   dpbtrs
+   dposv
+   dpotrf
+   dpotri
+   dpotrs
+   dsbev
+   dsbevd
+   dsbevx
+   dsyev
+   dsyevr
+   dsygv
+   dsygvd
+   dsygvx
+   dtrsyl
+   dtrtri
+   dtrtrs
+   sgbsv
+   sgbtrf
+   sgbtrs
+   sgebal
+   sgees
+   sgeev
+   sgegv
+   sgehrd
+   sgelss
+   sgeqp3
+   sgeqrf
+   sgerqf
+   sgesdd
+   sgesv
+   sgetrf
+   sgetri
+   sgetrs
+   sgges
+   sggev
+   slamch
+   slaswp
+   slauum
+   sorgqr
+   sorgrq
+   sormqr
+   spbsv
+   spbtrf
+   spbtrs
+   sposv
+   spotrf
+   spotri
+   spotrs
+   ssbev
+   ssbevd
+   ssbevx
+   ssyev
+   ssyevr
+   ssygv
+   ssygvd
+   ssygvx
+   strsyl
+   strtri
+   strtrs
+   zgbsv
+   zgbtrf
+   zgbtrs
+   zgebal
+   zgees
+   zgeev
+   zgegv
+   zgehrd
+   zgelss
+   zgeqp3
+   zgeqrf
+   zgerqf
+   zgesdd
+   zgesv
+   zgetrf
+   zgetri
+   zgetrs
+   zgges
+   zggev
+   zhbevd
+   zhbevx
+   zheev
+   zheevr
+   zhegv
+   zhegvd
+   zhegvx
+   zlaswp
+   zlauum
+   zpbsv
+   zpbtrf
+   zpbtrs
+   zposv
+   zpotrf
+   zpotri
+   zpotrs
+   ztrsyl
+   ztrtri
+   ztrtrs
+   zungqr
+   zungrq
+   zunmqr
+
+"""
 #
 # Author: Pearu Peterson, March 2002
 #
@@ -12,18 +208,23 @@ from blas import _get_funcs
 # Backward compatibility:
 from blas import find_best_blas_type as find_best_lapack_type
 
-from scipy.linalg import flapack
+from scipy.linalg import flapack as _flapack
 try:
-    from scipy.linalg import clapack
+    from scipy.linalg import clapack as _clapack
 except ImportError:
-    clapack = None
+    _clapack = None
 
 _use_force_clapack = 1
-if clapack is None:
-    clapack = flapack
+if _clapack is None:
+    _clapack = _flapack
     _use_force_clapack = 0
-elif hasattr(flapack,'empty_module'):
-    flapack = clapack
+elif hasattr(_flapack,'empty_module'):
+    _flapack = _clapack
+
+# Expose all functions (only flapack --- clapack is an implementation detail)
+empty_module = None
+from scipy.linalg.flapack import *
+del empty_module
 
 # some convenience alias for complex functions
 _lapack_alias = {
@@ -70,4 +271,4 @@ def get_lapack_funcs(names, arrays=(), dtype=None):
     are stored in attribute `typecode` of the returned functions.
     """
     return _get_funcs(names, arrays, dtype,
-                      "LAPACK", flapack, clapack, _lapack_alias)
+                      "LAPACK", _flapack, _clapack, _lapack_alias)

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -22,7 +22,12 @@ if clapack is None:
 elif hasattr(flapack,'empty_module'):
     flapack = clapack
 
-_lapack_alias = {}
+# some convenience alias for complex functions
+_lapack_alias = {
+    'corgqr': 'cungqr', 'zorgqr': 'zungqr',
+    'cormqr': 'cunmqr', 'zormqr': 'zunmqr',
+    'corgrq': 'cungrq', 'zorgrq': 'zungrq',
+}
 
 def get_lapack_funcs(names, arrays=(), dtype=None):
     """Return available LAPACK function objects from names.

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -200,9 +200,6 @@ All functions
 
 __all__ = ['get_lapack_funcs']
 
-# The following ensures that possibly missing flavor (C or Fortran) is
-# replaced with the available one. If none is available, exception
-# is raised at the first attempt to use the resources.
 from blas import _get_funcs
 
 # Backward compatibility:
@@ -213,11 +210,6 @@ try:
     from scipy.linalg import _clapack
 except ImportError:
     _clapack = None
-
-if _clapack is None:
-    _clapack = _flapack
-elif hasattr(_flapack,'empty_module'):
-    _flapack = _clapack
 
 # Expose all functions (only flapack --- clapack is an implementation detail)
 empty_module = None

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.linalg import LinAlgError
-import fblas
+import blas
 
 __all__ = ['LinAlgError', 'norm']
 
@@ -13,7 +13,7 @@ def norm(a, ord=None):
     if ord in (None, 2) and (a.ndim == 1) and (a.dtype.char in 'fdFD'):
         # use blas for fast and stable euclidean norm
         func_name = _nrm2_prefix.get(a.dtype.char, 'd') + 'nrm2'
-        nrm2 = getattr(fblas, func_name)
+        nrm2 = getattr(blas, func_name)
         return nrm2(a)
     return np.linalg.norm(a, ord=ord)
 

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -48,7 +48,7 @@ def configuration(parent_package='',top_path=None):
 
     # Note: `depends` needs to include fblaswrap(_veclib) for both files to be
     # included by "python setup.py sdist"
-    config.add_extension('fblas',
+    config.add_extension('_fblas',
                          sources = sources,
                          depends = ['fblas_l?.pyf.src',
                                     join('src', 'fblaswrap_veclib_c.c'),
@@ -57,7 +57,7 @@ def configuration(parent_package='',top_path=None):
                          )
 
     # flapack:
-    config.add_extension('flapack',
+    config.add_extension('_flapack',
                          sources = ['flapack.pyf.src'],
                          depends = ['flapack_user.pyf.src'],
                          extra_info = lapack_opt
@@ -65,14 +65,14 @@ def configuration(parent_package='',top_path=None):
 
     if atlas_version is not None:
         # cblas:
-        config.add_extension('cblas',
+        config.add_extension('_cblas',
                              sources = ['cblas.pyf.src'],
                              depends = ['cblas.pyf.src', 'cblas_l1.pyf.src'],
                              extra_info = lapack_opt
                              )
 
         # clapack:
-        config.add_extension('clapack',
+        config.add_extension('_clapack',
                              sources = ['clapack.pyf.src'],
                              depends = ['clapack.pyf.src'],
                              extra_info = lapack_opt

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -263,6 +263,8 @@ class TestSolveHBanded(TestCase):
 
 
 class TestSolve(TestCase):
+    def setUp(self):
+        np.random.seed(1234)
 
     def test_20Feb04_bug(self):
         a = [[1,1],[1.0,0]] # ok
@@ -416,6 +418,8 @@ class TestSolveTriangular(TestCase):
 
 
 class TestInv(TestCase):
+    def setUp(self):
+        np.random.seed(1234)
 
     def test_simple(self):
         a = [[1,2],[3,4]]
@@ -457,6 +461,8 @@ class TestInv(TestCase):
 
 
 class TestDet(TestCase):
+    def setUp(self):
+        np.random.seed(1234)
 
     def test_simple(self):
         a = [[1,2],[3,4]]
@@ -501,6 +507,9 @@ def direct_lstsq(a,b,cmplx=0):
     return solve(a1, b1)
 
 class TestLstsq(TestCase):
+    def setUp(self):
+        np.random.seed(1234)
+
     def test_random_overdet_large(self):
         #bug report: Nils Wagner
         n = 200

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -48,6 +48,14 @@ def test_get_blas_funcs():
     f1 = get_blas_funcs('gemm', dtype=np.longcomplex)
     assert_equal(f1.typecode, 'z')
 
+    # check safe complex upcasting
+    f1 = get_blas_funcs('axpy',
+                        (np.empty((2,2), dtype=np.float64),
+                         np.empty((2,2), dtype=np.complex64))
+                        )
+    assert_equal(f1.typecode, 'z')
+
+
 def test_get_blas_funcs_alias():
     # check alias for get_blas_funcs
     f, g = get_blas_funcs(('nrm2', 'dot'), dtype=np.complex64)

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -16,7 +16,7 @@ import numpy as np
 from numpy.testing import TestCase, run_module_suite, assert_equal, \
     assert_almost_equal, assert_array_almost_equal
 
-from scipy.linalg import fblas, cblas, get_blas_funcs
+from scipy.linalg import _fblas as fblas, _cblas as cblas, get_blas_funcs
 
 def test_get_blas_funcs():
     # check that it returns Fortran code for arrays that are

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -35,9 +35,10 @@ def test_get_blas_funcs():
     # get_blas_funcs will choose libraries depending on most generic
     # array
     assert_equal(f1.typecode, 'z')
-    assert_equal(f1.module_name, 'cblas')
     assert_equal(f2.typecode, 'z')
-    assert_equal(f2.module_name, 'cblas')
+    if cblas is not None:
+        assert_equal(f1.module_name, 'cblas')
+        assert_equal(f2.module_name, 'cblas')
 
     # check defaults.
     f1 = get_blas_funcs('rotg')

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -16,7 +16,12 @@ import numpy as np
 from numpy.testing import TestCase, run_module_suite, assert_equal, \
     assert_almost_equal, assert_array_almost_equal
 
-from scipy.linalg import _fblas as fblas, _cblas as cblas, get_blas_funcs
+from scipy.linalg import _fblas as fblas, get_blas_funcs
+
+try:
+    from scipy.linalg import _cblas as cblas
+except ImportError:
+    cblas = None
 
 def test_get_blas_funcs():
     # check that it returns Fortran code for arrays that are

--- a/scipy/linalg/tests/test_build.py
+++ b/scipy/linalg/tests/test_build.py
@@ -5,7 +5,7 @@ import re
 from numpy.testing import TestCase, dec
 from numpy.compat import asbytes
 
-from scipy.linalg import flapack
+from scipy.linalg import _flapack as flapack
 
 # XXX: this is copied from numpy trunk. Can be removed when we will depend on
 # numpy 1.3

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -18,7 +18,7 @@ from scipy.linalg import eig, eigvals, lu, svd, svdvals, cholesky, qr, \
      schur, rsf2csf, lu_solve, lu_factor, solve, diagsvd, hessenberg, rq, \
      eig_banded, eigvals_banded, eigh, eigvalsh, qr_multiply, LinAlgError, \
      qz
-from scipy.linalg.flapack import dgbtrf, dgbtrs, zgbtrf, zgbtrs, \
+from scipy.linalg.lapack import dgbtrf, dgbtrs, zgbtrf, zgbtrs, \
      dsbev, dsbevd, dsbevx, zhbevd, zhbevx
 
 from numpy import array, transpose, sometrue, diag, ones, linalg, \

--- a/scipy/linalg/tests/test_fblas.py
+++ b/scipy/linalg/tests/test_fblas.py
@@ -8,7 +8,7 @@
 
 from numpy import float32, float64, complex64, complex128, arange, array, \
                   zeros, shape, transpose, newaxis, common_type, conjugate
-from scipy.linalg import fblas
+from scipy.linalg import _fblas as fblas
 
 from numpy.testing import TestCase, run_module_suite, assert_array_equal, \
     assert_array_almost_equal, assert_

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -8,7 +8,7 @@ from numpy.testing import TestCase, run_module_suite, assert_equal, \
 
 import numpy as np
 
-from scipy.linalg import flapack, clapack
+from scipy.linalg import _flapack as flapack, _clapack as clapack
 from scipy.linalg.lapack import get_lapack_funcs
 
 REAL_DTYPES = [np.float32, np.float64]

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -8,7 +8,11 @@ from numpy.testing import TestCase, run_module_suite, assert_equal, \
 
 import numpy as np
 
-from scipy.linalg import _flapack as flapack, _clapack as clapack
+from scipy.linalg import _flapack as flapack
+try:
+    from scipy.linalg import _clapack as clapack
+except ImportError:
+    clapack = None
 from scipy.linalg.lapack import get_lapack_funcs
 
 REAL_DTYPES = [np.float32, np.float64]


### PR DESCRIPTION
The BLAS/LAPACK interfaces in scipy.linalg were sort of public, but the LAPACK part was only partly cleaned up last time when the scipy.lib.blas/lapack interfaces were deprecated. Moreover, they were essentially undocumented.

This PR cleans up the following:
- Make `get_lapack_funcs` fully compatible with `get_blas_funcs`, while maintaining backward compatibility.
- Add missing deprecation warnings to scipy.lib.lapack and scipy.lib.blas
- Add deprecation warnings to direct imports of scipy.linalg.fblas, .cblas, .flapack, .clapack which probably appear in existing third-party code.
- Remove dead code in linalg functions (checks for clapack functions, which never exist)
- Add missing functions to scipy.linalg which were in scipy.lib.
