### PR TITLE
DEP: deprecate stats.oneway.  Closes gh-2569.

### DIFF
--- a/doc/release/0.13.0-notes.rst
+++ b/doc/release/0.13.0-notes.rst
@@ -212,6 +212,12 @@ are deprecated. All users should use the numerically more robust
 `scipy.stats.oneway` is deprecated; `scipy.stats.f_oneway` should be used
 instead.
 
+`scipy.stats.glm` is deprecated.  `scipy.stats.ttest_ind` is an equivalent
+function; more full-featured general (and generalized) linear model
+implementations can be found in statsmodels.
+
+`scipy.stats.cmedian` is deprecated; ``numpy.median`` should be used instead.
+
 
 Backwards incompatible changes
 ==============================

--- a/doc/release/0.13.0-notes.rst
+++ b/doc/release/0.13.0-notes.rst
@@ -206,6 +206,12 @@ The matrix exponential functions `scipy.linalg.expm2` and `scipy.linalg.expm3`
 are deprecated. All users should use the numerically more robust
 `scipy.linalg.expm` function instead.
 
+``scipy.stats`` functions
+-------------------------
+
+`scipy.stats.oneway` is deprecated; `scipy.stats.f_oneway` should be used
+instead.
+
 
 Backwards incompatible changes
 ==============================

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1296,6 +1296,8 @@ def mood(x, y, axis=0):
     return z, pval
 
 
+@np.deprecate_with_doc("`oneway` was deprecated in scipy 0.13.0 and will be "
+                       "removed in 0.14.0.  Use `f_oneway` instead.")
 def oneway(*args,**kwds):
     """Test for equal means in two or more samples from the
     normal distribution.

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -602,6 +602,7 @@ def hmean(a, axis=0, dtype=None):
         raise ValueError("Harmonic mean only defined if all elements greater than zero")
 
 
+@np.deprecate(message="Deprecated in scipy 0.13.0 - use numpy.median instead.")
 def cmedian(a, numbins=1000):
     """
     Returns the computed median value of an array.
@@ -4222,6 +4223,10 @@ def betai(a, b, x):
 #####################################
 
 
+_msg = """`glm` is deprecated in scipy 0.13.0 and will be removed in 0.14.0.
+Use `ttest_ind` for the same functionality in scipy.stats, or `statsmodels.OLS`
+for a more full-featured general linear model."""
+@np.deprecate_with_doc(_msg)
 def glm(data, para):
     """
     Calculates a linear model fit ...

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -368,11 +368,6 @@ class TestMood(TestCase):
         assert_raises(ValueError, stats.mood, [1], [])
 
 
-def test_oneway_bad_arg():
-    """Raise ValueError is fewer than two args are given."""
-    assert_raises(ValueError, stats.oneway, [1])
-
-
 def test_wilcoxon_bad_arg():
     """Raise ValueError when two args of different lengths are given or
        zero_method is unknwon"""

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1025,14 +1025,6 @@ class TestScoreatpercentile(TestCase):
         assert_raises(ValueError, stats.scoreatpercentile, [1], -1)
 
 
-class TestCMedian(TestCase):
-    def test_basic(self):
-        data = [1,2,3,1,5,3,6,4,3,2,4,3,5,2.0]
-        assert_almost_equal(stats.cmedian(data,5),3.2916666666666665)
-        assert_almost_equal(stats.cmedian(data,3),3.083333333333333)
-        assert_almost_equal(stats.cmedian(data),3.0020020020020022)
-
-
 class TestMode(TestCase):
     def test_basic(self):
         data1 = [3,5,1,10,23,3,2,6,8,6,10,6]


### PR DESCRIPTION
`oneway` is broken, badly documented and a duplicate of `f_oneway`.
