### PR TITLE
Ni interpolation performance improvements

### DIFF
--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -354,7 +354,7 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
     char *po, *pi, *pc = NULL;
     npy_intp **edge_offsets = NULL, **data_offsets = NULL, filter_size;
     npy_intp ftmp[MAXDIM], *fcoordinates = NULL, *foffsets = NULL;
-    npy_intp cstride = 0, kk, hh, ll, jj, *idxs = NULL;
+    npy_intp cstride = 0, kk, hh, ll, jj;
     npy_intp size;
     double **splvals = NULL, icoor[MAXDIM];
     npy_intp idimensions[MAXDIM], istrides[MAXDIM];
@@ -416,11 +416,6 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
     filter_size = 1;
     for(jj = 0; jj < irank; jj++)
         filter_size *= order + 1;
-    idxs = (npy_intp*)malloc(filter_size * sizeof(idxs));
-    if (!idxs) {
-        PyErr_NoMemory();
-        goto exit;
-    }
 
     /* initialize output iterator: */
     if (!NI_InitPointIterator(output, &io))
@@ -554,7 +549,10 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
 
         if (!constant) {
             npy_intp *ff = fcoordinates;
+            const int type_num = NI_NormalizeType(input->descr->type_num);
+            t = 0.0;
             for(hh = 0; hh < filter_size; hh++) {
+                double coeff = 0.0;
                 int idx = 0;
                 if (edge) {
                     for(ll = 0; ll < irank; ll++) {
@@ -567,29 +565,20 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
                     idx = foffsets[hh];
                 }
                 idx += offset;
-                idxs[hh] = idx;
-                ff += irank;
-            }
-        }
-        if (!constant) {
-            npy_intp *ff = fcoordinates;
-            t = 0.0;
-            for(hh = 0; hh < filter_size; hh++) {
-                double coeff = 0.0;
-                switch (NI_NormalizeType(input->descr->type_num)) {
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], Bool);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], UInt8);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], UInt16);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], UInt32);
+                switch (type_num) {
+                    CASE_INTERP_COEFF(coeff, pi, idx, Bool);
+                    CASE_INTERP_COEFF(coeff, pi, idx, UInt8);
+                    CASE_INTERP_COEFF(coeff, pi, idx, UInt16);
+                    CASE_INTERP_COEFF(coeff, pi, idx, UInt32);
 #if HAS_UINT64
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], UInt64);
+                    CASE_INTERP_COEFF(coeff, pi, idx, UInt64);
 #endif
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], Int8);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], Int16);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], Int32);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], Int64);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], Float32);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], Float64);
+                    CASE_INTERP_COEFF(coeff, pi, idx, Int8);
+                    CASE_INTERP_COEFF(coeff, pi, idx, Int16);
+                    CASE_INTERP_COEFF(coeff, pi, idx, Int32);
+                    CASE_INTERP_COEFF(coeff, pi, idx, Int64);
+                    CASE_INTERP_COEFF(coeff, pi, idx, Float32);
+                    CASE_INTERP_COEFF(coeff, pi, idx, Float64);
                 default:
                     PyErr_SetString(PyExc_RuntimeError,
                                                     "data type not supported");
@@ -652,8 +641,6 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
         free(foffsets);
     if (fcoordinates)
         free(fcoordinates);
-    if (idxs)
-        free(idxs);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -665,7 +652,7 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
     npy_intp **zeros = NULL, **offsets = NULL, ***edge_offsets = NULL;
     npy_intp ftmp[MAXDIM], *fcoordinates = NULL, *foffsets = NULL;
     npy_intp jj, hh, kk, filter_size, odimensions[MAXDIM];
-    npy_intp idimensions[MAXDIM], istrides[MAXDIM], *idxs = NULL;
+    npy_intp idimensions[MAXDIM], istrides[MAXDIM];
     npy_intp size;
     double ***splvals = NULL;
     NI_Iterator io;
@@ -793,11 +780,6 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
     filter_size = 1;
     for(jj = 0; jj < rank; jj++)
         filter_size *= order + 1;
-    idxs = (npy_intp*)malloc(filter_size * sizeof(idxs));
-    if (!idxs) {
-        PyErr_NoMemory();
-        goto exit;
-    }
 
     if (!NI_InitPointIterator(output, &io))
         goto exit;
@@ -851,8 +833,11 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
 
         if (!zero) {
             npy_intp *ff = fcoordinates;
+            const int type_num = NI_NormalizeType(input->descr->type_num);
+            t = 0.0;
             for(hh = 0; hh < filter_size; hh++) {
                 int idx = 0;
+                double coeff = 0.0;
                 if (edge) {
                         /* use precalculated edge offsets: */
                     for(jj = 0; jj < rank; jj++) {
@@ -866,29 +851,20 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
                     /* use normal offsets: */
                     idx += oo + foffsets[hh];
                 }
-                idxs[hh] = idx;
-                ff += rank;
-            }
-        }
-        if (!zero) {
-            npy_intp *ff = fcoordinates;
-            t = 0.0;
-            for(hh = 0; hh < filter_size; hh++) {
-                double coeff = 0.0;
-                switch (NI_NormalizeType(input->descr->type_num)) {
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], Bool);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], UInt8);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], UInt16);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], UInt32);
+                switch (type_num) {
+                    CASE_INTERP_COEFF(coeff, pi, idx, Bool);
+                    CASE_INTERP_COEFF(coeff, pi, idx, UInt8);
+                    CASE_INTERP_COEFF(coeff, pi, idx, UInt16);
+                    CASE_INTERP_COEFF(coeff, pi, idx, UInt32);
 #if HAS_UINT64
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], UInt64);
+                    CASE_INTERP_COEFF(coeff, pi, idx, UInt64);
 #endif
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], Int8);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], Int16);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], Int32);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], Int64);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], Float32);
-                    CASE_INTERP_COEFF(coeff, pi, idxs[hh], Float64);
+                    CASE_INTERP_COEFF(coeff, pi, idx, Int8);
+                    CASE_INTERP_COEFF(coeff, pi, idx, Int16);
+                    CASE_INTERP_COEFF(coeff, pi, idx, Int32);
+                    CASE_INTERP_COEFF(coeff, pi, idx, Int64);
+                    CASE_INTERP_COEFF(coeff, pi, idx, Float32);
+                    CASE_INTERP_COEFF(coeff, pi, idx, Float64);
                 default:
                     PyErr_SetString(PyExc_RuntimeError,
                                                     "data type not supported");
@@ -969,7 +945,5 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
         free(foffsets);
     if (fcoordinates)
         free(fcoordinates);
-    if (idxs)
-        free(idxs);
     return PyErr_Occurred() ? 0 : 1;
 }

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -554,7 +554,8 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
             for(hh = 0; hh < filter_size; hh++) {
                 double coeff = 0.0;
                 int idx = 0;
-                if (edge) {
+
+                if (NI_UNLIKELY(edge)) {
                     for(ll = 0; ll < irank; ll++) {
                         if (edge_offsets[ll])
                             idx += edge_offsets[ll][ff[ll]];
@@ -838,7 +839,8 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
             for(hh = 0; hh < filter_size; hh++) {
                 int idx = 0;
                 double coeff = 0.0;
-                if (edge) {
+
+                if (NI_UNLIKELY(edge)) {
                         /* use precalculated edge offsets: */
                     for(jj = 0; jj < rank; jj++) {
                         if (edge_offsets[jj][io.coordinates[jj]])

--- a/scipy/ndimage/src/ni_support.h
+++ b/scipy/ndimage/src/ni_support.h
@@ -52,6 +52,27 @@ typedef enum {
     NI_EXTEND_DEFAULT = NI_EXTEND_MIRROR
 } NI_ExtendMode;
 
+
+/******************************************************************/
+/* Misc */
+/******************************************************************/
+
+/* compile time branch prediction hints */
+#ifdef __GNUC__
+  /* Test for GCC > 2.95 */
+  #if __GNUC__ > 2 || (__GNUC__ == 2 && (__GNUC_MINOR__ > 95))
+    #define NI_LIKELY(x)   __builtin_expect(!!(x), 1)
+    #define NI_UNLIKELY(x) __builtin_expect(!!(x), 0)
+  #else /* __GNUC__ > 2 ... */
+    #define NI_LIKELY(x)   (x)
+    #define NI_UNLIKELY(x) (x)
+  #endif /* __GNUC__ > 2 ... */
+#else /* __GNUC__ */
+  #define NI_LIKELY(x)   (x)
+  #define NI_UNLIKELY(x) (x)
+#endif /* __GNUC__ */
+
+
 /******************************************************************/
 /* Data types */
 /******************************************************************/

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -1785,6 +1785,27 @@ class TestNdimage:
                                                      order=order)
             assert_array_almost_equal(out1, out2)
 
+    def test_map_coordinates03(self):
+        "map coordinates non continuous"
+        data = numpy.array([[4, 1, 3, 2],
+                               [7, 6, 8, 5],
+                               [3, 5, 3, 6]], order='F')
+        idx = numpy.indices(data.shape) - 1
+        out = ndimage.map_coordinates(data, idx)
+        assert_array_almost_equal(out, [[0, 0, 0, 0],
+                                   [0, 4, 1, 3],
+                                   [0, 7, 6, 8]])
+        assert_array_almost_equal(out, ndimage.shift(data, (1, 1)))
+        idx = numpy.indices(data[::2].shape) - 1
+        out = ndimage.map_coordinates(data[::2], idx)
+        assert_array_almost_equal(out, [[0, 0, 0, 0],
+                                   [0, 4, 1, 3]])
+        assert_array_almost_equal(out, ndimage.shift(data[::2], (1, 1)))
+        idx = numpy.indices(data[:,::2].shape) - 1
+        out = ndimage.map_coordinates(data[:,::2], idx)
+        assert_array_almost_equal(out, [[0, 0], [0, 4], [0, 7]])
+        assert_array_almost_equal(out, ndimage.shift(data[:,::2], (1, 1)))
+
     def test_affine_transform01(self):
         "affine_transform 1"
         data = numpy.array([1])


### PR DESCRIPTION
performance improvements for ndimage interpolation.
Gain is about 5-10% with the default order and I think the code gets a bit clearer.

In both NI_GeometricTransform and NI_ZoomShift have two inner loops which can be merged removing some unnecessary looping operations and the need for the idxs temporary variable.
Also I moved the switch statement argument out of the inner loop as due to the many unrestricted pointers the (gcc) compiler can't do it (unlike the non pointer order conditional in the loop below).

Then I also added branch prediction hints which improve performance for larger 2d (or higher) images on a core2duo and a amd phenom X2.
The number of edge points will mostly be much smaller than the number of regular pixels on dimensions > 1.
You could certainly produce cases in which the hint is wrong, so I'm open to drop that commit.

I also ran the skimage testsuite successfully which uses these functions a bit more.
very simple benchmark:

```
Nx, Ny = 500, 1703
numpy.random.seed(23)
d = scipy.rand(Ny*Nx)
d.shape = Ny, Nx
ind = numpy.indices(d.shape, numpy.float64)
ind -= 1.7
%timeit -n 20 ndimage.map_coordinates(d, ind)
%timeit -n 20 ndimage.shift(d, 0.5)
```
