### PR TITLE
Backport #3033 to 0.13.x

### DIFF
--- a/scipy/ndimage/src/_ni_label.pyx
+++ b/scipy/ndimage/src/_ni_label.pyx
@@ -119,13 +119,31 @@ ctypedef bint (*write_line_func_t)(void *p, np.intp_t stride,
 cdef inline np.uintp_t mark_for_merge(np.uintp_t a,
                                       np.uintp_t b,
                                       np.uintp_t *mergetable) nogil:
-    # we keep the mergetable such that merged labels always point to the
-    # smallest value in the merge.
-    if mergetable[a] < mergetable[b]:
-        mergetable[b] = mergetable[a]
-    elif mergetable[a] > mergetable[b]:
-        mergetable[a] = mergetable[b]
-    return mergetable[a]
+
+    cdef:
+        np.uintp_t orig_a, orig_b, minlabel
+
+    orig_a = a
+    orig_b = b
+    # find smallest root for each of a and b
+    while a != mergetable[a]:
+        a = mergetable[a]
+    while b != mergetable[b]:
+        b = mergetable[b]
+    minlabel = a if (a < b) else b
+
+    # merge roots
+    mergetable[a] = mergetable[b] = minlabel
+
+    # merge every step to minlabel
+    a = orig_a
+    b = orig_b
+    while a != minlabel:
+        a, mergetable[a] = mergetable[a], minlabel
+    while b != minlabel:
+        b, mergetable[b] = mergetable[b], minlabel
+
+    return minlabel
 
 
 ######################################################################

--- a/scipy/ndimage/tests/test_regression.py
+++ b/scipy/ndimage/tests/test_regression.py
@@ -35,5 +35,15 @@ def test_ticket_742():
         # shouldn't crash
         SE(a)
 
+def test_gh_issue_3025():
+    """Github issue #3025 - improper merging of labels"""
+    d = np.zeros((60,320))
+    d[:,:257] = 1
+    d[:,260:] = 1
+    d[36,257] = 1
+    d[35,258] = 1
+    d[35,259] = 1
+    assert ndimage.label(d, np.ones((3,3)))[1] == 1
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Backport ndimage.label bugfix #3033 for maintenance/0.13.x

See https://github.com/scipy/scipy/issues/3049
