### PR TITLE
special: Reimplement Struve functions

### DIFF
--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -95,6 +95,29 @@ cdef void loop_f_f__As_f_f(char **args, np.npy_intp *dims, np.npy_intp *steps, v
         op0 += steps[1]
     sf_error.check_fpe(func_name)
 
+cdef void loop_d_ddi_d_As_ddl_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3], *op1 = args[4]
+    cdef double ov0
+    cdef double ov1
+    for i in range(n):
+        if <int>(<long*>ip2)[0] == (<long*>ip2)[0]:
+            ov0 = (<double(*)(double, double, int, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <int>(<long*>ip2)[0], &ov1)
+        else:
+            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
+            ov0 = <double>NPY_NAN
+            ov1 = <double>NPY_NAN
+        (<double *>op0)[0] = <double>ov0
+        (<double *>op1)[0] = <double>ov1
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        op0 += steps[3]
+        op1 += steps[4]
+    sf_error.check_fpe(func_name)
+
 cdef void loop_i_ddddd_dd_As_ddddd_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
@@ -143,6 +166,20 @@ cdef void loop_i_d_dd_As_d_dd(char **args, np.npy_intp *dims, np.npy_intp *steps
         ip0 += steps[0]
         op0 += steps[1]
         op1 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_DD__As_DD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double complex, double complex) nogil>func)(<double complex>(<double complex*>ip0)[0], <double complex>(<double complex*>ip1)[0])
+        (<double complex *>op0)[0] = <double complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
     sf_error.check_fpe(func_name)
 
 cdef void loop_D_D__As_D_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -220,21 +257,21 @@ cdef void loop_i_d_DDDD_As_f_FFFF(char **args, np.npy_intp *dims, np.npy_intp *s
         op3 += steps[4]
     sf_error.check_fpe(func_name)
 
-cdef void loop_i_d_dddd_As_f_ffff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_i_D_DDDD_As_F_FFFF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
     cdef char *ip0 = args[0], *op0 = args[1], *op1 = args[2], *op2 = args[3], *op3 = args[4]
-    cdef double ov0
-    cdef double ov1
-    cdef double ov2
-    cdef double ov3
+    cdef double complex ov0
+    cdef double complex ov1
+    cdef double complex ov2
+    cdef double complex ov3
     for i in range(n):
-        (<int(*)(double, double *, double *, double *, double *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
-        (<float *>op0)[0] = <float>ov0
-        (<float *>op1)[0] = <float>ov1
-        (<float *>op2)[0] = <float>ov2
-        (<float *>op3)[0] = <float>ov3
+        (<int(*)(double complex, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double complex>(<float complex*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
+        (<float complex *>op0)[0] = <float complex>ov0
+        (<float complex *>op1)[0] = <float complex>ov1
+        (<float complex *>op2)[0] = <float complex>ov2
+        (<float complex *>op3)[0] = <float complex>ov3
         ip0 += steps[0]
         op0 += steps[1]
         op1 += steps[2]
@@ -296,15 +333,15 @@ cdef void loop_d_ddd__As_fff_f(char **args, np.npy_intp *dims, np.npy_intp *step
         op0 += steps[3]
     sf_error.check_fpe(func_name)
 
-cdef void loop_D_dD__As_fF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_d_dd__As_ff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
     cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2]
-    cdef double complex ov0
+    cdef double ov0
     for i in range(n):
-        ov0 = (<double complex(*)(double, double complex) nogil>func)(<double>(<float*>ip0)[0], <double complex>(<float complex*>ip1)[0])
-        (<float complex *>op0)[0] = <float complex>ov0
+        ov0 = (<double(*)(double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0])
+        (<float *>op0)[0] = <float>ov0
         ip0 += steps[0]
         ip1 += steps[1]
         op0 += steps[2]
@@ -509,18 +546,27 @@ cdef void loop_D_Dld__As_Dld_D(char **args, np.npy_intp *dims, np.npy_intp *step
         op0 += steps[3]
     sf_error.check_fpe(func_name)
 
-cdef void loop_D_DD__As_DD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_d_ddi_d_As_ffl_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2]
-    cdef double complex ov0
+    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3], *op1 = args[4]
+    cdef double ov0
+    cdef double ov1
     for i in range(n):
-        ov0 = (<double complex(*)(double complex, double complex) nogil>func)(<double complex>(<double complex*>ip0)[0], <double complex>(<double complex*>ip1)[0])
-        (<double complex *>op0)[0] = <double complex>ov0
+        if <int>(<long*>ip2)[0] == (<long*>ip2)[0]:
+            ov0 = (<double(*)(double, double, int, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <int>(<long*>ip2)[0], &ov1)
+        else:
+            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
+            ov0 = <double>NPY_NAN
+            ov1 = <double>NPY_NAN
+        (<float *>op0)[0] = <float>ov0
+        (<float *>op1)[0] = <float>ov1
         ip0 += steps[0]
         ip1 += steps[1]
-        op0 += steps[2]
+        ip2 += steps[2]
+        op0 += steps[3]
+        op1 += steps[4]
     sf_error.check_fpe(func_name)
 
 cdef void loop_i_dd_dd_As_ff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -734,21 +780,21 @@ cdef void loop_D_ddD__As_ffF_F(char **args, np.npy_intp *dims, np.npy_intp *step
         op0 += steps[3]
     sf_error.check_fpe(func_name)
 
-cdef void loop_i_D_DDDD_As_F_FFFF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_i_d_dddd_As_f_ffff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
     cdef char *ip0 = args[0], *op0 = args[1], *op1 = args[2], *op2 = args[3], *op3 = args[4]
-    cdef double complex ov0
-    cdef double complex ov1
-    cdef double complex ov2
-    cdef double complex ov3
+    cdef double ov0
+    cdef double ov1
+    cdef double ov2
+    cdef double ov3
     for i in range(n):
-        (<int(*)(double complex, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double complex>(<float complex*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
-        (<float complex *>op0)[0] = <float complex>ov0
-        (<float complex *>op1)[0] = <float complex>ov1
-        (<float complex *>op2)[0] = <float complex>ov2
-        (<float complex *>op3)[0] = <float complex>ov3
+        (<int(*)(double, double *, double *, double *, double *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
+        (<float *>op0)[0] = <float>ov0
+        (<float *>op1)[0] = <float>ov1
+        (<float *>op2)[0] = <float>ov2
+        (<float *>op3)[0] = <float>ov3
         ip0 += steps[0]
         op0 += steps[1]
         op1 += steps[2]
@@ -845,15 +891,15 @@ cdef void loop_i_dd_dddd_As_dd_dddd(char **args, np.npy_intp *dims, np.npy_intp 
         op3 += steps[5]
     sf_error.check_fpe(func_name)
 
-cdef void loop_d_dd__As_ff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_D_dD__As_fF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
     cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2]
-    cdef double ov0
+    cdef double complex ov0
     for i in range(n):
-        ov0 = (<double(*)(double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0])
-        (<float *>op0)[0] = <float>ov0
+        ov0 = (<double complex(*)(double, double complex) nogil>func)(<double>(<float*>ip0)[0], <double complex>(<float complex*>ip1)[0])
+        (<float complex *>op0)[0] = <float complex>ov0
         ip0 += steps[0]
         ip1 += steps[1]
         op0 += steps[2]
@@ -1019,6 +1065,12 @@ cdef void loop_d_ld__As_ld_d(char **args, np.npy_intp *dims, np.npy_intp *steps,
 from lambertw cimport lambertw_scalar as _func_lambertw_scalar
 ctypedef double complex _proto_lambertw_scalar_t(double complex, long, double) nogil
 cdef _proto_lambertw_scalar_t *_proto_lambertw_scalar_t_var = &_func_lambertw_scalar
+cdef extern from "_ufuncs_defs.h":
+    cdef double _func_struve_asymp_large_z "struve_asymp_large_z"(double, double, int, double *) nogil
+cdef extern from "_ufuncs_defs.h":
+    cdef double _func_struve_bessel_series "struve_bessel_series"(double, double, int, double *) nogil
+cdef extern from "_ufuncs_defs.h":
+    cdef double _func_struve_power_series "struve_power_series"(double, double, int, double *) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef int _func_airy_wrap "airy_wrap"(double, double *, double *, double *, double *) nogil
 cdef extern from "_ufuncs_defs.h":
@@ -1440,7 +1492,7 @@ cdef extern from "_ufuncs_defs.h":
 cdef extern from "_ufuncs_defs.h":
     cdef int _func_modified_fresnel_plus_wrap "modified_fresnel_plus_wrap"(double, double complex *, double complex *) nogil
 cdef extern from "_ufuncs_defs.h":
-    cdef double _func_modstruve_wrap "modstruve_wrap"(double, double) nogil
+    cdef double _func_struve_l "struve_l"(double, double) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_nbdtr "nbdtr"(int, int, double) nogil
 from _legacy cimport nbdtr_unsafe as _func_nbdtr_unsafe
@@ -1574,7 +1626,7 @@ cdef extern from "_ufuncs_defs.h":
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_cdft2_wrap "cdft2_wrap"(double, double) nogil
 cdef extern from "_ufuncs_defs.h":
-    cdef double _func_struve_wrap "struve_wrap"(double, double) nogil
+    cdef double _func_struve_h "struve_h"(double, double) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_tandg "tandg"(double) nogil
 cdef extern from "_ufuncs_defs.h":
@@ -1632,6 +1684,84 @@ ufunc__lambertw_ptr[2*1+1] = <void*>(<char*>"_lambertw")
 ufunc__lambertw_data[0] = &ufunc__lambertw_ptr[2*0]
 ufunc__lambertw_data[1] = &ufunc__lambertw_ptr[2*1]
 _lambertw = np.PyUFunc_FromFuncAndData(ufunc__lambertw_loops, ufunc__lambertw_data, ufunc__lambertw_types, 2, 3, 1, 0, "_lambertw", ufunc__lambertw_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc__struve_asymp_large_z_loops[2]
+cdef void *ufunc__struve_asymp_large_z_ptr[4]
+cdef void *ufunc__struve_asymp_large_z_data[2]
+cdef char ufunc__struve_asymp_large_z_types[10]
+cdef char *ufunc__struve_asymp_large_z_doc = (
+    "Function for testing struve & modstruve")
+ufunc__struve_asymp_large_z_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddi_d_As_ffl_ff
+ufunc__struve_asymp_large_z_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddi_d_As_ddl_dd
+ufunc__struve_asymp_large_z_types[0] = <char>NPY_FLOAT
+ufunc__struve_asymp_large_z_types[1] = <char>NPY_FLOAT
+ufunc__struve_asymp_large_z_types[2] = <char>NPY_LONG
+ufunc__struve_asymp_large_z_types[3] = <char>NPY_FLOAT
+ufunc__struve_asymp_large_z_types[4] = <char>NPY_FLOAT
+ufunc__struve_asymp_large_z_types[5] = <char>NPY_DOUBLE
+ufunc__struve_asymp_large_z_types[6] = <char>NPY_DOUBLE
+ufunc__struve_asymp_large_z_types[7] = <char>NPY_LONG
+ufunc__struve_asymp_large_z_types[8] = <char>NPY_DOUBLE
+ufunc__struve_asymp_large_z_types[9] = <char>NPY_DOUBLE
+ufunc__struve_asymp_large_z_ptr[2*0] = <void*>_func_struve_asymp_large_z
+ufunc__struve_asymp_large_z_ptr[2*0+1] = <void*>(<char*>"_struve_asymp_large_z")
+ufunc__struve_asymp_large_z_ptr[2*1] = <void*>_func_struve_asymp_large_z
+ufunc__struve_asymp_large_z_ptr[2*1+1] = <void*>(<char*>"_struve_asymp_large_z")
+ufunc__struve_asymp_large_z_data[0] = &ufunc__struve_asymp_large_z_ptr[2*0]
+ufunc__struve_asymp_large_z_data[1] = &ufunc__struve_asymp_large_z_ptr[2*1]
+_struve_asymp_large_z = np.PyUFunc_FromFuncAndData(ufunc__struve_asymp_large_z_loops, ufunc__struve_asymp_large_z_data, ufunc__struve_asymp_large_z_types, 2, 3, 2, 0, "_struve_asymp_large_z", ufunc__struve_asymp_large_z_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc__struve_bessel_series_loops[2]
+cdef void *ufunc__struve_bessel_series_ptr[4]
+cdef void *ufunc__struve_bessel_series_data[2]
+cdef char ufunc__struve_bessel_series_types[10]
+cdef char *ufunc__struve_bessel_series_doc = (
+    "Function for testing struve & modstruve")
+ufunc__struve_bessel_series_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddi_d_As_ffl_ff
+ufunc__struve_bessel_series_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddi_d_As_ddl_dd
+ufunc__struve_bessel_series_types[0] = <char>NPY_FLOAT
+ufunc__struve_bessel_series_types[1] = <char>NPY_FLOAT
+ufunc__struve_bessel_series_types[2] = <char>NPY_LONG
+ufunc__struve_bessel_series_types[3] = <char>NPY_FLOAT
+ufunc__struve_bessel_series_types[4] = <char>NPY_FLOAT
+ufunc__struve_bessel_series_types[5] = <char>NPY_DOUBLE
+ufunc__struve_bessel_series_types[6] = <char>NPY_DOUBLE
+ufunc__struve_bessel_series_types[7] = <char>NPY_LONG
+ufunc__struve_bessel_series_types[8] = <char>NPY_DOUBLE
+ufunc__struve_bessel_series_types[9] = <char>NPY_DOUBLE
+ufunc__struve_bessel_series_ptr[2*0] = <void*>_func_struve_bessel_series
+ufunc__struve_bessel_series_ptr[2*0+1] = <void*>(<char*>"_struve_bessel_series")
+ufunc__struve_bessel_series_ptr[2*1] = <void*>_func_struve_bessel_series
+ufunc__struve_bessel_series_ptr[2*1+1] = <void*>(<char*>"_struve_bessel_series")
+ufunc__struve_bessel_series_data[0] = &ufunc__struve_bessel_series_ptr[2*0]
+ufunc__struve_bessel_series_data[1] = &ufunc__struve_bessel_series_ptr[2*1]
+_struve_bessel_series = np.PyUFunc_FromFuncAndData(ufunc__struve_bessel_series_loops, ufunc__struve_bessel_series_data, ufunc__struve_bessel_series_types, 2, 3, 2, 0, "_struve_bessel_series", ufunc__struve_bessel_series_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc__struve_power_series_loops[2]
+cdef void *ufunc__struve_power_series_ptr[4]
+cdef void *ufunc__struve_power_series_data[2]
+cdef char ufunc__struve_power_series_types[10]
+cdef char *ufunc__struve_power_series_doc = (
+    "Function for testing struve & modstruve")
+ufunc__struve_power_series_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddi_d_As_ffl_ff
+ufunc__struve_power_series_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddi_d_As_ddl_dd
+ufunc__struve_power_series_types[0] = <char>NPY_FLOAT
+ufunc__struve_power_series_types[1] = <char>NPY_FLOAT
+ufunc__struve_power_series_types[2] = <char>NPY_LONG
+ufunc__struve_power_series_types[3] = <char>NPY_FLOAT
+ufunc__struve_power_series_types[4] = <char>NPY_FLOAT
+ufunc__struve_power_series_types[5] = <char>NPY_DOUBLE
+ufunc__struve_power_series_types[6] = <char>NPY_DOUBLE
+ufunc__struve_power_series_types[7] = <char>NPY_LONG
+ufunc__struve_power_series_types[8] = <char>NPY_DOUBLE
+ufunc__struve_power_series_types[9] = <char>NPY_DOUBLE
+ufunc__struve_power_series_ptr[2*0] = <void*>_func_struve_power_series
+ufunc__struve_power_series_ptr[2*0+1] = <void*>(<char*>"_struve_power_series")
+ufunc__struve_power_series_ptr[2*1] = <void*>_func_struve_power_series
+ufunc__struve_power_series_ptr[2*1+1] = <void*>(<char*>"_struve_power_series")
+ufunc__struve_power_series_data[0] = &ufunc__struve_power_series_ptr[2*0]
+ufunc__struve_power_series_data[1] = &ufunc__struve_power_series_ptr[2*1]
+_struve_power_series = np.PyUFunc_FromFuncAndData(ufunc__struve_power_series_loops, ufunc__struve_power_series_data, ufunc__struve_power_series_types, 2, 3, 2, 0, "_struve_power_series", ufunc__struve_power_series_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_airy_loops[4]
 cdef void *ufunc_airy_ptr[8]
@@ -5919,9 +6049,9 @@ ufunc_modstruve_types[2] = <char>NPY_FLOAT
 ufunc_modstruve_types[3] = <char>NPY_DOUBLE
 ufunc_modstruve_types[4] = <char>NPY_DOUBLE
 ufunc_modstruve_types[5] = <char>NPY_DOUBLE
-ufunc_modstruve_ptr[2*0] = <void*>_func_modstruve_wrap
+ufunc_modstruve_ptr[2*0] = <void*>_func_struve_l
 ufunc_modstruve_ptr[2*0+1] = <void*>(<char*>"modstruve")
-ufunc_modstruve_ptr[2*1] = <void*>_func_modstruve_wrap
+ufunc_modstruve_ptr[2*1] = <void*>_func_struve_l
 ufunc_modstruve_ptr[2*1+1] = <void*>(<char*>"modstruve")
 ufunc_modstruve_data[0] = &ufunc_modstruve_ptr[2*0]
 ufunc_modstruve_data[1] = &ufunc_modstruve_ptr[2*1]
@@ -7419,9 +7549,9 @@ ufunc_struve_types[2] = <char>NPY_FLOAT
 ufunc_struve_types[3] = <char>NPY_DOUBLE
 ufunc_struve_types[4] = <char>NPY_DOUBLE
 ufunc_struve_types[5] = <char>NPY_DOUBLE
-ufunc_struve_ptr[2*0] = <void*>_func_struve_wrap
+ufunc_struve_ptr[2*0] = <void*>_func_struve_h
 ufunc_struve_ptr[2*0+1] = <void*>(<char*>"struve")
-ufunc_struve_ptr[2*1] = <void*>_func_struve_wrap
+ufunc_struve_ptr[2*1] = <void*>_func_struve_h
 ufunc_struve_ptr[2*1+1] = <void*>(<char*>"struve")
 ufunc_struve_data[0] = &ufunc_struve_ptr[2*0]
 ufunc_struve_data[1] = &ufunc_struve_ptr[2*1]

--- a/scipy/special/_ufuncs_defs.h
+++ b/scipy/special/_ufuncs_defs.h
@@ -1,5 +1,9 @@
 #ifndef UFUNCS_PROTO_H
 #define UFUNCS_PROTO_H 1
+#include "misc.h"
+npy_double struve_asymp_large_z(npy_double, npy_double, npy_int, npy_double *);
+npy_double struve_bessel_series(npy_double, npy_double, npy_int, npy_double *);
+npy_double struve_power_series(npy_double, npy_double, npy_int, npy_double *);
 #include "amos_wrappers.h"
 npy_int airy_wrap(npy_double, npy_double *, npy_double *, npy_double *, npy_double *);
 npy_int cairy_wrap(npy_cdouble, npy_cdouble *, npy_cdouble *, npy_cdouble *, npy_cdouble *);
@@ -143,7 +147,7 @@ npy_int msm2_wrap(npy_double, npy_double, npy_double, npy_double *, npy_double *
 npy_int sem_wrap(npy_double, npy_double, npy_double, npy_double *, npy_double *);
 npy_int modified_fresnel_minus_wrap(npy_double, npy_cdouble *, npy_cdouble *);
 npy_int modified_fresnel_plus_wrap(npy_double, npy_cdouble *, npy_cdouble *);
-npy_double modstruve_wrap(npy_double, npy_double);
+npy_double struve_l(npy_double, npy_double);
 npy_double nbdtr(npy_int, npy_int, npy_double);
 npy_double nbdtrc(npy_int, npy_int, npy_double);
 npy_double nbdtri(npy_int, npy_int, npy_double);
@@ -198,7 +202,7 @@ npy_double spence(npy_double);
 npy_double cdft1_wrap(npy_double, npy_double);
 npy_double cdft3_wrap(npy_double, npy_double);
 npy_double cdft2_wrap(npy_double, npy_double);
-npy_double struve_wrap(npy_double, npy_double);
+npy_double struve_h(npy_double, npy_double);
 npy_double tandg(npy_double);
 npy_double tukeylambdacdf(npy_double, npy_double);
 npy_double y0(npy_double);

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1572,3 +1572,19 @@ add_newdoc("scipy.special", "zetac",
     """
     y=zetac(x) returns 1.0 - the Riemann zeta function: sum(k**(-x), k=2..inf)
     """)
+
+add_newdoc("scipy.special", "_struve_asymp_large_z",
+    """
+    Function for testing struve & modstruve
+    """)
+
+add_newdoc("scipy.special", "_struve_power_series",
+    """
+    Function for testing struve & modstruve
+    """)
+
+add_newdoc("scipy.special", "_struve_bessel_series",
+    """
+    Function for testing struve & modstruve
+    """)
+

--- a/scipy/special/amos_wrappers.h
+++ b/scipy/special/amos_wrappers.h
@@ -31,6 +31,7 @@ npy_cdouble cbesi_wrap_e( double v, npy_cdouble z);
 double cbesi_wrap_e_real( double v, double z);
 npy_cdouble cbesj_wrap( double v, npy_cdouble z);
 npy_cdouble cbesj_wrap_e( double v, npy_cdouble z);
+double cbesj_wrap_real(double v, double z);
 double cbesj_wrap_e_real( double v, double z);
 npy_cdouble cbesy_wrap( double v, npy_cdouble z);
 double cbesy_wrap_real(double v, double x);

--- a/scipy/special/c_misc/double2.h
+++ b/scipy/special/c_misc/double2.h
@@ -1,0 +1,240 @@
+/*
+ * 2-double floating point numbers
+ *
+ * Almost 2 times the precision of double, by using 2 doubles.
+ */
+
+/*
+   Portions from:
+
+   Quad Double computation package
+   Copyright (C) 2003-2012
+   ================================================
+
+   Revision date:  13 Mar 2012
+
+   Authors:
+   Yozo Hida               U.C. Berkeley                   yozo@cs.berkeley.edu
+   Xiaoye S. Li            Lawrence Berkeley Natl Lab      xiaoye@nersc.gov
+   David H. Bailey         Lawrence Berkeley Natl Lab      dhbailey@lbl.gov
+  
+   C++ usage guide:
+   Alex Kaiser             Lawrence Berkeley Natl Lab      adkaiser@lbl.gov
+   
+
+   Berkeley Software Distribution Agreement
+   
+   This License Agreement is entered into by The Regents of the University
+   of California, Department of Energy contract-operators of the Lawrence
+   Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720
+   (“Berkeley Lab”), and the entity listed below (“you” or
+   "Licensee") having its place of business at the address below:
+   
+   The parties now agree as follows:
+   
+   1. Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+   
+   (1) Redistributions of source code must retain the copyright notice,
+   this list of conditions and the following disclaimer.
+   
+   (2) Redistributions in binary form must reproduce the copyright notice,
+   this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+   
+   (3) Neither the name of the University of California, Lawrence Berkeley
+   National Laboratory, U.S. Dept. of Energy nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+   
+   2. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+   PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+   OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   
+   3. You are under no obligation whatsoever to provide any bug fixes,
+   patches, or upgrades to the features, functionality or performance of
+   the source code ("Enhancements") to anyone; however, if you choose to
+   make your Enhancements available either publicly, or directly to
+   Lawrence Berkeley National Laboratory, without imposing a separate
+   written license agreement for such Enhancements, then you hereby grant
+   the following license: a non-exclusive, royalty-free perpetual license
+   to install, use, modify, prepare derivative works, incorporate into
+   other computer software, distribute, and sublicense such enhancements or
+   derivative works thereof, in binary and source code form.
+*/
+
+#ifndef DOUBLEN_H_
+#define DOUBLEN_H_
+
+#include <math.h>
+
+
+typedef struct
+{
+    double x[2];
+} double2_t;
+
+
+static void double2_init(double2_t *a, double y)
+{
+    a->x[0] = y;
+    a->x[1] = 0;
+}
+
+
+static void double2_init2(double2_t *a, double hi, double lo)
+{
+    a->x[0] = hi;
+    a->x[1] = lo;
+}
+
+
+static double double_sum_err(double a, double b, double *err)
+{
+    double tmp;
+    volatile double c, d, e, g, h, f, x;
+
+    if (fabs(a) < fabs(b)) {
+        tmp = b;
+        b = a;
+        a = tmp;
+    }
+
+    c = a + b;
+    e = c - a;
+    g = c - e;
+    h = g - a;
+    f = b - h;
+    d = f - e;
+    x = d + e;
+    if (x != f) {
+        c = a;
+        d = b;
+    }
+    *err = d;
+    return c;
+}
+
+
+#define _QD_SPLIT_THRESH 6.69692879491417e+299   /* = 2^996 */
+#define _QD_SPLITTER 134217729.0                 /* = 2^27 + 1 */
+
+static void double_split(double a, double *hi, double *lo)
+{
+    volatile double b, c;
+    if (a > _QD_SPLIT_THRESH || a < -_QD_SPLIT_THRESH) {
+        a *= 3.7252902984619140625e-09;  // 2^-28
+        b = _QD_SPLITTER * a;
+        c = b - a;
+        *hi = b - c;
+        *lo = a - *hi;
+        *hi *= 268435456.0;          // 2^28
+        *lo *= 268435456.0;          // 2^28
+    } else {
+        b = _QD_SPLITTER * a;
+        c = b - a;
+        *hi = b - c;
+        *lo = a - *hi;
+    }
+}
+
+
+static double double_mul_err(double a, double b, double *err)
+{
+    double a_hi, a_lo, b_hi, b_lo;
+    double p = a * b;
+    volatile double c, d;
+    double_split(a, &a_hi, &a_lo);
+    double_split(b, &b_hi, &b_lo);
+    c = a_hi * b_hi - p;
+    d = c + a_hi * b_lo + a_lo * b_hi;
+    *err = d + a_lo * b_lo;
+    return p;
+}
+
+
+static void double2_add(double2_t *a, double2_t *b, double2_t *c)
+{
+    double s1, s2, t1, t2;
+
+    s1 = double_sum_err(a->x[0], b->x[0], &s2);
+    t1 = double_sum_err(a->x[1], b->x[1], &t2);
+
+    s2 += t1;
+    s1 = double_sum_err(s1, s2, &s2);
+    s2 += t2;
+    s1 = double_sum_err(s1, s2, &s2);
+
+    double2_init2(c, s1, s2);
+}
+
+
+static void double2_neg(double2_t *a, double2_t *b)
+{
+    b->x[0] = -a->x[0];
+    b->x[1] = -a->x[1];
+}
+
+
+static void double2_sub(double2_t *a, double2_t *b, double2_t *c)
+{
+    double2_t d;
+    double2_neg(b, &d);
+    double2_add(a, &d, c);
+}
+
+
+static void double2_mul(double2_t *a, double2_t *b, double2_t *c)
+{
+    double p1, p2;
+    
+    p1 = double_mul_err(a->x[0], b->x[0], &p2);
+    p2 += (a->x[0] * b->x[1] + a->x[1] * b->x[0]);
+    p1 = double_sum_err(p1, p2, &p2);
+
+    double2_init2(c, p1, p2);
+}
+
+
+static void double2_div(double2_t *a, double2_t *b, double2_t *c)
+{
+    double q1, q2, q3;
+    double2_t r, e, f;
+
+    q1 = a->x[0] / b->x[0];  /* approximate quotient */
+
+    double2_init(&f, q1);
+    double2_mul(&f, b, &e);
+    double2_sub(a, &e, &r);
+
+    q2 = r.x[0] / b->x[0];
+
+    double2_init(&f, q2);
+    double2_mul(&f, b, &e);
+    double2_sub(&r, &e, &r);
+
+    q3 = r.x[0] / b->x[0];
+
+    q1 = double_sum_err(q1, q2, &q2);
+
+    double2_init2(&e, q1, q2);
+    double2_init(&f, q3);
+    double2_add(&e, &f, c);
+}
+
+
+static double double2_double(double2_t *a)
+{
+    return a->x[0] + a->x[1];
+}
+
+#endif /* DOUBLE2_H_ */

--- a/scipy/special/c_misc/double2.h
+++ b/scipy/special/c_misc/double2.h
@@ -132,13 +132,13 @@ static void double_split(double a, double *hi, double *lo)
 {
     volatile double b, c;
     if (a > _QD_SPLIT_THRESH || a < -_QD_SPLIT_THRESH) {
-        a *= 3.7252902984619140625e-09;  // 2^-28
+        a *= 3.7252902984619140625e-09;  /* 2^-28 */
         b = _QD_SPLITTER * a;
         c = b - a;
         *hi = b - c;
         *lo = a - *hi;
-        *hi *= 268435456.0;          // 2^28
-        *lo *= 268435456.0;          // 2^28
+        *hi *= 268435456.0;          /* 2^28 */
+        *lo *= 268435456.0;          /* 2^28 */
     } else {
         b = _QD_SPLITTER * a;
         c = b - a;

--- a/scipy/special/c_misc/misc.h
+++ b/scipy/special/c_misc/misc.h
@@ -24,6 +24,12 @@ double besselpoly(double a, double lambda, double nu);
 double gammaincinv(double a, double x);
 double gammasgn(double x);
 
+double struve_h(double v, double x);
+double struve_l(double v, double x);
+double struve_power_series(double v, double x, int is_h, double *err);
+double struve_asymp_large_z(double v, double z, int is_h, double *err);
+double struve_bessel_series(double v, double z, int is_h, double *err);
+
 #define gammaincinv_doc """gammaincinv(a, y) returns x such that gammainc(a, x) = y."""
 
 #endif /* C_MISC_MISC_H */

--- a/scipy/special/c_misc/struve.c
+++ b/scipy/special/c_misc/struve.c
@@ -91,6 +91,7 @@
 
 #define MAXITER 10000
 #define SUM_EPS 1e-16   /* be sure we are in the tail of the sum */
+#define SUM_TINY 1e-100
 #define GOOD_EPS 1e-12
 #define ACCEPTABLE_EPS 1e-7
 #define ACCEPTABLE_ATOL 1e-300
@@ -234,6 +235,7 @@ double struve_power_series(double v, double z, int is_h, double *err)
     else {
         scaleexp = 0;
     }
+    
     term = 2 / sqrt(M_PI) * exp(tmp) * gammasgn(v + 1.5);
     sum = term;
     maxterm = 0;
@@ -262,7 +264,7 @@ double struve_power_series(double v, double z, int is_h, double *err)
         if (fabs(term) > maxterm) {
             maxterm = fabs(term);
         }
-        if (fabs(term) < SUM_EPS * fabs(sum) || term == 0 || !npy_isfinite(sum)) {
+        if (fabs(term) < SUM_TINY * fabs(sum) || term == 0 || !npy_isfinite(sum)) {
             break;
         }
     }

--- a/scipy/special/c_misc/struve.c
+++ b/scipy/special/c_misc/struve.c
@@ -123,7 +123,14 @@ static double struve_hl(double v, double z, int is_h)
     int n;
 
     if (z < 0) {
-        return NPY_NAN;
+        n = v;
+        if (v == n) {
+            tmp = (n % 2 == 0) ? -1 : 1;
+            return tmp * struve_hl(v, -z, is_h);
+        }
+        else {
+            return NPY_NAN;
+        }
     }
     else if (z == 0) {
         if (v < -1) {

--- a/scipy/special/c_misc/struve.c
+++ b/scipy/special/c_misc/struve.c
@@ -299,6 +299,10 @@ double struve_bessel_series(double v, double z, int is_h, double *err)
     }
 
     *err = fabs(term) + fabs(maxterm) * 1e-16;
+
+    /* Account for potential underflow of the Bessel functions */
+    *err += 1e-300 * fabs(cterm);
+
     return sum;
 }
 

--- a/scipy/special/c_misc/struve.c
+++ b/scipy/special/c_misc/struve.c
@@ -18,32 +18,29 @@
  * (i)
  *
  * Looking at the error in the asymptotic expansion, one finds that
- * it's not worth trying it out unless |z| ~> 0.7 * |v| + 12.
+ * it's not worth trying if z ~> 0.7 * v + 12 for v > 0.
  *
  * (ii)
  *
  * The Bessel function expansion tends to fail for |z| >~ |v| and is not tried
  * there.
  *
- * For Struve H it covers the quadrant v > z where the power series tends to
- * fail to produce reasonable results due to loss of precision.
+ * For Struve H it covers the quadrant v > z where the power series may fail to
+ * produce reasonable results.
  *
  * (iii)
  *
  * The three expansions together cover for Struve H the region z > 0, v real.
+ *
+ * They also cover Struve L, except that some loss of precision may occur around
+ * the transition region z ~ 0.7 |v|, v < 0, |v| >> 1 where the function changes
+ * rapidly.
  *
  * (iv)
  *
  * The power series is evaluated in double-double precision. This fixes accuracy
  * issues in Struve H for |v| << |z| before the asymptotic expansion kicks in.
  * Moreover, it improves the Struve L behavior for negative v.
- *
- * (iv)
- *
- * For Struve L there remains a difficult region around v < 0, z ~ -0.7 v >> 1,
- * where all the expansions have convergence problems.
- *
- * This implementation returns NAN in this region for large -v.
  *
  *
  * References

--- a/scipy/special/c_misc/struve.c
+++ b/scipy/special/c_misc/struve.c
@@ -1,0 +1,374 @@
+/*
+ * Compute the Struve function.
+ *
+ * Notes
+ * -----
+ *
+ * We use three expansions for the Struve function discussed in [1]:
+ *
+ * - power series
+ * - expansion in Bessel functions
+ * - asymptotic large-z expansion
+ *
+ * Rounding errors are estimated based on the largest terms in the sums.
+ *
+ * ``struve_convergence.py`` plots the convergence regions of the different
+ * expansions.
+ *
+ * (i)
+ *
+ * Looking at the error in the asymptotic expansion, one finds that
+ * it's not worth trying it out unless |z| ~> 0.7 * |v| + 12.
+ *
+ * (ii)
+ *
+ * The Bessel function expansion tends to fail for |z| >~ |v| and is not tried
+ * there.
+ *
+ * For Struve H it covers the quadrant v > z where the power series tends to
+ * fail to produce reasonable results due to loss of precision.
+ *
+ * (iii)
+ *
+ * The three expansions together cover for Struve H the region z > 0, v real.
+ *
+ * (iv)
+ *
+ * The power series is evaluated in double-double precision. This fixes accuracy
+ * issues in Struve H for |v| << |z| before the asymptotic expansion kicks in.
+ * Moreover, it improves the Struve L behavior for negative v.
+ *
+ * (iv)
+ *
+ * For Struve L there remains a difficult region around v < 0, z ~ -0.7 v >> 1,
+ * where all the expansions have convergence problems.
+ *
+ * This implementation returns NAN in this region for large -v.
+ *
+ *
+ * References
+ * ----------
+ * [1] NIST Digital Library of Mathematical Functions
+ *     http://dlmf.nist.gov/11
+ */
+
+/*
+ * Copyright (C) 2013  Pauli Virtanen
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * a. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * b. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * c. Neither the name of Enthought nor the names of the SciPy Developers
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <math.h>
+
+#include "cephes.h"
+#include "amos_wrappers.h"
+#include "misc.h"
+
+#include "double2.h"
+
+#define MAXITER 10000
+#define SUM_EPS 1e-100   /* be sure we are in the tail of the sum */
+#define GOOD_EPS 1e-12
+#define ACCEPTABLE_EPS 1e-7
+#define ACCEPTABLE_ATOL 1e-300
+
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
+double struve_power_series(double v, double x, int is_h, double *err);
+double struve_asymp_large_z(double v, double z, int is_h, double *err);
+double struve_bessel_series(double v, double z, int is_h, double *err);
+
+static double bessel_y(double v, double x);
+static double bessel_i(double v, double x);
+static double bessel_j(double v, double x);
+static double struve_hl(double v, double x, int is_h);
+extern double polevl ( double x, void *P, int N );
+
+double struve_h(double v, double z)
+{
+    return struve_hl(v, z, 1);
+}
+
+double struve_l(double v, double z)
+{
+    return struve_hl(v, z, 0);
+}
+
+static double struve_hl(double v, double z, int is_h)
+{
+    double value[3], err[3], tmp;
+    int n;
+
+    if (z < 0) {
+        return NPY_NAN;
+    }
+    else if (z == 0) {
+        if (v < -1) {
+            return gammasgn(v + 1.5) * NPY_INFINITY;
+        }
+        else if (v == -1) {
+            return 2 / sqrt(M_PI) / Gamma(0.5);
+        }
+        else {
+            return 0;
+        }
+    }
+
+    n = -v - 0.5;
+    if (n == -v - 0.5 && n > 0) {
+        if (is_h) {
+            return (n % 2 == 0 ? 1 : -1) * bessel_j(n + 0.5, z);
+        }
+        else {
+            return bessel_i(n + 0.5, z);
+        }
+    }
+
+    /* Try the asymptotic expansion */
+    if (z >= 0.7*fabs(v) + 12) {
+        value[0] = struve_asymp_large_z(v, z, is_h, &err[0]);
+        if (err[0] < GOOD_EPS * fabs(value[0])) {
+            return value[0];
+        }
+    }
+    else {
+        err[0] = NPY_INFINITY;
+    }
+
+    /* Try power series */
+    value[1] = struve_power_series(v, z, is_h, &err[1]);
+    if (err[1] < GOOD_EPS * fabs(value[1])) {
+        return value[1];
+    }
+
+    /* Try bessel series */
+    if (fabs(z) < fabs(v) + 20) {
+        value[2] = struve_bessel_series(v, z, is_h, &err[2]);
+        if (err[2] < GOOD_EPS * fabs(value[2])) {
+            return value[2];
+        }
+    }
+    else {
+        err[2] = NPY_INFINITY;
+    }
+
+    /* Return the best of the three, if it is acceptable */
+    n = 0;
+    if (err[1] < err[n]) n = 1;
+    if (err[2] < err[n]) n = 2;
+    if (err[n] < ACCEPTABLE_EPS * fabs(value[n]) || err[n] < ACCEPTABLE_ATOL) {
+        return value[n];
+    }
+
+    /* Maybe it really is an overflow? */
+    tmp = -lgam(v + 1.5) + (v + 1)*log(z/2);
+    if (tmp > 700) {
+        sf_error("struve", SF_ERROR_OVERFLOW, "overflow in series");
+        return NPY_INFINITY * gammasgn(v + 1.5);
+    }
+
+    /* Failure */
+    sf_error("struve", SF_ERROR_NO_RESULT, "total loss of precision");
+    return NPY_NAN;
+}
+
+
+/*
+ * Power series for Struve H and L
+ * http://dlmf.nist.gov/11.2.1
+ *
+ * Starts to converge roughly at |n| > |z|
+ */
+double struve_power_series(double v, double z, int is_h, double *err)
+{
+    int n, sgn;
+    double term, sum, maxterm;
+    double2_t cterm, csum, cdiv, z2, c2v, ctmp, ctmp2;
+
+    if (is_h) {
+        sgn = -1;
+    }
+    else {
+        sgn = 1;
+    }
+    
+    term = 2 / sqrt(M_PI) * exp(-lgam(v + 1.5) + (v + 1)*log(z/2)) * gammasgn(v + 1.5);
+    sum = term;
+    maxterm = 0;
+
+    double2_init(&cterm, term);
+    double2_init(&csum, sum);
+    double2_init(&z2, sgn*z*z);
+    double2_init(&c2v, 2*v);
+
+    for (n = 0; n < MAXITER; ++n) {
+        /* cdiv = (3 + 2*n) * (3 + 2*n + 2*v)) */
+        double2_init(&cdiv, 3 + 2*n);
+        double2_init(&ctmp, 3 + 2*n);
+        double2_add(&ctmp, &c2v, &ctmp);
+        double2_mul(&cdiv, &ctmp, &cdiv);
+
+        /* cterm *= z2 / cdiv */
+        double2_mul(&cterm, &z2, &cterm);
+        double2_div(&cterm, &cdiv, &cterm);
+
+        double2_add(&csum, &cterm, &csum);
+
+        term = double2_double(&cterm);
+        sum = double2_double(&csum);
+
+        if (fabs(term) > maxterm) {
+            maxterm = fabs(term);
+        }
+        if (fabs(term) < SUM_EPS * fabs(sum) || term == 0 || !npy_isfinite(sum)) {
+            break;
+        }
+    }
+
+    *err = fabs(term) + fabs(maxterm) * 1e-22;
+    return sum;
+}
+
+
+/*
+ * Bessel series
+ * http://dlmf.nist.gov/11.4.19
+ */
+double struve_bessel_series(double v, double z, int is_h, double *err)
+{
+    int n, sgn;
+    double term, cterm, sum, maxterm;
+
+    if (is_h && v < 0) {
+        /* Works less reliably in this region */
+        *err = NPY_INFINITY;
+        return NPY_NAN;
+    }
+    
+    sum = 0;
+    maxterm = 0;
+
+    cterm = sqrt(z / (2*M_PI));
+
+    for (n = 0; n < MAXITER; ++n) {
+        if (is_h) {
+            term = cterm * bessel_j(n + v + 0.5, z) / (n + 0.5);
+            cterm *= z/2 / (n + 1);
+        }
+        else {
+            term = cterm * bessel_i(n + v + 0.5, z) / (n + 0.5);
+            cterm *= -z/2 / (n + 1);
+        }
+        sum += term;
+        if (fabs(term) > maxterm) {
+            maxterm = fabs(term);
+        }
+        if (fabs(term) < SUM_EPS * fabs(sum) || term == 0 || !npy_isfinite(sum)) {
+            break;
+        }
+    }
+
+    *err = fabs(term) + fabs(maxterm) * 1e-16;
+    return sum;
+}
+
+
+/*
+ * Large-z expansion for Struve H and L
+ * http://dlmf.nist.gov/11.6.1
+ */
+double struve_asymp_large_z(double v, double z, int is_h, double *err)
+{
+    int n, sgn, maxiter;
+    double term, sum, maxterm;
+    double m;
+
+    if (is_h) {
+        sgn = -1;
+    }
+    else {
+        sgn = 1;
+    }
+
+    /* Asymptotic expansion divergenge point */
+    m = z/2;
+    if (m <= 0) {
+        maxiter = 0;
+    }
+    else if (m > MAXITER) {
+        maxiter = MAXITER;
+    }
+    else {
+        maxiter = (int)m;
+    }
+    if (maxiter == 0) {
+        *err = NPY_INFINITY;
+        return NPY_NAN;
+    }
+
+    /* Evaluate sum */
+    term = -sgn / sqrt(M_PI) * exp(-lgam(v + 0.5) + (v - 1) * log(z/2)) * gammasgn(v + 0.5);
+    sum = term;
+    maxterm = 0;
+
+    for (n = 0; n < maxiter; ++n) {
+        term *= sgn * (1 + 2*n) * (1 + 2*n - 2*v) / (z*z);
+        sum += term;
+        if (fabs(term) > maxterm) {
+            maxterm = fabs(term);
+        }
+        if (fabs(term) < SUM_EPS * fabs(sum) || term == 0 || !npy_isfinite(sum)) {
+            break;
+        }
+    }
+
+    if (is_h) {
+        sum += bessel_y(v, z);
+    }
+    else {
+        sum += bessel_i(v, z);
+    }
+
+    *err = fabs(term) + fabs(maxterm) * 1e-16;
+
+    return sum;
+}
+
+
+static double bessel_y(double v, double x)
+{
+    return cbesy_wrap_real(v, x);
+}
+
+static double bessel_i(double v, double x)
+{
+    return cephes_iv(v, x);
+}
+
+static double bessel_j(double v, double x)
+{
+    return cbesj_wrap_real(v, x);
+}

--- a/scipy/special/c_misc/struve_convergence.py
+++ b/scipy/special/c_misc/struve_convergence.py
@@ -1,0 +1,130 @@
+"""
+Convergence regions of the expansions used in ``struve.c``
+
+Note that for v >> z both functions tend rapidly to 0,
+and for v << -z, they tend to infinity.
+
+The floating-point functions over/underflow in the lower left and right
+corners of the figure.
+
+
+Figure legend
+=============
+
+Red region
+    Power series is close (1e-12) to the mpmath result
+
+Blue region
+    Asymptotic series is close to the mpmath result
+
+Green region
+    Bessel series is close to the mpmath result
+
+Dotted colored lines
+    Boundaries of the regions
+
+Solid colored lines
+    Boundaries estimated by the routine itself. These will be used
+    for determining which of the results to use.
+
+Black dashed line
+    The line z = 0.7*|v| + 12
+
+"""
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+try:
+    import mpmath
+except:
+    from sympy import mpmath
+
+
+def err_metric(a, b, atol=1e-290):
+    m = abs(a - b) / (atol + abs(b))
+    m[np.isinf(b) & (a == b)] = 0
+    return m
+
+
+def do_plot(is_h=True):
+    from scipy.special._ufuncs import \
+         _struve_power_series, _struve_asymp_large_z, _struve_bessel_series
+
+    vs = np.linspace(-1000, 1000, 91)
+    zs = np.sort(np.r_[1e-5, 1.0, np.linspace(0, 700, 91)[1:]])
+
+    rp = _struve_power_series(vs[:,None], zs[None,:], is_h)
+    ra = _struve_asymp_large_z(vs[:,None], zs[None,:], is_h)
+    rb = _struve_bessel_series(vs[:,None], zs[None,:], is_h)
+
+    mpmath.mp.dps = 50
+    if is_h:
+        sh = lambda v, z: float(mpmath.struveh(mpmath.mpf(v), mpmath.mpf(z)))
+    else:
+        sh = lambda v, z: float(mpmath.struvel(mpmath.mpf(v), mpmath.mpf(z)))
+    ex = np.vectorize(sh, otypes='d')(vs[:,None], zs[None,:])
+
+    err_a = err_metric(ra[0], ex) + 1e-300
+    err_p = err_metric(rp[0], ex) + 1e-300
+    err_b = err_metric(rb[0], ex) + 1e-300
+
+    err_est_a = abs(ra[1]/ra[0])
+    err_est_p = abs(rp[1]/rp[0])
+    err_est_b = abs(rb[1]/rb[0])
+
+    z_cutoff = 0.7*abs(vs) + 12
+
+    levels = [-1000, -12]
+
+    plt.cla()
+
+    plt.hold(1)
+    plt.contourf(vs, zs, np.log10(err_p).T, levels=levels, colors=['r', 'r'], alpha=0.1)
+    plt.contourf(vs, zs, np.log10(err_a).T, levels=levels, colors=['b', 'b'], alpha=0.1)
+    plt.contourf(vs, zs, np.log10(err_b).T, levels=levels, colors=['g', 'g'], alpha=0.1)
+
+    plt.contour(vs, zs, np.log10(err_p).T, levels=levels, colors=['r', 'r'], linestyles=[':', ':'])
+    plt.contour(vs, zs, np.log10(err_a).T, levels=levels, colors=['b', 'b'], linestyles=[':', ':'])
+    plt.contour(vs, zs, np.log10(err_b).T, levels=levels, colors=['g', 'g'], linestyles=[':', ':'])
+
+    lp = plt.contour(vs, zs, np.log10(err_est_p).T, levels=levels, colors=['r', 'r'], linestyles=['-', '-'])
+    la = plt.contour(vs, zs, np.log10(err_est_a).T, levels=levels, colors=['b', 'b'], linestyles=['-', '-'])
+    lb = plt.contour(vs, zs, np.log10(err_est_b).T, levels=levels, colors=['g', 'g'], linestyles=['-', '-'])
+
+    plt.clabel(lp, fmt={-1000: 'P', -12: 'P'})
+    plt.clabel(la, fmt={-1000: 'A', -12: 'A'})
+    plt.clabel(lb, fmt={-1000: 'B', -12: 'B'})
+
+    plt.plot(vs, z_cutoff, 'k--')
+
+    plt.xlim(vs.min(), vs.max())
+    plt.ylim(zs.min(), zs.max())
+
+    plt.xlabel('v')
+    plt.ylabel('z')
+
+
+def main():
+    plt.clf()
+    plt.subplot(121)
+    do_plot(True)
+    plt.title('Struve H')
+
+    plt.subplot(122)
+    do_plot(False)
+    plt.title('Struve L')
+
+    plt.savefig('struve_convergence.png')
+    plt.show()
+
+if __name__ == "__main__":
+    import os, sys
+    if '--main' in sys.argv:
+        main()
+    else:
+        import subprocess
+        subprocess.call([sys.executable, os.path.join('..', '..', '..', 'runtests.py'),
+                         '-g', '--python', __file__, '--main'])

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -201,8 +201,11 @@ expm1 -- expm1: d->d                                       -- cephes.h
 cosm1 -- cosm1: d->d                                       -- cephes.h
 spence -- spence: d->d                                     -- cephes.h
 zetac -- zetac: d->d                                       -- cephes.h
-struve -- struve_wrap: dd->d                               -- specfun_wrappers.h
-modstruve -- modstruve_wrap: dd->d                         -- specfun_wrappers.h
+struve -- struve_h: dd->d                                  -- misc.h
+modstruve -- struve_l: dd->d                               -- misc.h
+_struve_power_series -- struve_power_series:  ddi*d->d     -- misc.h
+_struve_asymp_large_z -- struve_asymp_large_z: ddi*d->d    -- misc.h
+_struve_bessel_series -- struve_bessel_series: ddi*d->d    -- misc.h
 itstruve0 -- itstruve0_wrap: d->d                          -- specfun_wrappers.h
 it2struve0 -- it2struve0_wrap: d->d                        -- specfun_wrappers.h
 itmodstruve0 -- itmodstruve0_wrap: d->d                    -- specfun_wrappers.h

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -27,7 +27,7 @@ def configuration(parent_package='',top_path=None):
         define_macros.append(('_USE_MATH_DEFINES',None))
 
     curdir = os.path.abspath(os.path.dirname(__file__))
-    inc_dirs = [get_python_inc()]
+    inc_dirs = [get_python_inc(), os.path.join(curdir, "c_misc")]
     if inc_dirs[0] != get_python_inc(plat_specific=1):
         inc_dirs.append(get_python_inc(plat_specific=1))
     inc_dirs.insert(0, get_numpy_include_dirs())
@@ -64,7 +64,7 @@ def configuration(parent_package='',top_path=None):
                                   "c_misc/misc.h", "cephes/mconf.h", "cephes/cephes_names.h"],
                          sources=['_ufuncs.c', 'sf_error.c', '_logit.c.src',
                                   "amos_wrappers.c", "cdf_wrappers.c", "specfun_wrappers.c"],
-                         include_dirs=[curdir],
+                         include_dirs=[curdir] + inc_dirs,
                          define_macros=define_macros,
                          extra_info=get_info("npymath"))
 

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1476,12 +1476,17 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             atol=1e-8, n=6000,
                             dps=150)
 
-    @knownfailure_overridable("problems at extremely large arguments (absolute tolerance OK, relative not)")
-    def test_struve(self):
+    def test_struveh(self):
         assert_mpmath_equal(sc.struve,
-                            _exception_to_nan(lambda v, x: mpmath.struveh(v, x, **HYPERKW)),
-                            [Arg(-1e30, 1e30), Arg()],
-                            n=2000)
+                            _exception_to_nan(lambda v, x: mpmath.struveh(v, x)),
+                            [Arg(-1e3, 1e3), Arg(0, 1e3)],
+                            rtol=1e-10)
+
+    def test_struvel(self):
+        assert_mpmath_equal(sc.modstruve,
+                            _exception_to_nan(lambda v, x: mpmath.struvel(v, x)),
+                            [Arg(-1e3, 1e3), Arg(0, 1e3)],
+                            rtol=1e-10)
 
     def test_zeta(self):
         assert_mpmath_equal(sc.zeta,

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1478,15 +1478,26 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
 
     def test_struveh(self):
         assert_mpmath_equal(sc.struve,
-                            _exception_to_nan(lambda v, x: mpmath.struveh(v, x)),
+                            _exception_to_nan(mpmath.struveh),
                             [Arg(-1e4, 1e4), Arg(0, 1e4)],
-                            rtol=1e-10)
+                            rtol=5e-10)
 
     def test_struvel(self):
+        def mp_struvel(v, z):
+            if v < 0 and z < -v and abs(v) > 1000:
+                # larger DPS needed for correct results
+                old_dps = mpmath.mp.dps
+                try:
+                    mpmath.mp.dps = 300
+                    return mpmath.struvel(v, z)
+                finally:
+                    mpmath.mp.dps = old_dps
+            return mpmath.struvel(v, z)
+
         assert_mpmath_equal(sc.modstruve,
-                            _exception_to_nan(lambda v, x: mpmath.struvel(v, x)),
+                            _exception_to_nan(mp_struvel),
                             [Arg(-1e4, 1e4), Arg(0, 1e4)],
-                            rtol=1e-10,
+                            rtol=5e-10,
                             ignore_inf_sign=True)
 
     def test_zeta(self):

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1479,14 +1479,15 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
     def test_struveh(self):
         assert_mpmath_equal(sc.struve,
                             _exception_to_nan(lambda v, x: mpmath.struveh(v, x)),
-                            [Arg(-1e3, 1e3), Arg(0, 1e3)],
+                            [Arg(-1e4, 1e4), Arg(0, 1e4)],
                             rtol=1e-10)
 
     def test_struvel(self):
         assert_mpmath_equal(sc.modstruve,
                             _exception_to_nan(lambda v, x: mpmath.struvel(v, x)),
-                            [Arg(-1e3, 1e3), Arg(0, 1e3)],
-                            rtol=1e-10)
+                            [Arg(-1e4, 1e4), Arg(0, 1e4)],
+                            rtol=1e-10,
+                            ignore_inf_sign=True)
 
     def test_zeta(self):
         assert_mpmath_equal(sc.zeta,


### PR DESCRIPTION
The current Struve function implementations are from SPECFUN, and they work only for a restricted range of small `v`. The Cephes implementation is similar and does not appear to be very reliable.

This PR reimplements these functions in C, paying more attention to the convergence regions of the different expansions. Moreover, the power series is evaluated here in double-double precision, and a Bessel function expansion is added.

This seems to be enough to give reasonable results for Struve H and L in a large parameter regime.
The functions return `nan` if they determine that sufficient accuracy was not reached.

The new implementation is not perfect, but it is a big improvement over the present one. Browsing the literature didn't give immediate ready recipes for evaluating this function numerically, so improving this further would takes more time than I'm willing to invest now.

Some examples:

```
# BEFORE
>>> struve(0, 16.68) / mpmath.struveh(0, 16.68) - 1
mpf('7.0340915314659469e-9')
>>> struve(150, 106), mpmath.struveh(150, 106)
(-18680408435.606152, mpf('1.0291694296105514e-5'))
>>> modstruve(-150, 106), mpmath.struvel(-150, 106)
(-3.8270296070393437e+71, mpf('3423.1163055623661'))

# AFTER
>>> struve(0, 16.68) / mpmath.struveh(0, 16.68) - 1
mpf('-4.6629367034256575e-15')
>>> struve(150, 106), mpmath.struveh(150, 106)
(1.0291694296105773e-05, mpf('1.0291694296105514e-5'))
>>> modstruve(-150, 106), mpmath.struvel(-150, 106)
(3423.1163055626917, mpf('3423.1163055623661'))
```
