### PR TITLE
BUG: sparse/dsolve: detect invalid LAPACK parameters in superlu and bail out gracefully

### DIFF
--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/csnode_bmod.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/csnode_bmod.c
@@ -95,6 +95,12 @@ csnode_bmod (
 	CGEMV( ftcs2, &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );
 #else
+#if SCIPY_FIX
+	if (nsupr < nsupc) {
+	    /* Invalid input to LAPACK: fail more gracefully */
+	    ABORT("superlu failure (singular matrix?)");
+	}
+#endif
 	ctrsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr, 
 	      &lusup[ufirst], &incx );
 	cgemv_( "N", &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/dsnode_bmod.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/dsnode_bmod.c
@@ -94,6 +94,12 @@ dsnode_bmod (
 	SGEMV( ftcs2, &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );
 #else
+#if SCIPY_FIX
+	if (nsupr < nsupc) {
+	    /* Invalid input to LAPACK: fail more gracefully */
+	    ABORT("superlu failure (singular matrix?)");
+	}
+#endif
 	dtrsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr, 
 	      &lusup[ufirst], &incx );
 	dgemv_( "N", &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/ssnode_bmod.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/ssnode_bmod.c
@@ -94,6 +94,12 @@ ssnode_bmod (
 	SGEMV( ftcs2, &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );
 #else
+#if SCIPY_FIX
+	if (nsupr < nsupc) {
+	    /* Invalid input to LAPACK: fail more gracefully */
+	    ABORT("superlu failure (singular matrix?)");
+	}
+#endif
 	strsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr, 
 	      &lusup[ufirst], &incx );
 	sgemv_( "N", &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 

--- a/scipy/sparse/linalg/dsolve/SuperLU/SRC/zsnode_bmod.c
+++ b/scipy/sparse/linalg/dsolve/SuperLU/SRC/zsnode_bmod.c
@@ -95,6 +95,12 @@ zsnode_bmod (
 	CGEMV( ftcs2, &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );
 #else
+#if SCIPY_FIX
+	if (nsupr < nsupc) {
+	    /* Invalid input to LAPACK: fail more gracefully */
+	    ABORT("superlu failure (singular matrix?)");
+	}
+#endif
 	ztrsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr, 
 	      &lusup[ufirst], &incx );
 	zgemv_( "N", &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -32,6 +32,23 @@ class TestLinsolve(TestCase):
         b = array([1, 2, 3, 4, 5],dtype='d')
         x = spsolve(A, b, use_umfpack=False)
 
+    def test_singular_gh_3312(self):
+        # "Bad" test case that leads SuperLU to call LAPACK with invalid
+        # arguments. Check that it fails moderately gracefully.
+        ij = np.array([(17, 0), (17, 6), (17, 12), (10, 13)], dtype=np.int32)
+        v = np.array([ 0.284213  ,  0.94933781,  0.15767017,  0.38797296])
+        A = csc_matrix((v, ij.T), shape=(20, 20))
+        b = np.arange(20)
+
+        with warnings.catch_warnings():
+            try:
+                # should either raise a runtimeerror or return value
+                # appropriate for singular input
+                x = spsolve(A, b, use_umfpack=False)
+                assert_(not np.isfinite(x).any())
+            except RuntimeError:
+                pass
+
     def test_twodiags(self):
         A = spdiags([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]], [0, 1], 5, 5)
         b = array([1, 2, 3, 4, 5])


### PR DESCRIPTION
Hack around gh-3312.

LAPACK *TRSV require `lda >= n`. Catch this earlier, and bail out more gracefully with runtimerror before calling LAPACK with invalid arguments (which usually crashes the program).

The !VENDOR_BLAS code path does something also in the failing case. It's unclear if this is intended behavior, however.
