### PR TITLE
BUG: special.chndtr infinite loop (#3102)

### DIFF
--- a/scipy/special/cdflib/cdfchn.f
+++ b/scipy/special/cdflib/cdfchn.f
@@ -143,21 +143,21 @@ C     ..
 
    60 CONTINUE
    70 IF (which.EQ.2) GO TO 90
-      IF (.NOT. (x.LT.0.0D0)) GO TO 80
+      IF (x.GE.0.0D0) GO TO 80
       bound = 0.0D0
       status = -4
       RETURN
 
    80 CONTINUE
    90 IF (which.EQ.3) GO TO 110
-      IF (.NOT. (df.LE.0.0D0)) GO TO 100
+      IF (df.GT.0.0D0) GO TO 100
       bound = 0.0D0
       status = -5
       RETURN
 
   100 CONTINUE
   110 IF (which.EQ.4) GO TO 130
-      IF (.NOT. (pnonc.LT.0.0D0)) GO TO 120
+      IF (pnonc.GE.0.0D0) GO TO 120
       bound = 0.0D0
       status = -6
       RETURN

--- a/scipy/special/cdflib/cdfchn.f
+++ b/scipy/special/cdflib/cdfchn.f
@@ -112,6 +112,16 @@ C     ..
 C     .. External Subroutines ..
       EXTERNAL cumchn,dinvr,dstinv
 C     ..
+      IF (x.GT.inf) THEN
+          x = inf
+      END IF
+      IF (df.GT.inf) THEN
+          df = inf
+      END IF
+      IF (pnonc.GT.tent4) THEN
+          pnonc = tent4
+      END IF
+
       IF (.NOT. ((which.LT.1).OR. (which.GT.4))) GO TO 30
       IF (.NOT. (which.LT.1)) GO TO 10
       bound = 1.0D0

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -187,6 +187,9 @@ class TestCephes(TestCase):
                         rtol=1e-6, atol=0)
         assert_almost_equal(cephes.chndtr(np.inf, np.inf, 0), 2.0)
         assert_almost_equal(cephes.chndtr(2, 1, np.inf), 0.0)
+        assert_(np.isnan(cephes.chndtr(np.nan, 1, 2)))
+        assert_(np.isnan(cephes.chndtr(5, np.nan, 2)))
+        assert_(np.isnan(cephes.chndtr(5, 1, np.nan)))
 
     def test_chndtridf(self):
         assert_equal(cephes.chndtridf(0,0,1),5.0)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -185,6 +185,8 @@ class TestCephes(TestCase):
         assert_allclose(p, [1.21805009e-09, 2.81979982e-09, 6.25652736e-09,
                             1.33520017e-08, 2.74909967e-08],
                         rtol=1e-6, atol=0)
+        assert_almost_equal(cephes.chndtr(np.inf, np.inf, 0), 2.0)
+        assert_almost_equal(cephes.chndtr(2, 1, np.inf), 0.0)
 
     def test_chndtridf(self):
         assert_equal(cephes.chndtridf(0,0,1),5.0)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1853,5 +1853,10 @@ def test_docstrings():
                 assert_(re.search(regex, dist.__doc__) is None)
 
 
+def test_infinite_input():
+    assert_almost_equal(stats.skellam.sf(np.inf, 10, 11), 0)
+    assert_almost_equal(stats.ncx2._cdf(np.inf, 8, 0.1), 1)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
The comments in `cdfchn.f` say that the search ranges of `X`, `DF` and `PNONC` are limited, but in fact they are not. So the `cdfchn` will get stuck in an infinite loop if the input is infinite, which results in #3102.
Tests are not added because they will not return if they fail.
