### PR TITLE
TST/FIX sparse: ensure correct operation of has_sorted_indices

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -898,7 +898,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         """
 
         # first check to see if result was cached
-        if not hasattr(self,'__has_sorted_indices'):
+        if not hasattr(self,'_cs_matrix__has_sorted_indices'):
             fn = sparsetools.csr_has_sorted_indices
             self.__has_sorted_indices = \
                     fn(len(self.indptr) - 1, self.indptr, self.indices)

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -898,14 +898,14 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         """
 
         # first check to see if result was cached
-        if not hasattr(self,'_cs_matrix__has_sorted_indices'):
+        if not hasattr(self,'_has_sorted_indices'):
             fn = sparsetools.csr_has_sorted_indices
-            self.__has_sorted_indices = \
+            self._has_sorted_indices = \
                     fn(len(self.indptr) - 1, self.indptr, self.indices)
-        return self.__has_sorted_indices
+        return self._has_sorted_indices
 
     def __set_sorted(self, val):
-        self.__has_sorted_indices = bool(val)
+        self._has_sorted_indices = bool(val)
 
     has_sorted_indices = property(fget=__get_sorted, fset=__set_sorted)
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2820,6 +2820,33 @@ class TestCSR(sparse_test_class()):
             SIJ = SIJ.todense()
         assert_equal(SIJ, D[I,J])
 
+    def test_has_sorted_indices(self):
+        "Ensure has_sorted_indices memoizes sorted state for sort_indices"
+        sorted_inds = np.array([0, 1])
+        unsorted_inds = np.array([1, 0])
+        data = np.array([1, 1])
+        indptr = np.array([0, 2])
+        M = csr_matrix((data, sorted_inds, indptr)).copy()
+        assert_equal(True, M.has_sorted_indices)
+
+        M = csr_matrix((data, unsorted_inds, indptr)).copy()
+        assert_equal(False, M.has_sorted_indices)
+
+        # set by sorting
+        M.sort_indices()
+        assert_equal(True, M.has_sorted_indices)
+        assert_array_equal(M.indices, sorted_inds)
+
+        M = csr_matrix((data, unsorted_inds, indptr)).copy()
+        # set manually (although underlyingly unsorted)
+        M.has_sorted_indices = True
+        assert_equal(True, M.has_sorted_indices)
+        assert_array_equal(M.indices, unsorted_inds)
+
+        # ensure sort bypassed when has_sorted_indices == True
+        M.sort_indices()
+        assert_array_equal(M.indices, unsorted_inds)
+
 
 class TestCSC(sparse_test_class()):
     spmatrix = csc_matrix


### PR DESCRIPTION
This had used a mangled attribute incorrectly. Here's one patch. The alternative is to not use mangled attributes.
