### PR TITLE
BUG: lobpcg largest eigenvalues

### DIFF
--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -296,6 +296,9 @@ def lobpcg(A, X,
     M = _makeOperator(M, (n,n))
 
     if (n - sizeY) < (5 * sizeX):
+
+        #A = _makeOperator(A, (n,n))
+
         # warn('The problem size is small compared to the block size.' \
         #        ' Using dense eigensolver instead of LOBPCG.')
 
@@ -312,6 +315,11 @@ def lobpcg(A, X,
         A_dense = A(np.eye(n))
         B_dense = None if B is None else B(np.eye(n))
         return eigh(A_dense, B_dense, eigvals=eigvals, check_finite=False)
+
+    #if largest:
+        #A = _makeOperator(-A, (n,n))
+    #else:
+        #A = _makeOperator(A, (n,n))
 
     if residualTolerance is None:
         residualTolerance = np.sqrt(1e-15) * n
@@ -563,6 +571,9 @@ def lobpcg(A, X,
 
     aux = np.sum(blockVectorR.conjugate() * blockVectorR, 0)
     residualNorms = np.sqrt(aux)
+
+    #if largest:
+        #_lambda = -_lambda
 
     if verbosityLevel > 0:
         print('final eigenvalue:', _lambda)

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -291,13 +291,12 @@ def lobpcg(A, X,
     if sizeX > n:
         raise ValueError('X column dimension exceeds the row dimension')
 
-    A = _makeOperator(A, (n,n))
     B = _makeOperator(B, (n,n))
     M = _makeOperator(M, (n,n))
 
     if (n - sizeY) < (5 * sizeX):
 
-        #A = _makeOperator(A, (n,n))
+        A = _makeOperator(A, (n,n))
 
         # warn('The problem size is small compared to the block size.' \
         #        ' Using dense eigensolver instead of LOBPCG.')
@@ -316,10 +315,10 @@ def lobpcg(A, X,
         B_dense = None if B is None else B(np.eye(n))
         return eigh(A_dense, B_dense, eigvals=eigvals, check_finite=False)
 
-    #if largest:
-        #A = _makeOperator(-A, (n,n))
-    #else:
-        #A = _makeOperator(A, (n,n))
+    if largest:
+        A = _makeOperator(-A, (n,n))
+    else:
+        A = _makeOperator(A, (n,n))
 
     if residualTolerance is None:
         residualTolerance = np.sqrt(1e-15) * n
@@ -379,8 +378,6 @@ def lobpcg(A, X,
 
     _lambda, eigBlockVector = eigh(gramXAX, check_finite=False)
     ii = np.argsort(_lambda)[:sizeX]
-    if largest:
-        ii = ii[::-1]
     _lambda = _lambda[ii]
 
     eigBlockVector = np.asarray(eigBlockVector[:,ii])
@@ -509,8 +506,6 @@ def lobpcg(A, X,
         # Solve the generalized eigenvalue problem.
         _lambda, eigBlockVector = eigh(gramA, gramB, check_finite=False)
         ii = np.argsort(_lambda)[:sizeX]
-        if largest:
-            ii = ii[::-1]
         if verbosityLevel > 10:
             print(ii)
 
@@ -572,8 +567,9 @@ def lobpcg(A, X,
     aux = np.sum(blockVectorR.conjugate() * blockVectorR, 0)
     residualNorms = np.sqrt(aux)
 
-    #if largest:
-        #_lambda = -_lambda
+    if largest:
+        _lambda = -_lambda[::-1]
+        blockVectorX = np.fliplr(blockVectorX)
 
     if verbosityLevel > 0:
         print('final eigenvalue:', _lambda)

--- a/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
@@ -117,7 +117,6 @@ def test_eigenvalue_order():
         assert_allclose(w, d[-k:])
 
 
-
 def test_diagonal():
     # This test was moved from '__main__' in lobpcg.py.
     # Coincidentally or not, this is the same eigensystem

--- a/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
@@ -88,6 +88,20 @@ def test_regression():
     assert_allclose(w, [1])
 
 
+def test_eigenvalue_order():
+    # https://github.com/scipy/scipy/issues/4174
+    n = 99
+    d = np.arange(1, n+1)
+    A = np.diag(d)
+    for k in 6, 20:
+        x = np.random.rand(n, k)
+        w, v = lobpcg(A, x, tol=1e-5, maxiter=20000, largest=False)
+        assert_allclose(w, d[:k])
+        w, v = lobpcg(A, x, tol=1e-5, maxiter=20000, largest=True)
+        assert_allclose(w, d[-k:])
+
+
+
 def test_diagonal():
     # This test was moved from '__main__' in lobpcg.py.
     # Coincidentally or not, this is the same eigensystem


### PR DESCRIPTION
Should close https://github.com/scipy/scipy/issues/4174.

This bug caused lobpcg to give eigenpairs at the wrong end of the spectrum under a common usage (default flags and random thin `x`).
