### PR TITLE
BLD: ignore pep8 E302 (expected 2 blank lines, found 1)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,5 +38,5 @@ commands=python {toxinidir}/runtests.py -n -m full {posargs:}
 [pep8]
 max_line_length=79
 statistics = True
-ignore = E121,E122,E123,E125,E126,E127,E128,E226,E231,E265,E501,E712,W291,W293,W391
+ignore = E121,E122,E123,E125,E126,E127,E128,E226,E231,E265,E302,E501,E712,W291,W293,W391
 exclude = scipy/sparse/linalg/dsolve/umfpack/_umfpack.py,scipy/sparse/sparsetools/bsr.py,scipy/sparse/sparsetools/coo.py,scipy/sparse/sparsetools/csc.py,scipy/sparse/sparsetools/csgraph.py,scipy/sparse/sparsetools/csr.py,scipy/sparse/sparsetools/dia.py,scipy/__config__.py


### PR DESCRIPTION
Several recent scipy PRs by new contributors have been denied by this pep8 rule.  Perhaps we could keep the pep8 bot, but add this rule to the ignore list?  This is not to suggest not following this pep8 rule in scipy code.  And I understand that the change in this PR is controversial, so I don't necessarily expect it to be merged.
