### PR TITLE
stats.py fixes and test coverage

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -711,19 +711,22 @@ def mask_to_limits(a, limits, inclusive):
             am = ma.masked_less(am, lower_limit)
         else:
             am = ma.masked_less_equal(am, lower_limit)
+
     if upper_limit is not None:
         if upper_include:
             am = ma.masked_greater(am, upper_limit)
         else:
             am = ma.masked_greater_equal(am, upper_limit)
+
     if am.count() == 0:
         raise ValueError("No array values within given limits")
+
     return am
 
 
 def tmean(a, limits=None, inclusive=(True, True)):
     """
-    Compute the trimmed mean
+    Compute the trimmed mean.
 
     This function finds the arithmetic mean of given values, ignoring values
     outside the given `limits`.
@@ -731,12 +734,12 @@ def tmean(a, limits=None, inclusive=(True, True)):
     Parameters
     ----------
     a : array_like
-        array of values
+        Array of values.
     limits : None or (lower limit, upper limit), optional
         Values in the input array less than the lower limit or greater than the
-        upper limit will be ignored. When limits is None, then all values are
-        used. Either of the limit values in the tuple can also be None
-        representing a half-open interval.  The default value is None.
+        upper limit will be ignored.  When limits is None (default), then all
+        values are used.  Either of the limit values in the tuple can also be
+        None representing a half-open interval.
     inclusive : (bool, bool), optional
         A tuple consisting of the (lower flag, upper flag).  These flags
         determine whether values exactly equal to the lower or upper limits
@@ -748,15 +751,8 @@ def tmean(a, limits=None, inclusive=(True, True)):
 
     """
     a = asarray(a)
-
-    # Cast to a float if this is an integer array. If it is already a float
-    # array, leave it as is to preserve its precision.
-    if issubclass(a.dtype.type, np.integer):
-        a = a.astype(float)
-
-    # No trimming.
     if limits is None:
-        return np.mean(a,None)
+        return np.mean(a, None)
 
     am = mask_to_limits(a.ravel(), limits, inclusive)
     return am.mean()
@@ -779,7 +775,7 @@ def tvar(a, limits=None, inclusive=(True, True)):
     Parameters
     ----------
     a : array_like
-        array of values
+        Array of values.
     limits : None or (lower limit, upper limit), optional
         Values in the input array less than the lower limit or greater than the
         upper limit will be ignored. When limits is None, then all values are
@@ -794,6 +790,11 @@ def tvar(a, limits=None, inclusive=(True, True)):
     -------
     tvar : float
         Trimmed variance.
+
+    Notes
+    -----
+    `tvar` computes the unbiased sample variance, i.e. it uses a correction
+    factor ``n / (n - 1)``.
 
     """
     a = asarray(a)
@@ -838,7 +839,7 @@ def tmin(a, lowerlimit=None, axis=0, inclusive=True):
     return ma.minimum.reduce(am, axis)
 
 
-def tmax(a, upperlimit, axis=0, inclusive=True):
+def tmax(a, upperlimit=None, axis=0, inclusive=True):
     """
     Compute the trimmed maximum
 
@@ -895,13 +896,18 @@ def tstd(a, limits=None, inclusive=(True, True)):
     -------
     tstd : float
 
+    Notes
+    -----
+    `tstd` computes the unbiased sample standard deviation, i.e. it uses a
+    correction factor ``n / (n - 1)``.
+
     """
     return np.sqrt(tvar(a, limits, inclusive))
 
 
 def tsem(a, limits=None, inclusive=(True, True)):
     """
-    Compute the trimmed standard error of the mean
+    Compute the trimmed standard error of the mean.
 
     This function finds the standard error of the mean for given
     values, ignoring values outside the given `limits`.
@@ -924,14 +930,19 @@ def tsem(a, limits=None, inclusive=(True, True)):
     -------
     tsem : float
 
+    Notes
+    -----
+    `tsem` uses unbiased sample standard deviation, i.e. it uses a
+    correction factor ``n / (n - 1)``.
+
     """
     a = np.asarray(a).ravel()
     if limits is None:
-        n = float(len(a))
-        return a.std()/np.sqrt(n)
-    am = mask_to_limits(a.ravel(), limits, inclusive)
+        return a.std(ddof=1) / np.sqrt(a.size)
+
+    am = mask_to_limits(a, limits, inclusive)
     sd = np.sqrt(masked_var(am))
-    return sd / am.count()
+    return sd / np.sqrt(am.count())
 
 
 #####################################

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1669,8 +1669,9 @@ def histogram(a, numbins=10, defaultlimits=None, weights=None, printextras=False
         The weights for each value in `a`. Default is None, which gives each
         value a weight of 1.0
     printextras : bool, optional
-        If True, the number of extra points is printed to standard output.
-        Default is False.
+        If True, if there are extra points (i.e. the points that fall outside
+        the bin limits) a warning is raised saying how many of those points
+        there are.  Default is False.
 
     Returns
     -------
@@ -1693,7 +1694,7 @@ def histogram(a, numbins=10, defaultlimits=None, weights=None, printextras=False
     default if default limits is not set.
 
     """
-    a = np.ravel(a)               # flatten any >1D arrays
+    a = np.ravel(a)
     if defaultlimits is None:
         # no range given, so use values in `a`
         data_min = a.min()

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -865,17 +865,13 @@ def test_cumfreq():
 def test_relfreq():
     a = np.array([1, 4, 2, 1, 3, 1])
     relfreqs, lowlim, binsize, extrapoints = stats.relfreq(a, numbins=4)
-    assert_array_almost_equal(relfreqs, array([0.5, 0.16666667, 0.16666667, 0.16666667]))
+    assert_array_almost_equal(relfreqs,
+                              array([0.5, 0.16666667, 0.16666667, 0.16666667]))
 
     # check array_like input is accepted
-    relfreqs2, lowlim, binsize, extrapoints = stats.relfreq([1, 4, 2, 1, 3, 1], numbins=4)
+    relfreqs2, lowlim, binsize, extrapoints = stats.relfreq([1, 4, 2, 1, 3, 1],
+                                                            numbins=4)
     assert_array_almost_equal(relfreqs, relfreqs2)
-
-
-# Utility
-def compare_results(res,desired):
-    for i in range(len(desired)):
-        assert_array_equal(res[i],desired[i])
 
 
 class TestGMean(TestCase):
@@ -2124,7 +2120,7 @@ def test_kurtosistest_too_few_samples():
     assert_raises(ValueError, stats.kurtosistest, x)
 
 
-def mannwhitneyu():
+def test_mannwhitneyu():
     x = np.array([1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
         1., 1., 1., 1., 1., 1., 1., 1., 2., 1., 1., 1., 1., 1., 1., 1.,
         1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1059,25 +1059,22 @@ class TestScoreatpercentile(TestCase):
         assert_raises(ValueError, stats.scoreatpercentile, [1], -1)
 
 
-class TestItemfreq(TestCase):
+class TestItemfreq(object):
     a = [5, 7, 1, 2, 1, 5, 7] * 10
     b = [1, 2, 5, 7]
 
     def test_numeric_types(self):
         # Check itemfreq works for all dtypes (adapted from np.unique tests)
-        def _check_itemfreq(a, b, dt):
+        def _check_itemfreq(dt):
+            a = np.array(self.a, dt)
             v = stats.itemfreq(a)
             assert_array_equal(v[:, 0], [1, 2, 5, 7])
-            assert_array_equal(v[:, 1], np.bincount(v[:, 0]))
+            assert_array_equal(v[:, 1], np.array([20, 10, 20, 20], dtype=dt))
 
-        a, b = self.a, self.b
-        types = []
-        types.extend(np.typecodes['AllInteger'])
-        types.extend(np.typecodes['AllFloat'])
-        for dt in types:
-            aa = np.array(a, dt)
-            bb = np.array(b, dt)
-            yield _check_itemfreq, aa, bb, dt
+        dtypes = [np.int32, np.int64, np.float32, np.float64,
+                  np.complex64, np.complex128]
+        for dt in dtypes:
+            yield _check_itemfreq, dt
 
     def test_object_arrays(self):
         a, b = self.a, self.b

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -47,31 +47,63 @@ TINY = array([1e-12,2e-12,3e-12,4e-12,5e-12,6e-12,7e-12,8e-12,9e-12], float)
 ROUND = array([0.5,1.5,2.5,3.5,4.5,5.5,6.5,7.5,8.5], float)
 
 
-class TestBasicStats(TestCase):
-    """ W.II.C. Compute basic statistic on all the variables.
-
-        The means should be the fifth value of all the variables (case FIVE).
-        The standard deviations should be "undefined" or missing for MISS,
-        0 for ZERO, and 2.738612788 (times 10 to a power) for all the other variables.
-        II. C. Basic Statistics
-    """
-
+class TestTrimmedStats(TestCase):
+    # TODO: write these tests to handle missing values properly
     dprec = np.finfo(np.float64).precision
 
-    # Really need to write these tests to handle missing values properly
-    def test_tmeanX(self):
+    def test_tmean(self):
         y = stats.tmean(X, (2, 8), (True, True))
-        assert_approx_equal(y, 5.0, significant=TestBasicStats.dprec)
+        assert_approx_equal(y, 5.0, significant=self.dprec)
 
-    def test_tvarX(self):
-        y = stats.tvar(X, (2, 8), (True, True))
-        assert_approx_equal(y, 4.6666666666666661,
-                            significant=TestBasicStats.dprec)
+        y1 = stats.tmean(X, limits=(2, 8), inclusive=(False, False))
+        y2 = stats.tmean(X, limits=None)
+        assert_approx_equal(y1, y2, significant=self.dprec)
 
-    def test_tstdX(self):
+    def test_tvar(self):
+        y = stats.tvar(X, limits=(2, 8), inclusive=(True, True))
+        assert_approx_equal(y, 4.6666666666666661, significant=self.dprec)
+
+        y = stats.tvar(X, limits=None)
+        assert_approx_equal(y, X.var(ddof=1), significant=self.dprec)
+
+    def test_tstd(self):
         y = stats.tstd(X, (2, 8), (True, True))
-        assert_approx_equal(y, 2.1602468994692865,
-                            significant=TestBasicStats.dprec)
+        assert_approx_equal(y, 2.1602468994692865, significant=self.dprec)
+
+        y = stats.tstd(X, limits=None)
+        assert_approx_equal(y, X.std(ddof=1), significant=self.dprec)
+
+    def test_tmin(self):
+        x = np.arange(10)
+        assert_equal(stats.tmin(x), 0)
+        assert_equal(stats.tmin(x, lowerlimit=0), 0)
+        assert_equal(stats.tmin(x, lowerlimit=0, inclusive=False), 1)
+
+        x = x.reshape((5, 2))
+        assert_equal(stats.tmin(x, lowerlimit=0, inclusive=False), [2, 1])
+        assert_equal(stats.tmin(x, axis=1), [0, 2, 4, 6, 8])
+        assert_equal(stats.tmin(x, axis=None), 0)
+
+    def test_tmax(self):
+        x = np.arange(10)
+        assert_equal(stats.tmax(x), 9)
+        assert_equal(stats.tmax(x, upperlimit=9),9)
+        assert_equal(stats.tmax(x, upperlimit=9, inclusive=False), 8)
+
+        x = x.reshape((5, 2))
+        assert_equal(stats.tmax(x, upperlimit=9, inclusive=False), [8, 7])
+        assert_equal(stats.tmax(x, axis=1), [1, 3, 5, 7, 9])
+        assert_equal(stats.tmax(x, axis=None), 9)
+
+    def test_tsem(self):
+        y = stats.tsem(X, limits=(3, 8), inclusive=(False, True))
+        y_ref = np.array([4, 5, 6, 7, 8])
+        assert_approx_equal(y, y_ref.std(ddof=1) / np.sqrt(y_ref.size),
+                            significant=self.dprec)
+
+        assert_approx_equal(stats.tsem(X, limits=[-1, 10]),
+                            stats.tsem(X, limits=None),
+                            significant=self.dprec)
 
 
 class TestNanFunc(TestCase):


### PR DESCRIPTION
- Fixes test failure with older numpy.
- Fixes `stats.tsem`, it was returning `s/n` instead of `s/sqrt(n)` (no tests is really bad, yet again).
- Provides some test coverage for all trimmed statistics.

There's still some inconsistencies in the signatures of the trimmed stats functions, that should be fixed sometime soon.
