### PR TITLE
MAINT: remove some unnecessary use of np.matrix

### DIFF
--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -813,12 +813,11 @@ def newton_cotes(rn, equal=0):
     yi = rn / float(N)
     ti = 2.0*yi - 1
     nvec = np.arange(0,N+1)
-    C = np.mat(ti**nvec[:,np.newaxis])
-    Cinv = C.I
+    C = ti**nvec[:,np.newaxis]
+    Cinv = np.linalg.inv(C)
     # improve precision of result
-    Cinv = 2*Cinv - Cinv*C*Cinv
-    Cinv = 2*Cinv - Cinv*C*Cinv
-    Cinv = Cinv.A
+    for i in range(2):
+        Cinv = 2*Cinv - Cinv.dot(C).dot(Cinv)
     vec = 2.0 / (nvec[::2]+1)
     ai = np.dot(Cinv[:,::2],vec) * N/2
 

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -15,7 +15,6 @@ __all__ = ['expm', 'inv']
 import math
 
 from numpy import asarray, dot, eye, ceil, log2
-from numpy import matrix as mat
 import numpy as np
 
 import scipy.misc


### PR DESCRIPTION
**Edit**: Removed a comment remarking on the lack of remaining code in scipy that uses np.matrix for convenience.  This is clearly not true because np.matrix is still used for scipy.sparse and for some tests.
