### PR TITLE
ENH: allow non-monotonic input in interp1d

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -268,7 +268,7 @@ class interp2d(object):
 class interp1d(_Interpolator1D):
     """
     interp1d(x, y, kind='linear', axis=-1, copy=True, bounds_error=True,
-             assume_sorted=False, fill_value=np.nan)
+             fill_value=np.nan, assume_sorted=False)
 
     Interpolate a 1-D function.
 
@@ -301,13 +301,14 @@ class interp1d(_Interpolator1D):
         a value outside of the range of x (where extrapolation is
         necessary). If False, out of bounds values are assigned `fill_value`.
         By default, an error is raised.
-    assume_sorted : bool, optional
-        If False, values of `x` can be in any order and they are sorted first.
-	If True, `x` has to be an array of monotonically increasing values.    
     fill_value : float, optional
         If provided, then this value will be used to fill in for requested
         points outside of the data range. If not provided, then the default
         is NaN.
+    assume_sorted : bool, optional
+        If False, values of `x` can be in any order and they are sorted first.
+	If True, `x` has to be an array of monotonically increasing values.    
+
 
     See Also
     --------
@@ -331,8 +332,8 @@ class interp1d(_Interpolator1D):
     """
 
     def __init__(self, x, y, kind='linear', axis=-1,
-                 copy=True, bounds_error=True, assume_sorted=False,
-                 fill_value=np.nan):
+                 copy=True, bounds_error=True, fill_value=np.nan,
+                 assume_sorted=False):
         """ Initialize a 1D linear interpolation class."""
         _Interpolator1D.__init__(self, x, y, axis=axis)
 

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -353,8 +353,7 @@ class interp1d(_Interpolator1D):
         x = array(x, copy=self.copy)
         y = array(y, copy=self.copy)
 
-
-	if not assume_sorted:
+        if not assume_sorted:
             ind = np.argsort(x)
             x = x[ind]
             np.take(y,ind,axis=axis,out=y)

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -332,7 +332,7 @@ class interp1d(_Interpolator1D):
 
     def __init__(self, x, y, kind='linear', axis=-1,
                  copy=True, bounds_error=True, assume_sorted=False,
-		 fill_value=np.nan):
+                 fill_value=np.nan):
         """ Initialize a 1D linear interpolation class."""
         _Interpolator1D.__init__(self, x, y, axis=axis)
 
@@ -355,9 +355,9 @@ class interp1d(_Interpolator1D):
 
 
 	if not assume_sorted:
-		ind = np.argsort(x)
-		x = x[ind]
-		np.take(y,ind,axis=axis,out=y)
+            ind = np.argsort(x)
+            x = x[ind]
+            np.take(y,ind,axis=axis,out=y)
 
         if x.ndim != 1:
             raise ValueError("the x array must have exactly one dimension.")

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -268,7 +268,7 @@ class interp2d(object):
 class interp1d(_Interpolator1D):
     """
     interp1d(x, y, kind='linear', axis=-1, copy=True, bounds_error=True,
-             fill_value=np.nan)
+             assume_sorted=False, fill_value=np.nan)
 
     Interpolate a 1-D function.
 
@@ -279,7 +279,7 @@ class interp1d(_Interpolator1D):
     Parameters
     ----------
     x : (N,) array_like
-        A 1-D array of monotonically increasing real values.
+        A 1-D array of real values.
     y : (...,N,...) array_like
         A N-D array of real values. The length of `y` along the interpolation
         axis must be equal to the length of `x`.
@@ -301,6 +301,9 @@ class interp1d(_Interpolator1D):
         a value outside of the range of x (where extrapolation is
         necessary). If False, out of bounds values are assigned `fill_value`.
         By default, an error is raised.
+    assume_sorted : bool, optional
+        If False, values of `x` can be in any order and they are sorted first.
+	If True, `x` has to be an array of monotonically increasing values.    
     fill_value : float, optional
         If provided, then this value will be used to fill in for requested
         points outside of the data range. If not provided, then the default
@@ -328,7 +331,8 @@ class interp1d(_Interpolator1D):
     """
 
     def __init__(self, x, y, kind='linear', axis=-1,
-                 copy=True, bounds_error=True, fill_value=np.nan):
+                 copy=True, bounds_error=True, assume_sorted=False,
+		 fill_value=np.nan):
         """ Initialize a 1D linear interpolation class."""
         _Interpolator1D.__init__(self, x, y, axis=axis)
 
@@ -348,6 +352,12 @@ class interp1d(_Interpolator1D):
                                       "routines for other types." % kind)
         x = array(x, copy=self.copy)
         y = array(y, copy=self.copy)
+
+
+	if not assume_sorted:
+		ind = np.argsort(x)
+		x = x[ind]
+		np.take(y,ind,axis=axis,out=y)
 
         if x.ndim != 1:
             raise ValueError("the x array must have exactly one dimension.")

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -171,6 +171,28 @@ class TestInterp1D(object):
             self.y210,
         )
 
+
+    def test_sorting(self):
+        """ Check for unsorted arrays
+        """
+
+        interp10 = interp1d(self.x10, self.y10)
+	interp10_unsorted = interp1d(self.x10[::-1], self.y10[::-1])		
+
+        assert_array_almost_equal(
+            interp10_unsorted(self.x10),
+            self.y10,
+        )
+        assert_array_almost_equal(
+            interp10_unsorted(1.2),
+            np.array([1.2]),
+        )
+        assert_array_almost_equal(
+            interp10_unsorted([2.4, 5.6, 6.0]),
+            interp10([2.4, 5.6, 6.0]),
+        )
+
+
     def test_linear(self):
         """ Check the actual implementation of linear interpolation.
         """

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -177,7 +177,7 @@ class TestInterp1D(object):
         """
 
         interp10 = interp1d(self.x10, self.y10)
-	interp10_unsorted = interp1d(self.x10[::-1], self.y10[::-1])		
+        interp10_unsorted = interp1d(self.x10[::-1], self.y10[::-1])		
 
         assert_array_almost_equal(
             interp10_unsorted(self.x10),


### PR DESCRIPTION
I added sorting to interpolate.interp1d, so the values of x array might be in any order. I also added a new keyword argument assume_sorted=False, if assume_sorted==True, the sorting is omitted. Not sure if the way of sorting is the best one. 
I added a unit test, that checks if the behavior for unsorted arrays is the same as for sorted ones.

These are my first changes to the code, so please let me know if something should be done in a different way/place etc. 
