### PR TITLE
ENH: interpolate: add the rescale argument to griddata and NearestNDInterpolator

### DIFF
--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -55,7 +55,7 @@ class NDInterpolatorBase(object):
     """
 
     def __init__(self, points, values, fill_value=np.nan, ndim=None,
-                 rescale=False):
+                 rescale=False, need_contiguous=True, need_values=True):
         """
         Check shape of points and values arrays, and reshape values to
         (npoints, nvalues).  Ensure the `points` and values arrays are
@@ -77,25 +77,29 @@ class NDInterpolatorBase(object):
 
         self._check_init_shape(points, values, ndim=ndim)
 
-        points = np.ascontiguousarray(points, dtype=np.double)
+        if need_contiguous:
+            points = np.ascontiguousarray(points, dtype=np.double)
 
-        self.values_shape = values.shape[1:]
-        if values.ndim == 1:
-            self.values = values[:,None]
-        elif values.ndim == 2:
-            self.values = values
-        else:
-            self.values = values.reshape(values.shape[0],
-                                         np.prod(values.shape[1:]))
+        if need_values:
+            self.values_shape = values.shape[1:]
+            if values.ndim == 1:
+                self.values = values[:,None]
+            elif values.ndim == 2:
+                self.values = values
+            else:
+                self.values = values.reshape(values.shape[0],
+                                             np.prod(values.shape[1:]))
 
-        # Complex or real?
-        self.is_complex = np.issubdtype(self.values.dtype, np.complexfloating)
-        if self.is_complex:
-            self.values = np.ascontiguousarray(self.values, dtype=np.complex)
-            self.fill_value = complex(fill_value)
-        else:
-            self.values = np.ascontiguousarray(self.values, dtype=np.double)
-            self.fill_value = float(fill_value)
+            # Complex or real?
+            self.is_complex = np.issubdtype(self.values.dtype, np.complexfloating)
+            if self.is_complex:
+                if need_contiguous:
+                    self.values = np.ascontiguousarray(self.values, dtype=np.complex)
+                self.fill_value = complex(fill_value)
+            else:
+                if need_contiguous:
+                    self.values = np.ascontiguousarray(self.values, dtype=np.double)
+                self.fill_value = float(fill_value)
 
         if not rescale:
             self.scale = None
@@ -129,6 +133,12 @@ class NDInterpolatorBase(object):
             raise ValueError("number of dimensions in xi does not match x")
         return xi
 
+    def _scale_x(self, xi):
+        if self.scale is None:
+            return xi
+        else:
+            return (xi - self.offset) / self.scale
+
     def __call__(self, *args):
         """
         interpolator(xi)
@@ -147,16 +157,10 @@ class NDInterpolatorBase(object):
         xi = xi.reshape(-1, shape[-1])
         xi = np.ascontiguousarray(xi, dtype=np.double)
 
-        if self.scale is None:
-            if self.is_complex:
-                r = self._evaluate_complex(xi)
-            else:
-                r = self._evaluate_double(xi)
+        if self.is_complex:
+            r = self._evaluate_complex(self._scale_x(xi))
         else:
-            if self.is_complex:
-                r = self._evaluate_complex((xi - self.offset) / self.scale)
-            else:
-                r = self._evaluate_double((xi - self.offset) / self.scale)
+            r = self._evaluate_double(self._scale_x(xi))
 
         return np.asarray(r).reshape(shape[:-1] + self.values_shape)
 

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -25,8 +25,11 @@ class TestGriddata(object):
              + np.array([0,1])[None,:])
 
         for method in ('nearest', 'linear', 'cubic'):
-            yi = griddata((x[:,0], x[:,1]), y, (x[:,0], x[:,1]), method=method)
-            assert_allclose(y, yi, atol=1e-14, err_msg=method)
+            for rescale in (True, False):
+                msg = repr((method, rescale))
+                yi = griddata((x[:,0], x[:,1]), y, (x[:,0], x[:,1]), method=method,
+                              rescale=rescale)
+                assert_allclose(y, yi, atol=1e-14, err_msg=msg)
 
     def test_multivalue_2d(self):
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
@@ -35,8 +38,10 @@ class TestGriddata(object):
              + np.array([0,1])[None,:])
 
         for method in ('nearest', 'linear', 'cubic'):
-            yi = griddata(x, y, x, method=method)
-            assert_allclose(y, yi, atol=1e-14, err_msg=method)
+            for rescale in (True, False):
+                msg = repr((method, rescale))
+                yi = griddata(x, y, x, method=method, rescale=rescale)
+                assert_allclose(y, yi, atol=1e-14, err_msg=msg)
 
     def test_multipoint_2d(self):
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
@@ -46,11 +51,13 @@ class TestGriddata(object):
         xi = x[:,None,:] + np.array([0,0,0])[None,:,None]
 
         for method in ('nearest', 'linear', 'cubic'):
-            yi = griddata(x, y, xi, method=method)
+            for rescale in (True, False):
+                msg = repr((method, rescale))
+                yi = griddata(x, y, xi, method=method, rescale=rescale)
 
-            assert_equal(yi.shape, (5, 3), err_msg=method)
-            assert_allclose(yi, np.tile(y[:,None], (1, 3)),
-                            atol=1e-14, err_msg=method)
+                assert_equal(yi.shape, (5, 3), err_msg=msg)
+                assert_allclose(yi, np.tile(y[:,None], (1, 3)),
+                                atol=1e-14, err_msg=msg)
 
     def test_complex_2d(self):
         x = np.array([(0,0), (-0.5,-0.5), (-0.5,0.5), (0.5, 0.5), (0.25, 0.3)],
@@ -61,11 +68,13 @@ class TestGriddata(object):
         xi = x[:,None,:] + np.array([0,0,0])[None,:,None]
 
         for method in ('nearest', 'linear', 'cubic'):
-            yi = griddata(x, y, xi, method=method)
+            for rescale in (True, False):
+                msg = repr((method, rescale))
+                yi = griddata(x, y, xi, method=method, rescale=rescale)
 
-            assert_equal(yi.shape, (5, 3), err_msg=method)
-            assert_allclose(yi, np.tile(y[:,None], (1, 3)),
-                            atol=1e-14, err_msg=method)
+                assert_equal(yi.shape, (5, 3), err_msg=msg)
+                assert_allclose(yi, np.tile(y[:,None], (1, 3)),
+                                atol=1e-14, err_msg=msg)
 
     def test_1d(self):
         x = np.array([1, 2.5, 3, 4.5, 5, 6])
@@ -91,6 +100,25 @@ class TestGriddata(object):
             assert_allclose(griddata((x,), y, (x,), method=method), y,
                             err_msg=method, atol=1e-10)
 
+    def test_square_rescale_manual(self):
+        points  = np.array([(0,0), (0,100), (10,100), (10,0), (1, 5)], dtype=np.double)
+        points_rescaled = np.array([(0,0), (0,1), (1,1), (1,0), (0.1, 0.05)], dtype=np.double)
+        values = np.array([1., 2., -3., 5., 9.], dtype=np.double)
+
+        xx, yy = np.broadcast_arrays(np.linspace(0, 10, 14)[:,None],
+                                     np.linspace(0, 100, 14)[None,:])
+        xx = xx.ravel()
+        yy = yy.ravel()
+        xi = np.array([xx, yy]).T.copy()
+
+        for method in ('nearest', 'linear', 'cubic'):
+            msg = method
+            zi = griddata(points_rescaled, values, xi/np.array([10, 100.]),
+                          method=method)
+            zi_rescaled = griddata(points, values, xi, method=method,
+                                   rescale=True)
+            assert_allclose(zi, zi_rescaled, err_msg=msg,
+                            atol=1e-12)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
When it was added to the linear and cubic nd interpolators, the nearest-neighbor one and griddata() were missed.

Also, refactor NDInterpolatorBase to avoid some work that is unnecessary in the nearest neighbor interpolator.
