### PR TITLE
scipy.stats.sigmaclip doesn't appear in the html docs.

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -231,6 +231,7 @@ which work for masked arrays.
 .. autosummary::
    :toctree: generated/
 
+   sigmaclip
    threshold
    trimboth
    trim1


### PR DESCRIPTION
See here:
http://docs.scipy.org/doc/scipy-dev/reference/stats.html

This PR should add it (untested).
