### PR TITLE
Added newline to scipy.sparse.linalg.svds documentation for correct display.

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1656,6 +1656,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
         Return singular vectors (True) in addition to singular values
 
         .. versionadded:: 0.12.0
+
     Returns
     -------
     u : ndarray, shape=(M, k)


### PR DESCRIPTION
The absent newline before "Returns" causes it to display incorrectly on documentation html page: http://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.sparse.linalg.svds.html
