### PR TITLE
BUG: ndimage: use only normalized type_num in comparisons

### DIFF
--- a/scipy/ndimage/src/nd_image.h
+++ b/scipy/ndimage/src/nd_image.h
@@ -93,7 +93,7 @@ the specified type.
 static int
 satisfies(PyArrayObject *a, int requirements, NumarrayType t)
 {
-        int type_ok = (a->descr->type_num == t) || (t == tAny);
+        int type_ok = (t == tAny) || PyArray_EquivTypenums(a->descr->type_num, t);
 
         if (PyArray_ISCARRAY(a))
                 return type_ok;

--- a/scipy/ndimage/src/ni_filters.c
+++ b/scipy/ndimage/src/ni_filters.c
@@ -217,7 +217,7 @@ int NI_Correlate(PyArrayObject* input, PyArrayObject* weights,
     oo = offsets;
     for(jj = 0; jj < size; jj++) {
         double tmp = 0.0;
-        switch (input->descr->type_num) {
+        switch (NI_NormalizeType(input->descr->type_num)) {
             CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, Bool,
                                                      tmp, border_flag_value);
             CASE_CORRELATE_POINT(pi, ww, oo, filter_size, cvalue, UInt8,
@@ -246,7 +246,7 @@ int NI_Correlate(PyArrayObject* input, PyArrayObject* weights,
             PyErr_SetString(PyExc_RuntimeError, "array type not supported");
             goto exit;
         }
-        switch (output->descr->type_num) {
+        switch (NI_NormalizeType(output->descr->type_num)) {
             CASE_FILTER_OUT(po, tmp, Bool);
             CASE_FILTER_OUT(po, tmp, UInt8);
             CASE_FILTER_OUT(po, tmp, UInt16);
@@ -489,7 +489,7 @@ int NI_MinOrMaxFilter(PyArrayObject* input, PyArrayObject* footprint,
     oo = offsets;
     for(jj = 0; jj < size; jj++) {
         double tmp = 0.0;
-        switch (input->descr->type_num) {
+        switch (NI_NormalizeType(input->descr->type_num)) {
             CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, Bool,
                                                         minimum, tmp, border_flag_value, ss);
             CASE_MIN_OR_MAX_POINT(pi, oo, filter_size, cvalue, UInt8,
@@ -518,7 +518,7 @@ int NI_MinOrMaxFilter(PyArrayObject* input, PyArrayObject* footprint,
             PyErr_SetString(PyExc_RuntimeError, "array type not supported");
             goto exit;
         }
-        switch (output->descr->type_num) {
+        switch (NI_NormalizeType(output->descr->type_num)) {
             CASE_FILTER_OUT(po, tmp, Bool);
             CASE_FILTER_OUT(po, tmp, UInt8);
             CASE_FILTER_OUT(po, tmp, UInt16);
@@ -649,7 +649,7 @@ int NI_RankFilter(PyArrayObject* input, int rank,
     oo = offsets;
     for(jj = 0; jj < size; jj++) {
         double tmp = 0.0;
-        switch (input->descr->type_num) {
+        switch (NI_NormalizeType(input->descr->type_num)) {
             CASE_RANK_POINT(pi, oo, filter_size, cvalue, Bool,
                                             rank, buffer, tmp, border_flag_value);
             CASE_RANK_POINT(pi, oo, filter_size, cvalue, UInt8,
@@ -678,7 +678,7 @@ int NI_RankFilter(PyArrayObject* input, int rank,
             PyErr_SetString(PyExc_RuntimeError, "array type not supported");
             goto exit;
         }
-        switch (output->descr->type_num) {
+        switch (NI_NormalizeType(output->descr->type_num)) {
             CASE_FILTER_OUT(po, tmp, Bool);
             CASE_FILTER_OUT(po, tmp, UInt8);
             CASE_FILTER_OUT(po, tmp, UInt16);
@@ -833,7 +833,7 @@ int NI_GenericFilter(PyArrayObject* input,
     oo = offsets;
     for(jj = 0; jj < size; jj++) {
         double tmp = 0.0;
-        switch (input->descr->type_num) {
+        switch (NI_NormalizeType(input->descr->type_num)) {
             CASE_FILTER_POINT(pi, oo, filter_size, cvalue, Bool,
                                                 tmp, border_flag_value, function, data, buffer);
             CASE_FILTER_POINT(pi, oo, filter_size, cvalue, UInt8,
@@ -862,7 +862,7 @@ int NI_GenericFilter(PyArrayObject* input,
             PyErr_SetString(PyExc_RuntimeError, "array type not supported");
             goto exit;
         }
-        switch (output->descr->type_num) {
+        switch (NI_NormalizeType(output->descr->type_num)) {
             CASE_FILTER_OUT(po, tmp, Bool);
             CASE_FILTER_OUT(po, tmp, UInt8);
             CASE_FILTER_OUT(po, tmp, UInt16);

--- a/scipy/ndimage/src/ni_fourier.c
+++ b/scipy/ndimage/src/ni_fourier.c
@@ -360,17 +360,17 @@ int NI_FourierFilter(PyArrayObject *input, PyArrayObject* parameter_array,
         default:
             break;
         }
-        if (input->descr->type_num == tComplex64 ||
-                input->descr->type_num == tComplex128) {
+        if (NI_NormalizeType(input->descr->type_num) == tComplex64 ||
+                NI_NormalizeType(input->descr->type_num) == tComplex128) {
             double tmp_r = 0.0, tmp_i = 0.0;
-            switch (input->descr->type_num) {
+            switch (NI_NormalizeType(input->descr->type_num)) {
                 CASE_FOURIER_FILTER_RC(pi, tmp, tmp_r, tmp_i, Complex64);
                 CASE_FOURIER_FILTER_RC(pi, tmp, tmp_r, tmp_i, Complex128);
             default:
                 PyErr_SetString(PyExc_RuntimeError, "data type not supported");
                 goto exit;
             }
-            switch (output->descr->type_num) {
+            switch (NI_NormalizeType(output->descr->type_num)) {
                 CASE_FOURIER_OUT_CC(po, tmp_r, tmp_i, Complex64);
                 CASE_FOURIER_OUT_CC(po, tmp_r, tmp_i, Complex128);
             default:
@@ -378,7 +378,7 @@ int NI_FourierFilter(PyArrayObject *input, PyArrayObject* parameter_array,
                 goto exit;
             }
         } else {
-            switch (input->descr->type_num) {
+            switch (NI_NormalizeType(input->descr->type_num)) {
                 CASE_FOURIER_FILTER_RR(pi, tmp, Bool)
                 CASE_FOURIER_FILTER_RR(pi, tmp, UInt8)
                 CASE_FOURIER_FILTER_RR(pi, tmp, UInt16)
@@ -396,7 +396,7 @@ int NI_FourierFilter(PyArrayObject *input, PyArrayObject* parameter_array,
                 PyErr_SetString(PyExc_RuntimeError, "data type not supported");
                 goto exit;
             }
-            switch (output->descr->type_num) {
+            switch (NI_NormalizeType(output->descr->type_num)) {
                 CASE_FOURIER_OUT_RR(po, tmp, Float32);
                 CASE_FOURIER_OUT_RR(po, tmp, Float64);
                 CASE_FOURIER_OUT_RC(po, tmp, Complex64);
@@ -508,7 +508,7 @@ int NI_FourierShift(PyArrayObject *input, PyArrayObject* shift_array,
                 tmp += params[kk][ii.coordinates[kk]];
         sint = sin(tmp);
         cost = cos(tmp);
-        switch (input->descr->type_num) {
+        switch (NI_NormalizeType(input->descr->type_num)) {
             CASE_FOURIER_SHIFT_R(pi, tmp, r, i, cost, sint, Bool)
             CASE_FOURIER_SHIFT_R(pi, tmp, r, i, cost, sint, UInt8)
             CASE_FOURIER_SHIFT_R(pi, tmp, r, i, cost, sint, UInt16)
@@ -528,7 +528,7 @@ int NI_FourierShift(PyArrayObject *input, PyArrayObject* shift_array,
             PyErr_SetString(PyExc_RuntimeError, "data type not supported");
             goto exit;
         }
-        switch (output->descr->type_num) {
+        switch (NI_NormalizeType(output->descr->type_num)) {
             CASE_FOURIER_OUT_CC(po, r, i, Complex64);
             CASE_FOURIER_OUT_CC(po, r, i, Complex128);
         default:

--- a/scipy/ndimage/src/ni_measure.c
+++ b/scipy/ndimage/src/ni_measure.c
@@ -96,7 +96,7 @@ int NI_FindObjects(PyArrayObject* input, npy_intp max_label,
     }
     /* iterate over all points: */
     for(jj = 0 ; jj < size; jj++) {
-        switch (input->descr->type_num) {
+        switch (NI_NormalizeType(input->descr->type_num)) {
         CASE_FIND_OBJECT_POINT(pi, regions, input->nd, input->dimensions,
                                                      max_label, ii,  Bool);
         CASE_FIND_OBJECT_POINT(pi, regions, input->nd, input->dimensions,
@@ -347,7 +347,7 @@ int NI_Statistics(PyArrayObject *input, PyArrayObject *labels,
     }
     /* iterate over array: */
     for(jj = 0; jj < size; jj++) {
-        NI_GET_LABEL(pm, label, labels->descr->type_num);
+        NI_GET_LABEL(pm, label, NI_NormalizeType(labels->descr->type_num));
         if (min_label >= 0) {
             if (label >= min_label && label <= max_label) {
                 idx = indices[label - min_label];
@@ -360,7 +360,7 @@ int NI_Statistics(PyArrayObject *input, PyArrayObject *labels,
         }
         if (doit) {
             double val;
-            NI_GET_VALUE(pi, val, input->descr->type_num);
+            NI_GET_VALUE(pi, val, NI_NormalizeType(input->descr->type_num));
             if (sum)
                 sum[idx] += val;
             if (total)
@@ -411,7 +411,7 @@ int NI_Statistics(PyArrayObject *input, PyArrayObject *labels,
                 pm = (void *)PyArray_DATA(labels);
             }
             for(jj = 0; jj < size; jj++) {
-                NI_GET_LABEL(pm, label, labels->descr->type_num);
+                NI_GET_LABEL(pm, label, NI_NormalizeType(labels->descr->type_num));
                 if (min_label >= 0) {
                     if (label >= min_label && label <= max_label) {
                         idx = indices[label - min_label];
@@ -424,7 +424,7 @@ int NI_Statistics(PyArrayObject *input, PyArrayObject *labels,
                 }
                 if (doit) {
                     double val;
-                    NI_GET_VALUE(pi, val, input->descr->type_num);
+                    NI_GET_VALUE(pi, val, NI_NormalizeType(input->descr->type_num));
                     val = val - sum[idx] / total[idx];
                     variance[idx] += val * val;
                 }
@@ -479,7 +479,7 @@ int NI_CenterOfMass(PyArrayObject *input, PyArrayObject *labels,
     }
     /* iterate over array: */
     for(jj = 0; jj < size; jj++) {
-        NI_GET_LABEL(pm, label, labels->descr->type_num);
+        NI_GET_LABEL(pm, label, NI_NormalizeType(labels->descr->type_num));
         if (min_label >= 0) {
             if (label >= min_label && label <= max_label) {
                 idx = indices[label - min_label];
@@ -492,7 +492,7 @@ int NI_CenterOfMass(PyArrayObject *input, PyArrayObject *labels,
         }
         if (doit) {
             double val;
-            NI_GET_VALUE(pi, val, input->descr->type_num);
+            NI_GET_VALUE(pi, val, NI_NormalizeType(input->descr->type_num));
             sum[idx] += val;
             for(kk = 0; kk < input->nd; kk++)
                 center_of_mass[idx * input->nd + kk] += val * ii.coordinates[kk];
@@ -552,7 +552,7 @@ int NI_Histogram(PyArrayObject *input, PyArrayObject *labels,
         size *= input->dimensions[qq];
     /* iterate over array: */
     for(jj = 0; jj < size; jj++) {
-        NI_GET_LABEL(pm, label, labels->descr->type_num);
+        NI_GET_LABEL(pm, label, NI_NormalizeType(labels->descr->type_num));
         if (min_label >= 0) {
             if (label >= min_label && label <= max_label) {
                 idx = indices[label - min_label];
@@ -566,7 +566,7 @@ int NI_Histogram(PyArrayObject *input, PyArrayObject *labels,
         if (doit) {
             int bin;
             double val;
-            NI_GET_VALUE(pi, val, input->descr->type_num);
+            NI_GET_VALUE(pi, val, NI_NormalizeType(input->descr->type_num));
             if (val >= min && val < max) {
                 bin = (int)((val - min) / bsize);
                 ++(ph[idx][bin]);
@@ -692,7 +692,7 @@ int NI_WatershedIFT(PyArrayObject* input, PyArrayObject* markers,
     maxval = 0;
     for(jj = 0; jj < size; jj++) {
         int ival = 0;
-        switch(input->descr->type_num) {
+        switch(NI_NormalizeType(input->descr->type_num)) {
         CASE_GET_INPUT(ival, pi, UInt8);
         CASE_GET_INPUT(ival, pi, UInt16);
         default:
@@ -731,7 +731,7 @@ int NI_WatershedIFT(PyArrayObject* input, PyArrayObject* markers,
     for(jj = 0; jj < size; jj++) {
         /* get marker */
         int label = 0;
-        switch(markers->descr->type_num) {
+        switch(NI_NormalizeType(markers->descr->type_num)) {
         CASE_GET_LABEL(label, pm, UInt8);
         CASE_GET_LABEL(label, pm, UInt16);
         CASE_GET_LABEL(label, pm, UInt32);
@@ -746,7 +746,7 @@ int NI_WatershedIFT(PyArrayObject* input, PyArrayObject* markers,
             PyErr_SetString(PyExc_RuntimeError, "data type not supported");
             goto exit;
         }
-        switch(output->descr->type_num) {
+        switch(NI_NormalizeType(output->descr->type_num)) {
         CASE_PUT_LABEL(label, pl, UInt8);
         CASE_PUT_LABEL(label, pl, UInt16);
         CASE_PUT_LABEL(label, pl, UInt32);
@@ -869,7 +869,7 @@ int NI_WatershedIFT(PyArrayObject* input, PyArrayObject* markers,
                     if (!(p->done)) {
                         /* If the neighbor was not processed yet: */
                         int max, pval, vval, wvp, pcost, label, p_idx, v_idx;
-                        switch(input->descr->type_num) {
+                        switch(NI_NormalizeType(input->descr->type_num)) {
                         CASE_WINDEX1(v_index, p_index, strides, input->strides,
                                                  input->nd, i_contiguous, p_idx, v_idx, pi,
                                                  vval, pval, UInt8);
@@ -894,7 +894,7 @@ int NI_WatershedIFT(PyArrayObject* input, PyArrayObject* markers,
                                  adapt the cost and the label of the neighbor: */
                             int idx;
                             p->cost = max;
-                            switch(output->descr->type_num) {
+                            switch(NI_NormalizeType(output->descr->type_num)) {
                             CASE_WINDEX2(v_index, strides, output->strides, input->nd,
                                                      idx, o_contiguous, label, pl, UInt8);
                             CASE_WINDEX2(v_index, strides, output->strides, input->nd,
@@ -918,7 +918,7 @@ int NI_WatershedIFT(PyArrayObject* input, PyArrayObject* markers,
                                                                 "data type not supported");
                                 goto exit;
                             }
-                            switch(output->descr->type_num) {
+                            switch(NI_NormalizeType(output->descr->type_num)) {
                             CASE_WINDEX3(p_index, strides, output->strides, input->nd,
                                                      idx, o_contiguous, label, pl, UInt8);
                             CASE_WINDEX3(p_index, strides, output->strides, input->nd,

--- a/scipy/ndimage/src/ni_morphology.c
+++ b/scipy/ndimage/src/ni_morphology.c
@@ -156,7 +156,7 @@ int NI_BinaryErosion(PyArrayObject* input, PyArrayObject* strct,
     for(jj = 0; jj < size; jj++) {
         int pchange = 0;
         if (mask) {
-            switch(mask->descr->type_num) {
+            switch(NI_NormalizeType(mask->descr->type_num)) {
             CASE_GET_MASK(msk_value, pm, Bool);
             CASE_GET_MASK(msk_value, pm, UInt8);
             CASE_GET_MASK(msk_value, pm, UInt16);
@@ -175,7 +175,7 @@ int NI_BinaryErosion(PyArrayObject* input, PyArrayObject* strct,
                 return 0;
             }
         }
-        switch (input->descr->type_num) {
+        switch (NI_NormalizeType(input->descr->type_num)) {
         CASE_NI_ERODE_POINT(pi, out, oo, struct_size, Bool, msk_value,
                                                 bdr_value, border_flag_value, center_is_true,
                                                 true, false, pchange);
@@ -215,7 +215,7 @@ int NI_BinaryErosion(PyArrayObject* input, PyArrayObject* strct,
             PyErr_SetString(PyExc_RuntimeError, "data type not supported");
             goto exit;
         }
-        switch (output->descr->type_num) {
+        switch (NI_NormalizeType(output->descr->type_num)) {
         CASE_OUTPUT(po, out, Bool);
         CASE_OUTPUT(po, out, UInt8);
         CASE_OUTPUT(po, out, UInt16);
@@ -397,7 +397,7 @@ int NI_BinaryErosion2(PyArrayObject* array, PyArrayObject* strct,
         NI_ITERATOR_GOTO(ii, current_coordinates1, ibase, pi);
         NI_FILTER_GOTO(fi, ii, 0, oo);
 
-        switch (array->descr->type_num) {
+        switch (NI_NormalizeType(array->descr->type_num)) {
         CASE_ERODE_POINT2(struct_size, offsets, coordinate_offsets, pi,
                                             oo, array->nd, list1, list2, current_coordinates1,
                                             current_coordinates2, block1, block2,


### PR DESCRIPTION
Numpy type_num cannot be directly used in comparisons, since some of the values are equivalent, depending on the platform.
