### PR TITLE
MAINT: io: Remove a few unreachable return statements.

### DIFF
--- a/scipy/io/matlab/mio5_utils.pyx
+++ b/scipy/io/matlab/mio5_utils.pyx
@@ -293,7 +293,6 @@ cdef class VarReader5:
             mdtype_sde = mdtype & 0xffff
             if byte_count_sde > 4:
                 raise ValueError('Error in SDE format data')
-                return -1
             u4_ptr[0] = u4s[1]
             mdtype_ptr[0] = mdtype_sde
             byte_count_ptr[0] = byte_count_sde
@@ -472,7 +471,6 @@ cdef class VarReader5:
         self.read_element_into(&mdtype, &byte_count, <void *>int32p)
         if mdtype != miINT32:
             raise TypeError('Expecting miINT32 as data type')
-            return -1
         cdef int n_ints = byte_count // 4
         if self.is_swapped:
             for i in range(n_ints):

--- a/scipy/io/matlab/streams.pyx
+++ b/scipy/io/matlab/streams.pyx
@@ -82,7 +82,6 @@ cdef class GenericStream:
 
         if count != n:
             raise IOError('could not read bytes')
-            return -1
         return 0
 
     cdef object read_string(self, size_t n, void **pp, int copy=True):
@@ -301,7 +300,6 @@ cdef class FileStream(GenericStream):
         ret = fseek(self.file, offset, whence)
         if ret:
             raise IOError('Failed seek')
-            return -1
         return ret
 
     cpdef long int tell(self):
@@ -316,7 +314,6 @@ cdef class FileStream(GenericStream):
         n_red = fread(buf, 1, n, self.file)
         if n_red != n:
             raise IOError('Could not read bytes')
-            return -1
         return 0
 
     cdef object read_string(self, size_t n, void **pp, int copy=True):


### PR DESCRIPTION
This PR fixes the following warnings that occur when building scipy:

```
Processing scipy/io/matlab/mio5_utils.pyx
warning: mio5_utils.pyx:296:16: Unreachable code
warning: mio5_utils.pyx:475:12: Unreachable code
Processing scipy/io/matlab/streams.pyx
warning: streams.pyx:85:12: Unreachable code
warning: streams.pyx:304:12: Unreachable code
warning: streams.pyx:319:12: Unreachable code
```
