### PR TITLE
ENH: improve signal.convolve2d performance

### DIFF
--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -93,6 +93,13 @@ class _TestConvolve2d(TestCase):
         h = array([[62,80,98,116,134]])
         assert_array_equal(g, h)
 
+    def test_valid_mode_complx(self):
+        e = [[2,3,4,5,6,7,8], [4,5,6,7,8,9,10]]
+        f = np.array([[1,2,3], [3,4,5]], dtype=np.complex) + 1j
+        g = convolve2d(e, f, 'valid')
+        h = array([[62.+24.j, 80.+30.j, 98.+36.j, 116.+42.j, 134.+48.j]])
+        assert_array_almost_equal(g, h)
+
     def test_fillvalue(self):
         a = [[1,2,3],[3,4,5]]
         b = [[2,3,4],[4,5,6]]


### PR DESCRIPTION
Store indices in inner most loop and apply them in one typed loop one
level lower. This avoids expensive memcpy and function calls for very
cheap operations.
Improves performance by almost a factor 3 with relative small changes,
but there is still a lot of room for improvement.
