### PR TITLE
BUG: stats.kendalltau handling of inputs with only ties.

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2921,8 +2921,8 @@ def kendalltau(x, y, initial_lexsort=True):
     v += ((n - first) * (n - first - 1)) // 2
 
     tot = (n * (n - 1)) // 2
-    if tot == u and tot == v:
-        return 1    # Special case for all ties in both ranks
+    if tot == u or tot == v:
+        return (np.nan, np.nan)    # Special case for all ties in both ranks
 
     # Prevent overflow; equal to np.sqrt((tot - u) * (tot - v))
     denom = np.exp(0.5 * (np.log(tot - u) + np.log(tot - v)))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -610,8 +610,6 @@ class TestCorrSpearmanrTies(TestCase):
 
 @dec.knownfailureif(sys.version[:3] < '2.5', "Can't index array with np.int64")
 def test_kendalltau():
-    """Some tests for kendalltau."""
-
     # with some ties
     x1 = [12, 2, 1, 12, 2]
     x2 = [1, 4, 7, 1, 0]
@@ -619,6 +617,11 @@ def test_kendalltau():
     res = stats.kendalltau(x1, x2)
     assert_approx_equal(res[0], expected[0])
     assert_approx_equal(res[1], expected[1])
+
+    # with only ties in one or both inputs
+    assert_(np.all(np.isnan(stats.kendalltau([2,2,2], [2,2,2]))))
+    assert_(np.all(np.isnan(stats.kendalltau([2,0,2], [2,2,2]))))
+    assert_(np.all(np.isnan(stats.kendalltau([2,2,2], [2,0,2]))))
 
     # check two different sort methods
     assert_approx_equal(stats.kendalltau(x1, x2, initial_lexsort=False)[1],


### PR DESCRIPTION
That it returned only 1 instead of 2 values is a plain bug, returning nan is a
choice (see discussion on #1658).

Closes #1658 and #1690.
