### PR TITLE
BLD: use NPY_RELAXED_STRIDES_CHECKING for one TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,24 @@ matrix:
         - TESTMODE=fast
         - COVERAGE=
         - NUMPYSPEC=
+        - NPY_RELAXED_STRIDES_CHECKING=0
     - python: 3.3
       env:
         - TESTMODE=fast
         - COVERAGE=
         - NUMPYSPEC=
+        - NPY_RELAXED_STRIDES_CHECKING=0
     - python: 2.7
       env:
         - TESTMODE=full
         - COVERAGE=--coverage
+        - NPY_RELAXED_STRIDES_CHECKING=0
     - python: 2.6
       env:
         - TESTMODE=fast
         - NUMPYSPEC===1.5.1
         - OPTIMIZE=-OO
+        - NPY_RELAXED_STRIDES_CHECKING=0
     - python: 2.7
       env:
         - TESTMODE=fast
@@ -32,6 +36,7 @@ matrix:
       env:
         - PYFLAKES=1
         - PEP8=1
+        - NPY_RELAXED_STRIDES_CHECKING=0
       before_install:
         - pip install pep8==1.5.1
         - pip install pyflakes
@@ -61,7 +66,8 @@ before_install:
   # Speed up install by not compiling Cython
   - pip install --install-option="--no-cython-compile" Cython
     # Install numpy and report one of its compilation settings.
-  - pip install numpy$NUMPYSPEC
+  - if [ NPY_RELAXED_STRIDES_CHECKING = 0 ]; pip install numpy$NUMPYSPEC; fi
+  - if [ NPY_RELAXED_STRIDES_CHECKING = 1 ]; pip install --upgrade git+git://github.com/numpy/numpy.git@v1.9.1; fi
   - python -c 'import numpy as np; print("relaxed strides checking:", np.ones((10,1),order="C").flags.f_contiguous)'
   - pip install nose mpmath argparse
   - pip install gmpy2  # speeds up mpmath (scipy.special tests)

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,12 @@ matrix:
         - OPTIMIZE=-OO
     - python: 2.7
       env:
+        - TESTMODE=fast
+        - COVERAGE=
+        - NUMPYSPEC=
+        - NPY_RELAXED_STRIDES_CHECKING=1
+    - python: 2.7
+      env:
         - PYFLAKES=1
         - PEP8=1
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
       env:
         - TESTMODE=fast
         - COVERAGE=
-        - NUMPYSPEC=1.8.2
+        - NUMPYSPEC=
         - NPY_RELAXED_STRIDES_CHECKING=1
     - python: 2.7
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       env:
         - TESTMODE=fast
         - COVERAGE=
-        - NUMPYSPEC=
+        - NUMPYSPEC=1.8.2
         - NPY_RELAXED_STRIDES_CHECKING=1
     - python: 2.7
       env:
@@ -60,7 +60,9 @@ before_install:
   # End install gmpy2 dependencies
   # Speed up install by not compiling Cython
   - pip install --install-option="--no-cython-compile" Cython
+    # Install numpy and report one of its compilation settings.
   - pip install numpy$NUMPYSPEC
+  - python -c 'import numpy as np; print("relaxed strides checking:", np.ones((10,1),order="C").flags.f_contiguous)'
   - pip install nose mpmath argparse
   - pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - if [ "${TESTMODE}" == "full" ]; then pip install coverage coveralls; fi


### PR DESCRIPTION
This affects TravisCI so check its output carefully before merging.  In fact TravisCI should segfault in ndimage if TravisCI does what I am intending, at least until something like https://github.com/scipy/scipy/pull/4218 has been merged.  This PR should close https://github.com/scipy/scipy/issues/4217.

http://docs.scipy.org/doc/numpy/release.html#npy-relaxed-strides-checking
