### PR TITLE
ENH: Add ext parameter to UnivariateSpline call

### DIFF
--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -173,7 +173,7 @@ class UnivariateSpline(object):
         self._reset_class()
 
     @classmethod
-    def _from_tck(cls, tck, ext):
+    def _from_tck(cls, tck, ext=0):
         """Construct a spline object from given tck"""
         self = cls.__new__(cls)
         t, c, k = tck

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -61,6 +61,12 @@ if iopt=-1:
                     }
 
 
+# UnivariateSpline, ext parameter can be an int or a string
+_extrap_modes = {0: 0, 'extrapolate': 0,
+                 1: 1, 'zeros': 1,
+                 2: 2, 'raise': 2}
+
+
 class UnivariateSpline(object):
     """
     One-dimensional smoothing spline fit to a given set of data points.
@@ -91,13 +97,13 @@ class UnivariateSpline(object):
         If None (default), s=len(w) which should be a good value if 1/w[i] is
         an estimate of the standard deviation of y[i].  If 0, spline will
         interpolate through all data points.
-    ext : int, optional
-        Controls the extrapolation mode for elements 
-        not in the interval defined by the knot sequence            
-           
-        * if ext=0, return the extrapolated value.
-        * if ext=1, return 0
-        * if ext=2, raise a ValueError
+    ext : int or str, optional
+        Controls the extrapolation mode for elements
+        not in the interval defined by the knot sequence.
+
+        * if ext=0 or 'extrapolate', return the extrapolated value.
+        * if ext=1 or 'zeros', return 0
+        * if ext=2 or 'raise', raise a ValueError
 
         The default value is 0.
 
@@ -152,18 +158,20 @@ class UnivariateSpline(object):
                        if 1/w[i] is an estimate of the standard
                        deviation of y[i].
           ext        - Controls the extrapolation mode for elements 
-                       not in the interval defined by the knot sequence            
-                       
-                       * if ext=0, return the extrapolated value.
-                       * if ext=1, return 0
-                       * if ext=2, raise a ValueError
+                       not in the interval defined by the knot sequence.
+
+                       * if ext=0 or 'extrapolate', return the extrapolated value.
+                       * if ext=1 or 'zeros', return 0
+                       * if ext=2 or 'raise', raise a ValueError
 
                        The default value is 0.
         """
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
-        self.ext = ext
-        if ext not in (0, 1, 2):
-            raise ValueError("unknown extrapolation mode")
+        try:
+            self.ext = _extrap_modes[ext]
+        except KeyError:
+            raise ValueError("Unknown extrapolation mode %s." % ext)
+
         data = dfitpack.fpcurf0(x,y,k,w=w,
                                 xb=bbox[0],xe=bbox[1],s=s)
         if data[-1] == 1:
@@ -265,9 +273,9 @@ class UnivariateSpline(object):
             Controls the value returned for elements of ``x`` not in the
             interval defined by the knot sequence.
 
-            * if ext=0, return the extrapolated value.
-            * if ext=1, return 0
-            * if ext=2, raise a ValueError
+            * if ext=0 or 'extrapolate', return the extrapolated value.
+            * if ext=1 or 'zeros', return 0
+            * if ext=2 or 'raise', raise a ValueError
 
             The default value is 0, passed from the initialization of 
             UnivariateSpline.
@@ -281,6 +289,11 @@ class UnivariateSpline(object):
 #        return dfitpack.splder(nu=nu,*(self._eval_args+(x,)))
         if ext is None:
             ext = self.ext
+        else:
+            try:
+                ext = _extrap_modes[ext]
+            except KeyError:
+                raise ValueError("Unknown extrapolation mode %s." % ext)
         return fitpack.splev(x, self._eval_args, der=nu, ext=ext)
 
     def get_knots(self):
@@ -445,13 +458,13 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
         None (default), bbox=[x[0],x[-1]].
     k : int, optional
         Degree of the smoothing spline.  Must be 1 <= `k` <= 5.
-    ext : int, optional
+    ext : int or str, optional
         Controls the extrapolation mode for elements 
-        not in the interval defined by the knot sequence            
-           
-        * if ext=0, return the extrapolated value.
-        * if ext=1, return 0
-        * if ext=2, raise a ValueError
+        not in the interval defined by the knot sequence.
+
+        * if ext=0 or 'extrapolate', return the extrapolated value.
+        * if ext=1 or 'zeros', return 0
+        * if ext=2 or 'raise', raise a ValueError
 
         The default value is 0.
 
@@ -500,11 +513,11 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
                        By default, bbox=[x[0],x[-1]]
           k=3        - degree of the univariate spline.
           ext        - Controls the extrapolation mode for elements 
-                       not in the interval defined by the knot sequence            
-                       
-                       * if ext=0, return the extrapolated value.
-                       * if ext=1, return 0
-                       * if ext=2, raise a ValueError
+                       not in the interval defined by the knot sequence.
+
+                       * if ext=0 or 'extrapolate', return the extrapolated value.
+                       * if ext=1 or 'zeros', return 0
+                       * if ext=2 or 'raise', raise a ValueError
 
                        The default value is 0.
         """
@@ -512,9 +525,11 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
         self._data = dfitpack.fpcurf0(x,y,k,w=w,
                                       xb=bbox[0],xe=bbox[1],s=0)
         self._reset_class()
-        self.ext = ext
-        if ext not in (0, 1, 2):
-            raise ValueError("unknown extrapolation mode")
+
+        try:
+            self.ext = _extrap_modes[ext]
+        except KeyError:
+            raise ValueError("Unknown extrapolation mode %s." % ext)
 
 
 class LSQUnivariateSpline(UnivariateSpline):
@@ -541,13 +556,13 @@ class LSQUnivariateSpline(UnivariateSpline):
         None (default), bbox=[x[0],x[-1]].
     k : int, optional
         Degree of the smoothing spline.  Must be 1 <= `k` <= 5.
-    ext : int, optional
+    ext : int or str, optional
         Controls the extrapolation mode for elements 
-        not in the interval defined by the knot sequence            
-           
-        * if ext=0, return the extrapolated value.
-        * if ext=1, return 0
-        * if ext=2, raise a ValueError
+        not in the interval defined by the knot sequence.
+
+        * if ext=0 or 'extrapolate', return the extrapolated value.
+        * if ext=1 or 'zeros', return 0
+        * if ext=2 or 'raise', raise a ValueError
 
         The default value is 0.
 
@@ -606,11 +621,11 @@ class LSQUnivariateSpline(UnivariateSpline):
                        By default, bbox=[x[0],x[-1]]
           k=3        - degree of the univariate spline.
           ext        - Controls the extrapolation mode for elements 
-                       not in the interval defined by the knot sequence            
-                       
-                       * if ext=0, return the extrapolated value.
-                       * if ext=1, return 0
-                       * if ext=2, raise a ValueError
+                       not in the interval defined by the knot sequence.
+
+                       * if ext=0 or 'extrapolate', return the extrapolated value.
+                       * if ext=1 or 'zeros', return 0
+                       * if ext=2 or 'raise', raise a ValueError.
 
                        The default value is 0.
         """
@@ -629,9 +644,11 @@ class LSQUnivariateSpline(UnivariateSpline):
         data = dfitpack.fpcurfm1(x,y,k,t,w=w,xb=xb,xe=xe)
         self._data = data[:-3] + (None,None,data[-1])
         self._reset_class()
-        self.ext = ext
-        if ext not in (0, 1, 2):
-            raise ValueError("unknown extrapolation mode")
+
+        try:
+            self.ext = _extrap_modes[ext]
+        except KeyError:
+            raise ValueError("Unknown extrapolation mode %s." % ext)
 
 
 ################ Bivariate spline ####################

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -228,11 +228,28 @@ class UnivariateSpline(object):
         self._data = data
         self._reset_class()
 
-    def __call__(self, x, nu=0):
-        """ Evaluate spline (or its nu-th derivative) at positions x.
+    def __call__(self, x, nu=0, ext=0):
+        """ 
+        Evaluate spline (or its nu-th derivative) at positions x.
 
-        Note: x can be unordered but the evaluation is more efficient
-        if x is (partially) ordered.
+        Parameters
+        ----------
+        x : array_like
+            A 1-D array of points at which to return the value of the smoothed
+            spline or its derivatives. Note: x can be unordered but the 
+            evaluation is more efficient if x is (partially) ordered.
+        nu  : int
+            The order of derivative of the spline to compute.
+        ext : int
+            Controls the value returned for elements of ``x`` not in the
+            interval defined by the knot sequence.
+
+            * if ext=0, return the extrapolated value.
+            * if ext=1, return 0
+            * if ext=2, raise a ValueError
+
+            The default value is 0.
+
         """
         x = np.asarray(x)
         # empty input yields empty output
@@ -241,7 +258,7 @@ class UnivariateSpline(object):
 #        if nu is None:
 #            return dfitpack.splev(*(self._eval_args+(x,)))
 #        return dfitpack.splder(nu=nu,*(self._eval_args+(x,)))
-        return fitpack.splev(x, self._eval_args, der=nu)
+        return fitpack.splev(x, self._eval_args, der=nu, ext=ext)
 
     def get_knots(self):
         """ Return positions of (boundary and interior) knots of the spline.

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -173,7 +173,7 @@ class UnivariateSpline(object):
         self._reset_class()
 
     @classmethod
-    def _from_tck(cls, tck):
+    def _from_tck(cls, tck, ext):
         """Construct a spline object from given tck"""
         self = cls.__new__(cls)
         t, c, k = tck
@@ -181,6 +181,7 @@ class UnivariateSpline(object):
         #_data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         self._data = (None,None,None,None,None,k,None,len(t),t,
                       c,None,None,None,None)
+        self.ext = ext
         return self
 
     def _reset_class(self):
@@ -368,7 +369,7 @@ class UnivariateSpline(object):
 
         """
         tck = fitpack.splder(self._eval_args, n)
-        return UnivariateSpline._from_tck(tck)
+        return UnivariateSpline._from_tck(tck, self.ext)
 
     def antiderivative(self, n=1):
         """
@@ -419,7 +420,7 @@ class UnivariateSpline(object):
 
         """
         tck = fitpack.splantider(self._eval_args, n)
-        return UnivariateSpline._from_tck(tck)
+        return UnivariateSpline._from_tck(tck, self.ext)
 
 
 class InterpolatedUnivariateSpline(UnivariateSpline):
@@ -444,6 +445,15 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
         None (default), bbox=[x[0],x[-1]].
     k : int, optional
         Degree of the smoothing spline.  Must be 1 <= `k` <= 5.
+    ext : int, optional
+        Controls the extrapolation mode for elements 
+        not in the interval defined by the knot sequence            
+           
+        * if ext=0, return the extrapolated value.
+        * if ext=1, return 0
+        * if ext=2, raise a ValueError
+
+        The default value is 0.
 
     See Also
     --------
@@ -477,7 +487,7 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
 
     """
 
-    def __init__(self, x, y, w=None, bbox=[None]*2, k=3):
+    def __init__(self, x, y, w=None, bbox=[None]*2, k=3, ext=0):
         """
         Input:
           x,y   - 1-d sequences of data points (x must be
@@ -489,11 +499,22 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
                        the approximation interval.
                        By default, bbox=[x[0],x[-1]]
           k=3        - degree of the univariate spline.
+          ext        - Controls the extrapolation mode for elements 
+                       not in the interval defined by the knot sequence            
+                       
+                       * if ext=0, return the extrapolated value.
+                       * if ext=1, return 0
+                       * if ext=2, raise a ValueError
+
+                       The default value is 0.
         """
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         self._data = dfitpack.fpcurf0(x,y,k,w=w,
                                       xb=bbox[0],xe=bbox[1],s=0)
         self._reset_class()
+        self.ext = ext
+        if ext not in (0, 1, 2):
+            raise ValueError("unknown extrapolation mode")
 
 
 class LSQUnivariateSpline(UnivariateSpline):
@@ -520,6 +541,15 @@ class LSQUnivariateSpline(UnivariateSpline):
         None (default), bbox=[x[0],x[-1]].
     k : int, optional
         Degree of the smoothing spline.  Must be 1 <= `k` <= 5.
+    ext : int, optional
+        Controls the extrapolation mode for elements 
+        not in the interval defined by the knot sequence            
+           
+        * if ext=0, return the extrapolated value.
+        * if ext=1, return 0
+        * if ext=2, raise a ValueError
+
+        The default value is 0.
 
     Raises
     ------
@@ -560,7 +590,7 @@ class LSQUnivariateSpline(UnivariateSpline):
 
     """
 
-    def __init__(self, x, y, t, w=None, bbox=[None]*2, k=3):
+    def __init__(self, x, y, t, w=None, bbox=[None]*2, k=3, ext=0):
         """
         Input:
           x,y   - 1-d sequences of data points (x must be
@@ -575,6 +605,14 @@ class LSQUnivariateSpline(UnivariateSpline):
                        the approximation interval.
                        By default, bbox=[x[0],x[-1]]
           k=3        - degree of the univariate spline.
+          ext        - Controls the extrapolation mode for elements 
+                       not in the interval defined by the knot sequence            
+                       
+                       * if ext=0, return the extrapolated value.
+                       * if ext=1, return 0
+                       * if ext=2, raise a ValueError
+
+                       The default value is 0.
         """
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         xb = bbox[0]
@@ -591,6 +629,9 @@ class LSQUnivariateSpline(UnivariateSpline):
         data = dfitpack.fpcurfm1(x,y,k,t,w=w,xb=xb,xe=xe)
         self._data = data[:-3] + (None,None,data[-1])
         self._reset_class()
+        self.ext = ext
+        if ext not in (0, 1, 2):
+            raise ValueError("unknown extrapolation mode")
 
 
 ################ Bivariate spline ####################

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -79,19 +79,15 @@ class TestUnivariateSpline(TestCase):
         assert_allclose(spl([0.1, 0.5, 0.9, 0.99]), desired, atol=5e-4)
 
     def test_out_of_range_regression(self):
-        """Regression test for #3557."""
-        x_in_range = [-3., -2.33333333, -1.66666667, -1., -0.33333333,
-                      0.33333333, 1., 1.66666667, 2.33333333, 3.]
-        x_out_of_range = [-3.66666667, -3., -2.33333333, -1.66666667, -1.,
-                          -0.33333333, 0.33333333, 1., 1.66666667, 2.33333333,
-                          3., 3.66666667]
-        y = [-0.03443365, 0.02969204, 0.16251805, 0.33279394, 1.07995049, 
-             0.88203547,  0.31274008, -0.10215527, -0.0274716, -0.06661292]
-        desired = array([0., -0.21332128, 0.16590419, 0.41822373, 0.55728419,
-                         0.59673238, 0.55021514, 0.43137928, 0.25387164, 
-                         0.03133904, -0.22257169, 0.])
-        spl = UnivariateSpline(x=x_in_range, y=y)
-        assert_allclose(spl(x_out_of_range, ext=1), desired, atol=5e-4)
+        # Test different extrapolation modes. See ticket 3557
+        x = np.arange(5, dtype=np.float)
+        y = x ** 3
+        spl = UnivariateSpline(x=x, y=y)
+        xp = linspace(-8, 13, 100)
+        xp_zeros = xp.copy()
+        xp_zeros[np.logical_or(xp_zeros < 0., xp_zeros > 4.)] = 0
+        assert_allclose(spl(xp, ext=0), xp**3, atol=1e-16)
+        assert_allclose(spl(xp, ext=1), xp_zeros**3, atol=1e-16)
 
     def test_derivative_and_antiderivative(self):
         # Thin wrappers to splder/splantider, so light smoke test only.

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -78,6 +78,21 @@ class TestUnivariateSpline(TestCase):
         desired = array([0.35100374, 0.51715855, 0.87789547, 0.98719344])
         assert_allclose(spl([0.1, 0.5, 0.9, 0.99]), desired, atol=5e-4)
 
+    def test_out_of_range_regression(self):
+        """Regression test for #3557."""
+        x_in_range = [-3., -2.33333333, -1.66666667, -1., -0.33333333,
+                      0.33333333, 1., 1.66666667, 2.33333333, 3.]
+        x_out_of_range = [-3.66666667, -3., -2.33333333, -1.66666667, -1.,
+                          -0.33333333, 0.33333333, 1., 1.66666667, 2.33333333,
+                          3., 3.66666667]
+        y = [-0.03443365, 0.02969204, 0.16251805, 0.33279394, 1.07995049, 
+             0.88203547,  0.31274008, -0.10215527, -0.0274716, -0.06661292]
+        desired = array([0., -0.21332128, 0.16590419, 0.41822373, 0.55728419,
+                         0.59673238, 0.55021514, 0.43137928, 0.25387164, 
+                         0.03133904, -0.22257169, 0.])
+        spl = UnivariateSpline(x=x_in_range, y=y)
+        assert_allclose(spl(x_out_of_range, ext=1), desired, atol=5e-4)
+
     def test_derivative_and_antiderivative(self):
         # Thin wrappers to splder/splantider, so light smoke test only.
         x = np.linspace(0, 1, 70)**3


### PR DESCRIPTION
Pass parameter to fitpack.splev to control how to handle out of range
evaluations. Added test to scipy/interpolate/tests/test_fitpack2.py.

See ticket 3557.

closes gh-3557
