### PR TITLE
DOC: fix Ward's distance formula

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -579,7 +579,7 @@ def linkage(y, method='single', metric='euclidean'):
                                {T}d(v,s)^2
                         + \\frac{|v|+|t|}
                                {T}d(v,t)^2
-                        + \\frac{|v|}
+                        - \\frac{|v|}
                                {T}d(s,t)^2}
 
         where :math:`u` is the newly joined cluster consisting of


### PR DESCRIPTION
Just a minor sign error in the description.

From `_hierarchy_distance_update.pxi`

``` cython
cdef double _ward(double d_xi, double d_yi, double d_xy,
                  int size_x, int size_y, int size_i):
    cdef double t = 1.0 / (size_x + size_y + size_i)
    return sqrt((size_i + size_x) * t * d_xi * d_xi +
                (size_i + size_y) * t * d_yi * d_yi -
                size_i * t * d_xy * d_xy)
```
