### PR TITLE
ENH: spatial: reimplement cdist_cosine using np.dot

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -2213,8 +2213,6 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
             dm = cdist(XA, XB, minkowski, p=p)
         elif metric == 'test_wminkowski':
             dm = cdist(XA, XB, wminkowski, p=p, w=w)
-        elif metric == 'test_cosine':
-            dm = cdist(XA, XB, cosine)
         elif metric == 'test_correlation':
             dm = cdist(XA, XB, correlation)
         elif metric == 'test_hamming':

--- a/scipy/spatial/src/distance_impl.h
+++ b/scipy/spatial/src/distance_impl.h
@@ -314,13 +314,6 @@ dot_product(const double *u, const double *v, npy_intp n)
 }
 
 static NPY_INLINE double
-cosine_distance(const double *u, const double *v, npy_intp n,
-                double nu, double nv)
-{
-    return 1.0 - (dot_product(u, v, n) / (nu * nv));
-}
-
-static NPY_INLINE double
 seuclidean_distance(const double *var, const double *u, const double *v,
                     npy_intp n)
 {
@@ -426,7 +419,7 @@ pdist_cosine(const double *X, double *dm, npy_intp m, npy_intp n,
         for (j = i + 1; j < m; j++, dm++) {
             u = X + (n * i);
             v = X + (n * j);
-            *dm = cosine_distance(u, v, n, norms[i], norms[j]);
+            *dm = 1. - dot_product(u, v, n) / (norms[i] * norms[j]);
         }
     }
 }
@@ -528,23 +521,6 @@ cdist_mahalanobis(const double *XA, const double *XB,
         }
     }
     dimbuf2 = 0;
-}
-
-static NPY_INLINE void
-cdist_cosine(const double *XA, const double *XB, double *dm,
-             npy_intp mA, npy_intp mB, npy_intp n,
-             const double *normsA, const double *normsB)
-{
-    const double *u, *v;
-    npy_intp i, j;
-
-    for (i = 0; i < mA; i++) {
-        for (j = 0; j < mB; j++, dm++) {
-            u = XA + (n * i);
-            v = XB + (n * j);
-            *dm = cosine_distance(u, v, n, normsA[i], normsB[j]);
-        }
-    }
 }
 
 static NPY_INLINE void

--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -119,33 +119,6 @@ static PyObject *cdist_mahalanobis_wrap(PyObject *self, PyObject *args) {
   return Py_BuildValue("d", 0.0);
 }
 
-static PyObject *cdist_cosine_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *XA_, *XB_, *dm_, *normsA_, *normsB_;
-  int mA, mB, n;
-  double *dm;
-  const double *XA, *XB, *normsA, *normsB;
-  if (!PyArg_ParseTuple(args, "O!O!O!O!O!",
-			&PyArray_Type, &XA_, &PyArray_Type, &XB_, 
-			&PyArray_Type, &dm_,
-			&PyArray_Type, &normsA_,
-			&PyArray_Type, &normsB_)) {
-    return 0;
-  }
-  else {
-    XA = (const double*)XA_->data;
-    XB = (const double*)XB_->data;
-    dm = (double*)dm_->data;
-    normsA = (const double*)normsA_->data;
-    normsB = (const double*)normsB_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
-
-    cdist_cosine(XA, XB, dm, mA, mB, n, normsA, normsB);
-  }
-  return Py_BuildValue("d", 0.0);
-}
-
 static PyObject *cdist_seuclidean_wrap(PyObject *self, PyObject *args) {
   PyArrayObject *XA_, *XB_, *dm_, *var_;
   int mA, mB, n;
@@ -840,7 +813,6 @@ static PyMethodDef _distanceWrapMethods[] = {
   {"cdist_canberra_wrap", cdist_canberra_wrap, METH_VARARGS},
   {"cdist_chebyshev_wrap", cdist_chebyshev_wrap, METH_VARARGS},
   {"cdist_city_block_wrap", cdist_city_block_wrap, METH_VARARGS},
-  {"cdist_cosine_wrap", cdist_cosine_wrap, METH_VARARGS},
   {"cdist_dice_bool_wrap", cdist_dice_bool_wrap, METH_VARARGS},
   {"cdist_euclidean_wrap", cdist_euclidean_wrap, METH_VARARGS},
   {"cdist_sqeuclidean_wrap", cdist_sqeuclidean_wrap, METH_VARARGS},

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -252,7 +252,15 @@ class TestCdist(TestCase):
         X1 = eo['cdist-X1']
         X2 = eo['cdist-X2']
         Y1 = cdist(X1, X2, 'cosine')
-        Y2 = cdist(X1, X2, 'test_cosine')
+
+        # Naive implementation
+        def norms(X):
+            # NumPy 1.7: np.linalg.norm(X, axis=1).reshape(-1, 1)
+            return np.asarray([np.linalg.norm(row)
+                               for row in X]).reshape(-1, 1)
+
+        Y2 = 1 - np.dot((X1 / norms(X1)), (X2 / norms(X2)).T)
+
         _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
     def test_cdist_correlation_random(self):


### PR DESCRIPTION
This uses `np.dot` instead of a custom dot product routine for computing `cdist(A, B, 'cosine')`. It also uses `np.einsum`, if available, to get the space complexity to a strict O(_mn_) when the dtypes are both `double`, instead of O(_mn_ + _mk_ + _nl_) for _m_, _k_ = `A.shape`, _n_, _l_ = `B.shape`.

I also tried doing the whole thing with `einsum` only:

```
1 - np.einsum('ij,jk,i,k->ik', XA, XB.T, 1/normsA, 1/normsB)
```

... but that was much slower.

Tackling the corresponding `pdist` is much harder and out of scope for this PR.
