### PR TITLE
ENH: ndimage: gaussian filter truncation

### DIFF
--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -410,7 +410,7 @@ def laplace(input, output=None, mode="reflect", cval=0.0):
 
 @docfiller
 def gaussian_laplace(input, sigma, output=None, mode="reflect",
-                     cval=0.0):
+                     cval=0.0, **kwargs):
     """Multidimensional Laplace filter using gaussian second derivatives.
 
     Parameters
@@ -423,15 +423,19 @@ def gaussian_laplace(input, sigma, output=None, mode="reflect",
     %(output)s
     %(mode)s
     %(cval)s
+    Extra keyword arguments will be passed to gaussian_filter().
     """
     input = numpy.asarray(input)
 
-    def derivative2(input, axis, output, mode, cval, sigma):
+    def derivative2(input, axis, output, mode, cval, sigma, **kwargs):
         order = [0] * input.ndim
         order[axis] = 2
-        return gaussian_filter(input, sigma, order, output, mode, cval)
+        return gaussian_filter(input, sigma, order, output, mode, cval,
+                               **kwargs)
+
     return generic_laplace(input, derivative2, output, mode, cval,
-                           extra_arguments=(sigma,))
+                           extra_arguments=(sigma,),
+                           extra_keywords=kwargs)
 
 
 @docfiller
@@ -485,7 +489,7 @@ def generic_gradient_magnitude(input, derivative, output=None,
 
 @docfiller
 def gaussian_gradient_magnitude(input, sigma, output=None,
-                mode="reflect", cval=0.0):
+                mode="reflect", cval=0.0, **kwargs):
     """Multidimensional gradient magnitude using Gaussian derivatives.
 
     Parameters
@@ -498,15 +502,19 @@ def gaussian_gradient_magnitude(input, sigma, output=None,
     %(output)s
     %(mode)s
     %(cval)s
+    Extra keyword arguments will be passed to gaussian_filter().
     """
     input = numpy.asarray(input)
 
-    def derivative(input, axis, output, mode, cval, sigma):
+    def derivative(input, axis, output, mode, cval, sigma, **kwargs):
         order = [0] * input.ndim
         order[axis] = 1
-        return gaussian_filter(input, sigma, order, output, mode, cval)
+        return gaussian_filter(input, sigma, order, output, mode,
+                               cval, **kwargs)
+
     return generic_gradient_magnitude(input, derivative, output, mode,
-                            cval, extra_arguments=(sigma,))
+                                      cval, extra_arguments=(sigma,),
+                                      extra_keywords=kwargs)
 
 
 def _correlate_or_convolve(input, weights, output, mode, cval, origin,

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -178,7 +178,7 @@ def convolve1d(input, weights, axis=-1, output=None, mode="reflect",
 
 @docfiller
 def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
-                      mode="reflect", cval=0.0):
+                      mode="reflect", cval=0.0, truncate=4.0):
     """One-dimensional Gaussian filter.
 
     Parameters
@@ -195,6 +195,9 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
     %(output)s
     %(mode)s
     %(cval)s
+    truncate : float
+        Truncate the filter at this many standard deviations.
+        Default is 4.0.
 
     Returns
     -------
@@ -204,9 +207,8 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
     if order not in range(4):
         raise ValueError('Order outside 0..3 not implemented')
     sd = float(sigma)
-    # make the length of the filter equal to 4 times the standard
-    # deviations:
-    lw = int(4.0 * sd + 0.5)
+    # make the radius of the filter equal to truncate standard deviations
+    lw = int(truncate * sd + 0.5)
     weights = [0.0] * (2 * lw + 1)
     weights[lw] = 1.0
     sum = 1.0
@@ -247,7 +249,7 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
 
 @docfiller
 def gaussian_filter(input, sigma, order=0, output=None,
-                  mode="reflect", cval=0.0):
+                  mode="reflect", cval=0.0, truncate=4.0):
     """Multidimensional Gaussian filter.
 
     Parameters
@@ -268,6 +270,9 @@ def gaussian_filter(input, sigma, order=0, output=None,
     %(output)s
     %(mode)s
     %(cval)s
+    truncate : float
+        Truncate the filter at this many standard deviations.
+        Default is 4.0.
 
     Returns
     -------
@@ -296,7 +301,7 @@ def gaussian_filter(input, sigma, order=0, output=None,
     if len(axes) > 0:
         for axis, sigma, order in axes:
             gaussian_filter1d(input, sigma, axis, order, output,
-                              mode, cval)
+                              mode, cval, truncate)
             input = output
     else:
         output[...] = input[...]

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -53,3 +53,11 @@ def test_valid_origins():
         # Just check this raises an error instead of silently accepting or
         # segfaulting.
         assert_raises(ValueError, filter, data, 3, origin=2)
+
+def test_gaussian_truncate():
+    """Test that Gaussian filters can be truncated at different widths."""
+    arr = np.zeros((100, 100), np.float)
+    arr[50, 50] = 1
+    num_zeros_2 = (sndi.gaussian_filter(arr, 5, truncate=2) > 0).sum()
+    num_zeros_5 = (sndi.gaussian_filter(arr, 5, truncate=5) > 0).sum()
+    assert (num_zeros_5 > num_zeros_2 * 2)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -54,10 +54,43 @@ def test_valid_origins():
         # segfaulting.
         assert_raises(ValueError, filter, data, 3, origin=2)
 
+
 def test_gaussian_truncate():
-    """Test that Gaussian filters can be truncated at different widths."""
+    # Test that Gaussian filters can be truncated at different widths.
+    # These tests only check that the result has the expected number
+    # of nonzero elements.
     arr = np.zeros((100, 100), np.float)
     arr[50, 50] = 1
-    num_zeros_2 = (sndi.gaussian_filter(arr, 5, truncate=2) > 0).sum()
-    num_zeros_5 = (sndi.gaussian_filter(arr, 5, truncate=5) > 0).sum()
-    assert (num_zeros_5 > num_zeros_2 * 2)
+    num_nonzeros_2 = (sndi.gaussian_filter(arr, 5, truncate=2) > 0).sum()
+    assert_equal(num_nonzeros_2, 21**2)
+    num_nonzeros_5 = (sndi.gaussian_filter(arr, 5, truncate=5) > 0).sum()
+    assert_equal(num_nonzeros_5, 51**2)
+
+    # Test truncate when sigma is a sequence.
+    f = sndi.gaussian_filter(arr, [0.5, 2.5], truncate=3.5)
+    fpos = f > 0
+    n0 = fpos.any(axis=0).sum()
+    # n0 should be 2*int(2.5*3.5 + 0.5) + 1
+    assert_equal(n0, 19)
+    n1 = fpos.any(axis=1).sum()
+    # n1 should be 2*int(0.5*3.5 + 0.5) + 1
+    assert_equal(n1, 5)
+
+    # Test gaussian_filter1d.
+    x = np.zeros(51)
+    x[25] = 1
+    f = sndi.gaussian_filter1d(x, sigma=2, truncate=3.5)
+    n = (f > 0).sum()
+    assert_equal(n, 15)
+
+    # Test gaussian_laplace
+    y = sndi.gaussian_laplace(x, sigma=2, truncate=3.5)
+    nonzero_indices = np.where(y != 0)[0]
+    n = nonzero_indices.ptp() + 1
+    assert_equal(n, 15)
+
+    # Test gaussian_gradient_magnitude
+    y = sndi.gaussian_gradient_magnitude(x, sigma=2, truncate=3.5)
+    nonzero_indices = np.where(y != 0)[0]
+    n = nonzero_indices.ptp() + 1
+    assert_equal(n, 15)


### PR DESCRIPTION
This is an extension of https://github.com/scipy/scipy/pull/239
I added a commit that strengthens the existing test, and adds tests for more of the affected functions.

There are two API enhancements in this PR:
- Add the `truncate` argument to `gaussian_filter` and `gaussian_filter1d`.  This controls the size of the filter, measured in terms of the standard deviations of the gaussian.
- Add `**kwargs` to the signature of `gaussian_gradient_magnitude` and `gaussian_laplace`.  Any additional keyword arguments passed to these functions are passed on to `gaussian_filter`.  This allows these functions to use the `truncate` argument.

This API looks reasonable to me.  If there are no objections, I'd like to get this into 0.13.
