### PR TITLE
BUG: Fix tests that expect numpy 1.9 to implement __numpy_ufunc__.

### DIFF
--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1749,7 +1749,7 @@ class _TestInplaceArithmetic:
         b = self.spmatrix(a)
 
         with warnings.catch_warnings():
-            if NumpyVersion(np.__version__) < '1.9.0.dev-0':
+            if NumpyVersion(np.__version__) < '1.10.0.dev-0':
                 warnings.simplefilter("ignore", DeprecationWarning)
 
             x = a.copy()

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1554,13 +1554,13 @@ class _TestCommon:
 
     def test_unary_ufunc_overrides(self):
         def check(name):
-            if NumpyVersion(np.__version__) < '1.9.0.dev-0':
+            if NumpyVersion(np.__version__) < '1.10.0.dev-0':
                 if name == "sign":
                     raise nose.SkipTest("sign conflicts with comparison op "
-                                        "support on Numpy < 1.9")
+                                        "support on Numpy < 1.10")
                 if self.spmatrix in (dok_matrix, lil_matrix):
                     raise nose.SkipTest("Unary ops not implemented for dok/lil "
-                                        "with Numpy < 1.9")
+                                        "with Numpy < 1.10")
             ufunc = getattr(np, name)
 
             X = self.spmatrix(np.arange(20).reshape(4, 5) / 20.)
@@ -1569,8 +1569,8 @@ class _TestCommon:
             X2 = ufunc(X)
             assert_array_equal(X2.toarray(), X0)
 
-            if not (NumpyVersion(np.__version__) < '1.9.0.dev-0'):
-                # the out argument doesn't work on Numpy < 1.9
+            if not (NumpyVersion(np.__version__) < '1.10.0.dev-0'):
+                # the out argument doesn't work on Numpy < 1.10
                 out = np.zeros_like(X0)
                 X3 = ufunc(X, out=out)
                 assert_(X3 is out)
@@ -1606,8 +1606,8 @@ class _TestCommon:
         a_items = dict(dense=a, scalar=c, cplx_scalar=d, int_scalar=e, sparse=asp)
         b_items = dict(dense=b, scalar=c, cplx_scalar=d, int_scalar=e, sparse=bsp)
 
-        @dec.skipif(NumpyVersion(np.__version__) < '1.9.0.dev-0',
-                    "feature requires Numpy 1.9")
+        @dec.skipif(NumpyVersion(np.__version__) < '1.10.0.dev-0',
+                    "feature requires Numpy 1.10")
         def check(i, j, dtype):
             ax = a_items[i]
             bx = b_items[j]
@@ -1708,8 +1708,8 @@ class _TestCommon:
                     if i == 'sparse' or j == 'sparse':
                         yield check, i, j, dtype
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.9.0.dev-0',
-                "feature requires Numpy 1.9")
+    @dec.skipif(NumpyVersion(np.__version__) < '1.10.0.dev-0',
+                "feature requires Numpy 1.10")
     def test_ufunc_object_array(self):
         # This tests compatibility with previous Numpy object array
         # ufunc behavior. See gh-3345.


### PR DESCRIPTION
Change Numpy version tests to check for 1.10 instead.

I think I got all the right ones, all tests pass with 1.9.x.
