### PR TITLE
ENH: linalg: Add a function to compute the DFT matrix.

### DIFF
--- a/doc/release/0.14.0-notes.rst
+++ b/doc/release/0.14.0-notes.rst
@@ -21,6 +21,15 @@ This release requires Python 2.6, 2.7 or 3.2-3.3 and NumPy 1.5.1 or greater.
 New features
 ============
 
+``scipy.linalg`` improvements
+-----------------------------
+
+Discrete Fourier transform matrix
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The new function `scipy.linalg.dft` computes the matrix of the
+discrete Fourier transform.
+
 ``scipy.stats`` improvements
 ----------------------------
 

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -123,6 +123,7 @@ Special Matrices
    block_diag - Construct a block diagonal matrix from submatrices
    circulant - Circulant matrix
    companion - Companion matrix
+   dft - Discrete Fourier transform matrix
    hadamard - Hadamard matrix of order 2**n
    hankel - Hankel matrix
    hilbert - Hilbert matrix

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -9,7 +9,7 @@ from scipy.lib.six import string_types
 
 __all__ = ['tri', 'tril', 'triu', 'toeplitz', 'circulant', 'hankel',
            'hadamard', 'leslie', 'all_mat', 'kron', 'block_diag', 'companion',
-           'hilbert', 'invhilbert', 'pascal']
+           'hilbert', 'invhilbert', 'pascal', 'dft']
 
 
 #-----------------------------------------------------------------------------
@@ -801,3 +801,68 @@ def pascal(n, kind='symmetric', exact=True):
         p = np.dot(L_n, L_n.T)
 
     return p
+
+
+def dft(n, scale=None):
+    """
+    Discrete Fourier transform matrix.
+
+    Create the matrix that computes the discrete Fourier transform of a
+    sequence [1]_.  The n-th primitive root of unity used to generate the
+    matrix is exp(-2*pi*i/n), where i = sqrt(-1).
+
+    Parameters
+    ----------
+    n : int
+        Size the matrix to create.
+    scale : str, optional
+        Must be None, 'sqrtn', or 'n'.
+        If `scale` is 'sqrtn', the matrix is divided by `sqrt(n)`.
+        If `scale` is 'n', the matrix is divided by `n`.
+        If `scale` is None (the default), the matrix is not normalized, and the
+        return value is simply the Vandermonde matrix of the roots of unity.
+
+    Returns
+    -------
+    m : (n, n) ndarray
+        The DFT matrix.
+
+    Notes
+    -----
+    When `scale` is None, multiplying a vector by the matrix returned by
+    `dft` is mathematically equivalent to (but much less efficient than)
+    the calculation performed by `scipy.fftpack.fft`.
+
+    .. versionadded:: 0.14.0
+
+    References
+    ----------
+    .. [1] "DFT matrix", http://en.wikipedia.org/wiki/DFT_matrix
+
+    Examples
+    --------
+    >>> np.set_printoptions(precision=5, suppress=True)
+    >>> x = np.array([1, 2, 3, 0, 3, 2, 1, 0])
+    >>> m = dft(8)
+    >>> m.dot(x)   # Comute the DFT of x
+    array([ 12.+0.j,  -2.-2.j,   0.-4.j,  -2.+2.j,   4.+0.j,  -2.-2.j,
+            -0.+4.j,  -2.+2.j])
+
+    Verify that ``m.dot(x)`` is the same as ``fft(x)``.
+
+    >>> from scipy.fftpack import fft
+    >>> fft(x)     # Same result as m.dot(x)
+    array([ 12.+0.j,  -2.-2.j,   0.-4.j,  -2.+2.j,   4.+0.j,  -2.-2.j,
+             0.+4.j,  -2.+2.j])
+    """
+    if scale not in [None, 'sqrtn', 'n']:
+        raise ValueError("scale must be None, 'sqrtn', or 'n'; "
+                         "%r is not valid." % (scale,))
+
+    omegas = np.exp(-2j * np.pi * np.arange(n) / n).reshape(-1, 1)
+    m = omegas ** np.arange(n)
+    if scale == 'sqrtn':
+        m /= math.sqrt(n)
+    elif scale == 'n':
+        m /= n
+    return m

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -2,7 +2,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-from numpy import arange, add, array, eye, copy
+from numpy import arange, add, array, eye, copy, sqrt
 from numpy.testing import TestCase, run_module_suite, assert_raises, \
     assert_equal, assert_array_equal, assert_array_almost_equal, \
     assert_allclose
@@ -12,7 +12,8 @@ from scipy.lib.six import xrange
 from scipy.misc import comb
 from scipy.linalg import toeplitz, hankel, circulant, hadamard, leslie, \
                             companion, tri, triu, tril, kron, block_diag, \
-                            hilbert, invhilbert, pascal
+                            hilbert, invhilbert, pascal, dft
+from scipy.fftpack import fft
 from numpy.linalg import cond
 
 
@@ -486,6 +487,22 @@ class TestPascal(TestCase):
     def test_big(self):
         p = pascal(50)
         assert_equal(p[-1, -1], comb(98, 49, exact=True))
+
+
+def test_dft():
+    m = dft(2)
+    expected = array([[1.0, 1.0], [1.0, -1.0]])
+    yield (assert_array_almost_equal, m, expected)
+    m = dft(2, scale='n')
+    yield (assert_array_almost_equal, m, expected/2.0)
+    m = dft(2, scale='sqrtn')
+    yield (assert_array_almost_equal, m, expected/sqrt(2.0))
+
+    x = array([0, 1, 2, 3, 4, 5, 0, 1])
+    m = dft(8)
+    mx = m.dot(x)
+    fx = fft(x)
+    yield (assert_array_almost_equal, mx, fx)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the function `dft` to scipy/linalg/special_matrices.py.  See http://en.wikipedia.org/wiki/DFT_matrix for an explanation of the matrix created by `dft`.
