### PR TITLE
Don't claim scipy.cluster does distance matrix calculations.

### DIFF
--- a/scipy/cluster/__init__.py
+++ b/scipy/cluster/__init__.py
@@ -15,8 +15,8 @@ supports vector quantization and the k-means algorithms.
 
 The `hierarchy` module provides functions for hierarchical and
 agglomerative clustering.  Its features include generating hierarchical
-clusters from distance matrices, computing distance matrices from
-observation vectors, calculating statistics on clusters, cutting linkages
+clusters from distance matrices,
+calculating statistics on clusters, cutting linkages
 to generate flat clusters, and visualizing clusters with dendrograms.
 
 """


### PR DESCRIPTION
Distance matrix calculations were moved to scipy.spatial.distance
a long time ago.
