### PR TITLE
Numpy Ufunc and dot overrides (continued from gh-2732)

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -785,6 +785,14 @@ class spmatrix(object):
         elif func is np.true_divide:
             rdivide = (pos == 1)
             return self._divide(*without_self, true_divide=True, rdivide=rdivide)
+        elif func in (np.sin, np.tan, np.arcsin, np.arctan, np.sinh, np.tanh,
+                      np.arcsinh, np.arctanh, np.rint, np.sign, np.expm1, np.log1p,
+                      np.deg2rad, np.rad2deg, np.floor, np.ceil, np.trunc, np.sqrt):
+            func_name = func.__name__
+            if hasattr(self, func_name):
+                return getattr(self, func_name)()
+            else:
+                return getattr(self.tocsr(), func_name)()
         else:
             return NotImplemented
 

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -387,10 +387,14 @@ class spmatrix(object):
                 return self.astype(np.float_)._mul_scalar(1./other)
             else:
                 r = self._mul_scalar(1./other)
-                if np.issubdtype(r.dtype, np.floating):
+
+                scalar_dtype = np.asarray(other).dtype
+                if (np.issubdtype(self.dtype, np.integer)
+                        and np.issubdtype(scalar_dtype, np.integer)):
                     return r.astype(self.dtype)
                 else:
                     return r
+                    
         elif isdense(other):
             if not rdivide:
                 if true_divide:

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -377,9 +377,15 @@ class spmatrix(object):
 
     def __truediv__(self, other):
         if isscalarlike(other):
-            return self * (1./other)
+            if np.can_cast(self.dtype, np.float_):
+                return self.astype(np.float_) * (1./other)
+            else:
+                return self * (1./other)
         else:
-            return self.tocsr().__truediv__(other)
+            if np.can_cast(self.dtype, np.float_):
+                return self.astype(np.float_).tocsr().__truediv__(other)
+            else:
+                return self.tocsr().__truediv__(other)
 
     def __div__(self, other):
         # Always do true division

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -387,9 +387,16 @@ class spmatrix(object):
             else:
                 return self.tocsr().__truediv__(other)
 
+    def __rtruediv__(self, other):
+        return NotImplemented
+
     def __div__(self, other):
         # Always do true division
         return self.__truediv__(other)
+
+    def __rdiv__(self, other):
+        # Always do true division
+        return self.__rtruediv__(other)
 
     def __neg__(self):
         return -self.tocsr()
@@ -708,6 +715,52 @@ class spmatrix(object):
             return out
         else:
             return np.zeros(self.shape, dtype=self.dtype, order=order)
+
+    def __numpy_ufunc__(self, func, method, pos, inputs, **kwargs):
+        """Method for compatibility with NumPy's ufuncs and dot
+        functions.
+        """
+        if method != '__call__' or kwargs:
+            return NotImplemented
+
+        without_self = list(inputs)
+        del without_self[pos]
+        without_self = tuple(without_self)
+
+        # Associative operations
+        if func is np.multiply:
+            return self.multiply(*without_self)
+
+        elif func is np.add:
+            return self.__add__(*without_self)
+
+        # Non-associative operations
+        elif func is np.dot:
+            if pos == 0:
+                return self.__mul__(inputs[1])
+            else:
+                return self.__rmul__(inputs[0])
+
+        elif func is np.subtract:
+            if pos == 0:
+                return self.__sub__(inputs[1])
+            else:
+                return self.__rsub__(inputs[0])
+
+        elif func is np.divide:
+            if pos == 0:
+                return self.__div__(inputs[1])
+            else:
+                return NotImplemented
+
+        elif func is np.true_divide:
+            if pos == 0:
+                return self.__truediv__(inputs[1])
+            else:
+                return NotImplemented
+
+        else:
+            return NotImplemented
 
 
 def isspmatrix(x):

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -422,11 +422,12 @@ class spmatrix(object):
         return self._divide(other, true_divide=True)
 
     def __rtruediv__(self, other):
+        # Implementing this as the inverse would be too magical -- bail out
         return NotImplemented
 
     def __rdiv__(self, other):
-        # Always do true division
-        return self.__rtruediv__(other)
+        # Implementing this as the inverse would be too magical -- bail out
+        return NotImplemented
 
     def __neg__(self):
         return -self.tocsr()

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -413,27 +413,6 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         else:
             raise NotImplementedError
 
-    def __truediv__(self,other):
-        if isscalarlike(other):
-            if np.can_cast(self.dtype, np.float_):
-                return self.astype(np.float_) * (1./other)
-            else:
-                return self * (1./other)
-
-        elif isspmatrix(other):
-            if other.shape != self.shape:
-                raise ValueError('inconsistent shapes')
-            elif np.can_cast(self.dtype, np.float_):
-                return self.astype(np.float_)._binopt(other,'_eldiv_')
-            else:
-                return self._binopt(other,'_eldiv_')
-
-        elif isdense(other):
-            return self.todense().__truediv__(other)
-
-        else:
-            raise NotImplementedError
-
     def multiply(self, other):
         """Point-wise multiplication by another matrix, vector, or
         scalar.
@@ -931,3 +910,11 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         A = self.__class__((data, indices, indptr), shape=self.shape)
 
         return A
+
+    def _divide_sparse(self, other):
+        """
+        Divide this matrix by a second sparse matrix.
+        """
+        if other.shape != self.shape:
+            raise ValueError('inconsistent shapes')
+        return self._binopt(other, '_eldiv_')

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -415,13 +415,21 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
     def __truediv__(self,other):
         if isscalarlike(other):
-            return self * (1./other)
+            if np.can_cast(self.dtype, np.float_):
+                return self.astype(np.float_) * (1./other)
+            else:
+                return self * (1./other)
 
         elif isspmatrix(other):
             if other.shape != self.shape:
                 raise ValueError('inconsistent shapes')
+            elif np.can_cast(self.dtype, np.float_):
+                return self.astype(np.float_)._binopt(other,'_eldiv_')
+            else:
+                return self._binopt(other,'_eldiv_')
 
-            return self._binopt(other,'_eldiv_')
+        elif isdense(other):
+            return self.todense().__truediv__(other)
 
         else:
             raise NotImplementedError

--- a/scipy/sparse/sparsetools/csr.h
+++ b/scipy/sparse/sparsetools/csr.h
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <functional>
 
+#include "util.h"
 #include "dense.h"
 
 /*
@@ -916,7 +917,7 @@ void csr_eldiv_csr(const I n_row, const I n_col,
                    const I Bp[], const I Bj[], const T Bx[],
                          I Cp[],       I Cj[],       T Cx[])
 {
-    csr_binop_csr(n_row,n_col,Ap,Aj,Ax,Bp,Bj,Bx,Cp,Cj,Cx,std::divides<T>());
+    csr_binop_csr(n_row,n_col,Ap,Aj,Ax,Bp,Bj,Bx,Cp,Cj,Cx,safe_divides<T>());
 }
 
 

--- a/scipy/sparse/sparsetools/util.h
+++ b/scipy/sparse/sparsetools/util.h
@@ -1,0 +1,36 @@
+#ifndef __SPTOOLS_UTIL_H__
+#define __SPTOOLS_UTIL_H__
+
+/*
+ * Same as std::divides, except return x/0 == 0 for integer types, without
+ * raising a SIGFPE.
+ */
+template <class T>
+struct safe_divides {
+    T operator() (const T& x, const T& y) const {
+        if (y == 0) {
+            return 0;
+        }
+        else {
+            return x/y;
+        }
+    }
+
+    typedef T first_argument_type;
+    typedef T second_argument_type;
+    typedef T result_type;
+};
+
+#define OVERRIDE_safe_divides(typ) \
+    template<> typ safe_divides<typ>::operator()(const typ& x, const typ& y) const { return x/y; }
+
+OVERRIDE_safe_divides(float)
+OVERRIDE_safe_divides(double)
+OVERRIDE_safe_divides(long double)
+OVERRIDE_safe_divides(npy_cfloat_wrapper)
+OVERRIDE_safe_divides(npy_cdouble_wrapper)
+OVERRIDE_safe_divides(npy_clongdouble_wrapper)
+
+#undef OVERRIDE_safe_divides
+
+#endif

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -18,6 +18,7 @@ Run tests if scipy is installed:
 Run tests if sparse is not installed:
   python tests/test_base.py
 """
+from distutils.version import LooseVersion
 
 import warnings
 
@@ -1244,20 +1245,6 @@ class _TestCommon:
         for x, y in zip(A, B):
             assert_equal(x.todense(), y)
 
-    # Eventually we'd like to allow matrix products between dense
-    # and sparse matrices using the normal dot() function:
-    # def test_dense_dot_sparse(self):
-    #    a = array([1.,2.,3.])
-    #    dense_dot_dense = dot(a, self.dat)
-    #    dense_dot_sparse = dot(a, self.datsp)
-    #    assert_array_equal(dense_dot_dense, dense_dot_sparse)
-
-    # def test_sparse_dot_dense(self):
-    #    b = array([1.,2.,3.,4.])
-    #    dense_dot_dense = dot(self.dat, b)
-    #    dense_dot_sparse = dot(self.datsp, b)
-    #    assert_array_equal(dense_dot_dense, dense_dot_sparse)
-
     def test_size_zero_matrix_arithmetic(self):
         # Test basic matrix arithmatic with shapes like (0,0), (10,0),
         # (0, 3), etc.
@@ -1330,6 +1317,56 @@ class _TestCommon:
             assert_array_equal(spm.tolil().A, m)
             assert_array_equal(spm.todok().A, m)
             assert_array_equal(spm.tobsr().A, m)
+
+    # Eventually we'd like to allow matrix products between dense
+    # and sparse matrices using the normal dot() function:
+    # def test_dense_dot_sparse(self):
+    #    a = array([1.,2.,3.])
+    #    dense_dot_dense = dot(a, self.dat)
+    #    dense_dot_sparse = dot(a, self.datsp)
+    #    assert_array_equal(dense_dot_dense, dense_dot_sparse)
+
+    # def test_sparse_dot_dense(self):
+    #    b = array([1.,2.,3.,4.])
+    #    dense_dot_dense = dot(self.dat, b)
+    #    dense_dot_sparse = dot(self.datsp, b)
+    #    assert_array_equal(dense_dot_dense, dense_dot_sparse)
+
+    def test_ufunc_overrides(self):
+        def check():
+            #data
+            a = np.array([[1, 2, 3],
+                          [4, 5, 6],
+                          [7, 8, 9]])
+            b = np.array([[9, 8, 7],
+                          [6, 5, 4],
+                          [3, 2, 1]])
+
+            asp = self.spmatrix(a)
+            bsp = self.spmatrix(b)
+
+            # associative
+            # multiply
+            assert_array_equal(np.multiply(asp, bsp).A, np.multiply(a, b))
+            # add
+            assert_array_equal(np.add(asp, bsp).A, np.add(a, b))
+
+            # non-associative
+            # dot
+            assert_array_equal(np.dot(asp, bsp).A, np.dot(a, b))
+            assert_array_equal(np.dot(a, bsp), np.dot(a, b))
+            assert_array_equal(np.dot(asp, b), np.dot(a, b))
+            # subtract
+            assert_array_equal(np.subtract(asp, bsp).A, np.subtract(a, b))
+            assert_array_equal(np.subtract(a, bsp).A, np.subtract(a, b))
+            assert_array_equal(np.subtract(asp, b).A, np.subtract(a, b))
+            # divide
+            assert_array_equal(np.divide(asp, bsp).A, np.divide(a, b))
+            assert_array_equal(np.divide(asp, b).A, np.divide(a, b))
+            assert_raises(TypeError, np.divide, a, bsp)
+
+        if LooseVersion(np.version.version) > LooseVersion('1.9'):
+            yield check
 
 
 class _TestInplaceArithmetic:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1325,12 +1325,22 @@ class _TestCommon:
             assert_array_equal(spm.tobsr().A, m)
 
     def test_unary_ufunc_overrides(self):
-        X = self.spmatrix(np.arange(20).reshape(4, 5) / 20.)
-        for f in ["sin", "tan", "arcsin", "arctan", "sinh", "tanh",
-                  "arcsinh", "arctanh", "rint", "sign", "expm1", "log1p",
-                  "deg2rad", "rad2deg", "floor", "ceil", "trunc", "sqrt"]:
-            X2 = getattr(np, f)(X)
-            assert_array_equal(X2.toarray(), getattr(np, f)(X.toarray()))
+        def check(name):
+            if LooseVersion(np.version.version) < LooseVersion('1.9'):
+                if name == "sign":
+                    raise nose.SkipTest("sign conflicts with comparison op "
+                                        "support on Numpy < 1.9")
+                if self.spmatrix in (dok_matrix, lil_matrix):
+                    raise nose.SkipTest("Unary ops not implemented for dok/lil "
+                                        "with Numpy < 1.9")
+            X = self.spmatrix(np.arange(20).reshape(4, 5) / 20.)
+            X2 = getattr(np, name)(X)
+            assert_array_equal(X2.toarray(), getattr(np, name)(X.toarray()))
+        
+        for name in ["sin", "tan", "arcsin", "arctan", "sinh", "tanh",
+                     "arcsinh", "arctanh", "rint", "sign", "expm1", "log1p",
+                     "deg2rad", "rad2deg", "floor", "ceil", "trunc", "sqrt"]:
+            yield check, name
 
     def test_binary_ufunc_overrides(self):
         # data

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -60,6 +60,11 @@ def _can_cast_samekind(dtype1, dtype2):
     else:
         return np.can_cast(dtype1, dtype2, casting='same_kind')
 
+def todense(a):
+    if isinstance(a, np.ndarray) or isscalarlike(a):
+        return a
+    return a.todense()
+
 
 class MultipliesWithMatrix(object):
     """Class that knows how to multiply with a sparse matrix."""
@@ -74,6 +79,7 @@ class MultipliesWithMatrix(object):
 #------------------------------------------------------------------------------
 # Generic tests
 #------------------------------------------------------------------------------
+
 
 # TODO check that spmatrix( ... , copy=X ) is respected
 # TODO test prune
@@ -963,19 +969,19 @@ class _TestCommon:
                     assert_almost_equal(sp_mult, dense_mult)
 
     def test_elementwise_divide(self):
-        expected = [[1,0,0,1],[1,0,1,0],[0,1,0,0]]
-        assert_array_equal((self.datsp / self.datsp).todense(),expected)
+        expected = [[1,np.nan,np.nan,1],[1,np.nan,1,np.nan],[np.nan,1,np.nan,np.nan]]
+        assert_array_equal(todense(self.datsp / self.datsp),expected)
 
         denom = self.spmatrix(matrix([[1,0,0,4],[-1,0,0,0],[0,8,0,-5]],'d'))
-        res = matrix([[1,0,0,0.5],[-3,0,inf,0],[0,0.25,0,0]],'d')
-        assert_array_equal((self.datsp / denom).todense(),res)
+        res = matrix([[1,np.nan,np.nan,0.5],[-3,np.nan,inf,np.nan],[np.nan,0.25,np.nan,np.nan]],'d')
+        assert_array_equal(todense(self.datsp / denom),res)
 
         # complex
         A = array([[1-2j,0+5j,-1+0j],[4-3j,-3+6j,5]])
         B = array([[5+2j,7-3j,-2+1j],[0-1j,-4+2j,9]])
         Asp = self.spmatrix(A)
         Bsp = self.spmatrix(B)
-        assert_almost_equal((Asp / Bsp).todense(), A/B)
+        assert_almost_equal(todense(Asp / Bsp), A/B)
 
     def test_pow(self):
         A = matrix([[1,0,2,0],[0,3,4,0],[0,5,0,0],[0,6,7,8]])
@@ -1343,11 +1349,6 @@ class _TestCommon:
 
         a_items = dict(dense=a, scalar=c, cplx_scalar=d, int_scalar=e, sparse=asp)
         b_items = dict(dense=b, scalar=c, cplx_scalar=d, int_scalar=e, sparse=bsp)
-
-        def todense(a):
-            if isinstance(a, np.ndarray) or isscalarlike(a):
-                return a
-            return a.todense()
 
         @dec.skipif(LooseVersion(np.version.version) < LooseVersion('1.9'),
                     "feature requires Numpy 1.9")
@@ -1848,11 +1849,6 @@ class _TestFancyIndexing:
         B = asmatrix(arange(50).reshape(5,10))
         A = self.spmatrix(B)
 
-        def todense(a):
-            if isinstance(a, np.ndarray):
-                return a
-            return a.todense()
-
         # [i]
         assert_equal(A[[1,3]].todense(), B[[1,3]])
 
@@ -1945,12 +1941,6 @@ class _TestFancyIndexing:
     def test_fancy_indexing_boolean(self):
         random.seed(1234)  # make runs repeatable
 
-        # CSR matrix returns matrix in some cases
-        def todense(a):
-            if isinstance(a, (np.matrix, np.ndarray)):
-                return a
-            return a.todense()
-
         B = asmatrix(arange(50).reshape(5,10))
         A = self.spmatrix(B)
 
@@ -1977,12 +1967,6 @@ class _TestFancyIndexing:
 
     def test_fancy_indexing_sparse_boolean(self):
         random.seed(1234)  # make runs repeatable
-
-        # CSR matrix returns matrix in some cases
-        def todense(a):
-            if isinstance(a, (np.matrix, np.ndarray)):
-                return a
-            return a.todense()
 
         B = asmatrix(arange(50).reshape(5,10))
         A = self.spmatrix(B)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1371,7 +1371,12 @@ class _TestCommon:
 
             # add
             if isscalarlike(ax) or isscalarlike(bx):
-                assert_raises(TypeError, np.add, ax, bx)
+                try:
+                    assert_array_equal(todense(np.add(ax, bx)),
+                                       np.add(a, b))
+                except TypeError:
+                    # Not implemented for all spmatrix types
+                    pass
             else:
                 assert_array_equal(todense(np.add(ax, bx)), np.add(a, b))
 
@@ -1382,7 +1387,12 @@ class _TestCommon:
 
             # subtract
             if isscalarlike(ax) or isscalarlike(bx):
-                assert_raises(TypeError, np.subtract, ax, bx)
+                try:
+                    assert_array_equal(todense(np.subtract(ax, bx)),
+                                       np.subtract(a, b))
+                except TypeError:
+                    # Not implemented for all spmatrix types
+                    pass
             else:
                 assert_array_equal(todense(np.subtract(ax, bx)), np.subtract(a, b))
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1318,21 +1318,15 @@ class _TestCommon:
             assert_array_equal(spm.todok().A, m)
             assert_array_equal(spm.tobsr().A, m)
 
-    # Eventually we'd like to allow matrix products between dense
-    # and sparse matrices using the normal dot() function:
-    # def test_dense_dot_sparse(self):
-    #    a = array([1.,2.,3.])
-    #    dense_dot_dense = dot(a, self.dat)
-    #    dense_dot_sparse = dot(a, self.datsp)
-    #    assert_array_equal(dense_dot_dense, dense_dot_sparse)
+    def test_unary_ufunc_overrides(self):
+        X = self.spmatrix(np.arange(20).reshape(4, 5) / 20.)
+        for f in ["sin", "tan", "arcsin", "arctan", "sinh", "tanh",
+                  "arcsinh", "arctanh", "rint", "sign", "expm1", "log1p",
+                  "deg2rad", "rad2deg", "floor", "ceil", "trunc", "sqrt"]:
+            X2 = getattr(np, f)(X)
+            assert_array_equal(X2.toarray(), getattr(np, f)(X.toarray()))
 
-    # def test_sparse_dot_dense(self):
-    #    b = array([1.,2.,3.,4.])
-    #    dense_dot_dense = dot(self.dat, b)
-    #    dense_dot_sparse = dot(self.datsp, b)
-    #    assert_array_equal(dense_dot_dense, dense_dot_sparse)
-
-    def test_ufunc_overrides(self):
+    def test_binary_ufunc_overrides(self):
         # data
         a = np.array([[1, 2, 3],
                       [4, 5, 0],

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1335,11 +1335,12 @@ class _TestCommon:
     def test_ufunc_overrides(self):
         # data
         a = np.array([[1, 2, 3],
-                      [4, 5, 6],
+                      [4, 5, 0],
                       [7, 8, 9]])
         b = np.array([[9, 8, 7],
-                      [6, 5, 4],
+                      [6, 0, 0],
                       [3, 2, 1]])
+        c = 1.0
 
         asp = self.spmatrix(a)
         bsp = self.spmatrix(b)
@@ -1352,8 +1353,8 @@ class _TestCommon:
         @dec.skipif(LooseVersion(np.version.version) < LooseVersion('1.9'),
                     "feature requires Numpy 1.9")
         def check(i, j):
-            ax = (a, asp)[i]
-            bx = (b, bsp)[j]
+            ax = (a, c, asp)[i]
+            bx = (b, c, bsp)[j]
 
             # -- associative
 
@@ -1372,20 +1373,14 @@ class _TestCommon:
             assert_array_equal(todense(np.subtract(ax, bx)), np.subtract(a, b))
 
             # divide
-            if ax is asp or bx is b:
-                assert_array_equal(todense(np.divide(ax, bx)), np.divide(a, b))
-            if bx is bsp:
-                assert_raises(TypeError, np.divide, a, bx)
+            assert_array_equal(todense(np.divide(ax, bx)), np.divide(a, b))
 
             # true_divide
-            if ax is asp or bx is b:
-                assert_array_equal(todense(np.true_divide(ax, bx)), np.true_divide(a, b))
-            if bx is bsp:
-                assert_raises(TypeError, np.true_divide, a, bx)
+            assert_array_equal(todense(np.true_divide(ax, bx)), np.true_divide(a, b))
 
-        for i in (0, 1):
-            for j in (0, 1):
-                if i != 0 or j != 0:
+        for i in range(3):
+            for j in range(3):
+                if i == 2 or j == 2:
                     yield check, i, j
 
 


### PR DESCRIPTION
Continuation of gh-2732, which additional bug fixes required to make things work as in ndarrays.

The fixes are not easily separated to a separate PR, as testing them goes through the `__numpy_ufunc__` support.
