### PR TITLE
MAINT: linalg.orth memory efficiency

### DIFF
--- a/scipy/linalg/decomp_svd.py
+++ b/scipy/linalg/decomp_svd.py
@@ -198,7 +198,7 @@ def orth(A):
     svd : Singular value decomposition of a matrix
 
     """
-    u, s, vh = svd(A)
+    u, s, vh = svd(A, full_matrices=False)
     M, N = A.shape
     eps = numpy.finfo(float).eps
     tol = max(M,N) * numpy.amax(s) * eps

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2113,7 +2113,15 @@ def _check_orth(n):
 
 @dec.slow
 def test_orth_memory_efficiency():
-    _check_orth(10*1000*1000)
+    # Pick n so that 16*n bytes is reasonable but 8*n*n bytes is unreasonable.
+    # Keep in mind that @dec.slow tests are likely to be running
+    # under configurations that support 4Gb+ memory for tests related to
+    # 32 bit overflow.
+    n = 10*1000*1000
+    try:
+        _check_orth(n)
+    except MemoryError as e:
+        raise AssertionError('memory error perhaps caused by orth regression')
 
 
 def test_orth():

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -13,14 +13,15 @@ Run tests if linalg is not installed:
 """
 
 import numpy as np
-from numpy.testing import TestCase, assert_equal, assert_array_almost_equal, \
-        assert_array_equal, assert_raises, assert_, run_module_suite, dec
+from numpy.testing import (TestCase, assert_equal, assert_array_almost_equal,
+        assert_array_equal, assert_raises, assert_, assert_allclose,
+        run_module_suite, dec)
 
 from scipy.lib.six import xrange
 
-from scipy.linalg import eig, eigvals, lu, svd, svdvals, cholesky, qr, \
-     schur, rsf2csf, lu_solve, lu_factor, solve, diagsvd, hessenberg, rq, \
-     eig_banded, eigvals_banded, eigh, eigvalsh, qr_multiply, qz
+from scipy.linalg import (eig, eigvals, lu, svd, svdvals, cholesky, qr,
+     schur, rsf2csf, lu_solve, lu_factor, solve, diagsvd, hessenberg, rq,
+     eig_banded, eigvals_banded, eigh, eigvalsh, qr_multiply, qz, orth)
 from scipy.linalg.lapack import dgbtrf, dgbtrs, zgbtrf, zgbtrs, \
      dsbev, dsbevd, dsbevx, zhbevd, zhbevx
 from scipy.linalg.misc import norm
@@ -2098,6 +2099,27 @@ class TestOverwrite(object):
 
     def test_svdvals(self):
         assert_no_overwrite(svdvals, [(3,3)])
+
+
+def _check_orth(n):
+    X = np.ones((n, 2), dtype=float)
+    Y = orth(X)
+    assert_equal(Y.shape, (n, 1))
+    assert_allclose(Y, Y.mean())
+    Y = orth(X.T)
+    assert_equal(Y.shape, (2, 1))
+    assert_allclose(Y, Y.mean())
+
+
+@dec.slow
+def test_orth_memory_efficiency():
+    _check_orth(10*1000*1000)
+
+
+def test_orth():
+    for n in 1, 2, 3, 10, 100:
+        _check_orth(n)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
fixes an orth() memory efficiency problem uncovered in networkx https://github.com/networkx/networkx/pull/1134
