### PR TITLE
Weave: deprecate the module and disable slow tests on TravisCI

### DIFF
--- a/doc/release/0.15.0-notes.rst
+++ b/doc/release/0.15.0-notes.rst
@@ -39,6 +39,11 @@ of the algorithm.
 Deprecated features
 ===================
 
+The ``scipy.weave`` module is deprecated.  It was the only module never ported
+to Python 3.x, and is not recommended to be used for new code - use Cython
+instead.  In order to support existing code, ``scipy.weave`` has been packaged
+separately: `https://github.com/scipy/weave`_.  It is a pure Python package, so
+can easily be installed with ``pip install weave``.
 
 Backwards incompatible changes
 ==============================

--- a/scipy/weave/__init__.py
+++ b/scipy/weave/__init__.py
@@ -2,6 +2,10 @@
 C/C++ integration
 =================
 
+NOTE: this module is deprecated and will be removed from Scipy before
+the 1.0 release -- use the standalone weave package
+(`https://github.com/scipy/weave`_) instead.
+
         inline     -- a function for including C/C++ code within Python
         blitz      -- a function for compiling Numeric expressions to C++
         ext_tools  -- a module that helps construct C/C++ extension modules.
@@ -19,8 +23,22 @@ from __future__ import absolute_import, print_function
 
 import sys
 
+from numpy import deprecate
+
+
 if sys.version_info[0] >= 3:
     raise ImportError("scipy.weave only supports Python 2.x")
+
+
+@deprecate(old_name="scipy.weave", new_name="weave")
+def _deprecated():
+    pass
+try:
+    _deprecated()
+except DeprecationWarning as e:
+    # don't fail import if DeprecationWarnings raise error -- works around
+    # the situation with Numpy's test framework
+    pass
 
 
 from .weave_version import weave_version as __version__

--- a/scipy/weave/tests/test_blitz_tools.py
+++ b/scipy/weave/tests/test_blitz_tools.py
@@ -7,12 +7,12 @@ import warnings
 from numpy import (float32, float64, complex64, complex128,
                    zeros, random, array)
 
-from numpy.testing import (TestCase, dec, assert_equal,
+from numpy.testing import (TestCase, assert_equal,
                            assert_allclose, run_module_suite)
 
 from scipy.weave import blitz_tools, blitz, BlitzWarning
 from scipy.weave.ast_tools import harvest_variables
-from weave_test_utils import remove_whitespace, debug_print, TempdirBlitz
+from weave_test_utils import remove_whitespace, debug_print, TempdirBlitz, dec
 
 
 class TestAstToBlitzExpr(TestCase):

--- a/scipy/weave/tests/test_c_spec.py
+++ b/scipy/weave/tests/test_c_spec.py
@@ -6,13 +6,13 @@ import tempfile
 import string
 import time
 
-from numpy.testing import TestCase, dec, assert_, run_module_suite
+from numpy.testing import TestCase, assert_, run_module_suite
 
-from scipy.weave import inline_tools,ext_tools,c_spec
+from scipy.weave import inline_tools, ext_tools, c_spec
 from scipy.weave.build_tools import msvc_exists, gcc_exists
 from scipy.weave.catalog import unique_file
 
-from weave_test_utils import debug_print
+from weave_test_utils import debug_print, dec
 
 
 def unique_mod(d,file_name):

--- a/scipy/weave/tests/test_catalog.py
+++ b/scipy/weave/tests/test_catalog.py
@@ -10,12 +10,12 @@ import tempfile
 
 from distutils.dir_util import remove_tree
 
-from numpy.testing import TestCase, assert_, dec, run_module_suite
+from numpy.testing import TestCase, assert_, run_module_suite
 from numpy.testing.noseclasses import KnownFailureTest
 
 from scipy.weave import catalog
 from weave_test_utils import (clear_temp_catalog, restore_temp_catalog,
-                              empty_temp_dir, cleanup_temp_dir)
+                              empty_temp_dir, cleanup_temp_dir, dec)
 
 
 skip_on_windows = dec.skipif(sys.platform == 'win32',

--- a/scipy/weave/tests/test_ext_tools.py
+++ b/scipy/weave/tests/test_ext_tools.py
@@ -3,12 +3,11 @@ from __future__ import absolute_import, print_function
 import types
 
 from numpy import arange, float32, float64
-from numpy.testing import (TestCase, dec, assert_equal, assert_,
-                           run_module_suite)
+from numpy.testing import TestCase, assert_equal, assert_, run_module_suite
 
 from scipy.weave import ext_tools, c_spec
 from scipy.weave.standard_array_spec import array_converter
-from weave_test_utils import empty_temp_dir
+from weave_test_utils import empty_temp_dir, dec
 
 
 build_dir = empty_temp_dir()

--- a/scipy/weave/tests/test_inline_tools.py
+++ b/scipy/weave/tests/test_inline_tools.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import, print_function
 
-from numpy.testing import TestCase, dec, assert_, run_module_suite
+from numpy.testing import TestCase, assert_, run_module_suite
 
 from scipy.weave import inline_tools
+
+from weave_test_utils import dec
 
 
 class TestInline(TestCase):

--- a/scipy/weave/tests/test_numpy_scalar_spec.py
+++ b/scipy/weave/tests/test_numpy_scalar_spec.py
@@ -5,12 +5,14 @@ import sys
 import tempfile
 
 import numpy
-from numpy.testing import TestCase, dec, assert_, run_module_suite
+from numpy.testing import TestCase, assert_, run_module_suite
 
-from scipy.weave import inline_tools,ext_tools
+from scipy.weave import inline_tools, ext_tools
 from scipy.weave.build_tools import msvc_exists, gcc_exists
 from scipy.weave.catalog import unique_file
 from scipy.weave.numpy_scalar_spec import numpy_complex_scalar_converter
+
+from weave_test_utils import dec
 
 
 def unique_mod(d,file_name):

--- a/scipy/weave/tests/test_scxx_dict.py
+++ b/scipy/weave/tests/test_scxx_dict.py
@@ -4,10 +4,11 @@ from __future__ import absolute_import, print_function
 
 import sys
 
-from numpy.testing import (TestCase, dec, assert_, assert_raises,
-                           run_module_suite)
+from numpy.testing import TestCase, assert_, assert_raises, run_module_suite
 
 from scipy.weave import inline_tools
+
+from weave_test_utils import dec
 
 
 class TestDictConstruct(TestCase):

--- a/scipy/weave/tests/test_scxx_object.py
+++ b/scipy/weave/tests/test_scxx_object.py
@@ -5,12 +5,12 @@ from __future__ import absolute_import, print_function
 import sys
 from UserList import UserList
 
-from numpy.testing import (TestCase, dec, assert_equal, assert_, assert_raises,
+from numpy.testing import (TestCase, assert_equal, assert_, assert_raises,
                            run_module_suite)
 
 from scipy.weave import inline_tools
 
-from weave_test_utils import debug_print
+from weave_test_utils import debug_print, dec
 
 
 class TestObjectConstruct(TestCase):

--- a/scipy/weave/tests/test_scxx_sequence.py
+++ b/scipy/weave/tests/test_scxx_sequence.py
@@ -5,12 +5,12 @@ from __future__ import absolute_import, print_function
 import time
 import sys
 
-from numpy.testing import (TestCase, dec, assert_, assert_raises,
+from numpy.testing import (TestCase, assert_, assert_raises,
                            run_module_suite)
 
 from scipy.weave import inline_tools
 
-from weave_test_utils import debug_print
+from weave_test_utils import debug_print, dec
 
 
 class _TestSequenceBase(TestCase):

--- a/scipy/weave/tests/weave_test_utils.py
+++ b/scipy/weave/tests/weave_test_utils.py
@@ -7,7 +7,24 @@ import glob
 from distutils.errors import DistutilsFileError
 import distutils.file_util
 
+from numpy.testing import dec
+
 from scipy.weave import catalog
+
+
+def slow(t):
+    """Replacement for numpy.testing.dec.slow for weave."""
+    t.slow = True
+    if ('RUN_WEAVE_TESTS' in os.environ and
+                bool(os.environ['RUN_WEAVE_TESTS'])):
+        t.__test__ = True
+    else:
+        t.__test__ = False
+
+    return t
+
+
+dec.slow = slow
 
 
 def remove_whitespace(in_str):


### PR DESCRIPTION
Deprecation: see gh-3171 and recent mailing list discussions.

TravisCI timeout issue: see any recent PR. Weave tests marked with `@dec.slow` will now only run if an environment variable `RUN_WEAVE_TESTS` is set. Runtime of full test suite improves by more than 50%.

Please don't merge until we've created https://github.com/scipy/weave/ and released a first version of that standalone package on PyPi.
