### PR TITLE
MAINT: logm will be more like matlab for singular matrices

### DIFF
--- a/scipy/linalg/_matfuncs_inv_ssq.py
+++ b/scipy/linalg/_matfuncs_inv_ssq.py
@@ -372,6 +372,8 @@ def _inverse_squaring_helper(T0, theta):
     # this search will not terminate if any diagonal entry of T is zero.
     s0 = 0
     tmp_diag = np.diag(T)
+    if _count_nonzero(tmp_diag) != n:
+        raise Exception('internal inconsistency')
     while np.max(np.absolute(tmp_diag - 1)) > theta[7]:
         tmp_diag = np.sqrt(tmp_diag)
         s0 += 1
@@ -842,6 +844,7 @@ def _logm_triu(T):
 
 
 def _logm_fudge_singular_triangular_matrix(T):
+    # This should be called only when a diagonal of T is exactly zero.
     exact_singularity_msg = 'The logm input matrix is exactly singular.'
     warnings.warn(exact_singularity_msg, LogmRankWarning)
     n = T.shape[0]
@@ -897,7 +900,12 @@ def logm(A):
     A = np.asarray(A)
     if len(A.shape) != 2 or A.shape[0] != A.shape[1]:
         raise ValueError('expected a square matrix')
-    n, n = A.shape
+    n = A.shape[0]
+
+    # If the input matrix dtype is integer then copy to a float dtype matrix.
+    if issubclass(A.dtype.type, np.integer):
+        A = np.asarray(A, dtype=float)
+
     keep_it_real = np.isrealobj(A)
     try:
         if np.array_equal(A, np.triu(A)):

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -15,9 +15,10 @@ import functools
 import numpy as np
 from numpy import array, identity, dot, sqrt, double
 from numpy.testing import (TestCase, run_module_suite,
-        assert_array_equal, assert_array_less,
+        assert_array_equal, assert_array_less, assert_equal,
         assert_array_almost_equal, assert_array_almost_equal_nulp,
-        assert_allclose, assert_, assert_raises, decorators)
+        assert_allclose, assert_, assert_raises, decorators,
+        assert_raises)
 
 import scipy.linalg
 from scipy.linalg import norm
@@ -205,6 +206,18 @@ class TestLogM(TestCase):
             A = np.array(matrix_as_list, dtype=float)
             A_logm, info = logm(A, disp=False)
             assert_(A_logm.dtype.char in complex_dtype_chars)
+
+    def test_logm_exactly_singular(self):
+        A = np.array([[0, 0], [1j, 1j]])
+        for M in A, A.T:
+            expected_warning = _matfuncs_inv_ssq.LogmRankWarning
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                L, info = logm(M, disp=False)
+                assert_equal(len(w), 1)
+                assert_(issubclass(w[-1].category, expected_warning))
+                E = expm(L)
+                assert_allclose(E, M, atol=1e-14)
 
 
 class TestSqrtM(TestCase):

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -209,7 +209,8 @@ class TestLogM(TestCase):
 
     def test_logm_exactly_singular(self):
         A = np.array([[0, 0], [1j, 1j]])
-        for M in A, A.T:
+        B = np.asarray([[1, 1], [0, 0]])
+        for M in A, A.T, B, B.T:
             expected_warning = _matfuncs_inv_ssq.LogmRankWarning
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')


### PR DESCRIPTION
This PR addresses https://github.com/scipy/scipy/issues/3279 where someone uses MATLAB to find a `logm` of a complex matrix in a way that has small error in the sense that `expm(logm(A))` gives something that is near `A`.  When `A` is singular, the `logm` does not exist so it has infinite forward error, but could be possible to find an answer with small backward error.

This PR modifies scipy `logm(A)` in a way that returns something other than a matrix of `nan`s when `A` is singular, while also giving a warning in that case.  Although such an answer would have infinite forward error, it has a chance of having small backwards error.

I'm pasting some MATLAB R2012b output for singular real and complex matrices.  The output is strange because it returns NaN for a real singular matrix, but it returns non-NaN (analogous to `-46` for `log(0)`) for a complex singular matrix.

```
>> logm([0, 0; 1, 1])
Warning: At least one zero eigenvalue is detected in SCHUR(A).
         Matrix A may be singular or badly scaled. 
> In funm at 159
  In logm at 25 
Warning: Principal matrix logarithm is not defined for A with
         nonpositive real eigenvalues. A non-principal matrix
         logarithm is returned. 
> In funm at 164
  In logm at 25 

ans =

   NaN   NaN
   NaN   NaN

>> logm([0, 0; j, j])

ans =

 -37.4299 - 1.5708i  -0.0000          
  37.4299 + 3.1416i   0.0000 + 1.5708i
```
