### PR TITLE
BUG: sparse: fix crashes/wrong results in broadcasting multiply

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -431,29 +431,29 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             elif self.shape == (1,1):
                 return other.__mul__(self.tocsc().data[0])
             # A row times a column.
-            elif self.shape[1] == other.shape[0] == 1:
+            elif self.shape[1] == other.shape[0] and self.shape[1] == 1:
                 return self._mul_sparse_matrix(other.tocsc())
-            elif self.shape[0] == other.shape[1] == 1:
+            elif self.shape[0] == other.shape[1] and self.shape[0] == 1:
                 return other._mul_sparse_matrix(self.tocsc())
             # Row vector times matrix. other is a row.
             elif other.shape[0] == 1 and self.shape[1] == other.shape[1]:
                 other = dia_matrix((other.toarray().ravel(), [0]),
-                                    shape=self.shape)
+                                    shape=(other.shape[1], other.shape[1]))
                 return self._mul_sparse_matrix(other)
             # self is a row.
             elif self.shape[0] == 1 and self.shape[1] == other.shape[1]:
                 copy = dia_matrix((self.toarray().ravel(), [0]),
-                                    shape=other.shape)
+                                    shape=(self.shape[1], self.shape[1]))
                 return other._mul_sparse_matrix(copy)
             # Column vector times matrix. other is a column.
             elif other.shape[1] == 1 and self.shape[0] == other.shape[0]:
                 other = dia_matrix((other.toarray().ravel(), [0]),
-                                    shape=self.shape)
+                                    shape=(other.shape[0], other.shape[0]))
                 return other._mul_sparse_matrix(self)
             # self is a column.
             elif self.shape[1] == 1 and self.shape[0] == other.shape[0]:
                 copy = dia_matrix((self.toarray().ravel(), [0]),
-                                    shape=other.shape)
+                                    shape=(self.shape[0], self.shape[0]))
                 return copy._mul_sparse_matrix(other)
             else:
                 raise ValueError("inconsistent shapes")

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -934,6 +934,8 @@ class _TestCommon:
         E = array([[3],[2],[1]])
         F = array([[8,6,3],[-4,3,2],[6,6,6]])
         G = [1, 2, 3]
+        H = np.ones((3, 4))
+        J = H.T
 
         # Rank 1 arrays can't be cast as spmatrices (A and C) so leave
         # them out.
@@ -941,9 +943,14 @@ class _TestCommon:
         Dsp = self.spmatrix(D)
         Esp = self.spmatrix(E)
         Fsp = self.spmatrix(F)
+        Hsp = self.spmatrix(H)
+        Hspp = self.spmatrix(H[0,None])
+        Jsp = self.spmatrix(J)
+        Jspp = self.spmatrix(J[:,0,None])
 
-        matrices = [A, B, C, D, E, F, G]
-        spmatrices = [Bsp, Dsp, Esp, Fsp]
+        matrices = [A, B, C, D, E, F, G, H, J]
+        spmatrices = [Bsp, Dsp, Esp, Fsp, Hsp, Hspp, Jsp, Jspp]
+
         # sparse/sparse
         for i in spmatrices:
             for j in spmatrices:


### PR DESCRIPTION
The dia_matrices used to broadcast column/row vector elementwise
multiplications should be square.  The matrices are passed directly to
the internal `_mul_*` methods, which make no data size or shape checks, so
wrong size gives wrong results or segfaults with no warnings.
