### PR TITLE
Ticket1326 logpdf fails for beta and gamma

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -2190,8 +2190,9 @@ class beta_gen(rv_continuous):
         Px /= special.beta(a,b)
         return Px
     def _logpdf(self, x, a, b):
-        lPx = (b-1.0)*log(1.0-x) + (a-1.0)*log(x)
-        lPx -= log(special.beta(a,b))
+        logx = where((a==1) & (x==0),  0 , log(x)) 
+        log1mx = where((b==1) & (x==1), 0, log1p(-x))
+        lPx = (a-1)*logx + (b-1)*log1mx - log(special.beta(a,b)) 
         return lPx
     def _cdf(self, x, a, b):
         return special.btdtr(a,b,x)
@@ -3313,7 +3314,8 @@ class gamma_gen(rv_continuous):
     def _pdf(self, x, a):
         return exp(self._logpdf(x, a))
     def _logpdf(self, x, a):
-        return (a-1)*log(x) - x - gamln(a)
+        logx = where((a==1) & (x==0), 0, log(x))
+        return (a-1)*logx - x - gamln(a)
     def _cdf(self, x, a):
         return special.gammainc(a, x)
     def _ppf(self, q, a):

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -2186,13 +2186,10 @@ class beta_gen(rv_continuous):
     def _rvs(self, a, b):
         return mtrand.beta(a,b,self._size)
     def _pdf(self, x, a, b):
-        Px = (1.0-x)**(b-1.0) * x**(a-1.0)
-        Px /= special.beta(a,b)
-        return Px
+        return np.exp(self._logpdf(x, a, b))
     def _logpdf(self, x, a, b):
-        logx = where((a==1) & (x==0),  0 , log(x)) 
-        log1mx = where((b==1) & (x==1), 0, log1p(-x))
-        lPx = (a-1)*logx + (b-1)*log1mx - log(special.beta(a,b)) 
+        lPx = special.xlog1py(b-1.0, -x) + special.xlogy(a-1.0, x)
+        lPx -= special.betaln(a,b)
         return lPx
     def _cdf(self, x, a, b):
         return special.btdtr(a,b,x)
@@ -3314,8 +3311,7 @@ class gamma_gen(rv_continuous):
     def _pdf(self, x, a):
         return exp(self._logpdf(x, a))
     def _logpdf(self, x, a):
-        logx = where((a==1) & (x==0), 0, log(x))
-        return (a-1)*logx - x - gamln(a)
+        return special.xlogy(a-1.0, x) - x - gamln(a)
     def _cdf(self, x, a):
         return special.gammainc(a, x)
     def _ppf(self, q, a):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -410,9 +410,21 @@ class TestSkellam(TestCase):
 
         assert_almost_equal(stats.skellam.cdf(k, mu1, mu2), skcdfR, decimal=5)
 
-
+class TestBeta(TestCase):
+    def test_logpdf(self):
+        logpdf = stats.beta.logpdf(0,1,0.5)
+        assert_almost_equal(logpdf, -0.69314718056)
+        logpdf = stats.beta.logpdf(0,0.5,1)
+        assert_almost_equal(logpdf, np.inf)
+        
 class TestGamma(TestCase):
-
+    def test_logpdf(self):
+        ''' Regression test for Ticket #1326: 
+        cornercase avoid nan with 0*log(0) situation
+        '''
+        logpdf = stats.beta.logpdf(0,1,0.5)
+        assert_almost_equal(logpdf, 0)
+        
     def test_pdf(self):
         # a few test cases to compare with R
         pdf = stats.gamma.pdf(90, 394, scale=1./5)
@@ -420,8 +432,14 @@ class TestGamma(TestCase):
 
         pdf = stats.gamma.pdf(3, 10, scale=1./5)
         assert_almost_equal(pdf, 0.1620358)
-
-
+        
+    def test_logpdf(self):
+        ''' Regression test for Ticket #1326: 
+        cornercase avoid nan with 0*log(0) situation
+        '''
+        logpdf = stats.gamma.logpdf(0,1)
+        assert_almost_equal(logpdf, 0)
+        
 class TestChi2(TestCase):
     # regression tests after precision improvements, ticket:1041, not verified
     def test_precision(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -419,15 +419,8 @@ class TestBeta(TestCase):
         assert_almost_equal(logpdf, -0.69314718056)
         logpdf = stats.beta.logpdf(0,0.5,1)
         assert_almost_equal(logpdf, np.inf)
-        
-class TestGamma(TestCase):
-    def test_logpdf(self):
-        ''' Regression test for Ticket #1326: 
-        cornercase avoid nan with 0*log(0) situation
-        '''
-        logpdf = stats.beta.logpdf(0,1,0.5)
-        assert_almost_equal(logpdf, 0)
-        
+            
+class TestGamma(TestCase):    
     def test_pdf(self):
         # a few test cases to compare with R
         pdf = stats.gamma.pdf(90, 394, scale=1./5)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -412,6 +412,9 @@ class TestSkellam(TestCase):
 
 class TestBeta(TestCase):
     def test_logpdf(self):
+        ''' Regression test for Ticket #1326: 
+        cornercase avoid nan with 0*log(0) situation
+        '''
         logpdf = stats.beta.logpdf(0,1,0.5)
         assert_almost_equal(logpdf, -0.69314718056)
         logpdf = stats.beta.logpdf(0,0.5,1)


### PR DESCRIPTION
This PR fixes the three cornercases where 0*log(0) wrongfully was nan but should be:
 stats.gamma.logpdf(0,1)==  0
 stats.beta.logpdf(0,1,0.5)==-0.69314718056
 stats.beta.logpdf(0,0.5,1)==inf

See Ticket #1326
http://projects.scipy.org/scipy/ticket/1326
