### PR TITLE
increase precision of hyperu

### DIFF
--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -3084,7 +3084,7 @@ C
      &          .152746185967848D-01, .126781664768159D-01,
      &          .100475571822880D-01, .738993116334531D-02,
      &          .471272992695363D-02, .202681196887362D-02/
-        ID=7
+        ID=9
         A1=A-1.0D0
         B1=B-A-1.0D0
         C=12.0D0/X
@@ -3105,7 +3105,7 @@ C
               HU1=HU1+S*G
               D=D+2.0D0*G
 15         CONTINUE
-           IF (DABS(1.0D0-HU0/HU1).LT.1.0D-7) GO TO 25
+           IF (DABS(1.0D0-HU0/HU1).LT.1.0D-9) GO TO 25
            HU0=HU1
 20      CONTINUE
 25      CALL GAMMA2(A,GA)
@@ -3128,7 +3128,7 @@ C
               HU2=HU2+S*G
               D=D+2.0D0*G
 35         CONTINUE
-           IF (DABS(1.0D0-HU0/HU2).LT.1.0D-7) GO TO 45
+           IF (DABS(1.0D0-HU0/HU2).LT.1.0D-9) GO TO 45
            HU0=HU2
 40      CONTINUE
 45      CALL GAMMA2(A,GA)
@@ -4972,13 +4972,13 @@ C
         IF (B.NE.INT(B)) THEN
            CALL CHGUS(A,B,X,HU,ID1)
            MD=1
-           IF (ID1.GE.6) RETURN
+           IF (ID1.GE.9) RETURN
            HU1=HU
         ENDIF
         IF (IL1.OR.IL2.OR.IL3) THEN
            CALL CHGUL(A,B,X,HU,ID)
            MD=2
-           IF (ID.GE.6) RETURN
+           IF (ID.GE.9) RETURN
            IF (ID1.GT.ID) THEN
               MD=1
               ID=ID1

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1709,6 +1709,10 @@ class TestHyper(TestCase):
                                / (special.gamma(a)*special.gamma(2-b)))
         assert_array_almost_equal(hypu,hprl,12)
 
+    def test_hyperu_gh2287(self):
+        assert_almost_equal(special.hyperu(1, 1.5, 20.2),
+                            0.048360918656699191, 12)
+
 
 class TestBessel(TestCase):
     def test_itj0y0(self):


### PR DESCRIPTION
In gh-2287 it was pointed out that the precision of `hyperu` can be as low as 6 significant digits. The reason is that the code defines 6 significant digits as sufficient for a valid result. In this pull request, I propose to increase the precision to 9 significant digits which means that iterations are run a bit more often than before. The final check for valid results can stay at 6 significant digits. 

For the example from gh-2287 one obtains:

```
hyperu(1, 1.5, 20.2)
old code: 0.048360865288403269
new code: 0.04836091865669917
mpmath: 0.048360918656699191
```

which is a significant improvement without changing the basic algorithm.

An interesting effect happens for a set of parameters taken from `test_mpmath.py`:

```
hyperu(-0.1, 1, 10)
old code: 1.2577123535311705
new code: 1.2577123420521401
mpmath: 1.2577123420521652
```

In the old code the result from `CHGUL` was accepted as sufficiently accurate. In the new code, this is no longer the case and finally the better result coming from `CHGUBI` is used. Strangely enough, the estimate of accuracy is `ID=-3` (which is not caused by the changes proposed here) and does not reflect at all the 14 significant digits. As a consequence, an accuracy warning is now generated by the code, although the result is much better than with the old code. To remedy the situation, one probably would need to improve the error estimation in `CHGUBI` which is, however, not intended in this pull request. 

A side remark: Many parameter sets which lead to errors in `test_mpmath.py` are actually cases where the result is complex. However, `CHGU` is not designed to treat such cases. A typical situation are negative non-integer values for `a` and negative values for `x`. I wonder whether one should aim for an improved code or rather document the restrictions on the parameters and possibly restrict the tests to the valid parameter sets. The latter might be useful to identify the cases where problems exist with the present code.
