### PR TITLE
ENH: scipy.special: Improving sph_harm function 

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -552,6 +552,7 @@ from .orthogonal import *
 from .spfun_stats import multigammaln
 from .lambertw import lambertw
 
+
 __all__ = [s for s in dir() if not s.startswith('_')]
 
 from numpy.dual import register_func

--- a/scipy/special/_legacy.pxd
+++ b/scipy/special/_legacy.pxd
@@ -9,6 +9,8 @@ Here, we define such unsafe wrappers manually.
 
 cimport sf_error
 
+from sph_harm cimport sph_harmonic
+
 cdef extern from "cephes.h":
     double bdtrc(int k, int n, double p) nogil
     double bdtr(int k, int n, double p) nogil 
@@ -40,6 +42,9 @@ cdef inline void _legacy_cast_check(char *func_name, double x, double y) nogil:
                                "floating point number truncated to an integer",
                                1)
 
+cdef inline double complex sph_harmonic_unsafe(double m, double n, double theta, double phi) nogil:
+    _legacy_cast_check("sph_harm", m, n)
+    return sph_harmonic(<int>m, <int> n, theta, phi)
 cdef inline double bdtrc_unsafe(double k, double n, double p) nogil:
     _legacy_cast_check("bdtrc", k, n)
     return bdtrc(<int>k, <int>n, p)

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -169,6 +169,50 @@ cdef void loop_D_dD__As_dD_D(char **args, np.npy_intp *dims, np.npy_intp *steps,
         op0 += steps[2]
     sf_error.check_fpe(func_name)
 
+cdef void loop_D_iidd__As_llff_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef double complex ov0
+    for i in range(n):
+        if <int>(<long*>ip0)[0] == (<long*>ip0)[0] and <int>(<long*>ip1)[0] == (<long*>ip1)[0]:
+            ov0 = (<double complex(*)(int, int, double, double) nogil>func)(<int>(<long*>ip0)[0], <int>(<long*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0])
+        else:
+            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
+            ov0 = <double complex>NPY_NAN
+        (<float complex *>op0)[0] = <float complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_dddd__As_dddd_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double, double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
+        (<double complex *>op0)[0] = <double complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+    sf_error.check_fpe(func_name)
+
 cdef void loop_i_d_dd_As_d_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
@@ -619,6 +663,26 @@ cdef void loop_i_ddd_dd_As_ddd_dd(char **args, np.npy_intp *dims, np.npy_intp *s
         op1 += steps[4]
     sf_error.check_fpe(func_name)
 
+cdef void loop_D_dddd__As_ffff_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double, double, double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0])
+        (<float complex *>op0)[0] = <float complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+    sf_error.check_fpe(func_name)
+
 cdef void loop_D_Dld__As_Dld_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
@@ -744,20 +808,28 @@ cdef void loop_d_dddd__As_dddd_d(char **args, np.npy_intp *dims, np.npy_intp *st
         op0 += steps[4]
     sf_error.check_fpe(func_name)
 
-cdef void loop_D_DD__As_FF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_D_iidd__As_lldd_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
     cdef char *ip0 = args[0]
     cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
     cdef double complex ov0
     for i in range(n):
-        ov0 = (<double complex(*)(double complex, double complex) nogil>func)(<double complex>(<float complex*>ip0)[0], <double complex>(<float complex*>ip1)[0])
-        (<float complex *>op0)[0] = <float complex>ov0
+        if <int>(<long*>ip0)[0] == (<long*>ip0)[0] and <int>(<long*>ip1)[0] == (<long*>ip1)[0]:
+            ov0 = (<double complex(*)(int, int, double, double) nogil>func)(<int>(<long*>ip0)[0], <int>(<long*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
+        else:
+            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
+            ov0 = <double complex>NPY_NAN
+        (<double complex *>op0)[0] = <double complex>ov0
         ip0 += steps[0]
         ip1 += steps[1]
-        op0 += steps[2]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
     sf_error.check_fpe(func_name)
 
 cdef void loop_d_iid__As_lld_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -780,6 +852,22 @@ cdef void loop_d_iid__As_lld_d(char **args, np.npy_intp *dims, np.npy_intp *step
         ip1 += steps[1]
         ip2 += steps[2]
         op0 += steps[3]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_DD__As_FF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double complex, double complex) nogil>func)(<double complex>(<float complex*>ip0)[0], <double complex>(<float complex*>ip1)[0])
+        (<float complex *>op0)[0] = <float complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
     sf_error.check_fpe(func_name)
 
 cdef void loop_i_d_DD_As_d_DD(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -1807,6 +1895,12 @@ ctypedef double _proto_smirnovi_unsafe_t(double, double) nogil
 cdef _proto_smirnovi_unsafe_t *_proto_smirnovi_unsafe_t_var = &_func_smirnovi_unsafe
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_spence "spence"(double) nogil
+from sph_harm cimport sph_harmonic as _func_sph_harmonic
+ctypedef double complex _proto_sph_harmonic_t(int, int, double, double) nogil
+cdef _proto_sph_harmonic_t *_proto_sph_harmonic_t_var = &_func_sph_harmonic
+from _legacy cimport sph_harmonic_unsafe as _func_sph_harmonic_unsafe
+ctypedef double complex _proto_sph_harmonic_unsafe_t(double, double, double, double) nogil
+cdef _proto_sph_harmonic_unsafe_t *_proto_sph_harmonic_unsafe_t_var = &_func_sph_harmonic_unsafe
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_cdft1_wrap "cdft1_wrap"(double, double) nogil
 cdef extern from "_ufuncs_defs.h":
@@ -8741,6 +8835,81 @@ ufunc_spence_ptr[2*1+1] = <void*>(<char*>"spence")
 ufunc_spence_data[0] = &ufunc_spence_ptr[2*0]
 ufunc_spence_data[1] = &ufunc_spence_ptr[2*1]
 spence = np.PyUFunc_FromFuncAndData(ufunc_spence_loops, ufunc_spence_data, ufunc_spence_types, 2, 1, 1, 0, "spence", ufunc_spence_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc_sph_harm_loops[4]
+cdef void *ufunc_sph_harm_ptr[8]
+cdef void *ufunc_sph_harm_data[4]
+cdef char ufunc_sph_harm_types[20]
+cdef char *ufunc_sph_harm_doc = (
+    "sph_harm(m, n, theta, phi)\n"
+    "\n"
+    "Compute spherical harmonics.\n"
+    "\n"
+    "::\n"
+    "\n"
+    "    y_mn = sqrt((2*n+1)/4/pi)*sqrt(gamma(n-m+1)/gamma(n+m+1))*exp(1j*m*theta)*pmv(m,n,cos(phi))\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "m : int\n"
+    "   ``|m| <= n``; the order of the harmonic.\n"
+    "n : int\n"
+    "   where `n` >= 0; the degree of the harmonic.  This is often called\n"
+    "   ``l`` (lower case L) in descriptions of spherical harmonics.\n"
+    "theta : float\n"
+    "   [0, 2*pi]; the azimuthal (longitudinal) coordinate.\n"
+    "phi : float\n"
+    "   [0, pi]; the polar (colatitudinal) coordinate.\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "y_mn : complex float\n"
+    "   The harmonic :math:`Y^m_n` sampled at `theta` and `phi`\n"
+    "\n"
+    "Notes\n"
+    "-----\n"
+    "There are different conventions for the meaning of input arguments\n"
+    "`theta` and `phi`.  We take `theta` to be the azimuthal angle and\n"
+    "`phi` to be the polar angle.  It is common to see the opposite\n"
+    "convention - that is `theta` as the polar angle and `phi` as the\n"
+    "azimuthal angle.")
+ufunc_sph_harm_loops[0] = <np.PyUFuncGenericFunction>loop_D_iidd__As_llff_F
+ufunc_sph_harm_loops[1] = <np.PyUFuncGenericFunction>loop_D_iidd__As_lldd_D
+ufunc_sph_harm_loops[2] = <np.PyUFuncGenericFunction>loop_D_dddd__As_ffff_F
+ufunc_sph_harm_loops[3] = <np.PyUFuncGenericFunction>loop_D_dddd__As_dddd_D
+ufunc_sph_harm_types[0] = <char>NPY_LONG
+ufunc_sph_harm_types[1] = <char>NPY_LONG
+ufunc_sph_harm_types[2] = <char>NPY_FLOAT
+ufunc_sph_harm_types[3] = <char>NPY_FLOAT
+ufunc_sph_harm_types[4] = <char>NPY_CFLOAT
+ufunc_sph_harm_types[5] = <char>NPY_LONG
+ufunc_sph_harm_types[6] = <char>NPY_LONG
+ufunc_sph_harm_types[7] = <char>NPY_DOUBLE
+ufunc_sph_harm_types[8] = <char>NPY_DOUBLE
+ufunc_sph_harm_types[9] = <char>NPY_CDOUBLE
+ufunc_sph_harm_types[10] = <char>NPY_FLOAT
+ufunc_sph_harm_types[11] = <char>NPY_FLOAT
+ufunc_sph_harm_types[12] = <char>NPY_FLOAT
+ufunc_sph_harm_types[13] = <char>NPY_FLOAT
+ufunc_sph_harm_types[14] = <char>NPY_CFLOAT
+ufunc_sph_harm_types[15] = <char>NPY_DOUBLE
+ufunc_sph_harm_types[16] = <char>NPY_DOUBLE
+ufunc_sph_harm_types[17] = <char>NPY_DOUBLE
+ufunc_sph_harm_types[18] = <char>NPY_DOUBLE
+ufunc_sph_harm_types[19] = <char>NPY_CDOUBLE
+ufunc_sph_harm_ptr[2*0] = <void*>_func_sph_harmonic
+ufunc_sph_harm_ptr[2*0+1] = <void*>(<char*>"sph_harm")
+ufunc_sph_harm_ptr[2*1] = <void*>_func_sph_harmonic
+ufunc_sph_harm_ptr[2*1+1] = <void*>(<char*>"sph_harm")
+ufunc_sph_harm_ptr[2*2] = <void*>_func_sph_harmonic_unsafe
+ufunc_sph_harm_ptr[2*2+1] = <void*>(<char*>"sph_harm")
+ufunc_sph_harm_ptr[2*3] = <void*>_func_sph_harmonic_unsafe
+ufunc_sph_harm_ptr[2*3+1] = <void*>(<char*>"sph_harm")
+ufunc_sph_harm_data[0] = &ufunc_sph_harm_ptr[2*0]
+ufunc_sph_harm_data[1] = &ufunc_sph_harm_ptr[2*1]
+ufunc_sph_harm_data[2] = &ufunc_sph_harm_ptr[2*2]
+ufunc_sph_harm_data[3] = &ufunc_sph_harm_ptr[2*3]
+sph_harm = np.PyUFunc_FromFuncAndData(ufunc_sph_harm_loops, ufunc_sph_harm_data, ufunc_sph_harm_types, 4, 4, 1, 0, "sph_harm", ufunc_sph_harm_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_stdtr_loops[2]
 cdef void *ufunc_stdtr_ptr[4]

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -19,6 +19,41 @@ def get(name):
 def add_newdoc(place, name, doc):
     docdict['.'.join((place, name))] = doc
 
+add_newdoc("scipy.special", "sph_harm",
+    """
+    sph_harm(m, n, theta, phi)
+
+    Compute spherical harmonics.
+
+    ::
+
+        y_mn = sqrt((2*n+1)/4/pi)*sqrt(gamma(n-m+1)/gamma(n+m+1))*exp(1j*m*theta)*pmv(m,n,cos(phi))
+
+    Parameters
+    ----------
+    m : int
+       ``|m| <= n``; the order of the harmonic.
+    n : int
+       where `n` >= 0; the degree of the harmonic.  This is often called
+       ``l`` (lower case L) in descriptions of spherical harmonics.
+    theta : float
+       [0, 2*pi]; the azimuthal (longitudinal) coordinate.
+    phi : float
+       [0, pi]; the polar (colatitudinal) coordinate.
+
+    Returns
+    -------
+    y_mn : complex float
+       The harmonic :math:`Y^m_n` sampled at `theta` and `phi`
+
+    Notes
+    -----
+    There are different conventions for the meaning of input arguments
+    `theta` and `phi`.  We take `theta` to be the azimuthal angle and
+    `phi` to be the polar angle.  It is common to see the opposite
+    convention - that is `theta` as the polar angle and `phi` as the
+    azimuthal angle.
+    """)
 
 add_newdoc("scipy.special", "_lambertw",
     """

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -30,7 +30,7 @@ __all__ = ['agm', 'ai_zeros', 'assoc_laguerre', 'bei_zeros', 'beip_zeros',
            'mathieu_b', 'mathieu_even_coef', 'mathieu_odd_coef', 'ndtri',
            'obl_cv_seq', 'pbdn_seq', 'pbdv_seq', 'pbvv_seq', 'perm',
            'polygamma', 'pro_cv_seq', 'psi', 'riccati_jn', 'riccati_yn',
-           'sinc', 'sph_harm', 'sph_in', 'sph_inkn',
+           'sinc', 'sph_in', 'sph_inkn',
            'sph_jn', 'sph_jnyn', 'sph_kn', 'sph_yn', 'y0_zeros', 'y1_zeros',
            'y1p_zeros', 'yn_zeros', 'ynp_zeros', 'yv', 'yvp', 'zeta',
            'SpecialFunctionWarning']
@@ -402,50 +402,6 @@ def riccati_yn(n,x):
         n1 = n
     nm,jn,jnp = specfun.rcty(n1,x)
     return jn[:(n+1)],jnp[:(n+1)]
-
-
-def _sph_harmonic(m,n,theta,phi):
-    """Compute spherical harmonics.
-
-    This is a ufunc and may take scalar or array arguments like any
-    other ufunc.  The inputs will be broadcasted against each other.
-
-    Parameters
-    ----------
-    m : int
-       |m| <= n; the order of the harmonic.
-    n : int
-       where `n` >= 0; the degree of the harmonic.  This is often called
-       ``l`` (lower case L) in descriptions of spherical harmonics.
-    theta : float
-       [0, 2*pi]; the azimuthal (longitudinal) coordinate.
-    phi : float
-       [0, pi]; the polar (colatitudinal) coordinate.
-
-    Returns
-    -------
-    y_mn : complex float
-       The harmonic $Y^m_n$ sampled at `theta` and `phi`
-
-    Notes
-    -----
-    There are different conventions for the meaning of input arguments
-    `theta` and `phi`.  We take `theta` to be the azimuthal angle and
-    `phi` to be the polar angle.  It is common to see the opposite
-    convention - that is `theta` as the polar angle and `phi` as the
-    azimuthal angle.
-    """
-    x = cos(phi)
-    m,n = int(m), int(n)
-    Pmn,Pmn_deriv = lpmn(m,n,x)
-    # Legendre call generates all orders up to m and degrees up to n
-    val = Pmn[-1, -1]
-    val *= sqrt((2*n+1)/4.0/pi)
-    val *= exp(0.5*(gammaln(n-m+1)-gammaln(n+m+1)))
-    val *= exp(1j*m*theta)
-    return val
-
-sph_harm = vectorize(_sph_harmonic,'D')
 
 
 def erfinv(y):

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -81,6 +81,7 @@ from __future__ import division, print_function, absolute_import
 
 # Ufuncs without C++
 UFUNCS = """
+sph_harm -- sph_harmonic: iidd->D, sph_harmonic_unsafe: dddd->D -- sph_harm.pxd, _legacy.pxd
 _lambertw -- lambertw_scalar: Dld->D                       -- lambertw.pxd
 logit -- logitf: f->f, logit: d->d, logitl: g->g           -- _logit.h
 expit -- expitf: f->f, expit: d->d, expitl: g->g           -- _logit.h

--- a/scipy/special/sph_harm.pxd
+++ b/scipy/special/sph_harm.pxd
@@ -1,0 +1,35 @@
+cimport sf_error
+
+cdef extern from "specfun_wrappers.h":
+    double pmv_wrap(double, double, double) nogil
+
+cdef extern from "c_misc/misc.h":
+    double poch(double x, double m) nogil
+
+from _complexstuff cimport *
+from libc.math cimport cos, sqrt, exp, fabs, M_PI as pi
+from libc.stdlib cimport abs
+
+cdef inline double complex sph_harmonic(int m, int n, double theta, double phi) nogil:
+    cdef double x, prefactor
+    cdef double complex val
+    cdef int mp
+    x = cos(phi)
+    if abs(m) > n :
+        sf_error.error("sph_harm", sf_error.ARG, "m should not be greater than n")
+        return nan
+    if n < 0:
+        sf_error.error("sph_harm", sf_error.ARG, "n should not be negative")
+        return nan
+    if m < 0:
+        mp = -m
+        prefactor = (-1)**mp * poch(n + mp + 1, -2 * mp)
+    else:
+        mp = m
+    val = pmv_wrap(mp, n, x)
+    if  m < 0:
+        val *= prefactor
+    val *= sqrt((2*n + 1) / 4.0 / pi)
+    val *= sqrt(poch(n + m + 1, -2 * m))
+    val *= zexp(1j * m * theta)
+    return val


### PR DESCRIPTION
The sph_harm function used for calculating spherical harmonic at present is written in Python and it uses the routine lpmn to calculate the required Associated Legendre function. The routine lpmn iteratively evaluates the function for all values <= m,n every time it is passed, the value required by the sph_harm is just that of the function at m and n (and not at <m,n)
Therefore the routine is substituted by another similar existing routine lpmv, thus avoiding the unnecessary iterations and increasing the speed of the function.
Further the function is rewritten in Cython to increase the speed.  
