### PR TITLE
BUG: spatial/qhull: fix bug in incremental Voronoi + a deadlock

### DIFF
--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -730,9 +730,7 @@ cdef class _Qhull:
             if facet.visitid > 0:
                 # finite Voronoi vertex
 
-                center = facet.center
-                if center == NULL:
-                    center = qh_facetcenter(facet.vertices)
+                center = qh_facetcenter(facet.vertices)
 
                 nvoronoi_vertices = max(facet.visitid, nvoronoi_vertices)
                 if nvoronoi_vertices >= voronoi_vertices.shape[0]:
@@ -747,8 +745,7 @@ cdef class _Qhull:
                 for k in range(self.ndim):
                     voronoi_vertices[facet.visitid-1, k] = center[k]
 
-                if center != facet.center:
-                    qh_memfree(center, qh_qh.center_size)
+                qh_memfree(center, qh_qh.center_size)
 
                 if facet.coplanarset:
                     for k in range(qh_setsize(facet.coplanarset)):

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -205,6 +205,19 @@ _qhull_lock = threading.Lock()
 cdef _Qhull _active_qhull = None
 cdef int _qhull_count = 0
 
+# Qhull objects pending cleanup
+#
+# Python's garbage collector can trigger a call to a destructor while
+# the qhull lock is held.  Destructors, for instance that of
+# Voronoi/etc, can call _Qhull methods that require the lock, which
+# causes a deadlock also in a single-threaded code.
+#
+# We ensure that _Qhull.close is safe to call from a destructor, by
+# postponing the cleanup if the lock happens to be held. The other
+# methods are not safe to call.
+#
+cdef list _qhull_pending_cleanup = []
+
 class QhullError(RuntimeError):
     pass
 
@@ -313,16 +326,32 @@ cdef class _Qhull:
 
     @cython.final
     def close(self):
-        _qhull_lock.acquire()
-        try:
-            if _active_qhull is self or self._saved_qh != NULL:
+        if _qhull_lock.acquire(False):
+            try:
+                self._cleanup_pending()
                 self._uninit()
-        finally:
-            _qhull_lock.release()
+            finally:
+                _qhull_lock.release()
+        else:
+            # Failed to acquire the lock. 
+            _qhull_pending_cleanup.append(self)
 
     @cython.final
-    def __del__(self):
-        self.close()
+    cdef int _cleanup_pending(self) except -1:
+        """
+        Process any pending cleanups (_qhull_lock MUST be held when calling this)
+        """
+        cdef _Qhull qh
+        cdef int k
+
+        for k in range(len(_qhull_pending_cleanup)):
+            try:
+                qh = _qhull_pending_cleanup.pop()
+            except IndexError:
+                break
+            qh._uninit()
+
+        return 0
 
     @cython.final
     cdef int _activate(self) except -1:
@@ -367,6 +396,10 @@ cdef class _Qhull:
         """
         global _active_qhull, _qhull_count
         cdef int curlong, totlong
+
+        if not (_active_qhull is self or self._saved_qh != NULL):
+            # already freed
+            return 0
 
         self._activate()
 
@@ -1589,6 +1622,9 @@ class Delaunay(_QhullUser):
        Delaunay triangulation. Omitted points are listed in the
        `coplanar` attribute.
 
+    Do not call the ``add_points`` method from a ``__del__``
+    destructor.
+
     Examples
     --------
     Triangulation of a set of points:
@@ -2115,6 +2151,9 @@ class ConvexHull(_QhullUser):
     -----
     The convex hull is computed using the Qhull libary [Qhull]_.
 
+    Do not call the ``add_points`` method from a ``__del__``
+    destructor.
+
     Examples
     --------
 
@@ -2238,6 +2277,9 @@ class Voronoi(_QhullUser):
     Notes
     -----
     The Voronoi diagram is computed using the Qhull libary [Qhull]_.
+
+    Do not call the ``add_points`` method from a ``__del__``
+    destructor.
 
     Examples
     --------

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -828,9 +828,6 @@ class TestVoronoi:
             if INCREMENTAL_DATASETS[name][0][0].shape[1] > 3:
                 # too slow (testing of the result --- qhull is still fast)
                 continue
-            if name.startswith('pathological-1'):
-                # the test above fails -- but the plotted diagram looks OK
-                continue
 
             yield check, name
 

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -65,6 +65,15 @@ pathological_data_2 = np.array([
     [1, -1 - np.finfo(np.float_).eps], [1, 0], [1, 1],
 ])
 
+bug_2850_chunks = [np.random.rand(10, 2),
+                   np.array([[0,0], [0,1], [1,0], [1,1]]) # add corners
+                   ]
+
+# same with some additional chunks
+bug_2850_chunks_2 = (bug_2850_chunks +
+                     [np.random.rand(10, 2),
+                      0.25 + np.array([[0,0], [0,1], [1,0], [1,1]])])
+
 DATASETS = {
     'some-points': np.asarray(points),
     'random-2d': np.random.rand(30, 2),
@@ -77,6 +86,40 @@ DATASETS = {
     'pathological-1': pathological_data_1,
     'pathological-2': pathological_data_2
 }
+
+INCREMENTAL_DATASETS = {
+    'bug-2850': (bug_2850_chunks, None),
+    'bug-2850-2': (bug_2850_chunks_2, None),
+}
+
+def _add_inc_data(name, chunksize):
+    """
+    Generate incremental datasets from basic data sets
+    """
+    points = DATASETS[name]
+    ndim = points.shape[1]
+
+    opts = None
+    nmin = ndim + 2
+
+    if name == 'some-points':
+        # since Qz is not allowed, use QJ
+        opts = 'QJ Pp'
+    elif name == 'pathological-1':
+        # include enough points so that we get different x-coordinates
+        nmin = 12
+
+    chunks = [points[:nmin]]
+    for j in xrange(nmin, len(points), chunksize):
+        chunks.append(points[j:j+chunksize])
+
+    new_name = "%s-chunk-%d" % (name, chunksize)
+    assert new_name not in INCREMENTAL_DATASETS
+    INCREMENTAL_DATASETS[new_name] = (chunks, opts)
+
+for name in DATASETS:
+    for chunksize in 1, 4, 16:
+        _add_inc_data(name, chunksize)
 
 
 class Test_Qhull(object):
@@ -435,30 +478,22 @@ class TestDelaunay(object):
     def test_incremental(self):
         # Test incremental construction of the triangulation
 
-        def check(name, chunksize):
-            points = DATASETS[name]
-            ndim = points.shape[1]
+        def check(name):
+            chunks, opts = INCREMENTAL_DATASETS[name]
+            points = np.concatenate(chunks, axis=0)
 
-            opts = None
-            nmin = ndim + 2
-
-            if name == 'some-points':
-                # since Qz is not allowed, use QJ
-                opts = 'QJ Pp'
-            elif name == 'pathological-1':
-                # include enough points so that we get different x-coordinates
-                nmin = 12
-
-            obj = qhull.Delaunay(points[:nmin], incremental=True,
+            obj = qhull.Delaunay(chunks[0], incremental=True,
                                  qhull_options=opts)
-            for j in xrange(nmin, len(points), chunksize):
-                obj.add_points(points[j:j+chunksize])
+            for chunk in chunks[1:]:
+                obj.add_points(chunk)
 
             obj2 = qhull.Delaunay(points)
 
-            obj3 = qhull.Delaunay(points[:nmin], incremental=True,
+            obj3 = qhull.Delaunay(chunks[0], incremental=True,
                                   qhull_options=opts)
-            obj3.add_points(points[nmin:], restart=True)
+            if len(chunks) > 1:
+                obj3.add_points(np.concatenate(chunks[1:], axis=0),
+                                restart=True)
 
             # Check that the incremental mode agrees with upfront mode
             if name.startswith('pathological'):
@@ -476,9 +511,8 @@ class TestDelaunay(object):
             assert_unordered_tuple_list_equal(obj2.simplices, obj3.simplices,
                                               tpl=sorted_tuple)
 
-        for name in sorted(DATASETS):
-            for chunksize in 1, 4:
-                yield check, name, chunksize
+        for name in sorted(INCREMENTAL_DATASETS):
+            yield check, name
 
 
 def assert_hulls_equal(points, facets_1, facets_2):
@@ -563,32 +597,27 @@ class TestConvexHull:
 
     def test_incremental(self):
         # Test incremental construction of the convex hull
-        def check(name, chunksize):
-            points = DATASETS[name]
-            ndim = points.shape[1]
+        def check(name):
+            chunks, _ = INCREMENTAL_DATASETS[name]
+            points = np.concatenate(chunks, axis=0)
 
-            if name == 'pathological-1':
-                # include enough points so that we get different x-coordinates
-                nmin = 12
-            else:
-                nmin = ndim + 2
-
-            obj = qhull.ConvexHull(points[:nmin], incremental=True)
-            for j in xrange(nmin, len(points), chunksize):
-                obj.add_points(points[j:j+chunksize])
+            obj = qhull.ConvexHull(chunks[0], incremental=True)
+            for chunk in chunks[1:]:
+                obj.add_points(chunk)
 
             obj2 = qhull.ConvexHull(points)
 
-            obj3 = qhull.ConvexHull(points[:nmin], incremental=True)
-            obj3.add_points(points[nmin:], restart=True)
+            obj3 = qhull.ConvexHull(chunks[0], incremental=True)
+            if len(chunks) > 1:
+                obj3.add_points(np.concatenate(chunks[1:], axis=0),
+                                restart=True)
 
             # Check that the incremental mode agrees with upfront mode
             assert_hulls_equal(points, obj.simplices, obj2.simplices)
             assert_hulls_equal(points, obj.simplices, obj3.simplices)
 
-        for name in sorted(DATASETS):
-            for chunksize in 1, 4:
-                yield check, name, chunksize
+        for name in sorted(INCREMENTAL_DATASETS):
+            yield check, name
 
     def test_vertices_2d(self):
         # The vertices should be in counterclockwise order in 2-D
@@ -739,30 +768,22 @@ class TestVoronoi:
     def test_incremental(self):
         # Test incremental construction of the triangulation
 
-        def check(name, chunksize):
-            points = DATASETS[name]
-            ndim = points.shape[1]
+        def check(name):
+            chunks, opts = INCREMENTAL_DATASETS[name]
+            points = np.concatenate(chunks, axis=0)
 
-            opts = None
-            nmin = ndim + 2
-
-            if name == 'some-points':
-                # since Qz is not allowed, use QJ
-                opts = 'QJ Pp'
-            elif name == 'pathological-1':
-                # include enough points so that we get different x-coordinates
-                nmin = 12
-
-            obj = qhull.Voronoi(points[:nmin], incremental=True,
+            obj = qhull.Voronoi(chunks[0], incremental=True,
                                  qhull_options=opts)
-            for j in xrange(nmin, len(points), chunksize):
-                obj.add_points(points[j:j+chunksize])
+            for chunk in chunks[1:]:
+                obj.add_points(chunk)
 
             obj2 = qhull.Voronoi(points)
 
-            obj3 = qhull.Voronoi(points[:nmin], incremental=True,
+            obj3 = qhull.Voronoi(chunks[0], incremental=True,
                                  qhull_options=opts)
-            obj3.add_points(points[nmin:], restart=True)
+            if len(chunks) > 1:
+                obj3.add_points(np.concatenate(chunks[1:], axis=0),
+                                restart=True)
 
             # -- Check that the incremental mode agrees with upfront mode
 
@@ -778,7 +799,11 @@ class TestVoronoi:
                 def remap(x):
                     if hasattr(x, '__len__'):
                         return tuple(set([remap(y) for y in x]))
-                    return vertex_map.get(x, x)
+                    try:
+                        return vertex_map[x]
+                    except KeyError:
+                        raise AssertionError("incremental result has spurious vertex at %r"
+                                             % (objx.vertices[x],))
 
                 def simplified(x):
                     items = set(map(sorted_tuple, x))
@@ -799,15 +824,15 @@ class TestVoronoi:
 
                 # XXX: compare ridge_points --- not clear exactly how to do this
 
-        for name in sorted(DATASETS):
-            if DATASETS[name].shape[1] > 3:
+        for name in sorted(INCREMENTAL_DATASETS):
+            if INCREMENTAL_DATASETS[name][0][0].shape[1] > 3:
                 # too slow (testing of the result --- qhull is still fast)
                 continue
-            if name == 'pathological-1':
+            if name.startswith('pathological-1'):
                 # the test above fails -- but the plotted diagram looks OK
                 continue
-            for chunksize in 1, 4:
-                yield check, name, chunksize
+
+            yield check, name
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This PR fixes two issues:
- gh-2850 --- the Voronoi vertices are not updated properly if the incremental mode encounters a degenerate situation
- A deadlock due to the fact that Python garbage collector can execute a `__del__` method in any thread at any time. This can end up calling the `close()` method of one Qhull object while another Qhull object holds the lock and is computing (in single-threaded code!).

The deadlock fix is necessary for this PR, as the changes in the tests I made to test the other issue expose it.
The deadlock occurs only if the incremental mode is used, as otherwise the cleanup is done immediately and not from a destructor.

However, both of these issues are a bit nasty, and could be considered for backport in 0.13.0b2.
