### PR TITLE
Expand docs for return values of stats.binned_statistic

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -60,6 +60,10 @@ def binned_statistic(x, values, statistic='mean',
     binnumber : 1-D ndarray of ints
         This assigns to each observation an integer that represents the bin
         in which this observation falls. Array has the same length as values.
+        Each index ``i`` returned is such that ``bins[i-1] <= x < bins[i]`` if
+        `bins` is monotonically increasing, or ``bins[i-1] > x >= bins[i]`` if
+        `bins` is monotonically decreasing. If values in `x` are beyond the
+        bounds of `bins`, 0 or ``len(bins)`` is returned as appropriate. 
 
     See Also
     --------
@@ -168,6 +172,13 @@ def binned_statistic_2d(x, y, values, statistic='mean',
     binnumber : 1-D ndarray of ints
         This assigns to each observation an integer that represents the bin
         in which this observation falls. Array has the same length as `values`.
+        
+        To understand which integer belongs to which bin, imagine an (nx + 2, 
+        ny + 2) ndarray. If values in `x` or `y` are beyond the bounds of 
+        `bins`, they are sorted into the appropriate bin at the edge of that
+        array (first or last column or row). The inner [1:nx + 1,1:ny + 1] of
+        that array corresponds to valid bins. `binnumber` returns the index for
+        a flattened version of this array.
 
     See Also
     --------
@@ -254,6 +265,14 @@ def binned_statistic_dd(sample, values, statistic='mean',
     binnumber : 1-D ndarray of ints
         This assigns to each observation an integer that represents the bin
         in which this observation falls. Array has the same length as values.
+
+        To understand which integer belongs to which bin, imagine an (nx + 2, 
+        ny + 2, ...) ndarray. If values in `sample` are beyond the bounds of 
+        `bins`, they are sorted into the appropriate bin at the edge of that
+        array (first or last column or row). The inner [1:nx + 1,1:ny + 1, ...]
+        of that array corresponds to valid bins. `binnumber` returns the index
+        for a flattened version of this array.
+
 
     See Also
     --------


### PR DESCRIPTION
This is a proposal to improve the documentation for the return values
of `stats.binned_statistic` and its multi-dimensional variants.
I am not entirely happy with the proposed wording, but I think it is more
informative then what we have today and is a step in the right direction.

I have stuggeled for a while to understand what the indices mean and this is the best description I could come up with.
