### PR TITLE
ENH: Solve toeplitz linear systems 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ scipy/linalg/_fblasmodule.c
 scipy/linalg/_flapack-f2pywrappers.f
 scipy/linalg/_flapackmodule.c
 scipy/linalg/_interpolativemodule.c
+scipy/linalg/_solve_toeplitz.c
 scipy/linalg/cblas.pyf
 scipy/linalg/clapack.pyf
 scipy/linalg/fblas.pyf

--- a/THANKS.txt
+++ b/THANKS.txt
@@ -138,6 +138,8 @@ Alex Rothberg for stats.combine_pvalues.
 Brandon Liu for stats.combine_pvalues.
 Clark Fitzgerald for namedtuple outputs in scipy.stats.
 Florian Wilhelm for usage of RandomState in scipy.stats distributions.
+Robert T. McGibbon for Levinson-Durbin Toeplitz solver.
+
 
 Institutions
 ------------

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -26,6 +26,7 @@ Basics
    solve_banded - Solve a banded linear system
    solveh_banded - Solve a Hermitian or symmetric banded system
    solve_triangular - Solve a triangular matrix
+   solve_toeplitz - Solve a toeplitz matrix
    det - Find the determinant of a square matrix
    norm - Matrix and vector norm
    lstsq - Solve a linear least-squares problem

--- a/scipy/linalg/_solve_toeplitz.pyx
+++ b/scipy/linalg/_solve_toeplitz.pyx
@@ -1,0 +1,126 @@
+# Author: Robert T. McGibbon, December 2014
+#
+# cython: boundscheck=False, wraparound=False, cdivision=True
+from numpy import zeros, asarray, complex128, float64
+from numpy.linalg import LinAlgError
+from numpy cimport npy_intp, complex128_t, float64_t
+
+
+cdef fused dz:
+    float64_t
+    complex128_t
+
+
+def levinson(dz[::1] a, dz[::1] b):
+    """Solve a linear Toeplitz system using Levinson recursion.
+
+    Parameters
+    ----------
+    a : array, dtype=double or complex128, shape=(2n-1,)
+        The first column of the matrix in reverse order (without the diagonal)
+        followed by the first (see below)
+    b : array, dtype=double  or complex128, shape=(n,)
+        The right hand side vector. Both a and b must have the same type
+        (double or complex128).
+
+    Notes
+    -----
+    For example, the 5x5 toeplitz matrix below should be represented as
+    the linear array ``a`` on the right ::
+
+        [ a0    a1   a2  a3  a4 ]
+        [ a-1   a0   a1  a2  a3 ]
+        [ a-2  a-1   a0  a1  a2 ] -> [a-4  a-3  a-2  a-1  a0  a1  a2  a3  a4]
+        [ a-3  a-2  a-1  a0  a1 ]
+        [ a-4  a-3  a-2  a-1 a0 ]
+
+    Returns
+    -------
+    x : arrray, shape=(n,)
+        The solution vector
+    reflection_coeff : array, shape=(n+1,)
+        Toeplitz reflection coefficients. When a is symmetric Toeplitz and
+        ``b`` is ``a[n:]``, as in the solution of autoregressive systems,
+        then ``reflection_coeff`` also correspond to the partial
+        autocorrelation function.
+    """
+    # Adapted from toeplitz.f90 by Alan Miller, accessed at
+    # http://jblevins.org/mirror/amiller/toeplitz.f90
+    # Released under a Public domain declaration.
+
+    if dz is float64_t:
+        dtype = float64
+    else:
+        dtype = complex128
+
+    cdef npy_intp n, m, j, nmj, k, m2
+    n = b.shape[0]
+    cdef dz x_num, g_num, h_num, x_den, g_den
+    cdef dz gj, gk, hj, hk, c1, c2
+    cdef dz[:] x = zeros(n, dtype=dtype)  # result
+    cdef dz[:] g = zeros(n, dtype=dtype)  # workspace
+    cdef dz[:] h = zeros(n, dtype=dtype)  # workspace
+    cdef dz[:] reflection_coeff = zeros(n+1, dtype=dtype)  # history
+    assert len(a) == (2*n) - 1
+
+    if a[n-1] == 0:
+        raise LinAlgError('Singular principal minor')
+
+    x[0] = b[0] / a[n-1]
+    reflection_coeff[0] = 1
+    reflection_coeff[1] = x[0]
+
+    if (n == 1):
+        return asarray(x), asarray(reflection_coeff)
+
+    g[0] = a[n-2] / a[n-1]
+    h[0] = a[n] / a[n-1]
+
+    for m in range(1, n):
+        # Compute numerator and denominator of x[m]
+        x_num = -b[m]
+        x_den = -a[n-1]
+        for j in range(m):
+            nmj = n + m - (j+1)
+            x_num = x_num + a[nmj] * x[j]
+            x_den = x_den + a[nmj] * g[m-j-1]
+        if x_den == 0:
+            raise LinAlgError('Singular principal minor')
+        x[m] = x_num / x_den
+        reflection_coeff[m+1] = x[m]
+
+        # Compute x
+        for j in range(m):
+            x[j] = x[j] - x[m] * g[m-j-1]
+        if m == n-1:
+            return asarray(x), asarray(reflection_coeff)
+
+        # Compute the numerator and denominator of g[m] and h[m]
+        g_num = -a[n-m-2]
+        h_num = -a[n+m]
+        g_den = -a[n-1]
+        for j in range(m):
+            g_num = g_num + a[n+j-m-1] * g[j]
+            h_num = h_num + a[n+m-j-1] * h[j]
+            g_den = g_den + a[n+j-m-1] * h[m-j-1]
+
+        if g_den == 0.0:
+            raise LinAlgError("Singular principal minor")
+
+        # Compute g and h
+        g[m] = g_num / g_den
+        h[m] = h_num / x_den
+        k = m - 1
+        m2 = (m + 1) >> 1
+        c1 = g[m]
+        c2 = h[m]
+        for j in range(m2):
+            gj = g[j]
+            gk = g[k]
+            hj = h[j]
+            hk = h[k]
+            g[j] = gj - (c1 * hk)
+            g[k] = gk - (c1 * hj)
+            h[j] = hj - (c2 * gk)
+            h[k] = hk - (c2 * gj)
+            k -= 1

--- a/scipy/linalg/benchmarks/bench_solve_toeplitz.py
+++ b/scipy/linalg/benchmarks/bench_solve_toeplitz.py
@@ -1,0 +1,51 @@
+"""Benchmark the solve_toeplitz solver (Levinson recursion)
+"""
+from __future__ import division, print_function, absolute_import
+
+import time
+
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+import scipy.linalg
+
+
+def bench_solve_toeplitz():
+    random = np.random.RandomState(1234)
+    print()
+    print('                    solve_toeplitz vs. generic solver')
+    print('==============================================================')
+    print('      shape      |  solver     |        dtype       |   time   ')
+    print('                 |             |                    | (seconds)')
+    print('--------------------------------------------------------------')
+    fmt = ' %15s |   %s  | %18s | %6.2f '
+    for n in (100, 300, 1000):
+        for dtype in (np.float64, np.complex128):
+
+            # Sample a random Toeplitz matrix representation and rhs.
+            c = random.randn(n)
+            r = random.randn(n)
+            y = random.randn(n)
+            if dtype == np.complex128:
+                c = c + 1j*random.rand(n)
+                r = r + 1j*random.rand(n)
+                y = y + 1j*random.rand(n)
+
+            # generic solver
+            tm = time.clock()
+            T = scipy.linalg.toeplitz(c, r=r)
+            x_generic = scipy.linalg.solve(T, y)
+            nseconds = time.clock() - tm
+            print(fmt % (T.shape, 'generic ', T.dtype, nseconds))
+
+            # toeplitz-specific solver
+            tm = time.clock()
+            x_toeplitz = scipy.linalg.solve_toeplitz(c, r=r, b=y)
+            nseconds = time.clock() - tm
+            print(fmt % (T.shape, 'toeplitz', T.dtype, nseconds))
+
+            # Check that the solutions are the sameself.
+            assert_array_almost_equal(x_generic, x_toeplitz)
+
+
+if __name__ == '__main__':
+    bench_solve_toeplitz()

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -7,7 +7,7 @@ from os.path import join
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.system_info import get_info, NotFoundError
-    from numpy.distutils.misc_util import Configuration
+    from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
     from scipy._build_utils import get_sgemv_fix, get_g77_abi_wrappers, split_fortran_files
 
     config = Configuration('linalg',parent_package,top_path)
@@ -122,9 +122,15 @@ def configuration(parent_package='',top_path=None):
                          [join('src', 'calc_lwork.f')],
                          extra_info=lapack_opt)
 
+    # _solve_toeplitz:
+    config.add_extension('_solve_toeplitz',
+                         sources=[('_solve_toeplitz.c')],
+                         include_dirs=[get_numpy_include_dirs()])
+
     config.add_data_dir('tests')
     config.add_data_dir('benchmarks')
     return config
+
 
 if __name__ == '__main__':
     from numpy.distutils.core import setup

--- a/scipy/linalg/tests/test_solve_toeplitz.py
+++ b/scipy/linalg/tests/test_solve_toeplitz.py
@@ -1,0 +1,115 @@
+"""Test functions for linalg._solve_toeplitz module
+"""
+from __future__ import division, print_function, absolute_import
+import numpy as np
+from scipy.linalg._solve_toeplitz import levinson
+from scipy.linalg import solve, toeplitz, solve_toeplitz
+from numpy.testing import (run_module_suite, assert_equal, assert_allclose,
+                           assert_raises)
+from numpy.testing.decorators import knownfailureif
+
+
+def test_solve_equivalence():
+    # For toeplitz matrices, solve_toeplitz() should be equivalent to solve().
+    random = np.random.RandomState(1234)
+    for n in (1, 2, 3, 10):
+        c = random.randn(n)
+        if random.rand() < 0.5:
+            c = c + 1j * random.randn(n)
+        r = random.randn(n)
+        if random.rand() < 0.5:
+            r = r + 1j * random.randn(n)
+        y = random.randn(n)
+        if random.rand() < 0.5:
+            y = y + 1j * random.randn(n)
+
+        # Check equivalence when both the column and row are provided.
+        actual = solve_toeplitz((c,r), y)
+        desired = solve(toeplitz(c, r=r), y)
+        assert_allclose(actual, desired)
+
+        # Check equivalence when the column is provided but not the row.
+        actual = solve_toeplitz(c, b=y)
+        desired = solve(toeplitz(c), y)
+        assert_allclose(actual, desired)
+
+
+def test_multiple_rhs():
+    random = np.random.RandomState(1234)
+    c = random.randn(4)
+    r = random.randn(4)
+    for offset in [0, 1j]:
+        for yshape in ((4,), (4, 3), (4, 3, 2)):
+            y = random.randn(*yshape) + offset
+            actual = solve_toeplitz((c,r), b=y)
+            desired = solve(toeplitz(c, r=r), y)
+            assert_equal(actual.shape, yshape)
+            assert_equal(desired.shape, yshape)
+            assert_allclose(actual, desired)
+
+
+def test_zero_diag_error():
+    # The Levinson-Durbin implementation fails when the diagonal is zero.
+    random = np.random.RandomState(1234)
+    n = 4
+    c = random.randn(n)
+    r = random.randn(n)
+    y = random.randn(n)
+    c[0] = 0
+    assert_raises(np.linalg.LinAlgError,
+        solve_toeplitz, (c, r), b=y)
+
+
+def test_wikipedia_counterexample():
+    # The Levinson-Durbin implementation also fails in other cases.
+    # This example is from the talk page of the wikipedia article.
+    random = np.random.RandomState(1234)
+    c = [2, 2, 1]
+    y = random.randn(3)
+    assert_raises(np.linalg.LinAlgError, solve_toeplitz, c, b=y)
+
+
+def test_reflection_coeffs():
+    # check that that the partial solutions are given by the reflection
+    # coefficients
+
+    random = np.random.RandomState(1234)
+    y_d = random.randn(10)
+    y_z = random.randn(10) + 1j
+    reflection_coeffs_d = [1]
+    reflection_coeffs_z = [1]
+    for i in range(2, 10):
+        reflection_coeffs_d.append(solve_toeplitz(y_d[:(i-1)], b=y_d[1:i])[-1])
+        reflection_coeffs_z.append(solve_toeplitz(y_z[:(i-1)], b=y_z[1:i])[-1])
+
+    y_d_concat = np.concatenate((y_d[-2:0:-1], y_d[:-1]))
+    y_z_concat = np.concatenate((y_z[-2:0:-1].conj(), y_z[:-1]))
+    _, ref_d = levinson(y_d_concat, b=y_d[1:])
+    _, ref_z = levinson(y_z_concat, b=y_z[1:])
+
+    assert_allclose(reflection_coeffs_d, ref_d[:-1])
+    assert_allclose(reflection_coeffs_z, ref_z[:-1])
+
+
+@knownfailureif(True, 'Instability of Levinson iteraton')
+def test_unstable():
+    # this is a "Gaussian Toeplitz matrix", as mentioned in Example 2 of
+    # I. Gohbert, T. Kailath and V. Olshevsky "Fast Gaussian Elimination with
+    # Partial Pivoting for Matrices with Displacement Structure"
+    # Mathematics of Computation, 64, 212 (1995), pp 1557-1576
+    # which can be unstable for levinson recursion.
+
+    # other fast toeplitz solvers such as GKO or Burg should be better.
+    random = np.random.RandomState(1234)
+    n = 100
+    c = 0.9 ** (np.arange(n)**2)
+    y = random.randn(n)
+
+    solution1 = solve_toeplitz(c, b=y)
+    solution2 = solve(toeplitz(c), y)
+
+    assert_allclose(solution1, solution2)
+
+
+if __name__ == '__main__':
+    run_module_suite()


### PR DESCRIPTION
This PR implements Levinson recursion to solve toeplitz linear systems. Much of code is based on @argriffing's PR earlier PR #2754, but I used cython, and the performance is substantially improved. This is also related to #2432. The underlying cython code returns all the workspace variables, which I think is something that @josef-pkt mentioned are of interest for some timeseries applications.

```
$ python scipy/linalg/benchmarks/bench_solve_toeplitz.py

                    solve_toeplitz vs. generic solver
==============================================================
      shape      |  solver     |        dtype       |   time
                 |             |                    | (seconds)
--------------------------------------------------------------
      (100, 100) |   generic   |            float64 |   0.04
      (100, 100) |   toeplitz  |            float64 |   0.00
      (100, 100) |   generic   |         complex128 |   0.00
      (100, 100) |   toeplitz  |         complex128 |   0.00
      (300, 300) |   generic   |            float64 |   0.00
      (300, 300) |   toeplitz  |            float64 |   0.00
      (300, 300) |   generic   |         complex128 |   0.01
      (300, 300) |   toeplitz  |         complex128 |   0.00
    (1000, 1000) |   generic   |            float64 |   0.10
    (1000, 1000) |   toeplitz  |            float64 |   0.00
    (1000, 1000) |   generic   |         complex128 |   0.34
    (1000, 1000) |   toeplitz  |         complex128 |   0.01
```
Closes #2432 
