### PR TITLE
ENH: update expm from 2005 to 2009

### DIFF
--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -81,6 +81,8 @@ Matrix Functions
    :toctree: generated/
 
    expm - Matrix exponential using Pade approximation with scaling and squaring
+   expm2 - Matrix exponential using eigenvalue decomposition
+   expm3 - Matrix exponential using Taylor-series expansion
    logm - Matrix logarithm
    cosm - Matrix cosine
    sinm - Matrix sine

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -80,9 +80,7 @@ Matrix Functions
 .. autosummary::
    :toctree: generated/
 
-   expm - Matrix exponential using Pade approximation
-   expm2 - Matrix exponential using eigenvalue decomposition
-   expm3 - Matrix exponential using Taylor-series expansion
+   expm - Matrix exponential using Pade approximation with scaling and squaring
    logm - Matrix logarithm
    cosm - Matrix cosine
    sinm - Matrix sine

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -390,21 +390,14 @@ def logm(A, disp=True):
     """
     # Compute using general funm but then use better error estimator and
     #   make one step in improving estimate using a rotation matrix.
-    #
-    # XXX Using expm_2005 for bug-compatibility with the funm/expm_2005 tests.
-    # XXX In its current form, this function (funm) will sometimes return
-    # XXX a float64 numpy.matrix and sometimes return a float32 ndarray
-    # XXX when a float32 ndarray is provided as input.
-    # XXX This behavior should be changed sometime in the future.
-    #
-    from scipy.sparse.linalg.matfuncs import expm_2005
+    from scipy.sparse.linalg.matfuncs import expm
     A = mat(asarray(A))
     F, errest = funm(A,log,disp=0)
     errtol = 1000*eps
     # Only iterate if estimate of error is too large.
     if errest >= errtol:
         # Use better approximation of error
-        errest = norm(expm_2005(F)-A,1) / norm(A,1)
+        errest = norm(expm(F)-A,1) / norm(A,1)
         if not isfinite(errest) or errest >= errtol:
             N,N = A.shape
             X,Y = ogrid[1:N+1,1:N+1]
@@ -413,10 +406,10 @@ def logm(A, disp=True):
             F = R.H*F*R
             if (norm(imag(F),1) <= 1000*errtol*norm(F,1)):
                 F = mat(real(F))
-            E = mat(expm_2005(F))
+            E = mat(expm(F))
             temp = mat(solve(E.T,(E-A).T))
             F = F - temp.T
-            errest = norm(expm_2005(F)-A,1) / norm(A,1)
+            errest = norm(expm(F)-A,1) / norm(A,1)
     if disp:
         if not isfinite(errest) or errest >= errtol:
             print("Result may be inaccurate, approximate err =", errest)

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -390,13 +390,21 @@ def logm(A, disp=True):
     """
     # Compute using general funm but then use better error estimator and
     #   make one step in improving estimate using a rotation matrix.
+    #
+    # XXX Using expm_2005 for bug-compatibility with the funm/expm_2005 tests.
+    # XXX In its current form, this function (funm) will sometimes return
+    # XXX a float64 numpy.matrix and sometimes return a float32 ndarray
+    # XXX when a float32 ndarray is provided as input.
+    # XXX This behavior should be changed sometime in the future.
+    #
+    from scipy.sparse.linalg.matfuncs import expm_2005
     A = mat(asarray(A))
     F, errest = funm(A,log,disp=0)
     errtol = 1000*eps
     # Only iterate if estimate of error is too large.
     if errest >= errtol:
         # Use better approximation of error
-        errest = norm(expm(F)-A,1) / norm(A,1)
+        errest = norm(expm_2005(F)-A,1) / norm(A,1)
         if not isfinite(errest) or errest >= errtol:
             N,N = A.shape
             X,Y = ogrid[1:N+1,1:N+1]
@@ -405,10 +413,10 @@ def logm(A, disp=True):
             F = R.H*F*R
             if (norm(imag(F),1) <= 1000*errtol*norm(F,1)):
                 F = mat(real(F))
-            E = mat(expm(F))
+            E = mat(expm_2005(F))
             temp = mat(solve(E.T,(E-A).T))
             F = F - temp.T
-            errest = norm(expm(F)-A,1) / norm(A,1)
+            errest = norm(expm_2005(F)-A,1) / norm(A,1)
     if disp:
         if not isfinite(errest) or errest >= errtol:
             print("Result may be inaccurate, approximate err =", errest)

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -4,7 +4,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-__all__ = ['expm','cosm','sinm','tanm','coshm','sinhm',
+__all__ = ['expm','expm2','expm3','cosm','sinm','tanm','coshm','sinhm',
            'tanhm','logm','funm','signm','sqrtm',
            'expm_frechet']
 

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -4,7 +4,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-__all__ = ['expm','expm2','expm3','cosm','sinm','tanm','coshm','sinhm',
+__all__ = ['expm','cosm','sinm','tanm','coshm','sinhm',
            'tanhm','logm','funm','signm','sqrtm',
            'expm_frechet']
 

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -17,7 +17,7 @@ from numpy.testing import (TestCase, run_module_suite,
         assert_allclose, decorators)
 
 import scipy.linalg
-from scipy.linalg import signm, logm, sqrtm, expm, expm_frechet
+from scipy.linalg import signm, logm, sqrtm, expm_frechet
 from scipy.linalg.matfuncs import expm2, expm3
 import scipy.linalg._expm_frechet
 

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -17,7 +17,8 @@ from numpy.testing import (TestCase, run_module_suite,
         assert_allclose, decorators)
 
 import scipy.linalg
-from scipy.linalg import signm, logm, sqrtm, expm, expm2, expm3, expm_frechet
+from scipy.linalg import signm, logm, sqrtm, expm, expm_frechet
+from scipy.linalg.matfuncs import expm2, expm3
 import scipy.linalg._expm_frechet
 
 

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -17,7 +17,7 @@ from numpy.testing import (TestCase, run_module_suite,
         assert_allclose, decorators)
 
 import scipy.linalg
-from scipy.linalg import signm, logm, sqrtm, expm_frechet
+from scipy.linalg import signm, logm, sqrtm, expm, expm_frechet
 from scipy.linalg.matfuncs import expm2, expm3
 import scipy.linalg._expm_frechet
 

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -59,6 +59,7 @@ def inv(A):
     return Ainv
 
 
+
 def expm_2005(A):
     """
     Compute the matrix exponential using Pade approximation.
@@ -635,6 +636,5 @@ def _pade13(A, ident, A2=None, A4=None, A6=None):
     V = A6.dot(b[12]*A6 + b[10]*A4 + b[8]*A2) + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
     return U,V
 
-# define the default expm function
+# Define the default expm.
 expm = expm_2009
-

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -23,6 +23,8 @@ from scipy.sparse.base import isspmatrix
 from scipy.sparse.construct import eye as speye
 from scipy.sparse.linalg import spsolve
 
+import scipy.sparse
+import scipy.sparse.linalg
 from scipy.sparse.linalg.interface import LinearOperator
 
 

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -12,10 +12,13 @@ from __future__ import division, print_function, absolute_import
 
 __all__ = ['expm', 'inv']
 
+import math
+
 from numpy import asarray, dot, eye, ceil, log2
 from numpy import matrix as mat
 import numpy as np
 
+import scipy.misc
 from scipy.linalg.misc import norm
 from scipy.linalg.basic import solve, inv
 

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -23,6 +23,8 @@ from scipy.sparse.base import isspmatrix
 from scipy.sparse.construct import eye as speye
 from scipy.sparse.linalg import spsolve
 
+from scipy.sparse.linalg.interface import LinearOperator
+
 
 def inv(A):
     """
@@ -52,7 +54,7 @@ def inv(A):
     return Ainv
 
 
-def expm(A):
+def expm_2005(A):
     """
     Compute the matrix exponential using Pade approximation.
 
@@ -133,52 +135,501 @@ def expm(A):
 # ident is the identity matrix, which matches A in being sparse or dense.
 
 
-def _pade3(A, ident):
-    b = (120., 60., 12., 1.)
+def _exact_1_norm(A):
+    # A compatibility function which should eventually disappear.
+    # This is copypasted from expm_action.
+    if scipy.sparse.isspmatrix(A):
+        return max(abs(A).sum(axis=0).flat)
+    else:
+        return np.linalg.norm(A, 1)
+
+def _ident_like(A):
+    # A compatibility function which should eventually disappear.
+    # This is copypasted from expm_action.
+    if scipy.sparse.isspmatrix(A):
+        return scipy.sparse.construct.eye(A.shape[0], A.shape[1],
+                dtype=A.dtype, format=A.format)
+    else:
+        return np.eye(A.shape[0], A.shape[1], dtype=A.dtype)
+
+def _count_nonzero(A):
+    # A compatibility function which should eventually disappear.
+    #XXX There should be a better way to do this when A is sparse
+    #XXX in the traditional sense.
+    if isspmatrix(A):
+        return np.count_nonzero(A.toarray())
+    else:
+        return np.count_nonzero(A)
+
+def _is_upper_triangular(A):
+    # This function could possibly be of wider interest.
+    if isspmatrix(A):
+        lower_part = scipy.sparse.tril(A, -1)
+        if lower_part.nnz == 0:
+            # structural upper triangularity
+            return True
+        else:
+            # coincidental upper triangularity
+            return _count_nonzero(lower_part) == 0
+    else:
+        return _count_nonzero(np.tril(A, -1)) == 0
+
+
+class MatrixPowerOperator(LinearOperator):
+
+    def __init__(self, A, p):
+        if A.ndim != 2 or A.shape[0] != A.shape[1]:
+            raise ValueError('expected A to be like a square matrix')
+        if p < 0:
+            raise ValueError('expected p to be a non-negative integer')
+        self._A = A
+        self._p = p
+        self.ndim = A.ndim
+        self.shape = A.shape
+
+    def matvec(self, x):
+        for i in range(self._p):
+            x = self._A.dot(x)
+        return x
+
+    def rmatvec(self, x):
+        for i in range(self._p):
+            x = x.dot(self._A)
+        return x
+
+    def matmat(self, X):
+        for i in range(self._p):
+            X = self._A.dot(X)
+        return X
+    
+    @property
+    def T(self):
+        return MatrixPowerOperator(self._A.T, self._p)
+
+
+class ProductOperator(LinearOperator):
+    """
+    For now, this is limited to products of multiple square matrices.
+    """
+
+    def __init__(self, *args):
+        for A in args:
+            if len(A.shape) != 2 or A.shape[0] != A.shape[1]:
+                raise ValueError(
+                        'For now, the ProductOperator implementation is '
+                        'limited to the product of multiple square matrices.')
+        if args:
+            n = args[0].shape[0]
+            for A in args:
+                for d in A.shape:
+                    if d != n:
+                        raise ValueError(
+                                'The square matrices of the ProductOperator '
+                                'must all have the same shape.')
+            self.shape = (n, n)
+            self.ndim = len(self.shape)
+        self._operator_sequence = args
+
+    def matvec(self, x):
+        for A in reversed(self._operator_sequence):
+            x = A.dot(x)
+        return x
+
+    def rmatvec(self, x):
+        for A in self._operator_sequence:
+            x = x.dot(A)
+        return x
+
+    def matmat(self, X):
+        for A in reversed(self._operator_sequence):
+            X = A.dot(X)
+        return X
+    
+    @property
+    def T(self):
+        T_args = [A.T for A in reversed(self._operator_sequence)]
+        return ProductOperator(*T_args)
+
+
+def _onenormest_matrix_power(A, p,
+        t=2, itmax=5, compute_v=False, compute_w=False):
+    """
+    Efficiently estimate the 1-norm of A^p.
+
+    Parameters
+    ----------
+    A : ndarray
+        Matrix whose 1-norm of a power is to be computed.
+    p : int
+        Non-negative integer power.
+    t : int, optional
+        A positive parameter controlling the tradeoff between
+        accuracy versus time and memory usage.
+        Larger values take longer and use more memory
+        but give more accurate output.
+    itmax : int, optional
+        Use at most this many iterations.
+    compute_v : bool, optional
+        Request a norm-maximizing linear operator input vector if True.
+    compute_w : bool, optional
+        Request a norm-maximizing linear operator output vector if True.
+
+    Returns
+    -------
+    est : float
+        An underestimate of the 1-norm of the sparse matrix.
+    v : ndarray, optional
+        The vector such that ||Av||_1 == est*||v||_1.
+        It can be thought of as an input to the linear operator
+        that gives an output with particularly large norm.
+    w : ndarray, optional
+        The vector Av which has relatively large 1-norm.
+        It can be thought of as an output of the linear operator
+        that is relatively large in norm compared to the input.
+
+    """
+    #XXX Eventually turn this into an API function in the _onenormest module,
+    #XXX and remove its underscore,
+    #XXX but wait until expm_action and expm_2009 go into scipy.
+    return scipy.sparse.linalg.onenormest(MatrixPowerOperator(A, p))
+
+
+def _onenormest_product(operator_seq,
+        t=2, itmax=5, compute_v=False, compute_w=False):
+    """
+    Efficiently estimate the 1-norm of the matrix product of the args.
+
+    Parameters
+    ----------
+    operator_seq : linear operator sequence
+        Matrices whose 1-norm of product is to be computed.
+    t : int, optional
+        A positive parameter controlling the tradeoff between
+        accuracy versus time and memory usage.
+        Larger values take longer and use more memory
+        but give more accurate output.
+    itmax : int, optional
+        Use at most this many iterations.
+    compute_v : bool, optional
+        Request a norm-maximizing linear operator input vector if True.
+    compute_w : bool, optional
+        Request a norm-maximizing linear operator output vector if True.
+
+    Returns
+    -------
+    est : float
+        An underestimate of the 1-norm of the sparse matrix.
+    v : ndarray, optional
+        The vector such that ||Av||_1 == est*||v||_1.
+        It can be thought of as an input to the linear operator
+        that gives an output with particularly large norm.
+    w : ndarray, optional
+        The vector Av which has relatively large 1-norm.
+        It can be thought of as an output of the linear operator
+        that is relatively large in norm compared to the input.
+
+    """
+    #XXX Eventually turn this into an API function in the _onenormest module,
+    #XXX and remove its underscore,
+    #XXX but wait until expm_2009 goes into scipy.
+    return scipy.sparse.linalg.onenormest(ProductOperator(*operator_seq))
+
+
+
+def expm_2009(A):
+    """
+    Compute the matrix exponential using Pade approximation.
+
+    Parameters
+    ----------
+    A : (M,M) array or sparse matrix
+        2D Array or Matrix (sparse or dense) to be exponentiated
+
+    Returns
+    -------
+    expA : (M,M) ndarray
+        Matrix exponential of `A`
+
+    Notes
+    -----
+    This is algorithm (6.1) which is a simplification of algorithm (5.1).
+
+    References
+    ----------
+    .. [1] Awad H. Al-Mohy and Nicholas J. Higham (2009)
+           "A New Scaling and Squaring Algorithm for th Matrix Exponential."
+           SIAM Journal on Matrix Analysis and Applications.
+           31 (3). pp. 970-989. ISSN 1095-7162
+
+    """
+
+    # Define the identity matrix depending on sparsity.
+    ident = _ident_like(A)
+
+    # Try Pade order 3.
     A2 = A.dot(A)
+    d6 = _onenormest_matrix_power(A2, 3)**(1/6.)
+    eta_1 = max(_onenormest_matrix_power(A2, 2) **(1/4.), d6)
+    if eta_1 < 1.495585217958292e-002 and _ell(A, 3) == 0:
+        U, V = _pade3(A, ident, A2)
+        return _solve_P_Q(U, V)
+
+    # Try Pade order 5.
+    A4 = A2.dot(A2)
+    d4 = _exact_1_norm(A4)**(1/4.)
+    eta_2 = max(d4, d6)
+    if eta_2 < 2.539398330063230e-001 and _ell(A, 5) == 0:
+        U, V = _pade5(A, ident, A2, A4)
+        return _solve_P_Q(U, V)
+
+    # Try Pade orders 7 and 9.
+    A6 = A2.dot(A4)
+    d6 = _exact_1_norm(A6)**(1/6.)
+    d8 = _onenormest_matrix_power(A4, 2)**(1/8.)
+    eta_3 = max(d6, d8)
+    if eta_3 < 9.504178996162932e-001 and _ell(A, 7) == 0:
+        U, V = _pade7(A, ident, A2, A4, A6)
+        return _solve_P_Q(U, V)
+    if eta_3 < 2.097847961257068e+000 and _ell(A, 9) == 0:
+        U, V = _pade9(A, ident, A2, A4, A6)
+        return _solve_P_Q(U, V)
+
+    # Use Pade order 13.
+    d10 = _onenormest_product((A4, A6))**(1/10.)
+    eta_4 = max(d8, d10)
+    eta_5 = min(eta_3, eta_4)
+    theta_13 = 4.25
+    s = max(int(np.ceil(np.log2(eta_5 / theta_13))), 0)
+    s = s + _ell(2**-s * A, 13)
+    B = A * 2**-s
+    B2 = A2 * 2**(-2*s)
+    B4 = A4 * 2**(-4*s)
+    B6 = A6 * 2**(-6*s)
+    U, V = _pade13(B, ident, B2, B4, B6)
+    X = _solve_P_Q(U, V)
+    if _is_upper_triangular(A):
+        # Invoke Code Fragment 2.1.
+        X = _fragment_2_1(X, A, s)
+    else:
+        # X = r_13(A)^(2^s) by repeated squaring.
+        for i in range(s):
+            X = X.dot(X)
+    return X
+
+
+def _solve_P_Q(U, V):
+    """
+    A helper function for expm_2009.
+    """
+    P = U + V
+    Q = -U + V
+    if isspmatrix(U):
+        R = spsolve(Q, P)
+    else:
+        R = solve(Q, P)
+    return R
+
+
+def _sinch(x):
+    """
+    Stably evaluate sinch.
+
+    Notes
+    -----
+    The strategy of falling back to a sixth order Taylor expansion
+    was suggested by the Spallation Neutron Source docs
+    which was found on the internet by google search.
+    http://www.ornl.gov/~t6p/resources/xal/javadoc/gov/sns/tools/math/ElementaryFunction.html
+    The details of the cutoff point and the Horner-like evaluation
+    was picked without reference to anything in particular.
+
+    Note that sinch is not currently implemented in scipy.special,
+    whereas the "engineer's" definition of sinc is implemented.
+    The implementation of sinc involves a scaling factor of pi
+    that distinguishes it from the "mathematician's" version of sinc.
+
+    """
+
+    # If x is small then use sixth order Taylor expansion.
+    # How small is small? I am using the point where the relative error
+    # of the approximation is less than 1e-14.
+    # If x is large then directly evaluate sinh(x) / x.
+    x2 = x*x
+    if abs(x) < 0.0135:
+        return 1 + (x2/6.)*(1 + (x2/20.)*(1 + (x2/42.)))
+    else:
+        return np.sinh(x) / x
+
+
+def _eq_10_42(lam_1, lam_2, t_12):
+    """
+    Equation (10.42) of Functions of Matrices: Theory and Computation.
+
+    Notes
+    -----
+    This is a helper function for _fragment_2_1 of expm_2009.
+    Equation (10.42) is on page 251 in the section on Schur algorithms.
+    In particular, section 10.4.3 explains the Schur-Parlett algorithm.
+    expm([[lam_1, t_12], [0, lam_1])
+    =
+    [[exp(lam_1), t_12*exp((lam_1 + lam_2)/2)*sinch((lam_1 - lam_2)/2)],
+    [0, exp(lam_2)]
+    """
+
+    # The plain formula t_12 * (exp(lam_2) - exp(lam_2)) / (lam_2 - lam_1)
+    # apparently suffers from cancellation, according to Higham's textbook.
+    # A nice implementation of sinch, defined as sinh(x)/x,
+    # will apparently work around the cancellation.
+    a = 0.5 * (lam_1 + lam_2)
+    b = 0.5 * (lam_1 - lam_2)
+    return t_12 * np.exp(a) * _sinch(b)
+
+
+def _fragment_2_1(X, T, s):
+    """
+    A helper function for expm_2009.
+    Note that X is modified in-place,
+    but this modification is not the same as the returned value of the function.
+    """
+    # Form X = r_m(2^-s T)
+    # Replace diag(X) by exp(2^-s diag(T)).
+    n = X.shape[0]
+    diag_T = T.diagonal().copy()
+
+    # XXX Can this chunk be vectorized?
+    scale = 2 ** -s
+    exp_diag = np.exp(scale * diag_T)
+    for k in range(n):
+        X[k, k] = exp_diag[k]
+
+    for i in range(s-1, -1, -1):
+        scale = 2 ** -i
+        X = X.dot(X)
+
+        # Replace diag(X) by exp(2^-i diag(T)).
+        # XXX Can this chunk be vectorized?
+        exp_diag = np.exp(scale * diag_T)
+        for k in range(n):
+            X[k, k] = exp_diag[k]
+
+        # Replace (first) superdiagonal of X by explicit formula
+        # for superdiagonal of exp(2^-i T) from Eq (10.42) of 
+        # the author's 2008 textbook
+        # Functions of Matrices: Theory and Computation.
+        # XXX Can this chunk be vectorized?
+        for k in range(n-1):
+            lam_1 = scale * diag_T[k]
+            lam_2 = scale * diag_T[k+1]
+            t_12 = scale * T[k, k+1]
+            value = _eq_10_42(lam_1, lam_2, t_12)
+            X[k, k+1] = value
+
+    # Return the updated X matrix.
+    return X
+
+
+def _ell(A, m):
+    """
+    A helper function for expm_2009.
+
+    Parameters
+    ----------
+    A : linear operator
+        A linear operator whose norm of power we care about.
+    m : int
+        The power of the linear operator
+
+    Returns
+    -------
+    value : int
+        A value related to a bound.
+
+    """
+    p = 2*m + 1
+
+    # The c_i are explained in (2.2) and (2.6) of the 2005 expm paper.
+    # They are coefficients of terms of a generating function series expansion.
+    abs_c_recip = scipy.misc.comb(2*p, p, exact=True) * math.factorial(2*p + 1)
+
+    # This is explained after Eq. (1.2) of the 2009 expm paper.
+    # It is the "unit roundoff" of IEEE double precision arithmetic.
+    u = 2**-53
+
+    # Estimate the 1-norm of the matrix power.
+    est = _onenormest_matrix_power(abs(A), p)
+
+    # Treat zero norm as a special case.
+    if not est:
+        return 0
+
+    alpha = est / (_exact_1_norm(A) * abs_c_recip)
+    log2_alpha_div_u = np.log2(alpha/u)
+    value = int(np.ceil(log2_alpha_div_u / (2 * m)))
+    return max(value, 0)
+
+
+# Implementation of Pade approximations of various degree
+# using the algorithm presented in [Higham 2005].
+# These should apply to both dense and sparse matricies.
+# ident is the identity matrix, which matches A in being sparse or dense.
+def _pade3(A, ident, A2=None):
+    b = (120., 60., 12., 1.)
+    if A2 is None:
+        A2 = A.dot(A)
     U = A.dot(b[3]*A2 + b[1]*ident)
     V = b[2]*A2 + b[0]*ident
     return U,V
 
-
-def _pade5(A, ident):
+def _pade5(A, ident, A2=None, A4=None):
     b = (30240., 15120., 3360., 420., 30., 1.)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
+    if A2 is None:
+        A2 = A.dot(A)
+    if A4 is None:
+        A4 = A2.dot(A2)
     U = A.dot(b[5]*A4 + b[3]*A2 + b[1]*ident)
     V = b[4]*A4 + b[2]*A2 + b[0]*ident
     return U,V
 
-
-def _pade7(A, ident):
+def _pade7(A, ident, A2=None, A4=None, A6=None):
     b = (17297280., 8648640., 1995840., 277200., 25200., 1512., 56., 1.)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
-    A6 = A4.dot(A2)
+    if A2 is None:
+        A2 = A.dot(A)
+    if A4 is None:
+        A4 = A2.dot(A2)
+    if A6 is None:
+        A6 = A4.dot(A2)
     U = A.dot(b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
     V = b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
     return U,V
 
-
-def _pade9(A, ident):
+def _pade9(A, ident, A2=None, A4=None, A6=None):
     b = (17643225600., 8821612800., 2075673600., 302702400., 30270240.,
                 2162160., 110880., 3960., 90., 1.)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
-    A6 = A4.dot(A2)
+    if A2 is None:
+        A2 = A.dot(A)
+    if A4 is None:
+        A4 = A2.dot(A2)
+    if A6 is None:
+        A6 = A4.dot(A2)
     A8 = A6.dot(A2)
     U = A.dot(b[9]*A8 + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
     V = b[8]*A8 + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
     return U,V
 
-
-def _pade13(A, ident):
+def _pade13(A, ident, A2=None, A4=None, A6=None):
     b = (64764752532480000., 32382376266240000., 7771770303897600.,
     1187353796428800., 129060195264000., 10559470521600., 670442572800.,
     33522128640., 1323241920., 40840800., 960960., 16380., 182., 1.)
-    A2 = A.dot(A)
-    A4 = A2.dot(A2)
-    A6 = A4.dot(A2)
+    if A2 is None:
+        A2 = A.dot(A)
+    if A4 is None:
+        A4 = A2.dot(A2)
+    if A6 is None:
+        A6 = A4.dot(A2)
     U = A.dot(A6.dot(b[13]*A6 + b[11]*A4 + b[9]*A2) + b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
     V = A6.dot(b[12]*A6 + b[10]*A4 + b[8]*A2) + b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
     return U,V
+
+# define the default expm function
+expm = expm_2005
+

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -636,5 +636,5 @@ def _pade13(A, ident, A2=None, A4=None, A6=None):
     return U,V
 
 # define the default expm function
-expm = expm_2005
+expm = expm_2009
 

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -88,13 +88,8 @@ class TestExpM(TestCase):
                 assert_array_almost_equal_nulp(expm(a).toarray(), e, nulp=100)
 
     def test_logm_consistency(self):
-        #XXX This does not test precisions like you think it does.
-        #XXX Sometimes logm returns a high precision matrix
-        #XXX even when its input matrix is low precision.
-        #XXX Therefore the subsequent expm is high precision,
-        #XXX even within a test that is supposed to test low precision expm.
         random.seed(1234)
-        for dtype in [np.float32, np.float64, np.complex64, np.complex128]:
+        for dtype in [np.float64, np.complex128]:
             for n in range(1, 10):
                 for scale in [1e-4, 1e-3, 1e-2, 1e-1, 1, 1e1, 1e2]:
                     # make logm(A) be of a given scale
@@ -103,6 +98,7 @@ class TestExpM(TestCase):
                         A = A + 1j * random.rand(n, n) * scale
                     for expm in (expm_2005, expm_2009):
                         assert_array_almost_equal(expm(logm(A)), A)
+
 
     def test_overscaling_example(self):
         # See the blog post

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -7,6 +7,8 @@
 """
 from __future__ import division, print_function, absolute_import
 
+import math
+
 import numpy as np
 from numpy import array, eye, dot, sqrt, double, exp, random
 from numpy.linalg import matrix_power
@@ -16,8 +18,9 @@ from numpy.testing import (TestCase, run_module_suite,
 
 from scipy.sparse import csc_matrix
 from scipy.sparse.construct import eye as speye
-from scipy.sparse.linalg.matfuncs import expm_2005, expm_2009
-from scipy.sparse.linalg.matfuncs import ProductOperator, MatrixPowerOperator
+from scipy.sparse.linalg.matfuncs import (expm_2005, expm_2009,
+        ProductOperator, MatrixPowerOperator,
+        _is_upper_triangular)
 from scipy.linalg import logm
 import scipy.sparse
 import scipy.sparse.linalg

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -9,51 +9,165 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy import array, eye, dot, sqrt, double, exp, random
-from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal, \
-     assert_array_almost_equal_nulp
+from numpy.linalg import matrix_power
+from numpy.testing import (TestCase, run_module_suite,
+        assert_allclose, assert_, assert_array_almost_equal,
+        assert_array_almost_equal_nulp)
 
 from scipy.sparse import csc_matrix
 from scipy.sparse.construct import eye as speye
-from scipy.sparse.linalg import expm
+from scipy.sparse.linalg.matfuncs import expm_2005, expm_2009
+from scipy.sparse.linalg.matfuncs import ProductOperator, MatrixPowerOperator
 from scipy.linalg import logm
+import scipy.sparse
+import scipy.sparse.linalg
 
 
 class TestExpM(TestCase):
     def test_zero(self):
         a = array([[0.,0],[0,0]])
-        assert_array_almost_equal(expm(a),[[1,0],[0,1]])
+        for expm in (expm_2005, expm_2009):
+            assert_array_almost_equal(expm(a),[[1,0],[0,1]])
 
     def test_zero_sparse(self):
         a = csc_matrix([[0.,0],[0,0]])
-        assert_array_almost_equal(expm(a).toarray(),[[1,0],[0,1]])
+        for expm in (expm_2005, expm_2009):
+            assert_array_almost_equal(expm(a).toarray(),[[1,0],[0,1]])
 
-    def test_padecases_dtype(self):
-        for dtype in [np.float32, np.float64, np.complex64, np.complex128]:
-            # test double-precision cases
-            for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
-                a = scale * eye(3, dtype=dtype)
-                e = exp(scale) * eye(3, dtype=dtype)
-                assert_array_almost_equal_nulp(expm(a), e, nulp=100)
+    def test_bidiagonal_sparse(self):
+        A = csc_matrix([
+            [1, 3, 0],
+            [0, 1, 5],
+            [0, 0, 2]], dtype=float)
+        e1 = math.exp(1)
+        e2 = math.exp(2)
+        expected = np.array([
+            [e1, 3*e1, 15*(e2 - 2*e1)],
+            [0, e1, 5*(e2 - e1)],
+            [0, 0, e2]], dtype=float)
+        for expm in (expm_2005, expm_2009):
+            observed = expm(A).toarray()
+            assert_array_almost_equal(observed, expected)
 
-    def test_padecases_dtype_sparse(self):
+    def test_padecases_dtype_float(self):
+        for expm in (expm_2005, expm_2009):
+            for dtype in [np.float32, np.float64]:
+                for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
+                    A = scale * eye(3, dtype=dtype)
+                    observed = expm(A)
+                    expected = exp(scale) * eye(3, dtype=dtype)
+                    assert_array_almost_equal_nulp(observed, expected, nulp=100)
+
+    def test_padecases_dtype_complex(self):
+        for expm in (expm_2005, expm_2009):
+            for dtype in [np.complex64, np.complex128]:
+                for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
+                    a = scale * eye(3, dtype=dtype)
+                    e = exp(scale) * eye(3, dtype=dtype)
+                    assert_array_almost_equal_nulp(expm(a), e, nulp=100)
+
+    def test_padecases_dtype_sparse_float(self):
         # float32 and complex64 lead to errors in spsolve/UMFpack
-        for dtype in [np.float64, np.complex128]:
-            # test double-precision cases
-            for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
-                a = scale * speye(3, 3, dtype=dtype, format='csc')
-                e = exp(scale) * eye(3, dtype=dtype)
+        dtype = np.float64
+        for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
+            a = scale * speye(3, 3, dtype=dtype, format='csc')
+            e = exp(scale) * eye(3, dtype=dtype)
+            for expm in (expm_2005, expm_2009):
+                assert_array_almost_equal_nulp(expm(a).toarray(), e, nulp=100)
+
+    def test_padecases_dtype_sparse_complex(self):
+        # float32 and complex64 lead to errors in spsolve/UMFpack
+        dtype = np.complex128
+        for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
+            a = scale * speye(3, 3, dtype=dtype, format='csc')
+            e = exp(scale) * eye(3, dtype=dtype)
+            for expm in (expm_2005, expm_2009):
                 assert_array_almost_equal_nulp(expm(a).toarray(), e, nulp=100)
 
     def test_logm_consistency(self):
+        #XXX This does not test precisions like you think it does.
+        #XXX Sometimes logm returns a high precision matrix
+        #XXX even when its input matrix is low precision.
+        #XXX Therefore the subsequent expm is high precision,
+        #XXX even within a test that is supposed to test low precision expm.
         random.seed(1234)
         for dtype in [np.float32, np.float64, np.complex64, np.complex128]:
             for n in range(1, 10):
                 for scale in [1e-4, 1e-3, 1e-2, 1e-1, 1, 1e1, 1e2]:
-                    # make logm(a) be of a given scale
-                    a = (eye(n) + random.rand(n, n) * scale).astype(dtype)
-                    if np.iscomplexobj(a):
-                        a = a + 1j * random.rand(n, n) * scale
-                    assert_array_almost_equal(expm(logm(a)), a)
+                    # make logm(A) be of a given scale
+                    A = (eye(n) + random.rand(n, n) * scale).astype(dtype)
+                    if np.iscomplexobj(A):
+                        A = A + 1j * random.rand(n, n) * scale
+                    for expm in (expm_2005, expm_2009):
+                        assert_array_almost_equal(expm(logm(A)), A)
+
+    def test_overscaling_example(self):
+        # See the blog post
+        # http://blogs.mathworks.com/cleve/2012/07/23/a-balancing-act-for-the-matrix-exponential/
+        a = 2e10
+        b = 4e8/6.
+        c = 200/3.
+        d = 3
+        e = 1e-8
+        A = np.array([[0,e,0],[-(a+b), -d, a], [c, 0, -c]])
+
+        # This answer is wrong, and it is caused by overscaling.
+        wrong_solution = np.array([
+            [1.7465684381715e+17, -923050477.783131, -1.73117355055901e+17],
+            [-3.07408665108297e+25, 1.62463553675545e+17, 3.04699053651329e+25],
+            [1.09189154376804e+17, -577057840.468934, -1.08226721572342e+17]])
+
+        # This is the correct answer.
+        correct_solution = np.array([
+            [0.446849468283175, 1.54044157383952e-09, 0.462811453558774],
+            [-5743067.77947947, -0.0152830038686819, -4526542.71278401],
+            [0.447722977849494, 1.54270484519591e-09, 0.463480648837651]])
+
+        # Assert that the Higham 2005 expm gives the wrong answer.
+        assert_allclose(expm_2005(A), wrong_solution)
+
+        # Assert that the Higham 2009 expm gives the correct answer.
+        assert_allclose(expm_2009(A), correct_solution)
+
+    def test_expm_2009_random_upper_triangular(self):
+        random.seed(1234)
+        n = 10
+        nsamples = 20
+        for i in range(nsamples):
+            A = np.triu(np.random.randn(n, n))
+            assert_(_is_upper_triangular(A))
+            assert_allclose(expm_2009(A), expm_2005(A))
+
+
+class TestOperators(TestCase):
+
+    def test_product_operator(self):
+        random.seed(1234)
+        n = 5
+        k = 2
+        nsamples = 10
+        for i in range(nsamples):
+            A = np.random.randn(n, n)
+            B = np.random.randn(n, n)
+            C = np.random.randn(n, n)
+            D = np.random.randn(n, k)
+            op = ProductOperator(A, B, C)
+            assert_allclose(op.matmat(D), A.dot(B).dot(C).dot(D))
+            assert_allclose(op.T.matmat(D), (A.dot(B).dot(C)).T.dot(D))
+
+    def test_matrix_power_operator(self):
+        random.seed(1234)
+        n = 5
+        k = 2
+        p = 3
+        nsamples = 10
+        for i in range(nsamples):
+            A = np.random.randn(n, n)
+            B = np.random.randn(n, k)
+            op = MatrixPowerOperator(A, p)
+            assert_allclose(op.matmat(B), matrix_power(A, p).dot(B))
+            assert_allclose(op.T.matmat(B), matrix_power(A, p).T.dot(B))
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Both versions use Pade approximations with scaling and squaring, following algorithms described in academic publications by Nick Higham and his lab.  The new 2009 version corrects an overscaling issue, passing all of the old expm unit tests, and passing an additional test that addresses this overscaling.

This PR would close https://github.com/scipy/scipy/issues/2216

It also replaces the default expm ~~, and it makes the expm2 and expm3 functions less visible~~ .  See the discussion here https://github.com/scipy/scipy/pull/2441#issuecomment-17557830

Here's a link to my previous attempt at this expm update, where my git development started going off-script https://github.com/scipy/scipy/pull/2441

Edit:
I'm not going to try to mess with expm2 or expm3; I'm not sure why I had thought it would be a good idea to combine that into this PR...
