### PR TITLE
BUG: special: switch to AMOS implementation of Airy functions at large arguments

### DIFF
--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -1020,7 +1020,7 @@ from lambertw cimport lambertw_scalar as _func_lambertw_scalar
 ctypedef double complex _proto_lambertw_scalar_t(double complex, long, double) nogil
 cdef _proto_lambertw_scalar_t *_proto_lambertw_scalar_t_var = &_func_lambertw_scalar
 cdef extern from "_ufuncs_defs.h":
-    cdef int _func_airy "airy"(double, double *, double *, double *, double *) nogil
+    cdef int _func_airy_wrap "airy_wrap"(double, double *, double *, double *, double *) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef int _func_cairy_wrap "cairy_wrap"(double complex, double complex *, double complex *, double complex *, double complex *) nogil
 cdef extern from "_ufuncs_defs.h":
@@ -1666,9 +1666,9 @@ ufunc_airy_types[16] = <char>NPY_CDOUBLE
 ufunc_airy_types[17] = <char>NPY_CDOUBLE
 ufunc_airy_types[18] = <char>NPY_CDOUBLE
 ufunc_airy_types[19] = <char>NPY_CDOUBLE
-ufunc_airy_ptr[2*0] = <void*>_func_airy
+ufunc_airy_ptr[2*0] = <void*>_func_airy_wrap
 ufunc_airy_ptr[2*0+1] = <void*>(<char*>"airy")
-ufunc_airy_ptr[2*1] = <void*>_func_airy
+ufunc_airy_ptr[2*1] = <void*>_func_airy_wrap
 ufunc_airy_ptr[2*1+1] = <void*>(<char*>"airy")
 ufunc_airy_ptr[2*2] = <void*>_func_cairy_wrap
 ufunc_airy_ptr[2*2+1] = <void*>(<char*>"airy")

--- a/scipy/special/_ufuncs_defs.h
+++ b/scipy/special/_ufuncs_defs.h
@@ -1,11 +1,11 @@
 #ifndef UFUNCS_PROTO_H
 #define UFUNCS_PROTO_H 1
-#include "cephes.h"
-npy_int airy(npy_double, npy_double *, npy_double *, npy_double *, npy_double *);
 #include "amos_wrappers.h"
+npy_int airy_wrap(npy_double, npy_double *, npy_double *, npy_double *, npy_double *);
 npy_int cairy_wrap(npy_cdouble, npy_cdouble *, npy_cdouble *, npy_cdouble *, npy_cdouble *);
 npy_int cairy_wrap_e_real(npy_double, npy_double *, npy_double *, npy_double *, npy_double *);
 npy_int cairy_wrap_e(npy_cdouble, npy_cdouble *, npy_cdouble *, npy_cdouble *, npy_cdouble *);
+#include "cephes.h"
 npy_double bdtr(npy_int, npy_int, npy_double);
 npy_double bdtrc(npy_int, npy_int, npy_double);
 npy_double bdtri(npy_int, npy_int, npy_double);

--- a/scipy/special/amos_wrappers.c
+++ b/scipy/special/amos_wrappers.c
@@ -127,6 +127,30 @@ rotate_i(npy_cdouble i, npy_cdouble k, double v)
     return w;
 }
 
+int cephes_airy(double x, double *ai, double *aip, double *bi, double *bip);
+
+int airy_wrap(double x, double *ai, double *aip, double *bi, double *bip)
+{
+    npy_cdouble z, zai, zaip, zbi, zbip;
+
+    /* For small arguments, use Cephes as it's slightly faster.
+     * For large arguments, use AMOS as it's more accurate.
+     */
+    if (x < -10 || x > 10) {
+        z.real = x;
+        z.imag = 0;
+        cairy_wrap(z, &zai, &zaip, &zbi, &zbip);
+        *ai  = zai.real;
+        *aip = zaip.real;
+        *bi  = zbi.real;
+        *bip = zbip.real;
+    }
+    else {
+        cephes_airy(x, ai, aip, bi, bip);
+    }
+    return 0;
+}
+
 int cairy_wrap(npy_cdouble z, npy_cdouble *ai, npy_cdouble *aip, npy_cdouble *bi, npy_cdouble *bip) {
   int id = 0;
   int ierr = 0;

--- a/scipy/special/amos_wrappers.h
+++ b/scipy/special/amos_wrappers.h
@@ -22,6 +22,7 @@
 
 int ierr_to_sferr( int nz, int ierr);
 void set_nan_if_no_computation_done(npy_cdouble *var, int ierr);
+int airy_wrap(double x, double *ai, double *aip, double *bi, double *bip);
 int cairy_wrap(npy_cdouble z, npy_cdouble *ai, npy_cdouble *aip, npy_cdouble *bi, npy_cdouble *bip);
 int cairy_wrap_e(npy_cdouble z, npy_cdouble *ai, npy_cdouble *aip, npy_cdouble *bi, npy_cdouble *bip);
 int cairy_wrap_e_real(double z, double *ai, double *aip, double *bi, double *bip);

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -157,7 +157,7 @@ pdtri -- pdtri: id->d, pdtri_unsafe: dd->d                 -- cephes.h, _legacy.
 yn -- yn: id->d, yn_unsafe: dd->d                          -- cephes.h, _legacy.pxd
 smirnov -- smirnov: id->d, smirnov_unsafe: dd->d           -- cephes.h, _legacy.pxd
 smirnovi -- smirnovi: id->d, smirnovi_unsafe: dd->d        -- cephes.h, _legacy.pxd
-airy -- airy: d*dddd->*i, cairy_wrap: D*DDDD->*i           -- cephes.h, amos_wrappers.h
+airy -- airy_wrap: d*dddd->*i, cairy_wrap: D*DDDD->*i      -- amos_wrappers.h
 itairy -- itairy_wrap: d*dddd->*i                          -- specfun_wrappers.h
 airye -- cairy_wrap_e_real: d*dddd->*i, cairy_wrap_e: D*DDDD->*i -- amos_wrappers.h
 fresnel -- fresnl: d*dd->*i, cfresnl_wrap: D*DD->*i        -- cephes.h, specfun_wrappers.h

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -588,7 +588,6 @@ def _inf_to_nan(func):
 HYPERKW = dict(maxprec=200, maxterms=200)
 
 class TestSystematic(with_metaclass(_SystematicMeta, object)):
-    @knownfailure_overridable("accuracy issues at large arguments")
     def test_airyai(self):
         assert_mpmath_equal(lambda z: sc.airy(z)[0],
                             mpmath.airyai,
@@ -599,7 +598,6 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             mpmath.airyai,
                             [ComplexArg()])
 
-    @knownfailure_overridable("accuracy issues at large arguments")
     def test_airyai_prime(self):
         assert_mpmath_equal(lambda z: sc.airy(z)[1], lambda z:
                             mpmath.airyai(z, derivative=1),
@@ -610,7 +608,6 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             mpmath.airyai(z, derivative=1),
                             [ComplexArg()])
 
-    @knownfailure_overridable("accuracy issues at large arguments")
     def test_airybi(self):
         assert_mpmath_equal(lambda z: sc.airy(z)[2], lambda z:
                             mpmath.airybi(z),
@@ -621,7 +618,6 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             mpmath.airybi(z),
                             [ComplexArg()])
 
-    @knownfailure_overridable("accuracy issues at large arguments")
     def test_airybi_prime(self):
         assert_mpmath_equal(lambda z: sc.airy(z)[3], lambda z:
                             mpmath.airybi(z, derivative=1),


### PR DESCRIPTION
Goes on top of gh-500 (only commits a40d621 and c0d48b1 are for this PR).

Use the Airy function implementations from AMOS instead of Cephes at large real arguments. The Cephes implementation apparently doesn't use a correct asymptotic expansion.
