### PR TITLE
MAINT: remove numpy.matrix usage from linalg.matfuncs.py code and enable...

### DIFF
--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -8,33 +8,97 @@ __all__ = ['expm','expm2','expm3','cosm','sinm','tanm','coshm','sinhm',
            'tanhm','logm','funm','signm','sqrtm',
            'expm_frechet', 'expm_cond', 'fractional_matrix_power']
 
-from numpy import asarray, Inf, dot, eye, diag, exp, \
-     product, logical_not, ravel, transpose, conjugate, \
-     cast, log, ogrid, imag, real, absolute, amax, sign, \
-     isfinite, sqrt, single
-from numpy import matrix as mat
+from numpy import (Inf, dot, diag, exp, product, logical_not, cast, ravel,
+        transpose, conjugate, absolute, amax, sign, isfinite, sqrt, single)
 import numpy as np
-
+import warnings
 
 # Local imports
 from .misc import norm
 from .basic import solve, inv
-from .lapack import ztrsyl
-from .special_matrices import triu, all_mat
+from .special_matrices import triu
 from .decomp import eig
-from .decomp_svd import orth, svd
+from .decomp_svd import svd
 from .decomp_schur import schur, rsf2csf
 from ._expm_frechet import expm_frechet, expm_cond
 from ._matfuncs_sqrtm import sqrtm
-import warnings
 
 eps = np.finfo(float).eps
 feps = np.finfo(single).eps
+
+_array_precision = {'i': 1, 'l': 1, 'f': 0, 'd': 1, 'F': 0, 'D': 1}
+
+
+###############################################################################
+# Utility functions.
+
+
+def _asarray_square(A):
+    """
+    Wraps asarray with the extra requirement that the input be a square matrix.
+
+    The motivation is that the matfuncs module has real functions that have
+    been lifted to square matrix functions.
+
+    Parameters
+    ----------
+    A : array_like
+        A square matrix.
+
+    Returns
+    -------
+    out : ndarray
+        An ndarray copy or view or other representation of A.
+
+    """
+    A = np.asarray(A)
+    if len(A.shape) != 2 or A.shape[0] != A.shape[1]:
+        raise ValueError('expected square array_like input')
+    return A
+
+
+def _maybe_real(A, B, tol=None):
+    """
+    Return either B or the real part of B, depending on properties of A and B.
+
+    The motivation is that B has been computed as a complicated function of A,
+    and B may be perturbed by negligible imaginary components.
+    If A is real and B is complex with small imaginary components,
+    then return a real copy of B.  The assumption in that case would be that
+    the imaginary components of B are numerical artifacts.
+
+    Parameters
+    ----------
+    A : ndarray
+        Input array whose type is to be checked as real vs. complex.
+    B : ndarray
+        Array to be returned, possibly without its imaginary part.
+    tol : float
+        Absolute tolerance.
+
+    Returns
+    -------
+    out : real or complex array
+        Either the input array B or only the real part of the input array B.
+
+    """
+    # Note that booleans and integers compare as real.
+    if np.isrealobj(A) and np.iscomplexobj(B):
+        if tol is None:
+            tol = {0:feps*1e3, 1:eps*1e6}[_array_precision[B.dtype.char]]
+        if np.allclose(B.imag, 0.0, atol=tol):
+            B = B.real
+    return B
+
+
+###############################################################################
+# Matrix functions.
 
 
 def fractional_matrix_power(A, t):
     # This fixes some issue with imports;
     # this function calls onenormest which is in scipy.sparse.
+    A = _asarray_square(A)
     import scipy.linalg._matfuncs_inv_ssq
     return scipy.linalg._matfuncs_inv_ssq.fractional_matrix_power(A, t)
 
@@ -64,8 +128,9 @@ def logm(A, disp=True):
         1-norm of the estimated error, ||err||_1 / ||A||_1
 
     """
+    A = _asarray_square(A)
+    # Avoid circular import ... this is OK, right?
     import scipy.linalg._matfuncs_inv_ssq
-    A = mat(asarray(A))
     F = scipy.linalg._matfuncs_inv_ssq.logm(A)
     errtol = 1000*eps
     #TODO use a better error approximation
@@ -84,23 +149,26 @@ def expm(A, q=None):
 
     Parameters
     ----------
-    A : (N, N) array_like
-        Matrix to be exponentiated
+    A : (N, N) array_like or sparse matrix
+        Matrix to be exponentiated.
 
     Returns
     -------
     expm : (N, N) ndarray
-        Matrix exponential of `A`
+        Matrix exponential of `A`.
 
     References
     ----------
-    N. J. Higham,
-    "The Scaling and Squaring Method for the Matrix Exponential Revisited",
-    SIAM. J. Matrix Anal. & Appl. 26, 1179 (2005).
+    .. [1] Awad H. Al-Mohy and Nicholas J. Higham (2009)
+           "A New Scaling and Squaring Algorithm for the Matrix Exponential."
+           SIAM Journal on Matrix Analysis and Applications.
+           31 (3). pp. 970-989. ISSN 1095-7162
 
     """
-    if q:
-        warnings.warn("argument q=... in scipy.linalg.expm is deprecated.")
+    if q is not None:
+        msg = "argument q=... in scipy.linalg.expm is deprecated." 
+        warnings.warn(msg, DeprecationWarning)
+    # Input checking and conversion is provided by sparse.linalg.expm().
     import scipy.sparse.linalg
     return scipy.sparse.linalg.expm(A)
 
@@ -122,14 +190,14 @@ def expm2(A):
         Matrix exponential of `A`
 
     """
-    A = asarray(A)
+    A = _asarray_square(A)
     t = A.dtype.char
     if t not in ['f','F','d','D']:
         A = A.astype('d')
         t = 'd'
-    s,vr = eig(A)
+    s, vr = eig(A)
     vri = inv(vr)
-    r = dot(dot(vr,diag(exp(s))),vri)
+    r = dot(dot(vr, diag(exp(s))), vri)
     if t in ['f', 'd']:
         return r.real.astype(t)
     else:
@@ -155,42 +223,19 @@ def expm3(A, q=20):
         Matrix exponential of `A`
 
     """
-    A = asarray(A)
+    A = _asarray_square(A)
+    n = A.shape[0]
     t = A.dtype.char
     if t not in ['f','F','d','D']:
         A = A.astype('d')
         t = 'd'
-    A = mat(A)
-    eA = eye(*A.shape,**{'dtype':t})
-    trm = mat(eA, copy=True)
+    eA = np.identity(n, dtype=t)
+    trm = np.identity(n, dtype=t)
     castfunc = cast[t]
-    for k in range(1,q):
-        trm *= A / castfunc(k)
+    for k in range(1, q):
+        trm[:] = trm.dot(A) / castfunc(k)
         eA += trm
     return eA
-
-_array_precision = {'i': 1, 'l': 1, 'f': 0, 'd': 1, 'F': 0, 'D': 1}
-
-
-def toreal(arr, tol=None):
-    """Return as real array if imaginary part is small.
-
-    Parameters
-    ----------
-    arr : array
-    tol : float
-        Absolute tolerance
-
-    Returns
-    -------
-    arr : double or complex array
-    """
-    if tol is None:
-        tol = {0:feps*1e3, 1:eps*1e6}[_array_precision[arr.dtype.char]]
-    if (arr.dtype.char in ['F', 'D','G']) and \
-       np.allclose(arr.imag, 0.0, atol=tol):
-        arr = arr.real
-    return arr
 
 
 def cosm(A):
@@ -210,11 +255,11 @@ def cosm(A):
         Matrix cosine of A
 
     """
-    A = asarray(A)
-    if A.dtype.char not in ['F','D','G']:
-        return expm(1j*A).real
-    else:
+    A = _asarray_square(A)
+    if np.iscomplexobj(A):
         return 0.5*(expm(1j*A) + expm(-1j*A))
+    else:
+        return expm(1j*A).real
 
 
 def sinm(A):
@@ -234,11 +279,11 @@ def sinm(A):
         Matrix cosine of `A`
 
     """
-    A = asarray(A)
-    if A.dtype.char not in ['F','D','G']:
-        return expm(1j*A).imag
-    else:
+    A = _asarray_square(A)
+    if np.iscomplexobj(A):
         return -0.5j*(expm(1j*A) - expm(-1j*A))
+    else:
+        return expm(1j*A).imag
 
 
 def tanm(A):
@@ -258,11 +303,8 @@ def tanm(A):
         Matrix tangent of `A`
 
     """
-    A = asarray(A)
-    if A.dtype.char not in ['F','D','G']:
-        return toreal(solve(cosm(A), sinm(A)))
-    else:
-        return solve(cosm(A), sinm(A))
+    A = _asarray_square(A)
+    return _maybe_real(A, solve(cosm(A), sinm(A)))
 
 
 def coshm(A):
@@ -282,11 +324,8 @@ def coshm(A):
         Hyperbolic matrix cosine of `A`
 
     """
-    A = asarray(A)
-    if A.dtype.char not in ['F','D','G']:
-        return toreal(0.5*(expm(A) + expm(-A)))
-    else:
-        return 0.5*(expm(A) + expm(-A))
+    A = _asarray_square(A)
+    return _maybe_real(A, 0.5 * (expm(A) + expm(-A)))
 
 
 def sinhm(A):
@@ -306,11 +345,8 @@ def sinhm(A):
         Hyperbolic matrix sine of `A`
 
     """
-    A = asarray(A)
-    if A.dtype.char not in ['F','D']:
-        return toreal(0.5*(expm(A) - expm(-A)))
-    else:
-        return 0.5*(expm(A) - expm(-A))
+    A = _asarray_square(A)
+    return _maybe_real(A, 0.5 * (expm(A) - expm(-A)))
 
 
 def tanhm(A):
@@ -330,11 +366,8 @@ def tanhm(A):
         Hyperbolic matrix tangent of `A`
 
     """
-    A = asarray(A)
-    if A.dtype.char not in ['F','D']:
-        return toreal(solve(coshm(A), sinhm(A)))
-    else:
-        return solve(coshm(A), sinhm(A))
+    A = _asarray_square(A)
+    return _maybe_real(A, solve(coshm(A), sinhm(A)))
 
 
 def funm(A, func, disp=True):
@@ -366,14 +399,8 @@ def funm(A, func, disp=True):
         1-norm of the estimated error, ||err||_1 / ||A||_1
 
     """
+    A = _asarray_square(A)
     # Perform Shur decomposition (lapack ?gees)
-    A = asarray(A)
-    if len(A.shape) != 2:
-        raise ValueError("Non-matrix input to matrix function.")
-    if A.dtype.char in ['F', 'D', 'G']:
-        cmplx_type = 1
-    else:
-        cmplx_type = 0
     T, Z = schur(A)
     T, Z = rsf2csf(T,Z)
     n,n = T.shape
@@ -397,9 +424,8 @@ def funm(A, func, disp=True):
             F[i-1,j-1] = s
             minden = min(minden,abs(den))
 
-    F = dot(dot(Z, F),transpose(conjugate(Z)))
-    if not cmplx_type:
-        F = toreal(F)
+    F = dot(dot(Z, F), transpose(conjugate(Z)))
+    F = _maybe_real(A, F)
 
     tol = {0:feps, 1:eps}[_array_precision[F.dtype.char]]
     if minden == 0.0:
@@ -415,7 +441,7 @@ def funm(A, func, disp=True):
         return F, err
 
 
-def signm(a, disp=True):
+def signm(A, disp=True):
     """
     Matrix sign function.
 
@@ -448,14 +474,15 @@ def signm(a, disp=True):
     array([-1.+0.j,  1.+0.j,  1.+0.j])
 
     """
+    A = _asarray_square(A)
     def rounded_sign(x):
-        rx = real(x)
+        rx = np.real(x)
         if rx.dtype.char == 'f':
             c = 1e3*feps*amax(x)
         else:
             c = 1e3*eps*amax(x)
         return sign((absolute(rx) > c) * rx)
-    result,errest = funm(a, rounded_sign, disp=0)
+    result, errest = funm(A, rounded_sign, disp=0)
     errtol = {0:1e3*feps, 1:1e3*eps}[_array_precision[result.dtype.char]]
     if errest < errtol:
         return result
@@ -466,17 +493,16 @@ def signm(a, disp=True):
     # 8:237-250,1981" for how to improve the following (currently a
     # rather naive) iteration process:
 
-    a = asarray(a)
     # a = result # sometimes iteration converges faster but where??
 
     # Shifting to avoid zero eigenvalues. How to ensure that shifting does
     # not change the spectrum too much?
-    vals = svd(a,compute_uv=0)
+    vals = svd(A, compute_uv=0)
     max_sv = np.amax(vals)
     # min_nonzero_sv = vals[(vals>max_sv*errtol).tolist().count(1)-1]
     # c = 0.5/min_nonzero_sv
     c = 0.5/max_sv
-    S0 = a + c*np.identity(a.shape[0])
+    S0 = A + c*np.identity(A.shape[0])
     prev_errest = errest
     for i in range(100):
         iS0 = inv(S0)

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -557,7 +557,7 @@ def expm(A):
 
     Parameters
     ----------
-    A : (M,M) array or sparse matrix
+    A : (M,M) array_like or sparse matrix
         2D Array or Matrix (sparse or dense) to be exponentiated
 
     Returns
@@ -577,6 +577,12 @@ def expm(A):
            31 (3). pp. 970-989. ISSN 1095-7162
 
     """
+    # Avoid indiscriminate asarray() to allow sparse or other strange arrays.
+    if isinstance(A, (list, tuple)):
+        A = np.asarray(A)
+    if len(A.shape) != 2 or A.shape[0] != A.shape[1]:
+        raise ValueError('expected a square matrix')
+
     # Detect upper triangularity.
     structure = UPPER_TRIANGULAR if _is_upper_triangular(A) else None
 

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -85,6 +85,19 @@ class TestExpM(TestCase):
         a = np.matrix([[0.,0],[0,0]])
         assert_array_almost_equal(expm(a),[[1,0],[0,1]])
 
+    def test_misc_types(self):
+        A = expm(np.array([[1]]))
+        yield assert_allclose, expm(((1,),)), A
+        yield assert_allclose, expm([[1]]), A
+        yield assert_allclose, expm(np.matrix([[1]])), A
+        yield assert_allclose, expm(np.array([[1]])), A
+        yield assert_allclose, expm(csc_matrix([[1]])), A
+        B = expm(np.array([[1j]]))
+        yield assert_allclose, expm(((1j,),)), B
+        yield assert_allclose, expm([[1j]]), B
+        yield assert_allclose, expm(np.matrix([[1j]])), B
+        yield assert_allclose, expm(csc_matrix([[1j]])), B
+
     def test_bidiagonal_sparse(self):
         A = csc_matrix([
             [1, 3, 0],


### PR DESCRIPTION
... expm of more array_likes

Regarding

```
> How do you handle list and other array_likes in sparse?

if isinstance(t, (list, tuple)): asarray(...)
```

this wasn't actually being done for `expm()` so I added it.  Before this PR, `expm([[0]])` would give an `AttributeError` complaining that a list has no shape, but now it gives `array([[ 1.]])`.

I've also removed usage of `numpy.matrix` from `linalg/matfuncs.py` although the functions should still work correctly with numpy matrices.
