### PR TITLE
Coerce args into tuple if necessary.

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -328,6 +328,9 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
 
     """
 
+    if not isinstance(args, tuple):
+        args = (args,)
+
     if method is None:
         # Select automatically
         if constraints:

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -556,6 +556,9 @@ def minimize_scalar(fun, bracket=None, bounds=None, args=(),
     -2.0000002026
 
     """
+    if not isinstance(args, tuple):
+        args = (args,)
+
     if callable(method):
         meth = "_custom"
     else:

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -144,6 +144,9 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
     >>> sol.x
     array([ 0.8411639,  0.1588361])
     """
+    if not isinstance(args, tuple):
+        args = (args,)
+
     meth = method.lower()
     if options is None:
         options = {}

--- a/scipy/optimize/tests/test__root.py
+++ b/scipy/optimize/tests/test__root.py
@@ -38,3 +38,10 @@ class TestRoot(object):
             assert_(sol2.success, msg)
             assert_(abs(func(sol1.x)).max() < abs(func(sol2.x)).max(),
                     msg)
+
+    def test_minimize_scalar_coerce_args_param(self):
+        # github issue #3503
+        def func(z, f=1):
+            x, y = z
+            return np.array([x**3 - 1, y**3 - f])
+        root(func, [1.1, 1.1], args=1.5)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -780,6 +780,10 @@ class TestOptimizeScalar(TestCase):
                                        options=dict(stepsize=0.05))
         assert_allclose(res.x, self.solution, atol=1e-6)
 
+    def test_minimize_scalar_coerce_args_param(self):
+        # github issue #3503
+        optimize.minimize_scalar(self.fun, args=1.5)
+
 
 class TestNewtonCg(object):
     def test_rosenbrock(self):

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -586,6 +586,22 @@ class TestOptimize(object):
         assert_allclose(sol_3.x, 5, atol=1e-8)
         assert_allclose(sol_4.x, 2, atol=1e-8)
 
+    def test_minimize_coerce_args_param(self):
+        # github issue #3503
+        def Y(x, c):
+            return np.sum((x-c)**2)
+
+        def dY_dx(x, c=None):
+            return 2*(x-c)
+
+        c = np.array([3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5])
+        xinit = np.random.randn(len(c))
+
+        try:
+            optimize.minimize(Y, xinit, jac=dY_dx, args=(c), method="BFGS")
+        except TypeError:
+            self.fail('minimize did not coerce args into tuple.')
+
 
 class TestLBFGSBBounds(TestCase):
     """ Tests for L-BFGS-B with bounds """

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -596,11 +596,7 @@ class TestOptimize(object):
 
         c = np.array([3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5])
         xinit = np.random.randn(len(c))
-
-        try:
-            optimize.minimize(Y, xinit, jac=dY_dx, args=(c), method="BFGS")
-        except TypeError:
-            self.fail('minimize did not coerce args into tuple.')
+        optimize.minimize(Y, xinit, jac=dY_dx, args=(c), method="BFGS")
 
 
 class TestLBFGSBBounds(TestCase):


### PR DESCRIPTION
Same logic as in scipy.integrate.quad.

Fixes #3503 and Fixes #3785.
