### PR TITLE
Added 'wrap' as a vaild mode for savgol_filter.

### DIFF
--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -243,11 +243,11 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
         The axis of the array `x` along which the filter is to be applied.
         Default is -1.
     mode : str, optional
-        Must be 'mirror', 'constant', 'nearest' or 'interp'.  This
+        Must be 'mirror', 'constant', 'nearest', 'wrap' or 'interp'.  This
         determines the type of extension to use for the padded signal to
         which the filter is applied.  When `mode` is 'constant', the padding
         value is given by `cval`.  See the Notes for more details on 'mirror',
-        'constant' and 'nearest'.
+        'constant', 'wrap', and 'nearest'.
         When the 'interp' mode is selected (the default), no extension
         is used.  Instead, a degree `polyorder` polynomial is fit to the
         last `window_length` values of the edges, and this polynomial is
@@ -276,6 +276,8 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
             The extension contains the nearest input value.
         'constant':
             The extension contains the value given by the `cval` argument.
+        'wrap':
+            The extension contains the values from the other end of the array
 
     For example, if the input is [1, 2, 3, 4, 5, 6, 7, 8], and
     `window_length` is 7, the following shows the extended data for
@@ -286,6 +288,7 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
         'mirror'   | 4  3  2 | 1  2  3  4  5  6  7  8 | 7  6  5
         'nearest'  | 1  1  1 | 1  2  3  4  5  6  7  8 | 8  8  8
         'constant' | 0  0  0 | 1  2  3  4  5  6  7  8 | 0  0  0
+        'wrap'     | 6  7  8 | 1  2  3  4  5  6  7  8 | 1  2  3
 
     Examples
     --------
@@ -307,7 +310,7 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
     array([ 1.74,  3.03,  3.54,  2.86,  0.66,  0.17,  1.  ,  4.6 ,  7.97])
 
     """
-    if mode not in ["mirror", "constant", "nearest", "interp"]:
+    if mode not in ["mirror", "constant", "nearest", "interp", "wrap"]:
         raise ValueError("mode must be 'mirror', 'constant', 'nearest' "
                          "or 'interp'.")
 

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -277,7 +277,7 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
         'constant':
             The extension contains the value given by the `cval` argument.
         'wrap':
-            The extension contains the values from the other end of the array
+            The extension contains the values from the other end of the array.
 
     For example, if the input is [1, 2, 3, 4, 5, 6, 7, 8], and
     `window_length` is 7, the following shows the extended data for
@@ -312,7 +312,7 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
     """
     if mode not in ["mirror", "constant", "nearest", "interp", "wrap"]:
         raise ValueError("mode must be 'mirror', 'constant', 'nearest' "
-                         "or 'interp'.")
+                         "'wrap' or 'interp'.")
 
     x = np.asarray(x)
     # Ensure that x is either single or double precision floating point.

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -158,6 +158,10 @@ def test_sg_filter_trivial():
     y = savgol_filter(x, 3, 1, mode='nearest')
     assert_almost_equal(y, [3.0], decimal=15)
 
+    x = np.array([1.0] * 3)
+    y = savgol_filter(x, 3, 1, mode='wrap')
+    assert_almost_equal(y, [1.0, 1.0, 1.0], decimal=15)
+
 
 def test_sg_filter_basic():
     # Some basic test cases for savgol_filter().
@@ -167,6 +171,9 @@ def test_sg_filter_basic():
 
     y = savgol_filter(x, 3, 1, mode='mirror')
     assert_allclose(y, [5.0 / 3, 4.0 / 3, 5.0 / 3])
+
+    y = savgol_filter(x, 3, 1, mode='wrap')
+    assert_allclose(y, [4.0 / 3, 4.0 / 3, 4.0 / 3])
 
 
 def test_sg_filter_2d():


### PR DESCRIPTION
For applying the filter to periodic data (for example values measured around a circle) it is nice to be able to use `convolve1d`'s underlying `wrap` mode.
