### PR TITLE
Fix KeyboardInterrupt Behavior on Windows

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -85,8 +85,9 @@ if _os.name == 'nt':
         _thread.interrupt_main()
         return 1
 
-    # load numpy  fortran compiler library (but do not import numpy)
+    # load numpy  math and fortran libraries (but do not import numpy)
     basepath = _imp.find_module('numpy')[1]
+    _ctypes.CDLL(_os.path.join(basepath, 'core', 'libmmd.dll'))
     _ctypes.CDLL(_os.path.join(basepath, 'core', 'libifcoremd.dll'))
     # install handler
     routine = _ctypes.WINFUNCTYPE(_ctypes.c_int, _ctypes.c_uint)(handler)

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -67,34 +67,12 @@ from __future__ import division, print_function, absolute_import
 
 __all__ = ['test']
 
+# prevent interference with KeyboardInterrupt on Windows
+# due to MKL Fortran libraries
 import os as _os
-
 if _os.name == 'nt':
-    # prevent interference with KeyboardInterrupt on Windows
-    # due to Fortran libraries
-    # See stackoverflow for explanation:
-    # http://stackoverflow.com/questions/15457786/ctrl-c-crashes-python-after-importing-scipy-stats
-    import imp as _imp
-    import ctypes as _ctypes
-
-    def handler(sig):
-        try:
-            import _thread
-        except ImportError:
-            import thread as _thread
-        _thread.interrupt_main()
-        return 1
-
-    # load numpy  math and fortran libraries (but do not import numpy)
-    basepath = _imp.find_module('numpy')[1]
-    _ctypes.CDLL(_os.path.join(basepath, 'core', 'libmmd.dll'))
-    _ctypes.CDLL(_os.path.join(basepath, 'core', 'libifcoremd.dll'))
-    # install handler
-    routine = _ctypes.WINFUNCTYPE(_ctypes.c_int, _ctypes.c_uint)(handler)
-    _ctypes.windll.kernel32.SetConsoleCtrlHandler(routine, 1)
-
-    del _imp, _ctypes
-
+    from scipy import _fortran_fix
+    del _fortran_fix
 del _os
 
 from numpy import show_config as show_numpy_config

--- a/scipy/_fortran_fix.py
+++ b/scipy/_fortran_fix.py
@@ -1,0 +1,37 @@
+# prevent interference with KeyboardInterrupt on Windows
+# due to Fortran libraries
+# See stackoverflow for explanation:
+# http://stackoverflow.com/questions/15457786/ctrl-c-crashes-python-after-importing-scipy-stats
+import imp
+import ctypes
+import os
+
+INSTALL = False
+
+dirname = os.path.dirname(__file__)
+config_file = os.path.join(dirname, '__config__.py')
+
+if os.path.exists(config_file):
+    with open(config_file, 'rb') as fid:
+        text = fid.read()
+    if 'mkl_blas' in text:
+        INSTALL = True
+
+
+def handler(sig):
+    try:
+        import _thread
+    except ImportError:
+        import thread as _thread
+    _thread.interrupt_main()
+    return 1
+
+# load numpy  math and fortran libraries (but do not import numpy)
+basepath = imp.find_module('numpy')[1]
+ctypes.CDLL(os.path.join(basepath, 'core', 'libmmd.dll'))
+ctypes.CDLL(os.path.join(basepath, 'core', 'libifcoremd.dll'))
+# install handler
+routine = ctypes.WINFUNCTYPE(ctypes.c_int, ctypes.c_uint)(handler)
+
+if INSTALL:
+    ctypes.windll.kernel32.SetConsoleCtrlHandler(routine, 1)


### PR DESCRIPTION
The following code results in an error and python shutdown on Windows due to the Fortran imports in `scipy` when run from the terminal and interrupted using Ctrl+C:

``` python
import scipy.stats
import time

print('sleeping')
try:
    time.sleep(100)
except KeyboardInterrupt:
    print('interrupted')
```

```
sleeping
forrtl: error (200): program aborting due to control-C event
Image              PC                Routine            Line        Source

kernel32.dll       00000000775E4AE3  Unknown               Unknown  Unknown
kernel32.dll       00000000775A59ED  Unknown               Unknown  Unknown
ntdll.dll          00000000777DC541  Unknown               Unknown  Unknown
```

The same problem occurs with `scipy.io`, and likely any of the subpackages that use Fortran code.
This patch fixes this and is based on this [stackoverflow](http://stackoverflow.com/questions/15457786/ctrl-c-crashes-python-after-importing-scipy-stats) question, but without requiring the `win32api` library.

Notes: 
- This cannot be run within a function, it has to be run at the module level.
- This has to be done prior to importing `numpy` or `time` (hence the use of `imp`).
- Tested the behavior on Windows 7 with Anaconda builds of Scipy 0.14.0 for Python 2.7 and Python 3.3.
