### PR TITLE
FIX: scipy.stats.mstats.kurtosis() throwing ValueError

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1448,13 +1448,14 @@ skew.__doc__ = stats.skew.__doc__
 
 def kurtosis(a, axis=0, fisher=True, bias=True):
     a, axis = _chk_asarray(a, axis)
-    n = a.count(axis)
     m2 = moment(a,2,axis)
     m4 = moment(a,4,axis)
     vals = ma.where(m2 == 0, 0, m4/ m2**2.0)
     if not bias:
-        can_correct = (n > 3) & (m2 > 0)
+        n = a.count(axis)
+        can_correct = (n > 3) & (m2 is not ma.masked and m2 > 0)
         if can_correct.any():
+            n = np.extract(can_correct, n)
             m2 = np.extract(can_correct, m2)
             m4 = np.extract(can_correct, m4)
             nval = 1.0/(n-2)/(n-3)*((n*n-1.0)*m4/m2**2.0-3*(n-1)**2.0)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1075,7 +1075,12 @@ def kurtosis(a, axis=0, fisher=True, bias=True):
     m2 = moment(a,2,axis)
     m4 = moment(a,4,axis)
     zero = (m2 == 0)
-    vals = np.where(zero, 0, m4/ m2**2.0)
+    olderr = np.seterr(all='ignore')
+    try:
+        vals = np.where(zero, 0, m4/ m2**2.0)
+    finally:
+        np.seterr(**olderr)
+
     if not bias:
         can_correct = (n > 3) & (m2 > 0)
         if can_correct.any():

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -289,6 +289,18 @@ class TestMoments(TestCase):
     testcase = [1,2,3,4]
     testmathworks = ma.fix_invalid([1.165 , 0.6268, 0.0751, 0.3516, -0.6965,
                                     np.nan])
+    testcase_2d = ma.array(
+    np.array([[ 0.05245846,  0.50344235,  0.86589117,  0.36936353,  0.46961149],
+           [ 0.11574073,  0.31299969,  0.45925772,  0.72618805,  0.75194407],
+           [ 0.67696689,  0.91878127,  0.09769044,  0.04645137,  0.37615733],
+           [ 0.05903624,  0.29908861,  0.34088298,  0.66216337,  0.83160998],
+           [ 0.64619526,  0.94894632,  0.27855892,  0.0706151 ,  0.39962917]]),
+    mask = np.array([[ True, False, False,  True, False],
+           [ True,  True,  True, False,  True],
+           [False, False, False, False, False],        
+           [True, True, True, True, True], 
+           [False, False,  True, False, False]], dtype=np.bool))
+
     def test_moment(self):
         """
         mean((testcase-mean(testcase))**power,axis=0),axis=0))**power))"""
@@ -335,7 +347,26 @@ class TestMoments(TestCase):
         assert_almost_equal(y, 3.663542721189047,10)
         y = mstats.kurtosis(self.testcase,0,0)
         assert_almost_equal(y,1.64)
-    #
+        
+        # test that kurtosis works on multidimensional masked arrays
+        correct_2d = ma.array(
+          np.array([-1.5, -3., -1.47247052385,  0., -1.26979517952]),
+          mask=np.array([False, False, False,  True, False], dtype=np.bool))
+        assert_array_almost_equal(
+          mstats.kurtosis(self.testcase_2d, 1), correct_2d)
+        for i,row in enumerate(self.testcase_2d):
+            assert_almost_equal(mstats.kurtosis(row), correct_2d[i])
+
+        correct_2d_bias_corrected = ma.array(
+          np.array([-1.5, -3., -1.88988209538,  0., -0.5234638463918877]),
+          mask=np.array([False, False, False,  True, False], dtype=np.bool))
+        assert_array_almost_equal(
+          mstats.kurtosis(self.testcase_2d, 1, bias=False),
+          correct_2d_bias_corrected)
+        for i,row in enumerate(self.testcase_2d):
+            assert_almost_equal(mstats.kurtosis(row, bias=False),
+              correct_2d_bias_corrected[i])
+
     def test_mode(self):
         "Tests the mode"
         #


### PR DESCRIPTION
Fixed a bug in scipy.stats.mstats.kurtosis() that caused a ValueError to be
thrown when bias=False. In the same context, fixed a TypeError that was being
thrown for one-dimensional input where all elements are masked.

Appropriate tests have been added to the testing suite for the function.

Relates to ticket: http://projects.scipy.org/scipy/ticket/1798
