### PR TITLE
Add check_finite flag to UnivariateSpline

### DIFF
--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -110,6 +110,13 @@ class UnivariateSpline(object):
 
         The default value is 0.
 
+    check_finite : bool, optional
+        Whether to check that the input arrays contain only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination or non-sensical results) if the inputs
+        do contain infinities or NaNs.
+        Default is False.
+
     See Also
     --------
     InterpolatedUnivariateSpline : Subclass with smoothing forced to 0
@@ -156,7 +163,13 @@ class UnivariateSpline(object):
     >>> plt.show()
 
     """
-    def __init__(self, x, y, w=None, bbox=[None]*2, k=3, s=None, ext=0):
+    def __init__(self, x, y, w=None, bbox=[None]*2, k=3, s=None,
+                 ext=0, check_finite=False):
+
+        if check_finite:
+            if not np.isfinite(x).all() or not np.isfinite(y).all():
+                raise ValueError("x and y array must not contain NaNs or infs.")
+
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         try:
             self.ext = _extrap_modes[ext]
@@ -470,6 +483,13 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
 
         The default value is 0.
 
+    check_finite : bool, optional
+        Whether to check that the input arrays contain only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination or non-sensical results) if the inputs
+        do contain infinities or NaNs.
+        Default is False.
+
     See Also
     --------
     UnivariateSpline : Superclass -- allows knots to be selected by a
@@ -501,7 +521,14 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
     0.0
 
     """
-    def __init__(self, x, y, w=None, bbox=[None]*2, k=3, ext=0):
+    def __init__(self, x, y, w=None, bbox=[None]*2, k=3,
+                 ext=0, check_finite=False):
+
+        if check_finite:
+            if (not np.isfinite(x).all() or not np.isfinite(y).all() or
+                not np.isfinite(w).all()):
+                    raise ValueError("Input must not contain NaNs or infs.")
+
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         self._data = dfitpack.fpcurf0(x,y,k,w=w,
                                       xb=bbox[0],xe=bbox[1],s=0)
@@ -566,6 +593,13 @@ class LSQUnivariateSpline(UnivariateSpline):
 
         The default value is 0.
 
+    check_finite : bool, optional
+        Whether to check that the input arrays contain only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination or non-sensical results) if the inputs
+        do contain infinities or NaNs.
+        Default is False.
+
     Raises
     ------
     ValueError
@@ -612,7 +646,14 @@ class LSQUnivariateSpline(UnivariateSpline):
 
     """
 
-    def __init__(self, x, y, t, w=None, bbox=[None]*2, k=3, ext=0):
+    def __init__(self, x, y, t, w=None, bbox=[None]*2, k=3,
+                 ext=0, check_finite=False):
+
+        if check_finite:
+            if (not np.isfinite(x).all() or not np.isfinite(y).all() or
+                not np.isfinite(w).all() or not np.isfinite(t).all()):
+                    raise ValueError("Input(s) must not contain NaNs or infs.")
+
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         xb = bbox[0]
         xe = bbox[1]

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -142,6 +142,15 @@ class TestUnivariateSpline(TestCase):
         assert_allclose(spl2(0.6) - spl2(0.2),
                         spl.integral(0.2, 0.6))
 
+    def test_nan(self):
+        # bail out early if the input data contains nans
+        x = np.arange(10, dtype=float)
+        y = x**3
+        for z in [np.nan, np.inf, -np.inf]:
+            y[-1] = z
+            assert_raises(ValueError, UnivariateSpline,
+                    **dict(x=x, y=y, check_finite=True))
+
 
 class TestLSQBivariateSpline(TestCase):
     # NOTE: The systems in this test class are rank-deficient


### PR DESCRIPTION
<s>closes gh-3531</s>

At present, UnivariateSpline(x, y) will not do anything useful if the input arrays contain nans or infs: the underlying FITPACK tries to converge the smoothing conditions, and finally returns nans for the spline coefficients. 

This PR adds:
- a boolean `check_finite` flag to check input arrays, so that invalid input fails early and loudly. 
- A docstring example (due to @juliantaylor) of using the weights parameter to mask away nan values. 

I'm a bit conflicted on the default value for the `check_finite` flag. Consistency with `linalg` and common sense call for the default being to check,  but backwards compatibility calls for the default being `check_finite=False`. 

As this is probably rather small usability tweak, it's not worth introducing a compatibility issue, so I'm setting the default to False. 
