### PR TITLE
TST: stats: Fix some spurious warnings generated when the stats unit tests are run.

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -66,7 +66,7 @@ class binom_gen(rv_discrete):
 
     def _ppf(self, q, n, p):
         vals = ceil(special.bdtrik(q, n, p))
-        vals1 = vals-1
+        vals1 = np.maximum(vals - 1, 0)
         temp = special.bdtr(vals1, n, p)
         return np.where(temp >= q, vals1, vals)
 
@@ -445,9 +445,9 @@ class poisson_gen(rv_discrete):
 
     def _ppf(self, q, mu):
         vals = ceil(special.pdtrik(q, mu))
-        vals1 = vals - 1
+        vals1 = np.maximum(vals - 1, 0)
         temp = special.pdtr(vals1, mu)
-        return np.where((temp >= q), vals1, vals)
+        return np.where(temp >= q, vals1, vals)
 
     def _stats(self, mu):
         var = mu


### PR DESCRIPTION
When given a negative argument, special.bdtr and special.pdtr return nan, and using
a nan value in a numpy comparison generates a warning.  This commit ensures that
the values used in the comparison that takes place in binom._ppf and poisson._ppf are
not nan.

Here are the warnings (converted to errors) that I get when I run the `stats` unit tests from master:

```
$ python -c "import scipy.stats as m; m.test('full', raise_warnings='develop')"
Running unit tests for scipy.stats
NumPy version 1.8.1rc2.dev-06f9694
NumPy is installed in /Users/warren/local_scipy/lib/python2.7/site-packages/numpy
SciPy version 0.15.0.dev-d0c7914
SciPy is installed in /Users/warren/local_scipy/lib/python2.7/site-packages/scipy
Python version 2.7.6 |Anaconda 1.8.0 (x86_64)| (default, Jan 10 2014, 11:23:15) [GCC 4.0.1 (Apple Inc. build 5493)]
nose version 1.3.0
..................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................K...........K..............................................................................................................................................S..........S..........................................................................................................................................................................................................................................................................................................................................................................................................KKKKK.......................................................................................KKKK.....................................................................................................................................................KKKKK.....................................E.E..E.E....................................................E.E...........................................................................................................................................................................................K..................................K..........................S.............................................................S............................................................................................................S..........................................................................................................................................................................................K.KK..............KK.K................K....K......K.K.K..K.K.........K..K.K....K..........................................................................................S..S.....................................................................................................................................................................................................................................................................................................................................................................................................................
======================================================================
ERROR: test_discrete_basic.test_discrete_basic(<scipy.stats._discrete_distns.bernoulli_gen object at 0x103b25690>, (0.3,), array([0, 1]), 'bernoulli cdf_ppf')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/warren/anaconda/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/tests/test_discrete_basic.py", line 79, in check_cdf_ppf
    npt.assert_array_equal(distfn.ppf(distfn.cdf(supp, *arg) - 1e-8, *arg),
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_distn_infrastructure.py", line 2991, in ppf
    place(output, cond, self._ppf(*goodargs) + loc)
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_discrete_distns.py", line 127, in _ppf
    return binom._ppf(q, 1, p)
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_discrete_distns.py", line 71, in _ppf
    return np.where(temp >= q, vals1, vals)
RuntimeWarning: invalid value encountered in greater_equal

======================================================================
ERROR: test_discrete_basic.test_discrete_basic(<scipy.stats._discrete_distns.bernoulli_gen object at 0x103b25690>, (0.3,), array([0, 1]), 'bernoulli oth')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/warren/anaconda/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/tests/test_discrete_basic.py", line 110, in check_oth
    npt.assert_allclose(distfn.isf(q, *arg), distfn.ppf(1. - q, *arg),
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_distn_infrastructure.py", line 3036, in isf
    place(output, cond, self._isf(*goodargs) + loc)
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_distn_infrastructure.py", line 792, in _isf
    return self._ppf(1.0-q, *args)  # use correct _ppf for subclasses
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_discrete_distns.py", line 127, in _ppf
    return binom._ppf(q, 1, p)
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_discrete_distns.py", line 71, in _ppf
    return np.where(temp >= q, vals1, vals)
RuntimeWarning: invalid value encountered in greater_equal

======================================================================
ERROR: test_discrete_basic.test_discrete_basic(<scipy.stats._discrete_distns.binom_gen object at 0x103b253d0>, (5, 0.4), array([0, 1, 2, 3, 4, 5]), 'binom cdf_ppf')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/warren/anaconda/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/tests/test_discrete_basic.py", line 77, in check_cdf_ppf
    npt.assert_array_equal(distfn.ppf(distfn.cdf(supp, *arg), *arg),
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_distn_infrastructure.py", line 2991, in ppf
    place(output, cond, self._ppf(*goodargs) + loc)
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_discrete_distns.py", line 71, in _ppf
    return np.where(temp >= q, vals1, vals)
RuntimeWarning: invalid value encountered in greater_equal

======================================================================
ERROR: test_discrete_basic.test_discrete_basic(<scipy.stats._discrete_distns.binom_gen object at 0x103b253d0>, (5, 0.4), array([0, 1, 2, 3, 4, 5]), 'binom oth')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/warren/anaconda/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/tests/test_discrete_basic.py", line 110, in check_oth
    npt.assert_allclose(distfn.isf(q, *arg), distfn.ppf(1. - q, *arg),
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_distn_infrastructure.py", line 3036, in isf
    place(output, cond, self._isf(*goodargs) + loc)
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_distn_infrastructure.py", line 792, in _isf
    return self._ppf(1.0-q, *args)  # use correct _ppf for subclasses
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_discrete_distns.py", line 71, in _ppf
    return np.where(temp >= q, vals1, vals)
RuntimeWarning: invalid value encountered in greater_equal

======================================================================
ERROR: test_discrete_basic.test_discrete_basic(<scipy.stats._discrete_distns.poisson_gen object at 0x103b2e0d0>, (0.6,), array([0, 1, 2, 3, 4, 5]), 'poisson cdf_ppf')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/warren/anaconda/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/tests/test_discrete_basic.py", line 79, in check_cdf_ppf
    npt.assert_array_equal(distfn.ppf(distfn.cdf(supp, *arg) - 1e-8, *arg),
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_distn_infrastructure.py", line 2991, in ppf
    place(output, cond, self._ppf(*goodargs) + loc)
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_discrete_distns.py", line 450, in _ppf
    return np.where((temp >= q), vals1, vals)
RuntimeWarning: invalid value encountered in greater_equal

======================================================================
ERROR: test_discrete_basic.test_discrete_basic(<scipy.stats._discrete_distns.poisson_gen object at 0x103b2e0d0>, (0.6,), array([0, 1, 2, 3, 4, 5]), 'poisson oth')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/warren/anaconda/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/tests/test_discrete_basic.py", line 110, in check_oth
    npt.assert_allclose(distfn.isf(q, *arg), distfn.ppf(1. - q, *arg),
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_distn_infrastructure.py", line 3036, in isf
    place(output, cond, self._isf(*goodargs) + loc)
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_distn_infrastructure.py", line 792, in _isf
    return self._ppf(1.0-q, *args)  # use correct _ppf for subclasses
  File "/Users/warren/local_scipy/lib/python2.7/site-packages/scipy/stats/_discrete_distns.py", line 450, in _ppf
    return np.where((temp >= q), vals1, vals)
RuntimeWarning: invalid value encountered in greater_equal

----------------------------------------------------------------------
Ran 2899 tests in 121.256s

FAILED (KNOWNFAIL=35, SKIP=7, errors=6)
```
