### PR TITLE
MAINT: setup.py cleanups and additions

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -36,6 +36,10 @@ __ http://www.python.org
 
 __ http://www.numpy.org/
 
+3) If you want to build the documentation: Sphinx__ 1.1.0 or newer
+
+__ http://http://sphinx-doc.org/
+
 Windows
 -------
 
@@ -133,7 +137,12 @@ $HOME/lib/python2.4/site-packages/scipy).  Then type::
   git clean -xdf
   python setup.py install
  
- 
+Documentation
+-------------
+Type::
+
+  cd scipy
+  python setup.py build_sphinx
 
 INSTALLATION
 ============

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,4 +17,4 @@ prune scipy/special/tests/data/gsl
 prune doc/build
 prune doc/source/generated
 prune */__pycache__
-global-exclude *.pyc *~ *.bak
+global-exclude *.pyc *~ *.bak *.swp *.pyo

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,40 +1,20 @@
-# Use .add_data_files and .add_data_dir methods in a appropriate
-# setup.py files to include non-python files such as documentation,
-# data, etc files to distribution. Avoid using MANIFEST.in for that.
-#
 include MANIFEST.in
 include *.txt
-include setupscons.py
-include setupegg.py
-include setup.py
-include scipy/*.py
-# Cython generation
-include cythonize.dat
-include tools/cythonize.py
-include scipy/cluster/_vq_rewrite.c  # unused, but ship still
-# Add all source files
-recursive-include scipy *.src *.c *.f *.pyf
-# Add Cython files
-recursive-include scipy *.pyx *.pyx.in *.pxd *.pxi
-# Add swig files
-recursive-include scipy *.i
-# Adding scons build related files not found by distutils
-recursive-include scipy SConstruct SConscript
-recursive-include scipy README
-# Add files to allow Bento build
-include f2py.py
-include interface_gen.py
-include bscript bento.info
-recursive-include scipy bscript bento.info
+# Top-level build scripts
+include setup.py setupscons.py bscript bento.info
+# All source files
+recursive-include scipy *
+# All documentation
+recursive-include doc *
 # Add build and testing tools
-include tools/py3tool.py
 include tox.ini
-include tools/test-installed-scipy.py
-# Add documentation: we don't use add_data_dir since we do not want to include
-# this at installation, only for sdist-generated tarballs
-include doc/Makefile doc/postprocess.py
-recursive-include doc/release *
-recursive-include doc/source *
-recursive-include doc/sphinxext *
+recursive-include tools *
+# Cached Cython signatures
+include cythonize.dat
+# Exclude what we don't want to include
 prune scipy/special/tests/data/boost
-include scipy/special/Faddeeva.hh
+prune scipy/special/tests/data/gsl
+prune doc/build
+prune doc/source/generated
+prune */__pycache__
+global-exclude *.pyc *~ *.bak

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,8 @@ include scipy/*.py
 include cythonize.dat
 include tools/cythonize.py
 include scipy/cluster/_vq_rewrite.c  # unused, but ship still
+# Add all source files
+recursive-include scipy *.src *.c *.f *.pyf
 # Add Cython files
 recursive-include scipy *.pyx *.pyx.in *.pxd *.pxi
 # Add swig files

--- a/bscript
+++ b/bscript
@@ -125,10 +125,11 @@ def _set_mangling_var(conf, u, du, case, f2pycompat=True):
     env.DEFINES.extend(macros)
 
 def _generate_cython():
-    cwd = os.path.dirname(__file__)
+    cwd = os.path.abspath(os.path.dirname(__file__))
     subprocess.call([sys.executable,
                      os.path.join(cwd, 'tools', 'cythonize.py'),
-                     os.path.join(cwd, 'scipy')])
+                     'scipy'],
+                    cwd=cwd)
 
 @hooks.post_configure
 def post_configure(context):

--- a/doc/README.txt
+++ b/doc/README.txt
@@ -7,8 +7,7 @@ The easy way to build the documentation is to run
 
     python setup.py build_sphinx
 
-This will make first build Scipy in-place, and then generate documentation for
-it.
+This will first build Scipy in-place, and then generate documentation for it.
 
 Another way
 -----------

--- a/doc/README.txt
+++ b/doc/README.txt
@@ -1,12 +1,21 @@
-SciPy Reference Guide
-=====================
+SciPy Documentation
+===================
 
-Instructions
-------------
+How to build it
+---------------
+The easy way to build the documentation is to run
+
+    python setup.py build_sphinx
+
+This will make first build Scipy in-place, and then generate documentation for
+it.
+
+Another way
+-----------
 1. Optionally download an XML dump of the newest docstrings from the doc wiki
    at ``/pydocweb/dump`` and save it as ``dump.xml``.
 2. Run ``make html`` or ``make dist``
 
-You can also run ``summarize.py`` to see which parts of the Numpy
-namespace are documented.
+Note that ``make html`` builds the documentation for the currently installed
+version of Scipy, not the one corresponding to the source code here.
 

--- a/setup.py
+++ b/setup.py
@@ -198,6 +198,7 @@ def setup_package():
         cmdclass=cmdclass,
         classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
         platforms = ["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
+        test_suite='nose.collector',
     )
 
     if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or

--- a/setup.py
+++ b/setup.py
@@ -220,8 +220,9 @@ def setup_package():
     else:
         from numpy.distutils.core import setup
 
-        # Generate Cython sources
-        generate_cython()
+        if not ISRELEASED:
+            # Generate Cython sources
+            generate_cython()
 
         metadata['configuration'] = configuration
 

--- a/setup.py
+++ b/setup.py
@@ -149,10 +149,11 @@ if HAVE_SPHINX:
             BuildDoc.run(self)
 
 def generate_cython():
-    cwd = os.path.dirname(__file__)
+    cwd = os.path.abspath(os.path.dirname(__file__))
     p = subprocess.Popen([sys.executable,
                           os.path.join(cwd, 'tools', 'cythonize.py'),
-                          os.path.join(cwd, 'scipy')],
+                          'scipy'],
+                         cwd=cwd,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.STDOUT)
     out, err = p.communicate()

--- a/setup.py
+++ b/setup.py
@@ -177,6 +177,10 @@ def configuration(parent_package='',top_path=None):
     return config
 
 def setup_package():
+    try:
+        import setuptools
+    except ImportError:
+        pass
 
     # Rewrite the version file everytime
     write_version_py()
@@ -208,10 +212,7 @@ def setup_package():
         # They are required to succeed without Numpy for example when
         # pip is used to install Scipy when Numpy is not yet present in
         # the system.
-        try:
-            from setuptools import setup
-        except ImportError:
-           from distutils.core import setup
+        from distutils.core import setup
 
         FULLVERSION, GIT_REVISION = get_version_info()
         metadata['version'] = FULLVERSION

--- a/setupegg.py
+++ b/setupegg.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-"""
-A setup.py script to use setuptools, which gives egg goodness, etc.
-"""
-
-from setuptools import setup
-exec(compile(open('setup.py').read(), 'setup.py', 'exec'))

--- a/setupeggscons.py
+++ b/setupeggscons.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-"""
-A setup.py script to use setuptools, which gives egg goodness, etc.
-"""
-
-from setuptools import setup
-exec(compile(open('setupscons.py').read(), 'setupscons.py', 'exec'))

--- a/setupsconsegg.py
+++ b/setupsconsegg.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-"""
-A setup.py script to use setuptools, which gives egg goodness, etc.
-"""
-
-from setuptools import setup
-exec(compile(open('setupscons.py').read(), 'setupscons.py', 'exec'))


### PR DESCRIPTION
Misc. cleanups, fixes and additions regarding setup.py
- add `build_sphinx` command
- add `test` command
- remove `setup*egg*.py`, and always use setuptools if available
- add missing files to MANIFEST.in (only seems to matter when setuptools is enabled)
- fix building with pip without Cython
