### PR TITLE
Perform some geometric RV computations in log space to increase accuracy.

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -7358,15 +7358,18 @@ class geom_gen(rv_discrete):
 
     def _cdf(self, x, p):
         k = floor(x)
-        return (1.0-(1.0-p)**k)
+        return -np.expm1(np.log1p(-p)*k)
 
     def _sf(self, x, p):
+        return np.exp(self._logsf(x, p))
+
+    def _logsf(self, x, p):
         k = floor(x)
-        return (1.0-p)**k
+        return k*np.log1p(-p)
 
     def _ppf(self, q, p):
         vals = ceil(log(1.0-q)/log(1-p))
-        temp = 1.0-(1.0-p)**(vals-1)
+        temp = self._cdf(vals-1, p)
         return where((temp >= q) & (vals > 0), vals-1, vals)
 
     def _stats(self, p):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -245,11 +245,23 @@ class TestGeom(TestCase):
         assert_allclose(vals1, vals2, rtol=1e-15, atol=0)
 
     def test_cdf_sf(self):
-        vals = stats.geom.cdf([1,2,3],0.5)
-        vals_sf = stats.geom.sf([1,2,3],0.5)
-        expected = array([0.5,0.75,0.875])
-        assert_array_almost_equal(vals,expected)
-        assert_array_almost_equal(vals_sf,1-expected)
+        vals = stats.geom.cdf([1, 2, 3], 0.5)
+        vals_sf = stats.geom.sf([1, 2, 3], 0.5)
+        expected = array([0.5, 0.75, 0.875])
+        assert_array_almost_equal(vals, expected)
+        assert_array_almost_equal(vals_sf, 1-expected)
+
+    def test_logcdf_logsf(self):
+        vals = stats.geom.logcdf([1, 2, 3], 0.5)
+        vals_sf = stats.geom.logsf([1, 2, 3], 0.5)
+        expected = array([0.5, 0.75, 0.875])
+        assert_array_almost_equal(vals, np.log(expected))
+        assert_array_almost_equal(vals_sf, np.log1p(-expected))
+
+    def test_ppf(self):
+        vals = stats.geom.ppf([0.5, 0.75, 0.875], 0.5)
+        expected = array([1.0, 2.0, 3.0])
+        assert_array_almost_equal(vals, expected)
 
 
 class TestTruncnorm(TestCase):


### PR DESCRIPTION
I wanted to get nonzero answers to something like

```
geom.cdf(1e6, 1e-20)
```

These new functions seem to be a more computationally intense however, they seem to take an order of magnitude longer. With these new implementations,

```
geom.cdf(1e6, 1e-20) == 9.9999999999999495e-15
```

if you guys think the accuracy is worth it. I also threw in a few more tests for these functions.
