### PR TITLE
MAINT: fitpack: trim down compiler warnings (unused labels, variables)

### DIFF
--- a/scipy/interpolate/fitpack/bispeu.f
+++ b/scipy/interpolate/fitpack/bispeu.f
@@ -41,13 +41,13 @@ c  other subroutines required:
 c    fpbisp,fpbspl
 c
 c  ..scalar arguments..
-      integer nx,ny,kx,ky,m,lwrk,kwrk,ier
+      integer nx,ny,kx,ky,m,lwrk,ier
 c  ..array arguments..
       real*8 tx(nx),ty(ny),c((nx-kx-1)*(ny-ky-1)),x(m),y(m),z(m),
      *     wrk(lwrk)
 c  ..local scalars..
       integer iwrk(2)
-      integer i,iw,lwest
+      integer i, lwest
 c  ..
 c  before starting computations a data check is made. if the input data
 c  are invalid control is immediately repassed to the calling program.

--- a/scipy/interpolate/fitpack/concur.f
+++ b/scipy/interpolate/fitpack/concur.f
@@ -1,5 +1,6 @@
       subroutine concur(iopt,idim,m,u,mx,x,xx,w,ib,db,nb,ie,de,ne,k,s,
      * nest,n,t,nc,c,np,cp,fp,wrk,lwrk,iwrk,ier)
+      implicit none
 c  given the ordered set of m points x(i) in the idim-dimensional space
 c  and given also a corresponding set of strictly increasing values u(i)
 c  and the set of positive numbers w(i),i=1,2,...,m, subroutine concur
@@ -284,7 +285,7 @@ c  ..array arguments..
       real*8 cp(np)
       integer iwrk(nest)
 c  ..local scalars..
-      real*8 tol,dist
+      real*8 tol
       integer i,ib1,ie1,ja,jb,jfp,jg,jq,jz,j,k1,k2,lwest,maxit,nmin,
      * ncc,kk,mmin,nmax,mxx
 c ..function references

--- a/scipy/interpolate/fitpack/fpgrdi.f
+++ b/scipy/interpolate/fitpack/fpgrdi.f
@@ -293,7 +293,7 @@ c we update the sum of squared residuals
         do 395 j=1,mvv
           sq = sq+right(j)**2
  395    continue
- 400    if(nrold.eq.number) go to 420
+        if(nrold.eq.number) go to 420
  410    nrold = n1
         n1 = n1+1
         go to 250

--- a/scipy/interpolate/fitpack/fpgrsp.f
+++ b/scipy/interpolate/fitpack/fpgrsp.f
@@ -345,7 +345,7 @@ c  we update the sum of squared residuals.
  390    do 395 j=1,mvv
           sq = sq+right(j)**2
  395    continue
- 400    if(nrold.eq.number) go to 420
+        if(nrold.eq.number) go to 420
  410    nrold = n1
         n1 = n1+1
         go to 250

--- a/scipy/interpolate/fitpack/fpknot.f
+++ b/scipy/interpolate/fitpack/fpknot.f
@@ -1,4 +1,5 @@
       subroutine fpknot(x,m,t,n,fpint,nrdata,nrint,nest,istart)
+      implicit none
 c  subroutine fpknot locates an additional knot for a spline of degree
 c  k and adjusts the corresponding parameters,i.e.
 c    t     : the position of the knots.

--- a/scipy/interpolate/fitpack/fpopsp.f
+++ b/scipy/interpolate/fitpack/fpopsp.f
@@ -55,7 +55,7 @@ c  ..array arguments..
      *,
      * wrk(lwrk),step(2)
 c  ..local scalars..
-      real*8 res,sq,sqq,sq0,sq1,step1,step2,three
+      real*8 sq,sqq,sq0,sq1,step1,step2,three
       integer i,id0,iop0,iop1,i1,j,l,lau,lav1,lav2,la0,la1,lbu,lbv,lb0,
      * lb1,lc0,lc1,lcs,lq,lri,lsu,lsv,l1,l2,mm,mvnu,number
 c  ..local arrays..

--- a/scipy/interpolate/fitpack/fppola.f
+++ b/scipy/interpolate/fitpack/fppola.f
@@ -20,7 +20,7 @@ c  ..local scalars..
      * f1,f2,f3,hui,huj,p,pi,pinv,piv,pi2,p1,p2,p3,r,ratio,si,sigma,
      * sq,store,uu,u2,u3,wi,zi,rn,one,two,three,con1,con4,con9,half,ten
       integer i,iband,iband3,iband4,ich1,ich3,ii,il,in,ipar,ipar1,irot,
-     * iter,i1,i2,i3,j,jl,jrot,j1,j2,k,l,la,lf,lh,ll,lu,lv,lwest,l1,l2,
+     * iter,i1,i2,i3,j,jrot,j1,j2,k,l,la,lf,lh,ll,lu,lv,lwest,l1,l2,
      * l3,l4,ncof,ncoff,nvv,nv4,nreg,nrint,nrr,nr1,nuu,nu4,num,num1,
      * numin,nvmin,rank,iband1
 c  ..local arrays..
@@ -374,7 +374,7 @@ c  add the contribution of the row to the sum of squares of residual
 c  right hand sides.
  360      fp = fp+zi**2
 c  find the number of the next data point in the panel.
- 370      in = nummer(in)
+          in = nummer(in)
           go to 210
  380    continue
 c  find dmax, the maximum value for the diagonal elements in the reduced
@@ -437,7 +437,7 @@ c  find for each interval the sum of squared residuals fpint for the
 c  data points having the coordinate belonging to that knot interval.
 c  calculate also coord which is the same sum, weighted by the position
 c  of the data points considered.
- 440    do 450 i=1,nrint
+        do 450 i=1,nrint
           fpint(i) = 0.
           coord(i) = 0.
  450    continue

--- a/scipy/interpolate/fitpack/fpsphe.f
+++ b/scipy/interpolate/fitpack/fpsphe.f
@@ -324,7 +324,7 @@ c  add the contribution of the row to the sum of squares of residual
 c  right hand sides.
  320      fp = fp+ri**2
 c  find the number of the next data point in the panel.
- 330      in = nummer(in)
+          in = nummer(in)
           go to 170
  340    continue
 c  find dmax, the maximum value for the diagonal elements in the reduced
@@ -387,7 +387,7 @@ c  find for each interval the sum of squared residuals fpint for the
 c  data points having the coordinate belonging to that knot interval.
 c  calculate also coord which is the same sum, weighted by the position
 c  of the data points considered.
- 440    do 450 i=1,nrint
+        do 450 i=1,nrint
           fpint(i) = 0.
           coord(i) = 0.
  450    continue

--- a/scipy/interpolate/fitpack/fpsurf.f
+++ b/scipy/interpolate/fitpack/fpsurf.f
@@ -242,7 +242,7 @@ c  add the contribution of the row to the sum of squares of residual
 c  right hand sides.
  230      fp = fp+zi**2
 c  find the number of the next data point in the panel.
- 240      in = nummer(in)
+          in = nummer(in)
           go to 150
  250    continue
 c  find dmax, the maximum value for the diagonal elements in the reduced
@@ -302,7 +302,7 @@ c  find for each interval the sum of squared residuals fpint for the
 c  data points having the coordinate belonging to that knot interval.
 c  calculate also coord which is the same sum, weighted by the position
 c  of the data points considered.
- 310    do 320 i=1,nrint
+        do 320 i=1,nrint
           fpint(i) = 0.
           coord(i) = 0.
  320    continue

--- a/scipy/interpolate/fitpack/fptrpe.f
+++ b/scipy/interpolate/fitpack/fptrpe.f
@@ -14,7 +14,7 @@ c  ..array arguments..
       integer nr(m)
 c  ..local scalars..
       real*8 co,pinv,piv,si,one
-      integer i,iband,irot,it,ii,i2,i3,j,jj,l,mid,nmd,m2,m3,
+      integer i,irot,it,ii,i2,i3,j,jj,l,mid,nmd,m2,m3,
      * nrold,n4,number,n1,n7,n11,m1
 c  ..local arrays..
       real*8 h(5),h1(5),h2(4)

--- a/scipy/interpolate/fitpack/pardeu.f
+++ b/scipy/interpolate/fitpack/pardeu.f
@@ -67,7 +67,7 @@ c  ..array arguments..
      * wrk(lwrk)
 c  ..local scalars..
       integer i,iwx,iwy,j,kkx,kky,kx1,ky1,lx,ly,lwest,l1,l2,mm,m0,m1,
-     * nc,nkx1,nky1,nxx,nyy,iw
+     * nc,nkx1,nky1,nxx,nyy
       real*8 ak,fac
 c  ..
 c  before starting computations a data check is made. if the input data
@@ -84,7 +84,7 @@ c  are invalid control is immediately repassed to the calling program.
       if(lwrk.lt.lwest) go to 400
       if(kwrk.lt.(m+m)) go to 400
       if (m.lt.1) go to 400
-  60  ier = 0
+      ier = 0
       nxx = nkx1
       nyy = nky1
       kkx = kx

--- a/scipy/interpolate/fitpack/polar.f
+++ b/scipy/interpolate/fitpack/polar.f
@@ -1,5 +1,6 @@
       subroutine polar(iopt,m,x,y,z,w,rad,s,nuest,nvest,eps,nu,tu,
      *  nv,tv,u,v,c,fp,wrk1,lwrk1,wrk2,lwrk2,iwrk,kwrk,ier)
+      implicit none
 c  subroutine polar fits a smooth function f(x,y) to a set of data
 c  points (x(i),y(i),z(i)) scattered arbitrarily over an approximation
 c  domain  x**2+y**2 <= rad(atan(y/x))**2. through the transformation
@@ -349,7 +350,7 @@ c  ..user specified function
       real*8 rad
 c  ..local scalars..
       real*8 tol,pi,dist,r,one
-      integer i,ib1,ib3,ki,kn,kwest,la,lbu,lcc,lcs,lro,j
+      integer i,ib1,ib3,ki,kn,kwest,la,lbu,lcc,lcs,lro,j,
      * lbv,lco,lf,lff,lfp,lh,lq,lsu,lsv,lwest,maxit,ncest,ncc,nuu,
      * nvv,nreg,nrint,nu4,nv4,iopt1,iopt2,iopt3,ipar,nvmin
 c  ..function references..

--- a/scipy/interpolate/fitpack/sphere.f
+++ b/scipy/interpolate/fitpack/sphere.f
@@ -1,5 +1,6 @@
       subroutine sphere(iopt,m,teta,phi,r,w,s,ntest,npest,eps,
      *  nt,tt,np,tp,c,fp,wrk1,lwrk1,wrk2,lwrk2,iwrk,kwrk,ier)
+      implicit none
 c  subroutine sphere determines a smooth bicubic spherical spline
 c  approximation s(teta,phi), 0 <= teta <= pi ; 0 <= phi <= 2*pi
 c  to a given set of data points (teta(i),phi(i),r(i)),i=1,2,...,m.
@@ -314,7 +315,7 @@ c  ..array arguments..
       integer iwrk(kwrk)
 c  ..local scalars..
       real*8 tol,pi,pi2,one
-      integer i,ib1,ib3,ki,kn,kwest,la,lbt,lcc,lcs,lro,j
+      integer i,ib1,ib3,ki,kn,kwest,la,lbt,lcc,lcs,lro,j,
      * lbp,lco,lf,lff,lfp,lh,lq,lst,lsp,lwest,maxit,ncest,ncc,ntt,
      * npp,nreg,nrint,ncof,nt4,np4
 c  ..function references..

--- a/scipy/interpolate/fitpack/splder.f
+++ b/scipy/interpolate/fitpack/splder.f
@@ -81,7 +81,7 @@ c..++
 c--  10  do 20 i=2,m
 c--        if(x(i).lt.x(i-1)) go to 200
 c--  20  continue
-  30  ier = 0
+      ier = 0
 c  fetch tb and te, the boundaries of the approximation interval.
       k1 = k+1
       k3 = k1+1

--- a/scipy/interpolate/fitpack/splev.f
+++ b/scipy/interpolate/fitpack/splev.f
@@ -78,7 +78,7 @@ c..++
 c--  10  do 20 i=2,m
 c--        if(x(i).lt.x(i-1)) go to 100
 c--  20  continue
-  30  ier = 0
+      ier = 0
 c  fetch tb and te, the boundaries of the approximation interval.
       k1 = k + 1
 c++..


### PR DESCRIPTION
Fitpack sources have been patched anyway, upstream is not really active, so I think there is no danger in this.
