### PR TITLE
WIP: speed up convolve2d a tiny bit

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -252,3 +252,4 @@ from ._peak_finding import *
 __all__ = [s for s in dir() if not s.startswith('_')]
 from numpy.testing import Tester
 test = Tester().test
+bench = Tester().bench

--- a/scipy/signal/benchmarks/bench_convolve2d.py
+++ b/scipy/signal/benchmarks/bench_convolve2d.py
@@ -1,0 +1,54 @@
+"""
+Check the speed of 2d convolution.
+
+"""
+from __future__ import division, print_function, absolute_import
+
+from itertools import product
+import time
+
+import numpy as np
+from numpy.testing import Tester, TestCase, assert_allclose
+
+from scipy.signal import convolve2d, correlate2d
+
+
+
+def bench_convolve2d():
+    np.random.seed(1234)
+
+    # sample a bunch of pairs of 2d arrays
+    tm_start = time.clock()
+    pairs = []
+    for ma, na, mb, nb in product((1, 2, 8, 13, 30), repeat=4):
+        a = np.random.randn(ma, na)
+        b = np.random.randn(mb, nb)
+        pairs.append((a, b))
+    tm_end = time.clock()
+    tm_total = tm_end - tm_start
+    print('time to sample random pairs of 2d arrays:')
+    print(tm_total)
+    print()
+
+    fns = (convolve2d, correlate2d)
+    modes = ('full', 'valid', 'same')
+    boundaries = ('fill', 'wrap', 'symm')
+
+    # compute 2d convolutions and correlations for each 2d array pair
+    tm_start = time.clock()
+    for a, b in pairs:
+        for fn, mode, boundary in product(fns, modes, boundaries):
+            if mode == 'valid':
+                if b.shape[0] > a.shape[0] or b.shape[1] > a.shape[1]:
+                    continue
+            fn(a, b, mode=mode, boundary=boundary)
+    tm_end = time.clock()
+    tm_total = tm_end - tm_start
+    print('time to compute 2d convolutions:')
+    print(tm_total)
+    print()
+
+
+if __name__ == '__main__':
+    Tester().bench()
+

--- a/scipy/signal/firfilter.c
+++ b/scipy/signal/firfilter.c
@@ -114,9 +114,6 @@ int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
   if (type_num < 0 || type_num > MAXTYPES) return -4;  /* Invalid type */
   type_size = elsizes[type_num];
 
-  if ((sum = calloc(type_size,2))==NULL) return -3; /* No memory */
-  value = sum + type_size;
-
   if (outsize == FULL) {Os[0] = Ns[0]+Nwin[0]-1; Os[1] = Ns[1]+Nwin[1]-1;}
   else if (outsize == SAME) {Os[0] = Ns[0]; Os[1] = Ns[1];}
   else if (outsize == VALID) {Os[0] = Ns[0]-Nwin[0]+1; Os[1] = Ns[1]-Nwin[1]+1;}
@@ -132,6 +129,7 @@ case 26: /* outsize=FULL | boundary=CIRCULAR | convolve=FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m;
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n;
       for (j=0; j < Nwin[0]; j++) {
@@ -149,10 +147,9 @@ case 26: /* outsize=FULL | boundary=CIRCULAR | convolve=FLIPPED */
           } else if (ind1 >= Ns[1]) {
             ind1 = ind1 - Ns[1];
           }
-          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          value = in + ind0_memory + ind1*instr[1];
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -163,6 +160,7 @@ case 10: /* outsize=FULL | boundary=CIRCULAR | convolve=NOT_FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m - Nwin[0] + 1;
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n - Nwin[1] + 1;
       for (j=0; j < Nwin[0]; j++) {
@@ -180,10 +178,9 @@ case 10: /* outsize=FULL | boundary=CIRCULAR | convolve=NOT_FLIPPED */
           } else if (ind1 >= Ns[1]) {
             ind1 = ind1 - Ns[1];
           }
-          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          value = in + ind0_memory + ind1*instr[1];
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -194,6 +191,7 @@ case 22: /* outsize=FULL | boundary=REFLECT | convolve=FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m;
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n;
       for (j=0; j < Nwin[0]; j++) {
@@ -211,10 +209,9 @@ case 22: /* outsize=FULL | boundary=REFLECT | convolve=FLIPPED */
           } else if (ind1 >= Ns[1]) {
             ind1 = Ns[1] + Ns[1] - 1 - ind1;
           }
-          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          value = in + ind0_memory + ind1*instr[1];
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -225,6 +222,7 @@ case 6: /* outsize=FULL | boundary=REFLECT | convolve=NOT_FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m - Nwin[0] + 1;
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n - Nwin[1] + 1;
       for (j=0; j < Nwin[0]; j++) {
@@ -242,10 +240,9 @@ case 6: /* outsize=FULL | boundary=REFLECT | convolve=NOT_FLIPPED */
           } else if (ind1 >= Ns[1]) {
             ind1 = Ns[1] + Ns[1] - 1 - ind1;
           }
-          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          value = in + ind0_memory + ind1*instr[1];
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -256,6 +253,7 @@ case 18: /* outsize=FULL | boundary=PAD | convolve=FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m;
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n;
       for (j=0; j < Nwin[0]; j++) {
@@ -271,7 +269,7 @@ case 18: /* outsize=FULL | boundary=PAD | convolve=FLIPPED */
         }
         for (k=0; k < Nwin[1]; k++) {
           if (bounds_pad_flag) {
-            memcpy(value, fillvalue, type_size);
+            value = fillvalue;
           } else {
             ind1 = new_n - k;
             if (ind1 < 0) {
@@ -280,15 +278,14 @@ case 18: /* outsize=FULL | boundary=PAD | convolve=FLIPPED */
               bounds_pad_flag = 1;
             }
             if (bounds_pad_flag) {
-              memcpy(value, fillvalue, type_size);
+              value = fillvalue;
             } else {
-              memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+              value = in + ind0_memory + ind1*instr[1];
             }
             bounds_pad_flag = 0;
           }
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -299,6 +296,7 @@ case 2: /* outsize=FULL | boundary=PAD | convolve=NOT_FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m - Nwin[0] + 1;
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n - Nwin[1] + 1;
       for (j=0; j < Nwin[0]; j++) {
@@ -314,7 +312,7 @@ case 2: /* outsize=FULL | boundary=PAD | convolve=NOT_FLIPPED */
         }
         for (k=0; k < Nwin[1]; k++) {
           if (bounds_pad_flag) {
-            memcpy(value, fillvalue, type_size);
+            value = fillvalue;
           } else {
             ind1 = new_n + k;
             if (ind1 < 0) {
@@ -323,15 +321,14 @@ case 2: /* outsize=FULL | boundary=PAD | convolve=NOT_FLIPPED */
               bounds_pad_flag = 1;
             }
             if (bounds_pad_flag) {
-              memcpy(value, fillvalue, type_size);
+              value = fillvalue;
             } else {
-              memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+              value = in + ind0_memory + ind1*instr[1];
             }
             bounds_pad_flag = 0;
           }
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -342,6 +339,7 @@ case 25: /* outsize=SAME | boundary=CIRCULAR | convolve=FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m + ((Nwin[0]-1) >> 1);
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n + ((Nwin[1]-1) >> 1);
       for (j=0; j < Nwin[0]; j++) {
@@ -359,10 +357,9 @@ case 25: /* outsize=SAME | boundary=CIRCULAR | convolve=FLIPPED */
           } else if (ind1 >= Ns[1]) {
             ind1 = ind1 - Ns[1];
           }
-          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          value = in + ind0_memory + ind1*instr[1];
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -373,6 +370,7 @@ case 9: /* outsize=SAME | boundary=CIRCULAR | convolve=NOT_FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m - ((Nwin[0]-1) >> 1);
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n - ((Nwin[1]-1) >> 1);
       for (j=0; j < Nwin[0]; j++) {
@@ -390,10 +388,9 @@ case 9: /* outsize=SAME | boundary=CIRCULAR | convolve=NOT_FLIPPED */
           } else if (ind1 >= Ns[1]) {
             ind1 = ind1 - Ns[1];
           }
-          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          value = in + ind0_memory + ind1*instr[1];
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -404,6 +401,7 @@ case 21: /* outsize=SAME | boundary=REFLECT | convolve=FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m + ((Nwin[0]-1) >> 1);
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n + ((Nwin[1]-1) >> 1);
       for (j=0; j < Nwin[0]; j++) {
@@ -421,10 +419,9 @@ case 21: /* outsize=SAME | boundary=REFLECT | convolve=FLIPPED */
           } else if (ind1 >= Ns[1]) {
             ind1 = Ns[1] + Ns[1] - 1 - ind1;
           }
-          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          value = in + ind0_memory + ind1*instr[1];
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -435,6 +432,7 @@ case 5: /* outsize=SAME | boundary=REFLECT | convolve=NOT_FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m - ((Nwin[0]-1) >> 1);
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n - ((Nwin[1]-1) >> 1);
       for (j=0; j < Nwin[0]; j++) {
@@ -452,10 +450,9 @@ case 5: /* outsize=SAME | boundary=REFLECT | convolve=NOT_FLIPPED */
           } else if (ind1 >= Ns[1]) {
             ind1 = Ns[1] + Ns[1] - 1 - ind1;
           }
-          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          value = in + ind0_memory + ind1*instr[1];
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -466,6 +463,7 @@ case 17: /* outsize=SAME | boundary=PAD | convolve=FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m + ((Nwin[0]-1) >> 1);
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n + ((Nwin[1]-1) >> 1);
       for (j=0; j < Nwin[0]; j++) {
@@ -481,7 +479,7 @@ case 17: /* outsize=SAME | boundary=PAD | convolve=FLIPPED */
         }
         for (k=0; k < Nwin[1]; k++) {
           if (bounds_pad_flag) {
-            memcpy(value, fillvalue, type_size);
+            value = fillvalue;
           } else {
             ind1 = new_n - k;
             if (ind1 < 0) {
@@ -490,15 +488,14 @@ case 17: /* outsize=SAME | boundary=PAD | convolve=FLIPPED */
               bounds_pad_flag = 1;
             }
             if (bounds_pad_flag) {
-              memcpy(value, fillvalue, type_size);
+              value = fillvalue;
             } else {
-              memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+              value = in + ind0_memory + ind1*instr[1];
             }
             bounds_pad_flag = 0;
           }
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -509,6 +506,7 @@ case 1: /* outsize=SAME | boundary=PAD | convolve=NOT_FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m - ((Nwin[0]-1) >> 1);
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n - ((Nwin[1]-1) >> 1);
       for (j=0; j < Nwin[0]; j++) {
@@ -524,7 +522,7 @@ case 1: /* outsize=SAME | boundary=PAD | convolve=NOT_FLIPPED */
         }
         for (k=0; k < Nwin[1]; k++) {
           if (bounds_pad_flag) {
-            memcpy(value, fillvalue, type_size);
+            value = fillvalue;
           } else {
             ind1 = new_n + k;
             if (ind1 < 0) {
@@ -533,15 +531,14 @@ case 1: /* outsize=SAME | boundary=PAD | convolve=NOT_FLIPPED */
               bounds_pad_flag = 1;
             }
             if (bounds_pad_flag) {
-              memcpy(value, fillvalue, type_size);
+              value = fillvalue;
             } else {
-              memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+              value = in + ind0_memory + ind1*instr[1];
             }
             bounds_pad_flag = 0;
           }
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -552,6 +549,7 @@ case 24: /* outsize=VALID | boundary=CIRCULAR | convolve=FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m + Nwin[0] - 1;
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n + Nwin[1] - 1;
       for (j=0; j < Nwin[0]; j++) {
@@ -569,10 +567,9 @@ case 24: /* outsize=VALID | boundary=CIRCULAR | convolve=FLIPPED */
           } else if (ind1 >= Ns[1]) {
             ind1 = ind1 - Ns[1];
           }
-          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          value = in + ind0_memory + ind1*instr[1];
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -583,6 +580,7 @@ case 8: /* outsize=VALID | boundary=CIRCULAR | convolve=NOT_FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m;
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n;
       for (j=0; j < Nwin[0]; j++) {
@@ -600,10 +598,9 @@ case 8: /* outsize=VALID | boundary=CIRCULAR | convolve=NOT_FLIPPED */
           } else if (ind1 >= Ns[1]) {
             ind1 = ind1 - Ns[1];
           }
-          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          value = in + ind0_memory + ind1*instr[1];
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -614,6 +611,7 @@ case 20: /* outsize=VALID | boundary=REFLECT | convolve=FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m + Nwin[0] - 1;
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n + Nwin[1] - 1;
       for (j=0; j < Nwin[0]; j++) {
@@ -631,10 +629,9 @@ case 20: /* outsize=VALID | boundary=REFLECT | convolve=FLIPPED */
           } else if (ind1 >= Ns[1]) {
             ind1 = Ns[1] + Ns[1] - 1 - ind1;
           }
-          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          value = in + ind0_memory + ind1*instr[1];
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -645,6 +642,7 @@ case 4: /* outsize=VALID | boundary=REFLECT | convolve=NOT_FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m;
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n;
       for (j=0; j < Nwin[0]; j++) {
@@ -662,10 +660,9 @@ case 4: /* outsize=VALID | boundary=REFLECT | convolve=NOT_FLIPPED */
           } else if (ind1 >= Ns[1]) {
             ind1 = Ns[1] + Ns[1] - 1 - ind1;
           }
-          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          value = in + ind0_memory + ind1*instr[1];
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -676,6 +673,7 @@ case 16: /* outsize=VALID | boundary=PAD | convolve=FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m + Nwin[0] - 1;
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n + Nwin[1] - 1;
       for (j=0; j < Nwin[0]; j++) {
@@ -691,7 +689,7 @@ case 16: /* outsize=VALID | boundary=PAD | convolve=FLIPPED */
         }
         for (k=0; k < Nwin[1]; k++) {
           if (bounds_pad_flag) {
-            memcpy(value, fillvalue, type_size);
+            value = fillvalue;
           } else {
             ind1 = new_n - k;
             if (ind1 < 0) {
@@ -700,15 +698,14 @@ case 16: /* outsize=VALID | boundary=PAD | convolve=FLIPPED */
               bounds_pad_flag = 1;
             }
             if (bounds_pad_flag) {
-              memcpy(value, fillvalue, type_size);
+              value = fillvalue;
             } else {
-              memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+              value = in + ind0_memory + ind1*instr[1];
             }
             bounds_pad_flag = 0;
           }
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -719,6 +716,7 @@ case 0: /* outsize=VALID | boundary=PAD | convolve=NOT_FLIPPED */
   for (m=0; m < Os[0]; m++) {
     new_m = m;
     for (n=0; n < Os[1]; n++) {
+      sum = out + m*outstr[0] + n*outstr[1];
       memset(sum, 0, type_size);
       new_n = n;
       for (j=0; j < Nwin[0]; j++) {
@@ -734,7 +732,7 @@ case 0: /* outsize=VALID | boundary=PAD | convolve=NOT_FLIPPED */
         }
         for (k=0; k < Nwin[1]; k++) {
           if (bounds_pad_flag) {
-            memcpy(value, fillvalue, type_size);
+            value = fillvalue;
           } else {
             ind1 = new_n + k;
             if (ind1 < 0) {
@@ -743,15 +741,14 @@ case 0: /* outsize=VALID | boundary=PAD | convolve=NOT_FLIPPED */
               bounds_pad_flag = 1;
             }
             if (bounds_pad_flag) {
-              memcpy(value, fillvalue, type_size);
+              value = fillvalue;
             } else {
-              memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+              value = in + ind0_memory + ind1*instr[1];
             }
             bounds_pad_flag = 0;
           }
-          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
         }
-        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
       }
     }
   }
@@ -759,7 +756,6 @@ case 0: /* outsize=VALID | boundary=PAD | convolve=NOT_FLIPPED */
 }
 
 }
-  free(sum);
   return 0;
 }
 

--- a/scipy/signal/firfilter.c
+++ b/scipy/signal/firfilter.c
@@ -100,6 +100,7 @@ int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
   char *sum=NULL, *value=NULL;
   int new_m, new_n, ind0_memory=0;
   int boundary, outsize, convolve, type_num, type_size;
+  int fillvalue_is_zero = 1;
   OneMultAddFunction *mult_and_add;
 
   boundary = flag & BOUNDARY_MASK;  /* flag can be fill, reflecting, circular */
@@ -113,6 +114,10 @@ int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
 
   if (type_num < 0 || type_num > MAXTYPES) return -4;  /* Invalid type */
   type_size = elsizes[type_num];
+
+  for (j=0; j<type_size; j++) {
+    if (fillvalue[j]) fillvalue_is_zero = 0;
+  }
 
   if (outsize == FULL) {Os[0] = Ns[0]+Nwin[0]-1; Os[1] = Ns[1]+Nwin[1]-1;}
   else if (outsize == SAME) {Os[0] = Ns[0]; Os[1] = Ns[1];}
@@ -284,7 +289,9 @@ case 18: /* outsize=FULL | boundary=PAD | convolve=FLIPPED */
             }
             bounds_pad_flag = 0;
           }
-          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
+          if (!(value==fillvalue && fillvalue_is_zero)) {
+            mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
+          }
         }
       }
     }
@@ -327,7 +334,9 @@ case 2: /* outsize=FULL | boundary=PAD | convolve=NOT_FLIPPED */
             }
             bounds_pad_flag = 0;
           }
-          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
+          if (!(value==fillvalue && fillvalue_is_zero)) {
+            mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
+          }
         }
       }
     }
@@ -494,7 +503,9 @@ case 17: /* outsize=SAME | boundary=PAD | convolve=FLIPPED */
             }
             bounds_pad_flag = 0;
           }
-          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
+          if (!(value==fillvalue && fillvalue_is_zero)) {
+            mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
+          }
         }
       }
     }
@@ -537,7 +548,9 @@ case 1: /* outsize=SAME | boundary=PAD | convolve=NOT_FLIPPED */
             }
             bounds_pad_flag = 0;
           }
-          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
+          if (!(value==fillvalue && fillvalue_is_zero)) {
+            mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
+          }
         }
       }
     }
@@ -704,7 +717,9 @@ case 16: /* outsize=VALID | boundary=PAD | convolve=FLIPPED */
             }
             bounds_pad_flag = 0;
           }
-          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
+          if (!(value==fillvalue && fillvalue_is_zero)) {
+            mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
+          }
         }
       }
     }
@@ -747,7 +762,9 @@ case 0: /* outsize=VALID | boundary=PAD | convolve=NOT_FLIPPED */
             }
             bounds_pad_flag = 0;
           }
-          mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
+          if (!(value==fillvalue && fillvalue_is_zero)) {
+            mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);
+          }
         }
       }
     }

--- a/scipy/signal/firfilter.c
+++ b/scipy/signal/firfilter.c
@@ -125,6 +125,692 @@ int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
   if ((boundary != PAD) && (boundary != REFLECT) && (boundary != CIRCULAR)) 
     return -2;   /* Invalid boundary flag */
 
+  switch (flag & 31) {
+
+case 26: /* outsize=FULL | boundary=CIRCULAR | convolve=FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m;
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n;
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m - j;
+        if (ind0 < 0) {
+          ind0 = Ns[0] + ind0;
+        } else if (ind0 >= Ns[0]) {
+          ind0 = ind0 - Ns[0];
+        }
+        ind0_memory = ind0 * instr[0];
+        for (k=0; k < Nwin[1]; k++) {
+          ind1 = new_n - k;
+          if (ind1 < 0) {
+            ind1 = Ns[1] + ind1;
+          } else if (ind1 >= Ns[1]) {
+            ind1 = ind1 - Ns[1];
+          }
+          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 10: /* outsize=FULL | boundary=CIRCULAR | convolve=NOT_FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m - Nwin[0] + 1;
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n - Nwin[1] + 1;
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m + j;
+        if (ind0 < 0) {
+          ind0 = Ns[0] + ind0;
+        } else if (ind0 >= Ns[0]) {
+          ind0 = ind0 - Ns[0];
+        }
+        ind0_memory = ind0 * instr[0];
+        for (k=0; k < Nwin[1]; k++) {
+          ind1 = new_n + k;
+          if (ind1 < 0) {
+            ind1 = Ns[1] + ind1;
+          } else if (ind1 >= Ns[1]) {
+            ind1 = ind1 - Ns[1];
+          }
+          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 22: /* outsize=FULL | boundary=REFLECT | convolve=FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m;
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n;
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m - j;
+        if (ind0 < 0) {
+          ind0 = -1 - ind0;
+        } else if (ind0 >= Ns[0]) {
+          ind0 = Ns[0] + Ns[0] - 1 - ind0;
+        }
+        ind0_memory = ind0 * instr[0];
+        for (k=0; k < Nwin[1]; k++) {
+          ind1 = new_n - k;
+          if (ind1 < 0) {
+            ind1 = -1 - ind1;
+          } else if (ind1 >= Ns[1]) {
+            ind1 = Ns[1] + Ns[1] - 1 - ind1;
+          }
+          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 6: /* outsize=FULL | boundary=REFLECT | convolve=NOT_FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m - Nwin[0] + 1;
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n - Nwin[1] + 1;
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m + j;
+        if (ind0 < 0) {
+          ind0 = -1 - ind0;
+        } else if (ind0 >= Ns[0]) {
+          ind0 = Ns[0] + Ns[0] - 1 - ind0;
+        }
+        ind0_memory = ind0 * instr[0];
+        for (k=0; k < Nwin[1]; k++) {
+          ind1 = new_n + k;
+          if (ind1 < 0) {
+            ind1 = -1 - ind1;
+          } else if (ind1 >= Ns[1]) {
+            ind1 = Ns[1] + Ns[1] - 1 - ind1;
+          }
+          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 18: /* outsize=FULL | boundary=PAD | convolve=FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m;
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n;
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m - j;
+        bounds_pad_flag = 0;
+        if (ind0 < 0) {
+          bounds_pad_flag = 1;
+        } else if (ind0 >= Ns[0]) {
+          bounds_pad_flag = 1;
+        }
+        if (!bounds_pad_flag) {
+          ind0_memory = ind0 * instr[0];
+        }
+        for (k=0; k < Nwin[1]; k++) {
+          if (bounds_pad_flag) {
+            memcpy(value, fillvalue, type_size);
+          } else {
+            ind1 = new_n - k;
+            if (ind1 < 0) {
+              bounds_pad_flag = 1;
+            } else if (ind1 >= Ns[1]) {
+              bounds_pad_flag = 1;
+            }
+            if (bounds_pad_flag) {
+              memcpy(value, fillvalue, type_size);
+            } else {
+              memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+            }
+            bounds_pad_flag = 0;
+          }
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 2: /* outsize=FULL | boundary=PAD | convolve=NOT_FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m - Nwin[0] + 1;
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n - Nwin[1] + 1;
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m + j;
+        bounds_pad_flag = 0;
+        if (ind0 < 0) {
+          bounds_pad_flag = 1;
+        } else if (ind0 >= Ns[0]) {
+          bounds_pad_flag = 1;
+        }
+        if (!bounds_pad_flag) {
+          ind0_memory = ind0 * instr[0];
+        }
+        for (k=0; k < Nwin[1]; k++) {
+          if (bounds_pad_flag) {
+            memcpy(value, fillvalue, type_size);
+          } else {
+            ind1 = new_n + k;
+            if (ind1 < 0) {
+              bounds_pad_flag = 1;
+            } else if (ind1 >= Ns[1]) {
+              bounds_pad_flag = 1;
+            }
+            if (bounds_pad_flag) {
+              memcpy(value, fillvalue, type_size);
+            } else {
+              memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+            }
+            bounds_pad_flag = 0;
+          }
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 25: /* outsize=SAME | boundary=CIRCULAR | convolve=FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m + ((Nwin[0]-1) >> 1);
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n + ((Nwin[1]-1) >> 1);
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m - j;
+        if (ind0 < 0) {
+          ind0 = Ns[0] + ind0;
+        } else if (ind0 >= Ns[0]) {
+          ind0 = ind0 - Ns[0];
+        }
+        ind0_memory = ind0 * instr[0];
+        for (k=0; k < Nwin[1]; k++) {
+          ind1 = new_n - k;
+          if (ind1 < 0) {
+            ind1 = Ns[1] + ind1;
+          } else if (ind1 >= Ns[1]) {
+            ind1 = ind1 - Ns[1];
+          }
+          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 9: /* outsize=SAME | boundary=CIRCULAR | convolve=NOT_FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m - ((Nwin[0]-1) >> 1);
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n - ((Nwin[1]-1) >> 1);
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m + j;
+        if (ind0 < 0) {
+          ind0 = Ns[0] + ind0;
+        } else if (ind0 >= Ns[0]) {
+          ind0 = ind0 - Ns[0];
+        }
+        ind0_memory = ind0 * instr[0];
+        for (k=0; k < Nwin[1]; k++) {
+          ind1 = new_n + k;
+          if (ind1 < 0) {
+            ind1 = Ns[1] + ind1;
+          } else if (ind1 >= Ns[1]) {
+            ind1 = ind1 - Ns[1];
+          }
+          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 21: /* outsize=SAME | boundary=REFLECT | convolve=FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m + ((Nwin[0]-1) >> 1);
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n + ((Nwin[1]-1) >> 1);
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m - j;
+        if (ind0 < 0) {
+          ind0 = -1 - ind0;
+        } else if (ind0 >= Ns[0]) {
+          ind0 = Ns[0] + Ns[0] - 1 - ind0;
+        }
+        ind0_memory = ind0 * instr[0];
+        for (k=0; k < Nwin[1]; k++) {
+          ind1 = new_n - k;
+          if (ind1 < 0) {
+            ind1 = -1 - ind1;
+          } else if (ind1 >= Ns[1]) {
+            ind1 = Ns[1] + Ns[1] - 1 - ind1;
+          }
+          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 5: /* outsize=SAME | boundary=REFLECT | convolve=NOT_FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m - ((Nwin[0]-1) >> 1);
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n - ((Nwin[1]-1) >> 1);
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m + j;
+        if (ind0 < 0) {
+          ind0 = -1 - ind0;
+        } else if (ind0 >= Ns[0]) {
+          ind0 = Ns[0] + Ns[0] - 1 - ind0;
+        }
+        ind0_memory = ind0 * instr[0];
+        for (k=0; k < Nwin[1]; k++) {
+          ind1 = new_n + k;
+          if (ind1 < 0) {
+            ind1 = -1 - ind1;
+          } else if (ind1 >= Ns[1]) {
+            ind1 = Ns[1] + Ns[1] - 1 - ind1;
+          }
+          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 17: /* outsize=SAME | boundary=PAD | convolve=FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m + ((Nwin[0]-1) >> 1);
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n + ((Nwin[1]-1) >> 1);
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m - j;
+        bounds_pad_flag = 0;
+        if (ind0 < 0) {
+          bounds_pad_flag = 1;
+        } else if (ind0 >= Ns[0]) {
+          bounds_pad_flag = 1;
+        }
+        if (!bounds_pad_flag) {
+          ind0_memory = ind0 * instr[0];
+        }
+        for (k=0; k < Nwin[1]; k++) {
+          if (bounds_pad_flag) {
+            memcpy(value, fillvalue, type_size);
+          } else {
+            ind1 = new_n - k;
+            if (ind1 < 0) {
+              bounds_pad_flag = 1;
+            } else if (ind1 >= Ns[1]) {
+              bounds_pad_flag = 1;
+            }
+            if (bounds_pad_flag) {
+              memcpy(value, fillvalue, type_size);
+            } else {
+              memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+            }
+            bounds_pad_flag = 0;
+          }
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 1: /* outsize=SAME | boundary=PAD | convolve=NOT_FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m - ((Nwin[0]-1) >> 1);
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n - ((Nwin[1]-1) >> 1);
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m + j;
+        bounds_pad_flag = 0;
+        if (ind0 < 0) {
+          bounds_pad_flag = 1;
+        } else if (ind0 >= Ns[0]) {
+          bounds_pad_flag = 1;
+        }
+        if (!bounds_pad_flag) {
+          ind0_memory = ind0 * instr[0];
+        }
+        for (k=0; k < Nwin[1]; k++) {
+          if (bounds_pad_flag) {
+            memcpy(value, fillvalue, type_size);
+          } else {
+            ind1 = new_n + k;
+            if (ind1 < 0) {
+              bounds_pad_flag = 1;
+            } else if (ind1 >= Ns[1]) {
+              bounds_pad_flag = 1;
+            }
+            if (bounds_pad_flag) {
+              memcpy(value, fillvalue, type_size);
+            } else {
+              memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+            }
+            bounds_pad_flag = 0;
+          }
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 24: /* outsize=VALID | boundary=CIRCULAR | convolve=FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m + Nwin[0] - 1;
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n + Nwin[1] - 1;
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m - j;
+        if (ind0 < 0) {
+          ind0 = Ns[0] + ind0;
+        } else if (ind0 >= Ns[0]) {
+          ind0 = ind0 - Ns[0];
+        }
+        ind0_memory = ind0 * instr[0];
+        for (k=0; k < Nwin[1]; k++) {
+          ind1 = new_n - k;
+          if (ind1 < 0) {
+            ind1 = Ns[1] + ind1;
+          } else if (ind1 >= Ns[1]) {
+            ind1 = ind1 - Ns[1];
+          }
+          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 8: /* outsize=VALID | boundary=CIRCULAR | convolve=NOT_FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m;
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n;
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m + j;
+        if (ind0 < 0) {
+          ind0 = Ns[0] + ind0;
+        } else if (ind0 >= Ns[0]) {
+          ind0 = ind0 - Ns[0];
+        }
+        ind0_memory = ind0 * instr[0];
+        for (k=0; k < Nwin[1]; k++) {
+          ind1 = new_n + k;
+          if (ind1 < 0) {
+            ind1 = Ns[1] + ind1;
+          } else if (ind1 >= Ns[1]) {
+            ind1 = ind1 - Ns[1];
+          }
+          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 20: /* outsize=VALID | boundary=REFLECT | convolve=FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m + Nwin[0] - 1;
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n + Nwin[1] - 1;
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m - j;
+        if (ind0 < 0) {
+          ind0 = -1 - ind0;
+        } else if (ind0 >= Ns[0]) {
+          ind0 = Ns[0] + Ns[0] - 1 - ind0;
+        }
+        ind0_memory = ind0 * instr[0];
+        for (k=0; k < Nwin[1]; k++) {
+          ind1 = new_n - k;
+          if (ind1 < 0) {
+            ind1 = -1 - ind1;
+          } else if (ind1 >= Ns[1]) {
+            ind1 = Ns[1] + Ns[1] - 1 - ind1;
+          }
+          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 4: /* outsize=VALID | boundary=REFLECT | convolve=NOT_FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m;
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n;
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m + j;
+        if (ind0 < 0) {
+          ind0 = -1 - ind0;
+        } else if (ind0 >= Ns[0]) {
+          ind0 = Ns[0] + Ns[0] - 1 - ind0;
+        }
+        ind0_memory = ind0 * instr[0];
+        for (k=0; k < Nwin[1]; k++) {
+          ind1 = new_n + k;
+          if (ind1 < 0) {
+            ind1 = -1 - ind1;
+          } else if (ind1 >= Ns[1]) {
+            ind1 = Ns[1] + Ns[1] - 1 - ind1;
+          }
+          memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 16: /* outsize=VALID | boundary=PAD | convolve=FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m + Nwin[0] - 1;
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n + Nwin[1] - 1;
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m - j;
+        bounds_pad_flag = 0;
+        if (ind0 < 0) {
+          bounds_pad_flag = 1;
+        } else if (ind0 >= Ns[0]) {
+          bounds_pad_flag = 1;
+        }
+        if (!bounds_pad_flag) {
+          ind0_memory = ind0 * instr[0];
+        }
+        for (k=0; k < Nwin[1]; k++) {
+          if (bounds_pad_flag) {
+            memcpy(value, fillvalue, type_size);
+          } else {
+            ind1 = new_n - k;
+            if (ind1 < 0) {
+              bounds_pad_flag = 1;
+            } else if (ind1 >= Ns[1]) {
+              bounds_pad_flag = 1;
+            }
+            if (bounds_pad_flag) {
+              memcpy(value, fillvalue, type_size);
+            } else {
+              memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+            }
+            bounds_pad_flag = 0;
+          }
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+case 0: /* outsize=VALID | boundary=PAD | convolve=NOT_FLIPPED */
+{
+  for (m=0; m < Os[0]; m++) {
+    new_m = m;
+    for (n=0; n < Os[1]; n++) {
+      memset(sum, 0, type_size);
+      new_n = n;
+      for (j=0; j < Nwin[0]; j++) {
+        ind0 = new_m + j;
+        bounds_pad_flag = 0;
+        if (ind0 < 0) {
+          bounds_pad_flag = 1;
+        } else if (ind0 >= Ns[0]) {
+          bounds_pad_flag = 1;
+        }
+        if (!bounds_pad_flag) {
+          ind0_memory = ind0 * instr[0];
+        }
+        for (k=0; k < Nwin[1]; k++) {
+          if (bounds_pad_flag) {
+            memcpy(value, fillvalue, type_size);
+          } else {
+            ind1 = new_n + k;
+            if (ind1 < 0) {
+              bounds_pad_flag = 1;
+            } else if (ind1 >= Ns[1]) {
+              bounds_pad_flag = 1;
+            }
+            if (bounds_pad_flag) {
+              memcpy(value, fillvalue, type_size);
+            } else {
+              memcpy(value, in + ind0_memory + ind1*instr[1], type_size);
+            }
+            bounds_pad_flag = 0;
+          }
+          mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);
+        }
+        memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);
+      }
+    }
+  }
+  break;
+}
+
+}
+  free(sum);
+  return 0;
+}
+
+
+
+
+
+/* This could definitely be more optimized... */
+
+int pylab_convolve_2d_slowpath (char  *in,        /* Input data Ns[0] x Ns[1] */
+		       intp   *instr,     /* Input strides */
+		       char  *out,       /* Output data */
+		       intp   *outstr,    /* Ouput strides */
+		       char  *hvals,     /* coefficients in filter */
+		       intp   *hstr,      /* coefficients strides */ 
+		       intp   *Nwin,     /* Size of kernel Nwin[0] x Nwin[1] */
+		       intp   *Ns,        /* Size of image Ns[0] x Ns[1] */
+		       int   flag,       /* convolution parameters */
+		       char  *fillvalue) /* fill value */
+{
+  int bounds_pad_flag = 0;
+  int m, n, j, k, ind0, ind1;
+  int Os[2];
+  char *sum=NULL, *value=NULL;
+  int new_m, new_n, ind0_memory=0;
+  int boundary, outsize, convolve, type_num, type_size;
+  OneMultAddFunction *mult_and_add;
+
+  boundary = flag & BOUNDARY_MASK;  /* flag can be fill, reflecting, circular */
+  outsize = flag & OUTSIZE_MASK;
+  convolve = flag & FLIP_MASK;
+  type_num = (flag & TYPE_MASK) >> TYPE_SHIFT;
+  /*type_size*/
+
+  mult_and_add = OneMultAdd[type_num];
+  if (mult_and_add == NULL) return -5;  /* Not available for this type */
+
+  if (type_num < 0 || type_num > MAXTYPES) return -4;  /* Invalid type */
+  type_size = elsizes[type_num];
+
+  if ((sum = calloc(type_size,2))==NULL) return -3; /* No memory */
+  value = sum + type_size;
+
+  if (outsize == FULL) {Os[0] = Ns[0]+Nwin[0]-1; Os[1] = Ns[1]+Nwin[1]-1;}
+  else if (outsize == SAME) {Os[0] = Ns[0]; Os[1] = Ns[1];}
+  else if (outsize == VALID) {Os[0] = Ns[0]-Nwin[0]+1; Os[1] = Ns[1]-Nwin[1]+1;}
+  else return -1;  /* Invalid output flag */  
+  
+  if ((boundary != PAD) && (boundary != REFLECT) && (boundary != CIRCULAR)) 
+    return -2;   /* Invalid boundary flag */
+
   /* Speed this up by not doing any if statements in the for loop.  Need 3*3*2=18 different
      loops executed for different conditions */
 

--- a/scipy/signal/firfilter_codegen.py
+++ b/scipy/signal/firfilter_codegen.py
@@ -90,7 +90,6 @@ def case_codegen(outsize, boundary, convolve):
     if boundary == PAD:
         addline('if (bounds_pad_flag) {')
         addline('value = fillvalue;')
-        #addline('memcpy(value, fillvalue, type_size);')
         addline('} else {')
     rhs = 'new_n - k' if convolve else 'new_n + k'
     addline('ind1 = %s;' % rhs)
@@ -116,18 +115,23 @@ def case_codegen(outsize, boundary, convolve):
     if boundary == PAD:
         addline('if (bounds_pad_flag) {')
         addline('value = fillvalue;')
-        #addline('memcpy(value, fillvalue, type_size);')
         addline('} else {')
-    #addline('memcpy(value, in + ind0_memory + ind1*instr[1], type_size);')
     addline('value = in + ind0_memory + ind1*instr[1];')
     if boundary == PAD:
         addline('}')
         addline('bounds_pad_flag = 0;')
         addline('}')
+
+    # multiply and accumulate unless we are looking at a padding of zero
+    if boundary == PAD:
+        addline('if (!(value==fillvalue && fillvalue_is_zero)) {')
     addline('mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);')
+    if boundary == PAD:
+        addline('}')
+
+    # close the loops over the 2d kernel within the 2d image
     addline('}')
     addline('}')
-    #addline('memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);')
     addline('}')
     addline('}')
     

--- a/scipy/signal/firfilter_codegen.py
+++ b/scipy/signal/firfilter_codegen.py
@@ -42,6 +42,7 @@ def case_codegen(outsize, boundary, convolve):
 
     # loop over image columns
     addline('for (n=0; n < Os[1]; n++) {')
+    addline('sum = out + m*outstr[0] + n*outstr[1];')
     addline('memset(sum, 0, type_size);')
     if outsize == FULL:
         rhs = 'n' if convolve else 'n - Nwin[1] + 1'
@@ -88,7 +89,8 @@ def case_codegen(outsize, boundary, convolve):
     addline('for (k=0; k < Nwin[1]; k++) {')
     if boundary == PAD:
         addline('if (bounds_pad_flag) {')
-        addline('memcpy(value, fillvalue, type_size);')
+        addline('value = fillvalue;')
+        #addline('memcpy(value, fillvalue, type_size);')
         addline('} else {')
     rhs = 'new_n - k' if convolve else 'new_n + k'
     addline('ind1 = %s;' % rhs)
@@ -113,17 +115,19 @@ def case_codegen(outsize, boundary, convolve):
     addline('}')
     if boundary == PAD:
         addline('if (bounds_pad_flag) {')
-        addline('memcpy(value, fillvalue, type_size);')
+        addline('value = fillvalue;')
+        #addline('memcpy(value, fillvalue, type_size);')
         addline('} else {')
-    addline('memcpy(value, in + ind0_memory + ind1*instr[1], type_size);')
+    #addline('memcpy(value, in + ind0_memory + ind1*instr[1], type_size);')
+    addline('value = in + ind0_memory + ind1*instr[1];')
     if boundary == PAD:
         addline('}')
         addline('bounds_pad_flag = 0;')
         addline('}')
-    addline('mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);')
+    addline('mult_and_add(sum, hvals + j*hstr[0] + k*hstr[1], value);')
     addline('}')
-    addline('memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);')
     addline('}')
+    #addline('memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);')
     addline('}')
     addline('}')
     

--- a/scipy/signal/firfilter_codegen.py
+++ b/scipy/signal/firfilter_codegen.py
@@ -1,0 +1,173 @@
+"""
+Ad-hoc code generation for firfilter.c 2d convolution functions.
+
+Use python code to do loop unswitching instead of using the C compiler.
+
+"""
+from __future__ import division, print_function, absolute_import
+
+from itertools import product
+
+# outsize options
+FULL = 2
+SAME = 1
+VALID = 0
+
+# boundary options
+CIRCULAR = 8
+REFLECT = 4
+PAD = 0 
+
+# there are only two flip (convolve) options
+FLIPPED = 16
+NOT_FLIPPED = 0
+
+
+def case_codegen(outsize, boundary, convolve):
+    lines = []
+    def addline(line):
+        lines.append(line)
+
+    # loop over image rows
+    addline('for (m=0; m < Os[0]; m++) {')
+    if outsize == FULL:
+        rhs = 'm' if convolve else 'm - Nwin[0] + 1'
+    elif outsize == SAME:
+        rhs = 'm + ((Nwin[0]-1) >> 1)' if convolve else 'm - ((Nwin[0]-1) >> 1)'
+    elif outsize == VALID:
+        rhs = 'm + Nwin[0] - 1' if convolve else 'm'
+    else:
+        raise ValueError
+    addline('new_m = %s;' % rhs)
+
+    # loop over image columns
+    addline('for (n=0; n < Os[1]; n++) {')
+    addline('memset(sum, 0, type_size);')
+    if outsize == FULL:
+        rhs = 'n' if convolve else 'n - Nwin[1] + 1'
+    elif outsize == SAME:
+        rhs = 'n + ((Nwin[1]-1) >> 1)' if convolve else 'n - ((Nwin[1]-1) >> 1)'
+    elif outsize == VALID:
+        rhs = 'n + Nwin[1] - 1' if convolve else 'n'
+    else:
+        raise ValueError
+    addline('new_n = %s;' % rhs)
+
+    # sum over kernel
+    addline('for (j=0; j < Nwin[0]; j++) {')
+    rhs = 'new_m - j' if convolve else 'new_m + j'
+    addline('ind0 = %s;' % rhs)
+    if boundary == PAD:
+        addline('bounds_pad_flag = 0;')
+    addline('if (ind0 < 0) {')
+    if boundary == REFLECT:
+        addline('ind0 = -1 - ind0;')
+    elif boundary == CIRCULAR:
+        addline('ind0 = Ns[0] + ind0;')
+    elif boundary == PAD:
+        addline('bounds_pad_flag = 1;')
+    else:
+        raise ValueError
+    addline('} else if (ind0 >= Ns[0]) {')
+    if boundary == REFLECT:
+        addline('ind0 = Ns[0] + Ns[0] - 1 - ind0;')
+    elif boundary == CIRCULAR:
+        addline('ind0 = ind0 - Ns[0];')
+    elif boundary == PAD:
+        addline('bounds_pad_flag = 1;')
+    else:
+        raise ValueError
+    addline('}')
+    if boundary == PAD:
+        addline('if (!bounds_pad_flag) {')
+    addline('ind0_memory = ind0 * instr[0];')
+    if boundary == PAD:
+        addline('}')
+
+    # kernel columns
+    addline('for (k=0; k < Nwin[1]; k++) {')
+    if boundary == PAD:
+        addline('if (bounds_pad_flag) {')
+        addline('memcpy(value, fillvalue, type_size);')
+        addline('} else {')
+    rhs = 'new_n - k' if convolve else 'new_n + k'
+    addline('ind1 = %s;' % rhs)
+    addline('if (ind1 < 0) {')
+    if boundary == REFLECT:
+        addline('ind1 = -1 - ind1;')
+    elif boundary == CIRCULAR:
+        addline('ind1 = Ns[1] + ind1;')
+    elif boundary == PAD:
+        addline('bounds_pad_flag = 1;')
+    else:
+        raise ValueError
+    addline('} else if (ind1 >= Ns[1]) {')
+    if boundary == REFLECT:
+        addline('ind1 = Ns[1] + Ns[1] - 1 - ind1;')
+    elif boundary == CIRCULAR:
+        addline('ind1 = ind1 - Ns[1];')
+    elif boundary == PAD:
+        addline('bounds_pad_flag = 1;')
+    else:
+        raise ValueError
+    addline('}')
+    if boundary == PAD:
+        addline('if (bounds_pad_flag) {')
+        addline('memcpy(value, fillvalue, type_size);')
+        addline('} else {')
+    addline('memcpy(value, in + ind0_memory + ind1*instr[1], type_size);')
+    if boundary == PAD:
+        addline('}')
+        addline('bounds_pad_flag = 0;')
+        addline('}')
+    addline('mult_and_add(sum, hvals+j*hstr[0] + k*hstr[1], value);')
+    addline('}')
+    addline('memcpy(out + m*outstr[0] + n*outstr[1], sum, type_size);')
+    addline('}')
+    addline('}')
+    addline('}')
+    
+    return lines
+
+
+def ad_hoc_indent(lines, depth, spacing):
+    indented_lines = []
+    for line in lines:
+        if line.startswith('}'):
+            depth -= 1
+        indented_line = (spacing * depth) + line
+        indented_lines.append(indented_line)
+        if line.endswith('{'):
+            depth += 1
+    return '\n'.join(indented_lines)
+
+
+def main():
+
+    # Define some description strings.
+    d_outsize = {VALID : 'VALID', SAME : 'SAME', FULL : 'FULL'}
+    d_boundary = {PAD : 'PAD', REFLECT : 'REFLECT', CIRCULAR : 'CIRCULAR'}
+    d_convolve = {NOT_FLIPPED : 'NOT_FLIPPED', FLIPPED : 'FLIPPED'}
+
+    outsizes = (FULL, SAME, VALID)
+    boundaries = (CIRCULAR, REFLECT, PAD)
+    convolves = (FLIPPED, NOT_FLIPPED)
+
+    lines = []
+    for triple in product(outsizes, boundaries, convolves):
+        outsize, boundary, convolve = triple
+        description = ' | '.join((
+            'outsize=' + d_outsize[outsize],
+            'boundary=' + d_boundary[boundary],
+            'convolve=' + d_convolve[convolve]))
+        lines.append('case %s: /* %s */' % (sum(triple), description))
+        lines.append('{')
+        lines.extend(case_codegen(outsize, boundary, convolve))
+        lines.append('break;')
+        lines.append('}')
+    print(ad_hoc_indent(lines, 0, '  '))
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
This is a more or less failed experiment to prematurely optimize convolve2d.  I'm not convinced that breaking the convolve2d loops into 18 cases to get rid of the within-loop branching will significantly speed up the implementation.  It may be better to break it up by data type instead of by mode, possibly by using actual c++ templates.  Or just leave it alone.

The 2d convolution benchmark added by this PR is sped up nearly 2x, which is far from the 200x mentioned on the mailing list http://mail.scipy.org/pipermail/scipy-dev/2013-December/019501.html
