### PR TITLE
MAINT: remove NumPy <1.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       env:
         - TESTMODE=fast
         - OPTIMIZE=-OO
-        - NUMPYSPEC="numpy==1.5.1"
+        - NUMPYSPEC="numpy==1.6.2"
     - python: 2.7
       env:
         - TESTMODE=fast

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -113,9 +113,9 @@ else:
 
     from scipy.version import version as __version__
     from scipy.lib._version import NumpyVersion as _NumpyVersion
-    if _NumpyVersion(__numpy_version__) < '1.5.1':
+    if _NumpyVersion(__numpy_version__) < '1.6.2':
         import warnings
-        warnings.warn("Numpy 1.5.1 or above is recommended for this version of "
+        warnings.warn("Numpy 1.6.2 or above is recommended for this version of "
                       "scipy (detected version %s)" % __numpy_version__,
                       UserWarning)
 

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -20,7 +20,6 @@ import warnings
 import functools
 import operator
 
-from scipy.lib._version import NumpyVersion
 from scipy.lib.six import xrange, integer_types
 
 from . import fitpack
@@ -30,9 +29,6 @@ from .polyint import _Interpolator1D
 from . import _ppoly
 from .fitpack2 import RectBivariateSpline
 from .interpnd import _ndim_coords_from_arrays
-
-
-NUMPY_LT_160 = NumpyVersion(np.__version__) < '1.6.0'
 
 
 def reduce_sometrue(a):
@@ -1514,13 +1510,11 @@ class RegularGridInterpolator(object):
         self.fill_value = fill_value
         if fill_value is not None:
             fill_value_dtype = np.asarray(fill_value).dtype
-            if not NUMPY_LT_160:
-                if (hasattr(values,
-                            'dtype') and not np.can_cast(fill_value_dtype,
-                                                         values.dtype,
-                                                         casting='same_kind')):
-                    raise ValueError("fill_value must be either 'None' or "
-                                     "of a type compatible with values")
+            if (hasattr(values, 'dtype')
+                    and not np.can_cast(fill_value_dtype, values.dtype,
+                                        casting='same_kind')):
+                raise ValueError("fill_value must be either 'None' or "
+                                 "of a type compatible with values")
 
         for i, p in enumerate(points):
             if not np.all(np.diff(p) > 0.):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1451,9 +1451,8 @@ class TestRegularGridInterpolator(TestCase):
         RegularGridInterpolator((x, y), values, fill_value=1)
 
         # complex values cannot
-        if NumpyVersion(np.__version__) >= '1.6.0':
-            assert_raises(ValueError, RegularGridInterpolator,
-                          (x, y), values, fill_value=1+2j)
+        assert_raises(ValueError, RegularGridInterpolator,
+                      (x, y), values, fill_value=1+2j)
 
     def test_fillvalue_type(self):
         # from #3703; test that interpolator object construction succeeds

--- a/scipy/lib/_numpy_compat.py
+++ b/scipy/lib/_numpy_compat.py
@@ -45,10 +45,3 @@ else:
                 raise AssertionError("First warning for %s is not a "
                         "%s( is %s)" % (func.__name__, warning_class, l[0]))
         return result
-
-
-if NumpyVersion(np.__version__) >= '1.6.0':
-    count_nonzero = np.count_nonzero
-else:
-    def count_nonzero(a):
-        return (a != 0).sum()

--- a/scipy/linalg/_matfuncs_inv_ssq.py
+++ b/scipy/linalg/_matfuncs_inv_ssq.py
@@ -15,7 +15,6 @@ from scipy.linalg import svdvals, solve_triangular
 from scipy.sparse.linalg.interface import LinearOperator
 from scipy.sparse.linalg import onenormest
 import scipy.special
-from scipy.lib._numpy_compat import count_nonzero as _count_nonzero
 
 
 class LogmRankWarning(UserWarning):
@@ -371,7 +370,7 @@ def _inverse_squaring_helper(T0, theta):
     # this search will not terminate if any diagonal entry of T is zero.
     s0 = 0
     tmp_diag = np.diag(T)
-    if _count_nonzero(tmp_diag) != n:
+    if np.count_nonzero(tmp_diag) != n:
         raise Exception('internal inconsistency')
     while np.max(np.absolute(tmp_diag - 1)) > theta[7]:
         tmp_diag = np.sqrt(tmp_diag)
@@ -653,7 +652,7 @@ def _remainder_matrix_power(A, t):
     # Zeros on the diagonal of the triangular matrix are forbidden,
     # because the inverse scaling and squaring cannot deal with it.
     T_diag = np.diag(T)
-    if _count_nonzero(T_diag) != n:
+    if np.count_nonzero(T_diag) != n:
         raise FractionalMatrixPowerError(
                 'cannot use inverse scaling and squaring to find '
                 'the fractional matrix power of a singular matrix')

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -18,7 +18,6 @@ Functions
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from scipy.lib._numpy_compat import count_nonzero as _count_nonzero
 from .optimize import OptimizeResult, _check_unknown_options
 
 __all__ = ['linprog', 'linprog_verbose_callback', 'linprog_terse_callback']
@@ -636,7 +635,7 @@ def _linprog_simplex(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
 
     # The number of artificial variables (one for each lower-bound and equality
     # constraint)
-    n_artificial = meq + _count_nonzero(bub < 0)
+    n_artificial = meq + np.count_nonzero(bub < 0)
 
     try:
         Aub_rows, Aub_cols = Aub.shape

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -692,11 +692,9 @@ class spmatrix(object):
         """Average the matrix over the given axis.  If the axis is None,
         average over both rows and columns, returning a scalar.
         """
-        # Mimic numpy's casting.  The int32/int64 check works around numpy
-        # 1.5.x behavior of np.issubdtype, see gh-2677.
+        # Mimic numpy's casting.
         if (np.issubdtype(self.dtype, np.float_) or
-                np.issubdtype(self.dtype, np.int_) or
-                self.dtype in [np.dtype('int32'), np.dtype('int64')] or
+                np.issubdtype(self.dtype, np.integer) or
                 np.issubdtype(self.dtype, np.bool_)):
             res_dtype = np.float_
         elif np.issubdtype(self.dtype, np.complex_):

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -15,7 +15,7 @@ from .dia import dia_matrix
 from . import _sparsetools
 from .sputils import upcast, upcast_char, to_native, isdense, isshape, \
      getdtype, isscalarlike, isintlike, IndexMixin, get_index_dtype, \
-     downcast_intp_index, _compat_unique, _compat_bincount
+     downcast_intp_index, _compat_unique
 
 
 class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
@@ -104,8 +104,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             axis, _ = self._swap((axis, 1 - axis))
             _, N = self._swap(self.shape)
             if axis == 0:
-                return _compat_bincount(downcast_intp_index(self.indices),
-                                        minlength=N)
+                return np.bincount(downcast_intp_index(self.indices),
+                                   minlength=N)
             elif axis == 1:
                 return np.diff(self.indptr)
             raise ValueError('axis out of bounds')

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -15,7 +15,7 @@ from ._sparsetools import coo_tocsr, coo_todense, coo_matvec
 from .base import isspmatrix
 from .data import _data_matrix, _minmax_mixin
 from .sputils import (upcast, upcast_char, to_native, isshape, getdtype,
-        isintlike, get_index_dtype, downcast_intp_index, _compat_bincount)
+        isintlike, get_index_dtype, downcast_intp_index)
 
 
 class coo_matrix(_data_matrix, _minmax_mixin):
@@ -229,11 +229,11 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         if axis < 0:
             axis += 2
         if axis == 0:
-            return _compat_bincount(downcast_intp_index(self.col),
-                                    minlength=self.shape[1])
+            return np.bincount(downcast_intp_index(self.col),
+                               minlength=self.shape[1])
         elif axis == 1:
-            return _compat_bincount(downcast_intp_index(self.row),
-                                    minlength=self.shape[0])
+            return np.bincount(downcast_intp_index(self.row),
+                               minlength=self.shape[0])
         else:
             raise ValueError('axis out of bounds')
     nnz = property(fget=getnnz)

--- a/scipy/sparse/csgraph/tests/test_conversions.py
+++ b/scipy/sparse/csgraph/tests/test_conversions.py
@@ -1,8 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal, dec
-from scipy.lib._version import NumpyVersion
+from numpy.testing import assert_array_almost_equal
 from scipy.sparse import csr_matrix
 from scipy.sparse.csgraph import csgraph_from_dense, csgraph_to_dense
 
@@ -37,8 +36,6 @@ def test_csgraph_from_dense():
         assert_array_almost_equal(G, G_csr.toarray())
 
 
-@dec.skipif(NumpyVersion(np.__version__) < '1.6.0',
-            "Can't test arrays with infs.")
 def test_csgraph_to_dense():
     np.random.seed(1234)
     G = np.random.random((10, 10))

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -3,7 +3,6 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_raises, dec,
     run_module_suite, assert_array_equal)
-from scipy.lib._version import NumpyVersion
 from scipy.sparse.csgraph import (shortest_path, dijkstra, johnson,
     bellman_ford, construct_dist_matrix, NegativeCycleError)
 
@@ -58,8 +57,6 @@ undirected_pred = np.array([[-9999, 0, 0, 0, 0],
 methods = ['auto', 'FW', 'D', 'BF', 'J']
 
 
-@dec.skipif(NumpyVersion(np.__version__) < '1.6.0',
-            "Can't test arrays with infs.")
 def test_dijkstra_limit():
     limits = [0, 2, np.inf]
     results = [undirected_SP_limit_0,
@@ -74,8 +71,6 @@ def test_dijkstra_limit():
         yield check, limit, result
 
 
-@dec.skipif(NumpyVersion(np.__version__) < '1.6.0',
-            "Can't test arrays with infs.")
 def test_directed():
     def check(method):
         SP = shortest_path(directed_G, method=method, directed=True,
@@ -116,8 +111,6 @@ def test_shortest_path_indices():
             yield check, func, indshape
 
 
-@dec.skipif(NumpyVersion(np.__version__) < '1.6.0',
-            "Can't test arrays with infs.")
 def test_predecessors():
     SP_res = {True: directed_SP,
               False: undirected_SP}
@@ -136,8 +129,6 @@ def test_predecessors():
             yield check, method, directed
 
 
-@dec.skipif(NumpyVersion(np.__version__) < '1.6.0',
-            "Can't test arrays with infs.")
 def test_construct_shortest_path():
     def check(method, directed):
         SP1, pred = shortest_path(directed_G,
@@ -152,8 +143,6 @@ def test_construct_shortest_path():
             yield check, method, directed
 
 
-@dec.skipif(NumpyVersion(np.__version__) < '1.6.0',
-            "Can't test arrays with infs.")
 def test_unweighted_path():
     def check(method, directed):
         SP1 = shortest_path(directed_G,
@@ -186,8 +175,6 @@ def test_negative_cycles():
             yield check, method, directed
 
 
-@dec.skipif(NumpyVersion(np.__version__) < '1.6.0',
-            "Can't test arrays with infs.")
 def test_masked_input():
     G = np.ma.masked_equal(directed_G, 0)
 

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -17,7 +17,6 @@ import math
 import numpy as np
 
 import scipy.misc
-from scipy.lib._numpy_compat import count_nonzero as _np_count_nonzero
 from scipy.linalg.basic import solve, solve_triangular
 
 from scipy.sparse.base import isspmatrix
@@ -119,7 +118,7 @@ def _count_nonzero(A):
     if isspmatrix(A):
         return np.sum(A.toarray() != 0)
     else:
-        return _np_count_nonzero(A)
+        return np.count_nonzero(A)
 
 
 def _is_upper_triangular(A):

--- a/scipy/sparse/linalg/tests/test_onenormest.py
+++ b/scipy/sparse/linalg/tests/test_onenormest.py
@@ -6,7 +6,6 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy.testing import (assert_allclose, assert_equal, assert_,
         decorators, TestCase, run_module_suite)
-from scipy.lib._numpy_compat import count_nonzero as _count_nonzero
 import scipy.linalg
 import scipy.sparse.linalg
 from scipy.sparse.linalg._onenormest import _onenormest_core, _algorithm_2_2
@@ -77,7 +76,7 @@ class TestOnenormest(TestCase):
         assert_(0.05 < np.mean(nresample_list) < 0.2)
 
         # check the proportion of norms computed exactly correctly
-        nexact = _count_nonzero(relative_errors < 1e-14)
+        nexact = np.count_nonzero(relative_errors < 1e-14)
         proportion_exact = nexact / float(nsamples)
         assert_(0.9 < proportion_exact < 0.95)
 
@@ -117,7 +116,7 @@ class TestOnenormest(TestCase):
         assert_equal(np.max(nresample_list), 0)
 
         # check the proportion of norms computed exactly correctly
-        nexact = _count_nonzero(relative_errors < 1e-14)
+        nexact = np.count_nonzero(relative_errors < 1e-14)
         proportion_exact = nexact / float(nsamples)
         assert_(0.15 < proportion_exact < 0.25)
 
@@ -184,7 +183,7 @@ class TestOnenormest(TestCase):
         assert_equal(max_nresamples, 0)
 
         # check the proportion of norms computed exactly correctly
-        nexact = _count_nonzero(relative_errors < 1e-14)
+        nexact = np.count_nonzero(relative_errors < 1e-14)
         proportion_exact = nexact / float(nsamples)
         assert_(0.7 < proportion_exact < 0.8)
 

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -415,23 +415,3 @@ if NumpyVersion(np.__version__) > '1.7.0-dev':
     _compat_unique = np.unique
 else:
     _compat_unique = _compat_unique_impl
-
-
-def _compat_bincount_impl(x, weights=None, minlength=None):
-    """
-    Bincount with minlength keyword added for Numpy 1.5.
-    """
-    if weights is None:
-        x = np.bincount(x)
-    else:
-        x = np.bincount(x, weights=weights)
-    if minlength is not None:
-        if x.shape[0] < minlength:
-            x = np.r_[x, np.zeros((minlength - x.shape[0],))]
-    return x
-
-
-if NumpyVersion(np.__version__) > '1.6.0-dev':
-    _compat_bincount = np.bincount
-else:
-    _compat_bincount = _compat_bincount_impl

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -79,12 +79,6 @@ class TestSparseUtils(TestCase):
         j2 = np.array([0, 7, 14, 21, 28, 35, 42, 49, 56, 63])
         assert_array_equal(j1, j2)
 
-    def test_compat_bincount(self):
-        x = np.arange(4)
-        y1 = sputils._compat_bincount_impl(x, minlength=10)
-        y2 = np.array([1, 1, 1, 1, 0, 0, 0, 0, 0, 0])
-        assert_array_equal(y1, y2)
-
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -279,8 +279,6 @@ class TestUtilities(object):
             ok = (j != -1) | at_boundary
             assert_(ok.all(), "%s %s" % (err_msg, np.where(~ok)))
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.6.0',
-                "No einsum in numpy 1.5.x")
     def test_degenerate_barycentric_transforms(self):
         # The triangulation should not produce invalid barycentric
         # transforms that stump the simplex finding
@@ -299,8 +297,6 @@ class TestUtilities(object):
         self._check_barycentric_transforms(tri)
 
     @dec.slow
-    @dec.skipif(NumpyVersion(np.__version__) < '1.6.0',
-                "No einsum in numpy 1.5.x")
     def test_more_barycentric_transforms(self):
         # Triangulate some "nasty" grids
 

--- a/scipy/special/tests/test_logit.py
+++ b/scipy/special/tests/test_logit.py
@@ -3,7 +3,6 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy.testing import (TestCase, assert_equal, assert_almost_equal,
         assert_allclose)
-from scipy.lib._version import NumpyVersion
 from scipy.special import logit, expit
 
 
@@ -17,10 +16,7 @@ class TestLogit(TestCase):
         finally:
             np.seterr(**olderr)
 
-        if NumpyVersion(np.__version__) >= '1.6.0':
-            assert_almost_equal(actual, expected)
-        else:
-            assert_almost_equal(actual[1:-1], expected[1:-1])
+        assert_almost_equal(actual, expected)
 
         assert_equal(actual.dtype, np.dtype(dtype))
 

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -1,19 +1,10 @@
 from __future__ import division, print_function, absolute_import
 
-import sys
-
 import numpy as np
-from numpy.testing import assert_, assert_allclose, dec
+from numpy.testing import assert_, assert_allclose
 import scipy.special.orthogonal as orth
 
-from scipy.lib._version import NumpyVersion
 from scipy.special._testutils import FuncData
-
-
-# Early Numpy versions have bugs in ufunc keyword argument parsing
-numpy_version_requirement = dec.skipif(
-    NumpyVersion(np.__version__) < '1.6.0' and sys.version_info[0] >= 3,
-    "Bug in Numpy < 1.6 on Python 3")
 
 
 def test_eval_chebyt():
@@ -199,72 +190,58 @@ class TestRecurrence(object):
         finally:
             np.seterr(**olderr)
 
-    @numpy_version_requirement
     def test_jacobi(self):
         self.check_poly(orth.eval_jacobi,
                    param_ranges=[(-0.99, 10), (-0.99, 10)], x_range=[-1, 1])
 
-    @numpy_version_requirement
     def test_sh_jacobi(self):
         self.check_poly(orth.eval_sh_jacobi,
                    param_ranges=[(1, 10), (0, 1)], x_range=[0, 1])
 
-    @numpy_version_requirement
     def test_gegenbauer(self):
         self.check_poly(orth.eval_gegenbauer,
                    param_ranges=[(-0.499, 10)], x_range=[-1, 1])
 
-    @numpy_version_requirement
     def test_chebyt(self):
         self.check_poly(orth.eval_chebyt,
                    param_ranges=[], x_range=[-1, 1])
 
-    @numpy_version_requirement
     def test_chebyu(self):
         self.check_poly(orth.eval_chebyu,
                    param_ranges=[], x_range=[-1, 1])
 
-    @numpy_version_requirement
     def test_chebys(self):
         self.check_poly(orth.eval_chebys,
                    param_ranges=[], x_range=[-2, 2])
 
-    @numpy_version_requirement
     def test_chebyc(self):
         self.check_poly(orth.eval_chebyc,
                    param_ranges=[], x_range=[-2, 2])
 
-    @numpy_version_requirement
     def test_sh_chebyt(self):
         self.check_poly(orth.eval_sh_chebyt,
                    param_ranges=[], x_range=[0, 1])
 
-    @numpy_version_requirement
     def test_sh_chebyu(self):
         self.check_poly(orth.eval_sh_chebyu,
                    param_ranges=[], x_range=[0, 1])
 
-    @numpy_version_requirement
     def test_legendre(self):
         self.check_poly(orth.eval_legendre,
                    param_ranges=[], x_range=[-1, 1])
 
-    @numpy_version_requirement
     def test_sh_legendre(self):
         self.check_poly(orth.eval_sh_legendre,
                    param_ranges=[], x_range=[0, 1])
 
-    @numpy_version_requirement
     def test_genlaguerre(self):
         self.check_poly(orth.eval_genlaguerre,
                    param_ranges=[(-0.99, 10)], x_range=[0, 100])
 
-    @numpy_version_requirement
     def test_laguerre(self):
         self.check_poly(orth.eval_laguerre,
                    param_ranges=[], x_range=[0, 100])
 
-    @numpy_version_requirement
     def test_hermite(self):
         v = orth.eval_hermite(70, 1.0)
         a = -1.457076485701412e60

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -11,11 +11,10 @@ import numpy as np
 from numpy import (isscalar, r_, log, sum, around, unique, asarray,
                    zeros, arange, sort, amin, amax, any, atleast_1d,
                    sqrt, ceil, floor, array, poly1d, compress,
-                   pi, exp, ravel, angle)
+                   pi, exp, ravel, angle, count_nonzero)
 from numpy.testing.decorators import setastest
 
 from scipy.lib.six import string_types
-from scipy.lib._numpy_compat import count_nonzero
 from scipy import optimize
 from scipy import special
 from . import statlib


### PR DESCRIPTION
<del>To be merged only after a decision has been made wrt. the minimum NumPy version required.</del> I believe we have consensus on NumPy 1.6.2 as the minimum requirement.
