### PR TITLE
BUG: special: Fix asymptotic behavior of rgamma and reimplement poch

### DIFF
--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -1576,6 +1576,8 @@ cdef _proto_pdtri_unsafe_t *_proto_pdtri_unsafe_t_var = &_func_pdtri_unsafe
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_cdfpoi2_wrap "cdfpoi2_wrap"(double, double) nogil
 cdef extern from "_ufuncs_defs.h":
+    cdef double _func_poch "poch"(double, double) nogil
+cdef extern from "_ufuncs_defs.h":
     cdef double _func_prolate_aswfa_nocv_wrap "prolate_aswfa_nocv_wrap"(double, double, double, double, double *) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef int _func_prolate_aswfa_wrap "prolate_aswfa_wrap"(double, double, double, double, double, double *, double *) nogil
@@ -6973,6 +6975,36 @@ ufunc_pdtrik_ptr[2*1+1] = <void*>(<char*>"pdtrik")
 ufunc_pdtrik_data[0] = &ufunc_pdtrik_ptr[2*0]
 ufunc_pdtrik_data[1] = &ufunc_pdtrik_ptr[2*1]
 pdtrik = np.PyUFunc_FromFuncAndData(ufunc_pdtrik_loops, ufunc_pdtrik_data, ufunc_pdtrik_types, 2, 2, 1, 0, "pdtrik", ufunc_pdtrik_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc_poch_loops[2]
+cdef void *ufunc_poch_ptr[4]
+cdef void *ufunc_poch_data[2]
+cdef char ufunc_poch_types[6]
+cdef char *ufunc_poch_doc = (
+    "Pochhammer symbol (z)_m\n"
+    "\n"
+    "The Pochhammer symbol (rising factorial), is defined as::\n"
+    "\n"
+    "    (z)_m = gamma(z + m) / gamma(z)\n"
+    "\n"
+    "For positive integer `m` it reads::\n"
+    "\n"
+    "    (z)_m = z * (z + 1) * ... * (z + m - 1)")
+ufunc_poch_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
+ufunc_poch_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
+ufunc_poch_types[0] = <char>NPY_FLOAT
+ufunc_poch_types[1] = <char>NPY_FLOAT
+ufunc_poch_types[2] = <char>NPY_FLOAT
+ufunc_poch_types[3] = <char>NPY_DOUBLE
+ufunc_poch_types[4] = <char>NPY_DOUBLE
+ufunc_poch_types[5] = <char>NPY_DOUBLE
+ufunc_poch_ptr[2*0] = <void*>_func_poch
+ufunc_poch_ptr[2*0+1] = <void*>(<char*>"poch")
+ufunc_poch_ptr[2*1] = <void*>_func_poch
+ufunc_poch_ptr[2*1+1] = <void*>(<char*>"poch")
+ufunc_poch_data[0] = &ufunc_poch_ptr[2*0]
+ufunc_poch_data[1] = &ufunc_poch_ptr[2*1]
+poch = np.PyUFunc_FromFuncAndData(ufunc_poch_loops, ufunc_poch_data, ufunc_poch_types, 2, 2, 1, 0, "poch", ufunc_poch_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_pro_ang1_loops[2]
 cdef void *ufunc_pro_ang1_ptr[4]

--- a/scipy/special/_ufuncs_defs.h
+++ b/scipy/special/_ufuncs_defs.h
@@ -180,6 +180,7 @@ npy_double pdtr(npy_int, npy_double);
 npy_double pdtrc(npy_int, npy_double);
 npy_double pdtri(npy_int, npy_double);
 npy_double cdfpoi2_wrap(npy_double, npy_double);
+npy_double poch(npy_double, npy_double);
 npy_double prolate_aswfa_nocv_wrap(npy_double, npy_double, npy_double, npy_double, npy_double *);
 npy_int prolate_aswfa_wrap(npy_double, npy_double, npy_double, npy_double, npy_double, npy_double *, npy_double *);
 npy_double prolate_segv_wrap(npy_double, npy_double, npy_double);

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1336,6 +1336,19 @@ add_newdoc("scipy.special", "pdtrik",
     k=pdtrik(p,m) returns the quantile k such that pdtr(k,m)=p
     """)
 
+add_newdoc("scipy.special", "poch",
+    """
+    Pochhammer symbol (z)_m
+
+    The Pochhammer symbol (rising factorial), is defined as::
+
+        (z)_m = gamma(z + m) / gamma(z)
+
+    For positive integer `m` it reads::
+
+        (z)_m = z * (z + 1) * ... * (z + m - 1) 
+    """)
+
 add_newdoc("scipy.special", "pro_ang1",
     """
     (s,sp)=pro_ang1(m,n,c,x) computes the prolate sheroidal angular function

--- a/scipy/special/c_misc/misc.h
+++ b/scipy/special/c_misc/misc.h
@@ -23,6 +23,7 @@ fsolve_result_t false_position(double *a, double *fa, double *b, double *fb,
 double besselpoly(double a, double lambda, double nu);
 double gammaincinv(double a, double x);
 double gammasgn(double x);
+double poch(double x, double m);
 
 double struve_h(double v, double x);
 double struve_l(double v, double x);

--- a/scipy/special/c_misc/poch.c
+++ b/scipy/special/c_misc/poch.c
@@ -1,0 +1,88 @@
+/*
+ * Pochhammer symbol (a)_m = gamma(a + m) / gamma(a)
+ */
+
+#include <Python.h>
+#include <numpy/npy_math.h>
+
+#include <math.h>
+#include "cephes.h"
+#include "misc.h"
+
+static double is_nonpos_int(double x)
+{
+    return x <= 0 && x == ceil(x) && fabs(x) < 1e13;
+}
+
+double poch(double a, double m)
+{
+    double q;
+    double r;
+
+    r = 1.0;
+
+    /*
+     * 1. Reduce magnitude of `m` to |m| < 1 by using recurrence relations.
+     *
+     * This may end up in over/underflow, but then the function itself either
+     * diverges or goes to zero. In case the remainder goes to the opposite
+     * direction, we end up returning 0*INF = NAN, which is OK.
+     */
+
+    /* Recurse down */
+    while (m >= 1.0) {
+        if (a + m == 1) {
+            break;
+        }
+        m -= 1.0;
+        r *= (a + m);
+        if (!npy_isfinite(r) || r == 0) {
+            break;
+        }
+    }
+
+    /* Recurse up */
+    while (m <= -1.0) {
+        if (a + m == 0) {
+            break;
+        }
+        r /= (a + m);
+        m += 1.0;
+        if (!npy_isfinite(r) || r == 0) {
+            break;
+        }
+    }
+
+    /*
+     * 2. Evaluate function with reduced `m`
+     *
+     * Now either `m` is not big, or the `r` product has over/underflown.
+     * If so, the function itself does similarly.
+     */
+
+    if (m == 0) {
+        /* Easy case */
+        return r;
+    }
+    else if (a > 1e4 && fabs(m) <= 1) {
+        /* Avoid loss of precision */
+        return r * pow(a, m) * (
+            1
+            + m*(m-1)/(2*a)
+            + m*(m-1)*(m-2)*(3*m-1)/(24*a*a)
+            + m*m*(m-1)*(m-1)*(m-2)*(m-3)/(48*a*a*a)
+            );
+    }
+
+    /* Check for infinity */
+    if (is_nonpos_int(a + m) && !is_nonpos_int(a) && a + m != m) {
+        return NPY_INFINITY;
+    }
+
+    /* Check for zero */
+    if (!is_nonpos_int(a + m) && is_nonpos_int(a)) {
+        return 0;
+    }
+
+    return r * exp(lgam(a + m) - lgam(a)) * gammasgn(a + m) * gammasgn(a);
+}

--- a/scipy/special/cephes/rgamma.c
+++ b/scipy/special/cephes/rgamma.c
@@ -147,8 +147,7 @@ double x;
     int sign;
 
     if (x > 34.84425627277176174) {
-	mtherr(name, UNDERFLOW);
-	return 0.0;
+        return exp(-lgam(x));
     }
     if (x < -34.034) {
 	w = -x;

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -289,6 +289,7 @@ erfcx -- faddeeva_erfcx: d->d, faddeeva_erfcx_complex: D->D -- _faddeeva.h++
 erfi -- faddeeva_erfi: d->d, faddeeva_erfi_complex: D->D   -- _faddeeva.h++
 xlogy -- xlogy[double]: dd->d, xlogy[double_complex]: DD->D -- _xlogy.pxd
 xlog1py -- xlog1py: dd->d                                  -- _xlogy.pxd
+poch -- poch: dd->d                                        -- c_misc/misc.h
 """
 
 #---------------------------------------------------------------------------------

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -105,9 +105,8 @@ __all__ = ['legendre', 'chebyt', 'chebyu', 'chebyc', 'chebys',
            'eval_sh_jacobi', 'poch', 'binom']
 
 
-def poch(z, m):
-    """Pochhammer symbol (z)_m = (z)(z+1)....(z+m-1) = gamma(z+m)/gamma(z)"""
-    return _gam(z+m) / _gam(z)
+# For backward compatibility
+poch = cephes.poch
 
 
 class orthopoly1d(np.poly1d):

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1434,11 +1434,17 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             _time_limited()(_exception_to_nan(mpmath.polygamma)),
                             [IntArg(0, 1000), Arg()])
 
-    @knownfailure_overridable("all large negative arguments hit a pole --- the function itself is however numerically badly defined in this region, but maybe should return 0 instead?")
     def test_rgamma(self):
+        def rgamma(x):
+            if x < -8000:
+                return np.inf
+            else:
+                v = mpmath.rgamma(x)
+            return v
         assert_mpmath_equal(sc.rgamma,
-                            mpmath.rgamma,
-                            [Arg()])
+                            rgamma,
+                            [Arg()],
+                            ignore_inf_sign=True)
 
     @knownfailure_overridable("invalid inf at very large negative arguments, accuracy issues at negative arguments eps-close to poles (some loss of precision in cancellation)")
     def test_rf(self):

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1446,11 +1446,20 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             [Arg()],
                             ignore_inf_sign=True)
 
-    @knownfailure_overridable("invalid inf at very large negative arguments, accuracy issues at negative arguments eps-close to poles (some loss of precision in cancellation)")
     def test_rf(self):
+        def mppoch(a, m):
+            # deal with cases where the result in double precision
+            # hits exactly a non-positive integer, but the
+            # corresponding extended-precision mpf floats don't
+            if float(a + m) == int(a + m) and float(a + m) <= 0:
+                a = mpmath.mpf(a)
+                m = int(a + m) - a
+            return mpmath.rf(a, m)
+
         assert_mpmath_equal(sc.poch,
-                            mpmath.rf,
-                            [Arg(), Arg()], dps=100)
+                            mppoch,
+                            [Arg(), Arg()],
+                            dps=400)
 
     def test_shi(self):
         def shi(x):


### PR DESCRIPTION
The rgamma function in Cephes underflowed too early to 0, fix this by using lgam to evaluate the tail.
The behavior at large negative values is OK, the function is beyond float range (except at integers).

Reimplement the pochhammer symbol. The naive definition via gamma functions suffers from over/underflows and from hitting poles of the gamma functions which cancel out in several common cases.

Fixes gh-1437
