### PR TITLE
Implement fancy indexing for DOK matrices

### DIFF
--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -178,7 +178,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         i, j = self._index_to_arrays(i, j)
 
         if i.size == 0:
-            return dok_matrix((0, 0), dtype=self.dtype)
+            return dok_matrix(i.shape, dtype=self.dtype)
 
         min_i = i.min()
         if min_i < -self.shape[0] or i.max() >= self.shape[0]:

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -177,44 +177,13 @@ class dok_matrix(spmatrix, IndexMixin, dict):
 
         newdok = dok_matrix(i.shape, dtype=self.dtype)
 
-        if len(self) * _prod(i.shape) > _prod(self.shape):
-            # Most of the elements will probably be nonzeros
-            self._getitem_assume_dense(newdok, i, j)
-        else:
-            # Most of the elements will probably be zeros
-            self._getitem_assume_sparse(newdok, i, j)
-
-        return newdok
-
-    def _getitem_assume_dense(self, newdok, i, j):
-        """
-        Insert items at indices i, j to DOK matrix newdok,
-        assuming most of those items will be nonzero
-        """
         for a in xrange(i.shape[0]):
             for b in xrange(i.shape[1]):
-                dict.__setitem__(newdok, (a, b),
-                                 dict.get(self, (i[a,b], j[a,b]), 0.))
+                v = dict.get(self, (i[a,b], j[a,b]), 0.)
+                if v != 0:
+                    dict.__setitem__(newdok, (a, b), v)
 
-    def _getitem_assume_sparse(self, newdok, i, j):
-        """
-        Insert items at indices i, j t DOK matrix newdok,
-        assuming most of those items will be zero
-        """
-        i = i.flatten()
-        j = j.flatten()
-        i.sort()
-        j.sort()
-
-        for (ii, jj) in self.keys():
-            a = i.searchsorted(ii)
-            if a >= i.size or i[a] != ii:
-                continue
-            b = j.searchsorted(jj)
-            if b >= j.size or j[b] != jj:
-                continue
-            dict.__setitem__(newdok, (a, b),
-                             dict.__getitem__(self, (ii, jj)))
+        return newdok
 
     def __setitem__(self, index, x):
         i, j = self._unpack_index(index)

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -139,9 +139,9 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         i, j = self._unpack_index(index)
 
         if isintlike(i) and isintlike(j):
+            # Fast path
             i = int(i)
             j = int(j)
-            # Fast path
             if i < 0:
                 i += self.shape[0]
             if i < 0 or i >= self.shape[0]:
@@ -218,6 +218,27 @@ class dok_matrix(spmatrix, IndexMixin, dict):
 
     def __setitem__(self, index, x):
         i, j = self._unpack_index(index)
+
+        if isintlike(i) and isintlike(j):
+            # Fast path
+            i = int(i)
+            j = int(j)
+            x = self.dtype.type(x)
+            if i < 0:
+                i += self.shape[0]
+            if i < 0 or i >= self.shape[0]:
+                raise IndexError('index out of bounds')
+            if j < 0:
+                j += self.shape[1]
+            if j < 0 or j >= self.shape[1]:
+                raise IndexError('index out of bounds')
+            if x != 0:
+                dict.__setitem__(self, (i, j), x)
+            else:
+                if (i, j) in self:
+                    del self[(i, j)]
+            return
+
         i, j = self._index_to_arrays(i, j)
 
         if isspmatrix(x):

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -166,9 +166,9 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             newshape = (len(i_seq), len(j_seq))
             newsize = _prod(newshape)
 
-            if len(self) < newsize and newsize != 0:
+            if len(self) < 2*newsize and newsize != 0:
                 # Switch to the fast path only when advantageous
-                # (count the iterations in the loops)
+                # (count the iterations in the loops, adjust for complexity)
                 #
                 # We also don't handle newsize == 0 here (if
                 # i/j_intlike, it can mean index i or j was out of
@@ -207,12 +207,16 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         return newdok
 
     def _getitem_ranges(self, i_indices, j_indices, shape):
-        i_start, i_stop, i_stride = i_indices
-        j_start, j_stop, j_stride = j_indices
+        # performance golf: we don't want Numpy scalars here, they are slow
+        i_start, i_stop, i_stride = map(int, i_indices)
+        j_start, j_stop, j_stride = map(int, j_indices)
 
         newdok = dok_matrix(shape, dtype=self.dtype)
 
         for (ii, jj) in self.keys():
+            # ditto for numpy scalars
+            ii = int(ii)
+            jj = int(jj)
             a, ra = divmod(ii - i_start, i_stride)
             if a < 0 or a >= shape[0] or ra != 0:
                 continue

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -227,8 +227,6 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     def __setitem__(self, index, x):
         i, j = self._unpack_index(index)
         i, j = self._index_to_arrays(i, j)
-        i = i.ravel()
-        j = j.ravel()
 
         if isspmatrix(x):
             x = x.toarray()
@@ -259,11 +257,12 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             j = j.copy()
             j[j < 0] += self.shape[1]
 
-        dict.update(self, izip(izip(i, j), x))
+        i, j = np.broadcast_arrays(i, j)
+        dict.update(self, izip(izip(i.flat, j.flat), x.flat))
 
         if 0 in x:
             zeroes = x == 0
-            for key in izip(i[zeroes], j[zeroes]):
+            for key in izip(i[zeroes].flat, j[zeroes].flat):
                 if dict.__getitem__(self, key) == 0:
                     # may have been superseded by later update
                     del self[key]

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -173,8 +173,6 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             j = j.copy()
             j[j < 0] += self.shape[1]
 
-        i, j = np.broadcast_arrays(i, j)
-
         newdok = dok_matrix(i.shape, dtype=self.dtype)
 
         for a in xrange(i.shape[0]):
@@ -239,7 +237,6 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             j = j.copy()
             j[j < 0] += self.shape[1]
 
-        i, j = np.broadcast_arrays(i, j)
         dict.update(self, izip(izip(i.flat, j.flat), x.flat))
 
         if 0 in x:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2220,6 +2220,10 @@ class _TestFancyIndexing:
         desired_cols = np.ravel(mat.sum(0)) > 0
         assert_equal(mat[:, desired_cols].A, [[1, 0], [0, 1], [1, 0]])
 
+    def test_fancy_indexing_seq_assign(self):
+        mat = self.spmatrix(array([[1, 0], [0, 1]]))
+        assert_raises(ValueError, mat.__setitem__, (0, 0), np.array([1,2]))
+
 
 class _TestFancyIndexingAssign:
     def test_bad_index_assign(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2136,7 +2136,7 @@ class _TestFancyIndexing:
         assert_equal(A[:,s].todense(), B[:,2:4])
 
     def test_fancy_indexing_randomized(self):
-        random.seed(1234)  # make runs repeatable
+        np.random.seed(1234)  # make runs repeatable
 
         NUM_SAMPLES = 50
         M = 6
@@ -2162,7 +2162,7 @@ class _TestFancyIndexing:
         assert_raises(IndexError, S.__getitem__, (I,J_bad))
 
     def test_fancy_indexing_boolean(self):
-        random.seed(1234)  # make runs repeatable
+        np.random.seed(1234)  # make runs repeatable
 
         B = asmatrix(arange(50).reshape(5,10))
         A = self.spmatrix(B)
@@ -2193,7 +2193,7 @@ class _TestFancyIndexing:
         assert_raises((IndexError, ValueError), A.__getitem__, (X, 1))
 
     def test_fancy_indexing_sparse_boolean(self):
-        random.seed(1234)  # make runs repeatable
+        np.random.seed(1234)  # make runs repeatable
 
         B = asmatrix(arange(50).reshape(5,10))
         A = self.spmatrix(B)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2931,12 +2931,7 @@ class TestCSC(sparse_test_class()):
         assert_equal(SIJ, D[I,J])
 
 
-class TestDOK(sparse_test_class(slicing=False,
-                                slicing_assign=False,
-                                fancy_indexing=False,
-                                fancy_assign=False,
-                                minmax=False,
-                                nnz_axis=False)):
+class TestDOK(sparse_test_class(minmax=False, nnz_axis=False)):
     spmatrix = dok_matrix
     checked_dtypes = [np.int_, np.float_, np.complex_]
 


### PR DESCRIPTION
This PR implements fancy indexing for DOK matrices.

I didn't yet benchmark the `__getitem__` logic in assume-sparse vs. assume-dense item fetching.
Also slicing is not benchmarked.

**EDIT**: [benchmark here](https://gist.github.com/pv/8635783/raw/a4d17640177373fdf53e950c6d4f42b71f66220a/cmp2.txt) --- speedups for N > 1, perhaps minor slowdown for N=1. As the slice optimizations were removed in getitem, there's a slowdown for low-density matrices.

**EDIT2**: [updated benchmark](https://gist.github.com/pv/8677247/raw/687b28b78d134658bf3eda8e396cd0bf4d66b5d5/cmp3.txt) adding the slice optimizations back. Nothing else to add AFAIK.
