### PR TITLE
BUG: Homogenezie nnz type to be int for all sparse matrix types.

### DIFF
--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -264,7 +264,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
 
     def getnnz(self):
         R,C = self.blocksize
-        return self.indptr[-1] * R * C
+        return int(self.indptr[-1] * R * C)
     nnz = property(fget=getnnz)
 
     def __repr__(self):

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -84,7 +84,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin):
         self.check_format(full_check=False)
 
     def getnnz(self):
-        return self.indptr[-1]
+        return int(self.indptr[-1])
     nnz = property(fget=getnnz)
 
     def _set_self(self, other, copy=False):

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -199,7 +199,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         if np.rank(self.data) != 1 or np.rank(self.row) != 1 or np.rank(self.col) != 1:
             raise ValueError('row, column, and data arrays must have rank 1')
 
-        return nnz
+        return int(nnz)
     nnz = property(fget=getnnz)
 
     def _check(self):

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -160,7 +160,7 @@ class dia_matrix(_data_matrix):
                 nnz += min(M,N-k)
             else:
                 nnz += min(M+k,N)
-        return nnz
+        return int(nnz)
 
     nnz = property(fget=getnnz)
 


### PR DESCRIPTION
Now all nnz types are `int`, this fixes [issue 2574](https://github.com/scipy/scipy/issues/2574)

```
format = coo
getnnz type = <class 'int'>

format = bsr
getnnz type = <class 'int'>

format = csc
getnnz type = <class 'int'>

format = csr
getnnz type = <class 'int'>

format = dia
getnnz type = <class 'int'>

format = dok
getnnz type = <class 'int'>

format = lil
getnnz type = <class 'int'>
```
