### PR TITLE
Weights in Golub-Welsch

### DIFF
--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -149,7 +149,7 @@ class orthopoly1d(np.poly1d):
         self.__dict__['normcoef'] *= p
 
 
-def _gen_roots_and_weights(n, mu0, an_func, bn_func, f, df, symmetrize, mu):
+def _gen_roots_and_weights(n, mu0, an_func, bn_func, f, df, weights_formula, symmetrize, mu):
     """[x,w] = gen_roots_and_weights(n,an_func,sqrt_bn_func,mu)
 
     Returns the roots (x) of an nth order orthogonal polynomial,
@@ -168,22 +168,28 @@ def _gen_roots_and_weights(n, mu0, an_func, bn_func, f, df, symmetrize, mu):
     c = np.zeros((2, n))
     c[0,1:] = bn_func(k[1:])
     c[1,:] = an_func(k)
-    x = linalg.eigvals_banded(c, overwrite_a_band=True)
 
-    # improve roots by one application of Newton's method
-    y = f(n, x)
-    dy = df(n, x)
-    x -= y/dy
-
-    fm = f(n-1, x) 
-    fm /= np.abs(fm).max()
-    dy /= np.abs(dy).max()
-    w = 1.0 / (fm * dy)
+    if weights_formula:
+        x = linalg.eigvals_banded(c, overwrite_a_band=True)
+        # improve roots by one application of Newton's method
+        y = f(n, x)
+        dy = df(n, x)
+        x -= y/dy
+        fm = f(n-1, x)
+        fm /= np.abs(fm).max()
+        dy /= np.abs(dy).max()
+        w = 1.0 / (fm * dy)
+    else:
+        # Computing weights via explicit formula can fail for large n
+        # because of the division by a polynomial of high degree.
+        x, ev = linalg.eig_banded(c, overwrite_a_band=True)
+        w = ev[0,:]**2
 
     if symmetrize:
         w = (w + w[::-1]) / 2
         x = (x - x[::-1]) / 2
 
+    # scale w correctly
     w *= mu0 / w.sum()
 
     if mu:
@@ -255,7 +261,7 @@ def j_roots(n, alpha, beta, mu=False):
     f = lambda n, x: cephes.eval_jacobi(n, a, b, x)
     df = lambda n, x: 0.5 * (n + a + b + 1) \
                       * cephes.eval_jacobi(n-1, a+1, b+1, x)
-    return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, False, mu)
+    return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, True, False, mu)
 
 
 def jacobi(n, alpha, beta, monic=False):
@@ -403,7 +409,7 @@ def la_roots(n, alpha, mu=False):
     f = lambda n, x: cephes.eval_genlaguerre(n, alpha, x)
     df = lambda n, x: (n*cephes.eval_genlaguerre(n, alpha, x)
                      - (n + alpha)*cephes.eval_genlaguerre(n-1, alpha, x))/x
-    return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, False, mu)
+    return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, True, False, mu)
 
 
 def genlaguerre(n, alpha, monic=False):
@@ -490,7 +496,7 @@ def laguerre(n, monic=False):
 
 # Hermite  1                         H_n(x)
 
-def h_roots(n, mu=False):
+def h_roots(n, mu=False, formula=True):
     """Gauss-Hermite (physicst's) quadrature
 
     Computes the sample points and weights for Gauss-Hermite quadrature.
@@ -530,7 +536,7 @@ def h_roots(n, mu=False):
     bn_func = lambda k: np.sqrt(k/2.0)
     f = cephes.eval_hermite
     df = lambda n, x: 2.0 * n * cephes.eval_hermite(n-1, x)
-    return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, True, mu)
+    return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, formula, True, mu)
 
 
 def hermite(n, monic=False):
@@ -597,7 +603,7 @@ def he_roots(n, mu=False):
     bn_func = lambda k: np.sqrt(k)
     f = cephes.eval_hermitenorm
     df = lambda n, x: n * cephes.eval_hermitenorm(n-1, x)
-    return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, True, mu)
+    return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, True, True, mu)
 
 
 def hermitenorm(n, monic=False):
@@ -677,7 +683,7 @@ def cg_roots(n, alpha, mu=False):
     f = lambda n, x: cephes.eval_gegenbauer(n, alpha, x)
     df = lambda n, x: (-n*x*cephes.eval_gegenbauer(n, alpha, x)
          + (n + 2*alpha - 1)*cephes.eval_gegenbauer(n-1, alpha, x))/(1-x**2)
-    return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, True, mu)
+    return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, True, True, mu)
 
 
 def gegenbauer(n, alpha, monic=False):
@@ -1086,7 +1092,7 @@ def p_roots(n, mu=False):
     f = cephes.eval_legendre
     df = lambda n, x: (-n*x*cephes.eval_legendre(n, x)
                      + n*cephes.eval_legendre(n-1, x))/(1-x**2)
-    return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, True, mu)
+    return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, True, True, mu)
 
 
 def legendre(n, monic=False):

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -85,7 +85,7 @@ from __future__ import division, print_function, absolute_import
 
 # Scipy imports.
 import numpy as np
-from numpy import all, any, exp, inf, pi, sqrt
+from numpy import any, exp, inf, pi, sqrt
 from scipy import linalg
 
 # Local imports.
@@ -213,7 +213,7 @@ def j_roots(n, alpha, beta, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order 
+        quadrature order
     alpha : float
         alpha must be > -1
     beta : float
@@ -302,7 +302,7 @@ def js_roots(n, p1, q1, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order 
+        quadrature order
     p1 : float
         (p1 - q1) must be > -1
     q1 : float
@@ -318,7 +318,7 @@ def js_roots(n, p1, q1, mu=False):
         Weights
     mu : float
         Sum of the weights
-        
+
     See Also
     --------
     integrate.quadrature
@@ -368,7 +368,7 @@ def la_roots(n, alpha, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order 
+        quadrature order
     alpha : float
         alpha must be > -1
     mu : boolean
@@ -382,7 +382,7 @@ def la_roots(n, alpha, mu=False):
         Weights
     mu : float
         Sum of the weights
-        
+
     See Also
     --------
     integrate.quadrature
@@ -451,7 +451,7 @@ def l_roots(n, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order 
+        quadrature order
     mu : boolean
         If True, return the sum of the weights, optional.
 
@@ -508,7 +508,7 @@ def h_roots(n, mu=False, formula=True):
     Parameters
     ----------
     n : int
-        quadrature order 
+        quadrature order
     mu : boolean
         If True, return the sum of the weights, optional.
 
@@ -520,7 +520,7 @@ def h_roots(n, mu=False, formula=True):
         Weights
     mu : float
         Sum of the weights
-        
+
     See Also
     --------
     integrate.quadrature
@@ -575,7 +575,7 @@ def he_roots(n, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order 
+        quadrature order
     mu : boolean
         If True, return the sum of the weights, optional.
 
@@ -587,7 +587,7 @@ def he_roots(n, mu=False):
         Weights
     mu : float
         Sum of the weights
-        
+
     See Also
     --------
     integrate.quadrature
@@ -644,7 +644,7 @@ def cg_roots(n, alpha, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order 
+        quadrature order
     alpha : float
         alpha must be > -0.5
     mu : boolean
@@ -658,7 +658,7 @@ def cg_roots(n, alpha, mu=False):
         Weights
     mu : float
         Sum of the weights
-        
+
     See Also
     --------
     integrate.quadrature
@@ -672,7 +672,7 @@ def cg_roots(n, alpha, mu=False):
     elif alpha == 0.0:
         # C(n,0,x) == 0 uniformly, however, as alpha->0, C(n,alpha,x)->T(n,x)
         # strictly, we should just error out here, since the roots are not
-        # really defined, but we used to return something useful, so let's 
+        # really defined, but we used to return something useful, so let's
         # keep doing so.
         return t_roots(n, mu)
 
@@ -718,7 +718,7 @@ def t_roots(n, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order 
+        quadrature order
     mu : boolean
         If True, return the sum of the weights, optional.
 
@@ -730,7 +730,7 @@ def t_roots(n, mu=False):
         Weights
     mu : float
         Sum of the weights
-        
+
     See Also
     --------
     integrate.quadrature
@@ -784,14 +784,14 @@ def u_roots(n, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order 
+        quadrature order
     mu : boolean
         If True, return the sum of the weights, optional.
 
     Returns
     -------
     x : ndarray
-        Sample points 
+        Sample points
     w : ndarray
         Weights
     mu : float
@@ -840,14 +840,14 @@ def c_roots(n, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order 
+        quadrature order
     mu : boolean
         If True, return the sum of the weights, optional.
 
     Returns
     -------
     x : ndarray
-        Sample points 
+        Sample points
     w : ndarray
         Weights
     mu : float
@@ -901,14 +901,14 @@ def s_roots(n, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order 
+        quadrature order
     mu : boolean
         If True, return the sum of the weights, optional.
 
     Returns
     -------
     x : ndarray
-        Sample points 
+        Sample points
     w : ndarray
         Weights
     mu : float
@@ -964,14 +964,14 @@ def ts_roots(n, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order 
+        quadrature order
     mu : boolean
         If True, return the sum of the weights, optional.
 
     Returns
     -------
     x : ndarray
-        Sample points 
+        Sample points
     w : ndarray
         Weights
     mu : float
@@ -1015,14 +1015,14 @@ def us_roots(n, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order 
+        quadrature order
     mu : boolean
         If True, return the sum of the weights, optional.
 
     Returns
     -------
     x : ndarray
-        Sample points 
+        Sample points
     w : ndarray
         Weights
     mu : float
@@ -1063,7 +1063,7 @@ def p_roots(n, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order 
+        quadrature order
     mu : boolean
         If True, return the sum of the weights, optional.
 
@@ -1075,7 +1075,7 @@ def p_roots(n, mu=False):
         Weights
     mu : float
         Sum of the weights
-        
+
     See Also
     --------
     integrate.quadrature
@@ -1154,7 +1154,7 @@ def ps_roots(n, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order 
+        quadrature order
     mu : boolean
         If True, return the sum of the weights, optional.
 

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -396,6 +396,9 @@ def test_h_roots():
     assert_raises(ValueError, orth.h_roots, 0)
     assert_raises(ValueError, orth.h_roots, 3.3)
 
+    x, w = orth.h_roots(210, formula=False)
+    assert not np.any(np.isnan(w))
+
 def test_he_roots():
     verify_gauss_quad(orth.he_roots, orth.eval_hermitenorm, 5)
     verify_gauss_quad(orth.he_roots, orth.eval_hermitenorm, 25, atol=1e-13)

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import (rand, TestCase, assert_array_almost_equal, 
-        assert_almost_equal, assert_allclose, assert_raises)
+from numpy.testing import (rand, TestCase, assert_array_almost_equal,
+        assert_almost_equal, assert_allclose, assert_raises, assert_)
 
 from scipy.lib.six import xrange
 import numpy as np
@@ -397,7 +397,7 @@ def test_h_roots():
     assert_raises(ValueError, orth.h_roots, 3.3)
 
     x, w = orth.h_roots(210, formula=False)
-    assert not np.any(np.isnan(w))
+    assert_(not np.any(np.isnan(w)))
 
 def test_he_roots():
     verify_gauss_quad(orth.he_roots, orth.eval_hermitenorm, 5)


### PR DESCRIPTION
Compute the quadrature weights by full Golub-Welsch algorithm.

Reason: for large n the explicit formula for computing the weights will fail due to the division by a polynomial of high degree.
