### PR TITLE
Tweak docs/tutorial for stats

### DIFF
--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -59,8 +59,8 @@ call:
 We can list all methods and properties of the distribution with
 ``dir(norm)``.  As it turns out, some of the methods are private
 methods although they are not named as such (their name does not start
-with a leading underscore), for example ``veccdf`` or ``xa`` and
-``xb`` are only available for internal calculation.
+with a leading underscore), for example ``veccdf``, are only available
+for internal calculation.
 
 To obtain the `real` main methods, we list the methods of the frozen
 distribution. (We explain the meaning of a `frozen` distribution

--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -210,7 +210,7 @@ additional shape parameters. For instance, the gamma distribution, with density
 
 .. math::
 
-    \gamma(x,n) = \frac{\lambda (\lambda x)^{n-1}}{\Gamma(n)} e^{-\lambda x},
+    \gamma(x,n) = \frac{\lambda (\lambda x)^{n-1}}{\Gamma(n)} e^{-\lambda x}\;,
  
 requires the shape parameter :math:`n`. Observe that setting
 :math:`\lambda` can be obtained by setting the ``scale`` keyword to
@@ -229,8 +229,13 @@ Now we set the value of the shape variable to 1 to obtain the
 exponential distribution, so that we compare easily whether we get the
 results we expect.
 
-    >>>  gamma(1, scale=2.).stats(moments = "mv")
+    >>>  gamma(1, scale=2.).stats(moments="mv")
     (array(2.0), array(4.0))
+
+Notice that we can also specify shape parameters as keywords:
+
+   >>> gamma(a=1, scale=2.).stats(moments="mv")
+   (array(2.0), array(4.0))
 
 
 Freezing a Distribution
@@ -410,8 +415,8 @@ Making a Continuous Distribution, i.e., Subclassing ``rv_continuous``
 
 Making continuous distributions is fairly simple. 
 
-    >>> import scipy
-    >>> class deterministic_gen(scipy.stats.rv_continuous):
+    >>> import scipy.stats as stats
+    >>> class deterministic_gen(stats.rv_continuous):
     ...     def _cdf(self, x ): return np.where(x<0, 0., 1.)
     ...     def _stats(self): return 0., 0., 0., 0.
     ... 

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -6188,6 +6188,10 @@ class rv_discrete(rv_generic):
         else:
             self._construct_doc()
 
+        #discrete RV do not have the scale parameter, remove it
+        self.__doc__ = self.__doc__.replace(
+            '\n    scale : array_like, optional\n        scale parameter (default=1)','')
+
         ## This only works for old-style classes...
         # self.__class__.__doc__ = self.__doc__
 

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -78,6 +78,7 @@ def test_discrete_basic():
         spec_k = {'randint': 11, 'hypergeom': 4, 'bernoulli': 0, }
         k = spec_k.get(distname, 1)
         yield check_named_args, distfn, k, arg, locscale_defaults, meths
+        yield check_scale_docstring, distfn
 
 
 @npt.dec.slow
@@ -329,6 +330,10 @@ def check_named_args(distfn, x, shape_args, defaults, meths):
     # unknown arguments should not go through:
     k.update({'kaboom': 42})
     npt.assert_raises(TypeError, distfn.cdf, x, **k)
+
+
+def check_scale_docstring(distfn):
+    npt.assert_('scale' not in distfn.__doc__)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Remove `scale` from discrete distribution docstrings (fixes https://github.com/scipy/scipy/issues/2627).

Tweak the stats tutorial to mention the keyword args.  
