### PR TITLE
BUG: ndimage: return signed dtype from label by default

### DIFF
--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -156,7 +156,7 @@ def label(input, structure=None, output=None):
     # Use 32 bits if it's large enough for this image.
     # _ni_label.label()  needs two entries for background and
     # foreground tracking
-    need_64bits = input.size < (2**32 - 2)
+    need_64bits = input.size < (2**31 - 2)
 
     if isinstance(output, numpy.ndarray):
         if output.shape != input.shape:
@@ -165,7 +165,7 @@ def label(input, structure=None, output=None):
     else:
         caller_provided_output = False
         if output is None:
-            output = np.empty(input.shape, np.uintp if need_64bits else np.uint32)
+            output = np.empty(input.shape, np.intp if need_64bits else np.int32)
         else:
             output = np.empty(input.shape, output)
 
@@ -188,7 +188,7 @@ def label(input, structure=None, output=None):
     except _ni_label.NeedMoreBits:
         # Make another attempt with enough bits, then try to cast to the
         # new type.
-        tmp_output = np.empty(input.shape, np.uintp if need_64bits else np.uint32)
+        tmp_output = np.empty(input.shape, np.intp if need_64bits else np.int32)
         max_label = _ni_label._label(input, structure, tmp_output)
         output[...] = tmp_output[...]
         if not np.all(output == tmp_output):

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -343,6 +343,14 @@ def test_label_structuring_elements():
             r += 1
 
 
+def test_label_default_dtype():
+    test_array = np.random.rand(10, 10)
+    label, no_features = ndimage.label(test_array > 0.5)
+    assert_(label.dtype in (np.int32, np.int64))
+    # Shouldn't raise an exception
+    ndimage.find_objects(label)
+
+
 def test_find_objects01():
     "find_objects 1"
     data = np.ones([], dtype=int)


### PR DESCRIPTION
Change default return dtype from ndimage.label back to signed integer,
as find_objects and some other functions don't support unsigned intp.

Fixes gh-1992
