### PR TITLE
ENH: choice of cuts in Legendre P function

### DIFF
--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -703,7 +703,7 @@ def lpmn(m,n,z):
     return p,pd
 
 
-def clpmn(m,n,z):
+def clpmn(m,n,z,type=3):
     """Associated Legendre function of the first kind, Pmn(z)
 
     Computes the (associated) Legendre function of the first kind
@@ -725,6 +725,10 @@ def clpmn(m,n,z):
        Legendre function
     z : float or complex
         Input value.
+    type : int
+       takes values 2 or 3
+       2: cut on the real axis |x|>1
+       3: cut on the real axis -1<x<1 (default) 
 
     Returns
     -------
@@ -757,15 +761,20 @@ def clpmn(m,n,z):
         raise ValueError("n must be a non-negative integer.")
     if not isscalar(z):
         raise ValueError("z must be scalar.")
+    if not(type==2 or type==3):
+        raise ValueError("type must be either 2 or 3.")
     if (m < 0):
         mp = -m
         mf,nf = mgrid[0:mp+1,0:n+1]
         sv = errprint(0)
-        fixarr = where(mf > nf,0.0,gamma(nf-mf+1) / gamma(nf+mf+1))
+        if type==2:
+            fixarr = where(mf > nf,0.0, (-1)**mf * gamma(nf-mf+1) / gamma(nf+mf+1))
+        else:
+            fixarr = where(mf > nf,0.0,gamma(nf-mf+1) / gamma(nf+mf+1))
         sv = errprint(sv)
     else:
         mp = m
-    p,pd = specfun.clpmn(mp,n,real(z),imag(z))
+    p,pd = specfun.clpmn(mp,n,real(z),imag(z),type)
     if (m < 0):
         p = p * fixarr
         pd = pd * fixarr

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -743,11 +743,15 @@ def clpmn(m,n,z,type=3):
 
     Notes
     -----
-    Phase conventions are chosen according to [1] such that the
-    function is analytic. The cut lies on the interval (-1, 1).
-    Approaching the cut from above or below in general yields a phase
+    By default, i.e. for ``type=3``, phase conventions are chosen according
+    to [1] such that the function is analytic. The cut lies on the interval
+    (-1, 1). Approaching the cut from above or below in general yields a phase
     factor with respect to Ferrer's function of the first kind
     (cf. `lpmn`).
+
+    For ``type=2`` a cut at |x|>1 is chosen. Approaching the real values
+    on the interval (-1, 1) in the complex plane yields Ferrer's function
+    of the first kind.
 
     References
     ----------

--- a/scipy/special/specfun.pyf
+++ b/scipy/special/specfun.pyf
@@ -21,12 +21,13 @@ python module specfun ! in
           double precision intent(out),dimension(0:mm,0:n),depend(mm,n) :: qm
           double precision intent(out),dimension(0:mm,0:n),depend(mm,n) :: qd
         end subroutine lqmn
-        subroutine clpmn(mm,m,n,x,y,cpm,cpd) ! in :specfun:specfun.f
+        subroutine clpmn(mm,m,n,x,y,ntype,cpm,cpd) ! in :specfun:specfun.f
             integer intent(hide), depend(m) :: mm=m
             integer intent(in), check(m>=0) :: m
             integer intent(in), check(n>=0) :: n
             double precision intent(in) :: x
             double precision intent(in) :: y
+            integer intent(in), check(ntype==2||ntype==3) :: ntype
             complex*16 intent(out),dimension(0:m,0:n),depend(m,n) :: cpm
             complex*16 intent(out),dimension(0:m,0:n),depend(m,n) :: cpd
         end subroutine clpmn

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -233,17 +233,18 @@ C
 
 C       **********************************
 
-        SUBROUTINE CLPMN(MM,M,N,X,Y,CPM,CPD)
+        SUBROUTINE CLPMN(MM,M,N,X,Y,NTYPE,CPM,CPD)
 C
 C       =========================================================
 C       Purpose: Compute the associated Legendre functions Pmn(z)
 C                and their derivatives Pmn'(z) for a complex
 C                argument
-C       Input :  x  --- Real part of z
-C                y  --- Imaginary part of z
-C                m  --- Order of Pmn(z),  m = 0,1,2,...,n
-C                n  --- Degree of Pmn(z), n = 0,1,2,...,N
-C                mm --- Physical dimension of CPM and CPD
+C       Input :  x     --- Real part of z
+C                y     --- Imaginary part of z
+C                m     --- Order of Pmn(z),  m = 0,1,2,...,n
+C                n     --- Degree of Pmn(z), n = 0,1,2,...,N
+C                mm    --- Physical dimension of CPM and CPD
+C                ntype --- type of cut, either 2 or 3
 C       Output:  CPM(m,n) --- Pmn(z)
 C                CPD(m,n) --- Pmn'(z)
 C       =========================================================
@@ -272,12 +273,18 @@ C
 20         CONTINUE
            RETURN
         ENDIF
+        if (NTYPE.EQ.2) THEN
+C       sqrt(1 - z^2) with branch cut on |x|>1
+           ZS=(1.0D0-Z*Z)
+           ZQ=-CDSQRT(ZS)
+        ELSE
 C       sqrt(z^2 - 1) with branch cut between [-1, 1]
-        ZQ=CDSQRT(Z*Z-1.0D0)
-        IF (X.LT.0D0) THEN
-           ZQ=-ZQ
+           ZS=(Z*Z-1.0D0)
+           ZQ=CDSQRT(ZS)
+           IF (X.LT.0D0) THEN
+              ZQ=-ZQ
+           END IF
         END IF
-        ZS=(Z*Z-1.0D0)
         DO 25 I=1,M
 C       DLMF 14.7.15
 25         CPM(I,I)=(2.0D0*I-1.0D0)*ZQ*CPM(I-1,I-1)

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -277,6 +277,7 @@ C
 C       sqrt(1 - z^2) with branch cut on |x|>1
            ZS=(1.0D0-Z*Z)
            ZQ=-CDSQRT(ZS)
+           LS=-1
         ELSE
 C       sqrt(z^2 - 1) with branch cut between [-1, 1]
            ZS=(Z*Z-1.0D0)
@@ -284,6 +285,7 @@ C       sqrt(z^2 - 1) with branch cut between [-1, 1]
            IF (X.LT.0D0) THEN
               ZQ=-ZQ
            END IF
+           LS=1
         END IF
         DO 25 I=1,M
 C       DLMF 14.7.15
@@ -300,12 +302,13 @@ C       DLMF 14.10.3
         CPD(0,0)=(0.0D0,0.0D0)
         DO 40 J=1,N
 C       DLMF 14.10.5
-40         CPD(0,J)=J*(Z*CPM(0,J)-CPM(0,J-1))/ZS
+40         CPD(0,J)=LS*J*(Z*CPM(0,J)-CPM(0,J-1))/ZS
         DO 45 I=1,M
         DO 45 J=I,N
-C       derivative of DLMF 14.7.11 & DLMF 14.10.6
-           CPD(I,J)=-I*Z*CPM(I,J)/ZS+(J+I)*(J-I+1.0D0)
-     &              /ZQ*CPM(I-1,J)
+C       derivative of DLMF 14.7.11 & DLMF 14.10.6 for type 3
+C       derivative of DLMF 14.7.8 & DLMF 14.10.1 for type 2
+           CPD(I,J)=LS*(-I*Z*CPM(I,J)/ZS+(J+I)*(J-I+1.0D0)
+     &                  /ZQ*CPM(I-1,J))
 45      CONTINUE
         RETURN
         END

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1381,10 +1381,34 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             legenp,
                             [IntArg(-100, 100), Arg(-100, 100), Arg(-1, 1)])
 
-    def test_legenp_complex(self):
+    def test_legenp_complex_2(self):
         def clpnm(n, m, z):
             try:
-                return sc.clpmn(m.real, n.real, z)[0][-1,-1]
+                return sc.clpmn(m.real, n.real, z, type=2)[0][-1,-1]
+            except ValueError:
+                return np.nan
+
+        def legenp(n, m, z):
+            if abs(z) < 1e-15:
+                # mpmath has bad performance here
+                return np.nan
+            return _exception_to_nan(mpmath.legenp)(int(n.real), int(m.real), z, type=2)
+
+        # mpmath is quite slow here
+        x = np.array([-2, -0.99, -0.5, 0, 1e-5, 0.5, 0.99, 20, 2e3])
+        y = np.array([-1e3, -0.5, 0.5, 1.3])
+        z = (x[:,None] + 1j*y[None,:]).ravel()
+
+        assert_mpmath_equal(clpnm,
+                            legenp,
+                            [FixedArg([-2, -1, 0, 1, 2, 10]), FixedArg([-2, -1, 0, 1, 2, 10]), FixedArg(z)],
+                            rtol=1e-6,
+                            n=500)
+
+    def test_legenp_complex_3(self):
+        def clpnm(n, m, z):
+            try:
+                return sc.clpmn(m.real, n.real, z, type=3)[0][-1,-1]
             except ValueError:
                 return np.nan
 


### PR DESCRIPTION
Following the discussion in gh-2840 and also in view of gh-2396, I have implemented a version of the Legendre P function for complex arguments where by means of a variable `type` the form of the cut can be chosen. The possible values of `type` are consistent with those used in `mpmath`. Some tests have been adapted to make use of `type`. In addition, a test of the derivative of the Legendre P function, which so far was untested, has been introduced.

If this form of implementing the different choices of cuts is acceptable, I would think about doing the same for the Legendre Q function. There, the choice of the cut influences the result more strongly than for the Legendre P function. Therefore, implementing corresponding changes to the Legendre Q function is even more important than for the Legendre P function.
