### PR TITLE
BUG: in interp use 'take' in a less brittle way

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -366,7 +366,7 @@ class interp1d(_Interpolator1D):
         if not assume_sorted:
             ind = np.argsort(x)
             x = x[ind]
-            np.take(y, ind, axis=axis, out=y)
+            y = np.take(y, ind, axis=axis)
 
         if x.ndim != 1:
             raise ValueError("the x array must have exactly one dimension.")


### PR DESCRIPTION
Fixes an error raised when I test scipy with the numpy development branch.

```
======================================================================
ERROR: test_dlsim (test_dltisys.TestDLTI)
----------------------------------------------------------------------
Traceback (most recent call last):
/scipy/signal/tests/test_dltisys.py", line 53, in test_dlsim
    tout, yout, xout = dlsim((a, b, c, d, dt), u_sparse, t_sparse)
/scipy/interpolate/interpolate.py", line 370, in __init__
    np.take(y, ind, axis=axis, out=y)
/numpy/core/fromnumeric.py", line 118, in take
    return take(indices, axis, out, mode)
ValueError: UPDATEIFCOPY base is read-only
```

By the way, when I run the scipy tests with the numpy development branch, DeprecationWarning and RuntimeWarning are also raised as exceptions (rather than appearing as warnings), without having made any change to the scipy runtests.py script.  Is this expected or does it mean that I probably installed something wrong?
