### PR TITLE
BUG: sparse boolean indexing flaky test

### DIFF
--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -258,6 +258,8 @@ class csr_matrix(_cs_matrix, IndexMixin):
             elif issequence(col):                     # [[1,2],[1,2]]
                 row = asindices(row)
                 col = asindices(col)
+                if len(row) == 0 or len(col) == 0:
+                    return csr_matrix((0,0))
                 if row.ndim == 1:
                     if row.shape != col.shape:
                         raise IndexError('number of row and column indices differ')

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2130,11 +2130,13 @@ class _TestFancyIndexing:
 
         assert_equal(todense(A[I, J]), B[I, J])
 
-        Z = np.array(np.random.randint(0, 2, size=(5, 11)), dtype=bool)
-        Y = np.array(np.random.randint(0, 2, size=(6, 10)), dtype=bool)
+        Z = np.ones((5, 11), dtype=bool)
+        Y = np.ones((6, 10), dtype=bool)
 
         assert_raises(IndexError, A.__getitem__, Z)
+        assert_raises(IndexError, A.__getitem__, ~Z)
         assert_raises(IndexError, A.__getitem__, Y)
+        assert_raises(IndexError, A.__getitem__, ~Y)
         assert_raises((IndexError, ValueError), A.__getitem__, (X, 1))
 
     def test_fancy_indexing_sparse_boolean(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2130,13 +2130,15 @@ class _TestFancyIndexing:
 
         assert_equal(todense(A[I, J]), B[I, J])
 
-        Z = np.ones((5, 11), dtype=bool)
-        Y = np.ones((6, 10), dtype=bool)
+        Z1 = np.zeros((6, 11), dtype=bool)
+        Z2 = np.zeros((6, 11), dtype=bool)
+        Z2[0,-1] = True
+        Z3 = np.zeros((6, 11), dtype=bool)
+        Z3[-1,0] = True
 
-        assert_raises(IndexError, A.__getitem__, Z)
-        assert_raises(IndexError, A.__getitem__, ~Z)
-        assert_raises(IndexError, A.__getitem__, Y)
-        assert_raises(IndexError, A.__getitem__, ~Y)
+        assert_equal(A[Z1], np.array([]))
+        assert_raises(IndexError, A.__getitem__, Z2)
+        assert_raises(IndexError, A.__getitem__, Z3)
         assert_raises((IndexError, ValueError), A.__getitem__, (X, 1))
 
     def test_fancy_indexing_sparse_boolean(self):


### PR DESCRIPTION
The `test_fancy_indexing_boolean` test case was passing erroneously due to the random initialization of `Z` and `Y`.
Making changes to other parts of the file caused this case to fail when the last column of `Z` happened to be all `False`.

I looked at how numpy arrays handle boolean indexing, and changed the test case to reflect that behavior. In doing so, I had to fix a small bug with CSR matrices.
