### PR TITLE
MAINT: stats: stop silencing IntegrationWarnings in distributions.expect

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2210,10 +2210,7 @@ class rv_continuous(rv_generic):
         else:
             invfac = 1.0
         kwds['args'] = args
-        # Silence floating point warnings from integration.
-        olderr = np.seterr(all='ignore')
         vals = integrate.quad(fun, lb, ub, **kwds)[0] / invfac
-        np.seterr(**olderr)
         return vals
 
 


### PR DESCRIPTION
The docstring indicates that "The integration behavior of this function is inherited from `integrate.quad`". It seems to me it makes sense to inherit the warnings behavior as well, instead of silently swallowing the warnings in case of poor convergence. 

This does not cause much noise in the test suite.
