### PR TITLE
ENH integrate: quadrature accepts non-tuple "args" argument

### DIFF
--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -162,6 +162,8 @@ def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, maxiter=50,
     odeint: ODE integrator
 
     """
+    if not isinstance(args, tuple):
+        args = (args,)
     vfunc = vectorize1(func, args, vec_func=vec_func)
     val = np.inf
     err = np.inf


### PR DESCRIPTION
Copy quad behavior accepting a single element (integer) instead of the
expected tuple

Not sure about the necessity to change the error message mentionned in the issue, it looks clear to me

Closes gh-2044
