### PR TITLE
Fixed docs for return values of scipy.sparse.linalg.eigsh

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1305,8 +1305,8 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     w : array
         Array of k eigenvalues
     v : array
-       An array of k eigenvectors
-       The v[i] is the eigenvector corresponding to the eigenvector w[i]
+        An array representing the `k` eigenvectors.  The column ``v[:, i]`` is
+        the eigenvector corresponding to the eigenvalue ``w[i]``.
 
     Other Parameters
     ----------------


### PR DESCRIPTION
v[:, i](not v[i]) is indeed the eigenvector corresponding to w[i].
The docstring for eigs, also given in this file, is already correct.
