### PR TITLE
attempt to make ndimage interpolation compatible with numpy relaxed strides checking

### DIFF
--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -850,7 +850,7 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
         size *= output->dimensions[qq];
     for(kk = 0; kk < size; kk++) {
         double t = 0.0;
-        int edge = 0, oo = 0, zero = 0;
+        npy_intp edge = 0, oo = 0, zero = 0;
 
         for(hh = 0; hh < rank; hh++) {
             if (zeros && zeros[hh][io.coordinates[hh]]) {

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -782,10 +782,10 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
                         } else {
                             npy_intp s2 = 2 * len - 2;
                             if (idx < 0) {
-                                idx = s2 * (int)(-idx / s2) + idx;
+                                idx = s2 * (npy_intp)(-idx / s2) + idx;
                                 idx = idx <= 1 - len ? idx + s2 : -idx;
                             } else if (idx >= len) {
-                                idx -= s2 * (int)(idx / s2);
+                                idx -= s2 * (npy_intp)(idx / s2);
                                 if (idx >= len)
                                     idx = s2 - idx;
                             }


### PR DESCRIPTION
Changes a few lines in `ni_interpolation.c` according to https://github.com/scipy/scipy/issues/3733#issuecomment-65039012 and https://github.com/numpy/numpy/issues/4681#issuecomment-65045720. This works for me locally.  If this PR passes TravisCI checking then this would be evidence that it does not introduce regressions, but it would not say anything about fixing the compatibility with numpy relaxed strides checking.  Currently the scipy TravisCI does not have a configuration that checks this numpy build option which is enabled by default in the numpy development branch.
