### PR TITLE
BUG:  numerical precision in dirichlet

### DIFF
--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -4,19 +4,18 @@
 
 from __future__ import division, print_function, absolute_import
 
+import warnings
+
 import numpy as np
 from scipy.lib.six import xrange
 from numpy import (pi, asarray, floor, isscalar, iscomplex, real, imag, sqrt,
-                   where, mgrid, cos, sin, exp, place, issubdtype, extract,
-                   less, vectorize, inexact, nan, zeros, atleast_1d, sinc)
+                   where, mgrid, sin, place, issubdtype, extract,
+                   less, inexact, nan, zeros, atleast_1d, sinc)
 from ._ufuncs import (ellipkm1, mathieu_a, mathieu_b, iv, jv, gamma, psi, zeta,
                       hankel1, hankel2, yv, kv, gammaln, ndtri, errprint, poch,
-                      binom, xlogy)
-from . import _ufuncs
-import types
+                      binom)
 from . import specfun
 from . import orthogonal
-import warnings
 
 __all__ = ['agm', 'ai_zeros', 'assoc_laguerre', 'bei_zeros', 'beip_zeros',
            'ber_zeros', 'bernoulli', 'berp_zeros', 'bessel_diff_formula',
@@ -63,6 +62,19 @@ def diric(x, n):
     -------
     diric : ndarray
 
+    Examples
+    --------
+    >>> from scipy import special
+    >>> import matplotlib.pyplot as plt
+
+    >>> x = np.linspace(-8*np.pi, 8*np.pi, num=201)
+    >>> plt.figure(figsize=(8,8));
+    >>> for idx, n in enumerate([2,3,4,9]):
+    ...     plt.subplot(2, 2, idx+1)
+    ...     plt.plot(x, special.diric(x, n))
+    ...     plt.title('diric, n={}'.format(n))
+    >>> plt.show()
+
     """
     x, n = asarray(x), asarray(n)
     n = asarray(n + (x-x))
@@ -74,7 +86,7 @@ def diric(x, n):
     y = zeros(x.shape, ytype)
 
     # empirical minval for 32, 64 or 128 bit float computations
-    # where sin(x/2)<minval, result is fixed at +1 or -1
+    # where sin(x/2) < minval, result is fixed at +1 or -1
     if np.finfo(ytype).eps < 1e-18:
         minval = 1e-11
     elif np.finfo(ytype).eps < 1e-15:

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -43,8 +43,8 @@ class SpecialFunctionWarning(Warning):
 warnings.simplefilter("always", category=SpecialFunctionWarning)
 
 
-def diric(x,n):
-    """Returns the periodic sinc function, also called the Dirichlet function
+def diric(x, n):
+    """Return the periodic sinc function, also called the Dirichlet function.
 
     The Dirichlet function is defined as::
 
@@ -64,7 +64,7 @@ def diric(x,n):
     diric : ndarray
 
     """
-    x,n = asarray(x), asarray(n)
+    x, n = asarray(x), asarray(n)
     n = asarray(n + (x-x))
     x = asarray(x + (n-n))
     if issubdtype(x.dtype, inexact):
@@ -72,9 +72,9 @@ def diric(x,n):
     else:
         ytype = float
     y = zeros(x.shape, ytype)
-	
-	#empirical minval for 32, 64 or 128 bit float computations
-	#where sin(x/2)<minval, result is fixed at +1 or -1
+
+    # empirical minval for 32, 64 or 128 bit float computations
+    # where sin(x/2)<minval, result is fixed at +1 or -1
     if np.finfo(ytype).eps < 1e-18:
         minval = 1e-11
     elif np.finfo(ytype).eps < 1e-15:
@@ -83,22 +83,22 @@ def diric(x,n):
         minval = 1e-3
 
     mask1 = (n <= 0) | (n != floor(n))
-    place(y,mask1,nan)
-    
+    place(y, mask1, nan)
+
     x /= 2.0
     denom = sin(x)
     mask2 = (1-mask1) & (abs(denom) < minval)
     xsub = extract(mask2, x)
     nsub = extract(mask2, n)
     zsub = xsub / pi
-    place(y, mask2, pow(-1, np.round(zsub)*(nsub-1)))    
-   
+    place(y, mask2, pow(-1, np.round(zsub)*(nsub-1)))
+
     mask = (1-mask1) & (1-mask2)
     xsub = extract(mask, x)
     nsub = extract(mask, n)
     dsub = extract(mask, denom)
     place(y, mask, sin(nsub*xsub)/(nsub*dsub))
-    return y        
+    return y
 
 
 def jnjnp_zeros(nt):
@@ -1124,7 +1124,7 @@ def ellipk(m):
     ellipkinc : Incomplete elliptic integral of the first kind
     ellipe : Complete elliptic integral of the second kind
     ellipeinc : Incomplete elliptic integral of the second kind
- 
+
 
     """
     return ellipkm1(1 - asarray(m))

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -220,6 +220,27 @@ class TestCephes(TestCase):
         assert_equal(cephes.dawsn(0),0.0)
         assert_allclose(cephes.dawsn(1.23), 0.50053727749081767)
 
+    def test_diric(self):
+        # test behavior near multiples of 2*np.pi
+        n_odd = [1, 5, 25]
+        x = np.array(2*np.pi + 5e-5).astype(np.float32)
+        assert_almost_equal(special.diric(x, n_odd), 1.0, decimal=7)
+        x = np.array(2*np.pi + 1e-9).astype(np.float64)
+        assert_almost_equal(special.diric(x, n_odd), 1.0, decimal=15)
+        x = np.array(2*np.pi + 1e-15).astype(np.float64)
+        assert_almost_equal(special.diric(x, n_odd), 1.0, decimal=15)
+        x = np.array(2*np.pi + 1e-12).astype(np.float128)
+        assert_almost_equal(special.diric(x, n_odd), 1.0, decimal=19)
+        n_even = [2, 4, 24]
+        x = np.array(2*np.pi + 1e-9).astype(np.float64)
+        assert_almost_equal(special.diric(x, n_even), -1.0, decimal=15)
+
+        # test at some values not near a multiple of pi
+        x = np.arange(0.2*np.pi, 1.0*np.pi, 0.2*np.pi)
+        octave_result = [0.872677996249965, 0.539344662916632,
+                         0.127322003750035, -0.206011329583298]
+        assert_almost_equal(special.diric(x, 3), octave_result, decimal=15)
+
     def test_ellipe(self):
         assert_equal(cephes.ellipe(1),1.0)
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -221,7 +221,8 @@ class TestCephes(TestCase):
         assert_allclose(cephes.dawsn(1.23), 0.50053727749081767)
 
     def test_diric(self):
-        # test behavior near multiples of 2*np.pi
+        # Test behavior near multiples of 2pi.  Regression test for issue
+        # described in gh-4001.
         n_odd = [1, 5, 25]
         x = np.array(2*np.pi + 5e-5).astype(np.float32)
         assert_almost_equal(special.diric(x, n_odd), 1.0, decimal=7)
@@ -229,17 +230,25 @@ class TestCephes(TestCase):
         assert_almost_equal(special.diric(x, n_odd), 1.0, decimal=15)
         x = np.array(2*np.pi + 1e-15).astype(np.float64)
         assert_almost_equal(special.diric(x, n_odd), 1.0, decimal=15)
-        x = np.array(2*np.pi + 1e-12).astype(np.float128)
-        assert_almost_equal(special.diric(x, n_odd), 1.0, decimal=19)
+        if hasattr(np, 'float128'):
+            # No float128 available in 32-bit numpy
+            x = np.array(2*np.pi + 1e-12).astype(np.float128)
+            assert_almost_equal(special.diric(x, n_odd), 1.0, decimal=19)
+
         n_even = [2, 4, 24]
         x = np.array(2*np.pi + 1e-9).astype(np.float64)
         assert_almost_equal(special.diric(x, n_even), -1.0, decimal=15)
 
-        # test at some values not near a multiple of pi
+        # Test at some values not near a multiple of pi
         x = np.arange(0.2*np.pi, 1.0*np.pi, 0.2*np.pi)
         octave_result = [0.872677996249965, 0.539344662916632,
                          0.127322003750035, -0.206011329583298]
         assert_almost_equal(special.diric(x, 3), octave_result, decimal=15)
+
+    def test_diric_broadcasting(self):
+        x = np.arange(5)
+        n = np.array([1, 3, 7])
+        assert_(special.diric(x[:, np.newaxis], n).shape == (x.size, n.size))
 
     def test_ellipe(self):
         assert_equal(cephes.ellipe(1),1.0)


### PR DESCRIPTION
This is a numerical stability fix to `scipy.special.diric`

Two separate issues are addressed in this pull request:

1) For `diric(x, n)` with `x` very close to 2_pi, substantial oscillation occurs.  There was currently a fix when x was an *exact_ multiple of 2_pi.  The proposed fix extends this to within a certain precision threshold around 2_pi.  The optimal threshold to be used is up for debate, but the values proposed seem reasonable.  The following notebook illustrates the issues prior to and after the proposed fix:

http://nbviewer.ipython.org/github/grlee77/notebooks_sandbox/blob/master/diric_bugfix.ipynb

2) Although the docstring says `n` should be an integer, this was not being enforced and n was actually converted to an array equal in size to `x`.  I propose to return a ValueError if `n` is not a positive integer.  The previous behavior returned an array that was `nan` for any locations where the input `n` was not a positive integer.  This is also demonstrated in the notebook linked above.  Is there any case where the old behavior allowing an arbitrary array of `n` values would be used? 

Apologies in advance if this should have been two separate pull requests (I am still new to development on github).
