### PR TITLE
TST: fftpack: remove check of successful overwrite

### DIFF
--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -714,9 +714,6 @@ class TestOverwrite(object):
                 routine.__name__, x.dtype, x.shape, fftsize, axis, overwrite_x)
             if not should_overwrite:
                 assert_equal(x2, x, err_msg="spurious overwrite in %s" % sig)
-            else:
-                if (x2 == x).all():
-                    raise AssertionError("no overwrite in %s" % sig)
 
     def _check_1d(self, routine, dtype, shape, axis, overwritable_dtypes):
         np.random.seed(1234)

--- a/scipy/fftpack/tests/test_real_transforms.py
+++ b/scipy/fftpack/tests/test_real_transforms.py
@@ -358,9 +358,6 @@ class TestOverwrite(object):
             routine.__name__, x.dtype, x.shape, fftsize, axis, overwrite_x)
         if not should_overwrite:
             assert_equal(x2, x, err_msg="spurious overwrite in %s" % sig)
-        else:
-            if (x2 == x).all():
-                raise AssertionError("no overwrite in %s" % sig)
 
     def _check_1d(self, routine, dtype, shape, axis, overwritable_dtypes):
         np.random.seed(1234)


### PR DESCRIPTION
The overwrite may not happen if f2py decides to make copies e.g. due to
aligment. The purpose of the test is to check only that no spurious
overwrites occur.

Fixes part of gh-2890

Needs backport.
