### PR TITLE
MAINT: fix eigs and eigsh error messages, fix a related possibly off-by-one validation issue, and add a test

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -48,8 +48,8 @@ import warnings
 from . import _arpack
 import numpy as np
 from scipy.sparse.linalg.interface import aslinearoperator, LinearOperator
-from scipy.sparse import eye, csc_matrix, csr_matrix, \
-    isspmatrix, isspmatrix_csr
+from scipy.sparse import (eye, csc_matrix, csr_matrix,
+        isspmatrix, isspmatrix_csr)
 from scipy.linalg import lu_factor, lu_solve
 from scipy.sparse.sputils import isdense
 from scipy.sparse.linalg import gmres, splu
@@ -499,8 +499,10 @@ class _SymmetricArpackParams(_ArpackParams):
         if which not in _SEUPD_WHICH:
             raise ValueError("which must be one of %s"
                              % ' '.join(_SEUPD_WHICH))
-        if k >= n:
-            raise ValueError("k must be less than ndim(A), k=%d" % k)
+        if not (1 <= k < n):
+            raise ValueError('symmetric arpack params require 1 <= k < n '
+                    'where k=%d is the requested number of eigenvalues '
+                    'and n=%d is the order of the square input matrix' % (k, n))
 
         _ArpackParams.__init__(self, n, k, tp, mode, sigma,
                                ncv, v0, maxiter, which, tol)
@@ -681,8 +683,12 @@ class _UnsymmetricArpackParams(_ArpackParams):
         if which not in _NEUPD_WHICH:
             raise ValueError("Parameter which must be one of %s"
                              % ' '.join(_NEUPD_WHICH))
-        if k >= n - 1:
-            raise ValueError("k must be less than ndim(A)-1, k=%d" % k)
+
+        # require k < n-1 ???
+        if not (1 <= k < n):
+            raise ValueError('unsymmetric arpack params require 1 <= k < n '
+                    'where k=%d is the requested number of eigenvalues '
+                    'and n=%d is the order of the square input matrix' % (k, n))
 
         _ArpackParams.__init__(self, n, k, tp, mode, sigma,
                                ncv, v0, maxiter, which, tol)
@@ -1205,9 +1211,10 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
                           'This may adversely affect ARPACK convergence')
     n = A.shape[0]
 
-    if k <= 0 or k >= n:
-        raise ValueError("k=%d must be between 1 and ndim(A)-1=%d"
-                         % (k, n - 1))
+    if not (1 <= k < n):
+        raise ValueError('the eigs function requires 1 <= k < n '
+                'where k=%d is the requested number of eigenvalues '
+                'and n=%d is the order of the square matrix A' % (k, n))
 
     if sigma is None:
         matvec = _aslinearoperator_with_dtype(A).matvec
@@ -1483,8 +1490,10 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
                           'This may adversely affect ARPACK convergence')
     n = A.shape[0]
 
-    if k <= 0 or k >= n:
-        raise ValueError("k must be between 1 and ndim(A)-1")
+    if not (1 <= k < n):
+        raise ValueError('the eigsh function requires 1 <= k < n '
+                'where k=%d is the requested number of eigenvalues '
+                'and n=%d is the order of the square matrix A' % (k, n))
 
     if sigma is None:
         A = _aslinearoperator_with_dtype(A)

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -641,18 +641,43 @@ def test_svd_v0():
 
 def test_n_k_validation():
     # check that combinations of k and n are accepted or rejected as expected
+    def _check_vals(w):
+        assert_allclose(w, 1)
     for n in 3, 4:
+        # none of these functions work for extreme k
         for t in float, complex:
-            A = np.ones((n, n), dtype=t)
-            for f in eigs, eigsh:
-                for k in 0, n:
-                    for ev in False, True:
-                        kwargs = dict(k=k, return_eigenvectors=ev)
-                        assert_raises(ValueError, f, A, **kwargs)
-                for k in range(1, n):
-                    w = np.absolute(f(A, k=1, return_eigenvectors=0))
-                    assert_allclose(np.sum(w), n)
-                    assert_allclose(np.max(w), n)
+            A = np.identity(n, dtype=t)
+            for k in 0, n, n+1:
+                for return_vectors in False, True:
+                    assert_raises(ValueError, svds,
+                            A, k=k, return_singular_vectors=return_vectors)
+                    assert_raises(ValueError, eigs,
+                            A, k=k, return_eigenvectors=return_vectors)
+                    assert_raises(ValueError, eigsh,
+                            A, k=k, return_eigenvectors=return_vectors)
+        # eigsh and svds work for k == n-1 and real dtype
+        A = np.identity(n, dtype=float)
+        assert_raises(ValueError, eigs, A, k=n-1)
+        w = eigsh(A, k=n-1, return_eigenvectors=False)
+        _check_vals(w)
+        w = svds(A, k=n-1, return_singular_vectors=False)
+        _check_vals(w)
+        # for complex dtype all of these sparse functions fail
+        # because they ultimately fall back to eigs which requires k < n-1
+        A = np.identity(n, dtype=complex)
+        assert_raises(ValueError, eigs, A, k=n-1)
+        assert_raises(ValueError, eigsh, A, k=n-1)
+        assert_raises(ValueError, svds, A, k=n-1)
+        # all of the functions work for intermediate k
+        for t in float, complex:
+            A = np.identity(n, dtype=t)
+            for k in range(1, n-1):
+                w = svds(A, k=k, return_singular_vectors=False)
+                _check_vals(w)
+                w = eigs(A, k=k, return_eigenvectors=False)
+                _check_vals(w)
+                w = eigsh(A, k=k, return_eigenvectors=False)
+                _check_vals(w)
 
 
 if __name__ == "__main__":

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -10,16 +10,16 @@ import warnings
 
 import numpy as np
 
-from numpy.testing import assert_allclose, \
-        assert_array_almost_equal_nulp, TestCase, run_module_suite, dec, \
-        assert_raises, verbose, assert_equal
+from numpy.testing import (assert_allclose,
+        assert_array_almost_equal_nulp, TestCase, run_module_suite, dec,
+        assert_raises, verbose, assert_equal)
 
 from numpy import array, finfo, argsort, dot, round, conj, random
 from scipy.linalg import eig, eigh
 from scipy.sparse import csc_matrix, csr_matrix, lil_matrix, isspmatrix
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
-from scipy.sparse.linalg.eigen.arpack import eigs, eigsh, svds, \
-     ArpackNoConvergence
+from scipy.sparse.linalg.eigen.arpack import (eigs, eigsh, svds,
+     ArpackNoConvergence)
 
 from scipy.linalg import svd, hilbert
 
@@ -637,6 +637,22 @@ def test_svd_v0():
     u2, s2, vh2 = svds(x, 1, v0=u[:,0])
 
     assert_allclose(s, s2, atol=np.sqrt(1e-15))
+
+
+def test_n_k_validation():
+    # check that combinations of k and n are accepted or rejected as expected
+    for n in 3, 4:
+        for t in float, complex:
+            A = np.ones((n, n), dtype=t)
+            for f in eigs, eigsh:
+                for k in 0, n:
+                    for ev in False, True:
+                        kwargs = dict(k=k, return_eigenvectors=ev)
+                        assert_raises(ValueError, f, A, **kwargs)
+                for k in range(1, n):
+                    w = np.absolute(f(A, k=1, return_eigenvectors=0))
+                    assert_allclose(np.sum(w), n)
+                    assert_allclose(np.max(w), n)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Should close https://github.com/scipy/scipy/issues/3714.

Note that in addition to tweaking error messages and adding a test, this PR also technically changes the API a bit.  The `eigs` function will no longer reject `k == n-1`, which I assume was an off-by-one error in the original code.  No test covered that case.
