### PR TITLE
ENH: signal: Add a 1D Savitzky-Golay filter

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -54,6 +54,7 @@ Filtering
    lfilter_zi    -- Compute an initial state zi for the lfilter function that
                  -- corresponds to the steady state of the step response.
    filtfilt      -- A forward-backward filter.
+   savgol_filter -- Filter a signal using the Savitzky-Golay filter.
 
    deconvolve    -- 1-d deconvolution using lfilter.
 
@@ -87,6 +88,8 @@ Filter design
                     -- FIR filter attenuation.
    kaiserord     -- Design a Kaiser window to limit ripple and width of
                     -- transition region.
+   savgol_coeffs -- Compute the FIR filter coefficients for a Savitzky-Golay
+                    -- filter.
    remez         -- Optimal FIR filter design.
 
    unique_roots  -- Unique roots and their multiplicities.
@@ -239,6 +242,7 @@ from .fir_filter_design import *
 from .ltisys import *
 from .windows import *
 from .signaltools import *
+from ._savitzky_golay import savgol_coeffs, savgol_filter
 from .spectral import *
 from .wavelets import *
 from ._peak_finding import *

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -1,0 +1,325 @@
+import numpy as np
+from scipy.linalg import lstsq
+from math import factorial
+from scipy.ndimage import convolve1d
+from _arraytools import axis_slice
+
+
+def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
+                  use="conv"):
+    """Compute the coefficients for a 1-d Savitzky-Golay FIR filter.
+
+    Parameters
+    ----------
+    window_length : int
+        The length of the filter window (i.e. the number of coefficients).
+        `window_length` must be an odd positive integer.
+    polyorder : int
+        The order of the polynomial used to fit the samples.
+        `polyorder` must be less than `window_length`.
+    deriv : int, optional
+        The order of the derivative to compute.  This must be a
+        nonnegative integer.  The default is 0, which means to filter
+        the data without differentiating.
+    delta : float, optional
+        The spacing of the samples to which the filter will be applied.
+        This is only used if deriv > 0.
+    pos : int or None, optional
+        If pos is not None, it specifies evaluation position within the
+        window.  The default is the middle of the window.
+    use : str, optional
+        Either 'conv' or 'dot'.  This argument chooses the order of the
+        coefficients.  The default is 'conv', which means that the
+        coefficients are ordered to be used in a convolution.  With
+        use='dot', the order is reversed, so the filter is applied by
+        dotting the coefficients with the data set.
+
+    Returns
+    -------
+    coeffs : 1-d ndarray
+        The filter coefficients.
+
+    References
+    ----------
+    A. Savitzky, M. J. E. Golay, Smoothing and Differentiation of Data by
+    Simplified Least Squares Procedures. Analytical Chemistry, 1964, 36 (8),
+    pp 1627-1639.
+
+    See Also
+    --------
+    savgol_filter
+
+    Examples
+    --------
+    >>> savgol_coeffs(5, 2)
+    array([-0.08571429,  0.34285714,  0.48571429,  0.34285714, -0.08571429])
+    >>> savgol_coeffs(5, 2, deriv=1)
+    array([  2.00000000e-01,   1.00000000e-01,   2.00607895e-16,
+            -1.00000000e-01,  -2.00000000e-01])
+
+    Note that use='dot' simply reverses the coefficients.
+
+    >>> savgol_coeffs(5, 2, pos=3)
+    array([ 0.25714286,  0.37142857,  0.34285714,  0.17142857, -0.14285714])
+    >>> savgol_coeffs(5, 2, pos=3, use='dot')
+    array([-0.14285714,  0.17142857,  0.34285714,  0.37142857,  0.25714286])
+
+    `x` contains data from the parabola x = t**2, sampled at
+    t = -1, 0, 1, 2, 3.  `c` holds the coefficients that will compute the
+    derivative at the last position.  When dotted with `x` the result should
+    be 6.
+
+    >>> x = array([-1, 0, 1, 4, 9])
+    >>> c = savgol_coeffs(5, 2, pos=4, deriv=1, use='dot')
+    >>> c.dot(x)
+    6.0000000000000018
+    """
+
+    # An alternative method for finding the coefficients when deriv=0 is
+    #    t = np.arange(window_length)
+    #    unit = (t == pos).astype(int)
+    #    coeffs = np.polyval(np.polyfit(t, unit, polyorder), t)
+    # The method implemented here is faster.
+
+    # To recreate the table of sample coefficients shown in the chapter on
+    # the Savitzy-Golay filter in the Numerical Recipes book, use
+    #    window_length = nL + nR + 1
+    #    pos = nL + 1
+    #    c = savgol_coeffs(window_length, M, pos=pos, use='dot')
+
+    if polyorder >= window_length:
+        raise ValueError("polyorder must be less than window_length.")
+
+    halflen, rem = divmod(window_length, 2)
+
+    if rem == 0:
+        raise ValueError("window_length must be odd.")
+
+    if pos is None:
+        pos = halflen
+
+    if not (0 <= pos < window_length):
+        raise ValueError("pos must be nonnegative and less than "
+                         "window_length.")
+
+    if use not in ['conv', 'dot']:
+        raise ValueError("`use` must be 'conv' or 'dot'")
+
+    # Form the design matrix A.  The columns of A are powers of the integers
+    # from -pos to window_length - pos - 1.  The powers (i.e. rows) range
+    # from 0 to polyorder.  (That is, A is a vandermonde matrix, but not
+    # necessarily square.)
+    x = np.arange(-pos, window_length - pos)
+    if use == "conv":
+        # Reverse so that result can be used in a convolution.
+        x = x[::-1]
+    order = np.arange(polyorder + 1).reshape(-1, 1)
+    A = x ** order
+
+    # y determines which order derivative is returned.
+    y = np.zeros(polyorder + 1)
+    # The coefficient assigned to y[deriv] scales the result to take into
+    # account the order of the derivative and the sample spacing.
+    y[deriv] = factorial(deriv) / (delta ** deriv)
+
+    # Find the least-squares solution of A*c = y
+    coeffs, _, _, _ = lstsq(A, y)
+
+    return coeffs
+
+
+def _polyder(p, m):
+    """Differentiate polynomials represented with coefficients.
+
+    p must be a 1D or 2D array.  In the 2D case, each column gives
+    the coefficients of a polynomial; the first row holds the coefficients
+    associated with the highest power.  m must be a nonnegative integer.
+    (numpy.polyder doesn't handle the 2D case.)
+    """
+
+    if m == 0:
+        result = p
+    else:
+        n = len(p)
+        if n <= m:
+            result = np.zeros_like(p[:1, ...])
+        else:
+            dp = p[:-m].copy()
+            for k in range(m):
+                rng = np.arange(n - k - 1, m - k - 1, -1)
+                dp *= rng.reshape((n - m,) + (1,) * (p.ndim - 1))
+            result = dp
+    return result
+
+
+def _fit_edge(x, window_start, window_stop, interp_start, interp_stop,
+              axis, polyorder, deriv, delta, y):
+    """
+    Given an n-d array`x` and the specification of a slice of `x` from
+    `window_start` to `window_stop` along `axis`, create an interpolating
+    polynomial of each 1-d slice, and evaluate that polynomial in the slice
+    from `interp_start` to `interp_stop`.  Put the result into the
+    corresponding slice of `y`.
+    """
+
+    # Get the edge into a (window_length, -1) array.
+    x_edge = axis_slice(x, start=window_start, stop=window_stop, axis=axis)
+    if axis == 0 or axis == -x.ndim:
+        xx_edge = x_edge
+        swapped = False
+    else:
+        xx_edge = x_edge.swapaxes(axis, 0)
+        swapped = True
+    xx_edge = xx_edge.reshape(xx_edge.shape[0], -1)
+
+    # Fit the edges.  poly_coeffs has shape (polyorder + 1, -1),
+    # where '-1' is the same as in xx_edge.
+    poly_coeffs = np.polyfit(np.arange(0, window_stop - window_start),
+                             xx_edge, polyorder)
+
+    if deriv > 0:
+        poly_coeffs = _polyder(poly_coeffs, deriv)
+
+    # Compute the interpolated values for the edge.
+    i = np.arange(interp_start - window_start, interp_stop - window_start)
+    values = np.polyval(poly_coeffs, i.reshape(-1, 1)) / (delta ** deriv)
+
+    # Now put the values into the appropriate slice of y.
+    # First reshape values to match y.
+    shp = list(y.shape)
+    shp[0], shp[axis] = shp[axis], shp[0]
+    values = values.reshape(interp_stop - interp_start, *shp[1:])
+    if swapped:
+        values = values.swapaxes(0, axis)
+    # Get a view of the data to be replaced by values.
+    y_edge = axis_slice(y, start=interp_start, stop=interp_stop, axis=axis)
+    y_edge[...] = values
+
+
+def _fit_edges_polyfit(x, window_length, polyorder, deriv, delta, axis, y):
+    """
+    Use polynomial interpolation of x at the low and high ends of the axis
+    to fill in the halflen values in y.
+
+    This function just calls _fit_edge twice, once for each end of the axis.
+    """
+    halflen = window_length // 2
+    _fit_edge(x, 0, window_length, 0, halflen, axis,
+              polyorder, deriv, delta, y)
+    n = x.shape[axis]
+    _fit_edge(x, n - window_length, n, n - halflen, n, axis,
+              polyorder, deriv, delta, y)
+
+
+def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
+                  axis=-1, mode='interp', cval=0.0):
+    """ Apply a Savitzky-Golay filter to an array.
+
+    This is a 1-d filter.  If `x`  has dimension greater than 1, `axis`
+    determines the axis along which the filter is applied.
+
+    Parameters
+    ----------
+    x : array_like
+        The data to be filtered.
+    window_length : int
+        The length of the filter window (i.e. the number of coefficients).
+        `window_length` must be a positive odd integer.
+    polyorder : int
+        The order of the polynomial used to fit the samples.
+        `polyorder` must be less than `window_length`.
+    deriv : int, optional
+        The order of the derivative to compute.  This must be a
+        nonnegative integer.  The default is 0, which means to filter
+        the data without differentiating.
+    delta : float, optional
+        The spacing of the samples to which the filter will be applied.
+        This is only used if deriv > 0.  Default is 1.0.
+    axis : int, optional
+        The axis of the array `x` along which the filter is to be applied.
+        Default is -1.
+    mode : str, optional
+        Must be 'mirror', 'constant', 'nearest' or 'interp'.  This
+        determines the type of extension to use for the padded signal to
+        which the filter is applied.  When `mode` is 'constant', the padding
+        value is given by `cval`.  See the Notes for more details on 'mirror',
+        'constant' and 'nearest'.
+        When the 'interp' mode is selected (the default), no extension
+        is used.  Instead, a degree `polyorder` polynomial is fit to the
+        last `window_length` values of the edges, and this polynomial is
+        used to evaluate the last `window_length // 2` output values.
+    cval : scalar, optional
+        Value to fill past the edges of the input if `mode` is 'constant'.
+        Default is 0.0.
+
+    Returns
+    -------
+    y : ndarray, same shape as `x`
+        The filtered data.
+
+    See Also
+    --------
+    savgol_coeffs
+
+    Notes
+    -----
+    Details on the `mode` options:
+
+        'mirror':
+            Repeats the values at the edges in reverse order.  The value
+            closest to the edge is not included.
+        'nearest':
+            The extension contains the nearest input value.
+        'constant':
+            The extension contains the value given by the `cval` argument.
+
+    For example, if the input is [1, 2, 3, 4, 5, 6, 7, 8], and
+    `window_length` is 7, the following shows the extended data for
+    the various `mode` options (assuming `cval` is 0)::
+
+        mode       |   Ext   |         Input          |   Ext
+        -----------+---------+------------------------+---------
+        'mirror'   | 4  3  2 | 1  2  3  4  5  6  7  8 | 7  6  5
+        'nearest'  | 1  1  1 | 1  2  3  4  5  6  7  8 | 8  8  8
+        'constant' | 0  0  0 | 1  2  3  4  5  6  7  8 | 0  0  0
+
+    Examples
+    --------
+    >>> np.set_printoptions(precision=2)  # For compact display.
+    >>> x = np.array([2, 2, 5, 2, 1, 0, 1, 4, 9])
+
+    Filter with a window length of 5 and a degree 2 polynomial.  Use
+    the defaults for all other parameters.
+
+    >>> y = savgol_filter(x, 5, 2)
+    array([ 1.66,  3.17,  3.54,  2.86,  0.66,  0.17,  1.  ,  4.  ,  9.  ])
+
+    Note that the last five values in x are samples of a parabola, so
+    when mode='interp' (the dedault) is used with polyorder=2, the last
+    three values are unchanged.  Compare that to, for example,
+    `mode='nearest'`:
+
+    >>> savgol_filter(x, 5, 2, mode='nearest')
+    array([ 1.74,  3.03,  3.54,  2.86,  0.66,  0.17,  1.  ,  4.6 ,  7.97])
+
+    """
+    if mode not in ["mirror", "constant", "nearest", "interp"]:
+        raise ValueError("mode must be 'mirror', 'constant', 'nearest' "
+                         "or 'interp'.")
+
+    # Multiply by 1.0 to ensure float without forcing float64.
+    x = 1.0 * np.asarray(x)
+
+    coeffs = savgol_coeffs(window_length, polyorder, deriv=deriv, delta=delta)
+
+    if mode == "interp":
+        # Do not pad.  Instead, for the elements within `window_length // 2`
+        # of the ends of the sequence, use the polynomial that is fitted to
+        # the last `window_length` elements.
+        y = convolve1d(x, coeffs, axis=axis, mode="constant")
+        _fit_edges_polyfit(x, window_length, polyorder, deriv, delta, axis, y)
+    else:
+        # Any mode other than 'interp' is passed on to ndimage.convolve1d.
+        y = convolve1d(x, coeffs, axis=axis, mode=mode, cval=cval)
+
+    return y

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -221,7 +221,9 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
     Parameters
     ----------
     x : array_like
-        The data to be filtered.
+        The data to be filtered.  If `x` is not a single or double precision
+        floating point array, it will be converted to type `numpy.float64`
+        before filtering.
     window_length : int
         The length of the filter window (i.e. the number of coefficients).
         `window_length` must be a positive odd integer.
@@ -307,8 +309,10 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
         raise ValueError("mode must be 'mirror', 'constant', 'nearest' "
                          "or 'interp'.")
 
-    # Multiply by 1.0 to ensure float without forcing float64.
-    x = 1.0 * np.asarray(x)
+    x = np.asarray(x)
+    # Ensure that x is either single or double precision floating point.
+    if x.dtype != np.float64 and x.dtype != np.float32:
+        x = x.astype(np.float64)
 
     coeffs = savgol_coeffs(window_length, polyorder, deriv=deriv, delta=delta)
 

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -69,7 +69,7 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     derivative at the last position.  When dotted with `x` the result should
     be 6.
 
-    >>> x = array([-1, 0, 1, 4, 9])
+    >>> x = array([1, 0, 1, 4, 9])
     >>> c = savgol_coeffs(5, 2, pos=4, deriv=1, use='dot')
     >>> c.dot(x)
     6.0000000000000018

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -155,7 +155,7 @@ def _polyder(p, m):
 def _fit_edge(x, window_start, window_stop, interp_start, interp_stop,
               axis, polyorder, deriv, delta, y):
     """
-    Given an n-d array`x` and the specification of a slice of `x` from
+    Given an n-d array `x` and the specification of a slice of `x` from
     `window_start` to `window_stop` along `axis`, create an interpolating
     polynomial of each 1-d slice, and evaluate that polynomial in the slice
     from `interp_start` to `interp_stop`.  Put the result into the

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -295,7 +295,7 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
     array([ 1.66,  3.17,  3.54,  2.86,  0.66,  0.17,  1.  ,  4.  ,  9.  ])
 
     Note that the last five values in x are samples of a parabola, so
-    when mode='interp' (the dedault) is used with polyorder=2, the last
+    when mode='interp' (the default) is used with polyorder=2, the last
     three values are unchanged.  Compare that to, for example,
     `mode='nearest'`:
 

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -1,0 +1,275 @@
+
+import numpy as np
+from numpy.testing import (run_module_suite, assert_allclose, assert_equal,
+                           assert_array_equal)
+
+from scipy.ndimage import convolve1d
+
+from scipy.signal import savgol_coeffs, savgol_filter
+from scipy.signal._savitzky_golay import _polyder
+
+
+def check_polyder(p, m, expected):
+    dp = _polyder(p, m)
+    assert_array_equal(dp, expected)
+
+
+def test_polyder():
+    cases = [
+        ([5], 0, [5]),
+        ([5], 1, [0]),
+        ([3, 2, 1], 0, [3, 2, 1]),
+        ([3, 2, 1], 1, [6, 2]),
+        ([3, 2, 1], 2, [6]),
+        ([3, 2, 1], 3, [0]),
+        ([[3, 2, 1], [5, 6, 7]], 0, [[3, 2, 1], [5, 6, 7]]),
+        ([[3, 2, 1], [5, 6, 7]], 1, [[6, 2], [10, 6]]),
+        ([[3, 2, 1], [5, 6, 7]], 2, [[6], [10]]),
+        ([[3, 2, 1], [5, 6, 7]], 3, [[0], [0]]),
+    ]
+    for p, m, expected in cases:
+        yield check_polyder, np.array(p).T, m, np.array(expected).T
+
+
+#--------------------------------------------------------------------
+# savgol_coeffs tests
+#--------------------------------------------------------------------
+
+def alt_sg_coeffs(window_length, polyorder, pos):
+    """This is an alternative implementation of the SG coefficients.
+
+    It uses numpy.polyfit and numpy.polyval.  The results should be
+    equivalent to those of savgol_coeffs(), but this implementation
+    is slower.
+
+    window_length should be odd.
+
+    """
+    if pos is None:
+        pos = window_length // 2
+    t = np.arange(window_length)
+    unit = (t == pos).astype(int)
+    h = np.polyval(np.polyfit(t, unit, polyorder), t)
+    return h
+
+
+def test_sg_coeffs_trivial():
+    # Test a trivial case of savgol_coeffs: polyorder = window_length - 1
+    h = savgol_coeffs(1, 0)
+    assert_allclose(h, [1])
+
+    h = savgol_coeffs(3, 2)
+    assert_allclose(h, [0, 1, 0], atol=1e-10)
+
+    h = savgol_coeffs(5, 4)
+    assert_allclose(h, [0, 0, 1, 0, 0], atol=1e-10)
+
+    h = savgol_coeffs(5, 4, pos=1)
+    assert_allclose(h, [0, 0, 0, 1, 0], atol=1e-10)
+
+    h = savgol_coeffs(5, 4, pos=1, use='dot')
+    assert_allclose(h, [0, 1, 0, 0, 0], atol=1e-10)
+
+
+def compare_coeffs_to_alt(window_length, order):
+    # For the given window_length and order, compare the results
+    # of savgol_coeffs and alt_sg_coeffs for pos from 0 to window_length - 1.
+    # Also include pos=None.
+    for pos in [None] + range(window_length):
+        h1 = savgol_coeffs(window_length, order, pos=pos, use='dot')
+        h2 = alt_sg_coeffs(window_length, order, pos=pos)
+        assert_allclose(h1, h2, atol=1e-10,
+                        err_msg=("window_length = %d, order = %d, pos = %s" %
+                                 (window_length, order, pos)))
+
+
+def test_sg_coeffs_compare():
+    # Compare savgol_coeffs() to alt_sg_coeffs().
+    for window_length in range(1, 8, 2):
+        for order in range(window_length):
+            yield compare_coeffs_to_alt, window_length, order
+
+
+def test_sg_coeffs_exact():
+    polyorder = 4
+    window_length = 9
+    halflen = window_length // 2
+
+    x = np.linspace(0, 21, 43)
+    delta = x[1] - x[0]
+
+    # The data is a cubic polynomial.  We'll use an order 4
+    # SG filter, so the filtered values should equal the input data
+    # (except within half window_length of the edges).
+    y = 0.5 * x ** 3 - x
+    h = savgol_coeffs(window_length, polyorder)
+    y0 = convolve1d(y, h)
+    assert_allclose(y0[halflen:-halflen], y[halflen:-halflen])
+
+    # Check the same input, but use deriv=1.  dy is the exact result.
+    dy = 1.5 * x ** 2 - 1
+    h = savgol_coeffs(window_length, polyorder, deriv=1, delta=delta)
+    y1 = convolve1d(y, h)
+    assert_allclose(y1[halflen:-halflen], dy[halflen:-halflen])
+
+    # Check the same input, but use deriv=2. d2y is the exact result.
+    d2y = 3.0 * x
+    h = savgol_coeffs(window_length, polyorder, deriv=2, delta=delta)
+    y2 = convolve1d(y, h)
+    assert_allclose(y2[halflen:-halflen], d2y[halflen:-halflen])
+
+
+def test_sg_coeffs_deriv():
+    # The data in `x` is a sampled parabola, so using savgol_coeffs with an
+    # order 2 or higher polynomial should give exact results.
+    i = np.array([-2.0, 0.0, 2.0, 4.0, 6.0])
+    x = i ** 2 / 4
+    dx = i / 2
+    d2x = 0.5 * np.ones_like(i)
+    for pos in range(x.size):
+        coeffs0 = savgol_coeffs(5, 3, pos=pos, delta=2.0, use='dot')
+        assert_allclose(coeffs0.dot(x), x[pos], atol=1e-10)
+        coeffs1 = savgol_coeffs(5, 3, pos=pos, delta=2.0, use='dot', deriv=1)
+        assert_allclose(coeffs1.dot(x), dx[pos], atol=1e-10)
+        coeffs2 = savgol_coeffs(5, 3, pos=pos, delta=2.0, use='dot', deriv=2)
+        assert_allclose(coeffs2.dot(x), d2x[pos], atol=1e-10)
+
+
+#--------------------------------------------------------------------
+# savgol_filter tests
+#--------------------------------------------------------------------
+
+
+def test_sg_filter_trivial():
+    """ Test some trivial edge cases for savgol_filter()."""
+    x = np.array([1.0])
+    y = savgol_filter(x, 1, 0)
+    assert_equal(y, [1.0])
+
+    # Input is a single value.  With a window length of 3 and polyorder 1,
+    # the value in y is from the straight-line fit of (-1,0), (0,3) and
+    # (1, 0) at 0. This is just the average of the three values, hence 1.0.
+    x = np.array([3.0])
+    y = savgol_filter(x, 3, 1, mode='constant')
+    assert_equal(y, [1.0])
+
+    x = np.array([3.0])
+    y = savgol_filter(x, 3, 1, mode='nearest')
+    assert_equal(y, [3.0])
+
+
+def test_sg_filter_basic():
+    # Some basic test cases for savgol_filter().
+    x = np.array([1.0, 2.0, 1.0])
+    y = savgol_filter(x, 3, 1, mode='constant')
+    assert_allclose(y, [1.0, 4.0 / 3, 1.0])
+
+    y = savgol_filter(x, 3, 1, mode='mirror')
+    assert_allclose(y, [5.0 / 3, 4.0 / 3, 5.0 / 3])
+
+
+def test_sg_filter_2d():
+    x = np.array([[1.0, 2.0, 1.0],
+                  [2.0, 4.0, 2.0]])
+    expected = np.array([[1.0, 4.0 / 3, 1.0],
+                         [2.0, 8.0 / 3, 2.0]])
+    y = savgol_filter(x, 3, 1, mode='constant')
+    assert_allclose(y, expected)
+
+    y = savgol_filter(x.T, 3, 1, mode='constant', axis=0)
+    assert_allclose(y, expected.T)
+
+
+def test_sg_filter_interp_edges():
+    # Another test with low degree polynomial data, for which we can easily
+    # give the exact results.  In this test, we use mode='interp', so
+    # savgol_filter should match the exact solution for the entire data set,
+    # including the edges.
+    t = np.linspace(-5, 5, 21)
+    delta = t[1] - t[0]
+    # Polynomial test data.
+    x = np.array([t,
+                  3 * t ** 2,
+                  t ** 3 - t])
+    dx = np.array([np.ones_like(t),
+                   6 * t,
+                   3 * t ** 2 - 1.0])
+    d2x = np.array([np.zeros_like(t),
+                    6 * np.ones_like(t),
+                    6 * t])
+
+    window_length = 7
+
+    y = savgol_filter(x, window_length, 3, axis=-1, mode='interp')
+    assert_allclose(y, x, atol=1e-12)
+
+    y1 = savgol_filter(x, window_length, 3, axis=-1, mode='interp',
+                       deriv=1, delta=delta)
+    assert_allclose(y1, dx, atol=1e-12)
+
+    y2 = savgol_filter(x, window_length, 3, axis=-1, mode='interp',
+                       deriv=2, delta=delta)
+    assert_allclose(y2, d2x, atol=1e-12)
+
+    # Transpose everything, and test again with axis=0.
+
+    x = x.T
+    dx = dx.T
+    d2x = d2x.T
+
+    y = savgol_filter(x, window_length, 3, axis=0, mode='interp')
+    assert_allclose(y, x, atol=1e-12)
+
+    y1 = savgol_filter(x, window_length, 3, axis=0, mode='interp',
+                       deriv=1, delta=delta)
+    assert_allclose(y1, dx, atol=1e-12)
+
+    y2 = savgol_filter(x, window_length, 3, axis=0, mode='interp',
+                       deriv=2, delta=delta)
+    assert_allclose(y2, d2x, atol=1e-12)
+
+
+def test_sg_filter_interp_edges_3d():
+    # Test mode='interp' with a 3-D array.
+    t = np.linspace(-5, 5, 21)
+    delta = t[1] - t[0]
+    x1 = np.array([t, -t])
+    x2 = np.array([t ** 2, 3 * t ** 2 + 5])
+    x3 = np.array([t ** 3, 2 * t ** 3 + t ** 2 - 0.5 * t])
+    dx1 = np.array([np.ones_like(t), -np.ones_like(t)])
+    dx2 = np.array([2 * t, 6 * t])
+    dx3 = np.array([3 * t ** 2, 6 * t ** 2 + 2 * t - 0.5])
+
+    # z has shape (3, 2, 21)
+    z = np.array([x1, x2, x3])
+    dz = np.array([dx1, dx2, dx3])
+
+    y = savgol_filter(z, 7, 3, axis=-1, mode='interp', delta=delta)
+    assert_allclose(y, z, atol=1e-10)
+
+    dy = savgol_filter(z, 7, 3, axis=-1, mode='interp', deriv=1, delta=delta)
+    assert_allclose(dy, dz, atol=1e-10)
+
+    # z has shape (3, 21, 2)
+    z = np.array([x1.T, x2.T, x3.T])
+    dz = np.array([dx1.T, dx2.T, dx3.T])
+
+    y = savgol_filter(z, 7, 3, axis=1, mode='interp', delta=delta)
+    assert_allclose(y, z, atol=1e-10)
+
+    dy = savgol_filter(z, 7, 3, axis=1, mode='interp', deriv=1, delta=delta)
+    assert_allclose(dy, dz, atol=1e-10)
+
+    # z has shape (21, 3, 2)
+    z = z.swapaxes(0, 1).copy()
+    dz = dz.swapaxes(0, 1).copy()
+
+    y = savgol_filter(z, 7, 3, axis=0, mode='interp', delta=delta)
+    assert_allclose(y, z, atol=1e-10)
+
+    dy = savgol_filter(z, 7, 3, axis=0, mode='interp', deriv=1, delta=delta)
+    assert_allclose(dy, dz, atol=1e-10)
+
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
This PR adds two functions to `scipy.signal`: `savgol_coeffs` and `savgol_filter`.   `savgol_coeffs` computes the coefficients of a Savitzky-Golay FIR filter, with a range of options.  `savgol_filter` applies a such a filter to a numpy array.  It provides several options for dealing with the edges of the data.

This PR is a significant update to the the first version that was here: https://github.com/scipy/scipy/pull/304
