### PR TITLE
BUG: cast pchip arguments to floats

### DIFF
--- a/scipy/interpolate/_monotone.py
+++ b/scipy/interpolate/_monotone.py
@@ -60,7 +60,12 @@ class PchipInterpolator(object):
     """
     def __init__(self, x, y, axis=0, extrapolate=None):
         x = np.asarray(x)
+        if not np.issubdtype(x.dtype, np.inexact):
+            x = x.astype(float)
+
         y = np.asarray(y)
+        if not np.issubdtype(y.dtype, np.inexact):
+            y = y.astype(float)
 
         axis = axis % y.ndim
         

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -464,5 +464,17 @@ class TestPCHIP(TestCase):
             yp = p(xp)
             assert_(((y2-y1) * (yp[1:] - yp[:1]) > 0).all())
 
+    def test_cast(self):
+        # regression test for integer input data, see gh-3453
+        data = np.array([[0, 4, 12, 27, 47, 60, 79, 87, 99, 100],
+                         [-33, -33, -19, -2, 12, 26, 38, 45, 53, 55]])
+        xx = np.arange(100)
+        curve = pchip(data[0], data[1])(xx)
+
+        data1 = data * 1.0
+        curve1 = pchip(data1[0], data1[1])(xx)
+
+        assert_allclose(curve, curve1, atol=1e-14, rtol=1e-14)
+
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
As noted in https://github.com/scipy/scipy/issues/3453#issuecomment-45812768, `pchip` interpolator goes nuts when given integer input. This PR makes sure the arguments are cast to floats. 
