### PR TITLE
BUG: special: add a missing term in the asymptotic expansion of Fresnel C/S

### DIFF
--- a/scipy/special/cephes/fresnl.c
+++ b/scipy/special/cephes/fresnl.c
@@ -479,14 +479,13 @@ double xxa, *ssa, *cca;
 	goto done;
     }
 
-
-
-
-
-
     if (x > 36974.0) {
-	cc = 0.5;
-	ss = 0.5;
+        /*
+         * http://functions.wolfram.com/GammaBetaErf/FresnelC/06/02/
+         * http://functions.wolfram.com/GammaBetaErf/FresnelS/06/02/
+         */
+	cc = 0.5 + 1/(M_PI*x) * sin(M_PI*x*x/2);
+	ss = 0.5 - 1/(M_PI*x) * cos(M_PI*x*x/2);
 	goto done;
     }
 

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -884,7 +884,6 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             _exception_to_nan(mpmath.expint),
                             [IntArg(0, 100), Arg()])
 
-    @knownfailure_overridable("behavior at large arguments (asymptotic expansion missing a sub-leading term)")
     def test_fresnels(self):
         def fresnels(x):
             return sc.fresnel(x)[0]
@@ -892,7 +891,6 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             mpmath.fresnels,
                             [Arg()])
 
-    @knownfailure_overridable("behavior at large arguments (asymptotic expansion missing a sub-leading term)")
     def test_fresnelc(self):
         def fresnelc(x):
             return sc.fresnel(x)[1]


### PR DESCRIPTION
Goes on top of gh-500 (only commit 0586359 is for this PR).

Fix an inadequate asymptotic expansion used in the Cephes library.
