### PR TITLE
Remove reference cycles in LinearOperators et.al to allow garbage collection

### DIFF
--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -11,6 +11,7 @@ import scipy.sparse as sparse
 from itertools import product
 
 from scipy.sparse.linalg import interface
+from scipy.lib._gcutils import assert_deallocated
 
 
 class TestLinearOperator(TestCase):
@@ -129,6 +130,17 @@ class TestLinearOperator(TestCase):
             assert_equal((C**2).matmat([[1],[1]]), [[17],[37]])
 
             assert_(isinstance(C**2, interface._PowerLinearOperator))
+
+    def test_memory_deallocation(self):
+        """Test that memory is deallocatable by reference counting"""
+
+        rng = np.random.RandomState(0)
+        X = rng.rand(100, 100)
+        with assert_deallocated(interface.MatrixLinearOperator, X):
+            pass
+
+        with assert_deallocated(interface.LinearOperator, X.shape, X.dtype):
+            pass
 
 
 class TestAsLinearOperator(TestCase):


### PR DESCRIPTION
I'm not sure that this is the right way.When MatrixLinearOperator is called repeatedly on copies, it seems to me that there is a increase in memory. (Though I don't know why)

```
X = np.random.randn(24000, 2000)
for _ in range(5):
    t = MatrixLinearOperator(X)
```

If the range of the number is increased, one can see the increase in memory usage. A stopgap is to delete the attributes after every call that seems to work fine.

Sklearn's Ridge solvers use the `lsqr` function and when it is called repeatedly across a cross-validation object, it sometimes blows up the memory. The discussion in https://github.com/scikit-learn/scikit-learn/issues/3762 articulates this.
