### PR TITLE
BUG: fix leaking errstate, and ignore invalid= errors in a test

### DIFF
--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -14,7 +14,7 @@ from numpy.testing import (assert_equal, TestCase, assert_allclose,
 class TestDifferentialEvolutionSolver(TestCase):
 
     def setUp(self):
-        np.seterr(invalid='raise')
+        self.old_seterr = np.seterr(invalid='raise')
         self.limits = np.array([[0., 0.],
                                 [2., 2.]])
         self.bounds = [(0., 2.), (0., 2.)]
@@ -31,6 +31,9 @@ class TestDifferentialEvolutionSolver(TestCase):
         #[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]
         population = np.atleast_2d(np.arange(0.1, 0.8, 0.1)).T
         self.dummy_solver2.population = population
+
+    def tearDown(self):
+        np.seterr(**self.old_seterr)
 
     def quadratic(self, x):
         return x[0]**2

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -82,8 +82,6 @@ class TestExpmActionSimple(TestCase):
             expected = np.dot(scipy.linalg.expm(A), v)
             assert_allclose(observed, expected)
 
-    @decorators.knownfailureif(True,
-            'randomly started failing on Python 2.6 NumPy 1.5.1')
     def test_scaled_expm_multiply(self):
         np.random.seed(1234)
         n = 40
@@ -91,11 +89,12 @@ class TestExpmActionSimple(TestCase):
         nsamples = 10
         for i in range(nsamples):
             for t in (0.2, 1.0, 1.5):
-                A = scipy.linalg.inv(np.random.randn(n, n))
-                B = np.random.randn(n, k)
-                observed = _expm_multiply_simple(A, B, t=t)
-                expected = np.dot(scipy.linalg.expm(t*A), B)
-                assert_allclose(observed, expected)
+                with np.errstate(invalid='ignore'):
+                    A = scipy.linalg.inv(np.random.randn(n, n))
+                    B = np.random.randn(n, k)
+                    observed = _expm_multiply_simple(A, B, t=t)
+                    expected = np.dot(scipy.linalg.expm(t*A), B)
+                    assert_allclose(observed, expected)
 
     def test_scaled_expm_multiply_single_timepoint(self):
         np.random.seed(1234)


### PR DESCRIPTION
Apparently, Numpy error behavior is different for Python2.6/Numpy 1.5.1 compared to more recent versions, as the invalid flag is not raise in newer versions.

The origin of the failure is trying to exponentiate a matrix that results to matrix elements that overflow the floating point range.

Fixes gh-3662
