### PR TITLE
BUG: re-add `rv_frozen` to stats.distributions namespace.  Closes gh-3522

### DIFF
--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -7,7 +7,8 @@
 #
 from __future__ import division, print_function, absolute_import
 
-from ._distn_infrastructure import entropy, rv_discrete, rv_continuous
+from ._distn_infrastructure import (entropy, rv_discrete, rv_continuous,
+                                    rv_frozen)
 
 from . import _continuous_distns
 from . import _discrete_distns

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1153,6 +1153,10 @@ class TestFrozen(TestCase):
         rv1 = stats.genpareto(c=0.1)
         assert_(rv1.dist is not rv.dist)
 
+    def test_rv_frozen_in_namespace(self):
+        # Regression test for gh-3522
+        assert_(hasattr(stats.distributions, 'rv_frozen'))
+
 
 class TestExpect(TestCase):
     # Test for expect method.


### PR DESCRIPTION
Note that it was never in the stats namespace, so keep it like that.
