### PR TITLE
ENH: wrap xTRMM from blas level 3

### DIFF
--- a/scipy/linalg/fblas_l3.pyf.src
+++ b/scipy/linalg/fblas_l3.pyf.src
@@ -155,3 +155,41 @@ subroutine <prefix6><sy,\0,\0,\0,he,he>r2k(n,k,alpha,a,b,beta,c,trans,lower,lda,
 
 end subroutine <prefix><sy,\0,\0,\0,he,he>r2k
 
+
+subroutine <prefix>trmm(m, n, k, alpha, a, b, lda, ldb, side, lower, trans_a, diag)
+
+  !  performs one of the matrix-matrix operations
+  !
+  !     B := alpha*op( A )*B,   or   B := alpha*B*op( A )
+  !
+  !  where  alpha  is a scalar,  B  is an m by n matrix,  A  is a unit, or
+  !  non-unit,  upper or lower triangular matrix  and  op( A )  is one  of
+  !
+  !     op( A ) = A   or   op( A ) = A**T   or   op( A ) = A**H.
+  !
+  ! c = trmm(alpha, a, b, side=0, lower=0, trans_a=0, diag=0)
+
+  callstatement (*f2py_func)((side?"R":"L"), (lower?"L":"U"), &
+        (trans_a?(trans_a==2?"C":"T"):"N"), (diag?"U":"N"), &m, &n, &alpha, a, &lda, b, &ldb)
+  callprotoargument char*, char*, char*, char*, int*, int*, <ctype>*,<ctype>*,int*,<ctype>*, int*
+
+  integer optional, intent(in), check(side==0 || side==1) :: side = 0
+  integer optional, intent(in), check(lower==0 || lower==1) :: lower = 0
+  integer optional, intent(in), check(trans_a>=0 && trans_a <=2) :: trans_a = 0
+  integer optional, intent(in), check(diag==0 || diag==1) :: diag = 0
+
+  <ftype> intent(in) :: alpha
+
+  <ftype> dimension(lda, k), intent(in) :: a
+  <ftype> dimension(ldb, n), intent(in, out) :: b
+
+  integer depend(a), intent(hide) :: lda = shape(a, 0)
+  integer depend(a), intent(hide) :: k = shape(a, 1)
+
+  integer depend(b), intent(hide) :: ldb = shape(b, 0)
+  integer depend(b), intent(hide) :: n = shape(b, 1)
+
+  integer depend(side, a, b, n, k), intent(hide) :: m = (side ? n : k)
+
+end subroutine <prefix>trmm
+

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -445,5 +445,30 @@ class TestSyHe(TestCase):
             assert_array_almost_equal(np.triu(res), 2.*np.diag([1, 1]))
 
 
+class TestTRMM(TestCase):
+    """Quick and simple tests for dtrmm."""
+    def setUp(self):
+        self.a = np.array([[1., 2., ],
+                           [-2., 1.]])
+        self.b = np.array([[3., 4., -1.],
+                           [5., 6., -2.]])
+
+    def test_ab(self):
+        f = getattr(fblas, 'dtrmm', None)
+        if f is not None:
+            result = f(1., self.a, self.b)
+            expected = np.array([[13., 16., -5.],
+                                 [5., 6., -2.]]) # default a is upper triangular
+            assert_array_almost_equal(result, expected)
+
+    def test_ab_lower(self):
+        f = getattr(fblas, 'dtrmm', None)
+        if f is not None:
+            result = f(1., self.a, self.b, lower=True)
+            expected = np.array([[3., 4., -1.],
+                                 [-1., -2., 0.]]) # now a is lower triangular
+            assert_array_almost_equal(result, expected)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
addresses gh-2135.
the only missing one from blas3 is TRSM; as discussed in gh-2135, it's probably superseded by other functionality already present in scipy.
