### PR TITLE
ENH: Refactor and expand LinearOperator API

### DIFF
--- a/scipy/linalg/_matfuncs_inv_ssq.py
+++ b/scipy/linalg/_matfuncs_inv_ssq.py
@@ -69,8 +69,7 @@ class _MatrixM1PowerOperator(LinearOperator):
             X = self._A.dot(X) - X
         return X
 
-    @property
-    def T(self):
+    def _adjoint(self):
         return _MatrixM1PowerOperator(self._A.T, self._p)
 
 

--- a/scipy/linalg/_matfuncs_inv_ssq.py
+++ b/scipy/linalg/_matfuncs_inv_ssq.py
@@ -54,17 +54,17 @@ class _MatrixM1PowerOperator(LinearOperator):
         self.ndim = A.ndim
         self.shape = A.shape
 
-    def matvec(self, x):
+    def _matvec(self, x):
         for i in range(self._p):
             x = self._A.dot(x) - x
         return x
 
-    def rmatvec(self, x):
+    def _rmatvec(self, x):
         for i in range(self._p):
             x = x.dot(self._A) - x
         return x
 
-    def matmat(self, X):
+    def _matmat(self, X):
         for i in range(self._p):
             X = self._A.dot(X) - X
         return X

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -250,17 +250,17 @@ class MatrixPowerOperator(LinearOperator):
         self.ndim = A.ndim
         self.shape = A.shape
 
-    def matvec(self, x):
+    def _matvec(self, x):
         for i in range(self._p):
             x = self._A.dot(x)
         return x
 
-    def rmatvec(self, x):
+    def _rmatvec(self, x):
         for i in range(self._p):
             x = x.dot(self._A)
         return x
 
-    def matmat(self, X):
+    def _matmat(self, X):
         for i in range(self._p):
             X = self._A.dot(X)
         return X

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import scipy.linalg
 import scipy.sparse.linalg
-from scipy.sparse.linalg import LinearOperator
+from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
 __all__ = ['expm_multiply']
 
@@ -238,38 +238,6 @@ _theta = {
         }
 
 
-class MatrixPowerOperator(LinearOperator):
-
-    def __init__(self, A, p):
-        if A.ndim != 2 or A.shape[0] != A.shape[1]:
-            raise ValueError('expected A to be like a square matrix')
-        if p < 0:
-            raise ValueError('expected p to be a non-negative integer')
-        self._A = A
-        self._p = p
-        self.ndim = A.ndim
-        self.shape = A.shape
-
-    def _matvec(self, x):
-        for i in range(self._p):
-            x = self._A.dot(x)
-        return x
-
-    def _rmatvec(self, x):
-        for i in range(self._p):
-            x = x.dot(self._A)
-        return x
-
-    def _matmat(self, X):
-        for i in range(self._p):
-            X = self._A.dot(X)
-        return X
-
-    @property
-    def T(self):
-        return MatrixPowerOperator(self._A.T, self._p)
-
-
 def _onenormest_matrix_power(A, p,
         t=2, itmax=5, compute_v=False, compute_w=False):
     """
@@ -310,7 +278,7 @@ def _onenormest_matrix_power(A, p,
     #XXX Eventually turn this into an API function in the  _onenormest module,
     #XXX and remove its underscore,
     #XXX but wait until expm_multiply goes into scipy.
-    return scipy.sparse.linalg.onenormest(MatrixPowerOperator(A, p))
+    return scipy.sparse.linalg.onenormest(aslinearoperator(A) ** p)
 
 
 class LazyOperatorNormInfo:

--- a/scipy/sparse/linalg/_onenormest.py
+++ b/scipy/sparse/linalg/_onenormest.py
@@ -72,7 +72,8 @@ def onenormest(A, t=2, itmax=5, compute_v=False, compute_w=False):
     """
 
     # Check the input.
-    if len(A.shape) != 2 or A.shape[0] != A.shape[1]:
+    A = aslinearoperator(A)
+    if A.shape[0] != A.shape[1]:
         raise ValueError('expected the operator to act like a square matrix')
 
     # If the operator size is small compared to t,
@@ -93,7 +94,7 @@ def onenormest(A, t=2, itmax=5, compute_v=False, compute_w=False):
         w = A_explicit[:, argmax_j]
         est = col_abs_sums[argmax_j]
     else:
-        est, v, w, nmults, nresamples = _onenormest_core(A, A.T, t, itmax)
+        est, v, w, nmults, nresamples = _onenormest_core(A, A.H, t, itmax)
 
     # Report the norm estimate along with some certificates of the estimate.
     if compute_v or compute_w:

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -60,11 +60,6 @@ def as2d(ar):
         return aux
 
 
-class CallableLinearOperator(LinearOperator):
-    def __call__(self, x):
-        return self.matmat(x)
-
-
 def _makeOperator(operatorInput, expectedShape):
     """Takes a dense numpy array or a sparse matrix or
     a function and makes an operator performing matrix * blockvector
@@ -85,12 +80,6 @@ def _makeOperator(operatorInput, expectedShape):
 
     if operator.shape != expectedShape:
         raise ValueError('operator has invalid shape')
-
-    if sys.version_info[0] >= 3:
-        # special methods are looked up on the class -- so make a new one
-        operator.__class__ = CallableLinearOperator
-    else:
-        operator.__call__ = operator.matmat
 
     return operator
 

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -1,13 +1,17 @@
 from __future__ import division, print_function, absolute_import
 
+from abc import ABCMeta, abstractmethod
+
 import numpy as np
-from scipy.sparse.sputils import isshape, isintlike
+
+from scipy.lib.six import with_metaclass
 from scipy.sparse import isspmatrix
+from scipy.sparse.sputils import isshape, isintlike
 
 __all__ = ['LinearOperator', 'aslinearoperator']
 
 
-class LinearOperator(object):
+class LinearOperator(with_metaclass(ABCMeta, object)):
     """Common interface for performing matrix vector products
 
     Many iterative methods (e.g. cg, gmres) do not need to know the
@@ -17,15 +21,18 @@ class LinearOperator(object):
     an abstract interface between iterative solvers and matrix-like
     objects.
 
+    To construct a concrete LinearOperator, either pass appropriate
+    callables to the constructor of this class, or subclass it and
+    implement at least the method ``_matvec`` and the attributes or
+    properties ``shape`` (pair of integers) and dtype (may be None),
+    and optionally the methods ``_rmatvec`` and ``_matmat``.
+
     Parameters
     ----------
     shape : tuple
-        Matrix dimensions (M,N)
+        Matrix dimensions (M,N).
     matvec : callable f(v)
         Returns returns A * v.
-
-    Other Parameters
-    ----------------
     rmatvec : callable f(v)
         Returns A^H * v, where A^H is the conjugate transpose of A.
     matmat : callable f(V)
@@ -68,30 +75,14 @@ class LinearOperator(object):
     array([ 2.,  3.])
 
     """
-    def __init__(self, shape, matvec, rmatvec=None, matmat=None, dtype=None):
-
-        shape = tuple(shape)
-
-        if not isshape(shape):
-            raise ValueError('invalid shape')
-
-        self.shape = shape
-        self._matvec = matvec
-        self.args = ()
-
-        if rmatvec is None:
-            def rmatvec(v):
-                raise NotImplementedError('rmatvec is not defined')
-            self.rmatvec = rmatvec
+    def __new__(cls, *args, **kwargs):
+        if cls is LinearOperator:
+            # Operate as _CustomLinearOperator factory.
+            return _CustomLinearOperator(*args, **kwargs)
         else:
-            self.rmatvec = rmatvec
-
-        if matmat is not None:
-            # matvec each column of V
-            self._matmat = matmat
-
-        if dtype is not None:
-            self.dtype = np.dtype(dtype)
+            obj = super(LinearOperator, cls).__new__(cls)
+            obj.__init__(*args, **kwargs)
+            return obj
 
     def _matmat(self, X):
         """Default matrix-matrix multiplication handler.  Falls back on
@@ -100,8 +91,17 @@ class LinearOperator(object):
 
         return np.hstack([self.matvec(col.reshape(-1,1)) for col in X.T])
 
+    @abstractmethod
+    def _matvec(self, x):
+        """Matrix-vector multiplication.
+
+        If self is a linear operator of shape (M, N), then this method will
+        be called on a shape (N,) or (N, 1) ndarray, and should return a
+        shape (M,) or (M, 1) ndarray.
+        """
+
     def matvec(self, x):
-        """Matrix-vector multiplication
+        """Matrix-vector multiplication.
 
         Performs the operation y=A*x where A is an MxN linear
         operator and x is a column vector or rank-1 array.
@@ -119,8 +119,8 @@ class LinearOperator(object):
 
         Notes
         -----
-        This matvec wraps the user-specified matvec routine to ensure that
-        y has the correct shape and type.
+        This matvec wraps the user-specified matvec routine or overridden
+        _matvec method to ensure that y has the correct shape and type.
 
         """
 
@@ -147,8 +147,55 @@ class LinearOperator(object):
 
         return y
 
+    def rmatvec(self, x):
+        """Adjoint matrix-vector multiplication.
+
+        Performs the operation y = A^H * x where A is an MxN linear
+        operator and x is a column vector or rank-1 array.
+
+        Parameters
+        ----------
+        x : {matrix, ndarray}
+            An array with shape (M,) or (M,1).
+
+        Returns
+        -------
+        y : {matrix, ndarray}
+            A matrix or ndarray with shape (N,) or (N,1) depending
+            on the type and shape of the x argument.
+
+        Notes
+        -----
+        This rmatvec wraps the user-specified rmatvec routine or overridden
+        _rmatvec method to ensure that y has the correct shape and type.
+
+        """
+
+        x = np.asanyarray(x)
+
+        M,N = self.shape
+
+        if x.shape != (M,) and x.shape != (M,1):
+            raise ValueError('dimension mismatch')
+
+        y = self._rmatvec(x)
+
+        if isinstance(x, np.matrix):
+            y = np.asmatrix(y)
+        else:
+            y = np.asarray(y)
+
+        if x.ndim == 1:
+            y = y.reshape(N)
+        elif x.ndim == 2:
+            y = y.reshape(N,1)
+        else:
+            raise ValueError('invalid shape returned by user-defined rmatvec()')
+
+        return y
+
     def matmat(self, X):
-        """Matrix-matrix multiplication
+        """Matrix-matrix multiplication.
 
         Performs the operation y=A*X where A is an MxN linear
         operator and X dense N*K matrix or ndarray.
@@ -166,8 +213,8 @@ class LinearOperator(object):
 
         Notes
         -----
-        This matmat wraps any user-specified matmat routine to ensure that
-        y has the correct type.
+        This matmat wraps any user-specified matmat routine or overridden
+        _matmat method to ensure that y has the correct type.
 
         """
 
@@ -236,12 +283,53 @@ class LinearOperator(object):
 
     def __repr__(self):
         M,N = self.shape
-        if hasattr(self,'dtype'):
-            dt = 'dtype=' + str(self.dtype)
-        else:
+        if self.dtype is None:
             dt = 'unspecified dtype'
+        else:
+            dt = 'dtype=' + str(self.dtype)
 
         return '<%dx%d %s with %s>' % (M, N, self.__class__.__name__, dt)
+
+    @property
+    def H(self):
+        return self._adjoint()
+
+
+class _CustomLinearOperator(LinearOperator):
+    """Linear operator defined in terms of user-specified operations."""
+
+    def __init__(self, shape, matvec, rmatvec=None, matmat=None, dtype=None):
+        shape = tuple(shape)
+
+        if not isshape(shape):
+            raise ValueError('invalid shape')
+
+        self.args = ()
+        self.shape = shape
+
+        self.__matvec_impl = matvec
+        self.__rmatvec_impl = rmatvec
+        self.__matmat_impl = matmat
+
+        if dtype is None:
+            self.dtype = None
+        else:
+            self.dtype = np.dtype(dtype)
+
+    def _matmat(self, X):
+        if self.__matmat_impl is not None:
+            return self.__matmat_impl(X)
+        else:
+            return super(_CustomLinearOperator, self)._matmat(X)
+
+    def _matvec(self, x):
+        return self.__matvec_impl(x)
+
+    def _rmatvec(self, x):
+        func = self.__rmatvec_impl
+        if func is None:
+            raise NotImplemented("rmatvec is not defined")
+        return self.__rmatvec_impl(x)
 
 
 def _get_dtype(operators, dtypes=[]):
@@ -257,19 +345,24 @@ class _SumLinearOperator(LinearOperator):
                 not isinstance(B, LinearOperator):
             raise ValueError('both operands have to be a LinearOperator')
         if A.shape != B.shape:
-            raise ValueError('shape mismatch')
-        super(_SumLinearOperator, self).__init__(A.shape,
-                self.matvec, self.rmatvec, self.matmat, _get_dtype([A,B]))
+            raise ValueError('cannot add %r and %r: shape mismatch'
+                             % (A, B))
         self.args = (A, B)
+        self.dtype = _get_dtype([A, B])
+        self.shape = A.shape
 
-    def matvec(self, x):
+    def _matvec(self, x):
         return self.args[0].matvec(x) + self.args[1].matvec(x)
 
-    def rmatvec(self, x):
+    def _rmatvec(self, x):
         return self.args[0].rmatvec(x) + self.args[1].rmatvec(x)
 
-    def matmat(self, x):
+    def _matmat(self, x):
         return self.args[0].matmat(x) + self.args[1].matmat(x)
+
+    def _adjoint(self, x):
+        A, B = self.args
+        return A.H + B.H
 
 
 class _ProductLinearOperator(LinearOperator):
@@ -278,19 +371,24 @@ class _ProductLinearOperator(LinearOperator):
                 not isinstance(B, LinearOperator):
             raise ValueError('both operands have to be a LinearOperator')
         if A.shape[1] != B.shape[0]:
-            raise ValueError('shape mismatch')
-        super(_ProductLinearOperator, self).__init__((A.shape[0], B.shape[1]),
-                self.matvec, self.rmatvec, self.matmat, _get_dtype([A,B]))
+            raise ValueError('cannot multiply %r and %r: shape mismatch'
+                             % (A, B))
+        self.shape = (A.shape[0], B.shape[1])
         self.args = (A, B)
+        self.dtype = _get_dtype([A, B])
 
-    def matvec(self, x):
+    def _matvec(self, x):
         return self.args[0].matvec(self.args[1].matvec(x))
 
-    def rmatvec(self, x):
+    def _rmatvec(self, x):
         return self.args[1].rmatvec(self.args[0].rmatvec(x))
 
-    def matmat(self, x):
+    def _matmat(self, x):
         return self.args[0].matmat(self.args[1].matmat(x))
+
+    def _adjoint(self, x):
+        A, B = self.args
+        return A.H * B.H
 
 
 class _ScaledLinearOperator(LinearOperator):
@@ -299,19 +397,22 @@ class _ScaledLinearOperator(LinearOperator):
             raise ValueError('LinearOperator expected as A')
         if not np.isscalar(alpha):
             raise ValueError('scalar expected as alpha')
-        super(_ScaledLinearOperator, self).__init__(A.shape,
-                self.matvec, self.rmatvec, self.matmat,
-                _get_dtype([A], [type(alpha)]))
+        self.shape = A.shape
+        self.dtype = _get_dtype([A], [type(alpha)])
         self.args = (A, alpha)
 
-    def matvec(self, x):
+    def _matvec(self, x):
         return self.args[1] * self.args[0].matvec(x)
 
-    def rmatvec(self, x):
+    def _rmatvec(self, x):
         return np.conj(self.args[1]) * self.args[0].rmatvec(x)
 
-    def matmat(self, x):
+    def _matmat(self, x):
         return self.args[1] * self.args[0].matmat(x)
+
+    def _adjoint(self, x):
+        A, alpha = self.args
+        return A * alpha
 
 
 class _PowerLinearOperator(LinearOperator):
@@ -319,13 +420,13 @@ class _PowerLinearOperator(LinearOperator):
         if not isinstance(A, LinearOperator):
             raise ValueError('LinearOperator expected as A')
         if A.shape[0] != A.shape[1]:
-            raise ValueError('square LinearOperator expected as A')
+            raise ValueError('square LinearOperator expected, got %r' % A)
         if not isintlike(p):
             raise ValueError('integer expected as p')
-        super(_PowerLinearOperator, self).__init__(A.shape,
-                self.matvec, self.rmatvec, self.matmat,
-                _get_dtype([A]))
+
         self.args = (A, p)
+        self.dtype = _get_dtype([A])
+        self.shape = A.shape
 
     def _power(self, fun, x):
         res = np.array(x, copy=True)
@@ -333,49 +434,74 @@ class _PowerLinearOperator(LinearOperator):
             res = fun(res)
         return res
 
-    def matvec(self, x):
+    def _matvec(self, x):
         return self._power(self.args[0].matvec, x)
 
-    def rmatvec(self, x):
+    def _rmatvec(self, x):
         return self._power(self.args[0].rmatvec, x)
 
-    def matmat(self, x):
+    def _matmat(self, x):
         return self._power(self.args[0].matmat, x)
+
+    def _adjoint(self):
+        A, p = self.args
+        return A.H ** p
 
 
 class MatrixLinearOperator(LinearOperator):
     def __init__(self, A):
-        super(MatrixLinearOperator, self).__init__(shape=A.shape,
-                dtype=A.dtype, matvec=None, rmatvec=self.rmatvec)
-        self.matvec = A.dot
-        self.matmat = A.dot
-        self.__mul__ = A.dot
         self.A = A
-        self.A_conj = None
+        self.__adj = None
         self.args = (A,)
+        self.dtype = A.dtype
+        self.shape = A.shape
 
-    def rmatvec(self, x):
-        if self.A_conj is None:
-            self.A_conj = self.A.T.conj()
-        return self.A_conj.dot(x)
+    def _matmat(self, X):
+        return self.A.dot(X)
+
+    def _matvec(self, x):
+        return self.A.dot(x)
+
+    def _rmatvec(self, x):
+        return self._adjoint().matvec(x)
+
+    def _adjoint(self):
+        if self.__adj is None:
+            self.__adj = _AdjointMatrixOperator(self)
+        return self.__adj
+
+
+class _AdjointMatrixOperator(MatrixLinearOperator):
+    def __init__(self, adjoint):
+        self.A = adjoint.A.T.conj()
+        self.__adjoint = adjoint
+        self.args = (adjoint,)
+        self.shape = adjoint.shape[1], adjoint.shape[0]
+
+    @property
+    def dtype(self):
+        return self.__adjoint.dtype
+
+    def _adjoint(self):
+        return self.__adjoint
 
 
 class IdentityOperator(LinearOperator):
-    def __init__(self, shape, dtype):
-        super(IdentityOperator, self).__init__(shape=shape, dtype=dtype,
-                matvec=None, rmatvec=self.rmatvec)
+    def __init__(self, shape, dtype=None):
+        self.dtype = dtype
+        self.shape = shape
 
-    def matvec(self, x):
+    def _matvec(self, x):
         return x
 
-    def rmatvec(self, x):
+    def _rmatvec(self, x):
         return x
 
-    def matmat(self, x):
+    def _matmat(self, x):
         return x
 
-    def __mul__(self, x):
-        return x
+    def _adjoint(self):
+        return self
 
 
 def aslinearoperator(A):

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -193,17 +193,17 @@ class MatrixPowerOperator(LinearOperator):
         self.ndim = A.ndim
         self.shape = A.shape
 
-    def matvec(self, x):
+    def _matvec(self, x):
         for i in range(self._p):
             x = self._A.dot(x)
         return x
 
-    def rmatvec(self, x):
+    def _rmatvec(self, x):
         for i in range(self._p):
             x = x.dot(self._A)
         return x
 
-    def matmat(self, X):
+    def _matmat(self, X):
         for i in range(self._p):
             X = _smart_matrix_product(self._A, X, structure=self._structure)
         return X
@@ -237,17 +237,17 @@ class ProductOperator(LinearOperator):
             self.ndim = len(self.shape)
         self._operator_sequence = args
 
-    def matvec(self, x):
+    def _matvec(self, x):
         for A in reversed(self._operator_sequence):
             x = A.dot(x)
         return x
 
-    def rmatvec(self, x):
+    def _rmatvec(self, x):
         for A in self._operator_sequence:
             x = x.dot(A)
         return x
 
-    def matmat(self, X):
+    def _matmat(self, X):
         for A in reversed(self._operator_sequence):
             X = _smart_matrix_product(A, X, structure=self._structure)
         return X

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -190,6 +190,7 @@ class MatrixPowerOperator(LinearOperator):
         self._A = A
         self._p = p
         self._structure = structure
+        self.dtype = A.dtype
         self.ndim = A.ndim
         self.shape = A.shape
 
@@ -199,8 +200,10 @@ class MatrixPowerOperator(LinearOperator):
         return x
 
     def _rmatvec(self, x):
+        A_T = self._A.T
+        x = x.ravel()
         for i in range(self._p):
-            x = x.dot(self._A)
+            x = A_T.dot(x)
         return x
 
     def _matmat(self, X):
@@ -235,6 +238,7 @@ class ProductOperator(LinearOperator):
                                 'must all have the same shape.')
             self.shape = (n, n)
             self.ndim = len(self.shape)
+        self.dtype = np.find_common_type([x.dtype for x in args], [])
         self._operator_sequence = args
 
     def _matvec(self, x):
@@ -243,8 +247,9 @@ class ProductOperator(LinearOperator):
         return x
 
     def _rmatvec(self, x):
+        x = x.ravel()
         for A in self._operator_sequence:
-            x = x.dot(A)
+            x = A.T.dot(x)
         return x
 
     def _matmat(self, X):
@@ -577,6 +582,13 @@ def expm(A):
            31 (3). pp. 970-989. ISSN 1095-7162
 
     """
+    return _expm(A, use_exact_onenorm='auto')
+
+
+def _expm(A, use_exact_onenorm):
+    # Core of expm, separated to allow testing exact and approximate
+    # algorithms.
+
     # Avoid indiscriminate asarray() to allow sparse or other strange arrays.
     if isinstance(A, (list, tuple)):
         A = np.asarray(A)
@@ -586,8 +598,9 @@ def expm(A):
     # Detect upper triangularity.
     structure = UPPER_TRIANGULAR if _is_upper_triangular(A) else None
 
-    # Hardcode a matrix order threshold for exact vs. estimated one-norms.
-    use_exact_onenorm = A.shape[0] < 200
+    if use_exact_onenorm == "auto":
+        # Hardcode a matrix order threshold for exact vs. estimated one-norms.
+        use_exact_onenorm = A.shape[0] < 200
 
     # Track functions of A to help compute the matrix exponential.
     h = _ExpmPadeHelper(

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -253,7 +253,7 @@ def test_attributes():
         assert_(hasattr(op, "_matvec"))
 
 
-def test_botched_subclass():
+def test_inheritance():
     class Empty(interface.LinearOperator):
         pass
 
@@ -261,8 +261,7 @@ def test_botched_subclass():
 
     class Identity(interface.LinearOperator):
         def __init__(self, n):
-            self.shape = (n, n)
-            self.dtype = None
+            super(Identity, self).__init__(dtype=None, shape=(n, n))
 
         def _matvec(self, x):
             return x
@@ -270,3 +269,14 @@ def test_botched_subclass():
     id3 = Identity(3)
     assert_equal(id3.matvec([1, 2, 3]), [1, 2, 3])
     assert_raises(NotImplementedError, id3.rmatvec, [4, 5, 6])
+
+    class MatmatOnly(interface.LinearOperator):
+        def __init__(self, A):
+            super(MatmatOnly, self).__init__(A.dtype, A.shape)
+            self.A = A
+
+        def _matmat(self, x):
+            return self.A.dot(x)
+
+    mm = MatmatOnly(np.random.randn(5, 3))
+    assert_equal(mm.matvec(np.random.randn(3)).shape, (5,))

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -58,6 +58,7 @@ class TestLinearOperator(TestCase):
 
             assert_equal((2*A)*[1,1,1], [12,30])
             assert_equal((2*A).rmatvec([1,1]), [10, 14, 18])
+            assert_equal((2*A).H.matvec([1,1]), [10, 14, 18])
             assert_equal((2*A)*[[1],[1],[1]], [[12],[30]])
             assert_equal((2*A).matmat([[1],[1],[1]]), [[12],[30]])
             assert_equal((A*2)*[1,1,1], [12,30])
@@ -65,6 +66,7 @@ class TestLinearOperator(TestCase):
             assert_equal((2j*A)*[1,1,1], [12j,30j])
             assert_equal((A+A)*[1,1,1], [12, 30])
             assert_equal((A+A).rmatvec([1,1]), [10, 14, 18])
+            assert_equal((A+A).H.matvec([1,1]), [10, 14, 18])
             assert_equal((A+A)*[[1],[1],[1]], [[12], [30]])
             assert_equal((A+A).matmat([[1],[1],[1]]), [[12], [30]])
             assert_equal((-A)*[1,1,1], [-6,-15])
@@ -114,6 +116,7 @@ class TestLinearOperator(TestCase):
             assert_equal((A*B).matmat([[1],[1]]), [[50],[113]])
 
             assert_equal((A*B).rmatvec([1,1]), [71,92])
+            assert_equal((A*B).H.matvec([1,1]), [71,92])
 
             assert_(isinstance(A*B, interface._ProductLinearOperator))
 
@@ -128,6 +131,7 @@ class TestLinearOperator(TestCase):
 
             assert_equal((C**2)*[1,1], [17,37])
             assert_equal((C**2).rmatvec([1,1]), [22,32])
+            assert_equal((C**2).H.matvec([1,1]), [22,32])
             assert_equal((C**2).matmat([[1],[1]]), [[17],[37]])
 
             assert_(isinstance(C**2, interface._PowerLinearOperator))

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -20,7 +20,7 @@ from numpy.testing import (TestCase, run_module_suite,
 
 from scipy.sparse import csc_matrix, SparseEfficiencyWarning
 from scipy.sparse.construct import eye as speye
-from scipy.sparse.linalg.matfuncs import (expm,
+from scipy.sparse.linalg.matfuncs import (expm, _expm,
         ProductOperator, MatrixPowerOperator,
         _onenorm_matrix_power_nnm)
 from scipy.linalg import logm
@@ -136,7 +136,10 @@ class TestExpM(TestCase):
             for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
                 a = scale * speye(3, 3, dtype=dtype, format='csc')
                 e = exp(scale) * eye(3, dtype=dtype)
-                assert_array_almost_equal_nulp(expm(a).toarray(), e, nulp=100)
+                exact_onenorm = _expm(a, use_exact_onenorm=True).toarray()
+                inexact_onenorm = _expm(a, use_exact_onenorm=False).toarray()
+                assert_array_almost_equal_nulp(exact_onenorm, e, nulp=100)
+                assert_array_almost_equal_nulp(inexact_onenorm, e, nulp=100)
 
     def test_padecases_dtype_sparse_complex(self):
         # float32 and complex64 lead to errors in spsolve/UMFpack

--- a/scipy/sparse/linalg/tests/test_onenormest.py
+++ b/scipy/sparse/linalg/tests/test_onenormest.py
@@ -27,13 +27,13 @@ class MatrixProductOperator(scipy.sparse.linalg.LinearOperator):
         self.ndim = 2
         self.shape = (A.shape[0], B.shape[1])
 
-    def matvec(self, x):
+    def _matvec(self, x):
         return np.dot(self.A, np.dot(self.B, x))
 
-    def rmatvec(self, x):
+    def _rmatvec(self, x):
         return np.dot(np.dot(x, self.A), self.B)
 
-    def matmat(self, X):
+    def _matmat(self, X):
         return np.dot(self.A, np.dot(self.B, X))
 
     @property


### PR DESCRIPTION
In light of recent problems with the `scipy.sparse.linalg.LinearOperator` API (#4073, #4074), I decided to clean up the code and expand it. Highlights of this PR:
- cleaner separation of API and implementation
- documentation on how to subclass `LinearOperator`
- added an `adjoint` method, with short-hand notation `A.H` borrowed from [PyOperators](https://pchanial.github.io/pyoperators/documentation/)
- some more unit tests
- mostly backwards compatible, except for existing subclasses (but I'm not sure if subclassing was ever advertised?)

The main low-light is that it takes some trickery to pull off the backward compat (`__new__`), but not too much.

Still to-do:
- <del>make `adjoint` work whenever `rmatvec` is defined and vice-versa (this can get tricky...)</del>
- <del>make `[r]matvec` default to `[r]matmat` if that is defined</del>
- <del>prune away duplicate code in `scipy.sparse.linalg.matfuncs` and elsewhere.</del>
- Merge in new SVD code.
