### PR TITLE
Correcting the normalization of chebwin window function

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -68,13 +68,27 @@ cheb_even_true = array([0.203894, 0.107279, 0.133904,
 
 class TestChebWin(object):
 
-    def test_cheb_odd(self):
+    def test_cheb_odd_high_attenuation(self):
         cheb_odd = signal.chebwin(53, at=-40)
         assert_array_almost_equal(cheb_odd, cheb_odd_true, decimal=4)
 
-    def test_cheb_even(self):
+    def test_cheb_even_high_attenuation(self):
         cheb_even = signal.chebwin(54, at=-40)
         assert_array_almost_equal(cheb_even, cheb_even_true, decimal=4)
+
+    def test_cheb_odd_low_attenuation(self):
+        cheb_odd_low_at_true = array([1.000000, 0.519052, 0.586405,
+                                      0.610151, 0.586405, 0.519052,
+                                      1.000000])
+        cheb_odd = signal.chebwin(7, at=-10)
+        assert_array_almost_equal(cheb_odd, cheb_odd_low_at_true, decimal=4)
+
+    def test_cheb_even_low_attenuation(self):
+        cheb_even_low_at_true = array([1.000000, 0.451924, 0.51027,
+                                       0.541338, 0.541338, 0.51027,
+                                       0.451924, 1.000000])
+        cheb_even = signal.chebwin(8, at=-10)
+        assert_array_almost_equal(cheb_even, cheb_even_low_at_true, decimal=4)
 
 
 class TestGetWindow(object):

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -1227,14 +1227,14 @@ def chebwin(M, at, sym=True):
     if M % 2:
         w = np.real(fft(p))
         n = (M + 1) // 2
-        w = w[:n] / w[0]
+        w = w[:n]
         w = np.concatenate((w[n - 1:0:-1], w))
     else:
         p = p * np.exp(1.j * np.pi / M * np.r_[0:M])
         w = np.real(fft(p))
         n = M // 2 + 1
-        w = w / w[1]
         w = np.concatenate((w[n - 1:0:-1], w[1:n]))
+    w = w / max(w)
     if not sym and not odd:
         w = w[:-1]
     return w


### PR DESCRIPTION
I was trying to work on https://github.com/scipy/scipy/issues/2221 but noticed that the current normalization for Chebwin window function works correctly only for significant attenuation : 
##### Current :

```
In [3]: chebwin(6, 10)
Out[3]: 
array([ 1.46877571,  0.89172335,  1.        ,  1.        ,  0.89172335,
        1.46877571])

In [4]: chebwin(6, 20)
Out[4]: 
array([ 0.54057352,  0.77676753,  1.        ,  1.        ,  0.77676753,
        0.54057352])
```

In the case of 10dB(low) attenuation, chebwin is not correctly normalized. The tests missed this because they were on 40dB(significant) attenuation.
##### This PR :

```
In [2]: chebwin(6, 10)
Out[2]: array([ 1.        ,  0.60712017,  0.68083915,  0.68083915,  0.60712017,  1.        ])

In [3]: chebwin(6, 20)
Out[3]: 
array([ 0.54057352,  0.77676753,  1.        ,  1.        ,  0.77676753,
        0.54057352])
```

The results are in tune with Octave and Matlab.
##### Octave :

```
octave:8> chebwin(6, 10)
ans =

   1.00000
   0.60712
   0.68084
   0.68084
   0.60712
   1.00000

octave:9> chebwin(6, 20)
ans =

   0.54057
   0.77677
   1.00000
   1.00000
   0.77677
   0.54057

```
##### Matlab :

```
>> chebwin(6, 10)

ans =

    1.0000
    0.6071
    0.6808
    0.6808
    0.6071
    1.0000

>> chebwin(6, 20)

ans =

    0.5406
    0.7768
    1.0000
    1.0000
    0.7768
    0.5406
```
