### PR TITLE
BUG: Docstring claims to accept array_like, but does not

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -629,9 +629,15 @@ def impulse(system, X0=None, T=None, N=None):
 
     Parameters
     ----------
-    system : LTI class or tuple
-        If specified as a tuple, the system is described as
-        ``(num, den)``, ``(zero, pole, gain)``, or ``(A, B, C, D)``.
+    system : an instance of the LTI class or a tuple of array_like 
+        describing the system.
+        The following gives the number of elements in the tuple and
+        the interpretation:
+
+            * 2 (num, den)
+            * 3 (zeros, poles, gain)
+            * 4 (A, B, C, D)
+            
     X0 : array_like, optional
         Initial state-vector.  Defaults to zero.
     T : array_like, optional
@@ -677,7 +683,8 @@ def impulse2(system, X0=None, T=None, N=None, **kwargs):
 
     Parameters
     ----------
-    system : an instance of the LTI class or a tuple describing the system.
+    system : an instance of the LTI class or a tuple of array_like 
+        describing the system.
         The following gives the number of elements in the tuple and
         the interpretation:
 
@@ -685,13 +692,13 @@ def impulse2(system, X0=None, T=None, N=None, **kwargs):
             * 3 (zeros, poles, gain)
             * 4 (A, B, C, D)
 
+    X0 : 1-D array_like, optional
+        The initial condition of the state vector.  Default: 0 (the
+        zero vector).
     T : 1-D array_like, optional
         The time steps at which the input is defined and at which the
         output is desired.  If `T` is not given, the function will
         generate a set of time samples automatically.
-    X0 : 1-D array_like, optional
-        The initial condition of the state vector.  Default: 0 (the
-        zero vector).
     N : int, optional
         Number of time points to compute.  Default: 100.
     kwargs : various types
@@ -756,7 +763,8 @@ def step(system, X0=None, T=None, N=None):
 
     Parameters
     ----------
-    system : an instance of the LTI class or a tuple describing the system.
+    system : an instance of the LTI class or a tuple of array_like 
+        describing the system.
         The following gives the number of elements in the tuple and
         the interpretation:
 
@@ -805,7 +813,8 @@ def step2(system, X0=None, T=None, N=None, **kwargs):
 
     Parameters
     ----------
-    system : an instance of the LTI class or a tuple describing the system.
+    system : an instance of the LTI class or a tuple of array_like 
+        describing the system.
         The following gives the number of elements in the tuple and
         the interpretation:
 

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -331,8 +331,10 @@ class lti(object):
             self.__dict__[attr] = val
 
     def __repr__(self):
-        # Canonical representation using state-space to preserve numerical
-        # precision and any MIMO information
+        """
+        Canonical representation using state-space to preserve numerical
+        precision and any MIMO information
+        """
         return '{0}(\n{1},\n{2},\n{3},\n{4}\n)'.format(
             self.__class__.__name__,
             repr(self.A),
@@ -449,7 +451,7 @@ def lsim2(system, U=None, T=None, X0=None, **kwargs):
         # changed from a required positional argument to a keyword,
         # and T is after U in the argument list.  So we either: change
         # the API and move T in front of U; check here for T being
-        # None and raise an excpetion; or assign a default value to T
+        # None and raise an exception; or assign a default value to T
         # here.  This code implements the latter.
         T = linspace(0, 10.0, 101)
 
@@ -527,15 +529,6 @@ def lsim(system, U, T, X0=None, interp=1):
         Time-evolution of the state-vector.
 
     """
-    # system is an lti system or a sequence
-    #  with 2 (num, den)
-    #       3 (zeros, poles, gain)
-    #       4 (A, B, C, D)
-    #  describing the system
-    #  U is an input vector at times T
-    #   if system describes multiple inputs
-    #   then U can be a rank-2 array with the number of columns
-    #   being the number of inputs
     if isinstance(system, lti):
         sys = system
     else:
@@ -613,7 +606,8 @@ def _default_response_times(A, n):
         The 1-D array of length `n` of time samples at which the response
         is to be computed.
     """
-    # Create a reasonable time interval.  This could use some more work.
+    # Create a reasonable time interval.  
+    # TODO: This could use some more work.
     # For example, what is expected when the system is unstable?
     vals = linalg.eigvals(A)
     r = min(abs(real(vals)))

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -754,9 +754,8 @@ def impulse2(system, X0=None, T=None, N=None, **kwargs):
         T = _default_response_times(sys.A, N)
     # Move the impulse in the input to the initial conditions, and then
     # solve using lsim2().
-    U = zeros_like(T)
     ic = B + X0
-    Tr, Yr, Xr = lsim2(sys, U, T, ic, **kwargs)
+    Tr, Yr, Xr = lsim2(sys, T=T, X0=ic, **kwargs)
     return Tr, Yr
 
 

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -666,6 +666,8 @@ def impulse(system, X0=None, T=None, N=None):
         N = 100
     if T is None:
         T = _default_response_times(sys.A, N)
+    else:
+        T = asarray(T)
     h = zeros(T.shape, sys.A.dtype)
     s, v = linalg.eig(sys.A)
     vi = linalg.inv(v)
@@ -799,6 +801,8 @@ def step(system, X0=None, T=None, N=None):
         N = 100
     if T is None:
         T = _default_response_times(sys.A, N)
+    else:
+        T = asarray(T)
     U = ones(T.shape, sys.A.dtype)
     vals = lsim(sys, U, T, X0=X0)
     return vals[0], vals[1]
@@ -857,6 +861,8 @@ def step2(system, X0=None, T=None, N=None, **kwargs):
         N = 100
     if T is None:
         T = _default_response_times(sys.A, N)
+    else:
+        T = asarray(T)
     U = ones(T.shape, sys.A.dtype)
     vals = lsim2(sys, U, T, X0=X0, **kwargs)
     return vals[0], vals[1]

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -161,6 +161,14 @@ class Test_impulse2(object):
         expected_y = tout * np.exp(-tout)
         assert_almost_equal(y, expected_y)
 
+    def test_array_like(self):
+        # Test that function can accept sequences, scalars.
+        system = ([1.0], [1.0, 2.0, 1.0])
+        # TODO: add meaningful test where X0 is a list
+        tout, y = impulse2(system, X0=[3], T=[5, 6])
+        tout, y = impulse2(system, X0=[3], T=[5])
+        tout, y = impulse2(system, X0=3, T=5)
+
 
 class Test_step2(object):
 
@@ -223,6 +231,12 @@ class Test_step2(object):
         expected_y = 1 - (1 + tout) * np.exp(-tout)
         assert_almost_equal(y, expected_y)
 
+    def test_array_like(self):
+        # Test that function can accept sequences, scalars.
+        system = ([1.0], [1.0, 2.0, 1.0])
+        # TODO: add meaningful test where X0 is a list
+        tout, y = step2(system, T=[5, 6])
+
 
 class Test_impulse(object):
 
@@ -275,6 +289,13 @@ class Test_impulse(object):
         expected_y = np.ones_like(tout)
         assert_almost_equal(y, expected_y)
 
+    def test_array_like(self):
+        # Test that function can accept sequences, scalars.
+        system = ([1.0], [1.0, 2.0, 1.0])
+        # TODO: add meaningful test where X0 is a list
+        tout, y = impulse(system, X0=[3], T=[5, 6])
+        tout, y = impulse(system, X0=[3], T=[5])
+
 
 class Test_step(object):
 
@@ -319,6 +340,12 @@ class Test_step(object):
         tout, y = step(system, X0=[3.0])
         expected_y = 1 + 2.0*np.exp(-tout)
         assert_almost_equal(y, expected_y)
+
+    def test_array_like(self):
+        # Test that function can accept sequences, scalars.
+        system = ([1.0], [1.0, 2.0, 1.0])
+        # TODO: add meaningful test where X0 is a list
+        tout, y = step(system, X0=[3], T=[5, 6])
 
 
 def test_lti_instantiation():

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal, run_module_suite
 
 from scipy.signal.ltisys import ss2tf, lsim2, impulse2, step2, lti, bode, \
-    freqresp
+    freqresp, impulse, step
 from scipy.signal.filter_design import BadCoefficients
 import scipy.linalg as linalg
 
@@ -221,6 +221,103 @@ class Test_step2(object):
         system = ([1.0], [1.0, 2.0, 1.0])
         tout, y = step2(system, atol=1e-10, rtol=1e-8)
         expected_y = 1 - (1 + tout) * np.exp(-tout)
+        assert_almost_equal(y, expected_y)
+
+
+class Test_impulse(object):
+
+    def test_01(self):
+        # First order system: x'(t) + x(t) = u(t)
+        # Exact impulse response is x(t) = exp(-t).
+        system = ([1.0],[1.0,1.0])
+        tout, y = impulse(system)
+        expected_y = np.exp(-tout)
+        assert_almost_equal(y, expected_y)
+
+    def test_02(self):
+        """Specify the desired time values for the output."""
+
+        # First order system: x'(t) + x(t) = u(t)
+        # Exact impulse response is x(t) = exp(-t).
+        system = ([1.0],[1.0,1.0])
+        n = 21
+        t = np.linspace(0, 2.0, n)
+        tout, y = impulse(system, T=t)
+        assert_equal(tout.shape, (n,))
+        assert_almost_equal(tout, t)
+        expected_y = np.exp(-t)
+        assert_almost_equal(y, expected_y)
+
+    def test_03(self):
+        """Specify an initial condition as a scalar."""
+
+        # First order system: x'(t) + x(t) = u(t), x(0)=3.0
+        # Exact impulse response is x(t) = 4*exp(-t).
+        system = ([1.0],[1.0,1.0])
+        tout, y = impulse(system, X0=3.0)
+        expected_y = 4.0*np.exp(-tout)
+        assert_almost_equal(y, expected_y)
+
+    def test_04(self):
+        """Specify an initial condition as a list."""
+
+        # First order system: x'(t) + x(t) = u(t), x(0)=3.0
+        # Exact impulse response is x(t) = 4*exp(-t).
+        system = ([1.0],[1.0,1.0])
+        tout, y = impulse(system, X0=[3.0])
+        expected_y = 4.0*np.exp(-tout)
+        assert_almost_equal(y, expected_y)
+
+    def test_05(self):
+        # Simple integrator: x'(t) = u(t)
+        system = ([1.0],[1.0,0.0])
+        tout, y = impulse(system)
+        expected_y = np.ones_like(tout)
+        assert_almost_equal(y, expected_y)
+
+
+class Test_step(object):
+
+    def test_01(self):
+        # First order system: x'(t) + x(t) = u(t)
+        # Exact step response is x(t) = 1 - exp(-t).
+        system = ([1.0],[1.0,1.0])
+        tout, y = step(system)
+        expected_y = 1.0 - np.exp(-tout)
+        assert_almost_equal(y, expected_y)
+
+    def test_02(self):
+        """Specify the desired time values for the output."""
+
+        # First order system: x'(t) + x(t) = u(t)
+        # Exact step response is x(t) = 1 - exp(-t).
+        system = ([1.0],[1.0,1.0])
+        n = 21
+        t = np.linspace(0, 2.0, n)
+        tout, y = step(system, T=t)
+        assert_equal(tout.shape, (n,))
+        assert_almost_equal(tout, t)
+        expected_y = 1 - np.exp(-t)
+        assert_almost_equal(y, expected_y)
+
+    def test_03(self):
+        """Specify an initial condition as a scalar."""
+
+        # First order system: x'(t) + x(t) = u(t), x(0)=3.0
+        # Exact step response is x(t) = 1 + 2*exp(-t).
+        system = ([1.0],[1.0,1.0])
+        tout, y = step(system, X0=3.0)
+        expected_y = 1 + 2.0*np.exp(-tout)
+        assert_almost_equal(y, expected_y)
+
+    def test_04(self):
+        """Specify an initial condition as a list."""
+
+        # First order system: x'(t) + x(t) = u(t), x(0)=3.0
+        # Exact step response is x(t) = 1 + 2*exp(-t).
+        system = ([1.0],[1.0,1.0])
+        tout, y = step(system, X0=[3.0])
+        expected_y = 1 + 2.0*np.exp(-tout)
         assert_almost_equal(y, expected_y)
 
 


### PR DESCRIPTION
Tries to call T.shape

"AttributeError: 'list' object has no attribute 'shape'" etc.

Maybe should use `zeros_like` or `ones_like`, like impulse2?  Or maybe impulse2 should use `U = zeros(shape(T), sys.A.dtype)`?
