### PR TITLE
ENH: stats: Some enhancements to the chisquare functions:

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -812,8 +812,11 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
         Expected frequencies in each category.  By default the categories are
         assumed to be equally likely.
     ddof : int, optional
-        Adjustment to the degrees of freedom for the p-value.  The default
-        is one less than the number of data elements.
+        "Delta degrees of freedom": adjustment to the degrees of freedom
+        for the p-value.  The p-value is computed using a chi-squared
+        distribution with ``k - 1 - ddof`` degrees of freedom, where `k`
+        is the number of observed frequencies.  The default value of `ddof`
+        is 0.
     axis : int or None, optional
         The axis of the broadcast result of `f_obs` and `f_exp` along which to
         apply the test.  If axis is None, all values in `f_obs` are treated
@@ -822,9 +825,11 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     Returns
     -------
     chisq : float or np.ma.masked_array
-        The chisquare test statistic.
+        The chisquare test statistic.  The value is a float if `axis` is
+        None or `f_obs` and `f_exp` are 1-D.
     p : float or np.ma.masked_array
-        The p-value of the test.
+        The p-value of the test.  The value is a float if `ddof` and the
+        return value `chisq` are scalars.
 
     Notes
     -----
@@ -872,7 +877,7 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
            fill_value = 1e+20)
     )
 
-    By setting `axis=None`, the test is applied to all data in the array,
+    By setting ``axis=None``, the test is applied to all data in the array,
     which is equivalent to applying the test to the flattened array.
 
     >>> chisquare(obs, axis=None)
@@ -894,7 +899,7 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     `f_obs` and `f_exp` are also broadcast.  In the following, `f_obs` has
     shape (6,) and `f_exp` has shape (2, 6), so the result of broadcasting
     `f_obs` and `f_exp` has shape (2, 6).  To compute the desired chi-squared
-    statistics, we use `axis=1`:
+    statistics, we use ``axis=1``:
 
     >>> chisquare([16, 18, 16, 14, 12, 12],
     ...           f_exp=[[16, 16, 16, 16, 16, 8], [8, 20, 20, 16, 12, 12]],

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -798,7 +798,117 @@ ttest_rel.__doc__ = stats.ttest_rel.__doc__
 
 
 def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
+    """
+    Calculates a one-way chi square test.
 
+    The chi square test tests the null hypothesis that the categorical data
+    has the given frequencies.
+
+    Parameters
+    ----------
+    f_obs : array
+        Observed frequencies in each category.
+    f_exp : array, optional
+        Expected frequencies in each category.  By default the categories are
+        assumed to be equally likely.
+    ddof : int, optional
+        Adjustment to the degrees of freedom for the p-value.  The default
+        is one less than the number of data elements.
+    axis : int or None, optional
+        The axis of the broadcast result of `f_obs` and `f_exp` along which to
+        apply the test.  If axis is None, all values in `f_obs` are treated
+        as a single data set.  Default is 0.
+
+    Returns
+    -------
+    chisq : float or np.ma.masked_array
+        The chisquare test statistic.
+    p : float or np.ma.masked_array
+        The p-value of the test.
+
+    Notes
+    -----
+    This test is invalid when the observed or expected frequencies in each
+    category are too small.  A typical rule is that all of the observed
+    and expected frequencies should be at least 5.
+    The default degrees of freedom, k-1, are for the case when no parameters
+    of the distribution are estimated. If p parameters are estimated by
+    efficient maximum likelihood then the correct degrees of freedom are
+    k-1-p. If the parameters are estimated in a different way, then the
+    dof can be between k-1-p and k-1. However, it is also possible that
+    the asymptotic distribution is not a chisquare, in which case this
+    test is not appropriate.
+
+    References
+    ----------
+    .. [1] Lowry, Richard.  "Concepts and Applications of Inferential
+           Statistics". Chapter 8. http://faculty.vassar.edu/lowry/ch8pt1.html
+
+    Examples
+    --------
+    When just `f_obs` is given, it is assumed that the expected frequencies
+    are uniform and given by the mean of the observed frequencies.
+
+    >>> chisquare([16, 18, 16, 14, 12, 12])
+    (2.0, 0.84914503608460956)
+
+    With `f_exp` the expected frequencies can be given.
+
+    >>> chisquare([16, 18, 16, 14, 12, 12], f_exp=[16, 16, 16, 16, 16, 8])
+    (3.5, 0.62338762774958223)
+
+    When `f_obs` is 2-D, by default the test is applied to each column.
+
+    >>> obs = np.array([[16, 18, 16, 14, 12, 12], [32, 24, 16, 28, 20, 24]]).T
+    >>> obs.shape
+    (6, 2)
+    >>> chisquare(obs)
+    (masked_array(data = [2.0 6.666666666666667],
+                 mask = [False False],
+           fill_value = 1e+20)
+    ,
+     masked_array(data = [ 0.84914504  0.24663415],
+                 mask = False,
+           fill_value = 1e+20)
+    )
+
+    By setting `axis=None`, the test is applied to all data in the array,
+    which is equivalent to applying the test to the flattened array.
+
+    >>> chisquare(obs, axis=None)
+    (23.31034482758621, 0.015975692534127565)
+    >>> chisquare(obs.ravel())
+    (23.31034482758621, 0.015975692534127565)
+
+    `ddof` is the change to make to the default degrees of freedom.
+
+    >>> chisquare([16, 18, 16, 14, 12, 12], ddof=1)
+    (2.0, 0.73575888234288467)
+
+    The calculation of the p-values is done by broadcasting the
+    chi-squared statistic with `ddof`.
+
+    >>> chisquare([16, 18, 16, 14, 12, 12], ddof=[0,1,2])
+    (2.0, array([ 0.84914504,  0.73575888,  0.5724067 ]))
+
+    `f_obs` and `f_exp` are also broadcast.  In the following, `f_obs` has
+    shape (6,) and `f_exp` has shape (2, 6), so the result of broadcasting
+    `f_obs` and `f_exp` has shape (2, 6).  To compute the desired chi-squared
+    statistics, we use `axis=1`:
+
+    >>> chisquare([16, 18, 16, 14, 12, 12],
+    ...           f_exp=[[16, 16, 16, 16, 16, 8], [8, 20, 20, 16, 12, 12]],
+    ...           axis=1)
+    (masked_array(data = [3.5 9.25],
+                 mask = [False False],
+           fill_value = 1e+20)
+    ,
+     masked_array(data = [ 0.62338763  0.09949846],
+                 mask = False,
+           fill_value = 1e+20)
+    )
+
+    """
     f_obs = ma.asarray(f_obs)
 
     if f_exp is not None:
@@ -831,12 +941,10 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
         # In some cases, the `count` method returns a scalar array (e.g.
         # np.array(3)), but we want a plain integer.
         num_obs = int(num_obs)
-    ddof = ma.asanyarray(ddof)
+    ddof = np.asanyarray(ddof)
     p = stats.chisqprob(chisq, num_obs - 1 - ddof)
 
     return chisq, p
-
-chisquare.__doc__ = stats.chisquare.__doc__
 
 
 def mannwhitneyu(x,y, use_continuity=True):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3471,8 +3471,11 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
         Expected frequencies in each category.  By default the categories are
         assumed to be equally likely.
     ddof : int, optional
-        Adjustment to the degrees of freedom for the p-value.  The default
-        is one less than the number of data elements.
+        "Delta degrees of freedom": adjustment to the degrees of freedom
+        for the p-value.  The p-value is computed using a chi-squared
+        distribution with ``k - 1 - ddof`` degrees of freedom, where `k`
+        is the number of observed frequencies.  The default value of `ddof`
+        is 0.
     axis : int or None, optional
         The axis of the broadcast result of `f_obs` and `f_exp` along which to
         apply the test.  If axis is None, all values in `f_obs` are treated
@@ -3481,9 +3484,11 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     Returns
     -------
     chisq : float or ndarray
-        The chisquare test statistic.
+        The chisquare test statistic.  The value is a float if `axis` is
+        None or `f_obs` and `f_exp` are 1-D.
     p : float or ndarray
-        The p-value of the test.
+        The p-value of the test.  The value is a float if `ddof` and the
+        return value `chisq` are scalars.
 
     Notes
     -----
@@ -3524,7 +3529,7 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     >>> chisquare(obs)
     (array([ 2.        ,  6.66666667]), array([ 0.84914504,  0.24663415]))
 
-    By setting `axis=None`, the test is applied to all data in the array,
+    By setting ``axis=None``, the test is applied to all data in the array,
     which is equivalent to applying the test to the flattened array.
 
     >>> chisquare(obs, axis=None)
@@ -3546,7 +3551,7 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     `f_obs` and `f_exp` are also broadcast.  In the following, `f_obs` has
     shape (6,) and `f_exp` has shape (2, 6), so the result of broadcasting
     `f_obs` and `f_exp` has shape (2, 6).  To compute the desired chi-squared
-    statistics, we use `axis=1`:
+    statistics, we use ``axis=1``:
 
     >>> chisquare([16, 18, 16, 14, 12, 12],
     ...           f_exp=[[16, 16, 16, 16, 16, 8], [8, 20, 20, 16, 12, 12]],

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3456,7 +3456,7 @@ def kstest(rvs, cdf, args=(), N=20, alternative='two-sided', mode='approx',
                 return D, distributions.ksone.sf(D,N)*2
 
 
-def chisquare(f_obs, f_exp=None, ddof=0):
+def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     """
     Calculates a one-way chi square test.
 
@@ -3466,18 +3466,22 @@ def chisquare(f_obs, f_exp=None, ddof=0):
     Parameters
     ----------
     f_obs : array
-        observed frequencies in each category
+        Observed frequencies in each category.
     f_exp : array, optional
-        expected frequencies in each category.  By default the categories are
+        Expected frequencies in each category.  By default the categories are
         assumed to be equally likely.
     ddof : int, optional
-        adjustment to the degrees of freedom for the p-value
+        Adjustment to the degrees of freedom for the p-value.  The default
+        is one less than the number of data elements.
+    axis : int or None, optional
+        The axis of `f_obs` along which to apply the test.  If axis is None,
+        all values in `f_obs` are treated as a single data set.  Default is 0.
 
     Returns
     -------
-    chisquare statistic : float
-        The chisquare test statistic
-    p : float
+    chisq : float or ndarray
+        The chisquare test statistic.
+    p : float or ndarray
         The p-value of the test.
 
     Notes
@@ -3498,15 +3502,90 @@ def chisquare(f_obs, f_exp=None, ddof=0):
     .. [1] Lowry, Richard.  "Concepts and Applications of Inferential
            Statistics". Chapter 8. http://faculty.vassar.edu/lowry/ch8pt1.html
 
+    Examples
+    --------
+    When just `f_obs` is given, it is assumed that the expected frequencies
+    are uniform and given by the mean of the observed frequencies.
+
+    >>> chisquare([16, 18, 16, 14, 12, 12])
+    (2.0, 0.84914503608460956)
+
+    With `f_exp` the expected frequencies can be given.
+
+    >>> chisquare([16, 18, 16, 14, 12, 12], f_exp=[16, 16, 16, 16, 16, 8])
+    (3.5, 0.62338762774958223)
+
+    When `f_obs` is 2-D, by default the test is applied to each column.
+
+    >>> obs = np.array([[16, 18, 16, 14, 12, 12], [32, 24, 16, 28, 20, 24]]).T
+    >>> obs.shape
+    (6, 2)
+    >>> chisquare(obs)
+    (array([ 2.        ,  6.66666667]), array([ 0.84914504,  0.24663415]))
+
+    By setting `axis=None`, the test is applied to all data in the array,
+    which is equivalent to applying the test to the flattened array.
+
+    >>> chisquare(obs, axis=None)
+    (23.31034482758621, 0.015975692534127565)
+    >>> chisquare(obs.ravel())
+    (23.31034482758621, 0.015975692534127565)
+
+    `ddof` is the change to make to the default degrees of freedom.
+
+    >>> chisquare([16, 18, 16, 14, 12, 12], ddof=1)
+    (2.0, 0.73575888234288467)
+
+    The calculation of the p-values is done by broadcasting the
+    chi-squared statistic with `ddof`.
+
+    >>> chisquare([16, 18, 16, 14, 12, 12], ddof=[0,1,2])
+    (2.0, array([ 0.84914504,  0.73575888,  0.5724067 ]))
+
+    `f_obs` and `f_exp` are also broadcast.  In the following, `f_exp` has
+    shape (2, 6).
+
+    >>> chisquare([16, 18, 16, 14, 12, 12],
+    ...           f_exp=[[16, 16, 16, 16, 16, 8], [8, 20, 20, 16, 12, 12]])
+    (array([ 3.5 ,  9.25]), array([ 0.62338763,  0.09949846]))
+
     """
     f_obs = asarray(f_obs)
-    k = len(f_obs)
-    if f_exp is None:
-        f_exp = array([np.sum(f_obs,axis=0)/float(k)] * len(f_obs),float)
+    if axis is not None:
+        num_obs = f_obs.shape[axis]
+        reduced_shape = list(f_obs.shape)
+        reduced_shape[axis] = 1
+    else:
+        num_obs = f_obs.size
+        reduced_shape = (1,)
 
-    f_exp = f_exp.astype(float)
-    chisq = np.add.reduce((f_obs-f_exp)**2 / f_exp)
-    return chisq, chisqprob(chisq, k-1-ddof)
+    if f_exp is None:
+        if num_obs == 0:
+            f_exp = f_obs
+        else:
+            # The `keepdims` argument is not available in older versions
+            # of numpy, otherwise we could use the following line.
+            #   f_exp = np.mean(f_obs, axis=axis, keepdims=True)
+            # and we wouldn't need `reduced_shape`.
+            f_exp = np.atleast_1d(f_obs.mean(axis=axis))
+            f_exp.shape = reduced_shape
+    else:
+        f_exp = np.asfarray(f_exp)
+        if f_exp.ndim > f_obs.ndim and axis >= 0:
+            # When f_obs and f_exp are broadcast in np.add.reduce (below),
+            # the result will have more dimensions than f_obs.ndim.  The
+            # `axis` argument refers to the axis *of f_obs*, so to preserve
+            # that meaning, we change `axis` to its equivalent negative value.
+            # This ensures that, for example,
+            #     chisquare([2,2,3], f_exp=[[2,2,3], [1,2,4]])
+            # (where the default axis=0 is used) does the Right Thing.
+            axis = -f_obs.ndim + axis
+
+    ddof = asarray(ddof)
+
+    chisq = np.add.reduce((f_obs - f_exp)**2 / f_exp, axis=axis)
+    p = chisqprob(chisq, num_obs - 1 - ddof)
+    return chisq, p
 
 
 def ks_2samp(data1, data2):

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -517,14 +517,17 @@ def test_plotting_positions():
 
 
 def check_chisquare(f_obs, f_exp, ddof, axis, expected_chi2):
+    # Use this only for arrays that have no masked values.
     f_obs = np.asarray(f_obs)
     if axis is None:
         num_obs = f_obs.size
     else:
         if axis == 'no':
-            num_obs = f_obs.shape[0]
+            use_axis = 0
         else:
-            num_obs = f_obs.shape[axis]
+            use_axis = axis
+        b = np.broadcast(f_obs, f_exp)
+        num_obs = b.shape[use_axis]
 
     if axis == 'no':
         chi2, p = mstats.chisquare(f_obs, f_exp=f_exp, ddof=ddof)
@@ -606,7 +609,7 @@ def test_chisquare():
              expected_chi2=[4.0]),
         Case(f_obs=data2db.T, f_exp=None, ddof=0, axis=None,
              expected_chi2=[4.0]),
-        Case(f_obs=[1,2,3,2], f_exp=[[1],[2]], ddof=0, axis=0,
+        Case(f_obs=[1,2,3,2], f_exp=[[1],[2]], ddof=0, axis=1,
              expected_chi2=[6.0, 1.0]),
     ]
 

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -539,6 +539,15 @@ def check_chisquare(f_obs, f_exp, ddof, axis, expected_chi2):
     expected_p = stats.chisqprob(expected_chi2, num_obs - 1 - ddof)
     assert_array_equal(p, expected_p)
 
+    # Also compare to stats.chisquare
+    if axis == 'no':
+        stats_chisq, stats_p = stats.chisquare(f_obs, f_exp=f_exp, ddof=ddof)
+    else:
+        stats_chisq, stats_p = stats.chisquare(f_obs, f_exp=f_exp, ddof=ddof,
+                                               axis=axis)
+    assert_array_almost_equal(chi2, stats_chisq)
+    assert_array_almost_equal(p, stats_p)
+
 
 def test_chisquare():
     # The data sets here are chosen so that the chi2 statistic

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -657,6 +657,13 @@ def test_chisquare_masked_arrays():
     assert_array_equal(chisq, expected_chisq)
     assert_array_almost_equal(p, stats.chisqprob(expected_chisq, mobs.T.count(axis=1) - 1))
 
+    # When axis=None, the two values should have type np.float64.
+    chisq, p = mstats.chisquare([1,2,3], axis=None)
+    assert_(isinstance(chisq, np.float64))
+    assert_(isinstance(p, np.float64))
+    assert_equal(chisq, 1.0)
+    assert_almost_equal(p, stats.chisqprob(1.0, 2))
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -3,7 +3,7 @@ Tests for the stats.mstats module (support for maskd arrays)
 """
 from __future__ import division, print_function, absolute_import
 
-
+from collections import namedtuple
 import numpy as np
 from numpy import nan
 import numpy.ma as ma
@@ -12,8 +12,9 @@ from numpy.ma import masked, nomask
 import scipy.stats.mstats as mstats
 from scipy import stats
 from numpy.testing import TestCase, run_module_suite
-from numpy.ma.testutils import assert_equal, assert_almost_equal, \
-    assert_array_almost_equal, assert_array_almost_equal_nulp, assert_
+from numpy.ma.testutils import (assert_equal, assert_almost_equal,
+    assert_array_almost_equal, assert_array_almost_equal_nulp, assert_,
+    assert_array_equal)
 
 
 class TestMquantiles(TestCase):
@@ -513,6 +514,145 @@ def test_plotting_positions():
     """Regression test for #1256"""
     pos = mstats.plotting_positions(np.arange(3), 0, 0)
     assert_array_almost_equal(pos.data, np.array([0.25, 0.5, 0.75]))
+
+
+def check_chisquare(f_obs, f_exp, ddof, axis, expected_chi2):
+    f_obs = np.asarray(f_obs)
+    if axis is None:
+        num_obs = f_obs.size
+    else:
+        if axis == 'no':
+            num_obs = f_obs.shape[0]
+        else:
+            num_obs = f_obs.shape[axis]
+
+    if axis == 'no':
+        chi2, p = mstats.chisquare(f_obs, f_exp=f_exp, ddof=ddof)
+    else:
+        chi2, p = mstats.chisquare(f_obs, f_exp=f_exp, ddof=ddof, axis=axis)
+    assert_array_equal(chi2, expected_chi2)
+
+    ddof = np.asarray(ddof)
+    expected_p = stats.chisqprob(expected_chi2, num_obs - 1 - ddof)
+    assert_array_equal(p, expected_p)
+
+
+def test_chisquare():
+    # The data sets here are chosen so that the chi2 statistic
+    # can be calculated exactly, so a test for equality (rather than
+    # being numerically close) can be used.
+    Case = namedtuple('Case', ['f_obs', 'f_exp', 'ddof', 'axis',
+                                'expected_chi2'])
+    empty = np.array([[],[],[]])
+    data2da = np.array([[1, 4],
+                        [2, 8],
+                        [3, 12],
+                        [2, 8]])
+    data2db = np.array([[1, 2, 3, 2],
+                        [3, 2, 3, 0]])
+
+    # These cases use the default axis=0.
+    cases0 = [
+        # simple case, 1 data set:
+        Case(f_obs=[1,2,3,2], f_exp=None, ddof=0, axis=0,
+             expected_chi2=1.0),
+        # two simple data sets
+        Case(f_obs=data2da, f_exp=None, ddof=0, axis=0,
+             expected_chi2=[1.0, 4.0]),
+        # Edge case: one data set with length 0.
+        Case(f_obs=[], ddof=0, f_exp=None, axis=0, expected_chi2=0.0),
+        # Edge case: no data sets (data has shape (3,0)).
+        Case(f_obs=empty, f_exp=None, ddof=0, axis=0, expected_chi2=[]),
+        # Edge case: data has shape (0, 3) (3 data sets,
+        # but each has length 0).
+        Case(f_obs=empty.T, f_exp=None, ddof=0, axis=0,
+             expected_chi2=[0.0, 0.0, 0.0]),
+        # simple case, with scalar f_exp.
+        Case(f_obs=[1, 2, 3, 2], f_exp=2, ddof=0, axis=0,
+             expected_chi2=1.0),
+        # simple case with vector f_exp (uniform).
+        Case(f_obs=[1, 2, 3, 2], f_exp=[2, 2, 2, 2], ddof=0, axis=0,
+             expected_chi2=1.0),
+        # simple case with vector f_exp equal to f_obs.
+        Case(f_obs=[1, 2, 3, 2], f_exp=[1, 2, 3, 2], ddof=0, axis=0,
+             expected_chi2=0.0),
+        # 2-D data
+        Case(f_obs=data2db.T, f_exp=None, ddof=0, axis=0,
+             expected_chi2=[1.0, 3.0]),
+        Case(f_obs=data2db.T, f_exp=None, ddof=1, axis=0,
+             expected_chi2=[1.0, 3.0]),
+        # 2-D data, 1-D ddof
+        Case(f_obs=data2db.T, f_exp=None, ddof=[0,1], axis=0,
+             expected_chi2=[1.0, 3.0]),
+    ]
+    # All the cases in `cases0` have axis=0, which is the default value
+    # for the chisquare function.  Here we check each case twice, once
+    # in which the argument is not passed to chisquare (indicated by
+    # using the value 'no' in the call to check_chisquare), and again
+    # with the axis argument explicitly set to 0.
+    for case in cases0:
+        yield (check_chisquare, case.f_obs, case.f_exp, case.ddof, 'no',
+               case.expected_chi2)
+    for case in cases0:
+        yield (check_chisquare, case.f_obs, case.f_exp, case.ddof, 0,
+               case.expected_chi2)
+
+    # A few more cases, testing axis != 0 and basic broadcasting of
+    # f_obs and f_exp.
+    cases1 = [
+        Case(f_obs=data2da.T, f_exp=None, ddof=0, axis=1,
+             expected_chi2=[1.0, 4.0]),
+        Case(f_obs=data2db, f_exp=None, ddof=0, axis=None,
+             expected_chi2=[4.0]),
+        Case(f_obs=data2db.T, f_exp=None, ddof=0, axis=None,
+             expected_chi2=[4.0]),
+        Case(f_obs=[1,2,3,2], f_exp=[[1],[2]], ddof=0, axis=0,
+             expected_chi2=[6.0, 1.0]),
+    ]
+
+    for case in cases1:
+        yield (check_chisquare, case.f_obs, case.f_exp, case.ddof, case.axis,
+               case.expected_chi2)
+
+
+def test_chisquare_ddof_broadcasting():
+    # Test that ddof broadcasts correctly.
+
+    # obs has shape (4, 2).  We'll use the default axis=0, so chi2
+    # will have shape (2,).
+    obs = np.array([[1, 2, 3, 2], [3, 2, 2, 5]]).T
+
+    # ddof has shape (2, 1).  This is broadcast with chi2, so p will
+    # have shape (2,2).
+    ddof = np.array([[0], [1]])
+
+    chi2, p = mstats.chisquare(obs, ddof=ddof)
+    assert_array_equal(chi2, [1.0, 2.0])
+
+    chi20, p0 = mstats.chisquare(obs, ddof=ddof[0,0])
+    assert_array_equal(chi20, [1.0, 2.0])
+
+    chi21, p1 = mstats.chisquare(obs, ddof=ddof[1,0])
+    assert_array_equal(chi21, [1.0, 2.0])
+    assert_array_equal(p, np.vstack((p0, p1)))
+
+
+def test_chisquare_masked_arrays():
+    # The other tests were taken from the tests for stats.chisquare, so
+    # they don't test the function with masked arrays.  Here masked arrays
+    # are tested.
+    obs = np.array([[8, 8, 16, 32, -1], [-1, -1, 3, 4, 5]]).T
+    mask = np.array([[0, 0, 0, 0, 1], [1, 1, 0, 0, 0]]).T
+    mobs = ma.masked_array(obs, mask)
+    expected_chisq = np.array([24.0, 0.5])
+
+    chisq, p = mstats.chisquare(mobs)
+    assert_array_equal(chisq, expected_chisq)
+    assert_array_almost_equal(p, stats.chisqprob(expected_chisq, mobs.count(axis=0) - 1))
+
+    chisq, p = mstats.chisquare(mobs.T, axis=1)
+    assert_array_equal(chisq, expected_chisq)
+    assert_array_almost_equal(p, stats.chisqprob(expected_chisq, mobs.T.count(axis=1) - 1))
 
 
 if __name__ == "__main__":

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -9,6 +9,7 @@
 from __future__ import division, print_function, absolute_import
 
 import sys
+from collections import namedtuple
 
 from numpy.testing import TestCase, assert_, assert_equal, \
     assert_almost_equal, assert_array_almost_equal, assert_array_equal, \
@@ -1446,6 +1447,127 @@ def test_percentileofscore():
         yield assert_equal, \
               pcos([10, 20, 30, 50, 60, 70, 80, 90, 100, 110],
                    score, kind=kind), result
+
+
+def check_chisquare(f_obs, f_exp, ddof, axis, expected_chi2):
+    f_obs = np.asarray(f_obs)
+    if axis is None:
+        num_obs = f_obs.size
+    else:
+        if axis == 'no':
+            num_obs = f_obs.shape[0]
+        else:
+            num_obs = f_obs.shape[axis]
+
+    if axis == 'no':
+        chi2, p = stats.chisquare(f_obs, f_exp=f_exp, ddof=ddof)
+    else:
+        chi2, p = stats.chisquare(f_obs, f_exp=f_exp, ddof=ddof, axis=axis)
+    assert_array_equal(chi2, expected_chi2)
+
+    ddof = np.asarray(ddof)
+    expected_p = stats.chisqprob(expected_chi2, num_obs - 1 - ddof)
+    assert_array_equal(p, expected_p)
+
+
+def test_chisquare():
+    # The data sets here are chosen so that the chi2 statistic
+    # can be calculated exactly, so a test for equality (rather than
+    # being numerically close) can be used.
+    Case = namedtuple('Case', ['f_obs', 'f_exp', 'ddof', 'axis',
+                                'expected_chi2'])
+    empty = np.array([[],[],[]])
+    data2da = np.array([[1, 4],
+                        [2, 8],
+                        [3, 12],
+                        [2, 8]])
+    data2db = np.array([[1, 2, 3, 2],
+                        [3, 2, 3, 0]])
+
+    # These cases use the default axis=0.
+    cases0 = [
+        # simple case, 1 data set:
+        Case(f_obs=[1,2,3,2], f_exp=None, ddof=0, axis=0,
+             expected_chi2=1.0),
+        # two simple data sets
+        Case(f_obs=data2da, f_exp=None, ddof=0, axis=0,
+             expected_chi2=[1.0, 4.0]),
+        # Edge case: one data set with length 0.
+        Case(f_obs=[], ddof=0, f_exp=None, axis=0, expected_chi2=0.0),
+        # Edge case: no data sets (data has shape (3,0)).
+        Case(f_obs=empty, f_exp=None, ddof=0, axis=0, expected_chi2=[]),
+        # Edge case: data has shape (0, 3) (3 data sets,
+        # but each has length 0).
+        Case(f_obs=empty.T, f_exp=None, ddof=0, axis=0,
+             expected_chi2=[0.0, 0.0, 0.0]),
+        # simple case, with scalar f_exp.
+        Case(f_obs=[1, 2, 3, 2], f_exp=2, ddof=0, axis=0,
+             expected_chi2=1.0),
+        # simple case with vector f_exp (uniform).
+        Case(f_obs=[1, 2, 3, 2], f_exp=[2, 2, 2, 2], ddof=0, axis=0,
+             expected_chi2=1.0),
+        # simple case with vector f_exp equal to f_obs.
+        Case(f_obs=[1, 2, 3, 2], f_exp=[1, 2, 3, 2], ddof=0, axis=0,
+             expected_chi2=0.0),
+        # 2-D data
+        Case(f_obs=data2db.T, f_exp=None, ddof=0, axis=0,
+             expected_chi2=[1.0, 3.0]),
+        Case(f_obs=data2db.T, f_exp=None, ddof=1, axis=0,
+             expected_chi2=[1.0, 3.0]),
+        # 2-D data, 1-D ddof
+        Case(f_obs=data2db.T, f_exp=None, ddof=[0,1], axis=0,
+             expected_chi2=[1.0, 3.0]),
+    ]
+    # All the cases in `cases0` have axis=0, which is the default value
+    # for the chisquare function.  Here we check each case twice, once
+    # in which the argument is not passed to chisquare (indicated by
+    # using the value 'no' in the call to check_chisquare), and again
+    # with the axis argument explicitly set to 0.
+    for case in cases0:
+        yield (check_chisquare, case.f_obs, case.f_exp, case.ddof, 'no',
+               case.expected_chi2)
+    for case in cases0:
+        yield (check_chisquare, case.f_obs, case.f_exp, case.ddof, 0,
+               case.expected_chi2)
+
+    # A few more cases, testing axis != 0 and basic broadcasting of
+    # f_obs and f_exp.
+    cases1 = [
+        Case(f_obs=data2da.T, f_exp=None, ddof=0, axis=1,
+             expected_chi2=[1.0, 4.0]),
+        Case(f_obs=data2db, f_exp=None, ddof=0, axis=None,
+             expected_chi2=[4.0]),
+        Case(f_obs=data2db.T, f_exp=None, ddof=0, axis=None,
+             expected_chi2=[4.0]),
+        Case(f_obs=[1,2,3,2], f_exp=[[2, 2, 3, 1],[2, 2, 2, 2]], ddof=0, axis=0,
+             expected_chi2=[1.5, 1.0]),
+    ]
+
+    for case in cases1:
+        yield (check_chisquare, case.f_obs, case.f_exp, case.ddof, case.axis,
+               case.expected_chi2)
+
+
+def test_chisquare_ddof_broadcasting():
+    # Test that ddof broadcasts correctly.
+
+    # obs has shape (4, 2).  We'll use the default axis=0, so chi2
+    # will have shape (2,).
+    obs = np.array([[1, 2, 3, 2], [3, 2, 2, 5]]).T
+
+    # ddof has shape (2, 1).  This is broadcast with chi2, so p will
+    # have shape (2,2).
+    ddof = np.array([[0], [1]])
+
+    chi2, p = stats.chisquare(obs, ddof=ddof)
+    assert_array_equal(chi2, [1.0, 2.0])
+
+    chi20, p0 = stats.chisquare(obs, ddof=ddof[0,0])
+    assert_array_equal(chi20, [1.0, 2.0])
+
+    chi21, p1 = stats.chisquare(obs, ddof=ddof[1,0])
+    assert_array_equal(chi21, [1.0, 2.0])
+    assert_array_equal(p, np.vstack((p0, p1)))
 
 
 def test_friedmanchisquare():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1455,9 +1455,11 @@ def check_chisquare(f_obs, f_exp, ddof, axis, expected_chi2):
         num_obs = f_obs.size
     else:
         if axis == 'no':
-            num_obs = f_obs.shape[0]
+            use_axis = 0
         else:
-            num_obs = f_obs.shape[axis]
+            use_axis = axis
+        b = np.broadcast(f_obs, f_exp)
+        num_obs = b.shape[use_axis]
 
     if axis == 'no':
         chi2, p = stats.chisquare(f_obs, f_exp=f_exp, ddof=ddof)
@@ -1539,7 +1541,7 @@ def test_chisquare():
              expected_chi2=[4.0]),
         Case(f_obs=data2db.T, f_exp=None, ddof=0, axis=None,
              expected_chi2=[4.0]),
-        Case(f_obs=[1,2,3,2], f_exp=[[2, 2, 3, 1],[2, 2, 2, 2]], ddof=0, axis=0,
+        Case(f_obs=[1,2,3,2], f_exp=[[2, 2, 3, 1],[2, 2, 2, 2]], ddof=0, axis=1,
              expected_chi2=[1.5, 1.0]),
     ]
 


### PR DESCRIPTION
- Add the `axis` argument to stats.chisquare and stats.mstats.chisquare.
- Add the `ddof` argument to stats.mstats.chisquare.

Closes gh-2108 (trac #1583).

The changes should be backwards compatible.

_EDIT: The following comments refer to the initial version, and no longer apply:_

There is a change in behavior that I believe is a bug in the existing implementation.  Consider

```
>>> f_obs = np.array([12, 12, 24, 12])
>>> f_exp = np.array([[16, 16, 16, 12], [12, 12, 24, 12], [15, 15, 15, 15]])
```

In the call `chisquare(f_obs, f_exp)`, `f_obs` and `f_exp` are broadcast (which in this case results in an array with shape (3, 4)), and then a reduction operation computes the chi-squared statstic.  In the 0.12.0 implementation, the default is `axis=0`, which means the reduction that computes the chi-squared statistic operates on the wrong axis.  That is, in scipy 0.12.0 we get:

```
>>> chisquare(f_obs, f_exp)
(array([ 1.6,  1.6,  9.4,  0.6]), array([ 0.65938982,  0.65938982,  0.02441934,  0.89643237]))
```

Note that the arrays have shape (4,).  That is not the intended result.

The code in the pull request handles this case correctly:

```
>>> chisquare(f_obs, f_exp)
(array([ 6. ,  0. ,  7.2]), array([ 0.11161023,  1.        ,  0.06578905]))
```
