### PR TITLE
msvc9 compatibility 

### DIFF
--- a/scipy/integrate/__powidf2.c
+++ b/scipy/integrate/__powidf2.c
@@ -1,0 +1,14 @@
+
+double
+__powidf2 (double x, int m)
+{
+  unsigned int n = m < 0 ? -m : m;
+  double y = n % 2 ? x : 1;
+  while (n >>= 1)
+    {
+      x = x * x;
+      if (n % 2)
+        y = y * x;
+    }
+  return m < 0 ? 1/y : y;
+}

--- a/scipy/integrate/setup.py
+++ b/scipy/integrate/setup.py
@@ -47,7 +47,7 @@ def configuration(parent_package='',top_path=None):
             continue
         newblas[key] = blas_opt[key]
     config.add_extension('_odepack',
-                         sources=['_odepackmodule.c'],
+                         sources=['_odepackmodule.c', '__powidf2.c'],
                          libraries=libs,
                          depends=(['__odepack.h','multipack.h']
                                   + odepack_src + linpack_lite_src
@@ -56,7 +56,7 @@ def configuration(parent_package='',top_path=None):
 
     # vode
     config.add_extension('vode',
-                         sources=['vode.pyf'],
+                         sources=['vode.pyf', '__powidf2.c'],
                          libraries=libs,
                          depends=(odepack_src + linpack_lite_src
                                   + mach_src),
@@ -64,7 +64,7 @@ def configuration(parent_package='',top_path=None):
 
     # lsoda
     config.add_extension('lsoda',
-                         sources=['lsoda.pyf'],
+                         sources=['lsoda.pyf', '__powidf2.c'],
                          libraries=libs,
                          depends=(odepack_src + linpack_lite_src
                                   + mach_src),

--- a/scipy/interpolate/__powidf2.c
+++ b/scipy/interpolate/__powidf2.c
@@ -1,0 +1,14 @@
+
+double
+__powidf2 (double x, int m)
+{
+  unsigned int n = m < 0 ? -m : m;
+  double y = n % 2 ? x : 1;
+  while (n >>= 1)
+    {
+      x = x * x;
+      if (n % 2)
+        y = y * x;
+    }
+  return m < 0 ? 1/y : y;
+}

--- a/scipy/interpolate/setup.py
+++ b/scipy/interpolate/setup.py
@@ -23,7 +23,7 @@ def configuration(parent_package='',top_path=None):
                          )
 
     config.add_extension('dfitpack',
-                         sources=['src/fitpack.pyf'],
+                         sources=['src/fitpack.pyf', '__powidf2.c'],
                          libraries=['fitpack'],
                          depends=fitpack_src,
                          )

--- a/scipy/linalg/cexp.c
+++ b/scipy/linalg/cexp.c
@@ -1,0 +1,21 @@
+#include<math.h>
+
+typedef struct _complex cplx;
+
+cplx cexp (cplx z)
+{
+	cplx res;
+	double expre = exp(z.x);
+	res.x = expre * cos(z.y);
+	res.y = expre * sin(z.y);
+	return res;
+}
+
+int main(void)
+{
+	cplx x = {10., 1.};
+	cplx z;
+	z = cexp(x);
+	printf("%lf + i * %lf", z.x, z.y);
+	return 0;
+}

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -117,7 +117,7 @@ def configuration(parent_package='',top_path=None):
                                       'src', 'id_dist', 'src'),
                                  routines_to_split)
     fnames = [join('src', 'id_dist', 'src', f) for f in fnames]
-    config.add_extension('_interpolative', fnames + ["interpolative.pyf"],
+    config.add_extension('_interpolative', fnames + ["interpolative.pyf", "cexp.c"],
                          extra_info = lapack_opt
                          )
 

--- a/scipy/odr/__powidf2.c
+++ b/scipy/odr/__powidf2.c
@@ -1,0 +1,14 @@
+
+double
+__powidf2 (double x, int m)
+{
+  unsigned int n = m < 0 ? -m : m;
+  double y = n % 2 ? x : 1;
+  while (n >>= 1)
+    {
+      x = x * x;
+      if (n % 2)
+        y = y * x;
+    }
+  return m < 0 ? 1/y : y;
+}

--- a/scipy/odr/setup.py
+++ b/scipy/odr/setup.py
@@ -24,7 +24,7 @@ def configuration(parent_package='', top_path=None):
     odrpack_src = [join('odrpack', x) for x in libodr_files]
     config.add_library('odrpack', sources=odrpack_src)
 
-    sources = ['__odrpack.c']
+    sources = ['__odrpack.c', '__powidf2.c']
     libraries = ['odrpack'] + blas_info.pop('libraries', [])
     include_dirs = ['.'] + blas_info.pop('include_dirs', [])
     config.add_extension('__odrpack',

--- a/scipy/sparse/linalg/eigen/arpack/cplx.c
+++ b/scipy/sparse/linalg/eigen/arpack/cplx.c
@@ -1,0 +1,31 @@
+#include<math.h>
+
+typedef struct _complex cplx;
+typedef struct _cplxf{float x, y;} cplxf;
+
+float cabsf(cplxf z)
+{
+	return sqrtf(z.x * z.x + z.y * z.y);
+}
+
+cplxf csqrtf(cplxf z)
+{	
+	cplxf ret;
+	float r = cabsf(z);
+	ret.x = sqrtf((r + z.x)/2.);
+	ret.y = sqrtf((r - z.x)/2.);
+	if (z.y < 0)
+		ret.y = -ret.y;
+	return ret;
+}
+
+cplx csqrt(cplx z)
+{
+	cplx ret;
+	double r = cabs(z);
+	ret.x = sqrt((r + z.x)/2.);
+	ret.y = sqrt((r - z.x)/2.);
+	if (z.y < 0)
+		ret.y = -ret.y;
+	return ret;
+}

--- a/scipy/sparse/linalg/eigen/arpack/setup.py
+++ b/scipy/sparse/linalg/eigen/arpack/setup.py
@@ -27,7 +27,7 @@ def configuration(parent_package='',top_path=None):
                        include_dirs=[join('ARPACK', 'SRC')])
 
     config.add_extension('_arpack',
-                         sources='arpack.pyf.src',
+                         sources=['arpack.pyf.src', 'cplx.c'],
                          libraries=['arpack_scipy'],
                          extra_info=lapack_opt,
                          depends=arpack_sources,

--- a/scipy/sparse/linalg/isolve/cplx.c
+++ b/scipy/sparse/linalg/isolve/cplx.c
@@ -1,0 +1,31 @@
+#include<math.h>
+
+typedef struct _complex cplx;
+typedef struct _cplxf{float x, y;} cplxf;
+
+float cabsf(cplxf z)
+{
+	return sqrtf(z.x * z.x + z.y * z.y);
+}
+
+cplxf csqrtf(cplxf z)
+{	
+	cplxf ret;
+	float r = cabsf(z);
+	ret.x = sqrtf((r + z.x)/2.);
+	ret.y = sqrtf((r - z.x)/2.);
+	if (z.y < 0)
+		ret.y = -ret.y;
+	return ret;
+}
+
+cplx csqrt(cplx z)
+{
+	cplx ret;
+	double r = cabs(z);
+	ret.x = sqrt((r + z.x)/2.);
+	ret.y = sqrt((r - z.x)/2.);
+	if (z.y < 0)
+		ret.y = -ret.y;
+	return ret;
+}

--- a/scipy/sparse/linalg/isolve/setup.py
+++ b/scipy/sparse/linalg/isolve/setup.py
@@ -36,6 +36,7 @@ def configuration(parent_package='',top_path=None):
     sources = Util + methods + ['_iterative.pyf.src']
     sources = [join('iterative', x) for x in sources]
     sources += get_g77_abi_wrappers(lapack_opt)
+    sources.append('cplx.c')
 
     config.add_extension('_iterative',
                          sources=sources,

--- a/scipy/special/cplx.c
+++ b/scipy/special/cplx.c
@@ -1,0 +1,89 @@
+#include<math.h>
+
+typedef struct _complex cplx;
+
+cplx csqrt(cplx z)
+{
+	cplx ret;
+	double r = cabs(z);
+	ret.x = sqrt((r + z.x)/2.);
+	ret.y = sqrt((r - z.x)/2.);
+	if (z.y < 0)
+		ret.y = -ret.y;
+	return ret;
+}
+
+cplx cexp(cplx z)
+{
+	cplx res;
+	double expre = exp(z.x);
+	res.x = expre * cos(z.y);
+	res.y = expre * sin(z.y);
+	return res;
+}
+
+double __powidf2 (double x, int m)
+{
+  unsigned int n = m < 0 ? -m : m;
+  double y = n % 2 ? x : 1;
+  while (n >>= 1)
+    {
+      x = x * x;
+      if (n % 2)
+        y = y * x;
+    }
+  return m < 0 ? 1/y : y;
+}
+
+float __powisf2(float a, int b)
+{
+    const int recip = b < 0;
+    float r = 1;
+    while (1)
+    {
+        if (b & 1)
+            r *= a;
+        b /= 2;
+        if (b == 0)
+            break;
+        a *= a;
+    }
+    return recip ? 1/r : r;
+}
+
+cplx clog(cplx z)
+{
+	cplx ret = {log(cabs(z)), atan2(z.y, z.x)};
+	return ret;
+}
+
+cplx ccos(cplx z)
+{
+	cplx ret = {cos(z.x) * cosh(z.	y), - sin(z.x) * sinh(z.y)};
+	return ret;
+}
+
+cplx csin(cplx z)
+{
+	cplx ret = {sin(z.x) * cosh(z.y), cos(z.x) * sinh(z.y)};
+	return ret;
+}
+
+cplx cprod(cplx z1, cplx z2)
+{
+	cplx ret = {z1.x * z2.x - z1.y * z2.y, z1.x * z2.y + z2.x * z1.y};
+	return ret;
+}
+
+cplx cpow (cplx base, cplx exponent)
+{
+	return cexp(cprod(exponent, clog(base))); 
+}
+
+double trunc(double x)
+{
+	if (x < 0)
+		return -(int)abs(x);
+	return (int)abs(x);
+}
+

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -61,7 +61,7 @@ def configuration(parent_package='',top_path=None):
 
     # Extension specfun
     config.add_extension('specfun',
-                         sources=['specfun.pyf'],
+                         sources=['specfun.pyf', 'cplx.c'],
                          f2py_options=['--no-wrap-functions'],
                          depends=specfun_src,
                          define_macros=[],
@@ -70,7 +70,7 @@ def configuration(parent_package='',top_path=None):
     # Extension _ufuncs
     headers = ['*.h', join('c_misc', '*.h'), join('cephes', '*.h')]
     ufuncs_src = ['_ufuncs.c', 'sf_error.c', '_logit.c.src',
-                  "amos_wrappers.c", "cdf_wrappers.c", "specfun_wrappers.c"]
+                  "amos_wrappers.c", "cdf_wrappers.c", "specfun_wrappers.c", 'cplx.c']
     ufuncs_dep = (headers + ufuncs_src + amos_src + c_misc_src + cephes_src
                   + mach_src + cdf_src + specfun_src)
     config.add_extension('_ufuncs',


### PR DESCRIPTION
This commit should _NOT_ be merged as is (the extra source files should be required on windows only). It's just a hack I did on win64 with msvc9 to build scipy on win64 and I thought that perhaps it would help making a true solution that works across platforms and compilers.

I believe there must be a more elegant way to solve this (for instance, to use a single helper library, instead of copying the same code in multiple folders)

Also, before using the code, it would be a good idea to double-check the math.

Also note that in msvc2013 some of the functions (i.e. the math functions in C99) are included by the compiler and native runtime library, so defining them is not required any more

EDIT: these definitions were required when compiling fortran code
