### PR TITLE
BUG: arpack-ng: fix bug occurring on OSX or LAPACK 3.2.1

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/ARPACK/SRC/dseupd.f
+++ b/scipy/sparse/linalg/eigen/arpack/ARPACK/SRC/dseupd.f
@@ -760,6 +760,16 @@ c
      &                ldq   , workl(iw+ncv), workl(ihb),
      &                ncv   , temp         , ierr)
 c
+c        %-----------------------------------------------------%
+c        | Make a copy of the last row into                    |
+c        | workl(iw+ncv:iw+2*ncv), as it is needed again in    |
+c        | the Ritz vector purification step below             |
+c        %-----------------------------------------------------%
+c
+         do 67 j = 1, nconv
+            workl(iw+ncv+j-1) = workl(ihb+j-1)
+ 67      continue
+
       else if (rvec .and. howmny .eq. 'S') then
 c
 c     Not yet implemented. See remark 2 above.
@@ -830,14 +840,14 @@ c
       if (rvec .and. (type .eq. 'SHIFTI' .or. type .eq. 'CAYLEY')) then
 c
          do 110 k=0, nconv-1
-            workl(iw+k) = workl(iq+k*ldq+ncv-1)
+            workl(iw+k) = workl(iw+ncv+k)
      &                  / workl(iw+k)
  110     continue
 c
       else if (rvec .and. type .eq. 'BUCKLE') then
 c
          do 120 k=0, nconv-1
-            workl(iw+k) = workl(iq+k*ldq+ncv-1)
+            workl(iw+k) = workl(iw+ncv+k)
      &                  / (workl(iw+k)-one)
  120     continue
 c

--- a/scipy/sparse/linalg/eigen/arpack/ARPACK/SRC/sseupd.f
+++ b/scipy/sparse/linalg/eigen/arpack/ARPACK/SRC/sseupd.f
@@ -760,6 +760,16 @@ c
      &                ldq   , workl(iw+ncv), workl(ihb),
      &                ncv   , temp         , ierr)
 c
+c        %-----------------------------------------------------%
+c        | Make a copy of the last row into                    |
+c        | workl(iw+ncv:iw+2*ncv), as it is needed again in    |
+c        | the Ritz vector purification step below             |
+c        %-----------------------------------------------------%
+c
+         do 67 j = 1, nconv
+            workl(iw+ncv+j-1) = workl(ihb+j-1)
+ 67      continue
+
       else if (rvec .and. howmny .eq. 'S') then
 c
 c     Not yet implemented. See remark 2 above.
@@ -830,14 +840,14 @@ c
       if (rvec .and. (type .eq. 'SHIFTI' .or. type .eq. 'CAYLEY')) then
 c
          do 110 k=0, nconv-1
-            workl(iw+k) = workl(iq+k*ldq+ncv-1)
+            workl(iw+k) = workl(iw+ncv+k)
      &                  / workl(iw+k)
  110     continue
 c
       else if (rvec .and. type .eq. 'BUCKLE') then
 c
          do 120 k=0, nconv-1
-            workl(iw+k) = workl(iq+k*ldq+ncv-1)
+            workl(iw+k) = workl(iw+ncv+k)
      &                  / (workl(iw+k)-one)
  120     continue
 c


### PR DESCRIPTION
This PR fixes a bug in ARPACK that manifests with on OSX with Accelerate and on other platforms with LAPACK 3.2.1.

See discussion at http://forge.scilab.org/index.php/p/arpack-ng/issues/1259/

The Ritz vector purification step assumes workl(iq) still contains the original Q matrix. This is however overwritten by the call to xGEQR2 earlier. This code in ARPACK never actually functioned correctly, but due to the way most LAPACK versions form the QR decomposition, the applied correction would be zero.

This patch fixes the issue by making a copy of the last row of the eigenvector matrix, after it is recomputed after QR by xORM2R. The work space WORKL(IW+NCV:IW+2*NCV) used for the TAU values of the QR decomposition is not used later in the routine, and can be used to store a copy of the last row.

Fixes gh-2547
