### PR TITLE
MAINT: speed up 1-norm estimation for non-tiny linear operators

### DIFF
--- a/scipy/sparse/linalg/_onenormest.py
+++ b/scipy/sparse/linalg/_onenormest.py
@@ -216,7 +216,8 @@ def _algorithm_2_2(A, AT, t):
         Y = np.asarray(A_linear_operator.matmat(X))
         g = np.sum(np.abs(Y), axis=0)
         best_j = np.argmax(g)
-        g = np.sort(g)[::-1]
+        g.sort()
+        g = g[::-1]
         S = sign_round_up(Y)
         Z = np.asarray(AT_linear_operator.matmat(S))
         h = np.max(np.abs(Z), axis=1)

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -7,7 +7,7 @@ import warnings
 
 import numpy as np
 from numpy.testing import (TestCase, run_module_suite, assert_allclose,
-        assert_, assert_equal, decorators)
+        assert_, assert_equal)
 
 from scipy.sparse import SparseEfficiencyWarning
 import scipy.linalg


### PR DESCRIPTION
This also halves the `expm_multiply` time in `$ python runtests.py --bench -s sparse.linalg` on my system.
