### PR TITLE
MAINT: in integrate.ode, generate understandable error for f2py issue.

### DIFF
--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -109,6 +109,7 @@ class ode(object):
     f : callable ``f(t, y, *f_args)``
         Rhs of the equation. t is a scalar, ``y.shape == (n,)``.
         ``f_args`` is set by calling ``set_f_params(*args)``.
+        `f` should return a scalar, array or list (not a tuple).
     jac : callable ``jac(t, y, *jac_args)``
         Jacobian of the rhs, ``jac[i,j] = d f[i] / d y[j]``.
         ``jac_args`` is set by calling ``set_f_params(*args)``.
@@ -376,9 +377,15 @@ class ode(object):
             mth = self._integrator.run_relax
         else:
             mth = self._integrator.run
-        self._y, self.t = mth(self.f, self.jac or (lambda: None),
-                            self._y, self.t, t,
-                            self.f_params, self.jac_params)
+
+        try:
+            self._y, self.t = mth(self.f, self.jac or (lambda: None),
+                                self._y, self.t, t,
+                                self.f_params, self.jac_params)
+        except SystemError:
+            # f2py issue with tuple returns, see ticket 1187.
+            raise ValueError('Function to integrate must not return a tuple.')
+
         return self._y
 
     def successful(self):


### PR DESCRIPTION
Closes ticket 1187.  Note that this cannot be tested without a warning message
being printed by vodemodule.c, even when redirecting stderr::

```
import sys
from scipy import integrate

class RedirectStdStreams(object):
    def __init__(self, stdout=None, stderr=None):
        self._stdout = stdout or sys.stdout
        self._stderr = stderr or sys.stderr

    def __enter__(self):
        self.old_stdout, self.old_stderr = sys.stdout, sys.stderr
        self.old_stdout.flush(); self.old_stderr.flush()
        sys.stdout, sys.stderr = self._stdout, self._stderr

    def __exit__(self, exc_type, exc_value, traceback):
        self._stdout.flush(); self._stderr.flush()
        sys.stdout = self.old_stdout

y0, t0 = [1.0j, 2.0], 0
def f(t, y, arg1):
    return (1j*arg1*y[0] + y[1], -arg1*y[1]**2)

def jac(t, y, arg1):
    return [[1j*arg1, 1], [0, -arg1*2*y[1]]]

with RedirectStdStreams():
    r = integrate.ode(f, jac).set_integrator('zvode', method='bdf', with_jacobian=True)
    r.set_initial_value(y0, t0).set_f_params(2.0).set_jac_params(2.0)
    t1 = 10
    dt = 1
    while r.successful() and r.t < t1:
        r.integrate(r.t+dt)
```

For the f2py change suggested by Pearu, a numpy ticket should be opened.
