### PR TITLE
BLD: some updates to Bento config files and docs.  Closes gh-3978.

### DIFF
--- a/BENTO_BUILD.txt
+++ b/BENTO_BUILD.txt
@@ -11,6 +11,7 @@ No-frill version:
   * Clone Waf::
 
         $ git clone https://code.google.com/p/waf/ 
+        $ git checkout waf-1.7.13  # waf breaks API regularly, this version works
 
   * Set the WAFDIR environment variable to the base dir of the waf repo you
     just created (in your bash_login for example if you're going to build with

--- a/bento.info
+++ b/bento.info
@@ -1,8 +1,8 @@
 Name: scipy
-Version: 0.13.0
+Version: 0.16.0.dev0
 Summary: SciPy: Scientific Library for Python
 Url: http://www.scipy.org
-DownloadUrl: http://sourceforge.net/project/showfiles.php?group_id=27747&package_id=19531
+DownloadUrl: http://sourceforge.net/projects/scipy/files/scipy/
 Description:
     SciPy (pronounced "Sigh Pie") is open-source software for mathematics,
     science, and engineering. The SciPy library depends on NumPy, which

--- a/bscript
+++ b/bscript
@@ -163,7 +163,7 @@ def post_configure(context):
         conf.env.append_value('CXXFLAGS_PYEXT', "-Wfatal-errors")
 
     if sys.platform == "darwin":
-        conf.env["MACOSX_DEPLOYMENT_TARGET"] = "10.4"
+        conf.env["MACOSX_DEPLOYMENT_TARGET"] = "10.6"
 
         conf.check_cc_default_arch()
         archs = [conf.env.DEFAULT_CC_ARCH]


### PR DESCRIPTION
Update MACOSX_DEPLOYMENT_TARGET to 10.6 (same as most python.org installers
use) and the version to 0.16.0dev0.

Also add the correct SourceForge download URL and update the build instructions
to use the right Waf version.

[ci skip]
