### PR TITLE
Fixed cython.wraparound(False) bug in scipy/spatial/ckdtree.pyx

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -1164,7 +1164,6 @@ cdef class cKDTree:
 
 
     @cython.boundscheck(False)
-    @cython.wraparound(False)
     def query(cKDTree self, object x, np.intp_t k=1, np.float64_t eps=0,
               np.float64_t p=2, np.float64_t distance_upper_bound=infinity):
         """query(self, x, k=1, eps=0, p=2, distance_upper_bound=np.inf)
@@ -1864,7 +1863,6 @@ cdef class cKDTree:
         return 0
 
     @cython.boundscheck(False)
-    @cython.wraparound(False)
     def count_neighbors(cKDTree self, cKDTree other, object r, np.float64_t p=2.):
         """count_neighbors(self, other, r, p)
 


### PR DESCRIPTION
Two wrapper methods in ckdtree.pyx (query and count_neighbors) were marked with decorator @cython.wraparound(False), but one of them (query) referred to np.shape(x)[-1].  Since these methods are only wrappers to the methods that do the real work (__query and __count_neighbors_traverse) and are not performance critical, I've simply removed the @cython.wraparound(False) wrapper.  This preserves code clarity and fixes issue #2427.
