### PR TITLE
BUG+TST: distribution-specific _entropy methods

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -1964,7 +1964,7 @@ class rv_continuous(rv_generic):
         if not np.isnan(entr):
             return entr
         else:  # try with different limits if integration problems
-            low,upp = self.ppf([0.001,0.999],*args)
+            low, upp = self.ppf([1e-10, 1.-1e-10], *args)
             if np.isinf(self.b):
                 upper = upp
             else:
@@ -3949,7 +3949,8 @@ class gumbel_r_gen(rv_continuous):
                12*sqrt(6)/pi**3 * _ZETA3, 12.0/5
 
     def _entropy(self):
-        return 1.0608407169541684911
+        # http://en.wikipedia.org/wiki/Gumbel_distribution
+        return _EULER + 1.
 gumbel_r = gumbel_r_gen(name='gumbel_r')
 
 
@@ -3992,7 +3993,7 @@ class gumbel_l_gen(rv_continuous):
                -12*sqrt(6)/pi**3 * _ZETA3, 12.0/5
 
     def _entropy(self):
-        return 1.0608407169541684911
+        return _EULER + 1.
 gumbel_l = gumbel_l_gen(name='gumbel_l')
 
 
@@ -4568,7 +4569,8 @@ class logistic_gen(rv_continuous):
         return 0, pi*pi/3.0, 0, 6.0/5.0
 
     def _entropy(self):
-        return 1.0
+        # http://en.wikipedia.org/wiki/Logistic_distribution
+        return 2.0
 logistic = logistic_gen(name='logistic')
 
 

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -1960,11 +1960,11 @@ class rv_continuous(rv_generic):
             val = self._pdf(x, *args)
             return special.xlogy(val, val)
 
-        entr = -integrate.quad(integ,self.a,self.b)[0]
+        entr = -integrate.quad(integ,self.a, self.b)[0]
         if not np.isnan(entr):
             return entr
         else:  # try with different limits if integration problems
-            low, upp = self.ppf([1e-10, 1.-1e-10], *args)
+            low, upp = self.ppf([1e-10, 1. - 1e-10], *args)
             if np.isinf(self.b):
                 upper = upp
             else:
@@ -1973,7 +1973,7 @@ class rv_continuous(rv_generic):
                 lower = low
             else:
                 lower = self.a
-            return -integrate.quad(integ,lower,upper)[0]
+            return -integrate.quad(integ, lower, upper)[0]
 
     def entropy(self, *args, **kwds):
         """
@@ -1991,16 +1991,16 @@ class rv_continuous(rv_generic):
 
         """
         args, loc, scale = self._parse_args(*args, **kwds)
-        args = tuple(map(asarray,args))
+        args = tuple(map(asarray, args))
         cond0 = self._argcheck(*args) & (scale > 0) & (loc == loc)
-        output = zeros(shape(cond0),'d')
-        place(output,(1-cond0),self.badvalue)
+        output = zeros(shape(cond0), 'd')
+        place(output, (1-cond0), self.badvalue)
         goodargs = argsreduce(cond0, *args)
         # np.vectorize doesn't work when numargs == 0 in numpy 1.5.1
         if self.numargs == 0:
-            place(output,cond0,self._entropy()+log(scale))
+            place(output, cond0, self._entropy() + log(scale))
         else:
-            place(output,cond0,self.vecentropy(*goodargs)+log(scale))
+            place(output, cond0, self.vecentropy(*goodargs) + log(scale))
 
         return output
 
@@ -2670,7 +2670,7 @@ class burr_gen(rv_continuous):
         return mu, mu2, g1, g2
 burr = burr_gen(a=0.0, name='burr')
 
-#XXX: cf PR #2552
+#XXX: cf gh-2552
 class fisk_gen(burr_gen):
     """A Fisk continuous random variable.
 
@@ -3733,6 +3733,7 @@ class gamma_gen(rv_continuous):
 gamma = gamma_gen(a=0.0, name='gamma')
 
 
+#XXX: cf gh-2552
 class erlang_gen(gamma_gen):
     """An Erlang continuous random variable.
 
@@ -7224,6 +7225,7 @@ class binom_gen(rv_discrete):
 binom = binom_gen(name='binom')
 
 
+#XXX: cf gh-2552
 class bernoulli_gen(binom_gen):
     """A Bernoulli discrete random variable.
 

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -3656,7 +3656,7 @@ class gamma_gen(rv_continuous):
         return a, a, 2.0/sqrt(a), 6.0/a
 
     def _entropy(self, a):
-        return special.psi(a)*(1-a) + 1 + gamln(a)
+        return special.psi(a)*(1-a) + a + gamln(a)
 
     def _fitstart(self, data):
         # The skewness of the gamma distribution is `4 / sqrt(a)`.

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -2670,7 +2670,7 @@ class burr_gen(rv_continuous):
         return mu, mu2, g1, g2
 burr = burr_gen(a=0.0, name='burr')
 
-#XXX: cf gh-2552
+
 class fisk_gen(burr_gen):
     """A Fisk continuous random variable.
 
@@ -3733,7 +3733,6 @@ class gamma_gen(rv_continuous):
 gamma = gamma_gen(a=0.0, name='gamma')
 
 
-#XXX: cf gh-2552
 class erlang_gen(gamma_gen):
     """An Erlang continuous random variable.
 
@@ -7225,7 +7224,6 @@ class binom_gen(rv_discrete):
 binom = binom_gen(name='binom')
 
 
-#XXX: cf gh-2552
 class bernoulli_gen(binom_gen):
     """A Bernoulli discrete random variable.
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -212,6 +212,16 @@ def test_cont_basic():
         x = spec_x.get(distname, 0.5)
         yield check_named_args, distfn, x, arg, locscale_defaults, meths
 
+        # this asserts the vectorization of _entropy w/ no shape parameters
+        if distfn.numargs == 0:
+            yield check_vecentropy, distfn, arg
+        # compare a generic _entropy w/ distribution-specific implementation,
+        # if available
+        if distfn.__class__._entropy != stats.rv_continuous._entropy:
+            yield check_private_entropy, distfn, arg
+        yield check_edge_support, distfn, arg
+
+
 
 @npt.dec.slow
 def test_cont_basic_slow():
@@ -255,6 +265,14 @@ def test_cont_basic_slow():
             arg = (3,)
         yield check_named_args, distfn, x, arg, locscale_defaults, meths
 
+        # this asserts the vectorization of _entropy w/ no shape parameters
+        if distfn.numargs == 0:
+            yield check_vecentropy, distfn, arg
+        # compare a generic _entropy w/ distribution-specific implementation,
+        # if available
+        if distfn.__class__._entropy == stats.rv_continuous._entropy:
+            yield check_private_entropy, distfn, arg
+        yield check_edge_support, distfn, arg
 
 def check_moment(distfn, arg, m, v, msg):
     m1 = distfn.moment(1,*arg)
@@ -416,6 +434,10 @@ def check_normalization(distfn, args, distname):
     npt.assert_allclose(norm_cdf, 1.0)
 
 
+def check_vecentropy(distfn, args):
+    npt.assert_equal( distfn.vecentropy(*args), distfn._entropy(*args) )
+
+
 def check_named_args(distfn, x, shape_args, defaults, meths):
     """Check calling w/ named arguments."""
 
@@ -454,6 +476,26 @@ def check_named_args(distfn, x, shape_args, defaults, meths):
     # unknown arguments should not go through:
     k.update({'kaboom': 42})
     npt.assert_raises(TypeError, distfn.cdf, x, **k)
+
+
+def check_edge_support(distfn, args):
+    """Make sure the x=self.a and self.b are handled correctly."""
+    x = [distfn.a, distfn.b]
+    npt.assert_equal(distfn.cdf(x, *args), [0.0, 1.0])
+    npt.assert_equal(distfn.logcdf(x, *args), [-np.inf, 0.0])
+
+    npt.assert_equal(distfn.sf(x, *args), [1.0, 0.0])
+    npt.assert_equal(distfn.logsf(x, *args), [0.0, -np.inf])
+
+    npt.assert_equal(distfn.ppf([0.0, 1.0], *args), x)
+    npt.assert_equal(distfn.isf([0.0, 1.0], *args), x[::-1])
+    # pdf(x=[a, b], *args) depends on the distribution
+
+
+def check_private_entropy(distfn, args):
+    # compare a generic _entropy with the distribution-specific implementation
+    npt.assert_allclose(distfn._entropy(*args),
+                        super(distfn.__class__, distfn)._entropy(*args))
 
 
 if __name__ == "__main__":

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -211,8 +211,10 @@ def test_cont_basic():
         yield check_named_args, distfn, x, arg, locscale_defaults, meths
 
         # this asserts the vectorization of _entropy w/ no shape parameters
+        # NB: broken for older versions of numpy
         if distfn.numargs == 0:
-            yield check_vecentropy, distfn, arg
+            if np.__version__ > '1.7':
+                yield check_vecentropy, distfn, arg
         # compare a generic _entropy w/ distribution-specific implementation,
         # if available
         if distfn.__class__._entropy != stats.rv_continuous._entropy:

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -493,10 +493,11 @@ def check_edge_support(distfn, args):
     # pdf(x=[a, b], *args) depends on the distribution
 
 
+@_silence_fp_errors
 def check_private_entropy(distfn, args):
     # compare a generic _entropy with the distribution-specific implementation
     npt.assert_allclose(distfn._entropy(*args),
-                        super(distfn.__class__, distfn)._entropy(*args))
+                        stats.rv_continuous._entropy(distfn, *args))
 
 
 if __name__ == "__main__":

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -219,6 +219,7 @@ def test_cont_basic():
         # if available
         if distfn.__class__._entropy != stats.rv_continuous._entropy:
             yield check_private_entropy, distfn, arg
+
         yield check_edge_support, distfn, arg
 
 
@@ -270,7 +271,7 @@ def test_cont_basic_slow():
             yield check_vecentropy, distfn, arg
         # compare a generic _entropy w/ distribution-specific implementation,
         # if available
-        if distfn.__class__._entropy == stats.rv_continuous._entropy:
+        if distfn.__class__._entropy != stats.rv_continuous._entropy:
             yield check_private_entropy, distfn, arg
         yield check_edge_support, distfn, arg
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -194,8 +194,6 @@ def test_cont_basic():
         yield check_cdf_ppf, distfn, arg, distname
         yield check_sf_isf, distfn, arg, distname
         yield check_pdf, distfn, arg, distname
-        if distname in ['wald']:
-            continue
         yield check_pdf_logpdf, distfn, arg, distname
         yield check_cdf_logcdf, distfn, arg, distname
         yield check_sf_logsf, distfn, arg, distname

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -80,6 +80,10 @@ def test_discrete_basic():
         yield check_named_args, distfn, k, arg, locscale_defaults, meths
         yield check_scale_docstring, distfn
 
+        # compare a generic _entropy w/ distribution-specific implementation,
+        # if available
+        if distfn.__class__._entropy != stats.rv_discrete._entropy:
+            yield check_private_entropy, distfn, arg
 
 @npt.dec.slow
 def test_discrete_extra():
@@ -338,6 +342,11 @@ def check_named_args(distfn, x, shape_args, defaults, meths):
 
 def check_scale_docstring(distfn):
     npt.assert_('scale' not in distfn.__doc__)
+
+def check_private_entropy(distfn, args):
+    # compare a generic _entropy with the distribution-specific implementation
+    npt.assert_allclose(distfn._entropy(*args),
+                        super(distfn.__class__, distfn)._entropy(*args))
 
 
 if __name__ == "__main__":

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -346,8 +346,7 @@ def check_scale_docstring(distfn):
 def check_private_entropy(distfn, args):
     # compare a generic _entropy with the distribution-specific implementation
     npt.assert_allclose(distfn._entropy(*args),
-                        super(distfn.__class__, distfn)._entropy(*args))
-
+                        stats.rv_discrete._entropy(distfn, *args))
 
 if __name__ == "__main__":
     # nose.run(argv=['', __file__])


### PR DESCRIPTION
Should close https://github.com/scipy/scipy/issues/2765.

Fix distribution-specific `_entropy` methods. Turn @josef-pkt's  and @WarrenWeckesser's  checks in https://github.com/scipy/scipy/issues/2765 into runnable tests. 

Notice I'm silencing (a lot of) floating-point warnings, which is consistent with the rest of the stats test suite. Did not check all of them, but most warnings seem to be reasonably harmless. For example, an overflow warning in `exponpow` is thrown in numpy's `expm1`, which seems to handle the overflow correctly:

```
>>> stats.exponpow.cdf(100, 2.69)
/home/br/virtualenvs/scipy-dev/local/lib/python2.7/site-packages/scipy/stats/distributions.py:3088: RuntimeWarning: overflow encountered in expm1
  return -expm1(-expm1(x**b))
1.0
```
