### PR TITLE
MAINT: avoid redundant copies in scipy.sparse

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -83,7 +83,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                     self.shape = self._swap((major_dim,minor_dim))
 
         if dtype is not None:
-            self.data = self.data.astype(dtype)
+            self.data = self.data.astype(dtype, copy=False)
 
         self.check_format(full_check=False)
 
@@ -484,26 +484,26 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         fn = getattr(_sparsetools, self.format + '_matmat_pass1')
         fn(M, N,
-           self.indptr.astype(idx_dtype),
-           self.indices.astype(idx_dtype),
-           other.indptr.astype(idx_dtype),
-           other.indices.astype(idx_dtype),
+           self.indptr.astype(idx_dtype, copy=False),
+           self.indices.astype(idx_dtype, copy=False),
+           other.indptr.astype(idx_dtype, copy=False),
+           other.indices.astype(idx_dtype, copy=False),
            indptr)
 
         nnz = indptr[-1]
         idx_dtype = get_index_dtype((self.indptr, self.indices,
                                      other.indptr, other.indices),
                                     maxval=nnz)
-        indptr = indptr.astype(idx_dtype)
+        indptr = indptr.astype(idx_dtype, copy=False)
         indices = np.empty(nnz, dtype=idx_dtype)
         data = np.empty(nnz, dtype=upcast(self.dtype, other.dtype))
 
         fn = getattr(_sparsetools, self.format + '_matmat_pass2')
-        fn(M, N, self.indptr.astype(idx_dtype),
-           self.indices.astype(idx_dtype),
+        fn(M, N, self.indptr.astype(idx_dtype, copy=False),
+           self.indices.astype(idx_dtype, copy=False),
            self.data,
-           other.indptr.astype(idx_dtype),
-           other.indices.astype(idx_dtype),
+           other.indptr.astype(idx_dtype, copy=False),
+           other.indices.astype(idx_dtype, copy=False),
            other.data,
            indptr, indices, data)
 
@@ -705,8 +705,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         check_bounds(i, M)
         check_bounds(j, N)
 
-        i = i.astype(self.indices.dtype)
-        j = j.astype(self.indices.dtype)
+        i = i.astype(self.indices.dtype, copy=False)
+        j = j.astype(self.indices.dtype, copy=False)
 
         n_samples = len(x)
         offsets = np.empty(n_samples, dtype=self.indices.dtype)
@@ -758,12 +758,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         # Update index data type
         idx_dtype = get_index_dtype((self.indices, self.indptr),
                                     maxval=(self.indptr[-1] + x.size))
-        if idx_dtype != self.indptr.dtype:
-            self.indptr = self.indptr.astype(idx_dtype)
-            self.indices = self.indices.astype(idx_dtype)
-        if idx_dtype != i.dtype or idx_dtype != j.dtype:
-            i = i.astype(idx_dtype)
-            j = j.astype(idx_dtype)
+        self.indptr = self.indptr.astype(idx_dtype, copy=False)
+        self.indices = self.indices.astype(idx_dtype, copy=False)
+        i = i.astype(idx_dtype, copy=False)
+        j = j.astype(idx_dtype, copy=False)
 
         # Collate old and new in chunks by major index
         indices_parts = []
@@ -799,7 +797,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         # update attributes
         self.indices = np.concatenate(indices_parts)
         self.data = np.concatenate(data_parts)
-        nnzs = np.ediff1d(self.indptr, to_begin=0).astype(idx_dtype)
+        nnzs = np.ediff1d(self.indptr, to_begin=0).astype(idx_dtype, copy=False)
         nnzs[1:][ui] += new_nnzs
         self.indptr = np.cumsum(nnzs, out=nnzs)
 
@@ -1096,11 +1094,11 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             data = np.empty(maxnnz, dtype=upcast(self.dtype, other.dtype))
 
         fn(self.shape[0], self.shape[1],
-           self.indptr.astype(idx_dtype),
-           self.indices.astype(idx_dtype),
+           self.indptr.astype(idx_dtype, copy=False),
+           self.indices.astype(idx_dtype, copy=False),
            self.data,
-           other.indptr.astype(idx_dtype),
-           other.indices.astype(idx_dtype),
+           other.indptr.astype(idx_dtype, copy=False),
+           other.indices.astype(idx_dtype, copy=False),
            other.data,
            indptr, indices, data)
 


### PR DESCRIPTION
This is a rewrite of https://github.com/scipy/scipy/pull/4235 using the `copy=False` keyword argument of `astype` instead of writing and using a new helper function.

closes https://github.com/scipy/scipy/issues/4203

On my system this PR speeds up the sparse matrix multiplication example provided in https://github.com/scipy/scipy/issues/4203 by about 6x.
