### PR TITLE
TST: sparse: remove known failure that doesn't fail

### DIFF
--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -981,10 +981,7 @@ class _TestCommon:
             assert_array_equal(17.3*dat,(17.3*datsp).todense())
 
         for dtype in self.checked_dtypes:
-            fails = ((dtype == np.typeDict['int']) and
-                     isinstance(self, (TestLIL, TestDOK)))
-            msg = "LIL and DOK type's __rmul__ method has problems with int data."
-            yield dec.knownfailureif(fails, msg)(check), dtype
+            yield check, dtype
 
     def test_add(self):
         def check(dtype):


### PR DESCRIPTION
I tried various multiplications of scalars and DOK/LIL matrices, and I didn't get any unexpected results. (Maybe this fails for older NumPy, but in that case the test should be more specific.)
