### PR TITLE
DOC: tf2ss zpk2ss note controller canonical form

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -41,7 +41,8 @@ def tf2ss(num, den):
     Returns
     -------
     A, B, C, D : ndarray
-        State space representation of the system.
+        State space representation of the system, in controller canonical
+        form.
 
     """
     # Controller canonical state-space representation.
@@ -233,7 +234,8 @@ def zpk2ss(z, p, k):
     Returns
     -------
     A, B, C, D : ndarray
-        State-space matrices.
+        State space representation of the system, in controller canonical
+        form.
 
     """
     return tf2ss(*zpk2tf(z, p, k))


### PR DESCRIPTION
There is only one way to convert from state space form to transfer function, but there are multiple state space forms for a given transfer function.  (I'm trusting that the comment in tf2ss accurately describes the code.  This is what Matlab does too.)
