### PR TITLE
BUG: sparse: restore previous behavior in numpy ufuncs with object arrays

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -766,6 +766,13 @@ class spmatrix(object):
         functions.
         """
 
+        if any(not isinstance(x, spmatrix) and np.asarray(x).dtype == object
+               for x in inputs):
+            # preserve previous behavior with object arrays
+            with_self = list(inputs)
+            with_self[pos] = np.asarray(self, dtype=object)
+            return getattr(func, method)(*with_self, **kwargs)
+
         out = kwargs.pop('out', None)
         if method != '__call__' or kwargs:
             return NotImplemented


### PR DESCRIPTION
Some users may rely on ufuncs distributing operations on sparse matrices
across each entry of an object array.

This PR restores the previous behavior when the ufunc operates both on sparse
matrices and object arrays.

Fixes gh-3345
