### PR TITLE
BUG: interpolate: sproots works only for cubic splines

### DIFF
--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -622,10 +622,10 @@ def sproot(tck,mest=10):
     tck : tuple
         A tuple (t,c,k) containing the vector of knots,
         the B-spline coefficients, and the degree of the spline.
-        The number of knots must be >= 8.
+        The number of knots must be >= 8, and the degree must be 3.
         The knots must be a montonically increasing sequence.
     mest : int
-     An estimate of the number of zeros (Default is 10).
+        An estimate of the number of zeros (Default is 10).
 
     Returns
     -------
@@ -650,8 +650,8 @@ def sproot(tck,mest=10):
 
     """
     t,c,k=tck
-    if k==4: t=t[1:-1]
-    if k==5: t=t[2:-2]
+    if k != 3:
+        raise ValueError("sproot works only for cubic (k=3) splines")
     try:
         c[0][0]
         parametric = True

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -1,7 +1,8 @@
 from __future__ import division, print_function, absolute_import
 
 from numpy.testing import assert_equal, assert_almost_equal, assert_array_equal, \
-        assert_array_almost_equal, assert_allclose, assert_, TestCase
+        assert_array_almost_equal, assert_allclose, assert_, TestCase, \
+        assert_raises
 from numpy import array, diff, shape, asarray, pi, sin, cos, arange, dot, \
      ravel, sqrt, inf, round
 from scipy.interpolate.fitpack import splrep, splev, bisplrep, bisplev, \
@@ -140,11 +141,13 @@ class TestSmokeTests(TestCase):
               (f(None),repr(round(a,3)),repr(round(b,3))))
         for k in range(1,6):
             tck=splrep(x,v,s=s,per=per,k=k,xe=xe)
-            roots = sproot(tck)
             if k == 3:
-                assert_allclose(roots, pi*array([1, 2, 3, 4]),
-                                rtol=1e-3)
-            put('  %d  : %s'%(k,repr(roots.tolist())))
+                roots = sproot(tck)
+                assert_allclose(splev(roots, tck), 0, atol=1e-10, rtol=1e-10)
+                assert_allclose(roots, pi*array([1, 2, 3, 4]), rtol=1e-3)
+                put('  %d  : %s'%(k,repr(roots.tolist())))
+            else:
+                assert_raises(ValueError, sproot, tck)
 
     def check_4(self,f=f1,per=0,s=0,a=0,b=2*pi,N=20,xb=None,xe=None,
               ia=0,ib=2*pi,dx=0.2*pi):


### PR DESCRIPTION
The `sproot` subroutine in FITPACK actually [works correctly only for cubic splines](https://github.com/scipy/scipy/blob/master/scipy/interpolate/fitpack/sproot.f#L2).

The `sproot` function in Scipy attempted to do something also with splines of other orders, but there's no mathematical justification for what was attempted, and it produces wrong results. So, accept only order 3 splines from now on. (UnivariateSpline.roots correctly accepts only order 3 splines.)

Fixes gh-2438
