### PR TITLE
BUG: Removed unnecessary storage of args as instance variables in Rbf

### DIFF
--- a/scipy/interpolate/rbf.py
+++ b/scipy/interpolate/rbf.py
@@ -226,6 +226,6 @@ class Rbf(object):
         if not all([x.shape == y.shape for x in args for y in args]):
             raise ValueError("Array lengths must be equal")
         shp = args[0].shape
-        self.xa = asarray([a.flatten() for a in args], dtype=float_)
-        r = self._call_norm(self.xa, self.xi)
+        xa = asarray([a.flatten() for a in args], dtype=float_)
+        r = self._call_norm(xa, self.xi)
         return dot(self._function(r), self.nodes).reshape(shp)


### PR DESCRIPTION
A small change to  `Rbf.__call__` which means that the incoming arrays are no longer stored on self. This is an optimization for memory usage so that args in 'xa' are not stored between calls to Rbf. 

As far as I can see the usage of self.xa after a call is not documented, and this change passes existing tests. I have no idea how to write a test for this memory consumption. 
