### PR TITLE
Fix the sparse bool wrapper.

### DIFF
--- a/scipy/sparse/sparsetools/bool_ops.h
+++ b/scipy/sparse/sparsetools/bool_ops.h
@@ -7,6 +7,42 @@
 
 #include <numpy/arrayobject.h>
 
-typedef npy_int8 npy_bool_wrapper;
+class npy_bool_wrapper {
+    public:
+        char value;
+        
+        /* operators */
+        operator char() const {
+            if(value != 0) {
+                return 1;
+            } else {
+                return 0;
+            }
+        }
+        npy_bool_wrapper& operator=(const npy_bool_wrapper& x) {
+            value = x;
+            return (*this);
+        }
+        npy_bool_wrapper operator+(const npy_bool_wrapper& x) {
+            return x || value ? 1 : 0;
+        }
+        /* inplace operators */
+        npy_bool_wrapper operator+=(const npy_bool_wrapper& x) {
+            value = x || value ? 1 : 0;
+            return (*this);
+        }
+        npy_bool_wrapper operator*=(const npy_bool_wrapper& x) {
+            value = value && x ? 1 : 0;
+            return (*this);
+        }
+        /* constructors */
+        npy_bool_wrapper() { 
+            value = 0; 
+        }
+        template <class T>
+        npy_bool_wrapper(T x) {
+            value = x ? 1 : 0;
+        }
+};
 
 #endif

--- a/scipy/sparse/sparsetools/bool_ops.h
+++ b/scipy/sparse/sparsetools/bool_ops.h
@@ -30,15 +30,15 @@ class npy_bool_wrapper {
             return (*this);
         }
         npy_bool_wrapper operator+(const npy_bool_wrapper& x) {
-            return x || value ? 1 : 0;
+            return (x || value) ? 1 : 0;
         }
         /* inplace operators */
         npy_bool_wrapper operator+=(const npy_bool_wrapper& x) {
-            value = x || value ? 1 : 0;
+            value = (x || value) ? 1 : 0;
             return (*this);
         }
         npy_bool_wrapper operator*=(const npy_bool_wrapper& x) {
-            value = value && x ? 1 : 0;
+            value = (value && x) ? 1 : 0;
             return (*this);
         }
         /* constructors */
@@ -47,7 +47,7 @@ class npy_bool_wrapper {
         }
         template <class T>
         npy_bool_wrapper(T x) {
-            value = x ? 1 : 0;
+            value = (x) ? 1 : 0;
         }
 };
 

--- a/scipy/sparse/sparsetools/bool_ops.h
+++ b/scipy/sparse/sparsetools/bool_ops.h
@@ -1,11 +1,15 @@
-#ifndef BOOL_OPS_H
-#define BOOL_OPS_H
-
 /*
  * Functions to handle arithmetic operations on NumPy Bool values.
  */
-
 #include <numpy/arrayobject.h>
+#include <assert.h>
+
+/*
+ * A compiler time (ct) assert macro from 
+ * http://www.pixelbeat.org/programming/gcc/static_assert.html
+ * This is used to assure that npy_bool_wrapper is the right size.
+ */
+#define ct_assert(e) extern char (*ct_assert(void)) [sizeof(char[1 - 2*!(e)])]
 
 class npy_bool_wrapper {
     public:
@@ -44,5 +48,7 @@ class npy_bool_wrapper {
             value = x ? 1 : 0;
         }
 };
+
+ct_assert(sizeof(char) == sizeof(npy_bool_wrapper));
 
 #endif

--- a/scipy/sparse/sparsetools/bool_ops.h
+++ b/scipy/sparse/sparsetools/bool_ops.h
@@ -1,3 +1,5 @@
+#ifndef BOOL_OPS_H
+#define BOOL_OPS_H
 /*
  * Functions to handle arithmetic operations on NumPy Bool values.
  */

--- a/scipy/sparse/sparsetools/sparsetools.i
+++ b/scipy/sparse/sparsetools/sparsetools.i
@@ -175,7 +175,7 @@ DECLARE_DATA_TYPE( npy_clongdouble_wrapper )
 
 %define INSTANTIATE_ALL( f_name )
 /* 32-bit indices */
-%template(f_name)   f_name<int, npy_bool_wrapper>;
+%template(f_name)   f_name<int,npy_bool_wrapper>;
 %template(f_name)   f_name<int,signed char>;
 %template(f_name)   f_name<int,unsigned char>;
 %template(f_name)   f_name<int,short>;

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -89,6 +89,18 @@ class _TestCommon:
             msg = "Cannot create a rank <= 2 DOK matrix."
             yield dec.skipif(fails, msg)(check), dtype
 
+    def test_bool_rollover(self):
+        """bool's underlying dtype is 1 byte, check that it does not 
+        rollover True -> False at 256.
+        """
+        dat = np.matrix([[True, False]])
+        datsp = self.spmatrix(dat)
+
+        for _ in range(10):
+            datsp = datsp + datsp
+            dat = dat + dat
+        assert_array_equal(dat, datsp.todense())
+
     def test_eq(self):
         def check(dtype):
             dat = self.dat_dtypes[dtype]


### PR DESCRIPTION
The bool dtype for sparse matrices is implemented as a typedef for int8, so True rolls over to False when the underlying int reaches 256. Like this:

```
In [2]: a = sp.csr_matrix([True, False])

In [3]: for _ in range(8):
   ...:     a = a + a
   ...:     print(a.todense())
   ...:     
[[ True False]]
[[ True False]]
[[ True False]]
[[ True False]]
[[ True False]]
[[ True False]]
[[ True False]]
[[False False]]        # <----- !
```

This PR creates a class for the bool dtype with the boolean arithmetic properly implemented so this does not happen.

However, this currently needs 2 things:
- An `assert(sizeof(char) == sizeof(npy_bool_wrapper))`
- Compiler parameters that guarantee this.

But as of now this corrects the problem with boolean arithmetic.
