### PR TITLE
ENH: sqrtm improvement

### DIFF
--- a/scipy/linalg/benchmarks/bench_sqrtm.py
+++ b/scipy/linalg/benchmarks/bench_sqrtm.py
@@ -1,0 +1,50 @@
+""" Benchmark linalg.sqrtm for various blocksizes.
+
+"""
+
+from __future__ import division, print_function, absolute_import
+
+import time
+
+import numpy as np
+from numpy.testing import assert_allclose
+import scipy.linalg
+
+def bench_sqrtm():
+    np.random.seed(1234)
+    print()
+    print('                       Matrix Square Root')
+    print('==============================================================')
+    print('      shape      |   block   |        dtype       |   time   ')
+    print('                 |    size   |                    | (seconds)')
+    print('--------------------------------------------------------------')
+    fmt = ' %15s |   %6d  | %18s | %6.2f '
+    # 1024 was slower than most people would want to wait, on my computer.
+    for n in (16, 64, 256):
+        for dtype in (np.float64, np.complex128):
+
+            # Sample a random matrix.
+            # See Figs. 2 and 3 of Deadman and Higham and Ralha 2012
+            # "A Recursive Blocked Schur Algorithm
+            # for Computing the # Matrix Square Root"
+            A = np.random.rand(n, n)
+            if dtype == np.complex128:
+                A = A + 1j*np.random.rand(n, n)
+
+            # trivial blocksize
+            blocksize = 1
+            tm = time.clock()
+            B_1, info = scipy.linalg.sqrtm(A, disp=False, blocksize=blocksize)
+            nseconds = time.clock() - tm
+            print(fmt % (A.shape, blocksize, A.dtype, nseconds))
+
+            # interesting blocksize
+            blocksize = 32
+            tm = time.clock()
+            B_32, info = scipy.linalg.sqrtm(A, disp=False, blocksize=blocksize)
+            nseconds = time.clock() - tm
+            print(fmt % (A.shape, blocksize, A.dtype, nseconds))
+
+            # Check the results for the two block sizes.
+            assert_allclose(B_1, B_32)
+

--- a/scipy/linalg/benchmarks/bench_sqrtm.py
+++ b/scipy/linalg/benchmarks/bench_sqrtm.py
@@ -19,8 +19,7 @@ def bench_sqrtm():
     print('                 |    size   |                    | (seconds)')
     print('--------------------------------------------------------------')
     fmt = ' %15s |   %6d  | %18s | %6.2f '
-    # 1024 was slower than most people would want to wait, on my computer.
-    for n in (16, 64, 256):
+    for n in (64, 256):
         for dtype in (np.float64, np.complex128):
 
             # Sample a random matrix.
@@ -45,6 +44,14 @@ def bench_sqrtm():
             nseconds = time.clock() - tm
             print(fmt % (A.shape, blocksize, A.dtype, nseconds))
 
-            # Check the results for the two block sizes.
+            # bigger block size
+            blocksize = 64
+            tm = time.clock()
+            B_64, info = scipy.linalg.sqrtm(A, disp=False, blocksize=blocksize)
+            nseconds = time.clock() - tm
+            print(fmt % (A.shape, blocksize, A.dtype, nseconds))
+
+            # Check that the results are the same for all block sizes.
             assert_allclose(B_1, B_32)
+            assert_allclose(B_1, B_64)
 

--- a/scipy/linalg/benchmarks/bench_sqrtm.py
+++ b/scipy/linalg/benchmarks/bench_sqrtm.py
@@ -30,8 +30,8 @@ def bench_sqrtm():
             if dtype == np.complex128:
                 A = A + 1j*np.random.rand(n, n)
 
-            # trivial blocksize
-            blocksize = 1
+            # blocksize that corresponds to the block-free implementation
+            blocksize = n
             tm = time.clock()
             B_1, info = scipy.linalg.sqrtm(A, disp=False, blocksize=blocksize)
             nseconds = time.clock() - tm

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -19,6 +19,7 @@ import numpy as np
 # Local imports
 from .misc import norm
 from .basic import solve, inv
+from .lapack import ztrsyl
 from .special_matrices import triu, all_mat
 from .decomp import eig
 from .decomp_svd import orth, svd
@@ -496,7 +497,7 @@ def signm(a, disp=True):
         return S0, errest
 
 
-def sqrtm(A, disp=True):
+def sqrtm(A, disp=True, blocksize=1):
     """
     Matrix square root.
 
@@ -507,37 +508,99 @@ def sqrtm(A, disp=True):
     disp : bool, optional
         Print warning if error in the result is estimated large
         instead of returning estimated error. (Default: True)
+    blocksize : integer, optional
+        If the blocksize is not degenerate with respect to the
+        size of the input array, then use a blocked algorithm. (Default: 1)
 
     Returns
     -------
-    sgrtm : (N, N) ndarray
-        Value of the sign function at `A`
+    sqrtm : (N, N) ndarray
+        Value of the sqrt function at `A`
 
     errest : float
         (if disp == False)
 
         Frobenius norm of the estimated error, ||err||_F / ||A||_F
 
-    Notes
-    -----
-    Uses algorithm by Nicholas J. Higham
+    References
+    ----------
+    .. [1] Edvin Deadman, Nicholas J. Higham, Rui Ralha (2013)
+           "Blocked Schur Algorithms for Computing the Matrix Square Root,
+           Lecture Notes in Computer Science, 7782. pp. 171-182.
 
     """
     A = asarray(A)
     if len(A.shape) != 2:
         raise ValueError("Non-matrix input to matrix function.")
+    if blocksize < 1:
+        raise ValueError("The blocksize should be at least 1.")
     T, Z = schur(A)
     T, Z = rsf2csf(T,Z)
     n,n = T.shape
-
     R = np.zeros((n,n),T.dtype.char)
-    for j in range(n):
-        R[j,j] = sqrt(T[j,j])
-        for i in range(j-1,-1,-1):
-            s = 0
-            for k in range(i+1,j):
-                s = s + R[i,k]*R[k,j]
-            R[i,j] = (T[i,j] - s)/(R[i,i] + R[j,j])
+
+    # Compute the number of blocks to use.
+    # If this number is not interesting, then use the default method.
+    nblocks = n // blocksize
+    uninteresting_nblocks = (0, 1, n)
+
+    if nblocks in uninteresting_nblocks:
+        for j in range(n):
+            R[j,j] = sqrt(T[j,j])
+            for i in range(j-1,-1,-1):
+                s = 0
+                for k in range(i+1,j):
+                    s = s + R[i,k]*R[k,j]
+                R[i,j] = (T[i,j] - s)/(R[i,i] + R[j,j])
+    else:
+
+        # Compute the smaller of the two sizes of blocks that
+        # we will actually use, and compute the number of large blocks.
+        bsmall, nlarge = divmod(n, nblocks)
+        blarge = bsmall + 1
+        nsmall = nblocks - nlarge
+        if nsmall * bsmall + nlarge * blarge != n:
+            raise Exception('internal inconsistency')
+
+        # Define the index range covered by each block.
+        start_stop_pairs = []
+        start = 0
+        for count, size in ((nsmall, bsmall), (nlarge, blarge)):
+            for i in range(count):
+                start_stop_pairs.append((start, start + size))
+                start += size
+        
+        # Take square roots of the diagonal of the triangular matrix.
+        R[np.diag_indices(n)] = np.sqrt(np.diag(T))
+
+        # This is a within-block analog of the default method.
+        for start, stop in start_stop_pairs:
+            for j in range(start, stop):
+                for i in range(j-1, start-1, -1):
+                    s = 0
+                    for k in range(i+1, j):
+                        s = s + R[i,k]*R[k,j]
+                    R[i,j] = (T[i,j] - s)/(R[i,i] + R[j,j])
+
+        # This is a between-block analog of the default method.
+        for j in range(nblocks):
+            jstart, jstop = start_stop_pairs[j]
+            for i in range(j-1, -1, -1):
+                istart, istop = start_stop_pairs[i]
+                S = T[istart:istop, jstart:jstop]
+                for k in range(i+1, j):
+                    kstart, kstop = start_stop_pairs[k]
+                    Rik = R[istart:istop, kstart:kstop]
+                    Rkj = R[kstart:kstop, jstart:jstop]
+                    S = S - Rik.dot(Rkj)
+
+                # Invoke LAPACK.
+                # For more details, see the solve_sylvester implemention
+                # and the fortran ztrsyl docs.
+                Rii = R[istart:istop, istart:istop]
+                Rjj = R[jstart:jstop, jstart:jstop]
+                x, scale, info = ztrsyl(Rii, Rjj, S)
+                R[istart:istop, jstart:jstop] = x * scale
 
     R, Z = all_mat(R,Z)
     X = (Z * R * Z.H)

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -569,8 +569,8 @@ def sqrtm(A, disp=True, blocksize=1):
         for j in range(start, stop):
             for i in range(j-1, start-1, -1):
                 s = 0
-                for k in range(i+1, j):
-                    s = s + R[i,k]*R[k,j]
+                if j - i > 1:
+                    s = R[i, i+1:j].dot(R[i+1:j, j])
                 R[i,j] = (T[i,j] - s)/(R[i,i] + R[j,j])
 
     # This is a between-block analog of the default method.
@@ -579,11 +579,9 @@ def sqrtm(A, disp=True, blocksize=1):
         for i in range(j-1, -1, -1):
             istart, istop = start_stop_pairs[i]
             S = T[istart:istop, jstart:jstop]
-            for k in range(i+1, j):
-                kstart, kstop = start_stop_pairs[k]
-                Rik = R[istart:istop, kstart:kstop]
-                Rkj = R[kstart:kstop, jstart:jstop]
-                S = S - Rik.dot(Rkj)
+            if j - i > 1:
+                S = S - R[istart:istop, istop:jstart].dot(
+                        R[istop:jstart, jstart:jstop])
 
             # Invoke LAPACK.
             # For more details, see the solve_sylvester implemention

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -497,7 +497,7 @@ def signm(a, disp=True):
         return S0, errest
 
 
-def sqrtm(A, disp=True, blocksize=1):
+def sqrtm(A, disp=True, blocksize=64):
     """
     Matrix square root.
 
@@ -510,7 +510,7 @@ def sqrtm(A, disp=True, blocksize=1):
         instead of returning estimated error. (Default: True)
     blocksize : integer, optional
         If the blocksize is not degenerate with respect to the
-        size of the input array, then use a blocked algorithm. (Default: 1)
+        size of the input array, then use a blocked algorithm. (Default: 64)
 
     Returns
     -------
@@ -542,11 +542,8 @@ def sqrtm(A, disp=True, blocksize=1):
     # Take square roots of the diagonal of the triangular matrix.
     R[np.diag_indices(n)] = np.sqrt(np.diag(T))
 
-    # Compute the number of blocks to use.
-    # If this number is not interesting, then use the default method.
-    nblocks = n // blocksize
-    if nblocks in (0, 1, n):
-        nblocks = 1
+    # Compute the number of blocks to use; use at least one block.
+    nblocks = max(n // blocksize, 1)
 
     # Compute the smaller of the two sizes of blocks that
     # we will actually use, and compute the number of large blocks.
@@ -564,7 +561,7 @@ def sqrtm(A, disp=True, blocksize=1):
             start_stop_pairs.append((start, start + size))
             start += size
 
-    # This is a within-block analog of the default method.
+    # Within-block interactions.
     for start, stop in start_stop_pairs:
         for j in range(start, stop):
             for i in range(j-1, start-1, -1):
@@ -573,7 +570,7 @@ def sqrtm(A, disp=True, blocksize=1):
                     s = R[i, i+1:j].dot(R[i+1:j, j])
                 R[i,j] = (T[i,j] - s)/(R[i,i] + R[j,j])
 
-    # This is a between-block analog of the default method.
+    # Between-block interactions.
     for j in range(nblocks):
         jstart, jstop = start_stop_pairs[j]
         for i in range(j-1, -1, -1):

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -94,8 +94,23 @@ class TestSqrtM(TestCase):
                     [0,0,se,0],
                     [0,0,0,1]])
         assert_array_almost_equal(dot(sa,sa),a)
+        # Check default sqrtm.
         esa = sqrtm(a, disp=False)[0]
         assert_array_almost_equal(dot(esa,esa),a)
+        # Check sqrtm with 2x2 blocks.
+        esa = sqrtm(a, disp=False, blocksize=2)[0]
+        assert_array_almost_equal(dot(esa,esa),a)
+
+    def test_blocksizes(self):
+        # Make sure I do not goof up the blocksizes when they do not divide n.
+        np.random.seed(1234)
+        for n in range(1, 8):
+            A = np.random.rand(n, n) + 1j*np.random.randn(n, n)
+            A_sqrtm_default, info = sqrtm(A, disp=False)
+            assert_allclose(A, np.linalg.matrix_power(A_sqrtm_default, 2))
+            for blocksize in range(1, 10):
+                A_sqrtm_new, info = sqrtm(A, blocksize=blocksize, disp=False)
+                assert_allclose(A_sqrtm_default, A_sqrtm_new)
 
 
 class TestExpM(TestCase):

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -93,9 +93,10 @@ class TestSqrtM(TestCase):
                     [0,se,0,0],
                     [0,0,se,0],
                     [0,0,0,1]])
+        n = a.shape[0]
         assert_array_almost_equal(dot(sa,sa),a)
         # Check default sqrtm.
-        esa = sqrtm(a, disp=False)[0]
+        esa = sqrtm(a, disp=False, blocksize=n)[0]
         assert_array_almost_equal(dot(esa,esa),a)
         # Check sqrtm with 2x2 blocks.
         esa = sqrtm(a, disp=False, blocksize=2)[0]
@@ -106,10 +107,10 @@ class TestSqrtM(TestCase):
         np.random.seed(1234)
         for n in range(1, 8):
             A = np.random.rand(n, n) + 1j*np.random.randn(n, n)
-            A_sqrtm_default, info = sqrtm(A, disp=False)
+            A_sqrtm_default, info = sqrtm(A, disp=False, blocksize=n)
             assert_allclose(A, np.linalg.matrix_power(A_sqrtm_default, 2))
             for blocksize in range(1, 10):
-                A_sqrtm_new, info = sqrtm(A, blocksize=blocksize, disp=False)
+                A_sqrtm_new, info = sqrtm(A, disp=False, blocksize=blocksize)
                 assert_allclose(A_sqrtm_default, A_sqrtm_new)
 
 


### PR DESCRIPTION
This PR implements yet another matrix function improvement published by Nick Higham and his crew.  This time it is for the matrix square root.  http://eprints.ma.man.ac.uk/1951/

According to that pdf, the matrix square root function is allegedly useful not only for its own sake, but also as an ingredient in algorithms to compute the matrix logarithm, matrix pth roots, and arbitrary matrix powers.

The following table suggests that using the optional `blocksize` argument added by this PR can increase `sqrtm` speed, especially for large `float64` matrices.  When the `blocksize` is set to 1 (its default), the `sqrtm` function uses its current implementation rather than using the new blocked algorithm implemented by this PR.

The PR also includes tests and the informal benchmark that generated the table below, except without the slow `n=1024` cases.

---

<pre>
                       Matrix Square Root
==============================================================
      shape      |   block   |        dtype       |   time   
                 |    size   |                    | (seconds)
--------------------------------------------------------------
        (16, 16) |        1  |            float64 |   0.00 
        (16, 16) |       32  |            float64 |   0.01 
        (16, 16) |        1  |         complex128 |   0.01 
        (16, 16) |       32  |         complex128 |   0.00 
        (64, 64) |        1  |            float64 |   0.09 
        (64, 64) |       32  |            float64 |   0.05 
        (64, 64) |        1  |         complex128 |   0.09 
        (64, 64) |       32  |         complex128 |   0.04 
      (256, 256) |        1  |            float64 |   2.73 
      (256, 256) |       32  |            float64 |   0.47 
      (256, 256) |        1  |         complex128 |   2.96 
      (256, 256) |       32  |         complex128 |   0.71 
    (1024, 1024) |        1  |            float64 | 152.54 
    (1024, 1024) |       32  |            float64 |   8.47 
    (1024, 1024) |        1  |         complex128 | 158.15 
    (1024, 1024) |       32  |         complex128 |  16.01 

</pre>
