### PR TITLE
BUG: stats: The formula for the skew in poisson.stats() was incorrect--it did not take the sqrt.

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -7598,7 +7598,7 @@ class poisson_gen(rv_discrete):
     def _stats(self, mu):
         var = mu
         tmp = asarray(mu)
-        g1 = 1.0 / tmp
+        g1 = sqrt(1.0 / tmp)
         g2 = 1.0 / tmp
         return mu, var, g1, g2
 poisson = poisson_gen(name="poisson", longname='A Poisson')

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -483,6 +483,11 @@ class TestPoisson(TestCase):
         assert_(isinstance(val, numpy.ndarray))
         assert_(val.dtype.char in typecodes['AllInteger'])
 
+    def test_stats(self):
+        mu = 16.0
+        result = stats.poisson.stats(mu, moments='mvsk')
+        assert_allclose(result, [mu, mu, np.sqrt(1.0/mu), 1.0/mu])
+
 
 class TestZipf(TestCase):
     def test_rvs(self):


### PR DESCRIPTION
See, for example, http://en.wikipedia.org/wiki/Poisson_distribution
