### PR TITLE
MAINT: remove unnecessary null checks before free

### DIFF
--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -171,8 +171,7 @@ exit:
     Py_XDECREF(input);
     Py_XDECREF(weights);
     Py_XDECREF(output);
-    if (origin)
-        free(origin);
+    free(origin);
     return PyErr_Occurred() ? NULL : Py_BuildValue("");
 }
 
@@ -245,8 +244,7 @@ exit:
     Py_XDECREF(footprint);
     Py_XDECREF(structure);
     Py_XDECREF(output);
-    if (origin)
-        free(origin);
+    free(origin);
     return PyErr_Occurred() ? NULL : Py_BuildValue("");
 }
 
@@ -271,8 +269,7 @@ exit:
     Py_XDECREF(input);
     Py_XDECREF(footprint);
     Py_XDECREF(output);
-    if (origin)
-        free(origin);
+    free(origin);
     return PyErr_Occurred() ? NULL : Py_BuildValue("");
 }
 
@@ -435,8 +432,7 @@ exit:
     Py_XDECREF(input);
     Py_XDECREF(output);
     Py_XDECREF(footprint);
-    if (origin)
-        free(origin);
+    free(origin);
     return PyErr_Occurred() ? NULL : Py_BuildValue("");
 }
 
@@ -713,8 +709,7 @@ static PyObject *Py_FindObjects(PyObject *obj, PyObject *args)
     Py_XDECREF(start);
     Py_XDECREF(end);
     Py_XDECREF(slc);
-    if (regions)
-        free(regions);
+    free(regions);
     if (PyErr_Occurred()) {
         Py_XDECREF(result);
         return NULL;
@@ -849,8 +844,7 @@ exit:
     Py_XDECREF(strct);
     Py_XDECREF(mask);
     Py_XDECREF(output);
-    if (origins)
-        free(origins);
+    free(origins);
     if (PyErr_Occurred()) {
         Py_XDECREF(cobj);
         return NULL;
@@ -892,7 +886,7 @@ exit:
     Py_XDECREF(array);
     Py_XDECREF(strct);
     Py_XDECREF(mask);
-    if (origins) free(origins);
+    free(origins);
     return PyErr_Occurred() ? NULL : Py_BuildValue("");
 }
 

--- a/scipy/ndimage/src/ni_filters.c
+++ b/scipy/ndimage/src/ni_filters.c
@@ -133,8 +133,8 @@ exit:
     if (errmsg[0] != 0) {
         PyErr_SetString(PyExc_RuntimeError, errmsg);
     }
-    if (ibuffer) free(ibuffer);
-    if (obuffer) free(obuffer);
+    free(ibuffer);
+    free(obuffer);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -283,9 +283,9 @@ exit:
     if (err == 1) {
         PyErr_SetString(PyExc_RuntimeError, "array type not supported");
     }
-    if (offsets) free(offsets);
-    if (ww) free(ww);
-    if (pf) free(pf);
+    free(offsets);
+    free(ww);
+    free(pf);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -354,8 +354,8 @@ NI_UniformFilter1D(PyArrayObject *input, npy_intp filter_size,
     if (errmsg[0] != 0) {
         PyErr_SetString(PyExc_RuntimeError, errmsg);
     }
-    if (ibuffer) free(ibuffer);
-    if (obuffer) free(obuffer);
+    free(ibuffer);
+    free(obuffer);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -478,9 +478,9 @@ NI_MinOrMaxFilter1D(PyArrayObject *input, npy_intp filter_size,
     if (errmsg[0] != 0) {
         PyErr_SetString(PyExc_RuntimeError, errmsg);
     }
-    if (ibuffer) free(ibuffer);
-    if (obuffer) free(obuffer);
-    if (ring) free(ring);
+    free(ibuffer);
+    free(obuffer);
+    free(ring);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -634,8 +634,8 @@ exit:
     if (err == 1) {
         PyErr_SetString(PyExc_RuntimeError, "array type not supported");
     }
-    if (offsets) free(offsets);
-    if (ss) free(ss);
+    free(offsets);
+    free(ss);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -802,8 +802,8 @@ exit:
     if (err == 1) {
         PyErr_SetString(PyExc_RuntimeError, "array type not supported");
     }
-    if (offsets) free(offsets);
-    if (buffer) free(buffer);
+    free(offsets);
+    free(buffer);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -861,8 +861,8 @@ int NI_GenericFilter1D(PyArrayObject *input,
         }
     } while(more);
 exit:
-    if (ibuffer) free(ibuffer);
-    if (obuffer) free(obuffer);
+    free(ibuffer);
+    free(obuffer);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -991,7 +991,7 @@ int NI_GenericFilter(PyArrayObject* input,
         NI_FILTER_NEXT2(fi, ii, io, oo, pi, po);
     }
 exit:
-    if (offsets) free(offsets);
-    if (buffer) free(buffer);
+    free(offsets);
+    free(buffer);
     return PyErr_Occurred() ? 0 : 1;
 }

--- a/scipy/ndimage/src/ni_fourier.c
+++ b/scipy/ndimage/src/ni_fourier.c
@@ -558,7 +558,7 @@ int NI_FourierShift(PyArrayObject *input, PyArrayObject* shift_array,
     free(shifts);
     if (params) {
         for(kk = 0; kk < input->nd; kk++)
-            if (params[kk]) free(params[kk]);
+            free(params[kk]);
         free(params);
     }
     return PyErr_Occurred() ? 0 : 1;

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -312,7 +312,7 @@ int NI_SplineFilter1D(PyArrayObject *input, int order, int axis,
     if (errmsg[0] != 0) {
         PyErr_SetString(PyExc_RuntimeError, errmsg);
     }
-    if (buffer) free(buffer);
+    free(buffer);
     return PyErr_Occurred() ? 0 : 1;
 }
 

--- a/scipy/ndimage/src/ni_morphology.c
+++ b/scipy/ndimage/src/ni_morphology.c
@@ -789,10 +789,9 @@ int NI_DistanceTransformOnePass(PyArrayObject *strct,
 
  exit:
     NPY_END_THREADS;
-    if (offsets) free(offsets);
-    if (foffsets) free(foffsets);
-    if (footprint)
-        free(footprint);
+    free(offsets);
+    free(foffsets);
+    free(footprint);
     return PyErr_Occurred() ? 0 : 1;
 }
 
@@ -989,12 +988,9 @@ int NI_EuclideanFeatureTransform(PyArrayObject* input,
                input->nd, input->nd - 1, coor, f, g, features, sampling, 0);
 
  exit:
-    if (f)
-        free(f);
-    if (g)
-        free(g);
-    if (tmp)
-        free(tmp);
+    free(f);
+    free(g);
+    free(tmp);
 
     return PyErr_Occurred() ? 0 : 1;
 }

--- a/scipy/ndimage/src/ni_support.c
+++ b/scipy/ndimage/src/ni_support.c
@@ -694,8 +694,7 @@ int NI_InitFilterOffsets(PyArrayObject *array, Bool *footprint,
 
  exit:
     if (PyErr_Occurred()) {
-        if (*offsets)
-            free(*offsets);
+        free(*offsets);
         if (coordinate_offsets && *coordinate_offsets)
             free(*coordinate_offsets);
         return 0;
@@ -759,8 +758,7 @@ NI_CoordinateBlock* NI_CoordinateListDeleteBlock(NI_CoordinateList *list)
     NI_CoordinateBlock* block = list->blocks;
     if (block) {
         list->blocks = block->next;
-        if (block->coordinates)
-            free(block->coordinates);
+        free(block->coordinates);
         free(block);
     }
     return list->blocks;
@@ -773,8 +771,7 @@ void NI_FreeCoordinateList(NI_CoordinateList *list)
         while (block) {
             NI_CoordinateBlock *tmp = block;
             block = block->next;
-            if (tmp->coordinates)
-                free(tmp->coordinates);
+            free(tmp->coordinates);
             free(tmp);
         }
         list->blocks = NULL;

--- a/scipy/optimize/tnc/tnc.c
+++ b/scipy/optimize/tnc/tnc.c
@@ -411,11 +411,11 @@ cleanup:
   if (messages & TNC_MSG_EXIT)
     fprintf(stderr, "tnc: %s\n", tnc_rc_string[rc - TNC_MINRC]);
 
-  if (xscale) free(xscale);
+  free(xscale);
   if (free_low) free(low);
   if (free_up) free(up);
   if (free_g) free(g);
-  if (xoffset) free(xoffset);
+  free(xoffset);
 
   return rc;
 }
@@ -861,18 +861,18 @@ static tnc_rc tnc_minimize(int n, double x[],
   (*f) /= *fscale;
 
 cleanup:
-  if (oldg) free(oldg);
-  if (g) free(g);
-  if (temp) free(temp);
-  if (diagb) free(diagb);
-  if (pk) free(pk);
+  free(oldg);
+  free(g);
+  free(temp);
+  free(diagb);
+  free(pk);
 
-  if (sk) free(sk);
-  if (yk) free(yk);
-  if (sr) free(sr);
-  if (yr) free(yr);
+  free(sk);
+  free(yk);
+  free(sr);
+  free(yr);
 
-  if (pivot) free(pivot);
+  free(pivot);
 
   return rc;
 }
@@ -1170,11 +1170,11 @@ static int tnc_direction(double *zsol, double *diagb,
   dcopy1(n, emat, diagb);
 
 cleanup:
-  if (r) free(r);
-  if (v) free(v);
-  if (zk) free(zk);
-  if (emat) free(emat);
-  if (gv) free(gv);
+  free(r);
+  free(v);
+  free(zk);
+  free(emat);
+  free(gv);
   return frc;
 }
 
@@ -1314,9 +1314,9 @@ static int msolve(double g[], double y[], int n,
   }
 
 cleanup:
-  if (hg) free(hg);
-  if (hyk) free(hyk);
-  if (hyr) free(hyr);
+  free(hg);
+  free(hyk);
+  free(hyr);
 
   return frc;
 }
@@ -1522,9 +1522,9 @@ static ls_rc linearSearch(int n, tnc_function *function, void *state,
   else rc = LS_MAXFUN;
 
 cleanup:
-  if (temp) free(temp);
-  if (tempgfull) free(tempgfull);
-  if (newgfull) free(newgfull);
+  free(temp);
+  free(tempgfull);
+  free(newgfull);
 
   return rc;
 }


### PR DESCRIPTION
free is required to handle null in all versions of the C standard and
15+ year olds systems which might not comply to this basic requiremnent
likely can't run current scipy anyway.
Patch generated with semantic patch:

```
@@
expression E;
@@

- if (E != NULL) {
-   free(E);
- }
+ free(E);
```
