### PR TITLE
Fix 2 mistakes in MatrixMarket format parsing

### DIFF
--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -199,17 +199,16 @@ class MMFile (object):
             # read and validate header line
             line = source.readline()
             mmid, matrix, format, field, symmetry = \
-              [asstr(part.strip().lower()) for part in line.split()]
-            if not mmid.startswith('%%matrixmarket'):
+              [asstr(part.strip()) for part in line.split()]
+            if not mmid.startswith('%%MatrixMarket'):
                 raise ValueError('source is not in Matrix Market format')
-            if not matrix == 'matrix':
+            if not matrix.lower() == 'matrix':
                 raise ValueError("Problem reading file header: " + line)
 
-            # ??? Is this necessary?  I don't see 'dense' or 'sparse' in the spec
             # http://math.nist.gov/MatrixMarket/formats.html
-            if format == 'dense':
+            if format.lower() == 'array':
                 format = self.FORMAT_ARRAY
-            elif format == 'sparse':
+            elif format.lower() == 'coordinate':
                 format = self.FORMAT_COORDINATE
 
             # skip comments
@@ -227,7 +226,7 @@ class MMFile (object):
                     raise ValueError("Header line not of length 3: " + line)
                 rows, cols, entries = map(int, line)
 
-            return (rows, cols, entries, format, field, symmetry)
+            return (rows, cols, entries, format, field.lower(), symmetry.lower())
 
         finally:
             if close_it:
@@ -639,7 +638,7 @@ class MMFile (object):
 def _is_fromfile_compatible(stream):
     """
     Check whether stream is compatible with numpy.fromfile.
-    
+
     Passing a gzipped file to fromfile/fromstring doesn't work
     with Python3
 


### PR DESCRIPTION
As per the full spec ( http://math.nist.gov/MatrixMarket/reports/MMformat.ps ):
- the header line starts with '%%MatrixMarket' (capitalized)
- the strings which specify array or coordinate formats are resp. 'array'
  and 'coordinate'
