### PR TITLE
Ticket 1471: Fix for stats.lognorm.pdf(0,s) reports nan

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -4165,8 +4165,9 @@ class lognorm_gen(rv_continuous):
     def _rvs(self, s):
         return exp(s * norm.rvs(size=self._size))
     def _pdf(self, x, s):
-        Px = exp(-log(x)**2 / (2*s**2))
-        return Px / (s*x*sqrt(2*pi))
+        return exp(self._logpdf(x, s))
+    def _logpdf(self, x, s):
+        return -log(x)**2 / (2*s**2) + np.where(x==0 , 0, - log(s*x*sqrt(2*pi)))
     def _cdf(self, x, s):
         return norm.cdf(log(x)/s)
     def _ppf(self, q, s):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -410,6 +410,13 @@ class TestSkellam(TestCase):
 
         assert_almost_equal(stats.skellam.cdf(k, mu1, mu2), skcdfR, decimal=5)
 
+class TestLognorm(TestCase):
+    def test_pdf(self):
+        ''' Regression test for Ticket #1471: 
+        cornercase avoid nan with 0/0 situation
+        '''
+        pdf = stats.lognorm.pdf(0,1)
+        assert_almost_equal(pdf, 0.0)
 
 class TestGamma(TestCase):
 


### PR DESCRIPTION
This PR fix the problem reported in Ticket 1471 that stats.lognorm.pdf(0,s) gave nan
See http://projects.scipy.org/scipy/ticket/1471
