### PR TITLE
DOC: fix a typo in the special.zetac docs

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -498,7 +498,7 @@ Other Special Functions
    spence       -- Dilogarithm integral.
    lambertw     -- Lambert W function
    zeta         -- Riemann zeta function of two arguments.
-   zetac        -- 1.0 - standard Riemann zeta function.
+   zetac        -- Standard Riemann zeta function minus 1.
 
 Convenience Functions
 ---------------------

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -7922,7 +7922,7 @@ cdef void *ufunc_zetac_ptr[4]
 cdef void *ufunc_zetac_data[2]
 cdef char ufunc_zetac_types[4]
 cdef char *ufunc_zetac_doc = (
-    "y=zetac(x) returns 1.0 - the Riemann zeta function: sum(k**(-x), k=2..inf)")
+    "y=zetac(x) returns the Riemann zeta function minus 1.0: sum(k**(-x), k=2..inf)")
 ufunc_zetac_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_zetac_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_zetac_types[0] = <char>NPY_FLOAT

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -7899,8 +7899,20 @@ cdef void *ufunc_zeta_ptr[4]
 cdef void *ufunc_zeta_data[2]
 cdef char ufunc_zeta_types[6]
 cdef char *ufunc_zeta_doc = (
-    "y=zeta(x,q) returns the Riemann zeta function of two arguments:\n"
-    "sum((k+q)**(-x),k=0..inf)")
+    "zeta(x, q)\n"
+    "\n"
+    "The Riemann zeta function of two arguments (also known as the Hurwitz\n"
+    "zeta funtion).\n"
+    "\n"
+    "This function is defined as\n"
+    "\n"
+    ".. math:: \zeta(x, q) = \sum_{k=0}^{\infty} 1 / (k+q)^x,\n"
+    "\n"
+    "where ``x > 1`` and ``q > 0``.\n"
+    "\n"
+    "See also\n"
+    "--------\n"
+    "zetac")
 ufunc_zeta_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_zeta_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
 ufunc_zeta_types[0] = <char>NPY_FLOAT
@@ -7922,7 +7934,19 @@ cdef void *ufunc_zetac_ptr[4]
 cdef void *ufunc_zetac_data[2]
 cdef char ufunc_zetac_types[4]
 cdef char *ufunc_zetac_doc = (
-    "y=zetac(x) returns the Riemann zeta function minus 1.0: sum(k**(-x), k=2..inf)")
+    "zetac(x)\n"
+    "\n"
+    "The Riemann zeta function minus 1.\n"
+    "\n"
+    "This function is defined as\n"
+    "\n"
+    ".. math:: \zeta(x) = \sum_{k=2}^{\infty} 1 / k^x,\n"
+    "\n"
+    "where ``x > 1``.\n"
+    "\n"
+    "See also\n"
+    "--------\n"
+    "zeta")
 ufunc_zetac_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_zetac_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_zetac_types[0] = <char>NPY_FLOAT

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1577,14 +1577,39 @@ add_newdoc("scipy.special", "yve",
 
 add_newdoc("scipy.special", "zeta",
     """
-    y=zeta(x,q) returns the Riemann zeta function of two arguments (also 
-    known as the Hurwitz zeta function):
-    sum((k+q)**(-x), k=0..inf)
+    zeta(x, q)
+
+    The Riemann zeta function of two arguments (also known as the Hurwitz
+    zeta funtion).
+
+    This function is defined as
+
+    .. math:: \\zeta(x, q) = \\sum_{k=0}^{\\infty} 1 / (k+q)^x,
+
+    where ``x > 1`` and ``q > 0``.
+
+    See also
+    --------
+    zetac
+
     """)
 
 add_newdoc("scipy.special", "zetac",
     """
-    y=zetac(x) returns the Riemann zeta function minus 1.0: sum(k**(-x), k=2..inf)
+    zetac(x)
+
+    The Riemann zeta function minus 1.
+
+    This function is defined as
+
+    .. math:: \\zeta(x) = \\sum_{k=2}^{\\infty} 1 / k^x,
+
+    where ``x > 1``.
+
+    See also
+    --------
+    zeta
+
     """)
 
 add_newdoc("scipy.special", "_struve_asymp_large_z",

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1577,13 +1577,14 @@ add_newdoc("scipy.special", "yve",
 
 add_newdoc("scipy.special", "zeta",
     """
-    y=zeta(x,q) returns the Riemann zeta function of two arguments:
-    sum((k+q)**(-x),k=0..inf)
+    y=zeta(x,q) returns the Riemann zeta function of two arguments (also 
+    known as the Hurwitz zeta function):
+    sum((k+q)**(-x), k=0..inf)
     """)
 
 add_newdoc("scipy.special", "zetac",
     """
-    y=zetac(x) returns 1.0 - the Riemann zeta function: sum(k**(-x), k=2..inf)
+    y=zetac(x) returns the Riemann zeta function minus 1.0: sum(k**(-x), k=2..inf)
     """)
 
 add_newdoc("scipy.special", "_struve_asymp_large_z",


### PR DESCRIPTION
Also throw in the name for the Hurwitz zeta function. Which is trivial enough, but can cause confusion (eg http://stackoverflow.com/questions/9354343/) 
