### PR TITLE
TST: stats: guard test_moments with an env variable

### DIFF
--- a/scipy/lib/_util.py
+++ b/scipy/lib/_util.py
@@ -1,5 +1,9 @@
 import sys
 import warnings
+import os
+
+from nose import SkipTest
+from .decorator import decorator
 
 
 class DeprecatedImport(object):
@@ -34,3 +38,31 @@ class DeprecatedImport(object):
                       % (self._old_name, self._new_name),
                       DeprecationWarning)
         return getattr(self._mod, name)
+
+
+def setup_xslow():
+    """Convenience function for skipping xslow tests in nose generators.
+
+    Attaching a custom decorator to a nose test generator makes nose
+    unconditionally skip tests.
+    Use this one together with nose.with_setup::
+
+        from nose import with_setup
+
+        @with_setup(setup_xslow)
+        def test_gen():
+            yield check_a, a
+            ...
+
+        def check_a(a):
+            ...
+
+    """
+    try:
+        v = int(os.environ.get('SCIPY_XSLOW', '0'))
+        if not v:
+            raise ValueError()
+    except ValueError:
+        raise SkipTest("very slow test; set environment variable "
+                       "SCIPY_XSLOW=1 to run it")
+

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -4,6 +4,8 @@ import warnings
 
 import numpy as np
 import numpy.testing as npt
+from scipy.lib._util import setup_xslow
+from nose import with_setup
 
 from scipy import integrate
 from scipy import stats
@@ -196,7 +198,7 @@ def test_cont_basic_slow():
             yield check_edge_support, distfn, arg
 
 
-@npt.dec.slow
+@with_setup(setup_xslow)
 def test_moments():
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', category=integrate.IntegrationWarning)


### PR DESCRIPTION
Attempt to work around TravisCI 50 min timeout by fencing an expensive set of tests in stats by an env variable. 

Open questions: 
- do we even want this [I think we do]
- what sort of granularity of control do we want. At the moment I'm using the same env variable which is used in `test_sparsetools` --- IMO one env variable is enough.
- do we want to expose this to other places in scipy. ATM it's in `lib._util`, but it can be moved closer to where it's used in stats. Alternatively, we may want to move https://github.com/scipy/scipy/blob/master/scipy/sparse/tests/test_sparsetools.py#L19 to `lib._util` as well.

For the moment though, I'd like to see whether this actually helps (TravisCI?). 
