### PR TITLE
BUG: sparse: coo_matrix.todia() would fail when the matrix was all zeros.

### DIFF
--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -338,8 +338,11 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             pass
 
         #initialize and fill in data array
-        data = np.zeros( (len(diags), self.col.max()+1), dtype=self.dtype)
-        data[ np.searchsorted(diags,ks), self.col ] = self.data
+        if self.data.size == 0:
+            data = np.zeros((0, 0), dtype=self.dtype)
+        else:
+            data = np.zeros( (len(diags), self.col.max()+1), dtype=self.dtype)
+            data[ np.searchsorted(diags,ks), self.col ] = self.data
 
         return dia_matrix((data,diags), shape=self.shape)
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2112,6 +2112,11 @@ class TestCOO(sparse_test_class(getset=False,
         coo = coo_matrix(mat)
         assert_array_equal(coo.todense(),mat.reshape(1,-1))
 
+    def test_todia_all_zeros(self):
+        zeros = [[0, 0]]
+        dia = coo_matrix(zeros).todia()
+        assert_array_equal(dia.A, zeros)
+
 
 class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False,


### PR DESCRIPTION
This PR fixes a bug in coo_matrix.todia().  The method raises an exception if the array is all zeros.  For example:

```
In [3]: from scipy.sparse import coo_matrix

In [4]: z = [[0, 0]]

In [5]: c = coo_matrix(z)

In [6]: d = c.todia()
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-6-6294988ff569> in <module>()
----> 1 d = c.todia()

/home/warren/anaconda/lib/python2.7/site-packages/scipy/sparse/coo.pyc in todia(self)
    336 
    337         #initialize and fill in data array
--> 338         data = np.zeros( (len(diags), self.col.max()+1), dtype=self.dtype)
    339         data[ np.searchsorted(diags,ks), self.col ] = self.data
    340 

/home/warren/anaconda/lib/python2.7/site-packages/numpy/core/_methods.pyc in _amax(a, axis, out, keepdims)
      8 def _amax(a, axis=None, out=None, keepdims=False):
      9     return um.maximum.reduce(a, axis=axis,
---> 10                             out=out, keepdims=keepdims)
     11 
     12 def _amin(a, axis=None, out=None, keepdims=False):

ValueError: zero-size array to reduction operation maximum which has no identity
```
