### PR TITLE
BUG: fix buffer dtype mismatch on win-amd64

### DIFF
--- a/scipy/signal/_max_len_seq.pyx
+++ b/scipy/signal/_max_len_seq.pyx
@@ -73,9 +73,9 @@ def max_len_seq(nbits, state=None, length=None, taps=None):
             known_taps = np.array(list(_mls_taps.keys()))
             raise ValueError('nbits must be between %s and %s if taps is None'
                              % (known_taps.min(), known_taps.max()))
-        taps = np.array(_mls_taps[nbits], int)
+        taps = np.array(_mls_taps[nbits], np.intp)
     else:
-        taps = np.unique(np.array(taps, int))[::-1]
+        taps = np.unique(np.array(taps, np.intp))[::-1]
         if np.any(taps < 0) or np.any(taps > nbits) or taps.size < 1:
             raise ValueError('taps must be non-empty with values between '
                              'zero and nbits (inclusive)')


### PR DESCRIPTION
Using scipy-0.15.0b1.win-amd64-py3.4:

```
======================================================================
ERROR: test_mls_inputs (test_max_len_seq.TestMLS)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\scipy\signal\tests\test_max_len_seq.py", line 22, in test_mls_inputs
    assert_array_equal(max_len_seq(10, length=0)[0], [])
  File "scipy\signal\_max_len_seq.pyx", line 104, in scipy.signal._max_len_seq.max_len_seq (scipy\signal\_max_len_seq.c:2172)
ValueError: Buffer dtype mismatch, expected 'Py_ssize_t' but got 'long'

======================================================================
ERROR: test_mls_output (test_max_len_seq.TestMLS)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\scipy\signal\tests\test_max_len_seq.py", line 39, in test_mls_output
    taps=taps)[0]
  File "scipy\signal\_max_len_seq.pyx", line 104, in scipy.signal._max_len_seq.max_len_seq (scipy\signal\_max_len_seq.c:2172)
ValueError: Buffer dtype mismatch, expected 'Py_ssize_t' but got 'long'
```
