### PR TITLE
[MRG] use BLAS in scipy.spatial.distance (and waste less memory)

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -249,16 +249,19 @@ def sqeuclidean(u, v):
         The squared Euclidean distance between vectors `u` and `v`.
 
     """
-    u = _validate_vector(u)
-    v = _validate_vector(v)
+    # Preserve float dtypes, but convert everything else to np.float64
+    # for stability.
+    utype, vtype = None, None
+    if not (hasattr(u, "dtype") and np.issubdtype(u.dtype, np.inexact)):
+        utype = np.float64
+    if not (hasattr(v, "dtype") and np.issubdtype(v.dtype, np.inexact)):
+        vtype = np.float64
+
+    u = _validate_vector(u, dtype=utype)
+    v = _validate_vector(v, dtype=vtype)
     u_v = u - v
-    if (np.issubdtype(u_v.dtype, np.floating)
-        or u_v.dtype.itemsize >= np.dtype('intp').itemsize):
-        d = np.dot(u_v, u_v)
-    else:
-        # rely on the squaring and sum to upcast to a large enough type
-        d = np.sum(u_v ** 2)
-    return d
+
+    return np.dot(u_v, u_v)
 
 
 def cosine(u, v):

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -68,12 +68,12 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 import numpy as np
-from numpy.linalg import norm
 
 from scipy.lib.six import callable, string_types
 from scipy.lib.six import xrange
 
 from . import _distance_wrap
+from ..linalg import norm
 import collections
 
 
@@ -251,8 +251,14 @@ def sqeuclidean(u, v):
     """
     u = _validate_vector(u)
     v = _validate_vector(v)
-    dist = ((u - v) ** 2).sum()
-    return dist
+    u_v = u - v
+    if (np.issubdtype(u_v.dtype, np.floating)
+        or u_v.dtype.itemsize >= np.dtype('intp').itemsize):
+        d = np.dot(u_v, u_v)
+    else:
+        # rely on the squaring and sum to upcast to a large enough type
+        d = np.sum(u_v ** 2)
+    return d
 
 
 def cosine(u, v):

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -38,7 +38,7 @@ from __future__ import division, print_function, absolute_import
 import os.path
 from scipy.lib.six import xrange
 
-from nose.tools import assert_greater_equal
+from nose.tools import assert_true
 
 import numpy as np
 from numpy.linalg import norm
@@ -1872,15 +1872,22 @@ def test_euclideans():
 def test_sqeuclidean_dtypes():
     """Assert that sqeuclidean returns the right types of values.
 
-    Integer types should be upcast to intp or larger. Floating point types
-    should be the same as the input.
+    Integer types should be converted to floating for stability.
+    Floating point types should be the same as the input.
     """
     x = [1, 2, 3]
     y = [4, 5, 6]
 
     for dtype in [np.int8, np.int16, np.int32, np.int64]:
         d = sqeuclidean(np.asarray(x, dtype=dtype), np.asarray(y, dtype=dtype))
-        assert_greater_equal(d.nbytes, np.dtype('intp').itemsize)
+        assert_true(np.issubdtype(d.dtype, np.floating))
+
+    for dtype in [np.uint8, np.uint16, np.uint32, np.uint64]:
+        d1 = sqeuclidean([0], np.asarray([-1], dtype=dtype))
+        d2 = sqeuclidean(np.asarray([-1], dtype=dtype), [0])
+
+        assert_equal(d1, d2)
+        assert_equal(d1, np.float64(np.iinfo(dtype).max) ** 2)
 
     for dtype in [np.float16, np.float32, np.float64, np.float128,
                   np.complex64, np.complex128]:

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -38,6 +38,8 @@ from __future__ import division, print_function, absolute_import
 import os.path
 from scipy.lib.six import xrange
 
+from nose.tools import assert_greater_equal
+
 import numpy as np
 from numpy.linalg import norm
 from numpy.testing import (verbose, TestCase, run_module_suite,
@@ -1865,6 +1867,25 @@ def test_euclideans():
     d1 = euclidean(x, y)
     d2 = sqeuclidean(x, y)
     assert_almost_equal(d1**2, d2, decimal=14)
+
+
+def test_sqeuclidean_dtypes():
+    """Assert that sqeuclidean returns the right types of values.
+
+    Integer types should be upcast to intp or larger. Floating point types
+    should be the same as the input.
+    """
+    x = [1, 2, 3]
+    y = [4, 5, 6]
+
+    for dtype in [np.int8, np.int16, np.int32, np.int64]:
+        d = sqeuclidean(np.asarray(x, dtype=dtype), np.asarray(y, dtype=dtype))
+        assert_greater_equal(d.nbytes, np.dtype('intp').itemsize)
+
+    for dtype in [np.float16, np.float32, np.float64, np.float128,
+                  np.complex64, np.complex128]:
+        d = sqeuclidean(np.asarray(x, dtype=dtype), np.asarray(y, dtype=dtype))
+        assert_equal(d.dtype, dtype)
 
 
 def test_sokalmichener():


### PR DESCRIPTION
Alternative to #2815, q.v. for timings; plus, use `scipy.linalg.norm` (BLAS!) in `spatial.distance` instead of the naïve NumPy implementation.
