### PR TITLE
BUG: sparse: downcast 64-bit indices safely to intp when required

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -14,7 +14,8 @@ from .data import _data_matrix, _minmax_mixin
 from .dia import dia_matrix
 from . import sparsetools
 from .sputils import upcast, upcast_char, to_native, isdense, isshape, \
-     getdtype, isscalarlike, isintlike, IndexMixin, get_index_dtype
+     getdtype, isscalarlike, isintlike, IndexMixin, get_index_dtype, \
+     downcast_intp_index
 
 
 class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
@@ -102,7 +103,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             axis, _ = self._swap((axis, 1 - axis))
             _, N = self._swap(self.shape)
             if axis == 0:
-                return np.bincount(self.indices, minlength=N)
+                return np.bincount(downcast_intp_index(self.indices),
+                                   minlength=N)
             elif axis == 1:
                 return np.diff(self.indptr)
             raise ValueError('axis out of bounds')
@@ -588,7 +590,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             # Numpy < 1.8.0 don't handle empty arrays in reduceat
             value = np.zeros_like(self.data)
         else:
-            value = ufunc.reduceat(self.data, self.indptr[major_index])
+            value = ufunc.reduceat(self.data,
+                                   downcast_intp_index(self.indptr[major_index]))
         return major_index, value
 
     #######################

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -15,7 +15,7 @@ from .sparsetools import coo_tocsr, coo_todense, coo_matvec
 from .base import isspmatrix
 from .data import _data_matrix, _minmax_mixin
 from .sputils import upcast, upcast_char, to_native, isshape, getdtype, isintlike, \
-     get_index_dtype
+     get_index_dtype, downcast_intp_index
 
 
 class coo_matrix(_data_matrix, _minmax_mixin):
@@ -224,9 +224,11 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         if axis < 0:
             axis += 2
         if axis == 0:
-            return np.bincount(self.col, minlength=self.shape[1])
+            return np.bincount(downcast_intp_index(self.col),
+                               minlength=self.shape[1])
         elif axis == 1:
-            return np.bincount(self.row, minlength=self.shape[0])
+            return np.bincount(downcast_intp_index(self.row),
+                               minlength=self.shape[0])
         else:
             raise ValueError('axis out of bounds')
     nnz = property(fget=getnnz)

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -77,6 +77,24 @@ def upcast_scalar(dtype, scalar):
     return (np.array([0], dtype=dtype) * scalar).dtype
 
 
+def downcast_intp_index(arr):
+    """
+    Down-cast index array to np.intp dtype if it is of a larger dtype.
+
+    Raise an error if the array contains a value that is too large for
+    intp.
+    """
+    if arr.dtype.itemsize > np.dtype(np.intp).itemsize:
+        maxval = arr.max()
+        minval = arr.min()
+        if maxval > np.iinfo(np.intp).max or minval < np.iinfo(np.intp).min:
+            raise ValueError("Cannot deal with arrays with indices larger "
+                             "than the machine maximum address size "
+                             "(e.g. 64-bit indices on 32-bit machine).")
+        return arr.astype(np.intp)
+    return arr
+
+
 def to_native(A):
     return np.asarray(A,dtype=A.dtype.newbyteorder('native'))
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -51,7 +51,8 @@ import nose
 warnings.simplefilter('ignore', SparseEfficiencyWarning)
 warnings.simplefilter('ignore', ComplexWarning)
 
-def with_64bit_maxval_limit(maxval_limit=None, random=False, fixed_dtype=None):
+def with_64bit_maxval_limit(maxval_limit=None, random=False, fixed_dtype=None,
+                            downcast_maxval=None):
     """
     Monkeypatch the maxval threshold at which scipy.sparse switches to
     64-bit index arrays, or make it (pseudo-)random.
@@ -79,6 +80,12 @@ def with_64bit_maxval_limit(maxval_limit=None, random=False, fixed_dtype=None):
                     dtype = np.int64
             return dtype
 
+    if downcast_maxval is not None:
+        def new_downcast_intp_index(arr):
+            if arr.max() > downcast_maxval:
+                raise AssertionError("downcast limited")
+            return arr.astype(np.intp)
+
     @decorator
     def deco(func, *a, **kw):
         backup = []
@@ -88,12 +95,18 @@ def with_64bit_maxval_limit(maxval_limit=None, random=False, fixed_dtype=None):
                    scipy.sparse.compressed, scipy.sparse.construct]
         try:
             for mod in modules:
-                backup.append((mod, getattr(mod, 'get_index_dtype', None)))
+                backup.append((mod, 'get_index_dtype',
+                               getattr(mod, 'get_index_dtype', None)))
                 setattr(mod, 'get_index_dtype', new_get_index_dtype)
+                if downcast_maxval is not None:
+                    backup.append((mod, 'downcast_intp_index',
+                                   getattr(mod, 'downcast_intp_index', None)))
+                    setattr(mod, 'downcast_intp_index', new_downcast_intp_index)
             return func(*a, **kw)
         finally:
-            for mod, oldfunc in backup:
-                setattr(mod, 'get_index_dtype', oldfunc)
+            for mod, name, oldfunc in backup:
+                if oldfunc is not None:
+                    setattr(mod, name, oldfunc)
 
     return deco
 
@@ -3799,6 +3812,42 @@ class Test64Bit(object):
         for t in self._check_resiliency(fixed_dtype=np.int64):
             yield t
 
+    def test_downcast_intp(self):
+        # Check that bincount and ufunc.reduceat intp downcasts are
+        # dealt with. The point here is to trigger points in the code
+        # that can fail on 32-bit systems when using 64-bit indices,
+        # due to use of functions that only work with intp-size
+        # indices.
+
+        @with_64bit_maxval_limit(fixed_dtype=np.int64,
+                                 downcast_maxval=1)
+        def check_limited():
+            # These involve indices larger than `downcast_maxval`
+            a = csc_matrix([[1, 2], [3, 4], [5, 6]])
+            assert_raises(AssertionError, a.getnnz, axis=1)
+            assert_raises(AssertionError, a.sum, axis=0)
+
+            a = csr_matrix([[1, 2, 3], [3, 4, 6]])
+            assert_raises(AssertionError, a.getnnz, axis=0)
+
+            a = coo_matrix([[1, 2, 3], [3, 4, 5]])
+            assert_raises(AssertionError, a.getnnz, axis=0)
+
+        @with_64bit_maxval_limit(fixed_dtype=np.int64)
+        def check_unlimited():
+            # These involve indices larger than `downcast_maxval`
+            a = csc_matrix([[1, 2], [3, 4], [5, 6]])
+            a.getnnz(axis=1)
+            a.sum(axis=0)
+
+            a = csr_matrix([[1, 2, 3], [3, 4, 6]])
+            a.getnnz(axis=0)
+
+            a = coo_matrix([[1, 2, 3], [3, 4, 5]])
+            a.getnnz(axis=0)
+
+        check_limited()
+        check_unlimited()
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Downcast 64-bit indices to 32-bit intp when required, but check
whether this is a safe operation, to be sure.

ufunc.reduceat and np.bincount deal only with intp data type.
