### PR TITLE
BUG: sparse: fix bugs in dia_matrix.setdiag

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -728,25 +728,52 @@ class spmatrix(object):
         return self.tocsr().diagonal()
 
     def setdiag(self, values, k=0):
-        """Fills the diagonal elements {a_ii} with the values from the
-        given sequence.  If k != 0, fills the off-diagonal elements
-        {a_{i,i+k}} instead.
+        """
+        Set diagonal or off-diagonal elements of the array.
 
-        values may have any length.  If the diagonal is longer than values,
-        then the remaining diagonal entries will not be set.  If values if
-        longer than the diagonal, then the remaining values are ignored.
+        Parameters
+        ----------
+        values : array_like
+            New values of the diagonal elements.
+
+            Values may have any length.  If the diagonal is longer than values,
+            then the remaining diagonal entries will not be set.  If values if
+            longer than the diagonal, then the remaining values are ignored.
+
+            If a scalar value is given, all of the diagonal is set to it.
+
+        k : int, optional
+            Which off-diagonal to set, corresponding to elements a[i,i+k].
+            Default: 0 (the main diagonal).
+
         """
         M, N = self.shape
         if (k > 0 and k >= N) or (k < 0 and -k >= M):
             raise ValueError("k exceeds matrix dimensions")
         if k < 0:
-            max_index = min(M+k, N, len(values))
-            for i,v in enumerate(values[:max_index]):
-                self[i - k, i] = v
+            if np.asarray(values).ndim == 0:
+                # broadcast
+                max_index = min(M+k, N)
+                for i in xrange(max_index):
+                    self[i - k, i] = values
+            else:
+                max_index = min(M+k, N, len(values))
+                if max_index <= 0:
+                    return
+                for i,v in enumerate(values[:max_index]):
+                    self[i - k, i] = v
         else:
-            max_index = min(M, N-k, len(values))
-            for i,v in enumerate(values[:max_index]):
-                self[i, i + k] = v
+            if np.asarray(values).ndim == 0:
+                # broadcast
+                max_index = min(M, N-k)
+                for i in xrange(max_index):
+                    self[i, i + k] = values
+            else:
+                max_index = min(M, N-k, len(values))
+                if max_index <= 0:
+                    return
+                for i,v in enumerate(values[:max_index]):
+                    self[i, i + k] = v
 
     def _process_toarray_args(self, order, out):
         if out is not None:

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -188,13 +188,37 @@ class dia_matrix(_data_matrix):
         M, N = self.shape
         if k <= -M or k >= N:
             raise ValueError('k exceeds matrix dimensions')
+
+        values = np.asarray(values)
+
+        if values.ndim == 0:
+            # broadcast
+            values_n = np.inf
+        else:
+            values_n = len(values)
+
+        if k < 0:
+            n = min(M + k, N, values_n)
+            min_index = 0
+            max_index = n
+        else:
+            n = min(M, N - k, values_n)
+            min_index = k
+            max_index = k + n
+
+        if values.ndim != 0:
+            # allow also longer sequences
+            values = values[:n]
+
         if k in self.offsets:
-            self.data[self.offsets == k, :] = values
+            self.data[self.offsets == k, min_index:max_index] = values
         else:
             self.offsets = np.append(self.offsets, self.offsets.dtype.type(k))
-            self.data = np.vstack((self.data,
-                                   np.empty((1, N), dtype=self.data.dtype)))
-            self.data[-1, :] = values
+            m = max(max_index, self.data.shape[1])
+            data = np.zeros((self.data.shape[0]+1, m), dtype=self.data.dtype)
+            data[:-1,:self.data.shape[1]] = self.data
+            data[-1, min_index:max_index] = values
+            self.data = data
 
     setdiag.__doc__ = _data_matrix.setdiag.__doc__
 


### PR DESCRIPTION
Some bugs in dia_matrix.setdiag slipped through. This PR fixes:
- hide details of the internal dia_matrix data representation in
  setdiag(), so that setdiag() behavior is same for all spmatrix types
- fix bugs in resizing self.data, which doesn't always have
  self.shape[1]==N
- add scalar broadcasting behavior to setdiag() for all matrix types
- add comprehensive tests

(Milestone added --- we don't want to have setdiag with known bugs there...)
