### PR TITLE
BUG: special: ellip(k,e)inc nan and double expected value

### DIFF
--- a/scipy/special/cephes/ellie.c
+++ b/scipy/special/cephes/ellie.c
@@ -61,7 +61,7 @@ double ellie(phi, m)
 double phi, m;
 {
     double a, b, c, e, temp;
-    double lphi, t, E;
+    double lphi, t, E, denom;
     int d, mod, npio2, sign;
 
     if (m == 0.0)
@@ -107,8 +107,15 @@ double phi, m;
     while (fabs(c / a) > MACHEP) {
 	temp = b / a;
 	lphi = lphi + atan(t * temp) + mod * NPY_PI;
-	mod = (lphi + NPY_PI_2) / NPY_PI;
-	t = t * (1.0 + temp) / (1.0 - temp * t * t);
+        denom = 1 - temp * t * t;
+        if (fabs(denom) > 10*MACHEP) {
+            t = t * (1.0 + temp) / denom;
+            mod = (lphi + NPY_PI_2) / NPY_PI;
+        }
+        else {
+            t = tan(lphi);
+            mod = (int)floor((lphi - atan(t))/NPY_PI);
+        }
 	c = (a - b) / 2.0;
 	temp = sqrt(a * b);
 	a = (a + b) / 2.0;

--- a/scipy/special/cephes/ellik.c
+++ b/scipy/special/cephes/ellik.c
@@ -60,7 +60,7 @@ extern double MACHEP;
 double ellik(phi, m)
 double phi, m;
 {
-    double a, b, c, e, temp, t, K;
+    double a, b, c, e, temp, t, K, denom;
     int d, mod, sign, npio2;
 
     if (m == 0.0)
@@ -110,8 +110,15 @@ double phi, m;
     while (fabs(c / a) > MACHEP) {
 	temp = b / a;
 	phi = phi + atan(t * temp) + mod * NPY_PI;
-	mod = (phi + NPY_PI_2) / NPY_PI;
-	t = t * (1.0 + temp) / (1.0 - temp * t * t);
+        denom = 1.0 - temp * t * t;
+        if (fabs(denom) > 10*MACHEP) {
+	    t = t * (1.0 + temp) / denom;
+            mod = (phi + NPY_PI_2) / NPY_PI;
+        }
+        else {
+            t = tan(phi);
+            mod = (int)floor((phi - atan(t))/NPY_PI);
+        }
 	c = (a - b) / 2.0;
 	temp = sqrt(a * b);
 	a = (a + b) / 2.0;

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -31,7 +31,7 @@ from numpy import array, isnan, r_, arange, finfo, pi, sin, cos, tan, exp, \
 from numpy.testing import assert_equal, assert_almost_equal, \
         assert_array_equal, assert_array_almost_equal, assert_approx_equal, \
         assert_, rand, dec, TestCase, run_module_suite, assert_allclose, \
-        assert_raises
+        assert_raises, assert_array_almost_equal_nulp
 
 from scipy import special
 import scipy.special._ufuncs as cephes
@@ -1247,6 +1247,22 @@ class TestEllip(TestCase):
         assert_almost_equal(elkinc,0.79398143,8)
         # From pg. 614 of A & S
 
+    def test_ellipkinc_2(self):
+        # Regression test for gh-3550
+        # ellipkinc(phi, mbad) was NaN and mvals[2:6] were twice the correct value
+        mbad = 0.68359375000000011
+        phi = 0.9272952180016123
+        m = np.nextafter(mbad, 0)
+        mvals = []
+        for j in range(10):
+            mvals.append(m)
+            m = np.nextafter(m, 1)
+        f = special.ellipkinc(phi, mvals)
+        assert_array_almost_equal_nulp(f, 1.0259330100195334 * np.ones_like(f), 1)
+        # this bug also appears at phi + n * pi for at least small n
+        f1 = special.ellipkinc(phi + pi, mvals)
+        assert_array_almost_equal_nulp(f1, 5.1296650500976675 * np.ones_like(f1), 2)
+
     def test_ellipe(self):
         ele = special.ellipe(.2)
         assert_almost_equal(ele,1.4890350580958529,8)
@@ -1260,6 +1276,22 @@ class TestEllip(TestCase):
         m = sin(alpha)**2
         eleinc = special.ellipeinc(phi,m)
         assert_almost_equal(eleinc, 0.58823065, 8)
+
+    def test_ellipeinc_2(self):
+        # Regression test for gh-3550
+        # ellipeinc(phi, mbad) was NaN and mvals[2:6] were twice the correct value
+        mbad = 0.68359375000000011
+        phi = 0.9272952180016123
+        m = np.nextafter(mbad, 0)
+        mvals = []
+        for j in range(10):
+            mvals.append(m)
+            m = np.nextafter(m, 1)
+        f = special.ellipeinc(phi, mvals)
+        assert_array_almost_equal_nulp(f, 0.84442884574781019 * np.ones_like(f), 2)
+        # this bug also appears at phi + n * pi for at least small n
+        f1 = special.ellipeinc(phi + pi, mvals)
+        assert_array_almost_equal_nulp(f1, 3.3471442287390509 * np.ones_like(f1), 4)
 
 
 class TestErf(TestCase):


### PR DESCRIPTION
Both ellipkinc and ellipeinc returned nan for a particular value
due to cancelation in a tangent update formula.  Double the
expected value was returned in a small region around the value
returning nan due to using a fragile argument reduction formula.

Fixes gh-3550

This does seem to slow the functions down some.

New

```
In [4]: m = np.abs(np.random.random(2e3))

In [5]: phi = (np.random.random(2e3)+1)*np.pi

In [6]: timeit s.ellipkinc(phi, m[:,None])
1 loops, best of 3: 3.24 s per loop

In [7]: timeit s.ellipeinc(phi, m[:,None])
1 loops, best of 3: 4.5 s per loop
```

Old (using the same `m` and `phi` as above)

```
In [8]: timeit s.ellipkinc(phi, m[:,None])
1 loops, best of 3: 2.34 s per loop

In [9]: timeit s.ellipeinc(phi, m[:,None])
1 loops, best of 3: 3.56 s per loop
```

But correct is better than fast. If anyone has a better replacement for the `mod` variable update in ellik.c and ellie.c, I'll happily change it.
