### PR TITLE
DOC: scipy.signal.wavelets.cwt attribute order easyfix from #2748 ticket

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -122,6 +122,7 @@ Nils Werner for signal windowing and wavfile-writing improvements.
 Kenneth L. Ho for the wrapper around the Interpolative Decomposition code.
 Juan Luis Cano for refactorings in lti, sparse docs improvements and some
     trivial fixes.
+Pawel Chojnacki for simple documentation fixes.
 
 
 Institutions

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -342,8 +342,8 @@ def cwt(data, wavelet, widths):
     Notes
     -----
     >>> length = min(10 * width[ii], len(data))
-    >>> cwt[ii,:] = scipy.signal.convolve(data, wavelet(width[ii],
-    ...                                       length), mode='same')
+    >>> cwt[ii,:] = scipy.signal.convolve(data, wavelet(length,
+    ...                                       width[ii]), mode='same')
 
     Examples
     --------


### PR DESCRIPTION
Changed
wavelet(width[ii],  length) to wavelet(length,width[ii])
as suggested in the bug #2748.
