### PR TITLE
MRG: fix permissions error in netcdf tests

### DIFF
--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -17,6 +17,8 @@ from scipy.io.netcdf import netcdf_file
 
 from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 
+from scipy.lib._tmpdirs import in_tempdir
+
 TEST_DATA_PATH = pjoin(dirname(__file__), 'data')
 
 N_EG_ELS = 11  # number of elements for example variable
@@ -264,37 +266,34 @@ def test_zero_dimensional_var():
 def test_byte_gatts():
     # Check that global "string" atts work like they did before py3k
     # unicode and general bytes confusion
-    filename = pjoin(TEST_DATA_PATH, 'g_byte_atts.nc')
-    f = netcdf_file(filename, 'w')
-    f._attributes['holy'] = b'grail'
-    f._attributes['witch'] = 'floats'
-    f.close()
-
-    f = netcdf_file(filename, 'r')
-    assert_equal(f._attributes['holy'], b'grail')
-    assert_equal(f._attributes['witch'], b'floats')
-    f.close()
-
-    os.remove(filename)
+    with in_tempdir():
+        filename = 'g_byte_atts.nc'
+        f = netcdf_file(filename, 'w')
+        f._attributes['holy'] = b'grail'
+        f._attributes['witch'] = 'floats'
+        f.close()
+        f = netcdf_file(filename, 'r')
+        assert_equal(f._attributes['holy'], b'grail')
+        assert_equal(f._attributes['witch'], b'floats')
+        f.close()
 
 
 def test_open_append():
     # open 'w' put one attr
-    filename = pjoin(TEST_DATA_PATH, 'append_dat.nc')
-    f = netcdf_file(filename, 'w')
-    f._attributes['Kilroy'] = 'was here'
-    f.close()
+    with in_tempdir():
+        filename = 'append_dat.nc'
+        f = netcdf_file(filename, 'w')
+        f._attributes['Kilroy'] = 'was here'
+        f.close()
 
-    # open again in 'a', read the att and and a new one
-    f = netcdf_file(filename, 'a')
-    assert_equal(f._attributes['Kilroy'], b'was here')
-    f._attributes['naughty'] = b'Zoot'
-    f.close()
+        # open again in 'a', read the att and and a new one
+        f = netcdf_file(filename, 'a')
+        assert_equal(f._attributes['Kilroy'], b'was here')
+        f._attributes['naughty'] = b'Zoot'
+        f.close()
 
-    # open yet again in 'r' and check both atts
-    f = netcdf_file(filename, 'r')
-    assert_equal(f._attributes['Kilroy'], b'was here')
-    assert_equal(f._attributes['naughty'], b'Zoot')
-    f.close()
-
-    os.remove(filename)
+        # open yet again in 'r' and check both atts
+        f = netcdf_file(filename, 'r')
+        assert_equal(f._attributes['Kilroy'], b'was here')
+        assert_equal(f._attributes['naughty'], b'Zoot')
+        f.close()

--- a/scipy/lib/_tmpdirs.py
+++ b/scipy/lib/_tmpdirs.py
@@ -1,0 +1,87 @@
+''' Contexts for *with* statement providing temporary directories
+'''
+from __future__ import division, print_function, absolute_import
+import os
+from contextlib import contextmanager
+from shutil import rmtree
+from tempfile import mkdtemp
+
+
+@contextmanager
+def tempdir():
+    """Create and return a temporary directory.  This has the same
+    behavior as mkdtemp but can be used as a context manager.
+
+    Upon exiting the context, the directory and everthing contained
+    in it are removed.
+
+    Examples
+    --------
+    >>> import os
+    >>> with tempdir() as tmpdir:
+    ...     fname = os.path.join(tmpdir, 'example_file.txt')
+    ...     with open(fname, 'wt') as fobj:
+    ...         _ = fobj.write('a string\\n')
+    >>> os.path.exists(tmpdir)
+    False
+    """
+    d = mkdtemp()
+    yield d
+    rmtree(d)
+
+
+@contextmanager
+def in_tempdir():
+    ''' Create, return, and change directory to a temporary directory
+
+    Examples
+    --------
+    >>> import os
+    >>> my_cwd = os.getcwd()
+    >>> with in_tempdir() as tmpdir:
+    ...     _ = open('test.txt', 'wt').write('some text')
+    ...     assert os.path.isfile('test.txt')
+    ...     assert os.path.isfile(os.path.join(tmpdir, 'test.txt'))
+    >>> os.path.exists(tmpdir)
+    False
+    >>> os.getcwd() == my_cwd
+    True
+    '''
+    pwd = os.getcwd()
+    d = mkdtemp()
+    os.chdir(d)
+    yield d
+    os.chdir(pwd)
+    rmtree(d)
+
+
+@contextmanager
+def in_dir(dir=None):
+    """ Change directory to given directory for duration of ``with`` block
+
+    Useful when you want to use `in_tempdir` for the final test, but
+    you are still debugging.  For example, you may want to do this in the end:
+
+    >>> with in_tempdir() as tmpdir:
+    ...     # do something complicated which might break
+    ...     pass
+
+    But indeed the complicated thing does break, and meanwhile the
+    ``in_tempdir`` context manager wiped out the directory with the
+    temporary files that you wanted for debugging.  So, while debugging, you
+    replace with something like:
+
+    >>> with in_dir() as tmpdir: # Use working directory by default
+    ...     # do something complicated which might break
+    ...     pass
+
+    You can then look at the temporary file outputs to debug what is happening,
+    fix, and finally replace ``in_dir`` with ``in_tempdir`` again.
+    """
+    cwd = os.getcwd()
+    if dir is None:
+        yield cwd
+        return
+    os.chdir(dir)
+    yield dir
+    os.chdir(cwd)

--- a/scipy/lib/tests/test_tmpdirs.py
+++ b/scipy/lib/tests/test_tmpdirs.py
@@ -1,0 +1,43 @@
+""" Test tmpdirs module """
+from __future__ import division, print_function, absolute_import
+
+from os import getcwd
+from os.path import realpath, abspath, dirname, isfile, join as pjoin, exists
+
+from scipy.lib._tmpdirs import tempdir, in_tempdir, in_dir
+
+from nose.tools import assert_true, assert_false, assert_equal
+
+MY_PATH = abspath(__file__)
+MY_DIR = dirname(MY_PATH)
+
+
+def test_tempdir():
+    with tempdir() as tmpdir:
+        fname = pjoin(tmpdir, 'example_file.txt')
+        with open(fname, 'wt') as fobj:
+            _ = fobj.write('a string\\n')
+    assert_false(exists(tmpdir))
+
+
+def test_in_tempdir():
+    my_cwd = getcwd()
+    with in_tempdir() as tmpdir:
+        _ = open('test.txt', 'wt').write('some text')
+        assert_true(isfile('test.txt'))
+        assert_true(isfile(pjoin(tmpdir, 'test.txt')))
+    assert_false(exists(tmpdir))
+    assert_equal(getcwd(), my_cwd)
+
+
+def test_given_directory():
+    # Test InGivenDirectory
+    cwd = getcwd()
+    with in_dir() as tmpdir:
+        assert_equal(tmpdir, abspath(cwd))
+        assert_equal(tmpdir, abspath(getcwd()))
+    with in_dir(MY_DIR) as tmpdir:
+        assert_equal(tmpdir, MY_DIR)
+        assert_equal(realpath(MY_DIR), realpath(abspath(getcwd())))
+    # We were deleting the Given directory!  Check not so now.
+    assert_true(isfile(MY_PATH))


### PR DESCRIPTION
Netcdf tests failing when installed into system directories because the
tests are writing to the scipy/io/tests/data directory.

Add temporary directory context manager (from nibabel) and use it for
writing the test files.
