### PR TITLE
ENH: sparse: release GIL in sparsetools routines

### DIFF
--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -286,10 +286,16 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
         }
         else if (*p == 'V') {
             arg_list[j] = allocate_std_vector_typenum(I_typenum);
+            if (arg_list[j] == NULL) {
+                goto fail;
+            }
             continue;
         }
         else if (*p == 'W') {
             arg_list[j] = allocate_std_vector_typenum(T_typenum);
+            if (arg_list[j] == NULL) {
+                goto fail;
+            }
             continue;
         }
         else {
@@ -424,20 +430,24 @@ static void *allocate_std_vector_typenum(int typenum)
         return (void*)(new std::vector<ctype>());               \
     }
 
-    PROCESS(NPY_BOOL, npy_bool_wrapper);
-    PROCESS(NPY_BYTE, npy_byte);
-    PROCESS(NPY_UBYTE, npy_ubyte);
-    PROCESS(NPY_SHORT, npy_short);
-    PROCESS(NPY_USHORT, npy_ushort);
-    PROCESS(NPY_INT, npy_uint);
-    PROCESS(NPY_LONG, npy_ulong);
-    PROCESS(NPY_LONGLONG, npy_ulonglong);
-    PROCESS(NPY_FLOAT, npy_float);
-    PROCESS(NPY_DOUBLE, npy_double);
-    PROCESS(NPY_LONGDOUBLE, npy_longdouble);
-    PROCESS(NPY_CFLOAT, npy_cfloat_wrapper);
-    PROCESS(NPY_CDOUBLE, npy_cdouble_wrapper);
-    PROCESS(NPY_CLONGDOUBLE, npy_clongdouble_wrapper);
+    try {
+        PROCESS(NPY_BOOL, npy_bool_wrapper);
+        PROCESS(NPY_BYTE, npy_byte);
+        PROCESS(NPY_UBYTE, npy_ubyte);
+        PROCESS(NPY_SHORT, npy_short);
+        PROCESS(NPY_USHORT, npy_ushort);
+        PROCESS(NPY_INT, npy_uint);
+        PROCESS(NPY_LONG, npy_ulong);
+        PROCESS(NPY_LONGLONG, npy_ulonglong);
+        PROCESS(NPY_FLOAT, npy_float);
+        PROCESS(NPY_DOUBLE, npy_double);
+        PROCESS(NPY_LONGDOUBLE, npy_longdouble);
+        PROCESS(NPY_CFLOAT, npy_cfloat_wrapper);
+        PROCESS(NPY_CDOUBLE, npy_cdouble_wrapper);
+        PROCESS(NPY_CLONGDOUBLE, npy_clongdouble_wrapper);
+    } catch (std::exception &e) {
+        /* failed */
+    }
 
 #undef PROCESS
 

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -4,10 +4,12 @@ import sys
 import os
 import gc
 import re
+import time
+import threading
 
 from nose import SkipTest
 import numpy as np
-from numpy.testing import assert_raises, assert_equal, dec, run_module_suite
+from numpy.testing import assert_raises, assert_equal, dec, run_module_suite, assert_
 from scipy.sparse import (_sparsetools, coo_matrix, csr_matrix, csc_matrix,
                           bsr_matrix, dia_matrix)
 from scipy.lib.decorator import decorator
@@ -27,6 +29,37 @@ def xslow(func, *a, **kw):
 
 def test_exception():
     assert_raises(MemoryError, _sparsetools.test_throw_error)
+
+
+def test_threads():
+    # Smoke test for parallel threaded execution; doesn't actually
+    # check that code runs in parallel, but just that it produces
+    # expected results.
+    nthreads = 10
+    niter = 100
+
+    n = 20
+    a = csr_matrix(np.ones([n, n]))
+    bres = []
+
+    class Worker(threading.Thread):
+        def run(self):
+            b = a.copy()
+            for j in range(niter):
+                _sparsetools.csr_plus_csr(n, n,
+                                          a.indptr, a.indices, a.data,
+                                          a.indptr, a.indices, a.data,
+                                          b.indptr, b.indices, b.data)
+            bres.append(b)
+
+    threads = [Worker() for _ in range(nthreads)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    for b in bres:
+        assert_(np.all(b.toarray() == 2))
 
 
 class TestInt32Overflow(object):


### PR DESCRIPTION
The sparsetools routines are threadsafe, and do not use Python. This PR releases GIL when calling them.

The GIL release is thresholded to not occur for small arrays.

The exact threshold value is probably not exact science. Numpy ufunc loops threshold at 500 elements, but on the other hand, sparsetools routines are somewhat more complicated than typical ufunc inner loops.
