### PR TITLE
ENH: associated Legendre function of second kind with types 2 and 3

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -321,10 +321,11 @@ These are not universal functions:
    :toctree: generated/
 
    clpmn    -- [+]Associated Legendre Function of the first kind for complex arguments.
+   clpmn    -- [+]Associated Legendre Function of the second kind for complex arguments.
    lpn      -- [+]Legendre Functions (polynomials) of the first kind
    lqn      -- [+]Legendre Functions of the second kind.
    lpmn     -- [+]Associated Legendre Function of the first kind for real arguments.
-   lqmn     -- [+]Associated Legendre Function of the second kind.
+   lqmn     -- [+]Associated Legendre Function of the second kind for real arguments.
 
 Orthogonal polynomials
 ----------------------

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -321,7 +321,7 @@ These are not universal functions:
    :toctree: generated/
 
    clpmn    -- [+]Associated Legendre Function of the first kind for complex arguments.
-   clpmn    -- [+]Associated Legendre Function of the second kind for complex arguments.
+   clqmn    -- [+]Associated Legendre Function of the second kind for complex arguments.
    lpn      -- [+]Legendre Functions (polynomials) of the first kind
    lqn      -- [+]Legendre Functions of the second kind.
    lpmn     -- [+]Associated Legendre Function of the first kind for real arguments.

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -909,16 +909,21 @@ def clqmn(m,n,z,type=3):
     mm = max(1,m)
     nn = max(1,n)
 
-    q,qd = specfun.clqmn(mm,nn,real(z),imag(z),3)
+    if type==2 and imag(z)==0:
+        z = z+1e-300j
+    q,qd = specfun.clqmn(mm,nn,real(z),imag(z))
+    if imag(z)>0:
+        sign = 1
+    else:
+        sign = -1
     # DLMF 14.23.6
     if type==2:
-        if mm<=nn:
-            p,pd = specfun.clpmn(mm,nn,real(z),imag(z),3)
-            q = q-0.5j*pi*p
-            qd = qd-0.5j*pi*pd
-        phase = 1j**(-mm)
-        q = phase*q
-        qd = phase*qd
+        p,pd = specfun.clpmn(mm,nn,real(z),imag(z),3)
+        q = q+sign*0.5j*pi*p
+        qd = qd+sign*0.5j*pi*pd
+        phase = 1j**(sign*np.arange(mm+1).reshape(mm+1, 1))
+        q = q*phase
+        qd = qd*phase
     return q[:(m+1),:(n+1)],qd[:(m+1),:(n+1)]
 
 

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -909,15 +909,15 @@ def clqmn(m,n,z,type=3):
     mm = max(1,m)
     nn = max(1,n)
 
-    if type==2 and imag(z)==0:
+    if type == 2 and imag(z) == 0:
         z = z+1e-300j
     q,qd = specfun.clqmn(mm,nn,real(z),imag(z))
-    if imag(z)>0:
+    if imag(z) > 0:
         sign = 1
     else:
         sign = -1
     # DLMF 14.23.6
-    if type==2:
+    if type == 2:
         p,pd = specfun.clpmn(mm,nn,real(z),imag(z),3)
         q = q+sign*0.5j*pi*p
         qd = qd+sign*0.5j*pi*pd

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -909,7 +909,13 @@ def clqmn(m,n,z,type=3):
     mm = max(1,m)
     nn = max(1,n)
 
-    q,qd = specfun.clqmn(mm,nn,real(z),imag(z),type)
+    q,qd = specfun.clqmn(mm,nn,real(z),imag(z),3)
+    # DLMF 14.23.6
+    if type==2:
+        p,pd = specfun.clpmn(mm,nn,real(z),imag(z),3)
+        phase = 1j**(-mm)
+        q = phase*(q-0.5j*pi*p)
+        qd = phase*(qd-0.5j*pi*pd)
     return q[:(m+1),:(n+1)],qd[:(m+1),:(n+1)]
 
 

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -912,10 +912,13 @@ def clqmn(m,n,z,type=3):
     q,qd = specfun.clqmn(mm,nn,real(z),imag(z),3)
     # DLMF 14.23.6
     if type==2:
-        p,pd = specfun.clpmn(mm,nn,real(z),imag(z),3)
+        if mm<=nn:
+            p,pd = specfun.clpmn(mm,nn,real(z),imag(z),3)
+            q = q-0.5j*pi*p
+            qd = qd-0.5j*pi*pd
         phase = 1j**(-mm)
-        q = phase*(q-0.5j*pi*p)
-        qd = phase*(qd-0.5j*pi*pd)
+        q = phase*q
+        qd = phase*qd
     return q[:(m+1),:(n+1)],qd[:(m+1),:(n+1)]
 
 

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -20,8 +20,8 @@ import warnings
 
 __all__ = ['agm', 'ai_zeros', 'assoc_laguerre', 'bei_zeros', 'beip_zeros',
            'ber_zeros', 'bernoulli', 'berp_zeros', 'bessel_diff_formula',
-           'bi_zeros', 'clpmn', 'comb', 'digamma', 'diric', 'ellipk', 'erf_zeros',
-           'erfcinv', 'erfinv', 'errprint', 'euler', 'factorial',
+           'bi_zeros', 'clpmn', 'clqmn', 'comb', 'digamma', 'diric', 'ellipk',
+           'erf_zeros', 'erfcinv', 'erfinv', 'errprint', 'euler', 'factorial',
            'factorialk', 'factorial2', 'fresnel_zeros',
            'fresnelc_zeros', 'fresnels_zeros', 'gamma', 'gammaln', 'h1vp',
            'h2vp', 'hankel1', 'hankel2', 'hyp0f1', 'iv', 'ivp', 'jn_zeros',
@@ -771,12 +771,53 @@ def clpmn(m,n,z,type=3):
 
 
 def lqmn(m,n,z):
-    """Associated Legendre functions of the second kind, Qmn(z) and its
-    derivative, ``Qmn'(z)`` of order m and degree n.  Returns two
-    arrays of size ``(m+1, n+1)`` containing ``Qmn(z)`` and ``Qmn'(z)`` for
-    all orders from ``0..m`` and degrees from ``0..n``.
+    """Associated Legendre function of the second kind, Qmn(z)
 
-    z can be complex.
+    Computes the associated Legendre function of the second kind
+    of order m and degree n,::
+
+        Qmn(z) = Q_n^m(z)
+
+    and its derivative, ``Qmn'(z)``.  Returns two arrays of size
+    ``(m+1, n+1)`` containing ``Qmn(z)`` and ``Qmn'(z)`` for all
+    orders from ``0..m`` and degrees from ``0..n``.
+
+    This function takes a real argument ``z``. For complex arguments ``z``
+    use clqmn instead.
+
+    Parameters
+    ----------
+    m : int
+       the order of the Legendre function.
+    n : int
+       where ``n >= 0``; the degree of the Legendre function.  Often
+       called ``l`` (lower case L) in descriptions of the associated
+       Legendre function
+    z : float
+        Input value.
+
+    Returns
+    -------
+    Pmn_z : (m+1, n+1) array
+       Values for all orders 0..m and degrees 0..n
+    Pmn_d_z : (m+1, n+1) array
+       Derivatives for all orders 0..m and degrees 0..n
+
+    See Also
+    --------
+    clqmn: associated Legendre functions of the second kind for complex z
+
+    Notes
+    -----
+    In the interval (-1, 1), Ferrer's function of the second kind is
+    returned. The phase convention used for the intervals (1, inf)
+    and (-inf, -1) is such that the result is always real.
+
+    References
+    ----------
+    .. [1] NIST Digital Library of Mathematical Functions
+           http://dlmf.nist.gov/14.3
+
     """
     if not isscalar(m) or (m < 0):
         raise ValueError("m must be a non-negative integer.")
@@ -792,9 +833,81 @@ def lqmn(m,n,z):
     nn = max(1,n)
 
     if iscomplex(z):
-        q,qd = specfun.clqmn(mm,nn,z)
+        raise ValueError("Argument must be real. Use clqmn instead.")
     else:
         q,qd = specfun.lqmn(mm,nn,z)
+    return q[:(m+1),:(n+1)],qd[:(m+1),:(n+1)]
+
+
+def clqmn(m,n,z,type=3):
+    """Associated Legendre function of the second kind, Qmn(z)
+
+    Computes the (associated) Legendre function of the second kind
+    of order m and degree n,::
+
+        Qmn(z) = Q_n^m(z)
+
+    and its derivative, ``Qmn'(z)``.  Returns two arrays of size
+    ``(m+1, n+1)`` containing ``Qmn(z)`` and ``Qmn'(z)`` for all
+    orders from ``0..m`` and degrees from ``0..n``.
+
+    Parameters
+    ----------
+    m : int
+    n : int
+       where ``n >= 0``; the degree of the Legendre function.  Often
+       called ``l`` (lower case L) in descriptions of the associated
+       Legendre function
+    z : float or complex
+        Input value.
+    type : int
+       takes values 2 or 3
+       2: cut on the real axis |x|>1
+       3: cut on the real axis -1<x<1 (default)
+
+    Returns
+    -------
+    Qmn_z : (m+1, n+1) array
+       Values for all orders 0..m and degrees 0..n
+    Qmn_d_z : (m+1, n+1) array
+       Derivatives for all orders 0..m and degrees 0..n
+
+    See Also
+    --------
+    lqmn: associated Legendre functions of the second kind for real z
+
+    Notes
+    -----
+    By default, i.e. for ``type=3``, phase conventions are chosen according
+    to [1]_ such that the function is analytic. The cut lies on the interval
+    (-1, 1). Approaching the cut from above or below in general yields a phase
+    factor with respect to Ferrer's function of the second kind
+    (cf. `lqmn`).
+
+    For ``type=2`` a cut at |x|>1 is chosen. Approaching the real values
+    on the interval (-1, 1) in the complex plane yields Ferrer's function
+    of the first kind.
+
+    References
+    ----------
+    .. [1] NIST Digital Library of Mathematical Functions
+           http://dlmf.nist.gov/14.21
+
+    """
+    if not isscalar(m) or (m < 0):
+        raise ValueError("m must be a non-negative integer.")
+    if not isscalar(n) or (n < 0):
+        raise ValueError("n must be a non-negative integer.")
+    if not isscalar(z):
+        raise ValueError("z must be scalar.")
+    if not(type == 2 or type == 3):
+        raise ValueError("type must be either 2 or 3.")
+
+    # Ensure neither m nor n == 0
+    mm = max(1,m)
+    nn = max(1,n)
+
+    q,qd = specfun.clqmn(mm,nn,real(z),imag(z),type)
     return q[:(m+1),:(n+1)],qd[:(m+1),:(n+1)]
 
 

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -902,6 +902,8 @@ def clqmn(m,n,z,type=3):
         raise ValueError("z must be scalar.")
     if not(type == 2 or type == 3):
         raise ValueError("type must be either 2 or 3.")
+    m = int(m)
+    n = int(n)
 
     # Ensure neither m nor n == 0
     mm = max(1,m)

--- a/scipy/special/specfun.pyf
+++ b/scipy/special/specfun.pyf
@@ -3,13 +3,13 @@ python module specfun ! in
     interface  ! in :specfun
         ! cpdsa
         ! cfs
-        subroutine clqmn(mm,m,n,z,cqm,cqd) ! in :specfun:specfun.f
-            callstatement (*f2py_func)(&mm,&m,&n,&(z.r),&(z.i),cqm,cqd)
-            callprotoargument int*,int*,int*,double*,double*,complex_double*,complex_double*
+        subroutine clqmn(mm,m,n,x,y,ntype,cqm,cqd) ! in :specfun:specfun.f
             integer intent(hide),depend(m) :: mm=m
             integer intent(in), check(m>=1) :: m
             integer intent(in), check(n>=1) :: n
-            complex*16 intent(in) :: z
+            double precision intent(in) :: x
+            double precision intent(in) :: y
+            integer intent(in), check(ntype==2||ntype==3) :: ntype
             complex*16 intent(out),dimension(0:mm,0:n),depend(mm,n) :: cqm
             complex*16 intent(out),dimension(0:mm,0:n),depend(mm,n) :: cqd
         end subroutine clqmn

--- a/scipy/special/specfun.pyf
+++ b/scipy/special/specfun.pyf
@@ -3,13 +3,12 @@ python module specfun ! in
     interface  ! in :specfun
         ! cpdsa
         ! cfs
-        subroutine clqmn(mm,m,n,x,y,ntype,cqm,cqd) ! in :specfun:specfun.f
+        subroutine clqmn(mm,m,n,x,y,cqm,cqd) ! in :specfun:specfun.f
             integer intent(hide),depend(m) :: mm=m
             integer intent(in), check(m>=1) :: m
             integer intent(in), check(n>=1) :: n
             double precision intent(in) :: x
             double precision intent(in) :: y
-            integer intent(in), check(ntype==2||ntype==3) :: ntype
             complex*16 intent(out),dimension(0:mm,0:n),depend(mm,n) :: cqm
             complex*16 intent(out),dimension(0:mm,0:n),depend(mm,n) :: cqd
         end subroutine clqmn

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -12157,7 +12157,7 @@ C
 
 C       **********************************
 
-        SUBROUTINE CLQMN(MM,M,N,X,Y,NTYPE,CQM,CQD)
+        SUBROUTINE CLQMN(MM,M,N,X,Y,CQM,CQD)
 C
 C       =======================================================
 C       Purpose: Compute the associated Legendre functions of
@@ -12185,21 +12185,16 @@ C
            RETURN
         ENDIF
         XC=CDABS(Z)
-        IF (NTYPE.EQ.2) THEN
-           LS=1
-        ELSE
-           LS=-1
-        END IF
+        LS=-1
         ZQ=CDSQRT(LS*(1.0D0-Z*Z))
         IF (X.LT.0D0) THEN
            ZQ=LS*ZQ
         END IF
         ZS=LS*(1.0D0-Z*Z)
         CQ0=0.5D0*CDLOG(LS*(1.0D0+Z)/(1.0D0-Z))
-C       For |z|>1.0001 and NTYPE=3, backward recursion is needed.
-C       For 1<|z|<1.0001 and for NTYPE=2 for all 1<|z|, we can
-C       proceed as for |z|<1.
-        IF ((XC.LT.1.0001D0).OR.(NTYPE.EQ.2)) THEN
+C       For |z|>1.0001, backward recursion is needed.
+C       For 1<|z|<1.0001, we can proceed as for |z|<1.
+        IF (XC.LT.1.0001D0) THEN
            CQM(0,0)=CQ0
            CQM(0,1)=Z*CQ0-1.0D0
            CQM(1,0)=-1.0D0/ZQ
@@ -12210,8 +12205,7 @@ C       DLMF 14.10.3 applied to Q
               CQM(I,J)=((2.0D0*J-1.0D0)*Z*CQM(I,J-1)
      &                -(J+I-1.0D0)*CQM(I,J-2))/(J-I)
 15         CONTINUE
-C       NTYPE=2: DLMF 14.10.1 applied to Q
-C       NTYPE=3: DLMF 14.10.6 applied to Q
+C       DLMF 14.10.6 applied to Q
            DO 20 J=0,N
            DO 20 I=2,M
               CQM(I,J)=-2.0D0*(I-1.0D0)*Z/ZQ*CQM(I-1,J)-LS*
@@ -12248,8 +12242,7 @@ C       backward recursion with DLMF 14.10.3 applied to Q with mu=1
               DO 45 J=0,N
                  CQ0=CQM(0,J)
                  CQ1=CQM(1,J)
-C       NTYPE=2: DLMF 14.10.1 applied to Q
-C       NTYPE=3: DLMF 14.10.6 applied to Q
+C       DLMF 14.10.6 applied to Q
                  DO 45 I=0,M-2
                     CQF=-2.0D0*(I+1)*Z/ZQ*CQ1-LS*(J-I)*(J+I+1.0D0)*CQ0
                     CQM(I+2,J)=CQF
@@ -12262,10 +12255,8 @@ C       NTYPE=3: DLMF 14.10.6 applied to Q
 C       DLMF 14.10.5 applied to Q with mu=0
         DO 50 J=1,N
 50         CQD(0,J)=LS*J*(CQM(0,J-1)-Z*CQM(0,J))/ZS
-C       NTYPE=2: derivative of DLMF 14.7.9
-C                and DLMF 14.10.1 applied to Q
-C       NTYPE=3: derivative of LDMF 14.7.12
-C                and DLMF 14.10.6 applied to Q
+C       derivative of LDMF 14.7.12
+C       and DLMF 14.10.6 applied to Q
         DO 55 J=0,N
         DO 55 I=1,M
            CQD(I,J)=LS*I*Z/ZS*CQM(I,J)+(I+J)*(J-I+1.0D0)

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -169,6 +169,9 @@ C
         IF (DABS(X).GT.1.0D0) LS=-1
         XS=LS*(1.0D0-X*X)
         XQ=DSQRT(XS)
+        IF (X.LT.0D0) THEN
+           XQ=LS*XQ
+        END IF
         Q0=0.5D0*DLOG(DABS((X+1.0D0)/(X-1.0D0)))
         IF (DABS(X).LT.1.0001D0) THEN
            QM(0,0)=Q0

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -12190,6 +12190,9 @@ C
         ZQ=CDSQRT(LS*(1.0D0-Z*Z))
         ZS=LS*(1.0D0-Z*Z)
         CQ0=0.5D0*CDLOG(LS*(1.0D0+Z)/(1.0D0-Z))
+C       For |z|>1.0001 and NTYPE=3, backward recursion is needed.
+C       For 1<|z|<1.0001 and for NTYPE=2 for all 1<|z|, we can
+C       proceed as for |z|<1.
         IF ((XC.LT.1.0001D0).OR.(NTYPE.EQ.2)) THEN
            CQM(0,0)=CQ0
            CQM(0,1)=Z*CQ0-1.0D0

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -12188,6 +12188,9 @@ C
            LS=-1
         END IF
         ZQ=CDSQRT(LS*(1.0D0-Z*Z))
+        IF (X.LT.0D0) THEN
+           ZQ=LS*ZQ
+        END IF
         ZS=LS*(1.0D0-Z*Z)
         CQ0=0.5D0*CDLOG(LS*(1.0D0+Z)/(1.0D0-Z))
 C       For |z|>1.0001 and NTYPE=3, backward recursion is needed.

--- a/scipy/special/specfun/specfun.f
+++ b/scipy/special/specfun/specfun.f
@@ -273,7 +273,7 @@ C
 20         CONTINUE
            RETURN
         ENDIF
-        if (NTYPE.EQ.2) THEN
+        IF (NTYPE.EQ.2) THEN
 C       sqrt(1 - z^2) with branch cut on |x|>1
            ZS=(1.0D0-Z*Z)
            ZQ=-CDSQRT(ZS)
@@ -12154,11 +12154,11 @@ C
 
 C       **********************************
 
-        SUBROUTINE CLQMN(MM,M,N,X,Y,CQM,CQD)
+        SUBROUTINE CLQMN(MM,M,N,X,Y,NTYPE,CQM,CQD)
 C
 C       =======================================================
 C       Purpose: Compute the associated Legendre functions of
-C                the second kind, Qmn(z) and Qmn'(z), for a
+C                the second kind, Qmn(z) and Qmn'(z) for a
 C                complex argument
 C       Input :  x  --- Real part of z
 C                y  --- Imaginary part of z
@@ -12182,22 +12182,27 @@ C
            RETURN
         ENDIF
         XC=CDABS(Z)
-        LS=0
-        IF (DIMAG(Z).EQ.0.0D0.OR.XC.LT.1.0D0) LS=1
-        IF (XC.GT.1.0D0) LS=-1
+        IF (NTYPE.EQ.2) THEN
+           LS=1
+        ELSE
+           LS=-1
+        END IF
         ZQ=CDSQRT(LS*(1.0D0-Z*Z))
         ZS=LS*(1.0D0-Z*Z)
         CQ0=0.5D0*CDLOG(LS*(1.0D0+Z)/(1.0D0-Z))
-        IF (XC.LT.1.0001D0) THEN
+        IF ((XC.LT.1.0001D0).OR.(NTYPE.EQ.2)) THEN
            CQM(0,0)=CQ0
            CQM(0,1)=Z*CQ0-1.0D0
            CQM(1,0)=-1.0D0/ZQ
-           CQM(1,1)=-ZQ*(CQ0+Z/(1.0D0-Z*Z))
+           CQM(1,1)=-LS*ZQ*(CQ0+Z/(1.0D0-Z*Z))
+C       DLMF 14.10.3 applied to Q
            DO 15 I=0,1
            DO 15 J=2,N
               CQM(I,J)=((2.0D0*J-1.0D0)*Z*CQM(I,J-1)
      &                -(J+I-1.0D0)*CQM(I,J-2))/(J-I)
 15         CONTINUE
+C       NTYPE=2: DLMF 14.10.1 applied to Q
+C       NTYPE=3: DLMF 14.10.6 applied to Q
            DO 20 J=0,N
            DO 20 I=2,M
               CQM(I,J)=-2.0D0*(I-1.0D0)*Z/ZQ*CQM(I-1,J)-LS*
@@ -12209,6 +12214,7 @@ C
            ELSE
               KM=(40+M+N)*INT(-1.0-1.8*LOG(XC-1.0))
            ENDIF
+C       backward recursion with DLMF 14.10.3 applied to Q with mu=0
            CQF2=(0.0D0,0.0D0)
            CQF1=(1.0D0,0.0D0)
            DO 25 K=KM,0,-1
@@ -12218,29 +12224,39 @@ C
 25            CQF1=CQF0
            DO 30 K=0,N
 30            CQM(0,K)=CQ0*CQM(0,K)/CQF0
-           CQF2=0.0D0
-           CQF1=1.0D0
-           DO 35 K=KM,0,-1
-              CQF0=((2*K+3.0D0)*Z*CQF1-(K+1.0D0)*CQF2)/(K+2.0D0)
-              IF (K.LE.N) CQM(1,K)=CQF0
-              CQF2=CQF1
-35            CQF1=CQF0
-           CQ10=-1.0D0/ZQ
-           DO 40 K=0,N
-40            CQM(1,K)=CQ10*CQM(1,K)/CQF0
-           DO 45 J=0,N
-              CQ0=CQM(0,J)
-              CQ1=CQM(1,J)
-              DO 45 I=0,M-2
-                 CQF=-2.0D0*(I+1)*Z/ZQ*CQ1+(J-I)*(J+I+1.0D0)*CQ0
-                 CQM(I+2,J)=CQF
-                 CQ0=CQ1
-                 CQ1=CQF
-45         CONTINUE
+           IF (M.GT.0) THEN
+C       backward recursion with DLMF 14.10.3 applied to Q with mu=1
+              CQF2=0.0D0
+              CQF1=1.0D0
+              DO 35 K=KM,0,-1
+                 CQF0=((2*K+3.0D0)*Z*CQF1-(K+1.0D0)*CQF2)/(K+2.0D0)
+                 IF (K.LE.N) CQM(1,K)=CQF0
+                 CQF2=CQF1
+35               CQF1=CQF0
+              CQ10=-1.0D0/ZQ
+              DO 40 K=0,N
+40               CQM(1,K)=CQ10*CQM(1,K)/CQF0
+              DO 45 J=0,N
+                 CQ0=CQM(0,J)
+                 CQ1=CQM(1,J)
+C       NTYPE=2: DLMF 14.10.1 applied to Q
+C       NTYPE=3: DLMF 14.10.6 applied to Q
+                 DO 45 I=0,M-2
+                    CQF=-2.0D0*(I+1)*Z/ZQ*CQ1-LS*(J-I)*(J+I+1.0D0)*CQ0
+                    CQM(I+2,J)=CQF
+                    CQ0=CQ1
+                    CQ1=CQF
+45            CONTINUE
+           ENDIF
         ENDIF
         CQD(0,0)=LS/ZS
+C       DLMF 14.10.5 applied to Q with mu=0
         DO 50 J=1,N
 50         CQD(0,J)=LS*J*(CQM(0,J-1)-Z*CQM(0,J))/ZS
+C       NTYPE=2: derivative of DLMF 14.7.9
+C                and DLMF 14.10.1 applied to Q
+C       NTYPE=3: derivative of LDMF 14.7.12
+C                and DLMF 14.10.6 applied to Q
         DO 55 J=0,N
         DO 55 I=1,M
            CQD(I,J)=LS*I*Z/ZS*CQM(I,J)+(I+J)*(J-I+1.0D0)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2732,6 +2732,16 @@ class TestLegendreFunctions(TestCase):
         assert_equal(a.shape, (5, 1))
         assert_equal(b.shape, (5, 1))
 
+    def test_lqmn_clqmn(self):
+        m = 3
+        n = 3
+        for x in (-0.5, 0.5):
+            assert_allclose(special.lqmn(m, n, x),
+                            special.clqmn(m, n, x, 2))
+        for x in (-2, 2):
+            assert_allclose(special.lqmn(m, n, x),
+                            special.clqmn(m, n, x, 3))
+
     def test_lqn(self):
         lqf = special.lqn(2,.5)
         assert_array_almost_equal(lqf,(array([0.5493, -0.7253, -0.8187]),

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2699,6 +2699,15 @@ class TestLegendreFunctions(TestCase):
             assert_almost_equal(special.clqmn(m, n, x+1j*eps, type)[0][m, n],
                             special.clqmn(m, n, x-1j*eps, type)[0][m, n], 6)
 
+    def test_clqmn_across_imaginary_axis(self):
+        eps = 1e-7
+        m = 1
+        n = 1
+        x = 1j
+        for type in [2, 3]:
+            assert_almost_equal(special.clqmn(m, n, x+eps, type)[0][m, n],
+                            special.clqmn(m, n, x-eps, type)[0][m, n], 6)
+
     def test_deriv_clqmn(self):
         # data inside and outside of the unit circle
         zvals = [0.5+0.5j, -0.5+0.5j, -0.5-0.5j, 0.5-0.5j,

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2632,6 +2632,88 @@ class TestLegendreFunctions(TestCase):
             expected = 2/(x*x-1)
             assert_almost_equal(lq, expected)
 
+    def test_clqmn_2(self):
+        z = 0.5+0.3j
+        clq = special.clqmn(2, 2, z, 2)
+        q0 = 0.5*np.log((1+z)/(1-z))
+        q10 = -1/np.sqrt(1-z*z)
+        q10p = -z/(1-z*z)**1.5
+        assert_array_almost_equal(clq,
+                   (array([[q0, z*q0-1, 0.5*(3*z*z-1)*q0-1.5*z],
+                           [q10, q10*(z+(1-z*z)*q0), 3*q10*((1-z*z)*(z*q0-1)+1/3)],
+                           [2*z/(1-z*z), 2/(1-z*z), 3*(1-z*z)*q0+3*z+2*z/(1-z*z)]]),
+                    array([[1/(1-z*z), q0+z/(1-z*z), 3*z*q0+1/(1-z*z)-3],
+                           [q10p, (z*z-2)/(1-z*z)**1.5-z*q10*q0,
+                            -1.5/(1-z*z)**1.5*((1-z*z)*(1-2*z*z)*2*q0-4*z**3+14*z/3)],
+                           [2*(1+z*z)/(1-z*z)**2, 4*z/(1-z*z)**2,
+                            -6*z*q0+6+2*(1+z*z)/(1-z*z)**2]])),
+                    7)
+
+    def test_clqmn_3(self):
+        z = 0.5+0.3j
+        clq = special.clqmn(2, 2, z, 3)
+        q0 = 0.5*np.log((z+1)/(z-1))
+        q10 = -1/np.sqrt(z*z-1)
+        q10p = z/(z*z-1)**1.5
+        assert_array_almost_equal(clq,
+                   (array([[q0, z*q0-1, 0.5*(3*z*z-1)*q0-1.5*z],
+                           [q10, q10*(z+(1-z*z)*q0), 3*q10*((1-z*z)*(z*q0-1)+1/3)],
+                           [2*z/(z*z-1), 2/(z*z-1), 3*(z*z-1)*q0-3*z+2*z/(z*z-1)]]),
+                    array([[1/(1-z*z), q0+z/(1-z*z), 3*z*q0+1/(1-z*z)-3],
+                           [q10p, (2-z*z)/(z*z-1)**1.5-z*q10*q0,
+                            1.5/(z*z-1)**1.5*((z*z-1)*(2*z*z-1)*2*q0-4*z**3+14*z/3)],
+                           [-2*(z*z+1)/(z*z-1)**2, -4*z/(z*z-1)**2,
+                            6*z*q0-6-2*(z*z+1)/(z*z-1)**2]])),
+                    7)
+
+    def test_clqmn_close_to_real_2(self):
+        eps = 1e-10
+        m = 1
+        n = 3
+        x = 0.5
+        clq_plus = special.clqmn(m, n, x+1j*eps, 2)[0][m, n]
+        clq_minus = special.clqmn(m, n, x-1j*eps, 2)[0][m, n]
+        assert_array_almost_equal(array([clq_plus, clq_minus]),
+                                  array([special.lqmn(m, n, x)[0][m, n],
+                                         special.lqmn(m, n, x)[0][m, n]]),
+                                  7)
+ 
+    def test_clqmn_close_to_real_3(self):
+        eps = 1e-10
+        m = 1
+        n = 3
+        x = 1.5
+        clq_plus = special.clqmn(m, n, x+1j*eps, 3)[0][m, n]
+        clq_minus = special.clqmn(m, n, x-1j*eps, 3)[0][m, n]
+        assert_array_almost_equal(array([clq_plus, clq_minus]),
+                                  array([special.lqmn(m, n, x)[0][m, n],
+                                         special.lqmn(m, n, x)[0][m, n]]),
+                                  7)
+
+    def test_clqmn_across_unit_circle(self):
+        eps = 1e-7
+        m = 1
+        n = 1
+        x = 1j
+        for type in [2, 3]:
+            assert_almost_equal(special.clqmn(m, n, x+1j*eps, type)[0][m, n],
+                            special.clqmn(m, n, x-1j*eps, type)[0][m, n], 6)
+
+    def test_deriv_clqmn(self):
+        # data inside and outside of the unit circle
+        zvals = [0.5+0.5j, -0.5+0.5j, -0.5-0.5j, 0.5-0.5j,
+                 1+1j, -1+1j, -1-1j, 1-1j]
+        m = 2
+        n = 3
+        for type in [2, 3]:
+            for z in zvals:
+                for h in [1e-3, 1e-3j]:
+                    approx_derivative = (special.clqmn(m, n, z+0.5*h, type)[0]
+                                         - special.clqmn(m, n, z-0.5*h, type)[0])/h
+                    assert_allclose(special.clqmn(m, n, z, type)[1],
+                                    approx_derivative,
+                                    rtol=1e-4)
+
     def test_lqmn_shape(self):
         a, b = special.lqmn(4, 4, 1.1)
         assert_equal(a.shape, (5, 5))


### PR DESCRIPTION
This PR replaces #3903  where I was unable to resolve a merge conflict going back to 090b85d which I have resolved here. All changes of #3903 have been applied here to a recent version of upstream/master so that the present version corresponds to a0e7f51 discussed in #3903 as far as the associated Legendre function of second kind is concerned.
