### PR TITLE
BUG: limit input ranges in special.nctdtr

### DIFF
--- a/scipy/special/cdflib/cdftnc.f
+++ b/scipy/special/cdflib/cdftnc.f
@@ -41,8 +41,7 @@ C                Search range: [1e-100, 1E10]
 C                    DOUBLE PRECISION DF
 C
 C     PNONC <--> Noncentrality parameter of the noncentral t-distributio
-C                Input range: [-infinity , +infinity).
-C                Search range: [-1e4, 1E4]
+C                Input range: [-1e4, 1E4].
 C
 C     STATUS <-- 0 if calculation completed correctly
 C               -I if input parameter number I is out of range
@@ -102,19 +101,22 @@ C     ..
       IF (df.GT.1.0D10) THEN
           df = 1.0D10
       ENDIF
-      IF (pnonc.GT.tent4) THEN
-          pnonc = tent4
-      ELSE IF (pnonc.LT.-tent4) THEN
-          pnonc = -tent4
-      ENDIF
 
       IF (t.ne.t) THEN
           status = -4
           RETURN
       ENDIF
-      IF (pnonc.ne.pnonc) THEN
-          status = -6
-          RETURN
+
+      IF (which.NE.4) THEN
+          IF (.NOT. (pnonc.GE.-tent4)) THEN
+              status = -6
+              bound = -tent4
+              RETURN
+          ELSE IF (.NOT. (pnonc.LE.tent4)) THEN
+              status = -6
+              bound = tent4
+              RETURN
+          ENDIF
       ENDIF
 
       IF (.NOT. ((which.LT.1).OR. (which.GT.4))) GO TO 30

--- a/scipy/special/cdflib/cdftnc.f
+++ b/scipy/special/cdflib/cdftnc.f
@@ -41,7 +41,7 @@ C                Search range: [1e-100, 1E10]
 C                    DOUBLE PRECISION DF
 C
 C     PNONC <--> Noncentrality parameter of the noncentral t-distributio
-C                Input range: [-1e4, 1E4].
+C                Input range: [-1e6, 1E6].
 C
 C     STATUS <-- 0 if calculation completed correctly
 C               -I if input parameter number I is out of range
@@ -73,8 +73,8 @@ C     monotinicity of P with the other parameter.
 C
 C***********************************************************************
 C     .. Parameters ..
-      DOUBLE PRECISION tent4
-      PARAMETER (tent4=1.0D4)
+      DOUBLE PRECISION tent6
+      PARAMETER (tent6=1.0D6)
       DOUBLE PRECISION tol
       PARAMETER (tol=1.0D-8)
       DOUBLE PRECISION atol
@@ -108,13 +108,13 @@ C     ..
       ENDIF
 
       IF (which.NE.4) THEN
-          IF (.NOT. (pnonc.GE.-tent4)) THEN
+          IF (.NOT. (pnonc.GE.-tent6)) THEN
               status = -6
-              bound = -tent4
+              bound = -tent6
               RETURN
-          ELSE IF (.NOT. (pnonc.LE.tent4)) THEN
+          ELSE IF (.NOT. (pnonc.LE.tent6)) THEN
               status = -6
-              bound = tent4
+              bound = tent6
               RETURN
           ENDIF
       ENDIF
@@ -175,7 +175,7 @@ C     ..
 
       ELSE IF ((3).EQ. (which)) THEN
           df = 5.0D0
-          CALL dstinv(zero,tent4,0.5D0,0.5D0,5.0D0,atol,tol)
+          CALL dstinv(zero,tent6,0.5D0,0.5D0,5.0D0,atol,tol)
           status = 0
           CALL dinvr(status,df,fx,qleft,qhi)
   160     IF (.NOT. (status.EQ.1)) GO TO 170
@@ -197,7 +197,7 @@ C     ..
 
       ELSE IF ((4).EQ. (which)) THEN
           pnonc = 5.0D0
-          CALL dstinv(-tent4,tent4,0.5D0,0.5D0,5.0D0,atol,tol)
+          CALL dstinv(-tent6,tent6,0.5D0,0.5D0,5.0D0,atol,tol)
           status = 0
           CALL dinvr(status,pnonc,fx,qleft,qhi)
   210     IF (.NOT. (status.EQ.1)) GO TO 220
@@ -213,7 +213,7 @@ C     ..
           GO TO 240
 
   230     status = 2
-          bound = tent4
+          bound = tent6
   240     CONTINUE
   250 END IF
 

--- a/scipy/special/cdflib/cdftnc.f
+++ b/scipy/special/cdflib/cdftnc.f
@@ -94,6 +94,29 @@ C     ..
 C     .. External Subroutines ..
       EXTERNAL cumtnc,dinvr,dstinv
 C     ..
+      IF (t.GT.inf) THEN
+          t = inf
+      ELSE IF (t.LT.-inf) THEN
+          t = -inf
+      ENDIF
+      IF (df.GT.1.0D10) THEN
+          df = 1.0D10
+      ENDIF
+      IF (pnonc.GT.tent4) THEN
+          pnonc = tent4
+      ELSE IF (pnonc.LT.-tent4) THEN
+          pnonc = -tent4
+      ENDIF
+
+      IF (t.ne.t) THEN
+          status = -4
+          RETURN
+      ENDIF
+      IF (pnonc.ne.pnonc) THEN
+          status = -6
+          RETURN
+      ENDIF
+
       IF (.NOT. ((which.LT.1).OR. (which.GT.4))) GO TO 30
       IF (.NOT. (which.LT.1)) GO TO 10
       bound = 1.0D0
@@ -115,7 +138,7 @@ C     ..
 
    60 CONTINUE
    70 IF (which.EQ.3) GO TO 90
-      IF (.NOT. (df.LE.0.0D0)) GO TO 80
+      IF (df.GT.0.0D0) GO TO 80
       bound = 0.0D0
       status = -5
       RETURN

--- a/scipy/special/cdflib/cumtnc.f
+++ b/scipy/special/cdflib/cumtnc.f
@@ -111,7 +111,7 @@ C     Case pnonc essentially zero
 
 C     ******************** Case i = lambda
 
-      cent = int(lambda)
+      cent = aint(lambda)
 
       IF (cent.LT.one) cent = one
 

--- a/scipy/special/cdflib/cumtnc.f
+++ b/scipy/special/cdflib/cumtnc.f
@@ -69,7 +69,7 @@ C     .. External Subroutines ..
       EXTERNAL bratio,cumnor,cumt
 C     ..
 C     .. Intrinsic Functions ..
-      INTRINSIC abs,exp,int,log,max,min
+      INTRINSIC abs,exp,aint,log,max,min
 C     ..
 
 C     Case pnonc essentially zero

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -590,6 +590,14 @@ class TestCephes(TestCase):
     def test_nctdtr(self):
         assert_equal(cephes.nctdtr(1,0,0),0.5)
 
+        assert_approx_equal(cephes.nctdtr(np.inf, 1., 1.), 0.5, 5)
+        assert_approx_equal(cephes.nctdtr(2., np.inf, 10.), 0.0)
+        assert_approx_equal(cephes.nctdtr(2., 1., np.inf), 1.)
+
+        assert_(np.isnan(cephes.nctdtr(np.nan, 1., 1.)))
+        assert_(np.isnan(cephes.nctdtr(2., np.nan, 1.)))
+        assert_(np.isnan(cephes.nctdtr(2., 1., np.nan)))
+
     def __check_nctdtridf(self):
         cephes.nctdtridf(1,0.5,0)
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -589,6 +589,7 @@ class TestCephes(TestCase):
 
     def test_nctdtr(self):
         assert_equal(cephes.nctdtr(1,0,0),0.5)
+        assert_equal(cephes.nctdtr(9, 65536, 45), 0.0)
 
         assert_approx_equal(cephes.nctdtr(np.inf, 1., 1.), 0.5, 5)
         assert_(np.isnan(cephes.nctdtr(2., np.inf, 10.)))

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -591,7 +591,7 @@ class TestCephes(TestCase):
         assert_equal(cephes.nctdtr(1,0,0),0.5)
 
         assert_approx_equal(cephes.nctdtr(np.inf, 1., 1.), 0.5, 5)
-        assert_approx_equal(cephes.nctdtr(2., np.inf, 10.), 0.0)
+        assert_(np.isnan(cephes.nctdtr(2., np.inf, 10.)))
         assert_approx_equal(cephes.nctdtr(2., 1., np.inf), 1.)
 
         assert_(np.isnan(cephes.nctdtr(np.nan, 1., 1.)))

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3083,17 +3083,9 @@ class nct_gen(rv_continuous):
         return Px
 
     def _cdf(self, x, df, nc):
-        if (asarray(nc) > 1e4).any():
-            warnings.warn(
-                    'The noncentrality parameter is too large, '
-                    'which may result in incorrect output.', RuntimeWarning)
         return special.nctdtr(df, nc, x)
 
     def _ppf(self, q, df, nc):
-        if (asarray(nc) > 1e4).any():
-            warnings.warn(
-                    'The noncentrality parameter is too large, '
-                    'which may result in incorrect output.', RuntimeWarning)
         return special.nctdtrit(df, nc, q)
 
     def _stats(self, df, nc, moments='mv'):

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3083,9 +3083,17 @@ class nct_gen(rv_continuous):
         return Px
 
     def _cdf(self, x, df, nc):
+        if (asarray(nc) > 1e4).any():
+            warnings.warn(
+                    'The noncentrality parameter is too large, '
+                    'which may result in incorrect output.', RuntimeWarning)
         return special.nctdtr(df, nc, x)
 
     def _ppf(self, q, df, nc):
+        if (asarray(nc) > 1e4).any():
+            warnings.warn(
+                    'The noncentrality parameter is too large, '
+                    'which may result in incorrect output.', RuntimeWarning)
         return special.nctdtrit(df, nc, q)
 
     def _stats(self, df, nc, moments='mv'):


### PR DESCRIPTION
This PR is similar to #3153, and it will fix #2667. The limitations are described in the original comments.
This will also fix #3209 to some extent. There seems to be no efficient algorithm to calculate the PDF of the noncentral t distribution in high accuracy when the noncentrality parameter is large. The limitations will help avoid overflows and give a reasonable approximation under practical conditions. A warning will be issued in such cases as well.
