### PR TITLE
ENH: matrix square root for positive semi-definite matrices

### DIFF
--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -96,6 +96,7 @@ Matrix Functions
    tanhm - Matrix hyperbolic tangent
    signm - Matrix sign
    sqrtm - Matrix square root
+   sqrtm_psd - Matrix square root of a positive semi-definite matrix
    funm - Evaluating an arbitrary matrix function
    expm_frechet - Frechet derivative of the matrix exponential
    expm_cond - Relative condition number of expm in the Frobenius norm

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -98,6 +98,7 @@ Matrix Functions
    sqrtm - Matrix square root
    sqrtm_psd - Matrix square root of a positive semi-definite matrix
    funm - Evaluating an arbitrary matrix function
+   funm_psd - Evaluating a matrix function of a positive semi-definite matrix
    expm_frechet - Frechet derivative of the matrix exponential
    expm_cond - Relative condition number of expm in the Frobenius norm
    fractional_matrix_power - Fractional matrix power

--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -6,13 +6,14 @@ This module exists to avoid cyclic imports.
 """
 from __future__ import division, print_function, absolute_import
 
-__all__ = ['sqrtm']
+__all__ = ['sqrtm', 'sqrtm_psd']
 
 import numpy as np
 
 
 # Local imports
 from .misc import norm
+from .decomp import eigh
 from .lapack import ztrsyl, dtrsyl
 from .decomp_schur import schur, rsf2csf
 
@@ -135,6 +136,16 @@ def sqrtm(A, disp=True, blocksize=64):
 
         Frobenius norm of the estimated error, ||err||_F / ||A||_F
 
+    Notes
+    -----
+    Technically this function computes the unique principal matrix square root
+    and requires that no eigenvalue of the input matrix lies on the closed
+    negative real line.
+
+    See also
+    --------
+    sqrtm_psd : Matrix square root of a positive semi-definite matrix.
+
     References
     ----------
     .. [1] Edvin Deadman, Nicholas J. Higham, Rui Ralha (2013)
@@ -153,11 +164,23 @@ def sqrtm(A, disp=True, blocksize=64):
            [ 1.,  4.]])
 
     """
+    # Validate input.
     A = np.asarray(A)
     if len(A.shape) != 2:
         raise ValueError("Non-matrix input to matrix function.")
     if blocksize < 1:
         raise ValueError("The blocksize should be at least 1.")
+
+    # Special-case matrices that are exactly identically zero.
+    # Otherwise, generic singular matrices do not necessarily have
+    # matrix square roots.
+    A_frob_norm = norm(A, 'fro')
+    if not A_frob_norm:
+        if disp:
+            return A
+        else:
+            return A, np.inf
+
     keep_it_real = np.isrealobj(A)
     if keep_it_real:
         T, Z = schur(A)
@@ -175,6 +198,7 @@ def sqrtm(A, disp=True, blocksize=64):
         X = np.empty_like(A)
         X.fill(np.nan)
 
+    # disp and arg2 are for backward compatibility
     if disp:
         nzeig = np.any(np.diag(T) == 0)
         if nzeig:
@@ -184,9 +208,57 @@ def sqrtm(A, disp=True, blocksize=64):
         return X
     else:
         try:
-            arg2 = norm(X.dot(X) - A,'fro')**2 / norm(A,'fro')
+            arg2 = norm(X.dot(X) - A, 'fro')**2 / A_frob_norm
         except ValueError:
             # NaNs in matrix
             arg2 = np.inf
 
         return X, arg2
+
+
+def sqrtm_psd(A, check_finite=True):
+    """
+    Matrix square root of a positive semi-definite matrix.
+
+    Parameters
+    ----------
+    A : (N, N) array_like
+        Positive semi-definite matrix whose square root to evaluate.
+    check_finite : boolean, optional
+        Whether to check that the input matrices contain only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination) if the inputs do contain infinities or NaNs.
+
+    Returns
+    -------
+    sqrtm : (N, N) ndarray
+        Value of the sqrt function at `A`.
+    
+    See also
+    --------
+    sqrtm : Matrix square root without the psd restriction.
+
+    Examples
+    --------
+    >>> from scipy import linalg
+    >>> a = np.ones((4, 4))
+    >>> r = linalg.sqrtm_psd(a)
+    >>> r
+    array([[ 0.5,  0.5,  0.5,  0.5],
+           [ 0.5,  0.5,  0.5,  0.5],
+           [ 0.5,  0.5,  0.5,  0.5],
+           [ 0.5,  0.5,  0.5,  0.5]])
+    >>> r.dot(r)
+    array([[ 1.,  1.,  1.,  1.],
+           [ 1.,  1.,  1.,  1.],
+           [ 1.,  1.,  1.,  1.],
+           [ 1.,  1.,  1.,  1.]])
+
+    """
+    A = np.asarray(A)
+    if len(A.shape) != 2:
+        raise ValueError("Non-matrix input to matrix function.")
+    w, v = eigh(A, check_finite=check_finite)
+    w = np.sqrt(np.maximum(w, 0))
+    return (v * w).dot(v.conj().T)
+

--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -6,14 +6,13 @@ This module exists to avoid cyclic imports.
 """
 from __future__ import division, print_function, absolute_import
 
-__all__ = ['sqrtm', 'sqrtm_psd']
+__all__ = ['sqrtm']
 
 import numpy as np
 
 
 # Local imports
 from .misc import norm
-from .decomp import eigh
 from .lapack import ztrsyl, dtrsyl
 from .decomp_schur import schur, rsf2csf
 
@@ -214,47 +213,4 @@ def sqrtm(A, disp=True, blocksize=64):
             arg2 = np.inf
 
         return X, arg2
-
-
-def sqrtm_psd(A, check_finite=True):
-    """
-    Matrix square root of a positive semi-definite matrix.
-
-    Parameters
-    ----------
-    A : (N, N) array_like
-        Positive semi-definite matrix whose square root to evaluate.
-    check_finite : boolean, optional
-        Whether to check that the input matrices contain only finite numbers.
-        Disabling may give a performance gain, but may result in problems
-        (crashes, non-termination) if the inputs do contain infinities or NaNs.
-
-    Returns
-    -------
-    sqrtm : (N, N) ndarray
-        Value of the sqrt function at `A`.
-    
-    See also
-    --------
-    sqrtm : Matrix square root without the psd restriction.
-
-    Examples
-    --------
-    >>> from scipy import linalg
-    >>> a = np.outer([1, 2], [1, 2])
-    >>> r = scipy.linalg.sqrtm_psd(a)
-    >>> r
-    array([[ 0.4472136 ,  0.89442719],
-           [ 0.89442719,  1.78885438]])
-    >>> r.dot(r)
-    array([[ 1.,  2.],
-           [ 2.,  4.]])
-
-    """
-    A = np.asarray(A)
-    if len(A.shape) != 2:
-        raise ValueError("Non-matrix input to matrix function.")
-    w, v = eigh(A, check_finite=check_finite)
-    w = np.sqrt(np.maximum(w, 0))
-    return (v * w).dot(v.conj().T)
 

--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -241,18 +241,14 @@ def sqrtm_psd(A, check_finite=True):
     Examples
     --------
     >>> from scipy import linalg
-    >>> a = np.ones((4, 4))
-    >>> r = linalg.sqrtm_psd(a)
+    >>> a = np.outer([1, 2], [1, 2])
+    >>> r = scipy.linalg.sqrtm_psd(a)
     >>> r
-    array([[ 0.5,  0.5,  0.5,  0.5],
-           [ 0.5,  0.5,  0.5,  0.5],
-           [ 0.5,  0.5,  0.5,  0.5],
-           [ 0.5,  0.5,  0.5,  0.5]])
+    array([[ 0.4472136 ,  0.89442719],
+           [ 0.89442719,  1.78885438]])
     >>> r.dot(r)
-    array([[ 1.,  1.,  1.,  1.],
-           [ 1.,  1.,  1.,  1.],
-           [ 1.,  1.,  1.,  1.],
-           [ 1.,  1.,  1.,  1.]])
+    array([[ 1.,  2.],
+           [ 2.,  4.]])
 
     """
     A = np.asarray(A)

--- a/scipy/linalg/benchmarks/bench_sqrtm.py
+++ b/scipy/linalg/benchmarks/bench_sqrtm.py
@@ -10,7 +10,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 import scipy.linalg
 
-
 def bench_sqrtm():
     np.random.seed(1234)
     print()
@@ -55,3 +54,40 @@ def bench_sqrtm():
             # Check that the results are the same for all block sizes.
             assert_allclose(B_1, B_32)
             assert_allclose(B_1, B_64)
+
+
+def bench_sqrtm_psd():
+    np.random.seed(1234)
+    print()
+    print('            Positive Semi-Definite Matrix Square Root')
+    print('================================================================')
+    print('      shape      |    method    |        dtype       |   time   ')
+    print('                 |              |                    | (seconds)')
+    print('----------------------------------------------------------------')
+    fmt = ' %15s |   %9s  | %18s | %6.2f '
+    for n in (64, 256, 1024):
+        for dtype in (np.float64, np.complex128):
+
+            # Sample a random matrix.
+            if dtype == np.complex128:
+                A = np.random.rand(n, n) + 1j*np.random.rand(n, n)
+                A = np.dot(A, np.conj(A).T)
+            else:
+                A = np.random.rand(n, n)
+                A = np.dot(A, A.T)
+
+            # Compute the matrix square root generically.
+            tm = time.clock()
+            B_sqrtm, info = scipy.linalg.sqrtm(A, disp=False)
+            nseconds = time.clock() - tm
+            print(fmt % (A.shape, 'sqrtm', A.dtype, nseconds))
+
+            # Compute the matrix square root using positive semidefiniteness.
+            tm = time.clock()
+            B_sqrtm_psd = scipy.linalg.sqrtm_psd(A)
+            nseconds = time.clock() - tm
+            print(fmt % (A.shape, 'sqrtm_psd', A.dtype, nseconds))
+
+            # Check that the results of the two methods are the same.
+            assert_allclose(B_sqrtm_psd, B_sqrtm)
+

--- a/scipy/linalg/benchmarks/bench_sqrtm.py
+++ b/scipy/linalg/benchmarks/bench_sqrtm.py
@@ -10,6 +10,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import scipy.linalg
 
+
 def bench_sqrtm():
     np.random.seed(1234)
     print()

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -5,7 +5,7 @@
 from __future__ import division, print_function, absolute_import
 
 __all__ = ['expm','expm2','expm3','cosm','sinm','tanm','coshm','sinhm',
-           'tanhm','logm','funm','signm','sqrtm', 'sqrtm_psd',
+           'tanhm','logm','funm', 'funm_psd', 'signm','sqrtm', 'sqrtm_psd',
            'expm_frechet', 'expm_cond', 'fractional_matrix_power']
 
 from numpy import (Inf, dot, diag, exp, product, logical_not, cast, ravel,
@@ -17,11 +17,11 @@ import warnings
 from .misc import norm
 from .basic import solve, inv
 from .special_matrices import triu
-from .decomp import eig
+from .decomp import eig, eigh
 from .decomp_svd import svd
 from .decomp_schur import schur, rsf2csf
 from ._expm_frechet import expm_frechet, expm_cond
-from ._matfuncs_sqrtm import sqrtm, sqrtm_psd
+from ._matfuncs_sqrtm import sqrtm
 
 eps = np.finfo(float).eps
 feps = np.finfo(single).eps
@@ -529,6 +529,10 @@ def funm(A, func, disp=True):
 
         1-norm of the estimated error, ||err||_1 / ||A||_1
 
+    See also
+    --------
+    funm_psd : Evaluate a matrix function of a positive semi-definite matrix.
+
     Examples
     --------
     >>> a = np.array([[1.0, 3.0], [1.0, 4.0]])
@@ -580,6 +584,94 @@ def funm(A, func, disp=True):
         return F
     else:
         return F, err
+
+
+def funm_psd(A, func, check_finite=True):
+    """
+    Evaluate a matrix function of a positive semi-definite matrix.
+
+    Returns the value of matrix-valued function ``f`` at `A`. The
+    function ``f`` is an extension of the scalar-valued function `func`
+    to matrices.
+
+    Parameters
+    ----------
+    A : (N, N) array_like
+        Positive semi-definite matrix.
+    func : callable
+        Callable object that evaluates a scalar function f.
+        Must be vectorized (eg. using vectorize).
+    check_finite : boolean, optional
+        Whether to check that the input matrices contain only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination) if the inputs do contain infinities or NaNs.
+
+    Returns
+    -------
+    ret : (N, N) ndarray
+        Value of the matrix function at `A`.
+    
+    See also
+    --------
+    funm : Evaluate a matrix function without the psd restriction.
+
+    Examples
+    --------
+    >>> from scipy import linalg
+    >>> a = np.array([[1, 2], [2, 4]])
+    >>> r = linalg.funm_psd(a, np.sqrt)
+    >>> r
+    array([[ 0.4472136 ,  0.89442719],
+           [ 0.89442719,  1.78885438]])
+    >>> r.dot(r)
+    array([[ 1.,  2.],
+           [ 2.,  4.]])
+
+    """
+    A = np.asarray(A)
+    if len(A.shape) != 2:
+        raise ValueError("Non-matrix input to matrix function.")
+    w, v = eigh(A, check_finite=check_finite)
+    w = np.maximum(w, 0)
+    return (v * func(w)).dot(v.conj().T)
+
+
+def sqrtm_psd(A, check_finite=True):
+    """
+    Matrix square root of a positive semi-definite matrix.
+
+    Parameters
+    ----------
+    A : (N, N) array_like
+        Positive semi-definite matrix whose square root to evaluate.
+    check_finite : boolean, optional
+        Whether to check that the input matrices contain only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination) if the inputs do contain infinities or NaNs.
+
+    Returns
+    -------
+    sqrtm : (N, N) ndarray
+        Value of the sqrt function at `A`.
+    
+    See also
+    --------
+    sqrtm : Matrix square root without the psd restriction.
+
+    Examples
+    --------
+    >>> from scipy import linalg
+    >>> a = np.array([[1, 2], [2, 4]])
+    >>> r = scipy.linalg.sqrtm_psd(a)
+    >>> r
+    array([[ 0.4472136 ,  0.89442719],
+           [ 0.89442719,  1.78885438]])
+    >>> r.dot(r)
+    array([[ 1.,  2.],
+           [ 2.,  4.]])
+
+    """
+    return funm_psd(A, np.sqrt, check_finite)
 
 
 def signm(A, disp=True):

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -5,7 +5,7 @@
 from __future__ import division, print_function, absolute_import
 
 __all__ = ['expm','expm2','expm3','cosm','sinm','tanm','coshm','sinhm',
-           'tanhm','logm','funm','signm','sqrtm',
+           'tanhm','logm','funm','signm','sqrtm', 'sqrtm_psd',
            'expm_frechet', 'expm_cond', 'fractional_matrix_power']
 
 from numpy import (Inf, dot, diag, exp, product, logical_not, cast, ravel,
@@ -21,7 +21,7 @@ from .decomp import eig
 from .decomp_svd import svd
 from .decomp_schur import schur, rsf2csf
 from ._expm_frechet import expm_frechet, expm_cond
-from ._matfuncs_sqrtm import sqrtm
+from ._matfuncs_sqrtm import sqrtm, sqrtm_psd
 
 eps = np.finfo(float).eps
 feps = np.finfo(single).eps


### PR DESCRIPTION
Inspired by https://github.com/scipy/scipy/issues/3549 this PR adds `funm_psd` to evaluate general matrix functions of positive semi-definite matrices, and in particular adds `sqrtm_psd` specialized to the matrix square root.  It includes benchmarks and tests.  For real positive semi-definite matrices near size N=1000, `sqrtm_psd` is about twice as fast as the less specific `sqrtm` and correctly returns real (as opposed to complex) matrices for real positive semi-definite input matrices.

Interface advice would be welcome, for example maybe it would be better to add more kwargs to existing functions rather than to add new separate functions specialized to positive semi-definite matrices.  Another alternative would be to just provide a recipe for these functions in the scipy documentation rather than adding new functionality, because the implementations are thin wrappers around `eigh`.

```
            Positive Semi-Definite Matrix Square Root
================================================================
      shape      |    method    |        dtype       |   time   
                 |              |                    | (seconds)
----------------------------------------------------------------
        (64, 64) |       sqrtm  |            float64 |   0.07 
        (64, 64) |   sqrtm_psd  |            float64 |   0.02 
        (64, 64) |       sqrtm  |         complex128 |   0.20 
        (64, 64) |   sqrtm_psd  |         complex128 |   0.01 
      (256, 256) |       sqrtm  |            float64 |   1.14 
      (256, 256) |   sqrtm_psd  |            float64 |   0.55 
      (256, 256) |       sqrtm  |         complex128 |   1.57 
      (256, 256) |   sqrtm_psd  |         complex128 |   0.62 
    (1024, 1024) |       sqrtm  |            float64 |  41.72 
    (1024, 1024) |   sqrtm_psd  |            float64 |  17.55 
    (1024, 1024) |       sqrtm  |         complex128 |  71.01 
    (1024, 1024) |   sqrtm_psd  |         complex128 |  23.55 
```
