### PR TITLE
Remove empty strings warning from idl.py

### DIFF
--- a/scipy/io/idl.py
+++ b/scipy/io/idl.py
@@ -164,7 +164,6 @@ def _read_string(f):
         _align_32(f)
         chars = asstr(chars)
     else:
-        warnings.warn("warning: empty strings are now set to '' instead of None")
         chars = ''
     return chars
 
@@ -177,7 +176,6 @@ def _read_string_data(f):
         string_data = _read_bytes(f, length)
         _align_32(f)
     else:
-        warnings.warn("warning: empty strings are now set to '' instead of None")
         string_data = ''
     return string_data
 


### PR DESCRIPTION
This warning has been in the code for quite a while (therefore people who use it already know about it), and it can be rather annoying and verbose when reading large arrays with empty strings because it is printed for each occurrence. I propose to get rid of these warnings altogether.
