### PR TITLE
Misc fixes pointed out by Eclipse PyDev static code analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 .deps
 .libs
 .tox
+.project
+.pydevproject
+.settings
 cythonize.dat
 _configtest.c
 build.log

--- a/doc/source/tutorial/csgraph.rst
+++ b/doc/source/tutorial/csgraph.rst
@@ -1,5 +1,5 @@
-Compressed Sparse Graph Routines `scipy.sparse.csgraph`
-=======================================================
+Compressed Sparse Graph Routines (`scipy.sparse.csgraph`)
+=========================================================
 
 .. sectionauthor:: Jake Vanderplas <vanderplas@astro.washington.edu>
 

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -1052,7 +1052,7 @@ def dblint(xa,xb,ya,yb,tck):
         The value of the resulting integral.
     """
     tx,ty,c,kx,ky = tck
-    return dfitpack.dblint(tx,ty,c,kx,ky,xb,xe,yb,ye)
+    return dfitpack.dblint(tx,ty,c,kx,ky,xa,xb,ya,yb)
 
 
 def insert(x,tck,m=1,per=0):

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -238,19 +238,19 @@ class KDTree(object):
     class node(object):
         if sys.version_info[0] >= 3:
             def __lt__(self, other):
-                id(self) < id(other)
+                return id(self) < id(other)
 
             def __gt__(self, other):
-                id(self) > id(other)
+                return id(self) > id(other)
 
             def __le__(self, other):
-                id(self) <= id(other)
+                return id(self) <= id(other)
 
             def __ge__(self, other):
-                id(self) >= id(other)
+                return id(self) >= id(other)
 
             def __eq__(self, other):
-                id(self) == id(other)
+                return id(self) == id(other)
 
     class leafnode(node):
         def __init__(self, idx):

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -714,6 +714,13 @@ def test_ball_point_ints():
     assert_equal(sorted([4, 8, 9, 12]),
                  sorted(tree.query_ball_point((2, 0), 1)))
 
+
+def test_kdtree_comparisons():
+    """Regression test: node comparisons were done wrong in 0.12 w/Py3."""
+    nodes = [KDTree.node() for _ in range(3)]
+    assert_equal(sorted(nodes), sorted(nodes[::-1]))
+
+
 # cKDTree is specialized to type double points, so no need to make
 # a unit test corresponding to test_ball_point_ints()
 

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -784,7 +784,6 @@ def ttest_ind(a, b, axis=0):
     (n1, n2) = (a.count(axis), b.count(axis))
     df = n1+n2-2
     svar = ((n1-1)*v1+(n2-1)*v2) / float(df)
-    svar == 0
     t = (x1-x2)/ma.sqrt(svar*(1.0/n1 + 1.0/n2))  # N-D COMPUTATION HERE!!!!!!
     t = ma.filled(t, 1)           # replace NaN t-values with 1.0
     probs = betai(0.5*df,0.5,float(df)/(df+t*t)).reshape(t.shape)

--- a/scipy/weave/base_info.py
+++ b/scipy/weave/base_info.py
@@ -148,9 +148,6 @@ class info_list(UserList.UserList):
     def define_macros(self):
         return self.get_unique_values('define_macros')
 
-    def sources(self):
-        return self.get_unique_values('sources')
-
     def warnings(self):
         return self.get_unique_values('warnings')
 

--- a/scipy/weave/cpp_namespace_spec.py
+++ b/scipy/weave/cpp_namespace_spec.py
@@ -79,7 +79,7 @@ class cpp_namespace_converter(base_converter):
     def type_match(self,value):
         try:
             cpp_ident = value.split('_')[2]
-            if self.namespace in cpp.ident:
+            if self.namespace in cpp_ident:
                 return 1
         except:
             pass


### PR DESCRIPTION
Here's fixes for a few scipy issues pointed out by my editor (Eclipse PyDev).
I'm not familiar with the code and didn't test, so please check the changes carefully.

There's two more that I think might be real issues where I don't know what the correct fix is:

```
Description Resource    Path    Location    Type
Undefined variable: get_psolve  iterative.py    /scipy/scipy/sparse/linalg/isolve   line 198    PyDev Problem
Undefined variable: ct  hb.py   /scipy/scipy/io/harwell_boeing  line 257    PyDev Problem
```

https://coveralls.io/files/59355318#L199
https://coveralls.io/files/59355112#L258

All of these issues are not covered by unit tests.
