### PR TITLE
Enable Travis CI buildbot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+# After changing this file, check it on:
+#   http://lint.travis-ci.org/
+language: python
+python:
+  - 2.6
+  - 3.3
+matrix:
+  include:
+    - python: 2.7
+      env: TESTMODE=full
+before_install:
+  - uname -a
+  - free -m
+  - df -h
+  - ulimit -a
+  - mkdir builds
+  - pushd builds
+  - pip install nose
+  - pip install numpy
+  - pip install Cython
+  # mpmath for scipy.special tests
+  - pip install mpmath
+  # For Python 2.6 we also need argparse
+  - pip install argparse
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran
+  - python -V
+  - popd
+script:
+  - python runtests.py --show-build-log -g -v -m $TESTMODE
+env:
+  - TESTMODE=fast
+notifications:
+  # Perhaps we should have status emails sent to the mailing list, but
+  # let's wait to see what people think before turning that on.
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - python -V
   - popd
 script:
-  - python runtests.py --show-build-log -g -v -m $TESTMODE
+  - python runtests.py -g -m $TESTMODE
 env:
   - TESTMODE=fast
 notifications:

--- a/runtests.py
+++ b/runtests.py
@@ -68,6 +68,8 @@ def main(argv):
                         help="Start Unix shell with PYTHONPATH set")
     parser.add_argument("--debug", "-g", action="store_true",
                         help="Debug build")
+    parser.add_argument("--show-build-log", action="store_true",
+                        help="Show build output rather than using a log file")
     parser.add_argument("args", metavar="ARGS", default=[], nargs=REMAINDER,
                         help="Arguments to pass to Nose")
     args = parser.parse_args(argv)
@@ -175,17 +177,21 @@ def build_project(args):
 
     cmd += ['install', '--prefix=' + dst_dir]
 
-    print("Building, see build.log...")
-    with open('build.log', 'w') as log:
-        ret = subprocess.call(cmd, env=env, stdout=log, stderr=log,
-                              cwd=root_dir)
+    if args.show_build_log:
+        ret = subprocess.call(cmd, env=env, cwd=root_dir)
+    else:
+        print("Building, see build.log...")
+        with open('build.log', 'w') as log:
+            ret = subprocess.call(cmd, env=env, stdout=log, stderr=log,
+                                  cwd=root_dir)
 
     if ret == 0:
         print("Build OK")
     else:
-        with open('build.log', 'r') as f:
-            print(f.read())
-        print("Build failed!")
+        if not args.show_build_log:
+            with open('build.log', 'r') as f:
+                print(f.read())
+            print("Build failed!")
         sys.exit(1)
 
     from distutils.sysconfig import get_python_lib


### PR DESCRIPTION
This PR enables the Travis CI buildbot for Scipy, testing Python 2.6, 2.7, and 3.3.

The "fast" test suite completes in less than 10 minutes on Python 2.x and in less than 20 min on Python 3.3 (the difference comes from the dependencies not being preinstalled for Python 3.3). The "full" test suite runs up to ~30 min and is only run for Python 2.7.

Example of the results here: https://travis-ci.org/pv/scipy-work
