### PR TITLE
ENH: sparse: faster setdiag for CSR and CSC matrices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ MANIFEST
 # distutils configuration
 site.cfg
 # other temporary files
+.coverage
 .deps
 .libs
 

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -750,8 +750,12 @@ class spmatrix(object):
         M, N = self.shape
         if (k > 0 and k >= N) or (k < 0 and -k >= M):
             raise ValueError("k exceeds matrix dimensions")
+        self._setdiag(np.asarray(values), k)
+
+    def _setdiag(self, values, k):
+        M, N = self.shape
         if k < 0:
-            if np.asarray(values).ndim == 0:
+            if values.ndim == 0:
                 # broadcast
                 max_index = min(M+k, N)
                 for i in xrange(max_index):
@@ -763,7 +767,7 @@ class spmatrix(object):
                 for i,v in enumerate(values[:max_index]):
                     self[i - k, i] = v
         else:
-            if np.asarray(values).ndim == 0:
+            if values.ndim == 0:
                 # broadcast
                 max_index = min(M, N-k)
                 for i in xrange(max_index):

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -655,6 +655,36 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         i, j = self._swap((i.ravel(), j.ravel()))
         self._set_many(i, j, x.ravel())
 
+    def _setdiag(self, values, k):
+        if 0 in self.shape:
+            return
+
+        M, N = self.shape
+        broadcast = (values.ndim == 0)
+
+        if k < 0:
+            if broadcast:
+                max_index = min(M + k, N)
+            else:
+                max_index = min(M + k, N, len(values))
+            i = np.arange(max_index, dtype=self.indices.dtype)
+            j = np.arange(max_index, dtype=self.indices.dtype)
+            i -= k
+
+        else:
+            if broadcast:
+                max_index = min(M, N - k)
+            else:
+                max_index = min(M, N - k, len(values))
+            i = np.arange(max_index, dtype=self.indices.dtype)
+            j = np.arange(max_index, dtype=self.indices.dtype)
+            j += k
+
+        if not broadcast:
+            values = values[:len(i)]
+
+        self[i, j] = values
+
     def _set_many(self, i, j, x):
         """Sets value at each (i, j) to x
 

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -414,11 +414,8 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         return d
     diagonal.__doc__ = _data_matrix.diagonal.__doc__
 
-    def setdiag(self, values, k=0):
+    def _setdiag(self, values, k):
         M, N = self.shape
-        if k <= -M or k >= N:
-            raise ValueError('k exceeds matrix dimensions')
-        values = np.asarray(values, dtype=self.dtype)
         if values.ndim and not len(values):
             return
         idx_dtype = self.row.dtype
@@ -452,8 +449,6 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         self.col = np.concatenate((self.col[keep], new_col))
         self.data = np.concatenate((self.data[keep], new_data))
         self.has_canonical_format = False
-
-    setdiag.__doc__ = _data_matrix.setdiag.__doc__
 
     # needed by _data_matrix
     def _with_data(self,data,copy=True):

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -184,12 +184,8 @@ class dia_matrix(_data_matrix):
     def _mul_multimatrix(self, other):
         return np.hstack([self._mul_vector(col).reshape(-1,1) for col in other.T])
 
-    def setdiag(self, values, k=0):
+    def _setdiag(self, values, k=0):
         M, N = self.shape
-        if k <= -M or k >= N:
-            raise ValueError('k exceeds matrix dimensions')
-
-        values = np.asarray(values)
 
         if values.ndim == 0:
             # broadcast
@@ -219,8 +215,6 @@ class dia_matrix(_data_matrix):
             data[:-1,:self.data.shape[1]] = self.data
             data[-1, min_index:max_index] = values
             self.data = data
-
-    setdiag.__doc__ = _data_matrix.setdiag.__doc__
 
     def todia(self,copy=False):
         if copy:


### PR DESCRIPTION
Trying to speed up the tests here. Before, the four slowest tests were

```
test_base.TestCSRNonCanonical.test_setdiag: 4.6238s
test_base.TestCSCNonCanonical.test_setdiag: 4.5692s
test_base.TestCSR.test_setdiag: 4.4937s
test_base.TestCSC.test_setdiag: 4.4765s
```

After, it's the same four, but they take a little less time:

```
test_base.TestCSCNonCanonical.test_setdiag: 3.3904s
test_base.TestCSRNonCanonical.test_setdiag: 3.2470s
test_base.TestCSR.test_setdiag: 3.1338s
test_base.TestCSC.test_setdiag: 3.0898s
```

Not as quick as a I hoped, but still a net improvement.
