### PR TITLE
DOC: scipy.special.legendre docstring

### DIFF
--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -175,7 +175,7 @@ def gen_roots_and_weights(n, an_func, sqrt_bn_func, mu):
 # Jacobi Polynomials 1               P^(alpha,beta)_n(x)
 
 
-def j_roots(n, alpha, beta, mu=0):
+def j_roots(n, alpha, beta, mu=False):
     """[x,w] = j_roots(n,alpha,beta)
 
     Returns the roots (x) of the nth order Jacobi polynomial, P^(alpha,beta)_n(x)
@@ -222,7 +222,7 @@ def jacobi(n, alpha, beta, monic=False):
     if n == 0:
         return orthopoly1d([],[],1.0,1.0,wfunc,(-1,1),monic,
                            eval_func=np.ones_like)
-    x,w,mu = j_roots(n,alpha,beta,mu=1)
+    x,w,mu = j_roots(n,alpha,beta,mu=True)
     ab1 = alpha+beta+1.0
     hn = 2**ab1/(2*n+ab1)*_gam(n+alpha+1)
     hn *= _gam(n+beta+1.0) / _gam(n+1) / _gam(n+ab1)
@@ -235,7 +235,7 @@ def jacobi(n, alpha, beta, monic=False):
 # Jacobi Polynomials shifted         G_n(p,q,x)
 
 
-def js_roots(n, p1, q1, mu=0):
+def js_roots(n, p1, q1, mu=False):
     """[x,w] = js_roots(n,p,q)
 
     Returns the roots (x) of the nth order shifted Jacobi polynomial, G_n(p,q,x),
@@ -268,7 +268,7 @@ def js_roots(n, p1, q1, mu=0):
         return val
     # What code would look like using jacobi polynomial roots
     #if mu:
-    #    [x,w,mut] = j_roots(n,p-q,q-1,mu=1)
+    #    [x,w,mut] = j_roots(n,p-q,q-1,mu=True)
     #    return [(x+1)/2.0,w,mu0]
     #else:
     #    [x,w] = j_roots(n,p-q,q-1,mu=0)
@@ -288,7 +288,7 @@ def sh_jacobi(n, p, q, monic=False):
         return orthopoly1d([],[],1.0,1.0,wfunc,(-1,1),monic,
                            eval_func=np.ones_like)
     n1 = n
-    x,w,mu0 = js_roots(n1,p,q,mu=1)
+    x,w,mu0 = js_roots(n1,p,q,mu=True)
     hn = _gam(n+1)*_gam(n+q)*_gam(n+p)*_gam(n+p-q+1)
     hn /= (2*n+p)*(_gam(2*n+p)**2)
     # kn = 1.0 in standard form so monic is redundant.  Kept for compatibility.
@@ -300,7 +300,7 @@ def sh_jacobi(n, p, q, monic=False):
 # Generalized Laguerre               L^(alpha)_n(x)
 
 
-def la_roots(n, alpha, mu=0):
+def la_roots(n, alpha, mu=False):
     """[x,w] = la_roots(n,alpha)
 
     Returns the roots (x) of the nth order generalized (associated) Laguerre
@@ -337,7 +337,7 @@ def genlaguerre(n, alpha, monic=False):
         n1 = n+1
     else:
         n1 = n
-    x,w,mu0 = la_roots(n1,alpha,mu=1)
+    x,w,mu0 = la_roots(n1,alpha,mu=True)
     wfunc = lambda x: exp(-x) * x**alpha
     if n == 0:
         x,w = [],[]
@@ -350,7 +350,7 @@ def genlaguerre(n, alpha, monic=False):
 # Laguerre                      L_n(x)
 
 
-def l_roots(n, mu=0):
+def l_roots(n, mu=False):
     """[x,w] = l_roots(n)
 
     Returns the roots (x) of the nth order Laguerre polynomial, L_n(x),
@@ -371,7 +371,7 @@ def laguerre(n, monic=False):
         n1 = n+1
     else:
         n1 = n
-    x,w,mu0 = l_roots(n1,mu=1)
+    x,w,mu0 = l_roots(n1,mu=True)
     if n == 0:
         x,w = [],[]
     hn = 1.0
@@ -414,7 +414,7 @@ def _h_gen_roots_and_weights(n, mu, factor, func):
         return x, w
 
 
-def h_roots(n, mu=0):
+def h_roots(n, mu=False):
     """[x,w] = h_roots(n)
 
     Returns the roots (x) of the nth order Hermite polynomial,
@@ -435,7 +435,7 @@ def hermite(n, monic=False):
         n1 = n+1
     else:
         n1 = n
-    x,w,mu0 = h_roots(n1,mu=1)
+    x,w,mu0 = h_roots(n1,mu=True)
     wfunc = lambda x: exp(-x*x)
     if n == 0:
         x,w = [],[]
@@ -448,7 +448,7 @@ def hermite(n, monic=False):
 # Hermite  2                         He_n(x)
 
 
-def he_roots(n, mu=0):
+def he_roots(n, mu=False):
     """[x,w] = he_roots(n)
 
     Returns the roots (x) of the nth order Hermite polynomial,
@@ -469,7 +469,7 @@ def hermitenorm(n, monic=False):
         n1 = n+1
     else:
         n1 = n
-    x,w,mu0 = he_roots(n1,mu=1)
+    x,w,mu0 = he_roots(n1,mu=True)
     wfunc = lambda x: exp(-x*x/4.0)
     if n == 0:
         x,w = [],[]
@@ -484,7 +484,7 @@ def hermitenorm(n, monic=False):
 # Ultraspherical (Gegenbauer)        C^(alpha)_n(x)
 
 
-def cg_roots(n, alpha, mu=0):
+def cg_roots(n, alpha, mu=False):
     """[x,w] = cg_roots(n,alpha)
 
     Returns the roots (x) of the nth order Ultraspherical (Gegenbauer)
@@ -512,7 +512,7 @@ def gegenbauer(n, alpha, monic=False):
 #  Computed anew.
 
 
-def t_roots(n, mu=0):
+def t_roots(n, mu=False):
     """[x,w] = t_roots(n)
 
     Returns the roots (x) of the nth order Chebyshev (of the first kind)
@@ -546,7 +546,7 @@ def chebyt(n, monic=False):
         return orthopoly1d([],[],pi,1.0,wfunc,(-1,1),monic,
                            lambda x: eval_chebyt(n,x))
     n1 = n
-    x,w,mu = t_roots(n1,mu=1)
+    x,w,mu = t_roots(n1,mu=True)
     hn = pi/2
     kn = 2**(n-1)
     p = orthopoly1d(x,w,hn,kn,wfunc,(-1,1),monic,
@@ -557,7 +557,7 @@ def chebyt(n, monic=False):
 #    U_n(x) = (n+1)! sqrt(pi) / (2*_gam(n+3./2)) * P^(1/2,1/2)_n(x)
 
 
-def u_roots(n, mu=0):
+def u_roots(n, mu=False):
     """[x,w] = u_roots(n)
 
     Returns the roots (x) of the nth order Chebyshev (of the second kind)
@@ -581,7 +581,7 @@ def chebyu(n, monic=False):
 # Chebyshev of the first kind        C_n(x)
 
 
-def c_roots(n, mu=0):
+def c_roots(n, mu=False):
     """[x,w] = c_roots(n)
 
     Returns the roots (x) of the nth order Chebyshev (of the first kind)
@@ -589,10 +589,10 @@ def c_roots(n, mu=0):
     over [-2,2] with weighting function (1-(x/2)**2)**(-1/2).
     """
     if mu:
-        [x,w,mu0] = j_roots(n,-0.5,-0.5,mu=1)
+        [x,w,mu0] = j_roots(n,-0.5,-0.5,mu=True)
         return [x*2,w,mu0]
     else:
-        [x,w] = j_roots(n,-0.5,-0.5,mu=0)
+        [x,w] = j_roots(n,-0.5,-0.5,mu=False)
         return [x*2,w]
 
 
@@ -607,7 +607,7 @@ def chebyc(n, monic=False):
         n1 = n+1
     else:
         n1 = n
-    x,w,mu0 = c_roots(n1,mu=1)
+    x,w,mu0 = c_roots(n1,mu=True)
     if n == 0:
         x,w = [],[]
     hn = 4*pi * ((n == 0)+1)
@@ -621,7 +621,7 @@ def chebyc(n, monic=False):
 # Chebyshev of the second kind       S_n(x)
 
 
-def s_roots(n, mu=0):
+def s_roots(n, mu=False):
     """[x,w] = s_roots(n)
 
     Returns the roots (x) of the nth order Chebyshev (of the second kind)
@@ -629,10 +629,10 @@ def s_roots(n, mu=0):
     over [-2,2] with weighting function (1-(x/2)**2)**1/2.
     """
     if mu:
-        [x,w,mu0] = j_roots(n,0.5,0.5,mu=1)
+        [x,w,mu0] = j_roots(n,0.5,0.5,mu=True)
         return [x*2,w,mu0]
     else:
-        [x,w] = j_roots(n,0.5,0.5,mu=0)
+        [x,w] = j_roots(n,0.5,0.5,mu=False)
         return [x*2,w]
 
 
@@ -647,7 +647,7 @@ def chebys(n, monic=False):
         n1 = n+1
     else:
         n1 = n
-    x,w,mu0 = s_roots(n1,mu=1)
+    x,w,mu0 = s_roots(n1,mu=True)
     if n == 0:
         x,w = [],[]
     hn = pi
@@ -662,7 +662,7 @@ def chebys(n, monic=False):
 # Shifted Chebyshev of the first kind     T^*_n(x)
 
 
-def ts_roots(n, mu=0):
+def ts_roots(n, mu=False):
     """[x,w] = ts_roots(n)
 
     Returns the roots (x) of the nth order shifted Chebyshev (of the first kind)
@@ -688,7 +688,7 @@ def sh_chebyt(n, monic=False):
 
 
 # Shifted Chebyshev of the second kind    U^*_n(x)
-def us_roots(n, mu=0):
+def us_roots(n, mu=False):
     """[x,w] = us_roots(n)
 
     Returns the roots (x) of the nth order shifted Chebyshev (of the second kind)
@@ -712,7 +712,7 @@ def sh_chebyu(n, monic=False):
 # Legendre
 
 
-def p_roots(n, mu=0):
+def p_roots(n, mu=False):
     """[x,w] = p_roots(n)
 
     Returns the roots (x) of the nth order Legendre polynomial, P_n(x),
@@ -733,7 +733,7 @@ def legendre(n, monic=False):
         n1 = n+1
     else:
         n1 = n
-    x,w,mu0 = p_roots(n1,mu=1)
+    x,w,mu0 = p_roots(n1,mu=True)
     if n == 0:
         x,w = [],[]
     hn = 2.0/(2*n+1)
@@ -745,7 +745,7 @@ def legendre(n, monic=False):
 # Shifted Legendre              P^*_n(x)
 
 
-def ps_roots(n, mu=0):
+def ps_roots(n, mu=False):
     """[x,w] = ps_roots(n)
 
     Returns the roots (x) of the nth order shifted Legendre polynomial, P^*_n(x),
@@ -766,7 +766,7 @@ def sh_legendre(n, monic=False):
     if n == 0:
         return orthopoly1d([],[],1.0,1.0,wfunc,(0,1),monic,
                            lambda x: eval_sh_legendre(n,x))
-    x,w,mu0 = ps_roots(n,mu=1)
+    x,w,mu0 = ps_roots(n,mu=True)
     hn = 1.0/(2*n+1.0)
     kn = _gam(2*n+1)/_gam(n+1)**2
     p = orthopoly1d(x,w,hn,kn,wfunc,limits=(0,1),monic=monic,

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -111,7 +111,7 @@ poch = cephes.poch
 
 
 class orthopoly1d(np.poly1d):
-    def __init__(self, roots, weights=None, hn=1.0, kn=1.0, wfunc=None, limits=None, monic=0,eval_func=None):
+    def __init__(self, roots, weights=None, hn=1.0, kn=1.0, wfunc=None, limits=None, monic=False, eval_func=None):
         np.poly1d.__init__(self, roots, r=1)
         equiv_weights = [weights[k] / wfunc(roots[k]) for k in range(len(roots))]
         self.__dict__['weights'] = np.array(list(zip(roots,weights,equiv_weights)))
@@ -210,7 +210,7 @@ def j_roots(n, alpha, beta, mu=0):
         return val
 
 
-def jacobi(n, alpha, beta, monic=0):
+def jacobi(n, alpha, beta, monic=False):
     """Returns the nth order Jacobi polynomial, P^(alpha,beta)_n(x)
     orthogonal over [-1,1] with weighting function
     (1-x)**alpha (1+x)**beta with alpha,beta > -1.
@@ -275,7 +275,7 @@ def js_roots(n, p1, q1, mu=0):
     #    return [(x+1)/2.0,w]
 
 
-def sh_jacobi(n, p, q, monic=0):
+def sh_jacobi(n, p, q, monic=False):
     """Returns the nth order Jacobi polynomial, G_n(p,q,x)
     orthogonal over [0,1] with weighting function
     (1-x)**(p-q) (x)**(q-1) with p>q-1 and q > 0.
@@ -323,7 +323,7 @@ def la_roots(n, alpha, mu=0):
         return val
 
 
-def genlaguerre(n, alpha, monic=0):
+def genlaguerre(n, alpha, monic=False):
     """Returns the nth order generalized (associated) Laguerre polynomial,
     L^(alpha)_n(x), orthogonal over [0,inf) with weighting function
     exp(-x) x**alpha with alpha > -1
@@ -360,7 +360,7 @@ def l_roots(n, mu=0):
     return la_roots(n,0.0,mu=mu)
 
 
-def laguerre(n, monic=0):
+def laguerre(n, monic=False):
     """Return the nth order Laguerre polynoimal, L_n(x), orthogonal over
     [0,inf) with weighting function exp(-x)
     """
@@ -424,7 +424,7 @@ def h_roots(n, mu=0):
     return _h_gen_roots_and_weights(n, mu, 2.0, cephes.eval_hermite)
 
 
-def hermite(n, monic=0):
+def hermite(n, monic=False):
     """Return the nth order Hermite polynomial, H_n(x), orthogonal over
     (-inf,inf) with weighting function exp(-x**2)
     """
@@ -458,7 +458,7 @@ def he_roots(n, mu=0):
     return _h_gen_roots_and_weights(n, mu, 1.0, cephes.eval_hermitenorm)
 
 
-def hermitenorm(n, monic=0):
+def hermitenorm(n, monic=False):
     """Return the nth order normalized Hermite polynomial, He_n(x), orthogonal
     over (-inf,inf) with weighting function exp(-(x/2)**2)
     """
@@ -494,7 +494,7 @@ def cg_roots(n, alpha, mu=0):
     return j_roots(n,alpha-0.5,alpha-0.5,mu=mu)
 
 
-def gegenbauer(n, alpha, monic=0):
+def gegenbauer(n, alpha, monic=False):
     """Return the nth order Gegenbauer (ultraspherical) polynomial,
     C^(alpha)_n(x), orthogonal over [-1,1] with weighting function
     (1-x**2)**(alpha-1/2) with alpha > -1/2
@@ -534,7 +534,7 @@ def t_roots(n, mu=0):
         return val
 
 
-def chebyt(n, monic=0):
+def chebyt(n, monic=False):
     """Return nth order Chebyshev polynomial of first kind, Tn(x).  Orthogonal
     over [-1,1] with weight function (1-x**2)**(-1/2).
     """
@@ -567,7 +567,7 @@ def u_roots(n, mu=0):
     return j_roots(n,0.5,0.5,mu=mu)
 
 
-def chebyu(n, monic=0):
+def chebyu(n, monic=False):
     """Return nth order Chebyshev polynomial of second kind, Un(x).  Orthogonal
     over [-1,1] with weight function (1-x**2)**(1/2).
     """
@@ -596,7 +596,7 @@ def c_roots(n, mu=0):
         return [x*2,w]
 
 
-def chebyc(n, monic=0):
+def chebyc(n, monic=False):
     """Return nth order Chebyshev polynomial of first kind, Cn(x).  Orthogonal
     over [-2,2] with weight function (1-(x/2)**2)**(-1/2).
     """
@@ -636,7 +636,7 @@ def s_roots(n, mu=0):
         return [x*2,w]
 
 
-def chebys(n, monic=0):
+def chebys(n, monic=False):
     """Return nth order Chebyshev polynomial of second kind, Sn(x).  Orthogonal
     over [-2,2] with weight function (1-(x/)**2)**(1/2).
     """
@@ -672,7 +672,7 @@ def ts_roots(n, mu=0):
     return js_roots(n,0.0,0.5,mu=mu)
 
 
-def sh_chebyt(n, monic=0):
+def sh_chebyt(n, monic=False):
     """Return nth order shifted Chebyshev polynomial of first kind, Tn(x).
     Orthogonal over [0,1] with weight function (x-x**2)**(-1/2).
     """
@@ -698,7 +698,7 @@ def us_roots(n, mu=0):
     return js_roots(n,2.0,1.5,mu=mu)
 
 
-def sh_chebyu(n, monic=0):
+def sh_chebyu(n, monic=False):
     """Return nth order shifted Chebyshev polynomial of second kind, Un(x).
     Orthogonal over [0,1] with weight function (x-x**2)**(1/2).
     """
@@ -722,7 +722,7 @@ def p_roots(n, mu=0):
     return j_roots(n,0.0,0.0,mu=mu)
 
 
-def legendre(n, monic=0):
+def legendre(n, monic=False):
     """Returns the nth order Legendre polynomial, P_n(x), orthogonal over
     [-1,1] with weight function 1.
     """
@@ -755,7 +755,7 @@ def ps_roots(n, mu=0):
     return js_roots(n,1.0,1.0,mu=mu)
 
 
-def sh_legendre(n, monic=0):
+def sh_legendre(n, monic=False):
     """Returns the nth order shifted Legendre polynomial, P^*_n(x), orthogonal
     over [0,1] with weighting function 1.
     """

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -735,8 +735,32 @@ def p_roots(n, mu=False):
 
 
 def legendre(n, monic=False):
-    """Returns the nth order Legendre polynomial, P_n(x), orthogonal over
-    [-1,1] with weight function 1.
+    """
+    Legendre polynomial coefficients
+
+    Returns the nth-order Legendre polynomial, P_n(x), orthogonal over
+    [-1, 1] with weight function 1.
+
+    Parameters
+    ----------
+    n
+        Order of the polynomial
+    monic : bool, optional
+        If True, output is a monic polynomial (normalized so the leading
+        coefficient is 1).  Default is False.
+
+    Returns
+    -------
+    P : orthopoly1d
+        The Legendre polynomial object
+
+    Examples
+    --------
+    Generate the 3rd-order Legendre polynomial 1/2*(5x^3 + 0x^2 - 3x + 0):
+
+    >>> legendre(3)
+    poly1d([ 2.5,  0. , -1.5, -0. ])
+
     """
     if n < 0:
         raise ValueError("n must be nonnegative.")


### PR DESCRIPTION
1. Some arguments are boolean, so use True and False instead of 0 and 1.
2. PEP8 fixes
3. Expand docstring for legendre polynomials.  Similar docstrings could be made for all the others.  I think n is an int, but [not 100% sure](http://en.wikipedia.org/wiki/Legendre_polynomials#Legendre_functions_of_fractional_order), but I don't see how http://www.wolframalpha.com/input/?i=LegendreP[2.5%2C+x] is related to `legendre(2.5) = poly1d([ 1.9207,  0.    , -1.1524, -0.    ])` so it should probably say "int" and reject non-ints?

Example is from the list at http://en.wikipedia.org/wiki/Legendre_polynomials#Recursive_definition
