### PR TITLE
Update scipy/stats/stats.py

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2658,7 +2658,7 @@ def pointbiserialr(x, y):
 
     References
     ----------
-    http://www.childrens-mercy.org/stats/definitions/biserial.htm
+    http://en.wikipedia.org/wiki/Point-biserial_correlation_coefficient
 
     Examples
     --------


### PR DESCRIPTION
Reference link for pointbiserial is dead. Replace with wikipedia link. See http://projects.scipy.org/scipy/ticket/1822.
