### PR TITLE
ENH: speed up scipy.stats.chisquare

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3500,12 +3500,18 @@ def chisquare(f_obs, f_exp=None, ddof=0):
     """
     f_obs = asarray(f_obs)
     k = len(f_obs)
-    if f_exp is None:
-        f_exp = array([np.sum(f_obs,axis=0)/float(k)] * len(f_obs),float)
 
-    f_exp = f_exp.astype(float)
-    chisq = np.add.reduce((f_obs-f_exp)**2 / f_exp)
-    return chisq, chisqprob(chisq, k-1-ddof)
+    if f_exp is None:
+        f_exp = np.sum(f_obs, axis=0, dtype=float)
+        f_exp /= k
+    else:
+        f_exp = asarray(f_exp, dtype=float)
+
+    chisq = f_obs - f_exp
+    chisq **= 2
+    chisq /= f_exp
+    chisq = chisq.sum(axis=0)
+    return chisq, chisqprob(chisq, k - 1 - ddof)
 
 
 def ks_2samp(data1, data2):


### PR DESCRIPTION
My colleague found out that `scipy.stats.chisquare` is slow for large arrays. This version is about 4× faster according to

```
python -m timeit -s 'import numpy as np
                     from scipy.stats import chisquare
                     A = np.random.random([29, 90000])' 'chisquare(A)'
```

The main speedup comes from smarter use of NumPy broadcasting rules and skipping the construction of a large array with an intermediate list. In-place operations made it just a little faster.
