### PR TITLE
special: handle the edge case lambda=0 in pdtr, pdtrc and pdtrik

### DIFF
--- a/scipy/special/cdflib/cdfpoi.f
+++ b/scipy/special/cdflib/cdfpoi.f
@@ -20,7 +20,7 @@ C     WHICH --> Integer indicating which  argument
 C               value is to be calculated from the others.
 C               Legal range: 1..3
 C               iwhich = 1 : Calculate P and Q from S and XLAM
-C               iwhich = 2 : Calculate A from P,Q and XLAM
+C               iwhich = 2 : Calculate S from P,Q and XLAM
 C               iwhich = 3 : Calculate XLAM from P,Q and S
 C                    INTEGER WHICH
 C
@@ -77,6 +77,7 @@ C     monotinicity of P with the other parameter.
 C
 C
 C**********************************************************************
+      IMPLICIT NONE
 C     .. Parameters ..
       DOUBLE PRECISION tol
       PARAMETER (tol=1.0D-8)
@@ -167,6 +168,12 @@ C     ..
           status = 0
 
       ELSE IF ((2).EQ. (which)) THEN
+          IF ((xlam .LT. 1.0D-2) .AND. (p .LT. 0.975D0)) THEN
+C             For sufficiently small xlam and p, the result is 0.0.
+              s = 0.0D0
+              status = 0
+              GO TO 260
+          END IF
           s = 5.0D0
           CALL dstinv(0.0D0,inf,0.5D0,0.5D0,5.0D0,atol,tol)
           status = 0

--- a/scipy/special/cephes/pdtr.c
+++ b/scipy/special/cephes/pdtr.c
@@ -29,7 +29,7 @@
  *
  * y = pdtr( k, m ) = igamc( k+1, m ).
  *
- * The arguments must both be positive.
+ * The arguments must both be nonnegative.
  *
  *
  *
@@ -69,7 +69,7 @@
  *
  * y = pdtrc( k, m ) = igam( k+1, m ).
  *
- * The arguments must both be positive.
+ * The arguments must both be nonnegative.
  *
  *
  *
@@ -133,9 +133,12 @@ double m;
 {
     double v;
 
-    if ((k < 0) || (m <= 0.0)) {
+    if ((k < 0) || (m < 0.0)) {
         mtherr("pdtrc", DOMAIN);
         return (NPY_NAN);
+    }
+    if (m == 0.0) {
+        return 0.0;
     }
     v = k + 1;
     return (igam(v, m));
@@ -148,9 +151,12 @@ double m;
 {
     double v;
 
-    if ((k < 0) || (m <= 0.0)) {
+    if ((k < 0) || (m < 0.0)) {
         mtherr("pdtr", DOMAIN);
         return (NPY_NAN);
+    }
+    if (m == 0.0) {
+        return 1.0;
     }
     v = k + 1;
     return (igamc(v, m));

--- a/scipy/special/cephes/pdtr.c
+++ b/scipy/special/cephes/pdtr.c
@@ -38,9 +38,9 @@
  * See igamc().
  *
  */
-/*							pdtrc()
+/*  pdtrc()
  *
- *	Complemented poisson distribution
+ *  Complemented poisson distribution
  *
  *
  *
@@ -78,9 +78,9 @@
  * See igam.c.
  *
  */
-/*							pdtri()
+/*  pdtri()
  *
- *	Inverse Poisson distribution
+ *  Inverse Poisson distribution
  *
  *
  *
@@ -119,7 +119,7 @@
  *                     k < 0
  *
  */
-
+
 /*
  * Cephes Math Library Release 2.3:  March, 1995
  * Copyright 1984, 1987, 1995 by Stephen L. Moshier
@@ -134,13 +134,12 @@ double m;
     double v;
 
     if ((k < 0) || (m <= 0.0)) {
-	mtherr("pdtrc", DOMAIN);
-	return (NPY_NAN);
+        mtherr("pdtrc", DOMAIN);
+        return (NPY_NAN);
     }
     v = k + 1;
     return (igam(v, m));
 }
-
 
 
 double pdtr(k, m)
@@ -150,8 +149,8 @@ double m;
     double v;
 
     if ((k < 0) || (m <= 0.0)) {
-	mtherr("pdtr", DOMAIN);
-	return (NPY_NAN);
+        mtherr("pdtr", DOMAIN);
+        return (NPY_NAN);
     }
     v = k + 1;
     return (igamc(v, m));
@@ -165,8 +164,8 @@ double y;
     double v;
 
     if ((k < 0) || (y < 0.0) || (y >= 1.0)) {
-	mtherr("pdtri", DOMAIN);
-	return (NPY_NAN);
+        mtherr("pdtri", DOMAIN);
+        return (NPY_NAN);
     }
     v = k + 1;
     v = igami(v, y);

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -660,7 +660,11 @@ class TestCephes(TestCase):
             cephes.pdtri(0.5,0.5)
 
     def test_pdtrik(self):
-        cephes.pdtrik(0.5,1)
+        k = cephes.pdtrik(0.5, 1)
+        assert_almost_equal(cephes.gammaincc(k + 1, 1), 0.5)
+        # Edge case: m = 0 or very small.
+        k = cephes.pdtrik([[0], [0.25], [0.95]], [0, 1e-20, 1e-6])
+        assert_array_equal(k, np.zeros((3, 3)))
 
     def test_pro_ang1(self):
         cephes.pro_ang1(1,1,1,0)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -641,10 +641,18 @@ class TestCephes(TestCase):
         cephes.pbwa(1,0)
 
     def test_pdtr(self):
-        cephes.pdtr(0,1)
+        val = cephes.pdtr(0, 1)
+        assert_almost_equal(val, np.exp(-1))
+        # Edge case: m = 0.
+        val = cephes.pdtr([0, 1, 2], 0.0)
+        assert_array_equal(val, [1, 1, 1])
 
     def test_pdtrc(self):
-        cephes.pdtrc(0,1)
+        val = cephes.pdtrc(0, 1)
+        assert_almost_equal(val, 1 - np.exp(-1))
+        # Edge case: m = 0.
+        val = cephes.pdtrc([0, 1, 2], 0.0)
+        assert_array_equal(val, [0, 0, 0])
 
     def test_pdtri(self):
         with warnings.catch_warnings():


### PR DESCRIPTION
This PR makes a few changes so that `special.pdtr`, `special.pdtrc` and `special.pdtrik` give the correct limiting value when the Poisson parameter lambda is 0.

In the case of `pdtrik`, the function now immediately returns 0 for `lambda` < 0.01 and `p` < 0.975.  This is a lot more than the simple edge case `lambda = 0`, but it is based on the following figure showing the results of computing `pdtrik` from master on a grid of values:

![pdtrik_plot](https://f.cloud.github.com/assets/321463/1759235/7643aaf0-669b-11e3-8065-f44a9d865b26.png)

The gray dots are where the result is 0.  The red dots are where `pdtrik` returns 1e+100; the "correct" value is 0 at those points.

The script to generate the plot is in a gist: https://gist.github.com/WarrenWeckesser/7995139
