### PR TITLE
BUG: sparse.linalg: make *Inv objects in arpack garbage-collectable by refcount

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -19,8 +19,7 @@ from scipy.linalg import eig, eigh
 from scipy.sparse import csc_matrix, csr_matrix, lil_matrix, isspmatrix
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 from scipy.sparse.linalg.eigen.arpack import eigs, eigsh, svds, \
-     ArpackNoConvergence
-from scipy.sparse.linalg.eigen import arpack
+     ArpackNoConvergence, arpack
 
 from scipy.linalg import svd, hilbert
 


### PR DESCRIPTION
Setting self._method = self._method by passing self._method to
LinearOperator causes a reference cycle in the various inverse
operators. self._method = Class._method works.

The reference cycle prevents these objects from being GC'd immediately
by refcount.  Since these objects hold large amounts of data, it's easy
to run out of memory before cyclic GC runs, if eigs/eigsh is called in a
tight loop, so it's best to not create refcycles here.

[Issue spotted from a post on stackoverflow --- causes eigs/eigsh to appear to leak memory in a tight for loop raising MemoryErrors. The issue can be worked around by calling gc.collect(), but it's best to not create unnecessary refcycles in the first place.]
