### PR TITLE
MAINT: Fix some cython variable declarations to avoid warnings with cython 0.20.

### DIFF
--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -274,7 +274,9 @@ def real_roots(double[:,:,::1] c, double[::1] x, int report_discont,
     cdef list cur_roots
     cdef int interval, jp, k, i, p
 
-    cdef double *wr, *wi, last_root, va, vb
+    cdef double *wr
+    cdef double *wi
+    cdef double last_root, va, vb
     cdef double f, df, dx
     cdef void *workspace
 
@@ -556,7 +558,9 @@ cdef int croots_poly1(double[:,:,::1] c, int ci, int cj, double* wr, double* wi,
     Uses LAPACK + the companion matrix method.
 
     """
-    cdef double *a, *work, a0, a1, a2, d, br, bi
+    cdef double *a
+    cdef double *work
+    cdef double a0, a1, a2, d, br, bi
     cdef int lwork, n, i, j, order
     cdef int nworkspace, info
 
@@ -681,7 +685,8 @@ def _croots_poly1(double[:,:,::1] c, double_complex[:,:,::1] w):
 
     """
 
-    cdef double *wr, *wi
+    cdef double *wr
+    cdef double *wi
     cdef void *workspace
     cdef int i, j, k, nroots
 

--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -348,7 +348,8 @@ cdef int _estimate_gradients_2d_global(qhull.DelaunayInfo_t *d, double *data,
 
     """
     cdef double Q[2*2]
-    cdef double s[2], r[2]
+    cdef double s[2]
+    cdef double r[2]
     cdef int ipoint, iiter, k, ipoint2, jpoint2
     cdef double f1, f2, df2, ex, ey, L, L3, det, err, change
 

--- a/scipy/io/matlab/streams.pyx
+++ b/scipy/io/matlab/streams.pyx
@@ -159,7 +159,8 @@ cdef class ZlibInputStream(GenericStream):
     cdef int read_into(self, void *buf, size_t n) except -1:
         """Read n bytes from stream into pre-allocated buffer `buf`
         """
-        cdef char *dstp, *srcp
+        cdef char *dstp
+        cdef char *srcp
         cdef size_t read_size, count, size
 
         dstp = <char*>buf

--- a/scipy/ndimage/src/_ni_label.pyx
+++ b/scipy/ndimage/src/_ni_label.pyx
@@ -242,14 +242,18 @@ cpdef _label(np.ndarray input,
         write_line_func_t write_line = \
             <write_line_func_t> <void *> <Py_intptr_t> get_write_line(output.take([0]))
         np.flatiter _iti, _ito, _itstruct
-        PyArrayIterObject *iti, *ito, *itstruct
+        PyArrayIterObject *iti
+        PyArrayIterObject *ito
+        PyArrayIterObject *itstruct
         int axis, idim, num_neighbors, ni
         np.intp_t L, delta, i
         np.intp_t si, so, ss
         np.intp_t total_offset
         bint needs_self_labeling, valid, center, use_previous, overflowed
         np.ndarray _line_buffer, _neighbor_buffer
-        np.uintp_t *line_buffer, *neighbor_buffer, *tmp
+        np.uintp_t *line_buffer
+        np.uintp_t *neighbor_buffer
+        np.uintp_t *tmp
         np.uintp_t next_region, src_label, dest_label
         int mergetable_size
         np.uintp_t *mergetable

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -475,7 +475,8 @@ cdef _dijkstra_directed(
     cdef int return_pred = (pred.size > 0)
 
     cdef FibonacciHeap heap
-    cdef FibonacciNode *v, *current_node
+    cdef FibonacciNode *v
+    cdef FibonacciNode *current_node
     cdef FibonacciNode* nodes = <FibonacciNode*> malloc(N *
                                                         sizeof(FibonacciNode))
 
@@ -538,7 +539,8 @@ cdef _dijkstra_undirected(
     cdef int return_pred = (pred.size > 0)
 
     cdef FibonacciHeap heap
-    cdef FibonacciNode *v, *current_node
+    cdef FibonacciNode *v
+    cdef FibonacciNode *current_node
     cdef FibonacciNode* nodes = <FibonacciNode*> malloc(N *
                                                         sizeof(FibonacciNode))
 
@@ -1202,7 +1204,9 @@ cdef void link(FibonacciHeap* heap, FibonacciNode* node):
     #              - node is a valid pointer
     #              - node is already within heap
 
-    cdef FibonacciNode *linknode, *parent, *child
+    cdef FibonacciNode *linknode
+    cdef FibonacciNode *parent
+    cdef FibonacciNode *child
 
     if heap.roots_by_rank[node.rank] == NULL:
         heap.roots_by_rank[node.rank] = node
@@ -1223,7 +1227,9 @@ cdef void link(FibonacciHeap* heap, FibonacciNode* node):
 cdef FibonacciNode* remove_min(FibonacciHeap* heap):
     # Assumptions: - heap is a valid pointer
     #              - heap.min_node is a valid pointer
-    cdef FibonacciNode *temp, *temp_right, *out
+    cdef FibonacciNode *temp
+    cdef FibonacciNode *temp_right
+    cdef FibonacciNode *out
     cdef unsigned int i
 
     # make all min_node children into root nodes

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -203,7 +203,8 @@ cdef class coo_entries:
         np.intp_t n, n_max
         np.ndarray i, j
         np.ndarray v
-        np.intp_t  *i_data, *j_data
+        np.intp_t *i_data
+        np.intp_t *j_data
         np.float64_t *v_data
     
     def __init__(self):
@@ -1408,7 +1409,8 @@ cdef class cKDTree:
                                                     list results,
                                                     innernode* node1,
                                                     innernode* node2) except -1:
-        cdef leafnode *lnode1, *lnode2
+        cdef leafnode *lnode1
+        cdef leafnode *lnode2
         cdef list results_i
         cdef np.intp_t i, j
         
@@ -1441,7 +1443,8 @@ cdef class cKDTree:
                                                  innernode* node1,
                                                  innernode* node2,
                                                  RectRectDistanceTracker tracker) except -1:
-        cdef leafnode *lnode1, *lnode2
+        cdef leafnode *lnode1
+        cdef leafnode *lnode2
         cdef list results_i
         cdef np.float64_t d
         cdef np.intp_t i, j
@@ -1575,7 +1578,8 @@ cdef class cKDTree:
                                                 set results,
                                                 innernode* node1,
                                                 innernode* node2) except -1:
-        cdef leafnode *lnode1, *lnode2
+        cdef leafnode *lnode1
+        cdef leafnode *lnode2
         cdef list results_i
         cdef np.intp_t i, j, min_j
         
@@ -1621,7 +1625,8 @@ cdef class cKDTree:
                                              innernode* node1,
                                              innernode* node2,
                                              RectRectDistanceTracker tracker) except -1:
-        cdef leafnode *lnode1, *lnode2
+        cdef leafnode *lnode1
+        cdef leafnode *lnode2
         cdef list results_i
         cdef np.float64_t d
         cdef np.intp_t i, j, min_j
@@ -1762,7 +1767,8 @@ cdef class cKDTree:
                                         innernode* node1,
                                         innernode* node2,
                                         RectRectDistanceTracker tracker) except -1:
-        cdef leafnode *lnode1, *lnode2
+        cdef leafnode *lnode1
+        cdef leafnode *lnode2
         cdef np.float64_t d
         cdef np.intp_t *old_idx
         cdef np.intp_t old_n_queries, l, i, j
@@ -1946,7 +1952,8 @@ cdef class cKDTree:
                                                coo_entries results,
                                                innernode* node1, innernode* node2,
                                                RectRectDistanceTracker tracker) except -1:
-        cdef leafnode *lnode1, *lnode2
+        cdef leafnode *lnode1
+        cdef leafnode *lnode2
         cdef list results_i
         cdef np.float64_t d
         cdef np.intp_t i, j, min_j

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -848,8 +848,11 @@ cdef class _Qhull:
         See qhull/io.c:qh_printextremes_2d
 
         """
-        cdef facetT *facet, *startfacet, *nextfacet
-        cdef vertexT *vertexA, *vertexB
+        cdef facetT *facet
+        cdef facetT *startfacet
+        cdef facetT *nextfacet
+        cdef vertexT *vertexA
+        cdef vertexT *vertexB
         cdef int[:] extremes
         cdef int nextremes
 
@@ -990,7 +993,8 @@ def _get_barycentric_transforms(np.ndarray[np.double_t, ndim=2] points,
     cdef int i, j, n, nrhs, lda, ldb, info
     cdef int ipiv[NPY_MAXDIMS+1]
     cdef int ndim, nsimplex
-    cdef double centroid[NPY_MAXDIMS], c[NPY_MAXDIMS+1]
+    cdef double centroid[NPY_MAXDIMS]
+    cdef double c[NPY_MAXDIMS+1]
     cdef double *transform
     cdef double anorm, rcond
     cdef double nan, rcond_limit

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -70,7 +70,11 @@ cdef void loop_d_dddd__As_ffff_f(char **args, np.npy_intp *dims, np.npy_intp *st
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *ip3 = args[3], *op0 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
     cdef double ov0
     for i in range(n):
         ov0 = (<double(*)(double, double, double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0])
@@ -86,7 +90,8 @@ cdef void loop_f_f__As_f_f(char **args, np.npy_intp *dims, np.npy_intp *steps, v
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
     cdef float ov0
     for i in range(n):
         ov0 = (<float(*)(float) nogil>func)(<float>(<float*>ip0)[0])
@@ -99,7 +104,11 @@ cdef void loop_d_ddi_d_As_ddl_dd(char **args, np.npy_intp *dims, np.npy_intp *st
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3], *op1 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef char *op1 = args[4]
     cdef double ov0
     cdef double ov1
     for i in range(n):
@@ -122,7 +131,13 @@ cdef void loop_i_ddddd_dd_As_ddddd_dd(char **args, np.npy_intp *dims, np.npy_int
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *ip3 = args[3], *ip4 = args[4], *op0 = args[5], *op1 = args[6]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *ip4 = args[4]
+    cdef char *op0 = args[5]
+    cdef char *op1 = args[6]
     cdef double ov0
     cdef double ov1
     for i in range(n):
@@ -142,7 +157,9 @@ cdef void loop_D_dD__As_dD_D(char **args, np.npy_intp *dims, np.npy_intp *steps,
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
     cdef double complex ov0
     for i in range(n):
         ov0 = (<double complex(*)(double, double complex) nogil>func)(<double>(<double*>ip0)[0], <double complex>(<double complex*>ip1)[0])
@@ -156,7 +173,9 @@ cdef void loop_i_d_dd_As_d_dd(char **args, np.npy_intp *dims, np.npy_intp *steps
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1], *op1 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
     cdef double ov0
     cdef double ov1
     for i in range(n):
@@ -172,7 +191,9 @@ cdef void loop_D_DD__As_DD_D(char **args, np.npy_intp *dims, np.npy_intp *steps,
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
     cdef double complex ov0
     for i in range(n):
         ov0 = (<double complex(*)(double complex, double complex) nogil>func)(<double complex>(<double complex*>ip0)[0], <double complex>(<double complex*>ip1)[0])
@@ -186,7 +207,8 @@ cdef void loop_D_D__As_D_D(char **args, np.npy_intp *dims, np.npy_intp *steps, v
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
     cdef double complex ov0
     for i in range(n):
         ov0 = (<double complex(*)(double complex) nogil>func)(<double complex>(<double complex*>ip0)[0])
@@ -199,7 +221,12 @@ cdef void loop_d_dddi_d_As_fffl_ff(char **args, np.npy_intp *dims, np.npy_intp *
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *ip3 = args[3], *op0 = args[4], *op1 = args[5]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef char *op1 = args[5]
     cdef double ov0
     cdef double ov1
     for i in range(n):
@@ -223,7 +250,9 @@ cdef void loop_i_D_DD_As_F_FF(char **args, np.npy_intp *dims, np.npy_intp *steps
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1], *op1 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
     cdef double complex ov0
     cdef double complex ov1
     for i in range(n):
@@ -239,7 +268,11 @@ cdef void loop_i_d_DDDD_As_f_FFFF(char **args, np.npy_intp *dims, np.npy_intp *s
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1], *op1 = args[2], *op2 = args[3], *op3 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
     cdef double complex ov0
     cdef double complex ov1
     cdef double complex ov2
@@ -261,7 +294,11 @@ cdef void loop_i_D_DDDD_As_F_FFFF(char **args, np.npy_intp *dims, np.npy_intp *s
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1], *op1 = args[2], *op2 = args[3], *op3 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
     cdef double complex ov0
     cdef double complex ov1
     cdef double complex ov2
@@ -283,7 +320,12 @@ cdef void loop_d_dddi_d_As_dddl_dd(char **args, np.npy_intp *dims, np.npy_intp *
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *ip3 = args[3], *op0 = args[4], *op1 = args[5]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef char *op1 = args[5]
     cdef double ov0
     cdef double ov1
     for i in range(n):
@@ -307,7 +349,10 @@ cdef void loop_d_ldd__As_ldd_d(char **args, np.npy_intp *dims, np.npy_intp *step
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
     cdef double ov0
     for i in range(n):
         ov0 = (<double(*)(long, double, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0])
@@ -322,7 +367,10 @@ cdef void loop_d_ddd__As_fff_f(char **args, np.npy_intp *dims, np.npy_intp *step
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
     cdef double ov0
     for i in range(n):
         ov0 = (<double(*)(double, double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0])
@@ -337,7 +385,9 @@ cdef void loop_d_dd__As_ff_f(char **args, np.npy_intp *dims, np.npy_intp *steps,
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
     cdef double ov0
     for i in range(n):
         ov0 = (<double(*)(double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0])
@@ -351,7 +401,12 @@ cdef void loop_i_dd_dddd_As_ff_ffff(char **args, np.npy_intp *dims, np.npy_intp 
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2], *op1 = args[3], *op2 = args[4], *op3 = args[5]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef char *op1 = args[3]
+    cdef char *op2 = args[4]
+    cdef char *op3 = args[5]
     cdef double ov0
     cdef double ov1
     cdef double ov2
@@ -374,7 +429,10 @@ cdef void loop_i_dd_dd_As_dd_dd(char **args, np.npy_intp *dims, np.npy_intp *ste
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2], *op1 = args[3]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef char *op1 = args[3]
     cdef double ov0
     cdef double ov1
     for i in range(n):
@@ -391,7 +449,11 @@ cdef void loop_i_ddd_dd_As_fff_ff(char **args, np.npy_intp *dims, np.npy_intp *s
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3], *op1 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef char *op1 = args[4]
     cdef double ov0
     cdef double ov1
     for i in range(n):
@@ -409,7 +471,10 @@ cdef void loop_D_ddD__As_ddD_D(char **args, np.npy_intp *dims, np.npy_intp *step
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
     cdef double complex ov0
     for i in range(n):
         ov0 = (<double complex(*)(double, double, double complex) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double complex>(<double complex*>ip2)[0])
@@ -424,7 +489,11 @@ cdef void loop_D_dddD__As_dddD_D(char **args, np.npy_intp *dims, np.npy_intp *st
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *ip3 = args[3], *op0 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
     cdef double complex ov0
     for i in range(n):
         ov0 = (<double complex(*)(double, double, double, double complex) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double complex>(<double complex*>ip3)[0])
@@ -440,7 +509,11 @@ cdef void loop_i_d_dddd_As_d_dddd(char **args, np.npy_intp *dims, np.npy_intp *s
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1], *op1 = args[2], *op2 = args[3], *op3 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
     cdef double ov0
     cdef double ov1
     cdef double ov2
@@ -462,7 +535,13 @@ cdef void loop_i_ddddd_dd_As_fffff_ff(char **args, np.npy_intp *dims, np.npy_int
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *ip3 = args[3], *ip4 = args[4], *op0 = args[5], *op1 = args[6]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *ip4 = args[4]
+    cdef char *op0 = args[5]
+    cdef char *op1 = args[6]
     cdef double ov0
     cdef double ov1
     for i in range(n):
@@ -482,7 +561,8 @@ cdef void loop_D_D__As_F_F(char **args, np.npy_intp *dims, np.npy_intp *steps, v
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
     cdef double complex ov0
     for i in range(n):
         ov0 = (<double complex(*)(double complex) nogil>func)(<double complex>(<float complex*>ip0)[0])
@@ -495,7 +575,11 @@ cdef void loop_i_d_DDDD_As_d_DDDD(char **args, np.npy_intp *dims, np.npy_intp *s
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1], *op1 = args[2], *op2 = args[3], *op3 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
     cdef double complex ov0
     cdef double complex ov1
     cdef double complex ov2
@@ -517,7 +601,11 @@ cdef void loop_i_ddd_dd_As_ddd_dd(char **args, np.npy_intp *dims, np.npy_intp *s
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3], *op1 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef char *op1 = args[4]
     cdef double ov0
     cdef double ov1
     for i in range(n):
@@ -535,7 +623,10 @@ cdef void loop_D_Dld__As_Dld_D(char **args, np.npy_intp *dims, np.npy_intp *step
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
     cdef double complex ov0
     for i in range(n):
         ov0 = (<double complex(*)(double complex, long, double) nogil>func)(<double complex>(<double complex*>ip0)[0], <long>(<long*>ip1)[0], <double>(<double*>ip2)[0])
@@ -550,7 +641,11 @@ cdef void loop_d_ddi_d_As_ffl_ff(char **args, np.npy_intp *dims, np.npy_intp *st
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3], *op1 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef char *op1 = args[4]
     cdef double ov0
     cdef double ov1
     for i in range(n):
@@ -573,7 +668,10 @@ cdef void loop_i_dd_dd_As_ff_ff(char **args, np.npy_intp *dims, np.npy_intp *ste
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2], *op1 = args[3]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef char *op1 = args[3]
     cdef double ov0
     cdef double ov1
     for i in range(n):
@@ -590,7 +688,11 @@ cdef void loop_D_dddD__As_fffF_F(char **args, np.npy_intp *dims, np.npy_intp *st
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *ip3 = args[3], *op0 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
     cdef double complex ov0
     for i in range(n):
         ov0 = (<double complex(*)(double, double, double, double complex) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double complex>(<float complex*>ip3)[0])
@@ -606,7 +708,9 @@ cdef void loop_d_id__As_lf_f(char **args, np.npy_intp *dims, np.npy_intp *steps,
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
     cdef double ov0
     for i in range(n):
         if <int>(<long*>ip0)[0] == (<long*>ip0)[0]:
@@ -624,7 +728,11 @@ cdef void loop_d_dddd__As_dddd_d(char **args, np.npy_intp *dims, np.npy_intp *st
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *ip3 = args[3], *op0 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
     cdef double ov0
     for i in range(n):
         ov0 = (<double(*)(double, double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
@@ -640,7 +748,9 @@ cdef void loop_D_DD__As_FF_F(char **args, np.npy_intp *dims, np.npy_intp *steps,
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
     cdef double complex ov0
     for i in range(n):
         ov0 = (<double complex(*)(double complex, double complex) nogil>func)(<double complex>(<float complex*>ip0)[0], <double complex>(<float complex*>ip1)[0])
@@ -654,7 +764,10 @@ cdef void loop_d_iid__As_lld_d(char **args, np.npy_intp *dims, np.npy_intp *step
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
     cdef double ov0
     for i in range(n):
         if <int>(<long*>ip0)[0] == (<long*>ip0)[0] and <int>(<long*>ip1)[0] == (<long*>ip1)[0]:
@@ -673,7 +786,9 @@ cdef void loop_i_d_DD_As_d_DD(char **args, np.npy_intp *dims, np.npy_intp *steps
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1], *op1 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
     cdef double complex ov0
     cdef double complex ov1
     for i in range(n):
@@ -689,7 +804,8 @@ cdef void loop_d_d__As_f_f(char **args, np.npy_intp *dims, np.npy_intp *steps, v
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
     cdef double ov0
     for i in range(n):
         ov0 = (<double(*)(double) nogil>func)(<double>(<float*>ip0)[0])
@@ -702,7 +818,8 @@ cdef void loop_d_d__As_d_d(char **args, np.npy_intp *dims, np.npy_intp *steps, v
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
     cdef double ov0
     for i in range(n):
         ov0 = (<double(*)(double) nogil>func)(<double>(<double*>ip0)[0])
@@ -715,7 +832,12 @@ cdef void loop_d_dddd_d_As_ffff_ff(char **args, np.npy_intp *dims, np.npy_intp *
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *ip3 = args[3], *op0 = args[4], *op1 = args[5]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef char *op1 = args[5]
     cdef double ov0
     cdef double ov1
     for i in range(n):
@@ -734,7 +856,10 @@ cdef void loop_d_iid__As_llf_f(char **args, np.npy_intp *dims, np.npy_intp *step
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
     cdef double ov0
     for i in range(n):
         if <int>(<long*>ip0)[0] == (<long*>ip0)[0] and <int>(<long*>ip1)[0] == (<long*>ip1)[0]:
@@ -753,7 +878,11 @@ cdef void loop_d_lddd__As_lddd_d(char **args, np.npy_intp *dims, np.npy_intp *st
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *ip3 = args[3], *op0 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
     cdef double ov0
     for i in range(n):
         ov0 = (<double(*)(long, double, double, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
@@ -769,7 +898,10 @@ cdef void loop_D_ddD__As_ffF_F(char **args, np.npy_intp *dims, np.npy_intp *step
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
     cdef double complex ov0
     for i in range(n):
         ov0 = (<double complex(*)(double, double, double complex) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double complex>(<float complex*>ip2)[0])
@@ -784,7 +916,11 @@ cdef void loop_i_d_dddd_As_f_ffff(char **args, np.npy_intp *dims, np.npy_intp *s
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1], *op1 = args[2], *op2 = args[3], *op3 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
     cdef double ov0
     cdef double ov1
     cdef double ov2
@@ -806,7 +942,11 @@ cdef void loop_d_lddd__As_lfff_f(char **args, np.npy_intp *dims, np.npy_intp *st
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *ip3 = args[3], *op0 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
     cdef double ov0
     for i in range(n):
         ov0 = (<double(*)(long, double, double, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0])
@@ -822,7 +962,12 @@ cdef void loop_d_dddd_d_As_dddd_dd(char **args, np.npy_intp *dims, np.npy_intp *
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *ip3 = args[3], *op0 = args[4], *op1 = args[5]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef char *op1 = args[5]
     cdef double ov0
     cdef double ov1
     for i in range(n):
@@ -841,7 +986,9 @@ cdef void loop_i_D_DD_As_D_DD(char **args, np.npy_intp *dims, np.npy_intp *steps
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1], *op1 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
     cdef double complex ov0
     cdef double complex ov1
     for i in range(n):
@@ -857,7 +1004,10 @@ cdef void loop_D_Dld__As_Flf_F(char **args, np.npy_intp *dims, np.npy_intp *step
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
     cdef double complex ov0
     for i in range(n):
         ov0 = (<double complex(*)(double complex, long, double) nogil>func)(<double complex>(<float complex*>ip0)[0], <long>(<long*>ip1)[0], <double>(<float*>ip2)[0])
@@ -872,7 +1022,12 @@ cdef void loop_i_dd_dddd_As_dd_dddd(char **args, np.npy_intp *dims, np.npy_intp 
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2], *op1 = args[3], *op2 = args[4], *op3 = args[5]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef char *op1 = args[3]
+    cdef char *op2 = args[4]
+    cdef char *op3 = args[5]
     cdef double ov0
     cdef double ov1
     cdef double ov2
@@ -895,7 +1050,9 @@ cdef void loop_D_dD__As_fF_F(char **args, np.npy_intp *dims, np.npy_intp *steps,
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
     cdef double complex ov0
     for i in range(n):
         ov0 = (<double complex(*)(double, double complex) nogil>func)(<double>(<float*>ip0)[0], <double complex>(<float complex*>ip1)[0])
@@ -909,7 +1066,9 @@ cdef void loop_i_d_dd_As_f_ff(char **args, np.npy_intp *dims, np.npy_intp *steps
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1], *op1 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
     cdef double ov0
     cdef double ov1
     for i in range(n):
@@ -925,7 +1084,9 @@ cdef void loop_d_ld__As_lf_f(char **args, np.npy_intp *dims, np.npy_intp *steps,
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
     cdef double ov0
     for i in range(n):
         ov0 = (<double(*)(long, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<float*>ip1)[0])
@@ -939,7 +1100,9 @@ cdef void loop_d_id__As_ld_d(char **args, np.npy_intp *dims, np.npy_intp *steps,
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
     cdef double ov0
     for i in range(n):
         if <int>(<long*>ip0)[0] == (<long*>ip0)[0]:
@@ -957,7 +1120,9 @@ cdef void loop_d_dd__As_dd_d(char **args, np.npy_intp *dims, np.npy_intp *steps,
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
     cdef double ov0
     for i in range(n):
         ov0 = (<double(*)(double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0])
@@ -971,7 +1136,9 @@ cdef void loop_i_d_DD_As_f_FF(char **args, np.npy_intp *dims, np.npy_intp *steps
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1], *op1 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
     cdef double complex ov0
     cdef double complex ov1
     for i in range(n):
@@ -987,7 +1154,10 @@ cdef void loop_d_ddd__As_ddd_d(char **args, np.npy_intp *dims, np.npy_intp *step
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
     cdef double ov0
     for i in range(n):
         ov0 = (<double(*)(double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0])
@@ -1002,7 +1172,11 @@ cdef void loop_i_D_DDDD_As_D_DDDD(char **args, np.npy_intp *dims, np.npy_intp *s
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1], *op1 = args[2], *op2 = args[3], *op3 = args[4]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
     cdef double complex ov0
     cdef double complex ov1
     cdef double complex ov2
@@ -1024,7 +1198,8 @@ cdef void loop_g_g__As_g_g(char **args, np.npy_intp *dims, np.npy_intp *steps, v
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *op0 = args[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
     cdef long double ov0
     for i in range(n):
         ov0 = (<long double(*)(long double) nogil>func)(<long double>(<long double*>ip0)[0])
@@ -1037,7 +1212,10 @@ cdef void loop_d_ldd__As_lff_f(char **args, np.npy_intp *dims, np.npy_intp *step
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *ip2 = args[2], *op0 = args[3]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
     cdef double ov0
     for i in range(n):
         ov0 = (<double(*)(long, double, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0])
@@ -1052,7 +1230,9 @@ cdef void loop_d_ld__As_ld_d(char **args, np.npy_intp *dims, np.npy_intp *steps,
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0], *ip1 = args[1], *op0 = args[2]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
     cdef double ov0
     for i in range(n):
         ov0 = (<double(*)(long, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<double*>ip1)[0])

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -507,12 +507,10 @@ def generate_loop(func_inputs, func_outputs, func_retval,
     body += "    cdef void *func = (<void**>data)[0]\n"
     body += "    cdef char *func_name = <char*>(<void**>data)[1]\n"
 
-    pointers = []
     for j in range(len(ufunc_inputs)):
-        pointers.append("*ip%d = args[%d]" % (j, j))
+        body += "    cdef char *ip%d = args[%d]\n" % (j, j)
     for j in range(len(ufunc_outputs)):
-        pointers.append("*op%d = args[%d]" % (j, j + len(ufunc_inputs)))
-    body += "    cdef char %s\n" % ", ".join(pointers)
+        body += "    cdef char *op%d = args[%d]\n" % (j, j + len(ufunc_inputs))
 
     ftypes = []
     fvars = []


### PR DESCRIPTION
Cython 0.20 is picky about declarations that mix pointer and non-pointer variables.  For example, here are the warnings generated when cython 0.20 is run on `interpolate/_ppoly.pyx`:

```
$ cython _ppoly.pyx
warning: _ppoly.pyx:277:16: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
warning: _ppoly.pyx:277:21: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
warning: _ppoly.pyx:559:16: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
warning: _ppoly.pyx:559:20: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
warning: _ppoly.pyx:684:16: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
warning: _ppoly.pyx:684:21: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
```

Line 277 is:

```
    cdef double *wr, *wi, last_root, va, vb
```

This PR moves each pointer's `cdef` to its own line. 
