### PR TITLE
ENH: integrate: odeint: Handle exceptions in the callback functions.

### DIFF
--- a/scipy/integrate/__odepack.h
+++ b/scipy/integrate/__odepack.h
@@ -53,15 +53,13 @@ void ode_function(int *n, double *t, double *y, double *ydot)
 
   /* Append t to argument list */
   if ((arg1 = PyTuple_New(1)) == NULL) {
-    if (PyErr_Occurred())
-      PyErr_Print();
+    *n = -1;
     return;
   }
   PyTuple_SET_ITEM(arg1, 0, PyFloat_FromDouble(*t)); 
                 /* arg1 now owns newly created reference */
-  if ((arglist = PySequence_Concat( arg1, multipack_extra_arguments)) == NULL) {
-    if (PyErr_Occurred())
-      PyErr_Print();
+  if ((arglist = PySequence_Concat(arg1, multipack_extra_arguments)) == NULL) {
+    *n = -1;
     Py_DECREF(arg1);
     return;
   }
@@ -69,7 +67,7 @@ void ode_function(int *n, double *t, double *y, double *ydot)
   
   result_array = (PyArrayObject *)call_python_function(multipack_python_function, *n, y, arglist, 1, odepack_error);
   if (result_array == NULL) {
-    PyErr_Print();
+    *n = -1;
     Py_DECREF(arglist);
     return;
   }
@@ -94,15 +92,13 @@ int ode_jacobian_function(int *n, double *t, double *y, int *ml, int *mu, double
 
   /* Append t to argument list */
   if ((arg1 = PyTuple_New(1)) == NULL) {
-    if (PyErr_Occurred())
-      PyErr_Print();
+    *n = -1;
     return -1;
   }
   PyTuple_SET_ITEM(arg1, 0, PyFloat_FromDouble(*t)); 
                 /* arg1 now owns newly created reference */
   if ((arglist = PySequence_Concat( arg1, multipack_extra_arguments)) == NULL) {
-    if (PyErr_Occurred())
-      PyErr_Print();
+    *n = -1;
     Py_DECREF(arg1);
     return -1;
   }
@@ -110,6 +106,7 @@ int ode_jacobian_function(int *n, double *t, double *y, int *ml, int *mu, double
 
   result_array = (PyArrayObject *)call_python_function(multipack_python_jacobian, *n, y, arglist, 2, odepack_error);
   if (result_array == NULL) {
+    *n = -1;
     Py_DECREF(arglist);
     return -1;
   }

--- a/scipy/integrate/multipack.h
+++ b/scipy/integrate/multipack.h
@@ -163,7 +163,9 @@ static PyObject *call_python_function(PyObject *func, npy_intp n, double *x, PyO
 
   /* Build sequence argument from inputs */
   sequence = (PyArrayObject *)PyArray_SimpleNewFromData(1, &n, NPY_DOUBLE, (char *)x);
-  if (sequence == NULL) PYERR2(error_obj,"Internal failure to make an array of doubles out of first\n                 argument to function call.");
+  if (sequence == NULL) {
+    goto fail;
+  }
 
   /* Build argument list */
   if ((arg1 = PyTuple_New(1)) == NULL) {
@@ -172,11 +174,12 @@ static PyObject *call_python_function(PyObject *func, npy_intp n, double *x, PyO
   }
   PyTuple_SET_ITEM(arg1, 0, (PyObject *)sequence); 
                 /* arg1 now owns sequence reference */
-  if ((arglist = PySequence_Concat( arg1, args)) == NULL)
-    PYERR2(error_obj,"Internal error constructing argument list.");
+  if ((arglist = PySequence_Concat(arg1, args)) == NULL) {
+    goto fail;
+  }
 
   Py_DECREF(arg1);    /* arglist has a reference to sequence, now. */
-  arg1=NULL;
+  arg1 = NULL;
 
   /* Call function object --- variable passed to routine.  Extra
           arguments are in another passed variable.
@@ -185,8 +188,11 @@ static PyObject *call_python_function(PyObject *func, npy_intp n, double *x, PyO
     goto fail;
   }
 
-  if ((result_array = (PyArrayObject *)PyArray_ContiguousFromObject(result, NPY_DOUBLE, dim-1, dim))==NULL) 
-    PYERR2(error_obj,"Result from function call is not a proper array of floats.");
+  result_array = (PyArrayObject *)PyArray_ContiguousFromObject(
+                                      result, NPY_DOUBLE, dim-1, dim);
+  if (result_array == NULL) {
+    goto fail;
+  }
 
   Py_DECREF(result);
   Py_DECREF(arglist);
@@ -198,16 +204,3 @@ static PyObject *call_python_function(PyObject *func, npy_intp n, double *x, PyO
   Py_XDECREF(arg1);
   return NULL;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/scipy/integrate/odepack/lsoda.f
+++ b/scipy/integrate/odepack/lsoda.f
@@ -1210,6 +1210,8 @@ c initial call to f.  (lf0 points to yh(*,2).) -------------------------
       lf0 = lyh + nyh
       call srcma(rsav, isav, 1)
       call f (neq, t, y, rwork(lf0))
+c     SCIPY error check:
+      if (neq(1) .eq. -1) return
       call srcma(rsav, isav, 2)
       nfe = 1
 c load the initial value vector in yh. ---------------------------------
@@ -1353,6 +1355,8 @@ c-----------------------------------------------------------------------
       call stoda (neq, y, rwork(lyh), nyh, rwork(lyh), rwork(lewt),
      1   rwork(lsavf), rwork(lacor), rwork(lwm), iwork(liwm),
      2   f, jac, prja, solsy)
+c     SCIPY error check:
+      if (neq(1) .eq. -1) return
       kgo = 1 - kflag
       go to (300, 530, 540), kgo
 c-----------------------------------------------------------------------

--- a/scipy/integrate/odepack/prja.f
+++ b/scipy/integrate/odepack/prja.f
@@ -69,6 +69,8 @@ c if miter = 1, call jac and multiply by scalar. -----------------------
  110    wm(i+2) = 0.0d0
       call srcma (rsav, isav, 1)
       call jac (neq, tn, y, 0, 0, wm(3), n)
+c     SCIPY error check:
+      if (neq(1) .eq. -1) return
       call srcma (rsav, isav, 2)
       con = -hl0
       do 120 i = 1,lenp
@@ -87,6 +89,8 @@ c if miter = 2, make n calls to f to approximate j. --------------------
         fac = -hl0/r
         call srcma (rsav, isav, 1)
         call f (neq, tn, y, ftem)
+c       SCIPY error check:
+        if (neq(1) .eq. -1) return
         call srcma (rsav, isav, 2)
         do 220 i = 1,n
  220      wm(i+j1) = (ftem(i) - savf(i))*fac
@@ -122,6 +126,8 @@ c if miter = 4, call jac and multiply by scalar. -----------------------
  410    wm(i+2) = 0.0d0
       call srcma (rsav, isav, 1)
       call jac (neq, tn, y, ml, mu, wm(ml3), meband)
+c     SCIPY error check:
+      if (neq(1) .eq. -1) return
       call srcma (rsav, isav, 2)
       con = -hl0
       do 420 i = 1,lenp
@@ -145,6 +151,8 @@ c if miter = 5, make mband calls to f to approximate j. ----------------
  530      y(i) = y(i) + r
         call srcma (rsav, isav, 1)
         call f (neq, tn, y, ftem)
+c       SCIPY error check:
+        if (neq(1) .eq. -1) return
         call srcma (rsav, isav, 2)
         do 550 jj = j,n,mband
           y(jj) = yh(jj,1)

--- a/scipy/integrate/odepack/stoda.f
+++ b/scipy/integrate/odepack/stoda.f
@@ -253,6 +253,8 @@ c-----------------------------------------------------------------------
  230    y(i) = yh(i,1)
       call srcma (rsav, isav, 1)
       call f (neq, tn, y, savf)
+c     SCIPY error check:
+      if (neq(1) .eq. -1) return
       call srcma (rsav, isav, 2)
       nfe = nfe + 1
       if (ipup .le. 0) go to 250
@@ -262,6 +264,8 @@ c preprocessed before starting the corrector iteration.  ipup is set
 c to 0 as an indicator that this has been done.
 c-----------------------------------------------------------------------
       call pjac (neq, y, yh, nyh, ewt, acor, savf, wm, iwm, f, jac)
+c     SCIPY error check:
+      if (neq(1) .eq. -1) return
       ipup = 0
       rc = 1.0d0
       nslp = nst
@@ -328,6 +332,8 @@ c-----------------------------------------------------------------------
       delp = del
       call srcma (rsav, isav, 1)
       call f (neq, tn, y, savf)
+c     SCIPY error check:
+      if (neq(1) .eq. -1) return
       call srcma (rsav, isav, 2)
       nfe = nfe + 1
       go to 270
@@ -605,6 +611,8 @@ c-----------------------------------------------------------------------
  645    y(i) = yh(i,1)
       call srcma (rsav, isav, 1)
       call f (neq, tn, y, savf)
+c     SCIPY error check:
+      if (neq(1) .eq. -1) return
       call srcma (rsav, isav, 2)
       nfe = nfe + 1
       do 650 i = 1,n

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -653,5 +653,37 @@ def test_odeint_banded_jacobian():
     assert_array_equal(info1['nje'], info2['nje'])
 
 
+def test_odeint_errors():
+    def sys1d(x, t):
+        return -100*x
+
+    def bad1(x, t):
+        return 1.0/0
+
+    def bad2(x, t):
+        return "foo"
+
+    def bad_jac1(x, t):
+        return 1.0/0
+
+    def bad_jac2(x, t):
+        return [["foo"]]
+
+    def sys2d(x, t):
+        return [-100*x[0], -0.1*x[1]]
+
+    def sys2d_bad_jac(x, t):
+        return [[1.0/0, 0], [0, -0.1]]
+
+    assert_raises(ZeroDivisionError, odeint, bad1, 1.0, [0, 1])
+    assert_raises(ValueError, odeint, bad2, 1.0, [0, 1])
+
+    assert_raises(ZeroDivisionError, odeint, sys1d, 1.0, [0, 1], Dfun=bad_jac1)
+    assert_raises(ValueError, odeint, sys1d, 1.0, [0, 1], Dfun=bad_jac2)
+
+    assert_raises(ZeroDivisionError, odeint, sys2d, [1.0, 1.0], [0, 1],
+                  Dfun=sys2d_bad_jac)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Basic idea:  There are C functions that are called by the Fortran solver
LSODA.  These C functions call the user's Python callback function (i.e. the
definitions of the differential equations and Jacobian).  If an error occurs
in the Python code, the C functions set the "number of equations" parameter
to -1 to indicate that an error has occurred.  The Fortran code will now
check for this value, and simply return if it is detected.  The error set
in the user's python code will propagate up to the Python code that called
LSODA, so the user gets the exception.

Change summary:
__odepack.h:
    In the callback functions, instead of calling PyErr_Print() when an
    error occurs, set *n = -1.
multipack.h:
    Don't use PYERR2 (which does PyErr_Print and then sets a new exception).
    Instead, just let the error propagate.
Fortran code:
    Check for neq(1) being -1 on return from calls to user's code.
