### PR TITLE
DOC: sparse: don't recommend lil_matrix

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -93,8 +93,8 @@ There are seven available sparse matrix types:
     6. coo_matrix: COOrdinate format (aka IJV, triplet format)
     7. dia_matrix: DIAgonal format
 
-To construct a matrix efficiently, use either lil_matrix (recommended) or
-dok_matrix. The lil_matrix class supports basic slicing and fancy
+To construct a matrix efficiently, use either dok_matrix or lil_matrix.
+The lil_matrix class supports basic slicing and fancy
 indexing with a similar syntax to NumPy arrays.  As illustrated below,
 the COO format may also be used to efficiently construct matrices.
 


### PR DESCRIPTION
Constructing a lil_matrix can easily take quadratic time, while a dok_matrix should always take linear time. Given that sparse matrices are intended to handle very large datasets, recommending the quadratic time algorithm is a bad idea. I've seen this go wrong on several occasions and it comes up on [StackOverflow](http://stackoverflow.com/q/18737657/166749) every now and then.

A voice at the back of my head says `dok_matrix` should be rewritten in C++ for better performance and more operations, but I'll leave that for some other time.
