### PR TITLE
TST: switch from Rackspace wheelhouse to numpy/cython source installs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
         - PYFLAKES_NODOCTEST=1 pyflakes scipy | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused' > test.out; cat test.out; test \! -s test.out
         - pep8 scipy
 before_install:
-  # Automated travis-ci wheel builds
+  # Automated travis-ci wheel builds (disabled because intermittent issues)
   - WHEELHOUSE=https://8167b5c3a2af93a0a9fb-13c6eee0d707a05fa610c311eec04c66.ssl.cf2.rackcdn.com/
   - uname -a
   - free -m
@@ -54,7 +54,8 @@ before_install:
   - mkdir builds
   - pushd builds
   # Slow installs, force binary wheels
-  - pip install --find-links $WHEELHOUSE --no-index Cython numpy$NUMPYSPEC
+  - pip install Cython
+  - pip install numpy$NUMPYSPEC
   - pip install nose mpmath argparse
   - pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - if [ "${TESTMODE}" == "full" ]; then pip install coverage coveralls; fi


### PR DESCRIPTION
The Wheelhouse seems to have frequent connectivity issues, and
building Numpy and Cython only takes a couple of minutes.

See gh-3883.
