### PR TITLE
BUG: fixing linprog's kwarg order to match docs

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -791,7 +791,7 @@ def _linprog_simplex(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
                   message=messages[status], success=(status == 0))
 
 
-def linprog(c, A_eq=None, b_eq=None, A_ub=None, b_ub=None,
+def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
             bounds=None, method='simplex', callback=None,
             options=None):
     """


### PR DESCRIPTION
The upper bound and equality constraint kwargs were swapped, which means that people following the docstring ordering (and not using keywords) would inadvertently supply the wrong constraints.
