### PR TITLE
DOC: linalg: fix layout in cholesky_banded docstring

### DIFF
--- a/scipy/linalg/decomp_cholesky.py
+++ b/scipy/linalg/decomp_cholesky.py
@@ -184,7 +184,7 @@ def cholesky_banded(ab, overwrite_ab=False, lower=False, check_finite=True):
     Cholesky decompose a banded Hermitian positive-definite matrix
 
     The matrix a is stored in ab either in lower diagonal or upper
-    diagonal ordered form:
+    diagonal ordered form::
 
         ab[u + i - j, j] == a[i,j]        (if upper form; i <= j)
         ab[    i - j, j] == a[i,j]        (if lower form; i >= j)


### PR DESCRIPTION
One-character tweak to fix rendering of the definition of upper/lower diagonal storage:
http://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.linalg.cholesky_banded.html
