### PR TITLE
ENH minimize, minimize_scalar: Add support for user-provided methods

### DIFF
--- a/doc/release/0.14.0-notes.rst
+++ b/doc/release/0.14.0-notes.rst
@@ -58,6 +58,10 @@ has been added.
 `scipy.optimize.curve_fit` now has more controllable error estimation via the
 ``absolute_sigma`` keyword.
 
+Support for passing custom minimization methods to ``optimize.minimize()``
+and ``optimize.minimize_scalar()`` has been added, currently useful especially
+for combining ``optimize.basinhopping()`` with custom local optimizer routines.
+
 
 ``scipy.stats`` improvements
 ----------------------------
@@ -184,6 +188,7 @@ Authors
 * Marc Abramowitz +
 * andbo +
 * Vincent Arel-Bundock +
+* Petr Baudis +
 * Max Bolingbroke
 * François Boulogne
 * Matthew Brett

--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -520,6 +520,91 @@ For example, to find the minimum of :math:`J_{1}\left( x \right)` near
     5.33144184241
 
 
+Custom minimizers
+-----------------
+
+Sometimes, it may be useful to use a custom method as a (multivariate
+or univariate) minimizer, for example when using some library wrappers
+of :func:`minimize` (e.g. :func:`basinhopping`).
+
+We can achieve that by, instead of passing a method name, we pass
+a callable (either a function or an object implementing a `__call__`
+method) as the `method` parameter.
+
+Let us consider an (admittedly rather virtual) need to use a trivial
+custom multivariate minimization method that will just search the
+neighborhood in each dimension independently with a fixed step size::
+
+    >>> def custmin(fun, x0, args=(), maxfev=None, stepsize=0.1,
+    ...         maxiter=100, callback=None, **options):
+    ...     bestx = x0
+    ...     besty = fun(x0)
+    ...     funcalls = 1
+    ...     niter = 0
+    ...     improved = True
+    ...     stop = False
+    ...     
+    ...     while improved and not stop and niter < maxiter:
+    ...         improved = False
+    ...         niter += 1
+    ...         for dim in range(np.size(x0)):
+    ...             for s in [bestx[dim] - stepsize, bestx[dim] + stepsize]:
+    ...                 testx = np.copy(bestx)
+    ...                 testx[dim] = s
+    ...                 testy = fun(testx, *args)
+    ...                 funcalls += 1
+    ...                 if testy < besty:
+    ...                     besty = testy
+    ...                     bestx = testx
+    ...                     improved = True
+    ...             if callback is not None:
+    ...                 callback(bestx)
+    ...             if maxfev is not None and funcalls >= maxfev:
+    ...                 stop = True
+    ...                 break
+    ...     
+    ...     return OptimizeResult(fun=besty, x=bestx, nit=niter,
+    ...                           nfev=funcalls, success=(niter > 1))
+    >>> x0 = [1.35, 0.9, 0.8, 1.1, 1.2]
+    >>> res = minimize(rosen, x0, method=custmin, options=dict(stepsize=0.05))
+    >>> res.x
+    [ 1.  1.  1.  1.  1.]
+
+This will work just as well in case of univariate optimization::
+
+    >>> def custmin(fun, bracket, args=(), maxfev=None, stepsize=0.1,
+    ...         maxiter=100, callback=None, **options):
+    ...     bestx = (bracket[1] + bracket[0]) / 2.0
+    ...     besty = fun(bestx)
+    ...     funcalls = 1
+    ...     niter = 0
+    ...     improved = True
+    ...     stop = False
+    ...     
+    ...     while improved and not stop and niter < maxiter:
+    ...         improved = False
+    ...         niter += 1
+    ...         for testx in [bestx - stepsize, bestx + stepsize]:
+    ...             testy = fun(testx, *args)
+    ...             funcalls += 1
+    ...             if testy < besty:
+    ...                 besty = testy
+    ...                 bestx = testx
+    ...                 improved = True
+    ...         if callback is not None:
+    ...             callback(bestx)
+    ...         if maxfev is not None and funcalls >= maxfev:
+    ...             stop = True
+    ...             break
+    ...     
+    ...     return OptimizeResult(fun=besty, x=bestx, nit=niter,
+    ...                           nfev=funcalls, success=(niter > 1))
+    >>> res = minimize_scalar(f, bracket=(-3.5, 0), method=custmin,
+    ...                       options=dict(stepsize = 0.05))
+    >>> res.x
+    -2.0
+
+
 Root finding
 ------------
 

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -51,7 +51,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     args : tuple, optional
         Extra arguments passed to the objective function and its
         derivatives (Jacobian, Hessian).
-    method : str, optional
+    method : str or callable, optional
         Type of solver.  Should be one of
 
             - 'Nelder-Mead'
@@ -66,6 +66,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
             - 'SLSQP'
             - 'dogleg'
             - 'trust-ncg'
+            - custom - a callable object (added in version 0.14.0)
 
         If not given, chosen to be one of ``BFGS``, ``L-BFGS-B``, ``SLSQP``,
         depending if the problem has constraints or bounds.
@@ -207,6 +208,27 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     wrapper handles infinite values in bounds by converting them into large
     floating values.
 
+    **Custom minimizers**
+
+    It may be useful to pass a custom minimization method, for example
+    when using a frontend to this method such as `scipy.optimize.basinhopping`
+    or a different library.  You can simply pass a callable as the ``method``
+    parameter.
+
+    The callable is called as ``method(fun, x0, args, **kwargs, **options)``
+    where ``kwargs`` corresponds to any other parameters passed to `minimize`
+    (such as `callback`, `hess`, etc.), except the `options` dict, which has
+    its contents also passed as `method` parameters pair by pair.  Also, if
+    `jac` has been passed as a bool type, `jac` and `fun` are mangled so that
+    `fun` returns just the function values and `jac` is converted to a function
+    returning the Jacobian.  The method shall return an ``OptimizeResult``
+    object.
+
+    The provided `method` callable must be able to accept (and possibly ignore)
+    arbitrary parameters; the set of parameters accepted by `minimize` may
+    expand in future versions and then these parameters will be passed to
+    the method.  You can find an example in the scipy.optimize tutorial.
+
     References
     ----------
     .. [1] Nelder, J A, and R Mead. 1965. A Simplex Method for Function
@@ -315,7 +337,11 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         else:
             method = 'BFGS'
 
-    meth = method.lower()
+    if callable(method):
+        meth = "_custom"
+    else:
+        meth = method.lower()
+
     # deprecated methods
     if meth == 'anneal':
         warn('Method %s is deprecated in scipy 0.14.0' % method,
@@ -328,11 +354,11 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         warn('Method %s does not use gradient information (jac).' % method,
              RuntimeWarning)
     # - hess
-    if meth not in ('newton-cg', 'dogleg', 'trust-ncg') and hess is not None:
+    if meth not in ('newton-cg', 'dogleg', 'trust-ncg', '_custom') and hess is not None:
         warn('Method %s does not use Hessian information (hess).' % method,
              RuntimeWarning)
     # - hessp
-    if meth not in ('newton-cg', 'dogleg', 'trust-ncg') and hessp is not None:
+    if meth not in ('newton-cg', 'dogleg', 'trust-ncg', '_custom') and hessp is not None:
         warn('Method %s does not use Hessian-vector product '
                 'information (hessp).' % method, RuntimeWarning)
     # - constraints or bounds
@@ -376,10 +402,14 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
             options.setdefault('ftol', tol)
         if meth in ['bfgs', 'cg', 'l-bfgs-b', 'tnc', 'dogleg', 'trust-ncg']:
             options.setdefault('gtol', tol)
-        if meth in ['cobyla']:
+        if meth in ['cobyla', '_custom']:
             options.setdefault('tol', tol)
 
-    if meth == 'nelder-mead':
+    if meth == '_custom':
+        return method(fun, x0, args=args, jac=jac, hess=hess, hessp=hessp,
+                      bounds=bounds, constraints=constraints,
+                      callback=callback, **options)
+    elif meth == 'nelder-mead':
         return _minimize_neldermead(fun, x0, args, callback, **options)
     elif meth == 'powell':
         return _minimize_powell(fun, x0, args, callback, **options)
@@ -437,12 +467,13 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
         corresponding to the optimization bounds.
     args : tuple, optional
         Extra arguments passed to the objective function.
-    method : str, optional
+    method : str or callable, optional
         Type of solver.  Should be one of
 
             - 'Brent'
             - 'Bounded'
             - 'Golden'
+            - custom - a callable object (added in version 0.14.0)
     tol : float, optional
         Tolerance for termination. For detailed control, use solver-specific
         options.
@@ -486,6 +517,23 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
     Method *Bounded* can perform bounded minimization. It uses the Brent
     method to find a local minimum in the interval x1 < xopt < x2.
 
+    **Custom minimizers**
+
+    It may be useful to pass a custom minimization method, for example
+    when using some library frontend to minimize_scalar.  You can simply
+    pass a callable as the ``method`` parameter.
+
+    The callable is called as ``method(fun, args, **kwargs, **options)``
+    where ``kwargs`` corresponds to any other parameters passed to `minimize`
+    (such as `bracket`, `tol`, etc.), except the `options` dict, which has
+    its contents also passed as `method` parameters pair by pair.  The method
+    shall return an ``OptimizeResult`` object.
+
+    The provided `method` callable must be able to accept (and possibly ignore)
+    arbitrary parameters; the set of parameters accepted by `minimize` may
+    expand in future versions and then these parameters will be passed to
+    the method.  You can find an example in the scipy.optimize tutorial.
+
     Examples
     --------
     Consider the problem of minimizing the following function.
@@ -508,7 +556,10 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
     -2.0000002026
 
     """
-    meth = method.lower()
+    if callable(method):
+        meth = "_custom"
+    else:
+        meth = method.lower()
     if options is None:
         options = {}
 
@@ -518,10 +569,14 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
             warn("Method 'bounded' does not support relative tolerance in x; "
                  "defaulting to absolute tolerance.", RuntimeWarning)
             options['xatol'] = tol
+        elif meth == '_custom':
+            options.setdefault('tol', tol)
         else:
             options.setdefault('xtol', tol)
 
-    if meth == 'brent':
+    if meth == '_custom':
+        return method(fun, args=args, bracket=bracket, bounds=bounds, **options)
+    elif meth == 'brent':
         return _minimize_scalar_brent(fun, bracket, args, **options)
     elif meth == 'bounded':
         if bounds is None:

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -433,6 +433,44 @@ class TestOptimize(object):
 
             assert_allclose(v, self.func(self.solution), rtol=tol)
 
+    def test_custom(self):
+        # This function comes from the documentation example.
+        def custmin(fun, x0, args=(), maxfev=None, stepsize=0.1,
+                maxiter=100, callback=None, **options):
+            bestx = x0
+            besty = fun(x0)
+            funcalls = 1
+            niter = 0
+            improved = True
+            stop = False
+
+            while improved and not stop and niter < maxiter:
+                improved = False
+                niter += 1
+                for dim in range(np.size(x0)):
+                    for s in [bestx[dim] - stepsize, bestx[dim] + stepsize]:
+                        testx = np.copy(bestx)
+                        testx[dim] = s
+                        testy = fun(testx, *args)
+                        funcalls += 1
+                        if testy < besty:
+                            besty = testy
+                            bestx = testx
+                            improved = True
+                    if callback is not None:
+                        callback(bestx)
+                    if maxfev is not None and funcalls >= maxfev:
+                        stop = True
+                        break
+
+            return optimize.OptimizeResult(fun=besty, x=bestx, nit=niter,
+                                           nfev=funcalls, success=(niter > 1))
+
+        x0 = [1.35, 0.9, 0.8, 1.1, 1.2]
+        res = optimize.minimize(optimize.rosen, x0, method=custmin,
+                                options=dict(stepsize=0.05))
+        assert_allclose(res.x, 1.0, rtol=1e-4, atol=1e-4)
+
     def test_minimize(self):
         """Tests for the minimize wrapper."""
         self.setUp()
@@ -451,6 +489,8 @@ class TestOptimize(object):
         self.test_neldermead(True)
         self.setUp()
         self.test_powell(True)
+        self.setUp()
+        self.test_custom()
 
     def test_minimize_tol_parameter(self):
         # Check that the minimize() tol= argument does something
@@ -693,6 +733,40 @@ class TestOptimizeScalar(TestCase):
         x = optimize.minimize_scalar(self.fun, bounds=(1, np.array(5)),
                                      method='bounded').x
         assert_allclose(x, self.solution, atol=1e-6)
+
+    def test_minimize_scalar_custom(self):
+        # This function comes from the documentation example.
+        def custmin(fun, bracket, args=(), maxfev=None, stepsize=0.1,
+                maxiter=100, callback=None, **options):
+            bestx = (bracket[1] + bracket[0]) / 2.0
+            besty = fun(bestx)
+            funcalls = 1
+            niter = 0
+            improved = True
+            stop = False
+
+            while improved and not stop and niter < maxiter:
+                improved = False
+                niter += 1
+                for testx in [bestx - stepsize, bestx + stepsize]:
+                    testy = fun(testx, *args)
+                    funcalls += 1
+                    if testy < besty:
+                        besty = testy
+                        bestx = testx
+                        improved = True
+                if callback is not None:
+                    callback(bestx)
+                if maxfev is not None and funcalls >= maxfev:
+                    stop = True
+                    break
+
+            return optimize.OptimizeResult(fun=besty, x=bestx, nit=niter,
+                                           nfev=funcalls, success=(niter > 1))
+
+        res = optimize.minimize_scalar(self.fun, bracket=(0, 4), method=custmin,
+                                       options=dict(stepsize=0.05))
+        assert_allclose(res.x, self.solution, atol=1e-6)
 
 
 class TestNewtonCg(object):


### PR DESCRIPTION
I'm using the excellent scipy.optimize infrastructure for research, experiments and benchmarking of some custom local minimization strategies. However, without this simple change, I have no easy way to plug my minimizer to basinhopping to overload it for global minimization as well; first I added a direct override possibility in PR #3321, but it has been pointed out that a more generic mechanism that could cover other cases would be nicer. A global registry of custom method names has been another idea, implemented in PR #3333 and it has its merits, but it has been deemed that overally a simpler and nicer way is simply passing a callable as the method parameter, instead of a string.

Therefore, this change does just that, checking if method is a callable instead of a string and in that case just going ahead and calling it - both in minimize and minimize_scalar of scipy.optimize.  It now also includes examples in the documentation and test suite checks.
