### PR TITLE
BUG: fix weave issue with too long file names with MSVC.  Closes gh-3216...

### DIFF
--- a/scipy/weave/accelerate_tools.py
+++ b/scipy/weave/accelerate_tools.py
@@ -364,7 +364,7 @@ class accelerate(object):
         return fast
 
     def identifier(self,signature):
-        # Build a SHA-256 checksum
+        # Build a (truncated, see gh-3216) SHA-256 checksum
         f = self.function
         co = f.func_code
         identifier = str(signature) + \
@@ -372,7 +372,7 @@ class accelerate(object):
                      str(co.co_consts) + \
                      str(co.co_varnames) + \
                      co.co_code
-        return 'F' + sha256(identifier).hexdigest()
+        return 'F' + sha256(identifier).hexdigest()[:32]
 
     def accelerate(self,signature,identifier):
         P = Python2CXX(self.function,signature,name=identifier)

--- a/scipy/weave/build_tools.py
+++ b/scipy/weave/build_tools.py
@@ -236,8 +236,8 @@ def build_extension(module_path,compiler_name='',build_dir=None,
     # object files separated from each other.  gcc2.x and gcc3.x C++
     # object files are not compatible, so we'll stick them in a sub
     # dir based on their version. This will add a SHA-256 check sum
-    # of the compiler binary to the directory name to keep objects
-    # from different compilers in different locations.
+    # (truncated to 32 characters) of the compiler binary to the directory
+    # name to keep objects from different compilers in different locations.
 
     compiler_dir = platform_info.get_compiler_dir(compiler_name)
     temp_dir = os.path.join(temp_dir,compiler_dir)

--- a/scipy/weave/catalog.py
+++ b/scipy/weave/catalog.py
@@ -92,7 +92,9 @@ def expr_to_filename(expr):
     """
     from hashlib import sha256
     base = 'sc_'
-    return base + sha256(expr).hexdigest()
+    # 32 chars is enough for unique filenames; too long names don't work for
+    # MSVC (see gh-3216).  Don't use md5, gives a FIPS warning.
+    return base + sha256(expr).hexdigest()[:32]
 
 
 def unique_file(d,expr):

--- a/scipy/weave/platform_info.py
+++ b/scipy/weave/platform_info.py
@@ -103,7 +103,7 @@ def check_sum(file):
     except IOError:
         bytes = ''
     chk_sum = sha256(bytes)
-    return chk_sum.hexdigest()
+    return chk_sum.hexdigest()[:32]  # truncation needed, see gh-3216
 
 
 def get_compiler_dir(compiler_name):


### PR DESCRIPTION
....

This issue was introduced in 021e0ee15.  It's MSVC specific; MSVC
has a 260 char file name (including full path).  So truncation the
has to 50 chars, plus filename prefix (`sc_` or `compiler_`), leaves
200 chars for the path which should be enough.
