### PR TITLE
BUG: signal: fix bode() and freqresp() so they can handle the unfortunate case where the num attribute of an lti instance is a 2D array.

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -892,16 +892,7 @@ def bode(system, w=None, n=100):
     >>> plt.show()
 
     """
-    if isinstance(system, lti):
-        sys = system
-    else:
-        sys = lti(*system)
-
-    if w is None:
-        worN = n
-    else:
-        worN = w
-    w, y = freqs(sys.num, sys.den, worN=worN)
+    w, y = freqresp(system, w=w, n=n)
 
     mag = 20.0 * numpy.log10(abs(y))
     phase = numpy.arctan2(y.imag, y.real) * 180.0 / numpy.pi
@@ -961,9 +952,17 @@ def freqresp(system, w=None, n=10000):
     else:
         sys = lti(*system)
 
+    if sys.inputs != 1 or sys.outputs != 1:
+        raise ValueError("freqresp() requires a SISO (single input, single "
+                         "output) system.")
+
     if w is not None:
         worN = w
     else:
         worN = n
 
-    return freqs(sys.num, sys.den, worN=worN)
+    # In the call to freqs(), sys.num.ravel() is used because there are
+    # cases where sys.num is a 2-D array with a single row.
+    w, h = freqs(sys.num.ravel(), sys.den, worN=worN)
+
+    return w, h

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -864,9 +864,8 @@ def bode(system, w=None, n=100):
         calculated.
     n : int, optional
         Number of frequency points to compute if `w` is not given. The `n`
-        frequencies are logarithmically spaced in the range from two orders of
-        magnitude before the minimum (slowest) pole to two orders of magnitude
-        after the maximum (fastest) pole.
+        frequencies are logarithmically spaced in an interval chosen to
+        include the influence of the poles and zeros of the system.
 
     Returns
     -------
@@ -919,9 +918,8 @@ def freqresp(system, w=None, n=10000):
         set will be calculated.
     n : int, optional
         Number of frequency points to compute if `w` is not given. The `n`
-        frequencies are logarithmically spaced in the range from two orders of
-        magnitude before the minimum (slowest) pole to two orders of magnitude
-        after the maximum (fastest) pole.
+        frequencies are logarithmically spaced in an interval chosen to
+        include the influence of the poles and zeros of the system.
 
     Returns
     -------

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -310,6 +310,18 @@ class Test_bode(object):
         system = lti([1], [1, 0, 100])
         w, mag, phase = bode(system, n=2)
 
+    def test_from_state_space(self):
+        # Ensure that bode works with a system that was created from the
+        # state space representation matrices A, B, C, D.  In this case,
+        # system.num will be a 2-D array with shape (1, n+1), where (n,n)
+        # is the shape of A.
+        A = np.array([[1.0, 2.0], [3.0, 4.0]])
+        B = np.array([[5.0], [6.0]])
+        C = np.array([[7.0, 8.0]])
+        D = np.array([[9.0]])
+        system = lti(A, B, C, D)
+        w, mag, phase = bode(system, n=2)
+
 
 class Test_freqresp(object):
     
@@ -378,6 +390,18 @@ class Test_freqresp(object):
         system = lti([1], [1, 0])
         w, H = freqresp(system, n=2)
         assert_equal(w[0], 0.01)  # a fail would give not-a-number
+
+    def test_from_state_space(self):
+        # Ensure that freqresp works with a system that was created from the
+        # state space representation matrices A, B, C, D.  In this case,
+        # system.num will be a 2-D array with shape (1, n+1), where (n,n) is
+        # the shape of A.
+        A = np.array([[1.0, 2.0], [3.0, 4.0]])
+        B = np.array([[5.0], [6.0]])
+        C = np.array([[7.0, 8.0]])
+        D = np.array([[9.0]])
+        system = lti(A, B, C, D)
+        w, mag, phase = bode(system, n=2)
 
 
 if __name__ == "__main__":

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -80,11 +80,9 @@ class Test_lsim2(object):
         D = np.zeros((1,2))
 
         t = np.linspace(0, 10.0, 101)
-        warnings.simplefilter("ignore", BadCoefficients)
-        try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BadCoefficients)
             tout, y, x = lsim2((A,B,C,D), T=t, X0=[1.0, 1.0])
-        finally:
-            del warnings.filters[0]
         expected_y = np.exp(-tout)
         expected_x0 = np.exp(-tout)
         expected_x1 = np.exp(-2.0*tout)
@@ -288,10 +286,7 @@ class Test_bode(object):
         """Test that bode() finds a reasonable frequency range."""
         # 1st order low-pass filter: H(s) = 1 / (s + 1)
         system = lti([1], [1, 1])
-        vals = linalg.eigvals(system.A)
-        minpole = min(abs(np.real(vals)))
-        maxpole = max(abs(np.real(vals)))
-        n = 10;
+        n = 10 
         # Expected range is from 0.01 to 10.
         expected_w = np.logspace(-2, 1, n)
         w, mag, phase = bode(system, n=n)
@@ -315,12 +310,19 @@ class Test_bode(object):
         # state space representation matrices A, B, C, D.  In this case,
         # system.num will be a 2-D array with shape (1, n+1), where (n,n)
         # is the shape of A.
-        A = np.array([[1.0, 2.0], [3.0, 4.0]])
-        B = np.array([[5.0], [6.0]])
-        C = np.array([[7.0, 8.0]])
-        D = np.array([[9.0]])
-        system = lti(A, B, C, D)
-        w, mag, phase = bode(system, n=2)
+        # A Butterworth lowpass filter is used, so we know the exact
+        # frequency response.
+        a = np.array([1.0, 2.0, 2.0, 1.0])
+        A = linalg.companion(a).T
+        B = np.array([[0.0],[0.0],[1.0]])
+        C = np.array([[1.0, 0.0, 0.0]])
+        D = np.array([[0.0]])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BadCoefficients)
+            system = lti(A, B, C, D)
+        w, mag, phase = bode(system, n=100)
+        expected_magnitude = 20 * np.log10(np.sqrt(1.0 / (1.0 + w**6)))
+        assert_almost_equal(mag, expected_magnitude)
 
 
 class Test_freqresp(object):
@@ -376,9 +378,6 @@ class Test_freqresp(object):
         # 1st order low-pass filter: H(s) = 1 / (s + 1)
         # Expected range is from 0.01 to 10.
         system = lti([1], [1, 1])
-        vals = linalg.eigvals(system.A)
-        minpole = min(abs(np.real(vals)))
-        maxpole = max(abs(np.real(vals)))
         n = 10
         expected_w = np.logspace(-2, 1, n)
         w, H = freqresp(system, n=n)
@@ -396,12 +395,19 @@ class Test_freqresp(object):
         # state space representation matrices A, B, C, D.  In this case,
         # system.num will be a 2-D array with shape (1, n+1), where (n,n) is
         # the shape of A.
-        A = np.array([[1.0, 2.0], [3.0, 4.0]])
-        B = np.array([[5.0], [6.0]])
-        C = np.array([[7.0, 8.0]])
-        D = np.array([[9.0]])
-        system = lti(A, B, C, D)
-        w, mag, phase = bode(system, n=2)
+        # A Butterworth lowpass filter is used, so we know the exact
+        # frequency response.
+        a = np.array([1.0, 2.0, 2.0, 1.0])
+        A = linalg.companion(a).T
+        B = np.array([[0.0],[0.0],[1.0]])
+        C = np.array([[1.0, 0.0, 0.0]])
+        D = np.array([[0.0]])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BadCoefficients)
+            system = lti(A, B, C, D)            
+        w, H = freqresp(system, n=100)
+        expected_magnitude = np.sqrt(1.0 / (1.0 + w**6))
+        assert_almost_equal(np.abs(H), expected_magnitude)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes https://github.com/scipy/scipy/issues/2382.
