### PR TITLE
Fix include dir ordering in scipy.special

### DIFF
--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -30,7 +30,7 @@ def configuration(parent_package='',top_path=None):
     inc_dirs = [get_python_inc()]
     if inc_dirs[0] != get_python_inc(plat_specific=1):
         inc_dirs.append(get_python_inc(plat_specific=1))
-    inc_dirs.append(get_numpy_include_dirs())
+    inc_dirs.insert(0, get_numpy_include_dirs())
 
     # C libraries
     config.add_library('sc_c_misc',sources=[join('c_misc','*.c')],


### PR DESCRIPTION
When installing into a virtualenv with a recent version of numpy, if the system-wide python includes have super-old numpy headers, scipy.special wont build correctly (e.g. missing NPY_EULER).  Prioritizing the numpy include dirs fixes this.
