### PR TITLE
Add benchmark for conjugate gradient solver.

### DIFF
--- a/scipy/sparse/linalg/isolve/__init__.py
+++ b/scipy/sparse/linalg/isolve/__init__.py
@@ -9,7 +9,7 @@ from .lgmres import lgmres
 from .lsqr import lsqr
 from .lsmr import lsmr
 
-__all__ = [s for s in dir() if not s.startswith('_')]
+#__all__ = [s for s in dir() if not s.startswith('_')]
 from numpy.testing import Tester
 test = Tester().test
 bench = Tester().bench

--- a/scipy/sparse/linalg/isolve/__init__.py
+++ b/scipy/sparse/linalg/isolve/__init__.py
@@ -9,7 +9,7 @@ from .lgmres import lgmres
 from .lsqr import lsqr
 from .lsmr import lsmr
 
-#__all__ = [s for s in dir() if not s.startswith('_')]
+__all__ = [s for s in dir() if not s.startswith('_')]
 from numpy.testing import Tester
 test = Tester().test
 bench = Tester().bench

--- a/scipy/sparse/linalg/isolve/benchmarks/bench_cg.py
+++ b/scipy/sparse/linalg/isolve/benchmarks/bench_cg.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function, absolute_import
 import time
 
 import numpy as np
-from numpy.testing import Tester, TestCase
+from numpy.testing import Tester, TestCase, assert_allclose, assert_equal
 
 import scipy.linalg
 import scipy.sparse
@@ -18,8 +18,8 @@ def _create_sparse_poisson1d(n):
     return P1d
 
 def _create_sparse_poisson2d(n):
-    P1d = create_sparse_poisson1d(n)
-    P2d = scipy.sparse.kronsum(P, P)
+    P1d = _create_sparse_poisson1d(n)
+    P2d = scipy.sparse.kronsum(P1d, P1d)
     assert_equal(P2d.shape, (n*n, n*n))
     return P2d
 
@@ -27,47 +27,55 @@ class BenchmarkConjuateGradientSolver(TestCase):
 
     def bench_cg(self):
 
-        # plain solve vs sparse cg vs dense cg
-        # solver (dense generic vs cg)
-        # shape
-        # time
-
         # print headers and define the column formats
         print()
         print('         generic solve vs. conjugate gradient solve')
         print('==============================================================')
-        print('      shape      | repeats |      operation     |   time   ')
-        print('                                                | (seconds)')
+        print('       shape       | repeats |      operation     |   time   ')
+        print('                                                  | (seconds)')
         print('--------------------------------------------------------------')
-        fmt = ' %15s |   %3d   | %18s | %6.2f '
+        fmt = ' %17s |   %3d   | %18s | %6.2f '
 
-        np.random.seed(1234)
-        for n in 2, 10, 30:
-
-            P_sparse = _create_sparse_poisson2d(n)
-            P_dense = P2d.A
+        dense_is_active = True
+        sparse_is_active = True
+        repeats = 100
+        for n in 4, 6, 10, 16, 25, 40, 64, 100, 160, 250, 400, 640, 1000, 1600:
+            if not dense_is_active and not sparse_is_active:
+                break
             b = np.ones(n*n)
+            P_sparse = _create_sparse_poisson2d(n)
 
-            # Use the generic dense solver.
-            tm_start = time.clock()
-            x_dense = scipy.linalg.solve(P_dense, b)
-            tm_end = time.clock()
-            tm_dense = tm_end - tm_start
+            # Optionally use the generic dense solver.
+            if dense_is_active:
+                P_dense = P_sparse.A
+                tm_start = time.clock()
+                for i in range(repeats):
+                    x_dense = scipy.linalg.solve(P_dense, b)
+                tm_end = time.clock()
+                tm_dense = tm_end - tm_start
 
-            # Use the conjugate gradient solver with the sparse matrix.
-            tm_start = time.clock()
-            x_sparse = scipy.sparse.linalg.cg(P_sparse, b)
-            tm_end = time.clock()
-            tm_sparse = tm_end - tm_start
+            # Optionally use the sparse conjugate gradient solver.
+            if sparse_is_active:
+                tm_start = time.clock()
+                for i in range(repeats):
+                    x_sparse, info = scipy.sparse.linalg.cg(P_sparse, b)
+                tm_end = time.clock()
+                tm_sparse = tm_end - tm_start
 
             # Check that the solutions are close to each other.
-            assert_allclose(x_dense, x_sparse)
+            if dense_is_active and sparse_is_active:
+                assert_allclose(x_dense, x_sparse, rtol=1e-4)
 
             # Write the rows.
-            nrepeats = 1
             shape = (n*n, n*n)
-            print(fmt % (shape, nrepeats, 'dense solve', tm_dense))
-            print(fmt % (shape, nrepeats, 'sparse cg', tm_sparse))
+            if dense_is_active:
+                print(fmt % (shape, repeats, 'dense solve', tm_dense))
+            if sparse_is_active:
+                print(fmt % (shape, repeats, 'sparse cg', tm_sparse))
+
+            dense_is_active = (tm_dense < 5)
+            sparse_is_active = (tm_sparse < 5)
+
         print()
 
 

--- a/scipy/sparse/linalg/isolve/benchmarks/bench_cg.py
+++ b/scipy/sparse/linalg/isolve/benchmarks/bench_cg.py
@@ -1,0 +1,75 @@
+"""Check the speed of the conjugate gradient solver.
+"""
+from __future__ import division, print_function, absolute_import
+
+import time
+
+import numpy as np
+from numpy.testing import Tester, TestCase
+
+import scipy.linalg
+import scipy.sparse
+
+def _create_sparse_poisson1d(n):
+    # Make Gilbert Strang's favorite matrix
+    # http://www-math.mit.edu/~gs/PIX/cupcakematrix.jpg
+    P1d = scipy.sparse.diags([[-1]*(n-1), [2]*n, [-1]*(n-1)], [-1, 0, 1])
+    assert_equal(P1d.shape, (n, n))
+    return P1d
+
+def _create_sparse_poisson2d(n):
+    P1d = create_sparse_poisson1d(n)
+    P2d = scipy.sparse.kronsum(P, P)
+    assert_equal(P2d.shape, (n*n, n*n))
+    return P2d
+
+class BenchmarkConjuateGradientSolver(TestCase):
+
+    def bench_cg(self):
+
+        # plain solve vs sparse cg vs dense cg
+        # solver (dense generic vs cg)
+        # shape
+        # time
+
+        # print headers and define the column formats
+        print()
+        print('         generic solve vs. conjugate gradient solve')
+        print('==============================================================')
+        print('      shape      | repeats |      operation     |   time   ')
+        print('                                                | (seconds)')
+        print('--------------------------------------------------------------')
+        fmt = ' %15s |   %3d   | %18s | %6.2f '
+
+        np.random.seed(1234)
+        for n in 2, 10, 30:
+
+            P_sparse = _create_sparse_poisson2d(n)
+            P_dense = P2d.A
+            b = np.ones(n*n)
+
+            # Use the generic dense solver.
+            tm_start = time.clock()
+            x_dense = scipy.linalg.solve(P_dense, b)
+            tm_end = time.clock()
+            tm_dense = tm_end - tm_start
+
+            # Use the conjugate gradient solver with the sparse matrix.
+            tm_start = time.clock()
+            x_sparse = scipy.sparse.linalg.cg(P_sparse, b)
+            tm_end = time.clock()
+            tm_sparse = tm_end - tm_start
+
+            # Check that the solutions are close to each other.
+            assert_allclose(x_dense, x_sparse)
+
+            # Write the rows.
+            nrepeats = 1
+            shape = (n*n, n*n)
+            print(fmt % (shape, nrepeats, 'dense solve', tm_dense))
+            print(fmt % (shape, nrepeats, 'sparse cg', tm_sparse))
+        print()
+
+
+if __name__ == '__main__':
+    Tester().bench()

--- a/scipy/sparse/linalg/isolve/setup.py
+++ b/scipy/sparse/linalg/isolve/setup.py
@@ -38,6 +38,7 @@ def configuration(parent_package='',top_path=None):
                          extra_info=lapack_opt)
 
     config.add_data_dir('tests')
+    config.add_data_dir('benchmarks')
 
     return config
 


### PR DESCRIPTION
This benchmark should partially address https://github.com/scipy/scipy/pull/4087#issuecomment-65954520.  In particular, if you make a change to the abstract linear operator infrastructure which causes a huge slowdown, this should be detectable by running this benchmark before and after the change.

```
         generic solve vs. conjugate gradient solve
==============================================================
       shape       | repeats |      operation     |   time   
                                                  | (seconds)
--------------------------------------------------------------
          (16, 16) |   100   |        dense solve |   0.03 
          (16, 16) |   100   |          sparse cg |   0.06 
          (36, 36) |   100   |        dense solve |   0.09 
          (36, 36) |   100   |          sparse cg |   0.09 
        (100, 100) |   100   |        dense solve |   0.32 
        (100, 100) |   100   |          sparse cg |   0.24 
        (256, 256) |   100   |        dense solve |   1.26 
        (256, 256) |   100   |          sparse cg |   0.44 
        (625, 625) |   100   |        dense solve |   5.25 
        (625, 625) |   100   |          sparse cg |   0.55 
      (1600, 1600) |   100   |          sparse cg |   0.32 
      (4096, 4096) |   100   |          sparse cg |   0.82 
    (10000, 10000) |   100   |          sparse cg |   2.49 
    (25600, 25600) |   100   |          sparse cg |  65.20 
```
