### PR TITLE
BUG: integrate: odeint handled the banded jacobian incorrectly.

### DIFF
--- a/scipy/integrate/__odepack.h
+++ b/scipy/integrate/__odepack.h
@@ -114,7 +114,7 @@ int ode_jacobian_function(int *n, double *t, double *y, int *ml, int *mu, double
     return -1;
   }
   if (multipack_jac_transpose == 1) 
-    MATRIXC2F(pd, result_array->data, *n, *nrowpd)
+    MATRIXC2F(pd, result_array->data, *nrowpd, *n)
   else
     memcpy(pd, result_array->data, (*n)*(*nrowpd)*sizeof(double));
 

--- a/scipy/integrate/multipack.h
+++ b/scipy/integrate/multipack.h
@@ -96,11 +96,20 @@ the result tuple when the full_output argument is non-zero.
     diag = (double *)ap_diag -> data; \
     mode = 2; } }
 
-#define MATRIXC2F(jac,data,n,m) {double *p1=(double *)(jac), *p2, *p3=(double *)(data);\
-int i,j;\
-for (j=0;j<(m);p3++,j++) \
-  for (p2=p3,i=0;i<(n);p2+=(m),i++,p1++) \
-    *p1 = *p2; }
+/*
+ *  MATRIXC2F(jac, data, n, m)
+ *
+ *  Copy a C-contiguous matrix at `data` to an F-contiguous matrix at `jac`.
+ *  `n` and `m` are the number of rows and columns of the matrix, respectively.
+ */
+#define MATRIXC2F(jac, data, n, m) \
+{ \
+  double *p1 = (double *)(jac), *p2, *p3 = (double *)(data); \
+  int i, j; \
+  for (j = 0; j < (m); p3++, j++) \
+    for (p2 = p3, i = 0; i < (n); p2 += (m), i++, p1++) \
+      *p1 = *p2; \
+}
 
 static PyObject *multipack_python_function=NULL;
 static PyObject *multipack_python_jacobian=NULL;

--- a/scipy/integrate/odepack.py
+++ b/scipy/integrate/odepack.py
@@ -93,9 +93,13 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
         Jacobian is assumed to be banded.  These give the number of
         lower and upper non-zero diagonals in this banded matrix.
         For the banded case, `Dfun` should return a matrix whose
-        columns contain the non-zero bands (starting with the
-        lowest diagonal).  Thus, the return matrix from `Dfun` should
-        have shape ``len(y0) * (ml + mu + 1)`` when ``ml >=0`` or ``mu >=0``.
+        rows contain the non-zero bands (starting with the lowest diagonal).
+        Thus, the return matrix `jac` from `Dfun` should have shape
+        ``(ml + mu + 1, len(y0))`` when ``ml >=0`` or ``mu >=0``.
+        The data in `jac` must be stored such that ``jac[i - j + mu, j]``
+        holds the derivative of the `i`th equation with respect to the `j`th
+        state variable.  If `col_deriv` is True, the transpose of this
+        `jac` must be returned.
     rtol, atol : float, optional
         The input parameters `rtol` and `atol` determine the error
         control performed by the solver.  The solver will control the

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -4,7 +4,7 @@ Tests for numerical integration.
 """
 from __future__ import division, print_function, absolute_import
 
-import numpy
+import numpy as np
 from numpy import arange, zeros, array, dot, sqrt, cos, sin, eye, pi, exp, \
                   allclose
 
@@ -408,7 +408,7 @@ class Pi(ODE):
         return array([1./(t - 10 + 1j)])
 
     def verify(self, zs, t):
-        u = -2j*numpy.arctan(10)
+        u = -2j * np.arctan(10)
         return allclose(u, zs[-1,:], atol=self.atol, rtol=self.rtol)
 
 PROBLEMS = [SimpleOscillator, ComplexExp, Pi]
@@ -541,6 +541,53 @@ class ZVODECheckParameterUse(ODECheckParameterUse, TestCase):
 class LSODACheckParameterUse(ODECheckParameterUse, TestCase):
     solver_name = 'lsoda'
     solver_uses_jac = True
+
+
+def test_odeint_banded_jacobian():
+    # Test the use of the `Dfun`, `ml` and `mu` options of odeint.
+
+    def func(y, t, c):
+        return c.dot(y)
+
+    def jac(y, t, c):
+        return c
+
+    def bjac_cols(y, t, c):
+        return np.column_stack((np.r_[0, np.diag(c, 1)], np.diag(c)))
+
+    def bjac_rows(y, t, c):
+        return np.row_stack((np.r_[0, np.diag(c, 1)], np.diag(c)))
+
+    c = array([[-50,   75,     0],
+               [  0, -0.1,     1],
+               [  0,    0, -1e-4]])
+
+    y0 = arange(3)
+    t = np.linspace(0, 50, 6)
+
+    # The results of the following three calls should be the same.
+    sol0, info0 = odeint(func, y0, t, args=(c,), full_output=True,
+                         Dfun=jac)
+
+    sol1, info1 = odeint(func, y0, t, args=(c,), full_output=True,
+                         Dfun=bjac_cols, ml=0, mu=1, col_deriv=True)
+
+    sol2, info2 = odeint(func, y0, t, args=(c,), full_output=True,
+                         Dfun=bjac_rows, ml=0, mu=1)
+
+    # These could probably be compared using `assert_array_equal`.
+    # The code paths might not be *exactly* the same, so `allclose` is used
+    # to compare the solutions.
+    assert_allclose(sol0, sol1)
+    assert_allclose(sol0, sol2)
+
+    # Verify that the number of jacobian evaluations was the same
+    # for all three calls of odeint.  This is a regression test--there
+    # was a bug in the handling of banded jacobians that resulted in
+    # an incorrect jacobian matrix being passed to the LSODA code.
+    # That would cause errors or excessive jacobian evaluations.
+    assert_array_equal(info0['nje'], info1['nje'])
+    assert_array_equal(info0['nje'], info2['nje'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When `col_deriv` is False, the C wrapper that calls the user's python code that
computes the jacobian matrix uses a macro, MATRIXC2F(jac, data, n, m), to copy
the data into the array that is used by the Fortran solver.  In that macro.
`jac` is the destination, `data` is the source, and `n` and `m` are the number
of rows and columns of the matrix.  The wrapper had the last two arguments
reversed.  In the case of a full jacobian, this did not matter, because the
matrix is square.  In the banded case, the number of rows and columns are not
the same.  This means that the only way to correctly use a banded jacobian was
to put the bands in the columns of the matrix, and use `col_deriv=True` so
MATRIXC2F was not used.  That would result in the data being in the correct
Fortran order, since the Fortran code expects the bands to be in the rows.

This commit fixes the use of MATRIXC2F.  Also, the docstring of odeint is
updated to reflect the correct API:  the bands should be put in the rows
of the matrix, not the columns (unless `col_deriv=True` is used).
