### PR TITLE
Make scipy.io.wavfile.write buffer-friendlier

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -118,7 +118,7 @@ Gustav Larsson for a bug fix in convolve2d.
 Alex Griffing for expm 2009, expm_multiply, expm_frechet,
     trust region optimization methods, and sparse matrix onenormest
     implementations, plus bugfixes.
-Nils Werner for signal windowing improvements.
+Nils Werner for signal windowing and wavfile-writing improvements.
 
 Institutions
 ------------

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import os
 import tempfile
 import warnings
-import StringIO
+from io import BytesIO
 
 import numpy as np
 from numpy.testing import assert_equal, assert_, assert_raises, assert_array_equal
@@ -56,7 +56,7 @@ def _check_roundtrip(realfile, rate, dtype, channels):
         fd, tmpfile = tempfile.mkstemp(suffix='.wav')
         os.close(fd)
     else:
-        tmpfile = StringIO.StringIO()
+        tmpfile = BytesIO()
     try:
         data = np.random.rand(100, channels)
         if channels == 1:

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -52,7 +52,7 @@ def test_read_fail():
 
 
 def _check_roundtrip(realfile, rate, dtype, channels):
-    if(realfile == True):
+    if realfile:
         fd, tmpfile = tempfile.mkstemp(suffix='.wav')
         os.close(fd)
     else:
@@ -78,7 +78,7 @@ def _check_roundtrip(realfile, rate, dtype, channels):
 
             del data2
     finally:
-        if(realfile == True):
+        if realfile:
             os.unlink(tmpfile)
 
 

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -239,5 +239,5 @@ def write(file, rate, data):
     fid.seek(4)
     fid.write(struct.pack('<i', size-8))
 
-    if not hasattr(file,'read'):
+    if not hasattr(file,'write'):
         fid.close()

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -238,7 +238,7 @@ def write(filename, rate, data):
         import sys
         if data.dtype.byteorder == '>' or (data.dtype.byteorder == '=' and sys.byteorder == 'big'):
             data = data.byteswap()
-        fid.write(data.tostring())
+        fid.write(data.ravel().data)
         # Determine file size and place it in correct
         #  position at start of the file.
         size = fid.tell()

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -67,8 +67,6 @@ def _read_data_chunk(fid, comp, noc, bits, mmap=False):
         else:
             dtype += 'f%d' % bytes
     if not mmap:
-        # Old implementation, before wavfile.read() could accept buffers
-        #data = numpy.fromfile(fid, dtype=dtype, count=size//bytes)
         data = numpy.fromstring(fid.read(size), dtype=dtype)
     else:
         start = fid.tell()
@@ -238,11 +236,7 @@ def write(filename, rate, data):
     import sys
     if data.dtype.byteorder == '>' or (data.dtype.byteorder == '=' and sys.byteorder == 'big'):
         data = data.byteswap()
-
-    # Old implementation, before wavfile.write() could accept buffers
-    #data.tofile(fid)
     fid.write(data.tostring())
-
     # Determine file size and place it in correct
     #  position at start of the file.
     size = fid.tell()


### PR DESCRIPTION
This pullrequest aims to enable `scipy.io.wavfile.write()` to also accept buffers instead of just a filename.

Currently, only `scipy.io.wavfile.read()` supports a both filenames and buffers as the input file argument, after merging this PR, `write()` will be able to do the same. This means you can then read and write not only to .WAV files but also to and from `StringIO` variables.

I was able to test these changes with supplying both a filename and a buffer, and they worked fine. **But I haven't run any of the unittest** as I have yet to set up a proper testing environment.

So I would be grateful if anybody familiar with this matter could test the code.
