### PR TITLE
ENH: avoid repeated matrix inverse

### DIFF
--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -391,11 +391,12 @@ class gaussian_kde(object):
             large = other
 
         sum_cov = small.covariance + large.covariance
+        sum_cov_chol = linalg.cho_factor(sum_cov)
         result = 0.0
         for i in range(small.n):
             mean = small.dataset[:, i, newaxis]
             diff = large.dataset - mean
-            tdiff = dot(linalg.inv(sum_cov), diff)
+            tdiff = linalg.cho_solve(sum_cov_chol, diff)
 
             energies = sum(diff * tdiff, axis=0) / 2.0
             result += sum(exp(-energies), axis=0)


### PR DESCRIPTION
The `sum_cov` term doesn't change, so it's faster to use a factorized version and solve.

For proof, here's a quick before and after:

```
In [2]: a = np.random.random((20,2000))
In [3]: b = np.random.random((20,1500))
In [4]: kde_a = gaussian_kde(a)
In [5]: kde_b = gaussian_kde(b)
In [6]: %timeit kde_a.integrate_kde(kde_b)
1 loops, best of 3: 1.43 s per loop
```

And after (same setup code):

```
In [6]: %timeit kde_a.integrate_kde(kde_b)
1 loops, best of 3: 856 ms per loop
```
