### PR TITLE
MAINT: signal: Some clean up in _peak_finding.py:

### DIFF
--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -38,8 +38,8 @@ def _boolrelextrema(data, comparator,
     Returns
     -------
     extrema : ndarray
-        Indices of the extrema, as boolean array of same shape as data.
-        True for an extrema, False else.
+        Boolean array of the same shape as `data` that is True at an extrema,
+        False otherwise.
 
     See also
     --------
@@ -48,7 +48,7 @@ def _boolrelextrema(data, comparator,
     Examples
     --------
     >>> testdata = np.array([1,2,3,2,1])
-    >>> argrelextrema(testdata, np.greater, axis=0)
+    >>> _boolrelextrema(testdata, np.greater, axis=0)
     array([False, False,  True, False, False], dtype=bool)
 
     """
@@ -93,16 +93,30 @@ def argrelmin(data, axis=0, order=1, mode='clip'):
 
     Returns
     -------
-    extrema : ndarray
-        Indices of the minima, as an array of integers.
+    extrema : tuple of ndarrays
+        Indices of the minima in arrays of integers.  ``extrema[k]`` is
+        the array of indices of axis `k` of `data`.  Note that the
+        return value is a tuple even when `data` is one-dimensional.
 
-    See also
+    See Also
     --------
     argrelextrema, argrelmax
 
     Notes
     -----
     This function uses `argrelextrema` with np.less as comparator.
+
+    Examples
+    --------
+    >>> x = np.array([2, 1, 2, 3, 2, 0, 1, 0])
+    >>> argrelmin(x)
+    (array([1, 5]),)
+    >>> y = np.array([[1, 2, 1, 2],
+    ...               [2, 2, 0, 0],
+    ...               [5, 3, 4, 4]])
+    ...
+    >>> argrelmin(y, axis=1)
+    (array([0, 2]), array([2, 1]))
 
     """
     return argrelextrema(data, np.less, axis, order, mode)
@@ -131,10 +145,12 @@ def argrelmax(data, axis=0, order=1, mode='clip'):
 
     Returns
     -------
-    extrema : ndarray
-        Indices of the maxima, as an array of integers.
+    extrema : tuple of ndarrays
+        Indices of the maxima in arrays of integers.  ``extrema[k]`` is
+        the array of indices of axis `k` of `data`.  Note that the
+        return value is a tuple even when `data` is one-dimensional.
 
-    See also
+    See Also
     --------
     argrelextrema, argrelmin
 
@@ -142,6 +158,17 @@ def argrelmax(data, axis=0, order=1, mode='clip'):
     -----
     This function uses `argrelextrema` with np.greater as comparator.
 
+    Examples
+    --------
+    >>> x = np.array([2, 1, 2, 3, 2, 0, 1, 0])
+    >>> argrelmax(x)
+    (array([3, 6]),)
+    >>> y = np.array([[1, 2, 1, 2],
+    ...               [2, 2, 0, 0],
+    ...               [5, 3, 4, 4]])
+    ...
+    >>> argrelmax(y, axis=1)
+    (array([0]), array([1]))
     """
     return argrelextrema(data, np.greater, axis, order, mode)
 
@@ -171,21 +198,31 @@ def argrelextrema(data, comparator, axis=0, order=1, mode='clip'):
 
     Returns
     -------
-    extrema : ndarray
-        Indices of the extrema, as an array of integers (same format as
-        np.argmin, np.argmax).
+    extrema : tuple of ndarrays
+        Indices of the maxima in arrays of integers.  ``extrema[k]`` is
+        the array of indices of axis `k` of `data`.  Note that the
+        return value is a tuple even when `data` is one-dimensional.
 
-    See also
+    See Also
     --------
     argrelmin, argrelmax
+
+    Examples
+    --------
+    >>> x = np.array([2, 1, 2, 3, 2, 0, 1, 0])
+    >>> argrelextrema(x, np.greater)
+    (array([3, 6]),)
+    >>> y = np.array([[1, 2, 1, 2],
+    ...               [2, 2, 0, 0],
+    ...               [5, 3, 4, 4]])
+    ...
+    >>> argrelextrema(y, np.less, axis=1)
+    (array([0, 2]), array([2, 1]))
 
     """
     results = _boolrelextrema(data, comparator,
                               axis, order, mode)
-    if ~results.any():
-        return (np.array([]),) * 2
-    else:
-        return np.where(results)
+    return np.where(results)
 
 
 def _identify_ridge_lines(matr, max_distances, gap_thresh):
@@ -226,11 +263,11 @@ def _identify_ridge_lines(matr, max_distances, gap_thresh):
     Examples
     --------
     >>> data = np.random.rand(5,5)
-    >>> ridge_lines = identify_ridge_lines(data, 1, 1)
+    >>> ridge_lines = _identify_ridge_lines(data, 1, 1)
 
     Notes
     -----
-    This function is intended to be used in conjuction with `cwt`
+    This function is intended to be used in conjunction with `cwt`
     as part of `find_peaks_cwt`.
 
     """

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -3,15 +3,14 @@ from __future__ import division, print_function, absolute_import
 import copy
 
 import numpy as np
-from numpy.testing import TestCase, run_module_suite, assert_equal, \
-    assert_almost_equal, assert_array_equal, assert_array_almost_equal, \
-    assert_raises, assert_
-from scipy.signal._peak_finding import argrelmax, find_peaks_cwt, _identify_ridge_lines
+from numpy.testing import (TestCase, run_module_suite, assert_equal,
+    assert_array_equal, assert_)
+from scipy.signal._peak_finding import (argrelmax, argrelmin,
+    find_peaks_cwt, _identify_ridge_lines)
 from scipy.lib.six import xrange
 
 
 def _gen_gaussians(center_locs, sigmas, total_length):
-    num_peaks = len(sigmas)
     xdata = np.arange(0, total_length).astype(float)
     out_data = np.zeros(total_length, dtype=float)
     for ind, sigma in enumerate(sigmas):
@@ -163,15 +162,70 @@ class TestRidgeLines(TestCase):
             np.testing.assert_array_less(np.abs(agaps), max(gaps) + 0.1)
 
 
-class TestArgrelmax(TestCase):
+class TestArgrel(TestCase):
 
-    def test_highorder(self, order=2):
+    def test_empty(self):
+        # Regression test for gh-2832.
+        # When there are no relative extrema, make sure that
+        # the number of empty arrays returned matches the
+        # dimension of the input.
+
+        empty_array = np.array([], dtype=int)
+
+        z1 = np.zeros(5)
+
+        i = argrelmin(z1)
+        assert_equal(len(i), 1)
+        assert_array_equal(i[0], empty_array)
+
+        z2 = np.zeros((3,5))
+
+        row, col = argrelmin(z2, axis=0)
+        assert_array_equal(row, empty_array)
+        assert_array_equal(col, empty_array)
+
+        row, col = argrelmin(z2, axis=1)
+        assert_array_equal(row, empty_array)
+        assert_array_equal(col, empty_array)
+
+    def test_basic(self):
+        # Note: the docstrings for the argrel{min,max,extrema} functions
+        # do not give a guarantee of the order of the indices, so we'll
+        # sort them before testing.
+
+        x = np.array([[1, 2, 2, 3, 2],
+                      [2, 1, 2, 2, 3],
+                      [3, 2, 1, 2, 2],
+                      [2, 3, 2, 1, 2],
+                      [1, 2, 3, 2, 1]])
+
+        row, col = argrelmax(x, axis=0)
+        order = np.argsort(row)
+        assert_equal(row[order], [1, 2, 3])
+        assert_equal(col[order], [4, 0, 1])
+
+        row, col = argrelmax(x, axis=1)
+        order = np.argsort(row)
+        assert_equal(row[order], [0, 3, 4])
+        assert_equal(col[order], [3, 1, 2])
+
+        row, col = argrelmin(x, axis=0)
+        order = np.argsort(row)
+        assert_equal(row[order], [1, 2, 3])
+        assert_equal(col[order], [1, 2, 3])
+
+        row, col = argrelmin(x, axis=1)
+        order = np.argsort(row)
+        assert_equal(row[order], [1, 2, 3])
+        assert_equal(col[order], [1, 2, 3])
+
+    def test_highorder(self):
+        order = 2
         sigmas = [1.0, 2.0, 10.0, 5.0, 15.0]
         test_data, act_locs = _gen_gaussians_even(sigmas, 500)
         test_data[act_locs + order] = test_data[act_locs]*0.99999
         test_data[act_locs - order] = test_data[act_locs]*0.99999
-        rel_max_locs = argrelmax(test_data, order=2, mode='clip')[0]
-        #rel_max_locs = np.where(rel_max_matr)[0]
+        rel_max_locs = argrelmax(test_data, order=order, mode='clip')[0]
 
         assert_(len(rel_max_locs) == len(act_locs))
         assert_((rel_max_locs == act_locs).all())
@@ -182,8 +236,6 @@ class TestArgrelmax(TestCase):
         rot_factor = 20
         rot_range = np.arange(0, len(test_data)) - rot_factor
         test_data_2 = np.vstack([test_data, test_data[rot_range]])
-        #rel_max_matr = argrelmax(test_data_2, axis=1, order=1)
-        #rel_max_rows, rel_max_cols = np.where(rel_max_matr)
         rel_max_rows, rel_max_cols = argrelmax(test_data_2, axis=1, order=1)
 
         for rw in xrange(0, test_data_2.shape[0]):
@@ -242,6 +294,7 @@ class TestFindPeaks(TestCase):
         widths = np.arange(10, 50)
         found_locs = find_peaks_cwt(test_data, widths, min_snr=5, noise_perc=30)
         np.testing.assert_equal(len(found_locs), 0)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
- Fixed the description of the return value of argrelmin, argrelmax,
  argrelextrema and _boolrelextream.
- Fixed the example in the docstring of _boolrelextrema.
- Added examples to the docstrings of argrelmin, argrelmax and
  argrelextrema.
- Added more tests for argrelmin and argrelmax.
- Removed some commented-out code and unused imports from test_peak_finding.py
  along with an unused variable (num_peaks) in _gen_gaussians().
- Removed an argument ('order=2') from the signature of
  TestArgrel.test_higher_order() in test_peak_finding.py.
- Removed unnecessary special check in argrelextrema that incorrectly
  returned a length 2 tuple when there were no relative extrema,
  regardless of the dimension of the input.  Fixes gh-2832.
- Several more minor tweaks.
