### PR TITLE
BUG: io.netcdf: do not close mmap if there are references left to it

### DIFF
--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -102,7 +102,9 @@ class netcdf_file(object):
     mmap : None or bool, optional
         Whether to mmap `filename` when reading.  Default is True
         when `filename` is a file name, False when `filename` is a
-        file-like object
+        file-like object. Note that when mmap is in use, data arrays
+        returned refer directly to the mmapped data on disk, and the
+        file cannot be closed as long as references to it exist.
     version : {1, 2}, optional
         version of netcdf to read / write, where 1 means *Classic
         format* and 2 means *64-bit offset format*.  Default is 1.  See
@@ -146,6 +148,13 @@ class netcdf_file(object):
     unnecessary data into memory. It uses the ``mmap`` module to create
     Numpy arrays mapped to the data on disk, for the same purpose.
 
+    Note that when `netcdf_file` is used to open a file with mmap=True
+    (default for read-only), arrays returned by it refer to data
+    directly on the disk. The file should not be closed, and cannot be cleanly
+    closed when asked, if such arrays are alive. You may want to explicitly copy
+    data arrays obtained from mmapped Netcdf file, if they are to be processed after
+    the file is closed.
+
     Examples
     --------
     To create a NetCDF file:
@@ -184,6 +193,7 @@ class netcdf_file(object):
         >>> with netcdf.netcdf_file('simple.nc', 'r') as f:
         >>>     print(f.history)
         Created for a test
+
     """
     def __init__(self, filename, mode='r', mmap=None, version=1):
         """Initialize netcdf_file from fileobj (str or file-like)."""

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -151,9 +151,9 @@ class netcdf_file(object):
     Note that when `netcdf_file` is used to open a file with mmap=True
     (default for read-only), arrays returned by it refer to data
     directly on the disk. The file should not be closed, and cannot be cleanly
-    closed when asked, if such arrays are alive. You may want to explicitly copy
-    data arrays obtained from mmapped Netcdf file, if they are to be processed after
-    the file is closed.
+    closed when asked, if such arrays are alive. You may want to copy data arrays
+    obtained from mmapped Netcdf file if they are to be processed after the file
+    is closed, see the example below.
 
     Examples
     --------
@@ -185,7 +185,20 @@ class netcdf_file(object):
         (10,)
         >>> print(time[-1])
         9
+
+    NetCDF files, when opened read-only, return arrays that refer
+    directly to memory-mapped data on disk:
+
+        >>> data = time[:]
+        >>> data.base.base
+        <mmap.mmap object at 0x7fe753763180>
+
+    If the data is to be processed after the file is closed, it needs
+    to be copied to main memory:
+
+        >>> data = time[:].copy()
         >>> f.close()
+        >>> data.mean()
 
     A NetCDF file can also be used as context manager:
 

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -226,17 +226,6 @@ def test_ticket_1720():
         assert_allclose(float_var[:], items)
 
 
-def test_mmaps_closed():
-    # Regression test for gh-1550.  Will fail with "Too many open files"
-    # error if not all mmaps aren't closed by ``f.close()``.
-    filename = pjoin(TEST_DATA_PATH, 'example_1.nc')
-    vars = []
-    for i in range(1100):
-        f = netcdf_file(filename, mmap=True)
-        vars.append(f.variables['lat'][:].copy())
-        f.close()
-
-
 def test_mmaps_segfault():
     filename = pjoin(TEST_DATA_PATH, 'example_1.nc')
 

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -157,12 +157,16 @@ def test_read_example_data():
 def test_itemset_no_segfault_on_readonly():
     # Regression test for ticket #1202.
     # Open the test file in read-only mode.
-    filename = pjoin(TEST_DATA_PATH, 'example_1.nc')
-    with netcdf_file(filename, 'r') as f:
-        time_var = f.variables['time']
 
-    # time_var.assignValue(42) should raise a RuntimeError--not seg. fault!
-    assert_raises(RuntimeError, time_var.assignValue, 42)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        filename = pjoin(TEST_DATA_PATH, 'example_1.nc')
+        with netcdf_file(filename, 'r') as f:
+            time_var = f.variables['time']
+
+        # time_var.assignValue(42) should raise a RuntimeError--not seg. fault!
+        assert_raises(RuntimeError, time_var.assignValue, 42)
 
 
 def test_write_invalid_dtype():
@@ -239,9 +243,6 @@ def test_mmaps_segfault():
     def doit():
         with netcdf_file(filename, mmap=True) as f:
             return f.variables['lat'][:]
-
-    # should raise a warning
-    assert_warns(RuntimeWarning, doit)
 
     # should not crash
     with warnings.catch_warnings():


### PR DESCRIPTION
Fixes segfaults when using arrays referring to a closed memmapped netcdf_file, by detecting whether the memmap is still in use.

The 0.14.x branch will need a slightly different fix as the code there is different.

Supercedes gh-3633
Fixes gh-3630
