### PR TITLE
[WIP] stats distributions higher moments

### DIFF
--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -555,7 +555,7 @@ def sum(input, labels=None, index=None):
 
     Returns
     -------
-    sum : ndarray
+    sum : ndarray or scalar
         An array of the sums of values of `input` inside the regions defined
         by `labels` with the same shape as `index`. If 'index' is None or scalar,
         a scalar is returned. 
@@ -572,7 +572,7 @@ def sum(input, labels=None, index=None):
     [1.0, 5.0]
     >>> sum(input, labels, index=1)
     1
-    >>> sum(input, labels, index=1)
+    >>> sum(input, labels)
     6
 
 

--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -555,9 +555,10 @@ def sum(input, labels=None, index=None):
 
     Returns
     -------
-    sum : list
-        A list of the sums of the values of `input` inside the regions
-        defined by `labels`.
+    sum : ndarray
+        An array of the sums of values of `input` inside the regions defined
+        by `labels` with the same shape as `index`. If 'index' is None or scalar,
+        a scalar is returned. 
 
     See also
     --------
@@ -569,6 +570,11 @@ def sum(input, labels=None, index=None):
     >>> labels = [1,1,2,2]
     >>> sum(input, labels, index=[1,2])
     [1.0, 5.0]
+    >>> sum(input, labels, index=1)
+    1
+    >>> sum(input, labels, index=1)
+    6
+
 
     """
     count, sum = _stats(input, labels, index)

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -4595,7 +4595,6 @@ class loggamma_gen(rv_continuous):
         skewness = special.polygamma(2, c) / np.power(var, 1.5)
         excess_kurtosis = special.polygamma(3, c) / (var*var)
         return mean, var, skewness, excess_kurtosis
-
 loggamma = loggamma_gen(name='loggamma')
 
 

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -372,27 +372,27 @@ def _moment_from_stats(n, mu, mu2, g1, g2, moment_func, args):
         return 1.0
     elif (n == 1):
         if mu is None:
-            val = moment_func(1,*args)
+            val = moment_func(1, *args)
         else:
             val = mu
     elif (n == 2):
         if mu2 is None or mu is None:
-            val = moment_func(2,*args)
+            val = moment_func(2, *args)
         else:
             val = mu2 + mu*mu
     elif (n == 3):
         if g1 is None or mu2 is None or mu is None:
-            val = moment_func(3,*args)
+            val = moment_func(3, *args)
         else:
             mu3 = g1 * np.power(mu2, 1.5)  # 3rd central moment
-            val = mu3+3*mu*mu2+mu*mu*mu  # 3rd non-central moment
+            val = mu3 + 3*mu*mu2 + mu*mu*mu  # 3rd non-central moment
     elif (n == 4):
         if g1 is None or g2 is None or mu2 is None or mu is None:
-            val = moment_func(4,*args)
+            val = moment_func(4, *args)
         else:
-            mu4 = (g2+3.0)*(mu2**2.0)  # 4th central moment
+            mu4 = (g2 + 3.0) * (mu2**2.0)  # 4th central moment
             mu3 = g1*np.power(mu2, 1.5)  # 3rd central moment
-            val = mu4+4*mu*mu3+6*mu*mu*mu2+mu*mu*mu*mu
+            val = mu4 + 4*mu*mu3 + 6*mu*mu*mu2 + mu*mu*mu*mu
     else:
         val = moment_func(n, *args)
 
@@ -1076,7 +1076,7 @@ class rv_continuous(rv_generic):
             self.generic_moment = vectorize(self._mom0_sc, otypes='d')
         else:
             self.generic_moment = vectorize(self._mom1_sc, otypes='d')
-        self.generic_moment.nin = self.numargs+1  # Because of the *args argument
+        self.generic_moment.nin = self.numargs + 1  # Because of the *args argument
         # of _mom0_sc, vectorize cannot count the number of arguments correctly.
 
         if longname is None:
@@ -1593,13 +1593,13 @@ class rv_continuous(rv_generic):
 
         signature = inspect.getargspec(get_method_function(self._stats))
         if (signature[2] is not None) or ('moments' in signature[0]):
-            mu, mu2, g1, g2 = self._stats(*args,**{'moments':moments})
+            mu, mu2, g1, g2 = self._stats(*args, **{'moments': moments})
         else:
             mu, mu2, g1, g2 = self._stats(*args)
         if g1 is None:
             mu3 = None
         else:
-            mu3 = g1*np.power(mu2,1.5)  # (mu2**1.5) breaks down for nan and inf
+            mu3 = g1*np.power(mu2, 1.5)  # (mu2**1.5) breaks down for nan and inf
         default = valarray(shape(cond), self.badvalue)
         output = []
 
@@ -1629,11 +1629,11 @@ class rv_continuous(rv_generic):
 
             if 's' in moments:
                 if g1 is None:
-                    mu3p = self._munp(3.0,*goodargs)
+                    mu3p = self._munp(3, *goodargs)
                     if mu is None:
-                        mu = self._munp(1.0,*goodargs)
+                        mu = self._munp(1, *goodargs)
                     if mu2 is None:
-                        mu2p = self._munp(2.0,*goodargs)
+                        mu2p = self._munp(2, *goodargs)
                         mu2 = mu2p - mu*mu
                     mu3 = mu3p - 3*mu*mu2 - mu**3
                     g1 = mu3 / np.power(mu2, 1.5)
@@ -1695,10 +1695,10 @@ class rv_continuous(rv_generic):
         if (n > 0) and (n < 5):
             signature = inspect.getargspec(get_method_function(self._stats))
             if (signature[2] is not None) or ('moments' in signature[0]):
-                mdict = {'moments':{1:'m',2:'v',3:'vs',4:'vk'}[n]}
+                mdict = {'moments':{1:'m', 2:'v', 3:'vs', 4:'vk'}[n]}
             else:
                 mdict = {}
-            mu, mu2, g1, g2 = self._stats(*args,**mdict)
+            mu, mu2, g1, g2 = self._stats(*args, **mdict)
         val = _moment_from_stats(n, mu, mu2, g1, g2, self._munp, args)
 
         # Convert to transformed  X = L + S*Y
@@ -6891,7 +6891,7 @@ class rv_discrete(rv_generic):
 
         signature = inspect.getargspec(get_method_function(self._stats))
         if (signature[2] is not None) or ('moments' in signature[0]):
-            mu, mu2, g1, g2 = self._stats(*args,**{'moments':moments})
+            mu, mu2, g1, g2 = self._stats(*args, **{'moments':moments})
         else:
             mu, mu2, g1, g2 = self._stats(*args)
         if g1 is None:
@@ -6907,28 +6907,28 @@ class rv_discrete(rv_generic):
 
         if 'm' in moments:
             if mu is None:
-                mu = self._munp(1.0,*goodargs)
+                mu = self._munp(1.0, *goodargs)
             out0 = default.copy()
-            place(out0,cond,mu+loc)
+            place(out0, cond, mu + loc)
             output.append(out0)
 
         if 'v' in moments:
             if mu2 is None:
-                mu2p = self._munp(2.0,*goodargs)
+                mu2p = self._munp(2.0, *goodargs)
                 if mu is None:
-                    mu = self._munp(1.0,*goodargs)
+                    mu = self._munp(1.0, *goodargs)
                 mu2 = mu2p - mu*mu
             out0 = default.copy()
-            place(out0,cond,mu2)
+            place(out0, cond, mu2)
             output.append(out0)
 
         if 's' in moments:
             if g1 is None:
-                mu3p = self._munp(3.0,*goodargs)
+                mu3p = self._munp(3.0, *goodargs)
                 if mu is None:
-                    mu = self._munp(1.0,*goodargs)
+                    mu = self._munp(1.0, *goodargs)
                 if mu2 is None:
-                    mu2p = self._munp(2.0,*goodargs)
+                    mu2p = self._munp(2.0, *goodargs)
                     mu2 = mu2p - mu*mu
                 mu3 = mu3p - 3*mu*mu2 - mu**3
                 g1 = mu3 / np.power(mu2, 1.5)
@@ -6938,19 +6938,19 @@ class rv_discrete(rv_generic):
 
         if 'k' in moments:
             if g2 is None:
-                mu4p = self._munp(4.0,*goodargs)
+                mu4p = self._munp(4.0, *goodargs)
                 if mu is None:
-                    mu = self._munp(1.0,*goodargs)
+                    mu = self._munp(1.0, *goodargs)
                 if mu2 is None:
-                    mu2p = self._munp(2.0,*goodargs)
+                    mu2p = self._munp(2.0, *goodargs)
                     mu2 = mu2p - mu*mu
                 if mu3 is None:
-                    mu3p = self._munp(3.0,*goodargs)
+                    mu3p = self._munp(3.0, *goodargs)
                     mu3 = mu3p - 3*mu*mu2 - mu**3
                 mu4 = mu4p - 4*mu*mu3 - 6*mu*mu*mu2 - mu**4
                 g2 = mu4 / mu2**2.0 - 3.0
             out0 = default.copy()
-            place(out0,cond,g2)
+            place(out0, cond, g2)
             output.append(out0)
 
         if len(output) == 1:

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -7399,7 +7399,7 @@ class hypergeom_gen(rv_discrete):
     The probability mass function is defined as::
 
         pmf(k, M, n, N) = choose(n, k) * choose(M - n, N - k) / choose(M, N),
-                                               for N - (M-n) <= k <= min(m,N)
+                                       for max(0, N - (M-n)) <= k <= min(n, N)
 
     Examples
     --------

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -2646,28 +2646,9 @@ class burr_gen(rv_continuous):
     def _ppf(self, q, c, d):
         return (q**(-1.0/d)-1)**(-1.0/c)
 
-    def _stats(self, c, d, moments='mv'):
-        g2c, g2cd = gam(1-2.0/c), gam(2.0/c+d)
-        g1c, g1cd = gam(1-1.0/c), gam(1.0/c+d)
-        gd = gam(d)
-        k = gd*g2c*g2cd - g1c**2 * g1cd**2
-        mu = g1c*g1cd / gd
-        mu2 = k / gd**2.0
-        g1, g2 = None, None
-        g3c, g3cd = None, None
-        if 's' in moments:
-            g3c, g3cd = gam(1-3.0/c), gam(3.0/c+d)
-            g1 = 2*g1c**3 * g1cd**3 + gd*gd*g3c*g3cd - 3*gd*g2c*g1c*g1cd*g2cd
-            g1 /= sqrt(k**3)
-        if 'k' in moments:
-            if g3c is None:
-                g3c = gam(1-3.0/c)
-            if g3cd is None:
-                g3cd = gam(3.0/c+d)
-            g4c, g4cd = gam(1-4.0/c), gam(4.0/c+d)
-            g2 = 6*gd*g2c*g2cd * g1c**2 * g1cd**2 + gd**3 * g4c*g4cd
-            g2 -= 3*g1c**4 * g1cd**4 - 4*gd**2*g3c*g1c*g1cd*g3cd
-        return mu, mu2, g1, g2
+    def _munp(self, n, c, d):
+        nc = 1.*n/c
+        return d * special.beta(1.0 - nc, d + nc)
 burr = burr_gen(a=0.0, name='burr')
 
 #XXX: cf PR #2552
@@ -2695,8 +2676,8 @@ class fisk_gen(burr_gen):
     def _ppf(self, x, c):
         return burr_gen._ppf(self, x, c, 1.0)
 
-    def _stats(self, c):
-        return burr_gen._stats(self, c, 1.0)
+    def _munp(self, n, c):
+        return burr_gen._munp(self, n, c, 1.0)
 
     def _entropy(self, c):
         return 2 - log(c)

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -7696,7 +7696,7 @@ class boltzmann_gen(rv_discrete):
 
         boltzmann.pmf(k) = (1-exp(-lambda_)*exp(-lambda_*k)/(1-exp(-lambda_*N))
 
-    for ``k = 0,...,N-1``.
+    for ``k = 0,..., N-1``.
 
     `boltzmann` takes ``lambda_`` and ``N`` as shape parameters.
 
@@ -7803,7 +7803,7 @@ class zipf_gen(rv_discrete):
     -----
     The probability mass function for `zipf` is::
 
-        zipf.pmf(k) = 1/(zeta(a)*k**a)
+        zipf.pmf(k, a) = 1/(zeta(a)*k**a)
 
     for ``k >= 1``.
 
@@ -7819,13 +7819,13 @@ class zipf_gen(rv_discrete):
         return a > 1
 
     def _pmf(self, k, a):
-        Pk = 1.0 / asarray(special.zeta(a,1) * k**a)
+        Pk = 1.0 / special.zeta(a, 1) * k**a
         return Pk
 
     def _munp(self, n, a):
-        return special.zeta(a-n,1) / special.zeta(a,1)
+        return np.where(a > n +1, special.zeta(a-n, 1) / special.zeta(a, 1), np.nan)
 
-    def _stats(self, a):
+    def _stats_skip(self, a):
         sv = special.errprint(0)
         fac = asarray(special.zeta(a,1))
         mu = special.zeta(a-1.0,1)/fac

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -2810,10 +2810,7 @@ class chi2_gen(rv_continuous):
         return exp(self._logpdf(x, df))
 
     def _logpdf(self, x, df):
-        # term1 = (df/2.-1)*log(x)
-        # term1[(df==2)*(x==0)] = 0
-        # avoid 0*log(0)==nan
-        return (df/2.-1)*log(x+1e-300) - x/2. - gamln(df/2.) - (log(2)*df)/2.
+        return special.xlogy(df/2.-1, x) - x/2. - gamln(df/2.) - (log(2)*df)/2.
 
     def _cdf(self, x, df):
         return special.chdtr(df, x)
@@ -2893,15 +2890,15 @@ class dgamma_gen(rv_continuous):
 
     def _logpdf(self, x, a):
         ax = abs(x)
-        return (a-1.0)*log(ax) - ax - log(2) - gamln(a)
+        return special.xlogy(a-1.0, ax) - ax - log(2) - gamln(a)
 
     def _cdf(self, x, a):
         fac = 0.5*special.gammainc(a,abs(x))
-        return where(x > 0,0.5+fac,0.5-fac)
+        return where(x > 0, 0.5 + fac, 0.5 - fac)
 
     def _sf(self, x, a):
         fac = 0.5*special.gammainc(a,abs(x))
-        return where(x > 0,0.5-fac,0.5+fac)
+        return where(x > 0, 0.5-fac, 0.5+fac)
 
     def _ppf(self, q, a):
         fac = special.gammainccinv(a,1-abs(2*q-1))
@@ -2938,7 +2935,7 @@ class dweibull_gen(rv_continuous):
 
     def _logpdf(self, x, c):
         ax = abs(x)
-        return log(c) - log(2.0) + (c-1.0)*log(ax) - ax**c
+        return log(c) - log(2.0) + special.xlogy(c-1.0, ax) - ax**c
 
     def _cdf(self, x, c):
         Cx1 = 0.5*exp(-abs(x)**c)
@@ -3246,11 +3243,6 @@ class foldnorm_gen(rv_continuous):
     def _pdf(self, x, c):
         term = exp(-(x-c)*(x-c)/2) + exp(-(x+c)*(x+c)/2)
         return term / sqrt(2.*pi) 
-        #return sqrt(2.0/pi)*cosh(c*x)*exp(-(x*x+c*c)/2.0)
-        #return exp(self._logpdf(x, c))
-
-    #def _logpdf(self, x, c):
-    #    return log(2./pi) + log(cosh(c*x)) - (x*x + c*c)/2.
 
     def _cdf(self, x, c):
         return special.ndtr(x-c) + special.ndtr(x+c) - 1.0
@@ -4058,7 +4050,6 @@ class halflogistic_gen(rv_continuous):
     """
     def _pdf(self, x):
        return exp(self._logpdf(x))
-#        return 0.5/(cosh(x/2.0))**2.0
 
     def _logpdf(self, x):
         return log(2) - x - 2. * special.log1p(exp(-x))

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -2568,7 +2568,7 @@ class betaprime_gen(rv_continuous):
                                                     * (b-2.0)*(b-1.0)), inf)
         else:
             raise NotImplementedError
-betaprime = betaprime_gen(a=0.0, b=500.0, name='betaprime')
+betaprime = betaprime_gen(a=0.0, name='betaprime')
 
 
 class bradford_gen(rv_continuous):
@@ -4920,11 +4920,11 @@ class ncf_gen(rv_continuous):
 
     def _ppf(self, q, dfn, dfd, nc):
         return special.ncfdtri(dfn, dfd, nc, q)
-
+    
     def _munp(self, n, dfn, dfd, nc):
         val = (dfn * 1.0/dfd)**n
         term = gamln(n+0.5*dfn) + gamln(0.5*dfd-n) - gamln(dfd*0.5)
-        val *= exp(-nc / 2.0+term)
+        val *= exp(-nc/2.0 + term)
         val *= special.hyp1f1(n+0.5*dfn, 0.5*dfn, 0.5*nc)
         return val
 

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -2946,9 +2946,8 @@ class dweibull_gen(rv_continuous):
         fac = pow(asarray(log(1.0/fac)),1.0/c)
         return where(q > 0.5,fac,-fac)
 
-    def _stats(self, c):
-        var = gam(1+2.0/c)
-        return 0.0, var, 0.0, gam(1+4.0/c)/var
+    def _munp(self, n, c):
+        return (1 - n%2) * special.gamma(1.0 + 1.0*n/c)
 dweibull = dweibull_gen(name='dweibull')
 
 

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -5043,6 +5043,22 @@ class nct_gen(rv_continuous):
     def _ppf(self, q, df, nc):
         return special.nctdtrit(df, nc, q)
 
+	# this is still wrong, FIXME
+    def _munp(self, n, df, nc):
+        term = n*log(df/2.)
+        term += gamln((df-n)/2.) - gamln(df/2.)
+        
+        pol = {0: 1, 
+               1: nc, 
+               2: nc**2 + 1., 
+               3: nc*(nc**2 + 3.), 
+               4: nc**4 + 6.*nc**2 +3.}
+        try:
+            term = exp(term) * pol[n]
+        except KeyError:
+            raise NotImplementedError
+        return np.where(df > n, term, np.nan)
+
     def _stats(self, df, nc, moments='mv'):
         mu, mu2, g1, g2 = None, None, None, None
         val1 = gam((df-1.0)/2.0)
@@ -7696,9 +7712,9 @@ class randint_gen(rv_discrete):
     -----
     The probability mass function for `randint` is::
 
-        randint.pmf(k) = 1./(max- min)
+        randint.pmf(k) = 1./(max - min)
 
-    for ``k = min,...,max``.
+    for ``k = min, ..., max-1``.
 
     `randint` takes ``min`` and ``max`` as shape parameters.
 
@@ -7730,7 +7746,7 @@ class randint_gen(rv_discrete):
         d = m2 - m1
         var = (d-1)*(d+1.0)/12.0
         g1 = 0.0
-        g2 = -6.0/5.0*(d*d+1.0)/(d-1.0)*(d+1.0)
+        g2 = -6.0/5.0*(d*d+1.0)/(d*d-1.0)
         return mu, var, g1, g2
 
     def _rvs(self, min, max=None):

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -3096,12 +3096,14 @@ class fatiguelife_gen(rv_continuous):
         return 0.25*(tmp + sqrt(tmp**2 + 4))**2
 
     def _stats(self, c):
+        # kurtosis: wikipedia errs? 40 vs 41
+        # cf eg unalmed.edu.co/~estadist/seminario/conf_victor.pdf
         c2 = c*c
-        mu = c2 / 2.0 + 1
-        den = 5*c2 + 4
+        mu = c2 / 2.0 + 1.0
+        den = 5.0*c2 + 4.0
         mu2 = c2*den / 4.0
-        g1 = 4*c*sqrt(11*c2+6.0)/np.power(den, 1.5)
-        g2 = 6*c2*(93*c2+41.0) / den**2.0
+        g1 = 4*c*(11*c2+6.0)/np.power(den, 1.5)
+        g2 = 6*c2*(93*c2+40.0) / den**2.0
         return mu, mu2, g1, g2
 fatiguelife = fatiguelife_gen(a=0.0, name='fatiguelife')
 
@@ -3189,7 +3191,7 @@ class f_gen(rv_continuous):
             2 * (v1 + _v122) / (v2-6) * sqrt((2*v2-8) / (v1*_v122)),
             np.nan)
         g2 = where(v2 > 8, 
-            3/(2*v2-16)*(8+g1*g1*(v2-6)), 
+            3. / (2*v2-16) * (8+g1*g1*(v2-6)), 
             nan)
         return mu, mu2, g1, g2
 f = f_gen(a=0.0, name='f')

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -3179,13 +3179,18 @@ class f_gen(rv_continuous):
     def _stats(self, dfn, dfd):
         v2 = asarray(dfd*1.0)
         v1 = asarray(dfn*1.0)
-        mu = where(v2 > 2, v2 / asarray(v2 - 2), inf)
-        mu2 = 2*v2*v2*(v2+v1-2)/(v1*(v2-2)**2 * (v2-4))
-        mu2 = where(v2 > 4, mu2, inf)
-        g1 = 2*(v2+2*v1-2)/(v2-6)*sqrt((2*v2-8)/(v1*(v2+v1-2)))
-        g1 = where(v2 > 6, g1, nan)
-        g2 = 3/(2*v2-16)*(8+g1*g1*(v2-6))
-        g2 = where(v2 > 8, g2, nan)
+        _v22 = v2 / (v2 - 2)
+        mu = np.where(v2 > 2, _v22, np.inf)
+        mu2 = np.where(v2 > 4, 
+            2*(v2+v1-2)*_v22**2 / v1 / (v2-4),
+            np.inf)
+        _v122 = v1 + v2 -2.
+        g1 = where(v2 > 6, 
+            2 * (v1 + _v122) / (v2-6) * sqrt((2*v2-8) / (v1*_v122)),
+            np.nan)
+        g2 = where(v2 > 8, 
+            3/(2*v2-16)*(8+g1*g1*(v2-6)), 
+            nan)
         return mu, mu2, g1, g2
 f = f_gen(a=0.0, name='f')
 

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -7490,22 +7490,17 @@ class hypergeom_gen(rv_discrete):
         return exp(self._logpmf(k, M, n, N))
 
     def _stats(self, M, n, N):
-        tot, good = M, n
-        n = good*1.0
-        m = (tot-good)*1.0
-        N = N*1.0
-        tot = m+n
-        p = n/tot
+        M, n, N = 1.*M, 1.*n, 1.*N
+        m = M - n
+        p = n/M
         mu = N*p
-        var = m*n*N*(tot-N)*1.0/(tot*tot*(tot-1))
-        g1 = (m - n)*(tot-2*N) / (tot-2.0)*sqrt((tot-1.0)/(m*n*N*(tot-N)))
-        m2, m3, m4, m5 = m**2, m**3, m**4, m**5
-        n2, n3, n4, n5 = n**2, n**2, n**4, n**5
-        g2 = m3 - m5 + n*(3*m2-6*m3+m4) + 3*m*n2 - 12*m2*n2 + 8*m3*n2 + n3 \
-             - 6*m*n3 + 8*m2*n3 + m*n4 - n5 - 6*m3*N + 6*m4*N + 18*m2*n*N \
-             - 6*m3*n*N + 18*m*n2*N - 24*m2*n2*N - 6*n3*N - 6*m*n3*N \
-             + 6*n4*N + N*N*(6*m2 - 6*m3 - 24*m*n + 12*m2*n + 6*n2 +
-                             12*m*n2 - 6*n3)
+        var = m*n*N*(M - N)*1.0/(M*M*(M-1))
+        g1 = (m - n)*(M-2*N) / (M-2.0) * sqrt((M-1.0) / (m*n*N*(M-N)))
+
+        g2 = M*(M+1) - 6.*N*(M-N) - 6.*n*m
+        g2 *= (M-1)*M*M
+        g2 += 6.*n*N*(M-N)*m*(5.*M-6)
+        g2 /= n * N * (M-N) * m * (M-2.) * (M-3.)
         return mu, var, g1, g2
 
     def _entropy(self, M, n, N):

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -3244,7 +3244,13 @@ class foldnorm_gen(rv_continuous):
         return abs(mtrand.standard_normal(self._size) + c)
 
     def _pdf(self, x, c):
-        return sqrt(2.0/pi)*cosh(c*x)*exp(-(x*x+c*c)/2.0)
+        term = exp(-(x-c)*(x-c)/2) + exp(-(x+c)*(x+c)/2)
+        return term / sqrt(2.*pi) 
+        #return sqrt(2.0/pi)*cosh(c*x)*exp(-(x*x+c*c)/2.0)
+        #return exp(self._logpdf(x, c))
+
+    #def _logpdf(self, x, c):
+    #    return log(2./pi) + log(cosh(c*x)) - (x*x + c*c)/2.
 
     def _cdf(self, x, c):
         return special.ndtr(x-c) + special.ndtr(x+c) - 1.0
@@ -3373,8 +3379,7 @@ class genlogistic_gen(rv_continuous):
 
     """
     def _pdf(self, x, c):
-        Px = c*exp(-x)/(1+exp(-x))**(c+1.0)
-        return Px
+        return exp(self._logpdf(x, c))
 
     def _logpdf(self, x, c):
         return log(c) - x - (c+1.0)*log1p(exp(-x))
@@ -3894,8 +3899,10 @@ class gompertz_gen(rv_continuous):
 
     """
     def _pdf(self, x, c):
-        ex = exp(x)
-        return c*ex*exp(-c*(ex-1))
+        return exp(self._logpdf(x, c))
+
+    def _logpdf(self, x, c):
+        return log(c) + x - c * (exp(x) - 1.)
 
     def _cdf(self, x, c):
         return 1.0-exp(-c*(exp(x)-1))
@@ -3931,8 +3938,7 @@ class gumbel_r_gen(rv_continuous):
 
     """
     def _pdf(self, x):
-        ex = exp(-x)
-        return ex*exp(-ex)
+      return exp(self._logpdf(x))
 
     def _logpdf(self, x):
         return -x - exp(-x)
@@ -3978,8 +3984,7 @@ class gumbel_l_gen(rv_continuous):
 
     """
     def _pdf(self, x):
-        ex = exp(x)
-        return ex*exp(-ex)
+        return exp(self._logpdf(x))
 
     def _logpdf(self, x):
         return x - exp(x)
@@ -4052,7 +4057,11 @@ class halflogistic_gen(rv_continuous):
 
     """
     def _pdf(self, x):
-        return 0.5/(cosh(x/2.0))**2.0
+       return exp(self._logpdf(x))
+#        return 0.5/(cosh(x/2.0))**2.0
+
+    def _logpdf(self, x):
+        return log(2) - x - 2. * special.log1p(exp(-x))
 
     def _cdf(self, x):
         return tanh(x/2.0)
@@ -4553,11 +4562,13 @@ class logistic_gen(rv_continuous):
         return mtrand.logistic(size=self._size)
 
     def _pdf(self, x):
-        ex = np.where(x>0, exp(-x), exp(x))
-        return ex / (1+ex)**2
+       return exp(self._logpdf(x))
+
+    def _logpdf(self, x):
+        return -x -2. * special.log1p(exp(-x))
 
     def _cdf(self, x):
-        return 1.0/(1+exp(-x))
+        return special.expit(x)
 
     def _ppf(self, q):
         return -log(1.0/q-1)

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -3182,7 +3182,7 @@ class f_gen(rv_continuous):
         mu = where(v2 > 2, v2 / asarray(v2 - 2), inf)
         mu2 = 2*v2*v2*(v2+v1-2)/(v1*(v2-2)**2 * (v2-4))
         mu2 = where(v2 > 4, mu2, inf)
-        g1 = 2*(v2+2*v1-2)/(v2-6)*sqrt((2*v2-4)/(v1*(v2+v1-2)))
+        g1 = 2*(v2+2*v1-2)/(v2-6)*sqrt((2*v2-8)/(v1*(v2+v1-2)))
         g1 = where(v2 > 6, g1, nan)
         g2 = 3/(2*v2-16)*(8+g1*g1*(v2-6))
         g2 = where(v2 > 8, g2, nan)

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -4553,8 +4553,8 @@ class logistic_gen(rv_continuous):
         return mtrand.logistic(size=self._size)
 
     def _pdf(self, x):
-        ex = exp(-x)
-        return ex / (1+ex)**2.0
+        ex = np.where(x>0, exp(-x), exp(x))
+        return ex / (1+ex)**2
 
     def _cdf(self, x):
         return 1.0/(1+exp(-x))

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -3099,7 +3099,7 @@ class fatiguelife_gen(rv_continuous):
 
     """
     def _rvs(self, c):
-        z = norm.rvs(size=self._size)
+        z = mtrand.standard_normal(self._size)
         x = 0.5*c*z
         x2 = x*x
         t = 1.0 + 2*x2 + 2*x*sqrt(1 + x2)
@@ -3241,7 +3241,7 @@ class foldnorm_gen(rv_continuous):
         return (c >= 0)
 
     def _rvs(self, c):
-        return abs(norm.rvs(loc=c,size=self._size))
+        return abs(mtrand.standard_normal(self._size) + c)
 
     def _pdf(self, x, c):
         return sqrt(2.0/pi)*cosh(c*x)*exp(-(x*x+c*c)/2.0)
@@ -4095,7 +4095,7 @@ class halfnorm_gen(rv_continuous):
 
     """
     def _rvs(self):
-        return abs(norm.rvs(size=self._size))
+        return abs(mtrand.standard_normal(size=self._size))
 
     def _pdf(self, x):
         return sqrt(2.0/pi)*exp(-x*x/2.0)
@@ -4253,8 +4253,8 @@ class invgauss_gen(rv_continuous):
     def _cdf(self, x, mu):
         fac = sqrt(1.0/x)
         # Numerical accuracy for small `mu` is bad.  See #869.
-        C1 = norm.cdf(fac*(x-mu)/mu)
-        C1 += exp(1.0/mu) * norm.cdf(-fac*(x+mu)/mu) * exp(1.0/mu)
+        C1 = _norm_cdf(fac*(x-mu)/mu)
+        C1 += exp(1.0/mu) * _norm_cdf(-fac*(x+mu)/mu) * exp(1.0/mu)
         return C1
 
     def _stats(self, mu):
@@ -4328,14 +4328,14 @@ class johnsonsb_gen(rv_continuous):
         return (b > 0) & (a == a)
 
     def _pdf(self, x, a, b):
-        trm = norm.pdf(a+b*log(x/(1.0-x)))
+        trm = _norm_pdf(a + b*log(x/(1.0-x)))
         return b*1.0/(x*(1-x))*trm
 
     def _cdf(self, x, a, b):
-        return norm.cdf(a+b*log(x/(1.0-x)))
+        return _norm_cdf(a + b*log(x/(1.0-x)))
 
     def _ppf(self, q, a, b):
-        return 1.0/(1+exp(-1.0/b*(norm.ppf(q)-a)))
+        return 1.0 / (1 + exp(-1.0 / b * (_norm_ppf(q) - a)))
 johnsonsb = johnsonsb_gen(a=0.0, b=1.0, name='johnsonb')
 
 
@@ -4365,14 +4365,14 @@ class johnsonsu_gen(rv_continuous):
 
     def _pdf(self, x, a, b):
         x2 = x*x
-        trm = norm.pdf(a+b*log(x+sqrt(x2+1)))
+        trm = _norm_pdf(a + b * log(x + sqrt(x2+1)))
         return b*1.0/sqrt(x2+1.0)*trm
 
     def _cdf(self, x, a, b):
-        return norm.cdf(a+b*log(x+sqrt(x*x+1)))
+        return _norm_cdf(a + b * log(x + sqrt(x*x + 1)))
 
     def _ppf(self, q, a, b):
-        return sinh((norm.ppf(q)-a)/b)
+        return sinh((_norm_ppf(q) - a) / b)
 johnsonsu = johnsonsu_gen(name='johnsonsu')
 
 
@@ -4433,14 +4433,14 @@ class levy_gen(rv_continuous):
 
     """
     def _pdf(self, x):
-        return 1/sqrt(2*pi*x)/x*exp(-1/(2*x))
+        return 1 / sqrt(2*pi*x) / x * exp(-1/(2*x))
 
     def _cdf(self, x):
-        return 2*(1-norm._cdf(1/sqrt(x)))
+        return 2 * (1 - _norm_cdf(1 / sqrt(x)))
 
     def _ppf(self, q):
-        val = norm._ppf(1-q/2.0)
-        return 1.0/(val*val)
+        val = _norm_ppf(1 - q / 2.0)
+        return 1.0 / (val * val)
 
     def _stats(self):
         return inf, inf, nan, nan
@@ -4475,11 +4475,11 @@ class levy_l_gen(rv_continuous):
 
     def _cdf(self, x):
         ax = abs(x)
-        return 2*norm._cdf(1/sqrt(ax))-1
+        return 2 * _norm_cdf(1 / sqrt(ax)) - 1
 
     def _ppf(self, q):
-        val = norm._ppf((q+1.0)/2)
-        return -1.0/(val*val)
+        val = _norm_ppf((q + 1.0) / 2)
+        return -1.0 / (val * val)
 
     def _stats(self):
         return inf, inf, nan, nan
@@ -5030,7 +5030,7 @@ class nct_gen(rv_continuous):
         return (df > 0) & (nc == nc)
 
     def _rvs(self, df, nc):
-        return norm.rvs(loc=nc,size=self._size)*sqrt(df) / sqrt(chi2.rvs(df,size=self._size))
+        return norm.rvs(loc=nc, size=self._size)*sqrt(df) / sqrt(chi2.rvs(df, size=self._size))
 
     def _pdf(self, x, df, nc):
         n = df*1.0
@@ -5373,13 +5373,13 @@ class powerlognorm_gen(rv_continuous):
 
     """
     def _pdf(self, x, c, s):
-        return c/(x*s)*norm.pdf(log(x)/s)*pow(norm.cdf(-log(x)/s),c*1.0-1.0)
+        return c/(x*s) * _norm_pdf(log(x)/s) * pow(_norm_cdf(-log(x)/s), c*1.0-1.0)
 
     def _cdf(self, x, c, s):
-        return 1.0 - pow(norm.cdf(-log(x)/s),c*1.0)
+        return 1.0 - pow(_norm_cdf(-log(x)/s),c*1.0)
 
     def _ppf(self, q, c, s):
-        return exp(-s*norm.ppf(pow(1.0-q,1.0/c)))
+        return exp(-s * _norm_ppf(pow(1.0 - q, 1.0 / c)))
 powerlognorm = powerlognorm_gen(a=0.0, name="powerlognorm")
 
 
@@ -5411,7 +5411,7 @@ class powernorm_gen(rv_continuous):
         return 1.0-_norm_cdf(-x)**(c*1.0)
 
     def _ppf(self, q, c):
-        return -norm.ppf(pow(1.0-q,1.0/c))
+        return -_norm_ppf(pow(1.0 - q, 1.0 / c))
 powernorm = powernorm_gen(name='powernorm')
 
 

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -5443,11 +5443,11 @@ class rdist_gen(rv_continuous):
         # background.
         if any(np.isnan(res)):
             return rv_continuous._cdf(self, x, c)
-
         return res
 
     def _munp(self, n, c):
-        return (1 - (n % 2)) * special.beta((n + 1.0) / 2, c / 2.0)
+        numerator = (1 - (n % 2)) * special.beta((n + 1.0) / 2, c / 2.0) 
+        return numerator / special.beta(1./2, c/2.)
 rdist = rdist_gen(a=-1.0, b=1.0, name="rdist")
 
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -188,6 +188,7 @@ def test_cont_basic():
               'sample mean test'
         # the sample skew kurtosis test has known failures, not very good distance measure
         # yield check_sample_skew_kurt, distfn, arg, sskew, skurt, distname
+        yield check_normalization, distfn, arg, distname
         yield check_moment, distfn, arg, m, v, distname
         yield check_cdf_ppf, distfn, arg, distname
         yield check_sf_isf, distfn, arg, distname
@@ -417,6 +418,17 @@ def check_distribution_rvs(dist, args, alpha, rvs):
         D,pval = stats.kstest(dist,'',args=args, N=1000)
         npt.assert_(pval > alpha, "D = " + str(D) + "; pval = " + str(pval) +
                "; alpha = " + str(alpha) + "\nargs = " + str(args))
+
+
+def check_normalization(distfn, args, distname):
+    norm_moment = distfn.moment(0, *args)
+    npt.assert_allclose(norm_moment, 1.0)
+
+    norm_expect = distfn.expect(lambda x: 1, args=args)
+    npt.assert_allclose(norm_expect, 1.0, err_msg=distname, verbose=True)
+
+    norm_cdf = distfn.cdf(distfn.b, *args)
+    npt.assert_allclose(norm_cdf, 1.0)
 
 
 def check_named_args(distfn, x, shape_args, defaults, meths):

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -277,11 +277,14 @@ def check_moment(distfn, arg, m, v, s, k, msg):
         m2e = distfn.expect(lambda x: np.power(x - m1, 2), arg)
         if np.isfinite(m2e):
             m3e = distfn.expect(lambda x: np.power(x - m1, 3), arg)
-            npt.assert_almost_equal(m3e, s * np.power(m2e, 1.5), decimal=5)
+            npt.assert_allclose(m3e, s * np.power(m2e, 1.5), 
+                        atol=1e-7, rtol=1e-7)
 
         if not np.isnan(k) and np.isfinite(m2e):
             m4e = distfn.expect(lambda x: np.power(x - m1, 4), arg)
-            npt.assert_almost_equal(m4e, (k+3.) * m2e**2, decimal=5)
+            npt.assert_allclose(m4e, (k+3.) * m2e**2, 
+                        atol=1e-7, rtol=1e-7)
+
 
 def check_sample_meanvar_(distfn, arg, m, v, sm, sv, sn, msg):
     # this did not work, skipped silently by nose

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -242,6 +242,7 @@ def test_cont_basic_slow():
               'sample mean test'
         # the sample skew kurtosis test has known failures, not very good distance measure
         #yield check_sample_skew_kurt, distfn, arg, sskew, skurt, distname
+        yield check_normalization, distfn, arg, distname
         yield check_moment, distfn, arg, m, v, s, k, distname
         yield check_cdf_ppf, distfn, arg, distname
         yield check_sf_isf, distfn, arg, distname

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -59,7 +59,7 @@ distcont = [
     ['gausshyper', (13.763771604130699, 3.1189636648681431,
                     2.5145980350183019, 5.1811649903971615)],  # veryslow
     ['genexpon', (9.1325976465418908, 16.231956600590632, 3.2819552690843983)],
-    ['genextreme', (-0.1,)],  # sample mean test fails for (3.3184017469423535,)],
+    ['genextreme', (-0.1,)],
     ['gengamma', (4.4162385429431925, 3.1193091679242761)],
     ['genhalflogistic', (0.77274727809929322,)],
     ['genlogistic', (0.41192440799679475,)],
@@ -74,7 +74,7 @@ distcont = [
     ['hypsecant', ()],
     ['invgamma', (2.0668996136993067,)],
     ['invgauss', (0.14546264555347513,)],
-    ['invweibull', (10.58,)],  # sample mean test fails at(0.58847112119264788,)]
+    ['invweibull', (10.58,)],
     ['johnsonsb', (4.3172675099141058, 3.1837781130785063)],
     ['johnsonsu', (2.554395574161155, 2.2482281679651965)],
     ['ksone', (1000,)],  # replace 22 by 100 to avoid failing range, ticket 956
@@ -91,8 +91,7 @@ distcont = [
     ['lognorm', (0.95368226960575331,)],
     ['lomax', (1.8771398388773268,)],
     ['maxwell', ()],
-    ['mielke', (10.4, 3.6)],  # sample mean test fails for (4.6420495492121487, 0.59707419545516938)],
-                             # mielke: good results if 2nd parameter >2, weird mean or var below
+    ['mielke', (10.4, 3.6)], # mielke: good results if 2nd parameter >2, weird mean or var below
     ['nakagami', (4.9673794866666237,)],
     ['ncf', (27, 27, 0.41578441799226107)],
     ['nct', (14, 0.24045031331198066)],
@@ -121,6 +120,17 @@ distcont = [
     ['weibull_max', (2.8687961709100187,)],
     ['weibull_min', (1.7866166930421596,)],
     ['wrapcauchy', (0.031071279018614728,)]]
+
+distcont_extra = [
+    ['betaprime', (100, 86)],
+    ['fatiguelife', (5,)],
+    ['mielke', (4.6420495492121487, 0.59707419545516938)],
+    ['invweibull', (0.58847112119264788,)],
+    # burr: sample mean test fails still for c<1
+    #['burr', (0.94839838075366045, 4.3820284068855795)],
+    # genextreme: sample mean test, sf-logsf test fail
+    #['genextreme', (3.3184017469423535,)],
+]
 
 # for testing only specific functions
 # distcont = [
@@ -172,7 +182,7 @@ def _silence_fp_errors(func):
 
 def test_cont_basic():
     # this test skips slow distributions
-    for distname, arg in distcont[:]:
+    for distname, arg in distcont[:] + distcont_extra[:]:
         if distname in distslow:
             continue
         distfn = getattr(stats, distname)
@@ -231,7 +241,7 @@ def test_cont_basic_slow():
         yield check_sample_meanvar_, distfn, arg, m, v, sm, sv, sn, distname + \
               'sample mean test'
         # the sample skew kurtosis test has known failures, not very good distance measure
-        # yield check_sample_skew_kurt, distfn, arg, sskew, skurt, distname
+        #yield check_sample_skew_kurt, distfn, arg, sskew, skurt, distname
         yield check_moment, distfn, arg, m, v, s, k, distname
         yield check_cdf_ppf, distfn, arg, distname
         yield check_sf_isf, distfn, arg, distname
@@ -277,12 +287,12 @@ def check_moment(distfn, arg, m, v, s, k, msg):
         m2e = distfn.expect(lambda x: np.power(x - m1, 2), arg)
         if np.isfinite(m2e):
             m3e = distfn.expect(lambda x: np.power(x - m1, 3), arg)
-            npt.assert_allclose(m3e, s * np.power(m2e, 1.5), 
+            npt.assert_allclose(m3e, s * np.power(m2e, 1.5),
                         atol=1e-7, rtol=1e-7)
 
         if not np.isnan(k) and np.isfinite(m2e):
             m4e = distfn.expect(lambda x: np.power(x - m1, 4), arg)
-            npt.assert_allclose(m4e, (k+3.) * m2e**2, 
+            npt.assert_allclose(m4e, (k+3.) * m2e**2,
                         atol=1e-7, rtol=1e-7)
 
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -157,6 +157,7 @@ distslow = ['rdist', 'gausshyper', 'recipinvgauss', 'ksone', 'genexpon',
 # distslow are sorted by speed (very slow to slow)
 
 
+# NB: not needed anymore?
 def _silence_fp_errors(func):
     # warning: don't apply to test_ functions as is, then those will be skipped
     def wrap(*a, **kw):
@@ -255,8 +256,6 @@ def test_cont_basic_slow():
         yield check_named_args, distfn, x, arg, locscale_defaults, meths
 
 
-
-@_silence_fp_errors
 def check_moment(distfn, arg, m, v, msg):
     m1 = distfn.moment(1,*arg)
     m2 = distfn.moment(2,*arg)
@@ -266,27 +265,20 @@ def check_moment(distfn, arg, m, v, msg):
     else:                     # or np.isnan(m1),
         npt.assert_(np.isinf(m1),
                msg + ' - 1st moment -infinite, m1=%s' % str(m1))
-        # np.isnan(m1) temporary special treatment for loggamma
     if not np.isinf(v):
         npt.assert_almost_equal(m2-m1*m1, v, decimal=10, err_msg=msg +
                             ' - 2ndt moment')
     else:                     # or np.isnan(m2),
         npt.assert_(np.isinf(m2),
                msg + ' - 2nd moment -infinite, m2=%s' % str(m2))
-        # np.isnan(m2) temporary special treatment for loggamma
 
 
-@_silence_fp_errors
 def check_sample_meanvar_(distfn, arg, m, v, sm, sv, sn, msg):
     # this did not work, skipped silently by nose
-    # check_sample_meanvar, sm, m, msg + 'sample mean test'
-    # check_sample_meanvar, sv, v, msg + 'sample var test'
     if not np.isinf(m):
         check_sample_mean(sm, sv, sn, m)
     if not np.isinf(v):
         check_sample_var(sv, sn, v)
-##    check_sample_meanvar(sm, m, msg + 'sample mean test')
-##    check_sample_meanvar(sv, v, msg + 'sample var test')
 
 
 def check_sample_mean(sm,v,n, popmean):
@@ -328,15 +320,6 @@ def check_sample_skew_kurt(distfn, arg, ss, sk, msg):
     check_sample_meanvar(ss, skew, msg + 'sample skew test')
 
 
-def check_sample_meanvar(sm,m,msg):
-    if not np.isinf(m) and not np.isnan(m):
-        npt.assert_almost_equal(sm, m, decimal=DECIMAL, err_msg=msg +
-                                ' - finite moment')
-##    else:
-##        npt.assert_(abs(sm) > 10000), msg='infinite moment, sm = ' + str(sm))
-
-
-@_silence_fp_errors
 def check_cdf_ppf(distfn,arg,msg):
     values = [0.001, 0.5, 0.999]
     npt.assert_almost_equal(distfn.cdf(distfn.ppf(values, *arg), *arg),
@@ -344,7 +327,6 @@ def check_cdf_ppf(distfn,arg,msg):
                             ' - cdf-ppf roundtrip')
 
 
-@_silence_fp_errors
 def check_sf_isf(distfn,arg,msg):
     npt.assert_almost_equal(distfn.sf(distfn.isf([0.1,0.5,0.9], *arg), *arg),
                             [0.1,0.5,0.9], decimal=DECIMAL, err_msg=msg +
@@ -355,7 +337,6 @@ def check_sf_isf(distfn,arg,msg):
                             ' - cdf-sf relationship')
 
 
-@_silence_fp_errors
 def check_pdf(distfn, arg, msg):
     # compares pdf at median with numerical derivative of cdf
     median = distfn.ppf(0.5, *arg)
@@ -373,7 +354,6 @@ def check_pdf(distfn, arg, msg):
                 decimal=DECIMAL, err_msg=msg + ' - cdf-pdf relationship')
 
 
-@_silence_fp_errors
 def check_pdf_logpdf(distfn, args, msg):
     # compares pdf at several points with the log of the pdf
     points = np.array([0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
@@ -385,7 +365,6 @@ def check_pdf_logpdf(distfn, args, msg):
     npt.assert_almost_equal(np.log(pdf), logpdf, decimal=7, err_msg=msg + " - logpdf-log(pdf) relationship")
 
 
-@_silence_fp_errors
 def check_sf_logsf(distfn, args, msg):
     # compares sf at several points with the log of the sf
     points = np.array([0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
@@ -397,7 +376,6 @@ def check_sf_logsf(distfn, args, msg):
     npt.assert_almost_equal(np.log(sf), logsf, decimal=7, err_msg=msg + " - logsf-log(sf) relationship")
 
 
-@_silence_fp_errors
 def check_cdf_logcdf(distfn, args, msg):
     # compares cdf at several points with the log of the cdf
     points = np.array([0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
@@ -409,7 +387,6 @@ def check_cdf_logcdf(distfn, args, msg):
     npt.assert_almost_equal(np.log(cdf), logcdf, decimal=7, err_msg=msg + " - logcdf-log(cdf) relationship")
 
 
-@_silence_fp_errors
 def check_distribution_rvs(dist, args, alpha, rvs):
     # test from scipy.stats.tests
     # this version reuses existing random variables
@@ -424,8 +401,16 @@ def check_normalization(distfn, args, distname):
     norm_moment = distfn.moment(0, *args)
     npt.assert_allclose(norm_moment, 1.0)
 
+    # this is a temporary plug: either ncf or expect is problematic; 
+	# best be marked as a knownfail, but I've no clue how to do it.
+    if distname == "ncf":
+        atol, rtol = 1e-5, 0
+    else:
+        atol, rtol = 1e-7, 1e-7
+
     norm_expect = distfn.expect(lambda x: 1, args=args)
-    npt.assert_allclose(norm_expect, 1.0, err_msg=distname, verbose=True)
+    npt.assert_allclose(norm_expect, 1.0, atol=atol, rtol=rtol,
+            err_msg=distname, verbose=True)
 
     norm_cdf = distfn.cdf(distfn.b, *args)
     npt.assert_allclose(norm_cdf, 1.0)

--- a/scipy/stats/tests/test_continuous_extra.py
+++ b/scipy/stats/tests/test_continuous_extra.py
@@ -132,5 +132,20 @@ def test_rdist_cdf_gh1285():
                             values, decimal=5)
 
 
+def test_nct_inf_moments():
+    # n-th moment of nct only exists for df > n
+    m, v, s, k = stats.nct.stats(df=1.9, nc = 0.3, moments='mvsk')
+    npt.assert_(np.isfinite(m))
+    npt.assert_(not np.isfinite(v))
+    npt.assert_(not np.isfinite(s))
+    npt.assert_(not np.isfinite(k))
+
+    m, v, s, k = stats.nct.stats(df=3.1, nc = 0.3, moments='mvsk')
+    npt.assert_(np.isfinite(m))
+    npt.assert_(np.isfinite(v))
+    npt.assert_(np.isfinite(s))
+    npt.assert_(not np.isfinite(k))
+
+
 if __name__ == "__main__":
     npt.run_module_suite()

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -43,6 +43,7 @@ def test_discrete_basic():
         m, v, s, k = distfn.stats(*arg, moments='mvsk')
         #yield npt.assert_almost_equal(rvs.mean(), m, decimal=4,err_msg='mean')
         # yield npt.assert_almost_equal, rvs.mean(), m, 2, 'mean' # does not work
+        yield check_normalization, distfn, arg, distname
         yield check_sample_meanvar, rvs.mean(), m, distname + ' sample mean test'
         yield check_sample_meanvar, rvs.var(), v, distname + ' sample var test'
         yield check_moment, distfn, arg, m, v, s, k, distname
@@ -193,17 +194,6 @@ def check_moment(distfn, arg, m, v, s, k, msg):
             npt.assert_allclose(m4e, (k+3.) * m2e**2,
                         atol=1e-7, rtol=1e-7)
 
-'''
-# these are not run anyway
-def check_generic_moment(distfn, arg, m, k, decim):
-    npt.assert_almost_equal(distfn.generic_moment(k,*arg), m, decimal=decim,
-                            err_msg=str(distfn) + ' generic moment test')
-
-
-def check_moment_frozen(distfn, arg, m, k, decim):
-    npt.assert_almost_equal(distfn(*arg).moment(k), m, decimal=decim,
-                            err_msg=str(distfn) + ' frozen moment test')
-'''
 
 def check_oth(distfn, arg, msg):
     # checking other methods of distfn
@@ -323,6 +313,19 @@ def check_discrete_chisquare(distfn, arg, rvs, alpha, msg):
 
     npt.assert_(pval > alpha, 'chisquare - test for %s'
            ' at arg = %s with pval = %s' % (msg,str(arg),str(pval)))
+
+
+# this is a copy-paste from test_discrete_basic; FIXME
+def check_normalization(distfn, args, distname):
+    norm_moment = distfn.moment(0, *args)
+    npt.assert_allclose(norm_moment, 1.0)
+
+    norm_expect = distfn.expect(lambda x: 1, args=args)
+    npt.assert_allclose(norm_expect, 1.0, atol=1e-7, rtol=1e-7,
+            err_msg=distname, verbose=True)
+
+    norm_cdf = distfn.cdf(distfn.b, *args)
+    npt.assert_allclose(norm_cdf, 1.0)
 
 
 def check_named_args(distfn, x, shape_args, defaults, meths):

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -26,10 +26,10 @@ distdiscrete = [
     ['planck', (0.51,)],   # 4.1
     ['poisson', (0.6,)],
     ['randint', (7, 31)],
-    ['skellam', (15, 8)]]
-#    ['zipf',     (4,)] ]   # arg=4 is ok,
+    ['skellam', (15, 8)],
+    ['zipf',    (6,)]    # arg=4 is ok,
                            # Zipf broken for arg = 2, e.g. weird .stats
-                           # looking closer, mean, var should be inf for arg=2
+]                          # looking closer, mean, var should be inf for arg=2
 
 
 #@npt.dec.slow
@@ -41,7 +41,7 @@ def test_discrete_basic():
         rvs = distfn.rvs(size=2000,*arg)
         supp = np.unique(rvs)
         m, v, s, k = distfn.stats(*arg, moments='mvsk')
-        # yield npt.assert_almost_equal(rvs.mean(), m, decimal=4,err_msg='mean')
+        #yield npt.assert_almost_equal(rvs.mean(), m, decimal=4,err_msg='mean')
         # yield npt.assert_almost_equal, rvs.mean(), m, 2, 'mean' # does not work
         yield check_sample_meanvar, rvs.mean(), m, distname + ' sample mean test'
         yield check_sample_meanvar, rvs.var(), v, distname + ' sample var test'
@@ -50,21 +50,15 @@ def test_discrete_basic():
         yield check_cdf_ppf2, distfn, arg, supp, distname + ' cdf_ppf'
         yield check_pmf_cdf, distfn, arg, distname + ' pmf_cdf'
 
-        # zipf doesn't fail, but generates floating point warnings.
-        # Should be checked.
-        if not distname in ['zipf']:
-            yield check_oth, distfn, arg, distname + ' oth'
-            skurt = stats.kurtosis(rvs)
-            sskew = stats.skew(rvs)
-            yield check_sample_skew_kurt, distfn, arg, skurt, sskew, \
-                          distname + ' skew_kurt'
+        yield check_oth, distfn, arg, distname + ' oth'
+        skurt = stats.kurtosis(rvs)
+        sskew = stats.skew(rvs)
+        yield check_sample_skew_kurt, distfn, arg, skurt, sskew, \
+                      distname + ' skew_kurt'
 
-        # dlaplace doesn't fail, but generates lots of floating point warnings.
-        # Should be checked.
-        if not distname in ['dlaplace']:  # ['logser']:  #known failure, fixed
-            alpha = 0.01
-            yield check_discrete_chisquare, distfn, arg, rvs, alpha, \
-                          distname + ' chisquare'
+        alpha = 0.01
+        yield check_discrete_chisquare, distfn, arg, rvs, alpha, \
+                      distname + ' chisquare'
 
     seen = set()
     for distname, arg in distdiscrete:
@@ -134,7 +128,7 @@ def check_cdf_ppf(distfn,arg,msg):
 
 def check_cdf_ppf2(distfn,arg,supp,msg):
     npt.assert_array_equal(distfn.ppf(distfn.cdf(supp,*arg),*arg),
-                           supp, msg + '-roundtrip')
+                           supp, msg + '-roundtrip', verbose=True)
     npt.assert_array_equal(distfn.ppf(distfn.cdf(supp,*arg)-1e-8,*arg),
                            supp, msg + '-roundtrip')
     # -1e-8 could cause an error if pmf < 1e-8
@@ -375,5 +369,4 @@ def check_scale_docstring(distfn):
 
 
 if __name__ == "__main__":
-    # nose.run(argv=['', __file__])
     nose.runmodule(argv=[__file__,'-s'], exit=False)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -513,6 +513,23 @@ class TestZipf(TestCase):
         assert_(isinstance(val, numpy.ndarray))
         assert_(val.dtype.char in typecodes['AllInteger'])
 
+    def test_moments(self):
+        # n-th raw moment only exists for a>n+1
+        z = stats.zipf(1.5)
+        m, v, s, k = z.stats(moments='mvsk')
+        assert_(not np.isfinite(m))
+        assert_(not np.isfinite(v))
+        assert_(not np.isfinite(s))
+        assert_(not np.isfinite(k))
+
+        z = stats.zipf(3.5)
+        m, v, s, k = z.stats(moments='mvsk')
+        assert_(np.isfinite(m))
+        assert_(np.isfinite(v))
+        assert_(not np.isfinite(s))
+        assert_(not np.isfinite(k))
+
+
 
 class TestDLaplace(TestCase):
     def test_rvs(self):


### PR DESCRIPTION
_this is work in progress_

Check 3rd and 4th moments for continuous distributions, `moment` vs `expect`. Fix several errors in formulas in distribution-specific  `_stats` and/or `_munp`. 

Addresses https://github.com/scipy/scipy/issues/1329, fixes https://github.com/scipy/scipy/issues/1866.

~~Only continuous distributions are tested for now.~~ Added the test for discrete ones. 

At the moment, there are five fails left: ~~nct and~~ `ncf` (looks like an overflow is involved), `vonmises` and `kstwobign`,  `boltzmann` (accuracy?) and `hypergeom`.

Re-enabling sample tests for skew and kurtosis leads to 70+ failures.  

Would appreciate any comments. (@josef-pkt: how do these tests, `check_moment` in test_continuous_basic compare to your investigations in https://github.com/scipy/scipy/issues/1329 ?) 
