### PR TITLE
BUG: fix undefined behavior in alngam

### DIFF
--- a/scipy/special/cdflib/alngam.f
+++ b/scipy/special/cdflib/alngam.f
@@ -105,6 +105,7 @@ C
 C     IF NECESSARY MAKE X AT LEAST 12 AND CARRY CORRECTION IN OFFSET
 C
 C
+      IF ((x.GT.12.0D0)) GO TO 90
       n = int(12.0D0-x)
       IF (.NOT. (n.GT.0)) GO TO 90
       prod = 1.0D0


### PR DESCRIPTION
INT(A) is undefined if A cannot be represented as INT
In MIPS the result is positive triggering a huge loop for:

```
scipy.stats.skellam.sf(np.inf, 10, 11)
```
