### PR TITLE
Collection of fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 #   http://lint.travis-ci.org/
 language: python
 python:
-  - 2.6
   - 3.3
 matrix:
   include:
@@ -10,6 +9,10 @@ matrix:
       env:
         - TESTMODE=full
         - COVERAGE=--coverage
+    - python: 2.6
+      env:
+        - TESTMODE=fast
+        - OPTIMIZE=-OO
 before_install:
   - uname -a
   - free -m
@@ -31,7 +34,7 @@ before_install:
   - python -V
   - popd
 script:
-  - python runtests.py -g -m $TESTMODE $COVERAGE
+  - python $OPTIMIZE runtests.py -g -m $TESTMODE $COVERAGE
 env:
   - TESTMODE=fast
 notifications:

--- a/runtests.py
+++ b/runtests.py
@@ -29,7 +29,12 @@ EXTRA_PATH = ['/usr/lib/ccache', '/usr/lib/f90cache',
 
 # ---------------------------------------------------------------------
 
-__doc__ = __doc__.format(**globals())
+
+if __doc__ is None:
+    __doc__ = "Run without -OO if you want usage info"
+else:
+    __doc__ = __doc__.format(**globals())
+
 
 import sys
 import os
@@ -126,7 +131,7 @@ def main(argv):
         fn = os.path.join(dst_dir, 'coverage_html.js')
         if os.path.isdir(dst_dir) and os.path.isfile(fn):
             shutil.rmtree(dst_dir)
-        extra_argv += ['--cover-html', 
+        extra_argv += ['--cover-html',
                        '--cover-html-dir='+dst_dir]
 
     if args.build_only:

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -10,7 +10,6 @@ import warnings
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal, \
         TestCase, run_module_suite, assert_raises
-from numpy.testing.utils import WarningManager
 
 from scipy.cluster.vq import kmeans, kmeans2, py_vq, py_vq2, vq, ClusterError
 try:
@@ -114,22 +113,17 @@ class TestKMean(TestCase):
         assert_array_almost_equal(code1, CODET2)
 
     def test_kmeans_lost_cluster(self):
-        """This will cause kmean to have a cluster with no points."""
+        # This will cause kmean to have a cluster with no points.
         data = np.fromfile(DATAFILE1, sep=", ")
         data = data.reshape((200, 2))
         initk = np.array([[-1.8127404, -0.67128041],
                          [2.04621601, 0.07401111],
                          [-2.31149087,-0.05160469]])
 
-        res = kmeans(data, initk)
-
-        warn_ctx = WarningManager()
-        warn_ctx.__enter__()
-        try:
+        kmeans(data, initk)
+        with warnings.catch_warnings():
             warnings.simplefilter('ignore', UserWarning)
-            res = kmeans2(data, initk, missing='warn')
-        finally:
-            warn_ctx.__exit__()
+            kmeans2(data, initk, missing='warn')
 
         assert_raises(ClusterError, kmeans2, data, initk, missing='raise')
 
@@ -172,15 +166,11 @@ class TestKMean(TestCase):
         kmeans2(data[:, :1], 3, minit='points')  # special case (1-D)
 
         # minit='random' can give warnings, filter those
-        warn_ctx = WarningManager()
-        warn_ctx.__enter__()
-        try:
+        with warnings.catch_warnings():
             warnings.filterwarnings('ignore',
                         message="One of the clusters is empty. Re-run")
             kmeans2(data, 3, minit='random')
             kmeans2(data[:, :1], 3, minit='random')  # special case (1-D)
-        finally:
-            warn_ctx.__exit__()
 
     def test_kmeans2_empty(self):
         """Ticket #505."""

--- a/scipy/constants/__init__.py
+++ b/scipy/constants/__init__.py
@@ -295,7 +295,9 @@ _constant_names = [(_k.lower(), _k, _v)
 _constant_names = "\n".join(["``%s``%s  %s %s" % (_x[1], " "*(66-len(_x[1])),
                                                   _x[2][0], _x[2][1])
                              for _x in sorted(_constant_names)])
-__doc__ = __doc__ % dict(constant_names=_constant_names)
+if __doc__ is not None:
+    __doc__ = __doc__ % dict(constant_names=_constant_names)
+
 del _constant_names
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/scipy/constants/tests/test_codata.py
+++ b/scipy/constants/tests/test_codata.py
@@ -3,15 +3,12 @@ from __future__ import division, print_function, absolute_import
 import warnings
 
 from scipy.constants import constants, codata, find, value
-from numpy.testing import assert_equal, assert_, run_module_suite, \
-                          assert_almost_equal
-from numpy.testing.utils import WarningManager
+from numpy.testing import (assert_equal, assert_, run_module_suite,
+                           assert_almost_equal)
 
 
 def test_find():
-    warn_ctx = WarningManager()
-    warn_ctx.__enter__()
-    try:
+    with warnings.catch_warnings():
         warnings.simplefilter('ignore', DeprecationWarning)
 
         keys = find('weak mixing', disp=False)
@@ -31,8 +28,6 @@ def test_find():
                                     'natural unit of mom.um in MeV/c',
                                     'natural unit of length',
                                     'natural unit of time']))
-    finally:
-        warn_ctx.__exit__()
 
 
 def test_basic_table_parse():

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -1,14 +1,13 @@
 from __future__ import division, print_function, absolute_import
 
 import os
-import warnings
 
 import numpy as np
-from numpy.testing import assert_equal, assert_allclose, assert_, \
-    TestCase, assert_raises
+from numpy.testing import (assert_equal, assert_allclose, assert_,
+    TestCase, assert_raises, run_module_suite)
 from numpy import array, asarray, pi, sin, cos, arange, dot, ravel, sqrt, round
-from scipy.interpolate.fitpack import splrep, splev, bisplrep, bisplev, \
-     sproot, splprep, splint, spalde, splder, splantider, insert
+from scipy.interpolate.fitpack import (splrep, splev, bisplrep, bisplev,
+     sproot, splprep, splint, spalde, splder, splantider, insert)
 
 
 def data_file(basename):
@@ -358,6 +357,4 @@ class TestBisplrep(object):
 
 
 if __name__ == "__main__":
-    __put_prints = True
-    import nose
-    nose.runmodule()
+    run_module_suite()

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -7,8 +7,7 @@ import warnings
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal, assert_array_equal, \
         assert_array_almost_equal, assert_allclose, TestCase, run_module_suite
-from numpy.testing.utils import WarningManager
-from numpy import array, diff, linspace, meshgrid, ones, pi, roll, shape
+from numpy import array, diff, linspace, meshgrid, ones, pi, shape
 from scipy.interpolate.fitpack import bisplrep, bisplev
 from scipy.interpolate.fitpack2 import UnivariateSpline, \
     LSQBivariateSpline, SmoothBivariateSpline, RectBivariateSpline, \
@@ -113,17 +112,12 @@ class TestLSQBivariateSpline(TestCase):
         s = 0.1
         tx = [1+s,3-s]
         ty = [1+s,3-s]
-        warn_ctx = WarningManager()
-        warn_ctx.__enter__()
-        try:
+        with warnings.catch_warnings():
             # This seems to fail (ier=1, see ticket 1642).
             warnings.simplefilter('ignore', UserWarning)
             lut = LSQBivariateSpline(x,y,z,tx,ty,kx=1,ky=1)
-        finally:
-            warn_ctx.__exit__()
 
         tx, ty = lut.get_knots()
-
         for xa, xb in zip(tx[:-1], tx[1:]):
             for ya, yb in zip(ty[:-1], ty[1:]):
                 for t in [0.1, 0.5, 0.9]:
@@ -193,14 +187,10 @@ class TestSmoothBivariateSpline(TestCase):
         y = [1,2,3,1,2,3,1,2,3]
         z = array([0,7,8,3,4,7,1,3,4])
 
-        warn_ctx = WarningManager()
-        warn_ctx.__enter__()
-        try:
+        with warnings.catch_warnings():
             # This seems to fail (ier=1, see ticket 1642).
             warnings.simplefilter('ignore', UserWarning)
             lut = SmoothBivariateSpline(x, y, z, kx=1, ky=1, s=0)
-        finally:
-            warn_ctx.__exit__()
 
         tx = [1,2,4]
         ty = [1,2,3]

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -12,11 +12,12 @@ else:
 
 import numpy as np
 
-from numpy.testing import TestCase, assert_array_almost_equal, assert_equal, \
-        assert_, assert_raises
+from numpy.testing import (TestCase, assert_array_almost_equal, assert_equal,
+        assert_, assert_raises, run_module_suite)
 
 from scipy.io.arff.arffread import loadarff
 from scipy.io.arff.arffread import read_header, parse_type, ParseArffError
+
 
 data_path = pjoin(os.path.dirname(__file__), 'data')
 
@@ -116,5 +117,4 @@ class HeaderTest(TestCase):
         assert_(attrs[4][1] == '{class0, class1, class2, class3}')
 
 if __name__ == "__main__":
-    import nose
-    nose.run(argv=['', __file__])
+    run_module_suite()

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -20,10 +20,8 @@ import shutil
 import gzip
 
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_equal, assert_raises, run_module_suite)
-from numpy.testing.utils import WarningManager
-
-from nose.tools import assert_true
+                           assert_equal, assert_raises, run_module_suite,
+                           assert_)
 
 import numpy as np
 from numpy import array
@@ -251,16 +249,16 @@ def types_compatible(var1, var2):
 def _check_level(label, expected, actual):
     """ Check one level of a potentially nested array """
     if SP.issparse(expected):  # allow different types of sparse matrices
-        assert_true(SP.issparse(actual))
+        assert_(SP.issparse(actual))
         assert_array_almost_equal(actual.todense(),
                                   expected.todense(),
                                   err_msg=label,
                                   decimal=5)
         return
     # Check types are as expected
-    assert_true(types_compatible(expected, actual),
-           "Expected type %s, got %s at %s" %
-                (type(expected), type(actual), label))
+    assert_(types_compatible(expected, actual),
+            "Expected type %s, got %s at %s" %
+            (type(expected), type(actual), label))
     # A field in a record array may not be an ndarray
     # A scalar from a record array will be type np.void
     if not isinstance(expected,
@@ -268,11 +266,10 @@ def _check_level(label, expected, actual):
         assert_equal(expected, actual)
         return
     # This is an ndarray-like thing
-    assert_true(expected.shape == actual.shape,
-                msg='Expected shape %s, got %s at %s' % (expected.shape,
-                                                         actual.shape,
-                                                         label)
-                )
+    assert_(expected.shape == actual.shape,
+            msg='Expected shape %s, got %s at %s' % (expected.shape,
+                                                     actual.shape,
+                                                     label))
     ex_dtype = expected.dtype
     if ex_dtype.hasobject:  # array of objects
         if isinstance(expected, MatlabObject):
@@ -302,7 +299,7 @@ def _load_check_case(name, files, case):
         label = "test %s; file %s" % (name, file_name)
         for k, expected in case.items():
             k_label = "%s, variable %s" % (label, k)
-            assert_true(k in matdict, "Missing key at %s" % k_label)
+            assert_(k in matdict, "Missing key at %s" % k_label)
             _check_level(k_label, expected, matdict[k])
 
 
@@ -338,8 +335,8 @@ def test_load():
         expected = case['expected']
         filt = pjoin(test_data_path, 'test%s_*.mat' % name)
         files = glob(filt)
-        assert_true(len(files) > 0,
-                    "No files for test %s using filter %s" % (name, filt))
+        assert_(len(files) > 0,
+                "No files for test %s using filter %s" % (name, filt))
         yield _load_check_case, name, files, expected
 
 
@@ -351,8 +348,8 @@ def test_whos():
         classes = case['classes']
         filt = pjoin(test_data_path, 'test%s_*.mat' % name)
         files = glob(filt)
-        assert_true(len(files) > 0,
-                    "No files for test %s using filter %s" % (name, filt))
+        assert_(len(files) > 0,
+                "No files for test %s using filter %s" % (name, filt))
         yield _whos_check_case, name, files, expected, classes
 
 
@@ -427,7 +424,7 @@ def test_mat73():
     # Check any hdf5 files raise an error
     filenames = glob(
         pjoin(test_data_path, 'testhdf5*.mat'))
-    assert_true(len(filenames) > 0)
+    assert_(len(filenames) > 0)
     for filename in filenames:
         fp = open(filename, 'rb')
         assert_raises(NotImplementedError,
@@ -548,12 +545,12 @@ def test_use_small_element():
     sio.truncate(0)
     sio.seek(0)
     wtr.put_variables({'aaaa': arr})
-    yield assert_true, w_sz - len(sio.getvalue()) > 4
+    yield assert_, w_sz - len(sio.getvalue()) > 4
     # Whereas increasing name size makes less difference
     sio.truncate(0)
     sio.seek(0)
     wtr.put_variables({'aaaaaa': arr})
-    yield assert_true, len(sio.getvalue()) - w_sz < 4
+    yield assert_, len(sio.getvalue()) - w_sz < 4
 
 
 def test_save_dict():
@@ -622,7 +619,7 @@ def test_compression():
     compressed_len = len(stream.getvalue())
     vals = loadmat(stream)
     yield assert_array_equal, vals['arr'], arr
-    yield assert_true, raw_len > compressed_len
+    yield assert_, raw_len > compressed_len
     # Concatenate, test later
     arr2 = arr.copy()
     arr2[0,0] = 1
@@ -657,8 +654,8 @@ def test_skip_variable():
     # Prove that it loads with loadmat
     #
     d = loadmat(filename, struct_as_record=True)
-    yield assert_true, 'first' in d
-    yield assert_true, 'second' in d
+    yield assert_, 'first' in d
+    yield assert_, 'second' in d
     #
     # Make the factory
     #
@@ -667,7 +664,7 @@ def test_skip_variable():
     # This is where the factory breaks with an error in MatMatrixGetter.to_next
     #
     d = factory.get_variables('second')
-    yield assert_true, 'second' in d
+    yield assert_, 'second' in d
     factory.mat_stream.close()
 
 
@@ -680,7 +677,7 @@ def test_empty_struct():
     a = d['a']
     assert_equal(a.shape, (1,1))
     assert_equal(a.dtype, np.dtype(np.object))
-    assert_true(a[0,0] is None)
+    assert_(a[0,0] is None)
     stream = BytesIO()
     arr = np.array((), dtype='U')
     # before ticket fix, this used to give data type not understood
@@ -870,7 +867,7 @@ def test_func_read():
     rdr = MatFile5Reader(fp)
     d = rdr.get_variables()
     fp.close()
-    assert_true(isinstance(d['testfunc'], MatlabFunction))
+    assert_(isinstance(d['testfunc'], MatlabFunction))
     stream = BytesIO()
     wtr = MatFile5Writer(stream)
     assert_raises(MatWriteError, wtr.put_variables, d)
@@ -919,9 +916,9 @@ def test_scalar_squeeze():
     in_d = {'scalar': [[0.1]], 'string': 'my name', 'st':{'one':1, 'two':2}}
     savemat(stream, in_d)
     out_d = loadmat(stream, squeeze_me=True)
-    assert_true(isinstance(out_d['scalar'], float))
-    assert_true(isinstance(out_d['string'], string_types))
-    assert_true(isinstance(out_d['st'], np.ndarray))
+    assert_(isinstance(out_d['scalar'], float))
+    assert_(isinstance(out_d['string'], string_types))
+    assert_(isinstance(out_d['st'], np.ndarray))
 
 
 def test_str_round():

--- a/scipy/io/tests/test_idl.py
+++ b/scipy/io/tests/test_idl.py
@@ -6,9 +6,8 @@ import warnings
 DATA_PATH = path.join(path.dirname(__file__), 'data')
 
 import numpy as np
-from numpy.testing import assert_equal, assert_array_equal, run_module_suite
-from numpy.testing.utils import WarningManager
-from nose.tools import assert_true
+from numpy.testing import (assert_equal, assert_array_equal, run_module_suite,
+    assert_)
 
 from scipy.io.idl import readsav
 
@@ -48,7 +47,7 @@ class TestIdict:
         original_id = id(custom_dict)
         s = readsav(path.join(DATA_PATH, 'scalar_byte.sav'), idict=custom_dict, verbose=False)
         assert_equal(original_id, id(s))
-        assert_true('a' in s)
+        assert_('a' in s)
         assert_identical(s['a'], np.int16(999))
         assert_identical(s['i8u'], np.uint8(234))
 
@@ -118,13 +117,9 @@ class TestCompressed(TestScalars):
     '''Test that compressed .sav files can be read in'''
 
     def test_compressed(self):
-        warn_ctx = WarningManager()
-        warn_ctx.__enter__()
-        try:
+        with warnings.catch_warnings():
             warnings.filterwarnings('ignore', message="warning: empty strings")
             s = readsav(path.join(DATA_PATH, 'various_compressed.sav'), verbose=False)
-        finally:
-            warn_ctx.__exit__()
 
         assert_identical(s.i8u, np.uint8(234))
         assert_identical(s.f32, np.float32(-3.1234567e+37))
@@ -214,10 +209,10 @@ class TestStructures:
         s = readsav(path.join(DATA_PATH, 'struct_arrays_replicated.sav'), verbose=False)
 
         # Check column types
-        assert_true(s.arrays_rep.a.dtype.type is np.object_)
-        assert_true(s.arrays_rep.b.dtype.type is np.object_)
-        assert_true(s.arrays_rep.c.dtype.type is np.object_)
-        assert_true(s.arrays_rep.d.dtype.type is np.object_)
+        assert_(s.arrays_rep.a.dtype.type is np.object_)
+        assert_(s.arrays_rep.b.dtype.type is np.object_)
+        assert_(s.arrays_rep.c.dtype.type is np.object_)
+        assert_(s.arrays_rep.d.dtype.type is np.object_)
 
         # Check column shapes
         assert_equal(s.arrays_rep.a.shape, (5, ))
@@ -237,10 +232,10 @@ class TestStructures:
         s = readsav(path.join(DATA_PATH, 'struct_arrays_replicated_3d.sav'), verbose=False)
 
         # Check column types
-        assert_true(s.arrays_rep.a.dtype.type is np.object_)
-        assert_true(s.arrays_rep.b.dtype.type is np.object_)
-        assert_true(s.arrays_rep.c.dtype.type is np.object_)
-        assert_true(s.arrays_rep.d.dtype.type is np.object_)
+        assert_(s.arrays_rep.a.dtype.type is np.object_)
+        assert_(s.arrays_rep.b.dtype.type is np.object_)
+        assert_(s.arrays_rep.c.dtype.type is np.object_)
+        assert_(s.arrays_rep.d.dtype.type is np.object_)
 
         # Check column shapes
         assert_equal(s.arrays_rep.a.shape, (4, 3, 2))
@@ -272,7 +267,7 @@ class TestPointers:
         s = readsav(path.join(DATA_PATH, 'scalar_heap_pointer.sav'), verbose=False)
         assert_identical(s.c64_pointer1, np.complex128(1.1987253647623157e+112-5.1987258887729157e+307j))
         assert_identical(s.c64_pointer2, np.complex128(1.1987253647623157e+112-5.1987258887729157e+307j))
-        assert_true(s.c64_pointer1 is s.c64_pointer2)
+        assert_(s.c64_pointer1 is s.c64_pointer2)
 
 
 class TestPointerArray:
@@ -281,50 +276,50 @@ class TestPointerArray:
     def test_1d(self):
         s = readsav(path.join(DATA_PATH, 'array_float32_pointer_1d.sav'), verbose=False)
         assert_equal(s.array1d.shape, (123, ))
-        assert_true(np.all(s.array1d == np.float32(4.)))
-        assert_true(np.all(vect_id(s.array1d) == id(s.array1d[0])))
+        assert_(np.all(s.array1d == np.float32(4.)))
+        assert_(np.all(vect_id(s.array1d) == id(s.array1d[0])))
 
     def test_2d(self):
         s = readsav(path.join(DATA_PATH, 'array_float32_pointer_2d.sav'), verbose=False)
         assert_equal(s.array2d.shape, (22, 12))
-        assert_true(np.all(s.array2d == np.float32(4.)))
-        assert_true(np.all(vect_id(s.array2d) == id(s.array2d[0,0])))
+        assert_(np.all(s.array2d == np.float32(4.)))
+        assert_(np.all(vect_id(s.array2d) == id(s.array2d[0,0])))
 
     def test_3d(self):
         s = readsav(path.join(DATA_PATH, 'array_float32_pointer_3d.sav'), verbose=False)
         assert_equal(s.array3d.shape, (11, 22, 12))
-        assert_true(np.all(s.array3d == np.float32(4.)))
-        assert_true(np.all(vect_id(s.array3d) == id(s.array3d[0,0,0])))
+        assert_(np.all(s.array3d == np.float32(4.)))
+        assert_(np.all(vect_id(s.array3d) == id(s.array3d[0,0,0])))
 
     def test_4d(self):
         s = readsav(path.join(DATA_PATH, 'array_float32_pointer_4d.sav'), verbose=False)
         assert_equal(s.array4d.shape, (4, 5, 8, 7))
-        assert_true(np.all(s.array4d == np.float32(4.)))
-        assert_true(np.all(vect_id(s.array4d) == id(s.array4d[0,0,0,0])))
+        assert_(np.all(s.array4d == np.float32(4.)))
+        assert_(np.all(vect_id(s.array4d) == id(s.array4d[0,0,0,0])))
 
     def test_5d(self):
         s = readsav(path.join(DATA_PATH, 'array_float32_pointer_5d.sav'), verbose=False)
         assert_equal(s.array5d.shape, (4, 3, 4, 6, 5))
-        assert_true(np.all(s.array5d == np.float32(4.)))
-        assert_true(np.all(vect_id(s.array5d) == id(s.array5d[0,0,0,0,0])))
+        assert_(np.all(s.array5d == np.float32(4.)))
+        assert_(np.all(vect_id(s.array5d) == id(s.array5d[0,0,0,0,0])))
 
     def test_6d(self):
         s = readsav(path.join(DATA_PATH, 'array_float32_pointer_6d.sav'), verbose=False)
         assert_equal(s.array6d.shape, (3, 6, 4, 5, 3, 4))
-        assert_true(np.all(s.array6d == np.float32(4.)))
-        assert_true(np.all(vect_id(s.array6d) == id(s.array6d[0,0,0,0,0,0])))
+        assert_(np.all(s.array6d == np.float32(4.)))
+        assert_(np.all(vect_id(s.array6d) == id(s.array6d[0,0,0,0,0,0])))
 
     def test_7d(self):
         s = readsav(path.join(DATA_PATH, 'array_float32_pointer_7d.sav'), verbose=False)
         assert_equal(s.array7d.shape, (2, 1, 2, 3, 4, 3, 2))
-        assert_true(np.all(s.array7d == np.float32(4.)))
-        assert_true(np.all(vect_id(s.array7d) == id(s.array7d[0,0,0,0,0,0,0])))
+        assert_(np.all(s.array7d == np.float32(4.)))
+        assert_(np.all(vect_id(s.array7d) == id(s.array7d[0,0,0,0,0,0,0])))
 
     def test_8d(self):
         s = readsav(path.join(DATA_PATH, 'array_float32_pointer_8d.sav'), verbose=False)
         assert_equal(s.array8d.shape, (4, 3, 2, 1, 2, 3, 5, 4))
-        assert_true(np.all(s.array8d == np.float32(4.)))
-        assert_true(np.all(vect_id(s.array8d) == id(s.array8d[0,0,0,0,0,0,0,0])))
+        assert_(np.all(s.array8d == np.float32(4.)))
+        assert_(np.all(vect_id(s.array8d) == id(s.array8d[0,0,0,0,0,0,0,0])))
 
 
 class TestPointerStructures:
@@ -334,35 +329,35 @@ class TestPointerStructures:
         s = readsav(path.join(DATA_PATH, 'struct_pointers.sav'), verbose=False)
         assert_identical(s.pointers.g, np.array(np.float32(4.), dtype=np.object_))
         assert_identical(s.pointers.h, np.array(np.float32(4.), dtype=np.object_))
-        assert_true(id(s.pointers.g[0]) == id(s.pointers.h[0]))
+        assert_(id(s.pointers.g[0]) == id(s.pointers.h[0]))
 
     def test_pointers_replicated(self):
         s = readsav(path.join(DATA_PATH, 'struct_pointers_replicated.sav'), verbose=False)
         assert_identical(s.pointers_rep.g, np.repeat(np.float32(4.), 5).astype(np.object_))
         assert_identical(s.pointers_rep.h, np.repeat(np.float32(4.), 5).astype(np.object_))
-        assert_true(np.all(vect_id(s.pointers_rep.g) == vect_id(s.pointers_rep.h)))
+        assert_(np.all(vect_id(s.pointers_rep.g) == vect_id(s.pointers_rep.h)))
 
     def test_pointers_replicated_3d(self):
         s = readsav(path.join(DATA_PATH, 'struct_pointers_replicated_3d.sav'), verbose=False)
         assert_identical(s.pointers_rep.g, np.repeat(np.float32(4.), 24).reshape(4, 3, 2).astype(np.object_))
         assert_identical(s.pointers_rep.h, np.repeat(np.float32(4.), 24).reshape(4, 3, 2).astype(np.object_))
-        assert_true(np.all(vect_id(s.pointers_rep.g) == vect_id(s.pointers_rep.h)))
+        assert_(np.all(vect_id(s.pointers_rep.g) == vect_id(s.pointers_rep.h)))
 
     def test_arrays(self):
         s = readsav(path.join(DATA_PATH, 'struct_pointer_arrays.sav'), verbose=False)
         assert_array_identical(s.arrays.g[0], np.repeat(np.float32(4.), 2).astype(np.object_))
         assert_array_identical(s.arrays.h[0], np.repeat(np.float32(4.), 3).astype(np.object_))
-        assert_true(np.all(vect_id(s.arrays.g[0]) == id(s.arrays.g[0][0])))
-        assert_true(np.all(vect_id(s.arrays.h[0]) == id(s.arrays.h[0][0])))
-        assert_true(id(s.arrays.g[0][0]) == id(s.arrays.h[0][0]))
+        assert_(np.all(vect_id(s.arrays.g[0]) == id(s.arrays.g[0][0])))
+        assert_(np.all(vect_id(s.arrays.h[0]) == id(s.arrays.h[0][0])))
+        assert_(id(s.arrays.g[0][0]) == id(s.arrays.h[0][0]))
 
     def test_arrays_replicated(self):
 
         s = readsav(path.join(DATA_PATH, 'struct_pointer_arrays_replicated.sav'), verbose=False)
 
         # Check column types
-        assert_true(s.arrays_rep.g.dtype.type is np.object_)
-        assert_true(s.arrays_rep.h.dtype.type is np.object_)
+        assert_(s.arrays_rep.g.dtype.type is np.object_)
+        assert_(s.arrays_rep.h.dtype.type is np.object_)
 
         # Check column shapes
         assert_equal(s.arrays_rep.g.shape, (5, ))
@@ -372,21 +367,20 @@ class TestPointerStructures:
         for i in range(5):
             assert_array_identical(s.arrays_rep.g[i], np.repeat(np.float32(4.), 2).astype(np.object_))
             assert_array_identical(s.arrays_rep.h[i], np.repeat(np.float32(4.), 3).astype(np.object_))
-            assert_true(np.all(vect_id(s.arrays_rep.g[i]) == id(s.arrays_rep.g[0][0])))
-            assert_true(np.all(vect_id(s.arrays_rep.h[i]) == id(s.arrays_rep.h[0][0])))
+            assert_(np.all(vect_id(s.arrays_rep.g[i]) == id(s.arrays_rep.g[0][0])))
+            assert_(np.all(vect_id(s.arrays_rep.h[i]) == id(s.arrays_rep.h[0][0])))
 
     def test_arrays_replicated_3d(self):
-        warn_ctx = WarningManager()
-        warn_ctx.__enter__()
-        try:
-            warnings.filterwarnings('ignore', message="warning: multi-dimensional structures")
-            s = readsav(path.join(DATA_PATH, 'struct_pointer_arrays_replicated_3d.sav'), verbose=False)
-        finally:
-            warn_ctx.__exit__()
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore',
+                    message="warning: multi-dimensional structures")
+            s = readsav(path.join(DATA_PATH,
+                                  'struct_pointer_arrays_replicated_3d.sav'),
+                        verbose=False)
 
         # Check column types
-        assert_true(s.arrays_rep.g.dtype.type is np.object_)
-        assert_true(s.arrays_rep.h.dtype.type is np.object_)
+        assert_(s.arrays_rep.g.dtype.type is np.object_)
+        assert_(s.arrays_rep.h.dtype.type is np.object_)
 
         # Check column shapes
         assert_equal(s.arrays_rep.g.shape, (4, 3, 2))
@@ -398,8 +392,8 @@ class TestPointerStructures:
                 for k in range(2):
                     assert_array_identical(s.arrays_rep.g[i, j, k], np.repeat(np.float32(4.), 2).astype(np.object_))
                     assert_array_identical(s.arrays_rep.h[i, j, k], np.repeat(np.float32(4.), 3).astype(np.object_))
-                    assert_true(np.all(vect_id(s.arrays_rep.g[i, j, k]) == id(s.arrays_rep.g[0, 0, 0][0])))
-                    assert_true(np.all(vect_id(s.arrays_rep.h[i, j, k]) == id(s.arrays_rep.h[0, 0, 0][0])))
+                    assert_(np.all(vect_id(s.arrays_rep.g[i, j, k]) == id(s.arrays_rep.g[0, 0, 0][0])))
+                    assert_(np.all(vect_id(s.arrays_rep.h[i, j, k]) == id(s.arrays_rep.h[0, 0, 0][0])))
 
 
 if __name__ == "__main__":

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -6,8 +6,9 @@ import warnings
 from io import BytesIO
 
 import numpy as np
-from numpy.testing import assert_equal, assert_, assert_raises, assert_array_equal
-from numpy.testing.utils import WarningManager
+from numpy.testing import (assert_equal, assert_, assert_raises,
+    assert_array_equal, run_module_suite)
+
 from scipy.io import wavfile
 
 
@@ -17,14 +18,10 @@ def datafile(fn):
 
 def test_read_1():
     for mmap in [False, True]:
-        warn_ctx = WarningManager()
-        warn_ctx.__enter__()
-        try:
+        with warnings.catch_warnings():
             warnings.simplefilter('ignore', wavfile.WavFileWarning)
             rate, data = wavfile.read(datafile('test-44100-le-1ch-4bytes.wav'),
                                       mmap=mmap)
-        finally:
-            warn_ctx.__exit__()
 
         assert_equal(rate, 44100)
         assert_(np.issubdtype(data.dtype, np.int32))
@@ -109,3 +106,7 @@ def test_write_roundtrip():
                         for channels in (1, 2, 5):
                             dt = np.dtype('%s%s%s' % (endianness, dtypechar, size))
                             yield _check_roundtrip, realfile, rate, dt, channels
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/scipy/lib/blas/tests/test_blas.py
+++ b/scipy/lib/blas/tests/test_blas.py
@@ -16,9 +16,8 @@ import math
 import warnings
 
 from numpy import array
-from numpy.testing import assert_equal, assert_almost_equal, \
-        assert_array_almost_equal, TestCase, run_module_suite
-from numpy.testing.utils import WarningManager
+from numpy.testing import (assert_equal, assert_almost_equal,
+        assert_array_almost_equal, TestCase, run_module_suite)
 from scipy.lib.blas import fblas
 from scipy.lib.blas import cblas
 from scipy.lib.blas import get_blas_funcs
@@ -238,13 +237,9 @@ class TestBLAS(TestCase):
         b = array([[1],[1],[1]])
 
         # get_blas_funcs is deprecated, silence the warning
-        warn_ctx = WarningManager()
-        warn_ctx.__enter__()
-        try:
+        with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
             gemm, = get_blas_funcs(('gemm',),(a,b))
-        finally:
-            warn_ctx.__exit__()
 
         assert_array_almost_equal(gemm(1,a,b),[[3]],15)
 

--- a/scipy/misc/tests/test_doccer.py
+++ b/scipy/misc/tests/test_doccer.py
@@ -2,9 +2,13 @@
 
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import assert_equal
+import sys
+from numpy.testing import assert_equal, dec
 
 from scipy.misc import doccer
+
+# python -OO strips docstrings
+DOCSTRINGS_STRIPPED = sys.flags.optimize > 1
 
 docstring = \
 """Docstring
@@ -62,6 +66,7 @@ def test_docformat():
    with some indent"""
 
 
+@dec.skipif(DOCSTRINGS_STRIPPED)
 def test_decorator():
     # with unindentation of parameters
     decorator = doccer.filldoc(doc_dict, True)
@@ -90,10 +95,10 @@ def test_decorator():
         """
 
 
+@dec.skipif(DOCSTRINGS_STRIPPED)
 def test_inherit_docstring_from():
 
     class Foo(object):
-
         def func(self):
             '''Do something useful.'''
             return
@@ -102,7 +107,6 @@ def test_inherit_docstring_from():
             '''Something else.'''
 
     class Bar(Foo):
-
         @doccer.inherit_docstring_from(Foo)
         def func(self):
             '''%(super)sABC'''

--- a/scipy/sparse/csgraph/tests/test_graph_components.py
+++ b/scipy/sparse/csgraph/tests/test_graph_components.py
@@ -3,17 +3,14 @@ from __future__ import division, print_function, absolute_import
 import warnings
 
 import numpy as np
-from numpy.testing import assert_, assert_equal
-from numpy.testing.utils import WarningManager
+from numpy.testing import assert_, assert_equal, run_module_suite
 from scipy.sparse import csr_matrix, csgraph
 
 
 def test_cs_graph_components():
     D = np.eye(4, dtype=np.bool)
 
-    warn_ctx = WarningManager()
-    warn_ctx.__enter__()
-    try:
+    with warnings.catch_warnings():
         warnings.filterwarnings("ignore",
                     message="`cs_graph_components` is deprecated")
 
@@ -32,5 +29,7 @@ def test_cs_graph_components():
         n_comp, flag = csgraph.cs_graph_components(csr_matrix(D))
         assert_(n_comp == 2)
         assert_equal(flag, [0, 0, -2, 1])
-    finally:
-        warn_ctx.__exit__()
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/scipy/sparse/csgraph/tests/test_graph_laplacian.py
+++ b/scipy/sparse/csgraph/tests/test_graph_laplacian.py
@@ -4,6 +4,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
+from numpy.testing import run_module_suite
 from scipy import sparse
 
 from scipy.sparse import csgraph
@@ -66,5 +67,4 @@ def test_graph_laplacian():
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule()
+    run_module_suite()

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -1,11 +1,10 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import \
-    assert_array_almost_equal, assert_raises, TestCase, dec
-from scipy.sparse.csgraph import \
-    shortest_path, dijkstra, floyd_warshall, johnson,\
-    bellman_ford, construct_dist_matrix, NegativeCycleError
+from numpy.testing import (assert_array_almost_equal, assert_raises, dec,
+    run_module_suite)
+from scipy.sparse.csgraph import (shortest_path, dijkstra, johnson,
+    bellman_ford, construct_dist_matrix, NegativeCycleError)
 
 
 directed_G = np.array([[0, 3, 3, 0, 0],
@@ -171,5 +170,4 @@ def test_masked_input():
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule()
+    run_module_suite()

--- a/scipy/sparse/linalg/dsolve/umfpack/tests/test_umfpack.py
+++ b/scipy/sparse/linalg/dsolve/umfpack/tests/test_umfpack.py
@@ -10,8 +10,8 @@ from __future__ import division, print_function, absolute_import
 import warnings
 import random
 
-from numpy.testing import assert_array_almost_equal, dec, \
-        decorate_methods
+from numpy.testing import (assert_array_almost_equal, dec,
+        decorate_methods, run_module_suite)
 from numpy.testing.utils import WarningManager
 
 from scipy import rand, matrix, diag, eye
@@ -196,6 +196,6 @@ class TestFactorization(_DeprecationAccept):
 for cls in [TestSolvers, TestFactorization]:
     decorate_methods(cls, _umfpack_skip)
 
+
 if __name__ == "__main__":
-    import nose
-    nose.run(argv=['', __file__])
+    run_module_suite()

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -8,11 +8,10 @@ import warnings
 
 import numpy as np
 
-from numpy.testing import TestCase, assert_equal, assert_array_equal, \
-     assert_, assert_allclose, assert_raises
+from numpy.testing import (TestCase, assert_equal, assert_array_equal,
+     assert_, assert_allclose, assert_raises, run_module_suite)
 
-from numpy import zeros, ones, arange, array, abs, max, ones, eye, iscomplexobj
-from numpy.linalg import cond
+from numpy import zeros, arange, array, abs, max, ones, eye, iscomplexobj
 from scipy.linalg import norm
 from scipy.sparse import spdiags, csr_matrix, SparseEfficiencyWarning
 
@@ -354,6 +353,6 @@ class TestGMRES(TestCase):
         assert_allclose(r_x, x)
         assert_(r_info == info)
 
+
 if __name__ == "__main__":
-    import nose
-    nose.run(argv=['', __file__])
+    run_module_suite()

--- a/scipy/sparse/linalg/isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lgmres.py
@@ -4,7 +4,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import TestCase, assert_
+from numpy.testing import TestCase, assert_, run_module_suite
 
 from numpy import zeros, array, allclose
 from scipy.linalg import norm
@@ -13,6 +13,7 @@ from scipy.sparse import csr_matrix
 from scipy.sparse.linalg.interface import LinearOperator
 from scipy.sparse.linalg import splu
 from scipy.sparse.linalg.isolve import lgmres
+
 
 Am = csr_matrix(array([[-2,1,0,0,0,9],
                        [1,-2,1,0,5,0],
@@ -77,6 +78,6 @@ class TestLGMRES(TestCase):
         assert_(count_1 < count_0/2)
         assert_(allclose(x1, x0, rtol=1e-14))
 
+
 if __name__ == "__main__":
-    import nose
-    nose.run(argv=['', __file__])
+    run_module_suite()

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1347,7 +1347,7 @@ class _TestCommon:
             X = self.spmatrix(np.arange(20).reshape(4, 5) / 20.)
             X2 = getattr(np, name)(X)
             assert_array_equal(X2.toarray(), getattr(np, name)(X.toarray()))
-        
+
         for name in ["sin", "tan", "arcsin", "arctan", "sinh", "tanh",
                      "arcsinh", "arctanh", "rint", "sign", "expm1", "log1p",
                      "deg2rad", "rad2deg", "floor", "ceil", "trunc", "sqrt"]:
@@ -3128,6 +3128,7 @@ class TestBSR(sparse_test_class(getset=False,
     @dec.knownfailureif(True, "BSR not implemented")
     def test_iterator(self):
         pass
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1889,8 +1889,13 @@ def test_sqeuclidean_dtypes():
         assert_equal(d1, d2)
         assert_equal(d1, np.float64(np.iinfo(dtype).max) ** 2)
 
-    for dtype in [np.float16, np.float32, np.float64, np.float128,
-                  np.complex64, np.complex128]:
+    dtypes = [np.float32, np.float64, np.complex64, np.complex128]
+    for dtype in ['float16', 'float128']:
+        # These aren't present in older numpy versions
+        if hasattr(np, dtype):
+            dtypes.append(getattr(np, dtype))
+
+    for dtype in dtypes:
         d = sqeuclidean(np.asarray(x, dtype=dtype), np.asarray(y, dtype=dtype))
         assert_equal(d.dtype, dtype)
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -33,8 +33,6 @@ from numpy.testing import assert_equal, assert_almost_equal, \
         assert_, rand, dec, TestCase, run_module_suite, assert_allclose, \
         assert_raises
 
-from numpy.testing.utils import WarningManager
-
 from scipy import special
 import scipy.special._ufuncs as cephes
 from scipy.special import ellipk
@@ -649,13 +647,9 @@ class TestCephes(TestCase):
         cephes.pdtrc(0,1)
 
     def test_pdtri(self):
-        warn_ctx = WarningManager()
-        warn_ctx.__enter__()
-        try:
+        with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
             cephes.pdtri(0.5,0.5)
-        finally:
-            warn_ctx.__exit__()
 
     def test_pdtrik(self):
         cephes.pdtrik(0.5,1)
@@ -2724,9 +2718,7 @@ def test_agm_simple():
 
 
 def test_legacy():
-    warn_ctx = WarningManager()
-    warn_ctx.__enter__()
-    try:
+    with warnings.catch_warnings():
         warnings.simplefilter("ignore", RuntimeWarning)
 
         # Legacy behavior: truncating arguments to integers
@@ -2745,8 +2737,6 @@ def test_legacy():
         assert_equal(special.yn(1, 0.3), special.yn(1.8, 0.3))
         assert_equal(special.smirnov(1, 0.3), special.smirnov(1.8, 0.3))
         assert_equal(special.smirnovi(1, 0.3), special.smirnovi(1.8, 0.3))
-    finally:
-        warn_ctx.__exit__()
 
 
 @with_special_errors
@@ -2781,6 +2771,7 @@ def test_xlog1py():
                      (1, 1e-30)], dtype=float)
     w1 = np.vectorize(xfunc)(z1[:,0], z1[:,1])
     assert_func_equal(special.xlog1py, w1, z1, rtol=1e-13, atol=1e-13)
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -4,6 +4,7 @@
 #
 from __future__ import division, print_function, absolute_import
 
+import sys
 import warnings
 
 from scipy.lib.six import callable, string_types, get_method_function
@@ -1369,11 +1370,12 @@ class rv_continuous(rv_generic):
                 hstr = "A "
             longname = hstr + name
 
-        # generate docstring for subclass instances
-        if self.__doc__ is None:
-            self._construct_default_doc(longname=longname, extradoc=extradoc)
-        else:
-            self._construct_doc()
+        if sys.flags.optimize < 2:
+            # Skip adding docstrings if interpreter is run with -OO
+            if self.__doc__ is None:
+                self._construct_default_doc(longname=longname, extradoc=extradoc)
+            else:
+                self._construct_doc()
 
     def _construct_default_doc(self, longname=None, extradoc=None):
         """Construct instance docstring from the default template."""
@@ -1460,7 +1462,7 @@ class rv_continuous(rv_generic):
     def _cdf(self, x, *args):
         return self._cdfvec(x, *args)
 
-    ## generic _argcheck, _logcdf, _sf, _logsf, _ppf, _isf, _rvs are defined 
+    ## generic _argcheck, _logcdf, _sf, _logsf, _ppf, _isf, _rvs are defined
     ## in rv_generic
 
     def pdf(self,x,*args,**kwds):
@@ -3258,8 +3260,8 @@ class f_gen(rv_continuous):
         v1, v2 = 1. * dfn, 1. * dfd
         v2_2, v2_4, v2_6, v2_8 = v2 - 2., v2 - 4., v2 - 6., v2 - 8.
 
-        mu = _lazywhere(v2 > 2, (v2, v2_2), 
-                lambda v2, v2_2: v2 / v2_2, 
+        mu = _lazywhere(v2 > 2, (v2, v2_2),
+                lambda v2, v2_2: v2 / v2_2,
                 np.inf)
 
         mu2 = _lazywhere(v2 > 4, (v1, v2, v2_2, v2_4),
@@ -3273,7 +3275,7 @@ class f_gen(rv_continuous):
                 np.nan)
         g1 *= np.sqrt(8.)
 
-        g2 = _lazywhere(v2 > 8, (g1, v2_6, v2_8), 
+        g2 = _lazywhere(v2 > 8, (g1, v2_6, v2_8),
                 lambda g1, v2_6, v2_8: (8 + g1 * g1 * v2_6) / v2_8,
                 np.nan)
         g2 *= 3. / 2.
@@ -3851,17 +3853,18 @@ class erlang_gen(gamma_gen):
     def fit(self, data, *args, **kwds):
         return super(erlang_gen, self).fit(data, *args, **kwds)
 
-    fit.__doc__ = (rv_continuous.fit.__doc__ +
-        """
-        Notes
-        -----
-        The Erlang distribution is generally defined to have integer values
-        for the shape parameter.  This is not enforced by the `erlang` class.
-        When fitting the distribution, it will generally return a non-integer
-        value for the shape parameter.  By using the keyword argument
-        `f0=<integer>`, the fit method can be constrained to fit the data to
-        a specific integer shape parameter.
-        """)
+    if fit.__doc__ is not None:
+        fit.__doc__ = (rv_continuous.fit.__doc__ +
+            """
+            Notes
+            -----
+            The Erlang distribution is generally defined to have integer values
+            for the shape parameter.  This is not enforced by the `erlang` class.
+            When fitting the distribution, it will generally return a non-integer
+            value for the shape parameter.  By using the keyword argument
+            `f0=<integer>`, the fit method can be constrained to fit the data to
+            a specific integer shape parameter.
+            """)
 erlang = erlang_gen(a=0.0, name='erlang')
 
 
@@ -4294,10 +4297,10 @@ class invgamma_gen(rv_continuous):
 
         g1, g2 = None, None
         if 's' in moments:
-            g1 = _lazywhere(a > 3, (a,), 
+            g1 = _lazywhere(a > 3, (a,),
                     lambda x: 4. * np.sqrt(x - 2.) / (x - 3.), np.nan)
         if 'k' in moments:
-            g2 = _lazywhere(a > 4, (a,), 
+            g2 = _lazywhere(a > 4, (a,),
                     lambda x: 6. * (5. * x - 11.) / (x - 3.) / (x - 4.), np.nan)
         return m1, m2, g1, g2
 
@@ -5173,7 +5176,7 @@ class nct_gen(rv_continuous):
             c42 = df / (df-4.) - c11*c11 * (df-1.) / (df-3.)
             c42 *= 6.*df / (df-2.)
             c40 = 3.*df*df / (df-2.) / (df-4.)
-            
+
             mu4 = c44 * nc**4 + c42*nc**2 + c40
             g2 = np.where(df > 4, mu4/mu2**2 - 3.,
                                   np.nan)
@@ -5541,7 +5544,7 @@ class rdist_gen(rv_continuous):
         return res
 
     def _munp(self, n, c):
-        numerator = (1 - (n % 2)) * special.beta((n + 1.0) / 2, c / 2.0) 
+        numerator = (1 - (n % 2)) * special.beta((n + 1.0) / 2, c / 2.0)
         return numerator / special.beta(1. / 2, c / 2.)
 rdist = rdist_gen(a=-1.0, b=1.0, name="rdist")
 
@@ -6532,17 +6535,17 @@ class rv_discrete(rv_generic):
             else:
                 hstr = "A "
             longname = hstr + name
-        if self.__doc__ is None:
-            self._construct_default_doc(longname=longname, extradoc=extradoc)
-        else:
-            self._construct_doc()
 
-        #discrete RV do not have the scale parameter, remove it
-        self.__doc__ = self.__doc__.replace(
-            '\n    scale : array_like, optional\n        scale parameter (default=1)','')
+        if sys.flags.optimize < 2:
+            # Skip adding docstrings if interpreter is run with -OO
+            if self.__doc__ is None:
+                self._construct_default_doc(longname=longname, extradoc=extradoc)
+            else:
+                self._construct_doc()
 
-        ## This only works for old-style classes...
-        # self.__class__.__doc__ = self.__doc__
+            #discrete RV do not have the scale parameter, remove it
+            self.__doc__ = self.__doc__.replace('\n    scale : array_like, '
+                            'optional\n        scale parameter (default=1)', '')
 
 
     def _construct_default_doc(self, longname=None, extradoc=None):

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1160,7 +1160,9 @@ def trim(a, limits=None, inclusive=(True,True), relative=False, axis=None):
         return trimr(a, limits=limits, inclusive=inclusive, axis=axis)
     else:
         return trima(a, limits=limits, inclusive=inclusive)
-trim.__doc__ = trim.__doc__ % trimdoc
+
+if trim.__doc__ is not None:
+    trim.__doc__ = trim.__doc__ % trimdoc
 
 
 def trimboth(data, proportiontocut=0.2, inclusive=(True,True), axis=None):

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -28,7 +28,7 @@ distdiscrete = [
     ['planck', (0.51,)],   # 4.1
     ['poisson', (0.6,)],
     ['randint', (7, 31)],
-    ['skellam', (15, 8)], 
+    ['skellam', (15, 8)],
     ['zipf',     (4,)]    # arg=4 is ok,
                            # Zipf broken for arg = 2, e.g. weird .stats
                            # looking closer, mean, var should be inf for arg=2
@@ -362,7 +362,9 @@ def check_named_args(distfn, x, shape_args, defaults, meths):
 
 
 def check_scale_docstring(distfn):
-    npt.assert_('scale' not in distfn.__doc__)
+    if distfn.__doc__ is not None:
+        # Docstrings can be stripped if interpreter is run with -OO
+        npt.assert_('scale' not in distfn.__doc__)
 
 def check_private_entropy(distfn, args):
     # compare a generic _entropy with the distribution-specific implementation

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -4,7 +4,6 @@ import inspect
 
 import numpy.testing as npt
 import numpy as np
-import nose
 from scipy.lib.six import xrange
 
 from scipy import stats
@@ -253,14 +252,13 @@ def check_sample_skew_kurt(distfn, arg, sk, ss, msg):
     check_sample_meanvar, ss, s, msg + 'sample kurtosis test'
 
 
-def check_entropy(distfn,arg,msg):
+def check_entropy(distfn, arg, msg):
     ent = distfn.entropy(*arg)
-    # print 'Entropy =', ent
     npt.assert_(not np.isnan(ent), msg + 'test Entropy is nan')
 
 
 def check_discrete_chisquare(distfn, arg, rvs, alpha, msg):
-    '''perform chisquare test for random sample of a discrete distribution
+    """Perform chisquare test for random sample of a discrete distribution
 
     Parameters
     ----------
@@ -277,20 +275,14 @@ def check_discrete_chisquare(distfn, arg, rvs, alpha, msg):
         0 if test passes, 1 if test fails
 
     uses global variable debug for printing results
-    '''
 
-    # define parameters for test
-##    n=2000
+    """
     n = len(rvs)
     nsupp = 20
     wsupp = 1.0/nsupp
 
-##    distfn = getattr(stats, distname)
-##    np.random.seed(9765456)
-##    rvs = distfn.rvs(size=n,*arg)
-
     # construct intervals with minimum mass 1/nsupp
-    # intervalls are left-half-open as in a cdf difference
+    # intervals are left-half-open as in a cdf difference
     distsupport = xrange(max(distfn.a, -1000), min(distfn.b, 1000) + 1)
     last = 0
     distsupp = [max(distfn.a, -1000)]
@@ -372,5 +364,4 @@ def check_private_entropy(distfn, args):
                         stats.rv_discrete._entropy(distfn, *args))
 
 if __name__ == "__main__":
-    # nose.run(argv=['', __file__])
-    nose.runmodule(argv=[__file__,'-s'], exit=False)
+    npt.run_module_suite()

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -10,7 +10,6 @@ import sys
 from numpy.testing import (TestCase, run_module_suite, assert_equal,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
     assert_allclose, assert_, assert_raises, rand, dec)
-from numpy.testing.utils import WarningManager
 from nose import SkipTest
 
 import numpy
@@ -1433,15 +1432,13 @@ def test_ksone_fit_freeze():
          -0.10943985, -0.35243174, 0.06897665, -0.03553363, -0.0701746,
          -0.06037974, 0.37670779, -0.21684405])
 
-    olderr = np.seterr(invalid='ignore')
-    warn_ctx = WarningManager()
-    warn_ctx.__enter__()
     try:
-        warnings.simplefilter('ignore', UserWarning)
-        warnings.simplefilter('ignore', RuntimeWarning)
-        stats.ksone.fit(d)
+        olderr = np.seterr(invalid='ignore')
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            warnings.simplefilter('ignore', RuntimeWarning)
+            stats.ksone.fit(d)
     finally:
-        warn_ctx.__exit__()
         np.seterr(**olderr)
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 import re
-import inspect
+import sys
 
 from numpy.testing import (TestCase, run_module_suite, assert_equal,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
@@ -20,6 +20,10 @@ from scipy import special
 import scipy.stats as stats
 from scipy.stats.distributions import argsreduce
 from scipy.special import xlogy
+
+
+# python -OO strips docstrings
+DOCSTRINGS_STRIPPED = sys.flags.optimize > 1
 
 
 def kolmogorov_check(diststr, args=(), N=20, significance=0.01):
@@ -584,13 +588,13 @@ class TestF(TestCase):
         # no warnings should be generated for dfd = 2, 4, 6, 8 (div by zero)
         with warnings.catch_warnings():
             warnings.simplefilter('error', RuntimeWarning)
-            mvsk = stats.f.stats(dfn=[11]*4, 
+            mvsk = stats.f.stats(dfn=[11]*4,
                                  dfd=[2, 4, 6, 8], moments='mvsk')
 
     @dec.knownfailureif(True, 'f stats does not properly broadcast')
     def test_stats_broadcast(self):
         # stats do not fully broadcast just yet
-        mv = stats.f.stats(dfn=11, dfd=[11, 12])        
+        mv = stats.f.stats(dfn=11, dfd=[11, 12])
 
 
 def test_rvgeneric_std():
@@ -1287,6 +1291,7 @@ def test_regression_tukey_lambda():
     assert_((p[2] == 0.0).any())
 
 
+@dec.skipif(DOCSTRINGS_STRIPPED)
 def test_regression_ticket_1421():
     assert_('pdf(x, mu, loc=0, scale=1)' not in stats.poisson.__doc__)
     assert_('pmf(x,' in stats.poisson.__doc__)
@@ -1541,10 +1546,10 @@ def test_stats_shapes_argcheck():
     mv2_augmented = tuple(np.r_[_, np.nan] for _ in mv2)
     assert_equal(mv2_augmented, mv3)
 
-    # FIXME: this is only a quick-and-dirty test of a quick-and-dirty bugfix. 
-    # stats method with multiple shape parameters is not properly vectorized 
+    # FIXME: this is only a quick-and-dirty test of a quick-and-dirty bugfix.
+    # stats method with multiple shape parameters is not properly vectorized
     # anyway, so some distributions may or may not fail.
-    
+
 
 ## Test subclassing distributions w/ explicit shapes
 
@@ -1671,9 +1676,9 @@ class TestSubclassingExplicitShapes(TestCase):
                 return stats.norm._pdf(x) * extra_kwarg + offset
 
         dist = _dist_gen(shapes='offset, extra_kwarg')
-        assert_equal(dist.pdf(0.5, offset=111, extra_kwarg=33), 
+        assert_equal(dist.pdf(0.5, offset=111, extra_kwarg=33),
                      stats.norm.pdf(0.5)*33 + 111)
-        assert_equal(dist.pdf(0.5, 111, 33), 
+        assert_equal(dist.pdf(0.5, 111, 33),
                      stats.norm.pdf(0.5)*33 + 111)
 
     def test_extra_kwarg(self):
@@ -1712,6 +1717,7 @@ class TestSubclassingNoShapes(TestCase):
         dummy_distr = _distr2_gen(name='dummy')
         assert_almost_equal(dummy_distr.pdf(1, a=1), 1)
 
+    @dec.skipif(DOCSTRINGS_STRIPPED)
     def test_signature_inspection(self):
         # check that _pdf signature inspection works correctly, and is used in
         # the class docstring
@@ -1722,6 +1728,7 @@ class TestSubclassingNoShapes(TestCase):
                          dummy_distr.__doc__)
         assert_(len(res) == 1)
 
+    @dec.skipif(DOCSTRINGS_STRIPPED)
     def test_signature_inspection_2args(self):
         # same for 2 shape params and both _pdf and _cdf defined
         dummy_distr = _distr6_gen(name='dummy')
@@ -1734,14 +1741,14 @@ class TestSubclassingNoShapes(TestCase):
     def test_signature_inspection_2args_incorrect_shapes(self):
         # both _pdf and _cdf defined, but shapes are inconsistent: raises
         try:
-            dummy_distr = _distr3_gen(name='dummy')
+            _distr3_gen(name='dummy')
         except TypeError:
             pass
         else:
             raise AssertionError('TypeError not raised.')
 
     def test_defaults_raise(self):
-        # default arguments should raise 
+        # default arguments should raise
         class _dist_gen(stats.rv_continuous):
             def _pdf(self, x, a=42):
                 return 42
@@ -1762,6 +1769,7 @@ class TestSubclassingNoShapes(TestCase):
         assert_raises(TypeError, _dist_gen, **dict(name='dummy'))
 
 
+@dec.skipif(DOCSTRINGS_STRIPPED)
 def test_docstrings():
     badones = [',\s*,', '\(\s*,', '^\s*:']
     for distname in stats.__all__:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -556,6 +556,7 @@ class TestDLaplace(TestCase):
 
 
 class TestInvGamma(TestCase):
+    @dec.skipif(np.__version__ < '1.7', "assert_* funcs broken with inf/nan")
     def test_invgamma_inf_gh_1866(self):
         # invgamma's moments are only finite for a>n
         # specific numbers checked w/ boost 1.54
@@ -588,8 +589,7 @@ class TestF(TestCase):
         # no warnings should be generated for dfd = 2, 4, 6, 8 (div by zero)
         with warnings.catch_warnings():
             warnings.simplefilter('error', RuntimeWarning)
-            mvsk = stats.f.stats(dfn=[11]*4,
-                                 dfd=[2, 4, 6, 8], moments='mvsk')
+            stats.f.stats(dfn=[11]*4, dfd=[2, 4, 6, 8], moments='mvsk')
 
     @dec.knownfailureif(True, 'f stats does not properly broadcast')
     def test_stats_broadcast(self):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -6,15 +6,13 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 
-from numpy.testing import TestCase, run_module_suite, assert_array_equal, \
-    assert_almost_equal, assert_array_less, assert_array_almost_equal, \
-    assert_raises, assert_, assert_allclose, assert_equal
-from numpy.testing.utils import WarningManager
-
-import scipy.stats as stats
-
 import numpy as np
 from numpy.random import RandomState
+from numpy.testing import (TestCase, run_module_suite, assert_array_equal,
+    assert_almost_equal, assert_array_less, assert_array_almost_equal,
+    assert_raises, assert_, assert_allclose, assert_equal)
+
+import scipy.stats as stats
 
 
 g1 = [1.006, 0.996, 0.998, 1.000, 0.992, 0.993, 1.002, 0.999, 0.994, 1.000]
@@ -92,14 +90,10 @@ class TestAnsari(TestCase):
         parekh = np.array((107, 108, 106, 98, 105, 103, 110, 105, 104,
                            100, 96, 108, 103, 104, 114, 114, 113, 108, 106, 99))
 
-        warn_ctx = WarningManager()
-        warn_ctx.__enter__()
-        try:
+        with warnings.catch_warnings():
             warnings.filterwarnings('ignore',
                         message="Ties preclude use of exact statistic.")
             W, pval = stats.ansari(ramsay, parekh)
-        finally:
-            warn_ctx.__exit__()
 
         assert_almost_equal(W,185.5,11)
         assert_almost_equal(pval,0.18145819972867083,11)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,10 @@ DOCLINES = __doc__.split("\n")
 import os
 import sys
 import subprocess
-import shutil
+
+
+if sys.version_info[:2] < (2, 6) or (3, 0) <= sys.version_info[0:2] < (3, 2):
+    raise RuntimeError("Python version 2.6, 2.7 or >= 3.2 required.")
 
 if sys.version_info[0] < 3:
     import __builtin__ as builtins


### PR DESCRIPTION
- test failures with numpy 1.5.1
- Fix `python -OO` and test that on Travis CI
- Raise warning for unsupported Python versions
- Tests cleanup, remove `WarningManager` and nose imports
