### PR TITLE
MRG:fix for gh-4208

### DIFF
--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -743,7 +743,8 @@ class VarWriter5(object):
                           mxSPARSE_CLASS,
                           is_complex=is_complex,
                           is_logical=is_logical,
-                          nzmax=nz)
+                          # matlab won't load file with 0 nzmax
+                          nzmax=1 if nz == 0 else nz)
         self.write_element(A.indices.astype('i4'))
         self.write_element(A.indptr.astype('i4'))
         self.write_element(A.data.real)

--- a/scipy/io/matlab/mio5_utils.pyx
+++ b/scipy/io/matlab/mio5_utils.pyx
@@ -126,7 +126,7 @@ cdef class VarHeader5:
     cdef int is_complex
     cdef readonly int is_logical
     cdef public int is_global
-    cdef size_t nzmax
+    cdef readonly size_t nzmax
 
     def set_dims(self, dims):
         """ Allow setting of dimensions from python

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1048,6 +1048,14 @@ def test_empty_sparse():
     res = loadmat(sio)
     assert_array_equal(res['x'].shape, empty_sparse.shape)
     assert_array_equal(res['x'].todense(), 0)
+    # Do empty sparse matrices get written with max nnz 1?
+    # See https://github.com/scipy/scipy/issues/4208
+    sio.seek(0)
+    reader = MatFile5Reader(sio)
+    reader.initialize_read()
+    reader.read_file_header()
+    hdr, _ = reader.read_var_header()
+    assert_equal(hdr.nzmax, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Write max number of non-zeros as 1 when sparse matrix is empty.  Otherwise
MATLAB does not want to read the written array.
