### PR TITLE
BUG: gh-2331 (Bode plot should return continuous phase)

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -983,7 +983,7 @@ def bode(system, w=None, n=100):
     w, y = freqresp(system, w=w, n=n)
 
     mag = 20.0 * numpy.log10(abs(y))
-    phase = numpy.arctan2(y.imag, y.real) * 180.0 / numpy.pi
+    phase = numpy.unwrap(numpy.arctan2(y.imag, y.real)) * 180.0 / numpy.pi
 
     return w, mag, phase
 

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -351,6 +351,12 @@ class Test_bode(object):
         system = lti([1], [1, 0, 100])
         w, mag, phase = bode(system, n=2)
 
+    def test_08(self):
+        """Test that bode() return continuous phase, issues/2331."""
+        system = lti([], [-10,-30,-40,-60, -70], 1)
+        w, mag, phase = system.bode(w=np.logspace(-3, 40, 100))
+        assert_equal(min(phase), -450.0)
+
     def test_from_state_space(self):
         # Ensure that bode works with a system that was created from the
         # state space representation matrices A, B, C, D.  In this case,

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -353,9 +353,9 @@ class Test_bode(object):
 
     def test_08(self):
         """Test that bode() return continuous phase, issues/2331."""
-        system = lti([], [-10,-30,-40,-60, -70], 1)
+        system = lti([], [-10, -30, -40, -60, -70], 1)
         w, mag, phase = system.bode(w=np.logspace(-3, 40, 100))
-        assert_equal(min(phase), -450.0)
+        assert_almost_equal(min(phase), -450, decimal=15)
 
     def test_from_state_space(self):
         # Ensure that bode works with a system that was created from the


### PR DESCRIPTION
BUG: gh-2331( Bode plot should return continuous phase  ) is solved and a test for the issue is added.
