### PR TITLE
BUG: fitpack: avoid a memory error in splev(x, tck, der=k)

### DIFF
--- a/scipy/interpolate/fitpack/splder.f
+++ b/scipy/interpolate/fitpack/splder.f
@@ -1,4 +1,5 @@
       subroutine splder(t,n,c,k,nu,x,y,m,e,wrk,ier)
+      implicit none  
 c  subroutine splder evaluates in a number of points x(i),i=1,2,...,m
 c  the derivative of order nu of a spline s(x) of degree k,given in
 c  its b-spline representation.
@@ -132,7 +133,7 @@ c  check if arg is in the support
             endif
         endif
 c  search for knot interval t(l) <= arg < t(l+1)
- 65     if(arg.ge.t(l) .or. l+1.eq.k2) go to 70
+ 65     if(arg.ge.t(l) .or. l+1.eq.k3) go to 70
         l1 = l
         l = l-1
         j = j-1

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -390,5 +390,30 @@ def test_dblint():
     assert_almost_equal(dblint(-100, 100, -100, 100, tck), 1)
 
 
+def test_splev_der_k():
+    # regression test for gh-2188: splev(x, tck, der=k) gives garbage or crashes
+    # for x outside of knot range
+
+    # test case from gh-2188
+    tck = (np.array([0., 0., 2.5, 2.5]),
+           np.array([-1.56679978, 2.43995873, 0., 0.]),
+           1)
+    t, c, k = tck
+    x = np.array([-3, 0, 2.5, 3])
+
+    # an explicit form of the linear spline
+    assert_allclose(splev(x, tck), c[0] + (c[1] - c[0]) * x/t[2])
+    assert_allclose(splev(x, tck, 1), (c[1]-c[0]) / t[2])
+
+    # now check a random spline vs splder
+    np.random.seed(1234)
+    x = np.sort(np.random.random(30))
+    y = np.random.random(30)
+    t, c, k = splrep(x, y)
+
+    x = [t[0] - 1., t[-1] + 1.]
+    tck2 = splder((t, c, k), k)
+    assert_allclose(splev(x, (t, c, k), k), splev(x, tck2))
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Fix a memory error in splev(..., der=k) for x < t[0].
closes gh-2188
