### PR TITLE
ENH minimize, minimize_scalar: Add support for user-provided methods

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -140,6 +140,8 @@ Utility Functions
    line_search - Return a step that satisfies the strong Wolfe conditions
 
    show_options - Show specific options optimization solvers
+   register_minimize - Register a custom minimize method
+   register_minimize_scalar - Register a custom scalar minimize method
 
 """
 


### PR DESCRIPTION
I'm using the excellent scipy.optimize infrastructure for research, experiments and benchmarking of some custom local minimization strategies. However, without this simple change, I have no easy way to plug my minimizer to basinhopping to overload it for global minimization as well; first I added a direct override possibility in PR #3321, but it has been pointed out that a more generic mechanism that could cover other cases would be nicer.

Therefore, this change allows users to plug in their own minimization methods and still reuse all other code that uses the minimize() routines.
