### PR TITLE
Revert segfault-causing netcdf changes in 0.14.x

### DIFF
--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -43,6 +43,7 @@ from functools import reduce
 
 from scipy.lib.six import integer_types
 
+
 ABSENT = b'\x00\x00\x00\x00\x00\x00\x00\x00'
 ZERO = b'\x00\x00\x00\x00'
 NC_BYTE = b'\x00\x00\x00\x01'
@@ -198,7 +199,6 @@ class netcdf_file(object):
             if mmap is None:
                 mmap = True
         self.use_mmap = mmap
-        self._fds = []
         self.version_byte = version
 
         if not mode in 'rw':
@@ -231,8 +231,6 @@ class netcdf_file(object):
         if not self.fp.closed:
             try:
                 self.flush()
-                for mmap_fd in self._fds:
-                    mmap_fd.close()
             finally:
                 self.fp.close()
     __del__ = close
@@ -598,7 +596,6 @@ class netcdf_file(object):
                     mm = mmap(self.fp.fileno(), begin_+a_size, access=ACCESS_READ)
                     data = ndarray.__new__(ndarray, shape, dtype=dtype_,
                             buffer=mm, offset=begin_, order=0)
-                    self._fds.append(mm)
                 else:
                     pos = self.fp.tell()
                     self.fp.seek(begin_)
@@ -621,7 +618,6 @@ class netcdf_file(object):
                 mm = mmap(self.fp.fileno(), begin+self._recs*self._recsize, access=ACCESS_READ)
                 rec_array = ndarray.__new__(ndarray, (self._recs,), dtype=dtypes,
                         buffer=mm, offset=begin, order=0)
-                self._fds.append(mm)
             else:
                 pos = self.fp.tell()
                 self.fp.seek(begin)
@@ -631,7 +627,6 @@ class netcdf_file(object):
 
             for var in rec_vars:
                 self.variables[var].__dict__['data'] = rec_array[var]
-
 
     def _read_var(self):
         name = asstr(self._unpack_string())

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -5,12 +5,14 @@ import os
 from os.path import join as pjoin, dirname
 import shutil
 import tempfile
+import time
+import sys
 from io import BytesIO
 from glob import glob
 from contextlib import contextmanager
 
 import numpy as np
-from numpy.testing import assert_, assert_allclose
+from numpy.testing import dec, assert_, assert_allclose
 
 from scipy.io.netcdf import netcdf_file
 
@@ -196,14 +198,3 @@ def test_ticket_1720():
         assert_equal(float_var.units, b'metres')
         assert_equal(float_var.shape, (10,))
         assert_allclose(float_var[:], items)
-
-
-def test_mmaps_closed():
-    # Regression test for gh-1550.  Will fail with "Too many open files"
-    # error if not all mmaps aren't closed by ``f.close()``.
-    filename = pjoin(TEST_DATA_PATH, 'example_1.nc')
-    vars = []
-    for i in range(1100):
-        f = netcdf_file(filename, mmap=True)
-        vars.append(f.variables['lat'])
-        f.close()


### PR DESCRIPTION
This reintroduces gh-1555 to 0.14.x, but solves gh-3630

The other possible option is to backport the whole netdf.py to 0.14.x --- which one to take depends on how minimal changes we want in 0.14.x
