### PR TITLE
[ENH]: sparse.linalg.LinearOperator: add +, -, *, and ** operators

### DIFF
--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -59,15 +59,6 @@ class LinearOperator(object):
     array([ 2.,  3.])
 
     """
-    def __new__(cls, *args, **kwargs):
-        obj = object.__new__(cls)
-        obj._args = args
-        return obj
-
-    @property
-    def args(self):
-        return self._args
-
     def __init__(self, shape, matvec, rmatvec=None, matmat=None, dtype=None):
 
         shape = tuple(shape)
@@ -246,7 +237,7 @@ class _SumLinearOperator(LinearOperator):
             raise ValueError('both operands have to be a LinearOperator')
         if A.shape!=B.shape:
             raise ValueError('shape mismatch')
-        self._args = (A,B)
+        self.args = (A,B)
         super(_SumLinearOperator, self).__init__(A.shape,
                 self.matvec, self.rmatvec, self.matmat, _get_dtype([A,B]))
 
@@ -266,7 +257,7 @@ class _ProductLinearOperator(LinearOperator):
             raise ValueError('both operands have to be a LinearOperator')
         if A.shape[1]!=B.shape[0]:
             raise ValueError('shape mismatch')
-        self._args = (A,B)
+        self.args = (A,B)
         super(_ProductLinearOperator, self).__init__((A.shape[0],B.shape[1]),
                 self.matvec, self.rmatvec, self.matmat, _get_dtype([A,B]))
 
@@ -285,7 +276,7 @@ class _ScaledLinearOperator(LinearOperator):
             raise ValueError('LinearOperator expected as A')
         if not np.isscalar(alpha):
             raise ValueError('scalar expected as alpha')
-        self._args = (A,alpha)
+        self.args = (A,alpha)
         super(_ScaledLinearOperator, self).__init__(A.shape,
                 self.matvec, self.rmatvec, self.matmat,
                 _get_dtype([A], [type(alpha)]))
@@ -307,7 +298,7 @@ class _PowerLinearOperator(LinearOperator):
             raise ValueError('square LinearOperator expected as A')
         if not isintlike(p):
             raise ValueError('integer expected as p')
-        self._args = (A,p)
+        self.args = (A,p)
         super(_PowerLinearOperator, self).__init__(A.shape,
                 self.matvec, self.rmatvec, self.matmat,
                 _get_dtype([A]))

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -62,7 +62,6 @@ class LinearOperator(object):
     def __new__(cls, *args, **kwargs):
         obj = object.__new__(cls)
         obj._args = args
-        obj._kwargs = kwargs
         return obj
 
     @property

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -247,6 +247,7 @@ class _SumLinearOperator(LinearOperator):
             raise ValueError('both operands have to be a LinearOperator')
         if A.shape!=B.shape:
             raise ValueError('shape mismatch')
+        self._args = (A,B)
         super(_SumLinearOperator, self).__init__(A.shape,
                 self.matvec, self.rmatvec, self.matmat, _get_dtype([A,B]))
 
@@ -266,6 +267,7 @@ class _ProductLinearOperator(LinearOperator):
             raise ValueError('both operands have to be a LinearOperator')
         if A.shape[1]!=B.shape[0]:
             raise ValueError('shape mismatch')
+        self._args = (A,B)
         super(_ProductLinearOperator, self).__init__((A.shape[0],B.shape[1]),
                 self.matvec, self.rmatvec, self.matmat, _get_dtype([A,B]))
 
@@ -284,6 +286,7 @@ class _ScaledLinearOperator(LinearOperator):
             raise ValueError('LinearOperator expected as A')
         if not np.isscalar(alpha):
             raise ValueError('scalar expected as alpha')
+        self._args = (A,alpha)
         super(_ScaledLinearOperator, self).__init__(A.shape,
                 self.matvec, self.rmatvec, self.matmat,
                 _get_dtype([A], [type(alpha)]))
@@ -305,6 +308,7 @@ class _PowerLinearOperator(LinearOperator):
             raise ValueError('square LinearOperator expected as A')
         if not isintlike(p):
             raise ValueError('integer expected as p')
+        self._args = (A,p)
         super(_PowerLinearOperator, self).__init__(A.shape,
                 self.matvec, self.rmatvec, self.matmat,
                 _get_dtype([A]))

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from scipy.sparse.sputils import isshape
+from scipy.sparse.sputils import isshape, isintlike
 from scipy.sparse import isspmatrix
 
 __all__ = ['LinearOperator', 'aslinearoperator']
@@ -222,7 +222,7 @@ class LinearOperator:
             return NotImplemented
 
     def __pow__(self, p):
-        if isinstance(p, (int, long)):
+        if isintlike(p):
             if self.shape[0] != self.shape[1]:
                 raise ValueError('dimension mismatch')
             def power(y, fun):

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -178,6 +178,9 @@ class LinearOperator(object):
 
         return Y
 
+    def __call__(self, x):
+        return self*x
+
     def __mul__(self, x):
         if isinstance(x, LinearOperator):
             return _ProductLinearOperator(self, x)

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -182,38 +182,50 @@ class LinearOperator(object):
         return self*x
 
     def __mul__(self, x):
-        if isinstance(x, LinearOperator):
-            return _ProductLinearOperator(self, x)
-        elif np.isscalar(x):
-            return _ScaledLinearOperator(self, x)
-        else:
-            x = np.asarray(x)
-
-            if x.ndim == 1 or x.ndim == 2 and x.shape[1] == 1:
-                return self.matvec(x)
-            elif x.ndim == 2:
-                return self.matmat(x)
+        try:
+            if isinstance(x, LinearOperator):
+                return _ProductLinearOperator(self, x)
+            elif np.isscalar(x):
+                return _ScaledLinearOperator(self, x)
             else:
-                raise ValueError('expected rank-1 or rank-2 array or matrix')
+                x = np.asarray(x)
+
+                if x.ndim == 1 or x.ndim == 2 and x.shape[1] == 1:
+                    return self.matvec(x)
+                elif x.ndim == 2:
+                    return self.matmat(x)
+                else:
+                    raise ValueError('expected rank-1 or rank-2 array or matrix')
+        except ValueError:
+            return NotImplemented
 
     def dot(self, other):
         # modeled after scipy.sparse.base.dot
         return self * other
 
     def __rmul__(self, x):
-        if np.isscalar(x):
+        try:
             return _ScaledLinearOperator(self, x)
-        else:
+        except ValueError:
             return NotImplemented
 
     def __pow__(self, p):
-        return _PowerLinearOperator(self, p)
+        try:
+            return _PowerLinearOperator(self, p)
+        except ValueError:
+            return NotImplemented
 
     def __add__(self, x):
-        return _SumLinearOperator(self, x)
+        try:
+            return _SumLinearOperator(self, x)
+        except ValueError:
+            return NotImplemented
 
     def __neg__(self):
-        return _ScaledLinearOperator(self, -1)
+        try:
+            return _ScaledLinearOperator(self, -1)
+        except ValueError:
+            return NotImplemented
 
     def __sub__(self, x):
         return self + (-x)

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -320,8 +320,8 @@ class _PowerLinearOperator(LinearOperator):
 
 class MatrixLinearOperator(LinearOperator):
     def __init__(self, A):
-        LinearOperator.__init__(self, shape=A.shape, dtype=A.dtype,
-                                matvec=None, rmatvec=self.rmatvec)
+        super(MatrixLinearOperator, self).__init__(shape=A.shape,
+                dtype=A.dtype, matvec=None, rmatvec=self.rmatvec)
         self.matvec = A.dot
         self.matmat = A.dot
         self.__mul__ = A.dot
@@ -336,8 +336,8 @@ class MatrixLinearOperator(LinearOperator):
 
 class IdentityOperator(LinearOperator):
     def __init__(self, shape, dtype):
-        LinearOperator.__init__(self, shape=shape, dtype=dtype, matvec=None,
-                                rmatvec=self.rmatvec)
+        super(IdentityOperator, self).__init__(shape=shape, dtype=dtype,
+                matvec=None, rmatvec=self.rmatvec)
 
     def matvec(self, x):
         return x

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -72,10 +72,10 @@ class TestLinearOperator(TestCase):
             assert_(isinstance(A * np.matrix([[1],[2],[3]]), np.ndarray))
             assert_(isinstance(A.dot(np.matrix([[1],[2],[3]])), np.ndarray))
 
-            assert_(isinstance(2*A, interface.LinearOperator))
-            assert_(isinstance(A+A, interface.LinearOperator))
-            assert_(isinstance(-A, interface.LinearOperator))
-            assert_(isinstance(A-A, interface.LinearOperator))
+            assert_(isinstance(2*A, interface._ScaledLinearOperator))
+            assert_(isinstance(A+A, interface._SumLinearOperator))
+            assert_(isinstance(-A, interface._ScaledLinearOperator))
+            assert_(isinstance(A-A, interface._SumLinearOperator))
 
             assert_raises(ValueError, A.matvec, np.array([1,2]))
             assert_raises(ValueError, A.matvec, np.array([1,2,3,4]))
@@ -93,7 +93,7 @@ class TestLinearOperator(TestCase):
             assert_equal((A*B)*[1,1], [50,113])
             assert_equal((A*B)*[[1],[1]], [[50],[113]])
 
-            assert_(isinstance(A*B, interface.LinearOperator))
+            assert_(isinstance(A*B, interface._ProductLinearOperator))
 
             assert_raises(ValueError, A.__add__, B)
             assert_raises(ValueError, A.__pow__, 2)
@@ -103,7 +103,7 @@ class TestLinearOperator(TestCase):
 
             assert_equal((C**2)*[1,1], [17,37])
 
-            assert_(isinstance(C**2, interface.LinearOperator))
+            assert_(isinstance(C**2, interface._PowerLinearOperator))
 
 class TestAsLinearOperator(TestCase):
     def setUp(self):

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -20,6 +20,8 @@ class TestLinearOperator(TestCase):
         self.B = np.array([[1,2],
                            [3,4],
                            [5,6]])
+        self.C = np.array([[1,2],
+                           [3,4]])
 
     def test_matvec(self):
         def get_matvecs(A):
@@ -81,6 +83,7 @@ class TestLinearOperator(TestCase):
             assert_raises(ValueError, A.matvec, np.array([[1],[2],[3],[4]]))
 
             assert_raises(ValueError, A.__mul__, A)
+            assert_raises(ValueError, A.__pow__, 2)
 
         for matvecsA, matvecsB in product(get_matvecs(self.A),
                                           get_matvecs(self.B)):
@@ -94,6 +97,13 @@ class TestLinearOperator(TestCase):
 
             assert_raises(ValueError, A.__add__, B)
             assert_raises(ValueError, A.__pow__, 2)
+
+        for matvecsC in get_matvecs(self.C):
+            C = interface.LinearOperator(**matvecsC)
+
+            assert_equal((C**2)*[1,1], [17,37])
+
+            assert_(isinstance(C**2, interface.LinearOperator))
 
 class TestAsLinearOperator(TestCase):
     def setUp(self):

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -82,8 +82,8 @@ class TestLinearOperator(TestCase):
             assert_raises(ValueError, A.matvec, np.array([[1],[2]]))
             assert_raises(ValueError, A.matvec, np.array([[1],[2],[3],[4]]))
 
-            assert_raises(ValueError, A.__mul__, A)
-            assert_raises(ValueError, A.__pow__, 2)
+            assert_raises(TypeError, lambda: A*A)
+            assert_raises(TypeError, lambda: A**2)
 
         for matvecsA, matvecsB in product(get_matvecs(self.A),
                                           get_matvecs(self.B)):
@@ -95,8 +95,8 @@ class TestLinearOperator(TestCase):
 
             assert_(isinstance(A*B, interface._ProductLinearOperator))
 
-            assert_raises(ValueError, A.__add__, B)
-            assert_raises(ValueError, A.__pow__, 2)
+            assert_raises(TypeError, lambda: A+B)
+            assert_raises(TypeError, lambda: A**2)
 
         for matvecsC in get_matvecs(self.C):
             C = interface.LinearOperator(**matvecsC)


### PR DESCRIPTION
These commits enhance the `LinearOperator` class in `sparse.linalg` such that they can be added/substracted, multiplied and exponentiated. Unit tests are included and should cover all cases. I restructured the unit test for `LinearOperator` a bit.
# Background

With Krylov subspace methods, like the ones in `sparse.linalg` or in external packages like [KryPy](https://github.com/andrenarchy/krypy) (which I maintain), the `LinearOperator` class is very handy. However, sometimes you need to add or multiply LinearOperators. With these commits you can combine `LinearOperator`s like this:

``` python
from scipy.sparse.linalg import LinearOperator
A = LinearOperator([2,2], lambda x: [5*x[0]+x[1], -x[0]])
I = LinearOperator([2,2], lambda x: x)

B = A*(I-A)**2 + I

print(B*[1,1])
```
