### PR TITLE
ENH: Add Wishart and inverse Wishart distributions

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -150,6 +150,7 @@ Multivariate distributions
 
    multivariate_normal   -- Multivariate normal distribution
    dirichlet             -- Dirichlet
+   wishart               -- Wishart
 
 Discrete distributions
 ======================

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -151,6 +151,7 @@ Multivariate distributions
    multivariate_normal   -- Multivariate normal distribution
    dirichlet             -- Dirichlet
    wishart               -- Wishart
+   invwishart            -- Inverse Wishart
 
 Discrete distributions
 ======================

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1360,7 +1360,7 @@ class wishart_gen(object):
         # Calculate C A A' C'
         for index in np.ndindex(shape):
             CA = np.dot(C, A[index])
-            A[index] = np.dot(CA.T, CA)
+            A[index] = np.dot(CA, CA.T)
 
         return A
 
@@ -1853,7 +1853,7 @@ class invwishart_gen(wishart_gen):
 
         # Invert the draws to get draws from inverse Wishart
         for index in np.ndindex(shape):
-            scipy.linalg.cho_factor(out[index], lower=True, overwrite_a=True)
+            out[index] = scipy.linalg.cho_factor(out[index], lower=True)
             out[index] = scipy.linalg.cho_solve((out[index], True), eye)
 
         return out

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1139,7 +1139,7 @@ class wishart_gen(object):
         for i in range(x.shape[-1]):
             log_det_x[i] = np.log(np.linalg.det(x[:,:,i]))
             scale_inv_x[:,:,i] = scipy.linalg.cho_solve((C, True), x[:,:,i])
-            tr_scale_inv_x[i] = scale_inv_x[:,:,i].diagonal().sum()
+            tr_scale_inv_x[i] = scale_inv_x[:,:,i].trace()
 
         # Log PDF
         out = (
@@ -1291,7 +1291,7 @@ class wishart_gen(object):
 
         """
         var = scale**2
-        diag = scale.diagonal()[np.newaxis, :]  # 1 x dim array
+        diag = scale.diagonal()  # 1 x dim array
         var += np.outer(diag, diag)
         var *= df
         return var
@@ -1519,7 +1519,7 @@ for name in ['logpdf', 'pdf', 'mean', 'mode', 'var', 'rvs', 'entropy']:
 
 
 from numpy import asarray_chkfinite, asarray
-from scipy.linalg.misc import LinAlgError, _datacopied
+from scipy.linalg.misc import LinAlgError
 from scipy.linalg.lapack import get_lapack_funcs
 def _cho_inv_batch(a, check_finite=True):
     """
@@ -1720,7 +1720,7 @@ class invwishart_gen(wishart_gen):
             log_det_x[i] = 2 * np.sum(np.log(C.diagonal()))
 
             #scale_x_inv[:,:,i] = scipy.linalg.cho_solve((C, True), scale).T
-            tr_scale_x_inv[i] = np.dot(scale, x_inv[i]).diagonal().sum()
+            tr_scale_x_inv[i] = np.dot(scale, x_inv[i]).trace()
 
         # Log PDF
         out = (
@@ -1873,7 +1873,7 @@ class invwishart_gen(wishart_gen):
         """
         if df > dim + 3:
             var = (df - dim + 1) * scale**2
-            diag = scale.diagonal()[np.newaxis, :]  # 1 x dim array
+            diag = scale.diagonal()  # 1 x dim array
             var += (df - dim - 1) * np.outer(diag, diag)
             var /= (df - dim) * (df - dim - 1)**2 * (df - dim - 3)
         else:

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1698,7 +1698,10 @@ class invwishart_gen(wishart_gen):
         log_det_x = np.zeros(x.shape[-1])
         #scale_x_inv = np.zeros(x.shape)
         x_inv = np.copy(x).T
-        _cho_inv_batch(x_inv)  # works in-place
+        if dim > 1:
+            _cho_inv_batch(x_inv)  # works in-place
+        else:
+            x_inv = 1./x_inv
         tr_scale_x_inv = np.zeros(x.shape[-1])
 
         for i in range(x.shape[-1]):
@@ -1917,12 +1920,15 @@ class invwishart_gen(wishart_gen):
         out = super(invwishart_gen, self)._rvs(n, shape, dim, df, inv_scale, C)
 
         # Invert the draws to get draws from inverse Wishart
-        for index in np.ndindex(shape):
-            out[index] = scipy.linalg.cho_factor(out[index], lower=True)
-            out[index] = scipy.linalg.cho_solve((out[index], True), eye)
+        # for index in np.ndindex(shape):
+        #     out[index] = scipy.linalg.cho_factor(out[index], lower=True)
+        #     out[index] = scipy.linalg.cho_solve((out[index], True), eye)
 
         # (works on the arrays in-place)
-        _cho_inv_batch(out)
+        if dim > 1:
+            _cho_inv_batch(out)
+        else:
+            out = 1./out
 
         return out
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -478,6 +478,7 @@ class multivariate_normal_gen(object):
 
         """
         dim, mean, cov = _process_parameters(None, mean, cov)
+        # TODO replace with np.linalg.slogdet with Numpy 1.5.x not necessary
         return 0.5 * np.log(np.linalg.det(2 * np.pi * np.e * cov))
 
 
@@ -891,7 +892,7 @@ df : integer
     Degrees of freedom, must be greater than or equal to dimension of the
     scale matrix
 scale : array_like
-    Scale matrix of the distribution
+    Symmetric positive definite scale matrix of the distribution
 """
 
 _wishart_doc_callparams_note = ""
@@ -917,9 +918,10 @@ class wishart_gen(object):
     A Wishart random variable.
 
     The `df` keyword specifies the degrees of freedom. The `scale` keyword
-    specifies the scale matrix. In this context, the scale matrix is often
-    interpreted in terms of a multivariate normal precision matrix (the inverse
-    of the covariance matrix).
+    specifies the scale matrix, which must be symmetric and positive definite.
+    In this context, the scale matrix is often interpreted in terms of a
+    multivariate normal precision matrix (the inverse of the covariance
+    matrix).
 
     Methods
     -------
@@ -950,8 +952,9 @@ class wishart_gen(object):
     -----
     %(_doc_callparams_note)s
 
-    The scale matrix `scale` must be a (symmetric) positive definite
-    matrix.
+    The scale matrix `scale` must be a symmetric positive definite
+    matrix. Singular matrices, including the symmetric positive semi-definite
+    case, are not supported.
 
     The Wishart distribution is often denoted
 
@@ -963,7 +966,7 @@ class wishart_gen(object):
     :math:`p \times p` scale matrix.
 
     The probability density function for `wishart` has support over positive
-    definite matrices :math:`S`; if if :math:`S \sim W_p(\nu, \Sigma)`, then
+    definite matrices :math:`S`; if :math:`S \sim W_p(\nu, \Sigma)`, then
     its PDF is given by:
 
     .. math::
@@ -1150,6 +1153,7 @@ class wishart_gen(object):
         ----------
         x : array_like
             Quantiles, with the last axis of `x` denoting the components.
+            Each quantile must be a symmetric positive definite matrix.
         %(_doc_default_callparams)s
 
         Notes
@@ -1180,6 +1184,7 @@ class wishart_gen(object):
         ----------
         x : array_like
             Quantiles, with the last axis of `x` denoting the components.
+            Each quantile must be a symmetric positive definite matrix.
         %(_doc_default_callparams)s
 
         Notes
@@ -1432,6 +1437,7 @@ class wishart_gen(object):
         """
         dim, df, scale = self._process_parameters(df, scale)
 
+        # TODO replace with np.linalg.slogdet when Numpy 1.5.x not necessary
         log_det_scale = np.log(np.linalg.det(scale))
         
         return self._entropy(dim, df, log_det_scale)
@@ -1500,12 +1506,12 @@ for name in ['logpdf', 'pdf', 'mean', 'mode', 'var', 'rvs', 'entropy']:
 
 class invwishart_gen(wishart_gen):
     r"""
-    A Wishart random variable.
+    An inverse Wishart random variable.
 
     The `df` keyword specifies the degrees of freedom. The `scale` keyword
-    specifies the scale matrix. In this context, the scale matrix is often
-    interpreted in terms of a multivariate normal precision matrix (the inverse
-    of the covariance matrix).
+    specifies the scale matrix, which must be symmetric and positive definite.
+    In this context, the scale matrix is often interpreted in terms of a
+    multivariate normal covariance matrix.
 
     Methods
     -------
@@ -1514,9 +1520,7 @@ class invwishart_gen(wishart_gen):
     logpdf(x, df, scale)
         Log of the probability density function.
     rvs(df, scale, size=1)
-        Draw random samples from a Wishart distribution.
-    entropy()
-        Compute the differential entropy of the Wishart distribution.
+        Draw random samples from an inverse Wishart distribution.
 
     Parameters
     ----------
@@ -1525,10 +1529,10 @@ class invwishart_gen(wishart_gen):
     %(_doc_default_callparams)s
 
     Alternatively, the object may be called (as a function) to fix the degrees
-    of freedom and scale parameters, returning a "frozen" Wishart random
-    variable:
+    of freedom and scale parameters, returning a "frozen" inverse Wishart
+    random variable:
 
-    rv = wishart(df=1, scale=1)
+    rv = invwishart(df=1, scale=1)
         - Frozen object with the same methods but holding the given
           degrees of freedom and scale fixed.
 
@@ -1536,10 +1540,11 @@ class invwishart_gen(wishart_gen):
     -----
     %(_doc_callparams_note)s
 
-    The scale matrix `scale` must be a (symmetric) positive definite
-    matrix.
+    The scale matrix `scale` must be a symmetric positive definite
+    matrix. Singular matrices, including the symmetric positive semi-definite
+    case, are not supported.
 
-    The Wishart distribution is often denoted
+    The inverse Wishart distribution is often denoted
 
     .. math::
 
@@ -1549,7 +1554,7 @@ class invwishart_gen(wishart_gen):
     :math:`p \times p` scale matrix.
 
     The probability density function for `invwishart` has support over positive
-    definite matrices :math:`S`; if if :math:`S \sim W^{-1}_p(\nu, \Sigma)`,
+    definite matrices :math:`S`; if :math:`S \sim W^{-1}_p(\nu, \Sigma)`,
     then its PDF is given by:
 
     .. math::
@@ -1607,7 +1612,7 @@ class invwishart_gen(wishart_gen):
         ----------
         x : ndarray
             Points at which to evaluate the log of the probability
-            density function
+            density function.
         dim : int
             Dimension of the scale matrix
         df : int
@@ -1652,6 +1657,7 @@ class invwishart_gen(wishart_gen):
         ----------
         x : array_like
             Quantiles, with the last axis of `x` denoting the components.
+            Each quantile must be a symmetric positive definite matrix.
         %(_doc_default_callparams)s
 
         Notes
@@ -1667,6 +1673,7 @@ class invwishart_gen(wishart_gen):
         dim, df, scale = self._process_parameters(df, scale)
         x = self._process_quantiles(x, dim)
 
+        # TODO replace with np.linalg.slogdet when Numpy 1.5.x not necessary
         log_det_scale = np.log(np.linalg.det(scale))
 
         out = self._logpdf(x, dim, df, scale, log_det_scale)
@@ -1680,6 +1687,8 @@ class invwishart_gen(wishart_gen):
         ----------
         x : array_like
             Quantiles, with the last axis of `x` denoting the components.
+            Each quantile must be a symmetric positive definite matrix.
+
         %(_doc_default_callparams)s
 
         Notes

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1282,8 +1282,8 @@ class wishart_gen(object):
 
         """
         var = scale**2
-        diag = scale.diagonal()[np.newaxis, :] # 1 x dim array
-        var += np.dot(diag.T, diag) # outer product
+        diag = scale.diagonal()[np.newaxis, :]  # 1 x dim array
+        var += np.dot(diag.T, diag)  # outer product
         var *= df
         return var
 
@@ -1782,8 +1782,8 @@ class invwishart_gen(wishart_gen):
         """
         if df > dim + 3:
             var = (df - dim + 1) * scale**2
-            diag = scale.diagonal()[np.newaxis, :] # 1 x dim array
-            var += (df - dim - 1) * np.dot(diag.T, diag) # outer product
+            diag = scale.diagonal()[np.newaxis, :]  # 1 x dim array
+            var += (df - dim - 1) * np.dot(diag.T, diag)  # outer product
             var /= (df - dim) * (df - dim - 1)**2 * (df - dim - 3)
         else:
             var = None

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -562,7 +562,7 @@ def test_wishart_quantile_dimensions():
         np.array([[2,0],
                   [0,2]]),    # 2-dim
         np.array([[2,0],
-                  [0,2]])[:,:,np.newaxis] # 3-dim
+                  [0,2]])[:,:,np.newaxis]  # 3-dim
     ]
 
     w = wishart(2,np.eye(2))
@@ -592,7 +592,7 @@ def test_wishart_frozen():
 
     # Construct a 1D and 2D set of parameters
     parameters = [
-        (10, 1, np.linspace(0.1, 10, 5)), # 1D case
+        (10, 1, np.linspace(0.1, 10, 5)),  # 1D case
         (10, scale, X)
     ]
 
@@ -670,7 +670,7 @@ def test_invwishart_frozen():
 
     # Construct a 1D and 2D set of parameters
     parameters = [
-        (10, 1, np.linspace(0.1, 10, 5)), # 1D case
+        (10, 1, np.linspace(0.1, 10, 5)),  # 1D case
         (10, scale, X)
     ]
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -679,7 +679,7 @@ def test_invwishart_frozen():
         assert_equal(iw.var(), invwishart.var(df, scale))
         assert_equal(iw.mean(), invwishart.mean(df, scale))
         assert_equal(iw.mode(), invwishart.mode(df, scale))
-        assert_equal(iw.pdf(x), invwishart.pdf(x, df, scale))
+        assert_allclose(iw.pdf(x), invwishart.pdf(x, df, scale))
 
 def test_invwishart_1D_is_invgamma():
     # The 1-dimensional inverse Wishart with an identity scale matrix is just

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -20,6 +20,7 @@ import scipy.linalg
 from scipy.stats._multivariate import _PSD, _lnB
 from scipy.stats import multivariate_normal
 from scipy.stats import dirichlet, beta
+from scipy.stats import wishart, invwishart, chi2, invgamma
 from scipy.stats import norm
 
 from scipy.integrate import romb
@@ -480,6 +481,224 @@ def test_dimensions_mismatch():
         msg = "Dimension mismatch"
         assert_equal(str(e)[:len(msg)], msg)
 
+
+def test_wishart_scale_dimensions():
+    # Test that we can call the Wishart with various scale dimensions
+
+    # Test case: dim=1, scale=1
+    true_scale = np.array(1, ndmin=2)
+    scales = [
+        1,                    # scalar
+        [1],                  # iterable
+        np.array(1),          # 0-dim
+        np.r_[1],             # 1-dim
+        np.array(1, ndmin=2)  # 2-dim
+    ]
+    for scale in scales:
+        w = wishart(1, scale)
+        assert_equal(w.scale, true_scale)
+        assert_equal(w.scale.shape, true_scale.shape)
+
+    # Test case: dim=2, scale=[[1,0]
+    #                          [0,2]
+    true_scale = np.array([[1,0],
+                           [0,2]])
+    scales = [
+        [1,2],             # iterable
+        np.r_[1,2],        # 1-dim
+        np.array([[1,0],   # 2-dim
+                  [0,2]])
+    ]
+    for scale in scales:
+        w = wishart(2, scale)
+        assert_equal(w.scale, true_scale)
+        assert_equal(w.scale.shape, true_scale.shape)
+
+    # We cannot call with a df < dim
+    assert_raises(ValueError, wishart, 1, np.eye(2))
+
+    # We cannot call with a 3-dimension array
+    scale = np.array(1, ndmin=3)
+    assert_raises(ValueError, wishart, 1, scale)
+
+    
+def test_wishart_quantile_dimensions():
+    # Test that we can call the Wishart rvs with various quantile dimensions
+    
+    # If dim == 1, consider x.shape = [1,1,1]
+    X = [
+        1,                      # scalar
+        [1],                    # iterable
+        np.array(1),            # 0-dim
+        np.r_[1],               # 1-dim
+        np.array(1, ndmin=2),   # 2-dim
+        np.array([1], ndmin=3)  # 3-dim
+    ]
+
+    w = wishart(1,1)
+    density = w.pdf(np.array(1, ndmin=3))
+    for x in X:
+        assert_equal(w.pdf(x), density)
+
+    # If dim == 1, consider x.shape = [1,1,*]
+    X = [
+        [1,2,3],                     # iterable
+        np.r_[1,2,3],                # 1-dim
+        np.array([1,2,3], ndmin=3)   # 3-dim
+    ]
+
+    w = wishart(1,1)
+    density = w.pdf(np.array([1,2,3], ndmin=3))
+    for x in X:
+        assert_equal(w.pdf(x), density)
+
+    # If dim == 2, consider x.shape = [2,2,1]
+    # where x[:,:,*] = np.eye(1)*2
+    X = [
+        2,                    # scalar
+        [2,2],                # iterable
+        np.array(2),          # 0-dim
+        np.r_[2,2],           # 1-dim
+        np.array([[2,0],
+                  [0,2]]),    # 2-dim
+        np.array([[2,0],
+                  [0,2]])[:,:,np.newaxis] # 3-dim
+    ]
+
+    w = wishart(2,np.eye(2))
+    density = w.pdf(np.array([[2,0],
+                              [0,2]])[:,:,np.newaxis])
+    for x in X:
+        assert_equal(w.pdf(x), density)
+
+
+def test_wishart_frozen():
+    # Test that the frozen and non-frozen Wishart gives the same answers
+
+    # Construct an arbitrary positive definite scale matrix
+    dim = 4
+    scale = np.diag(np.arange(dim)+1)
+    scale[np.tril_indices(dim, k=-1)] = np.arange(dim*(dim-1)/2)
+    scale = np.dot(scale.T, scale)
+
+    # Construct a collection of positive definite matrices to test the PDF
+    X = []
+    for i in range(5):
+        x = np.diag(np.arange(dim)+(i+1)**2)
+        x[np.tril_indices(dim, k=-1)] = np.arange(dim*(dim-1)/2)
+        x = np.dot(x.T, x)
+        X.append(x)
+    X = np.array(X).T
+
+    # Construct a 1D and 2D set of parameters
+    parameters = [
+        (10, 1, np.linspace(0.1, 10, 5)), # 1D case
+        (10, scale, X)
+    ]
+
+    for (df, scale, x) in parameters:
+        w = wishart(df, scale)
+        assert_equal(w.var(), wishart.var(df, scale))
+        assert_equal(w.mean(), wishart.mean(df, scale))
+        assert_equal(w.mode(), wishart.mode(df, scale))
+        assert_equal(w.entropy(), wishart.entropy(df, scale))
+        assert_equal(w.pdf(x), wishart.pdf(x, df, scale))
+
+def test_wishart_1D_is_chisquared():
+    # The 1-dimensional Wishart with an identity scale matrix is just a
+    # chi-squared distribution.
+    # Test mean, mode, variance, pdf
+    np.random.seed(1234)
+
+    dim = 1
+    scale = np.eye(dim)
+
+    df_range = np.arange(1, 10, 2, dtype=float)
+    X = np.linspace(0.1,10,num=10)
+    for df in df_range:
+        w = wishart(df, scale)
+        c = chi2(df)
+
+        assert_allclose(w.var(), c.var())
+        assert_allclose(w.mean(), c.mean())
+        assert_allclose(w.entropy(), c.entropy())
+        assert_allclose(w.pdf(X), c.pdf(X))
+
+def test_wishart_is_scaled_chisquared():
+    # The 2-dimensional Wishart with an arbitrary scale matrix can be
+    # transformed to a scaled chi-squared distribution.
+    # For :math:`S \sim W_p(V,n)` and :math:`\lambda \in \mathbb{R}^p` we have
+    # :math:`\lambda' S \lambda \sim \lambda' V \lambda \times \chi^2(n)`
+
+    df = 10
+    dim = 4
+    # Construct an arbitrary positive definite matrix
+    scale = np.diag(np.arange(4)+1)
+    scale[np.tril_indices(4, k=-1)] = np.arange(6)
+    scale = np.dot(scale.T, scale)
+    # Use :math:`\lambda = [1, \dots, 1]'`
+    lamda = np.ones((dim,1))
+    sigma_lamda = lamda.T.dot(scale).dot(lamda).squeeze()
+    w = wishart(df, sigma_lamda)
+    c = chi2(df, scale=sigma_lamda)
+
+    assert_allclose(w.var(), c.var())
+    assert_allclose(w.mean(), c.mean())
+    assert_allclose(w.entropy(), c.entropy())
+
+    X = np.linspace(0.1,10,num=10)
+    assert_allclose(w.pdf(X), c.pdf(X))
+
+def test_invwishart_frozen():
+    # Test that the frozen and non-frozen inverse Wishart gives the same
+    # answers
+
+    # Construct an arbitrary positive definite scale matrix
+    dim = 4
+    scale = np.diag(np.arange(dim)+1)
+    scale[np.tril_indices(dim, k=-1)] = np.arange(dim*(dim-1)/2)
+    scale = np.dot(scale.T, scale)
+
+    # Construct a collection of positive definite matrices to test the PDF
+    X = []
+    for i in range(5):
+        x = np.diag(np.arange(dim)+(i+1)**2)
+        x[np.tril_indices(dim, k=-1)] = np.arange(dim*(dim-1)/2)
+        x = np.dot(x.T, x)
+        X.append(x)
+    X = np.array(X).T
+
+    # Construct a 1D and 2D set of parameters
+    parameters = [
+        (10, 1, np.linspace(0.1, 10, 5)), # 1D case
+        (10, scale, X)
+    ]
+
+    for (df, scale, x) in parameters:
+        iw = invwishart(df, scale)
+        assert_equal(iw.var(), invwishart.var(df, scale))
+        assert_equal(iw.mean(), invwishart.mean(df, scale))
+        assert_equal(iw.mode(), invwishart.mode(df, scale))
+        assert_equal(iw.pdf(x), invwishart.pdf(x, df, scale))
+
+def test_invwishart_1D_is_invgamma():
+    # The 1-dimensional inverse Wishart with an identity scale matrix is just
+    # an inverse gamma distribution.
+    # Test mean, mode, variance, pdf
+    np.random.seed(1234)
+
+    dim = 1
+    scale = np.eye(dim)
+
+    df_range = np.arange(5, 20, 2, dtype=float)
+    X = np.linspace(0.1,10,num=10)
+    for df in df_range:
+        iw = invwishart(df, scale)
+        ig = invgamma(df/2, scale=1./2)
+
+        assert_allclose(iw.var(), ig.var())
+        assert_allclose(iw.mean(), ig.mean())
+        assert_allclose(iw.pdf(X), ig.pdf(X))
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Adds `wishart` and `invwishart` to scipy.stats (also see #1063); Includes methods:
- `logpdf`
- `pdf`
- `mean`
- `mode`
- `var`
- `rvs`
- `entropy` (for Wishart only)

**Unit testing status**

In addition to dimensionality testing and testing the frozen against non-frozen output the unit tests current test the Wishart against the 1-dimensional special case of the chi-squared distribution and the inverse Wishart against the 1-dimensional special case of the inverse gamma distribution.

There are not many resources that I have found for multivariate testing (of e.g. pdf, mean, mode, etc.). I can test the PDF against the R package MCMCpack or probably PyMC, but I don't know of a source for testing the statistics or entropy.

I am not sure how to do unit tests for `rvs`. I can do Monte Carlo-esque checks, but to get even 2 digits of precision requires > 10,000 draws.
