### PR TITLE
BUG: optimize: ensure line search is not confused by float issues

### DIFF
--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -404,27 +404,27 @@ def _cubicmin(a, fa, fpa, b, fb, c, fc):
     """
     # f(x) = A *(x-a)^3 + B*(x-a)^2 + C*(x-a) + D
 
-    C = fpa
-    db = b - a
-    dc = c - a
-    if (db == 0) or (dc == 0) or (b == c):
+    with np.errstate(divide='raise', over='raise', invalid='raise'):
+        try:
+            C = fpa
+            db = b - a
+            dc = c - a
+            denom = (db * dc) ** 2 * (db - dc)
+            d1 = np.empty((2, 2))
+            d1[0, 0] = dc ** 2
+            d1[0, 1] = -db ** 2
+            d1[1, 0] = -dc ** 3
+            d1[1, 1] = db ** 3
+            [A, B] = np.dot(d1, np.asarray([fb - fa - C * db,
+                                            fc - fa - C * dc]).flatten())
+            A /= denom
+            B /= denom
+            radical = B * B - 3 * A * C
+            xmin = a + (-B + np.sqrt(radical)) / (3 * A)
+        except ArithmeticError:
+            return None
+    if not np.isfinite(xmin):
         return None
-    denom = (db * dc) ** 2 * (db - dc)
-    d1 = np.empty((2, 2))
-    d1[0, 0] = dc ** 2
-    d1[0, 1] = -db ** 2
-    d1[1, 0] = -dc ** 3
-    d1[1, 1] = db ** 3
-    [A, B] = np.dot(d1, np.asarray([fb - fa - C * db,
-                                    fc - fa - C * dc]).flatten())
-    A /= denom
-    B /= denom
-    radical = B * B - 3 * A * C
-    if radical < 0:
-        return None
-    if A == 0:
-        return None
-    xmin = a + (-B + np.sqrt(radical)) / (3 * A)
     return xmin
 
 
@@ -435,15 +435,17 @@ def _quadmin(a, fa, fpa, b, fb):
 
     """
     # f(x) = B*(x-a)^2 + C*(x-a) + D
-    D = fa
-    C = fpa
-    db = b - a * 1.0
-    if db == 0:
+    with np.errstate(divide='raise', over='raise', invalid='raise'):
+        try:
+            D = fa
+            C = fpa
+            db = b - a * 1.0
+            B = (fb - D - C * db) / (db * db)
+            xmin = a - C / (2.0 * B)
+        except ArithmeticError:
+            return None
+    if not np.isfinite(xmin):
         return None
-    B = (fb - D - C * db) / (db * db)
-    if B <= 0:
-        return None
-    xmin = a - C / (2.0 * B)
     return xmin
 
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -166,6 +166,15 @@ class TestOptimize(object):
         finally:
             np.seterr(**olderr)
 
+    def test_bfgs_gh_2169(self):
+        def f(x):
+            if x < 0:
+                return 1.79769313e+308
+            else:
+                return x + 1./x
+        xs = optimize.fmin_bfgs(f, [10.], disp=False)
+        assert_allclose(xs, 1.0, rtol=1e-4, atol=1e-4)
+
     def test_powell(self, use_wrapper=False):
         """ Powell (direction set) optimization routine
         """


### PR DESCRIPTION
Detect non-finite (nan, inf) results from _cubicmin and _quadmin so that
the rest of the line search doesn't become confused.  Avoids problems
when float overflows etc. occur.

Also replace intermediate value checks by exceptions.

Fixes gh-2169
