### PR TITLE
FIX: Raise value error if window data-type is unsupported

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
+import unittest
 
 import warnings
 import numpy as np
@@ -100,7 +101,7 @@ class TestChebWin(object):
         assert_array_almost_equal(cheb_even, cheb_even_low_at_true, decimal=4)
 
 
-class TestGetWindow(object):
+class TestGetWindow(unittest.TestCase):
 
     def test_boxcar(self):
         w = signal.get_window('boxcar', 12)
@@ -117,6 +118,15 @@ class TestGetWindow(object):
             warnings.simplefilter("ignore", UserWarning)
             w = signal.get_window(('chebwin', -40), 54, fftbins=False)
         assert_array_almost_equal(w, cheb_even_true, decimal=4)
+
+    def test_array_as_window(self):
+        # github issue 3603
+        osfactor = 128
+        sig = np.arange(128)
+
+        win = signal.get_window(('kaiser', 8.0), osfactor // 2)
+        with self.assertRaises(ValueError):
+            sig = signal.resample(sig, len(sig) * osfactor, window=win)
 
 
 def test_windowfunc_basics():

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -1,12 +1,10 @@
 from __future__ import division, print_function, absolute_import
 
-import unittest
-
 import warnings
 import numpy as np
 from numpy import array
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
-                           run_module_suite)
+                           run_module_suite, assert_raises)
 from scipy import signal
 
 
@@ -101,7 +99,7 @@ class TestChebWin(object):
         assert_array_almost_equal(cheb_even, cheb_even_low_at_true, decimal=4)
 
 
-class TestGetWindow(unittest.TestCase):
+class TestGetWindow(object):
 
     def test_boxcar(self):
         w = signal.get_window('boxcar', 12)
@@ -125,8 +123,7 @@ class TestGetWindow(unittest.TestCase):
         sig = np.arange(128)
 
         win = signal.get_window(('kaiser', 8.0), osfactor // 2)
-        with self.assertRaises(ValueError):
-            sig = signal.resample(sig, len(sig) * osfactor, window=win)
+        assert_raises(ValueError, signal.resample, (sig, len(sig) * osfactor), {'window': win})
 
 
 def test_windowfunc_basics():

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -1342,7 +1342,7 @@ def cosine(M, sym=True):
     w : ndarray
         The window, with the maximum value normalized to 1 (though the value 1
         does not appear if `M` is even and `sym` is True).
-    
+
     Notes
     -----
 
@@ -1464,6 +1464,8 @@ def get_window(window, Nx, fftbins=True):
                                     "more parameters  -- pass a tuple.")
             else:
                 winstr = window
+        else:
+            raise ValueError("%s as window type is not supported." % str(type(window)))
 
         if winstr in ['blackman', 'black', 'blk']:
             winfunc = blackman


### PR DESCRIPTION
Added unittest. (I had to derive the Test class from unittest.TestCase to use
self.asserRaises. This had no effect on the other tests of this class as they
use numpys test assertions. The number of executed tests was unchanged.
Fixes #3603
