### PR TITLE
Fix stats.scoreatpercentile

### DIFF
--- a/doc/release/0.14.0-notes.rst
+++ b/doc/release/0.14.0-notes.rst
@@ -83,6 +83,9 @@ scipy.stats
 The deprecated functions ``glm``, ``oneway`` and ``cmedian`` have been removed
 from ``scipy.stats``.
 
+``stats.scoreatpercentile`` now returns an array instead of a list of
+percentiles.
+
 
 Other changes
 =============

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1367,7 +1367,7 @@ def itemfreq(a):
 
 
 def scoreatpercentile(a, per, limit=(), interpolation_method='fraction',
-        axis=None):
+                      axis=None):
     """
     Calculate the score at a given percentile of the input sequence.
 
@@ -1419,6 +1419,12 @@ def scoreatpercentile(a, per, limit=(), interpolation_method='fraction',
     """
     # adapted from NumPy's percentile function
     a = np.asarray(a)
+    if a.size == 0:
+        # empty array, return nan(s) with shape matching `per`
+        if np.isscalar(per):
+            return np.nan
+        else:
+            return np.ones(np.asarray(per).shape, dtype=np.float64) * np.nan
 
     if limit:
         a = a[(limit[0] <= a) & (a <= limit[1])]
@@ -1473,7 +1479,7 @@ def _compute_qth_percentile(sorted, per, interpolation_method, axis):
         weights.shape = wshape
         sumval = weights.sum()
 
-    # Use np.add.reduce to coerce data type
+    # Use np.add.reduce (== np.sum but a little faster) to coerce data type
     return np.add.reduce(sorted[indexer] * weights, axis=axis) / sumval
 
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1409,6 +1409,14 @@ def scoreatpercentile(a, per, limit=(), interpolation_method='fraction',
     --------
     percentileofscore, numpy.percentile
 
+    Notes
+    -----
+    This function will become obsolete in the future.
+    For Numpy 1.9 and higher, `numpy.percentile` provides all the functionality
+    that `scoreatpercentile` provides.  And it's significantly faster.
+    Therefore it's recommended to use `numpy.percentile` for users that have
+    numpy >= 1.9.
+
     Examples
     --------
     >>> from scipy import stats

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1402,12 +1402,12 @@ def scoreatpercentile(a, per, limit=(), interpolation_method='fraction',
 
     Returns
     -------
-    score : float (or sequence of floats)
-        Score at percentile.
+    score : float or ndarray
+        Score at percentile(s).
 
     See Also
     --------
-    percentileofscore
+    percentileofscore, numpy.percentile
 
     Examples
     --------
@@ -1417,7 +1417,8 @@ def scoreatpercentile(a, per, limit=(), interpolation_method='fraction',
     49.5
 
     """
-    # adapted from NumPy's percentile function
+    # adapted from NumPy's percentile function.  When we require numpy >= 1.8,
+    # the implementation of this function can be replaced by np.percentile.
     a = np.asarray(a)
     if a.size == 0:
         # empty array, return nan(s) with shape matching `per`
@@ -1429,11 +1430,6 @@ def scoreatpercentile(a, per, limit=(), interpolation_method='fraction',
     if limit:
         a = a[(limit[0] <= a) & (a <= limit[1])]
 
-    if per == 0:
-        return a.min(axis=axis)
-    elif per == 100:
-        return a.max(axis=axis)
-
     sorted = np.sort(a, axis=axis)
     if axis is None:
         axis = 0
@@ -1444,8 +1440,9 @@ def scoreatpercentile(a, per, limit=(), interpolation_method='fraction',
 # handle sequence of per's without calling sort multiple times
 def _compute_qth_percentile(sorted, per, interpolation_method, axis):
     if not np.isscalar(per):
-        return [_compute_qth_percentile(sorted, i, interpolation_method, axis)
-             for i in per]
+        score = [_compute_qth_percentile(sorted, i, interpolation_method, axis)
+                 for i in per]
+        return np.array(score)
 
     if (per < 0) or (per > 100):
         raise ValueError("percentile must be in the range [0, 100]")

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -11,10 +11,11 @@ from __future__ import division, print_function, absolute_import
 import warnings
 from collections import namedtuple
 
-from numpy.testing import TestCase, assert_, assert_equal, \
-    assert_almost_equal, assert_array_almost_equal, assert_array_equal, \
-    assert_approx_equal, assert_raises, run_module_suite, \
-    assert_allclose, dec
+from numpy.testing import (TestCase, assert_, assert_equal,
+                           assert_almost_equal, assert_array_almost_equal,
+                           assert_array_equal, assert_approx_equal,
+                           assert_raises, run_module_suite, assert_allclose,
+                           dec)
 import numpy.ma.testutils as mat
 from numpy import array, arange, float32, float64, power
 import numpy as np
@@ -1036,11 +1037,11 @@ class TestScoreatpercentile(TestCase):
         x = arange(8) * 0.5
         expected = np.array([0, 3.5, 1.75])
         res = stats.scoreatpercentile(x, [0, 100, 50])
-        assert_equal(res, expected)
+        assert_allclose(res, expected)
         assert_(isinstance(res, np.ndarray))
         # Test with ndarray.  Regression test for gh-2861
-        assert_equal(stats.scoreatpercentile(x, np.array([0, 100, 50])),
-                     expected)
+        assert_allclose(stats.scoreatpercentile(x, np.array([0, 100, 50])),
+                        expected)
         # Also test combination of 2-D array, axis not None and array-like per
         res2 = stats.scoreatpercentile(np.arange(12).reshape((3,4)),
                                        np.array([0, 1, 100, 100]), axis=1)
@@ -1048,7 +1049,7 @@ class TestScoreatpercentile(TestCase):
                            [0.03, 4.03, 8.03],
                            [3, 7, 11],
                            [3, 7, 11]])
-        assert_equal(res2, expected2)
+        assert_allclose(res2, expected2)
 
     def test_axis(self):
         scoreatperc = stats.scoreatpercentile

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1032,9 +1032,23 @@ class TestScoreatpercentile(TestCase):
         assert_equal(scoreatperc(np.array([1, 10, 100]), 50, limit=(1, 10),
                                  interpolation_method='higher'), 10)
 
-    def test_sequence(self):
+    def test_sequence_per(self):
         x = arange(8) * 0.5
-        assert_equal(stats.scoreatpercentile(x, [0, 100, 50]), [0, 3.5, 1.75])
+        expected = np.array([0, 3.5, 1.75])
+        res = stats.scoreatpercentile(x, [0, 100, 50])
+        assert_equal(res, expected)
+        assert_(isinstance(res, np.ndarray))
+        # Test with ndarray.  Regression test for gh-2861
+        assert_equal(stats.scoreatpercentile(x, np.array([0, 100, 50])),
+                     expected)
+        # Also test combination of 2-D array, axis not None and array-like per
+        res2 = stats.scoreatpercentile(np.arange(12).reshape((3,4)),
+                                       np.array([0, 1, 100, 100]), axis=1)
+        expected2 = array([[0, 4, 8],
+                           [0.03, 4.03, 8.03],
+                           [3, 7, 11],
+                           [3, 7, 11]])
+        assert_equal(res2, expected2)
 
     def test_axis(self):
         scoreatperc = stats.scoreatpercentile

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1054,6 +1054,11 @@ class TestScoreatpercentile(TestCase):
         assert_raises(ValueError, stats.scoreatpercentile, [1], 101)
         assert_raises(ValueError, stats.scoreatpercentile, [1], -1)
 
+    def test_empty(self):
+        assert_equal(stats.scoreatpercentile([], 50), np.nan)
+        assert_equal(stats.scoreatpercentile(np.array([[], []]), 50), np.nan)
+        assert_equal(stats.scoreatpercentile([], [50, 99]), [np.nan, np.nan])
+
 
 class TestItemfreq(object):
     a = [5, 7, 1, 2, 1, 5, 7] * 10


### PR DESCRIPTION
Fix ndarray input for `per` parameter and empty input. Closes gh-1897 and gh-2861.
