### PR TITLE
OPT: Add a benchmark framework for the optimizers

### DIFF
--- a/scipy/optimize/benchmarks/bench_optimizers.py
+++ b/scipy/optimize/benchmarks/bench_optimizers.py
@@ -1,0 +1,65 @@
+import time
+
+import scipy.optimize
+from scipy.optimize.optimize import rosen, rosen_der, rosen_hess
+
+class BenchOptimizers(object):
+    def __init__(self):
+        self.results = []
+
+    def add_result(self, result, t, name):
+        result.time = t
+        result.name = name
+        if not hasattr(result, "njev"):
+            result.njev = 0
+        if not hasattr(result, "nhev"):
+            result.nhev = 0
+        self.results.append(result)
+    
+    def print_results(self):
+        results = sorted(self.results, key=lambda x:x.time)
+        print("Optimizer benchmark on the Rosenbrock function sorted by time")
+        for res in results:
+            if res.success:
+                success = "pass"
+            else:
+                success = "fail"
+            print("%15s %s nfev %4d njev %4d nhev %4d time %.6g" % 
+                  (res.name, success, res.nfev, res.njev, res.nhev, res.time))
+    
+    def bench_run(self, fun=rosen, der=rosen_der, hess=rosen_hess, 
+                  x0=[0.8, 1.2, 0.7]):
+        kwargs = dict(tol=1e-4)
+        
+        fonly_methods = ["COBYLA", 'Powell']
+        for method in fonly_methods:
+            t0 = time.time()
+            res = scipy.optimize.minimize(fun, x0, method=method, **kwargs)
+            t1 = time.time()
+            self.add_result(res, t1-t0, method)
+        
+        
+        gradient_methods = ['L-BFGS-B', 'BFGS', 'CG', 'TNC', 'SLSQP']
+        for method in gradient_methods:
+            t0 = time.time()
+            res = scipy.optimize.minimize(fun, x0, method=method, jac=der, 
+                                          **kwargs)
+            t1 = time.time()
+            self.add_result(res, t1-t0, method)
+
+        hessian_methods = ["Newton-CG", 'dogleg', 'trust-ncg']
+        for method in hessian_methods:
+            t0 = time.time()
+            res = scipy.optimize.minimize(fun, x0, method=method, jac=der, 
+                                          hess=hess, **kwargs)
+            t1 = time.time()
+            self.add_result(res, t1-t0, method)
+
+
+def main():
+    b = BenchOptimizers()
+    b.bench_run()
+    b.print_results()
+
+if __name__ == "__main__":
+    main()

--- a/scipy/optimize/benchmarks/bench_optimizers.py
+++ b/scipy/optimize/benchmarks/bench_optimizers.py
@@ -157,9 +157,18 @@ def bench_booth():
         b.bench_run(np.random.uniform(0,10,2))
     b.print_results()
 
+def bench_beale():
+    s = funcs.Beale()
+    print "checking gradient", scipy.optimize.check_grad(s.fun, s.der, np.array([1.1, -2.3]))
+    b = BenchOptimizers("Beale's function",
+                        fun=s.fun, der=s.der, hess=None)
+    for i in xrange(10):
+        b.bench_run(np.random.uniform(0,10,2))
+    b.print_results()
+
 def bench_LJ():
     s = funcs.LJ()
-#    print "checking gradient", scipy.optimize.check_grad(s.get_energy, s.get_gradient, np.random.uniform(-2,2,3*4))
+    print "checking gradient", scipy.optimize.check_grad(s.get_energy, s.get_gradient, np.random.uniform(-2,2,3*4))
     natoms = 4
     b = BenchOptimizers("%d atom Lennard Jones potential" % (natoms),
                         fun=s.get_energy, der=s.get_gradient, hess=None)
@@ -174,6 +183,7 @@ def main():
     bench_asymetric_quadratic()
     bench_sin_1d()
     bench_booth()
+    bench_beale()
     bench_LJ()
 
 if __name__ == "__main__":

--- a/scipy/optimize/benchmarks/bench_optimizers.py
+++ b/scipy/optimize/benchmarks/bench_optimizers.py
@@ -55,7 +55,7 @@ class _BenchOptimizers(object):
         print("")
         print("=========================================================")
         print("Optimizer benchmark: %s" % (self.function_name))
-        print("extra kwargs: %s" % (str(self.minimizer_kwargs)))
+        print("dimensions: %d, extra kwargs: %s" % (results[0].ndim, str(self.minimizer_kwargs)))
         print("averaged over %d starting configurations" % (results[0].ntrials))
         print("  Optimizer    nfail   nfev    njev    nhev    time")
         print("---------------------------------------------------------")
@@ -79,6 +79,10 @@ class _BenchOptimizers(object):
             newres.mean_time = np.mean([r.time for r in result_list])
             newres.ntrials = len(result_list)
             newres.nfail = len([r for r in result_list if not r.success])
+            try:
+                newres.ndim = len(result_list[0].x)
+            except TypeError:
+                newres.ndim = 1
             averaged_results[name] = newres
         return averaged_results.values()
     

--- a/scipy/optimize/benchmarks/bench_optimizers.py
+++ b/scipy/optimize/benchmarks/bench_optimizers.py
@@ -133,7 +133,7 @@ def bench_simple_quadratic():
 def bench_asymetric_quadratic():
     s = funcs.AsymmetricQuadratic()
 #    print "checking gradient", scipy.optimize.check_grad(s.fun, s.der, np.array([1.1, -2.3]))
-    b = BenchOptimizers("function x**2 - x",
+    b = BenchOptimizers("function sum(x**2) + x[0]",
                         fun=s.fun, der=s.der, hess=s.hess)
     for i in xrange(10):
         b.bench_run(np.random.uniform(-2,2,3))

--- a/scipy/optimize/benchmarks/bench_optimizers.py
+++ b/scipy/optimize/benchmarks/bench_optimizers.py
@@ -46,7 +46,7 @@ class BenchOptimizers(object):
         results = sorted(results, key=lambda x: (x.nfail, x.mean_time))
         print("")
         print("---------------------------------------------------------")
-        print("Optimizer benchmark on the %s" % (self.function_name))
+        print("Optimizer benchmark: %s" % (self.function_name))
         print("averaged over %d starting configurations" % (results[0].ntrials))
         print("      Optimizer   nfail  nfev   njev   nhev   time")
         print("---------------------------------------------------------")
@@ -148,7 +148,16 @@ def bench_sin_1d():
         b.bench_run(np.random.uniform(-2,2,1))
     b.print_results()
 
-def test_LJ():
+def bench_booth():
+    s = funcs.Booth()
+#    print "checking gradient", scipy.optimize.check_grad(s.fun, s.der, np.array([1.1, -2.3]))
+    b = BenchOptimizers("Booth's function",
+                        fun=s.fun, der=s.der, hess=None)
+    for i in xrange(10):
+        b.bench_run(np.random.uniform(0,10,2))
+    b.print_results()
+
+def bench_LJ():
     s = funcs.LJ()
 #    print "checking gradient", scipy.optimize.check_grad(s.get_energy, s.get_gradient, np.random.uniform(-2,2,3*4))
     natoms = 4
@@ -164,7 +173,8 @@ def main():
     bench_simple_quadratic()
     bench_asymetric_quadratic()
     bench_sin_1d()
-    test_LJ()
+    bench_booth()
+    bench_LJ()
 
 if __name__ == "__main__":
     main()

--- a/scipy/optimize/benchmarks/bench_optimizers.py
+++ b/scipy/optimize/benchmarks/bench_optimizers.py
@@ -2,7 +2,7 @@ import time
 from collections import defaultdict
 
 import numpy as np
-from numpy.testing import Tester
+from numpy.testing import Tester, TestCase
 
 import scipy.optimize
 from scipy.optimize.optimize import rosen, rosen_der, rosen_hess
@@ -114,93 +114,87 @@ class _BenchOptimizers(object):
                 t1 = time.time()
                 self.add_result(res, t1-t0, method)
 
-def bench_rosenbrock():
-    b = _BenchOptimizers("Rosenbrock function",
-                         fun=rosen, der=rosen_der, hess=rosen_hess)
+class BenchSmoothUnbounded(TestCase):
+    """Benchmark the optimizers with smooth, unbounded, functions"""
+    def bench_rosenbrock(self):
+        b = _BenchOptimizers("Rosenbrock function",
+                             fun=rosen, der=rosen_der, hess=rosen_hess)
+        for i in xrange(10):
+            b.bench_run(np.random.uniform(-3,3,3))
+        b.print_results()
     
-#    # do a single test
-#    b.bench_run([0.8, 1.2, 0.7])
-#    b.print_results()
+    def bench_rosenbrock_tight(self):
+        b = _BenchOptimizers("Rosenbrock function",
+                             fun=rosen, der=rosen_der, hess=rosen_hess,
+                             tol=1e-8)
+        for i in xrange(10):
+            b.bench_run(np.random.uniform(-3,3,3))
+        b.print_results()
     
-    # average over multiple starting points
-    b.reset()
-    for i in xrange(10):
-        b.bench_run(np.random.uniform(-3,3,3))
-    b.print_results()
-
-def bench_rosenbrock_tight():
-    b = _BenchOptimizers("Rosenbrock function",
-                         fun=rosen, der=rosen_der, hess=rosen_hess,
-                         tol=1e-8)
-    # average over multiple starting points
-    for i in xrange(10):
-        b.bench_run(np.random.uniform(-3,3,3))
-    b.print_results()
-
-def bench_simple_quadratic():
-    s = funcs.SimpleQuadratic()
-#    print "checking gradient", scipy.optimize.check_grad(s.fun, s.der, np.array([1.1, -2.3]))
-    b = _BenchOptimizers("simple quadratic function",
-                         fun=s.fun, der=s.der, hess=s.hess)
-    for i in xrange(10):
-        b.bench_run(np.random.uniform(-2,2,3))
-    b.print_results()
-
-def bench_asymetric_quadratic():
-    s = funcs.AsymmetricQuadratic()
-#    print "checking gradient", scipy.optimize.check_grad(s.fun, s.der, np.array([1.1, -2.3]))
-    b = _BenchOptimizers("function sum(x**2) + x[0]",
-                         fun=s.fun, der=s.der, hess=s.hess)
-    for i in xrange(10):
-        b.bench_run(np.random.uniform(-2,2,3))
-    b.print_results()
-
-def bench_sin_1d():
-    fun = lambda x: np.sin(x[0])
-    der = lambda x: np.array([np.cos(x[0])])
-    b = _BenchOptimizers("1d sin function",
-                         fun=fun, der=der, hess=None)
-    for i in xrange(10):
-        b.bench_run(np.random.uniform(-2,2,1))
-    b.print_results()
-
-def bench_booth():
-    s = funcs.Booth()
-#    print "checking gradient", scipy.optimize.check_grad(s.fun, s.der, np.array([1.1, -2.3]))
-    b = _BenchOptimizers("Booth's function",
-                         fun=s.fun, der=s.der, hess=None)
-    for i in xrange(10):
-        b.bench_run(np.random.uniform(0,10,2))
-    b.print_results()
-
-def bench_beale():
-    s = funcs.Beale()
-#    print "checking gradient", scipy.optimize.check_grad(s.fun, s.der, np.array([1.1, -2.3]))
-    b = _BenchOptimizers("Beale's function",
-                         fun=s.fun, der=s.der, hess=None)
-    for i in xrange(10):
-        b.bench_run(np.random.uniform(0,10,2))
-    b.print_results()
-
-def bench_LJ():
-    s = funcs.LJ()
-#    print "checking gradient", scipy.optimize.check_grad(s.get_energy, s.get_gradient, np.random.uniform(-2,2,3*4))
-    natoms = 4
-    b = _BenchOptimizers("%d atom Lennard Jones potential" % (natoms),
-                         fun=s.get_energy, der=s.get_gradient, hess=None)
-    for i in xrange(10):
-        b.bench_run(np.random.uniform(-2,2,natoms*3))
-    b.print_results()
-
-
-def main():
-    bench_rosenbrock()
-    bench_simple_quadratic()
-    bench_asymetric_quadratic()
-    bench_sin_1d()
-    bench_booth()
-    bench_beale()
-    bench_LJ()
+    def bench_simple_quadratic(self):
+        s = funcs.SimpleQuadratic()
+    #    print "checking gradient", scipy.optimize.check_grad(s.fun, s.der, np.array([1.1, -2.3]))
+        b = _BenchOptimizers("simple quadratic function",
+                             fun=s.fun, der=s.der, hess=s.hess)
+        for i in xrange(10):
+            b.bench_run(np.random.uniform(-2,2,3))
+        b.print_results()
+    
+    def bench_asymetric_quadratic(self):
+        s = funcs.AsymmetricQuadratic()
+    #    print "checking gradient", scipy.optimize.check_grad(s.fun, s.der, np.array([1.1, -2.3]))
+        b = _BenchOptimizers("function sum(x**2) + x[0]",
+                             fun=s.fun, der=s.der, hess=s.hess)
+        for i in xrange(10):
+            b.bench_run(np.random.uniform(-2,2,3))
+        b.print_results()
+    
+    def bench_sin_1d(self):
+        fun = lambda x: np.sin(x[0])
+        der = lambda x: np.array([np.cos(x[0])])
+        b = _BenchOptimizers("1d sin function",
+                             fun=fun, der=der, hess=None)
+        for i in xrange(10):
+            b.bench_run(np.random.uniform(-2,2,1))
+        b.print_results()
+    
+    def bench_booth(self):
+        s = funcs.Booth()
+    #    print "checking gradient", scipy.optimize.check_grad(s.fun, s.der, np.array([1.1, -2.3]))
+        b = _BenchOptimizers("Booth's function",
+                             fun=s.fun, der=s.der, hess=None)
+        for i in xrange(10):
+            b.bench_run(np.random.uniform(0,10,2))
+        b.print_results()
+    
+    def bench_beale(self):
+        s = funcs.Beale()
+    #    print "checking gradient", scipy.optimize.check_grad(s.fun, s.der, np.array([1.1, -2.3]))
+        b = _BenchOptimizers("Beale's function",
+                             fun=s.fun, der=s.der, hess=None)
+        for i in xrange(10):
+            b.bench_run(np.random.uniform(0,10,2))
+        b.print_results()
+    
+    def bench_LJ(self):
+        s = funcs.LJ()
+    #    print "checking gradient", scipy.optimize.check_grad(s.get_energy, s.get_gradient, np.random.uniform(-2,2,3*4))
+        natoms = 4
+        b = _BenchOptimizers("%d atom Lennard Jones potential" % (natoms),
+                             fun=s.get_energy, der=s.get_gradient, hess=None)
+        for i in xrange(10):
+            b.bench_run(np.random.uniform(-2,2,natoms*3))
+        b.print_results()
+    
+    
+#def main():
+#    bench_rosenbrock()
+#    bench_simple_quadratic()
+#    bench_asymetric_quadratic()
+#    bench_sin_1d()
+#    bench_booth()
+#    bench_beale()
+#    bench_LJ()
 
 if __name__ == "__main__":
     Tester().bench(extra_argv=dict())

--- a/scipy/optimize/benchmarks/bench_optimizers.py
+++ b/scipy/optimize/benchmarks/bench_optimizers.py
@@ -1,13 +1,37 @@
 import time
+from collections import defaultdict
+
+import numpy as np
 
 import scipy.optimize
 from scipy.optimize.optimize import rosen, rosen_der, rosen_hess
+import test_functions as funcs
+
 
 class BenchOptimizers(object):
-    def __init__(self):
+    """a framework for benchmarking the optimizer
+    
+    Parameters
+    ----------
+    function_name : string
+    fun : callable
+    der : callable
+        function that returns the derivitive (jacobian, gradient) of fun
+    hess : callable
+        function that returns the hessian of fun
+    """
+    def __init__(self, function_name, fun, der=None, hess=None):
+        self.function_name = function_name
+        self.fun = fun
+        self.der = der
+        self.hess = hess
+        self.results = []
+
+    def reset(self):
         self.results = []
 
     def add_result(self, result, t, name):
+        """add a result to the list"""
         result.time = t
         result.name = name
         if not hasattr(result, "njev"):
@@ -17,49 +41,130 @@ class BenchOptimizers(object):
         self.results.append(result)
     
     def print_results(self):
-        results = sorted(self.results, key=lambda x:x.time)
-        print("Optimizer benchmark on the Rosenbrock function sorted by time")
+        """print the current list of results"""
+        results = self.average_results()
+        results = sorted(results, key=lambda x: (x.nfail, x.mean_time))
+        print("")
+        print("---------------------------------------------------------")
+        print("Optimizer benchmark on the %s" % (self.function_name))
+        print("averaged over %d starting configurations" % (results[0].ntrials))
+        print("      Optimizer   nfail  nfev   njev   nhev   time")
+        print("---------------------------------------------------------")
         for res in results:
-            if res.success:
-                success = "pass"
-            else:
-                success = "fail"
-            print("%15s %s nfev %4d njev %4d nhev %4d time %.6g" % 
-                  (res.name, success, res.nfev, res.njev, res.nhev, res.time))
+            print("%15s   %4d   %4d   %4d   %4d   %.6g" % 
+                  (res.name, res.nfail, res.mean_nfev, res.mean_njev, res.mean_nhev, res.mean_time))
     
-    def bench_run(self, fun=rosen, der=rosen_der, hess=rosen_hess, 
-                  x0=[0.8, 1.2, 0.7]):
+    def average_results(self):
+        """group the results by minimizer and average over the runs"""
+        grouped_results = defaultdict(list)
+        for res in self.results:
+            grouped_results[res.name].append(res)
+        
+        averaged_results = dict()
+        for name, result_list in grouped_results.iteritems():
+            newres = scipy.optimize.Result()
+            newres.name = name
+            newres.mean_nfev = np.mean([r.nfev for r in result_list])
+            newres.mean_njev = np.mean([r.njev for r in result_list])
+            newres.mean_nhev = np.mean([r.nhev for r in result_list])
+            newres.mean_time = np.mean([r.time for r in result_list])
+            newres.ntrials = len(result_list)
+            newres.nfail = len([r for r in result_list if not r.success])
+            averaged_results[name] = newres
+        return averaged_results.values()
+    
+    def bench_run(self, x0):
+        """do an optimization test starting at x0 for all the optimizers"""
         kwargs = dict(tol=1e-4)
         
         fonly_methods = ["COBYLA", 'Powell']
         for method in fonly_methods:
             t0 = time.time()
-            res = scipy.optimize.minimize(fun, x0, method=method, **kwargs)
+            res = scipy.optimize.minimize(self.fun, x0, method=method, 
+                                          **kwargs)
             t1 = time.time()
             self.add_result(res, t1-t0, method)
         
         
         gradient_methods = ['L-BFGS-B', 'BFGS', 'CG', 'TNC', 'SLSQP']
-        for method in gradient_methods:
-            t0 = time.time()
-            res = scipy.optimize.minimize(fun, x0, method=method, jac=der, 
-                                          **kwargs)
-            t1 = time.time()
-            self.add_result(res, t1-t0, method)
+        if self.der is not None:
+            for method in gradient_methods:
+                t0 = time.time()
+                res = scipy.optimize.minimize(self.fun, x0, method=method, 
+                                              jac=self.der, **kwargs)
+                t1 = time.time()
+                self.add_result(res, t1-t0, method)
 
         hessian_methods = ["Newton-CG", 'dogleg', 'trust-ncg']
-        for method in hessian_methods:
-            t0 = time.time()
-            res = scipy.optimize.minimize(fun, x0, method=method, jac=der, 
-                                          hess=hess, **kwargs)
-            t1 = time.time()
-            self.add_result(res, t1-t0, method)
+        if self.hess is not None:
+            for method in hessian_methods:
+                t0 = time.time()
+                res = scipy.optimize.minimize(self.fun, x0, method=method, 
+                                              jac=self.der, hess=self.hess, 
+                                              **kwargs)
+                t1 = time.time()
+                self.add_result(res, t1-t0, method)
+
+
+
+def bench_rosenbrock():
+    b = BenchOptimizers("Rosenbrock function",
+                        fun=rosen, der=rosen_der, hess=rosen_hess)
+    
+#    # do a single test
+#    b.bench_run([0.8, 1.2, 0.7])
+#    b.print_results()
+    
+    # average over multiple starting points
+    b.reset()
+    for i in xrange(10):
+        b.bench_run(np.random.uniform(-3,3,3))
+    b.print_results()
+
+def bench_simple_quadratic():
+    s = funcs.SimpleQuadratic()
+#    print "checking gradient", scipy.optimize.check_grad(s.fun, s.der, np.array([1.1, -2.3]))
+    b = BenchOptimizers("simple quadratic function",
+                        fun=s.fun, der=s.der, hess=s.hess)
+    for i in xrange(10):
+        b.bench_run(np.random.uniform(-2,2,3))
+    b.print_results()
+
+def bench_asymetric_quadratic():
+    s = funcs.AsymmetricQuadratic()
+#    print "checking gradient", scipy.optimize.check_grad(s.fun, s.der, np.array([1.1, -2.3]))
+    b = BenchOptimizers("function x**2 - x",
+                        fun=s.fun, der=s.der, hess=s.hess)
+    for i in xrange(10):
+        b.bench_run(np.random.uniform(-2,2,3))
+    b.print_results()
+
+def bench_sin_1d():
+    fun = lambda x: np.sin(x[0])
+    der = lambda x: np.array([np.cos(x[0])])
+    b = BenchOptimizers("1d sin function",
+                        fun=fun, der=der, hess=None)
+    for i in xrange(10):
+        b.bench_run(np.random.uniform(-2,2,1))
+    b.print_results()
+
+def test_LJ():
+    s = funcs.LJ()
+#    print "checking gradient", scipy.optimize.check_grad(s.get_energy, s.get_gradient, np.random.uniform(-2,2,3*4))
+    natoms = 4
+    b = BenchOptimizers("%d atom Lennard Jones potential" % (natoms),
+                        fun=s.get_energy, der=s.get_gradient, hess=None)
+    for i in xrange(10):
+        b.bench_run(np.random.uniform(-2,2,natoms*3))
+    b.print_results()
 
 
 def main():
-    b = BenchOptimizers()
-    b.bench_run()
-    b.print_results()
+    bench_rosenbrock()
+    bench_simple_quadratic()
+    bench_asymetric_quadratic()
+    bench_sin_1d()
+    test_LJ()
 
 if __name__ == "__main__":
     main()

--- a/scipy/optimize/benchmarks/test_functions.py
+++ b/scipy/optimize/benchmarks/test_functions.py
@@ -1,0 +1,70 @@
+import numpy as np
+
+class SimpleQuadratic(object):
+    def fun(self, x):
+        return np.dot(x, x)
+    
+    def der(self, x):
+        return 2. * x
+
+    def hess(self, x):
+        return 2. * np.eye(x.size)
+
+class AsymmetricQuadratic(object):
+    def fun(self, x):
+        return np.dot(x, x) + x[0]
+    
+    def der(self, x):
+        d = 2. * x
+        d[0] += 1
+        return d
+
+    def hess(self, x):
+        return 2. * np.eye(x.size)
+
+class LJ(object):
+    """
+    Lennard-Jones pairwise potential energy
+    """
+    def __init__(self, eps=1.0, sig=1.0):
+        """ simple lennard jones potential"""
+        self.sig = sig
+        self.eps = eps
+
+    def vij(self, r):
+        return 4.*self.eps * ( (self.sig/r)**12 - (self.sig/r)**6 )
+
+    def dvij(self, r):
+        return 4.*self.eps * ( -12./self.sig*(self.sig/r)**13 + 6./self.sig*(self.sig/r)**7 )
+
+    def get_energy(self, coords):
+        coords = np.reshape(coords, [-1,3])
+        natoms = coords.shape[0]
+        energy=0.
+        for i in xrange(natoms):
+            for j in xrange(i+1,natoms):
+                dr = coords[j,:]- coords[i,:]
+                r = np.linalg.norm(dr)
+                energy += self.vij(r)
+        return energy
+
+    def get_energy_gradient(self, coords):
+        coords = np.reshape(coords, [-1,3])
+        natoms = coords.shape[0]
+        energy=0.
+        V = np.zeros([natoms,3])
+        for i in xrange(natoms):
+            for j in xrange(i+1,natoms):
+                dr = coords[j,:]- coords[i,:]
+                r = np.linalg.norm(dr)
+                energy += self.vij(r)
+                g = self.dvij(r)
+                V[i,:] += -g * dr/r
+                V[j,:] += g * dr/r
+        V = V.reshape([natoms*3])
+        return energy,V
+
+    def get_gradient(self, coords):
+        e, g = self.get_energy_gradient(coords)
+        return g
+    

--- a/scipy/optimize/benchmarks/test_functions.py
+++ b/scipy/optimize/benchmarks/test_functions.py
@@ -67,4 +67,20 @@ class LJ(object):
     def get_gradient(self, coords):
         e, g = self.get_energy_gradient(coords)
         return g
-    
+
+class Booth(object):
+#    target_E = 0.
+#    target_coords = np.array([1., 3.])
+#    xmin = np.array([-10., -10.])
+##    xmin = np.array([0., 0.])
+#    xmax = np.array([10., 10.])
+    def fun(self, coords):
+        x, y = coords
+        return (x + 2.*y - 7.)**2 + (2.*x + y - 5.)**2
+
+    def der(self, coords):
+        x, y = coords
+        dx = 2.*(x + 2.*y - 7.) + 4.*(2.*x + y - 5.)
+        dy = 4.*(x + 2.*y - 7.) + 2.*(2.*x + y - 5.)
+        return np.array([dx, dy])
+

--- a/scipy/optimize/benchmarks/test_functions.py
+++ b/scipy/optimize/benchmarks/test_functions.py
@@ -84,3 +84,19 @@ class Booth(object):
         dy = 4.*(x + 2.*y - 7.) + 2.*(2.*x + y - 5.)
         return np.array([dx, dy])
 
+class Beale(object):
+#    target_E = 0.
+#    target_coords = np.array([3., 0.5])
+#    xmin = np.array([-4.5, -4.5])
+##    xmin = np.array([0., 0.])
+#    xmax = np.array([4.5, 4.5])
+    def fun(self, coords):
+        x, y = coords
+        return (1.5 - x + x*y)**2 + (2.25 - x + x * y**2)**2 + (2.625 - x + x * y**3)**2
+        
+    def der(self, coords):
+        x, y = coords
+        dx = 2. * (1.5 - x + x*y) * (-1. + y) + 2. * (2.25 - x + x * y**2) * (-1. + y**2) + 2. * (2.625 - x + x * y**3) * (-1. + y**3)
+        dy = 2. * (1.5 - x + x*y) * (x) +       2. * (2.25 - x + x * y**2) * (2. * y * x) + 2. * (2.625 - x + x * y**3) * (3. * x * y**2)
+        return np.array([dx, dy])
+


### PR DESCRIPTION
This pull request adds a framework for benchmarking the optimizers, along with 8 or so benchmarks on different functions.  I used the numpy.testing.Tester().bench() framework so it already works alongside the other scipy benchmarks.  

Currently all the test functions are smooth functions like Rosenbrock, Booth, Beale, and the Lennard-Jones potential.  It would be great to have some other types of functions, especially ones where the gradient is not available and constrained problems.  Towards this end I wrote it to be really easy to add new functions with just a few lines of code, e.g.

```
b = _BenchOptimizers("Rosenbrock function",
                     fun=rosen, der=rosen_der, hess=rosen_hess)
for i in xrange(10):
    b.bench_run(np.random.uniform(-3,3,3))
b.print_results()
```

An example output is

```
=========================================================
Optimizer benchmark: Rosenbrock function
dimensions: 3, extra kwargs: {'tol': 0.0001}
averaged over 10 starting configurations
  Optimizer    nfail   nfev    njev    nhev    time
---------------------------------------------------------
   L-BFGS-B  |    0  |   41  |    0  |    0  | 0.00386183
      SLSQP  |    0  |   54  |   37  |    0  | 0.00547173
       BFGS  |    0  |   58  |   58  |    0  | 0.00888143
  trust-ncg  |    0  |   45  |   41  |   40  | 0.0109362
  Newton-CG  |    0  |   66  |  118  |   52  | 0.0186812
     Powell  |    0  |  981  |    0  |    0  | 0.0508468
         CG  |    1  |  103  |  102  |    0  | 0.0107903
     dogleg  |    2  |   19  |   17  |   16  | 0.00508533
        TNC  |    5  |   86  |    0  |    0  | 0.00598359
     COBYLA  |    8  |  831  |    0  |    0  | 0.0220224
```

Is this something scipy would be interested in?
