### PR TITLE
Rename README.txt to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Currently SciPy consists of the following files and directories:
   THANKS.txt
     SciPy developers and contributors. Please keep it up to date!!
 
-  README.txt
+  README.rst
     SciPy structure (this document).
 
   setup.py

--- a/pavement.py
+++ b/pavement.py
@@ -644,5 +644,5 @@ def write_log():
 
 @task
 def write_release_and_log():
-    write_release_task(os.path.join(options.installers.releasedir, 'README.txt'))
+    write_release_task(os.path.join(options.installers.releasedir, 'README.rst'))
     write_log_task(os.path.join(options.installers.releasedir, 'Changelog'))


### PR DESCRIPTION
Doesn't [this](https://github.com/kermit666/scipy/tree/patch-1) look a bit more readable on GitHub?
