### PR TITLE
ENH: improve stats.nanmedian more by assuming nans are rare

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -386,10 +386,18 @@ def _nanmedian(arr1d):  # This only works on 1d arrays
     m : float
         The median.
     """
-    cond = ~np.isnan(arr1d)
-    x = np.compress(cond, arr1d, axis=-1)
-    if x.size == 0:
+    x = arr1d.copy()
+    c = np.isnan(x)
+    s = np.where(c)[0]
+    if s.size == x.size:
         return np.nan
+    elif s.size != 0:
+        # select non-nans at end of array
+        enonan = x[-s.size:][~c[-s.size:]]
+        # fill nans in beginning of array with non-nans of end
+        x[s[:enonan.size]] = enonan
+        # slice nans away
+        x = x[:-s.size]
     return np.median(x, overwrite_input=True)
 
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -390,6 +390,7 @@ def _nanmedian(arr1d):  # This only works on 1d arrays
     c = np.isnan(x)
     s = np.where(c)[0]
     if s.size == x.size:
+        warnings.warn("All-NaN slice encountered", RuntimeWarning)
         return np.nan
     elif s.size != 0:
         # select non-nans at end of array

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -171,6 +171,14 @@ class TestNanFunc(TestCase):
         m = stats.nanmedian(self.X)
         assert_approx_equal(m, np.median(self.X))
 
+    def test_nanmedian_axis(self):
+        # Check nanmedian with axis
+        X = self.X.reshape(3,3)
+        m = stats.nanmedian(X, axis=0)
+        assert_equal(m, np.median(X, axis=0))
+        m = stats.nanmedian(X, axis=1)
+        assert_equal(m, np.median(X, axis=1))
+
     def test_nanmedian_some(self):
         # Check nanmedian when some values only are nan.
         m = stats.nanmedian(self.Xsome)
@@ -178,8 +186,21 @@ class TestNanFunc(TestCase):
 
     def test_nanmedian_all(self):
         # Check nanmedian when all values are nan.
-        m = stats.nanmedian(self.Xall)
-        assert_(np.isnan(m))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            m = stats.nanmedian(self.Xall)
+            assert_(np.isnan(m))
+            assert_equal(len(w), 1)
+            assert_(issubclass(w[0].category, RuntimeWarning))
+
+    def test_nanmedian_all_axis(self):
+        # Check nanmedian when all values are nan.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            m = stats.nanmedian(self.Xall.reshape(3,3), axis=1)
+            assert_(np.isnan(m).all())
+            assert_equal(len(w), 3)
+            assert_(issubclass(w[0].category, RuntimeWarning))
 
     def test_nanmedian_scalars(self):
         # Check nanmedian for scalar inputs. See ticket #1098.


### PR DESCRIPTION
Move nans to end of array instead of creating a new array without them.
This is faster under the reasonable assumption that nans are rare.
