### PR TITLE
Memory leak in convolve2d

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -114,6 +114,7 @@ Lorenzo Luengo for whosmat() in scipy.io.
 Eric Moore for orthogonal polynomial recurrences in scipy.special.
 Jacob Stevenson for the basinhopping optimization algorithm
 Daniel Smith for sparse matrix functionality improvements
+Gustav Larsson for a bug fix in convolve2d.
 
 
 Institutions

--- a/scipy/signal/sigtoolsmodule.c
+++ b/scipy/signal/sigtoolsmodule.c
@@ -1085,6 +1085,7 @@ static PyObject *sigtools_convolve2d(PyObject *NPY_UNUSED(dummy), PyObject *args
 
     switch (ret) {
     case 0:
+      free(aout_dimens);
       Py_DECREF(ain1);
       Py_DECREF(ain2);
       Py_XDECREF(afill);


### PR DESCRIPTION
The function `convolve2d` leaked memory allocated for the output array's shape. This is a temporary array that is passed to `PyArray_SimpleNew`, which makes a copy of it, so the original one must be freed. Before this fix, it was freed only when something failed. I fixed this by adding a call to `free` when it succeeds as well.

The amount of leaked memory is very small, but given enough calls to `convolve2d` it will add up. For me, I couldn't run my entire experiment without eventually getting killed by the OOM killer.

This is an easy test for checking this bug:

```
import numpy as np
import scipy.signal

X = np.ones((5, 5))
kernel = np.ones((4, 4))

while True:
    scipy.signal.convolve2d(X, kernel)
```

And then watch the memory usage steadily increase. I have experimentally confirmed that my proposed solution fixes this problem.
