### PR TITLE
Quadrature speed-up: scipy.special.orthogonal.p_roots with cache

### DIFF
--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -18,6 +18,18 @@ class AccuracyWarning(Warning):
     pass
 
 
+def _cached_p_roots(n):
+    """
+    Cache p_roots results for speeding up multiple calls of the fixed_quad function.
+    """
+    if n in _cached_p_roots.cache:
+        return _cached_p_roots.cache[n]
+
+    _cached_p_roots.cache[n] = p_roots(n)
+    return _cached_p_roots.cache[n]
+_cached_p_roots.cache = dict()
+
+
 def fixed_quad(func,a,b,args=(),n=5):
     """
     Compute a definite integral using fixed-order Gaussian quadrature.
@@ -57,7 +69,7 @@ def fixed_quad(func,a,b,args=(),n=5):
     odeint : ODE integrator
 
     """
-    [x,w] = p_roots(n)
+    [x,w] = _cached_p_roots(n)
     x = real(x)
     ainf, binf = map(isinf,(a,b))
     if ainf or binf:

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -738,7 +738,7 @@ def p_roots(n, mu=False):
         p_roots.cache[n] = j_roots(n, 0.0, 0.0, mu=False)
         return p_roots.cache[n]
 
-    return j_roots(n, 0.0, 0.0, mu=True)
+    return j_roots(n, 0.0, 0.0, mu=mu)
 p_roots.cache = dict()
 
 def legendre(n, monic=False):

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -738,7 +738,7 @@ def p_roots(n, mu=False):
         p_roots.cache[n] = j_roots(n, 0.0, 0.0, mu=False)
         return p_roots.cache[n]
 
-    return j_roots(n, 0.0, 0.0, mu=mu)
+    return j_roots(n, 0.0, 0.0, mu=True)
 p_roots.cache = dict()
 
 def legendre(n, monic=False):

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -731,15 +731,8 @@ def p_roots(n, mu=False):
     and weights (w) to use in Gaussian Quadrature over [-1,1] with weighting
     function 1.
     """
-    if mu is False:
-        if n in p_roots.cache:
-            return p_roots.cache[n]
+    return j_roots(n, 0.0, 0.0, mu=mu)
 
-        p_roots.cache[n] = j_roots(n, 0.0, 0.0, mu=False)
-        return p_roots.cache[n]
-
-    return j_roots(n, 0.0, 0.0, mu=True)
-p_roots.cache = dict()
 
 def legendre(n, monic=False):
     """

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -731,8 +731,15 @@ def p_roots(n, mu=False):
     and weights (w) to use in Gaussian Quadrature over [-1,1] with weighting
     function 1.
     """
-    return j_roots(n, 0.0, 0.0, mu=mu)
+    if mu is False:
+        if n in p_roots.cache:
+            return p_roots.cache[n]
 
+        p_roots.cache[n] = j_roots(n, 0.0, 0.0, mu=False)
+        return p_roots.cache[n]
+
+    return j_roots(n, 0.0, 0.0, mu=True)
+p_roots.cache = dict()
 
 def legendre(n, monic=False):
     """


### PR DESCRIPTION
The p_roots now caches its results. This is because scipy.integrate.quadrature, which makes use of this function, calls that function for basically the same inputs (integer values), over and over again. In my case, that single function was way more expensive than the function being integrated.

With the modification, I easily get 100-fold of speed up for scipy.integrate.quadrature. Here is the benchmark:

``` python
import numpy as np
from scipy.integrate import quadrature

def link(x):
    return 1.0 / (1.0 + np.exp(-x))

def gauss(x, mu, sig2):
    return np.exp(- (x - mu)**2 / sig2)

class Cases(object):
    def __init__(self):
        np.random.seed(1)

        self._n_small = 100
        self._mu_small = np.random.rand(self._n_small) - 0.5
        self._sig2_small = np.random.gamma(1, 0.5, self._n_small)

        self._n_big = 1000
        self._mu_big = np.random.rand(self._n_big) - 0.5
        self._sig2_big = np.random.gamma(1, 4.0, self._n_big)

    def run_small(self):
        for i in xrange(self._n_small):
            std = np.sqrt(self._sig2_small[i])
            a = self._mu_small[i] - 6 * std
            b = self._mu_small[i] + 6 * std
            quadrature(lambda x: x * link(x) * gauss(x, self._mu_small[i], self._sig2_small[i]), a, b)

    def run_big(self):
        for i in xrange(self._n_big):
            std = np.sqrt(self._sig2_big[i])
            a = self._mu_big[i] - 6 * std
            b = self._mu_big[i] + 6 * std
            quadrature(lambda x: x * link(x) * gauss(x, self._mu_big[i], self._sig2_big[i]), a, b,
                       miniter=100, maxiter=101)
```

And here are the results comparing scipy.integrate.quadrature using the previous and new p_roots:

| Case | previous | new | speedup |
| --- | --- | --- | --- |
| run_small | 1.28 sec | 137 msec | x9 |
| run_big | 21.6 sec | 107 msec | x201 |

The run_big case is the kind of setting I'm working with: I start with a miniter that is high enough for the quadrature to converge in one iteration.
