### PR TITLE
signal.__init__.py: remove duplicated `get_window` entry

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -60,7 +60,6 @@ Filtering
 
    hilbert       -- Compute 1-D analytic signal, using the Hilbert transform.
    hilbert2      -- Compute 2-D analytic signal, using the Hilbert transform.
-   get_window    -- Create FIR window.
 
    decimate      -- Downsample a signal.
    detrend       -- Remove linear and/or constant trends from data.


### PR DESCRIPTION
For a moment I was a bit confused about a duplicated mention of `get_window` routine(s) (with different description) in the overview of `scipy.signal` (i.e. in `scipy.signal.__init__.py` docstring). So for a moment I was concerned about a possible name clash, especially because I stumbled over this trying to restore backwards compatibility in our code (regarding the "new" `signal.windows` submodule).

I think it should be avoided to mention the routine (it seems there never was a different routine with the same name) twice in two different sections.

I'm basing this on `master` being a bit unsure whether it should rather be based on the current maintanance branch..
