### PR TITLE
ENH: allow sparse __mul__ to work with custom types

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -294,9 +294,14 @@ class spmatrix(object):
             other.shape
         except AttributeError:
             # If it's a list or whatever, treat it like a matrix
-            other = np.asanyarray(other)
+            other_a = np.asanyarray(other)
 
-        other = np.asanyarray(other)
+            if other_a.ndim == 0 and other_a.dtype == np.object_:
+                # Not interpretable as an array; raise NotImplemented so that
+                # other's __rmul__ can kick in if that's implemented.
+                return NotImplemented
+
+            other = other_a
 
         if other.ndim == 1 or other.ndim == 2 and other.shape[1] == 1:
             # dense row or column vector

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -60,6 +60,16 @@ def _can_cast_samekind(dtype1, dtype2):
         return np.can_cast(dtype1, dtype2, casting='same_kind')
 
 
+class MultipliesWithMatrix(object):
+    """Class that knows how to multiply with a sparse matrix."""
+
+    def __mul__(self, other):
+        return "matrix on the right"
+
+    def __rmul__(self, other):
+        return "matrix on the left"
+
+
 #------------------------------------------------------------------------------
 # Generic tests
 #------------------------------------------------------------------------------
@@ -971,6 +981,12 @@ class _TestCommon:
         assert_equal((A * array(1)).todense(), [[1],[2],[3]])
         assert_equal(A * array([1]), array([1,2,3]))
         assert_equal(A * array([[1]]), array([[1],[2],[3]]))
+
+    def test_multiply_custom(self):
+        A = self.spmatrix([[1], [2], [3]])
+        B = MultipliesWithMatrix()
+        assert_equal(A * B, "matrix on the left")
+        assert_equal(B * A, "matrix on the right")
 
     def test_matvec(self):
         M = self.spmatrix(matrix([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))


### PR DESCRIPTION
While implementing a custom sparse matrix class (a fast replacement for `dok_matrix` in Cython/C++), I noticed that there's no way to make a `scipy.sparse` matrix multiply with my type on the right, because `__mul__` was raising a `ValueError` instead of returning `NotImplemented`. I fixed that and included a unit test.
