### PR TITLE
BUG: fix ndimage functions for large data

### DIFF
--- a/scipy/ndimage/src/ni_filters.c
+++ b/scipy/ndimage/src/ni_filters.c
@@ -544,9 +544,10 @@ exit:
     return PyErr_Occurred() ? 0 : 1;
 }
 
-static double NI_Select(double *buffer, int min, int max, int rank)
+static double NI_Select(double *buffer, npy_intp min,
+                        npy_intp max, npy_intp rank)
 {
-    int ii, jj;
+    npy_intp ii, jj;
     double x, t;
 
     if (min == max)

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -457,7 +457,8 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
         size *= output->dimensions[qq];
     for(kk = 0; kk < size; kk++) {
         double t = 0.0;
-        int constant = 0, edge = 0, offset = 0;
+        int constant = 0, edge = 0;
+        npy_intp offset = 0;
         if (map) {
             /* call mappint functions: */
             if (!map(io.coordinates, icoor, orank, irank, map_data)) {
@@ -504,11 +505,11 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
             double cc = map_coordinate(icoor[hh], idimensions[hh], mode);
             if (cc > -1.0) {
                 /* find the filter location along this axis: */
-                int start;
+                npy_intp start;
                 if (order & 1) {
-                    start = (int)floor(cc) - order / 2;
+                    start = (npy_intp)floor(cc) - order / 2;
                 } else {
-                    start = (int)floor(cc + 0.5) - order / 2;
+                    start = (npy_intp)floor(cc + 0.5) - order / 2;
                 }
                 /* get the offset to the start of the filter: */
                 offset += istrides[hh] * start;
@@ -517,12 +518,12 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
                     edge = 1;
                     edge_offsets[hh] = data_offsets[hh];
                     for(ll = 0; ll <= order; ll++) {
-                        int idx = start + ll;
-                        int len = idimensions[hh];
+                        npy_intp idx = start + ll;
+                        npy_intp len = idimensions[hh];
                         if (len <= 1) {
                             idx = 0;
                         } else {
-                            int s2 = 2 * len - 2;
+                            npy_intp s2 = 2 * len - 2;
                             if (idx < 0) {
                                 idx = s2 * (int)(-idx / s2) + idx;
                                 idx = idx <= 1 - len ? idx + s2 : -idx;
@@ -553,7 +554,7 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
             t = 0.0;
             for(hh = 0; hh < filter_size; hh++) {
                 double coeff = 0.0;
-                int idx = 0;
+                npy_intp idx = 0;
 
                 if (NI_UNLIKELY(edge)) {
                     for(ll = 0; ll < irank; ll++) {
@@ -730,13 +731,13 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
                 cc *= zoom;
             cc = map_coordinate(cc, idimensions[jj], mode);
             if (cc > -1.0) {
-                int start;
+                npy_intp start;
                 if (zeros && zeros[jj])
                     zeros[jj][kk] = 0;
                 if (order & 1) {
-                    start = (int)floor(cc) - order / 2;
+                    start = (npy_intp)floor(cc) - order / 2;
                 } else {
-                    start = (int)floor(cc + 0.5) - order / 2;
+                    start = (npy_intp)floor(cc + 0.5) - order / 2;
                 }
                 offsets[jj][kk] = istrides[jj] * start;
                 if (start < 0 || start + order >= idimensions[jj]) {
@@ -746,12 +747,12 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
                         goto exit;
                     }
                     for(hh = 0; hh <= order; hh++) {
-                        int idx = start + hh;
-                         int len = idimensions[jj];
+                        npy_intp idx = start + hh;
+                        npy_intp len = idimensions[jj];
                         if (len <= 1) {
                             idx = 0;
                         } else {
-                            int s2 = 2 * len - 2;
+                            npy_intp s2 = 2 * len - 2;
                             if (idx < 0) {
                                 idx = s2 * (int)(-idx / s2) + idx;
                                 idx = idx <= 1 - len ? idx + s2 : -idx;
@@ -837,7 +838,7 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
             const int type_num = NI_NormalizeType(input->descr->type_num);
             t = 0.0;
             for(hh = 0; hh < filter_size; hh++) {
-                int idx = 0;
+                npy_intp idx = 0;
                 double coeff = 0.0;
 
                 if (NI_UNLIKELY(edge)) {

--- a/scipy/ndimage/src/ni_measure.c
+++ b/scipy/ndimage/src/ni_measure.c
@@ -564,11 +564,11 @@ int NI_Histogram(PyArrayObject *input, PyArrayObject *labels,
             doit = label != 0;
         }
         if (doit) {
-            int bin;
+            npy_intp bin;
             double val;
             NI_GET_VALUE(pi, val, NI_NormalizeType(input->descr->type_num));
             if (val >= min && val < max) {
-                bin = (int)((val - min) / bsize);
+                bin = (npy_intp)((val - min) / bsize);
                 ++(ph[idx][bin]);
             }
         }
@@ -691,7 +691,7 @@ int NI_WatershedIFT(PyArrayObject* input, PyArrayObject* markers,
     /* Initialization and find the maximum of the input. */
     maxval = 0;
     for(jj = 0; jj < size; jj++) {
-        int ival = 0;
+        npy_intp ival = 0;
         switch(NI_NormalizeType(input->descr->type_num)) {
         CASE_GET_INPUT(ival, pi, UInt8);
         CASE_GET_INPUT(ival, pi, UInt16);

--- a/scipy/ndimage/src/ni_morphology.c
+++ b/scipy/ndimage/src/ni_morphology.c
@@ -765,7 +765,7 @@ static void _VoronoiFT(char *pf, npy_intp len, npy_intp *coor, int rank,
                        npy_intp **f, npy_intp *g, Float64 *sampling)
 {
     npy_intp l = -1, ii, maxl, idx1, idx2;
-    int jj;
+    npy_intp jj;
 
     for(ii = 0; ii < len; ii++)
         for(jj = 0; jj < rank; jj++)
@@ -853,7 +853,7 @@ static void _ComputeFT(char *pi, char *pf, npy_intp *ishape,
                        int d, npy_intp *coor, npy_intp **f, npy_intp *g,
                                              PyArrayObject *features, Float64 *sampling)
 {
-    int kk;
+    npy_intp kk;
     npy_intp jj;
 
     if (d == 0) {

--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -32,11 +32,12 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 import math
+import sys
 
 import numpy
 from numpy import fft
 from numpy.testing import (assert_, assert_equal, assert_array_equal,
-        run_module_suite, assert_array_almost_equal, assert_almost_equal)
+        run_module_suite, assert_array_almost_equal, assert_almost_equal, dec)
 import scipy.ndimage as ndimage
 
 
@@ -1704,6 +1705,16 @@ class TestNdimage:
         out = ndimage.map_coordinates(data[:,::2], idx)
         assert_array_almost_equal(out, [[0, 0], [0, 4], [0, 7]])
         assert_array_almost_equal(out, ndimage.shift(data[:,::2], (1, 1)))
+
+    # do not run on 32 bit or windows (no sparse memory)
+    @dec.skipif('win32' in sys.platform or numpy.intp(0).itemsize < 8)
+    def test_map_coordinates_large_data(self):
+        # check crash on large data
+        n = 30000
+        a = numpy.empty(n**2, dtype=numpy.float32).reshape(n, n)
+        # fill the part we might read
+        a[n - 3:,n - 3:] = 0
+        ndimage.map_coordinates(a, [[n - 1.5], [n - 1.5]], order=1)
 
     def test_affine_transform01(self):
         data = numpy.array([1])


### PR DESCRIPTION
map_coordinates uses int to index into data arrays which can overflow
for arrays of several gigabytes size. Patch by @cgohlke.
some other occurances of int replaced by npy_intp for safety.
Closes gh-3733

rebased onto 0.14 merge base so it can be directly merged into master and 0.14
