### PR TITLE
Fix "imresize does not work with size = int"

### DIFF
--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -411,7 +411,8 @@ def imresize(arr, size, interp='bilinear', mode=None):
     im = toimage(arr, mode=mode)
     ts = type(size)
     if issubdtype(ts,int):
-        size = size / 100.0
+        percent = size / 100.0
+        size = (array(im.size)*percent).astype(int)
     elif issubdtype(type(size),float):
         size = (array(im.size)*size).astype(int)
     else:

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -40,6 +40,21 @@ class TestPILUtil(TestCase):
         im2 = misc.imresize(im, (30,60), interp='nearest')
         assert_equal(im2.shape, (30,60))
 
+    def test_imresize4(self):
+        im = np.array([[1,2],
+                       [3,4]])
+        res = np.array([[ 1. ,  1. ,  1.5,  2. ],
+                        [ 1. ,  1. ,  1.5,  2. ],
+                        [ 2. ,  2. ,  2.5,  3. ],
+                        [ 3. ,  3. ,  3.5,  4. ]], dtype=np.float32)
+        # Check that resizing by target size, float and int are the same
+        im2 = misc.imresize(im, (4,4), mode='F')  # output size
+        im3 = misc.imresize(im, 2., mode='F')  # fraction
+        im4 = misc.imresize(im, 200, mode='F')  # percentage
+        assert_equal(im2, res)
+        assert_equal(im3, res)
+        assert_equal(im4, res)
+
     def test_bytescale(self):
         x = np.array([0,1,2], np.uint8)
         y = np.array([0,1,2])


### PR DESCRIPTION
Solution from http://mail.scipy.org/pipermail/scipy-dev/2010-July/015132.html

Also adds test_imresize4.
