### PR TITLE
"linkage() function mistakes distance matrix as observation vectors"

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -465,7 +465,7 @@ def ward(y):
     return linkage(y, method='ward', metric='euclidean')
 
 
-def linkage(y, method='single', metric='euclidean'):
+def linkage(y, method='single', metric='euclidean', redundant_dm=False):
     """
     Performs hierarchical/agglomerative clustering on the condensed
     distance matrix y.
@@ -607,6 +607,8 @@ def linkage(y, method='single', metric='euclidean'):
     metric : str, optional
         The distance metric to use. See the ``distance.pdist`` function for a
         list of valid distance metrics.
+    redundant_dm: bool, optional
+        Boolean. True if y is a redundant distance matrix.
 
     Returns
     -------
@@ -640,7 +642,7 @@ def linkage(y, method='single', metric='euclidean'):
         if method not in _cpy_linkage_methods:
             raise ValueError('Invalid method: %s' % method)
         if method in _cpy_non_euclid_methods:
-            if distance.is_valid_dm(X): dm = distance.squareform(X)
+            if redundant_dm: dm = distance.squareform(X)
             else: dm = distance.pdist(X, metric)
             Z = np.zeros((n - 1, 4))
             _hierarchy_wrap.linkage_wrap(dm, Z, n,
@@ -649,7 +651,7 @@ def linkage(y, method='single', metric='euclidean'):
             if metric != 'euclidean':
                 raise ValueError(('Method %s requires the distance metric to '
                                  'be euclidean') % s)
-            if distance.is_valid_dm(X): dm = distance.squareform(X)
+            if redundant_dm: dm = distance.squareform(X)
             else: dm = distance.pdist(X, metric)
             Z = np.zeros((n - 1, 4))
             _hierarchy_wrap.linkage_euclid_wrap(dm, Z, X, m, n,

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -640,7 +640,8 @@ def linkage(y, method='single', metric='euclidean'):
         if method not in _cpy_linkage_methods:
             raise ValueError('Invalid method: %s' % method)
         if method in _cpy_non_euclid_methods:
-            dm = distance.pdist(X, metric)
+            if distance.is_valid_dm(X): dm = distance.squareform(X)
+            else: dm = distance.pdist(X, metric)
             Z = np.zeros((n - 1, 4))
             _hierarchy_wrap.linkage_wrap(dm, Z, n,
                                        int(_cpy_non_euclid_methods[method]))
@@ -648,7 +649,8 @@ def linkage(y, method='single', metric='euclidean'):
             if metric != 'euclidean':
                 raise ValueError(('Method %s requires the distance metric to '
                                  'be euclidean') % s)
-            dm = distance.pdist(X, metric)
+            if distance.is_valid_dm(X): dm = distance.squareform(X)
+            else: dm = distance.pdist(X, metric)
             Z = np.zeros((n - 1, 4))
             _hierarchy_wrap.linkage_euclid_wrap(dm, Z, X, m, n,
                                               int(_cpy_euclid_methods[method]))


### PR DESCRIPTION
this is to handle issue # 2614 ( scipy#2614 )
"linkage() function mistakes distance matrix as observation vectors"
If input to linkage() is a 2-dimensional matrix, it is first checked by predicate is_valid_dm(). If it is a distance matrix, it is converted to condensed vector. Otherwise it is considered to be observation vectors and condensed distance matrix is calculated using pdist() function.
