### PR TITLE
stub out inherited methods of Akima1DInterpolator

### DIFF
--- a/scipy/interpolate/_monotone.py
+++ b/scipy/interpolate/_monotone.py
@@ -327,3 +327,17 @@ class Akima1DInterpolator(PPoly):
     def extend(self):
         raise NotImplementedError("Extending a 1D Akima interpolator is not "
                 "yet implemented")
+
+    # These are inherited from PPoly, but they do not produce an Akima
+    # interpolor. Hence stub them out.
+    @classmethod    
+    def from_spline(cls, tck, extrapolate=None):
+        raise NotImplementedError("This method does not make sense for "
+                "an Akima interpolator.")
+
+    @classmethod
+    def from_bernstein_basis(cls, bp, extrapolate=None):
+        raise NotImplementedError("This method does not make sense for "
+                "an Akima interpolator.")
+
+    

--- a/scipy/interpolate/_monotone.py
+++ b/scipy/interpolate/_monotone.py
@@ -38,6 +38,10 @@ class PchipInterpolator(object):
     __call__
     derivative
 
+    See Also
+    --------
+    Akima1DInterpolator
+
     Notes
     -----
     The first derivatives are guaranteed to be continuous, but the second
@@ -257,6 +261,10 @@ class Akima1DInterpolator(PPoly):
     Methods
     -------
     __call__
+
+    See Also
+    --------
+    PchipInterpolator
 
     Notes
     -----


### PR DESCRIPTION
As it stands, `Akima1DInterpolator.from_spline` does not create an Akima interpolant --- it just creates a pp representation of its spline argument instead. 
Both `from_spline` and `from_bernstein_basis` are artifacts of inheritance from PPoly, hence stub them out with NotImplementedErrors.
(cross-ref  gh-3742) 

Also cross-reference  Akima1D and Pchip interpolators in the docs, while I'm at it.
