### PR TITLE
BUG: special: scrub corner cases in zeta, exp1

### DIFF
--- a/scipy/special/cephes/zeta.c
+++ b/scipy/special/cephes/zeta.c
@@ -111,69 +111,51 @@ double x, q;
 	    goto domerr;	/* because q^-x not defined */
     }
 
-    /* Euler-Maclaurin summation formula */
-    /*
-     * if( x < 25.0 )
+    /* Asymptotic expansion
+     * http://dlmf.nist.gov/25.11#E43
      */
-    {
-	/* Permit negative q but continue sum until n+q > +9 .
-	 * This case should be handled by a reflection formula.
-	 * If q<0 and x is an integer, there is a relation to
-	 * the polyGamma function.
-	 */
-	s = pow(q, -x);
-	a = q;
-	i = 0;
-	b = 0.0;
-	while ((i < 9) || (a <= 9.0)) {
-	    i += 1;
-	    a += 1.0;
-	    b = pow(a, -x);
-	    s += b;
-	    if (fabs(b / s) < MACHEP)
-		goto done;
-	}
-
-	w = a;
-	s += b * w / (x - 1.0);
-	s -= 0.5 * b;
-	a = 1.0;
-	k = 0.0;
-	for (i = 0; i < 12; i++) {
-	    a *= x + k;
-	    b /= w;
-	    t = a * b / A[i];
-	    s = s + t;
-	    t = fabs(t / s);
-	    if (t < MACHEP)
-		goto done;
-	    k += 1.0;
-	    a *= x + k;
-	    b /= w;
-	    k += 1.0;
-	}
-      done:
-	return (s);
+    if (q > 1e8) {
+        return (1/(x - 1) + 1/(2*q)) * pow(q, 1 - x);
     }
 
-
-
-    /* Basic sum of inverse powers */
-    /*
-     * pseres:
-     * 
-     * s = pow( q, -x );
-     * a = q;
-     * do
-     * {
-     * a += 2.0;
-     * b = pow( a, -x );
-     * s += b;
-     * }
-     * while( b/s > MACHEP );
-     * 
-     * b = pow( 2.0, -x );
-     * s = (s + b)/(1.0-b);
-     * return(s);
+    /* Euler-Maclaurin summation formula */
+    
+    /* Permit negative q but continue sum until n+q > +9 .
+     * This case should be handled by a reflection formula.
+     * If q<0 and x is an integer, there is a relation to
+     * the polyGamma function.
      */
+    s = pow(q, -x);
+    a = q;
+    i = 0;
+    b = 0.0;
+    while ((i < 9) || (a <= 9.0)) {
+        i += 1;
+        a += 1.0;
+        b = pow(a, -x);
+        s += b;
+        if (fabs(b / s) < MACHEP)
+            goto done;
+    }
+    
+    w = a;
+    s += b * w / (x - 1.0);
+    s -= 0.5 * b;
+    a = 1.0;
+    k = 0.0;
+    for (i = 0; i < 12; i++) {
+        a *= x + k;
+        b /= w;
+        t = a * b / A[i];
+        s = s + t;
+        t = fabs(t / s);
+        if (t < MACHEP)
+            goto done;
+        k += 1.0;
+        a *= x + k;
+        b /= w;
+        k += 1.0;
+    }
+done:
+    return (s);
 }

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -5578,9 +5578,20 @@ C       Output:  EI --- Ei(x)
 C       ============================================
 C
         IMPLICIT NONE
-        DOUBLE COMPLEX Z, CEI
+        DOUBLE COMPLEX Z, CEI, IMF
+        DOUBLE PRECISION PI
+        PI=3.141592653589793D0
         CALL E1Z(-Z, CEI)
-        CEI = -CEI + (CDLOG(Z) - CDLOG(1D0/Z))/2D0 - CDLOG(-Z)
+        CEI = -CEI
+        IF (DIMAG(Z).GT.0) THEN
+           CEI = CEI + (0d0,1d0)*PI
+        ELSE IF (DIMAG(Z).LT.0) THEN
+           CEI = CEI - (0d0,1d0)*PI
+        ELSE IF (DIMAG(Z).EQ.0) THEN
+           IF (DBLE(Z).GT.0) THEN
+              CEI = CEI - (0d0,1d0)*PI
+           ENDIF
+        ENDIF
         RETURN
         END
 
@@ -9181,7 +9192,13 @@ C
               CE1=CE1+CR
               IF (CDABS(CR).LE.CDABS(CE1)*1.0D-15) GO TO 15
 10         CONTINUE
-15         CE1=-EL-CDLOG(Z)+Z*CE1
+15         CONTINUE
+           IF (X.LE.0.0.AND.DIMAG(Z).EQ.0.0) THEN
+C             Careful on the branch cut -- avoid signed zeros
+              CE1=-EL-CDLOG(-Z)+Z*CE1-PI*(0.0D0,1.0D0)
+           ELSE
+              CE1=-EL-CDLOG(Z)+Z*CE1
+           ENDIF
         ELSE
            CT0=(0.0D0,0.0D0)
            DO 20 K=120,1,-1

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -902,11 +902,11 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             mpmath.ci,
                             [Arg()])
 
-    @knownfailure_overridable("Bad relative accuracy <eps-close to the pole at z=0")
     def test_digamma(self):
         assert_mpmath_equal(sc.digamma,
                             _exception_to_nan(mpmath.digamma),
-                            [Arg()])
+                            [Arg()],
+                            dps=50)
 
     @knownfailure_overridable()
     def test_digamma_complex(self):

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1376,9 +1376,8 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             [Arg(-1e30, 1e30), Arg()],
                             n=2000)
 
-    @knownfailure_overridable("accuracy problems at extremely large arguments (absolute tolerance OK, relative not)")
     def test_zeta(self):
         assert_mpmath_equal(sc.zeta,
                             _exception_to_nan(mpmath.zeta),
-                            [Arg(a=1, inclusive_a=False),
-                             Arg(a=0, inclusive_a=False)], n=1000)
+                            [Arg(a=1, b=1e10, inclusive_a=False),
+                             Arg(a=0, inclusive_a=False)])

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -931,7 +931,6 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             mpmath.ei,
                             [Arg()])
 
-    @knownfailure_overridable("picks the wrong branch of logarithm at real axis (Trac #1442)")
     def test_ei_complex(self):
         assert_mpmath_equal(sc.expi,
                             mpmath.ei,

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -920,21 +920,36 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             mpmath.e1,
                             [Arg()])
 
-    @knownfailure_overridable("issues at very large arguments near imaginary axis (absolute tolerance OK, relative tolerance not)")
     def test_e1_complex(self):
         assert_mpmath_equal(sc.exp1,
                             mpmath.e1,
-                            [ComplexArg()])
+                            [ComplexArg()],
+                            rtol=1e-11)
+
+        # Check cross-over reqion
+        assert_mpmath_equal(sc.exp1,
+                            mpmath.e1,
+                            (np.linspace(-50, 50, 171)[:,None] 
+                             + np.r_[0, np.logspace(-3, 2, 61),
+                                       -np.logspace(-3, 2, 11)]*1j
+                             ).ravel(),
+                            rtol=1e-11)
+        assert_mpmath_equal(sc.exp1,
+                            mpmath.e1,
+                            (np.linspace(-50, -35, 10000) + 0j),
+                            rtol=1e-11)
 
     def test_ei(self):
         assert_mpmath_equal(sc.expi,
                             mpmath.ei,
-                            [Arg()])
+                            [Arg()],
+                            rtol=1e-11)
 
     def test_ei_complex(self):
         assert_mpmath_equal(sc.expi,
                             mpmath.ei,
-                            [ComplexArg()])
+                            [ComplexArg()],
+                            rtol=1e-9)
 
     def test_ellipe(self):
         assert_mpmath_equal(sc.ellipe,


### PR DESCRIPTION
Add asymptotic expansion to zeta, so it overflows later. Improve exp1/expi accuracy on complex plane near negative real axis.

Compares OK to mpmath now. Fixes gh-1967 I believe.
