### PR TITLE
MAINT: hide the scipy.linalg.expm2 and expm3 functions

### DIFF
--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -80,9 +80,7 @@ Matrix Functions
 .. autosummary::
    :toctree: generated/
 
-   expm - Matrix exponential using Pade approximation
-   expm2 - Matrix exponential using eigenvalue decomposition
-   expm3 - Matrix exponential using Taylor-series expansion
+   expm - Matrix exponential using Pade approximation with squaring and scaling
    logm - Matrix logarithm
    cosm - Matrix cosine
    sinm - Matrix sine

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -4,7 +4,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-__all__ = ['expm','expm2','expm3','cosm','sinm','tanm','coshm','sinhm',
+__all__ = ['expm','cosm','sinm','tanm','coshm','sinhm',
            'tanhm','logm','funm','signm','sqrtm',
            'expm_frechet']
 

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -17,7 +17,8 @@ from numpy.testing import (TestCase, run_module_suite,
         assert_allclose, decorators)
 
 import scipy.linalg
-from scipy.linalg import signm, logm, sqrtm, expm, expm2, expm3, expm_frechet
+from scipy.linalg import signm, logm, sqrtm, expm, expm_frechet
+from scipy.linalg.matfuncs import expm2, expm3
 import scipy.linalg._expm_frechet
 
 


### PR DESCRIPTION
The expm2 and expm3 functions are not practical alternatives to expm except for testing, so I've made them harder to use accidentally, and reduced the amount of name space pollution.  See the discussion here:
https://github.com/scipy/scipy/pull/2441#issuecomment-17557830
