### PR TITLE
Move scipy.misc.factorial* to scipy.special

### DIFF
--- a/scipy/misc/__init__.py
+++ b/scipy/misc/__init__.py
@@ -18,9 +18,9 @@ systems that don't have PIL installed.
    central_diff_weights - Weights for an n-point central m-th derivative
    comb - Combinations of N things taken k at a time, "N choose k" (imported from scipy.special)
    derivative - Find the n-th derivative of a function at a point
-   factorial  - The factorial function, n! = special.gamma(n+1)
-   factorial2 - Double factorial, (n!)!
-   factorialk - (...((n!)!)!...)! where there are k '!'
+   factorial  - The factorial function, n! = special.gamma(n+1) (imported from scipy.special)
+   factorial2 - Double factorial, (n!)! (imported from scipy.special)
+   factorialk - (...((n!)!)!...)! where there are k '!' (imported from scipy.special)
    fromimage - Return a copy of a PIL image as a numpy array
    imfilter - Simple filtering of an image
    imread - Read an image file from a filename

--- a/scipy/misc/__init__.py
+++ b/scipy/misc/__init__.py
@@ -44,7 +44,7 @@ __all__ = ['who', 'source', 'info', 'doccer']
 from . import doccer
 from .common import *
 from numpy import who, source, info as _info
-from scipy.special import comb
+from scipy.special import comb, factorial, factorial2, factorialk
 
 import sys
 

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -5,14 +5,11 @@ Functions which are common and require SciPy Base and Level 1 SciPy
 
 from __future__ import division, print_function, absolute_import
 
-from scipy.lib.six import xrange
-
 from numpy import exp, log, asarray, arange, newaxis, hstack, product, array, \
-                  where, zeros, extract, place, pi, sqrt, eye, poly1d, dot, \
-                  r_, rollaxis, sum, fromstring, ndarray
+                  zeros, eye, poly1d, r_, rollaxis, sum, fromstring
 
-__all__ = ['logsumexp', 'factorial','factorial2','factorialk',
-           'central_diff_weights', 'derivative', 'pade', 'lena', 'ascent', 'face']
+__all__ = ['logsumexp', 'central_diff_weights', 'derivative', 'pade', 'lena',
+           'ascent', 'face']
 
 # XXX: the factorial functions could move to scipy.special, and the others
 # to numpy perhaps?
@@ -88,159 +85,6 @@ def logsumexp(a, axis=None, b=None):
         out = log(sum(exp(a - a_max), axis=0))
     out += a_max
     return out
-
-
-def factorial(n,exact=False):
-    """
-    The factorial function, n! = special.gamma(n+1).
-
-    If exact is 0, then floating point precision is used, otherwise
-    exact long integer is computed.
-
-    - Array argument accepted only for exact=False case.
-    - If n<0, the return value is 0.
-
-    Parameters
-    ----------
-    n : int or array_like of ints
-        Calculate ``n!``.  Arrays are only supported with `exact` set
-        to False.  If ``n < 0``, the return value is 0.
-    exact : bool, optional
-        The result can be approximated rapidly using the gamma-formula
-        above.  If `exact` is set to True, calculate the
-        answer exactly using integer arithmetic. Default is False.
-
-    Returns
-    -------
-    nf : float or int
-        Factorial of `n`, as an integer or a float depending on `exact`.
-
-    Examples
-    --------
-    >>> arr = np.array([3,4,5])
-    >>> sc.factorial(arr, exact=False)
-    array([   6.,   24.,  120.])
-    >>> sc.factorial(5, exact=True)
-    120L
-
-    """
-    if exact:
-        if n < 0:
-            return 0
-        val = 1
-        for k in xrange(1,n+1):
-            val *= k
-        return val
-    else:
-        from scipy import special
-        n = asarray(n)
-        sv = special.errprint(0)
-        vals = special.gamma(n+1)
-        sv = special.errprint(sv)
-        return where(n >= 0,vals,0)
-
-
-def factorial2(n, exact=False):
-    """
-    Double factorial.
-
-    This is the factorial with every second value skipped, i.e.,
-    ``7!! = 7 * 5 * 3 * 1``.  It can be approximated numerically as::
-
-      n!! = special.gamma(n/2+1)*2**((m+1)/2)/sqrt(pi)  n odd
-          = 2**(n/2) * (n/2)!                           n even
-
-    Parameters
-    ----------
-    n : int or array_like
-        Calculate ``n!!``.  Arrays are only supported with `exact` set
-        to False.  If ``n < 0``, the return value is 0.
-    exact : bool, optional
-        The result can be approximated rapidly using the gamma-formula
-        above (default).  If `exact` is set to True, calculate the
-        answer exactly using integer arithmetic.
-
-    Returns
-    -------
-    nff : float or int
-        Double factorial of `n`, as an int or a float depending on
-        `exact`.
-
-    Examples
-    --------
-    >>> factorial2(7, exact=False)
-    array(105.00000000000001)
-    >>> factorial2(7, exact=True)
-    105L
-
-    """
-    if exact:
-        if n < -1:
-            return 0
-        if n <= 0:
-            return 1
-        val = 1
-        for k in xrange(n,0,-2):
-            val *= k
-        return val
-    else:
-        from scipy import special
-        n = asarray(n)
-        vals = zeros(n.shape,'d')
-        cond1 = (n % 2) & (n >= -1)
-        cond2 = (1-(n % 2)) & (n >= -1)
-        oddn = extract(cond1,n)
-        evenn = extract(cond2,n)
-        nd2o = oddn / 2.0
-        nd2e = evenn / 2.0
-        place(vals,cond1,special.gamma(nd2o+1)/sqrt(pi)*pow(2.0,nd2o+0.5))
-        place(vals,cond2,special.gamma(nd2e+1) * pow(2.0,nd2e))
-        return vals
-
-
-def factorialk(n,k,exact=True):
-    """
-    n(!!...!)  = multifactorial of order k
-    k times
-
-    Parameters
-    ----------
-    n : int, array_like
-        Calculate multifactorial. Arrays are only supported with exact
-        set to False. If `n` < 0, the return value is 0.
-    exact : bool, optional
-        If exact is set to True, calculate the answer exactly using
-        integer arithmetic.
-
-    Returns
-    -------
-    val : int
-        Multi factorial of `n`.
-
-    Raises
-    ------
-    NotImplementedError
-        Raises when exact is False
-
-    Examples
-    --------
-    >>> sc.factorialk(5, 1, exact=True)
-    120L
-    >>> sc.factorialk(5, 3, exact=True)
-    10L
-
-    """
-    if exact:
-        if n < 1-k:
-            return 0
-        if n <= 0:
-            return 1
-        val = 1
-        for j in xrange(n,0,-k):
-            val = val*j
-        return val
-    else:
-        raise NotImplementedError
 
 
 def central_diff_weights(Np, ndiv=1):

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -503,6 +503,9 @@ Other Special Functions
    expn         -- Exponential integral.
    exp1         -- Exponential integral of order 1 (for complex argument)
    expi         -- Another exponential integral -- Ei(x)
+   factorial    -- The factorial function, n! = special.gamma(n+1)
+   factorial2   -- Double factorial, (n!)!
+   factorialk   -- [+](...((n!)!)!...)! where there are k '!'
    shichi       -- Hyperbolic sine and cosine integrals.
    sici         -- Integral of the sinc and "cosinc" functions.
    spence       -- Dilogarithm integral.

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -20,7 +20,8 @@ import warnings
 __all__ = ['agm', 'ai_zeros', 'assoc_laguerre', 'bei_zeros', 'beip_zeros',
            'ber_zeros', 'bernoulli', 'berp_zeros', 'bessel_diff_formula',
            'bi_zeros', 'clpmn', 'comb', 'digamma', 'diric', 'ellipk', 'erf_zeros',
-           'erfcinv', 'erfinv', 'errprint', 'euler', 'fresnel_zeros',
+           'erfcinv', 'erfinv', 'errprint', 'euler', 'factorial',
+           'factorialk', 'factorial2', 'fresnel_zeros',
            'fresnelc_zeros', 'fresnels_zeros', 'gamma', 'gammaln', 'h1vp',
            'h2vp', 'hankel1', 'hankel2', 'hyp0f1', 'iv', 'ivp', 'jn_zeros',
            'jnjnp_zeros', 'jnp_zeros', 'jnyn_zeros', 'jv', 'jvp', 'kei_zeros',
@@ -1262,3 +1263,151 @@ def perm(N, k, exact=False):
         elif not cond:
             vals = np.float64(0)
         return vals
+
+
+def factorial(n,exact=False):
+    """
+    The factorial function, n! = special.gamma(n+1).
+
+    If exact is 0, then floating point precision is used, otherwise
+    exact long integer is computed.
+
+    - Array argument accepted only for exact=False case.
+    - If n<0, the return value is 0.
+
+    Parameters
+    ----------
+    n : int or array_like of ints
+        Calculate ``n!``.  Arrays are only supported with `exact` set
+        to False.  If ``n < 0``, the return value is 0.
+    exact : bool, optional
+        The result can be approximated rapidly using the gamma-formula
+        above.  If `exact` is set to True, calculate the
+        answer exactly using integer arithmetic. Default is False.
+
+    Returns
+    -------
+    nf : float or int
+        Factorial of `n`, as an integer or a float depending on `exact`.
+
+    Examples
+    --------
+    >>> arr = np.array([3,4,5])
+    >>> sc.factorial(arr, exact=False)
+    array([   6.,   24.,  120.])
+    >>> sc.factorial(5, exact=True)
+    120L
+
+    """
+    if exact:
+        if n < 0:
+            return 0
+        val = 1
+        for k in xrange(1,n+1):
+            val *= k
+        return val
+    else:
+        n = asarray(n)
+        vals = gamma(n+1)
+        return where(n >= 0,vals,0)
+
+
+def factorial2(n, exact=False):
+    """
+    Double factorial.
+
+    This is the factorial with every second value skipped, i.e.,
+    ``7!! = 7 * 5 * 3 * 1``.  It can be approximated numerically as::
+
+      n!! = special.gamma(n/2+1)*2**((m+1)/2)/sqrt(pi)  n odd
+          = 2**(n/2) * (n/2)!                           n even
+
+    Parameters
+    ----------
+    n : int or array_like
+        Calculate ``n!!``.  Arrays are only supported with `exact` set
+        to False.  If ``n < 0``, the return value is 0.
+    exact : bool, optional
+        The result can be approximated rapidly using the gamma-formula
+        above (default).  If `exact` is set to True, calculate the
+        answer exactly using integer arithmetic.
+
+    Returns
+    -------
+    nff : float or int
+        Double factorial of `n`, as an int or a float depending on
+        `exact`.
+
+    Examples
+    --------
+    >>> factorial2(7, exact=False)
+    array(105.00000000000001)
+    >>> factorial2(7, exact=True)
+    105L
+
+    """
+    if exact:
+        if n < -1:
+            return 0
+        if n <= 0:
+            return 1
+        val = 1
+        for k in xrange(n,0,-2):
+            val *= k
+        return val
+    else:
+        n = asarray(n)
+        vals = zeros(n.shape,'d')
+        cond1 = (n % 2) & (n >= -1)
+        cond2 = (1-(n % 2)) & (n >= -1)
+        oddn = extract(cond1,n)
+        evenn = extract(cond2,n)
+        nd2o = oddn / 2.0
+        nd2e = evenn / 2.0
+        place(vals,cond1,gamma(nd2o+1)/sqrt(pi)*pow(2.0,nd2o+0.5))
+        place(vals,cond2,gamma(nd2e+1) * pow(2.0,nd2e))
+        return vals
+
+
+def factorialk(n,k,exact=True):
+    """
+    n(!!...!)  = multifactorial of order k
+    k times
+
+    Parameters
+    ----------
+    n : int
+        Calculate multifactorial. If `n` < 0, the return value is 0.
+    exact : bool, optional
+        If exact is set to True, calculate the answer exactly using
+        integer arithmetic.
+
+    Returns
+    -------
+    val : int
+        Multi factorial of `n`.
+
+    Raises
+    ------
+    NotImplementedError
+        Raises when exact is False
+
+    Examples
+    --------
+    >>> sc.factorialk(5, 1, exact=True)
+    120L
+    >>> sc.factorialk(5, 3, exact=True)
+    10L
+
+    """
+    if exact:
+        if n < 1-k:
+            return 0
+        if n <= 0:
+            return 1
+        val = 1
+        for j in xrange(n,0,-k):
+            val = val*j
+        return val
+    else:
+        raise NotImplementedError

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1394,7 +1394,7 @@ class TestExp(TestCase):
 
 class TestFactorialFunctions(TestCase):
     def test_factorial(self):
-        assert_array_almost_equal([6., 34., 120.],
+        assert_array_almost_equal([6., 24., 120.],
                 special.factorial([3, 4, 5], exact=False))
         assert_equal(special.factorial(5, exact=True), 120)
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1392,6 +1392,22 @@ class TestExp(TestCase):
         assert_array_almost_equal(ex1,exrl1,8)
 
 
+class TestFactorialFunctions(TestCase):
+    def test_factorial(self):
+        assert_array_almost_equal([6., 34., 120.],
+                special.factorial([3, 4, 5], exact=False))
+        assert_equal(special.factorial(5, exact=True), 120)
+
+    def test_factorial2(self):
+        assert_array_almost_equal([105., 384., 945.],
+                special.factorial2([7, 8, 9], exact=False))
+        assert_equal(special.factorial2(7, exact=True), 105)
+
+    def test_factorialk(self):
+        assert_equal(special.factorialk(5, 1, exact=True), 120)
+        assert_equal(special.factorialk(5, 3, exact=True), 10)
+
+
 class TestFresnel(TestCase):
     def test_fresnel(self):
         frs = array(special.fresnel(.5))


### PR DESCRIPTION
`scipy.misc.factorial`, `scipy.misc.factorial2` and `scipy.misc.factorialk` are moved to `scipy.special` in this PR. But they are also imported in `scipy.misc` for compatibility with existing code. Tests for them are added also.
