### PR TITLE
DOC: fix spatial.distance.squareform() argument/return parameters

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1381,13 +1381,6 @@ def squareform(X, force="no", checks=True):
     ----------
     X : ndarray
         Either a condensed or redundant distance matrix.
-
-    Returns
-    -------
-    Y : ndarray
-        If a condensed distance matrix is passed, a redundant one is
-        returned, or if a redundant one is passed, a condensed distance
-        matrix is returned.
     force : str, optional
         As with MATLAB(TM), if force is equal to 'tovector' or 'tomatrix',
         the input will be treated as a distance matrix or distance vector
@@ -1398,6 +1391,13 @@ def squareform(X, force="no", checks=True):
         ``X - X.T1`` is small and ``diag(X)`` is close to zero.
         These values are ignored any way so they do not disrupt the
         squareform transformation.
+
+    Returns
+    -------
+    Y : ndarray
+        If a condensed distance matrix is passed, a redundant one is
+        returned, or if a redundant one is passed, a condensed distance
+        matrix is returned.
 
     Notes
     -----


### PR DESCRIPTION
Some parameters were listed under the Returns heading.
