### PR TITLE
Misc: List formatting, typos, raw docstrings, and unused variables

### DIFF
--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -85,18 +85,22 @@ def griddata(points, values, xi, method='linear', fill_value=np.nan):
     method : {'linear', 'nearest', 'cubic'}, optional
         Method of interpolation. One of
 
-        ``nearest``: return the value at the data point closest to
+        ``nearest``
+          return the value at the data point closest to
           the point of interpolation.  See `NearestNDInterpolator` for
           more details.
 
-        ``linear``: tesselate the input point set to n-dimensional
+        ``linear``
+          tesselate the input point set to n-dimensional
           simplices, and interpolate linearly on each simplex.  See
           `LinearNDInterpolator` for more details.
 
-        ``cubic`` (1-D): return the value determined from a cubic
+        ``cubic`` (1-D)
+          return the value determined from a cubic
           spline.
 
-        ``cubic`` (2-D): return the value determined from a
+        ``cubic`` (2-D)
+          return the value determined from a
           piecewise cubic, continuously differentiable (C1), and
           approximately curvature-minimizing polynomial surface. See
           `CloughTocher2DInterpolator` for more details.

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -95,15 +95,21 @@ def fsolve(func, x0, args=(), fprime=None, full_output=0,
     infodict : dict
         A dictionary of optional outputs with the keys:
 
-          * 'nfev' : number of function calls
-          * 'njev' : number of Jacobian calls
-          * 'fvec' : function evaluated at the output
-          * 'fjac' : the orthogonal matrix, q, produced by the QR
-                    factorization of the final approximate Jacobian
-                    matrix, stored column wise
-          * 'r' : upper triangular matrix produced by QR factorization
-                  of the same matrix
-          * 'qtf': the vector ``(transpose(q) * fvec)``
+        ``nfev``
+            number of function calls
+        ``njev``
+            number of Jacobian calls
+        ``fvec``
+            function evaluated at the output
+        ``fjac``
+            the orthogonal matrix, q, produced by the QR
+            factorization of the final approximate Jacobian
+            matrix, stored column wise
+        ``r``
+            upper triangular matrix produced by QR factorization
+            of the same matrix
+        ``qtf``
+            the vector ``(transpose(q) * fvec)``
 
     ier : int
         An integer flag.  Set to 1 if a solution was found, otherwise refer
@@ -111,10 +117,10 @@ def fsolve(func, x0, args=(), fprime=None, full_output=0,
     mesg : str
         If no solution is found, `mesg` details the cause of failure.
 
-    See also
+    See Also
     --------
     root : Interface to root finding algorithms for multivariate
-           functions. See the 'hybr' `method` in particular.
+    functions. See the 'hybr' `method` in particular.
 
     Notes
     -----
@@ -308,22 +314,27 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
         residual variance to get the covariance of the
         parameter estimates -- see curve_fit.
     infodict : dict
-        a dictionary of optional outputs with the key s::
+        a dictionary of optional outputs with the key s:
 
-            - 'nfev' : the number of function calls
-            - 'fvec' : the function evaluated at the output
-            - 'fjac' : A permutation of the R matrix of a QR
-                     factorization of the final approximate
-                     Jacobian matrix, stored column wise.
-                     Together with ipvt, the covariance of the
-                     estimate can be approximated.
-            - 'ipvt' : an integer array of length N which defines
-                     a permutation matrix, p, such that
-                     fjac*p = q*r, where r is upper triangular
-                     with diagonal elements of nonincreasing
-                     magnitude. Column j of p is column ipvt(j)
-                     of the identity matrix.
-            - 'qtf'  : the vector (transpose(q) * fvec).
+        ``nfev``
+            The number of function calls
+        ``fvec``
+            The function evaluated at the output
+        ``fjac``
+            A permutation of the R matrix of a QR
+            factorization of the final approximate
+            Jacobian matrix, stored column wise.
+            Together with ipvt, the covariance of the
+            estimate can be approximated.
+        ``ipvt``
+            An integer array of length N which defines
+            a permutation matrix, p, such that
+            fjac*p = q*r, where r is upper triangular
+            with diagonal elements of nonincreasing
+            magnitude. Column j of p is column ipvt(j)
+            of the identity matrix.
+        ``qtf``
+            The vector (transpose(q) * fvec).
 
     mesg : str
         A string message giving information about the cause of failure.

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -827,7 +827,7 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba'):
 
     See also
     --------
-    cheb1ord.
+    cheb1ord
 
     Notes
     -----

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -729,7 +729,7 @@ def butter(N, Wn, btype='low', analog=False, output='ba'):
     Wn : array_like
         A scalar or length-2 sequence giving the critical frequencies.
         For a Butterworth filter, this is the point at which the gain
-        drops to 1/sqrt(1/2) that of the passband (the "-3 dB point").
+        drops to 1/sqrt(2) that of the passband (the "-3 dB point").
         For digital filters, `Wn` is normalized from 0 to 1, where 1 is the
         Nyquist frequency, pi radians/sample.  (`Wn` is thus in
         half-cycles / sample.)
@@ -1073,13 +1073,12 @@ def bessel(N, Wn, btype='low', analog=False, output='ba'):
     The digital Bessel filter is generated using the bilinear
     transform, which does not preserve the phase response of the analog
     filter. As such, it is only approximately correct at frequencies
-    below about fs/4.
-
-    To get maximally flat group delay at higher frequencies, the analog
-    Bessel filter must be transformed using phase-preserving techniques.
+    below about fs/4.  To get maximally flat group delay at higher 
+    frequencies, the analog Bessel filter must be transformed using 
+    phase-preserving techniques.
 
     For a given `Wn`, the lowpass and highpass filter have the same phase vs
-    frequency curves.
+    frequency curves; they are "phase-matched".
 
     Examples
     --------

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -1650,11 +1650,9 @@ def cheb2ap(N, rs):
     mu = arcsinh(1.0 / de) / N
 
     if N % 2:
-        m = N - 1
         n = numpy.concatenate((numpy.arange(1, N - 1, 2),
                                numpy.arange(N + 2, 2 * N, 2)))
     else:
-        m = N
         n = numpy.arange(1, 2 * N, 2)
 
     z = conjugate(1j / cos(n * pi / (2.0 * N)))
@@ -1717,7 +1715,6 @@ def ellipap(N, rp, rs):
         raise ValueError("Cannot design a filter with given rp and rs"
                          " specifications.")
 
-    wp = 1
     val = special.ellipk([ck1 * ck1, ck1p * ck1p])
     if abs(1 - ck1p * ck1p) < EPSILON:
         krat = 0
@@ -1731,8 +1728,6 @@ def ellipap(N, rp, rs):
                                maxiter=250, disp=0)
 
     capk = special.ellipk(m)
-    ws = wp / sqrt(m)
-    m1 = 1 - m
 
     j = numpy.arange(1 - N % 2, N, 2)
     jj = len(j)

--- a/scipy/signal/fir_filter_design.py
+++ b/scipy/signal/fir_filter_design.py
@@ -99,7 +99,7 @@ def kaiserord(ripple, width):
     -------
     numtaps : int
         The length of the kaiser window.
-    beta :
+    beta : float
         The beta parameter for the kaiser window.
 
     See Also
@@ -176,12 +176,11 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
         response is exactly unity at a certain frequency.
         That frequency is either:
 
-            0 (DC) if the first passband starts at 0 (i.e. pass_zero
-              is True)
-
-            `nyq` (the Nyquist rate) if the first passband ends at
-              `nyq` (i.e the filter is a single band highpass filter);
-              center of first passband otherwise
+        - 0 (DC) if the first passband starts at 0 (i.e. pass_zero
+          is True)
+        - `nyq` (the Nyquist rate) if the first passband ends at
+          `nyq` (i.e the filter is a single band highpass filter);
+          center of first passband otherwise
 
     nyq : float
         Nyquist frequency.  Each frequency in `cutoff` must be between 0

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -241,7 +241,7 @@ def bohman(M, sym=True):
 
 
 def blackman(M, sym=True):
-    """
+    r"""
     Return a Blackman window.
 
     The Blackman window is a taper formed by using the the first three
@@ -268,7 +268,7 @@ def blackman(M, sym=True):
     -----
     The Blackman window is defined as
 
-    .. math::  w(n) = 0.42 - 0.5 \\cos(2\\pi n/M) + 0.08 \\cos(4\\pi n/M)
+    .. math::  w(n) = 0.42 - 0.5 \cos(2\pi n/M) + 0.08 \cos(4\pi n/M)
 
     Most references to the Blackman window come from the signal processing
     literature, where it is used as one of many windowing functions for
@@ -508,7 +508,7 @@ def flattop(M, sym=True):
 
 
 def bartlett(M, sym=True):
-    """
+    r"""
     Return a Bartlett window.
 
     The Bartlett window is very similar to a triangular window, except
@@ -536,9 +536,9 @@ def bartlett(M, sym=True):
     -----
     The Bartlett window is defined as
 
-    .. math:: w(n) = \\frac{2}{M-1} \\left(
-              \\frac{M-1}{2} - \\left|n - \\frac{M-1}{2}\\right|
-              \\right)
+    .. math:: w(n) = \frac{2}{M-1} \left(
+              \frac{M-1}{2} - \left|n - \frac{M-1}{2}\right|
+              \right)
 
     Most references to the Bartlett window come from the signal
     processing literature, where it is used as one of many windowing
@@ -605,7 +605,7 @@ def bartlett(M, sym=True):
 
 
 def hann(M, sym=True):
-    """
+    r"""
     Return a Hann window.
 
     The Hann window is a taper formed by using a raised cosine or sine-squared
@@ -630,8 +630,8 @@ def hann(M, sym=True):
     -----
     The Hann window is defined as
 
-    .. math::  w(n) = 0.5 - 0.5 \\cos\\left(\\frac{2\\pi{n}}{M-1}\\right)
-               \\qquad 0 \\leq n \\leq M-1
+    .. math::  w(n) = 0.5 - 0.5 \cos\left(\frac{2\pi{n}}{M-1}\right)
+               \qquad 0 \leq n \leq M-1
 
     The window was named for Julius van Hann, an Austrian meterologist. It is
     also known as the Cosine Bell. It is sometimes erroneously referred to as


### PR DESCRIPTION
PEP 257 says 

> Use r"""raw triple double quotes""" if you use any backslashes in your docstrings.

I'm wary of removing the unused variables, since I don't know how these functions work, and their presence might indicate some unfinished feature or bug?  Maybe they should be converted to comments instead?  [Looks like they've been there since the functions were created in 2001](https://github.com/scipy/scipy/commit/9914c02ec386a389d80b0981b97d694748f28d81).
