### PR TITLE
bug fix for NetCDF endian problem (trac ticket #1720)

### DIFF
--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -290,7 +290,7 @@ class netcdf_file(object):
         if (typecode, size) not in REVERSE:
             raise ValueError("NetCDF 3 does not support type %s" % type)
 
-        data = empty(shape_, dtype=type)
+        data = empty(shape_, dtype=type.newbyteorder("B")) #convert to big endian always for NetCDF 3
         self.variables[name] = netcdf_variable(data, typecode, size, shape, dimensions)
         return self.variables[name]
 


### PR DESCRIPTION
This pull request is an attempt to fix the problem found in trac ticket #1720
 ( http://projects.scipy.org/scipy/ticket/1720 )

Changeset 76a983ec625 removed the explicit conversion of all outgoing
datatypes into big-endian format (e.g. see page 10 of
http://earthdata.nasa.gov/sites/default/files/esdswg/spg/rfc/esds-rfc-011/ESDS-RFC-011v1.00.pdf)

This changeset (eelsirhc/scipy@d2b5014c2a) converts the type to big-endian during the array creation in createVariable by calling the dtype.newbyteorder
function with the argument "B" for Big endian.
