### PR TITLE
BUG: psi(x) should return -inf at x=0, not inf

### DIFF
--- a/scipy/special/cephes/psi.c
+++ b/scipy/special/cephes/psi.c
@@ -121,7 +121,7 @@ double x;
 	p = floor(q);
 	if (p == q) {
 	    mtherr("psi", SING);
-	    return (NPY_INFINITY);
+	    return (-NPY_INFINITY);
 	}
 	/* Remove the zeros of tan(NPY_PI x)
 	 * by subtracting the nearest integer from x


### PR DESCRIPTION
See http://mathworld.wolfram.com/DigammaFunction.html

As x -> 0, psi(x) -> (-inf). Returning infinity is nonintuitive behaviour.
