### PR TITLE
ENH: Add "limit" parameter to dijkstra calculation

### DIFF
--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -410,7 +410,7 @@ def dijkstra(csgraph, directed=True, indices=None,
             raise ValueError("indices out of range 0...N")
 
     if not np.isscalar(limit):
-        raise ValueError('limit must be numeric (float)')
+        raise TypeError('limit must be numeric (float)')
     limit = float(limit)
 
     #------------------------------

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -495,17 +495,18 @@ cdef _dijkstra_directed(
                 current_node = &nodes[j_current]
                 if current_node.state != SCANNED:
                     next_val = v.val + csr_weights[j]
-                    if current_node.state == NOT_IN_HEAP:
-                        current_node.state = IN_HEAP
-                        current_node.val = next_val
-                        insert_node(&heap, current_node)
-                        if return_pred:
-                            pred[i, j_current] = v.index
-                    elif current_node.val > next_val && next_val <= limit:
-                        decrease_val(&heap, current_node,
-                                     next_val)
-                        if return_pred:
-                            pred[i, j_current] = v.index
+                    if next_val <= limit:
+                        if current_node.state == NOT_IN_HEAP:
+                            current_node.state = IN_HEAP
+                            current_node.val = next_val
+                            insert_node(&heap, current_node)
+                            if return_pred:
+                                pred[i, j_current] = v.index
+                        elif current_node.val > next_val:
+                            decrease_val(&heap, current_node,
+                                         next_val)
+                            if return_pred:
+                                pred[i, j_current] = v.index
 
             #v has now been scanned: add the distance to the results
             dist_matrix[i, v.index] = v.val
@@ -557,33 +558,35 @@ cdef _dijkstra_undirected(
                 current_node = &nodes[j_current]
                 if current_node.state != SCANNED:
                     next_val = v.val + csr_weights[j]
-                    if current_node.state == NOT_IN_HEAP:
-                        current_node.state = IN_HEAP
-                        current_node.val = next_val
-                        insert_node(&heap, current_node)
-                        if return_pred:
-                            pred[i, j_current] = v.index
-                    elif current_node.val > next_val && next_val <= limit:
-                        decrease_val(&heap, current_node,
-                                     next_val)
-                        if return_pred:
-                            pred[i, j_current] = v.index
+                    if next_val <= limit:
+                        if current_node.state == NOT_IN_HEAP:
+                            current_node.state = IN_HEAP
+                            current_node.val = next_val
+                            insert_node(&heap, current_node)
+                            if return_pred:
+                                pred[i, j_current] = v.index
+                        elif current_node.val > next_val:
+                            decrease_val(&heap, current_node,
+                                         next_val)
+                            if return_pred:
+                                pred[i, j_current] = v.index
 
             for j from csrT_indptr[v.index] <= j < csrT_indptr[v.index + 1]:
                 j_current = csrT_indices[j]
                 current_node = &nodes[j_current]
                 if current_node.state != SCANNED:
                     next_val = v.val + csrT_weights[j]
-                    if current_node.state == NOT_IN_HEAP:
-                        current_node.state = IN_HEAP
-                        current_node.val = next_val
-                        insert_node(&heap, current_node)
-                        if return_pred:
-                            pred[i, j_current] = v.index
-                    elif current_node.val > next_val && next_val <= limit:
-                        decrease_val(&heap, current_node, next_val)
-                        if return_pred:
-                            pred[i, j_current] = v.index
+                    if next_val <= limit:
+                        if current_node.state == NOT_IN_HEAP:
+                            current_node.state = IN_HEAP
+                            current_node.val = next_val
+                            insert_node(&heap, current_node)
+                            if return_pred:
+                                pred[i, j_current] = v.index
+                        elif current_node.val > next_val:
+                            decrease_val(&heap, current_node, next_val)
+                            if return_pred:
+                                pred[i, j_current] = v.index
 
             #v has now been scanned: add the distance to the results
             dist_matrix[i, v.index] = v.val
@@ -932,7 +935,7 @@ def johnson(csgraph, directed=True, indices=None,
     if directed:
         _dijkstra_directed(indices,
                            csr_data, csgraph.indices, csgraph.indptr,
-                           dist_matrix, predecessor_matrix)
+                           dist_matrix, predecessor_matrix, np.inf)
     else:
         csgraphT = csr_matrix((csr_data, csgraph.indices, csgraph.indptr),
                           csgraph.shape).T.tocsr()
@@ -941,7 +944,7 @@ def johnson(csgraph, directed=True, indices=None,
         _dijkstra_undirected(indices,
                              csr_data, csgraph.indices, csgraph.indptr,
                              csgraphT.data, csgraphT.indices, csgraphT.indptr,
-                             dist_matrix, predecessor_matrix)
+                             dist_matrix, predecessor_matrix, np.inf)
 
     #------------------------------
     # correct the distance matrix for the bellman-ford weights

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -349,9 +349,10 @@ def dijkstra(csgraph, directed=True, indices=None,
         the path between each point such that the sum of weights is minimized,
         find the path such that the number of edges is minimized.
     limit : float, optional
-        The maximum distance to calculate. Using a smaller limit will
-        decrease computation time by aborting calculations between pairs
-        that are separated by a distance > limit.
+        The maximum distance to calculate, must be >= 0. Using a smaller limit
+        will decrease computation time by aborting calculations between pairs
+        that are separated by a distance > limit. For such pairs, the distance
+        will be equal to np.inf (i.e., not connected).
         .. versionadded:: 0.14.0
 
     Returns
@@ -412,6 +413,8 @@ def dijkstra(csgraph, directed=True, indices=None,
     if not np.isscalar(limit):
         raise TypeError('limit must be numeric (float)')
     limit = float(limit)
+    if limit < 0:
+        raise ValueError('limit must be >= 0')
 
     #------------------------------
     # initialize dist_matrix for output

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -39,13 +39,14 @@ undirected_SP = np.array([[0, 3, 3, 1, 2],
                           [1, 2, 4, 0, 2],
                           [2, 4, 5, 2, 0]], dtype=float)
 
-undirected_SP_limit_2 = np.array([[0, -9999, -9999, 1, 2],
-                                  [-9999, 0, -9999, 2, -9999],
-                                  [-9999, -9999, 0, -9999, -9999],
-                                  [1, 2, -9999, 0, 2],
-                                  [2, -9999, -9999, 2, 0]], dtype=float)
+undirected_SP_limit_2 = np.array([[0, np.inf, np.inf, 1, 2],
+                                  [np.inf, 0, np.inf, 2, np.inf],
+                                  [np.inf, np.inf, 0, np.inf, np.inf],
+                                  [1, 2, np.inf, 0, 2],
+                                  [2, np.inf, np.inf, 2, 0]], dtype=float)
 
-undirected_SP_limit_0 = - 9999 * (np.ones((5, 5), dtype=float) - np.eye(5))
+undirected_SP_limit_0 = np.ones((5, 5), dtype=float) - np.eye(5)
+undirected_SP_limit_0[undirected_SP_limit_0 > 0] = np.inf
 
 undirected_pred = np.array([[-9999, 0, 0, 0, 0],
                             [1, -9999, 0, 1, 1],
@@ -64,7 +65,7 @@ def test_dijkstra_limit():
 
     def check(limit, result):
         SP = dijkstra(undirected_G, directed=False, limit=limit)
-        assert_array_almost_equal(SP, undirected_SP)
+        assert_array_almost_equal(SP, result)
 
     for limit, result in zip(limits, results):
         yield check, limit, result

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -39,6 +39,14 @@ undirected_SP = np.array([[0, 3, 3, 1, 2],
                           [1, 2, 4, 0, 2],
                           [2, 4, 5, 2, 0]], dtype=float)
 
+undirected_SP_limit_2 = np.array([[0, -9999, -9999, 1, 2],
+                                  [-9999, 0, -9999, 2, -9999],
+                                  [-9999, -9999, 0, -9999, -9999],
+                                  [1, 2, -9999, 0, 2],
+                                  [2, -9999, -9999, 2, 0]], dtype=float)
+
+undirected_SP_limit_0 = - 9999 * (np.ones((5, 5), dtype=float) - np.eye(5))
+
 undirected_pred = np.array([[-9999, 0, 0, 0, 0],
                             [1, -9999, 0, 1, 1],
                             [2, 0, -9999, 0, 0],
@@ -46,6 +54,20 @@ undirected_pred = np.array([[-9999, 0, 0, 0, 0],
                             [4, 4, 0, 4, -9999]], dtype=float)
 
 methods = ['auto', 'FW', 'D', 'BF', 'J']
+
+
+def test_dijkstra_limit():
+    limits = [0, 2, np.inf]
+    results = [undirected_SP_limit_0,
+               undirected_SP_limit_2,
+               undirected_SP]
+
+    def check(limit, result):
+        SP = dijkstra(undirected_G, directed=False, limit=limit)
+        assert_array_almost_equal(SP, undirected_SP)
+
+    for limit, result in zip(limits, results):
+        yield check, limit, result
 
 
 @dec.skipif(np.version.short_version < '1.6', "Can't test arrays with infs.")

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -57,6 +57,7 @@ undirected_pred = np.array([[-9999, 0, 0, 0, 0],
 methods = ['auto', 'FW', 'D', 'BF', 'J']
 
 
+@dec.skipif(np.version.short_version < '1.6', "Can't test arrays with infs.")
 def test_dijkstra_limit():
     limits = [0, 2, np.inf]
     results = [undirected_SP_limit_0,


### PR DESCRIPTION
This is pretty straightforward. Tests pass, and I have also tried it with a real example with > 100,000 nodes. Results are identical (to numerical precision) with C code someone else wrote. Using a `limit` in my use-case speeds up computation by a factor of 20.
