### PR TITLE
BLD: Fix msvc error C2036: 'void *' : unknown size

### DIFF
--- a/scipy/ndimage/src/_ni_label.pyx
+++ b/scipy/ndimage/src/_ni_label.pyx
@@ -58,7 +58,7 @@ cdef void fused_nonzero_line(data_t *p, np.intp_t stride,
     cdef np.uintp_t i
     for i in range(L):
         line[i] = FOREGROUND if \
-            (<data_t *> ((<void *> p) + i * stride))[0] \
+            (<data_t *> ((<char *> p) + i * stride))[0] \
             else BACKGROUND
 
 
@@ -69,7 +69,7 @@ cdef void fused_read_line(data_t *p, np.intp_t stride,
                           np.uintp_t *line, np.intp_t L) nogil:
     cdef np.uintp_t i
     for i in range(L):
-        line[i] = <np.uintp_t> (<data_t *> ((<void *> p) + i * stride))[0]
+        line[i] = <np.uintp_t> (<data_t *> ((<char *> p) + i * stride))[0]
 
 
 ######################################################################
@@ -85,7 +85,7 @@ cdef bint fused_write_line(data_t *p, np.intp_t stride,
         # in-place.
         if line[i] != <np.uintp_t> <data_t> line[i]:
             return True
-        (<data_t *> ((<void *> p) + i * stride))[0] = <data_t> line[i]
+        (<data_t *> ((<char *> p) + i * stride))[0] = <data_t> line[i]
     return False
 
 
@@ -302,8 +302,8 @@ cpdef _label(np.ndarray input,
                 PyArray_ITER_RESET(itstruct)
                 for ni in range(num_neighbors):
                     neighbor_use_prev = (<np.int_t *> PyArray_ITER_DATA(itstruct))[0]
-                    neighbor_use_adjacent = (<np.int_t *> (PyArray_ITER_DATA(itstruct) + ss))[0]
-                    neighbor_use_next = (<np.int_t *> (PyArray_ITER_DATA(itstruct) + 2 * ss))[0]
+                    neighbor_use_adjacent = (<np.int_t *> (<char *> PyArray_ITER_DATA(itstruct) + ss))[0]
+                    neighbor_use_next = (<np.int_t *> (<char *> PyArray_ITER_DATA(itstruct) + 2 * ss))[0]
                     if not (neighbor_use_prev or
                             neighbor_use_adjacent or
                             neighbor_use_next):
@@ -327,7 +327,7 @@ cpdef _label(np.ndarray input,
                         # becomes next iteration's neighbor buffer, so no
                         # need to read it here.
                         if output.ndim != 2:
-                            read_line(PyArray_ITER_DATA(ito) + total_offset, so,
+                            read_line(<char *> PyArray_ITER_DATA(ito) + total_offset, so,
                                       neighbor_buffer, L)
 
                         # be conservative about how much space we may need


### PR DESCRIPTION
The `scipy.ndimage._ni_label` extension from scipy 0.13.0b1 fails to build with Visual Studio compilers:

```
<snip>
building 'scipy.ndimage._ni_label' extension
compiling C sources
C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\BIN\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG  -Iscipy\ndimage\s
rc -IX:\Python27\lib\site-packages\numpy\core\include -IX:\Python27\lib\site-packages\numpy\core\include -IX:\Python27\i
nclude -IX:\Python27\PC /Tcscipy\ndimage\src\_ni_label.c /Fobuild\temp.win32-2.7\Release\scipy\ndimage\src\_ni_label.obj

_ni_label.c
x:\python27\lib\site-packages\numpy\core\include\numpy\npy_deprecated_api.h(8) : Warning Msg: Using deprecated NumPy API
, disable it by #defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
scipy\ndimage\src\_ni_label.c(2168) : warning C4018: '<' : signed/unsigned mismatch
scipy\ndimage\src\_ni_label.c(2178) : error C2036: 'void *' : unknown size
scipy\ndimage\src\_ni_label.c(2234) : warning C4018: '<' : signed/unsigned mismatch
scipy\ndimage\src\_ni_label.c(2244) : error C2036: 'void *' : unknown size
scipy\ndimage\src\_ni_label.c(2300) : warning C4018: '<' : signed/unsigned mismatch
scipy\ndimage\src\_ni_label.c(2310) : error C2036: 'void *' : unknown size
scipy\ndimage\src\_ni_label.c(2366) : warning C4018: '<' : signed/unsigned mismatch
scipy\ndimage\src\_ni_label.c(2376) : error C2036: 'void *' : unknown size
scipy\ndimage\src\_ni_label.c(2432) : warning C4018: '<' : signed/unsigned mismatch
scipy\ndimage\src\_ni_label.c(2442) : error C2036: 'void *' : unknown size
scipy\ndimage\src\_ni_label.c(2498) : warning C4018: '<' : signed/unsigned mismatch
scipy\ndimage\src\_ni_label.c(2508) : error C2036: 'void *' : unknown size
scipy\ndimage\src\_ni_label.c(2564) : warning C4018: '<' : signed/unsigned mismatch
scipy\ndimage\src\_ni_label.c(2574) : error C2036: 'void *' : unknown size
scipy\ndimage\src\_ni_label.c(2630) : warning C4018: '<' : signed/unsigned mismatch
scipy\ndimage\src\_ni_label.c(2640) : error C2036: 'void *' : unknown size
scipy\ndimage\src\_ni_label.c(2696) : warning C4018: '<' : signed/unsigned mismatch
scipy\ndimage\src\_ni_label.c(2706) : error C2036: 'void *' : unknown size
scipy\ndimage\src\_ni_label.c(2762) : warning C4018: '<' : signed/unsigned mismatch
scipy\ndimage\src\_ni_label.c(2772) : error C2036: 'void *' : unknown size
<snip>
```

The proposed fix uses `char *` instead of `void *` and passes all relevant tests.
