### PR TITLE
ENH: allow sph_inkn for order n=0

### DIFF
--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -372,12 +372,16 @@ def sph_inkn(n,z):
         raise ValueError("arguments must be scalars.")
     if (n != floor(n)) or (n < 0):
         raise ValueError("n must be a non-negative integer.")
-    if iscomplex(z) or less(z,0):
-        nm,In,Inp,kn,knp = specfun.csphik(n,z)
+    if (n < 1):
+        n1 = 1
     else:
-        nm,In,Inp = specfun.sphi(n,z)
-        nm,kn,knp = specfun.sphk(n,z)
-    return In,Inp,kn,knp
+        n1 = n
+    if iscomplex(z) or less(z,0):
+        nm,In,Inp,kn,knp = specfun.csphik(n1,z)
+    else:
+        nm,In,Inp = specfun.sphi(n1,z)
+        nm,kn,knp = specfun.sphk(n1,z)
+    return In[:(n+1)],Inp[:(n+1)],kn[:(n+1)],knp[:(n+1)]
 
 
 def riccati_jn(n,x):

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2658,6 +2658,21 @@ class TestSpherical(TestCase):
         inkn = r_[special.sph_inkn(1,.2)]
         assert_array_almost_equal(inkn,spikn,10)
 
+    def test_sph_in_kn_order0(self):
+        x = 1.
+        sph_i0 = special.sph_in(0, x)
+        sph_i0_expected = np.array([np.sinh(x)/x,
+                                    np.cosh(x)/x-np.sinh(x)/x**2])
+        assert_array_almost_equal(r_[sph_i0], sph_i0_expected)
+        sph_k0 = special.sph_kn(0, x)
+        sph_k0_expected = np.array([0.5*pi*exp(-x)/x,
+                                    -0.5*pi*exp(-x)*(1/x+1/x**2)])
+        assert_array_almost_equal(r_[sph_k0], sph_k0_expected)
+        sph_i0k0 = special.sph_inkn(0, x)
+        assert_array_almost_equal(r_[sph_i0+sph_k0],
+                                  r_[sph_i0k0],
+                                  10)
+
     def test_sph_jn(self):
         s1 = special.sph_jn(2,.2)
         s10 = -s1[0][1]


### PR DESCRIPTION
The modified spherical Bessel functions `sph_in` and `sph_kn` allow for order `n=0` while the combined function `sph_inkn` does not. In `specfun`, the minimum order has to be `n=1` which is solved in `sph_in` and `sph_kn` by using at least order `n=1` and returning a smaller array if `n=0` was requested. I propose to do the same for `sph_inkn` to avoid an unnecessary `specfun.error`. 
