### PR TITLE
ENH: Speed up fftconvolve by using 5-smooth length to pad FFT

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -209,20 +209,20 @@ def fftconvolve(in1, in2, mode="full"):
     s2 = array(in2.shape)
     complex_result = (np.issubdtype(in1.dtype, np.complex) or
                       np.issubdtype(in2.dtype, np.complex))
-    size = s1 + s2 - 1
+    shape = s1 + s2 - 1
 
     if mode == "valid":
         _check_valid_mode_shapes(s1, s2)
 
     # Always use 2**n-sized FFT
-    fsize = 2 ** np.ceil(np.log2(size)).astype(int)
-    fslice = tuple([slice(0, int(sz)) for sz in size])
+    fshape = 2 ** np.ceil(np.log2(shape)).astype(int)
+    fslice = tuple([slice(0, int(sz)) for sz in shape])
     if not complex_result:
-        ret = irfftn(rfftn(in1, fsize) *
-                     rfftn(in2, fsize), fsize)[fslice].copy()
+        ret = irfftn(rfftn(in1, fshape) *
+                     rfftn(in2, fshape), fshape)[fslice].copy()
         ret = ret.real
     else:
-        ret = ifftn(fftn(in1, fsize) * fftn(in2, fsize))[fslice].copy()
+        ret = ifftn(fftn(in1, fshape) * fftn(in2, fshape))[fslice].copy()
 
     if mode == "full":
         return ret

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -118,7 +118,7 @@ def correlate(in1, in2, mode='full'):
     except KeyError:
         raise ValueError("Acceptable mode flags are 'valid',"
                          " 'same', or 'full'.")
-    
+
     if rank(in1) == rank(in2) == 0:
         return in1 * in2
     elif not in1.ndim == in2.ndim:
@@ -155,6 +155,56 @@ def _centered(arr, newsize):
     endind = startind + newsize
     myslice = [slice(startind[k], endind[k]) for k in range(len(endind))]
     return arr[tuple(myslice)]
+
+
+def _next_regular(target):
+    """
+    Find the next regular number greater than or equal to target.
+    Regular numbers are composites of the prime factors 2, 3, and 5.
+    Also known as 5-smooth numbers or Hamming numbers, these are the optimal
+    size for inputs to FFTPACK.
+
+    Target must be a positive integer.
+    """
+    if target <= 6:
+        return target
+
+    # Quickly check if it's already a power of 2
+    if not (target & (target-1)):
+        return target
+
+    match = float('inf') # Anything found will be smaller
+    p5 = 1
+    while p5 < target:
+        p35 = p5
+        while p35 < target:
+            # Ceiling integer division, avoiding conversion to float
+            # (quotient = ceil(target / p35))
+            quotient = -(-target // p35)
+
+            # Quickly find next power of 2 >= quotient
+            try:
+                p2 = 2**((quotient - 1).bit_length())
+            except AttributeError:
+                # Fallback for Python <2.7
+                p2 = 2**(len(bin(quotient - 1)) - 2)
+
+            N = p2 * p35
+            if N == target:
+                return N
+            elif N < match:
+                match = N
+            p35 *= 3
+            if p35 == target:
+                return p35
+        if p35 < match:
+            match = p35
+        p5 *= 5
+        if p5 == target:
+            return p5
+    if p5 < match:
+        match = p5
+    return match
 
 
 def fftconvolve(in1, in2, mode="full"):
@@ -214,8 +264,8 @@ def fftconvolve(in1, in2, mode="full"):
     if mode == "valid":
         _check_valid_mode_shapes(s1, s2)
 
-    # Always use 2**n-sized FFT
-    fshape = 2 ** np.ceil(np.log2(shape)).astype(int)
+    # Speed up FFT by padding to optimal size for FFTPACK
+    fshape = [_next_regular(int(d)) for d in shape]
     fslice = tuple([slice(0, int(sz)) for sz in shape])
     if not complex_result:
         ret = irfftn(rfftn(in1, fshape) *


### PR DESCRIPTION
Fix for https://github.com/scipy/scipy/issues/2146

```
In [4]: in1 = rand(2**14+1) + 1j*rand(2**14+1)

In [5]: timeit fftconvolve(in1, in1)
100 loops, best of 3: 19.1 ms per loop

In [6]: timeit fftconvolvefast(in1, in1)
100 loops, best of 3: 3.75 ms per loop

In [10]: assert_array_almost_equal(fftconvolve(in1, in1), fftconvolvefast(in1, in1))

In [11]: 19.1/3.75
5.093333333333334
```
