### PR TITLE
Incbet fix

### DIFF
--- a/scipy/special/cephes/beta.c
+++ b/scipy/special/cephes/beta.c
@@ -52,7 +52,7 @@
 #include "mconf.h"
 
 #ifdef UNK
-#define MAXGAM 34.84425627277176174
+#define MAXGAM 171.624376956302725
 #endif
 #ifdef DEC
 #define MAXGAM 34.84425627277176174
@@ -131,16 +131,18 @@ double a, b;
     }
 
     y = Gamma(y);
+    a = Gamma(a);
+    b = Gamma(b);
     if (y == 0.0)
 	goto over;
 
-    if (a > b) {
-	y = Gamma(a) / y;
-	y *= Gamma(b);
+    if (fabs(fabs(a) - fabs(y)) > fabs(fabs(b) - fabs(y))) {
+        y = b / y;
+        y *= a;
     }
     else {
-	y = Gamma(b) / y;
-	y *= Gamma(a);
+        y = a / y;
+        y *= b;
     }
 
     return (y);
@@ -203,19 +205,21 @@ double a, b;
     }
 
     y = Gamma(y);
+    a = Gamma(a);
+    b = Gamma(b);
     if (y == 0.0) {
       over:
 	mtherr("lbeta", OVERFLOW);
 	return (sign * NPY_INFINITY);
     }
 
-    if (a > b) {
-	y = Gamma(a) / y;
-	y *= Gamma(b);
+    if (fabs(fabs(a) - fabs(y)) > fabs(fabs(b) - fabs(y))) {
+        y = b / y;
+        y *= a;
     }
     else {
-	y = Gamma(b) / y;
-	y *= Gamma(a);
+        y = a / y;
+        y *= b;
     }
 
     if (y < 0) {

--- a/scipy/special/cephes/incbet.c
+++ b/scipy/special/cephes/incbet.c
@@ -141,11 +141,11 @@ double aa, bb, xx;
 	t *= pow(x, a);
 	t /= a;
 	t *= w;
-	t *= Gamma(a + b) / (Gamma(a) * Gamma(b));
+	t *= 1.0 / beta(a, b);
 	goto done;
     }
     /* Resort to logarithms.  */
-    y += t + lgam(a + b) - lgam(a) - lgam(b);
+    y += t - lbeta(a,b);
     y += log(w / a);
     if (y < MINLOG)
 	t = 0.0;
@@ -366,11 +366,11 @@ double a, b, x;
 
     u = a * log(x);
     if ((a + b) < MAXGAM && fabs(u) < MAXLOG) {
-	t = Gamma(a + b) / (Gamma(a) * Gamma(b));
+        t = 1.0 / beta(a, b); 
 	s = s * t * pow(x, a);
     }
     else {
-	t = lgam(a + b) - lgam(a) - lgam(b) + u + log(s);
+	t = -lbeta(a,b) + u + log(s);
 	if (t < MINLOG)
 	    s = 0.0;
 	else

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -144,6 +144,7 @@ class TestCephes(TestCase):
 
     def test_betainc(self):
         assert_equal(cephes.betainc(1,1,1),1.0)
+        assert_allclose(cephes.betainc(0.0342, 171, 1e-10), 0.55269916901806648)
 
     def test_betaln(self):
         assert_equal(cephes.betaln(1,1),0.0)
@@ -152,6 +153,7 @@ class TestCephes(TestCase):
 
     def test_betaincinv(self):
         assert_equal(cephes.betaincinv(1,1,1),1.0)
+        assert_allclose(cephes.betaincinv(0.0342, 171, 0.25), 8.4231316935498957e-21, rtol=1e-12, atol=0)
 
     def test_beta_inf(self):
         assert_(np.isinf(special.beta(-1, 2)))

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -139,12 +139,16 @@ class TestCephes(TestCase):
 
     def test_beta(self):
         assert_equal(cephes.beta(1,1),1.0)
+        assert_allclose(cephes.beta(-100.3, 1e-200), cephes.gamma(1e-200))
+        assert_allclose(cephes.beta(0.0342, 171), 24.070498359873497, rtol=1e-14, atol=0)
 
     def test_betainc(self):
         assert_equal(cephes.betainc(1,1,1),1.0)
 
     def test_betaln(self):
         assert_equal(cephes.betaln(1,1),0.0)
+        assert_allclose(cephes.betaln(-100.3, 1e-200), cephes.gammaln(1e-200))
+        assert_allclose(cephes.betaln(0.0342, 170), 3.1811881124242447, rtol=1e-14, atol=0)
 
     def test_betaincinv(self):
         assert_equal(cephes.betaincinv(1,1,1),1.0)


### PR DESCRIPTION
Fixes #3761. 

The problem is that the incomplete beta function needs to calculate the beta function but was doing so semi poorly. It should just be calling the beta function since that is where we try pretty hard to calculate it well for all values.  Secondly, the value of the constant MAXGAM used in beta.c was too small.  This compromised the results for moderately sized inputs.  I also changed how we decide what order to evaluate the ratio of gammas since this fixes some failures revealed by the increased MAXGAM. 
