### PR TITLE
Sparse matrix multiplication: only convert array if needed (with proper fix branch)

### DIFF
--- a/scipy/sparse/benchmarks/bench_sparse.py
+++ b/scipy/sparse/benchmarks/bench_sparse.py
@@ -5,11 +5,11 @@ import time
 import warnings
 
 import numpy
-import numpy as np
-from numpy import ones, array, asarray, empty
+from numpy import ones, array, asarray, empty, random, zeros
 
-from numpy.testing import TestCase, run_module_suite
+from numpy.testing import Tester, TestCase
 
+import scipy
 from scipy import sparse
 from scipy.sparse import (csr_matrix, coo_matrix, dia_matrix, lil_matrix,
                           dok_matrix, rand, SparseEfficiencyWarning)
@@ -80,7 +80,7 @@ class BenchmarkSparse(TestCase):
             vars = dict([(var, mat.asformat(format)) for (var, _, mat) in matrices])
             for X,Y in [('A','A'),('A','B'),('B','A'),('B','B')]:
                 x,y = vars[X],vars[Y]
-                for op in ['__add__','__sub__','multiply','__div__','__mul__']:
+                for op in ['__add__','__sub__','multiply','__mul__']:
                     fn = getattr(x,op)
                     fn(y)  # warmup
 
@@ -302,11 +302,11 @@ class BenchmarkSparse(TestCase):
                 i, j = [], []
                 while len(i) < N:
                     n = N - len(i)
-                    ip = np.random.randint(0, A.shape[0], size=n)
-                    jp = np.random.randint(0, A.shape[1], size=n)
-                    i = np.r_[i, ip]
-                    j = np.r_[j, jp]
-                v = np.random.rand(n)
+                    ip = numpy.random.randint(0, A.shape[0], size=n)
+                    jp = numpy.random.randint(0, A.shape[1], size=n)
+                    i = numpy.r_[i, ip]
+                    j = numpy.r_[j, jp]
+                v = numpy.random.rand(n)
 
                 if N == 1:
                     i = int(i)
@@ -363,32 +363,36 @@ class BenchmarkSparse(TestCase):
         print('           Sparse Matrix fancy __getitem__')
         self._getset_bench(kernel, ['csr', 'csc', 'lil'])
 
-# class TestLarge(TestCase):
-#    def bench_large(self):
-#        # Create a 100x100 matrix with 100 non-zero elements
-#        # and play around with it
-#        #TODO move this out of Common since it doesn't use spmatrix
-#        random.seed(0)
-#        A = dok_matrix((100,100))
-#        for k in xrange(100):
-#            i = random.randrange(100)
-#            j = random.randrange(100)
-#            A[i,j] = 1.
-#        csr = A.tocsr()
-#        csc = A.tocsc()
-#        csc2 = csr.tocsc()
-#        coo = A.tocoo()
-#        csr2 = coo.tocsr()
-#        assert_array_equal(A.transpose().todense(), csr.transpose().todense())
-#        assert_array_equal(csc.todense(), csr.todense())
-#        assert_array_equal(csr.todense(), csr2.todense())
-#        assert_array_equal(csr2.todense().transpose(), coo.transpose().todense())
-#        assert_array_equal(csr2.todense(), csc2.todense())
-#        csr_plus_csc = csr + csc
-#        csc_plus_csr = csc + csr
-#        assert_array_equal(csr_plus_csc.todense(), (2*A).todense())
-#        assert_array_equal(csr_plus_csc.todense(), csc_plus_csr.todense())
+    def bench_large(self):
+        H1, W1 = 1, 100000
+        H2, W2 = W1, 1000
+        C1 = 10
+        C2 = 1000000
 
+        print()
+
+        random.seed(0)
+
+        print('                  Sparse Matrix Large Matrix Multiplication')
+        start = time.time()
+        matrix1 = lil_matrix(zeros((H1, W1)))
+        matrix2 = lil_matrix(zeros((H2, W2)))
+        for i in xrange(C1):
+            matrix1[random.randint(H1), random.randint(W1)] = random.rand()
+        for i in xrange(C2):
+            matrix2[random.randint(H2), random.randint(W2)] = random.rand()
+        matrix1 = matrix1.tocsr()
+        matrix2 = matrix2.tocsr()
+        end = time.time()
+
+        start = time.time()
+        for i in range(100):
+            matrix3 = matrix1 * matrix2
+        end = time.time()
+        print('==============================================================================')
+        print('Matrix 1 shape | Matrix 2 shape | Matrix 1 count | Matrix 2 count | time (sec)')
+        print('------------------------------------------------------------------------------')
+        print('%14s | %14s | %14d | %14d | %10.3f' % (matrix1.shape, matrix2.shape, C1, C2, end-start))
 
 if __name__ == "__main__":
-    run_module_suite()
+    test = Tester(__file__).bench()

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -83,7 +83,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                     self.shape = self._swap((major_dim,minor_dim))
 
         if dtype is not None:
-            self.data = self.data.astype(dtype)
+            self.data = np.asarray(self.data, dtype=dtype)
 
         self.check_format(full_check=False)
 
@@ -484,26 +484,26 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         fn = getattr(_sparsetools, self.format + '_matmat_pass1')
         fn(M, N,
-           self.indptr.astype(idx_dtype),
-           self.indices.astype(idx_dtype),
-           other.indptr.astype(idx_dtype),
-           other.indices.astype(idx_dtype),
+           np.asarray(self.indptr, dtype=idx_dtype),
+           np.asarray(self.indices, dtype=idx_dtype),
+           np.asarray(other.indptr, dtype=idx_dtype),
+           np.asarray(other.indices, dtype=idx_dtype),
            indptr)
 
         nnz = indptr[-1]
         idx_dtype = get_index_dtype((self.indptr, self.indices,
                                      other.indptr, other.indices),
                                     maxval=nnz)
-        indptr = indptr.astype(idx_dtype)
+        indptr = np.asarray(indptr, dtype=idx_dtype)
         indices = np.empty(nnz, dtype=idx_dtype)
         data = np.empty(nnz, dtype=upcast(self.dtype, other.dtype))
 
         fn = getattr(_sparsetools, self.format + '_matmat_pass2')
-        fn(M, N, self.indptr.astype(idx_dtype),
-           self.indices.astype(idx_dtype),
+        fn(M, N, np.asarray(self.indptr, dtype=idx_dtype),
+           np.asarray(self.indices, dtype=idx_dtype),
            self.data,
-           other.indptr.astype(idx_dtype),
-           other.indices.astype(idx_dtype),
+           np.asarray(other.indptr, dtype=idx_dtype),
+           np.asarray(other.indices, dtype=idx_dtype),
            other.data,
            indptr, indices, data)
 
@@ -705,8 +705,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         check_bounds(i, M)
         check_bounds(j, N)
 
-        i = i.astype(self.indices.dtype)
-        j = j.astype(self.indices.dtype)
+        i = np.asarray(i, dtype=self.indices.dtype)
+        j = np.asarray(j, dtype=self.indices.dtype)
 
         n_samples = len(x)
         offsets = np.empty(n_samples, dtype=self.indices.dtype)
@@ -758,12 +758,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         # Update index data type
         idx_dtype = get_index_dtype((self.indices, self.indptr),
                                     maxval=(self.indptr[-1] + x.size))
-        if idx_dtype != self.indptr.dtype:
-            self.indptr = self.indptr.astype(idx_dtype)
-            self.indices = self.indices.astype(idx_dtype)
-        if idx_dtype != i.dtype or idx_dtype != j.dtype:
-            i = i.astype(idx_dtype)
-            j = j.astype(idx_dtype)
+        self.indptr = np.asarray(self.indptr, dtype=idx_dtype)
+        self.indices = np.asarray(self.indices, dtype=idx_dtype)
+        i = np.asarray(i, dtype=idx_dtype)
+        j = np.asarray(j, dtype=idx_dtype)
 
         # Collate old and new in chunks by major index
         indices_parts = []
@@ -799,7 +797,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         # update attributes
         self.indices = np.concatenate(indices_parts)
         self.data = np.concatenate(data_parts)
-        nnzs = np.ediff1d(self.indptr, to_begin=0).astype(idx_dtype)
+        nnzs = np.asarray(np.ediff1d(self.indptr, to_begin=0), dtype=idx_dtype)
         nnzs[1:][ui] += new_nnzs
         self.indptr = np.cumsum(nnzs, out=nnzs)
 
@@ -1096,11 +1094,11 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             data = np.empty(maxnnz, dtype=upcast(self.dtype, other.dtype))
 
         fn(self.shape[0], self.shape[1],
-           self.indptr.astype(idx_dtype),
-           self.indices.astype(idx_dtype),
+           np.asarray(self.indptr, dtype=idx_dtype),
+           np.asarray(self.indices, dtype=idx_dtype),
            self.data,
-           other.indptr.astype(idx_dtype),
-           other.indices.astype(idx_dtype),
+           np.asarray(other.indptr, dtype=idx_dtype),
+           np.asarray(other.indices, dtype=idx_dtype),
            other.data,
            indptr, indices, data)
 


### PR DESCRIPTION
This overrides https://github.com/scipy/scipy/pull/4274 according to this comment: https://github.com/scipy/scipy/pull/4274#issuecomment-67024414

Fixes https://github.com/scipy/scipy/issues/4203

Also include the change requested in https://github.com/scipy/scipy/pull/4271
