### PR TITLE
Adding startiter keyword to scipy.integrate.quadrature

### DIFF
--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -106,8 +106,8 @@ def vectorize1(func, args=(), vec_func=False):
             return output
     return vfunc
 
-def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, startiter=1,
-               maxiter=50, vec_func=True):
+def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8,
+               maxiter=50, vec_func=True, startiter=1):
     """
     Compute a definite integral using fixed-tolerance Gaussian quadrature.
 
@@ -127,13 +127,13 @@ def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, startiter=1,
     tol, rol : float, optional
         Iteration stops when error between last two iterates is less than
         `tol` OR the relative change is less than `rtol`.
-    startiter : int, optional
-        Initial order of Gaussian quadrature.
     maxiter : int, optional
         Maximum order of Gaussian quadrature.
     vec_func : bool, optional
         True or False if func handles arrays as arguments (is
         a "vector" function). Default is True.
+    startiter : int, optional
+        Starting order of Gaussian quadrature.
 
     Returns
     -------

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -106,8 +106,8 @@ def vectorize1(func, args=(), vec_func=False):
             return output
     return vfunc
 
-def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, maxiter=50,
-               vec_func=True):
+def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, startiter=1,
+               maxiter=50, vec_func=True):
     """
     Compute a definite integral using fixed-tolerance Gaussian quadrature.
 
@@ -127,8 +127,10 @@ def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, maxiter=50,
     tol, rol : float, optional
         Iteration stops when error between last two iterates is less than
         `tol` OR the relative change is less than `rtol`.
+    startiter : int, optional
+        Initial order of Gaussian quadrature.
     maxiter : int, optional
-        Maximum number of iterations.
+        Maximum order of Gaussian quadrature.
     vec_func : bool, optional
         True or False if func handles arrays as arguments (is
         a "vector" function). Default is True.
@@ -157,7 +159,7 @@ def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, maxiter=50,
     vfunc = vectorize1(func, args, vec_func=vec_func)
     val = np.inf
     err = np.inf
-    for n in xrange(1, maxiter+1):
+    for n in xrange(startiter, maxiter+1):
         newval = fixed_quad(vfunc, a, b, (), n)[0]
         err = abs(newval-val)
         val = newval


### PR DESCRIPTION
For some numerical integrations it is known that a minimum number of Gaussian quadrature points is required. Adding the startiter keyword to the scipy.integrate.quadrature function will allow the starting order of the Gaussian quadrature to be specified.  This will save the lower orders being evaluated unnecessarily.
For example, one may know that the integration may require between 14 and 20 points.  Let us take the worst case scenario of 20 points. If you start from 1 point the function to be integrated will have to be called 20 times (assuming that it can be vectorized), but the total number of evaluations within the function will be 210. This number is the sum of the arithmetic sequence - order 1 requires 1 evaluation, order 2 requires 2 evaluations, etc.
On the other hand if you start from 14 then the total number of evaluations within the function will be 119.  This is a computational saving of 43%, significant if the evaluated function is somewhat expensive.
