### PR TITLE
add mode argument to ndimage.imread

### DIFF
--- a/scipy/ndimage/io.py
+++ b/scipy/ndimage/io.py
@@ -4,7 +4,7 @@ __all__ = ['imread']
 
 from numpy import array
 
-def imread(fname, flatten=False):
+def imread(fname, flatten=False, mode=None):
     """
     Load an image from file.
 
@@ -14,6 +14,9 @@ def imread(fname, flatten=False):
         Image file name, e.g. ``test.jpg``.
     flatten : bool, optional
         If true, convert the output to grey-scale. Default is False.
+    mode : str, optional
+        mode to convert image to, e.g. ``RGB``.
+
 
     Returns
     -------
@@ -36,10 +39,11 @@ def imread(fname, flatten=False):
                           " http://pypi.python.org/pypi/PIL/ for installation"
                           " instructions.")
 
-    fp = open(fname, "rb")
-    im = Image.open(fp)
-    if flatten:
-        im = im.convert('F')
-    result = array(im)
-    fp.close()
-    return result
+    with open(fname, "rb") as fp:
+        im = Image.open(fp)
+        if mode:
+            im = im.convert(mode)
+        if flatten:
+            im = im.convert('F')
+        result = array(im)
+        return result

--- a/scipy/ndimage/tests/test_io.py
+++ b/scipy/ndimage/tests/test_io.py
@@ -14,7 +14,7 @@ except ImportError:
 @dec.skipif(pil_missing, msg="The Python Image Library could not be found.")
 def test_imread():
     lp = os.path.join(os.path.dirname(__file__), 'dots.png')
-    img = ndi.imread(lp)
+    img = ndi.imread(lp, mode="RGB")
     assert_array_equal(img.shape, (300, 420, 3))
 
     img = ndi.imread(lp, flatten=True)


### PR DESCRIPTION
a test_io.test_imread test failure on ubuntu uncovered [0] that ndimage.imread offers no possibility to define the mode in which a image is opened

[0] the ubuntu package compresses dot.png so its in P mode, 8 bit pixels with palette, so the shape does not match, this patch also fixes the test failure.
