### PR TITLE
ENH: add two new ufuncs to scipy.special

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -494,6 +494,15 @@ Combinatorics
     comb    -- [+]Combinations of N things taken k at a time, "N choose k"
     perm    -- [+]Permutations of N things taken k at a time, "k-permutations of N"
 
+Information Theoretic Functions
+-------------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   entr         -- A ufunc related to entropy: x*log(x).
+   kl_div       -- A ufunc related to K-L divergence: x*log(x/y)-x+y.
+
 Other Special Functions
 -----------------------
 

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -500,7 +500,7 @@ Information Theoretic Functions
 .. autosummary::
    :toctree: generated/
 
-   entr         -- A ufunc related to entropy: x*log(x).
+   entr         -- A ufunc related to entropy: -x*log(x).
    kl_div       -- A ufunc related to K-L divergence: x*log(x/y)-x+y.
 
 Other Special Functions

--- a/scipy/special/_entr.pxd
+++ b/scipy/special/_entr.pxd
@@ -1,0 +1,14 @@
+
+cdef extern from "numpy/npy_math.h":
+        double inf "NPY_INFINITY"
+
+from libc.math cimport log
+
+
+cdef inline double entr(double x) nogil:
+    if x == 0:
+        return 0;
+    elif x < 0:
+        return -inf;
+    else:
+        return -x * log(x);

--- a/scipy/special/_kl_div.pxd
+++ b/scipy/special/_kl_div.pxd
@@ -15,4 +15,4 @@ cdef inline double kl_div(double x, double y) nogil:
     elif x == 0:
         return y;
     else:
-        return x * log(x / y) - x + y;
+        return x*log(x) - x*log(y) - x + y;

--- a/scipy/special/_kl_div.pxd
+++ b/scipy/special/_kl_div.pxd
@@ -1,0 +1,18 @@
+
+cdef extern from "numpy/npy_math.h":
+    double inf "NPY_INFINITY"
+
+from libc.math cimport log
+
+
+cdef inline double kl_div(double x, double y) nogil:
+    if x < 0 or y < 0 or (y == 0 and x != 0):
+        # extension of the natural domain to preserve convexity
+        return inf;
+    elif x == inf or y == inf:
+        # limits within the natural domain
+        return inf;
+    elif x == 0:
+        return y;
+    else:
+        return x * log(x / y) - x + y;

--- a/scipy/special/_testutils.py
+++ b/scipy/special/_testutils.py
@@ -241,10 +241,10 @@ class FuncData(object):
                 minf_x = np.isinf(x)
                 minf_y = np.isinf(y)
             else:
-                pinf_x = np.isinf(x) & (x > 0)
-                pinf_y = np.isinf(y) & (y > 0)
-                minf_x = np.isinf(x) & (x < 0)
-                minf_y = np.isinf(y) & (y < 0)
+                pinf_x = np.isposinf(x)
+                pinf_y = np.isposinf(y)
+                minf_x = np.isneginf(x)
+                minf_y = np.isneginf(y)
             nan_x = np.isnan(x)
             nan_y = np.isnan(y)
 

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -1167,6 +1167,9 @@ cdef extern from "_ufuncs_defs.h":
     cdef double _func_ellik "ellik"(double, double) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_ellpk "ellpk"(double) nogil
+from _entr cimport entr as _func_entr
+ctypedef double _proto_entr_t(double) nogil
+cdef _proto_entr_t *_proto_entr_t_var = &_func_entr
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_erf "erf"(double) nogil
 cdef extern from "_ufuncs_defs.h":
@@ -1448,6 +1451,9 @@ cdef extern from "_ufuncs_defs.h":
     cdef double _func_ker_wrap "ker_wrap"(double) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_kerp_wrap "kerp_wrap"(double) nogil
+from _kl_div cimport kl_div as _func_kl_div
+ctypedef double _proto_kl_div_t(double, double) nogil
+cdef _proto_kl_div_t *_proto_kl_div_t_var = &_func_kl_div
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_cbesk_wrap_real_int "cbesk_wrap_real_int"(int, double) nogil
 from _legacy cimport kn_unsafe as _func_kn_unsafe
@@ -3142,6 +3148,43 @@ ufunc_ellipkm1_ptr[2*1+1] = <void*>(<char*>"ellipkm1")
 ufunc_ellipkm1_data[0] = &ufunc_ellipkm1_ptr[2*0]
 ufunc_ellipkm1_data[1] = &ufunc_ellipkm1_ptr[2*1]
 ellipkm1 = np.PyUFunc_FromFuncAndData(ufunc_ellipkm1_loops, ufunc_ellipkm1_data, ufunc_ellipkm1_types, 2, 1, 1, 0, "ellipkm1", ufunc_ellipkm1_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc_entr_loops[2]
+cdef void *ufunc_entr_ptr[4]
+cdef void *ufunc_entr_data[2]
+cdef char ufunc_entr_types[4]
+cdef char *ufunc_entr_doc = (
+    "entr(x)\n"
+    "\n"
+    "Compute ``-x*log(x)`` so that the result is 0 if `x = 0`\n"
+    "and is negative infinity if `x < 0`.\n"
+    "If x is a finite distribution then the sum of entr is the entropy.\n"
+    "This function is concave.\n"
+    "\n"
+    ".. versionadded:: 0.14.0\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "x : array_like\n"
+    "    Argument\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "y : array_like\n"
+    "    Computed -x*log(x)")
+ufunc_entr_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
+ufunc_entr_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
+ufunc_entr_types[0] = <char>NPY_FLOAT
+ufunc_entr_types[1] = <char>NPY_FLOAT
+ufunc_entr_types[2] = <char>NPY_DOUBLE
+ufunc_entr_types[3] = <char>NPY_DOUBLE
+ufunc_entr_ptr[2*0] = <void*>_func_entr
+ufunc_entr_ptr[2*0+1] = <void*>(<char*>"entr")
+ufunc_entr_ptr[2*1] = <void*>_func_entr
+ufunc_entr_ptr[2*1+1] = <void*>(<char*>"entr")
+ufunc_entr_data[0] = &ufunc_entr_ptr[2*0]
+ufunc_entr_data[1] = &ufunc_entr_ptr[2*1]
+entr = np.PyUFunc_FromFuncAndData(ufunc_entr_loops, ufunc_entr_data, ufunc_entr_types, 2, 1, 1, 0, "entr", ufunc_entr_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_erf_loops[4]
 cdef void *ufunc_erf_ptr[8]
@@ -6142,6 +6185,49 @@ ufunc_kerp_ptr[2*1+1] = <void*>(<char*>"kerp")
 ufunc_kerp_data[0] = &ufunc_kerp_ptr[2*0]
 ufunc_kerp_data[1] = &ufunc_kerp_ptr[2*1]
 kerp = np.PyUFunc_FromFuncAndData(ufunc_kerp_loops, ufunc_kerp_data, ufunc_kerp_types, 2, 1, 1, 0, "kerp", ufunc_kerp_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc_kl_div_loops[2]
+cdef void *ufunc_kl_div_ptr[4]
+cdef void *ufunc_kl_div_data[2]
+cdef char ufunc_kl_div_types[6]
+cdef char *ufunc_kl_div_doc = (
+    "kl_div(x, y)\n"
+    "\n"
+    "Compute ``x*log(x/y)-x+y`` carefully handling the domain,\n"
+    "so that the result is infinity if either value is negative or if\n"
+    "y is zero and x is positive.  Otherwise if `x = 0` then the result is y.\n"
+    "If x and y are finite distributions then the sum of kl_div is\n"
+    "the Kullback-Leibler divergence of y from x.\n"
+    "This function is convex.\n"
+    "\n"
+    ".. versionadded:: 0.14.0\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "x : array_like\n"
+    "    Argument\n"
+    "y : array_like\n"
+    "    Argument\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "z : array_like\n"
+    "    Computed x*log(x/y)-x+y")
+ufunc_kl_div_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
+ufunc_kl_div_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
+ufunc_kl_div_types[0] = <char>NPY_FLOAT
+ufunc_kl_div_types[1] = <char>NPY_FLOAT
+ufunc_kl_div_types[2] = <char>NPY_FLOAT
+ufunc_kl_div_types[3] = <char>NPY_DOUBLE
+ufunc_kl_div_types[4] = <char>NPY_DOUBLE
+ufunc_kl_div_types[5] = <char>NPY_DOUBLE
+ufunc_kl_div_ptr[2*0] = <void*>_func_kl_div
+ufunc_kl_div_ptr[2*0+1] = <void*>(<char*>"kl_div")
+ufunc_kl_div_ptr[2*1] = <void*>_func_kl_div
+ufunc_kl_div_ptr[2*1+1] = <void*>(<char*>"kl_div")
+ufunc_kl_div_data[0] = &ufunc_kl_div_ptr[2*0]
+ufunc_kl_div_data[1] = &ufunc_kl_div_ptr[2*1]
+kl_div = np.PyUFunc_FromFuncAndData(ufunc_kl_div_loops, ufunc_kl_div_data, ufunc_kl_div_types, 2, 2, 1, 0, "kl_div", ufunc_kl_div_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_kn_loops[4]
 cdef void *ufunc_kn_ptr[8]

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -567,6 +567,29 @@ add_newdoc("scipy.special", "ellipkinc",
         integral(1/sqrt(1-m*sin(t)**2),t=0..phi)
     """)
 
+add_newdoc("scipy.special", "entr",
+    """
+    entr(x)
+
+    Compute ``-x*log(x)`` so that the result is 0 if `x = 0`
+    and is negative infinity if `x < 0`.
+    If x is a finite distribution then the sum of entr is the entropy.
+    This function is concave.
+
+    .. versionadded:: 0.14.0
+
+    Parameters
+    ----------
+    x : array_like
+        Argument
+
+    Returns
+    -------
+    y : array_like
+        Computed -x*log(x)
+
+    """)
+
 add_newdoc("scipy.special", "erf",
     """
     erf(z)
@@ -1598,6 +1621,33 @@ add_newdoc("scipy.special", "kerp",
     kerp(x)
 
     Derivative of the Kelvin function ker
+    """)
+
+add_newdoc("scipy.special", "kl_div",
+    """
+    kl_div(x, y)
+
+    Compute ``x*log(x/y)-x+y`` carefully handling the domain,
+    so that the result is infinity if either value is negative or if
+    y is zero and x is positive.  Otherwise if `x = 0` then the result is y.
+    If x and y are finite distributions then the sum of kl_div is
+    the Kullback-Leibler divergence of y from x.
+    This function is convex.
+
+    .. versionadded:: 0.14.0
+
+    Parameters
+    ----------
+    x : array_like
+        Argument
+    y : array_like
+        Argument
+
+    Returns
+    -------
+    z : array_like
+        Computed x*log(x/y)-x+y
+
     """)
 
 add_newdoc("scipy.special", "kn",

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -292,6 +292,8 @@ xlog1py -- xlog1py: dd->d                                  -- _xlogy.pxd
 poch -- poch: dd->d                                        -- c_misc/misc.h
 boxcox -- boxcox: dd->d                                    -- _boxcox.pxd
 boxcox1p -- boxcox1p: dd->d                                -- _boxcox.pxd
+entr -- entr: d->d                                         -- _entr.pxd
+kl_div -- kl_div: dd->d                                    -- _kl_div.pxd
 """
 
 #---------------------------------------------------------------------------------

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -22,6 +22,7 @@
 
 from __future__ import division, print_function, absolute_import
 
+import itertools
 import warnings
 
 import numpy as np
@@ -2880,6 +2881,44 @@ def test_xlog1py():
                      (1, 1e-30)], dtype=float)
     w1 = np.vectorize(xfunc)(z1[:,0], z1[:,1])
     assert_func_equal(special.xlog1py, w1, z1, rtol=1e-13, atol=1e-13)
+
+
+def test_entr():
+    def xfunc(x):
+        if x < 0:
+            return -np.inf
+        else:
+            return -special.xlogy(x, x)
+    values = (0, 0.5, 1.0, np.inf)
+    signs = (-1, 1)
+    arr = []
+    for sgn, v in itertools.product(signs, values):
+        arr.append(sgn*v)
+    z = np.array(arr, dtype=float)
+    w = np.vectorize(xfunc, otypes=[np.float64])(z)
+    assert_func_equal(special.entr, w, z, rtol=1e-13, atol=1e-13)
+
+
+def test_kl_div():
+    def xfunc(x, y):
+        if x < 0 or y < 0 or (y == 0 and x != 0):
+            # extension of the natural domain to preserve convexity
+            return np.inf
+        elif np.isposinf(x) or np.isposinf(y):
+            # limits within the natural domain
+            return np.inf
+        elif x == 0:
+            return y
+        else:
+            return special.xlogy(x, x/y) - x + y
+    values = (0, 0.5, 1.0, np.inf)
+    signs = (-1, 1)
+    arr = []
+    for sgna, va, sgnb, vb in itertools.product(signs, values, signs, values):
+        arr.append((sgna*va, sgnb*vb))
+    z = np.array(arr, dtype=float)
+    w = np.vectorize(xfunc, otypes=[np.float64])(z[:,0], z[:,1])
+    assert_func_equal(special.kl_div, w, z, rtol=1e-13, atol=1e-13)
 
 
 if __name__ == "__main__":

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -81,8 +81,7 @@ class binom_gen(rv_discrete):
     def _entropy(self, n, p):
         k = np.r_[0:n + 1]
         vals = self._pmf(k, n, p)
-        h = -np.sum(special.xlogy(vals, vals), axis=0)
-        return h
+        return np.sum(special.entr(vals), axis=0)
 binom = binom_gen(name='binom')
 
 
@@ -130,8 +129,7 @@ class bernoulli_gen(binom_gen):
         return binom._stats(1, p)
 
     def _entropy(self, p):
-        h = -special.xlogy(p, p) - special.xlogy(1 - p, 1 - p)
-        return h
+        return special.entr(p) + special.entr(1-p)
 bernoulli = bernoulli_gen(b=1, name='bernoulli')
 
 
@@ -341,8 +339,7 @@ class hypergeom_gen(rv_discrete):
     def _entropy(self, M, n, N):
         k = np.r_[N - (M - n):min(n, N) + 1]
         vals = self.pmf(k, M, n, N)
-        h = -np.sum(special.xlogy(vals, vals), axis=0)
-        return h
+        return np.sum(special.entr(vals), axis=0)
 
     def _sf(self, k, M, n, N):
         """More precise calculation, 1 - cdf doesn't cut it."""


### PR DESCRIPTION
These ufuncs `entr` and `kl_div` are useful building blocks for information theory, statistics, and convex optimization.

Here are some possible concerns or negative first impressions about these functions, with some comments.

One concern could be the weirdly abbreviated function names.  In general I prefer more verbose function names, but I've chosen these for a couple of reasons.  Firstly, they fit in well with the rest of the cryptically short `scipy.special` function names, and secondly they are standard atomic elementwise function names in convex optimization ([cvx](http://cvxr.com/cvx/), [cvxpy](https://github.com/cvxgrp/cvxpy), [dcp functions](http://dcp.stanford.edu/functions)).  Also the weird function names could help indicate the fact that they are lower level than actual `entropy` or `kl_divergence` functions -- the higher level functions of finite distributions are reductions (sums) of the elementwise ufuncs.

Another possible concern would be redundancy with existing ufuncs like `xlogy`.  I think they are different enough.  The `entr` is a unary instead of a binary function, and the `kl_div` shows its usefulness in this PR in the scipy code that computes kl-divergence.

The `kl_div` may appear to be defined in an unnecessarily complicated way, with the extra `- x + y`.  But this definition has the convenient property of being non-negative everywhere, and positive when `x != y`.
