### PR TITLE
BUG: change value of expit for large inputs from nan to 1

### DIFF
--- a/scipy/special/_logit.c.src
+++ b/scipy/special/_logit.c.src
@@ -30,7 +30,10 @@
 {
     if (x > 0) {
         x = npy_exp@c@(x);
-        return x / (1 + x);
+        if (npy_isinf(x))
+            return 1;
+        else
+            return x / (1 + x);
     }
     else {
         return 1 / (1 + npy_exp@c@(-x));

--- a/scipy/special/tests/test_logit.py
+++ b/scipy/special/tests/test_logit.py
@@ -73,3 +73,9 @@ class TestExpit(TestCase):
                             0.79139147, 0.9022274,
                             0.95734875, 0.98201379])
         self.check_expit_out('f8', expected)
+
+    def test_large_inputs(self):
+        dtypes = ['f4', 'f8']
+        inputs = [500, 900]
+        for x, d in zip(inputs, dtypes):
+            assert_equal(expit(np.array(x, dtype=d)), np.array(1, dtype=d))


### PR DESCRIPTION
As noted [on stackoverflow](http://stackoverflow.com/questions/22006650/scipy-expit-unexpected-behavour-nans), expit for large inputs returns nan, when it should return 1. With this fix, expit behaves as it should.
