### PR TITLE
ENH: add a new init method for k-means

### DIFF
--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -212,7 +212,10 @@ class TestKMean(TestCase):
 
         kmeans2(data, 3, minit='points')
         kmeans2(data[:, :1], 3, minit='points')  # special case (1-D)
-
+        
+        kmeans2(data, 3, minit='++')
+        kmeans2(data[:, :1], 3, minit='++')  # special case (1-D)
+        
         # minit='random' can give warnings, filter those
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore',

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -539,6 +539,11 @@ def _kpoints(data, k):
         row is one observation.
     k : int
         Number of samples to generate.
+   
+   Returns
+    -------
+    x : ndarray
+        A 'k' by 'N' containing the initial centroids
 
     """
     if data.ndim > 1:
@@ -566,6 +571,11 @@ def _krandinit(data, k):
         row is one observation.
     k : int
         Number of samples to generate.
+   
+    Returns
+    -------
+    x : ndarray
+        A 'k' by 'N' containing the initial centroids
 
     """
     def init_rank1(data):
@@ -592,7 +602,45 @@ def _krandinit(data, k):
     else:
         return init_rankn(data)
 
-_valid_init_meth = {'random': _krandinit, 'points': _kpoints}
+def _kpp(data, k):
+    """ Picks k points in data based on the kmeans++ method
+    
+    Parameters
+    ----------
+    data : ndarray
+        Expect a rank 1 or 2 array. Rank 1 are assumed to describe one
+        dimensional data, rank 2 multidimensional data, in which case one
+        row is one observation.
+    k : int
+        Number of samples to generate.
+   
+    Returns
+    -------
+    init : ndarray
+        A 'k' by 'N' containing the initial centroids
+   
+    Reference
+    ---------
+    D. Arthur and S. Vassilvitskii, "k-means++: the advantages of careful seeding"
+    
+    """
+
+    init = np.ndarray((k, data.shape[1]))
+    
+    for i in range(k):
+        if i == 0:
+            init[i] = data[randint(len(data))]
+               
+        else:
+            D2 = np.array([min([np.inner(init[j]-x, init[j]-x) for j in range(i)]) for x in data])
+            probs = D2/sum(D2)
+            cumprobs = probs.cumsum()
+            r = np.random.rand()
+            init[i] = data[np.searchsorted(cumprobs, r)]
+
+    return init
+    
+_valid_init_meth = {'random': _krandinit, 'points': _kpoints, '++': _kpp}
 
 
 def _missing_warn():
@@ -636,17 +684,17 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
         (not used yet)
     minit : string
         Method for initialization. Available methods are 'random',
-        'points', 'uniform', and 'matrix':
+        'points', '++' and 'matrix':
 
         'random': generate k centroids from a Gaussian with mean and
         variance estimated from the data.
 
         'points': choose k observations (rows) at random from data for
         the initial centroids.
-
-        'uniform': generate k observations from the data from a uniform
-        distribution defined by the data set (unsupported).
-
+         
+         '++': choose k observations accordingly to the kmeans++ method
+        (careful seeding)
+        
         'matrix': interpret the k parameter as a k by M (or length k
         array for one-dimensional data) array of initial centroids.
     missing : string

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -619,9 +619,10 @@ def _kpp(data, k):
     init : ndarray
         A 'k' by 'N' containing the initial centroids
    
-    Reference
-    ---------
-    D. Arthur and S. Vassilvitskii, "k-means++: the advantages of careful seeding"
+    References
+    ----------
+    D. Arthur and S. Vassilvitskii, "k-means++: the advantages of careful seeding",
+      Proceedings of the Eighteenth Annual ACM-SIAM Symposium on Discrete Algorithms, 2007.
     
     """
 
@@ -629,14 +630,14 @@ def _kpp(data, k):
     
     for i in range(k):
         if i == 0:
-            init[i] = data[randint(len(data))]
+            init[i, :] = data[randint(data.shape[1])]
                
         else:
             D2 = np.array([min([np.inner(init[j]-x, init[j]-x) for j in range(i)]) for x in data])
-            probs = D2/sum(D2)
+            probs = D2/D2.sum()
             cumprobs = probs.cumsum()
             r = np.random.rand()
-            init[i] = data[np.searchsorted(cumprobs, r)]
+            init[i, :] = data[np.searchsorted(cumprobs, r)]
 
     return init
     
@@ -692,7 +693,7 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
         'points': choose k observations (rows) at random from data for
         the initial centroids.
          
-         '++': choose k observations accordingly to the kmeans++ method
+        '++': choose k observations accordingly to the kmeans++ method
         (careful seeding)
         
         'matrix': interpret the k parameter as a k by M (or length k
@@ -713,6 +714,11 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
     label : ndarray
         label[i] is the code or index of the centroid the
         i'th observation is closest to.
+        
+    References
+    ----------
+    D. Arthur and S. Vassilvitskii, "k-means++: the advantages of careful seeding",
+      Proceedings of the Eighteenth Annual ACM-SIAM Symposium on Discrete Algorithms, 2007.
 
     """
     if missing not in _valid_miss_meth:


### PR DESCRIPTION
ENH: add a new init method for k-means
- implement the kmeans++ initialization (_kpp) as proposed by D. Arthur and S. Vassilvitski (2007)
- remove references to unsupported init methods ('uniform')
