### PR TITLE
sparse: enhancements for DIA format

### DIFF
--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -187,6 +187,20 @@ class dia_matrix(_data_matrix):
         else:
             return self
 
+    def transpose(self):
+        num_rows, num_cols = self.shape
+        max_dim = max(self.shape)
+        # flip diagonal offsets
+        offsets = -self.offsets
+        # re-align the data matrix
+        r = np.arange(len(offsets), dtype=np.intc)[:,None]
+        c = np.arange(num_rows, dtype=np.intc) - (offsets % max_dim)[:,None]
+        pad_amount = max(0, max_dim-self.data.shape[1])
+        data = np.hstack((self.data, np.zeros((self.data.shape[0], pad_amount),
+                                              dtype=self.data.dtype)))
+        data = data[r,c]
+        return dia_matrix((data, offsets), shape=(num_cols,num_rows))
+
     def tocsr(self):
         #this could be faster
         return self.tocoo().tocsr()
@@ -204,7 +218,7 @@ class dia_matrix(_data_matrix):
         mask = (row >= 0)
         mask &= (row < num_rows)
         mask &= (offset_inds < num_cols)
-        mask &= self.data != 0
+        mask &= (self.data != 0)
         row = row[mask]
         col = np.tile(offset_inds, num_offsets)[mask.ravel()]
         data = self.data[mask]

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -196,22 +196,18 @@ class dia_matrix(_data_matrix):
         return self.tocoo().tocsc()
 
     def tocoo(self):
-        num_data = len(self.data)
-        len_data = self.data.shape[1]
+        num_rows, num_cols = self.shape
+        num_offsets, offset_len = self.data.shape
+        offset_inds = np.arange(offset_len)
 
-        row = np.arange(len_data).reshape(1,-1).repeat(num_data,axis=0)
-        col = row.copy()
-
-        for i,k in enumerate(self.offsets):
-            row[i,:] -= k
-
-        row,col,data = row.ravel(),col.ravel(),self.data.ravel()
-
+        row = offset_inds - self.offsets[:,None]
         mask = (row >= 0)
-        mask &= (row < self.shape[0])
-        mask &= (col < self.shape[1])
-        mask &= data != 0
-        row,col,data = row[mask],col[mask],data[mask]
+        mask &= (row < num_rows)
+        mask &= (offset_inds < num_cols)
+        mask &= self.data != 0
+        row = row[mask]
+        col = np.tile(offset_inds, num_offsets)[mask.ravel()]
+        data = self.data[mask]
 
         from .coo import coo_matrix
         return coo_matrix((data,(row,col)), shape=self.shape)


### PR DESCRIPTION
This is still a WIP, due to slower speeds on `tocsr()`:
_Updated timings as of 50dbbfa_

```
In [2]: A = scipy.sparse.rand(200,300,density=0.8,format='dia')

In [3]: %timeit A.tocoo().tocsc()
100 loops, best of 3: 5.78 ms per loop

In [4]: %timeit A.tocsc()
100 loops, best of 3: 3.33 ms per loop

In [5]: %timeit A.tocoo().tocsr()
100 loops, best of 3: 4.42 ms per loop

In [6]: %timeit A.tocsr()
100 loops, best of 3: 8.06 ms per loop
```

Both `tocsc()` and `tocsr()` look like they can be optimized further.
