### PR TITLE
DOC: add note about using fftshift, change Nyquist sign

### DIFF
--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -205,21 +205,23 @@ def fft(x, n=None, axis=-1, overwrite_x=0):
     Notes
     -----
     The packing of the result is "standard": If A = fft(a, n), then A[0]
-    contains the zero-frequency term, A[1:n/2+1] contains the
-    positive-frequency terms, and A[n/2+1:] contains the negative-frequency
+    contains the zero-frequency term, A[1:n/2] contains the
+    positive-frequency terms, and A[n/2:] contains the negative-frequency
     terms, in order of decreasingly negative frequency. So for an 8-point
-    transform, the frequencies of the result are [ 0, 1, 2, 3, 4, -3, -2, -1].
+    transform, the frequencies of the result are [0, 1, 2, 3, -4, -3, -2, -1].
+    To rearrange the fft output so that the zero-frequency component is 
+    centered, like [-4, -3, -2, -1,  0,  1,  2,  3], use `fftshift`.
 
-    For n even, A[n/2] contains the sum of the positive and negative-frequency
-    terms. For n even and x real, A[n/2] will always be real.
+    For `n` even, A[n/2] contains the sum of the positive and negative-frequency
+    terms. For `n` even and `x` real, A[n/2] will always be real.
 
-    This is most efficient for n a power of two.
+    This is most efficient when `n` is a power of two.
 
     Examples
     --------
     >>> from scipy.fftpack import fft, ifft
     >>> x = np.arange(5)
-    >>> np.allclose(fft(ifft(x)), x, atol=1e-15)  #within numerical accuracy.
+    >>> np.allclose(fft(ifft(x)), x, atol=1e-15) # within numerical accuracy.
     True
 
     """


### PR DESCRIPTION
1. Added a note about using fftshift to re-center the frequencies
2. Changed the description so that the Nyquist frequency is considered negative, since this is how fftfreq and fftshift do it:
   
   ```
   In : fftshift(fftfreq(8, 1/8))
   Out: array([-4., -3., -2., -1.,  0.,  1.,  2.,  3.])
   ```
3. backticks around variables, whitespace changes

For #2, the description is different when n is odd, though:

```
In [31]: fftfreq(8, 1/8)
Out[31]: array([ 0.,  1.,  2.,  3., -4., -3., -2., -1.])

In [32]: fftfreq(7, 1/7)
Out[32]: array([ 0.,  1.,  2.,  3., -3., -2., -1.])
```

So maybe the description should say 

> A[1:(n+1)//2] contains the  positive-frequency terms, and 
> A[(n+1)//2:] contains the negative-frequency terms

but that's more complicated
