### PR TITLE
ENH: allow optional rescaling of input coordinates in ND interpolation

### DIFF
--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -103,6 +103,63 @@ class TestLinearNDInterpolation(object):
 
         assert_almost_equal(zi, ip(xx, yy))
 
+    def test_smoketest_rescale(self):
+        # Test at single points
+        x = np.array([(0, 0), (-5, -5), (-5, 5), (5, 5), (2.5, 3)],
+                     dtype=np.double)
+        y = np.arange(x.shape[0], dtype=np.double)
+
+        yi = interpnd.LinearNDInterpolator(x, y, rescale=True)(x)
+        assert_almost_equal(y, yi)
+
+    def test_square_rescale(self):
+        # Test barycentric interpolation on a rectangle with rescaling
+        # agaings the same implementation without rescaling
+
+        points = np.array([(0,0), (0,100), (10,100), (10,0)], dtype=np.double)
+        values = np.array([1., 2., -3., 5.], dtype=np.double)
+
+        xx, yy = np.broadcast_arrays(np.linspace(0, 10, 14)[:,None],
+                                     np.linspace(0, 100, 14)[None,:])
+        xx = xx.ravel()
+        yy = yy.ravel()
+        xi = np.array([xx, yy]).T.copy()
+        zi = interpnd.LinearNDInterpolator(points, values)(xi)
+        zi_rescaled = interpnd.LinearNDInterpolator(points, values,
+                rescale=True)(xi)
+
+        assert_almost_equal(zi, zi_rescaled)
+
+    def test_tripoints_input_rescale(self):
+        # Test at single points
+        x = np.array([(0,0), (-5,-5), (-5,5), (5, 5), (2.5, 3)],
+                     dtype=np.double)
+        y = np.arange(x.shape[0], dtype=np.double)
+        y = y - 3j*y
+
+        tri = qhull.Delaunay(x)
+        yi = interpnd.LinearNDInterpolator(tri.points, y)(x)
+        yi_rescale = interpnd.LinearNDInterpolator(tri.points, y,
+                rescale=True)(x)
+        assert_almost_equal(yi, yi_rescale)
+
+    def test_tri_input_rescale(self):
+        # Test at single points
+        x = np.array([(0,0), (-5,-5), (-5,5), (5, 5), (2.5, 3)],
+                     dtype=np.double)
+        y = np.arange(x.shape[0], dtype=np.double)
+        y = y - 3j*y
+
+        tri = qhull.Delaunay(x)
+        try:
+            interpnd.LinearNDInterpolator(tri, y, rescale=True)(x)
+        except ValueError, e:
+            if (e.message != "rescaling is not supported when passing a "
+                    "Delaunay triangulation as ``points``."):
+                raise
+        except:
+            raise
+
     def test_pickle(self):
         # Test at single points
         np.random.seed(1234)
@@ -153,7 +210,7 @@ class TestEstimateGradients2DGlobal(object):
 
 class TestCloughTocher2DInterpolator(object):
 
-    def _check_accuracy(self, func, x=None, tol=1e-6, alternate=False, **kw):
+    def _check_accuracy(self, func, x=None, tol=1e-6, alternate=False, rescale=False, **kw):
         np.random.seed(1234)
         if x is None:
             x = np.array([(0, 0), (0, 1),
@@ -163,11 +220,11 @@ class TestCloughTocher2DInterpolator(object):
 
         if not alternate:
             ip = interpnd.CloughTocher2DInterpolator(x, func(x[:,0], x[:,1]),
-                                                     tol=1e-6)
+                                                     tol=1e-6, rescale=rescale)
         else:
             ip = interpnd.CloughTocher2DInterpolator((x[:,0], x[:,1]),
                                                      func(x[:,0], x[:,1]),
-                                                     tol=1e-6)
+                                                     tol=1e-6, rescale=rescale)
 
         p = np.random.rand(50, 2)
 
@@ -199,6 +256,12 @@ class TestCloughTocher2DInterpolator(object):
             self._check_accuracy(func, tol=1e-13, atol=1e-7, rtol=1e-7,
                                  alternate=True,
                                  err_msg="Function (alternate) %d" % j)
+            # check rescaling
+            self._check_accuracy(func, tol=1e-13, atol=1e-7, rtol=1e-7,
+                                 err_msg="Function (rescaled) %d" % j, rescale=True)
+            self._check_accuracy(func, tol=1e-13, atol=1e-7, rtol=1e-7,
+                                 alternate=True, rescale=True,
+                                 err_msg="Function (alternate, rescaled) %d" % j)
 
     def test_quadratic_smoketest(self):
         # Should be reasonably accurate for quadratic functions
@@ -212,6 +275,8 @@ class TestCloughTocher2DInterpolator(object):
         for j, func in enumerate(funcs):
             self._check_accuracy(func, tol=1e-9, atol=0.22, rtol=0,
                                  err_msg="Function %d" % j)
+            self._check_accuracy(func, tol=1e-9, atol=0.22, rtol=0,
+                                 err_msg="Function %d" % j, rescale=True)
 
     def test_tri_input(self):
         # Test at single points
@@ -223,6 +288,35 @@ class TestCloughTocher2DInterpolator(object):
         tri = qhull.Delaunay(x)
         yi = interpnd.CloughTocher2DInterpolator(tri, y)(x)
         assert_almost_equal(y, yi)
+
+    def test_tri_input_rescale(self):
+        # Test at single points
+        x = np.array([(0,0), (-5,-5), (-5,5), (5, 5), (2.5, 3)],
+                     dtype=np.double)
+        y = np.arange(x.shape[0], dtype=np.double)
+        y = y - 3j*y
+
+        tri = qhull.Delaunay(x)
+        try:
+            interpnd.CloughTocher2DInterpolator(tri, y, rescale=True)(x)
+        except ValueError, a:
+            if (a.message != "rescaling is not supported when passing a "
+                    "Delaunay triangulation as ``points``."):
+                raise
+        except:
+            raise
+
+    def test_tripoints_input_rescale(self):
+        # Test at single points
+        x = np.array([(0,0), (-5,-5), (-5,5), (5, 5), (2.5, 3)],
+                     dtype=np.double)
+        y = np.arange(x.shape[0], dtype=np.double)
+        y = y - 3j*y
+
+        tri = qhull.Delaunay(x)
+        yi = interpnd.CloughTocher2DInterpolator(tri.points, y)(x)
+        yi_rescale = interpnd.CloughTocher2DInterpolator(tri.points, y, rescale=True)(x)
+        assert_almost_equal(yi, yi_rescale)
 
     def test_dense(self):
         # Should be more accurate for dense meshes
@@ -241,6 +335,8 @@ class TestCloughTocher2DInterpolator(object):
         for j, func in enumerate(funcs):
             self._check_accuracy(func, x=grid, tol=1e-9, atol=5e-3, rtol=1e-2,
                                  err_msg="Function %d" % j)
+            self._check_accuracy(func, x=grid, tol=1e-9, atol=5e-3, rtol=1e-2,
+                                 err_msg="Function %d" % j, rescale=True)
 
     def test_wrong_ndim(self):
         x = np.random.randn(30, 3)


### PR DESCRIPTION
In #2191, an optional rescaling of input coordinates for NDInterpolator was suggested. This PR implements this feature for both Linear and CloughTocher interpolators in cases when `points` is _not_ an instance of `qhull.Delaunay`.
