### PR TITLE
ENH: optimize: handle NaNs in curve_fit

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -499,6 +499,11 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False, **kw):
         How the `sigma` parameter affects the estimated covariance
         depends on `absolute_sigma` argument, as described above.
 
+    Raises
+    ------
+    ValueError
+        if ydata and xdata contain NaNs.
+
     See Also
     --------
     leastsq
@@ -538,11 +543,12 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False, **kw):
     if isscalar(p0):
         p0 = array([p0])
 
-    ydata = np.asanyarray(ydata)
-    if isinstance(xdata, (list, tuple)):
+    # NaNs can not be handled
+    ydata = np.asarray_chkfinite(ydata)
+    if isinstance(xdata, (list, tuple, np.ndarray)):
         # `xdata` is passed straight to the user-defined `f`, so allow
         # non-array_like `xdata`.
-        xdata = np.asarray(xdata)
+        xdata = np.asarray_chkfinite(xdata)
 
     args = (xdata, ydata, f)
     if sigma is None:

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -386,6 +386,16 @@ class TestCurveFit(TestCase):
         y = [2, 4, 6, 8]
         assert_allclose(curve_fit(f_linear, x, y)[0], [2, 0], atol=1e-10)
 
+    def test_NaN_handling(self):
+        # Test for correct handling of NaNs in input data: gh-3422
+
+        # create input with NaNs
+        xdata = np.array([1, np.nan, 3])
+        ydata = np.array([1, 2, 3])
+
+        assert_raises(ValueError, curve_fit, lambda x, a, b: a*x + b, xdata, ydata)
+        assert_raises(ValueError, curve_fit, lambda x, a, b: a*x + b, ydata, xdata)
+
 
 class TestFixedPoint(TestCase):
 


### PR DESCRIPTION
curve_fit now raises ValueError if input data contains NaNs.
Previously curve_fit would return nonsensical results.
Fixes #3422
