### PR TITLE
ENH Implement Jensen-Shannon Divergence

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5056,7 +5056,7 @@ def jensen_shannon_divergence(a, b):
     m = (a + b)
     m /= 2.
     m = np.where(m, m, 1.)
-    return 0.5*np.sum(special.xlogy(a,a/m)+special.xlogy(b,b/m), axis=0)
+    return 0.5*np.sum(special.xlogy(a, a/m) + special.xlogy(b, b/m), axis=0)
 
 
 def jsd_matrix(data):
@@ -5098,6 +5098,7 @@ def jsd_matrix(data):
     output *= (output > 0)
     output *= 0.5
     return output
+
 #####################################
 #      PROBABILITY CALCULATIONS     #
 #####################################

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5034,10 +5034,9 @@ def jensen_shannon_divergence(a, b):
     Parameters
     ----------
     a : array-like
-        possibly unnormalized distribution. This function is only defined for
-        1-dimensional arrays
+        possibly unnormalized distribution.
     b : array-like
-        possibly unnormalized distribution. Must be of same size as ``a``.
+        possibly unnormalized distribution. Must be of same shape as ``a``.
 
     Returns
     -------
@@ -5052,14 +5051,12 @@ def jensen_shannon_divergence(a, b):
     """
     a = np.asanyarray(a, dtype=float)
     b = np.asanyarray(b, dtype=float)
-    if a.ndim != 1 or b.ndim != 1:
-        raise ValueError('jensen_shannon_divergence only accepts 1-dimensional arguments')
-    a = a/a.sum()
-    b = b/b.sum()
+    a = a/a.sum(axis=0)
+    b = b/b.sum(axis=0)
     m = (a + b)
     m /= 2.
-    m = np.where(m,m,1.)
-    return 0.5*np.sum(special.xlogy(a,a/m)+special.xlogy(b,b/m))
+    m = np.where(m, m, 1.)
+    return 0.5*np.sum(special.xlogy(a,a/m)+special.xlogy(b,b/m), axis=0)
 
 
 def jsd_matrix(data):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5089,7 +5089,7 @@ def jsd_matrix(data):
         bs = data[(i+1):]
         m = bs + a
         m /= 2.
-        m = np.where(m, m, 1.)
+        m += (m == 0)
         out = special.xlogy(a, a/m).sum(1)
         out += special.xlogy(bs, bs/m).sum(1)
         output[p:(p+len(bs))] = out

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5034,7 +5034,8 @@ def jensen_shannon_divergence(a, b):
     Parameters
     ----------
     a : array-like
-        possibly unnormalized distribution
+        possibly unnormalized distribution. This function is only defined for
+        1-dimensional arrays
     b : array-like
         possibly unnormalized distribution. Must be of same size as ``a``.
 
@@ -5063,6 +5064,9 @@ def jensen_shannon_divergence(a, b):
 
 def jsd_matrix(data):
     """Compressed Jensen-Shannon Divergence Matrix
+
+    This function computes the Jensen-Shannon Divergence for each pair of
+    element in the input.
 
     Parameters
     ----------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5046,6 +5046,8 @@ def jensen_shannon_divergence(a, b):
     --------
     jsd_matrix : function
         Computes all pair-wise distances for a set of measurements
+    entropy : function
+        Computes entropy and K-L divergence
     """
     a = np.asanyarray(a, dtype=float)
     b = np.asanyarray(b, dtype=float)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5051,6 +5051,8 @@ def jensen_shannon_divergence(a, b):
     """
     a = np.asanyarray(a, dtype=float)
     b = np.asanyarray(b, dtype=float)
+    if a.ndim != 1 or b.ndim != 1:
+        raise ValueError('jensen_shannon_divergence only accepts 1-dimensional arguments')
     a = a/a.sum()
     b = b/b.sum()
     m = (a + b)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -5058,13 +5058,14 @@ def jensen_shannon_divergence(a, b):
     m = np.where(m,m,1.)
     return 0.5*np.sum(special.xlogy(a,a/m)+special.xlogy(b,b/m))
 
+
 def jsd_matrix(data):
     """Compressed Jensen-Shannon Divergence Matrix
 
     Parameters
     ----------
     data : array-like
-    
+
     Returns
     -------
     dist_matrix : ndarray
@@ -5079,13 +5080,13 @@ def jsd_matrix(data):
     n = len(data)
     data = np.array(data)
     data /= data.sum(1)[:,None]
-    output = np.empty( int(n*(n-1)/2), np.double)
+    output = np.empty(int(n*(n-1)/2), np.double)
     p = 0
     for i,a in enumerate(data):
         bs = data[(i+1):]
         m = bs + a
         m /= 2.
-        m = np.where(m,m,1.)
+        m = np.where(m, m, 1.)
         out = special.xlogy(a, a/m).sum(1)
         out += special.xlogy(bs, bs/m).sum(1)
         output[p:(p+len(bs))] = out

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4004,22 +4004,22 @@ def test_jensen_shannon_divergence():
         b = np.random.random(16)
         c = (a+b)
 
-        assert stats.jensen_shannon_divergence(a,a) < 1e-4
-        assert stats.jensen_shannon_divergence(a,b) > 0.
-        assert stats.jensen_shannon_divergence(a,b) > stats.jensen_shannon_divergence(a,c)
-        assert np.allclose(stats.jensen_shannon_divergence(a,b),stats.jensen_shannon_divergence(a,b*6))
+        assert_(stats.jensen_shannon_divergence(a,a) < 1e-4)
+        assert_(stats.jensen_shannon_divergence(a,b) > 0.)
+        assert_(stats.jensen_shannon_divergence(a,b) > stats.jensen_shannon_divergence(a,c))
+        assert_array_almost_equal(stats.jensen_shannon_divergence(a,b),stats.jensen_shannon_divergence(a,b*6))
 
 
 def test_jsd_matrix():
     from scipy.spatial.distance import squareform
     x = np.random.random((50,16))
     D = squareform(stats.jsd_matrix(x))
-    assert np.allclose(D,D.T)
-    assert D.trace() == 0
-    assert np.all(D >= 0)
+    assert_array_almost_equal(D,D.T)
+    assert_equal(D.trace(), 0)
+    assert_(np.all(D >= 0))
     for i in range(len(x)):
         for j in range(i+1,len(x)):
-            assert np.allclose(D[i,j], stats.jensen_shannon_divergence(x[i], x[j]))
+            assert_array_almost_equal(D[i,j], stats.jensen_shannon_divergence(x[i], x[j]))
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3998,5 +3998,28 @@ class TestCombinePvalues(TestCase):
                                      weights=np.array((1, 4, 9)))
         assert_approx_equal(p, 0.1464, significant=4)
 
+def test_jensen_shannon_divergence():
+    for _ in xrange(8):
+        a = np.random.random(16)
+        b = np.random.random(16)
+        c = (a+b)
+
+        assert stats.jensen_shannon_divergence(a,a) < 1e-4
+        assert stats.jensen_shannon_divergence(a,b) > 0.
+        assert stats.jensen_shannon_divergence(a,b) > stats.jensen_shannon_divergence(a,c)
+        assert np.allclose(stats.jensen_shannon_divergence(a,b),stats.jensen_shannon_divergence(a,b*6))
+
+
+def test_jsd_matrix():
+    from scipy.spatial.distance import squareform
+    x = np.random.random((50,16))
+    D = squareform(stats.jsd_matrix(x))
+    assert np.allclose(D,D.T)
+    assert D.trace() == 0
+    assert np.all(D >= 0)
+    for i in xrange(len(x)):
+        for j in xrange(i+1,len(x)):
+            assert np.allclose(D[i,j], stats.jensen_shannon_divergence(x[i], x[j]))
+
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3999,7 +3999,7 @@ class TestCombinePvalues(TestCase):
         assert_approx_equal(p, 0.1464, significant=4)
 
 def test_jensen_shannon_divergence():
-    for _ in xrange(8):
+    for _ in range(8):
         a = np.random.random(16)
         b = np.random.random(16)
         c = (a+b)
@@ -4017,8 +4017,8 @@ def test_jsd_matrix():
     assert np.allclose(D,D.T)
     assert D.trace() == 0
     assert np.all(D >= 0)
-    for i in xrange(len(x)):
-        for j in xrange(i+1,len(x)):
+    for i in range(len(x)):
+        for j in range(i+1,len(x)):
             assert np.allclose(D[i,j], stats.jensen_shannon_divergence(x[i], x[j]))
 
 if __name__ == "__main__":

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4009,8 +4009,11 @@ def test_jensen_shannon_divergence():
         assert_(stats.jensen_shannon_divergence(a,b) > stats.jensen_shannon_divergence(a,c))
         assert_array_almost_equal(stats.jensen_shannon_divergence(a,b),stats.jensen_shannon_divergence(a,b*6))
 
-    assert_raises(ValueError, stats.jensen_shannon_divergence, np.random.random((4,2)), np.random.random((4,2)))
-
+    a = np.random.random((4,16))
+    b = np.random.random((4,16))
+    direct = stats.jensen_shannon_divergence(a,b)
+    indirect = np.array([stats.jensen_shannon_divergence(aa, bb) for aa,bb in zip(a.T,b.T)])
+    assert_array_almost_equal(direct, indirect)
 
 def test_jsd_matrix():
     from scipy.spatial.distance import squareform

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4002,24 +4002,28 @@ def test_jensen_shannon_divergence():
     for _ in range(8):
         a = np.random.random(16)
         b = np.random.random(16)
-        c = (a+b)
+        c = a+b
 
-        assert_(stats.jensen_shannon_divergence(a,a) < 1e-4)
-        assert_(stats.jensen_shannon_divergence(a,b) > 0.)
-        assert_(stats.jensen_shannon_divergence(a,b) > stats.jensen_shannon_divergence(a,c))
-        assert_array_almost_equal(stats.jensen_shannon_divergence(a,b),stats.jensen_shannon_divergence(a,b*6))
+        assert_(stats.jensen_shannon_divergence(a, a) < 1e-4)
+        assert_(stats.jensen_shannon_divergence(a, b) > 1.)
+        assert_(stats.jensen_shannon_divergence(a, b) >
+                        stats.jensen_shannon_divergence(a, c))
+        assert_array_almost_equal(stats.jensen_shannon_divergence(a, b),
+                        stats.jensen_shannon_divergence(a, b*6))
 
     a = np.random.random((4,16))
     b = np.random.random((4,16))
     direct = stats.jensen_shannon_divergence(a,b)
-    indirect = np.array([stats.jensen_shannon_divergence(aa, bb) for aa,bb in zip(a.T,b.T)])
+    indirect = np.array([stats.jensen_shannon_divergence(aa, bb)
+                                for aa,bb in zip(a.T,b.T)])
     assert_array_almost_equal(direct, indirect)
+
 
 def test_jsd_matrix():
     from scipy.spatial.distance import squareform
     x = np.random.random((50,16))
     D = squareform(stats.jsd_matrix(x))
-    assert_array_almost_equal(D,D.T)
+    assert_array_almost_equal(D, D.T)
     assert_equal(D.trace(), 0)
     assert_(np.all(D >= 0))
     for i in range(len(x)):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4005,11 +4005,22 @@ def test_jensen_shannon_divergence():
         c = a+b
 
         assert_(stats.jensen_shannon_divergence(a, a) < 1e-4)
-        assert_(stats.jensen_shannon_divergence(a, b) > 1.)
+        assert_(stats.jensen_shannon_divergence(a, b) > 0.)
         assert_(stats.jensen_shannon_divergence(a, b) >
                         stats.jensen_shannon_divergence(a, c))
         assert_array_almost_equal(stats.jensen_shannon_divergence(a, b),
                         stats.jensen_shannon_divergence(a, b*6))
+
+
+    a = np.array([1, 0, 0, 0])
+    b = np.array([0, 1, 0, 0])
+    assert_almost_equal(stats.jensen_shannon_divergence(a, b), np.log(2))
+
+    a = np.array([1, 0, 0, 0], float)
+    b = np.array([1, 1, 1, 1], float)
+    m = a/a.sum() + b/b.sum()
+    expected = ( stats.entropy(a, m) + stats.entropy(b, m) )/ 2
+    assert_almost_equal(stats.jensen_shannon_divergence(a, b), expected)
 
     a = np.random.random((4,16))
     b = np.random.random((4,16))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4009,6 +4009,8 @@ def test_jensen_shannon_divergence():
         assert_(stats.jensen_shannon_divergence(a,b) > stats.jensen_shannon_divergence(a,c))
         assert_array_almost_equal(stats.jensen_shannon_divergence(a,b),stats.jensen_shannon_divergence(a,b*6))
 
+    assert_raises(ValueError, stats.jensen_shannon_divergence, np.random.random((4,2)), np.random.random((4,2)))
+
 
 def test_jsd_matrix():
     from scipy.spatial.distance import squareform


### PR DESCRIPTION
Adds two functions: one computes a pairwise divergence, the other a
matrix.

This is used to compute divergences between distributions. Interface is similar to that of `entropy()`.
