### PR TITLE
BLD: fix msvc compiler errors

### DIFF
--- a/scipy/integrate/tests/_test_multivariate.c
+++ b/scipy/integrate/tests/_test_multivariate.c
@@ -21,19 +21,19 @@
 #include "math.h"
 const double PI = 3.141592653589793238462643383279502884;
 EXPORT(double)
-_multivariate_typical(int n, double args[n])
+_multivariate_typical(int n, double *args)
 {
     return cos(args[1] * args[0] - args[2] * sin(args[0])) / PI;
 }
 
 EXPORT(double)
-_multivariate_indefinite(int n, double args[n])
+_multivariate_indefinite(int n, double *args)
 {
     return -exp(-args[0]) * log(args[0]);
 }
 
 EXPORT(double)
-_multivariate_sin(int n, double args[n])
+_multivariate_sin(int n, double *args)
 {
     return sin(args[0]);
 }
@@ -64,7 +64,7 @@ PyInit__test_multivariate(void)
 
 #else
 
-EXPORT(void)
+PyMODINIT_FUNC
 init_test_multivariate(void)
 {
     Py_InitModule("_test_multivariate", NULL);


### PR DESCRIPTION
```
_test_multivariate.c
scipy\integrate\tests\_test_multivariate.c(24) : error C2057: expected constant expression
scipy\integrate\tests\_test_multivariate.c(24) : error C2466: cannot allocate an array of constant size 0
scipy\integrate\tests\_test_multivariate.c(30) : error C2057: expected constant expression
scipy\integrate\tests\_test_multivariate.c(30) : error C2466: cannot allocate an array of constant size 0
scipy\integrate\tests\_test_multivariate.c(36) : error C2057: expected constant expression
scipy\integrate\tests\_test_multivariate.c(36) : error C2466: cannot allocate an array of constant size 0
```
