### PR TITLE
expm 2009

### DIFF
--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -136,8 +136,34 @@ def expm(A):
 
 def expm_2009(A):
     """
-    Algorithm (6.1) which is a simplification of algorithm (5.1).
+    Compute the matrix exponential using Pade approximation.
+
+    Parameters
+    ----------
+    A : (M,M) array or sparse matrix
+        2D Array or Matrix (sparse or dense) to be exponentiated
+
+    Returns
+    -------
+    expA : (M,M) ndarray
+        Matrix exponential of `A`
+
+    Notes
+    -----
+    This is algorithm (6.1) which is a simplification of algorithm (5.1).
+
+    References
+    ----------
+    .. [1] Awad H. Al-Mohy and Nicholas J. Higham (2009)
+           "A New Scaling and Squaring Algorithm for th Matrix Exponential."
+           SIAM Journal on Matrix Analysis and Applications.
+           31 (3). pp. 970-989. ISSN 1095-7162
+
     """
+
+    #XXX This function intends to use a fast norm estimate,
+    #XXX but because the fast norm estimation code has not yet made its
+    #XXX way into scipy, we are using slow exact norm calculations.
 
     # Define the identity matrix depending on sparsity.
     if isspmatrix(A):

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -12,13 +12,18 @@ from __future__ import division, print_function, absolute_import
 
 __all__ = ['expm', 'inv']
 
+import math
+
 from numpy import asarray, dot, eye, ceil, log2
 from numpy import matrix as mat
 import numpy as np
 
+import scipy.linalg
+import scipy.special
 from scipy.linalg.misc import norm
 from scipy.linalg.basic import solve, inv
 
+import scipy.sparse
 from scipy.sparse.base import isspmatrix
 from scipy.sparse.construct import eye as speye
 from scipy.sparse.linalg import spsolve
@@ -128,57 +133,371 @@ def expm(A):
 
     return R
 
-# implementation of Pade approximations of various degree using the algorithm presented in [Higham 2005]
+
+def expm_2009(A):
+    """
+    Algorithm (6.1) which is a simplification of algorithm (5.1).
+    """
+
+    # Define the identity matrix depending on sparsity.
+    if isspmatrix(A):
+        ident = speye(A.shape[0], A.shape[1], dtype=A.dtype, format=A.format)
+    else:
+        A = asarray(A)
+        ident = eye(A.shape[0], A.shape[1], dtype=A.dtype)
+
+    # Try Pade order 3.
+    A2 = A.dot(A)
+    d6 = _onenorm_of_power(A2, 3)**(1/6.)
+    eta_1 = max(_onenorm_of_power(A2, 2) **(1/4.), d6)
+    if eta_1 < 1.495585217958292e-002 and _ell(A, 3) == 0:
+        U, V = _pade3(A, ident, A2)
+        return _solve_P_Q(U, V)
+
+    # Try Pade order 5.
+    A4 = A2.dot(A2)
+    d4 = scipy.linalg.norm(A4, 1)**(1/4.)
+    eta_2 = max(d4, d6)
+    if eta_2 < 2.539398330063230e-001 and _ell(A, 5) == 0:
+        U, V = _pade5(A, ident, A2, A4)
+        return _solve_P_Q(U, V)
+
+    # Try Pade orders 7 and 9.
+    A6 = A2.dot(A4)
+    d6 = scipy.linalg.norm(A6, 1)**(1/6.)
+    d8 = _onenorm_of_power(A4, 2)**(1/8.)
+    eta_3 = max(d6, d8)
+    if eta_3 < 9.504178996162932e-001 and _ell(A, 7) == 0:
+        U, V = _pade7(A, ident, A2, A4, A6)
+        return _solve_P_Q(U, V)
+    if eta_3 < 2.097847961257068e+000 and _ell(A, 9) == 0:
+        U, V = _pade9(A, ident, A2, A4, A6)
+        return _solve_P_Q(U, V)
+
+    # Use Pade order 13.
+    d10 = _onenorm_of_product(A4, A6)**(1/10.)
+    eta_4 = max(d8, d10)
+    eta_5 = min(eta_3, eta_4)
+    theta_13 = 4.25
+    s = max(int(math.ceil(math.log(eta_5 / theta_13, 2))), 0)
+    s = s + _ell(2**-s * A, 13)
+    A *= 2**-s
+    A2 *= 2**(-2*s)
+    A4 *= 2**(-4*s)
+    A6 *= 2**(-6*s)
+    U, V = _pade13(A, ident, A2, A4, A6)
+    X = _solve_P_Q(U, V)
+    if _is_upper_triangular(A):
+        # Invoke Code Fragment 2.1.
+        _fragment_2_1(X, A, s)
+    else:
+        # X = r_13(A)^(2^s) by repeated squaring.
+        for i in range(s):
+            X = X.dot(X)
+    return X
+
+
+def _is_upper_triangular(A):
+    """
+    A helper function for expm_2009.
+    """
+    if isspmatrix(A):
+        return _sparse_count_nonzero(scipy.sparse.tril(A, -1)) == 0
+    else:
+        return np.count_nonzero(np.tril(A, -1)) == 0
+
+
+def _sparse_count_nonzero(A):
+    # XXX this is obviously not the right way to do this...
+    return np.count_nonzero(A.todense())
+
+
+def _solve_P_Q(U, V):
+    """
+    A helper function for expm_2009.
+    """
+    P = U + V
+    Q = -U + V
+    if isspmatrix(U):
+        R = spsolve(Q, P)
+    else:
+        R = solve(Q, P)
+    return R
+
+
+def _sinch(x):
+    """
+    Stably evaluate sinch.
+
+    Notes
+    -----
+    The strategy of falling back to a sixth order Taylor expansion
+    was suggested by the Spallation Neutron Source docs
+    which was found on the internet by google search.
+    http://www.ornl.gov/~t6p/resources/xal/javadoc/gov/sns/tools/math/ElementaryFunction.html
+    The details of the cutoff point and the Horner-like evaluation
+    was picked without reference to anything in particular.
+
+    Note that sinch is not currently implemented in scipy.special,
+    whereas the "engineer's" definition of sinc is implemented.
+    The implementation of sinc involves a scaling factor of pi
+    that distinguishes it from the "mathematician's" version of sinc.
+
+    """
+
+    # If x is small then use sixth order Taylor expansion.
+    # How small is small? I am using the point where the relative error
+    # of the approximation is less than 1e-14.
+    # If x is large then directly evaluate sinh(x) / x.
+    x2 = x*x
+    if abs(x) < 0.0135:
+        return 1 + (x2/6.)*(1 + (x2/20.)*(1 + (x2/42.)))
+    else:
+        return scipy.special.sinh(x) / x
+
+
+def _eq_10_42(lam_1, lam_2, t_12):
+    """
+    Equation (10.42) of Functions of Matrices: Theory and Computation.
+
+    Notes
+    -----
+    This is a helper function for _fragment_2_1 of expm_2009.
+    Equation (10.42) is on page 251 in the section on Schur algorithms.
+    In particular, section 10.4.3 explains the Schur-Parlett algorithm.
+    expm([[lam_1, t_12], [0, lam_1])
+    =
+    [[exp(lam_1), t_12*exp((lam_1 + lam_2)/2)*sinch((lam_1 - lam_2)/2)],
+    [0, exp(lam_2)]
+    """
+
+    # The plain formula t_12 * (exp(lam_2) - exp(lam_2)) / (lam_2 - lam_1)
+    # apparently suffers from cancellation, according to Higham's textbook.
+    # A nice implementation of sinch, defined as sinh(x)/x,
+    # will apparently work around the cancellation.
+    a = 0.5 * (lam_1 + lam_2)
+    b = 0.5 * (lam_1 - lam_2)
+    return t_12 * math.exp(a) * _sinch(b)
+
+
+def _fragment_2_1(X, T, s):
+    """
+    A helper function for expm_2009.
+    """
+    # Form X = r_m(2^-s T)
+    # Replace diag(X) by exp(2^-s diag(T)).
+    n = X.shape[0]
+    diag_T = np.diag(T)
+
+    # XXX Can this chunk be vectorized?
+    scale = 2 ** -s
+    exp_diag = np.exp(scale * diag_T)
+    for k in range(n):
+        X[k, k] = exp_diag[k]
+
+    for i in range(s-1, -1, -1):
+        scale = 2 ** -i
+        X = X.dot(X)
+
+        # Replace diag(X) by exp(2^-i diag(T)).
+        # XXX Can this chunk be vectorized?
+        exp_diag = np.exp(scale * diag_T)
+        for k in range(n):
+            X[k, k] = exp_diag[k]
+
+        # Replace (first) superdiagonal of X by explicit formula
+        # for superdiagonal of exp(2^-i T) from Eq (10.42) of 
+        # the author's 2008 textbook
+        # Functions of Matrices: Theory and Computation.
+        # XXX Can this chunk be vectorized?
+        for k in range(n-1):
+            lam_1 = scale * diag_T[k]
+            lam_2 = scale * diag_T[k+1]
+            t_12 = scale * T[k, k+1]
+            X[k, k+1] = _eq_10_42(lam_1, lam_2, t_12)
+
+
+def _ell(A, m):
+    """
+    A helper function for expm_2009.
+
+    Parameters
+    ----------
+    A : linear operator
+        A linear operator whose norm of power we care about.
+    m : int
+        The power of the linear operator
+
+    Returns
+    -------
+    value : int
+        A value related to a bound.
+
+    """
+    power = 2*m + 1
+
+    # The c_i are explained in (2.2) and (2.6) of the 2005 expm paper.
+    # They are coefficients of terms of a generating function series expansion.
+    c_numerator = pow(-1, power)*math.factorial(power)*math.factorial(power)
+    c_denominator = math.factorial(power*2)*math.factorial(power*2+1)
+    c_reciprocal = c_denominator / c_numerator
+    c = 1 / float(c_reciprocal)
+
+    # This is explained after Eq. (1.2) of the 2009 expm paper.
+    # It is the "unit roundoff" of IEEE double precision arithmetic.
+    u = 2**-53
+
+    # This should be computed using an estimate,
+    # but for now we are computing it exactly and inefficiently.
+    est = _onenorm_of_power(abs(A), power)
+
+    alpha = abs(c) * est / scipy.linalg.norm(A, 1)
+    return max(int(math.ceil(math.log(alpha/u, 2) / (2 * m))), 0)
+
+
+def _wrapped_onenorm(A):
+    """
+    Compute the 1-norm of a linear operator.
+
+    Parameters
+    ----------
+    A : linear operator
+        Linear operator whose 1-norm is requested.
+
+    Returns
+    -------
+    value : float
+        The 1-norm of the linear operator.
+
+    Notes
+    -----
+    It would be nice if this function did not have to exist.
+
+    """
+    if isspmatrix(A):
+        return max(abs(A).sum(axis=0).flat)
+    else:
+        return scipy.linalg.norm(asarray(A), 1)
+
+
+def _onenorm_of_product(*args):
+    """
+    Compute the 1-norm of a product of linear operators.
+
+    Parameters
+    ----------
+    args : sequence of linear operators
+        This is the sequence of operators whose 1-norm of product
+        is to be computed.
+
+    Returns
+    -------
+    value : float
+        The 1-norm of the product of the operators.
+
+    Notes
+    -----
+    This function is inexcusably inefficient for anything but testing.
+    It is a placeholder for a more efficient 1-norm estimation function.
+
+    """
+    if not args:
+        return 1.0
+    M_product = args[0]
+    for M in args[1:]:
+        M_product = M_product.dot(M)
+    return _wrapped_onenorm(M_product)
+
+
+def _onenorm_of_power(M, power):
+    """
+    Compute the 1-norm of a power of a linear operator.
+
+    Parameters
+    ----------
+    M : linear operator
+        The linear operator whose 1-norm of a power is to be computed.
+    power : nonnegative int
+        The requested power of the linear operator.
+
+    Returns
+    -------
+    value : float
+        The 1-norm of the power of the operator.
+
+    Notes
+    -----
+    This function is extremely inefficient.
+    It is a placeholder for a more efficient 1-norm estimation function.
+
+    """
+    if not power:
+        return 1.0
+    if int(power) != power or power < 1:
+        raise ValueError('expected a nonnegative integer power')
+    M_power = np.linalg.matrix_power(M, power)
+    return _wrapped_onenorm(M_power)
+
+
+
+# Implementation of Pade approximations of various degree
+# using the algorithm presented in [Higham 2005].
 # These should apply to both dense and sparse matricies.
 # ident is the identity matrix, which matches A in being sparse or dense.
-
-
-def _pade3(A, ident):
+def _pade3(A, ident, A2=None):
     b = (120., 60., 12., 1.)
-    A2 = A.dot(A)
+    if A2 is None:
+        A2 = A.dot(A)
     U = A.dot(b[3]*A2 + b[1]*ident)
     V = b[2]*A2 + b[0]*ident
     return U,V
 
-
-def _pade5(A, ident):
+def _pade5(A, ident, A2=None, A4=None):
     b = (30240., 15120., 3360., 420., 30., 1.)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
+    if A2 is None:
+        A2 = A.dot(A)
+    if A4 is None:
+        A4 = A2.dot(A2)
     U = A.dot(b[5]*A4 + b[3]*A2 + b[1]*ident)
     V = b[4]*A4 + b[2]*A2 + b[0]*ident
     return U,V
 
-
-def _pade7(A, ident):
+def _pade7(A, ident, A2=None, A4=None, A6=None):
     b = (17297280., 8648640., 1995840., 277200., 25200., 1512., 56., 1.)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
-    A6 = A4.dot(A2)
+    if A2 is None:
+        A2 = A.dot(A)
+    if A4 is None:
+        A4 = A2.dot(A2)
+    if A6 is None:
+        A6 = A4.dot(A2)
     U = A.dot(b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
     V = b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
     return U,V
 
-
-def _pade9(A, ident):
+def _pade9(A, ident, A2=None, A4=None, A6=None):
     b = (17643225600., 8821612800., 2075673600., 302702400., 30270240.,
                 2162160., 110880., 3960., 90., 1.)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
-    A6 = A4.dot(A2)
+    if A2 is None:
+        A2 = A.dot(A)
+    if A4 is None:
+        A4 = A2.dot(A2)
+    if A6 is None:
+        A6 = A4.dot(A2)
     A8 = A6.dot(A2)
     U = A.dot(b[9]*A8 + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
     V = b[8]*A8 + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
     return U,V
 
-
-def _pade13(A, ident):
+def _pade13(A, ident, A2=None, A4=None, A6=None):
     b = (64764752532480000., 32382376266240000., 7771770303897600.,
     1187353796428800., 129060195264000., 10559470521600., 670442572800.,
     33522128640., 1323241920., 40840800., 960960., 16380., 182., 1.)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
-    A6 = A4.dot(A2)
+    if A2 is None:
+        A2 = A.dot(A)
+    if A4 is None:
+        A4 = A2.dot(A2)
+    if A6 is None:
+        A6 = A4.dot(A2)
     U = A.dot(A6.dot(b[13]*A6 + b[11]*A4 + b[9]*A2) + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
     V = A6.dot(b[12]*A6 + b[10]*A4 + b[8]*A2) + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
     return U,V

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -122,7 +122,6 @@ def expm(A):
     Q = -U + V  # q_m(A) : denominator
 
     if Aissparse:
-        from scipy.sparse.linalg import spsolve
         R = spsolve(Q, P)
     else:
         R = solve(Q,P)

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -21,7 +21,7 @@ import numpy as np
 import scipy.linalg
 import scipy.special
 from scipy.linalg.misc import norm
-from scipy.linalg.basic import solve, inv
+from scipy.linalg.basic import solve
 
 import scipy.sparse
 import scipy.sparse.linalg

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -181,10 +181,10 @@ def expm_2009(A):
     theta_13 = 4.25
     s = max(int(math.ceil(math.log(eta_5 / theta_13, 2))), 0)
     s = s + _ell(2**-s * A, 13)
-    A *= 2**-s
-    A2 *= 2**(-2*s)
-    A4 *= 2**(-4*s)
-    A6 *= 2**(-6*s)
+    A = A * 2**-s
+    A2 = A2 * 2**(-2*s)
+    A4 = A4 * 2**(-4*s)
+    A6 = A6 * 2**(-6*s)
     U, V = _pade13(A, ident, A2, A4, A6)
     X = _solve_P_Q(U, V)
     if _is_upper_triangular(A):

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -7,16 +7,19 @@
 """
 from __future__ import division, print_function, absolute_import
 
+import math
+
 import numpy as np
 from numpy import array, eye, dot, sqrt, double, exp, random
 from numpy.testing import (TestCase, run_module_suite,
         assert_array_almost_equal, assert_array_almost_equal_nulp,
-        assert_allclose)
+        assert_allclose, assert_)
 
+import scipy.linalg
 from scipy.sparse import csc_matrix
 from scipy.sparse.construct import eye as speye
 from scipy.sparse.linalg import expm
-from scipy.sparse.linalg.matfuncs import expm_2009
+from scipy.sparse.linalg.matfuncs import expm_2009, _is_upper_triangular
 from scipy.linalg import logm
 
 
@@ -73,17 +76,26 @@ class TestExpM(TestCase):
             [-3.07408665108297e+25, 1.62463553675545e+17, 3.04699053651329e+25],
             [1.09189154376804e+17, -577057840.468934, -1.08226721572342e+17]])
 
-        # This is the correct answer, to not great precision.
+        # This is the correct answer.
         correct_solution = np.array([
-            [0.446849, 1.54044e-09, 0.462811],
-            [-5743070, -0.015283, -4526540],
-            [0.447723, 1.5427e-09, 0.463481]])
+            [0.446849468283175, 1.54044157383952e-09, 0.462811453558774],
+            [-5743067.77947947, -0.0152830038686819, -4526542.71278401],
+            [0.447722977849494, 1.54270484519591e-09, 0.463480648837651]])
 
         # Assert that the Higham 2005 expm gives the wrong answer.
         assert_allclose(expm(A), wrong_solution)
 
         # Assert that the Higham 2009 expm gives the correct answer.
-        assert_allclose(expm_2009(A), correct_solution, rtol=1e-4)
+        assert_allclose(expm_2009(A), correct_solution)
+
+    def test_expm_2009_random_upper_triangular(self):
+        random.seed(1234)
+        n = 10
+        nsamples = 20
+        for i in range(nsamples):
+            A = np.triu(np.random.randn(n, n))
+            assert_(_is_upper_triangular(A))
+            assert_allclose(expm_2009(A), expm(A))
 
 
 if __name__ == "__main__":

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -19,7 +19,8 @@ import scipy.linalg
 from scipy.sparse import csc_matrix
 from scipy.sparse.construct import eye as speye
 from scipy.sparse.linalg import expm
-from scipy.sparse.linalg.matfuncs import expm_2009, _is_upper_triangular
+from scipy.sparse.linalg.matfuncs import (expm_2009, _is_upper_triangular,
+        MatrixPowerOperator, ProductOperator)
 from scipy.linalg import logm
 
 
@@ -96,6 +97,31 @@ class TestExpM(TestCase):
             A = np.triu(np.random.randn(n, n))
             assert_(_is_upper_triangular(A))
             assert_allclose(expm_2009(A), expm(A))
+
+    def test_product_operator(self):
+        random.seed(1234)
+        n = 5
+        k = 2
+        nsamples = 10
+        for i in range(nsamples):
+            A = np.random.randn(n, n)
+            B = np.random.randn(n, n)
+            C = np.random.randn(n, n)
+            D = np.random.randn(n, k)
+            op = ProductOperator(A, B, C)
+            assert_allclose(op.matmat(D), A.dot(B).dot(C).dot(D))
+
+    def test_matrix_power_operator(self):
+        random.seed(1234)
+        n = 5
+        k = 2
+        p = 3
+        nsamples = 10
+        for i in range(nsamples):
+            A = np.random.randn(n, n)
+            B = np.random.randn(n, k)
+            op = MatrixPowerOperator(A, p)
+            assert_allclose(op.matmat(B), np.linalg.matrix_power(A, p).dot(B))
 
 
 if __name__ == "__main__":

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -9,12 +9,14 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy import array, eye, dot, sqrt, double, exp, random
-from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal, \
-     assert_array_almost_equal_nulp
+from numpy.testing import (TestCase, run_module_suite,
+        assert_array_almost_equal, assert_array_almost_equal_nulp,
+        assert_allclose)
 
 from scipy.sparse import csc_matrix
 from scipy.sparse.construct import eye as speye
 from scipy.sparse.linalg import expm
+from scipy.sparse.linalg.matfuncs import expm_2009
 from scipy.linalg import logm
 
 
@@ -54,6 +56,35 @@ class TestExpM(TestCase):
                     if np.iscomplexobj(a):
                         a = a + 1j * random.rand(n, n) * scale
                     assert_array_almost_equal(expm(logm(a)), a)
+
+    def test_overscaling_example(self):
+        # See the blog post
+        # http://blogs.mathworks.com/cleve/2012/07/23/a-balancing-act-for-the-matrix-exponential/
+        a = 2e10
+        b = 4e8/6.
+        c = 200/3.
+        d = 3
+        e = 1e-8
+        A = np.array([[0,e,0],[-(a+b), -d, a], [c, 0, -c]])
+
+        # This answer is wrong, and it is caused by overscaling.
+        wrong_solution = np.array([
+            [1.7465684381715e+17, -923050477.783131, -1.73117355055901e+17],
+            [-3.07408665108297e+25, 1.62463553675545e+17, 3.04699053651329e+25],
+            [1.09189154376804e+17, -577057840.468934, -1.08226721572342e+17]])
+
+        # This is the correct answer, to not great precision.
+        correct_solution = np.array([
+            [0.446849, 1.54044e-09, 0.462811],
+            [-5743070, -0.015283, -4526540],
+            [0.447723, 1.5427e-09, 0.463481]])
+
+        # Assert that the Higham 2005 expm gives the wrong answer.
+        assert_allclose(expm(A), wrong_solution)
+
+        # Assert that the Higham 2009 expm gives the correct answer.
+        assert_allclose(expm_2009(A), correct_solution, rtol=1e-4)
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -10,6 +10,7 @@ from __future__ import division, print_function, absolute_import
 import math
 
 import numpy as np
+from numpy.linalg import matrix_power
 from numpy import array, eye, dot, sqrt, double, exp, random
 from numpy.testing import (TestCase, run_module_suite,
         assert_array_almost_equal, assert_array_almost_equal_nulp,
@@ -110,6 +111,7 @@ class TestExpM(TestCase):
             D = np.random.randn(n, k)
             op = ProductOperator(A, B, C)
             assert_allclose(op.matmat(D), A.dot(B).dot(C).dot(D))
+            assert_allclose(op.T.matmat(D), (A.dot(B).dot(C)).T.dot(D))
 
     def test_matrix_power_operator(self):
         random.seed(1234)
@@ -121,7 +123,8 @@ class TestExpM(TestCase):
             A = np.random.randn(n, n)
             B = np.random.randn(n, k)
             op = MatrixPowerOperator(A, p)
-            assert_allclose(op.matmat(B), np.linalg.matrix_power(A, p).dot(B))
+            assert_allclose(op.matmat(B), matrix_power(A, p).dot(B))
+            assert_allclose(op.T.matmat(B), matrix_power(A, p).T.dot(B))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This updates the expm code from the 2005 algorithm https://github.com/scipy/scipy/pull/200 to the improved 2009 algorithm http://eprints.ma.man.ac.uk/1442/ , including a test where the current expm has trouble.  The code is currently inefficent (slow), as it is waiting on fast estimates of 1-norms of matrix products and powers, from PR https://github.com/scipy/scipy/pull/2436

The ability to deal with sparse matrices is under-tested, although I am doubting the claims in https://github.com/scipy/scipy/pull/287 that expm of a sparse matrix will stay sparse.  But I guess that expm preserves properties like diagonality, triangularity, and more generally reducibility, so the sparsity could be useful in these cases.  Usually I deal with sparse irreducible matrices which become completely dense under expm.

I think that the sparsity could be more useful in the un-implemented function that would compute only the action of the matrix exponential; this action is implemented in expokit https://github.com/scipy/scipy/pull/354 which is not yet merged, but it is possible that a more recent algorithm http://eprints.ma.man.ac.uk/1591/ could be better. 
