### PR TITLE
Guarantee oriented simplices for 2D delaunay

### DIFF
--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -43,7 +43,7 @@ cdef extern from "setjmp.h" nogil:
 # Define the clockwise constant
 cdef extern from "qhull/src/user.h":
     cdef enum:
-        qh_ORIENTclock = 0
+        qh_ORIENTclock
 
 cdef extern from "qhull/src/qset.h":
     ctypedef union setelemT:

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -179,7 +179,7 @@ class TestUtilities(object):
         # |1 \|
         # +---+
 
-        assert_equal(tri.vertices, [[3, 1, 2], [3, 1, 0]])
+        assert_equal(tri.vertices, [[1, 3, 2], [3, 1, 0]])
 
         for p in [(0.25, 0.25, 1),
                   (0.75, 0.75, 0),
@@ -227,7 +227,7 @@ class TestUtilities(object):
         # |1 \|
         # +---+
 
-        assert_equal(tri.convex_hull, [[1, 2], [3, 2], [1, 0], [3, 0]])
+        assert_equal(tri.convex_hull, [[3, 2], [1, 2], [1, 0], [3, 0]])
 
     def _check_barycentric_transforms(self, tri, err_msg="",
                                       unit_cube=False,
@@ -417,7 +417,7 @@ class TestDelaunay(object):
         points = np.array([(0,0), (0,1), (1,1), (1,0)], dtype=np.double)
         tri = qhull.Delaunay(points)
 
-        assert_equal(tri.vertices, [[3, 1, 2], [3, 1, 0]])
+        assert_equal(tri.vertices, [[1, 3, 2], [3, 1, 0]])
         assert_equal(tri.neighbors, [[-1, -1, 1], [-1, -1, 0]])
 
     def test_duplicate_points(self):
@@ -472,7 +472,7 @@ class TestDelaunay(object):
         points = [(0, 0), (0, 1), (1, 0), (0.5, 0.5), (1.1, 1.1)]
         tri = qhull.Delaunay(points, furthest_site=True)
 
-        expected = np.array([(1, 4, 0), (2, 4, 0)])  # from Qhull
+        expected = np.array([(1, 4, 0), (4, 2, 0)])  # from Qhull
         assert_array_equal(tri.simplices, expected)
 
     def test_incremental(self):


### PR DESCRIPTION
This commit updates the existing Delaunay code in order to ensure
that 2D triangulations maintain a consistent ordering. This
is similar to specifying the 'i' flag in QHull. This brings
the behaviour inline with Matlab, and is the most sensible output
for 2D triangulations.

This is achieved by swapping the first and second indices if
the orientation of the facet is clockwise. The logic is written
to try and minimise the impact on higher order triangulations.

Also note that the neighbours need to be swapped to maintain
the opposite vertex requirement.
