### PR TITLE
fixed bug in clpmn violating array bounds

### DIFF
--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -272,7 +272,7 @@ C
         ZS=LS*(1.0D0-Z*Z)
         DO 25 I=1,M
 25         CPM(I,I)=-LS*(2.0D0*I-1.0D0)*ZQ*CPM(I-1,I-1)
-        DO 30 I=0,M
+        DO 30 I=0,MIN(M,N-1)
 30         CPM(I,I+1)=(2.0D0*I+1.0D0)*Z*CPM(I,I)
         DO 35 I=0,M
         DO 35 J=I+2,N

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2186,6 +2186,17 @@ class TestLog1p(TestCase):
         assert_array_almost_equal(l1pm,l1pmrl,8)
 
 class TestLegendreFunctions(TestCase):
+    def test_clpmn(self):
+        clp = special.specfun.clpmn(1, 1, 0.5, 0.3)
+        assert_array_almost_equal(clp,(array([[ 1.0000,
+                                                0.5+0.3j ],
+                                              [ 0.0000,
+                                                -0.9305815721+0.1611895232j ]]),
+                                       array([[ 0.0000,
+                                                1.0000 ],
+                                              [ 0.0000,
+                                                0.4674335183+0.4033449589j ]])),7)
+
     def test_lpmn(self):
         lp = special.lpmn(0,2,.5)
         assert_array_almost_equal(lp,(array([       [ 1.00000 ,


### PR DESCRIPTION
Hi,

it seems that there is a bug in the Fortran code of CLPMN where data are written Into the array CPM beyond its bounds provided that M=N. A corresponding bug originally present in the real version LPMN was fixed in 3d5294d3 about eight years ago. This bug concerns not only the associated Legendre polynomials but also the spherical harmonics for complex angles. In Python, the bug becomes apparent in the following minimal code:

'''
from scipy.special.specfun import clpmn
clpmn(1, 1, 5, 3)
'''

The third and fourth argument should not be very important as long as they do not correspond to an argument 1 or -1.

This bug was found by Michael Hartmann and analyzed together with him.

The change in line 275 in b73f9f95 should fix the problem.

Best regards,
Gert
