### PR TITLE
Reraise exception on failure to read mat file.

### DIFF
--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -27,7 +27,7 @@ def _open_file(file_like, appendmat):
                 try:
                     return open(file_like, 'rb')
                 except IOError:
-                    pass # Rethrow the original exception.
+                    pass  # Rethrow the original exception.
             raise
     # not a string - maybe file-like object
     try:

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -24,8 +24,11 @@ def _open_file(file_like, appendmat):
         except IOError as e:
             if appendmat and not file_like.endswith('.mat'):
                 file_like += '.mat'
-                return open(file_like, 'rb')
-            raise IOError(e)
+                try:
+                    return open(file_like, 'rb')
+                except IOError:
+                    pass # Rethrow the original exception.
+            raise
     # not a string - maybe file-like object
     try:
         file_like.read(0)


### PR DESCRIPTION
When loadmat cannot even open the requested file, rethrow the exception
raised by (the first) open() (which could be FileNotFoundError or
PermissionError) rather than wrap it in OSError.

Fixes #3700.
