### PR TITLE
TST: relax bounds of interpolate test to accomodate rounding error

### DIFF
--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -758,7 +758,7 @@ class TestPPoly(TestCase):
         pp = PPoly.from_spline(spl)
 
         r = pp.roots()
-        r = r[(r >= 0) & (r <= 1)]
+        r = r[(r >= 0 - 1e-15) & (r <= 1 + 1e-15)]
         assert_allclose(r, sproot(spl), atol=1e-15)
 
     def test_roots_idzero(self):


### PR DESCRIPTION
A small rounding error appears with gcc-4.9 on i586 which causes the a
root to be -1e-19 instead of 0. and subsequently being cut by the exact
masking causing a testfailure.
