### PR TITLE
DOC: silence several Sphinx warnings when building the docs

### DIFF
--- a/doc/source/tutorial/fftpack.rst
+++ b/doc/source/tutorial/fftpack.rst
@@ -15,7 +15,7 @@ counterparts, it is called the discrete Fourier transform (DFT).  The DFT has
 become a mainstay of numerical computing in part because of a very fast
 algorithm for computing it, called the Fast Fourier Transform (FFT), which was
 known to Gauss (1805) and was brought to light in its current form by Cooley
-and Tukey [CT]_.  Press et al. [NR]_ provide an accessible introduction to
+and Tukey [CT65]_.  Press et al. [NR]_ provide an accessible introduction to
 Fourier analysis and its applications.
 
 
@@ -475,7 +475,7 @@ dst(type=3), idst(type=3), and idst(type=3) (``*dst2_cache``).
 References
 ----------
 
-.. [CT] Cooley, James W., and John W. Tukey, 1965, "An algorithm for the
+.. [CT65] Cooley, James W., and John W. Tukey, 1965, "An algorithm for the
         machine calculation of complex Fourier series," *Math. Comput.*
         19: 297-301.
 

--- a/doc/source/tutorial/ndimage.rst
+++ b/doc/source/tutorial/ndimage.rst
@@ -1674,10 +1674,10 @@ provided to these functions must match exactly that what they
 expect. Therefore we give here the prototypes of the callback
 functions. All these callback functions accept a void
 *callback_data* pointer that must be wrapped in a :ctype:`PyCObject` using
-the Python :cfunc:`PyCObject_FromVoidPtrAndDesc` function, which can also
+the Python :c:func:`PyCObject_FromVoidPtrAndDesc` function, which can also
 accept a pointer to a destructor function to free any memory
 allocated for *callback_data*. If *callback_data* is not needed,
-:cfunc:`PyCObject_FromVoidPtr` may be used instead. The callback
+:c:func:`PyCObject_FromVoidPtr` may be used instead. The callback
 functions must return an integer error status that is equal to zero
 if something went wrong, or 1 otherwise. If an error occurs, you
 should normally set the python error status with an informative

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -447,7 +447,7 @@ As an example consider the following system:
 
 The code calculates the signal :math:`y[n]` for a given signal :math:`x[n]`;
 first for initial condiditions :math:`y[-1] = 0` (default case), then for
-:math:`y[-1] = 2` by means of :fun:`lfiltic`.
+:math:`y[-1] = 2` by means of :func:`lfiltic`.
 
 >>> import numpy as np
 >>> from scipy import signal

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -108,7 +108,7 @@ class netcdf_file(object):
     version : {1, 2}, optional
         version of netcdf to read / write, where 1 means *Classic
         format* and 2 means *64-bit offset format*.  Default is 1.  See
-        `here <http://www.unidata.ucar.edu/software/netcdf/docs/netcdf/Which-Format.html>`_
+        `here <http://www.unidata.ucar.edu/software/netcdf/docs/netcdf/Which-Format.html>`__
         for more info.
 
     Notes
@@ -120,7 +120,7 @@ class netcdf_file(object):
     NetCDF files are a self-describing binary data format. The file contains
     metadata that describes the dimensions and variables in the file. More
     details about NetCDF files can be found `here
-    <http://www.unidata.ucar.edu/software/netcdf/docs/netcdf.html>`_. There
+    <http://www.unidata.ucar.edu/software/netcdf/docs/netcdf.html>`__. There
     are three main sections to a NetCDF data structure:
 
     1. Dimensions

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -1,5 +1,4 @@
 r"""
-.. module:: scipy.optimize.nonlin
 
 =================
 Nonlinear solvers
@@ -822,7 +821,7 @@ class LowRankMatrix(object):
         Reduce the rank of the matrix by retaining some SVD components.
 
         This corresponds to the \"Broyden Rank Reduction Inverse\"
-        algorithm described in [vR]_.
+        algorithm described in [1]_.
 
         Note that the SVD decomposition can be done by solving only a
         problem whose size is the effective rank of this matrix, which
@@ -838,7 +837,7 @@ class LowRankMatrix(object):
 
         References
         ----------
-        .. [vR] B.A. van der Rotten, PhD thesis,
+        .. [1] B.A. van der Rotten, PhD thesis,
            \"A limited memory Broyden method to solve high-dimensional
            systems of nonlinear equations\". Mathematisch Instituut,
            Universiteit Leiden, The Netherlands (2003).
@@ -896,7 +895,7 @@ _doc_parts['broyden_params'] = """
             - ``restart``: drop all matrix columns. Has no extra parameters.
             - ``simple``: drop oldest matrix column. Has no extra parameters.
             - ``svd``: keep only the most significant SVD components.
-              Takes an extra parameter, ``to_retain`, which determines the
+              Takes an extra parameter, ``to_retain``, which determines the
               number of SVD components to retain when rank reduction is done.
               Default is ``max_rank - 2``.
 
@@ -931,7 +930,7 @@ class BroydenFirst(GenericBroyden):
 
     References
     ----------
-    .. [vR] B.A. van der Rotten, PhD thesis,
+    .. [1] B.A. van der Rotten, PhD thesis,
        \"A limited memory Broyden method to solve high-dimensional
        systems of nonlinear equations\". Mathematisch Instituut,
        Universiteit Leiden, The Netherlands (2003).
@@ -1021,7 +1020,7 @@ class BroydenSecond(BroydenFirst):
 
     References
     ----------
-    .. [vR] B.A. van der Rotten, PhD thesis,
+    .. [1] B.A. van der Rotten, PhD thesis,
        \"A limited memory Broyden method to solve high-dimensional
        systems of nonlinear equations\". Mathematisch Instituut,
        Universiteit Leiden, The Netherlands (2003).
@@ -1370,8 +1369,7 @@ class KrylovJacobian(Jacobian):
     This function implements a Newton-Krylov solver. The basic idea is
     to compute the inverse of the Jacobian with an iterative Krylov
     method. These methods require only evaluating the Jacobian-vector
-    products, which are conveniently approximated by numerical
-    differentiation:
+    products, which are conveniently approximated by a finite difference:
 
     .. math:: J v \approx (f(x + \omega*v/|v|) - f(x)) / \omega
 
@@ -1384,13 +1382,13 @@ class KrylovJacobian(Jacobian):
     information obtained in the previous Newton steps to invert
     Jacobians in subsequent steps.
 
-    For a review on Newton-Krylov methods, see for example [KK]_,
-    and for the LGMRES sparse inverse method, see [BJM]_.
+    For a review on Newton-Krylov methods, see for example [1]_,
+    and for the LGMRES sparse inverse method, see [2]_.
 
     References
     ----------
-    .. [KK] D.A. Knoll and D.E. Keyes, J. Comp. Phys. 193, 357 (2003).
-    .. [BJM] A.H. Baker and E.R. Jessup and T. Manteuffel,
+    .. [1] D.A. Knoll and D.E. Keyes, J. Comp. Phys. 193, 357 (2003).
+    .. [2] A.H. Baker and E.R. Jessup and T. Manteuffel,
              SIAM J. Matrix Anal. Appl. 26, 962 (2005).
 
     """

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -622,9 +622,9 @@ def check_grad(func, grad, x0, *args, **kwargs):
 
     Parameters
     ----------
-    func : callable func(x0,*args)
+    func : callable ``func(x0, *args)``
         Function whose derivative is to be checked.
-    grad : callable grad(x0, *args)
+    grad : callable ``grad(x0, *args)``
         Gradient of `func`.
     x0 : ndarray
         Points to check `grad` against forward difference approximation of grad
@@ -648,8 +648,10 @@ def check_grad(func, grad, x0, *args, **kwargs):
 
     Examples
     --------
-    >>> def func(x): return x[0]**2 - 0.5 * x[1]**3
-    >>> def grad(x): return [2 * x[0], -1.5 * x[1]**2]
+    >>> def func(x):
+            return x[0]**2 - 0.5 * x[1]**3
+    >>> def grad(x):
+            return [2 * x[0], -1.5 * x[1]**2]
     >>> check_grad(func, grad, [1.5, -1.5])
     2.9802322387695312e-08
 
@@ -2710,7 +2712,7 @@ def show_options(solver=None, method=None):
         gtol : float
             Precision goal for the value of the projected gradient in
             the stopping criterion (after applying x scaling factors).
-            If gtol < 0.0, gtol is set to 1e-2 * sqrt(accuracy).
+            If gtol < 0.0, gtol is set to ``1e-2 * sqrt(accuracy)``.
             Setting it to 0.0 is not recommended.  Defaults to -1.
         scale : list of floats
             Scaling factors to apply to each variable.  If None, the
@@ -2721,13 +2723,13 @@ def show_options(solver=None, method=None):
             offsets are (up+low)/2 for interval bounded variables
             and x for the others.
         maxCGit : int
-            Maximum number of hessian*vector evaluations per main
+            Maximum number of hessian times vector evaluations per main
             iteration.  If maxCGit == 0, the direction chosen is
             -gradient if maxCGit < 0, maxCGit is set to
             max(1,min(50,n/2)).  Defaults to -1.
         maxiter : int
             Maximum number of function evaluation.  if None, `maxiter` is
-            set to max(100, 10*len(x0)).  Defaults to None.
+            set to ``max(100, 10*len(x0))``.  Defaults to None.
         eta : float
             Severity of the line search. if < 0 or > 1, set to 0.25.
             Defaults to -1.
@@ -2905,7 +2907,7 @@ def show_options(solver=None, method=None):
                         - ``svd``: keep only the most significant SVD
                             components.
                           Extra parameters:
-                              - ``to_retain`: number of SVD components to
+                              - ``to_retain``: number of SVD components to
                                   retain when rank reduction is done.
                                   Default is ``max_rank - 2``.
                 max_rank : int, optional
@@ -2959,7 +2961,7 @@ def show_options(solver=None, method=None):
                     - ``svd``: keep only the most significant SVD
                         components.
                       Extra parameters:
-                          - ``to_retain`: number of SVD components to
+                          - ``to_retain``: number of SVD components to
                               retain when rank reduction is done.
                               Default is ``max_rank - 2``.
             max_rank : int, optional
@@ -3013,7 +3015,7 @@ def show_options(solver=None, method=None):
             Print status to stdout on every iteration.
         maxiter : int, optional
             Maximum number of iterations to make. If more are needed to
-            meet convergence, `NoConvergence` is raised.
+            meet convergence, ``NoConvergence`` is raised.
         ftol : float, optional
             Relative tolerance for the residual. If omitted, not used.
         fatol : float, optional

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -3,8 +3,6 @@
 Signal processing (:mod:`scipy.signal`)
 =======================================
 
-.. module:: scipy.signal
-
 Convolution
 ===========
 

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -188,18 +188,18 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
 
     diag_pivot_thresh : float, optional
         Threshold used for a diagonal entry to be an acceptable pivot.
-        See SuperLU user's guide for details [SLU]_
+        See SuperLU user's guide for details [1]_
     drop_tol : float, optional
         (deprecated) No effect.
     relax : int, optional
         Expert option for customizing the degree of relaxing supernodes.
-        See SuperLU user's guide for details [SLU]_
+        See SuperLU user's guide for details [1]_
     panel_size : int, optional
         Expert option for customizing the panel size.
-        See SuperLU user's guide for details [SLU]_
+        See SuperLU user's guide for details [1]_
     options : dict, optional
         Dictionary containing additional expert options to SuperLU.
-        See SuperLU user guide [SLU]_ (section 2.4 on the 'Options' argument)
+        See SuperLU user guide [1]_ (section 2.4 on the 'Options' argument)
         for more details. For example, you can specify
         ``options=dict(Equil=False, IterRefine='SINGLE'))``
         to turn equilibration off and perform a single iterative refinement.
@@ -219,7 +219,7 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
 
     References
     ----------
-    .. [SLU] SuperLU http://crd.lbl.gov/~xiaoye/SuperLU/
+    .. [1] SuperLU http://crd.lbl.gov/~xiaoye/SuperLU/
 
     """
 

--- a/scipy/sparse/linalg/isolve/lgmres.py
+++ b/scipy/sparse/linalg/isolve/lgmres.py
@@ -22,7 +22,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
     """
     Solve a matrix equation using the LGMRES algorithm.
 
-    The LGMRES algorithm [BJM]_ [BPh]_ is designed to avoid some problems
+    The LGMRES algorithm [1]_ [2]_ is designed to avoid some problems
     in the convergence in restarted GMRES, and often converges in fewer
     iterations.
 
@@ -52,7 +52,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
         Number of inner GMRES iterations per each outer iteration.
     outer_k : int, optional
         Number of vectors to carry between inner GMRES iterations.
-        According to [BJM]_, good values are in the range of 1...3.
+        According to [1]_, good values are in the range of 1...3.
         However, note that if you want to use the additional vectors to
         accelerate solving multiple similar problems, larger values may
         be beneficial.
@@ -81,7 +81,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
 
     Notes
     -----
-    The LGMRES algorithm [BJM]_ [BPh]_ is designed to avoid the
+    The LGMRES algorithm [1]_ [2]_ is designed to avoid the
     slowing of convergence in restarted GMRES, due to alternating
     residual vectors. Typically, it often outperforms GMRES(m) of
     comparable memory requirements by some measure, or at least is not
@@ -97,9 +97,9 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
 
     References
     ----------
-    .. [BJM] A.H. Baker and E.R. Jessup and T. Manteuffel,
+    .. [1] A.H. Baker and E.R. Jessup and T. Manteuffel,
              SIAM J. Matrix Anal. Appl. 26, 962 (2005).
-    .. [BPh] A.H. Baker, PhD thesis, University of Colorado (2003).
+    .. [2] A.H. Baker, PhD thesis, University of Colorado (2003).
              http://amath.colorado.edu/activities/thesis/allisonb/Thesis.ps
 
     """

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -1738,7 +1738,7 @@ cdef class cKDTree:
         Returns
         -------
         results : set
-            Set of pairs ``(i,j)``, with ``i < j`, for which the corresponding
+            Set of pairs ``(i,j)``, with ``i < j``, for which the corresponding
             positions are close.
 
         """

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -1586,10 +1586,11 @@ class Delaunay(_QhullUser):
         For simplices at the boundary, -1 denotes no neighbor.
     equations : ndarray of double, shape (nsimplex, ndim+2)
         [normal, offset] forming the hyperplane equation of the facet
-        on the paraboloid (see [Qhull]_ documentation for more).
+        on the paraboloid
+        (see `Qhull documentation <http://www.qhull.org/>`__ for more).
     paraboloid_scale, paraboloid_shift : float
         Scale and shift for the extra paraboloid dimension
-        (see [Qhull]_ documentation for more).
+        (see `Qhull documentation <http://www.qhull.org/>`__ for more).
     transform : ndarray of double, shape (nsimplex, ndim+1, ndim)
         Affine transform from ``x`` to the barycentric coordinates ``c``.
         This is defined by::
@@ -1644,7 +1645,8 @@ class Delaunay(_QhullUser):
 
     Notes
     -----
-    The tesselation is computed using the Qhull library [Qhull]_.
+    The tesselation is computed using the Qhull library 
+    `Qhull library <http://www.qhull.org/>`__.
 
     .. note::
 
@@ -1709,10 +1711,6 @@ class Delaunay(_QhullUser):
 
     The coordinates for the first point are all positive, meaning it
     is indeed inside the triangle.
-
-    References
-    ----------
-    .. [Qhull] http://www.qhull.org/
 
     """
 
@@ -2161,7 +2159,7 @@ class ConvexHull(_QhullUser):
         -1 denotes no neighbor.
     equations : ndarray of double, shape (nfacet, ndim+1)
         [normal, offset] forming the hyperplane equation of the facet
-        (see [Qhull]_ documentation for more).
+        (see `Qhull documentation <http://www.qhull.org/>`__  for more).
     coplanar : ndarray of int, shape (ncoplanar, 3)
         Indices of coplanar points and the corresponding indices of
         the nearest facets and nearest vertex indices.  Coplanar
@@ -2180,7 +2178,8 @@ class ConvexHull(_QhullUser):
 
     Notes
     -----
-    The convex hull is computed using the Qhull library [Qhull]_.
+    The convex hull is computed using the 
+    `Qhull library <http://www.qhull.org/>`__.
 
     Do not call the ``add_points`` method from a ``__del__``
     destructor.
@@ -2285,11 +2284,11 @@ class Voronoi(_QhullUser):
         Coordinates of input points.
     vertices : ndarray of double, shape (nvertices, ndim)
         Coordinates of the Voronoi vertices.
-    ridge_points : ndarray of ints, shape (nridges, 2)
+    ridge_points : ndarray of ints, shape ``(nridges, 2)``
         Indices of the points between which each Voronoi ridge lies.
-    ridge_vertices : list of list of ints, shape (nridges, *)
+    ridge_vertices : list of list of ints, shape ``(nridges, *)``
         Indices of the Voronoi vertices forming each Voronoi ridge.
-    regions : list of list of ints, shape (nregions, *)
+    regions : list of list of ints, shape ``(nregions, *)``
         Indices of the Voronoi vertices forming each Voronoi region.
         -1 indicates vertex outside the Voronoi diagram.
     point_region : list of ints, shape (npoints)
@@ -2307,7 +2306,8 @@ class Voronoi(_QhullUser):
 
     Notes
     -----
-    The Voronoi diagram is computed using the Qhull library [Qhull]_.
+    The Voronoi diagram is computed using the 
+    `Qhull library <http://www.qhull.org/>`__.
 
     Do not call the ``add_points`` method from a ``__del__``
     destructor.
@@ -2359,10 +2359,6 @@ class Voronoi(_QhullUser):
            [2, 1],
            [4, 1],
            [4, 7]], dtype=int32)
-
-    References
-    ----------
-    .. [Qhull] http://www.qhull.org/
 
     """
     def __init__(self, points, furthest_site=False, incremental=False,

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -363,12 +363,12 @@ The following functions evaluate values of orthogonal polynomials:
    eval_sh_jacobi
 
 The functions below, in turn, return the polynomial coefficients in
-:ref:`orthopoly1d` objects, which function similarly as :ref:`numpy.poly1d`.
-The :ref:`orthopoly1d` class also has an attribute ``weights`` which returns
+:class:`~.orthopoly1d` objects, which function similarly as :ref:`numpy.poly1d`.
+The :class:`~.orthopoly1d` class also has an attribute ``weights`` which returns
 the roots, weights, and total weights for the appropriate form of Gaussian
 quadrature.  These are returned in an ``n x 3`` array with roots in the first
 column, weights in the second column, and total weights in the final column.
-Note that ``orthopoly1d`` objects are converted to ``poly1d`` when doing
+Note that :class:`~.orthopoly1d` objects are converted to ``poly1d`` when doing
 arithmetic, and lose information of the original orthogonal polynomial.
 
 .. autosummary::

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -9133,7 +9133,7 @@ cdef char *ufunc_pro_rad2_doc = (
     "\n"
     "Computes the prolate spheroidal radial function of the second kind\n"
     "and its derivative (with respect to x) for mode parameters m>=0\n"
-    "and n>=m, spheroidal parameter c and |x|<1.0.\n"
+    "and n>=m, spheroidal parameter c and ``|x| < 1.0``.\n"
     "\n"
     "Returns\n"
     "-------\n"

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -2847,7 +2847,7 @@ add_newdoc("scipy.special", "pro_rad2",
 
     Computes the prolate spheroidal radial function of the second kind
     and its derivative (with respect to x) for mode parameters m>=0
-    and n>=m, spheroidal parameter c and |x|<1.0.
+    and n>=m, spheroidal parameter c and ``|x| < 1.0``.
 
     Returns
     -------

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -491,7 +491,7 @@ def hyp0f1(v, z):
     .. math:: _0F_1(v,z) = \sum_{k=0}^{\inf}\frac{z^k}{(v)_k k!}.
 
     It's also the limit as q -> infinity of ``1F1(q;v;z/q)``, and satisfies
-    the differential equation :math:``f''(z) + vf'(z) = f(z)`.
+    the differential equation :math:`f''(z) + vf'(z) = f(z)`.
     """
     v = atleast_1d(v)
     z = atleast_1d(z)
@@ -688,7 +688,7 @@ def lpmn(m,n,z):
     return p,pd
 
 
-def clpmn(m,n,z,type=3):
+def clpmn(m, n, z, type=3):
     """Associated Legendre function of the first kind, Pmn(z)
 
     Computes the (associated) Legendre function of the first kind
@@ -712,15 +712,15 @@ def clpmn(m,n,z,type=3):
         Input value.
     type : int
        takes values 2 or 3
-       2: cut on the real axis |x|>1
-       3: cut on the real axis -1<x<1 (default)
+       2: cut on the real axis ``|x| > 1``
+       3: cut on the real axis ``-1 < x < 1`` (default)
 
     Returns
     -------
     Pmn_z : (m+1, n+1) array
-       Values for all orders 0..m and degrees 0..n
+       Values for all orders ``0..m`` and degrees ``0..n``
     Pmn_d_z : (m+1, n+1) array
-       Derivatives for all orders 0..m and degrees 0..n
+       Derivatives for all orders ``0..m`` and degrees ``0..n``
 
     See Also
     --------
@@ -734,7 +734,7 @@ def clpmn(m,n,z,type=3):
     factor with respect to Ferrer's function of the first kind
     (cf. `lpmn`).
 
-    For ``type=2`` a cut at |x|>1 is chosen. Approaching the real values
+    For ``type=2`` a cut at ``|x| > 1`` is chosen. Approaching the real values
     on the interval (-1, 1) in the complex plane yields Ferrer's function
     of the first kind.
 

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1848,8 +1848,8 @@ def obrientransform(*args):
     """
     Computes a transform on input data (any number of columns).  Used to
     test for homogeneity of variance prior to running one-way stats.  Each
-    array in *args is one level of a factor.  If an F_oneway() run on the
-    transformed data and found significant, variances are unequal.   From
+    array in ``*args`` is one level of a factor.  If an `f_oneway()` run on
+    the transformed data and found significant, variances are unequal.   From
     Maxwell and Delaney, p.112.
 
     Returns: transformed data for use in an ANOVA
@@ -1949,7 +1949,8 @@ def f_oneway(*args):
     any number of groups.  From Heiman, pp.394-7.
 
     Usage: ``f_oneway(*args)``, where ``*args`` is 2 or more arrays,
-                                one per treatment group.
+    one per treatment group.
+
     Returns: f-value, probability
 
     """

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -997,11 +997,11 @@ def skew(a, axis=0, bias=True):
 
     References
     ----------
-    [CRCProbStat2000]_ Section 2.2.24.1
 
-    .. [CRCProbStat2000] Zwillinger, D. and Kokoska, S. (2000). CRC Standard
+    .. [1] Zwillinger, D. and Kokoska, S. (2000). CRC Standard
        Probability and Statistics Tables and Formulae. Chapman & Hall: New
        York. 2000.
+       Section 2.2.24.1
 
     """
     a, axis = _chk_asarray(a,axis)
@@ -2690,11 +2690,11 @@ def spearmanr(a, b=None, axis=0):
 
     References
     ----------
-    [CRCProbStat2000]_ Section  14.7
 
-    .. [CRCProbStat2000] Zwillinger, D. and Kokoska, S. (2000). CRC Standard
+    .. [1] Zwillinger, D. and Kokoska, S. (2000). CRC Standard
        Probability and Statistics Tables and Formulae. Chapman & Hall: New
        York. 2000.
+       Section  14.7
 
     Examples
     --------


### PR DESCRIPTION
Fixes some twenty-odd Sphinx errors/warnings, mostly typos, unshielded markup (*, | etc), and complaints about duplicate references. The latter seem to be related to the fact that numpydoc mangles the numeric references, but not abbreviations, so that eg `[1]_` gets a unique number, but `[CT]_` does not.

No attempt is made at `document not included in any toctree` warnings of https://github.com/scipy/scipy/pull/3893

Done with @dimazest and @itziakos during the Bloomberg hackathon last Sunday.
@dimazest you have more fixes in your fork, correct?
