### PR TITLE
Size zero sparse matrices.

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -79,7 +79,7 @@ class spmatrix(object):
         except:
             raise TypeError('invalid shape')
 
-        if not (shape[0] >= 1 and shape[1] >= 1):
+        if not (shape[0] >= 0 and shape[1] >= 0):
             raise ValueError('invalid shape')
 
         if (self._shape != shape) and (self._shape is not None):

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -274,10 +274,6 @@ class csr_matrix(_cs_matrix, IndexMixin):
         # If all else fails, try elementwise
         row, col = self._index_to_arrays(row, col)
 
-        if row.size == 0 or col.size == 0:
-            raise ValueError("Slice returns a size 0 matrix which is not "
-            "supported by sparse matrices.")
-
         return self.__class__([[self._get_single_element(iii, jjj) for
                                 iii, jjj in zip(ii, jj)] for ii, jj in
                                zip(row.tolist(), col.tolist())])
@@ -358,9 +354,6 @@ class csr_matrix(_cs_matrix, IndexMixin):
                 row_indices = abs(row_indices[::-1])
 
             shape = (1, int(np.ceil(float(stop - start) / stride)))
-            if 0 in shape:
-                raise ValueError("Slice returns a size 0 matrix which is not "
-                "supported by sparse matrices.")
 
             row_slice = csr_matrix((row_data, row_indices, row_indptr),
                                    shape=shape)
@@ -396,9 +389,10 @@ class csr_matrix(_cs_matrix, IndexMixin):
                 raise TypeError('expected slice or scalar')
 
         def check_bounds(i0, i1, num):
-            if not (0 <= i0 < num) or not (0 < i1 <= num) or not (i0 < i1):
+            if not (0 <= i0 <= num) or not (0 <= i1 <= num) or not (i0 <= i1):
                 raise IndexError(
-                      "index out of bounds: 0<=%d<%d, 0<=%d<%d, %d<%d" %
+                      "index out of bounds: 0 <= %d <= %d, 0 <= %d <= %d,"
+                       " %d <= %d" %
                       (i0, num, i1, num, i0, i1))
 
         i0, i1 = process_slice(row_slice, M)


### PR DESCRIPTION
This allows sparse matrices to be size zero. Meaning one or both of their shape components is == 0.

This is needed because fancy indexing and other weird edge cases can occasionally return a sparse matrix shaped like this. For example:

``` python
In [1]: import numpy as np; import scipy.sparse as sp

In [2]: A = np.asmatrix(np.arange(50).reshape(5,10))

In [3]: Asp = sp.csr_matrix(A)

In [4]: A
Out[4]: 
matrix([[ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9],
        [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
        [20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
        [30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
        [40, 41, 42, 43, 44, 45, 46, 47, 48, 49]])

In [7]: A[5:5]
Out[7]: matrix([], shape=(0, 10), dtype=int64)

In [8]: Asp[5:5]
Out[8]: 
<0x10 sparse matrix of type '<class 'numpy.int64'>'
    with 0 stored elements in Compressed Sparse Row format>
```
