### PR TITLE
MAINT trim away >10 kLOC of generated C code

### DIFF
--- a/scipy/cluster/_vq.pyx
+++ b/scipy/cluster/_vq.pyx
@@ -7,6 +7,7 @@ Original C version by Damian Eads.
 Translated to Cython by David Warde-Farley, October 2009.
 """
 
+cimport cython
 import numpy as np
 cimport numpy as np
 from cluster_blas cimport *
@@ -247,6 +248,7 @@ def vq(np.ndarray obs, np.ndarray codes):
     return outcodes, outdists
 
 
+@cython.cdivision(True)
 cdef np.ndarray _update_cluster_means(vq_type *obs, int32_t *labels,
                                       vq_type *cb, int nobs, int nc, int nfeat):
     """

--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -10,8 +10,6 @@ cimport numpy as cnp
 
 cimport cython
 
-cdef double nan = np.nan
-
 cimport libc.stdlib
 cimport libc.math
 
@@ -26,6 +24,9 @@ cdef extern from "blas_defs.h":
                  int *lda, double *wr, double *wi, double *vl, int *ldvl,
                  double *vr, int *ldvr, double *work, int *lwork,
                  int *info)
+
+cdef extern from "numpy/npy_math.h":
+    double nan "NPY_NAN"
 
 #------------------------------------------------------------------------------
 # Piecewise power basis polynomials

--- a/scipy/io/matlab/mio_utils.pyx
+++ b/scipy/io/matlab/mio_utils.pyx
@@ -6,7 +6,7 @@ import numpy as np
 cimport numpy as cnp
 
 
-cpdef size_t cproduct(tup):
+def cproduct(tup):
     cdef size_t res = 1
     cdef int i
     for i in range(len(tup)):

--- a/scipy/sparse/_csparsetools.pyx.in
+++ b/scipy/sparse/_csparsetools.pyx.in
@@ -3,7 +3,7 @@
 # Tempita-templated Cython file
 #
 """
-Fast snippets for sparse matrices.
+Fast snippets for LIL matrices.
 """
 
 {{py:
@@ -61,54 +61,14 @@ def define_dispatch_map2(map_name, prefix, types, types2):
 }}
 
 cimport cython
-cimport cpython.list
-cimport cpython.int
-cimport cpython
 cimport numpy as cnp
 import numpy as np
 
 
-def prepare_index_for_memoryview(cnp.ndarray i, cnp.ndarray j, cnp.ndarray x=None):
-    """
-    Convert index and data arrays to form suitable for passing to the
-    Cython fancy getset routines.
-
-    The conversions are necessary since to (i) ensure the integer
-    index arrays are in one of the accepted types, and (ii) to ensure
-    the arrays are writable so that Cython memoryview support doesn't
-    choke on them.
-
-    Parameters
-    ----------
-    i, j
-        Index arrays
-    x : optional
-        Data arrays
-
-    Returns
-    -------
-    i, j, x
-        Re-formatted arrays (x is omitted, if input was None)
-
-    """
-    if i.dtype > j.dtype:
-        j = j.astype(i.dtype)
-    elif i.dtype < j.dtype:
-        i = i.astype(j.dtype)
-
-    if not i.flags.writeable or not i.dtype in (np.int32, np.int64):
-        i = i.astype(np.intp)
-    if not j.flags.writeable or not j.dtype in (np.int32, np.int64):
-        j = j.astype(np.intp)
-
-    if x is not None:
-        if not x.flags.writeable:
-            x = x.copy()
-        return i, j, x
-    else:
-        return i, j
+cnp.import_array()
 
 
+@cython.wraparound(False)
 cpdef lil_get1(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas,
                cnp.npy_intp i, cnp.npy_intp j):
     """
@@ -143,7 +103,7 @@ cpdef lil_get1(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas,
 
     row = rows[i]
     data = datas[i]
-    pos = bisect_left(row, j)
+    cdef cnp.npy_intp pos = bisect_left(row, j)
 
     if pos != len(data) and row[pos] == j:
         return data[pos]
@@ -151,14 +111,10 @@ cpdef lil_get1(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas,
         return 0
 
 
-def lil_insert(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas,
-               cnp.npy_intp i, cnp.npy_intp j, object x, object dtype):
-    return _LIL_INSERT_DISPATCH[dtype](M, N, rows, datas, i, j, x)
-
-
-{{for NAME, VALUE_T in get_dispatch(VALUE_TYPES)}}
-cpdef _lil_insert_{{NAME}}(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas,
-                           cnp.npy_intp i, cnp.npy_intp j, {{VALUE_T}} x):
+@cython.wraparound(False)
+cpdef int lil_insert(cnp.npy_intp M, cnp.npy_intp N, object[:] rows,
+                     object[:] datas, cnp.npy_intp i, cnp.npy_intp j,
+                     object x) except -1:
     """
     Insert a single item to LIL matrix.
 
@@ -175,7 +131,6 @@ cpdef _lil_insert_{{NAME}}(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, objec
 
     """
     cdef list row, data
-    cdef int is_zero
 
     if i < -M or i >= M:
         raise IndexError('row index (%d) out of bounds' % (i,))
@@ -190,14 +145,20 @@ cpdef _lil_insert_{{NAME}}(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, objec
     row = rows[i]
     data = datas[i]
 
+    cdef cnp.npy_intp pos = bisect_left(row, j)
     if x == 0:
-        lil_deleteat_nocheck(rows[i], datas[i], j)
+        if pos < len(row) and row[pos] == j:
+            del row[pos]
+            del data[pos]
     else:
-        lil_insertat_nocheck(rows[i], datas[i], j, x)
-{{endfor}}
-
-
-{{define_dispatch_map('_LIL_INSERT_DISPATCH', '_lil_insert', VALUE_TYPES)}}
+        if pos == len(row):
+            row.append(j)
+            data.append(x)
+        elif row[pos] != j:
+            row.insert(pos, j)
+            data.insert(pos, x)
+        else:
+            data[pos] = x
 
 
 def lil_fancy_get(cnp.npy_intp M, cnp.npy_intp N,
@@ -285,18 +246,21 @@ def lil_fancy_set(cnp.npy_intp M, cnp.npy_intp N,
     """
     if values.dtype == np.bool_:
         # Cython doesn't support np.bool_ as a memoryview type
-        return _lil_fancy_set_generic(M, N, rows, data, i_idx, j_idx, values)
-    else:
-        return _LIL_FANCY_SET_DISPATCH[i_idx.dtype, values.dtype](M, N, rows, data, i_idx, j_idx, values)
+        values = values.view(dtype=np.uint8)
+
+    assert i_idx.shape[0] == j_idx.shape[0] and i_idx.shape[1] == j_idx.shape[1]
+    return _LIL_FANCY_SET_DISPATCH[i_idx.dtype, values.dtype](M, N, rows, data, i_idx, j_idx, values)
 
 
 {{for PYIDX, PYVALUE, IDX_T, VALUE_T in get_dispatch2(IDX_TYPES, VALUE_TYPES)}}
-cpdef _lil_fancy_set_{{PYIDX}}_{{PYVALUE}}(cnp.npy_intp M, cnp.npy_intp N,
-                                           object[:] rows,
-                                           object[:] data,
-                                           {{IDX_T}}[:,:] i_idx,
-                                           {{IDX_T}}[:,:] j_idx,
-                                           {{VALUE_T}}[:,:] values):
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def _lil_fancy_set_{{PYIDX}}_{{PYVALUE}}(cnp.npy_intp M, cnp.npy_intp N,
+                                         object[:] rows,
+                                         object[:] data,
+                                         {{IDX_T}}[:,:] i_idx,
+                                         {{IDX_T}}[:,:] j_idx,
+                                         {{VALUE_T}}[:,:] values):
     cdef cnp.npy_intp x, y
     cdef cnp.npy_intp i, j
 
@@ -304,83 +268,17 @@ cpdef _lil_fancy_set_{{PYIDX}}_{{PYVALUE}}(cnp.npy_intp M, cnp.npy_intp N,
         for y in range(i_idx.shape[1]):
             i = i_idx[x,y]
             j = j_idx[x,y]
-            _lil_insert_{{PYVALUE}}(M, N, rows, data, i, j, values[x, y])
+            lil_insert(M, N, rows, data, i, j, values[x, y])
 {{endfor}}
 
 
 {{define_dispatch_map2('_LIL_FANCY_SET_DISPATCH', '_lil_fancy_set', IDX_TYPES, VALUE_TYPES)}}
 
 
-cpdef _lil_fancy_set_generic(cnp.npy_intp M, cnp.npy_intp N,
-                             object[:] rows,
-                             object[:] data,
-                             cnp.ndarray i_idx,
-                             cnp.ndarray j_idx,
-                             cnp.ndarray values):
-    cdef cnp.npy_intp x, y
-    cdef cnp.npy_intp i, j
-
-    for x in range(i_idx.shape[0]):
-        for y in range(i_idx.shape[1]):
-            i = i_idx[x,y]
-            j = j_idx[x,y]
-            _lil_insert_{{PYVALUE}}(M, N, rows, data, i, j, values[x, y])
-
-
-cdef lil_insertat_nocheck(list row, list data, cnp.npy_intp j, object x):
-    """
-    Insert a single item to LIL matrix.
-
-    Doesn't check for bounds errors. Doesn't check for zero x.
-
-    Parameters
-    ----------
-    M, N, rows, datas
-        Shape and data arrays for a LIL matrix
-    i, j : int
-        Indices at which to get
-    x
-        Value to insert.
-
-    """
-    cdef cnp.npy_intp pos
-
-    pos = bisect_left(row, j)
-    if pos == len(row):
-        row.append(j)
-        data.append(x)
-    elif row[pos] != j:
-        row.insert(pos, j)
-        data.insert(pos, x)
-    else:
-        data[pos] = x
-
-
-cdef lil_deleteat_nocheck(list row, list data, cnp.npy_intp j):
-    """
-    Delete a single item from a row in LIL matrix.
-
-    Doesn't check for bounds errors.
-
-    Parameters
-    ----------
-    row, data
-        Row data for LIL matrix.
-    j : int
-        Column index to delete at
-
-    """
-    cdef cnp.npy_intp pos
-    pos = bisect_left(row, j)
-    if pos < len(row) and row[pos] == j:
-        del row[pos]
-        del data[pos]
-
-
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef bisect_left(list a, cnp.npy_intp x):
+cdef inline cnp.npy_intp bisect_left(list a, cnp.npy_intp x) except -1:
     """
     Bisection search in a sorted list.
 
@@ -400,12 +298,12 @@ cdef bisect_left(list a, cnp.npy_intp x):
         it can be inserted maintaining order.
 
     """
-    cdef cnp.npy_intp hi = len(a)
-    cdef cnp.npy_intp lo = 0
-    cdef cnp.npy_intp mid, v
+    cdef Py_ssize_t hi = len(a)
+    cdef Py_ssize_t lo = 0
+    cdef Py_ssize_t mid, v
 
     while lo < hi:
-        mid = (lo + hi)//2
+        mid = lo + (hi - lo) // 2
         v = a[mid]
         if v < x:
             lo = mid + 1
@@ -414,7 +312,7 @@ cdef bisect_left(list a, cnp.npy_intp x):
     return lo
 
 
-def _fill_dtype_map(map, chars):
+cdef _fill_dtype_map(map, chars):
     """
     Fill in Numpy dtype chars for problematic types, working around
     Numpy < 1.6 bugs.
@@ -430,7 +328,7 @@ def _fill_dtype_map(map, chars):
                     break
 
 
-def _fill_dtype_map2(map):
+cdef _fill_dtype_map2(map):
     """
     Fill in Numpy dtype chars for problematic types, working around
     Numpy < 1.6 bugs.
@@ -448,6 +346,5 @@ def _fill_dtype_map2(map):
                         map[(dt1, dt2)] = v
                         break
 
-_fill_dtype_map(_LIL_INSERT_DISPATCH, np.typecodes['All'])
 _fill_dtype_map(_LIL_FANCY_GET_DISPATCH, np.typecodes['Integer'])
 _fill_dtype_map2(_LIL_FANCY_SET_DISPATCH)

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -7,12 +7,11 @@ __docformat__ = "restructuredtext en"
 
 __all__ = ['lil_matrix','isspmatrix_lil']
 
-
 import numpy as np
 
 from .base import spmatrix, isspmatrix
-from .sputils import getdtype, isshape, isscalarlike, \
-    IndexMixin, upcast_scalar, get_index_dtype
+from .sputils import (getdtype, isshape, isscalarlike, IndexMixin,
+                      upcast_scalar, get_index_dtype)
 
 from . import _csparsetools
 
@@ -258,7 +257,7 @@ class lil_matrix(spmatrix, IndexMixin):
 
         new = lil_matrix(i.shape, dtype=self.dtype)
 
-        i, j = _csparsetools.prepare_index_for_memoryview(i, j)
+        i, j = _prepare_index_for_memoryview(i, j)
         _csparsetools.lil_fancy_get(self.shape[0], self.shape[1],
                                     self.rows, self.data,
                                     new.rows, new.data,
@@ -280,8 +279,7 @@ class lil_matrix(spmatrix, IndexMixin):
                     # Triggered if input was an ndarray
                     raise ValueError("Trying to assign a sequence to an item")
                 _csparsetools.lil_insert(self.shape[0], self.shape[1],
-                                         self.rows, self.data,
-                                         i, j, x, self.dtype)
+                                         self.rows, self.data, i, j, x)
                 return
 
         # General indexing
@@ -309,7 +307,7 @@ class lil_matrix(spmatrix, IndexMixin):
             raise ValueError("shape mismatch in assignment")
 
         # Set values
-        i, j, x = _csparsetools.prepare_index_for_memoryview(i, j, x)
+        i, j, x = _prepare_index_for_memoryview(i, j, x)
         _csparsetools.lil_fancy_set(self.shape[0], self.shape[1],
                                     self.rows, self.data,
                                     i, j, x)
@@ -398,6 +396,47 @@ class lil_matrix(spmatrix, IndexMixin):
         """ Return Compressed Sparse Column format arrays for this matrix.
         """
         return self.tocsr().tocsc()
+
+
+def _prepare_index_for_memoryview(i, j, x=None):
+    """
+    Convert index and data arrays to form suitable for passing to the
+    Cython fancy getset routines.
+
+    The conversions are necessary since to (i) ensure the integer
+    index arrays are in one of the accepted types, and (ii) to ensure
+    the arrays are writable so that Cython memoryview support doesn't
+    choke on them.
+
+    Parameters
+    ----------
+    i, j
+        Index arrays
+    x : optional
+        Data arrays
+
+    Returns
+    -------
+    i, j, x
+        Re-formatted arrays (x is omitted, if input was None)
+
+    """
+    if i.dtype > j.dtype:
+        j = j.astype(i.dtype)
+    elif i.dtype < j.dtype:
+        i = i.astype(j.dtype)
+
+    if not i.flags.writeable or i.dtype not in (np.int32, np.int64):
+        i = i.astype(np.intp)
+    if not j.flags.writeable or j.dtype not in (np.int32, np.int64):
+        j = j.astype(np.intp)
+
+    if x is not None:
+        if not x.flags.writeable:
+            x = x.copy()
+        return i, j, x
+    else:
+        return i, j
 
 
 def isspmatrix_lil(x):

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -38,35 +38,16 @@ __all__ = ['cKDTree']
 # ints to lists.  The results of the if is known at compile time, so the
 # test is optimized away.
 
-cdef inline int set_add_pair(set results,
-                             np.intp_t i,
-                             np.intp_t j) except -1:
-
+cdef inline int set_add_ordered_pair(set results,
+                                     np.intp_t i, np.intp_t j) except -1:
+    if i > j:
+        i, j = j, i
     if sizeof(long) < sizeof(np.intp_t):
         # Win 64
         results.add((int(i), int(j)))
     else:
         # Other platforms
         results.add((i, j))
-    return 0
-
-
-cdef inline int set_add_ordered_pair(set results,
-                                     np.intp_t i,
-                                     np.intp_t j) except -1:
-
-    if sizeof(long) < sizeof(np.intp_t):
-        # Win 64
-        if i < j:
-            results.add((int(i), int(j)))
-        else:
-            results.add((int(j), int(i)))
-    else:
-        # Other platforms
-        if i < j:
-            results.add((i, j))
-        else:
-            results.add((j, i))
     return 0
 
 cdef inline int list_append(list results, np.intp_t i) except -1:
@@ -217,7 +198,8 @@ cdef class coo_entries:
         self.j_data = <np.intp_t *>np.PyArray_DATA(self.j)
         self.v_data = <np.float64_t*>np.PyArray_DATA(self.v)
 
-    cdef void add(coo_entries self, np.intp_t i, np.intp_t j, np.float64_t v):
+    cdef int add(coo_entries self, np.intp_t i, np.intp_t j,
+                 np.float64_t v) except -1:
         cdef np.intp_t k
         if self.n == self.n_max:
             self.n_max *= 2
@@ -807,8 +789,11 @@ cdef class cKDTree:
     cdef np.intp_t* raw_indices
 
     def __init__(cKDTree self, data, np.intp_t leafsize=10):
-        self.data = np.ascontiguousarray(data,dtype=np.float64)
-        self.n, self.m = np.shape(self.data)
+        cdef np.ndarray[np.float64_t, ndim=2] data_arr = \
+            np.ascontiguousarray(data, dtype=np.float64)
+        self.data = data_arr
+        self.n = data_arr.shape[0]
+        self.m = data_arr.shape[1]
         self.leafsize = leafsize
         if self.leafsize<1:
             raise ValueError("leafsize must be at least 1")
@@ -1208,21 +1193,20 @@ cdef class cKDTree:
         cdef np.ndarray[np.float64_t, ndim=2] dd
         cdef np.ndarray[np.float64_t, ndim=2] xx
         cdef np.intp_t c, n, i, j
-        x = np.asarray(x).astype(np.float64)
-        if np.shape(x)[-1] != self.m:
+        cdef np.ndarray x_arr = np.asarray(x, dtype=np.float64)
+        if x_arr.ndim == 0 or x_arr.shape[x_arr.ndim - 1] != self.m:
             raise ValueError("x must consist of vectors of length %d but "
                              "has shape %s" % (int(self.m), np.shape(x)))
         if p < 1:
             raise ValueError("Only p-norms with 1<=p<=infinity permitted")
-        if len(x.shape)==1:
+        if x_arr.ndim == 1:
             single = True
-            x = x[np.newaxis,:]
+            x_arr = x_arr[np.newaxis,:]
         else:
             single = False
         retshape = np.shape(x)[:-1]
         n = <np.intp_t> np.prod(retshape)
-        xx = np.reshape(x,(n,self.m))
-        xx = np.ascontiguousarray(xx,dtype=np.float64)
+        xx = np.ascontiguousarray(x_arr).reshape(n, self.m)
         dd = np.empty((n,k),dtype=np.float64)
         dd.fill(infinity)
         ii = np.empty((n,k),dtype=np.intp)
@@ -1386,7 +1370,7 @@ cdef class cKDTree:
         """
         cdef np.ndarray[np.float64_t, ndim=1, mode="c"] xx
         
-        x = np.asarray(x).astype(np.float64)
+        x = np.asarray(x, dtype=np.float64)
         if x.shape[-1] != self.m:
             raise ValueError("Searching for a %d-dimensional point in a " \
                              "%d-dimensional KDTree" % (int(x.shape[-1]), int(self.m)))
@@ -1395,7 +1379,7 @@ cdef class cKDTree:
             return self.__query_ball_point(&xx[0], r, p, eps)
         else:
             retshape = x.shape[:-1]
-            result = np.empty(retshape, dtype=np.object)
+            result = np.empty(retshape, dtype=object)
             for c in np.ndindex(retshape):
                 xx = np.ascontiguousarray(x[c], dtype=np.float64)
                 result[c] = self.__query_ball_point(&xx[0], r, p, eps)
@@ -1898,6 +1882,7 @@ cdef class cKDTree:
             and so may overflow if very large (2e9).
 
         """
+        cdef int r_ndim
         cdef np.intp_t n_queries, i
         cdef np.ndarray[np.float64_t, ndim=1, mode="c"] real_r
         cdef np.ndarray[np.intp_t, ndim=1, mode="c"] results, idx
@@ -1908,14 +1893,11 @@ cdef class cKDTree:
 
         # Make a copy of r array to ensure it's contiguous and to modify it
         # below
-        if np.shape(r) == ():
-            real_r = np.array([r], dtype=np.float64)
-            n_queries = 1
-        elif len(np.shape(r))==1:
-            real_r = np.array(r, dtype=np.float64)
-            n_queries = r.shape[0]
-        else:
+        r_ndim = len(np.shape(r))
+        if r_ndim > 1:
             raise ValueError("r must be either a single value or a one-dimensional array of values")
+        real_r = np.array(r, ndmin=1, dtype=np.float64, copy=True)
+        n_queries = real_r.shape[0]
 
         # Internally, we represent all distances as distance ** p
         if p != infinity:
@@ -1930,19 +1912,19 @@ cdef class cKDTree:
             p, 0.0, 0.0)
         
         # Go!
-        results = np.zeros((n_queries,), dtype=np.intp)
+        results = np.zeros(n_queries, dtype=np.intp)
         idx = np.arange(n_queries, dtype=np.intp)
         self.__count_neighbors_traverse(other, n_queries,
                                         &real_r[0], &results[0], &idx[0],
                                         self.tree, other.tree,
                                         tracker)
         
-        if np.shape(r) == ():
+        if r_ndim == 0:
             if results[0] <= <np.intp_t> LONG_MAX:
                 return int(results[0])
             else:
                 return results[0]
-        elif len(np.shape(r))==1:
+        else:
             return results
 
     # ----------------------

--- a/scipy/stats/vonmises.py
+++ b/scipy/stats/vonmises.py
@@ -21,7 +21,7 @@ def von_mises_cdf_series(k,x,p):
     return 0.5+x/(2*np.pi) + V/np.pi
 
 
-def von_mises_cdf_normalapprox(k,x,C1):
+def von_mises_cdf_normalapprox(k, x):
     b = np.sqrt(2/np.pi)*np.exp(k)/i0(k)
     z = b*np.sin(x/2.)
     return scipy.stats.norm.cdf(z)
@@ -35,13 +35,12 @@ def von_mises_cdf(k,x):
     # These values should give 12 decimal digits
     CK = 50
     a = [28., 0.5, 100., 5.0]
-    C1 = 50.1
 
     if k < CK:
         p = int(np.ceil(a[0]+a[1]*k-a[2]/(k+a[3])))
 
         F = np.clip(von_mises_cdf_series(k,x,p),0,1)
     else:
-        F = von_mises_cdf_normalapprox(k,x,C1)
+        F = von_mises_cdf_normalapprox(k, x)
 
     return F+ix

--- a/scipy/stats/vonmises_cython.pyx
+++ b/scipy/stats/vonmises_cython.pyx
@@ -2,11 +2,14 @@ import numpy as np
 import scipy.stats
 from scipy.special import i0
 import numpy.testing
+
+cimport cython
+from libc.math cimport cos, sin, sqrt
 cimport numpy as np
 
-cdef extern from "math.h":
-    double cos(double theta)
-    double sin(double theta)
+cdef extern from "numpy/npy_math.h":
+    double NPY_PI
+    double NPY_2_PI
 
 
 cdef double von_mises_cdf_series(double k,double x,unsigned int p):
@@ -23,39 +26,36 @@ cdef double von_mises_cdf_series(double k,double x,unsigned int p):
         R = 1./(2*n/k + R)
         V = R*(sn/n+V)
 
-    return 0.5+x/(2*np.pi) + V/np.pi
+    with cython.cdivision(True):
+        return 0.5 + x / (2 * NPY_PI) + V / NPY_PI
 
-def von_mises_cdf_normalapprox(k,x,C1):
-    b = np.sqrt(2/np.pi)*np.exp(k)/i0(k)
+cdef von_mises_cdf_normalapprox(k, x):
+    b = sqrt(NPY_2_PI) * np.exp(k) / i0(k)
     z = b*np.sin(x/2.)
-    C = 24*k
-    chi = z - z**3/((C-2*z**2-16)/3.-(z**4+7/4.*z**2+167./2)/(C+C1-z**2+3))**2
     return scipy.stats.norm.cdf(z)
 
-cimport cython
 @cython.boundscheck(False)
-def von_mises_cdf(k,x):
+def von_mises_cdf(k_obj, x_obj):
     cdef np.ndarray[double, ndim=1] temp, temp_xs, temp_ks
     cdef unsigned int i, p
-    cdef double a1, a2, a3, a4, C1, CK
+    cdef double a1, a2, a3, a4, CK
     #k,x = np.broadcast_arrays(np.asarray(k),np.asarray(x))
-    k = np.asarray(k)
-    x = np.asarray(x)
-    zerodim = k.ndim==0 and x.ndim==0
+    cdef np.ndarray k = np.asarray(k_obj)
+    cdef np.ndarray x = np.asarray(x_obj)
+    cdef bint zerodim = k.ndim==0 and x.ndim==0
 
     k = np.atleast_1d(k)
     x = np.atleast_1d(x)
-    ix = np.round(x/(2*np.pi))
-    x = x-ix*2*np.pi
+    ix = np.round(x / (2 * NPY_PI))
+    x = x - ix * (2 * NPY_PI)
 
     # These values should give 12 decimal digits
     CK=50
     a1, a2, a3, a4 = [28., 0.5, 100., 5.0]
-    C1 = 50.1
 
     bx, bk = np.broadcast_arrays(x,k)
     result = np.empty(bx.shape,dtype=np.float)
-     
+
     c_small_k = bk<CK
     temp = result[c_small_k]
     temp_xs = bx[c_small_k].astype(np.float)
@@ -68,7 +68,7 @@ def von_mises_cdf(k,x):
         elif temp[i]>1:
             temp[i]=1
     result[c_small_k] = temp
-    result[~c_small_k] = von_mises_cdf_normalapprox(bk[~c_small_k],bx[~c_small_k],C1)
+    result[~c_small_k] = von_mises_cdf_normalapprox(bk[~c_small_k],bx[~c_small_k])
 
     if not zerodim:
         return result+ix


### PR DESCRIPTION
Trimmed away some dead code and used lower-level APIs were it didn't hurt readability. This is intended to get smaller code, not extra speed, and the generated C code is <del>hundreds of</del> more than 10.000 lines shorter.
