### PR TITLE
Fix for #3596: Make fftconvolve threadsafe

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -351,7 +351,7 @@ def fftconvolve(in1, in2, mode="full"):
         # If we're here, it's either because we need a complex result, or we
         # failed to acquire _rfft_lock (meaning rfftn isn't threadsafe and
         # is already in use by another thread).  In either case, use the
-        # (threadsafe but slower) ScipPy complex-FFT routines instead.
+        # (threadsafe but slower) SciPy complex-FFT routines instead.
         ret = ifftn(fftn(in1, fshape) * fftn(in2, fshape))[fslice].copy()
         if not complex_result:
             ret = ret.real


### PR DESCRIPTION
First pass at a fix for #3596: For NumPy versions prior to 1.9.0, will make sure that numpy.fft.rfftn / irfftn are only called from one thread at a time.  Will fall back to the slower SciPy complex-FFT routines for all other simultaneous threads.
