### PR TITLE
BUG: fftconvolve should raise error for invalid mode instead of doing nothing

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -110,8 +110,13 @@ def correlate(in1, in2, mode='full'):
     in1 = asarray(in1)
     in2 = asarray(in2)
 
-    val = _valfrommode(mode)
-
+    # Don't use _valfrommode, since correlate should not accept numeric modes
+    try:
+        val = _modedict[mode]
+    except KeyError:
+        raise ValueError("Acceptable mode flags are 'valid',"
+                         " 'same', or 'full'.")
+    
     if rank(in1) == rank(in2) == 0:
         return in1 * in2
     elif not in1.ndim == in2.ndim:

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -223,6 +223,9 @@ def fftconvolve(in1, in2, mode="full"):
         return _centered(ret, s1)
     elif mode == "valid":
         return _centered(ret, s1 - s2 + 1)
+    else:
+        raise ValueError("Acceptable mode flags are 'valid',"
+                         " 'same', or 'full'.")
 
 
 def convolve(in1, in2, mode='full'):


### PR DESCRIPTION
BUG: fftconvolve should raise error for invalid mode instead of doing nothing

BUG: correlate's _valfrommode accepts a numerical mode without raising an error, but then correlate doesn't handle it correctly (though convolve2d and correlate2d do). I'm guessing this is for backwards compatibility?
