### PR TITLE
BUG: make stats.geom.logpmf(1,1) return 0.0 instead of nan

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -214,7 +214,6 @@ class geom_gen(rv_discrete):
         return np.power(1-p, k-1) * p
 
     def _logpmf(self, k, p):
-        
         return special.xlog1py(k - 1, -p) + log(p)
 
     def _cdf(self, x, p):

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -214,7 +214,7 @@ class geom_gen(rv_discrete):
         return np.power(1-p, k-1) * p
 
     def _logpmf(self, k, p):
-    	
+        
         return special.xlog1py(k - 1, -p) + log(p)
 
     def _cdf(self, x, p):

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -214,7 +214,8 @@ class geom_gen(rv_discrete):
         return np.power(1-p, k-1) * p
 
     def _logpmf(self, k, p):
-        return (k-1) * log(1-p) + log(p)
+    	
+        return special.xlog1py(k - 1, -p) + log(p)
 
     def _cdf(self, x, p):
         k = floor(x)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -265,6 +265,10 @@ class TestGeom(TestCase):
         vals2 = stats.geom.logpmf([1,2,3], 0.5)
         assert_allclose(vals1, vals2, rtol=1e-15, atol=0)
 
+        # BUG:4028 regression test
+        val = stats.geom.logpmf(1,1)
+        assert_equal(val,0.0)
+
     def test_cdf_sf(self):
         vals = stats.geom.cdf([1, 2, 3], 0.5)
         vals_sf = stats.geom.sf([1, 2, 3], 0.5)


### PR DESCRIPTION
BUG: 4028 fix. scipy.stats.geom.logpmf(1,1) returns 0.0.
