### PR TITLE
BUG: add swig filetype headers

### DIFF
--- a/scipy/sparse/sparsetools/bsr.i
+++ b/scipy/sparse/sparsetools/bsr.i
@@ -1,3 +1,4 @@
+/* -*- C++ -*- */
 %module bsr
 
 %include "sparsetools.i"

--- a/scipy/sparse/sparsetools/coo.i
+++ b/scipy/sparse/sparsetools/coo.i
@@ -1,3 +1,4 @@
+/* -*- C++ -*- */
 %module coo
 
 %include "sparsetools.i"

--- a/scipy/sparse/sparsetools/csc.i
+++ b/scipy/sparse/sparsetools/csc.i
@@ -1,3 +1,4 @@
+/* -*- C++ -*- */
 %module csc
 
 %include "sparsetools.i"

--- a/scipy/sparse/sparsetools/csgraph.i
+++ b/scipy/sparse/sparsetools/csgraph.i
@@ -1,4 +1,4 @@
-/* -*- C -*- */
+/* -*- C++ -*- */
 %module csgraph
 
 %include "sparsetools.i"

--- a/scipy/sparse/sparsetools/csr.i
+++ b/scipy/sparse/sparsetools/csr.i
@@ -1,3 +1,4 @@
+/* -*- C++ -*- */
 %module csr
 
 %include "sparsetools.i"

--- a/scipy/sparse/sparsetools/dia.i
+++ b/scipy/sparse/sparsetools/dia.i
@@ -1,3 +1,4 @@
+/* -*- C++ -*- */
 %module dia
 
 %include "sparsetools.i"

--- a/scipy/sparse/sparsetools/numpy.i
+++ b/scipy/sparse/sparsetools/numpy.i
@@ -1,4 +1,4 @@
-/* -*- C -*-  (not really, but good for syntax highlighting) */
+/* -*- C -*- */
 %{
 #ifndef SWIG_FILE_WITH_INIT
 #  define NO_IMPORT_ARRAY

--- a/scipy/sparse/sparsetools/sparsetools.i
+++ b/scipy/sparse/sparsetools/sparsetools.i
@@ -1,4 +1,4 @@
-/* -*- C -*-  (not really, but good for syntax highlighting) */
+/* -*- C++ -*- */
 /*%module sparsetools*/
 
  /* why does SWIG complain about int arrays? a typecheck is provided */


### PR DESCRIPTION
The swig files use C++ features so they should be declared as C++.
Some files even lie and declare themselves as C which causes a build
failure if one re-swigs with setup.py.
