### PR TITLE
BUG: special: fix up ellip_harm build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,7 @@ scipy/sparse/sparsetools/other_impl.h
 scipy/sparse/sparsetools/sparsetools_impl.h
 scipy/spatial/ckdtree.c
 scipy/spatial/qhull.c
+scipy/special/_ellip_harm_2.c
 scipy/special/_logit.c
 scipy/special/_ufuncs.c
 scipy/special/_ufuncs.h

--- a/scipy/special/_ellip_harm_2.pyx
+++ b/scipy/special/_ellip_harm_2.pyx
@@ -184,3 +184,21 @@ def _ellipsoid_norm(double h2, double k2, int n, int p):
     if  error > 10e-8*fabs(result):
         return nan 
     return result
+
+
+# Needed for the _sf_error calls in _ellip_harm.pxd
+
+cimport numpy as np
+
+np.import_array()
+np.import_ufunc()
+
+cdef extern from "numpy/ufuncobject.h":
+    int PyUFunc_getfperr() nogil
+
+cdef public int wrap_PyUFunc_getfperr() nogil:
+    """
+    Call PyUFunc_getfperr in a context where PyUFunc_API array is initialized;
+    this avoids messing with the UNIQUE_SYMBOL #defines
+    """
+    return PyUFunc_getfperr()

--- a/scipy/special/bento.info
+++ b/scipy/special/bento.info
@@ -39,10 +39,4 @@ Library:
     Extension: _ellip_harm_2
         Sources:
             _ellip_harm_2.c,
-            _ufuncs.c,
-            Faddeeva.cc,
-            sf_error.c,
-            _logit.c.src,
-            cdf_wrappers.c,
-            specfun_wrappers.c,
-            amos_wrappers.c
+            sf_error.c

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -98,10 +98,9 @@ def configuration(parent_package='',top_path=None):
                          define_macros=define_macros,
                          extra_info=get_info("npymath"))
 
+    cfg = dict(get_system_info('lapack_opt'))
     config.add_extension('_ellip_harm_2',
-                         sources=['_ellip_harm_2.c', '_ufuncs.c',
-                                  'Faddeeva.cc','sf_error.c','_logit.c.src',"cdf_wrappers.c",
-                                  "specfun_wrappers.c","amos_wrappers.c"],
+                         sources=['_ellip_harm_2.c', 'sf_error.c',],
                          **cfg
                          )
 


### PR DESCRIPTION
The ellip_harm build in special links in too many files, fix this up.
(Doesn't build in win32 due to mixing c++ and fortran.)
