### PR TITLE
Fixed signal.get_window with unicode window name

### DIFF
--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -6,6 +6,7 @@ import warnings
 import numpy as np
 from scipy import special, linalg
 from scipy.fftpack import fft
+from scipy.lib.six import string_types
 
 __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
            'blackmanharris', 'flattop', 'bartlett', 'hanning', 'barthann',
@@ -1454,7 +1455,7 @@ def get_window(window, Nx, fftbins=True):
             winstr = window[0]
             if len(window) > 1:
                 args = window[1:]
-        elif isinstance(window, str):
+        elif isinstance(window, string_types):
             if window in ['kaiser', 'ksr', 'gaussian', 'gauss', 'gss',
                         'general gaussian', 'general_gaussian',
                         'general gauss', 'general_gauss', 'ggs',


### PR DESCRIPTION
This minor fix allows unicode objects to be used in scipy.signal.get_window.

This code does not fail anymore (python2):
    from scipy.signal import get_window
    get_window(u'blackman', 32) # This failed because u'blackman' is not a string on python2.

This code does not fail anymore (python2):
    from **future** import unicode_literals
    from scipy.signal import get_window
    get_window('blackman', 32) # This failed because u'blackman' is unicode
