### PR TITLE
File object support for imread and imsave

### DIFF
--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -100,13 +100,13 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
     return cast[uint8](bytedata) + cast[uint8](low)
 
 
-def imread(imfile, flatten=0):
+def imread(name, flatten=0):
     """
     Read an image from a file as an array.
 
     Parameters
     ----------
-    imfile : str or file object
+    name : str or file object
         The file name or file object to be read.
     flatten : bool, optional
         If True, flattens the color layers into a single gray-scale layer.
@@ -123,17 +123,17 @@ def imread(imfile, flatten=0):
 
     """
 
-    im = Image.open(imfile)
+    im = Image.open(name)
     return fromimage(im,flatten=flatten)
 
 
-def imsave(imfile, arr, format=None):
+def imsave(name, arr, format=None):
     """
     Save an array as an image.
 
     Parameters
     ----------
-    imfile : str or file object
+    name : str or file object
         Output file name or file object.
     arr : ndarray, MxN or MxNx3 or MxNx4
         Array containing image values.  If the shape is ``MxN``, the array
@@ -165,9 +165,9 @@ def imsave(imfile, arr, format=None):
     """
     im = toimage(arr)
     if format is None:
-        im.save(imfile)
+        im.save(name)
     else:
-        im.save(imfile, format)
+        im.save(name, format)
     return
 
 

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -100,21 +100,21 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
     return cast[uint8](bytedata) + cast[uint8](low)
 
 
-def imread(name,flatten=0):
+def imread(imfile, flatten=0):
     """
-    Read an image file from a filename.
+    Read an image from a file as an array.
 
     Parameters
     ----------
-    name : str
-        The file name to be read.
+    imfile : str or file object
+        The file name or file object to be read.
     flatten : bool, optional
         If True, flattens the color layers into a single gray-scale layer.
 
     Returns
     -------
     imread : ndarray
-        The array obtained by reading image from file `name`.
+        The array obtained by reading image from file `imfile`.
 
     Notes
     -----
@@ -123,23 +123,27 @@ def imread(name,flatten=0):
 
     """
 
-    im = Image.open(name)
+    im = Image.open(imfile)
     return fromimage(im,flatten=flatten)
 
 
-def imsave(name, arr):
+def imsave(imfile, arr, format=None):
     """
     Save an array as an image.
 
     Parameters
     ----------
-    name : str
-        Output filename.
+    imfile : str or file object
+        Output file name or file object.
     arr : ndarray, MxN or MxNx3 or MxNx4
         Array containing image values.  If the shape is ``MxN``, the array
         represents a grey-level image.  Shape ``MxNx3`` stores the red, green
         and blue bands along the last dimension.  An alpha layer may be
         included, specified as the last colour band of an ``MxNx4`` array.
+    format : str
+        Image format. If omitted, the format to use is determined from the 
+        file name extension. If a file object was used instead of a file name,
+        this parameter should always be used.
 
     Examples
     --------
@@ -160,7 +164,10 @@ def imsave(name, arr):
 
     """
     im = toimage(arr)
-    im.save(name)
+    if format is None:
+        im.save(imfile)
+    else:
+        im.save(imfile, format)
     return
 
 

--- a/scipy/ndimage/io.py
+++ b/scipy/ndimage/io.py
@@ -5,14 +5,14 @@ __all__ = ['imread']
 from numpy import array
 
 
-def imread(fname, flatten=False, mode=None):
+def imread(imfile, flatten=False, mode=None):
     """
-    Load an image from file.
+    Read an image from a file as an array.
 
     Parameters
     ----------
-    fname : str
-        Image file name, e.g. ``test.jpg``.
+    imfile : str
+        Image file name, e.g. ``test.jpg``, or a file object.
     flatten : bool, optional
         If true, convert the output to grey-scale. Default is False.
     mode : str, optional
@@ -40,11 +40,10 @@ def imread(fname, flatten=False, mode=None):
                           " http://pypi.python.org/pypi/PIL/ for installation"
                           " instructions.")
 
-    with open(fname, "rb") as fp:
-        im = Image.open(fp)
-        if mode:
-            im = im.convert(mode)
-        if flatten:
-            im = im.convert('F')
-        result = array(im)
-        return result
+    im = Image.open(imfile)
+    if mode:
+        im = im.convert(mode)
+    if flatten:
+        im = im.convert('F')
+    result = array(im)
+    return result

--- a/scipy/ndimage/io.py
+++ b/scipy/ndimage/io.py
@@ -5,13 +5,13 @@ __all__ = ['imread']
 from numpy import array
 
 
-def imread(imfile, flatten=False, mode=None):
+def imread(fname, flatten=False, mode=None):
     """
     Read an image from a file as an array.
 
     Parameters
     ----------
-    imfile : str
+    fname : str
         Image file name, e.g. ``test.jpg``, or a file object.
     flatten : bool, optional
         If true, convert the output to grey-scale. Default is False.
@@ -40,7 +40,7 @@ def imread(imfile, flatten=False, mode=None):
                           " http://pypi.python.org/pypi/PIL/ for installation"
                           " instructions.")
 
-    im = Image.open(imfile)
+    im = Image.open(fname)
     if mode:
         im = im.convert(mode)
     if flatten:

--- a/scipy/ndimage/tests/test_io.py
+++ b/scipy/ndimage/tests/test_io.py
@@ -20,6 +20,11 @@ def test_imread():
 
     img = ndi.imread(lp, flatten=True)
     assert_array_equal(img.shape, (300, 420))
+    
+    fobj = open(lp)
+    img = ndi.imread(fobj, mode="RGB")
+    assert_array_equal(img.shape, (300, 420, 3))
+    
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Made changes to image reading and writing routines to support file objects properly. Actually scipy.misc.imread didn't have to be changed because PIL already supports file objects, but I changed the docstring to say explicitly that it supports them. I made similar changes to scipy.ndimage.misc.imread, though I'm not quite sure why that can't just import from scipy.misc.
