### PR TITLE
BUG: tools: Fix list of FMA instructions in detect_cpu_extensions_wine.py

### DIFF
--- a/tools/win32/detect_cpu_extensions_wine.py
+++ b/tools/win32/detect_cpu_extensions_wine.py
@@ -137,7 +137,7 @@ EXTS_simd = dict(
     sse4_1='mpsadbw phminposuw pmulld pmuldq     dpps dppd     blendps blendpd blendvps blendvpd pblendvb pblendw     pminsb pmaxsb pminuw pmaxuw pminud pmaxud pminsd pmaxsd     roundps roundss roundpd roundsd     insertps pinsrb pinsrd/pinsrq extractps pextrb pextrw pextrd/pextrq     pmovsxbw pmovzxbw pmovsxbd pmovzxbd pmovsxbq pmovzxbq pmovsxwd pmovzxwd pmovsxwq pmovzxwq pmovsxdq pmovzxdq     ptest     pcmpeqq     packusdw     movntdqa',
     sse4a='extrq insertq movntsd movntss',
     sse4_2='crc32     pcmpestri     pcmpestrm     pcmpistri     pcmpistrm     pcmpgtq',
-    fma='vfmaddpd vfmaddps vfmaddsd vfmaddss vfmaddsubpd vfmaddsubps vfmsubaddpd vfmsubaddps vfmsubpd vfmsubps vfmsubsd vfmsubss vfnmaddpd fndmaddps vfnmaddsd vfnmadss vfnmsubpd vfnmsubpd vfnmsubps vfnmsubsd vfnmsubss',
+    fma='vfmaddpd vfmaddps vfmaddsd vfmaddss vfmaddsubpd vfmaddsubps vfmsubaddpd vfmsubaddps vfmsubpd vfmsubps vfmsubsd vfmsubss vfnmaddpd vfnmaddps vfnmaddsd vfnmadss vfnmsubpd vfnmsubps vfnmsubsd vfnmsubss',
 )
 
 INSTRS = dict()


### PR DESCRIPTION
Looks like there was a typo and a duplicated entry in the list of FMA instructions.  The list now matches the list given here: http://en.wikipedia.org/wiki/X86_instruction_listings#FMA_instructions
