### PR TITLE
BUG: Use zpk in IIR filter design to improve accuracy

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -721,9 +721,33 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
 
 def _zpkbilinear(z, p, k, fs):
     """
+    Return a digital filter from an analog one using a bilinear transform.
+
     Transform a set of poles and zeros from the analog s-plane to the digital
-    z-plane using Tustin's method, which maintains the shape of the
-    frequency response.
+    z-plane using Tustin's method, which substitutes ``(z-1) / (z+1)`` for
+    ``s``, maintaining the shape of the frequency response.
+
+    Parameters
+    ----------
+    z : ndarray
+        Zeros of the analog IIR filter transfer function.
+    p : ndarray
+        Poles of the analog IIR filter transfer function.
+    k : float
+        System gain of the analog IIR filter transfer function.
+    fs : float
+        Sample rate, as ordinary frequency (e.g. hertz). No prewarping is 
+        done in this function.
+
+    Returns
+    -------
+    z : ndarray
+        Zeros of the transformed digital filter transfer function.
+    p : ndarray
+        Poles of the transformed digital filter transfer function.
+    k : float
+        System gain of the transformed digital filter.
+
     """
     degree = len(p) - len(z)
     if degree < 0:
@@ -745,8 +769,33 @@ def _zpkbilinear(z, p, k, fs):
 
 def _zpklp2lp(z, p, k, wo=1.0):
     """
-    Convert analog prototype lowpass filter to lowpass filter with cutoff
-    frequency `wo`.
+    Transform a lowpass filter prototype to a different frequency.
+
+    Return an analog low-pass filter with cutoff frequency `wo`
+    from an analog low-pass filter prototype with unity cutoff frequency,
+    using zeros, poles, and gain ('zpk') representation.
+
+    Parameters
+    ----------
+    z : ndarray
+        Zeros of the analog IIR filter transfer function.
+    p : ndarray
+        Poles of the analog IIR filter transfer function.
+    k : float
+        System gain of the analog IIR filter transfer function.
+    wo : float
+        Desired cutoff, as angular frequency (e.g. rad/s).
+        Defaults to no change.
+
+    Returns
+    -------
+    z : ndarray
+        Zeros of the transformed low-pass filter transfer function.
+    p : ndarray
+        Poles of the transformed low-pass filter transfer function.
+    k : float
+        System gain of the transformed low-pass filter.
+
     """
     z = atleast_1d(z)
     p = atleast_1d(p)
@@ -764,8 +813,33 @@ def _zpklp2lp(z, p, k, wo=1.0):
 
 def _zpklp2hp(z, p, k, wo=1.0):
     """
-    Convert analog prototype lowpass filter to highpass filter with cutoff
-    frequency `wo`.
+    Transform a lowpass filter prototype to a highpass filter.
+
+    Return an analog high-pass filter with cutoff frequency `wo`
+    from an analog low-pass filter prototype with unity cutoff frequency,
+    using zeros, poles, and gain ('zpk') representation.
+
+    Parameters
+    ----------
+    z : ndarray
+        Zeros of the analog IIR filter transfer function.
+    p : ndarray
+        Poles of the analog IIR filter transfer function.
+    k : float
+        System gain of the analog IIR filter transfer function.
+    wo : float
+        Desired cutoff, as angular frequency (e.g. rad/s).
+        Defaults to no change.
+
+    Returns
+    -------
+    z : ndarray
+        Zeros of the transformed high-pass filter transfer function.
+    p : ndarray
+        Poles of the transformed high-pass filter transfer function.
+    k : float
+        System gain of the transformed high-pass filter.
+
     """
     z = atleast_1d(z)
     p = atleast_1d(p)
@@ -786,11 +860,39 @@ def _zpklp2hp(z, p, k, wo=1.0):
 
 def _zpklp2bp(z, p, k, wo=1.0, bw=1.0):
     """
-    Convert analog prototype lowpass filter to bandpass filter with center
-    frequency `wo` and bandwidth `bw`.
+    Transform a lowpass filter prototype to a bandpass filter.
+
+    Return an analog band-pass filter with center frequency `wo` and
+    bandwidth `bw` from an analog low-pass filter prototype with unity
+    cutoff frequency, using zeros, poles, and gain ('zpk') representation.
 
     This is the "wideband" transformation, producing a passband with
-    geometric (log frequency) symmetry.
+    geometric (log frequency) symmetry about `wo`.
+
+    Parameters
+    ----------
+    z : ndarray
+        Zeros of the analog IIR filter transfer function.
+    p : ndarray
+        Poles of the analog IIR filter transfer function.
+    k : float
+        System gain of the analog IIR filter transfer function.
+    wo : float
+        Desired passband center, as angular frequency (e.g. rad/s).
+        Defaults to no change.
+    bw : float
+        Desired passband width, as angular frequency (e.g. rad/s).
+        Defaults to 1.
+
+    Returns
+    -------
+    z : ndarray
+        Zeros of the transformed band-pass filter transfer function.
+    p : ndarray
+        Poles of the transformed band-pass filter transfer function.
+    k : float
+        System gain of the transformed band-pass filter.
+
     """
     z = atleast_1d(z)
     p = atleast_1d(p)
@@ -820,11 +922,39 @@ def _zpklp2bp(z, p, k, wo=1.0, bw=1.0):
 
 def _zpklp2bs(z, p, k, wo=1.0, bw=1.0):
     """
-    Convert analog prototype lowpass filter to bandstop filter with center
-    frequency `wo` and bandwidth `bw`
+    Transform a lowpass filter prototype to a highpass filter.
+
+    Return an analog band-stop filter with center frequency `wo` and
+    stopband width `bw` from an analog low-pass filter prototype with unity
+    cutoff frequency, using zeros, poles, and gain ('zpk') representation.
 
     This is the "wideband" transformation, producing a stopband with
-    geometric (log frequency) symmetry.
+    geometric (log frequency) symmetry about `wo`.
+
+    Parameters
+    ----------
+    z : ndarray
+        Zeros of the analog IIR filter transfer function.
+    p : ndarray
+        Poles of the analog IIR filter transfer function.
+    k : float
+        System gain of the analog IIR filter transfer function.
+    wo : float
+        Desired stopband center, as angular frequency (e.g. rad/s).
+        Defaults to no change.
+    bw : float
+        Desired stopband width, as angular frequency (e.g. rad/s).
+        Defaults to 1.
+
+    Returns
+    -------
+    z : ndarray
+        Zeros of the transformed band-stop filter transfer function.
+    p : ndarray
+        Poles of the transformed band-stop filter transfer function.
+    k : float
+        System gain of the transformed band-stop filter.
+
     """
     z = atleast_1d(z)
     p = atleast_1d(p)

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -1907,7 +1907,7 @@ def cheb1ap(N, rp):
     elif N == 0:
         # Avoid divide-by-zero error
         # Even order filters have DC gain of -rp dB
-        return numpy.array([]), numpy.array([]), numpy.sqrt(10 ** (0.1 * -rp))
+        return numpy.array([]), numpy.array([]), 10**(-rp/20)
     z = numpy.array([])
     eps = numpy.sqrt(10 ** (0.1 * rp) - 1.0)
     n = numpy.arange(1, N + 1)
@@ -1995,7 +1995,7 @@ def ellipap(N, rp, rs):
     elif N == 0:
         # Avoid divide-by-zero warning
         # Even order filters have DC gain of -rp dB
-        return numpy.array([]), numpy.array([]), numpy.sqrt(10 ** (0.1 * -rp))
+        return numpy.array([]), numpy.array([]), 10**(-rp/20)
     elif N == 1:
         p = -sqrt(1.0 / (10 ** (0.1 * rp) - 1.0))
         k = -p

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -1958,8 +1958,9 @@ def buttap(N):
     if abs(int(N)) != N:
         raise ValueError("Filter order must be a nonnegative integer")
     z = numpy.array([])
-    n = numpy.arange(1, N + 1)
-    p = numpy.exp(1j * (2 * n - 1) / (2.0 * N) * pi) * 1j
+    m = numpy.arange(-N+1, N, 2)
+    # Middle value is 0 to ensure an exactly real pole
+    p = -numpy.exp(1j * pi * m / (2 * N))
     k = 1
     return z, p, k
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -766,10 +766,10 @@ def _zpkbilinear(z, p, k, fs):
     degree = _relative_degree(z, p)
 
     fs2 = 2*fs
-    
+
     # Bilinear transform the poles and zeros
-    p_z = (fs2 + p) / (fs2 - p)
     z_z = (fs2 + z) / (fs2 - z)
+    p_z = (fs2 + p) / (fs2 - p)
 
     # Any zeros that were at infinity get moved to the Nyquist frequency
     z_z = append(z_z, -ones(degree))
@@ -917,18 +917,18 @@ def _zpklp2bp(z, p, k, wo=1.0, bw=1.0):
     degree = _relative_degree(z, p)
 
     # Scale poles and zeros to desired bandwidth
-    p_lp = p * bw/2
     z_lp = z * bw/2
+    p_lp = p * bw/2
 
     # Square root needs to produce complex result, not NaN
-    p_lp = p_lp.astype(complex)
     z_lp = z_lp.astype(complex)
+    p_lp = p_lp.astype(complex)
 
     # Duplicate poles and zeros and shift from baseband to +wo and -wo
-    p_bp = concatenate((p_lp + sqrt(p_lp**2 - wo**2), 
-                        p_lp - sqrt(p_lp**2 - wo**2)))
-    z_bp = concatenate((z_lp + sqrt(z_lp**2 - wo**2), 
+    z_bp = concatenate((z_lp + sqrt(z_lp**2 - wo**2),
                         z_lp - sqrt(z_lp**2 - wo**2)))
+    p_bp = concatenate((p_lp + sqrt(p_lp**2 - wo**2),
+                        p_lp - sqrt(p_lp**2 - wo**2)))
 
     # Move half of any zeros that were at infinity to the origin for BPF
     z_bp = append(z_bp, zeros(degree))
@@ -981,18 +981,18 @@ def _zpklp2bs(z, p, k, wo=1.0, bw=1.0):
     degree = _relative_degree(z, p)
 
     # Invert to a highpass filter with desired bandwidth
-    p_hp = (bw/2) / p
     z_hp = (bw/2) / z
+    p_hp = (bw/2) / p
 
     # Square root needs to produce complex result, not NaN
-    p_hp = p_hp.astype(complex)
     z_hp = z_hp.astype(complex)
+    p_hp = p_hp.astype(complex)
 
     # Duplicate poles and zeros and shift from baseband to +wo and -wo
-    p_bs = concatenate((p_hp + sqrt(p_hp**2 - wo**2), 
-                        p_hp - sqrt(p_hp**2 - wo**2)))
-    z_bs = concatenate((z_hp + sqrt(z_hp**2 - wo**2), 
+    z_bs = concatenate((z_hp + sqrt(z_hp**2 - wo**2),
                         z_hp - sqrt(z_hp**2 - wo**2)))
+    p_bs = concatenate((p_hp + sqrt(p_hp**2 - wo**2),
+                        p_hp - sqrt(p_hp**2 - wo**2)))
 
     # Move any zeros that were at infinity to the center of the stopband
     z_bs = append(z_bs, +1j*wo * ones(degree))

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -677,7 +677,7 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
                              "elliptic filter.")
         z, p, k = typefunc(N, rp, rs)
     else:
-        raise NotImplementedError("%s not implemented in iirfilter." % ftype)
+        raise NotImplementedError("'%s' not implemented in iirfilter." % ftype)
 
     b, a = zpk2tf(z, p, k)
 
@@ -2130,13 +2130,17 @@ def besselap(N):
 
 filter_dict = {'butter': [buttap, buttord],
                'butterworth': [buttap, buttord],
+
                'cauer': [ellipap, ellipord],
                'elliptic': [ellipap, ellipord],
                'ellip': [ellipap, ellipord],
+
                'bessel': [besselap],
+
                'cheby1': [cheb1ap, cheb1ord],
                'chebyshev1': [cheb1ap, cheb1ord],
                'chebyshevi': [cheb1ap, cheb1ord],
+
                'cheby2': [cheb2ap, cheb2ord],
                'chebyshev2': [cheb2ap, cheb2ord],
                'chebyshevii': [cheb2ap, cheb2ord],
@@ -2146,14 +2150,19 @@ band_dict = {'band': 'bandpass',
              'bandpass': 'bandpass',
              'pass': 'bandpass',
              'bp': 'bandpass',
+
              'bs': 'bandstop',
              'bandstop': 'bandstop',
              'bands': 'bandstop',
              'stop': 'bandstop',
+
              'l': 'lowpass',
              'low': 'lowpass',
              'lowpass': 'lowpass',
+             'lp': 'lowpass',
+
              'high': 'highpass',
              'highpass': 'highpass',
              'h': 'highpass',
+             'hp': 'highpass',
              }

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -6,9 +6,9 @@ import warnings
 
 import numpy
 from numpy import (atleast_1d, poly, polyval, roots, real, asarray, allclose,
-    resize, pi, absolute, logspace, r_, sqrt, tan, log10, arctan, arcsinh,
-    cos, exp, cosh, arccosh, ceil, conjugate, zeros, sinh, append,
-    concatenate, prod, ones)
+                   resize, pi, absolute, logspace, r_, sqrt, tan, log10,
+                   arctan, arcsinh, cos, exp, cosh, arccosh, ceil, conjugate,
+                   zeros, sinh, append, concatenate, prod, ones)
 from numpy import mintypecode
 from scipy import special, optimize
 from scipy.misc import comb
@@ -1747,6 +1747,8 @@ def buttap(N):
     of 1.
 
     """
+    if abs(int(N)) != N:
+        raise ValueError("Filter order must be a positive integer")
     z = numpy.array([])
     n = numpy.arange(1, N + 1)
     p = numpy.exp(1j * (2 * n - 1) / (2.0 * N) * pi) * 1j
@@ -1762,7 +1764,9 @@ def cheb1ap(N, rp):
     defined as the point at which the gain first drops below -`rp`.
 
     """
-    if N == 0:
+    if abs(int(N)) != N:
+        raise ValueError("Filter order must be a positive integer")
+    elif N == 0:
         return numpy.array([]), numpy.array([]), 1
     z = numpy.array([])
     eps = numpy.sqrt(10 ** (0.1 * rp) - 1.0)
@@ -1785,6 +1789,8 @@ def cheb2ap(N, rs):
     defined as the point at which the gain first reaches -`rs`.
 
     """
+    if abs(int(N)) != N:
+        raise ValueError("Filter order must be a positive integer")
     de = 1.0 / sqrt(10 ** (0.1 * rs) - 1)
     mu = arcsinh(1.0 / de) / N
 
@@ -1841,9 +1847,11 @@ def ellipap(N, rp, rs):
     and 12.
 
     """
-    if N == 0:
+    if abs(int(N)) != N:
+        raise ValueError("Filter order must be a positive integer")
+    elif N == 0:
         return numpy.array([]), numpy.array([]), 1
-    if N == 1:
+    elif N == 1:
         p = -sqrt(1.0 / (10 ** (0.1 * rp) - 1.0))
         k = -p
         z = []
@@ -2266,7 +2274,7 @@ def besselap(N):
              -.2373280669322028974199184 - 1.211476658382565356579418j,
              -.2373280669322028974199184 + 1.211476658382565356579418j]
     else:
-        raise ValueError("Bessel Filter not supported for order %d" % N)
+        raise ValueError("Bessel Filter not supported for order %s" % N)
 
     return asarray(z), asarray(p), k
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -1759,6 +1759,8 @@ def cheb1ap(N, rp):
     defined as the point at which the gain first drops below -`rp`.
 
     """
+    if N == 0:
+        return numpy.array([]), numpy.array([]), 1
     z = numpy.array([])
     eps = numpy.sqrt(10 ** (0.1 * rp) - 1.0)
     n = numpy.arange(1, N + 1)
@@ -1836,6 +1838,8 @@ def ellipap(N, rp, rs):
     and 12.
 
     """
+    if N == 0:
+        return numpy.array([]), numpy.array([]), 1
     if N == 1:
         p = -sqrt(1.0 / (10 ** (0.1 * rp) - 1.0))
         k = -p

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -736,7 +736,7 @@ def _zpkbilinear(z, p, k, fs):
     k : float
         System gain of the analog IIR filter transfer function.
     fs : float
-        Sample rate, as ordinary frequency (e.g. hertz). No prewarping is 
+        Sample rate, as ordinary frequency (e.g. hertz). No prewarping is
         done in this function.
 
     Returns
@@ -1106,6 +1106,10 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba'):
     Type I filters roll off faster than Type II (`cheby2`), but Type II
     filters do not have any ripple in the passband.
 
+    The equiripple passband has N maxima or minima (for example, a
+    5th-order filter has 3 maxima and 2 minima).  Consequently, the DC gain is
+    unity for odd-order filters, or -rp dB for even-order filters.
+
     Examples
     --------
     Plot the filter's frequency response, showing the critical points:
@@ -1266,6 +1270,10 @@ def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba'):
     type II filter (`cheby2`).  As `rs` approaches 0, it becomes a Chebyshev
     type I filter (`cheby1`).  As both approach 0, it becomes a Butterworth
     filter (`butter`).
+
+    The equiripple passband has N maxima or minima (for example, a
+    5th-order filter has 3 maxima and 2 minima).  Consequently, the DC gain is
+    unity for odd-order filters, or -rp dB for even-order filters.
 
     Examples
     --------

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -637,6 +637,26 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     --------
     buttord, cheb1ord, cheb2ord, ellipord
 
+    Examples
+    --------
+    Generate a 17th-order Chebyshev II bandpass filter and plot the frequency
+    response:
+
+    >>> from scipy import signal
+    >>> import matplotlib.pyplot as plt
+
+    >>> b, a = signal.iirfilter(17, [50, 200], rs=60, btype='band',
+                                analog=True, ftype='cheby2')
+    >>> w, h = signal.freqs(b, a, 1000)
+    >>> plt.plot(w, 20 * np.log10(abs(h)))
+    >>> plt.xscale('log')
+    >>> plt.title('Chebyshev Type II bandpass frequency response')
+    >>> plt.xlabel('Frequency [radians / second]')
+    >>> plt.ylabel('Amplitude [dB]')
+    >>> plt.axis((10, 1000, -100, 10))
+    >>> plt.grid(which='both', axis='both')
+    >>> plt.show()
+
     """
     ftype, btype, output = [x.lower() for x in (ftype, btype, output)]
     Wn = asarray(Wn)
@@ -809,6 +829,12 @@ def _zpklp2lp(z, p, k, wo=1.0):
     k : float
         System gain of the transformed low-pass filter.
 
+    Notes
+    -----
+    This is derived from the s-plane substitution
+
+    .. math:: s \rightarrow \frac{s}{\omega_0}
+
     """
     z = atleast_1d(z)
     p = atleast_1d(p)
@@ -855,6 +881,12 @@ def _zpklp2hp(z, p, k, wo=1.0):
     k : float
         System gain of the transformed high-pass filter.
 
+    Notes
+    -----
+    This is derived from the s-plane substitution
+
+    .. math:: s \rightarrow \frac{\omega_0}{s}
+
     """
     z = atleast_1d(z)
     p = atleast_1d(p)
@@ -883,9 +915,6 @@ def _zpklp2bp(z, p, k, wo=1.0, bw=1.0):
     bandwidth `bw` from an analog low-pass filter prototype with unity
     cutoff frequency, using zeros, poles, and gain ('zpk') representation.
 
-    This is the "wideband" transformation, producing a passband with
-    geometric (log frequency) symmetry about `wo`.
-
     Parameters
     ----------
     z : ndarray
@@ -909,6 +938,15 @@ def _zpklp2bp(z, p, k, wo=1.0, bw=1.0):
         Poles of the transformed band-pass filter transfer function.
     k : float
         System gain of the transformed band-pass filter.
+
+    Notes
+    -----
+    This is derived from the s-plane substitution
+
+    .. math:: s \rightarrow \frac{s^2 + {\omega_0}^2}{s \cdot \mathrm{BW}}
+
+    This is the "wideband" transformation, producing a passband with
+    geometric (log frequency) symmetry about `wo`.
 
     """
     z = atleast_1d(z)
@@ -947,9 +985,6 @@ def _zpklp2bs(z, p, k, wo=1.0, bw=1.0):
     stopband width `bw` from an analog low-pass filter prototype with unity
     cutoff frequency, using zeros, poles, and gain ('zpk') representation.
 
-    This is the "wideband" transformation, producing a stopband with
-    geometric (log frequency) symmetry about `wo`.
-
     Parameters
     ----------
     z : ndarray
@@ -973,6 +1008,15 @@ def _zpklp2bs(z, p, k, wo=1.0, bw=1.0):
         Poles of the transformed band-stop filter transfer function.
     k : float
         System gain of the transformed band-stop filter.
+
+    Notes
+    -----
+    This is derived from the s-plane substitution
+
+    .. math:: s \rightarrow \frac{s \cdot \mathrm{BW}}{s^2 + {\omega_0}^2}
+
+    This is the "wideband" transformation, producing a stopband with
+    geometric (log frequency) symmetry about `wo`.
 
     """
     z = atleast_1d(z)

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -643,15 +643,15 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     try:
         btype = band_dict[btype]
     except KeyError:
-        raise ValueError("%s is an invalid bandtype for filter." % btype)
+        raise ValueError("'%s' is an invalid bandtype for filter." % btype)
 
     try:
         typefunc = filter_dict[ftype][0]
     except KeyError:
-        raise ValueError("%s is not a valid basic iir filter." % ftype)
+        raise ValueError("'%s' is not a valid basic IIR filter." % ftype)
 
     if output not in ['ba', 'zpk']:
-        raise ValueError("%s is not a valid output form." % output)
+        raise ValueError("'%s' is not a valid output form." % output)
 
     if rp is not None and rp < 0:
         raise ValueError("passband ripple (rp) must be positive")
@@ -692,16 +692,19 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
         z, p, k = _zpklp2lp(z, p, k, wo=warped)
     elif btype == 'highpass':
         z, p, k = _zpklp2hp(z, p, k, wo=warped)
-    elif btype == 'bandpass':
-        bw = warped[1] - warped[0]
-        wo = sqrt(warped[0] * warped[1])
-        z, p, k = _zpklp2bp(z, p, k, wo=wo, bw=bw)
-    elif btype == 'bandstop':
-        bw = warped[1] - warped[0]
-        wo = sqrt(warped[0] * warped[1])
-        z, p, k = _zpklp2bs(z, p, k, wo=wo, bw=bw)
+    elif btype in ('bandpass', 'bandstop'):
+        try:
+            bw = warped[1] - warped[0]
+            wo = sqrt(warped[0] * warped[1])
+        except IndexError:
+            raise ValueError('Wn must specify start and stop frequencies')
+
+        if btype == 'bandpass':
+            z, p, k = _zpklp2bp(z, p, k, wo=wo, bw=bw)
+        elif btype == 'bandstop':
+            z, p, k = _zpklp2bs(z, p, k, wo=wo, bw=bw)
     else:
-        raise NotImplementedError("%s not implemented in iirfilter." % btype)
+        raise NotImplementedError("'%s' not implemented in iirfilter." % btype)
 
     # Find discrete equivalent if necessary
     if not analog:

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -1748,7 +1748,7 @@ def buttap(N):
 
     """
     if abs(int(N)) != N:
-        raise ValueError("Filter order must be a positive integer")
+        raise ValueError("Filter order must be a nonnegative integer")
     z = numpy.array([])
     n = numpy.arange(1, N + 1)
     p = numpy.exp(1j * (2 * n - 1) / (2.0 * N) * pi) * 1j
@@ -1765,7 +1765,7 @@ def cheb1ap(N, rp):
 
     """
     if abs(int(N)) != N:
-        raise ValueError("Filter order must be a positive integer")
+        raise ValueError("Filter order must be a nonnegative integer")
     elif N == 0:
         return numpy.array([]), numpy.array([]), 1
     z = numpy.array([])
@@ -1790,7 +1790,7 @@ def cheb2ap(N, rs):
 
     """
     if abs(int(N)) != N:
-        raise ValueError("Filter order must be a positive integer")
+        raise ValueError("Filter order must be a nonnegative integer")
     de = 1.0 / sqrt(10 ** (0.1 * rs) - 1)
     mu = arcsinh(1.0 / de) / N
 
@@ -1848,7 +1848,7 @@ def ellipap(N, rp, rs):
 
     """
     if abs(int(N)) != N:
-        raise ValueError("Filter order must be a positive integer")
+        raise ValueError("Filter order must be a nonnegative integer")
     elif N == 0:
         return numpy.array([]), numpy.array([]), 1
     elif N == 1:

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -1980,15 +1980,20 @@ def cheb1ap(N, rp):
         # Even order filters have DC gain of -rp dB
         return numpy.array([]), numpy.array([]), 10**(-rp/20)
     z = numpy.array([])
+
+    # Ripple factor (epsilon)
     eps = numpy.sqrt(10 ** (0.1 * rp) - 1.0)
-    n = numpy.arange(1, N + 1)
-    mu = 1.0 / N * numpy.log((1.0 + numpy.sqrt(1 + eps * eps)) / eps)
-    theta = pi / 2.0 * (2 * n - 1.0) / N
-    p = (-numpy.sinh(mu) * numpy.sin(theta) +
-         1j * numpy.cosh(mu) * numpy.cos(theta))
+    mu = 1.0 / N * arcsinh(1 / eps)
+
+    # Arrange poles in an ellipse on the left half of the S-plane
+    m = numpy.arange(-N+1, N, 2)
+    theta = pi * m / (2*N)
+    p = -sinh(mu + 1j*theta)
+
     k = numpy.prod(-p, axis=0).real
     if N % 2 == 0:
         k = k / sqrt((1 + eps * eps))
+
     return z, p, k
 
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -1905,7 +1905,9 @@ def cheb1ap(N, rp):
     if abs(int(N)) != N:
         raise ValueError("Filter order must be a nonnegative integer")
     elif N == 0:
-        return numpy.array([]), numpy.array([]), 1
+        # Avoid divide-by-zero error
+        # Even order filters have DC gain of -rp dB
+        return numpy.array([]), numpy.array([]), numpy.sqrt(10 ** (0.1 * -rp))
     z = numpy.array([])
     eps = numpy.sqrt(10 ** (0.1 * rp) - 1.0)
     n = numpy.arange(1, N + 1)
@@ -1929,6 +1931,9 @@ def cheb2ap(N, rs):
     """
     if abs(int(N)) != N:
         raise ValueError("Filter order must be a nonnegative integer")
+    elif N == 0:
+        # Avoid divide-by-zero warning
+        return numpy.array([]), numpy.array([]), 1
     de = 1.0 / sqrt(10 ** (0.1 * rs) - 1)
     mu = arcsinh(1.0 / de) / N
 
@@ -1988,7 +1993,9 @@ def ellipap(N, rp, rs):
     if abs(int(N)) != N:
         raise ValueError("Filter order must be a nonnegative integer")
     elif N == 0:
-        return numpy.array([]), numpy.array([]), 1
+        # Avoid divide-by-zero warning
+        # Even order filters have DC gain of -rp dB
+        return numpy.array([]), numpy.array([]), numpy.sqrt(10 ** (0.1 * -rp))
     elif N == 1:
         p = -sqrt(1.0 / (10 ** (0.1 * rp) - 1.0))
         k = -p

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -7,7 +7,7 @@ import warnings
 import numpy
 from numpy import (atleast_1d, poly, polyval, roots, real, asarray, allclose,
                    resize, pi, absolute, logspace, r_, sqrt, tan, log10,
-                   arctan, arcsinh, cos, exp, cosh, arccosh, ceil, conjugate,
+                   arctan, arcsinh, sin, exp, cosh, arccosh, ceil, conjugate,
                    zeros, sinh, append, concatenate, prod, ones)
 from numpy import mintypecode
 from scipy import special, optimize
@@ -2010,19 +2010,25 @@ def cheb2ap(N, rs):
     elif N == 0:
         # Avoid divide-by-zero warning
         return numpy.array([]), numpy.array([]), 1
+
+    # Ripple factor (epsilon)
     de = 1.0 / sqrt(10 ** (0.1 * rs) - 1)
     mu = arcsinh(1.0 / de) / N
 
     if N % 2:
-        n = numpy.concatenate((numpy.arange(1, N - 1, 2),
-                               numpy.arange(N + 2, 2 * N, 2)))
+        m = numpy.concatenate((numpy.arange(-N+1, 0, 2),
+                               numpy.arange(   2, N, 2)))
     else:
-        n = numpy.arange(1, 2 * N, 2)
+        m = numpy.arange(-N+1, N, 2)
 
-    z = conjugate(1j / cos(n * pi / (2.0 * N)))
-    p = exp(1j * (pi * numpy.arange(1, 2 * N, 2) / (2.0 * N) + pi / 2.0))
+    z = -conjugate(1j / sin(m * pi / (2.0 * N)))
+
+    # Poles around the unit circle like Butterworth
+    p = -exp(1j * pi * numpy.arange(-N+1, N, 2) / (2 * N))
+    # Warp into Chebyshev II
     p = sinh(mu) * p.real + 1j * cosh(mu) * p.imag
     p = 1.0 / p
+
     k = (numpy.prod(-p, axis=0) / numpy.prod(-z, axis=0)).real
     return z, p, k
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -736,10 +736,14 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
         warped = Wn
 
     # transform to lowpass, bandpass, highpass, or bandstop
-    if btype == 'lowpass':
-        z, p, k = _zpklp2lp(z, p, k, wo=warped)
-    elif btype == 'highpass':
-        z, p, k = _zpklp2hp(z, p, k, wo=warped)
+    if btype in ('lowpass', 'highpass'):
+        if numpy.size(Wn) != 1:
+            raise ValueError('Must specify a single critical frequency Wn')
+
+        if btype == 'lowpass':
+            z, p, k = _zpklp2lp(z, p, k, wo=warped)
+        elif btype == 'highpass':
+            z, p, k = _zpklp2hp(z, p, k, wo=warped)
     elif btype in ('bandpass', 'bandstop'):
         try:
             bw = warped[1] - warped[0]

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -442,7 +442,7 @@ def lp2bp(b, a, wo=1.0, bw=1.0):
 
 def lp2bs(b, a, wo=1.0, bw=1.0):
     """
-    Transform a lowpass filter prototype to a highpass filter.
+    Transform a lowpass filter prototype to a bandstop filter.
 
     Return an analog band-stop filter with center frequency `wo` and
     bandwidth `bw` from an analog low-pass filter prototype with unity
@@ -922,7 +922,7 @@ def _zpklp2bp(z, p, k, wo=1.0, bw=1.0):
 
 def _zpklp2bs(z, p, k, wo=1.0, bw=1.0):
     """
-    Transform a lowpass filter prototype to a highpass filter.
+    Transform a lowpass filter prototype to a bandstop filter.
 
     Return an analog band-stop filter with center frequency `wo` and
     stopband width `bw` from an analog low-pass filter prototype with unity

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -312,6 +312,29 @@ def zpk2tf(z, p, k):
     else:
         b = k * poly(z)
     a = atleast_1d(poly(p))
+
+    # Use real output if possible.  Copied from numpy.poly, since
+    # we can't depend on a specific version of numpy.
+    if issubclass(b.dtype.type, numpy.complexfloating):
+        # if complex roots are all complex conjugates, the roots are real.
+        roots = numpy.asarray(z, complex)
+        pos_roots = numpy.compress(roots.imag > 0, roots)
+        neg_roots = numpy.conjugate(numpy.compress(roots.imag < 0, roots))
+        if len(pos_roots) == len(neg_roots):
+            if numpy.all(numpy.sort_complex(neg_roots) ==
+                         numpy.sort_complex(pos_roots)):
+                b = b.real.copy()
+
+    if issubclass(a.dtype.type, numpy.complexfloating):
+        # if complex roots are all complex conjugates, the roots are real.
+        roots = numpy.asarray(p, complex)
+        pos_roots = numpy.compress(roots.imag > 0, roots)
+        neg_roots = numpy.conjugate(numpy.compress(roots.imag < 0, roots))
+        if len(pos_roots) == len(neg_roots):
+            if numpy.all(numpy.sort_complex(neg_roots) ==
+                         numpy.sort_complex(pos_roots)):
+                a = a.real.copy()
+
     return b, a
 
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -840,6 +840,7 @@ def _zpklp2lp(z, p, k, wo=1.0):
     """
     z = atleast_1d(z)
     p = atleast_1d(p)
+    wo = float(wo) # Avoid np.int wraparound
 
     degree = _relative_degree(z, p)
 
@@ -895,6 +896,7 @@ def _zpklp2hp(z, p, k, wo=1.0):
     """
     z = atleast_1d(z)
     p = atleast_1d(p)
+    wo = float(wo)
 
     degree = _relative_degree(z, p)
 
@@ -956,6 +958,8 @@ def _zpklp2bp(z, p, k, wo=1.0, bw=1.0):
     """
     z = atleast_1d(z)
     p = atleast_1d(p)
+    wo = float(wo)
+    bw = float(bw)
 
     degree = _relative_degree(z, p)
 
@@ -1026,6 +1030,8 @@ def _zpklp2bs(z, p, k, wo=1.0, bw=1.0):
     """
     z = atleast_1d(z)
     p = atleast_1d(p)
+    wo = float(wo)
+    bw = float(bw)
 
     degree = _relative_degree(z, p)
 

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -646,15 +646,17 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     >>> import matplotlib.pyplot as plt
 
     >>> b, a = signal.iirfilter(17, [50, 200], rs=60, btype='band',
-                                analog=True, ftype='cheby2')
+    ...                         analog=True, ftype='cheby2')
     >>> w, h = signal.freqs(b, a, 1000)
-    >>> plt.plot(w, 20 * np.log10(abs(h)))
-    >>> plt.xscale('log')
-    >>> plt.title('Chebyshev Type II bandpass frequency response')
-    >>> plt.xlabel('Frequency [radians / second]')
-    >>> plt.ylabel('Amplitude [dB]')
-    >>> plt.axis((10, 1000, -100, 10))
-    >>> plt.grid(which='both', axis='both')
+    >>> fig = plt.figure()
+    >>> ax = fig.add_subplot(111)
+    >>> ax.plot(w, 20 * np.log10(abs(h)))
+    >>> ax.set_xscale('log')
+    >>> ax.set_title('Chebyshev Type II bandpass frequency response')
+    >>> ax.set_xlabel('Frequency [radians / second]')
+    >>> ax.set_ylabel('Amplitude [dB]')
+    >>> ax.axis((10, 1000, -100, 10))
+    >>> ax.grid(which='both', axis='both')
     >>> plt.show()
 
     """
@@ -887,6 +889,9 @@ def _zpklp2hp(z, p, k, wo=1.0):
 
     .. math:: s \rightarrow \frac{\omega_0}{s}
 
+    This maintains symmetry of the lowpass and highpass responses on a
+    logarithmic scale.
+
     """
     z = atleast_1d(z)
     p = atleast_1d(p)
@@ -968,7 +973,7 @@ def _zpklp2bp(z, p, k, wo=1.0, bw=1.0):
     p_bp = concatenate((p_lp + sqrt(p_lp**2 - wo**2),
                         p_lp - sqrt(p_lp**2 - wo**2)))
 
-    # Move half of any zeros that were at infinity to the origin for BPF
+    # Move degree zeros to origin, leaving degree zeros at infinity for BPF
     z_bp = append(z_bp, zeros(degree))
 
     # Cancel out gain change from frequency scaling

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -727,6 +727,9 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
 
     # Pre-warp frequencies for digital filter design
     if not analog:
+        if numpy.any(Wn < 0) or numpy.any(Wn > 1):
+            raise ValueError("Digital filter critical frequencies "
+                             "must be 0 <= Wn <= 1")
         fs = 2.0
         warped = 2 * fs * tan(pi * Wn / fs)
     else:

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1483,6 +1483,11 @@ class TestIIRFilter(TestCase):
                 assert_array_equal(sorted(p), sorted(p.conj()))
                 assert_equal(k, np.real(k))
 
+                b, a = iirfilter(N, 1.1, 1, 20, 'low', analog=True,
+                                    ftype=ftype, output='ba')
+                assert_(issubclass(b.dtype.type, np.floating))
+                assert_(issubclass(a.dtype.type, np.floating))
+
     def test_int_inputs(self):
         # Using integer frequency arguments and large N should not produce
         # np.ints that wraparound to negative numbers

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1496,5 +1496,19 @@ class TestIIRFilter(TestCase):
         k2 = 9.999999999999989e+47
         assert_allclose(k, k2)
 
+    def test_invalid_wn_size(self):
+        # low and high have 1 Wn, band and stop have 2 Wn
+        assert_raises(ValueError, iirfilter, 1, [0.1, 0.9], btype='low')
+        assert_raises(ValueError, iirfilter, 1, [0.2, 0.5], btype='high')
+        assert_raises(ValueError, iirfilter, 1, 0.2, btype='bp')
+        assert_raises(ValueError, iirfilter, 1, 400, btype='bs', analog=True)
+
+    def test_invalid_wn_range(self):
+        # For digital filters, 0 <= Wn <= 1
+        assert_raises(ValueError, iirfilter, 1, 2, btype='low')
+        assert_raises(ValueError, iirfilter, 1, -1, btype='high')
+        assert_raises(ValueError, iirfilter, 1, [1, 2], btype='band')
+        assert_raises(ValueError, iirfilter, 1, [10, 20], btype='stop')
+
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -3,11 +3,14 @@ from __future__ import division, print_function, absolute_import
 import warnings
 
 import numpy as np
-from numpy.testing import TestCase, assert_array_almost_equal, \
-        assert_array_equal, assert_raises, assert_equal, assert_, \
-        run_module_suite
+from numpy.testing import (TestCase, assert_array_almost_equal,
+                           assert_array_equal, assert_raises, assert_equal,
+                           assert_, run_module_suite)
 
-from scipy.signal import tf2zpk, zpk2tf, BadCoefficients, freqz, normalize
+from scipy.signal import (tf2zpk, zpk2tf, BadCoefficients, freqz, normalize,
+                          buttord, cheby1, cheby2, ellip, cheb1ord, cheb2ord,
+                          ellipord, butter, bessel, buttap, besselap,
+                          cheb1ap, cheb2ap, ellipap)
 
 
 class TestTf2zpk(TestCase):
@@ -135,6 +138,388 @@ class TestNormalize(TestCase):
         # breaks on another platform, it is probably fine to relax this lower.
         assert_array_almost_equal(b_matlab, b_output, decimal=13)
         assert_array_almost_equal(a_matlab, a_output, decimal=13)
+
+
+class TestBesselap(TestCase):
+
+    def test_output_type(self):
+        # Should consistently output arrays, not lists
+        # https://github.com/scipy/scipy/pull/441
+        for N in range(7):
+            z, p, k = besselap(N)
+            assert_(isinstance(z, np.ndarray))
+            assert_(isinstance(p, np.ndarray))
+
+
+class TestButtap(TestCase):
+
+    def test_output_type(self):
+        # Should consistently output arrays, not lists
+        # https://github.com/scipy/scipy/pull/441
+        for N in range(7):
+            z, p, k = buttap(N)
+            assert_(isinstance(z, np.ndarray))
+            assert_(isinstance(p, np.ndarray))
+
+
+class TestCheb1ap(TestCase):
+
+    def test_output_type(self):
+        # Should consistently output arrays, not lists
+        # https://github.com/scipy/scipy/pull/441
+        for N in range(7):
+            z, p, k = cheb1ap(N, 1)
+            assert_(isinstance(z, np.ndarray))
+            assert_(isinstance(p, np.ndarray))
+
+
+class TestCheb2ap(TestCase):
+
+    def test_output_type(self):
+        # Should consistently output arrays, not lists
+        # https://github.com/scipy/scipy/pull/441
+        for N in range(7):
+            z, p, k = cheb2ap(N, 20)
+            assert_(isinstance(z, np.ndarray))
+            assert_(isinstance(p, np.ndarray))
+
+
+class TestEllipap(TestCase):
+
+    def test_output_type(self):
+        # Should consistently output arrays, not lists
+        # https://github.com/scipy/scipy/pull/441
+        for N in range(7):
+            z, p, k = ellipap(N, 1, 20)
+            assert_(isinstance(z, np.ndarray))
+            assert_(isinstance(p, np.ndarray))
+
+
+class TestButtord(TestCase):
+
+    def test_basic(self):
+        # From http://dsp.etfbl.net/filtri/aproksimacija
+        assert_array_almost_equal(buttord(1, 550/450, 1, 26, analog=True),
+                                  [19, 1.0441379169150726])
+
+        assert_equal(buttord(1, 1.2, 1, 80, analog=True)[0], 55)
+
+        # From http://www.mathworks.com/help/signal/ref/buttord.html
+        n, Wn = buttord(40/500, 150/500, 3, 60)
+        assert_equal(n, 5)
+        assert_array_almost_equal(Wn, 0.0810, decimal=4)
+
+        n, Wn = buttord([60/500, 200/500], [50/500, 250/500], 3, 40)
+        assert_equal(n, 16)
+        assert_array_almost_equal(Wn, [0.1198, 0.4005], decimal=4)
+
+
+class TestCheb1ord(TestCase):
+
+    def test_basic(self):
+        # From http://dsp.etfbl.net/filtri/aproksimacija
+        assert_equal(cheb1ord(1, 1.2, 1, 80, analog=True)[0], 17)
+
+        # From http://www.mathworks.com/help/signal/ref/cheb1ord.html
+        n, Wp = cheb1ord(40/500, 150/500, 3, 60)
+        assert_equal(n, 4)
+        assert_array_almost_equal(Wp, 0.0800, decimal=4)
+
+        n, Wp = cheb1ord([60/500, 200/500], [50/500, 250/500], 3, 40)
+        assert_equal(n, 7)
+        assert_array_almost_equal(Wp, [0.1200, 0.4000], decimal=4)
+
+
+class TestCheb2ord(TestCase):
+
+    def test_basic(self):
+        # From http://www.mathworks.com/help/signal/ref/cheb2ord.html
+        n, Ws = cheb2ord(40/500, 150/500, 3, 60)
+        assert_equal(n, 4)
+        # TODO: This fails.  Matlab docs wrong?
+        # assert_array_almost_equal(Ws, 0.3000, decimal=4)
+
+        n, Ws = cheb2ord([60/500, 200/500], [50/500, 250/500], 3, 40)
+        assert_equal(n, 7)
+        # TODO: This fails.  Matlab docs wrong?
+        # assert_array_almost_equal(Ws, [0.1000, 0.5000], decimal=4)
+
+        # http://cens.ioc.ee/local/man/matlab/toolbox/signal/cheb2ord.html
+        n, Wn = cheb2ord(100/500, 150/500, 3, 15)
+        assert_equal(n, 3)
+        assert_array_almost_equal(Wn, 0.2609, decimal=4)
+
+        n, Wn = cheb2ord([100/500, 200/500], [50/500, 250/500], 3, 30)
+        assert_equal(n, 4)
+        assert_array_almost_equal(Wn, [0.1633, 0.4665], decimal=4)
+
+
+class TestEllipord(TestCase):
+
+    def test_basic(self):
+        # From http://dsp.etfbl.net/filtri/aproksimacija
+        assert_equal(ellipord(1, 1.2, 1, 80, analog=True)[0], 9)
+
+        # From http://www.mathworks.com/help/signal/ref/ellipord.html
+        n, Wp = ellipord(40/500, 150/500, 3, 60)
+        assert_equal(n, 4)
+        assert_array_almost_equal(Wp, 0.0800, decimal=4)
+
+        n, Wp = ellipord([60/500, 200/500], [50/500, 250/500], 3, 40)
+        assert_equal(n, 5)
+        assert_array_almost_equal(Wp, [0.1200, 0.4000], decimal=4)
+
+
+class TestBessel(TestCase):
+
+    def test_degenerate(self):
+        # 0-order filter is just a passthrough
+        b, a = bessel(0, 1, analog=True)
+        assert_array_equal(b, [1])
+        assert_array_equal(a, [1])
+
+        # 1-order filter is same for all types
+        b, a = bessel(1, 1, analog=True)
+        assert_array_almost_equal(b, [1])
+        assert_array_almost_equal(a, [1, 1])
+
+
+class TestButter(TestCase):
+
+    def test_degenerate(self):
+        # 0-order filter is just a passthrough
+        b, a = butter(0, 1, analog=True)
+        assert_array_equal(b, [1])
+        assert_array_equal(a, [1])
+
+        # 1-order filter is same for all types
+        b, a = butter(1, 1, analog=True)
+        assert_array_almost_equal(b, [1])
+        assert_array_almost_equal(a, [1, 1])
+
+    def test_basic(self):
+        # Requires https://github.com/scipy/scipy/pull/3085 to pass
+        for N in range(25):
+            wn = 0.01
+            z, p, k = butter(N, wn, 'low', analog=True, output='zpk')
+            assert_array_almost_equal([], z)
+            assert_(len(p) == N)
+            # All poles should be at distance wn from origin
+            assert_array_almost_equal(wn, abs(p))
+            assert_(all(np.real(p) <= 0)) # No poles in right half of S-plane
+            assert_array_almost_equal(wn**N, k)
+
+        for N in range(25):
+            wn = 0.01
+            z, p, k = butter(N, wn, 'high', analog=False, output='zpk')
+            assert_array_equal(np.ones(N), z) # All zeros exactly at DC
+            assert_(all(np.abs(p) <= 1)) # No poles outside unit circle
+
+        # From http://dsp.etfbl.net/filtri/aproksimacija
+        b1, a1 = butter(2, 1, analog=True)
+        assert_array_almost_equal(b1, [1])
+        assert_array_almost_equal(a1, [1, np.sqrt(2), 1])
+
+        b2, a2 = butter(5, 1, analog=True)
+        assert_array_almost_equal(b2, [1])
+        assert_array_almost_equal(a2, [1, 3.2361, 5.2361,
+                                       5.2361, 3.2361, 1], decimal=4)
+
+        b3, a3 = butter(10, 1, analog=True)
+        assert_array_almost_equal(b3, [1])
+        assert_array_almost_equal(a3, [1, 6.3925, 20.4317, 42.8021, 64.8824,
+                                       74.2334, 64.8824, 42.8021, 20.4317,
+                                       6.3925, 1], decimal=4)
+
+        b2, a2 = butter(19, 1.0441379169150726, analog=True)
+        assert_array_almost_equal(b2, [2.2720], decimal=4)
+        assert_array_almost_equal(a2, 1.0e+004 * np.array([
+                        0.0001, 0.0013, 0.0080, 0.0335, 0.1045, 0.2570,
+                        0.5164, 0.8669, 1.2338, 1.5010, 1.5672, 1.4044,
+                        1.0759, 0.6986, 0.3791, 0.1681, 0.0588, 0.0153,
+                        0.0026, 0.0002]), decimal=0)
+
+        # From https://sites.google.com/site/nahums84/research/digital-filters---matlab
+        b, a = butter(5, 0.4)
+        assert_array_almost_equal(b, [0.0219, 0.1097, 0.2194,
+                                      0.2194, 0.1097, 0.0219], decimal=4)
+        assert_array_almost_equal(a, [1.0000, -0.9853, 0.9738,
+                                     -0.3864, 0.1112, -0.0113], decimal=4)
+
+
+class TestCheby1(TestCase):
+
+    def test_degenerate(self):
+        # 0-order filter is just a passthrough
+        # Even-order filters have DC gain of -rp dB
+        b, a = cheby1(0, 10*np.log10(2), 1, analog=True)
+        assert_array_equal(b, [1/np.sqrt(2)])
+        assert_array_equal(a, [1])
+
+        # 1-order filter is same for all types
+        b, a = cheby1(1, 10*np.log10(2), 1, analog=True)
+        assert_array_almost_equal(b, [1])
+        assert_array_almost_equal(a, [1, 1])
+
+    def test_basic(self):
+        # Requires https://github.com/scipy/scipy/pull/3085 to pass
+        for N in range(25):
+            wn = 0.01
+            z, p, k = cheby1(N, 1, wn, 'low', analog=True, output='zpk')
+            assert_array_almost_equal([], z)
+            assert_(len(p) == N)
+            assert_(all(np.real(p) <= 0)) # No poles in right half of S-plane
+
+        for N in range(25):
+            wn = 0.01
+            z, p, k = cheby1(N, 1, wn, 'high', analog=False, output='zpk')
+            assert_array_equal(np.ones(N), z) # All zeros exactly at DC
+            assert_(all(np.abs(p) <= 1)) # No poles outside unit circle
+
+        # From TestNormalize
+        b, a = cheby1(8, 0.5, 0.048)
+        assert_array_almost_equal(b, np.array([
+                             2.150733144728282e-11, 1.720586515782626e-10,
+                             6.022052805239190e-10, 1.204410561047838e-09,
+                             1.505513201309798e-09, 1.204410561047838e-09,
+                             6.022052805239190e-10, 1.720586515782626e-10,
+                             2.150733144728282e-11]), decimal=14)
+        assert_array_almost_equal(a, np.array([
+                             1.000000000000000e+00, -7.782402035027959e+00,
+                             2.654354569747454e+01, -5.182182531666387e+01,
+                             6.334127355102684e+01, -4.963358186631157e+01,
+                             2.434862182949389e+01, -6.836925348604676e+00,
+                             8.412934944449140e-01]), decimal=14)
+
+        # From https://sites.google.com/site/vandankeuth/lab7-matlab
+        b, a = cheby1(4, 1, [0.4, 0.7], btype='band')
+        assert_array_almost_equal(b, [0.0084, 0, -0.0335, 0, 0.0502, 0,
+                                      -0.0335, 0, 0.0084], decimal=4)
+        assert_array_almost_equal(a, [1.0, 1.1191, 2.862, 2.2986, 3.4137,
+                                      1.8653, 1.8982, 0.5676, 0.4103],
+                                      decimal=4)
+
+        # From http://dsp.etfbl.net/filtri/aproksimacija
+        b2, a2 = cheby1(5, 3, 1, analog=True)
+        assert_array_almost_equal(b2, [0.0626], decimal=4)
+        assert_array_almost_equal(a2, [1, 0.5745, 1.4150, 0.5489, 0.4080,
+                                       0.0626], decimal=4)
+
+        # From http://searchcode.com/codesearch/raw/27092032
+        b, a = cheby1(8, 0.5, 0.1)
+        assert_array_almost_equal(b, 1.0e-006 * np.array([
+             0.00703924326028, 0.05631394608227, 0.19709881128793,
+             0.39419762257586, 0.49274702821983, 0.39419762257586,
+             0.19709881128793, 0.05631394608227, 0.00703924326028]),
+             decimal=13)
+        assert_array_almost_equal(a, [
+             1.00000000000000, -7.44912258934158,  24.46749067762108,
+           -46.27560200466141, 55.11160187999928, -42.31640010161038,
+            20.45543300484147, -5.69110270561444,   0.69770374759022],
+            decimal=13)
+
+        b, a = cheby1(8, 0.5, 0.25)
+        assert_array_almost_equal(b, 1.0e-003 * np.array([
+            0.00895261138923, 0.07162089111382, 0.25067311889837,
+            0.50134623779673, 0.62668279724591, 0.50134623779673,
+            0.25067311889837, 0.07162089111382, 0.00895261138923]),
+            decimal=13)
+        assert_array_almost_equal(a, [
+            1.00000000000000, -5.97529229188545, 16.58122329202101,
+            -27.71423273542923, 30.39509758355313, -22.34729670426879,
+            10.74509800434910, -3.08924633697497, 0.40707685889802],
+            decimal=13)
+
+
+class TestCheby2(TestCase):
+
+    def test_degenerate(self):
+        # 0-order filter is just a passthrough
+        # Stopband ripple factor doesn't matter
+        b, a = cheby2(0, 123.456, 1, analog=True)
+        assert_array_equal(b, [1])
+        assert_array_equal(a, [1])
+
+        # 1-order filter is same for all types
+        b, a = cheby2(1, 10*np.log10(2), 1, analog=True)
+        assert_array_almost_equal(b, [1])
+        assert_array_almost_equal(a, [1, 1])
+
+    def test_basic(self):
+        # Requires https://github.com/scipy/scipy/pull/3085 to pass
+        for N in range(25):
+            wn = 0.01
+            z, p, k = cheby2(N, 40, wn, 'low', analog=True, output='zpk')
+            assert_(len(p) == N)
+            assert_(all(np.real(p) <= 0)) # No poles in right half of S-plane
+
+        for N in range(25):
+            wn = 0.01
+            z, p, k = cheby2(N, 40, wn, 'high', analog=False, output='zpk')
+            assert_(all(np.abs(p) <= 1)) # No poles outside unit circle
+
+        # From http://www.dsprelated.com/showmessage/20207/1.php
+        B, A = cheby2(18, 100, 0.5)
+        assert_array_almost_equal(B, [
+            0.00167583914216, 0.01249479541868, 0.05282702120282,
+            0.15939804265706, 0.37690207631117, 0.73227013789108,
+            1.20191856962356, 1.69522872823393, 2.07598674519837,
+            2.21972389625291, 2.07598674519838, 1.69522872823395,
+            1.20191856962359, 0.73227013789110, 0.37690207631118,
+            0.15939804265707, 0.05282702120282, 0.01249479541868,
+            0.00167583914216], decimal=13)
+        assert_array_almost_equal(A, [
+            1.00000000000000, -0.27631970006174, 3.19751214254060,
+            -0.15685969461355, 4.13926117356269, 0.60689917820044,
+            2.95082770636540, 0.89016501910416, 1.32135245849798,
+            0.51502467236824, 0.38906643866660, 0.15367372690642,
+            0.07255803834919, 0.02422454070134, 0.00756108751837,
+            0.00179848550988, 0.00033713574499, 0.00004258794833,
+            0.00000281030149], decimal=13)
+
+
+class TestEllip(TestCase):
+
+    def test_degenerate(self):
+        # 0-order filter is just a passthrough
+        # Even-order filters have DC gain of -rp dB
+        # Stopband ripple factor doesn't matter
+        b, a = ellip(0, 10*np.log10(2), 123.456, 1, analog=True)
+        assert_array_equal(b, [1/np.sqrt(2)])
+        assert_array_equal(a, [1])
+
+        # 1-order filter is same for all types
+        b, a = ellip(1, 10*np.log10(2), 1, 1, analog=True)
+        assert_array_almost_equal(b, [1])
+        assert_array_almost_equal(a, [1, 1])
+
+    def test_basic(self):
+        # Requires https://github.com/scipy/scipy/pull/3085 to pass
+        for N in range(25):
+            wn = 0.01
+            z, p, k = ellip(N, 1, 40, wn, 'low', analog=True, output='zpk')
+            assert_(len(p) == N)
+            assert_(all(np.real(p) <= 0)) # No poles in right half of S-plane
+
+        for N in range(25):
+            wn = 0.01
+            z, p, k = ellip(N, 1, 40, wn, 'high', analog=False, output='zpk')
+            assert_(all(np.abs(p) <= 1)) # No poles outside unit circle
+
+        # From http://dsp.etfbl.net/filtri/aproksimacija
+        b3, a3 = ellip(5, 3, 26, 1, analog=True)
+        assert_array_almost_equal(b3, [0.1420, 0, 0.3764, 0,
+                                       0.2409], decimal=4)
+        assert_array_almost_equal(a3, [1, 0.5686, 1.8061, 0.8017, 0.8012,
+                                       0.2409], decimal=4)
+
+        # From https://sites.google.com/site/michaeltsessa/lab-7
+        b, a = ellip(3, 1, 60, [0.4, 0.7], 'stop')
+        assert_array_almost_equal(b, [0.3310, 0.3469, 1.1042, 0.7044, 1.1042,
+                                      0.3469, 0.3310], decimal=4)
+        assert_array_almost_equal(a, [1.0000, 0.6973, 1.1441, 0.5878, 0.7323,
+                                      0.1131, -0.0060], decimal=4)
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -10,7 +10,7 @@ from numpy.testing import (TestCase, assert_array_almost_equal,
 from scipy.signal import (tf2zpk, zpk2tf, BadCoefficients, freqz, normalize,
                           buttord, cheby1, cheby2, ellip, cheb1ord, cheb2ord,
                           ellipord, butter, bessel, buttap, besselap,
-                          cheb1ap, cheb2ap, ellipap)
+                          cheb1ap, cheb2ap, ellipap, iirfilter)
 
 
 class TestTf2zpk(TestCase):
@@ -519,6 +519,22 @@ class TestEllip(TestCase):
                                       0.3469, 0.3310], decimal=4)
         assert_array_almost_equal(a, [1.0000, 0.6973, 1.1441, 0.5878, 0.7323,
                                       0.1131, -0.0060], decimal=4)
+
+
+class TestIIRFilter(TestCase):
+
+    def test_symmetry(self):
+        # All built-in IIR filters are real, so should have perfectly
+        # symmetrical poles and zeros. Then ba representation (using
+        # numpy.poly) will be purely real instead of having negligible
+        # imaginary parts.
+        for N in np.arange(1, 26):
+            for ftype in ('butter', 'bessel', 'cheby1', 'cheby2', 'ellip'):
+                z, p, k = iirfilter(N, 1.1, 1, 20, 'low', analog=True, 
+                                    ftype=ftype, output='zpk')
+                assert_array_equal(sorted(z), sorted(z.conj()))
+                assert_array_equal(sorted(p), sorted(p.conj()))
+                assert_equal(k, np.real(k))
 
 
 if __name__ == "__main__":

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -11,7 +11,8 @@ from numpy.testing import (TestCase, assert_array_almost_equal,
 from scipy.signal import (tf2zpk, zpk2tf, BadCoefficients, freqz, normalize,
                           buttord, cheby1, cheby2, ellip, cheb1ord, cheb2ord,
                           ellipord, butter, bessel, buttap, besselap,
-                          cheb1ap, cheb2ap, ellipap, iirfilter, freqs)
+                          cheb1ap, cheb2ap, ellipap, iirfilter, freqs,
+                          lp2lp, lp2hp, lp2bp, lp2bs, bilinear)
 
 
 class TestTf2zpk(TestCase):
@@ -139,6 +140,65 @@ class TestNormalize(TestCase):
         # breaks on another platform, it is probably fine to relax this lower.
         assert_array_almost_equal(b_matlab, b_output, decimal=13)
         assert_array_almost_equal(a_matlab, a_output, decimal=13)
+
+
+class TestLp2lp(TestCase):
+
+    def test_basic(self):
+        b = [1]
+        a = [1, np.sqrt(2), 1]
+        b_lp, a_lp = lp2lp(b, a, 0.38574256627112119)
+        assert_array_almost_equal(b_lp, [0.1488], decimal=4)
+        assert_array_almost_equal(a_lp, [1, 0.5455, 0.1488], decimal=4)
+
+
+class TestLp2hp(TestCase):
+
+    def test_basic(self):
+        b = [0.25059432325190018]
+        a = [1, 0.59724041654134863, 0.92834805757524175, 0.25059432325190018]
+        b_hp, a_hp = lp2hp(b, a, 2*np.pi*5000)
+        assert_allclose(b_hp, [1, 0, 0, 0])
+        assert_allclose(a_hp, [1, 1.1638e5, 2.3522e9, 1.2373e14], rtol=1e-4)
+
+class TestLp2bp(TestCase):
+
+    def test_basic(self):
+        b = [1]
+        a = [1, 2, 2, 1]
+        b_bp, a_bp = lp2bp(b, a, 2*np.pi*4000, 2*np.pi*2000)
+        assert_allclose(b_bp, [1.9844e12, 0, 0, 0], rtol=1e-6)
+        assert_allclose(a_bp, [1, 2.5133e4, 2.2108e9, 3.3735e13,
+                               1.3965e18, 1.0028e22, 2.5202e26], rtol=1e-4)
+
+
+class TestLp2bs(TestCase):
+
+    def test_basic(self):
+        b = [1]
+        a = [1, 1]
+        b_bs, a_bs = lp2bs(b, a, 0.41722257286366754, 0.18460575326152251)
+        assert_array_almost_equal(b_bs, [1, 0, 0.17407], decimal=5)
+        assert_array_almost_equal(a_bs, [1, 0.18461, 0.17407], decimal=5)
+
+
+class TestBilinear(TestCase):
+
+    def test_basic(self):
+        b = [0.14879732743343033]
+        a = [1, 0.54552236880522209, 0.14879732743343033]
+        b_z, a_z = bilinear(b, a, 0.5)
+        assert_array_almost_equal(b_z, [0.087821, 0.17564, 0.087821],
+                                  decimal=5)
+        assert_array_almost_equal(a_z, [1, -1.0048, 0.35606], decimal=4)
+
+        b = [1, 0, 0.17407467530697837]
+        a = [1, 0.18460575326152251, 0.17407467530697837]
+        b_z, a_z = bilinear(b, a, 0.5)
+        assert_array_almost_equal(b_z, [0.86413, -1.2158, 0.86413],
+                                  decimal=4)
+        assert_array_almost_equal(a_z, [1, -1.2158, 0.72826],
+                                  decimal=4)
 
 
 class TestPrototypeType(TestCase):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1483,6 +1483,13 @@ class TestIIRFilter(TestCase):
                 assert_array_equal(sorted(p), sorted(p.conj()))
                 assert_equal(k, np.real(k))
 
+    def test_int_inputs(self):
+        # Using integer frequency arguments and large N should not produce
+        # np.ints that wraparound to negative numbers
+        k = iirfilter(24, 100, btype='low', analog=True, ftype='bessel',
+                      output='zpk')[2]
+        k2 = 9.999999999999989e+47
+        assert_allclose(k, k2)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -353,7 +353,7 @@ class TestCheby1(TestCase):
         # 0-order filter is just a passthrough
         # Even-order filters have DC gain of -rp dB
         b, a = cheby1(0, 10*np.log10(2), 1, analog=True)
-        assert_array_equal(b, [1/np.sqrt(2)])
+        assert_array_almost_equal(b, [1/np.sqrt(2)])
         assert_array_equal(a, [1])
 
         # 1-order filter is same for all types
@@ -485,7 +485,7 @@ class TestEllip(TestCase):
         # Even-order filters have DC gain of -rp dB
         # Stopband ripple factor doesn't matter
         b, a = ellip(0, 10*np.log10(2), 123.456, 1, analog=True)
-        assert_array_equal(b, [1/np.sqrt(2)])
+        assert_array_almost_equal(b, [1/np.sqrt(2)])
         assert_array_equal(a, [1])
 
         # 1-order filter is same for all types


### PR DESCRIPTION
Temporary fix for #2443, using private functions until a decision is made about how to arrange the functions for backwards compatibility, etc.

Examples:
17-pole digital Butterworth bandpass
Before:
![bad butter 17](https://f.cloud.github.com/assets/58611/1579769/ba499b88-51a6-11e3-8a44-60aee1ba17f7.png)

After:
![digital butter17](https://f.cloud.github.com/assets/58611/1579770/c638a3b2-51a6-11e3-8691-1cc5b9adb23f.png)

21-pole analog Butterworth lowpass at Wn=0.01
Before:
![signal butter 21 01 pz](https://f.cloud.github.com/assets/58611/1579783/5de5909e-51a7-11e3-8104-9e4c4fe5dd5b.png)

After:
![mine butter 21 01 pz](https://f.cloud.github.com/assets/58611/1579785/695665e8-51a7-11e3-8989-a6af4722ac9f.png)

cheby2 bandpass
Before:
![sloppy cheby2 freq resp](https://f.cloud.github.com/assets/58611/1579786/702f98f8-51a7-11e3-8cf1-5d25ee0a1a62.png)

After:
![better cheby2 freq resp](https://f.cloud.github.com/assets/58611/1579787/77a53908-51a7-11e3-8514-bbd0473358ad.png)
