### PR TITLE
MAINT: add install_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -179,6 +179,7 @@ def setup_package():
         license = 'BSD',
         classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
         platforms = ["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
+        install_requires=['numpy>=1.5.0'],
     )
 
     if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or


### PR DESCRIPTION
Tell pip and other tools that Numpy is required before build.
