### PR TITLE
Add optional `rtol` argument to 1D solvers

### DIFF
--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -103,6 +103,8 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     dimensional problems when such an interval has been found.
 
     """
+    if xtol <= 0:
+        raise ValueError("xtol too small (%g <= 0)" % xtol)
     if fprime is not None:
         # Newton-Rapheson method
         # Multiply by 1.0 to convert to floating point.  We don't use float(x0)
@@ -216,6 +218,8 @@ def bisect(f, a, b, args=(),
     """
     if not isinstance(args, tuple):
         args = (args,)
+    if xtol <= 0:
+        raise ValueError("xtol too small (%g <= 0)" % xtol)
     if rtol < _rtol:
         raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
     r = _zeros._bisect(f,a,b,xtol,rtol,maxiter,args,full_output,disp)
@@ -292,6 +296,8 @@ def ridder(f, a, b, args=(),
     """
     if not isinstance(args, tuple):
         args = (args,)
+    if xtol <= 0:
+        raise ValueError("xtol too small (%g <= 0)" % xtol)
     if rtol < _rtol:
         raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
     r = _zeros._ridder(f,a,b,xtol,rtol,maxiter,args,full_output,disp)
@@ -402,6 +408,8 @@ def brentq(f, a, b, args=(),
     """
     if not isinstance(args, tuple):
         args = (args,)
+    if xtol <= 0:
+        raise ValueError("xtol too small (%g <= 0)" % xtol)
     if rtol < _rtol:
         raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
     r = _zeros._brentq(f,a,b,xtol,rtol,maxiter,args,full_output,disp)
@@ -481,6 +489,8 @@ def brenth(f, a, b, args=(),
     """
     if not isinstance(args, tuple):
         args = (args,)
+    if xtol <= 0:
+        raise ValueError("xtol too small (%g <= 0)" % xtol)
     if rtol < _rtol:
         raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
     r = _zeros._brenth(f,a, b, xtol, rtol, maxiter, args, full_output, disp)

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -7,7 +7,6 @@ from numpy import finfo, sign, sqrt
 
 _iter = 100
 _xtol = 1e-12
-# not actually used at the moment
 _rtol = finfo(float).eps * 2
 
 __all__ = ['newton', 'bisect', 'ridder', 'brentq', 'brenth']
@@ -183,6 +182,10 @@ def bisect(f, a, b, args=(),
         The routine converges when a root is known to lie within `xtol` of the
         value return. Should be >= 0.  The routine modifies this to take into
         account the relative precision of doubles.
+    rtol : number, optional
+        The routine converges when a root is known to lie within `rtol` times
+        the value returned of the value returned. Should be >= 0. Defaults to
+        ``np.finfo(float).eps * 2``.
     maxiter : number, optional
         if convergence is not achieved in `maxiter` iterations, and error is
         raised.  Must be >= 0.
@@ -213,7 +216,7 @@ def bisect(f, a, b, args=(),
     """
     if not isinstance(args, tuple):
         args = (args,)
-    r = _zeros._bisect(f,a,b,xtol,maxiter,args,full_output,disp)
+    r = _zeros._bisect(f,a,b,xtol,rtol,maxiter,args,full_output,disp)
     return results_c(full_output, r)
 
 
@@ -236,6 +239,10 @@ def ridder(f, a, b, args=(),
         The routine converges when a root is known to lie within xtol of the
         value return. Should be >= 0.  The routine modifies this to take into
         account the relative precision of doubles.
+    rtol : number, optional
+        The routine converges when a root is known to lie within `rtol` times
+        the value returned of the value returned. Should be >= 0. Defaults to
+        ``np.finfo(float).eps * 2``.
     maxiter : number, optional
         if convergence is not achieved in maxiter iterations, and error is
         raised.  Must be >= 0.
@@ -283,7 +290,7 @@ def ridder(f, a, b, args=(),
     """
     if not isinstance(args, tuple):
         args = (args,)
-    r = _zeros._ridder(f,a,b,xtol,maxiter,args,full_output,disp)
+    r = _zeros._ridder(f,a,b,xtol,rtol,maxiter,args,full_output,disp)
     return results_c(full_output, r)
 
 
@@ -326,6 +333,10 @@ def brentq(f, a, b, args=(),
         The routine converges when a root is known to lie within xtol of the
         value return. Should be >= 0.  The routine modifies this to take into
         account the relative precision of doubles.
+    rtol : number, optional
+        The routine converges when a root is known to lie within `rtol` times
+        the value returned of the value returned. Should be >= 0. Defaults to
+        ``np.finfo(float).eps * 2``.
     maxiter : number, optional
         if convergence is not achieved in maxiter iterations, and error is
         raised.  Must be >= 0.
@@ -387,7 +398,7 @@ def brentq(f, a, b, args=(),
     """
     if not isinstance(args, tuple):
         args = (args,)
-    r = _zeros._brentq(f,a,b,xtol,maxiter,args,full_output,disp)
+    r = _zeros._brentq(f,a,b,xtol,rtol,maxiter,args,full_output,disp)
     return results_c(full_output, r)
 
 
@@ -417,6 +428,10 @@ def brenth(f, a, b, args=(),
         The routine converges when a root is known to lie within xtol of the
         value return. Should be >= 0.  The routine modifies this to take into
         account the relative precision of doubles.
+    rtol : number, optional
+        The routine converges when a root is known to lie within `rtol` times
+        the value returned of the value returned. Should be >= 0. Defaults to
+        ``np.finfo(float).eps * 2``.
     maxiter : number, optional
         if convergence is not achieved in maxiter iterations, and error is
         raised.  Must be >= 0.
@@ -460,5 +475,5 @@ def brenth(f, a, b, args=(),
     """
     if not isinstance(args, tuple):
         args = (args,)
-    r = _zeros._brenth(f,a, b, xtol, maxiter, args, full_output, disp)
+    r = _zeros._brenth(f,a, b, xtol, rtol, maxiter, args, full_output, disp)
     return results_c(full_output, r)

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -216,6 +216,8 @@ def bisect(f, a, b, args=(),
     """
     if not isinstance(args, tuple):
         args = (args,)
+    if rtol < _rtol:
+        raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
     r = _zeros._bisect(f,a,b,xtol,rtol,maxiter,args,full_output,disp)
     return results_c(full_output, r)
 
@@ -290,6 +292,8 @@ def ridder(f, a, b, args=(),
     """
     if not isinstance(args, tuple):
         args = (args,)
+    if rtol < _rtol:
+        raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
     r = _zeros._ridder(f,a,b,xtol,rtol,maxiter,args,full_output,disp)
     return results_c(full_output, r)
 
@@ -398,6 +402,8 @@ def brentq(f, a, b, args=(),
     """
     if not isinstance(args, tuple):
         args = (args,)
+    if rtol < _rtol:
+        raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
     r = _zeros._brentq(f,a,b,xtol,rtol,maxiter,args,full_output,disp)
     return results_c(full_output, r)
 
@@ -475,5 +481,7 @@ def brenth(f, a, b, args=(),
     """
     if not isinstance(args, tuple):
         args = (args,)
+    if rtol < _rtol:
+        raise ValueError("rtol too small (%g < %g)" % (rtol, _rtol))
     r = _zeros._brenth(f,a, b, xtol, rtol, maxiter, args, full_output, disp)
     return results_c(full_output, r)


### PR DESCRIPTION
This exposes an option to control the relative tolerance of the 1D
root-finding functions in `scipy.optimize`. The feature existed in the C
implementations but was not exposed by the Python interface.
