### PR TITLE
hyp2f1: more stable handling of arguments close to 1

### DIFF
--- a/scipy/special/cephes/hyp2f1.c
+++ b/scipy/special/cephes/hyp2f1.c
@@ -338,9 +338,9 @@ double *loss;
 		goto done;
 	    /* If power series fails, then apply AMS55 #15.3.6 */
 	    q = hys2f1(a, b, 1.0 - d, s, &err);
-	    q *= exp(lgam(d) - lgam(c - a) - lgam(c - b));
+	    q *= gammasgn(d)*gammasgn(c-a)*gammasgn(c-b) * exp(lgam(d) - lgam(c - a) - lgam(c - b));
 	    r = pow(s, d) * hys2f1(c - a, c - b, d + 1.0, s, &err1);
-	    r *= exp(lgam(-d) - lgam(a) - lgam(b));
+	    r *= gammasgn(-d)*gammasgn(a)*gammasgn(b) * exp(lgam(-d) - lgam(a) - lgam(b));
 	    y = q + r;
 
 	    q = fabs(q);	/* estimate cancellation error */

--- a/scipy/special/cephes/hyp2f1.c
+++ b/scipy/special/cephes/hyp2f1.c
@@ -96,6 +96,8 @@
 
 extern double MACHEP;
 
+extern int sgngam;
+
 static double hyt2f1(double a, double b, double c, double x, double *loss);
 static double hys2f1(double a, double b, double c, double x, double *loss);
 static double hyp2f1ra(double a, double b, double c, double x,
@@ -297,9 +299,9 @@ static double hyt2f1(a, b, c, x, loss)
 double a, b, c, x;
 double *loss;
 {
-    double p, q, r, s, t, y, d, err, err1;
+    double p, q, r, s, t, y, w, d, err, err1;
     double ax, id, d1, d2, e, y1;
-    int i, aid;
+    int i, aid, sign;
 
     int ia, ib, neg_int_a = 0, neg_int_b = 0;
 
@@ -338,9 +340,23 @@ double *loss;
 		goto done;
 	    /* If power series fails, then apply AMS55 #15.3.6 */
 	    q = hys2f1(a, b, 1.0 - d, s, &err);
-	    q *= gammasgn(d)*gammasgn(c-a)*gammasgn(c-b) * exp(lgam(d) - lgam(c - a) - lgam(c - b));
+            sign = 1;
+            w = lgam(d);
+            sign *= sgngam;
+            w -= lgam(c-a);
+            sign *= sgngam;
+            w -= lgam(c-b);
+            sign *= sgngam;
+	    q *= sign * exp(w);
 	    r = pow(s, d) * hys2f1(c - a, c - b, d + 1.0, s, &err1);
-	    r *= gammasgn(-d)*gammasgn(a)*gammasgn(b) * exp(lgam(-d) - lgam(a) - lgam(b));
+            sign = 1;
+            w = lgam(-d);
+            sign *= sgngam;
+            w -= lgam(a);
+            sign *= sgngam;   
+            w -= lgam(b);
+            sign *= sgngam;
+	    r *= sign * exp(w);
 	    y = q + r;
 
 	    q = fabs(q);	/* estimate cancellation error */

--- a/scipy/special/cephes/hyp2f1.c
+++ b/scipy/special/cephes/hyp2f1.c
@@ -338,9 +338,9 @@ double *loss;
 		goto done;
 	    /* If power series fails, then apply AMS55 #15.3.6 */
 	    q = hys2f1(a, b, 1.0 - d, s, &err);
-	    q *= gamma(d) / (gamma(c - a) * gamma(c - b));
+	    q *= exp(lgam(d) - lgam(c - a) - lgam(c - b));
 	    r = pow(s, d) * hys2f1(c - a, c - b, d + 1.0, s, &err1);
-	    r *= gamma(-d) / (gamma(a) * gamma(b));
+	    r *= exp(lgam(-d) - lgam(a) - lgam(b));
 	    y = q + r;
 
 	    q = fabs(q);	/* estimate cancellation error */

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -90,6 +90,7 @@ def test_hyp2f1_real_some_points():
         (-1,2,1,-1.0),
         (-3,13,5,1.0),
         (-3,13,5,-1.0),
+        (0.5, 1 - 270.5, 1.5, 0.999**2),  # from issue 1561
     ]
     dataset = [p + (float(mpmath.hyp2f1(*p)),) for p in pts]
     dataset = np.array(dataset, dtype=np.float_)


### PR DESCRIPTION
https://github.com/scipy/scipy/issues/1561#issuecomment-20554407 points out an issue with the hypergeometric function for a large negative value for `b` and a value for `x` close to 1. This problem can be fixed by evaluating the ratio of the gamma functions via the logarithm of gamma functions. Then, the ratio of two gamma functions  can be evaluated much more reliably even for large arguments. The chances to obtain `nan` are greatly reduced. 

I propose this change because it improves the evaluation of hyp2f1 even though it seems to cause problems with the test `check_cdf_ppf` in the `stats` module. Unfortunately, I am not yet sufficiently familiar with the `stats` module to propose a solution there. May be somebody else can see more clearly what is going wrong in the `stats` module.
