### PR TITLE
BF: ensure ordering of OrderedDict keys

### DIFF
--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -592,7 +592,8 @@ def test_save_dict():
     ab_exp = np.array([[(1, 2)]], dtype=[('a', object), ('b', object)])
     ba_exp = np.array([[(2, 1)]], dtype=[('b', object), ('a', object)])
     for dict_type, is_ordered in dict_types:
-        d = dict_type(a=1, b=2)
+        # Initialize with tuples to keep order for OrderedDict
+        d = dict_type([('a', 1), ('b', 2)])
         stream = BytesIO()
         savemat_future(stream, {'dict': d})
         stream.seek(0)


### PR DESCRIPTION
Test was failing because of unexpected key ordering - closes gh-2503.
