### PR TITLE
BUG: linalg: backward compatibility for people addressing scipy.linalg.lapack.flapack etc (#1808)

### DIFF
--- a/scipy/lib/_util.py
+++ b/scipy/lib/_util.py
@@ -1,0 +1,35 @@
+import sys
+import warnings
+
+class DeprecatedImport(object):
+    """
+    Deprecated import, with redirection + warning.
+
+    Examples
+    --------
+    Suppose you previously had in some module::
+
+        from foo import spam
+
+    If this has to be deprecated, do::
+
+        spam = DeprecatedImport("foo.spam", "baz")
+
+    to redirect users to use "baz" module instead.
+
+    """
+
+    def __init__(self, old_module_name, new_module_name):
+        self._old_name = old_module_name
+        self._new_name = new_module_name
+        __import__(self._new_name)
+        self._mod = sys.modules[self._new_name]
+
+    def __dir__(self):
+        return dir(self._mod)
+
+    def __getattr__(self, name):
+        warnings.warn("Module %s is deprecated, use %s instead"
+                      % (self._old_name, self._new_name),
+                      DeprecationWarning)
+        return getattr(self._mod, name)

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -121,6 +121,11 @@ empty_module = None
 from scipy.linalg._fblas import *
 del empty_module
 
+# Backward compatibility
+from scipy.lib._util import DeprecatedImport as _DeprecatedImport
+cblas = _DeprecatedImport("scipy.linalg.blas.cblas", "scipy.linalg.blas")
+fblas = _DeprecatedImport("scipy.linalg.blas.fblas", "scipy.linalg.blas")
+
 # 'd' will be default for 'i',..
 _type_conv = {'f':'s', 'd':'d', 'F':'c', 'D':'z', 'G':'z'}
 

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -18,7 +18,6 @@ Finding functions
 .. autosummary::
 
    get_lapack_funcs
-   find_best_blas_type
 
 All functions
 =============
@@ -218,6 +217,11 @@ try:
     from scipy.linalg import _clapack
 except ImportError:
     _clapack = None
+
+# Backward compatibility
+from scipy.lib._util import DeprecatedImport as _DeprecatedImport
+clapack = _DeprecatedImport("scipy.linalg.blas.clapack", "scipy.linalg.lapack")
+flapack = _DeprecatedImport("scipy.linalg.blas.flapack", "scipy.linalg.lapack")
 
 # Expose all functions (only flapack --- clapack is an implementation detail)
 empty_module = None


### PR DESCRIPTION
An additional backward compatible wrapper for people trying to access flapack etc via a strange import...

As a response to
http://projects.scipy.org/scipy/ticket/1808
