### PR TITLE
BUG: sparse: work around alignment issue in f2py in Numpy 1.9.1

### DIFF
--- a/scipy/lib/tests/test__util.py
+++ b/scipy/lib/tests/test__util.py
@@ -1,0 +1,41 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+from numpy.testing import assert_equal, assert_
+
+from scipy.lib._util import _aligned_zeros
+
+
+def test__aligned_zeros():
+    niter = 10
+
+    def check(shape, dtype, order, align):
+        err_msg = repr((shape, dtype, order, align))
+        x = _aligned_zeros(shape, dtype, order, align=align)
+        if align is None:
+            align = np.dtype(dtype).alignment
+        assert_equal(x.__array_interface__['data'][0] % align, 0)
+        if hasattr(shape, '__len__'):
+            assert_equal(x.shape, shape, err_msg)
+        else:
+            assert_equal(x.shape, (shape,), err_msg)
+        assert_equal(x.dtype, dtype)
+        if order == "C":
+            assert_(x.flags.c_contiguous, err_msg)
+        elif order == "F":
+            if x.size > 0:
+                # Size-0 arrays get invalid flags on Numpy 1.5
+                assert_(x.flags.f_contiguous, err_msg)
+        elif order is None:
+            assert_(x.flags.c_contiguous, err_msg)
+        else:
+            raise ValueError()
+
+    # try various alignments
+    for align in [1, 2, 3, 4, 8, 16, 32, 64, None]:
+        for n in [0, 1, 3, 11]:
+            for order in ["C", "F", None]:
+                for dtype in [np.uint8, np.float64]:
+                    for shape in [n, (1,2,3,n)]:
+                        for j in range(niter):
+                            check(shape, dtype, order, align)

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -54,6 +54,7 @@ from scipy.linalg import lu_factor, lu_solve
 from scipy.sparse.sputils import isdense
 from scipy.sparse.linalg import gmres, splu
 from scipy.linalg.lapack import get_lapack_funcs
+from scipy.lib._util import _aligned_zeros
 
 
 _type_conv = {'f': 's', 'd': 'd', 'F': 'c', 'D': 'z'}
@@ -509,8 +510,9 @@ class _SymmetricArpackParams(_ArpackParams):
         if self.ncv > n or self.ncv <= k:
             raise ValueError("ncv must be k<ncv<=n, ncv=%s" % self.ncv)
 
-        self.workd = np.zeros(3 * n, self.tp)
-        self.workl = np.zeros(self.ncv * (self.ncv + 8), self.tp)
+        # Use _aligned_zeros to work around a f2py bug in Numpy 1.9.1
+        self.workd = _aligned_zeros(3 * n, self.tp)
+        self.workl = _aligned_zeros(self.ncv * (self.ncv + 8), self.tp)
 
         ltr = _type_conv[self.tp]
         if ltr not in ["s", "d"]:
@@ -691,8 +693,9 @@ class _UnsymmetricArpackParams(_ArpackParams):
         if self.ncv > n or self.ncv <= k + 1:
             raise ValueError("ncv must be k+1<ncv<=n, ncv=%s" % self.ncv)
 
-        self.workd = np.zeros(3 * n, self.tp)
-        self.workl = np.zeros(3 * self.ncv * (self.ncv + 2), self.tp)
+        # Use _aligned_zeros to work around a f2py bug in Numpy 1.9.1
+        self.workd = _aligned_zeros(3 * n, self.tp)
+        self.workl = _aligned_zeros(3 * self.ncv * (self.ncv + 2), self.tp)
 
         ltr = _type_conv[self.tp]
         self._arpack_solver = _arpack.__dict__[ltr + 'naupd']
@@ -704,7 +707,8 @@ class _UnsymmetricArpackParams(_ArpackParams):
         self.ipntr = np.zeros(14, "int")
 
         if self.tp in 'FD':
-            self.rwork = np.zeros(self.ncv, self.tp.lower())
+            # Use _aligned_zeros to work around a f2py bug in Numpy 1.9.1
+            self.rwork = _aligned_zeros(self.ncv, self.tp.lower())
         else:
             self.rwork = None
 

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -10,6 +10,7 @@ import numpy as np
 from scipy.sparse.linalg.interface import LinearOperator
 from scipy.lib.decorator import decorator
 from .utils import make_system
+from scipy.lib._util import _aligned_zeros
 
 _type_conv = {'f':'s', 'd':'d', 'F':'c', 'D':'z'}
 
@@ -108,7 +109,8 @@ def bicg(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=Non
     resid = tol
     ndx1 = 1
     ndx2 = -1
-    work = np.zeros(6*n,dtype=x.dtype)
+    # Use _aligned_zeros to work around a f2py bug in Numpy 1.9.1
+    work = _aligned_zeros(6*n,dtype=x.dtype)
     ijob = 1
     info = 0
     ftflag = True
@@ -173,7 +175,8 @@ def bicgstab(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback
     resid = tol
     ndx1 = 1
     ndx2 = -1
-    work = np.zeros(7*n,dtype=x.dtype)
+    # Use _aligned_zeros to work around a f2py bug in Numpy 1.9.1
+    work = _aligned_zeros(7*n,dtype=x.dtype)
     ijob = 1
     info = 0
     ftflag = True
@@ -233,7 +236,8 @@ def cg(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None)
     resid = tol
     ndx1 = 1
     ndx2 = -1
-    work = np.zeros(4*n,dtype=x.dtype)
+    # Use _aligned_zeros to work around a f2py bug in Numpy 1.9.1
+    work = _aligned_zeros(4*n,dtype=x.dtype)
     ijob = 1
     info = 0
     ftflag = True
@@ -292,7 +296,8 @@ def cgs(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None
     resid = tol
     ndx1 = 1
     ndx2 = -1
-    work = np.zeros(7*n,dtype=x.dtype)
+    # Use _aligned_zeros to work around a f2py bug in Numpy 1.9.1
+    work = _aligned_zeros(7*n,dtype=x.dtype)
     ijob = 1
     info = 0
     ftflag = True
@@ -434,8 +439,9 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, xtype=None, M=Non
     resid = tol
     ndx1 = 1
     ndx2 = -1
-    work = np.zeros((6+restrt)*n,dtype=x.dtype)
-    work2 = np.zeros((restrt+1)*(2*restrt+2),dtype=x.dtype)
+    # Use _aligned_zeros to work around a f2py bug in Numpy 1.9.1
+    work = _aligned_zeros((6+restrt)*n,dtype=x.dtype)
+    work2 = _aligned_zeros((restrt+1)*(2*restrt+2),dtype=x.dtype)
     ijob = 1
     info = 0
     ftflag = True
@@ -587,7 +593,8 @@ def qmr(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M1=None, M2=None, cal
     resid = tol
     ndx1 = 1
     ndx2 = -1
-    work = np.zeros(11*n,x.dtype)
+    # Use _aligned_zeros to work around a f2py bug in Numpy 1.9.1
+    work = _aligned_zeros(11*n,x.dtype)
     ijob = 1
     info = 0
     ftflag = True


### PR DESCRIPTION
This version of Numpy specifies complex dtype alignments that are not
guaranteed by system malloc on win32, so that np.zeros does not produce
sufficiently aligned arrays.

Work around this issue by using an aligned allocator for intent(inout)
arrays that are potentially complex valued.

Workaround for gh-4168, while waiting for Numpy be fixed

This should cover all complex-valued f2py inout arrays in Scipy
