### PR TITLE
DOC: Docstring fixes

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -793,7 +793,7 @@ def hilbert(x, N=None, axis=-1):
 
     Notes
     -----
-    The analytic signal :math:`x_a(t)` of signal :math:`x(t)` is::
+    The analytic signal :math:`x_a(t)` of signal :math:`x(t)` is:
 
     .. math:: x_a = F^{-1}(F(x) 2U) = x + i y
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -793,7 +793,7 @@ def hilbert(x, N=None, axis=-1):
 
     Notes
     -----
-    The analytic signal :math:`x_a(t)` of signal :math:`x(t)` is:
+    The analytic signal `x_a(t)` of signal `x(t)` is:
 
     .. math:: x_a = F^{-1}(F(x) 2U) = x + i y
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -773,14 +773,14 @@ def deconvolve(signal, divisor):
 
 def hilbert(x, N=None, axis=-1):
     """
-    Compute the analytic signal.
+    Compute the analytic signal, using the Hilbert transform.
 
     The transformation is done along the last axis by default.
 
     Parameters
     ----------
     x : array_like
-        Signal data
+        Signal data.  Must be real.
     N : int, optional
         Number of Fourier components.  Default: ``x.shape[axis]``
     axis : int, optional
@@ -793,12 +793,17 @@ def hilbert(x, N=None, axis=-1):
 
     Notes
     -----
-    The analytic signal `x_a(t)` of `x(t)` is::
+    The analytic signal :math:`x_a(t)` of signal :math:`x(t)` is::
 
     .. math:: x_a = F^{-1}(F(x) 2U) = x + i y
 
-    where ``F`` is the Fourier transform, ``U`` the unit step function,
-    and ``y`` the Hilbert transform of ``x``. [1]_
+    where `F` is the Fourier transform, `U` the unit step function,
+    and `y` the Hilbert transform of `x`. [1]_
+    
+    In other words, the negative half of the frequency spectrum is zeroed 
+    out, turning the real-valued signal into a complex signal.  The Hilbert 
+    transformed signal can be obtained from ``np.imag(hilbert(x))``, and the 
+    original signal from ``np.real(hilbert(x))``.
 
     `axis` argument is new in scipy 0.8.0.
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -795,7 +795,7 @@ def hilbert(x, N=None, axis=-1):
     -----
     The analytic signal `x_a(t)` of `x(t)` is::
 
-        x_a = F^{-1}(F(x) 2U) = x + i y
+    .. math:: x_a = F^{-1}(F(x) 2U) = x + i y
 
     where ``F`` is the Fourier transform, ``U`` the unit step function,
     and ``y`` the Hilbert transform of ``x``. [1]_

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -122,6 +122,7 @@ def square(t, duty=0.5):
 
     A pulse-width modulated sine wave:
 
+    >>> plt.figure()
     >>> sig = np.sin(2 * np.pi * t)
     >>> pwm = signal.square(2 * np.pi * 30 * t, duty=(sig + 1)/2)
     >>> plt.subplot(2, 1, 1)

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -277,7 +277,7 @@ def ricker(points, a):
     Parameters
     ----------
     points : int
-        Number of points in `vector`. Default is ``10 * a``.
+        Number of points in `vector`.
         Will be centered around 0.
     a : scalar
         Width parameter of the wavelet.


### PR DESCRIPTION
1. Ricker doesn't have a default, so remove that (or maybe the default should be added to the function definition instead??)
2. Some TeX code without the math:: tag, then spelled out the Hilbert transform in more detail.
3. Add plt.figure() so the image displays on the web documentation
