### PR TITLE
BUG: handle fill_value dtype checks correctly in RegularGridInterpolator

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -19,6 +19,7 @@ import warnings
 import functools
 import operator
 
+from scipy.lib._version import NumpyVersion
 from scipy.lib.six import xrange, integer_types
 
 from . import fitpack
@@ -28,6 +29,9 @@ from .polyint import _Interpolator1D
 from . import _ppoly
 from .fitpack2 import RectBivariateSpline
 from .interpnd import _ndim_coords_from_arrays
+
+
+NUMPY_LT_160 = NumpyVersion(np.__version__) < '1.6.0'
 
 
 def reduce_sometrue(a):
@@ -1507,9 +1511,13 @@ class RegularGridInterpolator(object):
         self.fill_value = fill_value
         if fill_value is not None:
             fill_value_dtype = np.asarray(fill_value).dtype
-            if hasattr(values, 'dtype') and not np.can_cast(fill_value_dtype, values.dtype):
-                raise ValueError("fill_value must be either 'None' or "
-                                 "of a type compatible with values")
+            if not NUMPY_LT_160:
+                if (hasattr(values,
+                            'dtype') and not np.can_cast(fill_value_dtype,
+                                                         values.dtype,
+                                                         casting='same_kind')):
+                    raise ValueError("fill_value must be either 'None' or "
+                                     "of a type compatible with values")
 
         for i, p in enumerate(points):
             if not np.all(np.diff(p) > 0.):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1445,8 +1445,17 @@ class TestRegularGridInterpolator(TestCase):
         RegularGridInterpolator((x, y), values, fill_value=1)
 
         # complex values cannot
-        assert_raises(ValueError, RegularGridInterpolator,
-                      (x, y), values, fill_value=1+2j)
+        if NumpyVersion(np.__version__) >= '1.6.0':
+            assert_raises(ValueError, RegularGridInterpolator,
+                          (x, y), values, fill_value=1+2j)
+
+    def test_fillvalue_type(self):
+        # from #3703; test that interpolator object construction succeeds
+        values = np.ones((10, 20, 30), dtype='>f4')
+        points = [np.arange(n) for n in values.shape]
+        xi = [(1, 1, 1)]
+        interpolator = RegularGridInterpolator(points, values)
+        interpolator = RegularGridInterpolator(points, values, fill_value=0.)
 
 
 class MyValue(object):


### PR DESCRIPTION
This fixes #3703 on my machine.

However, I tried to test this with numpy 1.5.1 (clean `virtualenv --no-site-packages`, `pip install numpy==1.5.1`, Scipy install), and I couldn't even import scipy.interpolate:

```
Python 2.7.5+ (default, Feb 27 2014, 19:37:08) 
[GCC 4.8.1] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import scipy.interpolate
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "scipy/interpolate/__init__.py", line 160, in <module>
    from .interpolate import *
  File "scipy/interpolate/interpolate.py", line 15, in <module>
    import scipy.special as spec
  File "scipy/special/__init__.py", line 558, in <module>
    from ._ufuncs import *
  File "numpy.pxd", line 155, in init scipy.special._ufuncs (scipy/special/_ufuncs.c:21825)
ValueError: numpy.dtype has the wrong size, try recompiling
```

Apparently I'm doing something wrong here ...  If somebody could test this PR with numpy < 1.6 or help me resolve this issue it would be great.
