### PR TITLE
BUG: optimize: mark constraint violations in cobyla as failed solution

### DIFF
--- a/scipy/optimize/cobyla.py
+++ b/scipy/optimize/cobyla.py
@@ -22,7 +22,7 @@ __all__ = ['fmin_cobyla']
 
 
 def fmin_cobyla(func, x0, cons, args=(), consargs=None, rhobeg=1.0,
-                rhoend=1e-4, iprint=1, maxfun=1000, disp=None):
+                rhoend=1e-4, iprint=1, maxfun=1000, disp=None, catol=1e-6):
     """
     Minimize a function using the Constrained Optimization BY Linear
     Approximation (COBYLA) method. This method wraps a FORTRAN
@@ -55,6 +55,8 @@ def fmin_cobyla(func, x0, cons, args=(), consargs=None, rhobeg=1.0,
         Over-rides the iprint interface.  Preferred.
     maxfun : int
         Maximum number of function evaluations.
+    catol : float
+        Absolute tolerance for constraint violations.
 
     Returns
     -------
@@ -162,15 +164,19 @@ def fmin_cobyla(func, x0, cons, args=(), consargs=None, rhobeg=1.0,
             'tol': rhoend,
             'iprint': iprint,
             'disp': iprint != 0,
-            'maxiter': maxfun}
+            'maxiter': maxfun,
+            'catol': catol}
 
-    return _minimize_cobyla(func, x0, args, constraints=con,
-                            **opts)['x']
+    sol = _minimize_cobyla(func, x0, args, constraints=con,
+                           **opts)
+    if iprint > 0 and not sol['success']:
+        print("COBYLA failed to find a solution: %s" % (sol.message,))
+    return sol['x']
 
 
 def _minimize_cobyla(fun, x0, args=(), constraints=(),
                      rhobeg=1.0, tol=1e-4, iprint=1, maxiter=1000,
-                     disp=False, **unknown_options):
+                     disp=False, catol=1e-6, **unknown_options):
     """
     Minimize a scalar function of one or more variables using the
     Constrained Optimization BY Linear Approximation (COBYLA) algorithm.
@@ -186,6 +192,8 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(),
             `verbosity` is ignored as set to 0.
         maxiter : int
             Maximum number of function evaluations.
+        catol : float
+            Tolerance (absolute) for constraint violations
 
     This function is called by the `minimize` function with
     `method=COBYLA`. It is not supposed to be called directly.
@@ -237,6 +245,10 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(),
                                   rhoend=rhoend, iprint=iprint, maxfun=maxfun,
                                   dinfo=info)
 
+    if info[3] > catol:
+        # Check constraint violation
+        info[0] = 4
+
     return Result(x=xopt,
                   status=int(info[0]),
                   success=info[0] == 1,
@@ -244,7 +256,10 @@ def _minimize_cobyla(fun, x0, args=(), constraints=(),
                            2: 'Maximum number of function evaluations has '
                               'been exceeded.',
                            3: 'Rounding errors are becoming damaging in '
-                              'COBYLA subroutine.'
+                              'COBYLA subroutine.',
+                           4: 'Did not converge to a solution satisfying '
+                              'the constraints. See `maxcv` for magnitude '
+                              'of violation.'
                            }.get(info[0], 'Unknown exit status.'),
                   nfev=int(info[1]),
                   fun=info[2],

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2731,6 +2731,8 @@ def show_options(solver, method=None):
             Reasonable initial changes to the variables.
         maxfev : int
             Maximum number of function evaluations.
+        catol : float
+            Absolute tolerance for constraint violations (default: 1e-6).
 
     * SLSQP options:
         ftol : float

--- a/scipy/optimize/tests/test_cobyla.py
+++ b/scipy/optimize/tests/test_cobyla.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 import math
+import numpy as np
 
 from numpy.testing import assert_allclose, TestCase, run_module_suite, \
      assert_
@@ -41,6 +42,32 @@ class TestCobyla(TestCase):
         assert_(sol.maxcv < 1e-5, sol)
         assert_(sol.nfev < 70, sol)
         assert_(sol.fun < self.fun(self.solution) + 1e-3, sol)
+
+    def test_minimize_constraint_violation(self):
+        np.random.seed(1234)
+        pb = np.random.rand(10, 10)
+        spread = np.random.rand(10)
+
+        def p(w):
+            return pb.dot(w)
+        def f(w):
+            return -(w * spread).sum()
+        def c1(w):
+            return 500 - abs(p(w)).sum()
+        def c2(w):
+            return 5 - abs(p(w).sum())
+        def c3(w):
+            return 5 - abs(p(w)).max()
+
+        cons = ({'type': 'ineq', 'fun': c1},
+                {'type': 'ineq', 'fun': c2},
+                {'type': 'ineq', 'fun': c3})
+        w0 = np.zeros((10, 1))
+        sol = minimize(f, w0, method='cobyla', constraints=cons,
+                       options={'catol': 1e-6})
+        assert_(sol.maxcv > 1e-6)
+        assert_(not sol.success)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
The COBYLA solver can apparently return with status 1 even if the constraints are violated. The constraint violation is reported in the `maxcv` variable, which however was previously undocumented.

This PR checks the violation in the wrapper against a given tolerance, and marks the solution as failed if the tolerance is not satisfied.

This needs some review --- I don't understand exactly why the COBYLA code works like it does (doesn't make much sense for a constrained solver to do this), but it seems like this is just how the old fortran code was intended to behave, and the Python wrappers were just incorrectly written.

Addresses gh-2891
