### PR TITLE
MAINT: remove the file 'TEST_COMMIT'

### DIFF
--- a/TEST_COMMIT
+++ b/TEST_COMMIT
@@ -1,2 +1,0 @@
-cdavid: OK3
-ptvirtan: OK3


### PR DESCRIPTION
Is 'TEST_COMMIT' necessary?  If not, let's get rid of it.
