### PR TITLE
DOC improve scipy.sparse docstrings

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -120,13 +120,12 @@ array([ 1, -3, -1], dtype=int64)
 
 .. warning:: As of NumPy 1.7, `np.dot` is not aware of sparse matrices,
   therefore using it will result on unexpected results or errors.
-  The corresponding dense matrix should be obtained first instead:
+  The corresponding dense array should be obtained first instead:
 
-  >>> np.dot(A.todense(), v)
-  matrix([[ 1, -3, -1]], dtype=int64)
+  >>> np.dot(A.toarray(), v)
+  array([ 1, -3, -1], dtype=int64)
 
   but then all the performance advantages would be lost.
-  Notice that it returned a matrix, because `todense` returns a matrix.
 
 The CSR format is specially suitable for fast matrix vector products.
 
@@ -153,7 +152,7 @@ Now convert it to CSR format and solve A x = b for x:
 Convert it to a dense matrix and solve, and check that the result
 is the same:
 
->>> x_ = solve(A.todense(), b)
+>>> x_ = solve(A.toarray(), b)
 
 Now we can compute norm of the error with:
 

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -90,29 +90,29 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
     Examples
     --------
     >>> from scipy.sparse import bsr_matrix
-    >>> bsr_matrix((3,4), dtype=np.int8).todense()
-    matrix([[0, 0, 0, 0],
-            [0, 0, 0, 0],
-            [0, 0, 0, 0]], dtype=int8)
+    >>> bsr_matrix((3, 4), dtype=np.int8).toarray()
+    array([[0, 0, 0, 0],
+           [0, 0, 0, 0],
+           [0, 0, 0, 0]], dtype=int8)
 
-    >>> row = np.array([0,0,1,2,2,2])
-    >>> col = np.array([0,2,2,0,1,2])
-    >>> data = np.array([1,2,3,4,5,6])
-    >>> bsr_matrix((data, (row,col)), shape=(3,3)).todense()
-    matrix([[1, 0, 2],
-            [0, 0, 3],
-            [4, 5, 6]])
+    >>> row = np.array([0, 0, 1, 2, 2, 2])
+    >>> col = np.array([0, 2, 2, 0, 1, 2])
+    >>> data = np.array([1, 2, 3 ,4, 5, 6])
+    >>> bsr_matrix((data, (row, col)), shape=(3, 3)).toarray()
+    array([[1, 0, 2],
+           [0, 0, 3],
+           [4, 5, 6]])
 
-    >>> indptr = np.array([0,2,3,6])
-    >>> indices = np.array([0,2,2,0,1,2])
-    >>> data = np.array([1,2,3,4,5,6]).repeat(4).reshape(6,2,2)
-    >>> bsr_matrix((data,indices,indptr), shape=(6,6)).todense()
-    matrix([[1, 1, 0, 0, 2, 2],
-            [1, 1, 0, 0, 2, 2],
-            [0, 0, 0, 0, 3, 3],
-            [0, 0, 0, 0, 3, 3],
-            [4, 4, 5, 5, 6, 6],
-            [4, 4, 5, 5, 6, 6]])
+    >>> indptr = np.array([0, 2, 3, 6])
+    >>> indices = np.array([0, 2, 2, 0, 1, 2])
+    >>> data = np.array([1, 2, 3, 4, 5, 6]).repeat(4).reshape(6, 2, 2)
+    >>> bsr_matrix((data,indices,indptr), shape=(6, 6)).toarray()
+    array([[1, 1, 0, 0, 2, 2],
+           [1, 1, 0, 0, 2, 2],
+           [0, 0, 0, 0, 3, 3],
+           [0, 0, 0, 0, 3, 3],
+           [4, 4, 5, 5, 6, 6],
+           [4, 4, 5, 5, 6, 6]])
 
     """
     def __init__(self, arg1, shape=None, dtype=None, copy=False, blocksize=None):

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -46,13 +46,13 @@ def spdiags(data, diags, m, n, format=None):
 
     Examples
     --------
-    >>> data = np.array([[1,2,3,4],[1,2,3,4],[1,2,3,4]])
-    >>> diags = np.array([0,-1,2])
-    >>> spdiags(data, diags, 4, 4).todense()
-    matrix([[1, 0, 3, 0],
-            [1, 2, 0, 4],
-            [0, 2, 3, 0],
-            [0, 0, 3, 4]])
+    >>> data = array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]])
+    >>> diags = array([0, -1, 2])
+    >>> spdiags(data, diags, 4, 4).toarray()
+    array([[1, 0, 3, 0],
+           [1, 2, 0, 4],
+           [0, 2, 3, 0],
+           [0, 0, 3, 4]])
 
     """
     return dia_matrix((data, diags), shape=(m,n)).asformat(format)
@@ -103,31 +103,31 @@ def diags(diagonals, offsets, shape=None, format=None, dtype=None):
 
     Examples
     --------
-    >>> diagonals = [[1,2,3,4], [1,2,3], [1,2]]
-    >>> diags(diagonals, [0, -1, 2]).todense()
-    matrix([[1, 0, 1, 0],
-            [1, 2, 0, 2],
-            [0, 2, 3, 0],
-            [0, 0, 3, 4]])
+    >>> diagonals = [[1, 2, 3, 4], [1, 2, 3], [1, 2]]
+    >>> diags(diagonals, [0, -1, 2]).toarray()
+    array([[1, 0, 1, 0],
+           [1, 2, 0, 2],
+           [0, 2, 3, 0],
+           [0, 0, 3, 4]])
 
     Broadcasting of scalars is supported (but shape needs to be
     specified):
 
-    >>> diags([1, -2, 1], [-1, 0, 1], shape=(4, 4)).todense()
-    matrix([[-2.,  1.,  0.,  0.],
-            [ 1., -2.,  1.,  0.],
-            [ 0.,  1., -2.,  1.],
-            [ 0.,  0.,  1., -2.]])
+    >>> diags([1, -2, 1], [-1, 0, 1], shape=(4, 4)).toarray()
+    array([[-2.,  1.,  0.,  0.],
+           [ 1., -2.,  1.,  0.],
+           [ 0.,  1., -2.,  1.],
+           [ 0.,  0.,  1., -2.]])
 
 
     If only one diagonal is wanted (as in `numpy.diag`), the following
     works as well:
 
-    >>> diags([1, 2, 3], 1).todense()
-    matrix([[ 0.,  1.,  0.,  0.],
-            [ 0.,  0.,  2.,  0.],
-            [ 0.,  0.,  0.,  3.],
-            [ 0.,  0.,  0.,  0.]])
+    >>> diags([1, 2, 3], 1).toarray()
+    array([[ 0.,  1.,  0.,  0.],
+           [ 0.,  0.,  2.,  0.],
+           [ 0.,  0.,  0.,  3.],
+           [ 0.,  0.,  0.,  0.]])
     """
     # if offsets is not a sequence, assume that there's only one diagonal
     try:
@@ -201,10 +201,10 @@ def identity(n, dtype='d', format=None):
 
     Examples
     --------
-    >>> identity(3).todense()
-    matrix([[ 1.,  0.,  0.],
-            [ 0.,  1.,  0.],
-            [ 0.,  0.,  1.]])
+    >>> identity(3).toarray()
+    array([[ 1.,  0.,  0.],
+           [ 0.,  1.,  0.],
+           [ 0.,  0.,  1.]])
     >>> identity(3, dtype='int8', format='dia')
     <3x3 sparse matrix of type '<type 'numpy.int8'>'
             with 3 stored elements (1 diagonals) in DIAgonal format>
@@ -235,10 +235,10 @@ def eye(m, n=None, k=0, dtype=float, format=None):
     Examples
     --------
     >>> from scipy import sparse
-    >>> sparse.eye(3).todense()
-    matrix([[ 1.,  0.,  0.],
-            [ 0.,  1.,  0.],
-            [ 0.,  0.,  1.]])
+    >>> sparse.eye(3).toarray()
+    array([[ 1.,  0.,  0.],
+           [ 0.,  1.,  0.],
+           [ 0.,  0.,  1.]])
     >>> sparse.eye(3, dtype=np.int8)
     <3x3 sparse matrix of type '<type 'numpy.int8'>'
         with 3 stored elements (1 diagonals) in DIAgonal format>
@@ -288,19 +288,19 @@ def kron(A, B, format=None):
     Examples
     --------
     >>> from scipy import sparse
-    >>> A = sparse.csr_matrix(np.array([[0,2],[5,0]]))
-    >>> B = sparse.csr_matrix(np.array([[1,2],[3,4]]))
-    >>> kron(A, B).todense()
-    matrix([[ 0,  0,  2,  4],
-            [ 0,  0,  6,  8],
-            [ 5, 10,  0,  0],
-            [15, 20,  0,  0]])
+    >>> A = sparse.csr_matrix(array([[0, 2], [5, 0]]))
+    >>> B = sparse.csr_matrix(array([[1, 2], [3, 4]]))
+    >>> kron(A, B).toarray()
+    array([[ 0,  0,  2,  4],
+           [ 0,  0,  6,  8],
+           [ 5, 10,  0,  0],
+           [15, 20,  0,  0]])
 
-    >>> kron(A, [[1,2],[3,4]]).todense()
-    matrix([[ 0,  0,  2,  4],
-            [ 0,  0,  6,  8],
-            [ 5, 10,  0,  0],
-            [15, 20,  0,  0]])
+    >>> kron(A, [[1, 2], [3, 4]]).toarray()
+    array([[ 0,  0,  2,  4],
+           [ 0,  0,  6,  8],
+           [ 5, 10,  0,  0],
+           [15, 20,  0,  0]])
 
     """
     B = coo_matrix(B)
@@ -441,11 +441,11 @@ def hstack(blocks, format=None, dtype=None):
     Examples
     --------
     >>> from scipy.sparse import coo_matrix, hstack
-    >>> A = coo_matrix([[1,2],[3,4]])
-    >>> B = coo_matrix([[5],[6]])
-    >>> hstack( [A,B] ).todense()
-    matrix([[1, 2, 5],
-            [3, 4, 6]])
+    >>> A = coo_matrix([[1, 2], [3, 4]])
+    >>> B = coo_matrix([[5], [6]])
+    >>> hstack([A,B]).toarray()
+    array([[1, 2, 5],
+           [3, 4, 6]])
 
     """
     return bmat([blocks], format=format, dtype=dtype)
@@ -471,12 +471,12 @@ def vstack(blocks, format=None, dtype=None):
     Examples
     --------
     >>> from scipy.sparse import coo_matrix, vstack
-    >>> A = coo_matrix([[1,2],[3,4]])
-    >>> B = coo_matrix([[5,6]])
-    >>> vstack( [A,B] ).todense()
-    matrix([[1, 2],
-            [3, 4],
-            [5, 6]])
+    >>> A = coo_matrix([[1, 2], [3, 4]])
+    >>> B = coo_matrix([[5, 6]])
+    >>> vstack([A, B]).toarray()
+    array([[1, 2],
+           [3, 4],
+           [5, 6]])
 
     """
     return bmat([[b] for b in blocks], format=format, dtype=dtype)
@@ -510,18 +510,18 @@ def bmat(blocks, format=None, dtype=None):
     Examples
     --------
     >>> from scipy.sparse import coo_matrix, bmat
-    >>> A = coo_matrix([[1,2],[3,4]])
-    >>> B = coo_matrix([[5],[6]])
+    >>> A = coo_matrix([[1, 2], [3, 4]])
+    >>> B = coo_matrix([[5], [6]])
     >>> C = coo_matrix([[7]])
-    >>> bmat( [[A,B],[None,C]] ).todense()
-    matrix([[1, 2, 5],
-            [3, 4, 6],
-            [0, 0, 7]])
+    >>> bmat([[A, B], [None, C]]).toarray()
+    array([[1, 2, 5],
+           [3, 4, 6],
+           [0, 0, 7]])
 
-    >>> bmat( [[A,None],[None,C]] ).todense()
-    matrix([[1, 2, 0],
-            [3, 4, 0],
-            [0, 0, 7]])
+    >>> bmat([[A, None], [None, C]]).toarray()
+    array([[1, 2, 0],
+           [3, 4, 0],
+           [0, 0, 7]])
 
     """
 
@@ -637,12 +637,12 @@ def block_diag(mats, format=None, dtype=None):
     >>> A = coo_matrix([[1, 2], [3, 4]])
     >>> B = coo_matrix([[5], [6]])
     >>> C = coo_matrix([[7]])
-    >>> block_diag((A, B, C)).todense()
-    matrix([[1, 2, 0, 0],
-            [3, 4, 0, 0],
-            [0, 0, 5, 0],
-            [0, 0, 6, 0],
-            [0, 0, 0, 7]])
+    >>> block_diag((A, B, C)).toarray()
+    array([[1, 2, 0, 0],
+           [3, 4, 0, 0],
+           [0, 0, 5, 0],
+           [0, 0, 6, 0],
+           [0, 0, 0, 7]])
 
     """
     nmat = len(mats)

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -88,29 +88,29 @@ class coo_matrix(_data_matrix, _minmax_mixin):
     Examples
     --------
     >>> from scipy.sparse import coo_matrix
-    >>> coo_matrix((3,4), dtype=np.int8).todense()
-    matrix([[0, 0, 0, 0],
-            [0, 0, 0, 0],
-            [0, 0, 0, 0]], dtype=int8)
+    >>> coo_matrix((3, 4), dtype=np.int8).toarray()
+    array([[0, 0, 0, 0],
+           [0, 0, 0, 0],
+           [0, 0, 0, 0]], dtype=int8)
 
-    >>> row  = np.array([0,3,1,0])
-    >>> col  = np.array([0,3,1,2])
-    >>> data = np.array([4,5,7,9])
-    >>> coo_matrix((data,(row,col)), shape=(4,4)).todense()
-    matrix([[4, 0, 9, 0],
-            [0, 7, 0, 0],
-            [0, 0, 0, 0],
-            [0, 0, 0, 5]])
+    >>> row  = np.array([0, 3, 1, 0])
+    >>> col  = np.array([0, 3, 1, 2])
+    >>> data = np.array([4, 5, 7, 9])
+    >>> coo_matrix((data, (row, col)), shape=(4, 4)).toarray()
+    array([[4, 0, 9, 0],
+           [0, 7, 0, 0],
+           [0, 0, 0, 0],
+           [0, 0, 0, 5]])
 
     >>> # example with duplicates
-    >>> row  = np.array([0,0,1,3,1,0,0])
-    >>> col  = np.array([0,2,1,3,1,0,0])
-    >>> data = np.array([1,1,1,1,1,1,1])
-    >>> coo_matrix((data, (row,col)), shape=(4,4)).todense()
-    matrix([[3, 0, 1, 0],
-            [0, 2, 0, 0],
-            [0, 0, 0, 0],
-            [0, 0, 0, 1]])
+    >>> row  = np.array([0, 0, 1, 3, 1, 0, 0])
+    >>> col  = np.array([0, 2, 1, 3, 1, 0, 0])
+    >>> data = np.array([1, 1, 1, 1, 1, 1, 1])
+    >>> coo_matrix((data, (row, col)), shape=(4, 4)).toarray()
+    array([[3, 0, 1, 0],
+           [0, 2, 0, 0],
+           [0, 0, 0, 0],
+           [0, 0, 0, 1]])
 
     """
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
@@ -284,15 +284,15 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         --------
         >>> from numpy import array
         >>> from scipy.sparse import coo_matrix
-        >>> row  = array([0,0,1,3,1,0,0])
-        >>> col  = array([0,2,1,3,1,0,0])
-        >>> data = array([1,1,1,1,1,1,1])
-        >>> A = coo_matrix( (data,(row,col)), shape=(4,4)).tocsc()
-        >>> A.todense()
-        matrix([[3, 0, 1, 0],
-                [0, 2, 0, 0],
-                [0, 0, 0, 0],
-                [0, 0, 0, 1]])
+        >>> row  = array([0, 0, 1, 3, 1, 0, 0])
+        >>> col  = array([0, 2, 1, 3, 1, 0, 0])
+        >>> data = array([1, 1, 1, 1, 1, 1, 1])
+        >>> A = coo_matrix((data, (row, col)), shape=(4, 4)).tocsc()
+        >>> A.toarray()
+        array([[3, 0, 1, 0],
+               [0, 2, 0, 0],
+               [0, 0, 0, 0],
+               [0, 0, 0, 1]])
 
         """
         from .csc import csc_matrix
@@ -326,15 +326,15 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         --------
         >>> from numpy import array
         >>> from scipy.sparse import coo_matrix
-        >>> row  = array([0,0,1,3,1,0,0])
-        >>> col  = array([0,2,1,3,1,0,0])
-        >>> data = array([1,1,1,1,1,1,1])
-        >>> A = coo_matrix( (data,(row,col)), shape=(4,4)).tocsr()
-        >>> A.todense()
-        matrix([[3, 0, 1, 0],
-                [0, 2, 0, 0],
-                [0, 0, 0, 0],
-                [0, 0, 0, 1]])
+        >>> row  = array([0, 0, 1, 3, 1, 0, 0])
+        >>> col  = array([0, 2, 1, 3, 1, 0, 0])
+        >>> data = array([1, 1, 1, 1, 1, 1, 1])
+        >>> A = coo_matrix((data, (row, col)), shape=(4, 4)).tocsr()
+        >>> A.toarray()
+        array([[3, 0, 1, 0],
+               [0, 2, 0, 0],
+               [0, 0, 0, 0],
+               [0, 0, 0, 1]])
 
         """
         from .csr import csr_matrix

--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -86,26 +86,26 @@ class csc_matrix(_cs_matrix, IndexMixin):
 
     >>> from scipy.sparse import *
     >>> from scipy import *
-    >>> csc_matrix( (3,4), dtype=int8 ).todense()
-    matrix([[0, 0, 0, 0],
-            [0, 0, 0, 0],
-            [0, 0, 0, 0]], dtype=int8)
+    >>> csc_matrix((3, 4), dtype=int8).toarray()
+    array([[0, 0, 0, 0],
+           [0, 0, 0, 0],
+           [0, 0, 0, 0]], dtype=int8)
 
-    >>> row = array([0,2,2,0,1,2])
-    >>> col = array([0,0,1,2,2,2])
-    >>> data = array([1,2,3,4,5,6])
-    >>> csc_matrix( (data,(row,col)), shape=(3,3) ).todense()
-    matrix([[1, 0, 4],
-            [0, 0, 5],
-            [2, 3, 6]])
+    >>> row = array([0, 2, 2, 0, 1, 2])
+    >>> col = array([0, 0, 1, 2, 2, 2])
+    >>> data = array([1, 2, 3, 4, 5, 6])
+    >>> csc_matrix((data, (row, col)), shape=(3, 3)).toarray()
+    array([[1, 0, 4],
+           [0, 0, 5],
+           [2, 3, 6]])
 
-    >>> indptr = array([0,2,3,6])
-    >>> indices = array([0,2,2,0,1,2])
-    >>> data = array([1,2,3,4,5,6])
-    >>> csc_matrix( (data,indices,indptr), shape=(3,3) ).todense()
-    matrix([[1, 0, 4],
-            [0, 0, 5],
-            [2, 3, 6]])
+    >>> indptr = array([0, 2, 3, 6])
+    >>> indices = array([0, 2, 2, 0, 1, 2])
+    >>> data = array([1, 2, 3, 4, 5, 6])
+    >>> csc_matrix((data, indices, indptr), shape=(3, 3)).toarray()
+    array([[1, 0, 4],
+           [0, 0, 5],
+           [2, 3, 6]])
 
     """
 

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -82,26 +82,26 @@ class csr_matrix(_cs_matrix, IndexMixin):
 
     >>> from scipy.sparse import *
     >>> from scipy import *
-    >>> csr_matrix( (3,4), dtype=int8 ).todense()
-    matrix([[0, 0, 0, 0],
-            [0, 0, 0, 0],
-            [0, 0, 0, 0]], dtype=int8)
+    >>> csr_matrix((3, 4), dtype=int8).toarray()
+    array([[0, 0, 0, 0],
+           [0, 0, 0, 0],
+           [0, 0, 0, 0]], dtype=int8)
 
-    >>> row = array([0,0,1,2,2,2])
-    >>> col = array([0,2,2,0,1,2])
-    >>> data = array([1,2,3,4,5,6])
-    >>> csr_matrix( (data,(row,col)), shape=(3,3) ).todense()
-    matrix([[1, 0, 2],
-            [0, 0, 3],
-            [4, 5, 6]])
+    >>> row = array([0, 0, 1, 2, 2, 2])
+    >>> col = array([0, 2, 2, 0, 1, 2])
+    >>> data = array([1, 2, 3, 4, 5, 6])
+    >>> csr_matrix((data, (row, col)), shape=(3, 3)).toarray()
+    array([[1, 0, 2],
+           [0, 0, 3],
+           [4, 5, 6]])
 
-    >>> indptr = array([0,2,3,6])
-    >>> indices = array([0,2,2,0,1,2])
-    >>> data = array([1,2,3,4,5,6])
-    >>> csr_matrix( (data,indices,indptr), shape=(3,3) ).todense()
-    matrix([[1, 0, 2],
-            [0, 0, 3],
-            [4, 5, 6]])
+    >>> indptr = array([0, 2, 3, 6])
+    >>> indices = array([0, 2, 2, 0, 1, 2])
+    >>> data = array([1, 2, 3, 4, 5, 6])
+    >>> csr_matrix((data, indices, indptr), shape=(3, 3)).toarray()
+    array([[1, 0, 2],
+           [0, 0, 3],
+           [4, 5, 6]])
 
     """
 

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -103,6 +103,25 @@ class csr_matrix(_cs_matrix, IndexMixin):
            [0, 0, 3],
            [4, 5, 6]])
 
+    As an example of how to construct a CSR matrix incrementally,
+    the following snippet builds a term-document matrix from texts:
+
+    >>> docs = [["hello", "world", "hello"], ["goodbye", "cruel", "world"]]
+    >>> indptr = [0]
+    >>> indices = []
+    >>> data = []
+    >>> vocabulary = {}
+    >>> for d in docs:
+    ...     for term in d:
+    ...         index = vocabulary.setdefault(term, len(vocabulary))
+    ...         indices.append(index)
+    ...         data.append(1)
+    ...     indptr.append(len(indices))
+    ...
+    >>> csr_matrix((data, indices, indptr), dtype=int).toarray()
+    array([[2, 1, 0, 0],
+           [0, 1, 1, 1]])
+
     """
 
     def transpose(self, copy=False):

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -58,18 +58,18 @@ class dia_matrix(_data_matrix):
 
     >>> from scipy.sparse import *
     >>> from scipy import *
-    >>> dia_matrix( (3,4), dtype=int8).todense()
-    matrix([[0, 0, 0, 0],
-            [0, 0, 0, 0],
-            [0, 0, 0, 0]], dtype=int8)
+    >>> dia_matrix((3, 4), dtype=int8).toarray()
+    array([[0, 0, 0, 0],
+           [0, 0, 0, 0],
+           [0, 0, 0, 0]], dtype=int8)
 
-    >>> data = array([[1,2,3,4]]).repeat(3,axis=0)
+    >>> data = array([[1, 2, 3, 4]]).repeat(3, axis=0)
     >>> offsets = array([0,-1,2])
-    >>> dia_matrix( (data,offsets), shape=(4,4)).todense()
-    matrix([[1, 0, 3, 0],
-            [1, 2, 0, 4],
-            [0, 2, 3, 0],
-            [0, 0, 3, 4]])
+    >>> dia_matrix((data, offsets), shape=(4, 4)).toarray()
+    array([[1, 0, 3, 0],
+           [1, 2, 0, 4],
+           [0, 2, 3, 0],
+           [0, 0, 3, 4]])
 
     """
 

--- a/scipy/sparse/extract.py
+++ b/scipy/sparse/extract.py
@@ -71,25 +71,26 @@ def tril(A, k=0, format=None):
     Examples
     --------
     >>> from scipy.sparse import csr_matrix
-    >>> A = csr_matrix( [[1,2,0,0,3],[4,5,0,6,7],[0,0,8,9,0]], dtype='int32' )
-    >>> A.todense()
-    matrix([[1, 2, 0, 0, 3],
-            [4, 5, 0, 6, 7],
-            [0, 0, 8, 9, 0]])
-    >>> tril(A).todense()
-    matrix([[1, 0, 0, 0, 0],
-            [4, 5, 0, 0, 0],
-            [0, 0, 8, 0, 0]])
+    >>> A = csr_matrix([[1, 2, 0, 0, 3], [4, 5, 0, 6, 7], [0, 0, 8, 9, 0]],
+    ...                dtype='int32')
+    >>> A.toarray()
+    array([[1, 2, 0, 0, 3],
+           [4, 5, 0, 6, 7],
+           [0, 0, 8, 9, 0]])
+    >>> tril(A).toarray()
+    array([[1, 0, 0, 0, 0],
+           [4, 5, 0, 0, 0],
+           [0, 0, 8, 0, 0]])
     >>> tril(A).nnz
     4
-    >>> tril(A, k=1).todense()
-    matrix([[1, 2, 0, 0, 0],
-            [4, 5, 0, 0, 0],
-            [0, 0, 8, 9, 0]])
-    >>> tril(A, k=-1).todense()
-    matrix([[0, 0, 0, 0, 0],
-            [4, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0]])
+    >>> tril(A, k=1).toarray()
+    array([[1, 2, 0, 0, 0],
+           [4, 5, 0, 0, 0],
+           [0, 0, 8, 9, 0]])
+    >>> tril(A, k=-1).toarray()
+    array([[0, 0, 0, 0, 0],
+           [4, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0]])
     >>> tril(A, format='csc')
     <3x5 sparse matrix of type '<type 'numpy.int32'>'
             with 4 stored elements in Compressed Sparse Column format>
@@ -137,25 +138,26 @@ def triu(A, k=0, format=None):
     Examples
     --------
     >>> from scipy.sparse import csr_matrix
-    >>> A = csr_matrix( [[1,2,0,0,3],[4,5,0,6,7],[0,0,8,9,0]], dtype='int32' )
-    >>> A.todense()
-    matrix([[1, 2, 0, 0, 3],
-            [4, 5, 0, 6, 7],
-            [0, 0, 8, 9, 0]])
-    >>> triu(A).todense()
-    matrix([[1, 2, 0, 0, 3],
-            [0, 5, 0, 6, 7],
-            [0, 0, 8, 9, 0]])
+    >>> A = csr_matrix([[1, 2, 0, 0, 3], [4, 5, 0, 6, 7], [0, 0, 8, 9, 0]],
+    ...                dtype='int32')
+    >>> A.toarray()
+    array([[1, 2, 0, 0, 3],
+           [4, 5, 0, 6, 7],
+           [0, 0, 8, 9, 0]])
+    >>> triu(A).toarray()
+    array([[1, 2, 0, 0, 3],
+           [0, 5, 0, 6, 7],
+           [0, 0, 8, 9, 0]])
     >>> triu(A).nnz
     8
-    >>> triu(A, k=1).todense()
-    matrix([[0, 2, 0, 0, 3],
-            [0, 0, 0, 6, 7],
-            [0, 0, 0, 9, 0]])
-    >>> triu(A, k=-1).todense()
-    matrix([[1, 2, 0, 0, 3],
-            [4, 5, 0, 6, 7],
-            [0, 0, 8, 9, 0]])
+    >>> triu(A, k=1).toarray()
+    array([[0, 2, 0, 0, 3],
+           [0, 0, 0, 6, 7],
+           [0, 0, 0, 9, 0]])
+    >>> triu(A, k=-1).toarray()
+    array([[1, 2, 0, 0, 3],
+           [4, 5, 0, 6, 7],
+           [0, 0, 8, 9, 0]])
     >>> triu(A, format='csc')
     <3x5 sparse matrix of type '<type 'numpy.int32'>'
             with 8 stored elements in Compressed Sparse Column format>

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -24,8 +24,10 @@ from . import _csparsetools
 class lil_matrix(spmatrix, IndexMixin):
     """Row-based linked list sparse matrix
 
-    This is an efficient structure for constructing sparse
-    matrices incrementally.
+    This is a structure for constructing sparse matrices incrementally.
+    Note that inserting a single item can take linear time in the worst case;
+    to construct a matrix efficiently, make sure the items are pre-sorted by
+    index, per row.
 
     This can be instantiated in several ways:
         lil_matrix(D)


### PR DESCRIPTION
Here are three patches for scipy.sparse's documentation; they can be all pulled, or you may cherry-pick from them.
- The first warns about constructing a LIL matrix. This **quadratic time** operation is currently advertised as "efficient" in the docstring. I just answered [yet another SO question](http://stackoverflow.com/q/22796118/166749) amounting to "why does constructing a LIL matrix of 10k×10k take hours to run?"
- The second replaces all mentions of `todense` by `toarray`. The former returns the dreaded `np.matrix` class, which causes a lot of pain for the scikit-learn developers, and probably others. We have to educate all our contributors about using `toarray`.
- The third is an example of how to construct a CSR matrix incrementally. This is a recipe that I find myself reinventing over and over. It should give the user some more feel for how a CSR matrix is laid out, something that was previously hard to grasp from the docs.
