### PR TITLE
WIP: fix sporadic slepian failures

### DIFF
--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -1298,9 +1298,6 @@ def slepian(M, width, sym=True):
     >>> plt.xlabel("Normalized frequency [cycles per sample]")
 
     """
-    if (M * width > 27.38):
-        raise ValueError("Cannot reliably obtain Slepian sequences for"
-                         " M*width > 27.38.")
     if M < 1:
         return np.array([])
     if M == 1:
@@ -1309,20 +1306,21 @@ def slepian(M, width, sym=True):
     if not sym and not odd:
         M = M + 1
 
-    twoF = width / 2.0
-    alpha = (M - 1) / 2.0
-    m = np.arange(0, M) - alpha
-    n = m[:, np.newaxis]
-    k = m[np.newaxis, :]
-    AF = twoF * special.sinc(twoF * (n - k))
-    [lam, vec] = linalg.eig(AF)
-    ind = np.argmax(abs(lam), axis=-1)
-    w = np.abs(vec[:, ind])
-    w = w / max(w)
+    # our width is the full bandwidth
+    width = width / 2
+    # to match the old version 
+    width = width / 2
+    m = np.arange(M, dtype='d')
+    H = np.zeros((2, M))
+    H[0, 1:] = m[1:] * (M - m[1:]) / 2
+    H[1, :] = ((M - 1 - 2 * m) / 2)**2 * np.cos(2 * np.pi * width)
+
+    _, win = linalg.eig_banded(H, select='i', select_range=(M-1, M-1))
+    win = win.ravel() / win.max()
 
     if not sym and not odd:
-        w = w[:-1]
-    return w
+        win = win[:-1]
+    return win
 
 
 def cosine(M, sym=True):


### PR DESCRIPTION
This replaces the implementation for signal.slepian with one that uses a better algorithm (hat tip to nitime).  

This ought to fix #3675. 

The reason I've labeled this a work in progress is that I think the original slepian code was incorrect.  Going back to the [original source](http://www3.alcatel-lucent.com/bstj/vol57-1978/articles/bstj57-5-1371.pdf) we see that there is a missing factor of 2 in the original code. (Compare https://github.com/scipy/scipy/blob/master/scipy/signal/windows.py#L1316 with Eq. 18)   So we can keep our incorrect definition or we can break back compat and change it to something recognizable. 
