### PR TITLE
Test and fix for wrong result of spatial.cKDTree.sparse_distance_matrix

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -1965,7 +1965,7 @@ cdef class cKDTree:
                     if node1 == node2:
                         min_j = i+1
                     else:
-                        min_j = lnode2.end_idx
+                        min_j = lnode2.start_idx
                         
                     for j in range(min_j, lnode2.end_idx):
                         d = _distance_p(
@@ -1973,11 +1973,13 @@ cdef class cKDTree:
                             other.raw_data + other.raw_indices[j] * self.m,
                             tracker.p, self.m, tracker.upper_bound)
                         if d <= tracker.upper_bound:
+                            if tracker.p!=1 and tracker.p!=infinity:
+                                d = d**(1./tracker.p)
                             results.add(self.raw_indices[i],
-                                        self.raw_indices[j], d)
+                                        other.raw_indices[j], d)
                             if node1 == node2:
                                 results.add(self.raw_indices[j],
-                                            self.raw_indices[i], d)
+                                            other.raw_indices[i], d)
 
             else:  # 1 is a leaf node, 2 is inner node
                 tracker.push_less_of(2, node2)

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -553,7 +553,7 @@ class test_sparse_distance_matrix:
         m = 4
         self.T1 = KDTree(np.random.randn(n,m),leafsize=2)
         self.T2 = KDTree(np.random.randn(n,m),leafsize=2)
-        self.r = 0.3
+        self.r = 0.5
 
     def test_consistency_with_neighbors(self):
         M = self.T1.sparse_distance_matrix(self.T2, self.r)
@@ -573,9 +573,14 @@ class test_sparse_distance_matrix_compiled:
         n = 50
         m = 4
         np.random.seed(0)
-        self.T1 = cKDTree(np.random.randn(n,m),leafsize=2)
-        self.T2 = cKDTree(np.random.randn(n,m),leafsize=2)
-        self.r = 0.3
+        data1 = np.random.randn(n,m)
+        data2 = np.random.randn(n,m)
+        self.T1 = cKDTree(data1,leafsize=2)
+        self.T2 = cKDTree(data2,leafsize=2)
+        
+        self.ref_T1 = KDTree(data1, leafsize=2)
+        self.ref_T2 = KDTree(data2, leafsize=2)
+        self.r = 0.5
 
     def test_consistency_with_neighbors(self):
         M = self.T1.sparse_distance_matrix(self.T2, self.r)
@@ -589,6 +594,12 @@ class test_sparse_distance_matrix_compiled:
     def test_zero_distance(self):
         M = self.T1.sparse_distance_matrix(self.T1, self.r)  # raises an exception for bug 870 (FIXME: Does it?)
 
+    def test_consistecy_with_python(self):
+        M1 = self.T1.sparse_distance_matrix(self.T2, self.r)
+        M2 = self.ref_T1.sparse_distance_matrix(self.ref_T2, self.r)
+
+        assert_equal(M1, M2)
+    
 
 def test_distance_matrix():
     m = 10


### PR DESCRIPTION
First: cKDTree.sparse_distance_matrix was using wrong indexes to construct distance matrix. It was not caught in test case, because the search radius was to small. Fixed bug and changed radius in test case.

Second: After fixing above the results of KDTree and cKDTree.sparse_distance_matrix still weren't matching because KDTree reported distance and cKDTree distance**2. Fixed and added test for consistency between KDTree and cKDTree.sparse_distance_matrix.
