### PR TITLE
BLD: change .travis.yml to run only Python3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,36 +3,10 @@
 language: python
 matrix:
   include:
-    - python: 3.4
+    - python: 3.2
       env:
         - TESTMODE=fast
         - COVERAGE=
-        - NUMPYSPEC=numpy
-    - python: 3.3
-      env:
-        - TESTMODE=fast
-        - COVERAGE=
-        - NUMPYSPEC=numpy
-    - python: 2.7
-      env:
-        - TESTMODE=full
-        - COVERAGE=--coverage
-        - NUMPYSPEC=numpy        
-    - python: 2.6
-      env:
-        - TESTMODE=fast
-        - OPTIMIZE=-OO
-        - NUMPYSPEC="numpy==1.6.2"
-    - python: 2.7
-      env:
-        - TESTMODE=fast
-        - COVERAGE=
-        - NPY_RELAXED_STRIDES_CHECKING=1
-        - NUMPYSPEC="git+git://github.com/numpy/numpy.git@v1.9.1"
-    - python: 2.7
-      env:
-        - PYFLAKES=1
-        - PEP8=1
         - NUMPYSPEC=numpy
       before_install:
         - pip install pep8==1.5.1


### PR DESCRIPTION
This is related to TravisCI, please do not merge this.  I expect Python3.2 to find a syntax error in one of the stats tests.
