### PR TITLE
BUG: cast 'x' to correct dtype in KroghInterpolator._evaluate

### DIFF
--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -317,7 +317,7 @@ class KroghInterpolator(_Interpolator1DWithDerivatives):
         p = np.zeros((len(x), self.r), dtype=self.dtype)
         p += self.c[0,np.newaxis,:]
         for k in range(1, self.n):
-            w = x - self.xi[k-1]
+            w = np.asarray(x, dtype=self.dtype) - self.xi[k-1]
             pi = w*pi
             p += pi[:,np.newaxis] * self.c[k]
         return p


### PR DESCRIPTION
fixes #3669

as mentioned in the Issue, I still get unexpectedly large deviation for the rightmost point.  but the interpolating f has very large derivative at the right edge (-3.60800244e+11), so this might be expected.
