### PR TITLE
ENH: Changed scipy.stats.describe output from datalen to nobs

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1088,7 +1088,7 @@ def kurtosis(a, axis=0, fisher=True, bias=True):
         return vals
 
 
-_DescribeResult = namedtuple('DescribeResult', ('datalen', 'minmax', 'mean',
+_DescribeResult = namedtuple('DescribeResult', ('nobs', 'minmax', 'mean',
                                                 'variance', 'skewness',
                                                 'kurtosis'))
 
@@ -1109,8 +1109,8 @@ def describe(a, axis=0, ddof=1):
 
     Returns
     -------
-    datalen : int
-       Length of data along `axis`.
+    nobs : int
+       Number of observations (length of data along `axis`).
     minmax: tuple of ndarrays or floats
        Minimum and maximum value of data array.
     mean : ndarray or float

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2217,7 +2217,7 @@ class TestDescribe(TestCase):
 
     def test_describe_result_attributes(self):
         actual = stats.describe(np.arange(5))
-        attributes = ('datalen', 'minmax', 'mean', 'variance', 'skewness',
+        attributes = ('nobs', 'minmax', 'mean', 'variance', 'skewness',
                       'kurtosis')
         for i, attr in enumerate(attributes):
             assert_equal(actual[i], getattr(actual, attr))


### PR DESCRIPTION
Addresses #4192 for `scipy.stats`

Small change from `datalen` to `nobs` for consistency with statsmodels as suggested by @josef-pkt.

cc @rgommers
