### PR TITLE
MAINT: fix Python 3 syntax errors in scipy.weave

### DIFF
--- a/scipy/weave/__init__.py
+++ b/scipy/weave/__init__.py
@@ -15,6 +15,7 @@ C/C++ integration
           scipy.
 
 """
+from __future__ import absolute_import, print_function
 
 import sys
 
@@ -22,18 +23,18 @@ if sys.version_info[0] >= 3:
     raise ImportError("scipy.weave only supports Python 2.x")
 
 
-from weave_version import weave_version as __version__
+from .weave_version import weave_version as __version__
 
 try:
-    from blitz_tools import blitz
+    from .blitz_tools import blitz
 except ImportError:
     pass # scipy (core) wasn't available
 
-from inline_tools import inline
-import ext_tools
-from ext_tools import ext_module, ext_function
+from .inline_tools import inline
+from . import ext_tools
+from .ext_tools import ext_module, ext_function
 try:
-    from accelerate_tools import accelerate
+    from .accelerate_tools import accelerate
 except:
     pass
 

--- a/scipy/weave/accelerate_tools.py
+++ b/scipy/weave/accelerate_tools.py
@@ -8,6 +8,7 @@ accelerate_tools contains the interface for on-the-fly building of
 C++ equivalents to Python functions.
 """
 #**************************************************************************#
+from __future__ import absolute_import, print_function
 
 from types import InstanceType, XRangeType
 import inspect
@@ -15,7 +16,7 @@ import scipy.weave.md5_load as md5
 import scipy.weave as weave
 from numpy.testing import assert_
 
-from bytecodecompiler import CXXCoder,Type_Descriptor,Function_Descriptor
+from .bytecodecompiler import CXXCoder,Type_Descriptor,Function_Descriptor
 
 def CStr(s):
     "Hacky way to get legal C string from Python string"
@@ -315,9 +316,9 @@ class accelerate(object):
 
         # See if we have an accelerated version of module
         try:
-            print 'lookup',self.module.__name__+'_weave'
+            print('lookup',self.module.__name__+'_weave')
             accelerated_module = __import__(self.module.__name__+'_weave')
-            print 'have accelerated',self.module.__name__+'_weave'
+            print('have accelerated',self.module.__name__+'_weave')
             fast = getattr(accelerated_module,identifier)
             return fast
         except ImportError:

--- a/scipy/weave/ast_tools.py
+++ b/scipy/weave/ast_tools.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import token
 import symbol
 import parser
@@ -63,7 +65,7 @@ def build_atom(expr_string):
     if isinstance(expr_string, str):
         ast = parser.expr(expr_string).totuple()[1][1]
     else:
-        ast = parser.expr(`expr_string`).totuple()[1][1]
+        ast = parser.expr(repr(expr_string)).totuple()[1][1]
     return ast
 
 def atom_tuple(expr_string):

--- a/scipy/weave/base_info.py
+++ b/scipy/weave/base_info.py
@@ -8,6 +8,8 @@
     info_list -- a handy list class for working with multiple
                  info classes at the same time.
 """
+from __future__ import absolute_import, print_function
+
 import UserList
 
 class base_info(object):

--- a/scipy/weave/base_spec.py
+++ b/scipy/weave/base_spec.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 class base_converter(object):
     """
         Properties:
@@ -69,7 +71,7 @@ class base_converter(object):
         return '"' + self.name + '"'
 
 import UserList
-import base_info
+from . import base_info
 
 class arg_spec_list(UserList.UserList):
     def build_information(self):

--- a/scipy/weave/blitz_spec.py
+++ b/scipy/weave/blitz_spec.py
@@ -6,9 +6,10 @@
 
     array_info -- for building functions that use scipy arrays
 """
+from __future__ import absolute_import, print_function
 
-import base_info
-import standard_array_spec
+from . import base_info
+from . import standard_array_spec
 import os
 
 blitz_support_code =  \
@@ -56,7 +57,7 @@ static blitz::Array<T,N> py_to_blitz(PyArrayObject* arr_obj,const char* name)
 }
 """
 
-import blitz_spec
+from . import blitz_spec
 local_dir,junk = os.path.split(os.path.abspath(blitz_spec.__file__))
 blitz_dir = os.path.join(local_dir,'blitz')
 

--- a/scipy/weave/blitz_spec.py
+++ b/scipy/weave/blitz_spec.py
@@ -57,8 +57,7 @@ static blitz::Array<T,N> py_to_blitz(PyArrayObject* arr_obj,const char* name)
 }
 """
 
-from . import blitz_spec
-local_dir,junk = os.path.split(os.path.abspath(blitz_spec.__file__))
+local_dir,junk = os.path.split(os.path.abspath(__file__))
 blitz_dir = os.path.join(local_dir,'blitz')
 
 # The need to warn about compilers made the info_object method in

--- a/scipy/weave/blitz_tools.py
+++ b/scipy/weave/blitz_tools.py
@@ -1,15 +1,17 @@
+from __future__ import absolute_import, print_function
+
 import parser
 import sys
-import ast_tools
-import slice_handler
-import size_check
-import converters
+from . import ast_tools
+from . import slice_handler
+from . import size_check
+from . import converters
 
 import numpy
 import copy
 
-import inline_tools
-from inline_tools import attempt_function_call
+from . import inline_tools
+from .inline_tools import attempt_function_call
 function_catalog = inline_tools.function_catalog
 function_cache = inline_tools.function_cache
 
@@ -64,8 +66,8 @@ def blitz(expr,local_dict=None, global_dict=None,check_size=1,verbose=0,**kw):
         try:
             results = attempt_function_call(expr,local_dict,global_dict)
         except ValueError:
-            print 'warning: compilation failed. Executing as python code'
-            exec expr in global_dict, local_dict
+            print('warning: compilation failed. Executing as python code')
+            exec(expr, global_dict, local_dict)
 
 def ast_to_blitz_expr(ast_seq):
     """ Convert an ast_sequence to a blitz expression.

--- a/scipy/weave/build_tools.py
+++ b/scipy/weave/build_tools.py
@@ -16,6 +16,7 @@
     does this by converting a pythonxx.lib file to a libpythonxx.a file.
     Note that you need write access to the pythonxx/lib directory to do this.
 """
+from __future__ import absolute_import, print_function
 
 import sys
 import os
@@ -25,7 +26,7 @@ import commands
 import subprocess
 import warnings
 
-import platform_info
+from . import platform_info
 
 # If linker is 'gcc', this will convert it to 'g++'
 # necessary to make sure stdc++ is linked in cross-platform way.
@@ -248,7 +249,7 @@ def build_extension(module_path,compiler_name = '',build_dir = None,
     # the business end of the function
     try:
         if verbose == 1:
-            print 'Compiling code...'
+            print('Compiling code...')
 
         # set compiler verboseness 2 or more makes it output results
         if verbose > 1:
@@ -278,7 +279,7 @@ def build_extension(module_path,compiler_name = '',build_dir = None,
         t2 = time.time()
 
         if verbose == 1:
-            print 'finished compiling (sec): ', t2 - t1
+            print('finished compiling (sec): ', t2 - t1)
         success = 1
         configure_python_path(build_dir)
     except SyntaxError: #TypeError:
@@ -398,9 +399,9 @@ def configure_temp_dir(temp_dir=None):
     if temp_dir is None:
         temp_dir = tempfile.gettempdir()
     elif not os.path.exists(temp_dir) or not os.access(temp_dir,os.W_OK):
-        print "warning: specified temp_dir '%s' does not exist " \
+        print("warning: specified temp_dir '%s' does not exist " \
               "or is not writable. Using the default temp directory" % \
-              temp_dir
+              temp_dir)
         temp_dir = tempfile.gettempdir()
 
     # final check that that directories are writable.
@@ -425,9 +426,9 @@ def configure_build_dir(build_dir=None):
         # if it doesn't work use the current directory.  This should always
         # be writable.
         if not os.access(build_dir,os.W_OK):
-            print "warning:, neither the module's directory nor the "\
+            print("warning:, neither the module's directory nor the "\
                   "current directory are writable.  Using the temporary"\
-                  "directory."
+                  "directory.")
             build_dir = tempfile.gettempdir()
 
     # final check that that directories are writable.
@@ -610,7 +611,7 @@ if sys.platform == 'win32':
         success = not os.system(cmd)
         # for now, fail silently
         if not success:
-            print 'WARNING: failed to build import library for gcc. Linking will fail.'
+            print('WARNING: failed to build import library for gcc. Linking will fail.')
         #if not success:
         #    msg = "Couldn't find import library, and failed to build it."
         #    raise DistutilsPlatformError, msg

--- a/scipy/weave/bytecodecompiler.py
+++ b/scipy/weave/bytecodecompiler.py
@@ -6,9 +6,11 @@
 #**************************************************************************#
 #*  *#
 #**************************************************************************#
+from __future__ import absolute_import, print_function
+
 import sys
 import inspect
-import accelerate_tools
+from . import accelerate_tools
 
 from numpy.testing import assert_
 
@@ -1001,7 +1003,7 @@ class CXXCoder(ByteCodeMeaning):
             rhs_type.cxxtype,
             lhs,
             rhs))
-        print self.__body
+        print(self.__body)
         self.push(lhs,rhs_type)
         return
 
@@ -1029,7 +1031,7 @@ class CXXCoder(ByteCodeMeaning):
     def BINARY_SUBTRACT(self,pc):
         return self.binop(pc,'-')
     def BINARY_MULTIPLY(self,pc):
-        print 'MULTIPLY',self.stack[-2],self.types[-2],'*',self.stack[-1],self.types[-1]
+        print('MULTIPLY',self.stack[-2],self.types[-2],'*',self.stack[-1],self.types[-1])
         return self.binop(pc,'*')
     def BINARY_DIVIDE(self,pc):
         return self.binop(pc,'/')
@@ -1121,7 +1123,7 @@ class CXXCoder(ByteCodeMeaning):
         # Fetch the constant
         k = self.consts[consti]
         t = type(k)
-        print 'LOAD_CONST',repr(k),t
+        print('LOAD_CONST',repr(k),t)
 
         # Fetch a None is just skipped
         if t is None:
@@ -1154,13 +1156,13 @@ class CXXCoder(ByteCodeMeaning):
     def LOAD_FAST(self,pc,var_num):
         v = self.stack[var_num]
         t = self.types[var_num]
-        print 'LOADFAST',var_num,v,t
+        print('LOADFAST',var_num,v,t)
         for VV, TT in zip(self.stack, self.types):
-            print VV,':',TT
+            print(VV,':',TT)
         if t is None:
             raise TypeError('%s used before set?' % v)
-            print self.__body
-            print 'PC',pc
+            print(self.__body)
+            print('PC',pc)
         self.push(v,t)
         return
 
@@ -1171,10 +1173,10 @@ class CXXCoder(ByteCodeMeaning):
     def LOAD_ATTR(self,pc,namei):
         v,t = self.pop()
         attr_name = self.codeobject.co_names[namei]
-        print 'LOAD_ATTR',namei,v,t,attr_name
+        print('LOAD_ATTR',namei,v,t,attr_name)
         aType,aCode = t.get_attribute(attr_name)
-        print 'ATTR',aType
-        print aCode
+        print('ATTR',aType)
+        print(aCode)
         lhs = self.unique()
         rhs = v
         lhsType = aType.cxxtype
@@ -1189,12 +1191,12 @@ class CXXCoder(ByteCodeMeaning):
     def STORE_ATTR(self,pc,namei):
         v,t = self.pop()
         attr_name = self.codeobject.co_names[namei]
-        print 'STORE_ATTR',namei,v,t,attr_name
+        print('STORE_ATTR',namei,v,t,attr_name)
         v2,t2 = self.pop()
-        print 'SA value',v2,t2
+        print('SA value',v2,t2)
         aType,aCode = t.set_attribute(attr_name)
-        print 'ATTR',aType
-        print aCode
+        print('ATTR',aType)
+        print(aCode)
         assert_(t2 is aType)
         rhs = v2
         lhs = v
@@ -1274,7 +1276,7 @@ class CXXCoder(ByteCodeMeaning):
     def STORE_FAST(self,pc,var_num):
 
         v,t = self.pop()
-        print 'STORE FAST',var_num,v,t
+        print('STORE FAST',var_num,v,t)
 
         save = self.stack[var_num]
         saveT = self.types[var_num]
@@ -1393,4 +1395,4 @@ class CXXCoder(ByteCodeMeaning):
             self.emit('return;')
         else:
             self.emit('return %s;'%v)
-        print 'return with',v
+        print('return with',v)

--- a/scipy/weave/c_spec.py
+++ b/scipy/weave/c_spec.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import, print_function
+
 import types
-from base_spec import base_converter
-import base_info
+from .base_spec import base_converter
+from . import base_info
 
 #----------------------------------------------------------------------------
 # C++ code template for converting code from python objects to C++ objects
@@ -294,7 +296,7 @@ num_to_c_types[type(1)]  = 'long'
 num_to_c_types[type(1.)] = 'double'
 num_to_c_types[type(1.+1.j)] = 'std::complex<double> '
 # !! hmmm. The following is likely unsafe...
-num_to_c_types[type(1L)]  = 'npy_longlong'
+num_to_c_types[long]  = 'npy_longlong'
 
 #----------------------------------------------------------------------------
 # Numeric array Python numeric --> C type maps
@@ -460,10 +462,10 @@ class catchall_converter(scxx_converter):
 
 if __name__ == "__main__":
     x = list_converter().type_spec("x",1)
-    print x.py_to_c_code()
-    print
-    print x.c_to_py_code()
-    print
-    print x.declaration_code(inline=1)
-    print
-    print x.cleanup_code()
+    print(x.py_to_c_code())
+    print()
+    print(x.c_to_py_code())
+    print()
+    print(x.declaration_code(inline=1))
+    print()
+    print(x.cleanup_code())

--- a/scipy/weave/catalog.py
+++ b/scipy/weave/catalog.py
@@ -30,6 +30,7 @@
     along with the path information to its module, are also stored in a
     persistent catalog for future use by python sessions.
 """
+from __future__ import absolute_import, print_function
 
 import os
 import sys
@@ -104,7 +105,7 @@ def unique_file(d,expr):
     #base = 'scipy_compile'
     base = expr_to_filename(expr)
     for i in xrange(1000000):
-        fname = base + `i`
+        fname = base + repr(i)
         if not (fname+'.cpp' in files or
                 fname+'.o' in files or
                 fname+'.so' in files or
@@ -182,7 +183,7 @@ def default_dir():
         except KeyError:
             pass
 
-        temp_dir = `os.getuid()` + '_' + python_name
+        temp_dir = repr(os.getuid()) + '_' + python_name
         path_candidates.append(os.path.join(tempfile.gettempdir(), temp_dir))
     else:
         path_candidates.append(os.path.join(tempfile.gettempdir(),
@@ -200,8 +201,8 @@ def default_dir():
             break
 
     if not writable:
-        print 'warning: default directory is not write accessible.'
-        print 'default:', path
+        print('warning: default directory is not write accessible.')
+        print('default:', path)
 
     # Cache the default dir path so that this function returns quickly after
     # being called once (nothing in it should change after the first call)
@@ -224,8 +225,8 @@ def default_temp_dir():
     if not os.path.exists(path):
         os.makedirs(path, mode=0o700)
     if not is_writable(path):
-        print 'warning: default directory is not write accessible.'
-        print 'default:', path
+        print('warning: default directory is not write accessible.')
+        print('default:', path)
     return path
 
 
@@ -554,14 +555,14 @@ class catalog(object):
         try:
             writable_cat = get_catalog(catalog_path,'w')
         except:
-            print 'warning: unable to repair catalog entry\n %s\n in\n %s' % \
-                  (code,catalog_path)
+            print('warning: unable to repair catalog entry\n %s\n in\n %s' % \
+                  (code,catalog_path))
             # shelve doesn't guarantee flushing, so it's safest to explicitly
             # close the catalog
             writable_cat.close()
             return
         if code in writable_cat:
-            print 'repairing catalog by removing key'
+            print('repairing catalog by removing key')
             del writable_cat[code]
 
         # it is possible that the path key doesn't exist (if the function
@@ -665,7 +666,7 @@ class catalog(object):
         if cat is None:
             cat_dir = default_dir()
             cat_file = catalog_path(cat_dir)
-            print 'problems with default catalog -- removing'
+            print('problems with default catalog -- removing')
             import glob
             files = glob.glob(cat_file+'*')
             for f in files:

--- a/scipy/weave/common_info.py
+++ b/scipy/weave/common_info.py
@@ -4,8 +4,9 @@
         swig pointer (old style) conversion support
 
 """
+from __future__ import absolute_import, print_function
 
-import base_info
+from . import base_info
 
 module_support_code = \
 """
@@ -123,7 +124,7 @@ class inline_info(base_info.base_info):
 # installations. New style swig pointers are not yet supported.
 #----------------------------------------------------------------------------
 
-import swigptr
+from . import swigptr
 swig_support_code = swigptr.swigptr_code
 
 class swig_info(base_info.base_info):

--- a/scipy/weave/converters.py
+++ b/scipy/weave/converters.py
@@ -1,8 +1,9 @@
 """ converters.py
 """
+from __future__ import absolute_import, print_function
 
-import common_info
-import c_spec
+from . import common_info
+from . import c_spec
 
 #----------------------------------------------------------------------------
 # The "standard" conversion classes
@@ -25,7 +26,7 @@ default = [c_spec.int_converter(),
 # converter list.
 #----------------------------------------------------------------------------
 try:
-    import standard_array_spec
+    from . import standard_array_spec
     default.append(standard_array_spec.array_converter())
 except ImportError:
     pass
@@ -35,7 +36,7 @@ except ImportError:
 # converter list.
 #----------------------------------------------------------------------------
 try:
-    import numpy_scalar_spec
+    from . import numpy_scalar_spec
     default.append(numpy_scalar_spec.numpy_complex_scalar_converter())
 except ImportError:
     pass
@@ -45,7 +46,7 @@ except ImportError:
 #----------------------------------------------------------------------------
 
 try:
-    import vtk_spec
+    from . import vtk_spec
     default.insert(0,vtk_spec.vtk_converter())
 except IndexError:
     pass
@@ -68,7 +69,7 @@ standard_info += [x.generate_build_info() for x in default]
 # !! only available if numerix is installed !!
 #----------------------------------------------------------------------------
 try:
-    import blitz_spec
+    from . import blitz_spec
     blitz = [blitz_spec.array_converter()] + default
     #-----------------------------------
     # Add "sentinal" catchall converter

--- a/scipy/weave/cpp_namespace_spec.py
+++ b/scipy/weave/cpp_namespace_spec.py
@@ -5,6 +5,7 @@
     class ft_converter(cpp_namespace_converter):
         namespace = 'ft::'
 """
+from __future__ import absolute_import, print_function
 
 from weave import common_info
 from weave import  base_info

--- a/scipy/weave/examples/array3d.py
+++ b/scipy/weave/examples/array3d.py
@@ -4,6 +4,7 @@ converters and the other shows how it can be done without using blitz
 by accessing the numpy array data directly.
 
 """
+from __future__ import absolute_import, print_function
 
 import scipy.weave as weave
 from scipy.weave import converters
@@ -91,13 +92,13 @@ def blitz_inline(arr):
 
 def main():
     arr = create_array()
-    print "numpy:"
-    print arr
+    print("numpy:")
+    print(arr)
 
-    print "Pure Inline:"
+    print("Pure Inline:")
     pure_inline(arr)
 
-    print "Blitz Inline:"
+    print("Blitz Inline:")
     blitz_inline(arr)
 
 

--- a/scipy/weave/examples/binary_search.py
+++ b/scipy/weave/examples/binary_search.py
@@ -14,6 +14,7 @@
 # Note -- really need to differentiate between conversion errors and
 # run time errors.  This would reduce useless compiles and provide a
 # more intelligent control of things.
+from __future__ import absolute_import, print_function
 
 import sys
 sys.path.insert(0,'..')
@@ -142,13 +143,13 @@ def py_int_search(seq, t):
 import time
 
 def search_compare(a,n):
-    print 'Binary search for %d items in %d length list of integers:'%(n,m)
+    print('Binary search for %d items in %d length list of integers:'%(n,m))
     t1 = time.time()
     for i in range(n):
         py_int_search(a,i)
     t2 = time.time()
     py = (t2-t1)
-    print ' speed in python:', (t2 - t1)
+    print(' speed in python:', (t2 - t1))
 
     # bisect
     t1 = time.time()
@@ -156,8 +157,8 @@ def search_compare(a,n):
         bisect(a,i)
     t2 = time.time()
     bi = (t2-t1) +1e-20 # protect against div by zero
-    print ' speed of bisect:', bi
-    print ' speed up: %3.2f' % (py/bi)
+    print(' speed of bisect:', bi)
+    print(' speed up: %3.2f' % (py/bi))
 
     # get it in cache
     c_int_search(a,i)
@@ -166,8 +167,8 @@ def search_compare(a,n):
         c_int_search(a,i,chk=1)
     t2 = time.time()
     sp = (t2-t1)+1e-20 # protect against div by zero
-    print ' speed in c:',sp
-    print ' speed up: %3.2f' % (py/sp)
+    print(' speed in c:',sp)
+    print(' speed up: %3.2f' % (py/sp))
 
     # get it in cache
     c_int_search(a,i)
@@ -176,8 +177,8 @@ def search_compare(a,n):
         c_int_search(a,i,chk=0)
     t2 = time.time()
     sp = (t2-t1)+1e-20 # protect against div by zero
-    print ' speed in c(no asserts):',sp
-    print ' speed up: %3.2f' % (py/sp)
+    print(' speed in c(no asserts):',sp)
+    print(' speed up: %3.2f' % (py/sp))
 
     # get it in cache
     c_int_search_scxx(a,i)
@@ -186,8 +187,8 @@ def search_compare(a,n):
         c_int_search_scxx(a,i,chk=1)
     t2 = time.time()
     sp = (t2-t1)+1e-20 # protect against div by zero
-    print ' speed for scxx:',sp
-    print ' speed up: %3.2f' % (py/sp)
+    print(' speed for scxx:',sp)
+    print(' speed up: %3.2f' % (py/sp))
 
     # get it in cache
     c_int_search_scxx(a,i)
@@ -196,8 +197,8 @@ def search_compare(a,n):
         c_int_search_scxx(a,i,chk=0)
     t2 = time.time()
     sp = (t2-t1)+1e-20 # protect against div by zero
-    print ' speed for scxx(no asserts):',sp
-    print ' speed up: %3.2f' % (py/sp)
+    print(' speed for scxx(no asserts):',sp)
+    print(' speed up: %3.2f' % (py/sp))
 
     # get it in cache
     a = array(a)
@@ -209,8 +210,8 @@ def search_compare(a,n):
             c_array_int_search(a,i)
         t2 = time.time()
         sp = (t2-t1)+1e-20 # protect against div by zero
-        print ' speed in c(numpy arrays):',sp
-        print ' speed up: %3.2f' % (py/sp)
+        print(' speed in c(numpy arrays):',sp)
+        print(' speed up: %3.2f' % (py/sp))
     except:
         pass
 
@@ -220,6 +221,6 @@ if __name__ == "__main__":
     a = range(m)
     n = 50000
     search_compare(a,n)
-    print 'search(a,3450)', c_int_search(a,3450), py_int_search(a,3450), bisect(a,3450)
-    print 'search(a,-1)', c_int_search(a,-1), py_int_search(a,-1), bisect(a,-1)
-    print 'search(a,10001)', c_int_search(a,10001), py_int_search(a,10001),bisect(a,10001)
+    print('search(a,3450)', c_int_search(a,3450), py_int_search(a,3450), bisect(a,3450))
+    print('search(a,-1)', c_int_search(a,-1), py_int_search(a,-1), bisect(a,-1))
+    print('search(a,10001)', c_int_search(a,10001), py_int_search(a,10001),bisect(a,10001))

--- a/scipy/weave/examples/cast_copy_transpose.py
+++ b/scipy/weave/examples/cast_copy_transpose.py
@@ -13,6 +13,7 @@
 #  speed up: 3.48
 #  inplace transpose c: 0.129999995232
 #  speed up: 6.70
+from __future__ import absolute_import, print_function
 
 import numpy
 from numpy import *
@@ -138,14 +139,14 @@ import time
 def compare(m,n):
     a = ones((n,n),float64)
     type = float32
-    print 'Cast/Copy/Transposing (%d,%d)array %d times' % (n,n,m)
+    print('Cast/Copy/Transposing (%d,%d)array %d times' % (n,n,m))
     t1 = time.time()
     for i in range(m):
         for i in range(n):
             b = _castCopyAndTranspose(type,a)
     t2 = time.time()
     py = (t2-t1)
-    print ' speed in python:', (t2 - t1)/m
+    print(' speed in python:', (t2 - t1)/m)
 
 
     # load into cache
@@ -155,8 +156,8 @@ def compare(m,n):
         for i in range(n):
             b = cast_copy_transpose(type,a)
     t2 = time.time()
-    print ' speed in c (blitz):',(t2 - t1)/ m
-    print ' speed up   (blitz): %3.2f' % (py/(t2-t1))
+    print(' speed in c (blitz):',(t2 - t1)/ m)
+    print(' speed up   (blitz): %3.2f' % (py/(t2-t1)))
 
     # load into cache
     b = cast_copy_transpose2(type,a)
@@ -165,8 +166,8 @@ def compare(m,n):
         for i in range(n):
             b = cast_copy_transpose2(type,a)
     t2 = time.time()
-    print ' speed in c (pointers):',(t2 - t1)/ m
-    print ' speed up   (pointers): %3.2f' % (py/(t2-t1))
+    print(' speed in c (pointers):',(t2 - t1)/ m)
+    print(' speed up   (pointers): %3.2f' % (py/(t2-t1)))
 
     # inplace tranpose
     b = _inplace_transpose(a)
@@ -175,8 +176,8 @@ def compare(m,n):
         for i in range(n):
             b = _inplace_transpose(a)
     t2 = time.time()
-    print ' inplace transpose c:',(t2 - t1)/ m
-    print ' speed up: %3.2f' % (py/(t2-t1))
+    print(' inplace transpose c:',(t2 - t1)/ m)
+    print(' speed up: %3.2f' % (py/(t2-t1)))
 
 if __name__ == "__main__":
     m,n = 1,500

--- a/scipy/weave/examples/dict_sort.py
+++ b/scipy/weave/examples/dict_sort.py
@@ -12,6 +12,7 @@
 #     speed in c (scxx): 0.200000047684
 #     speed up: 1.25
 #    [0, 1, 2, 3, 4]
+from __future__ import absolute_import, print_function
 
 import sys
 sys.path.insert(0,'..')
@@ -77,32 +78,32 @@ def sortedDictValues3(adict):
 import time
 
 def sort_compare(a,n):
-    print 'Dict sort of %d items for %d iterations:'%(len(a),n)
+    print('Dict sort of %d items for %d iterations:'%(len(a),n))
     t1 = time.time()
     for i in range(n):
         b=sortedDictValues3(a)
     t2 = time.time()
     py = (t2-t1)
-    print ' speed in python:', (t2 - t1)
-    print b[:5]
+    print(' speed in python:', (t2 - t1))
+    print(b[:5])
 
     b=c_sort(a)
     t1 = time.time()
     for i in range(n):
         b=c_sort(a)
     t2 = time.time()
-    print ' speed in c (Python API):',(t2 - t1)
-    print ' speed up: %3.2f' % (py/(t2-t1))
-    print b[:5]
+    print(' speed in c (Python API):',(t2 - t1))
+    print(' speed up: %3.2f' % (py/(t2-t1)))
+    print(b[:5])
 
     b=c_sort2(a)
     t1 = time.time()
     for i in range(n):
         b=c_sort2(a)
     t2 = time.time()
-    print ' speed in c (scxx):',(t2 - t1)
-    print ' speed up: %3.2f' % (py/(t2-t1))
-    print b[:5]
+    print(' speed in c (scxx):',(t2 - t1))
+    print(' speed up: %3.2f' % (py/(t2-t1)))
+    print(b[:5])
 
 def setup_dict(m):
     " does insertion order matter?"

--- a/scipy/weave/examples/fibonacci.py
+++ b/scipy/weave/examples/fibonacci.py
@@ -9,6 +9,7 @@
 #  speed in c: 5.00000715256e-005
 #  speed up: 10.42
 # fib(30) 832040 832040 832040 832040
+from __future__ import absolute_import, print_function
 
 import sys
 sys.path.insert(0,'..')
@@ -98,13 +99,13 @@ def py_fib2(a):
 import time
 
 def recurse_compare(n):
-    print 'Recursively computing the first %d fibonacci numbers:' % n
+    print('Recursively computing the first %d fibonacci numbers:' % n)
     t1 = time.time()
     for i in range(n):
         py_fib1(i)
     t2 = time.time()
     py = t2- t1
-    print ' speed in python:', t2 - t1
+    print(' speed in python:', t2 - t1)
 
     #load into cache
     c_fib1(i)
@@ -112,18 +113,18 @@ def recurse_compare(n):
     for i in range(n):
         c_fib1(i)
     t2 = time.time()
-    print ' speed in c:',t2 - t1
-    print ' speed up: %3.2f' % (py/(t2-t1))
+    print(' speed in c:',t2 - t1)
+    print(' speed up: %3.2f' % (py/(t2-t1)))
 
 def loop_compare(m,n):
-    print 'Looping to compute the first %d fibonacci numbers:' % n
+    print('Looping to compute the first %d fibonacci numbers:' % n)
     t1 = time.time()
     for i in range(m):
         for i in range(n):
             py_fib2(i)
     t2 = time.time()
     py = (t2-t1)
-    print ' speed in python:', (t2 - t1)/m
+    print(' speed in python:', (t2 - t1)/m)
 
     #load into cache
     c_fib2(i)
@@ -132,12 +133,12 @@ def loop_compare(m,n):
         for i in range(n):
             c_fib2(i)
     t2 = time.time()
-    print ' speed in c:',(t2 - t1)/ m
-    print ' speed up: %3.2f' % (py/(t2-t1))
+    print(' speed in c:',(t2 - t1)/ m)
+    print(' speed up: %3.2f' % (py/(t2-t1)))
 
 if __name__ == "__main__":
     n = 30
     recurse_compare(n)
     m= 1000
     loop_compare(m,n)
-    print 'fib(30)', c_fib1(30),py_fib1(30),c_fib2(30),py_fib2(30)
+    print('fib(30)', c_fib1(30),py_fib1(30),c_fib2(30),py_fib2(30))

--- a/scipy/weave/examples/functional.py
+++ b/scipy/weave/examples/functional.py
@@ -7,6 +7,7 @@
 #       speed up: 0.666666666667
 #       c speed: 0.0200001001358
 #       speed up: 1.99998807913
+from __future__ import absolute_import, print_function
 
 import sys
 sys.path.insert(0,'..')
@@ -59,9 +60,9 @@ def c_list_map2(func,seq):
 
 def main():
     seq = ['aa','bbb','cccc']
-    print 'desired:', map(len,seq)
-    print 'actual:', c_list_map(len,seq)
-    print 'actual2:', c_list_map2(len,seq)
+    print('desired:', map(len,seq))
+    print('actual:', c_list_map(len,seq))
+    print('actual2:', c_list_map2(len,seq))
 
 def time_it(m,n):
     import time
@@ -71,7 +72,7 @@ def time_it(m,n):
         result = map(len,seq)
     t2 = time.time()
     py = t2 - t1
-    print 'python speed:', py
+    print('python speed:', py)
 
     #load cache
     result = c_list_map(len,seq)
@@ -80,8 +81,8 @@ def time_it(m,n):
         result = c_list_map(len,seq)
     t2 = time.time()
     c = t2-t1
-    print 'SCXX speed:', c
-    print 'speed up:', py / c
+    print('SCXX speed:', c)
+    print('speed up:', py / c)
 
     #load cache
     result = c_list_map2(len,seq)
@@ -90,8 +91,8 @@ def time_it(m,n):
         result = c_list_map2(len,seq)
     t2 = time.time()
     c = t2-t1
-    print 'c speed:', c
-    print 'speed up:', py / c
+    print('c speed:', c)
+    print('speed up:', py / c)
 
 if __name__ == "__main__":
     main()

--- a/scipy/weave/examples/increment_example.py
+++ b/scipy/weave/examples/increment_example.py
@@ -3,6 +3,8 @@
 #from weave import ext_tools
 
 # use the following so that development version is used.
+from __future__ import absolute_import, print_function
+
 import sys
 sys.path.insert(0,'..')
 import ext_tools
@@ -33,5 +35,5 @@ if __name__ == "__main__":
         build_increment_ext()
         import increment_ext
     a = 1
-    print 'a, a+1:', a, increment_ext.increment(a)
-    print 'a, a+2:', a, increment_ext.increment_by_2(a)
+    print('a, a+1:', a, increment_ext.increment(a))
+    print('a, a+2:', a, increment_ext.increment_by_2(a))

--- a/scipy/weave/examples/md5_speed.py
+++ b/scipy/weave/examples/md5_speed.py
@@ -27,6 +27,8 @@ their strings.  Yeah, the expected result, but it never hurts
 to check...
 
 """
+from __future__ import absolute_import, print_function
+
 import random, md5, time, cStringIO
 
 def speed(n,m):
@@ -35,7 +37,7 @@ def speed(n,m):
     for i in range(m):
         q= md5.new(s).digest()
     t2 = time.time()
-    print (t2 - t1) / m
+    print((t2 - t1) / m)
 
 #speed(50,1e6)
 
@@ -58,14 +60,14 @@ def md5_dict(lst):
         key= md5.new(s).digest()
         catalog[key] = None
     t2 = time.time()
-    print 'md5 build(len,sec,per):', len(lst), t2 - t1, (t2-t1)/len(lst)
+    print('md5 build(len,sec,per):', len(lst), t2 - t1, (t2-t1)/len(lst))
 
     t1 = time.time()
     for s in lst:
         key= md5.new(s).digest()
         val = catalog[key]
     t2 = time.time()
-    print 'md5 retrv(len,sec,per):', len(lst), t2 - t1, (t2-t1)/len(lst)
+    print('md5 retrv(len,sec,per):', len(lst), t2 - t1, (t2-t1)/len(lst))
 
 def std_dict(lst):
     catalog = {}
@@ -73,13 +75,13 @@ def std_dict(lst):
     for s in lst:
         catalog[s] = None
     t2 = time.time()
-    print 'std build(len,sec,per):', len(lst), t2 - t1, (t2-t1)/len(lst)
+    print('std build(len,sec,per):', len(lst), t2 - t1, (t2-t1)/len(lst))
 
     t1 = time.time()
     for s in lst:
         val = catalog[s]
     t2 = time.time()
-    print 'std retrv(len,sec,per):', len(lst), t2 - t1, (t2-t1)/len(lst)
+    print('std retrv(len,sec,per):', len(lst), t2 - t1, (t2-t1)/len(lst))
 
 def run(m=200,n=10):
     lst = generate_random(m,n)

--- a/scipy/weave/examples/object.py
+++ b/scipy/weave/examples/object.py
@@ -3,6 +3,8 @@
     Note: std::cout type operations currently crash python...
           Not sure what is up with this...
 """
+from __future__ import absolute_import, print_function
+
 import scipy.weave as weave
 
 #----------------------------------------------------------------------------
@@ -34,7 +36,7 @@ code = """
        return_val = result;
        """
 
-print 'initial, inc(2), set(5)/get:', weave.inline(code,['obj'])
+print('initial, inc(2), set(5)/get:', weave.inline(code,['obj']))
 
 #----------------------------------------------------------------------------
 # indexing of values.
@@ -53,4 +55,4 @@ code = """
            obj[i] = "goodbye";
        """
 weave.inline(code,['obj'])
-print "obj with new values:", obj
+print("obj with new values:", obj)

--- a/scipy/weave/examples/print_example.py
+++ b/scipy/weave/examples/print_example.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import sys
 sys.path.insert(0,'..')
 import inline_tools
@@ -5,10 +7,10 @@ import inline_tools
 import time
 
 def print_compare(n):
-    print 'Printing %d integers:'%n
+    print('Printing %d integers:'%n)
     t1 = time.time()
     for i in range(n):
-        print i,
+        print(i, end=' ')
     t2 = time.time()
     py = (t2-t1)
 
@@ -18,9 +20,9 @@ def print_compare(n):
     for i in range(n):
         inline_tools.inline('printf("%d",i);',['i'])
     t2 = time.time()
-    print ' speed in python:', py
-    print ' speed in c:',(t2 - t1)
-    print ' speed up: %3.2f' % (py/(t2-t1))
+    print(' speed in python:', py)
+    print(' speed in c:',(t2 - t1))
+    print(' speed up: %3.2f' % (py/(t2-t1)))
 
 def cout_example(lst):
     # get it in cache
@@ -34,7 +36,7 @@ def cout_example(lst):
 if __name__ == "__main__":
     n = 3000
     print_compare(n)
-    print "calling cout with integers:"
+    print("calling cout with integers:")
     cout_example([1,2,3])
-    print "calling cout with strings:"
+    print("calling cout with strings:")
     cout_example(['a','bb', 'ccc'])

--- a/scipy/weave/examples/py_none.py
+++ b/scipy/weave/examples/py_none.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 # This tests the amount of overhead added for inline() function calls.
 # It isn't a "real world" test, but is somewhat informative.
 # C:\home\ej\wrk\scipy\weave\examples>python py_none.py
@@ -19,13 +21,13 @@ for i in range(n):
     py_func()
 t2 = time.time()
 py_time = t2 - t1
-print 'python:', py_time
+print('python:', py_time)
 
 inline("",[])
 t1 = time.time()
 for i in range(n):
     inline("",[])
 t2 = time.time()
-print 'inline:', (t2-t1)
-print 'speed up:', py_time/(t2-t1)
-print 'or (more likely) slow down:', (t2-t1)/py_time
+print('inline:', (t2-t1))
+print('speed up:', py_time/(t2-t1))
+print('or (more likely) slow down:', (t2-t1)/py_time)

--- a/scipy/weave/examples/ramp.py
+++ b/scipy/weave/examples/ramp.py
@@ -14,6 +14,7 @@
     arr[500]: 0.0500050005001
 
 """
+from __future__ import absolute_import, print_function
 
 import time
 import scipy.weave as weave
@@ -81,8 +82,8 @@ def main():
         Ramp(arr, N_array, 0.0, 1.0)
     t2 = time.time()
     py_time = (t2 - t1) * ratio
-    print 'python (seconds*ratio):', py_time
-    print 'arr[500]:', arr[500]
+    print('python (seconds*ratio):', py_time)
+    print('arr[500]:', arr[500])
 
     arr1 = array([0]*N_array,float)
     # First call compiles function or loads from cache.
@@ -93,8 +94,8 @@ def main():
         Ramp_numeric1(arr1, 0.0, 1.0)
     t2 = time.time()
     c_time = (t2 - t1)
-    print 'compiled numeric1 (seconds, speed up):', c_time, py_time/ c_time
-    print 'arr[500]:', arr1[500]
+    print('compiled numeric1 (seconds, speed up):', c_time, py_time/ c_time)
+    print('arr[500]:', arr1[500])
 
     arr2 = array([0]*N_array,float)
     # First call compiles function or loads from cache.
@@ -105,8 +106,8 @@ def main():
         Ramp_numeric2(arr2, 0.0, 1.0)
     t2 = time.time()
     c_time = (t2 - t1)
-    print 'compiled numeric2 (seconds, speed up):', c_time, py_time/ c_time
-    print 'arr[500]:', arr2[500]
+    print('compiled numeric2 (seconds, speed up):', c_time, py_time/ c_time)
+    print('arr[500]:', arr2[500])
 
     arr3 = [0]*N_array
     # First call compiles function or loads from cache.
@@ -117,8 +118,8 @@ def main():
         Ramp_list1(arr3, 0.0, 1.0)
     t2 = time.time()
     c_time = (t2 - t1) * ratio
-    print 'compiled list1 (seconds, speed up):', c_time, py_time/ c_time
-    print 'arr[500]:', arr3[500]
+    print('compiled list1 (seconds, speed up):', c_time, py_time/ c_time)
+    print('arr[500]:', arr3[500])
 
     arr4 = [0]*N_array
     # First call compiles function or loads from cache.
@@ -129,8 +130,8 @@ def main():
         Ramp_list2(arr4, 0.0, 1.0)
     t2 = time.time()
     c_time = (t2 - t1) * ratio
-    print 'compiled list4 (seconds, speed up):', c_time, py_time/ c_time
-    print 'arr[500]:', arr4[500]
+    print('compiled list4 (seconds, speed up):', c_time, py_time/ c_time)
+    print('arr[500]:', arr4[500])
 
 
 if __name__ == '__main__':

--- a/scipy/weave/examples/ramp2.py
+++ b/scipy/weave/examples/ramp2.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 #
 #        C:\home\eric\wrk\scipy\weave\examples>python ramp2.py
 #        python (seconds): 2.94499993324
@@ -42,9 +44,9 @@ def main():
         Ramp(arr, 10000, 0.0, 1.0)
     t2 = time.time()
     py_time = t2 - t1
-    print 'python (seconds):', py_time
-    print 'arr[500]:', arr[500]
-    print
+    print('python (seconds):', py_time)
+    print('arr[500]:', arr[500])
+    print()
 
     try:
         import ramp_ext
@@ -56,8 +58,8 @@ def main():
         ramp_ext.Ramp(arr, 0.0, 1.0)
     t2 = time.time()
     c_time = (t2 - t1)
-    print 'compiled numeric (seconds, speed up):', c_time, (py_time*10000/200.)/ c_time
-    print 'arr[500]:', arr[500]
+    print('compiled numeric (seconds, speed up):', c_time, (py_time*10000/200.)/ c_time)
+    print('arr[500]:', arr[500])
 
 if __name__ == '__main__':
     main()

--- a/scipy/weave/examples/support_code_example.py
+++ b/scipy/weave/examples/support_code_example.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import sys
 sys.path.insert(0,'..')
 import inline_tools
@@ -13,4 +15,4 @@ support_code = """
 a='some string'
 val = inline_tools.inline("return_val = length(a);",['a'],
                           support_code=support_code)
-print val
+print(val)

--- a/scipy/weave/examples/swig2_example.py
+++ b/scipy/weave/examples/swig2_example.py
@@ -23,6 +23,7 @@ Copyright (c) 2004, Prabhu Ramachandran
 License: BSD Style.
 
 """
+from __future__ import absolute_import, print_function
 
 # Import our SWIG2 wrapped library
 import swig2_ext

--- a/scipy/weave/examples/tuple_return.py
+++ b/scipy/weave/examples/tuple_return.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import sys
 sys.path.insert(0,'..')
 import inline_tools
@@ -23,7 +25,7 @@ def compare(m):
         py_result = multi_return()
     t2 = time.time()
     py = t2 - t1
-    print 'python speed:', py
+    print('python speed:', py)
 
     #load cache
     result = c_multi_return()
@@ -32,11 +34,11 @@ def compare(m):
         c_result = c_multi_return()
     t2 = time.time()
     c = t2-t1
-    print 'c speed:', c
-    print 'speed up:', py / c
-    print 'or slow down (more likely:', c / py
-    print 'python result:', py_result
-    print 'c result:', c_result
+    print('c speed:', c)
+    print('speed up:', py / c)
+    print('or slow down (more likely:', c / py)
+    print('python result:', py_result)
+    print('c result:', c_result)
 
 if __name__ == "__main__":
     compare(10000)

--- a/scipy/weave/examples/vq.py
+++ b/scipy/weave/examples/vq.py
@@ -1,5 +1,7 @@
 """
 """
+from __future__ import absolute_import, print_function
+
 # C:\home\ej\wrk\scipy\weave\examples>python vq.py
 # vq with 1000 observation, 10 features and 30 codes fo 100 iterations
 #  speed in python: 0.150119999647
@@ -193,23 +195,23 @@ def compare(m,Nobs,Ncodes,Nfeatures):
     codes = RandomArray.normal(0.,1.,(Ncodes,Nfeatures))
     import scipy.cluster.vq
     scipy.cluster.vq
-    print 'vq with %d observation, %d features and %d codes for %d iterations' % \
-           (Nobs,Nfeatures,Ncodes,m)
+    print('vq with %d observation, %d features and %d codes for %d iterations' % \
+           (Nobs,Nfeatures,Ncodes,m))
     t1 = time.time()
     for i in range(m):
         code,dist = scipy.cluster.vq.py_vq(obs,codes)
     t2 = time.time()
     py = (t2-t1)
-    print ' speed in python:', (t2 - t1)/m
-    print code[:2],dist[:2]
+    print(' speed in python:', (t2 - t1)/m)
+    print(code[:2],dist[:2])
 
     t1 = time.time()
     for i in range(m):
         code,dist = scipy.cluster.vq.vq(obs,codes)
     t2 = time.time()
-    print ' speed in standard c:', (t2 - t1)/m
-    print code[:2],dist[:2]
-    print ' speed up: %3.2f' % (py/(t2-t1))
+    print(' speed in standard c:', (t2 - t1)/m)
+    print(code[:2],dist[:2])
+    print(' speed up: %3.2f' % (py/(t2-t1)))
 
     # load into cache
     b = vq(obs,codes)
@@ -217,9 +219,9 @@ def compare(m,Nobs,Ncodes,Nfeatures):
     for i in range(m):
         code,dist = vq(obs,codes)
     t2 = time.time()
-    print ' speed inline/blitz:',(t2 - t1)/ m
-    print code[:2],dist[:2]
-    print ' speed up: %3.2f' % (py/(t2-t1))
+    print(' speed inline/blitz:',(t2 - t1)/ m)
+    print(code[:2],dist[:2])
+    print(' speed up: %3.2f' % (py/(t2-t1)))
 
     # load into cache
     b = vq2(obs,codes)
@@ -227,9 +229,9 @@ def compare(m,Nobs,Ncodes,Nfeatures):
     for i in range(m):
         code,dist = vq2(obs,codes)
     t2 = time.time()
-    print ' speed inline/blitz2:',(t2 - t1)/ m
-    print code[:2],dist[:2]
-    print ' speed up: %3.2f' % (py/(t2-t1))
+    print(' speed inline/blitz2:',(t2 - t1)/ m)
+    print(code[:2],dist[:2])
+    print(' speed up: %3.2f' % (py/(t2-t1)))
 
     # load into cache
     b = vq3(obs,codes)
@@ -237,9 +239,9 @@ def compare(m,Nobs,Ncodes,Nfeatures):
     for i in range(m):
         code,dist = vq3(obs,codes)
     t2 = time.time()
-    print ' speed using C arrays:',(t2 - t1)/ m
-    print code[:2],dist[:2]
-    print ' speed up: %3.2f' % (py/(t2-t1))
+    print(' speed using C arrays:',(t2 - t1)/ m)
+    print(code[:2],dist[:2])
+    print(' speed up: %3.2f' % (py/(t2-t1)))
 
 if __name__ == "__main__":
     compare(100,1000,30,10)

--- a/scipy/weave/examples/vtk_example.py
+++ b/scipy/weave/examples/vtk_example.py
@@ -37,6 +37,7 @@ Copyright (c) 2004, Prabhu Ramachandran
 License: BSD Style.
 
 """
+from __future__ import absolute_import, print_function
 
 import scipy.weave as weave
 import vtk
@@ -60,7 +61,7 @@ def simple_test():
 
     a = vtk.vtkStructuredPoints()
     a.SetOrigin(1.0, 1.0, 1.0)
-    print "sys.getrefcount(a) = ", sys.getrefcount(a)
+    print("sys.getrefcount(a) = ", sys.getrefcount(a))
 
     code=r"""
     printf("a->ClassName() == %s\n", a->GetClassName());
@@ -70,7 +71,7 @@ def simple_test():
     """
     weave.inline(code, ['a'], include_dirs=inc_dirs, library_dirs=lib_dirs)
 
-    print "sys.getrefcount(a) = ", sys.getrefcount(a)
+    print("sys.getrefcount(a) = ", sys.getrefcount(a))
 
 
 def array_test():
@@ -81,14 +82,14 @@ def array_test():
 
     # Create a large numpy array.
     arr = numpy.arange(0, 10, 0.0001, 'f')
-    print "Number of elements in array = ", arr.shape[0]
+    print("Number of elements in array = ", arr.shape[0])
 
     # Copy it into a vtkFloatArray and time the process.
     v_arr = vtk.vtkFloatArray()
     ts = time.clock()
     for i in range(arr.shape[0]):
         v_arr.InsertNextValue(arr[i])
-    print "Time taken to do it in pure Python =", time.clock() - ts
+    print("Time taken to do it in pure Python =", time.clock() - ts)
 
     # Now do the same thing using weave.inline
     v_arr = vtk.vtkFloatArray()
@@ -101,14 +102,14 @@ def array_test():
     # Note the use of the include_dirs and library_dirs.
     weave.inline(code, ['arr', 'v_arr'], include_dirs=inc_dirs,
                  library_dirs=lib_dirs)
-    print "Time taken to do it using Weave =", time.clock() - ts
+    print("Time taken to do it using Weave =", time.clock() - ts)
 
     # Test the data to make certain that we have done it right.
-    print "Checking data."
+    print("Checking data.")
     for i in range(v_arr.GetNumberOfTuples()):
         val = (v_arr.GetValue(i) -arr[i] )
         assert (val < 1e-6), "i = %d, val= %f"%(i, val)
-    print "OK."
+    print("OK.")
 
 
 if __name__ == "__main__":

--- a/scipy/weave/examples/wx_example.py
+++ b/scipy/weave/examples/wx_example.py
@@ -4,7 +4,7 @@
     or so have been translated into C++.
 
 """
-
+from __future__ import absolute_import, print_function
 
 import sys
 sys.path.insert(0,'..')

--- a/scipy/weave/examples/wx_speed.py
+++ b/scipy/weave/examples/wx_speed.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 """ Implements a fast replacement for calling DrawLines with an array as an
     argument.  It uses weave, so you'll need that installed.
 
@@ -129,7 +131,7 @@ if __name__ == '__main__':
 
         def OnPaint(self,event):
             w,h = self.GetSizeTuple()
-            print len(self.points)
+            print(len(self.points))
             dc = wxPaintDC(self)
             dc.BeginDrawing()
 
@@ -163,7 +165,7 @@ if __name__ == '__main__':
                 pt_copy[:,1] = next_y
                 phase += ang
             t2 = time.clock()
-            print 'Weave Polyline:', t2-t1
+            print('Weave Polyline:', t2-t1)
 
             t1 = time.clock()
             pt_copy = self.points.copy()
@@ -184,7 +186,7 @@ if __name__ == '__main__':
                 phase += ang
             t2 = time.clock()
             dc.SetPen(red_pen)
-            print 'wxPython DrawLines:', t2-t1
+            print('wxPython DrawLines:', t2-t1)
 
             dc.EndDrawing()
 

--- a/scipy/weave/ext_tools.py
+++ b/scipy/weave/ext_tools.py
@@ -1,11 +1,13 @@
+from __future__ import absolute_import, print_function
+
 import os
 import sys
 import re
 
-import catalog
-import build_tools
-import converters
-import base_spec
+from . import catalog
+from . import build_tools
+from . import converters
+from . import base_spec
 
 class ext_function_from_specs(object):
     def __init__(self,name,code_block,arg_specs):
@@ -179,7 +181,7 @@ class ext_function(ext_function_from_specs):
         ext_function_from_specs.__init__(self,name,code_block,arg_specs)
 
 
-import base_info
+from . import base_info
 
 class ext_module(object):
     def __init__(self,name,compiler=''):

--- a/scipy/weave/inline_tools.py
+++ b/scipy/weave/inline_tools.py
@@ -1,10 +1,12 @@
 # should re-write compiled functions to take a local and global dict
 # as input.
+from __future__ import absolute_import, print_function
+
 import sys
 import os
-import ext_tools
-import catalog
-import common_info
+from . import ext_tools
+from . import catalog
+from . import common_info
 
 from numpy.core.multiarray import _get_ndarray_c_version
 ndarray_api_version = '/* NDARRAY API VERSION %x */' % (_get_ndarray_c_version(),)
@@ -73,7 +75,7 @@ class inline_ext_function(ext_tools.ext_function):
         return "".join(arg_strings)
 
     def function_code(self):
-        from ext_tools import indent
+        from .ext_tools import indent
         decl_code = indent(self.arg_declaration_code(),4)
         cleanup_code = indent(self.arg_cleanup_code(),4)
         function_code = indent(self.code_block,4)
@@ -322,13 +324,13 @@ def inline(code,arg_names=[],local_dict = None, global_dict = None,
         try:
             results = apply(function_cache[code],(local_dict,global_dict))
             return results
-        except TypeError, msg:
+        except TypeError as msg:
             msg = str(msg).strip()
             if msg[:16] == "Conversion Error":
                 pass
             else:
                 raise TypeError(msg)
-        except NameError, msg:
+        except NameError as msg:
             msg = str(msg).strip()
             if msg[:16] == "Conversion Error":
                 pass
@@ -367,13 +369,13 @@ def attempt_function_call(code,local_dict,global_dict):
     try:
         results = apply(function_cache[code],(local_dict,global_dict))
         return results
-    except TypeError, msg:
+    except TypeError as msg:
         msg = str(msg).strip()
         if msg[:16] == "Conversion Error":
             pass
         else:
             raise TypeError(msg)
-    except NameError, msg:
+    except NameError as msg:
         msg = str(msg).strip()
         if msg[:16] == "Conversion Error":
             pass
@@ -389,7 +391,7 @@ def attempt_function_call(code,local_dict,global_dict):
             function_catalog.fast_cache(code,func)
             function_cache[code] = func
             return results
-        except TypeError, msg: # should specify argument types here.
+        except TypeError as msg: # should specify argument types here.
             # This should really have its own error type, instead of
             # checking the beginning of the message, but I don't know
             # how to define that yet.
@@ -398,7 +400,7 @@ def attempt_function_call(code,local_dict,global_dict):
                 pass
             else:
                 raise TypeError(msg)
-        except NameError, msg:
+        except NameError as msg:
             msg = str(msg).strip()
             if msg[:16] == "Conversion Error":
                 pass
@@ -429,7 +431,7 @@ def inline_function_code(code,arg_names,local_dict=None,
     ext_func = inline_ext_function('compiled_func',code,arg_names,
                                    local_dict,global_dict,auto_downcast,
                                    type_converters = type_converters)
-    import build_tools
+    from . import build_tools
     compiler = build_tools.choose_compiler(compiler)
     ext_func.set_compiler(compiler)
     return ext_func.function_code()
@@ -474,7 +476,7 @@ def compile_function(code,arg_names,local_dict,global_dict,
     # it's nice to let the users know when anything gets compiled, as the
     # slowdown is very noticeable.
     if verbose > 0:
-        print '<weave: compiling>'
+        print('<weave: compiling>')
 
     # compile code in correct location, with the given compiler and verbosity
     # setting.  All input keywords are passed through to distutils
@@ -485,7 +487,7 @@ def compile_function(code,arg_names,local_dict,global_dict,
     # the directory where it lives is in the python path.
     try:
         sys.path.insert(0,storage_dir)
-        exec 'import ' + module_name
+        exec('import ' + module_name)
         func = eval(module_name+'.compiled_func')
     finally:
         del sys.path[0]

--- a/scipy/weave/md5_load.py
+++ b/scipy/weave/md5_load.py
@@ -1,6 +1,7 @@
 # Import correct md5, irrespective of the Python version
 #
 # `hashlib` was introduced in 2.5, deprecating `md5`
+from __future__ import absolute_import, print_function
 
 try:
     from hashlib import *

--- a/scipy/weave/numpy_scalar_spec.py
+++ b/scipy/weave/numpy_scalar_spec.py
@@ -1,8 +1,10 @@
 """ Converters for all of NumPy's scalar types such as
     int32, float32, complex128, etc.
 """
+from __future__ import absolute_import, print_function
+
 import numpy
-import c_spec
+from . import c_spec
 
 class numpy_complex_scalar_converter(c_spec.complex_converter):
     """ Handles conversion of all the NumPy complex types.

--- a/scipy/weave/platform_info.py
+++ b/scipy/weave/platform_info.py
@@ -4,6 +4,7 @@
     keep the object files and shared libaries straight when
     multiple platforms share the same file system.
 """
+from __future__ import absolute_import, print_function
 
 import os, sys, subprocess
 
@@ -227,10 +228,10 @@ if __name__ == "__main__":
     print
     """
     path = get_compiler_dir('gcc')
-    print 'gcc path:', path
-    print
+    print('gcc path:', path)
+    print()
     try:
         path = get_compiler_dir('msvc')
-        print 'gcc path:', path
+        print('gcc path:', path)
     except ValueError:
         pass

--- a/scipy/weave/setup.py
+++ b/scipy/weave/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import absolute_import, print_function
 
 from os.path import join
 
@@ -14,7 +15,7 @@ def configuration(parent_package='',top_path=None):
 
 if __name__ == '__main__':
     from numpy.distutils.core import setup
-    from weave_version import weave_version
+    from .weave_version import weave_version
     setup(version = weave_version,
           description = "Tools for inlining C/C++ in Python",
           author = "Eric Jones",

--- a/scipy/weave/setupscons.py
+++ b/scipy/weave/setupscons.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import absolute_import, print_function
 
 from os.path import join
 
@@ -14,7 +15,7 @@ def configuration(parent_package='',top_path=None):
 
 if __name__ == '__main__':
     from numpy.distutils.core import setup
-    from weave_version import weave_version
+    from .weave_version import weave_version
     setup(version = weave_version,
           description = "Tools for inlining C/C++ in Python",
           author = "Eric Jones",

--- a/scipy/weave/size_check.py
+++ b/scipy/weave/size_check.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 from numpy import ones, ndarray, array, asarray, concatenate, zeros, shape, \
          alltrue, equal, divide, arccos, arcsin, arctan, cos, cosh, \
          sin, sinh, exp, ceil, floor, fabs, log, log10, sqrt, argmin, \
@@ -27,8 +29,8 @@ def time_it():
     for i in range(N):
         passed = check_expr(expr,locals())
     t2 = time.time()
-    print 'time per call:', (t2 - t1)/N
-    print 'passed:', passed
+    print('time per call:', (t2 - t1)/N)
+    print('passed:', passed)
 
 def check_expr(expr,local_vars,global_vars={}):
     """ Currently only checks expressions (not suites).

--- a/scipy/weave/slice_handler.py
+++ b/scipy/weave/slice_handler.py
@@ -1,4 +1,6 @@
-from ast_tools import token, symbol, ast_to_string, match, atom_list
+from __future__ import absolute_import, print_function
+
+from .ast_tools import token, symbol, ast_to_string, match, atom_list
 
 def slice_ast_to_dict(ast_seq):
     sl_vars = {}
@@ -52,7 +54,7 @@ def build_slice_atom(slice_vars, position):
     else:
         begin = slice_vars['begin'].strip()
         if begin[0] == '-':
-            slice_vars['begin'] = 'N' + slice_vars['var']+`position`+begin;
+            slice_vars['begin'] = 'N' + slice_vars['var']+repr(position)+begin;
 
         end = slice_vars['end'].strip()
         if end != '_end' and end[0] != '-':

--- a/scipy/weave/standard_array_spec.py
+++ b/scipy/weave/standard_array_spec.py
@@ -1,5 +1,7 @@
-from c_spec import common_base_converter
-from c_spec import num_to_c_types
+from __future__ import absolute_import, print_function
+
+from .c_spec import common_base_converter
+from .c_spec import num_to_c_types
 import numpy
 
 num_typecode = {}

--- a/scipy/weave/swig2_spec.py
+++ b/scipy/weave/swig2_spec.py
@@ -74,10 +74,11 @@ to consider when using the swig2_converter.
 
 Prabhu Ramachandran <prabhu_r@users.sf.net>
 """
+from __future__ import absolute_import, print_function
 
 import sys
-from c_spec import common_base_converter
-import swigptr2
+from .c_spec import common_base_converter
+from . import swigptr2
 
 
 #----------------------------------------------------------------------
@@ -209,8 +210,8 @@ class swig2_converter(common_base_converter):
         elif nver == 1:
             return versions[0]
         else:
-            print "WARNING: Multiple SWIG versions detected.  No version was"
-            print "explicitly specified.  Using the highest possible version."
+            print("WARNING: Multiple SWIG versions detected.  No version was")
+            print("explicitly specified.  Using the highest possible version.")
             return max(versions)
 
     def init_info(self, runtime=0):
@@ -315,7 +316,7 @@ class swig2_converter(common_base_converter):
         else:
             # if there isn't a class_name, we don't want the
             # support_code to be included
-            import base_info
+            from . import base_info
             res = base_info.base_info()
         return res
 

--- a/scipy/weave/swigptr.py
+++ b/scipy/weave/swigptr.py
@@ -1,4 +1,5 @@
 # swigptr.py
+from __future__ import absolute_import, print_function
 
 swigptr_code = """
 

--- a/scipy/weave/swigptr2.py
+++ b/scipy/weave/swigptr2.py
@@ -4,6 +4,7 @@
 # it has been hand edited for brevity.
 #
 # Prabhu Ramachandran <prabhu_r@users.sf.net>
+from __future__ import absolute_import, print_function
 
 ######################################################################
 # This is for SWIG-1.3.x where x < 22.

--- a/scipy/weave/tests/scxx_timings.py
+++ b/scipy/weave/tests/scxx_timings.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import weave
 import time
 
@@ -35,31 +37,31 @@ def time_list_append(Na):
     """ Compare the list append method from scxx to using the Python API
         directly.
     """
-    print 'list appending times:',
+    print('list appending times:', end=' ')
 
     a = []
     t1 = time.time()
     list_append_c(a,Na)
     t2 = time.time()
-    print 'py api: ', t2 - t1, '<note: first time takes longer -- repeat below>'
+    print('py api: ', t2 - t1, '<note: first time takes longer -- repeat below>')
 
     a = []
     t1 = time.time()
     list_append_c(a,Na)
     t2 = time.time()
-    print 'py api: ', t2 - t1
+    print('py api: ', t2 - t1)
 
     a = []
     t1 = time.time()
     list_append_scxx(a,Na)
     t2 = time.time()
-    print 'scxx:   ', t2 - t1
+    print('scxx:   ', t2 - t1)
 
     a = []
     t1 = time.time()
     list_append_c(a,Na)
     t2 = time.time()
-    print 'python: ', t2 - t1
+    print('python: ', t2 - t1)
 
 #----------------------------------------------------------------------------
 #
@@ -94,35 +96,35 @@ def time_list_copy(N):
     """ Compare the list append method from scxx to using the Python API
         directly.
     """
-    print 'list copy times:',
+    print('list copy times:', end=' ')
 
     a = [0] * N
     b = [1] * N
     t1 = time.time()
     list_copy_c(a,b)
     t2 = time.time()
-    print 'py api: ', t2 - t1, '<note: first time takes longer -- repeat below>'
+    print('py api: ', t2 - t1, '<note: first time takes longer -- repeat below>')
 
     a = [0] * N
     b = [1] * N
     t1 = time.time()
     list_copy_c(a,b)
     t2 = time.time()
-    print 'py api: ', t2 - t1
+    print('py api: ', t2 - t1)
 
     a = [0] * N
     b = [1] * N
     t1 = time.time()
     list_copy_scxx(a,b)
     t2 = time.time()
-    print 'scxx:   ', t2 - t1
+    print('scxx:   ', t2 - t1)
 
     a = [0] * N
     b = [1] * N
     t1 = time.time()
     list_copy_c(a,b)
     t2 = time.time()
-    print 'python: ', t2 - t1
+    print('python: ', t2 - t1)
 
 if __name__ == "__main__":
     #time_list_append(N)

--- a/scipy/weave/tests/test_ast_tools.py
+++ b/scipy/weave/tests/test_ast_tools.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 from numpy.testing import TestCase, assert_equal
 
 from scipy.weave import ast_tools

--- a/scipy/weave/tests/test_blitz_tools.py
+++ b/scipy/weave/tests/test_blitz_tools.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import os
 import time
 
@@ -62,7 +64,7 @@ class TestBlitz(TestCase):
     def generic_check(self,expr,arg_dict,type,size,mod_location):
         clean_result = array(arg_dict['result'],copy=1)
         t1 = time.time()
-        exec expr in globals(),arg_dict
+        exec(expr, globals(),arg_dict)
         t2 = time.time()
         standard = t2 - t1
         desired = arg_dict['result']
@@ -83,11 +85,11 @@ class TestBlitz(TestCase):
             assert_(allclose(abs(actual.ravel()),abs(desired.ravel()),1e-4,1e-6))
         except:
             diff = actual-desired
-            print diff[:4,:4]
-            print diff[:4,-4:]
-            print diff[-4:,:4]
-            print diff[-4:,-4:]
-            print sum(abs(diff.ravel()),axis=0)
+            print(diff[:4,:4])
+            print(diff[:4,-4:])
+            print(diff[-4:,:4])
+            print(diff[-4:,-4:])
+            print(sum(abs(diff.ravel()),axis=0))
             raise AssertionError
         return standard,compiled
 
@@ -100,7 +102,7 @@ class TestBlitz(TestCase):
         arg_list = harvest_variables(ast.tolist())
         #print arg_list
         all_sizes = [(10,10), (50,50), (100,100), (500,500), (1000,1000)]
-        print '\nExpression:', expr
+        print('\nExpression:', expr)
         for size in all_sizes:
             result = zeros(size,typ)
             arg_dict = {}
@@ -109,23 +111,23 @@ class TestBlitz(TestCase):
                 # set imag part of complex values to non-zero value
                 try:     arg_dict[arg].imag = arg_dict[arg].real
                 except:  pass
-            print 'Run:', size,typ
+            print('Run:', size,typ)
             standard,compiled = self.generic_check(expr,arg_dict,type,size,
                                                   mod_location)
             try:
                 speed_up = standard/compiled
             except:
                 speed_up = -1.
-            print "1st run(numpy.numerix,compiled,speed up):  %3.4f, %3.4f, " \
-                  "%3.4f" % (standard,compiled,speed_up)
+            print("1st run(numpy.numerix,compiled,speed up):  %3.4f, %3.4f, " \
+                  "%3.4f" % (standard,compiled,speed_up))
             standard,compiled = self.generic_check(expr,arg_dict,type,size,
                                                   mod_location)
             try:
                 speed_up = standard/compiled
             except:
                 speed_up = -1.
-            print "2nd run(numpy.numerix,compiled,speed up):  %3.4f, %3.4f, " \
-                  "%3.4f" % (standard,compiled,speed_up)
+            print("2nd run(numpy.numerix,compiled,speed up):  %3.4f, %3.4f, " \
+                  "%3.4f" % (standard,compiled,speed_up))
         cleanup_temp_dir(mod_location)
 
     #def test_simple_2d(self):

--- a/scipy/weave/tests/test_build_tools.py
+++ b/scipy/weave/tests/test_build_tools.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 # still needed
 # tests for MingW32Compiler
 # don't know how to test gcc_exists() and msvc_exists()...

--- a/scipy/weave/tests/test_c_spec.py
+++ b/scipy/weave/tests/test_c_spec.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import os
 import sys
 
@@ -81,7 +83,7 @@ class IntConverter(TestCase):
         test = ext_tools.ext_function('test',code,['a'])
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b=1
         test(b)
         try:
@@ -108,7 +110,7 @@ class IntConverter(TestCase):
         test = ext_tools.ext_function('test',code,['a'])
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b=1
         c = test(b)
 
@@ -149,7 +151,7 @@ class FloatConverter(TestCase):
         test = ext_tools.ext_function('test',code,['a'])
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b=1.
         test(b)
         try:
@@ -176,7 +178,7 @@ class FloatConverter(TestCase):
         test = ext_tools.ext_function('test',code,['a'])
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b=1.
         c = test(b)
         assert_( c == 3.)
@@ -216,7 +218,7 @@ class ComplexConverter(TestCase):
         test = ext_tools.ext_function('test',code,['a'])
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b=1.+1j
         test(b)
         try:
@@ -243,7 +245,7 @@ class ComplexConverter(TestCase):
         test = ext_tools.ext_function('test',code,['a'])
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b=1.+1j
         c = test(b)
         assert_( c == 3.+3j)
@@ -385,7 +387,7 @@ class StringConverter(TestCase):
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
 
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b='bub'
         test(b)
         try:
@@ -412,7 +414,7 @@ class StringConverter(TestCase):
         test = ext_tools.ext_function('test',code,['a'])
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b='bub'
         c = test(b)
         assert_( c == 'hello')
@@ -444,7 +446,7 @@ class ListConverter(TestCase):
         test = ext_tools.ext_function('test',code,['a'])
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b=[1,2]
         test(b)
         try:
@@ -472,7 +474,7 @@ class ListConverter(TestCase):
         test = ext_tools.ext_function('test',code,['a'])
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b=[1,2]
         c = test(b)
         assert_( c == ['hello'])
@@ -515,18 +517,18 @@ class ListConverter(TestCase):
         no_checking = ext_tools.ext_function('no_checking',code,['a'])
         mod.add_function(no_checking)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import with_cxx, no_checking'
+        exec('from ' + mod_name + ' import with_cxx, no_checking')
         import time
         t1 = time.time()
         sum1 = with_cxx(a)
         t2 = time.time()
-        print 'speed test for list access'
-        print 'compiler:',  self.compiler
-        print 'scxx:',  t2 - t1
+        print('speed test for list access')
+        print('compiler:',  self.compiler)
+        print('scxx:',  t2 - t1)
         t1 = time.time()
         sum2 = no_checking(a)
         t2 = time.time()
-        print 'C, no checking:',  t2 - t1
+        print('C, no checking:',  t2 - t1)
         sum3 = 0
         t1 = time.time()
         for i in a:
@@ -535,7 +537,7 @@ class ListConverter(TestCase):
             else:
                 sum3 -= i
         t2 = time.time()
-        print 'python:', t2 - t1
+        print('python:', t2 - t1)
         assert_( sum1 == sum2 and sum1 == sum3)
 
 
@@ -565,7 +567,7 @@ class TupleConverter(TestCase):
         test = ext_tools.ext_function('test',code,['a'])
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b=(1,2)
         test(b)
         try:
@@ -594,7 +596,7 @@ class TupleConverter(TestCase):
         test = ext_tools.ext_function('test',code,['a'])
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b=(1,2)
         c = test(b)
         assert_( c == ('hello',None))
@@ -632,7 +634,7 @@ class DictConverter(TestCase):
         test = ext_tools.ext_function('test',code,['a'])
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b={'y':2}
         test(b)
         try:
@@ -660,7 +662,7 @@ class DictConverter(TestCase):
         test = ext_tools.ext_function('test',code,['a'])
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b = {'z':2}
         c = test(b)
         assert_( c['hello'] == 5)
@@ -674,11 +676,11 @@ class DictConverter(TestCase):
 for _n in dir():
     if _n[-9:]=='Converter':
         if msvc_exists():
-            exec "class Test%sMsvc(%s):\n    compiler = 'msvc'"%(_n,_n)
+            exec("class Test%sMsvc(%s):\n    compiler = 'msvc'"%(_n,_n))
         else:
-            exec "class Test%sUnix(%s):\n    compiler = ''"%(_n,_n)
+            exec("class Test%sUnix(%s):\n    compiler = ''"%(_n,_n))
         if gcc_exists():
-            exec "class Test%sGcc(%s):\n    compiler = 'gcc'"%(_n,_n)
+            exec("class Test%sGcc(%s):\n    compiler = 'gcc'"%(_n,_n))
 
 # class TestMsvcIntConverter(TestIntConverter):
 #     compiler = 'msvc'

--- a/scipy/weave/tests/test_catalog.py
+++ b/scipy/weave/tests/test_catalog.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import sys
 import os
 
@@ -351,7 +353,7 @@ class TestCatalog(TestCase):
         #assert_(funcs2 == [os.chdir,os.abort,string.replace,string.find])
         #assert_(funcs3 == [re.purge,re.match,os.open,
         #                  os.access,string.atoi,string.atof])
-        assert_(funcs1[:2] == [string.lower,string.upper]),`funcs1`
+        assert_(funcs1[:2] == [string.lower,string.upper]),repr(funcs1)
         assert_(funcs2[:4] == [os.chdir,os.abort,string.replace,string.find])
         assert_(funcs3[:6] == [re.purge,re.match,os.open,
                           os.access,string.atoi,string.atof])

--- a/scipy/weave/tests/test_ext_tools.py
+++ b/scipy/weave/tests/test_ext_tools.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 
 from numpy.testing import TestCase, dec, assert_equal, assert_
 

--- a/scipy/weave/tests/test_inline_tools.py
+++ b/scipy/weave/tests/test_inline_tools.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 
 from numpy.testing import TestCase, dec, assert_
 

--- a/scipy/weave/tests/test_numpy_scalar_spec.py
+++ b/scipy/weave/tests/test_numpy_scalar_spec.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import os
 import sys
 
@@ -65,7 +67,7 @@ class NumpyComplexScalarConverter(TestCase):
         test = ext_tools.ext_function('test',code,['a'])
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b=numpy.complex128(1.+1j)
         test(b)
         try:
@@ -92,7 +94,7 @@ class NumpyComplexScalarConverter(TestCase):
         test = ext_tools.ext_function('test',code,['a'])
         mod.add_function(test)
         mod.compile(location = test_dir, compiler = self.compiler)
-        exec 'from ' + mod_name + ' import test'
+        exec('from ' + mod_name + ' import test')
         b=1.+1j
         c = test(b)
         assert_( c == 3.+3j)
@@ -115,11 +117,11 @@ class NumpyComplexScalarConverter(TestCase):
 for _n in dir():
     if _n[-9:]=='Converter':
         if msvc_exists():
-            exec "class Test%sMsvc(%s):\n    compiler = 'msvc'"%(_n,_n)
+            exec("class Test%sMsvc(%s):\n    compiler = 'msvc'"%(_n,_n))
         else:
-            exec "class Test%sUnix(%s):\n    compiler = ''"%(_n,_n)
+            exec("class Test%sUnix(%s):\n    compiler = ''"%(_n,_n))
         if gcc_exists():
-            exec "class Test%sGcc(%s):\n    compiler = 'gcc'"%(_n,_n)
+            exec("class Test%sGcc(%s):\n    compiler = 'gcc'"%(_n,_n))
 
 
 def setup_test_location():
@@ -145,14 +147,14 @@ def remove_file(name):
 
 if not msvc_exists():
     for _n in dir():
-        if _n[:8]=='TestMsvc': exec 'del '+_n
+        if _n[:8]=='TestMsvc': exec('del '+_n)
 else:
     for _n in dir():
-        if _n[:8]=='TestUnix': exec 'del '+_n
+        if _n[:8]=='TestUnix': exec('del '+_n)
 
 if not (gcc_exists() and msvc_exists() and sys.platform == 'win32'):
     for _n in dir():
-        if _n[:7]=='TestGcc': exec 'del '+_n
+        if _n[:7]=='TestGcc': exec('del '+_n)
 
 
 if __name__ == "__main__":

--- a/scipy/weave/tests/test_scxx_dict.py
+++ b/scipy/weave/tests/test_scxx_dict.py
@@ -1,5 +1,6 @@
 """ Test refcounting and behavior of SCXX.
 """
+from __future__ import absolute_import, print_function
 
 import sys
 

--- a/scipy/weave/tests/test_scxx_object.py
+++ b/scipy/weave/tests/test_scxx_object.py
@@ -1,5 +1,6 @@
 """ Test refcounting and behavior of SCXX.
 """
+from __future__ import absolute_import, print_function
 
 import sys
 
@@ -91,7 +92,7 @@ class TestObjectPrint(TestCase):
                val.print(file_imposter);
                """
         res = inline_tools.inline(code,['file_imposter'])
-        print file_imposter.getvalue()
+        print(file_imposter.getvalue())
         assert_equal(file_imposter.getvalue(),"'how now brown cow'")
 
 ##    @dec.slow
@@ -217,8 +218,8 @@ class TestObjectHasattr(TestCase):
                 res = inline_tools.inline(code,['a'])
             except:
                 after2 = sys.getrefcount(a)
-            print "after and after2 should be equal in the following"
-            print 'before, after, after2:', before, after, after2
+            print("after and after2 should be equal in the following")
+            print('before, after, after2:', before, after, after2)
             pass
 
     @dec.slow
@@ -531,7 +532,7 @@ class TestObjectStr(TestCase):
         res = inline_tools.inline('return_val = a.str();',['a'])
         second = sys.getrefcount(res)
         assert_equal(first,second)
-        print res
+        print(res)
         assert_equal(res,"str return")
 
 
@@ -759,7 +760,7 @@ class TestObjectHash(TestCase):
                 return 123
         a= Foo()
         res = inline_tools.inline('return_val = a.hash(); ',['a'])
-        print 'hash:', res
+        print('hash:', res)
         assert_equal(res,123)
 
 

--- a/scipy/weave/tests/test_scxx_sequence.py
+++ b/scipy/weave/tests/test_scxx_sequence.py
@@ -1,5 +1,6 @@
 """ Test refcounting and behavior of SCXX.
 """
+from __future__ import absolute_import, print_function
 
 import time
 import sys
@@ -126,19 +127,19 @@ class _TestSequenceBase(TestCase):
     @dec.slow
     def test_access_speed(self):
         N = 1000000
-        print '%s access -- val = a[i] for N =', (self.seq_type, N)
+        print('%s access -- val = a[i] for N =', (self.seq_type, N))
         a = self.seq_type([0]) * N
         val = 0
         t1 = time.time()
         for i in xrange(N):
             val = a[i]
         t2 = time.time()
-        print 'python1:', t2 - t1
+        print('python1:', t2 - t1)
         t1 = time.time()
         for i in a:
             val = i
         t2 = time.time()
-        print 'python2:', t2 - t1
+        print('python2:', t2 - t1)
 
         code = """
                const int N = a.length();
@@ -151,13 +152,13 @@ class _TestSequenceBase(TestCase):
         t1 = time.time()
         inline_tools.inline(code,['a'])
         t2 = time.time()
-        print 'weave:', t2 - t1
+        print('weave:', t2 - t1)
 
 # Fails
     @dec.slow
     def test_access_set_speed(self):
         N = 1000000
-        print '%s access/set -- b[i] = a[i] for N =', (self.seq_type,N)
+        print('%s access/set -- b[i] = a[i] for N =', (self.seq_type,N))
         a = self.seq_type([0]) * N
         # b is always a list so we can assign to it.
         b = [1] * N
@@ -165,7 +166,7 @@ class _TestSequenceBase(TestCase):
         for i in xrange(N):
             b[i] = a[i]
         t2 = time.time()
-        print 'python:', t2 - t1
+        print('python:', t2 - t1)
 
         a = self.seq_type([0]) * N
         b = [1] * N
@@ -179,7 +180,7 @@ class _TestSequenceBase(TestCase):
         t1 = time.time()
         inline_tools.inline(code,['a','b'])
         t2 = time.time()
-        print 'weave:', t2 - t1
+        print('weave:', t2 - t1)
         assert_(list(b) == list(a))
 
 
@@ -391,14 +392,14 @@ class TestList(_TestSequenceBase):
     @dec.slow
     def test_string_add_speed(self):
         N = 1000000
-        print 'string add -- b[i] = a[i] + "blah" for N =', N
+        print('string add -- b[i] = a[i] + "blah" for N =', N)
         a = ["blah"] * N
         desired = [1] * N
         t1 = time.time()
         for i in xrange(N):
             desired[i] = a[i] + 'blah'
         t2 = time.time()
-        print 'python:', t2 - t1
+        print('python:', t2 - t1)
 
         a = ["blah"] * N
         b = [1] * N
@@ -413,20 +414,20 @@ class TestList(_TestSequenceBase):
         t1 = time.time()
         inline_tools.inline(code,['a','b'])
         t2 = time.time()
-        print 'weave:', t2 - t1
+        print('weave:', t2 - t1)
         assert_(b == desired)
 
     @dec.slow
     def test_int_add_speed(self):
         N = 1000000
-        print 'int add -- b[i] = a[i] + 1 for N =', N
+        print('int add -- b[i] = a[i] + 1 for N =', N)
         a = [0] * N
         desired = [1] * N
         t1 = time.time()
         for i in xrange(N):
             desired[i] = a[i] + 1
         t2 = time.time()
-        print 'python:', t2 - t1
+        print('python:', t2 - t1)
 
         a = [0] * N
         b = [0] * N
@@ -440,7 +441,7 @@ class TestList(_TestSequenceBase):
         t1 = time.time()
         inline_tools.inline(code,['a','b'])
         t2 = time.time()
-        print 'weave:', t2 - t1
+        print('weave:', t2 - t1)
         assert_(b == desired)
 
 

--- a/scipy/weave/tests/test_size_check.py
+++ b/scipy/weave/tests/test_size_check.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import numpy as np
 from numpy.testing import TestCase, assert_array_equal, run_module_suite
 
@@ -208,7 +210,7 @@ class TestDummyArrayIndexing(TestCase):
         """ through a bunch of different indexes at it for good measure.
         """
         import random
-        choices = map(lambda x: `x`,range(50)) + range(50) + ['']*50
+        choices = map(lambda x: repr(x),range(50)) + range(50) + ['']*50
         for i in range(100):
             try:
                 beg = random.choice(choices)
@@ -229,7 +231,7 @@ class TestDummyArrayIndexing(TestCase):
         """ through a bunch of different indexes at it for good measure.
         """
         import random
-        choices = map(lambda x: `x`,range(50)) + range(50) + ['']*50
+        choices = map(lambda x: repr(x),range(50)) + range(50) + ['']*50
         for i in range(100):
             try:
                 beg = random.choice(choices)
@@ -248,7 +250,7 @@ class TestDummyArrayIndexing(TestCase):
         """ through a bunch of different indexes at it for good measure.
         """
         import random
-        choices = map(lambda x: `x`,range(50)) + range(50) + ['']*50
+        choices = map(lambda x: repr(x),range(50)) + range(50) + ['']*50
         for i in range(100):
             try:
                 idx = []
@@ -314,9 +316,9 @@ class TestExpressions(TestCase):
         try:
             assert_array_equal(actual,desired, expr)
         except:
-            print 'EXPR:',expr
-            print 'ACTUAL:',actual
-            print 'DESIRED:',desired
+            print('EXPR:',expr)
+            print('ACTUAL:',actual)
+            print('DESIRED:',desired)
     def generic_wrap(self,expr,**kw):
         try:
             x = np.array(eval(expr,kw))

--- a/scipy/weave/tests/test_slice_handler.py
+++ b/scipy/weave/tests/test_slice_handler.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 from numpy.testing import TestCase, assert_equal
 
 from scipy.weave import slice_handler

--- a/scipy/weave/tests/test_standard_array_spec.py
+++ b/scipy/weave/tests/test_standard_array_spec.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 from numpy import arange
 from numpy.testing import TestCase, assert_
 

--- a/scipy/weave/tests/weave_test_utils.py
+++ b/scipy/weave/tests/weave_test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import os
 
 def remove_whitespace(in_str):
@@ -57,7 +59,7 @@ def empty_temp_dir():
     import tempfile
     d = catalog.default_dir()
     for i in range(10000):
-        new_d = os.path.join(d,tempfile.gettempprefix()[1:-1]+`i`)
+        new_d = os.path.join(d,tempfile.gettempprefix()[1:-1]+repr(i))
         if not os.path.exists(new_d):
             os.mkdir(new_d)
             break
@@ -102,7 +104,7 @@ def move_file (src, dst,
     import errno
 
     if verbose:
-        print "moving %s -> %s" % (src, dst)
+        print("moving %s -> %s" % (src, dst))
 
     if dry_run:
         return dst
@@ -123,7 +125,8 @@ def move_file (src, dst,
     copy_it = 0
     try:
         os.rename(src, dst)
-    except os.error, (num, msg):
+    except os.error as xxx_todo_changeme1:
+        (num, msg) = xxx_todo_changeme1.args
         if num == errno.EXDEV:
             copy_it = 1
         else:
@@ -134,7 +137,8 @@ def move_file (src, dst,
         distutils.file_util.copy_file(src, dst)
         try:
             os.unlink(src)
-        except os.error, (num, msg):
+        except os.error as xxx_todo_changeme:
+            (num, msg) = xxx_todo_changeme.args
             try:
                 os.unlink(dst)
             except os.error:

--- a/scipy/weave/vtk_spec.py
+++ b/scipy/weave/vtk_spec.py
@@ -15,8 +15,9 @@ Authors:
   Prabhu Ramachandran <prabhu@aero.iitm.ernet.in>
   Eric Jones <eric@enthought.com>
 """
+from __future__ import absolute_import, print_function
 
-from c_spec import common_base_converter
+from .c_spec import common_base_converter
 
 
 vtk_py_to_c_template = \
@@ -99,7 +100,7 @@ class vtk_converter(common_base_converter):
         else:
             # if there isn't a class_name, we don't want the
             # we don't want the support_code to be included
-            import base_info
+            from . import base_info
             res = base_info.base_info()
         return res
 

--- a/scipy/weave/weave_version.py
+++ b/scipy/weave/weave_version.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 major = 0
 minor = 4
 micro = 9


### PR DESCRIPTION
It's still not a port to Python 3, but probably makes the fedora people happier: http://projects.scipy.org/scipy/ticket/1843
