### PR TITLE
BUG: fix wrong output shape in ndimage.zoom()

### DIFF
--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -35,6 +35,8 @@ import numpy
 from . import _ni_support
 from . import _nd_image
 
+import warnings
+
 __all__ = ['spline_filter1d', 'spline_filter', 'geometric_transform',
            'map_coordinates', 'affine_transform', 'shift', 'zoom', 'rotate']
 
@@ -518,7 +520,15 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
     else:
         filtered = input
     zoom = _ni_support._normalize_sequence(zoom, input.ndim)
-    output_shape = tuple([int(round(ii * jj)) for ii, jj in zip(input.shape, zoom)])
+    output_shape = tuple(
+            [int(round(ii * jj)) for ii, jj in zip(input.shape, zoom)])
+    output_shape_old = tuple(
+            [int(ii * jj) for ii, jj in zip(input.shape, zoom)])
+
+    if output_shape != output_shape_old:
+        warnings.warn(
+                'The output shape of zoom() is calculated with '
+                'round() now and might not work as you expect')
 
     zoom_div = numpy.array(output_shape, float) - 1
     zoom = (numpy.array(input.shape) - 1) / zoom_div

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -518,7 +518,7 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
     else:
         filtered = input
     zoom = _ni_support._normalize_sequence(zoom, input.ndim)
-    output_shape = tuple([int(ii * jj) for ii, jj in zip(input.shape, zoom)])
+    output_shape = tuple([int(round(ii * jj)) for ii, jj in zip(input.shape, zoom)])
 
     zoom_div = numpy.array(output_shape, float) - 1
     zoom = (numpy.array(input.shape) - 1) / zoom_div

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -2210,6 +2210,13 @@ class TestNdimage:
         ref = numpy.zeros((1, 10, 10))
         assert_array_almost_equal(out, ref)
 
+    def test_zoom_output_shape_roundoff(self):
+        """zoom output shape roundoff"""
+        arr = numpy.zeros((3, 11, 25))
+        zoom = (4.0 / 3.0, 15.0 / 11, 29.0 / 25)
+        out = ndimage.zoom(arr, zoom)
+        assert_array_equal(out.shape, (4, 15, 29))
+
     def test_rotate01(self):
         "rotate 1"
         data = numpy.array([[0, 0, 0, 0],


### PR DESCRIPTION
`ndimage.zoom()` may calculate the output shape incorrectly due to round-off error in some occasions.
For example, an image with the shape of `(11, 25)` cannot be zoomed to `(15, 29)` with `(15.0 / 11, 29.0 / 25)` as the zoom factor. (An `(14, 28)` image will be returned instead)

Rounding to nearest may be a better method for calculating the the output shape compared to truncation.
