### PR TITLE
address svds returning nans for zero input matrix

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1570,6 +1570,30 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     return params.extract(return_eigenvectors)
 
 
+def _augmented_orthonormal_cols(x, k):
+    # extract the shape of the x array
+    n, m = x.shape
+    # create the expanded array and copy x into it
+    y = np.empty((n, m+k), dtype=x.dtype)
+    y[:, :m] = x
+    # do some modified gram schmidt to add k random orthonormal vectors
+    for i in range(k):
+        # sample a random initial vector
+        v = np.random.randn(n)
+        if np.iscomplexobj(x):
+            v += 1j*np.random.randn(n)
+        # subtract projections onto the existing unit length vectors
+        for j in range(m+i):
+            u = y[:, j]
+            v -= (np.inner(u, v) / np.inner(u, u)) * u
+        # normalize v
+        v /= np.linalg.norm(v)
+        # add v into the output array
+        y[:, m+i] = v
+    # return the expanded array
+    return y
+
+
 def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
          maxiter=None, return_singular_vectors=True):
     """Compute the largest k singular values/vectors for a sparse matrix.
@@ -1628,10 +1652,8 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
     if np.issubdtype(A.dtype, np.complexfloating):
         herm = lambda x: x.T.conjugate()
-        eigensolver = eigs
     else:
         herm = lambda x: x.T
-        eigensolver = eigsh
 
     if n > m:
         X = A
@@ -1646,23 +1668,63 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     XH_X = LinearOperator(matvec=matvec_XH_X, dtype=X.dtype,
                           shape=(X.shape[1], X.shape[1]))
 
-    if return_singular_vectors:
-        eigvals, eigvec = eigensolver(XH_X, k=k, tol=tol ** 2, maxiter=maxiter,
-                                      ncv=ncv, which=which, v0=v0)
-        s = np.sqrt(eigvals)
-    else:
-        eigvals = eigensolver(XH_X, k=k, tol=tol ** 2, maxiter=maxiter,
-                              ncv=ncv, which=which, v0=v0,
-                              return_eigenvectors=False)
-        s = np.sqrt(eigvals)
-        return s
+    # Get a low rank approximation of the implicitly defined gramian matrix.
+    # This is not a stable way to approach the problem.
+    eigvals, eigvec = eigsh(XH_X, k=k, tol=tol ** 2, maxiter=maxiter,
+                                  ncv=ncv, which=which, v0=v0)
 
-    if n > m:
-        v = eigvec
-        u = X.dot(v) / s
-        vh = herm(v)
+    # In 'LM' mode try to be clever about small eigenvalues.
+    # Otherwise in 'SM' mode do not try to be clever.
+    if which == 'LM':
+
+        # Gramian matrices have real non-negative eigenvalues.
+        eigvals = np.maximum(eigvals.real, 0)
+
+        # Copy the sophisticated detection of small eigenvalues from pinvh.
+        cond = None
+        rcond = None
+        if rcond is not None:
+            cond = rcond
+        if cond in [None, -1]:
+            t = eigvec.dtype.char.lower()
+            factor = {'f': 1E3, 'd': 1E6}
+            cond = factor[t] * np.finfo(t).eps
+        cutoff = cond * np.max(eigvals)
+
+        # Get a mask indicating which eigenpairs are not degenerately tiny,
+        # and create the re-ordered array of thresholded singular values.
+        above_cutoff = (eigvals > cutoff)
+        nlarge = above_cutoff.sum()
+        nsmall = k - nlarge
+        slarge = np.sqrt(eigvals[above_cutoff])
+        s = np.zeros_like(eigvals)
+        s[:nlarge] = slarge
+        if not return_singular_vectors:
+            return s
+
+        if n > m:
+            vlarge = eigvec[:, above_cutoff]
+            ularge = X.dot(vlarge) / slarge
+            v = _augmented_orthonormal_cols(vlarge, nsmall)
+            u = herm(_augmented_orthonormal_cols(herm(ularge), nsmall))
+            vh = herm(v)
+        else:
+            ularge = eigvec[:, above_cutoff]
+            vhlarge = herm(X.dot(ularge) / slarge)
+            u = _augmented_orthonormal_cols(ularge, nsmall)
+            vh = herm(_augmented_orthonormal_cols(herm(vhlarge), nsmall))
+
     else:
-        u = eigvec
-        vh = herm(X.dot(u) / s)
+
+        s = np.sqrt(eigvals)
+        if not return_singular_vectors:
+            return s
+        if n > m:
+            v = eigvec
+            u = X.dot(v) / s
+            vh = herm(v)
+        else:
+            u = eigvec
+            vh = herm(X.dot(u) / s)
 
     return u, s, vh

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -643,23 +643,23 @@ def _check_svds(A, k, U, s, VH):
     n, m = A.shape
 
     # Check shapes.
-    yield assert_equal, U.shape, (n, k)
-    yield assert_equal, s.shape, (k,)
-    yield assert_equal, VH.shape, (k, m)
+    assert_equal(U.shape, (n, k))
+    assert_equal(s.shape, (k,))
+    assert_equal(VH.shape, (k, m))
 
     # Check that the original matrix can be reconstituted.
     A_rebuilt = (U*s).dot(VH)
-    yield assert_equal, A_rebuilt.shape, A.shape
-    yield assert_allclose, A_rebuilt, A
+    assert_equal(A_rebuilt.shape, A.shape)
+    assert_allclose(A_rebuilt, A)
 
     # Check that U is a semi-orthogonal matrix.
     UH_U = np.dot(U.T.conj(), U)
-    yield assert_equal, UH_U.shape, (k, k)
+    assert_equal(UH_U.shape, (k, k))
     assert_allclose(UH_U, np.identity(k), atol=1e-12)
 
     # Check that V is a semi-orthogonal matrix.
     VH_V = np.dot(VH, VH.T.conj())
-    yield assert_equal, VH_V.shape, (k, k)
+    assert_equal(VH_V.shape, (k, k))
     assert_allclose(VH_V, np.identity(k), atol=1e-12)
 
 
@@ -672,13 +672,12 @@ def test_svd_LM_ones_matrix():
             U, s, VH = svds(A, k)
 
             # Check some generic properties of svd.
-            for condition in _check_svds(A, k, U, s, VH):
-                yield condition
+            _check_svds(A, k, U, s, VH)
 
             # Check that the largest singular value is near sqrt(n*m)
             # and the other singular values have been forced to zero.
-            yield assert_allclose, np.max(s), np.sqrt(n*m)
-            yield assert_array_equal, sorted(s)[:-1], 0
+            assert_allclose(np.max(s), np.sqrt(n*m))
+            assert_array_equal(sorted(s)[:-1], 0)
 
 
 def test_svd_LM_zeros_matrix():
@@ -690,11 +689,10 @@ def test_svd_LM_zeros_matrix():
             U, s, VH = svds(A, k)
 
             # Check some generic properties of svd.
-            for condition in _check_svds(A, k, U, s, VH):
-                yield condition
+            _check_svds(A, k, U, s, VH)
 
             # Check that the singular values are zero.
-            yield assert_array_equal, s, 0
+            assert_array_equal(s, 0)
 
 
 def test_svd_LM_zeros_matrix_gh_3452():
@@ -706,11 +704,10 @@ def test_svd_LM_zeros_matrix_gh_3452():
     U, s, VH = svds(A, k)
 
     # Check some generic properties of svd.
-    for condition in _check_svds(A, k, U, s, VH):
-        yield condition
+    _check_svds(A, k, U, s, VH)
 
     # Check that the singular values are zero.
-    yield assert_array_equal, s, 0
+    assert_array_equal(s, 0)
 
 
 if __name__ == "__main__":

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from numpy.testing import assert_allclose, \
         assert_array_almost_equal_nulp, TestCase, run_module_suite, dec, \
-        assert_raises, verbose, assert_equal
+        assert_raises, verbose, assert_equal, assert_array_equal
 
 from numpy import array, finfo, argsort, dot, round, conj, random
 from scipy.linalg import eig, eigh
@@ -637,6 +637,80 @@ def test_svd_v0():
     u2, s2, vh2 = svds(x, 1, v0=u[:,0])
 
     assert_allclose(s, s2, atol=np.sqrt(1e-15))
+
+
+def _check_svds(A, k, U, s, VH):
+    n, m = A.shape
+
+    # Check shapes.
+    yield assert_equal, U.shape, (n, k)
+    yield assert_equal, s.shape, (k,)
+    yield assert_equal, VH.shape, (k, m)
+
+    # Check that the original matrix can be reconstituted.
+    A_rebuilt = (U*s).dot(VH)
+    yield assert_equal, A_rebuilt.shape, A.shape
+    yield assert_allclose, A_rebuilt, A
+
+    # Check that U is a semi-orthogonal matrix.
+    UH_U = np.dot(U.T.conj(), U)
+    yield assert_equal, UH_U.shape, (k, k)
+    assert_allclose(UH_U, np.identity(k), atol=1e-12)
+
+    # Check that V is a semi-orthogonal matrix.
+    VH_V = np.dot(VH, VH.T.conj())
+    yield assert_equal, VH_V.shape, (k, k)
+    assert_allclose(VH_V, np.identity(k), atol=1e-12)
+
+
+def test_svd_LM_ones_matrix():
+    # Check that svds can deal with matrix_rank less than k in LM mode.
+    k = 3
+    for n, m in (6, 5), (5, 5), (5, 6):
+        for t in float, complex:
+            A = np.ones((n, m), dtype=t)
+            U, s, VH = svds(A, k)
+
+            # Check some generic properties of svd.
+            for condition in _check_svds(A, k, U, s, VH):
+                yield condition
+
+            # Check that the largest singular value is near sqrt(n*m)
+            # and the other singular values have been forced to zero.
+            yield assert_allclose, np.max(s), np.sqrt(n*m)
+            yield assert_array_equal, sorted(s)[:-1], 0
+
+
+def test_svd_LM_zeros_matrix():
+    # Check that svds can deal with matrices containing only zeros.
+    k = 1
+    for n, m in (3, 4), (4, 4), (4, 3):
+        for t in float, complex:
+            A = np.zeros((n, m), dtype=t)
+            U, s, VH = svds(A, k)
+
+            # Check some generic properties of svd.
+            for condition in _check_svds(A, k, U, s, VH):
+                yield condition
+
+            # Check that the singular values are zero.
+            yield assert_array_equal, s, 0
+
+
+def test_svd_LM_zeros_matrix_gh_3452():
+    # Regression test for a github issue.
+    # https://github.com/scipy/scipy/issues/3452
+    # Note that for complex dype the size of this matrix is too small for k=1.
+    n, m, k = 4, 2, 1
+    A = np.zeros((n, m))
+    U, s, VH = svds(A, k)
+
+    # Check some generic properties of svd.
+    for condition in _check_svds(A, k, U, s, VH):
+        yield condition
+
+    # Check that the singular values are zero.
+    yield assert_array_equal, s, 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fixes https://github.com/scipy/scipy/issues/3452 and passes sparse.linalg tests locally
