### PR TITLE
scipy.io.loadmat bug fix

### DIFF
--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -173,6 +173,9 @@ def loadmat(file_name,  mdict=None, appendmat=True, **kwargs):
     """
     variable_names = kwargs.pop('variable_names', None)
     MR = mat_reader_factory(file_name, appendmat, **kwargs)
+    # cast variable_names to list, as MR.get_variables calls list.pop
+    if variable_names is not None:
+        variable_names = list(variable_names)
     matfile_dict = MR.get_variables(variable_names)
     if mdict is not None:
         mdict.update(matfile_dict)

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -173,9 +173,6 @@ def loadmat(file_name,  mdict=None, appendmat=True, **kwargs):
     """
     variable_names = kwargs.pop('variable_names', None)
     MR = mat_reader_factory(file_name, appendmat, **kwargs)
-    # cast variable_names to list, as MR.get_variables calls list.pop
-    if variable_names is not None:
-        variable_names = list(variable_names)
     matfile_dict = MR.get_variables(variable_names)
     if mdict is not None:
         mdict.update(matfile_dict)

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -263,6 +263,9 @@ class MatFile5Reader(MatFileReader):
 
         If variable_names is None, then get all variables in file
         '''
+        if variable_names is not None:
+            variable_names = list(variable_names)
+
         if isinstance(variable_names, string_types):
             variable_names = [variable_names]
         self.mat_stream.seek(0)

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -977,6 +977,11 @@ def test_loadmat_varnames():
     assert_equal(set(vars.keys()), set(['a'] + sys_v_names))
     vars = loadmat(eg_file, variable_names=['theta'])
     assert_equal(set(vars.keys()), set(['theta'] + sys_v_names))
+    vars = loadmat(eg_file, variable_names=('theta',))
+    assert_equal(set(vars.keys()), set(['theta'] + sys_v_names))
+    vnames = ['theta']
+    vars = loadmat(eg_file, variable_names=vnames)
+    assert vnames != [], 'List modified'
 
 
 def test_round_types():

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -981,7 +981,7 @@ def test_loadmat_varnames():
     assert_equal(set(vars.keys()), set(['theta'] + sys_v_names))
     vnames = ['theta']
     vars = loadmat(eg_file, variable_names=vnames)
-    assert vnames != [], 'List modified'
+    assert_equal(vnames, ['theta'])
 
 
 def test_round_types():


### PR DESCRIPTION
This enables loadmat to take immutable sequences and fixes the bug
whereby loadmat empties a list passed to the variable_names kwarg.

Example:  Prior to this patch, the following code would empty  list `v`, which is annoying when trying to load identical variables from several files in a loop.

``` python
from scipyi.io import loadmat

v = ['x', 'y', 'z']
d = loadmat('/path/to/file.mat', variable_names=v)
```
