### PR TITLE
MAINT: remove more usage of numpy matrix

### DIFF
--- a/scipy/linalg/_matfuncs_inv_ssq.py
+++ b/scipy/linalg/_matfuncs_inv_ssq.py
@@ -10,7 +10,6 @@ import numpy as np
 
 from scipy.linalg._matfuncs_sqrtm import SqrtmError, _sqrtm_triu
 from scipy.linalg.decomp_schur import schur, rsf2csf
-from scipy.linalg.special_matrices import all_mat
 from scipy.linalg.matfuncs import funm
 from scipy.linalg import svdvals, solve_triangular
 from scipy.sparse.linalg.interface import LinearOperator
@@ -675,9 +674,8 @@ def _remainder_matrix_power(A, t):
     # and de-triangularize it if necessary.
     U = _remainder_matrix_power_triu(T, t)
     if Z is not None:
-        U, Z = all_mat(U, Z)
-        X = (Z * U * Z.H)
-        return X.A
+        ZH = np.conjugate(Z).T
+        return Z.dot(U).dot(ZH)
     else:
         return U
 
@@ -938,9 +936,8 @@ def logm(A):
                 T, Z = schur(A, output='complex')
             T = _logm_force_nonsingular_triangular_matrix(T, inplace=True)
             U = _logm_triu(T)
-            U, Z = all_mat(U, Z)
-            X = (Z * U * Z.H)
-            return X.A
+            ZH = np.conjugate(Z).T
+            return Z.dot(U).dot(ZH)
     except (SqrtmError, LogmError) as e:
         X = np.empty_like(A)
         X.fill(np.nan)

--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -14,7 +14,6 @@ import numpy as np
 # Local imports
 from .misc import norm
 from .lapack import ztrsyl, dtrsyl
-from .special_matrices import all_mat
 from .decomp_schur import schur, rsf2csf
 
 
@@ -158,11 +157,11 @@ def sqrtm(A, disp=True, blocksize=64):
     failflag = False
     try:
         R = _sqrtm_triu(T, blocksize=blocksize)
-        R, Z = all_mat(R,Z)
-        X = (Z * R * Z.H)
+        ZH = np.conjugate(Z).T
+        X = Z.dot(R).dot(ZH)
     except SqrtmError as e:
         failflag = True
-        X = np.matrix(np.empty_like(A))
+        X = np.empty_like(A)
         X.fill(np.nan)
 
     if disp:
@@ -171,12 +170,12 @@ def sqrtm(A, disp=True, blocksize=64):
             print("Matrix is singular and may not have a square root.")
         elif failflag:
             print("Failed to find a square root.")
-        return X.A
+        return X
     else:
         try:
-            arg2 = norm(X*X - A,'fro')**2 / norm(A,'fro')
+            arg2 = norm(X.dot(X) - A,'fro')**2 / norm(A,'fro')
         except ValueError:
             # NaNs in matrix
             arg2 = np.inf
 
-        return X.A, arg2
+        return X, arg2

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -429,6 +429,7 @@ def leslie(f, s):
     return a
 
 
+@np.deprecate
 def all_mat(*args):
     return list(map(np.matrix, args))
 


### PR DESCRIPTION
This PR removes old numpy.matrix calls from the matrix functions code.  It also deprecates `scipy.linalg.special_matrices.all_mat` which is part of the scipy public interface.  This PR together with an earlier PR remove all usage of `all_mat` within scipy.
