### PR TITLE
BUG: optimize: fix bug in minpack error handling string formatting on Py3

### DIFF
--- a/scipy/integrate/multipack.h
+++ b/scipy/integrate/multipack.h
@@ -107,7 +107,6 @@ static PyObject *multipack_python_jacobian=NULL;
 static PyObject *multipack_extra_arguments=NULL;    /* a tuple */
 static int multipack_jac_transpose=1;
 
-
 static PyArrayObject * my_make_numpy_array(PyObject *y0, int type, int mindim, int maxdim)
      /* This is just like PyArray_ContiguousFromObject except it handles
       * single numeric datatypes as 1-element, rank-1 arrays instead of as
@@ -148,7 +147,7 @@ static PyObject *call_python_function(PyObject *func, npy_intp n, double *x, PyO
   */
 
   PyArrayObject *sequence = NULL;
-  PyObject *arglist = NULL, *tmpobj = NULL;
+  PyObject *arglist = NULL;
   PyObject *arg1 = NULL, *str1 = NULL;
   PyObject *result = NULL;
   PyArrayObject *result_array = NULL;
@@ -174,14 +173,6 @@ static PyObject *call_python_function(PyObject *func, npy_intp n, double *x, PyO
           arguments are in another passed variable.
    */
   if ((result = PyEval_CallObject(func, arglist))==NULL) {
-    PyErr_Print();
-    tmpobj = PyObject_GetAttrString(func, "__name__");
-    if (tmpobj == NULL) goto fail;
-    str1 = PyString_FromString("Error occurred while calling the Python function named ");
-    if (str1 == NULL) { Py_DECREF(tmpobj); goto fail;}
-    PyString_ConcatAndDel(&str1, tmpobj);
-    PyErr_SetString(error_obj, PyString_AsString(str1));
-    Py_DECREF(str1);
     goto fail;
   }
 

--- a/scipy/interpolate/src/multipack.h
+++ b/scipy/interpolate/src/multipack.h
@@ -32,10 +32,6 @@ the result tuple when the full_output argument is non-zero.
 #include "numpy/arrayobject.h"
 
 #if PY_VERSION_HEX >= 0x03000000
-    #define PyString_AsString PyBytes_AsString
-    #define PyString_FromString PyBytes_FromString
-    #define PyString_ConcatAndDel PyBytes_ConcatAndDel
-
     #define PyInt_AsLong PyLong_AsLong
 
     /* Return True only if the long fits in a C long */
@@ -164,7 +160,7 @@ static PyObject *call_python_function(PyObject *func, npy_intp n, double *x, PyO
   */
 
   PyArrayObject *sequence = NULL;
-  PyObject *arglist = NULL, *tmpobj = NULL;
+  PyObject *arglist = NULL;
   PyObject *arg1 = NULL, *str1 = NULL;
   PyObject *result = NULL;
   PyArrayObject *result_array = NULL;
@@ -190,14 +186,6 @@ static PyObject *call_python_function(PyObject *func, npy_intp n, double *x, PyO
           arguments are in another passed variable.
    */
   if ((result = PyEval_CallObject(func, arglist))==NULL) {
-    PyErr_Print();
-    tmpobj = PyObject_GetAttrString(func, "func_name");
-    if (tmpobj == NULL) goto fail;
-    str1 = PyString_FromString("Error occurred while calling the Python function named ");
-    if (str1 == NULL) { Py_DECREF(tmpobj); goto fail;}
-    PyString_ConcatAndDel(&str1, tmpobj);
-    PyErr_SetString(error_obj, PyString_AsString(str1));
-    Py_DECREF(str1);
     goto fail;
   }
 

--- a/scipy/odr/__odrpack.c
+++ b/scipy/odr/__odrpack.c
@@ -98,8 +98,6 @@ void fcn_callback(int *n, int *m, int *np, int *nq, int *ldn, int *ldm,
 
       if ((result = PyEval_CallObject(odr_global.fcn, arglist)) == NULL)
         {
-          PyObject *tmpobj, *str1;
-
           if (PyErr_ExceptionMatches(odr_stop))
             {
               /* stop, don't fail */
@@ -108,23 +106,6 @@ void fcn_callback(int *n, int *m, int *np, int *nq, int *ldn, int *ldm,
               Py_DECREF(arglist);
               return;
             }
-
-          PyErr_Print();
-          tmpobj = PyObject_GetAttrString(odr_global.fcn, "__name__");
-          if (tmpobj == NULL)
-            goto fail;
-
-          str1 =
-            PyString_FromString
-            ("Error occurred while calling the Python function named ");
-          if (str1 == NULL)
-            {
-              Py_DECREF(tmpobj);
-              goto fail;
-            }
-          PyString_ConcatAndDel(&str1, tmpobj);
-          PyErr_SetString(odr_error, PyString_AsString(str1));
-          Py_DECREF(str1);
           goto fail;
         }
 
@@ -153,8 +134,6 @@ void fcn_callback(int *n, int *m, int *np, int *nq, int *ldn, int *ldm,
 
       if ((result = PyEval_CallObject(odr_global.fjacb, arglist)) == NULL)
         {
-          PyObject *tmpobj, *str1;
-
           if (PyErr_ExceptionMatches(odr_stop))
             {
               /* stop, don't fail */
@@ -163,23 +142,6 @@ void fcn_callback(int *n, int *m, int *np, int *nq, int *ldn, int *ldm,
               Py_DECREF(arglist);
               return;
             }
-
-          PyErr_Print();
-          tmpobj = PyObject_GetAttrString(odr_global.fjacb, "__name__");
-          if (tmpobj == NULL)
-            goto fail;
-
-          str1 =
-            PyString_FromString
-            ("Error occurred while calling the Python function named ");
-          if (str1 == NULL)
-            {
-              Py_DECREF(tmpobj);
-              goto fail;
-            }
-          PyString_ConcatAndDel(&str1, tmpobj);
-          PyErr_SetString(odr_error, PyString_AsString(str1));
-          Py_DECREF(str1);
           goto fail;
         }
 
@@ -231,8 +193,6 @@ void fcn_callback(int *n, int *m, int *np, int *nq, int *ldn, int *ldm,
 
       if ((result = PyEval_CallObject(odr_global.fjacd, arglist)) == NULL)
         {
-          PyObject *tmpobj, *str1;
-
           if (PyErr_ExceptionMatches(odr_stop))
             {
               /* stop, don't fail */
@@ -241,23 +201,6 @@ void fcn_callback(int *n, int *m, int *np, int *nq, int *ldn, int *ldm,
               Py_DECREF(arglist);
               return;
             }
-
-          PyErr_Print();
-          tmpobj = PyObject_GetAttrString(odr_global.fjacd, "__name__");
-          if (tmpobj == NULL)
-            goto fail;
-
-          str1 =
-            PyString_FromString
-            ("Error occurred while calling the Python function named ");
-          if (str1 == NULL)
-            {
-              Py_DECREF(tmpobj);
-              goto fail;
-            }
-          PyString_ConcatAndDel(&str1, tmpobj);
-          PyErr_SetString(odr_error, PyString_AsString(str1));
-          Py_DECREF(str1);
           goto fail;
         }
 

--- a/scipy/optimize/minpack.h
+++ b/scipy/optimize/minpack.h
@@ -31,7 +31,7 @@ the result tuple when the full_output argument is non-zero.
 #include "Python.h"
 #if PY_VERSION_HEX >= 0x03000000
     #define PyString_FromString PyBytes_FromString
-    #define PyString_ConcatAndDel PyBytes_ConcatAndDel
+    #define PyString_Concat PyBytes_Concat
     #define PyString_AsString PyBytes_AsString
     #define PyInt_FromLong PyLong_FromLong
 #endif
@@ -127,8 +127,8 @@ static PyObject *call_python_function(PyObject *func, npy_intp n, double *x, PyO
   */
 
   PyArrayObject *sequence = NULL;
-  PyObject *arglist = NULL, *tmpobj = NULL;
-  PyObject *arg1 = NULL, *str1 = NULL;
+  PyObject *arglist = NULL;
+  PyObject *arg1 = NULL;
   PyObject *result = NULL;
   PyArrayObject *result_array = NULL;
 
@@ -153,15 +153,7 @@ static PyObject *call_python_function(PyObject *func, npy_intp n, double *x, PyO
           arguments are in another passed variable.
    */
   if ((result = PyEval_CallObject(func, arglist))==NULL) {
-    PyErr_Print();
-    tmpobj = PyObject_GetAttrString(func, "__name__");
-    if (tmpobj == NULL) goto fail;
-    str1 = PyString_FromString("Error occurred while calling the Python function named ");
-    if (str1 == NULL) { Py_DECREF(tmpobj); goto fail;}
-    PyString_ConcatAndDel(&str1, tmpobj);
-    PyErr_SetString(error_obj, PyString_AsString(str1));
-    Py_DECREF(str1);
-    goto fail;
+      goto fail;
   }
 
   if ((result_array = (PyArrayObject *)PyArray_ContiguousFromObject(result, NPY_DOUBLE, dim-1, dim))==NULL) 
@@ -177,16 +169,3 @@ static PyObject *call_python_function(PyObject *func, npy_intp n, double *x, PyO
   Py_XDECREF(arg1);
   return NULL;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/scipy/optimize/tests/test_regression.py
+++ b/scipy/optimize/tests/test_regression.py
@@ -3,7 +3,10 @@
 """
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import TestCase, run_module_suite, assert_almost_equal
+import numpy as np
+from numpy.testing import TestCase, run_module_suite, assert_almost_equal, \
+        assert_raises
+
 import scipy.optimize
 
 class TestRegression(TestCase):
@@ -20,6 +23,21 @@ class TestRegression(TestCase):
         root = scipy.optimize.newton(lambda x: x**2 - 1, x0=2,
                                     fprime=lambda x: 2*x)
         assert_almost_equal(root, 1.0)
+
+    def test_lmdif_errmsg(self):
+        # this shouldn't cause a crash on Python 3
+        class SomeError(Exception):
+            pass
+        counter = [0]
+        def func(x):
+            counter[0] += 1
+            if counter[0] < 3:
+                return x**2 - np.array([9, 10, 11])
+            else:
+                raise SomeError()
+        assert_raises(SomeError,
+                      scipy.optimize.leastsq,
+                      func, [1, 2, 3])
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Somewhat straightforward bugfix for Python 3. (`__name__` is unicode)
