### PR TITLE
TST: more conversions from nose to numpy.testing

### DIFF
--- a/scipy/io/matlab/tests/test_mio_funcs.py
+++ b/scipy/io/matlab/tests/test_mio_funcs.py
@@ -5,26 +5,17 @@ of mat file.
 '''
 from __future__ import division, print_function, absolute_import
 
-from os.path import join as pjoin, dirname
+import os.path
 import sys
+import io
 
-from io import BytesIO
-
-from numpy.testing import \
-     assert_array_equal, \
-     assert_array_almost_equal, \
-     assert_equal, \
-     assert_raises, run_module_suite
-
-from nose.tools import assert_true
-
-import numpy as np
+from numpy.testing import run_module_suite
 from numpy.compat import asstr
 
-from scipy.io.matlab.mio5 import MatlabObject, MatFile5Writer, \
-      MatFile5Reader, MatlabFunction
+from scipy.io.matlab.mio5 import (MatlabObject, MatFile5Writer,
+                                  MatFile5Reader, MatlabFunction)
 
-test_data_path = pjoin(dirname(__file__), 'data')
+test_data_path = os.path.join(os.path.dirname(__file__), 'data')
 
 
 def read_minimat_vars(rdr):
@@ -50,7 +41,7 @@ def read_workspace_vars(fname):
     rdr = MatFile5Reader(fp, struct_as_record=True)
     vars = rdr.get_variables()
     fws = vars['__function_workspace__']
-    ws_bs = BytesIO(fws.tostring())
+    ws_bs = io.BytesIO(fws.tostring())
     ws_bs.seek(2)
     rdr.mat_stream = ws_bs
     # Guess byte order.
@@ -64,7 +55,7 @@ def read_workspace_vars(fname):
 
 def test_jottings():
     # example
-    fname = pjoin(test_data_path, 'parabola.mat')
+    fname = os.path.join(test_data_path, 'parabola.mat')
     ws_vars = read_workspace_vars(fname)
 
 if __name__ == "__main__":

--- a/scipy/io/matlab/tests/test_miobase.py
+++ b/scipy/io/matlab/tests/test_miobase.py
@@ -3,11 +3,7 @@
 
 import numpy as np
 
-from numpy.testing import (assert_almost_equal,
-                           assert_array_equal)
-
-from nose.tools import (assert_true, assert_false, assert_raises,
-                        assert_equal, assert_not_equal)
+from numpy.testing import assert_raises, assert_equal
 
 from scipy.io.matlab.miobase import matdims
 

--- a/scipy/io/matlab/tests/test_pathological.py
+++ b/scipy/io/matlab/tests/test_pathological.py
@@ -7,20 +7,7 @@ from __future__ import division, print_function, absolute_import
 from os.path import dirname, join as pjoin
 import sys
 
-if sys.version_info[0] >= 3:
-    from io import BytesIO
-    cStringIO = BytesIO
-else:
-    from io import StringIO as cStringIO
-    from io import StringIO as BytesIO
-
-import numpy as np
-
-from nose.tools import assert_true, assert_false, \
-     assert_equal, assert_raises
-
-from numpy.testing import assert_array_equal, assert_array_almost_equal, \
-     run_module_suite
+from numpy.testing import assert_
 
 from scipy.io.matlab.mio import loadmat
 
@@ -33,5 +20,5 @@ def test_multiple_fieldnames():
     multi_fname = pjoin(TEST_DATA_PATH, 'nasty_duplicate_fieldnames.mat')
     vars = loadmat(multi_fname)
     funny_names = vars['Summary'].dtype.names
-    assert_true(set(['_1_Station_Q', '_2_Station_Q',
+    assert_(set(['_1_Station_Q', '_2_Station_Q',
                      '_3_Station_Q']).issubset(funny_names))

--- a/scipy/io/matlab/tests/test_streams.py
+++ b/scipy/io/matlab/tests/test_streams.py
@@ -19,11 +19,8 @@ from tempfile import mkstemp
 
 import numpy as np
 
-from nose.tools import assert_true, assert_false, \
-     assert_equal, assert_raises
-
-from numpy.testing import assert_array_equal, assert_array_almost_equal, \
-     run_module_suite
+from numpy.testing import (assert_, assert_equal, assert_raises,
+                           run_module_suite)
 
 from scipy.io.matlab.streams import make_stream, \
     GenericStream, cStringStream, FileStream, ZlibInputStream, \
@@ -58,10 +55,10 @@ def teardown():
 def test_make_stream():
     global fs, gs, cs
     # test stream initialization
-    assert_true(isinstance(make_stream(gs), GenericStream))
+    assert_(isinstance(make_stream(gs), GenericStream))
     if sys.version_info[0] < 3:
-        assert_true(isinstance(make_stream(cs), cStringStream))
-        assert_true(isinstance(make_stream(fs), FileStream))
+        assert_(isinstance(make_stream(cs), cStringStream))
+        assert_(isinstance(make_stream(fs), FileStream))
 
 
 def test_tell_seek():
@@ -187,11 +184,11 @@ class TestZlibInputStream(object):
     def test_all_data_read(self):
         compressed_stream, compressed_data_len, data = self._get_data(1024)
         stream = ZlibInputStream(compressed_stream, compressed_data_len)
-        assert_false(stream.all_data_read())
+        assert_(not stream.all_data_read())
         stream.seek(512)
-        assert_false(stream.all_data_read())
+        assert_(not stream.all_data_read())
         stream.seek(1024)
-        assert_true(stream.all_data_read())
+        assert_(stream.all_data_read())
 
 
 if __name__ == "__main__":

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -11,11 +11,9 @@ from glob import glob
 from contextlib import contextmanager
 
 import numpy as np
-from numpy.testing import assert_, assert_allclose, assert_warns
+from numpy.testing import assert_, assert_allclose, assert_raises, assert_equal
 
 from scipy.io.netcdf import netcdf_file
-
-from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 
 from scipy.lib._tmpdirs import in_tempdir
 
@@ -64,20 +62,20 @@ def test_read_write_files():
         # To read the NetCDF file we just created::
         with netcdf_file('simple.nc') as f:
             # Using mmap is the default
-            assert_true(f.use_mmap)
+            assert_(f.use_mmap)
             check_simple(f)
             assert_equal(f._attributes['appendRan'], 1)
 
         # Read it in append (and check mmap is off)
         with netcdf_file('simple.nc', 'a') as f:
-            assert_false(f.use_mmap)
+            assert_(not f.use_mmap)
             check_simple(f)
             assert_equal(f._attributes['appendRan'], 1)
 
         # Now without mmap
         with netcdf_file('simple.nc', mmap=False) as f:
             # Using mmap is the default
-            assert_false(f.use_mmap)
+            assert_(not f.use_mmap)
             check_simple(f)
 
         # To read the NetCDF file we just created, as file object, no
@@ -88,19 +86,19 @@ def test_read_write_files():
         with open('simple.nc', 'rb') as fobj:
             with netcdf_file(fobj) as f:
                 # by default, don't use mmap for file-like
-                assert_false(f.use_mmap)
+                assert_(not f.use_mmap)
                 check_simple(f)
 
         # Read file from fileobj, with mmap
         with open('simple.nc', 'rb') as fobj:
             with netcdf_file(fobj, mmap=True) as f:
-                assert_true(f.use_mmap)
+                assert_(f.use_mmap)
                 check_simple(f)
 
         # Again read it in append mode (adding another att)
         with open('simple.nc', 'r+b') as fobj:
             with netcdf_file(fobj, 'a') as f:
-                assert_false(f.use_mmap)
+                assert_(not f.use_mmap)
                 check_simple(f)
                 f.createDimension('app_dim', 1)
                 var = f.createVariable('app_var', 'i', ('app_dim',))

--- a/scipy/lib/tests/test_tmpdirs.py
+++ b/scipy/lib/tests/test_tmpdirs.py
@@ -4,9 +4,8 @@ from __future__ import division, print_function, absolute_import
 from os import getcwd
 from os.path import realpath, abspath, dirname, isfile, join as pjoin, exists
 
+from numpy.testing import assert_, assert_equal
 from scipy.lib._tmpdirs import tempdir, in_tempdir, in_dir
-
-from nose.tools import assert_true, assert_false, assert_equal
 
 MY_PATH = abspath(__file__)
 MY_DIR = dirname(MY_PATH)
@@ -17,16 +16,16 @@ def test_tempdir():
         fname = pjoin(tmpdir, 'example_file.txt')
         with open(fname, 'wt') as fobj:
             _ = fobj.write('a string\\n')
-    assert_false(exists(tmpdir))
+    assert_(not exists(tmpdir))
 
 
 def test_in_tempdir():
     my_cwd = getcwd()
     with in_tempdir() as tmpdir:
         _ = open('test.txt', 'wt').write('some text')
-        assert_true(isfile('test.txt'))
-        assert_true(isfile(pjoin(tmpdir, 'test.txt')))
-    assert_false(exists(tmpdir))
+        assert_(isfile('test.txt'))
+        assert_(isfile(pjoin(tmpdir, 'test.txt')))
+    assert_(not exists(tmpdir))
     assert_equal(getcwd(), my_cwd)
 
 
@@ -40,4 +39,4 @@ def test_given_directory():
         assert_equal(tmpdir, MY_DIR)
         assert_equal(realpath(MY_DIR), realpath(abspath(getcwd())))
     # We were deleting the Given directory!  Check not so now.
-    assert_true(isfile(MY_PATH))
+    assert_(isfile(MY_PATH))

--- a/scipy/ndimage/tests/test_datatypes.py
+++ b/scipy/ndimage/tests/test_datatypes.py
@@ -5,9 +5,7 @@ from __future__ import division, print_function, absolute_import
 import sys
 
 import numpy as np
-from numpy.testing import (assert_array_almost_equal, dec,
-                           assert_array_equal)
-from nose.tools import assert_true, assert_equal, assert_raises
+from numpy.testing import assert_array_almost_equal, dec, assert_
 
 from scipy import ndimage
 
@@ -58,7 +56,7 @@ def test_uint64_max():
     # Tests geometric transform (map_coordinates, affine_transform)
     inds = np.indices(arr.shape) - 0.1
     x = ndimage.map_coordinates(arr, inds)
-    assert_true(x[1] > (2**63))
+    assert_(x[1] > (2**63))
     # Tests zoom / shift
     x = ndimage.shift(arr, 0.1)
-    assert_true(x[1] > (2**63))
+    assert_(x[1] > (2**63))


### PR DESCRIPTION
I also noticed that some of these test modules don't have a `__main__`.
