### PR TITLE
TST: stop shadowing ellip* tests vs boost data

### DIFF
--- a/scipy/special/tests/test_data.py
+++ b/scipy/special/tests/test_data.py
@@ -461,7 +461,6 @@ def test_local():
     for test in TESTS:
         yield _test_factory, test
 
-def test_local():
     TESTS = [
         data_local(ellip_harm_2, 'ellip',(0, 1, 2, 3, 4), 6, rtol=1e-10, atol=1e-13),
         data_local(ellip_harm, 'ellip',(0, 1, 2, 3, 4), 5, rtol=1e-10, atol=1e-13),


### PR DESCRIPTION
Fix a trivial typo in `special` tests (duplicate `def test_local`)

(found by pyflakes)
