### PR TITLE
expm maintenance

### DIFF
--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -21,7 +21,7 @@ import numpy as np
 import scipy.misc
 from scipy.linalg.misc import norm
 from scipy.linalg.basic import solve, solve_triangular, inv
-from scipy.linalg import _fblas as fblas
+from scipy.linalg import blas
 
 from scipy.sparse.base import isspmatrix
 from scipy.sparse.construct import eye as speye
@@ -169,13 +169,13 @@ def _smart_matrix_product(A, B, alpha=None, structure=None):
     if structure == UPPER_TRIANGULAR and A.dtype == B.dtype:
         if not isspmatrix(A) and not isspmatrix(B):
             if A.dtype == np.float32:
-                f = fblas.strmm
+                f = blas.strmm
             elif A.dtype == np.float64:
-                f = fblas.dtrmm
+                f = blas.dtrmm
             elif A.dtype == np.complex64:
-                f = fblas.ctrmm
+                f = blas.ctrmm
             elif A.dtype == np.complex128:
-                f = fblas.ztrmm
+                f = blas.ztrmm
     if f is not None:
         if alpha is None:
             alpha = 1.

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -171,8 +171,7 @@ def _smart_matrix_product(A, B, alpha=None, structure=None):
     if f is not None:
         if alpha is None:
             alpha = 1.
-        out = B.copy()
-        out = f(alpha, A, out)
+        out = f(alpha, A, B)
     else:
         if alpha is None:
             out = A.dot(B)

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -21,7 +21,6 @@ import numpy as np
 import scipy.misc
 from scipy.linalg.misc import norm
 from scipy.linalg.basic import solve, solve_triangular, inv
-from scipy.linalg import blas
 
 from scipy.sparse.base import isspmatrix
 from scipy.sparse.construct import eye as speye
@@ -166,16 +165,9 @@ def _smart_matrix_product(A, B, alpha=None, structure=None):
     if len(B.shape) != 2:
         raise ValueError('expected B to be a rectangular matrix')
     f = None
-    if structure == UPPER_TRIANGULAR and A.dtype == B.dtype:
+    if structure == UPPER_TRIANGULAR:
         if not isspmatrix(A) and not isspmatrix(B):
-            if A.dtype == np.float32:
-                f = blas.strmm
-            elif A.dtype == np.float64:
-                f = blas.dtrmm
-            elif A.dtype == np.complex64:
-                f = blas.ctrmm
-            elif A.dtype == np.complex128:
-                f = blas.ztrmm
+            f, = scipy.linalg.get_blas_funcs(('trmm',), (A, B))
     if f is not None:
         if alpha is None:
             alpha = 1.

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -642,6 +642,9 @@ def _ell(A, m):
         A value related to a bound.
 
     """
+    if A.ndim != 2 or A.shape[0] != A.shape[1]:
+        raise ValueError('expected A to be like a square matrix')
+
     p = 2*m + 1
 
     # The c_i are explained in (2.2) and (2.6) of the 2005 expm paper.
@@ -654,7 +657,9 @@ def _ell(A, m):
 
     # The 1-norm of a small power of a positive matrix
     # can be computed exactly and efficiently.
-    v = np.ones(A.shape[0], dtype=float)
+    # Explicitly make a column vector so that this works when A is a
+    # numpy matrix (as opposed to ndarray or sparse matrix).
+    v = np.ones((A.shape[0], 1), dtype=float)
     M = abs(A).T
     for i in range(p):
         v = M.dot(v)

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -21,7 +21,8 @@ from numpy.testing import (TestCase, run_module_suite,
 from scipy.sparse import csc_matrix, SparseEfficiencyWarning
 from scipy.sparse.construct import eye as speye
 from scipy.sparse.linalg.matfuncs import (expm,
-        ProductOperator, MatrixPowerOperator)
+        ProductOperator, MatrixPowerOperator,
+        _onenorm_matrix_power_nnm)
 from scipy.linalg import logm
 from scipy.misc import factorial
 import scipy.sparse
@@ -57,6 +58,17 @@ def _burkardt_13_power(n, p):
     large = np.power(10.0, -n*a)
     small = large * np.power(10.0, -n)
     return np.diag([large]*(n-b), b) + np.diag([small]*b, b-n)
+
+
+def test_onenorm_matrix_power_nnm():
+    np.random.seed(1234)
+    for n in range(1, 5):
+        for p in range(5):
+            M = np.random.random((n, n))
+            Mp = np.linalg.matrix_power(M, p)
+            observed = _onenorm_matrix_power_nnm(M, p)
+            expected = np.linalg.norm(Mp, 1)
+            assert_allclose(observed, expected)
 
 
 class TestExpM(TestCase):

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -21,8 +21,7 @@ from numpy.testing import (TestCase, run_module_suite,
 from scipy.sparse import csc_matrix, SparseEfficiencyWarning
 from scipy.sparse.construct import eye as speye
 from scipy.sparse.linalg.matfuncs import (expm,
-        ProductOperator, MatrixPowerOperator,
-        _is_upper_triangular)
+        ProductOperator, MatrixPowerOperator)
 from scipy.linalg import logm
 from scipy.misc import factorial
 import scipy.sparse
@@ -94,9 +93,10 @@ class TestExpM(TestCase):
     def test_padecases_dtype_complex(self):
         for dtype in [np.complex64, np.complex128]:
             for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
-                a = scale * eye(3, dtype=dtype)
-                e = exp(scale) * eye(3, dtype=dtype)
-                assert_array_almost_equal_nulp(expm(a), e, nulp=100)
+                A = scale * eye(3, dtype=dtype)
+                observed = expm(A)
+                expected = exp(scale) * eye(3, dtype=dtype)
+                assert_array_almost_equal_nulp(observed, expected, nulp=100)
 
     def test_padecases_dtype_sparse_float(self):
         # float32 and complex64 lead to errors in spsolve/UMFpack

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -60,13 +60,17 @@ def _burkardt_13_power(n, p):
 
 
 class TestExpM(TestCase):
-    def test_zero(self):
+    def test_zero_ndarray(self):
         a = array([[0.,0],[0,0]])
         assert_array_almost_equal(expm(a),[[1,0],[0,1]])
 
     def test_zero_sparse(self):
         a = csc_matrix([[0.,0],[0,0]])
         assert_array_almost_equal(expm(a).toarray(),[[1,0],[0,1]])
+
+    def test_zero_matrix(self):
+        a = np.matrix([[0.,0],[0,0]])
+        assert_array_almost_equal(expm(a),[[1,0],[0,1]])
 
     def test_bidiagonal_sparse(self):
         A = csc_matrix([


### PR DESCRIPTION
This PR speeds up expm a bit (from 40 seconds down to 34 seconds for an order 4k random.randn matrix on my computer, as an unofficial benchmark) and adds a test for numpy matrix input.

The speedup is mostly due to the correction of an earlier oversight where I was using a slow approximate way to get the 1-norm of a power of a positive matrix, but you can get this quickly and exactly.  This was somewhat obfuscated in the original paper because in one place the exact formula was given, but with a missing transpose, and in another place the approximation was used instead, so this was confusing to me.  Less importantly I am also using the newly added trmm for upper triangular matrices.

The expm function had no test for numpy matrices, but it happened to work.  One way that numpy matrices differ from numpy ndarrays and scipy sparse matrices is that `M.dot(M.dot(np.ones(M.shape[0])))` fails when M is a square numpy.matrix but works when M is a square numpy.ndarray or scipy.sparse matrix.  So I added a test for numpy.matrix input.
