### PR TITLE
CSR and CSC fancy indexing

### DIFF
--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -144,29 +144,16 @@ class csc_matrix(_cs_matrix, IndexMixin):
         if isinstance(key, tuple):
             row, col = self._unpack_index(key)
 
-            if isintlike(row) or isinstance(row, slice):
+            if (isintlike(row) or isinstance(row, slice) or isintlike(col) or 
+                isinstance(col,slice)):
                 return self.T[col,row].T
             else:
-                #[[1,2],??] or [[[1],[2]],??]
-                if isintlike(col) or isinstance(col,slice):
-                    return self.T[col,row].T
-                else:
-                    row = np.asarray(row, dtype=np.intc)
-                    col = np.asarray(col, dtype=np.intc)
-                    if len(row.shape) == 1:
-                        return self.T[col,row]
-                    elif len(row.shape) == 2:
-                        row = row.reshape(-1)
-                        col = col.reshape(-1,1)
-                        return self.T[col,row].T
-                    else:
-                        raise NotImplementedError('unsupported indexing')
-
-            return self.T[col,row].T
-        elif isintlike(key) or isinstance(key,slice):
-            return self.T[:,key].T                              #[i] or [1:2]
+                return self.T[col,row]
+        elif isinstance(key, np.ndarray) and key.dtype.kind == 'b':
+            row, col = self._check_Boolean(key, slice(None))
+            return self[row, col]
         else:
-            return self.T[:,key].T                              #[[1,2]]
+            return self.T[:,key].T                              #[i] or [1:2]
 
     def getrow(self, i):
         """Returns a copy of row i of the matrix, as a (1 x n)

--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -11,12 +11,12 @@ import numpy as np
 from scipy.lib.six.moves import xrange
 
 from .sparsetools import csc_tocsr
-from .sputils import upcast, isintlike
+from .sputils import upcast, isintlike, IndexMixin
 
 from .compressed import _cs_matrix
 
 
-class csc_matrix(_cs_matrix):
+class csc_matrix(_cs_matrix, IndexMixin):
     """
     Compressed Sparse Column matrix
 
@@ -142,8 +142,7 @@ class csc_matrix(_cs_matrix):
     def __getitem__(self, key):
         # use CSR to implement fancy indexing
         if isinstance(key, tuple):
-            row = key[0]
-            col = key[1]
+            row, col = self._unpack_index(key)
 
             if isintlike(row) or isinstance(row, slice):
                 return self.T[col,row].T

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -223,7 +223,7 @@ class csr_matrix(_cs_matrix, IndexMixin):
             return csr_matrix((data,indices,indptr), shape=shape)
 
         row, col = self._unpack_index(key)
-        # Check for Boolean data type, otherwise asindices() sees 0s and 1s
+        # Convert Boolean data type, otherwise asindices() sees 0s and 1s
         row, col = self._check_Boolean(row, col)
 
         # First attempt to use original row optimized methods
@@ -239,7 +239,8 @@ class csr_matrix(_cs_matrix, IndexMixin):
         elif isinstance(row, slice):
             #[1:2,??]
             if isintlike(col) or (isinstance(col, slice) and 
-                                  col.step and row.step in (1, None)):
+                                  col.step in (1, None) and 
+                                  row.step in (1, None)):
                 return self._get_submatrix(row, col)      #[1:2,j]
             elif issequence(col):
                 P = extractor(col,self.shape[1]).T        #[1:2,[1,2]]

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -223,16 +223,17 @@ class csr_matrix(_cs_matrix, IndexMixin):
             return csr_matrix((data,indices,indptr), shape=shape)
 
         row, col = self._unpack_index(key)
+        # First attempt to use original optimized methods
+        # Only if statements used 
         if isintlike(row):
             #[1,??]
             if isintlike(col):
                 return self._get_single_element(row, col) #[i,j]
             elif isinstance(col, slice):
                 return self._get_row_slice(row, col)      #[i,1:2]
-            else:
+            elif issequence(col):
                 P = extractor(col,self.shape[1]).T        #[i,[1,2]]
                 return self[row,:]*P
-
         elif isinstance(row, slice):
             #[1:2,??]
             if isintlike(col) or isinstance(col, slice):

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -264,10 +264,6 @@ class csr_matrix(_cs_matrix, IndexMixin):
                                       self.indptr, self.indices, self.data,
                                       num_samples, row, col, val)
                     return np.asmatrix(val)
-                elif row.ndim == 2 and row.shape[0] == 1:
-                    row = np.ravel(row)                   #[[[1],[2]],[1,2]]
-                    P = extractor(row, self.shape[0])
-                    return (P*self)[:,col]
 
         # If all else fails, try elementwise
         row, col = self._index_to_arrays(row, col)

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -222,67 +222,57 @@ class csr_matrix(_cs_matrix, IndexMixin):
 
             return csr_matrix((data,indices,indptr), shape=shape)
 
-
-        if isinstance(key, tuple):
-            row = key[0]
-            col = key[1]
-
-            if isintlike(row):
-                #[1,??]
-                if isintlike(col):
-                    return self._get_single_element(row, col) #[i,j]
-                elif isinstance(col, slice):
-                    return self._get_row_slice(row, col)      #[i,1:2]
-                else:
-                    P = extractor(col,self.shape[1]).T        #[i,[1,2]]
-                    return self[row,:]*P
-
-            elif isinstance(row, slice):
-                #[1:2,??]
-                if isintlike(col) or isinstance(col, slice):
-                    return self._get_submatrix(row, col)      #[1:2,j]
-                else:
-                    P = extractor(col,self.shape[1]).T        #[1:2,[1,2]]
-                    return self[row,:]*P
-
+        row, col = self._unpack_index(key)
+        if isintlike(row):
+            #[1,??]
+            if isintlike(col):
+                return self._get_single_element(row, col) #[i,j]
+            elif isinstance(col, slice):
+                return self._get_row_slice(row, col)      #[i,1:2]
             else:
-                #[[1,2],??] or [[[1],[2]],??]
-                if isintlike(col) or isinstance(col,slice):
-                    P = extractor(row, self.shape[0])        #[[1,2],j] or [[1,2],1:2]
+                P = extractor(col,self.shape[1]).T        #[i,[1,2]]
+                return self[row,:]*P
+
+        elif isinstance(row, slice):
+            #[1:2,??]
+            if isintlike(col) or isinstance(col, slice):
+                return self._get_submatrix(row, col)      #[1:2,j]
+            else:
+                P = extractor(col,self.shape[1]).T        #[1:2,[1,2]]
+                return self[row,:]*P
+
+        else:
+            #[[1,2],??] or [[[1],[2]],??]
+            if isintlike(col) or isinstance(col,slice):
+                P = extractor(row, self.shape[0])        #[[1,2],j] or [[1,2],1:2]
+                return (P*self)[:,col]
+            else:
+                row = asindices(row)
+                col = asindices(col)
+                if len(row.shape) == 1:
+                    if len(row) != len(col):             #[[1,2],[1,2]]
+                        raise IndexError('number of row and column indices differ')
+
+                    check_bounds(row, self.shape[0])
+                    check_bounds(col, self.shape[1])
+
+                    num_samples = len(row)
+                    val = np.empty(num_samples, dtype=self.dtype)
+                    csr_sample_values(self.shape[0], self.shape[1],
+                                      self.indptr, self.indices, self.data,
+                                      num_samples, row, col, val)
+                    #val = []
+                    #for i,j in zip(row,col):
+                    #    val.append(self._get_single_element(i,j))
+                    return np.asmatrix(val)
+
+                elif len(row.shape) == 2:
+                    row = np.ravel(row)                   #[[[1],[2]],[1,2]]
+                    P = extractor(row, self.shape[0])
                     return (P*self)[:,col]
 
                 else:
-                    row = asindices(row)
-                    col = asindices(col)
-                    if len(row.shape) == 1:
-                        if len(row) != len(col):             #[[1,2],[1,2]]
-                            raise IndexError('number of row and column indices differ')
-
-                        check_bounds(row, self.shape[0])
-                        check_bounds(col, self.shape[1])
-
-                        num_samples = len(row)
-                        val = np.empty(num_samples, dtype=self.dtype)
-                        csr_sample_values(self.shape[0], self.shape[1],
-                                          self.indptr, self.indices, self.data,
-                                          num_samples, row, col, val)
-                        #val = []
-                        #for i,j in zip(row,col):
-                        #    val.append(self._get_single_element(i,j))
-                        return np.asmatrix(val)
-
-                    elif len(row.shape) == 2:
-                        row = np.ravel(row)                   #[[[1],[2]],[1,2]]
-                        P = extractor(row, self.shape[0])
-                        return (P*self)[:,col]
-
-                    else:
-                        raise NotImplementedError('unsupported indexing')
-
-        elif isintlike(key) or isinstance(key,slice):
-            return self[key,:]                                #[i] or [1:2]
-        else:
-            return self[asindices(key),:]                     #[[1,2]]
+                    raise NotImplementedError('unsupported indexing')
 
 
     def _get_single_element(self,row,col):

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -223,6 +223,8 @@ class csr_matrix(_cs_matrix, IndexMixin):
             return csr_matrix((data,indices,indptr), shape=shape)
 
         row, col = self._unpack_index(key)
+        # Check for Boolean data type, otherwise asindices() sees 0s and 1s
+        row, col = self._check_Boolean(row, col)
         # First attempt to use original optimized methods
         # Only if statements used 
         if isintlike(row):

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -14,12 +14,11 @@ from scipy.lib.six.moves import xrange
 
 from .sparsetools import csr_tocsc, csr_tobsr, csr_count_blocks, \
         get_csr_submatrix, csr_sample_values
-from .sputils import upcast, isintlike
-
+from .sputils import upcast, isintlike, IndexMixin
 
 from .compressed import _cs_matrix
 
-class csr_matrix(_cs_matrix):
+class csr_matrix(_cs_matrix, IndexMixin):
     """
     Compressed Sparse Row matrix
 

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -13,7 +13,8 @@ import numpy as np
 from scipy.lib.six.moves import xrange
 
 from .base import spmatrix, isspmatrix
-from .sputils import getdtype, isshape, issequence, isscalarlike, ismatrix, IndexMixin
+from .sputils import getdtype, isshape, issequence, isscalarlike, ismatrix, \
+    IndexMixin
 
 from warnings import warn
 from .base import SparseEfficiencyWarning
@@ -228,6 +229,8 @@ class lil_matrix(spmatrix, IndexMixin):
         """Return the element(s) index=(i, j), where j may be a slice.
         This always returns a copy for consistency, since slices into
         Python lists return copies.
+
+        Utilities found in IndexMixin
         """
         i, j = self._unpack_index(index)
 

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -13,13 +13,13 @@ import numpy as np
 from scipy.lib.six.moves import xrange
 
 from .base import spmatrix, isspmatrix
-from .sputils import getdtype, isshape, issequence, isscalarlike, ismatrix
+from .sputils import getdtype, isshape, issequence, isscalarlike, ismatrix, IndexMixin
 
 from warnings import warn
 from .base import SparseEfficiencyWarning
 
 
-class lil_matrix(spmatrix):
+class lil_matrix(spmatrix, IndexMixin):
     """Row-based linked list sparse matrix
 
     This is an efficient structure for constructing sparse
@@ -224,80 +224,6 @@ class lil_matrix(spmatrix):
         else:
             return self.dtype.type(0)
 
-    def _slicetoarange(self, j, shape):
-        start, stop, step = j.indices(shape)
-        return np.arange(start, stop, step)
-
-    def _unpack_index(self, index):
-        if isinstance(index, tuple):
-            if len(index) == 2:
-                return index
-            elif len(index) == 1:
-                return index[0], slice(None)
-            else:
-                raise IndexError('invalid number of indices')
-        else:
-            return index, slice(None)
-
-    def _boolean_index_to_array(self, i):
-        if i.ndim<2:
-            i = i.nonzero()
-        elif (i.shape[0] > self.shape[0] or i.shape[1] > self.shape[1] or
-              i.ndim > 2):
-            raise IndexError('invalid index shape')
-        else:
-            i = i.nonzero()
-        return i
-
-    def _index_to_arrays(self, i, j):
-        if isinstance(i, np.ndarray) and i.dtype.kind == 'b':
-            i = self._boolean_index_to_array(i)
-            if len(i)==2:
-                if isinstance(j, slice):
-                    j = i[1]
-
-                else:
-                    raise ValueError('too many indices for array')
-            i = i[0]
-        if isinstance(j, np.ndarray) and j.dtype.kind == 'b':
-            j = self._boolean_index_to_array(j)[0]
-
-        i_slice = isinstance(i, slice)
-        if i_slice:
-            i = self._slicetoarange(i, self.shape[0])[:,None]
-        else:
-            i = np.atleast_1d(i)
-
-        if isinstance(j, slice):
-            j = self._slicetoarange(j, self.shape[1])[None,:]
-            if i.ndim == 1:
-                i = i[:,None]
-            elif not i_slice:
-                raise IndexError('index returns 3-dim structure')
-        elif isscalarlike(j):
-            # row vector special case
-            j = np.atleast_1d(j)
-            if i.ndim == 1:
-                i, j = np.broadcast_arrays(i, j)
-                i = i[:, None]
-                j = j[:, None]
-                return i, j
-        else:
-            j = np.atleast_1d(j)
-            if i_slice and j.ndim>1:
-                raise IndexError('index returns 3-dim structure')
-
-        i, j = np.broadcast_arrays(i, j)
-
-        if i.ndim == 1:
-            # return column vectors for 1-D indexing
-            i = i[None,:]
-            j = j[None,:]
-        elif i.ndim > 2:
-            raise IndexError("Index dimension must be <= 2")
-
-        return i, j
-
     def __getitem__(self, index):
         """Return the element(s) index=(i, j), where j may be a slice.
         This always returns a copy for consistency, since slices into
@@ -311,7 +237,8 @@ class lil_matrix(spmatrix):
         i, j = self._index_to_arrays(i, j)
         if i.size == 0:
             return lil_matrix((0,0), dtype=self.dtype)
-        return self.__class__([[self._get1(int(i[ii, jj]), int(j[ii, jj])) for jj in
+        return self.__class__([[self._get1(int(i[ii, jj]), 
+                                           int(j[ii, jj])) for jj in
                                 xrange(i.shape[1])] for ii in 
                                xrange(i.shape[0])])
 

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -240,10 +240,9 @@ class lil_matrix(spmatrix, IndexMixin):
         i, j = self._index_to_arrays(i, j)
         if i.size == 0:
             return lil_matrix((0,0), dtype=self.dtype)
-        return self.__class__([[self._get1(int(i[ii, jj]), 
-                                           int(j[ii, jj])) for jj in
-                                xrange(i.shape[1])] for ii in 
-                               xrange(i.shape[0])])
+        return self.__class__([[self._get1(iii, jjj) for iii, jjj in 
+                                zip(ii, jj)] for ii, jj in 
+                               zip(i.tolist(), j.tolist())])
 
     def _insertat2(self, row, data, j, x):
         """ helper for __setitem__: insert a value in the given row/data at

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -123,7 +123,7 @@ def isshape(x):
 
 
 def issequence(t):
-    return isinstance(t, (list, tuple))\
+    return (isinstance(t, (list, tuple)) and np.isscalar(t[0]))\
            or (isinstance(t, np.ndarray) and (t.ndim == 1))
 
 def ismatrix(t):

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -132,3 +132,82 @@ def ismatrix(t):
 
 def isdense(x):
     return isinstance(x, np.ndarray)
+
+class IndexMixin(object):
+    """
+    This class simply exists to hold the methods necessary for fancy indexing.
+    """
+    def _slicetoarange(self, j, shape):
+        start, stop, step = j.indices(shape)
+        return np.arange(start, stop, step)
+
+    def _unpack_index(self, index):
+        if isinstance(index, tuple):
+            if len(index) == 2:
+                return index
+            elif len(index) == 1:
+                return index[0], slice(None)
+            else:
+                raise IndexError('invalid number of indices')
+        else:
+            return index, slice(None)
+
+    def _boolean_index_to_array(self, i):
+        if i.ndim<2:
+            i = i.nonzero()
+        elif (i.shape[0] > self.shape[0] or i.shape[1] > self.shape[1] or
+              i.ndim > 2):
+            raise IndexError('invalid index shape')
+        else:
+            i = i.nonzero()
+        return i
+
+    def _index_to_arrays(self, i, j):
+        if isinstance(i, np.ndarray) and i.dtype.kind == 'b':
+            i = self._boolean_index_to_array(i)
+            if len(i)==2:
+                if isinstance(j, slice):
+                    j = i[1]
+
+                else:
+                    raise ValueError('too many indices for array')
+            i = i[0]
+        if isinstance(j, np.ndarray) and j.dtype.kind == 'b':
+            j = self._boolean_index_to_array(j)[0]
+
+        i_slice = isinstance(i, slice)
+        if i_slice:
+            i = self._slicetoarange(i, self.shape[0])[:,None]
+        else:
+            i = np.atleast_1d(i)
+
+        if isinstance(j, slice):
+            j = self._slicetoarange(j, self.shape[1])[None,:]
+            if i.ndim == 1:
+                i = i[:,None]
+            elif not i_slice:
+                raise IndexError('index returns 3-dim structure')
+        elif isscalarlike(j):
+            # row vector special case
+            j = np.atleast_1d(j)
+            if i.ndim == 1:
+                i, j = np.broadcast_arrays(i, j)
+                i = i[:, None]
+                j = j[:, None]
+                return i, j
+        else:
+            j = np.atleast_1d(j)
+            if i_slice and j.ndim>1:
+                raise IndexError('index returns 3-dim structure')
+
+        i, j = np.broadcast_arrays(i, j)
+
+        if i.ndim == 1:
+            # return column vectors for 1-D indexing
+            i = i[None,:]
+            j = j[None,:]
+        elif i.ndim > 2:
+            raise IndexError("Index dimension must be <= 2")
+
+        return i, j
+

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -168,7 +168,6 @@ class IndexMixin(object):
             if len(i)==2:
                 if isinstance(j, slice):
                     j = i[1]
-
                 else:
                     raise ValueError('too many indices for array')
             i = i[0]

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -162,7 +162,7 @@ class IndexMixin(object):
             i = i.nonzero()
         return i
 
-    def _index_to_arrays(self, i, j):
+    def _check_Boolean(self, i, j):
         if isinstance(i, np.ndarray) and i.dtype.kind == 'b':
             i = self._boolean_index_to_array(i)
             if len(i)==2:
@@ -174,6 +174,10 @@ class IndexMixin(object):
             i = i[0]
         if isinstance(j, np.ndarray) and j.dtype.kind == 'b':
             j = self._boolean_index_to_array(j)[0]
+        return i, j
+
+    def _index_to_arrays(self, i, j):
+        i, j = self._check_Boolean(i, j)
 
         i_slice = isinstance(i, slice)
         if i_slice:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1698,7 +1698,7 @@ class TestCSR(sparse_test_class()):
             SIJ = SIJ.todense()
         assert_equal(SIJ, D[I,J])
 
-class TestCSC(sparse_test_class(fancy_multidim_indexing=False)):
+class TestCSC(sparse_test_class()):
     spmatrix = csc_matrix
 
     def test_constructor1(self):
@@ -1802,23 +1802,6 @@ class TestCSC(sparse_test_class(fancy_multidim_indexing=False)):
         if isspmatrix(SIJ):
             SIJ = SIJ.todense()
         assert_equal(SIJ, D[I,J])
-
-    ##
-    ## TODO: CSC fails the following tests by producing invalid results
-    ##
-    """
-    @dec.knownfailureif(True, "CSC bug")
-    def test_fancy_indexing_ndarray(self):
-        pass
-
-    @dec.knownfailureif(True, "CSC not implemented")
-    def test_slicing_3(self):
-        pass
-
-    @dec.knownfailureif(True, "CSC not implemented")
-    def test_fancy_indexing_boolean(self):
-        pass
-    """
 
 class TestDOK(sparse_test_class(slicing=False,
                                 slicing_assign=False,

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -896,7 +896,7 @@ class _TestSlicing:
         A = self.spmatrix( B )
 
         s_ = np.s_
-        slices = [s_[:2], s_[1:2], s_[3:], s_[3::2],
+        slices = [s_[:2], s_[1:2], s_[3:], s_[3::2], s_[1:5:1],
                   s_[8:3:-1], s_[4::-2], s_[:5:-1],
                   0, 1, s_[:], s_[1:5], -1, -2, -5,
                   array(-1), np.int8(-3)]

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1047,6 +1047,8 @@ class _TestFancyIndexing:
         A = self.spmatrix(np.zeros([5, 5]))
         assert_raises((IndexError, ValueError, TypeError), A.__getitem__, "foo")
         assert_raises((IndexError, ValueError, TypeError), A.__getitem__, (2, "foo"))
+        assert_raises((IndexError, ValueError), A.__getitem__, 
+                      ([1, 2, 3], [1, 2, 3, 4]))
 
     def test_fancy_indexing(self):
         B = asmatrix(arange(50).reshape(5,10))

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1698,8 +1698,7 @@ class TestCSR(sparse_test_class()):
             SIJ = SIJ.todense()
         assert_equal(SIJ, D[I,J])
 
-class TestCSC(sparse_test_class(slicing_assign=False, fancy_assign=False,
-                                fancy_multidim_indexing=False)):
+class TestCSC(sparse_test_class(fancy_multidim_indexing=False)):
     spmatrix = csc_matrix
 
     def test_constructor1(self):
@@ -1807,7 +1806,7 @@ class TestCSC(sparse_test_class(slicing_assign=False, fancy_assign=False,
     ##
     ## TODO: CSC fails the following tests by producing invalid results
     ##
-
+    """
     @dec.knownfailureif(True, "CSC bug")
     def test_fancy_indexing_ndarray(self):
         pass
@@ -1819,6 +1818,7 @@ class TestCSC(sparse_test_class(slicing_assign=False, fancy_assign=False,
     @dec.knownfailureif(True, "CSC not implemented")
     def test_fancy_indexing_boolean(self):
         pass
+    """
 
 class TestDOK(sparse_test_class(slicing=False,
                                 slicing_assign=False,

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1570,8 +1570,7 @@ def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
 # Matrix class based tests
 #------------------------------------------------------------------------------
 
-class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False)):
-    #                            fancy_multidim_indexing=False)):
+class TestCSR(sparse_test_class()):
     spmatrix = csr_matrix
 
     def test_constructor1(self):
@@ -1698,16 +1697,6 @@ class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False)):
         if isspmatrix(SIJ):
             SIJ = SIJ.todense()
         assert_equal(SIJ, D[I,J])
-
-    """
-    @dec.knownfailureif(True, "CSR not implemented")
-    def test_slicing_3(self):
-        pass
-
-    @dec.knownfailureif(True, "CSR not implemented")
-    def test_fancy_indexing_boolean(self):
-        pass
-    """
 
 class TestCSC(sparse_test_class(slicing_assign=False, fancy_assign=False,
                                 fancy_multidim_indexing=False)):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1562,8 +1562,7 @@ def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
 # Matrix class based tests
 #------------------------------------------------------------------------------
 
-class TestCSR(sparse_test_class()):
-    #slicing_assign=False, fancy_assign=False,
+class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False)):
     #                            fancy_multidim_indexing=False)):
     spmatrix = csr_matrix
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1149,6 +1149,12 @@ class _TestFancyIndexing:
     def test_fancy_indexing_boolean(self):
         random.seed(1234) # make runs repeatable
 
+        # CSR matrix returns matrix in some cases
+        def todense(a):
+            if isinstance(a, (np.matrix, np.ndarray)):
+                return a
+            return a.todense()        
+
         B = asmatrix(arange(50).reshape(5,10))
         A = self.spmatrix( B )
 
@@ -1156,15 +1162,15 @@ class _TestFancyIndexing:
         J = np.array(np.random.randint(0, 2, size=10), dtype=bool)
         X = np.array(np.random.randint(0, 2, size=(5, 10)), dtype=bool)
 
-        assert_equal(A[I].todense(), B[I])
-        assert_equal(A[:,J].todense(), B[:, J])
-        assert_equal(A[X].todense(), B[X])
-        assert_equal(A[B>9].todense(), B[B>9])
+        assert_equal(todense(A[I]), B[I])
+        assert_equal(todense(A[:,J]), B[:, J])
+        assert_equal(todense(A[X]), B[X])
+        assert_equal(todense(A[B>9]), B[B>9])
 
         I = np.array([True, False, True, True, False])
         J = np.array([False, True, True, False, True])
 
-        assert_equal(A[I, J].todense(), B[I, J])
+        assert_equal(todense(A[I, J]), B[I, J])
 
         Z = np.array(np.random.randint(0, 2, size=(5, 11)), dtype=bool)
         Y = np.array(np.random.randint(0, 2, size=(6, 10)), dtype=bool)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -896,7 +896,7 @@ class _TestSlicing:
         A = self.spmatrix( B )
 
         s_ = np.s_
-        slices = [s_[:2], s_[1:2], s_[3:], s_[3::2], s_[1:5:1],
+        slices = [s_[:2], s_[1:2], s_[3:], s_[3::2],
                   s_[8:3:-1], s_[4::-2], s_[:5:-1],
                   0, 1, s_[:], s_[1:5], -1, -2, -5,
                   array(-1), np.int8(-3)]

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -712,7 +712,7 @@ class _TestGetSet:
             for j in range(-N, N):
                 assert_equal(A[i,j], D[i,j])
 
-        for ij in [(0,3),(-1,3),(4,0),(4,3),(4,-1)]:
+        for ij in [(0,3),(-1,3),(4,0),(4,3),(4,-1), (1, 2, 3)]:
             assert_raises(IndexError, A.__getitem__, ij)
 
     def test_setelement(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1562,8 +1562,9 @@ def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
 # Matrix class based tests
 #------------------------------------------------------------------------------
 
-class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False,
-                                fancy_multidim_indexing=False)):
+class TestCSR(sparse_test_class()):
+    #slicing_assign=False, fancy_assign=False,
+    #                            fancy_multidim_indexing=False)):
     spmatrix = csr_matrix
 
     def test_constructor1(self):
@@ -1691,6 +1692,7 @@ class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False,
             SIJ = SIJ.todense()
         assert_equal(SIJ, D[I,J])
 
+    """
     @dec.knownfailureif(True, "CSR not implemented")
     def test_slicing_3(self):
         pass
@@ -1698,7 +1700,7 @@ class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False,
     @dec.knownfailureif(True, "CSR not implemented")
     def test_fancy_indexing_boolean(self):
         pass
-
+    """
 
 class TestCSC(sparse_test_class(slicing_assign=False, fancy_assign=False,
                                 fancy_multidim_indexing=False)):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1179,7 +1179,7 @@ class _TestFancyIndexing:
 
         assert_raises(IndexError, A.__getitem__, Z)
         assert_raises(IndexError, A.__getitem__, Y)
-        assert_raises(ValueError, A.__getitem__, (X, 1))
+        assert_raises((IndexError, ValueError), A.__getitem__, (X, 1))
 
 class _TestFancyIndexingAssign:
     def test_bad_index_assign(self):


### PR DESCRIPTION
This probably needs some refactoring, but it is a start. CSR and CSC now pass all but one of the tests for fancy **getitem**. The one test it fails is when you give it a slice object that would generate an empty matrix, the underlying CSR class doesn't like that. I don't know whether the test or the class should be rewritten, so I just left that alone.

**setitem** was rewritten in the _cs_matrix class, so both CSC and CSR matrices have it. BSR might also, but I haven't run those tests.

Where refactoring/other help is probably needed is in getting CSC **getitem**(). The way I am reading the code now, the CSC **getitem**() is implicitly dependent upon the exact implementation of CSR **getitem**(). That's not the worst sin one could commit, but the code could probably be written in a smarter way.
