### PR TITLE
DOC: sparse: add the function 'find' to the module-level docstring

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -46,6 +46,13 @@ Building sparse matrices:
    vstack - Stack sparse matrices vertically (row wise)
    rand - Random values in a given shape
 
+Sparse matrix tools:
+
+.. autosummary::
+   :toctree: generated/
+
+   find
+
 Identifying sparse matrices:
 
 .. autosummary::


### PR DESCRIPTION
`find` is not currently in the docstring in `__init__.py`, so it doesn't show up in the online documentation.
