### PR TITLE
ENH: sparse: add count_nonzero method

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -88,7 +88,11 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         self.check_format(full_check=False)
 
     def getnnz(self, axis=None):
-        """Get the count of explicitly-stored values (nonzeros)
+        """Get the count of explicitly-stored values.
+
+        The name of this method is a misnomer, as the number of stored
+        elements may not actually be the number of non-zeros. Use the
+        count_nonzero member for the actual number of non-zeros.
 
         Parameters
         ----------

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -18,6 +18,12 @@ from .base import spmatrix
 from .sputils import isscalarlike
 from .lil import lil_matrix
 
+try:
+    from numpy import count_nonzero as _count_nonzero
+except ImportError:     # NumPy < 1.6.0
+    def _count_nonzero(x):
+        return len(np.flatnonzero(x))
+
 
 # TODO implement all relevant operations
 # use .data.__methods__() instead of /=, *=, etc.
@@ -67,6 +73,16 @@ class _data_matrix(spmatrix):
 
     def copy(self):
         return self._with_data(self.data.copy(), copy=True)
+
+    def count_nonzero(self):
+        """Number of non-zero entries.
+
+        Unlike getnnz and the nnz property, which return the number of stored
+        entries (the length of the data attribute) and tacitly assumes no
+        zeros are stored, this method counts the actual number of non-zero
+        entries in data.
+        """
+        return _count_nonzero(self.data)
 
     ###########################
     # Multiplication handlers #

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -111,8 +111,17 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             self.shape = arg1.shape
             self.dtype = d.dtype
 
-    def getnnz(self):
+    def count_nonzero(self):
+        """Count number of non-zero entries."""
         return dict.__len__(self)
+
+    def getnnz(self):
+        """Get number of stored entries.
+
+        Equivalent to count_nonzero for DOK matrices (but not necessarily for
+        other sparse matrix formats).
+        """
+        return self.count_nonzero()
     nnz = property(fget=getnnz)
 
     def __len__(self):

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -49,7 +49,7 @@ class lil_matrix(spmatrix, IndexMixin):
     ndim : int
         Number of dimensions (this is always 2)
     nnz
-        Number of nonzero elements
+        Number of stored elements
     data
         LIL format data array of the matrix
     rows
@@ -179,6 +179,15 @@ class lil_matrix(spmatrix, IndexMixin):
 
     # Whenever the dimensions change, empty lists should be created for each
     # row
+
+    def count_nonzero(self):
+        """Count number of non-zero stored entries.
+
+        For LIL matrices, this is equivalent to looking up the ``nnz``
+        attribute, because zeros are never stored (but this is not necessarily
+        true for other sparse matrix formats).
+        """
+        return self.nnz
 
     def getnnz(self, axis=None):
         """Get the count of explicitly-stored values (nonzeros)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -560,8 +560,9 @@ class _TestCommon:
 
     def test_empty(self):
         # create empty matrices
-        assert_equal(self.spmatrix((3,3)).todense(), np.zeros((3,3)))
-        assert_equal(self.spmatrix((3,3)).nnz, 0)
+        assert_equal(self.spmatrix((3, 3)).todense(), np.zeros((3,3)))
+        assert_equal(self.spmatrix((3, 3)).nnz, 0)
+        assert_equal(self.spmatrix((3, 2)).count_nonzero(), 0)
 
     def test_invalid_shapes(self):
         assert_raises(ValueError, self.spmatrix, (-1,3))


### PR DESCRIPTION
Here's a `count_nonzero` method for sparse matrices, as well as some better docs for `getnnz`, as discussed at #3343. It doesn't entirely fix that issue, and I'm not actually going to try to do that in a single PR.

Ping @argriffing, @chebee7i, @jnothman.
