### PR TITLE
Suppress warnings when running stats.test()

### DIFF
--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -2,17 +2,23 @@
 # Author: Nathan Woods 2013 (nquad &c)
 from __future__ import division, print_function, absolute_import
 
+import sys
+import warnings
 from functools import partial
 
 from . import _quadpack
-import sys
 import numpy
 from numpy import Inf
 
-__all__ = ['quad', 'dblquad', 'tplquad', 'nquad', 'quad_explain']
+__all__ = ['quad', 'dblquad', 'tplquad', 'nquad', 'quad_explain',
+           'IntegrationWarning']
 
 
 error = _quadpack.error
+
+
+class IntegrationWarning(UserWarning):
+    pass
 
 
 def quad_explain(output=sys.stdout):
@@ -312,8 +318,7 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
             else:
                 return retval[:-1] + (msg,)
         else:
-            import warnings
-            warnings.warn(msg)
+            warnings.warn(msg, IntegrationWarning)
             return retval[:-1]
     else:
         raise ValueError(msg)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1026,9 +1026,15 @@ class exponpow_gen(rv_continuous):
     -----
     The probability density function for `exponpow` is::
 
-        exponpow.pdf(x, b) = b * x**(b-1) * exp(1+x**b - exp(x**b))
+        exponpow.pdf(x, b) = b * x**(b-1) * exp(1 + x**b - exp(x**b))
 
-    for ``x >= 0``, ``b > 0``.
+    for ``x >= 0``, ``b > 0``.  Note that this is a different distribution
+    from the exponential power distribution that is also known under the names
+    "generalized normal" or "generalized Gaussian".
+
+    References
+    ----------
+    http://www.math.wm.edu/~leemis/chart/UDR/PDFs/Exponentialpower.pdf
 
     %(example)s
 

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -444,7 +444,7 @@ class poisson_gen(rv_discrete):
 
     def _ppf(self, q, mu):
         vals = ceil(special.pdtrik(q, mu))
-        vals1 = vals-1
+        vals1 = vals - 1
         temp = special.pdtr(vals1, mu)
         return np.where((temp >= q), vals1, vals)
 
@@ -674,7 +674,7 @@ class dlaplace_gen(rv_discrete):
 
         dlaplace.pmf(k) = tanh(a/2) * exp(-a*abs(k))
 
-    for ``a >0``.
+    for ``a > 0``.
 
     `dlaplace` takes ``a`` as shape parameter.
 
@@ -682,25 +682,20 @@ class dlaplace_gen(rv_discrete):
 
     """
     def _pmf(self, k, a):
-        return tanh(a/2.0)*exp(-a*abs(k))
+        return tanh(a/2.0) * exp(-a * abs(k))
 
     def _cdf(self, x, a):
         k = floor(x)
-        ind = (k >= 0)
-        const = exp(a)+1
-        olderr = np.seterr(all='ignore')
-        vals = np.where(ind, 1.0-exp(-a*k)/const, exp(a*(k+1))/const)
-        np.seterr(**olderr)
-        return vals
+        f = lambda k, a: 1.0 - exp(-a * k) / (exp(a) + 1)
+        f2 = lambda k, a: exp(a * (k+1)) / (exp(a) + 1)
+        return _lazywhere(k >= 0, (k, a), f=f, f2=f2)
 
     def _ppf(self, q, a):
-        const = 1.0/(1+exp(-a))
-        cons2 = 1+exp(a)
-        ind = q < const
-        vals = ceil(np.where(ind, log(q*cons2)/a-1, -log((1-q)*cons2)/a))
-        vals1 = (vals-1)
-        temp = self._cdf(vals1, a)
-        return np.where(temp >= q, vals1, vals)
+        const = 1 + exp(a)
+        vals = ceil(np.where(q < 1.0 / (1 + exp(-a)), log(q*const) / a - 1,
+                                                      -log((1-q) * const) / a))
+        vals1 = vals - 1
+        return np.where(self._cdf(vals1, a) >= q, vals1, vals)
 
     def _stats(self, a):
         ea = exp(a)

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -688,7 +688,10 @@ class dlaplace_gen(rv_discrete):
         k = floor(x)
         ind = (k >= 0)
         const = exp(a)+1
-        return np.where(ind, 1.0-exp(-a*k)/const, exp(a*(k+1))/const)
+        olderr = np.seterr(all='ignore')
+        vals = np.where(ind, 1.0-exp(-a*k)/const, exp(a*(k+1))/const)
+        np.seterr(**olderr)
+        return vals
 
     def _ppf(self, q, a):
         const = 1.0/(1+exp(-a))

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2023,10 +2023,15 @@ class rv_continuous(rv_generic):
             val = self._pdf(x, *args)
             return xlogy(val, val)
 
+        # upper limit is often inf, so suppress warnings when integrating
+        olderr = np.seterr(over='ignore')
         entr = -integrate.quad(integ, self.a, self.b)[0]
+        np.seterr(**olderr)
+
         if not np.isnan(entr):
             return entr
-        else:  # try with different limits if integration problems
+        else:
+            # try with different limits if integration problems
             low, upp = self.ppf([1e-10, 1. - 1e-10], *args)
             if np.isinf(self.b):
                 upper = upp

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -471,7 +471,7 @@ def valarray(shape, value=nan, typecode=None):
     return out
 
 
-def _lazywhere(cond, arrays, f, fillvalue):
+def _lazywhere(cond, arrays, f, fillvalue=None, f2=None):
     """
     np.where(cond, x, fillvalue) always evaluates x even where cond is False.
     This one only evaluates f(arr1[cond], arr2[cond], ...).
@@ -482,11 +482,27 @@ def _lazywhere(cond, arrays, f, fillvalue):
     >>> _lazywhere(a > 2, (a, b), f, np.nan)
     array([ nan,  nan,  21.,  32.])
 
-    Notice it assumes that all `arrays` are of the same shape.
+    Notice it assumes that all `arrays` are of the same shape, or can be
+    broadcasted together.
+
     """
+    if fillvalue is None:
+        if f2 is None:
+            raise ValueError("One of (fillvalue, f2) must be given.")
+        else:
+            fillvalue = np.nan
+    else:
+        if f2 is not None:
+            raise ValueError("Only one of (fillvalue, f2) can be given.")
+
+    arrays = np.broadcast_arrays(*arrays)
     temp = tuple(np.extract(cond, arr) for arr in arrays)
     out = valarray(shape(arrays[0]), value=fillvalue)
     np.place(out, cond, f(*temp))
+    if f2 is not None:
+        temp = tuple(np.extract(~cond, arr) for arr in arrays)
+        np.place(out, ~cond, f2(*temp))
+
     return out
 
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -663,7 +663,11 @@ class rv_generic(object):
 
     #  Central moments
     def _munp(self, n, *args):
-        return self.generic_moment(n, *args)
+        # Silence floating point warnings from integration.
+        olderr = np.seterr(all='ignore')
+        vals = self.generic_moment(n, *args)
+        np.seterr(**olderr)
+        return vals
 
     ## These are the methods you must define (standard form functions)
     ## NB: generic _pdf, _logpdf, _cdf are different for
@@ -2132,7 +2136,11 @@ class rv_continuous(rv_generic):
         else:
             invfac = 1.0
         kwds['args'] = args
-        return integrate.quad(fun, lb, ub, **kwds)[0] / invfac
+        # Silence floating point warnings from integration.
+        olderr = np.seterr(all='ignore')
+        vals = integrate.quad(fun, lb, ub, **kwds)[0] / invfac
+        np.seterr(**olderr)
+        return vals
 
 
 ## Handlers for generic case where xk and pk are given
@@ -3085,7 +3093,6 @@ class rv_discrete(rv_generic):
         low = max(min(-suppnmin, low), lb)
         upp = min(max(suppnmin, upp), ub)
         supp = np.arange(low, upp+1, self.inc)  # check limits
-        # print 'low, upp', low, upp
         tot = np.sum(fun(supp))
         diff = 1e100
         pos = upp + self.inc

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -1,8 +1,11 @@
 from __future__ import division, print_function, absolute_import
 
+import warnings
+
 import numpy as np
 import numpy.testing as npt
 
+from scipy import integrate
 from scipy import stats
 from common_tests import (check_normalization, check_moment, check_mean_expect,
         check_var_expect, check_skew_expect, check_kurt_expect,
@@ -177,120 +180,128 @@ def _silence_fp_errors(func):
 
 def test_cont_basic():
     # this test skips slow distributions
-    for distname, arg in distcont[:]:
-        if distname in distslow:
-            continue
-        distfn = getattr(stats, distname)
-        np.random.seed(765456)
-        sn = 500
-        rvs = distfn.rvs(size=sn, *arg)
-        sm = rvs.mean()
-        sv = rvs.var()
-        m, v = distfn.stats(*arg)
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=integrate.IntegrationWarning)
+        for distname, arg in distcont[:]:
+            if distname in distslow:
+                continue
+            distfn = getattr(stats, distname)
+            np.random.seed(765456)
+            sn = 500
+            rvs = distfn.rvs(size=sn, *arg)
+            sm = rvs.mean()
+            sv = rvs.var()
+            m, v = distfn.stats(*arg)
 
-        yield check_sample_meanvar_, distfn, arg, m, v, sm, sv, sn, distname + \
-              'sample mean test'
-        yield check_cdf_ppf, distfn, arg, distname
-        yield check_sf_isf, distfn, arg, distname
-        yield check_pdf, distfn, arg, distname
-        yield check_pdf_logpdf, distfn, arg, distname
-        yield check_cdf_logcdf, distfn, arg, distname
-        yield check_sf_logsf, distfn, arg, distname
-        if distname in distmissing:
-            alpha = 0.01
-            yield check_distribution_rvs, distname, arg, alpha, rvs
+            yield check_sample_meanvar_, distfn, arg, m, v, sm, sv, sn, \
+                   distname + 'sample mean test'
+            yield check_cdf_ppf, distfn, arg, distname
+            yield check_sf_isf, distfn, arg, distname
+            yield check_pdf, distfn, arg, distname
+            yield check_pdf_logpdf, distfn, arg, distname
+            yield check_cdf_logcdf, distfn, arg, distname
+            yield check_sf_logsf, distfn, arg, distname
+            if distname in distmissing:
+                alpha = 0.01
+                yield check_distribution_rvs, distname, arg, alpha, rvs
 
-        locscale_defaults = (0, 1)
-        meths = [distfn.pdf, distfn.logpdf, distfn.cdf, distfn.logcdf,
-                 distfn.logsf]
-        # make sure arguments are within support
-        spec_x = {'frechet_l': -0.5, 'weibull_max': -0.5, 'levy_l': -0.5,
-                  'pareto': 1.5, 'tukeylambda': 0.3}
-        x = spec_x.get(distname, 0.5)
-        yield check_named_args, distfn, x, arg, locscale_defaults, meths
+            locscale_defaults = (0, 1)
+            meths = [distfn.pdf, distfn.logpdf, distfn.cdf, distfn.logcdf,
+                     distfn.logsf]
+            # make sure arguments are within support
+            spec_x = {'frechet_l': -0.5, 'weibull_max': -0.5, 'levy_l': -0.5,
+                      'pareto': 1.5, 'tukeylambda': 0.3}
+            x = spec_x.get(distname, 0.5)
+            yield check_named_args, distfn, x, arg, locscale_defaults, meths
 
-        # Entropy
-        skp = npt.dec.skipif
-        yield check_entropy, distfn, arg, distname
+            # Entropy
+            skp = npt.dec.skipif
+            yield check_entropy, distfn, arg, distname
 
-        if distfn.numargs == 0:
-            yield skp(NUMPY_BELOW_1_7)(check_vecentropy), distfn, arg
-        if distfn.__class__._entropy != stats.rv_continuous._entropy:
-            yield check_private_entropy, distfn, arg, stats.rv_continuous
+            if distfn.numargs == 0:
+                yield skp(NUMPY_BELOW_1_7)(check_vecentropy), distfn, arg
+            if distfn.__class__._entropy != stats.rv_continuous._entropy:
+                yield check_private_entropy, distfn, arg, stats.rv_continuous
 
-        yield check_edge_support, distfn, arg
+            yield check_edge_support, distfn, arg
 
-        knf = npt.dec.knownfailureif
-        yield knf(distname == 'truncnorm')(check_ppf_private), distfn, arg,\
-                distname
+            knf = npt.dec.knownfailureif
+            yield knf(distname == 'truncnorm')(check_ppf_private), distfn, \
+                      arg, distname
 
 @npt.dec.slow
 def test_cont_basic_slow():
     # same as above for slow distributions
-    for distname, arg in distcont[:]:
-        if distname not in distslow:
-            continue
-        distfn = getattr(stats, distname)
-        np.random.seed(765456)
-        sn = 500
-        rvs = distfn.rvs(size=sn,*arg)
-        sm = rvs.mean()
-        sv = rvs.var()
-        m, v = distfn.stats(*arg)
-        yield check_sample_meanvar_, distfn, arg, m, v, sm, sv, sn, distname + \
-              'sample mean test'
-        yield check_cdf_ppf, distfn, arg, distname
-        yield check_sf_isf, distfn, arg, distname
-        yield check_pdf, distfn, arg, distname
-        yield check_pdf_logpdf, distfn, arg, distname
-        yield check_cdf_logcdf, distfn, arg, distname
-        yield check_sf_logsf, distfn, arg, distname
-        # yield check_oth, distfn, arg # is still missing
-        if distname in distmissing:
-            alpha = 0.01
-            yield check_distribution_rvs, distname, arg, alpha, rvs
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=integrate.IntegrationWarning)
+        for distname, arg in distcont[:]:
+            if distname not in distslow:
+                continue
+            distfn = getattr(stats, distname)
+            np.random.seed(765456)
+            sn = 500
+            rvs = distfn.rvs(size=sn,*arg)
+            sm = rvs.mean()
+            sv = rvs.var()
+            m, v = distfn.stats(*arg)
+            yield check_sample_meanvar_, distfn, arg, m, v, sm, sv, sn, \
+                  distname + 'sample mean test'
+            yield check_cdf_ppf, distfn, arg, distname
+            yield check_sf_isf, distfn, arg, distname
+            yield check_pdf, distfn, arg, distname
+            yield check_pdf_logpdf, distfn, arg, distname
+            yield check_cdf_logcdf, distfn, arg, distname
+            yield check_sf_logsf, distfn, arg, distname
+            # yield check_oth, distfn, arg # is still missing
+            if distname in distmissing:
+                alpha = 0.01
+                yield check_distribution_rvs, distname, arg, alpha, rvs
 
-        locscale_defaults = (0, 1)
-        meths = [distfn.pdf, distfn.logpdf, distfn.cdf, distfn.logcdf,
-                 distfn.logsf]
-        # make sure arguments are within support
-        x = 0.5
-        if distname == 'invweibull':
-            arg = (1,)
-        elif distname == 'ksone':
-            arg = (3,)
-        yield check_named_args, distfn, x, arg, locscale_defaults, meths
+            locscale_defaults = (0, 1)
+            meths = [distfn.pdf, distfn.logpdf, distfn.cdf, distfn.logcdf,
+                     distfn.logsf]
+            # make sure arguments are within support
+            x = 0.5
+            if distname == 'invweibull':
+                arg = (1,)
+            elif distname == 'ksone':
+                arg = (3,)
+            yield check_named_args, distfn, x, arg, locscale_defaults, meths
 
-        # Entropy
-        skp = npt.dec.skipif
-        ks_cond = distname in ['ksone', 'kstwobign']
-        yield skp(ks_cond)(check_entropy), distfn, arg, distname
+            # Entropy
+            skp = npt.dec.skipif
+            ks_cond = distname in ['ksone', 'kstwobign']
+            yield skp(ks_cond)(check_entropy), distfn, arg, distname
 
-        if distfn.numargs == 0:
-            yield skp(NUMPY_BELOW_1_7)(check_vecentropy), distfn, arg
-        if distfn.__class__._entropy != stats.rv_continuous._entropy:
-            yield check_private_entropy, distfn, arg, stats.rv_continuous
+            if distfn.numargs == 0:
+                yield skp(NUMPY_BELOW_1_7)(check_vecentropy), distfn, arg
+            if distfn.__class__._entropy != stats.rv_continuous._entropy:
+                yield check_private_entropy, distfn, arg, stats.rv_continuous
 
-        yield check_edge_support, distfn, arg
+            yield check_edge_support, distfn, arg
 
 
 @npt.dec.slow
 def test_moments():
-    knf = npt.dec.knownfailureif
-    fail_normalization = set(['vonmises', 'ksone'])
-    fail_higher = set(['vonmises', 'ksone', 'ncf'])
-    for distname, arg in distcont[:]:
-        distfn = getattr(stats, distname)
-        m, v, s, k = distfn.stats(*arg, moments='mvsk')
-        cond1, cond2 = distname in fail_normalization, distname in fail_higher
-        msg = distname + ' fails moments'
-        yield knf(cond1, msg)(check_normalization), distfn, arg, distname
-        yield knf(cond2, msg)(check_mean_expect), distfn, arg, m, distname
-        yield knf(cond2, msg)(check_var_expect), distfn, arg, m, v, distname
-        yield knf(cond2, msg)(check_skew_expect), distfn, arg, m, v, s, distname
-        yield knf(cond2, msg)(check_kurt_expect), distfn, arg, m, v, k, distname
-        yield check_loc_scale, distfn, arg, m, v, distname
-        yield check_moment, distfn, arg, m, v, distname
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=integrate.IntegrationWarning)
+        knf = npt.dec.knownfailureif
+        fail_normalization = set(['vonmises', 'ksone'])
+        fail_higher = set(['vonmises', 'ksone', 'ncf'])
+        for distname, arg in distcont[:]:
+            distfn = getattr(stats, distname)
+            m, v, s, k = distfn.stats(*arg, moments='mvsk')
+            cond1, cond2 = distname in fail_normalization, distname in fail_higher
+            msg = distname + ' fails moments'
+            yield knf(cond1, msg)(check_normalization), distfn, arg, distname
+            yield knf(cond2, msg)(check_mean_expect), distfn, arg, m, distname
+            yield knf(cond2, msg)(check_var_expect), distfn, arg, m, v, distname
+            yield knf(cond2, msg)(check_skew_expect), distfn, arg, m, v, s, \
+                  distname
+            yield knf(cond2, msg)(check_kurt_expect), distfn, arg, m, v, k, \
+                  distname
+            yield check_loc_scale, distfn, arg, m, v, distname
+            yield check_moment, distfn, arg, m, v, distname
 
 
 def check_sample_meanvar_(distfn, arg, m, v, sm, sv, sn, msg):

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -326,12 +326,6 @@ def check_sample_var(sv,n, popvar):
             (chi2,pval,popvar,sv))
 
 
-def check_sample_skew_kurt(distfn, arg, ss, sk, msg):
-    skew,kurt = distfn.stats(moments='sk',*arg)
-    check_sample_meanvar(sk, kurt, msg + 'sample kurtosis test')
-    check_sample_meanvar(ss, skew, msg + 'sample skew test')
-
-
 def check_cdf_ppf(distfn,arg,msg):
     values = [0.001, 0.5, 0.999]
     npt.assert_almost_equal(distfn.cdf(distfn.ppf(values, *arg), *arg),


### PR DESCRIPTION
Test output is clean now. Filtering integration warnings is a bit coarse, but that's OK I think because warnings will be raised regularly (most distributions have a limit of `inf`).

Also clarify what `stats.exponpow` is. Not sure we should keep it like that though, definition is obscure.
