### PR TITLE
ENH: reshape sparse matrices

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -83,7 +83,11 @@ class spmatrix(object):
             raise ValueError('invalid shape')
 
         if (self._shape != shape) and (self._shape is not None):
-            raise NotImplementedError('sparse matrix shape setting magic is broken')
+            raise NotImplementedError(
+                    'Changing the shape of a sparse matrix by directly '
+                    'modifying its .shape property is not currently '
+                    'supported.  Please consider using the .reshape() '
+                    'member function instead!')
             try:
                 self = self.reshape(shape)
             except NotImplementedError:

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -95,8 +95,9 @@ class spmatrix(object):
 
     shape = property(fget=get_shape, fset=set_shape)
 
-    def reshape(self,shape):
-        raise NotImplementedError
+    def reshape(self, shape):
+        """Returns a coo_matrix with shape `shape`."""
+        return self.tocoo().reshape(shape)
 
     def astype(self, t):
         return self.tocsr().astype(t).asformat(self.format)

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -96,8 +96,7 @@ class spmatrix(object):
     shape = property(fget=get_shape, fset=set_shape)
 
     def reshape(self, shape):
-        """Returns a coo_matrix with shape `shape`."""
-        return self.tocoo().reshape(shape)
+        return self.tocoo().reshape(shape).asformat(self.format)
 
     def astype(self, t):
         return self.tocsr().astype(t).asformat(self.format)

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -657,7 +657,7 @@ class spmatrix(object):
         return self.tocsr().tobsr(blocksize=blocksize)
 
     def copy(self):
-        return self.__class__(self,copy=True)
+        return self.__class__(self, copy=True)
 
     def sum(self, axis=None):
         """Sum the matrix over the given axis.  If the axis is None, sum

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -83,6 +83,7 @@ class spmatrix(object):
             raise ValueError('invalid shape')
 
         if (self._shape != shape) and (self._shape is not None):
+            raise NotImplementedError('sparse matrix shape setting magic is broken')
             try:
                 self = self.reshape(shape)
             except NotImplementedError:

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -205,7 +205,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
         self._check()
 
-    def reshape(self, shape, copy=True):
+    def reshape(self, shape, copy=False):
         """Returns a coo_matrix with shape `shape`."""
         if not isshape(shape):
             raise ValueError('`shape` must be a sequence of two integers')

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -213,7 +213,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         nrows, ncols = self.shape
         size = nrows * ncols
 
-        new_size =  shape[0] * shape[1]
+        new_size = shape[0] * shape[1]
         if new_size != size:
             raise ValueError('total size of new array must be unchanged')
 

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -207,7 +207,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
     def reshape(self, shape, copy=True):
         """Returns a coo_matrix with shape `shape`."""
-        if not hasattr(shape, '__len__') or len(shape) != 2:
+        if not isshape(shape):
             raise ValueError('`shape` must be a sequence of two integers')
 
         nrows, ncols = self.shape

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -205,7 +205,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
         self._check()
 
-    def reshape(self, shape):
+    def reshape(self, shape, copy=True):
         """Returns a coo_matrix with shape `shape`."""
         if not hasattr(shape, '__len__') or len(shape) != 2:
             raise ValueError('`shape` must be a sequence of two integers')
@@ -220,7 +220,8 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         flat_indices = ncols * self.row + self.col
         new_row, new_col = divmod(flat_indices, shape[1])
 
-        return coo_matrix((self.data, (new_row, new_col)), shape=shape)
+        return coo_matrix((self.data, (new_row, new_col)),
+                          shape=shape, copy=copy)
 
     def getnnz(self, axis=None):
         """Get the count of explicitly-stored values (nonzeros)

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -205,6 +205,23 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
         self._check()
 
+    def reshape(self, shape):
+        """Returns a coo_matrix with shape `shape`."""
+        if not hasattr(shape, '__len__') or len(shape) != 2:
+            raise ValueError('`shape` must be a sequence of two integers')
+
+        nrows, ncols = self.shape
+        size = nrows * ncols
+
+        new_size =  shape[0] * shape[1]
+        if new_size != size:
+            raise ValueError('total size of new array must be unchanged')
+
+        flat_indices = ncols * self.row + self.col
+        new_row, new_col = divmod(flat_indices, shape[1])
+
+        return coo_matrix((self.data, (new_row, new_col)), shape=shape)
+
     def getnnz(self, axis=None):
         """Get the count of explicitly-stored values (nonzeros)
 

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -371,33 +371,6 @@ class lil_matrix(spmatrix, IndexMixin):
         else:
             return self
 
-    def _concatenated_data(self):
-        """ Helper function for format conversions. """
-        data = []
-        for x in self.data:
-            data.extend(x)
-        return np.asarray(data, dtype=self.dtype)
-
-    def _concatenated_indices(self, idx_dtype):
-        """ Helper function for format conversions. """
-        indices = []
-        for x in self.rows:
-            indices.extend(x)
-        return np.asarray(indices, dtype=idx_dtype)
-
-    def tocoo(self):
-        """ Return a COO formatted sparse matrix.
-        """
-        lst = [len(x) for x in self.rows]
-        idx_dtype = get_index_dtype(maxval=max(self.shape[1], sum(lst)))
-
-        rows = np.repeat(np.arange(len(lst), dtype=idx_dtype), lst)
-        cols = self._concatenated_indices(idx_dtype)
-        data = self._concatenated_data()
-
-        from .coo import coo_matrix
-        return coo_matrix((data, (rows, cols)), shape=self.shape)
-
     def tocsr(self):
         """ Return Compressed Sparse Row format arrays for this matrix.
         """
@@ -405,8 +378,8 @@ class lil_matrix(spmatrix, IndexMixin):
         idx_dtype = get_index_dtype(maxval=max(self.shape[1], sum(lst)))
 
         indptr = np.cumsum([0] + lst, dtype=idx_dtype)
-        indices = self._concatenated_indices(idx_dtype)
-        data = self._concatenated_data()
+        indices = np.array([x for y in self.rows for x in y], dtype=idx_dtype)
+        data = np.array([x for y in self.data for x in y], dtype=self.dtype)
 
         from .csr import csr_matrix
         return csr_matrix((data, indices, indptr), shape=self.shape)

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -399,10 +399,7 @@ class lil_matrix(spmatrix, IndexMixin):
         lst = [len(x) for x in self.rows]
         idx_dtype = get_index_dtype(maxval=max(self.shape[1], sum(lst)))
 
-        indptr = np.asarray(lst, dtype=idx_dtype)
-        indptr = np.concatenate((np.array([0], dtype=idx_dtype),
-                                 np.cumsum(indptr, dtype=idx_dtype)))
-
+        indptr = np.cumsum([0] + lst, dtype=idx_dtype)
         indices = self._concatenated_indices(idx_dtype)
         data = self._concatenated_data()
 

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -146,6 +146,7 @@ class lil_matrix(spmatrix, IndexMixin):
             raise ValueError('invalid shape')
 
         if (self._shape != shape) and (self._shape is not None):
+            raise NotImplementedError('sparse matrix shape setting magic is broken')
             try:
                 self = self.reshape(shape)
             except NotImplementedError:

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -146,7 +146,11 @@ class lil_matrix(spmatrix, IndexMixin):
             raise ValueError('invalid shape')
 
         if (self._shape != shape) and (self._shape is not None):
-            raise NotImplementedError('sparse matrix shape setting magic is broken')
+            raise NotImplementedError(
+                    'Changing the shape of a sparse matrix by directly '
+                    'modifying its .shape property is not currently '
+                    'supported.  Please consider using the .reshape() '
+                    'member function instead!')
             try:
                 self = self.reshape(shape)
             except NotImplementedError:

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -349,15 +349,6 @@ class lil_matrix(spmatrix, IndexMixin):
         new.rows = deepcopy(self.rows)
         return new
 
-    def reshape(self,shape):
-        new = lil_matrix(shape, dtype=self.dtype)
-        j_max = self.shape[1]
-        for i,row in enumerate(self.rows):
-            for col,j in enumerate(row):
-                new_r,new_c = np.unravel_index(i*j_max + j,shape)
-                new[new_r,new_c] = self[i,j]
-        return new
-
     def toarray(self, order=None, out=None):
         """See the docstring for `spmatrix.toarray`."""
         d = self._process_toarray_args(order, out)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3653,6 +3653,20 @@ class TestCOO(sparse_test_class(getset=False,
         dok = coo.todok()
         assert_array_equal(dok.A, coo.A)
 
+    def test_reshape_copy(self):
+        arr = [[0, 10, 0, 0], [0, 0, 0, 0], [0, 20, 30, 40]]
+        new_shape = (2, 6)
+        x = coo_matrix(arr)
+
+        y = x.reshape(new_shape)
+        assert_(y.data is not x.data)
+
+        y = x.reshape(new_shape, copy=True)
+        assert_(y.data is not x.data)
+
+        y = x.reshape(new_shape, copy=False)
+        assert_(y.data is x.data)
+
 
 class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False,

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -621,10 +621,18 @@ class _TestCommon:
             assert_equal(self.spmatrix(m).diagonal(),diag(m))
 
     def test_reshape(self):
+        # This first example is taken from the lil_matrix reshaping test.
         x = self.spmatrix([[1, 0, 7], [0, 0, 0], [0, 3, 0], [0, 0, 5]])
         for s in [(12,1),(1,12)]:
             assert_array_equal(x.reshape(s).todense(),
                                x.todense().reshape(s))
+
+        # This example is taken from the stackoverflow answer at
+        # http://stackoverflow.com/questions/16511879
+        x = self.spmatrix([[0, 10, 0, 0], [0, 0, 0, 0], [0, 20, 30, 40]])
+        y = x.reshape((2, 6))
+        desired = [[0, 10, 0, 0, 0, 0], [0, 0, 0, 20, 30, 40]]
+        assert_array_equal(y.A, desired)
 
     @dec.slow
     def test_setdiag(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3659,13 +3659,13 @@ class TestCOO(sparse_test_class(getset=False,
         x = coo_matrix(arr)
 
         y = x.reshape(new_shape)
-        assert_(not np.may_share_memory(y.data, x.data))
-
-        y = x.reshape(new_shape, copy=True)
-        assert_(not np.may_share_memory(y.data, x.data))
+        assert_(y.data is x.data)
 
         y = x.reshape(new_shape, copy=False)
         assert_(y.data is x.data)
+
+        y = x.reshape(new_shape, copy=True)
+        assert_(not np.may_share_memory(y.data, x.data))
 
 
 class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=False,

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -620,6 +620,12 @@ class _TestCommon:
         for m in mats:
             assert_equal(self.spmatrix(m).diagonal(),diag(m))
 
+    def test_reshape(self):
+        x = self.spmatrix([[1, 0, 7], [0, 0, 0], [0, 3, 0], [0, 0, 5]])
+        for s in [(12,1),(1,12)]:
+            assert_array_equal(x.reshape(s).todense(),
+                               x.todense().reshape(s))
+
     @dec.slow
     def test_setdiag(self):
         def dense_setdiag(a, v, k):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3500,17 +3500,6 @@ class TestLIL(sparse_test_class(minmax=False)):
         x = x*0
         assert_equal(x[0,0],0)
 
-    def test_reshape(self):
-        x = lil_matrix((4,3))
-        x[0,0] = 1
-        x[2,1] = 3
-        x[3,2] = 5
-        x[0,2] = 7
-
-        for s in [(12,1),(1,12)]:
-            assert_array_equal(x.reshape(s).todense(),
-                               x.todense().reshape(s))
-
     def test_inplace_ops(self):
         A = lil_matrix([[0,2,3],[4,0,6]])
         B = lil_matrix([[0,1,0],[0,2,3]])

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3659,10 +3659,10 @@ class TestCOO(sparse_test_class(getset=False,
         x = coo_matrix(arr)
 
         y = x.reshape(new_shape)
-        assert_(y.data is not x.data)
+        assert_(not np.may_share_memory(y.data, x.data))
 
         y = x.reshape(new_shape, copy=True)
-        assert_(y.data is not x.data)
+        assert_(not np.may_share_memory(y.data, x.data))
 
         y = x.reshape(new_shape, copy=False)
         assert_(y.data is x.data)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -632,6 +632,7 @@ class _TestCommon:
         x = self.spmatrix([[0, 10, 0, 0], [0, 0, 0, 0], [0, 20, 30, 40]])
         y = x.reshape((2, 6))
         desired = [[0, 10, 0, 0, 0, 0], [0, 0, 0, 20, 30, 40]]
+        assert_equal(y.format, x.format)
         assert_array_equal(y.A, desired)
 
     @dec.slow


### PR DESCRIPTION
closes https://github.com/scipy/scipy/issues/3507

Before this PR, sparse matrix reshaping raised `NotImplementedError` except with the `lil_matrix` format.

The coordinate conversion implementation is due to @WarrenWeckesser at http://stackoverflow.com/questions/16511879 so please do not merge until he approves.

The test added to the base class is modeled on the only existing sparse matrix reshaping test -- the `test_reshape` test for `lil_matrix`.
