### PR TITLE
FIX: raise NotImplementedError, not NotImplemented

### DIFF
--- a/scipy/fftpack/realtransforms.py
+++ b/scipy/fftpack/realtransforms.py
@@ -221,7 +221,7 @@ def _dct(x, type, n=None, axis=-1, overwrite_x=False, normalize=None):
     if n is None:
         n = tmp.shape[axis]
     else:
-        raise NotImplemented("Padding/truncating not yet implemented")
+        raise NotImplementedError("Padding/truncating not yet implemented")
 
     if tmp.dtype == np.double:
         if type == 1:
@@ -435,7 +435,7 @@ def _dst(x, type, n=None, axis=-1, overwrite_x=False, normalize=None):
     if n is None:
         n = tmp.shape[axis]
     else:
-        raise NotImplemented("Padding/truncating not yet implemented")
+        raise NotImplementedError("Padding/truncating not yet implemented")
 
     if tmp.dtype == np.double:
         if type == 1:

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -309,7 +309,7 @@ class spmatrix(object):
             other_a = np.asanyarray(other)
 
             if other_a.ndim == 0 and other_a.dtype == np.object_:
-                # Not interpretable as an array; raise NotImplemented so that
+                # Not interpretable as an array; return NotImplemented so that
                 # other's __rmul__ can kick in if that's implemented.
                 return NotImplemented
 

--- a/scipy/weave/size_check.py
+++ b/scipy/weave/size_check.py
@@ -338,5 +338,5 @@ def reduction(ary,axis=0):
 
 
 def take(ary,axis=0):
-    raise NotImplemented
+    raise NotImplementedError
 # and all the rest


### PR DESCRIPTION
or else raising this error raises an error:

```
TypeError: 'NotImplementedType' object is not callable
```
