### PR TITLE
MAINT: reinstate symeig but with deprecation decorator

### DIFF
--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -23,6 +23,11 @@ from scipy.sparse.linalg import aslinearoperator, LinearOperator
 __all__ = ['lobpcg']
 
 
+@np.deprecate(new_name='eigh')
+def symeig(mtxA, mtxB=None, select=None):
+    return eigh(mtxA, b=mtxB, eigvals=select)
+
+
 def pause():
     # Used only when verbosity level > 10.
     input()


### PR DESCRIPTION
Fully removing `symeig` in https://github.com/scipy/scipy/pull/3599 was premature, causing downstream problems e.g.
https://github.com/rmcgibbo/mixtape/issues/180
https://github.com/scikit-learn/scikit-learn/issues/3177

I've put it back in with a deprecation decorator.  However, I'm not able to see any deprecation warning when I use it, but maybe this is a separate issue.
