### PR TITLE
BUG: handle array_like input in stats.circ* functions.  Closes gh-2062.

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1474,6 +1474,15 @@ def pdf_fromgamma(g1,g2,g3=0.0,g4=None):
     return thefunc
 
 
+def _circfuncs_common(samples, high, low):
+    samples = np.asarray(samples)
+    if samples.size == 0:
+        return np.nan, np.nan
+
+    ang = (samples - low)*2*pi / (high-low)
+    return samples, ang
+
+
 def circmean(samples, high=2*pi, low=0, axis=None):
     """
     Compute the circular mean for samples in a range.
@@ -1496,13 +1505,14 @@ def circmean(samples, high=2*pi, low=0, axis=None):
         Circular mean.
 
     """
-    ang = (samples - low)*2*pi / (high-low)
+    samples, ang = _circfuncs_common(samples, high, low)
     res = angle(np.mean(exp(1j*ang), axis=axis))
     mask = res < 0
     if (mask.ndim > 0):
         res[mask] += 2*pi
     elif mask:
         res = res + 2*pi
+
     return res*(high-low)/2.0/pi + low
 
 
@@ -1533,7 +1543,7 @@ def circvar(samples, high=2*pi, low=0, axis=None):
     angles returns a number close to the 'linear' variance.
 
     """
-    ang = (samples - low)*2*pi / (high-low)
+    samples, ang = _circfuncs_common(samples, high, low)
     res = np.mean(exp(1j*ang), axis=axis)
     R = abs(res)
     return ((high-low)/2.0/pi)**2 * 2 * log(1/R)
@@ -1568,7 +1578,7 @@ def circstd(samples, high=2*pi, low=0, axis=None):
     small angles returns a number close to the 'linear' standard deviation.
 
     """
-    ang = (samples - low)*2*pi / (high-low)
+    samples, ang = _circfuncs_common(samples, high, low)
     res = np.mean(exp(1j*ang), axis=axis)
     R = abs(res)
     return ((high-low)/2.0/pi) * sqrt(-2*log(R))

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -420,87 +420,95 @@ def test_boxcox_bad_arg():
     assert_raises(ValueError, stats.boxcox, x)
 
 
-def test_circstats():
-    x = np.array([355,5,2,359,10,350])
-    M = stats.circmean(x, high=360)
-    Mval = 0.167690146
-    assert_allclose(M, Mval, rtol=1e-7)
+class TestCircFuncs(TestCase):
+    def test_circfuncs(self):
+        x = np.array([355,5,2,359,10,350])
+        M = stats.circmean(x, high=360)
+        Mval = 0.167690146
+        assert_allclose(M, Mval, rtol=1e-7)
 
-    V = stats.circvar(x, high=360)
-    Vval = 42.51955609
-    assert_allclose(V, Vval, rtol=1e-7)
+        V = stats.circvar(x, high=360)
+        Vval = 42.51955609
+        assert_allclose(V, Vval, rtol=1e-7)
 
-    S = stats.circstd(x, high=360)
-    Sval = 6.520702116
-    assert_allclose(S, Sval, rtol=1e-7)
+        S = stats.circstd(x, high=360)
+        Sval = 6.520702116
+        assert_allclose(S, Sval, rtol=1e-7)
 
+    def test_circfuncs_small(self):
+        x = np.array([20,21,22,18,19,20.5,19.2])
+        M1 = x.mean()
+        M2 = stats.circmean(x, high=360)
+        assert_allclose(M2, M1, rtol=1e-5)
 
-def test_circmean_axis():
-    x = np.array([[355,5,2,359,10,350],
-                  [351,7,4,352,9,349],
-                  [357,9,8,358,4,356]])
-    M1 = stats.circmean(x, high=360)
-    M2 = stats.circmean(x.ravel(), high=360)
-    assert_allclose(M1, M2, rtol=1e-14)
+        V1 = x.var()
+        V2 = stats.circvar(x, high=360)
+        assert_allclose(V2, V1, rtol=1e-4)
 
-    M1 = stats.circmean(x, high=360, axis=1)
-    M2 = [stats.circmean(x[i], high=360) for i in range(x.shape[0])]
-    assert_allclose(M1, M2, rtol=1e-14)
+        S1 = x.std()
+        S2 = stats.circstd(x, high=360)
+        assert_allclose(S2, S1, rtol=1e-4)
 
-    M1 = stats.circmean(x, high=360, axis=0)
-    M2 = [stats.circmean(x[:,i], high=360) for i in range(x.shape[1])]
-    assert_allclose(M1, M2, rtol=1e-14)
+    def test_circmean_axis(self):
+        x = np.array([[355,5,2,359,10,350],
+                      [351,7,4,352,9,349],
+                      [357,9,8,358,4,356]])
+        M1 = stats.circmean(x, high=360)
+        M2 = stats.circmean(x.ravel(), high=360)
+        assert_allclose(M1, M2, rtol=1e-14)
 
+        M1 = stats.circmean(x, high=360, axis=1)
+        M2 = [stats.circmean(x[i], high=360) for i in range(x.shape[0])]
+        assert_allclose(M1, M2, rtol=1e-14)
 
-def test_circvar_axis():
-    x = np.array([[355,5,2,359,10,350],
-                  [351,7,4,352,9,349],
-                  [357,9,8,358,4,356]])
+        M1 = stats.circmean(x, high=360, axis=0)
+        M2 = [stats.circmean(x[:,i], high=360) for i in range(x.shape[1])]
+        assert_allclose(M1, M2, rtol=1e-14)
 
-    V1 = stats.circvar(x, high=360)
-    V2 = stats.circvar(x.ravel(), high=360)
-    assert_allclose(V1, V2, rtol=1e-11)
-
-    V1 = stats.circvar(x, high=360, axis=1)
-    V2 = [stats.circvar(x[i], high=360) for i in range(x.shape[0])]
-    assert_allclose(V1, V2, rtol=1e-11)
-
-    V1 = stats.circvar(x, high=360, axis=0)
-    V2 = [stats.circvar(x[:,i], high=360) for i in range(x.shape[1])]
-    assert_allclose(V1, V2, rtol=1e-11)
-
-
-def test_circstd_axis():
-    x = np.array([[355,5,2,359,10,350],
-                  [351,7,4,352,9,349],
+    def test_circvar_axis(self):
+        x = np.array([[355,5,2,359,10,350],
+                      [351,7,4,352,9,349],
                   [357,9,8,358,4,356]])
 
-    S1 = stats.circstd(x, high=360)
-    S2 = stats.circstd(x.ravel(), high=360)
-    assert_allclose(S1, S2, rtol=1e-11)
+        V1 = stats.circvar(x, high=360)
+        V2 = stats.circvar(x.ravel(), high=360)
+        assert_allclose(V1, V2, rtol=1e-11)
 
-    S1 = stats.circstd(x, high=360, axis=1)
-    S2 = [stats.circstd(x[i], high=360) for i in range(x.shape[0])]
-    assert_allclose(S1, S2, rtol=1e-11)
+        V1 = stats.circvar(x, high=360, axis=1)
+        V2 = [stats.circvar(x[i], high=360) for i in range(x.shape[0])]
+        assert_allclose(V1, V2, rtol=1e-11)
 
-    S1 = stats.circstd(x, high=360, axis=0)
-    S2 = [stats.circstd(x[:,i], high=360) for i in range(x.shape[1])]
-    assert_allclose(S1, S2, rtol=1e-11)
+        V1 = stats.circvar(x, high=360, axis=0)
+        V2 = [stats.circvar(x[:,i], high=360) for i in range(x.shape[1])]
+        assert_allclose(V1, V2, rtol=1e-11)
 
+    def test_circstd_axis(self):
+        x = np.array([[355,5,2,359,10,350],
+                      [351,7,4,352,9,349],
+                      [357,9,8,358,4,356]])
 
-def test_circstats_small():
-    x = np.array([20,21,22,18,19,20.5,19.2])
-    M1 = x.mean()
-    M2 = stats.circmean(x, high=360)
-    assert_allclose(M2, M1, rtol=1e-5)
+        S1 = stats.circstd(x, high=360)
+        S2 = stats.circstd(x.ravel(), high=360)
+        assert_allclose(S1, S2, rtol=1e-11)
 
-    V1 = x.var()
-    V2 = stats.circvar(x, high=360)
-    assert_allclose(V2, V1, rtol=1e-4)
+        S1 = stats.circstd(x, high=360, axis=1)
+        S2 = [stats.circstd(x[i], high=360) for i in range(x.shape[0])]
+        assert_allclose(S1, S2, rtol=1e-11)
 
-    S1 = x.std()
-    S2 = stats.circstd(x, high=360)
-    assert_allclose(S2, S1, rtol=1e-4)
+        S1 = stats.circstd(x, high=360, axis=0)
+        S2 = [stats.circstd(x[:,i], high=360) for i in range(x.shape[1])]
+        assert_allclose(S1, S2, rtol=1e-11)
+
+    def test_circfuncs_array_like(self):
+        x = [355,5,2,359,10,350]
+        assert_allclose(stats.circmean(x, high=360), 0.167690146, rtol=1e-7)
+        assert_allclose(stats.circvar(x, high=360), 42.51955609, rtol=1e-7)
+        assert_allclose(stats.circstd(x, high=360), 6.520702116, rtol=1e-7)
+
+    def test_empty(self):
+        assert_(np.isnan(stats.circmean([])))
+        assert_(np.isnan(stats.circstd([])))
+        assert_(np.isnan(stats.circvar([])))
 
 
 def test_accuracy_wilcoxon():


### PR DESCRIPTION
Also add test for empty input, return nans.
