### PR TITLE
ENH: io/matlab: avoid making copies of zlib compressed data when loading files

### DIFF
--- a/scipy/io/matlab/benchmarks/bench_memusage.py
+++ b/scipy/io/matlab/benchmarks/bench_memusage.py
@@ -108,7 +108,7 @@ def run_monitored(code):
         if ret is not None:
             break
 
-        with open('/proc/%d/status' % process.pid, 'rb') as f:
+        with open('/proc/%d/status' % process.pid, 'r') as f:
             procdata = f.read()
 
         m = re.search('VmRSS:\s*(\d+)\s*kB', procdata, re.S|re.I)

--- a/scipy/io/matlab/benchmarks/bench_memusage.py
+++ b/scipy/io/matlab/benchmarks/bench_memusage.py
@@ -7,13 +7,15 @@ import re
 import subprocess
 import time
 import textwrap
-import resource
 import tempfile
 import warnings
+
+from numpy.testing import dec
 
 import numpy as np
 from scipy.io import savemat, loadmat
 
+@dec.skipif(not sys.platform.startswith('linux'), "Memory benchmark works only on Linux")
 def bench_run():
     mem_info = get_mem_info()
     set_mem_rlimit(int(mem_info['memtotal'] * 0.7))
@@ -139,6 +141,7 @@ def set_mem_rlimit(max_mem):
     Set rlimit to 80% of total system memory, to avoid grinding halt
     because of swapping.
     """
+    import resource
     cur_limit = resource.getrlimit(resource.RLIMIT_AS)
     if cur_limit[0] > 0:
         max_mem = min(max_mem, cur_limit[0])

--- a/scipy/io/matlab/benchmarks/bench_memusage.py
+++ b/scipy/io/matlab/benchmarks/bench_memusage.py
@@ -1,0 +1,149 @@
+# Posix-only benchmark
+from __future__ import division, absolute_import, print_function
+
+import os
+import sys
+import re
+import subprocess
+import time
+import textwrap
+import resource
+import tempfile
+import warnings
+
+import numpy as np
+from scipy.io import savemat, loadmat
+
+def bench_run():
+    mem_info = get_mem_info()
+    set_mem_rlimit(int(mem_info['memtotal'] * 0.7))
+
+    # Setup temp file, make it fit in memory
+    f = tempfile.NamedTemporaryFile(suffix='.mat')
+    os.unlink(f.name)
+
+    max_size = int(mem_info['memtotal'] * 0.7)//4
+    sizes = [1e6, 10e6, 100e6, 300e6, 500e6, 1000e6]
+
+    print_table_row(['** loadmat benchmark'])
+    print_table_row(['size (MB)', 'compression', 'time (s)', 
+                     'peak memory (MB)', 'mem factor'])
+
+    for size in sizes:
+        for compressed in (False, True):
+            if size > max_size:
+                print_table_row(["%.1f" % (size/1e6,), compressed, "SKIP"])
+                continue
+
+            try:
+                x = np.random.rand(size//8).view(dtype=np.uint8)
+                savemat(f.name, dict(x=x), do_compression=compressed, oned_as='row')
+                del x
+            except MemoryError:
+                x = None
+                print_table_row(["%.1f" % (size/1e6,), compressed, "FAIL"])
+                continue
+
+            code = """
+            from scipy.io import loadmat
+            loadmat('%s')
+            """ % (f.name,)
+            time, peak_mem = run_monitored(code)
+
+            print_table_row(["%.1f" % (size/1e6,), compressed, time, 
+                             "%.1f" % (peak_mem/1e6,),
+                             "%.2f x" % (peak_mem/size,)])
+
+    print_table_row(['** savemat memory benchmark'])
+    print_table_row(['size (MB)', 'compression', 'time (s)', 
+                     'peak memory (MB)', 'mem factor'])
+
+    for size in sizes:
+        for compressed in (False, True):
+            if size > max_size:
+                print_table_row(["%.1f" % (size/1e6,), compressed, "SKIP"])
+                continue
+
+            code = """
+            import numpy as np
+            from scipy.io import savemat
+            x = np.random.rand(%d//8).view(dtype=np.uint8)
+            savemat('%s', dict(x=x), do_compression=%r, oned_as='row')
+            """ % (size, f.name, compressed)
+            try:
+                time, peak_mem = run_monitored(code)
+            except AssertionError:
+                print_table_row(["%.1f" % (size/1e6,), compressed, "FAIL"])
+                continue
+
+            print_table_row(["%.1f" % (size/1e6,), compressed, time, 
+                             "%.1f" % (peak_mem/1e6,),
+                             "%.2f x" % (peak_mem/size,)])
+
+def print_table_row(columns):
+    print(" | ".join("%-20s" % x for x in columns))
+
+def run_monitored(code):
+    """
+    Run code in a new Python process, and monitor peak memory usage.
+
+    Returns
+    -------
+    duration : float
+        Duration in seconds (including Python startup time)
+    peak_memusage : float
+        Peak memory usage (rough estimate only) in bytes
+
+    """
+    code = textwrap.dedent(code)
+    process = subprocess.Popen([sys.executable, '-c', code])
+
+    peak_memusage = -1
+
+    start = time.time()
+    while True:
+        ret = process.poll()
+        if ret is not None:
+            break
+
+        with open('/proc/%d/status' % process.pid, 'rb') as f:
+            procdata = f.read()
+
+        m = re.search('VmRSS:\s*(\d+)\s*kB', procdata, re.S|re.I)
+        if m is not None:
+            memusage = float(m.group(1)) * 1e3
+            peak_memusage = max(memusage, peak_memusage)
+        
+        time.sleep(0.01)
+
+    process.wait()
+
+    duration = time.time() - start
+
+    if process.returncode != 0:
+        raise AssertionError("Running failed:\n%s" % code)
+    
+    return duration, peak_memusage
+
+def get_mem_info():
+    """Get information about available memory"""
+    info = {}
+    with open('/proc/meminfo', 'r') as f:
+        for line in f:
+            p = line.split()
+            info[p[0].strip(':').lower()] = float(p[1]) * 1e3
+    return info
+
+def set_mem_rlimit(max_mem):
+    """
+    Set rlimit to 80% of total system memory, to avoid grinding halt
+    because of swapping.
+    """
+    cur_limit = resource.getrlimit(resource.RLIMIT_AS)
+    if cur_limit[0] > 0:
+        max_mem = min(max_mem, cur_limit[0])
+
+    resource.setrlimit(resource.RLIMIT_AS, (max_mem, cur_limit[1]))
+
+if __name__ == "__main__":
+    bench_run()

--- a/scipy/io/matlab/benchmarks/bench_structarr.py
+++ b/scipy/io/matlab/benchmarks/bench_structarr.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 from numpy.testing import *
 
-from io import StringIO
+from io import BytesIO
 
 import numpy as np
 import scipy.io as sio
@@ -19,25 +19,27 @@ def make_structarr(n_vars, n_fields, n_structs):
 
 
 def bench_run():
-    str_io = StringIO()
+    str_io = BytesIO()
     print()
     print('Read / writing matlab structs')
     print('='*60)
-    print(' write |  read |   vars | fields | structs ')
+    print(' write |  read |   vars | fields | structs | compressed')
     print('-'*60)
     print()
     for n_vars, n_fields, n_structs in (
-        (10, 10, 20),):
+        (10, 10, 20), (20, 20, 40), (30, 30, 50)):
         var_dict = make_structarr(n_vars, n_fields, n_structs)
-        str_io = StringIO()
-        write_time = measure('sio.savemat(str_io, var_dict)')
-        read_time = measure('sio.loadmat(str_io)')
-        print('%.5f | %.5f | %5d | %5d | %5d ' % (
-            write_time,
-            read_time,
-            n_vars,
-            n_fields,
-            n_structs))
+        for compression in (False, True):
+            str_io = BytesIO()
+            write_time = measure('sio.savemat(str_io, var_dict, do_compression=%r)' % compression)
+            read_time = measure('sio.loadmat(str_io)')
+            print('%.5f | %.5f | %5d | %5d | %5d | %r' % (
+                write_time,
+                read_time,
+                n_vars,
+                n_fields,
+                n_structs,
+                compression))
 
 
 if __name__ == '__main__' :

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -876,6 +876,7 @@ class MatFile5Writer(object):
                 tag = np.empty((), NDT_TAG_FULL)
                 tag['mdtype'] = miCOMPRESSED
                 tag['byte_count'] = len(out_str)
-                self.file_stream.write(tag.tostring() + out_str)
+                self.file_stream.write(tag.tostring())
+                self.file_stream.write(out_str)
             else: # not compressing
                 self._matrix_writer.write_top(var, asbytes(name), is_global)

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -104,6 +104,8 @@ from .mio5_params import MatlabObject, MatlabFunction, \
         mxCELL_CLASS, mxSTRUCT_CLASS, mxOBJECT_CLASS, mxCHAR_CLASS, \
         mxSPARSE_CLASS, mxDOUBLE_CLASS, mclass_info, mclass_dtypes_template
 
+from .streams import ZlibInputStream
+
 
 class MatFile5Reader(MatFileReader):
     ''' Reader for Mat 5 mat files
@@ -215,19 +217,14 @@ class MatFile5Reader(MatFileReader):
             raise ValueError("Did not read any bytes")
         next_pos = self.mat_stream.tell() + byte_count
         if mdtype == miCOMPRESSED:
-            # make new stream from compressed data
-            data = self.mat_stream.read(byte_count)
+            # Make new stream from compressed data
+            #
             # Some matlab files contain zlib streams without valid
             # Z_STREAM_END termination.  To get round this, we use the
             # decompressobj object, that allows you to decode an
             # incomplete stream.  See discussion at
             # http://bugs.python.org/issue8672
-            dcor = zlib.decompressobj()
-            stream = BytesIO(dcor.decompress(data))
-            # Check the stream is not so broken as to leave cruft behind
-            if not dcor.flush() == b'':
-                raise ValueError("Something wrong with byte stream.")
-            del data
+            stream = ZlibInputStream(self.mat_stream, byte_count)
             self._matrix_reader.set_stream(stream)
             mdtype, byte_count = self._matrix_reader.read_full_tag()
         else:

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -218,12 +218,6 @@ class MatFile5Reader(MatFileReader):
         next_pos = self.mat_stream.tell() + byte_count
         if mdtype == miCOMPRESSED:
             # Make new stream from compressed data
-            #
-            # Some matlab files contain zlib streams without valid
-            # Z_STREAM_END termination.  To get round this, we use the
-            # decompressobj object, that allows you to decode an
-            # incomplete stream.  See discussion at
-            # http://bugs.python.org/issue8672
             stream = ZlibInputStream(self.mat_stream, byte_count)
             self._matrix_reader.set_stream(stream)
             mdtype, byte_count = self._matrix_reader.read_full_tag()

--- a/scipy/io/matlab/streams.pyx
+++ b/scipy/io/matlab/streams.pyx
@@ -107,8 +107,17 @@ cdef class ZlibInputStream(GenericStream):
     ----------
     stream : file-like
         Stream to read compressed data from.
-    stream_length : int, optional
+    max_length : int, optional
         Maximum number of bytes to read from the stream.
+        -1 if the length is unlimited.
+
+    Notes
+    -----
+    Some matlab files contain zlib streams without valid Z_STREAM_END
+    termination.  To get round this, we use the decompressobj object, that
+    allows you to decode an incomplete stream.  See discussion at
+    http://bugs.python.org/issue8672
+
     """
 
     cdef ssize_t _max_length

--- a/scipy/io/matlab/tests/test_streams.py
+++ b/scipy/io/matlab/tests/test_streams.py
@@ -5,8 +5,8 @@
 from __future__ import division, print_function, absolute_import
 
 import os
-
 import sys
+import zlib
 
 from io import BytesIO
 
@@ -26,7 +26,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal, \
      run_module_suite
 
 from scipy.io.matlab.streams import make_stream, \
-    GenericStream, cStringStream, FileStream, \
+    GenericStream, cStringStream, FileStream, ZlibInputStream, \
     _read_into, _read_string
 
 
@@ -100,6 +100,82 @@ def test_read():
         res = _read_string(st, 4)
         yield assert_equal, res, b'ring'
         yield assert_raises, IOError, _read_string, st, 2
+
+
+class TestZlibInputStream(object):
+    def _get_data(self, size):
+        data = np.random.randint(0, 256, size).astype(np.uint8).tostring()
+        stream = BytesIO(zlib.compress(data))
+        return stream, data
+
+    def test_read(self):
+        block_size = 131072
+
+        SIZES = [0, 1, 10, block_size//2, block_size-1,
+                 block_size, block_size+1, 2*block_size-1]
+
+        READ_SIZES = [block_size//2, block_size-1, 
+                      block_size, block_size+1]
+
+        def check(size, read_size):
+            compressed_stream, data = self._get_data(size)
+            stream = ZlibInputStream(compressed_stream)
+            data2 = b''
+            so_far = 0
+            while True:
+                block = stream.read(min(read_size,
+                                        size - so_far))
+                if not block:
+                    break
+                so_far += len(block)
+                data2 += block
+            assert_equal(data, data2)
+
+        for size in SIZES:
+            for read_size in READ_SIZES:
+                yield check, size, read_size
+
+    def test_read_max_length(self):
+        size = 1234
+        data = np.random.randint(0, 256, size).astype(np.uint8).tostring()
+        compressed_data = zlib.compress(data)
+        compressed_stream = BytesIO(compressed_data + b"abbacaca")
+        stream = ZlibInputStream(compressed_stream, len(compressed_data))
+
+        stream.read(len(data))
+        assert_equal(compressed_stream.tell(), len(compressed_data))
+
+        assert_raises(IOError, stream.read, 1)
+
+    def test_seek(self):
+        compressed_stream, data = self._get_data(1024)
+
+        stream = ZlibInputStream(compressed_stream)
+
+        stream.seek(123)
+        p = 123
+        assert_equal(stream.tell(), p)
+        d1 = stream.read(11)
+        assert_equal(d1, data[p:p+11])
+
+        stream.seek(321, 1)
+        p = 123+11+321
+        assert_equal(stream.tell(), p)
+        d2 = stream.read(21)
+        assert_equal(d2, data[p:p+21])
+
+        stream.seek(641, 0)
+        p = 641
+        assert_equal(stream.tell(), p)
+        d3 = stream.read(11)
+        assert_equal(d3, data[p:p+11])
+
+        assert_raises(IOError, stream.seek, 10, 2)
+        assert_raises(IOError, stream.seek, -1, 1)
+        assert_raises(ValueError, stream.seek, 1, 123)
+
+        stream.seek(10000, 1)
+        assert_raises(IOError, stream.read, 12)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
The Matlab IO code makes some copies of the data when loading files with compressed data. This PR changes the code so that it avoids making any copies --- loading 1 GB of compressed data requires now roughly 1 GB of memory.

Closes [Trac #1894](http://projects.scipy.org/scipy/ticket/1894) (note that the test file supplied by the user there is malformed --- do something like `python2.7 -c 'import numpy as np; from scipy.io import savemat; x=np.zeros([int(500e6/8)]); savemat("foo.mat", dict(x=x), do_compression=1)'` to generate a test file.)
