### PR TITLE
improve *UnivariateSpline docs

### DIFF
--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -142,34 +142,6 @@ class UnivariateSpline(object):
     """
 
     def __init__(self, x, y, w=None, bbox=[None]*2, k=3, s=None, ext=0):
-        """
-        Input:
-          x,y   - 1-d sequences of data points (x must be
-                  in strictly ascending order)
-
-        Optional input:
-          w          - positive 1-d sequence of weights
-          bbox       - 2-sequence specifying the boundary of
-                       the approximation interval.
-                       By default, bbox=[x[0],x[-1]]
-          k=3        - degree of the univariate spline.
-          s          - positive smoothing factor defined for
-                       estimation condition:
-                         sum((w[i]*(y[i]-s(x[i])))**2,axis=0) <= s
-                       Default s=len(w) which should be a good value
-                       if 1/w[i] is an estimate of the standard
-                       deviation of y[i].
-          ext        - Controls the extrapolation mode for elements 
-                       not in the interval defined by the knot sequence.
-
-                       * if ext=0 or 'extrapolate', return the extrapolated value.
-                       * if ext=1 or 'zeros', return 0
-                       * if ext=2 or 'raise', raise a ValueError
-                       * if ext=3 or 'const', return the boundary value.
-
-                       The default value is 0.
-
-        """
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         try:
             self.ext = _extrap_modes[ext]
@@ -511,28 +483,7 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
     xs,ys is now a smoothed, super-sampled version of the noisy gaussian x,y
 
     """
-
     def __init__(self, x, y, w=None, bbox=[None]*2, k=3, ext=0):
-        """
-        Input:
-          x,y   - 1-d sequences of data points (x must be
-                  in strictly ascending order)
-
-        Optional input:
-          w          - positive 1-d sequence of weights
-          bbox       - 2-sequence specifying the boundary of
-                       the approximation interval.
-                       By default, bbox=[x[0],x[-1]]
-          k=3        - degree of the univariate spline.
-          ext        - Controls the extrapolation mode for elements 
-                       not in the interval defined by the knot sequence.
-
-                       * if ext=0 or 'extrapolate', return the extrapolated value.
-                       * if ext=1 or 'zeros', return 0
-                       * if ext=2 or 'raise', raise a ValueError
-
-                       The default value is 0.
-        """
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         self._data = dfitpack.fpcurf0(x,y,k,w=w,
                                       xb=bbox[0],xe=bbox[1],s=0)
@@ -633,30 +584,6 @@ class LSQUnivariateSpline(UnivariateSpline):
     """
 
     def __init__(self, x, y, t, w=None, bbox=[None]*2, k=3, ext=0):
-        """
-        Input:
-          x,y   - 1-d sequences of data points (x must be
-                  in strictly ascending order)
-          t     - 1-d sequence of the positions of user-defined
-                  interior knots of the spline (t must be in strictly
-                  ascending order and bbox[0]<t[0]<...<t[-1]<bbox[-1])
-
-        Optional input:
-          w          - positive 1-d sequence of weights
-          bbox       - 2-sequence specifying the boundary of
-                       the approximation interval.
-                       By default, bbox=[x[0],x[-1]]
-          k=3        - degree of the univariate spline.
-          ext        - Controls the extrapolation mode for elements
-                       not in the interval defined by the knot sequence.
-
-                       * if ext=0 or 'extrapolate', return the extrapolated
-                         value.
-                       * if ext=1 or 'zeros', return 0
-                       * if ext=2 or 'raise', raise a ValueError.
-
-                       The default value is 0.
-        """
         # _data == x,y,w,xb,xe,k,s,n,t,c,fp,fpint,nrdata,ier
         xb = bbox[0]
         xe = bbox[1]

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -72,7 +72,7 @@ class UnivariateSpline(object):
     """
     One-dimensional smoothing spline fit to a given set of data points.
 
-    Fits a spline y = s(x) of degree `k` to the provided `x`, `y` data.  `s`
+    Fits a spline y = spl(x) of degree `k` to the provided `x`, `y` data.  `s`
     specifies the number of knots by specifying a smoothing condition.
 
     Parameters
@@ -94,7 +94,7 @@ class UnivariateSpline(object):
         Positive smoothing factor used to choose the number of knots.  Number
         of knots will be increased until the smoothing condition is satisfied::
 
-            sum((w[i] * (y[i]-s(x[i])))**2, axis=0) <= s
+            sum((w[i] * (y[i]-spl(x[i])))**2, axis=0) <= s
 
         If None (default), ``s = len(w)`` which should be a good value if 
         ``1/w[i]`` is an estimate of the standard deviation of ``y[i]``.  
@@ -130,7 +130,7 @@ class UnivariateSpline(object):
 
     >>> w = np.isnan(y) 
     >>> y[w] = 0.
-    >>> s = UnivariateSpline(x, y, w=~w)
+    >>> spl = UnivariateSpline(x, y, w=~w)
 
     Notice the need to replace a ``nan`` by a numerical value (precise value
     does not matter as long as the corresponding weight is zero.)
@@ -306,7 +306,7 @@ class UnivariateSpline(object):
 
     def get_residual(self):
         """Return weighted sum of squared residuals of the spline
-        approximation: ``sum((w[i] * (y[i]-s(x[i])))**2, axis=0)``.
+        approximation: ``sum((w[i] * (y[i]-spl(x[i])))**2, axis=0)``.
         """
         return self._data[10]
 
@@ -441,7 +441,7 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
     """
     One-dimensional interpolating spline for a given set of data points.
 
-    Fits a spline y=s(x) of degree `k` to the provided `x`, `y` data. Spline
+    Fits a spline y = spl(x) of degree `k` to the provided `x`, `y` data. Spline
     function passes through all provided points. Equivalent to
     `UnivariateSpline` with  s=0.
 
@@ -495,7 +495,7 @@ class InterpolatedUnivariateSpline(UnivariateSpline):
     >>> plt.plot(xs, spl(xs), 'g', lw=3, alpha=0.7)
     >>> plt.show()
 
-    Notice that the `spl(x)` interpolates `y`:
+    Notice that the ``spl(x)`` interpolates `y`:
 
     >>> spl.get_residual()
     0.0
@@ -532,7 +532,7 @@ class LSQUnivariateSpline(UnivariateSpline):
     """
     One-dimensional spline with explicit internal knots.
 
-    Fits a spline y=s(x) of degree `k` to the provided `x`, `y` data.  `t`
+    Fits a spline y = spl(x) of degree `k` to the provided `x`, `y` data.  `t`
     specifies the internal knots of the spline
 
     Parameters

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -584,6 +584,10 @@ class LSQUnivariateSpline(UnivariateSpline):
     -----
     The number of data points must be larger than the spline degree `k`.
 
+    Knots `t` must satisfy the Schoenberg-Whitney conditions,
+    i.e., there must be a subset of data points ``x[j]`` such that
+    ``t[j] < x[j] < t[j+k+1]``, for ``j=0, 1,...,n-k-2``.
+
     Examples
     --------
     >>> from scipy.interpolate import LSQUnivariateSpline

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -123,6 +123,18 @@ class UnivariateSpline(object):
     -----
     The number of data points must be larger than the spline degree `k`.
 
+    **NaN handling**: If the input arrays contain ``nan`` values, the result
+    is not useful, since the underlying spline fitting routines cannot deal
+    with ``nan`` . A workaround is to use zero weights for not-a-number
+    data points:
+
+    >>> w = np.isnan(y) 
+    >>> y[w] = 0.
+    >>> s = UnivariateSpline(x, y, w=~w)
+
+    Notice the need to replace a ``nan`` by a numerical value (precise value
+    does not matter as long as the corresponding weight is zero.)
+
     Examples
     --------
     >>> import matplotlib.pyplot as plt


### PR DESCRIPTION
- document @juliantailor's trick of masking nans (https://github.com/scipy/scipy/issues/3531#issuecomment-40233093)
- remove docstring from `__init__` methods, as they simply duplicate the class docstrings
- tweak docstring examples so that plots actually render

If #3531 is viewed as a documentation issue, this PR fixes it.

[ci skip]
