### PR TITLE
ENH: levinson-durbin

### DIFF
--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -26,6 +26,7 @@ Basics
    solve_banded - Solve a banded linear system
    solveh_banded - Solve a Hermitian or symmetric banded system
    solve_triangular - Solve a triangular matrix
+   solve_toeplitz - Solve a Toeplitz matrix
    det - Find the determinant of a square matrix
    norm - Matrix and vector norm
    lstsq - Solve a linear least-squares problem
@@ -171,6 +172,7 @@ from .blas import *
 from .lapack import *
 from .special_matrices import *
 from ._solvers import *
+from ._levinson_durbin import *
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 

--- a/scipy/linalg/_levinson_durbin.py
+++ b/scipy/linalg/_levinson_durbin.py
@@ -1,19 +1,76 @@
+"""
+Implementation of the Levinson-Durbin algorithm for solving Toeplitz systems.
+
+"""
+from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal
 import scipy.linalg
 
 
-def _levinson_durbin_linear_memory(c, r=None, y=None):
-    """
-    c is the first column
-    r is the first row
-    y is the rhs of the matrix equation
-    """
-    if r is None:
-        r = np.conjugate(c)
+__all__ = ['solve_toeplitz']
 
-    N = c.shape[0]
+
+def solve_toeplitz(c, r=None, y=None):
+    """
+    Solve the matrix equation (T x = y) where T is a Toeplitz matrix.
+
+    The square Toeplitz input matrix T is represented through its
+    first column and optionally its first row.
+    This representation, including the ordering of the first two args,
+    is taken from the linalg.toeplitz function.
+
+    Parameters
+    ----------
+    c : 1d array_like
+        The first column of the Toeplitz matrix.
+    r : 1d array_like, optional
+        The first row of the Toeplitz matrix.
+    y : 1d array_like
+        The rhs of the matrix equation.
+
+    Returns
+    -------
+    x : 1d ndarray
+        The solution of the matrix equation (T x = y).
+
+    Notes
+    -----
+    This is an implementation of the Levinson-Durbin algorithm which uses
+    only O(N) memory and O(N^2) time, but which has less than stellar
+    numerical stability.
+
+    References
+    ----------
+    .. [1] Wikipedia, "Levinson recursion",
+           http://en.wikipedia.org/wiki/Levinson_recursion
+
+    """
+
+    #TODO special-case symmetric toeplitz
+    #TODO multiple simultaneous rhs using B instead of y
+
+    # This block has been copied from the linalg.toeplitz construction function.
+    c = np.asarray(c).ravel()
+    if r is None:
+        r = c.conjugate()
+    else:
+        r = np.asarray(r).ravel()
+
+    # Check that the rhs makes sense.
+    if y is None:
+        raise ValueError('missing rhs')
+    y = np.asarray(y)
+    if y.ndim != 1:
+        raise NotImplementedError('the rhs must be one-dimensional')
+    N = y.shape[0]
+
+    # Check that the Toeplitz representation makes sense
+    # and is compatible with the rhs shape.
+    if c.shape != r.shape:
+        raise ValueError('expected the Toeplitz matrix to be square')
+    if c.shape != y.shape:
+        raise ValueError('the rhs shape is incompatible with the matrix shape')
 
     # Key relating entries of the toeplitz matrix to entries of c, r,
     # assuming n is a positive integer less than N:
@@ -22,12 +79,12 @@ def _levinson_durbin_linear_memory(c, r=None, y=None):
     # M[0, 1:n+1] == r[1:n+1]
 
     # Initialize the forward, backward, and solution vectors.
-    f = np.zeros(N)
-    b = np.zeros(N)
-    x = np.zeros(N)
-    f_prev = np.zeros(N)
-    b_prev = np.zeros(N)
-    x_prev = np.zeros(N)
+    f_prev = np.zeros_like(y)
+    b_prev = np.zeros_like(y)
+    x_prev = np.zeros_like(y)
+    f = np.zeros_like(y)
+    b = np.zeros_like(y)
+    x = np.zeros_like(y)
     f[0] = 1 / c[0]
     b[0] = 1 / c[0]
     x[0] = y[0] / c[0]
@@ -37,12 +94,12 @@ def _levinson_durbin_linear_memory(c, r=None, y=None):
         f, f_prev = f_prev, f
         b, b_prev = b_prev, b
         x, x_prev = x_prev, x
-        f.fill(0)
-        b.fill(0)
-        x.fill(0)
         eps_f = np.dot(c[n:0:-1], f_prev[:n])
         eps_x = np.dot(c[n:0:-1], x_prev[:n])
         eps_b = np.dot(r[1:n+1], b_prev[:n])
+        f.fill(0)
+        b.fill(0)
+        x.fill(0)
         coeff = 1 / (1 - eps_f * eps_b)
         f[:n] += coeff * f_prev[:n]
         f[1:n+1] -= coeff * eps_f * b_prev[:n]
@@ -52,217 +109,3 @@ def _levinson_durbin_linear_memory(c, r=None, y=None):
 
     return x
 
-
-def _levinson_durbin_linear_extra_memory(M, y):
-    """
-    Implement the Levinson-Durbin solver using O(n) extra memory.
-    Eventually this can be done without the explicit toeplitz matrix.
-
-    """
-    N = M.shape[0]
-    assert_equal(M.shape, (N, N))
-    assert_equal(y.shape, (N,))
-
-    # Initialize the forward, backward, and solution vectors.
-    f = np.zeros(N)
-    b = np.zeros(N)
-    x = np.zeros(N)
-    f_prev = np.zeros(N)
-    b_prev = np.zeros(N)
-    x_prev = np.zeros(N)
-    f[0] = 1 / M[0, 0]
-    b[0] = 1 / M[0, 0]
-    x[0] = y[0] / M[0, 0]
-
-    # Compute forward, backward, and solution vectors recursively.
-    for n in range(1, N):
-        f, f_prev = f_prev, f
-        b, b_prev = b_prev, b
-        x, x_prev = x_prev, x
-        f.fill(0)
-        b.fill(0)
-        x.fill(0)
-        eps_f = np.dot(M[n, :n], f_prev[:n])
-        eps_x = np.dot(M[n, :n], x_prev[:n])
-        eps_b = np.dot(M[0, 1:n+1], b_prev[:n])
-        c = 1 / (1 - eps_f * eps_b)
-        f[:n] += c * f_prev[:n]
-        f[1:n+1] -= c * eps_f * b_prev[:n]
-        b[1:n+1] += c * b_prev[:n]
-        b[:n] -= c * eps_b * f_prev[:n]
-        x[:n+1] = x_prev[:n+1] + (y[n] - eps_x) * b[:n+1]
-
-    return x
-
-
-def _levinson_durbin_quadratic_memory_interleaved(M, y):
-    """
-    Implement the Levinson-Durbin solver using O(n^2) memory,
-    but interleaving the calculations of the forward, backward,
-    and solution vectors as in the hypothetical O(n) memory solution.
-
-    """
-    ntotal = M.shape[0]
-
-    # Initialize the forward and backward vectors.
-    F = np.zeros_like(M)
-    B = np.zeros_like(M)
-    X = np.zeros_like(M)
-    F[0, 0] = 1 / M[0, 0]
-    B[0, 0] = 1 / M[0, 0]
-    X[0, 0] = y[0] / M[0, 0]
-
-    # Compute forward and backward vectors recursively.
-    f_epsilons = []
-    b_epsilons = []
-    x_epsilons = []
-    for n in range(1, ntotal):
-        eps_f = np.dot(M[n, :n], F[n-1, :n])
-        eps_x = np.dot(M[n, :n], X[n-1, :n])
-        eps_b = np.dot(M[0, 1:n+1], B[n-1, :n])
-        c = 1 / (1 - eps_f * eps_b)
-        F[n, :n] += c * F[n-1, :n]
-        F[n, 1:n+1] -= c * eps_f * B[n-1, :n]
-        B[n, 1:n+1] += c * B[n-1, :n]
-        B[n, :n] -= c * eps_b * F[n-1, :n]
-        X[n, :n+1] = X[n-1, :n+1] + (y[n] - eps_x) * B[n, :n+1]
-        f_epsilons.append(eps_f)
-        b_epsilons.append(eps_b)
-        x_epsilons.append(eps_x)
-
-    return F, B, X, f_epsilons, b_epsilons, x_epsilons
-
-
-def _levinson_durbin_vectors(M):
-    """
-    First step of Levinson-Durbin algorithm.
-
-    Input is a square toeplitz matrix as an ndarray.
-    The diagonal must be nonzero.
-    Outputs are forward and backward vectors.
-
-    """
-    ntotal = M.shape[0]
-
-    # Initialize the forward and backward vectors.
-    F = np.zeros_like(M)
-    B = np.zeros_like(M)
-    F[0, 0] = 1 / M[0, 0]
-    B[0, 0] = 1 / M[0, 0]
-
-    # Compute forward and backward vectors recursively.
-    f_epsilons = []
-    b_epsilons = []
-    for n in range(1, ntotal):
-        eps_f = np.dot(M[n, :n], F[n-1, :n])
-        eps_b = np.dot(M[0, 1:n+1], B[n-1, :n])
-        c = 1 / (1 - eps_f * eps_b)
-        F[n, :n] += c * F[n-1, :n]
-        F[n, 1:n+1] -= c * eps_f * B[n-1, :n]
-        B[n, 1:n+1] += c * B[n-1, :n]
-        B[n, :n] -= c * eps_b * F[n-1, :n]
-        f_epsilons.append(eps_f)
-        b_epsilons.append(eps_b)
-
-    # Return the forward and backward vectors.
-    return F, B, f_epsilons, b_epsilons
-
-def _levinson_durbin_solve(M, B, y):
-    ntotal = M.shape[0]
-    X = np.zeros_like(M)
-    X[0, 0] = y[0] / M[0, 0]
-    x_epsilons = []
-    for n in range(1, ntotal):
-        eps_x = np.dot(M[n, :n], X[n-1, :n])
-        X[n, :n+1] = X[n-1, :n+1] + (y[n] - eps_x) * B[n, :n+1]
-        x_epsilons.append(eps_x)
-    return X, x_epsilons
-
-def solve_levinson_durbin(M, y):
-    F, B, f_epsilons, b_epsilons = _levinson_durbin_vectors(M)
-    X, x_epsilons = _levinson_durbin_solve(M, B, y)
-    return X[-1]
-
-def check_levinson_durbin_solve():
-    n = 4
-
-    # Construct a random toeplitz matrix.
-    first_column = np.random.randn(n)
-    first_row = np.random.randn(n)
-    first_row[0] = first_column[0]
-    M = scipy.linalg.toeplitz(first_column, r=first_row)
-
-    y = np.random.randn(n)
-    x_generic = scipy.linalg.solve(M, y)
-    F, B, f_epsilons, b_epsilons = _levinson_durbin_vectors(M)
-    X, x_epsilons = _levinson_durbin_solve(M, B, y)
-    x_levinson_durbin = X[-1]
-    print M
-    print y
-    print 'generic solution        :', x_generic
-    print 'levinson-durbin solution:', x_levinson_durbin
-    print
-
-    print 'checking forward vectors...'
-    print 'forward epsilons:', f_epsilons
-    for i in range(1, n):
-        u = np.array(F[i-1, :i].tolist() + [0])
-        T = M[:i+1, :i+1]
-        print 'iteration', i
-        print 'T:', T
-        print 'u:', u
-        print 'dot(T, u):', np.dot(T, u)
-        print
-    print
-
-    print 'checking backward vectors...'
-    print 'backward epsilons:', b_epsilons
-    for i in range(1, n):
-        u = np.array([0] + B[i-1, :i].tolist())
-        T = M[:i+1, :i+1]
-        print 'iteration', i
-        print 'T:', T
-        print 'u:', u
-        print 'dot(T, u):', np.dot(T, u)
-        print
-    print
-
-    print 'checking solution vectors...'
-    print 'x:', x_levinson_durbin
-    print 'y:', y
-    print 'x epsilons:', x_epsilons
-    for i in range(1, n):
-        u = np.array(X[i-1, :i].tolist() + [0])
-        T = M[:i+1, :i+1]
-        print 'iteration', i
-        print 'T:', T
-        print 'u:', u
-        print 'dot(T, u):', np.dot(T, u)
-        print
-    print
-
-    # check that the interleaved implementation gives the same result
-    info = _levinson_durbin_quadratic_memory_interleaved(M, y)
-    q_F, q_B, q_X, q_f_epsilons, q_b_epsilons, q_x_epsilons = info
-    assert_allclose(F, q_F)
-    assert_allclose(B, q_B)
-    assert_allclose(X, q_X)
-    assert_allclose(f_epsilons, q_f_epsilons)
-    assert_allclose(b_epsilons, q_b_epsilons)
-    assert_allclose(x_epsilons, q_x_epsilons)
-
-    x_linear_extra =  _levinson_durbin_linear_extra_memory(M, y)
-    x_linear_total = _levinson_durbin_linear_memory(first_column, first_row, y)
-    print 'revisit solutions...'
-    print 'generic         :', x_generic
-    print 'quadratic extra :', x_levinson_durbin
-    print 'linear extra    :', x_linear_extra
-    print 'linear total    :', x_linear_total
-    print
-
-
-def main():
-    check_levinson_durbin_solve()
-
-if __name__ == '__main__':
-    main()

--- a/scipy/linalg/_levinson_durbin.py
+++ b/scipy/linalg/_levinson_durbin.py
@@ -1,7 +1,136 @@
 
 import numpy as np
+from numpy.testing import assert_allclose, assert_equal
 import scipy.linalg
 
+
+def _levinson_durbin_linear_memory(c, r=None, y=None):
+    """
+    c is the first column
+    r is the first row
+    y is the rhs of the matrix equation
+    """
+    if r is None:
+        r = np.conjugate(c)
+
+    N = c.shape[0]
+
+    # Key relating entries of the toeplitz matrix to entries of c, r,
+    # assuming n is a positive integer less than N:
+    # M[0, 0] == c[0]
+    # M[n, :n] == c[n:0:-1]
+    # M[0, 1:n+1] == r[1:n+1]
+
+    # Initialize the forward, backward, and solution vectors.
+    f = np.zeros(N)
+    b = np.zeros(N)
+    x = np.zeros(N)
+    f_prev = np.zeros(N)
+    b_prev = np.zeros(N)
+    x_prev = np.zeros(N)
+    f[0] = 1 / c[0]
+    b[0] = 1 / c[0]
+    x[0] = y[0] / c[0]
+
+    # Compute forward, backward, and solution vectors recursively.
+    for n in range(1, N):
+        f, f_prev = f_prev, f
+        b, b_prev = b_prev, b
+        x, x_prev = x_prev, x
+        f.fill(0)
+        b.fill(0)
+        x.fill(0)
+        eps_f = np.dot(c[n:0:-1], f_prev[:n])
+        eps_x = np.dot(c[n:0:-1], x_prev[:n])
+        eps_b = np.dot(r[1:n+1], b_prev[:n])
+        coeff = 1 / (1 - eps_f * eps_b)
+        f[:n] += coeff * f_prev[:n]
+        f[1:n+1] -= coeff * eps_f * b_prev[:n]
+        b[1:n+1] += coeff * b_prev[:n]
+        b[:n] -= coeff * eps_b * f_prev[:n]
+        x[:n+1] = x_prev[:n+1] + (y[n] - eps_x) * b[:n+1]
+
+    return x
+
+
+def _levinson_durbin_linear_extra_memory(M, y):
+    """
+    Implement the Levinson-Durbin solver using O(n) extra memory.
+    Eventually this can be done without the explicit toeplitz matrix.
+
+    """
+    N = M.shape[0]
+    assert_equal(M.shape, (N, N))
+    assert_equal(y.shape, (N,))
+
+    # Initialize the forward, backward, and solution vectors.
+    f = np.zeros(N)
+    b = np.zeros(N)
+    x = np.zeros(N)
+    f_prev = np.zeros(N)
+    b_prev = np.zeros(N)
+    x_prev = np.zeros(N)
+    f[0] = 1 / M[0, 0]
+    b[0] = 1 / M[0, 0]
+    x[0] = y[0] / M[0, 0]
+
+    # Compute forward, backward, and solution vectors recursively.
+    for n in range(1, N):
+        f, f_prev = f_prev, f
+        b, b_prev = b_prev, b
+        x, x_prev = x_prev, x
+        f.fill(0)
+        b.fill(0)
+        x.fill(0)
+        eps_f = np.dot(M[n, :n], f_prev[:n])
+        eps_x = np.dot(M[n, :n], x_prev[:n])
+        eps_b = np.dot(M[0, 1:n+1], b_prev[:n])
+        c = 1 / (1 - eps_f * eps_b)
+        f[:n] += c * f_prev[:n]
+        f[1:n+1] -= c * eps_f * b_prev[:n]
+        b[1:n+1] += c * b_prev[:n]
+        b[:n] -= c * eps_b * f_prev[:n]
+        x[:n+1] = x_prev[:n+1] + (y[n] - eps_x) * b[:n+1]
+
+    return x
+
+
+def _levinson_durbin_quadratic_memory_interleaved(M, y):
+    """
+    Implement the Levinson-Durbin solver using O(n^2) memory,
+    but interleaving the calculations of the forward, backward,
+    and solution vectors as in the hypothetical O(n) memory solution.
+
+    """
+    ntotal = M.shape[0]
+
+    # Initialize the forward and backward vectors.
+    F = np.zeros_like(M)
+    B = np.zeros_like(M)
+    X = np.zeros_like(M)
+    F[0, 0] = 1 / M[0, 0]
+    B[0, 0] = 1 / M[0, 0]
+    X[0, 0] = y[0] / M[0, 0]
+
+    # Compute forward and backward vectors recursively.
+    f_epsilons = []
+    b_epsilons = []
+    x_epsilons = []
+    for n in range(1, ntotal):
+        eps_f = np.dot(M[n, :n], F[n-1, :n])
+        eps_x = np.dot(M[n, :n], X[n-1, :n])
+        eps_b = np.dot(M[0, 1:n+1], B[n-1, :n])
+        c = 1 / (1 - eps_f * eps_b)
+        F[n, :n] += c * F[n-1, :n]
+        F[n, 1:n+1] -= c * eps_f * B[n-1, :n]
+        B[n, 1:n+1] += c * B[n-1, :n]
+        B[n, :n] -= c * eps_b * F[n-1, :n]
+        X[n, :n+1] = X[n-1, :n+1] + (y[n] - eps_x) * B[n, :n+1]
+        f_epsilons.append(eps_f)
+        b_epsilons.append(eps_b)
+        x_epsilons.append(eps_x)
+
+    return F, B, X, f_epsilons, b_epsilons, x_epsilons
 
 
 def _levinson_durbin_vectors(M):
@@ -110,6 +239,25 @@ def check_levinson_durbin_solve():
         print 'u:', u
         print 'dot(T, u):', np.dot(T, u)
         print
+    print
+
+    # check that the interleaved implementation gives the same result
+    info = _levinson_durbin_quadratic_memory_interleaved(M, y)
+    q_F, q_B, q_X, q_f_epsilons, q_b_epsilons, q_x_epsilons = info
+    assert_allclose(F, q_F)
+    assert_allclose(B, q_B)
+    assert_allclose(X, q_X)
+    assert_allclose(f_epsilons, q_f_epsilons)
+    assert_allclose(b_epsilons, q_b_epsilons)
+    assert_allclose(x_epsilons, q_x_epsilons)
+
+    x_linear_extra =  _levinson_durbin_linear_extra_memory(M, y)
+    x_linear_total = _levinson_durbin_linear_memory(first_column, first_row, y)
+    print 'revisit solutions...'
+    print 'generic         :', x_generic
+    print 'quadratic extra :', x_levinson_durbin
+    print 'linear extra    :', x_linear_extra
+    print 'linear total    :', x_linear_total
     print
 
 

--- a/scipy/linalg/_levinson_durbin.py
+++ b/scipy/linalg/_levinson_durbin.py
@@ -1,0 +1,120 @@
+
+import numpy as np
+import scipy.linalg
+
+
+
+def _levinson_durbin_vectors(M):
+    """
+    First step of Levinson-Durbin algorithm.
+
+    Input is a square toeplitz matrix as an ndarray.
+    The diagonal must be nonzero.
+    Outputs are forward and backward vectors.
+
+    """
+    ntotal = M.shape[0]
+
+    # Initialize the forward and backward vectors.
+    F = np.zeros_like(M)
+    B = np.zeros_like(M)
+    F[0, 0] = 1 / M[0, 0]
+    B[0, 0] = 1 / M[0, 0]
+
+    # Compute forward and backward vectors recursively.
+    f_epsilons = []
+    b_epsilons = []
+    for n in range(1, ntotal):
+        eps_f = np.dot(M[n, :n], F[n-1, :n])
+        eps_b = np.dot(M[0, 1:n+1], B[n-1, :n])
+        c = 1 / (1 - eps_f * eps_b)
+        F[n, :n] += c * F[n-1, :n]
+        F[n, 1:n+1] -= c * eps_f * B[n-1, :n]
+        B[n, 1:n+1] += c * B[n-1, :n]
+        B[n, :n] -= c * eps_b * F[n-1, :n]
+        f_epsilons.append(eps_f)
+        b_epsilons.append(eps_b)
+
+    # Return the forward and backward vectors.
+    return F, B, f_epsilons, b_epsilons
+
+def _levinson_durbin_solve(M, B, y):
+    ntotal = M.shape[0]
+    X = np.zeros_like(M)
+    X[0, 0] = y[0] / M[0, 0]
+    x_epsilons = []
+    for n in range(1, ntotal):
+        eps_x = np.dot(M[n, :n], X[n-1, :n])
+        X[n, :n+1] = X[n-1, :n+1] + (y[n] - eps_x) * B[n, :n+1]
+        x_epsilons.append(eps_x)
+    return X, x_epsilons
+
+def solve_levinson_durbin(M, y):
+    F, B, f_epsilons, b_epsilons = _levinson_durbin_vectors(M)
+    X, x_epsilons = _levinson_durbin_solve(M, B, y)
+    return X[-1]
+
+def check_levinson_durbin_solve():
+    n = 4
+
+    # Construct a random toeplitz matrix.
+    first_column = np.random.randn(n)
+    first_row = np.random.randn(n)
+    first_row[0] = first_column[0]
+    M = scipy.linalg.toeplitz(first_column, r=first_row)
+
+    y = np.random.randn(n)
+    x_generic = scipy.linalg.solve(M, y)
+    F, B, f_epsilons, b_epsilons = _levinson_durbin_vectors(M)
+    X, x_epsilons = _levinson_durbin_solve(M, B, y)
+    x_levinson_durbin = X[-1]
+    print M
+    print y
+    print 'generic solution        :', x_generic
+    print 'levinson-durbin solution:', x_levinson_durbin
+    print
+
+    print 'checking forward vectors...'
+    print 'forward epsilons:', f_epsilons
+    for i in range(1, n):
+        u = np.array(F[i-1, :i].tolist() + [0])
+        T = M[:i+1, :i+1]
+        print 'iteration', i
+        print 'T:', T
+        print 'u:', u
+        print 'dot(T, u):', np.dot(T, u)
+        print
+    print
+
+    print 'checking backward vectors...'
+    print 'backward epsilons:', b_epsilons
+    for i in range(1, n):
+        u = np.array([0] + B[i-1, :i].tolist())
+        T = M[:i+1, :i+1]
+        print 'iteration', i
+        print 'T:', T
+        print 'u:', u
+        print 'dot(T, u):', np.dot(T, u)
+        print
+    print
+
+    print 'checking solution vectors...'
+    print 'x:', x_levinson_durbin
+    print 'y:', y
+    print 'x epsilons:', x_epsilons
+    for i in range(1, n):
+        u = np.array(X[i-1, :i].tolist() + [0])
+        T = M[:i+1, :i+1]
+        print 'iteration', i
+        print 'T:', T
+        print 'u:', u
+        print 'dot(T, u):', np.dot(T, u)
+        print
+    print
+
+
+def main():
+    check_levinson_durbin_solve()
+
+if __name__ == '__main__':
+    main()

--- a/scipy/linalg/_levinson_durbin.py
+++ b/scipy/linalg/_levinson_durbin.py
@@ -26,12 +26,12 @@ def solve_toeplitz(c, r=None, y=None):
         The first column of the Toeplitz matrix.
     r : 1d array_like, optional
         The first row of the Toeplitz matrix.
-    y : 1d array_like
+    y : array_like
         The rhs of the matrix equation.
 
     Returns
     -------
-    x : 1d ndarray
+    x : ndarray
         The solution of the matrix equation (T x = y).
 
     Notes

--- a/scipy/linalg/benchmarks/bench_levinson_durbin.py
+++ b/scipy/linalg/benchmarks/bench_levinson_durbin.py
@@ -1,0 +1,51 @@
+"""
+Benchmark the Levinson-Durbin implementation.
+
+This algorithm solves Toeplitz systems.
+
+"""
+from __future__ import division, print_function, absolute_import
+
+import time
+
+import numpy as np
+from numpy.testing import assert_allclose
+import scipy.linalg
+
+
+def bench_levinson_durbin():
+    np.random.seed(1234)
+    print()
+    print('                    Levinson-Durbin vs. generic solver')
+    print('==============================================================')
+    print('      shape      |  solver   |        dtype       |   time   ')
+    print('                 |           |                    | (seconds)')
+    print('--------------------------------------------------------------')
+    fmt = ' %15s |   %6s  | %18s | %6.2f '
+    for n in (100, 300, 1000):
+        for dtype in (np.float64, np.complex128):
+
+            # Sample a random Toeplitz matrix representation and rhs.
+            c = np.random.randn(n)
+            r = np.random.randn(n)
+            y = np.random.randn(n)
+            if dtype == np.complex128:
+                c = c + 1j*np.random.rand(n)
+                r = r + 1j*np.random.rand(n)
+                y = y + 1j*np.random.rand(n)
+
+            # generic solver
+            tm = time.clock()
+            T = scipy.linalg.toeplitz(c, r=r)
+            x_generic = scipy.linalg.solve(T, y)
+            nseconds = time.clock() - tm
+            print(fmt % (T.shape, 'generic', T.dtype, nseconds))
+
+            # toeplitz-specific solver
+            tm = time.clock()
+            x_toeplitz = scipy.linalg.solve_toeplitz(c, r=r, y=y)
+            nseconds = time.clock() - tm
+            print(fmt % (T.shape, 'toeplitz', T.dtype, nseconds))
+
+            # Check that the solutions are the same.
+            assert_allclose(x_generic, x_toeplitz)

--- a/scipy/linalg/tests/test_levinson_durbin.py
+++ b/scipy/linalg/tests/test_levinson_durbin.py
@@ -7,8 +7,10 @@ Test functions for linalg._levinson_durbin module
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import run_module_suite, assert_allclose, assert_raises
 import scipy.linalg
+
+from numpy.testing import (
+        run_module_suite, assert_equal, assert_allclose, assert_raises)
 
 
 def test_solve_equivalence():
@@ -33,6 +35,19 @@ def test_solve_equivalence():
         # Check equivalence when the column is provided but not the row.
         actual = scipy.linalg.solve_toeplitz(c, y=y)
         desired = scipy.linalg.solve(scipy.linalg.toeplitz(c), y)
+        assert_allclose(actual, desired)
+
+
+def test_multiple_rhs():
+    np.random.seed(1234)
+    c = np.random.randn(4)
+    r = np.random.randn(4)
+    for yshape in ((4,), (4, 3), (4, 3, 2)):
+        y = np.random.randn(*yshape)
+        actual = scipy.linalg.solve_toeplitz(c, r=r, y=y)
+        desired = scipy.linalg.solve(scipy.linalg.toeplitz(c, r=r), y)
+        assert_equal(actual.shape, yshape)
+        assert_equal(desired.shape, yshape)
         assert_allclose(actual, desired)
 
 

--- a/scipy/linalg/tests/test_levinson_durbin.py
+++ b/scipy/linalg/tests/test_levinson_durbin.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+#
+"""
+Test functions for linalg._levinson_durbin module
+
+"""
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+from numpy.testing import run_module_suite, assert_allclose, assert_raises
+import scipy.linalg
+
+
+def test_solve_equivalence():
+    # For toeplitz matrices, solve_toeplitz() should be equivalent to solve().
+    np.random.seed(1234)
+    for n in (1, 2, 3, 10):
+        c = np.random.randn(n)
+        if np.random.rand() < 0.5:
+            c = c + 1j * np.random.randn(n)
+        r = np.random.randn(n)
+        if np.random.rand() < 0.5:
+            r = r + 1j * np.random.randn(n)
+        y = np.random.randn(n)
+        if np.random.rand() < 0.5:
+            y = y + 1j * np.random.randn(n)
+
+        # Check equivalence when both the column and row are provided.
+        actual = scipy.linalg.solve_toeplitz(c, r=r, y=y)
+        desired = scipy.linalg.solve(scipy.linalg.toeplitz(c, r=r), y)
+        assert_allclose(actual, desired)
+
+        # Check equivalence when the column is provided but not the row.
+        actual = scipy.linalg.solve_toeplitz(c, y=y)
+        desired = scipy.linalg.solve(scipy.linalg.toeplitz(c), y)
+        assert_allclose(actual, desired)
+
+
+def test_zero_diag_error():
+    # The Levinson-Durbin implementation fails when the diagonal is zero.
+    np.random.seed(1234)
+    n = 4
+    c = np.random.randn(n)
+    r = np.random.randn(n)
+    y = np.random.randn(n)
+    c[0] = 0
+    assert_raises(np.linalg.LinAlgError,
+            scipy.linalg.solve_toeplitz, c, r=r, y=y)
+
+
+def test_wikipedia_counterexample():
+    # The Levinson-Durbin implementation also fails in other cases.
+    # This example is from the talk page of the wikipedia article.
+    np.random.seed(1234)
+    c = [2, 2, 1]
+    y = np.random.randn(3)
+    assert_raises(np.linalg.LinAlgError, scipy.linalg.solve_toeplitz, c, y=y)
+
+
+if __name__ == '__main__':
+    run_module_suite()


### PR DESCRIPTION
I implemented this off of the wikipedia page http://en.wikipedia.org/wiki/Levinson_recursion.  In its current form it's faster than naive solve() for big enough matrices, and maybe if it gets some cython love it could be even faster.  I also noticed that there are some O(N^2) memory algorithms that are more numerically stable which may be more appropriate, although they use more memory.

This implementation should partially address https://github.com/scipy/scipy/issues/2432 and I think there has been some discussion on mailing lists related to this feature in particular, in the context of scipy.signal.

```
                    Levinson-Durbin vs. generic solver
==============================================================
      shape      |  solver   |        dtype       |   time   
                 |           |                    | (seconds)
--------------------------------------------------------------
      (100, 100) |  generic  |            float64 |   0.00 
      (100, 100) |  toeplitz |            float64 |   0.00 
      (100, 100) |  generic  |         complex128 |   0.00 
      (100, 100) |  toeplitz |         complex128 |   0.00 
      (300, 300) |  generic  |            float64 |   0.01 
      (300, 300) |  toeplitz |            float64 |   0.02 
      (300, 300) |  generic  |         complex128 |   0.03 
      (300, 300) |  toeplitz |         complex128 |   0.02 
    (1000, 1000) |  generic  |            float64 |   0.26 
    (1000, 1000) |  toeplitz |            float64 |   0.08 
    (1000, 1000) |  generic  |         complex128 |   1.03 
    (1000, 1000) |  toeplitz |         complex128 |   0.11 
```
