### PR TITLE
BUG: add proper error handling when using interp2d on regular grids

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -178,6 +178,11 @@ class interp2d(object):
 
         rectangular_grid = (z.size == len(x) * len(y))
         if rectangular_grid:
+            if z.ndim == 2:
+                if z.shape != (len(y), len(x)):
+                    raise ValueError("When on a regular grid with x.size = m "
+                                     "and y.size = n, if z.ndim == 2, then z "
+                                     "must have shape (n, m)")
             if not np.all(x[1:] >= x[:-1]):
                 j = np.argsort(x)
                 x = x[j]

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -72,7 +72,7 @@ class TestInterp2D(TestCase):
     def test_interp2d_bounds(self):
         x = np.linspace(0, 1, 5)
         y = np.linspace(0, 2, 7)
-        z = x[:,None]**2 + y[None,:]
+        z = x[None, :]**2 + y[:, None]
 
         ix = np.linspace(-1, 3, 31)
         iy = np.linspace(-1, 3, 33)


### PR DESCRIPTION
fixes #1889

This is not the most thorough error checking, but given the very weak constraints interp2d poses on the user, I think it was best to break no working existing code. 

Of course there might be corner cases where `x.ndim==1`, `y.ndim==1`, `z.ndim!=2` and `z.size==x.size*y.size` but it would be almost impossible to catch these here, I believe. 
