### PR TITLE
 DEP: linalg: deprecate expm2 and expm3

### DIFF
--- a/doc/release/0.13.0-notes.rst
+++ b/doc/release/0.13.0-notes.rst
@@ -195,6 +195,13 @@ An option was added to `scipy.stats.wilcoxon` for continuity correction.
 Deprecated features
 ===================
 
+``expm2`` and ``expm3``
+-----------------------
+
+The matrix exponential functions `scipy.linalg.expm2` and `scipy.linalg.expm3`
+are deprecated. All users should use the numerically more robust
+`scipy.linalg.expm` function instead.
+
 
 Backwards incompatible changes
 ==============================

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -86,9 +86,7 @@ Matrix Functions
 .. autosummary::
    :toctree: generated/
 
-   expm - Matrix exponential using Pade approximation with scaling and squaring
-   expm2 - Matrix exponential using eigenvalue decomposition
-   expm3 - Matrix exponential using Taylor-series expansion
+   expm - Matrix exponential
    logm - Matrix logarithm
    cosm - Matrix cosine
    sinm - Matrix sine

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -105,6 +105,8 @@ def expm(A, q=None):
     return scipy.sparse.linalg.expm(A)
 
 
+# deprecated, but probably should be left there in the long term
+@np.deprecate(new_name="expm")
 def expm2(A):
     """
     Compute the matrix exponential using eigenvalue decomposition.
@@ -134,6 +136,8 @@ def expm2(A):
         return r.astype(t)
 
 
+# deprecated, but probably should be left there in the long term
+@np.deprecate(new_name="expm")
 def expm3(A, q=20):
     """
     Compute the matrix exponential using Taylor series.

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -147,7 +147,7 @@ def expm3(A, q=20):
     A : (N, N) array_like
         Matrix to be exponentiated
     q : int
-        Order of the Taylor series
+        Order of the Taylor series used is `q-1`
 
     Returns
     -------


### PR DESCRIPTION
The Pade approximant provided by expm is a superior alternative, so providing two worse methods just clutters the documentation.

Also correct the documentation of `expm3` about the order of the Taylor expansion.
