### PR TITLE
MAINT: optimize: remove some unused variables from show_options() in optimize.py

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2860,10 +2860,7 @@ def show_options(solver, method=None):
     solver = solver.lower()
     if solver not in ('minimize', 'root'):
         raise ValueError('Unknown solver.')
-    solver_header = (' ' * 4 + solver + "\n" + ' ' * 4 + '~' * len(solver))
 
-    notes_header = "Notes\n    -----"
-    all_doc = show_options.__doc__.split(notes_header)[1:]
     solvers_doc = [s.strip()
                    for s in show_options.__doc__.split('** ')[1:]]
     solver_doc = [s for s in solvers_doc


### PR DESCRIPTION
I think the deleted lines are left over from an earlier iteration of the code.
