### PR TITLE
add derivatives to bivariate splines

### DIFF
--- a/scipy/interpolate/fitpack/pardeu.f
+++ b/scipy/interpolate/fitpack/pardeu.f
@@ -1,0 +1,158 @@
+      subroutine pardeu(tx,nx,ty,ny,c,kx,ky,nux,nuy,x,y,z,m,
+     * wrk,lwrk,iwrk,kwrk,ier)
+c  subroutine pardeu evaluates on a set of points (x(i),y(i)),i=1,...,m
+c  the partial derivative ( order nux,nuy) of a bivariate spline
+c  s(x,y) of degrees kx and ky, given in the b-spline representation.
+c
+c  calling sequence:
+c     call parder(tx,nx,ty,ny,c,kx,ky,nux,nuy,x,mx,y,my,z,wrk,lwrk,
+c    * iwrk,kwrk,ier)
+c
+c  input parameters:
+c   tx    : real array, length nx, which contains the position of the
+c           knots in the x-direction.
+c   nx    : integer, giving the total number of knots in the x-direction
+c   ty    : real array, length ny, which contains the position of the
+c           knots in the y-direction.
+c   ny    : integer, giving the total number of knots in the y-direction
+c   c     : real array, length (nx-kx-1)*(ny-ky-1), which contains the
+c           b-spline coefficients.
+c   kx,ky : integer values, giving the degrees of the spline.
+c   nux   : integer values, specifying the order of the partial
+c   nuy     derivative. 0<=nux<kx, 0<=nuy<ky.
+c   kx,ky : integer values, giving the degrees of the spline.
+c   x     : real array of dimension (mx).
+c   y     : real array of dimension (my).
+c   m     : on entry m must specify the number points. m >= 1.
+c   wrk   : real array of dimension lwrk. used as workspace.
+c   lwrk  : integer, specifying the dimension of wrk.
+c           lwrk >= mx*(kx+1-nux)+my*(ky+1-nuy)+(nx-kx-1)*(ny-ky-1)
+c   iwrk  : integer array of dimension kwrk. used as workspace.
+c   kwrk  : integer, specifying the dimension of iwrk. kwrk >= mx+my.
+c
+c  output parameters:
+c   z     : real array of dimension (m).
+c           on succesful exit z(i) contains the value of the
+c           specified partial derivative of s(x,y) at the point
+c           (x(i),y(i)),i=1,...,m.
+c   ier   : integer error flag
+c   ier=0 : normal return
+c   ier=10: invalid input data (see restrictions)
+c
+c  restrictions:
+c   lwrk>=m*(kx+1-nux)+m*(ky+1-nuy)+(nx-kx-1)*(ny-ky-1),
+c
+c  other subroutines required:
+c    fpbisp,fpbspl
+c
+c  references :
+c    de boor c : on calculating with b-splines, j. approximation theory
+c                6 (1972) 50-62.
+c   dierckx p. : curve and surface fitting with splines, monographs on
+c                numerical analysis, oxford university press, 1993.
+c
+c  author :
+c    p.dierckx
+c    dept. computer science, k.u.leuven
+c    celestijnenlaan 200a, b-3001 heverlee, belgium.
+c    e-mail : Paul.Dierckx@cs.kuleuven.ac.be
+c
+c  latest update : march 1989
+c
+c  ..scalar arguments..
+      integer nx,ny,kx,ky,m,lwrk,kwrk,ier,nux,nuy
+c  ..array arguments..
+      integer iwrk(kwrk)
+      real*8 tx(nx),ty(ny),c((nx-kx-1)*(ny-ky-1)),x(m),y(m),z(m),
+     * wrk(lwrk)
+c  ..local scalars..
+      integer i,iwx,iwy,j,kkx,kky,kx1,ky1,lx,ly,lwest,l1,l2,mm,m0,m1,
+     * nc,nkx1,nky1,nxx,nyy,iw
+      real*8 ak,fac
+c  ..
+c  before starting computations a data check is made. if the input data
+c  are invalid control is immediately repassed to the calling program.
+      ier = 10
+      kx1 = kx+1
+      ky1 = ky+1
+      nkx1 = nx-kx1
+      nky1 = ny-ky1
+      nc = nkx1*nky1
+      if(nux.lt.0 .or. nux.ge.kx) go to 400
+      if(nuy.lt.0 .or. nuy.ge.ky) go to 400
+      lwest = nc +(kx1-nux)*m+(ky1-nuy)*m
+      if(lwrk.lt.lwest) go to 400
+      if(kwrk.lt.(m+m)) go to 400
+      if (m.lt.1) go to 400
+  60  ier = 0
+      nxx = nkx1
+      nyy = nky1
+      kkx = kx
+      kky = ky
+c  the partial derivative of order (nux,nuy) of a bivariate spline of
+c  degrees kx,ky is a bivariate spline of degrees kx-nux,ky-nuy.
+c  we calculate the b-spline coefficients of this spline
+      do 70 i=1,nc
+        wrk(i) = c(i)
+  70  continue
+      if(nux.eq.0) go to 200
+      lx = 1
+      do 100 j=1,nux
+        ak = kkx
+        nxx = nxx-1
+        l1 = lx
+        m0 = 1
+        do 90 i=1,nxx
+          l1 = l1+1
+          l2 = l1+kkx
+          fac = tx(l2)-tx(l1)
+          if(fac.le.0.) go to 90
+          do 80 mm=1,nyy
+            m1 = m0+nyy
+            wrk(m0) = (wrk(m1)-wrk(m0))*ak/fac
+            m0  = m0+1
+  80      continue
+  90    continue
+        lx = lx+1
+        kkx = kkx-1
+ 100  continue
+ 200  if(nuy.eq.0) go to 300
+      ly = 1
+      do 230 j=1,nuy
+        ak = kky
+        nyy = nyy-1
+        l1 = ly
+        do 220 i=1,nyy
+          l1 = l1+1
+          l2 = l1+kky
+          fac = ty(l2)-ty(l1)
+          if(fac.le.0.) go to 220
+          m0 = i
+          do 210 mm=1,nxx
+            m1 = m0+1
+            wrk(m0) = (wrk(m1)-wrk(m0))*ak/fac
+            m0  = m0+nky1
+ 210      continue
+ 220    continue
+        ly = ly+1
+        kky = kky-1
+ 230  continue
+      m0 = nyy
+      m1 = nky1
+      do 250 mm=2,nxx
+        do 240 i=1,nyy
+          m0 = m0+1
+          m1 = m1+1
+          wrk(m0) = wrk(m1)
+ 240    continue
+        m1 = m1+nuy
+ 250  continue
+c  we partition the working space and evaluate the partial derivative
+ 300  iwx = 1+nxx*nyy
+      iwy = iwx+m*(kx1-nux)
+      do 390 i=1,m
+        call fpbisp(tx(nux+1),nx-2*nux,ty(nuy+1),ny-2*nuy,wrk,kkx,kky,
+     *   x(i),1,y(i),1,z(i),wrk(iwx),wrk(iwy),iwrk(1),iwrk(2))
+ 390  continue
+ 400  return
+      end

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -990,17 +990,17 @@ class SphereBivariateSpline(_BivariateSplineBase):
             theta = np.sort(theta)
             theta = np.sort(theta)
             if (dtheta | dphi):
-                z,ier = dfitpack.parder(tx,ty,c,kx,ky,dx,dy,x,y)
+                z,ier = dfitpack.parder(tx,ty,c,kx,ky,dx,dy,theta,phi)
                 if not ier == 0:
                     raise ValueError("Error code returned by parder: %s" % ier)
             else:
-                z,ier = dfitpack.bispev(tx,ty,c,kx,ky,x,y)
+                z,ier = dfitpack.bispev(tx,ty,c,kx,ky,theta,phi)
                 if not ier == 0:
                     raise ValueError("Error code returned by bispev: %s" % ier)
         else:
             if (dtheta | dphi):
                 z,ier = dfitpack.pardeu(tx,ty,c,kx,ky,dtheta,dphi,theta,phi)
-            if not ier == 0:
+                if not ier == 0:
                     raise ValueError("Error code returned by pardeu: %s" % ier)
             else:
                 z,ier = dfitpack.bispeu(tx,ty,c,kx,ky,theta,phi)

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -29,7 +29,6 @@ import numpy as np
 
 from . import fitpack
 from . import dfitpack
-from . import _fitpack
 
 
 ################ Univariate spline ####################
@@ -110,18 +109,22 @@ class UnivariateSpline(object):
     --------
     >>> from numpy import linspace,exp
     >>> from numpy.random import randn
+    >>> import matplotlib.pyplot as plt
     >>> from scipy.interpolate import UnivariateSpline
     >>> x = linspace(-3, 3, 100)
     >>> y = exp(-x**2) + randn(100)/10
     >>> s = UnivariateSpline(x, y, s=1)
     >>> xs = linspace(-3, 3, 1000)
     >>> ys = s(xs)
+    >>> plt.plot(x, y, '.-')
+    >>> plt.plot(xs, ys)
+    >>> plt.show()
 
     xs,ys is now a smoothed, super-sampled version of the noisy gaussian x,y.
 
     """
 
-    def __init__(self, x, y, w=None, bbox = [None]*2, k=3, s=None):
+    def __init__(self, x, y, w=None, bbox=[None]*2, k=3, s=None):
         """
         Input:
           x,y   - 1-d sequences of data points (x must be
@@ -140,35 +143,46 @@ class UnivariateSpline(object):
                        if 1/w[i] is an estimate of the standard
                        deviation of y[i].
         """
-        #_data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
+        # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         data = dfitpack.fpcurf0(x,y,k,w=w,
                                 xb=bbox[0],xe=bbox[1],s=s)
-        if data[-1]==1:
+        if data[-1] == 1:
             # nest too small, setting to maximum bound
             data = self._reset_nest(data)
         self._data = data
         self._reset_class()
 
+    @classmethod
+    def _from_tck(cls, tck):
+        """Construct a spline object from given tck"""
+        self = cls.__new__(cls)
+        t, c, k = tck
+        self._eval_args = tck
+        #_data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
+        self._data = (None,None,None,None,None,k,None,len(t),t,
+                      c,None,None,None,None)
+        return self
+
     def _reset_class(self):
         data = self._data
         n,t,c,k,ier = data[7],data[8],data[9],data[5],data[-1]
         self._eval_args = t[:n],c[:n],k
-        if ier==0:
+        if ier == 0:
             # the spline returned has a residual sum of squares fp
             # such that abs(fp-s)/s <= tol with tol a relative
             # tolerance set to 0.001 by the program
             pass
-        elif ier==-1:
+        elif ier == -1:
             # the spline returned is an interpolating spline
             self._set_class(InterpolatedUnivariateSpline)
-        elif ier==-2:
+        elif ier == -2:
             # the spline returned is the weighted least-squares
             # polynomial of degree k. In this extreme case fp gives
             # the upper bound fp0 for the smoothing factor s.
             self._set_class(LSQUnivariateSpline)
         else:
             # error
-            if ier==1:
+            if ier == 1:
                 self._set_class(LSQUnivariateSpline)
             message = _curfit_messages.get(ier,'ier=%s' % (ier))
             warnings.warn(message)
@@ -186,7 +200,7 @@ class UnivariateSpline(object):
         n = data[10]
         if nest is None:
             k,m = data[5],len(data[0])
-            nest = m+k+1 # this is the maximum bound for nest
+            nest = m+k+1  # this is the maximum bound for nest
         else:
             if not n <= nest:
                 raise ValueError("`nest` can only be increased")
@@ -202,13 +216,13 @@ class UnivariateSpline(object):
 
         """
         data = self._data
-        if data[6]==-1:
+        if data[6] == -1:
             warnings.warn('smoothing factor unchanged for'
                           'LSQ spline with fixed knots')
             return
         args = data[:6] + (s,) + data[7:]
         data = dfitpack.fpcurf1(*args)
-        if data[-1]==1:
+        if data[-1] == 1:
             # nest too small, setting to maximum bound
             data = self._reset_nest(data)
         self._data = data
@@ -266,13 +280,107 @@ class UnivariateSpline(object):
         Restriction: only cubic splines are supported by fitpack.
         """
         k = self._data[5]
-        if k==3:
+        if k == 3:
             z,m,ier = dfitpack.sproot(*self._eval_args[:2])
             if not ier == 0:
                 raise ValueError("Error code returned by spalde: %s" % ier)
             return z[:m]
         raise NotImplementedError('finding roots unsupported for '
                                     'non-cubic splines')
+
+    def derivative(self, n=1):
+        """
+        Construct a new spline representing the derivative of this spline.
+
+        .. versionadded:: 0.13.0
+
+        Parameters
+        ----------
+        n : int, optional
+            Order of derivative to evaluate. Default: 1
+
+        Returns
+        -------
+        spline : UnivariateSpline
+            Spline of order k2=k-n representing the derivative of this
+            spline.
+
+        See Also
+        --------
+        splder, antiderivative
+
+        Examples
+        --------
+        This can be used for finding maxima of a curve:
+
+        >>> from scipy.interpolate import UnivariateSpline
+        >>> x = np.linspace(0, 10, 70)
+        >>> y = np.sin(x)
+        >>> spl = UnivariateSpline(x, y, k=4, s=0)
+
+        Now, differentiate the spline and find the zeros of the
+        derivative. (NB: `sproot` only works for order 3 splines, so we
+        fit an order 4 spline):
+
+        >>> spl.derivative().roots() / np.pi
+        array([ 0.50000001,  1.5       ,  2.49999998])
+
+        This agrees well with roots :math:`\pi/2 + n\pi` of `cos(x) = sin'(x)`.
+
+        """
+        tck = fitpack.splder(self._eval_args, n)
+        return UnivariateSpline._from_tck(tck)
+
+    def antiderivative(self, n=1):
+        """
+        Construct a new spline representing the antiderivative of this spline.
+
+        .. versionadded:: 0.13.0
+
+        Parameters
+        ----------
+        n : int, optional
+            Order of antiderivative to evaluate. Default: 1
+
+        Returns
+        -------
+        spline : UnivariateSpline
+            Spline of order k2=k+n representing the antiderivative of this
+            spline.
+
+        See Also
+        --------
+        splantider, derivative
+
+        Examples
+        --------
+        >>> from scipy.interpolate import UnivariateSpline
+        >>> x = np.linspace(0, np.pi/2, 70)
+        >>> y = 1 / np.sqrt(1 - 0.8*np.sin(x)**2)
+        >>> spl = UnivariateSpline(x, y, s=0)
+
+        The derivative is the inverse operation of the antiderivative,
+        although some floating point error accumulates:
+
+        >>> spl(1.7), spl.antiderivative().derivative()(1.7)
+        (array(2.1565429877197317), array(2.1565429877201865))
+
+        Antiderivative can be used to evaluate definite integrals:
+
+        >>> ispl = spl.antiderivative()
+        >>> ispl(np.pi/2) - ispl(0)
+        2.2572053588768486
+
+        This is indeed an approximation to the complete elliptic integral
+        :math:`K(m) = \\int_0^{\\pi/2} [1 - m\\sin^2 x]^{-1/2} dx`:
+
+        >>> from scipy.special import ellipk
+        >>> ellipk(0.8)
+        2.2572053268208538
+
+        """
+        tck = fitpack.splantider(self._eval_args, n)
+        return UnivariateSpline._from_tck(tck)
 
 
 class InterpolatedUnivariateSpline(UnivariateSpline):
@@ -316,17 +424,21 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
     >>> from numpy import linspace,exp
     >>> from numpy.random import randn
     >>> from scipy.interpolate import InterpolatedUnivariateSpline
+    >>> import matplotlib.pyplot as plt
     >>> x = linspace(-3, 3, 100)
     >>> y = exp(-x**2) + randn(100)/10
     >>> s = InterpolatedUnivariateSpline(x, y)
     >>> xs = linspace(-3, 3, 1000)
     >>> ys = s(xs)
+    >>> plt.plot(x, y, '.-')
+    >>> plt.plot(xs, ys)
+    >>> plt.show()
 
     xs,ys is now a smoothed, super-sampled version of the noisy gaussian x,y
 
     """
 
-    def __init__(self, x, y, w=None, bbox = [None]*2, k=3):
+    def __init__(self, x, y, w=None, bbox=[None]*2, k=3):
         """
         Input:
           x,y   - 1-d sequences of data points (x must be
@@ -339,7 +451,7 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
                        By default, bbox=[x[0],x[-1]]
           k=3        - degree of the univariate spline.
         """
-        #_data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
+        # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         self._data = dfitpack.fpcurf0(x,y,k,w=w,
                                       xb=bbox[0],xe=bbox[1],s=0)
         self._reset_class()
@@ -358,7 +470,7 @@ class LSQUnivariateSpline(UnivariateSpline):
         Input dimension of data points -- must be increasing
     y : (N,) array_like
         Input dimension of data points
-    t: (M,) array_like
+    t : (M,) array_like
         interior knots of the spline.  Must be in ascending order
         and bbox[0]<t[0]<...<t[-1]<bbox[-1]
     w : (N,) array_like, optional
@@ -393,19 +505,23 @@ class LSQUnivariateSpline(UnivariateSpline):
     >>> from numpy import linspace,exp
     >>> from numpy.random import randn
     >>> from scipy.interpolate import LSQUnivariateSpline
+    >>> import matplotlib.pyplot as plt
     >>> x = linspace(-3,3,100)
     >>> y = exp(-x**2) + randn(100)/10
     >>> t = [-1,0,1]
     >>> s = LSQUnivariateSpline(x,y,t)
     >>> xs = linspace(-3,3,1000)
     >>> ys = s(xs)
+    >>> plt.plot(x, y, '.-')
+    >>> plt.plot(xs, ys)
+    >>> plt.show()
 
     xs,ys is now a smoothed, super-sampled version of the noisy gaussian x,y
     with knots [-3,-1,0,1,3]
 
     """
 
-    def __init__(self, x, y, t, w=None, bbox = [None]*2, k=3):
+    def __init__(self, x, y, t, w=None, bbox=[None]*2, k=3):
         """
         Input:
           x,y   - 1-d sequences of data points (x must be
@@ -421,11 +537,13 @@ class LSQUnivariateSpline(UnivariateSpline):
                        By default, bbox=[x[0],x[-1]]
           k=3        - degree of the univariate spline.
         """
-        #_data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
-        xb=bbox[0]
-        xe=bbox[1]
-        if xb is None: xb = x[0]
-        if xe is None: xe = x[-1]
+        # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
+        xb = bbox[0]
+        xe = bbox[1]
+        if xb is None:
+            xb = x[0]
+        if xe is None:
+            xe = x[-1]
         t = concatenate(([xb]*(k+1),t,[xe]*(k+1)))
         n = len(t)
         if not alltrue(t[k+1:n-k]-t[k:n-k-1] > 0,axis=0):
@@ -512,6 +630,7 @@ system (deficiency=%i). If deficiency is large, the results may be
 inaccurate. Deficiency may strongly depend on the value of eps."""
                     }
 
+
 class BivariateSpline(_BivariateSplineBase):
     """
     Base class for bivariate splines.
@@ -520,6 +639,7 @@ class BivariateSpline(_BivariateSplineBase):
     the rectangle ``[xb, xe] * [yb, ye]`` calculated from a given set
     of data points ``(x, y, z)``.
 
+    This class is meant to be subclassed, not instantiated directly.
     To construct these splines, call either `SmoothBivariateSpline` or
     `LSQBivariateSpline`.
 
@@ -562,22 +682,25 @@ class BivariateSpline(_BivariateSplineBase):
                 y = np.sort(y)
                 if (dx | dy):
                     z,ier = dfitpack.parder(tx,ty,c,kx,ky,dx,dy,x,y)
+                    if not ier == 0:
+                        raise ValueError("Error code returned by parder: %s" % ier)
                 else:
                     z,ier = dfitpack.bispev(tx,ty,c,kx,ky,x,y)
-                if not ier == 0:
-                    raise ValueError("Error code returned by bispev: %s" % ier)
-                return z
+                    if not ier == 0:
+                        raise ValueError("Error code returned by bispev: %s" % ier)
             else:
                 x,y = x[:min(x.size,y.size)],y[:min(x.size,y.size)]
                 if (dx | dy):
                     z,ier = dfitpack.pardeu(tx,ty,c,kx,ky,dx,dy,x,y)
+                    if not ier == 0:
+                        raise ValueError("Error code returned by pardeu: %s" % ier)
                 else:
                     z,ier = dfitpack.bispeu(tx,ty,c,kx,ky,x,y)
+                    if not ier == 0:
+                        raise ValueError("Error code returned by bispeu: %s" % ier)
                 if xshape == yshape:
                     z = np.reshape(z,xshape)
-                if not ier == 0:
-                    raise ValueError("Error code returned by bispeu: %s" % ier)
-                return z
+            return z
         raise NotImplementedError('unknown method mth=%s' % mth)
 
     def ev(self, xi, yi, dx=0, dy=0):
@@ -655,7 +778,7 @@ class SmoothBivariateSpline(BivariateSpline):
                                                          xb,xe,yb,ye,
                                                          kx,ky,s=s,
                                                          eps=eps,lwrk2=1)
-        if ier in [0,-1,-2]: # normal return
+        if ier in [0,-1,-2]:  # normal return
             pass
         else:
             message = _surfit_messages.get(ier,'ier=%s' % (ier))
@@ -717,17 +840,17 @@ class LSQBivariateSpline(BivariateSpline):
         ty1[ky+1:ny-ky-1] = ty
 
         xb,xe,yb,ye = bbox
-        tx1,ty1,c,fp,ier = dfitpack.surfit_lsq(x,y,z,tx1,ty1,w,\
-                                               xb,xe,yb,ye,\
+        tx1,ty1,c,fp,ier = dfitpack.surfit_lsq(x,y,z,tx1,ty1,w,
+                                               xb,xe,yb,ye,
                                                kx,ky,eps,lwrk2=1)
-        if ier>10:
-            tx1,ty1,c,fp,ier = dfitpack.surfit_lsq(x,y,z,tx1,ty1,w,\
-                                                   xb,xe,yb,ye,\
+        if ier > 10:
+            tx1,ty1,c,fp,ier = dfitpack.surfit_lsq(x,y,z,tx1,ty1,w,
+                                                   xb,xe,yb,ye,
                                                    kx,ky,eps,lwrk2=ier)
-        if ier in [0,-1,-2]: # normal return
+        if ier in [0,-1,-2]:  # normal return
             pass
         else:
-            if ier<-2:
+            if ier < -2:
                 deficiency = (nx-kx-1)*(ny-ky-1)+ier
                 message = _surfit_messages.get(-3) % (deficiency)
             else:
@@ -841,7 +964,7 @@ class SphereBivariateSpline(_BivariateSplineBase):
         to create a BivariateSpline using weighted least-squares fitting
     """
 
-    def __call__(self, theta, phi, dt=0, dp=0, grid=True):
+    def __call__(self, theta, phi, dtheta=0, dphi=0, grid=True):
         """ Evaluate the spline at the grid ponts defined by the coordinate
         arrays theta, phi. """
         theta = np.asarray(theta)
@@ -849,6 +972,14 @@ class SphereBivariateSpline(_BivariateSplineBase):
         # empty input yields empty output
         if (theta.size == 0) and (phi.size == 0):
             return array([])
+        if not theta.shape:
+            theta = np.expand_dims(theta,0)
+        if not phi.shape:
+            phi = np.expand_dims(phi,0)
+        thetashape = theta.shape
+        phishape = phi.shape
+        theta = theta.flatten()
+        phi = phi.flatten()
         if theta.min() < 0. or theta.max() > np.pi:
             raise ValueError("requested theta out of bounds.")
         if phi.min() < 0. or phi.max() > 2. * np.pi:
@@ -856,24 +987,33 @@ class SphereBivariateSpline(_BivariateSplineBase):
         tx, ty, c = self.tck[:3]
         kx, ky = self.degrees
         if grid:
-            if (dt | dp):
-                r, ier = dfitpack.parder(tx, ty, c, kx, ky, theta, phi)
+            theta = np.sort(theta)
+            theta = np.sort(theta)
+            if (dtheta | dphi):
+                z,ier = dfitpack.parder(tx,ty,c,kx,ky,dx,dy,x,y)
+                if not ier == 0:
+                    raise ValueError("Error code returned by parder: %s" % ier)
             else:
-                r, ier = dfitpack.bispev(tx, ty, c, kx, ky, theta, phi)
+                z,ier = dfitpack.bispev(tx,ty,c,kx,ky,x,y)
+                if not ier == 0:
+                    raise ValueError("Error code returned by bispev: %s" % ier)
         else:
-            if (dt | dp):
-                r, ier = dfitpack.pardeu(tx, ty, c, kx, ky, theta, phi)
+            if (dtheta | dphi):
+                z,ier = dfitpack.pardeu(tx,ty,c,kx,ky,dtheta,dphi,theta,phi)
+            if not ier == 0:
+                    raise ValueError("Error code returned by pardeu: %s" % ier)
             else:
-                r, ier = dfitpack.bispeu(tx, ty, c, kx, ky, theta, phi)
-        if not ier == 0:
-            raise ValueError("Error code returned by bispev: %s" % ier)
-        return r
+                z,ier = dfitpack.bispeu(tx,ty,c,kx,ky,theta,phi)
+                if not ier == 0:
+                    raise ValueError("Error code returned by bispeu: %s" % ier)
+        return z
 
-    def ev(self, thetai, phii, dt=0, dp=0):
+    def ev(self, theta, phi, dtheta=0, dphi=0):
         """ Evaluate the spline at the points (theta[i], phi[i]),
-        i=0,...,len(theta)-1 for backwards compatibility
+        i=0,...,len(theta)-1
+        for backwards compatability
         """
-        return self.__call__(thetai, phii, dt=dt, dp=dp, grid=False)
+        return self.__call__(theta, phi, dtheta=dtheta, dphi=dphi, grid=False)
 
 
 class SmoothSphereBivariateSpline(SphereBivariateSpline):

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -990,7 +990,7 @@ class SphereBivariateSpline(_BivariateSplineBase):
             theta = np.sort(theta)
             theta = np.sort(theta)
             if (dtheta | dphi):
-                z,ier = dfitpack.parder(tx,ty,c,kx,ky,dx,dy,theta,phi)
+                z,ier = dfitpack.parder(tx,ty,c,kx,ky,dtheta,dphi,theta,phi)
                 if not ier == 0:
                     raise ValueError("Error code returned by parder: %s" % ier)
             else:

--- a/scipy/interpolate/src/fitpack.pyf
+++ b/scipy/interpolate/src/fitpack.pyf
@@ -342,6 +342,30 @@ static int calc_regrid_lwrk(int mx, int my, int kx, int ky,
        integer intent(out) :: ier
      end subroutine bispev
 
+     subroutine parder(tx,nx,ty,ny,c,kx,ky,nux,nuy,x,mx,y,my,z,wrk,lwrk,iwrk,kwrk,ier)
+       ! z,ier = parder(tx,ty,c,kx,ky,nux,nuy,x,y)
+       real*8 dimension(nx),intent(in) :: tx
+       integer intent(hide),depend(tx) :: nx=len(tx)
+       real*8 dimension(ny),intent(in) :: ty
+       integer intent(hide),depend(ty) :: ny=len(ty)
+       real*8 intent(in),dimension((nx-kx-1)*(ny-ky-1)),depend(nx,ny,kx,ky),&
+            check(len(c)==(nx-kx-1)*(ny-ky-1)):: c
+       integer :: kx
+       integer :: ky
+       integer :: nux
+       integer :: nuy
+       real*8 intent(in),dimension(mx) :: x
+       integer intent(hide),depend(x) :: mx=len(x)
+       real*8 intent(in),dimension(my) :: y
+       integer intent(hide),depend(y) :: my=len(y)
+       real*8 dimension(mx,my),depend(mx,my),intent(out,c) :: z
+       real*8 dimension(lwrk),depend(lwrk),intent(hide,cache) :: wrk
+       integer intent(hide),depend(mx,kx,my,ky,nx,ny) :: lwrk=(nx*ny)+(kx+1)*mx+(ky+1)*my
+       integer dimension(kwrk),depend(kwrk),intent(hide,cache) :: iwrk
+       integer intent(hide),depend(mx,my) :: kwrk=mx+my
+       integer intent(out) :: ier
+     end subroutine parder
+
      subroutine bispeu(tx,nx,ty,ny,c,kx,ky,x,y,z,m,wrk,lwrk,ier)
        ! z,ier = bispeu(tx,ty,c,kx,ky,x,y)
        real*8 dimension(nx),intent(in) :: tx
@@ -360,6 +384,29 @@ static int calc_regrid_lwrk(int mx, int my, int kx, int ky,
        integer intent(hide),depend(kx,ky) :: lwrk=kx+ky+2
        integer intent(out) :: ier
      end subroutine bispeu
+
+     subroutine pardeu(tx,nx,ty,ny,c,kx,ky,nux,nuy,x,y,z,m,wrk,lwrk,iwrk,kwrk,ier)
+       ! z,ier = pardeu(tx,ty,c,kx,ky,nux,nuy,x,y)
+       real*8 dimension(nx),intent(in) :: tx
+       integer intent(hide),depend(tx) :: nx=len(tx)
+       real*8 dimension(ny),intent(in) :: ty
+       integer intent(hide),depend(ty) :: ny=len(ty)
+       real*8 intent(in),dimension((nx-kx-1)*(ny-ky-1)),depend(nx,ny,kx,ky),&
+            check(len(c)==(nx-kx-1)*(ny-ky-1)):: c
+       integer :: kx
+       integer :: ky
+       integer :: nux
+       integer :: nuy
+       real*8 intent(in),dimension(m) :: x
+       real*8 intent(in),dimension(m) :: y
+       real*8 dimension(m),depend(m),intent(out,c) :: z
+       integer intent(hide),depend(x) :: m=len(x)
+       real*8 dimension(lwrk),depend(lwrk),intent(hide,cache) :: wrk
+       integer intent(hide),depend(m,kx,ky,nx,ny) :: lwrk=(nx*ny)+(kx+1)*m+(ky+1)*m
+       integer dimension(kwrk),depend(kwrk),intent(hide,cache) :: iwrk
+       integer intent(hide),depend(m) :: kwrk=m+m
+       integer intent(out) :: ier
+     end subroutine pardeu
 
      subroutine surfit_smth(iopt,m,x,y,z,w,xb,xe,yb,ye,kx,ky,s,nxest,nyest,&
           nmax,eps,nx,tx,ny,ty,c,fp,wrk1,lwrk1,wrk2,lwrk2,&

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -285,6 +285,32 @@ class TestRectBivariateSpline(TestCase):
 
         assert_almost_equal(zi, zi2)
 
+    def test_derivatives_grid(self):
+        x = array([1,2,3,4,5])
+        y = array([1,2,3,4,5])
+        z = array([[1,2,1,2,1],[1,2,1,2,1],[1,2,3,2,1],[1,2,2,2,1],[1,2,1,2,1]])
+        dx = array([[0,0,-20,0,0],[0,0,13,0,0],[0,0,4,0,0],
+            [0,0,-11,0,0],[0,0,4,0,0]])/6.
+        dy = array([[4,-1,0,1,-4],[4,-1,0,1,-4],[0,1.5,0,-1.5,0],
+            [2,.25,0,-.25,-2],[4,-1,0,1,-4]])
+        dxdy = array([[40,-25,0,25,-40],[-26,16.25,0,-16.25,26],
+            [-8,5,0,-5,8],[22,-13.75,0,13.75,-22],[-8,5,0,-5,8]])/6.
+        lut = RectBivariateSpline(x,y,z)
+        assert_array_almost_equal(lut(x,y,dx=1),dx)
+        assert_array_almost_equal(lut(x,y,dy=1),dy)
+        assert_array_almost_equal(lut(x,y,dx=1,dy=1),dxdy)
+
+    def test_derivatives(self):
+        x = array([1,2,3,4,5])
+        y = array([1,2,3,4,5])
+        z = array([[1,2,1,2,1],[1,2,1,2,1],[1,2,3,2,1],[1,2,2,2,1],[1,2,1,2,1]])
+        dx = array([0,0,2./3,0,0])
+        dy = array([4,-1,0,-.25,-4])
+        dxdy = array([160,65,0,55,32])/24.
+        lut = RectBivariateSpline(x,y,z)
+        assert_array_almost_equal(lut(x,y,dx=1,grid=False),dx)
+        assert_array_almost_equal(lut(x,y,dy=1,grid=False),dy)
+        assert_array_almost_equal(lut(x,y,dx=1,dy=1,grid=False),dxdy)
 
 class TestRectSphereBivariateSpline(TestCase):
     def test_defaults(self):


### PR DESCRIPTION
These changes add a fortran routine to return derivatives at arbitrary
points and includes derivative evaluation for Bivariate splines. Keyword
'grid' is added to the Bivariate spline evaluation to remove the
necessity of the 'ev' method for arbitrary point evaluation. These
changes have been tested as working with the 0.12 branch.
