### PR TITLE
MAINT: optimize: reorganize the list of optimization routines

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -8,23 +8,32 @@ Optimization and root finding (:mod:`scipy.optimize`)
 Optimization
 ============
 
-General-purpose
----------------
+Local Optimization
+------------------
 
 .. autosummary::
    :toctree: generated/
 
    minimize - Unified interface for minimizers of multivariate functions
+   minimize_scalar - Unified interface for minimizers of univariate functions
    OptimizeResult - The optimization result returned by some optimizers
+
+The specific optimization method interfaces below in this subsection are
+not recommended for use in new scripts; all of these methods are accessible
+via a newer, more consistent interface provided by the functions above.
+
+General-purpose multivariate methods:
+
+.. autosummary::
+   :toctree: generated/
+
    fmin - Nelder-Mead Simplex algorithm
    fmin_powell - Powell's (modified) level set method
    fmin_cg - Non-linear (Polak-Ribiere) conjugate gradient algorithm
    fmin_bfgs - Quasi-Newton method (Broydon-Fletcher-Goldfarb-Shanno)
    fmin_ncg - Line-search Newton Conjugate Gradient
-   leastsq - Minimize the sum of squares of M equations in N unknowns
 
-Constrained (multivariate)
---------------------------
+Constrained multivariate methods:
 
 .. autosummary::
    :toctree: generated/
@@ -33,10 +42,27 @@ Constrained (multivariate)
    fmin_tnc - Truncated Newton code
    fmin_cobyla - Constrained optimization by linear approximation
    fmin_slsqp - Minimization using sequential least-squares programming
+
+Univariate (scalar) minimization methods:
+
+.. autosummary::
+   :toctree: generated/
+
+   fminbound - Bounded minimization of a scalar function
+   brent - 1-D function minimization using Brent method
+   golden - 1-D function minimization using Golden Section method
+
+Equation (Local) Minimizers
+---------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   leastsq - Minimize the sum of squares of M equations in N unknowns
    nnls - Linear least-squares problem with non-negativity constraint
 
-Global
-------
+Global Optimization
+-------------------
 
 .. autosummary::
    :toctree: generated/
@@ -44,18 +70,6 @@ Global
    anneal - Simulated annealing
    basinhopping - Basinhopping stochastic optimizer
    brute - Brute force searching optimizer
-
-Scalar function minimizers
---------------------------
-
-.. autosummary::
-   :toctree: generated/
-
-   minimize_scalar - Unified interface for minimizers of univariate functions
-   fminbound - Bounded minimization of a scalar function
-   brent - 1-D function minimization using Brent method
-   golden - 1-D function minimization using Golden Section method
-   bracket - Bracket a minimum, given two starting points
 
 Rosenbrock function
 -------------------
@@ -136,6 +150,7 @@ Utility Functions
    :toctree: generated/
 
    approx_fprime - Approximate the gradient of a scalar function
+   bracket - Bracket a minimum, given two starting points
    check_grad - Check the supplied derivative using finite differences
    line_search - Return a step that satisfies the strong Wolfe conditions
 


### PR DESCRIPTION
When new users come to scipy.optimize, they may be confused by the slew of minimizer routines offered; I was when I did recently, and I think it's visible on the mailing list as well.

This attempts to reorganize the list of minimizers to better promote the new minimize(), minimize_scalar() interfaces (the fmin\* interfaces are listed only after a note not recommending to use them) and split the functions primarily as local vs. global minimizers.

(Possibly, one could just say "deprecated" instead of "not recommended to use in new code", but I'm not brave enough to do that myself, or sure that's 100% the plan.)

(I'm also not sure whether not to just put Equation (Local) Minimizers in the Fitting section. I don't care personally, I think both approaches work.)
