### PR TITLE
DOC: linalg: typo ("withouth")

### DIFF
--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -253,7 +253,7 @@ def get_blas_funcs(names, arrays=(), dtype=None):
     Parameters
     ----------
     names : str or sequence of str
-        Name(s) of BLAS functions withouth type prefix.
+        Name(s) of BLAS functions without type prefix.
 
     arrays : sequency of ndarrays, optional
         Arrays can be given to determine optiomal prefix of BLAS

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -244,7 +244,7 @@ def get_lapack_funcs(names, arrays=(), dtype=None):
     Parameters
     ----------
     names : str or sequence of str
-        Name(s) of LAPACK functions withouth type prefix.
+        Name(s) of LAPACK functions without type prefix.
 
     arrays : sequency of ndarrays, optional
         Arrays can be given to determine optiomal prefix of LAPACK


### PR DESCRIPTION
Caught two typos in linalg docstrings.
