### PR TITLE
ENH: speed up the semicircular distribution's ppf

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -158,7 +158,7 @@ distmissing = ['wald', 'gausshyper', 'genexpon', 'rv_continuous',
 
 distmiss = [[dist,args] for dist,args in distcont if dist in distmissing]
 distslow = ['rdist', 'gausshyper', 'recipinvgauss', 'ksone', 'genexpon',
-            'vonmises', 'vonmises_line', 'mielke', 'semicircular',
+            'vonmises', 'vonmises_line', 'mielke',
             'cosine', 'invweibull', 'powerlognorm', 'johnsonsu', 'kstwobign']
 # distslow are sorted by speed (very slow to slow)
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -775,7 +775,7 @@ class TestSemicircular(TestCase):
         def ppf(q):
             return brentq(lambda x: stats.semicircular.cdf(x) - q, -1., 1.)
         assert_allclose(stats.semicircular.ppf(qq), [ppf(q) for q in qq],
-                atol=1e-5, rtol=1e-5)
+                atol=1e-7, rtol=1e-10)
 
 
 class TestArrayArgument(TestCase):  # test for ticket:992

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -19,6 +19,7 @@ from scipy import special
 import scipy.stats as stats
 from scipy.stats.distributions import argsreduce
 from scipy.special import xlogy
+from scipy.optimize import brentq
 
 
 # python -OO strips docstrings
@@ -765,6 +766,16 @@ class TestChi2(TestCase):
     def test_precision(self):
         assert_almost_equal(stats.chi2.pdf(1000, 1000), 8.919133934753128e-003, 14)
         assert_almost_equal(stats.chi2.pdf(100, 100), 0.028162503162596778, 14)
+
+
+class TestSemicircular(TestCase):
+    def test_ppf(self):
+        # test interpolated ppf
+        qq = np.linspace(1e-8, 1 - 1e-8, 50)
+        def ppf(q):
+            return brentq(lambda x: stats.semicircular.cdf(x) - q, -1., 1.)
+        assert_allclose(stats.semicircular.ppf(qq), [ppf(q) for q in qq],
+                atol=1e-5, rtol=1e-5)
 
 
 class TestArrayArgument(TestCase):  # test for ticket:992


### PR DESCRIPTION
Mostly an experiment to try using interpolation in place of a generic calculation.
Timings with master:

```
In [3]: q = np.linspace(0, 1, 100)

In [5]: %timeit stats.semicircular.ppf(q)
10 loops, best of 3: 75.6 ms per loop

In [6]: %timeit stats.semicircular.rvs(size=1000)
1 loops, best of 3: 815 ms per loop
```

with this PR:

```
In [35]: %timeit stats.semicircular.ppf(q)
1000 loops, best of 3: 230 µs per loop

In [36]: %timeit stats.semicircular.rvs(size=1000)
10000 loops, best of 3: 155 µs per loop

```
