### PR TITLE
MAINT: better error message for multivariate normal.

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -53,14 +53,21 @@ def _process_parameters(dim, mean, cov):
         cov.shape = (1, 1)
 
     if mean.ndim != 1 or mean.shape[0] != dim:
-        raise ValueError("Array 'mean' must be vector of length %d." % dim)
+        raise ValueError("Array 'mean' must be a vector of length %d." % dim)
     if cov.ndim == 0:
         cov = cov * np.eye(dim)
     elif cov.ndim == 1:
         cov = np.diag(cov)
     elif cov.ndim == 2 and cov.shape != (dim, dim):
-        raise ValueError("Array 'cov' must be square if it is two dimensional,"
-                         " but cov.shape = %s" % str(cov.shape))
+        rows, cols = cov.shape
+        if rows != cols:
+            msg = ("Array 'cov' must be square if it is two dimensional,"
+                   " but cov.shape = %s." % str(cov.shape))
+        else:
+            msg = ("Dimension mismatch: array 'cov' is of shape %s,"
+                   " but 'mean' is a vector of length %d.")
+            msg = msg % (str(cov.shape), len(mean))
+        raise ValueError(msg)
     elif cov.ndim > 2:
         raise ValueError("Array 'cov' must be at most two-dimensional,"
                          " but cov.ndim = %d" % cov.ndim)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3,10 +3,11 @@
 #
 from __future__ import division, print_function, absolute_import
 
-from scipy.misc import doccer
-from functools import wraps
 import numpy as np
 import scipy.linalg
+from scipy.misc import doccer
+from scipy.special import gammaln
+
 
 __all__ = ['multivariate_normal', 'dirichlet']
 
@@ -58,11 +59,11 @@ def _process_parameters(dim, mean, cov):
     elif cov.ndim == 1:
         cov = np.diag(cov)
     elif cov.ndim == 2 and cov.shape != (dim, dim):
-        raise ValueError("Array 'cov' must be square if it is two dimensional, "
-                         "but cov.shape = %s" % str(cov.shape))
+        raise ValueError("Array 'cov' must be square if it is two dimensional,"
+                         " but cov.shape = %s" % str(cov.shape))
     elif cov.ndim > 2:
-        raise ValueError("Array 'cov' must be at most two-dimensional, "
-                         "but cov.ndim = %d" % cov.ndim)
+        raise ValueError("Array 'cov' must be at most two-dimensional,"
+                         " but cov.ndim = %d" % cov.ndim)
 
     return dim, mean, cov
 
@@ -311,6 +312,7 @@ class multivariate_normal_gen(object):
 
     Examples
     --------
+    >>> import matplotlib.pyplot as plt
     >>> from scipy.stats import multivariate_normal
     >>> x = np.linspace(0, 5, 10, endpoint=False)
     >>> y = multivariate_normal.pdf(x, mean=2.5, cov=0.5); y
@@ -507,8 +509,8 @@ class multivariate_normal_frozen(object):
 
     def logpdf(self, x):
         x = _process_quantiles(x, self.dim)
-        out = self._mnorm._logpdf(x, self.mean,
-                                  self.cov_info.U, self.cov_info.log_pdet, self.cov_info.rank)
+        out = self._mnorm._logpdf(x, self.mean, self.cov_info.U,
+                                  self.cov_info.log_pdet, self.cov_info.rank)
         return _squeeze_output(out)
 
     def pdf(self, x):
@@ -618,14 +620,15 @@ def _lnB(alpha):
         Helper quotient, internal use only
 
     """
-    return np.sum(scipy.special.gammaln(alpha)) - scipy.special.gammaln(np.sum(alpha))
+    return np.sum(gammaln(alpha)) - gammaln(np.sum(alpha))
 
 
 class dirichlet_gen(object):
     r"""
     A Dirichlet random variable.
 
-    The `alpha` keyword specifies the concentration parameters of the distribution.
+    The `alpha` keyword specifies the concentration parameters of the
+    distribution.
 
     .. versionadded:: 0.15.0
 
@@ -833,7 +836,7 @@ class dirichlet_gen(object):
             dimension of the random variable.
 
         """
-        a = _dirichlet_check_parameters(alpha)
+        alpha = _dirichlet_check_parameters(alpha)
         return np.random.dirichlet(alpha, size=size)
 
 
@@ -869,5 +872,6 @@ class dirichlet_frozen(object):
 for name in ['logpdf', 'pdf', 'rvs', 'mean', 'var', 'entropy']:
     method = dirichlet_gen.__dict__[name]
     method_frozen = dirichlet_frozen.__dict__[name]
-    method_frozen.__doc__ = doccer.docformat(method.__doc__, dirichlet_docdict_noparams)
+    method_frozen.__doc__ = doccer.docformat(
+        method.__doc__, dirichlet_docdict_noparams)
     method.__doc__ = doccer.docformat(method.__doc__, dirichlet_docdict_params)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -4,8 +4,14 @@ Test functions for multivariate normal distributions.
 """
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
-                           run_module_suite, assert_allclose, assert_equal, assert_raises)
+from numpy.testing import (
+    assert_allclose,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_equal,
+    assert_raises,
+    run_module_suite,
+)
 
 import numpy
 import numpy as np
@@ -58,7 +64,6 @@ def test_rank():
     np.random.seed(1234)
     n = 4
     mean = np.random.randn(n)
-    x = np.random.randn(n)
     for expected_rank in range(1, n + 1):
         s = np.random.randn(n, expected_rank)
         cov = np.dot(s, s.T)
@@ -74,7 +79,6 @@ def _sample_orthonormal_matrix(n):
 
 def test_degenerate_distributions():
     for n in range(1, 5):
-        mu = np.zeros(n)
         x = np.random.randn(n)
         for k in range(1, n + 1):
             # Sample a small covariance matrix.
@@ -132,7 +136,8 @@ def test_large_pseudo_determinant():
 
     # np.linalg.slogdet is only available in numpy 1.6+
     # but scipy currently supports numpy 1.5.1.
-    # assert_allclose(np.linalg.slogdet(cov[:npos, :npos]), (1, large_total_log))
+    # assert_allclose(np.linalg.slogdet(cov[:npos, :npos]),
+    #                 (1, large_total_log))
 
     # Check the pseudo-determinant.
     psd = _PSD(cov)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -461,5 +461,25 @@ def test_2D_dirichlet_is_beta():
     assert_almost_equal(b.var(), d.var()[0])
 
 
+def test_dimensions_mismatch():
+    # Regression test for GH #3493. Check that setting up a PDF with a mean of
+    # length M and a covariance matrix of size (N, N), where M != N, raises a
+    # ValueError with an informative error message.
+
+    mu = np.array([0.0, 0.0])
+    sigma = np.array([[1.0]])
+
+    assert_raises(ValueError, multivariate_normal, mu, sigma)
+
+    # A simple check that the right error message was passed along. Checking
+    # that the entire message is there, word for word, would be somewhat
+    # fragile, so we just check for the leading part.
+    try:
+        multivariate_normal(mu, sigma)
+    except ValueError as e:
+        msg = "Dimension mismatch"
+        assert_equal(str(e)[:len(msg)], msg)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
This is a small fix for #3493, and provides a more appropriate error message when a multivariate normal is instantiated whose mean and covariance matrix have non-matching dimensions.
