### PR TITLE
MAINT: remove __div__ from scipy sparse testing with np.inexact inputs

### DIFF
--- a/scipy/sparse/benchmarks/bench_sparse.py
+++ b/scipy/sparse/benchmarks/bench_sparse.py
@@ -80,7 +80,7 @@ class BenchmarkSparse(TestCase):
             vars = dict([(var, mat.asformat(format)) for (var, _, mat) in matrices])
             for X,Y in [('A','A'),('A','B'),('B','A'),('B','B')]:
                 x,y = vars[X],vars[Y]
-                for op in ['__add__','__sub__','multiply','__div__','__mul__']:
+                for op in ['__add__','__sub__','multiply','__mul__']:
                     fn = getattr(x,op)
                     fn(y)  # warmup
 


### PR DESCRIPTION
This fixes the second of three problems I was having with the benchmarks.  The `__div__` of sparse matrices was filling up my computer with nans to the point where the mouse wouldn't move anymore.  Maybe later it could be added back, if it uses only input matrices that are not `np.inexact`.
