### PR TITLE
Bug: stats trim_mean

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2258,7 +2258,7 @@ def sigmaclip(a, low=4., high=4.):
     return c, critlower, critupper
 
 
-def trimboth(a, proportiontocut):
+def trimboth(a, proportiontocut, axis=0):
     """
     Slices off a proportion of items from both ends of an array.
 
@@ -2275,6 +2275,10 @@ def trimboth(a, proportiontocut):
         Data to trim.
     proportiontocut : float or int
         Proportion of total data set to trim of each end.
+    axis : int or None
+        Axis along which the observations are trimmed. The default is to trim
+        along axis=0. If axis is None then the array will be flattened before
+        trimming.
 
     Returns
     -------
@@ -2290,12 +2294,19 @@ def trimboth(a, proportiontocut):
     (16,)
 
     """
-    a = asarray(a)
-    lowercut = int(proportiontocut*len(a))
-    uppercut = len(a) - lowercut
+    a = np.asarray(a)
+    if axis is None:
+        a = a.ravel()
+        axis = 0
+    nobs = a.shape[axis]
+    lowercut = int(proportiontocut * nobs)
+    uppercut = nobs - lowercut
     if (lowercut >= uppercut):
         raise ValueError("Proportion too big.")
-    return a[lowercut:uppercut]
+
+    sl = [slice(None)] * a.ndim
+    sl[axis] = slice(lowercut, uppercut)
+    return a[sl]
 
 
 def trim1(a, proportiontocut, tail='right'):
@@ -2332,7 +2343,7 @@ def trim1(a, proportiontocut, tail='right'):
     return a[lowercut:uppercut]
 
 
-def trim_mean(a, proportiontocut):
+def trim_mean(a, proportiontocut, axis=0):
     """
     Return mean of array after trimming distribution from both lower and upper
     tails.
@@ -2347,6 +2358,10 @@ def trim_mean(a, proportiontocut):
         Input array
     proportiontocut : float
         Fraction to cut off of both tails of the distribution
+    axis : int or None
+        Axis along which the trimmed means are computed. The default is axis=0.
+        If axis is None then the trimmed mean will be computed for the
+        flattened array.
 
     Returns
     -------
@@ -2354,8 +2369,8 @@ def trim_mean(a, proportiontocut):
         Mean of trimmed array.
 
     """
-    newa = trimboth(np.sort(a),proportiontocut)
-    return np.mean(newa,axis=0)
+    newa = trimboth(np.sort(a, axis), proportiontocut, axis=axis)
+    return np.mean(newa, axis=axis)
 
 
 def f_oneway(*args):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2387,6 +2387,7 @@ class Test_Trim(object):
         assert_equal(stats.trim_mean([5,4,3,1,2,0], 2/6.), 2.5)
 
         # check axis argument
+        np.random.seed(1234)
         a = np.random.randint(20, size=(5, 6, 4, 7))
         for axis in [0, 1, 2, 3, -1]:
             res1 = stats.trim_mean(a, 2/6., axis=axis)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2367,12 +2367,35 @@ class Test_Trim(object):
                np.arange(24).reshape(4,6).T, 4/6.)
 
     def test_trim_mean(self):
-        assert_equal(stats.trim_mean(np.arange(24).reshape(4,6).T, 2/6.),
+        # don't use pre-sorted arrays
+        a = np.array([ 4,  8,  2,  0,  9,  5, 10,  1,  7,  3,  6])
+        idx = np.array([3, 5, 0, 1, 2, 4])
+        a2 = np.arange(24).reshape(6, 4)[idx, :]
+        a3 = np.arange(24).reshape(6, 4, order='F')[idx, :]
+        assert_equal(stats.trim_mean(a3, 2/6.),
                         np.array([2.5, 8.5, 14.5, 20.5]))
-        assert_equal(stats.trim_mean(np.arange(24).reshape(4,6), 2/6.),
+        assert_equal(stats.trim_mean(a2, 2/6.),
+                        np.array([10., 11., 12., 13.]))
+        idx4 = np.array([1, 0, 3, 2])
+        a4 = np.arange(24).reshape(4, 6)[idx4, :]
+        assert_equal(stats.trim_mean(a4, 2/6.),
                         np.array([9., 10., 11., 12., 13., 14.]))
-        assert_equal(stats.trim_mean(np.arange(24), 2/6.), 11.5)
+        # shuffled arange(24)
+        a = np.array([ 7, 11, 12, 21, 16,  6, 22,  1,  5,  0, 18, 10, 17,  9,
+                      19, 15, 23, 20,  2, 14,  4, 13,  8,  3])
+        assert_equal(stats.trim_mean(a, 2/6.), 11.5)
         assert_equal(stats.trim_mean([5,4,3,1,2,0], 2/6.), 2.5)
+
+        # check axis argument
+        a = np.random.randint(20, size=(5, 6, 4, 7))
+        for axis in [0, 1, 2, 3, -1]:
+            res1 = stats.trim_mean(a, 2/6., axis=axis)
+            res2 = stats.trim_mean(np.rollaxis(a, axis), 2/6.)
+            assert_equal(res1, res2)
+
+        res1 = stats.trim_mean(a, 2/6., axis=None)
+        res2 = stats.trim_mean(a.ravel(), 2/6.)
+        assert_equal(res1, res2)
 
 
 class TestSigamClip(object):


### PR DESCRIPTION
fixes bug for >1d array, 
add axis argument closes #2554

Note: existing unit tests used sorted array, which didn't hit the sorting bug
I reshuffled the numbers

I tested this outside of scipy source and then copied it into the source files
