### PR TITLE
Bool support and tests

### DIFF
--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -9,10 +9,10 @@ __all__ = ['upcast','getdtype','isscalarlike','isintlike',
 import numpy as np
 
 # keep this list syncronized with sparsetools
-#supported_dtypes = ['int8', 'uint8', 'int16', 'uint16', 'int32', 'uint32',
+#supported_dtypes = ['bool', 'int8', 'uint8', 'int16', 'uint16', 'int32', 'uint32',
 #        'int64', 'uint64', 'float32', 'float64',
 #        'complex64', 'complex128']
-supported_dtypes = ['int8','uint8','short','ushort','intc','uintc',
+supported_dtypes = ['bool', 'int8','uint8','short','ushort','intc','uintc',
         'longlong','ulonglong','single','double','longdouble',
         'csingle','cdouble','clongdouble']
 supported_dtypes = [np.typeDict[x] for x in supported_dtypes]
@@ -32,7 +32,7 @@ def upcast(*args):
     >>> upcast('int32')
     <type 'numpy.int32'>
     >>> upcast('bool')
-    <type 'numpy.int8'>
+    <type 'numpy.bool_'>
     >>> upcast('int32','float32')
     <type 'numpy.float64'>
     >>> upcast('bool',complex,float)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -198,10 +198,13 @@ class _TestCommon:
         assert_array_almost_equal((sNexp - Nexp), zeros((3, 3)))
 
     def test_inv(self):
-        M = array([[1, 0, 2], [0, 0, 3], [-4, 5, 6]], float)
-        sM = self.spmatrix(M, shape=(3,3), dtype=float)
-        sMinv = inv(sM)
-        assert_array_almost_equal(sMinv.dot(sM).todense(), np.eye(3))
+        def check(dtype):
+            M = array([[1, 0, 2], [0, 0, 3], [-4, 5, 6]], dtype)
+            sM = self.spmatrix(M, shape=(3,3), dtype=dtype)
+            sMinv = inv(sM)
+            assert_array_almost_equal(sMinv.dot(sM).todense(), np.eye(3))
+        for dtype in [ float, bool ]:
+            yield check, dtype
 
     def test_from_array(self):
         A = array([[1,0,0],[2,3,4],[0,5,0],[0,0,0]])
@@ -350,6 +353,8 @@ class _TestCommon:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=np.ComplexWarning)
 
+            # Note this is global supported_dtypes imported from 
+            # sputils, not self.suppoted_dtypes.
             for x in supported_dtypes:
                 assert_equal(S.astype(x).dtype, D.astype(x).dtype)  # correct type
                 assert_equal(S.astype(x).toarray(), D.astype(x))        # correct values
@@ -1467,6 +1472,8 @@ class _TestArithmetic:
         assert_array_equal((self.__Asp+self.__Bsp).todense(),self.__A+self.__B)
 
         # check conversions
+        # Note this is global supported_dtypes imported from sputils, 
+        # not self.suppoted_dtypes.
         for x in supported_dtypes:
             A = self.__A.astype(x)
             Asp = self.spmatrix(A)
@@ -1501,6 +1508,8 @@ class _TestArithmetic:
         # basic tests
         assert_array_equal((self.__Asp*self.__Bsp.T).todense(),self.__A*self.__B.T)
 
+        # Note this is global supported_dtypes imported from sputils, 
+        # not self.suppoted_dtypes.
         for x in supported_dtypes:
             A = self.__A.astype(x)
             Asp = self.spmatrix(A)
@@ -1639,7 +1648,7 @@ def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
 class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False,
                                 fancy_multidim_indexing=False)):
     spmatrix = csr_matrix
-    supported_dtypes = [ np.typeDict[x] for x in [ 'int', 'float' ] ]
+    supported_dtypes = [ np.typeDict[x] for x in [ 'bool', 'int', 'float' ] ]
 
     def test_constructor1(self):
         b = matrix([[0,4,0],
@@ -1778,7 +1787,7 @@ class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False,
 class TestCSC(sparse_test_class(slicing_assign=False, fancy_assign=False,
                                 fancy_multidim_indexing=False)):
     spmatrix = csc_matrix
-    supported_dtypes = [ np.typeDict[x] for x in [ 'int', 'float' ] ]
+    supported_dtypes = [ np.typeDict[x] for x in [ 'bool', 'int', 'float' ] ]
 
     def test_constructor1(self):
         b = matrix([[1,0,0,0],[0,0,1,0],[0,2,0,3]],'d')

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -56,7 +56,7 @@ warnings.simplefilter('ignore', ComplexWarning)
 # TODO test has_sorted_indices
 class _TestCommon:
     """test common functionality shared by all sparse formats"""
-    supported_dtypes = supported_dtypes
+    checked_dtypes = supported_dtypes
 
     def __init__(self):
         # Cannonical data.
@@ -67,7 +67,7 @@ class _TestCommon:
         # dtype.
         self.dat_dtypes = {}
         self.datsp_dtypes = {}
-        for dtype in self.supported_dtypes:
+        for dtype in self.checked_dtypes:
             self.dat_dtypes[dtype] = self.dat.astype(dtype)
             self.datsp_dtypes[dtype] = self.spmatrix(self.dat.astype(dtype))
 
@@ -171,7 +171,7 @@ class _TestCommon:
             assert_array_equal(dat.sum(axis=None), datsp.sum(axis=None))
             assert_almost_equal(dat.sum(axis=0), datsp.sum(axis=0))
             assert_almost_equal(dat.sum(axis=1), datsp.sum(axis=1))
-        for dtype in self.supported_dtypes:
+        for dtype in self.checked_dtypes:
             yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_mean(self):
@@ -181,7 +181,7 @@ class _TestCommon:
             assert_array_equal(dat.mean(axis=None), datsp.mean(axis=None))
             assert_almost_equal(dat.mean(axis=0), datsp.mean(axis=0))
             assert_almost_equal(dat.mean(axis=1), datsp.mean(axis=1))
-        for dtype in self.supported_dtypes:
+        for dtype in self.checked_dtypes:
             yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_expm(self):
@@ -353,8 +353,6 @@ class _TestCommon:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=np.ComplexWarning)
 
-            # Note this is global supported_dtypes imported from
-            # sputils, not self.suppoted_dtypes.
             for x in supported_dtypes:
                 assert_equal(S.astype(x).dtype, D.astype(x).dtype)  # correct type
                 assert_equal(S.astype(x).toarray(), D.astype(x))        # correct values
@@ -378,7 +376,7 @@ class _TestCommon:
             assert_array_equal(dat*2,(datsp*2).todense())
             assert_array_equal(dat*17.3,(datsp*17.3).todense())
 
-        for dtype in self.supported_dtypes:
+        for dtype in self.checked_dtypes:
             fails = ((dtype == np.typeDict['int']) and 
                     (self.__class__ == TestLIL or
                      self.__class__ == TestDOK))
@@ -392,7 +390,7 @@ class _TestCommon:
             assert_array_equal(2*dat,(2*datsp).todense())
             assert_array_equal(17.3*dat,(17.3*datsp).todense())
 
-        for dtype in self.supported_dtypes:
+        for dtype in self.checked_dtypes:
             fails = ((dtype == np.typeDict['int']) and 
                     (self.__class__ == TestLIL or
                      self.__class__ == TestDOK))
@@ -409,7 +407,7 @@ class _TestCommon:
             c = b + a
             assert_array_equal(c, b.todense() + a)
 
-        for dtype in self.supported_dtypes:
+        for dtype in self.checked_dtypes:
             yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_radd(self):
@@ -420,7 +418,7 @@ class _TestCommon:
             c = a + b
             assert_array_equal(c, a + b.todense())
 
-        for dtype in self.supported_dtypes:
+        for dtype in self.checked_dtypes:
             yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_sub(self):
@@ -431,7 +429,7 @@ class _TestCommon:
             assert_array_equal((datsp - A).todense(),dat - A.todense())
             assert_array_equal((A - datsp).todense(),A.todense() - dat)
 
-        for dtype in self.supported_dtypes:
+        for dtype in self.checked_dtypes:
             yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_rsub(self):
@@ -445,7 +443,7 @@ class _TestCommon:
             assert_array_equal(A.todense() - datsp,A.todense() - dat)
             assert_array_equal(datsp - A.todense(),dat - A.todense())
 
-        for dtype in self.supported_dtypes:
+        for dtype in self.checked_dtypes:
             yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_add0(self):
@@ -457,7 +455,7 @@ class _TestCommon:
             sumD = sum([k * dat for k in range(1, 3)])
             assert_almost_equal(sumS.todense(), sumD)
 
-        for dtype in self.supported_dtypes:
+        for dtype in self.checked_dtypes:
             yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_elementwise_multiply(self):
@@ -717,7 +715,7 @@ class _TestCommon:
 
             assert_array_equal(self.spmatrix((3,4)).T.todense(), zeros((4,3)))
 
-        for dtype in self.supported_dtypes:
+        for dtype in self.checked_dtypes:
             yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_add_dense(self):
@@ -728,7 +726,7 @@ class _TestCommon:
             sum2 = datsp + dat
             assert_array_equal(sum2, dat + dat)
 
-        for dtype in self.supported_dtypes:
+        for dtype in self.checked_dtypes:
             yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_sub_dense(self):
@@ -748,7 +746,7 @@ class _TestCommon:
                 sum2 = (datsp + datsp + datsp) - dat
                 assert_array_equal(sum2, dat + dat)
 
-        for dtype in self.supported_dtypes:
+        for dtype in self.checked_dtypes:
             yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_copy(self):
@@ -825,7 +823,7 @@ class _TestInplaceArithmetic:
             b *= 17.3
             assert_array_equal(b, a.todense())
 
-        for dtype in self.supported_dtypes:
+        for dtype in self.checked_dtypes:
             yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_idiv_scalar(self):
@@ -842,7 +840,7 @@ class _TestInplaceArithmetic:
             b /= 17.3
             assert_array_equal(b, a.todense())
 
-        for dtype in self.supported_dtypes:
+        for dtype in self.checked_dtypes:
             yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
 
@@ -1549,8 +1547,6 @@ class _TestArithmetic:
         assert_array_equal((self.__Asp+self.__Bsp).todense(),self.__A+self.__B)
 
         # check conversions
-        # Note this is global supported_dtypes imported from sputils,
-        # not self.suppoted_dtypes.
         for x in supported_dtypes:
             A = self.__A.astype(x)
             Asp = self.spmatrix(A)
@@ -1585,8 +1581,6 @@ class _TestArithmetic:
         # basic tests
         assert_array_equal((self.__Asp*self.__Bsp.T).todense(),self.__A*self.__B.T)
 
-        # Note this is global supported_dtypes imported from sputils,
-        # not self.suppoted_dtypes.
         for x in supported_dtypes:
             A = self.__A.astype(x)
             Asp = self.spmatrix(A)
@@ -1725,7 +1719,7 @@ def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
 class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False,
                                 fancy_multidim_indexing=False)):
     spmatrix = csr_matrix
-    supported_dtypes = [np.typeDict[x] for x in ['bool', 'int', 'float']]
+    checked_dtypes = [np.typeDict[x] for x in ['bool', 'int', 'float']]
 
     def test_constructor1(self):
         b = matrix([[0,4,0],
@@ -1864,7 +1858,7 @@ class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False,
 class TestCSC(sparse_test_class(slicing_assign=False, fancy_assign=False,
                                 fancy_multidim_indexing=False)):
     spmatrix = csc_matrix
-    supported_dtypes = [np.typeDict[x] for x in ['bool', 'int', 'float']]
+    checked_dtypes = [np.typeDict[x] for x in ['bool', 'int', 'float']]
 
     def test_constructor1(self):
         b = matrix([[1,0,0,0],[0,0,1,0],[0,2,0,3]],'d')
@@ -1991,7 +1985,7 @@ class TestDOK(sparse_test_class(slicing=False,
                                 fancy_assign=False,
                                 minmax=False)):
     spmatrix = dok_matrix
-    supported_dtypes = [np.typeDict[x] for x in ['int', 'float']]
+    checked_dtypes = [np.typeDict[x] for x in ['int', 'float']]
 
     def test_mult(self):
         A = dok_matrix((10,10))
@@ -2136,7 +2130,7 @@ class TestDOK(sparse_test_class(slicing=False,
 
 class TestLIL(sparse_test_class(minmax=False)):
     spmatrix = lil_matrix
-    supported_dtypes = [np.typeDict[x] for x in ['int', 'float']]
+    checked_dtypes = [np.typeDict[x] for x in ['int', 'float']]
 
     def test_dot(self):
         A = matrix(zeros((10,10)))
@@ -2249,7 +2243,7 @@ class TestCOO(sparse_test_class(getset=False,
                                 slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False)):
     spmatrix = coo_matrix
-    supported_dtypes = [np.typeDict[x] for x in ['int', 'float']]
+    checked_dtypes = [np.typeDict[x] for x in ['int', 'float']]
 
     def test_constructor1(self):
         # unsorted triplet format
@@ -2310,7 +2304,7 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
                                 fancy_indexing=False, fancy_assign=False,
                                 minmax=False)):
     spmatrix = dia_matrix
-    supported_dtypes = [np.typeDict[x] for x in ['int', 'float']]
+    checked_dtypes = [np.typeDict[x] for x in ['int', 'float']]
 
     def test_constructor1(self):
         D = matrix([[1, 0, 3, 0],
@@ -2330,7 +2324,7 @@ class TestBSR(sparse_test_class(getset=False,
                                 slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False)):
     spmatrix = bsr_matrix
-    supported_dtypes = [np.typeDict[x] for x in ['int', 'float']]
+    checked_dtypes = [np.typeDict[x] for x in ['int', 'float']]
 
     def test_constructor1(self):
         # check native BSR format constructor

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -58,6 +58,7 @@ class _TestCommon:
     """test common functionality shared by all sparse formats"""
 
     def __init__(self):
+        self.supported_dtypes = supported_dtypes
         # Cannonical data.
         self.dat = matrix([[1,0,0,2],[3,0,1,0],[0,2,0,0]],'d')
         self.datsp = self.spmatrix(self.dat)
@@ -66,7 +67,7 @@ class _TestCommon:
         # dtype.
         self.dat_dtypes = {}
         self.datsp_dtypes = {}
-        for dtype in supported_dtypes:
+        for dtype in self.supported_dtypes:
             self.dat_dtypes[dtype] = self.dat.astype(dtype)
             self.datsp_dtypes[dtype] = self.spmatrix(self.dat.astype(dtype))
 
@@ -170,9 +171,8 @@ class _TestCommon:
             assert_array_equal(dat.sum(axis=None), datsp.sum(axis=None))
             assert_almost_equal(dat.sum(axis=0), datsp.sum(axis=0))
             assert_almost_equal(dat.sum(axis=1), datsp.sum(axis=1))
-        for dat, datsp in zip(self.dat_dtypes.values(),
-                              self.datsp_dtypes.values()):
-            yield check, dat, datsp
+        for dtype in self.supported_dtypes:
+            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_mean(self):
         def check(dat, datsp):
@@ -181,9 +181,8 @@ class _TestCommon:
             assert_array_equal(dat.mean(axis=None), datsp.mean(axis=None))
             assert_almost_equal(dat.mean(axis=0), datsp.mean(axis=0))
             assert_almost_equal(dat.mean(axis=1), datsp.mean(axis=1))
-        for dat, datsp in zip(self.dat_dtypes.values(),
-                              self.datsp_dtypes.values()):
-            yield check, dat, datsp
+        for dtype in self.supported_dtypes:
+            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_expm(self):
         M = array([[1, 0, 2], [0, 0, 3], [-4, 5, 6]], float)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -203,7 +203,7 @@ class _TestCommon:
             sM = self.spmatrix(M, shape=(3,3), dtype=dtype)
             sMinv = inv(sM)
             assert_array_almost_equal(sMinv.dot(sM).todense(), np.eye(3))
-        for dtype in [ float, bool ]:
+        for dtype in [float, bool]:
             yield check, dtype
 
     def test_from_array(self):
@@ -353,7 +353,7 @@ class _TestCommon:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=np.ComplexWarning)
 
-            # Note this is global supported_dtypes imported from 
+            # Note this is global supported_dtypes imported from
             # sputils, not self.suppoted_dtypes.
             for x in supported_dtypes:
                 assert_equal(S.astype(x).dtype, D.astype(x).dtype)  # correct type
@@ -380,10 +380,10 @@ class _TestCommon:
 
         for dtype in self.supported_dtypes:
             if (dtype == np.typeDict['int']) and (
-                    (self.__class__.__name__ == "TestLIL") or 
+                    (self.__class__.__name__ == "TestLIL") or
                     (self.__class__.__name__ == "TestDOK")):
                 yield dec.knownfailureif(
-                        True, 
+                        True,
                         "LIL and DOK type's __mul__ method has problems with int data."
                         )(check)
                 continue
@@ -393,13 +393,13 @@ class _TestCommon:
         def check(dat, datsp):
             assert_array_equal(2*dat,(2*datsp).todense())
             assert_array_equal(17.3*dat,(17.3*datsp).todense())
-        
+
         for dtype in self.supported_dtypes:
             if (dtype == np.typeDict['int']) and (
-                    (self.__class__.__name__ == "TestLIL") or 
+                    (self.__class__.__name__ == "TestLIL") or
                     (self.__class__.__name__ == "TestDOK")):
                 yield dec.knownfailureif(
-                        True, 
+                        True,
                         "LIL and DOK type's __rmul__ method has problems with int data."
                         )(check)
                 continue
@@ -1553,7 +1553,7 @@ class _TestArithmetic:
         assert_array_equal((self.__Asp+self.__Bsp).todense(),self.__A+self.__B)
 
         # check conversions
-        # Note this is global supported_dtypes imported from sputils, 
+        # Note this is global supported_dtypes imported from sputils,
         # not self.suppoted_dtypes.
         for x in supported_dtypes:
             A = self.__A.astype(x)
@@ -1589,7 +1589,7 @@ class _TestArithmetic:
         # basic tests
         assert_array_equal((self.__Asp*self.__Bsp.T).todense(),self.__A*self.__B.T)
 
-        # Note this is global supported_dtypes imported from sputils, 
+        # Note this is global supported_dtypes imported from sputils,
         # not self.suppoted_dtypes.
         for x in supported_dtypes:
             A = self.__A.astype(x)
@@ -1729,7 +1729,7 @@ def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
 class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False,
                                 fancy_multidim_indexing=False)):
     spmatrix = csr_matrix
-    supported_dtypes = [ np.typeDict[x] for x in [ 'bool', 'int', 'float' ] ]
+    supported_dtypes = [np.typeDict[x] for x in ['bool', 'int', 'float']]
 
     def test_constructor1(self):
         b = matrix([[0,4,0],
@@ -1868,7 +1868,7 @@ class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False,
 class TestCSC(sparse_test_class(slicing_assign=False, fancy_assign=False,
                                 fancy_multidim_indexing=False)):
     spmatrix = csc_matrix
-    supported_dtypes = [ np.typeDict[x] for x in [ 'bool', 'int', 'float' ] ]
+    supported_dtypes = [np.typeDict[x] for x in ['bool', 'int', 'float']]
 
     def test_constructor1(self):
         b = matrix([[1,0,0,0],[0,0,1,0],[0,2,0,3]],'d')
@@ -1995,7 +1995,7 @@ class TestDOK(sparse_test_class(slicing=False,
                                 fancy_assign=False,
                                 minmax=False)):
     spmatrix = dok_matrix
-    supported_dtypes = [ np.typeDict[x] for x in [ 'int', 'float' ] ]
+    supported_dtypes = [np.typeDict[x] for x in ['int', 'float']]
 
     def test_mult(self):
         A = dok_matrix((10,10))
@@ -2140,7 +2140,7 @@ class TestDOK(sparse_test_class(slicing=False,
 
 class TestLIL(sparse_test_class(minmax=False)):
     spmatrix = lil_matrix
-    supported_dtypes = [ np.typeDict[x] for x in [ 'int', 'float' ] ]
+    supported_dtypes = [np.typeDict[x] for x in ['int', 'float']]
 
     def test_dot(self):
         A = matrix(zeros((10,10)))
@@ -2253,7 +2253,7 @@ class TestCOO(sparse_test_class(getset=False,
                                 slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False)):
     spmatrix = coo_matrix
-    supported_dtypes = [ np.typeDict[x] for x in [ 'int', 'float' ] ]
+    supported_dtypes = [np.typeDict[x] for x in ['int', 'float']]
 
     def test_constructor1(self):
         # unsorted triplet format
@@ -2314,7 +2314,7 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
                                 fancy_indexing=False, fancy_assign=False,
                                 minmax=False)):
     spmatrix = dia_matrix
-    supported_dtypes = [ np.typeDict[x] for x in [ 'int', 'float' ] ]
+    supported_dtypes = [np.typeDict[x] for x in ['int', 'float']]
 
     def test_constructor1(self):
         D = matrix([[1, 0, 3, 0],
@@ -2334,7 +2334,7 @@ class TestBSR(sparse_test_class(getset=False,
                                 slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False)):
     spmatrix = bsr_matrix
-    supported_dtypes = [ np.typeDict[x] for x in [ 'int', 'float' ] ]
+    supported_dtypes = [np.typeDict[x] for x in ['int', 'float']]
 
     def test_constructor1(self):
         # check native BSR format constructor

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -58,8 +58,23 @@ class _TestCommon:
     """test common functionality shared by all sparse formats"""
 
     def __init__(self):
+        # Cannonical data.
         self.dat = matrix([[1,0,0,2],[3,0,1,0],[0,2,0,0]],'d')
         self.datsp = self.spmatrix(self.dat)
+
+        # Some sparse and dense matrices with data for every supported
+        # dtype.
+        self.dat_dtypes = {}
+        self.datsp_dtypes = {}
+        for dtype in supported_dtypes:
+            self.dat_dtypes[dtype] = self.dat.astype(dtype)
+            self.datsp_dtypes[dtype] = self.spmatrix(self.dat.astype(dtype))
+
+        # Check that the original data is equivalent to the
+        # corresponding dat_dtypes & datsp_dtypes.
+        assert_equal(self.dat, self.dat_dtypes[np.float64])
+        assert_equal(self.datsp.todense(),
+                     self.datsp_dtypes[np.float64].todense())
 
     def test_empty(self):
         # create empty matrices
@@ -149,18 +164,26 @@ class _TestCommon:
         assert_array_equal(self.datsp.getcol(-1).todense(), self.dat[:,-1])
 
     def test_sum(self):
-        # Does the matrix's .sum(axis=...) method work?
-        assert_array_equal(self.dat.sum(), self.datsp.sum())
-        assert_array_equal(self.dat.sum(axis=None), self.datsp.sum(axis=None))
-        assert_array_equal(self.dat.sum(axis=0), self.datsp.sum(axis=0))
-        assert_array_equal(self.dat.sum(axis=1), self.datsp.sum(axis=1))
+        def check(dat, datsp):
+            # Does the matrix's .sum(axis=...) method work?
+            assert_array_equal(dat.sum(), datsp.sum())
+            assert_array_equal(dat.sum(axis=None), datsp.sum(axis=None))
+            assert_almost_equal(dat.sum(axis=0), datsp.sum(axis=0))
+            assert_almost_equal(dat.sum(axis=1), datsp.sum(axis=1))
+        for dat, datsp in zip(self.dat_dtypes.values(),
+                              self.datsp_dtypes.values()):
+            yield check, dat, datsp
 
     def test_mean(self):
-        # Does the matrix's .mean(axis=...) method work?
-        assert_array_equal(self.dat.mean(), self.datsp.mean())
-        assert_array_equal(self.dat.mean(axis=None), self.datsp.mean(axis=None))
-        assert_array_equal(self.dat.mean(axis=0), self.datsp.mean(axis=0))
-        assert_array_equal(self.dat.mean(axis=1), self.datsp.mean(axis=1))
+        def check(dat, datsp):
+            # Does the matrix's .mean(axis=...) method work?
+            assert_array_equal(dat.mean(), datsp.mean())
+            assert_array_equal(dat.mean(axis=None), datsp.mean(axis=None))
+            assert_almost_equal(dat.mean(axis=0), datsp.mean(axis=0))
+            assert_almost_equal(dat.mean(axis=1), datsp.mean(axis=1))
+        for dat, datsp in zip(self.dat_dtypes.values(),
+                              self.datsp_dtypes.values()):
+            yield check, dat, datsp
 
     def test_expm(self):
         M = array([[1, 0, 2], [0, 0, 3], [-4, 5, 6]], float)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -366,7 +366,10 @@ class _TestCommon:
         assert_(B is C)
 
     def test_mul_scalar(self):
-        def check(dat, datsp):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
             assert_array_equal(dat*2,(datsp*2).todense())
             assert_array_equal(dat*17.3,(datsp*17.3).todense())
 
@@ -375,12 +378,13 @@ class _TestCommon:
                     (self.__class__ == TestLIL or
                      self.__class__ == TestDOK))
             msg = "LIL and DOK type's __mul__ method has problems with int data."
-            yield (dec.knownfailureif(fails, msg)(check),
-                   self.dat_dtypes[dtype],
-                   self.datsp_dtypes[dtype])
+            yield dec.knownfailureif(fails, msg)(check), dtype
 
     def test_rmul_scalar(self):
-        def check(dat, datsp):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
             assert_array_equal(2*dat,(2*datsp).todense())
             assert_array_equal(17.3*dat,(17.3*datsp).todense())
 
@@ -389,12 +393,13 @@ class _TestCommon:
                     (self.__class__ == TestLIL or
                      self.__class__ == TestDOK))
             msg = "LIL and DOK type's __rmul__ method has problems with int data."
-            yield (dec.knownfailureif(fails, msg)(check),
-                   self.dat_dtypes[dtype],
-                   self.datsp_dtypes[dtype])
+            yield dec.knownfailureif(fails, msg)(check), dtype
 
     def test_add(self):
-        def check(dat, datsp):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
             a = dat.copy()
             a[0,2] = 2.0
             b = datsp
@@ -402,10 +407,13 @@ class _TestCommon:
             assert_array_equal(c, b.todense() + a)
 
         for dtype in self.checked_dtypes:
-            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
+            yield check, dtype
 
     def test_radd(self):
-        def check(dat, datsp):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
             a = self.dat.copy()
             a[0,2] = 2.0
             b = self.datsp
@@ -413,10 +421,13 @@ class _TestCommon:
             assert_array_equal(c, a + b.todense())
 
         for dtype in self.checked_dtypes:
-            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
+            yield check, dtype
 
     def test_sub(self):
-        def check(dat, datsp):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
             assert_array_equal((datsp - datsp).todense(),[[0,0,0,0],[0,0,0,0],[0,0,0,0]])
 
             A = self.spmatrix(matrix([[1,0,0,4],[-1,0,0,0],[0,8,0,-5]],'d'))
@@ -424,10 +435,13 @@ class _TestCommon:
             assert_array_equal((A - datsp).todense(),A.todense() - dat)
 
         for dtype in self.checked_dtypes:
-            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
+            yield check, dtype
 
     def test_rsub(self):
-        def check(dat, datsp):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
             assert_array_equal((dat - datsp),[[0,0,0,0],[0,0,0,0],[0,0,0,0]])
             assert_array_equal((datsp - dat),[[0,0,0,0],[0,0,0,0],[0,0,0,0]])
 
@@ -438,10 +452,13 @@ class _TestCommon:
             assert_array_equal(datsp - A.todense(),dat - A.todense())
 
         for dtype in self.checked_dtypes:
-            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
+            yield check, dtype
 
     def test_add0(self):
-        def check(dat, datsp):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
             # Adding 0 to a sparse matrix
             assert_array_equal((datsp + 0).todense(), dat)
             # use sum (which takes 0 as a starting value)
@@ -450,7 +467,7 @@ class _TestCommon:
             assert_almost_equal(sumS.todense(), sumD)
 
         for dtype in self.checked_dtypes:
-            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
+            yield check, dtype
 
     def test_elementwise_multiply(self):
         # real/real
@@ -701,7 +718,10 @@ class _TestCommon:
                     assert_equal(fn(blocksize=(X,Y)).todense(), A)
 
     def test_transpose(self):
-        def check(dat, datsp):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
             a = datsp.transpose()
             b = dat.transpose()
             assert_array_equal(a.todense(), b)
@@ -710,10 +730,13 @@ class _TestCommon:
             assert_array_equal(self.spmatrix((3,4)).T.todense(), zeros((4,3)))
 
         for dtype in self.checked_dtypes:
-            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
+            yield check, dtype
 
     def test_add_dense(self):
-        def check(dat, datsp):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
             # adding a dense matrix to a sparse matrix
             sum1 = dat + datsp
             assert_array_equal(sum1, dat + dat)
@@ -721,11 +744,14 @@ class _TestCommon:
             assert_array_equal(sum2, dat + dat)
 
         for dtype in self.checked_dtypes:
-            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
+            yield check, dtype
 
     def test_sub_dense(self):
         # subtracting a dense matrix to/from a sparse matrix
-        def check(dat, datsp):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
             # Behavior is different for bool.
             if dat.dtype == bool:
                 sum1 = dat - datsp
@@ -741,7 +767,7 @@ class _TestCommon:
                 assert_array_equal(sum2, dat + dat)
 
         for dtype in self.checked_dtypes:
-            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
+            yield check, dtype
 
     def test_copy(self):
         # Check whether the copy=True and copy=False keywords work
@@ -804,7 +830,10 @@ class _TestCommon:
 
 class _TestInplaceArithmetic:
     def test_imul_scalar(self):
-        def check(dat, datsp):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
             a = datsp.copy()
             a *= 2
             b = dat.copy()
@@ -818,10 +847,13 @@ class _TestInplaceArithmetic:
             assert_array_equal(b, a.todense())
 
         for dtype in self.checked_dtypes:
-            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
+            yield check, dtype
 
     def test_idiv_scalar(self):
-        def check(dat, datsp):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
             a = datsp.copy()
             a /= 2
             b = dat.copy()
@@ -835,7 +867,7 @@ class _TestInplaceArithmetic:
             assert_array_equal(b, a.todense())
 
         for dtype in self.checked_dtypes:
-            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
+            yield check, dtype
 
 
 class _TestGetSet:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1713,7 +1713,7 @@ def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
 class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False,
                                 fancy_multidim_indexing=False)):
     spmatrix = csr_matrix
-    checked_dtypes = [np.typeDict[x] for x in ['bool', 'int', 'float']]
+    checked_dtypes = [np.bool_, np.int_, np.float_]
 
     def test_constructor1(self):
         b = matrix([[0,4,0],
@@ -1852,7 +1852,7 @@ class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False,
 class TestCSC(sparse_test_class(slicing_assign=False, fancy_assign=False,
                                 fancy_multidim_indexing=False)):
     spmatrix = csc_matrix
-    checked_dtypes = [np.typeDict[x] for x in ['bool', 'int', 'float']]
+    checked_dtypes = [np.bool_, np.int_, np.float_]
 
     def test_constructor1(self):
         b = matrix([[1,0,0,0],[0,0,1,0],[0,2,0,3]],'d')

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -165,24 +165,18 @@ class _TestCommon:
         assert_array_equal(self.datsp.getcol(-1).todense(), self.dat[:,-1])
 
     def test_sum(self):
-        def check(dat, datsp):
-            # Does the matrix's .sum(axis=...) method work?
-            assert_array_equal(dat.sum(), datsp.sum())
-            assert_array_equal(dat.sum(axis=None), datsp.sum(axis=None))
-            assert_almost_equal(dat.sum(axis=0), datsp.sum(axis=0))
-            assert_almost_equal(dat.sum(axis=1), datsp.sum(axis=1))
-        for dtype in self.checked_dtypes:
-            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
+        # Does the matrix's .sum(axis=...) method work?
+        assert_array_equal(self.dat.sum(), self.datsp.sum())
+        assert_array_equal(self.dat.sum(axis=None), self.datsp.sum(axis=None))
+        assert_almost_equal(self.dat.sum(axis=0), self.datsp.sum(axis=0))
+        assert_almost_equal(self.dat.sum(axis=1), self.datsp.sum(axis=1))
 
     def test_mean(self):
-        def check(dat, datsp):
-            # Does the matrix's .mean(axis=...) method work?
-            assert_array_equal(dat.mean(), datsp.mean())
-            assert_array_equal(dat.mean(axis=None), datsp.mean(axis=None))
-            assert_almost_equal(dat.mean(axis=0), datsp.mean(axis=0))
-            assert_almost_equal(dat.mean(axis=1), datsp.mean(axis=1))
-        for dtype in self.checked_dtypes:
-            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
+        # Does the matrix's .mean(axis=...) method work?
+        assert_array_equal(self.dat.mean(), self.datsp.mean())
+        assert_array_equal(self.dat.mean(axis=None), self.datsp.mean(axis=None))
+        assert_almost_equal(self.dat.mean(axis=0), self.datsp.mean(axis=0))
+        assert_almost_equal(self.dat.mean(axis=1), self.datsp.mean(axis=1))
 
     def test_expm(self):
         M = array([[1, 0, 2], [0, 0, 3], [-4, 5, 6]], float)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -30,7 +30,7 @@ from numpy import arange, zeros, array, dot, matrix, asmatrix, asarray, \
 import random
 from numpy.testing import assert_raises, assert_equal, assert_array_equal, \
         assert_array_almost_equal, assert_almost_equal, assert_, \
-        dec, TestCase, run_module_suite
+        dec, run_module_suite
 
 import scipy.linalg
 
@@ -57,7 +57,7 @@ warnings.simplefilter('ignore', ComplexWarning)
 class _TestCommon:
     """test common functionality shared by all sparse formats"""
 
-    def setUp(self):
+    def __init__(self):
         self.dat = matrix([[1,0,0,2],[3,0,1,0],[0,2,0,0]],'d')
         self.datsp = self.spmatrix(self.dat)
 
@@ -484,11 +484,11 @@ class _TestCommon:
 
         # invalid exponents
         for exponent in [-1, 2.2, 1 + 3j]:
-            self.assertRaises(Exception, B.__pow__, exponent)
+            assert_raises(Exception, B.__pow__, exponent)
 
         # nonsquare matrix
         B = self.spmatrix(A[:3,:])
-        self.assertRaises(Exception, B.__pow__, 1)
+        assert_raises(Exception, B.__pow__, 1)
 
     def test_rmatvec(self):
         M = self.spmatrix(matrix([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))
@@ -1593,8 +1593,7 @@ def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
                                      fancy_indexing and fancy_multidim_indexing),
              _possibly_unimplemented(_TestFancyMultidimAssign,
                                      fancy_multidim_assign and fancy_assign),
-             _possibly_unimplemented(_TestMinMax, minmax),
-             TestCase)
+             _possibly_unimplemented(_TestMinMax, minmax))
 
     # check that test names do not clash
     names = {}

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -374,26 +374,49 @@ class _TestCommon:
         assert_(B is C)
 
     def test_mul_scalar(self):
-        assert_array_equal(self.dat*2,(self.datsp*2).todense())
-        assert_array_equal(self.dat*17.3,(self.datsp*17.3).todense())
+        def check(dat, datsp):
+            assert_array_equal(dat*2,(datsp*2).todense())
+            assert_array_equal(dat*17.3,(datsp*17.3).todense())
+
+        for dtype in self.supported_dtypes:
+            # TODO show somehow in testing that int data case is
+            # skipped.
+            if dtype == np.typeDict['int']:
+                continue
+            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_rmul_scalar(self):
-        assert_array_equal(2*self.dat,(2*self.datsp).todense())
-        assert_array_equal(17.3*self.dat,(17.3*self.datsp).todense())
+        def check(dat, datsp):
+            assert_array_equal(2*self.dat,(2*self.datsp).todense())
+            assert_array_equal(17.3*self.dat,(17.3*self.datsp).todense())
+        
+        for dtype in self.supported_dtypes:
+            # TODO show int is skipped.
+            if dtype == np.typeDict['int']:
+                continue
+            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_add(self):
-        a = self.dat.copy()
-        a[0,2] = 2.0
-        b = self.datsp
-        c = b + a
-        assert_array_equal(c,[[2,0,2,4],[6,0,2,0],[0,4,0,0]])
+        def check(dat, datsp):
+            a = dat.copy()
+            a[0,2] = 2.0
+            b = datsp
+            c = b + a
+            assert_array_equal(c, b.todense() + a)
+
+        for dtype in self.supported_dtypes:
+            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_radd(self):
-        a = self.dat.copy()
-        a[0,2] = 2.0
-        b = self.datsp
-        c = a + b
-        assert_array_equal(c,[[2,0,2,4],[6,0,2,0],[0,4,0,0]])
+        def check(dat, datsp):
+            a = self.dat.copy()
+            a[0,2] = 2.0
+            b = self.datsp
+            c = a + b
+            assert_array_equal(c, a + b.todense())
+
+        for dtype in self.supported_dtypes:
+            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_sub(self):
         assert_array_equal((self.datsp - self.datsp).todense(),[[0,0,0,0],[0,0,0,0],[0,0,0,0]])

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -379,20 +379,29 @@ class _TestCommon:
             assert_array_equal(dat*17.3,(datsp*17.3).todense())
 
         for dtype in self.supported_dtypes:
-            # TODO show somehow in testing that int data case is
-            # skipped.
-            if dtype == np.typeDict['int']:
+            if (dtype == np.typeDict['int']) and (
+                    (self.__class__.__name__ == "TestLIL") or 
+                    (self.__class__.__name__ == "TestDOK")):
+                yield dec.knownfailureif(
+                        True, 
+                        "LIL and DOK type's __mul__ method has problems with int data."
+                        )(check)
                 continue
             yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 
     def test_rmul_scalar(self):
         def check(dat, datsp):
-            assert_array_equal(2*self.dat,(2*self.datsp).todense())
-            assert_array_equal(17.3*self.dat,(17.3*self.datsp).todense())
+            assert_array_equal(2*dat,(2*datsp).todense())
+            assert_array_equal(17.3*dat,(17.3*datsp).todense())
         
         for dtype in self.supported_dtypes:
-            # TODO show int is skipped.
-            if dtype == np.typeDict['int']:
+            if (dtype == np.typeDict['int']) and (
+                    (self.__class__.__name__ == "TestLIL") or 
+                    (self.__class__.__name__ == "TestDOK")):
+                yield dec.knownfailureif(
+                        True, 
+                        "LIL and DOK type's __rmul__ method has problems with int data."
+                        )(check)
                 continue
             yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -56,9 +56,9 @@ warnings.simplefilter('ignore', ComplexWarning)
 # TODO test has_sorted_indices
 class _TestCommon:
     """test common functionality shared by all sparse formats"""
+    supported_dtypes = supported_dtypes
 
     def __init__(self):
-        self.supported_dtypes = supported_dtypes
         # Cannonical data.
         self.dat = matrix([[1,0,0,2],[3,0,1,0],[0,2,0,0]],'d')
         self.datsp = self.spmatrix(self.dat)
@@ -1639,6 +1639,7 @@ def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
 class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False,
                                 fancy_multidim_indexing=False)):
     spmatrix = csr_matrix
+    supported_dtypes = [ np.typeDict[x] for x in [ 'int', 'float' ] ]
 
     def test_constructor1(self):
         b = matrix([[0,4,0],
@@ -1777,6 +1778,7 @@ class TestCSR(sparse_test_class(slicing_assign=False, fancy_assign=False,
 class TestCSC(sparse_test_class(slicing_assign=False, fancy_assign=False,
                                 fancy_multidim_indexing=False)):
     spmatrix = csc_matrix
+    supported_dtypes = [ np.typeDict[x] for x in [ 'int', 'float' ] ]
 
     def test_constructor1(self):
         b = matrix([[1,0,0,0],[0,0,1,0],[0,2,0,3]],'d')
@@ -1903,6 +1905,7 @@ class TestDOK(sparse_test_class(slicing=False,
                                 fancy_assign=False,
                                 minmax=False)):
     spmatrix = dok_matrix
+    supported_dtypes = [ np.typeDict[x] for x in [ 'int', 'float' ] ]
 
     def test_mult(self):
         A = dok_matrix((10,10))
@@ -2047,6 +2050,7 @@ class TestDOK(sparse_test_class(slicing=False,
 
 class TestLIL(sparse_test_class(minmax=False)):
     spmatrix = lil_matrix
+    supported_dtypes = [ np.typeDict[x] for x in [ 'int', 'float' ] ]
 
     def test_dot(self):
         A = matrix(zeros((10,10)))
@@ -2159,6 +2163,7 @@ class TestCOO(sparse_test_class(getset=False,
                                 slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False)):
     spmatrix = coo_matrix
+    supported_dtypes = [ np.typeDict[x] for x in [ 'int', 'float' ] ]
 
     def test_constructor1(self):
         # unsorted triplet format
@@ -2219,6 +2224,7 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
                                 fancy_indexing=False, fancy_assign=False,
                                 minmax=False)):
     spmatrix = dia_matrix
+    supported_dtypes = [ np.typeDict[x] for x in [ 'int', 'float' ] ]
 
     def test_constructor1(self):
         D = matrix([[1, 0, 3, 0],
@@ -2238,6 +2244,7 @@ class TestBSR(sparse_test_class(getset=False,
                                 slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False)):
     spmatrix = bsr_matrix
+    supported_dtypes = [ np.typeDict[x] for x in [ 'int', 'float' ] ]
 
     def test_constructor1(self):
         # check native BSR format constructor

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -379,15 +379,13 @@ class _TestCommon:
             assert_array_equal(dat*17.3,(datsp*17.3).todense())
 
         for dtype in self.supported_dtypes:
-            if (dtype == np.typeDict['int']) and (
-                    (self.__class__.__name__ == "TestLIL") or
-                    (self.__class__.__name__ == "TestDOK")):
-                yield dec.knownfailureif(
-                        True,
-                        "LIL and DOK type's __mul__ method has problems with int data."
-                        )(check)
-                continue
-            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
+            fails = ((dtype == np.typeDict['int']) and 
+                    (self.__class__ == TestLIL or
+                     self.__class__ == TestDOK))
+            msg = "LIL and DOK type's __mul__ method has problems with int data."
+            yield (dec.knownfailureif(fails, msg)(check),
+                   self.dat_dtypes[dtype],
+                   self.datsp_dtypes[dtype])
 
     def test_rmul_scalar(self):
         def check(dat, datsp):
@@ -395,15 +393,13 @@ class _TestCommon:
             assert_array_equal(17.3*dat,(17.3*datsp).todense())
 
         for dtype in self.supported_dtypes:
-            if (dtype == np.typeDict['int']) and (
-                    (self.__class__.__name__ == "TestLIL") or
-                    (self.__class__.__name__ == "TestDOK")):
-                yield dec.knownfailureif(
-                        True,
-                        "LIL and DOK type's __rmul__ method has problems with int data."
-                        )(check)
-                continue
-            yield check, self.dat_dtypes[dtype], self.datsp_dtypes[dtype]
+            fails = ((dtype == np.typeDict['int']) and 
+                    (self.__class__ == TestLIL or
+                     self.__class__ == TestDOK))
+            msg = "LIL and DOK type's __rmul__ method has problems with int data."
+            yield (dec.knownfailureif(fails, msg)(check),
+                   self.dat_dtypes[dtype],
+                   self.datsp_dtypes[dtype])
 
     def test_add(self):
         def check(dat, datsp):


### PR DESCRIPTION
Adds bool as a `supported_dtype`. Adds a bunch arithmatic tests for the bool dtype by parameterizing old tests, to take different dtypes and data. 

Changes dtype of `.sum` and `.mean`'s accumulator, and automatically upcasts small dtypes like numpy does. Tests for this are included too, as they also test `.sum` & `.mean` with bool dtype.
