### PR TITLE
BUG: sparse: fix backward compatibility issues in scipy.sparse vs 64-bit indices

### DIFF
--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -155,8 +155,9 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
             elif len(arg1) == 3:
                 # (data,indices,indptr) format
                 (data, indices, indptr) = arg1
-                self.indices = np.array(indices, copy=copy)
-                self.indptr = np.array(indptr, copy=copy)
+                idx_dtype = get_index_dtype((indices, indptr), check_contents=True)
+                self.indices = np.array(indices, copy=copy, dtype=idx_dtype)
+                self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)
                 self.data = np.array(data, copy=copy, dtype=getdtype(dtype, data))
             else:
                 raise ValueError('unrecognized bsr_matrix constructor usage')

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -487,7 +487,11 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         from .csr import csr_matrix
 
         # modifies self.indptr and self.indices *in place*
+        # since CSR constructor may end up in making copies (in case
+        # our index arrays are invalid in some way), play it safe
         proxy = csr_matrix((mask,self.indices,self.indptr),shape=(M//R,N//C))
+        proxy.indices = self.indices
+        proxy.indptr = self.indptr
         proxy.eliminate_zeros()
 
         self.prune()

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -50,8 +50,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 elif len(arg1) == 3:
                     # (data, indices, indptr) format
                     (data, indices, indptr) = arg1
-                    self.indices = np.array(indices, copy=copy)
-                    self.indptr = np.array(indptr, copy=copy)
+                    idx_dtype = get_index_dtype((indices, indptr), check_contents=True)
+                    self.indices = np.array(indices, copy=copy, dtype=idx_dtype)
+                    self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)
                     self.data = np.array(data, copy=copy, dtype=getdtype(dtype, data))
                 else:
                     raise ValueError("unrecognized %s_matrix constructor usage" %

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -198,7 +198,11 @@ class csr_matrix(_cs_matrix, IndexMixin):
         def asindices(x):
             try:
                 x = np.asarray(x)
-                x = x.astype(get_index_dtype(x))
+
+                # Check index contents, to avoid creating 64-bit arrays needlessly
+                idx_dtype = get_index_dtype((x,), check_contents=True)
+                if idx_dtype != x.dtype:
+                    x = x.astype(idx_dtype)
             except:
                 raise IndexError('invalid index')
             else:

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -87,6 +87,8 @@ def downcast_intp_index(arr):
     intp.
     """
     if arr.dtype.itemsize > np.dtype(np.intp).itemsize:
+        if arr.size == 0:
+            return arr.astype(np.intp)
         maxval = arr.max()
         minval = arr.min()
         if maxval > np.iinfo(np.intp).max or minval < np.iinfo(np.intp).min:

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -129,10 +129,26 @@ def getdtype(dtype, a=None, default=None):
     return newdtype
 
 
-def get_index_dtype(arrays=(), maxval=None):
+def get_index_dtype(arrays=(), maxval=None, check_contents=False):
     """
     Based on input (integer) arrays `a`, determine a suitable index data
     type that can hold the data in the arrays.
+
+    Parameters
+    ----------
+    arrays : tuple of array_like
+        Input arrays whose types/contents to check
+    maxval : float, optional
+        Maximum value needed
+    check_contents : bool, optional
+        Whether to check the values in the arrays and not just their types.
+        Default: False (check only the types)
+
+    Returns
+    -------
+    dtype : dtype
+        Suitable index data type (int32 or int64)
+
     """
 
     int32max = np.iinfo(np.int32).max
@@ -148,7 +164,20 @@ def get_index_dtype(arrays=(), maxval=None):
     for arr in arrays:
         arr = np.asarray(arr)
         if arr.dtype > np.int32:
+            if check_contents:
+                if arr.size == 0:
+                    # a bigger type not needed
+                    continue
+                elif np.issubdtype(arr.dtype, np.integer):
+                    maxval = arr.max()
+                    minval = arr.min()
+                    if minval >= np.iinfo(np.int32).min and maxval <= np.iinfo(np.int32).max:
+                        # a bigger type not needed
+                        continue
+
             dtype = np.int64
+            break
+
     return dtype
 
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -53,7 +53,7 @@ warnings.simplefilter('ignore', ComplexWarning)
 
 
 def with_64bit_maxval_limit(maxval_limit=None, random=False, fixed_dtype=None,
-                            downcast_maxval=None):
+                            downcast_maxval=None, assert_32bit=False):
     """
     Monkeypatch the maxval threshold at which scipy.sparse switches to
     64-bit index arrays, or make it (pseudo-)random.
@@ -62,8 +62,13 @@ def with_64bit_maxval_limit(maxval_limit=None, random=False, fixed_dtype=None,
     if maxval_limit is None:
         maxval_limit = 10
 
-    if fixed_dtype is not None:
-        def new_get_index_dtype(arrays=(), maxval=None):
+    if assert_32bit:
+        def new_get_index_dtype(arrays=(), maxval=None, check_contents=False):
+            tp = get_index_dtype(arrays, maxval, check_contents)
+            assert_equal(tp, np.int32)
+            return tp
+    elif fixed_dtype is not None:
+        def new_get_index_dtype(arrays=(), maxval=None, check_contents=False):
             return fixed_dtype
     elif random:
         counter = np.random.RandomState(seed=1234)
@@ -622,6 +627,7 @@ class _TestCommon:
         for m in mats:
             assert_equal(self.spmatrix(m).diagonal(),diag(m))
 
+    @dec.slow
     def test_setdiag(self):
         def dense_setdiag(a, v, k):
             v = np.asarray(v)
@@ -3912,7 +3918,9 @@ class Test64Bit(object):
 
         for cls in self.TEST_CLASSES:
             for method_name in dir(cls):
+                method = getattr(cls, method_name)
                 if (method_name.startswith('test_') and
+                    not getattr(method, 'slow', False) and
                     (cls.__name__ + '.' + method_name) not in skip):
                     msg = self.SKIP_TESTS.get(method_name)
                     yield dec.skipif(msg, msg)(check), cls, method_name
@@ -3936,6 +3944,10 @@ class Test64Bit(object):
 
     def test_resiliency_all_64(self):
         for t in self._check_resiliency(fixed_dtype=np.int64):
+            yield t
+
+    def test_no_64(self):
+        for t in self._check_resiliency(assert_32bit=True):
             yield t
 
     def test_downcast_intp(self):


### PR DESCRIPTION
This PR fixes two backward compat issues regarding 64-bit indices in scipy.sparse:
- `csr_matrix.__getitem__` inherited the integer type from the fancy index array. Fixed by casting to int32 when possible.
- scikit-learn, and presumably other libraries, implicitly assume that 64-bit indices passed to sparse matrix constructors are cast to 32-bit indices. Address this by casting int64 to int32 in CSR/CSC/BSR constructor, if the contents of the array can be represented in 32-bit.
- Added a test checking that 64-bit indices don't pop up in the base test suite

Fixes gh-3465 --- scikit-learn test suite passes for me after these changes.

Needs backport (and possibly 0.14.0b2 is also needed).
