### PR TITLE
BUG: sparse/superlu: fix || vs && mistake in L/U attributes + add test

### DIFF
--- a/scipy/sparse/linalg/dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/dsolve/_superluobject.c
@@ -574,8 +574,8 @@ LU_to_csc(SuperMatrix *L, SuperMatrix *U,
 #define IS_ZERO(p)                                                      \
     ((dtype == SLU_S) ? (*(float*)(p) == 0) :                           \
      ((dtype == SLU_D) ? (*(double*)(p) == 0) :                         \
-      ((dtype == SLU_C) ? (*(float*)(p) == 0 || *((float*)(p)+1) == 0) : \
-       (*(double*)(p) == 0 || *((double*)(p)+1) == 0))))
+      ((dtype == SLU_C) ? (*(float*)(p) == 0 && *((float*)(p)+1) == 0) : \
+       (*(double*)(p) == 0 && *((double*)(p)+1) == 0))))
 
     U_colptr[0] = 0;
     L_colptr[0] = 0;

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -405,23 +405,38 @@ class TestSplu(object):
         assert_(not np.isnan(B).any())
 
     def test_lu_attr(self):
-        A = self.A
-        n = A.shape[0]
-        lu = splu(A)
 
-        # Check that the decomposition is as advertized
+        def check(dtype, complex_2=False):
+            A = self.A.astype(dtype)
 
-        Pc = np.zeros((n, n))
-        Pc[np.arange(n), lu.perm_c] = 1
+            if complex_2:
+                A = A + 1j*A.T
 
-        Pr = np.zeros((n, n))
-        Pr[lu.perm_r, np.arange(n)] = 1
+            n = A.shape[0]
+            lu = splu(A)
 
-        Ad = A.toarray()
-        lhs = Pr.dot(Ad).dot(Pc)
-        rhs = (lu.L * lu.U).toarray()
+            # Check that the decomposition is as advertized
 
-        assert_allclose(lhs, rhs, atol=1e-10)
+            Pc = np.zeros((n, n))
+            Pc[np.arange(n), lu.perm_c] = 1
+
+            Pr = np.zeros((n, n))
+            Pr[lu.perm_r, np.arange(n)] = 1
+
+            Ad = A.toarray()
+            lhs = Pr.dot(Ad).dot(Pc)
+            rhs = (lu.L * lu.U).toarray()
+
+            eps = np.finfo(dtype).eps
+
+            assert_allclose(lhs, rhs, atol=100*eps)
+
+        check(np.float32)
+        check(np.float64)
+        check(np.complex64)
+        check(np.complex128)
+        check(np.complex64, True)
+        check(np.complex128, True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix mistaken substitution of `||` for `&&` in superlu wrapper.

Add tests.

Fixes gh-3631

Pretty nasty mistake, so should be backported to 0.14.x --- a 0.14.1 might come handy.
