### PR TITLE
DOC: clarification on the `which` parameter of ARPACK.

### DIFF
--- a/doc/source/tutorial/arpack.rst
+++ b/doc/source/tutorial/arpack.rst
@@ -40,15 +40,19 @@ The power of ARPACK is that it can compute only a specified subset of
 eigenvalue/eigenvector pairs.  This is accomplished through the keyword
 ``which``.  The following values of ``which`` are available:
 
-* ``which = 'LM'`` : Eigenvectors with largest magnitude (``eigs``, ``eigsh``)
-* ``which = 'SM'`` : Eigenvectors with smallest magnitude (``eigs``, ``eigsh``)
-* ``which = 'LR'`` : Eigenvectors with largest real part (``eigs``)
-* ``which = 'SR'`` : Eigenvectors with smallest real part (``eigs``)
-* ``which = 'LI'`` : Eigenvectors with largest imaginary part (``eigs``)
-* ``which = 'SI'`` : Eigenvectors with smallest imaginary part (``eigs``)
-* ``which = 'LA'`` : Eigenvectors with largest amplitude (``eigsh``)
-* ``which = 'SA'`` : Eigenvectors with smallest amplitude (``eigsh``)
-* ``which = 'BE'`` : Eigenvectors from both ends of the spectrum (``eigsh``)
+* ``which = 'LM'`` : Eigenvalues with largest magnitude (``eigs``, ``eigsh``),
+  that is, largest eigenvalues in the euclidean norm of complex numbers.
+* ``which = 'SM'`` : Eigenvalues with smallest magnitude (``eigs``, ``eigsh``),
+  that is, smallest eigenvalues in the euclidean norm of complex numbers.
+* ``which = 'LR'`` : Eigenvalues with largest real part (``eigs``)
+* ``which = 'SR'`` : Eigenvalues with smallest real part (``eigs``)
+* ``which = 'LI'`` : Eigenvalues with largest imaginary part (``eigs``)
+* ``which = 'SI'`` : Eigenvalues with smallest imaginary part (``eigs``)
+* ``which = 'LA'`` : Eigenvalues with largest algebraic value (``eigsh``),
+  that is, largest eigenvalues inclusive of any negative sign.
+* ``which = 'SA'`` : Eigenvalues with smallest algebraic value (``eigsh``),
+  that is, smallest eigenvalues inclusive of any negative sign.
+* ``which = 'BE'`` : Eigenvalues from both ends of the spectrum (``eigsh``)
 
 Note that ARPACK is generally better at finding extremal eigenvalues: that
 is, eigenvalues with large magnitudes.  In particular, using ``which = 'SM'``


### PR DESCRIPTION
I've had a hard time understanding the `which` parameter of ARPACK, so
I'm submitting this patch with the hope that it becomes clearer.

Changes:
- Eigenvectors have all norm 1, thus the parameter `which` is
   applied to eigenvalues and not eigenvectors.
- Clarification on what magnitude means in the context of
   complex eigenvalues.
- Clarification on what 'LA', 'SA' means. ARPACK docs refer to them
   as Largest/Smallest Algebraic value: those are real numbers with
   its respective sign (not in absolute value). I could not understand
   what was meant before as `Largest Amplitude`.
