### PR TITLE
BUG: Make sum & mean method's output dtypes behave like corresponding numpy methods.

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -564,7 +564,7 @@ class spmatrix(object):
     def copy(self):
         return self.__class__(self,copy=True)
 
-    def sum(self, axis=None):
+    def sum(self, axis=None, dtype=None):
         """Sum the matrix over the given axis.  If the axis is None, sum
         over both rows and columns, returning a scalar.
         """
@@ -574,13 +574,13 @@ class spmatrix(object):
         m, n = self.shape
         if axis == 0:
             # sum over columns
-            return np.asmatrix(np.ones((1, m), dtype=self.dtype)) * self
+            return np.asmatrix(np.ones((1, m), dtype=dtype)) * self
         elif axis == 1:
             # sum over rows
-            return self * np.asmatrix(np.ones((n, 1), dtype=self.dtype))
+            return self * np.asmatrix(np.ones((n, 1), dtype=dtype))
         elif axis is None:
             # sum over rows and columns
-            return (self * np.asmatrix(np.ones((n, 1), dtype=self.dtype))).sum()
+            return (self * np.asmatrix(np.ones((n, 1), dtype=dtype))).sum()
         else:
             raise ValueError("axis out of bounds")
 


### PR DESCRIPTION
This is to address [issue 2534 ](https://github.com/scipy/scipy/issues/2534) so these methods will act like the corresponding numpy methods. 

Note that this will change behavior, and could break code that relies on self.dtype being the default dtype. 

Also, there are no tests in this PR, I was writing new tests when I found this bug. And this PR is required for them to pass. But these tests are associated with adding tests for the new bool dtype, and other existing dtypes which did not have tests. 
