### PR TITLE
TST: fix test for special.multigammaln.

### DIFF
--- a/scipy/special/spfun_stats.py
+++ b/scipy/special/spfun_stats.py
@@ -36,7 +36,8 @@ analysis."""
 import numpy as np
 from scipy.special import gammaln as loggam
 
-__all__ = ['multigammln']
+
+__all__ = ['multigammaln']
 
 
 def multigammaln(a, d):
@@ -46,14 +47,14 @@ def multigammaln(a, d):
     Parameters
     ----------
     a : ndarray
-        the multivariate gamma is computed for each item of a
+        The multivariate gamma is computed for each item of `a`.
     d : int
-        the dimension of the space of integration.
+        The dimension of the space of integration.
 
     Returns
     -------
     res : ndarray
-        the values of the log multivariate gamma at the given points a.
+        The values of the log multivariate gamma at the given points `a`.
 
     Notes
     -----
@@ -62,10 +63,10 @@ def multigammaln(a, d):
 
         \Gamma_d(a) = \int_{A>0}{e^{-tr(A)\cdot{|A|}^{a - (m+1)/2}dA}}
 
-    with the condition a > (d-1)/2, and A>0 being the set of all the positive
-    definite matrices of dimension s. Note that a is a scalar: the integrand
-    only is multivariate, the argument is not (the function is defined over a
-    subset of the real set).
+    with the condition ``a > (d-1)/2``, and ``A > 0`` being the set of all the
+    positive definite matrices of dimension s.  Note that a is a scalar: the
+    integrand only is multivariate, the argument is not (the function is
+    defined over a subset of the real set).
 
     This can be proven to be equal to the much friendlier equation::
 
@@ -89,5 +90,6 @@ def multigammaln(a, d):
         axis = -1
     else:
         axis = 0
+
     res += np.sum(loggam([(a - (j - 1.)/2) for j in range(1, d+1)]), axis)
     return res

--- a/scipy/special/tests/test_spfun_stats.py
+++ b/scipy/special/tests/test_spfun_stats.py
@@ -1,22 +1,26 @@
 import numpy as np
-from numpy.testing import assert_array_equal, TestCase, run_module_suite
+from numpy.testing import assert_array_equal, TestCase, run_module_suite, \
+    assert_array_almost_equal_nulp
 
 from scipy.special import gammaln, multigammaln
 
 
 class TestMultiGammaLn(TestCase):
     def test1(self):
+        np.random.seed(1234)
         a = np.abs(np.random.randn())
         assert_array_equal(multigammaln(a, 1), gammaln(a))
 
     def test_ararg(self):
         d = 5
+        np.random.seed(1234)
         a = np.abs(np.random.randn(3, 2)) + d
 
         tr = multigammaln(a, d)
         assert_array_equal(tr.shape, a.shape)
         for i in range(a.size):
-            assert_array_equal(tr.ravel()[i], multigammaln(a.ravel()[i], d))
+            assert_array_almost_equal_nulp(tr.ravel()[i],
+                                           multigammaln(a.ravel()[i], d))
 
         d = 5
         a = np.abs(np.random.randn(1, 2)) + d
@@ -32,6 +36,7 @@ class TestMultiGammaLn(TestCase):
             raise Exception("Expected this call to fail")
         except ValueError:
             pass
+
 
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
Also fix an error in `__all__` dict, use random seeds in the test and a few docstring formatting cleanups.

Failing test was off by exactly one nulp:

```
======================================================================
FAIL: test_ararg (test_spfun_stats.TestMultiGammaLn)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rgommers/Code/scipy/scipy/special/tests/test_spfun_stats.py", line 25, in test_ararg
    assert_array_equal(tr.ravel()[i], multigammaln(a.ravel()[i], d))
  File "/home/rgommers/Code/numpy/numpy/testing/utils.py", line 719, in assert_array_equal
    verbose=verbose, header='Arrays are not equal')
  File "/home/rgommers/Code/numpy/numpy/testing/utils.py", line 645, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Arrays are not equal

(mismatch 100.0%)
 x: array(19.85104832116381)
 y: array(19.851048321163812)
```
