### PR TITLE
TST: decrease test tolerance of interpolate test.

### DIFF
--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -300,7 +300,10 @@ class TestSplder(object):
             dy = splev(xx, self.spl, n)
             spl2 = splder(self.spl, n)
             dy2 = splev(xx, spl2)
-            assert_allclose(dy, dy2)
+            if n == 1:
+                assert_allclose(dy, dy2, rtol=2e-6)
+            else:
+                assert_allclose(dy, dy2)
 
     def test_splantider_vs_splint(self):
         # Check antiderivative vs. FITPACK


### PR DESCRIPTION
Fixes the following failure on 32-bit Linux, Bento build:

```
======================================================================
FAIL: test_fitpack.TestSplder.test_splder_vs_splev
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rgommers/.local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/rgommers/Code/scipy/scipy/interpolate/tests/test_fitpack.py", line 304, in test_splder_vs_splev
    assert_allclose(dy, dy2)
  File "/home/rgommers/Code/numpy/numpy/testing/utils.py", line 1181, in assert_allclose
    verbose=verbose, header=header)
  File "/home/rgommers/Code/numpy/numpy/testing/utils.py", line 644, in assert_array_compare
    raise AssertionError(msg)
AssertionError:
Not equal to tolerance rtol=1e-07, atol=0

(mismatch 100.0%)
 x: array([-3980.01505714, -3968.01797701, -3956.03903697, ..., -4049.189339  ,
       -4060.77715859, -4072.38145423])
 y: array([-3980.01513343, -3968.01803805, -3956.039098  , ..., -4049.189339  ,
       -4060.77715859, -4072.38145423])
```
