### PR TITLE
ENH: sparse/dsolve: make the L and U factors of splu and spilu accessible

### DIFF
--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -91,6 +91,7 @@ Complete or incomplete LU factorizations
 
    splu -- Compute a LU decomposition for a sparse matrix
    spilu -- Compute an incomplete LU decomposition for a sparse matrix
+   SuperLU -- Object representing an LU factorization
 
 Exceptions
 ----------

--- a/scipy/sparse/linalg/dsolve/__init__.py
+++ b/scipy/sparse/linalg/dsolve/__init__.py
@@ -58,6 +58,8 @@ from __future__ import division, print_function, absolute_import
 #del umfpack
 
 from .linsolve import *
+from ._superlu import SuperLU
+from . import _add_newdocs
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 from numpy.testing import Tester

--- a/scipy/sparse/linalg/dsolve/_add_newdocs.py
+++ b/scipy/sparse/linalg/dsolve/_add_newdocs.py
@@ -11,6 +11,8 @@ add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU',
     To construct these `SuperLU` objects, call the `splu` and `spilu`
     functions.
 
+    .. versionadded:: 0.14.0
+
     Attributes
     ----------
     shape
@@ -108,14 +110,14 @@ add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU', ('L',
     Lower triangular factor with unit diagonal as a
     `scipy.sparse.csc_matrix`.
 
-    .. versionadded:: 0.15.0
+    .. versionadded:: 0.14.0
     """))
 
 add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU', ('U',
     """
     Upper triangular factor as a `scipy.sparse.csc_matrix`.
 
-    .. versionadded:: 0.15.0
+    .. versionadded:: 0.14.0
     """))
 
 add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU', ('shape',

--- a/scipy/sparse/linalg/dsolve/_add_newdocs.py
+++ b/scipy/sparse/linalg/dsolve/_add_newdocs.py
@@ -1,0 +1,149 @@
+from numpy.lib import add_newdoc
+
+add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU',
+    """
+    LU factorization of a sparse matrix.
+
+    Factorization is represented as::
+
+        Pr * A * Pc = L * U
+
+    To construct these `SuperLU` objects, call the `splu` and `spilu`
+    functions.
+
+    Attributes
+    ----------
+    shape
+    nnz
+    perm_c
+    perm_r
+    L
+    U
+
+    Methods
+    -------
+    solve
+
+    Examples
+    --------
+    The LU decomposition can be used to solve matrix equations. Consider:
+
+    >>> import numpy as np
+    >>> from scipy.sparse import csc_matrix, linalg as sla
+    >>> A = csc_matrix([[1,2,0,4],[1,0,0,1],[1,0,2,1],[2,2,1,0.]])
+
+    This can be solved for a given right-hand side:
+
+    >>> lu = sla.splu(A)
+    >>> b = np.array([1, 2, 3, 4])
+    >>> x = lu.solve(b)
+    >>> A.dot(x)
+    array([ 1.,  2.,  3.,  4.])
+
+    The ``lu`` object also contains an explicit representation of the
+    decomposition. The permutations are represented as mappings of
+    indices:
+
+    >>> lu.perm_r
+    array([0, 2, 1, 3], dtype=int32)
+    >>> lu.perm_c
+    array([2, 0, 1, 3], dtype=int32)
+
+    The L and U factors are sparse matrices in CSC format:
+
+    >>> lu.L.A
+    array([[ 1. ,  0. ,  0. ,  0. ],
+           [ 0. ,  1. ,  0. ,  0. ],
+           [ 0. ,  0. ,  1. ,  0. ],
+           [ 1. ,  0.5,  0.5,  1. ]])
+    >>> lu.U.A
+    array([[ 2.,  0.,  1.,  4.],
+           [ 0.,  2.,  1.,  1.],
+           [ 0.,  0.,  1.,  1.],
+           [ 0.,  0.,  0., -5.]])
+
+    The permutation matrices can be constructed:
+
+    >>> Pr = csc_matrix((4, 4))
+    >>> Pr[lu.perm_r, np.arange(4)] = 1
+    >>> Pc = csc_matrix((4, 4))
+    >>> Pc[np.arange(4), lu.perm_c] = 1
+
+    We can reassemble the original matrix:
+
+    >>> (Pr * (lu.L * lu.U) * Pc).A
+    array([[ 0.,  1.,  2.,  4.],
+           [ 0.,  1.,  0.,  1.],
+           [ 2.,  1.,  0.,  1.],
+           [ 1.,  2.,  2.,  0.]])
+    """)
+
+add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU', ('solve',
+    """
+    solve(b[, trans])
+
+    Solves linear system of equations with one or several right-hand sides.
+
+    Parameters
+    ----------
+    b : ndarray, shape (n,) or (n, k)
+        Right hand side(s) of equation
+    trans : {'N', 'T', 'H'}, optional
+        Type of system to solve::
+    
+            'N':   A   * x == b  (default)
+            'T':   A^T * x == b
+            'H':   A^H * x == b
+
+        i.e., normal, transposed, and hermitian conjugate.
+
+    Returns
+    -------
+    x : ndarray, shape b.shape
+        Solution vector(s)
+    """))
+
+add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU', ('L',
+    """
+    Lower triangular factor with unit diagonal as a
+    `scipy.sparse.csc_matrix`.
+
+    .. versionadded:: 0.15.0
+    """))
+
+add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU', ('U',
+    """
+    Upper triangular factor as a `scipy.sparse.csc_matrix`.
+
+    .. versionadded:: 0.15.0
+    """))
+
+add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU', ('shape',
+    """
+    Shape of the original matrix as a tuple of ints.
+    """))
+
+add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU', ('nnz',
+    """
+    Number of nonzero elements in the matrix.
+    """))
+
+add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU', ('perm_c',
+    """
+    Permutation Pc represented as an array of indices.
+
+    The column permutation matrix can be reconstructed via:
+
+    >>> Pc = np.zeros((n, n))
+    >>> Pc[np.arange(n), perm_c] = 1
+    """))
+
+add_newdoc('scipy.sparse.linalg.dsolve._superlu', 'SuperLU', ('perm_r',
+    """
+    Permutation Pr represented as an array of indices.
+
+    The row permutation matrix can be reconstructed via:
+
+    >>> Pr = np.zeros((n, n))
+    >>> Pr[perm_r, np.arange(n)] = 1
+    """))

--- a/scipy/sparse/linalg/dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/dsolve/_superlumodule.c
@@ -244,7 +244,7 @@ static PyObject *Py_gstrf(PyObject * self, PyObject * args,
 	goto fail;
     }
 
-    result = newSciPyLUObject(&A, option_dict, type, ilu);
+    result = newSuperLUObject(&A, option_dict, type, ilu);
     if (result == NULL) {
 	goto fail;
     }
@@ -323,7 +323,7 @@ PyObject *PyInit__superlu(void)
 
     import_array();
 
-    if (PyType_Ready(&SciPySuperLUType) < 0) {
+    if (PyType_Ready(&SuperLUType) < 0) {
 	return NULL;
     }
 
@@ -331,8 +331,8 @@ PyObject *PyInit__superlu(void)
     d = PyModule_GetDict(m);
 
     Py_INCREF(&PyArrayFlags_Type);
-    PyDict_SetItemString(d, "SciPyLUType",
-			 (PyObject *) & SciPySuperLUType);
+    PyDict_SetItemString(d, "SuperLU",
+			 (PyObject *) &SuperLUType);
 
     if (PyErr_Occurred())
 	Py_FatalError("can't initialize module _superlu");
@@ -348,8 +348,8 @@ PyMODINIT_FUNC init_superlu(void)
 
     import_array();
 
-    SciPySuperLUType.ob_type = &PyType_Type;
-    if (PyType_Ready(&SciPySuperLUType) < 0) {
+    SuperLUType.ob_type = &PyType_Type;
+    if (PyType_Ready(&SuperLUType) < 0) {
 	return;
     }
 
@@ -357,8 +357,8 @@ PyMODINIT_FUNC init_superlu(void)
     d = PyModule_GetDict(m);
 
     Py_INCREF(&PyArrayFlags_Type);
-    PyDict_SetItemString(d, "SciPyLUType",
-			 (PyObject *) & SciPySuperLUType);
+    PyDict_SetItemString(d, "SuperLU",
+			 (PyObject *) & SuperLUType);
 }
 
 #endif

--- a/scipy/sparse/linalg/dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/dsolve/_superluobject.c
@@ -17,68 +17,11 @@
 
 extern jmp_buf _superlu_py_jmpbuf;
 
-static char factored_lu_doc[] = (
-    "LU factorization of a sparse matrix\n"
-    "\n"
-    "Factorization is represented as::\n"
-    "\n"
-    "    Pr * A * Pc = (I + L) * (I + U)\n"
-    "\n"
-    "Attributes\n"
-    "-----------\n"
-    "shape : 2-tuple\n"
-    "    Shape of the orginal matrix factored\n"
-    "nnz : int\n"
-    "    Number of non-zero elements in the matrix\n"
-    "perm_c : ndarray of int\n"
-    "    Permutation Pc represented as an array of indices\n"
-    "perm_r : ndarray of int\n"
-    "    Permutation Pr represented as an array of indices\n"
-    "L : scipy.sparse.coo_matrix\n"
-    "    Lower triangular factor in the decomposition\n"
-    "U : scipy.sparse.csc_matrix\n"
-    "    Upper triangular factor in the decomposition.\n"
-    "    The unit diagonal is omitted from the matrix.\n"
-    "\n"
-    "Methods\n"
-    "-------\n"
-    "solve\n"
-    "\n"
-    "Examples\n"
-    "--------\n"
-    "The inverse matrix can be constructed from\n"
-    "\n"
-    "\n"
-    "\n"
-    );
-
-static char solve_doc[] = (
-    "solve(b[, trans])\n"
-    "\n"
-    "Solves linear system of equations with one or several right hand sides.\n"
-    "\n"
-    "Parameters\n"
-    "----------\n"
-    "b : ndarray, shape (n,) or (n, k)\n"
-    "    Right hand side(s) of equation\n"
-    "trans : {'N', 'T', 'H'}, optional\n"
-    "    Type of system to solve::\n"
-    "\n"
-    "        'N': solve A   * x == b  (default)\n"
-    "        'T': solve A^T * x == b\n"
-    "        'H': solve A^H * x == b\n"
-    "\n"
-    "Returns\n"
-    "-------\n"
-    "x : ndarray, shape b.shape\n"
-    "    Solution vector(s)\n"
-    );
-
 /*********************************************************************** 
- * SciPyLUObject methods
+ * SuperLUObject methods
  */
 
-static PyObject *SciPyLU_solve(SciPyLUObject * self, PyObject * args,
+static PyObject *SuperLU_solve(SuperLUObject * self, PyObject * args,
 			       PyObject * kwds)
 {
     PyArrayObject *b, *x = NULL;
@@ -166,18 +109,17 @@ static PyObject *SciPyLU_solve(SciPyLUObject * self, PyObject * args,
 
 /** table of object methods
  */
-PyMethodDef SciPyLU_methods[] = {
-    {"solve", (PyCFunction) SciPyLU_solve, METH_VARARGS | METH_KEYWORDS,
-     solve_doc},
+PyMethodDef SuperLU_methods[] = {
+    {"solve", (PyCFunction) SuperLU_solve, METH_VARARGS | METH_KEYWORDS, NULL},
     {NULL, NULL}		/* sentinel */
 };
 
 
 /*********************************************************************** 
- * SciPySuperLUType methods
+ * SuperLUType methods
  */
 
-static void SciPyLU_dealloc(SciPyLUObject * self)
+static void SuperLU_dealloc(SuperLUObject * self)
 {
     Py_XDECREF(self->cached_U);
     Py_XDECREF(self->cached_L);
@@ -192,7 +134,7 @@ static void SciPyLU_dealloc(SciPyLUObject * self)
     PyObject_Del(self);
 }
 
-static PyObject *SciPyLU_getter(SciPyLUObject *self, void *data)
+static PyObject *SuperLU_getter(SuperLUObject *self, void *data)
 {
     char *name = (char*)data;
 
@@ -259,31 +201,31 @@ static PyObject *SciPyLU_getter(SciPyLUObject *self, void *data)
 
 
 /***********************************************************************
- * SciPySuperLUType structure
+ * SuperLUType structure
  */
 
-PyGetSetDef SciPyLU_getset[] = {
-    {"shape", SciPyLU_getter, (setter)NULL, (char*)NULL, (void*)"shape"},
-    {"nnz", SciPyLU_getter, (setter)NULL, (char*)NULL, (void*)"nnz"},
-    {"perm_r", SciPyLU_getter, (setter)NULL, (char*)NULL, (void*)"perm_r"},
-    {"perm_c", SciPyLU_getter, (setter)NULL, (char*)NULL, (void*)"perm_c"},
-    {"U", SciPyLU_getter, (setter)NULL, (char*)NULL, (void*)"U"},
-    {"L", SciPyLU_getter, (setter)NULL, (char*)NULL, (void*)"L"},
+PyGetSetDef SuperLU_getset[] = {
+    {"shape", SuperLU_getter, (setter)NULL, (char*)NULL, (void*)"shape"},
+    {"nnz", SuperLU_getter, (setter)NULL, (char*)NULL, (void*)"nnz"},
+    {"perm_r", SuperLU_getter, (setter)NULL, (char*)NULL, (void*)"perm_r"},
+    {"perm_c", SuperLU_getter, (setter)NULL, (char*)NULL, (void*)"perm_c"},
+    {"U", SuperLU_getter, (setter)NULL, (char*)NULL, (void*)"U"},
+    {"L", SuperLU_getter, (setter)NULL, (char*)NULL, (void*)"L"},
     NULL
 };
 
 
-PyTypeObject SciPySuperLUType = {
+PyTypeObject SuperLUType = {
 #if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
 #else
     PyObject_HEAD_INIT(NULL)
     0,
 #endif
-    "factored_lu",
-    sizeof(SciPyLUObject),
+    "SuperLU",
+    sizeof(SuperLUObject),
     0,
-    (destructor) SciPyLU_dealloc,	/* tp_dealloc */
+    (destructor) SuperLU_dealloc, /* tp_dealloc */
     0,				/* tp_print */
     0,	                        /* tp_getattr */
     0,				/* tp_setattr */
@@ -299,16 +241,16 @@ PyTypeObject SciPySuperLUType = {
     0,				/* tp_setattro */
     0,				/* tp_as_buffer */
     Py_TPFLAGS_DEFAULT,		/* tp_flags */
-    factored_lu_doc,		/* tp_doc */
+    NULL,                       /* tp_doc */
     0,				/* tp_traverse */
     0,				/* tp_clear */
     0,				/* tp_richcompare */
     0,				/* tp_weaklistoffset */
     0,				/* tp_iter */
     0,				/* tp_iternext */
-    SciPyLU_methods,		/* tp_methods */
+    SuperLU_methods,		/* tp_methods */
     0,				/* tp_members */
-    SciPyLU_getset,		/* tp_getset */
+    SuperLU_getset,		/* tp_getset */
     0,				/* tp_base */
     0,				/* tp_dict */
     0,				/* tp_descr_get */
@@ -724,12 +666,12 @@ size_error:
 }
 
 
-PyObject *newSciPyLUObject(SuperMatrix * A, PyObject * option_dict,
-			   int intype, int ilu)
+PyObject *newSuperLUObject(SuperMatrix * A, PyObject * option_dict,
+                           int intype, int ilu)
 {
 
     /* A must be in SLU_NC format used by the factorization routine. */
-    SciPyLUObject *self;
+    SuperLUObject *self;
     SuperMatrix AC = { 0 };	/* Matrix postmultiplied by Pc */
     int lwork = 0;
     int *etree = NULL;
@@ -746,8 +688,8 @@ PyObject *newSciPyLUObject(SuperMatrix * A, PyObject * option_dict,
 	return NULL;
     }
 
-    /* Create SciPyLUObject */
-    self = PyObject_New(SciPyLUObject, &SciPySuperLUType);
+    /* Create SLUObject */
+    self = PyObject_New(SuperLUObject, &SuperLUType);
     if (self == NULL)
 	return PyErr_NoMemory();
     self->m = A->nrow;

--- a/scipy/sparse/linalg/dsolve/_superluobject.h
+++ b/scipy/sparse/linalg/dsolve/_superluobject.h
@@ -34,6 +34,8 @@ typedef struct {
     SuperMatrix U;
     int *perm_r;
     int *perm_c;
+    PyObject *cached_U;
+    PyObject *cached_L;
     int type;
 } SciPyLUObject;
 
@@ -44,6 +46,8 @@ int NRFormat_from_spMatrix(SuperMatrix *, int, int, int, PyArrayObject *,
 			   PyArrayObject *, PyArrayObject *, int);
 int NCFormat_from_spMatrix(SuperMatrix *, int, int, int, PyArrayObject *,
 			   PyArrayObject *, PyArrayObject *, int);
+int LU_to_csc_matrix(SuperMatrix *L, SuperMatrix *U,
+                     PyObject **L_csc, PyObject **U_csc);
 colperm_t superlu_module_getpermc(int);
 PyObject *newSciPyLUObject(SuperMatrix *, PyObject *, int, int);
 int set_superlu_options_from_dict(superlu_options_t * options,

--- a/scipy/sparse/linalg/dsolve/_superluobject.h
+++ b/scipy/sparse/linalg/dsolve/_superluobject.h
@@ -37,9 +37,9 @@ typedef struct {
     PyObject *cached_U;
     PyObject *cached_L;
     int type;
-} SciPyLUObject;
+} SuperLUObject;
 
-extern PyTypeObject SciPySuperLUType;
+extern PyTypeObject SuperLUType;
 
 int DenseSuper_from_Numeric(SuperMatrix *, PyObject *);
 int NRFormat_from_spMatrix(SuperMatrix *, int, int, int, PyArrayObject *,
@@ -49,7 +49,7 @@ int NCFormat_from_spMatrix(SuperMatrix *, int, int, int, PyArrayObject *,
 int LU_to_csc_matrix(SuperMatrix *L, SuperMatrix *U,
                      PyObject **L_csc, PyObject **U_csc);
 colperm_t superlu_module_getpermc(int);
-PyObject *newSciPyLUObject(SuperMatrix *, PyObject *, int, int);
+PyObject *newSuperLUObject(SuperMatrix *, PyObject *, int, int);
 int set_superlu_options_from_dict(superlu_options_t * options,
 				  int ilu, PyObject * option_dict,
 				  int *panel_size, int *relax);

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -206,7 +206,7 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
 
     Returns
     -------
-    invA : scipy.sparse.linalg.dsolve._superlu.SciPyLUType
+    invA : scipy.sparse.linalg.SuperLU
         Object, which has a ``solve`` method.
 
     See also
@@ -273,7 +273,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
 
     Returns
     -------
-    invA_approx : scipy.sparse.linalg.dsolve._superlu.SciPyLUType
+    invA_approx : scipy.sparse.linalg.SuperLU
         Object, which has a ``solve`` method.
 
     See also

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -6,7 +6,8 @@ import numpy as np
 from numpy import array, finfo, arange, eye, all, unique, ones, dot, matrix
 import numpy.random as random
 from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal, \
-    assert_raises, assert_almost_equal, assert_equal, assert_array_equal, assert_
+    assert_raises, assert_almost_equal, assert_equal, assert_array_equal, assert_, \
+    assert_allclose
 
 import scipy.linalg
 from scipy.linalg import norm, inv
@@ -365,6 +366,25 @@ class TestSplu(object):
                           b.astype(np.complex64))
             assert_raises(TypeError, lu.solve,
                           b.astype(np.complex128))
+
+    def test_lu_attr(self):
+        A = self.A
+        n = A.shape[0]
+        lu = splu(A)
+
+        # Check that the decomposition is as advertized
+
+        Pc = np.zeros((n, n))
+        Pc[np.arange(n), lu.perm_c] = 1
+
+        Pr = np.zeros((n, n))
+        Pr[lu.perm_r, np.arange(n)] = 1
+
+        Ad = A.toarray()
+        lhs = Pr.dot(Ad).dot(Pc)
+        rhs = (lu.L * lu.U).toarray()
+
+        assert_allclose(lhs, rhs, atol=1e-10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The L and U factors in sparse direct LU decomposition computed by SuperLU
are not currently accessible from Python. This PR makes them accessible.

The PR also renames the superlu object returned by splu() and spilu() to something
a bit saner, and links it to the documentation.

The module in principle could be rewritten in Cython, but that's a job for another day.

Goes on top of gh-3367 (new commits in this PR start from 1f49ccd)
