### PR TITLE
BUG: fix integer divisions + complexwarnings

### DIFF
--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -575,7 +575,7 @@ class TestIsValidLinkage(TestCase):
         for i in xrange(4, 15, 3):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
-            Z[int(i//2),0] = -2
+            Z[i//2,0] = -2
             self.assertTrue(is_valid_linkage(Z) == False)
             self.assertRaises(ValueError, is_valid_linkage, Z, throw=True)
 
@@ -584,7 +584,7 @@ class TestIsValidLinkage(TestCase):
         for i in xrange(4, 15, 3):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
-            Z[int(i//2),1] = -2
+            Z[i//2,1] = -2
             self.assertTrue(is_valid_linkage(Z) == False)
             self.assertRaises(ValueError, is_valid_linkage, Z, throw=True)
 
@@ -593,7 +593,7 @@ class TestIsValidLinkage(TestCase):
         for i in xrange(4, 15, 3):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
-            Z[int(i//2),2] = -0.5
+            Z[i//2,2] = -0.5
             self.assertTrue(is_valid_linkage(Z) == False)
             self.assertRaises(ValueError, is_valid_linkage, Z, throw=True)
 
@@ -602,7 +602,7 @@ class TestIsValidLinkage(TestCase):
         for i in xrange(4, 15, 3):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
-            Z[int(i//2),3] = -2
+            Z[i//2,3] = -2
             self.assertTrue(is_valid_linkage(Z) == False)
             self.assertRaises(ValueError, is_valid_linkage, Z, throw=True)
 
@@ -660,7 +660,7 @@ class TestIsValidInconsistent(TestCase):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             R = inconsistent(Z)
-            R[int(i//2),0] = -2.0
+            R[i//2,0] = -2.0
             self.assertTrue(is_valid_im(R) == False)
             self.assertRaises(ValueError, is_valid_im, R, throw=True)
 
@@ -670,7 +670,7 @@ class TestIsValidInconsistent(TestCase):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             R = inconsistent(Z)
-            R[int(i//2),1] = -2.0
+            R[i//2,1] = -2.0
             self.assertTrue(is_valid_im(R) == False)
             self.assertRaises(ValueError, is_valid_im, R, throw=True)
 
@@ -680,7 +680,7 @@ class TestIsValidInconsistent(TestCase):
             y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             R = inconsistent(Z)
-            R[int(i//2),2] = -0.5
+            R[i//2,2] = -0.5
             self.assertTrue(is_valid_im(R) == False)
             self.assertRaises(ValueError, is_valid_im, R, throw=True)
 

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -566,43 +566,43 @@ class TestIsValidLinkage(TestCase):
     def test_is_valid_linkage_4_and_up(self):
         "Tests is_valid_linkage(Z) on linkage on observation sets between sizes 4 and 15 (step size 3)."
         for i in xrange(4, 15, 3):
-            y = np.random.rand(i*(i-1)/2)
+            y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             self.assertTrue(is_valid_linkage(Z) == True)
 
     def test_is_valid_linkage_4_and_up_neg_index_left(self):
         "Tests is_valid_linkage(Z) on linkage on observation sets between sizes 4 and 15 (step size 3) with negative indices (left)."
         for i in xrange(4, 15, 3):
-            y = np.random.rand(i*(i-1)/2)
+            y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
-            Z[int(i/2),0] = -2
+            Z[int(i//2),0] = -2
             self.assertTrue(is_valid_linkage(Z) == False)
             self.assertRaises(ValueError, is_valid_linkage, Z, throw=True)
 
     def test_is_valid_linkage_4_and_up_neg_index_right(self):
         "Tests is_valid_linkage(Z) on linkage on observation sets between sizes 4 and 15 (step size 3) with negative indices (right)."
         for i in xrange(4, 15, 3):
-            y = np.random.rand(i*(i-1)/2)
+            y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
-            Z[int(i/2),1] = -2
+            Z[int(i//2),1] = -2
             self.assertTrue(is_valid_linkage(Z) == False)
             self.assertRaises(ValueError, is_valid_linkage, Z, throw=True)
 
     def test_is_valid_linkage_4_and_up_neg_dist(self):
         "Tests is_valid_linkage(Z) on linkage on observation sets between sizes 4 and 15 (step size 3) with negative distances."
         for i in xrange(4, 15, 3):
-            y = np.random.rand(i*(i-1)/2)
+            y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
-            Z[int(i/2),2] = -0.5
+            Z[int(i//2),2] = -0.5
             self.assertTrue(is_valid_linkage(Z) == False)
             self.assertRaises(ValueError, is_valid_linkage, Z, throw=True)
 
     def test_is_valid_linkage_4_and_up_neg_counts(self):
         "Tests is_valid_linkage(Z) on linkage on observation sets between sizes 4 and 15 (step size 3) with negative counts."
         for i in xrange(4, 15, 3):
-            y = np.random.rand(i*(i-1)/2)
+            y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
-            Z[int(i/2),3] = -2
+            Z[int(i//2),3] = -2
             self.assertTrue(is_valid_linkage(Z) == False)
             self.assertRaises(ValueError, is_valid_linkage, Z, throw=True)
 
@@ -649,7 +649,7 @@ class TestIsValidInconsistent(TestCase):
     def test_is_valid_im_4_and_up(self):
         "Tests is_valid_im(R) on im on observation sets between sizes 4 and 15 (step size 3)."
         for i in xrange(4, 15, 3):
-            y = np.random.rand(i*(i-1)/2)
+            y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             R = inconsistent(Z)
             self.assertTrue(is_valid_im(R) == True)
@@ -657,30 +657,30 @@ class TestIsValidInconsistent(TestCase):
     def test_is_valid_im_4_and_up_neg_index_left(self):
         "Tests is_valid_im(R) on im on observation sets between sizes 4 and 15 (step size 3) with negative link height means."
         for i in xrange(4, 15, 3):
-            y = np.random.rand(i*(i-1)/2)
+            y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             R = inconsistent(Z)
-            R[int(i/2),0] = -2.0
+            R[int(i//2),0] = -2.0
             self.assertTrue(is_valid_im(R) == False)
             self.assertRaises(ValueError, is_valid_im, R, throw=True)
 
     def test_is_valid_im_4_and_up_neg_index_right(self):
         "Tests is_valid_im(R) on im on observation sets between sizes 4 and 15 (step size 3) with negative link height standard deviations."
         for i in xrange(4, 15, 3):
-            y = np.random.rand(i*(i-1)/2)
+            y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             R = inconsistent(Z)
-            R[int(i/2),1] = -2.0
+            R[int(i//2),1] = -2.0
             self.assertTrue(is_valid_im(R) == False)
             self.assertRaises(ValueError, is_valid_im, R, throw=True)
 
     def test_is_valid_im_4_and_up_neg_dist(self):
         "Tests is_valid_im(R) on im on observation sets between sizes 4 and 15 (step size 3) with negative link counts."
         for i in xrange(4, 15, 3):
-            y = np.random.rand(i*(i-1)/2)
+            y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             R = inconsistent(Z)
-            R[int(i/2),2] = -0.5
+            R[int(i//2),2] = -0.5
             self.assertTrue(is_valid_im(R) == False)
             self.assertRaises(ValueError, is_valid_im, R, throw=True)
 
@@ -705,7 +705,7 @@ class TestNumObsLinkage(TestCase):
     def test_num_obs_linkage_4_and_up(self):
         "Tests num_obs_linkage(Z) on linkage on observation sets between sizes 4 and 15 (step size 3)."
         for i in xrange(4, 15, 3):
-            y = np.random.rand(i*(i-1)/2)
+            y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             self.assertTrue(num_obs_linkage(Z) == i)
 
@@ -783,19 +783,19 @@ class TestCorrespond(TestCase):
     def test_correspond_2_and_up(self):
         "Tests correspond(Z, y) on linkage and CDMs over observation sets of different sizes."
         for i in xrange(2, 4):
-            y = np.random.rand(i*(i-1)/2)
+            y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             self.assertTrue(correspond(Z, y))
         for i in xrange(4, 15, 3):
-            y = np.random.rand(i*(i-1)/2)
+            y = np.random.rand(i*(i-1)//2)
             Z = linkage(y)
             self.assertTrue(correspond(Z, y))
 
     def test_correspond_4_and_up(self):
         "Tests correspond(Z, y) on linkage and CDMs over observation sets of different sizes. Correspondance should be false."
         for (i, j) in list(zip(list(range(2, 4)), list(range(3, 5)))) + list(zip(list(range(3, 5)), list(range(2, 4)))):
-            y = np.random.rand(i*(i-1)/2)
-            y2 = np.random.rand(j*(j-1)/2)
+            y = np.random.rand(i*(i-1)//2)
+            y2 = np.random.rand(j*(j-1)//2)
             Z = linkage(y)
             Z2 = linkage(y2)
             self.assertTrue(correspond(Z, y2) == False)
@@ -804,8 +804,8 @@ class TestCorrespond(TestCase):
     def test_correspond_4_and_up_2(self):
         "Tests correspond(Z, y) on linkage and CDMs over observation sets of different sizes. Correspondance should be false."
         for (i, j) in list(zip(list(range(2, 7)), list(range(16, 21)))) + list(zip(list(range(2, 7)), list(range(16, 21)))):
-            y = np.random.rand(i*(i-1)/2)
-            y2 = np.random.rand(j*(j-1)/2)
+            y = np.random.rand(i*(i-1)//2)
+            y2 = np.random.rand(j*(j-1)//2)
             Z = linkage(y)
             Z2 = linkage(y2)
             self.assertTrue(correspond(Z, y2) == False)

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -87,7 +87,7 @@ def direct_rdft(x):
     n = len(x)
     w = -arange(n)*(2j*pi/n)
     r = zeros(n,dtype=double)
-    for i in range(int(n/2+1)):
+    for i in range(int(n//2+1)):
         y = dot(exp(i*w),x)
         if i:
             r[2*i-1] = y.real
@@ -101,7 +101,7 @@ def direct_irdft(x):
     x = asarray(x)
     n = len(x)
     x1 = zeros(n,dtype=cdouble)
-    for i in range(int(n/2+1)):
+    for i in range(int(n//2+1)):
         if i:
             if 2*i<n:
                 x1[i] = x[2*i-1] + 1j* x[2*i]
@@ -291,8 +291,8 @@ class _TestRFFTBase(TestCase):
             y2 = numpy_fft(x)
             y1 = zeros((n,),dtype=double)
             y1[0] = y2[0].real
-            y1[-1] = y2[n/2].real
-            for k in range(1, int(n/2)):
+            y1[-1] = y2[n//2].real
+            for k in range(1, int(n//2)):
                 y1[2*k-1] = y2[k].real
                 y1[2*k] = y2[k].imag
             y = fftpack.drfft(x)
@@ -336,10 +336,10 @@ class _TestIRFFTBase(TestCase):
             x = list(range(n))
             x1 = zeros((n,),dtype=cdouble)
             x1[0] = x[0]
-            for k in range(1, int(n/2)):
+            for k in range(1, int(n//2)):
                 x1[k] = x[2*k-1]+1j*x[2*k]
                 x1[n-k] = x[2*k-1]-1j*x[2*k]
-            x1[n/2] = x[-1]
+            x1[n//2] = x[-1]
             y1 = numpy_ifft(x1)
             y = fftpack.drfft(x,direction=-1)
             assert_array_almost_equal(y,y1)

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -87,7 +87,7 @@ def direct_rdft(x):
     n = len(x)
     w = -arange(n)*(2j*pi/n)
     r = zeros(n,dtype=double)
-    for i in range(int(n//2+1)):
+    for i in range(n//2+1):
         y = dot(exp(i*w),x)
         if i:
             r[2*i-1] = y.real
@@ -101,7 +101,7 @@ def direct_irdft(x):
     x = asarray(x)
     n = len(x)
     x1 = zeros(n,dtype=cdouble)
-    for i in range(int(n//2+1)):
+    for i in range(n//2+1):
         if i:
             if 2*i<n:
                 x1[i] = x[2*i-1] + 1j* x[2*i]
@@ -292,7 +292,7 @@ class _TestRFFTBase(TestCase):
             y1 = zeros((n,),dtype=double)
             y1[0] = y2[0].real
             y1[-1] = y2[n//2].real
-            for k in range(1, int(n//2)):
+            for k in range(1, n//2):
                 y1[2*k-1] = y2[k].real
                 y1[2*k] = y2[k].imag
             y = fftpack.drfft(x)
@@ -336,7 +336,7 @@ class _TestIRFFTBase(TestCase):
             x = list(range(n))
             x1 = zeros((n,),dtype=cdouble)
             x1[0] = x[0]
-            for k in range(1, int(n//2)):
+            for k in range(1, n//2):
                 x1[k] = x[2*k-1]+1j*x[2*k]
                 x1[n-k] = x[2*k-1]-1j*x[2*k]
             x1[n//2] = x[-1]

--- a/scipy/io/dumbdbm_patched.py
+++ b/scipy/io/dumbdbm_patched.py
@@ -90,7 +90,7 @@ class _Database(object):
 ## Does not work under MW compiler
 ##      pos = ((pos + _BLOCKSIZE - 1) / _BLOCKSIZE) * _BLOCKSIZE
 ##      f.seek(pos)
-        npos = ((pos + _BLOCKSIZE - 1) / _BLOCKSIZE) * _BLOCKSIZE
+        npos = ((pos + _BLOCKSIZE - 1) // _BLOCKSIZE) * _BLOCKSIZE
         f.write('\0'*(npos-pos))
         pos = npos
 
@@ -120,8 +120,8 @@ class _Database(object):
             self._addkey(key, (pos, siz))
         else:
             pos, siz = self._index[key]
-            oldblocks = (siz + _BLOCKSIZE - 1) / _BLOCKSIZE
-            newblocks = (len(val) + _BLOCKSIZE - 1) / _BLOCKSIZE
+            oldblocks = (siz + _BLOCKSIZE - 1) // _BLOCKSIZE
+            newblocks = (len(val) + _BLOCKSIZE - 1) // _BLOCKSIZE
             if newblocks <= oldblocks:
                 pos, siz = self._setval(pos, val)
                 self._index[key] = pos, siz

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -197,10 +197,10 @@ def solve_continuous_are(a, b, q, r):
 
     (m, n) = u.shape
 
-    u11 = u[0:m/2, 0:n/2]
-    u12 = u[0:m/2, n/2:n]
-    u21 = u[m/2:m, 0:n/2]
-    u22 = u[m/2:m, n/2:n]
+    u11 = u[0:m//2, 0:n//2]
+    u12 = u[0:m//2, n//2:n]
+    u21 = u[m//2:m, 0:n//2]
+    u22 = u[m//2:m, n//2:n]
     u11i = inv(u11)
 
     return np.dot(u21, u11i)
@@ -269,10 +269,10 @@ def solve_discrete_are(a, b, q, r):
 
     (m,n) = u.shape
 
-    u11 = u[0:m/2, 0:n/2]
-    u12 = u[0:m/2, n/2:n]
-    u21 = u[m/2:m, 0:n/2]
-    u22 = u[m/2:m, n/2:n]
+    u11 = u[0:m//2, 0:n//2]
+    u12 = u[0:m//2, n//2:n]
+    u21 = u[m//2:m, 0:n//2]
+    u22 = u[m//2:m, n//2:n]
     u11i = inv(u11)
 
     return np.dot(u21, u11i)

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -111,7 +111,7 @@ def iterate_structure(structure, iterations, origin = None):
         return structure.copy()
     ni = iterations - 1
     shape = [ii + ni * (ii - 1) for ii in structure.shape]
-    pos = [ni * (structure.shape[ii] / 2) for ii in range(len(shape))]
+    pos = [ni * (structure.shape[ii] // 2) for ii in range(len(shape))]
     slc = [slice(pos[ii], pos[ii] + structure.shape[ii], None)
            for ii in range(len(shape))]
     out = numpy.zeros(shape, bool)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -127,7 +127,7 @@ def _centered(arr, newsize):
     # Return the center newsize portion of the array.
     newsize = asarray(newsize)
     currsize = array(arr.shape)
-    startind = (currsize - newsize) / 2
+    startind = (currsize - newsize) // 2
     endind = startind + newsize
     myslice = [slice(startind[k], endind[k]) for k in range(len(endind))]
     return arr[tuple(myslice)]
@@ -319,7 +319,7 @@ def medfilt(volume, kernel_size=None):
     domain = ones(kernel_size)
 
     numels = product(kernel_size, axis=0)
-    order = int(numels / 2)
+    order = int(numels // 2)
     return sigtools._order_filterND(volume, domain, order)
 
 
@@ -714,11 +714,11 @@ def hilbert(x, N=None, axis=-1):
     Xf = fft(x, N, axis=axis)
     h = zeros(N)
     if N % 2 == 0:
-        h[0] = h[N / 2] = 1
-        h[1:N / 2] = 2
+        h[0] = h[N // 2] = 1
+        h[1:N // 2] = 2
     else:
         h[0] = 1
-        h[1:(N + 1) / 2] = 2
+        h[1:(N + 1) // 2] = 2
 
     if len(x.shape) > 1:
         ind = [newaxis] * x.ndim
@@ -772,11 +772,11 @@ def hilbert2(x, N=None):
         h = eval("h%d" % (p + 1))
         N1 = N[p]
         if N1 % 2 == 0:
-            h[0] = h[N1 / 2] = 1
-            h[1:N1 / 2] = 2
+            h[0] = h[N1 // 2] = 1
+            h[1:N1 // 2] = 2
         else:
             h[0] = 1
-            h[1:(N1 + 1) / 2] = 2
+            h[1:(N1 + 1) // 2] = 2
         exec("h%d = h" % (p + 1), globals(), locals())
 
     h = h1[:, newaxis] * h2[newaxis, :]
@@ -1198,9 +1198,9 @@ def resample(x, num, t=None, axis=0, window=None):
     newshape[axis] = num
     N = int(np.minimum(num, Nx))
     Y = zeros(newshape, 'D')
-    sl[axis] = slice(0, (N + 1) / 2)
+    sl[axis] = slice(0, (N + 1) // 2)
     Y[sl] = X[sl]
-    sl[axis] = slice(-(N - 1) / 2, None)
+    sl[axis] = slice(-(N - 1) // 2, None)
     Y[sl] = X[sl]
     y = ifft(Y, axis=axis) * (float(num) / float(Nx))
 
@@ -1275,7 +1275,7 @@ def detrend(data, axis=-1, type='linear', bp=0):
             axis = axis + rnk
         newdims = r_[axis, 0:axis, axis + 1:rnk]
         newdata = reshape(transpose(data, tuple(newdims)),
-                          (N, prod(dshape, axis=0) / N))
+                          (N, prod(dshape, axis=0) // N))
         newdata = newdata.copy()  # make sure we have a copy
         if newdata.dtype.char not in 'dfDF':
             newdata = newdata.astype(dtype)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -319,7 +319,7 @@ def medfilt(volume, kernel_size=None):
     domain = ones(kernel_size)
 
     numels = product(kernel_size, axis=0)
-    order = int(numels // 2)
+    order = numels // 2
     return sigtools._order_filterND(volume, domain, order)
 
 

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -107,7 +107,7 @@ def triang(M, sym=True):
     odd = M % 2
     if not sym and not odd:
         M = M + 1
-    n = np.arange(1, int((M + 1) // 2) + 1)
+    n = np.arange(1, (M + 1) // 2 + 1)
     if M % 2 == 0:
         w = (2 * n - 1.0) / M
         w = np.r_[w, w[::-1]]

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -107,7 +107,7 @@ def triang(M, sym=True):
     odd = M % 2
     if not sym and not odd:
         M = M + 1
-    n = np.arange(1, int((M + 1) / 2) + 1)
+    n = np.arange(1, int((M + 1) // 2) + 1)
     if M % 2 == 0:
         w = (2 * n - 1.0) / M
         w = np.r_[w, w[::-1]]

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -96,16 +96,16 @@ def generate_matrix(N, complex=False, hermitian=False,
         else:
             M = np.dot(M.conj(), M.T)
             if sparse:
-                i = np.random.randint(N, size=N * N / 4)
-                j = np.random.randint(N, size=N * N / 4)
+                i = np.random.randint(N, size=N * N // 4)
+                j = np.random.randint(N, size=N * N // 4)
                 ind = np.where(i == j)
                 j[ind] = (j[ind] + 1) % N
                 M[i,j] = 0
                 M[j,i] = 0
     else:
         if sparse:
-            i = np.random.randint(N, size=N * N / 2)
-            j = np.random.randint(N, size=N * N / 2)
+            i = np.random.randint(N, size=N * N // 2)
+            j = np.random.randint(N, size=N * N // 2)
             M[i,j] = 0
     return M
 
@@ -169,7 +169,7 @@ def argsort_which(eval, typ, k, which,
     elif which in ['SM', 'SA', 'SR', 'SI']:
         return ind[:k]
     elif which == 'BE':
-        return np.concatenate((ind[:k/2], ind[k/2-k:]))
+        return np.concatenate((ind[:k//2], ind[k//2-k:]))
 
 
 def eval_evec(symmetric, d, typ, k, which, v0=None, sigma=None,

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -189,7 +189,9 @@ class _TestCommon:
                    [       0, 2.0 + 5,      0],
                    [       0,       0,      0]])
         assert_array_equal(self.spmatrix(A).toarray(), A)
-        assert_array_equal(self.spmatrix(A, dtype='int16').toarray(), A.astype('int16'))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=np.ComplexWarning)
+            assert_array_equal(self.spmatrix(A, dtype='int16').toarray(), A.astype('int16'))
 
     def test_from_matrix(self):
         A = matrix([[1,0,0],[2,3,4],[0,5,0],[0,0,0]])
@@ -199,7 +201,9 @@ class _TestCommon:
                     [       0, 2.0 + 5,      0],
                     [       0,       0,      0]])
         assert_array_equal(self.spmatrix(A).toarray(), A)
-        assert_array_equal(self.spmatrix(A, dtype='int16').toarray(), A.astype('int16'))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=np.ComplexWarning)
+            assert_array_equal(self.spmatrix(A, dtype='int16').toarray(), A.astype('int16'))
 
     def test_from_list(self):
         A = [[1,0,0],[2,3,4],[0,5,0],[0,0,0]]
@@ -209,7 +213,9 @@ class _TestCommon:
              [       0, 2.0 + 5,      0],
              [       0,       0,      0]]
         assert_array_equal(self.spmatrix(A).toarray(), array(A))
-        assert_array_equal(self.spmatrix(A, dtype='int16').todense(), array(A).astype('int16'))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=np.ComplexWarning)
+            assert_array_equal(self.spmatrix(A, dtype='int16').todense(), array(A).astype('int16'))
 
     def test_from_sparse(self):
         D = array([[1,0,0],[2,3,4],[0,5,0],[0,0,0]])
@@ -219,15 +225,17 @@ class _TestCommon:
         assert_array_equal(self.spmatrix(S).toarray(), D)
 
 
-        D = array([[1.0 + 3j,       0,      0],
-                   [       0, 2.0 + 5,      0],
-                   [       0,       0,      0]])
-        S = csr_matrix(D)
-        assert_array_equal(self.spmatrix(S).toarray(), D)
-        assert_array_equal(self.spmatrix(S, dtype='int16').toarray(), D.astype('int16'))
-        S = self.spmatrix(D)
-        assert_array_equal(self.spmatrix(S).toarray(), D)
-        assert_array_equal(self.spmatrix(S, dtype='int16').toarray(), D.astype('int16'))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=np.ComplexWarning)
+            D = array([[1.0 + 3j,       0,      0],
+                       [       0, 2.0 + 5,      0],
+                       [       0,       0,      0]])
+            S = csr_matrix(D)
+            assert_array_equal(self.spmatrix(S).toarray(), D)
+            assert_array_equal(self.spmatrix(S, dtype='int16').toarray(), D.astype('int16'))
+            S = self.spmatrix(D)
+            assert_array_equal(self.spmatrix(S).toarray(), D)
+            assert_array_equal(self.spmatrix(S, dtype='int16').toarray(), D.astype('int16'))
 
     #def test_array(self):
     #    """test array(A) where A is in sparse format"""
@@ -310,10 +318,13 @@ class _TestCommon:
                    [       0,       0,      0]])
         S = self.spmatrix(D)
 
-        for x in supported_dtypes:
-            assert_equal(S.astype(x).dtype,     D.astype(x).dtype)  # correct type
-            assert_equal(S.astype(x).toarray(), D.astype(x))        # correct values
-            assert_equal(S.astype(x).format,    S.format)           # format preserved
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=np.ComplexWarning)
+
+            for x in supported_dtypes:
+                assert_equal(S.astype(x).dtype,     D.astype(x).dtype)  # correct type
+                assert_equal(S.astype(x).toarray(), D.astype(x))        # correct values
+                assert_equal(S.astype(x).format,    S.format)           # format preserved
 
     def test_asfptype(self):
         A = self.spmatrix( arange(6,dtype='int32').reshape(2,3) )
@@ -1012,7 +1023,10 @@ class _TestArithmetic:
             A   = self.A.astype(x)
             Asp = self.spmatrix(A)
             for y in supported_dtypes:
-                B   = self.B.astype(y)
+                if not np.issubdtype(y, np.complexfloating):
+                    B   = self.B.real.astype(y)
+                else:
+                    B   = self.B.astype(y)
                 Bsp = self.spmatrix(B)
 
                 #addition
@@ -1044,7 +1058,10 @@ class _TestArithmetic:
             A   = self.A.astype(x)
             Asp = self.spmatrix(A)
             for y in supported_dtypes:
-                B   = self.B.astype(y)
+                if np.issubdtype(y, np.complexfloating):
+                    B   = self.B.astype(y)
+                else:
+                    B   = self.B.real.astype(y)
                 Bsp = self.spmatrix(B)
 
                 D1 = A * B.T


### PR DESCRIPTION
Fix some cases of integer division issues revealed by the test suite. (Didn't find other points with similar issues by grepping the source code.)

Also fix some spurious ComplexWarnings raised by scipy.sparse tests.
