### PR TITLE
ensure analyticity of associate Legendre function of first kind

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -122,6 +122,7 @@ Nils Werner for signal windowing and wavfile-writing improvements.
 Kenneth L. Ho for the wrapper around the Interpolative Decomposition code.
 Juan Luis Cano for refactorings in lti, sparse docs improvements and some
     trivial fixes.
+Gert-Ludwig Ingold for contributions to special functions.
 
 
 Institutions

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -293,9 +293,10 @@ These are not universal functions:
 .. autosummary::
    :toctree: generated/
 
+   clpmn    -- [+]Associated Legendre Function of the first kind for complex arguments.
    lpn      -- [+]Legendre Functions (polynomials) of the first kind
    lqn      -- [+]Legendre Functions of the second kind.
-   lpmn     -- [+]Associated Legendre Function of the first kind.
+   lpmn     -- [+]Associated Legendre Function of the first kind for real arguments.
    lqmn     -- [+]Associated Legendre Function of the second kind.
 
 Orthogonal polynomials

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -19,7 +19,7 @@ import warnings
 
 __all__ = ['agm', 'ai_zeros', 'assoc_laguerre', 'bei_zeros', 'beip_zeros',
            'ber_zeros', 'bernoulli', 'berp_zeros', 'bessel_diff_formula',
-           'bi_zeros', 'digamma', 'diric', 'ellipk', 'erf_zeros', 'erfcinv',
+           'bi_zeros', 'clpmn', 'digamma', 'diric', 'ellipk', 'erf_zeros', 'erfcinv',
            'erfinv', 'errprint', 'euler', 'fresnel_zeros',
            'fresnelc_zeros', 'fresnels_zeros', 'gamma', 'gammaln', 'h1vp',
            'h2vp', 'hankel1', 'hankel2', 'hyp0f1', 'iv', 'ivp', 'jn_zeros',
@@ -665,9 +665,57 @@ def lpmn(m,n,z):
     else:
         mp = m
     if iscomplex(z):
-        p,pd = specfun.clpmn(mp,n,real(z),imag(z))
+        raise ValueError("Argument must be real. Use clpmn instead.")
     else:
         p,pd = specfun.lpmn(mp,n,z)
+    if (m < 0):
+        p = p * fixarr
+        pd = pd * fixarr
+    return p,pd
+
+
+def clpmn(m,n,z):
+    """Associated Legendre functions of the first kind, Pmn(z) and its
+    derivative, ``Pmn'(z)`` of order m and degree n.  Returns two
+    arrays of size ``(m+1, n+1)`` containing ``Pmn(z)`` and ``Pmn'(z)`` for
+    all orders from ``0..m`` and degrees from ``0..n``.
+
+    Phase conventions are chosen according to http://dlmf.nist.gov/14.21
+    such that the function is analytic.
+
+    Parameters
+    ----------
+    m : int
+       ``|m| <= n``; the order of the Legendre function.
+    n : int
+       where ``n >= 0``; the degree of the Legendre function.  Often
+       called ``l`` (lower case L) in descriptions of the associated
+       Legendre function
+    z : float or complex
+        Input value.
+
+    Returns
+    -------
+    Pmn_z : (m+1, n+1) array
+       Values for all orders 0..m and degrees 0..n
+    Pmn_d_z : (m+1, n+1) array
+       Derivatives for all orders 0..m and degrees 0..n
+    """
+    if not isscalar(m) or (abs(m) > n):
+        raise ValueError("m must be <= n.")
+    if not isscalar(n) or (n < 0):
+        raise ValueError("n must be a non-negative integer.")
+    if not isscalar(z):
+        raise ValueError("z must be scalar.")
+    if (m < 0):
+        mp = -m
+        mf,nf = mgrid[0:mp+1,0:n+1]
+        sv = errprint(0)
+        fixarr = where(mf > nf,0.0,gamma(nf-mf+1) / gamma(nf+mf+1))
+        sv = errprint(sv)
+    else:
+        mp = m
+    p,pd = specfun.clpmn(mp,n,real(z),imag(z))
     if (m < 0):
         p = p * fixarr
         pd = pd * fixarr

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -753,6 +753,8 @@ def clpmn(m,n,z):
         raise ValueError("n must be a non-negative integer.")
     if not isscalar(z):
         raise ValueError("z must be scalar.")
+    if z.imag==0 and -1<=z.real<=1:
+        raise ValueError("z may not lie on the cut [-1, 1]. Use lpmn instead.")
     if (m < 0):
         mp = -m
         mf,nf = mgrid[0:mp+1,0:n+1]

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -753,8 +753,6 @@ def clpmn(m,n,z):
         raise ValueError("n must be a non-negative integer.")
     if not isscalar(z):
         raise ValueError("z must be scalar.")
-    if z.imag==0 and -1<=z.real<=1:
-        raise ValueError("z may not lie on the cut [-1, 1]. Use lpmn instead.")
     if (m < 0):
         mp = -m
         mf,nf = mgrid[0:mp+1,0:n+1]

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -627,10 +627,13 @@ def mathieu_odd_coef(m,q):
 
 
 def lpmn(m,n,z):
-    """Associated Legendre functions of the first kind, Pmn(z) and its
-    derivative, ``Pmn'(z)`` of order m and degree n.  Returns two
-    arrays of size ``(m+1, n+1)`` containing ``Pmn(z)`` and ``Pmn'(z)`` for
-    all orders from ``0..m`` and degrees from ``0..n``.
+    """Associated Legendre functions of the first kind, ``Pmn(z)`` and its
+    derivative, ``Pmn'(z)`` of order m and degree n for real arguments ``z``.
+    Returns two arrays of size ``(m+1, n+1)`` containing ``Pmn(z)`` and
+    ``Pmn'(z)`` for all orders from ``0..m`` and degrees from ``0..n``.
+
+    This function takes a real argument ``z``. For complex arguments ``z``
+    use clpmn instead.
 
     Parameters
     ----------
@@ -640,7 +643,7 @@ def lpmn(m,n,z):
        where ``n >= 0``; the degree of the Legendre function.  Often
        called ``l`` (lower case L) in descriptions of the associated
        Legendre function
-    z : float or complex
+    z : float 
         Input value.
 
     Returns
@@ -649,6 +652,18 @@ def lpmn(m,n,z):
        Values for all orders 0..m and degrees 0..n
     Pmn_d_z : (m+1, n+1) array
        Derivatives for all orders 0..m and degrees 0..n
+
+    Notes
+    -----
+    In the interval (-1, 1), Ferrer's function of the first kind is returned.
+    The phase convention used for the interval (1, inf) is such that the
+    result is always real.
+
+    See Also
+    --------
+    clpmn: Associated Legendre functions of the first kind for complex
+    arguments ``z``.
+    
     """
     if not isscalar(m) or (abs(m) > n):
         raise ValueError("m must be <= n.")
@@ -680,9 +695,6 @@ def clpmn(m,n,z):
     arrays of size ``(m+1, n+1)`` containing ``Pmn(z)`` and ``Pmn'(z)`` for
     all orders from ``0..m`` and degrees from ``0..n``.
 
-    Phase conventions are chosen according to http://dlmf.nist.gov/14.21
-    such that the function is analytic.
-
     Parameters
     ----------
     m : int
@@ -700,6 +712,18 @@ def clpmn(m,n,z):
        Values for all orders 0..m and degrees 0..n
     Pmn_d_z : (m+1, n+1) array
        Derivatives for all orders 0..m and degrees 0..n
+
+    Notes
+    -----
+    Phase conventions are chosen according to http://dlmf.nist.gov/14.21
+    such that the function is analytic. The cut lies on the interval (-1, 1).
+    Approaching the cut from above or below in general yields a phase factor
+    with respect to Ferrer's function of the first kind (cf. ``lpmn(m, n, z)``).
+
+    See Also
+    --------
+    lpmn: Associated Legendre functions of the first kind for real
+    arguments ``z``
     """
     if not isscalar(m) or (abs(m) > n):
         raise ValueError("m must be <= n.")

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -627,10 +627,16 @@ def mathieu_odd_coef(m,q):
 
 
 def lpmn(m,n,z):
-    """Associated Legendre functions of the first kind, ``Pmn(z)`` and its
-    derivative, ``Pmn'(z)`` of order m and degree n for real arguments ``z``.
-    Returns two arrays of size ``(m+1, n+1)`` containing ``Pmn(z)`` and
-    ``Pmn'(z)`` for all orders from ``0..m`` and degrees from ``0..n``.
+    """Associated Legendre function of the first kind, Pmn(z)
+
+    Computes the associated Legendre function of the first kind
+    of order m and degree n,::
+
+        Pmn(z) = P_n^m(z)
+
+    and its derivative, ``Pmn'(z)``.  Returns two arrays of size
+    ``(m+1, n+1)`` containing ``Pmn(z)`` and ``Pmn'(z)`` for all
+    orders from ``0..m`` and degrees from ``0..n``.
 
     This function takes a real argument ``z``. For complex arguments ``z``
     use clpmn instead.
@@ -653,16 +659,20 @@ def lpmn(m,n,z):
     Pmn_d_z : (m+1, n+1) array
        Derivatives for all orders 0..m and degrees 0..n
 
-    Notes
-    -----
-    In the interval (-1, 1), Ferrer's function of the first kind is returned.
-    The phase convention used for the interval (1, inf) is such that the
-    result is always real.
-
     See Also
     --------
-    clpmn: Associated Legendre functions of the first kind for complex
-    arguments ``z``.
+    clpmn: associated Legendre functions of the first kind for complex z
+
+    Notes
+    -----
+    In the interval (-1, 1), Ferrer's function of the first kind is
+    returned. The phase convention used for the intervals (1, inf)
+    and (-inf, -1) is such that the result is always real.
+
+    References
+    ----------
+    .. [1] NIST Digital Library of Mathematical Functions
+           http://dlmf.nist.gov/14.3
     
     """
     if not isscalar(m) or (abs(m) > n):
@@ -690,10 +700,16 @@ def lpmn(m,n,z):
 
 
 def clpmn(m,n,z):
-    """Associated Legendre functions of the first kind, Pmn(z) and its
-    derivative, ``Pmn'(z)`` of order m and degree n.  Returns two
-    arrays of size ``(m+1, n+1)`` containing ``Pmn(z)`` and ``Pmn'(z)`` for
-    all orders from ``0..m`` and degrees from ``0..n``.
+    """Associated Legendre function of the first kind, Pmn(z)
+
+    Computes the (associated) Legendre function of the first kind
+    of order m and degree n,::
+
+        Pmn(z) = P_n^m(z)
+
+    and its derivative, ``Pmn'(z)``.  Returns two arrays of size
+    ``(m+1, n+1)`` containing ``Pmn(z)`` and ``Pmn'(z)`` for all
+    orders from ``0..m`` and degrees from ``0..n``.
 
     Parameters
     ----------
@@ -713,17 +729,23 @@ def clpmn(m,n,z):
     Pmn_d_z : (m+1, n+1) array
        Derivatives for all orders 0..m and degrees 0..n
 
-    Notes
-    -----
-    Phase conventions are chosen according to http://dlmf.nist.gov/14.21
-    such that the function is analytic. The cut lies on the interval (-1, 1).
-    Approaching the cut from above or below in general yields a phase factor
-    with respect to Ferrer's function of the first kind (cf. ``lpmn(m, n, z)``).
-
     See Also
     --------
-    lpmn: Associated Legendre functions of the first kind for real
-    arguments ``z``
+    lpmn: associated Legendre functions of the first kind for real z
+
+    Notes
+    -----
+    Phase conventions are chosen according to [1] such that the
+    function is analytic. The cut lies on the interval (-1, 1).
+    Approaching the cut from above or below in general yields a phase
+    factor with respect to Ferrer's function of the first kind
+    (cf. `lpmn`).
+
+    References
+    ----------
+    .. [1] NIST Digital Library of Mathematical Functions
+           http://dlmf.nist.gov/14.21
+
     """
     if not isscalar(m) or (abs(m) > n):
         raise ValueError("m must be <= n.")

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -266,10 +266,6 @@ C
 20         CONTINUE
            RETURN
         ENDIF
-C       LS=1
-C       IF (CDABS(Z).GT.1.0D0) LS=-1
-C       ZQ=CDSQRT(LS*(1.0D0-Z*Z))
-C       ZS=LS*(1.0D0-Z*Z)
         ZQ=CDSQRT(Z*Z-1.0D0)
         ZS=(Z*Z-1.0D0)
         DO 25 I=1,M
@@ -287,7 +283,6 @@ C       DLMF 14.10.3
         CPD(0,0)=(0.0D0,0.0D0)
         DO 40 J=1,N
 C       DLMF 14.10.5
-C 40         CPD(0,J)=LS*J*(CPM(0,J-1)-Z*CPM(0,J))/ZS
 40         CPD(0,J)=J*(Z*CPM(0,J)-CPM(0,J-1))/ZS
         DO 45 I=1,M
         DO 45 J=I,N

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -266,7 +266,11 @@ C
 20         CONTINUE
            RETURN
         ENDIF
+C       sqrt(z^2 - 1) with branch cut between [-1, 1]
         ZQ=CDSQRT(Z*Z-1.0D0)
+        IF (X.LT.0d0) THEN
+           ZQ=-ZQ
+        END IF
         ZS=(Z*Z-1.0D0)
         DO 25 I=1,M
 C       DLMF 14.7.15
@@ -6991,6 +6995,8 @@ C
         LS=1
         IF (DABS(X).GT.1.0D0) LS=-1
         XQ=DSQRT(LS*(1.0D0-X*X))
+C       Ensure connection to the complex-valued function for |x| > 1
+        IF (X.LT.-1d0) XQ=-XQ
         XS=LS*(1.0D0-X*X)
         DO 30 I=1,M
 30         PM(I,I)=-LS*(2.0D0*I-1.0D0)*XQ*PM(I-1,I-1)

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -266,25 +266,33 @@ C
 20         CONTINUE
            RETURN
         ENDIF
-        LS=1
-        IF (CDABS(Z).GT.1.0D0) LS=-1
-        ZQ=CDSQRT(LS*(1.0D0-Z*Z))
-        ZS=LS*(1.0D0-Z*Z)
+C       LS=1
+C       IF (CDABS(Z).GT.1.0D0) LS=-1
+C       ZQ=CDSQRT(LS*(1.0D0-Z*Z))
+C       ZS=LS*(1.0D0-Z*Z)
+        ZQ=CDSQRT(Z*Z-1.0D0)
+        ZS=(Z*Z-1.0D0)
         DO 25 I=1,M
-25         CPM(I,I)=-LS*(2.0D0*I-1.0D0)*ZQ*CPM(I-1,I-1)
+C       DLMF 14.7.15
+25         CPM(I,I)=(2.0D0*I-1.0D0)*ZQ*CPM(I-1,I-1)
         DO 30 I=0,MIN(M,N-1)
+C       DLMF 14.10.7
 30         CPM(I,I+1)=(2.0D0*I+1.0D0)*Z*CPM(I,I)
         DO 35 I=0,M
         DO 35 J=I+2,N
+C       DLMF 14.10.3
            CPM(I,J)=((2.0D0*J-1.0D0)*Z*CPM(I,J-1)-(I+J-
      &              1.0D0)*CPM(I,J-2))/(J-I)
 35      CONTINUE
         CPD(0,0)=(0.0D0,0.0D0)
         DO 40 J=1,N
-40         CPD(0,J)=LS*J*(CPM(0,J-1)-Z*CPM(0,J))/ZS
+C       DLMF 14.10.5
+C 40         CPD(0,J)=LS*J*(CPM(0,J-1)-Z*CPM(0,J))/ZS
+40         CPD(0,J)=J*(Z*CPM(0,J)-CPM(0,J-1))/ZS
         DO 45 I=1,M
         DO 45 J=I,N
-           CPD(I,J)=LS*I*Z*CPM(I,J)/ZS+(J+I)*(J-I+1.0D0)
+C       derivative of DLMF 14.7.11 & DLMF 14.10.6
+           CPD(I,J)=-I*Z*CPM(I,J)/ZS+(J+I)*(J-I+1.0D0)
      &              /ZQ*CPM(I-1,J)
 45      CONTINUE
         RETURN

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -6955,7 +6955,8 @@ C       **********************************
 C
 C       =====================================================
 C       Purpose: Compute the associated Legendre functions
-C                Pmn(x) and their derivatives Pmn'(x)
+C                Pmn(x) and their derivatives Pmn'(x) for
+C                real argument
 C       Input :  x  --- Argument of Pmn(x)
 C                m  --- Order of Pmn(x),  m = 0,1,2,...,n
 C                n  --- Degree of Pmn(x), n = 0,1,2,...,N

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -268,7 +268,7 @@ C
         ENDIF
 C       sqrt(z^2 - 1) with branch cut between [-1, 1]
         ZQ=CDSQRT(Z*Z-1.0D0)
-        IF (X.LT.0d0) THEN
+        IF (X.LT.0D0) THEN
            ZQ=-ZQ
         END IF
         ZS=(Z*Z-1.0D0)
@@ -6996,7 +6996,7 @@ C
         IF (DABS(X).GT.1.0D0) LS=-1
         XQ=DSQRT(LS*(1.0D0-X*X))
 C       Ensure connection to the complex-valued function for |x| > 1
-        IF (X.LT.-1d0) XQ=-XQ
+        IF (X.LT.-1D0) XQ=-XQ
         XS=LS*(1.0D0-X*X)
         DO 30 I=1,M
 30         PM(I,I)=-LS*(2.0D0*I-1.0D0)*XQ*PM(I-1,I-1)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2337,15 +2337,36 @@ class TestLog1p(TestCase):
 
 class TestLegendreFunctions(TestCase):
     def test_clpmn(self):
-        clp = special.specfun.clpmn(1, 1, 0.5, 0.3)
-        assert_array_almost_equal(clp,(array([[1.0000,
-                                                0.5+0.3j],
-                                              [0.0000,
-                                                -0.9305815721+0.1611895232j]]),
-                                       array([[0.0000,
-                                                1.0000],
-                                              [0.0000,
-                                                0.4674335183+0.4033449589j]])),7)
+        z = 0.5+0.3j
+        clp = special.clpmn(2, 2, z)
+        assert_array_almost_equal(clp,
+                   (array([[1.0000, z, 0.5*(3*z*z-1)],
+                           [0.0000, sqrt(z*z-1), 3*z*sqrt(z*z-1)],
+                           [0.0000, 0.0000, 3*(z*z-1)]]),
+                    array([[0.0000, 1.0000, 3*z],
+                           [0.0000, z/sqrt(z*z-1), 3*(2*z*z-1)/sqrt(z*z-1)],
+                           [0.0000, 0.0000, 6*z]]))
+                       ,7)
+
+    def test_clpmn_close_to_real(self):
+        eps = 1e-10
+        m = 1
+        n = 3
+        x = 0.5
+        clp_plus = special.clpmn(m, n, x+1j*eps)[0][m, n]
+        clp_minus = special.clpmn(m, n, x-1j*eps)[0][m, n]
+        assert_array_almost_equal(array([clp_plus, clp_minus]),
+                                  array([special.lpmv(m, n, x)*np.exp(-0.5j*m*np.pi),
+                                         special.lpmv(m, n, x)*np.exp(0.5j*m*np.pi)])
+                                  ,7)
+
+    def test_clpmn_across_unit_circle(self):
+        eps = 1e-7
+        m = 1
+        n = 1
+        x = 1j
+        assert_almost_equal(special.clpmn(m, n, x+1j*eps)[0][m, n],
+                            special.clpmn(m, n, x-1j*eps)[0][m, n], 6)
 
     def test_lpmn(self):
         lp = special.lpmn(0,2,.5)

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1362,7 +1362,7 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
         def lpnm(n, m, z):
             if m > n:
                 return 0.0
-            return sc.lpmn(m, n, z)[0][-1,-1]
+            return sc.clpmn(m, n, z)[0][-1,-1]
 
         def legenp(n, m, z):
             if abs(z) < 1e-15:

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1357,9 +1357,8 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             legenp,
                             [IntArg(0, 100), IntArg(0, 100), Arg(-1, 1)])
 
-    @knownfailure_overridable("wrong function at |z| > 1 (Trac #1877)")
     def test_legenp_complex(self):
-        def lpnm(n, m, z):
+        def clpnm(n, m, z):
             if m > n:
                 return 0.0
             return sc.clpmn(m, n, z)[0][-1,-1]
@@ -1370,7 +1369,7 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                 return np.nan
             return _exception_to_nan(mpmath.legenp)(int(n.real), int(m.real), **HYPERKW)
 
-        assert_mpmath_equal(lpnm,
+        assert_mpmath_equal(clpnm,
                             legenp,
                             [IntArg(0, 100), IntArg(0, 100), ComplexArg()])
 


### PR DESCRIPTION
gh-2396 discusses the problem of phase factors in the Legendre function for complex arguments. In fact, the Legendre function of the first kind as it is implemented, exhibits phase jumps on the unit circle (cf. figure in https://github.com/scipy/scipy/pull/482#issuecomment-15509462) and thus is not analytic. This pull request proposes to introduce a new function `clpmn` which provides an analytic associated Legendre function of the first kind. The existing function `lpmn` in the new version raises an exception if used for complex arguments. The present implementation follows the conventions stated in http://dlmf.nist.gov/14.21 with a cut on the interval `(-inf,1]`. Some tests have been added to `test_basic.py` focusing on the behavior close to the real axis and close to the unit circle. The latter tests the absence of phase jumps which were present before. Also, one test in `test_mpmath.py` has been adapted to the new function.

If the code proposed here is accepted, the documentation needs to be adapted. In particular, it should point out the existence of a phase factor with respect to Ferrer's function of the first kind as the real axis is approached (cf. http://dlmf.nist.gov/14.23#E1). Furthermore, a corresponding implementation for the associated Legendre polynomial of the second kind will be needed. This could go into a new function `clqmn`.
