### PR TITLE
ENH: Add callback to slsqp in scipy.optimize

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -330,7 +330,7 @@ def minimize(fun, x0, args=(), method='BFGS', jac=None, hess=None,
         warn('Method %s cannot handle bounds.' % method,
              RuntimeWarning)
     # - callback
-    if (meth in ['anneal', 'cobyla', 'slsqp'] and
+    if (meth in ['anneal', 'cobyla'] and
         callback is not None):
         warn('Method %s does not support callback.' % method,
              RuntimeWarning)
@@ -384,7 +384,7 @@ def minimize(fun, x0, args=(), method='BFGS', jac=None, hess=None,
         return _minimize_cobyla(fun, x0, args, constraints, **options)
     elif meth == 'slsqp':
         return _minimize_slsqp(fun, x0, args, jac, bounds,
-                               constraints, **options)
+                               constraints, callback=callback, **options)
     elif meth == 'dogleg':
         return _minimize_dogleg(fun, x0, args, jac, hess,
                                 callback=callback, **options)

--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -67,7 +67,7 @@ def approx_jacobian(x,func,epsilon,*args):
 def fmin_slsqp(func, x0, eqcons=[], f_eqcons=None, ieqcons=[], f_ieqcons=None,
                 bounds=[], fprime=None, fprime_eqcons=None,
                 fprime_ieqcons=None, args=(), iter = 100, acc = 1.0E-6,
-                iprint = 1, disp = None, full_output = 0, epsilon = _epsilon):
+                iprint = 1, disp = None, full_output = 0, epsilon = _epsilon, callback = None):
     """
     Minimize a function using Sequential Least SQuares Programming
 
@@ -131,6 +131,10 @@ def fmin_slsqp(func, x0, eqcons=[], f_eqcons=None, ieqcons=[], f_ieqcons=None,
         information.
     epsilon : float
         The step size for finite-difference derivative estimates.
+    callback : callable, optional
+        Called after each iteration, as ``callback(x)``, where ``x`` is the
+        current parameter vector.
+
 
     Returns
     -------
@@ -177,7 +181,8 @@ def fmin_slsqp(func, x0, eqcons=[], f_eqcons=None, ieqcons=[], f_ieqcons=None,
             'ftol': acc,
             'iprint': iprint,
             'disp': iprint != 0,
-            'eps': epsilon}
+            'eps': epsilon,
+            'callback': callback}
 
     # Build the constraints as a tuple of dictionaries
     cons = ()
@@ -206,7 +211,7 @@ def fmin_slsqp(func, x0, eqcons=[], f_eqcons=None, ieqcons=[], f_ieqcons=None,
 def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
                     constraints=(),
                     maxiter=100, ftol=1.0E-6, iprint=1, disp=False,
-                    eps=_epsilon,
+                    eps=_epsilon, callback=None,
                     **unknown_options):
     """
     Minimize a scalar function of one or more variables using Sequential
@@ -222,6 +227,9 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
             `verbosity` is ignored and set to 0.
         maxiter : int
             Maximum number of iterations.
+        callback : callable, optional
+            Called after each iteration, as ``callback(x)``, where ``x`` is the
+            current parameter vector.
 
     This function is called by the `minimize` function with
     `method=SLSQP`. It is not supposed to be called directly.
@@ -394,6 +402,10 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
 
         # Call SLSQP
         slsqp(m, meq, x, xl, xu, fx, c, g, a, acc, majiter, mode, w, jw)
+
+        # call callback if major iteration has incremented
+        if callback is not None and majiter > majiter_prev:
+            callback(x)
 
         # Print the status of the current iterate if iprint > 2 and the
         # major iteration has incremented

--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -65,9 +65,9 @@ def approx_jacobian(x,func,epsilon,*args):
 
 
 def fmin_slsqp(func, x0, eqcons=[], f_eqcons=None, ieqcons=[], f_ieqcons=None,
-                bounds=[], fprime=None, fprime_eqcons=None,
-                fprime_ieqcons=None, args=(), iter = 100, acc = 1.0E-6,
-                iprint = 1, disp = None, full_output = 0, epsilon = _epsilon, callback = None):
+               bounds=[], fprime=None, fprime_eqcons=None,
+               fprime_ieqcons=None, args=(), iter = 100, acc=1.0E-6,
+               iprint=1, disp=None, full_output=0, epsilon=_epsilon, callback=None):
     """
     Minimize a function using Sequential Least SQuares Programming
 
@@ -227,9 +227,6 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
             `verbosity` is ignored and set to 0.
         maxiter : int
             Maximum number of iterations.
-        callback : callable, optional
-            Called after each iteration, as ``callback(x)``, where ``x`` is the
-            current parameter vector.
 
     This function is called by the `minimize` function with
     `method=SLSQP`. It is not supposed to be called directly.

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -4,10 +4,24 @@ Unit test for SLSQP optimization.
 from __future__ import division, print_function, absolute_import
 
 from numpy.testing import assert_, assert_array_almost_equal, TestCase, \
-                          assert_allclose, run_module_suite
+                          assert_allclose, assert_equal, run_module_suite
 import numpy as np
 
 from scipy.optimize import fmin_slsqp, minimize
+
+
+class MyCallBack(object):
+    """pass a custom callback function
+
+    This makes sure it's being used.
+    """
+    def __init__(self):
+        self.been_called = False
+        self.ncalls = 0
+
+    def __call__(self, x):
+        self.been_called = True
+        self.ncalls += 1
 
 
 class TestSLSQP(TestCase):
@@ -297,6 +311,15 @@ class TestSLSQP(TestCase):
     def test_integer_bounds(self):
         # this should not raise an exception
         fmin_slsqp(lambda z: z**2 - 1, [0], bounds=[[0, 1]], iprint=0)
+
+    def test_callback(self):
+        """ Minimize, method='SLSQP': unbounded, approximated jacobian. Check for callback"""
+        callback = MyCallBack()
+        res = minimize(self.fun, [-1.0, 1.0], args=(-1.0, ),
+                       method='SLSQP', callback=callback, options=self.opts)
+        assert_(res['success'], res['message'])
+        assert_(callback.been_called)
+        assert_equal(callback.ncalls, res['nit'])
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -313,7 +313,7 @@ class TestSLSQP(TestCase):
         fmin_slsqp(lambda z: z**2 - 1, [0], bounds=[[0, 1]], iprint=0)
 
     def test_callback(self):
-        # Minimize, method='SLSQP': unbounded, approximated jacobian. Check for callback"""
+        # Minimize, method='SLSQP': unbounded, approximated jacobian. Check for callback
         callback = MyCallBack()
         res = minimize(self.fun, [-1.0, 1.0], args=(-1.0, ),
                        method='SLSQP', callback=callback, options=self.opts)

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -313,7 +313,7 @@ class TestSLSQP(TestCase):
         fmin_slsqp(lambda z: z**2 - 1, [0], bounds=[[0, 1]], iprint=0)
 
     def test_callback(self):
-        """ Minimize, method='SLSQP': unbounded, approximated jacobian. Check for callback"""
+        # Minimize, method='SLSQP': unbounded, approximated jacobian. Check for callback"""
         callback = MyCallBack()
         res = minimize(self.fun, [-1.0, 1.0], args=(-1.0, ),
                        method='SLSQP', callback=callback, options=self.opts)


### PR DESCRIPTION
I implemented a callback to the slsqp minimization in scipy.optimize. The callback is called after each major iteration of the slsqp algorithm. It can be used via the scipy.optimize.minimize interface.

I also implemented a test for the callback that checks whether the callback has been called and that it has been called the correct number of times.
