### PR TITLE
test case for R<-1 in scipy.stats.linregress and fix in the code

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2961,8 +2961,11 @@ def linregress(x, y=None):
         r = 0.0
     else:
         r = r_num / r_den
-        if (r > 1.0): r = 1.0 # from numerical error
-        elif (r < -1.0): r = -1.0  # from numerical error
+        # test for numerical error propagation
+        if (r > 1.0):
+            r = 1.0
+        elif (r < -1.0):
+            r = -1.0
     #z = 0.5*log((1.0+r+TINY)/(1.0-r+TINY))
     df = n-2
     t = r*np.sqrt(df/((1.0-r+TINY)*(1.0+r+TINY)))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2962,6 +2962,7 @@ def linregress(x, y=None):
     else:
         r = r_num / r_den
         if (r > 1.0): r = 1.0 # from numerical error
+        elif (r < -1.0): r = -1.0  # from numerical error
     #z = 0.5*log((1.0+r+TINY)/(1.0-r+TINY))
     df = n-2
     t = r*np.sqrt(df/((1.0-r+TINY)*(1.0+r+TINY)))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -743,6 +743,19 @@ class TestRegression(TestCase):
         res = (1.0, 5.0, 0.98229948625750, 7.45259691e-008, 0.063564172616372733)
         assert_array_almost_equal(stats.linregress(x,y),res,decimal=14)
 
+    def test_regress_simple_negative_cor(self):
+        """
+        If the slope of the regression is negative the factor R tend to -1 not 1 
+        """
+        a, n = 1e-71, 100000
+        x = np.linspace(a, 2 * a, n)
+        y = np.linspace(2 * a, a, n)
+        stats.linregress(x, y)
+        res = stats.linregress(x, y)
+        assert_equal(res[2] >= -1, True, "R factor is in [-1..1]")
+        assert_equal(np.isNan(res[4]), False, "stderr is finite")
+
+
 class TestHistogram(TestCase):
     """ Tests that histogram works as it should, and keeps old behaviour
     """

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -753,9 +753,9 @@ class TestRegression(TestCase):
         y = np.linspace(2 * a, a, n)
         stats.linregress(x, y)
         res = stats.linregress(x, y)
-        assert_(res[2] >= -1, "R factor is in [-1..1]")
-        assert_almost_equal(res[2], -1, "In this cas R=-1 => R**2=+1 ")
-        assert_(not np.isnan(res[4]), "Check stderr is not NaN")
+        assert_(res[2] >= -1, "propagated numerical errors were not corrected")
+        assert_almost_equal(res[2], -1, "perfect negative correlation case")
+        assert_(not np.isnan(res[4]), "stderr should stay finite")
 
 
 class TestHistogram(TestCase):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -745,15 +745,16 @@ class TestRegression(TestCase):
 
     def test_regress_simple_negative_cor(self):
         """
-        If the slope of the regression is negative the factor R tend to -1 not 1 
+        If the slope of the regression is negative the factor R tend to -1 not 1.
+        Sometimes rounding errors make it < -1 leading to   
         """
         a, n = 1e-71, 100000
         x = np.linspace(a, 2 * a, n)
         y = np.linspace(2 * a, a, n)
         stats.linregress(x, y)
         res = stats.linregress(x, y)
-        assert_equal(res[2] >= -1, True, "R factor is in [-1..1]")
-        assert_equal(np.isNan(res[4]), False, "stderr is finite")
+        assert_(res[2] >= -1, "R factor is in [-1..1]")
+        assert_(not np.isNan(res[4]), "stderr is finite")
 
 
 class TestHistogram(TestCase):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -746,7 +746,7 @@ class TestRegression(TestCase):
     def test_regress_simple_negative_cor(self):
         """
         If the slope of the regression is negative the factor R tend to -1 not 1.
-        Sometimes rounding errors make it < -1 leading to   
+        Sometimes rounding errors makes it < -1 leading to stderr being NaN
         """
         a, n = 1e-71, 100000
         x = np.linspace(a, 2 * a, n)
@@ -754,7 +754,8 @@ class TestRegression(TestCase):
         stats.linregress(x, y)
         res = stats.linregress(x, y)
         assert_(res[2] >= -1, "R factor is in [-1..1]")
-        assert_(not np.isNan(res[4]), "stderr is finite")
+        assert_almost_equal(res[2], -1, "In this cas R=-1 => R**2=+1 ")
+        assert_(not np.isnan(res[4]), "Check stderr is not NaN")
 
 
 class TestHistogram(TestCase):


### PR DESCRIPTION
Code for preventing R to be lower than -1.0 due to accumulation of numerical error scipy.stats.linregress and a test-case (tested under debian7, python2.7, amd64 and probably dependent on the compiler as well)
