### PR TITLE
FIX: Check type of lfiltic

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -903,7 +903,7 @@ def lfiltic(b, a, y, x=None):
     M = np.size(b) - 1
     K = max(M, N)
     y = asarray(y)
-    if y.dtype.kind == 'i':
+    if y.dtype.kind in 'bui':
         # ensure calculations are floating point
         y = y.astype(np.float64)
     zi = zeros(K, y.dtype)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -903,12 +903,12 @@ def lfiltic(b, a, y, x=None):
     M = np.size(b) - 1
     K = max(M, N)
     y = asarray(y)
-    # lfilter only supports these types:
-    if y.dtype.kind not in 'fcO':
-        raise TypeError('y must be float, complex, or object')
-    zi = zeros(K, y.dtype.char)
+    if y.dtype.kind == 'i':
+        # ensure calculations are floating point
+        y = y.astype(np.float64)
+    zi = zeros(K, y.dtype)
     if x is None:
-        x = zeros(M, y.dtype.char)
+        x = zeros(M, y.dtype)
     else:
         x = asarray(x)
         L = np.size(x)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -903,6 +903,9 @@ def lfiltic(b, a, y, x=None):
     M = np.size(b) - 1
     K = max(M, N)
     y = asarray(y)
+    # lfilter only supports these types:
+    if y.dtype.kind not in 'fcO':
+        raise TypeError('y must be float, complex, or object')
     zi = zeros(K, y.dtype.char)
     if x is None:
         x = zeros(M, y.dtype.char)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -599,7 +599,9 @@ class _TestLinearFilter(TestCase):
         a = np.ones(1).astype(self.dt)
         b = np.ones(1).astype(self.dt)
         # "y" sets the datatype of zi, so it truncates if int
-        self.assertRaises(TypeError, lfiltic, b, a, [1, 0])
+        zi = lfiltic(b, a, [1, 0])
+        zi_2 = lfiltic(b, a, [1., 0])
+        assert_array_equal(zi, zi_2)
 
 
 class TestLinearFilterFloat32(_TestLinearFilter):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -11,7 +11,7 @@ import scipy.signal as signal
 from scipy.signal import (
     correlate, convolve, convolve2d, fftconvolve,
     hilbert, hilbert2, lfilter, lfilter_zi, filtfilt, butter, tf2zpk,
-    invres, vectorstrength, signaltools)
+    invres, vectorstrength, signaltools, lfiltic)
 
 
 from numpy import array, arange
@@ -593,6 +593,13 @@ class _TestLinearFilter(TestCase):
         assert_array_almost_equal(y, x)
         self.assertTrue(zf.dtype == self.dt)
         self.assertTrue(zf.size == 0)
+
+    def test_bad_zi(self):
+        # Regression test for #3699: bad initial conditions
+        a = np.ones(1).astype(self.dt)
+        b = np.ones(1).astype(self.dt)
+        # "y" sets the datatype of zi, so it truncates if int
+        self.assertRaises(TypeError, lfiltic, b, a, [1, 0])
 
 
 class TestLinearFilterFloat32(_TestLinearFilter):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -594,13 +594,15 @@ class _TestLinearFilter(TestCase):
         self.assertTrue(zf.dtype == self.dt)
         self.assertTrue(zf.size == 0)
 
-    def test_bad_zi(self):
+    def test_lfiltic_bad_zi(self):
         # Regression test for #3699: bad initial conditions
         a = np.ones(1).astype(self.dt)
         b = np.ones(1).astype(self.dt)
         # "y" sets the datatype of zi, so it truncates if int
-        zi = lfiltic(b, a, [1, 0])
-        zi_2 = lfiltic(b, a, [1., 0])
+        zi = lfiltic(b, a, [1., 0])
+        zi_1 = lfiltic(b, a, [1, 0])
+        zi_2 = lfiltic(b, a, [True, False])
+        assert_array_equal(zi, zi_1)
         assert_array_equal(zi, zi_2)
 
 


### PR DESCRIPTION
Current `lfiltic` has a bug where the input `y` gets turned into an array, and the datatype of the result is used to set the datatype of `zi`. This is problematic when `y` is given as a set of integers, because then as `zi` gets accumulated from the product of `y` and `a`, the resulting value gets truncated to an integer. This is one possible way to solve that problem.

I wasn't sure where else `lfiltic` was tested (if at all, explicitly?), `git grep "lfiltic"` within `scipy/signal/` didn't turn up any instances within `tests/`, so hopefully the test I added is in an okay place.

Closes #3699.
