### PR TITLE
RF: fix reference cycle in interp1d; add gc utils

### DIFF
--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -8,6 +8,8 @@ import numpy as np
 
 from scipy.interpolate import interp1d, interp2d, lagrange
 
+from scipy.misc import check_refs_for
+
 
 class TestInterp2D(TestCase):
     def test_interp2d(self):
@@ -375,6 +377,15 @@ class TestInterp1D(object):
         #yield self._nd_check_interp, 'zero'
         #yield self._nd_check_interp, 'zero'
         pass
+
+    def test_circular_refs(self):
+        # Test interp1d can be automatically garbage collected
+        x = np.linspace(0, 1)
+        y = np.linspace(0, 1)
+        # Confirm interp can be released from memory after use
+        with check_refs_for(interp1d, x, y) as interp:
+            new_y = interp([0.1, 0.2])
+            del interp
 
 
 class TestLagrange(TestCase):

--- a/scipy/misc/__init__.py
+++ b/scipy/misc/__init__.py
@@ -34,6 +34,9 @@ systems that don't have PIL installed.
    pade - Pade approximation to function as the ratio of two polynomials
    toimage - Takes a numpy array and returns a PIL image
    who - Print the Numpy arrays in the given dictionary
+   set_gc_state - enable or disable garbage collection
+   gc_state - context manager for given state of garbage collector
+   check_refs_for - context manager to check for circular references on object
 
 """
 
@@ -64,6 +67,10 @@ except ImportError:
 from . import common
 __all__ += common.__all__
 del common
+
+from . import gcutils
+__all__ += gcutils.__all__
+from .gcutils import set_gc_state, gc_state, check_refs_for
 
 from numpy.testing import Tester
 test = Tester().test

--- a/scipy/misc/gcutils.py
+++ b/scipy/misc/gcutils.py
@@ -1,0 +1,82 @@
+""" Module for testing automatic garbage collection of objects
+"""
+import weakref
+import gc
+
+from contextlib import contextmanager
+
+__all__ = ['set_gc_state', 'gc_state', 'check_refs_for']
+
+class ReferenceError(Exception):
+    pass
+
+
+def set_gc_state(state):
+    """ Set status of garbage collector """
+    if gc.isenabled() == state:
+        return
+    if state:
+        gc.enable()
+    else:
+        gc.disable()
+
+
+@contextmanager
+def gc_state(state):
+    """ Context manager to set state of garbage collector to `state`
+
+    Parameters
+    ----------
+    state : bool
+        True for gc enabled, False for disabled
+
+    Examples
+    --------
+    >>> with gc_state(False):
+    ...     assert not gc.isenabled()
+    >>> with gc_state(True):
+    ...     assert gc.isenabled()
+    """
+    orig_state = gc.isenabled()
+    set_gc_state(state)
+    yield
+    set_gc_state(orig_state)
+
+
+@contextmanager
+def check_refs_for(func, *args, **kwargs):
+    """ Context manager to check for remaining references after deletion
+
+    Parameters
+    ----------
+    func : callable
+        Callable to create object to check
+    \*args : sequence
+        positional arguments to `func` in order to create object to check
+    \*\*kwargs : dict
+        keyword arguments to `func` in order to create object to check
+
+    Examples
+    --------
+    >>> class C(object): pass
+    >>> with check_refs_for(C) as c:
+    ...     # do something
+    ...     del c
+
+    >>> class C(object):
+    ...     def __init__(self):
+    ...         self._circular = self # Make circular reference
+    >>> with check_refs_for(C) as c: #doctest: +IGNORE_EXCEPTION_DETAIL
+    ...     # do something
+    ...     del c
+    Traceback (most recent call last):
+        ...
+    ReferenceError: Remaining reference(s) to object
+    """
+    with gc_state(False):
+        obj = func(*args, **kwargs)
+        ref = weakref.ref(obj)
+        yield obj
+        del obj
+        if ref() != None:
+            raise ReferenceError("Remaining reference(s) to object")

--- a/scipy/misc/tests/test_gcutils.py
+++ b/scipy/misc/tests/test_gcutils.py
@@ -1,0 +1,88 @@
+""" Test for check_refs_for context manager and gc utilities
+"""
+import gc
+
+from scipy.misc.gcutils import set_gc_state, gc_state, check_refs_for, ReferenceError
+
+from nose.tools import assert_equal, raises
+
+def test_set_gc_state():
+    gc_status = gc.isenabled()
+    try:
+        for state in (True, False):
+            gc.enable()
+            set_gc_state(state)
+            assert_equal(gc.isenabled(), state)
+            gc.disable()
+            set_gc_state(state)
+            assert_equal(gc.isenabled(), state)
+    finally:
+        if gc_status:
+            gc.enable()
+
+
+def test_gc_state():
+    # Test gc_state context manager
+    gc_status = gc.isenabled()
+    try:
+        for pre_state in (True, False):
+            set_gc_state(pre_state)
+            for with_state in (True, False):
+                # Check the gc state is with_state in with block
+                with gc_state(with_state):
+                    assert_equal(gc.isenabled(), with_state)
+                # And returns to previous state outside block
+                assert_equal(gc.isenabled(), pre_state)
+                # Even if the gc state is set explicitly within the block
+                with gc_state(with_state):
+                    assert_equal(gc.isenabled(), with_state)
+                    set_gc_state(not with_state)
+                assert_equal(gc.isenabled(), pre_state)
+    finally:
+        if gc_status:
+            gc.enable()
+
+
+def test_check_refs_for():
+    # Ordinary use
+    class C(object):
+        def __init__(self, arg0, arg1, name='myname'):
+            self.name = name
+    for gc_current in (True, False):
+        with gc_state(gc_current):
+            # We are deleting from with-block context, so that's OK
+            with check_refs_for(C, 0, 2, 'another name') as c:
+                assert_equal(c.name, 'another name')
+                del c
+            # Or not using the thing in with-block context, also OK
+            with check_refs_for(C, 0, 2, name='third name'):
+                pass
+            assert_equal(gc.isenabled(), gc_current)
+
+
+@raises(ReferenceError)
+def test_check_refs_for_nodel():
+    class C(object): pass
+    # Need to delete after using if in with-block context
+    with check_refs_for(C) as c:
+        pass
+
+
+@raises(ReferenceError)
+def test_check_refs_for_circular():
+    class C(object):
+        def __init__(self):
+            self._circular = self
+    # Circular reference, no automatic garbage collection
+    with check_refs_for(C) as c:
+        del c
+
+
+@raises(ReferenceError)
+def test_check_refs_for_circular2():
+    class C(object):
+        def __init__(self):
+            self._circular = self
+    # Still circular reference, no automatic garbage collection
+    with check_refs_for(C):
+        pass


### PR DESCRIPTION
interp1d was keeping references to self via a reference to one of its
methods, preventing it being cleared from memory without garbage
collection.
- add test for circular reference in interp1d
- add garbage collection utilities
- remove circular reference in interp1d
