### PR TITLE
MAINT: replace np.isinf(x) & (x>0) -> np.isposinf(x) to avoid RuntimeWarning

### DIFF
--- a/scipy/special/_testutils.py
+++ b/scipy/special/_testutils.py
@@ -241,10 +241,10 @@ class FuncData(object):
                 minf_x = np.isinf(x)
                 minf_y = np.isinf(y)
             else:
-                pinf_x = np.isinf(x) & (x > 0)
-                pinf_y = np.isinf(y) & (y > 0)
-                minf_x = np.isinf(x) & (x < 0)
-                minf_y = np.isinf(y) & (y < 0)
+                pinf_x = np.isposinf(x)
+                pinf_y = np.isposinf(y)
+                minf_x = np.isneginf(x)
+                minf_y = np.isneginf(y)
             nan_x = np.isnan(x)
             nan_y = np.isnan(y)
 


### PR DESCRIPTION
This fixes warnings of the type

```
scipy/special/_testutils.py", line 244, in check
    pinf_x = np.isinf(x) & (x > 0)
RuntimeWarning: invalid value encountered in greater
```

and is less complicated.

```
>>> import numpy as np
>>> a = np.nan
>>> b = np.inf
>>> c = -np.inf
>>> d = 4
>>> e = np.array([a, b, c, d])
>>> for x in (a, b, c, d, e): print np.isposinf(x)
... 
False
True
False
False
[False  True False False]
>>> for x in (a, b, c, d, e): print np.isinf(x) & (x > 0)
... 
False
True
False
False
__main__:1: RuntimeWarning: invalid value encountered in greater
[False  True False False]
```

This fix is pillaged from https://github.com/scipy/scipy/pull/3370.
