### PR TITLE
DOC: add 'Methods' section to interpolation classes

### DIFF
--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -198,6 +198,10 @@ class LinearNDInterpolator(NDInterpolatorBase):
 
     .. versionadded:: 0.9
 
+    Methods
+    -------
+    __call__
+
     Parameters
     ----------
     points : ndarray of floats, shape (npoints, ndims); or Delaunay
@@ -767,6 +771,10 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
     Piecewise cubic, C1 smooth, curvature-minimizing interpolant in 2D.
 
     .. versionadded:: 0.9
+
+    Methods
+    -------
+    __call__
 
     Parameters
     ----------

--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -27,6 +27,10 @@ class NearestNDInterpolator(NDInterpolatorBase):
 
     .. versionadded:: 0.9
 
+    Methods
+    -------
+    __call__
+
     Parameters
     ----------
     points : (Npoints, Ndims) ndarray of floats


### PR DESCRIPTION
the interpolation classes `LinearNDInterpolator`, `NearestNDInterpolator`, and `ToughClother2DInterpolator` were missing the 'Methods' section, making it impossible to see the call signatures.
