### PR TITLE
BUG: special/specfun: fix argument value check in KLVNZO

### DIFF
--- a/scipy/special/specfun.pyf
+++ b/scipy/special/specfun.pyf
@@ -404,7 +404,7 @@ python module specfun ! in
         end subroutine othpl
         subroutine klvnzo(nt,kd,zo) ! in :specfun:specfun.f
             integer intent(in), check(nt>0) :: nt
-            integer intent(in), check(kd>=1 || kd<=8) :: kd
+            integer intent(in), check((kd>=1)&&(kd<=8)) :: kd
             double precision intent(out), depend(nt), dimension(nt) :: zo
         end subroutine klvnzo
         ! rswfo


### PR DESCRIPTION
documentation of KLVNZO(NT,KD,ZO) in scipy/special/specfun.f
says 1<=KD<=8. Previous code resulted in always True.

gh-2718
