### PR TITLE
frechet derivative of the matrix exponential with tests

### DIFF
--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -93,6 +93,7 @@ Matrix Functions
    signm - Matrix sign
    sqrtm - Matrix square root
    funm - Evaluating an arbitrary matrix function
+   expm_frechet - Frechet derivative of the matrix exponential
 
 
 Matrix Equation Solvers

--- a/scipy/linalg/_expm_frechet.py
+++ b/scipy/linalg/_expm_frechet.py
@@ -1,0 +1,274 @@
+"""Frechet derivative of the matrix exponential."""
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+import scipy.linalg
+
+__all__ = ['expm_frechet']
+
+
+def expm_frechet(A, E, method="SPS", compute_expm=True, check_finite=True):
+    """
+    Frechet derivative of the matrix exponential of A in the direction E.
+
+    .. versionadded:: 0.13.0
+
+    Parameters
+    ----------
+    A : (N, N) array_like
+        Matrix of which to take the matrix exponential.
+    E : (N, N) array_like
+        Matrix direction in which to take the Frechet derivative.
+    method : str, optional
+        Choice of algorithm.  Should be one of
+
+        - `SPS`
+        - `blockEnlarge`
+
+    compute_expm : bool, optional
+        Whether to compute also `expm_A` in addition to `expm_frechet_AE`.
+        Default is True.
+    check_finite : boolean, optional
+        Whether to check that the input matrix contains only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination) if the inputs do contain infinities or NaNs.
+
+    Returns
+    -------
+    expm_A : ndarray
+        Matrix exponential of A.
+    expm_frechet_AE : ndarray
+        Frechet derivative of the matrix exponential of A in the direction E.
+
+    For ``compute_expm = False``, only `expm_frechet_AE` is returned.
+
+    See also
+    --------
+    expm : Compute the exponential of a matrix.
+
+    Notes
+    -----
+    This section describes the available implementations that can be selected
+    by the `method` parameter. The default method is *SPS*.
+
+    Method *blockEnlarge* is a naive algorithm.
+
+    Method *SPS* is Scaling-Pade-Squaring [1]_.
+    It is a sophisticated implementation which should take
+    only about 3/8 as much time as the naive implementation.
+    The asymptotics are the same.
+
+    References
+    ----------
+    .. [1] Awad H. Al-Mohy and Nicholas J. Higham (2009)
+           Computing the Frechet Derivative of the Matrix Exponential,
+           with an application to Condition Number Estimation.
+           SIAM Journal On Matrix Analysis and Applications.,
+           30 (4). pp. 1639-1657. ISSN 1095-7162
+
+    Examples
+    --------
+    >>> import scipy.linalg
+    >>> A = np.random.randn(3, 3)
+    >>> E = np.random.randn(3, 3)
+    >>> expm_A, expm_frechet_AE = scipy.linalg.expm_frechet(A, E)
+    >>> expm_A.shape, expm_frechet_AE.shape
+    ((3, 3), (3, 3))
+
+    >>> import scipy.linalg
+    >>> A = np.random.randn(3, 3)
+    >>> E = np.random.randn(3, 3)
+    >>> expm_A, expm_frechet_AE = scipy.linalg.expm_frechet(A, E)
+    >>> M = np.zeros((6, 6))
+    >>> M[:3, :3] = A; M[:3, 3:] = E; M[3:, 3:] = A
+    >>> expm_M = scipy.linalg.expm(M)
+    >>> np.allclose(expm_A, expm_M[:3, :3])
+    True
+    >>> np.allclose(expm_frechet_AE, expm_M[:3, 3:])
+    True
+
+    """
+    if check_finite:
+        A = np.asarray_chkfinite(A)
+        E = np.asarray_chkfinite(E)
+    else:
+        A = np.asarray(A)
+        E = np.asarray(E)
+    if A.ndim != 2 or A.shape[0] != A.shape[1]:
+        raise ValueError('expected A to be a square matrix')
+    if E.ndim != 2 or E.shape[0] != E.shape[1]:
+        raise ValueError('expected E to be a square matrix')
+    if A.shape != E.shape:
+        raise ValueError('expected A and E to be the same shape')
+    if method == 'SPS':
+        expm_A, expm_frechet_AE = expm_frechet_algo_64(A, E)
+    elif method == 'blockEnlarge':
+        expm_A, expm_frechet_AE = expm_frechet_block_enlarge(A, E)
+    else:
+        raise ValueError('Unknown implementation %s' % method)
+    if compute_expm:
+        return expm_A, expm_frechet_AE
+    else:
+        return expm_frechet_AE
+
+
+def expm_frechet_block_enlarge(A, E):
+    """
+    This is a helper function, mostly for testing and profiling.
+    Return expm(A), frechet(A, E)
+    """
+    n = A.shape[0]
+    M = np.vstack([
+        np.hstack([A, E]),
+        np.hstack([np.zeros_like(A), A])])
+    expm_M = scipy.linalg.expm(M)
+    return expm_M[:n, :n], expm_M[:n, n:]
+
+
+"""
+Maximal values ell_m of ||2**-s A|| such that the backward error bound
+does not exceed 2**-53.
+"""
+ell_table_61 = (
+        None,
+        # 1
+        2.11e-8,
+        3.56e-4,
+        1.08e-2,
+        6.49e-2,
+        2.00e-1,
+        4.37e-1,
+        7.83e-1,
+        1.23e0,
+        1.78e0,
+        2.42e0,
+        # 11
+        3.13e0,
+        3.90e0,
+        4.74e0,
+        5.63e0,
+        6.56e0,
+        7.52e0,
+        8.53e0,
+        9.56e0,
+        1.06e1,
+        1.17e1,
+        )
+
+
+# The b vectors and U and V are copypasted
+# from scipy.sparse.linalg.matfuncs.py.
+# M, Lu, Lv follow (6.11), (6.12), (6.13), (3.3)
+
+def _diff_pade3(A, E, ident):
+    b = (120., 60., 12., 1.)
+    A2 = A.dot(A)
+    M2 = np.dot(A, E) + np.dot(E, A)
+    U = A.dot(b[3]*A2 + b[1]*ident)
+    V = b[2]*A2 + b[0]*ident
+    Lu = A.dot(b[3]*M2) + E.dot(b[3]*A2 + b[1]*ident)
+    Lv = b[2]*M2
+    return U, V, Lu, Lv
+
+def _diff_pade5(A, E, ident):
+    b = (30240., 15120., 3360., 420., 30., 1.)
+    A2 = A.dot(A)
+    M2 = np.dot(A, E) + np.dot(E, A)
+    A4 = np.dot(A2, A2)
+    M4 = np.dot(A2, M2) + np.dot(M2, A2)
+    U = A.dot(b[5]*A4 + b[3]*A2 + b[1]*ident)
+    V = b[4]*A4 + b[2]*A2 + b[0]*ident
+    Lu = (A.dot(b[5]*M4 + b[3]*M2) +
+            E.dot(b[5]*A4 + b[3]*A2 + b[1]*ident))
+    Lv = b[4]*M4 + b[2]*M2
+    return U, V, Lu, Lv
+
+def _diff_pade7(A, E, ident):
+    b = (17297280., 8648640., 1995840., 277200., 25200., 1512., 56., 1.)
+    A2 = A.dot(A)
+    M2 = np.dot(A, E) + np.dot(E, A)
+    A4 = np.dot(A2, A2)
+    M4 = np.dot(A2, M2) + np.dot(M2, A2)
+    A6 = np.dot(A2, A4)
+    M6 = np.dot(A4, M2) + np.dot(M4, A2)
+    U = A.dot(b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
+    V = b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
+    Lu = (A.dot(b[7]*M6 + b[5]*M4 + b[3]*M2) +
+            E.dot(b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident))
+    Lv = b[6]*M6 + b[4]*M4 + b[2]*M2
+    return U, V, Lu, Lv
+
+def _diff_pade9(A, E, ident):
+    b = (17643225600., 8821612800., 2075673600., 302702400., 30270240.,
+            2162160., 110880., 3960., 90., 1.)
+    A2 = A.dot(A)
+    M2 = np.dot(A, E) + np.dot(E, A)
+    A4 = np.dot(A2, A2)
+    M4 = np.dot(A2, M2) + np.dot(M2, A2)
+    A6 = np.dot(A2, A4)
+    M6 = np.dot(A4, M2) + np.dot(M4, A2)
+    A8 = np.dot(A4, A4)
+    M8 = np.dot(A4, M4) + np.dot(M4, A4)
+    U = A.dot(b[9]*A8 + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
+    V = b[8]*A8 + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
+    Lu = (A.dot(b[9]*M8 + b[7]*M6 + b[5]*M4 + b[3]*M2) +
+            E.dot(b[9]*A8 + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident))
+    Lv = b[8]*M8 + b[6]*M6 + b[4]*M4 + b[2]*M2
+    return U, V, Lu, Lv
+
+
+def expm_frechet_algo_64(A, E):
+    n = A.shape[0]
+    s = None
+    ident = np.identity(n)
+    A_norm_1 = scipy.linalg.norm(A, 1)
+    m_pade_pairs = (
+            (3, _diff_pade3),
+            (5, _diff_pade5),
+            (7, _diff_pade7),
+            (9, _diff_pade9))
+    for m, pade in m_pade_pairs:
+        if A_norm_1 <= ell_table_61[m]:
+            U, V, Lu, Lv = pade(A, E, ident)
+            s = 0
+            break
+    if s is None:
+        # scaling
+        s = max(0, int(np.ceil(np.log2(A_norm_1 / ell_table_61[13]))))
+        A = A * 2.0**-s
+        E = E * 2.0**-s
+        # pade order 13
+        A2 = np.dot(A, A)
+        M2 = np.dot(A, E) + np.dot(E, A)
+        A4 = np.dot(A2, A2)
+        M4 = np.dot(A2, M2) + np.dot(M2, A2)
+        A6 = np.dot(A2, A4)
+        M6 = np.dot(A4, M2) + np.dot(M4, A2)
+        b = (64764752532480000., 32382376266240000., 7771770303897600.,
+                1187353796428800., 129060195264000., 10559470521600.,
+                670442572800., 33522128640., 1323241920., 40840800., 960960.,
+                16380., 182., 1.)
+        W1 = b[13]*A6 + b[11]*A4 + b[9]*A2
+        W2 = b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident
+        Z1 = b[12]*A6 + b[10]*A4 + b[8]*A2
+        Z2 = b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
+        W = np.dot(A6, W1) + W2
+        U = np.dot(A, W)
+        V = np.dot(A6, Z1) + Z2
+        Lw1 = b[13]*M6 + b[11]*M4 + b[9]*M2
+        Lw2 = b[7]*M6 + b[5]*M4 + b[3]*M2
+        Lz1 = b[12]*M6 + b[10]*M4 + b[8]*M2
+        Lz2 = b[6]*M6 + b[4]*M4 + b[2]*M2
+        Lw = np.dot(A6, Lw1) + np.dot(M6, W1) + Lw2
+        Lu = np.dot(A, Lw) + np.dot(E, W)
+        Lv = np.dot(A6, Lz1) + np.dot(M6, Z1) + Lz2
+    # factor once and solve twice
+    lu_piv = scipy.linalg.lu_factor(-U + V)
+    R = scipy.linalg.lu_solve(lu_piv, U + V)
+    L = scipy.linalg.lu_solve(lu_piv, Lu + Lv + np.dot((Lu - Lv), R))
+    # squaring
+    for k in range(s):
+        L = np.dot(R, L) + np.dot(L, R)
+        R = np.dot(R, R)
+    return R, L
+

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -5,7 +5,8 @@
 from __future__ import division, print_function, absolute_import
 
 __all__ = ['expm','expm2','expm3','cosm','sinm','tanm','coshm','sinhm',
-           'tanhm','logm','funm','signm','sqrtm']
+           'tanhm','logm','funm','signm','sqrtm',
+           'expm_frechet']
 
 from numpy import asarray, Inf, dot, eye, diag, exp, \
      product, logical_not, ravel, transpose, conjugate, \
@@ -22,6 +23,7 @@ from .special_matrices import triu, all_mat
 from .decomp import eig
 from .decomp_svd import orth, svd
 from .decomp_schur import schur, rsf2csf
+from ._expm_frechet import expm_frechet
 import warnings
 
 eps = np.finfo(float).eps

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -8,12 +8,17 @@
 
 from __future__ import division, print_function, absolute_import
 
-import numpy as np
-from numpy import array, identity, dot, sqrt, double, exp, random
-from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal, \
-     assert_array_almost_equal_nulp
+import random
 
-from scipy.linalg import signm, logm, sqrtm, expm, expm2, expm3
+import numpy as np
+from numpy import array, identity, dot, sqrt, double
+from numpy.testing import (TestCase, run_module_suite,
+        assert_array_almost_equal, assert_array_almost_equal_nulp,
+        assert_allclose, decorators)
+
+import scipy.linalg
+from scipy.linalg import signm, logm, sqrtm, expm, expm2, expm3, expm_frechet
+import scipy.linalg._expm_frechet
 
 
 class TestSignM(TestCase):
@@ -105,6 +110,124 @@ class TestExpM(TestCase):
         a = array([[1j,1],[-1,-2j]])
         assert_array_almost_equal(expm(a), expm2(a))
         assert_array_almost_equal(expm(a), expm3(a))
+
+
+class TestExpmFrechet(TestCase):
+
+    def test_expm_frechet(self):
+        # a test of the basic functionality
+        M = np.array([
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+            [0, 0, 1, 2],
+            [0, 0, 5, 6],
+            ], dtype=float)
+        A = np.array([
+            [1, 2],
+            [5, 6],
+            ], dtype=float)
+        E = np.array([
+            [3, 4],
+            [7, 8],
+            ], dtype=float)
+        expected_expm = scipy.linalg.expm(A)
+        expected_frechet = scipy.linalg.expm(M)[:2, 2:]
+        for kwargs in ({}, {'method':'SPS'}, {'method':'blockEnlarge'}):
+            observed_expm, observed_frechet = expm_frechet(A, E, **kwargs)
+            assert_allclose(expected_expm, observed_expm)
+            assert_allclose(expected_frechet, observed_frechet)
+
+    def test_small_norm_expm_frechet(self):
+        # methodically test matrices with a range of norms, for better coverage
+        M_original = np.array([
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+            [0, 0, 1, 2],
+            [0, 0, 5, 6],
+            ], dtype=float)
+        A_original = np.array([
+            [1, 2],
+            [5, 6],
+            ], dtype=float)
+        E_original = np.array([
+            [3, 4],
+            [7, 8],
+            ], dtype=float)
+        A_original_norm_1 = scipy.linalg.norm(A_original, 1)
+        selected_m_list = [1, 3, 5, 7, 9, 11, 13, 15]
+        m_neighbor_pairs = zip(selected_m_list[:-1], selected_m_list[1:])
+        for ma, mb in m_neighbor_pairs:
+            ell_a = scipy.linalg._expm_frechet.ell_table_61[ma]
+            ell_b = scipy.linalg._expm_frechet.ell_table_61[mb]
+            target_norm_1 = 0.5 * (ell_a + ell_b)
+            scale = target_norm_1 / A_original_norm_1
+            M = scale * M_original
+            A = scale * A_original
+            E = scale * E_original
+            expected_expm = scipy.linalg.expm(A)
+            expected_frechet = scipy.linalg.expm(M)[:2, 2:]
+            observed_expm, observed_frechet = expm_frechet(A, E)
+            assert_allclose(expected_expm, observed_expm)
+            assert_allclose(expected_frechet, observed_frechet)
+
+    def test_fuzz(self):
+        # try a bunch of crazy inputs
+        rfuncs = (
+                np.random.uniform,
+                np.random.normal,
+                np.random.standard_cauchy,
+                np.random.exponential)
+        ntests = 100
+        for i in range(ntests):
+            rfunc = random.choice(rfuncs)
+            target_norm_1 = random.expovariate(1.0)
+            n = random.randrange(2, 16)
+            A_original = rfunc(size=(n,n))
+            E_original = rfunc(size=(n,n))
+            A_original_norm_1 = scipy.linalg.norm(A_original, 1)
+            scale = target_norm_1 / A_original_norm_1
+            A = scale * A_original
+            E = scale * E_original
+            M = np.vstack([
+                np.hstack([A, E]),
+                np.hstack([np.zeros_like(A), A])])
+            expected_expm = scipy.linalg.expm(A)
+            expected_frechet = scipy.linalg.expm(M)[:n, n:]
+            observed_expm, observed_frechet = expm_frechet(A, E)
+            assert_allclose(expected_expm, observed_expm)
+            assert_allclose(expected_frechet, observed_frechet)
+
+    def test_problematic_matrix(self):
+        # this test case uncovered a bug which has since been fixed
+        A = np.array([
+                [ 1.50591997,  1.93537998],
+                [ 0.41203263,  0.23443516],
+                ], dtype=float)
+        E = np.array([
+                [1.87864034, 2.07055038],
+                [1.34102727, 0.67341123],
+                ], dtype=float)
+        A_norm_1 = scipy.linalg.norm(A, 1)
+        sps_expm, sps_frechet = expm_frechet(
+                A, E, method='SPS')
+        blockEnlarge_expm, blockEnlarge_frechet = expm_frechet(
+                A, E, method='blockEnlarge')
+        assert_allclose(sps_expm, blockEnlarge_expm)
+        assert_allclose(sps_frechet, blockEnlarge_frechet)
+
+    @decorators.slow
+    @decorators.skipif(True, 'this test is deliberately slow')
+    def test_medium_matrix(self):
+        # profile this to see the speed difference
+        n = 1000
+        A = np.random.exponential(size=(n, n))
+        E = np.random.exponential(size=(n, n))
+        sps_expm, sps_frechet = expm_frechet(
+                A, E, method='SPS')
+        blockEnlarge_expm, blockEnlarge_frechet = expm_frechet(
+                A, E, method='blockEnlarge')
+        assert_allclose(sps_expm, blockEnlarge_expm)
+        assert_allclose(sps_frechet, blockEnlarge_frechet)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is written based on my interpretation of http://eprints.ma.man.ac.uk/1218/ so that expm_frechet(A, E) is the Frechet derivative of the matrix exponential of matrix A in the direction of matrix E.

I did not go out of my way to support sparse matrices, so they are probably not supported, whereas expm currently supports sparse matrices.
