### PR TITLE
ENH: special: faster expit (logistic sigmoid)

### DIFF
--- a/scipy/special/_logit.c.src
+++ b/scipy/special/_logit.c.src
@@ -33,7 +33,7 @@
         return x / (1 + x);
     }
     else {
-        return 1 / (1 + npy_exp@c@(-x));
+        return .5 * (1 + npy_tanh@c@(.5 * x));
     }
 }
 


### PR DESCRIPTION
Follow-up to #3386. I obtained a ~1/6 speed increase in `scipy.special.expit` by reducing it to tanh in the usual way. Stability is preserved.

This is important to me since expit evaluations are a bottleneck in neural net training, second only to matrix multiplication.
