### PR TITLE
ENH: interpolate: implement spline derivatives and antiderivatives

### DIFF
--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -78,7 +78,7 @@ The above univariate spline classes have the following methods:
    UnivariateSpline.set_smoothing_factor
 
 
-Low-level interface to FITPACK functions:
+Functional interface to FITPACK functions:
 
 .. autosummary::
    :toctree: generated/
@@ -89,6 +89,8 @@ Low-level interface to FITPACK functions:
    splint
    sproot
    spalde
+   splder
+   splantider
    bisplrep
    bisplev
 

--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -72,6 +72,8 @@ The above univariate spline classes have the following methods:
    UnivariateSpline.derivatives
    UnivariateSpline.integral
    UnivariateSpline.roots
+   UnivariateSpline.derivative
+   UnivariateSpline.antiderivative
    UnivariateSpline.get_coeffs
    UnivariateSpline.get_knots
    UnivariateSpline.get_residual

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -1159,28 +1159,27 @@ def splder(tck, n=1):
     if n < 0:
         return splantider(tck, -n)
 
-    if n > tck[2]:
+    t, c, k = tck
+
+    if n > k:
         raise ValueError(("Order of derivative (n = %r) must be <= "
                           "order of spline (k = %r)") % (n, tck[2]))
 
     for j in range(n):
-        t, c, k = tck
-
         # See e.g. Schumaker, Spline Functions: Basic Theory, Chapter 5
 
         # Compute the denominator in the differentiation formula.
         dt = t[k+1:-1] - t[1:-k-1]
         dt[dt == 0] = np.inf
         # Compute the new coefficients
-        d = (c[1:-1-k] - c[:-2-k]) * k / dt
+        c = (c[1:-1-k] - c[:-2-k]) * k / dt
         # Pad coefficient array to same size as knots (FITPACK convention)
-        d = np.r_[d, [0]*k]
+        c = np.r_[c, [0]*k]
         # Adjust knots
-        t2 = t[1:-1]
-        # Done, return a new spline
-        tck = t2, d, k-1
+        t = t[1:-1]
+        k -= 1
 
-    return tck
+    return t, c, k
 
 def splantider(tck, n=1):
     """
@@ -1241,19 +1240,18 @@ def splantider(tck, n=1):
     if n < 0:
         return splder(tck, -n)
 
-    for j in range(n):
-        t, c, k = tck
+    t, c, k = tck
 
+    for j in range(n):
         # This is the inverse set of operations to splder.
 
         # Compute the multiplier in the antiderivative formula.
         dt = t[k+1:] - t[:-k-1]
         # Compute the new coefficients
-        d = np.cumsum(c[:-k-1] * dt) / (k + 1)
-        d = np.r_[0, d, [d[-1]]*(k+2)]
+        c = np.cumsum(c[:-k-1] * dt) / (k + 1)
+        c = np.r_[0, c, [c[-1]]*(k+2)]
         # New knots
-        t2 = np.r_[t[0], t, t[-1]]
-        # Done, return a new spline
-        tck = t2, d, k+1
+        t = np.r_[t[0], t, t[-1]]
+        k += 1
 
-    return tck
+    return t, c, k

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -25,8 +25,9 @@ from __future__ import division, print_function, absolute_import
 
 
 __all__ = ['splrep', 'splprep', 'splev', 'splint', 'sproot', 'spalde',
-    'bisplrep', 'bisplev', 'insert']
-__version__ = "$Revision$"[10:-1]
+    'bisplrep', 'bisplev', 'insert', 'splder', 'splantider']
+
+import numpy as np
 from . import _fitpack
 from numpy import atleast_1d, array, ones, zeros, sqrt, ravel, transpose, \
      dot, sin, cos, pi, arange, empty, iinfo, intc, asarray
@@ -1111,3 +1112,148 @@ def insert(x,tck,m=1,per=0):
         if ier:
             raise TypeError("An error occurred")
         return (tt, cc, k)
+
+def splder(tck, n=1):
+    """
+    Compute the spline representation of the derivative of a given spline
+
+    .. versionadded:: 0.13.0
+
+    Parameters
+    ----------
+    tck : tuple of (t, c, k)
+        Spline whose derivative to compute
+    n : int, optional
+        Order of derivative to evaluate. Default: 1
+
+    Returns
+    -------
+    tck_ader : tuple of (t2, c2, k2)
+        Spline of order k2 = max(0, k-1) representing the derivative
+        of the input spline.
+
+    See Also
+    --------
+    splantider, splev, spalde
+
+    Examples
+    --------
+    This can be used for finding maxima of a curve:
+
+    >>> from scipy.interpolate import splrep, splder, sproot
+    >>> x = np.linspace(0, 10, 70)
+    >>> y = np.sin(x)
+    >>> spl = splrep(x, y, k=4)
+
+    Now, differentiate the spline and find the zeros of the
+    derivative. (NB: `sproot` only works for order 3 splines, so we
+    fit an order 4 spline):
+
+    >>> dspl = splder(spl)
+    >>> sproot(dspl) / np.pi
+    array([ 0.50000001,  1.5       ,  2.49999998])
+
+    This agrees well with roots :math:`\pi/2 + n\pi` of `cos(x) = sin'(x)`.
+
+    """
+    if n < 0:
+        return splantider(tck, -n)
+
+    for j in range(n):
+        t, c, k = tck
+
+        if k <= 0:
+            # Derivative of a constant is zero
+            return t, zeros_like(c), k
+
+        # See e.g. Schumaker, Spline Functions: Basic Theory, Chapter 5
+
+        # Compute the denominator in the differentiation formula.
+        dt = t[k+1:-1] - t[1:-k-1]
+        dt[dt == 0] = np.inf
+        # Compute the new coefficients
+        d = (c[1:-1-k] - c[:-2-k]) * k / dt
+        # Pad coefficient array to same size as knots (FITPACK convention)
+        d = np.r_[d, [0]*k]
+        # Adjust knots
+        t2 = t[1:-1]
+        # Done, return a new spline
+        tck = t2, d, k-1
+
+    return tck
+
+def splantider(tck, n=1):
+    """
+    Compute the spline for the antiderivative (integral) of a given spline.
+
+    .. versionadded:: 0.13.0
+
+    Parameters
+    ----------
+    tck : tuple of (t, c, k)
+        Spline whose antiderivative to compute
+    n : int, optional
+        Order of antiderivative to evaluate. Default: 1
+
+    Returns
+    -------
+    tck_ader : tuple of (t2, c2, k2)
+        Spline of order k2=k+1 representing the antiderivative of the input
+        spline.
+
+    See Also
+    --------
+    splder, splev, spalde
+
+    Notes
+    -----
+    The `splder` function is the inverse operation of this function.
+    Namely, `splder(splantider(tck))` is identical to `spl`, modulo
+    rounding error.
+
+    Examples
+    --------
+    >>> from scipy.interpolate import splrep, splder, splantider
+    >>> x = np.linspace(0, np.pi/2, 70)
+    >>> y = 1 / np.sqrt(1 - 0.8*np.sin(x)**2)
+    >>> spl = splrep(x, y)
+
+    The derivative is the inverse operation of the antiderivative,
+    although some floating point error accumulates:
+
+    >>> splev(1.7, spl), splev(1.7, splder(splantider(spl)))
+    (array(2.1565429877197317), array(2.1565429877201865))
+
+    Antiderivative can be used to evaluate definite integrals:
+
+    >>> ispl = splantider(spl)
+    >>> splev(np.pi/2, ispl) - splev(0, ispl)
+    2.2572053588768486
+
+    This is indeed an approximation to the complete elliptic integral 
+    :math:`K(m) = \\int_0^{\\pi/2} [1 - m\\sin^2 x]^{-1/2} dx`:
+
+    >>> from scipy.special import ellipk
+    >>> ellipk(0.8)
+    2.2572053268208538
+
+    """
+    if n < 0:
+        return splder(tck, -n)
+
+    for j in range(n):
+        t, c, k = tck
+
+        # This is the inverse set of operations to splder.
+
+        # Compute the multiplier in the antiderivative formula.
+        dt = t[k+1:] - t[:-k-1]
+        # Compute the new coefficients
+        d = np.cumsum(c[:-k-1] * dt) / (k + 1)
+        d = np.r_[0, d, [d[-1]]*(k+2)]
+        # New knots
+        t2 = np.r_[t[0], t, t[-1]]
+        # Done, return a new spline
+        tck = t2, d, k+1
+
+    return tck

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -1128,8 +1128,8 @@ def splder(tck, n=1):
 
     Returns
     -------
-    tck_ader : tuple of (t2, c2, k2)
-        Spline of order k2 = max(0, k-1) representing the derivative
+    tck_der : tuple of (t2, c2, k2)
+        Spline of order k2=k-n representing the derivative
         of the input spline.
 
     See Also
@@ -1153,7 +1153,8 @@ def splder(tck, n=1):
     >>> sproot(dspl) / np.pi
     array([ 0.50000001,  1.5       ,  2.49999998])
 
-    This agrees well with roots :math:`\pi/2 + n\pi` of `cos(x) = sin'(x)`.
+    This agrees well with roots :math:`\pi/2 + n\pi` of
+    :math:`\cos(x) = \sin'(x)`.
 
     """
     if n < 0:
@@ -1201,7 +1202,7 @@ def splantider(tck, n=1):
     Returns
     -------
     tck_ader : tuple of (t2, c2, k2)
-        Spline of order k2=k+1 representing the antiderivative of the input
+        Spline of order k2=k+n representing the antiderivative of the input
         spline.
 
     See Also
@@ -1211,12 +1212,12 @@ def splantider(tck, n=1):
     Notes
     -----
     The `splder` function is the inverse operation of this function.
-    Namely, `splder(splantider(tck))` is identical to `spl`, modulo
+    Namely, ``splder(splantider(tck))`` is identical to `tck`, modulo
     rounding error.
 
     Examples
     --------
-    >>> from scipy.interpolate import splrep, splder, splantider
+    >>> from scipy.interpolate import splrep, splder, splantider, splev
     >>> x = np.linspace(0, np.pi/2, 70)
     >>> y = 1 / np.sqrt(1 - 0.8*np.sin(x)**2)
     >>> spl = splrep(x, y)

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -1159,12 +1159,12 @@ def splder(tck, n=1):
     if n < 0:
         return splantider(tck, -n)
 
+    if n > tck[2]:
+        raise ValueError(("Order of derivative (n = %r) must be <= "
+                          "order of spline (k = %r)") % (n, tck[2]))
+
     for j in range(n):
         t, c, k = tck
-
-        if k <= 0:
-            # Derivative of a constant is zero
-            return t, zeros_like(c), k
 
         # See e.g. Schumaker, Spline Functions: Basic Theory, Chapter 5
 

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -1165,19 +1165,23 @@ def splder(tck, n=1):
         raise ValueError(("Order of derivative (n = %r) must be <= "
                           "order of spline (k = %r)") % (n, tck[2]))
 
-    for j in range(n):
-        # See e.g. Schumaker, Spline Functions: Basic Theory, Chapter 5
+    with np.errstate(invalid='raise', divide='raise'):
+        try:
+            for j in range(n):
+                # See e.g. Schumaker, Spline Functions: Basic Theory, Chapter 5
 
-        # Compute the denominator in the differentiation formula.
-        dt = t[k+1:-1] - t[1:-k-1]
-        dt[dt == 0] = np.inf
-        # Compute the new coefficients
-        c = (c[1:-1-k] - c[:-2-k]) * k / dt
-        # Pad coefficient array to same size as knots (FITPACK convention)
-        c = np.r_[c, [0]*k]
-        # Adjust knots
-        t = t[1:-1]
-        k -= 1
+                # Compute the denominator in the differentiation formula.
+                dt = t[k+1:-1] - t[1:-k-1]
+                # Compute the new coefficients
+                c = (c[1:-1-k] - c[:-2-k]) * k / dt
+                # Pad coefficient array to same size as knots (FITPACK convention)
+                c = np.r_[c, [0]*k]
+                # Adjust knots
+                t = t[1:-1]
+                k -= 1
+        except FloatingPointError:
+            raise ValueError(("The spline has internal repeated knots "
+                              "and is not differentiable %d times") % n)
 
     return t, c, k
 

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -302,7 +302,7 @@ class UnivariateSpline(object):
         Returns
         -------
         spline : UnivariateSpline
-            Spline of order k2=max(0,k-1) representing the derivative of this
+            Spline of order k2=k-n representing the derivative of this
             spline.
 
         See Also
@@ -345,7 +345,7 @@ class UnivariateSpline(object):
         Returns
         -------
         spline : UnivariateSpline
-            Spline of order k2=k+1 representing the antiderivative of this
+            Spline of order k2=k+n representing the antiderivative of this
             spline.
 
         See Also

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -152,6 +152,17 @@ class UnivariateSpline(object):
         self._data = data
         self._reset_class()
 
+    @classmethod
+    def _from_tck(cls, tck):
+        """Construct a spline object from given tck"""
+        self = cls.__new__(cls)
+        t, c, k = tck
+        self._eval_args = tck
+        #_data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
+        self._data = (None,None,None,None,None,k,None,len(t),t,
+                      c,None,None,None,None)
+        return self
+
     def _reset_class(self):
         data = self._data
         n,t,c,k,ier = data[7],data[8],data[9],data[5],data[-1]
@@ -277,6 +288,99 @@ class UnivariateSpline(object):
         raise NotImplementedError('finding roots unsupported for '
                                     'non-cubic splines')
 
+    def derivative(self, n=1):
+        """
+        Construct a new spline representing the derivative of this spline.
+
+        .. versionadded:: 0.13.0
+
+        Parameters
+        ----------
+        n : int, optional
+            Order of derivative to evaluate. Default: 1
+
+        Returns
+        -------
+        spline : UnivariateSpline
+            Spline of order k2=max(0,k-1) representing the derivative of this
+            spline.
+
+        See Also
+        --------
+        splder, antiderivative
+
+        Examples
+        --------
+        This can be used for finding maxima of a curve:
+
+        >>> from scipy.interpolate import UnivariateSpline
+        >>> x = np.linspace(0, 10, 70)
+        >>> y = np.sin(x)
+        >>> spl = UnivariateSpline(x, y, k=4, s=0)
+
+        Now, differentiate the spline and find the zeros of the
+        derivative. (NB: `sproot` only works for order 3 splines, so we
+        fit an order 4 spline):
+
+        >>> spl.derivative().roots() / np.pi
+        array([ 0.50000001,  1.5       ,  2.49999998])
+
+        This agrees well with roots :math:`\pi/2 + n\pi` of `cos(x) = sin'(x)`.
+
+        """
+        tck = fitpack.splder(self._eval_args, n)
+        return UnivariateSpline._from_tck(tck)
+
+    def antiderivative(self, n=1):
+        """
+        Construct a new spline representing the antiderivative of this spline.
+
+        .. versionadded:: 0.13.0
+
+        Parameters
+        ----------
+        n : int, optional
+            Order of antiderivative to evaluate. Default: 1
+
+        Returns
+        -------
+        spline : UnivariateSpline
+            Spline of order k2=k+1 representing the antiderivative of this
+            spline.
+
+        See Also
+        --------
+        splantider, derivative
+
+        Examples
+        --------
+        >>> from scipy.interpolate import UnivariateSpline
+        >>> x = np.linspace(0, np.pi/2, 70)
+        >>> y = 1 / np.sqrt(1 - 0.8*np.sin(x)**2)
+        >>> spl = UnivariateSpline(x, y, s=0)
+
+        The derivative is the inverse operation of the antiderivative,
+        although some floating point error accumulates:
+
+        >>> spl(1.7), spl.antiderivative().derivative()(1.7)
+        (array(2.1565429877197317), array(2.1565429877201865))
+
+        Antiderivative can be used to evaluate definite integrals:
+
+        >>> ispl = spl.antiderivative()
+        >>> ispl(np.pi/2) - ispl(0)
+        2.2572053588768486
+
+        This is indeed an approximation to the complete elliptic integral 
+        :math:`K(m) = \\int_0^{\\pi/2} [1 - m\\sin^2 x]^{-1/2} dx`:
+
+        >>> from scipy.special import ellipk
+        >>> ellipk(0.8)
+        2.2572053268208538
+
+        """
+        tck = fitpack.splantider(self._eval_args, n)
+        return UnivariateSpline._from_tck(tck)
 
 class InterpolatedUnivariateSpline(UnivariateSpline):
     """

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -307,6 +307,10 @@ class TestSplder(object):
                 y2 = splev(x2, spl2) - splev(x1, spl2)
                 assert_allclose(y1, y2)
 
+    def test_order0_diff(self):
+        assert_raises(ValueError, splder, self.spl, 4)
+
+
 def test_bisplrep_overflow():
     a = np.linspace(0, 1, 620)
     b = np.linspace(0, 1, 620)

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_equal, assert_allclose, assert_, \
     TestCase, assert_raises, assert_array_almost_equal_nulp
 from numpy import array, asarray, pi, sin, cos, arange, dot, ravel, sqrt, round
 from scipy.interpolate.fitpack import splrep, splev, bisplrep, bisplev, \
-     sproot, splprep, splint, spalde, splder, splantider
+     sproot, splprep, splint, spalde, splder, splantider, insert
 
 
 def norm2(x):
@@ -309,6 +309,20 @@ class TestSplder(object):
 
     def test_order0_diff(self):
         assert_raises(ValueError, splder, self.spl, 4)
+
+    def test_kink(self):
+        # Should refuse to differentiate splines with kinks
+
+        spl2 = insert(0.5, self.spl, m=2)
+        splder(spl2, 2) # Should work
+        assert_raises(ValueError, splder, spl2, 3)
+
+        spl2 = insert(0.5, self.spl, m=3)
+        splder(spl2, 1) # Should work
+        assert_raises(ValueError, splder, spl2, 2)
+
+        spl2 = insert(0.5, self.spl, m=4)
+        assert_raises(ValueError, splder, spl2, 1)
 
 
 def test_bisplrep_overflow():

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose, assert_, \
-    TestCase, assert_raises, assert_array_almost_equal_nulp
+    TestCase, assert_raises
 from numpy import array, asarray, pi, sin, cos, arange, dot, ravel, sqrt, round
 from scipy.interpolate.fitpack import splrep, splev, bisplrep, bisplev, \
      sproot, splprep, splint, spalde, splder, splantider, insert
@@ -266,7 +266,7 @@ class TestSplder(object):
         self.spl = splrep(x, y)
 
         # double check that knots are non-uniform
-        assert np.diff(self.spl[0]).ptp() > 0
+        assert_(np.diff(self.spl[0]).ptp() > 0)
 
     def test_inverse(self):
         # Check that antiderivative + derivative is identity.
@@ -291,7 +291,7 @@ class TestSplder(object):
             dy = splev(xx, self.spl, n)
             spl2 = splder(self.spl, n)
             dy2 = splev(xx, spl2)
-            assert_array_almost_equal_nulp(dy, dy2, nulp=100)
+            assert_allclose(dy, dy2)
 
     def test_splantider_vs_splint(self):
         # Check antiderivative vs. FITPACK

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -2,10 +2,10 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose, assert_, \
-    TestCase, assert_raises
+    TestCase, assert_raises, assert_array_almost_equal_nulp
 from numpy import array, asarray, pi, sin, cos, arange, dot, ravel, sqrt, round
 from scipy.interpolate.fitpack import splrep, splev, bisplrep, bisplev, \
-     sproot, splprep, splint, spalde
+     sproot, splprep, splint, spalde, splder, splantider
 
 
 def norm2(x):
@@ -258,6 +258,54 @@ class TestSplev(TestCase):
         z = splev(1, tck)
         assert_equal(z.shape, ())
 
+class TestSplder(object):
+    def __init__(self):
+        # non-uniform grid, just to make it sure
+        x = np.linspace(0, 1, 100)**3
+        y = np.sin(20 * x)
+        self.spl = splrep(x, y)
+
+        # double check that knots are non-uniform
+        assert np.diff(self.spl[0]).ptp() > 0
+
+    def test_inverse(self):
+        # Check that antiderivative + derivative is identity.
+        for n in range(5):
+            spl2 = splantider(self.spl, n)
+            spl3 = splder(spl2, n)
+            assert_allclose(self.spl[0], spl3[0])
+            assert_allclose(self.spl[1], spl3[1])
+            assert_equal(self.spl[2], spl3[2])
+
+    def test_splder_vs_splev(self):
+        # Check derivative vs. FITPACK
+
+        for n in range(3+1):
+            # Also extrapolation!
+            xx = np.linspace(-1, 2, 2000)
+            if n == 3:
+                # ... except that FITPACK extrapolates strangely for
+                # order 0, so let's not check that.
+                xx = xx[(xx >= 0) & (xx <= 1)]
+
+            dy = splev(xx, self.spl, n)
+            spl2 = splder(self.spl, n)
+            dy2 = splev(xx, spl2)
+            assert_array_almost_equal_nulp(dy, dy2, nulp=100)
+
+    def test_splantider_vs_splint(self):
+        # Check antiderivative vs. FITPACK
+        spl2 = splantider(self.spl)
+
+        # no extrapolation, splint assumes function is zero outside
+        # range
+        xx = np.linspace(0, 1, 20)
+
+        for x1 in xx:
+            for x2 in xx:
+                y1 = splint(x1, x2, self.spl)
+                y2 = splev(x2, spl2) - splev(x1, spl2)
+                assert_allclose(y1, y2)
 
 def test_bisplrep_overflow():
     a = np.linspace(0, 1, 620)

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -4,6 +4,7 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 
+import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal, assert_array_equal, \
         assert_array_almost_equal, assert_allclose, TestCase, run_module_suite
 from numpy.testing.utils import WarningManager
@@ -76,6 +77,19 @@ class TestUnivariateSpline(TestCase):
         spl = UnivariateSpline(x=x, y=y, w=w, s=None)
         desired = array([0.35100374, 0.51715855, 0.87789547, 0.98719344])
         assert_allclose(spl([0.1, 0.5, 0.9, 0.99]), desired, atol=5e-4)
+
+    def test_derivative_and_antiderivative(self):
+        # Thin wrappers to splder/splantider, so light smoke test only.
+        x = np.linspace(0, 1, 70)**3
+        y = np.cos(x)
+
+        spl = UnivariateSpline(x, y, s=0)
+        spl2 = spl.antiderivative(2).derivative(2)
+        assert_allclose(spl(0.3), spl2(0.3))
+
+        spl2 = spl.antiderivative(1)
+        assert_allclose(spl2(0.6) - spl2(0.2), 
+                        spl.integral(0.2, 0.6))
 
 
 class TestLSQBivariateSpline(TestCase):


### PR DESCRIPTION
The derivatives and antiderivatives of B-splines are also B-splines, and the differentiation and antidifferentiation formulas are well-known. This PR adds routines for computing the derivative/antiderivative B-splines for a given B-spline.

Useful for e.g. finding maxima/minima of known 1-D functions, etc.
