### PR TITLE
MAINT: stats: Simplified the calculation of Pearson's R.

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -370,21 +370,21 @@ def pearsonr(x,y):
     (mx, my) = (x.mean(), y.mean())
     (xm, ym) = (x-mx, y-my)
     #
-    r_num = n*(ma.add.reduce(xm*ym))
-    r_den = n*ma.sqrt(ma.dot(xm,xm)*ma.dot(ym,ym))
-    r = (r_num / r_den)
+    r_num = ma.add.reduce(xm*ym)
+    r_den = ma.sqrt(ma.dot(xm,xm) * ma.dot(ym,ym))
+    r = r_num / r_den
     # Presumably, if r > 1, then it is only some small artifact of floating
     # point arithmetic.
     r = min(r, 1.0)
     r = max(r, -1.0)
-    df = n-2
-    #
-    t = ma.sqrt(df/((1.0-r)*(1.0+r))) * r
-    if t is masked:
+    df = n - 2
+
+    if r is masked or abs(r) == 1.0:
         prob = 0.
     else:
-        prob = betai(0.5*df,0.5,df/(df+t*t))
-    return (r,prob)
+        t_squared = (df / ((1.0 - r) * (1.0 + r))) * r * r
+        prob = betai(0.5*df, 0.5, df/(df + t_squared))
+    return r, prob
 
 
 def spearmanr(x, y, use_ties=True):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2428,9 +2428,9 @@ def pearsonr(x, y):
     mx = x.mean()
     my = y.mean()
     xm, ym = x-mx, y-my
-    r_num = n*(np.add.reduce(xm*ym))
-    r_den = n*np.sqrt(ss(xm)*ss(ym))
-    r = (r_num / r_den)
+    r_num = np.add.reduce(xm * ym)
+    r_den = np.sqrt(ss(xm) * ss(ym))
+    r = r_num / r_den
 
     # Presumably, if abs(r) > 1, then it is only some small artifact of floating
     # point arithmetic.

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -343,6 +343,15 @@ class TestCorrPearsonr(TestCase):
         assert_equal(r, -1.0)
         assert_equal(prob, 0.0)
 
+    def test_basic(self):
+        # A basic test, with a correlation coefficient
+        # that is not 1 or -1.
+        a = array([-1, 0, 1])
+        b = array([0, 0, 3])
+        r, prob = stats.pearsonr(a, b)
+        assert_approx_equal(r, np.sqrt(3)/2)
+        assert_approx_equal(prob, 1.0/3)
+
 
 class TestFisherExact(TestCase):
     """Some tests to show that fisher_exact() works correctly.


### PR DESCRIPTION
- Removed the common factor 'n' from the numerator and denominator in
  the calculation of Pearson's R.  (Closes the issue gh-2512.)
- Added basic tests of pearsonr. (All the existing tests were for perfect
  correlation or anticorrelation.)
- Modified stats.mstats.pearsonr to not raise RuntimeWarnings when abs(r) == 1.
