### PR TITLE
MAINT: stats: rename check_random_state test function

### DIFF
--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -153,7 +153,7 @@ def check_named_args(distfn, x, shape_args, defaults, meths):
     npt.assert_raises(TypeError, distfn.cdf, x, **k)
 
 
-def check_random_state(distfn, args):
+def check_random_state_property(distfn, args):
     # check the random_state attribute of a distribution *instance*
 
     # This test fiddles with distfn.random_state. This breaks other tests,

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -10,7 +10,7 @@ from scipy import stats
 from common_tests import (check_normalization, check_moment, check_mean_expect,
         check_var_expect, check_skew_expect, check_kurt_expect,
         check_entropy, check_private_entropy, NUMPY_BELOW_1_7,
-        check_edge_support, check_named_args, check_random_state)
+        check_edge_support, check_named_args, check_random_state_property)
 
 from scipy.stats._distr_params import distcont
 
@@ -125,7 +125,7 @@ def test_cont_basic():
                       'pareto': 1.5, 'tukeylambda': 0.3}
             x = spec_x.get(distname, 0.5)
             yield check_named_args, distfn, x, arg, locscale_defaults, meths
-            yield check_random_state, distfn, arg
+            yield check_random_state_property, distfn, arg
 
             # Entropy
             skp = npt.dec.skipif
@@ -183,7 +183,7 @@ def test_cont_basic_slow():
             elif distname == 'ksone':
                 arg = (3,)
             yield check_named_args, distfn, x, arg, locscale_defaults, meths
-            yield check_random_state, distfn, arg
+            yield check_random_state_property, distfn, arg
 
             # Entropy
             skp = npt.dec.skipif

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -8,7 +8,7 @@ from scipy import stats
 from common_tests import (check_normalization, check_moment, check_mean_expect,
         check_var_expect, check_skew_expect, check_kurt_expect,
         check_entropy, check_private_entropy, check_edge_support,
-        check_named_args, check_random_state)
+        check_named_args, check_random_state_property)
 from scipy.stats._distr_params import distdiscrete
 knf = npt.dec.knownfailureif
 
@@ -44,7 +44,7 @@ def test_discrete_basic():
         k = spec_k.get(distname, 1)
         yield check_named_args, distfn, k, arg, locscale_defaults, meths
         yield check_scale_docstring, distfn
-        yield check_random_state, distfn, arg
+        yield check_random_state_property, distfn, arg
 
         # Entropy
         yield check_entropy, distfn, arg, distname


### PR DESCRIPTION
This is to address https://github.com/scipy/scipy/pull/4129#issuecomment-68225885

(I added two private functions with the same name without much thinking; this PR renames one of them so that there is no confusion)
