### PR TITLE
`umfpack`: Avoid cleanup if initialization stopped short by ImportError.

### DIFF
--- a/scipy/sparse/linalg/dsolve/umfpack/umfpack.py
+++ b/scipy/sparse/linalg/dsolve/umfpack/umfpack.py
@@ -309,7 +309,8 @@ class UmfpackContext(Struct):
         self.control[UMFPACK_PRL] = 3
 
     def __del__(self):
-        self.free()
+        if _um is not None:
+            self.free()
 
     ##
     # 30.11.2005, c


### PR DESCRIPTION
When umfpack was not available, `UmfpackContext` did not finish initialization and raised an `ImportError`. If that error was caught, an `AttributeError` was raised because the `__del__` method tried to cleanup attributes that were never initialized:

```
Exception AttributeError: "'UmfpackContext' object has no attribute '_symbolic'" in <bound method UmfpackContext.__del__ of <scipy.sparse.linalg.dsolve.umfpack.umfpack.UmfpackContext object at 0x1012358d0>> ignored
```

Note that the error doesn't actually propagate (possibly because the clean up is occurring in the exception machinery)---it just prints to the terminal. Just for some context, this issue arises in scikit-image here:

https://github.com/scikit-image/scikit-image/blob/master/skimage/segmentation/random_walker_segmentation.py#L19

(Actually, the exception message doesn't print out until the next caught exception, a few lines down.)
