### PR TITLE
BUG: special/cdflib: sharper absolute tolerances in distribution fcn tails (#955)

### DIFF
--- a/scipy/special/cdflib/cumchn.f
+++ b/scipy/special/cdflib/cumchn.f
@@ -57,7 +57,8 @@ C     .. Scalar Arguments ..
 C     ..
 C     .. Local Scalars ..
       DOUBLE PRECISION adj,centaj,centwt,chid2,dfd2,eps,lcntaj,lcntwt,
-     +                 lfact,pcent,pterm,sum,sumadj,term,wt,xnonc,xx
+     +                 lfact,pcent,pterm,sum,sumadj,term,wt,xnonc,xx,
+     +                 abstol
       INTEGER i,icent
 C     ..
 C     .. External Functions ..
@@ -76,9 +77,10 @@ C     .. Statement Functions ..
 C     ..
 C     .. Data statements ..
       DATA eps/1.0D-5/
+      DATA abstol/1.0D-300/
 C     ..
 C     .. Statement Function definitions ..
-      qsmall(xx) = sum .LT. 1.0D-20 .OR. xx .LT. eps*sum
+      qsmall(xx) = sum .LT. abstol .OR. xx .LT. eps*sum
       dg(i) = df + 2.0D0*dble(i)
 C     ..
 C

--- a/scipy/special/cdflib/cumfnc.f
+++ b/scipy/special/cdflib/cumfnc.f
@@ -65,7 +65,7 @@ C     ..
 C     .. Local Scalars ..
       DOUBLE PRECISION dsum,dummy,prod,xx,yy
       DOUBLE PRECISION adn,aup,b,betdn,betup,centwt,dnterm,eps,sum,
-     +                 upterm,xmult,xnonc,x
+     +                 upterm,xmult,xnonc,x,abstol
       INTEGER i,icent,ierr
 C     ..
 C     .. External Functions ..
@@ -89,9 +89,10 @@ C     .. Parameters ..
 C     ..
 C     .. Data statements ..
       DATA eps/1.0D-4/
+      DATA abstol/1.0D-300/
 C     ..
 C     .. Statement Function definitions ..
-      qsmall(x) = sum .LT. 1.0D-20 .OR. x .LT. eps*sum
+      qsmall(x) = sum .LT. abstol .OR. x .LT. eps*sum
 C     ..
 C     .. Executable Statements ..
 C

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -165,6 +165,10 @@ class TestCephes(TestCase):
 
     def test_chndtr(self):
         assert_equal(cephes.chndtr(0,1,0),0.0)
+        p = cephes.chndtr(np.linspace(20, 25, 5), 2, 1.07458615e+02)
+        assert_allclose(p, [1.21805009e-09, 2.81979982e-09, 6.25652736e-09,
+                            1.33520017e-08,   2.74909967e-08],
+                        rtol=1e-6, atol=0)
     def test_chndtridf(self):
         assert_equal(cephes.chndtridf(0,0,1),5.0)
     def test_chndtrinc(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -992,6 +992,12 @@ def test_distribution_too_many_args():
     assert_raises(TypeError, stats.ncf.pdf, x, 3, 4, 5, 6, 1.0, scale=0.5)
     stats.ncf.pdf(x, 3, 4, 5, 6, 1.0)  # 3 args, plus loc/scale
 
+def test_ncx2_tails_ticket_955():
+    # Trac #955 -- check that the cdf computed by special functions
+    # matches the integrated pdf
+    a = stats.ncx2.cdf(np.arange(20, 25, 0.2), 2, 1.07458615e+02)
+    b = stats.ncx2.veccdf(np.arange(20, 25, 0.2), 2, 1.07458615e+02)
+    assert_allclose(a, b, rtol=1e-3, atol=0)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Fixes Trac #955, by giving more accurate results in the tails of the ncx2 distribution.
