### PR TITLE
BLD: fix Qhull build issue with MinGW-w64.  Closes gh-3237.

### DIFF
--- a/scipy/spatial/qhull/src/mem.h
+++ b/scipy/spatial/qhull/src/mem.h
@@ -78,7 +78,7 @@ Trace short and quick memory allocations at T5
     Qhull uses int instead of size_t except for system calls such as malloc, qsort, qh_malloc, etc.
     This matches Qt convention and is easier to work with.  
 */
-#if _MSC_VER && defined(_WIN64)
+#if (_MSC_VER || defined(__MINGW64__)) && defined(_WIN64)
 typedef long long ptr_intT;
 #else
 typedef long ptr_intT;


### PR DESCRIPTION
Thanks to @carlkl for the suggested fix. I can't easily test this, but simple enough to review that it shouldn't break anything for MSVC.
