### PR TITLE
BUG: io/wavfile: safer writing directly from buffer

### DIFF
--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -84,21 +84,28 @@ def _check_roundtrip(realfile, rate, dtype, channels):
 
 def test_write_roundtrip():
     for realfile in (False, True):
-        for signed in ('i', 'u', 'f'):
+        for dtypechar in ('i', 'u', 'f', 'g', 'q'):
             for size in (1, 2, 4, 8):
-                if size == 1 and signed == 'i':
+                if size == 1 and dtypechar == 'i':
                     # signed 8-bit integer PCM is not allowed
                     continue
-                if size > 1 and signed == 'u':
+                if size > 1 and dtypechar == 'u':
                     # unsigned > 8-bit integer PCM is not allowed
                     continue
-                if (size == 1 or size == 2) and signed == 'f':
+                if (size == 1 or size == 2) and dtypechar == 'f':
                     # 8- or 16-bit float PCM is not expected
                     continue
+                if dtypechar in 'gq':
+                    # no size allowed for these types
+                    if size == 1:
+                        size = ''
+                    else:
+                        continue
+
                 for endianness in ('>', '<'):
                     if size == 1 and endianness == '<':
                         continue
                     for rate in (8000, 32000):
                         for channels in (1, 2, 5):
-                            dt = np.dtype('%s%s%d' % (endianness, signed, size))
+                            dt = np.dtype('%s%s%s' % (endianness, dtypechar, size))
                             yield _check_roundtrip, realfile, rate, dt, channels

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -238,10 +238,8 @@ def write(filename, rate, data):
         fid.write(struct.pack('<i', data.nbytes))
         if data.dtype.byteorder == '>' or (data.dtype.byteorder == '=' and sys.byteorder == 'big'):
             data = data.byteswap()
-        if sys.version_info[0] >= 3:
-            fid.write(data.ravel().data)
-        else:
-            fid.write(data.tostring())
+        _array_tofile(fid, data)
+
         # Determine file size and place it in correct
         #  position at start of the file.
         size = fid.tell()
@@ -253,3 +251,12 @@ def write(filename, rate, data):
             fid.close()
         else:
             fid.seek(0)
+
+
+if sys.version_info[0] >= 3:
+    def _array_tofile(fid, data):
+        # ravel gives a c-contiguous buffer
+        fid.write(data.ravel().view('b').data)
+else:
+    def _array_tofile(fid, data):
+        fid.write(data.tostring())


### PR DESCRIPTION
Casting ndarray to a buffer fails for "non-native" datatypes in non-native byte order.
Since writing only cares about the bytes, we can as well make a byte view first.

Also test for a few more types.

Fixes gh-2928
