### PR TITLE
ENH getting single element from CSR/CSC sparse matrix with duplicates

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -765,19 +765,13 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         major_index, minor_index = self._swap((row,col))
 
+        # TODO make use of sorted indices (if present)
+
         start = self.indptr[major_index]
         end = self.indptr[major_index+1]
-        indxs = np.where(minor_index == self.indices[start:end])[0]
-
-        num_matches = len(indxs)
-
-        if num_matches == 0:
-            # entry does not appear in the matrix
-            return self.dtype.type(0)
-        elif num_matches == 1:
-            return self.data[start:end][indxs[0]]
-        else:
-            raise ValueError('nonzero entry (%d,%d) occurs more than once' % (row,col))
+        # can use np.add(..., where) from numpy 1.7
+        return np.compress(minor_index == self.indices[start:end],
+                           self.data[start:end]).sum(dtype=self.dtype)
 
     def _get_slice(self, i, start, stop, stride, shape):
         """Returns a copy of the elements

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -279,33 +279,6 @@ class csr_matrix(_cs_matrix, IndexMixin):
             return np.asmatrix(val)
         return self.__class__(val.reshape(row.shape))
 
-    def _get_single_element(self,row,col):
-        """Returns the single element self[row, col]
-        """
-        M, N = self.shape
-        if (row < 0):
-            row += M
-        if (col < 0):
-            col += N
-        if not (0 <= row < M) or not (0 <= col < N):
-            raise IndexError("index out of bounds")
-
-        # TODO make use of sorted indices (if present)
-
-        start = self.indptr[row]
-        end = self.indptr[row+1]
-        indxs = np.where(col == self.indices[start:end])[0]
-
-        num_matches = len(indxs)
-
-        if num_matches == 0:
-            # entry does not appear in the matrix
-            return self.dtype.type(0)
-        elif num_matches == 1:
-            return self.data[start:end][indxs[0]]
-        else:
-            raise ValueError('nonzero entry (%d,%d) occurs more than once' % (row,col))
-
     def getrow(self, i):
         """Returns a copy of row i of the matrix, as a (1 x n)
         CSR matrix (row vector).

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3415,28 +3415,8 @@ class _NonCanonicalCompressedMixin(_NonCanonicalMixin):
 
 
 class _NonCanonicalCSMixin(_NonCanonicalCompressedMixin):
-    @dec.knownfailureif(True, 'copy with non-canonical matrix not implemented due to __getitem__')
-    def test_copy(self):
-        pass
-
-    @dec.knownfailureif(True, '__getitem__ with non-canonical matrix not implemented')
-    def test_ellipsis_slicing(self):
-        pass
-
-    @dec.knownfailureif(True, '__getitem__ with non-canonical matrix broken for sparse boolean index')
+    @dec.knownfailureif(True, '__getitem__ with non-canonical matrix broken for sparse boolean index due to __gt__')
     def test_fancy_indexing_sparse_boolean(self):
-        pass
-
-    @dec.knownfailureif(True, '__getitem__ with non-canonical matrix not implemented')
-    def test_getelement(self):
-        pass
-
-    @dec.knownfailureif(True, '__getitem__ with non-canonical matrix not implemented')
-    def test_slicing_2(self):
-        pass
-
-    @dec.knownfailureif(True, '__getitem__ with non-canonical matrix not implemented')
-    def test_slicing_3(self):
         pass
 
     @dec.knownfailureif(True, 'broadcasting element-wise multiply broken with non-canonical matrix')


### PR DESCRIPTION
It's unclear to me why this wasn't handled before as it has little relative cost.

This also removes code from `csr.py` that duplicates `compressed.py`
