### PR TITLE
BUG: Match exception declarations in scipy/io/matlab/streams.pyx to their corresponding pxd declarations.

### DIFF
--- a/scipy/io/matlab/streams.pyx
+++ b/scipy/io/matlab/streams.pyx
@@ -202,6 +202,8 @@ cdef class ZlibInputStream(GenericStream):
                (self._buffer_size == self._buffer_position)
 
     cpdef long int tell(self) except -1:
+        if self._total_position == -1:
+            raise IOError("Invalid file position.")
         return self._total_position
 
     cpdef int seek(self, long int offset, int whence=0) except -1:
@@ -305,7 +307,10 @@ cdef class FileStream(GenericStream):
         return ret
 
     cpdef long int tell(self) except -1:
-        return ftell(self.file)
+        cdef long int position = ftell(self.file)
+        if position == -1:
+            raise IOError("Invalid file position.")
+        return position
 
     cdef int read_into(self, void *buf, size_t n) except -1:
         """ Read n bytes from stream into pre-allocated buffer `buf`

--- a/scipy/io/matlab/streams.pyx
+++ b/scipy/io/matlab/streams.pyx
@@ -201,7 +201,7 @@ cdef class ZlibInputStream(GenericStream):
         return (self._max_length == self._read_bytes) and \
                (self._buffer_size == self._buffer_position)
 
-    cpdef long int tell(self):
+    cpdef long int tell(self) except -1:
         return self._total_position
 
     cpdef int seek(self, long int offset, int whence=0) except -1:
@@ -304,7 +304,7 @@ cdef class FileStream(GenericStream):
             raise IOError('Failed seek')
         return ret
 
-    cpdef long int tell(self):
+    cpdef long int tell(self) except -1:
         return ftell(self.file)
 
     cdef int read_into(self, void *buf, size_t n) except -1:


### PR DESCRIPTION
In a recent [commit to Cython](https://github.com/cython/cython/commit/e6874284a11fb9cb7d5d5fb7b00c6451812aed20) stricter checking was added for function signatures declared in pyx and pxd files. This checking is now included in cython 21.1. This patch allows scipy to compile with the stricter checks.
