### PR TITLE
BUG: special: comb returned incorrect result when given large np.int64 arguments

### DIFF
--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -1147,7 +1147,7 @@ def agm(a,b):
     return (pi / 4) * s / ellipkm1(4 * a * b / s ** 2)
 
 
-def comb(N,k,exact=False,repetition=False):
+def comb(N, k, exact=False, repetition=False):
     """
     The number of combinations of N things taken k at a time.
 
@@ -1191,6 +1191,8 @@ def comb(N,k,exact=False,repetition=False):
     if repetition:
         return comb(N + k - 1, k, exact)
     if exact:
+        N = int(N)
+        k = int(k)
         if (k > N) or (N < 0) or (k < 0):
             return 0
         val = 1

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1068,6 +1068,14 @@ class TestCombinatorics(TestCase):
         assert_equal(special.comb(10, 3, exact=True), 120)
         assert_equal(special.comb(10, 3, exact=True, repetition=True), 220)
 
+    def test_comb_with_np_int64(self):
+        n = 70
+        k = 30
+        np_n = np.int64(n)
+        np_k = np.int64(k)
+        assert_equal(special.comb(np_n, np_k, exact=True),
+                     special.comb(n, k, exact=True))
+
     def test_comb_zeros(self):
         assert_equal(special.comb(2, 3, exact=True), 0)
         assert_equal(special.comb(-1, 3, exact=True), 0)


### PR DESCRIPTION
When given `exact=True`, cast the arguments of `comb` to python integers to
ensure that the result is a python integer.  Otherwise a call with arguments
that are, for example, `np.int64` can return an incorrect result:

```
>>> comb(70, 30, exact=True)   # correct result
55347740058143507128L
```

That result is too big for a 64 bit integer.  Here's what we get with `comb`
before this pull request:

```
>>>  comb(np.int64(70), np.int64(30), exact=True)  # incorrect result
261655728644386326
```
