### PR TITLE
ENH qhull: raise a ValueError if masked array given as `points` argument

### DIFF
--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -1656,7 +1656,7 @@ class Delaunay(_QhullUser):
     def __init__(self, points, furthest_site=False, incremental=False,
                  qhull_options=None):
         if np.ma.is_masked(points):
-            raise ValueError('Input points could not be masked array.')
+            raise ValueError('Input points cannot be masked array')
         points = np.ascontiguousarray(points, dtype=np.double)
 
         if qhull_options is None:
@@ -2151,7 +2151,7 @@ class ConvexHull(_QhullUser):
 
     def __init__(self, points, incremental=False, qhull_options=None):
         if np.ma.is_masked(points):
-            raise ValueError('Input points could not be masked array.')
+            raise ValueError('Input points cannot be masked array')
         points = np.ascontiguousarray(points, dtype=np.double)
 
         if qhull_options is None:
@@ -2301,7 +2301,7 @@ class Voronoi(_QhullUser):
     def __init__(self, points, furthest_site=False, incremental=False,
                  qhull_options=None):
         if np.ma.is_masked(points):
-            raise ValueError('Input points could not be masked array.')
+            raise ValueError('Input points cannot be masked array')
         points = np.ascontiguousarray(points, dtype=np.double)
 
         if qhull_options is None:

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -1656,7 +1656,7 @@ class Delaunay(_QhullUser):
     def __init__(self, points, furthest_site=False, incremental=False,
                  qhull_options=None):
         if np.ma.is_masked(points):
-            raise ValueError('Input points cannot be masked array')
+            raise ValueError('Input points cannot be a masked array')
         points = np.ascontiguousarray(points, dtype=np.double)
 
         if qhull_options is None:
@@ -2151,7 +2151,7 @@ class ConvexHull(_QhullUser):
 
     def __init__(self, points, incremental=False, qhull_options=None):
         if np.ma.is_masked(points):
-            raise ValueError('Input points cannot be masked array')
+            raise ValueError('Input points cannot be a masked array')
         points = np.ascontiguousarray(points, dtype=np.double)
 
         if qhull_options is None:
@@ -2301,7 +2301,7 @@ class Voronoi(_QhullUser):
     def __init__(self, points, furthest_site=False, incremental=False,
                  qhull_options=None):
         if np.ma.is_masked(points):
-            raise ValueError('Input points cannot be masked array')
+            raise ValueError('Input points cannot be a masked array')
         points = np.ascontiguousarray(points, dtype=np.double)
 
         if qhull_options is None:

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -1579,6 +1579,9 @@ class Delaunay(_QhullUser):
         Raised when Qhull encounters an error condition, such as
         geometrical degeneracy when options to resolve are not enabled.
 
+    ValueError
+        Raised when a Masked array is given as points argument.
+
     Notes
     -----
     The tesselation is computed using the Qhull library [Qhull]_.
@@ -1652,6 +1655,8 @@ class Delaunay(_QhullUser):
 
     def __init__(self, points, furthest_site=False, incremental=False,
                  qhull_options=None):
+        if np.ma.is_masked(points):
+            raise ValueError('Input points could not be masked array.')
         points = np.ascontiguousarray(points, dtype=np.double)
 
         if qhull_options is None:
@@ -2108,6 +2113,9 @@ class ConvexHull(_QhullUser):
         Raised when Qhull encounters an error condition, such as
         geometrical degeneracy when options to resolve are not enabled.
 
+    ValueError
+        Raised when a Masked array is given as points argument.
+
     Notes
     -----
     The convex hull is computed using the Qhull libary [Qhull]_.
@@ -2142,6 +2150,8 @@ class ConvexHull(_QhullUser):
     """
 
     def __init__(self, points, incremental=False, qhull_options=None):
+        if np.ma.is_masked(points):
+            raise ValueError('Input points could not be masked array.')
         points = np.ascontiguousarray(points, dtype=np.double)
 
         if qhull_options is None:
@@ -2228,6 +2238,9 @@ class Voronoi(_QhullUser):
         Raised when Qhull encounters an error condition, such as
         geometrical degeneracy when options to resolve are not enabled.
 
+    ValueError
+        Raised when a Masked array is given as points argument.
+
     Notes
     -----
     The Voronoi diagram is computed using the Qhull libary [Qhull]_.
@@ -2287,6 +2300,8 @@ class Voronoi(_QhullUser):
     """
     def __init__(self, points, furthest_site=False, incremental=False,
                  qhull_options=None):
+        if np.ma.is_masked(points):
+            raise ValueError('Input points could not be masked array.')
         points = np.ascontiguousarray(points, dtype=np.double)
 
         if qhull_options is None:

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -350,6 +350,9 @@ class TestDelaunay(object):
     Check that triangulation works.
 
     """
+    def test_masked_array_fails(self):
+        masked_array = np.ma.masked_all(1)
+        assert_raises(ValueError, qhull.Delaunay, masked_array)
 
     def test_nd_simplex(self):
         # simple smoke test: triangulate a n-dimensional simplex
@@ -534,6 +537,10 @@ def assert_hulls_equal(points, facets_1, facets_2):
 
 
 class TestConvexHull:
+    def test_masked_array_fails(self):
+        masked_array = np.ma.masked_all(1)
+        assert_raises(ValueError, qhull.ConvexHull, masked_array)
+
     def test_hull_consistency_tri(self):
         # Check that a convex hull returned by qhull in ndim
         # and the hull constructed from ndim delaunay agree
@@ -598,6 +605,10 @@ class TestConvexHull:
 
 
 class TestVoronoi:
+    def test_masked_array_fails(self):
+        masked_array = np.ma.masked_all(1)
+        assert_raises(ValueError, qhull.Voronoi, masked_array)
+
     def test_simple(self):
         # Simple case with known Voronoi diagram
         points = [(0, 0), (0, 1), (0, 2),


### PR DESCRIPTION
The `points` argument should contain the points coordinates. This has
no sense in the general case using masked array. In fact points could
not be partially defined, e.g. (X, --, Z) is not a point.

Moreover, the `points` array is always converted into a contiguous
array which does not contain the mask anymore. So, computations are
performed on the whole points set, even hidden points.

Closes gh-2675
