### PR TITLE
DOC: edit scipy.optimize.show_options parameters

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2683,8 +2683,10 @@ def show_options(solver=None, method=None):
             define the limited memory matrix. (The limited memory BFGS
             method does not store the full hessian but uses this many terms
             in an approximation to it.)
-        maxiter : int
+        maxfun : int
             Maximum number of function evaluations.
+        maxiter : int
+            Maximum number of iterations.
 
     *TNC* options:
 


### PR DESCRIPTION
Add maxfun parameter to output of parameters for L-BFGS-B. Fix maxiter
description. See ticket 3760.

closes gh-3760
