### PR TITLE
continuous wavelet transform speed up

### DIFF
--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -5,6 +5,7 @@ from numpy.dual import eig
 from scipy.misc import comb
 from scipy import linspace, pi, exp
 from scipy.signal import convolve
+from scipy.signal import fftconvolve
 
 __all__ = ['daub', 'qmf', 'cascade', 'morlet', 'ricker', 'cwt']
 
@@ -357,6 +358,6 @@ def cwt(data, wavelet, widths):
     output = np.zeros([len(widths), len(data)])
     for ind, width in enumerate(widths):
         wavelet_data = wavelet(min(10 * width, len(data)), width)
-        output[ind, :] = convolve(data, wavelet_data,
+        output[ind, :] = fftconvolve(data, wavelet_data,
                                               mode='same')
     return output


### PR DESCRIPTION
scipy.signal.cwt uses scipy.signal.convolve
Terribly slow.
Changed to scipy.signal.fftconvolve
