### PR TITLE
Fix test failures with numpy master. Closes gh-3554

### DIFF
--- a/scipy/lib/_version.py
+++ b/scipy/lib/_version.py
@@ -73,7 +73,7 @@ class NumpyVersion():
             else:
                 self.pre_release = ''
 
-        self.is_devversion = bool(re.search(r'.dev-', vstring))
+        self.is_devversion = bool(re.search(r'.dev', vstring))
 
     def _compare_version(self, other):
         """Compare major.minor.bugfix"""

--- a/scipy/sparse/linalg/isolve/tests/test_lsmr.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lsmr.py
@@ -18,8 +18,7 @@ Dept of MS&E, Stanford University.
 
 from __future__ import division, print_function, absolute_import
 
-from numpy import arange, concatenate, eye, zeros, ones, sqrt, \
-                  transpose, hstack
+from numpy import arange, eye, zeros, ones, sqrt, transpose, hstack
 from numpy.linalg import norm
 from numpy.testing import run_module_suite, assert_almost_equal
 
@@ -36,8 +35,8 @@ class TestLSMR:
     def assertCompatibleSystem(self, A, xtrue):
         Afun = aslinearoperator(A)
         b = Afun.matvec(xtrue)
-        x = lsmr(A,b)[0]
-        assert_almost_equal(norm(x - xtrue), 0, 6)
+        x = lsmr(A, b)[0]
+        assert_almost_equal(norm(x - xtrue), 0, decimal=5)
 
     def testIdentityACase1(self):
         A = eye(self.n)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1055,6 +1055,11 @@ class _TestCommon:
             assert_array_equal(datsp - A.todense(),dat - A.todense())
 
         for dtype in self.checked_dtypes:
+            if (dtype == np.dtype('bool')) and (
+                    NumpyVersion(np.__version__) >= '1.9.0.dev'):
+                # boolean array subtraction deprecated in 1.9.0
+                continue
+
             yield check, dtype
 
     def test_add0(self):
@@ -1389,6 +1394,11 @@ class _TestCommon:
                 assert_array_equal(sum2, dat + dat)
 
         for dtype in self.checked_dtypes:
+            if (dtype == np.dtype('bool')) and (
+                    NumpyVersion(np.__version__) >= '1.9.0.dev'):
+                # boolean array subtraction deprecated in 1.9.0
+                continue
+
             yield check, dtype
 
     def test_maximum_minimum(self):
@@ -2092,6 +2102,7 @@ class _TestSlicing:
             for j, b in enumerate(slices):
                 yield check_2, a, b
 
+    @dec.skipif(NumpyVersion(np.__version__) >= '1.9.0.dev')
     def test_ellipsis_slicing(self):
         b = asmatrix(arange(50).reshape(5,10))
         a = self.spmatrix(b)
@@ -2709,6 +2720,11 @@ class _TestArithmetic:
                 assert_array_equal(A + Bsp,D1)          # check dense + sparse
 
                 # subtraction
+                if (np.dtype('bool') in [x, y]) and (
+                        NumpyVersion(np.__version__) >= '1.9.0.dev'):
+                    # boolean array subtraction deprecated in 1.9.0
+                    continue
+
                 D1 = A - B
                 S1 = Asp - Bsp
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2102,7 +2102,6 @@ class _TestSlicing:
             for j, b in enumerate(slices):
                 yield check_2, a, b
 
-    @dec.skipif(NumpyVersion(np.__version__) >= '1.9.0.dev')
     def test_ellipsis_slicing(self):
         b = asmatrix(arange(50).reshape(5,10))
         a = self.spmatrix(b)
@@ -2110,21 +2109,28 @@ class _TestSlicing:
         assert_array_equal(a[...].A, b[...].A)
         assert_array_equal(a[...,].A, b[...,].A)
 
-        assert_array_equal(a[..., ...].A, b[..., ...].A)
         assert_array_equal(a[1, ...].A, b[1, ...].A)
         assert_array_equal(a[..., 1].A, b[..., 1].A)
         assert_array_equal(a[1:, ...].A, b[1:, ...].A)
         assert_array_equal(a[..., 1:].A, b[..., 1:].A)
 
-        assert_array_equal(a[..., ..., ...].A, b[..., ..., ...].A)
-        assert_array_equal(a[1, ..., ...].A, b[1, ..., ...].A)
-        assert_array_equal(a[1:, ..., ...].A, b[1:, ..., ...].A)
-        assert_array_equal(a[..., ..., 1:].A, b[..., ..., 1:].A)
         assert_array_equal(a[1:, 1, ...].A, b[1:, 1, ...].A)
         assert_array_equal(a[1, ..., 1:].A, b[1, ..., 1:].A)
         # These return ints
         assert_equal(a[1, 1, ...], b[1, 1, ...])
         assert_equal(a[1, ..., 1], b[1, ..., 1])
+
+    @dec.skipif(NumpyVersion(np.__version__) >= '1.9.0.dev')
+    def test_multiple_ellipsis_slicing(self):
+        b = asmatrix(arange(50).reshape(5,10))
+        a = self.spmatrix(b)
+
+        assert_array_equal(a[..., ...].A, b[..., ...].A)
+        assert_array_equal(a[..., ..., ...].A, b[..., ..., ...].A)
+        assert_array_equal(a[1, ..., ...].A, b[1, ..., ...].A)
+        assert_array_equal(a[1:, ..., ...].A, b[1:, ..., ...].A)
+        assert_array_equal(a[..., ..., 1:].A, b[..., ..., 1:].A)
+
         # Bug in NumPy's slicing
         assert_array_equal(a[..., ..., 1].A, b[..., ..., 1].A.reshape((5,1)))
 

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -712,12 +712,13 @@ class TestCompareWithStats(TestCase):
         np.random.seed(1234567)
         x = np.random.randn(n)
         y = x + np.random.randn(n)
-        xm = np.ones(len(x) + 5) * np.nan
-        ym = np.ones(len(y) + 5) * np.nan
+        xm = np.ones(len(x) + 5) * 1e16
+        ym = np.ones(len(y) + 5) * 1e16
         xm[0:len(x)] = x
         ym[0:len(y)] = y
-        xm = np.ma.array(xm, mask=np.isnan(xm))
-        ym = np.ma.array(ym, mask=np.isnan(ym))
+        mask = xm > 9e15
+        xm = np.ma.array(xm, mask=mask)
+        ym = np.ma.array(ym, mask=mask)
         return x, y, xm, ym
 
     def generate_xy_sample2D(self, n, nx):
@@ -764,11 +765,11 @@ class TestCompareWithStats(TestCase):
             x, y, xm, ym = self.generate_xy_sample(n)
             r = stats.gmean(abs(x))
             rm = stats.mstats.gmean(abs(xm))
-            assert_equal(r,rm)
+            assert_equal(r, rm)
 
             r = stats.gmean(abs(y))
             rm = stats.mstats.gmean(abs(ym))
-            assert_equal(r,rm)
+            assert_equal(r, rm)
 
     def test_hmean(self):
         for n in self.get_n():

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -255,25 +255,28 @@ class TestTrimming(TestCase):
 
         a = ma.arange(12)
         a[[0,-1]] = a[5] = masked
-        assert_equal(mstats.trim(a,(2,8)),
-                     [None,None,2,3,4,None,6,7,8,None,None,None])
+        assert_equal(mstats.trim(a, (2,8)),
+                     [None, None, 2, 3, 4, None, 6, 7, 8, None, None, None])
 
-        x = ma.arange(100).reshape(10,10)
-        trimx = mstats.trim(x,(0.1,0.2),relative=True,axis=None)
-        assert_equal(trimx._mask.ravel(),[1]*10+[0]*70+[1]*20)
-        trimx = mstats.trim(x,(0.1,0.2),relative=True,axis=0)
-        assert_equal(trimx._mask.ravel(),[1]*10+[0]*70+[1]*20)
-        trimx = mstats.trim(x,(0.1,0.2),relative=True,axis=-1)
-        assert_equal(trimx._mask.T.ravel(),[1]*10+[0]*70+[1]*20)
+        x = ma.arange(100).reshape(10, 10)
+        expected = [1]*10 + [0]*70 + [1]*20
+        trimx = mstats.trim(x, (0.1,0.2), relative=True, axis=None)
+        assert_equal(trimx._mask.ravel(), expected)
+        trimx = mstats.trim(x, (0.1,0.2), relative=True, axis=0)
+        assert_equal(trimx._mask.ravel(), expected)
+        trimx = mstats.trim(x, (0.1,0.2), relative=True, axis=-1)
+        assert_equal(trimx._mask.T.ravel(), expected)
 
-        x = ma.arange(110).reshape(11,10)
+        # same as above, but with an extra masked row inserted
+        x = ma.arange(110).reshape(11, 10)
         x[1] = masked
-        trimx = mstats.trim(x,(0.1,0.2),relative=True,axis=None)
-        assert_equal(trimx._mask.ravel(),[1]*20+[0]*70+[1]*20)
-        trimx = mstats.trim(x,(0.1,0.2),relative=True,axis=0)
-        assert_equal(trimx._mask.ravel(),[1]*20+[0]*70+[1]*20)
-        trimx = mstats.trim(x.T,(0.1,0.2),relative=True,axis=-1)
-        assert_equal(trimx.T._mask.ravel(),[1]*20+[0]*70+[1]*20)
+        expected = [1]*20 + [0]*70 + [1]*20
+        trimx = mstats.trim(x, (0.1,0.2), relative=True, axis=None)
+        assert_equal(trimx._mask.ravel(), expected)
+        trimx = mstats.trim(x, (0.1,0.2), relative=True, axis=0)
+        assert_equal(trimx._mask.ravel(), expected)
+        trimx = mstats.trim(x.T, (0.1,0.2), relative=True, axis=-1)
+        assert_equal(trimx.T._mask.ravel(), expected)
 
     def test_trim_old(self):
         x = ma.arange(100)
@@ -898,8 +901,8 @@ class TestCompareWithStats(TestCase):
     def test_tmean(self):
         for n in self.get_n():
             x, y, xm, ym = self.generate_xy_sample(n)
-            assert_equal(stats.tmean(x),stats.mstats.tmean(xm))
-            assert_equal(stats.tmean(y),stats.mstats.tmean(ym))
+            assert_almost_equal(stats.tmean(x),stats.mstats.tmean(xm), 14)
+            assert_almost_equal(stats.tmean(y),stats.mstats.tmean(ym), 14)
 
     def test_tmax(self):
         for n in self.get_n():


### PR DESCRIPTION
- fixes for deprecations of subtracting boolean arrays and indexing with more than one ellipsis.
- fixes two out of three failures of gh-3554 (third one is a numpy regression).
