### PR TITLE
BUG: sparse/dsolve: fix dense matrix fortran order bugs in superlu wrappers

### DIFF
--- a/scipy/sparse/linalg/dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/dsolve/_superlumodule.c
@@ -126,7 +126,7 @@ static PyObject *Py_gssv(PyObject * self, PyObject * args,
     /* Create Space for output */
     Py_X = (PyArrayObject*)PyArray_FROMANY(
         Py_B, type, 1, 2,
-        NPY_ARRAY_F_CONTIGUOUS | NPY_ARRAY_ENSURECOPY);
+        NPY_F_CONTIGUOUS | NPY_ENSURECOPY);
     if (Py_X == NULL)
 	return NULL;
 

--- a/scipy/sparse/linalg/dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/dsolve/_superlumodule.c
@@ -74,7 +74,8 @@ void XStatFree(SuperLUStat_t * stat)
 static PyObject *Py_gssv(PyObject * self, PyObject * args,
 			 PyObject * kwdict)
 {
-    PyObject *Py_B = NULL, *Py_X = NULL;
+    PyObject *Py_B = NULL;
+    PyArrayObject *Py_X = NULL;
     PyArrayObject *nzvals = NULL;
     PyArrayObject *colind = NULL, *rowptr = NULL;
     int N, nnz;
@@ -91,9 +92,9 @@ static PyObject *Py_gssv(PyObject * self, PyObject * args,
     int type;
     int ssv_finished = 0;
 
-    static char *kwlist[] =
-	{ "N", "nnz", "nzvals", "colind", "rowptr", "B", "csc",
-	"options", NULL
+    static char *kwlist[] = {
+        "N", "nnz", "nzvals", "colind", "rowptr", "B", "csc",
+        "options", NULL
     };
 
     /* Get input arguments */
@@ -123,9 +124,18 @@ static PyObject *Py_gssv(PyObject * self, PyObject * args,
     }
 
     /* Create Space for output */
-    Py_X = PyArray_CopyFromObject(Py_B, type, 1, 2);
+    Py_X = (PyArrayObject*)PyArray_FROMANY(
+        Py_B, type, 1, 2,
+        NPY_ARRAY_F_CONTIGUOUS | NPY_ARRAY_ENSURECOPY);
     if (Py_X == NULL)
 	return NULL;
+
+    if (Py_X->dimensions[0] != N) {
+        PyErr_SetString(PyExc_ValueError,
+                        "b array has invalid shape");
+        Py_DECREF(Py_X);
+        return NULL;
+    }
 
     if (csc) {
 	if (NCFormat_from_spMatrix(&A, N, N, nnz, nzvals, colind, rowptr,

--- a/scipy/sparse/linalg/dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/dsolve/_superluobject.c
@@ -345,14 +345,24 @@ int NRFormat_from_spMatrix(SuperMatrix * A, int m, int n, int nnz,
 			   PyArrayObject * nzvals, PyArrayObject * colind,
 			   PyArrayObject * rowptr, int typenum)
 {
-    int err = 0;
+    int ok = 0;
 
-    err = (nzvals->descr->type_num != typenum);
-    err += (nzvals->nd != 1);
-    err += (nnz > nzvals->dimensions[0]);
-    if (err) {
-	PyErr_SetString(PyExc_TypeError,
-			"Fourth argument must be a 1-D array at least as big as third argument.");
+    ok = (PyArray_EquivTypenums(PyArray_DESCR(nzvals)->type_num, typenum) &&
+          PyArray_EquivTypenums(PyArray_DESCR(colind)->type_num, NPY_INT) &&
+          PyArray_EquivTypenums(PyArray_DESCR(rowptr)->type_num, NPY_INT) &&
+          PyArray_NDIM(nzvals) == 1 &&
+          PyArray_NDIM(colind) == 1 &&
+          PyArray_NDIM(rowptr) == 1 &&
+          PyArray_ISCARRAY(nzvals) &&
+          PyArray_ISCARRAY(colind) &&
+          PyArray_ISCARRAY(rowptr) &&
+          nnz <= PyArray_DIM(nzvals, 0) &&
+          nnz <= PyArray_DIM(colind, 0) &&
+          m+1 <= PyArray_DIM(rowptr, 0));
+    if (!ok) {
+	PyErr_SetString(PyExc_ValueError,
+			"sparse matrix arrays must be 1-D C-contigous and of proper "
+                        "sizes and types");
 	return -1;
     }
 
@@ -378,14 +388,24 @@ int NCFormat_from_spMatrix(SuperMatrix * A, int m, int n, int nnz,
 			   PyArrayObject * nzvals, PyArrayObject * rowind,
 			   PyArrayObject * colptr, int typenum)
 {
-    int err = 0;
+    int ok = 0;
 
-    err = (nzvals->descr->type_num != typenum);
-    err += (nzvals->nd != 1);
-    err += (nnz > nzvals->dimensions[0]);
-    if (err) {
-	PyErr_SetString(PyExc_TypeError,
-			"Fifth argument must be a 1-D array at least as big as fourth argument.");
+    ok = (PyArray_EquivTypenums(PyArray_DESCR(nzvals)->type_num, typenum) &&
+          PyArray_EquivTypenums(PyArray_DESCR(rowind)->type_num, NPY_INT) &&
+          PyArray_EquivTypenums(PyArray_DESCR(colptr)->type_num, NPY_INT) &&
+          PyArray_NDIM(nzvals) == 1 &&
+          PyArray_NDIM(rowind) == 1 &&
+          PyArray_NDIM(colptr) == 1 &&
+          PyArray_ISCARRAY(nzvals) &&
+          PyArray_ISCARRAY(rowind) &&
+          PyArray_ISCARRAY(colptr) &&
+          nnz <= PyArray_DIM(nzvals, 0) &&
+          nnz <= PyArray_DIM(rowind, 0) &&
+          n+1 <= PyArray_DIM(colptr, 0));
+    if (!ok) {
+	PyErr_SetString(PyExc_ValueError,
+			"sparse matrix arrays must be 1-D C-contigous and of proper "
+                        "sizes and types");
 	return -1;
     }
 
@@ -812,44 +832,47 @@ int set_superlu_options_from_dict(superlu_options_t * options,
     _relax = sp_ienv(2);
 
     if (option_dict == NULL) {
-	return 0;
+        /* Proceed with default options */
+        ret = 1;
     }
-
-    args = PyTuple_New(0);
-    ret = PyArg_ParseTupleAndKeywords(args, option_dict,
-				      "|O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&",
-				      kwlist, fact_cvt, &options->Fact,
-				      yes_no_cvt, &options->Equil,
-				      colperm_cvt, &options->ColPerm,
-				      trans_cvt, &options->Trans,
-				      iterrefine_cvt, &options->IterRefine,
-				      double_cvt,
-				      &options->DiagPivotThresh,
-				      yes_no_cvt, &options->PivotGrowth,
-				      yes_no_cvt,
-				      &options->ConditionNumber,
-				      rowperm_cvt, &options->RowPerm,
-				      yes_no_cvt, &options->SymmetricMode,
-				      yes_no_cvt, &options->PrintStat,
-				      yes_no_cvt,
-				      &options->ReplaceTinyPivot,
-				      yes_no_cvt,
-				      &options->SolveInitialized,
-				      yes_no_cvt,
-				      &options->RefineInitialized,
-				      norm_cvt, &options->ILU_Norm,
-				      milu_cvt, &options->ILU_MILU,
-				      double_cvt, &options->ILU_DropTol,
-				      double_cvt, &options->ILU_FillTol,
-				      double_cvt, &options->ILU_FillFactor,
-				      droprule_cvt, &options->ILU_DropRule,
-				      int_cvt, &_panel_size, int_cvt,
-				      &_relax);
-    Py_DECREF(args);
+    else {
+        args = PyTuple_New(0);
+        ret = PyArg_ParseTupleAndKeywords(args, option_dict,
+                                          "|O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&",
+                                          kwlist, fact_cvt, &options->Fact,
+                                          yes_no_cvt, &options->Equil,
+                                          colperm_cvt, &options->ColPerm,
+                                          trans_cvt, &options->Trans,
+                                          iterrefine_cvt, &options->IterRefine,
+                                          double_cvt,
+                                          &options->DiagPivotThresh,
+                                          yes_no_cvt, &options->PivotGrowth,
+                                          yes_no_cvt,
+                                          &options->ConditionNumber,
+                                          rowperm_cvt, &options->RowPerm,
+                                          yes_no_cvt, &options->SymmetricMode,
+                                          yes_no_cvt, &options->PrintStat,
+                                          yes_no_cvt,
+                                          &options->ReplaceTinyPivot,
+                                          yes_no_cvt,
+                                          &options->SolveInitialized,
+                                          yes_no_cvt,
+                                          &options->RefineInitialized,
+                                          norm_cvt, &options->ILU_Norm,
+                                          milu_cvt, &options->ILU_MILU,
+                                          double_cvt, &options->ILU_DropTol,
+                                          double_cvt, &options->ILU_FillTol,
+                                          double_cvt, &options->ILU_FillFactor,
+                                          droprule_cvt, &options->ILU_DropRule,
+                                          int_cvt, &_panel_size, int_cvt,
+                                          &_relax);
+        Py_DECREF(args);
+    }
 
     if (panel_size != NULL) {
 	*panel_size = _panel_size;
     }
+
     if (relax != NULL) {
 	*relax = _relax;
     }

--- a/scipy/sparse/linalg/dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/dsolve/_superluobject.c
@@ -82,7 +82,7 @@ static PyObject *SciPyLU_solve(SciPyLUObject * self, PyObject * args,
 
     x = (PyArrayObject*)PyArray_FROMANY(
         (PyObject*)b, self->type, 1, 2,
-        NPY_ARRAY_F_CONTIGUOUS | NPY_ARRAY_ENSURECOPY);
+        NPY_F_CONTIGUOUS | NPY_ENSURECOPY);
     if (x == NULL) {
         goto fail;
     }
@@ -306,7 +306,7 @@ int DenseSuper_from_Numeric(SuperMatrix *X, PyObject *PyX)
         return -1;
     }
 
-    if (!(aX->flags & NPY_ARRAY_F_CONTIGUOUS)) {
+    if (!(aX->flags & NPY_F_CONTIGUOUS)) {
         PyErr_SetString(PyExc_ValueError, "array is not fortran contiguous");
         return -1;
     }

--- a/scipy/sparse/linalg/dsolve/_superluobject.h
+++ b/scipy/sparse/linalg/dsolve/_superluobject.h
@@ -28,7 +28,8 @@
  * SuperLUObject definition
  */
 typedef struct {
-    PyObject_HEAD npy_intp m, n;
+    PyObject_HEAD
+    npy_intp m, n;
     SuperMatrix L;
     SuperMatrix U;
     int *perm_r;

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -132,14 +132,13 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             b = b.toarray()
             b_is_sparse = False
 
-
-        if isspmatrix_csc(A):
-            flag = 1  # CSC format
-        else:
-            flag = 0  # CSR format
-        options = dict(ColPerm=permc_spec)
-
         if not b_is_sparse:
+            if isspmatrix_csc(A):
+                flag = 1  # CSC format
+            else:
+                flag = 0  # CSR format
+
+            options = dict(ColPerm=permc_spec)
             x, info = _superlu.gssv(N, A.nnz, A.data, A.indices, A.indptr,
                                     b, flag, options=options)
             if info != 0:

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -12,7 +12,7 @@ import scipy.linalg
 from scipy.linalg import norm, inv
 from scipy.sparse import spdiags, SparseEfficiencyWarning, csc_matrix, csr_matrix, \
      isspmatrix, dok_matrix, lil_matrix, bsr_matrix
-from scipy.sparse.linalg.dsolve import spsolve, use_solver, splu, spilu
+from scipy.sparse.linalg.dsolve import spsolve, use_solver, splu, spilu, MatrixRankWarning
 
 warnings.simplefilter('ignore',SparseEfficiencyWarning)
 
@@ -28,9 +28,13 @@ def toarray(a):
 
 class TestLinsolve(TestCase):
     def test_singular(self):
-        A = csc_matrix((5,5), dtype='d')
-        b = array([1, 2, 3, 4, 5],dtype='d')
-        x = spsolve(A, b, use_umfpack=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=MatrixRankWarning)
+
+            A = csc_matrix((5,5), dtype='d')
+            b = array([1, 2, 3, 4, 5],dtype='d')
+            x = spsolve(A, b, use_umfpack=False)
+            assert_(not np.isfinite(x).any())
 
     def test_twodiags(self):
         A = spdiags([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]], [0, 1], 5, 5)
@@ -176,24 +180,71 @@ class TestSplu(object):
         self.A = spdiags((d, 2*d, d[::-1]), (-3, 0, 5), n, n)
         random.seed(1234)
 
+    def _smoketest(self, spxlu, check, dtype):
+        if np.issubdtype(dtype, np.complexfloating):
+            A = self.A + 1j*self.A.T
+        else:
+            A = self.A
+
+        A = A.astype(dtype)
+        lu = spxlu(A)
+
+        # Input shapes
+        for k in [None, 1, 2, self.n, self.n+2]:
+            msg = "k=%r" % (k,)
+
+            if k is None:
+                b = random.rand(self.n)
+            else:
+                b = random.rand(self.n, k)
+
+            if np.issubdtype(dtype, np.complexfloating):
+                b = b + 1j*random.rand(*b.shape)
+            b = b.astype(dtype)
+
+            x = lu.solve(b)
+            check(A, b, x, msg)
+
+            x = lu.solve(b, 'T')
+            check(A.T, b, x, msg)
+
+            x = lu.solve(b, 'H')
+            check(A.T.conj(), b, x, msg)
+
     def test_splu_smoketest(self):
+        # Check that splu works at all
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=SparseEfficiencyWarning)
-            # Check that splu works at all
-            x = random.rand(self.n)
-            lu = splu(self.A)
-            r = self.A*lu.solve(x)
-            assert_(abs(x - r).max() < 1e-13)
+
+            def check(A, b, x, msg=""):
+                eps = np.finfo(A.dtype).eps
+                r = A * x
+                assert_(abs(r - b).max() < 1e3*eps, msg)
+
+            self._smoketest(splu, check, np.float32)
+            self._smoketest(splu, check, np.float64)
+            self._smoketest(splu, check, np.complex64)
+            self._smoketest(splu, check, np.complex128)
 
     def test_spilu_smoketest(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=SparseEfficiencyWarning)
-            # Check that spilu works at all
-            x = random.rand(self.n)
-            lu = spilu(self.A, drop_tol=1e-2, fill_factor=5)
-            r = self.A*lu.solve(x)
-            assert_(abs(x - r).max() < 1e-2)
-            assert_(abs(x - r).max() > 1e-5)
+
+            errors = []
+
+            def check(A, b, x, msg=""):
+                r = A * x
+                err = abs(r - b).max()
+                assert_(err < 1e-2, msg)
+                if b.dtype in (np.float64, np.complex128):
+                    errors.append(err)
+
+            self._smoketest(spilu, check, np.float32)
+            self._smoketest(spilu, check, np.float64)
+            self._smoketest(spilu, check, np.complex64)
+            self._smoketest(spilu, check, np.complex128)
+
+            assert_(max(errors) > 1e-5)
 
     def test_splu_nnz0(self):
         A = csc_matrix((5,5), dtype='d')
@@ -255,7 +306,6 @@ class TestSplu(object):
         lu = splu(a_)
 
         # And now test that we don't have a refcount bug
-        import gc
         import sys
         rc = sys.getrefcount(lu)
         for attr in ('perm_r', 'perm_c'):
@@ -263,6 +313,24 @@ class TestSplu(object):
             assert_equal(sys.getrefcount(lu), rc + 1)
             del perm
             assert_equal(sys.getrefcount(lu), rc)
+
+    def test_bad_inputs(self):
+        A = self.A.tocsc()
+
+        assert_raises(ValueError, splu, A[:,:4])
+        assert_raises(ValueError, spilu, A[:,:4])
+
+        for lu in [splu(A), spilu(A)]:
+            b = random.rand(42)
+            B = random.rand(42, 3)
+            BB = random.rand(self.n, 3, 9)
+            assert_raises(ValueError, lu.solve, b)
+            assert_raises(ValueError, lu.solve, B)
+            assert_raises(ValueError, lu.solve, BB)
+            assert_raises(TypeError, lu.solve,
+                          b.astype(np.complex64))
+            assert_raises(TypeError, lu.solve,
+                          b.astype(np.complex128))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The splu() SuperLU wrapper has been broken since time immemorial (< 0.7.2)
for matrix inputs, because of confusion in the C code between Fortran and C
order inputs.

This is fairly simple to fix, so let's fix it. This also allows passing in dense matrices
directly to SuperLU, without needing to loop on the Python side.

Fixes gh-3363
