### PR TITLE
Bug fix for #3842: Bug in scipy.optimize.line_search

### DIFF
--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -255,7 +255,7 @@ def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
             return np.dot(gval[0], pk)
 
     if gfk is None:
-        gfk = fprime(xk)
+        gfk = fprime(xk, *args)
     derphi0 = np.dot(gfk, pk)
 
     alpha_star, phi_star, old_fval, derphi_star = \

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -214,12 +214,20 @@ def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
 
     Returns
     -------
-    alpha0 : float
+    alpha : float
         Alpha for which ``x_new = x0 + alpha * pk``.
     fc : int
         Number of function evaluations made.
     gc : int
         Number of gradient evaluations made.
+    new_fval : float
+        New function value ``f(x_new)=f(x0+alpha*pk)``.
+    old_fval : float
+        Old function value ``f(x0)``.
+    new_slope : float
+        The local slope along the search direction at the
+        new value ``<myfprime(x_new), pk>``.
+    
 
     Notes
     -----


### PR DESCRIPTION
There is a bug in scipy.optimize.line_search, which as I believe is the function line_search_wolfe2 in scipy.optimize.linesearch.

I think line 258 should be
gfk=fprime(xk, *args) instead
of gfk=fprime(xk)

otherwise the optional arguments are not passed along to myfprime, if I do not specify the current value of the Jacobian gfk when calling the function.

The docstrings of scipy.optimize.line_search are also missing some of the stuff returned by scipy.optimize.linesearch.line_search_wolfe2. 

i) I have fixed the bug. Optional arguments are now passed along to myfprime. 

ii) I have added missing docstring for the return values of line_search_wolfe2. I have chosen the names on the basis of my understanding of the algorithm but I would be glad if someone more familiar with the code could review them.
