### PR TITLE
avoid spurious divergencies in .expect

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -232,6 +232,8 @@ def test_cont_basic_slow():
               'sample mean test'
         # the sample skew kurtosis test has known failures, not very good distance measure
         # yield check_sample_skew_kurt, distfn, arg, sskew, skurt, distname
+        if distname not in ['ksone', 'vonmises']:
+            yield check_normalization, distfn, arg, distname
         yield check_moment, distfn, arg, m, v, distname
         yield check_cdf_ppf, distfn, arg, distname
         yield check_sf_isf, distfn, arg, distname
@@ -398,8 +400,8 @@ def check_distribution_rvs(dist, args, alpha, rvs):
 
 
 def check_normalization(distfn, args, distname):
-    norm_moment = distfn.moment(0, *args)
-    npt.assert_allclose(norm_moment, 1.0)
+    normalization_moment = distfn.moment(0, *args)
+    npt.assert_allclose(normalization_moment, 1.0)
 
     # this is a temporary plug: either ncf or expect is problematic; 
 	# best be marked as a knownfail, but I've no clue how to do it.
@@ -408,12 +410,12 @@ def check_normalization(distfn, args, distname):
     else:
         atol, rtol = 1e-7, 1e-7
 
-    norm_expect = distfn.expect(lambda x: 1, args=args)
-    npt.assert_allclose(norm_expect, 1.0, atol=atol, rtol=rtol,
+    normalization_expect = distfn.expect(lambda x: 1, args=args)
+    npt.assert_allclose(normalization_expect, 1.0, atol=atol, rtol=rtol,
             err_msg=distname, verbose=True)
 
-    norm_cdf = distfn.cdf(distfn.b, *args)
-    npt.assert_allclose(norm_cdf, 1.0)
+    normalization_cdf = distfn.cdf(distfn.b, *args)
+    npt.assert_allclose(normalization_cdf, 1.0)
 
 
 def check_named_args(distfn, x, shape_args, defaults, meths):

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -188,8 +188,26 @@ def check_oth(distfn, arg, msg):
     npt.assert_(distfn.cdf(median_sf + 1, *arg) > 0.5)
     npt.assert_equal(distfn.isf(0.5, *arg), distfn.ppf(0.5, *arg))
 
-# next 3 functions copied from test_continous_extra
+# next 4 functions copied from test_continous_extra
 #    adjusted
+
+def check_normalization(distfn, args, distname):
+    normalization_moment = distfn.moment(0, *args)
+    npt.assert_allclose(normalization_moment, 1.0)
+
+    # this is a temporary plug: either ncf or expect is problematic; 
+	# best be marked as a knownfail, but I've no clue how to do it.
+    if distname == "ncf":
+        atol, rtol = 1e-5, 0
+    else:
+        atol, rtol = 1e-7, 1e-7
+
+    normalization_expect = distfn.expect(lambda x: 1, args=args)
+    npt.assert_allclose(normalization_expect, 1.0, atol=atol, rtol=rtol,
+            err_msg=distname, verbose=True)
+
+    normalization_cdf = distfn.cdf(distfn.b, *args)
+    npt.assert_allclose(normalization_cdf, 1.0)
 
 
 def check_ppf_limits(distfn,arg,msg):


### PR DESCRIPTION
For continuous distributions with unbounded support, `expect` returns spurious `inf`s in some cases. This can be traced to floating-point errors which make a distribution function an `inf`. For example:

```
>>> stats.rice.expect(lambda x: 1, args=(0.73,))
/home/br/virtualenvs/scipy-dev/local/lib/python2.7/site-packages/scipy/stats/distributions.py:5555: RuntimeWarning: invalid value encountered in multiply
  return x*exp(-(x*x+b*b)/2.0)*special.i0(x*b)
/home/br/virtualenvs/scipy-dev/local/lib/python2.7/site-packages/scipy/integrate/quadpack.py:293: UserWarning: The occurrence of roundoff error is detected, which prevents  the requested tolerance from being achieved.  The error may be  underestimated.
  warnings.warn(msg)
nan
```

While usually `quad` does an excellent job at doing integrals over the infinite support, here it cannot work it magic --- the function it tries to integrate overflows to infinity.

This PR implements a bit of heuristics in order to detect such situations and try adjusting the integration bounds to make them large but finite. Basically, it's a version of 'try integrating from -100 to 100'  course of action, only very slightly more flexible. 

The price to pay is that for diverging integrals, `expect` might produce a large but finite number and a warning.
