### PR TITLE
Wrap her, syr, her2, syr2 blas routines

### DIFF
--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -87,19 +87,25 @@ BLAS Level 2 functions
     cgeru
     chemv
     ctrmv
+    csyr
+    cher
     dgemv
     dger
     dsymv
     dtrmv
+    dsyr
     sgemv
     sger
     ssymv
     strmv
+    ssyr
     zgemv
     zgerc
     zgeru
     zhemv
     ztrmv
+    zsyr
+    zher
 
 BLAS Level 3 functions
 ======================

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -89,16 +89,19 @@ BLAS Level 2 functions
     ctrmv
     csyr
     cher
+    cher2
     dgemv
     dger
     dsymv
     dtrmv
     dsyr
+    dsyr2
     sgemv
     sger
     ssymv
     strmv
     ssyr
+    ssyr2
     zgemv
     zgerc
     zgeru
@@ -106,6 +109,7 @@ BLAS Level 2 functions
     ztrmv
     zsyr
     zher
+    zher2
 
 BLAS Level 3 functions
 ======================

--- a/scipy/linalg/fblas_l2.pyf.src
+++ b/scipy/linalg/fblas_l2.pyf.src
@@ -3,15 +3,16 @@
 !
 ! Author: Pearu Peterson
 ! Created: Jan-Feb 2002
-! Modified: Fabian Pedregosa, 2011
+! Modified: Fabian Pedregosa, 2011; Eric Moore, 2014
 !
 ! Implemented:
-!   gemv, hemv, symv, trmv, ger, geru, gerc
+!   gemv, hemv, symv, trmv, ger, geru, gerc, her, syr
 !
 ! Not implemented:
 !   gbmv, hbmv, hpmv, sbmv, spmv, tbmv, tpmv, trsv, tbsv, tpsv,
-!   her, hpr, her2, hpr2, syr, spr, syr2, spr2
+!   hpr, her2, hpr2, spr, syr2, spr2
 !
+
 
 subroutine <prefix>gemv(m,n,alpha,a,x,beta,y,offx,incx,offy,incy,trans,rows,cols,ly)
   ! Computes a matrix-vector product using a general matrix
@@ -140,3 +141,35 @@ subroutine <prefix6>ger<,,u,u,c,c>(m,n,alpha,x,incx,y,incy,a,lda)
   integer intent(hide), depend(m) :: lda=m
 
 end subroutine <prefix6>ger<,,u,u,c,c>
+
+
+! <ftype6=real,double precision,complex,double complex,\2,\3>
+! <ctype6=float,double,complex_float,complex_double,\2,\3>
+! <prefix6=s,d,c,z,\2,\3>
+subroutine <prefix6><sy,\0,\0,\0, he,\4>r(alpha,x,lower,incx,offx,n,a)
+  ! Performs a rank-1 update of a symmetric/hermitian matrix.
+  !
+  ! Calculate a <- alpha*x*x^T + a
+  ! Calculate a <- alpha*x*x^H + a
+  !
+    callstatement (*f2py_func)((lower?"L":"U"),&n,&alpha,x+offx,&incx,a,&n)
+    callprotoargument char*, int*, <ctype6>*, <ctype6>*, int*, <ctype6>*, int*
+
+    integer, optional, intent(in), check(lower == 0 || lower == 1) :: lower = 0
+    <ftype6> intent(in) :: alpha
+
+    <ftype6> dimension(*), depend(offx) :: x
+    check(offx >= 0 && offx < len(x)) :: x
+    integer, intent(in), optional :: offx = 0
+    integer, intent(in), optional, check(incx>0||incx<0) :: incx = 1
+
+    integer, intent(in), optional :: n = (len(x)-1-offx)/abs(incx)+1
+    check(n >= 0) :: n
+    check(n <= (len(x)-1-offx)/abs(incx)+1) :: n
+    depend(x, offx, incx) :: n
+
+    <ftype6> dimension(n,n), intent(in,copy,out), optional :: a
+    depend(x, offx, incx, n) :: a
+
+end subroutine <prefix6><sy,\0,\0,\0, he,\4>r
+

--- a/scipy/linalg/fblas_l2.pyf.src
+++ b/scipy/linalg/fblas_l2.pyf.src
@@ -6,11 +6,11 @@
 ! Modified: Fabian Pedregosa, 2011; Eric Moore, 2014
 !
 ! Implemented:
-!   gemv, hemv, symv, trmv, ger, geru, gerc, her, syr
+!   gemv, hemv, symv, trmv, ger, geru, gerc, her, syr, her2, syr2
 !
 ! Not implemented:
 !   gbmv, hbmv, hpmv, sbmv, spmv, tbmv, tpmv, trsv, tbsv, tpsv,
-!   hpr, her2, hpr2, spr, syr2, spr2
+!   hpr, hpr2, spr, spr2
 !
 
 
@@ -172,4 +172,33 @@ subroutine <prefix6><sy,\0,\0,\0, he,\4>r(alpha,x,lower,incx,offx,n,a)
     depend(x, offx, incx, n) :: a
 
 end subroutine <prefix6><sy,\0,\0,\0, he,\4>r
+
+
+subroutine <prefix><sy, \0, he, \2>r2(alpha,x,y,lower,incx,offx,incy,offy,n,a)
+  ! Performs a rank-2 update of a symmetric/hermitian matrix.
+  !
+  ! Calculate a <- alpha*x*y^T + alpha*y*x^T + a
+  ! Calculate a <- alpha*x*y^H + alpha*y*x^H + a
+  !
+    callstatement (*f2py_func)((lower?"L":"U"),&n,&alpha,x+offx,&incx,y+offy,&incy,a,&n)
+    callprotoargument char*, int*, <ctype>*, <ctype>*, int*, <ctype>*, int*, <ctype>*, int*
+
+    integer intent(in), optional, check(lower == 0 || lower == 1) :: lower = 0
+    <ftype> intent(in) :: alpha
+    <ftype> dimension(*), intent(in), check(offx >= 0 && offx < len(x)), depend(offx) :: x
+    <ftype> dimension(*), intent(in), check(offy >= 0 && offy < len(y)), depend(offy) :: y
+    integer intent(in), optional, check(incx>0||incx<0) :: incx = 1
+    integer intent(in), optional :: offx = 0
+    integer intent(in), optional, check(incy>0||incy<0) :: incy = 1
+    integer intent(in), optional :: offy = 0
+
+    integer intent(in), optional :: n = ((len(x)-1-offx)/abs(incx)+1 <= (len(y)-1-offy)/abs(incy)+1 ? (len(x)-1-offx)/abs(incx)+1 : (len(y)-1-offy)/abs(incy)+1)
+    depend(x,incx,offx,y,incy,offy) :: n
+    check(n>=0) :: n
+    check(n <= (len(x)-1-offx)/abs(incx)+1) :: n
+    check(n <= (len(y)-1-offy)/abs(incy)+1) :: n
+
+    <ftype> dimension(n,n), intent(in,copy,out), optional :: a
+    depend(incx, offx, x, incy, offy, y, n) :: a
+end subroutine <prefix><sy, \0, he, \2>r2
 

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -16,7 +16,8 @@ import math
 
 import numpy as np
 from numpy.testing import (TestCase, run_module_suite, assert_equal,
-    assert_almost_equal, assert_array_almost_equal, assert_raises, assert_)
+    assert_almost_equal, assert_array_almost_equal, assert_raises, assert_,
+    assert_allclose)
 
 from scipy.linalg import _fblas as fblas, get_blas_funcs
 
@@ -260,6 +261,105 @@ class TestFBLAS2Simple(TestCase):
                 assert_array_almost_equal(f(2,[1j,
                                                2j,
                                                3j],[3j,4j]),[[6,8],[12,16],[18,24]])
+
+    def test_syr_her(self):
+        x = np.arange(1, 5, dtype='d')
+        resx = np.triu(x[:, np.newaxis] * x)
+        resx_reverse = np.triu(x[::-1, np.newaxis] * x[::-1])
+
+        y = np.linspace(0,8.5,17,endpoint=False)
+
+        z = np.arange(1, 9, dtype='d').view('D')
+        resz = np.triu(z[:, np.newaxis] * z)
+        resz_reverse = np.triu(z[::-1, np.newaxis] * z[::-1])
+        rehz = np.triu(z[:, np.newaxis] * z.conj())
+        rehz_reverse = np.triu(z[::-1, np.newaxis] * z[::-1].conj())
+
+        w = np.c_[np.zeros(4), z, np.zeros(4)].ravel()
+     
+        for p, rtol in zip('sd',[1e-7,1e-14]):
+            f = getattr(fblas, p+'syr', None)
+            if f is None:
+                continue
+            assert_allclose(f(1.0, x), resx, rtol=rtol)
+            assert_allclose(f(1.0, x, lower=True), resx.T, rtol=rtol)
+            assert_allclose(f(1.0, y, incx=2, offx=2, n=4), resx, rtol=rtol)
+            # negative increments imply reversed vectors in blas
+            assert_allclose(f(1.0, y, incx=-2, offx=2, n=4),
+                resx_reverse, rtol=rtol)
+
+            a = np.zeros((4,4), 'f' if p == 's' else 'd', 'F')
+            b = f(1.0, x, a=a, overwrite_a=True)
+            assert_(a is b)
+            assert_allclose(a, resx, rtol=rtol)
+
+            b = f(2.0, x, a=a)
+            assert_(a is not b)
+            assert_allclose(b, 3*resx, rtol=rtol)
+
+            assert_raises(Exception, f, 1.0, x, incx=0)
+            assert_raises(Exception, f, 1.0, x, offx=5)
+            assert_raises(Exception, f, 1.0, x, offx=-2)
+            assert_raises(Exception, f, 1.0, x, n=-2)
+            assert_raises(Exception, f, 1.0, x, n=5)
+            assert_raises(Exception, f, 1.0, x, lower=2)
+            assert_raises(Exception, f, 1.0, x, a=np.zeros((2,2), 'd', 'F'))
+        
+        for p, rtol in zip('cz',[1e-7,1e-14]):
+            f = getattr(fblas, p+'syr', None)
+            if f is None:
+                continue
+            assert_allclose(f(1.0, z), resz, rtol=rtol)
+            assert_allclose(f(1.0, z, lower=True), resz.T, rtol=rtol)
+            assert_allclose(f(1.0, w, incx=3, offx=1, n=4), resz, rtol=rtol)
+            # negative increments imply reversed vectors in blas
+            assert_allclose(f(1.0, w, incx=-3, offx=1, n=4),
+                resz_reverse, rtol=rtol)
+
+            a = np.zeros((4,4), 'F' if p == 'c' else 'D', 'F')
+            b = f(1.0, z, a=a, overwrite_a=True)
+            assert_(a is b)
+            assert_allclose(a, resz, rtol=rtol)
+
+            b = f(2.0, z, a=a)
+            assert_(a is not b)
+            assert_allclose(b, 3*resz, rtol=rtol)
+
+            assert_raises(Exception, f, 1.0, x, incx=0)
+            assert_raises(Exception, f, 1.0, x, offx=5)
+            assert_raises(Exception, f, 1.0, x, offx=-2)
+            assert_raises(Exception, f, 1.0, x, n=-2)
+            assert_raises(Exception, f, 1.0, x, n=5)
+            assert_raises(Exception, f, 1.0, x, lower=2)
+            assert_raises(Exception, f, 1.0, x, a=np.zeros((2,2), 'd', 'F'))
+ 
+        for p, rtol in zip('cz',[1e-7,1e-14]):
+            f = getattr(fblas, p+'her', None)
+            if f is None:
+                continue
+            assert_allclose(f(1.0, z), rehz, rtol=rtol)
+            assert_allclose(f(1.0, z, lower=True), rehz.T.conj(), rtol=rtol)
+            assert_allclose(f(1.0, w, incx=3, offx=1, n=4), rehz, rtol=rtol)
+            # negative increments imply reversed vectors in blas
+            assert_allclose(f(1.0, w, incx=-3, offx=1, n=4),
+                rehz_reverse, rtol=rtol)
+
+            a = np.zeros((4,4), 'F' if p == 'c' else 'D', 'F')
+            b = f(1.0, z, a=a, overwrite_a=True)
+            assert_(a is b)
+            assert_allclose(a, rehz, rtol=rtol)
+
+            b = f(2.0, z, a=a)
+            assert_(a is not b)
+            assert_allclose(b, 3*rehz, rtol=rtol)
+
+            assert_raises(Exception, f, 1.0, x, incx=0)
+            assert_raises(Exception, f, 1.0, x, offx=5)
+            assert_raises(Exception, f, 1.0, x, offx=-2)
+            assert_raises(Exception, f, 1.0, x, n=-2)
+            assert_raises(Exception, f, 1.0, x, n=5)
+            assert_raises(Exception, f, 1.0, x, lower=2)
+            assert_raises(Exception, f, 1.0, x, a=np.zeros((2,2), 'd', 'F'))
 
 
 class TestFBLAS3Simple(TestCase):

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -361,6 +361,100 @@ class TestFBLAS2Simple(TestCase):
             assert_raises(Exception, f, 1.0, x, lower=2)
             assert_raises(Exception, f, 1.0, x, a=np.zeros((2,2), 'd', 'F'))
 
+    def test_syr2(self):
+        x = np.arange(1, 5, dtype='d')
+        y = np.arange(5, 9, dtype='d')
+        resxy = np.triu(x[:, np.newaxis] * y + y[:, np.newaxis] * x)
+        resxy_reverse = np.triu(x[::-1, np.newaxis] * y[::-1]
+                                + y[::-1, np.newaxis] * x[::-1])
+
+        q = np.linspace(0,8.5,17,endpoint=False)
+
+        for p, rtol in zip('sd',[1e-7,1e-14]):
+            f = getattr(fblas, p+'syr2', None)
+            if f is None:
+                continue
+            assert_allclose(f(1.0, x, y), resxy, rtol=rtol)
+            assert_allclose(f(1.0, x, y, n=3), resxy[:3,:3], rtol=rtol)
+            assert_allclose(f(1.0, x, y, lower=True), resxy.T, rtol=rtol)
+
+            assert_allclose(f(1.0, q, q, incx=2, offx=2, incy=2, offy=10),
+                            resxy, rtol=rtol)
+            assert_allclose(f(1.0, q, q, incx=2, offx=2, incy=2, offy=10, n=3),
+                            resxy[:3,:3], rtol=rtol)
+            # negative increments imply reversed vectors in blas
+            assert_allclose(f(1.0, q, q, incx=-2, offx=2, incy=-2, offy=10),
+                            resxy_reverse, rtol=rtol)
+
+            a = np.zeros((4,4), 'f' if p == 's' else 'd', 'F')
+            b = f(1.0, x, y, a=a, overwrite_a=True)
+            assert_(a is b)
+            assert_allclose(a, resxy, rtol=rtol)
+
+            b = f(2.0, x, y, a=a)
+            assert_(a is not b)
+            assert_allclose(b, 3*resxy, rtol=rtol)
+
+            assert_raises(Exception, f, 1.0, x, y, incx=0)
+            assert_raises(Exception, f, 1.0, x, y, offx=5)
+            assert_raises(Exception, f, 1.0, x, y, offx=-2)
+            assert_raises(Exception, f, 1.0, x, y, incy=0)
+            assert_raises(Exception, f, 1.0, x, y, offy=5)
+            assert_raises(Exception, f, 1.0, x, y, offy=-2)
+            assert_raises(Exception, f, 1.0, x, y, n=-2)
+            assert_raises(Exception, f, 1.0, x, y, n=5)
+            assert_raises(Exception, f, 1.0, x, y, lower=2)
+            assert_raises(Exception, f, 1.0, x, y, a=np.zeros((2,2), 'd', 'F'))
+  
+    def test_her2(self):
+        x = np.arange(1, 9, dtype='d').view('D')
+        y = np.arange(9, 17, dtype='d').view('D')
+        resxy = x[:, np.newaxis] * y.conj() + y[:, np.newaxis] * x.conj()
+        resxy = np.triu(resxy)
+
+        resxy_reverse = x[::-1, np.newaxis] * y[::-1].conj()
+        resxy_reverse += y[::-1, np.newaxis] * x[::-1].conj()
+        resxy_reverse = np.triu(resxy_reverse)
+
+        u = np.c_[np.zeros(4), x, np.zeros(4)].ravel()
+        v = np.c_[np.zeros(4), y, np.zeros(4)].ravel()
+
+        for p, rtol in zip('cz',[1e-7,1e-14]):
+            f = getattr(fblas, p+'her2', None)
+            if f is None:
+                continue
+            assert_allclose(f(1.0, x, y), resxy, rtol=rtol)
+            assert_allclose(f(1.0, x, y, n=3), resxy[:3,:3], rtol=rtol)
+            assert_allclose(f(1.0, x, y, lower=True), resxy.T.conj(), rtol=rtol)
+
+            assert_allclose(f(1.0, u, v, incx=3, offx=1, incy=3, offy=1),
+                            resxy, rtol=rtol)
+            assert_allclose(f(1.0, u, v, incx=3, offx=1, incy=3, offy=1, n=3),
+                            resxy[:3,:3], rtol=rtol)
+            # negative increments imply reversed vectors in blas
+            assert_allclose(f(1.0, u, v, incx=-3, offx=1, incy=-3, offy=1),
+                            resxy_reverse, rtol=rtol)
+
+            a = np.zeros((4,4), 'F' if p == 'c' else 'D', 'F')
+            b = f(1.0, x, y, a=a, overwrite_a=True)
+            assert_(a is b)
+            assert_allclose(a, resxy, rtol=rtol)
+
+            b = f(2.0, x, y, a=a)
+            assert_(a is not b)
+            assert_allclose(b, 3*resxy, rtol=rtol)
+
+            assert_raises(Exception, f, 1.0, x, y, incx=0)
+            assert_raises(Exception, f, 1.0, x, y, offx=5)
+            assert_raises(Exception, f, 1.0, x, y, offx=-2)
+            assert_raises(Exception, f, 1.0, x, y, incy=0)
+            assert_raises(Exception, f, 1.0, x, y, offy=5)
+            assert_raises(Exception, f, 1.0, x, y, offy=-2)
+            assert_raises(Exception, f, 1.0, x, y, n=-2)
+            assert_raises(Exception, f, 1.0, x, y, n=5)
+            assert_raises(Exception, f, 1.0, x, y, lower=2)
+            assert_raises(Exception, f, 1.0, x, y, a=np.zeros((2,2), 'd', 'F'))
+ 
 
 class TestFBLAS3Simple(TestCase):
 


### PR DESCRIPTION
As a start toward including the rest of the currently unwrapped blas routines, I've wrapped these. 

I'd like some feedback here on what we actually want out of these wrappers.  Specifically, what we have doesn't seem particularly consistent from function to function (some have offx, some don't, etc.)  

There also seem to be some issues (cf. #3983) and it looks to me like `x` and `y` in `ger` shouldn't really have the overwrite flag, since those are input only.  I haven't changed that, since it would change the signature which we probably can't from a back compat standpoint.
