### PR TITLE
ENH: stats: Rewrote stats.obrientransform:

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1898,15 +1898,25 @@ def obrientransform(*args):
 
     Examples
     --------
-    >>> a = np.array([10, 12, 5, 17, 17, 11, 9, 9])
-    >>> b = np.array([23, 19, 30, 29])
-    >>> ta, tb = obrientransform(a, b)
-    >>> ta
-    array([  0.53571429,  -0.70238095,  46.96428571,  39.53571429,
-            39.53571429,  -1.32142857,   4.86904762,   4.86904762])
-    >>> tb
-    array([  1.70833333,  58.375     ,  30.875     ,  16.70833333])
+    We'll test the following data sets for differences in their variance.
 
+    >>> x = [10, 11, 13, 9, 7, 12, 12, 9, 10]
+    >>> y = [13, 21, 5, 10, 8, 14, 10, 12, 7, 15]
+
+    Apply the O'Brien transform to the data.
+
+    >>> tx, ty = obrientransform(x, y)
+
+    Use `scipy.stats.f_oneway` to apply a one-way ANOVA test to the
+    transformed data.
+
+    >>> from scipy.stats import f_oneway
+    >>> F, p = f_oneway(tx, ty)
+    >>> p
+    0.1314139477040335
+
+    If we require that ``p < 0.05`` for significance, we cannot conclude
+    that the variances are different.
     """
     TINY = np.sqrt(np.finfo(float).eps)
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1931,7 +1931,15 @@ def obrientransform(*args):
 
         arrays.append(t)
 
-    return np.array(arrays)
+    # If the arrays are not all the same shape, calling np.array(arrays)
+    # creates a 1-D array with dtype `object` in numpy 1.6+. In numpy
+    # 1.5.x, it raises an exception.  To work around this, we explicitly
+    # set the dtype to `object` when the arrays are not all the same shape.
+    if len(arrays) < 2 or all(x.shape == arrays[0].shape for x in arrays[1:]):
+        dt = None
+    else:
+        dt = object
+    return np.array(arrays, dtype=dt)
 
 
 def signaltonoise(a, axis=0, ddof=0):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1999,8 +1999,30 @@ def test_pointbiserial():
 
 
 def test_obrientransform():
+    # A couple tests calculated by hand.
+    x1 = np.array([0, 2, 4])
+    t1 = stats.obrientransform(x1)
+    expected = [7, -2, 7]
+    assert_allclose(t1[0], expected)
+
+    x2 = np.array([0, 3, 6, 9])
+    t2 = stats.obrientransform(x2)
+    expected = np.array([30, 0, 0, 30])
+    assert_allclose(t2[0], expected)
+
+    # Test two arguments.
+    a, b = stats.obrientransform(x1, x2)
+    assert_equal(a, t1[0])
+    assert_equal(b, t2[0])
+
+    # Test three arguments.
+    a, b, c = stats.obrientransform(x1, x2, x1)
+    assert_equal(a, t1[0])
+    assert_equal(b, t2[0])
+    assert_equal(c, t1[0])
+
     # This is a regression test to check np.var replacement.
-    # I didn't separately verify the numbers.
+    # The author of this test didn't separately verify the numbers.
     x1 = np.arange(5)
     result = np.array(
       [[5.41666667, 1.04166667, -0.41666667, 1.04166667, 5.41666667],

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1999,13 +1999,24 @@ def test_pointbiserial():
 
 
 def test_obrientransform():
-    # this is a regression test to check np.var replacement
-    # I didn't separately verigy the numbers
+    # This is a regression test to check np.var replacement.
+    # I didn't separately verify the numbers.
     x1 = np.arange(5)
     result = np.array(
       [[5.41666667, 1.04166667, -0.41666667, 1.04166667, 5.41666667],
        [21.66666667, 4.16666667, -1.66666667, 4.16666667, 21.66666667]])
     assert_array_almost_equal(stats.obrientransform(x1, 2*x1), result, decimal=8)
+
+    # Example from "O'Brien Test for Homogeneity of Variance"
+    # by Herve Abdi.
+    values = range(5, 11)
+    reps = np.array([5, 11, 9, 3, 2, 2])
+    data = np.repeat(values, reps)
+    transformed_values = np.array([3.1828, 0.5591, 0.0344,
+                                   1.6086, 5.2817, 11.0538])
+    expected = np.repeat(transformed_values, reps)
+    result = stats.obrientransform(data)
+    assert_array_almost_equal(result[0], expected, decimal=4)
 
 
 class HarMeanTestCase:


### PR DESCRIPTION
- Vectorized and simplified the computation.  For largeish arrays,
  this gives up to 60 times speed improvement.
- Copy-edited the docstring, and added 'References' and 'Examples'.
- `TINY` changed from 1e-10 to `np.sqrt(np.finfo(float).eps)`.
- Added more tests.

Note that this PR maintains (and documents) the current API.  In particular, when the arguments are arrays of different lengths, the return value is a single numpy array with dtype `object`.  For example, this is scipy 0.12.0 with numpy 1.7.1:

```
In [1]: import scipy

In [2]: scipy.__version__
Out[2]: '0.12.0'

In [3]: from scipy.stats import obrientransform

In [4]: a = np.arange(3)

In [5]: b = np.arange(4)

In [6]: obrientransform(a,b)
Out[6]: 
array([array([ 1.75, -0.5 ,  1.75]),
       array([ 3.33333333,  0.        ,  0.        ,  3.33333333])], dtype=object)
```

After this PR, the results are the same.

Changing this API (as discussed in the comments below) is a separate issue from this PR.
