### PR TITLE
Deprecate inconsistent behavior of fftconvolve valid mode in 0.12.x

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -77,7 +77,9 @@ def correlate(in1, in2, mode='full'):
     in1 : array_like
         First input.
     in2 : array_like
-        Second input. Should have the same number of dimensions as `in1`.
+        Second input. Should have the same number of dimensions as `in1`;
+        if sizes of `in1` and `in2` are not equal then `in1` has to be the
+        larger array.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
 
@@ -163,7 +165,9 @@ def fftconvolve(in1, in2, mode="full"):
     in1 : array_like
         First input.
     in2 : array_like
-        Second input. Should have the same number of dimensions as `in1`.
+        Second input. Should have the same number of dimensions as `in1`;
+        if sizes of `in1` and `in2` are not equal then `in1` has to be the
+        larger array.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
 
@@ -238,7 +242,9 @@ def convolve(in1, in2, mode='full'):
     in1 : array_like
         First input.
     in2 : array_like
-        Second input. Should have the same number of dimensions as `in1`.
+        Second input. Should have the same number of dimensions as `in1`;
+        if sizes of `in1` and `in2` are not equal then `in1` has to be the
+        larger array.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -201,7 +201,12 @@ def fftconvolve(in1, in2, mode="full"):
     size = s1 + s2 - 1
 
     if mode == "valid":
-        _check_valid_mode_shapes(s1, s2)
+        for d1, d2 in zip(s1, s2):
+            if not d1 >= d2:
+                warnings.warn("in1 should have at least as many items as in2 in "
+                              "every dimension for 'valid' mode.  In scipy "
+                              "0.13.0 this will raise an error",
+                              DeprecationWarning)
 
     # Always use 2**n-sized FFT
     fsize = 2 ** np.ceil(np.log2(size)).astype(int)
@@ -218,7 +223,7 @@ def fftconvolve(in1, in2, mode="full"):
     elif mode == "same":
         return _centered(ret, s1)
     elif mode == "valid":
-        return _centered(ret, s1 - s2 + 1)
+        return _centered(ret, abs(s1 - s2) + 1)
 
 
 def convolve(in1, in2, mode='full'):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -188,11 +188,11 @@ class TestFFTConvolve(TestCase):
         assert_array_almost_equal(c,d)
 
     def test_real_valid_mode(self):
+        # len(a) < len(b) deprecated in 0.12.0, removed for 0.13.0
         a = array([3,2,1])
         b = array([3,3,5,6,8,7,9,0,1])
-        def _test():
-            fftconvolve(a,b,'valid')
-        self.assertRaises(ValueError, _test)
+        assert_array_almost_equal(fftconvolve(a, b, 'valid'),
+                                  fftconvolve(b, a, 'valid'))
 
     def test_real_valid_mode2(self):
         a = array([3,3,5,6,8,7,9,0,1])


### PR DESCRIPTION
   DEP: deprecate behavior of valid mode in fftconvolve where inputs were switched

```
Note that this behavior was inconsistent with that of convolve.  In master the
same function is now used for all valid modes in signaltools, so they are
consistent.  In 66fe7c8929 @jseabold noted that outright making the change
caused an issue in statsmodels, so deprecation in 0.12.x is needed.
```

The second commit (doc update) should be applied to master as well.
