### PR TITLE
Sparse ellipsis slicing

### DIFF
--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1624,6 +1624,31 @@ class _TestSlicing:
             for j, b in enumerate(slices):
                 yield check_2, a, b
 
+    def test_ellipsis_slicing(self):
+        b = asmatrix(arange(50).reshape(5,10))
+        a = self.spmatrix(b)
+
+        assert_array_equal(a[...].A, b[...].A)
+        assert_array_equal(a[...,].A, b[...,].A)
+
+        assert_array_equal(a[..., ...].A, b[..., ...].A)
+        assert_array_equal(a[1, ...].A, b[1, ...].A)
+        assert_array_equal(a[..., 1].A, b[..., 1].A)
+        assert_array_equal(a[1:, ...].A, b[1:, ...].A)
+        assert_array_equal(a[..., 1:].A, b[..., 1:].A)
+
+        assert_array_equal(a[..., ..., ...].A, b[..., ..., ...].A)
+        assert_array_equal(a[1, ..., ...].A, b[1, ..., ...].A)
+        assert_array_equal(a[1:, ..., ...].A, b[1:, ..., ...].A)
+        assert_array_equal(a[..., ..., 1:].A, b[..., ..., 1:].A)
+        assert_array_equal(a[1:, 1, ...].A, b[1:, 1, ...].A)
+        assert_array_equal(a[1, ..., 1:].A, b[1, ..., 1:].A)
+        # These return ints
+        assert_equal(a[1, 1, ...], b[1, 1, ...])
+        assert_equal(a[1, ..., 1], b[1, ..., 1])
+        # Bug in NumPy's slicing
+        assert_array_equal(a[..., ..., 1].A, b[..., ..., 1].A.reshape((5,1)))
+
 
 class _TestSlicingAssign:
     def test_slice_scalar_assign(self):


### PR DESCRIPTION
This add indexing with `Ellipsis` (`...`) to sparse matrices. This closes [issue #2721](https://github.com/scipy/scipy/issues/2721). 

There is a possible bug with NumPy's indexing with `Ellipsis` in its matrices which I choose not to replicate. I made an issue [here](https://github.com/numpy/numpy/issues/3646).
