### PR TITLE
MAINT: stats: Fix chisquare and mstats.chisquare to work with numpy 1.5.1

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -939,7 +939,11 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     # `w` is the array of terms that are summed along `axis` to create
     # the chi-squared statistic.
     w = (f_obs - f_exp)**2 / f_exp
-    chisq = ma.add.reduce(w, axis=axis)
+    if axis == None:
+        # When using numpy 1.5.1, `ma.add.reduce` does not accept `axis=None`.
+        chisq = w.sum()
+    else:
+        chisq = ma.add.reduce(w, axis=axis)
 
     # Compute the corresponding p values.
     # Masked elements are ignored, so the data sets may have different

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3579,7 +3579,11 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     # `w` is the array of terms that are summed along `axis` to create
     # the chi-squared statistic.
     w = (f_obs - f_exp)**2 / f_exp
-    chisq = np.add.reduce(w, axis=axis)
+    if axis is None:
+        # np.add.reduce() in numpy 1.5.1 does not accept `axis=None`.
+        chisq = w.sum()
+    else:
+        chisq = np.add.reduce(w, axis=axis)
 
     # Compute the corresponding p values.
     if axis is None:


### PR DESCRIPTION
In numpy 1.5.1, the functions `np.add.reduce` and `np.ma.add.reduce` do not accept `axis=None`, so instead we use the corresponding `sum` function.
