### PR TITLE
BUG (WIP): stats: Handle mu=0 correctly in poisson.pmf. Closes gh-2618.

### DIFF
--- a/scipy/special/cdflib/cdfpoi.f
+++ b/scipy/special/cdflib/cdfpoi.f
@@ -20,7 +20,7 @@ C     WHICH --> Integer indicating which  argument
 C               value is to be calculated from the others.
 C               Legal range: 1..3
 C               iwhich = 1 : Calculate P and Q from S and XLAM
-C               iwhich = 2 : Calculate A from P,Q and XLAM
+C               iwhich = 2 : Calculate S from P,Q and XLAM
 C               iwhich = 3 : Calculate XLAM from P,Q and S
 C                    INTEGER WHICH
 C
@@ -167,6 +167,11 @@ C     ..
           status = 0
 
       ELSE IF ((2).EQ. (which)) THEN
+          IF (XLAM .EQ. 0.0D0) THEN
+              s = 0.0D0
+              status = 0
+              GO TO 260
+          END IF
           s = 5.0D0
           CALL dstinv(0.0D0,inf,0.5D0,0.5D0,5.0D0,atol,tol)
           status = 0

--- a/scipy/special/cephes/pdtr.c
+++ b/scipy/special/cephes/pdtr.c
@@ -29,7 +29,7 @@
  *
  * y = pdtr( k, m ) = igamc( k+1, m ).
  *
- * The arguments must both be positive.
+ * The arguments must both be nonnegative.
  *
  *
  *
@@ -69,7 +69,7 @@
  *
  * y = pdtrc( k, m ) = igam( k+1, m ).
  *
- * The arguments must both be positive.
+ * The arguments must both be nonnegative.
  *
  *
  *
@@ -133,9 +133,12 @@ double m;
 {
     double v;
 
-    if ((k < 0) || (m <= 0.0)) {
-    mtherr("pdtrc", DOMAIN);
-    return (NPY_NAN);
+    if ((k < 0) || (m < 0.0)) {
+        mtherr("pdtrc", DOMAIN);
+        return (NPY_NAN);
+    }
+    if (m == 0.0) {
+        return 0.0;
     }
     v = k + 1;
     return (igam(v, m));
@@ -149,9 +152,12 @@ double m;
 {
     double v;
 
-    if ((k < 0) || (m <= 0.0)) {
-    mtherr("pdtr", DOMAIN);
-    return (NPY_NAN);
+    if ((k < 0) || (m < 0.0)) {
+        mtherr("pdtr", DOMAIN);
+        return (NPY_NAN);
+    }
+    if (m == 0.0) {
+        return 1.0;
     }
     v = k + 1;
     return (igamc(v, m));

--- a/scipy/special/cephes/pdtr.c
+++ b/scipy/special/cephes/pdtr.c
@@ -38,9 +38,9 @@
  * See igamc().
  *
  */
-/*							pdtrc()
+/*                         pdtrc()
  *
- *	Complemented poisson distribution
+ *  Complemented poisson distribution
  *
  *
  *
@@ -78,9 +78,9 @@
  * See igam.c.
  *
  */
-/*							pdtri()
+/*                         pdtri()
  *
- *	Inverse Poisson distribution
+ *  Inverse Poisson distribution
  *
  *
  *
@@ -134,8 +134,8 @@ double m;
     double v;
 
     if ((k < 0) || (m <= 0.0)) {
-	mtherr("pdtrc", DOMAIN);
-	return (NPY_NAN);
+    mtherr("pdtrc", DOMAIN);
+    return (NPY_NAN);
     }
     v = k + 1;
     return (igam(v, m));
@@ -150,8 +150,8 @@ double m;
     double v;
 
     if ((k < 0) || (m <= 0.0)) {
-	mtherr("pdtr", DOMAIN);
-	return (NPY_NAN);
+    mtherr("pdtr", DOMAIN);
+    return (NPY_NAN);
     }
     v = k + 1;
     return (igamc(v, m));
@@ -165,8 +165,8 @@ double y;
     double v;
 
     if ((k < 0) || (y < 0.0) || (y >= 1.0)) {
-	mtherr("pdtri", DOMAIN);
-	return (NPY_NAN);
+    mtherr("pdtri", DOMAIN);
+    return (NPY_NAN);
     }
     v = k + 1;
     v = igami(v, y);

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -665,6 +665,9 @@ class TestCephes(TestCase):
 
     def test_pdtrik(self):
         cephes.pdtrik(0.5,1)
+        # Edge case: m = 0
+        k = cephes.pdtrik([0.25, 0.75], 0)
+        assert_array_equal(k, [0, 0])
 
     def test_pro_ang1(self):
         cephes.pro_ang1(1,1,1,0)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -644,9 +644,15 @@ class TestCephes(TestCase):
 
     def test_pdtr(self):
         cephes.pdtr(0,1)
+        # Edge case: m = 0.
+        val = cephes.pdtr([0, 1, 2], 0.0)
+        assert_array_equal(val, [1, 1, 1])
 
     def test_pdtrc(self):
         cephes.pdtrc(0,1)
+        # Edge case: m = 0.
+        val = cephes.pdtrc([0, 1, 2], 0.0)
+        assert_array_equal(val, [0, 0, 0])
 
     def test_pdtri(self):
         warn_ctx = WarningManager()

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -7276,11 +7276,18 @@ class poisson_gen(rv_discrete):
     %(example)s
 
     """
+    # Override rv_discrete._argcheck to allow 0.
+    def _argcheck(self, *args):
+        cond = 1
+        for arg in args:
+            cond &= (arg >= 0)
+        return cond
+
     def _rvs(self, mu):
         return mtrand.poisson(mu, self._size)
 
     def _logpmf(self, k, mu):
-        Pk = k*log(mu)-gamln(k+1) - mu
+        Pk = special.xlogy(k, mu) - gamln(k + 1) - mu
         return Pk
 
     def _pmf(self, k, mu):

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -6504,8 +6504,8 @@ class rv_discrete(rv_generic):
         cond = cond0 & cond1
         output = valarray(shape(cond),value=self.badvalue,typecode='d')
         # output type 'd' to handle nin and inf
-        place(output,(q == 0)*(cond == cond), self.a-1)
-        place(output,cond2,self.b)
+        place(output,(q == 0)*(cond == cond), asarray(self.a-1).flat)
+        place(output, cond2, asarray(self.b).flat)
         if any(cond):
             goodargs = argsreduce(cond, *((q,)+args+(loc,)))
             loc, goodargs = goodargs[-1], goodargs[:-1]
@@ -6547,8 +6547,8 @@ class rv_discrete(rv_generic):
         # same problem as with ppf; copied from ppf and changed
         output = valarray(shape(cond),value=self.badvalue,typecode='d')
         # output type 'd' to handle nin and inf
-        place(output,(q == 0)*(cond == cond), self.b)
-        place(output,cond2,self.a-1)
+        place(output,(q == 0)*(cond == cond), asarray(self.b).flat)
+        place(output, cond2, asarray(self.a-1).flat)
 
         # call place only if at least 1 valid argument
         if any(cond):

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -7276,12 +7276,11 @@ class poisson_gen(rv_discrete):
     %(example)s
 
     """
-    # Override rv_discrete._argcheck to allow 0.
-    def _argcheck(self, *args):
-        cond = 1
-        for arg in args:
-            cond &= (arg >= 0)
-        return cond
+    # Override rv_discrete._argcheck to allow mu == 0.
+    def _argcheck(self, mu):
+        mu = asarray(mu)
+        self.b = np.where(mu > 0, inf, 0)
+        return mu >= 0
 
     def _rvs(self, mu):
         return mtrand.poisson(mu, self._size)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -14,6 +14,7 @@ import numpy as np
 from numpy import typecodes, array
 import scipy.stats as stats
 from scipy.stats.distributions import argsreduce
+from scipy import special
 from scipy.special import xlogy
 import warnings
 
@@ -491,6 +492,13 @@ class TestPoisson(TestCase):
         vals = stats.poisson.pmf([0, 1, 2], 0)
         expected = [1, 0, 0]
         assert_array_equal(vals, expected)
+
+    def test_pmf_broadcasting(self):
+        k = np.array([0, 1, 2, 3])
+        mu = k.reshape(-1, 1)
+        vals = stats.poisson.pmf(k, mu)
+        expected = mu**k * np.exp(-mu) / special.gamma(k + 1)
+        assert_allclose(vals, expected)
 
 
 class TestZipf(TestCase):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -487,18 +487,28 @@ class TestPoisson(TestCase):
         expected = [0.5, ln2/2, ln2**2/4]
         assert_allclose(vals, expected)
 
-    def test_pmf_edge(self):
-        # Edge case: mu=0
-        vals = stats.poisson.pmf([0, 1, 2], 0)
-        expected = [1, 0, 0]
-        assert_array_equal(vals, expected)
-
     def test_pmf_broadcasting(self):
         k = np.array([0, 1, 2, 3])
         mu = k.reshape(-1, 1)
         vals = stats.poisson.pmf(k, mu)
         expected = mu**k * np.exp(-mu) / special.gamma(k + 1)
         assert_allclose(vals, expected)
+
+    def test_mu_zero(self):
+        # Edge case: mu=0.
+        # In this case, the distribution should behave like
+        # the distribution rv_discrete(values=([0], [1]))
+        vals = stats.poisson.pmf([0, 1, 2], 0)
+        assert_array_equal(vals, [1, 0, 0])
+
+        vals = stats.poisson.cdf([0, 1, 2], 0)
+        assert_array_equal(vals, [1, 1, 1])
+
+        vals = stats.poisson.sf([0, 1, 2], 0)
+        assert_array_equal(vals, [0, 0, 0])
+
+        vals = stats.poisson.ppf([0, 0.25, 0.75, 1], 0)
+        assert_array_equal(vals, [-1, 0, 0, 0])
 
 
 class TestZipf(TestCase):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -479,6 +479,19 @@ class TestPoisson(TestCase):
         assert_(isinstance(val, numpy.ndarray))
         assert_(val.dtype.char in typecodes['AllInteger'])
 
+    def test_pmf_basic(self):
+        # Basic case
+        ln2 = np.log(2)
+        vals = stats.poisson.pmf([0, 1, 2], ln2)
+        expected = [0.5, ln2/2, ln2**2/4]
+        assert_allclose(vals, expected)
+
+    def test_pmf_edge(self):
+        # Edge case: mu=0
+        vals = stats.poisson.pmf([0, 1, 2], 0)
+        expected = [1, 0, 0]
+        assert_array_equal(vals, expected)
+
 
 class TestZipf(TestCase):
     def test_rvs(self):


### PR DESCRIPTION
_Work in progress; do not merge!_

This PR should close gh-2618.  The issue was fixed by changing `k*log(mu)` to `special.xlogy(k, mu)`, and by allowing mu=0 as an argument.
