### PR TITLE
TST: open image file in binary mode

### DIFF
--- a/scipy/ndimage/tests/test_io.py
+++ b/scipy/ndimage/tests/test_io.py
@@ -21,7 +21,7 @@ def test_imread():
     img = ndi.imread(lp, flatten=True)
     assert_array_equal(img.shape, (300, 420))
     
-    with open(lp) as fobj:
+    with open(lp, 'rb') as fobj:
         img = ndi.imread(fobj, mode="RGB")
         assert_array_equal(img.shape, (300, 420, 3))
 


### PR DESCRIPTION
Fix test error on Windows:

```
======================================================================
ERROR: test_io.test_imread
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python34\lib\site-packages\numpy\testing\decorators.py", line 146, in skipper_func
    return f(*args, **kwargs)
  File "X:\Python34\lib\site-packages\scipy\ndimage\tests\test_io.py", line 26, in test_imread
    img = ndi.imread(fobj, mode="RGB")
  File "X:\Python34\lib\site-packages\scipy\ndimage\io.py", line 43, in imread
    im = Image.open(fname)
  File "X:\Python34\lib\site-packages\PIL\Image.py", line 1997, in open
    prefix = fp.read(16)
  File "X:\Python34\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 84: character maps to <undefined>

```
