### PR TITLE
BUG: fix non normalized vectors in gen. eig solver

### DIFF
--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -21,8 +21,9 @@ import numpy
 from numpy import array, asarray_chkfinite, asarray, diag, zeros, ones, \
         isfinite, inexact, nonzero, iscomplexobj, cast, flatnonzero, conj
 # Local imports
+from scipy.lib.six import xrange
 from scipy.linalg import calc_lwork
-from .misc import LinAlgError, _datacopied
+from .misc import LinAlgError, _datacopied, norm
 from .lapack import get_lapack_funcs
 from .blas import get_blas_funcs
 
@@ -71,6 +72,12 @@ def _geneig(a1, b1, left, right, overwrite_a, overwrite_b):
             vl = _make_complex_eigvecs(w, vl, t)
         if right:
             vr = _make_complex_eigvecs(w, vr, t)
+
+    # the eigenvectors returned rfom the lapack function are NOT normalized
+    for i in xrange(vr.shape[0]):
+        vr[:, i] /= norm(vr[:, i])
+        vl[:, i] /= norm(vl[:, i])
+
     if not (left or right):
         return w
     if left:

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -24,6 +24,7 @@ from scipy.linalg import eig, eigvals, lu, svd, svdvals, cholesky, qr, \
      qz
 from scipy.linalg.lapack import dgbtrf, dgbtrs, zgbtrf, zgbtrs, \
      dsbev, dsbevd, dsbevx, zhbevd, zhbevx
+from scipy.linalg.misc import norm
 
 from numpy import array, transpose, sometrue, diag, ones, linalg, \
      argsort, zeros, arange, float32, complex64, dot, conj, identity, \
@@ -204,6 +205,11 @@ class TestEig(object):
 
         assert_array_almost_equal(sort(w[isfinite(w)]), sort(wt[isfinite(wt)]),
                                   err_msg=msg)
+
+        length = np.empty(len(vr))
+        for i in xrange(len(vr)):
+            length[i] = norm(vr[:, i])
+        assert_array_almost_equal(length, np.ones(length.size), err_msg=msg)
 
     def test_singular(self):
         """Test singular pair"""


### PR DESCRIPTION
The eigenvectors returned by the generalized eigenvalue solver were not
normalized. This seems to be an error in the lapack function. This
commit adds a fix for scipy and a unit-test
