### PR TITLE
Fix for scipy.stats.mstats.kurtosistest not working with 1D inputs

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -52,6 +52,7 @@ import warnings
 
 # import scipy.stats as stats
 from . import stats
+from . import distributions
 import scipy.special as special
 import scipy.misc as misc
 # import scipy.stats.futil as futil
@@ -1661,7 +1662,7 @@ def skewtest(a, axis=0):
     alpha = ma.sqrt(2.0/(W2-1))
     y = ma.where(y == 0, 1, y)
     Z = delta*ma.log(y/alpha + ma.sqrt((y/alpha)**2+1))
-    return Z, (1.0 - stats.zprob(Z))*2
+    return Z, 2 * distributions.norm.sf(np.abs(Z)) # (1.0 - stats.zprob(Z))*2
 skewtest.__doc__ = stats.skewtest.__doc__
 
 
@@ -1689,7 +1690,7 @@ def kurtosistest(a, axis=0):
             denom)
     term2 = ma.power((1-2.0/A)/denom,1/3.0)
     Z = (term1 - term2) / np.sqrt(2/(9.0*A))
-    return Z, (1.0-stats.zprob(Z))*2
+    return Z, 2 * distributions.norm.sf(np.abs(Z)) # (1.0 - stats.zprob(Z))*2
 kurtosistest.__doc__ = stats.kurtosistest.__doc__
 
 

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1667,7 +1667,7 @@ skewtest.__doc__ = stats.skewtest.__doc__
 
 def kurtosistest(a, axis=0):
     a, axis = _chk_asarray(a, axis)
-    n = a.count(axis=axis).astype(float)
+    n = a.count(axis=axis).astype(float) if a.ndim > 1 else float(a.count(axis=axis))
     if np.min(n) < 20:
         warnings.warn(
             "kurtosistest only valid for n>=20 ... continuing anyway, n=%i" %
@@ -1681,7 +1681,12 @@ def kurtosistest(a, axis=0):
     A = 6.0 + 8.0/sqrtbeta1 * (2.0/sqrtbeta1 + np.sqrt(1+4.0/(sqrtbeta1**2)))
     term1 = 1 - 2./(9.0*A)
     denom = 1 + x*ma.sqrt(2/(A-4.0))
-    denom[denom < 0] = masked
+    if a.ndim > 1:
+        denom[denom < 0] = masked
+    elif denom < 0:
+        warnings.warn(
+            "only denom value is negative ... continuing anyway, denom=%f" %
+            denom)
     term2 = ma.power((1-2.0/A)/denom,1/3.0)
     Z = (term1 - term2) / np.sqrt(2/(9.0*A))
     return Z, (1.0-stats.zprob(Z))*2

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -523,6 +523,16 @@ class TestMisc(TestCase):
         assert_almost_equal(result[1], 0.5692, 4)
 
 
+def test_normalitytests():
+    # numbers verified with R: dagoTest in package fBasics
+    st_normal, st_skew, st_kurt = (3.92371918, 1.98078826, -0.01403734)
+    pv_normal, pv_skew, pv_kurt = (0.14059673, 0.04761502, 0.98880019)
+    x = np.array((-2,-1,0,1,2,3)*4)**2
+    yield assert_array_almost_equal, mstats.normaltest(x), (st_normal, pv_normal)
+    yield assert_array_almost_equal, mstats.skewtest(x), (st_skew, pv_skew)
+    yield assert_array_almost_equal, mstats.kurtosistest(x), (st_kurt, pv_kurt)
+
+
 def test_regress_simple():
     """Regress a line with sinusoidal noise. Test for #1273."""
     x = np.linspace(0, 100, 100)


### PR DESCRIPTION
Fix for scipy.stats.mstats.kurtosistes now working with 1D inputs plus a simple normalitytest for mstats - the test is similar to the test for scipy.stats.kurtosistest
Should fix Issues gh-2186 and gh-2288.
