### PR TITLE
step size parameter for check_grad

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -613,7 +613,7 @@ def approx_fprime(xk, f, epsilon, *args):
     return grad
 
 
-def check_grad(func, grad, x0, *args):
+def check_grad(func, grad, x0, step=_epsilon, *args):
     """Check the correctness of a gradient function by comparing it against a
     (forward) finite-difference approximation of the gradient.
 
@@ -626,6 +626,9 @@ def check_grad(func, grad, x0, *args):
     x0 : ndarray
         Points to check `grad` against forward difference approximation of grad
         using `func`.
+    step : float, optional
+        Step size for the finite difference approximation. Defaults to
+        `sqrt(numpy.finfo(float).eps)`, which is approximately 1.49e-08.
     args : \*args, optional
         Extra arguments passed to `func` and `grad`.
 
@@ -640,11 +643,6 @@ def check_grad(func, grad, x0, *args):
     --------
     approx_fprime
 
-    Notes
-    -----
-    The step size used for the finite difference approximation is
-    `sqrt(numpy.finfo(float).eps)`, which is approximately 1.49e-08.
-
     Examples
     --------
     >>> def func(x): return x[0]**2 - 0.5 * x[1]**3
@@ -654,7 +652,7 @@ def check_grad(func, grad, x0, *args):
 
     """
     return sqrt(sum((grad(x0, *args) -
-                     approx_fprime(x0, func, _epsilon, *args))**2))
+                     approx_fprime(x0, func, step, *args))**2))
 
 
 def approx_fhess_p(x0, p, fprime, epsilon, *args):

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -628,7 +628,7 @@ def check_grad(func, grad, x0, step=_epsilon, *args):
         using `func`.
     step : float, optional
         Step size for the finite difference approximation. Defaults to
-        ``sqrt(numpy.finfo(float).eps)``, which is approximately 1.49e-08.
+        `sqrt(numpy.finfo(float).eps)`, which is approximately 1.49e-08.
     args : \*args, optional
         Extra arguments passed to `func` and `grad`.
 

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -613,7 +613,7 @@ def approx_fprime(xk, f, epsilon, *args):
     return grad
 
 
-def check_grad(func, grad, x0, *args):
+def check_grad(func, grad, x0, *args, **kwargs):
     """Check the correctness of a gradient function by comparing it against a
     (forward) finite-difference approximation of the gradient.
 
@@ -628,6 +628,11 @@ def check_grad(func, grad, x0, *args):
         using `func`.
     args : \*args, optional
         Extra arguments passed to `func` and `grad`.
+    kwargs : \*\*kwargs, optional
+        The step size used for the finite difference approximation can be
+        specified by passing the keyword argument `epsilon`. Otherwise,
+        it defaults to ``sqrt(numpy.finfo(float).eps)``, which is approximately
+        1.49e-08.
 
     Returns
     -------
@@ -640,11 +645,6 @@ def check_grad(func, grad, x0, *args):
     --------
     approx_fprime
 
-    Notes
-    -----
-    The step size used for the finite difference approximation is
-    `sqrt(numpy.finfo(float).eps)`, which is approximately 1.49e-08.
-
     Examples
     --------
     >>> def func(x): return x[0]**2 - 0.5 * x[1]**3
@@ -653,8 +653,9 @@ def check_grad(func, grad, x0, *args):
     2.9802322387695312e-08
 
     """
+    step = kwargs.get('epsilon', _epsilon)
     return sqrt(sum((grad(x0, *args) -
-                     approx_fprime(x0, func, _epsilon, *args))**2))
+                     approx_fprime(x0, func, step, *args))**2))
 
 
 def approx_fhess_p(x0, p, fprime, epsilon, *args):

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -628,11 +628,9 @@ def check_grad(func, grad, x0, *args, **kwargs):
         using `func`.
     args : \*args, optional
         Extra arguments passed to `func` and `grad`.
-    kwargs : \*\*kwargs, optional
-        The step size used for the finite difference approximation can be
-        specified by passing the keyword argument `epsilon`. Otherwise,
-        it defaults to ``sqrt(numpy.finfo(float).eps)``, which is approximately
-        1.49e-08.
+    epsilon : float, optional
+        Step size used for the finite difference approximation. It defaults to
+        ``sqrt(numpy.finfo(float).eps)``, which is approximately 1.49e-08.
 
     Returns
     -------
@@ -653,7 +651,10 @@ def check_grad(func, grad, x0, *args, **kwargs):
     2.9802322387695312e-08
 
     """
-    step = kwargs.get('epsilon', _epsilon)
+    step = kwargs.pop('epsilon', _epsilon)
+    if kwargs:
+        raise ValueError("Unknown keyword arguments: %r" %
+                         (list(kwargs.keys()),))
     return sqrt(sum((grad(x0, *args) -
                      approx_fprime(x0, func, step, *args))**2))
 

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -613,7 +613,7 @@ def approx_fprime(xk, f, epsilon, *args):
     return grad
 
 
-def check_grad(func, grad, x0, step=_epsilon, *args):
+def check_grad(func, grad, x0, *args):
     """Check the correctness of a gradient function by comparing it against a
     (forward) finite-difference approximation of the gradient.
 
@@ -626,9 +626,6 @@ def check_grad(func, grad, x0, step=_epsilon, *args):
     x0 : ndarray
         Points to check `grad` against forward difference approximation of grad
         using `func`.
-    step : float, optional
-        Step size for the finite difference approximation. Defaults to
-        `sqrt(numpy.finfo(float).eps)`, which is approximately 1.49e-08.
     args : \*args, optional
         Extra arguments passed to `func` and `grad`.
 
@@ -643,6 +640,11 @@ def check_grad(func, grad, x0, step=_epsilon, *args):
     --------
     approx_fprime
 
+    Notes
+    -----
+    The step size used for the finite difference approximation is
+    `sqrt(numpy.finfo(float).eps)`, which is approximately 1.49e-08.
+
     Examples
     --------
     >>> def func(x): return x[0]**2 - 0.5 * x[1]**3
@@ -652,7 +654,7 @@ def check_grad(func, grad, x0, step=_epsilon, *args):
 
     """
     return sqrt(sum((grad(x0, *args) -
-                     approx_fprime(x0, func, step, *args))**2))
+                     approx_fprime(x0, func, _epsilon, *args))**2))
 
 
 def approx_fhess_p(x0, p, fprime, epsilon, *args):

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -628,7 +628,7 @@ def check_grad(func, grad, x0, step=_epsilon, *args):
         using `func`.
     step : float, optional
         Step size for the finite difference approximation. Defaults to
-        `sqrt(numpy.finfo(float).eps)`, which is approximately 1.49e-08.
+        ``sqrt(numpy.finfo(float).eps)``, which is approximately 1.49e-08.
     args : \*args, optional
         Extra arguments passed to `func` and `grad`.
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -15,9 +15,34 @@ import warnings
 
 import numpy as np
 from numpy.testing import (assert_raises, assert_allclose, assert_equal,
-                           assert_, TestCase, run_module_suite, dec)
+                           assert_, TestCase, run_module_suite, dec,
+                           assert_almost_equal)
 
 from scipy import optimize
+
+
+def test_check_grad():
+    """ Verify if check_grad is able to estimate the derivative of the
+    logistic function.
+    """
+
+    def logit(x):
+        return 1 / (1 + np.exp(-x))
+
+    def der_logit(x):
+        return np.exp(-x) / (1 + np.exp(-x))**2
+
+    x0 = np.array([1.5])
+
+    r = optimize.check_grad(logit, der_logit, x0)
+    assert_almost_equal(r, 0)
+
+    r = optimize.check_grad(logit, der_logit, x0, epsilon=1e-6)
+    assert_almost_equal(r, 0)
+
+    # Check if the epsilon parameter is being considered.
+    r = abs(optimize.check_grad(logit, der_logit, x0, epsilon=1e-1) - 0)
+    assert r > 1e-7
 
 
 class TestOptimize(object):

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -22,9 +22,8 @@ from scipy import optimize
 
 
 def test_check_grad():
-    """ Verify if check_grad is able to estimate the derivative of the
-    logistic function.
-    """
+    # Verify if check_grad is able to estimate the derivative of the
+    # logistic function.
 
     def logit(x):
         return 1 / (1 + np.exp(-x))
@@ -42,7 +41,7 @@ def test_check_grad():
 
     # Check if the epsilon parameter is being considered.
     r = abs(optimize.check_grad(logit, der_logit, x0, epsilon=1e-1) - 0)
-    assert r > 1e-7
+    assert_(r > 1e-7)
 
 
 class TestOptimize(object):


### PR DESCRIPTION
I use finite difference approximation for checking my derivatives. However, I'm cannot use check_grad from scipy for several of those because the (fixed) step size of check_grad is too small. I propose this modification for letting the user decide whether to use the default step size or not.
