### PR TITLE
Fixed #1429: "pip install numpy scipy" was failing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,15 +155,8 @@ def configuration(parent_package='',top_path=None):
 
 
 def setup_package():
-    from numpy.distutils.core import setup
 
-    # Rewrite the version file everytime
-    write_version_py()
-
-    # Generate Cython sources
-    generate_cython()
-
-    setup(
+    META_DATA = dict(
         name = 'scipy',
         maintainer = "SciPy Developers",
         maintainer_email = "scipy-dev@scipy.org",
@@ -174,8 +167,25 @@ def setup_package():
         license = 'BSD',
         classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
         platforms = ["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
-        configuration=configuration)
+    )
 
+    # NumPy is required for install and build only
+    # for other cases just META_DATA is required and
+    # simple setuptools.setup will do the job
+    if sys.argv[1] in ('install', 'build'):
+        from numpy.distutils.core import setup
+
+        # Rewrite the version file everytime
+        write_version_py()
+
+        # Generate Cython sources
+        generate_cython()
+
+        META_DATA['configuration'] = configuration
+    else:
+        from setuptools import setup
+
+    setup(**META_DATA)
 
 if __name__ == '__main__':
     setup_package()

--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,9 @@ def configuration(parent_package='',top_path=None):
 
 def setup_package():
 
+    # Rewrite the version file everytime
+    write_version_py()
+
     META_DATA = dict(
         name = 'scipy',
         maintainer = "SciPy Developers",
@@ -169,21 +172,22 @@ def setup_package():
         platforms = ["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
     )
 
-    # NumPy is required for install and build only
-    # for other cases just META_DATA is required and
-    # simple setuptools.setup will do the job
-    if sys.argv[1] in ('install', 'build'):
+    # For actins line egg_info and --version NumPy is not required
+    if '--help' in sys.argv[1:] or \
+      sys.argv[1] in ('--help-commands', 'egg_info', '--version'):
+        try:
+            from setuptools import setup
+        except ImportError:
+            from distutils.core import setup
+        from scipy.version import full_version
+        META_DATA['version'] = full_version
+    else:
         from numpy.distutils.core import setup
-
-        # Rewrite the version file everytime
-        write_version_py()
 
         # Generate Cython sources
         generate_cython()
 
         META_DATA['configuration'] = configuration
-    else:
-        from setuptools import setup
 
     setup(**META_DATA)
 

--- a/setup.py
+++ b/setup.py
@@ -88,18 +88,7 @@ if os.path.exists('MANIFEST'):
 # a lot more robust than what was previously being used.
 builtins.__SCIPY_SETUP__ = True
 
-def write_version_py(filename='scipy/version.py'):
-    cnt = """
-# THIS FILE IS GENERATED FROM SCIPY SETUP.PY
-short_version = '%(version)s'
-version = '%(version)s'
-full_version = '%(full_version)s'
-git_revision = '%(git_revision)s'
-release = %(isrelease)s
-
-if not release:
-    version = full_version
-"""
+def get_version_info():
     # Adding the git rev number needs to be done inside
     # write_version_py(), otherwise the import of scipy.version messes
     # up the build under Python 3.
@@ -114,6 +103,23 @@ if not release:
 
     if not ISRELEASED:
         FULLVERSION += '.dev-' + GIT_REVISION[:7]
+
+    return FULLVERSION, GIT_REVISION
+
+
+def write_version_py(filename='scipy/version.py'):
+    cnt = """
+# THIS FILE IS GENERATED FROM SCIPY SETUP.PY
+short_version = '%(version)s'
+version = '%(version)s'
+full_version = '%(full_version)s'
+git_revision = '%(git_revision)s'
+release = %(isrelease)s
+
+if not release:
+    version = full_version
+"""
+    FULLVERSION, GIT_REVISION = get_version_info()
 
     a = open(filename, 'w')
     try:
@@ -178,9 +184,10 @@ def setup_package():
         try:
             from setuptools import setup
         except ImportError:
-            from distutils.core import setup
-        from scipy.version import full_version
-        META_DATA['version'] = full_version
+           from distutils.core import setup
+
+        FULLVERSION, GIT_REVISION = get_version_info()
+        META_DATA['version'] = FULLVERSION
     else:
         from numpy.distutils.core import setup
 

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,10 @@ def get_version_info():
         GIT_REVISION = git_version()
     elif os.path.exists('scipy/version.py'):
         # must be a source distribution, use existing version file
-        from scipy.version import git_revision as GIT_REVISION
+        # load it as a separate module to not load scipy/__init__.py
+        import imp
+        version = imp.load_source('scipy.version', 'scipy/version.py')
+        GIT_REVISION = version.git_revision
     else:
         GIT_REVISION = "Unknown"
 


### PR DESCRIPTION
It was failing because of the pre installation request from pip to ./setup.py egg_info (which is perfectly valid request and shouldn't fail), before numpy actually was installed.

This is pretty popular issue:
http://projects.scipy.org/scipy/ticket/1429
https://github.com/pypa/pip/issues/25
https://github.com/pypa/pip/issues/272
https://github.com/sjsrey/pysal/issues/207
http://bb10.com/python-testing-general/2011-06/msg00028.html
etc...

This really annoying when using tox - with this fix just set up requirements file and be sure that it will work on any machine (including on machines has already preinstalled numpy with different version that required).

Fix is straightforward - not to use numpy for commands that are not connected with build and install.
