### PR TITLE
BUG: Fix the automatic frequency selection of scipy.signal.bode.

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -28,6 +28,34 @@ abs = absolute
 
 
 def findfreqs(num, den, N):
+    """
+    Find an array of frequencies for computing the response of a filter.
+
+    Parameters
+    ----------
+    num, den : array_like, 1-D
+        The polynomial coefficients of the numerator and denominator of the
+        transfer function of the filter or LTI system.  The coefficients are
+        ordered from highest to lowest degree.
+    N : int
+        The length of the array to be computed.
+
+    Returns
+    -------
+    w : (N,) ndarray
+        A 1-D array of frequencies, logarithmically spaced.
+
+    Examples
+    --------
+    Find a set of nine frequencies that span the "interesting part" of the
+    frequency response for the filter with the transfer function
+        H(s) = s / (s^2 + 8s + 25)
+
+    >>> findfreqs([1, 0], [1, 8, 25], N=9)
+    array([  1.00000000e-02,   3.16227766e-02,   1.00000000e-01,
+             3.16227766e-01,   1.00000000e+00,   3.16227766e+00,
+             1.00000000e+01,   3.16227766e+01,   1.00000000e+02])
+    """
     ep = atleast_1d(roots(den)) + 0j
     tz = atleast_1d(roots(num)) + 0j
 

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -284,19 +284,15 @@ class Test_bode(object):
         assert_almost_equal(phase, expected_phase)
 
     def test_05(self):
-        """Test that bode() finds a reasonable frequency range.
-
-        A reasonable frequency range is two orders of magnitude before the
-        minimum (slowest) pole and two orders of magnitude after the maximum
-        (fastest) pole.
-        """
+        """Test that bode() finds a reasonable frequency range."""
         # 1st order low-pass filter: H(s) = 1 / (s + 1)
         system = lti([1], [1, 1])
         vals = linalg.eigvals(system.A)
         minpole = min(abs(np.real(vals)))
         maxpole = max(abs(np.real(vals)))
         n = 10;
-        expected_w = np.logspace(np.log10(minpole) - 2, np.log10(maxpole) + 2, n)
+        # Expected range is from 0.01 to 10.
+        expected_w = np.logspace(-2, 1, n)
         w, mag, phase = bode(system, n=n)
         assert_almost_equal(w, expected_w)
 
@@ -306,6 +302,13 @@ class Test_bode(object):
         system = lti([1], [1, 0])
         w, mag, phase = bode(system, n=2)
         assert_equal(w[0], 0.01)  # a fail would give not-a-number
+
+    def test_07(self):
+        """bode() should not fail on a system with pure imaginary poles."""
+        # The test passes if bode doesn't raise an exception.
+        system = lti([1], [1, 0, 100])
+        w, mag, phase = bode(system, n=2)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
The automatic selection of the frequencies could miss zeros or resonance peaks, so use the existing function scipy.signal.findfreqs instead of _default_response_frequencies.

Specific changes:
- Modifed the function scipy.signal.bode to use scipy.signal.freqs.
- Added a docstring to scipy.signal.findfreqs.
### More details

The function `_default_response_frequencies` in ltisys.py, used by `signal.bode`, attempts to compute a good range of frequencies for showing the frequency response of an LTI system.  This actually duplicates the functionality provided by the function `findfreqs` in filter_design.py.

Because `_default_response_frequencies` doesn't use the zeros or the imaginary parts of the poles of the system, it can generate bad frequency ranges.

For example, the follow either fail or miss important features of the frequency response:

```
>>> w, mag, phase = bode(([1],[1, 0, 100]))    # Raises exception
>>> w, mag, phase = bode(([1],[1, 1e-2, 100])) # Misses the resonance peak near 10
>>> w, mag, phase = bode(([0.01j, -0.01j], [2,2], [0.5])) # Misses the zero at 0.01.
```

Compare the plots created by `semilogx(w, mag)` to the corresponding plots with data generated by `scipy.signal.freqs`, e.g

```
>>> system = lti([1], [1, 1e-2, 100])
>>> fw, fh = freqs(system.num, system.den, worN=1000)
>>> semilogx(fw, 20*numpy.log10(abs(fh)))
```

So in this pull request, I have changed the bode function to use `scipy.signal.freqs` instead of `_default_response_frequencies`.  This improves the behavior of `bode` and removes redundant functionality.

I also added a docstring to `findfreqs` in filter_design.py.  This is the function used by `freqs` to find the range of frequencies when the frequencies are not specified.  It takes into account the zeros and the poles (real and imaginary parts) to choose the frequencies.

In the cases where `_default_response_frequencies` worked, it generally produced a larger range of values than `findfreqs` does, and this often looked better because it went a little further into the asymptotic ranges.  Whether `findfreqs` should be tweaked to generate a wider range is something that could be discussed here or in another pull request.
