### PR TITLE
DOC: Extended tutorial/integrate

### DIFF
--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -26,6 +26,7 @@ the interval :math:`[0,4.5].`
 
     \[ I=\int_{0}^{4.5}J_{2.5}\left(x\right)\, dx.\]
 
+
 This could be computed using :obj:`quad`:
 
     >>> result = integrate.quad(lambda x: special.jv(2.5,x), 0, 4.5)
@@ -68,17 +69,14 @@ reported error bound.
 If the function to integrate takes additional parameters, the can be provided
 in the `args` argument. Suppose that the following integral shall be calculated:
 
-
-
 .. math::
-   :nowrap:
+    I(a,b)=\int_{0}^{1} ax^2+b \, dx.
 
-    \[ I(a,b)=\int_{0}^{1} ax^2+b \, dx.\]
 
 This integral can be evaluated by using the following code:
 
 >>> from scipy.integrate import quad
->>> def integrand(x,a,b):
+>>> def integrand(x, a, b):
 ...     return a * x + b
 >>> a = 2
 >>> b = 1
@@ -174,8 +172,7 @@ This integral can be evaluated using the expression below (Note the use of the
 non-constant lambda functions for the upper limit of the inner integral):
 
 >>> from scipy.integrate import dblquad
->>> area = dblquad(lambda x,y: x*y, 0,0.5, lambda x:0,lambda x:1-2*x)
->>> print area
+>>> area = dblquad(lambda x, y: x*y, 0, 0.5, lambda x: 0, lambda x: 1-2*x)
 (0.010416666666666668, 1.1564823173178715e-16)
 
 
@@ -242,7 +239,7 @@ of order 2 or less.
 21.0
 
 
-This corresponds exactely to 
+This corresponds exactly to 
 
 .. math::
    :nowrap:

--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -22,9 +22,7 @@ suppose you wish to integrate a bessel function ``jv(2.5,x)`` along
 the interval :math:`[0,4.5].`
 
 .. math::
-   :nowrap:
-
-    \[ I=\int_{0}^{4.5}J_{2.5}\left(x\right)\, dx.\]
+    I=\int_{0}^{4.5}J_{2.5}\left(x\right)\, dx.
 
 
 This could be computed using :obj:`quad`:
@@ -50,16 +48,12 @@ element holding an upper bound on the error. Notice, that in this
 case, the true value of this integral is
 
 .. math::
-   :nowrap:
-
-    \[ I=\sqrt{\frac{2}{\pi}}\left(\frac{18}{27}\sqrt{2}\cos\left(4.5\right)-\frac{4}{27}\sqrt{2}\sin\left(4.5\right)+\sqrt{2\pi}\textrm{Si}\left(\frac{3}{\sqrt{\pi}}\right)\right),\]
+    I=\sqrt{\frac{2}{\pi}}\left(\frac{18}{27}\sqrt{2}\cos\left(4.5\right)-\frac{4}{27}\sqrt{2}\sin\left(4.5\right)+\sqrt{2\pi}\textrm{Si}\left(\frac{3}{\sqrt{\pi}}\right)\right),
 
 where
 
 .. math::
-   :nowrap:
-
-    \[ \textrm{Si}\left(x\right)=\int_{0}^{x}\sin\left(\frac{\pi}{2}t^{2}\right)\, dt.\]
+    \textrm{Si}\left(x\right)=\int_{0}^{x}\sin\left(\frac{\pi}{2}t^{2}\right)\, dt.
 
 is the Fresnel sine integral. Note that the numerically-computed integral is
 within :math:`1.04\times10^{-11}` of the exact result --- well below the
@@ -89,9 +83,7 @@ Infinite inputs are also allowed in :obj:`quad` by using :math:`\pm`
 value for the exponential integral:
 
 .. math::
-   :nowrap:
-
-    \[ E_{n}\left(x\right)=\int_{1}^{\infty}\frac{e^{-xt}}{t^{n}}\, dt.\]
+    E_{n}\left(x\right)=\int_{1}^{\infty}\frac{e^{-xt}}{t^{n}}\, dt.
 
 is desired (and the fact that this integral can be computed as
 ``special.expn(n,x)`` is forgotten). The functionality of the function
@@ -117,9 +109,7 @@ error bound may underestimate the error due to possible numerical error in the
 integrand from the use of :obj:`quad` ). The integral in this case is
 
 .. math::
-   :nowrap:
-
-    \[ I_{n}=\int_{0}^{\infty}\int_{1}^{\infty}\frac{e^{-xt}}{t^{n}}\, dt\, dx=\frac{1}{n}.\]
+    I_{n}=\int_{0}^{\infty}\int_{1}^{\infty}\frac{e^{-xt}}{t^{n}}\, dt\, dx=\frac{1}{n}.
 
 >>> result = quad(lambda x: expint(3, x), 0, inf)
 >>> print result
@@ -163,9 +153,7 @@ An example of using double integration to compute several values of
 As example for non-constant limits consider the integral
 
 .. math::
-   :nowrap:
-
-    \[ I=\int_{0}^{1/2}\int_{1}^{1-2x} x y \, dx\, dy=\frac{1}{96}. \]
+    I=\int_{0}^{1/2}\int_{1}^{1-2x} x y \, dx\, dy=\frac{1}{96}.
 
 
 This integral can be evaluated using the expression below (Note the use of the
@@ -242,9 +230,7 @@ of order 2 or less.
 This corresponds exactly to 
 
 .. math::
-   :nowrap:
-
-    \[ \int_{1}^{4} x^2 \, dx = 21, \]
+    \int_{1}^{4} x^2 \, dx = 21,
 
 whereas integrating the second function
 
@@ -256,9 +242,7 @@ whereas integrating the second function
 does not correspond to
 
 .. math::
-   :nowrap:
-
-    \[ \int_{1}^{4} x^3 \, dx = 63.75 \]
+    \int_{1}^{4} x^3 \, dx = 63.75
 
 because the order of the polynomial in f2 is larger than two.
 
@@ -272,9 +256,7 @@ initial conditions is another useful example. The function
 vector differential equation:
 
 .. math::
-   :nowrap:
-
-    \[ \frac{d\mathbf{y}}{dt}=\mathbf{f}\left(\mathbf{y},t\right),\]
+    \frac{d\mathbf{y}}{dt}=\mathbf{f}\left(\mathbf{y},t\right),
 
 given initial conditions :math:`\mathbf{y}\left(0\right)=y_{0}`, where
 :math:`\mathbf{y}` is a length :math:`N` vector and :math:`\mathbf{f}`
@@ -287,17 +269,13 @@ For example suppose it is desired to find the solution to the
 following second-order differential equation:
 
 .. math::
-   :nowrap:
-
-    \[ \frac{d^{2}w}{dz^{2}}-zw(z)=0\]
+    \frac{d^{2}w}{dz^{2}}-zw(z)=0
 
 with initial conditions :math:`w\left(0\right)=\frac{1}{\sqrt[3]{3^{2}}\Gamma\left(\frac{2}{3}\right)}` and :math:`\left.\frac{dw}{dz}\right|_{z=0}=-\frac{1}{\sqrt[3]{3}\Gamma\left(\frac{1}{3}\right)}.` It is known that the solution to this differential equation with these
 boundary conditions is the Airy function
 
 .. math::
-   :nowrap:
-
-    \[ w=\textrm{Ai}\left(z\right),\]
+    w=\textrm{Ai}\left(z\right),
 
 which gives a means to check the integrator using :func:`special.airy <scipy.special.airy>`.
 
@@ -306,16 +284,12 @@ First, convert this ODE into standard form by setting
 the differential equation becomes
 
 .. math::
-   :nowrap:
-
-    \[ \frac{d\mathbf{y}}{dt}=\left[\begin{array}{c} ty_{1}\\ y_{0}\end{array}\right]=\left[\begin{array}{cc} 0 & t\\ 1 & 0\end{array}\right]\left[\begin{array}{c} y_{0}\\ y_{1}\end{array}\right]=\left[\begin{array}{cc} 0 & t\\ 1 & 0\end{array}\right]\mathbf{y}.\]
+    \frac{d\mathbf{y}}{dt}=\left[\begin{array}{c} ty_{1}\\ y_{0}\end{array}\right]=\left[\begin{array}{cc} 0 & t\\ 1 & 0\end{array}\right]\left[\begin{array}{c} y_{0}\\ y_{1}\end{array}\right]=\left[\begin{array}{cc} 0 & t\\ 1 & 0\end{array}\right]\mathbf{y}.
 
 In other words,
 
 .. math::
-   :nowrap:
-
-    \[ \mathbf{f}\left(\mathbf{y},t\right)=\mathbf{A}\left(t\right)\mathbf{y}.\]
+    \mathbf{f}\left(\mathbf{y},t\right)=\mathbf{A}\left(t\right)\mathbf{y}.
 
 As an interesting reminder, if :math:`\mathbf{A}\left(t\right)`
 commutes with :math:`\int_{0}^{t}\mathbf{A}\left(\tau\right)\, d\tau`
@@ -323,9 +297,7 @@ under matrix multiplication, then this linear differential equation
 has an exact solution using the matrix exponential:
 
 .. math::
-   :nowrap:
-
-    \[ \mathbf{y}\left(t\right)=\exp\left(\int_{0}^{t}\mathbf{A}\left(\tau\right)d\tau\right)\mathbf{y}\left(0\right),\]
+    \mathbf{y}\left(t\right)=\exp\left(\int_{0}^{t}\mathbf{A}\left(\tau\right)d\tau\right)\mathbf{y}\left(0\right),
 
 However, in this case, :math:`\mathbf{A}\left(t\right)` and its integral do not commute.
 

--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -22,6 +22,7 @@ suppose you wish to integrate a bessel function ``jv(2.5,x)`` along
 the interval :math:`[0,4.5].`
 
 .. math::
+
     I=\int_{0}^{4.5}J_{2.5}\left(x\right)\, dx.
 
 
@@ -48,11 +49,13 @@ element holding an upper bound on the error. Notice, that in this
 case, the true value of this integral is
 
 .. math::
+
     I=\sqrt{\frac{2}{\pi}}\left(\frac{18}{27}\sqrt{2}\cos\left(4.5\right)-\frac{4}{27}\sqrt{2}\sin\left(4.5\right)+\sqrt{2\pi}\textrm{Si}\left(\frac{3}{\sqrt{\pi}}\right)\right),
 
 where
 
 .. math::
+
     \textrm{Si}\left(x\right)=\int_{0}^{x}\sin\left(\frac{\pi}{2}t^{2}\right)\, dt.
 
 is the Fresnel sine integral. Note that the numerically-computed integral is
@@ -64,6 +67,7 @@ If the function to integrate takes additional parameters, the can be provided
 in the `args` argument. Suppose that the following integral shall be calculated:
 
 .. math::
+
     I(a,b)=\int_{0}^{1} ax^2+b \, dx.
 
 
@@ -83,6 +87,7 @@ Infinite inputs are also allowed in :obj:`quad` by using :math:`\pm`
 value for the exponential integral:
 
 .. math::
+
     E_{n}\left(x\right)=\int_{1}^{\infty}\frac{e^{-xt}}{t^{n}}\, dt.
 
 is desired (and the fact that this integral can be computed as
@@ -109,6 +114,7 @@ error bound may underestimate the error due to possible numerical error in the
 integrand from the use of :obj:`quad` ). The integral in this case is
 
 .. math::
+
     I_{n}=\int_{0}^{\infty}\int_{1}^{\infty}\frac{e^{-xt}}{t^{n}}\, dt\, dx=\frac{1}{n}.
 
 >>> result = quad(lambda x: expint(3, x), 0, inf)
@@ -153,6 +159,7 @@ An example of using double integration to compute several values of
 As example for non-constant limits consider the integral
 
 .. math::
+
     I=\int_{0}^{1/2}\int_{1}^{1-2x} x y \, dx\, dy=\frac{1}{96}.
 
 
@@ -230,6 +237,7 @@ of order 2 or less.
 This corresponds exactly to 
 
 .. math::
+
     \int_{1}^{4} x^2 \, dx = 21,
 
 whereas integrating the second function
@@ -242,6 +250,7 @@ whereas integrating the second function
 does not correspond to
 
 .. math::
+
     \int_{1}^{4} x^3 \, dx = 63.75
 
 because the order of the polynomial in f2 is larger than two.
@@ -256,6 +265,7 @@ initial conditions is another useful example. The function
 vector differential equation:
 
 .. math::
+
     \frac{d\mathbf{y}}{dt}=\mathbf{f}\left(\mathbf{y},t\right),
 
 given initial conditions :math:`\mathbf{y}\left(0\right)=y_{0}`, where
@@ -269,12 +279,14 @@ For example suppose it is desired to find the solution to the
 following second-order differential equation:
 
 .. math::
+
     \frac{d^{2}w}{dz^{2}}-zw(z)=0
 
 with initial conditions :math:`w\left(0\right)=\frac{1}{\sqrt[3]{3^{2}}\Gamma\left(\frac{2}{3}\right)}` and :math:`\left.\frac{dw}{dz}\right|_{z=0}=-\frac{1}{\sqrt[3]{3}\Gamma\left(\frac{1}{3}\right)}.` It is known that the solution to this differential equation with these
 boundary conditions is the Airy function
 
 .. math::
+
     w=\textrm{Ai}\left(z\right),
 
 which gives a means to check the integrator using :func:`special.airy <scipy.special.airy>`.
@@ -284,11 +296,13 @@ First, convert this ODE into standard form by setting
 the differential equation becomes
 
 .. math::
+
     \frac{d\mathbf{y}}{dt}=\left[\begin{array}{c} ty_{1}\\ y_{0}\end{array}\right]=\left[\begin{array}{cc} 0 & t\\ 1 & 0\end{array}\right]\left[\begin{array}{c} y_{0}\\ y_{1}\end{array}\right]=\left[\begin{array}{cc} 0 & t\\ 1 & 0\end{array}\right]\mathbf{y}.
 
 In other words,
 
 .. math::
+
     \mathbf{f}\left(\mathbf{y},t\right)=\mathbf{A}\left(t\right)\mathbf{y}.
 
 As an interesting reminder, if :math:`\mathbf{A}\left(t\right)`
@@ -297,6 +311,7 @@ under matrix multiplication, then this linear differential equation
 has an exact solution using the matrix exponential:
 
 .. math::
+
     \mathbf{y}\left(t\right)=\exp\left(\int_{0}^{t}\mathbf{A}\left(\tau\right)d\tau\right)\mathbf{y}\left(0\right),
 
 However, in this case, :math:`\mathbf{A}\left(t\right)` and its integral do not commute.

--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -60,8 +60,31 @@ where
 
     \[ \textrm{Si}\left(x\right)=\int_{0}^{x}\sin\left(\frac{\pi}{2}t^{2}\right)\, dt.\]
 
-is the Fresnel sine integral. Note that the numerically-computed
-integral is within :math:`1.04\times10^{-11}` of the exact result --- well below the reported error bound.
+is the Fresnel sine integral. Note that the numerically-computed integral is
+within :math:`1.04\times10^{-11}` of the exact result --- well below the
+reported error bound.
+
+
+If the function to integrate takes additional parameters, the can be provided
+in the `args` argument. Suppose that the following integral shall be calculated:
+
+
+
+.. math::
+   :nowrap:
+
+    \[ I(a,b)=\int_{0}^{1} ax^2+b \, dx.\]
+
+This integral can be evaluated by using the following code:
+
+>>> from scipy.integrate import quad
+>>> def integrand(x,a,b):
+...     return a * x + b
+>>> a = 2
+>>> b = 1
+>>> I = quad(integrand, 0, 1, args=(a,b))
+>>> I = (2.0, 2.220446049250313e-14)
+
 
 Infinite inputs are also allowed in :obj:`quad` by using :math:`\pm`
 ``inf`` as one of the arguments. For example, suppose that a numerical
@@ -91,9 +114,9 @@ is desired (and the fact that this integral can be computed as
     >>> special.expn(3,arange(1.0,4.0,0.5))
     array([ 0.1097,  0.0567,  0.0301,  0.0163,  0.0089,  0.0049])
 
-The function which is integrated can even use the quad argument
-(though the error bound may underestimate the error due to possible
-numerical error in the integrand from the use of :obj:`quad` ). The integral in this case is
+The function which is integrated can even use the quad argument (though the
+error bound may underestimate the error due to possible numerical error in the
+integrand from the use of :obj:`quad` ). The integral in this case is
 
 .. math::
    :nowrap:
@@ -112,14 +135,20 @@ numerical error in the integrand from the use of :obj:`quad` ). The integral in 
 8.77306560731e-11     
     
 This last example shows that multiple integration can be handled using
-repeated calls to :func:`quad`. The mechanics of this for double and
-triple integration have been wrapped up into the functions
-:obj:`dblquad` and :obj:`tplquad`. The function, :obj:`dblquad`
-performs double integration. Use the help function to be sure that the
-arguments are defined in the correct order. In addition, the limits on
-all inner integrals are actually functions which can be constant
-functions. An example of using double integration to compute several
-values of :math:`I_{n}` is shown below:
+repeated calls to :func:`quad`. 
+
+
+
+General multiple integration (:func:`dblquad`, :func:`tplquad`)
+---------------------------------------------------------------
+
+The mechanics for double and triple integration have been wrapped up into the
+functions :obj:`dblquad` and :obj:`tplquad`. These functions take the function
+to  integrate and four, or six arguments, respecively. The limits of all
+inner integrals need to be defined as functions.
+
+An example of using double integration to compute several values of
+:math:`I_{n}` is shown below:
 
     >>> from scipy.integrate import quad, dblquad
     >>> def I(n):
@@ -133,8 +162,27 @@ values of :math:`I_{n}` is shown below:
     (0.49999999999857514, 1.8855523253868967e-09)
 
 
-Gaussian quadrature (integrate.gauss_quadtol)
----------------------------------------------
+As example for non-constant limits consider the integral
+
+.. math::
+   :nowrap:
+
+    \[ I=\int_{0}^{1/2}\int_{1}^{1-2x} x y \, dx\, dy=\frac{1}{96}. \]
+
+
+This integral can be evaluated using the expression below (Note the use of the
+non-constant lambda functions for the upper limit of the inner integral):
+
+>>> from scipy.integrate import dblquad
+>>> area = dblquad(lambda x,y: x*y, 0,0.5, lambda x:0,lambda x:1-2*x)
+>>> print area
+(0.010416666666666668, 1.1564823173178715e-16)
+
+
+
+
+Gaussian quadrature
+-------------------
 
 A few functions are also provided in order to perform simple Gaussian
 quadrature over a fixed interval. The first is :obj:`fixed_quad` which
@@ -148,27 +196,74 @@ themselves are available as special functions returning instances of
 the polynomial class --- e.g. :obj:`special.legendre <scipy.special.legendre>`).
 
 
-Integrating using samples
+
+Romberg Integration
+-------------------
+
+Romberg's method [WPR]_ is another method for numerically evaluating an
+integral. See the help function for :func:`romberg` for further details.
+
+
+
+
+Integrating using Samples
 -------------------------
 
-There are three functions for computing integrals given only samples:
-:obj:`trapz` , :obj:`simps`, and :obj:`romb` . The first two
-functions use Newton-Coates formulas of order 1 and 2 respectively to
-perform integration. These two functions can handle,
-non-equally-spaced samples. The trapezoidal rule approximates the
-function as a straight line between adjacent points, while Simpson's
-rule approximates the function between three adjacent points as a
-parabola.
-
 If the samples are equally-spaced and the number of samples available
-is :math:`2^{k}+1` for some integer :math:`k`, then Romberg
+is :math:`2^{k}+1` for some integer :math:`k`, then Romberg :obj:`romb`
 integration can be used to obtain high-precision estimates of the
 integral using the available samples. Romberg integration uses the
 trapezoid rule at step-sizes related by a power of two and then
 performs Richardson extrapolation on these estimates to approximate
-the integral with a higher-degree of accuracy. (A different interface
-to Romberg integration useful when the function can be provided is
-also available as :func:`romberg`).
+the integral with a higher-degree of accuracy.
+
+In case of arbitrary spaced samples, the two functions trapz (defined in numpy
+[NPT]_) and :obj:`simps` are available. They are using Newton-Coates formulas
+of order 1 and 2 respectively to perform integration. The trapezoidal rule
+approximates the function as a straight line between adjacent points, while
+Simpson's rule approximates the function between three adjacent points as a
+parabola.
+
+For an odd number of samples that are equally spaced Simpson's rule is exact
+if the function is a polynomial of order 3 or less. If the samples are not
+equally spaced, then the result is exact only if the function is a polynomial
+of order 2 or less.
+
+>>> from scipy.integrate import simps
+>>> import numpy as np
+>>> def f(x):
+...    return x**2
+>>> def f2(x):
+...    return x**3
+>>> x = np.array([1,3,4])
+>>> y1 = f1(x)
+>>> I1 = integrate.simps(y1,x)
+>>> print(I1)
+21.0
+
+
+This corresponds exactely to 
+
+.. math::
+   :nowrap:
+
+    \[ \int_{1}^{4} x^2 \, dx = 21, \]
+
+whereas integrating the second function
+
+>>> y2 = f2(x)
+>>> I2 = integrate.simps(y2,x)
+>>> print(I2)
+61.5
+
+does not correspond to
+
+.. math::
+   :nowrap:
+
+    \[ \int_{1}^{4} x^3 \, dx = 63.75 \]
+
+because the order of the polynomial in f2 is larger than two.
 
 
 Ordinary differential equations (:func:`odeint`)
@@ -278,3 +373,13 @@ usage of the *Dfun* option which allows the user to specify a gradient
     
     >>> print y2[:36:6,1]
     [ 0.355028  0.339511  0.324067  0.308763  0.293658  0.278806]
+
+
+
+
+References
+~~~~~~~~~~
+
+.. [WPR] http://en.wikipedia.org/wiki/Romberg's_method
+
+.. [NPT] http://docs.scipy.org/doc/numpy/reference/generated/numpy.trapz.html


### PR DESCRIPTION
- added description & example  of "args" keyword in quad
- split single integration & multiple integration
- added example for dblquad with non-constant limits
- moved Romberg to a separate section
- restructured "Integration using samples" section
