### PR TITLE
BUG: integrate: odeint crashed when the integration time was 0.

### DIFF
--- a/scipy/integrate/odepack.py
+++ b/scipy/integrate/odepack.py
@@ -7,6 +7,7 @@ from . import _odepack
 from copy import copy
 
 _msgs = {2: "Integration successful.",
+         1: "Nothing was done; the integration time was 0.",
          -1: "Excess work done on this call (perhaps wrong Dfun type).",
          -2: "Excess accuracy requested (tolerances too small).",
          -3: "Illegal input detected (internal error).",

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -607,6 +607,15 @@ class LSODACheckParameterUse(ODECheckParameterUse, TestCase):
     solver_uses_jac = True
 
 
+def test_odeint_trivial_time():
+    # Test that odeint succeeds when given a single time point
+    # and full_output=True.  This is a regression test for gh-4282.
+    y0 = 1
+    t = [0]
+    y, info = odeint(lambda y, t: -y, y0, t, full_output=True)
+    assert_array_equal(y, np.array([[y0]]))
+
+
 def test_odeint_banded_jacobian():
     # Test the use of the `Dfun`, `ml` and `mu` options of odeint.
 


### PR DESCRIPTION
When only a single time point (or only a single repeated time value)
was given along with the argument full_output=True, a KeyError was
raised because the _msgs dict didn't have the key 1 (the 'istate'
value returned by the Fortran solver when no work was done).

Closes gh-4282.
