### PR TITLE
BUG: integrate: Fix banded jacobian handling in the "vode" and "zvode" solvers.

### DIFF
--- a/scipy/integrate/tests/test_banded_ode_solvers.py
+++ b/scipy/integrate/tests/test_banded_ode_solvers.py
@@ -1,0 +1,178 @@
+
+from __future__ import division, print_function, absolute_import
+
+import itertools
+import numpy as np
+from numpy.testing import run_module_suite, assert_allclose
+from scipy.integrate import ode
+
+
+def _band_count(a):
+    """Returns ml and mu, the lower and upper band sizes of a."""
+    nrows, ncols = a.shape
+    ml = 0
+    for k in range(-nrows+1, 0):
+        if np.diag(a, k).any():
+            ml = -k
+            break
+    mu = 0
+    for k in range(nrows-1, 0, -1):
+        if np.diag(a, k).any():
+            mu = k
+            break
+    return ml, mu
+
+
+def _linear_func(t, y, a):
+    """Linear system dy/dt = a * y"""
+    return a.dot(y)
+
+
+def _linear_jac(t, y, a):
+    """Jacobian of a * y is a."""
+    return a
+
+
+def _linear_banded_jac(t, y, a):
+    """Banded Jacobian."""
+    ml, mu = _band_count(a)
+    bjac = []
+    for k in range(mu, 0, -1):
+        bjac.append(np.r_[[0] * k, np.diag(a, k)])
+    bjac.append(np.diag(a))
+    for k in range(-1, -ml-1, -1):
+        bjac.append(np.r_[np.diag(a, k), [0] * (-k)])
+    return bjac
+
+
+def _solve_linear_sys(a, y0, tend=1, dt=0.1,
+                      solver=None, method='bdf', use_jac=True,
+                      with_jacobian=False, banded=False):
+    """Use scipy.integrate.ode to solve a linear system of ODEs."""
+    if banded:
+        lband, uband = _band_count(a)
+    else:
+        lband = None
+        uband = None
+
+    if use_jac:
+        if banded:
+            r = ode(_linear_func, _linear_banded_jac)
+        else:
+            r = ode(_linear_func, _linear_jac)
+    else:
+        r = ode(_linear_func)
+
+    if solver is None:
+        if np.iscomplexobj(a):
+            solver = "zvode"
+        else:
+            solver = "vode"
+
+    r.set_integrator(solver,
+                     with_jacobian=with_jacobian,  # Is this redundant?
+                     method=method,
+                     lband=lband, uband=uband,
+                     rtol=1e-9, atol=1e-10,
+                     )
+    t0 = 0
+    r.set_initial_value(y0, t0)
+    r.set_f_params(a)
+    r.set_jac_params(a)
+
+    t = [t0]
+    y = [y0]
+    while r.successful() and r.t < tend:
+        r.integrate(r.t + dt)
+        t.append(r.t)
+        y.append(r.y)
+
+    t = np.array(t)
+    y = np.array(y)
+    return t, y
+
+
+def _analytical_solution(a, y0, t):
+    """
+    Analytical solution to the linear differential equations dy/dt = a*y.
+
+    The solution is only valid if `a` is diagonalizable.
+
+    Returns a 2-d array with shape (len(t), len(y0)).
+    """
+    lam, v = np.linalg.eig(a)
+    c = np.linalg.solve(v, y0)
+    e = c * np.exp(lam * t.reshape(-1, 1))
+    sol = e.dot(v.T)
+    return sol
+
+
+def test_banded_ode_solvers():
+    # Test the "lsoda", "vode" and "zvode" solvers of the `ode` class
+    # with a system that has a banded Jacobian matrix.
+
+    # lband = 2, uband = 1:
+    a_real = np.array([[-0.6,  0.1,    0,    0,    0],
+                       [ 0.2, -0.5,  0.9,    0,    0],
+                       [ 0.1,  0.1, -0.4,  0.1,    0],
+                       [   0,  0.3, -0.1, -0.9, -0.3],
+                       [   0,    0,  0.1,  0.1, -0.7]])
+    # lband = 0, uband = 1:
+    a_real_upper = np.triu(a_real)
+    # lband = 2, uband = 0:
+    a_real_lower = np.tril(a_real)
+    # lband = 0, uband = 0
+    a_real_diag = np.triu(a_real_lower)
+
+    # complex, lband = 2, uband = 1:
+    a_complex = a_real - 0.5j * a_real
+    # complex, lband = 0, uband = 0
+    a_complex_diag = np.diag(np.diag(a_complex))
+
+    tend = 1.0
+    dt = 0.25
+    t_exact = np.arange(0, tend + 0.5*dt, dt)
+
+    # Real systems
+    for a in [a_real, a_real_upper, a_real_lower, a_real_diag]:
+        y0 = np.arange(1, a.shape[0]+1)
+        y_exact = _analytical_solution(a, y0, t_exact)
+        p = [['vode', 'lsoda'],  # solver
+             ['bdf', 'adams'],   # method
+             [False, True],      # use_jac
+             [False, True],      # with_jacobian
+             [False, True],      # banded
+            ]
+        for solver, method, use_jac, with_jacobian, banded in \
+                                                 itertools.product(*p):
+            t, y = _solve_linear_sys(a, y0, tend=tend, dt=dt,
+                                     solver=solver,
+                                     method=method,
+                                     use_jac=use_jac,
+                                     with_jacobian=with_jacobian,
+                                     banded=banded)
+            yield assert_allclose, t, t_exact
+            yield assert_allclose, y, y_exact
+
+    # Complex systems (solver is "zvode")
+    for a in [a_complex, a_complex_diag]:
+        y0 = np.arange(1, a.shape[0]+1) + 1j
+        y_exact = _analytical_solution(a, y0, t_exact)
+        p = [['bdf', 'adams'],  # method
+             [False, True],     # use_jac
+             [False, True],     # with_jacobian
+             [False, True],     # banded
+            ]
+        for method, use_jac, with_jacobian, banded in itertools.product(*p):
+            t, y = _solve_linear_sys(a, y0, tend=tend, dt=dt,
+                                     solver="zvode",
+                                     method=method,
+                                     use_jac=use_jac,
+                                     with_jacobian=with_jacobian,
+                                     banded=banded)
+            yield assert_allclose, t, t_exact
+            yield assert_allclose, y, y_exact
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/scipy/integrate/vode.pyf
+++ b/scipy/integrate/vode.pyf
@@ -19,7 +19,7 @@ python module dvode__user__routines
          double precision dimension(n),intent(c,in) :: y
          integer intent(hide) :: ml,mu
          integer intent(hide):: nrowpd
-         double precision intent(out) :: jac(nrowpd, n)
+         double precision intent(out) :: jac(ipar, n)
          double precision intent(hide) :: rpar
          integer intent(hide) :: ipar
        end subroutine jac
@@ -42,7 +42,7 @@ python module zvode__user__routines
          double complex dimension(n),intent(c,in) :: y
          integer intent(hide) :: ml,mu
          integer intent(hide):: nrowpd
-         double complex intent(out) :: jac(nrowpd, n)
+         double complex intent(out) :: jac(ipar, n)
          double precision intent(hide) :: rpar
          integer intent(hide) :: ipar
        end subroutine jac
@@ -76,7 +76,7 @@ python module vode
          integer intent(hide),check(len(iwork)>=liw),depend(iwork) :: liw=len(iwork)
          integer intent(in) :: mf
          double precision intent(hide) :: rpar = 0.0
-         integer intent(hide) :: ipar = 0
+         integer intent(hide) :: ipar = (((mf == 14) || (mf == 24)) ? (iwork[0] + iwork[1] + 1) : neq)
        end subroutine dvode
     end interface
 
@@ -108,7 +108,7 @@ python module vode
          integer intent(hide),check(len(iwork)>=liw),depend(iwork) :: liw=len(iwork)
          integer intent(in) :: mf
          double precision intent(hide) :: rpar = 0.0
-         integer intent(hide) :: ipar = 0
+         integer intent(hide) :: ipar = (((mf == 14) || (mf == 24)) ? (iwork[0] + iwork[1] + 1) : neq)
        end subroutine zvode
     end interface
 end python module vode


### PR DESCRIPTION
The "vode" solver in the ode class is a wrapper of the Fortran routine
DVODE.  DVODE accepts a JAC argument, which is the user's implementation
of the Jacobian function.  JAC has the signature

```
SUBROUTINE JAC (NEQ, T, Y, ML, MU, PD, NROWPD, RPAR, IPAR)
DOUBLE PRECISION T, Y, PD, RPAR
DIMENSION Y(NEQ), PD(NROWPD,NEQ)
```

In the banded case, JAC is called with NROWPD = 2*ML + MU + 1.
JAC must fill in PD as described in the DVODE documentation:

```
In the band matrix case (MITER = 4), the elements
within the band are to be loaded into PD in columnwise
manner, with diagonal lines of df/dy loaded into the rows
of PD. Thus df(i)/dy(j) is to be loaded into PD(i-j+MU+1,j).
ML and MU are the half-bandwidth parameters.
```

Even though PD has dimension (NROWPD, NEQ), and NROWPD is
2*ML + MU + 1, the number of rows in PD to be filled in by JAC
is ML + MU + 1.  So there are ML extra rows of PD that can be
ignored in JAC.  This is fine in Fortran--it is call-by-reference,
so JAC just fills in the first ML + MU + 1 rows and returns.

The .pyf file used by F2PY to create a wrapper for the user-defined
python Jacobian function specifies the interface for JAC as

```
   subroutine jac(n,t,y,ml,mu,jac,nrowpd,rpar,ipar)
     integer intent(hide) :: n
     double precision :: t
     double precision dimension(n),intent(c,in) :: y
     integer intent(hide) :: ml,mu
     integer intent(hide):: nrowpd
     double precision intent(out) :: jac(nrowpd, n)
     double precision intent(hide) :: rpar
     integer intent(hide) :: ipar
   end subroutine jac
```

Note that the argument `jac` is declared intent(out), and it has
dimensions (nrowpd, n) (which matches the Fortran signature).
This means that even though there are only ml + mu + 1 nonzero
diagonals (so one would expect to create an array with shape
(ml + mu + 1, n)),  the user's Python function must return an array
with shape (2*ml + mu + 1, n).  Otherwise, the F2Py wrapper generates
an error.

This is a pointless requirement, since the Python wrapper takes the
returned array and copies it into the Fortran function's JAC argument
So the Python code has to pad its array with rows that are not used.

_**That's a summary of the problem.  The following describes the changes in this PR, but those changes won't work, so you can stop reading. :) *_*

This commit fixes the problem by making a few small changes to the .pyf
interface file. The declaration of the argument `jac` is changed to

```
     double precision intent(out) :: jac(ipar, n)
```

and in the declaration of the interface to the dvode function,
the declaration of `ipar` is changed from

```
     integer intent(hide) :: ipar = 0
```

to

```
     integer intent(hide) :: ipar = (((mf == 14) || (mf == 24)) ? (iwork[0] + iwork[1] + 1) : neq)
```

The banded case is indicated by the digit 4 in `mf`.  `iwork[0]` and
`iwork[1]` hold `ml` and `mu`, respectively.  So we are using the
previously unused integer parameter `ipar` to hold the _actual_
required number of rows in the Jacobian matrix.

The "zvode" solver has the same problem.  Both "vode" and "zvode"
are fixed in this commit.

The problem was pointed out by @bjodah in https://github.com/scipy/scipy/pull/3206
