### PR TITLE
ENH : a faster io/mmread

### DIFF
--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -459,22 +459,27 @@ class MMFile (object):
                 # fallback - fromfile fails for some file-like objects
                 flat_data = fromstring(stream.read(), sep=' ')
 
-                # TODO use iterator (e.g. xreadlines) to avoid reading
-                # the whole file into memory
+            # Note we have used the default dtype=float in
+            # from(file|string) above
+            total_length = flat_data.shape[0]
+            local_float_size = flat_data.strides[0]
 
             if is_pattern:
-                flat_data = flat_data.reshape(-1,2)
+                flat_data.shape = (total_length / 2, 2)
+                flat_data.strides = (2 * local_float_size, local_float_size)
                 I = ascontiguousarray(flat_data[:,0], dtype='intc')
                 J = ascontiguousarray(flat_data[:,1], dtype='intc')
                 V = ones(len(I), dtype='int8')  # filler
             elif is_complex:
-                flat_data = flat_data.reshape(-1,4)
+                flat_data.shape = (total_length / 4, 4)
+                flat_data.strides = (4 * local_float_size, local_float_size)
                 I = ascontiguousarray(flat_data[:,0], dtype='intc')
                 J = ascontiguousarray(flat_data[:,1], dtype='intc')
                 V = ascontiguousarray(flat_data[:,2], dtype='complex')
                 V.imag = flat_data[:,3]
             else:
-                flat_data = flat_data.reshape(-1,3)
+                flat_data.shape = (total_length / 3, 3)
+                flat_data.strides = (3 * local_float_size, local_float_size)
                 I = ascontiguousarray(flat_data[:,0], dtype='intc')
                 J = ascontiguousarray(flat_data[:,1], dtype='intc')
                 V = ascontiguousarray(flat_data[:,2], dtype='float')


### PR DESCRIPTION
- remove 1 memory copy through manual re-shaping

Tested on a 1.7GB matrix:

``` python
In [2]: print scipy.__version__
0.14.0
In [4]: %timeit io.mmread("/Users/huitseeker/tmp/test.mtx")
1 loops, best of 3: 6min 13s per loop
```

After a4d600f:

``` python
In [15]: %timeit io.mmread("/Users/huitseeker/tmp/test.mtx")
1 loops, best of 3: 5min 46s per loop

In [17]: print scipy.__version__
0.15.0.dev-a4d600f
```

review by @stefanv, who kindly [volunteered](https://twitter.com/stefanvdwalt/status/504617667521945600)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/scipy/scipy/3970)

<!-- Reviewable:end -->
