### PR TITLE
ENH: stats: add an option for continuity correction to stats.wilcoxon

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1334,7 +1334,7 @@ def oneway(*args,**kwds):
     return F, pval
 
 
-def wilcoxon(x, y=None, zero_method="wilcox"):
+def wilcoxon(x, y=None, zero_method="wilcox", correction=False):
     """
     Calculate the Wilcoxon signed-rank test.
 
@@ -1360,6 +1360,10 @@ def wilcoxon(x, y=None, zero_method="wilcox"):
         "zsplit":
             Zero rank split: just like Pratt, but spliting the zero rank
             between positive and negative ones
+    correction : bool, optional
+        If True, apply continuity correction by adjusting the Wilcoxon rank
+        statistic by 0.5 towards the mean value when computing the
+        z-statistic.  Default is False.
 
     Returns
     -------
@@ -1421,7 +1425,8 @@ def wilcoxon(x, y=None, zero_method="wilcox"):
         se -= 0.5 * (repnum * (repnum * repnum - 1)).sum()
 
     se = sqrt(se / 24)
-    z = (T - mn) / se
+    correction = 0.5 * int(bool(correction)) * np.sign(T - mn)
+    z = (T - mn - correction) / se
     prob = 2. * distributions.norm.sf(abs(z))
     return T, prob
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -8,7 +8,7 @@ import warnings
 
 from numpy.testing import TestCase, run_module_suite, assert_array_equal, \
     assert_almost_equal, assert_array_less, assert_array_almost_equal, \
-    assert_raises, assert_, assert_allclose
+    assert_raises, assert_, assert_allclose, assert_equal
 from numpy.testing.utils import WarningManager
 
 import scipy.stats as stats
@@ -518,6 +518,18 @@ def test_accuracy_wilcoxon():
     T, p = stats.wilcoxon(x, y, "wilcox")
     assert_allclose(T, 327)
     assert_allclose(p, 0.00641346115861)
+
+    # Test the 'correction' option, using values computed in R with:
+    # > wilcox.test(x, y, paired=TRUE, exact=FALSE, correct={FALSE,TRUE})
+    x = np.array([120, 114, 181, 188, 180, 146, 121, 191, 132, 113, 127, 112])
+    y = np.array([133, 143, 119, 189, 112, 199, 198, 113, 115, 121, 142, 187])
+    T, p = stats.wilcoxon(x, y, correction=False)
+    assert_equal(T, 34)
+    assert_allclose(p, 0.6948866, rtol=1e-6)
+    T, p = stats.wilcoxon(x, y, correction=True)
+    assert_equal(T, 34)
+    assert_allclose(p, 0.7240817, rtol=1e-6)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
The new option corresponds to the option `correct={FALSE,TRUE}` of the function `wilcox.test` in R.
