### PR TITLE
Fix windows build

### DIFF
--- a/scipy/special/c_misc/struve.c
+++ b/scipy/special/c_misc/struve.c
@@ -77,6 +77,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/* Do NOT remove python.h inclusion as it sets up configuration for stdio.h and
+ * math.h inclusion */
+#include <Python.h>
 #include <stdio.h>
 #include <math.h>
 

--- a/scipy/special/c_misc/struve.c
+++ b/scipy/special/c_misc/struve.c
@@ -77,6 +77,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stdio.h>
+#include <math.h>
+
 #include "cephes.h"
 #include "amos_wrappers.h"
 #include "misc.h"


### PR DESCRIPTION
This fixes the regression introduced by the RH5 fix for struve.c.

I have tested it on both windows (32 and 64, msvc + ifort + MKL) and RH5 (32 and 64, gcc/gfortran + MKL).
