### PR TITLE
Include need_contiguous argument in LinearNDInterpolator class

### DIFF
--- a/scipy/interpolate/interpnd.pyx
+++ b/scipy/interpolate/interpnd.pyx
@@ -232,9 +232,10 @@ class LinearNDInterpolator(NDInterpolatorBase):
 
     """
 
-    def __init__(self, points, values, fill_value=np.nan, rescale=False):
+    def __init__(self, points, values, fill_value=np.nan, rescale=False,
+        need_contiguous=True):
         NDInterpolatorBase.__init__(self, points, values, fill_value=fill_value,
-                rescale=rescale)
+                rescale=rescale, need_contiguous=need_contiguous)
         if self.tri is None:
             self.tri = qhull.Delaunay(self.points)
 


### PR DESCRIPTION
This is a very minor change that permits the use of large, memory-mapped (`np.memmap`) arrays as `points` or `values` in the `LinearNDInterpolator`. 

If `need_contiguous` gets passed as `False` to `NDInterpolatorBase` (which is the default behaviour) then any memory-mapped array gets copied-on-read, so any arrays that are larger than the available RAM will raise `MemoryError`. Allowing `need_contiguous` to be passed from `LinearNDInterpolator` permits memory-mapped arrays to be used correctly in `LinearNDInterpolator` without them needing to be copied on read.
