### PR TITLE
MAINT: fftpack benchmark integer division vs true division

### DIFF
--- a/scipy/fftpack/benchmarks/bench_basic.py
+++ b/scipy/fftpack/benchmarks/bench_basic.py
@@ -174,7 +174,7 @@ class TestIrfft(TestCase):
             x = random([size]).astype(double)
             x1 = zeros(size/2+1,dtype=cdouble)
             x1[0] = x[0]
-            for i in range(1,size/2):
+            for i in range(1,size//2):
                 x1[i] = x[2*i-1] + 1j * x[2*i]
             if not size % 2:
                 x1[-1] = x[-1]


### PR DESCRIPTION
Having been inspired by https://github.com/scipy/scipy/pull/4087 to run the scipy benchmarks
`$ python runtests.py --bench`
I see three errors in the output.  This single-character PR fixes one of the errors.
