### PR TITLE
DOC: fixed typo in linalg.eigh eigvals parameter description

### DIFF
--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -225,7 +225,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
         only for generalized eigenvalue problem and if eigvals=None)
     eigvals : tuple (lo, hi)
         Indexes of the smallest and largest (in ascending order) eigenvalues
-        and corresponding eigenvectors to be returned: 0 <= lo < hi <= M-1.
+        and corresponding eigenvectors to be returned: 0 <= lo <= hi <= M-1.
         If omitted, all eigenvalues and eigenvectors are returned.
     type : integer
         Specifies the problem type to be solved:


### PR DESCRIPTION
Hi!

There's a typo in the docstring of scipy.linalg.eigh suggesting to use `eigvals=(0,1)` for computing the first eigenvector/-value pair, while it should be `eigvals=(0,0)` instead.
This commit fixes the typo ("lo <= hi" instead of "lo < hi").

Best, Jan
