### PR TITLE
RF: check write attr of fileobject without writing

### DIFF
--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -189,13 +189,10 @@ def savemat(file_name, mdict,
             file_name = file_name + ".mat"
         file_stream = open(file_name, 'wb')
     else:
-        try:
-            file_name.write(b'')
-        except AttributeError:
+        if not hasattr(file_name, 'write'):
             raise IOError('Writer needs file name or writeable '
                            'file-like object')
         file_stream = file_name
-
     if format == '4':
         if long_field_names:
             raise ValueError("Long field names are not available for version 4 files")


### PR DESCRIPTION
I was checking whether passed file object could write by doing a write of an
empty string. Writing an empty string can fail for bz2 objects in python 3.3:

http://bugs.python.org/issue16828

In any case, testing that 'write' is callable with an empty string is asking
too much of the interface. Instead just check if the object has a
'write' attribute.
