### PR TITLE
ENH: sparse.csgraph: a faster DFS implementation: (i) linear (ii) releases gil

### DIFF
--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -400,8 +400,8 @@ cdef unsigned int _breadth_first_undirected(
     return i_nl
 
 cdef struct DfsStackEntry:
-    Py_ssize_t node
-    Py_ssize_t index
+    np.int64_t node
+    np.int64_t index
 
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -418,7 +418,16 @@ cdef void _depth_first_iterative(int32_or_int64 i_start,
     cdef int32_or_int64 order_end = 0
 
     cdef int* status = <int*> stdlib.malloc(n*sizeof(int))
+    if not status:
+        with gil:
+            raise MemoryError()
+
     cdef DfsStackEntry* stack = <DfsStackEntry*>stdlib.malloc(n * sizeof(DfsStackEntry))
+    if not stack:
+        stdlib.free(status)
+        with gil:
+            raise MemoryError()
+
     cdef DfsStackEntry* head = stack
     
     for idx in range(n):

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -400,8 +400,8 @@ cdef unsigned int _breadth_first_undirected(
     return i_nl
 
 cdef struct DfsStackEntry:
-    long node
-    long index
+    Py_ssize_t node
+    Py_ssize_t index
 
 @cython.boundscheck(False)
 @cython.wraparound(False)


### PR DESCRIPTION
I've re-implemented `depth_first_order`. 

The new implementation offers the following advantages:
1. linear in the the size of the input graph 
2. releases gil (does not use the interpreter at all)

As a result the new implementation is much faster.

In addition, this new implementation offers a deviation from the original functionality by representing the root of the tree using a self loop (which, to the best of my knowledge, is more standard). The original implementation uses "-9999" which introduces indices outside the domain of the nodes. Currently this behavior is only available through a deisgnated keyword.  
