### PR TITLE
NumPy Ufunc and dot overrides for sparse matrices.

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -360,9 +360,15 @@ class spmatrix(object):
 
     def __truediv__(self, other):
         if isscalarlike(other):
-            return self * (1./other)
+            if np.can_cast(self.dtype, np.float_):
+                return self.astype(np.float_) * (1./other)
+            else:
+                return self * (1./other)
         else:
-            return self.tocsr().__truediv__(other)
+            if np.can_cast(self.dtype, np.float_):
+                return self.astype(np.float_).tocsr().__truediv__(other)
+            else:
+                return self.tocsr().__truediv__(other)
 
     def __div__(self, other):
         # Always do true division

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -370,9 +370,16 @@ class spmatrix(object):
             else:
                 return self.tocsr().__truediv__(other)
 
+    def __rtruediv__(self, other):
+        return NotImplemented
+
     def __div__(self, other):
         # Always do true division
         return self.__truediv__(other)
+
+    def __rdiv__(self, other):
+        # Always do true division
+        return self.__rtruediv__(other)
 
     def __neg__(self):
         return -self.tocsr()
@@ -691,6 +698,52 @@ class spmatrix(object):
             return out
         else:
             return np.zeros(self.shape, dtype=self.dtype, order=order)
+
+    def __numpy_ufunc__(self, func, method, pos, inputs, **kwargs):
+        """Method for compatibility with NumPy's ufuncs and dot
+        functions.
+        """
+        if method != '__call__' or kwargs:
+            return NotImplemented
+
+        without_self = list(inputs)
+        del without_self[pos]
+        without_self = tuple(without_self)
+
+        # Associative operations
+        if func is np.multiply:
+            return self.multiply(*without_self)
+
+        elif func is np.add:
+            return self.__add__(*without_self)
+
+        # Non-associative operations
+        elif func is np.dot:
+            if pos == 0:
+                return self.__mul__(inputs[1])
+            else:
+                return self.__rmul__(inputs[0])
+
+        elif func is np.subtract:
+            if pos == 0:
+                return self.__sub__(inputs[1])
+            else:
+                return self.__rsub__(inputs[0])
+
+        elif func is np.divide:
+            if pos == 0:
+                return self.__div__(inputs[1])
+            else:
+                return NotImplemented
+
+        elif func is np.true_divide:
+            if pos == 0:
+                return self.__truediv__(inputs[1])
+            else:
+                return NotImplemented
+
+        else:
+            return NotImplemented
 
 
 def isspmatrix(x):

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -415,13 +415,21 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
     def __truediv__(self,other):
         if isscalarlike(other):
-            return self * (1./other)
+            if np.can_cast(self.dtype, np.float_):
+                return self.astype(np.float_) * (1./other)
+            else:
+                return self * (1./other)
 
         elif isspmatrix(other):
             if other.shape != self.shape:
                 raise ValueError('inconsistent shapes')
+            elif np.can_cast(self.dtype, np.float_):
+                return self.astype(np.float_)._binopt(other,'_eldiv_')
+            else:
+                return self._binopt(other,'_eldiv_')
 
-            return self._binopt(other,'_eldiv_')
+        elif isdense(other):
+            return self.todense().__truediv__(other)
 
         else:
             raise NotImplementedError

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -18,6 +18,7 @@ Run tests if scipy is installed:
 Run tests if sparse is not installed:
   python tests/test_base.py
 """
+from distutils.version import LooseVersion
 
 import warnings
 
@@ -1245,6 +1246,42 @@ class _TestCommon:
     #    dense_dot_dense = dot(self.dat, b)
     #    dense_dot_sparse = dot(self.datsp, b)
     #    assert_array_equal(dense_dot_dense, dense_dot_sparse)
+
+    def test_ufunc_overrides(self):
+        def check():
+            #data
+            a = np.array([[1, 2, 3],
+                          [4, 5, 6],
+                          [7, 8, 9]])
+            b = np.array([[9, 8, 7],
+                          [6, 5, 4],
+                          [3, 2, 1]])
+
+            asp = self.spmatrix(a)
+            bsp = self.spmatrix(b)
+
+            # associative
+            # multiply
+            assert_array_equal(np.multiply(asp, bsp).A, np.multiply(a, b))
+            # add
+            assert_array_equal(np.add(asp, bsp).A, np.add(a, b))
+
+            # non-associative
+            # dot
+            assert_array_equal(np.dot(asp, bsp).A, np.dot(a, b))
+            assert_array_equal(np.dot(a, bsp), np.dot(a, b))
+            assert_array_equal(np.dot(asp, b), np.dot(a, b))
+            # subtract
+            assert_array_equal(np.subtract(asp, bsp).A, np.subtract(a, b))
+            assert_array_equal(np.subtract(a, bsp).A, np.subtract(a, b))
+            assert_array_equal(np.subtract(asp, b).A, np.subtract(a, b))
+            # divide
+            assert_array_equal(np.divide(asp, bsp).A, np.divide(a, b))
+            assert_array_equal(np.divide(asp, b).A, np.divide(a, b))
+            assert_raises(TypeError, np.divide, a, bsp)
+
+        if LooseVersion(np.version.version) > LooseVersion('1.9'):
+            yield check
 
 
 class _TestInplaceArithmetic:


### PR DESCRIPTION
This pull request is dependent on the `__numpy_ufunc__` functionality being added to NumPy-1.8 [link](https://github.com/numpy/numpy/pull/3524). That has not been accepted yet, so I'm not sure if this can be considered for SciPy-0.13.

This overrides `np.dot`, `np.multiply`, `np.divide`, `np.subtract`, and `np.add` when they are called on sparse matrices. Tests are included which check NumPy's verision is > 1.8. It also fixes an upcasting bug in `__div__` and `__truediv__` which was similar to the on described in [this issue](https://github.com/scipy/scipy/issues/2542) and fixed in [this PR](https://github.com/scipy/scipy/pull/2719).
