### PR TITLE
DOC: stats: add nanmean, nanstd and nanmedian to the stats module-level ...

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -188,6 +188,9 @@ which work for masked arrays.
    tmax              --
    tstd              --
    tsem              --
+   nanmean           -- Mean, ignoring NaN values
+   nanstd            -- Standard deviation, ignoring NaN values
+   nanmedian         -- Median, ignoring NaN values
    variation         -- Coefficient of variation
 
 .. autosummary::


### PR DESCRIPTION
...documentation.

This PR was motivated by the following question on stackoverflow:
http://stackoverflow.com/questions/16952836/scipy-stats-nanemean-documentation
