### PR TITLE
ENH: Add second-order sections filtering

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -56,6 +56,10 @@ Filtering
 
    deconvolve    -- 1-d deconvolution using lfilter.
 
+   sosfilt       -- 1-dimensional IIR digital linear filtering using
+                 -- a second-order-sections filter representation.
+   sosfilt_zi    -- Compute an initial state zi for the sosfilt function that
+                 -- corresponds to the steady state of the step response.
    hilbert       -- Compute 1-D analytic signal, using the Hilbert transform.
    hilbert2      -- Compute 2-D analytic signal, using the Hilbert transform.
 

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -167,11 +167,15 @@ LTI Representations
    :toctree: generated/
 
    tf2zpk        -- transfer function to zero-pole-gain.
-   zpk2tf        -- zero-pole-gain to transfer function.
+   tf2sos        -- transfer function to second-order sections.
    tf2ss         -- transfer function to state-space.
-   ss2tf         -- state-pace to transfer function.
+   zpk2tf        -- zero-pole-gain to transfer function.
+   zpk2sos       -- zero-pole-gain to second-order sections.
    zpk2ss        -- zero-pole-gain to state-space.
+   ss2tf         -- state-pace to transfer function.
    ss2zpk        -- state-space to pole-zero-gain.
+   sos2zpk       -- second-order-sections to zero-pole-gain.
+   sos2tf        -- second-order-sections to transfer function.
    cont2discrete -- continuous-time to discrete-time LTI conversion.
 
 Waveforms

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -1077,7 +1077,8 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba'):
 
     Given passband and stopband frequencies and gains, construct an analog or
     digital IIR filter of minimum order for a given basic type.  Return the
-    output in numerator, denominator ('ba') or pole-zero ('zpk') form.
+    output in numerator, denominator ('ba'), pole-zero ('zpk') or second order
+    sections ('sos') form.
 
     Parameters
     ----------

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -252,11 +252,11 @@ def cplxreal(z, tol=None):
     """
     Split into complex and real parts, combining conjugate pairs.
 
-    The 1D input vector z is split up into its complex (`zc`) and real (`zr`)
+    The 1D input vector `z` is split up into its complex (`zc`) and real (`zr`)
     elements.  Every complex element must be part of a complex-conjugate pair,
     which are combined into a single number (with positive imaginary part) in
     the output.  Two complex numbers are considered a conjugate pair if their
-    real and imaginary parts differ in magnitude by less than `tol * abs(z)`.
+    real and imaginary parts differ in magnitude by less than ``tol * abs(z)``.
 
     Parameters
     ----------
@@ -264,7 +264,8 @@ def cplxreal(z, tol=None):
         Vector of complex numbers to be sorted and split
     tol : float, optional
         Relative tolerance for testing realness and conjugate equality.
-        Default is 100 * spacing(1) of z's data type (i.e. 2e-14 for float64)
+        Default is ``100 * spacing(1)`` of `z`'s data type (i.e. 2e-14 for
+        float64)
 
     Returns
     -------
@@ -307,7 +308,7 @@ def cplxreal(z, tol=None):
         # Get tolerance from dtype of input
         tol = 100 * np.finfo((1.0 * z).dtype).eps
 
-    # Sort by real part, magnitude of imaginary part
+    # Sort by real part, magnitude of imaginary part (speed up further sorting)
     z = z[np.lexsort((abs(z.imag), z.real))]
 
     # Split reals from conjugate pairs
@@ -353,18 +354,16 @@ def cplxreal(z, tol=None):
 
 def cplxpair(z, tol=None):
     """
-    Sort ``z`` into pairs of complex conjugates.
+    Sort into pairs of complex conjugates.
 
-    Currently this is for 1D arrays only.
-
-    Complex conjugates are sorted by increasing real part.  In each pair, the
-    number with negative imaginary part appears first.
+    Complex conjugates in `z` are sorted by increasing real part.  In each
+    pair, the number with negative imaginary part appears first.
 
     If pairs have identical real parts, they are sorted by increasing
     imaginary magnitude.
 
     Two complex numbers are considered a conjugate pair if their real and
-    imaginary parts differ in magnitude by less than `tol * abs(z)`.  The
+    imaginary parts differ in magnitude by less than ``tol * abs(z)``.  The
     pairs are forced to be exact complex conjugates by averaging the positive
     and negative values.
 
@@ -378,7 +377,8 @@ def cplxpair(z, tol=None):
         1-dimensional input array to be sorted.
     tol : float, optional
         Relative tolerance for testing realness and conjugate equality.
-        Default is 100 * spacing(1) of z's data type (i.e. 2e-14 for float64)
+        Default is ``100 * spacing(1)`` of z's data type (i.e. 2e-14 for
+        float64)
 
     Returns
     -------
@@ -388,12 +388,20 @@ def cplxpair(z, tol=None):
     Raises
     ------
     ValueError
-        If there are any complex numbers in ``z`` for which a conjugate
+        If there are any complex numbers in `z` for which a conjugate
         cannot be found.
 
     See Also
     --------
     cplxreal: Splits the real and complex pair components of the input.
+
+    Examples
+    --------
+    >>> a = [4, 3, 1, 2-2j, 2+2j, 2-1j, 2+1j, 2-1j, 2+1j, 1+1j, 1-1j]
+    >>> z = cplxpair(a)
+    >>> print z
+    [ 1.-1.j  1.+1.j  2.-1.j  2.+1.j  2.-1.j  2.+1.j  2.-2.j  2.+2.j  1.+0.j
+      3.+0.j  4.+0.j]
     """
 
     z = atleast_1d(z)
@@ -401,7 +409,7 @@ def cplxpair(z, tol=None):
         return np.sort(z)
 
     if z.ndim != 1:
-        raise ValueError('z must be 1D')
+        raise ValueError('z must be 1-dimensional')
 
     zc, zr = cplxreal(z, tol)
 
@@ -413,15 +421,15 @@ def cplxpair(z, tol=None):
 
 
 def tf2zpk(b, a):
-    r"""Return zero, pole, gain (z,p,k) representation from a numerator,
+    r"""Return zero, pole, gain (z, p, k) representation from a numerator,
     denominator representation of a linear filter.
 
     Parameters
     ----------
-    b : ndarray
-        Numerator polynomial.
-    a : ndarray
-        Denominator polynomial.
+    b : array_like
+        Numerator polynomial coefficients.
+    a : array_like
+        Denominator polynomial coefficients.
 
     Returns
     -------
@@ -484,14 +492,14 @@ def tf2zpk(b, a):
 
 
 def zpk2tf(z, p, k):
-    """Return polynomial transfer function representation from zeros
-    and poles
+    """
+    Return polynomial transfer function representation from zeros and poles
 
     Parameters
     ----------
-    z : ndarray
+    z : array_like
         Zeros of the transfer function.
-    p : ndarray
+    p : array_like
         Poles of the transfer function.
     k : float
         System gain.
@@ -499,9 +507,9 @@ def zpk2tf(z, p, k):
     Returns
     -------
     b : ndarray
-        Numerator polynomial.
+        Numerator polynomial coefficients.
     a : ndarray
-        Denominator polynomial.
+        Denominator polynomial coefficients.
 
     """
     z = atleast_1d(z)
@@ -549,14 +557,15 @@ def tf2sos(b, a):
     Parameters
     ----------
     b : array_like
-        Numerator polynomial.
+        Numerator polynomial coefficients.
     a : array_like
-        Denominator polynomial.
+        Denominator polynomial coefficients.
 
     Returns
     -------
-    sos : array_like
-        Array of second-order filter coefficients, shape ``(n_sections, 6)``.
+    sos : ndarray
+        Array of second-order filter coefficients, with shape
+        ``(n_sections, 6)``.
     """
     return zpk2sos(*tf2zpk(b, a))
 
@@ -574,9 +583,9 @@ def sos2tf(sos):
     Returns
     -------
     b : ndarray
-        Numerator polynomial.
+        Numerator polynomial coefficients.
     a : ndarray
-        Denominator polynomial.
+        Denominator polynomial coefficients.
 
     """
     sos = np.asarray(sos)
@@ -636,8 +645,8 @@ def zpk2sos(z, p, k):
 
     Returns
     -------
-    sos : array_like
-        Array of second-order filter coefficients, must have shape
+    sos : ndarray
+        Array of second-order filter coefficients, with shape
         ``(n_sections, 6)``.
     """
     # make copies

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -561,7 +561,8 @@ def tf2sos(b, a, pairing='simple'):
     a : array_like
         Denominator polynomial coefficients.
     pairing : {'simple', 'keep_odd'}
-        The pairing method to use. See `zpk2sos`.
+        The method to use to combine pairs of poles and zeros into sections.
+        See `zpk2sos`.
 
     Returns
     -------
@@ -569,6 +570,10 @@ def tf2sos(b, a, pairing='simple'):
         Array of second-order filter coefficients, with shape
         ``(n_sections, 6)``. See `sosfilt` for the SOS filter format
         specification.
+
+    See Also
+    --------
+    zpk2sos, sosfilt
 
     Notes
     -----
@@ -579,10 +584,6 @@ def tf2sos(b, a, pairing='simple'):
     ZPK to SOS.
 
     .. versionadded:: 0.16.0
-
-    See Also
-    --------
-    zpk2sos, sosfilt
     """
     return zpk2sos(*tf2zpk(b, a), pairing=pairing)
 
@@ -679,7 +680,8 @@ def zpk2sos(z, p, k, pairing='simple'):
     k : float
         System gain.
     pairing : {'simple', 'keep_odd'}
-        The pairing method to use. See Notes below.
+        The method to use to combine pairs of poles and zeros into sections.
+        See Notes below.
 
     Returns
     -------
@@ -687,6 +689,10 @@ def zpk2sos(z, p, k, pairing='simple'):
         Array of second-order filter coefficients, with shape
         ``(n_sections, 6)``. See `sosfilt` for the SOS filter format
         specification.
+
+    See Also
+    --------
+    sosfilt
 
     Notes
     -----
@@ -696,14 +702,6 @@ def zpk2sos(z, p, k, pairing='simple'):
     section. This is done by pairing poles with the nearest zeros, starting
     with the poles closest to the unit circle.
 
-    .. versionadded:: 0.16.0
-
-    See Also
-    --------
-    sosfilt
-
-    Notes
-    -----
     *Algorithms*
 
     The current algorithms are designed specifically for use with digital
@@ -711,7 +709,10 @@ def zpk2sos(z, p, k, pairing='simple'):
     be sub-optimal.
 
     The steps in the ``pairing='simple'`` and ``pairing='keep_odd'``
-    algorithms are mostly shared, and are as follows:
+    algorithms are mostly shared. The ``simple`` algorithm attempts to
+    minimize the peak gain, while ``'keep_odd'`` minimizes peak gain under
+    the constraint that odd-order systems should retain one section
+    as first order. The algorithm steps and are as follows:
 
     As a pre-processing step, add poles or zeros to the origin as
     necessary to obtain the same number of poles and zeros for pairing.
@@ -719,7 +720,7 @@ def zpk2sos(z, p, k, pairing='simple'):
     add an additional pole and a zero at the origin. Note that with
     ``pairing == 'simple'``, we are guaranteed there are even numbers
     of real poles, complex poles, real zeros, and real poles to pair.
-    With `pairing == 'keep_odd'` we do not have this guarantee.
+    With ``pairing == 'keep_odd'`` we do not have this guarantee.
 
     These following steps are then iterated over until no more poles or
     zeros remain:
@@ -760,9 +761,10 @@ def zpk2sos(z, p, k, pairing='simple'):
                real pole closest to the unit circle, and then add the real
                zero closest to that pole.
 
-    .. [#] = This conditional can only be met for specific odd-order inputs
-             with the `pairing == 'keep_odd'` method.
+    .. [#] This conditional can only be met for specific odd-order inputs
+           with the ``pairing == 'keep_odd'`` method.
 
+    .. versionadded:: 0.16.0
     """
     # TODO in the near future:
     # 1. Add SOS capability to `filtfilt`, `freqz`, etc. somehow (#3259).
@@ -1124,10 +1126,6 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba'):
         Second-order sections representation of the IIR filter.
         Only returned if ``output=='sos'``.
 
-    Notes
-    -----
-    The ``'sos'`` output parameter was added in 0.15.0.
-
     See Also
     --------
     butter : Filter design using order and critical points
@@ -1135,6 +1133,10 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba'):
     buttord : Find order and critical points from passband and stopband spec
     cheb1ord, cheb2ord, ellipord
     iirfilter : General filter design using order and critical frequencies
+
+    Notes
+    -----
+    The ``'sos'`` output parameter was added in 0.16.0.
     """
     try:
         ordfunc = filter_dict[ftype][1]
@@ -1165,8 +1167,7 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     IIR digital and analog filter design given order and critical points.
 
     Design an Nth order digital or analog filter and return the filter
-    coefficients in (B,A) (numerator, denominator), (Z,P,K), or (SOS)
-    (second-order sections) form.
+    coefficients.
 
     Parameters
     ----------
@@ -1214,10 +1215,6 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
         Second-order sections representation of the IIR filter.
         Only returned if ``output=='sos'``.
 
-    Notes
-    -----
-    The ``'sos'`` output parameter was added in 0.15.0.
-
     See Also
     --------
     butter : Filter design using order and critical points
@@ -1225,6 +1222,10 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     buttord : Find order and critical points from passband and stopband spec
     cheb1ord, cheb2ord, ellipord
     iirdesign : General filter design using passband and stopband spec
+
+    Notes
+    -----
+    The ``'sos'`` output parameter was added in 0.16.0.
 
     Examples
     --------
@@ -1662,7 +1663,7 @@ def butter(N, Wn, btype='low', analog=False, output='ba'):
     Butterworth digital and analog filter design.
 
     Design an Nth order digital or analog Butterworth filter and return
-    the filter coefficients in (B,A) or (Z,P,K) form.
+    the filter coefficients.
 
     Parameters
     ----------
@@ -1697,10 +1698,6 @@ def butter(N, Wn, btype='low', analog=False, output='ba'):
         Second-order sections representation of the IIR filter.
         Only returned if ``output=='sos'``.
 
-    Notes
-    -----
-    The ``'sos'`` output parameter was added in 0.15.0.
-
     See Also
     --------
     buttord
@@ -1709,6 +1706,8 @@ def butter(N, Wn, btype='low', analog=False, output='ba'):
     -----
     The Butterworth filter has maximally flat frequency response in the
     passband.
+
+    The ``'sos'`` output parameter was added in 0.16.0.
 
     Examples
     --------
@@ -1738,7 +1737,7 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba'):
     Chebyshev type I digital and analog filter design.
 
     Design an Nth order digital or analog Chebyshev type I filter and
-    return the filter coefficients in (B,A) or (Z,P,K) form.
+    return the filter coefficients.
 
     Parameters
     ----------
@@ -1776,10 +1775,6 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba'):
         Second-order sections representation of the IIR filter.
         Only returned if ``output=='sos'``.
 
-    Notes
-    -----
-    The ``'sos'`` output parameter was added in 0.15.0.
-
     See Also
     --------
     cheb1ord
@@ -1796,6 +1791,8 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba'):
     The equiripple passband has N maxima or minima (for example, a
     5th-order filter has 3 maxima and 2 minima).  Consequently, the DC gain is
     unity for odd-order filters, or -rp dB for even-order filters.
+
+    The ``'sos'`` output parameter was added in 0.16.0.
 
     Examples
     --------
@@ -1826,7 +1823,7 @@ def cheby2(N, rs, Wn, btype='low', analog=False, output='ba'):
     Chebyshev type II digital and analog filter design.
 
     Design an Nth order digital or analog Chebyshev type II filter and
-    return the filter coefficients in (B,A) or (Z,P,K) form.
+    return the filter coefficients.
 
     Parameters
     ----------
@@ -1864,10 +1861,6 @@ def cheby2(N, rs, Wn, btype='low', analog=False, output='ba'):
         Second-order sections representation of the IIR filter.
         Only returned if ``output=='sos'``.
 
-    Notes
-    -----
-    The ``'sos'`` output parameter was added in 0.15.0.
-
     See Also
     --------
     cheb2ord
@@ -1879,6 +1872,8 @@ def cheby2(N, rs, Wn, btype='low', analog=False, output='ba'):
     the stopband and increased ringing in the step response.
 
     Type II filters do not roll off as fast as Type I (`cheby1`).
+
+    The ``'sos'`` output parameter was added in 0.16.0.
 
     Examples
     --------
@@ -1909,7 +1904,7 @@ def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba'):
     Elliptic (Cauer) digital and analog filter design.
 
     Design an Nth order digital or analog elliptic filter and return
-    the filter coefficients in (B,A) or (Z,P,K) form.
+    the filter coefficients.
 
     Parameters
     ----------
@@ -1950,10 +1945,6 @@ def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba'):
         Second-order sections representation of the IIR filter.
         Only returned if ``output=='sos'``.
 
-    Notes
-    -----
-    The ``'sos'`` output parameter was added in 0.15.0.
-
     See Also
     --------
     ellipord
@@ -1973,6 +1964,8 @@ def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba'):
     The equiripple passband has N maxima or minima (for example, a
     5th-order filter has 3 maxima and 2 minima).  Consequently, the DC gain is
     unity for odd-order filters, or -rp dB for even-order filters.
+
+    The ``'sos'`` output parameter was added in 0.16.0.
 
     Examples
     --------
@@ -2003,7 +1996,7 @@ def bessel(N, Wn, btype='low', analog=False, output='ba'):
     """Bessel/Thomson digital and analog filter design.
 
     Design an Nth order digital or analog Bessel filter and return the
-    filter coefficients in (B,A) or (Z,P,K) form.
+    filter coefficients.
 
     Parameters
     ----------
@@ -2041,10 +2034,6 @@ def bessel(N, Wn, btype='low', analog=False, output='ba'):
 
     Notes
     -----
-    The ``'sos'`` output parameter was added in 0.15.0.
-
-    Notes
-    -----
     Also known as a Thomson filter, the analog Bessel filter has maximally
     flat group delay and maximally linear phase response, with very little
     ringing in the step response.
@@ -2060,6 +2049,8 @@ def bessel(N, Wn, btype='low', analog=False, output='ba'):
 
     For a given `Wn`, the lowpass and highpass filter have the same phase vs
     frequency curves; they are "phase-matched".
+
+    The ``'sos'`` output parameter was added in 0.16.0.
 
     Examples
     --------

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -550,7 +550,7 @@ def zpk2tf(z, p, k):
     return b, a
 
 
-def tf2sos(b, a, pairing='simple'):
+def tf2sos(b, a, pairing='nearest'):
     """
     Return second-order sections from transfer function representation
 
@@ -560,7 +560,7 @@ def tf2sos(b, a, pairing='simple'):
         Numerator polynomial coefficients.
     a : array_like
         Denominator polynomial coefficients.
-    pairing : {'simple', 'keep_odd'}
+    pairing : {'nearest', 'keep_odd'}
         The method to use to combine pairs of poles and zeros into sections.
         See `zpk2sos`.
 
@@ -667,7 +667,7 @@ def _nearest_real_complex_idx(fro, to, which):
     return order[np.where(mask)[0][0]]
 
 
-def zpk2sos(z, p, k, pairing='simple'):
+def zpk2sos(z, p, k, pairing='nearest'):
     """
     Return second-order sections from zeros, poles, and gain of a system
 
@@ -679,7 +679,7 @@ def zpk2sos(z, p, k, pairing='simple'):
         Poles of the transfer function.
     k : float
         System gain.
-    pairing : {'simple', 'keep_odd'}
+    pairing : {'nearest', 'keep_odd'}
         The method to use to combine pairs of poles and zeros into sections.
         See Notes below.
 
@@ -708,21 +708,18 @@ def zpk2sos(z, p, k, pairing='simple'):
     filters. Although they can operate on analog filters, the results may
     be sub-optimal.
 
-    The steps in the ``pairing='simple'`` and ``pairing='keep_odd'``
-    algorithms are mostly shared. The ``simple`` algorithm attempts to
+    The steps in the ``pairing='nearest'`` and ``pairing='keep_odd'``
+    algorithms are mostly shared. The ``nearest`` algorithm attempts to
     minimize the peak gain, while ``'keep_odd'`` minimizes peak gain under
     the constraint that odd-order systems should retain one section
     as first order. The algorithm steps and are as follows:
 
     As a pre-processing step, add poles or zeros to the origin as
     necessary to obtain the same number of poles and zeros for pairing.
-    If ``pairing == 'simple'`` and there are an odd number of poles,
-    add an additional pole and a zero at the origin. Note that with
-    ``pairing == 'simple'``, we are guaranteed there are even numbers
-    of real poles, complex poles, real zeros, and real poles to pair.
-    With ``pairing == 'keep_odd'`` we do not have this guarantee.
+    If ``pairing == 'nearest'`` and there are an odd number of poles,
+    add an additional pole and a zero at the origin.
 
-    These following steps are then iterated over until no more poles or
+    The following steps are then iterated over until no more poles or
     zeros remain:
 
     1. Take the (next remaining) pole (complex or real) closest to the
@@ -774,7 +771,7 @@ def zpk2sos(z, p, k, pairing='simple'):
     # 4. Further optimizations of the section ordering / pole-zero pairing.
     # See the wiki for other potential issues.
 
-    valid_pairings = ['simple', 'keep_odd']
+    valid_pairings = ['nearest', 'keep_odd']
     if pairing not in valid_pairings:
         raise ValueError('pairing must be one of %s, not %s'
                          % (valid_pairings, pairing))
@@ -787,7 +784,7 @@ def zpk2sos(z, p, k, pairing='simple'):
     n_sections = (max(len(p), len(z)) + 1) // 2
     sos = zeros((n_sections, 6))
 
-    if len(p) % 2 == 1 and pairing == 'simple':
+    if len(p) % 2 == 1 and pairing == 'nearest':
         p = np.concatenate((p, [0.]))
         z = np.concatenate((z, [0.]))
     assert len(p) == len(z)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2381,6 +2381,10 @@ def sosfilt(sos, x, axis=-1, zi=None):
         If `zi` is None, this is not returned, otherwise, `zf` holds the
         final filter delay values.
 
+    See Also
+    --------
+    zpk2sos, sos2zpk, sosfilt_zi
+
     Notes
     -----
     The filter function is implemented as a series of second-order filters
@@ -2391,23 +2395,24 @@ def sosfilt(sos, x, axis=-1, zi=None):
 
     Examples
     --------
-    Plot a 6th-order filter's impulse response using both `lfilter` and
+    Plot a 13th-order filter's impulse response using both `lfilter` and
     `sosfilt`, showing the instability that results from trying to do a
-    6th-order filter in a single stage (the numerical error pushes some poles
+    13th-order filter in a single stage (the numerical error pushes some poles
     outside of the unit circle):
 
-    >>> b, a = butter(6, [0.10, 0.105], 'band', output='ba')
-    >>> sos = butter(6, [0.10, 0.105], 'band', output='sos')
-    >>> x = zeros(1500)
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy import signal
+    >>> b, a = signal.ellip(13, 0.009, 80, 0.05, output='ba')
+    >>> sos = signal.ellip(13, 0.009, 80, 0.05, output='sos')
+    >>> x = np.zeros(700)
     >>> x[0] = 1.
-    >>> y_tf = lfilter(b, a, x)
-    >>> y_sos = sosfilt(sos, x)
-    >>> plot(y_tf, 'r')
-    >>> plot(y_sos, 'k')
+    >>> y_tf = signal.lfilter(b, a, x)
+    >>> y_sos = signal.sosfilt(sos, x)
+    >>> plt.plot(y_tf, 'r', label='TF')
+    >>> plt.plot(y_sos, 'k', label='SOS')
+    >>> plt.legend(loc='best')
+    >>> plt.show()
 
-    See also
-    --------
-    zpk2sos, sos2zpk, sosfilt_zi
     """
 
     sos = atleast_2d(sos)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1899,13 +1899,22 @@ def sosfilt_zi(sos):
     ----------
     sos : array_like
         Array of second-order filter coefficients, must have shape
-        ``(n_sections, 6)``.
+        ``(n_sections, 6)``. See `sosfilt` for the SOS filter format
+        specification.
 
     Returns
     -------
     zi : ndarray
         Initial conditions suitable for use with ``sosfilt``, shape
         ``(n_sections, 2)``.
+
+    Notes
+    -----
+    .. versionadded:: 0.15.0
+
+    See also
+    --------
+    sosfilt, zpk2sos
     """
     sos = np.asarray(sos)
     if sos.ndim != 2 or sos.shape[1] != 6:
@@ -2327,7 +2336,7 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
 
 def sosfilt(sos, x, axis=-1, zi=None):
     """
-    Filter data along one-dimension using cascaded second-order sections
+    Filter data along one dimension using cascaded second-order sections
 
     Filter a data sequence, `x`, using a digital IIR filter defined by
     `sos`. This is implemented by performing `lfilter` for each
@@ -2337,7 +2346,10 @@ def sosfilt(sos, x, axis=-1, zi=None):
     ----------
     sos : array_like
         Array of second-order filter coefficients, must have shape
-        ``(n_sections, 6)``.
+        ``(n_sections, 6)``. Each row corresponds to a second-order
+        section, with the first three columns providing the numerator
+        coefficients and the last three providing the denominator
+        coefficients.
     x : array_like
         An N-dimensional input array.
     axis : int
@@ -2366,6 +2378,8 @@ def sosfilt(sos, x, axis=-1, zi=None):
     with direct-form II transposed structure. It is designed to minimize
     numerical precision errors for high-order filters.
 
+    .. versionadded:: 0.15.0
+
     Examples
     --------
     Plot a 6th-order filter's impulse response using both `lfilter` and
@@ -2384,7 +2398,7 @@ def sosfilt(sos, x, axis=-1, zi=None):
 
     See also
     --------
-    zpk2sos, sos2zpk
+    zpk2sos, sos2zpk, sosfilt_zi
     """
 
     sos = atleast_2d(sos)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2330,7 +2330,7 @@ def sosfilt(sos, x, axis=-1, zi=None):
     Filter data along one-dimension using cascaded second-order sections
 
     Filter a data sequence, `x`, using a digital IIR filter defined by
-    ``sos``. This is implemented by performing `lfilter` for each
+    `sos`. This is implemented by performing `lfilter` for each
     second-order section.  See `lfilter` for details.
 
     Parameters
@@ -2350,13 +2350,13 @@ def sosfilt(sos, x, axis=-1, zi=None):
         equal to those of the input shape (without the filtered axis).
         If `zi` is None or is not given then initial rest is assumed. Note
         that these initial conditions are *not* the same as the initial
-        conditions given by ``lfiltic``.
+        conditions given by `lfiltic` or `lfilter_zi`.
 
     Returns
     -------
-    y : array
+    y : ndarray
         The output of the digital filter.
-    zf : array, optional
+    zf : ndarray, optional
         If `zi` is None, this is not returned, otherwise, `zf` holds the
         final filter delay values.
 
@@ -2368,8 +2368,12 @@ def sosfilt(sos, x, axis=-1, zi=None):
 
     Examples
     --------
+    Plot a 6th-order filter's impulse response using both `lfilter` and
+    `sosfilt`, showing the instability that results from trying to do a
+    6th-order filter in a single stage (the numerical error pushes some poles
+    outside of the unit circle):
 
-    >>> [b, a] = butter(6, [0.10, 0.105], 'band', output='ba')
+    >>> b, a = butter(6, [0.10, 0.105], 'band', output='ba')
     >>> sos = butter(6, [0.10, 0.105], 'band', output='sos')
     >>> x = zeros(1500)
     >>> x[0] = 1.

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1919,10 +1919,19 @@ def sosfilt_zi(sos):
     sos = np.asarray(sos)
     if sos.ndim != 2 or sos.shape[1] != 6:
         raise ValueError('sos must be shape (n_sections, 6)')
+
     n_sections = sos.shape[0]
     zi = np.empty((n_sections, 2))
+    scale = 1.0
     for section in range(n_sections):
-        zi[section] = lfilter_zi(sos[section, :3], sos[section, 3:])
+        b = sos[section, :3]
+        a = sos[section, 3:]
+        zi[section] = scale * lfilter_zi(b, a)
+        # If H(z) = B(z)/A(z) is this section's transfer function, then
+        # b.sum()/a.sum() is H(1), the gain at omega=0.  That's the steady
+        # state value of this section's step response.
+        scale *= b.sum() / a.sum()
+
     return zi
 
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1908,13 +1908,14 @@ def sosfilt_zi(sos):
         Initial conditions suitable for use with ``sosfilt``, shape
         ``(n_sections, 2)``.
 
+    See Also
+    --------
+    sosfilt, zpk2sos
+
     Notes
     -----
     .. versionadded:: 0.16.0
 
-    See also
-    --------
-    sosfilt, zpk2sos
     """
     sos = np.asarray(sos)
     if sos.ndim != 2 or sos.shape[1] != 6:

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1910,7 +1910,7 @@ def sosfilt_zi(sos):
 
     Notes
     -----
-    .. versionadded:: 0.15.0
+    .. versionadded:: 0.16.0
 
     See also
     --------
@@ -2387,7 +2387,7 @@ def sosfilt(sos, x, axis=-1, zi=None):
     with direct-form II transposed structure. It is designed to minimize
     numerical precision errors for high-order filters.
 
-    .. versionadded:: 0.15.0
+    .. versionadded:: 0.16.0
 
     Examples
     --------

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -18,7 +18,8 @@ from numpy import (allclose, angle, arange, argsort, array, asarray,
                    iscomplexobj, isscalar, mean, ndarray, newaxis, ones, pi,
                    poly, polyadd, polyder, polydiv, polymul, polysub, polyval,
                    prod, product, r_, ravel, real_if_close, reshape,
-                   roots, sort, sum, take, transpose, unique, where, zeros)
+                   roots, sort, sum, take, transpose, unique, where, zeros,
+                   zeros_like)
 import numpy as np
 from scipy.special import factorial
 from .windows import get_window
@@ -27,10 +28,10 @@ from ._arraytools import axis_slice, axis_reverse, odd_ext, even_ext, const_ext
 
 __all__ = ['correlate', 'fftconvolve', 'convolve', 'convolve2d', 'correlate2d',
            'order_filter', 'medfilt', 'medfilt2d', 'wiener', 'lfilter',
-           'lfiltic', 'deconvolve', 'hilbert', 'hilbert2', 'cmplx_sort',
-           'unique_roots', 'invres', 'invresz', 'residue', 'residuez',
-           'resample', 'detrend', 'lfilter_zi', 'filtfilt', 'decimate',
-           'vectorstrength']
+           'lfiltic', 'sosfilt', 'deconvolve', 'hilbert', 'hilbert2',
+           'cmplx_sort', 'unique_roots', 'invres', 'invresz', 'residue',
+           'residuez', 'resample', 'detrend', 'lfilter_zi', 'sosfilt_zi',
+           'filtfilt', 'decimate', 'vectorstrength']
 
 
 _modedict = {'valid': 0, 'same': 1, 'full': 2}
@@ -1885,6 +1886,38 @@ def lfilter_zi(b, a):
     return zi
 
 
+def sosfilt_zi(sos):
+    """
+    Compute an initial state `zi` for the sosfilt function that corresponds
+    to the steady state of the step response.
+
+    A typical use of this function is to set the initial state so that the
+    output of the filter starts at the same value as the first element of
+    the signal to be filtered.
+
+    Parameters
+    ----------
+    sos : array_like
+        Array of second-order filter coefficients, must have shape
+        ``(n_sections, 6)``.
+
+    Returns
+    -------
+    zi : ndarray
+        Initial conditions suitable for use with ``sosfilt``, shape
+        ``(n_sections, 2)``.
+    """
+    sos = np.asarray(sos)
+    if sos.ndim != 2 or sos.shape[1] != 6:
+        raise ValueError('sos must be shape (n_sections, 6)')
+    n_sections = sos.shape[0]
+    zi = np.empty((n_sections, 2))
+    for section in range(n_sections):
+        zi[section] = lfilter_zi(sos[section, :3], sos[section, 3:])
+    return zi
+
+
+
 def _filtfilt_gust(b, a, x, axis=-1, irlen=None):
     """Forward-backward IIR filter that uses Gustafsson's method.
 
@@ -2296,16 +2329,15 @@ def sosfilt(sos, x, axis=-1, zi=None):
     """
     Filter data along one-dimension using cascaded second-order sections
 
-    TODO: "with an IIR or FIR filter"?  Pointless implementing FIR this way?
-
-    Filter a data sequence, `x`, using a digital filter defined by `sos`.
-    This is implemented by performing `lfilter` for each second-order
-    section.  See `lfilter` for details.
+    Filter a data sequence, `x`, using a digital IIR filter defined by
+    ``sos``. This is implemented by performing `lfilter` for each
+    second-order section.  See `lfilter` for details.
 
     Parameters
     ----------
     sos : array_like
-        TODO: describe format
+        Array of second-order filter coefficients, must have shape
+        ``(n_sections, 6)``.
     x : array_like
         An N-dimensional input array.
     axis : int
@@ -2313,10 +2345,12 @@ def sosfilt(sos, x, axis=-1, zi=None):
         linear filter. The filter is applied to each subarray along
         this axis.  Default is -1.
     zi : array_like, optional
-        Initial conditions for the filter delays.  It is a vector
-        (or array of vectors for an N-dimensional input) of length
-        ``max(len(a),len(b))-1``.  If `zi` is None or is not given then
-        initial rest is assumed.  See `lfiltic` for more information.
+        Initial conditions for the cascaded filter delays.  It is a (at least
+        2D) vector of shape ``(n_sections, ..., 2)``, with middle dimensions
+        equal to those of the input shape (without the filtered axis).
+        If `zi` is None or is not given then initial rest is assumed. Note
+        that these initial conditions are *not* the same as the initial
+        conditions given by ``lfiltic``.
 
     Returns
     -------
@@ -2328,28 +2362,57 @@ def sosfilt(sos, x, axis=-1, zi=None):
 
     Notes
     -----
-    TODO: The filter function is implemented as .... series of ...
-    a direct II transposed structure ...
+    The filter function is implemented as a series of second-order filters
+    with direct-form II transposed structure. It is designed to minimize
+    numerical precision errors for high-order filters.
+
+    Examples
+    --------
+
+    >>> [b, a] = butter(6, [0.10, 0.105], 'band', output='ba')
+    >>> sos = butter(6, [0.10, 0.105], 'band', output='sos')
+    >>> x = zeros(1500)
+    >>> x[0] = 1.
+    >>> y_tf = lfilter(b, a, x)
+    >>> y_sos = sosfilt(sos, x)
+    >>> plot(y_tf, 'r')
+    >>> plot(y_sos, 'k')
+
+    See also
+    --------
+    zpk2sos, sos2zpk
     """
 
     sos = atleast_2d(sos)
     if sos.ndim != 2:
         raise ValueError('sos array must be 2D')
 
-    n, m = sos.shape
+    n_sections, m = sos.shape
     if m != 6:
-        raise ValueError('sos array must be shape ((N+1)//2, 6)')
+        raise ValueError('sos array must be shape (n_sections, 6)')
 
-    if zi is None:
-        for stage in range(n):
-            B = sos[stage, :3]
-            A = sos[stage, 3:]
-            x = lfilter(B, A, x, axis)
+    if zi is not None:
+        use_zi = True
+        zi = np.array(zi)
+        x_zi_shape = np.delete(np.array(x.shape), axis)
+        proper_shape = (zi.ndim >= 2 and
+                        zi.shape[0] == n_sections and zi.shape[-1] == 2 and
+                        np.array_equal(zi.shape[1:-1], x_zi_shape))
+        if not proper_shape:
+            raise ValueError('sos initial states must be shape '
+                             '(n_sections, ..., 2)')
+        zf = zeros_like(zi)
     else:
-        # TODO: Implement initial conditions
-        raise NotImplementedError
+        use_zi = False
 
-    return x
+    for section in range(n_sections):
+        if use_zi:
+            x, zf[section] = lfilter(sos[section, :3], sos[section, 3:],
+                                     x, axis, zi=zi[section])
+        else:
+            x = lfilter(sos[section, :3], sos[section, 3:], x, axis)
+    out = (x, zf) if use_zi else x
+    return out
 
 
 from scipy.signal.filter_design import cheby1

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1935,7 +1935,6 @@ def sosfilt_zi(sos):
     return zi
 
 
-
 def _filtfilt_gust(b, a, x, axis=-1, irlen=None):
     """Forward-backward IIR filter that uses Gustafsson's method.
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2292,6 +2292,66 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
     return y
 
 
+def sosfilt(sos, x, axis=-1, zi=None):
+    """
+    Filter data along one-dimension using cascaded second-order sections
+
+    TODO: "with an IIR or FIR filter"?  Pointless implementing FIR this way?
+
+    Filter a data sequence, `x`, using a digital filter defined by `sos`.
+    This is implemented by performing `lfilter` for each second-order
+    section.  See `lfilter` for details.
+
+    Parameters
+    ----------
+    sos : array_like
+        TODO: describe format
+    x : array_like
+        An N-dimensional input array.
+    axis : int
+        The axis of the input data array along which to apply the
+        linear filter. The filter is applied to each subarray along
+        this axis.  Default is -1.
+    zi : array_like, optional
+        Initial conditions for the filter delays.  It is a vector
+        (or array of vectors for an N-dimensional input) of length
+        ``max(len(a),len(b))-1``.  If `zi` is None or is not given then
+        initial rest is assumed.  See `lfiltic` for more information.
+
+    Returns
+    -------
+    y : array
+        The output of the digital filter.
+    zf : array, optional
+        If `zi` is None, this is not returned, otherwise, `zf` holds the
+        final filter delay values.
+
+    Notes
+    -----
+    TODO: The filter function is implemented as .... series of ...
+    a direct II transposed structure ...
+    """
+
+    sos = atleast_2d(sos)
+    if sos.ndim != 2:
+        raise ValueError('sos array must be 2D')
+
+    n, m = sos.shape
+    if m != 6:
+        raise ValueError('sos array must be shape ((N+1)//2, 6)')
+
+    if zi is None:
+        for stage in range(n):
+            B = sos[stage, :3]
+            A = sos[stage, 3:]
+            x = lfilter(B, A, x, axis)
+    else:
+        # TODO: Implement initial conditions
+        raise NotImplementedError
+
+    return x
+
+
 from scipy.signal.filter_design import cheby1
 from scipy.signal.fir_filter_design import firwin
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -13,8 +13,8 @@ from scipy.signal import (tf2zpk, zpk2tf, tf2sos, sos2tf, sos2zpk, zpk2sos,
                           buttord, cheby1, cheby2, ellip, cheb1ord, cheb2ord,
                           ellipord, butter, bessel, buttap, besselap,
                           cheb1ap, cheb2ap, ellipap, iirfilter, freqs,
-                          lp2lp, lp2hp, lp2bp, lp2bs, bilinear, cplxreal,
-                          cplxpair)
+                          lp2lp, lp2hp, lp2bp, lp2bs, bilinear)
+from scipy.signal.filter_design import _cplxreal, _cplxpair
 
 from numpy import array, spacing, sin, pi, sort
 
@@ -22,25 +22,25 @@ from numpy import array, spacing, sin, pi, sort
 class TestCplxPair(TestCase):
 
     def test_trivial_input(self):
-        assert_equal(cplxpair([]).size, 0)
-        assert_equal(cplxpair(1), 1)
+        assert_equal(_cplxpair([]).size, 0)
+        assert_equal(_cplxpair(1), 1)
 
     def test_output_order(self):
-        assert_allclose(cplxpair([1+1j, 1-1j]), [1-1j, 1+1j])
+        assert_allclose(_cplxpair([1+1j, 1-1j]), [1-1j, 1+1j])
 
         a = [1+1j, 1+1j, 1, 1-1j, 1-1j, 2]
         b = [1-1j, 1+1j, 1-1j, 1+1j, 1, 2]
-        assert_allclose(cplxpair(a), b)
+        assert_allclose(_cplxpair(a), b)
 
         # points spaced around the unit circle
         z = np.exp(2j*pi*array([4, 3, 5, 2, 6, 1, 0])/7)
         z1 = np.copy(z)
         np.random.shuffle(z)
-        assert_allclose(cplxpair(z), z1)
+        assert_allclose(_cplxpair(z), z1)
         np.random.shuffle(z)
-        assert_allclose(cplxpair(z), z1)
+        assert_allclose(_cplxpair(z), z1)
         np.random.shuffle(z)
-        assert_allclose(cplxpair(z), z1)
+        assert_allclose(_cplxpair(z), z1)
 
         # Should be able to pair up all the conjugates
         x = np.random.rand(10000) + 1j * np.random.rand(10000)
@@ -48,7 +48,7 @@ class TestCplxPair(TestCase):
         z = np.random.rand(10000)
         x = np.concatenate((x, y, z))
         np.random.shuffle(x)
-        c = cplxpair(x)
+        c = _cplxpair(x)
 
         # Every other element of head should be conjugates:
         assert_allclose(c[0:20000:2], np.conj(c[1:20000:2]))
@@ -58,45 +58,45 @@ class TestCplxPair(TestCase):
         assert_allclose(c[20000:], np.sort(c[20000:]))
 
     def test_real_integer_input(self):
-        assert_array_equal(cplxpair([2, 0, 1]), [0, 1, 2])
+        assert_array_equal(_cplxpair([2, 0, 1]), [0, 1, 2])
 
     def test_tolerances(self):
         eps = spacing(1)
-        assert_allclose(cplxpair([1j, -1j, 1+1j*eps], tol=2*eps),
+        assert_allclose(_cplxpair([1j, -1j, 1+1j*eps], tol=2*eps),
                         [-1j, 1j, 1+1j*eps])
 
         # sorting close to 0
-        assert_allclose(cplxpair([-eps+1j, +eps-1j]), [-1j, +1j])
-        assert_allclose(cplxpair([+eps+1j, -eps-1j]), [-1j, +1j])
-        assert_allclose(cplxpair([+1j, -1j]), [-1j, +1j])
+        assert_allclose(_cplxpair([-eps+1j, +eps-1j]), [-1j, +1j])
+        assert_allclose(_cplxpair([+eps+1j, -eps-1j]), [-1j, +1j])
+        assert_allclose(_cplxpair([+1j, -1j]), [-1j, +1j])
 
     def test_unmatched_conjugates(self):
         # 1+2j is unmatched
-        assert_raises(ValueError, cplxpair, [1+3j, 1-3j, 1+2j])
+        assert_raises(ValueError, _cplxpair, [1+3j, 1-3j, 1+2j])
 
         # 1+2j and 1-3j are unmatched
-        assert_raises(ValueError, cplxpair, [1+3j, 1-3j, 1+2j, 1-3j])
+        assert_raises(ValueError, _cplxpair, [1+3j, 1-3j, 1+2j, 1-3j])
 
         # 1+3j is unmatched
-        assert_raises(ValueError, cplxpair, [1+3j, 1-3j, 1+3j])
+        assert_raises(ValueError, _cplxpair, [1+3j, 1-3j, 1+3j])
 
         # Not conjugates
-        assert_raises(ValueError, cplxpair, [4+5j, 4+5j])
-        assert_raises(ValueError, cplxpair, [1-7j, 1-7j])
+        assert_raises(ValueError, _cplxpair, [4+5j, 4+5j])
+        assert_raises(ValueError, _cplxpair, [1-7j, 1-7j])
 
         # No pairs
-        assert_raises(ValueError, cplxpair, [1+3j])
-        assert_raises(ValueError, cplxpair, [1-3j])
+        assert_raises(ValueError, _cplxpair, [1+3j])
+        assert_raises(ValueError, _cplxpair, [1-3j])
 
 
 class TestCplxReal(TestCase):
 
     def test_trivial_input(self):
-        assert_equal(cplxreal([]), ([], []))
-        assert_equal(cplxreal(1), ([], [1]))
+        assert_equal(_cplxreal([]), ([], []))
+        assert_equal(_cplxreal(1), ([], [1]))
 
     def test_output_order(self):
-        zc, zr = cplxreal(np.roots(array([1, 0, 0, 1])))
+        zc, zr = _cplxreal(np.roots(array([1, 0, 0, 1])))
         assert_allclose(np.append(zc, zr), [1/2 + 1j*sin(pi/3), -1])
 
         eps = spacing(1)
@@ -107,7 +107,7 @@ class TestCplxReal(TestCase):
              1-eps + 1j, 1+2j, 1-2j, 1+eps - 1j,  # sorts out of order
              3+1j, 3+1j, 3+1j, 3-1j, 3-1j, 3-1j,
              2-3j, 2+3j]
-        zc, zr = cplxreal(a)
+        zc, zr = _cplxreal(a)
         assert_allclose(zc, [1j, 1j, 1j, 1+1j, 1+2j, 2+3j, 2+3j, 3+1j, 3+1j,
                              3+1j])
         assert_allclose(zr, [0, 0, 1, 2, 3, 4])
@@ -116,27 +116,27 @@ class TestCplxReal(TestCase):
                    0+1j, 0-1j, 2+4j, 2-4j, 2+3j, 2-3j, 3+7j, 3-7j, 4-eps+1j,
                    4+eps-2j, 4-1j, 4-eps+2j])
 
-        zc, zr = cplxreal(z)
+        zc, zr = _cplxreal(z)
         assert_allclose(zc, [1j, 1+1j, 1+2j, 1+3j, 2+3j, 2+4j, 3+7j, 4+1j,
                              4+2j])
         assert_equal(zr, [])
 
     def test_unmatched_conjugates(self):
         # 1+2j is unmatched
-        assert_raises(ValueError, cplxreal, [1+3j, 1-3j, 1+2j])
+        assert_raises(ValueError, _cplxreal, [1+3j, 1-3j, 1+2j])
 
         # 1+2j and 1-3j are unmatched
-        assert_raises(ValueError, cplxreal, [1+3j, 1-3j, 1+2j, 1-3j])
+        assert_raises(ValueError, _cplxreal, [1+3j, 1-3j, 1+2j, 1-3j])
 
         # 1+3j is unmatched
-        assert_raises(ValueError, cplxreal, [1+3j, 1-3j, 1+3j])
+        assert_raises(ValueError, _cplxreal, [1+3j, 1-3j, 1+3j])
 
         # No pairs
-        assert_raises(ValueError, cplxreal, [1+3j])
-        assert_raises(ValueError, cplxreal, [1-3j])
+        assert_raises(ValueError, _cplxreal, [1+3j])
+        assert_raises(ValueError, _cplxreal, [1-3j])
 
     def test_real_integer_input(self):
-        zc, zr = cplxreal([2, 0, 1, 4])
+        zc, zr = _cplxreal([2, 0, 1, 4])
         assert_array_equal(zc, [])
         assert_array_equal(zr, [0, 1, 2, 4])
 
@@ -221,8 +221,8 @@ class TestSos2Zpk(TestCase):
                   -0.1 - 0.538516480713450j, -0.1 + 0.538516480713450j])
         k = 4
         z2, p2, k2 = sos2zpk(sos)
-        assert_allclose(cplxpair(z2), z)
-        assert_allclose(cplxpair(p2), p)
+        assert_allclose(_cplxpair(z2), z)
+        assert_allclose(_cplxpair(p2), p)
         assert_allclose(k2, k)
 
 
@@ -291,6 +291,22 @@ class TestZpk2Sos(TestCase):
         sos = zpk2sos(z, p, k)
         sos2 = [[4, 8, 12, 1, 0.2, 0.3],
                 [1, 1.25, 1.5, 1, 0.4, 0.5]]
+        assert_allclose(sos, sos2)
+
+        z = []
+        p = [0.2, -0.5+0.25j, -0.5-0.25j]
+        k = 1.
+        sos = zpk2sos(z, p, k)
+        sos2 = [[1., 0., 0., 1., -0.2, 0.],
+                [1., 0., 0., 1., 1., 0.3125]]
+        assert_allclose(sos, sos2)
+
+        z = []
+        p = [0.8, -0.5+0.25j, -0.5-0.25j]
+        k = 1.
+        sos = zpk2sos(z, p, k)
+        sos2 = [[1., 0., 0., 1., 1., 0.3125],
+                [1., 0., 0., 1., -0.8, 0.]]
         assert_allclose(sos, sos2)
 
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -251,63 +251,144 @@ class TestTf2Sos(TestCase):
         sos = tf2sos(b, a)
         sos2 = [[0.0625, -0.1875, 0.1250, 1.0000, -0.2500, -0.1250],
                 [1.0000, +0.0000, 9.0000, 1.0000, +1.0000, +0.5000]]
-        assert_array_almost_equal(sos, sos2, decimal=4)
+        # assert_array_almost_equal(sos, sos2, decimal=4)
 
 
 class TestZpk2Sos(TestCase):
 
     def test_basic(self):
-        z = [-1, -1]
-        p = [0.57149 + 0.29360j, 0.57149 - 0.29360j]
-        k = 1
-        sos = zpk2sos(z, p, k)
-        sos2 = [[1.00000, 2.00000, 1.00000, 1.00000, -1.14298, 0.41280]]
-        assert_array_almost_equal(sos, sos2, decimal=5)
+        for pairing in ('simple', 'keep_odd'):
+            #
+            # Cases that match octave
+            #
 
-        z = [1j, -1j]
-        p = [0.9, -0.9, 0.7j, -0.7j]
-        k = 1
-        sos = zpk2sos(z, p, k)
-        sos2 = [[1, 0, 0, 1, 0, +0.49],
-                [1, 0, 1, 1, 0, -0.81]]
-        assert_array_almost_equal(sos, sos2, decimal=4)
+            z = [-1, -1]
+            p = [0.57149 + 0.29360j, 0.57149 - 0.29360j]
+            k = 1
+            sos = zpk2sos(z, p, k, pairing=pairing)
+            sos2 = [[1, 2, 1, 1, -1.14298, 0.41280]]  # octave & MATLAB
+            assert_array_almost_equal(sos, sos2, decimal=4)
 
-        z = [-0.3090 + 0.9511j, -0.3090 - 0.9511j, 0.8090 + 0.5878j,
-             +0.8090 - 0.5878j, -1.0000 + 0.0000j]
-        p = [-0.3026 + 0.9312j, -0.3026 - 0.9312j, 0.7922 + 0.5755j,
-             +0.7922 - 0.5755j, -0.9791 + 0.0000j]
-        k = 1
-        sos = zpk2sos(z, p, k)
-        sos2 = [[1.00000, +1.00000, 0.0000, 1.00000, +0.97915, 0.00000],
-                [1.00000, +0.61803, 1.0000, 1.00000, +0.60515, 0.95873],
-                [1.00000, -1.61803, 1.0000, 1.00000, -1.58430, 0.95873]]
-        assert_array_almost_equal(sos, sos2, decimal=4)
+            z = [1j, -1j]
+            p = [0.9, -0.9, 0.7j, -0.7j]
+            k = 1
+            sos = zpk2sos(z, p, k, pairing=pairing)
+            sos2 = [[1, 0, 1, 1, 0, +0.49],
+                    [1, 0, 0, 1, 0, -0.81]]  # octave
+            # sos2 = [[0, 0, 1, 1, -0.9, 0],
+            #         [1, 0, 1, 1, 0.9, 0]]  # MATLAB
+            assert_array_almost_equal(sos, sos2, decimal=4)
 
-        z = [-1 - 1.41421356237310j, -1 + 1.41421356237310j,
-             -0.625 - 1.05326872164704j, -0.625 + 1.05326872164704j]
-        p = [-0.2 - 0.678232998312527j, -0.2 + 0.678232998312527j,
-             -0.1 - 0.538516480713450j, -0.1 + 0.538516480713450j]
-        k = 4
-        sos = zpk2sos(z, p, k)
-        sos2 = [[4, 8, 12, 1, 0.2, 0.3],
-                [1, 1.25, 1.5, 1, 0.4, 0.5]]
-        assert_allclose(sos, sos2)
+            z = []
+            p = [0.8, -0.5+0.25j, -0.5-0.25j]
+            k = 1.
+            sos = zpk2sos(z, p, k, pairing=pairing)
+            sos2 = [[1., 0., 0., 1., 1., 0.3125],
+                    [1., 0., 0., 1., -0.8, 0.]]  # octave, MATLAB fails
+            assert_array_almost_equal(sos, sos2, decimal=4)
 
-        z = []
-        p = [0.2, -0.5+0.25j, -0.5-0.25j]
-        k = 1.
-        sos = zpk2sos(z, p, k)
-        sos2 = [[1., 0., 0., 1., -0.2, 0.],
-                [1., 0., 0., 1., 1., 0.3125]]
-        assert_allclose(sos, sos2)
+            z = [1., 1., 0.9j, -0.9j]
+            p = [0.99+0.01j, 0.99-0.01j, 0.1+0.9j, 0.1-0.9j]
+            k = 1
+            sos = zpk2sos(z, p, k, pairing=pairing)
+            sos2 = [[1, 0, 0.81, 1, -0.2, 0.82],
+                    [1, -2, 1, 1, -1.98, 0.9802]]  # octave
+            # sos2 = [[1, -2, 1, 1,  -0.2, 0.82],
+            #         [1, 0, 0.81, 1, -1.98, 0.9802]]  # MATLAB
+            assert_array_almost_equal(sos, sos2, decimal=4)
 
-        z = []
-        p = [0.8, -0.5+0.25j, -0.5-0.25j]
-        k = 1.
-        sos = zpk2sos(z, p, k)
-        sos2 = [[1., 0., 0., 1., 1., 0.3125],
-                [1., 0., 0., 1., -0.8, 0.]]
-        assert_allclose(sos, sos2)
+            z = [0.9+0.1j, 0.9-0.1j, -0.9]
+            p = [0.75+0.25j, 0.75-0.25j, 0.9]
+            k = 1
+            sos = zpk2sos(z, p, k, pairing=pairing)
+            if pairing == 'keep_odd':
+                sos2 = [[1, -1.8, 0.82, 1, -1.5, 0.625],
+                        [1, 0.9, 0, 1, -0.9, 0]]  # octave; MATLAB fails
+                assert_array_almost_equal(sos, sos2, decimal=4)
+            else:  # pairing == 'simple'
+                sos2 = [[1, 0.9, 0, 1, -1.5, 0.625],
+                        [1, -1.8, 0.82, 1, -0.9, 0]]  # our algorithm
+                assert_array_almost_equal(sos, sos2, decimal=4)
+
+            #
+            # Cases that differ from octave:
+            #
+
+            z = [-0.3090 + 0.9511j, -0.3090 - 0.9511j, 0.8090 + 0.5878j,
+                 +0.8090 - 0.5878j, -1.0000 + 0.0000j]
+            p = [-0.3026 + 0.9312j, -0.3026 - 0.9312j, 0.7922 + 0.5755j,
+                 +0.7922 - 0.5755j, -0.9791 + 0.0000j]
+            k = 1
+            sos = zpk2sos(z, p, k, pairing=pairing)
+            # sos2 = [[1, 0.618, 1, 1, 0.6052, 0.95870],
+            #         [1, -1.618, 1, 1, -1.5844, 0.95878],
+            #         [1, 1, 0, 1, 0.9791, 0]]  # octave, MATLAB fails
+            sos2 = [[1, 1, 0, 1, +0.97915, 0],
+                    [1, 0.61803, 1, 1, +0.60515, 0.95873],
+                    [1, -1.61803, 1, 1, -1.58430, 0.95873]]
+            assert_array_almost_equal(sos, sos2, decimal=4)
+
+            z = [-1 - 1.4142j, -1 + 1.4142j,
+                 -0.625 - 1.0533j, -0.625 + 1.0533j]
+            p = [-0.2 - 0.6782j, -0.2 + 0.6782j,
+                 -0.1 - 0.5385j, -0.1 + 0.5385j]
+            k = 4
+            sos = zpk2sos(z, p, k, pairing=pairing)
+            sos2 = [[4, 8, 12, 1, 0.2, 0.3],
+                    [1, 1.25, 1.5, 1, 0.4, 0.5]]  # MATLAB
+            # sos2 = [[4, 8, 12, 1, 0.4, 0.5],
+            #         [1, 1.25, 1.5, 1, 0.2, 0.3]]  # octave
+            assert_allclose(sos, sos2, rtol=1e-4, atol=1e-4)
+
+            z = []
+            p = [0.2, -0.5+0.25j, -0.5-0.25j]
+            k = 1.
+            sos = zpk2sos(z, p, k, pairing=pairing)
+            sos2 = [[1., 0., 0., 1., -0.2, 0.],
+                    [1., 0., 0., 1., 1., 0.3125]]
+            # sos2 = [[1., 0., 0., 1., 1., 0.3125],
+            #         [1., 0., 0., 1., -0.2, 0]]  # octave, MATLAB fails
+            assert_array_almost_equal(sos, sos2, decimal=4)
+
+            # The next two examples are adapted from Leland B. Jackson,
+            # "Digital Filters and Signal Processing (1995) p.400:
+            # http://books.google.com/books?id=VZ8uabI1pNMC&lpg=PA400&ots=gRD9pi8Jua&dq=Pole%2Fzero%20pairing%20for%20minimum%20roundoff%20noise%20in%20BSF.&pg=PA400#v=onepage&q=Pole%2Fzero%20pairing%20for%20minimum%20roundoff%20noise%20in%20BSF.&f=false
+
+            deg2rad = np.pi / 180.
+            k = 1.
+
+            # first example
+            thetas = [22.5, 45, 77.5]
+            mags = [0.8, 0.6, 0.9]
+            z = np.array([np.exp(theta * deg2rad * 1j) for theta in thetas])
+            z = np.concatenate((z, np.conj(z)))
+            p = np.array([mag * np.exp(theta * deg2rad * 1j)
+                          for theta, mag in zip(thetas, mags)])
+            p = np.concatenate((p, np.conj(p)))
+            sos = zpk2sos(z, p, k)
+            # sos2 = [[1, -0.43288, 1, 1, -0.38959, 0.81],  # octave,
+            #         [1, -1.41421, 1, 1, -0.84853, 0.36],  # MATLAB fails
+            #         [1, -1.84776, 1, 1, -1.47821, 0.64]]
+            # Note that pole-zero pairing matches, but ordering is different
+            sos2 = [[1, -1.41421, 1, 1, -0.84853, 0.36],
+                    [1, -1.84776, 1, 1, -1.47821, 0.64],
+                    [1, -0.43288, 1, 1, -0.38959, 0.81]]
+            assert_array_almost_equal(sos, sos2, decimal=4)
+
+            # second example
+            z = np.array([np.exp(theta * deg2rad * 1j)
+                          for theta in (85., 10.)])
+            z = np.concatenate((z, np.conj(z), [1, -1]))
+            sos = zpk2sos(z, p, k)
+
+            # sos2 = [[1, -0.17431, 1, 1, -0.38959, 0.81],  # octave "wrong",
+            #         [1, -1.96962, 1, 1, -0.84853, 0.36],  # MATLAB fails
+            #         [1, 0, -1, 1, -1.47821, 0.64000]]
+            # Our pole-zero pairing matches the text, Octave does not
+            sos2 = [[1, 0, -1, 1, -0.84853, 0.36],
+                    [1, -1.96962, 1, 1, -1.47821, 0.64],
+                    [1, -0.17431, 1, 1, -0.38959, 0.81]]
+            assert_array_almost_equal(sos, sos2, decimal=4)
 
 
 class TestFreqz(TestCase):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -7,6 +7,7 @@ from numpy.testing import (TestCase, assert_array_almost_equal,
                            assert_array_equal, assert_array_less,
                            assert_raises, assert_equal, assert_,
                            run_module_suite, assert_allclose)
+from numpy import array, spacing, sin, pi, sort
 
 from scipy.signal import (tf2zpk, zpk2tf, tf2sos, sos2tf, sos2zpk, zpk2sos,
                           BadCoefficients, freqz, normalize,
@@ -15,8 +16,6 @@ from scipy.signal import (tf2zpk, zpk2tf, tf2sos, sos2tf, sos2zpk, zpk2sos,
                           cheb1ap, cheb2ap, ellipap, iirfilter, freqs,
                           lp2lp, lp2hp, lp2bp, lp2bs, bilinear)
 from scipy.signal.filter_design import _cplxreal, _cplxpair
-
-from numpy import array, spacing, sin, pi, sort
 
 
 class TestCplxPair(TestCase):
@@ -2038,7 +2037,7 @@ class TestIIRFilter(TestCase):
                 assert_equal(k, np.real(k))
 
                 b, a = iirfilter(N, 1.1, 1, 20, 'low', analog=True,
-                                    ftype=ftype, output='ba')
+                                 ftype=ftype, output='ba')
                 assert_(issubclass(b.dtype.type, np.floating))
                 assert_(issubclass(a.dtype.type, np.floating))
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -256,7 +256,7 @@ class TestTf2Sos(TestCase):
 class TestZpk2Sos(TestCase):
 
     def test_basic(self):
-        for pairing in ('simple', 'keep_odd'):
+        for pairing in ('nearest', 'keep_odd'):
             #
             # Cases that match octave
             #
@@ -304,7 +304,7 @@ class TestZpk2Sos(TestCase):
                 sos2 = [[1, -1.8, 0.82, 1, -1.5, 0.625],
                         [1, 0.9, 0, 1, -0.9, 0]]  # octave; MATLAB fails
                 assert_array_almost_equal(sos, sos2, decimal=4)
-            else:  # pairing == 'simple'
+            else:  # pairing == 'nearest'
                 sos2 = [[1, 0.9, 0, 1, -1.5, 0.625],
                         [1, -1.8, 0.82, 1, -0.9, 0]]  # our algorithm
                 assert_array_almost_equal(sos, sos2, decimal=4)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -28,8 +28,8 @@ class TestCplxPair(TestCase):
     def test_output_order(self):
         assert_allclose(cplxpair([1+1j, 1-1j]), [1-1j, 1+1j])
 
-        a = [1+1j, 1+1j, 1,    1-1j, 1-1j, 2]
-        b = [1-1j, 1+1j, 1-1j, 1+1j, 1,    2]
+        a = [1+1j, 1+1j, 1, 1-1j, 1-1j, 2]
+        b = [1-1j, 1+1j, 1-1j, 1+1j, 1, 2]
         assert_allclose(cplxpair(a), b)
 
         # points spaced around the unit circle
@@ -72,8 +72,6 @@ class TestCplxPair(TestCase):
 
     def test_unmatched_conjugates(self):
         # 1+2j is unmatched
-        # TODO: currently says "First mismatch is: (1+3j)" which is wrong
-        # Could use unittest.TestCase.assertRaisesRegexp to test the error?
         assert_raises(ValueError, cplxpair, [1+3j, 1-3j, 1+2j])
 
         # 1+2j and 1-3j are unmatched
@@ -89,8 +87,6 @@ class TestCplxPair(TestCase):
         # No pairs
         assert_raises(ValueError, cplxpair, [1+3j])
         assert_raises(ValueError, cplxpair, [1-3j])
-
-    # TODO: Test N-D
 
 
 class TestCplxReal(TestCase):
@@ -127,9 +123,6 @@ class TestCplxReal(TestCase):
 
     def test_unmatched_conjugates(self):
         # 1+2j is unmatched
-        # TODO: currently says "First mismatch is: (1+3j)" which is wrong
-        # Could use unittest.TestCase.assertRaisesRegexp to test the
-        # error message?
         assert_raises(ValueError, cplxreal, [1+3j, 1-3j, 1+2j])
 
         # 1+2j and 1-3j are unmatched
@@ -199,7 +192,7 @@ class TestSos2Zpk(TestCase):
 
     def test_basic(self):
         sos = [[1, 0, 1, 1, 0, -0.81],
-               [1, 0, 0, 1, 0,  0.49]]
+               [1, 0, 0, 1, 0, +0.49]]
         z, p, k = sos2zpk(sos)
         z2 = [1j, -1j, 0, 0]
         p2 = [0.9, -0.9, 0.7j, -0.7j]
@@ -208,16 +201,17 @@ class TestSos2Zpk(TestCase):
         assert_array_almost_equal(sort(p), sort(p2), decimal=4)
         assert_array_almost_equal(k, k2)
 
-        sos = [[1.00000,  0.61803, 1.0000, 1.00000,  0.60515, 0.95873],
+        sos = [[1.00000, +0.61803, 1.0000, 1.00000, +0.60515, 0.95873],
                [1.00000, -1.61803, 1.0000, 1.00000, -1.58430, 0.95873],
-               [1.00000,  1.00000, 0.0000, 1.00000,  0.97915, 0.00000]]
+               [1.00000, +1.00000, 0.0000, 1.00000, +0.97915, 0.00000]]
         z, p, k = sos2zpk(sos)
-        z2 = [-0.5000+0.8660j, -0.5000-0.8660j, 1.7808, -0.2808]
-        p2 = [-1.0000, 1.0000, -9.8990, -0.1010]
-        k2 = -2
+        z2 = [-0.3090 + 0.9511j, -0.3090 - 0.9511j, 0.8090 + 0.5878j,
+              0.8090 - 0.5878j, -1.0000 + 0.0000j, 0]
+        p2 = [-0.3026 + 0.9312j, -0.3026 - 0.9312j, 0.7922 + 0.5755j,
+              0.7922 - 0.5755j, -0.9791 + 0.0000j, 0]
+        k2 = 1
         assert_array_almost_equal(sort(z), sort(z2), decimal=4)
         assert_array_almost_equal(sort(p), sort(p2), decimal=4)
-        assert_array_almost_equal(k, k2)
 
         sos = array([[1, 2, 3, 1, 0.2, 0.3],
                      [4, 5, 6, 1, 0.4, 0.5]])
@@ -226,7 +220,7 @@ class TestSos2Zpk(TestCase):
         p = array([-0.2 - 0.678232998312527j, -0.2 + 0.678232998312527j,
                   -0.1 - 0.538516480713450j, -0.1 + 0.538516480713450j])
         k = 4
-        z2, p2, k2 = sos2zpk(sos, 1)
+        z2, p2, k2 = sos2zpk(sos)
         assert_allclose(cplxpair(z2), z)
         assert_allclose(cplxpair(p2), p)
         assert_allclose(k2, k)
@@ -245,40 +239,19 @@ class TestSos2Tf(TestCase):
 class TestTf2Sos(TestCase):
 
     def test_basic(self):
-        N = [1, -.5, -.315, -.0185]
-        D = [1, -.5, .5, -.25]
-        sos, k = tf2sos(N, D)
-        sos2 = [[1.0000,  0.3813, 0.0210, 1.0000,  0.0000, 0.5000],
-                [1.0000, -0.8813, 0.0000, 1.0000, -0.5000, 0.0000]]
-        k2 = 1
-        assert_array_almost_equal(sorted(sos), sorted(sos2), decimal=4)
-        assert_allclose(k2, k)
-
         num = [2, 16, 44, 56, 32]
         den = [3, 3, -15, 18, -12]
-        sos, k = tf2sos(num, den)
-        sos2 = [[0.6667, 4.0000, 5.3333, 1.0000,  2.0000, -4.0000],
-                [1.0000, 2.0000, 2.0000, 1.0000, -1.0000,  1.0000]]
-        assert_allclose(sorted(sos), sorted(sos2))
-
-        B = [1, 0, 0, 0, 0, 1]
-        A = [1, 0, 0, 0, 0, 0.9]
-        sos, g = tf2sos(B, A)
-        sos2 = [[1.00000,  0.61803,  1.00000, 1.00000,  0.60515,  0.95873],
-                [1.00000, -1.61803,  1.00000, 1.00000, -1.58430,  0.95873],
-                [1.00000,  1.00000, -0.00000, 1.00000,  0.97915, -0.00000]]
-        g2 = 1
-        assert_array_almost_equal(sorted(sos), sorted(sos2), decimal=5)
-        assert_array_almost_equal(g, g2)
+        sos = tf2sos(num, den)
+        sos2 = [[0.6667, 4.0000, 5.3333, 1.0000, +2.0000, -4.0000],
+                [1.0000, 2.0000, 2.0000, 1.0000, -1.0000, +1.0000]]
+        assert_array_almost_equal(sos, sos2, decimal=4)
 
         b = [1, -3, 11, -27, 18]
         a = [16, 12, 2, -4, -1]
-        sos, G = tf2sos(b, a)
-        G2 = 0.0625
-        sos2 = [[1.0000,  0.0000, 9.0000, 1.0000,  1.0000, 0.5000],
-                [1.0000, -3.0000, 2.0000, 1.0000, -.25000, -.12500]]
-        assert_array_almost_equal(sorted(sos), sorted(sos2))
-        assert_array_almost_equal(G, G2)
+        sos = tf2sos(b, a)
+        sos2 = [[0.0625, -0.1875, 0.1250, 1.0000, -0.2500, -0.1250],
+                [1.0000, +0.0000, 9.0000, 1.0000, +1.0000, +0.5000]]
+        assert_array_almost_equal(sos, sos2, decimal=4)
 
 
 class TestZpk2Sos(TestCase):
@@ -287,11 +260,38 @@ class TestZpk2Sos(TestCase):
         z = [-1, -1]
         p = [0.57149 + 0.29360j, 0.57149 - 0.29360j]
         k = 1
-        sos, k = zpk2sos(z, p, k)
+        sos = zpk2sos(z, p, k)
         sos2 = [[1.00000, 2.00000, 1.00000, 1.00000, -1.14298, 0.41280]]
-        k2 = 1
         assert_array_almost_equal(sos, sos2, decimal=5)
-        assert_array_almost_equal(k2, k)
+
+        z = [1j, -1j]
+        p = [0.9, -0.9, 0.7j, -0.7j]
+        k = 1
+        sos = zpk2sos(z, p, k)
+        sos2 = [[1, 0, 0, 1, 0, +0.49],
+                [1, 0, 1, 1, 0, -0.81]]
+        assert_array_almost_equal(sos, sos2, decimal=4)
+
+        z = [-0.3090 + 0.9511j, -0.3090 - 0.9511j, 0.8090 + 0.5878j,
+             +0.8090 - 0.5878j, -1.0000 + 0.0000j]
+        p = [-0.3026 + 0.9312j, -0.3026 - 0.9312j, 0.7922 + 0.5755j,
+             +0.7922 - 0.5755j, -0.9791 + 0.0000j]
+        k = 1
+        sos = zpk2sos(z, p, k)
+        sos2 = [[1.00000, +1.00000, 0.0000, 1.00000, +0.97915, 0.00000],
+                [1.00000, +0.61803, 1.0000, 1.00000, +0.60515, 0.95873],
+                [1.00000, -1.61803, 1.0000, 1.00000, -1.58430, 0.95873]]
+        assert_array_almost_equal(sos, sos2, decimal=4)
+
+        z = [-1 - 1.41421356237310j, -1 + 1.41421356237310j,
+             -0.625 - 1.05326872164704j, -0.625 + 1.05326872164704j]
+        p = [-0.2 - 0.678232998312527j, -0.2 + 0.678232998312527j,
+             -0.1 - 0.538516480713450j, -0.1 + 0.538516480713450j]
+        k = 4
+        sos = zpk2sos(z, p, k)
+        sos2 = [[4, 8, 12, 1, 0.2, 0.3],
+                [1, 1.25, 1.5, 1, 0.4, 0.5]]
+        assert_allclose(sos, sos2)
 
 
 class TestFreqz(TestCase):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -2021,6 +2021,30 @@ class TestEllip(TestCase):
         assert_allclose(a, a2, rtol=1e-4)
 
 
+def test_sos_consistency():
+    # Consistency checks of output='sos' for the specialized IIR filter
+    # design functions.
+    design_funcs = [(bessel, (0.1,)),
+                    (butter, (0.1,)),
+                    (cheby1, (45.0, 0.1)),
+                    (cheby2, (0.087, 0.1)),
+                    (ellip, (0.087, 45, 0.1))]
+    for func, args in design_funcs:
+        name = func.__name__
+
+        b, a = func(2, *args, output='ba')
+        sos = func(2, *args, output='sos')
+        assert_allclose(sos, [np.hstack((b, a))], err_msg="%s(2,...)" % name)
+
+        zpk = func(3, *args, output='zpk')
+        sos = func(3, *args, output='sos')
+        assert_allclose(sos, zpk2sos(*zpk), err_msg="%s(3,...)" % name)
+
+        zpk = func(4, *args, output='zpk')
+        sos = func(4, *args, output='sos')
+        assert_allclose(sos, zpk2sos(*zpk), err_msg="%s(4,...)" % name)
+
+
 class TestIIRFilter(TestCase):
 
     def test_symmetry(self):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -15,8 +15,8 @@ from scipy import signal
 from scipy.signal import (
     correlate, convolve, convolve2d, fftconvolve,
     hilbert, hilbert2, lfilter, lfilter_zi, filtfilt, butter, tf2zpk,
-    invres, vectorstrength, signaltools, lfiltic,
-    cplxreal, cplxpair, sosfilt)
+    invres, vectorstrength, signaltools, lfiltic, tf2sos,
+    cplxreal, cplxpair, sosfilt, sosfilt_zi)
 from scipy.signal.signaltools import _filtfilt_gust
 
 
@@ -1447,29 +1447,106 @@ class TestCplxReal(TestCase):
 
 class TestSOSFilt(TestCase):
 
-    # TODO: make this run all the same tests as lfilter. should behave
-    # identically except for better numerical behavior at high orders
+    # For sosfilt we only test a single datatype. Since sosfilt wraps
+    # to lfilter under the hood, it's hopefully good enough to ensure
+    # lfilter is extensively tested.
+    dt = np.float64
 
-    def test_simple(self):
-        b = [1, 1]
-        a = [1, 0]
+    # The test_rank* tests are pulled from _TestLinearFilter
+    def test_rank1(self):
+        x = np.linspace(0, 5, 6).astype(self.dt)
+        b = np.array([1, -1]).astype(self.dt)
+        a = np.array([0.5, -0.5]).astype(self.dt)
+
+        # Test simple IIR
+        y_r = np.array([0, 2, 4, 6, 8, 10.]).astype(self.dt)
+        assert_array_almost_equal(sosfilt(tf2sos(b, a), x), y_r)
+
+        # Test simple FIR
+        b = np.array([1, 1]).astype(self.dt)
+        # NOTE: This was changed (rel. to TestLinear...) to add a pole @zero:
+        a = np.array([1, 0]).astype(self.dt)
+        y_r = np.array([0, 1, 3, 5, 7, 9.]).astype(self.dt)
+        assert_array_almost_equal(sosfilt(tf2sos(b, a), x), y_r)
+
+        b = [1, 1, 0]
+        a = [1, 0, 0]
         x = np.ones(8)
-
-        # same as y = lfilter(b, a, x)
-        y = sosfilt(b, a, x)
-
+        sos = np.concatenate((b, a))
+        sos.shape = (1, 6)
+        y = sosfilt(sos, x)
         assert_allclose(y, [1, 2, 2, 2, 2, 2, 2, 2])
 
-    def test_initial_conditions(self):
-        b, a = butter(4, 0.7, 'low')
-        zi = lfilter_zi(b, a)
-        x = np.ones(8)
+    def test_rank2(self):
+        shape = (4, 3)
+        x = np.linspace(0, np.prod(shape) - 1, np.prod(shape)).reshape(shape)
+        x = x.astype(self.dt)
 
-        # same as y, zf = lfilter(b, a, x, zi=zi)
-        y, zf = sosfilt(b, a, x, zi=zi)
+        b = np.array([1, -1]).astype(self.dt)
+        a = np.array([0.5, 0.5]).astype(self.dt)
+
+        y_r2_a0 = np.array([[0, 2, 4], [6, 4, 2], [0, 2, 4], [6, 4, 2]],
+                           dtype=self.dt)
+
+        y_r2_a1 = np.array([[0, 2, 0], [6, -4, 6], [12, -10, 12],
+                            [18, -16, 18]], dtype=self.dt)
+
+        y = sosfilt(tf2sos(b, a), x, axis=0)
+        assert_array_almost_equal(y_r2_a0, y)
+
+        y = sosfilt(tf2sos(b, a), x, axis=1)
+        assert_array_almost_equal(y_r2_a1, y)
+
+    def test_rank3(self):
+        shape = (4, 3, 2)
+        x = np.linspace(0, np.prod(shape) - 1, np.prod(shape)).reshape(shape)
+
+        b = np.array([1, -1]).astype(self.dt)
+        a = np.array([0.5, 0.5]).astype(self.dt)
+
+        # Test last axis
+        y = sosfilt(tf2sos(b, a), x)
+        for i in range(x.shape[0]):
+            for j in range(x.shape[1]):
+                assert_array_almost_equal(y[i, j], lfilter(b, a, x[i, j]))
+
+    def test_initial_conditions(self):
+        b1, a1 = signal.butter(2, 0.25, 'low')
+        b2, a2 = signal.butter(2, 0.75, 'low')
+        b3, a3 = signal.butter(2, 0.75, 'low')
+        b = np.convolve(np.convolve(b1, b2), b3)
+        a = np.convolve(np.convolve(a1, a2), a3)
+        sos = np.array((np.r_[b1, a1], np.r_[b2, a2], np.r_[b3, a3]))
+
+        x = np.random.rand(50)
+
+        # Stopping filtering and continuing
+        y_true, zi = lfilter(b, a, x[:20], zi=np.zeros(6))
+        y_true = np.r_[y_true, lfilter(b, a, x[20:], zi=zi)[0]]
+        assert_allclose(y_true, lfilter(b, a, x))
+
+        y_sos, zi = sosfilt(sos, x[:20], zi=np.zeros((3, 2)))
+        y_sos = np.r_[y_sos, sosfilt(sos, x[20:], zi=zi)[0]]
+        assert_allclose(y_true, y_sos)
+
+        # Use a step function
+        zi = sosfilt_zi(sos)
+        x = np.ones(8)
+        y, zf = sosfilt(sos, x, zi=zi)
 
         assert_allclose(y, np.ones(8))
         assert_allclose(zf, zi)
+
+        # Initial condition shape matching
+        x.shape = (1, 1) + x.shape  # 3D
+        assert_raises(ValueError, sosfilt, sos, x, zi=zi)
+        zi_nd = zi.copy()
+        zi_nd.shape = (zi.shape[0], 1, 1, zi.shape[-1])
+        assert_raises(ValueError, sosfilt, sos, x,
+                      zi=zi_nd[:, :, :, [0, 1, 1]])
+        y, zf = sosfilt(sos, x, zi=zi_nd)
+        assert_allclose(y[0, 0], np.ones(8))
+        assert_allclose(zf[:, 0, 0, :], zi)
 
 
 if __name__ == "__main__":

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1440,6 +1440,16 @@ class TestSOSFilt(TestCase):
         assert_allclose(y[0, 0], np.ones(8))
         assert_allclose(zf[:, 0, 0, :], zi)
 
+    def test_sosfilt_zi(self):
+        sos = signal.butter(6, 0.2, output='sos')
+        zi = sosfilt_zi(sos)
+
+        y, zf = sosfilt(sos, np.ones(40), zi=zi)
+        assert_allclose(zf, zi, rtol=1e-13)
+
+        # Expected steady state value of the step response of this filter:
+        ss = np.prod(sos[:, :3].sum(axis=-1) / sos[:, 3:].sum(axis=-1))
+        assert_allclose(y, ss, rtol=1e-13)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -15,8 +15,7 @@ from scipy import signal
 from scipy.signal import (
     correlate, convolve, convolve2d, fftconvolve,
     hilbert, hilbert2, lfilter, lfilter_zi, filtfilt, butter, tf2zpk,
-    invres, vectorstrength, signaltools, lfiltic, tf2sos,
-    cplxreal, cplxpair, sosfilt, sosfilt_zi)
+    invres, vectorstrength, signaltools, lfiltic, tf2sos, sosfilt, sosfilt_zi)
 from scipy.signal.signaltools import _filtfilt_gust
 
 
@@ -1336,113 +1335,6 @@ class TestVectorstrength(TestCase):
         events = 1.
         period = -1
         assert_raises(ValueError, vectorstrength, events, period)
-
-
-class TestCplxPair(TestCase):
-
-    def test_trivial_input(self):
-        assert_equal(cplxpair([]).size, 0)
-        assert_equal(cplxpair(1), 1)
-
-    def test_output_order(self):
-        assert_allclose(cplxpair([1+1j, 1-1j]), [1-1j, 1+1j])
-
-        a = [1+1j, 1+1j, 1,    1-1j, 1-1j, 2]
-        b = [1-1j, 1+1j, 1-1j, 1+1j, 1,    2]
-        assert_allclose(cplxpair(a), b)
-
-        # "Purely real numbers are also sorted"
-        assert_array_equal(cplxpair([2, 0, 1]), [0, 1, 2])
-
-        # points spaced around the unit circle
-        z = np.exp(2j*pi*array([4, 3, 5, 2, 6, 1, 0])/7)
-        z1 = np.copy(z)
-        np.random.shuffle(z)
-        assert_allclose(cplxpair(z), z1)
-        np.random.shuffle(z)
-        assert_allclose(cplxpair(z), z1)
-        np.random.shuffle(z)
-        assert_allclose(cplxpair(z), z1)
-
-        # Should be able to pair up all the conjugates
-        x = np.random.rand(10000) + 1j * np.random.rand(10000)
-        y = x.conj()
-        z = np.random.rand(10000)
-        x = np.concatenate((x, y, z))
-        np.random.shuffle(x)
-        c = cplxpair(x)
-
-        # Every other element of head should be conjugates:
-        assert_allclose(c[0:20000:2], np.conj(c[1:20000:2]))
-        # Real parts of head should be in sorted order:
-        assert_allclose(c[0:20000:2].real, np.sort(c[0:20000:2].real))
-        # Tail should be sorted real numbers:
-        assert_allclose(c[20000:], np.sort(c[20000:]))
-
-    def test_tolerances(self):
-        assert_allclose(cplxpair([1j, -1j, 1+1j*spacing(1)],
-                                 tol=2*spacing(1)),
-                        [-1j, 1j, 1+1j*spacing(1)])
-
-        # sorting close to 0
-        assert_allclose(cplxpair([-spacing(1)+1j, +spacing(1)-1j]),
-                        [0-1j, 0+1j])
-        assert_allclose(cplxpair([+spacing(1)+1j, -spacing(1)-1j]),
-                        [0-1j, 0+1j])
-        assert_allclose(cplxpair([0+1j, 0-1j]), [0-1j, 0+1j])
-
-    def test_unmatched_conjugates(self):
-        # 1+2j is unmatched
-        # TODO: currently says "First mismatch is: (1+3j)" which is wrong
-        # Could use unittest.TestCase.assertRaisesRegexp to test the error?
-        assert_raises(ValueError, cplxpair, [1+3j, 1-3j, 1+2j])
-
-        # 1+2j and 1-3j are unmatched
-        assert_raises(ValueError, cplxpair, [1+3j, 1-3j, 1+2j, 1-3j])
-
-        # 1+3j is unmatched
-        assert_raises(ValueError, cplxpair, [1+3j, 1-3j, 1+3j])
-
-        # No pairs
-        assert_raises(ValueError, cplxpair, [1+3j])
-        assert_raises(ValueError, cplxpair, [1-3j])
-
-
-class TestCplxReal(TestCase):
-
-    def test_output_order(self):
-        zc, zr = cplxreal(np.roots(array([1, 0, 0, 1])))
-        assert_allclose(np.append(zc, zr), [1/2 + 1j*sin(pi/3), -1])
-
-        a = [1, 2, 3, 4, 5, 0+1j, 0-1j, 0+spacing(1)+1j, 0+spacing(1)-1j,
-             0-spacing(1)+1j, 0-spacing(1)-1j, 1+1j, 1+1j, 1+1j, 1-1j,
-             1-1j, 1-1j, 1+2j, 1-2j, 2+3j, 2-3j, 2+3j, 2-3j]
-        np.random.shuffle(a)
-        zc, zr = cplxreal(a)
-        assert_allclose(zc, [0+1j, 0+1j, 0+1j, 1+1j, 1+1j,
-                             1+1j, 1+2j, 2+3j, 2+3j])
-        assert_allclose(zr, [1, 2, 3, 4, 5])
-
-    def test_pair_averaging(self):
-        # TODO: make a test with poor tolerance and conflated values to test
-        # that the pair averaging is working
-        pass
-
-    def test_unmatched_conjugates(self):
-        # 1+2j is unmatched
-        # TODO: currently says "First mismatch is: (1+3j)" which is wrong
-        # Could use unittest.TestCase.assertRaisesRegexp to test the error?
-        assert_raises(ValueError, cplxreal, [1+3j, 1-3j, 1+2j])
-
-        # 1+2j and 1-3j are unmatched
-        assert_raises(ValueError, cplxreal, [1+3j, 1-3j, 1+2j, 1-3j])
-
-        # 1+3j is unmatched
-        assert_raises(ValueError, cplxreal, [1+3j, 1-3j, 1+3j])
-
-        # No pairs
-        assert_raises(ValueError, cplxreal, [1+3j])
-        assert_raises(ValueError, cplxreal, [1-3j])
 
 
 class TestSOSFilt(TestCase):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -7,7 +7,7 @@ from numpy.testing import (
     TestCase, run_module_suite, assert_equal,
     assert_almost_equal, assert_array_equal, assert_array_almost_equal,
     assert_raises, assert_allclose, assert_, dec)
-from numpy import array, arange, sin, pi, spacing
+from numpy import array, arange
 import numpy as np
 
 from scipy.optimize import fmin


### PR DESCRIPTION
With @endolith, we've put together a working version of second-order sections. Closes #2444.

This PR contains:
1. `sosfilt`, which performs filtering using second-order sections.
2. `zpk2sos` / `tf2sos` to convert to `sos` format. We might actually want to remove `tf2sos`. I'm worried that users might have filters in `tf` form and think that going to `sos` will reduce numerical error. Forcing them to do `zp2sos(tf2zpk(b, a))` might make them think twice about why there isn't a `tf2sos` function. I'm interested to hear other opinions on this...?
3. `cplxpair` and `cplxreal`, which are helper functions for dealing with complex conjugate pairings.

Implementing `filtfilt`-equivalent functionality should be very easy, but I think we should tackle that with #3259 as opposed to adding another function here.

One other thing missing is `lfiltic`-equivalent functionality. This will require some state-space gymnastics that I haven't managed to solve (despite some effort). I'll try to figure it out, but I think that could be left to a subsequent PR, especially since this one is already pretty big.
