### PR TITLE
Pr/3923 

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -451,7 +451,8 @@ def _weighted_general_function(params, xdata, ydata, function, weights):
     return weights * (function(xdata, *params) - ydata)
 
 
-def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False, **kw):
+def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
+              check_finite=True, **kw):
     """
     Use non-linear least squares to fit a function, f, to data.
 
@@ -488,6 +489,12 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False, **kw):
         If True, `sigma` describes one standard deviation errors of
         the input data points. The estimated covariance in `pcov` is
         based on these values.
+    check_finite : bool, optional
+        If True, check that the input arrays do not contain nans of infs,
+        and raise a ValueError if they do. Setting this parameter to
+        False may silently produce nonsensical results if the input arrays
+        do contain nans.
+        Default is True.
 
     Returns
     -------
@@ -550,11 +557,17 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False, **kw):
         p0 = array([p0])
 
     # NaNs can not be handled
-    ydata = np.asarray_chkfinite(ydata)
+    if check_finite:
+        ydata = np.asarray_chkfinite(ydata)
+    else:
+        ydata = np.asarray(ydata)
     if isinstance(xdata, (list, tuple, np.ndarray)):
         # `xdata` is passed straight to the user-defined `f`, so allow
         # non-array_like `xdata`.
-        xdata = np.asarray_chkfinite(xdata)
+        if check_finite:
+            xdata = np.asarray_chkfinite(xdata)
+        else:
+            xdata = np.asarray(xdata)
 
     args = (xdata, ydata, f)
     if sigma is None:

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -507,6 +507,9 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False, **kw):
     OptimizeWarning
         if covariance of the parameters can not be estimated.
 
+    ValueError
+        if ydata and xdata contain NaNs.
+
     See Also
     --------
     leastsq
@@ -546,11 +549,12 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False, **kw):
     if isscalar(p0):
         p0 = array([p0])
 
-    ydata = np.asanyarray(ydata)
-    if isinstance(xdata, (list, tuple)):
+    # NaNs can not be handled
+    ydata = np.asarray_chkfinite(ydata)
+    if isinstance(xdata, (list, tuple, np.ndarray)):
         # `xdata` is passed straight to the user-defined `f`, so allow
         # non-array_like `xdata`.
-        xdata = np.asarray(xdata)
+        xdata = np.asarray_chkfinite(xdata)
 
     args = (xdata, ydata, f)
     if sigma is None:

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -403,6 +403,9 @@ class TestCurveFit(TestCase):
         assert_raises(ValueError, curve_fit, lambda x, a, b: a*x + b, xdata, ydata)
         assert_raises(ValueError, curve_fit, lambda x, a, b: a*x + b, ydata, xdata)
 
+        assert_raises(ValueError, curve_fit, lambda x, a, b: a*x + b,
+                      xdata, ydata, **{"check_finite": True})
+
 
 class TestFixedPoint(TestCase):
 

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -384,14 +384,25 @@ class TestCurveFit(TestCase):
             return a*x + b
 
         x = [1, 2, 3, 4]
-        y = [1, 2, 3, 4]
-        assert_allclose(curve_fit(f_linear, x, y)[0], [1, 0], atol=1e-10)
+        y = [3, 5, 7, 9]
+        assert_allclose(curve_fit(f_linear, x, y)[0], [2, 1], atol=1e-10)
 
     def test_indeterminate_covariance(self):
         # Test that a warning is returned when pcov is indeterminate
         xdata = np.array([1, 2, 3, 4, 5, 6])
         ydata = np.array([1, 2, 3, 4, 5.5, 6])
         _assert_warns(OptimizeWarning, curve_fit, lambda x, a, b: a*x, xdata, ydata)
+
+    def test_NaN_handling(self):
+        # Test for correct handling of NaNs in input data: gh-3422
+
+        # create input with NaNs
+        xdata = np.array([1, np.nan, 3])
+        ydata = np.array([1, 2, 3])
+
+        assert_raises(ValueError, curve_fit, lambda x, a, b: a*x + b, xdata, ydata)
+        assert_raises(ValueError, curve_fit, lambda x, a, b: a*x + b, ydata, xdata)
+
 
 class TestFixedPoint(TestCase):
 


### PR DESCRIPTION
this is a suggested redo of gh-3923: this adds a `check_finite` flag to `curve_fit`, modelled after a similar flag in `linalg`. IMO having this flag is a reasonable price to pay for fixing the nonsense of gh-3422, but apparently, there is a range of opinions, see gh-3923 for discussion.

I think it would be nice to fix the original issue, gh-3422, for 0.15.
This PR and gh-3925 provide slightly different ways of fixing it, and I personally would be fine with either of them.

And yeah, in case this is decided to be the one to be merged, github magic: closes gh-3923, fixes gh-3422
