### PR TITLE
Tutorial fftpack

### DIFF
--- a/doc/source/tutorial/fftpack.rst
+++ b/doc/source/tutorial/fftpack.rst
@@ -95,7 +95,6 @@ The example plots the FFT of the sum of two sines.
     >>> plt.grid()
     >>> plt.show()
 
-..   :caption: FFT-Plot of the sum of two sines
 
 The FFT input signal is inherently truncated. This truncation can be modelled
 as multiplication of an inifinte signal with a rectangular window function. In
@@ -127,9 +126,6 @@ truncated illustrative purposes).
     >>> plt.legend(['FFT', 'FFT w. window'])
     >>> plt.grid()
     >>> plt.show()
-
-..   :caption: FFT-Plot of the sum of two sines with window functions.
-
 
 
 In case the sequence x is complex-valued, the spectrum is no longer symmetric.
@@ -170,9 +166,6 @@ asymmetric spectrum.
     >>> plt.plot(xf, 1.0/N * np.abs(yplot))
     >>> plt.grid()
     >>> plt.show()
-
-..   :caption: FFT-Plot of the sum of two sines
-
 
 
 The function :func:`rfft` calculates the FFT of a real sequence and outputs
@@ -221,30 +214,28 @@ The example below demonstrates a 2-dimensional IFFT and plots the resulting
     >>> xf[0, 5] = 1
     >>> xf[0, N-5] = 1
     >>> Z = ifftn(xf)
-    >>> ax1.imshow(xf, cmap=cm.binary)
+    >>> ax1.imshow(xf, cmap=cm.Reds)
     >>> ax4.imshow(np.real(Z), cmap=cm.binary)
     >>> xf = np.zeros((N, N))
     >>> xf[5, 0] = 1
     >>> xf[N-5, 0] = 1
     >>> Z = ifftn(xf)
-    >>> ax2.imshow(xf, cmap=cm.binary)
+    >>> ax2.imshow(xf, cmap=cm.Reds)
     >>> ax5.imshow(np.real(Z), cmap=cm.binary)
     >>> xf = np.zeros((N, N))
     >>> xf[5, 10] = 1
     >>> xf[N-5, N-10] = 1
     >>> Z = ifftn(xf)
-    >>> ax3.imshow(xf, cmap=cm.binary)
+    >>> ax3.imshow(xf, cmap=cm.Reds)
     >>> ax6.imshow(np.real(Z), cmap=cm.binary)
     >>> plt.show()
 
-..   :caption: 2-dimensional FFT example
 
+.. FFT convolution
+.. _______________
 
-FFT convolution
-_______________
-
-scipy.fftpack.convolve performs a convolution of two one-dimensional
-arrays in frequency domain.
+.. scipy.fftpack.convolve performs a convolution of two one-dimensional
+.. arrays in frequency domain.
 
 
 
@@ -357,10 +348,10 @@ and normalizations.
 Example
 _______
 
-The DCT exhibits the "energy compaction property", meaning that only the first
-few DCT coefficients have significant magnitude. Zeroing out the other
-coefficients leads to a small reconstruction error, a fact which is exploited
-in lossy signal compression (e.g. JPEG compression).
+The DCT exhibits the "energy compaction property", meaning that for many
+signals only the first few DCT coefficients have significant magnitude.
+Zeroing out the other coefficients leads to a small reconstruction error, a
+fact which is exploited in lossy signal compression (e.g. JPEG compression).
 
 The example below shows a signal x and two reconstructions (:math:`x_{20}` and
 :math:`x_{15}`)from the signal's DCT coefficients. The signal :math:`x_{20}`
@@ -379,11 +370,11 @@ provides a five-fold compression rate.
     >>> x = np.exp(-t/3)*np.cos(2*t)
     >>> y = dct(x, norm='ortho')
     >>> window = np.zeros(N)
-    >>> window[:25] = 1
+    >>> window[:20] = 1
     >>> yr = idct(y*window, norm='ortho')
     >>> sum(abs(x-yr)**2) / sum(abs(x)**2)
     0.0010901402257
-    >>> plt.plot(t, x, 'bx')
+    >>> plt.plot(t, x, '-bx')
     >>> plt.plot(t, yr, 'ro')
     >>> window = np.zeros(N)
     >>> window[:15] = 1

--- a/doc/source/tutorial/fftpack.rst
+++ b/doc/source/tutorial/fftpack.rst
@@ -5,11 +5,6 @@ Fourier Transforms (:mod:`scipy.fftpack`)
 
 .. currentmodule:: scipy.fftpack
 
-.. warning::
-
-   This is currently a stub page
-
-
 .. contents::
 
 
@@ -30,18 +25,18 @@ Fast Fourier transforms
 One dimensional discrete Fourier transforms
 ___________________________________________
 
-The FFT `y[k]` of length :math:`N` of the length-:math:`N` sequence `x_n` is
-defined as a
+The FFT `y[k]` of length :math:`N` of the length-:math:`N` sequence `x[n]` is
+defined as
 
 .. math::
 
-    y_k = \sum_{n=0}^{N-1} e^{-2 \pi j \frac{k n}{N} } x_n
+    y[k] = \sum_{n=0}^{N-1} e^{-2 \pi j \frac{k n}{N} } x[n] \, ,
 
-The inverse transform is defined as follows
+and the inverse transform is defined as follows
 
 .. math::
 
-    x_n = \frac{1}{N} \sum_{n=0}^{N-1} e^{2 \pi j \frac{k n}{N} } y_k \, .
+    x[n] = \frac{1}{N} \sum_{n=0}^{N-1} e^{2 \pi j \frac{k n}{N} } y[k] \, .
 
 These transforms can be calculated by means of :func:`fft` and :func:`ifft`,
 respectively as shown in the following example.
@@ -61,21 +56,25 @@ From the definition of the FFT it can be seen that
 
 .. math::
 
-    y_0 = \sum_{n=0}^{N-1} x_n \, .
+    y[0] = \sum_{n=0}^{N-1} x[n] \, .
 
 In the example
 
 >>> np.sum(x)
 4.5
 
-which corresponds to `y[0]`. The elements `y[1]`...`y[N/2+1]` contain the
-positive-frequency terms, and the elements `y[N/2]`...`y[N-1]` contain the
-negative-frequency terms, in order of decreasingly negative frequency.
+which corresponds to :math:`y[0]`. For N even, the elements
+:math:`y[1]...y[N/2-1]` contain the positive-frequency terms, and the elements
+:math:`y[N/2]...y[N-1]` contain the negative-frequency terms, in order of
+decreasingly negative frequency. For N odd, the elements
+:math:`y[1]...y[(N-1)/2]` contain the positive- frequency terms, and the
+elements :math:`y[(N+1)/2]...y[N-1]` contain the negative- frequency terms, in
+order of decreasingly negative frequency.
 
-In case the sequence x is real-valued, the values of `y[n]` for positive
-frequencies is the conjugate of the values `y[n]` for negative frequencies
-(because the spectrum is symmetric). Typically, only the FFT corresponding to
-positive frequencies is plotted.
+In case the sequence x is real-valued, the values of :math:`y[n]` for positive
+frequencies is the conjugate of the values :math:`y[n]` for negative
+frequencies (because the spectrum is symmetric). Typically, only the FFT
+corresponding to positive frequencies is plotted.
 
 The example plots the FFT of the sum of two sines.
 
@@ -169,9 +168,10 @@ asymmetric spectrum.
 
 
 The function :func:`rfft` calculates the FFT of a real sequence and outputs
-the FFT coefficients :math:`y_n` with separate real and imaginary parts. In
-case of N being even: :math:`[y_0, Re(y_1), Im(y_1),..., Re(y_{N/2})]`; in
-case N being odd :math:`[y_0, Re(y_1),Im(y_1),..., Re(y_{N/2}), Im(y_{N/2})]`.
+the FFT coefficients :math:`y[n]` with separate real and imaginary parts. In
+case of N being even: :math:`[y[0], Re(y[1]), Im(y[1]),..., Re(y[N/2])]`; in
+case N being odd :math:`[y[0], Re(y[1]),Im(y[1]),..., Re(y[N/2]),
+Im(y[N/2])]`.
 
 The corresponding function :func:`irfft` calculates the IFFT of the FFT
 coefficients with this special ordering.
@@ -197,8 +197,8 @@ Two and n-dimensional discrete Fourier transforms
 _________________________________________________
 
 The functions :func:`fft2` and :func:`ifft2` provide 2-dimensional FFT, and
-IFFT, respectively. Similar, :func:`fftn` and :func:`ifftn` provide n-dimensional FFT, and
-IFFT, respectively.
+IFFT, respectively. Similar, :func:`fftn` and :func:`ifftn` provide
+n-dimensional FFT, and IFFT, respectively.
 
 The example below demonstrates a 2-dimensional IFFT and plots the resulting
 (2-dimensional) time-domain signals.
@@ -262,7 +262,7 @@ Scipy uses the following definition of the unnormalized DCT-I
 
 .. math::
 
-    y_k = x_0 + (-1)^k x_{N-1} + 2\sum_{n=1}^{N-2} x_n
+    y[k] = x_0 + (-1)^k x_{N-1} + 2\sum_{n=1}^{N-2} x[n]
     \cos\left({\pi nk\over N-1}\right),
     \qquad 0 \le k < N.
 
@@ -277,23 +277,23 @@ Scipy uses the following definition of the unnormalized DCT-II
 
 .. math::
 
-    y_k = 2 \sum_{n=0}^{N-1} x_n \cos \left({\pi(2n+1)k \over 2N} \right)
+    y[k] = 2 \sum_{n=0}^{N-1} x[n] \cos \left({\pi(2n+1)k \over 2N} \right)
     \qquad 0 \le k < N.
 
 In case of the normalized DCT (``norm='ortho'``), the DCT coefficients
-:math:`y_k` are multiplied by a scaling factor `f`:
+:math:`y[k]` are multiplied by a scaling factor `f`:
 
 .. math::
 
     f = \begin{cases} \sqrt{1/(4N)}, & \text{if $k = 0$} \\    \sqrt{1/(2N)},
     & \text{otherwise} \end{cases} \, .
 
-In this case, the DCT "base functions" :math:`\phi_k(n) = 2 f \cos
+In this case, the DCT "base functions" :math:`\phi_k[n] = 2 f \cos
 \left({\pi(2n+1)k \over 2N} \right)` become orthonormal:
 
 .. math::
 
-   \sum_{n=0}^{N-1} \phi_k(n) \phi_l(n) = \delta_{lk}
+   \sum_{n=0}^{N-1} \phi_k[n] \phi_l[n] = \delta_{lk}
 
 
 Type III DCT
@@ -304,14 +304,14 @@ Scipy uses the following definition of the unnormalized DCT-III
 
 .. math::
 
-    y_k = x_0 + 2 \sum_{n=1}^{N-1} x_n \cos\left({\pi n(2k+1) \over 2N}\right)
+    y[k] = x_0 + 2 \sum_{n=1}^{N-1} x[n] \cos\left({\pi n(2k+1) \over 2N}\right)
     \qquad 0 \le k < N,
 
 or, for ``norm='ortho'``:
 
 .. math::
 
-    y_k = {x_0\over\sqrt{N}} + {2\over\sqrt{N}} \sum_{n=1}^{N-1} x_n
+    y[k] = {x_0\over\sqrt{N}} + {2\over\sqrt{N}} \sum_{n=1}^{N-1} x[n]
     \cos\left({\pi n(2k+1) \over 2N}\right) \qquad 0 \le k < N.
 
 
@@ -406,7 +406,7 @@ definition of the unnormalized DST-I (``norm='None'``):
 
 .. math::
 
-    y_k = 2\sum_{n=0}^{N-1} x_n  \sin\left( \pi {(n+1) (k+1)}\over{N+1}
+    y[k] = 2\sum_{n=0}^{N-1} x[n]  \sin\left( \pi {(n+1) (k+1)}\over{N+1}
     \right), \qquad 0 \le k < N.
 
 Only ``None`` is supported as normalization mode for DST-I. Note also that the
@@ -421,7 +421,7 @@ the following definition of the unnormalized DST-II (``norm='None'``):
 
 .. math::
 
-    y_k = 2 \sum_{n=0}^{N-1} x_n  \sin\left( {\pi (n+1/2)(k+1)} \over N
+    y[k] = 2 \sum_{n=0}^{N-1} x[n]  \sin\left( {\pi (n+1/2)(k+1)} \over N
     \right), \qquad 0 \le k < N.
 
 Type III DST
@@ -432,7 +432,7 @@ the following definition of the unnormalized DST-III (``norm='None'``):
 
 .. math::
 
-    y_k = (-1)^k x_{N-1} + 2 \sum_{n=0}^{N-2} x_n \sin \left( {\pi
+    y[k] = (-1)^k x[N-1] + 2 \sum_{n=0}^{N-2} x[n] \sin \left( {\pi
     (n+1)(k+1/2)} \over N \right), \qquad 0 \le k < N.
 
 
@@ -468,7 +468,7 @@ and normalizations.
 .. Differential and pseudo-differential operators
 .. ----------------------------------------------
 ..
-.. :func:`diff` - I have no idea what this does!
+.. :func:`diff`
 
 
 Cache Destruction

--- a/doc/source/tutorial/fftpack.rst
+++ b/doc/source/tutorial/fftpack.rst
@@ -13,171 +13,481 @@ Fourier Transforms (:mod:`scipy.fftpack`)
 .. contents::
 
 
-Fourier analysis is fundamentally a method for expressing a function as a
-sum of periodic components, and for recovering the signal from those
-components.  When both the function and its Fourier transform are
-replaced with discretized counterparts, it is called the discrete Fourier
-transform (DFT).  The DFT has become a mainstay of numerical computing in
-part because of a very fast algorithm for computing it, called the Fast
-Fourier Transform (FFT), which was known to Gauss (1805) and was brought
-to light in its current form by Cooley and Tukey [CT]_.  Press et al. [NR]_
-provide an accessible introduction to Fourier analysis and its
-applications.
+Fourier analysis is a method for expressing a function as a sum of periodic
+components, and for recovering the signal from those components.  When both
+the function and its Fourier transform are replaced with discretized
+counterparts, it is called the discrete Fourier transform (DFT).  The DFT has
+become a mainstay of numerical computing in part because of a very fast
+algorithm for computing it, called the Fast Fourier Transform (FFT), which was
+known to Gauss (1805) and was brought to light in its current form by Cooley
+and Tukey [CT]_.  Press et al. [NR]_ provide an accessible introduction to
+Fourier analysis and its applications.
 
 
 Fast Fourier transforms
 -----------------------
 
 One dimensional discrete Fourier transforms
--------------------------------------------
+___________________________________________
 
-fft, ifft, rfft, irfft
+The FFT `y[k]` of length :math:`N` of the length-:math:`N` sequence `x_n` is
+defined as a
+
+.. math::
+
+    y_k = \sum_{n=0}^{N-1} e^{-2 \pi j \frac{k n}{N} } x_n
+
+The inverse transform is defined as follows
+
+.. math::
+
+    x_n = \frac{1}{N} \sum_{n=0}^{N-1} e^{2 \pi j \frac{k n}{N} } y_k \, .
+
+These transforms can be calculated by means of :func:`fft` and :func:`ifft`,
+respectively as shown in the following example.
+
+>>> from scipy.fftpack import fft, ifft
+>>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5])
+>>> y = fft(x)
+>>> y
+[ 4.50000000+0.j          2.08155948-1.65109876j -1.83155948+1.60822041j
+ -1.83155948-1.60822041j  2.08155948+1.65109876j]
+>>> yinv = ifft(y)
+>>> yinv
+[ 1.0+0.j  2.0+0.j  1.0+0.j -1.0+0.j  1.5+0.j]
 
 
-Two and n dimensional discrete Fourier transforms
--------------------------------------------------
+From the definition of the FFT it can be seen that
 
-fft in more than one dimension
+.. math::
+
+    y_0 = \sum_{n=0}^{N-1} x_n \, .
+
+In the example
+
+>>> np.sum(x)
+4.5
+
+which corresponds to `y[0]`. The elements `y[1]`...`y[N/2+1]` contain the
+positive-frequency terms, and the elements `y[N/2]`...`y[N-1]` contain the
+negative-frequency terms, in order of decreasingly negative frequency.
+
+In case the sequence x is real-valued, the values of `y[n]` for positive
+frequencies is the conjugate of the values `y[n]` for negative frequencies
+(because the spectrum is symmetric). Typically, only the FFT corresponding to
+positive frequencies is plotted.
+
+The example plots the FFT of the sum of two sines.
+
+.. plot::
+
+    >>> from scipy.fftpack import fft
+    >>> # Number of samplepoints
+    >>> N = 600
+    >>> # sample spacing
+    >>> T = 1.0 / 800.0
+    >>> x = np.linspace(0.0, N*T, N)
+    >>> y = np.sin(50.0 * 2.0*np.pi*x) + 0.5*np.sin(80.0 * 2.0*np.pi*x)
+    >>> yf = fft(y)
+    >>> xf = np.linspace(0.0, 1.0/(2.0*T), N/2)
+    >>> import matplotlib.pyplot as plt
+    >>> plt.plot(xf, 2.0/N * np.abs(yf[0:N/2]))
+    >>> plt.grid()
+    >>> plt.show()
+
+..   :caption: FFT-Plot of the sum of two sines
+
+The FFT input signal is inherently truncated. This truncation can be modelled
+as multiplication of an inifinte signal with a rectangular window function. In
+the spectral domain this multiplication becomes convolution of the signal
+spectrum with the window function spectrum, being of form :math:`sin(x)/x`.
+This convolution is the cause of an effect called spectral leakage (see
+[WPW]_). Windowing the signal with a dedicated window function helps mitigate
+spectral leakage. The example below uses a Blackman window from scipy.signal
+and shows the effect of windowing (the zero component of the FFT has been
+truncated illustrative purposes).
+
+.. plot::
+
+    >>> from scipy.fftpack import fft
+    >>> # Number of samplepoints
+    >>> N = 600
+    >>> # sample spacing
+    >>> T = 1.0 / 800.0
+    >>> x = np.linspace(0.0, N*T, N)
+    >>> y = np.sin(50.0 * 2.0*np.pi*x) + 0.5*np.sin(80.0 * 2.0*np.pi*x)
+    >>> yf = fft(y)
+    >>> from scipy.signal import blackman
+    >>> w = blackman(N)
+    >>> ywf = fft(y*w)
+    >>> xf = np.linspace(0.0, 1.0/(2.0*T), N/2)
+    >>> import matplotlib.pyplot as plt
+    >>> plt.semilogy(xf[1:N/2], 2.0/N * np.abs(yf[1:N/2]), '-b')
+    >>> plt.semilogy(xf[1:N/2], 2.0/N * np.abs(ywf[1:N/2]), '-r')
+    >>> plt.legend(['FFT', 'FFT w. window'])
+    >>> plt.grid()
+    >>> plt.show()
+
+..   :caption: FFT-Plot of the sum of two sines with window functions.
+
+
+
+In case the sequence x is complex-valued, the spectrum is no longer symmetric.
+To simplify working wit the FFT functions, scipy provides the following two
+helper functions.
+
+The function :func:`fftfreq` returns the FFT sample frequency points.
+
+>>> from scipy.fftpack import fftfreq
+>>> freq = fftfreq(np.arange(8), 0.125)
+[ 0.  1.  2.  3. -4. -3. -2. -1.]
+
+In a similar spirit, the function :func:`fftshift` allows swapping the lower
+and upper halves of a vector, so that it becomes suitable for display.
+
+>>> from scipy.fftpack import fftfreq
+>>> x = np.arange(8)
+>>> sf.fftshift(x)
+[4 5 6 7 0 1 2 3]
+
+The example below plots the FFT of two complex exponentials; note the
+asymmetric spectrum.
+
+.. plot::
+
+    >>> from scipy.fftpack import fft, fftfreq, fftshift
+    >>> # number of signal points
+    >>> N = 400
+    >>> # sample spacing
+    >>> T = 1.0 / 800.0
+    >>> x = np.linspace(0.0, N*T, N)
+    >>> y = np.exp(50.0 * 1.j * 2.0*np.pi*x) + 0.5*np.exp(-80.0 * 1.j * 2.0*np.pi*x)
+    >>> yf = fft(y)
+    >>> xf = fftfreq(N, T)
+    >>> xf = fftshift(xf)
+    >>> yplot = fftshift(yf)
+    >>> import matplotlib.pyplot as plt
+    >>> plt.plot(xf, 1.0/N * np.abs(yplot))
+    >>> plt.grid()
+    >>> plt.show()
+
+..   :caption: FFT-Plot of the sum of two sines
+
+
+
+The function :func:`rfft` calculates the FFT of a real sequence and outputs
+the FFT coefficients :math:`y_n` with separate real and imaginary parts. In
+case of N being even: :math:`[y_0, Re(y_1), Im(y_1),..., Re(y_{N/2})]`; in
+case N being odd :math:`[y_0, Re(y_1),Im(y_1),..., Re(y_{N/2}), Im(y_{N/2})]`.
+
+The corresponding function :func:`irfft` calculates the IFFT of the FFT
+coefficients with this special ordering.
+
+>>> from scipy.fftpack import fft, rfft, irfft
+>>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5, 1.0])
+>>> fft(x)
+[ 5.50+0.j          2.25-0.4330127j  -2.75-1.29903811j  1.50+0.j
+ -2.75+1.29903811j  2.25+0.4330127j ]
+>>> yr = rfft(x)
+[ 5.5         2.25       -0.4330127  -2.75       -1.29903811  1.5       ]
+>>> irfft(yr)
+[ 1.   2.   1.  -1.   1.5  1. ]
+>>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5])
+>>> fft(x)
+[ 4.50000000+0.j          2.08155948-1.65109876j -1.83155948+1.60822041j
+ -1.83155948-1.60822041j  2.08155948+1.65109876j]
+>>> yr = rfft(x)
+[ 4.5         2.08155948 -1.65109876 -1.83155948  1.60822041]
+
+
+Two and n-dimensional discrete Fourier transforms
+_________________________________________________
+
+The functions :func:`fft2` and :func:`ifft2` provide 2-dimensional FFT, and
+IFFT, respectively. Similar, :func:`fftn` and :func:`ifftn` provide n-dimensional FFT, and
+IFFT, respectively.
+
+The example below demonstrates a 2-dimensional IFFT and plots the resulting
+(2-dimensional) time-domain signals.
+
+.. plot::
+
+    >>> from scipy.fftpack import ifftn
+    >>> import matplotlib.pyplot as plt
+    >>> import matplotlib.cm as cm
+    >>> N = 30
+    >>> f, ((ax1, ax2, ax3), (ax4, ax5, ax6)) = plt.subplots(2, 3, sharex='col', sharey='row')
+    >>> xf = np.zeros((N,N))
+    >>> xf[0, 5] = 1
+    >>> xf[0, N-5] = 1
+    >>> Z = ifftn(xf)
+    >>> ax1.imshow(xf, cmap=cm.binary)
+    >>> ax4.imshow(np.real(Z), cmap=cm.binary)
+    >>> xf = np.zeros((N, N))
+    >>> xf[5, 0] = 1
+    >>> xf[N-5, 0] = 1
+    >>> Z = ifftn(xf)
+    >>> ax2.imshow(xf, cmap=cm.binary)
+    >>> ax5.imshow(np.real(Z), cmap=cm.binary)
+    >>> xf = np.zeros((N, N))
+    >>> xf[5, 10] = 1
+    >>> xf[N-5, N-10] = 1
+    >>> Z = ifftn(xf)
+    >>> ax3.imshow(xf, cmap=cm.binary)
+    >>> ax6.imshow(np.real(Z), cmap=cm.binary)
+    >>> plt.show()
+
+..   :caption: 2-dimensional FFT example
+
+
+FFT convolution
+_______________
+
+scipy.fftpack.convolve performs a convolution of two one-dimensional
+arrays in frequency domain.
+
 
 
 Discrete Cosine Transforms
 --------------------------
 
+Scipy provides a DCT with the function :func:`dct` and a corresponding IDCT
+with the function :func:`idct`. There are 8 types of the DCT [WPC]_, [Mak]_;
+however, only the first 3 types are implemented in scipy. "The" DCT generally
+refers to DCT type 2, and "the" Inverse DCT generally refers to DCT type 3. In
+addition, the DCT coefficients can be normalized differently (for most types,
+scipy provides ``None`` and ``ortho``). Two parameters of the dct/idct
+function calls allow setting the DCT type and coefficient normalization.
 
-Return the Discrete Cosine Transform [Mak]_ of arbitrary type sequence ``x``.
+For a single dimension array x, dct(x, norm='ortho') is equal to
+MATLAB dct(x).
 
-For a single dimension array ``x``, ``dct(x, norm='ortho')`` is equal to
-MATLAB ``dct(x)``.
 
-There are theoretically 8 types of the DCT [WPC]_, only the first 3 types are
-implemented in scipy. 'The' DCT generally refers to DCT type 2, and 'the'
-Inverse DCT generally refers to DCT type 3.
+Type I DCT
+__________
 
-type I
-~~~~~~
-
-There are several definitions of the DCT-I; we use the following
-(for ``norm=None``):
+Scipy uses the following definition of the unnormalized DCT-I
+(``norm='None'``):
 
 .. math::
-   :nowrap:
 
-    \[ y_k = x_0 + (-1)^k x_{N-1} + 2\sum_{n=1}^{N-2} x_n
+    y_k = x_0 + (-1)^k x_{N-1} + 2\sum_{n=1}^{N-2} x_n
     \cos\left({\pi nk\over N-1}\right),
-    \qquad 0 \le k < N. \]
+    \qquad 0 \le k < N.
 
-Only None is supported as normalization mode for DCT-I. Note also that the
+Only ``None`` is supported as normalization mode for DCT-I. Note also that the
 DCT-I is only supported for input size > 1
 
-type II
-~~~~~~~
+Type II DCT
+___________
 
-There are several definitions of the DCT-II; we use the following
-(for ``norm=None``):
-
-.. math::
-   :nowrap:
-
-    \[ y_k = 2 \sum_{n=0}^{N-1} x_n
-    \cos \left({\pi(2n+1)k \over 2N} \right)
-    \qquad 0 \le k < N.\]
-
-If ``norm='ortho'``, :math:`y_k` is multiplied by a scaling factor `f`:
+Scipy uses the following definition of the unnormalized DCT-II
+(``norm='None'``):
 
 .. math::
-   :nowrap:
 
-    \[f = \begin{cases} \sqrt{1/(4N)}, & \text{if $k = 0$} \\
-       \sqrt{1/(2N)}, & \text{otherwise} \end{cases} \]
+    y_k = 2 \sum_{n=0}^{N-1} x_n \cos \left({\pi(2n+1)k \over 2N} \right)
+    \qquad 0 \le k < N.
 
-
-Which makes the corresponding matrix of coefficients orthonormal
-(`OO' = Id`).
-
-type III
-~~~~~~~~
-
-There are several definitions of the DCT-III, we use the following
-(for ``norm=None``):
+In case of the normalized DCT (``norm='ortho'``), the DCT coefficients
+:math:`y_k` are multiplied by a scaling factor `f`:
 
 .. math::
-   :nowrap:
 
-    \[ y_k = x_0 + 2 \sum_{n=1}^{N-1} x_n
-    \cos\left({\pi n(2k+1) \over 2N}\right)
-    \qquad 0 \le k < N,\]
+    f = \begin{cases} \sqrt{1/(4N)}, & \text{if $k = 0$} \\    \sqrt{1/(2N)},
+    & \text{otherwise} \end{cases} \, .
+
+In this case, the DCT "base functions" :math:`\phi_k(n) = 2 f \cos
+\left({\pi(2n+1)k \over 2N} \right)` become orthonormal:
+
+.. math::
+
+   \sum_{n=0}^{N-1} \phi_k(n) \phi_l(n) = \delta_{lk}
+
+
+Type III DCT
+____________
+
+Scipy uses the following definition of the unnormalized DCT-III
+(``norm='None'``):
+
+.. math::
+
+    y_k = x_0 + 2 \sum_{n=1}^{N-1} x_n \cos\left({\pi n(2k+1) \over 2N}\right)
+    \qquad 0 \le k < N,
 
 or, for ``norm='ortho'``:
 
 .. math::
-   :nowrap:
 
-    \[ y_k = {x_0\over\sqrt{N}} + {1\over\sqrt{N}} \sum_{n=1}^{N-1}
-    x_n \cos\left({\pi n(2k+1) \over 2N}\right)
-    \qquad 0 \le k < N.\]
+    y_k = {x_0\over\sqrt{N}} + {1\over\sqrt{N}} \sum_{n=1}^{N-1} x_n
+    \cos\left({\pi n(2k+1) \over 2N}\right) \qquad 0 \le k < N.
 
-The (unnormalized) DCT-III is the inverse of the (unnormalized) DCT-II, up
-to a factor `2N`. The orthonormalized DCT-III is exactly the inverse of the
-orthonormalized DCT-II.
 
+DCT and IDCT
+____________
+
+
+The (unnormalized) DCT-III is the inverse of the (unnormalized) DCT-II, up to
+a factor `2N`. The orthonormalized DCT-III is exactly the inverse of the orthonormalized DCT-
+II. The function :func:`idct` performs the mappings between the DCT and IDCT types.
+
+The example below shows the relation between DCT and IDCT for different types
+and normalizations.
+
+>>> from scipy.fftpack import dct, idct
+>>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5])
+>>>  # scaling factor 2*N = 10
+>>> idct(dct(x, type=2), type=2)
+[ 10.  20.  10. -10.  15.]
+>>>  # no scaling factor
+>>> idct(dct(x, type=2, norm='ortho'), type=2, norm='ortho')
+[ 1.   2.   1.  -1.   1.5]
+>>>  # scaling factor 2*N = 10
+>>> idct(dct(x, type=3), type=3)
+[ 10.  20.  10. -10.  15.]
+>>>  # no scaling factor
+>>> idct(dct(x, type=3, norm='ortho'), type=3, norm='ortho')
+[ 1.   2.   1.  -1.   1.5]
+>>>  # scaling factor 2*(N-1) = 8
+>>> idct(dct(x, type=1), type=1)
+[  8.  16.   8.  -8.  12.]
+
+
+Example
+_______
+
+The DCT exhibits the "energy compaction property", meaning that only the first
+few DCT coefficients have significant magnitude. Zeroing out the other
+coefficients leads to a small reconstruction error, a fact which is exploited
+in lossy signal compression (e.g. JPEG compression).
+
+The example below shows a signal x and two reconstructions (:math:`x_{20}` and
+:math:`x_{15}`)from the signal's DCT coefficients. The signal :math:`x_{20}`
+is reconstructed from the first 20 DCT coefficients, :math:`x_{15}` is
+reconstructed from the first 15 DCT coefficients. It can be seen that the
+relative error of using 20 coefficients is still very small (~0.1%), but
+provides a five-fold compression rate.
+
+
+.. plot::
+
+    >>> from scipy.fftpack import dct, idct
+    >>> import matplotlib.pyplot as plt
+    >>> N = 100
+    >>> t = np.linspace(0,20,N)
+    >>> x = np.exp(-t/3)*np.cos(2*t)
+    >>> y = dct(x, norm='ortho')
+    >>> window = np.zeros(N)
+    >>> window[:25] = 1
+    >>> yr = idct(y*window, norm='ortho')
+    >>> sum(abs(x-yr)**2) / sum(abs(x)**2)
+    0.0010901402257
+    >>> plt.plot(t, x, 'bx')
+    >>> plt.plot(t, yr, 'ro')
+    >>> window = np.zeros(N)
+    >>> window[:15] = 1
+    >>> yr = idct(y*window, norm='ortho')
+    >>> sum(abs(x-yr)**2) / sum(abs(x)**2)
+    0.0718818065008
+    >>> plt.plot(t, yr, 'g+')
+    >>> plt.legend(['x', '$x_{20}$', '$x_{15}$'])
+    >>> plt.grid()
+    >>> plt.show()
 
 Discrete Sine Transforms
---------------------------
+------------------------
 
+Scipy provides a DST [Mak]_ with the function :func:`dst` and a corresponding IDST
+with the function :func:`idst`.
 
-Return the Discrete Sine Transform [Mak]_ of arbitrary type sequence ``x``.
+There are theoretically 8 types of the DST for different combinations of
+even/odd boundary conditions and boundary off sets [WPS]_, only the first 3
+types are implemented in scipy.
 
-There are theoretically 8 types of the DST for different combinations of even/odd
-boundary conditions and boundary off sets [WPS]_, only the first 3 types are
-implemented in scipy.
+Type I DST
+__________
 
-type I
-~~~~~~
-
-There are several definitions of the DST-I; we use the following
-for ``norm=None``.  DST-I assumes the input is odd around n=-1 and n=N.
-
-.. math::
-   :nowrap:
-
-    \[ y_k = 2\sum_{n=0}^{N-1} x_n 
-    \sin\left( \pi {(n+1) (k+1)}\over{N+1} \right),
-    \qquad 0 \le k < N. \]
-
-Only None is supported as normalization mode for DST-I. Note also that the
-DCT-I is only supported for input size > 1.
-The (unnormalized) DCT-I is its own inverse, up to a factor `2(N+1)`.
-
-type II
-~~~~~~~
-
-There are several definitions of the DST-II; we use the following
-(for ``norm=None``).  DST-II assumes the input is odd around n=-1/2 and even
-around n=N
+DST-I assumes the input is odd around n=-1 and n=N. Scipy uses the following
+definition of the unnormalized DST-I (``norm='None'``):
 
 .. math::
-   :nowrap:
 
-    \[ y_k = 2 \sum_{n=0}^{N-1} x_n 
-    \sin\left( {\pi (n+1/2)(k+1)} \over N \right),
-    \qquad 0 \le k < N. \]
+    y_k = 2\sum_{n=0}^{N-1} x_n  \sin\left( \pi {(n+1) (k+1)}\over{N+1}
+    \right), \qquad 0 \le k < N.
 
-type III
-~~~~~~~~
+Only ``None`` is supported as normalization mode for DST-I. Note also that the
+DST-I is only supported for input size > 1. The (unnormalized) DST-I is its
+own inverse, up to a factor `2(N+1)`.
 
-There are several definitions of the DST-III, we use the following
-(for ``norm=None``).  DST-III assumes the input is odd around n=-1
-and even around n=N-1
+Type II DST
+___________
+
+DST-II assumes the input is odd around n=-1/2 and even around n=N. Scipy uses
+the following definition of the unnormalized DST-II (``norm='None'``):
 
 .. math::
-   :nowrap:
 
-    \[ y_k = (-1)^k x_{N-1} + 2 \sum_{n=0}^{N-2} x_n
-    \sin \left( {\pi (n+1)(k+1/2)} \over N \right),
-    \qquad 0 \le k < N. \]
+    y_k = 2 \sum_{n=0}^{N-1} x_n  \sin\left( {\pi (n+1/2)(k+1)} \over N
+    \right), \qquad 0 \le k < N.
 
-The (unnormalized) DCT-III is the inverse of the (unnormalized) DCT-II, up
-to a factor `2N`.
+Type III DST
+____________
+
+DST-III assumes the input is odd around n=-1 and even around n=N-1. Scipy uses
+the following definition of the unnormalized DST-III (``norm='None'``):
+
+.. math::
+
+    y_k = (-1)^k x_{N-1} + 2 \sum_{n=0}^{N-2} x_n \sin \left( {\pi
+    (n+1)(k+1/2)} \over N \right), \qquad 0 \le k < N.
+
+
+DST and IDST
+____________
+
+
+The example below shows the relation between DST and IDST for different types
+and normalizations.
+
+>>> from scipy.fftpack import dst, idst
+>>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5])
+>>>  # scaling factor 2*N = 10
+>>> idst(dst(x, type=2), type=2)
+[ 10.  20.  10. -10.  15.]
+>>>  # no scaling factor
+>>> idst(dst(x, type=2, norm='ortho'), type=2, norm='ortho')
+[ 1.   2.   1.  -1.   1.5]
+>>>  # scaling factor 2*N = 10
+>>> idst(dst(x, type=3), type=3)
+[ 10.  20.  10. -10.  15.]
+>>>  # no scaling factor
+>>> idst(dst(x, type=3, norm='ortho'), type=3, norm='ortho')
+[ 1.   2.   1.  -1.   1.5]
+>>>  # scaling factor 2*(N+1) = 8
+>>> idst(dst(x, type=1), type=1)
+[  8.  16.   8.  -8.  12.]
+
+
+
+
+
+.. Differential and pseudo-differential operators
+.. ----------------------------------------------
+..
+.. :func:`diff` - I have no idea what this does!
+
+
+Cache Destruction
+-----------------
+
+To accelerate repeat transforms on arrays of the same shape and dtype,
+scipy.fftpack keeps a cache of the prime factorization of length of the array
+and pre-computed trigonometric functions.  These caches can be destroyed by
+calling the appropriate function in scipy.fftpack._fftpack.  dst(type=1) and
+idst(type=1) share a cache (*dst1_cache).  As do dst(type=2), dst(type=3),
+idst(type=3), and idst(type=3) (*dst2_cache).
+
 
 References
 ~~~~~~~~~~
@@ -194,26 +504,8 @@ References
        `IEEE Transactions on acoustics, speech and signal processing`
        vol. 28(1), pp. 27-34, http://dx.doi.org/10.1109/TASSP.1980.1163351
 
+.. [WPW] http://en.wikipedia.org/wiki/Window_function
+
 .. [WPC] http://en.wikipedia.org/wiki/Discrete_cosine_transform
 
 .. [WPS] http://en.wikipedia.org/wiki/Discrete_sine_transform
-
-
-FFT convolution
----------------
-
-scipy.fftpack.convolve performs a convolution of two one-dimensional
-arrays in frequency domain.
-
-Cache Destruction
------------------
-
-To accelerate repeat transforms on arrays of the same shape and dtype,
-scipy.fftpack keeps a cache of the prime factorization of length of the array
-and pre-computed trigonometric functions.  These caches can be destroyed by
-calling the appropriate function in scipy.fftpack._fftpack.  dst(type=1) and
-idst(type=1) share a cache (*dst1_cache).  As do dst(type=2), dst(type=3),
-idst(type=3), and idst(type=3) (*dst2_cache).
-
-
-

--- a/doc/source/tutorial/fftpack.rst
+++ b/doc/source/tutorial/fftpack.rst
@@ -311,7 +311,7 @@ or, for ``norm='ortho'``:
 
 .. math::
 
-    y_k = {x_0\over\sqrt{N}} + {1\over\sqrt{N}} \sum_{n=1}^{N-1} x_n
+    y_k = {x_0\over\sqrt{N}} + {2\over\sqrt{N}} \sum_{n=1}^{N-1} x_n
     \cos\left({\pi n(2k+1) \over 2N}\right) \qquad 0 \le k < N.
 
 

--- a/doc/source/tutorial/fftpack.rst
+++ b/doc/source/tutorial/fftpack.rst
@@ -328,6 +328,8 @@ and normalizations.
 
 >>> from scipy.fftpack import dct, idct
 >>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5])
+>>> dct(dct(x, type=2, norm='ortho'), type=3, norm='ortho')
+[1.0, 2.0, 1.0, -1.0, 1.5]
 >>>  # scaling factor 2*N = 10
 >>> idct(dct(x, type=2), type=2)
 [ 10.  20.  10. -10.  15.]


### PR DESCRIPTION
Enhanced the fftpack example. Some open issues:
- Issue https://github.com/scipy/scipy/issues/2720 pointed out that there is an error in the dct docstring (and in the tutorial as well). I commented there; if 2720 is resolved, the tutorial needs to be updated.
- I'm not sure if copying the DCT / DST definitions from the docstring is really useful for a tutorial - any opinions on that?
- I found that the fftpack documentation does not contain dst & idst - is this on purpose or an error (although I didn't find out what keeps the docstrings from being included)?
- Not everything is included (yet); e.g. differential operators, convolutions (see mail on mailing list as I don't understand what this does)... are missing. Do you prefer PRs which are "complete" or is this step-wise approach ok for you?
