### PR TITLE
modification of PR2808

### DIFF
--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -696,8 +696,7 @@ def lpmn(m,n,z):
         sv = errprint(sv)
     else:
         mp = m
-    else:
-        p,pd = specfun.lpmn(mp,n,z)
+    p,pd = specfun.lpmn(mp,n,z)
     if (m < 0):
         p = p * fixarr
         pd = pd * fixarr

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -685,7 +685,12 @@ def lpmn(m,n,z):
         mp = -m
         mf,nf = mgrid[0:mp+1,0:n+1]
         sv = errprint(0)
-        fixarr = where(mf > nf,0.0,(-1)**mf * gamma(nf-mf+1) / gamma(nf+mf+1))
+        if abs(z) < 1:
+            # Ferrier function; DLMF 14.9.3
+            fixarr = where(mf > nf,0.0,(-1)**mf * gamma(nf-mf+1) / gamma(nf+mf+1))
+        else:
+            # Match to clpmn; DLMF 14.9.13
+            fixarr = where(mf > nf,0.0, gamma(nf-mf+1) / gamma(nf+mf+1))
         sv = errprint(sv)
     else:
         mp = m

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -681,12 +681,14 @@ def lpmn(m,n,z):
         raise ValueError("n must be a non-negative integer.")
     if not isscalar(z):
         raise ValueError("z must be scalar.")
+    if iscomplex(z):
+        raise ValueError("Argument must be real. Use clpmn instead.")
     if (m < 0):
         mp = -m
         mf,nf = mgrid[0:mp+1,0:n+1]
         sv = errprint(0)
         if abs(z) < 1:
-            # Ferrier function; DLMF 14.9.3
+            # Ferrer function; DLMF 14.9.3
             fixarr = where(mf > nf,0.0,(-1)**mf * gamma(nf-mf+1) / gamma(nf+mf+1))
         else:
             # Match to clpmn; DLMF 14.9.13
@@ -694,8 +696,6 @@ def lpmn(m,n,z):
         sv = errprint(sv)
     else:
         mp = m
-    if iscomplex(z):
-        raise ValueError("Argument must be real. Use clpmn instead.")
     else:
         p,pd = specfun.lpmn(mp,n,z)
     if (m < 0):

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1350,20 +1350,19 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
             return v
 
         def legenp(n, m, z):
-            if z == 1 and int(n) == n:
-                # Special case (mpmath gives inf, we take the limit by
+            if (z == 1 or z == -1) and int(n) == n:
+                # Special case (mpmath may give inf, we take the limit by
                 # continuity)
                 if m == 0:
-                    return 1
+                    if n < 0:
+                        n = -n - 1
+                    return mpmath.power(mpmath.sign(z), n)
                 else:
                     return 0
 
             if abs(z) < 1e-15:
                 # mpmath has bad performance here
                 return np.nan
-
-            if z == 1:
-                z = 1 - 1e-9
 
             typ = 2 if abs(z) < 1 else 3
             v = _exception_to_nan(mpmath.legenp)(n, m, z, type=typ)
@@ -1376,11 +1375,11 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
 
         assert_mpmath_equal(lpnm,
                             legenp,
-                            [IntArg(0, 100), IntArg(0, 100), Arg()])
+                            [IntArg(-100, 100), IntArg(-100, 100), Arg()])
 
         assert_mpmath_equal(lpnm_2,
                             legenp,
-                            [IntArg(0, 100), IntArg(0, 100), Arg(-1, 1)])
+                            [IntArg(-100, 100), Arg(-100, 100), Arg(-1, 1)])
 
     def test_legenp_complex(self):
         def clpnm(n, m, z):
@@ -1402,7 +1401,7 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
 
         assert_mpmath_equal(clpnm,
                             legenp,
-                            [FixedArg([0, 1, 2, 10]), FixedArg([0, 1, 2, 10]), FixedArg(z)],
+                            [FixedArg([-2, -1, 0, 1, 2, 10]), FixedArg([-2, -1, 0, 1, 2, 10]), FixedArg(z)],
                             rtol=1e-6,
                             n=500)
 


### PR DESCRIPTION
It seems more appropriate to check for complex arguments before creating arrays to handle negative orders.

Otherwise, the changes in SHA:  6456e83 seem consistent with my comment https://github.com/scipy/scipy/issues/2396#issuecomment-23469671 written before looking at the new code in SHA: 6456e83.
