### PR TITLE
ENH: interpolate: piecewise N-D tensor-product polynomials

### DIFF
--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -26,6 +26,7 @@ cdef extern:
                 double *vr, int *ldvr, double *work, int *lwork,
                 int *info)
 
+DEF MAX_DIMS = 64
 
 #------------------------------------------------------------------------------
 # Piecewise power basis polynomials
@@ -88,7 +89,7 @@ def evaluate(double_or_complex[:,:,::1] c,
         xval = xp[ip]
 
         # Find correct interval
-        i = find_interval(x, xval, interval, extrapolate)
+        i = find_interval(&x[0], x.shape[0], xval, interval, extrapolate)
         if i < 0:
             # xval was nan etc
             for jp in range(c.shape[2]):
@@ -100,6 +101,159 @@ def evaluate(double_or_complex[:,:,::1] c,
         # Evaluate the local polynomial(s)
         for jp in range(c.shape[2]):
             out[ip, jp] = evaluate_poly1(xval - x[interval], c, interval, jp, dx)
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+def evaluate_nd(double_or_complex[:,:,::1] c,
+                tuple xs,
+                int[:] ks,
+                double[:,:] xp,
+                int[:] dx,
+                int extrapolate,
+                double_or_complex[:,::1] out):
+    """
+    Evaluate a piecewise tensor-product polynomial.
+
+    Parameters
+    ----------
+    c : ndarray, shape (k_1*...*k_d, m_1*...*m_d, n)
+        Coefficients local polynomials of order `k-1` in
+        `m_1`, ..., `m_d` intervals. There are `n` polynomials
+        in each interval.
+    ks : ndarray of int, shape (d,)
+        Orders of polynomials in each dimension
+    xs : d-tuple of ndarray of shape (m_d+1,) each
+        Breakpoints of polynomials
+    xp : ndarray, shape (r, d)
+        Points to evaluate the piecewise polynomial at.
+    dx : ndarray of int, shape (d,)
+        Orders of derivative to evaluate.  The derivative is evaluated
+        piecewise and may have discontinuities.
+    extrapolate : int, optional
+        Whether to extrapolate to ouf-of-bounds points based on first
+        and last intervals, or to return NaNs.
+    out : ndarray, shape (r, n)
+        Value of each polynomial at each of the input points.
+        For points outside the span ``x[0] ... x[-1]``,
+        ``nan`` is returned.
+        This argument is modified in-place.
+
+    """
+    cdef size_t ntot
+    cdef ssize_t strides[MAX_DIMS]
+    cdef ssize_t kstrides[MAX_DIMS]
+    cdef double* xx[MAX_DIMS]
+    cdef size_t nxx[MAX_DIMS]
+    cdef double[::1] y
+    cdef double_or_complex[:,:,::1] c2
+    cdef int ip, jp, k, ndim
+    cdef int interval[MAX_DIMS], pos, kpos, koutpos
+    cdef int out_of_range
+    cdef double xval
+
+    ndim = len(xs)
+
+    if ndim > MAX_DIMS:
+        raise ValueError("Too many dimensions (maximum: %d)" % (MAX_DIMS,))
+
+    # shape checks
+    if dx.shape[0] != ndim:
+        raise ValueError("dx has incompatible shape")
+    if xp.shape[1] != ndim:
+        raise ValueError("xp has incompatible shape")
+    if out.shape[0] != xp.shape[0]:
+        raise ValueError("out and xp have incompatible shapes")
+    if out.shape[1] != c.shape[2]:
+        raise ValueError("out and c have incompatible shapes")
+
+    # compute interval strides
+    ntot = 1
+    for ip in xrange(ndim-1, -1, -1):
+        if dx[ip] < 0:
+            raise ValueError("Order of derivative cannot be negative")
+
+        y = xs[ip]
+        if y.shape[0] < 2:
+            raise ValueError("each dimension must have >= 2 points")
+
+        strides[ip] = ntot
+        ntot *= y.shape[0] - 1
+
+        # grab array pointers
+        nxx[ip] = y.shape[0]
+        xx[ip] = <double*>&y[0]
+        y = None
+
+    if c.shape[1] != ntot:
+        raise ValueError("xs and c have incompatible shapes")
+
+    # compute order strides
+    ntot = 1
+    for ip in xrange(ndim):
+        kstrides[ip] = ntot
+        ntot *= ks[ip]
+
+    if c.shape[0] != ntot:
+        raise ValueError("ks and c have incompatible shapes")
+
+    # temporary storage
+    if double_or_complex is double:
+        c2 = np.zeros((c.shape[0], 1, 1), dtype=float)
+    else:
+        c2 = np.zeros((c.shape[0], 1, 1), dtype=complex)
+
+    # evaluate
+    for ip in xrange(ndim):
+        interval[ip] = 0
+
+    for ip in range(xp.shape[0]):
+        out_of_range = 0
+
+        # Find correct intervals
+        for k in range(ndim):
+            xval = xp[ip, k]
+
+            i = find_interval(xx[k],
+                              nxx[k],
+                              xval,
+                              interval[k],
+                              extrapolate)
+            if i < 0:
+                out_of_range = 1
+                break
+            else:
+                interval[k] = i
+
+        if out_of_range:
+            # xval was nan etc
+            for jp in range(c.shape[2]):
+                out[ip, jp] = nan
+            continue
+
+        pos = 0
+        for k in range(ndim):
+            pos += interval[k] * strides[k]
+
+        # Evaluate the local polynomials, via nested 1D polynomial evaluation
+        #
+        # sum_{ijk} c[kx-i,ky-j,kz-k] x**i y**j z**k = sum_i a[i] x**i
+        # a[i] = sum_j b[i,j] y**j
+        # b[i,j] = sum_k c[kx-i,ky-j,kz-k] z**k
+        #
+        # The array c2 is used to hold the intermediate sums a,b,...
+        for jp in range(c.shape[2]):
+            c2[:,0,0] = c[:,pos,jp]
+
+            for k in range(ndim-1, -1, -1):
+                xval = xp[ip, k] - xx[k][interval[k]]
+                kpos = 0
+                for koutpos in range(kstrides[k]):
+                    c2[koutpos,0,0] = evaluate_poly1(xval, c2[kpos:kpos+ks[k],:,:], 0, 0, dx[k])
+                    kpos += ks[k]
+
+            out[ip,jp] = c2[0,0,0]
 
 
 @cython.wraparound(False)
@@ -211,12 +365,12 @@ def integrate(double_or_complex[:,:,::1] c,
         raise ValueError("Integral bounds not in order")
 
     # find intervals
-    start_interval = find_interval(x, a, 0, extrapolate)
+    start_interval = find_interval(&x[0], x.shape[0], a, 0, extrapolate)
     if start_interval < 0:
         out[:] = nan
         return
 
-    end_interval = find_interval(x, b, 0, extrapolate)
+    end_interval = find_interval(&x[0], x.shape[0], b, 0, extrapolate)
     if end_interval < 0:
         out[:] = nan
         return
@@ -380,7 +534,8 @@ def real_roots(double[:,:,::1] c, double[::1] x, int report_discont,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision(True)
-cdef int find_interval(double[::1] x,
+cdef int find_interval(double *x,
+                       size_t nx,
                        double xval,
                        int prev_interval=0,
                        int extrapolate=1) nogil:
@@ -411,10 +566,10 @@ cdef int find_interval(double[::1] x,
     cdef double a, b
 
     a = x[0]
-    b = x[x.shape[0]-1]
+    b = x[nx-1]
 
     interval = prev_interval
-    if interval < 0 or interval >= x.shape[0]:
+    if interval < 0 or interval >= nx:
         interval = 0
 
     if not (a <= xval <= b):
@@ -424,19 +579,19 @@ cdef int find_interval(double[::1] x,
             interval = 0
         elif xval > b and extrapolate:
             # above
-            interval = x.shape[0] - 2
+            interval = nx - 2
         else:
             # nan or no extrapolation
             interval = -1
     elif xval == b:
         # Make the interval closed from the right
-        interval = x.shape[0] - 2
+        interval = nx - 2
     else:
         # Find the interval the coordinate is in
         # (binary search with locality)
         if xval >= x[interval]:
             low = interval
-            high = x.shape[0]-2
+            high = nx - 2
         else:
             low = 0
             high = interval
@@ -831,7 +986,7 @@ def evaluate_bernstein(double_or_complex[:,:,::1] c,
         xval = xp[ip]
 
         # Find correct interval
-        i = find_interval(x, xval, interval, extrapolate)
+        i = find_interval(&x[0], x.shape[0], xval, interval, extrapolate)
         if i < 0:
             # xval was nan etc
             for jp in range(c.shape[2]):

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -797,7 +797,7 @@ class PPoly(_PPolyBase):
         # fix continuity of added degrees of freedom
         self._ensure_c_contiguous()
         _ppoly.fix_continuity(c.reshape(c.shape[0], c.shape[1], -1),
-                              self.x, nu)
+                              self.x, nu-1)
 
         # construct a compatible polynomial
         return self.construct_fast(c, self.x, self.extrapolate)

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -3,7 +3,7 @@
 from __future__ import division, print_function, absolute_import
 
 __all__ = ['interp1d', 'interp2d', 'spline', 'spleval', 'splmake', 'spltopp',
-           'ppform', 'lagrange', 'PPoly', 'BPoly']
+           'ppform', 'lagrange', 'PPoly', 'BPoly', 'NdPPoly']
 
 from numpy import shape, sometrue, array, transpose, searchsorted, \
                   ones, logical_or, atleast_1d, atleast_2d, ravel, \
@@ -23,6 +23,7 @@ from . import dfitpack
 from . import _fitpack
 from .polyint import _Interpolator1D
 from . import _ppoly
+from . import interpnd
 
 def reduce_sometrue(a):
     all = a
@@ -681,9 +682,7 @@ class PPoly(_PPolyBase):
     x : ndarray
         Breakpoints.
     c : ndarray
-        Coefficients of the polynomials. They are reshaped
-        to a 3-dimensional array with the last dimension representing
-        the trailing dimensions of the original coefficient array.
+        Coefficients of the polynomials.
 
     Methods
     -------
@@ -995,9 +994,7 @@ class BPoly(_PPolyBase):
     x : ndarray
         Breakpoints.
     c : ndarray
-        Coefficients of the polynomials. They are reshaped
-        to a 3-dimensional array with the last dimension representing
-        the trailing dimensions of the original coefficient array.
+        Coefficients of the polynomials.
 
     Methods
     -------
@@ -1372,6 +1369,187 @@ class BPoly(_PPolyBase):
             for j in range(d+1):
                 out[a+j] += f * comb(d, j) / comb(k+d, a+j)
         return out
+
+
+class NdPPoly(object):
+    """
+    Piecewise tensor product polynomial
+
+    The value at point `xp = (x', y', z', ...)` is evaluated by first
+    computing the interval indices `i` such that::
+
+        x[0][i[0]] <= x' < x[0][i[0]+1]
+        x[1][i[1]] <= y' < x[1][i[1]+1]
+        ...
+
+    and then computing::
+
+        S = sum(c[k0-m0-1,...,kn-mn-1,i[0],...,i[n]]
+                * (xp[0] - x[0][i[0]])**m0
+                * ...
+                * (xp[n] - x[n][i[n]])**mn
+                for m0 in range(k[0]+1)
+                ...
+                for mn in range(k[n]+1))
+
+    where ``k[j]`` is the degree of the polynomial in dimension j. This
+    representation is the piecewise multivariate power basis.
+
+    Parameters
+    ----------
+    c : ndarray, shape (k0, ..., kn, m0, ..., mn, ...)
+        Polynomial coefficients, with polynomial order `kj` and
+        `mj+1` intervals for each dimension `j`.
+    x : ndim-tuple of ndarrays, shapes (mj+1,)
+        Polynomial breakpoints for each dimension. These must be
+        sorted in increasing order.
+    extrapolate : bool, optional
+        Whether to extrapolate to ouf-of-bounds points based on first
+        and last intervals, or to return NaNs. Default: True.
+
+    Attributes
+    ----------
+    x : tuple of ndarrays
+        Breakpoints.
+    c : ndarray
+        Coefficients of the polynomials.
+
+    Methods
+    -------
+    __call__
+    construct_fast
+
+    See also
+    --------
+    PPoly : piecewise polynomials in 1D
+
+    Notes
+    -----
+    High-order polynomials in the power basis can be numerically
+    unstable.
+
+    """
+
+    def __init__(self, c, x, extrapolate=None):
+        self.x = tuple(np.ascontiguousarray(v, dtype=np.float64) for v in x)
+        self.c = np.asarray(c)
+        if extrapolate is None:
+            extrapolate = True
+        self.extrapolate = bool(extrapolate)
+
+        ndim = len(self.x)
+        if any(v.ndim != 1 for v in self.x):
+            raise ValueError("x arrays must all be 1-dimensional")
+        if any(v.size < 2 for v in self.x):
+            raise ValueError("x arrays must all contain at least 2 points")
+        if c.ndim < 2*ndim:
+            raise ValueError("c must have at least 2*len(x) dimensions")
+        if any(np.any(v[1:] - v[:-1] < 0) for v in self.x):
+            raise ValueError("x-coordinates are not in increasing order")
+        if any(a != b.size - 1 for a, b in zip(c.shape[ndim:2*ndim], self.x)):
+            raise ValueError("x and c do not agree on the number of intervals")
+
+        dtype = self._get_dtype(self.c.dtype)
+        self.c = np.ascontiguousarray(self.c, dtype=dtype)
+
+
+    @classmethod
+    def construct_fast(cls, c, x, extrapolate=None):
+        """
+        Construct the piecewise polynomial without making checks.
+
+        Takes the same parameters as the constructor. Input arguments
+        `c` and `x` must be arrays of the correct shape and type.  The
+        `c` array can only be of dtypes float and complex, and `x`
+        array must have dtype float.
+
+        """
+        self = object.__new__(cls)
+        self.c = c
+        self.x = x
+        if extrapolate is None:
+            extrapolate = True
+        self.extrapolate = extrapolate
+        return self
+
+
+    def _get_dtype(self, dtype):
+        if np.issubdtype(dtype, np.complexfloating) \
+               or np.issubdtype(self.c.dtype, np.complexfloating):
+            return np.complex_
+        else:
+            return np.float_
+
+
+    def _ensure_c_contiguous(self):
+        if not self.c.flags.c_contiguous:
+            self.c = self.c.copy()
+        if not isinstance(self.x, tuple):
+            self.x = tuple(self.x)
+
+
+    def __call__(self, x, nu=None, extrapolate=None):
+        """
+        Evaluate the piecewise polynomial or its derivative
+
+        Parameters
+        ----------
+        x : array-like
+            Points to evaluate the interpolant at.
+        nu : tuple, optional
+            Orders of derivatives to evaluate. Each must be non-negative.
+        extrapolate : bool, optional
+            Whether to extrapolate to ouf-of-bounds points based on first
+            and last intervals, or to return NaNs.
+
+        Returns
+        -------
+        y : array-like
+            Interpolated values. Shape is determined by replacing
+            the interpolation axis in the original array with the shape of x.
+
+        Notes
+        -----
+        Derivatives are evaluated piecewise for each polynomial
+        segment, even if the polynomial is not differentiable at the
+        breakpoints. The polynomial intervals are considered half-open,
+        ``[a, b)``, except for the last interval which is closed
+        ``[a, b]``.
+
+        """
+        if extrapolate is None:
+            extrapolate = self.extrapolate
+
+        ndim = len(self.x)
+
+        x = interpnd._ndim_coords_from_arrays(x)
+        x_shape = x.shape
+        x = np.ascontiguousarray(x.reshape(-1, x.shape[-1]), dtype=np.float_)
+
+        if nu is None:
+            nu = np.zeros((ndim,), dtype=np.intc)
+        else:
+            nu = np.asarray(nu, dtype=np.intc)
+            if nu.ndim != 1 or nu.shape[0] != ndim:
+                raise ValueError("invalid number of derivative orders nu")
+
+        dim1 = prod(self.c.shape[:ndim])
+        dim2 = prod(self.c.shape[ndim:2*ndim])
+        dim3 = prod(self.c.shape[2*ndim:])
+        ks = np.array(self.c.shape[:ndim], dtype=np.intc)
+
+        out = np.empty((x.shape[0], dim3), dtype=self.c.dtype)
+        self._ensure_c_contiguous()
+
+        _ppoly.evaluate_nd(self.c.reshape(dim1, dim2, dim3),
+                           self.x,
+                           ks,
+                           x,
+                           nu,
+                           bool(extrapolate),
+                           out)
+
+        return out.reshape(x_shape[:-1] + self.c.shape[2*ndim:])
 
 
 # backward compatibility wrapper

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -626,7 +626,7 @@ class _PPolyBase(object):
         nu : int, optional
             Order of derivative to evaluate. Must be non-negative.
         extrapolate : bool, optional
-            Whether to extrapolate to ouf-of-bounds points based on first
+            Whether to extrapolate to out-of-bounds points based on first
             and last intervals, or to return NaNs.
 
         Returns
@@ -674,7 +674,7 @@ class PPoly(_PPolyBase):
         Polynomial breakpoints. These must be sorted in
         increasing order.
     extrapolate : bool, optional
-        Whether to extrapolate to ouf-of-bounds points based on first
+        Whether to extrapolate to out-of-bounds points based on first
         and last intervals, or to return NaNs. Default: True.
 
     Attributes
@@ -813,7 +813,7 @@ class PPoly(_PPolyBase):
         b : float
             Upper integration bound
         extrapolate : bool, optional
-            Whether to extrapolate to ouf-of-bounds points based on first
+            Whether to extrapolate to out-of-bounds points based on first
             and last intervals, or to return NaNs.
 
         Returns
@@ -917,7 +917,7 @@ class PPoly(_PPolyBase):
         tck
             A spline, as returned by `splrep`
         extrapolate : bool, optional
-            Whether to extrapolate to ouf-of-bounds points based on first
+            Whether to extrapolate to out-of-bounds points based on first
             and last intervals, or to return NaNs. Default: True.
 
         """
@@ -941,7 +941,7 @@ class PPoly(_PPolyBase):
         bp : BPoly
             A Bernstein basis polynomial, as created by BPoly
         extrapolate : bool, optional
-            Whether to extrapolate to ouf-of-bounds points based on first
+            Whether to extrapolate to out-of-bounds points based on first
             and last intervals, or to return NaNs. Default: True.
 
         """
@@ -986,7 +986,7 @@ class BPoly(_PPolyBase):
         Polynomial breakpoints. These must be sorted in
         increasing order.
     extrapolate : bool, optional
-        Whether to extrapolate to ouf-of-bounds points based on first
+        Whether to extrapolate to out-of-bounds points based on first
         and last intervals, or to return NaNs. Default: True.
 
     Attributes
@@ -1109,7 +1109,7 @@ class BPoly(_PPolyBase):
         pp : PPoly
             A piecewise polynomial in the power basis
         extrapolate : bool, optional
-            Whether to extrapolate to ouf-of-bounds points based on first
+            Whether to extrapolate to out-of-bounds points based on first
             and last intervals, or to return NaNs. Default: True.
 
         """
@@ -1147,7 +1147,7 @@ class BPoly(_PPolyBase):
         axis : int, optional
             Interpolation axis, default is 0.
         extrapolate : bool, optional
-            Whether to extrapolate to ouf-of-bounds points based on first
+            Whether to extrapolate to out-of-bounds points based on first
             and last intervals, or to return NaNs. Default: True.        
 
         Notes
@@ -1404,7 +1404,7 @@ class NdPPoly(object):
         Polynomial breakpoints for each dimension. These must be
         sorted in increasing order.
     extrapolate : bool, optional
-        Whether to extrapolate to ouf-of-bounds points based on first
+        Whether to extrapolate to out-of-bounds points based on first
         and last intervals, or to return NaNs. Default: True.
 
     Attributes
@@ -1495,7 +1495,7 @@ class NdPPoly(object):
         nu : tuple, optional
             Orders of derivatives to evaluate. Each must be non-negative.
         extrapolate : bool, optional
-            Whether to extrapolate to ouf-of-bounds points based on first
+            Whether to extrapolate to out-of-bounds points based on first
             and last intervals, or to return NaNs.
 
         Returns
@@ -1710,7 +1710,7 @@ class NdPPoly(object):
         axis : int
             Dimension over which to compute the 1D integrals
         extrapolate : bool, optional
-            Whether to extrapolate to ouf-of-bounds points based on first
+            Whether to extrapolate to out-of-bounds points based on first
             and last intervals, or to return NaNs.
 
         Returns
@@ -1761,7 +1761,7 @@ class NdPPoly(object):
             Sequence of lower and upper bounds for each dimension,
             ``[(a[0], b[0]), ..., (a[ndim-1], b[ndim-1])]``
         extrapolate : bool, optional
-            Whether to extrapolate to ouf-of-bounds points based on first
+            Whether to extrapolate to out-of-bounds points based on first
             and last intervals, or to return NaNs.
 
         Returns

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1515,6 +1515,8 @@ class NdPPoly(object):
         """
         if extrapolate is None:
             extrapolate = self.extrapolate
+        else:
+            extrapolate = bool(extrapolate)
 
         ndim = len(self.x)
 
@@ -1687,6 +1689,116 @@ class NdPPoly(object):
 
         p._ensure_c_contiguous()
         return p
+
+    def integrate_1d(self, a, b, axis, extrapolate=None):
+        r"""
+        Compute NdPPoly representation for one dimensional definite integral
+
+        The result is a piecewise polynomial representing the integral:
+
+        .. math::
+
+           p(y, z, ...) = \int_a^b dx\, p(x, y, z, ...)
+
+        where the dimension integrated over is specified with the
+        `axis` parameter.
+
+        Parameters
+        ----------
+        a, b : float
+            Lower and upper bound for integration.
+        axis : int
+            Dimension over which to compute the 1D integrals
+        extrapolate : bool, optional
+            Whether to extrapolate to ouf-of-bounds points based on first
+            and last intervals, or to return NaNs.
+
+        Returns
+        -------
+        ig : NdPPoly or array-like
+            Definite integral of the piecewise polynomial over [a, b].
+            If the polynomial was 1-dimensional, an array is returned,
+            otherwise, an NdPPoly object.
+
+        """
+        if extrapolate is None:
+            extrapolate = self.extrapolate
+        else:
+            extrapolate = bool(extrapolate)
+        
+        ndim = len(self.x)
+        axis = int(axis) % ndim
+
+        # Reuse 1D integration routines
+        c = self.c
+        swap = list(range(c.ndim))
+        swap.insert(0, swap[axis])
+        del swap[axis + 1]
+        swap.insert(1, swap[ndim + axis])
+        del swap[ndim + axis + 1]
+
+        c = c.transpose(swap)
+        p = PPoly.construct_fast(c.reshape(c.shape[0], c.shape[1], -1),
+                                 self.x[axis],
+                                 extrapolate=extrapolate)
+        out = p.integrate(a, b, extrapolate=extrapolate)
+
+        # Construct result
+        if ndim == 1:
+            return out.reshape(c.shape[2:])
+        else:
+            c = out.reshape(c.shape[2:])
+            x = self.x[:axis] + self.x[axis+1:]
+            return self.construct_fast(c, x, extrapolate=extrapolate)
+
+    def integrate(self, ranges, extrapolate=None):
+        """
+        Compute a definite integral over a piecewise polynomial.
+
+        Parameters
+        ----------
+        ranges : ndim-tuple of 2-tuples float
+            Sequence of lower and upper bounds for each dimension,
+            ``[(a[0], b[0]), ..., (a[ndim-1], b[ndim-1])]``
+        extrapolate : bool, optional
+            Whether to extrapolate to ouf-of-bounds points based on first
+            and last intervals, or to return NaNs.
+
+        Returns
+        -------
+        ig : array_like
+            Definite integral of the piecewise polynomial over
+            [a[0], b[0]] x ... x [a[ndim-1], b[ndim-1]]
+
+        """
+
+        ndim = len(self.x)
+
+        if extrapolate is None:
+            extrapolate = self.extrapolate
+        else:
+            extrapolate = bool(extrapolate)
+        
+
+        if not hasattr(ranges, '__len__') or len(ranges) != ndim:
+            raise ValueError("Range not a sequence of correct length")
+
+        self._ensure_c_contiguous()
+
+        # Reuse 1D integration routine
+        c = self.c
+        for n, (a, b) in enumerate(ranges):
+            swap = list(range(c.ndim))
+            swap.insert(1, swap[ndim - n])
+            del swap[ndim - n + 1]
+
+            c = c.transpose(swap)
+
+            p = PPoly.construct_fast(c, self.x[n], extrapolate=extrapolate)
+            out = p.integrate(a, b, extrapolate=extrapolate)
+            c = out.reshape(c.shape[2:])
+
+        return c
 
 
 # backward compatibility wrapper

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1452,7 +1452,6 @@ class NdPPoly(object):
         dtype = self._get_dtype(self.c.dtype)
         self.c = np.ascontiguousarray(self.c, dtype=dtype)
 
-
     @classmethod
     def construct_fast(cls, c, x, extrapolate=None):
         """
@@ -1472,7 +1471,6 @@ class NdPPoly(object):
         self.extrapolate = extrapolate
         return self
 
-
     def _get_dtype(self, dtype):
         if np.issubdtype(dtype, np.complexfloating) \
                or np.issubdtype(self.c.dtype, np.complexfloating):
@@ -1480,13 +1478,11 @@ class NdPPoly(object):
         else:
             return np.float_
 
-
     def _ensure_c_contiguous(self):
         if not self.c.flags.c_contiguous:
             self.c = self.c.copy()
         if not isinstance(self.x, tuple):
             self.x = tuple(self.x)
-
 
     def __call__(self, x, nu=None, extrapolate=None):
         """
@@ -1550,6 +1546,154 @@ class NdPPoly(object):
                            out)
 
         return out.reshape(x_shape[:-1] + self.c.shape[2*ndim:])
+
+    @classmethod
+    def _derivative_one(cls, c, x, nu, axis):
+        """
+        Compute 1D derivative along a selected dimension
+        """
+        if nu < 0:
+            return cls._antiderivative_one(c, x, -nu, axis)
+
+        ndim = len(x)
+        axis = axis % ndim
+
+        perm = list(range(ndim))
+        perm[0], perm[axis] = perm[axis], perm[0]
+        perm = perm + list(range(ndim, c.ndim))
+
+        c = c.transpose(perm)
+
+        # reduce order
+        if nu == 0:
+            c2 = c.copy()
+        else:
+            c2 = c[:-nu].copy()
+
+        if c2.shape[0] == 0:
+            # derivative of order 0 is zero
+            c2 = np.zeros((1,) + c2.shape[1:], dtype=c2.dtype)
+
+        # multiply by the correct rising factorials
+        factor = spec.poch(np.arange(c2.shape[0], 0, -1), nu)
+        c2 *= factor[(slice(None),) + (None,)*(c2.ndim-1)]
+
+        return c2.transpose(perm)
+
+    @classmethod
+    def _antiderivative_one(cls, c, x, nu, axis):
+        """
+        Compute 1D antiderivative along a selected dimension
+        """
+        if nu <= 0:
+            return cls._derivative_one(c, x, -nu, axis)
+
+        ndim = len(x)
+        axis = axis % ndim
+
+        perm = list(range(ndim))
+        perm[0], perm[axis] = perm[axis], perm[0]
+        perm = perm + list(range(ndim, c.ndim))
+
+        c = c.transpose(perm)
+
+        c2 = np.zeros((c.shape[0] + nu,) + c.shape[1:],
+                     dtype=c.dtype)
+        c2[:-nu] = c
+
+        # divide by the correct rising factorials
+        factor = spec.poch(np.arange(c.shape[0], 0, -1), nu)
+        c2[:-nu] /= factor[(slice(None),) + (None,)*(c.ndim-1)]
+
+        # fix continuity of added degrees of freedom
+        perm2 = list(range(c2.ndim))
+        perm2[1], perm2[ndim+axis] = perm2[ndim+axis], perm2[1]
+
+        c2 = c2.transpose(perm2)
+        c2 = c2.copy()
+        _ppoly.fix_continuity(c2.reshape(c2.shape[0], c2.shape[1], -1),
+                              x[axis], nu-1)
+
+        c2 = c2.transpose(perm2)
+        c2 = c2.transpose(perm)
+        return c2.copy()
+
+    def derivative(self, nu):
+        """
+        Construct a new piecewise polynomial representing the derivative.
+
+        Parameters
+        ----------
+        nu : ndim-tuple of int
+            Order of derivatives to evaluate for each dimension.
+            If negative, the antiderivative is returned.
+
+        Returns
+        -------
+        pp : NdPPoly
+            Piecewise polynomial of orders (k[0] - nu[0], ..., k[n] - nu[n])
+            representing the derivative of this polynomial.
+
+        Notes
+        -----
+        Derivatives are evaluated piecewise for each polynomial
+        segment, even if the polynomial is not differentiable at the
+        breakpoints. The polynomial intervals in each dimension are
+        considered half-open, ``[a, b)``, except for the last interval
+        which is closed ``[a, b]``.
+
+        """
+
+        c2 = self.c
+        for axis, n in enumerate(nu):
+            if n != 0:
+                c2 = self._derivative_one(c2, self.x, n, axis)
+
+        if c2 is self.c:
+            # always make a copy
+            c2 = c2.copy()
+
+        # construct a compatible polynomial
+        return self.construct_fast(c2, self.x, self.extrapolate)
+
+    def antiderivative(self, nu):
+        """
+        Construct a new piecewise polynomial representing the antiderivative.
+
+        Antiderivativative is also the indefinite integral of the function,
+        and derivative is its inverse operation.
+
+        Parameters
+        ----------
+        nu : ndim-tuple of int
+            Order of derivatives to evaluate for each dimension.
+            If negative, the derivative is returned.
+
+        Returns
+        -------
+        pp : PPoly
+            Piecewise polynomial of order k2 = k + n representing
+            the antiderivative of this polynomial.
+
+        Notes
+        -----
+        The antiderivative returned by this function is continuous and
+        continuously differentiable to order n-1, up to floating point
+        rounding error.
+
+        """
+
+        c2 = self.c
+        for axis, n in enumerate(nu):
+            if n != 0:
+                c2 = self._antiderivative_one(c2, self.x, n, axis)
+
+        if c2 is self.c:
+            # always make a copy
+            c2 = c2.copy()
+
+        # construct a compatible polynomial
+        return self.construct_fast(c2, self.x, self.extrapolate)
 
 
 # backward compatibility wrapper

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1547,55 +1547,56 @@ class NdPPoly(object):
 
         return out.reshape(x_shape[:-1] + self.c.shape[2*ndim:])
 
-    @classmethod
-    def _derivative_one(cls, c, x, nu, axis):
+    def _derivative_inplace(self, nu, axis):
         """
-        Compute 1D derivative along a selected dimension
+        Compute 1D derivative along a selected dimension in-place
+        May result to non-contiguous c array.
         """
         if nu < 0:
-            return cls._antiderivative_one(c, x, -nu, axis)
+            return self._antiderivative_inplace(-nu, axis)
 
-        ndim = len(x)
+        ndim = len(self.x)
         axis = axis % ndim
-
-        perm = list(range(ndim))
-        perm[0], perm[axis] = perm[axis], perm[0]
-        perm = perm + list(range(ndim, c.ndim))
-
-        c = c.transpose(perm)
 
         # reduce order
         if nu == 0:
-            c2 = c.copy()
+            # noop
+            return
         else:
-            c2 = c[:-nu].copy()
+            sl = [slice(None)]*ndim
+            sl[axis] = slice(None, -nu, None)
+            c2 = self.c[sl]
 
-        if c2.shape[0] == 0:
+        if c2.shape[axis] == 0:
             # derivative of order 0 is zero
-            c2 = np.zeros((1,) + c2.shape[1:], dtype=c2.dtype)
+            shp = list(c2.shape)
+            shp[axis] = 1
+            c2 = np.zeros(shp, dtype=c2.dtype)
 
         # multiply by the correct rising factorials
-        factor = spec.poch(np.arange(c2.shape[0], 0, -1), nu)
-        c2 *= factor[(slice(None),) + (None,)*(c2.ndim-1)]
+        factor = spec.poch(np.arange(c2.shape[axis], 0, -1), nu)
+        sl = [None]*c2.ndim
+        sl[axis] = slice(None)
+        c2 *= factor[sl]
 
-        return c2.transpose(perm)
+        self.c = c2
 
-    @classmethod
-    def _antiderivative_one(cls, c, x, nu, axis):
+    def _antiderivative_inplace(self, nu, axis):
         """
         Compute 1D antiderivative along a selected dimension
+        May result to non-contiguous c array.
         """
         if nu <= 0:
-            return cls._derivative_one(c, x, -nu, axis)
+            return self._derivative_inplace(-nu, axis)
 
-        ndim = len(x)
+        ndim = len(self.x)
         axis = axis % ndim
 
         perm = list(range(ndim))
         perm[0], perm[axis] = perm[axis], perm[0]
-        perm = perm + list(range(ndim, c.ndim))
+        perm = perm + list(range(ndim, self.c.ndim))
 
-        c = c.transpose(perm)
+        c = self.c.transpose(perm)
 
         c2 = np.zeros((c.shape[0] + nu,) + c.shape[1:],
                      dtype=c.dtype)
@@ -1612,11 +1613,13 @@ class NdPPoly(object):
         c2 = c2.transpose(perm2)
         c2 = c2.copy()
         _ppoly.fix_continuity(c2.reshape(c2.shape[0], c2.shape[1], -1),
-                              x[axis], nu-1)
+                              self.x[axis], nu-1)
 
         c2 = c2.transpose(perm2)
         c2 = c2.transpose(perm)
-        return c2.copy()
+
+        # Done
+        self.c = c2
 
     def derivative(self, nu):
         """
@@ -1643,18 +1646,13 @@ class NdPPoly(object):
         which is closed ``[a, b]``.
 
         """
+        p = self.construct_fast(self.c.copy(), self.x, self.extrapolate)
 
-        c2 = self.c
         for axis, n in enumerate(nu):
-            if n != 0:
-                c2 = self._derivative_one(c2, self.x, n, axis)
+            p._derivative_inplace(n, axis)
 
-        if c2 is self.c:
-            # always make a copy
-            c2 = c2.copy()
-
-        # construct a compatible polynomial
-        return self.construct_fast(c2, self.x, self.extrapolate)
+        p._ensure_c_contiguous()
+        return p
 
     def antiderivative(self, nu):
         """
@@ -1682,18 +1680,13 @@ class NdPPoly(object):
         rounding error.
 
         """
+        p = self.construct_fast(self.c.copy(), self.x, self.extrapolate)
 
-        c2 = self.c
         for axis, n in enumerate(nu):
-            if n != 0:
-                c2 = self._antiderivative_one(c2, self.x, n, axis)
+            p._antiderivative_inplace(n, axis)
 
-        if c2 is self.c:
-            # always make a copy
-            c2 = c2.copy()
-
-        # construct a compatible polynomial
-        return self.construct_fast(c2, self.x, self.extrapolate)
+        p._ensure_c_contiguous()
+        return p
 
 
 # backward compatibility wrapper

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -691,6 +691,20 @@ class TestPPoly(TestCase):
             assert_allclose(pp2(xi), splev(xi, spl2),
                             rtol=1e-7)
 
+    def test_antiderivative_continuity(self):
+        c = np.array([[2, 1, 2, 2], [2, 1, 3, 3]]).T
+        x = np.array([0, 0.5, 1])
+
+        p = PPoly(c, x)
+        ip = p.antiderivative()
+
+        # check continuity
+        assert_allclose(ip(0.5 - 1e-9), ip(0.5 + 1e-9), rtol=1e-8)
+
+        # check that only lowest order coefficients were changed
+        p2 = ip.derivative()
+        assert_allclose(p2.c, p.c)
+
     def test_integrate(self):
         np.random.seed(1234)
         x = np.sort(np.r_[0, np.random.rand(11), 1])

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -14,6 +14,8 @@ from scipy.lib.six import xrange
 from scipy.interpolate import (interp1d, interp2d, lagrange, PPoly, BPoly,
          ppform, splrep, splev, splantider, splint, sproot, NdPPoly)
 
+from scipy.special import poch
+
 from scipy.interpolate import _ppoly
 
 from scipy.lib._gcutils import assert_deallocated
@@ -1175,8 +1177,10 @@ class TestNdPPoly(object):
         assert_allclose(v1, v2)
 
         p = NdPPoly(c, (x, y))
-        v3 = p(np.c_[xi, yi])
-        assert_allclose(v3, v2)
+        for nu in (None, (0, 0), (0, 1), (1, 0), (2, 3), (9, 2)):
+            v1 = p(np.c_[xi, yi], nu=nu)
+            v2 = _ppoly2d_eval(c, (x, y), xi, yi, nu=nu)
+            assert_allclose(v1, v2, err_msg=repr(nu))
 
     def test_simple_3d(self):
         np.random.seed(1234)
@@ -1186,15 +1190,17 @@ class TestNdPPoly(object):
         y = np.linspace(0, 1, 8+1)**2
         z = np.linspace(0, 1, 9+1)**3
 
-        xi = np.random.rand(200)
-        yi = np.random.rand(200)
-        zi = np.random.rand(200)
+        xi = np.random.rand(40)
+        yi = np.random.rand(40)
+        zi = np.random.rand(40)
 
         p = NdPPoly(c, (x, y, z))
-        v1 = p((xi, yi, zi))
 
-        v2 = _ppoly3d_eval(c, (x, y, z), xi, yi, zi)
-        assert_allclose(v1, v2)
+        for nu in (None, (0, 0, 0), (0, 1, 0), (1, 0, 0), (2, 3, 0),
+                   (6, 0, 2)):
+            v1 = p((xi, yi, zi), nu=nu)
+            v2 = _ppoly3d_eval(c, (x, y, z), xi, yi, zi, nu=nu)
+            assert_allclose(v1, v2, err_msg=repr(nu))
 
     def test_simple_4d(self):
         np.random.seed(1234)
@@ -1256,10 +1262,25 @@ def _ppoly_eval_2(coeffs, breaks, xnew, fill=np.nan):
     return res
 
 
-def _ppoly2d_eval(c, xs, xnew, ynew):
+def _dpow(x, y, n):
+    """
+    d^n (x**y) / dx^n
+    """
+    if n < 0:
+        raise ValueError("invalid derivative order")
+    elif n > y:
+        return 0
+    else:
+        return poch(y - n + 1, n) * x**(y - n)
+
+
+def _ppoly2d_eval(c, xs, xnew, ynew, nu=None):
     """
     Straightforward evaluation of 2D piecewise polynomial
     """
+    if nu is None:
+        nu = (0, 0)
+
     out = np.empty((len(xnew),), dtype=c.dtype)
 
     nx, ny = c.shape[:2]
@@ -1280,17 +1301,22 @@ def _ppoly2d_eval(c, xs, xnew, ynew):
 
         for k1 in range(c.shape[0]):
             for k2 in range(c.shape[1]):
-                val += c[nx-k1-1,ny-k2-1,j1,j2] * s1**k1 * s2**k2
+                val += (c[nx-k1-1,ny-k2-1,j1,j2]
+                        * _dpow(s1, k1, nu[0])
+                        * _dpow(s2, k2, nu[1]))
 
         out[jout] = val
 
     return out
 
 
-def _ppoly3d_eval(c, xs, xnew, ynew, znew):
+def _ppoly3d_eval(c, xs, xnew, ynew, znew, nu=None):
     """
     Straightforward evaluation of 3D piecewise polynomial
     """
+    if nu is None:
+        nu = (0, 0, 0)
+
     out = np.empty((len(xnew),), dtype=c.dtype)
 
     nx, ny, nz = c.shape[:3]
@@ -1315,20 +1341,25 @@ def _ppoly3d_eval(c, xs, xnew, ynew, znew):
             for k2 in range(c.shape[1]):
                 for k3 in range(c.shape[2]):
                     val += (c[nx-k1-1,ny-k2-1,nz-k3-1,j1,j2,j3]
-                            * s1**k1 * s2**k2 * s3**k3)
+                            * _dpow(s1, k1, nu[0])
+                            * _dpow(s2, k2, nu[1])
+                            * _dpow(s3, k3, nu[2]))
 
         out[jout] = val
 
     return out
 
 
-def _ppoly4d_eval(c, xs, xnew, ynew, znew, unew):
+def _ppoly4d_eval(c, xs, xnew, ynew, znew, unew, nu=None):
     """
     Straightforward evaluation of 4D piecewise polynomial
     """
+    if nu is None:
+        nu = (0, 0, 0, 0)
+
     out = np.empty((len(xnew),), dtype=c.dtype)
 
-    nx, ny, nz, nu = c.shape[:4]
+    mx, my, mz, mu = c.shape[:4]
 
     for jout, (x, y, z, u) in enumerate(zip(xnew, ynew, znew, unew)):
         if not ((xs[0][0] <= x <= xs[0][-1]) and
@@ -1353,8 +1384,11 @@ def _ppoly4d_eval(c, xs, xnew, ynew, znew, unew):
             for k2 in range(c.shape[1]):
                 for k3 in range(c.shape[2]):
                     for k4 in range(c.shape[3]):
-                        val += (c[nx-k1-1,ny-k2-1,nz-k3-1,nu-k4-1,j1,j2,j3,j4]
-                                * s1**k1 * s2**k2 * s3**k3 * s4**k4)
+                        val += (c[mx-k1-1,my-k2-1,mz-k3-1,mu-k4-1,j1,j2,j3,j4]
+                                * _dpow(s1, k1, nu[0])
+                                * _dpow(s2, k2, nu[1])
+                                * _dpow(s3, k3, nu[2])
+                                * _dpow(s4, k4, nu[3]))
 
         out[jout] = val
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -14,7 +14,7 @@ from scipy.lib.six import xrange
 from scipy.interpolate import (interp1d, interp2d, lagrange, PPoly, BPoly,
          ppform, splrep, splev, splantider, splint, sproot, NdPPoly)
 
-from scipy.special import poch
+from scipy.special import poch, gamma
 
 from scipy.interpolate import _ppoly
 
@@ -1235,7 +1235,77 @@ class TestNdPPoly(object):
 
         v2 = _ppoly4d_eval(c, (x, y, z, u), xi, yi, zi, ui)
         assert_allclose(v1, v2)
-        
+
+    def test_deriv_1d(self):
+        np.random.seed(1234)
+
+        c = np.random.rand(4, 5)
+        x = np.linspace(0, 1, 5+1)
+
+        p = NdPPoly(c, (x,))
+
+        # derivative
+        dp = p.derivative(nu=[1])
+        p1 = PPoly(c, x)
+        dp1 = p1.derivative()
+        assert_allclose(dp.c, dp1.c)
+
+        # antiderivative
+        dp = p.antiderivative(nu=[2])
+        p1 = PPoly(c, x)
+        dp1 = p1.antiderivative(2)
+        assert_allclose(dp.c, dp1.c)
+
+    def test_deriv_3d(self):
+        np.random.seed(1234)
+
+        c = np.random.rand(4, 5, 6, 7, 8, 9)
+        x = np.linspace(0, 1, 7+1)
+        y = np.linspace(0, 1, 8+1)**2
+        z = np.linspace(0, 1, 9+1)**3
+
+        p = NdPPoly(c, (x, y, z))
+
+        # differentiate vs x
+        p1 = PPoly(c.transpose(0, 3, 1, 2, 4, 5), x)
+        dp = p.derivative(nu=[2])
+        dp1 = p1.derivative(2)
+        assert_allclose(dp.c,
+                        dp1.c.transpose(0, 2, 3, 1, 4, 5))
+
+        # antidifferentiate vs y
+        p1 = PPoly(c.transpose(1, 4, 0, 2, 3, 5), y)
+        dp = p.antiderivative(nu=[0, 1, 0])
+        dp1 = p1.antiderivative(1)
+        assert_allclose(dp.c,
+                        dp1.c.transpose(2, 0, 3, 4, 1, 5))
+
+        # differentiate vs z
+        p1 = PPoly(c.transpose(2, 5, 0, 1, 3, 4), z)
+        dp = p.derivative(nu=[0, 0, 3])
+        dp1 = p1.derivative(3)
+        assert_allclose(dp.c,
+                        dp1.c.transpose(2, 3, 0, 4, 5, 1))
+
+    def test_deriv_3d_simple(self):
+        # Integrate to obtain function x y**2 z**4 / (2! 4!)
+
+        c = np.ones((1, 1, 1, 3, 4, 5))
+        x = np.linspace(0, 1, 3+1)**1
+        y = np.linspace(0, 1, 4+1)**2
+        z = np.linspace(0, 1, 5+1)**3
+
+        p = NdPPoly(c, (x, y, z))
+        ip = p.antiderivative((1, 0, 4))
+        ip = ip.antiderivative((0, 2, 0))
+
+        xi = np.random.rand(20)
+        yi = np.random.rand(20)
+        zi = np.random.rand(20)
+
+        assert_allclose(ip((xi, yi, zi)),
+                        xi * yi**2 * zi**4 / (gamma(3)*gamma(5)))
+
 
 def _ppoly_eval_1(c, x, xps):
     """Evaluate piecewise polynomial manually"""

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -12,7 +12,7 @@ import warnings
 from scipy.lib.six import xrange
 
 from scipy.interpolate import (interp1d, interp2d, lagrange, PPoly, BPoly,
-         ppform, splrep, splev, splantider, splint, sproot)
+         ppform, splrep, splev, splantider, splint, sproot, NdPPoly)
 
 from scipy.interpolate import _ppoly
 
@@ -1136,6 +1136,87 @@ class TestPpform(TestCase):
             assert_equal(p(xp).shape, (3, 4, 5, 6, 7))
 
 
+class TestNdPPoly(object):
+    def test_simple_1d(self):
+        np.random.seed(1234)
+
+        c = np.random.rand(4, 5)
+        x = np.linspace(0, 1, 5+1)
+
+        xi = np.random.rand(200)
+
+        p = NdPPoly(c, (x,))
+        v1 = p((xi,))
+
+        v2 = _ppoly_eval_1(c[:,:,None], x, xi).ravel()
+        assert_allclose(v1, v2)
+
+    def test_simple_2d(self):
+        np.random.seed(1234)
+
+        c = np.random.rand(4, 5, 6, 7)
+        x = np.linspace(0, 1, 6+1)
+        y = np.linspace(0, 1, 7+1)**2
+
+        xi = np.random.rand(200)
+        yi = np.random.rand(200)
+
+        v1 = np.empty([len(xi), 1], dtype=c.dtype)
+        v1.fill(np.nan)
+        _ppoly.evaluate_nd(c.reshape(4*5, 6*7, 1),
+                           (x, y),
+                           np.array([4, 5], dtype=np.intc),
+                           np.c_[xi, yi],
+                           np.array([0, 0], dtype=np.intc),
+                           1,
+                           v1)
+        v1 = v1.ravel()
+        v2 = _ppoly2d_eval(c, (x, y), xi, yi)
+        assert_allclose(v1, v2)
+
+        p = NdPPoly(c, (x, y))
+        v3 = p(np.c_[xi, yi])
+        assert_allclose(v3, v2)
+
+    def test_simple_3d(self):
+        np.random.seed(1234)
+
+        c = np.random.rand(4, 5, 6, 7, 8, 9)
+        x = np.linspace(0, 1, 7+1)
+        y = np.linspace(0, 1, 8+1)**2
+        z = np.linspace(0, 1, 9+1)**3
+
+        xi = np.random.rand(200)
+        yi = np.random.rand(200)
+        zi = np.random.rand(200)
+
+        p = NdPPoly(c, (x, y, z))
+        v1 = p((xi, yi, zi))
+
+        v2 = _ppoly3d_eval(c, (x, y, z), xi, yi, zi)
+        assert_allclose(v1, v2)
+
+    def test_simple_4d(self):
+        np.random.seed(1234)
+
+        c = np.random.rand(4, 5, 6, 7, 8, 9, 10, 11)
+        x = np.linspace(0, 1, 8+1)
+        y = np.linspace(0, 1, 9+1)**2
+        z = np.linspace(0, 1, 10+1)**3
+        u = np.linspace(0, 1, 11+1)**4
+
+        xi = np.random.rand(20)
+        yi = np.random.rand(20)
+        zi = np.random.rand(20)
+        ui = np.random.rand(20)
+
+        p = NdPPoly(c, (x, y, z, u))
+        v1 = p((xi, yi, zi, ui))
+
+        v2 = _ppoly4d_eval(c, (x, y, z, u), xi, yi, zi, ui)
+        assert_allclose(v1, v2)
+        
+
 def _ppoly_eval_1(c, x, xps):
     """Evaluate piecewise polynomial manually"""
     out = np.zeros((len(xps), c.shape[2]))
@@ -1174,6 +1255,110 @@ def _ppoly_eval_2(coeffs, breaks, xnew, fill=np.nan):
     res.shape = saveshape
     return res
 
+
+def _ppoly2d_eval(c, xs, xnew, ynew):
+    """
+    Straightforward evaluation of 2D piecewise polynomial
+    """
+    out = np.empty((len(xnew),), dtype=c.dtype)
+
+    nx, ny = c.shape[:2]
+
+    for jout, (x, y) in enumerate(zip(xnew, ynew)):
+        if not ((xs[0][0] <= x <= xs[0][-1]) and
+                (xs[1][0] <= y <= xs[1][-1])):
+            out[jout] = np.nan
+            continue
+
+        j1 = np.searchsorted(xs[0], x) - 1
+        j2 = np.searchsorted(xs[1], y) - 1
+
+        s1 = x - xs[0][j1]
+        s2 = y - xs[1][j2]
+
+        val = 0
+
+        for k1 in range(c.shape[0]):
+            for k2 in range(c.shape[1]):
+                val += c[nx-k1-1,ny-k2-1,j1,j2] * s1**k1 * s2**k2
+
+        out[jout] = val
+
+    return out
+
+
+def _ppoly3d_eval(c, xs, xnew, ynew, znew):
+    """
+    Straightforward evaluation of 3D piecewise polynomial
+    """
+    out = np.empty((len(xnew),), dtype=c.dtype)
+
+    nx, ny, nz = c.shape[:3]
+
+    for jout, (x, y, z) in enumerate(zip(xnew, ynew, znew)):
+        if not ((xs[0][0] <= x <= xs[0][-1]) and
+                (xs[1][0] <= y <= xs[1][-1]) and
+                (xs[2][0] <= z <= xs[2][-1])):
+            out[jout] = np.nan
+            continue
+
+        j1 = np.searchsorted(xs[0], x) - 1
+        j2 = np.searchsorted(xs[1], y) - 1
+        j3 = np.searchsorted(xs[2], z) - 1
+
+        s1 = x - xs[0][j1]
+        s2 = y - xs[1][j2]
+        s3 = z - xs[2][j3]
+
+        val = 0
+        for k1 in range(c.shape[0]):
+            for k2 in range(c.shape[1]):
+                for k3 in range(c.shape[2]):
+                    val += (c[nx-k1-1,ny-k2-1,nz-k3-1,j1,j2,j3]
+                            * s1**k1 * s2**k2 * s3**k3)
+
+        out[jout] = val
+
+    return out
+
+
+def _ppoly4d_eval(c, xs, xnew, ynew, znew, unew):
+    """
+    Straightforward evaluation of 4D piecewise polynomial
+    """
+    out = np.empty((len(xnew),), dtype=c.dtype)
+
+    nx, ny, nz, nu = c.shape[:4]
+
+    for jout, (x, y, z, u) in enumerate(zip(xnew, ynew, znew, unew)):
+        if not ((xs[0][0] <= x <= xs[0][-1]) and
+                (xs[1][0] <= y <= xs[1][-1]) and
+                (xs[2][0] <= z <= xs[2][-1]) and
+                (xs[3][0] <= u <= xs[3][-1])):
+            out[jout] = np.nan
+            continue
+
+        j1 = np.searchsorted(xs[0], x) - 1
+        j2 = np.searchsorted(xs[1], y) - 1
+        j3 = np.searchsorted(xs[2], z) - 1
+        j4 = np.searchsorted(xs[3], u) - 1
+
+        s1 = x - xs[0][j1]
+        s2 = y - xs[1][j2]
+        s3 = z - xs[2][j3]
+        s4 = u - xs[3][j4]
+
+        val = 0
+        for k1 in range(c.shape[0]):
+            for k2 in range(c.shape[1]):
+                for k3 in range(c.shape[2]):
+                    for k4 in range(c.shape[3]):
+                        val += (c[nx-k1-1,ny-k2-1,nz-k3-1,nu-k4-1,j1,j2,j3,j4]
+                                * s1**k1 * s2**k2 * s3**k3 * s4**k4)
+
+        out[jout] = val
+
+    return out
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -20,6 +20,8 @@ from scipy.interpolate import _ppoly
 
 from scipy.lib._gcutils import assert_deallocated
 
+from scipy.integrate import nquad
+
 
 class TestInterp2D(TestCase):
     def test_interp2d(self):
@@ -1305,6 +1307,66 @@ class TestNdPPoly(object):
 
         assert_allclose(ip((xi, yi, zi)),
                         xi * yi**2 * zi**4 / (gamma(3)*gamma(5)))
+
+    def test_integrate_2d(self):
+        np.random.seed(1234)
+        c = np.random.rand(4, 5, 16, 17)
+        x = np.linspace(0, 1, 16+1)**1
+        y = np.linspace(0, 1, 17+1)**2
+
+        # make continuously differentiable so that nquad() has an
+        # easier time
+        c = c.transpose(0, 2, 1, 3)
+        cx = c.reshape(c.shape[0], c.shape[1], -1).copy()
+        _ppoly.fix_continuity(cx, x, 2)
+        c = cx.reshape(c.shape)
+        c = c.transpose(0, 2, 1, 3)
+        c = c.transpose(1, 3, 0, 2)
+        cx = c.reshape(c.shape[0], c.shape[1], -1).copy()
+        _ppoly.fix_continuity(cx, y, 2)
+        c = cx.reshape(c.shape)
+        c = c.transpose(2, 0, 3, 1).copy()
+
+        # Check integration
+        p = NdPPoly(c, (x, y))
+
+        for ranges in [[(0, 1), (0, 1)],
+                       [(0, 0.5), (0, 1)],
+                       [(0, 1), (0, 0.5)],
+                       [(0.3, 0.7), (0.6, 0.2)]]:
+
+            ig = p.integrate(ranges)
+            ig2, err2 = nquad(lambda x, y: p((x, y)), ranges,
+                              opts=[dict(epsrel=1e-5, epsabs=1e-5)]*2)
+            assert_allclose(ig, ig2, rtol=1e-5, atol=1e-5,
+                            err_msg=repr(ranges))
+
+    def test_integrate_1d(self):
+        np.random.seed(1234)
+        c = np.random.rand(4, 5, 6, 16, 17, 18)
+        x = np.linspace(0, 1, 16+1)**1
+        y = np.linspace(0, 1, 17+1)**2
+        z = np.linspace(0, 1, 18+1)**3
+
+        # Check 1D integration
+        p = NdPPoly(c, (x, y, z))
+
+        u = np.random.rand(200)
+        v = np.random.rand(200)
+        a, b = 0.2, 0.7
+
+        px = p.integrate_1d(a, b, axis=0)
+        pax = p.antiderivative((1, 0, 0))
+        assert_allclose(px((u, v)), pax((b, u, v)) - pax((a, u, v)))
+
+        py = p.integrate_1d(a, b, axis=1)
+        pay = p.antiderivative((0, 1, 0))
+        assert_allclose(py((u, v)), pay((u, b, v)) - pay((u, a, v)))
+
+        pz = p.integrate_1d(a, b, axis=2)
+        paz = p.antiderivative((0, 0, 1))
+        assert_allclose(pz((u, v)), paz((u, v, b)) - paz((u, v, a)))
+
 
 
 def _ppoly_eval_1(c, x, xps):


### PR DESCRIPTION
This PR adds piecewise tensor-product polynomials to scipy.interpolate.

Constructing interpolating polynomials is also on the TODO list, but out of scope for this PR which just tries to put the data structures in place.

(The next step would then be to implement similar structures and evaluation routines as for PPoly/NdPPoly for the B-splines.)
