### PR TITLE
ENH: Efficient interpolation on regular grids in arbitrary dimensions

### DIFF
--- a/doc/release/0.14.0-notes.rst
+++ b/doc/release/0.14.0-notes.rst
@@ -36,6 +36,10 @@ If performance is critical, sorting can be turned off by using the new
 Functionality for evaluation of bivariate spline derivatives in
 ``scipy.interpolate`` has been added.
 
+Functionality for fast interpolation on regular, unevenly spaced grids
+in arbitrary dimensions has been added as
+`scipy.interpolate.RegularGridInterpolator` .
+
 
 ``scipy.linalg`` improvements
 -----------------------------

--- a/doc/release/0.14.0-notes.rst
+++ b/doc/release/0.14.0-notes.rst
@@ -36,6 +36,11 @@ If performance is critical, sorting can be turned off by using the new
 Functionality for evaluation of bivariate spline derivatives in
 ``scipy.interpolate`` has been added.
 
+A new wrapper function `scipy.interpolate.interpn` for interpolation on regular
+grids has been added. `interpn` supports linear and nearest-neighbor
+interpolation in arbitrary dimensions and spline interpolation in two
+dimensions.
+
 Functionality for fast interpolation on regular, unevenly spaced grids
 in arbitrary dimensions has been added as
 `scipy.interpolate.RegularGridInterpolator` .

--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -52,6 +52,7 @@ For data on a grid:
 .. autosummary::
    :toctree: generated/
 
+   interpn
    RegularGridInterpolator
    RectBivariateSpline
 

--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -50,7 +50,9 @@ Unstructured data:
 For data on a grid:
 
 .. autosummary::
+   :toctree: generated/
 
+   RegularGridInterpolator
    RectBivariateSpline
 
 .. seealso:: `scipy.ndimage.interpolation.map_coordinates`

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1466,26 +1466,25 @@ class RegularGridInterpolator(object):
     def __init__(self, points, values, kind="linear", bounds_error=True,
                  fill_value=np.nan):
         if kind not in ["linear", "nearest"]:
-            raise ValueError("Kind '{}' is not defined".format(kind))
+            raise ValueError("Kind '%s' is not defined" % kind)
         self.kind = kind
         self.bounds_error = bounds_error
         if fill_value is not None and not isinstance(fill_value, float):
             raise ValueError("fill_value must be either 'None' or a float")
         self.fill_value = fill_value
         if not len(points) == values.ndim:
-            raise ValueError("There are {} point arrays, but values has {} "
-                             "dimensions".format(len(points), values.ndim))
+            raise ValueError("There are %d point arrays, but values has %d "
+                             "dimensions" % (len(points), values.ndim))
         for i, p in enumerate(points):
             if not np.all(np.diff(p) > 0.):
-                raise ValueError("The points in dimension {} must be strictly "
-                                 "ascending".format(i))
+                raise ValueError("The points in dimension %d must be strictly "
+                                 "ascending" % i)
             if not np.asarray(p).ndim == 1:
-                raise ValueError("The points in dimension {} must be "
-                                 "1-dimensional".format(i))
+                raise ValueError("The points in dimension %d must be "
+                                 "1-dimensional" % i)
             if not values.shape[i] == len(p):
-                raise ValueError("There are {} points and {} values in "
-                                 "dimension {}".format(len(p), values.shape[i],
-                                                       i))
+                raise ValueError("There are %d points and %d values in "
+                                 "dimension %d" % (len(p), values.shape[i], i))
         self.grid = tuple([np.asarray(p) for p in points])
         self.values = values
 
@@ -1505,18 +1504,18 @@ class RegularGridInterpolator(object):
         """
         kind = self.kind if kind is None else kind
         if kind not in ["linear", "nearest"]:
-            raise ValueError("Kind '{}' is not defined".format(kind))
+            raise ValueError("Kind '%s' is not defined" % kind)
         xi = np.atleast_2d(xi)
         if not xi.shape[1] == len(self.grid):
             raise ValueError("The requested sample points xi have dimension "
-                             "{}, but this RegularGridInterpolator has "
-                             "dimension {}".format(xi.shape[1], len(self.grid)))
+                             "%d, but this RegularGridInterpolator has "
+                             "dimension %d" % (xi.shape[1], len(self.grid)))
         if self.bounds_error:
             for i, p in enumerate(xi.T):
                 if not np.logical_and(np.all(self.grid[i][0] <= p),
                                       np.all(p <= self.grid[i][-1])):
                     raise ValueError("One of the requested xi is out of bounds "
-                                     "in dimension {}".format(i))
+                                     "in dimension %d" % i)
 
         indices, norm_distances, out_of_bounds = self._find_indices(xi.T)
         if kind == "linear":
@@ -1604,39 +1603,43 @@ def interpn(points, values, xi, method="linear"):
     # sanity check 'method' kwarg
     if method not in ["linear", "nearest", "splinef2d"]:
         raise ValueError("interpn only understands the methods 'linear', "
-                         "'nearest', and 'splinef2d'. You provided "
-                         "{}".format(method))
+                         "'nearest', and 'splinef2d'. You provided %s." %
+                         method)
     ndim = values.ndim
     if ndim > 2 and method == "splinef2d":
         raise ValueError("The method spline2fd can only be used for "
                          "2-dimensional input data")
+
     # sanity check consistency of input dimensions
     if not len(points) == ndim:
-        raise ValueError("There are {} point arrays, but values has {} "
-                         "dimensions".format(len(points), ndim))
+        raise ValueError("There are %d point arrays, but values has %d "
+                         "dimensions" % (len(points), ndim))
+
     # sanity check input grid
     for i, p in enumerate(points):
         if not np.all(np.diff(p) > 0.):
-            raise ValueError("The points in dimension {} must be strictly "
-                             "ascending".format(i))
+            raise ValueError("The points in dimension %d must be strictly "
+                             "ascending" % i)
         if not np.asarray(p).ndim == 1:
-            raise ValueError("The points in dimension {} must be "
-                             "1-dimensional".format(i))
+            raise ValueError("The points in dimension %d must be "
+                             "1-dimensional" % i)
         if not values.shape[i] == len(p):
-            raise ValueError("There are {} points and {} values in "
-                             "dimension {}".format(len(p), values.shape[i], i))
+            raise ValueError("There are %d points and %d values in "
+                             "dimension %d" % (len(p), values.shape[i], i))
     grid = tuple([np.asarray(p) for p in points])
+
     # sanity check requested xi
     xi = np.atleast_2d(xi)
     if not xi.shape[1] == len(grid):
         raise ValueError("The requested sample points xi have dimension "
-                         "{}, but this RegularGridInterpolator has "
-                         "dimension {}".format(xi.shape[1], len(grid)))
+                         "%d, but this RegularGridInterpolator has "
+                         "dimension %d" % (xi.shape[1], len(grid)))
     for i, p in enumerate(xi.T):
         if not np.logical_and(np.all(grid[i][0] <= p),
                               np.all(p <= grid[i][-1])):
             raise ValueError("One of the requested xi is out of bounds "
-                             "in dimension {}".format(i))
+                             "in dimension %d" % i)
+
     # perform interpolation
     if method == "linear":
         interp = RegularGridInterpolator(points, values, kind="linear")

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1415,6 +1415,16 @@ class RegularGridInterpolator(object):
         "nearest". This parameter will become the default for the object's
         ``__call__`` method.
 
+    bounds_error : bool, optional
+        If True, when interpolated values are requested outside of the
+        domain of the input data, a ValueError is raised.
+        If False, then `fill_value` is used.
+
+    fill_value : number, optional
+        If provided, the value to use for points outside of the
+        interpolation domain. If None, values outside
+        the domain are extrapolated.
+
     Methods
     -------
     __call__
@@ -1437,23 +1447,29 @@ class RegularGridInterpolator(object):
 
     References
     ----------
-    - Python package *regulargrid* by Johannes Buchner, see https://pypi.python.org/pypi/regulargrid/
-    - Trilinear interpolation. (2013, January 17). In Wikipedia, The Free Encyclopedia.
-      Retrieved 27 Feb 2013 01:28.
-      http://en.wikipedia.org/w/index.php?title=Trilinear_interpolation&oldid=533448871
-    - Weiser, Alan, and Sergio E. Zarantonello. "A note on piecewise linear
-      and multilinear table interpolation in many dimensions." MATH. COMPUT.
-      50.181 (1988): 189-196.
-      http://www.ams.org/journals/mcom/1988-50-181/S0025-5718-1988-0917826-0/S0025-5718-1988-0917826-0.pdf
+    .. [1] Python package *regulargrid* by Johannes Buchner, see
+           https://pypi.python.org/pypi/regulargrid/
+    .. [2] Trilinear interpolation. (2013, January 17). In Wikipedia, The Free
+           Encyclopedia. Retrieved 27 Feb 2013 01:28.
+           http://en.wikipedia.org/w/index.php?title=Trilinear_interpolation&oldid=533448871
+    .. [3] Weiser, Alan, and Sergio E. Zarantonello. "A note on piecewise linear
+           and multilinear table interpolation in many dimensions." MATH.
+           COMPUT. 50.181 (1988): 189-196.
+           http://www.ams.org/journals/mcom/1988-50-181/S0025-5718-1988-0917826-0/S0025-5718-1988-0917826-0.pdf
 
     """
     # this class is based on code originally programmed by Johannes Buchner,
     # see https://github.com/JohannesBuchner/regulargrid
 
-    def __init__(self, points, values, kind="linear"):
+    def __init__(self, points, values, kind="linear", bounds_error=True,
+                 fill_value=np.nan):
         if kind not in ["linear", "nearest"]:
             raise ValueError("Kind '{}' is not defined".format(kind))
         self.kind = kind
+        self.bounds_error = bounds_error
+        if fill_value is not None and not isinstance(fill_value, float):
+            raise ValueError("fill_value must be either 'None' or a float")
+        self.fill_value = fill_value
         if not len(points) == values.ndim:
             raise ValueError("There are {} point arrays, but values has {} "
                              "dimensions".format(len(points), values.ndim))
@@ -1493,19 +1509,23 @@ class RegularGridInterpolator(object):
             raise ValueError("The requested sample points xi have dimension "
                              "{}, but this RegularGridInterpolator has "
                              "dimension {}".format(xi.shape[1], len(self.grid)))
-        for i, p in enumerate(xi.T):
-            if not np.logical_and(np.all(self.grid[i][0] <= p),
-                                  np.all(p <= self.grid[i][-1])):
-                raise ValueError("One of the requested xi is out of bounds in "
-                                 "dimension {}".format(i))
+        if self.bounds_error:
+            for i, p in enumerate(xi.T):
+                if not np.logical_and(np.all(self.grid[i][0] <= p),
+                                      np.all(p <= self.grid[i][-1])):
+                    raise ValueError("One of the requested xi is out of bounds "
+                                     "in dimension {}".format(i))
 
-        indices, norm_distances = self._find_indices(xi.T)
+        indices, norm_distances, out_of_bounds = self._find_indices(xi.T)
         if kind == "linear":
-            return self._evaluate_linear(indices, norm_distances)
+            result = self._evaluate_linear(indices, norm_distances, out_of_bounds)
         elif kind == "nearest":
-            return self._evaluate_nearest(indices, norm_distances)
+            result = self._evaluate_nearest(indices, norm_distances, out_of_bounds)
+        if not self.bounds_error and self.fill_value is not None:
+            result[out_of_bounds] = self.fill_value
+        return result
 
-    def _evaluate_linear(self, indices, norm_distances):
+    def _evaluate_linear(self, indices, norm_distances, out_of_bounds):
         # find relevant values
         # each i and i+1 represents a edge
         edges = itertools.product(*[[i, i + 1] for i in indices])
@@ -1517,9 +1537,7 @@ class RegularGridInterpolator(object):
             values += self.values[edge_indices] * weight
         return values
 
-    def _evaluate_nearest(self, indices, norm_distances):
-        # find relevant values
-        # each i and i+1 represents a edge
+    def _evaluate_nearest(self, indices, norm_distances, out_of_bounds):
         idx_res = []
         for i, yi in zip(indices, norm_distances):
             idx_res.append(np.where(yi <= .5, i, i + 1))
@@ -1530,15 +1548,20 @@ class RegularGridInterpolator(object):
         indices = []
         # compute distance to lower edge in unity units
         norm_distances = []
+        # check for out of bounds xi
+        out_of_bounds = np.zeros((xi.shape[1]), dtype=bool)
+        # iterate through dimensions
         for x, grid in zip(xi, self.grid):
             i = np.searchsorted(grid, x) - 1
-            # when i == -1, we're located at the upper bound
-            i = np.where(i == -1, 0, i)
+            i[i < 0] = 0
+            i[i > grid.size - 2] = grid.size - 2
             indices.append(i)
             norm_distances.append((x - grid[i]) /
                                   (grid[i + 1] - grid[i]))
-
-        return indices, norm_distances
+            if not self.bounds_error:
+                out_of_bounds += x < grid[0]
+                out_of_bounds += x > grid[-1]
+        return indices, norm_distances, out_of_bounds
 
 
 # backward compatibility wrapper

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1401,8 +1401,10 @@ class RegularGridInterpolator(object):
 
     The data must be defined on a regular grid; the grid spacing however may be
     uneven.  Linear and nearest-neighbour interpolation are supported. After
-    setting up the interpolator object, the interpolation kind (*linear* or
+    setting up the interpolator object, the interpolation method (*linear* or
     *nearest*) may be chosen at each evaluation.
+
+    .. versionadded:: 0.14
 
     Parameters
     ----------
@@ -1412,8 +1414,8 @@ class RegularGridInterpolator(object):
     values : anything of dtype float that can be indexed like an ndarray of shape (m1, ..., mn)
         The data on the regular grid in n dimensions.
 
-    kind : str
-        The kind of interpolation to perform. Supported are "linear" and
+    method : str
+        The method of interpolation to perform. Supported are "linear" and
         "nearest". This parameter will become the default for the object's
         ``__call__`` method.
 
@@ -1433,8 +1435,6 @@ class RegularGridInterpolator(object):
 
     Notes
     -----
-    .. versionadded:: 0.14
-
     Contrary to LinearNDInterpolator and NearestNDInterpolator, this class
     avoids expensive triangulation of the input data by taking advantage of the
     regular grid structure.
@@ -1463,11 +1463,11 @@ class RegularGridInterpolator(object):
     # this class is based on code originally programmed by Johannes Buchner,
     # see https://github.com/JohannesBuchner/regulargrid
 
-    def __init__(self, points, values, kind="linear", bounds_error=True,
+    def __init__(self, points, values, method="linear", bounds_error=True,
                  fill_value=np.nan):
-        if kind not in ["linear", "nearest"]:
-            raise ValueError("Kind '%s' is not defined" % kind)
-        self.kind = kind
+        if method not in ["linear", "nearest"]:
+            raise ValueError("Method '%s' is not defined" % method)
+        self.method = method
         self.bounds_error = bounds_error
         if fill_value is not None and not isinstance(fill_value, float):
             raise ValueError("fill_value must be either 'None' or a float")
@@ -1488,7 +1488,7 @@ class RegularGridInterpolator(object):
         self.grid = tuple([np.asarray(p) for p in points])
         self.values = values
 
-    def __call__(self, xi, kind=None):
+    def __call__(self, xi, method=None):
         """
         interpolation at coordinates
 
@@ -1497,14 +1497,14 @@ class RegularGridInterpolator(object):
         xi : ndarray of shape (ndim, ) or (nsamplepoints, ndim)
             The coordinates to sample the gridded data at
 
-        kind : str
-            The kind of interpolation to perform. Supported are "linear" and
+        method : str
+            The method of interpolation to perform. Supported are "linear" and
             "nearest".
 
         """
-        kind = self.kind if kind is None else kind
-        if kind not in ["linear", "nearest"]:
-            raise ValueError("Kind '%s' is not defined" % kind)
+        method = self.method if method is None else method
+        if method not in ["linear", "nearest"]:
+            raise ValueError("Method '%s' is not defined" % method)
         xi = np.atleast_2d(xi)
         if not xi.shape[1] == len(self.grid):
             raise ValueError("The requested sample points xi have dimension "
@@ -1518,9 +1518,9 @@ class RegularGridInterpolator(object):
                                      "in dimension %d" % i)
 
         indices, norm_distances, out_of_bounds = self._find_indices(xi.T)
-        if kind == "linear":
+        if method == "linear":
             result = self._evaluate_linear(indices, norm_distances, out_of_bounds)
-        elif kind == "nearest":
+        elif method == "nearest":
             result = self._evaluate_nearest(indices, norm_distances, out_of_bounds)
         if not self.bounds_error and self.fill_value is not None:
             result[out_of_bounds] = self.fill_value
@@ -1570,6 +1570,8 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     """
     Multidimensional interpolation on regular grids.
 
+    .. versionadded:: 0.14
+
     Parameters
     ----------
     points : tuple of ndarray of float, with shapes (m1, ), ..., (mn, )
@@ -1578,7 +1580,7 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     values : anything of dtype float that can be indexed like an ndarray of shape (m1, ..., mn)
         The data on the regular grid in n dimensions.
 
-    xi : ndarray of shape (n, ) or (nsamplepoints, n)
+    xi : ndarray of shape (nsamplepoints, n)
         The coordinates to sample the gridded data at
 
     method : str
@@ -1594,11 +1596,8 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     fill_value : number, optional
         If provided, the value to use for points outside of the
         interpolation domain. If None, values outside
-        the domain are extrapolated.
-
-    Notes
-    -----
-    .. versionadded:: 0.14
+        the domain are extrapolated.  Extrapolation is not supported by method
+        "splinef2d".
 
     See also
     --------
@@ -1645,7 +1644,11 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     grid = tuple([np.asarray(p) for p in points])
 
     # sanity check requested xi
-    xi = np.atleast_2d(xi)
+    if not xi.ndim == 2:
+        raise ValueError("The requested sample points xi must have "
+                         "shape (nsamplepoints, ndim), so xi must have "
+                         "dimension 2. The xi you provided has shape %s." %
+                         xi.shape)
     if not xi.shape[1] == len(grid):
         raise ValueError("The requested sample points xi have dimension "
                          "%d, but this RegularGridInterpolator has "
@@ -1658,12 +1661,12 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
 
     # perform interpolation
     if method == "linear":
-        interp = RegularGridInterpolator(points, values, kind="linear",
+        interp = RegularGridInterpolator(points, values, method="linear",
                                          bounds_error=bounds_error,
                                          fill_value=fill_value)
         return interp(xi)
     elif method == "nearest":
-        interp = RegularGridInterpolator(points, values, kind="nearest",
+        interp = RegularGridInterpolator(points, values, method="nearest",
                                          bounds_error=bounds_error,
                                          fill_value=fill_value)
         return interp(xi)
@@ -1673,7 +1676,9 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
                             grid[1][0] <= xi[:, 1], xi[:, 1] <= grid[1][-1]),
                            axis=0)
         result = np.empty_like(xi[:, 0])
-        interp = RectBivariateSpline(points[0], points[1], values)
+
+        # make a copy of values for RectBivariateSpline
+        interp = RectBivariateSpline(points[0], points[1], values[:])
         result[idx_valid] = interp.ev(xi[idx_valid, 0], xi[idx_valid, 1])
         result[np.logical_not(idx_valid)] = fill_value
         return result

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -3,7 +3,9 @@
 from __future__ import division, print_function, absolute_import
 
 __all__ = ['interp1d', 'interp2d', 'spline', 'spleval', 'splmake', 'spltopp',
-           'ppform', 'lagrange', 'PPoly', 'BPoly']
+           'ppform', 'lagrange', 'PPoly', 'BPoly', 'RegularGridInterpolator']
+
+import itertools
 
 from numpy import shape, sometrue, array, transpose, searchsorted, \
                   ones, logical_or, atleast_1d, atleast_2d, ravel, \
@@ -1389,6 +1391,154 @@ class BPoly(_PPolyBase):
             for j in range(d+1):
                 out[a+j] += f * comb(d, j) / comb(k+d, a+j)
         return out
+
+
+class RegularGridInterpolator(object):
+    """
+    Interpolation on a regular grid in arbitrary dimensions
+
+    The data must be defined on a regular grid; the grid spacing however may be
+    uneven.  Linear and nearest-neighbour interpolation are supported. After
+    setting up the interpolator object, the interpolation kind (*linear* or
+    *nearest*) may be chosen at each evaluation.
+
+    Parameters
+    ----------
+    points : tuple of ndarray of float, with shapes (m1, ), ..., (mn, )
+        The points defining the regular grid in n dimensions.
+
+    values : anything of dtype float that can be indexed like an ndarray of shape (m1, ..., mn)
+        The data on the regular grid in n dimensions.
+
+    kind : str
+        The kind of interpolation to perform. Supported are "linear" and
+        "nearest". This parameter will become the default for the object's
+        ``__call__`` method.
+
+    Methods
+    -------
+    __call__
+
+    Notes
+    -----
+    .. versionadded:: 0.14
+
+    Contrary to LinearNDInterpolator and NearestNDInterpolator, this class
+    avoids expensive triangulation of the input data by taking advantage of the
+    regular grid structure.
+
+    See also
+    --------
+    NearestNDInterpolator : Nearest neighbour interpolation on unstructured
+                            data in N dimensions
+
+    LinearNDInterpolator : Piecewise linear interpolant on unstructured data
+                           in N dimensions
+
+    References
+    ----------
+    - Python package *regulargrid* by Johannes Buchner, see https://pypi.python.org/pypi/regulargrid/
+    - Trilinear interpolation. (2013, January 17). In Wikipedia, The Free Encyclopedia.
+      Retrieved 27 Feb 2013 01:28.
+      http://en.wikipedia.org/w/index.php?title=Trilinear_interpolation&oldid=533448871
+    - Weiser, Alan, and Sergio E. Zarantonello. "A note on piecewise linear
+      and multilinear table interpolation in many dimensions." MATH. COMPUT.
+      50.181 (1988): 189-196.
+      http://www.ams.org/journals/mcom/1988-50-181/S0025-5718-1988-0917826-0/S0025-5718-1988-0917826-0.pdf
+
+    """
+    # this class is based on code originally programmed by Johannes Buchner,
+    # see https://github.com/JohannesBuchner/regulargrid
+
+    def __init__(self, points, values, kind="linear"):
+        if kind not in ["linear", "nearest"]:
+            raise ValueError("Kind '{}' is not defined".format(kind))
+        self.kind = kind
+        if not len(points) == values.ndim:
+            raise ValueError("There are {} point arrays, but values has {} "
+                             "dimensions".format(len(points), values.ndim))
+        for i, p in enumerate(points):
+            if not np.all(np.diff(p) > 0.):
+                raise ValueError("The points in dimension {} must be strictly "
+                                 "ascending".format(i))
+            if not np.asarray(p).ndim == 1:
+                raise ValueError("The points in dimension {} must be "
+                                 "1-dimensional".format(i))
+            if not values.shape[i] == len(p):
+                raise ValueError("There are {} points and {} values in "
+                                 "dimension {}".format(len(p), values.shape[i],
+                                                       i))
+        self.grid = tuple([np.asarray(p) for p in points])
+        self.values = values
+
+    def __call__(self, xi, kind=None):
+        """
+        interpolation at coordinates
+
+        Parameters
+        ----------
+        xi : ndarray of shape (ndim, ) or (nsamplepoints, ndim)
+            The coordinates to sample the gridded data at
+
+        kind : str
+            The kind of interpolation to perform. Supported are "linear" and
+            "nearest".
+
+        """
+        kind = self.kind if kind is None else kind
+        if kind not in ["linear", "nearest"]:
+            raise ValueError("Kind '{}' is not defined".format(kind))
+        xi = np.atleast_2d(xi)
+        if not xi.shape[1] == len(self.grid):
+            raise ValueError("The requested sample points xi have dimension "
+                             "{}, but this RegularGridInterpolator has "
+                             "dimension {}".format(xi.shape[1], len(self.grid)))
+        for i, p in enumerate(xi.T):
+            if not np.logical_and(np.all(self.grid[i][0] <= p),
+                                  np.all(p <= self.grid[i][-1])):
+                raise ValueError("One of the requested xi is out of bounds in "
+                                 "dimension {}".format(i))
+
+        indices, norm_distances = self._find_indices(xi.T)
+        if kind == "linear":
+            return self._evaluate_linear(indices, norm_distances)
+        elif kind == "nearest":
+            return self._evaluate_nearest(indices, norm_distances)
+
+    def _evaluate_linear(self, indices, norm_distances):
+        # find relevant values
+        # each i and i+1 represents a edge
+        edges = itertools.product(*[[i, i + 1] for i in indices])
+        values = 0.
+        for edge_indices in edges:
+            weight = 1.
+            for ei, i, yi in zip(edge_indices, indices, norm_distances):
+                weight *= np.where(ei == i, 1 - yi, yi)
+            values += self.values[edge_indices] * weight
+        return values
+
+    def _evaluate_nearest(self, indices, norm_distances):
+        # find relevant values
+        # each i and i+1 represents a edge
+        idx_res = []
+        for i, yi in zip(indices, norm_distances):
+            idx_res.append(np.where(yi <= .5, i, i + 1))
+        return self.values[idx_res]
+
+    def _find_indices(self, xi):
+        # find relevant edges between which xi are situated
+        indices = []
+        # compute distance to lower edge in unity units
+        norm_distances = []
+        for x, grid in zip(xi, self.grid):
+            i = np.searchsorted(grid, x) - 1
+            # when i == -1, we're located at the upper bound
+            i = np.where(i == -1, 0, i)
+            indices.append(i)
+            norm_distances.append((x - grid[i]) /
+                                  (grid[i + 1] - grid[i]))
+
+        return indices, norm_distances
 
 
 # backward compatibility wrapper

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1565,7 +1565,8 @@ class RegularGridInterpolator(object):
         return indices, norm_distances, out_of_bounds
 
 
-def interpn(points, values, xi, method="linear"):
+def interpn(points, values, xi, method="linear", bounds_error=True,
+            fill_value=np.nan):
     """
     Multidimensional interpolation on regular grids.
 
@@ -1577,10 +1578,23 @@ def interpn(points, values, xi, method="linear"):
     values : anything of dtype float that can be indexed like an ndarray of shape (m1, ..., mn)
         The data on the regular grid in n dimensions.
 
-    kind : str
-        The kind of interpolation to perform. Supported are "linear" and
+    xi : ndarray of shape (n, ) or (nsamplepoints, n)
+        The coordinates to sample the gridded data at
+
+    method : str
+        The method of interpolation to perform. Supported are "linear" and
         "nearest", and "splinef2d". "splinef2d" is only supported for
         2-dimensional data.
+
+    bounds_error : bool, optional
+        If True, when interpolated values are requested outside of the
+        domain of the input data, a ValueError is raised.
+        If False, then `fill_value` is used.
+
+    fill_value : number, optional
+        If provided, the value to use for points outside of the
+        interpolation domain. If None, values outside
+        the domain are extrapolated.
 
     Notes
     -----
@@ -1609,6 +1623,8 @@ def interpn(points, values, xi, method="linear"):
     if ndim > 2 and method == "splinef2d":
         raise ValueError("The method spline2fd can only be used for "
                          "2-dimensional input data")
+    if not bounds_error and fill_value is None and method == "splinef2d":
+        raise ValueError("The method spline2fd does not support extrapolation.")
 
     # sanity check consistency of input dimensions
     if not len(points) == ndim:
@@ -1635,21 +1651,32 @@ def interpn(points, values, xi, method="linear"):
                          "%d, but this RegularGridInterpolator has "
                          "dimension %d" % (xi.shape[1], len(grid)))
     for i, p in enumerate(xi.T):
-        if not np.logical_and(np.all(grid[i][0] <= p),
-                              np.all(p <= grid[i][-1])):
+        if bounds_error and not np.logical_and(np.all(grid[i][0] <= p),
+                                               np.all(p <= grid[i][-1])):
             raise ValueError("One of the requested xi is out of bounds "
                              "in dimension %d" % i)
 
     # perform interpolation
     if method == "linear":
-        interp = RegularGridInterpolator(points, values, kind="linear")
+        interp = RegularGridInterpolator(points, values, kind="linear",
+                                         bounds_error=bounds_error,
+                                         fill_value=fill_value)
         return interp(xi)
     elif method == "nearest":
-        interp = RegularGridInterpolator(points, values, kind="nearest")
+        interp = RegularGridInterpolator(points, values, kind="nearest",
+                                         bounds_error=bounds_error,
+                                         fill_value=fill_value)
         return interp(xi)
     elif method == "splinef2d":
+        # RectBivariateSpline doesn't support fill_value; we need to wrap here
+        idx_valid = np.all((grid[0][0] <= xi[:, 0], xi[:, 0] <= grid[0][-1],
+                            grid[1][0] <= xi[:, 1], xi[:, 1] <= grid[1][-1]),
+                           axis=0)
+        result = np.empty_like(xi[:, 0])
         interp = RectBivariateSpline(points[0], points[1], values)
-        return interp.ev(xi[:, 0], xi[:, 1])
+        result[idx_valid] = interp.ev(xi[idx_valid, 0], xi[idx_valid, 1])
+        result[np.logical_not(idx_valid)] = fill_value
+        return result
 
 
 # backward compatibility wrapper

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1160,7 +1160,7 @@ class TestRegularGridInterpolator(TestCase):
         values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
         values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
         values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
-        interp = RegularGridInterpolator(points, values, kind="nearest")
+        interp = RegularGridInterpolator(points, values, method="nearest")
         sample = np.asarray([0.1, 0.1, .9, .9])
         wanted = 1100.
         assert_array_almost_equal(interp(sample), wanted)
@@ -1207,7 +1207,7 @@ class TestRegularGridInterpolator(TestCase):
         assert_raises(ValueError, RegularGridInterpolator, points, values)
         points = [(0., .5, 1.), (0., .5, 1.)]
         assert_raises(ValueError, RegularGridInterpolator, points, values,
-                      kind="undefkind")
+                      method="undefmethod")
 
     def test_valid_call(self):
         # create a 4d grid of 3 points in each dimension
@@ -1220,7 +1220,7 @@ class TestRegularGridInterpolator(TestCase):
         values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
         interp = RegularGridInterpolator(points, values)
         sample = np.asarray([[0., 0., 0., 0.], [1., 1., 1., 1.]])
-        assert_raises(ValueError, interp, sample, "undefkind")
+        assert_raises(ValueError, interp, sample, "undefmethod")
         sample = np.asarray([[0., 0., 0.], [1., 1., 1.]])
         assert_raises(ValueError, interp, sample)
         sample = np.asarray([[0., 0., 0., 0.], [1., 1., 1., 1.1]])
@@ -1240,9 +1240,9 @@ class TestRegularGridInterpolator(TestCase):
         sample = np.asarray([[-.1, -.1, -.1, -.1], [1.1, 1.1, 1.1, 1.1],
                              [21, 2.1, -1.1, -11], [2.1, 2.1, -1.1, -1.1]])
         wanted = np.asarray([0., 1111., 11., 11.])
-        assert_array_almost_equal(interp(sample, kind="nearest"), wanted)
+        assert_array_almost_equal(interp(sample, method="nearest"), wanted)
         wanted = np.asarray([-111.1, 1222.1, -11068., -1186.9])
-        assert_array_almost_equal(interp(sample, kind="linear"), wanted)
+        assert_array_almost_equal(interp(sample, method="linear"), wanted)
 
     def test_out_of_bounds_extrap2(self):
         # create a 4d grid of 3 points in each dimension
@@ -1258,9 +1258,9 @@ class TestRegularGridInterpolator(TestCase):
         sample = np.asarray([[-.1, -.1, -.1, -.1], [1.1, 1.1, 1.1, 1.1],
                              [21, 2.1, -1.1, -11], [2.1, 2.1, -1.1, -1.1]])
         wanted = np.asarray([0., 11., 11., 11.])
-        assert_array_almost_equal(interp(sample, kind="nearest"), wanted)
+        assert_array_almost_equal(interp(sample, method="nearest"), wanted)
         wanted = np.asarray([-12.1, 133.1, -1069., -97.9])
-        assert_array_almost_equal(interp(sample, kind="linear"), wanted)
+        assert_array_almost_equal(interp(sample, method="linear"), wanted)
 
     def test_out_of_bounds_fill(self):
         # create a 4d grid of 3 points in each dimension
@@ -1276,8 +1276,8 @@ class TestRegularGridInterpolator(TestCase):
         sample = np.asarray([[-.1, -.1, -.1, -.1], [1.1, 1.1, 1.1, 1.1],
                              [2.1, 2.1, -1.1, -1.1]])
         wanted = np.asarray([np.nan, np.nan, np.nan])
-        assert_array_almost_equal(interp(sample, kind="nearest"), wanted)
-        assert_array_almost_equal(interp(sample, kind="linear"), wanted)
+        assert_array_almost_equal(interp(sample, method="nearest"), wanted)
+        assert_array_almost_equal(interp(sample, method="linear"), wanted)
         sample = np.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
                              [0.5, 0.5, .5, .5]])
         wanted = np.asarray([1001.1, 846.2, 555.5])
@@ -1292,7 +1292,7 @@ class TestRegularGridInterpolator(TestCase):
         values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
         values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
         values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
-        interp = RegularGridInterpolator(points, values, kind="nearest")
+        interp = RegularGridInterpolator(points, values, method="nearest")
         points_qhull = itertools.product(*points)
         points_qhull = [p for p in points_qhull]
         points_qhull = np.asarray(points_qhull)
@@ -1365,7 +1365,7 @@ class TestInterpN(TestCase):
         values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
         values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
         interp_rg = RegularGridInterpolator(points, values)
-        sample = np.asarray([0.1, 0.1, 10., 9.])
+        sample = np.asarray([[0.1, 0.1, 10., 9.]])
         wanted = interpn(points, values, sample, method="linear")
         assert_array_almost_equal(interp_rg(sample), wanted)
 
@@ -1378,7 +1378,7 @@ class TestInterpN(TestCase):
         values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
         values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
         values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
-        sample = np.asarray([0.1, -0.1, 10.1, 9.])
+        sample = np.asarray([[0.1, -0.1, 10.1, 9.]])
         wanted = 999.99
         actual = interpn(points, values, sample, method="linear",
                          bounds_error=False, fill_value=999.99)
@@ -1393,8 +1393,8 @@ class TestInterpN(TestCase):
         values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
         values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
         values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
-        interp_rg = RegularGridInterpolator(points, values, kind="nearest")
-        sample = np.asarray([0.1, 0.1, 10., 9.])
+        interp_rg = RegularGridInterpolator(points, values, method="nearest")
+        sample = np.asarray([[0.1, 0.1, 10., 9.]])
         wanted = interpn(points, values, sample, method="nearest")
         assert_array_almost_equal(interp_rg(sample), wanted)
 
@@ -1407,11 +1407,23 @@ class TestInterpN(TestCase):
         values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
         values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
         values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
-        sample = np.asarray([0.1, -0.1, 10.1, 9.])
+        sample = np.asarray([[0.1, -0.1, 10.1, 9.]])
         wanted = 999.99
         actual = interpn(points, values, sample, method="nearest",
                          bounds_error=False, fill_value=999.99)
         assert_array_almost_equal(actual, wanted)
+
+    def test_raises_xi1d(self):
+        # verify that xi has to be 2D
+        points = [(0., .5, 1.)] * 2 + [(0., 5., 10.)] * 2
+        values = np.asarray([0., .5, 1.])
+        values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
+        values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
+        values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
+        values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
+        values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
+        sample = np.asarray([0.1, -0.1, 10.1, 9.])
+        assert_raises(ValueError, interpn, points, values, sample)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1224,6 +1224,62 @@ class TestRegularGridInterpolator(TestCase):
         sample = np.asarray([[0., 0., 0., 0.], [1., 1., 1., 1.1]])
         assert_raises(ValueError, interp, sample)
 
+    def test_out_of_bounds_extrap(self):
+        # create a 4d grid of 3 points in each dimension
+        points = [(0., .5, 1.)] * 4
+        values = np.asarray([0., .5, 1.])
+        values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
+        values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
+        values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
+        values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
+        values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
+        interp = RegularGridInterpolator(points, values, bounds_error=False,
+                                         fill_value=None)
+        sample = np.asarray([[-.1, -.1, -.1, -.1], [1.1, 1.1, 1.1, 1.1],
+                             [21, 2.1, -1.1, -11], [2.1, 2.1, -1.1, -1.1]])
+        wanted = np.asarray([0., 1111., 11., 11.])
+        assert_array_almost_equal(interp(sample, kind="nearest"), wanted)
+        wanted = np.asarray([-111.1, 1222.1, -11068., -1186.9])
+        assert_array_almost_equal(interp(sample, kind="linear"), wanted)
+
+    def test_out_of_bounds_extrap2(self):
+        # create a 4d grid of 3 points in each dimension
+        points = [(0., .5, 1.)] * 2 + [(0., 5., 10.)] * 2
+        values = np.asarray([0., .5, 1.])
+        values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
+        values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
+        values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
+        values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
+        values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
+        interp = RegularGridInterpolator(points, values, bounds_error=False,
+                                         fill_value=None)
+        sample = np.asarray([[-.1, -.1, -.1, -.1], [1.1, 1.1, 1.1, 1.1],
+                             [21, 2.1, -1.1, -11], [2.1, 2.1, -1.1, -1.1]])
+        wanted = np.asarray([0., 11., 11., 11.])
+        assert_array_almost_equal(interp(sample, kind="nearest"), wanted)
+        wanted = np.asarray([-12.1, 133.1, -1069., -97.9])
+        assert_array_almost_equal(interp(sample, kind="linear"), wanted)
+
+    def test_out_of_bounds_fill(self):
+        # create a 4d grid of 3 points in each dimension
+        points = [(0., .5, 1.)] * 4
+        values = np.asarray([0., .5, 1.])
+        values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
+        values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
+        values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
+        values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
+        values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
+        interp = RegularGridInterpolator(points, values, bounds_error=False,
+                                         fill_value=np.nan)
+        sample = np.asarray([[-.1, -.1, -.1, -.1], [1.1, 1.1, 1.1, 1.1],
+                             [2.1, 2.1, -1.1, -1.1]])
+        wanted = np.asarray([np.nan, np.nan, np.nan])
+        assert_array_almost_equal(interp(sample, kind="nearest"), wanted)
+        assert_array_almost_equal(interp(sample, kind="linear"), wanted)
+        sample = np.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
+                             [0.5, 0.5, .5, .5]])
+        wanted = np.asarray([1001.1, 846.2, 555.5])
+        assert_array_almost_equal(interp(sample), wanted)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -12,7 +12,8 @@ from scipy.lib.six import xrange
 from scipy.lib._version import NumpyVersion
 
 from scipy.interpolate import (interp1d, interp2d, lagrange, PPoly, BPoly,
-         ppform, splrep, splev, splantider, splint, sproot)
+         ppform, splrep, splev, splantider, splint, sproot,
+         RegularGridInterpolator)
 
 from scipy.interpolate import _ppoly
 
@@ -1116,6 +1117,112 @@ def _ppoly_eval_2(coeffs, breaks, xnew, fill=np.nan):
     res[mask] = values
     res.shape = saveshape
     return res
+
+
+class TestRegularGridInterpolator(TestCase):
+    def test_linear_xi1d(self):
+        # create a 4d grid of 3 points in each dimension
+        points = [(0., .5, 1.)] * 2 + [(0., 5., 10.)] * 2
+        values = np.asarray([0., .5, 1.])
+        values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
+        values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
+        values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
+        values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
+        values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
+        interp = RegularGridInterpolator(points, values)
+        sample = np.asarray([0.1, 0.1, 10., 9.])
+        wanted = 1001.1
+        assert_array_almost_equal(interp(sample), wanted)
+
+    def test_linear_xi3d(self):
+        # create a 4d grid of 3 points in each dimension
+        points = [(0., .5, 1.)] * 4
+        values = np.asarray([0., .5, 1.])
+        values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
+        values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
+        values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
+        values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
+        values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
+        interp = RegularGridInterpolator(points, values)
+        sample = np.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
+                             [0.5, 0.5, .5, .5]])
+        wanted = np.asarray([1001.1, 846.2, 555.5])
+        assert_array_almost_equal(interp(sample), wanted)
+
+    def test_nearest(self):
+        # create a 4d grid of 3 points in each dimension
+        points = [(0., .5, 1.)] * 4
+        values = np.asarray([0., .5, 1.])
+        values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
+        values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
+        values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
+        values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
+        values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
+        interp = RegularGridInterpolator(points, values, kind="nearest")
+        sample = np.asarray([0.1, 0.1, .9, .9])
+        wanted = 1100.
+        assert_array_almost_equal(interp(sample), wanted)
+        sample = np.asarray([0.1, 0.1, 0.1, 0.1])
+        wanted = 0.
+        assert_array_almost_equal(interp(sample), wanted)
+        sample = np.asarray([0., 0., 0., 0.])
+        wanted = 0.
+        assert_array_almost_equal(interp(sample), wanted)
+        sample = np.asarray([1., 1., 1., 1.])
+        wanted = 1111.
+        assert_array_almost_equal(interp(sample), wanted)
+        sample = np.asarray([0.1, 0.4, 0.6, 0.9])
+        wanted = 1055.
+        assert_array_almost_equal(interp(sample), wanted)
+
+    def test_linear_edges(self):
+        # create a 4d grid of 3 points in each dimension
+        points = [(0., .5, 1.)] * 4
+        values = np.asarray([0., .5, 1.])
+        values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
+        values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
+        values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
+        values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
+        values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
+        interp = RegularGridInterpolator(points, values)
+        sample = np.asarray([[0., 0., 0., 0.], [1., 1., 1., 1.]])
+        wanted = np.asarray([0., 1111.])
+        assert_array_almost_equal(interp(sample), wanted)
+
+    def test_valid_create(self):
+        # create a 4d grid of 3 points in each dimension
+        points = [(0., .5, 1.), (0., 1., .5)]
+        values = np.asarray([0., .5, 1.])
+        values0 = values[:, np.newaxis]
+        values1 = values[np.newaxis, :]
+        values = (values0 + values1 * 10)
+        assert_raises(ValueError, RegularGridInterpolator, points, values)
+        points = [((0., .5, 1.), ), (0., .5, 1.)]
+        assert_raises(ValueError, RegularGridInterpolator, points, values)
+        points = [(0., .5, .75, 1.), (0., .5, 1.)]
+        assert_raises(ValueError, RegularGridInterpolator, points, values)
+        points = [(0., .5, 1.), (0., .5, 1.), (0., .5, 1.)]
+        assert_raises(ValueError, RegularGridInterpolator, points, values)
+        points = [(0., .5, 1.), (0., .5, 1.)]
+        assert_raises(ValueError, RegularGridInterpolator, points, values,
+                      kind="undefkind")
+
+    def test_valid_call(self):
+        # create a 4d grid of 3 points in each dimension
+        points = [(0., .5, 1.)] * 4
+        values = np.asarray([0., .5, 1.])
+        values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
+        values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
+        values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
+        values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
+        values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
+        interp = RegularGridInterpolator(points, values)
+        sample = np.asarray([[0., 0., 0., 0.], [1., 1., 1., 1.]])
+        assert_raises(ValueError, interp, sample, "undefkind")
+        sample = np.asarray([[0., 0., 0.], [1., 1., 1.]])
+        assert_raises(ValueError, interp, sample)
+        sample = np.asarray([[0., 0., 0., 0.], [1., 1., 1., 1.1]])
+        assert_raises(ValueError, interp, sample)
 
 
 if __name__ == "__main__":

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -13,9 +13,9 @@ from scipy.lib.six import xrange
 from scipy.lib._version import NumpyVersion
 
 from scipy.interpolate import (interp1d, interp2d, lagrange, PPoly, BPoly,
-         ppform, splrep, splev, splantider, splint, sproot,
+         ppform, splrep, splev, splantider, splint, sproot, interpn,
          RegularGridInterpolator, LinearNDInterpolator,
-         NearestNDInterpolator)
+         NearestNDInterpolator, RectBivariateSpline)
 
 from scipy.interpolate import _ppoly
 
@@ -1320,6 +1320,49 @@ class TestRegularGridInterpolator(TestCase):
         sample = np.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
                              [0.5, 0.5, .5, .5]])
         assert_array_almost_equal(interp(sample), interp_qhull(sample))
+
+class TestInterpN(TestCase):
+    def test_spline_2d(self):
+        x = np.arange(1, 6)
+        x = np.array([.5, 2., 3., 4., 5.5])
+        y = np.arange(1, 6)
+        y = np.array([.5, 2., 3., 4., 5.5])
+        z = np.array([[1, 2, 1, 2, 1], [1, 2, 1, 2, 1], [1, 2, 3, 2, 1],
+                      [1, 2, 2, 2, 1], [1, 2, 1, 2, 1]])
+        lut = RectBivariateSpline(x, y, z)
+
+        xi = np.array([[1, 2.3, 5.3, 0.5, 3.3, 1.2, 3],
+                       [1, 3.3, 1.2, 4.0, 5.0, 1.0, 3]]).T
+        assert_array_almost_equal(interpn((x, y), z, xi, method="splinef2d"),
+                                  lut.ev(xi[:, 0], xi[:, 1]))
+
+    def test_linear_4d(self):
+        # create a 4d grid of 3 points in each dimension
+        points = [(0., .5, 1.)] * 2 + [(0., 5., 10.)] * 2
+        values = np.asarray([0., .5, 1.])
+        values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
+        values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
+        values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
+        values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
+        values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
+        interp_rg = RegularGridInterpolator(points, values)
+        sample = np.asarray([0.1, 0.1, 10., 9.])
+        wanted = interpn(points, values, sample, method="linear")
+        assert_array_almost_equal(interp_rg(sample), wanted)
+
+    def test_nearest_4d(self):
+        # create a 4d grid of 3 points in each dimension
+        points = [(0., .5, 1.)] * 2 + [(0., 5., 10.)] * 2
+        values = np.asarray([0., .5, 1.])
+        values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
+        values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
+        values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
+        values3 = values[np.newaxis, np.newaxis, np.newaxis, :]
+        values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
+        interp_rg = RegularGridInterpolator(points, values, kind="nearest")
+        sample = np.asarray([0.1, 0.1, 10., 9.])
+        wanted = interpn(points, values, sample, method="nearest")
+        assert_array_almost_equal(interp_rg(sample), wanted)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Based on Johannes Buchner's _regulargrid_ package (see https://github.com/JohannesBuchner/regulargrid), I implemented a new class `RegularGridInterpolator` for efficient linear and nearest-neighbour interpolation on regular (possibly unevenly spaced) grids in arbitrary dimensions.

I believe this is a significant addition to the `scipy.interpolate` package because the existing ND-interpolators perform a triangulation of the input points with becomes unfeasible with medium (~8) dimensions.  There, by taking advantage of the regular grid structure, the interpolation can be sped up quite a bit.

Another advantage of this class is that it accepts anthing that can be appropriately indexed as _values_ parameter, meaning that it is possible to use this interpolation object for interpolation of disk-based data sets (netCDF, pytables, ...).

I asked for permission about inclusion in Scipy; the (positive) answer is here: https://github.com/JohannesBuchner/regulargrid/issues/2.
