### PR TITLE
Updated integrate.ode doc (lband, uband)

### DIFF
--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -155,10 +155,11 @@ class ode(object):
         - rtol : float or sequence
           relative tolerance for solution
         - lband : None or int
-        - rband : None or int
-          Jacobian band width, jac[i,j] != 0 for i-lband <= j <= i+rband.
+        - uband : None or int
+          Jacobian band width, jac[i,j] != 0 for i-lband <= j <= i+uband.
           Setting these requires your jac routine to return the jacobian
-          in packed format, jac_packed[i-j+lband, j] = jac[i,j].
+          in packed format, jac_packed[i-j+uband, j] = jac[i,j]. The
+          dimension of the matrix need to be (2*lband+uband+1, len(y)).
         - method: 'adams' or 'bdf'
           Which solver to use, Adams (non-stiff) or BDF (stiff)
         - with_jacobian : bool
@@ -226,10 +227,10 @@ class ode(object):
         - rtol : float or sequence
           relative tolerance for solution
         - lband : None or int
-        - rband : None or int
-          Jacobian band width, jac[i,j] != 0 for i-lband <= j <= i+rband.
+        - uband : None or int
+          Jacobian band width, jac[i,j] != 0 for i-lband <= j <= i+uband.
           Setting these requires your jac routine to return the jacobian
-          in packed format, jac_packed[i-j+lband, j] = jac[i,j].
+          in packed format, jac_packed[i-j+uband, j] = jac[i,j].
         - with_jacobian : bool
           Whether to use the jacobian
         - nsteps : int


### PR DESCRIPTION
The reference to `rband` in the docstring is puzzling to me (right?).
I also added info about the dimension requirements for the Jacobian. That extra lband is used as work space
if my memory serves me correctly (I vaguely remember this is done in LAPACK too but I couldn't find any reference about it).

Example of lband=uband=4 when using a matrix dimension of (lband+uband+1, len(y)):

0-th dimension must be fixed to 13 but got 9
rv_cb_arr is NULL
Call-back cb_jac_in_dvode__user__routines failed.
Traceback (most recent call last):
  File "four_species.py", line 63, in <module>
    argh.dispatch_command(main)
  File "/usr/local/lib/python2.7/dist-packages/argh/dispatching.py", line 224, in dispatch_command
    dispatch(parser, _args, *_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/argh/dispatching.py", line 121, in dispatch
    for line in lines:
  File "/usr/local/lib/python2.7/dist-packages/argh/dispatching.py", line 197, in _execute_command
    for line in result:
  File "/usr/local/lib/python2.7/dist-packages/argh/dispatching.py", line 180, in _call
    result = args.function(_positional, *_keywords)
  File "four_species.py", line 55, in main
    tout, yout, info = run(sys, y0, t0, tend, nt)
  File "/home/bjorn/vc/chemreac/chemreac/integrate.py", line 69, in run
    runner.integrate(tout[i])
  File "/usr/local/lib/python2.7/dist-packages/scipy/integrate/_ode.py", line 334, in integrate
    self.f_params, self.jac_params)
  File "/usr/local/lib/python2.7/dist-packages/scipy/integrate/_ode.py", line 636, in run
    args[5:]))
SystemError: NULL result without error in PyObject_Call

changing the dimension to  (2*lband+uband+1, len(y)) fixes this. It would be great if someone could confirm that this is the case.
