### PR TITLE
small tweaks to the docs

### DIFF
--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -734,9 +734,9 @@ cdef double_or_complex evaluate_bpoly1(double_or_complex s,
                                        double_or_complex[:,:,::1] c,
                                        int ci, int cj) nogil:
     """
-    Evaluate polynomial in the Berstein basis in a single interval.
+    Evaluate polynomial in the Bernstein basis in a single interval.
 
-    A Berstein polynomial is defined as
+    A Bernstein polynomial is defined as
 
         .. math:: b_{j, k} = comb(k, j) x^{j} (1-x)^{k-j}
 
@@ -787,10 +787,10 @@ cdef double_or_complex evaluate_bpoly1_deriv(double_or_complex s,
                                              int nu,
                                              double_or_complex[:,:,::1] wrk) nogil:
     """
-    Evaluate the derivative of a polynomial in the Berstein basis 
+    Evaluate the derivative of a polynomial in the Bernstein basis 
     in a single interval.
 
-    A Berstein polynomial is defined as
+    A Bernstein polynomial is defined as
 
         .. math:: b_{j, k} = comb(k, j) x^{j} (1-x)^{k-j}
 

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1401,7 +1401,7 @@ class BPoly(_PPolyBase):
 
         Notes
         -----
-        This uses the fact that a Berstein polynomial `b_{a, k}` can be
+        This uses the fact that a Bernstein polynomial `b_{a, k}` can be
         identically represented as a linear combination of polynomials of
         a higher degree `k+d`:
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1493,6 +1493,9 @@ class genextreme_gen(rv_continuous):
             exp(-exp(-x))*exp(-x),                    for c==0
             exp(-(1-c*x)**(1/c))*(1-c*x)**(1/c-1),    for x <= 1/c, c > 0
 
+    Note that several sources and software packages use the opposite 
+    convention for the sign of the shape parameter ``c``. 
+
     %(example)s
 
     """


### PR DESCRIPTION
Two unrelated things:
- fix a typo in BPoly docstrings
- add to the docstring of `genextreme` a cautionary note about the sign of the shape parameter.

closes gh-3844, closes gh-1851
