### PR TITLE
ENH: Add feature to read/write floating point WAV files to scipy.io.wavfile module.

### DIFF
--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -54,7 +54,11 @@ def _check_roundtrip(rate, dtype, channels):
         data = np.random.rand(100, channels)
         if channels == 1:
             data = data[:,0]
-        data = (data*128).astype(dtype)
+        if dtype.kind == 'f':
+            # The range of the float type should be in [-1, 1]
+            data = data.astype(dtype)
+        else:
+            data = (data*128).astype(dtype)
 
         wavfile.write(tmpfile, rate, data)
 
@@ -70,10 +74,13 @@ def _check_roundtrip(rate, dtype, channels):
         os.unlink(tmpfile)
 
 def test_write_roundtrip():
-    for signed in ('i', 'u'):
+    for signed in ('i', 'u', 'f'):
         for size in (1, 2, 4, 8):
             if size == 1 and signed == 'i':
                 # signed 8-bit integer PCM is not allowed
+                continue
+            if (size == 1 or size == 2) and signed == 'f':
+                # 8- or 16-bit float PCM is not expected
                 continue
             for endianness in ('>', '<'):
                 if size == 1 and endianness == '<':

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -177,13 +177,17 @@ def write(filename, rate, data):
       (Nsamples, Nchannels).
 
     """
+    dkind = data.dtype.kind
+    if not (dkind == 'i' or dkind == 'f' or (dkind == 'u' and data.dtype.itemsize == 1)):
+        raise TypeError("Unsupported data type '%s'" % data.dtype)
+
     fid = open(filename, 'wb')
     fid.write(b'RIFF')
     fid.write(b'\x00\x00\x00\x00')
     fid.write(b'WAVE')
     # fmt chunk
     fid.write(b'fmt ')
-    if data.dtype.kind == 'f':
+    if dkind == 'f':
         comp = 3
     else:
         comp = 1


### PR DESCRIPTION
The enhancement adds a feature to read and write floating point WAV files to `scipy.io.wavfile.read` and `scipy.io.wavfile.write` functions where currently only integer types are supported.
