### PR TITLE
MAINT: special: use NPY_PI, not M_PI

### DIFF
--- a/scipy/special/amos_wrappers.c
+++ b/scipy/special/amos_wrappers.c
@@ -77,7 +77,7 @@ static double sin_pi(double x)
          */
         return 0;
     }
-    return sin(M_PI * x);
+    return sin(NPY_PI * x);
 }
 
 static double cos_pi(double x)
@@ -89,7 +89,7 @@ static double cos_pi(double x)
          */
         return 0;
     }
-    return cos(M_PI * x);
+    return cos(NPY_PI * x);
 }
 
 static npy_cdouble

--- a/scipy/special/cephes/fresnl.c
+++ b/scipy/special/cephes/fresnl.c
@@ -484,8 +484,8 @@ double xxa, *ssa, *cca;
          * http://functions.wolfram.com/GammaBetaErf/FresnelC/06/02/
          * http://functions.wolfram.com/GammaBetaErf/FresnelS/06/02/
          */
-	cc = 0.5 + 1/(M_PI*x) * sin(M_PI*x*x/2);
-	ss = 0.5 - 1/(M_PI*x) * cos(M_PI*x*x/2);
+	cc = 0.5 + 1/(NPY_PI*x) * sin(NPY_PI*x*x/2);
+	ss = 0.5 - 1/(NPY_PI*x) * cos(NPY_PI*x*x/2);
 	goto done;
     }
 

--- a/scipy/special/specfun_wrappers.c
+++ b/scipy/special/specfun_wrappers.c
@@ -308,7 +308,7 @@ double it2struve0_wrap(double x) {
   F_FUNC(itth0,ITTH0)(&x,&out);
   CONVINF("it2struve0", out);
   if (flag) {
-    out = M_PI - out;
+    out = NPY_PI - out;
   }
   return out;
 }

--- a/scipy/special/sph_harm.pxd
+++ b/scipy/special/sph_harm.pxd
@@ -7,7 +7,7 @@ cdef extern from "c_misc/misc.h":
     double poch(double x, double m) nogil
 
 from _complexstuff cimport *
-from libc.math cimport cos, sqrt, exp, fabs, M_PI as pi
+from libc.math cimport cos, sqrt, fabs
 from libc.stdlib cimport abs
 
 cdef inline double complex sph_harmonic(int m, int n, double theta, double phi) nogil:


### PR DESCRIPTION
M_PI is commonly available, but non-standard, so certain compiler flags may
hide it.
