### PR TITLE
MAINT: add pyflakes to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,13 @@ matrix:
       env:
         - TESTMODE=fast
         - OPTIMIZE=-OO
+    - python: 2.7
+      env:
+        - PYFLAKES=1
+      before_install:
+        - pip install pyflakes
+      script:
+        - PYFLAKES_NODOCTEST=1 pyflakes scipy | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused' > test.out; cat test.out; test \! -s test.out
 before_install:
   - uname -a
   - free -m

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -74,6 +74,7 @@ from numpy import __version__ as __numpy_version__
 
 # Import numpy symbols to scipy name space
 import numpy as _num
+linalg = None
 from numpy import *
 from numpy.random import rand, randn
 from numpy.fft import fft, ifft

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1848,7 +1848,7 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
                 e = matplotlib.patches.Ellipse((y, x),
                                                width=dvw / 100, height=1.0)
                 ax.add_artist(e)
-                e.set_clip_box(axis.bbox)
+                e.set_clip_box(ax.bbox)
                 e.set_alpha(0.5)
                 e.set_facecolor('k')
         if orientation in ('top', 'bottom'):
@@ -1856,7 +1856,7 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
                 e = matplotlib.patches.Ellipse((x, y),
                                              width=1.0, height=dvw / 100)
                 ax.add_artist(e)
-                e.set_clip_box(axis.bbox)
+                e.set_clip_box(ax.bbox)
                 e.set_alpha(0.5)
                 e.set_facecolor('k')
 

--- a/scipy/cluster/tests/vq_test.py
+++ b/scipy/cluster/tests/vq_test.py
@@ -32,9 +32,9 @@ def read_data(name):
     f = open(name,'r')
     data = []
     for line in f.readlines():
-        data.append(list(map(float,string.split(line))))
+        data.append(list(map(float, line.split())))
     f.close()
-    return array(data)
+    return np.array(data)
 
 
 def main():

--- a/scipy/interpolate/benchmarks/bench_memusage.py
+++ b/scipy/interpolate/benchmarks/bench_memusage.py
@@ -12,6 +12,7 @@ from numpy.testing import dec
 from scipy.stats import spearmanr
 
 import numpy as np
+from numpy.testing import run_module_suite
 
 
 @dec.skipif(not sys.platform.startswith('linux'), "Memory benchmark works only on Linux")
@@ -130,4 +131,4 @@ def set_mem_rlimit(max_mem):
     resource.setrlimit(resource.RLIMIT_AS, (max_mem, cur_limit[1]))
 
 if __name__ == "__main__":
-    bench_run()
+    run_module_suite()

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -204,7 +204,7 @@ class UnivariateSpline(object):
         else:
             if not n <= nest:
                 raise ValueError("`nest` can only be increased")
-        t, c, fpint, nrdata = [np.resize(data[n], nest) for n in [8,9,11,12]]
+        t, c, fpint, nrdata = [np.resize(data[j], nest) for j in [8,9,11,12]]
 
         args = data[:8] + (t,c,n,fpint,nrdata,data[13])
         data = dfitpack.fpcurf1(*args)

--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -244,26 +244,6 @@ def tokenize_attribute(iterable, attribute):
     return name, type, next_item
 
 
-def tokenize_multilines(iterable, val):
-    """Can tokenize an attribute spread over several lines."""
-    # If one line does not match, read all the following lines up to next
-    # line with meta character, and try to parse everything up to there.
-    if not r_mcomattrval.match(val):
-        all = [val]
-        i = next(iterable)
-        while not r_meta.match(i):
-            all.append(i)
-            i = next(iterable)
-        if r_mend.search(i):
-            raise ValueError("relational attribute not supported yet")
-        print("".join(all[:-1]))
-        m = r_comattrval.match("".join(all[:-1]))
-        return m.group(1), m.group(2), i
-    else:
-        raise ValueError("Cannot parse attribute names spread over multi "
-                        "lines yet")
-
-
 def tokenize_single_comma(val):
     # XXX we match twice the same string (here and at the caller level). It is
     # stupid, but it is easier for now...
@@ -662,23 +642,6 @@ def test_weka(filename):
 
 # make sure nose does not find this as a test
 test_weka.__test__ = False
-
-
-def floupi(filename):
-    data, meta = loadarff(filename)
-    from attrselect import print_dataset_info
-    print_dataset_info(data)
-    print("relation %s, has %d instances" % (meta.name, data.size))
-    itp = iter(types)
-    for i in data.dtype.names:
-        print_attribute(i,next(itp),data[i])
-        #tp = itp.next()
-        #if tp == 'numeric' or tp == 'real' or tp == 'integer':
-        #    min, max, mean, std = basic_stats(data[i])
-        #    print "\tinstance %s: min %f, max %f, mean %f, std %f" % \
-        #            (i, min, max, mean, std)
-        #else:
-        #    print "\tinstance %s is non numeric" % i
 
 
 if __name__ == '__main__':

--- a/scipy/io/harwell_boeing/hb.py
+++ b/scipy/io/harwell_boeing/hb.py
@@ -29,7 +29,7 @@ from scipy.io.harwell_boeing._fortran_format_parser import \
 
 from scipy.lib.six import string_types
 
-__all__ = ["MalformedHeader", "read_hb", "write", "HBInfo", "HBFile",
+__all__ = ["MalformedHeader", "hb_read", "hb_write", "HBInfo", "HBFile",
            "HBMatrixType"]
 
 
@@ -255,7 +255,7 @@ class HBInfo(object):
             # XXX: fortran int -> dtype association ?
             values_dtype = np.int
         else:
-            raise ValueError("Unsupported format for values %s" % ct[2])
+            raise ValueError("Unsupported format for values %r" % (values_format,))
 
         self.pointer_format = pointer_format
         self.indices_format = indices_format

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -13,8 +13,7 @@ from .miobase import get_matfile_version, docfiller
 from .mio4 import MatFile4Reader, MatFile4Writer
 from .mio5 import MatFile5Reader, MatFile5Writer
 
-__all__ = ['find_mat_file', 'mat_reader_factory', 'loadmat', 'savemat',
-           'whosmat']
+__all__ = ['mat_reader_factory', 'loadmat', 'savemat', 'whosmat']
 
 
 def _open_file(file_like, appendmat):

--- a/scipy/io/matlab/tests/test_streams.py
+++ b/scipy/io/matlab/tests/test_streams.py
@@ -30,6 +30,12 @@ from scipy.io.matlab.streams import make_stream, \
     _read_into, _read_string
 
 
+fs = None
+gs = None
+cs = None
+fname = None
+
+
 def setup():
     val = b'a\x00string'
     global fs, gs, cs, fname

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -411,8 +411,8 @@ class netcdf_file(object):
                 vsize = var.data[0].size * var.data.itemsize
             except IndexError:
                 vsize = 0
-            rec_vars = len([var for var in self.variables.values()
-                    if var.isrec])
+            rec_vars = len([v for v in self.variables.values()
+                            if v.isrec])
             if rec_vars > 1:
                 vsize += -vsize % 4
         self.variables[name].__dict__['_vsize'] = vsize

--- a/scipy/lib/blas/tests/test_fblas.py
+++ b/scipy/lib/blas/tests/test_fblas.py
@@ -11,7 +11,7 @@ from __future__ import division, print_function, absolute_import
 from numpy import zeros, transpose, newaxis, shape, float32, float64, \
                   complex64, complex128, arange, array, common_type, conjugate
 from numpy.testing import assert_equal, assert_array_almost_equal, \
-        run_module_suite, TestCase
+        run_module_suite, TestCase, assert_
 from scipy.lib.six import xrange
 from scipy.lib.blas import fblas
 

--- a/scipy/lib/lapack/__init__.py
+++ b/scipy/lib/lapack/__init__.py
@@ -223,6 +223,7 @@ def get_lapack_funcs(names,arrays=(),debug=0,force_clapack=1):
                 func2 = getattr(m2,func_name,None)
                 if func2 is not None:
                     import new
+                    func_code = None   # defined in exec
                     exec(_colmajor_func_template % {'func_name':func_name})
                     func = new.function(func_code,{'clapack_func':func2},func_name)
                     func.module_name = m2_name

--- a/scipy/lib/lapack/tests/test_esv.py
+++ b/scipy/lib/lapack/tests/test_esv.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import TestCase, assert_array_almost_equal, dec, \
-                          assert_equal, assert_
+                          assert_equal, assert_, run_module_suite
 
 from common import FUNCS_TP, FLAPACK_IS_EMPTY, CLAPACK_IS_EMPTY, FUNCS_FLAPACK, \
                    FUNCS_CLAPACK, PREC

--- a/scipy/lib/lapack/tests/test_gesv.py
+++ b/scipy/lib/lapack/tests/test_gesv.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import TestCase, assert_array_almost_equal, dec, \
-                          assert_equal, assert_
+                          assert_equal, assert_, run_module_suite
 
 from common import FUNCS_TP, FLAPACK_IS_EMPTY, CLAPACK_IS_EMPTY, FUNCS_FLAPACK, \
                    FUNCS_CLAPACK, PREC

--- a/scipy/linalg/benchmarks/bench_basic.py
+++ b/scipy/linalg/benchmarks/bench_basic.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 import sys
-from numpy.testing import measure, rand, assert_, TestCase
+from numpy.testing import measure, rand, assert_, TestCase, run_module_suite
 import numpy.linalg as nl
 import scipy.linalg as sl
 

--- a/scipy/linalg/tests/test_build.py
+++ b/scipy/linalg/tests/test_build.py
@@ -26,7 +26,7 @@ class FindDependenciesLdd:
         p = Popen(self.cmd + [file], stdout=PIPE, stderr=PIPE)
         stdout, stderr = p.communicate()
         if not (p.returncode == 0):
-            raise RuntimeError("Failed to check dependencies for %s" % libfile)
+            raise RuntimeError("Failed to check dependencies for %s" % file)
 
         return stdout
 

--- a/scipy/sparse/linalg/_onenormest.py
+++ b/scipy/sparse/linalg/_onenormest.py
@@ -348,6 +348,7 @@ def _onenormest_core(A, AT, t, itmax):
     est_old = 0
     S = np.zeros((n, t), dtype=float)
     k = 1
+    ind = None
     while True:
         Y = np.asarray(A_linear_operator.matmat(X))
         nmults += 1

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -348,6 +348,11 @@ def lobpcg(A, X,
 
     ##
     # Main iteration loop.
+
+    blockVectorP = None  # set during iteration
+    blockVectorAP = None
+    blockVectorBP = None
+
     for iterationNumber in xrange(maxIterations):
         if verbosityLevel > 0:
             print('iteration %d' % iterationNumber)

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -195,8 +195,6 @@ def bicgstab(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback
             work[slice2] *= sclr2
             work[slice2] += sclr1*matvec(work[slice1])
         elif (ijob == 2):
-            if psolve is None:
-                psolve = get_psolve(A)
             work[slice1] = psolve(work[slice2])
         elif (ijob == 3):
             work[slice2] *= sclr2

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -138,6 +138,8 @@ class IterativeParams(object):
                                skip=sym_solvers+[cgs, qmr, bicg]))
 
 
+params = None
+
 def setup_module():
     global params
     params = IterativeParams()

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -11,6 +11,7 @@ import keyword
 import re
 import inspect
 import types
+import warnings
 
 from scipy.misc import doccer
 from ._distr_params import distcont, distdiscrete

--- a/scipy/weave/tests/scxx_timings.py
+++ b/scipy/weave/tests/scxx_timings.py
@@ -97,11 +97,6 @@ def list_copy_c(a,b):
     weave.inline(code,['a','b'],force=force,compiler='gcc')
 
 
-def list_copy_py(a,b):
-    for item in a:
-        b[i] = item
-
-
 def time_list_copy(N):
     """ Compare the list append method from scxx to using the Python API
         directly.


### PR DESCRIPTION
Static code checking can be useful in some cases, esp. catching missing imports and so on. Of the Python static checkers, pyflakes seems to do the least amount of opinion-based style checking, and seems the best for this purpose.

This PR adds pyflakes run to the automated test suite. I filter out most "assigned but unused" failures, as those shouldn't result to Travis failures.

I also fix some issues it finds. Mainly harmless, although some of them were actual bugs.
