### PR TITLE
Specifying absolute errors in curve_fit

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -448,7 +448,7 @@ def _weighted_general_function(params, xdata, ydata, function, weights):
     return weights * (function(xdata, *params) - ydata)
 
 
-def curve_fit(f, xdata, ydata, p0=None, sigma=None, **kw):
+def curve_fit(f, xdata, ydata, p0=None, sigma=None, scale_pcov=True, **kw):
     """
     Use non-linear least squares to fit a function, f, to data.
 
@@ -471,8 +471,20 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, **kw):
         can be determined using introspection, otherwise a ValueError
         is raised).
     sigma : None or N-length sequence
-        If not None, this vector will be used as relative weights in the
-        least-squares problem.
+        If not None, this vector will be used as relative weights
+        (if ``scale_pcov=True``) or standard deviation errors on ``ydata``
+        (if ``scale_pcov=False``) in the least-squares problem.
+    scale_pcov : bool
+        Multiply output covariance matrix ``pcov`` by ``sum(chi ** 2) / dof``,
+        where ``chi = (f(xdata, *popt) - ydata) / sigma`` and
+        ``dof = len(xdata) - len(popt)``.
+        Use ``scale_pcov=True`` if the ``sigma`` represent relative
+        weights and you would like to estimate the parameter uncertainty
+        based on the actual data. In this case multiplying the ``sigma`` array
+        by any number will not change the output ``pcov``.
+        Use ``scale_pcov=False`` if the ``sigma`` represent one standard
+        deviation errors on ``ydata``. In this case multiplying the ``sigma`` array
+        by a factor ``k`` will change the output ``pcov`` by a factor ``k ** 2``.
 
     Returns
     -------
@@ -480,8 +492,9 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, **kw):
         Optimal values for the parameters so that the sum of the squared error
         of ``f(xdata, *popt) - ydata`` is minimized
     pcov : 2d array
-        The estimated covariance of popt.  The diagonals provide the variance
-        of the parameter estimate.
+        The estimated covariance of popt. The diagonals provide the variance
+        of the parameter estimate. To compute one standard deviation errors
+        on the parameters use ``perr = np.sqrt(np.diag(pcov))``. 
 
     See Also
     --------
@@ -497,13 +510,13 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, **kw):
     >>> import numpy as np
     >>> from scipy.optimize import curve_fit
     >>> def func(x, a, b, c):
-    ...     return a*np.exp(-b*x) + c
+    ...     return a * np.exp(-b * x) + c
 
-    >>> x = np.linspace(0,4,50)
-    >>> y = func(x, 2.5, 1.3, 0.5)
-    >>> yn = y + 0.2*np.random.normal(size=len(x))
+    >>> xdata = np.linspace(0, 4, 50)
+    >>> y = func(xdata, 2.5, 1.3, 0.5)
+    >>> ydata = y + 0.2 * np.random.normal(size=len(xdata))
 
-    >>> popt, pcov = curve_fit(func, x, yn)
+    >>> popt, pcov = curve_fit(func, xdata, ydata)
 
     """
     if p0 is None:
@@ -537,11 +550,12 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, **kw):
         msg = "Optimal parameters not found: " + errmsg
         raise RuntimeError(msg)
 
-    if (len(ydata) > len(p0)) and pcov is not None:
-        s_sq = (func(popt, *args)**2).sum()/(len(ydata)-len(p0))
-        pcov = pcov * s_sq
-    else:
-        pcov = inf
+    if scale_pcov:
+        if (len(ydata) > len(p0)) and pcov is not None:
+            s_sq = (func(popt, *args)**2).sum()/(len(ydata)-len(p0))
+            pcov = pcov * s_sq
+        else:
+            pcov = inf
 
     if return_full:
         return popt, pcov, infodict, errmsg, ier

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -551,12 +551,16 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False, **kw):
         msg = "Optimal parameters not found: " + errmsg
         raise RuntimeError(msg)
 
-    if not absolute_sigma:
-        if len(ydata) > len(p0) and pcov is not None:
+    if pcov is None:
+        # indeterminate covariance
+        pcov = zeros((len(popt), len(popt)), dtype=float)
+        pcov.fill(inf)
+    elif not absolute_sigma:
+        if len(ydata) > len(p0):
             s_sq = (asarray(func(popt, *args))**2).sum() / (len(ydata) - len(p0))
             pcov = pcov * s_sq
         else:
-            pcov = inf
+            pcov.fill(inf)
 
     if return_full:
         return popt, pcov, infodict, errmsg, ier

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -362,6 +362,19 @@ class TestCurveFit(TestCase):
         perr = np.sqrt(np.diag(pcov))
         assert_allclose(perr, [3*0.30714756, 3*0.85045308], rtol=1e-3)
 
+        # infinite variances
+
+        def f_flat(x, a, b):
+            return a*x
+
+        popt, pcov = curve_fit(f_flat, xdata, ydata, p0=[2, 0], sigma=sigma)
+        assert_(pcov.shape == (2, 2))
+        assert_array_equal(pcov, np.inf)
+
+        popt, pcov = curve_fit(f, xdata[:2], ydata[:2], p0=[2, 0])
+        assert_(pcov.shape == (2, 2))
+        assert_array_equal(pcov, np.inf)
+
 
 class TestFixedPoint(TestCase):
 

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -336,6 +336,32 @@ class TestCurveFit(TestCase):
         popt, pcov = curve_fit(f_double_gauss, x, y, guess, maxfev=10000)
         assert_allclose(popt, good, rtol=1e-5)
 
+    def test_pcov(self):
+        xdata = np.array([0, 1, 2, 3, 4, 5])
+        ydata = np.array([1, 1, 5, 7, 8, 12])
+        sigma = np.array([1, 2, 1, 2, 1, 2])
+
+        def f(x, a, b):
+            return a*x + b
+
+        popt, pcov = curve_fit(f, xdata, ydata, p0=[2, 0], sigma=sigma)
+        perr_scaled = np.sqrt(np.diag(pcov))
+        assert_allclose(perr_scaled, [ 0.20659803, 0.57204404], rtol=1e-3)
+
+        popt, pcov = curve_fit(f, xdata, ydata, p0=[2, 0], sigma=3*sigma)
+        perr_scaled = np.sqrt(np.diag(pcov))
+        assert_allclose(perr_scaled, [ 0.20659803, 0.57204404], rtol=1e-3)
+
+        popt, pcov = curve_fit(f, xdata, ydata, p0=[2, 0], sigma=sigma,
+                               absolute_sigma=True)
+        perr = np.sqrt(np.diag(pcov))
+        assert_allclose(perr, [0.30714756, 0.85045308], rtol=1e-3)
+
+        popt, pcov = curve_fit(f, xdata, ydata, p0=[2, 0], sigma=3*sigma,
+                               absolute_sigma=True)
+        perr = np.sqrt(np.diag(pcov))
+        assert_allclose(perr, [3*0.30714756, 3*0.85045308], rtol=1e-3)
+
 
 class TestFixedPoint(TestCase):
 


### PR DESCRIPTION
Continued from gh-448

An option absolute_sigma is added to scipy.optimize.curve_fit, to accommodate the common cases:
- sigma = relative weights, pcov variance estimated from data
- sigma = one standard deviation errors on ydata, determines pcov variances

Also, make the returned `pcov` always be a 2D array. In indeterminate cases, it used to return a scalar, which may not be desirable.
