### PR TITLE
BUG: sparse: Fix bench_sparse.py

### DIFF
--- a/scipy/sparse/benchmarks/bench_sparse.py
+++ b/scipy/sparse/benchmarks/bench_sparse.py
@@ -11,8 +11,8 @@ from numpy import ones, array, asarray, empty
 from numpy.testing import TestCase, run_module_suite
 
 from scipy import sparse
-from scipy.sparse import (csr_matrix, coo_matrix, dia_matrix, rand,
-                          SparseEfficiencyWarning)
+from scipy.sparse import (csr_matrix, coo_matrix, dia_matrix, lil_matrix,
+                          dok_matrix, rand, SparseEfficiencyWarning)
 
 
 def random_sparse(m,n,nnz_per_row):
@@ -231,13 +231,13 @@ class BenchmarkSparse(TestCase):
         for name,A in matrices:
             A = A.tocoo()
 
-            for format in ['lil','dok']:
+            for format, cls in [('lil', lil_matrix), ('dok', dok_matrix)]:
 
                 start = time.clock()
 
                 iter = 0
                 while time.clock() < start + 0.5:
-                    T = eval(format + '_matrix')(A.shape)
+                    T = cls(A.shape)
                     for i,j,v in zip(A.row,A.col,A.data):
                         T[i,j] = v
                     iter += 1


### PR DESCRIPTION
In a previous change to bench_sparse.py, the imports of dok_matrix and
lil_matrix were removed, because pyflakes reported them as unused.
In fact, these were needed for a benchmark that was creating instances of
these matrices using eval().

In this commit, instead of constructing the names as a string and then
eval'ing the string, the class names are used explicitly.
