### PR TITLE
BUG: linalg.eig: fix division by zero

### DIFF
--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -73,10 +73,12 @@ def _geneig(a1, b1, left, right, overwrite_a, overwrite_b):
         if right:
             vr = _make_complex_eigvecs(w, vr, t)
 
-    # the eigenvectors returned rfom the lapack function are NOT normalized
+    # the eigenvectors returned by the lapack function are NOT normalized
     for i in xrange(vr.shape[0]):
-        vr[:, i] /= norm(vr[:, i])
-        vl[:, i] /= norm(vl[:, i])
+        if right:
+            vr[:, i] /= norm(vr[:, i])
+        if left:
+            vl[:, i] /= norm(vl[:, i])
 
     if not (left or right):
         return w


### PR DESCRIPTION
The current implementation of the generalized eigenvalue problem raises a `RuntimeWarning` (division by zero) if the left eigenvectors are not requested:

```
  File "/tmp/scipy/build/testenv/lib/python2.7/site-packages/scipy/linalg/decomp.py", line 79, in _geneig
    vl[:, i] /= norm(vl[:, i])
RuntimeWarning: invalid value encountered in true_divide
```

This commit fixes only normalizes the eigenvectors if they have actually been computed.
