### PR TITLE
BUG: orthogonal eval issue with use of uninitialized variable

### DIFF
--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -221,8 +221,8 @@ cdef inline double eval_gegenbauer_l(long n, double alpha, double x) nogil:
         p = 0
         for kk in range(a+1):
             p += d
-            d *= -4*x**2 * (a - k) * (-a + alpha + k + n) / (
-                (n + 1 - 2*a + 2*k) * (n + 2 - 2*a + 2*k))
+            d *= -4*x**2 * (a - kk) * (-a + alpha + kk + n) / (
+                (n + 1 - 2*a + 2*kk) * (n + 2 - 2*a + 2*kk))
             if fabs(d) == 1e-20*fabs(p):
                 # converged
                 break
@@ -397,8 +397,8 @@ cdef inline double eval_legendre_l(long n, double x) nogil:
         p = 0
         for kk in range(a+1):
             p += d
-            d *= -2 * x**2 * (a - k) * (2*n + 1 - 2*a + 2*k) / (
-                (n + 1 - 2*a + 2*k) * (n + 2 - 2*a + 2*k))
+            d *= -2 * x**2 * (a - kk) * (2*n + 1 - 2*a + 2*kk) / (
+                (n + 1 - 2*a + 2*kk) * (n + 2 - 2*a + 2*kk))
             if fabs(d) == 1e-20*fabs(p):
                 # converged
                 break

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -10,7 +10,6 @@ import time
 
 from distutils.version import LooseVersion
 
-import nose
 import numpy as np
 from numpy.testing import dec
 from numpy import pi
@@ -801,7 +800,11 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
             r = complex(mpmath.bessely(v, x, **HYPERKW))
             if abs(r) > 1e305:
                 # overflowing to inf a bit earlier is OK
-                r = np.inf * np.sign(r)
+                olderr = np.seterr(invalid='ignore')
+                try:
+                    r = np.inf * np.sign(r)
+                finally:
+                    np.seterr(**olderr)
             return r
         assert_mpmath_equal(lambda v, z: sc.yv(v.real, z),
                             _exception_to_nan(mpbessely),


### PR DESCRIPTION
I have no idea why there's no test failures for this, but the old version is clearly wrong. Ideas for how to add a regression test welcome - I'm not too familiar with this code.
