### PR TITLE
ENH: Add MLS method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ scipy/optimize/minpack2/minpack2module.c
 scipy/optimize/nnls/_nnlsmodule.c
 scipy/optimize/slsqp/_slsqpmodule.c
 scipy/signal/_spectral.c
+scipy/signal/_max_len_seq.c
 scipy/signal/correlate_nd.c
 scipy/signal/lfilter.c
 scipy/sparse/_csparsetools.c

--- a/doc/release/0.15.0-notes.rst
+++ b/doc/release/0.15.0-notes.rst
@@ -45,6 +45,11 @@ gradient methods), and can search large areas of candidate space, but often
 requires larger numbers of function evaluations than conventional gradient
 based techniques.
 
+``scipy.signal`` improvements
+-----------------------------
+The function ``max_len_seq`` was added, which computes a Maximum
+Length Sequence (MLS) signal.
+
 Deprecated features
 ===================
 
@@ -78,6 +83,7 @@ Authors
 
 * Rob Falck
 * Andrew Nelson
+* Eric Larson
 
 Issues closed
 -------------
@@ -87,6 +93,6 @@ Pull requests
 -------------
 
 - `#3342 <https://github.com/scipy/scipy/pull/3342>`__: ENH: linprog function for linear programming
+- `#3351 <https://github.com/scipy/scipy/pull/3351>`__: ENH: Add MLS method
 - `#3446 <https://github.com/scipy/scipy/pull/3446>`__: ENH: scipy.optimize - adding differential_evolution
-
 

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -161,6 +161,7 @@ Waveforms
 
    chirp       -- Frequency swept cosine signal, with several freq functions.
    gausspulse  -- Gaussian modulated sinusoid
+   max_len_seq -- Maximum length sequence
    sawtooth    -- Periodic sawtooth
    square      -- Square wave
    sweep_poly  -- Frequency swept cosine signal; freq is arbitrary polynomial
@@ -231,6 +232,7 @@ from __future__ import division, print_function, absolute_import
 
 from . import sigtools
 from .waveforms import *
+from ._max_len_seq import max_len_seq
 
 # The spline module (a C extension) provides:
 #     cspline2d, qspline2d, sepfir2d, symiirord1, symiirord2

--- a/scipy/signal/_max_len_seq.pyx
+++ b/scipy/signal/_max_len_seq.pyx
@@ -1,0 +1,123 @@
+# Author: Eric Larson
+# 2014
+
+"""Tools for MLS generation"""
+
+import numpy as np
+cimport numpy as np
+cimport cython
+
+__all__ = ['max_len_seq']
+
+
+# These are definitions of linear shift register taps for use in max_len_seq()
+_mls_taps = {2: [1], 3: [2], 4: [3], 5: [3], 6: [5], 7: [6], 8: [7, 6, 1],
+             9: [5], 10: [7], 11: [9], 12: [11, 10, 4], 13: [12, 11, 8],
+             14: [13, 12, 2], 15: [14], 16: [15, 13, 4], 17: [14],
+             18: [11], 19: [18, 17, 14], 20: [17], 21: [19], 22: [21],
+             23: [18], 24: [23, 22, 17], 25: [22], 26: [25, 24, 20],
+             27: [26, 25, 22], 28: [25], 29: [27], 30: [29, 28, 7],
+             31: [28], 32: [31, 30, 10]}
+
+@cython.cdivision(True)  # faster modulo
+@cython.boundscheck(False)  # designed to stay within bounds
+@cython.wraparound(False)  # we don't use negative indexing
+def max_len_seq(nbits, state=None, length=None, taps=None):
+    """
+    max_len_seq(nbits, state=None, length=None, taps=None)
+
+    Maximum Length Sequence (MLS) generator
+
+    Parameters
+    ----------
+    nbits : int
+        Number of bits to use. Length of the resulting sequence will
+        be ``(2**nbits) - 1``. Note that generating long sequences
+        (e.g., greater than ``nbits == 16``) can take a long time.
+    state : array_like, optional
+        If array, must be of length ``nbits``, and will be cast to binary
+        (bool) representation. If None, a seed of ones will be used,
+        producing a repeatable representation. If ``state`` is all
+        zeros, an error is raised as this is invalid. Default: None.
+    length : int | None, optional
+        Number of samples to compute. If None, the entire length
+        ``(2**nbits) - 1`` is computed.
+    taps : array_like, optional
+        Polynomial taps to use (e.g., ``[7, 6, 1]`` for an 8-bit sequence).
+        If None, taps will be automatically selected (for up to
+        ``nbits == 32``).
+
+    Returns
+    -------
+    seq : array
+        Resulting MLS sequence of 0's and 1's.
+    state : array
+        The final state of the shift register.
+
+    Notes
+    -----
+    The algorithm for MLS generation is generically described in:
+
+        http://en.wikipedia.org/wiki/Maximum_length_sequence
+
+    The default values for taps are specifically taken from the first
+    option listed for each value of ``nbits`` in:
+
+        http://www.newwaveinstruments.com/resources/articles/
+            m_sequence_linear_feedback_shift_register_lfsr.htm
+
+    .. versionadded:: 0.15.0
+    """
+    if taps is None:
+        if nbits not in _mls_taps:
+            known_taps = np.array(list(_mls_taps.keys()))
+            raise ValueError('nbits must be between %s and %s if taps is None'
+                             % (known_taps.min(), known_taps.max()))
+        taps = np.array(_mls_taps[nbits], int)
+    else:
+        taps = np.unique(np.array(taps, int))[::-1]
+        if np.any(taps < 0) or np.any(taps > nbits) or taps.size < 1:
+            raise ValueError('taps must be non-empty with values between '
+                             'zero and nbits (inclusive)')
+        taps = np.ascontiguousarray(taps)  # needed for Cython
+    n_max = (2**nbits) - 1
+    if length is None:
+        length = n_max
+    else:
+        length = int(length)
+        if length < 0:
+            raise ValueError('length must be greater than or equal to 0')
+    # We use int8 instead of bool here because numpy arrays of bools
+    # don't seem to work nicely with Cython
+    if state is None:
+        state = np.ones(nbits, dtype=np.int8, order='c')
+    else:
+        # makes a copy if need be, ensuring it's 0's and 1's
+        state = np.array(state, dtype=bool, order='c').astype(np.int8)
+    if state.ndim != 1 or state.size != nbits:
+        raise ValueError('state must be a 1-dimensional array of size nbits')
+    if np.all(state == 0):
+        raise ValueError('state must not be all zeros')
+
+    # Here we compute MLS using a shift register, indexed using a ring buffer
+    # technique (faster than using something like np.roll to shift)
+    cdef np.ndarray[Py_ssize_t, ndim=1, mode='c'] c_taps = taps
+    cdef np.ndarray[np.int8_t, ndim=1, mode='c'] c_state = state
+    cdef Py_ssize_t c_nbits = nbits
+    cdef Py_ssize_t n_out = length
+    cdef Py_ssize_t n_taps = taps.size
+    cdef Py_ssize_t idx = 0
+    cdef Py_ssize_t fidx = 0
+    cdef np.int8_t feedback
+    cdef np.ndarray[np.int8_t, ndim=1, mode='c'] seq = \
+        np.empty(n_out, dtype=np.int8, order='c')
+    for ii in range(n_out):
+        feedback = c_state[idx]
+        seq[ii] = feedback
+        for ti in range(n_taps):
+            feedback ^= c_state[(c_taps[ti] + idx) % c_nbits]
+        c_state[idx] = feedback
+        idx = (idx + 1) % c_nbits
+    # state must be rolled s.t. next run, when idx==0, it's in the right place
+    state = np.roll(state, -idx, axis=0)
+    return seq, state

--- a/scipy/signal/bento.info
+++ b/scipy/signal/bento.info
@@ -10,6 +10,8 @@ Library:
             medianfilter.c
     Extension: _spectral
         Sources: _spectral.c
+    Extension: _max_len_seq
+        Sources: _max_len_seq.c
     Extension: spline
         Sources:
             splinemodule.c,

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -19,11 +19,11 @@ def configuration(parent_package='', top_path=None):
                          )
 
     config.add_extension('_spectral', sources=['_spectral.c'])
+    config.add_extension('_max_len_seq', sources=['_max_len_seq.c'])
 
-    config.add_extension('spline',
-        sources=['splinemodule.c', 'S_bspline_util.c', 'D_bspline_util.c',
-                 'C_bspline_util.c', 'Z_bspline_util.c', 'bspline_util.c'],
-    )
+    spline_src = ['splinemodule.c', 'S_bspline_util.c', 'D_bspline_util.c',
+                  'C_bspline_util.c', 'Z_bspline_util.c', 'bspline_util.c']
+    config.add_extension('spline', sources=spline_src)
 
     return config
 

--- a/scipy/signal/tests/test_max_len_seq.py
+++ b/scipy/signal/tests/test_max_len_seq.py
@@ -1,0 +1,69 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+from numpy.testing import (TestCase, assert_raises, run_module_suite,
+                           assert_allclose, assert_array_equal)
+from numpy.fft import fft, ifft
+
+from scipy.signal import max_len_seq
+
+
+class TestMLS(TestCase):
+
+    def test_mls_inputs(self):
+        # can't all be zero state
+        assert_raises(ValueError, max_len_seq,
+                      10, state=np.zeros(10))
+        # wrong size state
+        assert_raises(ValueError, max_len_seq, 10,
+                      state=np.ones(3))
+        # wrong length
+        assert_raises(ValueError, max_len_seq, 10, length=-1)
+        assert_array_equal(max_len_seq(10, length=0)[0], [])
+        # unknown taps
+        assert_raises(ValueError, max_len_seq, 64)
+        # bad taps
+        assert_raises(ValueError, max_len_seq, 10, taps=[-1, 1])
+
+    def test_mls_output(self):
+        # define some alternate working taps
+        alt_taps = {2: [1], 3: [2], 4: [3], 5: [4, 3, 2], 6: [5, 4, 1], 7: [4],
+                    8: [7, 5, 3]}
+        # assume the other bit levels work, too slow to test higher orders...
+        for nbits in range(2, 8):
+            for state in [None, np.round(np.random.rand(nbits))]:
+                for taps in [None, alt_taps[nbits]]:
+                    if state is not None and np.all(state == 0):
+                        state[0] = 1  # they can't all be zero
+                    orig_m = max_len_seq(nbits, state=state,
+                                         taps=taps)[0]
+                    m = 2. * orig_m - 1.  # convert to +/- 1 representation
+                    # First, make sure we got all 1's or -1
+                    err_msg = "mls had non binary terms"
+                    assert_array_equal(np.abs(m), np.ones_like(m),
+                                       err_msg=err_msg)
+                    # Test via circular cross-correlation, which is just mult.
+                    # in the frequency domain with one signal conjugated
+                    tester = np.real(ifft(fft(m) * np.conj(fft(m))))
+                    out_len = 2**nbits - 1
+                    # impulse amplitude == test_len
+                    err_msg = "mls impulse has incorrect value"
+                    assert_allclose(tester[0], out_len, err_msg=err_msg)
+                    # steady-state is -1
+                    err_msg = "mls steady-state has incorrect value"
+                    assert_allclose(tester[1:], -1 * np.ones(out_len - 1),
+                                    err_msg=err_msg)
+                    # let's do the split thing using a couple options
+                    for n in (1, 2**(nbits - 1)):
+                        m1, s1 = max_len_seq(nbits, state=state, taps=taps,
+                                             length=n)
+                        m2, s2 = max_len_seq(nbits, state=s1, taps=taps,
+                                             length=1)
+                        m3, s3 = max_len_seq(nbits, state=s2, taps=taps,
+                                             length=out_len - n - 1)
+                        new_m = np.concatenate((m1, m2, m3))
+                        assert_array_equal(orig_m, new_m)
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -1,8 +1,9 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import TestCase, assert_almost_equal, assert_equal, assert_, \
-        assert_raises, assert_allclose, run_module_suite
+from numpy.testing import (TestCase, assert_almost_equal, assert_equal,
+                           assert_, assert_raises, run_module_suite,
+                           assert_allclose)
 
 import scipy.signal.waveforms as waveforms
 
@@ -77,7 +78,7 @@ class TestChirp(TestCase):
 
     def test_quadratic_at_zero2(self):
         w = waveforms.chirp(t=0, f0=1.0, f1=2.0, t1=1.0, method='quadratic',
-                                                                vertex_zero=False)
+                            vertex_zero=False)
         assert_almost_equal(w, 1.0)
 
     def test_quadratic_freq_01(self):

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -8,7 +8,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy import asarray, zeros, place, nan, mod, pi, extract, log, sqrt, \
-     exp, cos, sin, polyval, polyint
+    exp, cos, sin, polyval, polyint
 
 __all__ = ['sawtooth', 'square', 'gausspulse', 'chirp', 'sweep_poly']
 
@@ -223,7 +223,7 @@ def gausspulse(t, fc=1000, bw=0.5, bwr=-6, tpr=-60, retquad=False,
         raise ValueError("Fractional bandwidth (bw=%.2f) must be > 0." % bw)
     if bwr >= 0:
         raise ValueError("Reference level for bandwidth (bwr=%.2f) must "
-              "be < 0 dB" % bwr)
+                         "be < 0 dB" % bwr)
 
     # exp(-a t^2) <->  sqrt(pi/a) exp(-pi^2/a * f^2)  = g(f)
 
@@ -392,7 +392,8 @@ def _chirp_phase(t, f0, t1, f1, method='linear', vertex_zero=True):
 
     else:
         raise ValueError("method must be 'linear', 'quadratic', 'logarithmic',"
-                " or 'hyperbolic', but a value of %r was given." % method)
+                         " or 'hyperbolic', but a value of %r was given."
+                         % method)
 
     return phase
 


### PR DESCRIPTION
This adds MLS calculation. Not 100% sure `waveforms` is the correct place for it, but it is a waveform, so perhaps it is.

Cython was about a factor of 10x faster than Python, so I used that.
