### PR TITLE
BUG/ENH: stats: make frozen distributions hold separate instances

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -395,7 +395,13 @@ class rv_frozen(object):
     def __init__(self, dist, *args, **kwds):
         self.args = args
         self.kwds = kwds
-        self.dist = dist
+
+        # create a new instance
+        self.dist = dist.__class__(**dist._ctor_param)    
+
+        # a, b may be set in _argcheck, depending on *args, **kwds. Ouch.
+        shapes, _, _ = self.dist._parse_args(*args, **kwds) 
+        self.dist._argcheck(*shapes)
 
     def pdf(self, x):   # raises AttributeError in frozen discrete distribution
         return self.dist.pdf(x, *self.args, **self.kwds)
@@ -1330,6 +1336,11 @@ class rv_continuous(rv_generic):
                  shapes=None, extradoc=None):
 
         super(rv_continuous, self).__init__()
+
+        # save the ctor parameters, cf generic freeze
+        self._ctor_param = dict(momtype=momtype, a=a, b=b, xtol=xtol,
+                badvalue=badvalue, name=name, longname=longname,
+                shapes=shapes, extradoc=extradoc)
 
         if badvalue is None:
             badvalue = nan
@@ -2523,6 +2534,11 @@ class rv_discrete(rv_generic):
                  shapes=None, extradoc=None):
 
         super(rv_discrete, self).__init__()
+
+        # cf generic freeze
+        self._ctor_param = dict(a=a, b=b, name=name, badvalue=badvalue,
+                 moment_tol=moment_tol, values=values, inc=inc,
+                 longname=longname, shapes=shapes, extradoc=extradoc)
 
         if badvalue is None:
             badvalue = nan

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1131,6 +1131,24 @@ class TestFrozen(TestCase):
         # the focus of this test.
         assert_equal(m1, m2)
 
+    def test_ab(self):
+        # test that the support of a frozen distribution 
+        # (i) remains frozen even if it changes for the original one
+        # (ii) is actually correct if the shape parameters are such that
+        #      the values of [a, b] are not the default [0, inf]
+        # take a genpareto as an example where the support
+        # depends on the value of the shape parameter:
+        # for c > 0: a, b = 0, inf
+        # for c < 0: a, b = 0, -1/c
+        rv = stats.genpareto(c=-0.1)
+        a, b = rv.dist.a, rv.dist.b
+        assert_equal([a, b], [0., 10.])
+
+        stats.genpareto.pdf(0, c=0.1)  # this changes genpareto.b
+        assert_equal([rv.dist.a, rv.dist.b], [a, b])
+
+        rv1 = stats.genpareto(c=0.1)
+        assert_(rv1.dist is not rv.dist)
 
 class TestExpect(TestCase):
     # Test for expect method.


### PR DESCRIPTION
This PR fixes two bugs related to frozen distributions with parameter-dependent support.

Previously, rv_frozen instances held a reference to a global distribution instance. 
For some distributions, support is parameter-dependent, and thus some spooky action on a distance:

```
>>> import scipy.stats as stats
>>> rv = stats.genpareto(c=0.1)
>>> rv.dist.a, rv.dist.b
(0.0, inf)                            # correct
>>> 
>>> stats.genpareto.pdf(0, -0.1)       #  _argcheck sets  self.b
1.0
>>> rv.dist.a, rv.dist.b
(0.0, array(10.0))                 # oops
>>> 
```

A separate bug is that freezing did not call _argcheck, so that self.dist.a and self.dist.b were always the defaults:

```
>>> rv = stats.genpareto(c=-0.1)
>>> rv.dist.a, rv.dist.b 
(0.0, inf)                             #: should be (0, 10)
>>> 
```
