### PR TITLE
DOC: sparse.linalg: Fix lobpcg docstring.

### DIFF
--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -249,8 +249,8 @@ def lobpcg(A, X,
         For this specific problem, a good simple preconditioner function would
         be a linear solve for A, which is easy to code since A is tridiagonal.
 
-    Acknowledgements
-    ----------------
+    *Acknowledgements*
+
     lobpcg.py code was written by Robert Cimrman.
     Many thanks belong to Andrew Knyazev, the author of the algorithm,
     for lots of advice and support.


### PR DESCRIPTION
Change the markup of the "Acknowledgements" title from a section heading
to emphasis markers within the "Notes" section.

The docstring standard doesn't include an "Acknowledgements" section,
so including one in a docstring generates a warning when building the
docs, and the section is not included in the HTML output.
