### PR TITLE
Speed up test('full'), solve Travis CI timeout issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,21 @@ before_install:
   - ulimit -a
   - sudo apt-get update -qq
   - sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran
+  - sudo apt-get install -qq libgmp-dev libmpfr-dev
+  # Install gmpy2 dependencies
+  - wget ftp://ftp.gnu.org/gnu/mpc/mpc-1.0.2.tar.gz
+  - tar xzvf mpc-1.0.2.tar.gz
+  - cd mpc-1.0.2
+  - ./configure
+  - make
+  - sudo make install
+  - cd ..
+  # End install gmpy2 dependencies
   - mkdir builds
   - pushd builds
   - pip install --upgrade pip setuptools  # Upgrade pip and setuptools to get ones with `wheel` support
   - pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --use-wheel --use-mirrors nose numpy$NUMPYSPEC Cython mpmath argparse
+  - pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - if [ "${TESTMODE}" == "full" ]; then pip install coverage coveralls; fi
   - python -V
   - popd

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -11,7 +11,7 @@ import time
 from distutils.version import LooseVersion
 
 import numpy as np
-from numpy.testing import dec
+from numpy.testing import dec, run_module_suite
 from numpy import pi
 
 import scipy.special as sc
@@ -1606,3 +1606,7 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             n=200,
                             dps=60,
                             rtol=1e-13)
+
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
Full test suite should run about 25% faster now. mpmath without gmpy2 is very very slow.
