### PR TITLE
DOC: add rankdata to the stats module docstring.

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -256,6 +256,7 @@ which work for masked arrays.
    ks_2samp
    mannwhitneyu
    tiecorrect
+   rankdata
    ranksums
    wilcoxon
    kruskal


### PR DESCRIPTION
`rankdata` is missing from the stats module docstring.  This change adds it.
