### PR TITLE
TST: run PEP8 and Pyflakes on the same TravisCI worker.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,13 @@ matrix:
     - python: 2.7
       env:
         - PYFLAKES=1
-      before_install:
-        - pip install pyflakes
-      script:
-        - PYFLAKES_NODOCTEST=1 pyflakes scipy | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused' > test.out; cat test.out; test \! -s test.out
-    - python: 2.7
-      env:
         - PEP8=1
       before_install:
         - pip install pep8
+        - pip install pyflakes
       script:
         - pep8 scipy
+        - PYFLAKES_NODOCTEST=1 pyflakes scipy | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused' > test.out; cat test.out; test \! -s test.out
 before_install:
   - uname -a
   - free -m


### PR DESCRIPTION
Saves a little runtime, but more importantly less chance for flaky (no pun
intented) results due to git submodule update failures etc.

As suggested by @cowlicks on gh-3273.
