### PR TITLE
BUG: stats: Fix ValueError message in chi2_contingency.

### DIFF
--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -246,9 +246,9 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     if np.any(expected == 0):
         # Include one of the positions where expected is zero in
         # the exception message.
-        zeropos = list(np.where(expected == 0)[0])
+        zeropos = list(zip(*np.where(expected == 0)))[0]
         raise ValueError("The internally computed table of expected "
-                         "frequencies has a zero element at %s." % zeropos)
+                         "frequencies has a zero element at %s." % (zeropos,))
 
     # The degrees of freedom
     dof = expected.size - sum(expected.shape) + expected.ndim - 1


### PR DESCRIPTION
chi2_contingency raises a ValueError when a zero occurs in the
table of expected frequencies.  The exception message includes
the position of the zero, but the code that figured out that
position was incorrect.
