### PR TITLE
BF: fix error saving zero entries in sparse matrix

### DIFF
--- a/scipy/io/matlab/miobase.py
+++ b/scipy/io/matlab/miobase.py
@@ -8,6 +8,10 @@ MATLAB is a registered trademark of the Mathworks inc.
 from __future__ import division, print_function, absolute_import
 
 import sys
+import operator
+
+from scipy.lib.six.moves import reduce
+
 import numpy as np
 
 if sys.version_info[0] >= 3:
@@ -293,11 +297,11 @@ def matdims(arr, oned_as='column'):
     ValueError: 1D option "bizarre" is strange
 
     """
-    if arr.size == 0:  # empty
-        return (0,) * np.max([arr.ndim, 2])
     shape = arr.shape
     if shape == ():  # scalar
         return (1,1)
+    if reduce(operator.mul, shape) == 0: # zero elememts
+        return (0,) * np.max([arr.ndim, 2])
     if len(shape) == 1:  # 1D
         if oned_as == 'column':
             return shape + (1,)

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1083,5 +1083,17 @@ def test_unicode_mat4():
     assert_equal(var_back['second_cat'], var['second_cat'])
 
 
+def test_empty_sparse():
+    # Can we read empty sparse matrices?
+    sio = BytesIO()
+    import scipy.sparse
+    empty_sparse = scipy.sparse.csr_matrix([[0,0],[0,0]])
+    savemat(sio, dict(x = empty_sparse))
+    sio.seek(0)
+    res = loadmat(sio)
+    assert_array_equal(res['x'].shape, empty_sparse.shape)
+    assert_array_equal(res['x'].todense(), 0)
+
+
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/io/matlab/tests/test_miobase.py
+++ b/scipy/io/matlab/tests/test_miobase.py
@@ -1,0 +1,34 @@
+""" Testing miobase module
+"""
+
+import numpy as np
+
+from numpy.testing import (assert_almost_equal,
+                           assert_array_equal)
+
+from nose.tools import (assert_true, assert_false, assert_raises,
+                        assert_equal, assert_not_equal)
+
+from scipy.io.matlab.miobase import matdims
+
+
+def test_matdims():
+    # Test matdims dimension finder
+    assert_equal(matdims(np.array(1)), (1, 1)) # numpy scalar
+    assert_equal(matdims(np.array([1])), (1, 1)) # 1d array, 1 element
+    assert_equal(matdims(np.array([1,2])), (2, 1)) # 1d array, 2 elements
+    assert_equal(matdims(np.array([[2],[3]])), (2, 1)) # 2d array, column vector
+    assert_equal(matdims(np.array([[2,3]])), (1, 2)) # 2d array, row vector
+    # 3d array, rowish vector
+    assert_equal(matdims(np.array([[[2,3]]])), (1, 1, 2))
+    assert_equal(matdims(np.array([])), (0, 0)) # empty 1d array
+    assert_equal(matdims(np.array([[]])), (0, 0)) # empty 2d
+    assert_equal(matdims(np.array([[[]]])), (0, 0, 0)) # empty 3d
+    # Optional argument flips 1-D shape behavior.
+    assert_equal(matdims(np.array([1,2]), 'row'), (1, 2)) # 1d array, 2 elements
+    # The argument has to make sense though
+    assert_raises(ValueError, matdims, np.array([1,2]), 'bizarre')
+    # Check empty sparse matrices get their own shape
+    from scipy.sparse import csr_matrix, csc_matrix
+    assert_equal(matdims(csr_matrix(np.zeros((3, 3)))), (3, 3))
+    assert_equal(matdims(csc_matrix(np.zeros((2, 2)))), (2, 2))


### PR DESCRIPTION
I assumed obj.size was the same as np.prod(obj.shape), but this isn't so for
sparse matrices.  Fix and test.

Closes gh-2700
