### PR TITLE
ENH much more efficient sparse min/max with axis

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -535,8 +535,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         # so we only do the case axis=None here
         if axis is None:
             return self.data.sum()
-        elif axis in self._swap(((1, -1), (0, 2)))[0]:
-            # faster than multiplication for large minor axis
+        elif (not hasattr(self, 'blocksize') and
+              axis in self._swap(((1, -1), (0, 2)))[0]):
+            # faster than multiplication for large minor axis in CSC/CSR
             dtype = self.dtype
             if np.issubdtype(dtype, np.bool_):
                 dtype = np.int_

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -523,6 +523,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         fn(self.shape[0], self.shape[1], self.indptr, self.indices, self.data, y)
         return y
 
+    #####################
+    # Reduce operations #
+    #####################
+
     def sum(self, axis=None):
         """Sum the matrix over the given axis.  If the axis is None, sum
         over both rows and columns, returning a scalar.
@@ -531,9 +535,37 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         # so we only do the case axis=None here
         if axis is None:
             return self.data.sum()
+        elif axis in self._swap(((1, -1), (0, 2)))[0]:
+            # faster than multiplication for large minor axis
+            dtype = self.dtype
+            if np.issubdtype(dtype, np.bool_):
+                dtype = np.int_
+            ret = np.zeros(len(self.indptr) - 1, dtype=dtype)
+            major_index, value = self._minor_reduce(np.add)
+            ret[major_index] = value
+            ret = np.asmatrix(ret)
+            if axis % 2 == 1:
+                ret = ret.T
+            return ret
         else:
-            return spmatrix.sum(self,axis)
-            raise ValueError("axis out of bounds")
+            return spmatrix.sum(self, axis)
+
+    def _minor_reduce(self, ufunc):
+        """Reduce nonzeros with a ufunc over the minor axis when non-empty
+
+        Warning: this does not call sum_duplicates()
+
+        Returns
+        -------
+        major_index : array of ints
+            Major indices where nonzero
+
+        value : array of self.dtype
+            Reduce result for nonzeros in each major_index
+        """
+        major_index = np.flatnonzero(np.diff(self.indptr))
+        value = ufunc.reduceat(self.data, self.indptr[major_index])
+        return major_index, value
 
     #######################
     # Getting and Setting #

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -118,7 +118,9 @@ class _minmax_mixin(object):
         trunc = np.searchsorted(indptr, indptr[-1])
         min_or_max.reduceat(mat.data, indptr[:trunc], out=out[:trunc])
         nnz = np.diff(indptr)
+        # compare to 0 in non-full rows
         min_or_max(out, zero, where=nnz < N, out=out)
+        # reduceat will have filled empty rows with another data entry
         out[nnz == 0] = zero
 
         out = lil_matrix(out, dtype=self.dtype)

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -104,9 +104,12 @@ class _minmax_mixin(object):
     """
 
     def _min_or_max_axis(self, axis, min_or_max):
+        N = self.shape[axis]
+        if N == 0:
+            raise ValueError("zero-size array to reduction operation")
+
         mat = self.tocsc() if axis == 0 else self.tocsr()
         mat.sum_duplicates()
-        N = mat.shape[axis]
 
         zero = self.dtype.type(0)
         out_mat = lil_matrix((1, len(mat.indptr) - 1), dtype=self.dtype)
@@ -126,10 +129,10 @@ class _minmax_mixin(object):
         return self.__class__(out_mat)
 
     def _min_or_max(self, axis, min_or_max):
-        if 0 in self.shape:
-            raise ValueError("zero-size array to reduction operation")
-
         if axis is None:
+            if 0 in self.shape:
+                raise ValueError("zero-size array to reduction operation")
+
             zero = self.dtype.type(0)
             if self.nnz == 0:
                 return zero

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -136,7 +136,7 @@ class _minmax_mixin(object):
             zero = self.dtype.type(0)
             if self.nnz == 0:
                 return zero
-            m = min_or_max.reduce(self.data)
+            m = min_or_max.reduce(self.data.ravel())
             if self.nnz != np.product(self.shape):
                 m = min_or_max(zero, m)
             return m

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -119,7 +119,8 @@ class _minmax_mixin(object):
         min_or_max.reduceat(mat.data, indptr[:trunc], out=out[:trunc])
         nnz = np.diff(indptr)
         # compare to 0 in non-full rows
-        min_or_max(out, zero, where=nnz < N, out=out)
+        mask = nnz < N
+        out[mask] = min_or_max(out[mask], zero)
         # reduceat will have filled empty rows with another data entry
         out[nnz == 0] = zero
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2517,12 +2517,19 @@ class _TestMinMax(object):
         assert_array_equal(X.min(axis=1).A, D.min(axis=1).A)
 
         # zero-size matrices
-        for D in [np.zeros((0, 0)), np.zeros((0, 10)), np.zeros((10, 0))]:
-            X = self.spmatrix(D)
-            assert_raises(ValueError, X.min, axis=0)
-            assert_raises(ValueError, X.max, axis=0)
-            assert_raises(ValueError, X.min, axis=1)
-            assert_raises(ValueError, X.max, axis=1)
+        D = np.zeros((0, 10))
+        X = self.spmatrix(D)
+        assert_raises(ValueError, X.min, axis=0)
+        assert_raises(ValueError, X.max, axis=0)
+        assert_array_equal([], X.min(axis=1).A)
+        assert_array_equal([], X.max(axis=1).A)
+
+        D = np.zeros((10, 0))
+        X = self.spmatrix(D)
+        assert_raises(ValueError, X.min, axis=1)
+        assert_raises(ValueError, X.max, axis=1)
+        assert_array_equal([], X.min(axis=0).A)
+        assert_array_equal([], X.max(axis=0).A)
 
 
 #------------------------------------------------------------------------------

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2503,13 +2503,14 @@ class _TestMinMax(object):
 
     def test_minmax_axis(self):
         D = np.matrix(np.arange(50).reshape(5,10))
-        # completely empty rows/cols:
+        # completely empty rows, leaving some completely full:
         D[1, :] = 0
-        D[:, 1] = 0
-        # empty at end for reduceat
+        # empty at end for reduceat:
         D[:, 9] = 0
         # partial rows/cols:
         D[3, 3] = 0
+        # entries on either side of 0:
+        D[2, 2] = -1
         X = self.spmatrix(D)
 
         assert_array_equal(X.max(axis=0).A, D.max(axis=0).A)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2495,17 +2495,34 @@ class _TestMinMax(object):
         assert_equal(X.min(), 0)
         assert_equal(X.max(), 19)
 
-    def test_minmax_axis(self):
-        def check():
-            D = np.matrix(np.arange(50).reshape(5,10))
+        # zero-size matrices
+        for D in [np.zeros((0, 0)), np.zeros((0, 10)), np.zeros((10, 0))]:
             X = self.spmatrix(D)
-            assert_array_equal(X.max(axis=0).A, D.max(axis=0).A)
-            assert_array_equal(X.max(axis=1).A, D.max(axis=1).A)
+            assert_raises(ValueError, X.min)
+            assert_raises(ValueError, X.max)
 
-            assert_array_equal(X.min(axis=0).A, D.min(axis=0).A)
-            assert_array_equal(X.min(axis=1).A, D.min(axis=1).A)
+    def test_minmax_axis(self):
+        D = np.matrix(np.arange(50).reshape(5,10))
+        # completely empty rows/cols:
+        D[1, :] = 0
+        D[:, 1] = 0
+        # partial rows/cols:
+        D[3, 3] = 0
+        X = self.spmatrix(D)
 
-        yield check
+        assert_array_equal(X.max(axis=0).A, D.max(axis=0).A)
+        assert_array_equal(X.max(axis=1).A, D.max(axis=1).A)
+
+        assert_array_equal(X.min(axis=0).A, D.min(axis=0).A)
+        assert_array_equal(X.min(axis=1).A, D.min(axis=1).A)
+
+        # zero-size matrices
+        for D in [np.zeros((0, 0)), np.zeros((0, 10)), np.zeros((10, 0))]:
+            X = self.spmatrix(D)
+            assert_raises(ValueError, X.min, axis=0)
+            assert_raises(ValueError, X.max, axis=0)
+            assert_raises(ValueError, X.min, axis=1)
+            assert_raises(ValueError, X.max, axis=1)
 
 
 #------------------------------------------------------------------------------

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2506,6 +2506,8 @@ class _TestMinMax(object):
         # completely empty rows/cols:
         D[1, :] = 0
         D[:, 1] = 0
+        # empty at end for reduceat
+        D[:, 9] = 0
         # partial rows/cols:
         D[3, 3] = 0
         X = self.spmatrix(D)
@@ -2521,15 +2523,15 @@ class _TestMinMax(object):
         X = self.spmatrix(D)
         assert_raises(ValueError, X.min, axis=0)
         assert_raises(ValueError, X.max, axis=0)
-        assert_array_equal([], X.min(axis=1).A)
-        assert_array_equal([], X.max(axis=1).A)
+        assert_array_equal(np.zeros((0, 1)), X.min(axis=1).A)
+        assert_array_equal(np.zeros((0, 1)), X.max(axis=1).A)
 
         D = np.zeros((10, 0))
         X = self.spmatrix(D)
         assert_raises(ValueError, X.min, axis=1)
         assert_raises(ValueError, X.max, axis=1)
-        assert_array_equal([], X.min(axis=0).A)
-        assert_array_equal([], X.max(axis=0).A)
+        assert_array_equal(np.zeros((1, 0)), X.min(axis=0).A)
+        assert_array_equal(np.zeros((1, 0)), X.max(axis=0).A)
 
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
The current implementation of `min`, `max` for sparse matrices with a specified axis is very slow, and the use of `np.where(M.indices == col)` wastes both time and memory. I don't promise this to be the tightest possible alternative, but it certainly works much faster at scale!

Benchmarks in seconds:

```
side    density master   commit1  latest
100     0.001   0.0232   0.0011   0.0009
100     0.01    0.0238   0.0033   0.0009
100     0.1     0.0162   0.0050   0.0009
1000    0.001   0.1574   0.0275   0.0010
1000    0.01    0.1858   0.0281   0.0013 
1000    0.1     0.4279   0.0302   0.0032 
10000   0.001   4.2201   0.2791   0.0048
10000   0.01   27.7040   0.2979   0.0188
10000   0.1          -   0.5101   0.2276
```
