### PR TITLE
MAINT: stats: A small improvement to the wilcoxon code

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1331,18 +1331,16 @@ def wilcoxon(x, y=None, zero_method="wilcox"):
     if zero_method == "pratt":
         r = r[d != 0]
 
-    if (len(r) != len(unique(r))):  # handle ties in data
-        replist, repnum = find_repeats(r)
-        corr = 0.0
-        for i in range(len(replist)):
-            si = repnum[i]
-            corr += 0.5 * si * (si * si - 1.0)
-        se -= corr
+    replist, repnum = find_repeats(r)
+    if repnum.size != 0:
+        # Correction for repeated elements.
+        se -= 0.5 * (repnum * (repnum * repnum - 1)).sum()
 
     se = sqrt(se / 24)
     z = (T - mn) / se
     prob = 2. * distributions.norm.sf(abs(z))
     return T, prob
+
 
 def _hermnorm(N):
     # return the negatively normalized hermite polynomials up to order N-1

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -199,11 +199,19 @@ class TestBinomP(TestCase):
 
 
 class TestFindRepeats(TestCase):
+
     def test_basic(self):
         a = [1,2,3,4,1,2,3,4,1,2,5]
         res,nums = stats.find_repeats(a)
         assert_array_equal(res,[1,2,3,4])
         assert_array_equal(nums,[3,3,2,2])
+
+    def test_empty_result(self):
+        # Check that empty arrays are returned when there are no repeats.
+        a = [10, 20, 50, 30, 40]
+        repeated, counts = stats.find_repeats(a)
+        assert_array_equal(repeated, [])
+        assert_array_equal(counts, [])
 
 
 class TestFligner(TestCase):


### PR DESCRIPTION
This is small improvement to the code in the function `wilcoxon`.  `find_repeats` is actually faster than `np.unique`, so just call `find_repeats` and check the result to determine if a correction for ties is needed.
