### PR TITLE
Update the parameter documentation in curve_fit

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -452,8 +452,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, **kw):
         can be determined using introspection, otherwise a ValueError
         is raised).
     sigma : None or N-length sequence
-        If not None, it represents the standard-deviation of ydata.
-        This vector, if given, will be used as weights in the
+        If not None, this vector will be used as relative weights in the
         least-squares problem.
 
     Returns


### PR DESCRIPTION
The documentation describing the `sigma` parameter of the
`optimize.curve_fit` function was updated to remove the reference
to representing the standard deviation of the data.  This is 
misleading because the `sigma` value is used purely as a relative
weighting factor.

See also:
http://mail.scipy.org/pipermail/scipy-user/2013-February/034191.html
