### PR TITLE
optimize: handle matrix objects as initial guess (ticket #1770)

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -183,7 +183,7 @@ def _root_hybr(func, x0, args=(), jac=None,
     _check_unknown_options(unknown_options)
     epsfcn = eps
 
-    x0 = array(x0, ndmin=1)
+    x0 = asarray(x0).flatten()
     n = len(x0)
     if type(args) != type(()):
         args = (args,)
@@ -350,7 +350,7 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
          params
 
     """
-    x0 = array(x0, ndmin=1)
+    x0 = asarray(x0).flatten()
     n = len(x0)
     if type(args) != type(()):
         args = (args,)

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_, assert_almost_equal, assert_array_equal, \
         assert_array_almost_equal, TestCase, run_module_suite, assert_raises, \
         assert_allclose
 import numpy as np
-from numpy import array, float64
+from numpy import array, float64, matrix
 
 from scipy import optimize
 from scipy.optimize.minpack import leastsq, curve_fit, fixed_point
@@ -155,7 +155,7 @@ class TestRootHybr(TestCase):
         """root/hybr with gradient, equal pipes -> equal flows"""
         k = np.ones(4) * 0.5
         Qtot = 4
-        initial_guess = array([2., 0., 2., 0.])
+        initial_guess = matrix([2., 0., 2., 0.])
         final_flows = optimize.root(pressure_network, initial_guess,
                                     args=(Qtot, k), method='hybr',
                                     jac=pressure_network_jacobian).x
@@ -206,7 +206,7 @@ class TestLeastSq(TestCase):
         assert_array_almost_equal(params_fit, self.abc, decimal=2)
 
     def test_full_output(self):
-        p0 = array([0,0,0])
+        p0 = matrix([0,0,0])
         full_output = leastsq(self.residuals, p0,
                               args=(self.y_meas, self.x),
                               full_output=True)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -730,8 +730,8 @@ class TestTnc(TestCase):
         assert_equal(len(iterx), res.nit)
 
     def test_minimize_tnc1b(self):
-        """Minimize, method=TNC, 1b (approx gradient)"""
-        x0, bnds = [-2, 1], ([-np.inf, None],[-1.5, None])
+        """Minimize, method=TNC, 1b (approx gradient), x0 is a matrix"""
+        x0, bnds = np.matrix([-2, 1]), ([-np.inf, None],[-1.5, None])
         xopt = [1, 1]
         x = optimize.minimize(self.f1, x0, method='TNC',
                               bounds=bnds, options=self.opts).x

--- a/scipy/optimize/tnc.py
+++ b/scipy/optimize/tnc.py
@@ -36,7 +36,7 @@ from __future__ import division, print_function, absolute_import
 
 from scipy.optimize import moduleTNC, approx_fprime
 from .optimize import MemoizeJac, Result, _check_unknown_options
-from numpy import asarray, inf, array
+from numpy import asarray, inf, array, asfarray
 
 __all__ = ['fmin_tnc']
 
@@ -332,7 +332,7 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
     fmin = minfev
     pgtol = gtol
 
-    x0 = asarray(x0, dtype=float).tolist()
+    x0 = asfarray(x0).flatten().tolist()
     n = len(x0)
 
     if bounds is None:


### PR DESCRIPTION
TNC and MINPACK solvers do not handle `numpy.matrix` objects as initial guess correctly.
- updated the tests to introduce `matrix` here and there
- use `flatten()` as it is done in other solvers.
