### PR TITLE
BF: allow any sequence for variable_names and mat4

### DIFF
--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -380,6 +380,8 @@ class MatFile4Reader(MatFileReader):
         '''
         if isinstance(variable_names, string_types):
             variable_names = [variable_names]
+        elif variable_names is not None:
+            variable_names = list(variable_names)
         self.mat_stream.seek(0)
         # set up variable reader
         self.initialize_read()

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -998,21 +998,23 @@ def test_fieldnames():
 
 def test_loadmat_varnames():
     # Test that we can get just one variable from a mat file using loadmat
-    eg_file = pjoin(test_data_path, 'testmulti_7.4_GLNX86.mat')
-    sys_v_names = ['__globals__',
-                   '__header__',
-                   '__version__']
-    vars = loadmat(eg_file)
-    assert_equal(set(vars.keys()), set(['a', 'theta'] + sys_v_names))
-    vars = loadmat(eg_file, variable_names=['a'])
-    assert_equal(set(vars.keys()), set(['a'] + sys_v_names))
-    vars = loadmat(eg_file, variable_names=['theta'])
-    assert_equal(set(vars.keys()), set(['theta'] + sys_v_names))
-    vars = loadmat(eg_file, variable_names=('theta',))
-    assert_equal(set(vars.keys()), set(['theta'] + sys_v_names))
-    vnames = ['theta']
-    vars = loadmat(eg_file, variable_names=vnames)
-    assert_equal(vnames, ['theta'])
+    mat5_sys_names = ['__globals__',
+                      '__header__',
+                      '__version__']
+    for eg_file, sys_v_names in (
+        (pjoin(test_data_path, 'testmulti_4.2c_SOL2.mat'), []),
+        (pjoin(test_data_path, 'testmulti_7.4_GLNX86.mat'), mat5_sys_names)):
+        vars = loadmat(eg_file)
+        assert_equal(set(vars.keys()), set(['a', 'theta'] + sys_v_names))
+        vars = loadmat(eg_file, variable_names=['a'])
+        assert_equal(set(vars.keys()), set(['a'] + sys_v_names))
+        vars = loadmat(eg_file, variable_names=['theta'])
+        assert_equal(set(vars.keys()), set(['theta'] + sys_v_names))
+        vars = loadmat(eg_file, variable_names=('theta',))
+        assert_equal(set(vars.keys()), set(['theta'] + sys_v_names))
+        vnames = ['theta']
+        vars = loadmat(eg_file, variable_names=vnames)
+        assert_equal(vnames, ['theta'])
 
 
 def test_round_types():


### PR DESCRIPTION
Mat4 `variable_names` parameter that was not a list raised an error; cast
iterable to list to allow tuples etc as input.
