### PR TITLE
Docstring formatting at top-level leads to failed import

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1160,7 +1160,9 @@ def trim(a, limits=None, inclusive=(True,True), relative=False, axis=None):
         return trimr(a, limits=limits, inclusive=inclusive, axis=axis)
     else:
         return trima(a, limits=limits, inclusive=inclusive)
-trim.__doc__ = trim.__doc__ % trimdoc
+
+if trim.__doc__ is not None:
+    trim.__doc__ = trim.__doc__ % trimdoc
 
 
 def trimboth(data, proportiontocut=0.2, inclusive=(True,True), axis=None):


### PR DESCRIPTION
When Python is running with -OO, the doctsrings are removed at compile time and all **doc** references become None. The line below leads to a failed import in applications that use the optimization by default, like uwsgi with optimize=1 or 2.
