### PR TITLE
MAINT: avoid indexing with a float array

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3156,8 +3156,8 @@ def theilslopes(y, x=None, alpha=0.95):
                      np.sum(k * (k-1) * (2*k + 5) for k in nyreps))
     # Find the confidence interval indices in `slopes`
     sigma = np.sqrt(sigsq)
-    Ru = min(np.round((nt - z*sigma)/2.), len(slopes)-1)
-    Rl = max(np.round((nt + z*sigma)/2.) - 1, 0)
+    Ru = min(int(np.round((nt - z*sigma)/2.)), len(slopes)-1)
+    Rl = max(int(np.round((nt + z*sigma)/2.)) - 1, 0)
     delta = slopes[[Rl, Ru]]
     return medslope, medinter, delta[0], delta[1]
 


### PR DESCRIPTION
Avoids `IndexError: non integer (and non boolean) array-likes will not be accepted as in
dices in the future`.  Perhaps this error occurs only with a new version or even only the development version of numpy.
