### PR TITLE
Fixing unicode support for method name in linkage (Trac 1887)

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -614,7 +614,7 @@ def linkage(y, method='single', metric='euclidean'):
         The hierarchical clustering encoded as a linkage matrix.
 
     """
-    if not isinstance(method, str):
+    if not isinstance(method, string_types):
         raise TypeError("Argument 'method' must be a string.")
 
     y = _convert_to_double(np.asarray(y, order='c'))

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -40,6 +40,7 @@ import numpy as np
 from numpy.testing import TestCase, run_module_suite
 
 from scipy.lib.six.moves import xrange
+from scipy.lib.six import u
 
 from scipy.cluster.hierarchy import linkage, from_mlab_linkage, to_mlab_linkage,\
         num_obs_linkage, inconsistent, cophenet, fclusterdata, fcluster, \
@@ -144,6 +145,14 @@ class TestLinkage(TestCase):
         "Tests linkage(Y, 'weighted') on the tdist data set."
         Z = linkage(_ytdist, 'weighted')
         Zmlab = eo['linkage-weighted-tdist']
+        eps = 1e-10
+        expectedZ = from_mlab_linkage(Zmlab)
+        self.assertTrue(within_tol(Z, expectedZ, eps))
+
+    def test_linkage_with_unicode_method_name(self):
+        "Tests linkage(Y, u'single') on the tdist data set."
+        Z = linkage(_ytdist, u('single'))
+        Zmlab = eo['linkage-single-tdist']
         eps = 1e-10
         expectedZ = from_mlab_linkage(Zmlab)
         self.assertTrue(within_tol(Z, expectedZ, eps))


### PR DESCRIPTION
Simply replaced the test if isinstance(method, str) by  if isinstance(method, string_types). String_types were already imported previously and used in other places of the module.
