### PR TITLE
MAINT: sparse: Numpy 1.5 compatibility fixes

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -15,7 +15,7 @@ from .dia import dia_matrix
 from . import sparsetools
 from .sputils import upcast, upcast_char, to_native, isdense, isshape, \
      getdtype, isscalarlike, isintlike, IndexMixin, get_index_dtype, \
-     downcast_intp_index, _safe_unique
+     downcast_intp_index, _safe_unique, _safe_bincount
 
 
 class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
@@ -103,8 +103,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             axis, _ = self._swap((axis, 1 - axis))
             _, N = self._swap(self.shape)
             if axis == 0:
-                return np.bincount(downcast_intp_index(self.indices),
-                                   minlength=N)
+                return _safe_bincount(downcast_intp_index(self.indices),
+                                      minlength=N)
             elif axis == 1:
                 return np.diff(self.indptr)
             raise ValueError('axis out of bounds')

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -15,7 +15,7 @@ from .dia import dia_matrix
 from . import sparsetools
 from .sputils import upcast, upcast_char, to_native, isdense, isshape, \
      getdtype, isscalarlike, isintlike, IndexMixin, get_index_dtype, \
-     downcast_intp_index, _safe_unique, _safe_bincount
+     downcast_intp_index, _compat_unique, _compat_bincount
 
 
 class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
@@ -103,8 +103,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             axis, _ = self._swap((axis, 1 - axis))
             _, N = self._swap(self.shape)
             if axis == 0:
-                return _safe_bincount(downcast_intp_index(self.indices),
-                                      minlength=N)
+                return _compat_bincount(downcast_intp_index(self.indices),
+                                        minlength=N)
             elif axis == 1:
                 return np.diff(self.indptr)
             raise ValueError('axis out of bounds')
@@ -727,7 +727,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         # Collate old and new in chunks by major index
         indices_parts = []
         data_parts = []
-        ui, ui_indptr = _safe_unique(i, return_index=True)
+        ui, ui_indptr = _compat_unique(i, return_index=True)
         ui_indptr = np.append(ui_indptr, len(j))
         new_nnzs = np.diff(ui_indptr)
         prev = 0
@@ -739,7 +739,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             data_parts.append(self.data[start:stop])
 
             # handle duplicate j: keep last setting
-            uj, uj_indptr = _safe_unique(j[js:je][::-1], return_index=True)
+            uj, uj_indptr = _compat_unique(j[js:je][::-1], return_index=True)
             if len(uj) == je - js:
                 indices_parts.append(j[js:je])
                 data_parts.append(x[js:je])

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -15,7 +15,7 @@ from .sparsetools import coo_tocsr, coo_todense, coo_matvec
 from .base import isspmatrix
 from .data import _data_matrix, _minmax_mixin
 from .sputils import upcast, upcast_char, to_native, isshape, getdtype, isintlike, \
-     get_index_dtype, downcast_intp_index
+     get_index_dtype, downcast_intp_index, _safe_bincount
 
 
 class coo_matrix(_data_matrix, _minmax_mixin):
@@ -224,11 +224,11 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         if axis < 0:
             axis += 2
         if axis == 0:
-            return np.bincount(downcast_intp_index(self.col),
-                               minlength=self.shape[1])
+            return _safe_bincount(downcast_intp_index(self.col),
+                                  minlength=self.shape[1])
         elif axis == 1:
-            return np.bincount(downcast_intp_index(self.row),
-                               minlength=self.shape[0])
+            return _safe_bincount(downcast_intp_index(self.row),
+                                  minlength=self.shape[0])
         else:
             raise ValueError('axis out of bounds')
     nnz = property(fget=getnnz)

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -15,7 +15,7 @@ from .sparsetools import coo_tocsr, coo_todense, coo_matvec
 from .base import isspmatrix
 from .data import _data_matrix, _minmax_mixin
 from .sputils import upcast, upcast_char, to_native, isshape, getdtype, isintlike, \
-     get_index_dtype, downcast_intp_index, _safe_bincount
+     get_index_dtype, downcast_intp_index, _compat_bincount
 
 
 class coo_matrix(_data_matrix, _minmax_mixin):
@@ -224,11 +224,11 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         if axis < 0:
             axis += 2
         if axis == 0:
-            return _safe_bincount(downcast_intp_index(self.col),
-                                  minlength=self.shape[1])
+            return _compat_bincount(downcast_intp_index(self.col),
+                                    minlength=self.shape[1])
         elif axis == 1:
-            return _safe_bincount(downcast_intp_index(self.row),
-                                  minlength=self.shape[0])
+            return _compat_bincount(downcast_intp_index(self.row),
+                                    minlength=self.shape[0])
         else:
             raise ValueError('axis out of bounds')
     nnz = property(fget=getnnz)

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -381,3 +381,20 @@ else:
             ar.sort()
             flag = np.concatenate(([True], ar[1:] != ar[:-1]))
             return ar[flag]
+
+
+if NumpyVersion(np.__version__) > '1.6.0-dev':
+    _safe_bincount = np.bincount
+else:
+    def _safe_bincount(x, weights=None, minlength=None):
+        """
+        Bincount with minlength keyword added for Numpy 1.5.
+        """
+        if weights is None:
+            x = np.bincount(x)
+        else:
+            x = np.bincount(x, weights=weights)
+        if minlength is not None:
+            if x.shape[0] < minlength:
+                x = np.r_[x, np.zeros((minlength - x.shape[0],))]
+        return x

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -335,9 +335,9 @@ class IndexMixin(object):
 
 
 if NumpyVersion(np.__version__) > '1.7.0-dev':
-    _safe_unique = np.unique
+    _compat_unique = np.unique
 else:
-    def _safe_unique(ar, return_index=False, return_inverse=False):
+    def _compat_unique(ar, return_index=False, return_inverse=False):
         """
         Copy of numpy.unique() from Numpy 1.7.1.
 
@@ -384,9 +384,9 @@ else:
 
 
 if NumpyVersion(np.__version__) > '1.6.0-dev':
-    _safe_bincount = np.bincount
+    _compat_bincount = np.bincount
 else:
-    def _safe_bincount(x, weights=None, minlength=None):
+    def _compat_bincount(x, weights=None, minlength=None):
         """
         Bincount with minlength keyword added for Numpy 1.5.
         """

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3743,8 +3743,8 @@ class _NonCanonicalCompressedMixin(_NonCanonicalMixin):
                                                     indptr=M.indptr)
         # unsorted
         for start, stop in izip(indptr, indptr[1:]):
-            indices[start:stop] = indices[start:stop][::-1]
-            data[start:stop] = data[start:stop][::-1]
+            indices[start:stop] = indices[start:stop][::-1].copy()
+            data[start:stop] = data[start:stop][::-1].copy()
         return data, indices, indptr
 
 

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -3,7 +3,8 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import TestCase, run_module_suite, assert_equal
+from numpy.testing import TestCase, run_module_suite, assert_equal, dec, \
+     assert_array_equal
 from scipy.sparse import sputils
 
 
@@ -66,6 +67,24 @@ class TestSparseUtils(TestCase):
     def test_isdense(self):
         assert_equal(sputils.isdense(np.array([1])),True)
         assert_equal(sputils.isdense(np.matrix([1])),True)
+
+    def test_compat_unique(self):
+        x = np.array([0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1,
+                      2, 2, 2, 2, 2, 2, 2, 3, 3,3, 3, 3, 3, 3,
+                      4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5,
+                      6, 6, 6, 6,6, 6, 6, 7, 7, 7, 7, 7, 7, 7,
+                      8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9,9],
+                     dtype=np.int32)
+        y, j1 = sputils._compat_unique_impl(x, return_index=True)
+        j2 = np.array([ 0,  7, 14, 21, 28, 35, 42, 49, 56, 63])
+        assert_array_equal(j1, j2)
+
+    def test_compat_bincount(self):
+        x = np.arange(4)
+        y1 = sputils._compat_bincount_impl(x, minlength=10)
+        y2 = np.array([1, 1, 1, 1, 0, 0, 0, 0, 0, 0])
+        assert_array_equal(y1, y2)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Add compatibility routine for bincount. Fix a bug in test preparation.
Add some tests for the compatibility routines.

Should fix the remaining issues in gh-3330
