### PR TITLE
ENH: signal: enable simulation of MIMO systems

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -280,9 +280,9 @@ class lti(object):
                 self.outputs = 1
         elif N == 4:       # State-space form
             self._A, self._B, self._C, self._D = abcd_normalize(*args)
-            self._update(N)
             self.inputs = self.B.shape[-1]
             self.outputs = self.C.shape[0]
+            self._update(N)
         else:
             raise ValueError("Needs 2, 3, or 4 arguments.")
 
@@ -388,10 +388,11 @@ class lti(object):
             self._num, self._den = zpk2tf(self.zeros, self.poles, self.gain)
             self._A, self._B, self._C, self._D = zpk2ss(self.zeros,
                                                         self.poles, self.gain)
-        if N == 4:
-            self._num, self._den = ss2tf(self.A, self.B, self.C, self.D)
-            self._zeros, self._poles, self._gain = ss2zpk(self.A, self.B,
-                                                          self.C, self.D)
+        if N== 4:
+            if self.inputs==1:
+                self._num, self._den = ss2tf(self.A, self.B, self.C, self.D)
+                self._zeros, self._poles, self._gain = ss2zpk(self.A, self.B,
+                                                              self.C, self.D)
 
     def impulse(self, X0=None, T=None, N=None):
         return impulse(self, X0=X0, T=T, N=N)
@@ -529,7 +530,7 @@ def lsim2(system, U=None, T=None, X0=None, **kwargs):
 
         def fprime(x, t, sys, ufunc):
             """The vector field of the linear system."""
-            return dot(sys.A, x) + squeeze(dot(sys.B, nan_to_num(ufunc([t]))))
+            return dot(sys.A, x) + squeeze(dot(sys.B, nan_to_num(ufunc([t])).T))
         xout = integrate.odeint(fprime, X0, T, args=(sys, ufunc), **kwargs)
         yout = dot(sys.C, transpose(xout)) + dot(sys.D, transpose(U))
     else:

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -100,6 +100,27 @@ class Test_lsim2(object):
         expected_x = (1.0 - tout) * np.exp(-tout)
         assert_almost_equal(x[:,0], expected_x)
 
+    def test_07(self):
+        """Test the simulation of a MIMO system"""
+        # Basic MIMO system. Two inputs, two outputs. Output same as input.
+        A = np.zeros((1,1))
+        B = np.zeros((1,2))
+        C = np.zeros((2,1))
+        D = np.eye(2)
+
+        t=np.arange(3)
+        u0=np.arange(3)
+        u1=2*u0
+        u=np.vstack((u0,u1)).T
+        tout, y, x = lsim2((A,B,C,D),T=t,U=u)
+        expected_y = u
+        expected_x = np.zeros((3,1))
+        assert_almost_equal(y, expected_y)
+        assert_almost_equal(x, expected_x)
+
+
+
+
 
 class _TestImpulseFuncs(object):
     # Common tests for impulse/impulse2 (= self.func)


### PR DESCRIPTION
Until now lsim2 was unable to simulate MIMO systems because lti tried to create tf and zpk representations. Those cannot be created for multiple input systems. The transformation is now skipped if there is more than one input.

Additionally the fprime function used a transposed version of the input. This is fixed now.

I added a test to test_ltisys.py testing the simulation of a two-input-two-output system, where the output is simply a copy of the input. All previous tests still pass. Behaviour for single input systems has not changed, so no working existing code should break.
