### PR TITLE
ENH: Add k-sample Anderson-Darling test to stats module

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -125,6 +125,7 @@ Juan Luis Cano for refactorings in lti, sparse docs improvements and some
 Pawel Chojnacki for simple documentation fixes.
 Gert-Ludwig Ingold for contributions to special functions.
 Joris Vankerschaver for multivariate Gaussian functionality.
+Jörg Dietrich for the k-sample Anderson Darling test.
 
 
 Institutions

--- a/doc/release/0.14.0-notes.rst
+++ b/doc/release/0.14.0-notes.rst
@@ -39,6 +39,13 @@ Multivariate random variables
 A new class `scipy.stats.multivariate_normal` with functionality for 
 multivariate normal random variables has been added.
 
+k-sample Anderson-Darling test
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The new function `scipy.stats.anderson_ksamp` computes the k-sample
+Anderson-Darling test for the null hypothesis that k samples come from
+the same parent population.
+
 ``scipy.signal`` improvements
 -----------------------------
 

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -271,6 +271,7 @@ which work for masked arrays.
    levene
    shapiro
    anderson
+   anderson_ksamp
    binom_test
    fligner
    mood

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1264,9 +1264,9 @@ def anderson_ksamp(samples, discrete=False):
 
     References
     ----------
-    .. [1] Scholz, F. W & Stephens, M. A. (1987), K-Sample Anderson-Darling
-           Tests, Journal of the American Statistical Association, Vol. 82,
-           pp. 918-924.
+    .. [1] Scholz, F. W and Stephens, M. A. (1987), K-Sample
+           Anderson-Darling Tests, Journal of the American Statistical
+           Association, Vol. 82, pp. 918-924.
 
     Examples:
     ---------

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1259,9 +1259,9 @@ def anderson_ksamp(samples, midrank=True):
     midrank empirical distribution function. This test is applicable
     to continuous and discrete data. If midrank is set to False, the
     right side empirical distribution is used for a test for discrete
-    data. According to [1]_, the two test statistics differ only
-    slightly if a few collisions due to round-off errors occur in the
-    test not adjusted for ties between samples.
+    data. According to [1]_, the two discrete test statistics differ
+    only slightly if a few collisions due to round-off errors occur in
+    the test not adjusted for ties between samples.
 
     .. versionadded:: 0.14.0
 

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1137,7 +1137,7 @@ def _anderson_ksamp_midrank(samples, Z, Zstar, k, n, N):
 
     Parameters
     ----------
-    samples : array_like
+    samples : sequence of 1-D array_like
         Array of sample arrays.
     Z : array_like
         Sorted array of all observations.
@@ -1158,8 +1158,11 @@ def _anderson_ksamp_midrank(samples, Z, Zstar, k, n, N):
 
     A2akN = 0.
     Z_ssorted_left = Z.searchsorted(Zstar, 'left')
-    lj = Z.searchsorted(Zstar, 'right') - Z_ssorted_left
-    Bj = Z.searchsorted(Zstar) + lj / 2.
+    if N == Zstar.size:
+        lj = 1.
+    else:
+        lj = Z.searchsorted(Zstar, 'right') - Z_ssorted_left
+    Bj = Z_ssorted_left + lj / 2.
     for i in arange(0, k):
         s = np.sort(samples[i])
         s_ssorted_right = s.searchsorted(Zstar, side='right')
@@ -1179,7 +1182,7 @@ def _anderson_ksamp_right(samples, Z, Zstar, k, n, N):
 
     Parameters
     ----------
-    samples : array_like
+    samples : sequence of 1-D array_like
         Array of sample arrays.
     Z : array_like
         Sorted array of all observations.
@@ -1221,7 +1224,7 @@ def anderson_ksamp(samples, midrank=True):
 
     Parameters
     ----------
-    samples : array_like
+    samples : sequence of 1-D array_like
         Array of sample data in arrays.
     midrank : bool, optional
         Type of Anderson-Darling test which is computed. Default is
@@ -1230,10 +1233,9 @@ def anderson_ksamp(samples, midrank=True):
 
     Returns
     -------
-    Tk : float
-        Normalized k-sample Anderson-Darling test statistic, not adjusted for
-        ties.
-    tm : array
+    A2 : float
+        Normalized k-sample Anderson-Darling test statistic.
+    critical : array
         The critical values for significance levels 25%, 10%, 5%, 2.5%, 1%.
     p : float
         An approximate significance level at which the null hypothesis for the
@@ -1333,20 +1335,20 @@ def anderson_ksamp(samples, midrank=True):
     d = (2*h + 6)*k**2 - 4*h*k
     sigmasq = (a*N**3 + b*N**2 + c*N + d) / ((N - 1.) * (N - 2.) * (N - 3.))
     m = k - 1
-    Tk = (A2kN - m) / math.sqrt(sigmasq)
+    A2 = (A2kN - m) / math.sqrt(sigmasq)
 
     # The b_i values are the interpolation coefficients from Table 2
     # of Scholz and Stephens 1987
     b0 = np.array([0.675, 1.281, 1.645, 1.96, 2.326])
     b1 = np.array([-0.245, 0.25, 0.678, 1.149, 1.822])
     b2 = np.array([-0.105, -0.305, -0.362, -0.391, -0.396])
-    tm = b0 + b1 / math.sqrt(m) + b2 / m
-    pf = np.polyfit(tm, log(np.array([0.25, 0.1, 0.05, 0.025, 0.01])), 2)
-    if Tk < tm.min() or Tk > tm.max():
+    critical = b0 + b1 / math.sqrt(m) + b2 / m
+    pf = np.polyfit(critical, log(np.array([0.25, 0.1, 0.05, 0.025, 0.01])), 2)
+    if A2 < critical.min() or A2 > critical.max():
         warnings.warn("approximate p-value will be computed by extrapolation")
 
-    p = math.exp(np.polyval(pf, Tk))
-    return Tk, tm, p
+    p = math.exp(np.polyval(pf, A2))
+    return A2, critical, p
 
 
 def ansari(x,y):

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1227,9 +1227,10 @@ def anderson_ksamp(samples, midrank=True):
     samples : sequence of 1-D array_like
         Array of sample data in arrays.
     midrank : bool, optional
-        Type of Anderson-Darling test which is computed. Default is
-        the midrank test applicable to continuous and discrete
-        populations.
+        Type of Anderson-Darling test which is computed. Default
+        (True) is the midrank test applicable to continuous and
+        discrete populations. If False, the right side empirical
+        distribution is used.
 
     Returns
     -------

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1131,9 +1131,9 @@ def anderson(x,dist='norm'):
     return A2, critical, sig
 
 
-def _anderson_ksamp_both(samples, Z, Zstar, k, n, N):
+def _anderson_ksamp_midrank(samples, Z, Zstar, k, n, N):
     """
-    Compute A2akN equation 7 of Scholz & Stephens.
+    Compute A2akN equation 7 of Scholz and Stephens.
 
     Parameters
     ----------
@@ -1173,7 +1173,7 @@ def _anderson_ksamp_both(samples, Z, Zstar, k, n, N):
     return A2akN
 
 
-def _anderson_ksamp_discrete(samples, Z, Zstar, k, n, N):
+def _anderson_ksamp_right(samples, Z, Zstar, k, n, N):
     """
     Compute A2akN equation 6 of Scholz & Stephens.
 
@@ -1210,7 +1210,7 @@ def _anderson_ksamp_discrete(samples, Z, Zstar, k, n, N):
     return A2kN
 
 
-def anderson_ksamp(samples, discrete=False):
+def anderson_ksamp(samples, midrank=True):
     """The Anderson-Darling test for k-samples.
 
     The k-sample Anderson-Darling test is a modification of the
@@ -1223,9 +1223,10 @@ def anderson_ksamp(samples, discrete=False):
     ----------
     samples : array_like
         Array of sample data in arrays.
-    discrete : bool, optional
-        Type of Anderson-Darling test which is computed. Default is a test
-        applicable to discrete and continous distributions.
+    midrank : bool, optional
+        Type of Anderson-Darling test which is computed. Default is
+        the midrank test applicable to continuous and discrete
+        populations.
 
     Returns
     -------
@@ -1252,14 +1253,15 @@ def anderson_ksamp(samples, discrete=False):
     Notes
     -----
     [1]_ Defines three versions of the k-sample Anderson-Darling test:
-    one for continous distributions and two for discrete
-    distributions, in which ties between samples may occur. The latter
-    variant of the test is also applicable to continuous data. By
-    default, this routine computes the test for continuous and
-    discrete data. If discrete is set to True, the test for discrete
-    data is computed. According to [1]_, the two test statistics
-    differ only slightly if a few collisions due to round-off errors
-    occur in the test not adjusted for ties between samples.
+    one for continuous distributions and two for discrete
+    distributions, in which ties between samples may occur. The
+    default of this routine is to compute the version based on the
+    midrank empirical distribution function. This test is applicable
+    to continuous and discrete data. If midrank is set to False, the
+    right side empirical distribution is used for a test for discrete
+    data. According to [1]_, the two test statistics differ only
+    slightly if a few collisions due to round-off errors occur in the
+    test not adjusted for ties between samples.
 
     .. versionadded:: 0.14.0
 
@@ -1314,10 +1316,10 @@ def anderson_ksamp(samples, discrete=False):
         raise ValueError("anderson_ksamp encountered sample without "
                          "observations")
 
-    if discrete:
-        A2kN = _anderson_ksamp_discrete(samples, Z, Zstar, k, n, N)
+    if midrank:
+        A2kN = _anderson_ksamp_midrank(samples, Z, Zstar, k, n, N)
     else:
-        A2kN = _anderson_ksamp_both(samples, Z, Zstar, k, n, N)
+        A2kN = _anderson_ksamp_right(samples, Z, Zstar, k, n, N)
 
     h = (1. / arange(1, N)).sum()
     H = (1. / n).sum()

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1335,6 +1335,8 @@ def anderson_ksamp(samples, discrete=False):
     m = k - 1
     Tk = (A2kN - m) / math.sqrt(sigmasq)
 
+    # The b_i values are the interpolation coefficients from Table 2
+    # of Scholz and Stephens 1987
     b0 = np.array([0.675, 1.281, 1.645, 1.96, 2.326])
     b1 = np.array([-0.245, 0.25, 0.678, 1.149, 1.822])
     b2 = np.array([-0.105, -0.305, -0.362, -0.391, -0.396])

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1302,12 +1302,10 @@ def anderson_ksamp(samples, discrete=False):
         raise ValueError("anderson_ksamp needs at least two samples")
 
     samples = list(map(np.asarray, samples))
-    Z = np.hstack(samples)
+    Z = np.sort(np.hstack(samples))
     N = Z.size
-    Z.sort()
     Zstar = np.unique(Z)
-    L = Zstar.size
-    if not L > 1:
+    if Zstar.size < 2:
         raise ValueError("anderson_ksamp needs more than one distinct "
                          "observation")
 

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1137,7 +1137,7 @@ def _anderson_ksamp_midrank(samples, Z, Zstar, k, n, N):
 
     Parameters
     ----------
-    samples : array_like
+    samples : sequence of 1-D array_like
         Array of sample arrays.
     Z : array_like
         Sorted array of all observations.
@@ -1158,7 +1158,10 @@ def _anderson_ksamp_midrank(samples, Z, Zstar, k, n, N):
 
     A2akN = 0.
     Z_ssorted_left = Z.searchsorted(Zstar, 'left')
-    lj = Z.searchsorted(Zstar, 'right') - Z_ssorted_left
+    if N == Zstar.size:
+        lj = 1.
+    else:
+        lj = Z.searchsorted(Zstar, 'right') - Z_ssorted_left
     Bj = Z.searchsorted(Zstar) + lj / 2.
     for i in arange(0, k):
         s = np.sort(samples[i])
@@ -1179,7 +1182,7 @@ def _anderson_ksamp_right(samples, Z, Zstar, k, n, N):
 
     Parameters
     ----------
-    samples : array_like
+    samples : sequence of 1-D array_like
         Array of sample arrays.
     Z : array_like
         Sorted array of all observations.
@@ -1221,7 +1224,7 @@ def anderson_ksamp(samples, midrank=True):
 
     Parameters
     ----------
-    samples : array_like
+    samples : sequence of 1-D array_like
         Array of sample data in arrays.
     midrank : bool, optional
         Type of Anderson-Darling test which is computed. Default is

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1285,21 +1285,22 @@ def anderson_ksamp(samples, midrank=True):
     not at the 2.5% level. The interpolation gives an approximate
     significance level of 3.1%:
 
-    >>> stats.anderson_ksamp(np.random.normal(size=50), ...
-            np.random.normal(loc=0.5, size=30))
-    (2.4632469079409978, array([ 0.325,  1.226,  1.961,  2.718,  3.752]),
-      0.03130207656720708)
+    >>> stats.anderson_ksamp([np.random.normal(size=50), 
+    ... np.random.normal(loc=0.5, size=30)])
+    (2.4615796189876105,
+      array([ 0.325,  1.226,  1.961,  2.718,  3.752]),
+      0.03134990135800783)
+
 
     The null hypothesis cannot be rejected for three samples from an
     identical distribution. The approximate p-value (87%) has to be
     computed by extrapolation and may not be very accurate:
 
-    >>> stats.anderson_ksamp(np.random.normal(size=50), ...
-            np.random.normal(size=30), np.random.normal(size=20))
-    (-0.72478622084152444,
-      array([ 0.44925884,  1.3052767,  1.9434184,  2.57696569,  3.41634856]),
-      0.8732440333177699)
-
+    >>> stats.anderson_ksamp([np.random.normal(size=50),
+    ... np.random.normal(size=30), np.random.normal(size=20)])
+    (-0.73091722665244196,
+      array([ 0.44925884,  1.3052767 ,  1.9434184 ,  2.57696569,  3.41634856]),
+      0.8789283903979661)
     """
 
     k = len(samples)

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1162,7 +1162,7 @@ def _anderson_ksamp_midrank(samples, Z, Zstar, k, n, N):
         lj = 1.
     else:
         lj = Z.searchsorted(Zstar, 'right') - Z_ssorted_left
-    Bj = Z.searchsorted(Zstar) + lj / 2.
+    Bj = Z_ssorted_left + lj / 2.
     for i in arange(0, k):
         s = np.sort(samples[i])
         s_ssorted_right = s.searchsorted(Zstar, side='right')
@@ -1233,10 +1233,9 @@ def anderson_ksamp(samples, midrank=True):
 
     Returns
     -------
-    Tk : float
-        Normalized k-sample Anderson-Darling test statistic, not adjusted for
-        ties.
-    tm : array
+    A2 : float
+        Normalized k-sample Anderson-Darling test statistic.
+    critical : array
         The critical values for significance levels 25%, 10%, 5%, 2.5%, 1%.
     p : float
         An approximate significance level at which the null hypothesis for the
@@ -1336,20 +1335,20 @@ def anderson_ksamp(samples, midrank=True):
     d = (2*h + 6)*k**2 - 4*h*k
     sigmasq = (a*N**3 + b*N**2 + c*N + d) / ((N - 1.) * (N - 2.) * (N - 3.))
     m = k - 1
-    Tk = (A2kN - m) / math.sqrt(sigmasq)
+    A2 = (A2kN - m) / math.sqrt(sigmasq)
 
     # The b_i values are the interpolation coefficients from Table 2
     # of Scholz and Stephens 1987
     b0 = np.array([0.675, 1.281, 1.645, 1.96, 2.326])
     b1 = np.array([-0.245, 0.25, 0.678, 1.149, 1.822])
     b2 = np.array([-0.105, -0.305, -0.362, -0.391, -0.396])
-    tm = b0 + b1 / math.sqrt(m) + b2 / m
-    pf = np.polyfit(tm, log(np.array([0.25, 0.1, 0.05, 0.025, 0.01])), 2)
-    if Tk < tm.min() or Tk > tm.max():
+    critical = b0 + b1 / math.sqrt(m) + b2 / m
+    pf = np.polyfit(critical, log(np.array([0.25, 0.1, 0.05, 0.025, 0.01])), 2)
+    if A2 < critical.min() or A2 > critical.max():
         warnings.warn("approximate p-value will be computed by extrapolation")
 
-    p = math.exp(np.polyval(pf, Tk))
-    return Tk, tm, p
+    p = math.exp(np.polyval(pf, A2))
+    return A2, critical, p
 
 
 def ansari(x,y):

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1138,22 +1138,22 @@ def _anderson_ksamp_both(samples, Z, Zstar, k, n, N):
     Parameters
     ----------
     samples : array_like
-        array of sample arrays
+        Array of sample arrays.
     Z : array_like
-        sorted array of all observations
+        Sorted array of all observations.
     Zstar : array_like
-        sorted array of unique observations
+        Sorted array of unique observations.
     k : int
-        number of samples
+        Number of samples.
     n : array_like
-        number of observations in each sample
+        Number of observations in each sample.
     N : int
-        total number of observations
+        Total number of observations.
 
     Returns
     -------
     A2aKN : float
-        The A2aKN statistics of Scholz and Stephens 1987
+        The A2aKN statistics of Scholz and Stephens 1987.
     """
 
     A2akN = 0.
@@ -1180,22 +1180,22 @@ def _anderson_ksamp_discrete(samples, Z, Zstar, k, n, N):
     Parameters
     ----------
     samples : array_like
-        array of sample arrays
+        Array of sample arrays.
     Z : array_like
-        sorted array of all observations
+        Sorted array of all observations.
     Zstar : array_like
-        sorted array of unique observations
+        Sorted array of unique observations.
     k : int
-        number of samples
+        Number of samples.
     n : array_like
-        number of observations in each sample
+        Number of observations in each sample.
     N : int
-        total number of observations
+        Total number of observations.
 
     Returns
     -------
     A2KN : float
-        The A2KN statistics of Scholz & Stephens
+        The A2KN statistics of Scholz and Stephens 1987.
     """
 
     A2kN = 0.
@@ -1222,21 +1222,21 @@ def anderson_ksamp(samples, discrete=False):
     Parameters
     ----------
     samples : array_like
-        array of sample data in arrays
+        Array of sample data in arrays.
     discrete : bool, optional
-        type of Anderson-Darling test which is computed. Default is a test
+        Type of Anderson-Darling test which is computed. Default is a test
         applicable to discrete and continous distributions.
 
     Returns
     -------
     Tk : float
         Normalized k-sample Anderson-Darling test statistic, not adjusted for
-        ties
+        ties.
     tm : array
-        The critical values for significance levels 25%, 10%, 5%, 2.5%, 1%
+        The critical values for significance levels 25%, 10%, 5%, 2.5%, 1%.
     p : float
         An approximate significance level at which the null hypothesis for the
-        provided samples can be rejected
+        provided samples can be rejected.
 
     Raises
     ------

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1221,7 +1221,6 @@ def anderson_ksamp(samples, discrete=False):
     ----------
     samples : array_like
         array of sample data in arrays
-
     discrete : bool, optional
         type of Anderson-Darling test which is computed. Default is a test
         applicable to discrete and continous distributions.
@@ -1299,6 +1298,7 @@ def anderson_ksamp(samples, discrete=False):
     k = len(samples)
     if (k < 2):
         raise ValueError("anderson_ksamp needs at least two samples")
+
     samples = list(map(np.asarray, samples))
     Z = np.hstack(samples)
     N = Z.size
@@ -1308,10 +1308,12 @@ def anderson_ksamp(samples, discrete=False):
     if not L > 1:
         raise ValueError("anderson_ksamp needs more than one distinct "
                          "observation")
+
     n = np.array([sample.size for sample in samples])
     if any(n == 0):
         raise ValueError("anderson_ksamp encountered sample without "
                          "observations")
+
     if discrete:
         A2kN = _anderson_ksamp_discrete(samples, Z, Zstar, k, n, N)
     else:
@@ -1338,6 +1340,7 @@ def anderson_ksamp(samples, discrete=False):
     pf = np.polyfit(tm, log(np.array([0.25, 0.1, 0.05, 0.025, 0.01])), 2)
     if Tk < tm.min() or Tk > tm.max():
         warnings.warn("approximate p-value will be computed by extrapolation")
+
     p = math.exp(np.polyval(pf, Tk))
     return Tk, tm, p
 

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1157,12 +1157,14 @@ def _anderson_ksamp_both(samples, Z, Zstar, k, n, N):
     """
 
     A2akN = 0.
-    lj = Z.searchsorted(Zstar, 'right') - Z.searchsorted(Zstar, 'left')
+    Z_ssorted_left = Z.searchsorted(Zstar, 'left')
+    lj = Z.searchsorted(Zstar, 'right') - Z_ssorted_left
     Bj = Z.searchsorted(Zstar) + lj / 2.
     for i in arange(0, k):
         s = np.sort(samples[i])
-        Mij = s.searchsorted(Zstar, side='right').astype(np.float)
-        fij = s.searchsorted(Zstar, 'right') - s.searchsorted(Zstar, 'left')
+        s_ssorted_right = s.searchsorted(Zstar, side='right')
+        Mij = s_ssorted_right.astype(np.float)
+        fij = s_ssorted_right - s.searchsorted(Zstar, 'left')
         Mij -= fij / 2.
         inner = lj / float(N) * (N * Mij - Bj * n[i])**2 / \
             (Bj * (N - Bj) - N * lj / 4.)
@@ -1278,7 +1280,7 @@ def anderson_ksamp(samples, discrete=False):
     not at the 2.5% level. The interpolation gives an approximate
     significance level of 3.1%:
 
-    >>> stats.anderson_ksamp(np.random.normal(size=50), \
+    >>> stats.anderson_ksamp(np.random.normal(size=50), ...
             np.random.normal(loc=0.5, size=30))
     (2.4632469079409978, array([ 0.325,  1.226,  1.961,  2.718,  3.752]),
       0.03130207656720708)
@@ -1287,7 +1289,7 @@ def anderson_ksamp(samples, discrete=False):
     identical distribution. The approximate p-value (87%) has to be
     computed by extrapolation and may not be very accurate:
 
-    >>> stats.anderson_ksamp(np.random.normal(size=50), \
+    >>> stats.anderson_ksamp(np.random.normal(size=50), ...
             np.random.normal(size=30), np.random.normal(size=20))
     (-0.72478622084152444,
       array([ 0.44925884,  1.3052767,  1.9434184,  2.57696569,  3.41634856]),

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1250,7 +1250,7 @@ def anderson_ksamp(samples, discrete=False):
 
     Notes
     -----
-    [1]_ Define three versions of the k-sample Anderson-Darling test:
+    [1]_ Defines three versions of the k-sample Anderson-Darling test:
     one for continous distributions and two for discrete
     distributions, in which ties between samples may occur. The latter
     variant of the test is also applicable to continuous data. By

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1153,7 +1153,7 @@ def _anderson_ksamp_both(samples, Z, Zstar, k, n, N):
     Returns
     -------
     A2aKN : float
-        The A2aKN statistics of Scholz & Stephens
+        The A2aKN statistics of Scholz and Stephens 1987
     """
 
     A2akN = 0.
@@ -1264,9 +1264,9 @@ def anderson_ksamp(samples, discrete=False):
 
     References
     ----------
-    .. [1] Scholz, F. W & Stephens, M. A. (1987), K-Sample Anderson-Darling
-           Tests, Journal of the American Statistical Association, Vol. 82,
-           pp. 918-924.
+    .. [1] Scholz, F. W and Stephens, M. A. (1987), K-Sample
+           Anderson-Darling Tests, Journal of the American Statistical
+           Association, Vol. 82, pp. 918-924.
 
     Examples:
     ---------

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1153,7 +1153,7 @@ def _anderson_ksamp_both(samples, Z, Zstar, k, n, N):
     Returns
     -------
     A2aKN : float
-        The A2aKN statistics of Scholz & Stephens
+        The A2aKN statistics of Scholz and Stephens 1987
     """
 
     A2akN = 0.

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -94,7 +94,7 @@ class TestAndersonKSamp(TestCase):
         t3 = np.array([34.0, 35.0, 39.0, 40.0, 43.0, 43.0, 44.0, 45.0])
         t4 = np.array([34.0, 34.8, 34.8, 35.4, 37.2, 37.8, 41.2, 42.8])
         Tk, tm, p = assert_warns(UserWarning, stats.anderson_ksamp, (t1, t2,
-                                 t3, t4), discrete=True)
+                                 t3, t4), midrank=False)
         assert_almost_equal(Tk, 4.449, 3)
         assert_array_almost_equal([0.4985, 1.3237, 1.9158, 2.4930, 3.2459],
                                   tm, 4)
@@ -110,7 +110,7 @@ class TestAndersonKSamp(TestCase):
         t3 = np.array([34.0, 35.0, 39.0, 40.0, 43.0, 43.0, 44.0, 45.0])
         t4 = np.array([34.0, 34.8, 34.8, 35.4, 37.2, 37.8, 41.2, 42.8])
         Tk, tm, p = assert_warns(UserWarning, stats.anderson_ksamp, (t1, t2,
-                                 t3, t4), discrete=False)
+                                 t3, t4), midrank=True)
         assert_almost_equal(Tk, 4.480, 3)
         assert_array_almost_equal([0.4985, 1.3237, 1.9158, 2.4930, 3.2459],
                                   tm, 4)
@@ -141,7 +141,7 @@ class TestAndersonKSamp(TestCase):
                61, 34]
         Tk, tm, p = assert_warns(UserWarning, stats.anderson_ksamp,
                                  (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10,
-                                  t11, t12, t13, t14), discrete=True)
+                                  t11, t12, t13, t14), midrank=False)
         assert_almost_equal(Tk, 3.288, 3)
         assert_array_almost_equal([0.5990, 1.3269, 1.8052, 2.2486, 2.8009],
                                   tm, 4)
@@ -171,7 +171,7 @@ class TestAndersonKSamp(TestCase):
                61, 34]
         Tk, tm, p = assert_warns(UserWarning, stats.anderson_ksamp,
                                  (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10,
-                                  t11, t12, t13, t14), discrete=False)
+                                  t11, t12, t13, t14), midrank=True)
         assert_almost_equal(Tk, 3.294, 3)
         assert_array_almost_equal([0.5990, 1.3269, 1.8052, 2.2486, 2.8009],
                                   tm, 4)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy.random import RandomState
 from numpy.testing import (TestCase, run_module_suite, assert_array_equal,
     assert_almost_equal, assert_array_less, assert_array_almost_equal,
-    assert_raises, assert_, assert_allclose, assert_equal, dec)
+    assert_raises, assert_, assert_allclose, assert_equal, dec, assert_warns)
 
 from scipy import stats
 
@@ -81,6 +81,64 @@ class TestAnderson(TestCase):
 
     def test_bad_arg(self):
         assert_raises(ValueError, stats.anderson, [1], dist='plate_of_shrimp')
+
+
+class TestAndersonKSamp(TestCase):
+    def test_example1(self):
+        # Example data from Scholz & Stephens (1987), originally
+        # published in Lehmann (1995, Nonparametrics, Statistical
+        # Methods Based on Ranks, p. 309)
+        # Pass a mixture of lists and arrays
+        t1 = [38.7, 41.5, 43.8, 44.5, 45.5, 46.0, 47.7, 58.0]
+        t2 = np.array([39.2, 39.3, 39.7, 41.4, 41.8, 42.9, 43.3, 45.8])
+        t3 = np.array([34.0, 35.0, 39.0, 40.0, 43.0, 43.0, 44.0, 45.0])
+        t4 = np.array([34.0, 34.8, 34.8, 35.4, 37.2, 37.8, 41.2, 42.8])
+        Tk, tm, p = assert_warns(UserWarning, stats.anderson_ksamp, t1, t2,
+                                 t3, t4)
+        assert_almost_equal(Tk, 4.449, 3)
+        assert_array_almost_equal([0.4985, 1.3237, 1.9158, 2.4930, 3.2459],
+                                  tm, 4)
+        assert_almost_equal(p, 0.0021, 4)
+
+    def test_example2(self):
+        # Example data taken from an earlier technical report of
+        # Scholz and Stephens
+        # Pass lists instead of arrays
+        t1 = [194, 15, 41, 29, 33, 181]
+        t2 = [413, 14, 58, 37, 100, 65, 9, 169, 447, 184, 36, 201, 118]
+        t3 = [34, 31, 18, 18, 67, 57, 62, 7, 22, 34]
+        t4 = [90, 10, 60, 186, 61, 49, 14, 24, 56, 20, 79, 84, 44, 59, 29,
+              118, 25, 156, 310, 76, 26, 44, 23, 62]
+        t5 = [130, 208, 70, 101, 208]
+        t6 = [74, 57, 48, 29, 502, 12, 70, 21, 29, 386, 59, 27]
+        t7 = [55, 320, 56, 104, 220, 239, 47, 246, 176, 182, 33]
+        t8 = [23, 261, 87, 7, 120, 14, 62, 47, 225, 71, 246, 21, 42, 20, 5,
+              12, 120, 11, 3, 14, 71, 11, 14, 11, 16, 90, 1, 16, 52, 95]
+        t9 = [97, 51, 11, 4, 141, 18, 142, 68, 77, 80, 1, 16, 106, 206, 82,
+              54, 31, 216, 46, 111, 39, 63, 18, 191, 18, 163, 24]
+        t10 = [50, 44, 102, 72, 22, 39, 3, 15, 197, 188, 79, 88, 46, 5, 5, 36,
+               22, 139, 210, 97, 30, 23, 13, 14]
+        t11 = [359, 9, 12, 270, 603, 3, 104, 2, 438]
+        t12 = [50, 254, 5, 283, 35, 12]
+        t13 = [487, 18, 100, 7, 98, 5, 85, 91, 43, 230, 3, 130]
+        t14 = [102, 209, 14, 57, 54, 32, 67, 59, 134, 152, 27, 14, 230, 66,
+               61, 34]
+        Tk, tm, p = assert_warns(UserWarning, stats.anderson_ksamp, t1, t2, t3,
+                                 t4, t5, t6, t7, t8, t9, t10, t11, t12, t13,
+                                 t14)
+        assert_almost_equal(Tk, 3.288, 3)
+        assert_array_almost_equal([0.5990, 1.3269, 1.8052, 2.2486, 2.8009],
+                                  tm, 4)
+        assert_almost_equal(p, 0.0041, 4)
+
+    def test_not_enough_samples(self):
+        assert_raises(ValueError, stats.anderson_ksamp, np.ones(5))
+
+    def test_no_distinct_observations(self):
+        assert_raises(ValueError, stats.anderson_ksamp, np.ones(5), np.ones(5))
+
+    def test_empty_sample(self):
+        assert_raises(ValueError, stats.anderson_ksamp, np.ones(5), [])
 
 
 class TestAnsari(TestCase):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -84,7 +84,7 @@ class TestAnderson(TestCase):
 
 
 class TestAndersonKSamp(TestCase):
-    def test_example1(self):
+    def test_example1a(self):
         # Example data from Scholz & Stephens (1987), originally
         # published in Lehmann (1995, Nonparametrics, Statistical
         # Methods Based on Ranks, p. 309)
@@ -93,14 +93,30 @@ class TestAndersonKSamp(TestCase):
         t2 = np.array([39.2, 39.3, 39.7, 41.4, 41.8, 42.9, 43.3, 45.8])
         t3 = np.array([34.0, 35.0, 39.0, 40.0, 43.0, 43.0, 44.0, 45.0])
         t4 = np.array([34.0, 34.8, 34.8, 35.4, 37.2, 37.8, 41.2, 42.8])
-        Tk, tm, p = assert_warns(UserWarning, stats.anderson_ksamp, t1, t2,
-                                 t3, t4)
+        Tk, tm, p = assert_warns(UserWarning, stats.anderson_ksamp, (t1, t2,
+                                 t3, t4), discrete=True)
         assert_almost_equal(Tk, 4.449, 3)
         assert_array_almost_equal([0.4985, 1.3237, 1.9158, 2.4930, 3.2459],
                                   tm, 4)
         assert_almost_equal(p, 0.0021, 4)
 
-    def test_example2(self):
+    def test_example1b(self):
+        # Example data from Scholz & Stephens (1987), originally
+        # published in Lehmann (1995, Nonparametrics, Statistical
+        # Methods Based on Ranks, p. 309)
+        # Pass arrays
+        t1 = np.array([38.7, 41.5, 43.8, 44.5, 45.5, 46.0, 47.7, 58.0])
+        t2 = np.array([39.2, 39.3, 39.7, 41.4, 41.8, 42.9, 43.3, 45.8])
+        t3 = np.array([34.0, 35.0, 39.0, 40.0, 43.0, 43.0, 44.0, 45.0])
+        t4 = np.array([34.0, 34.8, 34.8, 35.4, 37.2, 37.8, 41.2, 42.8])
+        Tk, tm, p = assert_warns(UserWarning, stats.anderson_ksamp, (t1, t2,
+                                 t3, t4), discrete=False)
+        assert_almost_equal(Tk, 4.480, 3)
+        assert_array_almost_equal([0.4985, 1.3237, 1.9158, 2.4930, 3.2459],
+                                  tm, 4)
+        assert_almost_equal(p, 0.0020, 4)
+
+    def test_example2a(self):
         # Example data taken from an earlier technical report of
         # Scholz and Stephens
         # Pass lists instead of arrays
@@ -123,10 +139,40 @@ class TestAndersonKSamp(TestCase):
         t13 = [487, 18, 100, 7, 98, 5, 85, 91, 43, 230, 3, 130]
         t14 = [102, 209, 14, 57, 54, 32, 67, 59, 134, 152, 27, 14, 230, 66,
                61, 34]
-        Tk, tm, p = assert_warns(UserWarning, stats.anderson_ksamp, t1, t2, t3,
-                                 t4, t5, t6, t7, t8, t9, t10, t11, t12, t13,
-                                 t14)
+        Tk, tm, p = assert_warns(UserWarning, stats.anderson_ksamp,
+                                 (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10,
+                                  t11, t12, t13, t14), discrete=True)
         assert_almost_equal(Tk, 3.288, 3)
+        assert_array_almost_equal([0.5990, 1.3269, 1.8052, 2.2486, 2.8009],
+                                  tm, 4)
+        assert_almost_equal(p, 0.0041, 4)
+
+    def test_example2b(self):
+        # Example data taken from an earlier technical report of
+        # Scholz and Stephens
+        t1 = [194, 15, 41, 29, 33, 181]
+        t2 = [413, 14, 58, 37, 100, 65, 9, 169, 447, 184, 36, 201, 118]
+        t3 = [34, 31, 18, 18, 67, 57, 62, 7, 22, 34]
+        t4 = [90, 10, 60, 186, 61, 49, 14, 24, 56, 20, 79, 84, 44, 59, 29,
+              118, 25, 156, 310, 76, 26, 44, 23, 62]
+        t5 = [130, 208, 70, 101, 208]
+        t6 = [74, 57, 48, 29, 502, 12, 70, 21, 29, 386, 59, 27]
+        t7 = [55, 320, 56, 104, 220, 239, 47, 246, 176, 182, 33]
+        t8 = [23, 261, 87, 7, 120, 14, 62, 47, 225, 71, 246, 21, 42, 20, 5,
+              12, 120, 11, 3, 14, 71, 11, 14, 11, 16, 90, 1, 16, 52, 95]
+        t9 = [97, 51, 11, 4, 141, 18, 142, 68, 77, 80, 1, 16, 106, 206, 82,
+              54, 31, 216, 46, 111, 39, 63, 18, 191, 18, 163, 24]
+        t10 = [50, 44, 102, 72, 22, 39, 3, 15, 197, 188, 79, 88, 46, 5, 5, 36,
+               22, 139, 210, 97, 30, 23, 13, 14]
+        t11 = [359, 9, 12, 270, 603, 3, 104, 2, 438]
+        t12 = [50, 254, 5, 283, 35, 12]
+        t13 = [487, 18, 100, 7, 98, 5, 85, 91, 43, 230, 3, 130]
+        t14 = [102, 209, 14, 57, 54, 32, 67, 59, 134, 152, 27, 14, 230, 66,
+               61, 34]
+        Tk, tm, p = assert_warns(UserWarning, stats.anderson_ksamp,
+                                 (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10,
+                                  t11, t12, t13, t14), discrete=False)
+        assert_almost_equal(Tk, 3.294, 3)
         assert_array_almost_equal([0.5990, 1.3269, 1.8052, 2.2486, 2.8009],
                                   tm, 4)
         assert_almost_equal(p, 0.0041, 4)
@@ -135,10 +181,11 @@ class TestAndersonKSamp(TestCase):
         assert_raises(ValueError, stats.anderson_ksamp, np.ones(5))
 
     def test_no_distinct_observations(self):
-        assert_raises(ValueError, stats.anderson_ksamp, np.ones(5), np.ones(5))
+        assert_raises(ValueError, stats.anderson_ksamp,
+                      (np.ones(5), np.ones(5)))
 
     def test_empty_sample(self):
-        assert_raises(ValueError, stats.anderson_ksamp, np.ones(5), [])
+        assert_raises(ValueError, stats.anderson_ksamp, (np.ones(5), []))
 
 
 class TestAnsari(TestCase):


### PR DESCRIPTION
This PR adds the k-sample Anderson-Darling test for continuous distributions as described by Scholz & Stephen (1987, Journal of the American Statistical Association, Vol. 82, pp. 918-924) to the stats module.
