### PR TITLE
BUG+ENH: stats:  Improve the 'fit' method of norm_gen, gamma_gen and beta_gen.

### DIFF
--- a/scipy/misc/doccer.py
+++ b/scipy/misc/doccer.py
@@ -5,8 +5,8 @@ from __future__ import division, print_function, absolute_import
 
 import sys
 
-__all__ = ['docformat', 'indentcount_lines', 'filldoc',
-           'unindent_dict', 'unindent_string']
+__all__ = ['docformat', 'inherit_docstring_from', 'indentcount_lines',
+           'filldoc', 'unindent_dict', 'unindent_string']
 
 
 def docformat(docstring, docdict=None):
@@ -66,6 +66,63 @@ def docformat(docstring, docdict=None):
         except IndexError:
             indented[name] = dstr
     return docstring % indented
+
+
+def inherit_docstring_from(cls):
+    """
+    This decorator modifies the decorated function's docstring by
+    replacing occurrences of '%(super)s' with the docstring of the
+    method of the same name from the class `cls`.
+
+    If the decorated method has no docstring, it is simply given the
+    docstring of `cls`s method.
+
+    Parameters
+    ----------
+    cls : Python class or instance
+        A class with a method with the same name as the decorated method.
+        The docstring of the method in this class replaces '%(super)s' in the
+        docstring of the decorated method.
+
+    Returns
+    -------
+    f : function
+        The decorator function that modifies the __doc__ attribute
+        of its argument.
+
+    Examples
+    --------
+    In the following, the docstring for Bar.func created using the
+    docstring of `Foo.func`.
+
+    >>> class Foo(object):
+    ...     def func(self):
+    ...         '''Do something useful.'''
+    ...         return
+    ...
+    >>> class Bar(Foo):
+    ...     @inherit_docstring_from(Foo)
+    ...     def func(self):
+    ...         '''%(super)s
+    ...         Do it fast.
+    ...         '''
+    ...         return
+    ...
+    >>> b = Bar()
+    >>> b.func.__doc__
+    'Do something useful.\n        Do it fast.\n        '
+
+    """
+    def _doc(func):
+        cls_docstring = getattr(cls, func.__name__).__doc__
+        func_docstring = func.__doc__
+        if func_docstring is None:
+            func.__doc__ = cls_docstring
+        else:
+            new_docstring = func_docstring % dict(super=cls_docstring)
+            func.__doc__ = new_docstring
+        return func
+    return _doc
 
 
 def indentcount_lines(lines):

--- a/scipy/misc/tests/test_doccer.py
+++ b/scipy/misc/tests/test_doccer.py
@@ -2,11 +2,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-import numpy as np
-
-from numpy.testing import assert_equal, assert_raises
-
-from nose.tools import assert_true
+from numpy.testing import assert_equal
 
 from scipy.misc import doccer
 
@@ -92,3 +88,33 @@ def test_decorator():
             Another test
                with some indent
         """
+
+
+def test_inherit_docstring_from():
+
+    class Foo(object):
+
+        def func(self):
+            '''Do something useful.'''
+            return
+
+        def func2(self):
+            '''Something else.'''
+
+    class Bar(Foo):
+
+        @doccer.inherit_docstring_from(Foo)
+        def func(self):
+            '''%(super)sABC'''
+            return
+
+        @doccer.inherit_docstring_from(Foo)
+        def func2(self):
+            # No docstring.
+            return
+
+    assert_equal(Bar.func.__doc__, Foo.func.__doc__ + 'ABC')
+    assert_equal(Bar.func2.__doc__, Foo.func2.__doc__)
+    bar = Bar()
+    assert_equal(bar.func.__doc__, Foo.func.__doc__ + 'ABC')
+    assert_equal(bar.func2.__doc__, Foo.func2.__doc__)


### PR DESCRIPTION
This should close gh-2514.

The specific changes are summarized in the commit message.

An example of the improved performance:

```
In [5]: from scipy.stats import beta, rv_continuous

In [6]: x = beta.rvs(0.5, 1.5, 0, 4, size=500)

In [7]: beta.fit(x, floc=0, fscale=4)
Out[7]: (0.51490904775491819, 1.4783326683085065, 0, 4)

In [8]: rv_continuous.fit(beta, x, floc=0, fscale=4)
/home/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/distributions.py:2442: RuntimeWarning: invalid value encountered in sqrt
  sk = 2*(b-a)*sqrt(a + b + 1) / (a + b + 2) / sqrt(a*b)
Out[8]: (0.51491189692021333, 1.4783061325955025, 0, 4)

In [9]: %timeit beta.fit(x, floc=0, fscale=4)
1000 loops, best of 3: 370 us per loop

In [10]: %timeit rv_continuous.fit(beta, x, floc=0, fscale=4)
100 loops, best of 3: 9.59 ms per loop

In [11]: 9.59/.37
Out[11]: 25.91891891891892
```

In this case, the new `fit` method is almost 26 times faster than `rv_continuous.fit`.
