### PR TITLE
BLD: don't rebuild fortran files if nothing changed

### DIFF
--- a/scipy/_build_utils/_fortran.py
+++ b/scipy/_build_utils/_fortran.py
@@ -2,6 +2,7 @@ import re
 import sys
 import os
 import glob
+from distutils.dep_util import newer
 
 
 __all__ = ['needs_g77_abi_wrapper', 'split_fortran_files',
@@ -135,6 +136,8 @@ def split_fortran_files(source_dir, subroutines=None):
             for nfile in range(num_files):
                 new_fname = fname[:-2] + '_subr_' + str(nfile) + '.f'
                 new_fnames.append(new_fname)
+                if not newer(fname, new_fname):
+                    continue
                 with open(new_fname, 'wb') as fn:
                     if nfile + 1 == num_files:
                         fn.writelines(lines[subs[nfile]:])


### PR DESCRIPTION
if the split source isn't newer than the target no need to resplit it
and rebuild all fortran files.
Saves a lot of time on incremental builds
