### PR TITLE
Sparse bitwise operations

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -482,6 +482,24 @@ class spmatrix(object):
         else:
             raise NotImplementedError
 
+    def __and__(self, other):  # self & other
+        return self.tocsr().__and__(other)
+
+    def __rand__(self, other):
+        return self.tocsr().__rand__(other)
+
+    def __or__(self, other):  # self & other
+        return self.tocsr().__or__(other)
+
+    def __ror__(self, other):  # self & other
+        return self.tocsr().__ror__(other)
+
+    def __xor__(self, other):  # self & other
+        return self.tocsr().__xor__(other)
+
+    def __rxor__(self, other):  # self & other
+        return self.tocsr().__rxor__(other)
+        
     def __getattr__(self, attr):
         if attr == 'A':
             return self.toarray()

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -15,7 +15,8 @@ from .dia import dia_matrix
 from . import _sparsetools
 from .sputils import upcast, upcast_char, to_native, isdense, isshape, \
      getdtype, isscalarlike, isintlike, IndexMixin, get_index_dtype, \
-     downcast_intp_index, _compat_unique, _compat_bincount
+     downcast_intp_index, _compat_unique, _compat_bincount, \
+     supported_bitwise_dtypes
 
 
 class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
@@ -359,6 +360,79 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
     def __radd__(self,other):
         return self.__add__(other)
+
+
+    def __or__(self, other):
+        # First check if argument is a scalar
+        if self.dtype not in supported_bitwise_dtypes:
+            raise TypeError("Unsupported dtype for 'or': %s " % self.dtype)
+        if isscalarlike(other):
+            if not other:
+                # Just copy ourselves
+                return self.copy()
+
+            else:  # Now we would add this scalar to every element.
+                raise NotImplementedError('or-ing a nonzero scalar to a '
+                                          'sparse matrix is not supported')
+        elif isspmatrix(other):
+            if (other.shape != self.shape):
+                raise ValueError("inconsistent shapes")
+
+            return self._binopt(other,'_bor_')
+        elif isdense(other):
+            # Convert this matrix to a dense matrix and add them
+            return self.todense() | other
+        else:
+            return NotImplemented
+
+    def __ror__(self, other):
+        return self.__or__(other)
+
+    def __and__(self, other):
+        # First check if argument is a scalar        
+        if self.dtype not in supported_bitwise_dtypes:
+            raise TypeError("Unsupported dtype for 'and': %s " % self.dtype)
+        if isscalarlike(other):
+            if not other:
+                # Return empty array of current shape and dtype 
+                return self.__class__(self.shape, self.dtype)
+
+            else:  # Now we would add this scalar to every element.
+                raise NotImplementedError('and-ing a nonzero scalar to a '
+                                          'sparse matrix is not supported')
+        elif isspmatrix(other):
+            if (other.shape != self.shape):
+                raise ValueError("inconsistent shapes")
+
+            return self._binopt(other,'_band_')
+        elif isdense(other):
+            # Convert this matrix to a dense matrix and add them
+            return self.todense() & other
+        else:
+            return NotImplemented
+
+    def __rand__(self, other):
+        return self.__and__(other)
+
+    def __xor__(self, other):
+        if self.dtype not in supported_bitwise_dtypes:
+            raise TypeError("Unsupported dtype for 'xor': %s " % self.dtype)
+        if isscalarlike(other):
+            raise NotImplementedError('xoring a scalar and a sparse matrix'
+                                      'is not implemented')
+
+        elif isspmatrix(other):
+            if (other.shape != self.shape):
+                raise ValueError("inconsistent shapes")
+            return self._binopt(other, '_bxor_')
+        elif isdense(other):
+            return self.todense() ^ other
+        
+        else:
+            return NotImplemented
+
+    def __rxor__(self, other):
+        return self.__xor__(other)
 
     def __sub__(self,other):
         # First check if argument is a scalar

--- a/scipy/sparse/generate_sparsetools.py
+++ b/scipy/sparse/generate_sparsetools.py
@@ -24,6 +24,7 @@ from distutils.dep_util import newer
 # List of all routines and their argument types.
 #
 # The first code indicates the return value, the rest the arguments.
+# Constraints are listed last (bitwise constrains code generation to only bitwise compatible)
 #
 
 # bsr.h
@@ -85,6 +86,11 @@ csr_plus_csr        v iiIITIIT*I*I*T
 csr_minus_csr       v iiIITIIT*I*I*T
 csr_maximum_csr     v iiIITIIT*I*I*T
 csr_minimum_csr     v iiIITIIT*I*I*T
+csr_land_csr        v iiIITIIT*I*I*T 
+csr_lor_csr         v iiIITIIT*I*I*T 
+csr_band_csr        v iiIITIIT*I*I*T bitwise
+csr_bor_csr         v iiIITIIT*I*I*T bitwise
+csr_bxor_csr         v iiIITIIT*I*I*T bitwise
 csr_ne_csr          v iiIITIIT*I*I*B
 csr_lt_csr          v iiIITIIT*I*I*B
 csr_gt_csr          v iiIITIIT*I*I*B
@@ -115,6 +121,7 @@ coo_count_diagonals i iII
 dia_matvec          v iiiiITT*T
 cs_graph_components i iII*I
 """
+CONSTRAINTS = ['bitwise']
 
 # List of compilation units
 COMPILATION_UNITS = [
@@ -155,6 +162,19 @@ T_TYPES = [
     ('NPY_CLONGDOUBLE', 'npy_clongdouble_wrapper'),
 ]
 
+# Integer types
+BITWISE_NPY_TYPES = set((
+    'NPY_BOOL',
+    'NPY_BYTE',
+    'NPY_UBYTE',
+    'NPY_SHORT',
+    'NPY_USHORT',
+    'NPY_INT', 
+    'NPY_UINT',
+    'NPY_LONG',
+    'NPY_ULONG',
+    'NPY_LONGLONG',
+    'NPY_ULONGLONG'))
 #
 # Code templates
 #
@@ -235,7 +255,7 @@ def get_thunk_type_set():
     return i_types, it_types, GET_THUNK_CASE_TEMPLATE % dict(content=getter_code)
 
 
-def parse_routine(name, args, types):
+def parse_routine(name, args, types, bitwise=False):
     """
     Generate thunk and method code for a given routine.
 
@@ -292,6 +312,9 @@ def parse_routine(name, args, types):
     thunk_content = """int j = get_thunk_case(I_typenum, T_typenum);
     switch (j) {"""
     for j, I_typenum, T_typenum, I_type, T_type in types:
+        
+        if bitwise and T_typenum not in BITWISE_NPY_TYPES:
+            continue
         arglist = get_arglist(I_type, T_type)
         if T_type is None:
             dispatch = "%s" % (I_type,)
@@ -355,12 +378,16 @@ def main():
                 name, args = line.split(None, 1)
             except ValueError:
                 raise ValueError("Malformed line: %r" % (line,))
+            
+            bitwise = args.endswith("bitwise")
+            if bitwise:
+                args = args.rsplit(None, 1)[0]
 
             args = "".join(args.split())
             if 't' in args or 'T' in args:
-                thunk, method = parse_routine(name, args, it_types)
+                thunk, method = parse_routine(name, args, it_types, bitwise=bitwise)
             else:
-                thunk, method = parse_routine(name, args, i_types)
+                thunk, method = parse_routine(name, args, i_types, bitwise=bitwise)
 
             if name in names:
                 raise ValueError("Duplicate routine %r" % (name,))

--- a/scipy/sparse/sparsetools/csr.h
+++ b/scipy/sparse/sparsetools/csr.h
@@ -970,6 +970,53 @@ void csr_minimum_csr(const I n_row, const I n_col,
     csr_binop_csr(n_row,n_col,Ap,Aj,Ax,Bp,Bj,Bx,Cp,Cj,Cx,minimum<T>());
 }
 
+template <class I, class T>
+  void csr_land_csr(const I n_row, const I n_col, 
+		      const I Ap[], const I Aj[], const T Ax[],
+		      const I Bp[], const I Bj[], const T Bx[],
+		      I Cp[],       I Cj[],       T Cx[])
+{
+    csr_binop_csr(n_row,n_col,Ap,Aj,Ax,Bp,Bj,Bx,Cp,Cj,Cx,std::logical_and<T>());
+}
+
+
+template <class I, class T>
+  void csr_lor_csr(const I n_row, const I n_col, 
+		     const I Ap[], const I Aj[], const T Ax[],
+		     const I Bp[], const I Bj[], const T Bx[],
+		     I Cp[],       I Cj[],       T Cx[])
+{
+    csr_binop_csr(n_row,n_col,Ap,Aj,Ax,Bp,Bj,Bx,Cp,Cj,Cx,std::logical_or<T>());
+}
+
+template <class I, class T>
+  void csr_band_csr(const I n_row, const I n_col, 
+		      const I Ap[], const I Aj[], const T Ax[],
+		      const I Bp[], const I Bj[], const T Bx[],
+		      I Cp[],       I Cj[],       T Cx[])
+{
+    csr_binop_csr(n_row,n_col,Ap,Aj,Ax,Bp,Bj,Bx,Cp,Cj,Cx,std::bit_and<T>());
+}
+
+
+template <class I, class T>
+  void csr_bor_csr(const I n_row, const I n_col, 
+		     const I Ap[], const I Aj[], const T Ax[],
+		     const I Bp[], const I Bj[], const T Bx[],
+		     I Cp[],       I Cj[],       T Cx[])
+{
+    csr_binop_csr(n_row,n_col,Ap,Aj,Ax,Bp,Bj,Bx,Cp,Cj,Cx,std::bit_or<T>());
+}
+
+template <class I, class T>
+  void csr_bxor_csr(const I n_row, const I n_col, 
+		     const I Ap[], const I Aj[], const T Ax[],
+		     const I Bp[], const I Bj[], const T Bx[],
+		     I Cp[],       I Cj[],       T Cx[])
+{
+    csr_binop_csr(n_row,n_col,Ap,Aj,Ax,Bp,Bj,Bx,Cp,Cj,Cx,std::bit_xor<T>());
+}
+
 
 /*
  * Sum together duplicate column entries in each row of CSR matrix A

--- a/scipy/sparse/sparsetools/sparsetools.cxx
+++ b/scipy/sparse/sparsetools/sparsetools.cxx
@@ -106,6 +106,7 @@ call_thunk(char ret_spec, const char *spec, thunk_t *thunk, PyObject *args)
     int T_typenum = -1;
     int VW_count = 0;
     int I_in_arglist = 0;
+    int J_in_arglist = 0;
     int T_in_arglist = 0;
     int next_is_output = 0;
     int j, k, arg_j;

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -18,8 +18,10 @@ from scipy.lib._version import NumpyVersion
 supported_dtypes = ['bool', 'int8','uint8','short','ushort','intc','uintc',
         'longlong','ulonglong','single','double','longdouble',
         'csingle','cdouble','clongdouble']
+bitwise_dtypes = ['bool', 'int8','uint8','short','ushort','intc','uintc',
+        'longlong','ulonglong']
 supported_dtypes = [np.typeDict[x] for x in supported_dtypes]
-
+supported_bitwise_dtypes = [np.typeDict[x] for x in bitwise_dtypes]
 _upcast_memo = {}
 
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2887,7 +2887,7 @@ class _TestMinMax(object):
         X = -X
         assert_equal(X.max(), -1)
 
-        # and a fully sparse matrix`
+        # and a fully sparse matrix
         Z = self.spmatrix(np.zeros(1))
         assert_equal(Z.min(), 0)
         assert_equal(Z.max(), 0)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -39,7 +39,7 @@ import scipy.sparse as sparse
 from scipy.sparse import (csc_matrix, csr_matrix, dok_matrix,
         coo_matrix, lil_matrix, dia_matrix, bsr_matrix,
         eye, isspmatrix, SparseEfficiencyWarning, issparse)
-from scipy.sparse.sputils import supported_dtypes, isscalarlike, get_index_dtype
+from scipy.sparse.sputils import supported_dtypes, isscalarlike, get_index_dtype, supported_bitwise_dtypes
 from scipy.sparse.linalg import splu, expm, inv
 
 from scipy.lib._version import NumpyVersion
@@ -181,6 +181,10 @@ class BinopTester(object):
 class _TestCommon:
     """test common functionality shared by all sparse formats"""
     checked_dtypes = supported_dtypes
+    
+    @property
+    def checked_bitwise_dtypes(self):
+        return [x for x in self.checked_dtypes if x in supported_bitwise_dtypes]
 
     def __init__(self):
         # Canonical data.
@@ -1050,6 +1054,82 @@ class _TestCommon:
                 continue
 
             yield check, dtype
+
+    def test_and(self):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
+            a = dat.copy()
+            a[0,2] = 2.0
+            b = datsp
+            c = b & a
+            assert_array_equal(c, b.todense() & a)
+
+        for dtype in self.checked_bitwise_dtypes:
+            yield check, dtype
+
+    def test_rand(self):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+            
+            a = dat.copy()
+            a[0,2] = 2.0
+            b = datsp
+            c = a & b
+            assert_array_equal(c, a & b.todense())
+             
+    def test_or(self):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
+            a = dat.copy()
+            a[0,2] = 2.0
+            b = datsp
+            c = b | a
+            assert_array_equal(c, b.todense() | a)
+            
+        for dtype in self.checked_bitwise_dtypes:
+            yield check, dtype
+
+    def test_ror(self):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+            
+            a = dat.copy()
+            a[0,2] = 2.0
+            b = datsp
+            c = a | b
+            assert_array_equal(c, a | b.todense())
+
+    def test_xor(self):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+
+            a = dat.copy()
+            a[0,2] = 2.0
+            b = datsp
+            c = b ^ a
+            assert_array_equal(c, b.todense() ^ a)
+            
+        for dtype in self.checked_bitwise_dtypes:
+            yield check, dtype
+
+    def test_rxor(self):
+        def check(dtype):
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+            
+            a = dat.copy()
+            a[0,2] = 2.0
+            b = datsp
+            c = a ^ b
+            assert_array_equal(c, a ^ b.todense())
+
 
     def test_add0(self):
         def check(dtype):
@@ -2807,7 +2887,7 @@ class _TestMinMax(object):
         X = -X
         assert_equal(X.max(), -1)
 
-        # and a fully sparse matrix
+        # and a fully sparse matrix`
         Z = self.spmatrix(np.zeros(1))
         assert_equal(Z.min(), 0)
         assert_equal(Z.max(), 0)


### PR DESCRIPTION
This partially fixes #3590, implementing bitwise &,| and ^ for sparse arrays. It provides **and**, **rand**, etc methods similar to the **add**, **radd**, etc methods which convert to csr and dispatch to the appropriate C++ std::bit_and, std::bit_or std::bit_xor method, with some checking that the datatype is appropriate for bitwise operations. The additional tests check functionality on valid types, but I might not have handled appropriate return types for impossible operations (e.g. float64 & complex). 

I've not implemented negation for various reasons, many discussed in #1166

First PR so let me know if I'm doing it wrong!
