### PR TITLE
TST Use same C runtime library as Python executable

### DIFF
--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -12,6 +12,7 @@ from scipy.lib.six import xrange
 
 try:
     import ctypes
+    import ctypes.util
     _ctypes_missing = False
 except ImportError:
     _ctypes_missing = True
@@ -28,7 +29,7 @@ class TestCtypesQuad(TestCase):
     @dec.skipif(_ctypes_missing, msg="Ctypes library could not be found")
     def setUp(self):
         if sys.platform == 'win32':
-            file = 'msvcrt.dll'
+            file = ctypes.util.find_msvcrt()
         elif sys.platform == 'darwin':
             file = 'libm.dylib'
         else:


### PR DESCRIPTION
Use `ctypes.util.find_msvcrt()` instead of `'msvcrt.dll'` on Windows. See https://pydocs2cn.readthedocs.org/en/latest/library/ctypes.html#ctypes.util.find_msvcrt
