### PR TITLE
refactor stats/distributions.py

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -562,8 +562,8 @@ class rv_generic(object):
     def _construct_argparser(self, names_to_inspect, locscale_in, locscale_out):
         """Construct the parser for the shape arguments.
 
-        Generates the argument-parsing functions dynamically.
-        Modifies the calling class.
+        Generates the argument-parsing functions dynamically and attaches
+        them to the instance. 
         Is supposed to be called in __init__ of a class for each distribution.
 
         If self.shapes is a non-empty string, interprets it as a comma-separated
@@ -704,7 +704,6 @@ class rv_generic(object):
 
     def _isf(self, q, *args):
         return self._ppf(1.0-q, *args)  # use correct _ppf for subclasses
-
 
     # These are actually called, and should not be overwritten if you
     # want to keep error checking.
@@ -1340,7 +1339,7 @@ class rv_continuous(rv_generic):
         self._cdfvec.nin = self.numargs + 1
 
         # backwards compatibility
-        self.vecfunc = self._ppfvec  
+        self.vecfunc = self._ppfvec
         self.veccdf = self._cdfvec
 
         self.extradoc = extradoc
@@ -1792,7 +1791,10 @@ class rv_continuous(rv_generic):
             return output[()]
         return output
 
+<<<<<<< HEAD
 
+=======
+>>>>>>> DOC: correct the docstring of _construct_argparser
     def _nnlf(self, x, *args):
         return -sum(self._logpdf(x, *args),axis=0)
 
@@ -2107,7 +2109,7 @@ class rv_continuous(rv_generic):
 
         """
         lockwds = {'loc': loc,
-                   'scale':scale}
+                   'scale': scale}
         self._argcheck(*args)
         if func is None:
             def fun(x, *args):

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -559,6 +559,15 @@ class rv_generic(object):
     and rv_continuous.
 
     """
+    def __init__(self):
+        super(rv_generic, self).__init__()
+        
+        # figure out if _stats signature has 'moments' keyword
+        sign = inspect.getargspec(get_method_function(self._stats))
+        self._stats_has_moments = ((sign[2] is not None) or
+                                   ('moments' in sign[0]))
+
+
     def _construct_argparser(self, names_to_inspect, locscale_in, locscale_out):
         """Construct the parser for the shape arguments.
 
@@ -792,8 +801,7 @@ class rv_generic(object):
         args = tuple(map(asarray, args))
         cond = self._argcheck(*args) & (scale > 0) & (loc == loc)
 
-        signature = inspect.getargspec(get_method_function(self._stats))
-        if (signature[2] is not None) or ('moments' in signature[0]):
+        if self._stats_has_moments:
             mu, mu2, g1, g2 = self._stats(*args, **{'moments': moments})
         else:
             mu, mu2, g1, g2 = self._stats(*args)
@@ -927,12 +935,11 @@ class rv_generic(object):
             raise ValueError("Moment must be positive.")
         mu, mu2, g1, g2 = None, None, None, None
         if (n > 0) and (n < 5):
-            signature = inspect.getargspec(get_method_function(self._stats))
-            if (signature[2] is not None) or ('moments' in signature[0]):
-                mdict = {'moments':{1:'m',2:'v',3:'vs',4:'vk'}[n]}
+            if self._stats_has_moments:
+                mdict = {'moments': {1: 'm', 2: 'v', 3: 'vs', 4: 'vk'}[n]}
             else:
                 mdict = {}
-            mu, mu2, g1, g2 = self._stats(*args,**mdict)
+            mu, mu2, g1, g2 = self._stats(*args, **mdict)
         val = _moment_from_stats(n, mu, mu2, g1, g2, self._munp, args)
 
         # Convert to transformed  X = L + S*Y
@@ -1304,7 +1311,7 @@ class rv_continuous(rv_generic):
                  badvalue=None, name=None, longname=None,
                  shapes=None, extradoc=None):
 
-        rv_generic.__init__(self)
+        super(rv_continuous, self).__init__()
 
         if badvalue is None:
             badvalue = nan
@@ -1791,10 +1798,7 @@ class rv_continuous(rv_generic):
             return output[()]
         return output
 
-<<<<<<< HEAD
 
-=======
->>>>>>> DOC: correct the docstring of _construct_argparser
     def _nnlf(self, x, *args):
         return -sum(self._logpdf(x, *args),axis=0)
 
@@ -2064,9 +2068,7 @@ class rv_continuous(rv_generic):
             place(output, cond0, self.vecentropy(*goodargs) + log(scale))
 
         return output
-=======
 
->>>>>>> MAINT: Lift entropy to rv_generic.
 
     def expect(self, func=None, args=(), loc=0, scale=1, lb=None, ub=None,
                conditional=False, **kwds):
@@ -6439,7 +6441,7 @@ class rv_discrete(rv_generic):
                  moment_tol=1e-8,values=None,inc=1,longname=None,
                  shapes=None, extradoc=None):
 
-        super(rv_generic,self).__init__()
+        super(rv_discrete, self).__init__()
 
         if badvalue is None:
             badvalue = nan

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -19,13 +19,13 @@ from scipy.special import gammaln as gamln
 import keyword
 import re
 import inspect
-from numpy import all, where, arange, putmask, \
-     ravel, take, ones, sum, shape, product, reshape, \
-     zeros, floor, logical_and, log, sqrt, exp, arctanh, tan, sin, arcsin, \
-     arctan, tanh, ndarray, cos, cosh, sinh, newaxis, log1p, expm1
-from numpy import atleast_1d, polyval, ceil, place, extract, \
-     any, argsort, argmax, vectorize, r_, asarray, nan, inf, pi, isinf, \
-     NINF, empty
+from numpy import (all, where, arange, putmask,
+     ravel, take, ones, sum, shape, product, reshape,
+     zeros, floor, logical_and, log, sqrt, exp, arctanh, tan, sin, arcsin,
+     arctan, tanh, ndarray, cos, cosh, sinh, newaxis, log1p, expm1)
+from numpy import (atleast_1d, polyval, ceil, place, extract,
+     any, argsort, argmax, vectorize, r_, asarray, nan, inf, pi, isinf,
+     NINF, empty)
 
 import numpy as np
 import numpy.random as mtrand
@@ -1332,11 +1332,11 @@ class rv_continuous(rv_generic):
                                   locscale_out='loc, scale')
 
         # nin correction
-        self._ppfvec = sgf(self._ppf_single,otypes='d')
+        self._ppfvec = vectorize(self._ppf_single,otypes='d')
         self._ppfvec.nin = self.numargs + 1
-        self.vecentropy = sgf(self._entropy,otypes='d')
+        self.vecentropy = vectorize(self._entropy,otypes='d')
         self.vecentropy.nin = self.numargs + 1
-        self._cdfvec = sgf(self._cdf_single,otypes='d')
+        self._cdfvec = vectorize(self._cdf_single,otypes='d')
         self._cdfvec.nin = self.numargs + 1
 
         # backwards compatibility
@@ -6449,9 +6449,9 @@ class rv_discrete(rv_generic):
         self.name = name
         self.moment_tol = moment_tol
         self.inc = inc
-        self._cdfvec = sgf(self._cdf_single,otypes='d')
+        self._cdfvec = vectorize(self._cdf_single,otypes='d')
         self.return_integers = 1
-        self.vecentropy = sgf(self._entropy)
+        self.vecentropy = vectorize(self._entropy)
         self.shapes = shapes
         self.extradoc = extradoc
 
@@ -6488,7 +6488,7 @@ class rv_discrete(rv_generic):
 
             # nin correction needs to be after we know numargs
             # correct nin for generic moment vectorization
-            _vec_generic_moment = sgf(_drv2_moment, otypes='d')
+            _vec_generic_moment = vectorize(_drv2_moment, otypes='d')
             _vec_generic_moment.nin = self.numargs + 2
             self.generic_moment = instancemethod(_vec_generic_moment,
                                                  self, rv_discrete)
@@ -6786,7 +6786,7 @@ class rv_discrete(rv_generic):
             return output[()]
         return output
 
-    def logsf(self,k,*args,**kwds):
+    def logsf(self, k, *args, **kwds):
         """
         Log of the survival function of the given RV.
 
@@ -6805,8 +6805,8 @@ class rv_discrete(rv_generic):
 
         Returns
         -------
-        sf : ndarray
-            Survival function evaluated at `k`.
+        logsf : ndarray
+            Log of the survival function evaluated at `k`.
 
         """
         args, loc, _ = self._parse_args(*args, **kwds)

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -669,9 +669,19 @@ class rv_generic(object):
         return self.generic_moment(n, *args)
 
     ## These are the methods you must define (standard form functions)
-    ## NB: generic _argcheck, _pdf, _logpdf, _cdf are different for
+    ## NB: generic _pdf, _logpdf, _cdf are different for
     ## rv_continuous and rv_discrete hence are defined in there
-	## Besides, _argcheck: bitwise and vs logical and --- is that on purpose?
+    def _argcheck(self, *args):
+        """Default check for correct values on args and keywords.
+
+        Returns condition array of 1's where arguments are correct and
+         0's where they are not.
+
+        """
+        cond = 1
+        for arg in args:
+            cond = logical_and(cond, (asarray(arg) > 0))
+        return cond
 
     ##(return 1-d using self._size to get number)
     def _rvs(self, *args):
@@ -1430,16 +1440,6 @@ class rv_continuous(rv_generic):
     def _mom1_sc(self, m,*args):
         return integrate.quad(self._mom_integ1, 0, 1,args=(m,)+args)[0]
 
-    ## These are the methods you must define (standard form functions)
-    def _argcheck(self, *args):
-        # Default check for correct values on args and keywords.
-        # Returns condition array of 1's where arguments are correct and
-        #  0's where they are not.
-        cond = 1
-        for arg in args:
-            cond = logical_and(cond,(asarray(arg) > 0))
-        return cond
-
     def _pdf(self, x, *args):
         return derivative(self._cdf, x, dx=1e-5, args=args, order=5)
 
@@ -1453,7 +1453,8 @@ class rv_continuous(rv_generic):
     def _cdf(self, x, *args):
         return self._cdfvec(x, *args)
 
-    ## generic _logcdf, _sf, _logsf, _ppf, _isf, _rvs are defined in rv_generic
+    ## generic _argcheck, _logcdf, _sf, _logsf, _ppf, _isf, _rvs are defined 
+    ## in rv_generic
 
     def pdf(self,x,*args,**kwds):
         """
@@ -6554,12 +6555,6 @@ class rv_discrete(rv_generic):
 
     def _nonzero(self, k, *args):
         return floor(k) == k
-
-    def _argcheck(self, *args):
-        cond = 1
-        for arg in args:
-            cond &= (arg > 0)
-        return cond
 
     def _pmf(self, k, *args):
         return self._cdf(k, *args) - self._cdf(k-1, *args)

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -722,6 +722,118 @@ class rv_generic(object):
         return vals
 
 
+    def stats(self, *args, **kwds):
+        """
+        Some statistics of the given RV
+
+        Parameters
+        ----------
+        arg1, arg2, arg3,... : array_like
+            The shape parameter(s) for the distribution (see docstring of the
+            instance object for more information)
+        loc : array_like, optional
+            location parameter (default=0)
+        scale : array_like, optional (discrete RVs only)
+            scale parameter (default=1)
+        moments : str, optional
+            composed of letters ['mvsk'] defining which moments to compute:
+            'm' = mean,
+            'v' = variance,
+            's' = (Fisher's) skew,
+            'k' = (Fisher's) kurtosis.
+            (default='mv')
+
+        Returns
+        -------
+        stats : sequence
+            of requested moments.
+
+        """
+        args, loc, scale, moments = self._parse_args_stats(*args, **kwds)
+        # scale = 1 by construction for discrete RVs
+        loc, scale = map(asarray, (loc, scale))
+        args = tuple(map(asarray, args))
+        cond = self._argcheck(*args) & (scale > 0) & (loc == loc)
+
+        signature = inspect.getargspec(get_method_function(self._stats))
+        if (signature[2] is not None) or ('moments' in signature[0]):
+            mu, mu2, g1, g2 = self._stats(*args, **{'moments': moments})
+        else:
+            mu, mu2, g1, g2 = self._stats(*args)
+        if g1 is None:
+            mu3 = None
+        else:
+            mu3 = g1*np.power(mu2, 1.5)  # (mu2**1.5) breaks down for nan and inf
+        default = valarray(shape(cond), self.badvalue)
+        output = []
+
+        # Use only entries that are valid in calculation
+        if any(cond):
+            goodargs = argsreduce(cond, *(args + (scale, loc)))
+            scale, loc, goodargs = goodargs[-2], goodargs[-1], goodargs[:-2]
+            if 'm' in moments:
+                if mu is None:
+                    mu = self._munp(1.0, *goodargs)
+                out0 = default.copy()
+                place(out0, cond, mu*scale + loc)
+                output.append(out0)
+
+            if 'v' in moments:
+                if mu2 is None:
+                    mu2p = self._munp(2.0, *goodargs)
+                    if mu is None:
+                        mu = self._munp(1.0, *goodargs)
+                    mu2 = mu2p - mu*mu
+                    if np.isinf(mu):
+                        #if mean is inf then var is also inf
+                        mu2 = np.inf
+                out0 = default.copy()
+                place(out0, cond, mu2*scale*scale)
+                output.append(out0)
+
+            if 's' in moments:
+                if g1 is None:
+                    mu3p = self._munp(3.0, *goodargs)
+                    if mu is None:
+                        mu = self._munp(1.0, *goodargs)
+                    if mu2 is None:
+                        mu2p = self._munp(2.0, *goodargs)
+                        mu2 = mu2p - mu*mu
+                    mu3 = mu3p - 3*mu*mu2 - mu**3
+                    g1 = mu3 / np.power(mu2, 1.5) #mu2**1.5
+                out0 = default.copy()
+                place(out0, cond, g1)
+                output.append(out0)
+
+            if 'k' in moments:
+                if g2 is None:
+                    mu4p = self._munp(4.0, *goodargs)
+                    if mu is None:
+                        mu = self._munp(1.0, *goodargs)
+                    if mu2 is None:
+                        mu2p = self._munp(2.0, *goodargs)
+                        mu2 = mu2p - mu*mu
+                    if mu3 is None:
+                        mu3p = self._munp(3.0, *goodargs)
+                        mu3 = mu3p - 3*mu*mu2 - mu**3
+                    mu4 = mu4p - 4*mu*mu3 - 6*mu*mu*mu2 - mu**4
+                    g2 = mu4 / mu2**2.0 - 3.0
+                out0 = default.copy()
+                place(out0,cond, g2)
+                output.append(out0)
+        else:  # no valid args
+            output = []
+            for _ in moments:
+                out0 = default.copy()
+                output.append(out0)
+
+        if len(output) == 1:
+            return output[0]
+        else:
+            return tuple(output)
+
+
+
     def entropy(self, *args, **kwds):
         """
         Differential entropy of the RV.
@@ -1667,115 +1779,6 @@ class rv_continuous(rv_generic):
         if output.ndim == 0:
             return output[()]
         return output
-
-    def stats(self,*args,**kwds):
-        """
-        Some statistics of the given RV
-
-        Parameters
-        ----------
-        arg1, arg2, arg3,... : array_like
-            The shape parameter(s) for the distribution (see docstring of the
-            instance object for more information)
-        loc : array_like, optional
-            location parameter (default=0)
-        scale : array_like, optional
-            scale parameter (default=1)
-        moments : str, optional
-            composed of letters ['mvsk'] defining which moments to compute:
-            'm' = mean,
-            'v' = variance,
-            's' = (Fisher's) skew,
-            'k' = (Fisher's) kurtosis.
-            (default='mv')
-
-        Returns
-        -------
-        stats : sequence
-            of requested moments.
-
-        """
-        args, loc, scale, moments = self._parse_args_stats(*args, **kwds)
-        loc, scale = map(asarray, (loc, scale))
-        args = tuple(map(asarray, args))
-        cond = self._argcheck(*args) & (scale > 0) & (loc == loc)
-
-        signature = inspect.getargspec(get_method_function(self._stats))
-        if (signature[2] is not None) or ('moments' in signature[0]):
-            mu, mu2, g1, g2 = self._stats(*args,**{'moments':moments})
-        else:
-            mu, mu2, g1, g2 = self._stats(*args)
-        if g1 is None:
-            mu3 = None
-        else:
-            mu3 = g1*np.power(mu2,1.5)  # (mu2**1.5) breaks down for nan and inf
-        default = valarray(shape(cond), self.badvalue)
-        output = []
-
-        # Use only entries that are valid in calculation
-        if any(cond):
-            goodargs = argsreduce(cond, *(args+(scale,loc)))
-            scale, loc, goodargs = goodargs[-2], goodargs[-1], goodargs[:-2]
-            if 'm' in moments:
-                if mu is None:
-                    mu = self._munp(1.0,*goodargs)
-                out0 = default.copy()
-                place(out0,cond,mu*scale+loc)
-                output.append(out0)
-
-            if 'v' in moments:
-                if mu2 is None:
-                    mu2p = self._munp(2.0,*goodargs)
-                    if mu is None:
-                        mu = self._munp(1.0,*goodargs)
-                    mu2 = mu2p - mu*mu
-                    if np.isinf(mu):
-                        #if mean is inf then var is also inf
-                        mu2 = np.inf
-                out0 = default.copy()
-                place(out0,cond,mu2*scale*scale)
-                output.append(out0)
-
-            if 's' in moments:
-                if g1 is None:
-                    mu3p = self._munp(3.0,*goodargs)
-                    if mu is None:
-                        mu = self._munp(1.0,*goodargs)
-                    if mu2 is None:
-                        mu2p = self._munp(2.0,*goodargs)
-                        mu2 = mu2p - mu*mu
-                    mu3 = mu3p - 3*mu*mu2 - mu**3
-                    g1 = mu3 / np.power(mu2, 1.5)
-                out0 = default.copy()
-                place(out0,cond,g1)
-                output.append(out0)
-
-            if 'k' in moments:
-                if g2 is None:
-                    mu4p = self._munp(4.0,*goodargs)
-                    if mu is None:
-                        mu = self._munp(1.0,*goodargs)
-                    if mu2 is None:
-                        mu2p = self._munp(2.0,*goodargs)
-                        mu2 = mu2p - mu*mu
-                    if mu3 is None:
-                        mu3p = self._munp(3.0,*goodargs)
-                        mu3 = mu3p - 3*mu*mu2 - mu**3
-                    mu4 = mu4p - 4*mu*mu3 - 6*mu*mu*mu2 - mu**4
-                    g2 = mu4 / mu2**2.0 - 3.0
-                out0 = default.copy()
-                place(out0,cond,g2)
-                output.append(out0)
-        else:  # no valid args
-            output = []
-            for _ in moments:
-                out0 = default.copy()
-                output.append(out0)
-
-        if len(output) == 1:
-            return output[0]
-        else:
-            return tuple(output)
 
 
     def _nnlf(self, x, *args):
@@ -6917,111 +6920,6 @@ class rv_discrete(rv_generic):
         if output.ndim == 0:
             return output[()]
         return output
-
-    def stats(self, *args, **kwds):
-        """
-        Some statistics of the given discrete RV.
-
-        Parameters
-        ----------
-        arg1, arg2, arg3,... : array_like
-            The shape parameter(s) for the distribution (see docstring of the
-            instance object for more information).
-        loc : array_like, optional
-            Location parameter (default=0).
-        moments : string, optional
-            Composed of letters ['mvsk'] defining which moments to compute:
-
-              - 'm' = mean,
-              - 'v' = variance,
-              - 's' = (Fisher's) skew,
-              - 'k' = (Fisher's) kurtosis.
-
-            The default is'mv'.
-
-        Returns
-        -------
-        stats : sequence
-            of requested moments.
-
-        """
-        try:
-            kwds["moments"] = kwds.pop("moment") # test suite is full of these; a feature?
-        except KeyError:
-            pass
-        args, loc, _, moments = self._parse_args_stats(*args, **kwds)
-        loc = asarray(loc)
-        args = tuple(map(asarray,args))
-        cond = self._argcheck(*args) & (loc == loc)
-
-        signature = inspect.getargspec(get_method_function(self._stats))
-        if (signature[2] is not None) or ('moments' in signature[0]):
-            mu, mu2, g1, g2 = self._stats(*args,**{'moments':moments})
-        else:
-            mu, mu2, g1, g2 = self._stats(*args)
-        if g1 is None:
-            mu3 = None
-        else:
-            mu3 = g1 * np.power(mu2, 1.5)
-        default = valarray(shape(cond), self.badvalue)
-        output = []
-
-        # Use only entries that are valid in calculation
-        goodargs = argsreduce(cond, *(args+(loc,)))
-        loc, goodargs = goodargs[-1], goodargs[:-1]
-
-        if 'm' in moments:
-            if mu is None:
-                mu = self._munp(1.0,*goodargs)
-            out0 = default.copy()
-            place(out0,cond,mu+loc)
-            output.append(out0)
-
-        if 'v' in moments:
-            if mu2 is None:
-                mu2p = self._munp(2.0,*goodargs)
-                if mu is None:
-                    mu = self._munp(1.0,*goodargs)
-                mu2 = mu2p - mu*mu
-            out0 = default.copy()
-            place(out0,cond,mu2)
-            output.append(out0)
-
-        if 's' in moments:
-            if g1 is None:
-                mu3p = self._munp(3.0,*goodargs)
-                if mu is None:
-                    mu = self._munp(1.0,*goodargs)
-                if mu2 is None:
-                    mu2p = self._munp(2.0,*goodargs)
-                    mu2 = mu2p - mu*mu
-                mu3 = mu3p - 3*mu*mu2 - mu**3
-                g1 = mu3 / np.power(mu2, 1.5)
-            out0 = default.copy()
-            place(out0,cond,g1)
-            output.append(out0)
-
-        if 'k' in moments:
-            if g2 is None:
-                mu4p = self._munp(4.0,*goodargs)
-                if mu is None:
-                    mu = self._munp(1.0,*goodargs)
-                if mu2 is None:
-                    mu2p = self._munp(2.0,*goodargs)
-                    mu2 = mu2p - mu*mu
-                if mu3 is None:
-                    mu3p = self._munp(3.0,*goodargs)
-                    mu3 = mu3p - 3*mu*mu2 - mu**3
-                mu4 = mu4p - 4*mu*mu3 - 6*mu*mu*mu2 - mu**4
-                g2 = mu4 / mu2**2.0 - 3.0
-            out0 = default.copy()
-            place(out0,cond,g2)
-            output.append(out0)
-
-        if len(output) == 1:
-            return output[0]
-        else:
-            return tuple(output)
 
 
     def _entropy(self, *args):

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -222,7 +222,6 @@ def test_cont_basic():
         # if available
         if distfn.__class__._entropy != stats.rv_continuous._entropy:
             yield check_private_entropy, distfn, arg
-
         yield check_edge_support, distfn, arg
 
 
@@ -507,6 +506,21 @@ def check_private_entropy(distfn, args):
     npt.assert_allclose(distfn._entropy(*args),
                         stats.rv_continuous._entropy(distfn, *args))
 
+
+
+
+def check_edge_support(distfn, args):
+    """Make sure the x=self.a and self.b are handled correctly."""
+    x = [distfn.a, distfn.b]
+    npt.assert_equal(distfn.cdf(x, *args), [0.0, 1.0])
+    npt.assert_equal(distfn.logcdf(x, *args), [-np.inf, 0.0])
+
+    npt.assert_equal(distfn.sf(x, *args), [1.0, 0.0])
+    npt.assert_equal(distfn.logsf(x, *args), [0.0, -np.inf])
+
+    npt.assert_equal(distfn.ppf([0.0, 1.0], *args), x)
+    npt.assert_equal(distfn.isf([0.0, 1.0], *args), x[::-1])
+    # pdf(x=[a, b], *args) depends on the distribution
 
 
 if __name__ == "__main__":

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -226,7 +226,6 @@ def test_cont_basic():
         yield check_edge_support, distfn, arg
 
 
-
 @npt.dec.slow
 def test_cont_basic_slow():
     # same as above for slow distributions
@@ -280,6 +279,7 @@ def test_cont_basic_slow():
         if distfn.__class__._entropy != stats.rv_continuous._entropy:
             yield check_private_entropy, distfn, arg
         yield check_edge_support, distfn, arg
+
 
 @npt.dec.slow
 def test_moments():
@@ -502,11 +502,11 @@ def check_edge_support(distfn, args):
     # pdf(x=[a, b], *args) depends on the distribution
 
 
-@_silence_fp_errors
 def check_private_entropy(distfn, args):
     # compare a generic _entropy with the distribution-specific implementation
     npt.assert_allclose(distfn._entropy(*args),
                         stats.rv_continuous._entropy(distfn, *args))
+
 
 
 if __name__ == "__main__":

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -249,7 +249,7 @@ def assert_equal_inf_nan(v1,v2,msg):
 
 
 def check_sample_skew_kurt(distfn, arg, sk, ss, msg):
-    k,s = distfn.stats(moment='ks',*arg)
+    k,s = distfn.stats(moments='ks', *arg)
     check_sample_meanvar, sk, k, msg + 'sample skew test'
     check_sample_meanvar, ss, s, msg + 'sample kurtosis test'
 

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -38,7 +38,7 @@ distdiscrete = [
 def test_discrete_basic():
     for distname, arg in distdiscrete:
         distfn = getattr(stats,distname)
-        # npt.assert_(stats.dlaplace.rvs(0.8) is not None)
+        #npt.assert_(stats.dlaplace.rvs(0.8) is not None)
         np.random.seed(9765456)
         rvs = distfn.rvs(size=2000,*arg)
         supp = np.unique(rvs)
@@ -60,7 +60,6 @@ def test_discrete_basic():
         alpha = 0.01
         yield check_discrete_chisquare, distfn, arg, rvs, alpha, \
                       distname + ' chisquare'
-
 
     seen = set()
     for distname, arg in distdiscrete:


### PR DESCRIPTION
Deduplicate a bit of code in stats/distributions.py: move exact duplicates from `rv_continuous` and `rv_discrete` to `rv_generic`, fix a couple of typos.  
