### PR TITLE
Added 'eps' in scipy.optimize.show_options for L-BFGS-B

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2675,6 +2675,8 @@ def show_options(solver=None, method=None):
             The iteration will stop when ``max{|proj g_i | i = 1, ..., n}
             <= gtol`` where ``pg_i`` is the i-th component of the
             projected gradient.
+        eps : float or ndarray
+            If `jac` is approximated, use this value for the step size.            
         maxcor : int
             The maximum number of variable metric corrections used to
             define the limited memory matrix. (The limited memory BFGS


### PR DESCRIPTION
In scipy.optimize.minimize, when algorithm is L-BFGS-B, there is an
option called eps. However, this options is missing if we use
scipy.optimize.show_options('minimize', 'L-BFGS-B') to look up its
options.
