### PR TITLE
ENH: change to use array view in signal/_peak_finding.py

### DIFF
--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -392,9 +392,9 @@ def _filter_ridge_lines(cwt, ridge_lines, window_size=None, min_length=None,
     row_one = cwt[0, :]
     noises = np.zeros_like(row_one)
     for ind, val in enumerate(row_one):
-        window = np.arange(max([ind - hf_window, 0]), min([ind + hf_window, num_points]))
-        window = window.astype(int)
-        noises[ind] = scoreatpercentile(row_one[window], per=noise_perc)
+        window_start = int(max(ind - hf_window, 0))
+        window_end = int(min(ind + hf_window, num_points))
+        noises[ind] = scoreatpercentile(row_one[window_start:window_end], per=noise_perc)
 
     def filt_func(line):
         if len(line[0]) < min_length:

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -386,14 +386,16 @@ def _filter_ridge_lines(cwt, ridge_lines, window_size=None, min_length=None,
         min_length = np.ceil(cwt.shape[0] / 4)
     if window_size is None:
         window_size = np.ceil(num_points / 20)
-    hf_window = window_size / 2
+
+    window_size = int(window_size)
+    hf_window, odd = divmod(window_size, 2)
 
     #Filter based on SNR
     row_one = cwt[0, :]
     noises = np.zeros_like(row_one)
     for ind, val in enumerate(row_one):
-        window_start = int(max(ind - hf_window, 0))
-        window_end = int(min(ind + hf_window, num_points))
+        window_start = max(ind - hf_window, 0)
+        window_end = min(ind + hf_window + odd, num_points)
         noises[ind] = scoreatpercentile(row_one[window_start:window_end], per=noise_perc)
 
     def filt_func(line):

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -396,7 +396,8 @@ def _filter_ridge_lines(cwt, ridge_lines, window_size=None, min_length=None,
     for ind, val in enumerate(row_one):
         window_start = max(ind - hf_window, 0)
         window_end = min(ind + hf_window + odd, num_points)
-        noises[ind] = scoreatpercentile(row_one[window_start:window_end], per=noise_perc)
+        noises[ind] = scoreatpercentile(row_one[window_start:window_end],
+                                        per=noise_perc)
 
     def filt_func(line):
         if len(line[0]) < min_length:


### PR DESCRIPTION
Unnecessary call to `arange` and copying of data. Changed to call `scoreatpercentile` on a view of the array `row_one` .
