### PR TITLE
FIX: Do not rely on strides for contiguous arrays in signal.medfilt

### DIFF
--- a/scipy/signal/sigtoolsmodule.c
+++ b/scipy/signal/sigtoolsmodule.c
@@ -772,8 +772,8 @@ static void fill_buffer(char *ip1, PyArrayObject *ap1, PyArrayObject *ap2, char 
   int ndims = ap1->nd;
   intp *dims2 = ap2->dimensions;
   intp *dims1 = ap1->dimensions;
-  intp is1 = ap1->strides[ndims-1];
-  intp is2 = ap2->strides[ndims-1];
+  intp is1 = ap1->elsize;
+  intp is2 = ap2->elsize;
   char *ip2 = ap2->data;
   int elsize = ap1->descr->elsize;
   char *ptr;

--- a/scipy/signal/sigtoolsmodule.c
+++ b/scipy/signal/sigtoolsmodule.c
@@ -772,8 +772,8 @@ static void fill_buffer(char *ip1, PyArrayObject *ap1, PyArrayObject *ap2, char 
   int ndims = ap1->nd;
   intp *dims2 = ap2->dimensions;
   intp *dims1 = ap1->dimensions;
-  intp is1 = ap1->elsize;
-  intp is2 = ap2->elsize;
+  intp is1 = ap1->descr->elsize;
+  intp is2 = ap2->descr->elsize;
   char *ip2 = ap2->data;
   int elsize = ap1->descr->elsize;
   char *ptr;

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -216,6 +216,13 @@ class TestMedFilt(TestCase):
             signal.medfilt(None)
         except:
             pass
+        # Expand on this test to avoid a regression with possible contiguous
+        # numpy arrays that have odd strides. The stride value below gets
+        # us into wrong memory if used (but it does not need to be used)
+        a = np.lib.stride_tricks.as_strided(np.ones(1), shape=(1,), strides=(2**31,))
+        # a may be contiguous (and is certainly for numpy <1.8) because it
+        # has only one element
+        signal.medfilt(a)
 
 class TestWiener(TestCase):
     def test_basic(self):


### PR DESCRIPTION
When an array is contiguous in memory but has shape[dim] == 1, then
its strides[dim] is not really used, so it can be considered arbitrary
even if the array is contiguous. This is generally true for 0-sized arrays.

Even without a change in numpy, this code (at least with numpy <1.8.)
could segfault for one dimensional arrays with one element.

---

This fixes problems with current numpy master (even if it is probably going to be changed in numpy any time). This was already previously buggy in corner cases for older numpy, so I think it should be changed here anyway, also I would prefere if the assumption of `strides[-1] == itemsize` is just generally not used, for the future, so that maybe the contiguous flags can be set in a better way in the future.
