### PR TITLE
MAINT: require Cython 0.19

### DIFF
--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -54,8 +54,8 @@ def process_pyx(fromfile, tofile):
     try:
         from Cython.Compiler.Version import version as cython_version
         from distutils.version import LooseVersion
-        if LooseVersion(cython_version) < LooseVersion('0.17'):
-            raise Exception('Building SciPy requires Cython >= 0.17')
+        if LooseVersion(cython_version) < LooseVersion('0.19'):
+            raise Exception('Building SciPy requires Cython >= 0.19')
 
     except ImportError:
         pass


### PR DESCRIPTION
Earlier versions have memory leaks in fused types (see gh-2388).
