### PR TITLE
BUG: sparse: allow operator overloading

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -443,19 +443,19 @@ class spmatrix(object):
         return -self.tocsr()
 
     def __iadd__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __isub__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __imul__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __idiv__(self, other):
         return self.__itruediv__(other)
 
     def __itruediv__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __pow__(self, other):
         if self.shape[0] != self.shape[1]:

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -347,7 +347,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             # Convert this matrix to a dense matrix and add them
             return self.todense() + other
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     def __radd__(self,other):
         return self.__add__(other)
@@ -369,7 +369,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             # Convert this matrix to a dense matrix and subtract them
             return self.todense() - other
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     def __rsub__(self,other):  # other - self
         # note: this can't be replaced by other + (-self) for unsigned types
@@ -383,7 +383,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             # Convert this matrix to a dense matrix and subtract them
             return other - self.todense()
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     def multiply(self, other):
         """Point-wise multiplication by another matrix, vector, or

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -49,7 +49,7 @@ class _data_matrix(spmatrix):
             self.data *= other
             return self
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     def __itruediv__(self, other):  # self /= other
         if isscalarlike(other):
@@ -57,7 +57,7 @@ class _data_matrix(spmatrix):
             self.data *= recip
             return self
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     def astype(self, t):
         return self._with_data(self.data.astype(t))

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -309,7 +309,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         elif isdense(other):
             new = self.todense() + other
         else:
-            raise TypeError("data type not understood")
+            return NotImplemented
         return new
 
     def __radd__(self, other):
@@ -336,7 +336,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         elif isdense(other):
             new = other + self.todense()
         else:
-            raise TypeError("data type not understood")
+            return NotImplemented
         return new
 
     def __neg__(self):
@@ -377,7 +377,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             # new.dtype.char = self.dtype.char
             return self
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     def __truediv__(self, other):
         if isscalarlike(other):
@@ -398,7 +398,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
                 self[key] = val / other
             return self
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     # What should len(sparse) return? For consistency with dense matrices,
     # perhaps it should be the number of rows?  For now it returns the number

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -168,14 +168,14 @@ class lil_matrix(spmatrix, IndexMixin):
             self[:,:] = self * other
             return self
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     def __itruediv__(self,other):
         if isscalarlike(other):
             self[:,:] = self / other
             return self
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     # Whenever the dimensions change, empty lists should be created for each
     # row

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1849,6 +1849,28 @@ class _TestInplaceArithmetic:
             if not np.can_cast(dtype, np.int_):
                 yield check, dtype
 
+    def test_inplace_success(self):
+        # Inplace ops should work even if a specialized version is not
+        # implemented, falling back to x = x <op> y
+        a = self.spmatrix(np.eye(5))
+        b = self.spmatrix(np.eye(5))
+        bp = self.spmatrix(np.eye(5))
+
+        b += a
+        bp = bp + a
+        assert_allclose(b.A, bp.A)
+
+        b *= a
+        bp = bp * a
+        assert_allclose(b.A, bp.A)
+
+        b -= a
+        bp = bp - a
+        assert_allclose(b.A, bp.A)
+
+        assert_raises(TypeError, operator.itruediv, a, b)
+        assert_raises(TypeError, operator.ifloordiv, a, b)
+
 
 class _TestGetSet:
     def test_getelement(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1795,9 +1795,6 @@ class _TestInplaceArithmetic:
             y *= b.T
             assert_array_equal(x, y)
 
-            # Matrix (non-elementwise) division is not defined
-            assert_raises(TypeError, operator.itruediv, x, b)
-
             # Matrix (non-elementwise) floor division is not defined
             assert_raises(TypeError, operator.ifloordiv, x, b)
 
@@ -1868,7 +1865,6 @@ class _TestInplaceArithmetic:
         bp = bp - a
         assert_allclose(b.A, bp.A)
 
-        assert_raises(TypeError, operator.itruediv, a, b)
         assert_raises(TypeError, operator.ifloordiv, a, b)
 
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -148,13 +148,25 @@ def todense(a):
     return a.todense()
 
 
-class MultipliesWithMatrix(object):
-    """Class that knows how to multiply with a sparse matrix."""
+class BinopTester(object):
+    # Custom type to test binary operations on sparse matrices.
 
-    def __mul__(self, other):
+    def __add__(self, mat):
         return "matrix on the right"
 
-    def __rmul__(self, other):
+    def __mul__(self, mat):
+        return "matrix on the right"
+
+    def __sub__(self, mat):
+        return "matrix on the right"
+
+    def __radd__(self, mat):
+        return "matrix on the left"
+
+    def __rmul__(self, mat):
+        return "matrix on the left"
+
+    def __rsub__(self, mat):
         return "matrix on the left"
 
 
@@ -1196,10 +1208,18 @@ class _TestCommon:
         assert_equal(A * array([1]), array([1,2,3]))
         assert_equal(A * array([[1]]), array([[1],[2],[3]]))
 
-    def test_multiply_custom(self):
+    def test_binop_custom_type(self):
+        # Non-regression test: previously, binary operations would raise
+        # NotImplementedError instead of returning NotImplemented
+        # (https://docs.python.org/library/constants.html#NotImplemented)
+        # so overloading Custom + matrix etc. didn't work.
         A = self.spmatrix([[1], [2], [3]])
-        B = MultipliesWithMatrix()
+        B = BinopTester()
+        assert_equal(A + B, "matrix on the left")
+        assert_equal(A - B, "matrix on the left")
         assert_equal(A * B, "matrix on the left")
+        assert_equal(B + A, "matrix on the right")
+        assert_equal(B - A, "matrix on the right")
         assert_equal(B * A, "matrix on the right")
 
     def test_matvec(self):


### PR DESCRIPTION
New take on #3580 with fewer changes than #3584. In particular, does not implement element-wise division of sparse matrices, which needs more work than I'm able to put in right now.
