### PR TITLE
ENH: more scalable sqeuclidean in spatial.distance

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -251,7 +251,7 @@ def sqeuclidean(u, v):
     """
     u = _validate_vector(u)
     v = _validate_vector(v)
-    dist = ((u - v) ** 2).sum()
+    dist = np.dot(u, u) + np.dot(v, v) - 2 * np.dot(u, v)
     return dist
 
 


### PR DESCRIPTION
Memory complexity down to O(1) additional space instead of O(n), assuming a smart implementation of `np.dot`.

Timings of old version, new version and the obvious alternative, with two random vectors of length 1000:

```
>>> %timeit ((u - v) ** 2).sum()
100000 loops, best of 3: 15.2 us per loop
>>> %timeit np.dot(u, u) + np.dot(v, v) - 2 * np.dot(u, v)
100000 loops, best of 3: 9.27 us per loop
>>> %timeit u_v = u - v; np.dot(u_v, u_v)
100000 loops, best of 3: 8.17 us per loop
```

Length 10000:

```
>>> %timeit ((u - v) ** 2).sum()
10000 loops, best of 3: 71 us per loop
>>> %timeit np.dot(u, u) + np.dot(v, v) - 2 * np.dot(u, v)
10000 loops, best of 3: 42.4 us per loop
>>> %timeit u_v = u - v; np.dot(u_v, u_v)
10000 loops, best of 3: 38.9 us per loop
```

Length 100000:

```
>>> %timeit ((u - v) ** 2).sum()
1000 loops, best of 3: 2.01 ms per loop
>>> %timeit np.dot(u, u) + np.dot(v, v) - 2 * np.dot(u, v)
1000 loops, best of 3: 493 us per loop
>>> %timeit u_v = u - v; np.dot(u_v, u_v)
1000 loops, best of 3: 552 us per loop
```

Vectors generated with `np.random.randn`; NumPy 1.6.2 linked against ATLAS 3.8.4.
