### PR TITLE
MAINT: add 2d convolution benchmark

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -252,3 +252,4 @@ from ._peak_finding import *
 __all__ = [s for s in dir() if not s.startswith('_')]
 from numpy.testing import Tester
 test = Tester().test
+bench = Tester().bench

--- a/scipy/signal/benchmarks/bench_convolve2d.py
+++ b/scipy/signal/benchmarks/bench_convolve2d.py
@@ -1,0 +1,48 @@
+"""
+Check the speed of 2d convolution.
+
+"""
+from __future__ import division, print_function, absolute_import
+
+from itertools import product
+import time
+
+import numpy as np
+from numpy.testing import Tester, TestCase, assert_allclose
+
+from scipy.signal import convolve2d, correlate2d
+
+
+def bench_convolve2d():
+    np.random.seed(1234)
+
+    # sample a bunch of pairs of 2d arrays
+    tm_start = time.clock()
+    pairs = []
+    for ma, na, mb, nb in product((1, 2, 8, 13, 30), repeat=4):
+        a = np.random.randn(ma, na)
+        b = np.random.randn(mb, nb)
+        pairs.append((a, b))
+    tm_end = time.clock()
+    tm_total = tm_end - tm_start
+    print('time to sample random pairs of 2d arrays:')
+    print(tm_total)
+    print()
+
+    fns = (convolve2d, correlate2d)
+    modes = ('full', 'valid', 'same')
+    boundaries = ('fill', 'wrap', 'symm')
+
+    # compute 2d convolutions and correlations for each 2d array pair
+    tm_start = time.clock()
+    for a, b in pairs:
+        for fn, mode, boundary in product(fns, modes, boundaries):
+            if mode == 'valid':
+                if b.shape[0] > a.shape[0] or b.shape[1] > a.shape[1]:
+                    continue
+            fn(a, b, mode=mode, boundary=boundary)
+    tm_end = time.clock()
+    tm_total = tm_end - tm_start
+    print('time to compute 2d convolutions:')
+    print(tm_total)
+    print()

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -8,6 +8,7 @@ def configuration(parent_package='', top_path=None):
     config = Configuration('signal', parent_package, top_path)
 
     config.add_data_dir('tests')
+    config.add_data_dir('benchmarks')
 
     config.add_extension('sigtools',
                          sources=['sigtoolsmodule.c', 'firfilter.c',


### PR DESCRIPTION
This shows that https://github.com/scipy/scipy/pull/3277 gives a significant performance improvement.

Usage:
`$ python runtests.py -s signal --bench`
