### PR TITLE
BLD: track add_library dependencies in distutils

### DIFF
--- a/scipy/fftpack/setup.py
+++ b/scipy/fftpack/setup.py
@@ -14,11 +14,11 @@ def configuration(parent_package='',top_path=None):
     config.add_data_dir('tests')
     config.add_data_dir('benchmarks')
 
-    config.add_library('dfftpack',
-                       sources=[join('src/dfftpack','*.f')])
+    dfftpack_src = [join('src/dfftpack','*.f')]
+    config.add_library('dfftpack', sources=dfftpack_src)
 
-    config.add_library('fftpack',
-                       sources=[join('src/fftpack','*.f')])
+    fftpack_src = [join('src/fftpack','*.f')]
+    config.add_library('fftpack', sources=fftpack_src)
 
     sources = ['fftpack.pyf','src/zfft.c','src/drfft.c','src/zrfft.c',
                'src/zfftnd.c', 'src/dct.c.src', 'src/dst.c.src']
@@ -26,11 +26,13 @@ def configuration(parent_package='',top_path=None):
     config.add_extension('_fftpack',
         sources=sources,
         libraries=['dfftpack', 'fftpack'],
-        include_dirs=['src'])
+        include_dirs=['src'],
+        depends=(dfftpack_src + fftpack_src))
 
     config.add_extension('convolve',
         sources=['convolve.pyf','src/convolve.c'],
         libraries=['dfftpack'],
+        depends=dfftpack_src,
     )
     return config
 

--- a/scipy/integrate/setup.py
+++ b/scipy/integrate/setup.py
@@ -11,17 +11,18 @@ def configuration(parent_package='',top_path=None):
 
     blas_opt = get_info('blas_opt',notfound_action=2)
 
-    config.add_library('linpack_lite',
-                       sources=[join('linpack_lite','*.f')])
-    config.add_library('mach',
-                       sources=[join('mach','*.f')],
+    linpack_lite_src = [join('linpack_lite','*.f')]
+    mach_src = [join('mach','*.f')]
+    quadpack_src = [join('quadpack','*.f')]
+    odepack_src = [join('odepack','*.f')]
+    dop_src = [join('dop','*.f')]
+
+    config.add_library('linpack_lite', sources=linpack_lite_src)
+    config.add_library('mach', sources=mach_src,
                        config_fc={'noopt':(__file__,1)})
-    config.add_library('quadpack',
-                       sources=[join('quadpack','*.f')])
-    config.add_library('odepack',
-                       sources=[join('odepack','*.f')])
-    config.add_library('dop',
-                       sources=[join('dop','*.f')])
+    config.add_library('quadpack', sources=quadpack_src)
+    config.add_library('odepack', sources=odepack_src)
+    config.add_library('dop', sources=dop_src)
     # should we try to weed through files and replace with calls to
     # LAPACK routines?
     # Yes, someday...
@@ -32,7 +33,8 @@ def configuration(parent_package='',top_path=None):
     config.add_extension('_quadpack',
                          sources=['_quadpackmodule.c'],
                          libraries=['quadpack', 'linpack_lite', 'mach'],
-                         depends=['quadpack.h','__quadpack.h'])
+                         depends=(['quadpack.h','__quadpack.h']
+                                  + quadpack_src + linpack_lite_src + mach_src))
     # odepack
     libs = ['odepack','linpack_lite','mach']
 
@@ -47,25 +49,32 @@ def configuration(parent_package='',top_path=None):
     config.add_extension('_odepack',
                          sources=['_odepackmodule.c'],
                          libraries=libs,
-                         depends=['__odepack.h','multipack.h'],
+                         depends=(['__odepack.h','multipack.h']
+                                  + odepack_src + linpack_lite_src
+                                  + mach_src),
                          **newblas)
 
     # vode
     config.add_extension('vode',
                          sources=['vode.pyf'],
                          libraries=libs,
+                         depends=(odepack_src + linpack_lite_src
+                                  + mach_src),
                          **newblas)
 
     # lsoda
     config.add_extension('lsoda',
                          sources=['lsoda.pyf'],
                          libraries=libs,
+                         depends=(odepack_src + linpack_lite_src
+                                  + mach_src),
                          **newblas)
 
     # dop
     config.add_extension('_dop',
                          sources=['dop.pyf'],
-                         libraries=['dop'])
+                         libraries=['dop'],
+                         depends=dop_src)
 
     config.add_data_dir('tests')
     return config

--- a/scipy/interpolate/setup.py
+++ b/scipy/interpolate/setup.py
@@ -9,9 +9,8 @@ def configuration(parent_package='',top_path=None):
 
     config = Configuration('interpolate', parent_package, top_path)
 
-    config.add_library('fitpack',
-                       sources=[join('fitpack', '*.f')],
-                       )
+    fitpack_src = [join('fitpack', '*.f')]
+    config.add_library('fitpack', sources=fitpack_src)
 
     config.add_extension('interpnd',
                          sources=['interpnd.c'])
@@ -19,12 +18,14 @@ def configuration(parent_package='',top_path=None):
     config.add_extension('_fitpack',
                          sources=['src/_fitpackmodule.c'],
                          libraries=['fitpack'],
-                         depends=['src/__fitpack.h','src/multipack.h']
+                         depends=(['src/__fitpack.h','src/multipack.h']
+                                  + fitpack_src)
                          )
 
     config.add_extension('dfitpack',
                          sources=['src/fitpack.pyf'],
                          libraries=['fitpack'],
+                         depends=fitpack_src,
                          )
 
     config.add_extension('_interpolate',

--- a/scipy/odr/setup.py
+++ b/scipy/odr/setup.py
@@ -21,8 +21,9 @@ def configuration(parent_package='', top_path=None):
         warnings.warn(BlasNotFoundError.__doc__)
         libodr_files.append('d_lpkbls.f')
 
-    libodr = [join('odrpack', x) for x in libodr_files]
-    config.add_library('odrpack', sources=libodr)
+    odrpack_src = [join('odrpack', x) for x in libodr_files]
+    config.add_library('odrpack', sources=odrpack_src)
+
     sources = ['__odrpack.c']
     libraries = ['odrpack'] + blas_info.pop('libraries', [])
     include_dirs = ['.'] + blas_info.pop('include_dirs', [])
@@ -30,7 +31,7 @@ def configuration(parent_package='', top_path=None):
         sources=sources,
         libraries=libraries,
         include_dirs=include_dirs,
-        depends=['odrpack.h'],
+        depends=(['odrpack.h'] + odrpack_src),
         **blas_info
     )
 

--- a/scipy/optimize/setup.py
+++ b/scipy/optimize/setup.py
@@ -9,19 +9,24 @@ def configuration(parent_package='',top_path=None):
     from numpy.distutils.system_info import get_info
     config = Configuration('optimize',parent_package, top_path)
 
-    config.add_library('minpack',sources=[join('minpack','*f')])
+    minpack_src = [join('minpack','*f')]
+    config.add_library('minpack',sources=minpack_src)
     config.add_extension('_minpack',
                          sources=['_minpackmodule.c'],
                          libraries=['minpack'],
-                         depends=["minpack.h","__minpack.h"])
+                         depends=(["minpack.h","__minpack.h"]
+                                  + minpack_src))
 
+    rootfind_src = [join('Zeros','*.c')]
+    rootfind_hdr = [join('Zeros','zeros.h')]
     config.add_library('rootfind',
-                       sources=[join('Zeros','*.c')],
-                       headers=[join('Zeros','zeros.h')])
+                       sources=rootfind_src,
+                       headers=rootfind_hdr)
 
     config.add_extension('_zeros',
                          sources=['zeros.c'],
-                         libraries=['rootfind'])
+                         libraries=['rootfind'],
+                         depends=(rootfind_src + rootfind_hdr))
 
     lapack = get_info('lapack_opt')
     sources = ['lbfgsb.pyf', 'lbfgsb.f', 'linpack.f', 'timer.f']

--- a/scipy/sparse/linalg/dsolve/setup.py
+++ b/scipy/sparse/linalg/dsolve/setup.py
@@ -24,6 +24,7 @@ def configuration(parent_package='',top_path=None):
     superlu_src = join(dirname(__file__), 'SuperLU', 'SRC')
 
     sources = list(glob.glob(join(superlu_src, '*.c')))
+    headers = list(glob.glob(join(superlu_src, '*.h')))
     if os.name == 'nt' and ('FPATH' in os.environ or 'MKLROOT' in os.environ):
         # when using MSVC + MKL, lsame is already in MKL
         sources.remove(join(superlu_src, 'lsame.c'))
@@ -40,6 +41,7 @@ def configuration(parent_package='',top_path=None):
                                     '_superlu_utils.c',
                                     '_superluobject.c'],
                          libraries=['superlu_src'],
+                         depends=(sources + headers),
                          extra_info=lapack_opt,
                          )
 

--- a/scipy/sparse/linalg/eigen/arpack/setup.py
+++ b/scipy/sparse/linalg/eigen/arpack/setup.py
@@ -41,7 +41,8 @@ def configuration(parent_package='',top_path=None):
     config.add_extension('_arpack',
                          sources='arpack.pyf.src',
                          libraries=['arpack_scipy'],
-                         extra_info=lapack_opt
+                         extra_info=lapack_opt,
+                         depends=arpack_sources,
                          )
 
     config.add_data_dir('tests')

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -33,48 +33,63 @@ def configuration(parent_package='',top_path=None):
     inc_dirs.insert(0, get_numpy_include_dirs())
 
     # C libraries
-    config.add_library('sc_c_misc',sources=[join('c_misc','*.c')],
+    c_misc_src = [join('c_misc','*.c')]
+    c_misc_hdr = [join('c_misc','*.h')]
+    cephes_src = [join('cephes','*.c')]
+    cephes_hdr = [join('cephes', '*.h')]
+    config.add_library('sc_c_misc',sources=c_misc_src,
                        include_dirs=[curdir] + inc_dirs,
+                       depends=(cephes_hdr + cephes_src
+                                + c_misc_hdr + cephes_hdr
+                                + ['*.h']),
                        macros=define_macros)
-    config.add_library('sc_cephes',sources=[join('cephes','*.c')],
+    config.add_library('sc_cephes',sources=cephes_src,
                        include_dirs=[curdir] + inc_dirs,
+                       depends=(cephes_hdr + ['*.h']),
                        macros=define_macros)
 
     # Fortran/C++ libraries
-    config.add_library('sc_mach',sources=[join('mach','*.f')],
+    mach_src = [join('mach','*.f')]
+    amos_src = [join('amos','*.f')]
+    cdf_src = [join('cdflib','*.f')]
+    specfun_src = [join('specfun','*.f')]
+    config.add_library('sc_mach',sources=mach_src,
                        config_fc={'noopt':(__file__,1)})
-    config.add_library('sc_amos',sources=[join('amos','*.f')])
-    config.add_library('sc_cdf',sources=[join('cdflib','*.f')])
-    config.add_library('sc_specfun',sources=[join('specfun','*.f')])
+    config.add_library('sc_amos',sources=amos_src)
+    config.add_library('sc_cdf',sources=cdf_src)
+    config.add_library('sc_specfun',sources=specfun_src)
 
     # Extension specfun
     config.add_extension('specfun',
                          sources=['specfun.pyf'],
                          f2py_options=['--no-wrap-functions'],
+                         depends=specfun_src,
                          define_macros=[],
                          libraries=['sc_specfun'])
 
     # Extension _ufuncs
+    headers = ['*.h', join('c_misc', '*.h'), join('cephes', '*.h')]
+    ufuncs_src = ['_ufuncs.c', 'sf_error.c', '_logit.c.src',
+                  "amos_wrappers.c", "cdf_wrappers.c", "specfun_wrappers.c"]
+    ufuncs_dep = (headers + ufuncs_src + amos_src + c_misc_src + cephes_src
+                  + mach_src + cdf_src + specfun_src)
     config.add_extension('_ufuncs',
                          libraries=['sc_amos','sc_c_misc','sc_cephes','sc_mach',
                                     'sc_cdf', 'sc_specfun'],
-                         depends=["_logit.h", "cephes.h",
-                                  "amos_wrappers.h",
-                                  "cdf_wrappers.h", "specfun_wrappers.h",
-                                  "c_misc/misc.h", "cephes/mconf.h", "cephes/cephes_names.h"],
-                         sources=['_ufuncs.c', 'sf_error.c', '_logit.c.src',
-                                  "amos_wrappers.c", "cdf_wrappers.c", "specfun_wrappers.c"],
+                         depends=ufuncs_dep,
+                         sources=ufuncs_src,
                          include_dirs=[curdir] + inc_dirs,
                          define_macros=define_macros,
                          extra_info=get_info("npymath"))
 
     # Extension _ufuncs_cxx
+    ufuncs_cxx_src = ['_ufuncs_cxx.cxx', 'sf_error.c',
+                      '_faddeeva.cxx', 'Faddeeva.cc']
+    ufuncs_cxx_dep = (headers + ufuncs_cxx_src + cephes_src
+                      + ['*.hh'])
     config.add_extension('_ufuncs_cxx',
-                         sources=['_ufuncs_cxx.cxx',
-                                  'sf_error.c',
-                                  '_faddeeva.cxx',
-                                  'Faddeeva.cc',
-                                  ],
+                         sources=ufuncs_cxx_src,
+                         depends=ufuncs_cxx_dep,
                          include_dirs=[curdir],
                          define_macros=define_macros,
                          extra_info=get_info("npymath"))

--- a/scipy/stats/setup.py
+++ b/scipy/stats/setup.py
@@ -10,14 +10,15 @@ def configuration(parent_package='',top_path=None):
 
     config.add_data_dir('tests')
 
-    config.add_library('statlib',
-                       sources=[join('statlib', '*.f')])
+    statlib_src = [join('statlib', '*.f')]
+    config.add_library('statlib', sources=statlib_src)
 
     # add statlib module
     config.add_extension('statlib',
         sources=['statlib.pyf'],
         f2py_options=['--no-wrap-functions'],
         libraries=['statlib'],
+        depends=statlib_src
     )
 
     # add vonmises_cython module


### PR DESCRIPTION
Distutils does not automatically track source dependencies to numpy.distutils add_library libraries. So it needs to be manually.

This commit causes the appropriate extension modules be rebuilt if a change has been made in some of the sources of the libraries it depends on.

This addresses a major annoyance during development.
