### PR TITLE
Parameter for coloring dendrogram above threshold

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2267,7 +2267,7 @@ def _dendrogram_calculate_info(Z, p, truncate_mode,
                                leaf_label_func=None, level=0,
                                contraction_marks=None,
                                link_color_func=None,
-                               abv_threshold_color='k'):
+                               abv_threshold_color='b'):
     """
     Calculates the endpoints of the links as well as the labels for the
     the dendrogram rooted at the node with index i. iv is the independent

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2183,7 +2183,8 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
         currently_below_threshold=currently_below_threshold,
         leaf_label_func=leaf_label_func,
         contraction_marks=contraction_marks,
-        link_color_func=link_color_func)
+        link_color_func=link_color_func,
+        abv_threshold_color=abv_threshold_color)
 
     if not no_plot:
         mh = max(Z[:, 2])
@@ -2265,7 +2266,8 @@ def _dendrogram_calculate_info(Z, p, truncate_mode,
                                currently_below_threshold=[],
                                leaf_label_func=None, level=0,
                                contraction_marks=None,
-                               link_color_func=None):
+                               link_color_func=None,
+                               abv_threshold_color='k'):
     """
     Calculates the endpoints of the links as well as the labels for the
     the dendrogram rooted at the node with index i. iv is the independent
@@ -2436,11 +2438,12 @@ def _dendrogram_calculate_info(Z, p, truncate_mode,
             currently_below_threshold=currently_below_threshold,
             leaf_label_func=leaf_label_func,
             level=level + 1, contraction_marks=contraction_marks,
-            link_color_func=link_color_func)
+            link_color_func=link_color_func,
+            abv_threshold_color=abv_threshold_color)
 
     h = Z[i - n, 2]
     if h >= color_threshold or color_threshold <= 0:
-        c = 'b'
+        c = abv_threshold_color
 
         if currently_below_threshold[0]:
             current_color[0] = (current_color[0] + 1) % len(_link_line_colors)
@@ -2468,7 +2471,8 @@ def _dendrogram_calculate_info(Z, p, truncate_mode,
             currently_below_threshold=currently_below_threshold,
             leaf_label_func=leaf_label_func,
             level=level + 1, contraction_marks=contraction_marks,
-            link_color_func=link_color_func)
+            link_color_func=link_color_func,
+            abv_threshold_color=abv_threshold_color)
 
     max_dist = max(uamd, ubmd, h)
 

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1686,7 +1686,7 @@ def _get_tick_rotation(p):
 def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
                      no_labels, color_list, leaf_font_size=None,
                      leaf_rotation=None, contraction_marks=None,
-                     ax=None):
+                     ax=None, abv_threshold_color='b'):
     # Import matplotlib here so that it's not imported unless dendrograms
     # are plotted. Raise an informative error if importing fails.
     try:
@@ -1830,16 +1830,15 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
                                                      colors=(color,))
         colors_to_collections[color] = coll
 
-    # Add all the non-blue link groupings, i.e. those groupings below the
-    # color threshold.
+    # Add all the groupings below the color threshold.
 
     for color in colors_used:
-        if color != 'b':
+        if color != abv_threshold_color:
             ax.add_collection(colors_to_collections[color])
-    # If there is a blue grouping (i.e., links above the color threshold),
+    # If there is a grouping of links above the color threshold,
     # it should go last.
-    if 'b' in colors_to_collections:
-        ax.add_collection(colors_to_collections['b'])
+    if abv_threshold_color in colors_to_collections:
+        ax.add_collection(colors_to_collections[abv_threshold_color])
 
     if contraction_marks is not None:
         if orientation in ('left', 'right'):
@@ -1896,7 +1895,7 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
                no_plot=False, no_labels=False, color_list=None,
                leaf_font_size=None, leaf_rotation=None, leaf_label_func=None,
                no_leaves=False, show_contracted=False,
-               link_color_func=None, ax=None):
+               link_color_func=None, ax=None, abv_threshold_color='b'):
     """
     Plots the hierarchical clustering as a dendrogram.
 
@@ -2075,6 +2074,9 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
         on the current axes.  Otherwise if `no_plot` is not True the
         dendrogram will be plotted on the given ``Axes`` instance. This can be
         useful if the dendrogram is part of a more complex figure.
+    abv_threshold_color : str, optional
+        This matplotlib color string sets the color of the links above the
+        color_threshold. The default is 'b'.
 
     Returns
     -------
@@ -2182,13 +2184,16 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
         leaf_label_func=leaf_label_func,
         contraction_marks=contraction_marks,
         link_color_func=link_color_func)
+
     if not no_plot:
         mh = max(Z[:, 2])
         _plot_dendrogram(icoord_list, dcoord_list, ivl, p, n, mh, orientation,
-                         no_labels, color_list, leaf_font_size=leaf_font_size,
+                         no_labels, color_list,
+                         leaf_font_size=leaf_font_size,
                          leaf_rotation=leaf_rotation,
                          contraction_marks=contraction_marks,
-                         ax=ax)
+                         ax=ax,
+                         abv_threshold_color=abv_threshold_color)
 
     return R
 


### PR DESCRIPTION
In the current code one can provide a color palette to be used for the clusters in `scipy.cluster.hierarchy.dendrogram` using the `set_link_color_palette` function in the same module. However, the parent tree, above the color threshold for clusters, is hard coded to the matplotlib color string `'b'.

This patch adds a parameter to `dendrogram` called `abv_threshold_color`, default still set to `'b'`, which changes this color.

As an example, I've attached an image where the parameter is set to `'lightgrey'`.
![figure_1](https://cloud.githubusercontent.com/assets/668803/3421603/a36b824e-fef5-11e3-8ad4-9d24aecff901.png)
