### PR TITLE
MAINT: Fix deprecated non-integer index to numpy arrays

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2313,8 +2313,8 @@ def _dendrogram_calculate_info(Z, p, truncate_mode, \
     # !!! Otherwise, we don't have a leaf node, so work on plotting a
     # non-leaf node.
     # Actual indices of a and b
-    aa = Z[i - n, 0]
-    ab = Z[i - n, 1]
+    aa = int(Z[i - n, 0])
+    ab = int(Z[i - n, 1])
     if aa > n:
         # The number of singletons below cluster a
         na = Z[aa - n, 3]

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -1373,9 +1373,9 @@ def calculate_maximum_distances(Z):
         left = Z[i, 0]
         right = Z[i, 1]
         if left >= n:
-            q[0] = B[left - n]
+            q[0] = B[int(left) - n]
         if right >= n:
-            q[1] = B[right - n]
+            q[1] = B[int(right) - n]
         q[2] = Z[i, 2]
         B[i] = q.max()
     return B
@@ -1391,9 +1391,9 @@ def calculate_maximum_inconsistencies(Z, R, k=3):
         left = Z[i, 0]
         right = Z[i, 1]
         if left >= n:
-            q[0] = B[left - n]
+            q[0] = B[int(left) - n]
         if right >= n:
-            q[1] = B[right - n]
+            q[1] = B[int(right) - n]
         q[2] = R[i, k]
         B[i] = q.max()
     return B

--- a/scipy/stats/mstats_extras.py
+++ b/scipy/stats/mstats_extras.py
@@ -352,6 +352,7 @@ def idealfourths(data, axis=None):
         if n < 3:
             return [np.nan,np.nan]
         (j,h) = divmod(n/4. + 5/12.,1)
+        j = int(j)
         qlo = (1-h)*x[j-1] + h*x[j]
         k = n - j
         qup = (1-h)*x[k] + h*x[k-1]

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1470,15 +1470,15 @@ def scoreatpercentile(a, per, limit=(), interpolation_method='fraction'):
 
     idx = per /100. * (values.shape[0] - 1)
     if (idx % 1 == 0):
-        score = values[idx]
+        score = values[int(idx)]
     else:
         if interpolation_method == 'fraction':
             score = _interpolate(values[int(idx)], values[int(idx) + 1],
                                  idx % 1)
         elif interpolation_method == 'lower':
-            score = values[np.floor(idx)]
+            score = values[int(np.floor(idx))]
         elif interpolation_method == 'higher':
-            score = values[np.ceil(idx)]
+            score = values[int(np.ceil(idx))]
         else:
             raise ValueError("interpolation_method can only be 'fraction', " \
                              "'lower' or 'higher'")


### PR DESCRIPTION
I'm not sure why but these DeprecationWarnings from numpy were raising errors in nose for me.
