### PR TITLE
ENH: check for valid 'orientation' kwarg in dendrogram()

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2114,6 +2114,10 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
     #         pre-order traversal.
     Z = np.asarray(Z, order='c')
 
+    if orientation not in ["top", "left", "bottom", "right"]:
+        raise ValueError("orientation must be one of 'top', 'left', "
+                         "'bottom', or 'right'")
+
     is_valid_linkage(Z, throw=True, name='Z')
     Zs = Z.shape
     n = Zs[0] + 1

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -1433,6 +1433,10 @@ class TestDendrogram(TestCase):
         leaves = R["leaves"]
         self.assertEqual(leaves, [2, 5, 1, 0, 3, 4])
 
+    def test_valid_orientation(self):
+        Z = linkage(_ytdist, 'single')
+        assert_raises(ValueError, dendrogram, Z, orientation="foo")
+
     @dec.skipif(not have_matplotlib)
     def test_dendrogram_plot(self):
         # Tests dendrogram plotting.


### PR DESCRIPTION
fixes #3668
