### PR TITLE
ENH function to return nnz per row/column in some sparse matrices

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -83,8 +83,26 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         self.check_format(full_check=False)
 
-    def getnnz(self):
-        return int(self.indptr[-1])
+    def getnnz(self, axis=None):
+        """Get the count of explicitly-stored values (nonzeros)
+
+        Parameters
+        ----------
+        axis : None, 0, or 1
+            Select between the number of values across the whole matrix, in
+            each column, or in each row.
+        """
+        if axis is None:
+            return int(self.indptr[-1])
+        else:
+            axis, _ = self._swap((axis, 1 - axis))
+            _, N = self._swap(self.shape)
+            if axis == 0:
+                return np.bincount(self.indices, minlength=N)
+            elif axis == 1:
+                return np.diff(self.indptr)
+            raise ValueError('Unknown axis: %r' % axis)
+
     nnz = property(fget=getnnz)
 
     def _set_self(self, other, copy=False):

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -192,15 +192,33 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
         self._check()
 
-    def getnnz(self):
-        nnz = len(self.data)
-        if nnz != len(self.row) or nnz != len(self.col):
-            raise ValueError('row, column, and data array must all be the same length')
+    def getnnz(self, axis=None):
+        """Get the count of explicitly-stored values (nonzeros)
 
-        if np.rank(self.data) != 1 or np.rank(self.row) != 1 or np.rank(self.col) != 1:
-            raise ValueError('row, column, and data arrays must have rank 1')
+        Parameters
+        ----------
+        axis : None, 0, or 1
+            Select between the number of values across the whole matrix, in
+            each column, or in each row.
+        """
+        if axis is None:
+            nnz = len(self.data)
+            if nnz != len(self.row) or nnz != len(self.col):
+                raise ValueError('row, column, and data array must all be the '
+                                 'same length')
 
-        return int(nnz)
+            if np.rank(self.data) != 1 or np.rank(self.row) != 1 or \
+               np.rank(self.col) != 1:
+                raise ValueError('row, column, and data arrays must have '
+                                 'rank 1')
+
+            return int(nnz)
+        elif axis == 0:
+            return np.bincount(self.col, minlength=self.shape[1])
+        elif axis == 1:
+            return np.bincount(self.row, minlength=self.shape[0])
+        else:
+            raise ValueError('Unknown axis: %r' % axis)
     nnz = property(fget=getnnz)
 
     def _check(self):

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -177,8 +177,26 @@ class lil_matrix(spmatrix, IndexMixin):
     # Whenever the dimensions change, empty lists should be created for each
     # row
 
-    def getnnz(self):
-        return sum([len(rowvals) for rowvals in self.data])
+    def getnnz(self, axis=None):
+        """Get the count of explicitly-stored values (nonzeros)
+
+        Parameters
+        ----------
+        axis : None, 0, or 1
+            Select between the number of values across the whole matrix, in
+            each column, or in each row.
+        """
+        if axis is None:
+            return sum([len(rowvals) for rowvals in self.data])
+        elif axis == 0:
+            out = np.zeros(self.shape[1])
+            for row in self.rows:
+                out[row] += 1
+            return out
+        elif axis == 1:
+            return np.array([len(rowvals) for rowvals in self.data])
+        else:
+            raise ValueError('Unknown axis: %r' % axis)
     nnz = property(fget=getnnz)
 
     def __str__(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2508,6 +2508,22 @@ class _TestMinMax(object):
         yield check
 
 
+class _TestGetNnzAxis(object):
+    def test_getnnz_axis(self):
+        dat = np.matrix([[0, 2],
+                        [3, 5],
+                        [-6, 9]])
+        bool_dat = dat.astype(bool).A
+        datsp = self.spmatrix(dat)
+
+        assert_array_equal(bool_dat.sum(axis=None), datsp.getnnz(axis=None))
+        assert_array_equal(bool_dat.sum(), datsp.getnnz())
+        assert_array_equal(bool_dat.sum(axis=0), datsp.getnnz(axis=0))
+        assert_array_equal(bool_dat.sum(axis=1), datsp.getnnz(axis=1))
+        assert_raises(ValueError, datsp.getnnz, axis=2)
+        assert_raises(ValueError, datsp.getnnz, axis=-1)
+
+
 #------------------------------------------------------------------------------
 # Tailored base class for generic tests
 #------------------------------------------------------------------------------
@@ -2543,7 +2559,7 @@ def _possibly_unimplemented(cls, require=True):
 def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
                       fancy_indexing=True, fancy_assign=True,
                       fancy_multidim_indexing=True, fancy_multidim_assign=True,
-                      minmax=True):
+                      minmax=True, nnz_axis=True):
     """
     Construct a base class, optionally converting some of the tests in
     the suite to check that the feature is not implemented.
@@ -2562,7 +2578,8 @@ def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
                                      fancy_indexing and fancy_multidim_indexing),
              _possibly_unimplemented(_TestFancyMultidimAssign,
                                      fancy_multidim_assign and fancy_assign),
-             _possibly_unimplemented(_TestMinMax, minmax))
+             _possibly_unimplemented(_TestMinMax, minmax),
+             _possibly_unimplemented(_TestGetNnzAxis, nnz_axis))
 
     # check that test names do not clash
     names = {}
@@ -2824,7 +2841,8 @@ class TestDOK(sparse_test_class(slicing=False,
                                 slicing_assign=False,
                                 fancy_indexing=False,
                                 fancy_assign=False,
-                                minmax=False)):
+                                minmax=False,
+                                nnz_axis=False)):
     spmatrix = dok_matrix
     checked_dtypes = [np.int_, np.float_, np.complex_]
 
@@ -3156,7 +3174,7 @@ class TestCOO(sparse_test_class(getset=False,
 
 class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False,
-                                minmax=False)):
+                                minmax=False, nnz_axis=False)):
     spmatrix = dia_matrix
     checked_dtypes = [np.int_, np.float_, np.complex_]
 
@@ -3176,7 +3194,8 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
 
 class TestBSR(sparse_test_class(getset=False,
                                 slicing=False, slicing_assign=False,
-                                fancy_indexing=False, fancy_assign=False)):
+                                fancy_indexing=False, fancy_assign=False,
+                                nnz_axis=False)):
     spmatrix = bsr_matrix
     checked_dtypes = [np.int_, np.float_, np.complex_]
 


### PR DESCRIPTION
I often use `np.diff(mat.indptr)` to get the number of nonzeros in each row of a CSR or each column of a CSC. `bincount` can be used for the minor axis. Reading these expressions is unfriendly and un-polymorphic, so I propose a method to get `nnz` by axis. This PR overloads `getnnz` to that purpose in appropriate matrices.
