### PR TITLE
DOC: sparse: clarify CSC and CSR constructor usage

### DIFF
--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -34,9 +34,9 @@ class csc_matrix(_cs_matrix, IndexMixin):
             to construct an empty matrix with shape (M, N)
             dtype is optional, defaulting to dtype='d'.
 
-        csc_matrix((data, ij), [shape=(M, N)])
-            where ``data`` and ``ij`` satisfy the relationship
-            ``a[ij[0, k], ij[1, k]] = data[k]``
+        csc_matrix((data, (row_ind, col_ind)), [shape=(M, N)])
+            where ``data``, ``row_ind`` and ``col_ind`` satisfy the
+            relationship ``a[row_ind[k], col_ind[k]] = data[k]``.
 
         csc_matrix((data, indices, indptr), [shape=(M, N)])
             is the standard CSC representation where the row indices for

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -32,9 +32,9 @@ class csr_matrix(_cs_matrix, IndexMixin):
             to construct an empty matrix with shape (M, N)
             dtype is optional, defaulting to dtype='d'.
 
-        csr_matrix((data, ij), [shape=(M, N)])
-            where ``data`` and ``ij`` satisfy the relationship
-            ``a[ij[0, k], ij[1, k]] = data[k]``
+        csr_matrix((data, (row_ind, col_ind)), [shape=(M, N)])
+            where ``data``, ``row_ind`` and ``col_ind`` satisfy the
+            relationship ``a[row_ind[k], col_ind[k]] = data[k]``.
 
         csr_matrix((data, indices, indptr), [shape=(M, N)])
             is the standard CSR representation where the column indices for


### PR DESCRIPTION
Same treatment as given to COO in 3f19f49b83223e826d2e7d97c7060773a8522a0b.
