### PR TITLE
MAINT: fix coverage and coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ notifications:
   # let's wait to see what people think before turning that on.
   email: false
 after_success:
-    - if [ "${TESTMODE}" == "full" ]; then cp build/test/.coverage . && coveralls; fi
+    - if [ "${TESTMODE}" == "full" ]; then pushd build/testenv/lib/python*/site-packages/ && cp ../../../../test/.coverage . && coveralls && popd; fi

--- a/runtests.py
+++ b/runtests.py
@@ -215,6 +215,9 @@ def main(argv):
     except OSError:
         pass
 
+    shutil.copyfile(os.path.join(ROOT_DIR, '.coveragerc'),
+                    os.path.join(test_dir, '.coveragerc'))
+
     cwd = os.getcwd()
     try:
         os.chdir(test_dir)


### PR DESCRIPTION
Ensure .coveragerc is in the directory where the tests are run, and make
submission coveralls.io generate correct path names.
