### PR TITLE
DOC: special: note that expit is aka the logistic

### DIFF
--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -496,8 +496,8 @@ add_newdoc('scipy.special', 'expit',
     """
     Expit ufunc for ndarrays.
 
-    The expit function is defined as expit(x) = 1/(1+exp(-x)).
-    Note that expit is the inverse logit function.
+    The expit function, also known as the logistic function, is defined as
+    expit(x) = 1/(1+exp(-x)). It is the inverse of the logit function.
 
     .. versionadded:: 0.10.0
 


### PR DESCRIPTION
I only found this function, which I'd implemented several times myself (using `tanh`), when I noticed the word "logit" popping up in build output; machine learning literature invariably calls this the logistic rather than the expit. [MathWorld](http://mathworld.wolfram.com/SigmoidFunction.html) doesn't mention expit either.
