### PR TITLE
TST: signal: loosen some error tolerances in the filter tests.  Closes gh-3412.

### DIFF
--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -460,7 +460,7 @@ class TestCheb2ord(TestCase):
 
         assert_equal(N, 10)
         assert_allclose(Wn, [0.19926249974781743, 0.50125246585567362],
-                        rtol=1e-15)
+                        rtol=1e-6)
 
     def test_analog(self):
         wp = [20, 50]
@@ -821,7 +821,7 @@ class TestButter(TestCase):
         assert_array_equal(z, z2)
         assert_allclose(sorted(p, key=np.imag),
                         sorted(p2, key=np.imag), rtol=1e-13)
-        assert_allclose(k, k2, rtol=1e-15)
+        assert_allclose(k, k2, rtol=1e-13)
 
         # bandpass analog
         z, p, k = butter(4, [90.5, 110.5], 'bp', analog=True, output='zpk')


### PR DESCRIPTION
With these tolerances, the tests that failed in gh-3412 now pass.

@endolith: I think you created these tests.  Those error tolerances were pretty tight.  Do you have a reason to expect such high accuracy?  If so, I have some more debugging to do with my setup.
