### PR TITLE
MAINT: optimize: remove a couple unused variables in zeros.c

### DIFF
--- a/scipy/optimize/zeros.c
+++ b/scipy/optimize/zeros.c
@@ -191,7 +191,7 @@ static struct PyModuleDef moduledef = {
 
 PyObject *PyInit__zeros(void)
 {
-    PyObject *m, *d, *s;
+    PyObject *m;
 
     m = PyModule_Create(&moduledef);
 


### PR DESCRIPTION
This eliminates a couple compiler warnings that occur when building with Python 3.
