### PR TITLE
[WIP] Data from netcdf variable is invalid after file close.

### DIFF
--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -872,7 +872,7 @@ class netcdf_variable(object):
         return self._size
 
     def __getitem__(self, index):
-        return self.data[index]
+        return np.array(self.data[index], copy=True)
 
     def __setitem__(self, index, data):
         # Expand data for record vars?

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -206,3 +206,24 @@ def test_mmaps_closed():
         f = netcdf_file(filename, mmap=True)
         vars.append(f.variables['lat'])
         f.close()
+
+
+def test_data_after_close():
+    # test that arrays returned are still valid after
+    # the handle is closed
+    cwd = os.getcwd()
+    try:
+        tmpdir = tempfile.mkdtemp()
+        os.chdir(tmpdir)
+        with make_simple('simple.nc', 'w') as f:
+            pass
+            
+        with netcdf_file('simple.nc', 'r', mmap=True) as f:
+            t = f.variables['time'][:]
+        
+        t.sum()
+    
+    finally:
+        os.chdir(cwd)
+        shutil.rmtree(tmpdir)
+    


### PR DESCRIPTION
On the current master (actually since 2dfffc7beeb924d6aa5e6529f25745c5330a7bac) the following code segfaults.

```
with open('my-netcdf-file', 'r') as f:
    x = f.variables['varname'][:]
print x.sum()
```

cc #3630
