### PR TITLE
option to avoid computing possibly unused svd matrix

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1728,7 +1728,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
             ularge = eigvec[:, above_cutoff]
             vhlarge = _herm(X.dot(ularge) / slarge) if return_singular_vectors != 'u' else None
 
-        u  = _augmented_orthonormal_cols(ularge, nsmall)  if ularge  is not None else None
+        u = _augmented_orthonormal_cols(ularge, nsmall) if ularge is not None else None
         vh = _augmented_orthonormal_rows(vhlarge, nsmall) if vhlarge is not None else None
 
     else:

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1652,8 +1652,10 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
         Maximum number of iterations.
 
         .. versionadded:: 0.12.0
-    return_singular_vectors : bool, optional
-        Return singular vectors (True) in addition to singular values
+    return_singular_vectors : bool or str, optional
+        True: return singular vectors (True) in addition to singular values.
+        'u': only return the u matrix, without computing vh (if N > M)
+        'vh': only return the vh matrix, without computing u (if N <= M)
 
         .. versionadded:: 0.12.0
 
@@ -1720,14 +1722,14 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
         if n > m:
             vlarge = eigvec[:, above_cutoff]
-            ularge = X.dot(vlarge) / slarge
+            ularge = (X.dot(vlarge) / slarge) if return_singular_vectors != 'vh' else None
             vhlarge = _herm(vlarge)
         else:
             ularge = eigvec[:, above_cutoff]
-            vhlarge = _herm(X.dot(ularge) / slarge)
+            vhlarge = _herm(X.dot(ularge) / slarge) if return_singular_vectors != 'u' else None
 
-        u = _augmented_orthonormal_cols(ularge, nsmall)
-        vh = _augmented_orthonormal_rows(vhlarge, nsmall)
+        u  = _augmented_orthonormal_cols(ularge, nsmall)  if ularge  is not None else None
+        vh = _augmented_orthonormal_rows(vhlarge, nsmall) if vhlarge is not None else None
 
     else:
 
@@ -1737,10 +1739,10 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
         if n > m:
             v = eigvec
-            u = X.dot(v) / s
+            u = (X.dot(v) / s) if return_singular_vectors != 'vh' else None
             vh = _herm(v)
         else:
             u = eigvec
-            vh = _herm(X.dot(u) / s)
+            vh = _herm(X.dot(u) / s) if return_singular_vectors != 'u' else None
 
     return u, s, vh

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -735,5 +735,30 @@ def test_linearoperator_deallocation():
         pass
 
 
+def test_svds_partial_return():
+    x = np.array([[1, 2, 3],
+                  [3, 4, 3],
+                  [1, 0, 2],
+                  [0, 0, 1]], np.float)
+    # test vertical matrix
+    z = csr_matrix(x)
+    vh_full = svds(z, 2)[-1]
+    vh_partial = svds(z, 2, return_singular_vectors='vh')[-1]
+    dvh = np.linalg.norm(np.abs(vh_full) - np.abs(vh_partial))
+    if dvh > 1e-10:
+        raise AssertionError('right eigenvector matrices differ when using return_singular_vectors parameter')
+    if svds(z, 2, return_singular_vectors='vh')[0] is not None:
+        raise AssertionError('left eigenvector matrix was computed when it should not have been')
+    # test horizontal matrix
+    z = csr_matrix(x.T)
+    u_full = svds(z, 2)[0]
+    u_partial = svds(z, 2, return_singular_vectors='vh')[0]
+    du = np.linalg.norm(np.abs(u_full) - np.abs(u_partial))
+    if du > 1e-10:
+        raise AssertionError('left eigenvector matrices differ when using return_singular_vectors parameter')
+    if svds(z, 2, return_singular_vectors='u')[-1] is not None:
+        raise AssertionError('right eigenvector matrix was computed when it should not have been')
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
When calling svds on a very large sparse matrix the returned `U` and and `VT` matrices are dense and possibly very large, taking up a lot of memory.
This patch adds the option to only compute the smallest of the eigenvector matrices (`VT` for vertical input matrices, `U` for horizontal ones) in case the other one is not needed.
