### PR TITLE
BUG: sparse: The dtype argument to the dok_matrix constructor was not handled correctly when the input data was a list of lists.

### DIFF
--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -103,9 +103,10 @@ class dok_matrix(spmatrix, dict):
                 raise TypeError('expected rank <=2 dense array or matrix')
 
             from .coo import coo_matrix
-            self.update( coo_matrix(arg1, dtype=dtype).todok() )
+            d = coo_matrix(arg1, dtype=dtype).todok()
+            self.update(d)
             self.shape = arg1.shape
-            self.dtype = arg1.dtype
+            self.dtype = d.dtype
 
     def getnnz(self):
         return dict.__len__(self)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -617,7 +617,6 @@ class _TestCommon:
         sum2 = 3*self.datsp - self.dat
         assert_array_equal(sum2, 2*self.dat)
 
-
     def test_copy(self):
         # Check whether the copy=True and copy=False keywords work
         A = self.datsp
@@ -1876,11 +1875,19 @@ class TestDOK(sparse_test_class(slicing=False,
         # Dense ctor
         b = matrix([[1,0,0,0],[0,0,1,0],[0,2,0,3]],'d')
         A = dok_matrix(b)
+        assert_equal(b.dtype, A.dtype)
         assert_equal(A.todense(), b)
 
         # Sparse ctor
         c = csr_matrix(b)
         assert_equal(A.todense(), c.todense())
+
+        data = [[0, 1, 2], [3, 0, 0]]
+        d = dok_matrix(data, dtype=np.float32)
+        assert_equal(d.dtype, np.float32)
+        da = d.toarray()
+        assert_equal(da.dtype, np.float32)
+        assert_array_equal(da, data)
 
     def test_resize(self):
         #A couple basic tests of the resize() method.


### PR DESCRIPTION
Example of the issue:

```
In [1]: from scipy.sparse import dok_matrix

In [2]: d = dok_matrix([[0, 1, 2], [3, 0, 0]], dtype=np.float32)

In [3]: d.dtype
Out[3]: dtype('int64')
```

The result in `Out[3]` should be 'float32'.
