### PR TITLE
Also generate a tar.xz when running paver sdist

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -312,13 +312,21 @@ def sdist():
     sh('python setup.py sdist --formats=tar')
     if os.path.exists(os.path.join('dist', tarball_name("xztar"))):
         os.unlink(os.path.join('dist', tarball_name("xztar")))
-    sh('xz %s'%os.path.join('dist', tarball_name("tar")))
+    sh('xz %s'%os.path.join('dist', tarball_name("tar")), ignore_error=True)
 
     # Copy the superpack into installers dir
     if not os.path.exists(options.installers.installersdir):
         os.makedirs(options.installers.installersdir)
 
-    for t in ['xztar', 'gztar', 'zip']:
+    if not os.path.exists(os.path.join('dist', tarball_name("xztar"))):
+        warnings.warn("Could not create tar.xz! Do you have xz installed?")
+    else:
+        t = 'xztar'
+        source = os.path.join('dist', tarball_name(t))
+        target = os.path.join(options.installers.installersdir, tarball_name(t))
+        shutil.copy(source, target)
+
+    for t in ['gztar', 'zip']:
         source = os.path.join('dist', tarball_name(t))
         target = os.path.join(options.installers.installersdir, tarball_name(t))
         shutil.copy(source, target)

--- a/pavement.py
+++ b/pavement.py
@@ -310,6 +310,8 @@ def sdist():
     # do not play well together.
     sh('python setup.py sdist --formats=gztar,zip')
     sh('python setup.py sdist --formats=tar')
+    if os.path.exists(os.path.join('dist', tarball_name("xztar"))):
+        os.unlink(os.path.join('dist', tarball_name("xztar")))
     sh('xz %s'%os.path.join('dist', tarball_name("tar")))
 
     # Copy the superpack into installers dir

--- a/pavement.py
+++ b/pavement.py
@@ -296,6 +296,10 @@ def tarball_name(type='gztar'):
     root = 'scipy-%s' % FULLVERSION
     if type == 'gztar':
         return root + '.tar.gz'
+    elif type == 'xztar':
+        return root + '.tar.xz'
+    elif type == 'tar':
+        return root + '.tar'
     elif type == 'zip':
         return root + '.zip'
     raise ValueError("Unknown type %s" % type)
@@ -305,12 +309,14 @@ def sdist():
     # To be sure to bypass paver when building sdist... paver + scipy.distutils
     # do not play well together.
     sh('python setup.py sdist --formats=gztar,zip')
+    sh('python setup.py sdist --formats=tar')
+    sh('xz %s'%os.path.join('dist', tarball_name("tar")))
 
     # Copy the superpack into installers dir
     if not os.path.exists(options.installers.installersdir):
         os.makedirs(options.installers.installersdir)
 
-    for t in ['gztar', 'zip']:
+    for t in ['xztar', 'gztar', 'zip']:
         source = os.path.join('dist', tarball_name(t))
         target = os.path.join(options.installers.installersdir, tarball_name(t))
         shutil.copy(source, target)


### PR DESCRIPTION
Would it be possible to also generate a tar.xz, when generating sdists?

This patch generates a tar.xz when running paver sdist as a first step.
