### PR TITLE
ENH: sparse: speedup LIL matrix slicing

### DIFF
--- a/scipy/sparse/_csparsetools.pyx
+++ b/scipy/sparse/_csparsetools.pyx
@@ -306,6 +306,85 @@ cpdef _lil_fancy_set(cnp.npy_intp M, cnp.npy_intp N,
             _lil_insert[value_t](M, N, rows, data, i, j, values[x, y])
 
 
+def lil_get_row_ranges(cnp.npy_intp M, cnp.npy_intp N,
+                       object[:] rows, object[:] datas,
+                       object[:] new_rows, object[:] new_datas,
+                       object irows,
+                       cnp.npy_intp j_start,
+                       cnp.npy_intp j_stop,
+                       cnp.npy_intp j_stride,
+                       cnp.npy_intp nj):
+    """
+    Column-slicing fast path for LIL matrices.
+
+    Extracts values from rows/datas and inserts in to
+    new_rows/new_datas.
+
+    Parameters
+    ----------
+    M, N
+         Shape of input array
+    rows, datas
+         LIL data for input array, shape (M, N)
+    new_rows, new_datas
+         LIL data for output array, shape (len(irows), nj)
+    irows : iterator
+         Iterator yielding row indices
+    j_start, j_stop, j_stride
+         Column range(j_start, j_stop, j_stride) to get
+    nj : int
+         Number of columns corresponding to j_* variables.
+
+    """
+    cdef cnp.npy_intp nk, k, j, a, b, m, r, p
+    cdef list cur_row, cur_data, new_row, new_data
+
+    if j_stride == 0:
+        raise ValueError("cannot index with zero stride")
+
+    for nk, k in enumerate(irows):
+        if k >= M or k < -M:
+            raise ValueError("row index %d out of bounds" % (k,))
+        if k < 0:
+            k += M
+
+        if j_stride == 1 and nj == N:
+            # full row slice
+            new_rows[nk] = list(rows[k])
+            new_datas[nk] = list(datas[k])
+        else:
+            # partial row slice
+            cur_row = rows[k]
+            cur_data = datas[k]
+            new_row = new_rows[nk]
+            new_data = new_datas[nk]
+
+            if j_stride > 0:
+                a = bisect_left(cur_row, j_start)
+                for m in range(a, len(cur_row)):
+                    j = cur_row[m]
+                    if j >= j_stop:
+                        break
+                    r = (j - j_start) % j_stride
+                    if r != 0:
+                        continue
+                    p = (j - j_start) // j_stride
+                    new_row.append(p)
+                    new_data.append(cur_data[m])
+            else:
+                a = bisect_right(cur_row, j_stop)
+                for m in range(a, len(cur_row)):
+                    j = cur_row[m]
+                    if j > j_start:
+                        break
+                    r = (j - j_start) % j_stride
+                    if r != 0:
+                        continue
+                    p = (j - j_start) // j_stride
+                    new_row.insert(0, p)
+                    new_data.insert(0, cur_data[m])
+
+
 cdef lil_insertat_nocheck(list row, list data, cnp.npy_intp j, object x):
     """
     Insert a single item to LIL matrix.
@@ -359,7 +438,7 @@ cdef lil_deleteat_nocheck(list row, list data, cnp.npy_intp j):
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef bisect_left(list a, cnp.npy_intp x):
+cdef cnp.npy_intp bisect_left(list a, cnp.npy_intp x) except -1:
     """
     Bisection search in a sorted list.
 
@@ -390,4 +469,41 @@ cdef bisect_left(list a, cnp.npy_intp x):
             lo = mid + 1
         else:
             hi = mid
+    return lo
+
+
+@cython.cdivision(True)
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef cnp.npy_intp bisect_right(list a, cnp.npy_intp x) except -1:
+    """
+    Bisection search in a sorted list.
+
+    List is assumed to contain objects castable to integers.
+
+    Parameters
+    ----------
+    a
+        List to search in
+    x
+        Value to search for
+
+    Returns
+    -------
+    j : int
+        Index immediately at the right of the value (if present), or at
+        the point to which it can be inserted maintaining order.
+
+    """
+    cdef cnp.npy_intp hi = len(a)
+    cdef cnp.npy_intp lo = 0
+    cdef cnp.npy_intp mid, v
+
+    while lo < hi:
+        mid = (lo + hi)//2
+        v = a[mid]
+        if x < v:
+            hi = mid
+        else:
+            lo = mid + 1
     return lo

--- a/scipy/sparse/benchmarks/bench_sparse.py
+++ b/scipy/sparse/benchmarks/bench_sparse.py
@@ -301,6 +301,7 @@ class BenchmarkSparse(TestCase):
         print('-'*80)
 
         for M, density in itertools.product(Ms, densities):
+            np.random.seed(1234)
             A = rand(M, M, density=density)
             for N, spat in itertools.product(Ns, spats):
                 # indices to assign to
@@ -349,6 +350,7 @@ class BenchmarkSparse(TestCase):
         A[i, j]
 
     def _getset_args_random(self, A, N):
+        np.random.seed(1234)
         i, j = [], []
         while len(i) < N:
             n = N - len(i)
@@ -377,6 +379,7 @@ class BenchmarkSparse(TestCase):
                            msg='__getitem__[i, j]; len(i) = len(j) = N; random indices')
 
     def _getset_args_fullrows(self, A, N):
+        np.random.seed(1234)
         N //= A.shape[0]
         i, j = [], slice(None)
         while len(i) < N:
@@ -425,6 +428,7 @@ class BenchmarkSparse(TestCase):
                            msg="__getitem__[:,idx]; len(idx)*M == N")
 
     def _getset_args_slices(self, A, N):
+        np.random.seed(1234)
         k = max(1, int(np.sqrt(N)))
         i = slice((A.shape[0]-k)//2, (A.shape[0]+k)//2)
         j = slice((A.shape[0]-k)//2, (A.shape[0]+k)//2)

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -7,11 +7,10 @@ __docformat__ = "restructuredtext en"
 
 __all__ = ['lil_matrix','isspmatrix_lil']
 
-from itertools import izip
 from bisect import bisect_left, bisect_right
 
 import numpy as np
-from scipy.lib.six import xrange
+from scipy.lib.six import xrange, zip as izip
 
 from .base import spmatrix, isspmatrix
 from .sputils import getdtype, isshape, issequence, isscalarlike, ismatrix, \

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -7,14 +7,15 @@ __docformat__ = "restructuredtext en"
 
 __all__ = ['lil_matrix','isspmatrix_lil']
 
-from bisect import bisect_left
+from itertools import izip
+from bisect import bisect_left, bisect_right
 
 import numpy as np
 from scipy.lib.six import xrange
 
 from .base import spmatrix, isspmatrix
 from .sputils import getdtype, isshape, issequence, isscalarlike, ismatrix, \
-    IndexMixin, upcast_scalar, get_index_dtype
+    IndexMixin, upcast_scalar, get_index_dtype, isintlike
 
 from warnings import warn
 from .base import SparseEfficiencyWarning
@@ -220,10 +221,29 @@ class lil_matrix(spmatrix, IndexMixin):
     def getrow(self, i):
         """Returns a copy of the 'i'th row.
         """
+        if i < 0:
+            i += self.shape[0]
+        if i < 0 or i >= self.shape[0]:
+            raise IndexError('row index out of bounds')
+
         new = lil_matrix((1, self.shape[1]), dtype=self.dtype)
         new.rows[0] = self.rows[i][:]
         new.data[0] = self.data[i][:]
         return new
+
+    def _check_row_bounds(self, i):
+        if i < 0:
+            i += self.shape[0]
+        if i < 0 or i >= self.shape[0]:
+            raise IndexError('row index out of bounds')
+        return i
+
+    def _check_col_bounds(self, j):
+        if j < 0:
+            j += self.shape[1]
+        if j < 0 or j >= self.shape[1]:
+            raise IndexError('column index out of bounds')
+        return j
 
     def __getitem__(self, index):
         """Return the element(s) index=(i, j), where j may be a slice.
@@ -248,11 +268,36 @@ class lil_matrix(spmatrix, IndexMixin):
         i, j = self._unpack_index(index)
 
         # Proper check for other scalar index types
-        if isscalarlike(i) and isscalarlike(j):
+        i_intlike = isintlike(i)
+        j_intlike = isintlike(j)
+
+        if i_intlike and j_intlike:
             v = _csparsetools.lil_get1(self.shape[0], self.shape[1],
                                        self.rows, self.data,
                                        i, j)
             return self.dtype.type(v)
+        elif j_intlike or isinstance(j, slice):
+            # column slicing fast path
+            if j_intlike:
+                j = self._check_col_bounds(j)
+                j = slice(j, j+1)
+
+            if i_intlike:
+                i = self._check_row_bounds(i)
+                i = xrange(i, i+1)
+                i_shape = None
+            elif isinstance(i, slice):
+                i = xrange(*i.indices(self.shape[0]))
+                i_shape = None
+            else:
+                i = np.atleast_1d(i)
+                i_shape = i.shape
+
+            if i_shape is None or len(i_shape) == 1:
+                return self._get_row_ranges(i, j)
+        elif isinstance(i, slice):
+            # yes, this is quite a bit faster
+            return self.tocsr()[i,j].tolil()
 
         i, j = self._index_to_arrays(i, j)
         if i.size == 0:
@@ -266,6 +311,69 @@ class lil_matrix(spmatrix, IndexMixin):
                                     new.rows, new.data,
                                     i, j)
         return new
+
+    def _get_row_ranges(self, rows, col_slice):
+        """
+        Fast path for indexing in the case where column index is slice.
+
+        This gains performance improvement over brute force by more
+        efficient skipping of zeros, by accessing the elements
+        column-wise in order.
+
+        Parameters
+        ----------
+        rows : sequence or xrange
+            Rows indexed. If xrange, must be within valid bounds.
+        col_slice : slice
+            Columns indexed
+
+        """
+        j_start, j_stop, j_stride = col_slice.indices(self.shape[1])
+        col_range = xrange(j_start, j_stop, j_stride)
+
+        if not isinstance(rows, xrange):
+            rows = [self._check_row_bounds(k) for k in rows]
+
+        if j_stride == 1 and len(col_range) == self.shape[1]:
+            # full row slice
+            new = lil_matrix((len(rows), self.shape[1]), dtype=self.dtype)
+            for nk, k in enumerate(rows):
+                new.rows[nk] = self.rows[k][:]
+                new.data[nk] = self.data[k][:]
+            return new
+        else:
+            # partial row slice
+            nj = len(col_range)
+            new = lil_matrix((len(rows), nj), dtype=self.dtype)
+            for nk, k in enumerate(rows):
+                cur_row = self.rows[k]
+
+                if j_stride > 0:
+                    a = bisect_left(cur_row, j_start)
+                    b = bisect_left(cur_row, j_stop)
+
+                    if j_stride == 1:
+                        new.rows[nk].extend(j - j_start for j in cur_row[a:b])
+                        new.data[nk].extend(self.data[k][a:b])
+                    else:
+                        for j, v in izip(cur_row[a:b], self.data[k][a:b]):
+                            p, r = divmod(j - j_start, j_stride)
+                            if r != 0:
+                                continue
+                            new.rows[nk].append(p)
+                            new.data[nk].append(v)
+                else:
+                    a = bisect_right(cur_row, j_stop)
+                    b = bisect_right(cur_row, j_start)
+
+                    for j, v in izip(cur_row[a:b], self.data[k][a:b]):
+                        p, r = divmod(j - j_start, j_stride)
+                        if r != 0:
+                            continue
+                        new.rows[nk].insert(0, p)
+                        new.data[nk].insert(0, v)
+                            
+            return new
 
     def __setitem__(self, index, x):
         # Scalar fast path first


### PR DESCRIPTION
The current implementation for slicing LIL matrices is very pessimal. Replace it with a more optimal implementation.

Gives a factor of ~1/density speedup:

```
In []: A = rand(3000, 3000, density=1e-3, format="lil")

# Before (9ccc68475)
In [4]: %timeit A[::2,::-2]
10 loops, best of 3: 87.5 ms per loop

# After (d47e27b0)
In [4]: %timeit A[::2,::-2]
1000 loops, best of 3: 603 µs per loop
```

Gives speedups also for smaller slices:

```
# Before
In [5]: %timeit A[3,:]
1000 loops, best of 3: 213 µs per loop
In [6]: %timeit A[:,3]
1000 loops, best of 3: 901 µs per loop
In [7]: %timeit A[1:5,1:5]
10000 loops, best of 3: 83.3 µs per loop

# After
In [5]: %timeit A[3,:]
10000 loops, best of 3: 38.8 µs per loop
In [6]: %timeit A[:,3]
1000 loops, best of 3: 702 µs per loop
In [7]: %timeit A[1:5,1:5]
10000 loops, best of 3: 40.3 µs per loop
```

(Column slices in LIL are still problematic, but that's due to the matrix format.)

**EDIT** updated benchmarks
