### PR TITLE
ENH: stats: Add the power_divergence function that generalizes the chi-squared test statistic, and allow it to be used in chi2_contingency.

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -246,6 +246,7 @@ which work for masked arrays.
    ttest_rel
    kstest
    chisquare
+   power_divergence
    ks_2samp
    mannwhitneyu
    tiecorrect

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -57,6 +57,7 @@ import scipy.misc as misc
 # import scipy.stats.futil as futil
 from . import futil
 
+
 genmissingvaldoc = """
 Notes
 -----
@@ -797,159 +798,11 @@ def ttest_rel(a,b,axis=None):
 ttest_rel.__doc__ = stats.ttest_rel.__doc__
 
 
-def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
-    """
-    Calculates a one-way chi square test.
-
-    The chi square test tests the null hypothesis that the categorical data
-    has the given frequencies.
-
-    Parameters
-    ----------
-    f_obs : array
-        Observed frequencies in each category.
-    f_exp : array, optional
-        Expected frequencies in each category.  By default the categories are
-        assumed to be equally likely.
-    ddof : int, optional
-        "Delta degrees of freedom": adjustment to the degrees of freedom
-        for the p-value.  The p-value is computed using a chi-squared
-        distribution with ``k - 1 - ddof`` degrees of freedom, where `k`
-        is the number of observed frequencies.  The default value of `ddof`
-        is 0.
-    axis : int or None, optional
-        The axis of the broadcast result of `f_obs` and `f_exp` along which to
-        apply the test.  If axis is None, all values in `f_obs` are treated
-        as a single data set.  Default is 0.
-
-    Returns
-    -------
-    chisq : float or np.ma.masked_array
-        The chisquare test statistic.  The value is a float if `axis` is
-        None or `f_obs` and `f_exp` are 1-D.
-    p : float or np.ma.masked_array
-        The p-value of the test.  The value is a float if `ddof` and the
-        return value `chisq` are scalars.
-
-    Notes
-    -----
-    This test is invalid when the observed or expected frequencies in each
-    category are too small.  A typical rule is that all of the observed
-    and expected frequencies should be at least 5.
-    The default degrees of freedom, k-1, are for the case when no parameters
-    of the distribution are estimated. If p parameters are estimated by
-    efficient maximum likelihood then the correct degrees of freedom are
-    k-1-p. If the parameters are estimated in a different way, then the
-    dof can be between k-1-p and k-1. However, it is also possible that
-    the asymptotic distribution is not a chisquare, in which case this
-    test is not appropriate.
-
-    References
-    ----------
-    .. [1] Lowry, Richard.  "Concepts and Applications of Inferential
-           Statistics". Chapter 8. http://faculty.vassar.edu/lowry/ch8pt1.html
-
-    Examples
-    --------
-    When just `f_obs` is given, it is assumed that the expected frequencies
-    are uniform and given by the mean of the observed frequencies.
-
-    >>> chisquare([16, 18, 16, 14, 12, 12])
-    (2.0, 0.84914503608460956)
-
-    With `f_exp` the expected frequencies can be given.
-
-    >>> chisquare([16, 18, 16, 14, 12, 12], f_exp=[16, 16, 16, 16, 16, 8])
-    (3.5, 0.62338762774958223)
-
-    When `f_obs` is 2-D, by default the test is applied to each column.
-
-    >>> obs = np.array([[16, 18, 16, 14, 12, 12], [32, 24, 16, 28, 20, 24]]).T
-    >>> obs.shape
-    (6, 2)
-    >>> chisquare(obs)
-    (masked_array(data = [2.0 6.666666666666667],
-                 mask = [False False],
-           fill_value = 1e+20)
-    ,
-     masked_array(data = [ 0.84914504  0.24663415],
-                 mask = False,
-           fill_value = 1e+20)
-    )
-
-    By setting ``axis=None``, the test is applied to all data in the array,
-    which is equivalent to applying the test to the flattened array.
-
-    >>> chisquare(obs, axis=None)
-    (23.31034482758621, 0.015975692534127565)
-    >>> chisquare(obs.ravel())
-    (23.31034482758621, 0.015975692534127565)
-
-    `ddof` is the change to make to the default degrees of freedom.
-
-    >>> chisquare([16, 18, 16, 14, 12, 12], ddof=1)
-    (2.0, 0.73575888234288467)
-
-    The calculation of the p-values is done by broadcasting the
-    chi-squared statistic with `ddof`.
-
-    >>> chisquare([16, 18, 16, 14, 12, 12], ddof=[0,1,2])
-    (2.0, array([ 0.84914504,  0.73575888,  0.5724067 ]))
-
-    `f_obs` and `f_exp` are also broadcast.  In the following, `f_obs` has
-    shape (6,) and `f_exp` has shape (2, 6), so the result of broadcasting
-    `f_obs` and `f_exp` has shape (2, 6).  To compute the desired chi-squared
-    statistics, we use ``axis=1``:
-
-    >>> chisquare([16, 18, 16, 14, 12, 12],
-    ...           f_exp=[[16, 16, 16, 16, 16, 8], [8, 20, 20, 16, 12, 12]],
-    ...           axis=1)
-    (masked_array(data = [3.5 9.25],
-                 mask = [False False],
-           fill_value = 1e+20)
-    ,
-     masked_array(data = [ 0.62338763  0.09949846],
-                 mask = False,
-           fill_value = 1e+20)
-    )
-
-    """
-    f_obs = ma.asarray(f_obs)
-
-    if f_exp is not None:
-        f_exp = ma.asanyarray(f_exp)
-    else:
-        # Compute the equivalent of
-        #   f_exp = f_obs.mean(axis=axis, keepdims=True)
-        # Older versions of numpy do not have the 'keepdims' argument, so
-        # we have to do a little work to achieve the same result.
-        # Ignore 'invalid' errors so the edge case of data sets with length 0
-        # is handled without spurious warnings.
-        with np.errstate(invalid='ignore'):
-            f_exp = np.atleast_1d(f_obs.mean(axis=axis))
-        if axis is not None:
-            reduced_shape = list(f_obs.shape)
-            reduced_shape[axis] = 1
-            f_exp.shape = reduced_shape
-
-    # `w` is the array of terms that are summed along `axis` to create
-    # the chi-squared statistic.
-    w = (f_obs - f_exp)**2 / f_exp
-    chisq = ma.add.reduce(w, axis=axis)
-
-    # Compute the corresponding p values.
-    # Masked elements are ignored, so the data sets may have different
-    # lengths.  Use the `count` method to get the number of elements in
-    # each data set.
-    num_obs = w.count(axis=axis)
-    if isinstance(num_obs, np.ndarray) and num_obs.ndim == 0:
-        # In some cases, the `count` method returns a scalar array (e.g.
-        # np.array(3)), but we want a plain integer.
-        num_obs = int(num_obs)
-    ddof = np.asanyarray(ddof)
-    p = stats.chisqprob(chisq, num_obs - 1 - ddof)
-
-    return chisq, p
+# stats.chisquare works with masked arrays, so we don't need to
+# implement it here.
+# For backwards compatibilty, stats.chisquare is included in
+# the stats.mstats namespace.
+chisquare = stats.chisquare
 
 
 def mannwhitneyu(x,y, use_continuity=True):

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -5,7 +5,6 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 
-from collections import namedtuple
 import numpy as np
 from numpy import nan
 import numpy.ma as ma
@@ -15,8 +14,7 @@ import scipy.stats.mstats as mstats
 from scipy import stats
 from numpy.testing import TestCase, run_module_suite
 from numpy.ma.testutils import (assert_equal, assert_almost_equal,
-    assert_array_almost_equal, assert_array_almost_equal_nulp, assert_,
-    assert_array_equal)
+    assert_array_almost_equal, assert_array_almost_equal_nulp, assert_)
 
 
 class TestMquantiles(TestCase):
@@ -532,164 +530,6 @@ def test_plotting_positions():
     """Regression test for #1256"""
     pos = mstats.plotting_positions(np.arange(3), 0, 0)
     assert_array_almost_equal(pos.data, np.array([0.25, 0.5, 0.75]))
-
-
-def check_chisquare(f_obs, f_exp, ddof, axis, expected_chi2):
-    # Use this only for arrays that have no masked values.
-    f_obs = np.asarray(f_obs)
-    if axis is None:
-        num_obs = f_obs.size
-    else:
-        if axis == 'no':
-            use_axis = 0
-        else:
-            use_axis = axis
-        b = np.broadcast(f_obs, f_exp)
-        num_obs = b.shape[use_axis]
-
-    if axis == 'no':
-        chi2, p = mstats.chisquare(f_obs, f_exp=f_exp, ddof=ddof)
-    else:
-        chi2, p = mstats.chisquare(f_obs, f_exp=f_exp, ddof=ddof, axis=axis)
-    assert_array_equal(chi2, expected_chi2)
-
-    ddof = np.asarray(ddof)
-    expected_p = stats.chisqprob(expected_chi2, num_obs - 1 - ddof)
-    assert_array_equal(p, expected_p)
-
-    # Also compare to stats.chisquare
-    if axis == 'no':
-        stats_chisq, stats_p = stats.chisquare(f_obs, f_exp=f_exp, ddof=ddof)
-    else:
-        stats_chisq, stats_p = stats.chisquare(f_obs, f_exp=f_exp, ddof=ddof,
-                                               axis=axis)
-    assert_array_almost_equal(chi2, stats_chisq)
-    assert_array_almost_equal(p, stats_p)
-
-
-def test_chisquare():
-    # The data sets here are chosen so that the chi2 statistic
-    # can be calculated exactly, so a test for equality (rather than
-    # being numerically close) can be used.
-    Case = namedtuple('Case', ['f_obs', 'f_exp', 'ddof', 'axis',
-                                'expected_chi2'])
-    empty = np.array([[],[],[]])
-    data2da = np.array([[1, 4],
-                        [2, 8],
-                        [3, 12],
-                        [2, 8]])
-    data2db = np.array([[1, 2, 3, 2],
-                        [3, 2, 3, 0]])
-
-    # These cases use the default axis=0.
-    cases0 = [
-        # simple case, 1 data set:
-        Case(f_obs=[1,2,3,2], f_exp=None, ddof=0, axis=0,
-             expected_chi2=1.0),
-        # two simple data sets
-        Case(f_obs=data2da, f_exp=None, ddof=0, axis=0,
-             expected_chi2=[1.0, 4.0]),
-        # Edge case: one data set with length 0.
-        Case(f_obs=[], ddof=0, f_exp=None, axis=0, expected_chi2=0.0),
-        # Edge case: no data sets (data has shape (3,0)).
-        Case(f_obs=empty, f_exp=None, ddof=0, axis=0, expected_chi2=[]),
-        # Edge case: data has shape (0, 3) (3 data sets,
-        # but each has length 0).
-        Case(f_obs=empty.T, f_exp=None, ddof=0, axis=0,
-             expected_chi2=[0.0, 0.0, 0.0]),
-        # simple case, with scalar f_exp.
-        Case(f_obs=[1, 2, 3, 2], f_exp=2, ddof=0, axis=0,
-             expected_chi2=1.0),
-        # simple case with vector f_exp (uniform).
-        Case(f_obs=[1, 2, 3, 2], f_exp=[2, 2, 2, 2], ddof=0, axis=0,
-             expected_chi2=1.0),
-        # simple case with vector f_exp equal to f_obs.
-        Case(f_obs=[1, 2, 3, 2], f_exp=[1, 2, 3, 2], ddof=0, axis=0,
-             expected_chi2=0.0),
-        # 2-D data
-        Case(f_obs=data2db.T, f_exp=None, ddof=0, axis=0,
-             expected_chi2=[1.0, 3.0]),
-        Case(f_obs=data2db.T, f_exp=None, ddof=1, axis=0,
-             expected_chi2=[1.0, 3.0]),
-        # 2-D data, 1-D ddof
-        Case(f_obs=data2db.T, f_exp=None, ddof=[0,1], axis=0,
-             expected_chi2=[1.0, 3.0]),
-    ]
-    # All the cases in `cases0` have axis=0, which is the default value
-    # for the chisquare function.  Here we check each case twice, once
-    # in which the argument is not passed to chisquare (indicated by
-    # using the value 'no' in the call to check_chisquare), and again
-    # with the axis argument explicitly set to 0.
-    for case in cases0:
-        yield (check_chisquare, case.f_obs, case.f_exp, case.ddof, 'no',
-               case.expected_chi2)
-    for case in cases0:
-        yield (check_chisquare, case.f_obs, case.f_exp, case.ddof, 0,
-               case.expected_chi2)
-
-    # A few more cases, testing axis != 0 and basic broadcasting of
-    # f_obs and f_exp.
-    cases1 = [
-        Case(f_obs=data2da.T, f_exp=None, ddof=0, axis=1,
-             expected_chi2=[1.0, 4.0]),
-        Case(f_obs=data2db, f_exp=None, ddof=0, axis=None,
-             expected_chi2=[4.0]),
-        Case(f_obs=data2db.T, f_exp=None, ddof=0, axis=None,
-             expected_chi2=[4.0]),
-        Case(f_obs=[1,2,3,2], f_exp=[[1],[2]], ddof=0, axis=1,
-             expected_chi2=[6.0, 1.0]),
-    ]
-
-    for case in cases1:
-        yield (check_chisquare, case.f_obs, case.f_exp, case.ddof, case.axis,
-               case.expected_chi2)
-
-
-def test_chisquare_ddof_broadcasting():
-    # Test that ddof broadcasts correctly.
-
-    # obs has shape (4, 2).  We'll use the default axis=0, so chi2
-    # will have shape (2,).
-    obs = np.array([[1, 2, 3, 2], [3, 2, 2, 5]]).T
-
-    # ddof has shape (2, 1).  This is broadcast with chi2, so p will
-    # have shape (2,2).
-    ddof = np.array([[0], [1]])
-
-    chi2, p = mstats.chisquare(obs, ddof=ddof)
-    assert_array_equal(chi2, [1.0, 2.0])
-
-    chi20, p0 = mstats.chisquare(obs, ddof=ddof[0,0])
-    assert_array_equal(chi20, [1.0, 2.0])
-
-    chi21, p1 = mstats.chisquare(obs, ddof=ddof[1,0])
-    assert_array_equal(chi21, [1.0, 2.0])
-    assert_array_equal(p, np.vstack((p0, p1)))
-
-
-def test_chisquare_masked_arrays():
-    # The other tests were taken from the tests for stats.chisquare, so
-    # they don't test the function with masked arrays.  Here masked arrays
-    # are tested.
-    obs = np.array([[8, 8, 16, 32, -1], [-1, -1, 3, 4, 5]]).T
-    mask = np.array([[0, 0, 0, 0, 1], [1, 1, 0, 0, 0]]).T
-    mobs = ma.masked_array(obs, mask)
-    expected_chisq = np.array([24.0, 0.5])
-
-    chisq, p = mstats.chisquare(mobs)
-    assert_array_equal(chisq, expected_chisq)
-    assert_array_almost_equal(p, stats.chisqprob(expected_chisq, mobs.count(axis=0) - 1))
-
-    chisq, p = mstats.chisquare(mobs.T, axis=1)
-    assert_array_equal(chisq, expected_chisq)
-    assert_array_almost_equal(p, stats.chisqprob(expected_chisq, mobs.T.count(axis=1) - 1))
-
-    # When axis=None, the two values should have type np.float64.
-    chisq, p = mstats.chisquare([1,2,3], axis=None)
-    assert_(isinstance(chisq, np.float64))
-    assert_(isinstance(p, np.float64))
-    assert_equal(chisq, 1.0)
-    assert_almost_equal(p, stats.chisqprob(1.0, 2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
API enhancements:
- Added the new function `power_divergence` to `scipy.stats` that performs
  a goodnes of fit test using the Cressie-Read power divergence statistic.
  This family includes the log-likelihood ratio, which is also known as
  the G-test.
- Added the `lambda_` argument to `scipy.stats.chi2_contingency`, to allow
  the Cressie-Read family of statistics to be used in that test.

Refactoring:
- `stats.chisquare` is now a one-liner that calls `power_divergence`.
- `power_divergence` (and therefore `chisquare`) handles masked arrays,
  so `stats.mstats.chisquare` is now just another name for `stats.chisquare`.
