### PR TITLE
DEP: put back veccdf/vecfunc/vec_generic_momemt in stats.distributions.

### DIFF
--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -60,7 +60,8 @@ We can list all methods and properties of the distribution with
 ``dir(norm)``.  As it turns out, some of the methods are private
 methods although they are not named as such (their name does not start
 with a leading underscore), for example ``veccdf``, are only available
-for internal calculation.
+for internal calculation (those methods will give warnings when one tries to
+use them, and will be removed at some point).
 
 To obtain the `real` main methods, we list the methods of the frozen
 distribution. (We explain the meaning of a `frozen` distribution

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1432,6 +1432,11 @@ class rv_continuous(rv_generic):
         self._cdfvec = vectorize(self._cdf_single, otypes='d')
         self._cdfvec.nin = self.numargs + 1
 
+        # backwards compat.  these were removed in 0.14.0, put back but
+        # deprecated in 0.14.1:
+        self.vecfunc = np.deprecate(self._ppfvec, "vecfunc")
+        self.veccdf = np.deprecate(self._cdfvec, "veccdf")
+
         self.extradoc = extradoc
         if momtype == 0:
             self.generic_moment = vectorize(self._mom0_sc, otypes='d')
@@ -2634,6 +2639,11 @@ class rv_discrete(rv_generic):
             _vec_generic_moment.nin = self.numargs + 2
             self.generic_moment = instancemethod(_vec_generic_moment,
                                                  self, rv_discrete)
+            # backwards compat.  was removed in 0.14.0, put back but
+            # deprecated in 0.14.1:
+            self.vec_generic_moment = np.deprecate(_vec_generic_moment,
+                                                   "vec_generic_moment",
+                                                   "generic_moment")
 
             # correct nin for ppf vectorization
             _vppf = vectorize(_drv2_ppfsingle, otypes='d')


### PR DESCRIPTION
Removed erroneously in gh-3243 for 0.14.0.  These methods were always
private ones but not marked as such, and as the comments on gh-3243 show
they were used. Hence now deprecated.
