### PR TITLE
BUG: stats.entropy broken (issue #3030)

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -6138,8 +6138,8 @@ def entropy(pk, qk=None, base=None):
         mask = (qk == 0.0) & (pk != 0.0)
         qk[mask] = 1.0 #Avoid the divide-by-zero warning
         quotient = pk / qk
-        quotient[mask] = inf
         vec = -special.xlogy(pk, quotient)
+        vec[mask] = -inf
     S = -sum(vec, axis=0)
     if base is not None:
         S /= log(base)

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -6135,9 +6135,11 @@ def entropy(pk, qk=None, base=None):
         qk = 1.0*qk / sum(qk, axis=0)
         # If qk is zero anywhere, then unless pk is zero at those places
         #   too, the relative entropy is infinite.
-        if any(take(pk, nonzero(qk == 0.0), axis=0) != 0.0, 0):
-            return inf
-        vec = -special.xlogy(pk, pk / qk)
+        mask = (qk == 0.0) & (pk != 0.0)
+        qk[mask] = 1.0 #Avoid the divide-by-zero warning
+        quotient = pk / qk
+        quotient[mask] = inf
+        vec = -special.xlogy(pk, quotient)
     S = -sum(vec, axis=0)
     if base is not None:
         S /= log(base)

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -6136,7 +6136,7 @@ def entropy(pk, qk=None, base=None):
         # If qk is zero anywhere, then unless pk is zero at those places
         #   too, the relative entropy is infinite.
         mask = (qk == 0.0) & (pk != 0.0)
-        qk[mask] = 1.0 #Avoid the divide-by-zero warning
+        qk[mask] = 1.0  # Avoid the divide-by-zero warning
         quotient = pk / qk
         vec = -special.xlogy(pk, quotient)
         vec[mask] = -inf

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -6135,11 +6135,12 @@ def entropy(pk, qk=None, base=None):
         qk = 1.0*qk / sum(qk, axis=0)
         # If qk is zero anywhere, then unless pk is zero at those places
         #   too, the relative entropy is infinite.
-        mask = (qk == 0.0) & (pk != 0.0)
+        mask = qk == 0.0
         qk[mask] = 1.0  # Avoid the divide-by-zero warning
         quotient = pk / qk
         vec = -special.xlogy(pk, quotient)
-        vec[mask] = -inf
+        vec[mask & (pk != 0.0)] = -inf
+        vec[mask & (pk == 0.0)] = 0.0
     S = -sum(vec, axis=0)
     if base is not None:
         S /= log(base)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -813,6 +813,18 @@ class TestEntropy(TestCase):
         assert_almost_equal(stats.entropy([0, 1, 2]), 0.63651416829481278,
                             decimal=12)
 
+    def test_entropy_2d(self):
+        pk = [[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]]
+        qk = [[0.2, 0.1], [0.3, 0.6], [0.5, 0.3]]
+        assert_array_almost_equal(stats.entropy(pk, qk),
+                [0.1933259, 0.18609809])
+
+    def test_entropy_2d_zero(self):
+        pk = [[0.1, 0.2], [0.6, 0.3], [0.3, 0.5]]
+        qk = [[0.0, 0.1], [0.3, 0.6], [0.5, 0.3]]
+        assert_array_almost_equal(stats.entropy(pk, qk),
+                [np.inf, 0.18609809])
+
 
 def TestArgsreduce():
     a = array([1,3,2,1,2,3,3])

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -825,6 +825,10 @@ class TestEntropy(TestCase):
         assert_array_almost_equal(stats.entropy(pk, qk),
                 [np.inf, 0.18609809])
 
+        pk[0][0] = 0.0
+        assert_array_almost_equal(stats.entropy(pk, qk),
+                [0.17403988, 0.18609809])
+
 
 def TestArgsreduce():
     a = array([1,3,2,1,2,3,3])


### PR DESCRIPTION
`stats.entropy` will fail when calculate relative entropy of arrays whose ndim > 1. (issue #3030)
According to the comment in the original code, `inf` should be given if there's a zero in `qk` but the corresponding place of `pk` is not zero. But the checking does not work with arrays whose ndim > 1.
