### PR TITLE
BUG: Change working dir when building extension.

### DIFF
--- a/scipy/weave/build_tools.py
+++ b/scipy/weave/build_tools.py
@@ -266,6 +266,11 @@ def build_extension(module_path,compiler_name='',build_dir=None,
         old_SysExit = builtin.__dict__['SystemExit']
         builtin.__dict__['SystemExit'] = CompileError
 
+        # change current working directory to 'build_dir' so compiler won't
+        # pick up anything by mistake
+        oldcwd = os.path.abspath(os.getcwd())
+        os.chdir(build_dir)
+
         # distutils for MSVC messes with the environment, so we save the
         # current state and restore them afterward.
         import copy
@@ -277,6 +282,8 @@ def build_extension(module_path,compiler_name='',build_dir=None,
             os.environ = environ
             # restore SystemExit
             builtin.__dict__['SystemExit'] = old_SysExit
+            # restore working directory to one before setup
+            os.chdir(oldcwd)
         t2 = time.time()
 
         if verbose == 1:


### PR DESCRIPTION
Current working directory should be changed (to trusted one) when building
an extension so compiler accidentally won't pick up anything from (untrusted)
current directory.

Ran scipy.weave tests and they passed:

```
$ scipy.weave.test('full', verbose=10)

Ran 443 tests in 147.585s

OK (KNOWNFAIL=2)
```

This is extremely minor security issue which should not supposedly be able to be exploited.
