### PR TITLE
Fast sqeuclidean

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1220,8 +1220,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
         if mstr in set(['euclidean', 'euclid', 'eu', 'e']):
             _distance_wrap.pdist_euclidean_wrap(_convert_to_double(X), dm)
         elif mstr in set(['sqeuclidean', 'sqe', 'sqeuclid']):
-            _distance_wrap.pdist_euclidean_wrap(_convert_to_double(X), dm)
-            dm = dm ** 2.0
+            _distance_wrap.pdist_sqeuclidean_wrap(_convert_to_double(X), dm)
         elif mstr in set(['cityblock', 'cblock', 'cb', 'c']):
             _distance_wrap.pdist_city_block_wrap(X, dm)
         elif mstr in set(['hamming', 'hamm', 'ha', 'h']):
@@ -2010,9 +2009,8 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
             _distance_wrap.cdist_euclidean_wrap(_convert_to_double(XA),
                                                 _convert_to_double(XB), dm)
         elif mstr in set(['sqeuclidean', 'sqe', 'sqeuclid']):
-            _distance_wrap.cdist_euclidean_wrap(_convert_to_double(XA),
+            _distance_wrap.cdist_sqeuclidean_wrap(_convert_to_double(XA),
                                                 _convert_to_double(XB), dm)
-            dm **= 2.0
         elif mstr in set(['cityblock', 'cblock', 'cb', 'c']):
             _distance_wrap.cdist_city_block_wrap(_convert_to_double(XA),
                                                  _convert_to_double(XB), dm)

--- a/scipy/spatial/src/distance.c
+++ b/scipy/spatial/src/distance.c
@@ -51,6 +51,16 @@ static NPY_INLINE double euclidean_distance(const double *u, const double *v, in
   return sqrt(s);
 }
 
+static NPY_INLINE double sqeuclidean_distance(const double *u, const double *v, int n) {
+  int i = 0;
+  double s = 0.0, d;
+  for (i = 0; i < n; i++) {
+    d = u[i] - v[i];
+    s = s + d * d;
+  }
+  return s;
+}
+
 static NPY_INLINE double ess_distance(const double *u, const double *v, int n) {
   int i = 0;
   double s = 0.0, d;
@@ -335,6 +345,19 @@ void pdist_euclidean(const double *X, double *dm, int m, int n) {
       u = X + (n * i);
       v = X + (n * j);
       *it = euclidean_distance(u, v, n);
+    }
+  }
+}
+
+void pdist_sqeuclidean(const double *X, double *dm, int m, int n) {
+  int i, j;
+  const double *u, *v;
+  double *it = dm;
+  for (i = 0; i < m; i++) {
+    for (j = i + 1; j < m; j++, it++) {
+      u = X + (n * i);
+      v = X + (n * j);
+      *it = sqeuclidean_distance(u, v, n);
     }
   }
 }
@@ -659,6 +682,20 @@ void cdist_euclidean(const double *XA,
       u = XA + (n * i);
       v = XB + (n * j);
       *it = euclidean_distance(u, v, n);
+    }
+  }
+}
+
+void cdist_sqeuclidean(const double *XA,
+		     const double *XB, double *dm, int mA, int mB, int n) {
+  int i, j;
+  const double *u, *v;
+  double *it = dm;
+  for (i = 0; i < mA; i++) {
+    for (j = 0; j < mB; j++, it++) {
+      u = XA + (n * i);
+      v = XB + (n * j);
+      *it = sqeuclidean_distance(u, v, n);
     }
   }
 }

--- a/scipy/spatial/src/distance.h
+++ b/scipy/spatial/src/distance.h
@@ -40,6 +40,7 @@
 void dist_to_squareform_from_vector(double *M, const double *v, int n);
 void dist_to_vector_from_squareform(const double *M, double *v, int n);
 void pdist_euclidean(const double *X, double *dm, int m, int n);
+void pdist_sqeuclidean(const double *X, double *dm, int m, int n);
 void pdist_seuclidean(const double *X,
 		      const double *var, double *dm, int m, int n);
 void pdist_mahalanobis(const double *X, const double *covinv,
@@ -65,6 +66,7 @@ void pdist_sokalmichener_bool(const char *X, double *dm, int m, int n);
 void pdist_sokalsneath_bool(const char *X, double *dm, int m, int n);
 
 void cdist_euclidean(const double *XA, const double *XB, double *dm, int mA, int mB, int n);
+void cdist_sqeuclidean(const double *XA, const double *XB, double *dm, int mA, int mB, int n);
 void cdist_mahalanobis(const double *XA, const double *XB,
 		       const double *covinv,
 		       double *dm, int mA, int mB, int n);

--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -63,6 +63,31 @@ extern PyObject *cdist_euclidean_wrap(PyObject *self, PyObject *args) {
   return Py_BuildValue("d", 0.0);
 }
 
+
+extern PyObject *cdist_sqeuclidean_wrap(PyObject *self, PyObject *args) {
+  PyArrayObject *XA_, *XB_, *dm_;
+  int mA, mB, n;
+  double *dm;
+  const double *XA, *XB;
+  if (!PyArg_ParseTuple(args, "O!O!O!",
+			&PyArray_Type, &XA_, &PyArray_Type, &XB_, 
+			&PyArray_Type, &dm_)) {
+    return 0;
+  }
+  else {
+    XA = (const double*)XA_->data;
+    XB = (const double*)XB_->data;
+    dm = (double*)dm_->data;
+    mA = XA_->dimensions[0];
+    mB = XB_->dimensions[0];
+    n = XA_->dimensions[1];
+
+    cdist_sqeuclidean(XA, XB, dm, mA, mB, n);
+  }
+  return Py_BuildValue("d", 0.0);
+}
+
+
 extern PyObject *cdist_canberra_wrap(PyObject *self, PyObject *args) {
   PyArrayObject *XA_, *XB_, *dm_;
   int mA, mB, n;
@@ -585,6 +610,29 @@ extern PyObject *pdist_euclidean_wrap(PyObject *self, PyObject *args) {
   return Py_BuildValue("d", 0.0);
 }
 
+
+extern PyObject *pdist_sqeuclidean_wrap(PyObject *self, PyObject *args) {
+  PyArrayObject *X_, *dm_;
+  int m, n;
+  double *dm;
+  const double *X;
+  if (!PyArg_ParseTuple(args, "O!O!",
+			&PyArray_Type, &X_,
+			&PyArray_Type, &dm_)) {
+    return 0;
+  }
+  else {
+    X = (const double*)X_->data;
+    dm = (double*)dm_->data;
+    m = X_->dimensions[0];
+    n = X_->dimensions[1];
+
+    pdist_sqeuclidean(X, dm, m, n);
+  }
+  return Py_BuildValue("d", 0.0);
+}
+
+
 extern PyObject *pdist_canberra_wrap(PyObject *self, PyObject *args) {
   PyArrayObject *X_, *dm_;
   int m, n;
@@ -1088,6 +1136,7 @@ static PyMethodDef _distanceWrapMethods[] = {
   {"cdist_cosine_wrap", cdist_cosine_wrap, METH_VARARGS},
   {"cdist_dice_bool_wrap", cdist_dice_bool_wrap, METH_VARARGS},
   {"cdist_euclidean_wrap", cdist_euclidean_wrap, METH_VARARGS},
+  {"cdist_sqeuclidean_wrap", cdist_sqeuclidean_wrap, METH_VARARGS},
   {"cdist_hamming_wrap", cdist_hamming_wrap, METH_VARARGS},
   {"cdist_hamming_bool_wrap", cdist_hamming_bool_wrap, METH_VARARGS},
   {"cdist_jaccard_wrap", cdist_jaccard_wrap, METH_VARARGS},
@@ -1110,6 +1159,7 @@ static PyMethodDef _distanceWrapMethods[] = {
   {"pdist_cosine_wrap", pdist_cosine_wrap, METH_VARARGS},
   {"pdist_dice_bool_wrap", pdist_dice_bool_wrap, METH_VARARGS},
   {"pdist_euclidean_wrap", pdist_euclidean_wrap, METH_VARARGS},
+  {"pdist_sqeuclidean_wrap", pdist_sqeuclidean_wrap, METH_VARARGS},
   {"pdist_hamming_wrap", pdist_hamming_wrap, METH_VARARGS},
   {"pdist_hamming_bool_wrap", pdist_hamming_bool_wrap, METH_VARARGS},
   {"pdist_jaccard_wrap", pdist_jaccard_wrap, METH_VARARGS},


### PR DESCRIPTION
Current scipy.spatial.distance.cdist() and scipy.spatial.distance.pdist() have a very slow implementation for metric='sqeuclidean' (see issue #3251). The current scipy implementation consists of computing the distances with metric='euclidean' (which involves sqrt()) and then - literally - "*_2". Since both sqrt() and *_2 are useless for 'sqeuclidean' and expensive, this PR means to enhance the speed of computation by avoiding useless computations. This PR adds low-level C functions for 'sqeuclidean' computation, adds the wrappers and the necessary Python code to call them from pdist() and cdist(). Note that there is no change in the API or in the docs. The improved cdist() and pdist() of this PR - when metric='sqeuclidean' - are at least 2x faster than current scipy's ones.
