### PR TITLE
ENH: sparse: speed up LIL indexing + assignment via Cython

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,25 +24,6 @@ scipy/sparse/sparsetools/dia_wrap.cxx binary
 scipy/sparse/sparsetools/csgraph.py binary
 scipy/sparse/sparsetools/csgraph_wrap.cxx binary
 
-# Cython-generated files
-scipy/interpolate/interpnd.c binary
-scipy/io/matlab/mio_utils.c binary
-scipy/io/matlab/mio5_utils.c binary
-scipy/io/matlab/streams.c binary
-scipy/signal/_spectral.c binary
-scipy/sparse/csgraph/_min_spanning_tree.c binary
-scipy/sparse/csgraph/_shortest_path.c binary
-scipy/sparse/csgraph/_tools.c binary
-scipy/sparse/csgraph/_traversal.c binary
-scipy/spatial/ckdtree.c binary
-scipy/spatial/qhull.c binary
-scipy/special/_ufuncs.c binary
-scipy/special/_ufuncs_cxx.cxx binary
-scipy/special/_ufuncs_defs.h binary
-scipy/special/_ufuncs_cxx_defs.h binary
-scipy/stats/_rank.c binary
-scipy/stats/vonmises_cython.c binary
-
 # Numerical data files
 scipy/special/tests/data/*.txt binary
 scipy/special/tests/data/*/*.txt binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -30,6 +30,7 @@ scipy/io/matlab/mio_utils.c binary
 scipy/io/matlab/mio5_utils.c binary
 scipy/io/matlab/streams.c binary
 scipy/signal/_spectral.c binary
+scipy/sparse/_csparsetools.c
 scipy/sparse/csgraph/_min_spanning_tree.c binary
 scipy/sparse/csgraph/_shortest_path.c binary
 scipy/sparse/csgraph/_tools.c binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -30,7 +30,6 @@ scipy/io/matlab/mio_utils.c binary
 scipy/io/matlab/mio5_utils.c binary
 scipy/io/matlab/streams.c binary
 scipy/signal/_spectral.c binary
-scipy/sparse/_csparsetools.c
 scipy/sparse/csgraph/_min_spanning_tree.c binary
 scipy/sparse/csgraph/_shortest_path.c binary
 scipy/sparse/csgraph/_tools.c binary

--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,7 @@ scipy/optimize/slsqp/_slsqpmodule.c
 scipy/signal/_spectral.c
 scipy/signal/correlate_nd.c
 scipy/signal/lfilter.c
+scipy/sparse/_csparsetools.c
 scipy/sparse/csgraph/_min_spanning_tree.c
 scipy/sparse/csgraph/_shortest_path.c
 scipy/sparse/csgraph/_tools.c

--- a/scipy/sparse/_csparsetools.pyx
+++ b/scipy/sparse/_csparsetools.pyx
@@ -15,9 +15,50 @@ ctypedef fused idx_t:
     cnp.int64_t
 
 
-cpdef lil_get1(cnp.intp_t M, cnp.intp_t N, object[:] rows, object[:] datas, cnp.intp_t i, cnp.intp_t j):
+ctypedef fused value_t:
+    cnp.npy_bool
+    cnp.npy_int8
+    cnp.npy_uint8
+    cnp.npy_int16
+    cnp.npy_uint16
+    cnp.npy_int32
+    cnp.npy_uint32
+    cnp.npy_int64
+    cnp.npy_uint64
+    cnp.npy_float32
+    cnp.npy_float64
+    float complex
+    double complex
+
+
+cpdef lil_get1(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas, cnp.npy_intp i, cnp.npy_intp j):
     cdef list row, data
-    
+
+    if i < 0:
+        i += M
+    if i < 0 or i >= M:
+        raise IndexError('row index out of bounds')
+
+    if j < 0:
+        j += N
+    if j < 0 or j >= N:
+        raise IndexError('column index out of bounds')
+
+    row = rows[i]
+    data = datas[i]
+    pos = bisect_left(row, j)
+
+    if pos != len(data) and row[pos] == j:
+        return data[pos]
+    else:
+        return 0
+
+
+cpdef lil_insert(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas,
+                 cnp.npy_intp i, cnp.npy_intp j, value_t x):
+    cdef list row, data
+    cdef int is_zero
+
     if i < 0:
         i += M
     if i < 0 or i >= M:
@@ -31,16 +72,14 @@ cpdef lil_get1(cnp.intp_t M, cnp.intp_t N, object[:] rows, object[:] datas, cnp.
     row = rows[i]
     data = datas[i]
 
-    pos = bisect_left(row, j)
-
-    if pos != len(data) and row[pos] == j:
-        return data[pos]
+    if x == 0:
+        lil_deleteat_nocheck(rows[i], datas[i], j)
     else:
-        return 0
+        lil_insertat_nocheck(rows[i], datas[i], j, x)
 
 
-cdef lil_insert_nocheck(cnp.intp_t N, list row, list data, cnp.intp_t j, object x):
-    cdef cnp.intp_t pos
+cdef lil_insertat_nocheck(list row, list data, cnp.npy_intp j, object x):
+    cdef cnp.npy_intp pos
 
     pos = bisect_left(row, j)
     if pos == len(row):
@@ -48,19 +87,27 @@ cdef lil_insert_nocheck(cnp.intp_t N, list row, list data, cnp.intp_t j, object 
         data.append(x)
     elif row[pos] != j:
         row.insert(pos, j)
-        row.insert(pos, x)
+        data.insert(pos, x)
     else:
         data[pos] = x
 
 
-def lil_fancy_get(cnp.intp_t M, cnp.intp_t N,
+cdef lil_deleteat_nocheck(list row, list data, cnp.npy_intp j):
+    cdef cnp.npy_intp pos
+    pos = bisect_left(row, j)
+    if pos < len(row) and row[pos] == j:
+        del row[pos]
+        del data[pos]
+
+
+def lil_fancy_get(cnp.npy_intp M, cnp.npy_intp N,
                   object[:] rows,
                   object[:] data,
                   object[:] new_rows,
                   object[:] new_data,
-                  cnp.ndarray[cnp.intp_t, ndim=2] i_idx,
-                  cnp.ndarray[cnp.intp_t, ndim=2] j_idx):
-    cdef cnp.intp_t x, y, i, j
+                  cnp.ndarray[cnp.npy_intp, ndim=2] i_idx,
+                  cnp.ndarray[cnp.npy_intp, ndim=2] j_idx):
+    cdef cnp.npy_intp x, y, i, j
     cdef object value
 
     for x in range(i_idx.shape[0]):
@@ -74,22 +121,38 @@ def lil_fancy_get(cnp.intp_t M, cnp.intp_t N,
                 # Object identity as shortcut
                 continue
 
-            lil_insert_nocheck(i_idx.shape[1],
-                               new_rows[x], new_data[x],
-                               y, value)
+            lil_insertat_nocheck(new_rows[x], new_data[x],
+                                 y, value)
 
 
-cdef bisect_left(list a, cnp.intp_t x):
-    cdef cnp.intp_t hi = len(a)
-    cdef cnp.intp_t lo = 0
-    cdef cnp.intp_t mid_v
-    cdef cpython.PyObject* v
+def lil_fancy_set(cnp.npy_intp M, cnp.npy_intp N,
+                  object[:] rows,
+                  object[:] data,
+                  cnp.ndarray[cnp.npy_intp, ndim=2] i_idx,
+                  cnp.ndarray[cnp.npy_intp, ndim=2] j_idx,
+                  value_t[:,:] values):
+
+    cdef cnp.npy_intp x, y, i, j
+
+    for x in range(i_idx.shape[0]):
+        for y in range(i_idx.shape[1]):
+            i = i_idx[x,y]
+            j = j_idx[x,y]
+            lil_insert[value_t](M, N, rows, data, i, j, values[x, y])
+
+
+@cython.cdivision(True)
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef bisect_left(list a, cnp.npy_intp x):
+    cdef cnp.npy_intp hi = len(a)
+    cdef cnp.npy_intp lo = 0
+    cdef cnp.npy_intp mid, v
 
     while lo < hi:
         mid = (lo + hi)//2
-        v = cpython.list.PyList_GET_ITEM(a, mid)
-        mid_v = cpython.int.PyInt_AsLong(<object>v)
-        if mid_v < x:
+        v = a[mid]
+        if v < x:
             lo = mid + 1
         else:
             hi = mid

--- a/scipy/sparse/_csparsetools.pyx
+++ b/scipy/sparse/_csparsetools.pyx
@@ -1,0 +1,96 @@
+"""
+Fast snippets for sparse matrices
+"""
+
+cimport cython
+cimport cpython.list
+cimport cpython.int
+cimport cpython
+cimport numpy as cnp
+import numpy as np
+
+
+ctypedef fused idx_t:
+    cnp.int32_t
+    cnp.int64_t
+
+
+cpdef lil_get1(cnp.intp_t M, cnp.intp_t N, object[:] rows, object[:] datas, cnp.intp_t i, cnp.intp_t j):
+    cdef list row, data
+    
+    if i < 0:
+        i += M
+    if i < 0 or i >= M:
+        raise IndexError('row index out of bounds')
+
+    if j < 0:
+        j += N
+    if j < 0 or j >= N:
+        raise IndexError('column index out of bounds')
+
+    row = rows[i]
+    data = datas[i]
+
+    pos = bisect_left(row, j)
+
+    if pos != len(data) and row[pos] == j:
+        return data[pos]
+    else:
+        return 0
+
+
+cdef lil_insert_nocheck(cnp.intp_t N, list row, list data, cnp.intp_t j, object x):
+    cdef cnp.intp_t pos
+
+    pos = bisect_left(row, j)
+    if pos == len(row):
+        row.append(j)
+        data.append(x)
+    elif row[pos] != j:
+        row.insert(pos, j)
+        row.insert(pos, x)
+    else:
+        data[pos] = x
+
+
+def lil_fancy_get(cnp.intp_t M, cnp.intp_t N,
+                  object[:] rows,
+                  object[:] data,
+                  object[:] new_rows,
+                  object[:] new_data,
+                  cnp.ndarray[cnp.intp_t, ndim=2] i_idx,
+                  cnp.ndarray[cnp.intp_t, ndim=2] j_idx):
+    cdef cnp.intp_t x, y, i, j
+    cdef object value
+
+    for x in range(i_idx.shape[0]):
+        for y in range(i_idx.shape[1]):
+            i = i_idx[x,y]
+            j = j_idx[x,y]
+
+            value = lil_get1(M, N, rows, data, i, j)
+
+            if value is 0:
+                # Object identity as shortcut
+                continue
+
+            lil_insert_nocheck(i_idx.shape[1],
+                               new_rows[x], new_data[x],
+                               y, value)
+
+
+cdef bisect_left(list a, cnp.intp_t x):
+    cdef cnp.intp_t hi = len(a)
+    cdef cnp.intp_t lo = 0
+    cdef cnp.intp_t mid_v
+    cdef cpython.PyObject* v
+
+    while lo < hi:
+        mid = (lo + hi)//2
+        v = cpython.list.PyList_GET_ITEM(a, mid)
+        mid_v = cpython.int.PyInt_AsLong(<object>v)
+        if mid_v < x:
+            lo = mid + 1
+        else:
+            hi = mid
+    return lo

--- a/scipy/sparse/_csparsetools.pyx
+++ b/scipy/sparse/_csparsetools.pyx
@@ -31,6 +31,19 @@ ctypedef fused value_t:
     double complex
 
 
+def prepare_index_arrays(cnp.ndarray i, cnp.ndarray j, cnp.ndarray x=None):
+    if not i.flags.writeable or not i.dtype in (np.int32, np.int64):
+        i = i.astype(np.intp)
+    if not j.flags.writeable or not j.dtype in (np.int32, np.int64):
+        j = j.astype(np.intp)
+    if x is not None:
+        if not x.flags.writeable:
+            x = x.copy()
+        return i, j, x
+    else:
+        return i, j
+
+
 cpdef lil_get1(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas, cnp.npy_intp i, cnp.npy_intp j):
     cdef list row, data
 
@@ -105,9 +118,10 @@ def lil_fancy_get(cnp.npy_intp M, cnp.npy_intp N,
                   object[:] data,
                   object[:] new_rows,
                   object[:] new_data,
-                  cnp.ndarray[cnp.npy_intp, ndim=2] i_idx,
-                  cnp.ndarray[cnp.npy_intp, ndim=2] j_idx):
-    cdef cnp.npy_intp x, y, i, j
+                  idx_t[:,:] i_idx,
+                  idx_t[:,:] j_idx):
+    cdef cnp.npy_intp x, y
+    cdef idx_t i, j
     cdef object value
 
     for x in range(i_idx.shape[0]):
@@ -128,11 +142,12 @@ def lil_fancy_get(cnp.npy_intp M, cnp.npy_intp N,
 def lil_fancy_set(cnp.npy_intp M, cnp.npy_intp N,
                   object[:] rows,
                   object[:] data,
-                  cnp.ndarray[cnp.npy_intp, ndim=2] i_idx,
-                  cnp.ndarray[cnp.npy_intp, ndim=2] j_idx,
+                  idx_t[:,:] i_idx,
+                  idx_t[:,:] j_idx,
                   value_t[:,:] values):
 
-    cdef cnp.npy_intp x, y, i, j
+    cdef cnp.npy_intp x, y
+    cdef idx_t i, j
 
     for x in range(i_idx.shape[0]):
         for y in range(i_idx.shape[1]):

--- a/scipy/sparse/_csparsetools.pyx
+++ b/scipy/sparse/_csparsetools.pyx
@@ -1,5 +1,5 @@
 """
-Fast snippets for sparse matrices
+Fast snippets for sparse matrices.
 """
 
 cimport cython
@@ -32,6 +32,24 @@ ctypedef fused value_t:
 
 
 def prepare_index_arrays(cnp.ndarray i, cnp.ndarray j, cnp.ndarray x=None):
+    """
+    Convert index and data arrays to form suitable for passing to the
+    Cython fancy getset routines.
+
+    Parameters
+    ----------
+    i, j
+        Index arrays
+    x : optional
+        Data arrays
+
+    Returns
+    -------
+    i, j, x
+        Re-formatted arrays (x is omitted, if input was None)
+
+    """
+
     if not i.flags.writeable or not i.dtype in (np.int32, np.int64):
         i = i.astype(np.intp)
     if not j.flags.writeable or not j.dtype in (np.int32, np.int64):
@@ -44,7 +62,26 @@ def prepare_index_arrays(cnp.ndarray i, cnp.ndarray j, cnp.ndarray x=None):
         return i, j
 
 
-cpdef lil_get1(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas, cnp.npy_intp i, cnp.npy_intp j):
+cpdef lil_get1(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas,
+               cnp.npy_intp i, cnp.npy_intp j):
+    """
+    Get a single item from LIL matrix.
+
+    Doesn't do output type conversion. Checks for bounds errors.
+
+    Parameters
+    ----------
+    M, N, rows, datas
+        Shape and data arrays for a LIL matrix
+    i, j : int
+        Indices at which to get
+
+    Returns
+    -------
+    x
+        Value at indices.
+
+    """
     cdef list row, data
 
     if i < 0:
@@ -69,6 +106,21 @@ cpdef lil_get1(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas, 
 
 cpdef lil_insert(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas,
                  cnp.npy_intp i, cnp.npy_intp j, value_t x):
+    """
+    Insert a single item to LIL matrix.
+
+    Checks for bounds errors and deletes item if x is zero.
+
+    Parameters
+    ----------
+    M, N, rows, datas
+        Shape and data arrays for a LIL matrix
+    i, j : int
+        Indices at which to get
+    x
+        Value to insert.
+
+    """
     cdef list row, data
     cdef int is_zero
 
@@ -91,28 +143,6 @@ cpdef lil_insert(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas
         lil_insertat_nocheck(rows[i], datas[i], j, x)
 
 
-cdef lil_insertat_nocheck(list row, list data, cnp.npy_intp j, object x):
-    cdef cnp.npy_intp pos
-
-    pos = bisect_left(row, j)
-    if pos == len(row):
-        row.append(j)
-        data.append(x)
-    elif row[pos] != j:
-        row.insert(pos, j)
-        data.insert(pos, x)
-    else:
-        data[pos] = x
-
-
-cdef lil_deleteat_nocheck(list row, list data, cnp.npy_intp j):
-    cdef cnp.npy_intp pos
-    pos = bisect_left(row, j)
-    if pos < len(row) and row[pos] == j:
-        del row[pos]
-        del data[pos]
-
-
 def lil_fancy_get(cnp.npy_intp M, cnp.npy_intp N,
                   object[:] rows,
                   object[:] data,
@@ -120,6 +150,21 @@ def lil_fancy_get(cnp.npy_intp M, cnp.npy_intp N,
                   object[:] new_data,
                   idx_t[:,:] i_idx,
                   idx_t[:,:] j_idx):
+    """
+    Get multiple items at given indices in LIL matrix and store to
+    another LIL.
+
+    Parameters
+    ----------
+    M, N, rows, data
+        LIL matrix data
+    new_rows, new_idx
+        Data for LIL matrix to insert to.
+        Must be preallocated to shape `i_idx.shape`!
+    i_idx, j_idx
+        Indices of elements to insert to the new LIL matrix.
+
+    """
     cdef cnp.npy_intp x, y
     cdef idx_t i, j
     cdef object value
@@ -145,7 +190,21 @@ def lil_fancy_set(cnp.npy_intp M, cnp.npy_intp N,
                   idx_t[:,:] i_idx,
                   idx_t[:,:] j_idx,
                   value_t[:,:] values):
+    """
+    Set multiple items to a LIL matrix.
 
+    Checks for zero elements and deletes them.
+
+    Parameters
+    ----------
+    M, N, rows, data
+        LIL matrix data
+    i_idx, j_idx
+        Indices of elements to insert to the new LIL matrix.
+    values
+        Values of items to set.
+
+    """
     cdef cnp.npy_intp x, y
     cdef idx_t i, j
 
@@ -156,10 +215,79 @@ def lil_fancy_set(cnp.npy_intp M, cnp.npy_intp N,
             lil_insert[value_t](M, N, rows, data, i, j, values[x, y])
 
 
+cdef lil_insertat_nocheck(list row, list data, cnp.npy_intp j, object x):
+    """
+    Insert a single item to LIL matrix.
+
+    Doesn't check for bounds errors. Doesn't check for zero x.
+
+    Parameters
+    ----------
+    M, N, rows, datas
+        Shape and data arrays for a LIL matrix
+    i, j : int
+        Indices at which to get
+    x
+        Value to insert.
+
+    """
+    cdef cnp.npy_intp pos
+
+    pos = bisect_left(row, j)
+    if pos == len(row):
+        row.append(j)
+        data.append(x)
+    elif row[pos] != j:
+        row.insert(pos, j)
+        data.insert(pos, x)
+    else:
+        data[pos] = x
+
+
+cdef lil_deleteat_nocheck(list row, list data, cnp.npy_intp j):
+    """
+    Delete a single item from a row in LIL matrix.
+
+    Doesn't check for bounds errors.
+
+    Parameters
+    ----------
+    row, data
+        Row data for LIL matrix.
+    j : int
+        Column index to delete at
+
+    """
+    cdef cnp.npy_intp pos
+    pos = bisect_left(row, j)
+    if pos < len(row) and row[pos] == j:
+        del row[pos]
+        del data[pos]
+
+
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef bisect_left(list a, cnp.npy_intp x):
+    """
+    Bisection search in a sorted list.
+
+    List is assumed to contain objects castable to integers.
+
+    Parameters
+    ----------
+    a
+        List to search in
+    x
+        Value to search for
+
+    Returns
+    -------
+    j : int
+        Index at value (if present), or at the point to which
+        it can be inserted maintaining order.
+
+    """
     cdef cnp.npy_intp hi = len(a)
     cdef cnp.npy_intp lo = 0
     cdef cnp.npy_intp mid, v

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -248,11 +248,7 @@ class lil_matrix(spmatrix, IndexMixin):
 
         new = lil_matrix(i.shape, dtype=self.dtype)
 
-        if i.dtype != np.intp:
-            i = i.astype(np.intp)
-        if j.dtype != np.intp:
-            j = j.astype(np.intp)
-
+        i, j = _csparsetools.prepare_index_arrays(i, j)
         _csparsetools.lil_fancy_get(self.shape[0], self.shape[1],
                                     self.rows, self.data,
                                     new.rows, new.data,
@@ -284,13 +280,7 @@ class lil_matrix(spmatrix, IndexMixin):
             raise ValueError("shape mismatch in assignment")
 
         # Set values
-        if i.dtype != np.intp:
-            i = i.astype(np.intp)
-        if j.dtype != np.intp:
-            j = j.astype(np.intp)
-        if x.dtype != self.dtype:
-            x = x.astype(self.dtype)
-
+        i, j, x = _csparsetools.prepare_index_arrays(i, j, x)
         _csparsetools.lil_fancy_set(self.shape[0], self.shape[1],
                                     self.rows, self.data,
                                     i, j, x)

--- a/scipy/sparse/setup.py
+++ b/scipy/sparse/setup.py
@@ -15,6 +15,9 @@ def configuration(parent_package='',top_path=None):
     config.add_subpackage('sparsetools')
     config.add_subpackage('csgraph')
 
+    config.add_extension('_csparsetools',
+                         sources=['_csparsetools.c'])
+
     return config
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR gains 5...50x speedups in LIL matrix setitem/getitem by writing the fancy indexing code more carefully. I also add fast paths for scalar indexing (~5x faster).

The fancy getitem speed is now not far from CSR/CSC. Fancy setitem is also not far from CSR/CSC (and for changing sparsity pattern, LIL can now be much faster than CSR/CSC).

Benchmarks: https://gist.githubusercontent.com/pv/9102868/raw/a256bfe058b44131f8acba0f41ab90eafacbe127/gistfile1.txt
