### PR TITLE
TST: misc. clean up for sparse tests

### DIFF
--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2346,7 +2346,6 @@ class _TestFancyMultidimAssign:
 
         D = np.asmatrix(np.random.rand(5, 7))
         S = self.spmatrix(D)
-        X = np.random.rand(2, 3)
 
         I = [[1, 2, 3], [3, 4, 2]]
         J = [[5, 6, 3], [2, 3, 1]]
@@ -2881,7 +2880,6 @@ class TestDOK(sparse_test_class(slicing=False,
         assert_array_equal(csr.toarray()[m-1,:], zeros(n,))
 
     def test_ctor(self):
-        caught = 0
         # Empty ctor
         assert_raises(TypeError, dok_matrix)
 

--- a/scipy/sparse/tests/test_extract.py
+++ b/scipy/sparse/tests/test_extract.py
@@ -11,22 +11,20 @@ from scipy.sparse import extract
 
 class TestExtract(TestCase):
     def setUp(self):
-        cases = []
-
-        cases.append(csr_matrix([[1,2]]))
-        cases.append(csr_matrix([[1,0]]))
-        cases.append(csr_matrix([[0,0]]))
-        cases.append(csr_matrix([[1],[2]]))
-        cases.append(csr_matrix([[1],[0]]))
-        cases.append(csr_matrix([[0],[0]]))
-        cases.append(csr_matrix([[1,2],[3,4]]))
-        cases.append(csr_matrix([[0,1],[0,0]]))
-        cases.append(csr_matrix([[0,0],[1,0]]))
-        cases.append(csr_matrix([[0,0],[0,0]]))
-        cases.append(csr_matrix([[1,2,0,0,3],[4,5,0,6,7],[0,0,8,9,0]]))
-        cases.append(csr_matrix([[1,2,0,0,3],[4,5,0,6,7],[0,0,8,9,0]]).T)
-
-        self.cases = cases
+        self.cases = [
+            csr_matrix([[1,2]]),
+            csr_matrix([[1,0]]),
+            csr_matrix([[0,0]]),
+            csr_matrix([[1],[2]]),
+            csr_matrix([[1],[0]]),
+            csr_matrix([[0],[0]]),
+            csr_matrix([[1,2],[3,4]]),
+            csr_matrix([[0,1],[0,0]]),
+            csr_matrix([[0,0],[1,0]]),
+            csr_matrix([[0,0],[0,0]]),
+            csr_matrix([[1,2,0,0,3],[4,5,0,6,7],[0,0,8,9,0]]),
+            csr_matrix([[1,2,0,0,3],[4,5,0,6,7],[0,0,8,9,0]]).T,
+        ]
 
     def find(self):
         for A in self.cases:


### PR DESCRIPTION
May depend on PR #3076. Removing the call to `np.random.rand` on line 2349 triggered the flaky test for me.
