### PR TITLE
Update special docs

### DIFF
--- a/doc/release/0.15.0-notes.rst
+++ b/doc/release/0.15.0-notes.rst
@@ -54,6 +54,10 @@ instead.  In order to support existing code, ``scipy.weave`` has been packaged
 separately: `https://github.com/scipy/weave`_.  It is a pure Python package, so
 can easily be installed with ``pip install weave``.
 
+``scipy.special.bessel_diff_formula`` is deprecated.  It is a private function,
+and therefore will be removed from the public API in a following release.
+
+
 Backwards incompatible changes
 ==============================
 

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -61,7 +61,6 @@ Bessel Functions
 .. autosummary::
    :toctree: generated/
 
-   jn       -- Bessel function of integer order and real argument.
    jv       -- Bessel function of real-valued order and complex argument.
    jve      -- Exponentially scaled Bessel function.
    yn       -- Bessel function of second kind (integer order).

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -320,6 +320,7 @@ The following functions evaluate values of orthogonal polynomials:
 .. autosummary::
    :toctree: generated/
 
+   assoc_laguerre
    eval_legendre
    eval_chebyt
    eval_chebyu

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -209,10 +209,15 @@ Raw Statistical Functions
    nbdtr      -- Sum of terms 0 through k of the negative binomial pdf.
    nbdtrc     -- Sum of terms k+1 to infinity under negative binomial pdf.
    nbdtri     -- Inverse of nbdtr
-   nctdtr     -- CDF of non-central t distribution.
-   nctdtridf  -- Find degrees of freedom of non-central t distribution.
-   nctdtrit   -- Inverse CDF of non-central t distribution.
-   nctdtrinc  -- Find noncentrality parameter of non-central t distribution.
+   ncfdtr     -- CDF of non-central t distribution.
+   ncfdtridfd -- Find degrees of freedom (denominator) of noncentral F distribution.
+   ncfdtridfn -- Find degrees of freedom (numerator) of noncentral F distribution.
+   ncfdtri    -- Inverse CDF of noncentral F distribution.
+   ncfdtrinc  -- Find noncentrality parameter of noncentral F distribution.
+   nctdtr     -- CDF of noncentral t distribution.
+   nctdtridf  -- Find degrees of freedom of noncentral t distribution.
+   nctdtrit   -- Inverse CDF of noncentral t distribution.
+   nctdtrinc  -- Find noncentrality parameter of noncentral t distribution.
    pdtr       -- Sum of terms 0 through k of the Poisson pdf.
    pdtrc      -- Sum of terms k+1 to infinity of the Poisson pdf.
    pdtri      -- Inverse of pdtr

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -218,6 +218,8 @@ Raw Statistical Functions
    nctdtridf  -- Find degrees of freedom of noncentral t distribution.
    nctdtrit   -- Inverse CDF of noncentral t distribution.
    nctdtrinc  -- Find noncentrality parameter of noncentral t distribution.
+   nrdtrimn   -- Find mean of normal distribution from cdf and std.
+   nrdtrisd   -- Find std of normal distribution from cdf and mean.
    pdtr       -- Sum of terms 0 through k of the Poisson pdf.
    pdtrc      -- Sum of terms k+1 to infinity of the Poisson pdf.
    pdtri      -- Inverse of pdtr

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -26,6 +26,7 @@ Example:
    :toctree: generated/
 
    errprint
+   SpecialFunctionWarning -- Warning that can be issued with ``errprint(True)``
 
 Available functions
 ===================
@@ -208,6 +209,10 @@ Raw Statistical Functions
    nbdtr      -- Sum of terms 0 through k of the negative binomial pdf.
    nbdtrc     -- Sum of terms k+1 to infinity under negative binomial pdf.
    nbdtri     -- Inverse of nbdtr
+   nctdtr     -- CDF of non-central t distribution.
+   nctdtridf  -- Find degrees of freedom of non-central t distribution.
+   nctdtrit   -- Inverse CDF of non-central t distribution.
+   nctdtrinc  -- Find noncentrality parameter of non-central t distribution.
    pdtr       -- Sum of terms 0 through k of the Poisson pdf.
    pdtrc      -- Sum of terms k+1 to infinity of the Poisson pdf.
    pdtri      -- Inverse of pdtr

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -5940,7 +5940,7 @@ cdef char ufunc_ive_types[12]
 cdef char *ufunc_ive_doc = (
     "ive(v,z)\n"
     "\n"
-    "Exponentially scaled modified Bessel function of the first kind \n"
+    "Exponentially scaled modified Bessel function of the first kind\n"
     "\n"
     "Defined as::\n"
     "\n"
@@ -7230,7 +7230,54 @@ cdef void *ufunc_ncfdtr_ptr[4]
 cdef void *ufunc_ncfdtr_data[2]
 cdef char ufunc_ncfdtr_types[10]
 cdef char *ufunc_ncfdtr_doc = (
-    "")
+    "ncfdtr(dfn, dfd, nc, f)\n"
+    "\n"
+    "Cumulative distribution function of the non-central F distribution.\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "dfn : array_like\n"
+    "    Degrees of freedom of the numerator sum of squares.  Range (0, inf).\n"
+    "dfd : array_like\n"
+    "    Degrees of freedom of the denominator sum of squares.  Range (0, inf).\n"
+    "nc : array_like\n"
+    "    Noncentrality parameter.  Should be in range (0, 1e4).\n"
+    "f : array_like\n"
+    "    Quantiles, i.e. the upper limit of integration.\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "cdf : float or ndarray\n"
+    "    The calculated CDF.  If all inputs are scalar, the return will be a\n"
+    "    float.  Otherwise it will be an array.\n"
+    "\n"
+    "See Also\n"
+    "--------\n"
+    "ncdfdtri : Inverse CDF (iCDF) of the non-central F distribution.\n"
+    "ncdfdtridfd : Calculate dfd, given CDF and iCDF values.\n"
+    "ncdfdtridfn : Calculate dfn, given CDF and iCDF values.\n"
+    "ncdfdtrinc : Calculate noncentrality parameter, given CDF, iCDF, dfn, dfd.\n"
+    "\n"
+    "Examples\n"
+    "--------\n"
+    ">>> from scipy import special\n"
+    ">>> from scipy import stats\n"
+    ">>> import matplotlib.pyplot as plt\n"
+    "\n"
+    "Plot the CDF of the non-central F distribution, for nc=0.  Compare with the\n"
+    "F-distribution from scipy.stats:\n"
+    "\n"
+    ">>> x = np.linspace(-1, 8, num=500)\n"
+    ">>> dfn = 3\n"
+    ">>> dfd = 2\n"
+    ">>> ncf_stats = stats.f.cdf(x, dfn, dfd)\n"
+    ">>> ncf_special = special.ncfdtr(dfn, dfd, 0, x)\n"
+    "\n"
+    ">>> fig = plt.figure()\n"
+    ">>> ax = fig.add_subplot(111)\n"
+    ">>> ax.plot(x, ncf_stats, 'b-', lw=3)\n"
+    ">>> ax.plot(x, ncf_special, 'r-')\n"
+    ">>> plt.show()")
 ufunc_ncfdtr_loops[0] = <np.PyUFuncGenericFunction>loop_d_dddd__As_ffff_f
 ufunc_ncfdtr_loops[1] = <np.PyUFuncGenericFunction>loop_d_dddd__As_dddd_d
 ufunc_ncfdtr_types[0] = <char>NPY_FLOAT
@@ -7256,7 +7303,11 @@ cdef void *ufunc_ncfdtri_ptr[4]
 cdef void *ufunc_ncfdtri_data[2]
 cdef char ufunc_ncfdtri_types[10]
 cdef char *ufunc_ncfdtri_doc = (
-    "")
+    "ncfdtri(p, dfn, dfd, nc)\n"
+    "\n"
+    "Inverse cumulative distribution function of the non-central F distribution.\n"
+    "\n"
+    "See `ncfdtr` for more details.")
 ufunc_ncfdtri_loops[0] = <np.PyUFuncGenericFunction>loop_d_dddd__As_ffff_f
 ufunc_ncfdtri_loops[1] = <np.PyUFuncGenericFunction>loop_d_dddd__As_dddd_d
 ufunc_ncfdtri_types[0] = <char>NPY_FLOAT
@@ -7282,7 +7333,11 @@ cdef void *ufunc_ncfdtridfd_ptr[4]
 cdef void *ufunc_ncfdtridfd_data[2]
 cdef char ufunc_ncfdtridfd_types[10]
 cdef char *ufunc_ncfdtridfd_doc = (
-    "")
+    "ncfdtridfd(p, f, dfn, nc)\n"
+    "\n"
+    "Calculate degrees of freedom (denominator) for the noncentral F-distribution.\n"
+    "\n"
+    "See `ncfdtr` for more details.")
 ufunc_ncfdtridfd_loops[0] = <np.PyUFuncGenericFunction>loop_d_dddd__As_ffff_f
 ufunc_ncfdtridfd_loops[1] = <np.PyUFuncGenericFunction>loop_d_dddd__As_dddd_d
 ufunc_ncfdtridfd_types[0] = <char>NPY_FLOAT
@@ -7308,7 +7363,11 @@ cdef void *ufunc_ncfdtridfn_ptr[4]
 cdef void *ufunc_ncfdtridfn_data[2]
 cdef char ufunc_ncfdtridfn_types[10]
 cdef char *ufunc_ncfdtridfn_doc = (
-    "")
+    "ncfdtridfn(p, f, dfd, nc)\n"
+    "\n"
+    "Calculate degrees of freedom (numerator) for the noncentral F-distribution.\n"
+    "\n"
+    "See `ncfdtr` for more details.")
 ufunc_ncfdtridfn_loops[0] = <np.PyUFuncGenericFunction>loop_d_dddd__As_ffff_f
 ufunc_ncfdtridfn_loops[1] = <np.PyUFuncGenericFunction>loop_d_dddd__As_dddd_d
 ufunc_ncfdtridfn_types[0] = <char>NPY_FLOAT
@@ -7334,7 +7393,11 @@ cdef void *ufunc_ncfdtrinc_ptr[4]
 cdef void *ufunc_ncfdtrinc_data[2]
 cdef char ufunc_ncfdtrinc_types[10]
 cdef char *ufunc_ncfdtrinc_doc = (
-    "")
+    "ncfdtrinc(p, f, dfn, dfd)\n"
+    "\n"
+    "Calculate non-centrality parameter for non-central F distribution.\n"
+    "\n"
+    "See `ncfdtr` for more details.")
 ufunc_ncfdtrinc_loops[0] = <np.PyUFuncGenericFunction>loop_d_dddd__As_ffff_f
 ufunc_ncfdtrinc_loops[1] = <np.PyUFuncGenericFunction>loop_d_dddd__As_dddd_d
 ufunc_ncfdtrinc_types[0] = <char>NPY_FLOAT
@@ -7360,7 +7423,50 @@ cdef void *ufunc_nctdtr_ptr[4]
 cdef void *ufunc_nctdtr_data[2]
 cdef char ufunc_nctdtr_types[8]
 cdef char *ufunc_nctdtr_doc = (
-    "")
+    "nctdtr (df, nc, t)\n"
+    "\n"
+    "Cumulative distribution function of the non-central t distribution.\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "df : array_like\n"
+    "    Degrees of freedom of the distribution.  Should be in range (0, inf).\n"
+    "nc : array_like\n"
+    "    Noncentrality parameter.  Should be in range (-1e6, 1e6).\n"
+    "t : array_like\n"
+    "    Quantiles, i.e. the upper limit of integration.\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "cdf : float or ndarray\n"
+    "    The calculated CDF.  If all inputs are scalar, the return will be a\n"
+    "    float.  Otherwise it will be an array.\n"
+    "\n"
+    "See Also\n"
+    "--------\n"
+    "nctdtrit : Inverse CDF (iCDF) of the non-central t distribution.\n"
+    "nctdtridf : Calculate degrees of freedom, given CDF and iCDF values.\n"
+    "nctdtrinc : Calculate non-centrality parameter, given CDF iCDF values.\n"
+    "\n"
+    "Examples\n"
+    "--------\n"
+    ">>> from scipy import special\n"
+    ">>> from scipy import stats\n"
+    ">>> import matplotlib.pyplot as plt\n"
+    "\n"
+    "Plot the CDF of the non-central t distribution, for nc=0.  Compare with the\n"
+    "t-distribution from scipy.stats:\n"
+    "\n"
+    ">>> x = np.linspace(-5, 5, num=500)\n"
+    ">>> df = 3\n"
+    ">>> nct_stats = stats.t.cdf(x, df)\n"
+    ">>> nct_special = special.nctdtr(df, 0, x)\n"
+    "\n"
+    ">>> fig = plt.figure()\n"
+    ">>> ax = fig.add_subplot(111)\n"
+    ">>> ax.plot(x, nct_stats, 'b-', lw=3)\n"
+    ">>> ax.plot(x, nct_special, 'r-')\n"
+    ">>> plt.show()")
 ufunc_nctdtr_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_nctdtr_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_nctdtr_types[0] = <char>NPY_FLOAT
@@ -7384,7 +7490,20 @@ cdef void *ufunc_nctdtridf_ptr[4]
 cdef void *ufunc_nctdtridf_data[2]
 cdef char ufunc_nctdtridf_types[8]
 cdef char *ufunc_nctdtridf_doc = (
-    "")
+    "nctdtridf (p, nc, t)\n"
+    "\n"
+    "Calculate degrees of freedom for non-central t distribution.\n"
+    "\n"
+    "See `nctdtr` for more details.\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "p : array_like\n"
+    "    CDF values, in range (0, 1].\n"
+    "nc : array_like\n"
+    "    Noncentrality parameter.  Should be in range (-1e6, 1e6).\n"
+    "t : array_like\n"
+    "    Quantiles, i.e. the upper limit of integration.")
 ufunc_nctdtridf_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_nctdtridf_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_nctdtridf_types[0] = <char>NPY_FLOAT
@@ -7408,7 +7527,20 @@ cdef void *ufunc_nctdtrinc_ptr[4]
 cdef void *ufunc_nctdtrinc_data[2]
 cdef char ufunc_nctdtrinc_types[8]
 cdef char *ufunc_nctdtrinc_doc = (
-    "")
+    "nctdtrinc (df, p, t)\n"
+    "\n"
+    "Calculate non-centrality parameter for non-central t distribution.\n"
+    "\n"
+    "See `nctdtr` for more details.\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "df : array_like\n"
+    "    Degrees of freedom of the distribution.  Should be in range (0, inf).\n"
+    "p : array_like\n"
+    "    CDF values, in range (0, 1].\n"
+    "t : array_like\n"
+    "    Quantiles, i.e. the upper limit of integration.")
 ufunc_nctdtrinc_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_nctdtrinc_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_nctdtrinc_types[0] = <char>NPY_FLOAT
@@ -7432,7 +7564,20 @@ cdef void *ufunc_nctdtrit_ptr[4]
 cdef void *ufunc_nctdtrit_data[2]
 cdef char ufunc_nctdtrit_types[8]
 cdef char *ufunc_nctdtrit_doc = (
-    "")
+    "nctdtrit (df, nc, p)\n"
+    "\n"
+    "Inverse cumulative distribution function of the non-central t distribution.\n"
+    "\n"
+    "See `nctdtr` for more details.\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "df : array_like\n"
+    "    Degrees of freedom of the distribution.  Should be in range (0, inf).\n"
+    "nc : array_like\n"
+    "    Noncentrality parameter.  Should be in range (-1e6, 1e6).\n"
+    "p : array_like\n"
+    "    CDF values, in range (0, 1].")
 ufunc_nctdtrit_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_nctdtrit_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_nctdtrit_types[0] = <char>NPY_FLOAT
@@ -7509,7 +7654,27 @@ cdef void *ufunc_nrdtrimn_ptr[4]
 cdef void *ufunc_nrdtrimn_data[2]
 cdef char ufunc_nrdtrimn_types[8]
 cdef char *ufunc_nrdtrimn_doc = (
-    "")
+    "nrdtrimn(p, x, std)\n"
+    "\n"
+    "Calculate mean of normal distribution given other params.\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "p : array_like\n"
+    "    CDF values, in range (0, 1].\n"
+    "x : array_like\n"
+    "    Quantiles, i.e. the upper limit of integration.\n"
+    "std : array_like\n"
+    "    Standard deviation.\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "mn : float or ndarray\n"
+    "    The mean of the normal distribution.\n"
+    "\n"
+    "See Also\n"
+    "--------\n"
+    "nrdtrimn, ndtr")
 ufunc_nrdtrimn_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_nrdtrimn_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_nrdtrimn_types[0] = <char>NPY_FLOAT
@@ -7533,7 +7698,27 @@ cdef void *ufunc_nrdtrisd_ptr[4]
 cdef void *ufunc_nrdtrisd_data[2]
 cdef char ufunc_nrdtrisd_types[8]
 cdef char *ufunc_nrdtrisd_doc = (
-    "")
+    "nrdtrisd(p, x, mn)\n"
+    "\n"
+    "Calculate standard deviation of normal distribution given other params.\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "p : array_like\n"
+    "    CDF values, in range (0, 1].\n"
+    "x : array_like\n"
+    "    Quantiles, i.e. the upper limit of integration.\n"
+    "mn : float or ndarray\n"
+    "    The mean of the normal distribution.\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "std : array_like\n"
+    "    Standard deviation.\n"
+    "\n"
+    "See Also\n"
+    "--------\n"
+    "nrdtristd, ndtr")
 ufunc_nrdtrisd_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_nrdtrisd_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_nrdtrisd_types[0] = <char>NPY_FLOAT

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1975,18 +1975,108 @@ add_newdoc("scipy.special", "ncfdtrinc",
 
 add_newdoc("scipy.special", "nctdtr",
     """
+    nctdtr (df, nc, t)
+
+    Cumulative distribution function of the non-central t distribution.
+
+    Parameters
+    ----------
+    df : array_like
+        Degrees of freedom of the distribution.  Should be in range (0, inf).
+    nc : array_like
+        Noncentrality parameter.  Should be in range (-1e6, 1e6).
+    t : array_like
+        Quantiles, i.e. the upper limit of integration.
+
+    Returns
+    -------
+    cdf : float or ndarray
+        The calculated CDF.  If all inputs are scalar, the return will be a
+        float.  Otherwise it will be an array.
+
+    See Also
+    --------
+    nctdtrit : Inverse CDF (iCDF) of the non-central t distribution.
+    nctdtridf : Calculate degrees of freedom, given CDF and iCDF values.
+    nctdtrinc : Calculate non-centrality parameter, given CDF iCDF values.
+
+    Examples
+    --------
+    >>> from scipy import special
+    >>> from scipy import stats
+    >>> import matplotlib.pyplot as plt
+
+    Plot the CDF of the non-central t distribution, for nc=0.  Compare with the
+    t-distribution from scipy.stats:
+
+    >>> x = np.linspace(-5, 5, num=500)
+    >>> df = 3
+    >>> nct_stats = stats.t.cdf(x, df)
+    >>> nct_special = special.nctdtr(df, 0, x)
+
+    >>> fig = plt.figure()
+    >>> ax = fig.add_subplot(111)
+    >>> ax.plot(x, nct_stats, 'b-', lw=3)
+    >>> ax.plot(x, nct_special, 'r-')
+    >>> plt.show()
+
     """)
 
 add_newdoc("scipy.special", "nctdtridf",
     """
+    nctdtridf (p, nc, t)
+
+    Calculate degrees of freedom for non-central t distribution.
+
+    See `nctdtr` for more details.
+
+    Parameters
+    ----------
+    p : array_like
+        CDF values, in range (0, 1].
+    nc : array_like
+        Noncentrality parameter.  Should be in range (-1e6, 1e6).
+    t : array_like
+        Quantiles, i.e. the upper limit of integration.
+
     """)
 
 add_newdoc("scipy.special", "nctdtrinc",
     """
+    nctdtrinc (df, p, t)
+
+    Calculate non-centrality parameter for non-central t distribution.
+
+    See `nctdtr` for more details.
+
+    Parameters
+    ----------
+    df : array_like
+        Degrees of freedom of the distribution.  Should be in range (0, inf).
+    p : array_like
+        CDF values, in range (0, 1].
+    t : array_like
+        Quantiles, i.e. the upper limit of integration.
+
     """)
 
 add_newdoc("scipy.special", "nctdtrit",
     """
+    nctdtrit (df, nc, p)
+
+    Inverse cumulative distribution function of the non-central t distribution.
+
+    See `nctdtr` for more details.
+
+    Parameters
+    ----------
+    df : array_like
+        Degrees of freedom of the distribution.  Should be in range (0, inf).
+    nc : array_like
+        Noncentrality parameter.  Should be in range (-1e6, 1e6).
+    p : array_like
+        CDF values, in range (0, 1].
+
     """)
 
 add_newdoc("scipy.special", "ndtr",

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -419,7 +419,7 @@ add_newdoc("scipy.special", "chndtr",
     chndtr(x, df, nc)
 
     Non-central chi square cumulative distribution function
-    
+
     """)
 
 add_newdoc("scipy.special", "chndtrix",
@@ -847,7 +847,7 @@ add_newdoc("scipy.special", "fdtr",
     fdtr(dfn, dfd, x)
 
     F cumulative distribution function
-    
+
     Returns the area from zero to x under the F density function (also
     known as Snedcor's density or the variance ratio density).  This
     is the density of X = (unum/dfn)/(uden/dfd), where unum and uden
@@ -919,7 +919,7 @@ add_newdoc("scipy.special", "gamma",
     gamma(z)
 
     Gamma function
-    
+
     The gamma function is often referred to as the generalized
     factorial since ``z*gamma(z) = gamma(z+1)`` and ``gamma(n+1) =
     n!`` for natural number *n*.
@@ -930,9 +930,9 @@ add_newdoc("scipy.special", "gammainc",
     gammainc(a, x)
 
     Incomplete gamma function
-    
+
     Defined as::
-    
+
         1 / gamma(a) * integral(exp(-t) * t**(a-1), t=0..x)
 
     `a` must be positive and `x` must be >= 0.
@@ -1388,7 +1388,7 @@ add_newdoc("scipy.special", "itairy",
     itairy(x)
 
     Integrals of Airy functios
-    
+
     Calculates the integral of Airy functions from 0 to x
 
     Returns
@@ -1419,7 +1419,7 @@ add_newdoc("scipy.special", "itj0y0",
     itj0y0(x)
 
     Integrals of Bessel functions of order 0
-    
+
     Returns simple integrals from 0 to x of the zeroth order Bessel
     functions j0 and y0.
 
@@ -1471,7 +1471,7 @@ add_newdoc("scipy.special", "ive",
     """
     ive(v,z)
 
-    Exponentially scaled modified Bessel function of the first kind 
+    Exponentially scaled modified Bessel function of the first kind
 
     Defined as::
 
@@ -1496,7 +1496,12 @@ add_newdoc("scipy.special", "jn",
     """
     jn(n, x)
 
-    Bessel function of the first kind of integer order n
+    Bessel function of the first kind of integer order n.
+
+    Notes
+    -----
+    `jn` is an alias of `jv`.
+
     """)
 
 add_newdoc("scipy.special", "jv",
@@ -1713,7 +1718,7 @@ add_newdoc("scipy.special", "mathieu_a",
     mathieu_a(m,q)
 
     Characteristic value of even Mathieu functions
-    
+
     Returns the characteristic value for the even solution,
     ``ce_m(z,q)``, of Mathieu's equation.
     """)
@@ -1897,7 +1902,7 @@ add_newdoc("scipy.special", "nbdtr",
     nbdtr(k, n, p)
 
     Negative binomial cumulative distribution function
-    
+
     Returns the sum of the terms 0 through k of the negative binomial
     distribution::
 
@@ -1989,7 +1994,7 @@ add_newdoc("scipy.special", "ndtr",
     ndtr(x)
 
     Gaussian cumulative distribution function
-    
+
     Returns the area under the standard Gaussian probability
     density function, integrated from minus infinity to x::
 
@@ -2171,7 +2176,7 @@ add_newdoc("scipy.special", "pbvv",
     pbvv(v,x)
 
     Parabolic cylinder function V
-    
+
     Returns the parabolic cylinder function Vv(x) in v and the
     derivative, Vv'(x) in vp.
 
@@ -2556,7 +2561,7 @@ add_newdoc("scipy.special", "wofz",
     wofz(z)
 
     Faddeeva function
-    
+
     Returns the value of the Faddeeva function for complex argument::
 
         exp(-z**2)*erfc(-i*z)

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1951,26 +1951,95 @@ add_newdoc("scipy.special", "nbdtrin",
 
 add_newdoc("scipy.special", "ncfdtr",
     """
+    ncfdtr(dfn, dfd, nc, f)
+
+    Cumulative distribution function of the non-central F distribution.
+
+    Parameters
+    ----------
+    dfn : array_like
+        Degrees of freedom of the numerator sum of squares.  Range (0, inf).
+    dfd : array_like
+        Degrees of freedom of the denominator sum of squares.  Range (0, inf).
+    nc : array_like
+        Noncentrality parameter.  Should be in range (0, 1e4).
+    f : array_like
+        Quantiles, i.e. the upper limit of integration.
+
+    Returns
+    -------
+    cdf : float or ndarray
+        The calculated CDF.  If all inputs are scalar, the return will be a
+        float.  Otherwise it will be an array.
+
+    See Also
+    --------
+    ncdfdtri : Inverse CDF (iCDF) of the non-central F distribution.
+    ncdfdtridfd : Calculate dfd, given CDF and iCDF values.
+    ncdfdtridfn : Calculate dfn, given CDF and iCDF values.
+    ncdfdtrinc : Calculate noncentrality parameter, given CDF, iCDF, dfn, dfd.
+
+    Examples
+    --------
+    >>> from scipy import special
+    >>> from scipy import stats
+    >>> import matplotlib.pyplot as plt
+
+    Plot the CDF of the non-central F distribution, for nc=0.  Compare with the
+    F-distribution from scipy.stats:
+
+    >>> x = np.linspace(-1, 8, num=500)
+    >>> dfn = 3
+    >>> dfd = 2
+    >>> ncf_stats = stats.f.cdf(x, dfn, dfd)
+    >>> ncf_special = special.ncfdtr(dfn, dfd, 0, x)
+
+    >>> fig = plt.figure()
+    >>> ax = fig.add_subplot(111)
+    >>> ax.plot(x, ncf_stats, 'b-', lw=3)
+    >>> ax.plot(x, ncf_special, 'r-')
+    >>> plt.show()
+
     """)
 
 add_newdoc("scipy.special", "ncfdtri",
     """
-    """)
+    ncfdtri(p, dfn, dfd, nc)
 
-add_newdoc("scipy.special", "ncfdtrifn",
-    """
+    Inverse cumulative distribution function of the non-central F distribution.
+
+    See `ncfdtr` for more details.
+
     """)
 
 add_newdoc("scipy.special", "ncfdtridfd",
     """
+    ncfdtridfd(p, f, dfn, nc)
+
+    Calculate degrees of freedom (denominator) for the noncentral F-distribution.
+
+    See `ncfdtr` for more details.
+
     """)
 
 add_newdoc("scipy.special", "ncfdtridfn",
     """
+    ncfdtridfn(p, f, dfd, nc)
+
+    Calculate degrees of freedom (numerator) for the noncentral F-distribution.
+
+    See `ncfdtr` for more details.
+
     """)
 
 add_newdoc("scipy.special", "ncfdtrinc",
     """
+    ncfdtrinc(p, f, dfn, dfd)
+
+    Calculate non-centrality parameter for non-central F distribution.
+
+    See `ncfdtr` for more details.
+
     """)
 
 add_newdoc("scipy.special", "nctdtr",

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -2163,10 +2163,54 @@ add_newdoc("scipy.special", "ndtr",
 
 add_newdoc("scipy.special", "nrdtrimn",
     """
+    nrdtrimn(p, x, std)
+
+    Calculate mean of normal distribution given other params.
+
+    Parameters
+    ----------
+    p : array_like
+        CDF values, in range (0, 1].
+    x : array_like
+        Quantiles, i.e. the upper limit of integration.
+    std : array_like
+        Standard deviation.
+
+    Returns
+    -------
+    mn : float or ndarray
+        The mean of the normal distribution.
+
+    See Also
+    --------
+    nrdtrimn, ndtr
+
     """)
 
 add_newdoc("scipy.special", "nrdtrisd",
     """
+    nrdtrisd(p, x, mn)
+
+    Calculate standard deviation of normal distribution given other params.
+
+    Parameters
+    ----------
+    p : array_like
+        CDF values, in range (0, 1].
+    x : array_like
+        Quantiles, i.e. the upper limit of integration.
+    mn : float or ndarray
+        The mean of the normal distribution.
+
+    Returns
+    -------
+    std : array_like
+        Standard deviation.
+
+    See Also
+    --------
+    nrdtristd, ndtr
+
     """)
 
 add_newdoc("scipy.special", "log_ndtr",

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -551,7 +551,18 @@ def hyp0f1(v, z):
     return num / den
 
 
-def assoc_laguerre(x,n,k=0.0):
+def assoc_laguerre(x, n, k=0.0):
+    """Returns the n-th order generalized (associated) Laguerre polynomial.
+
+    The polynomial :math:`L^(alpha)_n(x)` is orthogonal over ``[0, inf)``,
+    with weighting function ``exp(-x) * x**alpha`` with ``alpha > -1``.
+
+    Notes
+    -----
+    `assoc_laguerre` is a simple wrapper around `eval_genlaguerre`, with
+    reversed argument order ``(x, n, k=0.0) --> (n, k, x)``.
+
+    """
     return orthogonal.eval_genlaguerre(n, k, x)
 
 digamma = psi

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -189,7 +189,7 @@ def y1p_zeros(nt,complex=0):
     return specfun.cyzo(nt,kf,kc)
 
 
-def bessel_diff_formula(v, z, n, L, phase):
+def _bessel_diff_formula(v, z, n, L, phase):
     # from AMS55.
     # L(v,z) = J(v,z), Y(v,z), H1(v,z), H2(v,z), phase = -1
     # L(v,z) = I(v,z) or exp(v*pi*i)K(v,z), phase = 1
@@ -202,6 +202,10 @@ def bessel_diff_formula(v, z, n, L, phase):
     return s / (2.**n)
 
 
+bessel_diff_formula = np.deprecate(_bessel_diff_formula,
+    message="bessel_diff_formula is a private function, do not use it!")
+
+
 def jvp(v,z,n=1):
     """Return the nth derivative of Jv(z) with respect to z.
     """
@@ -210,7 +214,7 @@ def jvp(v,z,n=1):
     if n == 0:
         return jv(v,z)
     else:
-        return bessel_diff_formula(v, z, n, jv, -1)
+        return _bessel_diff_formula(v, z, n, jv, -1)
 #        return (jvp(v-1,z,n-1) - jvp(v+1,z,n-1))/2.0
 
 
@@ -222,7 +226,7 @@ def yvp(v,z,n=1):
     if n == 0:
         return yv(v,z)
     else:
-        return bessel_diff_formula(v, z, n, yv, -1)
+        return _bessel_diff_formula(v, z, n, yv, -1)
 #        return (yvp(v-1,z,n-1) - yvp(v+1,z,n-1))/2.0
 
 
@@ -234,7 +238,7 @@ def kvp(v,z,n=1):
     if n == 0:
         return kv(v,z)
     else:
-        return (-1)**n * bessel_diff_formula(v, z, n, kv, 1)
+        return (-1)**n * _bessel_diff_formula(v, z, n, kv, 1)
 
 
 def ivp(v,z,n=1):
@@ -245,7 +249,7 @@ def ivp(v,z,n=1):
     if n == 0:
         return iv(v,z)
     else:
-        return bessel_diff_formula(v, z, n, iv, 1)
+        return _bessel_diff_formula(v, z, n, iv, 1)
 
 
 def h1vp(v,z,n=1):
@@ -256,7 +260,7 @@ def h1vp(v,z,n=1):
     if n == 0:
         return hankel1(v,z)
     else:
-        return bessel_diff_formula(v, z, n, hankel1, -1)
+        return _bessel_diff_formula(v, z, n, hankel1, -1)
 #        return (h1vp(v-1,z,n-1) - h1vp(v+1,z,n-1))/2.0
 
 
@@ -268,7 +272,7 @@ def h2vp(v,z,n=1):
     if n == 0:
         return hankel2(v,z)
     else:
-        return bessel_diff_formula(v, z, n, hankel2, -1)
+        return _bessel_diff_formula(v, z, n, hankel2, -1)
 #        return (h2vp(v-1,z,n-1) - h2vp(v+1,z,n-1))/2.0
 
 

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -6,11 +6,12 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from scipy.lib.six import xrange
-from numpy import pi, asarray, floor, isscalar, iscomplex, real, imag, sqrt, \
-        where, mgrid, cos, sin, exp, place, seterr, issubdtype, extract, \
-        less, vectorize, inexact, nan, zeros, sometrue, atleast_1d, sinc
-from ._ufuncs import ellipkm1, mathieu_a, mathieu_b, iv, jv, gamma, psi, zeta, \
-        hankel1, hankel2, yv, kv, gammaln, ndtri, errprint, poch, binom
+from numpy import (pi, asarray, floor, isscalar, iscomplex, real, imag, sqrt,
+                   where, mgrid, cos, sin, exp, place, issubdtype, extract,
+                   less, vectorize, inexact, nan, zeros, atleast_1d, sinc)
+from ._ufuncs import (ellipkm1, mathieu_a, mathieu_b, iv, jv, gamma, psi, zeta,
+                      hankel1, hankel2, yv, kv, gammaln, ndtri, errprint, poch,
+                      binom)
 from . import _ufuncs
 import types
 from . import specfun
@@ -37,16 +38,31 @@ __all__ = ['agm', 'ai_zeros', 'assoc_laguerre', 'bei_zeros', 'beip_zeros',
 
 
 class SpecialFunctionWarning(Warning):
+    """Warning that can be issued with ``errprint(True)``"""
     pass
 warnings.simplefilter("always", category=SpecialFunctionWarning)
 
 
 def diric(x,n):
-    """Returns the periodic sinc function, also called the Dirichlet function:
+    """Returns the periodic sinc function, also called the Dirichlet function
 
-    diric(x) = sin(x *n / 2) / (n sin(x / 2))
+    The Dirichlet function is defined as::
+
+        diric(x) = sin(x * n/2) / (n * sin(x / 2)),
 
     where n is a positive integer.
+
+    Parameters
+    ----------
+    x : array_like
+        Input data
+    n : int
+        Integer defining the periodicity.
+
+    Returns
+    -------
+    diric : ndarray
+
     """
     x,n = asarray(x), asarray(n)
     n = asarray(n + (x-x))


### PR DESCRIPTION
- Removes `special.jn` from the refguide, closes gh-2564.
- Adds `nctdtr*`, `ncfdtr*` and `nrdtri*` docstrings.
- Adds `SpecialFunctionWarning` to the refguide.

This should close gh-2746. 

There are only two functions left without docstring: `bessel_diff_formula` and `assoc_laguerre`. I'm not sure what the state of those is or why one would like to use them, so I left those out. Suggestions on what to do with those welcome.
