### PR TITLE
TST: integrate: Remove an invalid test of odeint.

### DIFF
--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -582,12 +582,11 @@ def test_odeint_banded_jacobian():
     assert_allclose(sol0, sol2)
 
     # Verify that the number of jacobian evaluations was the same
-    # for all three calls of odeint.  This is a regression test--there
-    # was a bug in the handling of banded jacobians that resulted in
-    # an incorrect jacobian matrix being passed to the LSODA code.
+    # for the calls of odeint with banded jacobian.  This is a regression
+    # test--there was a bug in the handling of banded jacobians that resulted
+    # in an incorrect jacobian matrix being passed to the LSODA code.
     # That would cause errors or excessive jacobian evaluations.
-    assert_array_equal(info0['nje'], info1['nje'])
-    assert_array_equal(info0['nje'], info2['nje'])
+    assert_array_equal(info1['nje'], info2['nje'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In a test of the use of the banded jacobian arguments
of scipy.integrate.odeint, there is a check that two
different calls to odeint result in the same number
of jacobian evaluations at each step.  In one call,
the banded jacobian arguments are not used.  This is
an overly optimistic test; we can't really be sure that
the number of jacobian calls will be the same in these
two cases.
