### PR TITLE
BUG: Fix lombscargle ZeroDivisionError

### DIFF
--- a/scipy/signal/_spectral.pyx
+++ b/scipy/signal/_spectral.pyx
@@ -13,7 +13,7 @@ __all__ = ['lombscargle']
 cdef extern from "math.h":
     double cos(double)
     double sin(double)
-    double atan(double)
+    double atan2(double, double)
 
 @cython.boundscheck(False)
 def lombscargle(np.ndarray[np.float64_t, ndim=1] x,
@@ -154,7 +154,7 @@ def lombscargle(np.ndarray[np.float64_t, ndim=1] x,
             ss += s * s
             cs += c * s
 
-        tau = atan(2 * cs / (cc - ss)) / (2 * freqs[i])
+        tau = atan2(2 * cs, cc - ss) / (2 * freqs[i])
         c_tau = cos(freqs[i] * tau)
         s_tau = sin(freqs[i] * tau)
         c_tau2 = c_tau * c_tau


### PR DESCRIPTION
Change calculation of tau to use atan2 function instead of atan.

closes gh-3787
