### PR TITLE
Sort netcdf variables in a Python-3 compatible way

### DIFF
--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -797,7 +797,7 @@ class netcdf_variable(object):
         `netcdf_variable`.
 
         """
-        return self.data.shape and not self._shape[0]
+        return bool(self.data.shape) and not self._shape[0]
     isrec = property(isrec)
 
     def shape(self):

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -381,11 +381,13 @@ class netcdf_file(object):
             self.fp.write(NC_VARIABLE)
             self._pack_int(len(self.variables))
 
-            # Sort variables non-recs first, then recs. We use a DSU
-            # since some people use pupynere with Python 2.3.x.
-            deco = [(v._shape and not v.isrec, k) for (k, v) in self.variables.items()]
-            deco.sort()
-            variables = [k for (unused, k) in deco][::-1]
+            # Sort variable names non-recs first, then recs.
+            def sortkey(n):
+                v = self.variables[n]
+                if v.isrec:
+                    return (-1,)
+                return v._shape
+            variables = sorted(self.variables, key=sortkey, reverse=True)
 
             # Set the metadata for all variables.
             for name in variables:

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -207,6 +207,7 @@ def test_mmaps_closed():
         vars.append(f.variables['lat'])
         f.close()
 
+
 def test_zero_dimensional_var():
     io = BytesIO()
     with make_simple(io, 'w') as f:

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -206,3 +206,12 @@ def test_mmaps_closed():
         f = netcdf_file(filename, mmap=True)
         vars.append(f.variables['lat'])
         f.close()
+
+def test_zero_dimensional_var():
+    io = BytesIO()
+    with make_simple(io, 'w') as f:
+        v = f.createVariable('zerodim', 'i2', [])
+        # This is checking that .isrec returns a boolean - don't simplify it
+        # to 'assert not ...'
+        assert v.isrec is False, v.isrec
+        f.flush()


### PR DESCRIPTION
The previous implementation ran into issues with comparing different types (tuples and bools).

Also simplified the sorting, since Python 2.3 support is no longer an issue.
