### PR TITLE
MAINT: stats: Add note about change to scoreatpercentile in release 0.12.0.

### DIFF
--- a/doc/release/0.12.0-notes.rst
+++ b/doc/release/0.12.0-notes.rst
@@ -144,9 +144,16 @@ now removed.
 Its private support modules ``scipy.io.dumbdbm_patched`` and
 ``scipy.io.dumb_shelve`` are also removed.
 
+`axis` argument added to `scipy.stats.scoreatpercentile`
+--------------------------------------------------------
 
-Other changes
-=============
+The function `scipy.stats.scoreatpercentile` has been given an `axis`
+argument.  The default argument is `axis=None`, which means the calculation
+is done on the flattened array.  Before this change, `scoreatpercentile`
+would act as if `axis=0` had been given.  Code using `scoreatpercentile`
+with a multidimensional array will need to add `axis=0` to the function call
+to preserve the old behavior.  (This API change was not noticed until
+long after the release of 0.12.0.)
 
 
 Authors

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1019,14 +1019,6 @@ class TestScoreatpercentile(TestCase):
         assert_equal(stats.scoreatpercentile(x, 100), 3.5)
         assert_equal(stats.scoreatpercentile(x, 50), 1.75)
 
-    def test_2D(self):
-        x = array([[1, 1, 1],
-                   [1, 1, 1],
-                   [4, 4, 3],
-                   [1, 1, 1],
-                   [1, 1, 1]])
-        assert_array_equal(stats.scoreatpercentile(x, 50), [1, 1, 1])
-
     def test_fraction(self):
         scoreatperc = stats.scoreatpercentile
 
@@ -1107,6 +1099,18 @@ class TestScoreatpercentile(TestCase):
 
         r1 = [[0.75, 4.75, 8.75], [1.5, 5.5, 9.5], [3, 7, 11]]
         assert_equal(scoreatperc(x, (25, 50, 100), axis=1), r1)
+
+        x = array([[1, 1, 1],
+                   [1, 1, 1],
+                   [4, 4, 3],
+                   [1, 1, 1],
+                   [1, 1, 1]])
+        score = stats.scoreatpercentile(x, 50)
+        assert_equal(score.shape, ())
+        assert_equal(score, 1.0)
+        score = stats.scoreatpercentile(x, 50, axis=0)
+        assert_equal(score.shape, (3,))
+        assert_equal(score, [1, 1, 1])
 
     def test_exception(self):
         assert_raises(ValueError, stats.scoreatpercentile, [1, 2], 56,


### PR DESCRIPTION
Also make a test of scoreatpercentile on a 2D array more explicit
about the expected result.

Closes gh-3329.
