### PR TITLE
BUG: logsumexp() does not support masked arrays

### DIFF
--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -53,6 +53,10 @@ def logsumexp(a, axis=None, b=None):
     only handles two arguments. `logaddexp.reduce` is similar to this
     function, but may be less stable.
 
+    This function preserves ndarray subclasses, and works also with
+    matrices and masked arrays (it uses `asanyarray` instead of `asarray`
+    for parameters).
+
     Examples
     --------
     >>> from scipy.misc import logsumexp

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -9,7 +9,7 @@ from scipy.lib.six import xrange
 
 from numpy import exp, log, asarray, arange, newaxis, hstack, product, array, \
                   where, zeros, extract, place, pi, sqrt, eye, poly1d, dot, \
-                  r_, rollaxis, sum, fromstring, asanyarray
+                  r_, rollaxis, sum, fromstring, asanyarray, multiply
 
 __all__ = ['logsumexp', 'factorial','factorial2','factorialk','comb',
            'central_diff_weights', 'derivative', 'pade', 'lena', 'ascent', 'face']
@@ -83,7 +83,7 @@ def logsumexp(a, axis=None, b=None):
             b = b.ravel()
         else:
             b = rollaxis(b, axis)
-        out = log(sum(b * exp(a - a_max), axis=0))
+        out = log(sum(multiply(b, exp(a - a_max)), axis=0))
     else:
         out = log(sum(exp(a - a_max), axis=0))
     out += a_max

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -9,7 +9,7 @@ from scipy.lib.six import xrange
 
 from numpy import exp, log, asarray, arange, newaxis, hstack, product, array, \
                   where, zeros, extract, place, pi, sqrt, eye, poly1d, dot, \
-                  r_, rollaxis, sum, fromstring
+                  r_, rollaxis, sum, fromstring, asanyarray
 
 __all__ = ['logsumexp', 'factorial','factorial2','factorialk','comb',
            'central_diff_weights', 'derivative', 'pade', 'lena', 'ascent', 'face']
@@ -71,14 +71,14 @@ def logsumexp(a, axis=None, b=None):
     >>> np.log(np.sum(b*np.exp(a)))
     9.9170178533034647
     """
-    a = asarray(a)
+    a = asanyarray(a)
     if axis is None:
         a = a.ravel()
     else:
         a = rollaxis(a, axis)
     a_max = a.max(axis=0)
     if b is not None:
-        b = asarray(b)
+        b = asanyarray(b)
         if axis is None:
             b = b.ravel()
         else:

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -60,6 +60,9 @@ def test_logsumexp():
     assert_array_almost_equal(np.exp(logsumexp(logX, axis=0)), X.sum(axis=0))
     assert_array_almost_equal(np.exp(logsumexp(logX, axis=1)), X.sum(axis=1))
 
+    x = np.ma.array([0, 1, 2], mask=[1, 0, 0])
+    assert_array_almost_equal(logsumexp(x), np.log(np.sum(np.exp(x))))
+
 
 def test_logsumexp_b():
     a = np.arange(200)

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -63,6 +63,9 @@ def test_logsumexp():
     x = np.ma.array([0, 1, 2], mask=[1, 0, 0])
     assert_array_almost_equal(logsumexp(x.compressed()),
                               np.log(np.sum(np.exp(x.compressed()))))
+    X = np.matrix([[1, 2], [3, 4]])
+    assert_array_almost_equal(logsumexp(X),
+                              np.log(np.sum(np.exp(X))))
 
 
 def test_logsumexp_b():
@@ -88,6 +91,11 @@ def test_logsumexp_b():
                                 (B * X).sum(axis=0))
     assert_array_almost_equal(np.exp(logsumexp(logX, b=B, axis=1)),
                                 (B * X).sum(axis=1))
+
+    X = np.matrix([[1, 2], [3, 4]])
+    b = np.array([[1, 2], [3, 4]])
+    assert_array_almost_equal(logsumexp(X, None, b),
+                              np.log(np.sum(np.multiply(b, np.exp(X)))))
 
 
 def test_face():

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -61,7 +61,8 @@ def test_logsumexp():
     assert_array_almost_equal(np.exp(logsumexp(logX, axis=1)), X.sum(axis=1))
 
     x = np.ma.array([0, 1, 2], mask=[1, 0, 0])
-    assert_array_almost_equal(logsumexp(x), np.log(np.sum(np.exp(x))))
+    assert_array_almost_equal(logsumexp(x.compressed()),
+                              np.log(np.sum(np.exp(x.compressed()))))
 
 
 def test_logsumexp_b():


### PR DESCRIPTION
Simply use `asanyarray` instead of `asarray`. I guess that many other functions should be fixed the same way.

Fixes gh-3034
