### PR TITLE
BUG: sparse: allow matrices to have length 0 dimensions

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -70,7 +70,7 @@ class spmatrix(object):
         except:
             raise TypeError('invalid shape')
 
-        if not (shape[0] >= 1 and shape[1] >= 1):
+        if not (shape[0] >= 0 and shape[1] >= 0):
             raise ValueError('invalid shape')
 
         if (self._shape != shape) and (self._shape is not None):


### PR DESCRIPTION
Fix for ticket 1602

Seems like a silly bug, but now it is consistent with the rest of numpy.
