### PR TITLE
Bringing float16 support to scipy.ndimage

### DIFF
--- a/scipy/ndimage/setup.py
+++ b/scipy/ndimage/setup.py
@@ -4,6 +4,12 @@ from numpy.distutils.core import setup
 from numpy.distutils.misc_util import Configuration
 from numpy import get_include
 
+try:
+    from numpy.distutils.misc_util import get_info
+except ImportError:
+    raise ValueError("numpy >= 1.4 is required (detected %s from %s)" % \
+                     (numpy.__version__, numpy.__file__))
+
 def configuration(parent_package='', top_path=None):
 
     config = Configuration('ndimage', parent_package, top_path)
@@ -14,6 +20,7 @@ def configuration(parent_package='', top_path=None):
                  "src/ni_measure.c",
                  "src/ni_morphology.c","src/ni_support.c"],
         include_dirs=['src']+[get_include()],
+        extra_info=get_info('npymath'),
     )
 
     # Cython wants the .c and .pyx to have the underscore.

--- a/scipy/ndimage/src/nd_image.h
+++ b/scipy/ndimage/src/nd_image.h
@@ -63,7 +63,8 @@ typedef enum
          tComplex128=NPY_COMPLEX128,
          tObject=NPY_OBJECT,        /* placeholder... does nothing */
          tMaxType=NPY_NTYPES,
-         tDefault=NPY_FLOAT64
+         tDefault=NPY_FLOAT64,
+         tFloat16=NPY_FLOAT16
 } NumarrayType;
 
 #define NI_MAXDIM NPY_MAXDIMS

--- a/scipy/ndimage/src/ni_filters.c
+++ b/scipy/ndimage/src/ni_filters.c
@@ -238,6 +238,8 @@ int NI_Correlate(PyArrayObject* input, PyArrayObject* weights,
                                                      tmp, border_flag_value);
             CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, Int64,
                                                      tmp, border_flag_value);
+            CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, Float16,
+                                                     tmp, border_flag_value);
             CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, Float32,
                                                      tmp, border_flag_value);
             CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, Float64,
@@ -258,6 +260,7 @@ int NI_Correlate(PyArrayObject* input, PyArrayObject* weights,
             CASE_FILTER_OUT(po, tmp, Int16);
             CASE_FILTER_OUT(po, tmp, Int32);
             CASE_FILTER_OUT(po, tmp, Int64);
+            CASE_FILTER_OUT(po, tmp, Float16);
             CASE_FILTER_OUT(po, tmp, Float32);
             CASE_FILTER_OUT(po, tmp, Float64);
         default:
@@ -510,6 +513,8 @@ int NI_MinOrMaxFilter(PyArrayObject* input, PyArrayObject* footprint,
                                                         minimum, tmp, border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, Int64,
                                                         minimum, tmp, border_flag_value, ss);
+            CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, Float16,
+                                                        minimum, tmp, border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, Float32,
                                                         minimum, tmp, border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, Float64,
@@ -530,6 +535,7 @@ int NI_MinOrMaxFilter(PyArrayObject* input, PyArrayObject* footprint,
             CASE_FILTER_OUT(po, tmp, Int16);
             CASE_FILTER_OUT(po, tmp, Int32);
             CASE_FILTER_OUT(po, tmp, Int64);
+            CASE_FILTER_OUT(po, tmp, Float16);
             CASE_FILTER_OUT(po, tmp, Float32);
             CASE_FILTER_OUT(po, tmp, Float64);
         default:
@@ -670,6 +676,8 @@ int NI_RankFilter(PyArrayObject* input, int rank,
                                             rank, buffer, tmp, border_flag_value);
             CASE_RANK_POINT(pi, oo, filter_size, cvalue, Int64,
                                             rank, buffer, tmp, border_flag_value);
+            CASE_RANK_POINT(pi, oo, filter_size, cvalue, Float16,
+                                            rank, buffer, tmp, border_flag_value);
             CASE_RANK_POINT(pi, oo, filter_size, cvalue, Float32,
                                             rank, buffer, tmp, border_flag_value);
             CASE_RANK_POINT(pi, oo, filter_size, cvalue, Float64,
@@ -690,6 +698,7 @@ int NI_RankFilter(PyArrayObject* input, int rank,
             CASE_FILTER_OUT(po, tmp, Int16);
             CASE_FILTER_OUT(po, tmp, Int32);
             CASE_FILTER_OUT(po, tmp, Int64);
+            CASE_FILTER_OUT(po, tmp, Float16);
             CASE_FILTER_OUT(po, tmp, Float32);
             CASE_FILTER_OUT(po, tmp, Float64);
         default:
@@ -854,6 +863,8 @@ int NI_GenericFilter(PyArrayObject* input,
                                                 tmp, border_flag_value, function, data, buffer);
             CASE_FILTER_POINT(pi, oo, filter_size, cvalue, Int64,
                                                 tmp, border_flag_value, function, data, buffer);
+            CASE_FILTER_POINT(pi, oo, filter_size, cvalue, Float16,
+                                                tmp, border_flag_value, function, data, buffer);
             CASE_FILTER_POINT(pi, oo, filter_size, cvalue, Float32,
                                                 tmp, border_flag_value, function, data, buffer);
             CASE_FILTER_POINT(pi, oo, filter_size, cvalue, Float64,
@@ -874,6 +885,7 @@ int NI_GenericFilter(PyArrayObject* input,
             CASE_FILTER_OUT(po, tmp, Int16);
             CASE_FILTER_OUT(po, tmp, Int32);
             CASE_FILTER_OUT(po, tmp, Int64);
+            CASE_FILTER_OUT(po, tmp, Float16);
             CASE_FILTER_OUT(po, tmp, Float32);
             CASE_FILTER_OUT(po, tmp, Float64);
         default:

--- a/scipy/ndimage/src/ni_support.c
+++ b/scipy/ndimage/src/ni_support.c
@@ -359,6 +359,7 @@ int NI_ArrayToLineBuffer(NI_LineBuffer *buffer,
             CASE_COPY_DATA_TO_LINE(pa, pb, length, buffer->line_stride, Int16);
             CASE_COPY_DATA_TO_LINE(pa, pb, length, buffer->line_stride, Int32);
             CASE_COPY_DATA_TO_LINE(pa, pb, length, buffer->line_stride, Int64);
+            CASE_COPY_DATA_TO_LINE(pa, pb, length, buffer->line_stride, Float16);
             CASE_COPY_DATA_TO_LINE(pa, pb, length, buffer->line_stride, Float32);
             CASE_COPY_DATA_TO_LINE(pa, pb, length, buffer->line_stride, Float64);
         default:
@@ -422,6 +423,7 @@ int NI_LineBufferToArray(NI_LineBuffer *buffer)
             CASE_COPY_LINE_TO_DATA(pb, pa, length, buffer->line_stride, Int16);
             CASE_COPY_LINE_TO_DATA(pb, pa, length, buffer->line_stride, Int32);
             CASE_COPY_LINE_TO_DATA(pb, pa, length, buffer->line_stride, Int64);
+            CASE_COPY_LINE_TO_DATA(pb, pa, length, buffer->line_stride, Float16);
             CASE_COPY_LINE_TO_DATA(pb, pa, length, buffer->line_stride, Float32);
             CASE_COPY_LINE_TO_DATA(pb, pa, length, buffer->line_stride, Float64);
         default:


### PR DESCRIPTION
Just recently realized that convolve() didn't work with float16 arrays.  Seems like this is more of an oversight rather than a technical limitation.  This is intended to just get the filters working... no tests or anything like that yet.
