### PR TITLE
MRG: fix matlab output type of logical array

### DIFF
--- a/scipy/io/matlab/mio5_params.py
+++ b/scipy/io/matlab/mio5_params.py
@@ -130,6 +130,7 @@ NP_TO_MTYPES = {
     'u1': miUINT8,
     'S1': miUINT8,
     'U1': miUTF16,
+    'b1': miUINT8,  # not standard but seems MATLAB uses this (gh-4022)
     }
 
 
@@ -149,6 +150,7 @@ NP_TO_MXTYPES = {
     'u2': mxUINT16_CLASS,
     'u1': mxUINT8_CLASS,
     'S1': mxUINT8_CLASS,
+    'b1': mxUINT8_CLASS,  # not standard but seems MATLAB uses this
     }
 
 ''' Before release v7.1 (release 14) matlab (TM) used the system

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -32,6 +32,7 @@ from scipy.io.matlab.miobase import matdims, MatWriteError
 from scipy.io.matlab.mio import (mat_reader_factory, loadmat, savemat, whosmat)
 from scipy.io.matlab.mio5 import (MatlabObject, MatFile5Writer, MatFile5Reader,
                                   MatlabFunction, varmats_from_mat)
+from scipy.io.matlab import mio5_params as mio5p
 
 
 test_data_path = pjoin(dirname(__file__), 'data')
@@ -845,6 +846,23 @@ def test_logical_array():
     x = np.array([[True], [False]], dtype=np.bool_)
     assert_array_equal(d['testbools'], x)
     assert_equal(d['testbools'].dtype, x.dtype)
+
+
+def test_logical_out_type():
+    # Confirm that bool type written as uint8, uint8 class
+    # See gh-4022
+    stream = BytesIO()
+    barr = np.array([False, True, False])
+    savemat(stream, {'barray': barr})
+    stream.seek(0)
+    reader = MatFile5Reader(stream)
+    reader.initialize_read()
+    reader.read_file_header()
+    hdr, _ = reader.read_var_header()
+    assert_equal(hdr.mclass, mio5p.mxUINT8_CLASS)
+    assert_equal(hdr.is_logical, True)
+    var = reader.read_var_array(hdr, False)
+    assert_equal(var.dtype.type, np.uint8)
 
 
 def test_mat4_3d():

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -837,12 +837,11 @@ def test_write_opposite_endian():
 
 
 def test_logical_array():
-    # The roundtrip test doesn't verify that we load the data up with the correct (bool) dtype
-    fp = open(pjoin(test_data_path, 'testbool_8_WIN64.mat'), 'rb')
-    rdr = MatFile5Reader(fp, mat_dtype=True)
-    d = rdr.get_variables()
-    fp.close()
-
+    # The roundtrip test doesn't verify that we load the data up with the
+    # correct (bool) dtype
+    with open(pjoin(test_data_path, 'testbool_8_WIN64.mat'), 'rb') as fobj:
+        rdr = MatFile5Reader(fobj, mat_dtype=True)
+        d = rdr.get_variables()
     x = np.array([[True], [False]], dtype=np.bool_)
     assert_array_equal(d['testbools'], x)
     assert_equal(d['testbools'].dtype, x.dtype)


### PR DESCRIPTION
Fixes output type for logical arrays for MATLAB.

MATLAB apparently insists that logical arrays are in output type UINT8.
