### PR TITLE
BUG: expm of integer matrices

### DIFF
--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -792,7 +792,8 @@ def _ell(A, m):
 
     # The c_i are explained in (2.2) and (2.6) of the 2005 expm paper.
     # They are coefficients of terms of a generating function series expansion.
-    abs_c_recip = scipy.misc.comb(2*p, p, exact=True) * math.factorial(2*p + 1)
+    choose_2p_p = scipy.misc.comb(2*p, p, exact=True)
+    abs_c_recip = float(choose_2p_p * math.factorial(2*p + 1))
 
     # This is explained after Eq. (1.2) of the 2009 expm paper.
     # It is the "unit roundoff" of IEEE double precision arithmetic.

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -16,8 +16,7 @@ from numpy import array, eye, dot, sqrt, double, exp, random
 from numpy.linalg import matrix_power
 from numpy.testing import (TestCase, run_module_suite,
         assert_allclose, assert_, assert_array_almost_equal, assert_equal,
-        assert_array_equal, assert_array_almost_equal_nulp, decorators,
-        assert_array_less)
+        assert_array_equal, assert_array_almost_equal_nulp, decorators)
 
 from scipy.sparse import csc_matrix, SparseEfficiencyWarning
 from scipy.sparse.construct import eye as speye
@@ -166,7 +165,7 @@ class TestExpM(TestCase):
             [1, -3, 1, 1],
             [1, 1, -3, 1],
             [1, 1, 1, -3]])
-        assert_array_less(0, expm(Q))
+        assert_allclose(expm(Q), expm(1.0 * Q))
 
     def test_triangularity_perturbation(self):
         # Experiment (1) of

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -16,7 +16,8 @@ from numpy import array, eye, dot, sqrt, double, exp, random
 from numpy.linalg import matrix_power
 from numpy.testing import (TestCase, run_module_suite,
         assert_allclose, assert_, assert_array_almost_equal, assert_equal,
-        assert_array_equal, assert_array_almost_equal_nulp, decorators)
+        assert_array_equal, assert_array_almost_equal_nulp, decorators,
+        assert_array_less)
 
 from scipy.sparse import csc_matrix, SparseEfficiencyWarning
 from scipy.sparse.construct import eye as speye
@@ -158,6 +159,14 @@ class TestExpM(TestCase):
                     if np.iscomplexobj(A):
                         A = A + 1j * random.rand(n, n) * scale
                     assert_array_almost_equal(expm(logm(A)), A)
+
+    def test_integer_matrix(self):
+        Q = np.array([
+            [-3, 1, 1, 1],
+            [1, -3, 1, 1],
+            [1, 1, -3, 1],
+            [1, 1, 1, -3]])
+        assert_array_less(0, expm(Q))
 
     def test_triangularity_perturbation(self):
         # Experiment (1) of


### PR DESCRIPTION
expm worked with sparse matrices, np.matrices, np.ndarrays, floating point and complex inputs, but apparently not with integer dtypes
