### PR TITLE
Sparse DOK and LIL improvements

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -8,7 +8,7 @@ Sparse matrices (:mod:`scipy.sparse`)
 |   Sparse is better than dense.
 |   --- *Tim Peters*, The Zen of Python
 
-SciPy 2-D sparse matrix package.
+SciPy 2-D sparse matrix package for numeric data.
 
 Contents
 ========

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -5,6 +5,9 @@ Sparse matrices (:mod:`scipy.sparse`)
 
 .. currentmodule:: scipy.sparse
 
+|   Sparse is better than dense.
+|   --- *Tim Peters*, The Zen of Python
+
 SciPy 2-D sparse matrix package.
 
 Contents

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -5,9 +5,6 @@ Sparse matrices (:mod:`scipy.sparse`)
 
 .. currentmodule:: scipy.sparse
 
-|   Sparse is better than dense.
-|   --- *Tim Peters*, The Zen of Python
-
 SciPy 2-D sparse matrix package for numeric data.
 
 Contents

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -471,6 +471,24 @@ class dok_matrix(spmatrix, dict):
         new.update(self)
         return new
 
+    def getrow(self, i):
+        """Returns a copy of row i of the matrix as a (1 x n)
+        DOK matrix.
+        """
+        out = self.__class__((1, self.shape[1]), dtype=self.dtype)
+        for j in range(self.shape[1]):
+            out[0, j] = self[i, j]
+        return out
+
+    def getcol(self, j):
+        """Returns a copy of column j of the matrix as a (m x 1)
+        DOK matrix.
+        """
+        out = self.__class__((self.shape[0], 1), dtype=self.dtype)
+        for i in range(self.shape[0]):
+            out[i, 0] = self[i, j]
+        return out
+
     def take(self, cols_or_rows, columns=1):
         # Extract columns or rows as indictated from matrix
         # assume cols_or_rows is sorted

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -491,52 +491,6 @@ class dok_matrix(spmatrix, dict):
             out[i, 0] = self[i, j]
         return out
 
-    def take(self, cols_or_rows, columns=1):
-        # Extract columns or rows as indictated from matrix
-        # assume cols_or_rows is sorted
-        new = dok_matrix(dtype=self.dtype)    # what should the dimensions be ?!
-        indx = int((columns == 1))
-        N = len(cols_or_rows)
-        if indx:  # columns
-            for key in self.keys():
-                num = np.searchsorted(cols_or_rows, key[1])
-                if num < N:
-                    newkey = (key[0], num)
-                    new[newkey] = self[key]
-        else:
-            for key in self.keys():
-                num = np.searchsorted(cols_or_rows, key[0])
-                if num < N:
-                    newkey = (num, key[1])
-                    new[newkey] = self[key]
-        return new
-
-    def split(self, cols_or_rows, columns=1):
-        # Similar to take but returns two arrays, the extracted columns plus
-        # the resulting array.  Assumes cols_or_rows is sorted
-        base = dok_matrix()
-        ext = dok_matrix()
-        indx = int((columns == 1))
-        if indx:
-            for key in self.keys():
-                num = np.searchsorted(cols_or_rows, key[1])
-                if cols_or_rows[num] == key[1]:
-                    newkey = (key[0], num)
-                    ext[newkey] = self[key]
-                else:
-                    newkey = (key[0], key[1]-num)
-                    base[newkey] = self[key]
-        else:
-            for key in self.keys():
-                num = np.searchsorted(cols_or_rows, key[0])
-                if cols_or_rows[num] == key[0]:
-                    newkey = (num, key[1])
-                    ext[newkey] = self[key]
-                else:
-                    newkey = (key[0]-num, key[1])
-                    base[newkey] = self[key]
-        return base, ext
-
     def tocoo(self):
         """ Return a copy of this matrix in COOrdinate format"""
         from .coo import coo_matrix

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -392,8 +392,10 @@ class dok_matrix(spmatrix, dict):
         return new
 
     def _mul_scalar(self, other):
+        # Get the result dtype in a bad way.
+        res_dtype = (np.array([0], dtype=self.dtype) * other).dtype
         # Multiply this scalar by every element.
-        new = dok_matrix(self.shape, dtype=self.dtype)
+        new = dok_matrix(self.shape, dtype=res_dtype)
         for (key, val) in iteritems(self):
             new[key] = val * other
         return new

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -381,7 +381,11 @@ class lil_matrix(spmatrix):
             # Multiply by zero: return the zero matrix
             new = lil_matrix(self.shape, dtype=self.dtype)
         else:
+            # Get the result dtype in a bad way.
+            res_dtype = (np.array([0], dtype=self.dtype) * other).dtype
+
             new = self.copy()
+            new = new.astype(res_dtype)
             # Multiply this scalar by every element.
             new.data[:] = [[val*other for val in rowvals] for
                            rowvals in new.data]

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -91,6 +91,8 @@ def getdtype(dtype, a=None, default=None):
                 canCast = False
             else:
                 raise TypeError("could not interpret data type")
+    elif dtype == object or dtype == np.object_:
+        raise TypeError("object dtype is not implemented for sparse matrices.")
     else:
         newdtype = np.dtype(dtype)
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -765,11 +765,7 @@ class _TestCommon:
             assert_array_equal(dat*17.3,(datsp*17.3).todense())
 
         for dtype in self.checked_dtypes:
-            fails = ((dtype == np.typeDict['int']) and
-                    (self.__class__ == TestLIL or
-                     self.__class__ == TestDOK))
-            msg = "LIL and DOK type's __mul__ method has problems with int data."
-            yield dec.knownfailureif(fails, msg)(check), dtype
+            yield check, dtype
 
     def test_rmul_scalar(self):
         def check(dtype):


### PR DESCRIPTION
This fixes issues [#2528](https://github.com/scipy/scipy/issues/2542), [#2645](https://github.com/scipy/scipy/issues/2645), and [#2542](https://github.com/scipy/scipy/issues/2542).
- #2542 This raises an error when you try to create a sparse matrix with `dtype=object`, and adds a note to the docs stating that SciPy Sparse is for numeric data.
- #2645 This removes the broken and undocumented `take` and `split` methods. And adds `getrow` and `getcol`. 
- #2542 This fixes the casting for scalar multiplication with LIL and DOK and turns on tests for them.

The way I did the casting to correct #2542 is a dirty hack. Please let me know if there is a better way. See [these lines](https://github.com/cowlicks/scipy/compare/dok-lil-improvements?expand=1#L2R384).
