### PR TITLE
BUG: eval_hermite overflows early and h_roots are inaccurate at high order (#1991)

### DIFF
--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -87,6 +87,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy import all, any, exp, inf, pi, sqrt
 from numpy.dual import eig
+from scipy import linalg
 
 # Local imports.
 from . import _ufuncs as cephes
@@ -382,6 +383,38 @@ def laguerre(n, monic=0):
 
 
 # Hermite  1                         H_n(x)
+def _h_gen_roots_and_weights(n, mu, factor, func):
+    """Compute the roots and weights for Gaussian-Hermite quadrature.
+    Internal function.
+    """
+    if n < 1:
+        raise ValueError("n must be positive.")
+    
+    bn = np.sqrt(np.arange(1,n, dtype=np.float64)/factor)
+    c = np.diag(bn, -1)
+    x = linalg.eigvalsh(c, overwrite_a=True)
+
+    # improve roots by one application of Newton's method
+    dy = func(n, x)
+    df = factor*n*func(n-1, x)
+    x -= dy/df
+
+    df /= df.max()
+    w = 1 / (df * df)
+
+    # symmetrize
+    w = (w + w[::-1])/2
+    x = (x - x[::-1])/2
+
+    # scale w correctly
+    w *= np.sqrt(2.0*np.pi/factor) / w.sum()
+
+    if mu:
+        return [x, w, mu]
+    else:
+        return x, w
+ 
+
 def h_roots(n, mu=0):
     """[x,w] = h_roots(n)
 
@@ -389,18 +422,8 @@ def h_roots(n, mu=0):
     H_n(x), and weights (w) to use in Gaussian Quadrature over
     [-inf,inf] with weighting function exp(-x**2).
     """
-    if n < 1:
-        raise ValueError("n must be positive.")
-
-    sbn_H = lambda k: sqrt(k/2)  # from recurrence relation
-    an_H = lambda k: 0*k
-    mu0 = sqrt(pi)               # integral of weight over interval
-    val = gen_roots_and_weights(n,an_H,sbn_H,mu0)
-    if mu:
-        return val + [mu0]
-    else:
-        return val
-
+    return _h_gen_roots_and_weights(n, mu, 2.0, cephes.eval_hermite)
+   
 
 def hermite(n, monic=0):
     """Return the nth order Hermite polynomial, H_n(x), orthogonal over
@@ -433,17 +456,7 @@ def he_roots(n, mu=0):
     He_n(x), and weights (w) to use in Gaussian Quadrature over
     [-inf,inf] with weighting function exp(-(x/2)**2).
     """
-    if n < 1:
-        raise ValueError("n must be positive.")
-
-    sbn_He = lambda k: sqrt(k)   # from recurrence relation
-    an_He = lambda k: 0*k
-    mu0 = sqrt(2*pi)             # integral of weight over interval
-    val = gen_roots_and_weights(n,an_He,sbn_He,mu0)
-    if mu:
-        return val + [mu0]
-    else:
-        return val
+    return _h_gen_roots_and_weights(n, mu, 1.0, cephes.eval_hermitenorm)
 
 
 def hermitenorm(n, monic=0):

--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -468,26 +468,33 @@ cdef inline double eval_laguerre_l(long n, double x) nogil:
     return eval_genlaguerre_l(n, 0., x)
 
 #-----------------------------------------------------------------------------
+# Hermite (statistician's)
+#-----------------------------------------------------------------------------
+
+cdef inline double eval_hermitenorm(long n, double x) nogil:
+    cdef long k
+    cdef double y1, y2, y3
+
+    if n < 0:
+        return 0.0
+    elif n == 0:
+        return 1.0
+    elif n == 1:
+        return x
+    else:
+        y3 = 0.0
+        y2 = 1.0
+        for k in range(n, 1, -1):
+            y1 = x*y2 - k*y3
+            y3 = y2
+            y2 = y1
+        return x*y2 - y3
+
+#-----------------------------------------------------------------------------
 # Hermite (physicist's)
 #-----------------------------------------------------------------------------
 
 @cython.cdivision(True)
 cdef inline double eval_hermite(long n, double x) nogil:
-    cdef long m
+    return eval_hermitenorm(n, sqrt(2)*x) * 2**(n/2.0)
 
-    if n % 2 == 0:
-        m = n/2
-        return ((-1)**m * 2**(2*m) * Gamma(1+m)
-                 * eval_genlaguerre_l(m, -0.5, x**2))
-    else:
-        m = (n-1)/2
-        return ((-1)**m * 2**(2*m+1) * Gamma(1+m)
-                  * x * eval_genlaguerre_l(m, 0.5, x**2))
-
-#-----------------------------------------------------------------------------
-# Hermite (statistician's)
-#-----------------------------------------------------------------------------
-
-@cython.cdivision(True)
-cdef inline double eval_hermitenorm(long n, double x) nogil:
-    return eval_hermite(n, x/sqrt(2)) * 2**(-n/2.0)

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -6,7 +6,7 @@ from scipy.lib.six.moves import xrange
 import numpy as np
 from numpy import array, sqrt
 import scipy.special.orthogonal as orth
-from scipy.special import gamma
+from scipy.special import gamma, eval_hermite
 
 
 class TestCheby(TestCase):
@@ -133,6 +133,22 @@ class TestHermite(TestCase):
         assert_array_almost_equal(H3.c,he3.c,13)
         assert_array_almost_equal(H4.c,he4.c,13)
         assert_array_almost_equal(H5.c,he5.c,13)
+
+    def test_h_roots(self):
+        # this test is copied from numpy's TestGauss in test_hermite.py
+        x, w = orth.h_roots(100)
+
+        n = np.arange(100)
+        v = eval_hermite(n[:, np.newaxis], x[np.newaxis,:])
+        vv = np.dot(v*w, v.T)
+        vd = 1 / np.sqrt(vv.diagonal())
+        vv = vd[:, np.newaxis] * vv * vd
+        assert_almost_equal(vv, np.eye(100))
+
+        # check that the integral of 1 is correct
+        assert_almost_equal(w.sum(), np.sqrt(np.pi))
+
+
 
 
 class _test_sh_legendre(TestCase):

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_
+from numpy.testing import assert_, assert_allclose
 import scipy.special.orthogonal as orth
 
 from scipy.special._testutils import FuncData
@@ -235,3 +235,10 @@ class TestRecurrence(object):
     def test_laguerre(self):
         self.check_poly(orth.eval_laguerre,
                    param_ranges=[], x_range=[0, 100])
+
+    def test_hermite(self):
+        v =  orth.eval_hermite(70, 1.0)
+        a = -1.457076485701412e60 
+        assert_allclose(v,a)
+
+        


### PR DESCRIPTION
Fixes #1991. 

The h_roots changes are just those described in #1991 by @charris.  After this h_roots returns the same roots and weights as numpy.polynomial.hermite.hermgauss. 

The changes to eval_hermite allow evaluating higher order polynomials than were possible using the relationship to the laguerre polynomials.
