### PR TITLE
optimize.leastsq should allow for ValueError when inverting curvature matrix

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -410,7 +410,7 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
             R = dot(r, perm)
             try:
                 cov_x = inv(dot(transpose(R),R))
-            except LinAlgError:
+            except (LinAlgError, ValueError):
                 pass
         return (retval[0], cov_x) + retval[1:-1] + (mesg, info)
     else:


### PR DESCRIPTION
optimize.leastsq should allow for ValueError as well as LinAlgError when inverting curvature matrix.  That is, the code around line 413 should read
          try:
                cov_x = inv(dot(transpose(R),R))
            except (LinAlgError, ValueError):
                pass
