### PR TITLE
BLD: except clause for Sphinx import in setup.py should catch everything.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ if not release:
 try:
     from sphinx.setup_command import BuildDoc
     HAVE_SPHINX = True
-except ImportError:
+except:
     HAVE_SPHINX = False
 
 if HAVE_SPHINX:


### PR DESCRIPTION
Closes gh-2926.  The Sphinx version currently shipping with MacPorts for Python 3.2 seems broken, so while a bare except is not great style it's necessary.
