### PR TITLE
BUG: account for None in bounds in SLSQP

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -78,7 +78,7 @@ def minimize(fun, x0, args=(), method='BFGS', jac=None, hess=None,
         using finite differences on `jac`. `hessp` must compute the Hessian
         times an arbitrary vector.
     bounds : sequence, optional
-        Bounds for variables (only for L-BFGS-B, TNC, COBYLA and SLSQP).
+        Bounds for variables (only for L-BFGS-B, TNC and SLSQP).
         ``(min, max)`` pairs for each element in ``x``, defining
         the bounds on that parameter. Use None for one of ``min`` or
         ``max`` when there is no bound in that direction.
@@ -303,7 +303,7 @@ def minimize(fun, x0, args=(), method='BFGS', jac=None, hess=None,
     if meth in ['l-bfgs-b', 'tnc'] and any(constraints):
         warn('Method %s cannot handle constraints.' % method,
              RuntimeWarning)
-    if meth is 'cobyla' and bounds is not None:
+    if meth == 'cobyla' and bounds is not None:
         warn('Method %s cannot handle bounds.' % method,
              RuntimeWarning)
     # - callback

--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -19,7 +19,7 @@ __all__ = ['approx_jacobian','fmin_slsqp']
 
 from scipy.optimize._slsqp import slsqp
 from numpy import zeros, array, linalg, append, asfarray, concatenate, finfo, \
-                  sqrt, vstack, exp, inf, where, isinf, atleast_1d
+                  sqrt, vstack, exp, inf, where, isfinite, atleast_1d
 from .optimize import wrap_function, Result, _check_unknown_options
 
 __docformat__ = "restructuredtext en"
@@ -331,8 +331,8 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
                              ', '.join(str(b) for b in bnderr))
         xl, xu = bnds[:, 0], bnds[:, 1]
 
-        # filter -inf and inf values
-        infbnd = isinf(bnds)
+        # filter -inf, inf and NaN values
+        infbnd = ~isfinite(bnds)
         xl[infbnd[:, 0]] = -1.0E12
         xu[infbnd[:, 1]] = 1.0E12
 

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -99,6 +99,14 @@ class TestSLSQP(TestCase):
         assert_(res['success'], res['message'])
         assert_allclose(res.x, [2, 1])
 
+    def test_minimize_bounded_approximated(self):
+        """ Minimize, method='SLSQP': bounded, approximated jacobian. """
+        res = minimize(self.fun, [-1.0, 1.0], args = (-1.0, ),
+                       bounds=((2.5, None), (None, 0.5)),
+                       method='SLSQP', options=self.opts)
+        assert_(res['success'], res['message'])
+        assert_allclose(res.x, [2.5, 0.5])
+
     def test_minimize_unbounded_combined(self):
         """ \
         Minimize, method='SLSQP': unbounded, combined function and jacobian.


### PR DESCRIPTION
`None` in bounds are converted to nan in SLSQP.
