### PR TITLE
Fix typo in docstring for scipy.spatial.cKDTree

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -784,7 +784,7 @@ cdef class cKDTree:
     Parameters
     ----------
     data : array-like, shape (n,m)
-        The n data points of dimension mto be indexed. This array is 
+        The n data points of dimension m to be indexed. This array is 
         not copied unless this is necessary to produce a contiguous 
         array of doubles, and so modifying this data will result in 
         bogus results.


### PR DESCRIPTION
Fix typo in docstring for scipy.spatial.cKDTree
