### PR TITLE
MAINT: use custom templating instead of fused types in _csparsetools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ scipy/signal/_spectral.c
 scipy/signal/correlate_nd.c
 scipy/signal/lfilter.c
 scipy/sparse/_csparsetools.c
+scipy/sparse/_csparsetools.pyx
 scipy/sparse/csgraph/_min_spanning_tree.c
 scipy/sparse/csgraph/_shortest_path.c
 scipy/sparse/csgraph/_tools.c

--- a/scipy/sparse/_csparsetools.pyx
+++ b/scipy/sparse/_csparsetools.pyx
@@ -91,11 +91,16 @@ def prepare_index_for_memoryview(cnp.ndarray i, cnp.ndarray j, cnp.ndarray x=Non
         Re-formatted arrays (x is omitted, if input was None)
 
     """
+    if i.dtype > j.dtype:
+        j = j.astype(i.dtype)
+    elif i.dtype < j.dtype:
+        i = i.astype(j.dtype)
 
     if not i.flags.writeable or not i.dtype in (np.int32, np.int64):
         i = i.astype(np.intp)
     if not j.flags.writeable or not j.dtype in (np.int32, np.int64):
         j = j.astype(np.intp)
+
     if x is not None:
         if not x.flags.writeable:
             x = x.copy()

--- a/scipy/sparse/_csparsetools.pyx.in
+++ b/scipy/sparse/_csparsetools.pyx.in
@@ -1,6 +1,64 @@
+# -*- cython -*-
+#
+# Tempita-templated Cython file
+#
 """
 Fast snippets for sparse matrices.
 """
+
+{{py:
+
+IDX_TYPES = {
+    "int32": "cnp.npy_int32",
+    "int64": "cnp.npy_int64",
+}
+
+VALUE_TYPES = {
+    "bool_": "cnp.npy_bool",
+    "int8": "cnp.npy_int8",
+    "uint8": "cnp.npy_uint8",
+    "int16": "cnp.npy_int16",
+    "uint16": "cnp.npy_uint16",
+    "int32": "cnp.npy_int32",
+    "uint32": "cnp.npy_uint32",
+    "int64": "cnp.npy_int64",
+    "uint64": "cnp.npy_uint64",
+    "float32": "cnp.npy_float32",
+    "float64": "cnp.npy_float64",
+    "longdouble": "long double",
+    "complex64": "float complex",
+    "complex128": "double complex",
+    "clongdouble": "long double complex",
+}
+
+def get_dispatch(types):
+    for pyname, cyname in types.items():
+        yield pyname, cyname
+
+def get_dispatch2(types, types2):
+    for pyname, cyname in types.items():
+        for pyname2, cyname2 in types2.items():
+            yield pyname, pyname2, cyname, cyname2
+
+def define_dispatch_map(map_name, prefix, types):
+    result = ["cdef dict %s = {\n" % map_name]
+    for pyname, cyname in types.items():
+        a = "np.dtype(np.%s)" % (pyname,)
+        b = prefix + "_" + pyname
+        result.append('%s: %s,' % (a, b))
+    result.append("}\n\n")
+    return "\n".join(result)
+
+def define_dispatch_map2(map_name, prefix, types, types2):
+    result = ["cdef dict %s = {\n" % map_name]
+    for pyname, cyname in types.items():
+        for pyname2, cyname2 in types2.items():
+            a = "(np.dtype(np.%s), np.dtype(np.%s))" % (pyname, pyname2)
+            b = prefix + "_" + pyname + "_" + pyname2
+            result.append('%s: %s,' % (a, b))
+    result.append("}\n\n")
+    return "\n".join(result)
+}}
 
 cimport cython
 cimport cpython.list
@@ -8,64 +66,6 @@ cimport cpython.int
 cimport cpython
 cimport numpy as cnp
 import numpy as np
-
-
-ctypedef fused idx_t:
-    cnp.npy_int32
-    cnp.npy_int64
-
-
-ctypedef fused value_t:
-    cnp.npy_bool
-    cnp.npy_int8
-    cnp.npy_uint8
-    cnp.npy_int16
-    cnp.npy_uint16
-    cnp.npy_int32
-    cnp.npy_uint32
-    cnp.npy_int64
-    cnp.npy_uint64
-    cnp.npy_float32
-    cnp.npy_float64
-    long double
-    float complex
-    double complex
-    long double complex
-
-
-# Use .char to work around dtype comparison bugs in earlier Numpy
-# versions
-
-DTYPE_NAME_MAP = {
-    np.dtype(np.bool_).char: "npy_bool",
-    np.dtype(np.int8).char: "npy_int8",
-    np.dtype(np.uint8).char: "npy_uint8",
-    np.dtype(np.int16).char: "npy_int16",
-    np.dtype(np.uint16).char: "npy_uint16",
-    np.dtype(np.int32).char: "npy_int32",
-    np.dtype(np.uint32).char: "npy_uint32",
-    np.dtype(np.int64).char: "npy_int64",
-    np.dtype(np.uint64).char: "npy_uint64",
-    np.dtype(np.float32).char: "npy_float32",
-    np.dtype(np.float64).char: "npy_float64",
-    np.dtype(np.longdouble).char: "long double",
-    np.dtype(np.complex64).char: "float complex",
-    np.dtype(np.complex128).char: "double complex",
-    np.dtype(np.clongdouble).char: "long double complex"
-}
-
-if np.dtype('q').itemsize == 4:
-    DTYPE_NAME_MAP['q'] = "npy_int32"
-    DTYPE_NAME_MAP['Q'] = "npy_uint32"
-elif np.dtype('q').itemsize == 8:
-    DTYPE_NAME_MAP['q'] = "npy_int64"
-    DTYPE_NAME_MAP['Q'] = "npy_uint64"
-if np.dtype('i').itemsize == 4:
-    DTYPE_NAME_MAP['i'] = "npy_int32"
-    DTYPE_NAME_MAP['I'] = "npy_uint32"
-elif np.dtype('i').itemsize == 8:
-    DTYPE_NAME_MAP['i'] = "npy_int64"
-    DTYPE_NAME_MAP['I'] = "npy_uint64"
 
 
 def prepare_index_for_memoryview(cnp.ndarray i, cnp.ndarray j, cnp.ndarray x=None):
@@ -153,20 +153,12 @@ cpdef lil_get1(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas,
 
 def lil_insert(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas,
                cnp.npy_intp i, cnp.npy_intp j, object x, object dtype):
-    """
-    Work around broken Cython fused type dispatch
-    """
-    dtype = np.dtype(dtype)
-    try:
-        key = DTYPE_NAME_MAP[dtype.char]
-    except KeyError:
-        raise ValueError("Unsupported data type: %r" % (dtype.char,))
-
-    _lil_insert[key](M, N, rows, datas, i, j, x)
+    return _LIL_INSERT_DISPATCH[dtype](M, N, rows, datas, i, j, x)
 
 
-cpdef _lil_insert(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas,
-                  cnp.npy_intp i, cnp.npy_intp j, value_t x):
+{{for NAME, VALUE_T in get_dispatch(VALUE_TYPES)}}
+cpdef _lil_insert_{{NAME}}(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas,
+                           cnp.npy_intp i, cnp.npy_intp j, {{VALUE_T}} x):
     """
     Insert a single item to LIL matrix.
 
@@ -202,6 +194,10 @@ cpdef _lil_insert(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] data
         lil_deleteat_nocheck(rows[i], datas[i], j)
     else:
         lil_insertat_nocheck(rows[i], datas[i], j, x)
+{{endfor}}
+
+
+{{define_dispatch_map('_LIL_INSERT_DISPATCH', '_lil_insert', VALUE_TYPES)}}
 
 
 def lil_fancy_get(cnp.npy_intp M, cnp.npy_intp N,
@@ -209,8 +205,8 @@ def lil_fancy_get(cnp.npy_intp M, cnp.npy_intp N,
                   object[:] datas,
                   object[:] new_rows,
                   object[:] new_datas,
-                  idx_t[:,:] i_idx,
-                  idx_t[:,:] j_idx):
+                  cnp.ndarray i_idx,
+                  cnp.ndarray j_idx):
     """
     Get multiple items at given indices in LIL matrix and store to
     another LIL.
@@ -226,8 +222,19 @@ def lil_fancy_get(cnp.npy_intp M, cnp.npy_intp N,
         Indices of elements to insert to the new LIL matrix.
 
     """
+    return _LIL_FANCY_GET_DISPATCH[i_idx.dtype](M, N, rows, datas, new_rows, new_datas, i_idx, j_idx)
+
+
+{{for NAME, IDX_T in get_dispatch(IDX_TYPES)}}
+def _lil_fancy_get_{{NAME}}(cnp.npy_intp M, cnp.npy_intp N,
+                            object[:] rows,
+                            object[:] datas,
+                            object[:] new_rows,
+                            object[:] new_datas,
+                            {{IDX_T}}[:,:] i_idx,
+                            {{IDX_T}}[:,:] j_idx):
     cdef cnp.npy_intp x, y
-    cdef idx_t i, j
+    cdef cnp.npy_intp i, j
     cdef object value
     cdef list new_row
     cdef list new_data
@@ -249,43 +256,18 @@ def lil_fancy_get(cnp.npy_intp M, cnp.npy_intp N,
 
         new_rows[x] = new_row
         new_datas[x] = new_data
+{{endfor}}
+
+
+{{define_dispatch_map('_LIL_FANCY_GET_DISPATCH', '_lil_fancy_get', IDX_TYPES)}}
 
 
 def lil_fancy_set(cnp.npy_intp M, cnp.npy_intp N,
                   object[:] rows,
                   object[:] data,
-                  object i_idx,
-                  object j_idx,
-                  object values):
-    """
-    Work around broken Cython fused type dispatch
-    """
-    try:
-        key = DTYPE_NAME_MAP[values.dtype.char]
-    except KeyError:
-        raise ValueError("Unsupported data type: %r" % (values.dtype.char,))
-    try:
-        ikey = DTYPE_NAME_MAP[i_idx.dtype.char]
-    except KeyError:
-        raise ValueError("Unsupported data type: %r" % (i_idx.dtype.char,))
-
-    if key != "npy_bool":
-        _lil_fancy_set[ikey, key](M, N, rows, data, i_idx, j_idx, values)
-    else:
-        # bool has no memoryview support
-        for x in range(i_idx.shape[0]):
-            for y in range(i_idx.shape[1]):
-                i = i_idx[x,y]
-                j = j_idx[x,y]
-                _lil_insert[key](M, N, rows, data, i, j, values[x, y])
-
-
-cpdef _lil_fancy_set(cnp.npy_intp M, cnp.npy_intp N,
-                     object[:] rows,
-                     object[:] data,
-                     idx_t[:,:] i_idx,
-                     idx_t[:,:] j_idx,
-                     value_t[:,:] values):
+                  cnp.ndarray i_idx,
+                  cnp.ndarray j_idx,
+                  cnp.ndarray values):
     """
     Set multiple items to a LIL matrix.
 
@@ -301,14 +283,48 @@ cpdef _lil_fancy_set(cnp.npy_intp M, cnp.npy_intp N,
         Values of items to set.
 
     """
+    if values.dtype == np.bool_:
+        # Cython doesn't support np.bool_ as a memoryview type
+        return _lil_fancy_set_generic(M, N, rows, data, i_idx, j_idx, values)
+    else:
+        return _LIL_FANCY_SET_DISPATCH[i_idx.dtype, values.dtype](M, N, rows, data, i_idx, j_idx, values)
+
+
+{{for PYIDX, PYVALUE, IDX_T, VALUE_T in get_dispatch2(IDX_TYPES, VALUE_TYPES)}}
+cpdef _lil_fancy_set_{{PYIDX}}_{{PYVALUE}}(cnp.npy_intp M, cnp.npy_intp N,
+                                           object[:] rows,
+                                           object[:] data,
+                                           {{IDX_T}}[:,:] i_idx,
+                                           {{IDX_T}}[:,:] j_idx,
+                                           {{VALUE_T}}[:,:] values):
     cdef cnp.npy_intp x, y
-    cdef idx_t i, j
+    cdef cnp.npy_intp i, j
 
     for x in range(i_idx.shape[0]):
         for y in range(i_idx.shape[1]):
             i = i_idx[x,y]
             j = j_idx[x,y]
-            _lil_insert[value_t](M, N, rows, data, i, j, values[x, y])
+            _lil_insert_{{PYVALUE}}(M, N, rows, data, i, j, values[x, y])
+{{endfor}}
+
+
+{{define_dispatch_map2('_LIL_FANCY_SET_DISPATCH', '_lil_fancy_set', IDX_TYPES, VALUE_TYPES)}}
+
+
+cpdef _lil_fancy_set_generic(cnp.npy_intp M, cnp.npy_intp N,
+                             object[:] rows,
+                             object[:] data,
+                             cnp.ndarray i_idx,
+                             cnp.ndarray j_idx,
+                             cnp.ndarray values):
+    cdef cnp.npy_intp x, y
+    cdef cnp.npy_intp i, j
+
+    for x in range(i_idx.shape[0]):
+        for y in range(i_idx.shape[1]):
+            i = i_idx[x,y]
+            j = j_idx[x,y]
+            _lil_insert_{{PYVALUE}}(M, N, rows, data, i, j, values[x, y])
 
 
 cdef lil_insertat_nocheck(list row, list data, cnp.npy_intp j, object x):
@@ -396,3 +412,42 @@ cdef bisect_left(list a, cnp.npy_intp x):
         else:
             hi = mid
     return lo
+
+
+def _fill_dtype_map(map, chars):
+    """
+    Fill in Numpy dtype chars for problematic types, working around
+    Numpy < 1.6 bugs.
+    """
+    for c in chars:
+        if c in "SUVO":
+            continue
+        dt = np.dtype(c)
+        if dt not in map:
+            for k, v in map.items():
+                if k.kind == dt.kind and k.itemsize == dt.itemsize:
+                    map[dt] = v
+                    break
+
+
+def _fill_dtype_map2(map):
+    """
+    Fill in Numpy dtype chars for problematic types, working around
+    Numpy < 1.6 bugs.
+    """
+    for c1 in np.typecodes['Integer']:
+        for c2 in np.typecodes['All']:
+            if c2 in "SUVO":
+                continue
+            dt1 = np.dtype(c1)
+            dt2 = np.dtype(c2)
+            if (dt1, dt2) not in map:
+                for k, v in map.items():
+                    if (k[0].kind == dt1.kind and k[0].itemsize == dt1.itemsize and
+                        k[1].kind == dt2.kind and k[1].itemsize == dt2.itemsize):
+                        map[(dt1, dt2)] = v
+                        break
+
+_fill_dtype_map(_LIL_INSERT_DISPATCH, np.typecodes['All'])
+_fill_dtype_map(_LIL_FANCY_GET_DISPATCH, np.typecodes['Integer'])
+_fill_dtype_map2(_LIL_FANCY_SET_DISPATCH)

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -90,12 +90,12 @@ def process_tempita_pyx(fromfile, tofile):
     except ImportError:
         raise Exception('Building SciPy requires Tempita: '
                         'pip install --user Tempita')
-    with open(fromfile, "rb") as f:
+    with open(fromfile, "r") as f:
         tmpl = f.read()
     pyxcontent = tempita.sub(tmpl)
     assert fromfile.endswith('.pyx.in')
     pyxfile = fromfile[:-len('.pyx.in')] + '.pyx'
-    with open(pyxfile, "wb") as f:
+    with open(pyxfile, "w") as f:
         f.write(pyxcontent)
     process_pyx(pyxfile, tofile)
 

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -82,7 +82,14 @@ def process_pyx(fromfile, tofile):
         raise OSError('Cython needs to be installed')
 
 def process_tempita_pyx(fromfile, tofile):
-    import tempita
+    try:
+        try:
+            from Cython import Tempita as tempita
+        except ImportError:
+            import tempita
+    except ImportError:
+        raise Exception('Building SciPy requires Tempita: '
+                        'pip install --user Tempita')
     with open(fromfile, "rb") as f:
         tmpl = f.read()
     pyxcontent = tempita.sub(tmpl)
@@ -163,6 +170,9 @@ def find_process_files(root_dir):
     hash_db = load_hashes(HASH_FILE)
     for cur_dir, dirs, files in os.walk(root_dir):
         for filename in files:
+            in_file = os.path.join(cur_dir, filename + ".in")
+            if filename.endswith('.pyx') and os.path.isfile(in_file):
+                continue
             for fromext, function in rules.items():
                 if filename.endswith(fromext):
                     toext = ".c"


### PR DESCRIPTION
Cython (as of 0.20.1) fused types have issues: (i) unnecessary code generation, (ii) bugs in type dispatch.
The issues seem to crop up if a function signature has two fused-types arrays of the same fused type.

Since we can't postpone 0.14.0 to wait for Cython fixes, this PR converts `_csparsetools` (where the issues appear) to use custom templating rather than fused types dispatch.

Fixes gh-3461

Cython discussions:
http://permalink.gmane.org/gmane.comp.python.cython.devel/15250
http://permalink.gmane.org/gmane.comp.python.cython.devel/15245
