### PR TITLE
Add advise to use nquad instead of tplquad in some situations.

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -123,6 +123,7 @@ Kenneth L. Ho for the wrapper around the Interpolative Decomposition code.
 Juan Luis Cano for refactorings in lti, sparse docs improvements and some
     trivial fixes.
 Pawel Chojnacki for simple documentation fixes.
+Pierre de Buyl for simple documentation fixes.
 
 
 Institutions

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -448,6 +448,9 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     Return the triple integral of ``func(z, y, x)`` from ``x = a..b``,
     ``y = gfun(x)..hfun(x)``, and ``z = qfun(x,y)..rfun(x,y)``.
 
+    For simple domains (bounds in x, y and z given) that involve infinities, it
+    is advised to use nquad instead.
+
     Parameters
     ----------
     func : function


### PR DESCRIPTION
Add advice not to use tplquad for infinite boundaries.

Fixes gh-1585

Example:
    import numpy as np
    from scipy.integrate import nquad

```
def fx(x,y,z):
    return np.exp(-x)
def fy(x,y,z):
    return np.exp(-y)
def fz(x,y,z):
    return np.exp(-z)
def fxyz(x,y,z):
    return np.exp(-x-y-z)

print nquad(fx, [(0,np.inf), (0,1), (0,1) ] )
print nquad(fy, [(0,1), (0,np.inf), (0,1) ] )
print nquad(fz, [(0,1), (0,1), (0,np.inf) ] )
print nquad(fxyz, [(0,np.inf), (0,np.inf), (0,np.inf) ] )
```
