### PR TITLE
ENH: fast paths for hstack/vstack with csc/csr matrices

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -443,9 +443,6 @@ def hstack(blocks, format=None, dtype=None):
             [3, 4, 6]])
 
     """
-    if format in (None,'csc') and all(b.format == 'csc' for b in blocks):
-        # Fast path for hstacking CSC matrices
-        return _compressed_sparse_stack(blocks, 0)
     return bmat([blocks], format=format, dtype=dtype)
 
 
@@ -477,9 +474,6 @@ def vstack(blocks, format=None, dtype=None):
             [5, 6]])
 
     """
-    if format in (None,'csr') and all(b.format == 'csr' for b in blocks):
-        # Fast path for vstacking CSR matrices
-        return _compressed_sparse_stack(blocks, 1)
     return bmat([[b] for b in blocks], format=format, dtype=dtype)
 
 

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -404,9 +404,10 @@ def _compressed_sparse_stack(blocks, axis):
         if b.shape[axis] != constant_dim:
             raise ValueError('incompatible dimensions for axis %d' % axis)
         sum_dim += b.shape[~axis]
-        indptr.extend(b.indptr[:-1] + last_indptr)
+        indptr.append(b.indptr[:-1] + last_indptr)
         last_indptr += b.indptr[-1]
-    indptr.append(last_indptr)
+    indptr.append([last_indptr])
+    indptr = np.concatenate(indptr)
     if axis == 1:
         return csr_matrix((data, indices, indptr),
                           shape=(sum_dim, constant_dim))

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -534,12 +534,12 @@ def bmat(blocks, format=None, dtype=None):
     M,N = blocks.shape
 
     # check for fast path cases
-    if (M == 1 and format in (None, 'csr')
+    if (N == 1 and format in (None, 'csr')
         and all(b is not None and b.format == 'csr' for b in blocks.flat)):
-        return _compressed_sparse_stack(blocks, 1)
-    elif (N == 1 and format in (None, 'csc')
+        return _compressed_sparse_stack(blocks[:,0], 1)
+    elif (M == 1 and format in (None, 'csc')
           and all(b is not None and b.format == 'csc' for b in blocks.flat)):
-        return _compressed_sparse_stack(blocks, 0)
+        return _compressed_sparse_stack(blocks[0,:], 0)
 
     block_mask = np.zeros(blocks.shape, dtype=np.bool)
     brow_lengths = np.zeros(blocks.shape[0], dtype=np.intc)

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -276,6 +276,8 @@ class TestConstructUtils(TestCase):
                            [3, 4],
                            [5, 6]])
         assert_equal(construct.vstack([A,B]).todense(), expected)
+        assert_equal(construct.vstack([A.tocsr(),B.tocsr()]).todense(),
+                     expected)
 
     def test_hstack(self):
 
@@ -285,6 +287,8 @@ class TestConstructUtils(TestCase):
         expected = matrix([[1, 2, 5],
                            [3, 4, 6]])
         assert_equal(construct.hstack([A,B]).todense(), expected)
+        assert_equal(construct.hstack([A.tocsc(),B.tocsc()]).todense(),
+                     expected)
 
     def test_bmat(self):
 


### PR DESCRIPTION
The current version calls `bmat`, which converts everything to COO format. This change provides a considerable speedup for the fast-path cases:

```
import numpy as np
import scipy.sparse as sps
a = sps.csc_matrix(np.arange(1000).reshape(5,-1))
b = sps.csc_matrix(np.arange(1000).reshape(5,-1))
```

Before this PR:

```
%timeit sps.hstack((a,b))
1000 loops, best of 3: 820 us per loop
```

After:

```
%timeit sps.hstack((a,b))
1000 loops, best of 3: 113 us per loop
```
