### PR TITLE
ENH: Improve cryptic error messages for invalid FFT sizes

### DIFF
--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -152,6 +152,11 @@ def _raw_fft(x, n, axis, direction, overwrite_x, work_function):
     elif n != x.shape[axis]:
         x, copy_made = _fix_shape(x,n,axis)
         overwrite_x = overwrite_x or copy_made
+
+    if n < 1:
+        raise ValueError("Invalid number of FFT data points "
+                         "(%d) specified." % n)
+
     if axis == -1 or axis == len(x.shape)-1:
         r = work_function(x,n,direction,overwrite_x=overwrite_x)
     else:
@@ -252,6 +257,10 @@ def fft(x, n=None, axis=-1, overwrite_x=False):
         tmp, copy_made = _fix_shape(tmp,n,axis)
         overwrite_x = overwrite_x or copy_made
 
+    if n < 1:
+        raise ValueError("Invalid number of FFT data points "
+                         "(%d) specified." % n)
+
     if axis == -1 or axis == len(tmp.shape) - 1:
         return work_function(tmp,n,1,0,overwrite_x)
 
@@ -317,6 +326,10 @@ def ifft(x, n=None, axis=-1, overwrite_x=False):
     elif n != tmp.shape[axis]:
         tmp, copy_made = _fix_shape(tmp,n,axis)
         overwrite_x = overwrite_x or copy_made
+
+    if n < 1:
+        raise ValueError("Invalid number of FFT data points "
+                         "(%d) specified." % n)
 
     if axis == -1 or axis == len(tmp.shape) - 1:
         return work_function(tmp,n,-1,1,overwrite_x)
@@ -480,7 +493,8 @@ def _raw_fftnd(x, s, axes, direction, overwrite_x, work_function):
 
     for dim in s:
         if dim < 1:
-            raise ValueError("Invalid number of FFT data points (%d) specified." % s)
+            raise ValueError("Invalid number of FFT data points "
+                             "(%s) specified." % (s,))
 
     # No need to swap axes, array is in C order
     if noaxes:

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -168,6 +168,10 @@ class _TestFFTBase(TestCase):
             y = fftpack.zrfft(x)
             assert_array_almost_equal(y,y2)
 
+    def test_invalid_sizes(self):
+        assert_raises(ValueError, fft, [])
+        assert_raises(ValueError, fft, [[1,1],[2,2]], -5)
+
 
 class TestDoubleFFT(_TestFFTBase):
     def setUp(self):
@@ -273,6 +277,10 @@ class _TestIFFTBase(TestCase):
             self.assertTrue(np.linalg.norm(x - y) < rtol*np.linalg.norm(x),
                             (size, self.rdt))
 
+    def test_invalid_sizes(self):
+        assert_raises(ValueError, ifft, [])
+        assert_raises(ValueError, ifft, [[1,1],[2,2]], -5)
+
 
 class TestDoubleIFFT(_TestIFFTBase):
     def setUp(self):
@@ -313,6 +321,10 @@ class _TestRFFTBase(TestCase):
                 y1[2*k] = y2[k].imag
             y = fftpack.drfft(x)
             assert_array_almost_equal(y,y1)
+
+    def test_invalid_sizes(self):
+        assert_raises(ValueError, rfft, [])
+        assert_raises(ValueError, rfft, [[1,1],[2,2]], -5)
 
 
 class TestRFFTDouble(_TestRFFTBase):
@@ -394,9 +406,13 @@ class _TestIRFFTBase(TestCase):
             self.assertTrue(np.linalg.norm(x - y) < rtol*np.linalg.norm(x),
                             (size, self.rdt))
 
+    def test_invalid_sizes(self):
+        assert_raises(ValueError, irfft, [])
+        assert_raises(ValueError, irfft, [[1,1],[2,2]], -5)
+
+
 # self.ndec is bogus; we should have a assert_array_approx_equal for number of
 # significant digits
-
 
 class TestIRFFTDouble(_TestIRFFTBase):
     def setUp(self):
@@ -424,6 +440,10 @@ class Testfft2(TestCase):
         y = fft2(x, shape=(8,8), axes=(-3,-2))
         y_r = numpy.fft.fftn(x, s=(8, 8), axes=(-3, -2))
         assert_array_almost_equal(y, y_r)
+
+    def test_invalid_sizes(self):
+        assert_raises(ValueError, fft2, [[]])
+        assert_raises(ValueError, fft2, [[1,1],[2,2]], (4, -3))
 
 
 class TestFftnSingle(TestCase):
@@ -610,6 +630,11 @@ class TestFftn(TestCase):
         x = zeros((4, 4, 2))
         assert_raises(ValueError, fftn, x, shape=(8, 8, 2, 1))
 
+    def test_invalid_sizes(self):
+        assert_raises(ValueError, fftn, [[]])
+        assert_raises(ValueError, fftn, [[1,1],[2,2]], (4, -3))
+
+
 
 class _TestIfftn(TestCase):
     dtype = None
@@ -633,6 +658,11 @@ class _TestIfftn(TestCase):
             x = random([size,size]) + 1j*random([size,size])
             assert_array_almost_equal_nulp(ifftn(fftn(x)),x,self.maxnlp)
             assert_array_almost_equal_nulp(fftn(ifftn(x)),x,self.maxnlp)
+
+    def test_invalid_sizes(self):
+        assert_raises(ValueError, ifftn, [[]])
+        assert_raises(ValueError, ifftn, [[1,1],[2,2]], (4, -3))
+
 
 
 class TestIfftnDouble(_TestIfftn):


### PR DESCRIPTION
fft([]) used to produce `error: (n>0&&n<=size(x)) failed for 1st keyword n: zrfft:n=0`.

Now it says `ValueError: Invalid number of FFT data points (0) specified.`

BUG: Also fix my own mistake in error message for fftn that would raise `TypeError: not all arguments converted during string formatting` if s were a tuple.
