### PR TITLE
DOC: Add BSD rationale to FAQ

### DIFF
--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -203,6 +203,13 @@ Therefore if you copied existing code with such a license or made a direct
 translation to Python of it, your code can't be included.  See also `license
 compatibility`_.
 
+*Why is SciPy under the BSD license and not, say, the GPL?*
+
+Like Python, SciPy uses a "permissive" open source license, which allows 
+proprietary re-use. While this allows companies to use and modify the software 
+without giving anything back, it is felt that the larger user base results in 
+more contributions overall, and companies often publish their modifications 
+anyway, without being required to.  See John Hunter's `BSD pitch`_.
 
 *How do I set up SciPy so I can edit files, run the tests and make commits?*
 
@@ -327,3 +334,4 @@ for bug reports, Github for patches.
 
 .. _virtualenvwrapper: http://www.doughellmann.com/projects/virtualenvwrapper/
 
+.. _bsd pitch: http://nipy.sourceforge.net/nipy/stable/faq/johns_bsd_pitch.html


### PR DESCRIPTION
Due to http://projects.scipy.org/scipy/ticket/648#comment:7, I've been reading about BSD vs GPL, and trying to convince myself to rewrite the GPL code from scratch for inclusion in SciPy.  :)  I couldn't find any rationale in the SciPy docs for _why_ the BSD license is used, but eventually found [a post in a mailing list](http://mail.scipy.org/pipermail/scipy-user/2007-January/010602.html) by John Hunter (which others in the thread [requested be included in the SciPy FAQ](http://mail.scipy.org/pipermail/scipy-user/2007-January/010621.html), but I don't think it has).

Also found that nipy has [several FAQ questions about this](http://nipy.sourceforge.net/nipy/stable/faq/licensing.html#why-did-you-choose-bsd), and links to [a copy of the same pitch](http://nipy.sourceforge.net/nipy/stable/faq/johns_bsd_pitch.html#johns-bsd-pitch).  Their questions might be included in SciPy's FAQ, too.

Instead of linking to nipy's copy, it might be best to include the pitch directly in scipy, and then have nipy link to scipy's copy instead?

This is just a proposed wording.  Feel free to reject it and write your own, I just want it mentioned somewhere.  Maybe it would be better at http://www.scipy.org/License_Compatibility instead of here? (though I can't edit that)
