### PR TITLE
DOC:Add freqz magnitude plotting example

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -195,7 +195,7 @@ def freqz(b, a=1, worN=None, whole=0, plot=None):
     -----
     Using Matplotlib's "plot" function as the callable for `plot` produces
     unexpected results,  this plots the real part of the complex transfer
-    function, not the magnitude.
+    function, not the magnitude.  Try `lambda w, h:plot(w, abs(h))`.
 
     Examples
     --------

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -117,7 +117,7 @@ def freqs(b, a, worN=None, plot=None):
     -----
     Using Matplotlib's "plot" function as the callable for `plot` produces
     unexpected results,  this plots the real part of the complex transfer
-    function, not the magnitude.
+    function, not the magnitude.  Try ``lambda w, h: plot(w, abs(h))``.
 
     Examples
     --------
@@ -195,7 +195,7 @@ def freqz(b, a=1, worN=None, whole=0, plot=None):
     -----
     Using Matplotlib's "plot" function as the callable for `plot` produces
     unexpected results,  this plots the real part of the complex transfer
-    function, not the magnitude.  Try `lambda w, h:plot(w, abs(h))`.
+    function, not the magnitude.  Try ``lambda w, h: plot(w, abs(h))``.
 
     Examples
     --------


### PR DESCRIPTION
Mention a callable that produces the expected plot

I don't know why this parameter even exists, though, if it doesn't produce what people expect.  Maybe instead of this doc change, the function itself should be modified to pass abs(h) in the first place?  You can always work with w and h output directly if you need the phase information, but if you're using the "quick plot" parameter, that's probably not what you want.
