### PR TITLE
ENH: adding  `sum_duplicates` method to COO sparse matrix

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -909,7 +909,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     def eliminate_zeros(self):
         """Remove zero entries from the matrix
 
-        The is an *in place* operation
+        This is an *in place* operation
         """
         fn = _sparsetools.csr_eliminate_zeros
         M,N = self._swap(self.shape)

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -425,19 +425,13 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         self.row = self.row[order]
         self.col = self.col[order]
         self.data = self.data[order]
-        prev_idx = 0
-        prev_inds = (self.row[0], self.col[0])
-        mask = np.ones(len(self.row), dtype=bool)
-        for idx, inds in enumerate(izip(self.row[1:], self.col[1:]), 1):
-            if inds == prev_inds:
-                mask[idx] = False
-                self.data[prev_idx] += self.data[idx]
-            else:
-                prev_inds = inds
-                prev_idx = idx
-        self.row = self.row[mask]
-        self.col = self.col[mask]
-        self.data = self.data[mask]
+        unique_mask = ((self.row[1:] != self.row[:-1]) |
+                       (self.col[1:] != self.col[:-1]))
+        unique_mask = np.append(True, unique_mask)
+        self.row = self.row[unique_mask]
+        self.col = self.col[unique_mask]
+        unique_inds, = np.nonzero(unique_mask)
+        self.data = np.add.reduceat(self.data, unique_inds, dtype=self.dtype)
         self.has_canonical_format = True
 
     ###########################

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -124,6 +124,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                 self.row = np.array([], dtype=idx_dtype)
                 self.col = np.array([], dtype=idx_dtype)
                 self.data = np.array([], getdtype(dtype, default=float))
+                self.has_canonical_format = True
             else:
                 try:
                     obj, ij = arg1
@@ -155,6 +156,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                 idx_dtype = get_index_dtype(maxval=max(self.shape))
                 self.row = self.row.astype(idx_dtype)
                 self.col = self.col.astype(idx_dtype)
+                self.has_canonical_format = False
 
         elif arg1 is None:
             # Initialize an empty matrix.
@@ -167,6 +169,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             self.data = np.array([], getdtype(dtype, default=float))
             self.row = np.array([], dtype=idx_dtype)
             self.col = np.array([], dtype=idx_dtype)
+            self.has_canonical_format = True
         else:
             if isspmatrix(arg1):
                 if isspmatrix_coo(arg1) and copy:
@@ -180,6 +183,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                     self.col = coo.col
                     self.data = coo.data
                     self.shape = coo.shape
+                self.has_canonical_format = False
             else:
                 #dense argument
                 try:
@@ -194,6 +198,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
                 self.row, self.col = M.nonzero()
                 self.data = M[self.row, self.col]
+                self.has_canonical_format = True
 
         if dtype is not None:
             self.data = self.data.astype(dtype)
@@ -414,7 +419,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
         This is an *in place* operation
         """
-        if len(self.data) == 0:
+        if self.has_canonical_format or len(self.data) == 0:
             return
         order = np.lexsort((self.row,self.col))
         self.row = self.row[order]
@@ -433,6 +438,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         self.row = self.row[mask]
         self.col = self.col[mask]
         self.data = self.data[mask]
+        self.has_canonical_format = True
 
 
     ###########################

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -427,7 +427,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         self.data = self.data[order]
         prev_idx = 0
         prev_inds = (self.row[0], self.col[0])
-        mask = np.ones_like(self.row, dtype=bool)
+        mask = np.ones(len(self.row), dtype=bool)
         for idx, inds in enumerate(izip(self.row[1:], self.col[1:]), 1):
             if inds == prev_inds:
                 mask[idx] = False
@@ -439,7 +439,6 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         self.col = self.col[mask]
         self.data = self.data[mask]
         self.has_canonical_format = True
-
 
     ###########################
     # Multiplication handlers #

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3594,6 +3594,24 @@ class TestCOO(sparse_test_class(getset=False,
     def test_setdiag(self):
         pass
 
+    def test_sum_duplicates(self):
+        coo = coo_matrix((4,3))
+        coo.sum_duplicates()
+        coo = coo_matrix(([1,2], ([1,0], [1,0])))
+        coo.sum_duplicates()
+        assert_array_equal(coo.A, [[2,0],[0,1]])
+        coo = coo_matrix(([1,2], ([1,1], [1,1])))
+        coo.sum_duplicates()
+        assert_array_equal(coo.A, [[0,0],[0,3]])
+        assert_array_equal(coo.row, [1])
+        assert_array_equal(coo.col, [1])
+        assert_array_equal(coo.data, [3])
+
+    def test_todok_duplicates(self):
+        coo = coo_matrix(([1,1,1,1], ([0,2,2,0], [0,1,1,0])))
+        dok = coo.todok()
+        assert_array_equal(dok.A, coo.A)
+
 
 class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False,


### PR DESCRIPTION
Fixes https://github.com/scipy/scipy/issues/3624 by adding a `sum_duplicates` method and calling it before the `todok` conversion.

Also adds some test cases for both `sum_duplicates` and `todok` with duplicates.
