### PR TITLE
MRG: acting on pendng matlab io deprecations

### DIFF
--- a/doc/release/0.13.0-notes.rst
+++ b/doc/release/0.13.0-notes.rst
@@ -247,6 +247,21 @@ Removed deprecated keywords ``xa`` and ``xb`` from ``stats.distributions``
 The keywords ``xa`` and ``xb``, which were deprecated since 0.11.0, have
 been removed from the distributions in ``scipy.stats``.
 
+Changes to MATLAB file readers / writers
+----------------------------------------
+
+The major change is that 1D arrays in numpy now become row vectors (shape 1, N)
+when saved to a MATLAB 5 format file.  Previously 1D arrays saved as column
+vectors (N, 1).  This is to harmonize the behavior of writing MATLAB 4 and 5
+formats, and adapt to the defaults of numpy and MATLAB - for example
+``np.atleast_2d`` returns 1D arrays as row vectors.
+
+Trying to save arrays of greater than 2 dimensions in MATLAB 4 format now raises
+an error instead of silently reshaping the array as 2D.
+
+``scipy.io.loadmat('afile')`` used to look for `afile` on the Python system path
+(``sys.path``); now ``loadmat`` only looks in the current directory for a
+relative path filename.
 
 Other changes
 =============

--- a/doc/source/tutorial/io.rst
+++ b/doc/source/tutorial/io.rst
@@ -84,7 +84,7 @@ the command line for me):
 Now, to Python:
 
   >>> mat_contents = sio.loadmat('octave_a.mat')
-  >>> print mat_contents
+  >>> mat_contents
   {'a': array([[[  1.,   4.,   7.,  10.],
           [  2.,   5.,   8.,  11.],
           [  3.,   6.,   9.,  12.]]]),
@@ -93,54 +93,22 @@ Now, to Python:
    Octave 3.6.3, 2013-02-17 21:02:11 UTC',
    '__globals__': []}
   >>> oct_a = mat_contents['a']
-  >>> print oct_a
-  [[[  1.   4.   7.  10.]
-    [  2.   5.   8.  11.]
-    [  3.   6.   9.  12.]]]
-  >>> print oct_a.shape
+  >>> oct_a
+  array([[[  1.,   4.,   7.,  10.],
+          [  2.,   5.,   8.,  11.],
+          [  3.,   6.,   9.,  12.]]])
+  >>> oct_a.shape
   (1, 3, 4)
 
 Now let's try the other way round:
 
   >>> import numpy as np
   >>> vect = np.arange(10)
-  >>> print vect.shape
+  >>> vect.shape
   (10,)
   >>> sio.savemat('np_vector.mat', {'vect':vect})
-  /Users/mb312/usr/local/lib/python2.7/site-packages/scipy/io/matlab/mio.py:267: FutureWarning: Using oned_as default value ('column') This will change to 'row' in future versions
-    oned_as=oned_as)
 
 Then back to Octave:
-
-.. sourcecode:: octave
-
-   octave:5> load np_vector.mat
-   octave:6> vect
-   vect =
-
-     0
-     1
-     2
-     3
-     4
-     5
-     6
-     7
-     8
-     9
-
-   octave:7> size(vect)
-   ans =
-
-      10    1
-
-Note the deprecation warning.  The ``oned_as`` keyword determines the way in
-which one-dimensional vectors are stored.  In the future, this will default
-to ``row`` instead of ``column``:
-
-   >>> sio.savemat('np_vector.mat', {'vect':vect}, oned_as='row')
-
-We can load this in Octave or MATLAB:
 
 .. sourcecode:: octave
 
@@ -187,23 +155,23 @@ a single struct is an array of shape (1, 1).
 We can load this in Python:
 
    >>> mat_contents = sio.loadmat('octave_struct.mat')
-   >>> print mat_contents
+   >>> mat_contents
    {'my_struct': array([[([[1.0]], [[2.0]])]],
          dtype=[('field1', 'O'), ('field2', 'O')]), '__version__': '1.0', '__header__': 'MATLAB 5.0 MAT-file, written by Octave 3.6.3, 2013-02-17 21:23:14 UTC', '__globals__': []}
    >>> oct_struct = mat_contents['my_struct']
-   >>> print oct_struct.shape
+   >>> oct_struct.shape
    (1, 1)
    >>> val = oct_struct[0,0]
-   >>> print val
+   >>> val
    ([[1.0]], [[2.0]])
-   >>> print val['field1']
-   [[ 1.]]
-   >>> print val['field2']
-   [[ 2.]]
-   >>> print val.dtype
-   [('field1', 'O'), ('field2', 'O')]
+   >>> val['field1']
+   array([[ 1.]])
+   >>> val['field2']
+   array([[ 2.]])
+   >>> val.dtype
+   dtype([('field1', 'O'), ('field2', 'O')])
 
-In this version of Scipy (0.12.0), MATLAB structs come back as numpy
+In versions of Scipy from 0.12.0, MATLAB structs come back as numpy
 structured arrays, with fields named for the struct fields.  You can see
 the field names in the ``dtype`` output above.  Note also:
 
@@ -228,9 +196,9 @@ squeezed out, try this:
    ()
 
 Sometimes, it's more convenient to load the MATLAB structs as python
-objects rather than numpy structured arrarys - it can make the access
+objects rather than numpy structured arrays - it can make the access
 syntax in python a bit more similar to that in MATLAB.  In order to do
-this, use the ``struct_as_record=False`` parameter to ``loadmat``.
+this, use the ``struct_as_record=False`` parameter setting to ``loadmat``.
 
    >>> mat_contents = sio.loadmat('octave_struct.mat', struct_as_record=False)
    >>> oct_struct = mat_contents['my_struct']
@@ -245,9 +213,9 @@ this, use the ``struct_as_record=False`` parameter to ``loadmat``.
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    AttributeError: 'mat_struct' object has no attribute 'shape'
-   >>> print type(oct_struct)
+   >>> type(oct_struct)
    <class 'scipy.io.matlab.mio5_params.mat_struct'>
-   >>> print oct_struct.field1
+   >>> oct_struct.field1
    1.0
 
 Saving struct arrays can be done in various ways.  One simple method is
@@ -274,8 +242,9 @@ like this:
 
    >>> dt = [('f1', 'f8'), ('f2', 'S10')]
    >>> arr = np.zeros((2,), dtype=dt)
-   >>> print arr
-   [(0.0, '') (0.0, '')]
+   >>> arr
+   array([(0.0, ''), (0.0, '')], 
+         dtype=[('f1', '<f8'), ('f2', 'S10')])
    >>> arr[0]['f1'] = 0.5
    >>> arr[0]['f2'] = 'python'
    >>> arr[1]['f1'] = 99
@@ -308,12 +277,12 @@ Back to Python:
 
    >>> mat_contents = sio.loadmat('octave_cells.mat')
    >>> oct_cells = mat_contents['my_cells']
-   >>> print oct_cells.dtype
+   >>> print(oct_cells.dtype)
    object
    >>> val = oct_cells[0,0]
-   >>> print val
-   [[ 1.]]
-   >>> print val.dtype
+   >>> val
+   array([[ 1.]])
+   >>> print(val.dtype)
    float64
 
 Saving to a MATLAB cell array just involves making a numpy object array:
@@ -321,8 +290,8 @@ Saving to a MATLAB cell array just involves making a numpy object array:
    >>> obj_arr = np.zeros((2,), dtype=np.object)
    >>> obj_arr[0] = 1
    >>> obj_arr[1] = 'a string'
-   >>> print obj_arr
-   [1 'a string']
+   >>> obj_arr
+   array([1, 'a string'], dtype=object)
    >>> sio.savemat('np_cells.mat', {'obj_arr':obj_arr})
 
 .. sourcecode:: octave

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -5,10 +5,6 @@ Module for reading and writing matlab (TM) .mat files
 
 from __future__ import division, print_function, absolute_import
 
-import os
-import sys
-import warnings
-
 import numpy as np
 
 from scipy.lib.six import string_types
@@ -19,49 +15,6 @@ from .mio5 import MatFile5Reader, MatFile5Writer
 
 __all__ = ['find_mat_file', 'mat_reader_factory', 'loadmat', 'savemat',
            'whosmat']
-
-@np.deprecate(message='find_mat_file will be removed in the next '
-              'version of scipy')
-@docfiller
-def find_mat_file(file_name, appendmat=True):
-    ''' Try to find .mat file on system path
-
-    Parameters
-    ----------
-    file_name : str
-       file name for mat file
-    %(append_arg)s
-
-    Returns
-    -------
-    full_name : string
-       possibly modified name after path search
-    '''
-    warnings.warn('Searching for mat files on python system path will be ' +
-                  'removed in next version of scipy',
-                   DeprecationWarning, stacklevel=2)
-    if appendmat and file_name.endswith(".mat"):
-        file_name = file_name[:-4]
-    if os.sep in file_name:
-        full_name = file_name
-        if appendmat:
-            full_name = file_name + ".mat"
-    else:
-        full_name = None
-        junk, file_name = os.path.split(file_name)
-        for path in [os.curdir] + list(sys.path):
-            test_name = os.path.join(path, file_name)
-            if appendmat:
-                test_name += ".mat"
-            try:
-                fid = open(test_name,'rb')
-                fid.close()
-                full_name = test_name
-                break
-            except IOError:
-                pass
-    return full_name
-
 
 def _open_file(file_like, appendmat):
     ''' Open `file_like` and return as file-like object '''

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -186,7 +186,7 @@ def savemat(file_name, mdict,
             format='5',
             long_field_names=False,
             do_compression=False,
-            oned_as=None):
+            oned_as='row'):
     """
     Save a dictionary of names and arrays into a MATLAB-style .mat file.
 
@@ -214,31 +214,14 @@ def savemat(file_name, mdict,
         which works for MATLAB 7.6+
     do_compression : bool, optional
         Whether or not to compress matrices on write.  Default is False.
-    oned_as : {'column', 'row', None}, optional
+    oned_as : {'row', 'column'}, optional
         If 'column', write 1-D numpy arrays as column vectors.
         If 'row', write 1-D numpy arrays as row vectors.
-        If None (the default), the behavior depends on the value of `format`
-        (see Notes below).
 
     See also
     --------
     mio4.MatFile4Writer
     mio5.MatFile5Writer
-
-    Notes
-    -----
-    If ``format == '4'``, `mio4.MatFile4Writer` is called, which sets
-    `oned_as` to 'row' if it had been None.  If ``format == '5'``,
-    `mio5.MatFile5Writer` is called, which sets `oned_as` to 'column' if
-    it had been None, but first it executes:
-
-    ``warnings.warn("Using oned_as default value ('column')" +``
-                  ``" This will change to 'row' in future versions",``
-                  ``FutureWarning, stacklevel=2)``
-
-    without being more specific as to precisely when the change will take
-    place.
-
     """
     file_is_string = isinstance(file_name, string_types)
     if file_is_string:

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -9,6 +9,8 @@ import os
 import sys
 import warnings
 
+import numpy as np
+
 from scipy.lib.six import string_types
 
 from .miobase import get_matfile_version, docfiller
@@ -18,7 +20,8 @@ from .mio5 import MatFile5Reader, MatFile5Writer
 __all__ = ['find_mat_file', 'mat_reader_factory', 'loadmat', 'savemat',
            'whosmat']
 
-
+@np.deprecate(message='find_mat_file will be removed in the next '
+              'version of scipy')
 @docfiller
 def find_mat_file(file_name, appendmat=True):
     ''' Try to find .mat file on system path
@@ -65,19 +68,11 @@ def _open_file(file_like, appendmat):
     if isinstance(file_like, string_types):
         try:
             return open(file_like, 'rb')
-        except IOError:
-            pass
-        if appendmat and not file_like.endswith('.mat'):
-            try:
-                return open(file_like + '.mat', 'rb')
-            except IOError:
-                pass
-        # search the python path - we'll remove this soon
-        full_name = find_mat_file(file_like, appendmat)
-        if full_name is None:
-            raise IOError("%s not found on the path."
-                          % file_like)
-        return open(full_name, 'rb')
+        except IOError as e:
+            if appendmat and not file_like.endswith('.mat'):
+                file_like += '.mat'
+                return open(file_like, 'rb')
+            raise IOError(e)
     # not a string - maybe file-like object
     try:
         file_like.read(0)

--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -424,11 +424,7 @@ class MatFile4Reader(MatFileReader):
 def arr_to_2d(arr, oned_as='row'):
     ''' Make ``arr`` exactly two dimensional
 
-    If `arr` has more than 2 dimensions, then, for the sake of
-    compatibility with previous versions of scipy, we reshape to 2D
-    preserving the last dimension and increasing the first dimension.
-    In future versions we will raise an error, as this is at best a very
-    counterinituitive thing to do.
+    If `arr` has more than 2 dimensions, raise a ValueError
 
     Parameters
     ----------
@@ -444,13 +440,8 @@ def arr_to_2d(arr, oned_as='row'):
     '''
     dims = matdims(arr, oned_as)
     if len(dims) > 2:
-        warnings.warn('Matlab 4 files only support <=2 '
-                      'dimensions; the next version of scipy will '
-                      'raise an error when trying to write >2D arrays '
-                      'to matlab 4 format files',
-                      DeprecationWarning,
-                      )
-        return arr.reshape((-1,dims[-1]))
+        raise ValueError('Matlab 4 files cannot save arrays with more than '
+                         '2 dimensions')
     return arr.reshape(dims)
 
 

--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -12,9 +12,8 @@ import scipy.sparse
 
 from scipy.lib.six import string_types
 
-from .miobase import MatFileReader, docfiller, matdims, \
-     read_dtype, convert_dtypes, arr_to_chars, arr_dtype_number, \
-     MatWriteError
+from .miobase import (MatFileReader, docfiller, matdims, read_dtype,
+                      convert_dtypes, arr_to_chars, arr_dtype_number)
 
 from .mio_utils import squeeze_element, chars_to_strings
 from functools import reduce

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -797,7 +797,7 @@ class MatFile5Writer(object):
                  unicode_strings=False,
                  global_vars=None,
                  long_field_names=False,
-                 oned_as=None):
+                 oned_as='row'):
         ''' Initialize writer for matlab 5 format files
 
         Parameters
@@ -817,13 +817,6 @@ class MatFile5Writer(object):
         else:
             self.global_vars = []
         self.long_field_names = long_field_names
-        # deal with deprecations
-        if oned_as is None:
-            warnings.warn("Using oned_as default value ('row') "
-                          "This default has changed from 'column' "
-                          "in scipy versions < 0.13",
-                          UserWarning, stacklevel=2)
-            oned_as = 'row'
         self.oned_as = oned_as
         self._matrix_writer = None
 

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -819,10 +819,11 @@ class MatFile5Writer(object):
         self.long_field_names = long_field_names
         # deal with deprecations
         if oned_as is None:
-            warnings.warn("Using oned_as default value ('column')" +
-                          " This will change to 'row' in future versions",
-                          FutureWarning, stacklevel=2)
-            oned_as = 'column'
+            warnings.warn("Using oned_as default value ('row') "
+                          "This default has changed from 'column' "
+                          "in scipy versions < 0.13",
+                          UserWarning, stacklevel=2)
+            oned_as = 'row'
         self.oned_as = oned_as
         self._matrix_writer = None
 

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -90,19 +90,19 @@ from scipy.lib.six import string_types
 
 from .byteordercodes import native_code, swapped_code
 
-from .miobase import MatFileReader, docfiller, matdims, \
-     read_dtype, arr_to_chars, arr_dtype_number, \
-     MatWriteError, MatReadError, MatReadWarning
+from .miobase import (MatFileReader, docfiller, matdims, read_dtype,
+                      arr_to_chars, arr_dtype_number, MatWriteError,
+                      MatReadError, MatReadWarning)
 
 # Reader object for matlab 5 format variables
 from .mio5_utils import VarReader5
 
 # Constants and helper objects
-from .mio5_params import MatlabObject, MatlabFunction, \
-        MDTYPES, NP_TO_MTYPES, NP_TO_MXTYPES, \
-        miCOMPRESSED, miMATRIX, miINT8, miUTF8, miUINT32, \
-        mxCELL_CLASS, mxSTRUCT_CLASS, mxOBJECT_CLASS, mxCHAR_CLASS, \
-        mxSPARSE_CLASS, mxDOUBLE_CLASS, mclass_info, mclass_dtypes_template
+from .mio5_params import (MatlabObject, MatlabFunction, MDTYPES, NP_TO_MTYPES,
+                          NP_TO_MXTYPES, miCOMPRESSED, miMATRIX, miINT8, miUTF8,
+                          miUINT32, mxCELL_CLASS, mxSTRUCT_CLASS,
+                          mxOBJECT_CLASS, mxCHAR_CLASS, mxSPARSE_CLASS,
+                          mxDOUBLE_CLASS, mclass_info)
 
 from .streams import ZlibInputStream
 

--- a/scipy/io/matlab/miobase.py
+++ b/scipy/io/matlab/miobase.py
@@ -80,7 +80,7 @@ matlab_compatible : bool, optional
          '''do_compression : bool, optional
    Whether to compress matrices on write. Default is False.''',
      'oned_as':
-         '''oned_as : {'column', 'row'}, optional
+         '''oned_as : {'row', 'column'}, optional
    If 'column', write 1-D numpy arrays as column vectors.
    If 'row', write 1D numpy arrays as row vectors.''',
      'unicode_strings':

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -587,28 +587,26 @@ def test_save_dict():
 def test_1d_shape():
     # New 5 behavior is 1D -> row vector
     arr = np.arange(5)
-    # silence warnings for tests
-    with warnings.catch_warnings():
-        for format in ('4', '5'):
-            # Column is the default
-            stream = BytesIO()
-            savemat(stream, {'oned': arr}, format=format)
-            vals = loadmat(stream)
-            assert_equal(vals['oned'].shape, (1, 5))
-            # can be explicitly 'column' for oned_as
-            stream = BytesIO()
-            savemat(stream, {'oned':arr},
-                    format=format,
-                    oned_as='column')
-            vals = loadmat(stream)
-            assert_equal(vals['oned'].shape, (5,1))
-            # but different from 'row'
-            stream = BytesIO()
-            savemat(stream, {'oned':arr},
-                    format=format,
-                    oned_as='row')
-            vals = loadmat(stream)
-            assert_equal(vals['oned'].shape, (1,5))
+    for format in ('4', '5'):
+        # Column is the default
+        stream = BytesIO()
+        savemat(stream, {'oned': arr}, format=format)
+        vals = loadmat(stream)
+        assert_equal(vals['oned'].shape, (1, 5))
+        # can be explicitly 'column' for oned_as
+        stream = BytesIO()
+        savemat(stream, {'oned':arr},
+                format=format,
+                oned_as='column')
+        vals = loadmat(stream)
+        assert_equal(vals['oned'].shape, (5,1))
+        # but different from 'row'
+        stream = BytesIO()
+        savemat(stream, {'oned':arr},
+                format=format,
+                oned_as='row')
+        vals = loadmat(stream)
+        assert_equal(vals['oned'].shape, (1,5))
 
 
 def test_compression():

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -31,8 +31,7 @@ import scipy.sparse as SP
 
 import scipy.io.matlab.byteordercodes as boc
 from scipy.io.matlab.miobase import matdims, MatWriteError
-from scipy.io.matlab.mio import (find_mat_file, mat_reader_factory, loadmat,
-                                 savemat, whosmat)
+from scipy.io.matlab.mio import (mat_reader_factory, loadmat, savemat, whosmat)
 from scipy.io.matlab.mio5 import (MatlabObject, MatFile5Writer, MatFile5Reader,
                                   MatlabFunction, varmats_from_mat)
 
@@ -439,19 +438,16 @@ def test_mat73():
 
 
 def test_warnings():
+    # This test is an echo of the previous behavior, which was to raise a
+    # warning if the user triggered a search for mat files on the Python system
+    # path.  We can remove the test in the next version after upcoming (0.13)
     fname = pjoin(test_data_path, 'testdouble_7.1_GLNX86.mat')
-    warn_ctx = WarningManager()
-    warn_ctx.__enter__()
-    try:
+    with warnings.catch_warnings():
         warnings.simplefilter('error')
         # This should not generate a warning
         mres = loadmat(fname, struct_as_record=True)
         # This neither
         mres = loadmat(fname, struct_as_record=False)
-        # This should - because of deprecated system path search
-        assert_raises(DeprecationWarning, find_mat_file, fname)
-    finally:
-        warn_ctx.__exit__()
 
 
 def test_regression_653():

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -7,13 +7,11 @@ Need function load / save / roundtrip tests
 '''
 from __future__ import division, print_function, absolute_import
 
-import sys
 import os
 from os.path import join as pjoin, dirname
 from glob import glob
 from io import BytesIO
 from tempfile import mkdtemp
-from functools import partial
 
 from scipy.lib.six import u, text_type, string_types
 
@@ -21,11 +19,8 @@ import warnings
 import shutil
 import gzip
 
-from numpy.testing import \
-     assert_array_equal, \
-     assert_array_almost_equal, \
-     assert_equal, \
-     assert_raises, run_module_suite
+from numpy.testing import (assert_array_equal, assert_array_almost_equal,
+                           assert_equal, assert_raises, run_module_suite)
 from numpy.testing.utils import WarningManager
 
 from nose.tools import assert_true
@@ -35,12 +30,11 @@ from numpy import array
 import scipy.sparse as SP
 
 import scipy.io.matlab.byteordercodes as boc
-from scipy.io.matlab.miobase import matdims, MatFileReader, \
-    MatWriteError
-from scipy.io.matlab.mio import find_mat_file, mat_reader_factory, \
-    loadmat, savemat, whosmat
-from scipy.io.matlab.mio5 import MatlabObject, MatFile5Writer, \
-      MatFile5Reader, MatlabFunction, varmats_from_mat
+from scipy.io.matlab.miobase import matdims, MatWriteError
+from scipy.io.matlab.mio import (find_mat_file, mat_reader_factory, loadmat,
+                                 savemat, whosmat)
+from scipy.io.matlab.mio5 import (MatlabObject, MatFile5Writer, MatFile5Reader,
+                                  MatlabFunction, varmats_from_mat)
 
 # Use future defaults to silence unwanted test warnings
 savemat_future = partial(savemat, oned_as='row')

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -36,17 +36,6 @@ from scipy.io.matlab.mio import (find_mat_file, mat_reader_factory, loadmat,
 from scipy.io.matlab.mio5 import (MatlabObject, MatFile5Writer, MatFile5Reader,
                                   MatlabFunction, varmats_from_mat)
 
-# Use future defaults to silence unwanted test warnings
-savemat_future = partial(savemat, oned_as='row')
-
-
-class MatFile5Reader_future(MatFile5Reader):
-    def __init__(self, *args, **kwargs):
-        sar = kwargs.get('struct_as_record')
-        if sar is None:
-            kwargs['struct_as_record'] = True
-        super(MatFile5Reader_future, self).__init__(*args, **kwargs)
-
 
 test_data_path = pjoin(dirname(__file__), 'data')
 
@@ -338,7 +327,7 @@ def _whos_check_case(name, files, case, classes):
 # Round trip tests
 def _rt_check_case(name, expected, format):
     mat_stream = BytesIO()
-    savemat_future(mat_stream, expected, format=format)
+    savemat(mat_stream, expected, format=format)
     mat_stream.seek(0)
     _load_check_case(name, [mat_stream], expected)
 
@@ -392,7 +381,7 @@ def test_gzip_simple():
     try:
         fname = pjoin(tmpdir,name)
         mat_stream = gzip.open(fname,mode='wb')
-        savemat_future(mat_stream, expected, format=format)
+        savemat(mat_stream, expected, format=format)
         mat_stream.close()
 
         mat_stream = gzip.open(fname,mode='rb')
@@ -415,15 +404,15 @@ def test_multiple_open():
         fname = pjoin(tmpdir, "a.mat")
 
         # Check that file is not left open
-        savemat(fname, x, oned_as='row')
+        savemat(fname, x)
         os.unlink(fname)
-        savemat(fname, x, oned_as='row')
+        savemat(fname, x)
         loadmat(fname)
         os.unlink(fname)
 
         # Check that stream is left open
         f = open(fname, 'wb')
-        savemat(f, x, oned_as='column')
+        savemat(f, x)
         f.seek(0)
         f.close()
 
@@ -467,7 +456,7 @@ def test_warnings():
 
 def test_regression_653():
     """Regression test for #653."""
-    assert_raises(TypeError, savemat_future, BytesIO(), {'d':{1:2}}, format='5')
+    assert_raises(TypeError, savemat, BytesIO(), {'d':{1:2}}, format='5')
 
 
 def test_structname_len():
@@ -476,17 +465,17 @@ def test_structname_len():
     fldname = 'a' * lim
     st1 = np.zeros((1,1), dtype=[(fldname, object)])
     mat_stream = BytesIO()
-    savemat_future(BytesIO(), {'longstruct': st1}, format='5')
+    savemat(BytesIO(), {'longstruct': st1}, format='5')
     fldname = 'a' * (lim+1)
     st1 = np.zeros((1,1), dtype=[(fldname, object)])
-    assert_raises(ValueError, savemat_future, BytesIO(),
+    assert_raises(ValueError, savemat, BytesIO(),
                   {'longstruct': st1}, format='5')
 
 
 def test_4_and_long_field_names_incompatible():
     # Long field names option not supported in 4
     my_struct = np.zeros((1,1),dtype=[('my_fieldname',object)])
-    assert_raises(ValueError, savemat_future, BytesIO(),
+    assert_raises(ValueError, savemat, BytesIO(),
                   {'my_struct':my_struct}, format='4', long_field_names=True)
 
 
@@ -496,10 +485,10 @@ def test_long_field_names():
     fldname = 'a' * lim
     st1 = np.zeros((1,1), dtype=[(fldname, object)])
     mat_stream = BytesIO()
-    savemat_future(BytesIO(), {'longstruct': st1}, format='5',long_field_names=True)
+    savemat(BytesIO(), {'longstruct': st1}, format='5',long_field_names=True)
     fldname = 'a' * (lim+1)
     st1 = np.zeros((1,1), dtype=[(fldname, object)])
-    assert_raises(ValueError, savemat_future, BytesIO(),
+    assert_raises(ValueError, savemat, BytesIO(),
                   {'longstruct': st1}, format='5',long_field_names=True)
 
 
@@ -513,11 +502,11 @@ def test_long_field_names_in_struct():
     cell[0,0] = st1
     cell[0,1] = st1
     mat_stream = BytesIO()
-    savemat_future(BytesIO(), {'longstruct': cell}, format='5',long_field_names=True)
+    savemat(BytesIO(), {'longstruct': cell}, format='5',long_field_names=True)
     #
     # Check to make sure it fails with long field names off
     #
-    assert_raises(ValueError, savemat_future, BytesIO(),
+    assert_raises(ValueError, savemat, BytesIO(),
                   {'longstruct': cell}, format='5', long_field_names=False)
 
 
@@ -529,17 +518,17 @@ def test_cell_with_one_thing_in_it():
     cells[0,0] = 'Hello'
     cells[0,1] = 'World'
     mat_stream = BytesIO()
-    savemat_future(BytesIO(), {'x': cells}, format='5')
+    savemat(BytesIO(), {'x': cells}, format='5')
 
     cells = np.ndarray((1,1),dtype=object)
     cells[0,0] = 'Hello, world'
     mat_stream = BytesIO()
-    savemat_future(BytesIO(), {'x': cells}, format='5')
+    savemat(BytesIO(), {'x': cells}, format='5')
 
 
 def test_writer_properties():
     # Tests getting, setting of properties of matrix writer
-    mfw = MatFile5Writer(BytesIO(), oned_as='row')
+    mfw = MatFile5Writer(BytesIO())
     yield assert_equal, mfw.global_vars, []
     mfw.global_vars = ['avar']
     yield assert_equal, mfw.global_vars, ['avar']
@@ -554,7 +543,7 @@ def test_writer_properties():
 def test_use_small_element():
     # Test whether we're using small data element or not
     sio = BytesIO()
-    wtr = MatFile5Writer(sio, oned_as='column')
+    wtr = MatFile5Writer(sio)
     # First check size for no sde for name
     arr = np.zeros(10)
     wtr.put_variables({'aaaaa': arr})
@@ -586,7 +575,7 @@ def test_save_dict():
         # Initialize with tuples to keep order for OrderedDict
         d = dict_type([('a', 1), ('b', 2)])
         stream = BytesIO()
-        savemat_future(stream, {'dict': d})
+        savemat(stream, {'dict': d})
         stream.seek(0)
         vals = loadmat(stream)['dict']
         assert_equal(set(vals.dtype.names), set(['a', 'b']))
@@ -600,23 +589,16 @@ def test_save_dict():
 
 
 def test_1d_shape():
-    # Current 5 behavior is 1D -> column vector
+    # New 5 behavior is 1D -> row vector
     arr = np.arange(5)
-    stream = BytesIO()
-    warn_ctx = WarningManager()
-    warn_ctx.__enter__()
-    try:
-        # silence warnings for tests
-        warnings.simplefilter('ignore')
-        savemat(stream, {'oned':arr}, format='5')
-        vals = loadmat(stream)
-        assert_equal(vals['oned'].shape, (5,1))
-        # Current 4 behavior is 1D -> row vector
-        stream = BytesIO()
-        savemat(stream, {'oned':arr}, format='4')
-        vals = loadmat(stream)
-        assert_equal(vals['oned'].shape, (1, 5))
+    # silence warnings for tests
+    with warnings.catch_warnings():
         for format in ('4', '5'):
+            # Column is the default
+            stream = BytesIO()
+            savemat(stream, {'oned': arr}, format=format)
+            vals = loadmat(stream)
+            assert_equal(vals['oned'].shape, (1, 5))
             # can be explicitly 'column' for oned_as
             stream = BytesIO()
             savemat(stream, {'oned':arr},
@@ -631,20 +613,18 @@ def test_1d_shape():
                     oned_as='row')
             vals = loadmat(stream)
             assert_equal(vals['oned'].shape, (1,5))
-    finally:
-        warn_ctx.__exit__()
 
 
 def test_compression():
     arr = np.zeros(100).reshape((5,20))
     arr[2,10] = 1
     stream = BytesIO()
-    savemat_future(stream, {'arr':arr})
+    savemat(stream, {'arr':arr})
     raw_len = len(stream.getvalue())
     vals = loadmat(stream)
     yield assert_array_equal, vals['arr'], arr
     stream = BytesIO()
-    savemat_future(stream, {'arr':arr}, do_compression=True)
+    savemat(stream, {'arr':arr}, do_compression=True)
     compressed_len = len(stream.getvalue())
     vals = loadmat(stream)
     yield assert_array_equal, vals['arr'], arr
@@ -653,18 +633,18 @@ def test_compression():
     arr2 = arr.copy()
     arr2[0,0] = 1
     stream = BytesIO()
-    savemat_future(stream, {'arr':arr, 'arr2':arr2}, do_compression=False)
+    savemat(stream, {'arr':arr, 'arr2':arr2}, do_compression=False)
     vals = loadmat(stream)
     yield assert_array_equal, vals['arr2'], arr2
     stream = BytesIO()
-    savemat_future(stream, {'arr':arr, 'arr2':arr2}, do_compression=True)
+    savemat(stream, {'arr':arr, 'arr2':arr2}, do_compression=True)
     vals = loadmat(stream)
     yield assert_array_equal, vals['arr2'], arr2
 
 
 def test_single_object():
     stream = BytesIO()
-    savemat_future(stream, {'A':np.array(1, dtype=object)})
+    savemat(stream, {'A':np.array(1, dtype=object)})
 
 
 def test_skip_variable():
@@ -710,7 +690,7 @@ def test_empty_struct():
     stream = BytesIO()
     arr = np.array((), dtype='U')
     # before ticket fix, this used to give data type not understood
-    savemat_future(stream, {'arr':arr})
+    savemat(stream, {'arr':arr})
     d = loadmat(stream)
     a2 = d['arr']
     assert_array_equal(a2, arr)
@@ -726,7 +706,7 @@ def test_recarray():
     arr[1]['f1'] = 99
     arr[1]['f2'] = 'not perl'
     stream = BytesIO()
-    savemat_future(stream, {'arr': arr})
+    savemat(stream, {'arr': arr})
     d = loadmat(stream, struct_as_record=False)
     a20 = d['arr'][0,0]
     yield assert_equal, a20.f1, 0.5
@@ -750,7 +730,7 @@ def test_save_object():
     c.field1 = 1
     c.field2 = 'a string'
     stream = BytesIO()
-    savemat_future(stream, {'c': c})
+    savemat(stream, {'c': c})
     d = loadmat(stream, struct_as_record=False)
     c2 = d['c'][0,0]
     assert_equal(c2.field1, 1)
@@ -766,30 +746,30 @@ def test_read_opts():
     # initialization
     arr = np.arange(6).reshape(1,6)
     stream = BytesIO()
-    savemat_future(stream, {'a': arr})
-    rdr = MatFile5Reader_future(stream)
+    savemat(stream, {'a': arr})
+    rdr = MatFile5Reader(stream)
     back_dict = rdr.get_variables()
     rarr = back_dict['a']
     assert_array_equal(rarr, arr)
-    rdr = MatFile5Reader_future(stream, squeeze_me=True)
+    rdr = MatFile5Reader(stream, squeeze_me=True)
     assert_array_equal(rdr.get_variables()['a'], arr.reshape((6,)))
     rdr.squeeze_me = False
     assert_array_equal(rarr, arr)
-    rdr = MatFile5Reader_future(stream, byte_order=boc.native_code)
+    rdr = MatFile5Reader(stream, byte_order=boc.native_code)
     assert_array_equal(rdr.get_variables()['a'], arr)
     # inverted byte code leads to error on read because of swapped
     # header etc
-    rdr = MatFile5Reader_future(stream, byte_order=boc.swapped_code)
+    rdr = MatFile5Reader(stream, byte_order=boc.swapped_code)
     assert_raises(Exception, rdr.get_variables)
     rdr.byte_order = boc.native_code
     assert_array_equal(rdr.get_variables()['a'], arr)
     arr = np.array(['a string'])
     stream.truncate(0)
     stream.seek(0)
-    savemat_future(stream, {'a': arr})
-    rdr = MatFile5Reader_future(stream)
+    savemat(stream, {'a': arr})
+    rdr = MatFile5Reader(stream)
     assert_array_equal(rdr.get_variables()['a'], arr)
-    rdr = MatFile5Reader_future(stream, chars_as_strings=False)
+    rdr = MatFile5Reader(stream, chars_as_strings=False)
     carr = np.atleast_2d(np.array(list(arr.item()), dtype='U1'))
     assert_array_equal(rdr.get_variables()['a'], carr)
     rdr.chars_as_strings = True
@@ -800,7 +780,7 @@ def test_empty_string():
     # make sure reading empty string does not raise error
     estring_fname = pjoin(test_data_path, 'single_empty_string.mat')
     fp = open(estring_fname, 'rb')
-    rdr = MatFile5Reader_future(fp)
+    rdr = MatFile5Reader(fp)
     d = rdr.get_variables()
     fp.close()
     assert_array_equal(d['a'], np.array([], dtype='U1'))
@@ -810,14 +790,14 @@ def test_empty_string():
     # arrays of char.  There is no way of having an array of char that
     # is not empty, but contains an empty string.
     stream = BytesIO()
-    savemat_future(stream, {'a': np.array([''])})
-    rdr = MatFile5Reader_future(stream)
+    savemat(stream, {'a': np.array([''])})
+    rdr = MatFile5Reader(stream)
     d = rdr.get_variables()
     assert_array_equal(d['a'], np.array([], dtype='U1'))
     stream.truncate(0)
     stream.seek(0)
-    savemat_future(stream, {'a': np.array([], dtype='U1')})
-    rdr = MatFile5Reader_future(stream)
+    savemat(stream, {'a': np.array([], dtype='U1')})
+    rdr = MatFile5Reader(stream)
     d = rdr.get_variables()
     assert_array_equal(d['a'], np.array([], dtype='U1'))
     stream.close()
@@ -827,7 +807,7 @@ def test_read_both_endian():
     # make sure big- and little- endian data is read correctly
     for fname in ('big_endian.mat', 'little_endian.mat'):
         fp = open(pjoin(test_data_path, fname), 'rb')
-        rdr = MatFile5Reader_future(fp)
+        rdr = MatFile5Reader(fp)
         d = rdr.get_variables()
         fp.close()
         assert_array_equal(d['strings'],
@@ -846,10 +826,10 @@ def test_write_opposite_endian():
     int_arr = np.arange(6).reshape((2, 3))
     uni_arr = np.array(['hello', 'world'], dtype='U')
     stream = BytesIO()
-    savemat_future(stream, {'floats': float_arr.byteswap().newbyteorder(),
+    savemat(stream, {'floats': float_arr.byteswap().newbyteorder(),
                             'ints': int_arr.byteswap().newbyteorder(),
                             'uni_arr': uni_arr.byteswap().newbyteorder()})
-    rdr = MatFile5Reader_future(stream)
+    rdr = MatFile5Reader(stream)
     d = rdr.get_variables()
     assert_array_equal(d['floats'], float_arr)
     assert_array_equal(d['ints'], int_arr)
@@ -860,7 +840,7 @@ def test_write_opposite_endian():
 def test_logical_array():
     # The roundtrip test doesn't verify that we load the data up with the correct (bool) dtype
     fp = open(pjoin(test_data_path, 'testbool_8_WIN64.mat'), 'rb')
-    rdr = MatFile5Reader_future(fp, mat_dtype=True)
+    rdr = MatFile5Reader(fp, mat_dtype=True)
     d = rdr.get_variables()
     fp.close()
 
@@ -879,25 +859,25 @@ def test_mat4_3d():
 def test_func_read():
     func_eg = pjoin(test_data_path, 'testfunc_7.4_GLNX86.mat')
     fp = open(func_eg, 'rb')
-    rdr = MatFile5Reader_future(fp)
+    rdr = MatFile5Reader(fp)
     d = rdr.get_variables()
     fp.close()
-    yield assert_true, isinstance(d['testfunc'], MatlabFunction)
+    assert_true(isinstance(d['testfunc'], MatlabFunction))
     stream = BytesIO()
-    wtr = MatFile5Writer(stream, oned_as='row')
-    yield assert_raises, MatWriteError, wtr.put_variables, d
+    wtr = MatFile5Writer(stream)
+    assert_raises(MatWriteError, wtr.put_variables, d)
 
 
 def test_mat_dtype():
     double_eg = pjoin(test_data_path, 'testmatrix_6.1_SOL2.mat')
     fp = open(double_eg, 'rb')
-    rdr = MatFile5Reader_future(fp, mat_dtype=False)
+    rdr = MatFile5Reader(fp, mat_dtype=False)
     d = rdr.get_variables()
     fp.close()
     yield assert_equal, d['testmatrix'].dtype.kind, 'u'
 
     fp = open(double_eg, 'rb')
-    rdr = MatFile5Reader_future(fp, mat_dtype=True)
+    rdr = MatFile5Reader(fp, mat_dtype=True)
     d = rdr.get_variables()
     fp.close()
     yield assert_equal, d['testmatrix'].dtype.kind, 'f'
@@ -908,7 +888,7 @@ def test_sparse_in_struct():
     # ndarray return type, but getting sparse matrix
     st = {'sparsefield': SP.coo_matrix(np.eye(4))}
     stream = BytesIO()
-    savemat_future(stream, {'a':st})
+    savemat(stream, {'a':st})
     d = loadmat(stream, struct_as_record=True)
     yield assert_array_equal, d['a'][0,0]['sparsefield'].todense(), np.eye(4)
 
@@ -916,7 +896,7 @@ def test_sparse_in_struct():
 def test_mat_struct_squeeze():
     stream = BytesIO()
     in_d = {'st':{'one':1, 'two':2}}
-    savemat_future(stream, in_d)
+    savemat(stream, in_d)
     # no error without squeeze
     out_d = loadmat(stream, struct_as_record=False)
     # previous error was with squeeze, with mat_struct
@@ -929,7 +909,7 @@ def test_mat_struct_squeeze():
 def test_scalar_squeeze():
     stream = BytesIO()
     in_d = {'scalar': [[0.1]], 'string': 'my name', 'st':{'one':1, 'two':2}}
-    savemat_future(stream, in_d)
+    savemat(stream, in_d)
     out_d = loadmat(stream, squeeze_me=True)
     assert_true(isinstance(out_d['scalar'], float))
     assert_true(isinstance(out_d['string'], string_types))
@@ -941,7 +921,7 @@ def test_str_round():
     stream = BytesIO()
     in_arr = np.array(['Hello', 'Foob'])
     out_arr = np.array(['Hello', 'Foob '])
-    savemat_future(stream, dict(a=in_arr))
+    savemat(stream, dict(a=in_arr))
     res = loadmat(stream)
     # resulted in ['HloolFoa', 'elWrdobr']
     assert_array_equal(res['a'], out_arr)
@@ -953,14 +933,14 @@ def test_str_round():
                              dtype=in_arr.dtype,
                              order='F',
                              buffer=in_str)
-    savemat_future(stream, dict(a=in_from_str))
+    savemat(stream, dict(a=in_from_str))
     assert_array_equal(res['a'], out_arr)
     # unicode save did lead to buffer too small error
     stream.truncate(0)
     stream.seek(0)
     in_arr_u = in_arr.astype('U')
     out_arr_u = out_arr.astype('U')
-    savemat_future(stream, {'a': in_arr_u})
+    savemat(stream, {'a': in_arr_u})
     res = loadmat(stream)
     assert_array_equal(res['a'], out_arr_u)
 
@@ -968,7 +948,7 @@ def test_str_round():
 def test_fieldnames():
     # Check that field names are as expected
     stream = BytesIO()
-    savemat_future(stream, {'a': {'a':1, 'b':2}})
+    savemat(stream, {'a': {'a':1, 'b':2}})
     res = loadmat(stream)
     field_names = res['a'].dtype.names
     assert_equal(set(field_names), set(('a', 'b')))
@@ -1005,7 +985,7 @@ def test_round_types():
                 'u8','u4','u2','u1','c16','c8'):
         stream.truncate(0)
         stream.seek(0)  # needed for BytesIO in python 3
-        savemat_future(stream, {'arr': arr.astype(dts)})
+        savemat(stream, {'arr': arr.astype(dts)})
         vars = loadmat(stream)
         assert_equal(np.dtype(dts), vars['arr'].dtype)
 
@@ -1021,7 +1001,7 @@ def test_varmats_from_mat():
         def items(self):
             return names_vars
     stream = BytesIO()
-    savemat_future(stream, C())
+    savemat(stream, C())
     varmats = varmats_from_mat(stream)
     assert_equal(len(varmats), 3)
     for i in range(3):
@@ -1036,7 +1016,7 @@ def test_one_by_zero():
     ''' Test 1x0 chars get read correctly '''
     func_eg = pjoin(test_data_path, 'one_by_zero_char.mat')
     fp = open(func_eg, 'rb')
-    rdr = MatFile5Reader_future(fp)
+    rdr = MatFile5Reader(fp)
     d = rdr.get_variables()
     fp.close()
     assert_equal(d['var'].shape, (0,))

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -873,21 +873,7 @@ def test_mat4_3d():
     # test behavior when writing 3D arrays to matlab 4 files
     stream = BytesIO()
     arr = np.arange(24).reshape((2,3,4))
-
-    warn_ctx = WarningManager()
-    warn_ctx.__enter__()
-    try:
-        warnings.simplefilter('error')
-        assert_raises(DeprecationWarning, savemat_future,
-                      stream, {'a': arr}, True, '4')
-        # For now, we save a 3D array as 2D
-        warnings.simplefilter('ignore')
-        savemat_future(stream, {'a': arr}, format='4')
-    finally:
-        warn_ctx.__exit__()
-
-    d = loadmat(stream)
-    assert_array_equal(d['a'], arr.reshape((6,4)))
+    assert_raises(ValueError, savemat, stream, {'a': arr}, True, '4')
 
 
 def test_func_read():


### PR DESCRIPTION
No longer look on python sys.path for .mat files.

Passing a 3D or greater array to Matlab 4 file savemat raises an error

1D vector saved into Matlab 5 format file is a row vector by default,
rather than a column vector.
