### PR TITLE
ENH reproducible scipy.sparse.rand

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -83,7 +83,7 @@ Jeff Armstrong for discrete state-space and linear time-invariant functionality
 Mark Wiebe for fixing type casting after changes in Numpy.
 Andrey Smirnov for improvements to FIR filter design.
 Anthony Scopatz for help with code review and merging.
-Lars Buitinck for improvements to io.arff.
+Lars Buitinck for improvements to io.arff and scipy.sparse.
 Scott Sinclair for documentation improvements and some bug fixes.
 Gael Varoquaux for cleanups in scipy.sparse.
 Skipper Seabold for a fix to special.gammainc.

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -341,7 +341,6 @@ class TestConstructUtils(TestCase):
         assert_equal(construct.block_diag([1]).todense(),
                      matrix([[1]]))
 
-
     def test_rand(self):
         # Simple sanity checks for sparse.rand
         for t in [np.float32, np.float64, np.longdouble]:
@@ -350,8 +349,16 @@ class TestConstructUtils(TestCase):
             assert_equal(x.shape, (5, 10))
             assert_equal(x.nonzero()[0].size, 5)
 
-        x = sprand(5, 10, density=0.1)
-        assert_equal(x.dtype, np.double)
+        x1 = sprand(5, 10, density=0.1,
+                    random_state=4321)
+        assert_equal(x1.dtype, np.double)
+
+        x2 = sprand(5, 10, density=0.1,
+                    random_state=np.random.RandomState(4321))
+
+        assert_array_equal(x1.data, x2.data)
+        assert_array_equal(x1.row, x2.row)
+        assert_array_equal(x1.col, x2.col)
 
         for fmt in ['coo', 'csc', 'csr', 'lil']:
             x = sprand(5, 10, format=fmt)


### PR DESCRIPTION
Added a `random_state` argument on `scipy.sparse.rand`, to make it more useful in reproducible unit tests. The name of the argument follows scikit-learn conventions; I wasn't aware of a SciPy convention on naming these things.

Also renamed the `id` variable to `ind` (`id` is the name of a Python built-in!) and `tp` to `typ` for readability; and changed the index type to `np.intc` since `np.intp` will allow sizes that are much too large and trigger cryptic error messages (but see #442, which may have to change this back).
