### PR TITLE
FIX incorrect sorting during fancy assignment

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -775,6 +775,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         if do_sort:
             # TODO: only sort where necessary
+            self.has_sorted_indices = False
             self.sort_indices()
 
         self.check_format(full_check=False)


### PR DESCRIPTION
Bug reported by @perimosocordiae on #3264

One of the tests added here fails on master in `TestCSR.test_fancy_indexing_multidim_set`
