### PR TITLE
BUG: stats: Refactor argument validation to avoid a unicode issue.

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -265,13 +265,9 @@ def binned_statistic_dd(sample, values, statistic='mean',
     .. versionadded:: 0.11.0
 
     """
-    if type(statistic) == str:
-        if statistic not in ['mean', 'median', 'count', 'sum', 'std']:
-            raise ValueError('unrecognized statistic "%s"' % statistic)
-    elif callable(statistic):
-        pass
-    else:
-        raise ValueError("statistic not understood")
+    known_stats = ['mean', 'median', 'count', 'sum', 'std']
+    if not callable(statistic) and statistic not in known_stats:
+        raise ValueError('invalid statistic %r' % (statistic,))
 
     # This code is based on np.histogramdd
     try:

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -130,6 +130,16 @@ class TestBinnedStatistic(object):
         assert_array_almost_equal(binx1, binx2)
         assert_array_almost_equal(biny1, biny2)
 
+    def test_2d_mean_unicode(self):
+        x = self.x
+        y = self.y
+        v = self.v
+        stat1, binx1, biny1, bc = binned_statistic_2d(x, y, v, u'mean', bins=5)
+        stat2, binx2, biny2, bc = binned_statistic_2d(x, y, v, np.mean, bins=5)
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(binx1, binx2)
+        assert_array_almost_equal(biny1, biny2)
+
     def test_2d_std(self):
         x = self.x
         y = self.y


### PR DESCRIPTION
Fixes the handling of a unicode argument to the binned statistics
functions.

Closes gh-4026.
