### PR TITLE
MAINT: optimize: clean up Zeros code

### DIFF
--- a/scipy/optimize/Zeros/bisect.c
+++ b/scipy/optimize/Zeros/bisect.c
@@ -1,9 +1,11 @@
 /* Written by Charles Harris charles.harris@sdl.usu.edu */
 
+#include <math.h>
 #include "zeros.h"
 
 double
-bisect(callback_type f, double xa, double xb, double xtol, double rtol, int iter, default_parameters *params)
+bisect(callback_type f, double xa, double xb, double xtol, double rtol,
+       int iter, default_parameters *params)
 {
     int i;
     double dm,xm,fm,fa,fb,tol;
@@ -13,12 +15,19 @@ bisect(callback_type f, double xa, double xb, double xtol, double rtol, int iter
     fa = (*f)(xa,params);
     fb = (*f)(xb,params);
     params->funcalls = 2;
-    if (fa*fb > 0) {ERROR(params,SIGNERR,0.0);}
-    if (fa == 0) return xa;
-    if (fb == 0) return xb;
+    if (fa*fb > 0) {
+        params->error_num = SIGNERR;
+        return 0.;
+    }
+    if (fa == 0) {
+        return xa;
+    }
+    if (fb == 0) {
+        return xb;
+    }
     dm = xb - xa;
     params->iterations = 0;
-    for(i=0; i<iter; i++) {
+    for (i=0; i<iter; i++) {
         params->iterations++;
         dm *= .5;
         xm = xa + dm;
@@ -27,8 +36,10 @@ bisect(callback_type f, double xa, double xb, double xtol, double rtol, int iter
         if (fm*fa >= 0) {
             xa = xm;
         }
-        if (fm == 0 || fabs(dm) < tol)
+        if (fm == 0 || fabs(dm) < tol) {
             return xm;
+        }
     }
-    ERROR(params,CONVERR,xa);
+    params->error_num = CONVERR;
+    return xa;
 }

--- a/scipy/optimize/Zeros/brentq.c
+++ b/scipy/optimize/Zeros/brentq.c
@@ -1,11 +1,11 @@
-
 /* Written by Charles Harris charles.harris@sdl.usu.edu */
 
+#include <math.h>
 #include "zeros.h"
 
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 /*
-
   At the top of the loop the situation is the following:
 
     1. the root is bracketed between xa and xb
@@ -34,21 +34,30 @@
 */
 
 double
-brentq(callback_type f, double xa, double xb, double xtol, double rtol, int iter, default_parameters *params)
+brentq(callback_type f, double xa, double xb, double xtol, double rtol,
+       int iter, default_parameters *params)
 {
     double xpre = xa, xcur = xb;
-    double xblk = 0.0, fpre, fcur, fblk = 0.0, spre = 0.0, scur = 0.0, sbis, tol;
+    double xblk = 0., fpre, fcur, fblk = 0., spre = 0., scur = 0., sbis, tol;
     double stry, dpre, dblk;
     int i;
 
     fpre = (*f)(xpre, params);
     fcur = (*f)(xcur, params);
     params->funcalls = 2;
-    if (fpre*fcur > 0) {ERROR(params,SIGNERR,0.0);}
-    if (fpre == 0) return xpre;
-    if (fcur == 0) return xcur;
+    if (fpre*fcur > 0) {
+        params->error_num = SIGNERR;
+        return 0.;
+    }
+    if (fpre == 0) {
+        return xpre;
+    }
+    if (fcur == 0) {
+        return xcur;
+    }
+
     params->iterations = 0;
-    for(i = 0; i < iter; i++) {
+    for (i = 0; i < iter; i++) {
         params->iterations++;
         if (fpre*fcur < 0) {
             xblk = xpre;
@@ -56,14 +65,20 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol, int iter
             spre = scur = xcur - xpre;
         }
         if (fabs(fblk) < fabs(fcur)) {
-            xpre = xcur; xcur = xblk; xblk = xpre;
-            fpre = fcur; fcur = fblk; fblk = fpre;
+            xpre = xcur;
+            xcur = xblk;
+            xblk = xpre;
+
+            fpre = fcur;
+            fcur = fblk;
+            fblk = fpre;
         }
 
         tol = xtol + rtol*fabs(xcur);
         sbis = (xblk - xcur)/2;
-        if (fcur == 0 || fabs(sbis) < tol)
+        if (fcur == 0 || fabs(sbis) < tol) {
             return xcur;
+        }
 
         if (fabs(spre) > tol && fabs(fcur) < fabs(fpre)) {
             if (xpre == xblk) {
@@ -77,27 +92,33 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol, int iter
                 stry = -fcur*(fblk*dblk - fpre*dpre)
                     /(dblk*dpre*(fblk - fpre));
             }
-            if (2*fabs(stry) < DMIN(fabs(spre), 3*fabs(sbis) - tol)) {
+            if (2*fabs(stry) < MIN(fabs(spre), 3*fabs(sbis) - tol)) {
                 /* good short step */
-                spre = scur; scur = stry;
+                spre = scur;
+                scur = stry;
             } else {
                 /* bisect */
-                spre = sbis; scur = sbis;
+                spre = sbis;
+                scur = sbis;
             }
         }
         else {
             /* bisect */
-            spre = sbis; scur = sbis;
+            spre = sbis;
+            scur = sbis;
         }
 
         xpre = xcur; fpre = fcur;
-        if (fabs(scur) > tol)
+        if (fabs(scur) > tol) {
             xcur += scur;
-        else
+        }
+        else {
             xcur += (sbis > 0 ? tol : -tol);
+        }
 
         fcur = (*f)(xcur, params);
         params->funcalls++;
     }
-    ERROR(params,CONVERR, xcur);
+    params->error_num = CONVERR;
+    return xcur;
 }

--- a/scipy/optimize/Zeros/ridder.c
+++ b/scipy/optimize/Zeros/ridder.c
@@ -1,14 +1,21 @@
-/* Originally written by Charles Harris charles.harris@sdl.usu.edu */
-/* Modified by Travis Oliphant to not depend on Python */
+/*
+ * Originally written by Charles Harris charles.harris@sdl.usu.edu.
+ * Modified by Travis Oliphant to not depend on Python.
+ */
 
+#include <math.h>
 #include "zeros.h"
+
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define SIGN(a) ((a) > 0. ? 1. : -1.)
 
 /* Sets params->error_num SIGNERR for sign_error;
                          CONVERR for convergence_error;
 */
 
 double
-ridder(callback_type f, double xa, double xb, double xtol, double rtol, int iter, default_parameters *params)
+ridder(callback_type f, double xa, double xb, double xtol, double rtol,
+       int iter, default_parameters *params)
 {
     int i;
     double dm,dn,xm,xn=0.0,fn,fm,fa,fb,tol;
@@ -17,17 +24,25 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol, int iter
     fa = (*f)(xa,params);
     fb = (*f)(xb,params);
     params->funcalls = 2;
-    if (fa*fb > 0) {ERROR(params,SIGNERR,0.0);}
-    if (fa == 0) return xa;
-    if (fb == 0) return xb;
+    if (fa*fb > 0) {
+        params->error_num = SIGNERR;
+        return 0.;
+    }
+    if (fa == 0) {
+        return xa;
+    }
+    if (fb == 0) {
+        return xb;
+    }
+
     params->iterations=0;
-    for(i=0; i<iter; i++) {
+    for (i=0; i<iter; i++) {
         params->iterations++;
         dm = 0.5*(xb - xa);
         xm = xa + dm;
         fm = (*f)(xm,params);
         dn = SIGN(fb - fa)*dm*fm/sqrt(fm*fm - fa*fb);
-        xn = xm - SIGN(dn)*DMIN(fabs(dn),fabs(dm) - .5*tol);
+        xn = xm - SIGN(dn) * MIN(fabs(dn), fabs(dm) - .5*tol);
         fn = (*f)(xn,params);
         params->funcalls += 2;
         if (fn*fm < 0.0) {
@@ -39,8 +54,10 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol, int iter
         else {
             xa = xn; fa = fn;
         }
-        if (fn == 0.0 || fabs(xb - xa) < tol)
+        if (fn == 0.0 || fabs(xb - xa) < tol) {
             return xn;
+        }
     }
-    ERROR(params,CONVERR,xn);
+    params->error_num = CONVERR;
+    return xn;
 }

--- a/scipy/optimize/Zeros/zeros.h
+++ b/scipy/optimize/Zeros/zeros.h
@@ -3,22 +3,15 @@
 /* Modified to not depend on Python everywhere by Travis Oliphant.
  */
 
-
 #ifndef ZEROS_H
 #define ZEROS_H
 
-#define ZEROS_PARAM_HEAD int funcalls; int iterations; int error_num
-
 typedef struct {
-    ZEROS_PARAM_HEAD;
+    int funcalls;
+    int iterations;
+    int error_num;
 } default_parameters;
 
-static double dminarg1,dminarg2;
-#define DMIN(a,b) (dminarg1=(a),dminarg2=(b),(dminarg1) < (dminarg2) ?\
-        (dminarg1) : (dminarg2))
-
-#define SIGN(a)   ((a) > 0.0 ? 1.0 : -1.0)
-#define ERROR(params,num,val) (params)->error_num=(num); return (val)
 #define SIGNERR -1
 #define CONVERR -2
 
@@ -29,9 +22,5 @@ extern double bisect(callback_type f, double xa, double xb, double xtol, double 
 extern double ridder(callback_type f, double xa, double xb, double xtol, double rtol, int iter, default_parameters *params);
 extern double brenth(callback_type f, double xa, double xb, double xtol, double rtol, int iter, default_parameters *params);
 extern double brentq(callback_type f, double xa, double xb, double xtol, double rtol, int iter, default_parameters *params);
-
-
-extern double fabs(double);
-extern double sqrt(double);
 
 #endif


### PR DESCRIPTION
- Use standard C header file `<math.h>`
- Decouple implementation from interface in `zeros.h` (expanded out the `ERROR` macro for readability)
- Don't use `static` variables, they make code non-reentrant  and hinder compiler optimizations
- Indentation, `{}`, split multi-statement lines
