### PR TITLE
BUG: cluster: _vq unable to handle large features

### DIFF
--- a/scipy/cluster/_vq.pyx
+++ b/scipy/cluster/_vq.pyx
@@ -15,10 +15,6 @@ cdef extern from "math.h":
     float sqrtf(float num)
     double sqrt(double num)
 
-cdef extern from "numpy/npy_math.h":
-    cdef enum:
-        NPY_INFINITY
-
 ctypedef np.float64_t float64_t
 ctypedef np.float32_t float32_t
 ctypedef np.int32_t int32_t
@@ -215,8 +211,8 @@ def vq(np.ndarray obs, np.ndarray codes):
     # Initialize outdists and outcodes array.
     # Outdists should be initialized as INF.
     outdists = np.empty((nobs,), dtype=obs.dtype)
-    outdists.fill(NPY_INFINITY)
     outcodes = np.empty((nobs,), dtype=np.int32)
+    outdists.fill(np.inf)
 
     if obs.dtype.type is np.float32:
         _vq(<float32_t *>obs_a.data, <float32_t *>codes_a.data,

--- a/scipy/cluster/_vq.pyx
+++ b/scipy/cluster/_vq.pyx
@@ -191,6 +191,10 @@ def vq(np.ndarray obs, np.ndarray codes):
     obs_a = np.PyArray_FROM_OF(obs, flags)
     codes_a = np.PyArray_FROM_OF(codes, flags)
 
+    if obs.dtype != codes.dtype:
+        raise TypeError('observation and code should have same dtype')
+    if obs.dtype not in (np.float32, np.float64):
+        raise TypeError('type other than float or double not supported')
     if obs_a.ndim != codes_a.ndim:
         raise ValueError('observation and code should have same rank')
 
@@ -214,16 +218,14 @@ def vq(np.ndarray obs, np.ndarray codes):
     outdists.fill(NPY_INFINITY)
     outcodes = np.empty((nobs,), dtype=np.int32)
 
-    if obs.dtype == np.float32:
+    if obs.dtype.type is np.float32:
         _vq(<float32_t *>obs_a.data, <float32_t *>codes_a.data,
             ncodes, nfeat, nobs, <int32_t *>outcodes.data,
             <float32_t *>outdists.data)
-    elif obs.dtype == np.float64:
+    elif obs.dtype.type is np.float64:
         _vq(<float64_t *>obs_a.data, <float64_t *>codes_a.data,
             ncodes, nfeat, nobs, <int32_t *>outcodes.data,
             <float64_t *>outdists.data)
-    else:
-        raise ValueError('type other than float or double not supported')
 
     return outcodes, outdists
 

--- a/scipy/cluster/_vq.pyx
+++ b/scipy/cluster/_vq.pyx
@@ -175,8 +175,9 @@ def vq(np.ndarray obs, np.ndarray codes):
 
     Notes
     -----
-    The observation matrix and code book matrix should have same rank and
-    same number of columns (features). Only rank 1 and rank 2 are supported.
+    The observation matrix and code book matrix should have same ndim and
+    same number of columns (features). Only 1-dimensional and 2-dimensional
+    arrays are supported.
     """
     cdef int nobs, ncodes, nfeat
     cdef np.ndarray obs_a, codes_a
@@ -192,7 +193,8 @@ def vq(np.ndarray obs, np.ndarray codes):
     if obs.dtype not in (np.float32, np.float64):
         raise TypeError('type other than float or double not supported')
     if obs_a.ndim != codes_a.ndim:
-        raise ValueError('observation and code should have same rank')
+        raise ValueError(
+            'observation and code should have same number of dimensions')
 
     if obs_a.ndim == 1:
         nfeat = 1
@@ -206,7 +208,7 @@ def vq(np.ndarray obs, np.ndarray codes):
             raise ValueError('obs and code should have same number of '
                              'features (columns)')
     else:
-        raise ValueError('rank different than 1 or 2 are not supported')
+        raise ValueError('ndim different than 1 or 2 are not supported')
 
     # Initialize outdists and outcodes array.
     # Outdists should be initialized as INF.

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -107,9 +107,14 @@ class TestVq(TestCase):
 
     def test__vq_sametype(self):
         if TESTC:
-            a = np.array([1, 2])
-            b = a.astype(float)
-            assert_raises(ValueError, _vq.vq, a, b)
+            a = np.array([1.0, 2.0], dtype=np.float64)
+            b = a.astype(np.float32)
+            assert_raises(TypeError, _vq.vq, a, b)
+
+    def test__vq_invalid_type(self):
+        if TESTC:
+            a = np.array([1, 2], dtype=np.int)
+            assert_raises(TypeError, _vq.vq, a, a)
 
     def test_vq_large_nfeat(self):
         X = np.random.rand(20, 20)

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -133,6 +133,15 @@ class TestVq(TestCase):
         assert_allclose(dis0, dis1, 1e-5)
         assert_array_equal(codes0, codes1)
 
+    def test_vq_large_features(self):
+        X = np.random.rand(10, 5) * 1000000
+        code_book = np.random.rand(2, 5) * 1000000
+
+        codes0, dis0 = _vq.vq(X, code_book)
+        codes1, dis1 = py_vq(X, code_book)
+        assert_allclose(dis0, dis1, 1e-5)
+        assert_array_equal(codes0, codes1)
+
 
 class TestKMean(TestCase):
     def test_large_features(self):


### PR DESCRIPTION
`_vq.vq` should initialize `outdists` to INF but `ndarray.fill` seems to treat `NPY_INFINITY` as an int32 and initialize outdists to `2 ^ 31 - 1`, so that the result may be wrong when the features are large. Use `np.inf` to fill `outdists` would be safer.

`ndarray.fill(np.inf)` will fail with numpy 1.5 (only in Cython, no idea why), but `np.PyArray_FillWithScalar` will not. So use the latter instead.
