### PR TITLE
DOC: optimize: approx_fprime missing from documentation

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -134,8 +134,9 @@ Utility Functions
 .. autosummary::
    :toctree: generated/
 
-   line_search - Return a step that satisfies the strong Wolfe conditions
+   approx_fprime - Approximate the gradient of a scalar function
    check_grad - Check the supplied derivative using finite differences
+   line_search - Return a step that satisfies the strong Wolfe conditions
 
    show_options - Show specific options optimization solvers
 


### PR DESCRIPTION
I couldn't find the approximate gradient function in SciPy, until I figured from a broken link in the `check_grad` function that it's there, but missing from the documentation.
