### PR TITLE
ENH: Add canonical representation for lti objects

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -330,6 +330,17 @@ class lti(object):
         else:
             self.__dict__[attr] = val
 
+    def __repr__(self):
+        # Canonical representation using state-space to preserve numerical 
+        # precision and any MIMO information
+        return '{0}(\n{1},\n{2},\n{3},\n{4}\n)'.format(
+            self.__class__.__name__, 
+            repr(self.A),
+            repr(self.B),
+            repr(self.C),
+            repr(self.D),
+            )
+
     def impulse(self, X0=None, T=None, N=None):
         return impulse(self, X0=X0, T=T, N=N)
 


### PR DESCRIPTION
> repr(). Returns a canonical string representation of the object. For most object types, eval(repr(object)) == object.

Uses ABCD state-space to preserve numerical precision and any MIMO information.

So:

```
In [10]: lti([1,1], [1,1])
Out[10]: 
lti(
array([[-1.]]),
array([[ 1.]]),
array([[ 0.]]),
array([ 1.])
)
```

Could be modified to add extra space.  I'm not sure the ideal way to pretty-print things like this:

```
In [12]: lti([1,1], [1,1])
Out[12]: 
lti(
    array([[-1.]]),
    array([[ 1.]]),
    array([[ 0.]]),
    array([ 1.])
)
```

Without space, the arrays line up with themselves at least:

```
In [15]: lti([1,2,3,4,5,6,7], [1,2,3,4,5,6,7])
Out[15]: 
lti(
array([[-2., -3., -4., -5., -6., -7.],
       [ 1.,  0.,  0.,  0.,  0.,  0.],
       [ 0.,  1.,  0.,  0.,  0.,  0.],
       [ 0.,  0.,  1.,  0.,  0.,  0.],
       [ 0.,  0.,  0.,  1.,  0.,  0.],
       [ 0.,  0.,  0.,  0.,  1.,  0.]]),
array([[ 1.],
       [ 0.],
       [ 0.],
       [ 0.],
       [ 0.],
       [ 0.]]),
array([[ 0.,  0.,  0.,  0.,  0.,  0.]]),
array([ 1.])
)
```
