### PR TITLE
Fixes multiple bugs in mstats.theilslopes

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -245,6 +245,7 @@ which work for masked arrays.
    pointbiserialr
    kendalltau
    linregress
+   theilslopes
 
 .. autosummary::
    :toctree: generated/

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -678,7 +678,7 @@ def theilslopes(y, x=None, alpha=0.05):
     y : array_like
         Dependent variable.
     x : {None, array_like}, optional
-        Independent variable. If None, use arange(len(y)) instead.
+        Independent variable. If None, use ``arange(len(y))`` instead.
     alpha : float
         Confidence degree between 0 and 1. Default is 95% confidence.
 
@@ -692,22 +692,21 @@ def theilslopes(y, x=None, alpha=0.05):
         Lower bound of the confidence interval on medslope
     up_slope : float
         Upper bound of the confidence interval on medslope
-    
+
     Examples
     --------
     >>> from scipy.stats import mstats
-    >>> import numpy as np
     >>> y = np.random.random(10)
-    
+
     # Compute the slope, intercept and 90% confidence interval:
-    
+
     >>> medslope, medintercept, lo_slope, up_slope = mstats.theilslopes(y, 0.9)
-    
+
     References
     ----------
-    Sen, P. (1968). Estimates of the regression coefficient based on 
+    Sen, P. (1968). Estimates of the regression coefficient based on
     Kendall's tau.
-    
+
     """
     y = ma.asarray(y).flatten()
     if x is None:

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -669,45 +669,7 @@ if stats.linregress.__doc__:
     linregress.__doc__ = stats.linregress.__doc__ + genmissingvaldoc
 
 
-def theilslopes(y, x=None, alpha=0.05):
-    """
-    Computes the Theil slope as the median of all slopes between paired values.
-
-    Parameters
-    ----------
-    y : array_like
-        Dependent variable.
-    x : {None, array_like}, optional
-        Independent variable. If None, use ``arange(len(y))`` instead.
-    alpha : float
-        Confidence degree between 0 and 1. Default is 95% confidence.
-
-    Returns
-    -------
-    medslope : float
-        Theil slope
-    medintercept : float
-        Intercept of the Theil line, as median(y)-medslope*median(x)
-    lo_slope : float
-        Lower bound of the confidence interval on medslope
-    up_slope : float
-        Upper bound of the confidence interval on medslope
-
-    Examples
-    --------
-    >>> from scipy.stats import mstats
-    >>> y = np.random.random(10)
-
-    # Compute the slope, intercept and 90% confidence interval:
-
-    >>> medslope, medintercept, lo_slope, up_slope = mstats.theilslopes(y, 0.9)
-
-    References
-    ----------
-    Sen, P. (1968). Estimates of the regression coefficient based on
-    Kendall's tau.
-
-    """
+def theilslopes(y, x=None, alpha=0.95):
     y = ma.asarray(y).flatten()
     if x is None:
         x = ma.arange(len(y), dtype=float)
@@ -715,6 +677,7 @@ def theilslopes(y, x=None, alpha=0.05):
         x = ma.asarray(x).flatten()
         if len(x) != len(y):
             raise ValueError("Incompatible lengths ! (%s<>%s)" % (len(y),len(x)))
+
     m = ma.mask_or(ma.getmask(x), ma.getmask(y))
     y._mask = x._mask = m
     # Disregard any masked elements of x or y
@@ -722,6 +685,7 @@ def theilslopes(y, x=None, alpha=0.05):
     x = x.compressed().astype(float)
     # We now have unmasked arrays so can use `stats.theilslopes`
     return stats.theilslopes(y, x, alpha=alpha)
+theilslopes.__doc__ = stats.theilslopes.__doc__
 
 
 def sen_seasonal_slopes(x):

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -724,6 +724,7 @@ def theilslopes(y, x=None, alpha=0.05):
     # We now have unmasked arrays so can use `stats.theilslopes`
     return stats.theilslopes(y, x, alpha=alpha)
 
+
 def sen_seasonal_slopes(x):
     x = ma.array(x, subok=True, copy=False, ndmin=2)
     (n,_) = x.shape

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -680,7 +680,7 @@ def theilslopes(y, x=None, alpha=0.05):
     x : {None, array_like}, optional
         Independent variable. If None, use arange(len(y)) instead.
     alpha : float
-        Confidence degree.
+        Confidence degree between 0 and 1. Default is 95% confidence.
 
     Returns
     -------
@@ -692,7 +692,22 @@ def theilslopes(y, x=None, alpha=0.05):
         Lower bound of the confidence interval on medslope
     up_slope : float
         Upper bound of the confidence interval on medslope
-
+    
+    Examples
+    --------
+    >>> from scipy.stats import mstats
+    >>> import numpy as np
+    >>> y = np.random.random(10)
+    
+    # Compute the slope, intercept and 90% confidence interval:
+    
+    >>> medslope, medintercept, lo_slope, up_slope = mstats.theilslopes(y, 0.9)
+    
+    References
+    ----------
+    Sen, P. (1968). Estimates of the regression coefficient based on 
+    Kendall's tau.
+    
     """
     y = ma.asarray(y).flatten()
     if x is None:
@@ -706,30 +721,8 @@ def theilslopes(y, x=None, alpha=0.05):
     # Disregard any masked elements of x or y
     y = y.compressed()
     x = x.compressed().astype(float)
-    # Compute sorted slopes only when deltax > 0
-    deltax = x[:,np.newaxis] - x
-    deltay = y[:,np.newaxis] - y
-    slopes = deltay[deltax > 0] / deltax[deltax > 0]
-    slopes.sort()
-    medslope = ma.median(slopes)
-    medinter = ma.median(y) - medslope*ma.median(x)
-    # Now compute confidence intervals
-    if alpha > 0.5:
-        alpha = 1.-alpha
-    z = stats.distributions.norm.ppf(alpha/2.)
-    #
-    xties = count_tied_groups(x)
-    nt = len(slopes)       # N in Sen (1968)
-    ny = len(y)            # n in Sen (1968)
-    sigsq = (1/18.) * (    # equation 2.6 in Sen (1968)
-        ny*(ny-1)*(2*ny+5)
-        - np.sum(v*k*(k-1)*(2*k+5) for (k,v) in iteritems(xties)))
-    sigma = np.sqrt(sigsq)
-    Ru = min(np.round((nt - z*sigma)/2.), len(slopes)-1)
-    Rl = max(np.round((nt + z*sigma)/2.) - 1, 0)
-    delta = slopes[[Rl,Ru]]
-    return medslope, medinter, delta[0], delta[1]
-
+    # We now have unmasked arrays so can use `stats.theilslopes`
+    return stats.theilslopes(y, x, alpha=alpha)
 
 def sen_seasonal_slopes(x):
     x = ma.array(x, subok=True, copy=False, ndmin=2)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3040,8 +3040,8 @@ def linregress(x, y=None):
     return slope, intercept, r, prob, sterrest
 
 
-def theilslopes(y, x=None, alpha=0.05):
-    """
+def theilslopes(y, x=None, alpha=0.95):
+    r"""
     Computes the Theil-Sen estimator for a set of points (x, y).
 
     `theilslopes` implements a method for robust linear regression.  It
@@ -3070,6 +3070,10 @@ def theilslopes(y, x=None, alpha=0.05):
     up_slope : float
         Upper bound of the confidence interval on `medslope`.
 
+    Notes
+    -----
+    The implementation of `theilslopes` follows [1]_.
+
     References
     ----------
     .. [1] P.K. Sen, "Estimates of the regression coefficient based on Kendall's tau",
@@ -3081,11 +3085,30 @@ def theilslopes(y, x=None, alpha=0.05):
     Examples
     --------
     >>> from scipy import stats
-    >>> y = np.random.random(10)
+    >>> import matplotlib.pyplot as plt
 
-    # Compute the slope, intercept and 90% confidence interval:
+    >>> x = np.linspace(0, 5, num=150)
+    >>> y = x + np.random.normal(size=x.size)
+    >>> y[11:15] += 10  # add outliers
+    >>> y[-5:] -= 7
 
-    >>> medslope, medintercept, lo_slope, up_slope = stats.theilslopes(y, 0.9)
+    Compute the slope, intercept and 90% confidence interval.  For comparison,
+    also compute the least-squares fit with `linregress`:
+
+    >>> res = stats.theilslopes(y, x, 0.90)
+    >>> lsq_res = stats.linregress(x, y)
+
+    Plot the results, with the Theil-Sen confidence interval (red dashes) and
+    the comparison with `linregress` (green):
+
+    >>> fig = plt.figure()
+    >>> ax = fig.add_subplot(111)
+    >>> ax.plot(x, y, 'b.')
+    >>> ax.plot(x, res[1] + res[0] * x, 'r-')
+    >>> ax.plot(x, res[1] + res[2] * x, 'r--')
+    >>> ax.plot(x, res[1] + res[3] * x, 'r--')
+    >>> ax.plot(x, lsq_res[1] + lsq_res[0] * x, 'g-')
+    >>> plt.show()
 
     """
     y = np.asarray(y).flatten()

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3099,12 +3099,14 @@ def theilslopes(y, x=None, alpha=0.05):
         alpha = 1.-alpha
     z = distributions.norm.ppf(alpha/2.)
     # this implements (2.6) from Sen (1968)
-    xreps, nreps = find_repeats(x)
+    _, nxreps = find_repeats(x)
+    _, nyreps = find_repeats(y)
     nt = len(slopes)       # N in Sen (1968)
     ny = len(y)            # n in Sen (1968)
     sigsq = (1/18.) * (    # equation 2.6 in Sen (1968)
         ny*(ny-1)*(2*ny+5)
-        - np.sum(k*(k-1)*(2*k+5) for k in nreps))
+        - np.sum(k*(k-1)*(2*k+5) for k in nxreps)
+        - np.sum(k*(k-1)*(2*k+5) for k in nyreps))
     # find the confidence interval indices in `slopes`
     sigma = np.sqrt(sigsq)
     Ru = min(np.round((nt - z*sigma)/2.), len(slopes)-1)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -112,6 +112,7 @@ Correlation Functions
    pointbiserialr
    kendalltau
    linregress
+   theilslopes
 
 Inferential Stats
 -----------------
@@ -187,25 +188,23 @@ from . import distributions
 
 from ._rank import rankdata, tiecorrect
 
-__all__ = ['find_repeats', 'gmean', 'hmean', 'mode',
-           'tmean', 'tvar', 'tmin', 'tmax', 'tstd', 'tsem',
-           'moment', 'variation', 'skew', 'kurtosis', 'describe',
-           'skewtest', 'kurtosistest', 'normaltest', 'jarque_bera',
-           'itemfreq', 'scoreatpercentile', 'percentileofscore',
-           'histogram', 'histogram2', 'cumfreq', 'relfreq',
-           'obrientransform', 'signaltonoise', 'sem', 'zmap', 'zscore',
-           'threshold', 'sigmaclip', 'trimboth', 'trim1', 'trim_mean',
-           'f_oneway', 'pearsonr', 'fisher_exact',
-           'spearmanr', 'pointbiserialr', 'kendalltau', 'linregress',
-           'ttest_1samp', 'ttest_ind', 'ttest_rel', 'kstest',
-           'chisquare', 'power_divergence', 'ks_2samp', 'mannwhitneyu',
+__all__ = ['find_repeats', 'gmean', 'hmean', 'mode', 'tmean', 'tvar',
+           'tmin', 'tmax', 'tstd', 'tsem', 'moment', 'variation',
+           'skew', 'kurtosis', 'describe', 'skewtest', 'kurtosistest',
+           'normaltest', 'jarque_bera', 'itemfreq',
+           'scoreatpercentile', 'percentileofscore', 'histogram',
+           'histogram2', 'cumfreq', 'relfreq', 'obrientransform',
+           'signaltonoise', 'sem', 'zmap', 'zscore', 'threshold',
+           'sigmaclip', 'trimboth', 'trim1', 'trim_mean', 'f_oneway',
+           'pearsonr', 'fisher_exact', 'spearmanr', 'pointbiserialr',
+           'kendalltau', 'linregress', 'theilslopes', 'ttest_1samp',
+           'ttest_ind', 'ttest_rel', 'kstest', 'chisquare',
+           'power_divergence', 'ks_2samp', 'mannwhitneyu',
            'tiecorrect', 'ranksums', 'kruskal', 'friedmanchisquare',
            'zprob', 'chisqprob', 'ksprob', 'fprob', 'betai',
            'f_value_wilks_lambda', 'f_value', 'f_value_multivariate',
-           'ss', 'square_of_sums',
-           'fastsort', 'rankdata',
-           'nanmean', 'nanstd', 'nanmedian',
-           ]
+           'ss', 'square_of_sums', 'fastsort', 'rankdata', 'nanmean',
+           'nanstd', 'nanmedian', ]
 
 
 def _chk_asarray(a, axis):
@@ -3039,6 +3038,79 @@ def linregress(x, y=None):
     intercept = ymean - slope*xmean
     sterrest = np.sqrt((1-r*r)*ssym / ssxm / df)
     return slope, intercept, r, prob, sterrest
+
+
+def theilslopes(y, x=None, alpha=0.05):
+    """
+    Computes the Theil slope as the median of all slopes between paired values.
+
+    Parameters
+    ----------
+    y : array_like
+        Dependent variable.
+    x : {None, array_like}, optional
+        Independent variable. If None, use arange(len(y)) instead.
+    alpha : float
+        Confidence degree between 0 and 1. Default is 95% confidence.
+
+    Returns
+    -------
+    medslope : float
+        Theil slope
+    medintercept : float
+        Intercept of the Theil line, as median(y)-medslope*median(x)
+    lo_slope : float
+        Lower bound of the confidence interval on medslope
+    up_slope : float
+        Upper bound of the confidence interval on medslope
+    
+    Examples
+    --------
+    >>> from scipy import stats
+    >>> import numpy as np
+    >>> y = np.random.random(10)
+    
+    # Compute the slope, intercept and 90% confidence interval:
+    
+    >>> medslope, medintercept, lo_slope, up_slope = stats.theilslopes(y, 0.9)
+
+    References
+    ----------
+    Sen, P. (1968). Estimates of the regression coefficient based on 
+    Kendall's tau.
+    
+    """
+    y = np.asarray(y).flatten()
+    if x is None:
+        x = np.arange(len(y), dtype=float)
+    else:
+        x = np.asarray(x, dtype=float).flatten()
+        if len(x) != len(y):
+            raise ValueError("Incompatible lengths ! (%s<>%s)" % (len(y),len(x)))
+    # Compute sorted slopes only when deltax > 0
+    deltax = x[:,np.newaxis] - x
+    deltay = y[:,np.newaxis] - y
+    slopes = deltay[deltax > 0] / deltax[deltax > 0]
+    slopes.sort()
+    medslope = np.median(slopes)
+    medinter = np.median(y) - medslope*np.median(x)
+    # Now compute confidence intervals
+    if alpha > 0.5:
+        alpha = 1.-alpha
+    z = distributions.norm.ppf(alpha/2.)
+    # this implements (2.6) from Sen (1968)
+    xreps, nreps = find_repeats(x)
+    nt = len(slopes)       # N in Sen (1968)
+    ny = len(y)            # n in Sen (1968)
+    sigsq = (1/18.) * (    # equation 2.6 in Sen (1968)
+        ny*(ny-1)*(2*ny+5)
+        - np.sum(k*(k-1)*(2*k+5) for k in nreps))
+    # find the confidence interval indices in `slopes`
+    sigma = np.sqrt(sigsq)
+    Ru = min(np.round((nt - z*sigma)/2.), len(slopes)-1)
+    Rl = max(np.round((nt + z*sigma)/2.) - 1, 0)
+    delta = slopes[[Rl,Ru]]
+    return medslope, medinter, delta[0], delta[1]
 
 
 #####################################

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3116,10 +3116,11 @@ def theilslopes(y, x=None, alpha=0.95):
     >>> plt.show()
 
     The Theil-Sen regression line is shown in red, with the dashed red
-    lines illustrating the confidence interval of the slope. Note that
-    this is not the confidence interval of the regression as the
-    confidence interval of the intercept is not included. The green
-    line shows the least-squares fit for comparison.
+    lines illustrating the confidence interval of the slope (note that
+    the dashed red lines are not the confidence interval of the
+    regression as the confidence interval of the intercept is not
+    included). The green line shows the least-squares fit for
+    comparison.
 
     """
     y = np.asarray(y).flatten()

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3046,7 +3046,6 @@ def theilslopes(y, x=None, alpha=0.95):
 
     `theilslopes` implements a method for robust linear regression.  It
     computes the slope as the median of all slopes between paired values.
-    A confidence interval
 
     Parameters
     ----------
@@ -3072,7 +3071,12 @@ def theilslopes(y, x=None, alpha=0.95):
 
     Notes
     -----
-    The implementation of `theilslopes` follows [1]_.
+    The implementation of `theilslopes` follows [1]_. The intercept is
+    not defined in [1]_, and here it is defined as ``median(y) -
+    medslope*median(x)``, which is given in [3]_. Other definitions of
+    the intercept exist in the literature. A confidence interval for
+    the intercept is not given as this question is not addressed in
+    [1]_.
 
     References
     ----------
@@ -3081,13 +3085,15 @@ def theilslopes(y, x=None, alpha=0.95):
     .. [2] H. Theil, "A rank-invariant method of linear and polynomial
            regression analysis I, II and III",  Nederl. Akad. Wetensch., Proc.
            53:, pp. 386-392, pp. 521-525, pp. 1397-1412, 1950.
+    .. [3] W.L. Conover, "Practical nonparametric statistics", 2nd ed.,
+           John Wiley and Sons, New York, pp. 493.
 
     Examples
     --------
     >>> from scipy import stats
     >>> import matplotlib.pyplot as plt
 
-    >>> x = np.linspace(0, 5, num=150)
+    >>> x = np.linspace(-5, 5, num=150)
     >>> y = x + np.random.normal(size=x.size)
     >>> y[11:15] += 10  # add outliers
     >>> y[-5:] -= 7
@@ -3098,8 +3104,7 @@ def theilslopes(y, x=None, alpha=0.95):
     >>> res = stats.theilslopes(y, x, 0.90)
     >>> lsq_res = stats.linregress(x, y)
 
-    Plot the results, with the Theil-Sen confidence interval (red dashes) and
-    the comparison with `linregress` (green):
+    Plot the results:
 
     >>> fig = plt.figure()
     >>> ax = fig.add_subplot(111)
@@ -3109,6 +3114,12 @@ def theilslopes(y, x=None, alpha=0.95):
     >>> ax.plot(x, res[1] + res[3] * x, 'r--')
     >>> ax.plot(x, lsq_res[1] + lsq_res[0] * x, 'g-')
     >>> plt.show()
+
+    The Theil-Sen regression line is shown in red, with the dashed red
+    lines illustrating the confidence interval of the slope. Note that
+    this is not the confidence interval of the regression as the
+    confidence interval of the intercept is not included. The green
+    line shows the least-squares fit for comparison.
 
     """
     y = np.asarray(y).flatten()

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -537,6 +537,25 @@ def test_regress_simple():
     assert_almost_equal(intercept, 10.211269918932341)
 
 
+def test_theilslopes():
+    # Test for correct masking 1.
+    slope, intercept, lower, upper = mstats.theilslopes([0,1,1])
+    assert_almost_equal(slope, 0.5)
+    assert_almost_equal(intercept, 0.5)
+    # Test for correct masking 2.
+    y = np.ma.array([0,1,100,1], mask=[False, False, True, False])
+    slope, intercept, lower, upper = mstats.theilslopes(y)
+    assert_almost_equal(slope, 1./3)
+    assert_almost_equal(intercept, 2./3)
+    # Test of confidence intervals from example in Sen (1968).
+    x = [1, 2, 3, 4, 10, 12, 18]
+    y = [9, 15, 19, 20, 45, 55, 78]
+    slope, intercept, lower, upper = mstats.theilslopes(y, x, 0.07)
+    assert_almost_equal(slope, 4)
+    assert_almost_equal(upper, 4.38, decimal=2)
+    assert_almost_equal(lower, 3.71, decimal=2)
+
+
 def test_plotting_positions():
     # Regression test for #1256
     pos = mstats.plotting_positions(np.arange(3), 0, 0)

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -538,15 +538,17 @@ def test_regress_simple():
 
 
 def test_theilslopes():
-    # Test for correct masking 1.
+    # Test for basic slope and intercept.
     slope, intercept, lower, upper = mstats.theilslopes([0,1,1])
     assert_almost_equal(slope, 0.5)
     assert_almost_equal(intercept, 0.5)
-    # Test for correct masking 2.
+
+    # Test for correct masking.
     y = np.ma.array([0,1,100,1], mask=[False, False, True, False])
     slope, intercept, lower, upper = mstats.theilslopes(y)
     assert_almost_equal(slope, 1./3)
     assert_almost_equal(intercept, 2./3)
+
     # Test of confidence intervals from example in Sen (1968).
     x = [1, 2, 3, 4, 10, 12, 18]
     y = [9, 15, 19, 20, 45, 55, 78]

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -744,6 +744,19 @@ class TestRegression(TestCase):
         assert_almost_equal(res[2], -1)  # perfect negative correlation case
         assert_(not np.isnan(res[4]))  # stderr should stay finite
 
+def test_theilslopes():
+    # Basic slope test.
+    slope, intercept, lower, upper = stats.theilslopes([0,1,1])
+    assert_almost_equal(slope, 0.5)
+    assert_almost_equal(intercept, 0.5)
+    
+    # Test of confidence intervals.
+    x = [1, 2, 3, 4, 10, 12, 18]
+    y = [9, 15, 19, 20, 45, 55, 78]
+    slope, intercept, lower, upper = stats.theilslopes(y, x, 0.07)
+    assert_almost_equal(slope, 4)
+    assert_almost_equal(upper, 4.38, decimal=2)
+    assert_almost_equal(lower, 3.71, decimal=2)
 
 class TestHistogram(TestCase):
     # Tests that histogram works as it should, and keeps old behaviour

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -744,6 +744,7 @@ class TestRegression(TestCase):
         assert_almost_equal(res[2], -1)  # perfect negative correlation case
         assert_(not np.isnan(res[4]))  # stderr should stay finite
 
+
 def test_theilslopes():
     # Basic slope test.
     slope, intercept, lower, upper = stats.theilslopes([0,1,1])
@@ -757,6 +758,7 @@ def test_theilslopes():
     assert_almost_equal(slope, 4)
     assert_almost_equal(upper, 4.38, decimal=2)
     assert_almost_equal(lower, 3.71, decimal=2)
+
 
 class TestHistogram(TestCase):
     # Tests that histogram works as it should, and keeps old behaviour


### PR DESCRIPTION
This fixes multiple bugs in `scipy.stats.mstats.theilslopes`. I believe that the original code is implementing the method given in Sen (1968) for the slope and confidence intervals (this is the standard method), and I have therefore corrected the implementation to follow Sen (1968) faithfully. I have also added a test that highlights some of the failures of the original code.

An outline of the changes:
1. The original implementation erroneously always masked the last element of the input data (line 699 in the original code), and so the last element was always omitted from the remaining calculations.
2. The code retained the masked values in the `slopes` array, which caused problems when the confidence intervals are calculated by array index. I now use `x.compressed()` and `y.compressed()` to remove masked values.
3. Slopes were being computed for repeated values of x, not in accordance with the Sen (1968) method. This is fixed by replacing the routine for computing `slopes` with one that only includes values where `deltax > 0`.
4. The original calculation of `sigsq` does not divide the second term by 18 (line 722 in original code). It also includes a `yties` term for handling repeated `y` values (line 723 in original code) that  does not appear in Sen (1968) equation (2.6).
5. The confidence intervals are computed by computing indices in the `slopes` array. In Sen (1968), these indices are 1-indexed, but python is 0-indexed. Therefore, we must subtract 1 from the values computed by Sen (1968) to index the `slopes` array correctly (see lines 728-729 in the new code).
