### PR TITLE
ENH: add matrix_rank

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -863,7 +863,7 @@ def matrix_rank(M, tol=None, check_finite=True):
         raise TypeError('array should have 2 or fewer dimensions')
     if M.ndim < 2:
         return int(not np.all(M==0))
-    S = svdvals(M, check_finite=False)
+    S = svdvals(check_finite=False)
     if tol is None:
         tol = S.max() * max(M.shape) * np.finfo(S.dtype).eps
     return np.sum(S > tol)

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -770,6 +770,8 @@ def matrix_rank(M, tol=None, check_finite=True):
     Rank of the array is the number of SVD singular values of the array that are
     greater than `tol`.
 
+    .. versionadded:: 0.14.0
+
     Parameters
     ----------
     M : {(M,), (M, N)} array_like
@@ -779,6 +781,20 @@ def matrix_rank(M, tol=None, check_finite=True):
        None, and ``S`` is an array with singular values for `M`, and
        ``eps`` is the epsilon value for datatype of ``S``, then `tol` is
        set to ``S.max() * max(M.shape) * eps``.
+    check_finite : boolean, optional
+        Whether to check that the input matrix contains only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination) if the inputs do contain infinities or NaNs.
+
+    Returns
+    -------
+    rank : int
+        The effective rank of the matrix.
+
+    Raises
+    ------
+    LinAlgError
+        If SVD computation does not converge.
 
     Notes
     -----
@@ -828,7 +844,7 @@ def matrix_rank(M, tol=None, check_finite=True):
 
     Examples
     --------
-    >>> from numpy.linalg import matrix_rank
+    >>> from scipy.linalg import matrix_rank
     >>> matrix_rank(np.eye(4)) # Full rank matrix
     4
     >>> I=np.eye(4); I[-1,-1] = 0. # rank deficient matrix

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -14,7 +14,7 @@ import numpy as np
 from .flinalg import get_flinalg_funcs
 from .lapack import get_lapack_funcs
 from .misc import LinAlgError, _datacopied
-from .decomp_svd import svd
+from .decomp_svd import svd, svdvals
 from .decomp import eigh
 from scipy.linalg import calc_lwork
 
@@ -863,7 +863,7 @@ def matrix_rank(M, tol=None, check_finite=True):
         raise TypeError('array should have 2 or fewer dimensions')
     if M.ndim < 2:
         return int(not np.all(M==0))
-    S = svd(M, compute_uv=False, check_finite=False)
+    S = svdvals(check_finite=False)
     if tol is None:
         tol = S.max() * max(M.shape) * np.finfo(S.dtype).eps
     return np.sum(S > tol)

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -866,5 +866,5 @@ def matrix_rank(M, tol=None, check_finite=True):
     S = svd(M, compute_uv=False, check_finite=False)
     if tol is None:
         tol = S.max() * max(M.shape) * np.finfo(S.dtype).eps
-    return sum(S > tol)
+    return np.sum(S > tol)
 

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -605,7 +605,7 @@ def pinv(a, cond=None, rcond=None, return_rank=False, check_finite=True):
     if rcond is not None:
         cond = rcond
 
-    x, resids, rank, s = lstsq(a, b, cond=cond)
+    x, resids, rank, s = lstsq(a, b, cond=cond, check_finite=False)
 
     if return_rank:
         return x, rank
@@ -663,7 +663,7 @@ def pinv2(a, cond=None, rcond=None, return_rank=False, check_finite=True):
         a = np.asarray_chkfinite(a)
     else:
         a = np.asarray(a)
-    u, s, vh = svd(a, full_matrices=False)
+    u, s, vh = svd(a, full_matrices=False, check_finite=False)
 
     if rcond is not None:
         cond = rcond
@@ -741,7 +741,7 @@ def pinvh(a, cond=None, rcond=None, lower=True, return_rank=False,
         a = np.asarray_chkfinite(a)
     else:
         a = np.asarray(a)
-    s, u = eigh(a, lower=lower)
+    s, u = eigh(a, lower=lower, check_finite=False)
 
     if rcond is not None:
         cond = rcond
@@ -847,7 +847,7 @@ def matrix_rank(M, tol=None, check_finite=True):
         raise TypeError('array should have 2 or fewer dimensions')
     if M.ndim < 2:
         return int(not np.all(M==0))
-    S = svd(M, compute_uv=False)
+    S = svd(M, compute_uv=False, check_finite=False)
     if tol is None:
         tol = S.max() * max(M.shape) * np.finfo(S.dtype).eps
     return sum(S > tol)

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -863,7 +863,7 @@ def matrix_rank(M, tol=None, check_finite=True):
         raise TypeError('array should have 2 or fewer dimensions')
     if M.ndim < 2:
         return int(not np.all(M==0))
-    S = svdvals(check_finite=False)
+    S = svdvals(M, check_finite=False)
     if tol is None:
         tol = S.max() * max(M.shape) * np.finfo(S.dtype).eps
     return np.sum(S > tol)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -31,7 +31,7 @@ from numpy.testing import TestCase, rand, run_module_suite, assert_raises, \
     assert_allclose
 
 from scipy.linalg import solve, inv, det, lstsq, pinv, pinv2, pinvh, norm,\
-        solve_banded, solveh_banded, solve_triangular
+        solve_banded, solveh_banded, solve_triangular, matrix_rank
 
 from scipy.linalg._testutils import assert_no_overwrite
 
@@ -719,6 +719,26 @@ class TestNorm(object):
         assert_equal(norm([1,2,3], 0), 3)
 
 
+class TestMatrixRank(object):
+    def test_matrix_rank(self):
+        # Full rank matrix
+        yield assert_equal, 4, matrix_rank(np.eye(4))
+        # rank deficient matrix
+        I=np.eye(4); I[-1, -1] = 0.
+        yield assert_equal, matrix_rank(I), 3
+        # All zeros - zero rank
+        yield assert_equal, matrix_rank(np.zeros((4, 4))), 0
+        # 1 dimension - rank 1 unless all 0
+        yield assert_equal, matrix_rank([1, 0, 0, 0]), 1
+        yield assert_equal, matrix_rank(np.zeros((4,))), 0
+        # accepts array-like
+        yield assert_equal, matrix_rank([1]), 1
+        # greater than 2 dimensions raises error
+        yield assert_raises, TypeError, matrix_rank, np.zeros((2, 2, 2))
+        # works on scalar
+        yield assert_equal, matrix_rank(1), 1
+
+
 class TestOverwrite(object):
     def test_solve(self):
         assert_no_overwrite(solve, [(3,3), (3,)])
@@ -750,6 +770,10 @@ class TestOverwrite(object):
 
     def test_pinvh(self):
         assert_no_overwrite(pinvh, [(3,3)])
+
+    def test_matrix_rank(self):
+        assert_no_overwrite(matrix_rank, [(3,3)])
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
The `numpy.linalg.matrix_rank` uses `numpy.linalg.svd`.  This PR copypastes that function into scipy as `scipy.linalg.matrix_rank` using `scipy.linalg.svd`.

As evidence for demand for this kind of thing, see for example
https://github.com/nipy/nipy/blob/master/nipy/algorithms/utils/matrices.py

This PR also removes some redundant input checks from some `scipy.linalg` functions.

**Edit**: numpy and scipy use the same svd implementations, so this PR makes no sense
