### PR TITLE
BUG: optimize: fix botched test for scalars

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -32,6 +32,7 @@ import numpy
 from scipy.lib.six import callable
 from numpy import (atleast_1d, eye, mgrid, argmin, zeros, shape, squeeze,
                    vectorize, asarray, sqrt, Inf, asfarray, isinf)
+import numpy as np
 from .linesearch import (line_search_wolfe1, line_search_wolfe2,
                          line_search_wolfe2 as line_search)
 
@@ -136,7 +137,7 @@ def is_array_scalar(x):
     """Test whether `x` is either a scalar or an array scalar.
 
     """
-    return len(atleast_1d(x) == 1)
+    return np.size(x) == 1
 
 _epsilon = sqrt(numpy.finfo(float).eps)
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -711,8 +711,11 @@ class TestOptimizeScalar(TestCase):
         assert_raises(ValueError, optimize.fminbound, self.fun, 5, 1)
 
     def test_fminbound_scalar(self):
-        assert_raises(ValueError, optimize.fminbound, self.fun,
-                      np.zeros(2), 1)
+        try:
+            optimize.fminbound(self.fun, np.zeros((1, 2)), 1)
+            self.fail("exception not raised")
+        except ValueError as e:
+            assert_('must be scalar' in str(e))
 
         x = optimize.fminbound(self.fun, 1, np.array(5))
         assert_allclose(x, self.solution, atol=1e-6)


### PR DESCRIPTION
Any row-vector or other ndarray with shape[0] == 1 was passed through.
