### PR TITLE
BUG: make a fully connected csgraph from an ndarray with no zeros

### DIFF
--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -41,12 +41,8 @@ def csgraph_from_masked(graph):
         raise ValueError("graph should be a square array")
 
     # construct the csr matrix using graph and mask
-    if np.ma.is_masked(graph):
-        data = graph.compressed()
-        mask = ~graph.mask
-    else:
-        data = graph.data
-        mask = np.ones(graph.shape, dtype='bool')
+    data = graph.compressed()
+    mask = ~graph.mask
 
     data = np.asarray(data, dtype=DTYPE, order='c')
 

--- a/scipy/sparse/csgraph/tests/test_connected_components.py
+++ b/scipy/sparse/csgraph/tests/test_connected_components.py
@@ -91,3 +91,11 @@ def test_ticket1876():
     assert_equal(n_components, 2)
     assert_equal(labels[0], labels[1])
     assert_equal(labels[2], labels[3])
+
+
+def test_fully_connected_graph():
+    # Fully connected dense matrices raised an exception.
+    # https://github.com/scipy/scipy/issues/3818
+    g = np.ones((4, 4))
+    n_components, labels = csgraph.connected_components(g)
+    assert_equal(n_components, 1)


### PR DESCRIPTION
Should close https://github.com/scipy/scipy/issues/3818.  A problem was that `np.ma.is_masked(x)` returns `False` if `x` is a masked array with no elements masked-out.  The change in this PR might look disruptive but it passes all of the `scipy.sparse` unit tests locally, plus a new one.
