### PR TITLE
BUG: Fix Superlu crash with python-dbg (Trac 1789)

### DIFF
--- a/scipy/sparse/linalg/dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/dsolve/_superluobject.c
@@ -468,7 +468,7 @@ fail:
   SUPERLU_FREE(etree);
   Destroy_CompCol_Permuted(&AC);
   StatFree(&stat);
-  SciPyLU_dealloc(self);
+  Py_DECREF(self);
   return NULL;
 }
 

--- a/scipy/sparse/linalg/dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/dsolve/_superluobject.c
@@ -414,6 +414,9 @@ newSciPyLUObject(SuperMatrix *A, PyObject *option_dict, int intype, int ilu)
   self->U.Store = NULL;
   self->type = intype;
 
+  memset(&AC, 0, sizeof(SuperMatrix));
+  memset(&stat, 0, sizeof(SuperLUStat_t));
+
   if (setjmp(_superlu_py_jmpbuf)) goto fail;
   
   /* Calculate and apply minimum degree ordering*/

--- a/scipy/sparse/linalg/dsolve/_superluobject.h
+++ b/scipy/sparse/linalg/dsolve/_superluobject.h
@@ -50,6 +50,12 @@ int set_superlu_options_from_dict(superlu_options_t *options,
                                   int ilu, PyObject *option_dict,
                                   int *panel_size, int *relax);
 
+void XDestroy_SuperMatrix_Store(SuperMatrix *);
+void XDestroy_SuperNode_Matrix(SuperMatrix *);
+void XDestroy_CompCol_Matrix(SuperMatrix *);
+void XDestroy_CompCol_Permuted(SuperMatrix *);
+void XStatFree(SuperLUStat_t *);
+
 /*
  * Definitions for other SuperLU data types than Z,
  * and type-generic definitions.


### PR DESCRIPTION
This should fix #1789. http://projects.scipy.org/scipy/ticket/1789

The other commit then fixes bad initialization of variables, and removes a hacky workaround...
Note that this code path is covered by the test suite.
