### PR TITLE
BUG: stats: stats.levy.cdf with small arguments loses precision.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2467,10 +2467,12 @@ class levy_gen(rv_continuous):
         return 1 / sqrt(2*pi*x) / x * exp(-1/(2*x))
 
     def _cdf(self, x):
-        return 2 * (1 - _norm_cdf(1 / sqrt(x)))
+        # Equivalent to 2*norm.sf(sqrt(1/x))
+        return special.erfc(sqrt(0.5 / x))
 
     def _ppf(self, q):
-        val = _norm_ppf(1 - q / 2.0)
+        # Equivalent to 1.0/(norm.isf(q/2)**2) or 0.5/(erfcinv(q)**2)
+        val = -special.ndtri(q/2)
         return 1.0 / (val * val)
 
     def _stats(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1573,6 +1573,30 @@ def test_norm_logcdf():
         np.seterr(**olderr)
 
 
+def test_levy_cdf_ppf():
+    # Test levy.cdf, including small arguments.
+    x = np.array([1000, 1.0, 0.5, 0.1, 0.01, 0.001])
+
+    # Expected values were calculated separately with mpmath.
+    # E.g.
+    # >>> mpmath.mp.dps = 100
+    # >>> x = mpmath.mp.mpf('0.01')
+    # >>> cdf = mpmath.erfc(mpmath.sqrt(1/(2*x)))
+    expected = np.array([0.9747728793699604,
+                         0.3173105078629141,
+                         0.1572992070502851,
+                         0.0015654022580025495,
+                         1.523970604832105e-23,
+                         1.795832784800726e-219])
+
+    y = stats.levy.cdf(x)
+    assert_allclose(y, expected, rtol=1e-10)
+
+    # ppf(expected) should get us back to x.
+    xx = stats.levy.ppf(expected)
+    assert_allclose(xx, x, rtol=1e-13)
+
+
 def test_hypergeom_interval_1802():
     # these two had endless loops
     assert_equal(stats.hypergeom.interval(.95, 187601, 43192, 757),


### PR DESCRIPTION
Change the implementation of stats.levy._cdf from

```
def _cdf(self, x):
    return 2*(1-norm._cdf(1/sqrt(x)))
```

to

```
def _cdf(self, x):
    return special.erfc(np.sqrt(0.5 / x))
```

The old implementation suffers from catastrophic cancellation when
x is small, because then norm._cdf(1/sqrt(x)) is approximately 1.

For example, with the old implementation:

```
In [56]: x = np.array([0.05, 0.015, 0.0125, 0.011, 0.01, 0.001])

In [57]: stats.levy.cdf(x)
Out[57]: 
array([  7.74421643e-06,   2.22044605e-16,   0.00000000e+00,
         0.00000000e+00,   0.00000000e+00,   0.00000000e+00])
```

The new implementation is:

```
In [58]: special.erfc(np.sqrt(0.5/x))
Out[58]: 
array([  7.74421643e-006,   3.21526273e-016,   3.74409738e-019,
         1.50426951e-021,   1.52397060e-023,   1.79583278e-219])
```

`levy.ppf` also suffered from loss of precision with small arguments.   To fix it, the line

```
    val = _norm_ppf(1 - q / 2.0)
```

is changed to

```
    val = -special.ndtri(q/2)
```
