### PR TITLE
ENH: Support LinearOperator as input to svds

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -83,7 +83,7 @@ Jeff Armstrong for discrete state-space and linear time-invariant functionality
 Mark Wiebe for fixing type casting after changes in Numpy.
 Andrey Smirnov for improvements to FIR filter design.
 Anthony Scopatz for help with code review and merging.
-Lars Buitinck for improvements to io.arff and scipy.sparse.
+Lars Buitinck for improvements to scipy.sparse and various other modules.
 Scott Sinclair for documentation improvements and some bug fixes.
 Gael Varoquaux for cleanups in scipy.sparse.
 Skipper Seabold for a fix to special.gammainc.

--- a/doc/release/0.15.0-notes.rst
+++ b/doc/release/0.15.0-notes.rst
@@ -57,6 +57,10 @@ redesigned. It is now possible to use scipy.integrate to integrate
 multivariate ctypes functions, thus avoiding callbacks to Python and providing 
 better performance, especially for complex integrand functions.
 
+``scipy.sparse`` improvements
+-----------------------------
+``scipy.sparse.linalg.svds`` now takes a ``LinearOperator`` as its main input.
+
 ``scipy.stats`` improvements
 ----------------------------
 Added a Dirichlet distribution as multivariate distribution.

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1623,7 +1623,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
     Parameters
     ----------
-    A : sparse matrix
+    A : {sparse matrix, LinearOperator}
         Array to compute the SVD on, of shape (M, N)
     k : int, optional
         Number of singular values and vectors to compute.
@@ -1671,23 +1671,41 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     This is a naive implementation using ARPACK as an eigensolver
     on A.H * A or A * A.H, depending on which one is more efficient.
     """
-    if not (isinstance(A, np.ndarray) or isspmatrix(A)):
+    if not (isinstance(A, LinearOperator) or isspmatrix(A)):
         A = np.asarray(A)
 
     n, m = A.shape
 
-    if n > m:
-        X = A
-        XH = _herm(A)
+    if isinstance(A, LinearOperator):
+        if n > m:
+            X_dot = A.matvec
+            X_matmat = A.matmat
+            XH_dot = A.rmatvec
+        else:
+            X_dot = A.rmatvec
+            XH_dot = A.matvec
+
+            # A^H * V; works around lack of LinearOperator.adjoint.
+            # XXX This can be slow!
+            def X_matmat(V):
+                out = np.empty((V.shape[1], m))
+                for i, col in enumerate(V.T):
+                    out[i, :] = A.rmatvec(col.reshape(-1, 1)).T
+                return out.T
+
     else:
-        XH = A
-        X = _herm(A)
+        if n > m:
+            X_dot = X_matmat = A.dot
+            XH_dot = _herm(A).dot
+        else:
+            XH_dot = A.dot
+            X_dot = X_matmat = _herm(A).dot
 
     def matvec_XH_X(x):
-        return XH.dot(X.dot(x))
+        return XH_dot(X_dot(x))
 
-    XH_X = LinearOperator(matvec=matvec_XH_X, dtype=X.dtype,
-                          shape=(X.shape[1], X.shape[1]))
+    XH_X = LinearOperator(matvec=matvec_XH_X, dtype=A.dtype,
+                          shape=(min(A.shape), min(A.shape)))
 
     # Get a low rank approximation of the implicitly defined gramian matrix.
     # This is not a stable way to approach the problem.
@@ -1720,11 +1738,11 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
         if n > m:
             vlarge = eigvec[:, above_cutoff]
-            ularge = X.dot(vlarge) / slarge
+            ularge = X_matmat(vlarge) / slarge
             vhlarge = _herm(vlarge)
         else:
             ularge = eigvec[:, above_cutoff]
-            vhlarge = _herm(X.dot(ularge) / slarge)
+            vhlarge = _herm(X_matmat(ularge) / slarge)
 
         u = _augmented_orthonormal_cols(ularge, nsmall)
         vh = _augmented_orthonormal_rows(vhlarge, nsmall)
@@ -1737,10 +1755,10 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
         if n > m:
             v = eigvec
-            u = X.dot(v) / s
+            u = X_matmat(v) / s
             vh = _herm(v)
         else:
             u = eigvec
-            vh = _herm(X.dot(u) / s)
+            vh = _herm(X_matmat(u) / s)
 
     return u, s, vh

--- a/scipy/sparse/linalg/isolve/lsqr.py
+++ b/scipy/sparse/linalg/isolve/lsqr.py
@@ -117,7 +117,7 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
 
     Parameters
     ----------
-    A : {sparse matrix, ndarray, LinearOperatorLinear}
+    A : {sparse matrix, ndarray, LinearOperator}
         Representation of an m-by-n matrix.  It is required that
         the linear operator can produce ``Ax`` and ``A^T x``.
     b : (m,) ndarray


### PR DESCRIPTION
This adds support for `LinearOperator` arguments in `scipy.sparse.linalg.svds`. My goal is to perform PCA on sparse matrices. As you know, PCA is SVD on a mean-centered matrix X - μ; the mean-centering is problematic since it destroys sparsity and my matrices don't fit in memory in dense format. Representing X - μ as a composite `LinearOperator` solves this problem.
