### PR TITLE
DOC: fix a couple of issues in stats docstrings.

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1271,8 +1271,7 @@ class rv_continuous(rv_generic):
     ``fit(data, <shape(s)>, loc=0, scale=1)``
         Parameter estimates for generic data
 
-    ``expect(func=None, args=(), loc=0, scale=1, lb=None, ub=None,
-             conditional=False, **kwds)``
+    ``expect(func=None, args=(), loc=0, scale=1, lb=None, ub=None, conditional=False, **kwds)``
         Expected value of a function with respect to the distribution.
         Additional kwd arguments passed to integrate.quad
 
@@ -2476,8 +2475,7 @@ class rv_discrete(rv_generic):
     ``generic.entropy(<shape(s)>, loc=0)``
         entropy of the RV
 
-    ``generic.expect(func=None, args=(), loc=0, lb=None, ub=None,
-            conditional=False)``
+    ``generic.expect(func=None, args=(), loc=0, lb=None, ub=None, conditional=False)``
         Expected value of a function with respect to the distribution.
         Additional kwd arguments passed to integrate.quad
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3114,7 +3114,11 @@ def theilslopes(y, x=None, alpha=0.95):
     >>> res = stats.theilslopes(y, x, 0.90)
     >>> lsq_res = stats.linregress(x, y)
 
-    Plot the results:
+    Plot the results. The Theil-Sen regression line is shown in red, with the
+    dashed red lines illustrating the confidence interval of the slope (note
+    that the dashed red lines are not the confidence interval of the regression
+    as the confidence interval of the intercept is not included). The green
+    line shows the least-squares fit for comparison.
 
     >>> fig = plt.figure()
     >>> ax = fig.add_subplot(111)
@@ -3124,13 +3128,6 @@ def theilslopes(y, x=None, alpha=0.95):
     >>> ax.plot(x, res[1] + res[3] * x, 'r--')
     >>> ax.plot(x, lsq_res[1] + lsq_res[0] * x, 'g-')
     >>> plt.show()
-
-    The Theil-Sen regression line is shown in red, with the dashed red
-    lines illustrating the confidence interval of the slope (note that
-    the dashed red lines are not the confidence interval of the
-    regression as the confidence interval of the intercept is not
-    included). The green line shows the least-squares fit for
-    comparison.
 
     """
     y = np.asarray(y).flatten()


### PR DESCRIPTION
Code in double backticks should be on a single line.
`stats.theilslopes` plot wasn't rendering, apparently text in docstring
examples cannot be at the end.
