### PR TITLE
Raise more informative error when interp1d is given unsorted x

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -340,6 +340,10 @@ class interp1d(object):
         if len_x < minval:
             raise ValueError("x and y arrays must have at "
                              "least %d entries" % minval)
+
+        if not np.array_equal(x, np.sort(x)):
+            raise ValueError("x must have monotonically increasing values")
+
         self.x = x
         self.y = oriented_y
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -109,6 +109,8 @@ class TestInterp1D(object):
         assert_raises(ValueError, interp1d, self.x10, self.y1)
         assert_raises(ValueError, interp1d, self.x1, self.y1)
 
+        # Check that x has monotonically increasing values
+        assert_raises(ValueError, interp1d, np.array([2., 1.]), np.array([1., 2.]))
 
     def test_init(self):
         """ Check that the attributes are initialized appropriately by the


### PR DESCRIPTION
Right now the error is confusing.

``` python
from scipy.interpolate import interp1d
x = [0.1, 0.2, 0.]
y = [0.5, 0.6, 0.4]
f = interp1d(x, y)
print f(0.)
```

results in:

```
ValueError: A value in x_new is below the interpolation range.
```
