### PR TITLE
Variance branch

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -1589,9 +1589,9 @@ class rv_continuous(rv_generic):
                     if mu is None:
                         mu = self._munp(1.0,*goodargs)
                     mu2 = mu2p - mu*mu
-                if np.isinf(mu):
-                    #if mean is inf then var is also inf
-                    mu2 = np.inf
+                    if np.isinf(mu):
+                        #if mean is inf then var is also inf
+                        mu2 = np.inf
                 out0 = default.copy()
                 place(out0,cond,mu2*scale*scale)
                 output.append(out0)

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -4492,11 +4492,13 @@ class nct_gen(rv_continuous):
         nct.pdf(x, df, nc) = ----------------------------------------------------
                              2**df*exp(nc**2/2) * (df+x**2)**(df/2) * gamma(df/2)
 
-    for ``df > 0``, ``nc > 0``.
+    for ``df > 0``.
 
     %(example)s
 
     """
+    def _argcheck(self, df, nc):
+        return (df > 0)
     def _rvs(self, df, nc):
         return norm.rvs(loc=nc,size=self._size)*sqrt(df) / sqrt(chi2.rvs(df,size=self._size))
     def _pdf(self, x, df, nc):

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -4498,7 +4498,7 @@ class nct_gen(rv_continuous):
 
     """
     def _argcheck(self, df, nc):
-        return (df > 0)
+        return (df > 0) & (nc == nc)
     def _rvs(self, df, nc):
         return norm.rvs(loc=nc,size=self._size)*sqrt(df) / sqrt(chi2.rvs(df,size=self._size))
     def _pdf(self, x, df, nc):

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -2951,11 +2951,13 @@ class foldnorm_gen(rv_continuous):
     %(example)s
 
     """
+    def _argcheck(self, c):
+        return (c >= 0)
     def _rvs(self, c):
         return abs(norm.rvs(loc=c,size=self._size))
     def _pdf(self, x, c):
         return sqrt(2.0/pi)*cosh(c*x)*exp(-(x*x+c*c)/2.0)
-    def _cdf(self, x, c,):
+    def _cdf(self, x, c):
         return special.ndtr(x-c) + special.ndtr(x+c) - 1.0
     def _stats(self, c):
         fac = special.erf(c/sqrt(2))

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1087,8 +1087,8 @@ def test_ncx2_tails_ticket_955():
     assert_allclose(a, b, rtol=1e-3, atol=0)
 
 def test_foldnorm_ticket_1880():
-    # Parameter value c = 0 was not enabled
-    rv=foldnorm(0, scale=1)
+    # Parameter value c=0 was not enabled
+    rv = foldnorm(0, scale=1)
     assert_equal(rv.cdf(0),0)  # rv.cdf(0) previously resulted in: nan
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1089,7 +1089,15 @@ def test_ncx2_tails_ticket_955():
 def test_foldnorm_ticket_1880():
     # Parameter value c=0 was not enabled
     rv = foldnorm(0, scale=1)
-    assert_equal(rv.cdf(0),0)  # rv.cdf(0) previously resulted in: nan
+    assert_equal(rv.cdf(0), 0)  # rv.cdf(0) previously resulted in: nan
+
+def test_nct_ticket_1883():
+    # Parameter values c<=0 were not enabled
+    # For negative values c and for c=0 results of rv.cdf(0) below were nan
+    rv = nct(5, 0)
+    assert_equal(rv.cdf(0), 0.5)
+    rv = nct(5, -1)
+    assert_almost_equal(rv.cdf(0), 0.841344746069, decimal=10)
 
 
 if __name__ == "__main__":

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1099,6 +1099,14 @@ def test_nct_ticket_1883():
     rv = nct(5, -1)
     assert_almost_equal(rv.cdf(0), 0.841344746069, decimal=10)
 
-
+def text_var_ticket_1882():
+    # Computation of the variance of a non-central t-distribution resulted 
+    # in a TyoeError: ufunc 'isinf' not supported for the input types,
+    # and the inputs could not be safely coerced to any supported types 
+    # according to the casting rule 'safe'
+    rv = nct(4, 0)
+    assert_equal(rv.var(), 2.0)
+    
+    
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1042,7 +1042,6 @@ def test_hypergeom_interval_1802():
     assert_equal(stats.hypergeom.ppf(0.02, 100, 100, 8), 8)
     assert_equal(stats.hypergeom.ppf(1, 100, 100, 8), 8)
 
-
 def test_distribution_too_many_args():
     # Check that a TypeError is raised when too many args are given to a method
     # Regression test for ticket 1815.
@@ -1086,6 +1085,12 @@ def test_ncx2_tails_ticket_955():
     a = stats.ncx2.cdf(np.arange(20, 25, 0.2), 2, 1.07458615e+02)
     b = stats.ncx2.veccdf(np.arange(20, 25, 0.2), 2, 1.07458615e+02)
     assert_allclose(a, b, rtol=1e-3, atol=0)
+
+def test_foldnorm_ticket_1880():
+    # Parameter value c = 0 was not enabled
+    rv=foldnorm(0, scale=1)
+    assert_equal(rv.cdf(0),0)  # rv.cdf(0) previously resulted in: nan
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Increasing the indentation level of three lines in distribution.py enables the computation of the variance of (a.o.?) a non-central t-distribution. See the discussion on ticket # 1882.
