### PR TITLE
TST: fix sparse test errors due to axis=-1,-2 usage in np.matrix.sum().

### DIFF
--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -655,7 +655,6 @@ class _TestCommon:
             dat = np.matrix(matrices[j], dtype=dtype)
             datsp = self.spmatrix(dat, dtype=dtype)
 
-            # Does the matrix's .sum(axis=...) method work?
             assert_array_almost_equal(dat.sum(), datsp.sum())
             assert_equal(dat.sum().dtype, datsp.sum().dtype)
             assert_array_almost_equal(dat.sum(axis=None), datsp.sum(axis=None))
@@ -664,10 +663,12 @@ class _TestCommon:
             assert_equal(dat.sum(axis=0).dtype, datsp.sum(axis=0).dtype)
             assert_array_almost_equal(dat.sum(axis=1), datsp.sum(axis=1))
             assert_equal(dat.sum(axis=1).dtype, datsp.sum(axis=1).dtype)
-            assert_array_almost_equal(dat.sum(axis=-2), datsp.sum(axis=-2))
-            assert_equal(dat.sum(axis=-2).dtype, datsp.sum(axis=-2).dtype)
-            assert_array_almost_equal(dat.sum(axis=-1), datsp.sum(axis=-1))
-            assert_equal(dat.sum(axis=-1).dtype, datsp.sum(axis=-1).dtype)
+            if NumpyVersion(np.__version__) >= '1.7.0':
+                # np.matrix.sum with negative axis arg doesn't work for < 1.7
+                assert_array_almost_equal(dat.sum(axis=-2), datsp.sum(axis=-2))
+                assert_equal(dat.sum(axis=-2).dtype, datsp.sum(axis=-2).dtype)
+                assert_array_almost_equal(dat.sum(axis=-1), datsp.sum(axis=-1))
+                assert_equal(dat.sum(axis=-1).dtype, datsp.sum(axis=-1).dtype)
 
         for dtype in self.checked_dtypes:
             for j in range(len(matrices)):
@@ -680,7 +681,6 @@ class _TestCommon:
                             [-6, 7, 9]], dtype=dtype)
             datsp = self.spmatrix(dat, dtype=dtype)
 
-            # Does the matrix's .mean(axis=...) method work?
             assert_array_almost_equal(dat.mean(), datsp.mean())
             assert_equal(dat.mean().dtype, datsp.mean().dtype)
             assert_array_almost_equal(dat.mean(axis=None), datsp.mean(axis=None))
@@ -689,10 +689,12 @@ class _TestCommon:
             assert_equal(dat.mean(axis=0).dtype, datsp.mean(axis=0).dtype)
             assert_array_almost_equal(dat.mean(axis=1), datsp.mean(axis=1))
             assert_equal(dat.mean(axis=1).dtype, datsp.mean(axis=1).dtype)
-            assert_array_almost_equal(dat.mean(axis=-2), datsp.mean(axis=-2))
-            assert_equal(dat.mean(axis=-2).dtype, datsp.mean(axis=-2).dtype)
-            assert_array_almost_equal(dat.mean(axis=-1), datsp.mean(axis=-1))
-            assert_equal(dat.mean(axis=-1).dtype, datsp.mean(axis=-1).dtype)
+            if NumpyVersion(np.__version__) >= '1.7.0':
+                # np.matrix.sum with negative axis arg doesn't work for < 1.7
+                assert_array_almost_equal(dat.mean(axis=-2), datsp.mean(axis=-2))
+                assert_equal(dat.mean(axis=-2).dtype, datsp.mean(axis=-2).dtype)
+                assert_array_almost_equal(dat.mean(axis=-1), datsp.mean(axis=-1))
+                assert_equal(dat.mean(axis=-1).dtype, datsp.mean(axis=-1).dtype)
 
         for dtype in self.checked_dtypes:
             yield check, dtype
@@ -1257,7 +1259,7 @@ class _TestCommon:
         dat_1 = self.dat
         dat_2 = np.array([[]])
         matrices = [dat_1, dat_2]
-        
+
         def check(dtype, j):
             dat = np.matrix(matrices[j], dtype=dtype)
             datsp = self.spmatrix(dat)
@@ -2694,40 +2696,53 @@ class _TestMinMax(object):
         D[2, 2] = -1
         X = self.spmatrix(D)
 
-        for axis in [-2, -1, 0, 1]:
+        if NumpyVersion(np.__version__) >= '1.7.0':
+            # np.matrix.sum with negative axis arg doesn't work for < 1.7
+            axes = [-2, -1, 0, 1]
+        else:
+            axes = [0, 1]
+
+        for axis in axes:
             assert_array_equal(X.max(axis=axis).A, D.max(axis=axis).A)
             assert_array_equal(X.min(axis=axis).A, D.min(axis=axis).A)
 
         # full matrix
         D = np.matrix(np.arange(1, 51).reshape(10, 5))
         X = self.spmatrix(D)
-        for axis in [-2, -1, 0, 1]:
+        for axis in axes:
             assert_array_equal(X.max(axis=axis).A, D.max(axis=axis).A)
             assert_array_equal(X.min(axis=axis).A, D.min(axis=axis).A)
 
         # empty matrix
         D = np.matrix(np.zeros((10, 5)))
         X = self.spmatrix(D)
-        for axis in [-2, -1, 0, 1]:
+        for axis in axes:
             assert_array_equal(X.max(axis=axis).A, D.max(axis=axis).A)
             assert_array_equal(X.min(axis=axis).A, D.min(axis=axis).A)
+
+        if NumpyVersion(np.__version__) >= '1.7.0':
+            axes_even = [0, -2]
+            axes_odd = [1, -1]
+        else:
+            axes_even = [0]
+            axes_odd = [1]
 
         # zero-size matrices
         D = np.zeros((0, 10))
         X = self.spmatrix(D)
-        for axis in [0, -2]:
+        for axis in axes_even:
             assert_raises(ValueError, X.min, axis=axis)
             assert_raises(ValueError, X.max, axis=axis)
-        for axis in [1, -1]:
+        for axis in axes_odd:
             assert_array_equal(np.zeros((0, 1)), X.min(axis=axis).A)
             assert_array_equal(np.zeros((0, 1)), X.max(axis=axis).A)
 
         D = np.zeros((10, 0))
         X = self.spmatrix(D)
-        for axis in [1, -1]:
+        for axis in axes_odd:
             assert_raises(ValueError, X.min, axis=axis)
             assert_raises(ValueError, X.max, axis=axis)
-        for axis in [0, -2]:
+        for axis in axes_even:
             assert_array_equal(np.zeros((1, 0)), X.min(axis=axis).A)
             assert_array_equal(np.zeros((1, 0)), X.max(axis=axis).A)
 
@@ -2744,8 +2759,11 @@ class _TestGetNnzAxis(object):
         assert_array_equal(bool_dat.sum(), datsp.getnnz())
         assert_array_equal(bool_dat.sum(axis=0), datsp.getnnz(axis=0))
         assert_array_equal(bool_dat.sum(axis=1), datsp.getnnz(axis=1))
-        assert_array_equal(bool_dat.sum(axis=-2), datsp.getnnz(axis=-2))
-        assert_array_equal(bool_dat.sum(axis=-1), datsp.getnnz(axis=-1))
+        if NumpyVersion(np.__version__) >= '1.7.0':
+            # np.matrix.sum with negative axis arg doesn't work for < 1.7
+            assert_array_equal(bool_dat.sum(axis=-2), datsp.getnnz(axis=-2))
+            assert_array_equal(bool_dat.sum(axis=-1), datsp.getnnz(axis=-1))
+
         assert_raises(ValueError, datsp.getnnz, axis=2)
 
 


### PR DESCRIPTION
Negative axis arguments are not supported by numpy < 1.7.0.
Fixes part of gh-3330.
