### PR TITLE
basinhopping: deal more cleanly with failed minimizations

### DIFF
--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -69,11 +69,10 @@ class BasinHoppingRunner(object):
 
         # do initial minimization
         minres = minimizer(self.x)
-        if hasattr(minres, "success"):
-            if not minres.success:
-                self.res.minimization_failures += 1
-                if self.disp:
-                    print("warning: basinhopping: local minimization failure")
+        if not minres.success:
+            self.res.minimization_failures += 1
+            if self.disp:
+                print("warning: basinhopping: local minimization failure")
         self.x = np.copy(minres.x)
         self.energy = minres.fun
         if self.disp:
@@ -104,11 +103,10 @@ class BasinHoppingRunner(object):
         minres = self.minimizer(x_after_step)
         x_after_quench = minres.x
         energy_after_quench = minres.fun
-        if hasattr(minres, "success"):
-            if not minres.success:
-                self.res.minimization_failures += 1
-                if self.disp:
-                    print("warning: basinhopping: local minimization failure")
+        if not minres.success:
+            self.res.minimization_failures += 1
+            if self.disp:
+                print("warning: basinhopping: local minimization failure")
         if hasattr(minres, "nfev"):
             self.res.nfev += minres.nfev
         if hasattr(minres, "njev"):

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -12,10 +12,10 @@ __all__ = ['basinhopping']
 
 
 class Storage(object):
+    """
+    Class used to store the lowest energy structure
+    """
     def __init__(self, x, f):
-        """
-        Class used to store the lowest energy structure
-        """
         self._add(x, f)
 
     def _add(self, x, f):
@@ -34,6 +34,26 @@ class Storage(object):
 
 
 class BasinHoppingRunner(object):
+    """this class implements the core of the basinhopping algorithm
+
+    x0 : ndarray
+        The starting coordinates
+    minimizer : callable, ``result = minimizer(x)``
+        The local minimizer.  The return value is a scpipy.optimize.Result
+        object
+    step_taking : callable, ``x_new = step_taking(x)``
+        This function displaces the coordinates randomly.  x can be modified
+        in-place.
+    accept_tests : list of callables
+        To each test is passed the kwargs `f_new`, `x_new`, `f_old` and
+        `x_old`.  These tests will be used to judge whether or not to accept
+        the step.  The acceptable return values are True, False, or ``"force
+        accept"``.  If the latter, then this will override any other tests in
+        order to accept the step.  This can be used, for example, to forcefully
+        escape from a local minimum that ``basinhopping`` is trapped in.
+    disp : bool, optional
+        display status messages
+    """
     def __init__(self, x0, minimizer, step_taking, accept_tests, disp=False):
         self.x = np.copy(x0)
         self.minimizer = minimizer
@@ -43,18 +63,25 @@ class BasinHoppingRunner(object):
 
         self.nstep = 0
 
-        #do initial minimization
+        # initialize return object
+        self.res = scipy.optimize.Result()
+        self.res.minimization_failures = 0
+
+        # do initial minimization
         minres = minimizer(self.x)
+        if hasattr(minres, "success"):
+            if not minres.success:
+                self.res.minimization_failures += 1
+                if self.disp:
+                    print("warning: basinhopping: local minimization failure")
         self.x = np.copy(minres.x)
         self.energy = minres.fun
         if self.disp:
             print("basinhopping step %d: f %g" % (self.nstep, self.energy))
 
-        #initialize storage class
+        # initialize storage class
         self.storage = Storage(self.x, self.energy)
 
-        #initialize return object
-        self.res = scipy.optimize.Result()
         if hasattr(minres, "nfev"):
             self.res.nfev = minres.nfev
         if hasattr(minres, "njev"):
@@ -63,18 +90,25 @@ class BasinHoppingRunner(object):
             self.res.nhev = minres.nhev
 
     def _monte_carlo_step(self):
-        #Take a random step.  Make a copy of x because the step_taking
-        #algorithm might change x in place
+        """Do one monte carlo iteration
+
+        Randomly displace the coordinates, minimize, and decide whether
+        or not to accept the new coordinates.
+        """
+        # Take a random step.  Make a copy of x because the step_taking
+        # algorithm might change x in place
         x_after_step = np.copy(self.x)
         x_after_step = self.step_taking(x_after_step)
 
-        #do a local minimization
+        # do a local minimization
         minres = self.minimizer(x_after_step)
         x_after_quench = minres.x
         energy_after_quench = minres.fun
         if hasattr(minres, "success"):
-            if not minres.success and self.disp:
-                print("warning: basinhoppping: local minimization failure")
+            if not minres.success:
+                self.res.minimization_failures += 1
+                if self.disp:
+                    print("warning: basinhopping: local minimization failure")
         if hasattr(minres, "nfev"):
             self.res.nfev += minres.nfev
         if hasattr(minres, "njev"):
@@ -82,11 +116,11 @@ class BasinHoppingRunner(object):
         if hasattr(minres, "nhev"):
             self.res.nhev += minres.nhev
 
-        #accept the move based on self.accept_tests. If any test is false, than
-        #reject the step.  If any test returns the special value, the
-        #string 'force accept', accept the step regardless.
-        #This can be used to forcefully escape from a local minima if normal
-        #basin hopping steps are not sufficient.
+        # accept the move based on self.accept_tests. If any test is false,
+        # than reject the step.  If any test returns the special value, the
+        # string 'force accept', accept the step regardless.  This can be used
+        # to forcefully escape from a local minima if normal basin hopping
+        # steps are not sufficient.
         accept = True
         for test in self.accept_tests:
             testres = test(f_new=energy_after_quench, x_new=x_after_quench,
@@ -105,8 +139,8 @@ class BasinHoppingRunner(object):
                 raise ValueError("accept test must return bool or string "
                                  "'force accept'. Type is", type(testres))
 
-        #Report the result of the acceptance test to the take step class.  This
-        #is for adaptive step taking
+        # Report the result of the acceptance test to the take step class.
+        # This is for adaptive step taking
         if hasattr(self.step_taking, "report"):
             self.step_taking.report(accept, f_new=energy_after_quench,
                                     x_new=x_after_quench, f_old=self.energy,
@@ -115,6 +149,8 @@ class BasinHoppingRunner(object):
         return x_after_quench, energy_after_quench, accept
 
     def one_cycle(self):
+        """Do one cycle of the basinhopping algorithm
+        """
         self.nstep += 1
         new_global_min = False
 
@@ -125,14 +161,14 @@ class BasinHoppingRunner(object):
             self.x = np.copy(xtrial)
             new_global_min = self.storage.update(self.x, self.energy)
 
-        #print some information
+        # print some information
         if self.disp:
             self.print_report(energy_trial, accept)
             if new_global_min:
                 print("found new global minimum on step %d with function"
                       " value %g" % (self.nstep, self.energy))
 
-        #save some variables as BasinHoppingRunner attributes
+        # save some variables as BasinHoppingRunner attributes
         self.xtrial = xtrial
         self.energy_trial = energy_trial
         self.accept = accept
@@ -140,6 +176,7 @@ class BasinHoppingRunner(object):
         return new_global_min
 
     def print_report(self, energy_trial, accept):
+        """print a status update"""
         xlowest, energy_lowest = self.storage.get_lowest()
         print("basinhopping step %d: f %g trial_f %g accepted %d "
               " lowest_f %g" % (self.nstep, self.energy, energy_trial,
@@ -528,13 +565,13 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     """
     x0 = np.array(x0)
 
-    #set up minimizer
+    # set up minimizer
     if minimizer_kwargs is None:
         minimizer_kwargs = dict()
     wrapped_minimizer = MinimizerWrapper(scipy.optimize.minimize, func,
                                          **minimizer_kwargs)
 
-    #set up step taking algorithm
+    # set up step taking algorithm
     if take_step is not None:
         if not isinstance(take_step, collections.Callable):
             raise TypeError("take_step must be callable")
@@ -546,19 +583,19 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
         else:
             take_step_wrapped = take_step
     else:
-        #use default
+        # use default
         displace = RandomDisplacement(stepsize=stepsize)
         take_step_wrapped = AdaptiveStepsize(displace, interval=interval,
                                              verbose=disp)
 
-    #set up accept tests
+    # set up accept tests
     if accept_test is not None:
         if not isinstance(accept_test, collections.Callable):
             raise TypeError("accept_test must be callable")
         accept_tests = [accept_test]
     else:
         accept_tests = []
-    ##use default
+    # use default
     metropolis = Metropolis(T)
     accept_tests.append(metropolis)
 
@@ -568,7 +605,7 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     bh = BasinHoppingRunner(x0, wrapped_minimizer, take_step_wrapped,
                             accept_tests, disp=disp)
 
-    #start main iteration loop
+    # start main iteration loop
     count = 0
     message = ["requested number of basinhopping iterations completed"
                " successfully"]
@@ -576,7 +613,7 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
         new_global_min = bh.one_cycle()
 
         if isinstance(callback, collections.Callable):
-            #should we pass acopy of x?
+            # should we pass a copy of x?
             val = callback(bh.xtrial, bh.energy_trial, bh.accept)
             if val is not None:
                 if val:
@@ -591,7 +628,7 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
             message = ["success condition satisfied"]
             break
 
-    #prepare return object
+    # prepare return object
     lowest = bh.storage.get_lowest()
     res = bh.res
     res.x = np.copy(lowest[0])

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -4,8 +4,8 @@ Unit tests for the basin hopping global minimization algorithm.
 from __future__ import division, print_function, absolute_import
 import copy
 
-from numpy.testing import TestCase, run_module_suite, \
-    assert_almost_equal, assert_
+from numpy.testing import *
+from numpy.testing.utils import *
 import numpy as np
 from numpy import cos, sin
 
@@ -139,10 +139,10 @@ class TestBasinHopping(TestCase):
         # test the TypeErrors are raised on bad input
         i = 1
         # if take_step is passed, it must be callable
-        self.assertRaises(TypeError, basinhopping, func2d, self.x0[i],
+        assert_raises(TypeError, basinhopping, func2d, self.x0[i],
                           take_step=1)
         # if accept_test is passed, it must be callable
-        self.assertRaises(TypeError, basinhopping, func2d, self.x0[i],
+        assert_raises(TypeError, basinhopping, func2d, self.x0[i],
                           accept_test=1)
         # accept_test must return bool or string "force_accept"
 
@@ -151,10 +151,10 @@ class TestBasinHopping(TestCase):
 
         def bad_accept_test2(*args, **kwargs):
             return "not force_accept"
-        self.assertRaises(ValueError, basinhopping, func2d, self.x0[i],
+        assert_raises(ValueError, basinhopping, func2d, self.x0[i],
                           minimizer_kwargs=self.kwargs,
                           accept_test=bad_accept_test1)
-        self.assertRaises(ValueError, basinhopping, func2d, self.x0[i],
+        assert_raises(ValueError, basinhopping, func2d, self.x0[i],
                           minimizer_kwargs=self.kwargs,
                           accept_test=bad_accept_test2)
 
@@ -171,7 +171,7 @@ class TestBasinHopping(TestCase):
         res = basinhopping(func2d, self.x0[i], minimizer_kwargs=self.kwargs,
                            niter=self.niter, disp=self.disp)
         assert_almost_equal(res.x, self.sol[i], self.tol)
-        self.assertTrue(res.nfev > 0)
+        assert_(res.nfev > 0)
 
     def test_njev(self):
         # test njev is returned correctly
@@ -182,8 +182,8 @@ class TestBasinHopping(TestCase):
         res = basinhopping(func2d, self.x0[i],
                            minimizer_kwargs=minimizer_kwargs, niter=self.niter,
                            disp=self.disp)
-        self.assertTrue(res.nfev > 0)
-        self.assertEqual(res.nfev, res.njev)
+        assert_(res.nfev > 0)
+        assert_equal(res.nfev, res.njev)
 
     def test_2d_nograd(self):
         # test 2d minimizations without gradient
@@ -252,7 +252,7 @@ class TestBasinHopping(TestCase):
                            niter=30, disp=self.disp, callback=callback)
         assert_(callback.been_called)
         assert_("callback" in res.message[0])
-        assert_(res.nit == 10)
+        assert_equal(res.nit, 10)
 
     def test_minimizer_fail(self):
         # test if a minimizer fails
@@ -264,7 +264,7 @@ class TestBasinHopping(TestCase):
                            niter=self.niter, disp=self.disp)
         # the number of failed minimizations should be the number of
         # iterations + 1
-        assert_(res.nit + 1 == res.minimization_failures)
+        assert_equal(res.nit + 1, res.minimization_failures)
 
 
 class Test_Storage(TestCase):
@@ -276,16 +276,16 @@ class Test_Storage(TestCase):
     def test_higher_f_rejected(self):
         ret = self.storage.update(self.x0 + 1, self.f0 + 1)
         x, f = self.storage.get_lowest()
-        self.assertEqual(self.x0, x)
-        self.assertEqual(self.f0, f)
-        self.assertFalse(ret)
+        assert_equal(self.x0, x)
+        assert_equal(self.f0, f)
+        assert_(not ret)
 
     def test_lower_f_accepted(self):
         ret = self.storage.update(self.x0 + 1, self.f0 - 1)
         x, f = self.storage.get_lowest()
-        self.assertNotEqual(self.x0, x)
-        self.assertNotEqual(self.f0, f)
-        self.assertTrue(ret)
+        assert_(self.x0 != x)
+        assert_(self.f0 != f)
+        assert_(ret)
 
 
 class Test_RandomDisplacement(TestCase):
@@ -301,8 +301,8 @@ class Test_RandomDisplacement(TestCase):
         # note these tests are random, they will fail from time to time
         x = self.displace(self.x0)
         v = (2. * self.stepsize) ** 2 / 12
-        self.assertAlmostEqual(np.mean(x), 0., 1)
-        self.assertAlmostEqual(np.var(x), v, 1)
+        assert_almost_equal(np.mean(x), 0., 1)
+        assert_almost_equal(np.var(x), v, 1)
 
 
 class Test_Metropolis(TestCase):
@@ -317,12 +317,12 @@ class Test_Metropolis(TestCase):
         assert isinstance(ret, bool)
 
     def test_lower_f_accepted(self):
-        self.assertTrue(self.met(f_new=0., f_old=1.))
+        assert_(self.met(f_new=0., f_old=1.))
 
     def test_KeyError(self):
         # should raise KeyError if kwargs f_old or f_new is not passed
-        self.assertRaises(KeyError, self.met, f_old=1.)
-        self.assertRaises(KeyError, self.met, f_new=1.)
+        assert_raises(KeyError, self.met, f_old=1.)
+        assert_raises(KeyError, self.met, f_new=1.)
 
     def test_accept(self):
         # test that steps are randomly accepted for f_new > f_old
@@ -336,8 +336,8 @@ class Test_Metropolis(TestCase):
                 one_accept = True
             else:
                 one_reject = True
-        self.assertTrue(one_accept)
-        self.assertTrue(one_reject)
+        assert_(one_accept)
+        assert_(one_reject)
 
 
 class Test_AdaptiveStepsize(TestCase):
@@ -356,7 +356,7 @@ class Test_AdaptiveStepsize(TestCase):
         for i in range(self.takestep.interval):
             self.takestep(x)
             self.takestep.report(True)
-        self.assertTrue(self.ts.stepsize > self.stepsize)
+        assert_(self.ts.stepsize > self.stepsize)
 
     def test_adaptive_decrease(self):
         # if few steps are rejected, the stepsize should increase
@@ -366,7 +366,7 @@ class Test_AdaptiveStepsize(TestCase):
         for i in range(self.takestep.interval):
             self.takestep(x)
             self.takestep.report(False)
-        self.assertTrue(self.ts.stepsize < self.stepsize)
+        assert_(self.ts.stepsize < self.stepsize)
 
     def test_all_accepted(self):
         # test that everything works OK if all steps were accepted
@@ -374,7 +374,7 @@ class Test_AdaptiveStepsize(TestCase):
         for i in range(self.takestep.interval + 1):
             self.takestep(x)
             self.takestep.report(True)
-        self.assertTrue(self.ts.stepsize > self.stepsize)
+        assert_(self.ts.stepsize > self.stepsize)
 
     def test_all_rejected(self):
         # test that everything works OK if all steps were rejected
@@ -382,7 +382,7 @@ class Test_AdaptiveStepsize(TestCase):
         for i in range(self.takestep.interval + 1):
             self.takestep(x)
             self.takestep.report(False)
-        self.assertTrue(self.ts.stepsize < self.stepsize)
+        assert_(self.ts.stepsize < self.stepsize)
 
 
 if __name__ == "__main__":

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -39,18 +39,6 @@ def func2d(x):
     return f, df
 
 
-class Minimizer(object):
-    def __init__(self, func, **kwargs):
-        self.kwargs = kwargs
-        self.func = func
-
-    def __call__(self, x0, **newkwargs):
-        #combine the two kwargs
-        kwargs = dict(list(newkwargs.items()) + list(self.kwargs.items()))
-        res = minimize(self.func, x0, **kwargs)
-        return res
-
-
 class MyTakeStep1(RandomDisplacement):
     """use a copy of displace, but have it set a special parameter to
     make sure it's actually being used."""

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -236,7 +236,7 @@ class TestBasinHopping(TestCase):
         # are accepted.
         accept_test = MyAcceptTest()
         i = 1
-        #there's no point in running it more than a few steps.
+        # there's no point in running it more than a few steps.
         res = basinhopping(func2d, self.x0[i], minimizer_kwargs=self.kwargs,
                            niter=10, disp=self.disp, accept_test=accept_test)
         assert_(accept_test.been_called)
@@ -245,15 +245,26 @@ class TestBasinHopping(TestCase):
         # test passing a custom callback function
         # This makes sure it's being used.  It also returns True after 10 steps
         # to ensure that it's stopping early.
-
         callback = MyCallBack()
         i = 1
-        #there's no point in running it more than a few steps.
+        # there's no point in running it more than a few steps.
         res = basinhopping(func2d, self.x0[i], minimizer_kwargs=self.kwargs,
                            niter=30, disp=self.disp, callback=callback)
         assert_(callback.been_called)
         assert_("callback" in res.message[0])
         assert_(res.nit == 10)
+
+    def test_minimizer_fail(self):
+        # test if a minimizer fails
+        i = 1
+        self.kwargs["options"] = dict(maxiter=0)
+        self.niter = 10
+        self.disp = True
+        res = basinhopping(func2d, self.x0[i], minimizer_kwargs=self.kwargs,
+                           niter=self.niter, disp=self.disp)
+        # the number of failed minimizations should be the number of
+        # iterations + 1
+        assert_(res.nit + 1 == res.minimization_failures)
 
 
 class Test_Storage(TestCase):
@@ -285,9 +296,9 @@ class Test_RandomDisplacement(TestCase):
         self.x0 = np.zeros([self.N])
 
     def test_random(self):
-        #the mean should be 0
-        #the variance should be (2*stepsize)**2 / 12
-        #note these tests are random, they will fail from time to time
+        # the mean should be 0
+        # the variance should be (2*stepsize)**2 / 12
+        # note these tests are random, they will fail from time to time
         x = self.displace(self.x0)
         v = (2. * self.stepsize) ** 2 / 12
         self.assertAlmostEqual(np.mean(x), 0., 1)
@@ -300,8 +311,8 @@ class Test_Metropolis(TestCase):
         self.met = Metropolis(self.T)
 
     def test_boolean_return(self):
-        #the return must be a bool.  else an error will be raised in
-        #basinhopping
+        # the return must be a bool.  else an error will be raised in
+        # basinhopping
         ret = self.met(f_new=0., f_old=1.)
         assert isinstance(ret, bool)
 
@@ -309,12 +320,12 @@ class Test_Metropolis(TestCase):
         self.assertTrue(self.met(f_new=0., f_old=1.))
 
     def test_KeyError(self):
-        #should raise KeyError if kwargs f_old or f_new is not passed
+        # should raise KeyError if kwargs f_old or f_new is not passed
         self.assertRaises(KeyError, self.met, f_old=1.)
         self.assertRaises(KeyError, self.met, f_new=1.)
 
     def test_accept(self):
-        #test that steps are randomly accepted for f_new > f_old
+        # test that steps are randomly accepted for f_new > f_old
         one_accept = False
         one_reject = False
         for i in range(1000):
@@ -338,7 +349,7 @@ class Test_AdaptiveStepsize(TestCase):
                                           accept_rate=self.target_accept_rate)
 
     def test_adaptive_increase(self):
-        #if few steps are rejected, the stepsize should increase
+        # if few steps are rejected, the stepsize should increase
         x = 0.
         self.takestep(x)
         self.takestep.report(False)
@@ -348,7 +359,7 @@ class Test_AdaptiveStepsize(TestCase):
         self.assertTrue(self.ts.stepsize > self.stepsize)
 
     def test_adaptive_decrease(self):
-        #if few steps are rejected, the stepsize should increase
+        # if few steps are rejected, the stepsize should increase
         x = 0.
         self.takestep(x)
         self.takestep.report(True)
@@ -358,7 +369,7 @@ class Test_AdaptiveStepsize(TestCase):
         self.assertTrue(self.ts.stepsize < self.stepsize)
 
     def test_all_accepted(self):
-        #test that everything works OK if all steps were accepted
+        # test that everything works OK if all steps were accepted
         x = 0.
         for i in range(self.takestep.interval + 1):
             self.takestep(x)
@@ -366,7 +377,7 @@ class Test_AdaptiveStepsize(TestCase):
         self.assertTrue(self.ts.stepsize > self.stepsize)
 
     def test_all_rejected(self):
-        #test that everything works OK if all steps were rejected
+        # test that everything works OK if all steps were rejected
         x = 0.
         for i in range(self.takestep.interval + 1):
             self.takestep(x)


### PR DESCRIPTION
There was a question on scipy-user mailing list a while back 

http://scipy-user.10969.n7.nabble.com/SciPy-User-determining-success-of-scipy-optimize-basinhopping-td18515.html

which pointed out that the global minimizer optimize.basinhopping() doesn't deal very cleanly with failed minimizations.  Currently it just prints a warning if disp is True.

This pull request modifies basinhopping very slightly so that it now keeps track of how many failed minimizations there were and returns the total in the Result() object as `result.minimization_failures`.

I also added a test to ensure that this was handled correctly.

Also, I took this opportunity to clean up some of the basinhopping comment formatting and add more comments and documentation.
