### PR TITLE
Add `perm` function and support for combinations with repetition (#3094)

### DIFF
--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -2,7 +2,6 @@ from __future__ import division, print_function, absolute_import
 
 import math
 import numpy as np
-from scipy.misc import comb
 from scipy.lib.six import xrange
 from scipy.lib.six import string_types
 
@@ -702,6 +701,7 @@ def invhilbert(n, exact=False):
     42475099528537378560L
 
     """
+    from scipy.special import comb
     if exact:
         if n > 14:
             dtype = object
@@ -743,7 +743,7 @@ def pascal(n, kind='symmetric', exact=True):
         If `exact` is True, the result is either an array of type
         numpy.uint64 (if n <= 35) or an object array of Python long integers.
         If `exact` is False, the coefficients in the matrix are computed using
-        `scipy.misc.comb` with `exact=False`.  The result will be a floating
+        `scipy.special.comb` with `exact=False`.  The result will be a floating
         point array, and the values in the array will not be the exact
         coefficients, but this version is much faster than `exact=True`.
 
@@ -772,12 +772,13 @@ def pascal(n, kind='symmetric', exact=True):
            [1, 3, 3, 1]], dtype=uint64)
     >>> pascal(50)[-1, -1]
     25477612258980856902730428600L
-    >>> from scipy.misc import comb
+    >>> from scipy.special import comb
     >>> comb(98, 49, exact=True)
     25477612258980856902730428600L
 
     """
 
+    from scipy.special import comb
     if kind not in ['symmetric', 'lower', 'upper']:
         raise ValueError("kind must be 'symmetric', 'lower', or 'upper'")
 

--- a/scipy/misc/__init__.py
+++ b/scipy/misc/__init__.py
@@ -32,7 +32,6 @@ systems that don't have PIL installed.
    lena - Get classic image processing example image Lena
    logsumexp - Compute the log of the sum of exponentials of input elements
    pade - Pade approximation to function as the ratio of two polynomials
-   perm - Permutations of N things taken k at a time, "k-permutations of N" (imported from scipy.special)
    toimage - Takes a numpy array and returns a PIL image
    who - Print the Numpy arrays in the given dictionary
 
@@ -45,7 +44,7 @@ __all__ = ['who', 'source', 'info', 'doccer']
 from . import doccer
 from .common import *
 from numpy import who, source, info as _info
-from scipy.special import perm, comb
+from scipy.special import comb
 
 import sys
 

--- a/scipy/misc/__init__.py
+++ b/scipy/misc/__init__.py
@@ -16,7 +16,7 @@ systems that don't have PIL installed.
 
    bytescale - Byte scales an array (image)
    central_diff_weights - Weights for an n-point central m-th derivative
-   comb - Combinations of N things taken k at a time, "N choose k"
+   comb - Combinations of N things taken k at a time, "N choose k" (imported from scipy.special)
    derivative - Find the n-th derivative of a function at a point
    factorial  - The factorial function, n! = special.gamma(n+1)
    factorial2 - Double factorial, (n!)!
@@ -32,7 +32,7 @@ systems that don't have PIL installed.
    lena - Get classic image processing example image Lena
    logsumexp - Compute the log of the sum of exponentials of input elements
    pade - Pade approximation to function as the ratio of two polynomials
-   perm - Permutations of N things taken k at a time, "k-permutations of N"
+   perm - Permutations of N things taken k at a time, "k-permutations of N" (imported from scipy.special)
    toimage - Takes a numpy array and returns a PIL image
    who - Print the Numpy arrays in the given dictionary
 
@@ -45,6 +45,7 @@ __all__ = ['who', 'source', 'info', 'doccer']
 from . import doccer
 from .common import *
 from numpy import who, source, info as _info
+from scipy.special import perm, comb
 
 import sys
 

--- a/scipy/misc/__init__.py
+++ b/scipy/misc/__init__.py
@@ -17,7 +17,6 @@ systems that don't have PIL installed.
    bytescale - Byte scales an array (image)
    central_diff_weights - Weights for an n-point central m-th derivative
    comb - Combinations of N things taken k at a time, "N choose k"
-   perm - Permutations of N things taken k at a time, "k-permutations of N"
    derivative - Find the n-th derivative of a function at a point
    factorial  - The factorial function, n! = special.gamma(n+1)
    factorial2 - Double factorial, (n!)!
@@ -33,6 +32,7 @@ systems that don't have PIL installed.
    lena - Get classic image processing example image Lena
    logsumexp - Compute the log of the sum of exponentials of input elements
    pade - Pade approximation to function as the ratio of two polynomials
+   perm - Permutations of N things taken k at a time, "k-permutations of N"
    toimage - Takes a numpy array and returns a PIL image
    who - Print the Numpy arrays in the given dictionary
 

--- a/scipy/misc/__init__.py
+++ b/scipy/misc/__init__.py
@@ -17,6 +17,7 @@ systems that don't have PIL installed.
    bytescale - Byte scales an array (image)
    central_diff_weights - Weights for an n-point central m-th derivative
    comb - Combinations of N things taken k at a time, "N choose k"
+   perm - Permutations of N things taken k at a time, "k-permutations of N"
    derivative - Find the n-th derivative of a function at a point
    factorial  - The factorial function, n! = special.gamma(n+1)
    factorial2 - Double factorial, (n!)!

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -9,7 +9,7 @@ from scipy.lib.six import xrange
 
 from numpy import exp, log, asarray, arange, newaxis, hstack, product, array, \
                   where, zeros, extract, place, pi, sqrt, eye, poly1d, dot, \
-                  r_, rollaxis, sum, fromstring
+                  r_, rollaxis, sum, fromstring, ndarray
 
 __all__ = ['logsumexp', 'factorial','factorial2','factorialk','comb', 'perm',
            'central_diff_weights', 'derivative', 'pade', 'lena', 'ascent', 'face']
@@ -299,7 +299,8 @@ def comb(N,k,exact=False,repetition=False):
         lgam = special.gammaln
         cond = (k <= N) & (N >= 0) & (k >= 0)
         vals = exp(lgam(N+1) - lgam(N-k+1) - lgam(k+1))
-        vals[~cond] = 0
+        if isinstance(vals, ndarray):
+            vals[~cond] = 0
         return vals
 
 
@@ -351,7 +352,8 @@ def perm(N, k, exact=False):
         k, N = asarray(k), asarray(N)
         cond = (k <= N) & (N >= 0) & (k >= 0)
         vals = special.poch(N - k + 1, k)
-        vals[~cond] = 0
+        if isinstance(vals, ndarray):
+            vals[~cond] = 0
         return vals
 
 

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -90,14 +90,14 @@ def logsumexp(a, axis=None, b=None):
     return out
 
 
-def factorial(n,exact=0):
+def factorial(n,exact=False):
     """
     The factorial function, n! = special.gamma(n+1).
 
     If exact is 0, then floating point precision is used, otherwise
     exact long integer is computed.
 
-    - Array argument accepted only for exact=0 case.
+    - Array argument accepted only for exact=False case.
     - If n<0, the return value is 0.
 
     Parameters
@@ -198,7 +198,7 @@ def factorial2(n, exact=False):
         return vals
 
 
-def factorialk(n,k,exact=1):
+def factorialk(n,k,exact=True):
     """
     n(!!...!)  = multifactorial of order k
     k times
@@ -243,7 +243,7 @@ def factorialk(n,k,exact=1):
         raise NotImplementedError
 
 
-def comb(N,k,exact=0):
+def comb(N,k,exact=False):
     """
     The number of combinations of N things taken k at a time.
 
@@ -255,8 +255,8 @@ def comb(N,k,exact=0):
         Number of things.
     k : int, ndarray
         Number of elements taken.
-    exact : int, optional
-        If `exact` is 0, then floating point precision is used, otherwise
+    exact : bool, optional
+        If `exact` is False, then floating point precision is used, otherwise
         exact long integer is computed.
 
     Returns
@@ -266,7 +266,7 @@ def comb(N,k,exact=0):
 
     Notes
     -----
-    - Array arguments accepted only for exact=0 case.
+    - Array arguments accepted only for exact=False case.
     - If k > N, N < 0, or k < 0, then a 0 is returned.
 
     Examples

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -298,10 +298,9 @@ def comb(N,k,exact=False,repetition=False):
         k,N = asarray(k), asarray(N)
         lgam = special.gammaln
         cond = (k <= N) & (N >= 0) & (k >= 0)
-        sv = special.errprint(0)
         vals = exp(lgam(N+1) - lgam(N-k+1) - lgam(k+1))
-        sv = special.errprint(sv)
-        return where(cond, vals, 0.0)
+        vals[~cond] = 0
+        return vals
 
 
 def perm(N, k, exact=False):
@@ -351,10 +350,9 @@ def perm(N, k, exact=False):
         from scipy import special
         k, N = asarray(k), asarray(N)
         cond = (k <= N) & (N >= 0) & (k >= 0)
-        sv = special.errprint(0)
         vals = special.poch(N - k + 1, k)
-        sv = special.errprint(sv)
-        return where(cond, vals, 0.0)
+        vals[~cond] = 0
+        return vals
 
 
 def central_diff_weights(Np, ndiv=1):

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -11,7 +11,7 @@ from numpy import exp, log, asarray, arange, newaxis, hstack, product, array, \
                   where, zeros, extract, place, pi, sqrt, eye, poly1d, dot, \
                   r_, rollaxis, sum, fromstring, ndarray
 
-__all__ = ['logsumexp', 'factorial','factorial2','factorialk','comb', 'perm',
+__all__ = ['logsumexp', 'factorial','factorial2','factorialk',
            'central_diff_weights', 'derivative', 'pade', 'lena', 'ascent', 'face']
 
 # XXX: the factorial functions could move to scipy.special, and the others
@@ -241,120 +241,6 @@ def factorialk(n,k,exact=True):
         return val
     else:
         raise NotImplementedError
-
-
-def comb(N,k,exact=False,repetition=False):
-    """
-    The number of combinations of N things taken k at a time.
-
-    This is often expressed as "N choose k".
-
-    Parameters
-    ----------
-    N : int, ndarray
-        Number of things.
-    k : int, ndarray
-        Number of elements taken.
-    exact : bool, optional
-        If `exact` is False, then floating point precision is used, otherwise
-        exact long integer is computed.
-    repetition : bool, optional
-        If `repetition` is True, then the number of combinations with
-        repetition is computed.
-
-    Returns
-    -------
-    val : int, ndarray
-        The total number of combinations.
-
-    Notes
-    -----
-    - Array arguments accepted only for exact=False case.
-    - If k > N, N < 0, or k < 0, then a 0 is returned.
-
-    Examples
-    --------
-    >>> k = np.array([3, 4])
-    >>> n = np.array([10, 10])
-    >>> sc.comb(n, k, exact=False)
-    array([ 120.,  210.])
-    >>> sc.comb(10, 3, exact=True)
-    120L
-    >>> sc.comb(10, 3, exact=True, repetition=True)
-    220L
-
-    """
-    if repetition:
-        return comb(N + k - 1, k, exact)
-    if exact:
-        if (k > N) or (N < 0) or (k < 0):
-            return 0
-        val = 1
-        for j in xrange(min(k, N-k)):
-            val = (val*(N-j))//(j+1)
-        return val
-    else:
-        from scipy import special
-        k,N = asarray(k), asarray(N)
-        lgam = special.gammaln
-        cond = (k <= N) & (N >= 0) & (k >= 0)
-        vals = exp(lgam(N+1) - lgam(N-k+1) - lgam(k+1))
-        if isinstance(vals, ndarray):
-            vals[~cond] = 0
-        return vals
-
-
-def perm(N, k, exact=False):
-    """
-    Permutations of N things taken k at a time, i.e., k-permutations of N.
-
-    It's also known as "partial permutations".
-
-    Parameters
-    ----------
-    N : int, ndarray
-        Number of things.
-    k : int, ndarray
-        Number of elements taken.
-    exact : bool, optional
-        If `exact` is False, then floating point precision is used, otherwise
-        exact long integer is computed.
-
-    Returns
-    -------
-    val : int, ndarray
-        The number of k-permutations of N.
-
-    Notes
-    -----
-    - Array arguments accepted only for exact=False case.
-    - If k > N, N < 0, or k < 0, then a 0 is returned.
-
-    Examples
-    --------
-    >>> k = np.array([3, 4])
-    >>> n = np.array([10, 10])
-    >>> perm(n, k)
-    array([  720.,  5040.])
-    >>> perm(10, 3, exact=True)
-    720
-
-    """
-    if exact:
-        if (k > N) or (N < 0) or (k < 0):
-            return 0
-        val = 1
-        for i in xrange(N - k + 1, N + 1):
-            val *= i
-        return val
-    else:
-        from scipy import special
-        k, N = asarray(k), asarray(N)
-        cond = (k <= N) & (N >= 0) & (k >= 0)
-        vals = special.poch(N - k + 1, k)
-        if isinstance(vals, ndarray):
-            vals[~cond] = 0
-        return vals
 
 
 def central_diff_weights(Np, ndiv=1):

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -243,7 +243,7 @@ def factorialk(n,k,exact=True):
         raise NotImplementedError
 
 
-def comb(N,k,exact=False):
+def comb(N,k,exact=False,repetition=False):
     """
     The number of combinations of N things taken k at a time.
 
@@ -258,6 +258,9 @@ def comb(N,k,exact=False):
     exact : bool, optional
         If `exact` is False, then floating point precision is used, otherwise
         exact long integer is computed.
+    repetition : bool, optional
+        If `repetition` is True, then the number of combinations with
+        repetition is computed.
 
     Returns
     -------
@@ -277,8 +280,12 @@ def comb(N,k,exact=False):
     array([ 120.,  210.])
     >>> sc.comb(10, 3, exact=True)
     120L
+    >>> sc.comb(10, 3, exact=True, repetition=True)
+    220L
 
     """
+    if repetition:
+        return comb(N + k - 1, k, exact)
     if exact:
         if (k > N) or (N < 0) or (k < 0):
             return 0

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -11,7 +11,7 @@ from numpy import exp, log, asarray, arange, newaxis, hstack, product, array, \
                   where, zeros, extract, place, pi, sqrt, eye, poly1d, dot, \
                   r_, rollaxis, sum, fromstring
 
-__all__ = ['logsumexp', 'factorial','factorial2','factorialk','comb',
+__all__ = ['logsumexp', 'factorial','factorial2','factorialk','comb', 'perm',
            'central_diff_weights', 'derivative', 'pade', 'lena', 'ascent', 'face']
 
 # XXX: the factorial functions could move to scipy.special, and the others
@@ -300,6 +300,59 @@ def comb(N,k,exact=False,repetition=False):
         cond = (k <= N) & (N >= 0) & (k >= 0)
         sv = special.errprint(0)
         vals = exp(lgam(N+1) - lgam(N-k+1) - lgam(k+1))
+        sv = special.errprint(sv)
+        return where(cond, vals, 0.0)
+
+
+def perm(N, k, exact=False):
+    """
+    Permutations of N things taken k at a time, i.e., k-permutations of N.
+
+    It's also known as "partial permutations".
+
+    Parameters
+    ----------
+    N : int, ndarray
+        Number of things.
+    k : int, ndarray
+        Number of elements taken.
+    exact : bool, optional
+        If `exact` is False, then floating point precision is used, otherwise
+        exact long integer is computed.
+
+    Returns
+    -------
+    val : int, ndarray
+        The number of k-permutations of N.
+
+    Notes
+    -----
+    - Array arguments accepted only for exact=False case.
+    - If k > N, N < 0, or k < 0, then a 0 is returned.
+
+    Examples
+    --------
+    >>> k = np.array([3, 4])
+    >>> n = np.array([10, 10])
+    >>> perm(n, k)
+    array([  720.,  5040.])
+    >>> perm(10, 3, exact=True)
+    720
+
+    """
+    if exact:
+        if (k > N) or (N < 0) or (k < 0):
+            return 0
+        val = 1
+        for i in xrange(N - k + 1, N + 1):
+            val *= i
+        return val
+    else:
+        from scipy import special
+        k, N = asarray(k), asarray(N)
+        cond = (k <= N) & (N >= 0) & (k >= 0)
+        sv = special.errprint(0)
+        vals = special.poch(N - k + 1, k)
         sv = special.errprint(sv)
         return where(cond, vals, 0.0)
 

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_almost_equal, \
                           assert_array_almost_equal, assert_equal
 
-from scipy.misc import pade, logsumexp, face, ascent
+from scipy.misc import pade, logsumexp, face, ascent, comb
 
 
 def test_pade_trivial():
@@ -92,3 +92,9 @@ def test_face():
 
 def test_ascent():
     assert_equal(ascent().shape, (512, 512))
+
+
+def test_comb():
+    assert_array_almost_equal(comb([10, 10], [3, 4]), [120., 210.])
+    assert_equal(comb(10, 3, exact=True), 120)
+    assert_equal(comb(10, 3, exact=True, repetition=True), 220)

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -98,3 +98,8 @@ def test_comb():
     assert_array_almost_equal(comb([10, 10], [3, 4]), [120., 210.])
     assert_equal(comb(10, 3, exact=True), 120)
     assert_equal(comb(10, 3, exact=True, repetition=True), 220)
+
+
+def test_perm():
+    assert_array_almost_equal(perm([10, 10], [3, 4]), [720., 5040.])
+    assert_equal(perm(10, 3, exact=True), 720)

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -96,10 +96,12 @@ def test_ascent():
 
 def test_comb():
     assert_array_almost_equal(comb([10, 10], [3, 4]), [120., 210.])
+    assert_almost_equal(comb(10, 3), 120.)
     assert_equal(comb(10, 3, exact=True), 120)
     assert_equal(comb(10, 3, exact=True, repetition=True), 220)
 
 
 def test_perm():
     assert_array_almost_equal(perm([10, 10], [3, 4]), [720., 5040.])
+    assert_almost_equal(perm(10, 3), 720.)
     assert_equal(perm(10, 3, exact=True), 720)

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_almost_equal, \
                           assert_array_almost_equal, assert_equal
 
-from scipy.misc import pade, logsumexp, face, ascent, comb
+from scipy.misc import pade, logsumexp, face, ascent, comb, perm
 
 
 def test_pade_trivial():

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_almost_equal, \
                           assert_array_almost_equal, assert_equal
 
-from scipy.misc import pade, logsumexp, face, ascent, comb, perm
+from scipy.misc import pade, logsumexp, face, ascent
 
 
 def test_pade_trivial():
@@ -92,16 +92,3 @@ def test_face():
 
 def test_ascent():
     assert_equal(ascent().shape, (512, 512))
-
-
-def test_comb():
-    assert_array_almost_equal(comb([10, 10], [3, 4]), [120., 210.])
-    assert_almost_equal(comb(10, 3), 120.)
-    assert_equal(comb(10, 3, exact=True), 120)
-    assert_equal(comb(10, 3, exact=True, repetition=True), 220)
-
-
-def test_perm():
-    assert_array_almost_equal(perm([10, 10], [3, 4]), [720., 5040.])
-    assert_almost_equal(perm(10, 3), 720.)
-    assert_equal(perm(10, 3, exact=True), 720)

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -483,6 +483,15 @@ These are not universal functions:
    kerp_zeros   -- [+]Zeros of derivative of Kelvin function ker x
    keip_zeros   -- [+]Zeros of derivative of Kelvin function kei x
 
+Combinatorics
+-------------
+
+.. autosummary::
+    :toctree: generated/
+
+    comb    -- [+]Combinations of N things taken k at a time, "N choose k"
+    perm    -- [+]Permutations of N things taken k at a time, "k-permutations of N"
+
 Other Special Functions
 -----------------------
 

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -19,7 +19,7 @@ import warnings
 
 __all__ = ['agm', 'ai_zeros', 'assoc_laguerre', 'bei_zeros', 'beip_zeros',
            'ber_zeros', 'bernoulli', 'berp_zeros', 'bessel_diff_formula',
-           'bi_zeros', 'comb', 'clpmn', 'digamma', 'diric', 'ellipk', 'erf_zeros',
+           'bi_zeros', 'clpmn', 'comb', 'digamma', 'diric', 'ellipk', 'erf_zeros',
            'erfcinv', 'erfinv', 'errprint', 'euler', 'fresnel_zeros',
            'fresnelc_zeros', 'fresnels_zeros', 'gamma', 'gammaln', 'h1vp',
            'h2vp', 'hankel1', 'hankel2', 'hyp0f1', 'iv', 'ivp', 'jn_zeros',

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -10,7 +10,7 @@ from numpy import pi, asarray, floor, isscalar, iscomplex, real, imag, sqrt, \
         where, mgrid, cos, sin, exp, place, seterr, issubdtype, extract, \
         less, vectorize, inexact, nan, zeros, sometrue, atleast_1d
 from ._ufuncs import ellipkm1, mathieu_a, mathieu_b, iv, jv, gamma, psi, zeta, \
-        hankel1, hankel2, yv, kv, gammaln, ndtri, errprint, poch
+        hankel1, hankel2, yv, kv, gammaln, ndtri, errprint, poch, binom
 from . import _ufuncs
 import types
 from . import specfun
@@ -1199,9 +1199,8 @@ def comb(N,k,exact=False,repetition=False):
         return val
     else:
         k,N = asarray(k), asarray(N)
-        lgam = gammaln
         cond = (k <= N) & (N >= 0) & (k >= 0)
-        vals = exp(lgam(N+1) - lgam(N-k+1) - lgam(k+1))
+        vals = binom(N, k)
         if isinstance(vals, np.ndarray):
             vals[~cond] = 0
         return vals

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1061,6 +1061,19 @@ class TestBeta(TestCase):
         assert_almost_equal(comp,.5,5)
 
 
+class TestCombinatorics(TestCase):
+    def test_comb(self):
+        assert_array_almost_equal(special.comb([10, 10], [3, 4]), [120., 210.])
+        assert_almost_equal(special.comb(10, 3), 120.)
+        assert_equal(special.comb(10, 3, exact=True), 120)
+        assert_equal(special.comb(10, 3, exact=True, repetition=True), 220)
+
+    def test_perm(self):
+        assert_array_almost_equal(special.perm([10, 10], [3, 4]), [720., 5040.])
+        assert_almost_equal(special.perm(10, 3), 720.)
+        assert_equal(special.perm(10, 3, exact=True), 720)
+
+
 class TestTrigonometric(TestCase):
     def test_cbrt(self):
         cb = special.cbrt(27)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1068,10 +1068,24 @@ class TestCombinatorics(TestCase):
         assert_equal(special.comb(10, 3, exact=True), 120)
         assert_equal(special.comb(10, 3, exact=True, repetition=True), 220)
 
+    def test_comb_zeros(self):
+        assert_equal(special.comb(2, 3, exact=True), 0)
+        assert_equal(special.comb(-1, 3, exact=True), 0)
+        assert_equal(special.comb(2, -1, exact=True), 0)
+        assert_array_almost_equal(special.comb([2, -1, 2, 10], [3, 3, -1, 3]),
+                [0., 0., 0., 120.])
+
     def test_perm(self):
         assert_array_almost_equal(special.perm([10, 10], [3, 4]), [720., 5040.])
         assert_almost_equal(special.perm(10, 3), 720.)
         assert_equal(special.perm(10, 3, exact=True), 720)
+
+    def test_perm_zeros(self):
+        assert_equal(special.perm(2, 3, exact=True), 0)
+        assert_equal(special.perm(-1, 3, exact=True), 0)
+        assert_equal(special.perm(2, -1, exact=True), 0)
+        assert_array_almost_equal(special.perm([2, -1, 2, 10], [3, 3, -1, 3]),
+                [0., 0., 0., 720.])
 
 
 class TestTrigonometric(TestCase):


### PR DESCRIPTION
As discussed in #3094, this PR add a `perm` function, which computes the number of k-combinations of n, into `scipy.misc`.
It also adds the support for combinations with repetition to `comb` function.
As for moving them into `scipy.special`, I noticed that `scipy.special` imports packages that depend on `comb` in turn, and such a movement will result in some `ImportError` . I haven't found a proper way to fix it so I just leave them in `scipy.misc`.
Some docstrings about the `exact` parameters are fixed in this PR as well.
