### PR TITLE
make 'a' and 'b' coefficients atleast_1d array in filtfilt

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1928,8 +1928,8 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None):
                          "be 'even', 'odd', 'constant', or None.") %
                          padtype)
 
-    b = np.asarray(b)
-    a = np.asarray(a)
+    b = np.atleast_1d(b)
+    a = np.atleast_1d(a)
     x = np.asarray(x)
 
     ntaps = max(len(a), len(b))

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -865,7 +865,7 @@ class TestFiltFilt(TestCase):
         y2 = filtfilt(b, a, np.swapaxes(x, 0, 2), padlen=0, axis=2)
         assert_array_equal(y0, np.swapaxes(y2, 0, 2))
 
-	def test_a_coeff(self):
+    def test_a_coeff(self):
         # test for 'a' coefficient as single number
         out = signal.filtfilt([.1, .5], 1, np.arange(10))
         assert_equal(out, arange(10))		

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -866,7 +866,7 @@ class TestFiltFilt(TestCase):
         assert_array_equal(y0, np.swapaxes(y2, 0, 2))
 
 	def test_a_coeff(self):
-		# test for 'a' coefficient as single number
+        # test for 'a' coefficient as single number
         out = signal.filtfilt([.1, .5], 1, np.arange(10))
         assert_equal(out, arange(10))		
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -865,9 +865,9 @@ class TestFiltFilt(TestCase):
         y2 = filtfilt(b, a, np.swapaxes(x, 0, 2), padlen=0, axis=2)
         assert_array_equal(y0, np.swapaxes(y2, 0, 2))
 
-    def test_a_coeff(self):
+    def test_acoeff(self):
         # test for 'a' coefficient as single number
-        out = signal.filtfilt([.1, .5], 1, np.arange(10))
+        out = signal.filtfilt([.5, .5], 1, np.arange(10))
         assert_equal(out, arange(10))		
 
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -865,6 +865,11 @@ class TestFiltFilt(TestCase):
         y2 = filtfilt(b, a, np.swapaxes(x, 0, 2), padlen=0, axis=2)
         assert_array_equal(y0, np.swapaxes(y2, 0, 2))
 
+	def test_a_coeff(self):
+		# test for 'a' coefficient as single number
+        out = signal.filtfilt([.1, .5], 1, np.arange(10))
+        assert_equal(out, arange(10))		
+
 
 class TestDecimate(TestCase):
 


### PR DESCRIPTION
The following crashes:

```
import numpy as np
from scipy.signal import filtfilt
x = np.random.randn(100)
y = filtfilt(np.ones(5)/5, 1, x)  # filtfilt(b, a, x)
```

The problem is in lines 1931 and 1932 of the filfilt function:

```
b = np.asarray(b)
a = np.asarray(a)
```

These lines should be replaced by:

```
b = np.atleast_1d(b)
a = np.atleast_1d(a)
```

In order to the line 1935 to work properly:

```
ntaps = max(len(a), len(b))
```
