### PR TITLE
Remove duplicated words in documentation or comments.

### DIFF
--- a/doc/release/0.7.1-notes.rst
+++ b/doc/release/0.7.1-notes.rst
@@ -76,7 +76,7 @@ Windows binaries for python 2.6
 ===============================
 
 python 2.6 binaries for windows are now included. The binary for python 2.5
-requires numpy 1.2.0 or above, and and the one for python 2.6 requires numpy
+requires numpy 1.2.0 or above, and the one for python 2.6 requires numpy
 1.3.0 or above.
 
 Universal build for scipy

--- a/doc/source/tutorial/ndimage.rst
+++ b/doc/source/tutorial/ndimage.rst
@@ -58,7 +58,7 @@ Filter functions
 .. currentmodule:: scipy.ndimage.filters
 
 The functions described in this section all perform some type of spatial
-filtering of the the input array: the elements in the output are some function
+filtering of the input array: the elements in the output are some function
 of the values in the neighborhood of the corresponding input element. We refer
 to this neighborhood of elements as the filter kernel, which is often
 rectangular in shape but may also have an arbitrary footprint. Many

--- a/doc/source/tutorial/weave.rst
+++ b/doc/source/tutorial/weave.rst
@@ -1702,7 +1702,7 @@ dictionary. Look at the examples/md5_speed.py file for the test run.
 Catalog search paths and the PYTHONCOMPILED variable
 ----------------------------------------------------
 
-The default location for catalog files on Unix is is ~/.pythonXX_compiled
+The default location for catalog files on Unix is ~/.pythonXX_compiled
 where XX is version of Python being used. If this directory doesn't exist, it
 is created the first time a catalog is used. The directory must be writable.
 If, for any reason it isn't, then the catalog attempts to create a directory

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1910,8 +1910,8 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
 
         'lastp': the last ``p`` non-singleton formed in the linkage
           are the only non-leaf nodes in the linkage; they correspond
-          to to rows ``Z[n-p-2:end]`` in ``Z``. All other
-          non-singleton clusters are contracted into leaf nodes.
+          to rows ``Z[n-p-2:end]`` in ``Z``. All other non-singleton
+          clusters are contracted into leaf nodes.
 
         'mlab': This corresponds to MATLAB(TM) behavior. (not
           implemented yet)
@@ -2235,7 +2235,7 @@ def _dendrogram_calculate_info(Z, p, truncate_mode,
     ivl is a list to store the labels of the leaf nodes. The leaf_label_func
     is called whenever ivl != None, labels == None, and
     leaf_label_func != None. When ivl != None and labels != None, the
-    labels list is used only for labeling the the leaf nodes. When
+    labels list is used only for labeling the leaf nodes. When
     ivl == None, no labels are generated for leaf nodes.
 
     When get_leaves==True, a list of leaves is built as they are visited

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -399,7 +399,7 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
         exp( -(func(xnew) - func(xold)) / T )
 
     So, for best results, ``T`` should to be comparable to the typical
-    difference in function value between between local minima
+    difference in function values between local minima.
 
     References
     ----------

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -247,10 +247,10 @@ def blackman(M, sym=True):
     r"""
     Return a Blackman window.
 
-    The Blackman window is a taper formed by using the the first three
-    terms of a summation of cosines. It was designed to have close to the
-    minimal leakage possible.  It is close to optimal, only slightly worse
-    than a Kaiser window.
+    The Blackman window is a taper formed by using the first three terms of
+    a summation of cosines. It was designed to have close to the minimal
+    leakage possible.  It is close to optimal, only slightly worse than a
+    Kaiser window.
 
     Parameters
     ----------

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -345,7 +345,7 @@ class dok_matrix(spmatrix, dict):
         elif isinstance(other, dok_matrix):
             if other.shape != self.shape:
                 raise ValueError("matrix dimensions are not equal")
-            # We could alternatively set the dimensions to the the largest of
+            # We could alternatively set the dimensions to the largest of
             # the two matrices to be summed.  Would this be a good idea?
             res_dtype = upcast(self.dtype, other.dtype)
             new = dok_matrix(self.shape, dtype=res_dtype)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -15,7 +15,7 @@ stored in a rectangular array.
    :toctree: generated/
 
    pdist   -- pairwise distances between observation vectors.
-   cdist   -- distances between between two collections of observation vectors
+   cdist   -- distances between two collections of observation vectors
    squareform -- convert distance matrix to a condensed one and vice versa
 
 Predicates for checking the validity of distance matrices, both

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -193,7 +193,7 @@ Raw Statistical Functions
 .. autosummary::
    :toctree: generated/
 
-   bdtr       -- Sum of terms 0 through k of of the binomial pdf.
+   bdtr       -- Sum of terms 0 through k of the binomial pdf.
    bdtrc      -- Sum of terms k+1 through n of the binomial pdf.
    bdtri      -- Inverse of bdtr
    btdtr      -- Integral from 0 to x of beta pdf.

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -92,7 +92,7 @@ def jnjnp_zeros(nt):
     Returns
     -------
     zo[l-1] : ndarray
-        Value of the lth zero of of Jn(x) and Jn'(x). Of length `nt`.
+        Value of the lth zero of Jn(x) and Jn'(x). Of length `nt`.
     n[l-1] : ndarray
         Order of the Jn(x) or Jn'(x) associated with lth zero. Of length `nt`.
     m[l-1] : ndarray

--- a/scipy/weave/inline_tools.py
+++ b/scipy/weave/inline_tools.py
@@ -197,7 +197,7 @@ def inline(code,arg_names=[],local_dict=None, global_dict=None,
         On Unix, it'll probably use the same compiler that was used when
         compiling Python. Cygwin's behavior should be similar.
     verbose : {0,1,2}, optional
-        Specifies how much much information is printed during the compile
+        Specifies how much information is printed during the compile
         phase of inlining code.  0 is silent (except on windows with msvc
         where it still prints some garbage). 1 informs you when compiling
         starts, finishes, and how long it took.  2 prints out the command

--- a/scipy/weave/swig2_spec.py
+++ b/scipy/weave/swig2_spec.py
@@ -177,7 +177,7 @@ class swig2_converter(common_base_converter):
           If `pycobj` is 0 then code is generated to deal with string
           representations of the SWIG wrapped pointer.  If it is 1,
           then code is generated to deal with a PyCObject.  If it is 2
-          then code is generated to deal with with PySwigObject.
+          then code is generated to deal with a PySwigObject.
 
         - runtime_version : `int`
 

--- a/scipy/weave/swigptr2.py
+++ b/scipy/weave/swigptr2.py
@@ -1455,7 +1455,7 @@ SWIG_Python_MustGetPtr(PyObject *obj, swig_type_info *ty, int argnum, int flags)
   return result;
 }
 
-/* Convert a packed value value */
+/* Convert a packed value */
 SWIGRUNTIME int
 SWIG_Python_ConvertPacked(PyObject *obj, void *ptr, size_t sz, swig_type_info *ty, int flags) {
   swig_type_info *tc;
@@ -2794,7 +2794,7 @@ SWIG_Python_MustGetPtr(PyObject *obj, swig_type_info *ty, int argnum, int flags)
   return result;
 }
 
-/* Convert a packed value value */
+/* Convert a packed value */
 SWIGRUNTIME int
 SWIG_Python_ConvertPacked(PyObject *obj, void *ptr, size_t sz, swig_type_info *ty, int flags) {
   swig_cast_info *tc;
@@ -5032,7 +5032,7 @@ SWIG_Python_ConvertFunctionPtr(PyObject *obj, void **ptr, swig_type_info *ty) {
   }
 }
 
-/* Convert a packed value value */
+/* Convert a packed value */
 
 SWIGRUNTIME int
 SWIG_Python_ConvertPacked(PyObject *obj, void *ptr, size_t sz, swig_type_info *ty) {


### PR DESCRIPTION
After noticing a duplicated word in a docstring, I used variations of the `grin` command

```
grin " ([a-z]+) \1 "
```

to find more.  This PR removes most of the dups that would be visible to a user. 
