### PR TITLE
BUG: levene didn't sort before trimming 

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -970,7 +970,7 @@ def levene(*args,**kwds):
     elif center == 'mean':
         func = lambda x: np.mean(x, axis=0)
     else:  # center == 'trimmed'
-        args = tuple(stats.trimboth(arg, proportiontocut) for arg in args)
+        args = tuple(stats.trimboth(np.sort(arg), proportiontocut) for arg in args)
         func = lambda x: np.mean(x, axis=0)
 
     for j in range(k):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -145,6 +145,7 @@ class TestLevene(TestCase):
     def test_trimmed2(self):
         x = [1.2, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 100.0]
         y = [0.0, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 200.0]
+        np.random.seed(1234)
         x2 = np.random.permutation(x)
 
         # Use center='trimmed'
@@ -159,6 +160,7 @@ class TestLevene(TestCase):
 
     def test_equal_mean_median(self):
         x = np.linspace(-1,1,21)
+        np.random.seed(1234)
         x2 = np.random.permutation(x)
         y = x**3
         W1, pval1 = stats.levene(x, y, center='mean')

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -145,19 +145,24 @@ class TestLevene(TestCase):
     def test_trimmed2(self):
         x = [1.2, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 100.0]
         y = [0.0, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 200.0]
+        x2 = np.random.permutation(x)
+
         # Use center='trimmed'
-        W1, pval1 = stats.levene(x, y, center='trimmed', proportiontocut=0.125)
+        W0, pval0 = stats.levene(x, y, center='trimmed', proportiontocut=0.125)
+        W1, pval1 = stats.levene(x2, y, center='trimmed', proportiontocut=0.125)
         # Trim the data here, and use center='mean'
         W2, pval2 = stats.levene(x[1:-1], y[1:-1], center='mean')
         # Result should be the same.
+        assert_almost_equal(W0, W2)
         assert_almost_equal(W1, W2)
         assert_almost_equal(pval1, pval2)
 
     def test_equal_mean_median(self):
         x = np.linspace(-1,1,21)
+        x2 = np.random.permutation(x)
         y = x**3
         W1, pval1 = stats.levene(x, y, center='mean')
-        W2, pval2 = stats.levene(x, y, center='median')
+        W2, pval2 = stats.levene(x2, y, center='median')
         assert_almost_equal(W1, W2)
         assert_almost_equal(pval1, pval2)
 


### PR DESCRIPTION
minimal bugfix for levene with center='trimmed'

added some shuffling in test so arrays are not pre-sorted

I didn't try to use trim_mean.

closes #2555
