### PR TITLE
ENH: add multivariate normal option to return the effective rank

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -133,37 +133,33 @@ class _PSD(object):
     The functions are designed to coordinate with scipy.linalg.pinvh()
     but not necessarily with np.linalg.det() or with np.linalg.matrix_rank().
 
+    Parameters
+    ----------
+    M : 2d array-like
+        Symmetric positive semidefinite matrix.
+    cond, rcond : float, optional
+        Cutoff for small eigenvalues.
+        Singular values smaller than rcond * largest_eigenvalue are
+        considered zero.
+        If None or -1, suitable machine precision is used.
+    lower : bool, optional
+        Whether the pertinent array data is taken from the lower
+        or upper triangle of M. (Default: lower)
+    check_finite : bool, optional
+        Whether to check that the input matrices contain only finite
+        numbers. Disabling may give a performance gain, but may result
+        in problems (crashes, non-termination) if the inputs do contain
+        infinities or NaNs.
+    allow_singular : bool, optional
+        Whether to allow a singular matrix.  (Default: True)
+
+    Notes
+    -----
+    The arguments are similar to those of scipy.linalg.pinvh().
+
     """
     def __init__(self, M, cond=None, rcond=None, lower=True,
             check_finite=True, allow_singular=True):
-        """
-        Compute functions of a symmetric positive semidefinite matrix.
-
-        Parameters
-        ----------
-        M : 2d array-like
-            Symmetric positive semidefinite matrix.
-        cond, rcond : float, optional
-            Cutoff for small eigenvalues.
-            Singular values smaller than rcond * largest_eigenvalue are
-            considered zero.
-            If None or -1, suitable machine precision is used.
-        lower : bool, optional
-            Whether the pertinent array data is taken from the lower
-            or upper triangle of M. (Default: lower)
-        check_finite : bool, optional
-            Whether to check that the input matrices contain only finite
-            numbers. Disabling may give a performance gain, but may result
-            in problems (crashes, non-termination) if the inputs do contain
-            infinities or NaNs.
-        allow_singular : bool, optional
-            Whether to allow a singular matrix.  (Default: True)
-
-        Notes
-        -----
-        The arguments are similar to those of scipy.linalg.pinvh().
-
-        """
         # Compute the symmetric eigendecomposition.
         # Note that eigh takes care of array conversion, chkfinite,
         # and assertion that the matrix is square.

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -245,11 +245,11 @@ class multivariate_normal_gen(object):
 
     Methods
     -------
-    pdf(x, mean=None, cov=1)
+    pdf(x, mean=None, cov=1, allow_singular=False)
         Probability density function.
-    logpdf(x, mean=None, cov=1)
+    logpdf(x, mean=None, cov=1, allow_singular=False)
         Log of the probability density function.
-    rvs(mean=None, cov=1, size=1)
+    rvs(mean=None, cov=1, allow_singular=False, size=1)
         Draw random samples from a multivariate normal distribution.
     entropy()
         Compute the differential entropy of the multivariate normal.
@@ -264,8 +264,8 @@ class multivariate_normal_gen(object):
     and covariance parameters, returning a "frozen" multivariate normal
     random variable:
 
-    rv = multivariate_normal(mean=None, scale=1)
-        - Frozen  object with the same methods but holding the given
+    rv = multivariate_normal(mean=None, cov=1, allow_singular=False)
+        - Frozen object with the same methods but holding the given
           mean and covariance fixed.
 
     Notes

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -58,10 +58,12 @@ def _process_parameters(dim, mean, cov):
         cov = cov * np.eye(dim)
     elif cov.ndim == 1:
         cov = np.diag(cov)
-    else:
-        if cov.shape != (dim, dim):
-            raise ValueError("Array 'cov' must be at most two-dimensional,"
-                                 " but cov.ndim = %d" % cov.ndim)
+    elif cov.ndim == 2 and cov.shape != (dim, dim):
+        raise ValueError("Array 'cov' must be square if it is two dimensional, "
+                "but cov.shape = %s" % cov.shape)
+    elif cov.ndim > 2:
+        raise ValueError("Array 'cov' must be at most two-dimensional, "
+                "but cov.ndim = %d" % cov.ndim)
 
     return dim, mean, cov
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -118,7 +118,7 @@ def _pinv_1d(v, eps=1e-5):
 
 
 def _psd_pinv_decomposed_log_pdet(mat, cond=None, rcond=None,
-        lower=True, return_rank=False, check_finite=True):
+        lower=True, check_finite=True):
     """
     Compute a decomposition of the pseudo-inverse and the logarithm of
     the pseudo-determinant of a symmetric positive semi-definite
@@ -140,8 +140,6 @@ def _psd_pinv_decomposed_log_pdet(mat, cond=None, rcond=None,
     lower : bool, optional
         Whether the pertinent array data is taken from the lower or upper
         triangle of `mat`. (Default: lower)
-    return_rank : bool, optional
-        if True, return the effective rank of the matrix
     check_finite : boolean, optional
         Whether to check that the input matrix contains only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -154,7 +152,7 @@ def _psd_pinv_decomposed_log_pdet(mat, cond=None, rcond=None,
     log_pdet : float
         Logarithm of the pseudo-determinant of the matrix.
     rank : int
-        The effective rank of the matrix.  Returned if return_rank == True
+        The effective rank of the matrix.
 
     """
     # Compute the symmetric eigendecomposition.
@@ -187,11 +185,7 @@ def _psd_pinv_decomposed_log_pdet(mat, cond=None, rcond=None,
     U = np.multiply(u, np.sqrt(s_pinv))
     d = s[s > eps]
     log_pdet = np.sum(np.log(d))
-
-    if return_rank:
-        return U, log_pdet, len(d)
-    else:
-        return U, log_pdet
+    return U, log_pdet, len(d)
 
 
 _doc_default_callparams = """\
@@ -199,8 +193,6 @@ mean : array_like, optional
     Mean of the distribution (default zero)
 cov : array_like, optional
     Covariance matrix of the distribution (default one)
-return_rank : bool, optional
-    if True, return the effective rank of the matrix (default False)
 """
 
 _doc_callparams_note = \
@@ -238,9 +230,9 @@ class multivariate_normal_gen(object):
 
     Methods
     -------
-    pdf(x, mean=None, cov=1, return_rank=False)
+    pdf(x, mean=None, cov=1)
         Probability density function.
-    logpdf(x, mean=None, cov=1, return_rank=False)
+    logpdf(x, mean=None, cov=1)
         Log of the probability density function.
     rvs(mean=None, cov=1, size=1)
         Draw random samples from a multivariate normal distribution.
@@ -313,7 +305,7 @@ class multivariate_normal_gen(object):
         """
         return multivariate_normal_frozen(mean, cov)
 
-    def _logpdf(self, x, mean, prec_U, log_det_cov):
+    def _logpdf(self, x, mean, prec_U, log_det_cov, rank):
         """
         Parameters
         ----------
@@ -327,6 +319,8 @@ class multivariate_normal_gen(object):
             is the precision matrix, i.e. inverse of the covariance matrix.
         log_det_cov : float
             Logarithm of the determinant of the covariance matrix
+        rank : int
+            Rank of the covariance matrix.
 
         Notes
         -----
@@ -334,12 +328,11 @@ class multivariate_normal_gen(object):
         called directly; use 'logpdf' instead.
 
         """
-        dim = x.shape[-1]
         dev = x - mean
         maha = np.sum(np.square(np.dot(dev, prec_U)), axis=-1)
-        return -0.5 * (dim * _LOG_2PI + log_det_cov + maha)
+        return -0.5 * (rank * _LOG_2PI + log_det_cov + maha)
 
-    def logpdf(self, x, mean, cov, return_rank=False):
+    def logpdf(self, x, mean, cov):
         """
         Log of the multivariate normal probability density function.
 
@@ -361,16 +354,11 @@ class multivariate_normal_gen(object):
         """
         dim, mean, cov = _process_parameters(None, mean, cov)
         x = _process_quantiles(x, dim)
-        prec_U, log_det_cov, rank = _psd_pinv_decomposed_log_pdet(
-                cov, return_rank=True)
-        out = self._logpdf(x, mean, prec_U, log_det_cov)
-        out = _squeeze_output(out)
-        if return_rank:
-            return out, rank
-        else:
-            return out
+        prec_U, log_det_cov, rank = _psd_pinv_decomposed_log_pdet(cov)
+        out = self._logpdf(x, mean, prec_U, log_det_cov, rank)
+        return _squeeze_output(out)
 
-    def pdf(self, x, mean, cov, return_rank=False):
+    def pdf(self, x, mean, cov):
         """
         Multivariate normal probability density function.
 
@@ -392,14 +380,9 @@ class multivariate_normal_gen(object):
         """
         dim, mean, cov = _process_parameters(None, mean, cov)
         x = _process_quantiles(x, dim)
-        prec_U, log_det_cov, rank = _psd_pinv_decomposed_log_pdet(
-                cov, return_rank=True)
-        out = np.exp(self._logpdf(x, mean, prec_U, log_det_cov))
-        out = _squeeze_output(out)
-        if return_rank:
-            return out, rank
-        else:
-            return out
+        prec_U, log_det_cov, rank = _psd_pinv_decomposed_log_pdet(cov)
+        out = np.exp(self._logpdf(x, mean, prec_U, log_det_cov, rank))
+        return _squeeze_output(out)
 
     def rvs(self, mean=None, cov=1, size=1):
         """
@@ -476,25 +459,20 @@ class multivariate_normal_frozen(object):
 
         """
         self.dim, self.mean, self.cov = _process_parameters(None, mean, cov)
-        info = _psd_pinv_decomposed_log_pdet(self.cov, return_rank=True)
-        self.prec_U, self._log_det_cov, self._rank = info
+        info = _psd_pinv_decomposed_log_pdet(self.cov)
+        self.prec_U, self._log_det_cov, self.rank = info
         self._mnorm = multivariate_normal_gen()
 
-    def logpdf(self, x, return_rank=False):
+    def logpdf(self, x):
         x = _process_quantiles(x, self.dim)
-        out = self._mnorm._logpdf(x, self.mean, self.prec_U, self._log_det_cov)
+        out = self._mnorm._logpdf(
+                x, self.mean, self.prec_U, self._log_det_cov, self.rank)
         out = _squeeze_output(out)
-        if return_rank:
-            return out, self._rank
-        else:
-            return out
+        return out
 
-    def pdf(self, x, return_rank=False):
+    def pdf(self, x):
         out = np.exp(self.logpdf(x))
-        if return_rank:
-            return out, self._rank
-        else:
-            return out
+        return out
 
     def rvs(self, size=1):
         return self._mnorm.rvs(self.mean, self.cov, size)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -123,7 +123,7 @@ class _PSD(object):
 
     This class addresses two issues.  Firstly it allows the pseudoinverse,
     the logarithm of the pseudo-determinant, and the rank of the matrix
-    to be computed using one eigh instead of three.
+    to be computed using one call to eigh instead of three.
     Secondly it allows these functions to be computed in a way
     that gives mutually compatible results.
     All of the functions are computed with a common understanding as to

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -60,7 +60,7 @@ def _process_parameters(dim, mean, cov):
         cov = np.diag(cov)
     elif cov.ndim == 2 and cov.shape != (dim, dim):
         raise ValueError("Array 'cov' must be square if it is two dimensional, "
-                "but cov.shape = %s" % cov.shape)
+                "but cov.shape = %s" % str(cov.shape))
     elif cov.ndim > 2:
         raise ValueError("Array 'cov' must be at most two-dimensional, "
                 "but cov.ndim = %d" % cov.ndim)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -21,8 +21,8 @@ from scipy.integrate import romb
 def test_input_shape():
     mu = np.arange(3)
     cov = np.identity(2)
-    assert_raises(ValueError, multivariate_normal.pdf, (0, 1), mean, cov)
-    assert_raises(ValueError, multivariate_normal.pdf, (0, 1, 2), mean, cov)
+    assert_raises(ValueError, multivariate_normal.pdf, (0, 1), mu, cov)
+    assert_raises(ValueError, multivariate_normal.pdf, (0, 1, 2), mu, cov)
 
 
 def test_scalar_values():

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -47,6 +47,20 @@ def test_logpdf():
     assert_allclose(d1, np.log(d2))
 
 
+def test_return_rank():
+    # Check that the rank is detected and returned correctly.
+    np.random.seed(1234)
+    n = 4
+    mean = np.random.randn(n)
+    x = np.random.randn(n)
+    for expected_rank in range(1, n+1):
+        s = np.random.randn(n, expected_rank)
+        cov = np.dot(s, s.T)
+        for f in (multivariate_normal.logpdf, multivariate_normal.pdf):
+            out, rank = f(x, mean, cov, return_rank=True)
+            assert_equal(rank, expected_rank)
+
+
 def test_large_pseudo_determinant():
     # Check that large pseudo-determinants are handled appropriately.
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -54,7 +54,7 @@ def test_rank():
     for expected_rank in range(1, n+1):
         s = np.random.randn(n, expected_rank)
         cov = np.dot(s, s.T)
-        distn = multivariate_normal(mean, cov)
+        distn = multivariate_normal(mean, cov, allow_singular=True)
         assert_equal(distn.cov_info.rank, expected_rank)
 
 
@@ -67,8 +67,10 @@ def test_degenerate_distributions():
             cov_kk = np.dot(s, s.T)
             cov_nn = np.zeros((n, n))
             cov_nn[:k, :k] = cov_kk
-            distn_kk = multivariate_normal(np.zeros(k), cov_kk)
-            distn_nn = multivariate_normal(np.zeros(n), cov_nn)
+            distn_kk = multivariate_normal(np.zeros(k), cov_kk,
+                    allow_singular=True)
+            distn_nn = multivariate_normal(np.zeros(n), cov_nn,
+                    allow_singular=True)
             assert_equal(distn_kk.cov_info.rank, k)
             assert_equal(distn_nn.cov_info.rank, k)
             pdf_kk = distn_kk.pdf(x[:k])
@@ -218,6 +220,16 @@ def test_exception_nonfinite_cov():
 def test_exception_non_psd_cov():
     cov = [[1, 0], [0, -1]]
     assert_raises(ValueError, _PSD, cov)
+
+def test_exception_singular_cov():
+    np.random.seed(1234)
+    x = np.random.randn(5)
+    mean = np.random.randn(5)
+    cov = np.ones((5, 5))
+    e = np.linalg.LinAlgError
+    assert_raises(e, multivariate_normal, mean, cov)
+    assert_raises(e, multivariate_normal.pdf, x, mean, cov)
+    assert_raises(e, multivariate_normal.logpdf, x, mean, cov)
 
 
 def test_R_values():

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -18,6 +18,13 @@ from scipy.stats import norm
 from scipy.integrate import romb
 
 
+def test_input_shape():
+    mu = np.arange(3)
+    cov = np.identity(2)
+    assert_raises(ValueError, multivariate_normal.pdf, (0, 1), mean, cov)
+    assert_raises(ValueError, multivariate_normal.pdf, (0, 1, 2), mean, cov)
+
+
 def test_scalar_values():
     np.random.seed(1234)
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -11,8 +11,7 @@ import numpy
 import numpy as np
 
 import scipy.linalg
-from scipy.stats._multivariate import (
-        multivariate_normal_frozen, _psd_pinv_decomposed_log_pdet)
+from scipy.stats._multivariate import _psd_pinv_decomposed_log_pdet
 from scipy.stats import multivariate_normal
 from scipy.stats import norm
 
@@ -55,7 +54,7 @@ def test_rank():
     for expected_rank in range(1, n+1):
         s = np.random.randn(n, expected_rank)
         cov = np.dot(s, s.T)
-        distn = multivariate_normal_frozen(mean, cov)
+        distn = multivariate_normal(mean, cov)
         assert_equal(distn.rank, expected_rank)
 
 
@@ -68,8 +67,8 @@ def test_degenerate_distributions():
             cov_kk = np.dot(s, s.T)
             cov_nn = np.zeros((n, n))
             cov_nn[:k, :k] = cov_kk
-            distn_kk = multivariate_normal_frozen(np.zeros(k), cov_kk)
-            distn_nn = multivariate_normal_frozen(np.zeros(n), cov_nn)
+            distn_kk = multivariate_normal(np.zeros(k), cov_kk)
+            distn_nn = multivariate_normal(np.zeros(n), cov_nn)
             assert_equal(distn_kk.rank, k)
             assert_equal(distn_nn.rank, k)
             pdf_kk = distn_kk.pdf(x[:k])


### PR DESCRIPTION
When the covariance matrix is nearly singular, the scipy code that computes the multivariate normal pdf and logpdf will use a degenerate distribution.  Optionally return the internal effective rank of the covariance matrix of the distribution.
