### PR TITLE
ENH prevent copy in dok_matrix.tocoo

### DIFF
--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -527,9 +527,10 @@ class dok_matrix(spmatrix, dict):
         if self.nnz == 0:
             return coo_matrix(self.shape, dtype=self.dtype)
         else:
-            data    = np.asarray(list(self.values()), dtype=self.dtype)
-            indices = np.asarray(list(self.keys()), dtype=np.intc).T
-            return coo_matrix((data,indices), shape=self.shape, dtype=self.dtype)
+            data    = np.asarray(_list(self.values()), dtype=self.dtype)
+            indices = np.asarray(_list(self.keys()), dtype=np.intc).T
+            return coo_matrix((data,indices), shape=self.shape,
+                              dtype=self.dtype)
 
     def todok(self,copy=False):
         if copy:
@@ -566,6 +567,12 @@ class dok_matrix(spmatrix, dict):
                     del self[i, j]
         self._shape = shape
 
+
+def _list(x):
+    """Force x to a list."""
+    if not isinstance(x, list):
+        x = list(x)
+    return x
 
 
 def isspmatrix_dok(x):


### PR DESCRIPTION
In Python 2, `dict.keys` and `dict.values` already return lists, so calling `list` on their results causes a copy to occur.
