### PR TITLE
FIX: restore np.abs ufunc support for scipy.sparse

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -837,8 +837,14 @@ class spmatrix(object):
             result = self.minimum(*without_self)
         elif func in (np.sin, np.tan, np.arcsin, np.arctan, np.sinh, np.tanh,
                       np.arcsinh, np.arctanh, np.rint, np.sign, np.expm1, np.log1p,
-                      np.deg2rad, np.rad2deg, np.floor, np.ceil, np.trunc, np.sqrt):
-            func_name = func.__name__
+                      np.deg2rad, np.rad2deg, np.floor, np.ceil, np.trunc, np.sqrt,
+                      np.abs):
+            if func is np.abs:
+                # Special case: map the numpy absolute ufunc to the builtin
+                # __abs__ ufunc
+                func_name = '__abs__'
+            else:
+                func_name = func.__name__
             if hasattr(self, func_name):
                 result = getattr(self, func_name)()
             else:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1560,7 +1560,8 @@ class _TestCommon:
 
         for name in ["sin", "tan", "arcsin", "arctan", "sinh", "tanh",
                      "arcsinh", "arctanh", "rint", "sign", "expm1", "log1p",
-                     "deg2rad", "rad2deg", "floor", "ceil", "trunc", "sqrt"]:
+                     "deg2rad", "rad2deg", "floor", "ceil", "trunc", "sqrt",
+                     "abs"]:
             yield check, name
 
     def test_binary_ufunc_overrides(self):


### PR DESCRIPTION
`np.abs(csr_matrix(-np.ones(3)))` use to work in numpy < 1.9. With numpy and scipy master it triggers:

```
TypeError: __numpy_ufunc__ not implemented for this type.
```

This PR should restore the support for the `np.abs` function on scipy sparse matrices by mapping it to the builtin `__abs__` ufunc.
