### PR TITLE
ENH: interpolate: rewrite ppform evaluation in Cython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ scipy/fftpack/src/dst.c
 scipy/integrate/_dopmodule.c
 scipy/integrate/lsodamodule.c
 scipy/integrate/vodemodule.c
+scipy/interpolate/_ppoly.c
 scipy/interpolate/interpnd.c
 scipy/interpolate/src/dfitpack-f2pywrappers.f
 scipy/interpolate/src/dfitpackmodule.c

--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -28,6 +28,7 @@ Univariate interpolation
    krogh_interpolate
    piecewise_polynomial_interpolate
    pchip_interpolate
+   PPoly
 
 
 Multivariate interpolation

--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -181,11 +181,10 @@ def fix_continuity(double_or_complex[:,:,::1] c,
 
     """
 
-    cdef int ip, jp, kp, i, dx
+    cdef int ip, jp, kp, dx
     cdef int interval
-    cdef int has_out_of_bounds
     cdef double_or_complex z, res
-    cdef double a, b, prefactor, xval
+    cdef double prefactor, xval
 
     # check derivative order
     if dx < 0:
@@ -200,12 +199,6 @@ def fix_continuity(double_or_complex[:,:,::1] c,
         raise ValueError("order negative")
 
     # evaluate
-    a = x[0]
-    b = x[x.shape[0]-1]
-
-    interval = 0
-    has_out_of_bounds = 0
-
     for ip in range(1, len(x)-1):
         xval = x[ip]
         interval = ip - 1
@@ -239,5 +232,3 @@ def fix_continuity(double_or_complex[:,:,::1] c,
                     res /= kp + 1
 
                 c[c.shape[0] - dx - 1, ip, jp] = res
-
-    return has_out_of_bounds

--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -18,6 +18,7 @@ def evaluate(double_or_complex[:,:,::1] c,
              double[::1] x,
              double[::1] xp,
              int dx,
+             int at_endpoint,
              double_or_complex[:,::1] out):
     """
     Evaluate a piecewise polynomial.
@@ -35,6 +36,10 @@ def evaluate(double_or_complex[:,:,::1] c,
     dx : int
         Order of derivative to evaluate.  The derivative is evaluated
         piecewise and may have discontinuities.
+    at_endpoint : bool
+        Evaluate the value of the polynomial at the endpoints of each
+        break points, xp[j]=x[j+1]. If True, the parameter `xp` is ignored
+        and `out` should be of length `x-1`.
 
     Returns
     -------
@@ -49,11 +54,23 @@ def evaluate(double_or_complex[:,:,::1] c,
     cdef int interval, high, low, mid
     cdef int has_out_of_bounds
     cdef double_or_complex z, res
-    cdef double a, b, prefactor
+    cdef double a, b, prefactor, xval
 
+    # check derivative order
     if dx < 0:
         raise ValueError("Order of derivative cannot be negative")
 
+    # shape checks
+    if at_endpoint:
+        if out.shape[0] != x.shape[0] - 1:
+            raise ValueError("at_endpoint given but out has wrong shape")
+    else:
+        if out.shape[0] != xp.shape[0]:
+            raise ValueError("out and xp have incompatible shapes")
+    if out.shape[1] != c.shape[2]:
+        raise ValueError("out and c have incompatible shapes")
+
+    # evaluate
     a = x[0]
     b = x[x.shape[0]-1]
 
@@ -61,69 +78,78 @@ def evaluate(double_or_complex[:,:,::1] c,
     has_out_of_bounds = 0
 
     for ip in range(len(xp)):
-        # Find correct interval
-        if not (a <= xp[ip] <= b):
-            # Out-of-bounds (or nan)
-            has_out_of_bounds = 1
-            for jp in range(c.shape[2]):
-                out[ip, jp] = nan
-            continue
-        elif xp[ip] == b:
-            # Make the interval closed from the right
-            interval = x.shape[0] - 2
+        if at_endpoint:
+            # Evaluate at interval endpoints
+            xval = x[ip+1]
+            interval = ip
         else:
-            # Find the interval the coordinate is in
-            # (binary search with locality)
-            if xp[ip] >= x[interval]:
-                low = interval
-                high = x.shape[0]-2
+            xval = xp[ip]
+
+            # Find correct interval
+            if not (a <= xval <= b):
+                # Out-of-bounds (or nan)
+                has_out_of_bounds = 1
+                for jp in range(c.shape[2]):
+                    out[ip, jp] = nan
+                continue
+            elif xval == b:
+                # Make the interval closed from the right
+                interval = x.shape[0] - 2
             else:
-                low = 0
-                high = interval
-
-            if xp[ip] < x[low+1]:
-                high = low
-
-            while low < high:
-                mid = (high + low)//2
-                if xp[ip] < x[mid]:
-                    # mid < high
-                    high = mid
-                elif xp[ip] >= x[mid + 1]:
-                    low = mid + 1
+                # Find the interval the coordinate is in
+                # (binary search with locality)
+                if xval >= x[interval]:
+                    low = interval
+                    high = x.shape[0]-2
                 else:
-                    # x[mid] <= xp[ip] < x[mid+1]
-                    low = mid
-                    break
+                    low = 0
+                    high = interval
 
-            interval = low
+                if xval < x[low+1]:
+                    high = low
 
-            assert x[interval] <= xp[ip] < x[interval+1]
+                while low < high:
+                    mid = (high + low)//2
+                    if xval < x[mid]:
+                        # mid < high
+                        high = mid
+                    elif xval >= x[mid + 1]:
+                        low = mid + 1
+                    else:
+                        # x[mid] <= xval < x[mid+1]
+                        low = mid
+                        break
+
+                interval = low
+
+                assert x[interval] <= xval < x[interval+1]
 
         # Evaluate the local polynomial(s)
         for jp in range(c.shape[2]):
             out[ip, jp] = 0
 
-        z = 1.0
-        for kp in range(c.shape[0]):
-            # prefactor of term after differentiation
-            if kp < dx:
-                continue
-            else:
-                prefactor = 1.0
-                for i in range(kp, kp - dx, -1):
-                    prefactor *= i
+            res = 0
+            z = 1.0
 
-            # sum terms
-            if prefactor == 1:
-                for jp in range(c.shape[2]):
-                    out[ip, jp] = out[ip, jp] + c[c.shape[0] - kp - 1, interval, jp] * z
-            else:
-                for jp in range(c.shape[2]):
-                    out[ip, jp] = out[ip, jp] + c[c.shape[0] - kp - 1, interval, jp] * z * prefactor
+            for kp in range(c.shape[0]):
+                # prefactor of term after differentiation
+                if kp < dx:
+                    continue
+                else:
+                    prefactor = 1.0
+                    for i in range(kp, kp - dx, -1):
+                        prefactor *= i
 
-            # compute x**max(k-dx,0)
-            if kp < c.shape[0] - 1 and kp >= dx:
-                z *= xp[ip] - x[interval]
+                # sum terms
+                if prefactor == 1:
+                    res = res + c[c.shape[0] - kp - 1, interval, jp] * z
+                else:
+                    res = res + c[c.shape[0] - kp - 1, interval, jp] * z * prefactor
+
+                # compute x**max(k-dx,0)
+                if kp < c.shape[0] - 1 and kp >= dx:
+                    z *= xval - x[interval]
+
+            out[ip, jp] = res
 
     return has_out_of_bounds

--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -218,15 +218,15 @@ def integrate(double_or_complex[:,:,::1] c,
         for interval in range(start_interval, end_interval+1):
             # local antiderivative, end point
             if interval == end_interval:
-                vb = evaluate_poly1(b - x[interval], c, interval, jp, dx=-1)
+                vb = evaluate_poly1(b - x[interval], c, interval, jp, -1)
             else:
-                vb = evaluate_poly1(x[interval+1] - x[interval], c, interval, jp, dx=-1)
+                vb = evaluate_poly1(x[interval+1] - x[interval], c, interval, jp, -1)
 
             # local antiderivative, start point
             if interval == start_interval:
-                va = evaluate_poly1(a - x[interval], c, interval, jp, dx=-1)
+                va = evaluate_poly1(a - x[interval], c, interval, jp, -1)
             else:
-                va = evaluate_poly1(0, c, interval, jp, dx=-1)
+                va = evaluate_poly1(0, c, interval, jp, -1)
 
             # integral
             vtot = vtot + (vb - va)

--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -731,7 +731,7 @@ cdef double_or_complex evaluate_bpoly1(double_or_complex s, double_or_complex[:,
 
     A Berstein polynomial is defined as ..math::
 
-    b_{j, k} = comb(k, j) x^{j} (1-x)^{k-j}
+        b_{j, k} = comb(k, j) x^{j} (1-x)^{k-j}
 
     with ``0 <= x <= 1``
 

--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -762,7 +762,7 @@ cdef double_or_complex evaluate_bpoly1(double_or_complex s, double_or_complex[:,
         res = (c[0, ci, cj] * s1*s1*s1 + c[1, ci, cj] * 3.*s1*s1*s +
                c[2, ci, cj] * 3.*s1*s*s + c[3, ci, cj] * s*s*s)
     else:
-        # XX: replace with de Casteljau's algorithm is needs be
+        # XXX: replace with de Casteljau's algorithm, if needs be
         res, comb = 0., 1.
         for j in range(k+1):
             res += comb * s**j * s1**(k-j) * c[j, ci, cj]
@@ -771,7 +771,7 @@ cdef double_or_complex evaluate_bpoly1(double_or_complex s, double_or_complex[:,
     return res
 
 #
-# Only differs from _ppoly by evaluate_poly1 -> evaluate_bpoly1
+# Evaluation; only differs from _ppoly by evaluate_poly1 -> evaluate_bpoly1
 #
 @cython.wraparound(False)
 @cython.boundscheck(False)

--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -1,0 +1,107 @@
+from .polyint import _Interpolator1D
+import numpy as np
+
+cimport cython
+
+cdef double nan = np.nan
+
+ctypedef double complex double_complex
+
+ctypedef fused double_or_complex:
+    double
+    double complex
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+def evaluate(double_or_complex[:,:,::1] c,
+             double[::1] x,
+             double[::1] xp,
+             double_or_complex[:,::1] out):
+    """
+    Evaluate a piecewise polynomial.
+
+    Parameters
+    ----------
+    c : ndarray, shape (k, m, n)
+        Coefficients local polynomials of order `k-1` in `m` intervals.
+        There are `n` polynomials in each interval.
+        Coefficient of highest order-term comes first.
+    x : ndarray, shape (m+1,)
+        Breakpoints of polynomials
+    xp : ndarray, shape (r,)
+        Points to evaluate the piecewise polynomial at.
+
+    Returns
+    -------
+    out : ndarray, shape (r, n)
+        Value of each polynomial at each of the input points.
+        For points outside the span ``x[0] ... x[-1]``,
+        ``nan`` is returned.
+
+    """
+
+    cdef int ip, jp, kp
+    cdef int interval, high, low, mid
+    cdef int has_out_of_bounds
+    cdef double_or_complex z, res
+    cdef double a, b
+
+    a = x[0]
+    b = x[x.shape[0]-1]
+
+    interval = 0
+    has_out_of_bounds = 0
+
+    for ip in range(len(xp)):
+        # Find correct interval
+        if not (a <= xp[ip] <= b):
+            # Out-of-bounds (or nan)
+            has_out_of_bounds = 1
+            for jp in range(c.shape[2]):
+                out[ip, jp] = nan
+            continue
+        elif xp[ip] == b:
+            # Make the interval closed from the right
+            interval = x.shape[0] - 2
+        else:
+            # Find the interval the coordinate is in
+            # (binary search with locality)
+            if xp[ip] >= x[interval]:
+                low = interval
+                high = x.shape[0]-2
+            else:
+                low = 0
+                high = interval
+
+            if xp[ip] < x[low+1]:
+                high = low
+
+            while low < high:
+                mid = (high + low)//2
+                if xp[ip] < x[mid]:
+                    # mid < high
+                    high = mid
+                elif xp[ip] >= x[mid + 1]:
+                    low = mid + 1
+                else:
+                    # x[mid] <= xp[ip] < x[mid+1]
+                    low = mid
+                    break
+
+            interval = low
+
+            assert x[interval] <= xp[ip] < x[interval+1]
+
+        # Evaluate the local polynomial(s)
+        for jp in range(c.shape[2]):
+            out[ip, jp] = 0
+
+        z = 1.0
+        for kp in range(c.shape[0]):
+            for jp in range(c.shape[2]):
+                out[ip, jp] = out[ip, jp] + c[c.shape[0] - kp - 1, interval, jp] * z
+            if kp < c.shape[0] - 1:
+                z *= xp[ip] - x[interval]
+
+    return has_out_of_bounds

--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -1,3 +1,9 @@
+"""
+Routines for evaluating and manipulating piecewise polynomials in
+local power basis.
+
+"""
+
 from .polyint import _Interpolator1D
 import numpy as np
 
@@ -10,6 +16,7 @@ ctypedef double complex double_complex
 ctypedef fused double_or_complex:
     double
     double complex
+
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
@@ -49,7 +56,7 @@ def evaluate(double_or_complex[:,:,::1] c,
     cdef int interval, high, low, mid
     cdef int has_out_of_bounds
     cdef double_or_complex z, res
-    cdef double a, b, prefactor, xval
+    cdef double prefactor, xval
 
     # check derivative order
     if dx < 0:
@@ -64,9 +71,6 @@ def evaluate(double_or_complex[:,:,::1] c,
         raise ValueError("x and c have incompatible shapes")
 
     # evaluate
-    a = x[0]
-    b = x[x.shape[0]-1]
-
     interval = 0
     has_out_of_bounds = 0
 
@@ -74,71 +78,17 @@ def evaluate(double_or_complex[:,:,::1] c,
         xval = xp[ip]
 
         # Find correct interval
-        if not (a <= xval <= b):
-            # Out-of-bounds (or nan)
+        i = find_interval(x, xval, interval)
+        if i < 0:
             has_out_of_bounds = 1
             for jp in range(c.shape[2]):
                 out[ip, jp] = nan
             continue
-        elif xval == b:
-            # Make the interval closed from the right
-            interval = x.shape[0] - 2
-        else:
-            # Find the interval the coordinate is in
-            # (binary search with locality)
-            if xval >= x[interval]:
-                low = interval
-                high = x.shape[0]-2
-            else:
-                low = 0
-                high = interval
-
-            if xval < x[low+1]:
-                high = low
-
-            while low < high:
-                mid = (high + low)//2
-                if xval < x[mid]:
-                    # mid < high
-                    high = mid
-                elif xval >= x[mid + 1]:
-                    low = mid + 1
-                else:
-                    # x[mid] <= xval < x[mid+1]
-                    low = mid
-                    break
-
-            interval = low
-
-            assert x[interval] <= xval < x[interval+1]
+        interval = i
 
         # Evaluate the local polynomial(s)
         for jp in range(c.shape[2]):
-            out[ip, jp] = 0
-
-            res = 0
-            z = 1.0
-
-            for kp in range(c.shape[0]):
-                # prefactor of term after differentiation
-                if kp < dx:
-                    continue
-                else:
-                    prefactor = 1.0
-                    for i in range(kp, kp - dx, -1):
-                        prefactor *= i
-
-                # sum terms
-                if prefactor == 1:
-                    res = res + c[c.shape[0] - kp - 1, interval, jp] * z
-                else:
-                    res = res + c[c.shape[0] - kp - 1, interval, jp] * z * prefactor
-
-                # compute x**max(k-dx,0)
-                if kp < c.shape[0] - 1 and kp >= dx:
-                    z *= xval - x[interval]
-
-            out[ip, jp] = res
+            out[ip, jp] = evaluate_poly1(xval - x[interval], c, interval, jp, dx)
 
     return has_out_of_bounds
 
@@ -173,7 +123,7 @@ def fix_continuity(double_or_complex[:,:,::1] c,
     cdef double prefactor, xval
 
     # check derivative order
-    if dx < 0:
+    if order < 0:
         raise ValueError("Order of derivative cannot be negative")
 
     # shape checks
@@ -195,22 +145,7 @@ def fix_continuity(double_or_complex[:,:,::1] c,
             # ones, but not vice versa)
             for dx in range(order, -1, -1):
                 # evaluate dx-th derivative of the polynomial in previous interval
-                res = 0
-                z = 1.0
-                for kp in range(c.shape[0]):
-                    # prefactor of term after differentiation
-                    if kp < dx:
-                        continue
-                    else:
-                        prefactor = 1.0
-                        for i in range(kp, kp - dx, -1):
-                            prefactor *= i
-
-                    res = res + c[c.shape[0] - kp - 1, interval, jp] * z * prefactor
-
-                    # compute x**max(k-dx,0)
-                    if kp < c.shape[0] - 1 and kp >= dx:
-                        z *= xval - x[interval]
+                res = evaluate_poly1(xval - x[interval], c, interval, jp, dx)
 
                 # set dx-th coefficient of polynomial in current
                 # interval so that the dx-th derivative is continuous
@@ -218,3 +153,212 @@ def fix_continuity(double_or_complex[:,:,::1] c,
                     res /= kp + 1
 
                 c[c.shape[0] - dx - 1, ip, jp] = res
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+def integrate(double_or_complex[:,:,::1] c,
+              double[::1] x,
+              double a,
+              double b,
+              double_or_complex[::1] out):
+    """
+    Compute integral over a piecewise polynomial.
+
+    Parameters
+    ----------
+    c : ndarray, shape (k, m, n)
+        Coefficients local polynomials of order `k-1` in `m` intervals.
+    x : ndarray, shape (m+1,)
+        Breakpoints of polynomials
+    a : double
+        Start point of integration.
+    b : double
+        End point of integration.
+    out
+        Integral of the piecewise polynomial, assuming the polynomial
+        is zero outside the range (x[0], x[-1]).
+
+    """
+
+    cdef int ip, jp, kp, dx
+    cdef int start_interval, end_interval, interval, sign
+    cdef double_or_complex z, res, va, vb, vtot
+    cdef double prefactor, xval
+
+    # shape checks
+    if c.shape[1] != x.shape[0] - 1:
+        raise ValueError("x and c have incompatible shapes")
+    if out.shape[0] != c.shape[2]:
+        raise ValueError("x and c have incompatible shapes")
+
+    # fix integration order
+    if not (b >= a):
+        raise ValueError("Integral bounds not in order")
+
+    # find intervals
+    start_interval = find_interval(x, a)
+    if start_interval < 0:
+        raise ValueError("a out of range")
+
+    end_interval = find_interval(x, b)
+    if end_interval < 0:
+        raise ValueError("b out of range")
+
+    # evaluate
+    for jp in range(c.shape[2]):
+        vtot = 0
+        for interval in range(start_interval, end_interval+1):
+            # local antiderivative, end point
+            if interval == end_interval:
+                vb = evaluate_poly1(b - x[interval], c, interval, jp, dx=-1)
+            else:
+                vb = evaluate_poly1(x[interval+1] - x[interval], c, interval, jp, dx=-1)
+
+            # local antiderivative, start point
+            if interval == start_interval:
+                va = evaluate_poly1(a - x[interval], c, interval, jp, dx=-1)
+            else:
+                va = evaluate_poly1(0, c, interval, jp, dx=-1)
+
+            # integral
+            vtot = vtot + (vb - va)
+
+        out[jp] = vtot
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cdef int find_interval(double[::1] x,
+                       double xval,
+                       int prev_interval=0) nogil:
+    """
+    Find an interval such that x[interval] <= xval < x[interval+1]
+
+    Parameters
+    ----------
+    x : array of double, shape (m,)
+        Piecewise polynomial breakpoints
+    xval : double
+        Point to find
+    prev_interval : int, optional
+        Interval where a previous point was found
+
+    Returns
+    -------
+    interval : int
+        Interval where previous point was found, or
+        -1 below lower bound, -2 if above upper bound,
+        or -3 if nan.
+
+    """
+    cdef int interval, high, low, mid
+    cdef double a, b
+
+    a = x[0]
+    b = x[x.shape[0]-1]
+
+    interval = prev_interval
+    if interval < 0 or interval >= x.shape[0]:
+        interval = 0
+
+    if not (a <= xval <= b):
+        # Out-of-bounds (or nan)
+        if xval < a:
+            interval = -1 # below
+        elif xval > b:
+            interval = -2 # above
+        else:
+            interval = -3 # nan or something
+    elif xval == b:
+        # Make the interval closed from the right
+        interval = x.shape[0] - 2
+    else:
+        # Find the interval the coordinate is in
+        # (binary search with locality)
+        if xval >= x[interval]:
+            low = interval
+            high = x.shape[0]-2
+        else:
+            low = 0
+            high = interval
+
+        if xval < x[low+1]:
+            high = low
+
+        while low < high:
+            mid = (high + low)//2
+            if xval < x[mid]:
+                # mid < high
+                high = mid
+            elif xval >= x[mid + 1]:
+                low = mid + 1
+            else:
+                # x[mid] <= xval < x[mid+1]
+                low = mid
+                break
+
+        interval = low
+
+    return interval
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cdef double_or_complex evaluate_poly1(double s, double_or_complex[:,:,::1] c, int ci, int cj, int dx) nogil:
+    """
+    Evaluate polynomial, derivative, or antiderivative in a single interval.
+
+    Antiderivatives are evaluated assuming zero integration constants.
+
+    Parameters
+    ----------
+    s : double
+        Polynomial x-value
+    c : double[:,:,:]
+        Polynomial coefficients. c[:,ci,cj] will be used
+    ci, cj : int
+        Which of the coefs to use
+    dx : int
+        Order of derivative (> 0) or antiderivative (< 0) to evaluate.
+
+    """
+    cdef int kp, k
+    cdef double_or_complex res, z
+    cdef double prefactor
+
+    res = 0.0
+    z = 1.0
+
+    if dx < 0:
+        for k in range(-dx):
+            z *= s
+
+    for kp in range(c.shape[0]):
+        # prefactor of term after differentiation
+        if dx == 0:
+            prefactor = 1.0
+        elif dx > 0:
+            # derivative
+            if kp < dx:
+                continue
+            else:
+                prefactor = 1.0
+                for k in range(kp, kp - dx, -1):
+                    prefactor *= k
+        else:
+            # antiderivative
+            prefactor = 1.0
+            for k in range(kp, kp - dx):
+                prefactor /= k + 1
+
+        res = res + c[c.shape[0] - kp - 1, ci, cj] * z * prefactor
+
+        # compute x**max(k-dx,0)
+        if kp < c.shape[0] - 1 and kp >= dx:
+            z *= s
+
+    return res

--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -762,7 +762,7 @@ cdef double_or_complex evaluate_bpoly1(double_or_complex s, double_or_complex[:,
         res = (c[0, ci, cj] * s1*s1*s1 + c[1, ci, cj] * 3.*s1*s1*s +
                c[2, ci, cj] * 3.*s1*s*s + c[3, ci, cj] * s*s*s)
     else:
-        # XXX: replace with de Casteljau's algorithm, if needs be
+        # XX: replace with de Casteljau's algorithm if needs be
         res, comb = 0., 1.
         for j in range(k+1):
             res += comb * s**j * s1**(k-j) * c[j, ci, cj]

--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -798,10 +798,11 @@ def evaluate_bernstein(double_or_complex[:,:,::1] c,
     dx : int
         Order of derivative to evaluate.  The derivative is evaluated
         piecewise and may have discontinuities.
+    extrapolate : int, optional
+        Whether to extrapolate to ouf-of-bounds points based on first
+        and last intervals, or to return NaNs.
     out : ndarray, shape (r, n)
         Value of each polynomial at each of the input points.
-        For points outside the span ``x[0] ... x[-1]``,
-        ``nan`` is returned.
         This argument is modified in-place.
 
     """

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -756,7 +756,7 @@ class PPoly(_PPolyBase):
         c2 *= factor[(slice(None),) + (None,)*(c2.ndim-1)]
 
         # construct a compatible polynomial
-        return PPoly.construct_fast(c2, self.x, self.extrapolate)
+        return self.construct_fast(c2, self.x, self.extrapolate)
 
     def antiderivative(self, nu=1):
         """
@@ -801,7 +801,7 @@ class PPoly(_PPolyBase):
                               self.x, nu)
 
         # construct a compatible polynomial
-        return PPoly.construct_fast(c, self.x, self.extrapolate)
+        return self.construct_fast(c, self.x, self.extrapolate)
 
     def integrate(self, a, b, extrapolate=None):
         """
@@ -1092,7 +1092,7 @@ class BPoly(_PPolyBase):
             c2 = np.zeros((1,) + c2.shape[1:], dtype=c2.dtype)
 
         # construct a compatible polynomial
-        return BPoly.construct_fast(c2, self.x, self.extrapolate)
+        return self.construct_fast(c2, self.x, self.extrapolate)
 
     def extend(self, c, x, right=True):
         k = max(self.c.shape[0], c.shape[0])
@@ -1132,8 +1132,8 @@ class BPoly(_PPolyBase):
 
         return cls.construct_fast(c, pp.x, extrapolate)
 
-    @staticmethod
-    def from_derivatives(xi, yi, orders=None, direction=None,
+    @classmethod
+    def from_derivatives(cls, xi, yi, orders=None, direction=None,
                          axis=0, extrapolate=None):
         """Construct a piecewise polynomial in the Bernstein basis,
         compatible with the specified values and derivatives at breakpoints.
@@ -1245,7 +1245,7 @@ class BPoly(_PPolyBase):
             c.append(b)
 
         c = np.asarray(c)
-        return BPoly(c.swapaxes(0, 1), xi, extrapolate)
+        return cls(c.swapaxes(0, 1), xi, extrapolate)
 
     @staticmethod
     def _construct_from_derivatives(xa, xb, ya, yb):

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1182,6 +1182,43 @@ def _construct_from_derivatives(xa, xb, ya, yb):
     return c
 
 
+def _raise_degree(c, d):
+    """Raise a degree of a polynomial in the Bernstein basis.
+
+    Given the coefficients of a polynomial degree `k`, return (the 
+    coefficients of) the equivalent polynomial of degree `k+d`.
+
+    Parameters
+    ----------
+    c : array_like
+        coefficient array, 1D
+    d : integer
+
+    Returns
+    -------
+    array
+        coefficient array, 1D array of length `c.shape[0] + d`
+
+    Notes
+    -----
+    This uses the fact that a Berstein polynomial `b_{a, k}` can be
+    identically represented as a linear combination of polynomials of
+    a higher degree `k+d`:
+
+        ..math:: b_{a, k} = comb(k, a) \sum_{j=0}^{d} b_{a+j, k+d} \
+                            comb(d, j) / comb(k+d, a+j)
+
+    """
+    k = c.shape[0] - 1
+    out = np.zeros(c.shape[0] + d)
+
+    for a in range(c.shape[0]):
+        f = c[a] * comb(k, a)
+        for j in range(d+1):
+            out[a+j] += f * comb(d, j) / comb(k+d, a+j)
+    return out
+
+
 # backward compatibility wrapper
 class ppform(PPoly):
     """

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -544,6 +544,9 @@ class PPoly(_Interpolator1D):
         self._set_dtype(self.c.dtype)
 
         if self.c.ndim != 3:
+            if self.c.size == 0:
+                # reshape raises a difficult to understand error
+                raise ValueError("No coefficients")
             self.c = self.c.reshape(self.c.shape[0], self.c.shape[1], -1)
         self.c = np.ascontiguousarray(self.c, dtype=self.dtype)
 
@@ -785,7 +788,10 @@ class PPoly(_Interpolator1D):
         if self._y_extra_shape == ():
             return r[0]
         else:
-            return np.array(r, dtype=object).reshape(self._y_extra_shape)
+            # Careful when constructing the object array
+            r2 = np.empty((np.prod(self._y_extra_shape),), dtype=object)
+            r2[...] = r
+            return r2.reshape(self._y_extra_shape)
 
     @classmethod
     def from_spline(cls, tck, fill_value=None):

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1094,6 +1094,13 @@ class BPoly(_PPolyBase):
         # construct a compatible polynomial
         return BPoly.construct_fast(c2, self.x, self.extrapolate)
 
+    def extend(self, c, x, right=True):
+        k = max(self.c.shape[0], c.shape[0])
+        self.c = self._raise_degree(self.c, k - self.c.shape[0])
+        c = self._raise_degree(c, k - c.shape[0])
+        return _PPolyBase.extend(self, c, x, right)
+    extend.__doc__ = _PPolyBase.extend.__doc__
+
     @classmethod
     def from_power_basis(cls, pp, extrapolate=None):
         """
@@ -1114,7 +1121,7 @@ class BPoly(_PPolyBase):
 
         rest = (None,)*(pp.c.ndim-2)
 
-        c = np.zeros_like(pp.c)
+        c = np.zeros_like(pp.c, dtype=pp.c.dtype)
         for a in range(k+1):
             factor = pp.c[a, ...] / comb(k, k-a) * dx[(slice(None),)+rest]**(k-a)
             for j in range(k-a, k+1):
@@ -1342,8 +1349,11 @@ class BPoly(_PPolyBase):
                                 comb(d, j) / comb(k+d, a+j)
 
         """
+        if d == 0:
+            return c
+
         k = c.shape[0] - 1
-        out = np.zeros(c.shape[0] + d)
+        out = np.zeros((c.shape[0] + d,) + c.shape[1:], dtype=c.dtype)
 
         for a in range(c.shape[0]):
             f = c[a] * comb(k, a)

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -711,7 +711,7 @@ class PPoly(_PPolyBase):
 
     def _evaluate(self, x, nu, extrapolate, out):
         _ppoly.evaluate(self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
-                        self.x, 1.*x, nu, bool(extrapolate), out)
+                        self.x, x, nu, bool(extrapolate), out)
 
     def derivative(self, nu=1):
         """

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -964,14 +964,14 @@ class BPoly(_PPolyBase):
     """
     Piecewise polynomial in terms of coefficients and breakpoints
 
-    The polynomial in the ``i``-th interval is ``x[i] <= xp < x[i+1]``
+    The polynomial in the ``i``-th interval ``x[i] <= xp < x[i+1]``
     is written in the Bernstein polynomial basis::
 
-        S = sum(c[m, i] * b(m, k; x) for m in range(k+1))
+        S = sum(c[a, i] * b(a, k; x) for a in range(k+1))
 
     where ``k`` is the degree of the polynomial, and::
 
-        b(m, k; x) = comb(k, m) * t**k * (1-t)**(k-m)
+        b(a, k; x) = comb(k, a) * t**k * (1-t)**(k-a)
 
     with ``t = (x - x[i]) / (x[i+1] - x[i])``.
 
@@ -1007,6 +1007,16 @@ class BPoly(_PPolyBase):
     See also
     --------
     PPoly : piecewise polynomials in the power basis
+
+    Notes
+    -----
+    Properties of Bernstein polynomials are well documented in the literature. 
+    Here's a non-exhaustive list:
+    [1]_ http://en.wikipedia.org/wiki/Bernstein_polynomial
+    [2]_ Kenneth I. Joy, Bernstein polynomials, 
+       http://www.idav.ucdavis.edu/education/CAGDNotes/Bernstein-Polynomials.pdf
+    [3]_ E. H. Doha, A. H. Bhrawy, and M. A. Saker, Boundary Value Problems,
+         vol 2011, article ID 829546, doi:10.1155/2011/829543
 
     Examples
     --------
@@ -1059,14 +1069,14 @@ class BPoly(_PPolyBase):
 
         Parameters
         ----------
-        n : int, optional
+        nu : int, optional
             Order of derivative to evaluate. (Default: 1)
             If negative, the antiderivative is returned.
 
         Returns
         -------
         bp : BPoly
-            Piecewise polynomial of order k2 = k - n representing the derivative
+            Piecewise polynomial of order k2 = k - nu representing the derivative
             of this polynomial.
 
         """

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -955,8 +955,9 @@ class PPoly(_PPolyBase):
             for s in range(a, k+1):
                 val = comb(k-a, s-a) * (-1)**s
                 c[k-s, ...] += factor * val / dx[:, None]**s
-
-        return cls.construct_fast(c, bp.x, extrapolate)
+        pp = cls.construct_fast(c, bp.x, extrapolate)
+        pp._y_extra_shape = bp._y_extra_shape
+        return pp
 
 
 class BPoly(_PPolyBase):
@@ -1048,8 +1049,9 @@ class BPoly(_PPolyBase):
             factor = pp.c[a, ...] / comb(k, k-a) * dx[:, None]**(k-a)
             for j in range(k-a, k+1):
                 c[j, ...] += factor * comb(j, k-a)
-
-        return cls.construct_fast(c, pp.x, extrapolate)
+        bp = cls.construct_fast(c, pp.x, extrapolate)
+        bp._y_extra_shape = pp._y_extra_shape
+        return bp
 
     def derivative(self, nu=1):
         """

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -725,6 +725,61 @@ class PPoly(_Interpolator1D):
         range_int *= sign
         return range_int
 
+    def roots(self, discontinuity=True):
+        """
+        Find real roots of the piecewise polynomial.
+
+        Parameters
+        ----------
+        discont : bool, optional
+            Whether to report sign changes across discontinuities as
+            breakpoints as roots.
+
+        Returns
+        -------
+        roots : ndarray
+            Roots of the polynomial(s).
+
+            If the PPoly object describes multiple polynomials, the
+            return value is an object array whose each element is an
+            ndarray containing the roots.
+
+        Notes
+        -----
+        This routine works only on real-valued polynomials.
+
+        If the piecewise polynomial contains sections that are
+        identically zero, the root list will contain the start point
+        of the corresponding interval, followed by a ``nan`` value.
+
+        If the polynomial is discontinuous across a breakpoint, and
+        there is a sign change across the breakpoint, this is reported
+        if the `discont` parameter is True.
+
+        Examples
+        --------
+
+        Finding roots of ``[x**2 - 1, (x - 1)**2]`` defined on intervals
+        ``[-2, 1], [1, 2]``:
+
+        >>> from scipy.interpolate import PPoly
+        >>> pp = PPoly(np.array([[1, 0, -1], [1, 0, 0]]).T, [-2, 1, 2])
+        >>> pp.roots()
+        array([-1.,  1.])
+
+        """
+        self._ensure_c_contiguous()
+
+        if np.issubdtype(self.c.dtype, np.complexfloating):
+            raise ValueError("Root finding is only for "
+                             "real-valued polynomials")
+
+        r = _ppoly.real_roots(self.c, self.x, bool(discontinuity))
+        if self._y_extra_shape == ():
+            return r[0]
+        else:
+            return np.array(r, dtype=object).reshape(self._y_extra_shape)
+
     @classmethod
     def from_spline(cls, tck, fill_value=None):
         """

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -11,6 +11,7 @@ from numpy import shape, sometrue, array, transpose, searchsorted, \
 import numpy as np
 import scipy.special as spec
 import math
+import warnings
 
 from scipy.lib.six import xrange
 
@@ -919,6 +920,9 @@ class ppform(PPoly):
     """
 
     def __init__(self, coeffs, breaks, fill=0.0, sort=False):
+        warnings.warn("ppform is deprecated -- use PPoly instead",
+                      category=DeprecationWarning)
+
         if sort:
             breaks = np.sort(breaks)
         else:

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1051,7 +1051,7 @@ class BPoly(_PPolyBase):
             # we need to correct for an extra power of dy
 
             k = self.c.shape[0] - 1
-            c2 = k * np.diff(self.c, axis=0) / np.diff(self.x)[:, None, None]
+            c2 = k * np.diff(self.c, axis=0) / np.diff(self.x)[None, :, None]
 
         # construct a compatible polynomial
         pp = BPoly(c2, self.x)

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -648,13 +648,7 @@ class PPoly(_Interpolator1D):
         c[:-nu] /= factor[:,None,None]
 
         # fix continuity of added degrees of freedom
-        val = np.empty((c.shape[1], c.shape[2]), dtype=c.dtype)
-        for k in range(nu-1, -1, -1):
-            _ppoly.evaluate(c, self.x, self.x[1:], k,
-                            at_endpoint=True,
-                            out=val)
-            val /= spec.gamma(1 + k)
-            c[c.shape[0] - k - 1,1:,:] = np.cumsum(val, axis=0)[:-1,:]
+        _ppoly.fix_continuity(c, self.x, nu)
 
         # construct a compatible polynomial
         pp = PPoly(c, self.x, fill_value=self.fill_value)

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -492,7 +492,8 @@ class PPoly(_Interpolator1D):
 
         S = sum(c[m, i] * (xp - x[i])**(k-m) for m in range(k+1))
 
-    where ``k`` is the degree of the polynomial.
+    where ``k`` is the degree of the polynomial. This representation
+    is the local power basis.
 
     Parameters
     ----------
@@ -513,6 +514,12 @@ class PPoly(_Interpolator1D):
     -------
     __call__
     from_spline
+
+    Notes
+    -----
+    High-order polynomials in the power basis can be numerically
+    unstable.  Precision problems can start to appear for orders
+    larger than 20-30.
 
     """
 

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -628,7 +628,9 @@ class _PPolyBase(_Interpolator1D):
         -----
         Derivatives are evaluated piecewise for each polynomial
         segment, even if the polynomial is not differentiable at the
-        breakpoints.
+        breakpoints. The polynomial intervals are considered half-open,
+        ``[a, b)``, except for the last interval which is closed
+        ``[a, b]``.
 
         """
         x, x_shape = self._prepare_x(x)
@@ -712,10 +714,11 @@ class PPoly(_PPolyBase):
 
         Notes
         -----
-        If the piecewise polynomial is not differentiable at the
-        breakpoints, the piecewise polynomial returned by this
-        function does not agree with the real derivative at the
-        breakpoints.
+        Derivatives are evaluated piecewise for each polynomial
+        segment, even if the polynomial is not differentiable at the
+        breakpoints. The polynomial intervals are considered half-open,
+        ``[a, b)``, except for the last interval which is closed
+        ``[a, b]``.
 
         """
         if nu < 0:
@@ -826,8 +829,8 @@ class PPoly(_PPolyBase):
 
         Parameters
         ----------
-        discont : bool, optional
-            Whether to report sign changes across discontinuities as
+        discontinuity : bool, optional
+            Whether to report sign changes across discontinuities at
             breakpoints as roots.
         extrapolate : bool, optional
             Whether to return roots from the polynomial extrapolated

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -16,7 +16,7 @@ import warnings
 import functools
 import operator
 
-from scipy.lib.six import xrange
+from scipy.lib.six import xrange, integer_types
 
 from . import fitpack
 from . import dfitpack
@@ -1000,9 +1000,9 @@ class BPoly(_PPolyBase):
     __call__
     extend
     derivative
-    from_spline
     construct_fast
     from_power_basis
+    from_derivatives
 
     See also
     --------
@@ -1061,6 +1061,119 @@ class BPoly(_PPolyBase):
         bp = cls.construct_fast(c, pp.x, extrapolate)
         bp._y_extra_shape = pp._y_extra_shape
         return bp
+
+    @staticmethod
+    def from_derivatives(xi, yi, orders=None, direction=None,
+            axis=0, extrapolate=None):
+        """Construct a piecewise polynomial in the Bernstein basis,
+        compatible with the specified values and derivatives at breakpoints.
+
+        Parameters
+        ----------
+        xi : array_like
+            sorted 1D array of x-coordinates
+        yi : array_like or list of array-likes
+            `yi[i][j]` is the `j`-th derivative known at `xi[i]`
+        orders : None or int or array_like of ints. Default: None.
+            Specifies the degree of local polynomials. If not None, some
+            derivatives are ignored. 
+        axis : int, optional
+            Interpolation axis, default is 0.
+        extrapolate : bool, optional
+            Whether to extrapolate to ouf-of-bounds points based on first
+            and last intervals, or to return NaNs. Default: True.        
+
+        Notes
+        -----
+        If `k` derivatives are specified at a breakpoint `x`, the
+        constructed polynomial is exactly `k` times continuously 
+        differentiable at `x`, unless the `order` is provided explicitly.
+        In the latter case, the smoothness of the polynomial at
+        the breakpoint is controlled by the `order`.
+        
+        Deduces the number of derivatives to match at each end
+        from `order` and the number of derivatives available. If
+        possible it uses the same number of derivatives from
+        each end; if the number is odd it tries to take the
+        extra one from y2. In any case if not enough derivatives
+        are available at one end or another it draws enough to
+        make up the total from the other end.
+        
+        If the order is too high and not enough derivatives are available,
+        an exception is raised.
+
+        Examples
+        --------
+
+        >>> PiecewiseP([0, 1], [[1, 2], [3, 4]])
+        Creates a polynomial `f(x)` of degree 3, defined on `[0, 1]`
+        such that `f(0) = 1, df/dx(0) = 2, f(1) = 3, df/dx(1) = 4`
+
+        >>> PiecewiseP([0, 1, 2], [[0, 1], [0], [2])
+        Creates a piecewise polynomial `f(x)`, such that
+        `f(0) = f(1) = 0`, `f(2) = 2`, and `df/dx(0) = 1`.
+        Based on the number of derivatives provided, the order of the
+        local polynomials is 2 on `[0, 1]` and 1 on `[1, 2]`.
+        Notice that no restriction is imposed on the derivatives at
+        `x = 1` and `x = 2`.
+
+        Indeed, the explicit form of the polynomial is
+        f(x) = | x * (1 - x),  0 <= x < 1
+               | 2 * (x - 1),  1 <= x <= 2
+        So that f'(1-0) = -1 and f'(1+0) = 2
+
+        """
+        if axis != 0:
+            raise NotImplementedError
+        if direction is not None:
+            raise NotImplementedError
+            
+        xi = np.asarray(xi)
+        if len(xi) != len(yi):
+            raise ValueError("xi and yi need to have the same length")
+        if np.any(xi[1:] - xi[:1] <= 0):
+            raise ValueError("x coordinates are not in increasing order")
+
+        # number of intervals
+        m = len(xi) - 1
+
+        # global poly order is k-1, local orders are <=k and can vary
+        k = max(len(yi[i]) + len(yi[i+1]) for i in range(m))
+        if orders is None:
+            orders = [None] * m
+        else:
+            if isinstance(orders, integer_types):
+                orders = [orders] * m
+            k = max(k, max(orders))
+            
+            if any(o <= 0 for o in orders):
+                raise ValueError("Orders must be positive.")
+
+        c = []
+        for i in range(m):
+            y1, y2 = yi[i], yi[i+1]
+            if orders[i] is None:
+                n1, n2 = len(y1), len(y2)
+            else:
+                n = orders[i]+1
+                n1 = min(n//2, len(y1))
+                n2 = min(n - n1, len(y2))
+                n1 = min(n - n2, len(y2))
+                if n1+n2 != n:
+                    raise ValueError("Point %g has %d derivatives, point %g"
+                            " has %d derivatives, but order %d requested" %
+                            (xi[i], len(y1), xi[i+1], len(y2), orders[i]))
+                if not (n1 <= len(y1) and n2 <= len(y2)):
+                    raise ValueError("`order` input incompatible with"
+                            " length y1 or y2.")
+            
+            b = _construct_from_derivatives(xi[i], xi[i+1],  y1[:n1], y2[:n2])
+            if len(b) < k:
+                b = _raise_degree(b, k - len(b))
+            c.append(b)
+
+        c = np.asarray(c).T
+        return BPoly(c, xi, extrapolate)
 
     def derivative(self, nu=1):
         """

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -563,7 +563,7 @@ class PPoly(_Interpolator1D):
 
     def _evaluate(self, x, nu):
         out = np.empty((len(x), self.c.shape[2]), dtype=self.dtype)
-        has_out_of_bounds = _ppoly.evaluate(self.c, self.x, x, nu, False, out)
+        has_out_of_bounds = _ppoly.evaluate(self.c, self.x, x, nu, out)
         if has_out_of_bounds:
             out[~((x >= self.x[0]) & (x <= self.x[-1]))] = self.fill_value
         return out

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -25,7 +25,31 @@ class _Interpolator1D(object):
     actual interpolator can assume the y-data is of shape (n, r) where
     `n` is the number of x-points, and `r` the number of variables,
     and use self.dtype as the y-data type.
+
+    Attributes
+    ----------
+    _y_axis
+        Axis along which the interpolation goes in the original array
+    _y_extra_shape
+        Additional trailing shape of the input arrays, excluding
+        the interpolation axis.
+    dtype
+        Dtype of the y-data arrays. Can be set via set_dtype, which
+        forces it to be float or complex.
+
+    Methods
+    -------
+    __call__
+    _prepare_x
+    _finish_y
+    _reshape_yi
+    _set_yi
+    _set_dtype
+    _evaluate
+
     """
+
+    __slots__ = ('_y_axis', '_y_extra_shape', 'dtype')
 
     def __init__(self, xi=None, yi=None, axis=None):
         self._y_axis = axis
@@ -53,6 +77,12 @@ class _Interpolator1D(object):
         x, x_shape = self._prepare_x(x)
         y = self._evaluate(x)
         return self._finish_y(y, x_shape)
+
+    def _evaluate(self, x):
+        """
+        Actually evaluate the value of the interpolator.
+        """
+        raise NotImplementedError()
 
     def _prepare_x(self, x):
         """Reshape input x array to 1-D"""

--- a/scipy/interpolate/setup.py
+++ b/scipy/interpolate/setup.py
@@ -6,6 +6,9 @@ from os.path import join
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
+    from numpy.distutils.system_info import get_info
+
+    lapack_opt = get_info('lapack_opt', notfound_action=2)
 
     config = Configuration('interpolate', parent_package, top_path)
 
@@ -16,7 +19,8 @@ def configuration(parent_package='',top_path=None):
                          sources=['interpnd.c'])
 
     config.add_extension('_ppoly',
-                         sources=['_ppoly.c'])
+                         sources=['_ppoly.c'],
+                         **lapack_opt)
 
     config.add_extension('_fitpack',
                          sources=['src/_fitpackmodule.c'],

--- a/scipy/interpolate/setup.py
+++ b/scipy/interpolate/setup.py
@@ -15,6 +15,9 @@ def configuration(parent_package='',top_path=None):
     config.add_extension('interpnd',
                          sources=['interpnd.c'])
 
+    config.add_extension('_ppoly',
+                         sources=['_ppoly.c'])
+
     config.add_extension('_fitpack',
                          sources=['src/_fitpackmodule.c'],
                          libraries=['fitpack'],

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -614,6 +614,29 @@ class TestPPoly(TestCase):
         assert_array_equal(pp.roots(), [0.5])
         assert_array_equal(pp.roots(discontinuity=False), [])
 
+    def test_roots_random(self):
+        # Check high-order polynomials with random coefficients
+        np.random.seed(1234)
+
+        num = 0
+
+        for order in range(0, 20):
+            x = np.unique(np.r_[0, 10 * np.random.rand(30), 10])
+            c = 2*np.random.rand(order+1, len(x)-1, 2, 3) - 1
+
+            pp = PPoly(c, x)
+            r = pp.roots(discontinuity=False)
+
+            for i in range(2):
+                for j in range(3):
+                    if r[i,j].size > 0:
+                        # Check that the reported roots indeed are roots
+                        num += r[i,j].size
+                        assert_allclose(pp(r[i,j])[:,i,j], 0, atol=1e-7)
+
+        # Check that we checked a number of roots
+        assert_(num > 100, repr(num))
+
 
 class TestPpform(TestCase):
     def test_shape(self):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -783,6 +783,30 @@ class TestBPoly(TestCase):
         assert_allclose(bp(1.7), 2 * (0.7/2)**2)
 
 
+class TestConversions(TestCase):
+
+    def test_bp_from_pp(self):
+        x = [0, 1, 3]
+        c = [[3, 2], [1, 8], [4, 3]]
+        pp = PPoly(c, x)
+        bp = BPoly.from_power_basis(pp)
+        pp1 = PPoly.from_bernstein_basis(bp)
+
+        for xp in [0.1, 1.4]:
+            assert_allclose(pp(xp), bp(xp))
+            assert_allclose(pp(xp), pp1(xp))
+
+    def test_pp_from_bp(self):
+        x = [0, 1, 3]
+        c = [[3, 3], [1, 1], [4, 2]]
+        bp = BPoly(c, x)
+        pp = PPoly.from_bernstein_basis(bp)
+        bp1 = BPoly.from_power_basis(pp)
+
+        for xp in [0.1, 1.4]:
+            assert_allclose(bp(xp), pp(xp))
+            assert_allclose(bp(xp), bp1(xp))
+
 
 class TestPpform(TestCase):
     def test_shape(self):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -9,9 +9,10 @@ import warnings
 
 from scipy.lib.six import xrange
 
-from scipy.interpolate import (interp1d, interp2d, lagrange, PPoly, BPoly, ppform, 
-     splrep, splev, splantider, splint, sproot)
-from scipy.interpolate.interpolate import _construct_from_derivatives
+from scipy.interpolate import (interp1d, interp2d, lagrange, PPoly, BPoly,
+         ppform, splrep, splev, splantider, splint, sproot)
+from scipy.interpolate.interpolate import (_construct_from_derivatives, 
+        _raise_degree)
 
 from scipy.interpolate import _ppoly
 
@@ -936,6 +937,19 @@ class TestFromDerivatives(TestCase):
         for j in range(6):
             assert_allclose([pp(0.), pp(1.)], [ya[j], yb[j]])
             pp = pp.derivative()
+
+    def test_raise_degree(self):
+        np.random.seed(12345)
+        x = [0, 1]
+        k, d = 8, 5
+        c = np.random.random(k)
+        bp = BPoly(c[:, None], x)
+
+        c1 = _raise_degree(c, d)
+        bp1 = BPoly(c1[:, None], x)
+
+        xp = np.linspace(0, 1, 11)
+        assert_allclose(bp(xp), bp1(xp))
 
 
 class TestPpform(TestCase):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -673,6 +673,30 @@ class TestPPoly(TestCase):
         assert_array_equal(pp2.c, pp3.c)
         assert_array_equal(pp2.x, pp3.x)
 
+    def test_extend_diff_orders(self):
+        # Test extending polynomial with different order one
+        np.random.seed(1234)
+
+        x = np.linspace(0, 1, 6)
+        c = np.random.rand(2, 5)
+
+        x2 = np.linspace(1, 2, 6)
+        c2 = np.random.rand(4, 5)
+
+        pp1 = PPoly(c, x)
+        pp2 = PPoly(c2, x2)
+
+        pp_comb = PPoly(c, x)
+        pp_comb.extend(c2, x2[1:])
+
+        # NB. doesn't match to pp1 at the endpoint, because pp1 is not
+        #     continuous with pp2 as we took random coefs.
+        xi1 = np.linspace(0, 1, 300, endpoint=False)
+        xi2 = np.linspace(1, 2, 300)
+
+        assert_allclose(pp1(xi1), pp_comb(xi1))
+        assert_allclose(pp2(xi2), pp_comb(xi2))
+
 
 class TestPpform(TestCase):
     def test_shape(self):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -607,13 +607,13 @@ class TestPPoly(TestCase):
         # Check roots repeated in multiple sections are reported only
         # once.
 
-        # [(x + 2)**2 - 1, 1 - (x - 1)**2]
+        # [(x + 1)**2 - 1, -x**2] ; x == 0 is a repeated root
         c = np.array([[1, 0, -1], [-1, 0, 0]]).T
-        x = np.array([-2, 1, 2])
+        x = np.array([-1, 0, 1])
 
         pp = PPoly(c, x)
-        assert_array_equal(pp.roots(), [-3, -1, 1])
-        assert_array_equal(pp.roots(extrapolate=False), [-1, 1])
+        assert_array_equal(pp.roots(), [-2, 0])
+        assert_array_equal(pp.roots(extrapolate=False), [0])
 
     def test_roots_discont(self):
         # Check that a discontinuity across zero is reported as root

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_, assert_equal, assert_almost_equal, \
         dec, TestCase, run_module_suite, assert_allclose
 from numpy import mgrid, pi, sin, ogrid, poly1d, linspace
 import numpy as np
+import warnings
 
 from scipy.lib.six import xrange
 
@@ -730,12 +731,15 @@ class TestPPoly(TestCase):
 
 class TestPpform(TestCase):
     def test_shape(self):
-        np.random.seed(1234)
-        c = np.random.rand(3, 12, 5, 6, 7)
-        x = np.sort(np.random.rand(13))
-        p = ppform(c, x)
-        xp = np.random.rand(3, 4)
-        assert_equal(p(xp).shape, (3, 4, 5, 6, 7))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+
+            np.random.seed(1234)
+            c = np.random.rand(3, 12, 5, 6, 7)
+            x = np.sort(np.random.rand(13))
+            p = ppform(c, x)
+            xp = np.random.rand(3, 4)
+            assert_equal(p(xp).shape, (3, 4, 5, 6, 7))
 
 
 def _ppoly_eval_1(c, x, xps):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -9,8 +9,8 @@ import warnings
 
 from scipy.lib.six import xrange
 
-from scipy.interpolate import interp1d, interp2d, lagrange, PPoly, ppform, \
-     splrep, splev, splantider, splint, sproot
+from scipy.interpolate import (interp1d, interp2d, lagrange, PPoly, BPoly, ppform, 
+     splrep, splev, splantider, splint, sproot)
 
 from scipy.interpolate import _ppoly
 
@@ -724,6 +724,64 @@ class TestPPoly(TestCase):
 
         assert_allclose(pp1(xi1), pp_comb(xi1))
         assert_allclose(pp2(xi2), pp_comb(xi2))
+
+
+class TestBPoly(TestCase):
+
+    def test_simple(self):
+        x = [0, 1]
+        c = [[3]]
+        bp  = BPoly(c, x)
+        assert_allclose(bp(0.1), 3.)
+
+    def test_simple2(self):
+        x = [0, 1]
+        c = [[3], [1]]
+        bp = BPoly(c, x)   # 3*(1-x) + 1*x
+        assert_allclose(bp(0.1), 3*0.9 + 1.*0.1)
+
+    def test_simple3(self):
+        x = [0, 1]
+        c = [[3], [1], [4]]
+        bp = BPoly(c, x)   # 3 * (1-x)**2 + 2 * x (1-x) + 4 * x**2
+        assert_allclose(bp(0.2), 
+                3 * 0.8*0.8 + 1 * 2*0.2*0.8 + 4 * 0.2*0.2)
+
+    def test_simple4(self):
+        x = [0, 1]
+        c = [[1], [1], [1], [2]]
+        bp = BPoly(c, x)
+        assert_allclose(bp(0.3), 0.7**3 +
+                                 3 * 0.7**2 * 0.3 +
+                                 3 * 0.7 * 0.3**2 +
+                             2 * 0.3**3)
+
+    def test_simple5(self):
+        x = [0, 1]
+        c = [[1], [1], [8], [2], [1]]
+        bp = BPoly(c, x)
+        assert_allclose(bp(0.3), 0.7**4 +
+                                 4 * 0.7**3 * 0.3 +
+                             8 * 6 * 0.7**2 * 0.3**2 +
+                             2 * 4 * 0.7 * 0.3**3 +
+                                 0.3**4)
+
+    def test_interval_length(self):
+        x = [0, 2]
+        c = [[3], [1], [4]]
+        bp = BPoly(c, x)
+        xval = 0.1
+        s = xval / 2  # s = (x - xa) / (xb - xa)
+        assert_allclose(bp(xval), 3 * (1-s)*(1-s) + 1 * 2*s*(1-s) + 4 * s*s)
+    
+    def test_two_intervals(self):
+        x = [0, 1, 3]
+        c = [[3, 0], [0, 0], [0, 2]]
+        bp = BPoly(c, x)  # [3*(1-x)**2, 2*(x/2)**2]
+
+        assert_allclose(bp(0.4), 3 * 0.6*0.6)
+        assert_allclose(bp(1.7), 2 * (0.7/2)**2)
+
 
 
 class TestPpform(TestCase):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -841,9 +841,8 @@ class TestBPolyCalculus(TestCase):
         for d in range(k):
             bp = bp.derivative()
             pp = pp.derivative()
-            for xp in np.linspace(x[0], x[-1], 11):
-                assert_allclose(bp(xp), pp(xp))
-
+            xp = np.linspace(x[0], x[-1], 21)
+            assert_allclose(bp(xp), pp(xp))
 
 class TestConversions(TestCase):
 
@@ -854,9 +853,9 @@ class TestConversions(TestCase):
         bp = BPoly.from_power_basis(pp)
         pp1 = PPoly.from_bernstein_basis(bp)
 
-        for xp in [0.1, 1.4]:
-            assert_allclose(pp(xp), bp(xp))
-            assert_allclose(pp(xp), pp1(xp))
+        xp = [0.1, 1.4]
+        assert_allclose(pp(xp), bp(xp))
+        assert_allclose(pp(xp), pp1(xp))
 
     def test_bp_from_pp_random(self):
         np.random.seed(1234)
@@ -867,9 +866,9 @@ class TestConversions(TestCase):
         bp = BPoly.from_power_basis(pp)
         pp1 = PPoly.from_bernstein_basis(bp)
 
-        for xp in np.linspace(x[0], x[-1], 11):
-            assert_allclose(pp(xp), bp(xp))
-            assert_allclose(pp(xp), pp1(xp))
+        xp = np.linspace(x[0], x[-1], 21)
+        assert_allclose(pp(xp), bp(xp))
+        assert_allclose(pp(xp), pp1(xp))
 
     def test_pp_from_bp(self):
         x = [0, 1, 3]
@@ -878,9 +877,9 @@ class TestConversions(TestCase):
         pp = PPoly.from_bernstein_basis(bp)
         bp1 = BPoly.from_power_basis(pp)
 
-        for xp in [0.1, 1.4]:
-            assert_allclose(bp(xp), pp(xp))
-            assert_allclose(bp(xp), bp1(xp))
+        xp = [0.1, 1.4]
+        assert_allclose(bp(xp), pp(xp))
+        assert_allclose(bp(xp), bp1(xp))
 
     def test_bp_from_pp_random(self):
         np.random.seed(1234)
@@ -891,9 +890,9 @@ class TestConversions(TestCase):
         pp = PPoly.from_bernstein_basis(bp)
         bp1 = BPoly.from_power_basis(pp)
 
-        for xp in np.linspace(x[0], x[-1], 11):
-            assert_allclose(pp(xp), bp(xp))
-            assert_allclose(pp(xp), bp1(xp))
+        xp = np.linspace(x[0], x[-1], 21)
+        assert_allclose(pp(xp), bp(xp))
+        assert_allclose(pp(xp), bp1(xp))
 
 
 class TestPpform(TestCase):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -408,6 +408,21 @@ class TestPPoly(TestCase):
         p = PPoly(c, x)
         assert_allclose(p(0.3), 1*0.3**2 + 2*0.3 + 3)
         assert_allclose(p(0.7), 4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6)
+        assert_(np.isnan(p(-0.1)))
+
+    def test_construct_fast(self):
+        np.random.seed(1234)
+        c = np.array([[1, 4], [2, 5], [3, 6]], dtype=float)
+        x = np.array([0, 0.5, 1])
+        p = PPoly.construct_fast(c, x)
+        assert_allclose(p(0.3), 1*0.3**2 + 2*0.3 + 3)
+        assert_allclose(p(0.7), 4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6)
+        assert_(np.isnan(p(-0.1)))
+
+    def test_sort_check(self):
+        c = np.array([[1, 4], [2, 5], [3, 6]])
+        x = np.array([0, 1, 0.5])
+        assert_raises(ValueError, PPoly, c, x)
 
     def test_vs_alternative_implementations(self):
         np.random.seed(1234)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -404,6 +404,81 @@ class TestLagrange(TestCase):
         assert_array_almost_equal(p.coeffs,pl.coeffs)
 
 
+class TestPPolyCommn(TestCase):
+    # test basic functionality for PPoly and BPoly
+    def test_sort_check(self):
+        c = np.array([[1, 4], [2, 5], [3, 6]])
+        x = np.array([0, 1, 0.5])
+        assert_raises(ValueError, PPoly, c, x)
+        assert_raises(ValueError, BPoly, c, x)
+
+    def test_extend(self):
+        # Test adding new points to the piecewise polynomial
+        np.random.seed(1234)
+
+        order = 3
+        x = np.unique(np.r_[0, 10 * np.random.rand(30), 10])
+        c = 2*np.random.rand(order+1, len(x)-1, 2, 3) - 1
+
+        for cls in (PPoly, BPoly):
+            pp = cls(c[:,:9], x[:10])
+            pp.extend(c[:,9:], x[10:])
+
+            pp2 = cls(c[:,10:], x[10:])
+            pp2.extend(c[:,:10], x[:10], right=False)
+
+            pp3 = cls(c, x)
+
+            assert_array_equal(pp.c, pp3.c)
+            assert_array_equal(pp.x, pp3.x)
+            assert_array_equal(pp2.c, pp3.c)
+            assert_array_equal(pp2.x, pp3.x)
+
+    def test_extend_diff_orders(self):
+        # Test extending polynomial with different order one
+        np.random.seed(1234)
+
+        x = np.linspace(0, 1, 6)
+        c = np.random.rand(2, 5)
+
+        x2 = np.linspace(1, 2, 6)
+        c2 = np.random.rand(4, 5)
+
+        for cls in (PPoly, BPoly):
+            pp1 = cls(c, x)
+            pp2 = cls(c2, x2)
+
+            pp_comb = cls(c, x)
+            pp_comb.extend(c2, x2[1:])
+
+            # NB. doesn't match to pp1 at the endpoint, because pp1 is not
+            #     continuous with pp2 as we took random coefs.
+            xi1 = np.linspace(0, 1, 300, endpoint=False)
+            xi2 = np.linspace(1, 2, 300)
+
+            assert_allclose(pp1(xi1), pp_comb(xi1))
+            assert_allclose(pp2(xi2), pp_comb(xi2))
+
+    def test_shape(self):
+        np.random.seed(1234)
+        c = np.random.rand(8, 12, 5, 6, 7)
+        x = np.sort(np.random.rand(13))
+        xp = np.random.rand(3, 4)
+        for cls in (PPoly, BPoly):
+            p = cls(c, x)
+            assert_equal(p(xp).shape, (3, 4, 5, 6, 7))
+
+        # 'scalars'
+        for cls in (PPoly, BPoly):
+            p = cls(c[..., 0, 0, 0], x)
+
+            assert_equal(np.shape(p(0.5)), ())
+            assert_equal(np.shape(p(np.array(0.5))), ())
+
+            # can't use dtype=object
+            assert_raises(ValueError, p, np.array([[0.1, 0.2], [0.4]]))
+
+
 class TestPPoly(TestCase):
     def test_simple(self):
         c = np.array([[1, 4], [2, 5], [3, 6]])
@@ -436,11 +511,6 @@ class TestPPoly(TestCase):
         assert_allclose(p(0.3), 1*0.3**2 + 2*0.3 + 3)
         assert_allclose(p(0.7), 4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6)
 
-    def test_sort_check(self):
-        c = np.array([[1, 4], [2, 5], [3, 6]])
-        x = np.array([0, 1, 0.5])
-        assert_raises(ValueError, PPoly, c, x)
-
     def test_vs_alternative_implementations(self):
         np.random.seed(1234)
         c = np.random.rand(3, 12, 22)
@@ -454,14 +524,6 @@ class TestPPoly(TestCase):
 
         expected = _ppoly_eval_2(c[:,:,0], x, xp)
         assert_allclose(p(xp)[:,0], expected)
-
-    def test_shape(self):
-        np.random.seed(1234)
-        c = np.random.rand(3, 12, 5, 6, 7)
-        x = np.sort(np.random.rand(13))
-        p = PPoly(c, x)
-        xp = np.random.rand(3, 4)
-        assert_equal(p(xp).shape, (3, 4, 5, 6, 7))
 
     def test_from_spline(self):
         np.random.seed(1234)
@@ -696,50 +758,6 @@ class TestPPoly(TestCase):
             res = res[~np.isnan(res)]
             assert_allclose(res, 0, atol=1e-10)
 
-    def test_extend(self):
-        # Test adding new points to the piecewise polynomial
-        np.random.seed(1234)
-
-        order = 3
-        x = np.unique(np.r_[0, 10 * np.random.rand(30), 10])
-        c = 2*np.random.rand(order+1, len(x)-1, 2, 3) - 1
-
-        pp = PPoly(c[:,:9], x[:10])
-        pp.extend(c[:,9:], x[10:])
-
-        pp2 = PPoly(c[:,10:], x[10:])
-        pp2.extend(c[:,:10], x[:10], right=False)
-
-        pp3 = PPoly(c, x)
-
-        assert_array_equal(pp.c, pp3.c)
-        assert_array_equal(pp.x, pp3.x)
-        assert_array_equal(pp2.c, pp3.c)
-        assert_array_equal(pp2.x, pp3.x)
-
-    def test_extend_diff_orders(self):
-        # Test extending polynomial with different order one
-        np.random.seed(1234)
-
-        x = np.linspace(0, 1, 6)
-        c = np.random.rand(2, 5)
-
-        x2 = np.linspace(1, 2, 6)
-        c2 = np.random.rand(4, 5)
-
-        pp1 = PPoly(c, x)
-        pp2 = PPoly(c2, x2)
-
-        pp_comb = PPoly(c, x)
-        pp_comb.extend(c2, x2[1:])
-
-        # NB. doesn't match to pp1 at the endpoint, because pp1 is not
-        #     continuous with pp2 as we took random coefs.
-        xi1 = np.linspace(0, 1, 300, endpoint=False)
-        xi2 = np.linspace(1, 2, 300)
-
-        assert_allclose(pp1(xi1), pp_comb(xi1))
-        assert_allclose(pp2(xi2), pp_comb(xi2))
 
     def test_extrapolate_attr(self):
         # [ 1 - x**2 ]
@@ -764,7 +782,6 @@ class TestPPoly(TestCase):
 
 
 class TestBPoly(TestCase):
-
     def test_simple(self):
         x = [0, 1]
         c = [[3]]
@@ -837,7 +854,7 @@ class TestBPoly(TestCase):
         c = [[3], [1], [4]]
         bp = BPoly(c, x)
 
-        for extrapolate in [True, False, None]:
+        for extrapolate in (True, False, None):
             bp = BPoly(c, x, extrapolate=extrapolate)
             bp_d = bp.derivative()
             if extrapolate is False:
@@ -849,7 +866,6 @@ class TestBPoly(TestCase):
 
 
 class TestBPolyCalculus(TestCase):
-
     def test_derivative(self):
         x = [0, 1, 3]
         c = [[3, 0], [0, 0], [0, 2]]

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -404,7 +404,7 @@ class TestLagrange(TestCase):
         assert_array_almost_equal(p.coeffs,pl.coeffs)
 
 
-class TestPPolyCommn(TestCase):
+class TestPPolyCommon(TestCase):
     # test basic functionality for PPoly and BPoly
     def test_sort_check(self):
         c = np.array([[1, 4], [2, 5], [3, 6]])
@@ -889,8 +889,8 @@ class TestBPolyCalculus(TestCase):
             xp = np.linspace(x[0], x[-1], 21)
             assert_allclose(bp(xp), pp(xp))
 
-class TestPolyConversions(TestCase):
 
+class TestPolyConversions(TestCase):
     def test_bp_from_pp(self):
         x = [0, 1, 3]
         c = [[3, 2], [1, 8], [4, 3]]
@@ -1064,7 +1064,14 @@ class TestBPolyFromDerivatives(TestCase):
                 assert_allclose(pp(x - 1e-12), pp(x + 1e-12))
                 pp = pp.derivative()
             assert_(not np.allclose(pp(x - 1e-12), pp(x + 1e-12)))
-   
+
+    def test_yi_trailing_dims(self):
+        m, k = 7, 5
+        xi = np.sort(np.random.random(m+1))
+        yi = np.random.random((m+1, k, 6, 7, 8))
+        pp = BPoly.from_derivatives(xi, yi)
+        assert_equal(pp.c.shape, (2*k, m, 6, 7, 8))
+
 
 class TestPpform(TestCase):
     def test_shape(self):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -777,10 +777,31 @@ class TestBPoly(TestCase):
     def test_two_intervals(self):
         x = [0, 1, 3]
         c = [[3, 0], [0, 0], [0, 2]]
-        bp = BPoly(c, x)  # [3*(1-x)**2, 2*(x/2)**2]
+        bp = BPoly(c, x)  # [3*(1-x)**2, 2*((x-1)/2)**2]
 
         assert_allclose(bp(0.4), 3 * 0.6*0.6)
         assert_allclose(bp(1.7), 2 * (0.7/2)**2)
+
+
+class TestBPolyCalculus(TestCase):
+
+    def setUp(self):
+        self.x = [0, 1, 3]
+        self.c = [[3, 0], [0, 0], [0, 2]]
+        self.bp = BPoly(self.c, self.x)  # [3*(1-x)**2, 2*((x-1)/2)**2]
+
+    def test_derivative(self):
+        bp_der = self.bp.derivative()
+
+        assert_allclose(bp_der(0.4), -6*(0.6))
+        assert_allclose(bp_der(1.7), 0.7)
+
+        #make sure it's consistent w/ power basis
+        pp = PPoly.from_bernstein_basis(self.bp)
+        pp_der = pp.derivative()
+        
+        for xp in [0.4, 1.7]:
+            assert_allclose(bp_der(xp), pp_der(xp))
 
 
 class TestConversions(TestCase):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -411,7 +411,6 @@ class TestPPoly(TestCase):
         p = PPoly(c, x)
         assert_allclose(p(0.3), 1*0.3**2 + 2*0.3 + 3)
         assert_allclose(p(0.7), 4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6)
-        assert_(np.isnan(p(-0.1)))
 
     def test_construct_fast(self):
         np.random.seed(1234)
@@ -420,7 +419,6 @@ class TestPPoly(TestCase):
         p = PPoly.construct_fast(c, x)
         assert_allclose(p(0.3), 1*0.3**2 + 2*0.3 + 3)
         assert_allclose(p(0.7), 4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6)
-        assert_(np.isnan(p(-0.1)))
 
     def test_sort_check(self):
         c = np.array([[1, 4], [2, 5], [3, 6]])
@@ -434,7 +432,7 @@ class TestPPoly(TestCase):
 
         p = PPoly(c, x)
 
-        xp = np.r_[0.3, -0.1, 0.5, 0.33, 1.1, 2.1, 0.6]
+        xp = np.r_[0.3, 0.5, 0.33, 0.6]
         expected = _ppoly_eval_1(c, x, xp)
         assert_allclose(p(xp), expected)
 
@@ -455,11 +453,10 @@ class TestPPoly(TestCase):
         y = np.random.rand(len(x))
 
         spl = splrep(x, y, s=0)
-        pp = PPoly.from_spline(spl, fill_value=np.nan)
+        pp = PPoly.from_spline(spl)
 
         xi = np.linspace(0, 1, 200)
         assert_allclose(pp(xi), splev(xi, spl))
-        assert_(np.isnan(pp([-0.1, 1.1])).all())
 
     def test_derivative_simple(self):
         np.random.seed(1234)
@@ -481,7 +478,7 @@ class TestPPoly(TestCase):
         y = np.random.rand(len(x))
 
         spl = splrep(x, y, s=0)
-        pp = PPoly.from_spline(spl, fill_value=np.nan)
+        pp = PPoly.from_spline(spl)
 
         xi = np.linspace(0, 1, 200)
         for dx in range(0, 3):
@@ -493,7 +490,7 @@ class TestPPoly(TestCase):
         y = np.random.rand(len(x))
 
         spl = splrep(x, y, s=0, k=5)
-        pp = PPoly.from_spline(spl, fill_value=np.nan)
+        pp = PPoly.from_spline(spl)
 
         xi = np.linspace(0, 1, 200)
         for dx in range(0, 10):
@@ -514,7 +511,7 @@ class TestPPoly(TestCase):
                         [0, 0, 1.6875/2, 0.328125, 0.037434895833333336]]).T[:,:,None]
         x = np.array([0, 0.25, 1])
 
-        pp = PPoly(c, x, fill_value=np.nan)
+        pp = PPoly(c, x)
         ipp = pp.antiderivative()
         iipp = pp.antiderivative(2)
         iipp2 = ipp.antiderivative()
@@ -529,7 +526,7 @@ class TestPPoly(TestCase):
         x = np.linspace(0, 1, 30)**2
         y = np.random.rand(len(x))
         spl = splrep(x, y, s=0, k=5)
-        pp = PPoly.from_spline(spl, fill_value=np.nan)
+        pp = PPoly.from_spline(spl)
 
         for dx in range(0, 10):
             ipp = pp.antiderivative(dx)
@@ -554,7 +551,7 @@ class TestPPoly(TestCase):
         y = np.random.rand(len(x))
 
         spl = splrep(x, y, s=0, k=5)
-        pp = PPoly.from_spline(spl, fill_value=np.nan)
+        pp = PPoly.from_spline(spl)
 
         for dx in range(0, 10):
             pp2 = pp.antiderivative(dx)
@@ -570,7 +567,7 @@ class TestPPoly(TestCase):
         y = np.random.rand(len(x))
 
         spl = splrep(x, y, s=0, k=5)
-        pp = PPoly.from_spline(spl, fill_value=np.nan)
+        pp = PPoly.from_spline(spl)
 
         a, b = 0.3, 0.9
         ig = pp.integrate(a, b)
@@ -580,25 +577,12 @@ class TestPPoly(TestCase):
 
         assert_allclose(ig, splint(a, b, spl))
 
-        # check fill value handling
-        pp = PPoly.from_spline(spl, fill_value=123)
-        assert_allclose(pp.integrate(-1, 0.5),
-                        splint(0, 0.5, spl) + 123)
-
-        pp = PPoly.from_spline(spl, fill_value=123)
-        assert_allclose(pp.integrate(0.5, 1.5),
-                        splint(0.5, 1, spl) + 123*0.5)
-
-        pp = PPoly.from_spline(spl, fill_value=123)
-        assert_allclose(pp.integrate(-1, 3),
-                        splint(0, 1, spl) + 123*3)
-
     def test_roots(self):
         x = np.linspace(0, 1, 31)**2
         y = np.sin(30*x)
 
         spl = splrep(x, y, s=0, k=3)
-        pp = PPoly.from_spline(spl, fill_value=np.nan)
+        pp = PPoly.from_spline(spl)
 
         assert_allclose(pp.roots(), sproot(spl),
                         atol=1e-15)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -6,6 +6,8 @@ from numpy.testing import assert_, assert_equal, assert_almost_equal, \
 from numpy import mgrid, pi, sin, ogrid, poly1d, linspace
 import numpy as np
 
+from scipy.lib.six import xrange
+
 from scipy.interpolate import interp1d, interp2d, lagrange, PPoly, ppform, \
      splrep, splev
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -11,8 +11,6 @@ from scipy.lib.six import xrange
 
 from scipy.interpolate import (interp1d, interp2d, lagrange, PPoly, BPoly,
          ppform, splrep, splev, splantider, splint, sproot)
-from scipy.interpolate.interpolate import (_construct_from_derivatives, 
-        _raise_degree)
 
 from scipy.interpolate import _ppoly
 
@@ -915,32 +913,32 @@ class TestPolyConversions(TestCase):
 
 class TestBPolyFromDerivatives(TestCase):
     def test_make_poly_1(self):
-        c1 = _construct_from_derivatives(0, 1, [2], [3])
+        c1 = BPoly._construct_from_derivatives(0, 1, [2], [3])
         assert_allclose(c1, [2., 3.])
 
     def test_make_poly_2(self):
-        c1 = _construct_from_derivatives(0, 1, [1, 0], [1])
+        c1 = BPoly._construct_from_derivatives(0, 1, [1, 0], [1])
         assert_allclose(c1, [1., 1., 1.])
 
         # f'(0) = 3
-        c2 = _construct_from_derivatives(0, 1, [2, 3], [1])
+        c2 = BPoly._construct_from_derivatives(0, 1, [2, 3], [1])
         assert_allclose(c2, [2., 7./2, 1.])
 
         # f'(1) = 3
-        c3 = _construct_from_derivatives(0, 1, [2], [1, 3])
+        c3 = BPoly._construct_from_derivatives(0, 1, [2], [1, 3])
         assert_allclose(c3, [2., -0.5, 1.])
 
     def test_make_poly_3(self):
         # f'(0)=2, f''(0)=3
-        c1 = _construct_from_derivatives(0, 1, [1, 2, 3], [4])
+        c1 = BPoly._construct_from_derivatives(0, 1, [1, 2, 3], [4])
         assert_allclose(c1, [1., 5./3, 17./6, 4.])
 
         # f'(1)=2, f''(1)=3
-        c2 = _construct_from_derivatives(0, 1, [1], [4, 2, 3])
+        c2 = BPoly._construct_from_derivatives(0, 1, [1], [4, 2, 3])
         assert_allclose(c2, [1., 19./6, 10./3, 4.])
 
         # f'(0)=2, f'(1)=3
-        c3 = _construct_from_derivatives(0, 1, [1, 2], [4, 3])
+        c3 = BPoly._construct_from_derivatives(0, 1, [1, 2], [4, 3])
         assert_allclose(c3, [1., 5./3, 3., 4.])
 
     def test_make_poly_12(self):
@@ -948,7 +946,7 @@ class TestBPolyFromDerivatives(TestCase):
         ya = np.r_[0, np.random.random(5)]
         yb = np.r_[0, np.random.random(5)]
 
-        c = _construct_from_derivatives(0, 1, ya, yb)
+        c = BPoly._construct_from_derivatives(0, 1, ya, yb)
         pp = BPoly(c[:, None], [0, 1])
         for j in range(6):
             assert_allclose([pp(0.), pp(1.)], [ya[j], yb[j]])
@@ -961,7 +959,7 @@ class TestBPolyFromDerivatives(TestCase):
         c = np.random.random(k)
         bp = BPoly(c[:, None], x)
 
-        c1 = _raise_degree(c, d)
+        c1 = BPoly._raise_degree(c, d)
         bp1 = BPoly(c1[:, None], x)
 
         xp = np.linspace(0, 1, 11)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -972,11 +972,11 @@ class TestBPolyFromDerivatives(TestCase):
         np.random.seed(12345)
         x = [0, 1]
         k, d = 8, 5
-        c = np.random.random(k)
-        bp = BPoly(c[:, None], x)
+        c = np.random.random((k, 1, 2, 3, 4))
+        bp = BPoly(c, x)
 
         c1 = BPoly._raise_degree(c, d)
-        bp1 = BPoly(c1[:, None], x)
+        bp1 = BPoly(c1, x)
 
         xp = np.linspace(0, 1, 11)
         assert_allclose(bp(xp), bp1(xp))

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -442,7 +442,46 @@ class TestPPoly(TestCase):
         xi = np.linspace(0, 1, 200)
         assert_allclose(pp(xi), splev(xi, spl))
         assert_(np.isnan(pp([-0.1, 1.1])).all())
-        
+
+    def test_derivative_simple(self):
+        np.random.seed(1234)
+        c = np.array([[4, 3, 2, 1]]).T
+        dc = np.array([[3*4, 2*3, 2]]).T
+        ddc = np.array([[2*3*4, 1*2*3]]).T
+        x = np.array([0, 1])
+
+        pp = PPoly(c, x)
+        dpp = PPoly(dc, x)
+        ddpp = PPoly(ddc, x)
+
+        assert_allclose(pp.derivative().c, dpp.c)
+        assert_allclose(pp.derivative(2).c, ddpp.c)
+
+    def test_derivative_eval(self):
+        np.random.seed(1234)
+        x = np.sort(np.r_[0, np.random.rand(11), 1])
+        y = np.random.rand(len(x))
+
+        spl = splrep(x, y, s=0)
+        pp = PPoly.from_spline(spl, fill_value=np.nan)
+
+        xi = np.linspace(0, 1, 200)
+        for dx in range(0, 3):
+            assert_allclose(pp(xi, dx), splev(xi, spl, dx))
+
+    def test_derivative(self):
+        np.random.seed(1234)
+        x = np.sort(np.r_[0, np.random.rand(11), 1])
+        y = np.random.rand(len(x))
+
+        spl = splrep(x, y, s=0, k=5)
+        pp = PPoly.from_spline(spl, fill_value=np.nan)
+
+        xi = np.linspace(0, 1, 200)
+        for dx in range(0, 10):
+            assert_allclose(pp(xi, dx), pp.derivative(dx)(xi),
+                            err_msg="dx=%d" % (dx,))
+
 
 class TestPpform(TestCase):
     def test_shape(self):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -479,6 +479,52 @@ class TestPPolyCommon(TestCase):
             assert_raises(ValueError, p, np.array([[0.1, 0.2], [0.4]]))
 
 
+class TestPolySubclassing(TestCase):
+    class P(PPoly):
+        pass
+    class B(BPoly):
+        pass
+
+    def _make_polynomials(self):
+        np.random.seed(1234)
+        x = np.sort(np.random.random(3))
+        c = np.random.random((4, 2))
+        return self.P(c, x), self.B(c, x)
+
+    def test_derivative(self):
+        pp, bp = self._make_polynomials()
+        for p in (pp, bp):
+            pd = p.derivative()
+            assert_equal(p.__class__, pd.__class__)
+
+        ppa = pp.antiderivative()
+        assert_equal(pp.__class__, ppa.__class__)
+
+    def test_from_spline(self):
+        np.random.seed(1234)
+        x = np.sort(np.r_[0, np.random.rand(11), 1])
+        y = np.random.rand(len(x))
+
+        spl = splrep(x, y, s=0)
+        pp = self.P.from_spline(spl)
+        assert_equal(pp.__class__, self.P)
+
+    def test_conversions(self):
+        pp, bp = self._make_polynomials()
+        
+        pp1 = self.P.from_bernstein_basis(bp)
+        assert_equal(pp1.__class__, self.P)
+
+        bp1 = self.B.from_power_basis(pp)
+        assert_equal(bp1.__class__, self.B)
+
+    def test_from_derivatives(self):
+        x = [0, 1, 2]
+        y = [[1], [2], [3]]
+        bp = self.B.from_derivatives(x, y)
+        assert_equal(bp.__class__, self.B)
+
+
 class TestPPoly(TestCase):
     def test_simple(self):
         c = np.array([[1, 4], [2, 5], [3, 6]])

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -725,6 +725,27 @@ class TestPPoly(TestCase):
         assert_allclose(pp1(xi1), pp_comb(xi1))
         assert_allclose(pp2(xi2), pp_comb(xi2))
 
+    def test_extrapolate_attr(self):
+        # [ 1 - x**2 ]
+        c = np.array([[-1, 0, 1]]).T
+        x = np.array([0, 1])
+
+        for extrapolate in [True, False, None]:
+            pp = PPoly(c, x, extrapolate=extrapolate)
+            pp_d = pp.derivative()
+            pp_i = pp.antiderivative()
+
+            if extrapolate is False:
+                assert_(np.isnan(pp([-0.1, 1.1])).all())
+                assert_(np.isnan(pp_i([-0.1, 1.1])).all())
+                assert_(np.isnan(pp_d([-0.1, 1.1])).all())
+                assert_equal(pp.roots(), [1])
+            else:
+                assert_allclose(pp([-0.1, 1.1]), [1-0.1**2, 1-1.1**2])
+                assert_(not np.isnan(pp_i([-0.1, 1.1])).any())
+                assert_(not np.isnan(pp_d([-0.1, 1.1])).any())
+                assert_allclose(pp.roots(), [1, -1])
+
 
 class TestBPoly(TestCase):
 
@@ -781,6 +802,21 @@ class TestBPoly(TestCase):
 
         assert_allclose(bp(0.4), 3 * 0.6*0.6)
         assert_allclose(bp(1.7), 2 * (0.7/2)**2)
+
+    def test_extrapolate_attr(self):
+        x = [0, 2]
+        c = [[3], [1], [4]]
+        bp = BPoly(c, x)
+
+        for extrapolate in [True, False, None]:
+            bp = BPoly(c, x, extrapolate=extrapolate)
+            bp_d = bp.derivative()
+            if extrapolate is False:
+                assert_(np.isnan(bp([-0.1, 2.1])).all())
+                assert_(np.isnan(bp_d([-0.1, 2.1])).all())
+            else:
+                assert_(not np.isnan(bp([-0.1, 2.1])).any())
+                assert_(not np.isnan(bp_d([-0.1, 2.1])).any())
 
 
 class TestBPolyCalculus(TestCase):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -637,6 +637,27 @@ class TestPPoly(TestCase):
         # Check that we checked a number of roots
         assert_(num > 100, repr(num))
 
+    def test_extend(self):
+        # Test adding new points to the piecewise polynomial
+        np.random.seed(1234)
+
+        order = 3
+        x = np.unique(np.r_[0, 10 * np.random.rand(30), 10])
+        c = 2*np.random.rand(order+1, len(x)-1, 2, 3) - 1
+
+        pp = PPoly(c[:,:9], x[:10])
+        pp.extend(c[:,9:], x[10:])
+
+        pp2 = PPoly(c[:,10:], x[10:])
+        pp2.extend(c[:,:10], x[:10], right=False)
+
+        pp3 = PPoly(c, x)
+
+        assert_array_equal(pp.c, pp3.c)
+        assert_array_equal(pp.x, pp3.x)
+        assert_array_equal(pp2.c, pp3.c)
+        assert_array_equal(pp2.x, pp3.x)
+
 
 class TestPpform(TestCase):
     def test_shape(self):


### PR DESCRIPTION
This PR replaces the piecewise polynomial evaluation algorithm, which was O(N^2) in memory usage and time with one with a O(N) memory usage and O(N log N) in time with O(N) best case.

I also attempt to correct API defects in `ppform` by defining a new piecewise polynomial class `PPoly` --- non-pep8 naming, and incompatible spline convention in `fromspline`, `fill` keyword name instead of `fill_value`.

NB: this is still work in progress, with the following missing:
- derivatives (numerical values and derivative polynomials)
- comparison to `PiecewisePolynomial` (i.e. what worthwhile features are missing)

The long-term plan would be to deprecate both `ppform` and `PiecewisePolynomial` with a faster and better designed alternative.

This may be of interest to @EvgeniBurovski (though the improved `fill_value` handling is missing --- but it can be bolted on later) and @andreas-h (for Akima interpolation).
