### PR TITLE
TST: use non-interactive matplotlib backend

### DIFF
--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -55,6 +55,8 @@ from scipy.spatial.distance import squareform, pdist
 # Matplotlib is not a scipy dependency but is optionally used in dendrogram, so
 # check if it's available
 try:
+    import matplotlib
+    matplotlib.rcParams['backend'] = 'Agg'
     import matplotlib.pyplot as plt
     have_matplotlib = True
 except:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -17,6 +17,8 @@ from scipy import stats
 # Matplotlib is not a scipy dependency but is optionally used in probplot, so
 # check if it's available
 try:
+    import matplotlib
+    matplotlib.rcParams['backend'] = 'Agg'
     import matplotlib.pyplot as plt
     have_matplotlib = True
 except:


### PR DESCRIPTION
Fixes a segfault at the end of `scipy.test()` on Python 3.4 for Windows when matplotlib 1.3.1 is installed and `TkAgg` is the default backend. Please consider backporting to version 0.14.x.
Probably related to https://github.com/scipy/scipy/pull/3546. The fix is based on https://github.com/scipy/scipy/blob/master/scipy/spatial/tests/test__plotutils.py#L6

```
Running unit tests for scipy
NumPy version 1.8.1
NumPy is installed in X:\Python34\lib\site-packages\numpy
SciPy version 0.14.0rc2
SciPy is installed in X:\Python34\lib\site-packages\scipy
Python version 3.4.0 (v3.4.0:04f714765c13, Mar 16 2014, 19:25:23) [MSC v.1600 64 bit (AMD64)]
nose version 1.3.1
<snip>
----------------------------------------------------------------------
Ran 16416 tests in 193.865s

OK (KNOWNFAIL=277, SKIP=1157)
alloc: invalid block: 0000000005D4FE00: 60 5
```
