### PR TITLE
added test for associated Laguerre polynomials (gh-992)

### DIFF
--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -534,6 +534,8 @@ def hyp0f1(v, z):
 
 
 def assoc_laguerre(x,n,k=0.0):
+    if k <= -1:
+        raise ValueError("k must be > -1")
     return orthogonal.eval_genlaguerre(n, k, x)
 
 digamma = psi

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -859,6 +859,10 @@ class TestAssocLaguerre(TestCase):
         a2 = special.assoc_laguerre(1,11,1)
         assert_array_almost_equal(a2,a1(1),8)
 
+    def test_assoc_laguerre_n_eq_0(self): # gh-992
+        assert_almost_equal(special.assoc_laguerre(0, 0, -2), 1)
+        assert_almost_equal(special.assoc_laguerre(2, 0, -2), 1)
+
 
 class TestBesselpoly(TestCase):
     def test_besselpoly(self):

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -859,10 +859,6 @@ class TestAssocLaguerre(TestCase):
         a2 = special.assoc_laguerre(1,11,1)
         assert_array_almost_equal(a2,a1(1),8)
 
-    def test_assoc_laguerre_n_eq_0(self): # gh-992
-        assert_almost_equal(special.assoc_laguerre(0, 0, -2), 1)
-        assert_almost_equal(special.assoc_laguerre(2, 0, -2), 1)
-
 
 class TestBesselpoly(TestCase):
     def test_besselpoly(self):


### PR DESCRIPTION
The problem with associated Laguerre polynomials `L_0^(alpha)` yielding `inf` mentioned in https://github.com/scipy/scipy/issues/992#issuecomment-17020819 does not seem to exist anymore. I have added two tests which verify that everything is fine.

Incidentally, I do not see why the problem should be related to the behavior of `hyp1f1` because `b` should be positive while problems with `hyp1f1` only arise for nonpositive integers.
