### PR TITLE
DOC (WIP): sphinx: Add the custom autosummary template 'base.rst'

### DIFF
--- a/doc/source/_templates/autosummary/base.rst
+++ b/doc/source/_templates/autosummary/base.rst
@@ -1,0 +1,8 @@
+:orphan: 1
+
+{{ fullname }}
+{{ underline }}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}


### PR DESCRIPTION
The only difference between the default 'base.rst' and the custom
one is the addition of ':orphan: 1' added to the beginning of the file.
This prevents the warning output

```
WARNING: document isn't included in any toctree
```

that is printed for each file in the generated directory.
