### PR TITLE
DOC: fix up quad() and show_options() docstrings

### DIFF
--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -30,110 +30,7 @@ def quad_explain(output=sys.stdout):
     None
 
     """
-    output.write("""
-Extra information for quad() inputs and outputs:
-
-  If full_output is non-zero, then the third output argument (infodict)
-  is a dictionary with entries as tabulated below.  For infinite limits, the
-  range is transformed to (0,1) and the optional outputs are given with
-  respect to this transformed range.  Let M be the input argument limit and
-  let K be infodict['last'].  The entries are:
-
-  'neval' : The number of function evaluations.
-  'last'  : The number, K, of subintervals produced in the subdivision process.
-  'alist' : A rank-1 array of length M, the first K elements of which are the
-            left end points of the subintervals in the partition of the
-            integration range.
-  'blist' : A rank-1 array of length M, the first K elements of which are the
-            right end points of the subintervals.
-  'rlist' : A rank-1 array of length M, the first K elements of which are the
-            integral approximations on the subintervals.
-  'elist' : A rank-1 array of length M, the first K elements of which are the
-            moduli of the absolute error estimates on the subintervals.
-  'iord'  : A rank-1 integer array of length M, the first L elements of
-            which are pointers to the error estimates over the subintervals
-            with L=K if K<=M/2+2 or L=M+1-K otherwise. Let I be the sequence
-            infodict['iord'] and let E be the sequence infodict['elist'].
-            Then E[I[1]], ..., E[I[L]] forms a decreasing sequence.
-
-  If the input argument points is provided (i.e. it is not None), the
-  following additional outputs are placed in the output dictionary.  Assume the
-  points sequence is of length P.
-
-  'pts'   : A rank-1 array of length P+2 containing the integration limits
-            and the break points of the intervals in ascending order.
-            This is an array giving the subintervals over which integration
-            will occur.
-  'level' : A rank-1 integer array of length M (=limit), containing the
-            subdivision levels of the subintervals, i.e., if (aa,bb) is a
-            subinterval of (pts[1], pts[2]) where pts[0] and pts[2] are
-            adjacent elements of infodict['pts'], then (aa,bb) has level l if
-            |bb-aa|=|pts[2]-pts[1]| * 2**(-l).
-  'ndin'  : A rank-1 integer array of length P+2.  After the first integration
-            over the intervals (pts[1], pts[2]), the error estimates over some
-            of the intervals may have been increased artificially in order to
-            put their subdivision forward.  This array has ones in slots
-            corresponding to the subintervals for which this happens.
-
-Weighting the integrand:
-
-  The input variables, weight and wvar, are used to weight the integrand by
-  a select list of functions.  Different integration methods are used
-  to compute the integral with these weighting functions.  The possible values
-  of weight and the corresponding weighting functions are.
-
-  'cos'     : cos(w*x)                            : wvar = w
-  'sin'     : sin(w*x)                            : wvar = w
-  'alg'     : g(x) = ((x-a)**alpha)*((b-x)**beta) : wvar = (alpha, beta)
-  'alg-loga': g(x)*log(x-a)                       : wvar = (alpha, beta)
-  'alg-logb': g(x)*log(b-x)                       : wvar = (alpha, beta)
-  'alg-log' : g(x)*log(x-a)*log(b-x)              : wvar = (alpha, beta)
-  'cauchy'  : 1/(x-c)                             : wvar = c
-
-  wvar holds the parameter w, (alpha, beta), or c depending on the weight
-  selected.  In these expressions, a and b are the integration limits.
-
-  For the 'cos' and 'sin' weighting, additional inputs and outputs are
-  available.
-
-  For finite integration limits, the integration is performed using a
-  Clenshaw-Curtis method which uses Chebyshev moments.  For repeated
-  calculations, these moments are saved in the output dictionary:
-
-  'momcom' : The maximum level of Chebyshev moments that have been computed,
-             i.e., if M_c is infodict['momcom'] then the moments have been
-             computed for intervals of length |b-a|* 2**(-l), l=0,1,...,M_c.
-  'nnlog'  : A rank-1 integer array of length M(=limit), containing the
-             subdivision levels of the subintervals, i.e., an element of this
-             array is equal to l if the corresponding subinterval is
-             |b-a|* 2**(-l).
-  'chebmo' : A rank-2 array of shape (25, maxp1) containing the computed
-             Chebyshev moments.  These can be passed on to an integration
-             over the same interval by passing this array as the second
-             element of the sequence wopts and passing infodict['momcom'] as
-             the first element.
-
-  If one of the integration limits is infinite, then a Fourier integral is
-  computed (assuming w neq 0).  If full_output is 1 and a numerical error
-  is encountered, besides the error message attached to the output tuple,
-  a dictionary is also appended to the output tuple which translates the
-  error codes in the array info['ierlst'] to English messages.  The output
-  information dictionary contains the following entries instead of 'last',
-  'alist', 'blist', 'rlist', and 'elist':
-
-  'lst'    : The number of subintervals needed for the integration (call it K_f).
-  'rslst'  : A rank-1 array of length M_f=limlst, whose first K_f elements
-             contain the integral contribution over the interval (a+(k-1)c,
-             a+kc) where c = (2*floor(|w|) + 1) * pi / |w| and k=1,2,...,K_f.
-  'erlst'  : A rank-1 array of length M_f containing the error estimate
-             corresponding to the interval in the same position in
-             infodict['rslist'].
-  'ierlst' : A rank-1 integer array of length M_f containing an error flag
-             corresponding to the interval in the same position in
-             infodict['rslist'].  See the explanation dictionary (last entry
-             in the output tuple) for the meaning of the codes.
-""")
-    return
+    output.write(quad.__doc__)
 
 
 def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
@@ -144,9 +41,6 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
 
     Integrate func from `a` to `b` (possibly infinite interval) using a
     technique from the Fortran library QUADPACK.
-
-    Run scipy.integrate.quad_explain() for more information on the
-    more esoteric inputs and outputs.
 
     Parameters
     ----------
@@ -196,7 +90,8 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
         singularities, discontinuities). The sequence does not have
         to be sorted.
     weight : float or int, optional
-        String indicating weighting function.
+        String indicating weighting function. Full explanation for this
+        and the remaining arguments can be found below.
     wvar : optional
         Variables for use with weighting functions.
     wopts : optional
@@ -219,6 +114,134 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     simps : integrator for sampled data
     romb : integrator for sampled data
     scipy.special : for coefficients and roots of orthogonal polynomials
+
+    Notes
+    -----
+
+    **Extra information for quad() inputs and outputs**
+
+    If full_output is non-zero, then the third output argument
+    (infodict) is a dictionary with entries as tabulated below.  For
+    infinite limits, the range is transformed to (0,1) and the
+    optional outputs are given with respect to this transformed range.
+    Let M be the input argument limit and let K be infodict['last'].
+    The entries are:
+
+    'neval'
+        The number of function evaluations.
+    'last'
+        The number, K, of subintervals produced in the subdivision process.
+    'alist'
+        A rank-1 array of length M, the first K elements of which are the
+        left end points of the subintervals in the partition of the
+        integration range.
+    'blist'
+        A rank-1 array of length M, the first K elements of which are the
+        right end points of the subintervals.
+    'rlist'
+        A rank-1 array of length M, the first K elements of which are the
+        integral approximations on the subintervals.
+    'elist'
+        A rank-1 array of length M, the first K elements of which are the
+        moduli of the absolute error estimates on the subintervals.
+    'iord'
+        A rank-1 integer array of length M, the first L elements of
+        which are pointers to the error estimates over the subintervals
+        with L=K if K<=M/2+2 or L=M+1-K otherwise. Let I be the sequence
+        infodict['iord'] and let E be the sequence infodict['elist'].
+        Then E[I[1]], ..., E[I[L]] forms a decreasing sequence.
+
+    If the input argument points is provided (i.e. it is not None),
+    the following additional outputs are placed in the output
+    dictionary.  Assume the points sequence is of length P.
+
+    'pts'
+        A rank-1 array of length P+2 containing the integration limits
+        and the break points of the intervals in ascending order.
+        This is an array giving the subintervals over which integration
+        will occur.
+    'level'
+        A rank-1 integer array of length M (=limit), containing the
+        subdivision levels of the subintervals, i.e., if (aa,bb) is a
+        subinterval of (pts[1], pts[2]) where pts[0] and pts[2] are
+        adjacent elements of infodict['pts'], then (aa,bb) has level l if
+        |bb-aa|=|pts[2]-pts[1]| * 2**(-l).
+    'ndin'
+        A rank-1 integer array of length P+2.  After the first integration
+        over the intervals (pts[1], pts[2]), the error estimates over some
+        of the intervals may have been increased artificially in order to
+        put their subdivision forward.  This array has ones in slots
+        corresponding to the subintervals for which this happens.
+
+    **Weighting the integrand**
+
+    The input variables, *weight* and *wvar*, are used to weight the
+    integrand by a select list of functions.  Different integration
+    methods are used to compute the integral with these weighting
+    functions.  The possible values of weight and the corresponding
+    weighting functions are.
+
+    ==========  ===================================   =====================
+    ``weight``  Weight function used                  ``wvar``
+    ==========  ===================================   =====================
+    'cos'       cos(w*x)                              wvar = w
+    'sin'       sin(w*x)                              wvar = w
+    'alg'       g(x) = ((x-a)**alpha)*((b-x)**beta)   wvar = (alpha, beta)
+    'alg-loga'  g(x)*log(x-a)                         wvar = (alpha, beta)
+    'alg-logb'  g(x)*log(b-x)                         wvar = (alpha, beta)
+    'alg-log'   g(x)*log(x-a)*log(b-x)                wvar = (alpha, beta)
+    'cauchy'    1/(x-c)                               wvar = c
+    ==========  ===================================   =====================
+
+    wvar holds the parameter w, (alpha, beta), or c depending on the weight
+    selected.  In these expressions, a and b are the integration limits.
+
+    For the 'cos' and 'sin' weighting, additional inputs and outputs are
+    available.
+
+    For finite integration limits, the integration is performed using a
+    Clenshaw-Curtis method which uses Chebyshev moments.  For repeated
+    calculations, these moments are saved in the output dictionary:
+    
+    'momcom'
+        The maximum level of Chebyshev moments that have been computed,
+        i.e., if M_c is infodict['momcom'] then the moments have been
+        computed for intervals of length |b-a|* 2**(-l), l=0,1,...,M_c.
+    'nnlog'
+        A rank-1 integer array of length M(=limit), containing the
+        subdivision levels of the subintervals, i.e., an element of this
+        array is equal to l if the corresponding subinterval is
+        |b-a|* 2**(-l).
+    'chebmo'
+        A rank-2 array of shape (25, maxp1) containing the computed
+        Chebyshev moments.  These can be passed on to an integration
+        over the same interval by passing this array as the second
+        element of the sequence wopts and passing infodict['momcom'] as
+        the first element.
+
+    If one of the integration limits is infinite, then a Fourier integral is
+    computed (assuming w neq 0).  If full_output is 1 and a numerical error
+    is encountered, besides the error message attached to the output tuple,
+    a dictionary is also appended to the output tuple which translates the
+    error codes in the array info['ierlst'] to English messages.  The output
+    information dictionary contains the following entries instead of 'last',
+    'alist', 'blist', 'rlist', and 'elist':
+
+    'lst'
+        The number of subintervals needed for the integration (call it K_f).
+    'rslst'
+        A rank-1 array of length M_f=limlst, whose first K_f elements
+        contain the integral contribution over the interval (a+(k-1)c,
+        a+kc) where c = (2*floor(|w|) + 1) * pi / |w| and k=1,2,...,K_f.
+    'erlst'
+        A rank-1 array of length M_f containing the error estimate
+        corresponding to the interval in the same position in
+        infodict['rslist'].
+    'ierlst'
+        A rank-1 integer array of length M_f containing an error flag
+        corresponding to the interval in the same position in
+        infodict['rslist'].  See the explanation dictionary (last entry
+        in the output tuple) for the meaning of the codes.
 
     Examples
     --------

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -113,7 +113,7 @@ def minimize(fun, x0, args=(), method='BFGS', jac=None, hess=None,
                 Maximum number of iterations to perform.
             disp : bool
                 Set to True to print convergence messages.
-        For method-specific options, see `show_options('minimize', method)`.
+        For method-specific options, see :func:`show_options()`.
     callback : callable, optional
         Called after each iteration, as ``callback(xk)``, where ``xk`` is the
         current parameter vector.
@@ -130,8 +130,9 @@ def minimize(fun, x0, args=(), method='BFGS', jac=None, hess=None,
 
     See also
     --------
-    minimize_scalar: Interface to minimization algorithms for scalar
-        univariate functions.
+    minimize_scalar : Interface to minimization algorithms for scalar
+        univariate functions
+    show_options : Additional options accepted by the solvers
 
     Notes
     -----
@@ -434,6 +435,8 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
             disp : bool
                 Set to True to print convergence messages.
 
+        See :func:`show_options()` for solver-specific options.
+
     Returns
     -------
     res : Result
@@ -445,8 +448,9 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
 
     See also
     --------
-    minimize: Interface to minimization algorithms for scalar multivariate
-        functions.
+    minimize : Interface to minimization algorithms for scalar multivariate
+        functions
+    show_options : Additional options accepted by the solvers
 
     Notes
     -----

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -63,7 +63,7 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
         the corresponding residual. For all methods but 'hybr' and 'lm'.
     options : dict, optional
         A dictionary of solver options. E.g. `xtol` or `maxiter`, see
-        ``show_options('root', method)`` for details.
+        :obj:`show_options()` for details.
 
     Returns
     -------
@@ -73,6 +73,10 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
         Boolean flag indicating if the algorithm exited successfully and
         ``message`` which describes the cause of the termination. See
         `Result` for a description of other attributes.
+
+    See also
+    --------
+    show_options : Additional options accepted by the solvers
 
     Notes
     -----

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2568,7 +2568,7 @@ def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
         return xmin
 
 
-def show_options(solver, method=None):
+def show_options(solver=None, method=None):
     """
     Show documentation for additional options of optimization solvers.
 
@@ -2578,7 +2578,7 @@ def show_options(solver, method=None):
     Parameters
     ----------
     solver : str
-        Type of optimization solver. One of {`minimize`, `root`}.
+        Type of optimization solver. One of 'minimize', 'minimize_scalar', 'root'.
     method : str, optional
         If not given, shows all methods of the specified solver. Otherwise,
         show only the options for the specified method. Valid values
@@ -2588,9 +2588,10 @@ def show_options(solver, method=None):
     Notes
     -----
 
-    ** minimize options
+    **Minimize options**
 
-    * BFGS options:
+    *BFGS* options:
+
         gtol : float
             Gradient norm must be less than `gtol` before successful
             termination.
@@ -2599,7 +2600,8 @@ def show_options(solver, method=None):
         eps : float or ndarray
             If `jac` is approximated, use this value for the step size.
 
-    * Nelder-Mead options:
+    *Nelder-Mead* options:
+    
         xtol : float
             Relative error in solution `xopt` acceptable for convergence.
         ftol : float
@@ -2607,14 +2609,16 @@ def show_options(solver, method=None):
         maxfev : int
             Maximum number of function evaluations to make.
 
-    * Newton-CG options:
+    *Newton-CG* options:
+
         xtol : float
             Average relative error in solution `xopt` acceptable for
             convergence.
         eps : float or ndarray
             If `jac` is approximated, use this value for the step size.
 
-    * CG options:
+    *CG* options:
+
         gtol : float
             Gradient norm must be less than `gtol` before successful
             termination.
@@ -2623,7 +2627,8 @@ def show_options(solver, method=None):
         eps : float or ndarray
             If `jac` is approximated, use this value for the step size.
 
-    * Powell options:
+    *Powell* options:
+
         xtol : float
             Relative error in solution `xopt` acceptable for convergence.
         ftol : float
@@ -2633,7 +2638,8 @@ def show_options(solver, method=None):
         direc : ndarray
             Initial set of direction vectors for the Powell method.
 
-    * Anneal options:
+    *Anneal* options:
+
         ftol : float
             Relative error in ``fun(x)`` acceptable for convergence.
         schedule : str
@@ -2660,7 +2666,8 @@ def show_options(solver, method=None):
         dwell : int
             The number of times to search the space at each temperature.
 
-    * L-BFGS-B options:
+    *L-BFGS-B* options:
+
         ftol : float
             The iteration stops when ``(f^k -
             f^{k+1})/max{|f^k|,|f^{k+1}|,1} <= ftol``.
@@ -2676,7 +2683,8 @@ def show_options(solver, method=None):
         maxiter : int
             Maximum number of function evaluations.
 
-    * TNC options:
+    *TNC* options:
+
         ftol : float
             Precision goal for the value of f in the stoping criterion.
             If ftol < 0.0, ftol is set to 0.0 defaults to -1.
@@ -2723,7 +2731,8 @@ def show_options(solver, method=None):
             rescaling.  If 0, rescale at each iteration.  If a large
             value, never rescale.  If < 0, rescale is set to 1.3.
 
-    * COBYLA options:
+    *COBYLA* options:
+
         tol : float
             Final accuracy in the optimization (not precisely guaranteed).
             This is a lower bound on the size of the trust region.
@@ -2734,7 +2743,8 @@ def show_options(solver, method=None):
         catol : float
             Absolute tolerance for constraint violations (default: 1e-6).
 
-    * SLSQP options:
+    *SLSQP* options:
+
         ftol : float
             Precision goal for the value of f in the stopping criterion.
         eps : float
@@ -2742,7 +2752,8 @@ def show_options(solver, method=None):
         maxiter : int
             Maximum number of iterations.
 
-    * dogleg options:
+    *dogleg* options:
+
         initial_trust_radius : float
             Initial trust-region radius.
         max_trust_radius : float
@@ -2754,26 +2765,34 @@ def show_options(solver, method=None):
             Gradient norm must be less than `gtol` before successful
             termination.
 
-    * trust-ncg options:
-        see dogleg options.
+    *trust-ncg* options:
 
-    ** minimize_scalar options
+        See dogleg options.
 
-    * brent options:
+
+    **minimize_scalar options**
+
+    *brent* options:
+
         xtol : float
+
             Relative error in solution `xopt` acceptable for convergence.
 
-    * bounded options:
+    *bounded* options:
+
         xatol : float
             Absolute error in solution `xopt` acceptable for convergence.
 
-    * golden options:
+    *golden* options:
+
         xtol : float
             Relative error in solution `xopt` acceptable for convergence.
 
-    ** root options
 
-    * hybrd options:
+    **root options**
+
+    *hybrd* options:
+
         col_deriv : bool
             Specify whether the Jacobian function computes derivatives down
             the columns (faster, because there is no transpose operation).
@@ -2800,7 +2819,8 @@ def show_options(solver, method=None):
             N positive entries that serve as a scale factors for the
             variables.
 
-    * LM options:
+    *LM* options:
+
         col_deriv : bool
             non-zero to specify that the Jacobian function computes derivatives
             down the columns (faster, because there is no transpose operation).
@@ -2825,7 +2845,8 @@ def show_options(solver, method=None):
         diag : sequence
             N positive entries that serve as a scale factors for the variables.
 
-    * Broyden1 options:
+    *Broyden1* options:
+
         nit : int, optional
             Number of iterations to make. If omitted (default), make as many
             as required to meet tolerances.
@@ -2877,7 +2898,8 @@ def show_options(solver, method=None):
                     Maximum rank for the Broyden matrix.
                     Default is infinity (ie., no rank reduction).
 
-    * Broyden2 options:
+    *Broyden2* options:
+
         nit : int, optional
             Number of iterations to make. If omitted (default), make as many
             as required to meet tolerances.
@@ -2905,31 +2927,33 @@ def show_options(solver, method=None):
             'armijo'.
         jac_options : dict, optional
             Options for the respective Jacobian approximation.
-                alpha : float, optional
-                    Initial guess for the Jacobian is (-1/alpha).
-                reduction_method : str or tuple, optional
-                    Method used in ensuring that the rank of the Broyden
-                    matrix stays low. Can either be a string giving the
-                    name of the method, or a tuple of the form ``(method,
-                    param1, param2, ...)`` that gives the name of the
-                    method and values for additional parameters.
 
-                    Methods available:
-                        - ``restart``: drop all matrix columns. Has no
-                            extra parameters.
-                        - ``simple``: drop oldest matrix column. Has no
-                            extra parameters.
-                        - ``svd``: keep only the most significant SVD
-                            components.
-                          Extra parameters:
-                              - ``to_retain`: number of SVD components to
-                                  retain when rank reduction is done.
-                                  Default is ``max_rank - 2``.
-                max_rank : int, optional
-                    Maximum rank for the Broyden matrix.
-                    Default is infinity (ie., no rank reduction).
+            alpha : float, optional
+                Initial guess for the Jacobian is (-1/alpha).
+            reduction_method : str or tuple, optional
+                Method used in ensuring that the rank of the Broyden
+                matrix stays low. Can either be a string giving the
+                name of the method, or a tuple of the form ``(method,
+                param1, param2, ...)`` that gives the name of the
+                method and values for additional parameters.
 
-    * Anderson options:
+                Methods available:
+                    - ``restart``: drop all matrix columns. Has no
+                        extra parameters.
+                    - ``simple``: drop oldest matrix column. Has no
+                        extra parameters.
+                    - ``svd``: keep only the most significant SVD
+                        components.
+                      Extra parameters:
+                          - ``to_retain`: number of SVD components to
+                              retain when rank reduction is done.
+                              Default is ``max_rank - 2``.
+            max_rank : int, optional
+                Maximum rank for the Broyden matrix.
+                Default is infinity (ie., no rank reduction).
+
+    *Anderson* options:
+
         nit : int, optional
             Number of iterations to make. If omitted (default), make as many
             as required to meet tolerances.
@@ -2957,15 +2981,17 @@ def show_options(solver, method=None):
             'armijo'.
         jac_options : dict, optional
             Options for the respective Jacobian approximation.
-                alpha : float, optional
-                    Initial guess for the Jacobian is (-1/alpha).
-                M : float, optional
-                    Number of previous vectors to retain. Defaults to 5.
-                w0 : float, optional
-                    Regularization parameter for numerical stability.
-                    Compared to unity, good values of the order of 0.01.
 
-    * LinearMixing options:
+            alpha : float, optional
+                Initial guess for the Jacobian is (-1/alpha).
+            M : float, optional
+                Number of previous vectors to retain. Defaults to 5.
+            w0 : float, optional
+                Regularization parameter for numerical stability.
+                Compared to unity, good values of the order of 0.01.
+
+    *LinearMixing* options:
+
         nit : int, optional
             Number of iterations to make. If omitted (default), make as many
             as required to meet tolerances.
@@ -2993,10 +3019,12 @@ def show_options(solver, method=None):
             'armijo'.
         jac_options : dict, optional
             Options for the respective Jacobian approximation.
-                alpha : float, optional
-                    initial guess for the jacobian is (-1/alpha).
 
-    * DiagBroyden options:
+            alpha : float, optional
+                initial guess for the jacobian is (-1/alpha).
+
+    *DiagBroyden* options:
+
         nit : int, optional
             Number of iterations to make. If omitted (default), make as many
             as required to meet tolerances.
@@ -3024,10 +3052,12 @@ def show_options(solver, method=None):
             'armijo'.
         jac_options : dict, optional
             Options for the respective Jacobian approximation.
-                alpha : float, optional
-                    initial guess for the jacobian is (-1/alpha).
 
-    * ExcitingMixing options:
+            alpha : float, optional
+                initial guess for the jacobian is (-1/alpha).
+
+    *ExcitingMixing* options:
+
         nit : int, optional
             Number of iterations to make. If omitted (default), make as many
             as required to meet tolerances.
@@ -3055,13 +3085,15 @@ def show_options(solver, method=None):
             'armijo'.
         jac_options : dict, optional
             Options for the respective Jacobian approximation.
-                alpha : float, optional
-                    Initial Jacobian approximation is (-1/alpha).
-                alphamax : float, optional
-                    The entries of the diagonal Jacobian are kept in the range
-                    ``[alpha, alphamax]``.
 
-    * Krylov options:
+            alpha : float, optional
+                Initial Jacobian approximation is (-1/alpha).
+            alphamax : float, optional
+                The entries of the diagonal Jacobian are kept in the range
+                ``[alpha, alphamax]``.
+
+    *Krylov* options:
+
         nit : int, optional
             Number of iterations to make. If omitted (default), make as many
             as required to meet tolerances.
@@ -3089,54 +3121,67 @@ def show_options(solver, method=None):
             'armijo'.
         jac_options : dict, optional
             Options for the respective Jacobian approximation.
-                rdiff : float, optional
-                    Relative step size to use in numerical differentiation.
-                method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres'} or
-                    function
-                    Krylov method to use to approximate the Jacobian.
-                    Can be a string, or a function implementing the same
-                    interface as the iterative solvers in
-                    `scipy.sparse.linalg`.
 
-                    The default is `scipy.sparse.linalg.lgmres`.
-                inner_M : LinearOperator or InverseJacobian
-                    Preconditioner for the inner Krylov iteration.
-                    Note that you can use also inverse Jacobians as (adaptive)
-                    preconditioners. For example,
+            rdiff : float, optional
+                Relative step size to use in numerical differentiation.
+            method : {'lgmres', 'gmres', 'bicgstab', 'cgs', 'minres'} or function
+                Krylov method to use to approximate the Jacobian.
+                Can be a string, or a function implementing the same
+                interface as the iterative solvers in
+                `scipy.sparse.linalg`.
 
-                    >>> jac = BroydenFirst()
-                    >>> kjac = KrylovJacobian(inner_M=jac.inverse).
+                The default is `scipy.sparse.linalg.lgmres`.
+            inner_M : LinearOperator or InverseJacobian
+                Preconditioner for the inner Krylov iteration.
+                Note that you can use also inverse Jacobians as (adaptive)
+                preconditioners. For example,
 
-                    If the preconditioner has a method named 'update', it will
-                    be called as ``update(x, f)`` after each nonlinear step,
-                    with ``x`` giving the current point, and ``f`` the current
-                    function value.
-                inner_tol, inner_maxiter, ...
-                    Parameters to pass on to the "inner" Krylov solver.
-                    See `scipy.sparse.linalg.gmres` for details.
-                outer_k : int, optional
-                    Size of the subspace kept across LGMRES nonlinear
-                    iterations.
+                >>> jac = BroydenFirst()
+                >>> kjac = KrylovJacobian(inner_M=jac.inverse).
 
-                    See `scipy.sparse.linalg.lgmres` for details.
+                If the preconditioner has a method named 'update', it will
+                be called as ``update(x, f)`` after each nonlinear step,
+                with ``x`` giving the current point, and ``f`` the current
+                function value.
+            inner_tol, inner_maxiter, ...
+                Parameters to pass on to the "inner" Krylov solver.
+                See `scipy.sparse.linalg.gmres` for details.
+            outer_k : int, optional
+                Size of the subspace kept across LGMRES nonlinear
+                iterations.
+
+                See `scipy.sparse.linalg.lgmres` for details.
 
     """
+    import textwrap
+
+    if solver is None:
+        print("\nminimize")
+        print("--------\n")
+        show_options('minimize')
+        print("\nminimize_scalar")
+        print("---------------\n")
+        show_options('minimize_scalar')
+        print("\nroot")
+        print("----\n")
+        show_options('root')
+        return
+
     solver = solver.lower()
-    if solver not in ('minimize', 'root'):
+    if solver not in ('minimize', 'minimize_scalar', 'root'):
         raise ValueError('Unknown solver.')
 
     solvers_doc = [s.strip()
-                   for s in show_options.__doc__.split('** ')[1:]]
+                   for s in show_options.__doc__.split('    **')[1:]]
     solver_doc = [s for s in solvers_doc
-                  if s.lower().startswith(solver)]
+                  if s.lower().startswith(solver + " options")]
     if method is None:
-        doc = solver_doc
+        doc = ['    **'] + solver_doc
     else:
-        doc = solver_doc[0].split('* ')[1:]
-        doc = [s.strip() for s in doc]
-        doc = [s for s in doc if s.lower().startswith(method.lower())]
+        doc = solver_doc[0].split('    *')[1:]
+        doc = ['        *'] + [s for s in doc if s.lower().startswith(method.lower())]
 
-    print('\n'.join(doc))
+    print(textwrap.dedent(''.join(doc)).rstrip())
 
     return
 


### PR DESCRIPTION
The quad_explain function was not linked in the main docs. However, this explanation should actually be in the `quad` docstring, so I moved it there.

The optimize `show_options` stuff was also not up to scratch for HTML output, so cleaned up.
