### PR TITLE
This adds root finding to pchip as this is possible to do optimal because pchip is a monotonic interpolation.

### DIFF
--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -1069,84 +1069,25 @@ class PchipInterpolator(PiecewisePolynomial):
         d : ndarray
             root of the cubic polynomial interpolated at the y-points. 
         """
-        #convert Krogh to normal a x**3 + b x**2 + c x + d
-        c0 = cubic.c[0]
-        c1 = cubic.c[1]
-        c2 = cubic.c[2]
-        c3 = cubic.c[3]
+        from scipy.interpolate._ppoly import real_roots
         x0 = cubic.xi[0]
-        x1 = cubic.xi[1]
         x2 = cubic.xi[2]
-        x3 = cubic.xi[3]
         if (cubic.yi[0][0] >= cubic.yi[2][0]):
             raise ValueError("Not a strictly increasing monotone function")
-        a = c3
-        b = (c2 - c3*x0 - c3*x1 - c3*x2)
-        c = (c1 - c2*x0 - c2*x1 + c3*x0*x1 + c3*x0*x2 + c3*x1*x2)
-        d = c0 - c1*x0 + c2*x0*x1 - c3*x0*x1*x2
-        # root of cubic f(x) - y = 0
-        d = d - y
-        # would np.roots([a,b,c,d]) be faster?
-        if a:
-#            This function gives a nice real root, however, only one and it 
-#            could be the wrong one, see 
-#            http://www.math.vanderbilt.edu/~schectex/courses/cubic/
-#            p = -b / (3*a)
-#            # we need calculus with imaginary
-#            q = p**3 + (b*c-3*a*d)/(6*a**2) + 0J
-#            r = c / (3*a)
-#            result = np.power(q+np.sqrt(q**2+(r-p**2)**3), 1/3.) + \
-#                    np.power(q-np.sqrt(q**2+(r-p**2)**3), 1/3.) + p
-#           so instead we use formula from http://en.wikipedia.org/wiki/Cubic_function
-            discr0 = b*b - 3*a*c
-            discr1 = 2*b*b*b-9*a*b*c+27*a*a*d
-            C = np.power((discr1 + np.sqrt(discr1*discr1 + 0J-4*np.power(discr0,3)))/2,1/3.)
-            u = 1
-            res1 = -1/(3*a)*(b+u*C+discr0/(C)*u*u)
-            u = (-1+np.sqrt(3)*1J)/2
-            res2 = -1/(3*a)*(b+u*C+discr0/(C)*u*u)
-            u = (-1-np.sqrt(3)*1J)/2
-            res3 = -1/(3*a)*(b+u*C+discr0/(C)*u*u)
-            result = np.empty(res1.shape, float)
-            for ind in np.arange(len(result)):
-                for res in [res1, res2, res3]:
-                    ires = np.imag(res[ind])
-                    #we know there is a real solution, discard small imaginary
-                    if np.allclose(ires, 0., atol=1e-10):
-                        rres = np.real(res[ind])
-                        if x1<= rres <= x3:
-                            result[ind] = rres
-                            break
-                        else:
-                            if np.allclose(x1-rres, 0., atol=1e-10):
-                                result[ind] = x1
-                                break
-                            elif np.allclose(x3-rres, 0., atol=1e-10):
-                                result[ind] = x3
-                                break
-                else:
-                    raise ValueError("No root")
-            return result
-        elif b:
-            #kwadratic
-            res1 = -c + np.sqrt(c**2-4*b*d*1J)/2/b
-            res2 = -c - np.sqrt(c**2-4*b*d*1J)/2/b
-            if np.any(np.imag(res1)):
-                raise ValueError('No root')
-            result = np.empty(res1.shape, float)
-            for ind in np.arange(len(result)):
-                if x0 <= res1[ind] <= x3:
-                    result[ind] = np.real(res1)
-                elif  x0 <= res2[ind] <= x3:
-                    result[ind] = np.real(res2)
-                else:
-                    raise ValueError('No root')
-            return result
-        elif c:
-            #linear
-            return -d/c
-        else:
-            raise ValueError('No unique root')
+        #convert Krogh c structure to c structure of PPoly
+        ourc = np.empty((4,1), cubic.c.dtype)
+        ourc[0, 0] = cubic.c[3,0]
+        ourc[1, 0] = cubic.c[2,0]
+        ourc[2, 0] = cubic.c[1,0]
+        ourc[1,0] += cubic.c[3]*(x0-x2)
+        ourc = ourc.reshape(4,1,1)
+        y = np.asarray(y)
+        result = np.empty(y.shape, float)
+        for ind, yval in enumerate(y):
+            ourc[3, 0, 0] = cubic.c[0,0] - yval
+            roots = real_roots(ourc, np.array([x0,x2], float), 0, 0)
+            result[ind] = roots[0]
+        return result
 
 
 def pchip_interpolate(xi, yi, x, der=0, axis=0):

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -363,6 +363,45 @@ class CheckPiecewise(TestCase):
         assert_almost_equal(P.derivative(self.test_xs,2),piecewise_polynomial_interpolate(self.xi,self.yi,self.test_xs,der=2))
         assert_almost_equal(P.derivatives(self.test_xs,2),piecewise_polynomial_interpolate(self.xi,self.yi,self.test_xs,der=[0,1]))
 
+class CheckInvertPchip(TestCase):
+    
+    def setUp(self):
+        x = np.linspace(0, 10, 11)
+        self.pch_lin = pchip(x, x)
+        self.pch_kwa = pchip(x, np.power(x,2))
+        self.pch_cub = pchip(x, np.power(x,3))
+        self.pch_limit = pchip([0,2], [0,4])
+        h = -np.power(10, x[::-1])/5
+        u    = 1/np.power(1+ np.power(-0.015 * h, 1.3), 1. - 1./1.3)
+        self.pch_vGn = pchip(h, u)
+
+    def test_inv_lin(self):
+        test = np.array([1., 3.5, 8.3])
+        assert_almost_equal(self.pch_lin.root(test), test)
+
+    def test_inv_kwa(self):
+        test = np.array([1., 2.1, 8.3])
+        assert_almost_equal(self.pch_kwa.root(np.power(test, 2)), test, 2)
+        
+    def test_inv_cub(self):
+        test = np.array([1., 2.1, 8.3])
+        assert_almost_equal(self.pch_cub.root(np.power(test, 3)), test, 1)
+   
+    def test_inv_vGn(self):
+        testx = np.array([-19., -54., -200., -500.])
+        testy = self.pch_vGn(testx)
+        invx = self.pch_vGn.root(testy)
+        assert_almost_equal(invx, testx, 7)
+
+    def test_scalar(self):
+        testx = -54
+        testy = self.pch_vGn(testx)
+        invx = self.pch_vGn.root(testy)
+        assert_almost_equal(invx, testx, 7)
+
+    def test_inv_limit(self):
+        test = 2
+        assert_almost_equal(self.pch_limit.root(test), 1)
 
 if __name__ == '__main__':
     run_module_suite()

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -385,7 +385,7 @@ class CheckInvertPchip(TestCase):
         
     def test_inv_cub(self):
         test = np.array([1., 2.1, 8.3])
-        assert_almost_equal(self.pch_cub.root(np.power(test, 3)), test, 1)
+        assert_almost_equal(self.pch_cub.root(np.power(test, 3)), test, 2)
    
     def test_inv_vGn(self):
         testx = np.array([-19., -54., -200., -500.])


### PR DESCRIPTION
Alternative would be fsolve and friends, but those would not use the known structure of pchip.

A typical use for pchip is an interpolation that can be inverted.  This adds a root finding to pchip that uses the pchip form to invert fast.

I am not sure this is the best way. It might be better to use phcip to obtain yi=f(xi) and yi' = f'(xi), then create the cubic monotonic interpolation through yi with derivatives yi' as self.pchipinv. This should be the correct f^-1. 
Then when asking roots, one can use this self.pchipinv. 

The algorithm proposed here works differently: search the cubic for the y value given, calculate the 3 cubic roots. As it is a monotonic function only 1 of the roots will be in the correct interval.

Some problems:
1. computing cubic roots gives imaginary parts which need to be discarded.
   See the np.allclose(ires, 0., atol=1e-10) to discard this. -10 is hard coded
2. return value can be numerically close to the bounding edges.
   See the np.allclose(x1-rres, 0., atol=1e-10) to recognize this. -10 is hard coded
3. Use of newaxis to dump the results: x[c] = ress[:, np.newaxis] 
    I believe this will be correct for the use cases possible
