### PR TITLE
[stats] fix formulas for higher moments of R, Burr, Fisk and F distributions

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -2656,28 +2656,9 @@ class burr_gen(rv_continuous):
     def _ppf(self, q, c, d):
         return (q**(-1.0/d)-1)**(-1.0/c)
 
-    def _stats(self, c, d, moments='mv'):
-        g2c, g2cd = gam(1-2.0/c), gam(2.0/c+d)
-        g1c, g1cd = gam(1-1.0/c), gam(1.0/c+d)
-        gd = gam(d)
-        k = gd*g2c*g2cd - g1c**2 * g1cd**2
-        mu = g1c*g1cd / gd
-        mu2 = k / gd**2.0
-        g1, g2 = None, None
-        g3c, g3cd = None, None
-        if 's' in moments:
-            g3c, g3cd = gam(1-3.0/c), gam(3.0/c+d)
-            g1 = 2*g1c**3 * g1cd**3 + gd*gd*g3c*g3cd - 3*gd*g2c*g1c*g1cd*g2cd
-            g1 /= sqrt(k**3)
-        if 'k' in moments:
-            if g3c is None:
-                g3c = gam(1-3.0/c)
-            if g3cd is None:
-                g3cd = gam(3.0/c+d)
-            g4c, g4cd = gam(1-4.0/c), gam(4.0/c+d)
-            g2 = 6*gd*g2c*g2cd * g1c**2 * g1cd**2 + gd**3 * g4c*g4cd
-            g2 -= 3*g1c**4 * g1cd**4 - 4*gd**2*g3c*g1c*g1cd*g3cd
-        return mu, mu2, g1, g2
+    def _munp(self, n, c, d):
+        nc = 1. * n / c
+        return d * special.beta(1.0 - nc, d + nc)
 burr = burr_gen(a=0.0, name='burr')
 
 
@@ -2705,8 +2686,8 @@ class fisk_gen(burr_gen):
     def _ppf(self, x, c):
         return burr_gen._ppf(self, x, c, 1.0)
 
-    def _stats(self, c):
-        return burr_gen._stats(self, c, 1.0)
+    def _munp(self, n, c):
+        return burr_gen._munp(self, n, c, 1.0)
 
     def _entropy(self, c):
         return 2 - log(c)

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -3193,7 +3193,7 @@ class f_gen(rv_continuous):
         mu = where(v2 > 2, v2 / asarray(v2 - 2), inf)
         mu2 = 2*v2*v2*(v2+v1-2)/(v1*(v2-2)**2 * (v2-4))
         mu2 = where(v2 > 4, mu2, inf)
-        g1 = 2*(v2+2*v1-2)/(v2-6)*sqrt((2*v2-4)/(v1*(v2+v1-2)))
+        g1 = 2*(v2+2*v1-2)/(v2-6)*sqrt((2*v2-8)/(v1*(v2+v1-2)))
         g1 = where(v2 > 6, g1, nan)
         g2 = 3/(2*v2-16)*(8+g1*g1*(v2-6))
         g2 = where(v2 > 8, g2, nan)

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -3103,25 +3103,30 @@ class fatiguelife_gen(rv_continuous):
         return t
 
     def _pdf(self, x, c):
-        return (x+1)/asarray(2*c*sqrt(2*pi*x**3))*exp(-(x-1)**2/asarray((2.0*x*c**2)))
+        return np.exp(self._logpdf(x, c))
 
     def _logpdf(self, x, c):
         return log(x+1) - (x-1)**2 / (2.0*x*c**2) - log(2*c) - 0.5*(log(2*pi) + 3*log(x))
 
     def _cdf(self, x, c):
-        return special.ndtr(1.0/c*(sqrt(x)-1.0/asarray(sqrt(x))))
+        return special.ndtr(1.0 / c * (sqrt(x) - 1.0/sqrt(x)))
 
     def _ppf(self, q, c):
         tmp = c*special.ndtri(q)
-        return 0.25*(tmp + sqrt(tmp**2 + 4))**2
+        return 0.25 * (tmp + sqrt(tmp**2 + 4))**2
 
     def _stats(self, c):
+        # NB: the formula for kurtosis in wikipedia seems to have an error:
+        # it's 40, not 41. At least it disagrees with the one from Wolfram Alpha.
+        # And the latter one, below, passes the tests, while the wiki one doesn't
+        # So far I didn't have the guts to actually check the coefficients
+        # from the expressions for the raw moments.
         c2 = c*c
-        mu = c2 / 2.0 + 1
-        den = 5*c2 + 4
+        mu = c2 / 2.0 + 1.0
+        den = 5.0 * c2 + 4.0
         mu2 = c2*den / 4.0
-        g1 = 4*c*sqrt(11*c2+6.0)/np.power(den, 1.5)
-        g2 = 6*c2*(93*c2+41.0) / den**2.0
+        g1 = 4 * c * (11*c2 + 6.0) / np.power(den, 1.5)
+        g2 = 6 * c2 * (93*c2 + 40.0) / den**2.0
         return mu, mu2, g1, g2
 fatiguelife = fatiguelife_gen(a=0.0, name='fatiguelife')
 

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -5089,31 +5089,38 @@ class nct_gen(rv_continuous):
         return special.nctdtrit(df, nc, q)
 
     def _stats(self, df, nc, moments='mv'):
+        #
+        # See D. Hogben, R.S. Pinkham, and M.B. Wilk,
+        # 'The moments of the non-central t-distribution'
+        # Biometrika 48, p. 465 (2961).
+        # e.g. http://www.jstor.org/stable/2332772 (gated)
+        #
         mu, mu2, g1, g2 = None, None, None, None
-        val1 = gam((df-1.0)/2.0)
-        val2 = gam(df/2.0)
-        if 'm' in moments:
-            mu = nc*sqrt(df/2.0)*val1/val2
-        if 'v' in moments:
-            var = (nc*nc+1.0)*df/(df-2.0)
-            var -= nc*nc*df * val1**2 / 2.0 / val2**2
-            mu2 = var
+        
+        gfac = gam(df/2.-0.5) / gam(df/2.)
+        c11 = sqrt(df/2.) * gfac
+        c20 = df / (df-2.)
+        c22 = c20 - c11*c11
+        mu = np.where(df > 1, nc*c11, np.inf)
+        mu2 = np.where(df > 2, c22*nc*nc + c20, np.inf)
         if 's' in moments:
-            g1n = 2*nc*sqrt(df)*val1*((nc*nc*(2*df-7)-3)*val2**2
-                                      - nc*nc*(df-2)*(df-3)*val1**2)
-            g1d = (df-3)*sqrt(2*df*(nc*nc+1)/(df-2) -
-                              nc*nc*df*(val1/val2)**2) * val2 * \
-                              (nc*nc*(df-2)*val1**2 -
-                               2*(nc*nc+1)*val2**2)
-            g1 = g1n/g1d
+            c33t = df * (7.-2.*df) / (df-2.) / (df-3.) + 2.*c11*c11
+            c31t = 3.*df / (df-2.) / (df-3.)
+            mu3 = (c33t*nc*nc + c31t) * c11*nc
+            g1 = np.where(df > 3, mu3 / np.power(mu2, 1.5),
+                                  np.nan)
+        #kurtosis
         if 'k' in moments:
-            g2n = 2*(-3*nc**4*(df-2)**2 * (df-3) * (df-4)*val1**4 +
-                     2**(6-2*df) * nc*nc*(df-2)*(df-4) *
-                     (nc*nc*(2*df-7)-3)*pi*gam(df+1)**2 -
-                     4*(nc**4*(df-5)-6*nc*nc-3)*(df-3)*val2**4)
-            g2d = (df-3)*(df-4)*(nc*nc*(df-2)*val1**2 -
-                                 2*(nc*nc+1)*val2)**2
-            g2 = g2n / g2d
+            c44 = df*df / (df-2.) / (df-4.)
+            c44 -= c11*c11 * 2.*df*(5.-df) / (df-2.) / (df-3.)
+            c44 -= 3.*c11**4
+            c42 = df / (df-4.) - c11*c11 * (df-1.) / (df-3.)
+            c42 *= 6.*df / (df-2.)
+            c40 = 3.*df*df / (df-2.) / (df-4.)
+            
+            mu4 = c44 * nc**4 + c42*nc**2 + c40
+            g2 = np.where(df > 4, mu4/mu2**2 - 3.,
+                                  np.nan)
         return mu, mu2, g1, g2
 nct = nct_gen(name="nct")
 

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -5466,11 +5466,11 @@ class rdist_gen(rv_continuous):
         # background.
         if any(np.isnan(res)):
             return rv_continuous._cdf(self, x, c)
-
         return res
 
     def _munp(self, n, c):
-        return (1 - (n % 2)) * special.beta((n + 1.0) / 2, c / 2.0)
+        numerator = (1 - (n % 2)) * special.beta((n + 1.0) / 2, c / 2.0) 
+        return numerator / special.beta(1. / 2, c / 2.)
 rdist = rdist_gen(a=-1.0, b=1.0, name="rdist")
 
 

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -67,8 +67,8 @@ def check_skew_expect(distfn, arg, m, v, s, msg):
 def check_kurt_expect(distfn, arg, m, v, k, msg):
     if np.isfinite(k):
         m4e = distfn.expect(lambda x: np.power(x-m, 4), arg)
-        npt.assert_almost_equal(m4e, (k + 3.) * np.power(v, 2), 
-                decimal=5, err_msg=msg + ' - kurtosis')
+        npt.assert_allclose(m4e, (k + 3.) * np.power(v, 2), atol=1e-5, rtol=1e-5,
+                err_msg=msg + ' - kurtosis')
     else:
         npt.assert_(np.isnan(k))
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -284,7 +284,7 @@ def test_cont_basic_slow():
 @npt.dec.slow
 def test_moments():
      knf = npt.dec.knownfailureif
-     distfailing = set(['burr', 'dweibull', 'f', 
+     distfailing = set(['dweibull', 'f',
                 'fatiguelife', 'foldnorm', 'ksone', 'ncf', 'nct', 
                 'vonmises'])
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -284,9 +284,8 @@ def test_cont_basic_slow():
 @npt.dec.slow
 def test_moments():
      knf = npt.dec.knownfailureif
-     distfailing = set(['dweibull', 'fatiguelife', 'foldnorm', 'ksone', 
+     distfailing = set(['dweibull', 'foldnorm', 'ksone', 
             'ncf', 'nct', 'vonmises'])
-
      for distname, arg in distcont[:]:
         distfn = getattr(stats, distname)
         m, v, s, k = distfn.stats(*arg, moments='mvsk')
@@ -421,26 +420,6 @@ def check_distribution_rvs(dist, args, alpha, rvs):
         D,pval = stats.kstest(dist,'',args=args, N=1000)
         npt.assert_(pval > alpha, "D = " + str(D) + "; pval = " + str(pval) +
                "; alpha = " + str(alpha) + "\nargs = " + str(args))
-
-
-def check_normalization(distfn, args, distname):
-    normalization_moment = distfn.moment(0, *args)
-    npt.assert_allclose(normalization_moment, 1.0)
-
-    # this is a temporary plug: either ncf or expect is problematic;
-    msg = "ncf normalization requires low tolerance"
-    npt.dec.knownfailureif(distname=="ncf", msg)(lambda: None)()
-    if distname == "ncf":
-        atol, rtol = 1e-5, 0
-    else:
-        atol, rtol = 1e-7, 1e-7
-
-    normalization_expect = distfn.expect(lambda x: 1, args=args)
-    npt.assert_allclose(normalization_expect, 1.0, atol=atol, rtol=rtol,
-            err_msg=distname, verbose=True)
-
-    normalization_cdf = distfn.cdf(distfn.b, *args)
-    npt.assert_allclose(normalization_cdf, 1.0)
 
 
 def check_vecentropy(distfn, args):

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -284,7 +284,7 @@ def test_cont_basic_slow():
 @npt.dec.slow
 def test_moments():
      knf = npt.dec.knownfailureif
-     distfailing = set(['dweibull', 'foldnorm', 'ksone', 'ncf', 'vonmises'])
+     distfailing = set(['dweibull', 'ksone', 'ncf', 'vonmises'])
      for distname, arg in distcont[:]:
         distfn = getattr(stats, distname)
         m, v, s, k = distfn.stats(*arg, moments='mvsk')

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -273,8 +273,11 @@ def test_cont_basic_slow():
         yield check_named_args, distfn, x, arg, locscale_defaults, meths
 
         # this asserts the vectorization of _entropy w/ no shape parameters
+        # this asserts the vectorization of _entropy w/ no shape parameters
+        # NB: broken for older versions of numpy
         if distfn.numargs == 0:
-            yield check_vecentropy, distfn, arg
+            if np.__version__ > '1.7':
+                yield check_vecentropy, distfn, arg
         # compare a generic _entropy w/ distribution-specific implementation,
         # if available
         if distfn.__class__._entropy != stats.rv_continuous._entropy:

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -284,8 +284,7 @@ def test_cont_basic_slow():
 @npt.dec.slow
 def test_moments():
      knf = npt.dec.knownfailureif
-     distfailing = set(['dweibull', 'foldnorm', 'ksone', 
-            'ncf', 'nct', 'vonmises'])
+     distfailing = set(['dweibull', 'foldnorm', 'ksone', 'ncf', 'vonmises'])
      for distname, arg in distcont[:]:
         distfn = getattr(stats, distname)
         m, v, s, k = distfn.stats(*arg, moments='mvsk')

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -284,9 +284,8 @@ def test_cont_basic_slow():
 @npt.dec.slow
 def test_moments():
      knf = npt.dec.knownfailureif
-     distfailing = set(['dweibull', 'f',
-                'fatiguelife', 'foldnorm', 'ksone', 'ncf', 'nct', 
-                'vonmises'])
+     distfailing = set(['dweibull', 'fatiguelife', 'foldnorm', 'ksone', 
+            'ncf', 'nct', 'vonmises'])
 
      for distname, arg in distcont[:]:
         distfn = getattr(stats, distname)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -285,8 +285,8 @@ def test_cont_basic_slow():
 def test_moments():
      knf = npt.dec.knownfailureif
      distfailing = set(['burr', 'dweibull', 'f', 
-                'fatiguelife', 'foldnorm', 'invgamma', 'ksone', 'ncf', 'nct', 
-                'rdist', 'rice', 'vonmises'])
+                'fatiguelife', 'foldnorm', 'ksone', 'ncf', 'nct', 
+                'vonmises'])
 
      for distname, arg in distcont[:]:
         distfn = getattr(stats, distname)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1233,13 +1233,23 @@ class TestNct(TestCase):
                           [0.00153078, 0.00291093, 0.00525206, 0.00900815]])
         assert_allclose(res, expected, rtol=1e-5)
 
-    def text_variance_gh_issue_2401():
+    def text_variance_gh_issue_2401(self):
         # Computation of the variance of a non-central t-distribution resulted
         # in a TypeError: ufunc 'isinf' not supported for the input types,
         # and the inputs could not be safely coerced to any supported types
         # according to the casting rule 'safe'
         rv = stats.nct(4, 0)
         assert_equal(rv.var(), 2.0)
+
+    def test_nct_inf_moments(self):
+        # n-th moment of nct only exists for df > n
+        m, v, s, k = stats.nct.stats(df=1.9, nc = 0.3, moments='mvsk')
+        assert_(np.isfinite(m))
+        assert_equal([v, s, k], [np.inf, np.nan, np.nan])
+
+        m, v, s, k = stats.nct.stats(df=3.1, nc = 0.3, moments='mvsk')
+        assert_(np.isfinite([m, v, s]).all())
+        assert_equal(k, np.nan)
 
 
 def test_regression_ticket_1316():

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -570,6 +570,28 @@ class TestInvGamma(TestCase):
                          [np.nan, np.nan, 24.51923076]))        # kkk
 
 
+class TestF(TestCase):
+    def test_f_moments(self):
+        # n-th moment of F distributions is only finite for n < dfd / 2
+        m, v, s, k = stats.f.stats(11, 6.5, moments='mvsk')
+        assert_(np.isfinite(m))
+        assert_(np.isfinite(v))
+        assert_(np.isfinite(s))
+        assert_(not np.isfinite(k))
+
+    def test_moments_warnings(self):
+        # no warnings should be generated for dfd = 2, 4, 6, 8 (div by zero)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', RuntimeWarning)
+            mvsk = stats.f.stats(dfn=[11]*4, 
+                                 dfd=[2, 4, 6, 8], moments='mvsk')
+
+    @dec.knownfailureif(True, 'f stats does not properly broadcast')
+    def test_stats_broadcast(self):
+        # stats do not full broadcast yet just yet
+        mv = stats.f.stats(dfn=11, dfd=[11, 12])        
+
+
 def test_rvgeneric_std():
     # Regression test for #1191
     assert_array_almost_equal(stats.t.std([5, 6]), [1.29099445, 1.22474487])

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -588,7 +588,7 @@ class TestF(TestCase):
 
     @dec.knownfailureif(True, 'f stats does not properly broadcast')
     def test_stats_broadcast(self):
-        # stats do not full broadcast yet just yet
+        # stats do not fully broadcast just yet
         mv = stats.f.stats(dfn=11, dfd=[11, 12])        
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -563,11 +563,12 @@ class TestInvGamma(TestCase):
 
             a = [1.1, 3.1, 5.6]
             mvsk = stats.invgamma.stats(a=a, moments='mvsk')
-            assert_array_almost_equal(mvsk,
-                        ([10., 0.476190476, 0.2173913043],      # mmm
-                         [np.inf, 0.2061430632, 0.01312749422], # vvv
-                         [np.nan, 41.95235392, 2.919025532],    # sss
-                         [np.nan, np.nan, 24.51923076]))        # kkk
+            expected = ([10., 0.476190476, 0.2173913043],      # mmm
+                        [np.inf, 0.2061430632, 0.01312749422], # vvv
+                        [np.nan, 41.95235392, 2.919025532],    # sss
+                        [np.nan, np.nan, 24.51923076])         # kkk
+            for x, y in zip(mvsk, expected):
+                assert_almost_equal(x, y)
 
 
 class TestF(TestCase):


### PR DESCRIPTION
Also rework the stats method of F to avoid having spurious division-by-zero warnings.
The latter were generated because of the dispatch on numpy.where: 

```
>>> a = np.array([1, 2, 3])
>>> np.where(a > 1, 1./a, np.nan)
```

(caught by Warren in gh-2849). 

There is still a broadcasting failure left: `f` has two shape arguments, and `f.stats` fails when called with different lengths: `f.stats(11, [1, 2, 3])`.
I'm pretty sure this is not the only distribution which does this, thus am marking this test as a knownfailure. Until we fix it generically. 
