### PR TITLE
Small performance improvement

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -373,10 +373,11 @@ class spmatrix(object):
             elif other == 1:
                 return self.copy()
             else:
-                result = self
-                for i in range(1,other):
-                    result = result*self
-                return result
+                tmp = self.__pow__(self, other//2)
+                if (other % 2):
+                    return self * tmp * tmp
+                else:
+                    return tmp * tmp
         elif isscalarlike(other):
             raise ValueError('exponent must be an integer')
         else:

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -373,7 +373,7 @@ class spmatrix(object):
             elif other == 1:
                 return self.copy()
             else:
-                tmp = self.__pow__(self, other//2)
+                tmp = self.__pow__(other//2)
                 if (other % 2):
                     return self * tmp * tmp
                 else:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2120,6 +2120,10 @@ class TestCOO(sparse_test_class(getset=False,
         coo = coo_matrix(mat)
         assert_array_equal(coo.todense(),mat.reshape(1,-1))
 
+    # COO does not have a __getitem__ to support iteration
+    def test_iterator(self):
+        pass
+
 
 class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False,
@@ -2135,6 +2139,9 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
         offsets = np.array([0,-1,2])
         assert_equal(dia_matrix( (data,offsets), shape=(4,4)).todense(), D)
 
+    # DIA does not have a __getitem__ to support iteration
+    def test_iterator(self):
+        pass
 
 class TestBSR(sparse_test_class(getset=False,
                                 slicing=False, slicing_assign=False,
@@ -2208,6 +2215,10 @@ class TestBSR(sparse_test_class(getset=False,
         A = bsr_matrix( arange(2*3*4*5).reshape(2*4,3*5), blocksize=(4,5) )
         x = arange(A.shape[1]*6).reshape(-1,6)
         assert_equal(A*x, A.todense()*x)
+
+    @dec.knownfailureif(True, "BSR not implemented")
+    def test_iterator(self):
+        pass
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -655,6 +655,14 @@ class _TestCommon:
             # not all sparse matrices can be indexed
             pass
 
+    # test that __iter__ is compatible with NumPy matrix
+    def test_iterator(self):
+        B = np.matrix(np.arange(50).reshape(5, 10))
+        A = self.spmatrix(B)
+
+        for x, y in zip(A, B):
+            assert_equal(x.todense(), y)
+
     # Eventually we'd like to allow matrix products between dense
     # and sparse matrices using the normal dot() function:
     #def test_dense_dot_sparse(self):


### PR DESCRIPTION
I implemented exponentiation by squaring as the new default **pow** for spmatrix. It should be Python 3 compliant. On a 1000 x 1000 CSC matrix with 1000 entries, I saw about a 20% speedup.
