### PR TITLE
BUG: linalg: bump ZGESDD RWORK work array size

### DIFF
--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -500,7 +500,7 @@ interface
    <ftype2c> dimension(u0,u1),intent(out),depend(u0,u1) :: u
    <ftype2c> dimension(vt0,vt1),intent(out),depend(vt0,vt1) :: vt
    <ftype2c> dimension(lwork),intent(hide,cache),depend(lwork) :: work
-   <ftype2> dimension((compute_uv?minmn*MAX(5*minmn+7, 2*MAX(m,n)+2*minmn+1):5*minmn)),intent(hide,cache),depend(minmn,compute_uv) :: rwork
+   <ftype2> dimension((compute_uv?minmn*MAX(5*minmn+7, 2*MAX(m,n)+2*minmn+1):7*minmn)),intent(hide,cache),depend(minmn,compute_uv) :: rwork
    integer optional,intent(in),depend(minmn,compute_uv) &
         :: lwork = (compute_uv?2*minmn*minmn+MAX(m,n)+2*minmn:2*minmn+MAX(m,n))
    check(lwork>=(compute_uv?2*minmn*minmn+MAX(m,n)+2*minmn:2*minmn+MAX(m,n))) :: lwork

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -927,6 +927,13 @@ class TestSVDVals(TestCase):
         assert_(len(s) == 3)
         assert_(s[0] >= s[1] >= s[2])
 
+    @dec.slow
+    def test_crash_2609(self):
+        np.random.seed(1234)
+        a = np.random.rand(1500, 2800)
+        # Shouldn't crash:
+        svdvals(a)
+
 
 class TestDiagSVD(TestCase):
 


### PR DESCRIPTION
The LAPACK documentation is apparently incorrect as the recommended 5*MIN(m,n) does not work.

Fixes gh-2609
