### PR TITLE
BUG: close intermediate file descriptor right after it is used in netcdf.py

### DIFF
--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -595,6 +595,8 @@ class netcdf_file(object):
                     mm = mmap(self.fp.fileno(), begin_+a_size, access=ACCESS_READ)
                     data = ndarray.__new__(ndarray, shape, dtype=dtype_,
                                            buffer=mm, offset=begin_, order=0).copy()
+                    if self.mode is 'r':
+                        data.flags.writeable = False
                     mm.close()
                 else:
                     pos = self.fp.tell()
@@ -618,6 +620,8 @@ class netcdf_file(object):
                 mm = mmap(self.fp.fileno(), begin+self._recs*self._recsize, access=ACCESS_READ)
                 rec_array = ndarray.__new__(ndarray, (self._recs,), dtype=dtypes,
                                             buffer=mm, offset=begin, order=0).copy()
+                if self.mode is 'r':
+                    rec_array.flags.writeable = False
                 mm.close()
             else:
                 pos = self.fp.tell()

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -198,7 +198,6 @@ class netcdf_file(object):
             if mmap is None:
                 mmap = True
         self.use_mmap = mmap
-        self._fds = []
         self.version_byte = version
 
         if not mode in 'rw':
@@ -231,8 +230,6 @@ class netcdf_file(object):
         if not self.fp.closed:
             try:
                 self.flush()
-                for mmap_fd in self._fds:
-                    mmap_fd.close()
             finally:
                 self.fp.close()
     __del__ = close
@@ -598,7 +595,7 @@ class netcdf_file(object):
                     mm = mmap(self.fp.fileno(), begin_+a_size, access=ACCESS_READ)
                     data = ndarray.__new__(ndarray, shape, dtype=dtype_,
                             buffer=mm, offset=begin_, order=0)
-                    self._fds.append(mm)
+                    mm.close()
                 else:
                     pos = self.fp.tell()
                     self.fp.seek(begin_)
@@ -621,7 +618,7 @@ class netcdf_file(object):
                 mm = mmap(self.fp.fileno(), begin+self._recs*self._recsize, access=ACCESS_READ)
                 rec_array = ndarray.__new__(ndarray, (self._recs,), dtype=dtypes,
                         buffer=mm, offset=begin, order=0)
-                self._fds.append(mm)
+                mm.close()
             else:
                 pos = self.fp.tell()
                 self.fp.seek(begin)

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -594,7 +594,7 @@ class netcdf_file(object):
                 if self.use_mmap:
                     mm = mmap(self.fp.fileno(), begin_+a_size, access=ACCESS_READ)
                     data = ndarray.__new__(ndarray, shape, dtype=dtype_,
-                            buffer=mm, offset=begin_, order=0)
+                                           buffer=mm, offset=begin_, order=0).copy()
                     mm.close()
                 else:
                     pos = self.fp.tell()
@@ -617,7 +617,7 @@ class netcdf_file(object):
             if self.use_mmap:
                 mm = mmap(self.fp.fileno(), begin+self._recs*self._recsize, access=ACCESS_READ)
                 rec_array = ndarray.__new__(ndarray, (self._recs,), dtype=dtypes,
-                        buffer=mm, offset=begin, order=0)
+                                            buffer=mm, offset=begin, order=0).copy()
                 mm.close()
             else:
                 pos = self.fp.tell()

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -135,6 +135,13 @@ def test_itemset_no_segfault_on_readonly():
     # time_var.assignValue(42) should raise a RuntimeError--not seg. fault!
     assert_raises(RuntimeError, time_var.assignValue, 42)
 
+    # test without mmap
+    with netcdf_file(filename, 'r', mmap=False) as f:
+        time_var = f.variables['time']
+
+    # time_var.assignValue(42) should raise a RuntimeError--not seg. fault!
+    assert_raises(RuntimeError, time_var.assignValue, 42)
+
 
 def test_write_invalid_dtype():
     dtypes = ['int64', 'uint64']


### PR DESCRIPTION
netcdf opens intermediate file descriptors and they are closed when the main file descriptor is closed.  But this causes a too many open files error when the number of intermediate descriptors are too many.  This patch closes the intermediate file descriptor right after it is used.
