### PR TITLE
BUG: allow empty dict as proxy for empty struct

### DIFF
--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -410,53 +410,6 @@ def to_writeable(source):
     Returns
     -------
     arr : ndarray
-
-    Examples
-    --------
-    >>> to_writeable(np.array([1])) # pass through ndarrays
-    array([1])
-    >>> expected = np.array([(1, 2)], dtype=[('a', '|O8'), ('b', '|O8')])
-    >>> np.all(to_writeable({'a':1,'b':2}) == expected)
-    True
-    >>> np.all(to_writeable({'a':1,'b':2, '_c':3}) == expected)
-    True
-    >>> np.all(to_writeable({'a':1,'b':2, 100:3}) == expected)
-    True
-    >>> np.all(to_writeable({'a':1,'b':2, '99':3}) == expected)
-    True
-    >>> class klass(object): pass
-    >>> c = klass
-    >>> c.a = 1
-    >>> c.b = 2
-    >>> np.all(to_writeable({'a':1,'b':2}) == expected)
-    True
-    >>> to_writeable([])
-    array([], dtype=float64)
-    >>> to_writeable(())
-    array([], dtype=float64)
-    >>> to_writeable(None)
-
-    >>> to_writeable('a string').dtype.type == np.str_
-    True
-    >>> to_writeable(1)
-    array(1)
-    >>> to_writeable([1])
-    array([1])
-    >>> to_writeable([1])
-    array([1])
-    >>> to_writeable(object()) # not convertable
-
-    dict keys with legal characters are convertible
-
-    >>> to_writeable({'a':1})['a']
-    array([1], dtype=object)
-
-    but not with illegal characters
-
-    >>> to_writeable({'1':1}) is None
-    True
-    >>> to_writeable({'_a':1}) is None
-    True
     '''
     if isinstance(source, np.ndarray):
         return source

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -99,8 +99,8 @@ from .mio5_utils import VarReader5
 
 # Constants and helper objects
 from .mio5_params import (MatlabObject, MatlabFunction, MDTYPES, NP_TO_MTYPES,
-                          NP_TO_MXTYPES, miCOMPRESSED, miMATRIX, miINT8, miUTF8,
-                          miUINT32, mxCELL_CLASS, mxSTRUCT_CLASS,
+                          NP_TO_MXTYPES, miCOMPRESSED, miMATRIX, miINT8,
+                          miUTF8, miUINT32, mxCELL_CLASS, mxSTRUCT_CLASS,
                           mxOBJECT_CLASS, mxCHAR_CLASS, mxSPARSE_CLASS,
                           mxDOUBLE_CLASS, mclass_info)
 
@@ -400,6 +400,10 @@ def varmats_from_mat(file_obj):
     return named_mats
 
 
+class EmptyStructMarker(object):
+    """ Class to indicate presence of empty matlab struct on output """
+
+
 def to_writeable(source):
     ''' Convert input object ``source`` to something we can write
 
@@ -409,7 +413,11 @@ def to_writeable(source):
 
     Returns
     -------
-    arr : ndarray
+    arr : None or ndarray or EmptyStructMarker
+        If `source` cannot be converted to something we can write to a matfile,
+        return None.  If `source` is equivalent to an empty dictionary, return
+        ``EmptyStructMarker``.  Otherwise return `source` converted to an
+        ndarray with contents for writing to matfile.
     '''
     if isinstance(source, np.ndarray):
         return source
@@ -429,12 +437,12 @@ def to_writeable(source):
         for field, value in source.items():
             if (isinstance(field, string_types) and
                     field[0] not in '_0123456789'):
-                dtype.append((field,object))
+                dtype.append((field, object))
                 values.append(value)
         if dtype:
-            return np.array([tuple(values)],dtype)
+            return np.array([tuple(values)], dtype)
         else:
-            return None
+            return EmptyStructMarker
     # Next try and convert to an array
     narr = np.asanyarray(source)
     if narr.dtype.type in (np.object, np.object_) and \
@@ -602,6 +610,8 @@ class VarWriter5(object):
             self.write_object(narr)
         elif isinstance(narr, MatlabFunction):
             raise MatWriteError('Cannot write matlab functions')
+        elif narr is EmptyStructMarker: # empty struct array
+            self.write_empty_struct()
         elif narr.dtype.fields:  # struct array
             self.write_struct(narr)
         elif narr.dtype.hasobject:  # cell array
@@ -711,6 +721,13 @@ class VarWriter5(object):
         A = np.atleast_2d(arr).flatten('F')
         for el in A:
             self.write(el)
+
+    def write_empty_struct(self):
+        self.write_header((1, 1), mxSTRUCT_CLASS)
+        # max field name length set to 1 in an example matlab struct
+        self.write_element(np.array(1, dtype=np.int32))
+        # Field names element is empty
+        self.write_element(np.array([], dtype=np.int8))
 
     def write_struct(self, arr):
         self.write_header(matdims(arr, self.oned_as),

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -610,7 +610,7 @@ class VarWriter5(object):
             self.write_object(narr)
         elif isinstance(narr, MatlabFunction):
             raise MatWriteError('Cannot write matlab functions')
-        elif narr is EmptyStructMarker: # empty struct array
+        elif narr is EmptyStructMarker:  # empty struct array
             self.write_empty_struct()
         elif narr.dtype.fields:  # struct array
             self.write_struct(narr)

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -706,14 +706,14 @@ def assert_any_equal(output, alternatives):
     one_equal = False
     for expected in alternatives:
         if np.all(output == expected):
-             one_equal = True
-             break
+            one_equal = True
+            break
     assert_(one_equal)
 
 
 def test_to_writeable():
     # Test to_writeable function
-    res = to_writeable(np.array([1])) # pass through ndarrays
+    res = to_writeable(np.array([1]))  # pass through ndarrays
     assert_equal(res.shape, (1,))
     assert_array_equal(res, 1)
     # Dict fields can be written in any order
@@ -728,7 +728,10 @@ def test_to_writeable():
     # String fields that are valid Python identifiers discarded
     assert_any_equal(to_writeable({'a':1,'b':2, '99':3}), alternatives)
     # Object with field names is equivalent
-    class klass(object): pass
+
+    class klass(object):
+        pass
+
     c = klass
     c.a = 1
     c.b = 2
@@ -754,7 +757,10 @@ def test_to_writeable():
     # Object does not have (even empty) __dict__
     assert_(to_writeable(object()) is None)
     # Custom object does have empty __dict__, returns EmptyStructMarker
-    class C(object): pass
+
+    class C(object):
+        pass
+
     assert_(to_writeable(c()) is EmptyStructMarker)
     # dict keys with legal characters are convertible
     res = to_writeable({'a': 1})['a']

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -35,8 +35,6 @@ from scipy.io.matlab.mio5 import (MatlabObject, MatFile5Writer, MatFile5Reader,
                                   to_writeable, EmptyStructMarker)
 from scipy.io.matlab import mio5_params as mio5p
 
-from nose.tools import assert_true
-
 test_data_path = pjoin(dirname(__file__), 'data')
 
 
@@ -729,7 +727,7 @@ def test_to_writeable():
     assert_equal(res.shape, (0,))
     assert_equal(res.dtype.type, np.float64)
     # None -> None
-    assert_true(to_writeable(None) is None)
+    assert_(to_writeable(None) is None)
     # String to strings
     assert_equal(to_writeable('a string').dtype.type, np.str_)
     # Scalars to numpy to numpy scalars
@@ -738,19 +736,19 @@ def test_to_writeable():
     assert_equal(res.dtype.type, np.array(1).dtype.type)
     assert_array_equal(res, 1)
     # Empty dict returns EmptyStructMarker
-    assert_true(to_writeable({}) is EmptyStructMarker)
+    assert_(to_writeable({}) is EmptyStructMarker)
     # Object does not have (even empty) __dict__
-    assert_true(to_writeable(object()) is None)
+    assert_(to_writeable(object()) is None)
     # Custom object does have empty __dict__, returns EmptyStructMarker
     class C(object): pass
-    assert_true(to_writeable(c()) is EmptyStructMarker)
+    assert_(to_writeable(c()) is EmptyStructMarker)
     # dict keys with legal characters are convertible
     res = to_writeable({'a': 1})['a']
     assert_equal(res.shape, (1,))
     assert_equal(res.dtype.type, np.object_)
     # Only fields with illegal characters, falls back to EmptyStruct
-    assert_true(to_writeable({'1':1}) is EmptyStructMarker)
-    assert_true(to_writeable({'_a':1}) is EmptyStructMarker)
+    assert_(to_writeable({'1':1}) is EmptyStructMarker)
+    assert_(to_writeable({'_a':1}) is EmptyStructMarker)
     # Unless there are valid fields, in which case structured array
     assert_equal(to_writeable({'1':1, 'f': 2}),
                  np.array([(2,)], dtype=[('f', '|O8')]))

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -700,25 +700,39 @@ def test_save_empty_dict():
     assert_(a[0,0] is None)
 
 
+def assert_any_equal(output, alternatives):
+    """ Assert `output` is equal to at least one element in `alternatives`
+    """
+    one_equal = False
+    for expected in alternatives:
+        if np.all(output == expected):
+             one_equal = True
+             break
+    assert_(one_equal)
+
+
 def test_to_writeable():
     # Test to_writeable function
     res = to_writeable(np.array([1])) # pass through ndarrays
     assert_equal(res.shape, (1,))
     assert_array_equal(res, 1)
-    expected = np.array([(1, 2)], dtype=[('a', '|O8'), ('b', '|O8')])
-    assert_array_equal(to_writeable({'a':1,'b':2}), expected)
+    # Dict fields can be written in any order
+    expected1 = np.array([(1, 2)], dtype=[('a', '|O8'), ('b', '|O8')])
+    expected2 = np.array([(2, 1)], dtype=[('b', '|O8'), ('a', '|O8')])
+    alternatives = (expected1, expected2)
+    assert_any_equal(to_writeable({'a':1,'b':2}), alternatives)
     # Fields with underscores discarded
-    assert_array_equal(to_writeable({'a':1,'b':2, '_c':3}), expected)
+    assert_any_equal(to_writeable({'a':1,'b':2, '_c':3}), alternatives)
     # Not-string fields discarded
-    assert_array_equal(to_writeable({'a':1,'b':2, 100:3}), expected)
+    assert_any_equal(to_writeable({'a':1,'b':2, 100:3}), alternatives)
     # String fields that are valid Python identifiers discarded
-    assert_array_equal(to_writeable({'a':1,'b':2, '99':3}), expected)
+    assert_any_equal(to_writeable({'a':1,'b':2, '99':3}), alternatives)
     # Object with field names is equivalent
     class klass(object): pass
     c = klass
     c.a = 1
     c.b = 2
-    assert_array_equal(to_writeable(c), expected)
+    assert_any_equal(to_writeable(c), alternatives)
     # empty list and tuple go to empty array
     res = to_writeable([])
     assert_equal(res.shape, (0,))


### PR DESCRIPTION
Previously passing an empty dict as a value for a matlab array would
raise an error, whereas a dict with valid fields would not.  Allow empty
dicts (and dicts with only invalid fields) by saving them as empty
matlab stucts.

This changes the API somewhat because previously dicts or objects with
no or only invalid fields would raise an error.

Fixes gh-3798
