### PR TITLE
BUG: fix usage of unicode literals that breaks Python 3.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ matrix:
         - TESTMODE=fast
         - COVERAGE=
         - NUMPYSPEC=numpy
+    - python: 3.2
+      env:
+        - TESTMODE=fast
+        - COVERAGE=
+        - NUMPYSPEC=numpy
     - python: 2.7
       env:
         - TESTMODE=full

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -38,7 +38,7 @@ import numpy as np
 from numpy.testing import (TestCase, run_module_suite, dec, assert_raises,
                            assert_allclose, assert_equal, assert_)
 
-from scipy.lib.six import xrange
+from scipy.lib.six import xrange, u
 
 import scipy.cluster.hierarchy
 from scipy.cluster.hierarchy import (
@@ -72,7 +72,7 @@ class TestLinkage(object):
         assert_raises(ValueError, linkage, y)
 
     def test_linkage_tdist(self):
-        for method in ['single', 'complete', 'average', 'weighted', u'single']:
+        for method in ['single', 'complete', 'average', 'weighted', u('single')]:
             yield self.check_linkage_tdist, method
 
     def check_linkage_tdist(self, method):

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -36,7 +36,7 @@
 from __future__ import division, print_function, absolute_import
 
 import os.path
-from scipy.lib.six import xrange
+from scipy.lib.six import xrange, u
 
 from nose.tools import assert_true
 
@@ -45,8 +45,6 @@ from numpy.linalg import norm
 from numpy.testing import (verbose, TestCase, run_module_suite,
         assert_raises, assert_array_equal, assert_equal, assert_almost_equal,
         assert_allclose)
-
-from scipy.lib.six import u
 
 from scipy.spatial.distance import (squareform, pdist, cdist, matching,
         jaccard, dice, sokalsneath, rogerstanimoto, russellrao, yule,

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -2,8 +2,10 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal, run_module_suite
-from scipy.stats import \
-    binned_statistic, binned_statistic_2d, binned_statistic_dd
+from scipy.stats import (binned_statistic, binned_statistic_2d,
+                         binned_statistic_dd)
+
+from scipy.lib.six import u
 
 
 class TestBinnedStatistic(object):
@@ -134,7 +136,7 @@ class TestBinnedStatistic(object):
         x = self.x
         y = self.y
         v = self.v
-        stat1, binx1, biny1, bc = binned_statistic_2d(x, y, v, u'mean', bins=5)
+        stat1, binx1, biny1, bc = binned_statistic_2d(x, y, v, u('mean'), bins=5)
         stat2, binx2, biny2, bc = binned_statistic_2d(x, y, v, np.mean, bins=5)
         assert_array_almost_equal(stat1, stat2)
         assert_array_almost_equal(binx1, binx2)


### PR DESCRIPTION
Also enable Python 3.2 tests on TravisCI.
