### PR TITLE
Add the limiting distributions to generalized Pareto distribution with shapes c=0 and c=-1

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -15,7 +15,7 @@ from scipy.special import (gammaln as gamln, gamma as gam, boxcox, boxcox1p)
 
 from numpy import (where, arange, putmask, ravel, sum, shape,
                    log, sqrt, exp, arctanh, tan, sin, arcsin, arctan,
-                   tanh, cos, cosh, sinh, expm1)
+                   tanh, cos, cosh, sinh)
 
 from numpy import polyval, place, extract, any, asarray, nan, inf, pi
 
@@ -941,7 +941,7 @@ class expon_gen(rv_continuous):
         return -x
 
     def _cdf(self, x):
-        return -expm1(-x)
+        return -special.expm1(-x)
 
     def _ppf(self, q):
         return -special.log1p(-q)
@@ -991,7 +991,7 @@ class exponweib_gen(rv_continuous):
         return logp
 
     def _cdf(self, x, a, c):
-        exm1c = -expm1(-x**c)
+        exm1c = -special.expm1(-x**c)
         return exm1c**a
 
     def _ppf(self, q, a, c):
@@ -1031,10 +1031,10 @@ class exponpow_gen(rv_continuous):
         return 1 + log(b) + (b-1.0)*log(x) + xb - exp(xb)
 
     def _cdf(self, x, b):
-        return -expm1(-expm1(x**b))
+        return -special.expm1(-special.expm1(x**b))
 
     def _sf(self, x, b):
-        return exp(-expm1(x**b))
+        return exp(-special.expm1(x**b))
 
     def _isf(self, x, b):
         return (special.log1p(-log(x)))**(1./b)
@@ -1289,7 +1289,7 @@ class frechet_r_gen(rv_continuous):
         return log(c) + (c-1)*log(x) - pow(x, c)
 
     def _cdf(self, x, c):
-        return -expm1(-pow(x, c))
+        return -special.expm1(-pow(x, c))
 
     def _ppf(self, q, c):
         return pow(-special.log1p(-q), 1.0/c)
@@ -1424,7 +1424,7 @@ class genpareto_gen(rv_continuous):
         return -(c + 1.) * self._log1pcx(x, c)
 
     def _cdf(self, x, c):
-        return -np.expm1(self._logsf(x, c))
+        return -special.expm1(self._logsf(x, c))
 
     def _sf(self, x, c):
        return np.exp(self._logsf(x, c))
@@ -1483,13 +1483,15 @@ class genexpon_gen(rv_continuous):
 
     """
     def _pdf(self, x, a, b, c):
-        return (a+b*(-expm1(-c*x)))*exp((-a-b)*x+b*(-expm1(-c*x))/c)
+        return (a + b*(-special.expm1(-c*x)))*exp((-a-b)*x + \
+            b*(-special.expm1(-c*x))/c)
 
     def _cdf(self, x, a, b, c):
-        return -expm1((-a-b)*x + b*(-expm1(-c*x))/c)
+        return -special.expm1((-a-b)*x + b*(-special.expm1(-c*x))/c)
 
     def _logpdf(self, x, a, b, c):
-        return np.log(a+b*(-expm1(-c*x))) + (-a-b)*x+b*(-expm1(-c*x))/c
+        return np.log(a+b*(-special.expm1(-c*x))) + \
+                (-a-b)*x+b*(-special.expm1(-c*x))/c
 genexpon = genexpon_gen(a=0.0, name='genexpon')
 
 
@@ -1537,7 +1539,7 @@ class genextreme_gen(rv_continuous):
 
     def _ppf(self, q, c):
         x = -log(-log(q))
-        return where((c == 0)*(x == x), x, -expm1(-c*x)/c)
+        return where((c == 0)*(x == x), x, -special.expm1(-c*x)/c)
 
     def _stats(self, c):
         g = lambda n: gam(n*c+1)
@@ -1547,9 +1549,9 @@ class genextreme_gen(rv_continuous):
         g4 = g(4)
         g2mg12 = where(abs(c) < 1e-7, (c*pi)**2.0/6.0, g2-g1**2.0)
         gam2k = where(abs(c) < 1e-7, pi**2.0/6.0,
-                      expm1(gamln(2.0*c+1.0)-2*gamln(c+1.0))/c**2.0)
+                      special.expm1(gamln(2.0*c+1.0)-2*gamln(c+1.0))/c**2.0)
         eps = 1e-14
-        gamk = where(abs(c) < eps, -_EULER, expm1(gamln(c+1))/c)
+        gamk = where(abs(c) < eps, -_EULER, special.expm1(gamln(c+1))/c)
 
         m = where(c < -1.0, nan, -gamk)
         v = where(c < -0.5, nan, g1**2.0*gam2k)
@@ -3757,9 +3759,9 @@ class truncexpon_gen(rv_continuous):
         # wrong answer with formula, same as in continuous.pdf
         # return gam(n+1)-special.gammainc(1+n, b)
         if n == 1:
-            return (1-(b+1)*exp(-b))/(-expm1(-b))
+            return (1-(b+1)*exp(-b))/(-special.expm1(-b))
         elif n == 2:
-            return 2*(1-0.5*(b*b+2*b+2)*exp(-b))/(-expm1(-b))
+            return 2*(1-0.5*(b*b+2*b+2)*exp(-b))/(-special.expm1(-b))
         else:
             # return generic for higher moments
             # return rv_continuous._mom1_sc(self, n, b)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1439,12 +1439,15 @@ class genpareto_gen(rv_continuous):
         return -boxcox(q, -c)
 
     def _munp(self, n, c):
-        if c != 0:
-            k = arange(0, n+1)
-            val = (-1.0/c)**n * sum(comb(n, k)*(-1)**k / (1.0-c*k), axis=0)
-            return where(c*n < 1, val, inf)
-        else:
-            return gam(n+1)
+        def __munp(n, c):
+            val = 0.0
+            k = arange(0, n + 1)
+            for ki, cnk in zip(k, comb(n, k)):
+                val = val + cnk * (-1) ** ki / (1.0 - c * ki)
+            return where(c * n < 1, val * (-1.0 / c) ** n, inf)
+        return _lazywhere(c != 0, (c,),
+                lambda c: __munp(n, c),
+                gam(n + 1))
 
     def _entropy(self, c):
         return 1. + c

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -15,7 +15,7 @@ from scipy.special import (gammaln as gamln, gamma as gam, boxcox, boxcox1p)
 
 from numpy import (where, arange, putmask, ravel, sum, shape,
                    log, sqrt, exp, arctanh, tan, sin, arcsin, arctan,
-                   tanh, cos, cosh, sinh, log1p, expm1)
+                   tanh, cos, cosh, sinh, expm1)
 
 from numpy import polyval, place, extract, any, asarray, nan, inf, pi
 
@@ -944,7 +944,7 @@ class expon_gen(rv_continuous):
         return -expm1(-x)
 
     def _ppf(self, q):
-        return -log1p(-q)
+        return -special.log1p(-q)
 
     def _sf(self, x):
         return exp(-x)
@@ -995,7 +995,7 @@ class exponweib_gen(rv_continuous):
         return exm1c**a
 
     def _ppf(self, q, a, c):
-        return (-log1p(-q**(1.0/a)))**asarray(1.0/c)
+        return (-special.log1p(-q**(1.0/a)))**asarray(1.0/c)
 exponweib = exponweib_gen(a=0.0, name='exponweib')
 
 
@@ -1037,10 +1037,10 @@ class exponpow_gen(rv_continuous):
         return exp(-expm1(x**b))
 
     def _isf(self, x, b):
-        return (log1p(-log(x)))**(1./b)
+        return (special.log1p(-log(x)))**(1./b)
 
     def _ppf(self, q, b):
-        return pow(log1p(-log1p(-q)), 1.0/b)
+        return pow(special.log1p(-special.log1p(-q)), 1.0/b)
 exponpow = exponpow_gen(a=0.0, name='exponpow')
 
 
@@ -1292,7 +1292,7 @@ class frechet_r_gen(rv_continuous):
         return -expm1(-pow(x, c))
 
     def _ppf(self, q, c):
-        return pow(-log1p(-q), 1.0/c)
+        return pow(-special.log1p(-q), 1.0/c)
 
     def _munp(self, n, c):
         return special.gamma(1.0+n*1.0/c)
@@ -1367,7 +1367,7 @@ class genlogistic_gen(rv_continuous):
         return exp(self._logpdf(x, c))
 
     def _logpdf(self, x, c):
-        return log(c) - x - (c+1.0)*log1p(exp(-x))
+        return log(c) - x - (c+1.0)*special.log1p(exp(-x))
 
     def _cdf(self, x, c):
         Cx = (1+exp(-x))**(-c)
@@ -1452,7 +1452,7 @@ class genpareto_gen(rv_continuous):
     def _log1pcx(self, x, c):
         # log(1+c*x)/c incl c\to 0 limit
         return _lazywhere((x==x) & (c != 0), (x, c),
-            lambda x, c: np.log1p(c*x) / c,
+            lambda x, c: special.log1p(c*x) / c,
             x)
 genpareto = genpareto_gen(a=0.0, name='genpareto')
 
@@ -1523,7 +1523,7 @@ class genextreme_gen(rv_continuous):
 
     def _pdf(self, x, c):
         cx = c*x
-        logex2 = where((c == 0)*(x == x), 0.0, log1p(-cx))
+        logex2 = where((c == 0)*(x == x), 0.0, special.log1p(-cx))
         logpex2 = where((c == 0)*(x == x), -x, logex2/c)
         pex2 = exp(logpex2)
         # Handle special cases
@@ -1532,7 +1532,7 @@ class genextreme_gen(rv_continuous):
         return exp(logpdf)
 
     def _cdf(self, x, c):
-        loglogcdf = where((c == 0)*(x == x), -x, log1p(-c*x)/c)
+        loglogcdf = where((c == 0)*(x == x), -x, special.log1p(-c*x)/c)
         return exp(-exp(loglogcdf))
 
     def _ppf(self, q, c):
@@ -2034,7 +2034,7 @@ class halfcauchy_gen(rv_continuous):
         return 2.0/pi/(1.0+x*x)
 
     def _logpdf(self, x):
-        return np.log(2.0/pi) - np.log1p(x*x)
+        return np.log(2.0/pi) - special.log1p(x*x)
 
     def _cdf(self, x):
         return 2.0/pi*arctan(x)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -27,6 +27,7 @@ not for numerically exact results.
 
 DECIMAL = 5  # specify the precision of the tests  # increased from 0 to 5
 
+
 ## Last four of these fail all around. Need to be checked
 distcont_extra = [
     ['betaprime', (100, 86)],

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -27,7 +27,6 @@ not for numerically exact results.
 
 DECIMAL = 5  # specify the precision of the tests  # increased from 0 to 5
 
-
 ## Last four of these fail all around. Need to be checked
 distcont_extra = [
     ['betaprime', (100, 86)],

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -465,6 +465,80 @@ class TestPareto(TestCase):
             assert_allclose(k, 6*(4.5**3 + 4.5**2 - 6*4.5 - 2)/(4.5*1.5*0.5))
 
 
+class TestGenpareto(TestCase):
+    def test_ab(self):
+        # c >= 0: a, b = [0, inf]
+        for c in [1., 0.]:
+            c = np.asarray(c)
+            stats.genpareto._argcheck(c)  # ugh
+            assert_equal(stats.genpareto.a, 0.)
+            assert_(np.isposinf(stats.genpareto.b))
+
+        # c < 0: a=0, b=1/|c|
+        c = np.asarray(-2.)
+        stats.genpareto._argcheck(c)
+        assert_allclose([stats.genpareto.a, stats.genpareto.b], [0., 0.5])
+
+    def test_c0(self):
+        # with c=0, genpareto reduces to the exponential distribution
+        rv = stats.genpareto(c=0.)
+        x = np.linspace(0, 10., 30)
+        assert_allclose(rv.pdf(x), stats.expon.pdf(x))
+        assert_allclose(rv.cdf(x), stats.expon.cdf(x))
+        assert_allclose(rv.sf(x), stats.expon.sf(x))
+
+        q = np.linspace(0., 1., 10)
+        assert_allclose(rv.ppf(q), stats.expon.ppf(q))
+
+    def test_x_inf(self):
+        # make sure x=inf is handled gracefully 
+        rv = stats.genpareto(c=0.1)
+        assert_allclose([rv.pdf(np.inf), rv.cdf(np.inf)], [0., 1.])
+
+        rv = stats.genpareto(c=0.)
+        assert_allclose([rv.pdf(np.inf), rv.cdf(np.inf)], [0., 1.])
+
+    def test_c_continuity(self):
+        # pdf is continuous at c=0
+        x = np.linspace(0, 10, 30)
+        pdf0 = stats.genpareto.pdf(x, c=0)
+        for c in [1e-14, -1e-14]:
+            pdfc = stats.genpareto.pdf(x, c)
+            assert_allclose(pdf0, pdfc, atol=1e-12)
+
+        cdf0 = stats.genpareto.cdf(x, c=0)
+        for c in [1e-14, -1e-14]:
+            cdfc = stats.genpareto.cdf(x, c)
+            assert_allclose(cdf0, cdfc, atol=1e-12)
+
+    def test_c_continuity_ppf(self):
+        q = np.r_[np.logspace(1e-12, 0.01, base=0.1),
+                  np.linspace(0.01, 1, 30, endpoint=False),
+                  1. - np.logspace(1e-12, 0.01, base=0.1)]
+        ppf0 = stats.genpareto.ppf(q, c=0)
+        for c in [1e-14, -1e-14]:
+            ppfc = stats.genpareto.ppf(q, c)
+            assert_allclose(ppf0, ppfc, atol=1e-12)
+
+    def test_c_continuity_isf(self):
+        q = np.r_[np.logspace(1e-12, 0.01, base=0.1),
+                  np.linspace(0.01, 1, 30, endpoint=False),
+                  1. - np.logspace(1e-12, 0.01, base=0.1)]
+        isf0 = stats.genpareto.isf(q, c=0)
+        for c in [1e-14, -1e-14]:
+            isfc = stats.genpareto.isf(q, c)
+            assert_allclose(isf0, isfc, atol=1e-12)
+
+    def test_cdf_ppf_roundtrip(self):
+        # this should pass with machine precision. hat tip @pbrod
+        q = np.r_[np.logspace(1e-12, 0.01, base=0.1),
+                  np.linspace(0.01, 1, 30, endpoint=False),
+                  1. - np.logspace(1e-12, 0.01, base=0.1)]
+        for c in [1e-8, -1e-18, 1e-15, -1e-15]:
+            assert_allclose(stats.genpareto.cdf(stats.genpareto.ppf(q, c), c),
+                    q, atol=1e-15)
+
+
 class TestPearson3(TestCase):
     def test_rvs(self):
         vals = stats.pearson3.rvs(0.1, size=(2, 50))

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -494,9 +494,11 @@ class TestGenpareto(TestCase):
         # make sure x=inf is handled gracefully 
         rv = stats.genpareto(c=0.1)
         assert_allclose([rv.pdf(np.inf), rv.cdf(np.inf)], [0., 1.])
+        assert_(np.isneginf(rv.logpdf(np.inf)))
 
         rv = stats.genpareto(c=0.)
         assert_allclose([rv.pdf(np.inf), rv.cdf(np.inf)], [0., 1.])
+        assert_(np.isneginf(rv.logpdf(np.inf)))
 
     def test_c_continuity(self):
         # pdf is continuous at c=0


### PR DESCRIPTION
closes gh-1295

The implementation here is similar to the original one by @pbrod, as listed in gh-1295.

Several points I'd like to flag for a review:
- The exact properties of the c\to 0 limit. For example, I'm currently skipping the (otherwise failing) test for continuity of the `ppf` at small `c` --- I first wrote the test without much thinking, but in fact I'm not sure if the requirement of the test is not too stringent. The specific question here, I guess, is whether the Box-Cox transform is uniformly convergent at `lambda\to 0`.
- We might want to add a new ufunc for computing `log(1 + a*x)/x` with the correct behavior at `x=0`, instead of a private helper in `genpareto`.
- `_munp` and `entropy` are not properly vectorized at the moment (neither in master, not in this PR).
