### PR TITLE
Added boolean ndarray indexing for LIL matrix

### DIFF
--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -239,11 +239,28 @@ class lil_matrix(spmatrix):
         else:
             return index, slice(None)
 
+    def _boolean_to_array(self, i):
+        if i.ndim<2:
+            i = i.nonzero()
+        elif (i.shape[0]>self.shape[0] or i.shape[1]>self.shape[1] or
+              i.ndim>2):
+            raise IndexError('invalid index shape')
+        else:
+            i = i.nonzero()
+        return i
+
     def _index_to_arrays(self, i, j):
         if isinstance(i, np.ndarray) and i.dtype.kind=='b':
-            i = i.nonzero()
+            i = self._boolean_to_array(i)
+            if len(i)==2:
+                if isinstance(j, slice):
+                    j = i[1]
+
+                else:
+                    raise ValueError('too many incdices for array')
+            i = i[0]
         if isinstance(j, np.ndarray) and j.dtype.kind=='b':
-            j = j.nonzero()
+            j = self._boolean_to_array(j)[0]
 
         i_slice = isinstance(i, slice)
         if i_slice:

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -239,28 +239,28 @@ class lil_matrix(spmatrix):
         else:
             return index, slice(None)
 
-    def _boolean_to_array(self, i):
+    def _boolean_index_to_array(self, i):
         if i.ndim<2:
             i = i.nonzero()
-        elif (i.shape[0]>self.shape[0] or i.shape[1]>self.shape[1] or
-              i.ndim>2):
+        elif (i.shape[0] > self.shape[0] or i.shape[1] > self.shape[1] or
+              i.ndim > 2):
             raise IndexError('invalid index shape')
         else:
             i = i.nonzero()
         return i
 
     def _index_to_arrays(self, i, j):
-        if isinstance(i, np.ndarray) and i.dtype.kind=='b':
-            i = self._boolean_to_array(i)
+        if isinstance(i, np.ndarray) and i.dtype.kind == 'b':
+            i = self._boolean_index_to_array(i)
             if len(i)==2:
                 if isinstance(j, slice):
                     j = i[1]
 
                 else:
-                    raise ValueError('too many incdices for array')
+                    raise ValueError('too many indices for array')
             i = i[0]
-        if isinstance(j, np.ndarray) and j.dtype.kind=='b':
-            j = self._boolean_to_array(j)[0]
+        if isinstance(j, np.ndarray) and j.dtype.kind == 'b':
+            j = self._boolean_index_to_array(j)[0]
 
         i_slice = isinstance(i, slice)
         if i_slice:

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -240,6 +240,11 @@ class lil_matrix(spmatrix):
             return index, slice(None)
 
     def _index_to_arrays(self, i, j):
+        if isinstance(i, np.ndarray) and i.dtype.kind=='b':
+            i = i.nonzero()
+        if isinstance(j, np.ndarray) and j.dtype.kind=='b':
+            j = j.nonzero()
+
         i_slice = isinstance(i, slice)
         if i_slice:
             i = self._slicetoarange(i, self.shape[0])[:,None]

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1150,13 +1150,19 @@ class _TestFancyIndexing:
 
         assert_equal(A[I].todense(), B[I])
         assert_equal(A[:,J].todense(), B[:, J])
-        assert_equal(A[X], B[X])
+        assert_equal(A[X].todense(), B[X])
 
         I = np.array([True, False, True, True, False])
         J = np.array([False, True, True, False, True])
 
         assert_equal(A[I, J].todense(), B[I, J])
-        
+
+        Z = np.array(np.random.randint(0, 2, size=(5, 11)), dtype=bool)
+        Y = np.array(np.random.randint(0, 2, size=(6, 10)), dtype=bool)
+
+        assert_raises(IndexError, A.__getitem__, Z)
+        assert_raises(IndexError, A.__getitem__, Y)
+        assert_raises(ValueError, A.__getitem__, (X, 1))
 
 class _TestFancyIndexingAssign:
     def test_bad_index_assign(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1682,9 +1682,14 @@ class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False,
             SIJ = SIJ.todense()
         assert_equal(SIJ, D[I,J])
 
-    @dec.knownfailureif(True, "CSC not implemented")
+    @dec.knownfailureif(True, "CSR not implemented")
     def test_slicing_3(self):
         pass
+
+    @dec.knownfailureif(True, "CSR not implemented")
+    def test_fancy_indexing_boolean(self):
+        pass
+
 
 class TestCSC(sparse_test_class(slicing_assign=False, fancy_assign=False,
                                 fancy_multidim_indexing=False)):
@@ -1804,6 +1809,9 @@ class TestCSC(sparse_test_class(slicing_assign=False, fancy_assign=False,
     def test_slicing_3(self):
         pass
 
+    @dec.knownfailureif(True, "CSC not implemented")
+    def test_fancy_indexing_boolean(self):
+        pass
 
 class TestDOK(sparse_test_class(slicing=False,
                                 slicing_assign=False,

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1151,6 +1151,7 @@ class _TestFancyIndexing:
         assert_equal(A[I].todense(), B[I])
         assert_equal(A[:,J].todense(), B[:, J])
         assert_equal(A[X].todense(), B[X])
+        assert_equal(A[B>9].todense(), B[B>9])
 
         I = np.array([True, False, True, True, False])
         J = np.array([False, True, True, False, True])

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1138,6 +1138,25 @@ class _TestFancyIndexing:
         assert_raises(IndexError, S.__getitem__, (I_bad,J))
         assert_raises(IndexError, S.__getitem__, (I,J_bad))
 
+    def test_fancy_indexing_boolean(self):
+        random.seed(1234) # make runs repeatable
+
+        B = asmatrix(arange(50).reshape(5,10))
+        A = self.spmatrix( B )
+
+        I = np.array(np.random.randint(0, 2, size=5), dtype=bool)
+        J = np.array(np.random.randint(0, 2, size=10), dtype=bool)
+        X = np.array(np.random.randint(0, 2, size=(5, 10)), dtype=bool)
+
+        assert_equal(A[I].todense(), B[I])
+        assert_equal(A[:,J].todense(), B[:, J])
+        assert_equal(A[X], B[X])
+
+        I = np.array([True, False, True, True, False])
+        J = np.array([False, True, True, False, True])
+
+        assert_equal(A[I, J].todense(), B[I, J])
+        
 
 class _TestFancyIndexingAssign:
     def test_bad_index_assign(self):


### PR DESCRIPTION
I added a couple of lines to allow for indexing with boolean ndarrays. For the type testing, I'm using i.dtype.kind == 'b'. If anyone has a better method for type testing, please let me know. I wasn't able to find anything when I searched. I added a couple of tests comparing the sparse matrix class to the NumPy matrix indexing.
