### PR TITLE
ENH: cluster: reimplement the update-step of K-means in Cython

### DIFF
--- a/scipy/cluster/_vq.pyx
+++ b/scipy/cluster/_vq.pyx
@@ -68,12 +68,33 @@ cdef inline void cal_M(int nobs, int ncodes, int nfeat, vq_type *obs,
 cdef void _vq(vq_type *obs, vq_type *code_book,
               int ncodes, int nfeat, int nobs,
               int32_t *codes, vq_type *low_dist):
+    """
+    The underlying function (template) of _vq.vq.
+
+    Parameters
+    ----------
+    obs : vq_type*
+        The pointer to the observation matrix.
+    code_book : vq_type*
+        The pointer to the code book matrix.
+    ncodes : int
+        The number of centroids (codes).
+    nfeat : int
+        The number of features of each observation.
+    nobs : int
+        The number of observations.
+    codes : vq_type*
+        The pointer to the new codes array.
+    low_dist : vq_type*
+        low_dist[i] is the Euclidean distance from obs[i] to the corresponding
+        centroid.
+    """
     # Naive algorithm is prefered when nfeat is small
     if nfeat < NFEATURES_CUTOFF:
         _vq_small_nf(obs, code_book, ncodes, nfeat, nobs, codes, low_dist)
         return
 
-    cdef int obs_index, code_index
+    cdef np.npy_intp i, j
     cdef vq_type *p_obs
     cdef vq_type *p_codes
     cdef vq_type dist_sqr
@@ -90,76 +111,76 @@ cdef void _vq(vq_type *obs, vq_type *code_book,
         M = np.ndarray((nobs, ncodes), np.float64)
 
     p_obs = obs
-    for obs_index in range(nobs):
+    for i in range(nobs):
         # obs_sqr[i] is the inner product of the i-th observation with itself
-        obs_sqr[obs_index] = vec_sqr(nfeat, p_obs)
+        obs_sqr[i] = vec_sqr(nfeat, p_obs)
         p_obs += nfeat
 
     p_codes = code_book
-    for code_index in range(ncodes):
+    for i in range(ncodes):
         # codes_sqr[i] is the inner product of the i-th code with itself
-        codes_sqr[code_index] = vec_sqr(nfeat, p_codes)
+        codes_sqr[i] = vec_sqr(nfeat, p_codes)
         p_codes += nfeat
 
     # M[i][j] is the inner product of the i-th obs and j-th code
     # M = obs * codes.T
     cal_M(nobs, ncodes, nfeat, obs, code_book, <vq_type *>M.data)
 
-    for obs_index in range(nobs):
-        for code_index in range(ncodes):
-            dist_sqr = (M[obs_index, code_index] +
-                    obs_sqr[obs_index] + codes_sqr[code_index])
-            if dist_sqr < low_dist[obs_index]:
-                codes[obs_index] = code_index
-                low_dist[obs_index] = dist_sqr
+    for i in range(nobs):
+        for j in range(ncodes):
+            dist_sqr = (M[i, j] +
+                    obs_sqr[i] + codes_sqr[j])
+            if dist_sqr < low_dist[i]:
+                codes[i] = j
+                low_dist[i] = dist_sqr
 
         # dist_sqr may be negative due to float point errors
-        if low_dist[obs_index] > 0:
-            low_dist[obs_index] = _sqrt(low_dist[obs_index])
+        if low_dist[i] > 0:
+            low_dist[i] = _sqrt(low_dist[i])
         else:
-            low_dist[obs_index] = 0
+            low_dist[i] = 0
 
 
 cdef void _vq_small_nf(vq_type *obs, vq_type *code_book,
                        int ncodes, int nfeat, int nobs,
                        int32_t *codes, vq_type *low_dist):
     """
-    Vector quantization for float32 using naive algorithm.
+    Vector quantization using naive algorithm.
     This is prefered when nfeat is small.
+    The parameters are the same as those of _vq.
     """
     # Temporary variables
     cdef vq_type dist_sqr, diff
-    cdef int32_t obs_index, code_index, feature
-    cdef int32_t offset = 0
+    cdef np.npy_intp i, j, k, obs_offset = 0, code_offset
 
     # Index and pointer to keep track of the current position in
     # both arrays so that we don't have to always do index * nfeat.
-    cdef int codebook_pos
     cdef vq_type *current_obs
+    cdef vq_type *current_code
 
-    for obs_index in range(nobs):
-        codebook_pos = 0
-        for code_index in range(ncodes):
+    for i in range(nobs):
+        code_offset = 0
+        current_obs = &(obs[obs_offset])
+
+        for j in range(ncodes):
             dist_sqr = 0
+            current_code = &(code_book[code_offset])
 
-            # Distance between code_book[code_index] and obs[obs_index]
-            for feature in range(nfeat):
-                # Use current_obs pointer and codebook_pos to minimize
-                # pointer arithmetic necessary (i.e. no multiplications)
-                current_obs = &(obs[offset])
-                diff = code_book[codebook_pos] - current_obs[feature]
+            # Distance between code_book[j] and obs[i]
+            for k in range(nfeat):
+                diff = current_code[k] - current_obs[k]
                 dist_sqr += diff * diff
-                codebook_pos += 1
+            code_offset += nfeat
 
             # Replace the code assignment and record distance if necessary
-            if dist_sqr < low_dist[obs_index]:
-                codes[obs_index] = code_index
-                low_dist[obs_index] = dist_sqr
+            if dist_sqr < low_dist[i]:
+                codes[i] = j
+                low_dist[i] = dist_sqr
 
-        low_dist[obs_index] = _sqrt(low_dist[obs_index])
+        low_dist[i] = _sqrt(low_dist[i])
 
         # Update the offset of the current observation
-        offset += nfeat
+        obs_offset += nfeat
 
 
 def vq(np.ndarray obs, np.ndarray codes):
@@ -180,31 +201,29 @@ def vq(np.ndarray obs, np.ndarray codes):
     arrays are supported.
     """
     cdef int nobs, ncodes, nfeat
-    cdef np.ndarray obs_a, codes_a
     cdef np.ndarray outcodes, outdists
-    cdef int flags = np.NPY_CONTIGUOUS | np.NPY_NOTSWAPPED | np.NPY_ALIGNED
 
-    # Ensure the arrays are contiguous - done in C to minimize overhead.
-    obs_a = np.PyArray_FROM_OF(obs, flags)
-    codes_a = np.PyArray_FROM_OF(codes, flags)
+    # Ensure the arrays are contiguous
+    obs = np.ascontiguousarray(obs)
+    codes = np.ascontiguousarray(codes)
 
     if obs.dtype != codes.dtype:
         raise TypeError('observation and code should have same dtype')
     if obs.dtype not in (np.float32, np.float64):
         raise TypeError('type other than float or double not supported')
-    if obs_a.ndim != codes_a.ndim:
+    if obs.ndim != codes.ndim:
         raise ValueError(
             'observation and code should have same number of dimensions')
 
-    if obs_a.ndim == 1:
+    if obs.ndim == 1:
         nfeat = 1
-        nobs = obs_a.shape[0]
-        ncodes = codes_a.shape[0]
-    elif obs_a.ndim == 2:
-        nfeat = obs_a.shape[1]
-        nobs = obs_a.shape[0]
-        ncodes = codes_a.shape[0]
-        if nfeat != codes_a.shape[1]:
+        nobs = obs.shape[0]
+        ncodes = codes.shape[0]
+    elif obs.ndim == 2:
+        nfeat = obs.shape[1]
+        nobs = obs.shape[0]
+        ncodes = codes.shape[0]
+        if nfeat != codes.shape[1]:
             raise ValueError('obs and code should have same number of '
                              'features (columns)')
     else:
@@ -217,45 +236,69 @@ def vq(np.ndarray obs, np.ndarray codes):
     outdists.fill(np.inf)
 
     if obs.dtype.type is np.float32:
-        _vq(<float32_t *>obs_a.data, <float32_t *>codes_a.data,
+        _vq(<float32_t *>obs.data, <float32_t *>codes.data,
             ncodes, nfeat, nobs, <int32_t *>outcodes.data,
             <float32_t *>outdists.data)
     elif obs.dtype.type is np.float64:
-        _vq(<float64_t *>obs_a.data, <float64_t *>codes_a.data,
+        _vq(<float64_t *>obs.data, <float64_t *>codes.data,
             ncodes, nfeat, nobs, <int32_t *>outcodes.data,
             <float64_t *>outdists.data)
 
     return outcodes, outdists
 
 
-cdef np.ndarray _update(vq_type *obs, int32_t *labels,
-                        vq_type *cb, int nobs, int nc, int nfeat):
-    cdef int obs_index, label_index, feat_index, cluster_size
+cdef np.ndarray _update_cluster_means(vq_type *obs, int32_t *labels,
+                                      vq_type *cb, int nobs, int nc, int nfeat):
+    """
+    The underlying function (template) of _vq.update_cluster_means.
+
+    Parameters
+    ----------
+    obs : vq_type*
+        The pointer to the observation matrix.
+    labels : int32_t*
+        The pointer to the array of the labels (codes) of the observations.
+    cb : vq_type*
+        The pointer to the new code book matrix.
+    nobs : int
+        The number of observations.
+    nc : int
+        The number of centroids (codes).
+    nfeat : int
+        The number of features of each observation.
+
+    Returns
+    -------
+    has_members : ndarray
+        A boolean array indicating which clusters have members.
+    """
+    cdef np.npy_intp i, j, cluster_size, label
     cdef vq_type *obs_p
     cdef vq_type *cb_p
     cdef np.ndarray[int, ndim=1] obs_count
 
-    # Calculate the sums of obs in each cluster
+    # Calculate the sums the numbers of obs in each cluster
     obs_count = np.zeros(nc, np.int32)
     obs_p = obs
-    for obs_index in range(nobs):
-        cb_p = cb + nfeat * labels[obs_index]
+    for i in range(nobs):
+        label = labels[i]
+        cb_p = cb + nfeat * label
 
-        for feat_index in range(nfeat):
-            cb_p[feat_index] += obs_p[feat_index]
+        for j in range(nfeat):
+            cb_p[j] += obs_p[j]
 
         # Count the obs in each cluster
-        obs_count[labels[obs_index]] += 1
+        obs_count[label] += 1
         obs_p += nfeat
 
     cb_p = cb
-    for label_index in range(nc):
-        cluster_size = obs_count[label_index]
+    for i in range(nc):
+        cluster_size = obs_count[i]
 
         if cluster_size > 0:
             # Calculate the centroid of each cluster
-            for feat_index in range(nfeat):
-                cb_p[feat_index] /= cluster_size
+            for j in range(nfeat):
+                cb_p[j] /= cluster_size
 
         cb_p += nfeat
 
@@ -263,7 +306,7 @@ cdef np.ndarray _update(vq_type *obs, int32_t *labels,
     return obs_count > 0
 
 
-def update(np.ndarray obs, np.ndarray labels, int nc):
+def update_cluster_means(np.ndarray obs, np.ndarray labels, int nc):
     """
     The update-step of K-means. Calculate the mean of observations in each
     cluster.
@@ -271,7 +314,8 @@ def update(np.ndarray obs, np.ndarray labels, int nc):
     Parameters
     ----------
     obs : ndarray
-        The observation matrix. Each row is an observation.
+        The observation matrix. Each row is an observation. Its dtype must be
+        float32 or float64.
     labels : ndarray
         The label of each observation. Must be an 1d array.
     nc : int
@@ -290,36 +334,39 @@ def update(np.ndarray obs, np.ndarray labels, int nc):
     in `has_members` will be `False`. The upper level function should decide
     how to deal with them.
     """
-    cdef np.ndarray _obs, _labels, has_members, cb
+    cdef np.ndarray has_members, cb
     cdef int nfeat
-    cdef int flags = np.NPY_CONTIGUOUS | np.NPY_NOTSWAPPED | np.NPY_ALIGNED
 
     # Ensure the arrays are contiguous
-    _obs = np.PyArray_FROM_OF(obs, flags)
-    _labels = np.PyArray_FROM_OF(labels, flags)
+    obs = np.ascontiguousarray(obs)
+    labels = np.ascontiguousarray(labels)
 
-    if _obs.dtype not in (np.float32, np.float64):
+    if obs.dtype not in (np.float32, np.float64):
         raise TypeError('type other than float or double not supported')
-    if _labels.dtype.type is not np.int32:
-        _labels = _labels.astype(np.int32)
-    if _labels.ndim != 1:
+    if labels.dtype.type is not np.int32:
+        labels = labels.astype(np.int32)
+    if labels.ndim != 1:
         raise ValueError('labels must be an 1d array')
 
-    if _obs.ndim == 1:
+    if obs.ndim == 1:
         nfeat = 1
-        cb = np.zeros(nc, dtype=_obs.dtype)
-    elif _obs.ndim == 2:
-        nfeat = _obs.shape[1]
-        cb = np.zeros((nc, nfeat), dtype=_obs.dtype)
+        cb = np.zeros(nc, dtype=obs.dtype)
+    elif obs.ndim == 2:
+        nfeat = obs.shape[1]
+        cb = np.zeros((nc, nfeat), dtype=obs.dtype)
     else:
         raise ValueError('ndim different than 1 or 2 are not supported')
 
-    if _obs.dtype.type is np.float32:
-        has_members = _update(<float32_t *>_obs.data, <int32_t *>_labels.data,
-                              <float32_t *>cb.data, _obs.shape[0], nc, nfeat)
-    elif _obs.dtype.type is np.float64:
-        has_members = _update(<float64_t *>_obs.data, <int32_t *>_labels.data,
-                              <float64_t *>cb.data, _obs.shape[0], nc, nfeat)
+    if obs.dtype.type is np.float32:
+        has_members = _update_cluster_means(<float32_t *>obs.data,
+                                            <int32_t *>labels.data,
+                                            <float32_t *>cb.data,
+                                            obs.shape[0], nc, nfeat)
+    elif obs.dtype.type is np.float64:
+        has_members = _update_cluster_means(<float64_t *>obs.data,
+                                            <int32_t *>labels.data,
+                                            <float64_t *>cb.data,
+                                            obs.shape[0], nc, nfeat)
 
     return cb, has_members
 

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -13,12 +13,7 @@ from numpy.testing import (assert_array_equal, assert_array_almost_equal,
 
 from scipy.cluster.vq import (kmeans, kmeans2, py_vq, py_vq2, vq, whiten,
     ClusterError)
-try:
-    from scipy.cluster import _vq
-    TESTC = True
-except ImportError:
-    print("== Error while importing _vq, not testing C imp of vq ==")
-    TESTC = False
+from scipy.cluster import _vq
 
 # Optional:
 # import modules that are located in the same directory as this file.
@@ -77,12 +72,9 @@ class TestVq(TestCase):
 
     def test_vq(self):
         initc = np.concatenate(([[X[0]], [X[1]], [X[2]]]))
-        if TESTC:
-            label1, dist = _vq.vq(X, initc)
-            assert_array_equal(label1, LABEL1)
-            tlabel1, tdist = vq(X, initc)
-        else:
-            print("== not testing C imp of vq ==")
+        label1, dist = _vq.vq(X, initc)
+        assert_array_equal(label1, LABEL1)
+        tlabel1, tdist = vq(X, initc)
 
     # def test_py_vq_1d(self):
     #     """Test special rank 1 vq algo, python implementation."""
@@ -97,24 +89,19 @@ class TestVq(TestCase):
         """Test special rank 1 vq algo, python implementation."""
         data = X[:, 0]
         initc = data[:3]
-        if TESTC:
-            a, b = _vq.vq(data, initc)
-            ta, tb = py_vq(data[:, np.newaxis], initc[:, np.newaxis])
-            assert_array_equal(a, ta)
-            assert_array_equal(b, tb)
-        else:
-            print("== not testing C imp of vq (rank 1) ==")
+        a, b = _vq.vq(data, initc)
+        ta, tb = py_vq(data[:, np.newaxis], initc[:, np.newaxis])
+        assert_array_equal(a, ta)
+        assert_array_equal(b, tb)
 
     def test__vq_sametype(self):
-        if TESTC:
-            a = np.array([1.0, 2.0], dtype=np.float64)
-            b = a.astype(np.float32)
-            assert_raises(TypeError, _vq.vq, a, b)
+        a = np.array([1.0, 2.0], dtype=np.float64)
+        b = a.astype(np.float32)
+        assert_raises(TypeError, _vq.vq, a, b)
 
     def test__vq_invalid_type(self):
-        if TESTC:
-            a = np.array([1, 2], dtype=np.int)
-            assert_raises(TypeError, _vq.vq, a, a)
+        a = np.array([1, 2], dtype=np.int)
+        assert_raises(TypeError, _vq.vq, a, a)
 
     def test_vq_large_nfeat(self):
         X = np.random.rand(20, 20)

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -402,7 +402,7 @@ def _kmeans(obs, guess, thresh=1e-5):
         avg_dist.append(mean(distort, axis=-1))
         # recalc code_book as centroids of associated obs
         if(diff > thresh):
-            code_book, has_members = _vq.update(obs, obs_code, nc)
+            code_book, has_members = _vq.update_cluster_means(obs, obs_code, nc)
             code_book = code_book.compress(has_members, axis=0)
         if len(avg_dist) > 1:
             diff = avg_dist[-2] - avg_dist[-1]
@@ -729,7 +729,7 @@ def _kmeans2(data, code, niter, nc, missing):
         # using the current code book
         label = vq(data, code)[0]
         # Update the code by computing centroids using the new code book
-        new_code, has_members = _vq.update(data, label, nc)
+        new_code, has_members = _vq.update_cluster_means(data, label, nc)
         if not has_members.all():
             missing()
             # Set the empty clusters to their previous positions

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -193,28 +193,24 @@ def vq(obs, code_book):
     (array([1, 1, 0],'i'), array([ 0.43588989,  0.73484692,  0.83066239]))
 
     """
-    try:
-        from . import _vq
-        ct = common_type(obs, code_book)
+    ct = common_type(obs, code_book)
 
-        # avoid copying when dtype is the same
-        # should be replaced with c_obs = astype(ct, copy=False)
-        # when we get to numpy 1.7.0
-        if obs.dtype != ct:
-            c_obs = obs.astype(ct)
-        else:
-            c_obs = obs
+    # avoid copying when dtype is the same
+    # should be replaced with c_obs = astype(ct, copy=False)
+    # when we get to numpy 1.7.0
+    if obs.dtype != ct:
+        c_obs = obs.astype(ct)
+    else:
+        c_obs = obs
 
-        if code_book.dtype != ct:
-            c_code_book = code_book.astype(ct)
-        else:
-            c_code_book = code_book
+    if code_book.dtype != ct:
+        c_code_book = code_book.astype(ct)
+    else:
+        c_code_book = code_book
 
-        if ct in (single, double):
-            results = _vq.vq(c_obs, c_code_book)
-        else:
-            results = py_vq(obs, code_book)
-    except ImportError:
+    if ct in (single, double):
+        results = _vq.vq(c_obs, c_code_book)
+    else:
         results = py_vq(obs, code_book)
     return results
 


### PR DESCRIPTION
The current implementation of update-step in `vq.kmeans` and `vq.kmeans2` is inefficient due to unnecessary copying and high cache-miss rate (I guess).

I calculate the sums of obs in each cluster first and then divide them by the numbers of obs. It should be more efficient. And the benchmark shows that the speedup seems to be significant for low dimensional data.

```
old:                        new:

30000 x 100, k = 10         30000 x 100, k = 10
--float64: 15504.6652ms     --float64: 12687.4250ms
--float32: 6647.2686ms      --float32: 5272.2000ms

10000 x 1, k = 3            10000 x 1, k = 3
--float64: 96.9102ms        --float64: 41.6186ms
--float32: 99.7274ms        --float32: 41.9904ms

100000 x 3, k = 4           100000 x 3, k = 4
--float64: 1396.6506ms      --float64: 529.0992ms
--float32: 1028.3450ms      --float32: 431.0248ms

10000 x 30, k = 10          10000 x 30, k = 10
--float64: 1164.1506ms      --float64: 752.1930ms
--float32: 992.7966ms       --float32: 658.1064ms

1000 x 3, k = 4             1000 x 3, k = 4
--float64: 30.8582ms        --float64: 9.8542ms
--float32: 31.3026ms        --float32: 12.4894ms
```
