### PR TITLE
Small optimization in LIL __getitem__ and __setitem__

### DIFF
--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -13,13 +13,14 @@ import numpy as np
 from scipy.lib.six.moves import xrange
 
 from .base import spmatrix, isspmatrix
-from .sputils import getdtype, isshape, issequence, isscalarlike, ismatrix
+from .sputils import getdtype, isshape, issequence, isscalarlike, ismatrix, \
+    IndexMixin
 
 from warnings import warn
 from .base import SparseEfficiencyWarning
 
 
-class lil_matrix(spmatrix):
+class lil_matrix(spmatrix, IndexMixin):
     """Row-based linked list sparse matrix
 
     This is an efficient structure for constructing sparse
@@ -224,84 +225,12 @@ class lil_matrix(spmatrix):
         else:
             return self.dtype.type(0)
 
-    def _slicetoarange(self, j, shape):
-        start, stop, step = j.indices(shape)
-        return np.arange(start, stop, step)
-
-    def _unpack_index(self, index):
-        if isinstance(index, tuple):
-            if len(index) == 2:
-                return index
-            elif len(index) == 1:
-                return index[0], slice(None)
-            else:
-                raise IndexError('invalid number of indices')
-        else:
-            return index, slice(None)
-
-    def _boolean_index_to_array(self, i):
-        if i.ndim<2:
-            i = i.nonzero()
-        elif (i.shape[0] > self.shape[0] or i.shape[1] > self.shape[1] or
-              i.ndim > 2):
-            raise IndexError('invalid index shape')
-        else:
-            i = i.nonzero()
-        return i
-
-    def _index_to_arrays(self, i, j):
-        if isinstance(i, np.ndarray) and i.dtype.kind == 'b':
-            i = self._boolean_index_to_array(i)
-            if len(i)==2:
-                if isinstance(j, slice):
-                    j = i[1]
-
-                else:
-                    raise ValueError('too many indices for array')
-            i = i[0]
-        if isinstance(j, np.ndarray) and j.dtype.kind == 'b':
-            j = self._boolean_index_to_array(j)[0]
-
-        i_slice = isinstance(i, slice)
-        if i_slice:
-            i = self._slicetoarange(i, self.shape[0])[:,None]
-        else:
-            i = np.atleast_1d(i)
-
-        if isinstance(j, slice):
-            j = self._slicetoarange(j, self.shape[1])[None,:]
-            if i.ndim == 1:
-                i = i[:,None]
-            elif not i_slice:
-                raise IndexError('index returns 3-dim structure')
-        elif isscalarlike(j):
-            # row vector special case
-            j = np.atleast_1d(j)
-            if i.ndim == 1:
-                i, j = np.broadcast_arrays(i, j)
-                i = i[:, None]
-                j = j[:, None]
-                return i, j
-        else:
-            j = np.atleast_1d(j)
-            if i_slice and j.ndim>1:
-                raise IndexError('index returns 3-dim structure')
-
-        i, j = np.broadcast_arrays(i, j)
-
-        if i.ndim == 1:
-            # return column vectors for 1-D indexing
-            i = i[None,:]
-            j = j[None,:]
-        elif i.ndim > 2:
-            raise IndexError("Index dimension must be <= 2")
-
-        return i, j
-
     def __getitem__(self, index):
         """Return the element(s) index=(i, j), where j may be a slice.
         This always returns a copy for consistency, since slices into
         Python lists return copies.
+
+        Utilities found in IndexMixin
         """
         i, j = self._unpack_index(index)
 
@@ -311,9 +240,10 @@ class lil_matrix(spmatrix):
         i, j = self._index_to_arrays(i, j)
         if i.size == 0:
             return lil_matrix((0,0), dtype=self.dtype)
-        return self.__class__([[self._get1(iii, jjj) for iii, jjj in 
-                               zip(ii, jj)] for ii, jj in 
-                               zip(i.tolist(), j.tolist())])
+        return self.__class__([[self._get1(int(i[ii, jj]), 
+                                           int(j[ii, jj])) for jj in
+                                xrange(i.shape[1])] for ii in 
+                               xrange(i.shape[0])])
 
     def _insertat2(self, row, data, j, x):
         """ helper for __setitem__: insert a value in the given row/data at
@@ -373,9 +303,8 @@ class lil_matrix(spmatrix):
             raise ValueError("shape mismatch in assignment")
 
         # Set values
-        for ii, jj, xx in zip(i.tolist(), j.tolist(), x.tolist()):
-            for iii, jjj, xxx in zip(ii, jj, xx):
-                self._insertat2(self.rows[iii], self.data[iii], jjj, xxx)
+        for ii, jj, xx in zip(i.ravel(), j.ravel(), x.ravel()):
+            self._insertat2(self.rows[int(ii)], self.data[int(ii)], int(jj), xx)
 
 
     def _mul_scalar(self, other):

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -309,11 +309,11 @@ class lil_matrix(spmatrix):
             return self._get1(int(i), int(j))
 
         i, j = self._index_to_arrays(i, j)
-        if i.size == 0:
+        if i.shape[0] == 0:
             return lil_matrix((0,0), dtype=self.dtype)
-        return self.__class__([[self._get1(int(i[ii, jj]), int(j[ii, jj])) for jj in
-                                xrange(i.shape[1])] for ii in 
-                               xrange(i.shape[0])])
+        return self.__class__([[self._get1(iii, jjj) for iii, jjj in 
+                               zip(ii, jj)] for ii, jj in 
+                               zip(i.tolist(), j.tolist())])
 
     def _insertat2(self, row, data, j, x):
         """ helper for __setitem__: insert a value in the given row/data at
@@ -373,8 +373,9 @@ class lil_matrix(spmatrix):
             raise ValueError("shape mismatch in assignment")
 
         # Set values
-        for ii, jj, xx in zip(i.ravel(), j.ravel(), x.ravel()):
-            self._insertat2(self.rows[int(ii)], self.data[int(ii)], int(jj), xx)
+        for ii, jj, xx in zip(i.tolist(), j.tolist(), x.tolist()):
+            for iii, jjj, xxx in zip(ii, jj, xx):
+                self._insertat2(self.rows[iii], self.data[iii], jjj, xxx)
 
 
     def _mul_scalar(self, other):

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -240,10 +240,9 @@ class lil_matrix(spmatrix, IndexMixin):
         i, j = self._index_to_arrays(i, j)
         if i.size == 0:
             return lil_matrix((0,0), dtype=self.dtype)
-        return self.__class__([[self._get1(int(i[ii, jj]), 
-                                           int(j[ii, jj])) for jj in
-                                xrange(i.shape[1])] for ii in 
-                               xrange(i.shape[0])])
+        return self.__class__([[self._get1(iii, jjj) for iii, jjj in 
+                                zip(ii, jj)] for ii, jj in 
+                               zip(i.tolist(), j.tolist())])
 
     def _insertat2(self, row, data, j, x):
         """ helper for __setitem__: insert a value in the given row/data at

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -309,7 +309,7 @@ class lil_matrix(spmatrix):
             return self._get1(int(i), int(j))
 
         i, j = self._index_to_arrays(i, j)
-        if i.shape[0] == 0:
+        if i.size == 0:
             return lil_matrix((0,0), dtype=self.dtype)
         return self.__class__([[self._get1(iii, jjj) for iii, jjj in 
                                zip(ii, jj)] for ii, jj in 

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -132,3 +132,82 @@ def ismatrix(t):
 
 def isdense(x):
     return isinstance(x, np.ndarray)
+
+class IndexMixin(object):
+    """
+    This class simply exists to hold the methods necessary for fancy indexing.
+    """
+    def _slicetoarange(self, j, shape):
+        start, stop, step = j.indices(shape)
+        return np.arange(start, stop, step)
+
+    def _unpack_index(self, index):
+        if isinstance(index, tuple):
+            if len(index) == 2:
+                return index
+            elif len(index) == 1:
+                return index[0], slice(None)
+            else:
+                raise IndexError('invalid number of indices')
+        else:
+            return index, slice(None)
+
+    def _boolean_index_to_array(self, i):
+        if i.ndim<2:
+            i = i.nonzero()
+        elif (i.shape[0] > self.shape[0] or i.shape[1] > self.shape[1] or
+              i.ndim > 2):
+            raise IndexError('invalid index shape')
+        else:
+            i = i.nonzero()
+        return i
+
+    def _index_to_arrays(self, i, j):
+        if isinstance(i, np.ndarray) and i.dtype.kind == 'b':
+            i = self._boolean_index_to_array(i)
+            if len(i)==2:
+                if isinstance(j, slice):
+                    j = i[1]
+
+                else:
+                    raise ValueError('too many indices for array')
+            i = i[0]
+        if isinstance(j, np.ndarray) and j.dtype.kind == 'b':
+            j = self._boolean_index_to_array(j)[0]
+
+        i_slice = isinstance(i, slice)
+        if i_slice:
+            i = self._slicetoarange(i, self.shape[0])[:,None]
+        else:
+            i = np.atleast_1d(i)
+
+        if isinstance(j, slice):
+            j = self._slicetoarange(j, self.shape[1])[None,:]
+            if i.ndim == 1:
+                i = i[:,None]
+            elif not i_slice:
+                raise IndexError('index returns 3-dim structure')
+        elif isscalarlike(j):
+            # row vector special case
+            j = np.atleast_1d(j)
+            if i.ndim == 1:
+                i, j = np.broadcast_arrays(i, j)
+                i = i[:, None]
+                j = j[:, None]
+                return i, j
+        else:
+            j = np.atleast_1d(j)
+            if i_slice and j.ndim>1:
+                raise IndexError('index returns 3-dim structure')
+
+        i, j = np.broadcast_arrays(i, j)
+
+        if i.ndim == 1:
+            # return column vectors for 1-D indexing
+            i = i[None,:]
+            j = j[None,:]
+        elif i.ndim > 2:
+            raise IndexError("Index dimension must be <= 2")
+
+        return i, j
+

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -712,7 +712,7 @@ class _TestGetSet:
             for j in range(-N, N):
                 assert_equal(A[i,j], D[i,j])
 
-        for ij in [(0,3),(-1,3),(4,0),(4,3),(4,-1)]:
+        for ij in [(0,3),(-1,3),(4,0),(4,3),(4,-1),(1,2,3)]:
             assert_raises(IndexError, A.__getitem__, ij)
 
     def test_setelement(self):


### PR DESCRIPTION
At the very last moment, when **getitem** and **setitem** are looping through the element-wise indices, the indices are converted to lists. Benchmarks:

import scipy.sparse as sparse
import numpy as np

np.random.seed(1234)
x = sparse.rand(10000, 10000, 0.001).tolil()

Before:

%timeit x[np.arange(100), np.arange(100)]
1000 loops, best of 3: 789 us

%timeit x[np.arange(100), np.arange(100)] = 1
1000 loops, best of 3: 695 us

Now:

%timeit x[np.arange(100), np.arange(100)]
1000 loops, best of 3: 706 us

%timeit x[np.arange(100), np.arange(100)] = 1
1000 loops, best of 3: 609 us
