### PR TITLE
ENH: stats: add a random_state property to distributions

### DIFF
--- a/scipy/lib/_util.py
+++ b/scipy/lib/_util.py
@@ -1,5 +1,8 @@
 import sys
 import warnings
+import numbers
+
+import numpy as np
 
 
 class DeprecatedImport(object):
@@ -34,3 +37,23 @@ class DeprecatedImport(object):
                       % (self._old_name, self._new_name),
                       DeprecationWarning)
         return getattr(self._mod, name)
+
+
+# copy-pasted from scikit-learn utils/validation.py
+def check_random_state(seed):
+    """Turn seed into a np.random.RandomState instance
+
+    If seed is None (or np.random), return the RandomState singleton used 
+    by np.random.
+    If seed is an int, return a new RandomState instance seeded with seed.
+    If seed is already a RandomState instance, return it.
+    Otherwise raise ValueError.
+    """
+    if seed is None or seed is np.random:
+        return np.random.mtrand._rand
+    if isinstance(seed, (numbers.Integral, np.integer)):
+        return np.random.RandomState(seed)
+    if isinstance(seed, np.random.RandomState):
+        return seed
+    raise ValueError('%r cannot be used to seed a numpy.random.RandomState'
+                     ' instance' % seed)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -20,7 +20,6 @@ from numpy import (where, arange, putmask, ravel, sum, shape,
 from numpy import polyval, place, extract, any, asarray, nan, inf, pi
 
 import numpy as np
-import numpy.random as mtrand
 from . import vonmises_cython
 from ._tukeylambda_stats import (tukeylambda_variance as _tlvar,
                                  tukeylambda_kurtosis as _tlkurt)
@@ -124,7 +123,7 @@ class norm_gen(rv_continuous):
 
     """
     def _rvs(self):
-        return mtrand.standard_normal(self._size)
+        return self._random_state.standard_normal(self._size)
 
     def _pdf(self, x):
         return _norm_pdf(x)
@@ -358,7 +357,7 @@ class beta_gen(rv_continuous):
 
     """
     def _rvs(self, a, b):
-        return mtrand.beta(a, b, self._size)
+        return self._random_state.beta(a, b, self._size)
 
     def _pdf(self, x, a, b):
         return np.exp(self._logpdf(x, a, b))
@@ -513,8 +512,9 @@ class betaprime_gen(rv_continuous):
 
     """
     def _rvs(self, a, b):
-        u1 = gamma.rvs(a, size=self._size)
-        u2 = gamma.rvs(b, size=self._size)
+        sz, rndm = self._size, self._random_state
+        u1 = gamma.rvs(a, size=sz, random_state=rndm)
+        u2 = gamma.rvs(b, size=sz, random_state=rndm)
         return (u1 / u2)
 
     def _pdf(self, x, a, b):
@@ -723,7 +723,8 @@ class chi_gen(rv_continuous):
 
     """
     def _rvs(self, df):
-        return sqrt(chi2.rvs(df, size=self._size))
+        sz, rndm = self._size, self._random_state
+        return sqrt(chi2.rvs(df, size=sz, random_state=rndm))
 
     def _pdf(self, x, df):
         return x**(df-1.)*exp(-x*x*0.5)/(2.0)**(df*0.5-1)/gam(df*0.5)
@@ -760,7 +761,7 @@ class chi2_gen(rv_continuous):
 
     """
     def _rvs(self, df):
-        return mtrand.chisquare(df, self._size)
+        return self._random_state.chisquare(df, self._size)
 
     def _pdf(self, x, df):
         return exp(self._logpdf(x, df))
@@ -837,8 +838,10 @@ class dgamma_gen(rv_continuous):
 
     """
     def _rvs(self, a):
-        u = mtrand.random_sample(size=self._size)
-        return (gamma.rvs(a, size=self._size)*where(u >= 0.5, 1, -1))
+        sz, rndm = self._size, self._random_state
+        u = rndm.random_sample(size=sz)
+        gm = gamma.rvs(a, size=sz, random_state=rndm)
+        return gm * where(u >= 0.5, 1, -1)
 
     def _pdf(self, x, a):
         ax = abs(x)
@@ -881,8 +884,10 @@ class dweibull_gen(rv_continuous):
 
     """
     def _rvs(self, c):
-        u = mtrand.random_sample(size=self._size)
-        return weibull_min.rvs(c, size=self._size) * (where(u >= 0.5, 1, -1))
+        sz, rndm = self._size, self._random_state
+        u = rndm.random_sample(size=sz)
+        w = weibull_min.rvs(c, size=sz, random_state=rndm)
+        return w * (where(u >= 0.5, 1, -1))
 
     def _pdf(self, x, c):
         ax = abs(x)
@@ -935,7 +940,7 @@ class expon_gen(rv_continuous):
 
     """
     def _rvs(self):
-        return mtrand.standard_exponential(self._size)
+        return self._random_state.standard_exponential(self._size)
 
     def _pdf(self, x):
         return exp(-x)
@@ -1069,7 +1074,7 @@ class fatiguelife_gen(rv_continuous):
 
     """
     def _rvs(self, c):
-        z = mtrand.standard_normal(self._size)
+        z = self._random_state.standard_normal(self._size)
         x = 0.5*c*z
         x2 = x*x
         t = 1.0 + 2*x2 + 2*x*sqrt(1 + x2)
@@ -1122,7 +1127,8 @@ class foldcauchy_gen(rv_continuous):
 
     """
     def _rvs(self, c):
-        return abs(cauchy.rvs(loc=c, size=self._size))
+        return abs(cauchy.rvs(loc=c, size=self._size,
+                              random_state=self._random_state))
 
     def _pdf(self, x, c):
         return 1.0/pi*(1.0/(1+(x-c)**2) + 1.0/(1+(x+c)**2))
@@ -1154,7 +1160,7 @@ class f_gen(rv_continuous):
 
     """
     def _rvs(self, dfn, dfd):
-        return mtrand.f(dfn, dfd, self._size)
+        return self._random_state.f(dfn, dfd, self._size)
 
     def _pdf(self, x, dfn, dfd):
         return exp(self._logpdf(x, dfn, dfd))
@@ -1235,7 +1241,7 @@ class foldnorm_gen(rv_continuous):
         return (c >= 0)
 
     def _rvs(self, c):
-        return abs(mtrand.standard_normal(self._size) + c)
+        return abs(self._random_state.standard_normal(self._size) + c)
 
     def _pdf(self, x, c):
         return _norm_pdf(x + c) + _norm_pdf(x-c)
@@ -1668,7 +1674,7 @@ class gamma_gen(rv_continuous):
 
     """
     def _rvs(self, a):
-        return mtrand.standard_gamma(a, self._size)
+        return self._random_state.standard_gamma(a, self._size)
 
     def _pdf(self, x, a):
         return exp(self._logpdf(x, a))
@@ -2133,7 +2139,7 @@ class halfnorm_gen(rv_continuous):
 
     """
     def _rvs(self):
-        return abs(mtrand.standard_normal(size=self._size))
+        return abs(self._random_state.standard_normal(size=self._size))
 
     def _pdf(self, x):
         return sqrt(2.0/pi)*exp(-x*x/2.0)
@@ -2293,7 +2299,7 @@ class invgauss_gen(rv_continuous):
 
     """
     def _rvs(self, mu):
-        return mtrand.wald(mu, 1.0, size=self._size)
+        return self._random_state.wald(mu, 1.0, size=self._size)
 
     def _pdf(self, x, mu):
         return 1.0/sqrt(2*pi*x**3.0)*exp(-1.0/(2*x)*((x-mu)/mu)**2)
@@ -2442,7 +2448,7 @@ class laplace_gen(rv_continuous):
 
     """
     def _rvs(self):
-        return mtrand.laplace(0, 1, size=self._size)
+        return self._random_state.laplace(0, 1, size=self._size)
 
     def _pdf(self, x):
         return 0.5*exp(-abs(x))
@@ -2603,7 +2609,7 @@ class logistic_gen(rv_continuous):
 
     """
     def _rvs(self):
-        return mtrand.logistic(size=self._size)
+        return self._random_state.logistic(size=self._size)
 
     def _pdf(self, x):
         return exp(self._logpdf(x))
@@ -2643,7 +2649,7 @@ class loggamma_gen(rv_continuous):
 
     """
     def _rvs(self, c):
-        return log(mtrand.gamma(c, size=self._size))
+        return log(self._random_state.gamma(c, size=self._size))
 
     def _pdf(self, x, c):
         return exp(c*x-exp(x)-gamln(c))
@@ -2732,7 +2738,7 @@ class lognorm_gen(rv_continuous):
 
     """
     def _rvs(self, s):
-        return exp(s * mtrand.standard_normal(self._size))
+        return exp(s * self._random_state.standard_normal(self._size))
 
     def _pdf(self, x, s):
         return exp(self._logpdf(x, s))
@@ -2776,7 +2782,7 @@ class gilbrat_gen(rv_continuous):
 
     """
     def _rvs(self):
-        return exp(mtrand.standard_normal(self._size))
+        return exp(self._random_state.standard_normal(self._size))
 
     def _pdf(self, x):
         return exp(self._logpdf(x))
@@ -2827,7 +2833,7 @@ class maxwell_gen(rv_continuous):
     %(example)s
     """
     def _rvs(self):
-        return chi.rvs(3.0, size=self._size)
+        return chi.rvs(3.0, size=self._size, random_state=self._random_state)
 
     def _pdf(self, x):
         return sqrt(2.0/pi)*x*x*exp(-x*x/2.0)
@@ -2930,7 +2936,7 @@ class ncx2_gen(rv_continuous):
 
     """
     def _rvs(self, df, nc):
-        return mtrand.noncentral_chisquare(df, nc, self._size)
+        return self._random_state.noncentral_chisquare(df, nc, self._size)
 
     def _logpdf(self, x, df, nc):
         return _ncx2_log_pdf(x, df, nc)
@@ -2973,7 +2979,7 @@ class ncf_gen(rv_continuous):
 
     """
     def _rvs(self, dfn, dfd, nc):
-        return mtrand.noncentral_f(dfn, dfd, nc, self._size)
+        return self._random_state.noncentral_f(dfn, dfd, nc, self._size)
 
     def _pdf_skip(self, x, dfn, dfd, nc):
         n1, n2 = dfn, dfd
@@ -3028,7 +3034,7 @@ class t_gen(rv_continuous):
 
     """
     def _rvs(self, df):
-        return mtrand.standard_t(df, size=self._size)
+        return self._random_state.standard_t(df, size=self._size)
 
     def _pdf(self, x, df):
         r = asarray(df*1.0)
@@ -3084,8 +3090,10 @@ class nct_gen(rv_continuous):
         return (df > 0) & (nc == nc)
 
     def _rvs(self, df, nc):
-        return (norm.rvs(loc=nc, size=self._size) * sqrt(df) /
-                sqrt(chi2.rvs(df, size=self._size)))
+        sz, rndm = self._size, self._random_state
+        n = norm.rvs(loc=nc, size=sz, random_state=rndm)
+        c2 = chi2.rvs(df, size=sz, random_state=rndm)
+        return n * sqrt(df) / sqrt(c2)
 
     def _pdf(self, x, df, nc):
         n = df*1.0
@@ -3360,8 +3368,8 @@ class pearson3_gen(rv_continuous):
         ans, x, transx, skew, mask, invmask, beta, alpha, zeta = (
             self._preprocess([0], skew))
         if mask[0]:
-            return mtrand.standard_normal(self._size)
-        ans = mtrand.standard_gamma(alpha, self._size)/beta + zeta
+            return self._random_state.standard_normal(self._size)
+        ans = self._random_state.standard_gamma(alpha, self._size)/beta + zeta
         if ans.size == 1:
             return ans[0]
         return ans
@@ -3534,7 +3542,7 @@ class rayleigh_gen(rv_continuous):
 
     """
     def _rvs(self):
-        return chi.rvs(2, size=self._size)
+        return chi.rvs(2, size=self._size, random_state=self._random_state)
 
     def _pdf(self, r):
         return r * exp(-0.5 * r**2)
@@ -3620,7 +3628,7 @@ class rice_gen(rv_continuous):
     def _rvs(self, b):
         # http://en.wikipedia.org/wiki/Rice_distribution
         sz = self._size if self._size else 1
-        t = b/np.sqrt(2) + mtrand.standard_normal(size=(2, sz))
+        t = b/np.sqrt(2) + self._random_state.standard_normal(size=(2, sz))
         return np.sqrt((t*t).sum(axis=0))
 
     def _pdf(self, x, b):
@@ -3653,7 +3661,7 @@ class recipinvgauss_gen(rv_continuous):
 
     """
     def _rvs(self, mu):
-        return 1.0/mtrand.wald(mu, 1.0, size=self._size)
+        return 1.0/self._random_state.wald(mu, 1.0, size=self._size)
 
     def _pdf(self, x, mu):
         return 1.0/sqrt(2*pi*x)*exp(-(1-mu*x)**2.0 / (2*x*mu**2.0))
@@ -3718,7 +3726,7 @@ class triang_gen(rv_continuous):
 
     """
     def _rvs(self, c):
-        return mtrand.triangular(0, c, 1, self._size)
+        return self._random_state.triangular(0, c, 1, self._size)
 
     def _argcheck(self, c):
         return (c >= 0) & (c <= 1)
@@ -3906,7 +3914,7 @@ class uniform_gen(rv_continuous):
 
     """
     def _rvs(self):
-        return mtrand.uniform(0.0, 1.0, self._size)
+        return self._random_state.uniform(0.0, 1.0, self._size)
 
     def _pdf(self, x):
         return 1.0*(x == x)
@@ -3950,7 +3958,7 @@ class vonmises_gen(rv_continuous):
 
     """
     def _rvs(self, kappa):
-        return mtrand.vonmises(0.0, kappa, size=self._size)
+        return self._random_state.vonmises(0.0, kappa, size=self._size)
 
     def _pdf(self, x, kappa):
         return exp(kappa * cos(x)) / (2*pi*special.i0(kappa))
@@ -3982,7 +3990,7 @@ class wald_gen(invgauss_gen):
     %(example)s
     """
     def _rvs(self):
-        return mtrand.wald(1.0, 1.0, size=self._size)
+        return self._random_state.wald(1.0, 1.0, size=self._size)
 
     def _pdf(self, x):
         return invgauss._pdf(x, 1.0)

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -10,7 +10,6 @@ from scipy.special import entr, gammaln as gamln
 from numpy import floor, ceil, log, exp, sqrt, log1p, expm1, tanh, cosh, sinh
 
 import numpy as np
-import numpy.random as mtrand
 
 from ._distn_infrastructure import (
         rv_discrete, _lazywhere, _ncx2_pdf, _ncx2_cdf, get_distribution_names)
@@ -35,7 +34,7 @@ class binom_gen(rv_discrete):
 
     """
     def _rvs(self, n, p):
-        return mtrand.binomial(n, p, self._size)
+        return self._random_state.binomial(n, p, self._size)
 
     def _argcheck(self, n, p):
         self.b = n
@@ -149,7 +148,7 @@ class nbinom_gen(rv_discrete):
 
     """
     def _rvs(self, n, p):
-        return mtrand.negative_binomial(n, p, self._size)
+        return self._random_state.negative_binomial(n, p, self._size)
 
     def _argcheck(self, n, p):
         return (n > 0) & (p >= 0) & (p <= 1)
@@ -206,7 +205,7 @@ class geom_gen(rv_discrete):
 
     """
     def _rvs(self, p):
-        return mtrand.geometric(p, size=self._size)
+        return self._random_state.geometric(p, size=self._size)
 
     def _argcheck(self, p):
         return (p <= 1) & (p >= 0)
@@ -295,7 +294,7 @@ class hypergeom_gen(rv_discrete):
 
     """
     def _rvs(self, M, n, N):
-        return mtrand.hypergeometric(n, M-n, N, size=self._size)
+        return self._random_state.hypergeometric(n, M-n, N, size=self._size)
 
     def _argcheck(self, M, n, N):
         cond = rv_discrete._argcheck(self, M, n, N)
@@ -376,7 +375,7 @@ class logser_gen(rv_discrete):
     def _rvs(self, p):
         # looks wrong for p>0.5, too few k=1
         # trying to use generic is worse, no k=1 at all
-        return mtrand.logseries(p, size=self._size)
+        return self._random_state.logseries(p, size=self._size)
 
     def _argcheck(self, p):
         return (p > 0) & (p < 1)
@@ -420,7 +419,7 @@ class poisson_gen(rv_discrete):
 
     """
     def _rvs(self, mu):
-        return mtrand.poisson(mu, self._size)
+        return self._random_state.poisson(mu, self._size)
 
     def _logpmf(self, k, mu):
         Pk = k*log(mu)-gamln(k+1) - mu
@@ -613,7 +612,7 @@ class randint_gen(rv_discrete):
 
         If ``high`` is ``None``, then range is >=0  and < low
         """
-        return mtrand.randint(low, high, self._size)
+        return self._random_state.randint(low, high, self._size)
 
     def _entropy(self, low, high):
         return log(high - low)
@@ -641,7 +640,7 @@ class zipf_gen(rv_discrete):
 
     """
     def _rvs(self, a):
-        return mtrand.zipf(a, size=self._size)
+        return self._random_state.zipf(a, size=self._size)
 
     def _argcheck(self, a):
         return a > 1
@@ -732,7 +731,8 @@ class skellam_gen(rv_discrete):
     """
     def _rvs(self, mu1, mu2):
         n = self._size
-        return mtrand.poisson(mu1, n) - mtrand.poisson(mu2, n)
+        return (self._random_state.poisson(mu1, n) -
+                self._random_state.poisson(mu2, n))
 
     def _pmf(self, x, mu1, mu2):
         px = np.where(x < 0,

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -10,7 +10,7 @@ from scipy import stats
 from common_tests import (check_normalization, check_moment, check_mean_expect,
         check_var_expect, check_skew_expect, check_kurt_expect,
         check_entropy, check_private_entropy, NUMPY_BELOW_1_7,
-        check_edge_support, check_named_args)
+        check_edge_support, check_named_args, check_random_state)
 
 from scipy.stats._distr_params import distcont
 
@@ -125,6 +125,7 @@ def test_cont_basic():
                       'pareto': 1.5, 'tukeylambda': 0.3}
             x = spec_x.get(distname, 0.5)
             yield check_named_args, distfn, x, arg, locscale_defaults, meths
+            yield check_random_state, distfn, arg
 
             # Entropy
             skp = npt.dec.skipif
@@ -182,6 +183,7 @@ def test_cont_basic_slow():
             elif distname == 'ksone':
                 arg = (3,)
             yield check_named_args, distfn, x, arg, locscale_defaults, meths
+            yield check_random_state, distfn, arg
 
             # Entropy
             skp = npt.dec.skipif

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -8,7 +8,7 @@ from scipy import stats
 from common_tests import (check_normalization, check_moment, check_mean_expect,
         check_var_expect, check_skew_expect, check_kurt_expect,
         check_entropy, check_private_entropy, check_edge_support,
-        check_named_args)
+        check_named_args, check_random_state)
 from scipy.stats._distr_params import distdiscrete
 knf = npt.dec.knownfailureif
 
@@ -44,6 +44,7 @@ def test_discrete_basic():
         k = spec_k.get(distname, 1)
         yield check_named_args, distfn, k, arg, locscale_defaults, meths
         yield check_scale_docstring, distfn
+        yield check_random_state, distfn, arg
 
         # Entropy
         yield check_entropy, distfn, arg, distname


### PR DESCRIPTION
Distributions can either rely on the global `numpy.random` state (in a backwards compatible way), or set the instance-level random_state, or use a specific RandomState object for each rvs(...) call.

closes gh-3975

While gh-3975 mentions thread-safety, I don't think distributions are thread-safe with or without this change. 
(at least the way the `size` parameter is handled between a generic `rvs` and distribution specific `_rvs` methods is suspicious).  
