### PR TITLE
Fancy indexing for CSR and CSC matrices. 

### DIFF
--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -181,8 +181,6 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
                 if np.rank(M) != 2:
                     raise TypeError('expected rank <= 2 array or matrix')
-                elif M.size == 0:
-                    self.shape = (1,1)
                 else:
                     self.shape = M.shape
 

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -352,7 +352,10 @@ class csr_matrix(_cs_matrix, IndexMixin):
                 row_data = row_data[::-1]
                 row_indices = abs(row_indices[::-1])
 
-            shape = (1, np.ceil(float(stop - start) / stride))
+            shape = (1, int(np.ceil(float(stop - start) / stride)))
+            # Catch empty slice.
+            if 0 in shape:
+                shape = (1,1)
 
             row_slice = csr_matrix((row_data, row_indices, row_indptr),
                                    shape=shape)

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -273,6 +273,11 @@ class csr_matrix(_cs_matrix, IndexMixin):
 
         # If all else fails, try elementwise
         row, col = self._index_to_arrays(row, col)
+
+        if row.size == 0 or col.size == 0:
+            raise ValueError("Slice returns a size 0 matrix which is not "
+            "supported by sparse matrices.")
+
         return self.__class__([[self._get_single_element(iii, jjj) for
                                 iii, jjj in zip(ii, jj)] for ii, jj in
                                zip(row.tolist(), col.tolist())])
@@ -353,9 +358,9 @@ class csr_matrix(_cs_matrix, IndexMixin):
                 row_indices = abs(row_indices[::-1])
 
             shape = (1, int(np.ceil(float(stop - start) / stride)))
-            # Catch empty slice.
             if 0 in shape:
-                shape = (1,1)
+                raise ValueError("Slice returns a size 0 matrix which is not "
+                "supported by sparse matrices.")
 
             row_slice = csr_matrix((row_data, row_indices, row_indptr),
                                    shape=shape)


### PR DESCRIPTION
This is based off of @daniel-b-smith's work (thanks!).

I also add support for indexing with sparse boolean matrices, but it does not have tests yet. I will add tests for this tomorrow. For now I just wanted to get this out because it finishes what Daniel started.

Here's a demo of what I mean by indexing with sparse boolean matrices.

```
>>> from scipy.sparse import csr_matrix
>>> from numpy.random import randint

>>> x = csr_matrix(randint(6, size=(4,4)))
>>> x.todense()

matrix([[3, 5, 0, 4],
        [4, 3, 4, 0],
        [0, 3, 2, 0],
        [2, 2, 0, 1]], dtype=int64)

>>> x[x > 3] = 1
>>> x.todense()

matrix([[3, 1, 0, 1],
        [1, 3, 1, 0],
        [0, 3, 2, 0],
        [2, 2, 0, 1]], dtype=int64)

```
