### PR TITLE
BUG: optimize: fix issues related to line searches

### DIFF
--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -144,7 +144,7 @@ def scalar_search_wolfe1(phi, derphi, phi0=None, old_phi0=None, derphi0=None,
     if derphi0 is None:
         derphi0 = derphi(0.)
 
-    if old_phi0 is not None:
+    if old_phi0 is not None and derphi0 != 0:
         alpha1 = min(1.0, 1.01*2*(phi0 - old_phi0)/derphi0)
         if alpha1 < 0:
             alpha1 = 1.0
@@ -327,7 +327,7 @@ def scalar_search_wolfe2(phi, derphi=None, phi0=None,
         derphi0 = derphi(0.)
 
     alpha0 = 0
-    if old_phi0 is not None:
+    if old_phi0 is not None and derphi0 != 0:
         alpha1 = min(1.0, 1.01*2*(phi0 - old_phi0)/derphi0)
     else:
         alpha1 = 1.0

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -519,8 +519,9 @@ def _zoom(a_lo, a_hi, phi_lo, phi_hi, derphi_lo,
             derphi_lo = derphi_aj
         i += 1
         if (i > maxiter):
-            a_star = a_j
-            val_star = phi_aj
+            # Failed to find a conforming step size
+            a_star = None
+            val_star = None
             valprime_star = None
             break
     return a_star, val_star, valprime_star

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -828,7 +828,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     I = numpy.eye(N, dtype=int)
     Hk = I
     old_fval = f(x0)
-    old_old_fval = old_fval + 5000
+    old_old_fval = None
     xk = x0
     if retall:
         allvecs = [x0]
@@ -1133,7 +1133,7 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
     k = 0
     xk = x0
     old_fval = f(xk)
-    old_old_fval = old_fval + 5000
+    old_old_fval = None
 
     if retall:
         allvecs = [xk]

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -1400,7 +1400,8 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
                 if (i > 0):
                     break
                 else:
-                    xsupi = xsupi + dri0 / curv * psupi
+                    # fall back to steepest descent direction
+                    xsupi = dri0 / (-curv) * b
                     break
             alphai = dri0 / curv
             xsupi = xsupi + alphai * psupi

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -1362,6 +1362,7 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
         allvecs = [xk]
     k = 0
     old_fval = f(x0)
+    old_old_fval = None
     float64eps = numpy.finfo(numpy.float64).eps
     warnflag = 0
     while (numpy.add.reduce(numpy.abs(update)) > xtol) and (k < maxiter):
@@ -1412,14 +1413,15 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
 
         pk = xsupi  # search direction is solution to system.
         gfk = -b    # gradient at xk
-        alphak, fc, gc, old_fval2 = line_search_BFGS(f, xk, pk, gfk, old_fval)
 
-        if alphak is None:
+        try:
+            alphak, fc, gc, old_fval, old_old_fval, gfkp1 = \
+                     _line_search_wolfe12(f, fprime, xk, pk, gfk,
+                                          old_fval, old_old_fval)
+        except _LineSearchError:
             # Line search failed to find a better solution.
             warnflag = 2
             break
-        else:
-            old_fval = old_fval2
 
         update = alphak * pk
         xk = xk + update        # upcast if necessary

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -654,6 +654,17 @@ class TestNewtonCg(object):
         assert_(sol.success, sol.message)
         assert_allclose(sol.x, np.array([1, 1]), rtol=1e-4)
 
+    def test_himmelblau(self):
+        x0 = np.array(himmelblau_x0)
+        sol = optimize.minimize(himmelblau,
+                                x0,
+                                jac=himmelblau_grad,
+                                hess=himmelblau_hess,
+                                method='Newton-CG',
+                                tol=1e-6)
+        assert_(sol.success, sol.message)
+        assert_allclose(sol.x, himmelblau_xopt, rtol=1e-4)
+        assert_allclose(sol.fun, himmelblau_min, atol=1e-4)
 
 class TestRosen(TestCase):
 
@@ -665,6 +676,29 @@ class TestRosen(TestCase):
         dothp = np.dot(optimize.rosen_hess(x), p)
         assert_equal(hp, dothp)
 
+def himmelblau(p):
+    """
+    R^2 -> R^1 test function for optimization.  The function has four local
+    minima where himmelblau(xopt) == 0.
+    """
+    x, y = p
+    a = x*x + y - 11
+    b = x + y*y - 7
+    return a*a + b*b
+
+def himmelblau_grad(p):
+    x, y = p
+    return np.array([4*x**3 + 4*x*y - 42*x + 2*y**2 - 14,
+                     2*x**2 + 4*x*y + 4*y**3 - 26*y - 22])
+
+def himmelblau_hess(p):
+    x, y = p
+    return np.array([[12*x**2 + 4*y - 42, 4*x + 4*y],
+                     [4*x + 4*y, 4*x + 12*y**2 - 26]])
+
+himmelblau_x0 = [-0.27, -0.9]
+himmelblau_xopt = [3, 2]
+himmelblau_min = 0.0
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -269,7 +269,8 @@ class TestOptimize(TestCase):
         # Ensure that function call counts are 'known good'; these are from
         # Scipy 0.7.0. Don't allow them to increase.
         assert_(self.funccalls == 7, self.funccalls)
-        assert_(self.gradcalls <= 18, self.gradcalls) # 0.9.0
+        assert_(self.gradcalls <= 20, self.gradcalls) # 0.13.0
+        #assert_(self.gradcalls <= 18, self.gradcalls) # 0.9.0
         #assert_(self.gradcalls == 18, self.gradcalls) # 0.8.0
         #assert_(self.gradcalls == 22, self.gradcalls) # 0.7.0
 
@@ -610,6 +611,18 @@ class TestOptimizeScalar(TestCase):
         x = optimize.minimize_scalar(self.fun, bounds=(1, np.array(5)),
                                      method='bounded').x
         assert_allclose(x, self.solution, atol=1e-6)
+
+
+class TestNewtonCg(object):
+    def test_rosenbrock(self):
+        x0 = np.array([-1.2, 1.0])
+        sol = optimize.minimize(optimize.rosen, x0,
+                                jac=optimize.rosen_der,
+                                hess=optimize.rosen_hess,
+                                tol=1e-5,
+                                method='Newton-CG')
+        assert_(sol.success, sol.message)
+        assert_allclose(sol.x, np.array([1, 1]), rtol=1e-4)
 
 
 class TestRosen(TestCase):


### PR DESCRIPTION
This PR does the following:
- Deal properly with failing line searches, don't update variables spuriously.
- Convert fmin_ncg to use wolfe criterion (see [Trac #1778](http://projects.scipy.org/scipy/ticket/1778)).
- Clean up some magic numbers away from the code. Having `old_old_fval >> old_fval` results to initial step length of 1.0. However, `old_old_fval is None` achieves the same.
- Make `line_search_wolfe2` to actually signal a failure if it doesn't manage to find a suitable step length. Previously, it would just return some small number in the case of a failure.

The code is unfortunately a bit light on tests, so some careful review is warranted here.
