### PR TITLE
Sparse: faster CSR/CSC setitem with change in sparsity

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -689,7 +689,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         else:
             # Use matrix addition to create new entries
             from .coo import coo_matrix
-            out = self + coo_matrix((x, (i, j)), shape=self.shape)
+            out = self + coo_matrix((x, self._swap((i, j))), shape=self.shape)
             assert out.format == self.format
             self.indices = out.indices
             self.data = out.data

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -699,77 +699,12 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             i[i < 0] += M
             j = j[mask]
             j[j < 0] += N
-            self._insert_many(i, j, x[mask])
-
-    def _insert_many(self, i, j, x):
-        """Inserts new nonzero at each (i, j) with value x
-
-        Here (i,j) index major and minor respectively.
-        i, j and x must be non-empty, 1d arrays.
-        Inserts each major group (e.g. all entries per row) at a time.
-        Maintains has_sorted_indices property.
-        Modifies i, j, x in place.
-        """
-        order = np.argsort(i, kind='mergesort')  # stable for duplicates
-        i = i.take(order, mode='clip')
-        j = j.take(order, mode='clip')
-        x = x.take(order, mode='clip')
-
-        do_sort = self.has_sorted_indices
-
-        # Update index data type
-        idx_dtype = get_index_dtype((self.indices, self.indptr),
-                                    maxval=(self.indptr[-1] + x.size))
-        if idx_dtype != self.indptr.dtype:
-            self.indptr = self.indptr.astype(idx_dtype)
-            self.indices = self.indices.astype(idx_dtype)
-        if idx_dtype != i.dtype or idx_dtype != j.dtype:
-            i = i.astype(idx_dtype)
-            j = j.astype(idx_dtype)
-
-        # Collate old and new in chunks by major index
-        indices_parts = []
-        data_parts = []
-        ui, ui_indptr = _compat_unique(i, return_index=True)
-        ui_indptr = np.append(ui_indptr, len(j))
-        new_nnzs = np.diff(ui_indptr)
-        prev = 0
-        for c, (ii, js, je) in enumerate(izip(ui, ui_indptr, ui_indptr[1:])):
-            # old entries
-            start = self.indptr[prev]
-            stop = self.indptr[ii]
-            indices_parts.append(self.indices[start:stop])
-            data_parts.append(self.data[start:stop])
-
-            # handle duplicate j: keep last setting
-            uj, uj_indptr = _compat_unique(j[js:je][::-1], return_index=True)
-            if len(uj) == je - js:
-                indices_parts.append(j[js:je])
-                data_parts.append(x[js:je])
-            else:
-                indices_parts.append(j[js:je][::-1][uj_indptr])
-                data_parts.append(x[js:je][::-1][uj_indptr])
-                new_nnzs[c] = len(uj)
-
-            prev = ii
-
-        # remaining old entries
-        start = self.indptr[ii]
-        indices_parts.append(self.indices[start:])
-        data_parts.append(self.data[start:])
-
-        # update attributes
-        self.indices = np.concatenate(indices_parts)
-        self.data = np.concatenate(data_parts)
-        nnzs = np.ediff1d(self.indptr, to_begin=0).astype(idx_dtype)
-        nnzs[1:][ui] += new_nnzs
-        self.indptr = np.cumsum(nnzs, out=nnzs)
-
-        if do_sort:
-            # TODO: only sort where necessary
-            self.sort_indices()
-
-        self.check_format(full_check=False)
+            from .coo import coo_matrix
+            out = self + coo_matrix((x[mask], (i, j)), shape=self.shape)
+            assert out.format == self.format
+            self.indices = out.indices
+            self.data = out.data
+            self.indptr = out.indptr
 
     def _get_single_element(self,row,col):
         M, N = self.shape

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -699,8 +699,20 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             i[i < 0] += M
             j = j[mask]
             j[j < 0] += N
+            x = x[mask]
+
+            # remove duplicates, retaining last
+            order = np.lexsort([j, i])[::-1]
+            mask = np.zeros(len(i), dtype=bool)
+            mask[order] = np.hstack([True, np.logical_or(np.diff(i[order]),
+                                                         np.diff(j[order]))])
+            i = i[mask]
+            j = j[mask]
+            x = x[mask]
+
+            # use matrix addition
             from .coo import coo_matrix
-            out = self + coo_matrix((x[mask], (i, j)), shape=self.shape)
+            out = self + coo_matrix((x, (i, j)), shape=self.shape)
             assert out.format == self.format
             self.indices = out.indices
             self.data = out.data


### PR DESCRIPTION
Given @pv's comment at https://github.com/scipy/scipy/issues/3501#issuecomment-41467146, here's a faster change-in-sparsity path for CSR/CSC `__setitem__`.

Master:

```
           Sparse Matrix fancy __setitem__
==========================================================
      N | s.patt. |     csr |     csc |     lil |     dok |
----------------------------------------------------------
      1 |  change |  0.80ms |  0.67ms |  0.01ms |  0.01ms
      1 |    same |  0.16ms |  0.15ms |  0.01ms |  0.01ms
     10 |  change |  0.87ms |  0.82ms |  0.20ms |  0.15ms
     10 |    same |  0.17ms |  0.16ms |  0.12ms |  0.15ms
    100 |  change |  3.50ms |  3.89ms |  0.11ms |  0.21ms
    100 |    same |  0.17ms |  0.16ms |  0.14ms |  0.20ms
   1000 |  change | 21.00ms | 22.00ms |  0.45ms |    n/a
   1000 |    same |  0.21ms |  0.22ms |  0.25ms |    n/a
  10000 |  change | 38.33ms | 38.33ms |  1.92ms |    n/a
  10000 |    same |  0.84ms |  0.89ms |  2.04ms |    n/a
```

This PR

```
           Sparse Matrix fancy __setitem__
==========================================================
      N | s.patt. |     csr |     csc |     lil |     dok |
----------------------------------------------------------
      1 |  change |  1.09ms |  1.05ms |  0.03ms |  0.03ms
      1 |    same |  0.16ms |  0.65ms |  0.01ms |  0.01ms
     10 |  change |  0.70ms |  0.59ms |  0.16ms |  0.17ms
     10 |    same |  0.16ms |  0.68ms |  0.12ms |  0.15ms
    100 |  change |  0.79ms |  0.76ms |  0.16ms |  0.19ms
    100 |    same |  0.17ms |  0.68ms |  0.13ms |  0.21ms
   1000 |  change |  0.78ms |  0.78ms |  0.29ms |    n/a
   1000 |    same |  0.23ms |  0.84ms |  0.24ms |    n/a
  10000 |  change |  1.62ms |  1.94ms |  2.30ms |    n/a
  10000 |    same |  0.85ms |  2.13ms |  2.02ms |    n/a
```
