### PR TITLE
BUG+TST: setdiag implementation for dia_matrix (Close #2931) + test_setdiag (was untested)

### DIFF
--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -181,6 +181,16 @@ class dia_matrix(_data_matrix):
     def _mul_multimatrix(self, other):
         return np.hstack([self._mul_vector(col).reshape(-1,1) for col in other.T])
 
+    def setdiag(self, values, k=0):
+        M, N = self.shape
+        if (not k in self.offsets):
+            raise ValueError(
+                "dia matrix does not support assignment for unknown diagonals. "
+                "Known offsets are: %s" % self.offsets)
+        self.data[self.offsets == k, :] = values
+
+    setdiag.__doc__ = _data_matrix.setdiag.__doc__
+
     def todia(self,copy=False):
         if copy:
             return self.copy()

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -182,11 +182,15 @@ class dia_matrix(_data_matrix):
         return np.hstack([self._mul_vector(col).reshape(-1,1) for col in other.T])
 
     def setdiag(self, values, k=0):
-        if k not in self.offsets:
-            self.offsets = self.offsets.append((k,))
-            self.data = self.data.vstack((self.data, values))
-        else:
+        M, N = self.shape
+        if k <= -M or k >= N:
+            raise ValueError('k exceeds matrix dimensions')
+        if k in self.offsets:
             self.data[self.offsets == k, :] = values
+        else:
+            self.offsets = np.append(self.offsets, (k,))
+            self.data = np.vstack((self.data, np.empty((1,N))))
+            self.data[-1, :] = values
 
     setdiag.__doc__ = _data_matrix.setdiag.__doc__
 

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -182,12 +182,11 @@ class dia_matrix(_data_matrix):
         return np.hstack([self._mul_vector(col).reshape(-1,1) for col in other.T])
 
     def setdiag(self, values, k=0):
-        M, N = self.shape
-        if (not k in self.offsets):
-            raise ValueError(
-                "dia matrix does not support assignment for unknown diagonals. "
-                "Known offsets are: %s" % self.offsets)
-        self.data[self.offsets == k, :] = values
+        if k not in self.offsets:
+            self.offsets = self.offsets.append((k,))
+            self.data = self.data.vstack((self.data, values))
+        else:
+            self.data[self.offsets == k, :] = values
 
     setdiag.__doc__ = _data_matrix.setdiag.__doc__
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -553,10 +553,7 @@ class _TestCommon:
             assert_equal(self.spmatrix(m).diagonal(),diag(m))
 
     def test_setdiag(self):
-        #yoh: could not find a better way to deduce 'format' for the
-        #given matrix
-        format_ = self.spmatrix.__module__.split('.')[-1]
-        m = scipy.sparse.identity(3, format=format_)
+        m = self.spmatrix(np.eye(3))
         values = [3, 2, 1]
         # it is out of limits
         assert_raises(ValueError, m.setdiag, values, k=4)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3020,6 +3020,10 @@ class TestCOO(sparse_test_class(getset=False,
         dia = coo_matrix(zeros).todia()
         assert_array_equal(dia.A, zeros)
 
+    @dec.knownfailureif(True, "known deficiency in COO")
+    def test_setdiag(self):
+        pass
+
 
 class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False,
@@ -3117,6 +3121,10 @@ class TestBSR(sparse_test_class(getset=False,
 
     @dec.knownfailureif(True, "BSR not implemented")
     def test_iterator(self):
+        pass
+
+    @dec.knownfailureif(True, "known deficiency in BSR")
+    def test_setdiag(self):
         pass
 
 if __name__ == "__main__":

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -563,7 +563,11 @@ class _TestCommon:
         m.setdiag(values)
         assert_array_equal(m.diagonal(), values)
 
-        # TODO: test setting offdiagonals (k!=0)
+        # test setting offdiagonals (k!=0)
+        m.setdiag((9,), k=2)
+        assert_array_equal(m.A[0,2], 9)
+        m.setdiag((9,), k=-2)
+        assert_array_equal(m.A[2,0], 9)
 
     def test_nonzero(self):
         A = array([[1, 0, 1],[0, 1, 1],[0, 0, 1]])

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -552,6 +552,19 @@ class _TestCommon:
         for m in mats:
             assert_equal(self.spmatrix(m).diagonal(),diag(m))
 
+    def test_setdiag(self):
+        #yoh: could not find a better way to deduce 'format' for the
+        #given matrix
+        format_ = self.spmatrix.__module__.split('.')[-1]
+        m = scipy.sparse.identity(3, format=format_)
+        values = [3, 2, 1]
+        # it is out of limits
+        assert_raises(ValueError, m.setdiag, values, k=4)
+        m.setdiag(values)
+        assert_array_equal(m.diagonal(), values)
+
+        # TODO: test setting offdiagonals (k!=0)
+
     def test_nonzero(self):
         A = array([[1, 0, 1],[0, 1, 1],[0, 0, 1]])
         Asp = self.spmatrix(A)


### PR DESCRIPTION
Revealed similar lack of setdiag imlementation for COO and BSR matrices (TODO)
