### PR TITLE
MAINT: stats: Use explicit formulas for the loggamma stats.

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -4434,8 +4434,8 @@ class loggamma_gen(rv_continuous):
         # Ping Shing Chan (thesis, McMaster University, 1993).
         mean = special.digamma(c)
         var = special.polygamma(1, c)
-        skewness = special.polygamma(2, c) / special.polygamma(1, c)**1.5
-        excess_kurtosis = special.polygamma(3, c) / special.polygamma(1, c)**2
+        skewness = special.polygamma(2, c) / var**1.5
+        excess_kurtosis = special.polygamma(3, c) / (var*var)
         return mean, var, skewness, excess_kurtosis
 
 loggamma = loggamma_gen(name='loggamma', shapes='c')

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -4429,9 +4429,15 @@ class loggamma_gen(rv_continuous):
     def _ppf(self, q, c):
         return log(special.gammaincinv(c,q))
 
-    def _munp(self,n,*args):
-        # use generic moment calculation using ppf
-        return self._mom0_sc(n,*args)
+    def _stats(self, c):
+        # See, for example, "A Statistical Study of Log-Gamma Distribution", by
+        # Ping Shing Chan (thesis, McMaster University, 1993).
+        mean = special.digamma(c)
+        var = special.polygamma(1, c)
+        skewness = special.polygamma(2, c) / special.polygamma(1, c)**1.5
+        excess_kurtosis = special.polygamma(3, c) / special.polygamma(1, c)**2
+        return mean, var, skewness, excess_kurtosis
+
 loggamma = loggamma_gen(name='loggamma', shapes='c')
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -311,7 +311,8 @@ class TestLoggamma(TestCase):
             ]).reshape(-1, 5)
         for c, mean, var, skew, kurt in table:
             computed = stats.loggamma.stats(c, moments='msvk')
-            assert_array_almost_equal(computed, [mean, var, skew, kurt], decimal=4)
+            assert_array_almost_equal(computed, [mean, var, skew, kurt],
+                                      decimal=4)
 
 
 class TestLogser(TestCase):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -297,6 +297,23 @@ class TestHypergeom(TestCase):
         assert_allclose(res2, expected2, atol=0, rtol=5e-7)
 
 
+class TestLoggamma(TestCase):
+
+    def test_stats(self):
+        # The following precomputed values are from the table in section 2.2
+        # of "A Statistical Study of Log-Gamma Distribution", by Ping Shing
+        # Chan (thesis, McMaster University, 1993).
+        table = np.array([
+                # c,      mean,     var,      skew,    exc. kurt.
+                 0.5,   -1.9635,   4.9348,  -1.5351,   4.0000,
+                 1.0,   -0.5772,   1.6449,  -1.1395,   2.4000,
+                12.0,    2.4427,   0.0869,  -0.2946,   0.1735,
+            ]).reshape(-1, 5)
+        for c, mean, var, skew, kurt in table:
+            computed = stats.loggamma.stats(c, moments='msvk')
+            assert_array_almost_equal(computed, [mean, var, skew, kurt], decimal=4)
+
+
 class TestLogser(TestCase):
     def test_rvs(self):
         vals = stats.logser.rvs(0.75, size=(2, 50))


### PR DESCRIPTION
The log-gamma distribution has explicit formulas for its moments, so use them.

This PR also gets rid of a RuntimeWarning that occurs when the stats tests are run.
