### PR TITLE
Rice distribution: extend to b=0, add an explicit rvs method.

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -5576,6 +5576,12 @@ class rice_gen(rv_continuous):
     def _argcheck(self, b):
         return b >= 0
 
+    def _rvs(self, b):
+        # http://en.wikipedia.org/wiki/Rice_distribution
+        sz = self._size if self._size else 1
+        t = b/np.sqrt(2) + mtrand.standard_normal(size=(2, sz))
+        return np.sqrt((t*t).sum(axis=0))
+
     def _pdf(self, x, b):
         return x * exp(-(x-b)*(x-b)/2.0) * special.i0e(x*b)
 

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -5573,6 +5573,9 @@ class rice_gen(rv_continuous):
     %(example)s
 
     """
+    def _argcheck(self, b):
+        return b >= 0
+
     def _pdf(self, x, b):
         return x * exp(-(x-b)*(x-b)/2.0) * special.i0e(x*b)
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -153,7 +153,7 @@ distmissing = ['wald', 'gausshyper', 'genexpon', 'rv_continuous',
 
 distmiss = [[dist,args] for dist,args in distcont if dist in distmissing]
 distslow = ['rdist', 'gausshyper', 'recipinvgauss', 'ksone', 'genexpon',
-            'vonmises', 'vonmises_line', 'rice', 'mielke', 'semicircular',
+            'vonmises', 'vonmises_line', 'mielke', 'semicircular',
             'cosine', 'invweibull', 'powerlognorm', 'johnsonsu', 'kstwobign']
 # distslow are sorted by speed (very slow to slow)
 

--- a/scipy/stats/tests/test_continuous_extra.py
+++ b/scipy/stats/tests/test_continuous_extra.py
@@ -153,5 +153,13 @@ def test_rice_zero_b():
     np.allclose(stats.rice.pdf(x, 0), stats.rice.pdf(x, b),
             atol = b, rtol=0)
 
+
+def test_rice_rvs():
+    # a supplement to the KS test (which is run separately)
+    rvs = stats.rice.rvs
+    npt.assert_equals(rvs(b=3.).size, 1)
+    npt.assert_equals(rvs(b=3., size=(3, 5)).shape, (3, 5))
+
+
 if __name__ == "__main__":
     npt.run_module_suite()

--- a/scipy/stats/tests/test_continuous_extra.py
+++ b/scipy/stats/tests/test_continuous_extra.py
@@ -150,15 +150,14 @@ def test_rice_zero_b():
     # rice.pdf(x, b\to 0) = x exp(-x^2/2) + O(b^2)
     # see e.g. Abramovich & Stegun 9.6.7 & 9.6.10
     b = 1e-8
-    np.allclose(stats.rice.pdf(x, 0), stats.rice.pdf(x, b),
+    npt.assert_allclose(stats.rice.pdf(x, 0), stats.rice.pdf(x, b),
             atol = b, rtol=0)
 
 
 def test_rice_rvs():
-    # a supplement to the KS test (which is run separately)
     rvs = stats.rice.rvs
-    npt.assert_equals(rvs(b=3.).size, 1)
-    npt.assert_equals(rvs(b=3., size=(3, 5)).shape, (3, 5))
+    npt.assert_equal(rvs(b=3.).size, 1)
+    npt.assert_equal(rvs(b=3., size=(3, 5)).shape, (3, 5))
 
 
 if __name__ == "__main__":

--- a/scipy/stats/tests/test_continuous_extra.py
+++ b/scipy/stats/tests/test_continuous_extra.py
@@ -132,5 +132,26 @@ def test_rdist_cdf_gh1285():
                             values, decimal=5)
 
 
+def test_rice_zero_b():
+    # rice distribution should work with b=0, cf gh-2164
+    x = [0.2, 1., 5.]
+    npt.assert_(np.isfinite(stats.rice.pdf(x, b=0.)).all())
+    npt.assert_(np.isfinite(stats.rice.logpdf(x, b=0.)).all())
+    npt.assert_(np.isfinite(stats.rice.cdf(x, b=0.)).all())
+    npt.assert_(np.isfinite(stats.rice.logcdf(x, b=0.)).all())
+
+    q = [0.1, 0.1, 0.5, 0.9]
+    npt.assert_(np.isfinite(stats.rice.ppf(q, b=0.)).all())
+
+    mvsk = stats.rice.stats(0, moments='mvsk')
+    npt.assert_(np.isfinite(mvsk).all())
+
+    # furthermore, pdf is continuous as b\to 0
+    # rice.pdf(x, b\to 0) = x exp(-x^2/2) + O(b^2)
+    # see e.g. Abramovich & Stegun 9.6.7 & 9.6.10
+    b = 1e-8
+    np.allclose(stats.rice.pdf(x, 0), stats.rice.pdf(x, b),
+            atol = b, rtol=0)
+
 if __name__ == "__main__":
     npt.run_module_suite()


### PR DESCRIPTION
closes gh-2164 and gh-2742.

As a bonus, rvs get a bit faster. With current master: 

```
In [10]: scipy.__version__
Out[10]: '0.14.0.dev-efbde60'

In [11]: %timeit stats.rice.rvs(b=3.)
100 loops, best of 3: 4.18 ms per loop

In [12]: %timeit stats.rice.rvs(b=3., size=1000)
1 loops, best of 3: 4.13 s per loop
```

with this PR:

```
In [6]: scipy.__version__
Out[6]: '0.14.0.dev-bf7d8d9'

In [7]: %timeit stats.rice.rvs(b=3.)
10000 loops, best of 3: 45.5 µs per loop

In [8]: %timeit stats.rice.rvs(b=3., size=1000)
10000 loops, best of 3: 192 µs per loop
```
