### PR TITLE
DOC: fix link to FITPACK library

### DIFF
--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -10,7 +10,7 @@ Sub-package for objects used in interpolation.
 As listed below, this sub-package contains spline functions and classes,
 one-dimensional and multi-dimensional (univariate and multivariate)
 interpolation classes, Lagrange and Taylor polynomial interpolators, and
-wrappers for `FITPACK <http://www.cisl.ucar.edu/softlib/FITPACK.html>`_
+wrappers for `FITPACK <http://www.netlib.org/dierckx/>`__
 and DFITPACK functions.
 
 Univariate interpolation

--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -93,8 +93,6 @@ Functional interface to FITPACK functions:
    spalde
    splder
    splantider
-   bisplrep
-   bisplev
 
 
 2-D Splines


### PR DESCRIPTION
The link to the FITPACK library in the interpolation module docstring was broken.

As far as I understand, the FITPACK routines in scipy.interpolate are actually the version by P. Dierckx, so I updated the link to point to the DIERCKX library on netlib.org.
