### PR TITLE
FIX comparison operators for non-canonical CSR/C sparse matrices

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -202,9 +202,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             self.sum_duplicates()
         except NotImplementedError:
             pass
-        const = np.asarray(const)
-        data = self.data.astype(const.dtype)
-        data[:] = const
+        data = np.empty(self.data.shape, dtype=np.asarray(const).dtype)
+        data.fill(const)
         return self.__class__((data, self.indices, self.indptr), shape=self.shape)
 
     def __eq__(self, other):
@@ -271,7 +270,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 raise NotImplementedError(" >= and <= don't work with 0.")
             elif op(0, other):
                 warn(bad_scalar_msg, SparseEfficiencyWarning)
-                other_arr = np.empty(self.shape)
+                other_arr = np.empty(self.shape, dtype=np.asarray(other).dtype)
                 other_arr.fill(other)
                 other_arr = self.__class__(other_arr)
                 return self._binopt(other_arr, op_name)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3462,6 +3462,30 @@ class TestBSRNonCanonical(_NonCanonicalCompressedMixin, TestBSR):
     def test_expm(self):
         pass
 
+    @dec.knownfailureif(True, 'inequalities require sum_duplicates, not implemented for BSR')
+    def test_eq(self):
+        pass
+
+    @dec.knownfailureif(True, 'inequalities require sum_duplicates, not implemented for BSR')
+    def test_ne(self):
+        pass
+
+    @dec.knownfailureif(True, 'inequalities require sum_duplicates, not implemented for BSR')
+    def test_gt(self):
+        pass
+
+    @dec.knownfailureif(True, 'inequalities require sum_duplicates, not implemented for BSR')
+    def test_lt(self):
+        pass
+
+    @dec.knownfailureif(True, 'inequalities require sum_duplicates, not implemented for BSR')
+    def test_ge(self):
+        pass
+
+    @dec.knownfailureif(True, 'inequalities require sum_duplicates, not implemented for BSR')
+    def test_le(self):
+        pass
+
 
 class TestCOONonCanonical(_NonCanonicalMixin, TestCOO):
     def _arg1_for_noncanonical(self, M):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -117,7 +117,7 @@ class _TestCommon:
             assert_(self.spmatrix([1]))
             assert_(not self.spmatrix([0]))
         for dtype in self.checked_dtypes:
-            fails = self.__class__ == TestDOK
+            fails = isinstance(self, TestDOK)
             msg = "Cannot create a rank <= 2 DOK matrix."
             yield dec.skipif(fails, msg)(check), dtype
 
@@ -158,8 +158,7 @@ class _TestCommon:
             assert_array_equal(dat == 1, (datsp == 1).todense())
 
         msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
-        fails = not (self.__class__ == TestBSR or self.__class__ == TestCSC or
-                     self.__class__ == TestCSR)
+        fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))
         for dtype in self.checked_dtypes:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=np.ComplexWarning)
@@ -194,8 +193,7 @@ class _TestCommon:
             assert_array_equal(1 != dat, (1 != datsp).todense())
 
         msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
-        fails = not (self.__class__ == TestBSR or self.__class__ == TestCSC or
-                     self.__class__ == TestCSR)
+        fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))
         for dtype in self.checked_dtypes:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=np.ComplexWarning)
@@ -259,8 +257,7 @@ class _TestCommon:
             assert_array_equal(dat < datsp2, datsp < dat2)
 
         msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
-        fails = not (self.__class__ == TestBSR or self.__class__ == TestCSC or
-                     self.__class__ == TestCSR)
+        fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))
         for dtype in self.checked_dtypes:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=np.ComplexWarning)
@@ -330,8 +327,7 @@ class _TestCommon:
             assert_array_equal(dat > datsp2, datsp > dat2)
 
         msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
-        fails = not (self.__class__ == TestBSR or self.__class__ == TestCSC or
-                     self.__class__ == TestCSR)
+        fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))
         for dtype in self.checked_dtypes:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=np.ComplexWarning)
@@ -399,8 +395,7 @@ class _TestCommon:
             assert_array_equal(dat <= datsp2, datsp <= dat2)
 
         msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
-        fails = not (self.__class__ == TestBSR or self.__class__ == TestCSC or
-                     self.__class__ == TestCSR)
+        fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))
         for dtype in self.checked_dtypes:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=np.ComplexWarning)
@@ -469,8 +464,7 @@ class _TestCommon:
             assert_array_equal(dat >= datsp2, datsp >= dat2)
 
         msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
-        fails = not (self.__class__ == TestBSR or self.__class__ == TestCSC or
-                     self.__class__ == TestCSR)
+        fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))
         for dtype in self.checked_dtypes:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=np.ComplexWarning)
@@ -841,8 +835,7 @@ class _TestCommon:
 
         for dtype in self.checked_dtypes:
             fails = ((dtype == np.typeDict['int']) and
-                    (self.__class__ == TestLIL or
-                     self.__class__ == TestDOK))
+                     isinstance(self, (TestLIL, TestDOK)))
             msg = "LIL and DOK type's __rmul__ method has problems with int data."
             yield dec.knownfailureif(fails, msg)(check), dtype
 


### PR DESCRIPTION
Fixes #3268, ensures tests are run, and refactors the implementation.
