### PR TITLE
DOC: docstring example in stats.distributions

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -6163,7 +6163,7 @@ class rv_discrete(rv_generic):
 
     To create a new discrete distribution, we would do the following::
 
-        class poisson_gen(rv_continuous):
+        class poisson_gen(rv_discrete):
             #"Poisson distribution"
             def _pmf(self, k, mu):
                 ...


### PR DESCRIPTION
inherit `poisson` from `rv_discrete` in a docstring example
