### PR TITLE
BLD: fix a number of Bento build warnings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,7 @@ scipy/sparse/sparsetools/sparsetools_impl.h
 scipy/spatial/ckdtree.c
 scipy/spatial/qhull.c
 scipy/special/_ellip_harm_2.c
+scipy/special/_ellip_harm_2.h
 scipy/special/_logit.c
 scipy/special/_ufuncs.c
 scipy/special/_ufuncs.h

--- a/scipy/special/bscript
+++ b/scipy/special/bscript
@@ -18,10 +18,10 @@ def pre_build(context):
     context.tweak_extension("_ufuncs_cxx", features="cxx cxxshlib pyext bento",
                             use="NPYMATH")
 
-    context.waf_context.env.INCLUDES.append("c_misc")
     context.tweak_extension("_ufuncs",
                             use="sc_amos sc_c_misc sc_cephes sc_mach sc_cdf "\
-                                "sc_specfun NPYMATH CLIB LAPACK")
+                                "sc_specfun NPYMATH CLIB LAPACK",
+                            includes=["c_misc"])
 
     context.tweak_extension("_ellip_harm_2",
                             use="sc_amos sc_c_misc sc_cephes sc_mach sc_cdf "\


### PR DESCRIPTION
c_misc was first added to includes for all modules, not just when needed.

Also update .gitignore for missing generated _ellip_harm_2.h file.

[ci skip]
