### PR TITLE
Add routines for updating QR decompositions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,7 @@ scipy/linalg/_fblasmodule.c
 scipy/linalg/_flapack-f2pywrappers.f
 scipy/linalg/_flapackmodule.c
 scipy/linalg/_interpolativemodule.c
+scipy/linalg/_solve_toeplitz.c
 scipy/linalg/_decomp_update.c
 scipy/linalg/cblas.pyf
 scipy/linalg/clapack.pyf

--- a/.gitignore
+++ b/.gitignore
@@ -144,7 +144,7 @@ scipy/linalg/_fblasmodule.c
 scipy/linalg/_flapack-f2pywrappers.f
 scipy/linalg/_flapackmodule.c
 scipy/linalg/_interpolativemodule.c
-scipy/linalg/_solve_toeplitz.c
+scipy/linalg/_decomp_update.c
 scipy/linalg/cblas.pyf
 scipy/linalg/clapack.pyf
 scipy/linalg/cython_blas.c

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -73,6 +73,7 @@ Decompositions
    polar - Compute the polar decomposition.
    qr - QR decomposition of a matrix
    qr_multiply - QR decomposition and multiplication by Q
+   qr_update - Rank k QR update
    qr_delete - QR downdate on row or column deletion
    qr_insert - QR update on row or column insertion
    rq - RQ decomposition of a matrix

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -73,6 +73,7 @@ Decompositions
    polar - Compute the polar decomposition.
    qr - QR decomposition of a matrix
    qr_multiply - QR decomposition and multiplication by Q
+   qr_delete - QR downdate on row or column deletion
    rq - RQ decomposition of a matrix
    qz - QZ decomposition of a pair of matrices
    schur - Schur decomposition of a matrix
@@ -182,6 +183,7 @@ from .lapack import *
 from .special_matrices import *
 from ._solvers import *
 from ._procrustes import *
+from ._decomp_update import *
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -74,6 +74,7 @@ Decompositions
    qr - QR decomposition of a matrix
    qr_multiply - QR decomposition and multiplication by Q
    qr_delete - QR downdate on row or column deletion
+   qr_insert - QR update on row or column insertion
    rq - RQ decomposition of a matrix
    qz - QZ decomposition of a pair of matrices
    schur - Schur decomposition of a matrix

--- a/scipy/linalg/_decomp_update.pyx
+++ b/scipy/linalg/_decomp_update.pyx
@@ -557,8 +557,8 @@ cdef void qr_rank_1_update(int m, int n, blas_t* q, int* qs, blas_t* r, int* rs,
         lartg(index1(u, us, j), index1(u, us, j+1), &c, &s)
 
         # update jth and (j+1)th rows of r.
-        # reduce this n to skip all the zeros in r.
-        rot(n, row(r, rs, j), rs[1], row(r, rs, j+1), rs[1], c, s)
+        if n-j > 0:
+            rot(n-j, index2(r, rs, j, j), rs[1], index2(r, rs, j+1, j), rs[1], c, s)
 
         # update jth and (j+1)th cols of q.
         rot(m, col(q, qs, j), qs[0], col(q, qs, j+1), qs[0], c, s.conjugate())

--- a/scipy/linalg/_decomp_update.pyx
+++ b/scipy/linalg/_decomp_update.pyx
@@ -1552,7 +1552,7 @@ cdef void* extract(cnp.ndarray arr, int* arrs):
     return cnp.PyArray_DATA(arr)
 
 @cython.embedsignature(True)
-def qr_delete(Q, R, k, p=1, which='row', overwrite_qr=True, check_finite=True):
+def qr_delete(Q, R, k, p=1, which='row', overwrite_qr=False, check_finite=True):
     """QR downdate on row or column deletions
 
     If ``A = Q R`` is the QR factorization of ``A``, return the QR
@@ -1574,7 +1574,7 @@ def qr_delete(Q, R, k, p=1, which='row', overwrite_qr=True, check_finite=True):
     overwrite_qr : bool, optional
         If True, consume Q and R, overwriting their contents with their
         downdated versions, and returning approriately sized views.  
-        Defaults to True.
+        Defaults to False.
     check_finite : bool, optional
         Whether to check that the input matrix contains only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -1776,7 +1776,7 @@ def qr_delete(Q, R, k, p=1, which='row', overwrite_qr=True, check_finite=True):
         raise ValueError("'which' must be either 'row' or 'col'")
 
 @cython.embedsignature(True)
-def qr_insert(Q, R, u, k, which='row', rcond=None, overwrite_qru=True, check_finite=True):
+def qr_insert(Q, R, u, k, which='row', rcond=None, overwrite_qru=False, check_finite=True):
     """QR update on row or column insertions
 
     If ``A = Q R`` is the QR factorization of ``A``, return the QR
@@ -1802,7 +1802,7 @@ def qr_insert(Q, R, u, k, which='row', rcond=None, overwrite_qru=True, check_fin
         None.
     overwrite_qru : bool, optional
         If True, consume Q, R, and u, if possible, while performing the update,
-        otherwise make copies as necessary. Defaults to True.
+        otherwise make copies as necessary. Defaults to False.
     check_finite : bool, optional
         Whether to check that the input matrices contain only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -2118,7 +2118,7 @@ def qr_insert_col(Q, R, u, k, rcond, overwrite_qru, check_finite):
         else:
             frc = rcond
     elif rcond is not None:
-        raise ValueError("'rcond' is not used when updated full, (M,M) (M,N) "
+        raise ValueError("'rcond' is not used when updating full, (M,M) (M,N) "
                          "decompositions and must be None.")
 
     if economic:
@@ -2227,7 +2227,7 @@ def qr_insert_col(Q, R, u, k, rcond, overwrite_qru, check_finite):
         return q1, rnew
 
 @cython.embedsignature(True)
-def qr_update(Q, R, u, v, overwrite_qruv=True, check_finite=True):
+def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
     """Rank-k QR update
 
     If ``A = Q R`` is the QR factorization of ``A``, return the QR
@@ -2246,7 +2246,7 @@ def qr_update(Q, R, u, v, overwrite_qruv=True, check_finite=True):
         Right update vector
     overwrite_qruv : bool, optional
         If True, consume Q, R, u, and v, if possible, while performing the
-        update, otherwise make copies as necessary. Defaults to True.
+        update, otherwise make copies as necessary. Defaults to False.
     check_finite : bool, optional
         Whether to check that the input matrix contains only finite numbers.
         Disabling may give a performance gain, but may result in problems

--- a/scipy/linalg/_decomp_update.pyx
+++ b/scipy/linalg/_decomp_update.pyx
@@ -1,0 +1,567 @@
+"""
+Routines for updating QR decompositions
+
+.. versionadded: 0.16.0
+
+"""
+# 
+# Copyright (C) 2014 Eric Moore
+#
+# A few references for Updating QR factorizations:
+#
+# 1. Golub, G. H. & Loan, C. F. van V. Matrix Computations, 3rd Ed.
+#    (Johns Hopkins University Press, 1996).
+#
+# 2. Daniel, J. W., Gragg, W. B., Kaufman, L. & Stewart, G. W.
+#    Reorthogonalization and stable algorithms for updating the Gram-Schmidt QR
+#    factorization. Math. Comput. 30, 772795 (1976).
+#
+# 3. Gill, P. E., Golub, G. H., Murray, W. & Saunders, M. A. Methods for
+#    modifying matrix factorizations. Math. Comp. 28, 505535 (1974).
+#
+# 4. Hammarling, S. & Lucas, C. Updating the QR factorization and the least
+#    squares problem. 1-73 (The University of Manchester, 2008).
+#    at <http://eprints.ma.man.ac.uk/1192/>
+# 
+
+cimport cython
+cimport libc.stdlib
+cimport libc.limits as limits
+from libc.string cimport memset
+cimport numpy as cnp
+
+cdef int NPY_ANYORDER = 0  
+cdef int MEMORY_ERROR = limits.INT_MAX
+
+# These are commented out in the numpy support we cimported above.
+# Here I have declared them with as taking void* instead of PyArrayDescr
+# and object. In this file, only NULL is passed to these parameters.
+cdef extern from *:
+    cnp.ndarray PyArray_CheckFromAny(object, void*, int, int, int, void*)
+    cnp.ndarray PyArray_FromArray(cnp.ndarray, void*, int)
+
+from scipy.linalg cimport blas_pointers
+from scipy.linalg cimport lapack_pointers
+
+import numpy as np
+
+#------------------------------------------------------------------------------
+# These are a set of fused type wrappers around the BLAS and LAPACK calls used. 
+#------------------------------------------------------------------------------
+
+ctypedef float complex float_complex
+ctypedef double complex double_complex
+ctypedef fused blas_t:
+    float
+    double
+    float_complex
+    double_complex
+
+cdef inline blas_t* index2(blas_t* a, int* as, int i, int j) nogil:
+    return a + i*as[0] + j*as[1]
+
+cdef inline blas_t* index1(blas_t* a, int* as, int i) nogil:
+    return a + i*as[0]
+
+cdef inline blas_t* row(blas_t* a, int* as, int i) nogil:
+    return a + i*as[0]
+
+cdef inline blas_t* col(blas_t* a, int* as, int j) nogil:
+    return a + j*as[1]
+    
+cdef inline void copy(int n, blas_t* x, int incx, blas_t* y, int incy) nogil:
+    if blas_t is float:
+        blas_pointers.scopy(&n, x, &incx, y, &incy) 
+    elif blas_t is double:
+        blas_pointers.dcopy(&n, x, &incx, y, &incy)
+    elif blas_t is float_complex:
+        blas_pointers.ccopy(&n, x, &incx, y, &incy)
+    else:
+        blas_pointers.zcopy(&n, x, &incx, y, &incy)
+
+cdef inline void swap(int n, blas_t* x, int incx, blas_t* y, int incy) nogil:
+    if blas_t is float:
+        blas_pointers.sswap(&n, x, &incx, y, &incy) 
+    elif blas_t is double:
+        blas_pointers.dswap(&n, x, &incx, y, &incy)
+    elif blas_t is float_complex:
+        blas_pointers.cswap(&n, x, &incx, y, &incy)
+    else:
+        blas_pointers.zswap(&n, x, &incx, y, &incy)
+
+cdef inline void axpy(int n, blas_t a, blas_t* x, int incx,
+                      blas_t* y, int incy) nogil:
+    if blas_t is float:
+        blas_pointers.saxpy(&n, &a, x, &incx, y, &incy)
+    elif blas_t is double:
+        blas_pointers.daxpy(&n, &a, x, &incx, y, &incy)
+    elif blas_t is float_complex:
+        blas_pointers.caxpy(&n, &a, x, &incx, y, &incy)
+    else:
+        blas_pointers.zaxpy(&n, &a, x, &incx, y, &incy)
+
+cdef inline void lartg(blas_t* a, blas_t* b, blas_t* c, blas_t* s) nogil:
+    cdef blas_t g
+    if blas_t is float:
+        lapack_pointers.slartg(a, b, c, s, &g)
+    elif blas_t is double:
+        lapack_pointers.dlartg(a, b, c, s, &g)
+    elif blas_t is float_complex:
+        lapack_pointers.clartg(a, b, <float*>c, s, &g)
+    else:
+        lapack_pointers.zlartg(a, b, <double*>c, s, &g)
+    # make this function more like the BLAS drotg
+    a[0] = g
+    b[0] = 0
+
+cdef inline void rot(int n, blas_t* x, int incx, blas_t* y, int incy,
+                     blas_t c, blas_t s) nogil:
+    if blas_t is float:
+        blas_pointers.srot(&n, x, &incx, y, &incy, &c, &s) 
+    elif blas_t is double:
+        blas_pointers.drot(&n, x, &incx, y, &incy, &c, &s)
+    elif blas_t is float_complex:
+        lapack_pointers.crot(&n, x, &incx, y, &incy, <float*>&c, &s)
+    else:
+        lapack_pointers.zrot(&n, x, &incx, y, &incy, <double*>&c, &s)
+
+cdef inline void larfg(int n, blas_t* alpha, blas_t* x, int incx,
+                       blas_t* tau) nogil:
+    if blas_t is float:
+        lapack_pointers.slarfg(&n, alpha, x, &incx, tau)
+    elif blas_t is double:
+        lapack_pointers.dlarfg(&n, alpha, x, &incx, tau)
+    elif blas_t is float_complex:
+        lapack_pointers.clarfg(&n, alpha, x, &incx, tau)
+    else:
+        lapack_pointers.zlarfg(&n, alpha, x, &incx, tau)
+
+cdef inline void larf(char* side, int m, int n, blas_t* v, int incv, blas_t tau,
+    blas_t* c, int ldc, blas_t* work) nogil:
+    if blas_t is float:
+        lapack_pointers.slarf(side, &m, &n, v, &incv, &tau, c, &ldc, work)
+    elif blas_t is double:
+        lapack_pointers.dlarf(side, &m, &n, v, &incv, &tau, c, &ldc, work)
+    elif blas_t is float_complex:
+        lapack_pointers.clarf(side, &m, &n, v, &incv, &tau, c, &ldc, work)
+    else:
+        lapack_pointers.zlarf(side, &m, &n, v, &incv, &tau, c, &ldc, work)
+
+#------------------------------------------------------------------------------
+# Utility routines
+#------------------------------------------------------------------------------
+
+cdef cnp.ndarray PyArray_FromArraySafe(cnp.ndarray arr, void* newtype, int flags):
+    """In Numpy 1.5.1, Use of the NPY_F_CONTIGUOUS flag is broken when used
+    with a 1D input array.  The work around is to pass NPY_C_CONTIGUOUS since
+    for 1D arrays these are equivalent.  This is Numpy's gh-2287, fixed in
+    9b8ff38.
+
+    FIXME: Is it worth only applying this for numpy 1.5.1? 
+    """
+    if arr.ndim == 1 and (flags & cnp.NPY_F_CONTIGUOUS):
+        flags = flags & ~cnp.NPY_F_CONTIGUOUS
+        flags |= cnp.NPY_C_CONTIGUOUS
+    return PyArray_FromArray(arr, newtype, flags)
+
+cdef void blas_t_conj(int n, blas_t* x, int* xs) nogil:
+    cdef int j
+    if blas_t is float_complex or blas_t is double_complex:
+        for j in range(n):
+            index1(x, xs, j)[0] = index1(x, xs, j)[0].conjugate()
+
+#------------------------------------------------------------------------------
+# QR update routines start here.
+#------------------------------------------------------------------------------
+cdef void qr_row_delete(int m, int n, blas_t* q, int* qs, blas_t* r, int* rs,
+                        int k) nogil:
+    cdef int j
+    cdef blas_t c, s
+    
+    if k != 0:
+        for j in range(k, 0, -1):
+            swap(m, row(q, qs, j), qs[1], row(q, qs, j-1), qs[1])
+
+    blas_t_conj(m, row(q, qs, 0), &qs[1])
+
+    for j in range(m-2, -1, -1):
+        lartg(index2(q, qs, 0, j), index2(q, qs, 0, j+1), &c, &s)
+
+        # update the columns of r if there is a nonzero row.
+        if j < n:
+            rot(n-j, index2(r, rs, j, j), rs[1], index2(r, rs, j+1, j), rs[1],
+                    c, s)
+
+        # update the rows of q
+        rot(m-1, index2(q, qs, 1, j), qs[0], index2(q, qs, 1, j+1), qs[0],
+                c, s.conjugate())
+
+cdef void qr_block_row_delete(int m, int n, blas_t* q, int* qs,
+                              blas_t* r, int* rs, int k, int p) nogil:
+    cdef int i, j
+    cdef blas_t c,s
+    cdef blas_t* W
+    cdef int* ws
+
+    if k != 0:
+        for j in range(k, 0, -1):
+            swap(m, row(q, qs, j+p-1), qs[1], row(q, qs, j-1), qs[1])
+    
+    # W is the block of rows to be removed from q, has shape, (p,m)
+    W = q
+    ws = qs
+
+    for j in range(p):
+        blas_t_conj(m, row(W, ws, j), &ws[1])
+
+    for i in range(p):
+        for j in range(m-2, i-1, -1):
+            lartg(index2(W, ws, i, j), index2(W, ws, i, j+1), &c, &s)
+            
+            # update W
+            if i+1 < p:
+                rot(p-i-1, index2(W, ws, i+1, j), ws[0],
+                    index2(W, ws, i+1, j+1), ws[0], c, s)
+
+            # update r if there is a nonzero row.
+            if j-i < n:
+                rot(n-j+i, index2(r, rs, j, j-i), rs[1],
+                    index2(r, rs, j+1, j-i), rs[1], c, s)
+
+            # update q
+            rot(m-p, index2(q, qs, p, j), qs[0], index2(q, qs, p, j+1), qs[0],
+                c, s.conjugate())
+
+cdef void qr_col_delete(int m, int n, blas_t* q, int* qs, blas_t* r, int* rs,
+                        int k) nogil:
+    cdef int j
+
+    for j in range(k, n-1):
+        copy(m, col(r, rs, j+1), rs[0], col(r, rs, j), rs[0])
+
+    hessenberg_qr(m, n-1, q, qs, r, rs, k)
+
+cdef int qr_block_col_delete(int m, int n, blas_t* q, int* qs,
+                              blas_t* r, int* rs, int k, int p) nogil:
+    cdef int j
+    cdef blas_t* work
+    cdef int worksize = max(m, n)
+
+    work = <blas_t*>libc.stdlib.malloc(worksize*sizeof(blas_t))
+    if not work:
+        return MEMORY_ERROR
+
+    # move the columns to removed to the end
+    for j in range(k, n-p):
+        copy(m, col(r, rs, j+p), rs[0], col(r, rs, j), rs[0])
+
+    p_subdiag_qr(m, n-p, q, qs, r, rs, k, p, work)
+
+    libc.stdlib.free(work)
+    return 0
+
+cdef void hessenberg_qr(int m, int n, blas_t* q, int* qs, blas_t* r, int* rs,
+                        int k) nogil:
+    """Reduce an upper hessenberg matrix r, to upper triangluar,
+    starting in row j.  Apply these transformation to q as well.
+    """
+    cdef int j
+    cdef blas_t c, s
+    cdef int limit = min(m-1, n)
+
+    for j in range(k, limit):
+        lartg(index2(r, rs, j, j), index2(r, rs, j+1, j), &c, &s)
+
+        # update the rest of r
+        if j+1 < m:
+            rot(n-j-1, index2(r, rs, j, j+1), rs[1],
+                    index2(r, rs, j+1, j+1), rs[1], c, s) 
+
+        # update q
+        rot(m, col(q, qs, j), qs[0], col(q, qs, j+1), qs[0], c, s.conjugate())
+
+cdef void p_subdiag_qr(int m, int n, blas_t* q, int* qs, blas_t* r, int* rs,
+                       int k, int p, blas_t* work) nogil:
+    """ Reduce a matrix r to upper triangular form by eliminating the lower p 
+        subdiagionals using reflectors.
+        
+        q and r must be fortran order here, with work at least max(m,n) long.
+    """
+    cdef int j
+    cdef int last
+    cdef blas_t tau
+    cdef blas_t rjj 
+    cdef int limit = min(m-1, n)
+    cdef char* sideR = 'R'
+    cdef char* sideL = 'L'
+
+    # R now has p subdiagonal values to be removed starting from col k.
+    for j in range(k, limit):
+        # length of the reflector
+        last = min(p+1, m-j)
+        rjj = index2(r, rs, j, j)[0]
+        larfg(last, &rjj, index2(r, rs, j+1, j), rs[0], &tau)
+        index2(r, rs, j, j)[0] = 1
+
+        # apply the reflector to r if necessary
+        if j+1 < n:
+            larf(sideL, last, n-j-1, index2(r, rs, j, j), rs[0],
+                    tau.conjugate(), index2(r, rs, j, j+1), rs[1], work)
+
+        # apply the reflector to q
+        larf(sideR, m, last, index2(r, rs, j, j), rs[0], tau,
+                index2(q, qs, 0, j), qs[1], work)
+
+        # rezero the householder vector we no longer need.
+        memset(index2(r, rs, j+1, j), 0, (last-1)*sizeof(blas_t))
+
+        # restore the rjj element
+        index2(r, rs, j, j)[0] = rjj
+
+cdef validate_array(cnp.ndarray a):
+    # here we check that a has positive strides and that its size is small
+    # enough to fit in into an int, as BLAS/LAPACK require
+    cdef bint copy = False
+    cdef bint too_large = False
+    cdef int j
+
+    for j in range(a.ndim):
+        if a.strides[j] <= 0 or \
+                (a.strides[j] / a.descr.itemsize) >= limits.INT_MAX:
+            copy = True
+        if a.shape[j] >= limits.INT_MAX:
+            raise ValueError('Input array to large for use with BLAS')
+
+    if copy:
+            return PyArray_FromArraySafe(a, NULL, cnp.NPY_F_CONTIGUOUS)
+    return a
+
+cdef validate_qr(object q0, object r0, bint overwrite_q, int q_order,
+                 bint overwrite_r, int r_order):
+    cdef cnp.ndarray Q
+    cdef cnp.ndarray R
+    cdef int typecode
+
+    q_order |= cnp.NPY_BEHAVED_NS | cnp.NPY_ELEMENTSTRIDES  
+    r_order |= cnp.NPY_BEHAVED_NS | cnp.NPY_ELEMENTSTRIDES
+
+    if not overwrite_q:
+        q_order |= cnp.NPY_ENSURECOPY
+
+    if not overwrite_r:
+        r_order |= cnp.NPY_ENSURECOPY
+
+    # in the interests of giving better error messages take any number of
+    # dimensions here.
+    Q = PyArray_CheckFromAny(q0, NULL, 0, 0, q_order, NULL)
+    R = PyArray_CheckFromAny(r0, NULL, 0, 0, r_order, NULL)
+
+    if Q.ndim != 2 or R.ndim != 2:
+        raise ValueError('Q and R must be 2d')
+
+    typecode = cnp.PyArray_TYPE(Q)
+
+    if typecode != cnp.PyArray_TYPE(R):
+        raise ValueError('q and r must have the same type')
+
+    if not (typecode == cnp.NPY_FLOAT or typecode == cnp.NPY_DOUBLE 
+            or typecode == cnp.NPY_CFLOAT or typecode == cnp.NPY_CDOUBLE):
+        raise ValueError('only floatingcomplex arrays supported')
+
+    if Q.shape[1] != R.shape[0]:
+        raise ValueError('Q and R do not have compatible shapes')
+
+    # economic decomposition are not supported.
+    if Q.shape[0] != Q.shape[1]:
+        raise ValueError('economic mode decompositions are not supported.')
+
+    Q = validate_array(Q)
+    R = validate_array(R)
+
+    return Q, R, typecode, Q.shape[0], R.shape[1]
+ 
+cdef void* extract(cnp.ndarray a, int* as):
+    if a.ndim == 2:
+        as[0] = a.strides[0] / cnp.PyArray_ITEMSIZE(a)
+        as[1] = a.strides[1] / cnp.PyArray_ITEMSIZE(a)
+    elif a.ndim == 1:
+        as[0] = a.strides[0] / cnp.PyArray_ITEMSIZE(a)
+        as[1] = 0
+    return cnp.PyArray_DATA(a)
+
+@cython.embedsignature(True)
+def qr_delete(Q, R, k, p=1, which='row', overwrite_qr=True):
+    """QR downdate on row or column deletions
+
+    If ``A = Q R`` is the qr factorization of A, return the qr factorization
+    of `A` where `p` rows or columns have been removed starting at row or
+    column `k`.
+
+    Parameters
+    ----------
+    Q : array_like
+        Unitary/orthogonal matrix from QR decomposition.
+    R : array_like
+        Upper trianglar matrix from QR decomposition.
+    k : int
+        index of the first row or column to delete.
+    p : int, optional
+        number of rows or columns to delete, defaults to 1.
+    which: {'row', 'col'}, optional
+        Determines if rows or columns will be deleted, defaults to 'row'
+    overwrite_qr : bool, optional
+        If True, consume Q and R, overwriting their contents with their
+        downdated versions, and returning approriately sized views.  
+        Defaults to True.
+
+    Returns
+    -------
+    Q1 : ndarray
+        Updated unitary/orthogonal factor
+    R1 : ndarray
+        Updated upper triangular factor
+
+    Notes
+    -----
+    This routine does not guarantee that the diagonal entries of `R1` are
+    positive.
+
+    .. versionadded:: 0.16.0
+
+    Examples
+    --------
+    >>> from scipy import linalg
+    >>> a = np.array([[  3.,  -2.,  -2.],
+                      [  6.,  -9.,  -3.],
+                      [ -3.,  10.,   1.],
+                      [  6.,  -7.,   4.],
+                      [  7.,   8.,  -6.]])
+    >>> q, r = linalg.qr(a)
+
+    Given this q, r decomposition, update q and r when 2 rows are removed.
+
+    >>> q1, r1 = linalg.qr_delete(q, r, 2, 2, 'row', False)
+    >>> q1
+    array([[ 0.30942637,  0.15347579,  0.93845645],
+           [ 0.61885275,  0.71680171, -0.32127338],
+           [ 0.72199487, -0.68017681, -0.12681844]])
+    >>> r1
+    array([[  9.69535971,  -0.4125685 ,  -6.80738023],
+           [  0.        , -12.19958144,   1.62370412],
+           [  0.        ,   0.        ,  -0.15218213]])
+
+    The update is equivalent, but faster than the following.
+
+    >>> a1 = np.delete(a, slice(2,4), 0)
+    >>> a1
+    array([[ 3., -2., -2.],
+           [ 6., -9., -3.],
+           [ 7.,  8., -6.]])
+    >>> q_direct, r_direct = linalg.qr(a1)
+
+    Check that we have equivalent results:
+
+    >>> np.dot(q1, r1)
+    array([[ 3., -2., -2.],
+           [ 6., -9., -3.],
+           [ 7.,  8., -6.]])
+    >>> np.allclose(np.dot(q1, r1), a1)
+    True
+
+    And the updated Q is still unitary:
+
+    >>> np.allclose(np.dot(q1.T, q1), np.eye(3))
+    True
+
+    """
+    cdef cnp.ndarray q1, r1
+    cdef int k1 = k
+    cdef int p1 = p
+    cdef int typecode, m, n, info
+    cdef int qs[2]
+    cdef int rs[2]
+
+    if which == 'row':
+        q1, r1, typecode, m, n = validate_qr(Q, R, overwrite_qr, NPY_ANYORDER,
+                overwrite_qr, NPY_ANYORDER)
+        if not (-m <= k1 < m):
+            raise ValueError('k is not a valid index')
+        if k1 < 0:
+            k1 += m
+        if k1 + p1 > m or p1 <= 0: 
+            raise ValueError('p out of range')
+        if p1 == 1:
+            if typecode == cnp.NPY_FLOAT:
+                qr_row_delete(m, n, <float*>extract(q1, qs), qs,
+                    <float*>extract(r1, rs), rs, k1)
+            elif typecode == cnp.NPY_DOUBLE:
+                qr_row_delete(m, n, <double*>extract(q1, qs), qs,
+                    <double*>extract(r1, rs), rs, k1)
+            elif typecode == cnp.NPY_CFLOAT:
+                qr_row_delete(m, n, <float_complex*>extract(q1, qs), qs,
+                    <float_complex*>extract(r1, rs), rs, k1)
+            else:  # cnp.NPY_CDOUBLE:
+                qr_row_delete(m, n, <double_complex*>extract(q1, qs), qs,
+                    <double_complex*>extract(r1, rs), rs, k1)
+        else:
+            if typecode == cnp.NPY_FLOAT:
+                qr_block_row_delete(m, n, <float*>extract(q1, qs), qs,
+                    <float*>extract(r1, rs), rs, k1, p1)
+            elif typecode == cnp.NPY_DOUBLE:
+                qr_block_row_delete(m, n, <double*>extract(q1, qs), qs,
+                    <double*>extract(r1, rs), rs, k1, p1)
+            elif typecode == cnp.NPY_CFLOAT:
+                qr_block_row_delete(m, n, <float_complex*>extract(q1, qs), qs,
+                    <float_complex*>extract(r1, rs), rs, k1, p1)
+            else:  # cnp.NPY_CDOUBLE:
+                qr_block_row_delete(m, n, <double_complex*>extract(q1, qs), qs,
+                    <double_complex*>extract(r1, rs), rs, k1, p1)
+        return q1[p:, p:], r1[p:, :]
+    elif which == 'col':
+        if p1 > 1:
+            q1, r1, typecode, m, n = validate_qr(Q, R, overwrite_qr,
+                    cnp.NPY_F_CONTIGUOUS, overwrite_qr, cnp.NPY_F_CONTIGUOUS)
+        else:
+            q1, r1, typecode, m, n = validate_qr(Q, R, overwrite_qr,
+                    NPY_ANYORDER, overwrite_qr, NPY_ANYORDER)
+        if not (-n <= k1 < n):
+            raise ValueError('k is not a valid index')
+        if k1 < 0:
+            k1 += n
+        if k1 + p1 > n or p1 <= 0:
+            raise ValueError('p out of range')
+
+        if p1 == 1:
+            if typecode == cnp.NPY_FLOAT:
+                qr_col_delete(m, n, <float*>extract(q1, qs), qs, 
+                    <float*>extract(r1, rs), rs, k1)
+            elif typecode == cnp.NPY_DOUBLE:
+                qr_col_delete(m, n, <double*>extract(q1, qs), qs, 
+                    <double*>extract(r1, rs), rs, k1)
+            elif typecode == cnp.NPY_CFLOAT:
+                qr_col_delete(m, n, <float_complex*>extract(q1, qs), qs, 
+                    <float_complex*>extract(r1, rs), rs, k1)
+            else:  # cnp.NPY_CDOUBLE:
+                qr_col_delete(m, n, <double_complex*>extract(q1, qs), qs, 
+                    <double_complex*>extract(r1, rs), rs, k1)
+        else:
+            if typecode == cnp.NPY_FLOAT:
+                info = qr_block_col_delete(m, n, <float*>extract(q1, qs), qs,
+                    <float*>extract(r1, rs), rs, k1, p1)
+            elif typecode == cnp.NPY_DOUBLE:
+                info = qr_block_col_delete(m, n, <double*>extract(q1, qs), qs,
+                    <double*>extract(r1, rs), rs, k1, p1)
+            elif typecode == cnp.NPY_CFLOAT:
+                info = qr_block_col_delete(m, n, <float_complex*>extract(q1, qs), qs,
+                    <float_complex*>extract(r1, rs), rs, k1, p1)
+            else:  # cnp.NPY_CDOUBLE:
+                info = qr_block_col_delete(m, n, <double_complex*>extract(q1, qs), qs,
+                    <double_complex*>extract(r1, rs), rs, k1, p1)
+            if info == MEMORY_ERROR:
+                raise MemoryError('malloc failed')
+        return q1, r1[:,:-p]
+    else:
+        raise ValueError("which must be either 'row' or 'col'")
+
+cnp.import_array()
+

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1654,11 +1654,12 @@ def qr_delete(Q, R, k, p=1, which='row', overwrite_qr=False, check_finite=True):
                 p_full = p1 - p_eco
             qptr = extract(q1, qs)
             rptr = extract(r1, rs)
-            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
-            {{COND}} typecode == {{TYPECODE}}:
-                info = thin_qr_row_delete(m, n, <{{CNAME}}*>qptr, qs, qisF,
-                    <{{CNAME}}*>rptr, rs, k1, p_eco, p_full)
-            {{endfor}}
+            with nogil:
+                {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+                {{COND}} typecode == {{TYPECODE}}:
+                    info = thin_qr_row_delete(m, n, <{{CNAME}}*>qptr, qs, qisF,
+                        <{{CNAME}}*>rptr, rs, k1, p_eco, p_full)
+                {{endfor}}
             if info == 1:
                 return q1[p_full:-p_eco, p_full:], r1[p_full:,:]
             elif info == MEMORY_ERROR:
@@ -1668,11 +1669,12 @@ def qr_delete(Q, R, k, p=1, which='row', overwrite_qr=False, check_finite=True):
         else:
             qptr = extract(q1, qs)
             rptr = extract(r1, rs)
-            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
-            {{COND}} typecode == {{TYPECODE}}:
-                qr_block_row_delete(m, n, <{{CNAME}}*>qptr, qs,
-                    <{{CNAME}}*>rptr, rs, k1, p1)
-            {{endfor}}
+            with nogil:
+                {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+                {{COND}} typecode == {{TYPECODE}}:
+                    qr_block_row_delete(m, n, <{{CNAME}}*>qptr, qs,
+                        <{{CNAME}}*>rptr, rs, k1, p1)
+                {{endfor}}
             return q1[p1:, p1:], r1[p1:, :]
     elif which == 'col':
         # Special case single column removal to be more accepting of C ordered
@@ -1695,17 +1697,19 @@ def qr_delete(Q, R, k, p=1, which='row', overwrite_qr=False, check_finite=True):
         qptr = extract(q1, qs)
         rptr = extract(r1, rs)
         if p1 == 1:
-            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
-            {{COND}} typecode == {{TYPECODE}}:
-                qr_col_delete(m, o, n, <{{CNAME}}*>qptr, qs,
-                    <{{CNAME}}*>rptr, rs, k1)
-            {{endfor}}
+            with nogil:
+                {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+                {{COND}} typecode == {{TYPECODE}}:
+                    qr_col_delete(m, o, n, <{{CNAME}}*>qptr, qs,
+                        <{{CNAME}}*>rptr, rs, k1)
+                {{endfor}}
         else:
-            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
-            {{COND}} typecode == {{TYPECODE}}:
-                info = qr_block_col_delete(m, o, n, <{{CNAME}}*>qptr, qs,
-                    <{{CNAME}}*>rptr, rs, k1, p1)
-            {{endfor}}
+            with nogil:
+                {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+                {{COND}} typecode == {{TYPECODE}}:
+                    info = qr_block_col_delete(m, o, n, <{{CNAME}}*>qptr, qs,
+                        <{{CNAME}}*>rptr, rs, k1, p1)
+                {{endfor}}
             if info == MEMORY_ERROR:
                 raise MemoryError('Unable to allocate memory for array')
         if economic:
@@ -1918,11 +1922,12 @@ def qr_insert_row(Q, R, u, k, overwrite_qru, check_finite):
             qptr = extract(qnew, qs)
             rptr = extract(r1, rs)
             uptr = extract(u1, us)
-            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
-            {{COND}} typecode == {{TYPECODE}}:
-                thin_qr_row_insert(m+p, n, <{{CNAME}}*>qptr, qs,
-                    <{{CNAME}}*>rptr, rs, <{{CNAME}}*>uptr, us, k1)
-            {{endfor}}
+            with nogil:
+                {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+                {{COND}} typecode == {{TYPECODE}}:
+                    thin_qr_row_insert(m+p, n, <{{CNAME}}*>qptr, qs,
+                        <{{CNAME}}*>rptr, rs, <{{CNAME}}*>uptr, us, k1)
+                {{endfor}}
         else:
             # only copies if if necessary.
             r1 = PyArray_FromArray(r1, NULL, cnp.NPY_F_CONTIGUOUS)
@@ -1930,11 +1935,12 @@ def qr_insert_row(Q, R, u, k, overwrite_qru, check_finite):
             qptr = extract(qnew, qs)
             rptr = extract(r1, rs)
             uptr = extract(u1, us)
-            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
-            {{COND}} typecode == {{TYPECODE}}:
-                thin_qr_block_row_insert(m+p, n, <{{CNAME}}*>qptr, qs,
-                    <{{CNAME}}*>rptr, rs, <{{CNAME}}*>uptr, us, k1, p)
-            {{endfor}}
+            with nogil:
+                {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+                {{COND}} typecode == {{TYPECODE}}:
+                    thin_qr_block_row_insert(m+p, n, <{{CNAME}}*>qptr, qs,
+                        <{{CNAME}}*>rptr, rs, <{{CNAME}}*>uptr, us, k1, p)
+                {{endfor}}
         return qnew[:, :-p], r1
     else:
         shape[0] = m + p
@@ -1952,17 +1958,19 @@ def qr_insert_row(Q, R, u, k, overwrite_qru, check_finite):
         qptr = extract(qnew, qs)
         rptr = extract(rnew, rs)
         if p == 1:
-            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
-            {{COND}} typecode == {{TYPECODE}}:
-                qr_row_insert(m+p, n, <{{CNAME}}*>qptr, qs,
-                    <{{CNAME}}*>rptr, rs, k1)
-            {{endfor}}
+            with nogil:
+                {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+                {{COND}} typecode == {{TYPECODE}}:
+                    qr_row_insert(m+p, n, <{{CNAME}}*>qptr, qs,
+                        <{{CNAME}}*>rptr, rs, k1)
+                {{endfor}}
         else:
-            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
-            {{COND}} typecode == {{TYPECODE}}:
-                info = qr_block_row_insert(m+p, n, <{{CNAME}}*>qptr, qs,
-                    <{{CNAME}}*>rptr, rs, k1, p)
-            {{endfor}}
+            with nogil:
+                {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+                {{COND}} typecode == {{TYPECODE}}:
+                    info = qr_block_row_insert(m+p, n, <{{CNAME}}*>qptr, qs,
+                        <{{CNAME}}*>rptr, rs, k1, p)
+                {{endfor}}
             if info == MEMORY_ERROR:
                 raise MemoryError('Unable to allocate memory for array')
         return qnew, rnew
@@ -2052,12 +2060,13 @@ def qr_insert_col(Q, R, u, k, rcond, overwrite_qru, check_finite):
 {{py: 
 RCONDS = ['&frc', '&drc', '<float_complex*>&frc', '<double_complex*>&drc']
 }}
-        {{for COND, TYPECODE, CNAME, RC in zip(CONDS, TCODES, CNAMES, RCONDS)}}
-        {{COND}} typecode == {{TYPECODE}}:
-            info = thin_qr_col_insert(m, n, <{{CNAME}}*>qptr, qs,
-                <{{CNAME}}*>rptr, rs, <{{CNAME}}*>uptr, us, k1, p_eco,
-                p_full, {{RC}})
-        {{endfor}}
+        with nogil:
+            {{for COND, TYPECODE, CNAME, RC in zip(CONDS, TCODES, CNAMES, RCONDS)}}
+            {{COND}} typecode == {{TYPECODE}}:
+                info = thin_qr_col_insert(m, n, <{{CNAME}}*>qptr, qs,
+                    <{{CNAME}}*>rptr, rs, <{{CNAME}}*>uptr, us, k1, p_eco,
+                    p_full, {{RC}})
+            {{endfor}}
         if info == 2:
             raise LinAlgError("One of the columns of u lies in the span of Q. "
                               "Found reciprocal condition number of %s for Q "
@@ -2086,17 +2095,19 @@ RCONDS = ['&frc', '&drc', '<float_complex*>&frc', '<double_complex*>&drc']
         
         qptr = extract(q1, qs)
         if p == 1:
-            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
-            {{COND}} typecode == {{TYPECODE}}:
-                qr_col_insert(m, n+p, <{{CNAME}}*>qptr, qs,
-                    <{{CNAME}}*>rptr, rs, k1)
-            {{endfor}}
+            with nogil:
+                {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+                {{COND}} typecode == {{TYPECODE}}:
+                    qr_col_insert(m, n+p, <{{CNAME}}*>qptr, qs,
+                        <{{CNAME}}*>rptr, rs, k1)
+                {{endfor}}
         else:
-            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
-            {{COND}} typecode == {{TYPECODE}}:
-                info = qr_block_col_insert(m, n+p, <{{CNAME}}*>qptr, qs,
-                    <{{CNAME}}*>rptr, rs, k1, p)
-            {{endfor}}
+            with nogil:
+                {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+                {{COND}} typecode == {{TYPECODE}}:
+                    info = qr_block_col_insert(m, n+p, <{{CNAME}}*>qptr, qs,
+                        <{{CNAME}}*>rptr, rs, k1, p)
+                {{endfor}}
             if info != 0:
                 if info > 0: 
                     raise ValueError('The {0}th argument to ?geqrf was '
@@ -2335,20 +2346,21 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
         uptr = extract(u1, us)
         vptr = extract(v1, vs)
         sptr = extract(s, ss)
-        if p == 1:
-            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
-            {{COND}} typecode == {{TYPECODE}}:
-                thin_qr_rank_1_update(m, n, <{{CNAME}}*>qptr, qs, qisF,
-                    <{{CNAME}}*>rptr, rs, <{{CNAME}}*>uptr, us,
-                    <{{CNAME}}*>vptr, vs, <{{CNAME}}*>sptr, ss)
-            {{endfor}}
-        else:
-            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
-            {{COND}} typecode == {{TYPECODE}}:
-                thin_qr_rank_p_update(m, n, p, <{{CNAME}}*>qptr, qs, qisF,
-                    <{{CNAME}}*>rptr, rs, <{{CNAME}}*>uptr, us,
-                    <{{CNAME}}*>vptr, vs, <{{CNAME}}*>sptr, ss)
-            {{endfor}}
+        with nogil:
+            if p == 1:
+                {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+                {{COND}} typecode == {{TYPECODE}}:
+                    thin_qr_rank_1_update(m, n, <{{CNAME}}*>qptr, qs, qisF,
+                        <{{CNAME}}*>rptr, rs, <{{CNAME}}*>uptr, us,
+                        <{{CNAME}}*>vptr, vs, <{{CNAME}}*>sptr, ss)
+                {{endfor}}
+            else:
+                {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+                {{COND}} typecode == {{TYPECODE}}:
+                    thin_qr_rank_p_update(m, n, p, <{{CNAME}}*>qptr, qs, qisF,
+                        <{{CNAME}}*>rptr, rs, <{{CNAME}}*>uptr, us,
+                        <{{CNAME}}*>vptr, vs, <{{CNAME}}*>sptr, ss)
+                {{endfor}}
     else:
         qTu = cnp.PyArray_ZEROS(u1.ndim, u1.shape, typecode, 1)
         qTuptr = extract(qTu, qTus)
@@ -2359,12 +2371,13 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
             qptr = extract(q1, qs)
             rptr = extract(r1, rs)
             vptr = extract(v1, vs)
-            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
-            {{COND}} typecode == {{TYPECODE}}:
-                qr_rank_1_update(m, n, <{{CNAME}}*>qptr, qs,
-                    <{{CNAME}}*>rptr, rs, <{{CNAME}}*>qTuptr, qTus,
-                    <{{CNAME}}*>vptr, vs)
-            {{endfor}}
+            with nogil:
+                {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+                {{COND}} typecode == {{TYPECODE}}:
+                    qr_rank_1_update(m, n, <{{CNAME}}*>qptr, qs,
+                        <{{CNAME}}*>rptr, rs, <{{CNAME}}*>qTuptr, qTus,
+                        <{{CNAME}}*>vptr, vs)
+                {{endfor}}
         else:
             if not cnp.PyArray_CHKFLAGS(q1, cnp.NPY_F_CONTIGUOUS):
                 q1 = PyArray_FromArray(q1, NULL, cnp.NPY_F_CONTIGUOUS)
@@ -2380,12 +2393,13 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
             qptr = extract(q1, qs)
             rptr = extract(r1, rs)
             vptr = extract(v1, vs)
-            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
-            {{COND}} typecode == {{TYPECODE}}:
-                info = qr_rank_p_update(m, n, p, <{{CNAME}}*>qptr, qs,
-                    <{{CNAME}}*>rptr, rs, <{{CNAME}}*>qTuptr, qTus,
-                    <{{CNAME}}*>vptr, vs)
-            {{endfor}}
+            with nogil:
+                {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+                {{COND}} typecode == {{TYPECODE}}:
+                    info = qr_rank_p_update(m, n, p, <{{CNAME}}*>qptr, qs,
+                        <{{CNAME}}*>rptr, rs, <{{CNAME}}*>qTuptr, qTus,
+                        <{{CNAME}}*>vptr, vs)
+                {{endfor}}
             if info != 0:
                 if info > 0: 
                     raise ValueError('The {0}th argument to ?geqrf was '

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -32,6 +32,15 @@ Routines for updating QR decompositions
 #    Updating the QR Decomposition. ACM Trans. Math. Softw. 16, 369–377 (1990).
 # 
 
+{{py: 
+
+TCODES = ['cnp.NPY_FLOAT', 'cnp.NPY_DOUBLE', 'cnp.NPY_CFLOAT', 'cnp.NPY_CDOUBLE']
+CNAMES = ['float', 'double', 'float_complex', 'double_complex']
+CONDS = ['if', 'elif', 'elif', 'else:  #']
+PREFIX = ['s', 'd', 'c', 'z']    
+
+}}
+
 cimport cython
 cimport libc.stdlib
 cimport libc.limits 
@@ -84,47 +93,31 @@ cdef inline blas_t* row(blas_t* a, int* as, int i) nogil:
 
 cdef inline blas_t* col(blas_t* a, int* as, int j) nogil:
     return a + j*as[1]
-    
+
 cdef inline void copy(int n, blas_t* x, int incx, blas_t* y, int incy) nogil:
-    if blas_t is float:
-        blas_pointers.scopy(&n, x, &incx, y, &incy) 
-    elif blas_t is double:
-        blas_pointers.dcopy(&n, x, &incx, y, &incy)
-    elif blas_t is float_complex:
-        blas_pointers.ccopy(&n, x, &incx, y, &incy)
-    else:
-        blas_pointers.zcopy(&n, x, &incx, y, &incy)
+    {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
+    {{COND}} blas_t is {{CNAME}}:
+        blas_pointers.{{C}}copy(&n, x, &incx, y, &incy)
+    {{endfor}}
 
 cdef inline void swap(int n, blas_t* x, int incx, blas_t* y, int incy) nogil:
-    if blas_t is float:
-        blas_pointers.sswap(&n, x, &incx, y, &incy) 
-    elif blas_t is double:
-        blas_pointers.dswap(&n, x, &incx, y, &incy)
-    elif blas_t is float_complex:
-        blas_pointers.cswap(&n, x, &incx, y, &incy)
-    else:
-        blas_pointers.zswap(&n, x, &incx, y, &incy)
+    {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
+    {{COND}} blas_t is {{CNAME}}:
+        blas_pointers.{{C}}swap(&n, x, &incx, y, &incy)
+    {{endfor}}
 
 cdef inline void scal(int n, blas_t a, blas_t* x, int incx) nogil:
-    if blas_t is float:
-        blas_pointers.sscal(&n, &a, x, &incx)
-    elif blas_t is double:
-        blas_pointers.dscal(&n, &a, x, &incx)
-    elif blas_t is float_complex:
-        blas_pointers.cscal(&n, &a, x, &incx)
-    else:
-        blas_pointers.zscal(&n, &a, x, &incx)
+    {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
+    {{COND}} blas_t is {{CNAME}}:
+        blas_pointers.{{C}}scal(&n, &a, x, &incx)
+    {{endfor}}
 
 cdef inline void axpy(int n, blas_t a, blas_t* x, int incx,
                       blas_t* y, int incy) nogil:
-    if blas_t is float:
-        blas_pointers.saxpy(&n, &a, x, &incx, y, &incy)
-    elif blas_t is double:
-        blas_pointers.daxpy(&n, &a, x, &incx, y, &incy)
-    elif blas_t is float_complex:
-        blas_pointers.caxpy(&n, &a, x, &incx, y, &incy)
-    else:
-        blas_pointers.zaxpy(&n, &a, x, &incx, y, &incy)
+    {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
+    {{COND}} blas_t is {{CNAME}}:
+        blas_pointers.{{C}}axpy(&n, &a, x, &incx, y, &incy)
+    {{endfor}}
 
 cdef inline blas_t nrm2(int n, blas_t* x, int incx) nogil:
     # since dnrm2 etc are functions, we can't at present call them...
@@ -235,25 +228,17 @@ cdef inline void rot(int n, blas_t* x, int incx, blas_t* y, int incy,
 
 cdef inline void larfg(int n, blas_t* alpha, blas_t* x, int incx,
                        blas_t* tau) nogil:
-    if blas_t is float:
-        lapack_pointers.slarfg(&n, alpha, x, &incx, tau)
-    elif blas_t is double:
-        lapack_pointers.dlarfg(&n, alpha, x, &incx, tau)
-    elif blas_t is float_complex:
-        lapack_pointers.clarfg(&n, alpha, x, &incx, tau)
-    else:
-        lapack_pointers.zlarfg(&n, alpha, x, &incx, tau)
+    {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
+    {{COND}} blas_t is {{CNAME}}:
+        lapack_pointers.{{C}}larfg(&n, alpha, x, &incx, tau)
+    {{endfor}}
 
 cdef inline void larf(char* side, int m, int n, blas_t* v, int incv, blas_t tau,
     blas_t* c, int ldc, blas_t* work) nogil:
-    if blas_t is float:
-        lapack_pointers.slarf(side, &m, &n, v, &incv, &tau, c, &ldc, work)
-    elif blas_t is double:
-        lapack_pointers.dlarf(side, &m, &n, v, &incv, &tau, c, &ldc, work)
-    elif blas_t is float_complex:
-        lapack_pointers.clarf(side, &m, &n, v, &incv, &tau, c, &ldc, work)
-    else:
-        lapack_pointers.zlarf(side, &m, &n, v, &incv, &tau, c, &ldc, work)
+    {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
+    {{COND}} blas_t is {{CNAME}}:
+        lapack_pointers.{{C}}larf(side, &m, &n, v, &incv, &tau, c, &ldc, work)
+    {{endfor}}
 
 cdef inline void ger(int m, int n, blas_t alpha, blas_t* x, int incx, blas_t* y,
         int incy, blas_t* a, int lda) nogil:
@@ -268,61 +253,36 @@ cdef inline void ger(int m, int n, blas_t alpha, blas_t* x, int incx, blas_t* y,
 
 cdef inline void gemv(char* trans, int m, int n, blas_t alpha, blas_t* a,
         int lda, blas_t* x, int incx, blas_t beta, blas_t* y, int incy) nogil:
-    if blas_t is float:
-        blas_pointers.sgemv(trans, &m, &n, &alpha, a, &lda, x, &incx, &beta,
-                y, &incy)
-    elif blas_t is double:
-        blas_pointers.dgemv(trans, &m, &n, &alpha, a, &lda, x, &incx, &beta,
-                y, &incy)
-    elif blas_t is float_complex:
-        blas_pointers.cgemv(trans, &m, &n, &alpha, a, &lda, x, &incx, &beta,
-                y, &incy)
-    else:
-        blas_pointers.zgemv(trans, &m, &n, &alpha, a, &lda, x, &incx, &beta,
-                y, &incy)
+    {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
+    {{COND}} blas_t is {{CNAME}}:
+        blas_pointers.{{C}}gemv(trans, &m, &n, &alpha, a, &lda, x, &incx,
+                &beta, y, &incy)
+    {{endfor}}
 
 cdef inline void gemm(char* transa, char* transb, int m, int n, int k,
         blas_t alpha, blas_t* a, int lda, blas_t* b, int ldb, blas_t beta,
         blas_t* c, int ldc) nogil:
-    if blas_t is float:
-        blas_pointers.sgemm(transa, transb, &m, &n, &k, &alpha, a, &lda,
+    {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
+    {{COND}} blas_t is {{CNAME}}:
+        blas_pointers.{{C}}gemm(transa, transb, &m, &n, &k, &alpha, a, &lda,
                 b, &ldb, &beta, c, &ldc)
-    elif blas_t is double:
-        blas_pointers.dgemm(transa, transb, &m, &n, &k, &alpha, a, &lda,
-                b, &ldb, &beta, c, &ldc)
-    elif blas_t is float_complex:
-        blas_pointers.cgemm(transa, transb, &m, &n, &k, &alpha, a, &lda,
-                b, &ldb, &beta, c, &ldc)
-    else:
-        blas_pointers.zgemm(transa, transb, &m, &n, &k, &alpha, a, &lda,
-                b, &ldb, &beta, c, &ldc)
+    {{endfor}}
 
 cdef inline void trmm(char* side, char* uplo, char* transa, char* diag, int m,
         int n, blas_t alpha, blas_t* a, int lda, blas_t* b, int ldb) nogil:
-    if blas_t is float:
-        blas_pointers.strmm(side, uplo, transa, diag, &m, &n, &alpha, a, &lda,
+    {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
+    {{COND}} blas_t is {{CNAME}}:
+        blas_pointers.{{C}}trmm(side, uplo, transa, diag, &m, &n, &alpha, a, &lda,
                 b, &ldb)
-    elif blas_t is double:
-        blas_pointers.dtrmm(side, uplo, transa, diag, &m, &n, &alpha, a, &lda,
-                b, &ldb)
-    elif blas_t is float_complex:
-        blas_pointers.ctrmm(side, uplo, transa, diag, &m, &n, &alpha, a, &lda,
-                b, &ldb)
-    else:
-        blas_pointers.ztrmm(side, uplo, transa, diag, &m, &n, &alpha, a, &lda,
-                b, &ldb)
+    {{endfor}}
 
 cdef inline int geqrf(int m, int n, blas_t* a, int lda, blas_t* tau,
                       blas_t* work, int lwork) nogil:
     cdef int info
-    if blas_t is float:
-        lapack_pointers.sgeqrf(&m, &n, a, &lda, tau, work, &lwork, &info)
-    elif blas_t is double:
-        lapack_pointers.dgeqrf(&m, &n, a, &lda, tau, work, &lwork, &info)
-    elif blas_t is float_complex:
-        lapack_pointers.cgeqrf(&m, &n, a, &lda, tau, work, &lwork, &info)
-    else:
-        lapack_pointers.zgeqrf(&m, &n, a, &lda, tau, work, &lwork, &info)
+    {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
+    {{COND}} blas_t is {{CNAME}}:
+        lapack_pointers.{{C}}geqrf(&m, &n, a, &lda, tau, work, &lwork, &info)
+    {{endfor}}
     return info
 
 cdef inline int ormqr(char* side, char* trans, int m, int n, int k, blas_t* a,
@@ -1663,6 +1623,8 @@ def qr_delete(Q, R, k, p=1, which='row', overwrite_qr=False, check_finite=True):
     cdef int p1 = p
     cdef int p_eco, p_full
     cdef int typecode, m, n, info
+    cdef void* qptr
+    cdef void* rptr
     cdef int qs[2]
     cdef int rs[2]
     cdef bint economic, qisF = False 
@@ -1690,18 +1652,13 @@ def qr_delete(Q, R, k, p=1, which='row', overwrite_qr=False, check_finite=True):
             else:
                 p_eco = m-n
                 p_full = p1 - p_eco
-            if typecode == cnp.NPY_FLOAT:
-                info = thin_qr_row_delete(m, n, <float*>extract(q1, qs), qs, qisF,
-                    <float*>extract(r1, rs), rs, k1, p_eco, p_full)
-            elif typecode == cnp.NPY_DOUBLE:
-                info = thin_qr_row_delete(m, n, <double*>extract(q1, qs), qs, qisF,
-                    <double*>extract(r1, rs), rs, k1, p_eco, p_full)
-            elif typecode == cnp.NPY_CFLOAT:
-                info = thin_qr_row_delete(m, n, <float_complex*>extract(q1, qs), qs, qisF,
-                    <float_complex*>extract(r1, rs), rs, k1, p_eco, p_full)
-            else:  #  cnp.NPY_CDOUBLE
-                info = thin_qr_row_delete(m, n, <double_complex*>extract(q1, qs), qs, qisF,
-                    <double_complex*>extract(r1, rs), rs, k1, p_eco, p_full)
+            qptr = extract(q1, qs)
+            rptr = extract(r1, rs)
+            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+            {{COND}} typecode == {{TYPECODE}}:
+                info = thin_qr_row_delete(m, n, <{{CNAME}}*>qptr, qs, qisF,
+                    <{{CNAME}}*>rptr, rs, k1, p_eco, p_full)
+            {{endfor}}
             if info == 1:
                 return q1[p_full:-p_eco, p_full:], r1[p_full:,:]
             elif info == MEMORY_ERROR:
@@ -1709,18 +1666,13 @@ def qr_delete(Q, R, k, p=1, which='row', overwrite_qr=False, check_finite=True):
             else:
                 raise ValueError('Reorthogonalization Failed, unable to perform row deletion.')
         else:
-            if typecode == cnp.NPY_FLOAT:
-                qr_block_row_delete(m, n, <float*>extract(q1, qs), qs,
-                    <float*>extract(r1, rs), rs, k1, p1)
-            elif typecode == cnp.NPY_DOUBLE:
-                qr_block_row_delete(m, n, <double*>extract(q1, qs), qs,
-                    <double*>extract(r1, rs), rs, k1, p1)
-            elif typecode == cnp.NPY_CFLOAT:
-                qr_block_row_delete(m, n, <float_complex*>extract(q1, qs), qs,
-                    <float_complex*>extract(r1, rs), rs, k1, p1)
-            else:  # cnp.NPY_CDOUBLE:
-                qr_block_row_delete(m, n, <double_complex*>extract(q1, qs), qs,
-                    <double_complex*>extract(r1, rs), rs, k1, p1)
+            qptr = extract(q1, qs)
+            rptr = extract(r1, rs)
+            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+            {{COND}} typecode == {{TYPECODE}}:
+                qr_block_row_delete(m, n, <{{CNAME}}*>qptr, qs,
+                    <{{CNAME}}*>rptr, rs, k1, p1)
+            {{endfor}}
             return q1[p1:, p1:], r1[p1:, :]
     elif which == 'col':
         # Special case single column removal to be more accepting of C ordered
@@ -1740,32 +1692,20 @@ def qr_delete(Q, R, k, p=1, which='row', overwrite_qr=False, check_finite=True):
         if k1 + p1 > n or p1 <= 0:
             raise ValueError("'p' is out of range")
 
+        qptr = extract(q1, qs)
+        rptr = extract(r1, rs)
         if p1 == 1:
-            if typecode == cnp.NPY_FLOAT:
-                qr_col_delete(m, o, n, <float*>extract(q1, qs), qs, 
-                    <float*>extract(r1, rs), rs, k1)
-            elif typecode == cnp.NPY_DOUBLE:
-                qr_col_delete(m, o, n, <double*>extract(q1, qs), qs, 
-                    <double*>extract(r1, rs), rs, k1)
-            elif typecode == cnp.NPY_CFLOAT:
-                qr_col_delete(m, o, n, <float_complex*>extract(q1, qs), qs,
-                    <float_complex*>extract(r1, rs), rs, k1)
-            else:  # cnp.NPY_CDOUBLE:
-                qr_col_delete(m, o, n, <double_complex*>extract(q1, qs), qs,
-                    <double_complex*>extract(r1, rs), rs, k1)
+            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+            {{COND}} typecode == {{TYPECODE}}:
+                qr_col_delete(m, o, n, <{{CNAME}}*>qptr, qs,
+                    <{{CNAME}}*>rptr, rs, k1)
+            {{endfor}}
         else:
-            if typecode == cnp.NPY_FLOAT:
-                info = qr_block_col_delete(m, o, n, <float*>extract(q1, qs), qs,
-                    <float*>extract(r1, rs), rs, k1, p1)
-            elif typecode == cnp.NPY_DOUBLE:
-                info = qr_block_col_delete(m, o, n, <double*>extract(q1, qs), qs,
-                    <double*>extract(r1, rs), rs, k1, p1)
-            elif typecode == cnp.NPY_CFLOAT:
-                info = qr_block_col_delete(m, o, n, <float_complex*>extract(q1, qs), qs,
-                    <float_complex*>extract(r1, rs), rs, k1, p1)
-            else:  # cnp.NPY_CDOUBLE:
-                info = qr_block_col_delete(m, o, n, <double_complex*>extract(q1, qs), qs,
-                    <double_complex*>extract(r1, rs), rs, k1, p1)
+            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+            {{COND}} typecode == {{TYPECODE}}:
+                info = qr_block_col_delete(m, o, n, <{{CNAME}}*>qptr, qs,
+                    <{{CNAME}}*>rptr, rs, k1, p1)
+            {{endfor}}
             if info == MEMORY_ERROR:
                 raise MemoryError('Unable to allocate memory for array')
         if economic:
@@ -1916,6 +1856,9 @@ def qr_insert_row(Q, R, u, k, overwrite_qru, check_finite):
     cdef int j, k1 = k 
     cdef int u_flags = cnp.NPY_BEHAVED_NS | cnp.NPY_ELEMENTSTRIDES
     cdef int typecode, m, n, p, info 
+    cdef void* qptr
+    cdef void* rptr
+    cdef void* uptr
     cdef int qs[2]
     cdef int rs[2]
     cdef int us[2]
@@ -1972,50 +1915,26 @@ def qr_insert_row(Q, R, u, k, overwrite_qru, check_finite):
             qnew[m+j, n+j] = 1
 
         if p == 1:
-            if typecode == cnp.NPY_FLOAT:
-                thin_qr_row_insert(m+p, n,
-                        <float*>extract(qnew, qs), qs,
-                        <float*>extract(r1, rs), rs,
-                        <float*>extract(u1, us), us, k1)
-            elif typecode == cnp.NPY_DOUBLE:
-                thin_qr_row_insert(m+p, n,
-                        <double*>extract(qnew, qs), qs,
-                        <double*>extract(r1, rs), rs,
-                        <double*>extract(u1, us), us, k1)
-            elif typecode == cnp.NPY_CFLOAT:
-                thin_qr_row_insert(m+p, n,
-                        <float_complex*>extract(qnew, qs), qs,
-                        <float_complex*>extract(r1, rs), rs,
-                        <float_complex*>extract(u1, us), us, k1)
-            else:  # cnp.NPY_CDOUBLE:
-                thin_qr_row_insert(m+p, n,
-                        <double_complex*>extract(qnew, qs), qs,
-                        <double_complex*>extract(r1, rs), rs,
-                        <double_complex*>extract(u1, us), us, k1)
+            qptr = extract(qnew, qs)
+            rptr = extract(r1, rs)
+            uptr = extract(u1, us)
+            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+            {{COND}} typecode == {{TYPECODE}}:
+                thin_qr_row_insert(m+p, n, <{{CNAME}}*>qptr, qs,
+                    <{{CNAME}}*>rptr, rs, <{{CNAME}}*>uptr, us, k1)
+            {{endfor}}
         else:
             # only copies if if necessary.
             r1 = PyArray_FromArray(r1, NULL, cnp.NPY_F_CONTIGUOUS)
             u1 = PyArray_FromArray(u1, NULL, cnp.NPY_F_CONTIGUOUS)
-            if typecode == cnp.NPY_FLOAT:
-                thin_qr_block_row_insert(m+p, n,
-                        <float*>extract(qnew, qs), qs,
-                        <float*>extract(r1, rs), rs,
-                        <float*>extract(u1, us), us, k1, p)
-            elif typecode == cnp.NPY_DOUBLE:
-                thin_qr_block_row_insert(m+p, n,
-                        <double*>extract(qnew, qs), qs,
-                        <double*>extract(r1, rs), rs,
-                        <double*>extract(u1, us), us, k1, p)
-            elif typecode == cnp.NPY_CFLOAT:
-                thin_qr_block_row_insert(m+p, n,
-                        <float_complex*>extract(qnew, qs), qs,
-                        <float_complex*>extract(r1, rs), rs,
-                        <float_complex*>extract(u1, us), us, k1, p)
-            else:  # cnp.NPY_CDOUBLE:
-                thin_qr_block_row_insert(m+p, n,
-                        <double_complex*>extract(qnew, qs), qs,
-                        <double_complex*>extract(r1, rs), rs,
-                        <double_complex*>extract(u1, us), us, k1, p)
+            qptr = extract(qnew, qs)
+            rptr = extract(r1, rs)
+            uptr = extract(u1, us)
+            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+            {{COND}} typecode == {{TYPECODE}}:
+                thin_qr_block_row_insert(m+p, n, <{{CNAME}}*>qptr, qs,
+                    <{{CNAME}}*>rptr, rs, <{{CNAME}}*>uptr, us, k1, p)
+            {{endfor}}
         return qnew[:, :-p], r1
     else:
         shape[0] = m + p
@@ -2030,36 +1949,20 @@ def qr_insert_row(Q, R, u, k, overwrite_qru, check_finite):
         for j in range(m, m+p):
             qnew[j, j] = 1
 
+        qptr = extract(qnew, qs)
+        rptr = extract(rnew, rs)
         if p == 1:
-            if typecode == cnp.NPY_FLOAT:
-                qr_row_insert(m+p, n, <float*>extract(qnew, qs), qs,
-                        <float*>extract(rnew, rs), rs, k1)
-            elif typecode == cnp.NPY_DOUBLE:
-                qr_row_insert(m+p, n, <double*>extract(qnew, qs), qs,
-                        <double*>extract(rnew, rs), rs, k1)
-            elif typecode == cnp.NPY_CFLOAT:
-                qr_row_insert(m+p, n, <float_complex*>extract(qnew, qs), qs,
-                        <float_complex*>extract(rnew, rs), rs, k1)
-            else:  # cnp.NPY_CDOUBLE:
-                qr_row_insert(m+p, n, <double_complex*>extract(qnew, qs),
-                        qs, <double_complex*>extract(rnew, rs), rs, k1)
+            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+            {{COND}} typecode == {{TYPECODE}}:
+                qr_row_insert(m+p, n, <{{CNAME}}*>qptr, qs,
+                    <{{CNAME}}*>rptr, rs, k1)
+            {{endfor}}
         else:
-            if typecode == cnp.NPY_FLOAT:
-                info = qr_block_row_insert(m+p, n,
-                        <float*>extract(qnew, qs), qs,
-                        <float*>extract(rnew, rs), rs, k1, p)
-            elif typecode == cnp.NPY_DOUBLE:
-                info = qr_block_row_insert(m+p, n,
-                        <double*>extract(qnew, qs), qs,
-                        <double*>extract(rnew, rs), rs, k1, p)
-            elif typecode == cnp.NPY_CFLOAT:
-                info = qr_block_row_insert(m+p, n,
-                        <float_complex*>extract(qnew, qs), qs,
-                        <float_complex*>extract(rnew, rs), rs, k1, p)
-            else:  # cnp.NPY_CDOUBLE
-                info = qr_block_row_insert(m+p, n,
-                        <double_complex*>extract(qnew, qs), qs,
-                        <double_complex*>extract(rnew, rs), rs, k1, p)
+            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+            {{COND}} typecode == {{TYPECODE}}:
+                info = qr_block_row_insert(m+p, n, <{{CNAME}}*>qptr, qs,
+                    <{{CNAME}}*>rptr, rs, k1, p)
+            {{endfor}}
             if info == MEMORY_ERROR:
                 raise MemoryError('Unable to allocate memory for array')
         return qnew, rnew
@@ -2070,8 +1973,10 @@ def qr_insert_col(Q, R, u, k, rcond, overwrite_qru, check_finite):
     cdef int q_flags = ARRAY_ANYORDER
     cdef int u_flags = cnp.NPY_BEHAVED_NS | cnp.NPY_ELEMENTSTRIDES
     cdef int typecode, m, n, p, info, p_eco, p_full
+    cdef void* qptr
+    cdef void* rptr
+    cdef void* uptr
     cdef int qs[2]
-    cdef void* rvoid
     cdef int rs[2]
     cdef int us[2]
     cdef cnp.npy_intp shape[2]
@@ -2141,24 +2046,18 @@ def qr_insert_col(Q, R, u, k, rcond, overwrite_qru, check_finite):
         rnew[:n,:k1] = r1[:,:k1]
         rnew[:n,k1+p:] = r1[:,k1:]
         u1 = validate_array(u1, check_finite)
-        if typecode == cnp.NPY_FLOAT:
-            info = thin_qr_col_insert(m, n, <float*>extract(qnew, qs), qs,
-                    <float*>extract(rnew, rs), rs,
-                    <float*>extract(u1, us), us, k1, p_eco, p_full, &frc)
-        elif typecode == cnp.NPY_DOUBLE:
-            info = thin_qr_col_insert(m, n, <double*>extract(qnew, qs), qs,
-                    <double*>extract(rnew, rs), rs,
-                    <double*>extract(u1, us), us, k1, p_eco, p_full, &drc)
-        elif typecode == cnp.NPY_CFLOAT:
-            info = thin_qr_col_insert(m, n, <float_complex*>extract(qnew, qs), qs,
-                    <float_complex*>extract(rnew, rs), rs,
-                    <float_complex*>extract(u1, us), us, k1, p_eco, p_full,
-                    <float_complex*>&frc)
-        else:  # cnp.NPY_CDOUBLE:
-            info = thin_qr_col_insert(m, n, <double_complex*>extract(qnew, qs), qs,
-                    <double_complex*>extract(rnew, rs), rs,
-                    <double_complex*>extract(u1, us), us, k1, p_eco, p_full,
-                    <double_complex*>&drc)
+        qptr = extract(qnew, qs)
+        rptr = extract(rnew, rs)
+        uptr = extract(u1, us)
+{{py: 
+RCONDS = ['&frc', '&drc', '<float_complex*>&frc', '<double_complex*>&drc']
+}}
+        {{for COND, TYPECODE, CNAME, RC in zip(CONDS, TCODES, CNAMES, RCONDS)}}
+        {{COND}} typecode == {{TYPECODE}}:
+            info = thin_qr_col_insert(m, n, <{{CNAME}}*>qptr, qs,
+                <{{CNAME}}*>rptr, rs, <{{CNAME}}*>uptr, us, k1, p_eco,
+                p_full, {{RC}})
+        {{endfor}}
         if info == 2:
             raise LinAlgError("One of the columns of u lies in the span of Q. "
                               "Found reciprocal condition number of %s for Q "
@@ -2180,41 +2079,24 @@ def qr_insert_col(Q, R, u, k, rcond, overwrite_qru, check_finite):
         rnew[:,k1+p:] = r1[:,k1:]
 
         u1 = validate_array(u1, check_finite)
-        rvoid = extract(rnew, rs)
-        form_qTu(q1, u1, rvoid, rs, k1)
+        rptr = extract(rnew, rs)
+        form_qTu(q1, u1, rptr, rs, k1)
         if not overwrite_qru:
             q1 = q1.copy('F')
         
+        qptr = extract(q1, qs)
         if p == 1:
-            if typecode == cnp.NPY_FLOAT:
-                qr_col_insert(m, n+p, <float*>extract(q1, qs), qs,
-                        <float*>rvoid, rs, k1)
-            elif typecode == cnp.NPY_DOUBLE:
-                qr_col_insert(m, n+p, <double*>extract(q1, qs), qs,
-                        <double*>rvoid, rs, k1)
-            elif typecode == cnp.NPY_CFLOAT:
-                qr_col_insert(m, n+p, <float_complex*>extract(q1, qs), qs,
-                        <float_complex*>rvoid, rs, k1)
-            else:  # cnp.NPY_CDOUBLE
-                qr_col_insert(m, n+p, <double_complex*>extract(q1, qs), qs,
-                        <double_complex*>rvoid, rs, k1)
+            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+            {{COND}} typecode == {{TYPECODE}}:
+                qr_col_insert(m, n+p, <{{CNAME}}*>qptr, qs,
+                    <{{CNAME}}*>rptr, rs, k1)
+            {{endfor}}
         else:
-            if typecode == cnp.NPY_FLOAT:
-                info = qr_block_col_insert(m, n+p,
-                        <float*>extract(q1, qs), qs,
-                        <float*>rvoid, rs, k1, p)
-            elif typecode == cnp.NPY_DOUBLE:
-                info = qr_block_col_insert(m, n+p,
-                        <double*>extract(q1, qs), qs,
-                        <double*>rvoid, rs, k1, p)
-            elif typecode == cnp.NPY_CFLOAT:
-                info = qr_block_col_insert(m, n+p,
-                        <float_complex*>extract(q1, qs),
-                        qs, <float_complex*>rvoid, rs, k1, p)
-            else:  # cnp.NPY_CDOUBLE:
-                info = qr_block_col_insert(m, n+p,
-                        <double_complex*>extract(q1, qs),
-                        qs, <double_complex*>rvoid, rs, k1, p)
+            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+            {{COND}} typecode == {{TYPECODE}}:
+                info = qr_block_col_insert(m, n+p, <{{CNAME}}*>qptr, qs,
+                    <{{CNAME}}*>rptr, rs, k1, p)
+            {{endfor}}
             if info != 0:
                 if info > 0: 
                     raise ValueError('The {0}th argument to ?geqrf was '
@@ -2382,9 +2264,14 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
     cdef cnp.ndarray q1, r1, u1, v1, qTu, s
     cdef int uv_flags = cnp.NPY_BEHAVED_NS | cnp.NPY_ELEMENTSTRIDES
     cdef int typecode, p, m, n, info
+    cdef void* qptr
+    cdef void* rptr
+    cdef void* uptr
+    cdef void* vptr
+    cdef void* sptr
+    cdef void* qTuptr
     cdef int qs[2]
     cdef int rs[2]
-    cdef void* qTuvoid
     cdef int qTus[2]
     cdef int us[2]
     cdef int vs[2]
@@ -2443,95 +2330,41 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
             qisF = True
         else:
             qisF = False
+        qptr = extract(q1, qs)
+        rptr = extract(r1, rs)
+        uptr = extract(u1, us)
+        vptr = extract(v1, vs)
+        sptr = extract(s, ss)
         if p == 1:
-            if typecode == cnp.NPY_FLOAT:
-                thin_qr_rank_1_update(m, n,
-                    <float*>extract(q1, qs), qs, qisF,
-                    <float*>extract(r1, rs), rs,
-                    <float*>extract(u1, us), us,
-                    <float*>extract(v1, vs), vs,
-                    <float*>extract(s, ss), ss)
-            elif typecode == cnp.NPY_DOUBLE:
-                thin_qr_rank_1_update(m, n,
-                    <double*>extract(q1, qs), qs, qisF,
-                    <double*>extract(r1, rs), rs,
-                    <double*>extract(u1, us), us,
-                    <double*>extract(v1, vs), vs,
-                    <double*>extract(s, ss), ss)
-            elif typecode == cnp.NPY_CFLOAT:
-                thin_qr_rank_1_update(m, n,
-                    <float_complex*>extract(q1, qs), qs, qisF,
-                    <float_complex*>extract(r1, rs), rs,
-                    <float_complex*>extract(u1, us), us,
-                    <float_complex*>extract(v1, vs), vs,
-                    <float_complex*>extract(s, ss), ss)
-            else: # cnp.NPY_CDOUBLE
-                thin_qr_rank_1_update(m, n,
-                    <double_complex*>extract(q1, qs), qs, qisF,
-                    <double_complex*>extract(r1, rs), rs,
-                    <double_complex*>extract(u1, us), us,
-                    <double_complex*>extract(v1, vs), vs,
-                    <double_complex*>extract(s, ss), ss)
+            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+            {{COND}} typecode == {{TYPECODE}}:
+                thin_qr_rank_1_update(m, n, <{{CNAME}}*>qptr, qs, qisF,
+                    <{{CNAME}}*>rptr, rs, <{{CNAME}}*>uptr, us,
+                    <{{CNAME}}*>vptr, vs, <{{CNAME}}*>sptr, ss)
+            {{endfor}}
         else:
-            if typecode == cnp.NPY_FLOAT:
-                thin_qr_rank_p_update(m, n, p,
-                    <float*>extract(q1, qs), qs, qisF,
-                    <float*>extract(r1, rs), rs,
-                    <float*>extract(u1, us), us,
-                    <float*>extract(v1, vs), vs,
-                    <float*>extract(s, ss), ss)
-            elif typecode == cnp.NPY_DOUBLE:
-                thin_qr_rank_p_update(m, n, p,
-                    <double*>extract(q1, qs), qs, qisF,
-                    <double*>extract(r1, rs), rs,
-                    <double*>extract(u1, us), us,
-                    <double*>extract(v1, vs), vs,
-                    <double*>extract(s, ss), ss)
-            elif typecode == cnp.NPY_CFLOAT:
-                thin_qr_rank_p_update(m, n, p,
-                    <float_complex*>extract(q1, qs), qs, qisF,
-                    <float_complex*>extract(r1, rs), rs,
-                    <float_complex*>extract(u1, us), us,
-                    <float_complex*>extract(v1, vs), vs,
-                    <float_complex*>extract(s, ss), ss)
-            else: # cnp.NPY_CDOUBLE
-                thin_qr_rank_p_update(m, n, p,
-                    <double_complex*>extract(q1, qs), qs, qisF,
-                    <double_complex*>extract(r1, rs), rs,
-                    <double_complex*>extract(u1, us), us,
-                    <double_complex*>extract(v1, vs), vs,
-                    <double_complex*>extract(s, ss), ss)
+            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+            {{COND}} typecode == {{TYPECODE}}:
+                thin_qr_rank_p_update(m, n, p, <{{CNAME}}*>qptr, qs, qisF,
+                    <{{CNAME}}*>rptr, rs, <{{CNAME}}*>uptr, us,
+                    <{{CNAME}}*>vptr, vs, <{{CNAME}}*>sptr, ss)
+            {{endfor}}
     else:
         qTu = cnp.PyArray_ZEROS(u1.ndim, u1.shape, typecode, 1)
-        qTuvoid = extract(qTu, qTus)
+        qTuptr = extract(qTu, qTus)
         if p == 1:
             if not cnp.PyArray_ISONESEGMENT(q1):
                 q1 = PyArray_FromArray(q1, NULL, cnp.NPY_F_CONTIGUOUS)
-            form_qTu(q1, u1, qTuvoid, qTus, 0)
-            if typecode == cnp.NPY_FLOAT:
-                qr_rank_1_update(m, n,
-                    <float*>extract(q1, qs), qs,
-                    <float*>extract(r1, rs), rs,
-                    <float*>qTuvoid, qTus,
-                    <float*>extract(v1, vs), vs)
-            elif typecode == cnp.NPY_DOUBLE:
-                qr_rank_1_update(m, n,
-                    <double*>extract(q1, qs), qs,
-                    <double*>extract(r1, rs), rs,
-                    <double*>qTuvoid, qTus,
-                    <double*>extract(v1, vs), vs)
-            elif typecode == cnp.NPY_CFLOAT:
-                qr_rank_1_update(m, n,
-                    <float_complex*>extract(q1, qs), qs,
-                    <float_complex*>extract(r1, rs), rs,
-                    <float_complex*>qTuvoid, qTus,
-                    <float_complex*>extract(v1, vs), vs)
-            else: # cnp.NPY_CDOUBLE
-                qr_rank_1_update(m, n,
-                    <double_complex*>extract(q1, qs), qs,
-                    <double_complex*>extract(r1, rs), rs,
-                    <double_complex*>qTuvoid, qTus,
-                    <double_complex*>extract(v1, vs), vs)
+            form_qTu(q1, u1, qTuptr, qTus, 0)
+            qptr = extract(q1, qs)
+            rptr = extract(r1, rs)
+            vptr = extract(v1, vs)
+            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+            {{COND}} typecode == {{TYPECODE}}:
+                qr_rank_1_update(m, n, <{{CNAME}}*>qptr, qs,
+                    <{{CNAME}}*>rptr, rs, <{{CNAME}}*>qTuptr, qTus,
+                    <{{CNAME}}*>vptr, vs)
+            {{endfor}}
         else:
             if not cnp.PyArray_CHKFLAGS(q1, cnp.NPY_F_CONTIGUOUS):
                 q1 = PyArray_FromArray(q1, NULL, cnp.NPY_F_CONTIGUOUS)
@@ -2542,33 +2375,17 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
             # v.T must be F contiguous --> v must be C contiguous
             if not cnp.PyArray_CHKFLAGS(v1, cnp.NPY_C_CONTIGUOUS):
                 v1 = PyArray_FromArray(v1, NULL, cnp.NPY_C_CONTIGUOUS)
-
             v1 = v1.T
-            form_qTu(q1, u1, qTuvoid, qTus, 0)
-            if typecode == cnp.NPY_FLOAT:
-                info = qr_rank_p_update(m, n, p,
-                    <float*>extract(q1, qs), qs,
-                    <float*>extract(r1, rs), rs,
-                    <float*>qTuvoid, qTus,
-                    <float*>extract(v1, vs), vs)
-            elif typecode == cnp.NPY_DOUBLE:
-                info = qr_rank_p_update(m, n, p,
-                    <double*>extract(q1, qs), qs,
-                    <double*>extract(r1, rs), rs,
-                    <double*>qTuvoid, qTus,
-                    <double*>extract(v1, vs), vs)
-            elif typecode == cnp.NPY_CFLOAT:
-                info = qr_rank_p_update(m, n, p,
-                    <float_complex*>extract(q1, qs), qs,
-                    <float_complex*>extract(r1, rs), rs,
-                    <float_complex*>qTuvoid, qTus,
-                    <float_complex*>extract(v1, vs), vs)
-            else: # cnp.NPY_CDOUBLE
-                info = qr_rank_p_update(m, n, p,
-                    <double_complex*>extract(q1, qs), qs,
-                    <double_complex*>extract(r1, rs), rs,
-                    <double_complex*>qTuvoid, qTus,
-                    <double_complex*>extract(v1, vs), vs)
+            form_qTu(q1, u1, qTuptr, qTus, 0)
+            qptr = extract(q1, qs)
+            rptr = extract(r1, rs)
+            vptr = extract(v1, vs)
+            {{for COND, TYPECODE, CNAME in zip(CONDS, TCODES, CNAMES)}}
+            {{COND}} typecode == {{TYPECODE}}:
+                info = qr_rank_p_update(m, n, p, <{{CNAME}}*>qptr, qs,
+                    <{{CNAME}}*>rptr, rs, <{{CNAME}}*>qTuptr, qTus,
+                    <{{CNAME}}*>vptr, vs)
+            {{endfor}}
             if info != 0:
                 if info > 0: 
                     raise ValueError('The {0}th argument to ?geqrf was '

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -29,7 +29,7 @@ Routines for updating QR decompositions
 #    factorization. Math. Comput. 30, 772-795 (1976).
 #
 # 5. Reichel, L. & Gragg, W. B. Algorithm 686: FORTRAN Subroutines for
-#    Updating the QR Decomposition. ACM Trans. Math. Softw. 16, 369–377 (1990).
+#    Updating the QR Decomposition. ACM Trans. Math. Softw. 16, 3693-77 (1990).
 # 
 
 {{py: 
@@ -65,8 +65,8 @@ cdef extern from *:
     cnp.ndarray PyArray_CheckFromAny(object, void*, int, int, int, void*)
     cnp.ndarray PyArray_FromArray(cnp.ndarray, void*, int)
 
-from scipy.linalg cimport blas_pointers
-from scipy.linalg cimport lapack_pointers
+from . cimport cython_blas as blas_pointers
+from . cimport cython_lapack as lapack_pointers
 
 import numpy as np
 
@@ -120,86 +120,10 @@ cdef inline void axpy(int n, blas_t a, blas_t* x, int incx,
     {{endfor}}
 
 cdef inline blas_t nrm2(int n, blas_t* x, int incx) nogil:
-    # since dnrm2 etc are functions, we can't at present call them...
-    # this is mostly cribbed from netlib's dnrm2
-    cdef double norm, scale, ssq, absxi
-    cdef float fnorm, fscale, fssq, fabsxi
-    if blas_t is float:
-        if n < 1 or incx < 1:
-            fnorm = 0
-        elif n == 1:
-            fnorm = fabs(x[0])
-        else:
-            fscale = 0.0
-            fssq = 1.0
-    
-            for k in range(n):
-                if index1(x, &incx, k)[0] != 0:
-                    fabsxi = fabs(index1(x, &incx, k)[0])
-                    if fscale < fabsxi:
-                        fssq = 1 + fssq * (fscale/fabsxi)**2
-                        fscale = fabsxi
-                    else:
-                        fssq = fssq + (fabsxi/fscale)**2
-            fnorm = fscale*sqrt(fssq)
-        return fnorm
-    elif blas_t is double:
-        if n < 1 or incx < 1:
-            norm = 0
-        elif n == 1:
-            norm = fabs(x[0])
-        else:
-            scale = 0.0
-            ssq = 1.0
-    
-            for k in range(n):
-                if index1(x, &incx, k)[0] != 0:
-                    absxi = fabs(index1(x, &incx, k)[0])
-                    if scale < absxi:
-                        ssq = 1 + ssq * (scale/absxi)**2
-                        scale = absxi
-                    else:
-                        ssq = ssq + (absxi/scale)**2
-            norm = scale*sqrt(ssq)
-        return norm
-    elif blas_t is float_complex:
-        if n < 1 or incx < 1:
-            fnorm = 0
-        elif n == 1:
-            fnorm = hypot(x[0].real, x[0].imag)
-        else:
-            fscale = 0.0
-            fssq = 1.0
-    
-            for k in range(n):
-                if index1(x, &incx, k)[0] != 0:
-                    fabsxi = hypot(index1(x, &incx, k)[0].real, index1(x, &incx, k)[0].imag)
-                    if fscale < fabsxi:
-                        fssq = 1 + fssq * (fscale/fabsxi)**2
-                        fscale = fabsxi
-                    else:
-                        fssq = fssq + (fabsxi/fscale)**2
-            fnorm = fscale*sqrt(fssq)
-        return fnorm
-    else:
-        if n < 1 or incx < 1:
-            norm = 0
-        elif n == 1:
-            norm = hypot(x[0].real, x[0].imag)
-        else:
-            scale = 0.0
-            ssq = 1.0
-    
-            for k in range(n):
-                if index1(x, &incx, k)[0] != 0:
-                    absxi = hypot(index1(x, &incx, k)[0].real, index1(x, &incx, k)[0].imag)
-                    if scale < absxi:
-                        ssq = 1 + ssq * (scale/absxi)**2
-                        scale = absxi
-                    else:
-                        ssq = ssq + (absxi/scale)**2
-            norm = scale*sqrt(ssq)
-        return norm
+    {{for COND, CNAME, C in zip(CONDS, CNAMES, ['s', 'd', 'sc', 'dz'])}}
+    {{COND}} blas_t is {{CNAME}}:
+        return blas_pointers.{{C}}nrm2(&n, x, &incx)
+    {{endfor}}
 
 cdef inline void lartg(blas_t* a, blas_t* b, blas_t* c, blas_t* s) nogil:
     cdef blas_t g
@@ -397,7 +321,6 @@ cdef bint reorthx(int m, int n, blas_t* q, int* qs, bint qisF, int j, blas_t* u,
             blas_t_conj(m, u, &ss)
             blas_t_conj(n, s+n, &ss)
         gemv(T, n, m, -1, q, n, s+n, 1, 1, u, 1)
-        
     wpnorm = nrm2(m, u, 1) 
     
     if blas_t_less_than(wpnorm, wnorm/inv_root2): # u lies in span(q) 
@@ -1569,7 +1492,7 @@ def qr_delete(Q, R, k, p=1, which='row', overwrite_qr=False, check_finite=True):
            Gram-Schmidt QR factorization. Math. Comput. 30, 772-795 (1976).
 
     .. [3] Reichel, L. & Gragg, W. B. Algorithm 686: FORTRAN Subroutines for
-           Updating the QR Decomposition. ACM Trans. Math. Softw. 16, 369–377
+           Updating the QR Decomposition. ACM Trans. Math. Softw. 16, 369-377
            (1990).
 
     Examples
@@ -1787,7 +1710,7 @@ def qr_insert(Q, R, u, k, which='row', rcond=None, overwrite_qru=False, check_fi
            Gram-Schmidt QR factorization. Math. Comput. 30, 772-795 (1976).
 
     .. [3] Reichel, L. & Gragg, W. B. Algorithm 686: FORTRAN Subroutines for
-           Updating the QR Decomposition. ACM Trans. Math. Softw. 16, 369–377
+           Updating the QR Decomposition. ACM Trans. Math. Softw. 16, 369-377
            (1990).
 
     Examples
@@ -2174,7 +2097,7 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
            Gram-Schmidt QR factorization. Math. Comput. 30, 772-795 (1976).
 
     .. [3] Reichel, L. & Gragg, W. B. Algorithm 686: FORTRAN Subroutines for
-           Updating the QR Decomposition. ACM Trans. Math. Softw. 16, 369–377
+           Updating the QR Decomposition. ACM Trans. Math. Softw. 16, 369-377
            (1990).
 
     Examples

--- a/scipy/linalg/bento.info
+++ b/scipy/linalg/bento.info
@@ -34,3 +34,6 @@ Library:
         Sources:
             cython_lapack.c,
             _lapack_subroutine_wrappers.f
+    Extension: _decomp_update
+        Sources:
+            _decomp_update.c

--- a/scipy/linalg/fblas_l1.pyf.src
+++ b/scipy/linalg/fblas_l1.pyf.src
@@ -109,7 +109,7 @@ subroutine <tchar=s,d,cs,zd>rot(n,x,offx,incx,y,offy,incy,c,s)
   check(offx>=0 && offx<len(x)) :: offx
   check(offy>=0 && offy<len(y)) :: offy
   integer optional, intent(in), depend(x,incx,offx,y,incy,offy) :: &
-       n = (len(x)-offx)/abs(incx)
+       n = (len(x)-1-offx)/abs(incx)+1
   check(len(x)-offx>(n-1)*abs(incx)) :: n
   check(len(y)-offy>(n-1)*abs(incy)) :: n
 

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -2759,7 +2759,6 @@ subroutine zhegvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,m,w,z,l
     integer intent(out) :: info
 end subroutine zhegvx
 
-
 function <prefix2>lange(norm,m,n,a,lda,work) result(n2)
     ! the one norm, or the Frobenius norm, or the  infinity norm, or the
     ! element of largest absolute value of a real matrix A.
@@ -2792,8 +2791,52 @@ function <prefix2c>lange(norm,m,n,a,lda,work) result(n2)
     <ftype2> dimension(MAX(m,1)),intent(cache,hide) :: work
 end function <prefix2c>lange
 
+subroutine <prefix>larfg(n, alpha, x, incx, tau)
+    integer intent(in), check(n>=1) :: n
+    <ftype> intent(in,out) :: alpha
+    <ftype> intent(in,copy,out), dimension(*), depend(n,incx), check(len(x) >= (n-2)*incx) :: x
+    integer intent(in), check(incx>0||incx<0) :: incx = 1
+    <ftype> intent(out) :: tau
+end subroutine <prefix>larfg
 
+subroutine <prefix>larf(side,m,n,v,incv,tau,c,ldc,work)
+    character intent(in), check(side[0]=='L'||side[0]=='R') :: side = 'L'
+    integer intent(in,hide), depend(c) :: m = shape(c,0)
+    integer intent(in,hide), depend(c) :: n = shape(c,1)
+    <ftype> dimension(*), intent(in), depend(n,m,side,incv), check(side[0]=='L'?len(v)>=(m-1)*incv+1:len(v)>=(n-1)*incv+1) :: v
+    integer intent(in), check(incv>0||incv<0) :: incv = 1
+    <ftype> intent(in) :: tau
+    <ftype> dimension(m,n), intent(in,copy,out) :: c
+    integer intent(in,hide) :: ldc = shape(c,0)
+    <ftype> dimension(*), intent(in), depend(side,m,n), check(side[0]=='L'?len(work)>=n:len(work)>=m) :: work
+end subroutine <prefix>larf
 
+subroutine <prefix>lartg(f,g,cs,sn,r)
+    <ftype> intent(in) :: f
+    <ftype> intent(in) :: g
+    <real,double precision,\0,\1> intent(out) :: cs
+    <ftype> intent(out) :: sn
+    <ftype> intent(out) :: r
+end subroutine <prefix>lartg
+
+subroutine <prefix2c>rot(n,x,offx,incx,y,offy,incy,c,s)
+    callstatement (*f2py_func)(&n,x+offx,&incx,y+offy,&incy,&c,&s)
+    callprotoargument int*,<ctype2c>*,int*,<ctype2c>*,int*,<float,double>*,<ctype2c>*
+    <ftype2c> dimension(*),intent(in,out,copy) :: x,y
+    <real,double precision> intent(in) :: c
+    <ftype2c> intent(in) :: s
+    integer optional, intent(in), check(incx>0||incx<0) :: incx = 1
+    integer optional, intent(in), check(incy>0||incy<0) :: incy = 1
+    integer optional, intent(in), depend(x) :: offx=0
+    integer optional, intent(in), depend(y) :: offy=0
+    check(offx>=0 && offx<len(x)) :: offx
+    check(offy>=0 && offy<len(y)) :: offy
+    integer optional, intent(in), depend(x,incx,offx,y,incy,offy) :: &
+        n = (len(x)-1-offx)/abs(incx)+1
+    check(len(x)-offx>(n-1)*abs(incx)) :: n
+    check(len(y)-offy>(n-1)*abs(incy)) :: n
+end subroutine <prefix2c>rot
+ 
 end interface
 
 end python module _flapack

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -190,6 +190,21 @@ All functions
    chegvx
    zhegvx
    
+   slarf
+   dlarf
+   clarf
+   zlarf
+
+   slarfg
+   dlarfg
+   clarfg
+   zlarfg
+
+   slartg
+   dlartg
+   clartg
+   zlartg
+
    dlasd4
    slasd4
 
@@ -238,6 +253,9 @@ All functions
    cpotrs
    zpotrs
 
+   crot
+   zrot
+
    strsyl
    dtrsyl
    ctrsyl
@@ -280,7 +298,6 @@ All functions
 
    sorghr
    dorghr
-
    sorgqr
    dorgqr
 

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -156,6 +156,9 @@ def configuration(parent_package='',top_path=None):
                          libraries=['fwrappers'],
                          extra_info=lapack_opt)
 
+    config.add_extension('_decomp_update',
+                         sources=['_decomp_update.c'])
+
     return config
 
 

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -840,9 +840,20 @@ class BaseQRupdate(BaseQRdeltas):
         a1 = a + np.outer(u, v.conj())
         check_qr(q1, r1, a1, self.rtol, self.atol, False)
 
-    def base_non_simple_strides(self, adjust_strides, p, overwriteable):
+    def test_economic_rank_p(self):
+        for p in [1, 2, 3, 5]:
+            a, q, r, u, v = self.generate('tall', 'economic', p)
+            if p == 1:
+                u = u.reshape(u.size, 1)
+                v = v.reshape(v.size, 1)
+            q1, r1 = qr_update(q, r, u, v, False)
+            a1 = a + np.dot(u, v.T.conj())
+            check_qr(q1, r1, a1, self.rtol, self.atol, False)
+
+    def base_non_simple_strides(self, adjust_strides, mode, p, overwriteable):
+        assert_sqr = False if mode == 'economic' else True
         for type in ['sqr', 'tall', 'fat']:
-            a, q0, r0, u0, v0 = self.generate(type, p=p)
+            a, q0, r0, u0, v0 = self.generate(type, mode, p)
             qs, rs, us, vs = adjust_strides((q0, r0, u0, v0))
             if p == 1:
                 aup = a + np.outer(u0, v0.conj())
@@ -859,9 +870,9 @@ class BaseQRupdate(BaseQRdeltas):
             u = u0.copy('F')
             v = v0.copy('C')
             q1, r1 = qr_update(qs, r, u, v, False)
-            check_qr(q1, r1, aup, self.rtol, self.atol)
+            check_qr(q1, r1, aup, self.rtol, self.atol, assert_sqr)
             q1o, r1o = qr_update(qs, r, u, v, True)
-            check_qr(q1o, r1o, aup, self.rtol, self.atol)
+            check_qr(q1o, r1o, aup, self.rtol, self.atol, assert_sqr)
             if overwriteable:
                 assert_allclose(r1o, r, rtol=self.rtol, atol=self.atol)
                 assert_allclose(v, v0.conj(), rtol=self.rtol, atol=self.atol)
@@ -871,9 +882,9 @@ class BaseQRupdate(BaseQRdeltas):
             u = u0.copy('F')
             v = v0.copy('C')
             q2, r2 = qr_update(q, rs, u, v, False)
-            check_qr(q2, r2, aup, self.rtol, self.atol)
+            check_qr(q2, r2, aup, self.rtol, self.atol, assert_sqr)
             q2o, r2o = qr_update(q, rs, u, v, True)
-            check_qr(q2o, r2o, aup, self.rtol, self.atol)
+            check_qr(q2o, r2o, aup, self.rtol, self.atol, assert_sqr)
             if overwriteable:
                 assert_allclose(r2o, rs, rtol=self.rtol, atol=self.atol)
                 assert_allclose(v, v0.conj(), rtol=self.rtol, atol=self.atol)
@@ -883,9 +894,9 @@ class BaseQRupdate(BaseQRdeltas):
             u = u0.copy('F')
             v = v0.copy('C')
             q3, r3 = qr_update(q, r, us, v, False)
-            check_qr(q3, r3, aup, self.rtol, self.atol)
+            check_qr(q3, r3, aup, self.rtol, self.atol, assert_sqr)
             q3o, r3o = qr_update(q, r, us, v, True)
-            check_qr(q3o, r3o, aup, self.rtol, self.atol)
+            check_qr(q3o, r3o, aup, self.rtol, self.atol, assert_sqr)
             if overwriteable:
                 assert_allclose(r3o, r, rtol=self.rtol, atol=self.atol)
                 assert_allclose(v, v0.conj(), rtol=self.rtol, atol=self.atol)
@@ -895,9 +906,9 @@ class BaseQRupdate(BaseQRdeltas):
             u = u0.copy('F')
             v = v0.copy('C')
             q4, r4 = qr_update(q, r, u, vs, False)
-            check_qr(q4, r4, aup, self.rtol, self.atol)
+            check_qr(q4, r4, aup, self.rtol, self.atol, assert_sqr)
             q4o, r4o = qr_update(q, r, u, vs, True)
-            check_qr(q4o, r4o, aup, self.rtol, self.atol)
+            check_qr(q4o, r4o, aup, self.rtol, self.atol, assert_sqr)
             if overwriteable:
                 assert_allclose(r4o, r, rtol=self.rtol, atol=self.atol)
                 assert_allclose(vs, v0.conj(), rtol=self.rtol, atol=self.atol)
@@ -909,36 +920,61 @@ class BaseQRupdate(BaseQRdeltas):
             # since some of these were consumed above
             qs, rs, us, vs = adjust_strides((q, r, u, v))
             q5, r5 = qr_update(qs, rs, us, vs, False)
-            check_qr(q5, r5, aup, self.rtol, self.atol)
+            check_qr(q5, r5, aup, self.rtol, self.atol, assert_sqr)
             q5o, r5o = qr_update(qs, rs, us, vs, True)
-            check_qr(q5o, r5o, aup, self.rtol, self.atol)
+            check_qr(q5o, r5o, aup, self.rtol, self.atol, assert_sqr)
             if overwriteable:
                 assert_allclose(r5o, rs, rtol=self.rtol, atol=self.atol)
                 assert_allclose(vs, v0.conj(), rtol=self.rtol, atol=self.atol)
 
     def test_non_unit_strides_rank_1(self):
-        self.base_non_simple_strides(make_strided, 1, True)
+        self.base_non_simple_strides(make_strided, 'full', 1, True)
+
+    def test_non_unit_strides_economic_rank_1(self):
+        self.base_non_simple_strides(make_strided, 'economic', 1, True)
 
     def test_non_unit_strides_rank_p(self):
-        self.base_non_simple_strides(make_strided, 3, False)
+        self.base_non_simple_strides(make_strided, 'full', 3, False)
+
+    def test_non_unit_strides_economic_rank_p(self):
+        self.base_non_simple_strides(make_strided, 'economic', 3, False)
 
     def test_neg_strides_rank_1(self):
-        self.base_non_simple_strides(negate_strides, 1, False)
+        self.base_non_simple_strides(negate_strides, 'full', 1, False)
+
+    def test_neg_strides_economic_rank_1(self):
+        self.base_non_simple_strides(negate_strides, 'economic', 1, False)
 
     def test_neg_strides_rank_p(self):
-        self.base_non_simple_strides(negate_strides, 3, False)
-    
+        self.base_non_simple_strides(negate_strides, 'full', 3, False)
+
+    def test_neg_strides_economic_rank_p(self):
+        self.base_non_simple_strides(negate_strides, 'economic', 3, False)
+     
     def test_non_itemsize_strides_rank_1(self):
-        self.base_non_simple_strides(nonitemsize_strides, 1, False)
+        self.base_non_simple_strides(nonitemsize_strides, 'full', 1, False)
+
+    def test_non_itemsize_strides_economic_rank_1(self):
+        self.base_non_simple_strides(nonitemsize_strides, 'economic', 1, False)
 
     def test_non_itemsize_strides_rank_p(self):
-        self.base_non_simple_strides(nonitemsize_strides, 3, False)
+        self.base_non_simple_strides(nonitemsize_strides, 'full', 3, False)
+
+    def test_non_itemsize_strides_economic_rank_p(self):
+        self.base_non_simple_strides(nonitemsize_strides, 'economic', 3, False)
 
     def test_non_native_byte_order_rank_1(self):
-        self.base_non_simple_strides(make_nonnative, 1, False)
+        self.base_non_simple_strides(make_nonnative, 'full', 1, False)
+
+    def test_non_native_byte_order_economic_rank_1(self):
+        self.base_non_simple_strides(make_nonnative, 'economic', 1, False)
 
     def test_non_native_byte_order_rank_p(self):
-        self.base_non_simple_strides(make_nonnative, 3, False)
+        self.base_non_simple_strides(make_nonnative, 'full', 3, False)
+
+    def test_non_native_byte_order_economic_rank_p(self):
+        self.base_non_simple_strides(make_nonnative, 'economic', 3, False)
+
 
     def test_overwrite_qruv_rank_1(self):
         # Any positive strided q, r, u, and v can be overwritten for a rank 1 
@@ -1021,10 +1057,6 @@ class BaseQRupdate(BaseQRdeltas):
         # verify the overwriting, no good way to check u and v.
         assert_allclose(q2, q, rtol=self.rtol, atol=self.atol)
         assert_allclose(r2, r, rtol=self.rtol, atol=self.atol)
-
-    def test_economic_qr(self):
-        a, q, r, u, v = self.generate('tall', mode='economic', p=3)
-        assert_raises(ValueError, qr_update, q, r, u, v)
 
     def test_empty_inputs(self):
         a, q, r, u, v = self.generate('tall')

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -197,6 +197,37 @@ class BaseQRdelete(BaseQRdeltas):
                 a1 = np.delete(a, slice(col, col+ndel), 1)
                 check_qr(q1, r1, a1, self.rtol, self.atol)
 
+    def test_economic_1_row(self):
+        # this test always starts and ends with an economic decomp.
+        a, q, r = self.generate('tall', 'economic')
+        for row in range(r.shape[0]):
+            q1, r1 = qr_delete(q, r, row, overwrite_qr=False)
+            a1 = np.delete(a, row, 0)
+            check_qr(q1, r1, a1, self.rtol, self.atol, False)
+
+    # for economic row deletes 
+    # eco - prow = eco
+    # eco - prow = sqr
+    # eco - prow = fat
+    def base_economic_p_row_xxx(self, ndel):
+        a, q, r = self.generate('tall', 'economic')
+        for row in range(a.shape[0]-ndel):
+            q1, r1 = qr_delete(q, r, row, ndel, overwrite_qr=False)
+            a1 = np.delete(a, slice(row, row+ndel), 0)
+            check_qr(q1, r1, a1, self.rtol, self.atol, False)
+
+    def test_economic_p_row_economic(self):
+        # (12, 7) - (3, 7) = (9,7) --> stays economic
+        self.base_economic_p_row_xxx(3)
+
+    def test_economic_p_row_sqr(self):
+        # (12, 7) - (5, 7) = (7, 7) --> becomes square
+        self.base_economic_p_row_xxx(5)
+
+    def test_economic_p_row_fat(self):
+        # (12, 7) - (7,7) = (5, 7) --> becomes fat
+        self.base_economic_p_row_xxx(7)
+
     # all row deletes and single column deletes should be able to
     # handle any non negative strides. (only row and column vector
     # operations are used.) p column delete require fortran ordered
@@ -371,7 +402,7 @@ class BaseQRdelete(BaseQRdeltas):
     def test_economic_qr(self):
         a, q, r = self.generate('tall', mode='economic')
         # only test row delete, this logic is shared.
-        assert_raises(ValueError, qr_delete, q, r, 0)
+        assert_raises(ValueError, qr_delete, q, r, 0, 1, 'col')
 
     def test_bad_which(self):
         a, q, r = self.generate('sqr')

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -592,7 +592,7 @@ class BaseQRinsert(BaseQRdeltas):
         self.base_tall_p_col_xxx(3)
 
     def test_tall_p_col_sqr(self):
-        # 12x7 + 12x5 = 12x10 --> becomes sqr
+        # 12x7 + 12x5 = 12x12 --> becomes sqr
         self.base_tall_p_col_xxx(5)
 
     def test_tall_p_col_fat(self):
@@ -658,6 +658,36 @@ class BaseQRinsert(BaseQRdeltas):
             q1, r1 = qr_insert(q, r, u, row, overwrite_qru=False)
             a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
+
+    def test_economic_1_col(self):
+        a, q, r, u = self.generate('tall', 'economic',  which='col')
+        for col in range(r.shape[1]):
+            q1, r1 = qr_insert(q, r, u.copy(), col, 'col', False)
+            a1 = np.insert(a, col, u, 1)
+            check_qr(q1, r1, a1, self.rtol, self.atol, False)
+
+    # for column adds to economic matrices there are three cases to test
+    # eco + pcol --> eco
+    # eco + pcol --> sqr
+    # eco + pcol --> fat
+    def base_economic_p_col_xxx(self, p):
+        a, q, r, u = self.generate('tall', 'economic', which='col', p=p)
+        for col in range(r.shape[1]):
+            q1, r1 = qr_insert(q, r, u, col, 'col', False)
+            a1 = np.insert(a, col*np.ones(p, np.intp), u, 1)
+            check_qr(q1, r1, a1, self.rtol, self.atol, False)
+
+    def test_economic_p_col_eco(self):
+        # 12x7 + 12x3 = 12x10 --> stays eco
+        self.base_economic_p_col_xxx(3)
+
+    def test_economic_p_col_sqr(self):
+        # 12x7 + 12x5 = 12x12 --> becomes sqr
+        self.base_economic_p_col_xxx(5)
+
+    def test_economic_p_col_fat(self):
+        # 12x7 + 12x7 = 12x14 --> becomes fat
+        self.base_economic_p_col_xxx(7)
 
     def base_non_simple_strides(self, adjust_strides, k, p, which):
         for type in ['sqr', 'tall', 'fat']:
@@ -807,10 +837,6 @@ class BaseQRinsert(BaseQRdeltas):
         q2, r2 = qr_insert(q, r, u, 0, 'col', True)
         check_qr(q2, r2, a1, self.rtol, self.atol)
         assert_allclose(q2, q, rtol=self.rtol, atol=self.atol)
-
-    def test_economic_qr(self):
-        a, q, r, u = self.generate('tall', which='col', mode='economic')
-        assert_raises(ValueError, qr_insert, q, r, u, 0, 'col')
 
     def test_empty_inputs(self):
         a, q, r, u = self.generate('sqr', which='row')

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -418,6 +418,23 @@ class BaseQRdelete(BaseQRdeltas):
         r = q.copy()  # doesn't matter
         assert_raises(ValueError, qr_delete, q, r, 0, 1)
 
+    def test_check_finite(self):
+        a0, q0, r0 = self.generate('tall')
+
+        q = q0.copy('F')
+        q[1,1] = np.nan
+        assert_raises(ValueError, qr_delete, q, r0, 0, 1, 'row')
+        assert_raises(ValueError, qr_delete, q, r0, 0, 3, 'row')
+        assert_raises(ValueError, qr_delete, q, r0, 0, 1, 'col')
+        assert_raises(ValueError, qr_delete, q, r0, 0, 3, 'col')
+
+        r = r0.copy('F')
+        r[1,1] = np.nan
+        assert_raises(ValueError, qr_delete, q0, r, 0, 1, 'row')
+        assert_raises(ValueError, qr_delete, q0, r, 0, 3, 'row')
+        assert_raises(ValueError, qr_delete, q0, r, 0, 1, 'col')
+        assert_raises(ValueError, qr_delete, q0, r, 0, 3, 'col')
+
 class TestQRdelete_f(BaseQRdelete):
     dtype = np.dtype('f')
 
@@ -750,6 +767,30 @@ class BaseQRinsert(BaseQRdeltas):
         u = q[:, 0].copy()
         assert_raises(ValueError, qr_insert, q, r, u, 0, 'row')
         assert_raises(ValueError, qr_insert, q, r, u, 0, 'col')
+    
+    def test_check_finite(self):
+        a0, q0, r0, u0 = self.generate('sqr', which='row', p=3)
+
+        q = q0.copy('F')
+        q[1,1] = np.nan
+        assert_raises(ValueError, qr_insert, q, r0, u0[:,0], 0, 'row')
+        assert_raises(ValueError, qr_insert, q, r0, u0, 0, 'row')
+        assert_raises(ValueError, qr_insert, q, r0, u0[:,0], 0, 'col')
+        assert_raises(ValueError, qr_insert, q, r0, u0, 0, 'col')
+
+        r = r0.copy('F')
+        r[1,1] = np.nan
+        assert_raises(ValueError, qr_insert, q0, r, u0[:,0], 0, 'row')
+        assert_raises(ValueError, qr_insert, q0, r, u0, 0, 'row')
+        assert_raises(ValueError, qr_insert, q0, r, u0[:,0], 0, 'col')
+        assert_raises(ValueError, qr_insert, q0, r, u0, 0, 'col')
+
+        u = u0.copy('F')
+        u[0,0] = np.nan
+        assert_raises(ValueError, qr_insert, q0, r0, u[:,0], 0, 'row')
+        assert_raises(ValueError, qr_insert, q0, r0, u, 0, 'row')
+        assert_raises(ValueError, qr_insert, q0, r0, u[:,0], 0, 'col')
+        assert_raises(ValueError, qr_insert, q0, r0, u, 0, 'col')
 
 class TestQRinsert_f(BaseQRinsert):
     dtype = np.dtype('f')
@@ -975,7 +1016,6 @@ class BaseQRupdate(BaseQRdeltas):
     def test_non_native_byte_order_economic_rank_p(self):
         self.base_non_simple_strides(make_nonnative, 'economic', 3, False)
 
-
     def test_overwrite_qruv_rank_1(self):
         # Any positive strided q, r, u, and v can be overwritten for a rank 1 
         # update, only checking C and F contiguous.
@@ -1078,6 +1118,52 @@ class BaseQRupdate(BaseQRdeltas):
         u = q[:, 0].copy()
         v = r[0, :].copy()
         assert_raises(ValueError, qr_update, q, r, u, v)
+
+    def test_check_finite(self):
+        a0, q0, r0, u0, v0 = self.generate('tall', p=3)
+
+        q = q0.copy('F')
+        q[1,1] = np.nan
+        assert_raises(ValueError, qr_update, q, r0, u0[:,0], v0[:,0])
+        assert_raises(ValueError, qr_update, q, r0, u0, v0)
+
+        r = r0.copy('F')
+        r[1,1] = np.nan
+        assert_raises(ValueError, qr_update, q0, r, u0[:,0], v0[:,0])
+        assert_raises(ValueError, qr_update, q0, r, u0, v0)
+
+        u = u0.copy('F')
+        u[0,0] = np.nan
+        assert_raises(ValueError, qr_update, q0, r0, u[:,0], v0[:,0])
+        assert_raises(ValueError, qr_update, q0, r0, u, v0)
+
+        v = v0.copy('F')
+        v[0,0] = np.nan
+        assert_raises(ValueError, qr_update, q0, r0, u[:,0], v[:,0])
+        assert_raises(ValueError, qr_update, q0, r0, u, v)
+
+    def test_economic_check_finite(self):
+        a0, q0, r0, u0, v0 = self.generate('tall', mode='economic', p=3)
+
+        q = q0.copy('F')
+        q[1,1] = np.nan
+        assert_raises(ValueError, qr_update, q, r0, u0[:,0], v0[:,0])
+        assert_raises(ValueError, qr_update, q, r0, u0, v0)
+
+        r = r0.copy('F')
+        r[1,1] = np.nan
+        assert_raises(ValueError, qr_update, q0, r, u0[:,0], v0[:,0])
+        assert_raises(ValueError, qr_update, q0, r, u0, v0)
+
+        u = u0.copy('F')
+        u[0,0] = np.nan
+        assert_raises(ValueError, qr_update, q0, r0, u[:,0], v0[:,0])
+        assert_raises(ValueError, qr_update, q0, r0, u, v0)
+
+        v = v0.copy('F')
+        v[0,0] = np.nan
+        assert_raises(ValueError, qr_update, q0, r0, u[:,0], v[:,0])
+        assert_raises(ValueError, qr_update, q0, r0, u, v)
 
 class TestQRupdate_f(BaseQRupdate):
     dtype = np.dtype('f')

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -218,14 +218,15 @@ class BaseQRdelete(BaseQRdeltas):
             else:
                 s = slice(k,k+p)
                 if k < 0:
-                    s = slice(k, k+p+ (a.shape[0] if which == 'row' else a.shape[1]))
+                    s = slice(k, k + p + (a.shape[0] if which == 'row' else a.shape[1]))
                 a1 = np.delete(a, s, 0 if which == 'row' else 1)
 
             # for each variable, q, r we try with it strided and
             # overwrite=False. Then we try with overwrite=True, and make
             # sure that q and r are still overwritten.
 
-            q = q0.copy('F'); r = r0.copy('F') 
+            q = q0.copy('F')
+            r = r0.copy('F') 
             q1, r1 = qr_delete(qs, r, k, p, which, False)
             check_qr(q1, r1, a1, self.rtol, self.atol)
             q1o, r1o = qr_delete(qs, r, k, p, which, True)
@@ -234,7 +235,8 @@ class BaseQRdelete(BaseQRdeltas):
                 assert_allclose(q1o, qs[qind], rtol=self.rtol, atol=self.atol)
                 assert_allclose(r1o, r[rind], rtol=self.rtol, atol=self.atol)
 
-            q = q0.copy('F'); r = r0.copy('F')
+            q = q0.copy('F')
+            r = r0.copy('F')
             q2, r2 = qr_delete(q, rs, k, p, which, False)
             check_qr(q2, r2, a1, self.rtol, self.atol)
             q2o, r2o = qr_delete(q, rs, k, p, which, True)
@@ -243,7 +245,8 @@ class BaseQRdelete(BaseQRdeltas):
                 assert_allclose(q2o, q[qind], rtol=self.rtol, atol=self.atol)
                 assert_allclose(r2o, rs[rind], rtol=self.rtol, atol=self.atol)
 
-            q = q0.copy('F'); r = r0.copy('F')
+            q = q0.copy('F')
+            r = r0.copy('F')
             # since some of these were consumed above
             qs, rs = adjust_strides((q, r))
             q3, r3 = qr_delete(qs, rs, k, p, which, False)
@@ -326,13 +329,15 @@ class BaseQRdelete(BaseQRdeltas):
             a1 = np.delete(a, slice(3, 3+p), 0 if which == 'row' else 1)
 
         # don't overwrite
-        q = q0.copy('F'); r = r0.copy('F')
+        q = q0.copy('F')
+        r = r0.copy('F')
         q1, r1 = qr_delete(q, r, 3, p, which, False)
         check_qr(q1, r1, a1, self.rtol, self.atol)
         check_qr(q, r, a, self.rtol, self.atol)
 
         if test_F:
-            q = q0.copy('F'); r = r0.copy('F')
+            q = q0.copy('F')
+            r = r0.copy('F')
             q2, r2 = qr_delete(q, r, 3, p, which, True)
             check_qr(q2, r2, a1, self.rtol, self.atol)
             # verify the overwriting
@@ -340,7 +345,8 @@ class BaseQRdelete(BaseQRdeltas):
             assert_allclose(r2, r[rind], rtol=self.rtol, atol=self.atol)
 
         if test_C:
-            q = q0.copy('C'); r = r0.copy('C')
+            q = q0.copy('C')
+            r = r0.copy('C')
             q3, r3 = qr_delete(q, r, 3, p, which, True)
             check_qr(q3, r3, a1, self.rtol, self.atol)
             assert_allclose(q3, q[qind], rtol=self.rtol, atol=self.atol)
@@ -568,7 +574,7 @@ class BaseQRinsert(BaseQRdeltas):
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def base_non_simple_strides(self, adjust_strides, k, p, which):
-        for type in ['sqr']:#, 'tall', 'fat']:
+        for type in ['sqr', 'tall', 'fat']:
             a, q0, r0, u0 = self.generate(type, which=which, p=p)
             qs, rs, us = adjust_strides((q0, r0, u0))
             if p == 1:
@@ -583,25 +589,33 @@ class BaseQRinsert(BaseQRdeltas):
             # is checked to see if it can be overwritten, since only
             # F ordered Q can be overwritten when adding columns.
 
-            q = q0.copy('F'); r = r0.copy('F'); u = u0.copy('F')
+            q = q0.copy('F')
+            r = r0.copy('F')
+            u = u0.copy('F')
             q1, r1 = qr_insert(qs, r, u, k, which, False)
             check_qr(q1, r1, ai, self.rtol, self.atol)
             q1o, r1o = qr_insert(qs, r, u, k, which, True)
             check_qr(q1o, r1o, ai, self.rtol, self.atol)
 
-            q = q0.copy('F'); r = r0.copy('F'); u = u0.copy('F')
+            q = q0.copy('F')
+            r = r0.copy('F')
+            u = u0.copy('F')
             q2, r2 = qr_insert(q, rs, u, k, which, False)
             check_qr(q2, r2, ai, self.rtol, self.atol)
             q2o, r2o = qr_insert(q, rs, u, k, which, True)
             check_qr(q2o, r2o, ai, self.rtol, self.atol)
 
-            q = q0.copy('F'); r = r0.copy('F'); u = u0.copy('F')
+            q = q0.copy('F')
+            r = r0.copy('F')
+            u = u0.copy('F')
             q3, r3 = qr_insert(q, r, us, k, which, False)
             check_qr(q3, r3, ai, self.rtol, self.atol)
             q3o, r3o = qr_insert(q, r, us, k, which, True)
             check_qr(q3o, r3o, ai, self.rtol, self.atol)
 
-            q = q0.copy('F'); r = r0.copy('F'); u = u0.copy('F')
+            q = q0.copy('F')
+            r = r0.copy('F')
+            u = u0.copy('F')
             # since some of these were consumed above
             qs, rs, us = adjust_strides((q, r, u))
             q5, r5 = qr_insert(qs, rs, us, k, which, False)
@@ -834,7 +848,10 @@ class BaseQRupdate(BaseQRdeltas):
             # sure that if p == 1, r and v are still overwritten.
             # a strided q and u must always be copied.
 
-            q = q0.copy('F'); r = r0.copy('F'); u = u0.copy('F'); v = v0.copy('C')
+            q = q0.copy('F')
+            r = r0.copy('F')
+            u = u0.copy('F')
+            v = v0.copy('C')
             q1, r1 = qr_update(qs, r, u, v, False)
             check_qr(q1, r1, aup, self.rtol, self.atol)
             q1o, r1o = qr_update(qs, r, u, v, True)
@@ -843,7 +860,10 @@ class BaseQRupdate(BaseQRdeltas):
                 assert_allclose(r1o, r, rtol=self.rtol, atol=self.atol)
                 assert_allclose(v, v0.conj(), rtol=self.rtol, atol=self.atol)
 
-            q = q0.copy('F'); r = r0.copy('F'); u = u0.copy('F'); v = v0.copy('C')
+            q = q0.copy('F')
+            r = r0.copy('F')
+            u = u0.copy('F')
+            v = v0.copy('C')
             q2, r2 = qr_update(q, rs, u, v, False)
             check_qr(q2, r2, aup, self.rtol, self.atol)
             q2o, r2o = qr_update(q, rs, u, v, True)
@@ -852,7 +872,10 @@ class BaseQRupdate(BaseQRdeltas):
                 assert_allclose(r2o, rs, rtol=self.rtol, atol=self.atol)
                 assert_allclose(v, v0.conj(), rtol=self.rtol, atol=self.atol)
 
-            q = q0.copy('F'); r = r0.copy('F'); u = u0.copy('F'); v = v0.copy('C')
+            q = q0.copy('F')
+            r = r0.copy('F')
+            u = u0.copy('F')
+            v = v0.copy('C')
             q3, r3 = qr_update(q, r, us, v, False)
             check_qr(q3, r3, aup, self.rtol, self.atol)
             q3o, r3o = qr_update(q, r, us, v, True)
@@ -861,7 +884,10 @@ class BaseQRupdate(BaseQRdeltas):
                 assert_allclose(r3o, r, rtol=self.rtol, atol=self.atol)
                 assert_allclose(v, v0.conj(), rtol=self.rtol, atol=self.atol)
 
-            q = q0.copy('F'); r = r0.copy('F'); u = u0.copy('F'); v = v0.copy('C')
+            q = q0.copy('F')
+            r = r0.copy('F')
+            u = u0.copy('F')
+            v = v0.copy('C')
             q4, r4 = qr_update(q, r, u, vs, False)
             check_qr(q4, r4, aup, self.rtol, self.atol)
             q4o, r4o = qr_update(q, r, u, vs, True)
@@ -870,7 +896,10 @@ class BaseQRupdate(BaseQRdeltas):
                 assert_allclose(r4o, r, rtol=self.rtol, atol=self.atol)
                 assert_allclose(vs, v0.conj(), rtol=self.rtol, atol=self.atol)
 
-            q = q0.copy('F'); r = r0.copy('F'); u = u0.copy('F'); v = v0.copy('C')
+            q = q0.copy('F')
+            r = r0.copy('F')
+            u = u0.copy('F')
+            v = v0.copy('C')
             # since some of these were consumed above
             qs, rs, us, vs = adjust_strides((q, r, u, v))
             q5, r5 = qr_update(qs, rs, us, vs, False)
@@ -910,7 +939,10 @@ class BaseQRupdate(BaseQRdeltas):
         # update, only checking C and F contiguous.
         a, q0, r0, u0, v0 = self.generate('sqr')
         a1 = a + np.outer(u0, v0.conj())
-        q = q0.copy('F'); r = r0.copy('F'); u = u0.copy('F'); v = v0.copy('F')
+        q = q0.copy('F')
+        r = r0.copy('F')
+        u = u0.copy('F')
+        v = v0.copy('F')
 
         # don't overwrite
         q1, r1 = qr_update(q, r, u, v, False)
@@ -923,7 +955,10 @@ class BaseQRupdate(BaseQRdeltas):
         assert_allclose(q2, q, rtol=self.rtol, atol=self.atol)
         assert_allclose(r2, r, rtol=self.rtol, atol=self.atol)
 
-        q = q0.copy('C'); r = r0.copy('C'); u = u0.copy('C'); v = v0.copy('C')
+        q = q0.copy('C')
+        r = r0.copy('C')
+        u = u0.copy('C')
+        v = v0.copy('C')
         q3, r3 = qr_update(q, r, u, v, True)
         check_qr(q3, r3, a1, self.rtol, self.atol)
         assert_allclose(q3, q, rtol=self.rtol, atol=self.atol)
@@ -934,7 +969,10 @@ class BaseQRupdate(BaseQRdeltas):
         # and u can be C or F, but is only overwritten if Q is C and complex
         a, q0, r0, u0, v0 = self.generate('sqr', p=3)
         a1 = a + np.dot(u0, v0.T.conj())
-        q = q0.copy('F'); r = r0.copy('F'); u = u0.copy('F'); v = v0.copy('C')
+        q = q0.copy('F')
+        r = r0.copy('F')
+        u = u0.copy('F')
+        v = v0.copy('C')
 
         # don't overwrite
         q1, r1 = qr_update(q, r, u, v, False)
@@ -995,7 +1033,7 @@ def test_form_qTu():
     # should we test a Mx1 2d array?
 
     q_order = ['F', 'C']
-    u_order = ['F', 'C', 'A'] # here A means is not F not C
+    u_order = ['F', 'C', 'A']  # here A means is not F not C
     u_shape = [1, 3]
     dtype = ['f', 'd', 'F', 'D']
 

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -674,7 +674,7 @@ class BaseQRinsert(BaseQRdeltas):
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
 
     def test_economic_1_col(self):
-        a, q, r, u = self.generate('tall', 'economic',  which='col')
+        a, q, r, u = self.generate('tall', 'economic', which='col')
         for col in range(r.shape[1]):
             q1, r1 = qr_insert(q, r, u.copy(), col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
@@ -683,7 +683,7 @@ class BaseQRinsert(BaseQRdeltas):
     def test_economic_1_col_bad_update(self):
         # When the column to be added lies in the span of Q, the update is
         # not meaningful.  This is detected, and a LinAlgError is issued.
-        q = np.eye(5 ,3, dtype=self.dtype)
+        q = np.eye(5, 3, dtype=self.dtype)
         r = np.eye(3, dtype=self.dtype)
         u = np.array([1, 0, 0, 0, 0], self.dtype)
         assert_raises(linalg.LinAlgError, qr_insert, q, r, u, 0, 'col')

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -1,0 +1,427 @@
+import itertools
+import numpy as np
+from numpy.testing import assert_, assert_allclose, assert_raises
+from scipy import linalg
+import scipy.linalg._decomp_update as _decomp_update
+from scipy.linalg._decomp_update import *
+
+def assert_unitary(a, rtol=None, atol=None, assert_sqr=True):
+    if rtol is None:
+        rtol = 10.0 ** -(np.finfo(a.dtype).precision-2)
+    if atol is None:
+        atol = 2*np.finfo(a.dtype).eps
+
+    if assert_sqr:
+        assert_(a.shape[0] == a.shape[1], 'unitary matrices must be square')
+    aTa = np.dot(a.T.conj(), a)
+    assert_allclose(aTa, np.eye(a.shape[1]), rtol=rtol, atol=atol)
+
+def assert_upper_tri(a, rtol=None, atol=None):
+    if rtol is None:
+        rtol = 10.0 ** -(np.finfo(a.dtype).precision-2)
+    if atol is None:
+        atol = 2*np.finfo(a.dtype).eps
+    mask = np.tri(a.shape[0], a.shape[1], -1, np.bool_)
+    assert_allclose(a[mask], 0.0, rtol=rtol, atol=atol)
+
+def check_qr(q, r, a, rtol, atol, assert_sqr=True):
+    assert_unitary(q, rtol, atol, assert_sqr)
+    assert_upper_tri(r, rtol, atol)
+    assert_allclose(q.dot(r), a, rtol=rtol, atol=atol)
+
+def make_strided(arrs):
+    strides = [(3, 7), (2, 2), (3, 4), (4, 2), (5, 4), (2, 3), (2, 1), (4, 5)]
+    kmax = len(strides)
+    k = 0
+    ret = []
+    for a in arrs:
+        if a.ndim == 1:
+            s = strides[k % kmax]
+            k += 1
+            base = np.zeros(s[0]*a.shape[0]+s[1], a.dtype)
+            view = base[s[1]::s[0]]
+            view[...] = a
+        elif a.ndim == 2:
+            s = strides[k % kmax]
+            t = strides[(k+1) % kmax]
+            k += 2
+            base = np.zeros((s[0]*a.shape[0]+s[1], t[0]*a.shape[1]+t[1]), a.dtype)
+            view = base[s[1]::s[0], t[1]::t[0]]
+            view[...] = a
+        else:
+            raise ValueError('make_strided only works for ndim = 1 or 2 arrays')
+        ret.append(view)
+    return ret
+
+def negate_strides(arrs):
+    ret = []
+    for a in arrs:
+        b = np.zeros_like(a)
+        if b.ndim == 2:
+            b = b[::-1, ::-1]
+        elif b.ndim == 1:
+            b = b[::-1]
+        else:
+            raise ValueError('negate_strides only works for ndim = 1 or 2 arrays')
+        b[...] = a
+        ret.append(b)
+    return ret
+
+def nonitemsize_strides(arrs):
+    out = []
+    for a in arrs:
+        a_dtype = a.dtype
+        b = np.zeros(a.shape, [('a', a_dtype), ('junk', 'S1')])
+        c = b.getfield(a_dtype)
+        c[...] = a
+        out.append(c)
+    return out
+
+def make_nonnative(arrs):
+    out = []
+    for a in arrs:
+        out.append(a.astype(a.dtype.newbyteorder()))
+    return out
+
+class BaseQRdeltas(object):
+    def __init__(self):
+        self.rtol = 10.0 ** -(np.finfo(self.dtype).precision-2)
+        self.atol = 5 * np.finfo(self.dtype).eps
+
+    def generate(self, type, mode='full'):
+        np.random.seed(29382)
+        shape = {'sqr': (8, 8), 'tall': (12, 7), 'fat': (7, 12)}[type]
+        a = np.random.random(shape)
+        if np.iscomplexobj(self.dtype.type(1)):
+            b = np.random.random(shape)
+            a = a + 1j * b
+        a = a.astype(self.dtype)
+        q, r = linalg.qr(a, mode=mode)
+        # numpy 1.5.1 np.triu can modify array dtype. So qr of 'f' arrays
+        # will return a 'd' r and a 'f' q.
+        if r.dtype != self.dtype:
+            r = r.astype(self.dtype)
+        return a, q, r
+
+class BaseQRdelete(BaseQRdeltas):
+    def test_sqr_1_row(self):
+        a, q, r = self.generate('sqr')
+        for row in range(r.shape[0]):
+            q1, r1 = qr_delete(q, r, row, overwrite_qr=False)
+            a1 = np.delete(a, row, 0)
+            check_qr(q1, r1, a1, self.rtol, self.atol)
+
+    def test_sqr_p_row(self):
+        a, q, r = self.generate('sqr')
+        for ndel in range(2, 6):
+            for row in range(a.shape[0]-ndel):
+                q1, r1 = qr_delete(q, r, row, ndel, overwrite_qr=False)
+                a1 = np.delete(a, slice(row, row+ndel), 0)
+                check_qr(q1, r1, a1, self.rtol, self.atol)
+
+    def test_sqr_1_col(self):
+        a, q, r = self.generate('sqr')
+        for col in range(r.shape[1]):
+            q1, r1 = qr_delete(q, r, col, which='col', overwrite_qr=False)
+            a1 = np.delete(a, col, 1)
+            check_qr(q1, r1, a1, self.rtol, self.atol)
+
+    def test_sqr_p_col(self):
+        a, q, r = self.generate('sqr')
+        for ndel in range(2, 6):
+            for col in range(r.shape[1]-ndel):
+                q1, r1 = qr_delete(q, r, col, ndel, which='col',
+                                   overwrite_qr=False)
+                a1 = np.delete(a, slice(col, col+ndel), 1)
+                check_qr(q1, r1, a1, self.rtol, self.atol)
+
+    def test_tall_1_row(self):
+        a, q, r = self.generate('tall')
+        for row in range(r.shape[0]):
+            q1, r1 = qr_delete(q, r, row, overwrite_qr=False)
+            a1 = np.delete(a, row, 0)
+            check_qr(q1, r1, a1, self.rtol, self.atol)
+
+    def test_tall_p_row(self):
+        a, q, r = self.generate('tall')
+        for ndel in range(2, 6):
+            for row in range(a.shape[0]-ndel):
+                q1, r1 = qr_delete(q, r, row, ndel, overwrite_qr=False)
+                a1 = np.delete(a, slice(row, row+ndel), 0)
+                check_qr(q1, r1, a1, self.rtol, self.atol)
+
+    def test_tall_1_col(self):
+        a, q, r = self.generate('tall')
+        for col in range(r.shape[1]):
+            q1, r1 = qr_delete(q, r, col, which='col', overwrite_qr=False)
+            a1 = np.delete(a, col, 1)
+            check_qr(q1, r1, a1, self.rtol, self.atol)
+
+    def test_tall_p_col(self):
+        a, q, r = self.generate('tall')
+        for ndel in range(2, 6):
+            for col in range(r.shape[1]-ndel):
+                q1, r1 = qr_delete(q, r, col, ndel, which='col',
+                                   overwrite_qr=False)
+                a1 = np.delete(a, slice(col, col+ndel), 1)
+                check_qr(q1, r1, a1, self.rtol, self.atol)
+
+    def test_fat_1_row(self):
+        a, q, r = self.generate('fat')
+        for row in range(r.shape[0]):
+            q1, r1 = qr_delete(q, r, row, overwrite_qr=False)
+            a1 = np.delete(a, row, 0)
+            check_qr(q1, r1, a1, self.rtol, self.atol)
+
+    def test_fat_p_row(self):
+        a, q, r = self.generate('fat')
+        for ndel in range(2, 6):
+            for row in range(a.shape[0]-ndel):
+                q1, r1 = qr_delete(q, r, row, ndel, overwrite_qr=False)
+                a1 = np.delete(a, slice(row, row+ndel), 0)
+                check_qr(q1, r1, a1, self.rtol, self.atol)
+
+    def test_fat_1_col(self):
+        a, q, r = self.generate('fat')
+        for col in range(r.shape[1]):
+            q1, r1 = qr_delete(q, r, col, which='col', overwrite_qr=False)
+            a1 = np.delete(a, col, 1)
+            check_qr(q1, r1, a1, self.rtol, self.atol)
+
+    def test_fat_p_col(self):
+        a, q, r = self.generate('fat')
+        for ndel in range(2, 6):
+            for col in range(r.shape[1]-ndel):
+                q1, r1 = qr_delete(q, r, col, ndel, which='col',
+                                   overwrite_qr=False)
+                a1 = np.delete(a, slice(col, col+ndel), 1)
+                check_qr(q1, r1, a1, self.rtol, self.atol)
+
+    # all row deletes and single column deletes should be able to
+    # handle any non negative strides. (only row and column vector
+    # operations are used.) p column delete require fortran ordered
+    # Q and R and will make a copy as necessary.
+
+    def base_non_simple_strides(self, adjust_strides, ks, p, which, overwriteable):
+        if which == 'row':
+            qind = (slice(p,None), slice(p,None))
+            rind = (slice(p,None), slice(None))
+        else:
+            qind = (slice(None), slice(None))
+            rind = (slice(None), slice(None,-p))
+
+        for type, k in itertools.product(['sqr', 'tall', 'fat'], ks):
+            a, q0, r0, = self.generate(type)
+            qs, rs = adjust_strides((q0, r0))
+            if p == 1:
+                a1 = np.delete(a, k, 0 if which == 'row' else 1)
+            else:
+                s = slice(k,k+p)
+                if k < 0:
+                    s = slice(k, k+p+ (a.shape[0] if which == 'row' else a.shape[1]))
+                a1 = np.delete(a, s, 0 if which == 'row' else 1)
+
+            # for each variable, q, r we try with it strided and
+            # overwrite=False. Then we try with overwrite=True, and make
+            # sure that q and r are still overwritten.
+
+            q = q0.copy('F'); r = r0.copy('F') 
+            q1, r1 = qr_delete(qs, r, k, p, which, False)
+            check_qr(q1, r1, a1, self.rtol, self.atol)
+            q1o, r1o = qr_delete(qs, r, k, p, which, True)
+            check_qr(q1o, r1o, a1, self.rtol, self.atol)
+            if overwriteable:
+                assert_allclose(q1o, qs[qind], rtol=self.rtol, atol=self.atol)
+                assert_allclose(r1o, r[rind], rtol=self.rtol, atol=self.atol)
+
+            q = q0.copy('F'); r = r0.copy('F')
+            q2, r2 = qr_delete(q, rs, k, p, which, False)
+            check_qr(q2, r2, a1, self.rtol, self.atol)
+            q2o, r2o = qr_delete(q, rs, k, p, which, True)
+            check_qr(q2o, r2o, a1, self.rtol, self.atol)
+            if overwriteable:
+                assert_allclose(q2o, q[qind], rtol=self.rtol, atol=self.atol)
+                assert_allclose(r2o, rs[rind], rtol=self.rtol, atol=self.atol)
+
+            q = q0.copy('F'); r = r0.copy('F')
+            # since some of these were consumed above
+            qs, rs = adjust_strides((q, r))
+            q3, r3 = qr_delete(qs, rs, k, p, which, False)
+            check_qr(q3, r3, a1, self.rtol, self.atol)
+            q3o, r3o = qr_delete(qs, rs, k, p, which, True)
+            check_qr(q3o, r3o, a1, self.rtol, self.atol)
+            if overwriteable:
+                assert_allclose(q2o, qs[qind], rtol=self.rtol, atol=self.atol)
+                assert_allclose(r3o, rs[rind], rtol=self.rtol, atol=self.atol)
+
+    def test_non_unit_strides_1_row(self):
+        self.base_non_simple_strides(make_strided, [0], 1, 'row', True)
+
+    def test_non_unit_strides_p_row(self):
+        self.base_non_simple_strides(make_strided, [0], 3, 'row', True)
+
+    def test_non_unit_strides_1_col(self):
+        self.base_non_simple_strides(make_strided, [0], 1, 'col', True)
+
+    def test_non_unit_strides_p_col(self):
+        self.base_non_simple_strides(make_strided, [0], 3, 'col', False)
+
+    def test_neg_strides_1_row(self):
+        self.base_non_simple_strides(negate_strides, [0], 1, 'row', False)
+
+    def test_neg_strides_p_row(self):
+        self.base_non_simple_strides(negate_strides, [0], 3, 'row', False)
+
+    def test_neg_strides_1_col(self):
+        self.base_non_simple_strides(negate_strides, [0], 1, 'col', False)
+
+    def test_neg_strides_p_col(self):
+        self.base_non_simple_strides(negate_strides, [0], 3, 'col', False)
+
+    def test_non_itemize_strides_1_row(self):
+        self.base_non_simple_strides(nonitemsize_strides, [0], 1, 'row', False)
+
+    def test_non_itemize_strides_p_row(self):
+        self.base_non_simple_strides(nonitemsize_strides, [0], 3, 'row', False)
+
+    def test_non_itemize_strides_1_col(self):
+        self.base_non_simple_strides(nonitemsize_strides, [0], 1, 'col', False)
+
+    def test_non_itemize_strides_p_col(self):
+        self.base_non_simple_strides(nonitemsize_strides, [0], 3, 'col', False)
+
+    def test_non_native_byte_order_1_row(self):
+        self.base_non_simple_strides(make_nonnative, [0], 1, 'row', False)
+
+    def test_non_native_byte_order_p_row(self):
+        self.base_non_simple_strides(make_nonnative, [0], 3, 'row', False)
+
+    def test_non_native_byte_order_1_col(self):
+        self.base_non_simple_strides(make_nonnative, [0], 1, 'col', False)
+
+    def test_non_native_byte_order_p_col(self):
+        self.base_non_simple_strides(make_nonnative, [0], 3, 'col', False)
+
+    def test_neg_k(self):
+        a, q, r = self.generate('sqr')
+        for k, p, w in itertools.product([-3, -7], [1, 3], ['row', 'col']):
+            q1, r1 = qr_delete(q, r, k, p, w, overwrite_qr=False)
+            if w == 'row':
+                a1 = np.delete(a, slice(k+a.shape[0], k+p+a.shape[0]), 0)
+            else:
+                a1 = np.delete(a, slice(k+a.shape[0], k+p+a.shape[1]), 1)
+            check_qr(q1, r1, a1, self.rtol, self.atol)
+
+    def base_overwrite_qr(self, which, p, test_C, test_F):
+        if which == 'row':
+            qind = (slice(p,None), slice(p,None))
+            rind = (slice(p,None), slice(None))
+        else:
+            qind = (slice(None), slice(None))
+            rind = (slice(None), slice(None,-p))
+        a, q0, r0 = self.generate('sqr')
+        if p == 1:
+            a1 = np.delete(a, 3, 0 if which == 'row' else 1)
+        else:
+            a1 = np.delete(a, slice(3, 3+p), 0 if which == 'row' else 1)
+
+        # don't overwrite
+        q = q0.copy('F'); r = r0.copy('F')
+        q1, r1 = qr_delete(q, r, 3, p, which, False)
+        check_qr(q1, r1, a1, self.rtol, self.atol)
+        check_qr(q, r, a, self.rtol, self.atol)
+
+        if test_F:
+            q = q0.copy('F'); r = r0.copy('F')
+            q2, r2 = qr_delete(q, r, 3, p, which, True)
+            check_qr(q2, r2, a1, self.rtol, self.atol)
+            # verify the overwriting
+            assert_allclose(q2, q[qind], rtol=self.rtol, atol=self.atol)
+            assert_allclose(r2, r[rind], rtol=self.rtol, atol=self.atol)
+
+        if test_C:
+            q = q0.copy('C'); r = r0.copy('C')
+            q3, r3 = qr_delete(q, r, 3, p, which, True)
+            check_qr(q3, r3, a1, self.rtol, self.atol)
+            assert_allclose(q3, q[qind], rtol=self.rtol, atol=self.atol)
+            assert_allclose(r3, r[rind], rtol=self.rtol, atol=self.atol)
+
+    def test_overwrite_qr_1_row(self):
+        # any positively strided q and r.
+        self.base_overwrite_qr('row', 1, True, True)
+
+    def test_overwrite_qr_1_col(self):
+        # any positively strided q and r.
+        self.base_overwrite_qr('col', 1, True, True)
+
+    def test_overwrite_qr_p_row(self):
+        # any positively strided q and r.
+        self.base_overwrite_qr('row', 3, True, True)
+
+    def test_overwrite_qr_p_col(self):
+        # only F orderd q and r can be overwritten for cols
+        self.base_overwrite_qr('col', 3, False, True)
+
+    def test_economic_qr(self):
+        a, q, r = self.generate('tall', mode='economic')
+        # only test row delete, this logic is shared.
+        assert_raises(ValueError, qr_delete, q, r, 0)
+
+    def test_bad_which(self):
+        a, q, r = self.generate('sqr')
+        assert_raises(ValueError, qr_delete, q, r, 0, which='foo')
+
+    def test_bad_k(self):
+        a, q, r = self.generate('tall')
+        assert_raises(ValueError, qr_delete, q, r, q.shape[0], 1)
+        assert_raises(ValueError, qr_delete, q, r, -q.shape[0]-1, 1)
+        assert_raises(ValueError, qr_delete, q, r, r.shape[0], 1, 'col')
+        assert_raises(ValueError, qr_delete, q, r, -r.shape[0]-1, 1, 'col')
+
+    def test_bad_p(self):
+        a, q, r = self.generate('tall')
+        # p must be positive
+        assert_raises(ValueError, qr_delete, q, r, 0, -1)
+        assert_raises(ValueError, qr_delete, q, r, 0, -1, 'col')
+
+        # and nonzero
+        assert_raises(ValueError, qr_delete, q, r, 0, 0)
+        assert_raises(ValueError, qr_delete, q, r, 0, 0, 'col')
+
+        # must have at least k+p rows or cols, depending.
+        assert_raises(ValueError, qr_delete, q, r, 3, q.shape[0]-2)
+        assert_raises(ValueError, qr_delete, q, r, 3, r.shape[1]-2, 'col')
+
+    def test_empty_q(self):
+        a, q, r = self.generate('tall')
+        # same code path for 'row' and 'col'
+        assert_raises(ValueError, qr_delete, np.array([]), r, 0, 1)
+
+    def test_empty_r(self):
+        a, q, r = self.generate('tall')
+        # same code path for 'row' and 'col'
+        assert_raises(ValueError, qr_delete, q, np.array([]), 0, 1)
+
+    def test_mismatched_q_and_r(self):
+        a, q, r = self.generate('tall')
+        r = r[1:]
+        assert_raises(ValueError, qr_delete, q, r, 0, 1)
+
+    def test_integer_input(self):
+        q = np.arange(16).reshape(4, 4)
+        r = q.copy()  # doesn't matter
+        assert_raises(ValueError, qr_delete, q, r, 0, 1)
+
+class TestQRdelete_f(BaseQRdelete):
+    dtype = np.dtype('f')
+
+class TestQRdelete_F(BaseQRdelete):
+    dtype = np.dtype('F')
+
+class TestQRdelete_d(BaseQRdelete):
+    dtype = np.dtype('d')
+
+class TestQRdelete_D(BaseQRdelete):
+    dtype = np.dtype('D')
+
+

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -644,6 +644,21 @@ class BaseQRinsert(BaseQRdeltas):
             a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
+    def test_economic_1_row(self):
+        a, q, r, u = self.generate('tall', 'economic', 'row')
+        for row in range(r.shape[0]):
+            q1, r1 = qr_insert(q, r, u, row, overwrite_qru=False)
+            a1 = np.insert(a, row, u, 0)
+            check_qr(q1, r1, a1, self.rtol, self.atol, False)
+
+    def test_economic_p_row(self):
+        # tall + rows --> tall always
+        a, q, r, u = self.generate('tall', 'economic', 'row', 3)
+        for row in range(r.shape[0]):
+            q1, r1 = qr_insert(q, r, u, row, overwrite_qru=False)
+            a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
+            check_qr(q1, r1, a1, self.rtol, self.atol, False)
+
     def base_non_simple_strides(self, adjust_strides, k, p, which):
         for type in ['sqr', 'tall', 'fat']:
             a, q0, r0, u0 = self.generate(type, which=which, p=p)
@@ -794,8 +809,8 @@ class BaseQRinsert(BaseQRdeltas):
         assert_allclose(q2, q, rtol=self.rtol, atol=self.atol)
 
     def test_economic_qr(self):
-        a, q, r, u = self.generate('tall', which='row', mode='economic')
-        assert_raises(ValueError, qr_insert, q, r, u, 0)
+        a, q, r, u = self.generate('tall', which='col', mode='economic')
+        assert_raises(ValueError, qr_insert, q, r, u, 0, 'col')
 
     def test_empty_inputs(self):
         a, q, r, u = self.generate('sqr', which='row')

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -1,4 +1,5 @@
 import itertools
+
 import numpy as np
 from numpy.testing import assert_, assert_allclose, assert_raises
 from scipy import linalg
@@ -467,10 +468,24 @@ class BaseQRdelete(BaseQRdeltas):
         r = r[1:]
         assert_raises(ValueError, qr_delete, q, r, 0, 1)
 
-    def test_integer_input(self):
-        q = np.arange(16).reshape(4, 4)
-        r = q.copy()  # doesn't matter
-        assert_raises(ValueError, qr_delete, q, r, 0, 1)
+    def test_unsupported_dtypes(self):
+        dts = ['int8', 'int16', 'int32', 'int64', 
+               'uint8', 'uint16', 'uint32', 'uint64',
+               'float16', 'longdouble', 'longcomplex',
+               'bool']
+        a, q0, r0 = self.generate('tall')
+        for dtype in dts:
+            q = q0.real.astype(dtype)
+            r = r0.real.astype(dtype)
+            assert_raises(ValueError, qr_delete, q, r0, 0, 1, 'row')
+            assert_raises(ValueError, qr_delete, q, r0, 0, 2, 'row')
+            assert_raises(ValueError, qr_delete, q, r0, 0, 1, 'col')
+            assert_raises(ValueError, qr_delete, q, r0, 0, 2, 'col')
+
+            assert_raises(ValueError, qr_delete, q0, r, 0, 1, 'row')
+            assert_raises(ValueError, qr_delete, q0, r, 0, 2, 'row')
+            assert_raises(ValueError, qr_delete, q0, r, 0, 1, 'col')
+            assert_raises(ValueError, qr_delete, q0, r, 0, 2, 'col')
 
     def test_check_finite(self):
         a0, q0, r0 = self.generate('tall')
@@ -856,13 +871,23 @@ class BaseQRinsert(BaseQRdeltas):
         assert_raises(ValueError, qr_insert, q[:-2], r, u, 0, 'col')
         assert_raises(ValueError, qr_insert, q, r, u[1:], 0, 'col')
 
-    def test_integer_input(self):
-        q = np.arange(16).reshape(4, 4)
-        r = q.copy()  # doesn't matter
-        u = q[:, 0].copy()
-        assert_raises(ValueError, qr_insert, q, r, u, 0, 'row')
-        assert_raises(ValueError, qr_insert, q, r, u, 0, 'col')
-    
+    def test_unsupported_dtypes(self):
+        dts = ['int8', 'int16', 'int32', 'int64', 
+               'uint8', 'uint16', 'uint32', 'uint64',
+               'float16', 'longdouble', 'longcomplex',
+               'bool']
+        a, q0, r0, u0 = self.generate('sqr', which='row')
+        for dtype in dts:
+            q = q0.real.astype(dtype)
+            r = r0.real.astype(dtype)
+            u = u0.real.astype(dtype)
+            assert_raises(ValueError, qr_insert, q, r0, u0, 0, 'row')
+            assert_raises(ValueError, qr_insert, q, r0, u0, 0, 'col')
+            assert_raises(ValueError, qr_insert, q0, r, u0, 0, 'row')
+            assert_raises(ValueError, qr_insert, q0, r, u0, 0, 'col')
+            assert_raises(ValueError, qr_insert, q0, r0, u, 0, 'row')
+            assert_raises(ValueError, qr_insert, q0, r0, u, 0, 'col')
+
     def test_check_finite(self):
         a0, q0, r0, u0 = self.generate('sqr', which='row', p=3)
 
@@ -1207,6 +1232,22 @@ class BaseQRupdate(BaseQRdeltas):
         assert_raises(ValueError, qr_update, q, r, u[1:], v)
         assert_raises(ValueError, qr_update, q, r, u, v[1:])
 
+    def test_unsupported_dtypes(self):
+        dts = ['int8', 'int16', 'int32', 'int64', 
+               'uint8', 'uint16', 'uint32', 'uint64',
+               'float16', 'longdouble', 'longcomplex',
+               'bool']
+        a, q0, r0, u0, v0 = self.generate('tall')
+        for dtype in dts:
+            q = q0.real.astype(dtype)
+            r = r0.real.astype(dtype)
+            u = u0.real.astype(dtype)
+            v = v0.real.astype(dtype)
+            assert_raises(ValueError, qr_update, q, r0, u0, v0)
+            assert_raises(ValueError, qr_update, q0, r, u0, v0)
+            assert_raises(ValueError, qr_update, q0, r0, u, v0)
+            assert_raises(ValueError, qr_update, q0, r0, u0, v)
+
     def test_integer_input(self):
         q = np.arange(16).reshape(4, 4)
         r = q.copy()  # doesn't matter
@@ -1320,4 +1361,8 @@ def check_form_qTu(q_order, u_order, u_shape, dtype):
     expected = np.dot(q.T.conj(), u)
     res = _decomp_update._form_qTu(q, u)
     assert_allclose(res, expected, rtol=rtol, atol=atol)
+
+
+if __name__ == "__main__":
+    run_module_suite()
  

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -98,10 +98,6 @@ class BaseQRdeltas(object):
             a = a + 1j * b
         a = a.astype(self.dtype)
         q, r = linalg.qr(a, mode=mode)
-        # numpy 1.5.1 np.triu can modify array dtype. So qr of 'f' arrays
-        # will return a 'd' r and a 'f' q.
-        if r.dtype != self.dtype:
-            r = r.astype(self.dtype)
         return a, q, r
 
 class BaseQRdelete(BaseQRdeltas):

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -86,7 +86,7 @@ def make_nonnative(arrs):
 class BaseQRdeltas(object):
     def __init__(self):
         self.rtol = 10.0 ** -(np.finfo(self.dtype).precision-2)
-        self.atol = 5 * np.finfo(self.dtype).eps
+        self.atol = 10 * np.finfo(self.dtype).eps
 
     def generate(self, type, mode='full'):
         np.random.seed(29382)


### PR DESCRIPTION
This pull request goes on top of #4021, accordingly only the last few commits are relevant here.

Here three new functions are added to perform various modifications of qr decompositions: `qr_update`, `qr_insert` and `qr_delete` for performing rank-k updates, adding row(s) or column(s) and removing row(s) or column(s).  

The methods used are essentially those in [1], with some input from [2].

I've endeavored to write this such that updates can be performed in-place as much as possible.  This is, for instance, why the rank-1 update and the rank-k update algorithms are slightly different.  This allows the rank-1 update to support updating `q` and `r` when they are stored in C order.  (In this spirit, it might be worth changing `linalg.qr` to return fortran ordered 'r', since at present it always returns a C ordered `r`,  and a F ordered `q`.  Numpy's qr returns both as C order.)

Edit: both are done (3/18/15)
Some outstanding things:
1.  I suppose I'll need to add a 'check_finite'  flag to these.  
2.  `overwrite_qr` should probably default to `False` instead of true.

References
1.  Golub, G. H. & Loan, C. F. van V. Matrix Computations, 3rd Ed. (Johns Hopkins University Press, 1996).
2.  Hammarling, S. & Lucas, C. Updating the QR factorization and the least squares problem. 1-73 (The University of Manchester, 2008). at http://eprints.ma.man.ac.uk/1192/
