### PR TITLE
MAINT: stats: alias the erlang to the gamma distribution.  Add gamma._sf...

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -19,7 +19,7 @@ from scipy.special import gammaln as gamln
 
 import inspect
 from numpy import all, where, arange, putmask, \
-     ravel, take, ones, sum, shape, product, repeat, reshape, \
+     ravel, take, ones, sum, shape, product, reshape, \
      zeros, floor, logical_and, log, sqrt, exp, arctanh, tan, sin, arcsin, \
      arctan, tanh, ndarray, cos, cosh, sinh, newaxis, log1p, expm1
 from numpy import atleast_1d, polyval, ceil, place, extract, \
@@ -2788,60 +2788,7 @@ class dweibull_gen(rv_continuous):
 dweibull = dweibull_gen(name='dweibull', shapes='c')
 
 
-## ERLANG
-##
-## Special case of the Gamma distribution with shape parameter an integer.
-##
-class erlang_gen(rv_continuous):
-    """An Erlang continuous random variable.
-
-    %(before_notes)s
-
-    See Also
-    --------
-    gamma
-
-    Notes
-    -----
-    The Erlang distribution is a special case of the Gamma
-    distribution, with the shape parameter ``a`` an integer. Refer to
-    the ``gamma`` distribution for further examples.
-
-    """
-    def _rvs(self, a):
-        return gamma.rvs(a, size=self._size)
-
-    def _arg_check(self, a):
-        return (a > 0) & (floor(a) == a)
-
-    def _pdf(self, x, a):
-        Px = (x)**(a-1.0)*exp(-x)/special.gamma(a)
-        return Px
-
-    def _logpdf(self, x, a):
-        return (a-1.0)*log(x) - x - gamln(a)
-
-    def _cdf(self, x, a):
-        return special.gdtr(1.0,a,x)
-
-    def _sf(self, x, a):
-        return special.gdtrc(1.0,a,x)
-
-    def _ppf(self, q, a):
-        return special.gdtrix(1.0, a, q)
-
-    def _stats(self, a):
-        a = a*1.0
-        return a, a, 2/sqrt(a), 6/a
-
-    def _entropy(self, a):
-        return special.psi(a)*(1-a) + 1 + gamln(a)
-erlang = erlang_gen(a=0.0, name='erlang', shapes='a')
-
-
 ## Exponential (gamma distributed with a=1.0, loc=loc and scale=scale)
-## scale == 1.0 / lambda
-
 class expon_gen(rv_continuous):
     """An exponential continuous random variable.
 
@@ -3538,6 +3485,9 @@ class gamma_gen(rv_continuous):
     def _cdf(self, x, a):
         return special.gammainc(a, x)
 
+    def _sf(self, x, a):
+        return special.gammaincc(a, x)
+
     def _ppf(self, q, a):
         return special.gammaincinv(a,q)
 
@@ -3569,6 +3519,28 @@ class gamma_gen(rv_continuous):
         else:
             return super(gamma_gen, self).fit(data, *args, **kwds)
 gamma = gamma_gen(a=0.0, name='gamma', shapes='a')
+
+
+# Erlang
+class erlang_gen(gamma_gen):
+    """An Erlang continuous random variable.
+
+    %(before_notes)s
+
+    See Also
+    --------
+    gamma
+
+    Notes
+    -----
+    The Erlang distribution is a special case of the Gamma distribution, with
+    the shape parameter ``a`` an integer.  Note that this restriction is not
+    enforced by `erlang`.
+
+    Refer to `gamma` for examples.
+
+    """
+erlang = erlang_gen(a=0.0, name='erlang', shapes='a')
 
 
 # Generalized Gamma

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -44,7 +44,7 @@ distcont = [
     ['cosine', ()],
     ['dgamma', (1.1023326088288166,)],
     ['dweibull', (2.0685080649914673,)],
-    ['erlang', (20,)],    # correction numargs = 1
+    ['erlang', (10,)],
     ['expon', ()],
     ['exponpow', (2.697119160358469,)],
     ['exponweib', (2.8923945291034436, 1.9505288745913174)],
@@ -126,7 +126,6 @@ distcont = [
 
 # for testing only specific functions
 # distcont = [
-##    ['erlang', (20,)],    #correction numargs = 1
 ##    ['fatiguelife', (29,)],   #correction numargs = 1
 ##    ['loggamma', (0.41411931826052117,)]]
 

--- a/scipy/stats/tests/test_continuous_extra.py
+++ b/scipy/stats/tests/test_continuous_extra.py
@@ -6,6 +6,7 @@
 #       truncnorm fails by design for private method _ppf test
 from __future__ import division, print_function, absolute_import
 
+import warnings
 
 import numpy.testing as npt
 import numpy as np
@@ -101,6 +102,26 @@ def assert_equal_inf_nan(v1,v2,msg):
     else:
         npt.assert_(np.isinf(v2) or np.isnan(v2),
                msg + ' - infinite, v2=%s' % str(v2))
+
+
+def test_erlang_runtimewarning():
+    # erlang should generate a RuntimeWarning if a non-integer
+    # shape parameter is used.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+
+        # The non-integer shape parameter 1.3 should trigger a RuntimeWarning
+        npt.assert_raises(RuntimeWarning,
+                          stats.erlang.rvs, 1.3, loc=0, scale=1, size=4)
+
+        # Calling the fit method with `f0` set to an integer should
+        # *not* trigger a RuntimeWarning.  It should return the same
+        # values as gamma.fit(...).
+        data = [0.5, 1.0, 2.0, 4.0]
+        result_erlang = stats.erlang.fit(data, f0=1)
+        result_gamma = stats.gamma.fit(data, f0=1)
+        npt.assert_allclose(result_erlang, result_gamma, rtol=1e-3)
+
 
 if __name__ == "__main__":
     import nose

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -34,7 +34,7 @@ def kolmogorov_check(diststr, args=(), N=20, significance=0.01):
 dists = ['uniform','norm','lognorm','expon','beta',
          'powerlaw','bradford','burr','fisk','cauchy','halfcauchy',
          'foldcauchy','gamma','gengamma','loggamma',
-         'alpha','anglit','arcsine','betaprime','erlang',
+         'alpha','anglit','arcsine','betaprime',
          'dgamma','exponweib','exponpow','frechet_l','frechet_r',
          'gilbrat','f','ncf','chi2','chi','nakagami','genpareto',
          'genextreme','genhalflogistic','pareto','lomax','halfnorm',
@@ -66,9 +66,8 @@ def test_all_distributions():
         alpha = 0.01
         if dist == 'fatiguelife':
             alpha = 0.001
-        if dist == 'erlang':
-            args = (4,)+tuple(rand(2))
-        elif dist == 'frechet':
+
+        if dist == 'frechet':
             args = tuple(2*rand(1))+(0,)+tuple(2*rand(2))
         elif dist == 'triang':
             args = tuple(rand(nargs))
@@ -82,6 +81,7 @@ def test_all_distributions():
             args = tuple(1.0+rand(nargs))
         else:
             args = tuple(1.0+rand(nargs))
+
         yield check_distribution, dist, args, alpha
 
 
@@ -610,7 +610,7 @@ class TestFitMethod(object):
             # Only check the length of the return
             # FIXME: should check the actual results to see if we are 'close'
             #   to what was created --- but what is 'close' enough
-            if dist in ['erlang', 'frechet']:
+            if dist == 'frechet':
                 assert_(len(vals) == len(args))
                 assert_(len(vals2) == len(args))
             else:
@@ -624,8 +624,8 @@ class TestFitMethod(object):
     def test_fix_fit(self):
         def check(func, dist, args, alpha):
             # Not sure why 'ncf', and 'beta' are failing
-            # erlang and frechet have different len(args) than distfunc.numargs
-            if dist in self.skip + ['erlang', 'frechet']:
+            # frechet has different len(args) than distfunc.numargs
+            if dist in self.skip + ['frechet']:
                 raise SkipTest("%s fit known to fail" % dist)
             distfunc = getattr(stats, dist)
             with np.errstate(all='ignore'):

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -35,6 +35,10 @@ failing_fits = [
         'wrapcauchy',
 ]
 
+# Don't run the fit test on these:
+skip_fit = [
+    'erlang',  # Subclass of gamma, generates a warning.
+]
 
 @dec.slow
 def test_cont_fit():
@@ -43,7 +47,8 @@ def test_cont_fit():
     # Note: is slow, some distributions don't converge with sample size <= 10000
 
     for distname, arg in distcont:
-        yield check_cont_fit, distname,arg
+        if distname not in skip_fit:
+            yield check_cont_fit, distname,arg
 
 
 def check_cont_fit(distname,arg):

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -20,7 +20,6 @@ failing_fits = [
         'burr',
         'chi',
         'chi2',
-        'erlang',
         'gausshyper',
         'genexpon',
         'gengamma',


### PR DESCRIPTION
...().

Closes gh-2172 and gh-198.  See discussion on gh-2172 for details.

Most people seemed to be in favor of making erlang an alias, so I went with that.
