### PR TITLE
TST: expm sparse and dense matrix benchmark

### DIFF
--- a/scipy/sparse/linalg/benchmarks/bench_expm.py
+++ b/scipy/sparse/linalg/benchmarks/bench_expm.py
@@ -1,0 +1,94 @@
+"""Compare the speed of expm for sparse vs. dense matrices.
+"""
+from __future__ import division, print_function, absolute_import
+
+import time
+import math
+
+import numpy as np
+from numpy.testing import (Tester, TestCase, assert_allclose)
+
+import scipy.sparse
+import scipy.linalg
+
+
+def random_sparse(m, n, nnz_per_row):
+    # Copied from the scipy.sparse benchmark.
+    rows = np.arange(m).repeat(nnz_per_row)
+    cols = np.random.random_integers(low=0, high=n-1, size=nnz_per_row*m)
+    vals = np.random.random_sample(m*nnz_per_row)
+    M = scipy.sparse.coo_matrix((vals,(rows,cols)), (m,n), dtype=float)
+    # Use csc instead of csr, because sparse LU decomposition
+    # raises a warning when I use csr.
+    return M.tocsc()
+
+
+class BenchmarkExpm(TestCase):
+
+    def bench_expm_sparse_vs_dense(self):
+
+        # print headers and define the column formats
+        print()
+        print('               Sparse and Dense Matrix Exponential')
+        print('==============================================================')
+        print('      shape      |   nnz   |      operation     |   time   ')
+        print('                 | per row |                    | (seconds)')
+        print('--------------------------------------------------------------')
+        fmt = ' %15s |   %3d   | %18s | %6.2f '
+
+        # check three roughly exponentially increasing matrix orders
+        np.random.seed(1234)
+        for n in (30, 100, 300):
+
+            # Let the number of nonzero entries per row
+            # scale like the log of the order of the matrix.
+            nnz_per_row = int(math.ceil(math.log(n)))
+            shape = (n, n)
+
+            # time the sampling of a random sparse matrix
+            tm_start = time.clock()
+            A_sparse = random_sparse(n, n, nnz_per_row)
+            tm_end = time.clock()
+            tm_sampling = tm_end - tm_start
+
+            # first format conversion
+            tm_start = time.clock()
+            A_dense = A_sparse.toarray()
+            tm_end = time.clock()
+            tm_first_fmt = tm_end - tm_start
+
+            # sparse matrix exponential
+            tm_start = time.clock()
+            A_sparse_expm = scipy.linalg.expm(A_sparse)
+            tm_end = time.clock()
+            tm_sparse = tm_end - tm_start
+
+            # dense matrix exponential
+            tm_start = time.clock()
+            A_dense_expm = scipy.linalg.expm(A_dense)
+            tm_end = time.clock()
+            tm_dense = tm_end - tm_start
+
+            # second format conversion
+            tm_start = time.clock()
+            A_sparse_expm_as_dense = A_sparse_expm.toarray()
+            tm_end = time.clock()
+            tm_second_fmt = tm_end - tm_start
+
+            # sum the format conversion times
+            tm_fmt = tm_first_fmt + tm_second_fmt
+
+            # check that the matrix exponentials are the same
+            assert_allclose(A_sparse_expm_as_dense, A_dense_expm)
+
+            # write the rows
+            print(fmt % (shape, nnz_per_row, 'matrix sampling', tm_sampling))
+            print(fmt % (shape, nnz_per_row, 'fmt conversions', tm_fmt))
+            print(fmt % (shape, nnz_per_row, 'sparse expm', tm_sparse))
+            print(fmt % (shape, nnz_per_row, 'dense expm', tm_dense))
+        print()
+
+
+if __name__ == '__main__':
+    Tester().bench()
+


### PR DESCRIPTION
Add an expm benchmark.

This is for the default version of expm; it doesn't depend on anything added to scipy in recent history, or at least since expm was extended to support sparse matrices.

In the table below I've pasted some benchmark times up to a minute, but the python code in the PR does not attempt the slowest of these iterations.  I've prefixed this PR with "TST" but "BENCH" could have been better if that were a thing.

The benchmark shows that sparse expm is relatively slow compared to dense expm.  This is what I expected to see, at least when the sparsity does not have any particular structure.  No replication is attempted for the purposes of accounting for runtime variance; this is a rough benchmark that shows large (orders of magnitude) differences.

```
               Sparse and Dense Matrix Exponential
==============================================================
      shape      |   nnz   |      operation     |   time   
                 | per row |                    | (seconds)
--------------------------------------------------------------
        (30, 30) |     4   |    matrix sampling |   0.00 
        (30, 30) |     4   |    fmt conversions |   0.00 
        (30, 30) |     4   |        sparse expm |   0.12 
        (30, 30) |     4   |         dense expm |   0.01 
      (100, 100) |     5   |    matrix sampling |   0.00 
      (100, 100) |     5   |    fmt conversions |   0.01 
      (100, 100) |     5   |        sparse expm |   0.82 
      (100, 100) |     5   |         dense expm |   0.01 
      (300, 300) |     6   |    matrix sampling |   0.00 
      (300, 300) |     6   |    fmt conversions |   0.01 
      (300, 300) |     6   |        sparse expm |   2.81 
      (300, 300) |     6   |         dense expm |   0.10 
    (1000, 1000) |     7   |    matrix sampling |   0.00 
    (1000, 1000) |     7   |    fmt conversions |   0.15 
    (1000, 1000) |     7   |        sparse expm |  62.43 
    (1000, 1000) |     7   |         dense expm |   2.42 
```
