### PR TITLE
BUG: signal: In lfilter_zi, b was not rescaled correctly when a[0] was not 1.

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1848,8 +1848,8 @@ def lfilter_zi(b, a):
 
     if a[0] != 1.0:
         # Normalize the coefficients so a[0] == 1.
-        a = a / a[0]
         b = b / a[0]
+        a = a / a[0]
 
     n = max(len(a), len(b))
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -813,6 +813,15 @@ class TestLFilterZI(TestCase):
         zi = lfilter_zi(b, a)
         assert_array_almost_equal(zi, zi_expected)
 
+    def test_scale_invariance(self):
+        # Regression test.  There was a bug in which b was not correctly
+        # rescaled when a[0] was nonzero.
+        b = np.array([2, 8, 5])
+        a = np.array([1, 1, 8])
+        zi1 = lfilter_zi(b, a)
+        zi2 = lfilter_zi(2*b, 2*a)
+        assert_allclose(zi2, zi1, rtol=1e-12)
+
 
 class TestFiltFilt(TestCase):
 


### PR DESCRIPTION
The problem was reported here: https://github.com/scipy/scipy/commit/8d4665f77ffab58d40ef712a36030450007b48e0#commitcomment-6889990
