### PR TITLE
TST tests for non-canonical input to sparse matrix operations

### DIFF
--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3346,7 +3346,8 @@ class TestBSR(sparse_test_class(getset=False,
 def _same_sum_duplicate(data, *inds, **kwargs):
     """Duplicates entries to produce the same matrix"""
     indptr = kwargs.pop('indptr', None)
-    if np.issubdtype(data.dtype, np.bool_):
+    if np.issubdtype(data.dtype, np.bool_) or \
+       np.issubdtype(data.dtype, np.unsignedinteger):
         if indptr is None:
             return (data,) + inds
         else:
@@ -3380,20 +3381,12 @@ class _NonCanonicalMixin(object):
     def test_abs(self):
         pass
 
-    @dec.knownfailureif(True, 'add/subtract broken with non-canonical matrix')
-    def test_add_sub(self):
-        pass
-
     @dec.knownfailureif(True, 'bool(matrix) broken with non-canonical matrix')
     def test_bool(self):
         pass
 
     @dec.knownfailureif(True, 'min/max broken with non-canonical matrix')
     def test_minmax(self):
-        pass
-
-    @dec.knownfailureif(True, 'mu broken with non-canonical matrix')
-    def test_mu(self):
         pass
 
     @dec.knownfailureif(True, 'format conversion broken with non-canonical matrix')

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3339,6 +3339,10 @@ class TestBSR(sparse_test_class(getset=False,
         pass
 
 
+#------------------------------------------------------------------------------
+# Tests for non-canonical representations (with duplicates, unsorted indices)
+#------------------------------------------------------------------------------
+
 def _same_sum_duplicate(data, *inds, **kwargs):
     """Duplicates entries to produce the same matrix"""
     indptr = kwargs.pop('indptr', None)
@@ -3357,7 +3361,7 @@ def _same_sum_duplicate(data, *inds, **kwargs):
     if indptr is None:
         return (data,) + inds
     else:
-        return (data,) + inds + 2 * indptr
+        return (data,) + inds + (indptr * 2,)
 
 
 class _NonCanonicalCompressedMixin(object):
@@ -3384,11 +3388,11 @@ class TestCSRNonCanonical(_NonCanonicalCompressedMixin, TestCSR):
     pass
 
 
-class TestCSCNonCanonical(_NonCanonicalCompressedMixin, TestCSR):
+class TestCSCNonCanonical(_NonCanonicalCompressedMixin, TestCSC):
     pass
 
 
-class TestBSRNonCanonical(_NonCanonicalCompressedMixin, TestCSR):
+class TestBSRNonCanonical(_NonCanonicalCompressedMixin, TestBSR):
     pass
 
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2472,7 +2472,7 @@ class _TestArithmetic:
                 D1 = A * B.T
                 S1 = Asp * Bsp.T
 
-                assert_array_equal(S1.todense(),D1)
+                assert_allclose(S1.todense(),D1)
                 assert_equal(S1.dtype,D1.dtype)
 
 
@@ -3374,7 +3374,7 @@ class _NonCanonicalMixin(object):
         if 'shape' not in kwargs:
             kwargs['shape'] = M.shape
         NC = construct(arg1, **kwargs)
-        assert_array_almost_equal(M.A, NC.A)
+        assert_allclose(M.A, NC.A)
         return NC
 
     @dec.knownfailureif(True, 'abs broken with non-canonical matrix')


### PR DESCRIPTION
A number of sparse matrix formats are designed to treat duplicate values as their sum; they prefer indices in sorted order, but should be capable when unsorted. The current test suite largely compares functionality to numpy arrays/matrices, and so constructs sparse matrices from those, producing only _canonical_ sparse forms.

This introduces tests for non-canonical forms, but finds many test failures. I don't intend to fix them all here, but we can perhaps add known failure decorations.
