### PR TITLE
DOC: stats: Add 'entropy' to the stats package-level documentation.

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -284,6 +284,8 @@ which work for masked arrays.
    boxcox_normmax
    boxcox_llf
 
+   entropy
+
 Contingency table functions
 ===========================
 


### PR DESCRIPTION
It was noted (indirectly) in a comment on an answer to http://stackoverflow.com/questions/22097409/kl-divergence-of-continuous-pdfs that `entropy` is not in the scipy.stats module docstring.

I put it at the end of the list, because its arguments are qualitatively different from most of the other statistical functions in the module.
