### PR TITLE
FIX: spsolve deals with vectors improperly (#3032)

### DIFF
--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -97,7 +97,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
         b = b.squeeze()
 
     else:
-        if isspmatrix(b) and not (isspmatrix_csc(b) or isspmatrix_csr(b)):
+        if not (isspmatrix_csc(b) or isspmatrix_csr(b)):
             b = csc_matrix(b)
             warn('solve requires b be CSC or CSR matrix format',
                  SparseEfficiencyWarning)

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -89,7 +89,8 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
                 SparseEfficiencyWarning)
 
     # b is a vector only if b have shape (n,) or (n, 1)
-    b_is_vector = ((b.ndim == 1) or (b.ndim == 2 and b.shape[1] == 1))
+    b_is_squeezed = b.ndim == 1
+    b_is_vector = (b_is_squeezed or (b.ndim == 2 and b.shape[1] == 1))
     b_is_sparse_matrix = isspmatrix(b)
 
     if b_is_vector:
@@ -156,6 +157,10 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             tempj.fill(j)
             x = x + A.__class__((xj[w], (w, tempj[:len(w)])),
                                 shape=b.shape, dtype=A.dtype)
+
+    if b_is_vector and not b_is_squeezed:
+        x = x.reshape((M, 1))
+
     return x
 
 

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -98,6 +98,23 @@ class TestLinsolve(TestCase):
 
             assert_array_almost_equal(X, sX.todense())
 
+    def test_shape_compatibility(self):
+        A = csc_matrix([[1.]])
+        x = array([[1., 2., 3.]])
+        b = csc_matrix([[1., 2., 3.]])
+        assert_array_almost_equal(x, spsolve(A, b).todense())
+
+        A = csc_matrix((3, 3))
+        b = csc_matrix((1, 3))
+        assert_raises(ValueError, spsolve, A, b)
+
+    def test_ndarray_support(self):
+        A = array([[1., 2.], [2., 0.]])
+        x = array([[1., 1.], [0.5, -0.5]]) 
+        b = array([[2., 0.], [2., 2.]])
+
+        assert_array_almost_equal(x, spsolve(A, b).todense())
+
 
 class TestSplu(object):
     def setUp(self):

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -9,7 +9,9 @@ from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal,
 
 import scipy.linalg
 from scipy.linalg import norm, inv
-from scipy.sparse import spdiags, SparseEfficiencyWarning, csc_matrix, csr_matrix
+from scipy.sparse import spdiags, SparseEfficiencyWarning, \
+csc_matrix, csr_matrix, bsr_matrix, coo_matrix, dia_matrix, \
+dok_matrix, lil_matrix
 from scipy.sparse.linalg.dsolve import spsolve, use_solver, splu, spilu
 
 warnings.simplefilter('ignore',SparseEfficiencyWarning)
@@ -114,6 +116,39 @@ class TestLinsolve(TestCase):
         b = array([[2., 0.], [2., 2.]])
 
         assert_array_almost_equal(x, spsolve(A, b).todense())
+
+    def test_various_types_of_b(self):
+        A = csc_matrix([[1., 2.], [2., 0.]])
+
+        b_vec = [[2.5], [1.]]
+        x_vec = [.5, 1.]
+        b_vec_s = [
+                array(b_vec),
+                array(b_vec).flatten(),
+                csc_matrix(b_vec),
+                csr_matrix(b_vec),
+                bsr_matrix(b_vec),
+                dia_matrix(b_vec),
+                dok_matrix(b_vec),
+                lil_matrix(b_vec),
+                ]
+
+        b_mat = [[2., 0.], [2., 2.]]
+        x_mat = [[1., 1.], [0.5, -0.5]]
+        b_mat_s = [
+                array(b_mat),
+                csc_matrix(b_mat),
+                csr_matrix(b_mat),
+                bsr_matrix(b_mat),
+                dia_matrix(b_mat),
+                dok_matrix(b_mat),
+                lil_matrix(b_mat),
+                ]
+
+        for b in b_vec_s:
+            assert_array_almost_equal(x_vec, spsolve(A, b))
+        for b in b_mat_s:
+            assert_array_almost_equal(x_mat, spsolve(A, b).todense())
 
 
 class TestSplu(object):

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -10,8 +10,8 @@ from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal,
 import scipy.linalg
 from scipy.linalg import norm, inv
 from scipy.sparse import spdiags, SparseEfficiencyWarning, \
-csc_matrix, csr_matrix, bsr_matrix, coo_matrix, dia_matrix, \
-dok_matrix, lil_matrix
+    csc_matrix, csr_matrix, bsr_matrix, coo_matrix, dia_matrix, \
+    dok_matrix, lil_matrix
 from scipy.sparse.linalg.dsolve import spsolve, use_solver, splu, spilu
 
 warnings.simplefilter('ignore',SparseEfficiencyWarning)
@@ -112,7 +112,7 @@ class TestLinsolve(TestCase):
 
     def test_ndarray_support(self):
         A = array([[1., 2.], [2., 0.]])
-        x = array([[1., 1.], [0.5, -0.5]]) 
+        x = array([[1., 1.], [0.5, -0.5]])
         b = array([[2., 0.], [2., 2.]])
 
         assert_array_almost_equal(x, spsolve(A, b).todense())
@@ -121,10 +121,9 @@ class TestLinsolve(TestCase):
         A = csc_matrix([[1., 2.], [2., 0.]])
 
         b_vec = [[2.5], [1.]]
-        x_vec = [.5, 1.]
+        x_vec = [[.5], [1.]]
         b_vec_s = [
                 array(b_vec),
-                array(b_vec).flatten(),
                 csc_matrix(b_vec),
                 csr_matrix(b_vec),
                 bsr_matrix(b_vec),
@@ -145,6 +144,8 @@ class TestLinsolve(TestCase):
                 lil_matrix(b_mat),
                 ]
 
+        assert_array_almost_equal(array(x_vec).flatten(),
+                spsolve(A, array(b_vec).flatten()))
         for b in b_vec_s:
             assert_array_almost_equal(x_vec, spsolve(A, b))
         for b in b_mat_s:


### PR DESCRIPTION
`sparse.linalg.spsolve` deals with vectors imporperly (#3032).
In addition, `spsolve` will fail when `b` is an ndarray.
