### PR TITLE
BUG: sparse: Allow sparsematrix.multiply to work with vector type ndarrays

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -241,7 +241,16 @@ class _cs_matrix(_data_matrix, _minmax_mixin):
     def multiply(self, other):
         """Point-wise multiplication by another matrix
         """
-        if other.shape != self.shape:
+        # Check if other shape is a vector (e.g. shape = (n,))
+        if len(other.shape) == 1:
+            if self.shape[0] != 1:
+                raise ValueError('inconsistent shapes')
+            elif other.shape[0] != self.shape[1]:
+                raise ValueError('inconsistent shapes')
+            else:
+                return np.multiply(self.todense(),other)
+
+        elif other.shape != self.shape:
             raise ValueError('inconsistent shapes')
 
         if isdense(other):

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -249,25 +249,21 @@ class _cs_matrix(_data_matrix, _minmax_mixin):
         if (isdense(other) or isinstance(other, tuple) or 
             isinstance(other, list)):
             return np.multiply(self.todense(), other)
-        # Sparse matrix or vector. 
+        # Sparse matrix or vector.
         if isspmatrix(other):
             if self.shape == other.shape:
                 other = self.__class__(other)
                 return self._binopt(other, '_elmul_')
-            # singl element
+            # Single element.
             elif other.shape == (1,1):
                 return self.__mul__(other.tocsc().data[0])
             elif self.shape == (1,1):
                 return other.__mul__(self.tocsc().data[0])
-            # a row times a column
-            if self.shape[::-1] == other.shape:
-                if self.shape[1] == other.shape[0] == 1:
-                    return self._mul_sparse_matrix(other.tocsc())
-                elif self.shape[0] == other.shape[1] == 1:
-                    return other._mul_sparse_matrix(self.tocsc())
-                else:
-                    raise ValueError("inconsistent shapes")
-
+            # A row times a column.
+            elif self.shape[1] == other.shape[0] == 1:
+                return self._mul_sparse_matrix(other.tocsc())
+            elif self.shape[0] == other.shape[1] == 1:
+                return other._mul_sparse_matrix(self.tocsc())
             # Row vector times matrix. other is a row.
             elif other.shape[0] == 1 and self.shape[1] == other.shape[1]:
                 other = dia_matrix((other.toarray().ravel(), [0]), 

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -242,6 +242,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin):
         """Point-wise multiplication by another matrix
         """
         # Check if other shape is a vector (e.g. shape = (n,))
+        if isscalarlike(other):
+            return self.__mul__(other)
         if len(other.shape) == 1:
             if self.shape[0] != 1:
                 raise ValueError('inconsistent shapes')

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -241,9 +241,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin):
     def multiply(self, other):
         """Point-wise multiplication by another matrix
         """
-        # Check if other shape is a vector (e.g. shape = (n,))
+        # scalar mult if necessary
         if isscalarlike(other):
             return self.__mul__(other)
+        # Check if other shape is a vector (e.g. shape = (n,))
         if len(other.shape) == 1:
             if self.shape[0] != 1:
                 raise ValueError('inconsistent shapes')

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -408,6 +408,28 @@ class _TestCommon:
         assert_almost_equal( Asp.multiply(Dsp).todense(), A*D) #sparse/sparse
         assert_almost_equal( Asp.multiply(D),             A*D) #sparse/dense
 
+    def test_elementwise_multiply_broadcast(self):
+        A = array([4])
+        B = array([[-9]])
+        C = array([1,-1,0])
+        D = array([[7,9,-9]])
+        E = array([[8,6,3],[-4,3,2],[6,6,6]])
+
+        # Rank 1 arrays can't be cast as spmatrices (A and C) so leave
+        # them out.
+        Bsp = self.spmatrix(B)
+        Dsp = self.spmatrix(D)
+        Esp = self.spmatrix(E)
+        
+        assert_almost_equal( Esp.multiply(A).todense(),     E*A) #sparse/dense
+
+        assert_almost_equal( Esp.multiply(Bsp).todense(),   E*B) #sparse/sparse
+        assert_almost_equal( Esp.multiply(B).todense(),     E*B) #sparse/dense
+
+        assert_almost_equal( Esp.multiply(C),               E*C) #sparse/dense
+
+        assert_almost_equal( Esp.multiply(Dsp),             E*D) #sparse/sparse
+        assert_almost_equal( Esp.multiply(D),               E*D) #sparse/dense
 
     def test_elementwise_divide(self):
         expected = [[1,0,0,1],[1,0,1,0],[0,1,0,0]]

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -415,6 +415,7 @@ class _TestCommon:
         D = array([[7,9,-9]])
         E = array([[3],[2],[1]])
         F = array([[8,6,3],[-4,3,2],[6,6,6]])
+        G = [1, 2, 3]
 
         # Rank 1 arrays can't be cast as spmatrices (A and C) so leave
         # them out.
@@ -423,14 +424,17 @@ class _TestCommon:
         Esp = self.spmatrix(E)
         Fsp = self.spmatrix(F)
         
+        assert_almost_equal( Fsp.multiply(6).todense(),         F*6) #sparse/scalar
         assert_almost_equal( Fsp.multiply(A),                   F*A) #sparse/dense
         assert_almost_equal( Fsp.multiply(Bsp).todense(),       F*B) #sparse/sparse
         assert_almost_equal( Fsp.multiply(B),                   F*B) #sparse/dense
         assert_almost_equal( Fsp.multiply(C),                   F*C) #sparse/dense
         assert_almost_equal( Fsp.multiply(Dsp).todense(),       F*D) #sparse/sparse
         assert_almost_equal( Fsp.multiply(D),                   F*D) #sparse/dense
-        assert_almost_equal( Fsp.multiply(E),                   F*E)
-        assert_almost_equal( Fsp.multiply(Esp).todense(),       F*E)
+        assert_almost_equal( Fsp.multiply(E),                   F*E) #sparse/dense
+        assert_almost_equal( Fsp.multiply(Esp).todense(),       F*E) #spares/sparse
+        assert_almost_equal( Fsp.multiply(G),                   F*G) #sparse/dense
+
 
     def test_elementwise_divide(self):
         expected = [[1,0,0,1],[1,0,1,0],[0,1,0,0]]

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -423,18 +423,36 @@ class _TestCommon:
         Dsp = self.spmatrix(D)
         Esp = self.spmatrix(E)
         Fsp = self.spmatrix(F)
-        
-        assert_almost_equal( Fsp.multiply(6).todense(),         F*6) #sparse/scalar
-        assert_almost_equal( Fsp.multiply(A),                   F*A) #sparse/dense
-        assert_almost_equal( Fsp.multiply(Bsp).todense(),       F*B) #sparse/sparse
-        assert_almost_equal( Fsp.multiply(B),                   F*B) #sparse/dense
-        assert_almost_equal( Fsp.multiply(C),                   F*C) #sparse/dense
-        assert_almost_equal( Fsp.multiply(Dsp).todense(),       F*D) #sparse/sparse
-        assert_almost_equal( Fsp.multiply(D),                   F*D) #sparse/dense
-        assert_almost_equal( Fsp.multiply(E),                   F*E) #sparse/dense
-        assert_almost_equal( Fsp.multiply(Esp).todense(),       F*E) #spares/sparse
-        assert_almost_equal( Fsp.multiply(G),                   F*G) #sparse/dense
 
+        matrices = [A, B, C, D, E, F, G]
+        spmatrices = [Bsp, Dsp, Esp, Fsp]
+        # sparse/sparse
+        for i in spmatrices:
+            for j in spmatrices:
+                try:
+                    dense_mult = np.multiply(i.todense(), j.todense())
+                except ValueError:
+                    assert_raises(ValueError, i.multiply, j)
+                    continue
+                sp_mult = i.multiply(j)
+                if isspmatrix(sp_mult):
+                    assert_almost_equal(sp_mult.todense(), dense_mult)
+                else:
+                    assert_almost_equal(sp_mult, dense_mult)
+        
+        # sparse/dense
+        for i in spmatrices:
+            for j in matrices:
+                try:
+                    dense_mult = np.multiply(i.todense(), j)
+                except ValueError:
+                    assert_raises(ValueError, i.multiply, j)
+                    continue
+                sp_mult = i.multiply(j)
+                if isspmatrix(sp_mult):
+                    assert_almost_equal(sp_mult.todense(), dense_mult)
+                else:
+                    assert_almost_equal(sp_mult, dense_mult)
 
     def test_elementwise_divide(self):
         expected = [[1,0,0,1],[1,0,1,0],[0,1,0,0]]

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -413,23 +413,24 @@ class _TestCommon:
         B = array([[-9]])
         C = array([1,-1,0])
         D = array([[7,9,-9]])
-        E = array([[8,6,3],[-4,3,2],[6,6,6]])
+        E = array([[3],[2],[1]])
+        F = array([[8,6,3],[-4,3,2],[6,6,6]])
 
         # Rank 1 arrays can't be cast as spmatrices (A and C) so leave
         # them out.
         Bsp = self.spmatrix(B)
         Dsp = self.spmatrix(D)
         Esp = self.spmatrix(E)
+        Fsp = self.spmatrix(F)
         
-        assert_almost_equal( Esp.multiply(A).todense(),     E*A) #sparse/dense
-
-        assert_almost_equal( Esp.multiply(Bsp).todense(),   E*B) #sparse/sparse
-        assert_almost_equal( Esp.multiply(B).todense(),     E*B) #sparse/dense
-
-        assert_almost_equal( Esp.multiply(C),               E*C) #sparse/dense
-
-        assert_almost_equal( Esp.multiply(Dsp),             E*D) #sparse/sparse
-        assert_almost_equal( Esp.multiply(D),               E*D) #sparse/dense
+        assert_almost_equal( Fsp.multiply(A),                   F*A) #sparse/dense
+        assert_almost_equal( Fsp.multiply(Bsp).todense(),       F*B) #sparse/sparse
+        assert_almost_equal( Fsp.multiply(B),                   F*B) #sparse/dense
+        assert_almost_equal( Fsp.multiply(C),                   F*C) #sparse/dense
+        assert_almost_equal( Fsp.multiply(Dsp).todense(),       F*D) #sparse/sparse
+        assert_almost_equal( Fsp.multiply(D),                   F*D) #sparse/dense
+        assert_almost_equal( Fsp.multiply(E),                   F*E)
+        assert_almost_equal( Fsp.multiply(Esp).todense(),       F*E)
 
     def test_elementwise_divide(self):
         expected = [[1,0,0,1],[1,0,1,0],[0,1,0,0]]


### PR DESCRIPTION
This commit allows spmatrix.multiply to be used with vector type (e.g. ndarray.shape = (3,)) ndarray objects. 

This bug was brought up in [trac ticket #1042](http://projects.scipy.org/scipy/ticket/1042)
