### PR TITLE
add several features to frozen distributions

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -435,6 +435,7 @@ class rv_frozen(object):
         # a, b may be set in _argcheck, depending on *args, **kwds. Ouch.
         shapes, _, _ = self.dist._parse_args(*args, **kwds)
         self.dist._argcheck(*shapes)
+        self.a, self.b = self.dist.a, self.dist.b
 
     def pdf(self, x):   # raises AttributeError in frozen discrete distribution
         return self.dist.pdf(x, *self.args, **self.kwds)

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -437,6 +437,14 @@ class rv_frozen(object):
         self.dist._argcheck(*shapes)
         self.a, self.b = self.dist.a, self.dist.b
 
+    @property
+    def random_state(self):
+        return self.dist._random_state
+
+    @random_state.setter
+    def random_state(self, seed):
+        self.dist._random_state = check_random_state(seed)
+
     def pdf(self, x):   # raises AttributeError in frozen discrete distribution
         return self.dist.pdf(x, *self.args, **self.kwds)
 
@@ -455,9 +463,9 @@ class rv_frozen(object):
     def isf(self, q):
         return self.dist.isf(q, *self.args, **self.kwds)
 
-    def rvs(self, size=None):
+    def rvs(self, size=None, random_state=None):
         kwds = self.kwds.copy()
-        kwds.update({'size': size})
+        kwds.update({'size': size, 'random_state': random_state})
         return self.dist.rvs(*self.args, **kwds)
 
     def sf(self, x):

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -506,6 +506,21 @@ class rv_frozen(object):
     def interval(self, alpha):
         return self.dist.interval(alpha, *self.args, **self.kwds)
 
+    def expect(self, func=None, lb=None, ub=None, 
+                     conditional=False, **kwds):
+        # expect method only accepts shape parameters as positional args
+        # hence convert self.args, self.kwds, also loc/scale
+        # See the .expect method docstrings for the meaning of
+        # other parameters.
+        a, loc, scale = self.dist._parse_args(*self.args, **self.kwds)
+        if isinstance(self.dist, rv_discrete):
+            if kwds:
+                raise ValueError("Discrete expect does not accept **kwds.")
+            return self.dist.expect(func, a, loc, lb, ub, conditional)
+        else:
+            return self.dist.expect(func, a, loc, scale, lb, ub,
+                                    conditional, **kwds)
+
 
 def valarray(shape, value=nan, typecode=None):
     """Return an array of all value.

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1305,6 +1305,23 @@ class TestFrozen(TestCase):
         rndm = np.random.RandomState(1234)
         frozen.rvs(size=8, random_state=rndm)
 
+    def test_expect(self):
+        # smoke test the expect method of the frozen distribution
+        # only take a gamma w/loc and scale and poisson with loc specified
+        def func(x):
+            return x
+
+        gm = stats.gamma(a=2, loc=3, scale=4)
+        gm_val = gm.expect(func, lb=1, ub=2, conditional=True)
+        gamma_val = stats.gamma.expect(func, args=(2,), loc=3, scale=4,
+                                       lb=1, ub=2, conditional=True)
+        assert_allclose(gm_val, gamma_val)
+
+        p = stats.poisson(3, loc=4)
+        p_val = p.expect(func)
+        poisson_val = stats.poisson.expect(func, args=(3,), loc=4)
+        assert_allclose(p_val, poisson_val)
+
 
 class TestExpect(TestCase):
     # Test for expect method.

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1196,6 +1196,9 @@ class TestFrozen(TestCase):
         result = dist.moment(2,loc=10.0, scale=3.0)
         assert_equal(result_f, result)
 
+        assert_equal(frozen.a, dist.a)
+        assert_equal(frozen.b, dist.b)
+
     def test_gamma(self):
         a = 2.0
         dist = stats.gamma
@@ -1245,6 +1248,9 @@ class TestFrozen(TestCase):
         result = dist.moment(2, a)
         assert_equal(result_f, result)
 
+        assert_equal(frozen.a, frozen.dist.a)
+        assert_equal(frozen.b, frozen.dist.b)
+
     def test_regression_ticket_1293(self):
         # Create a frozen distribution.
         frozen = stats.lognorm(1)
@@ -1272,9 +1278,11 @@ class TestFrozen(TestCase):
         rv = stats.genpareto(c=-0.1)
         a, b = rv.dist.a, rv.dist.b
         assert_equal([a, b], [0., 10.])
+        assert_equal([rv.a, rv.b], [0., 10.])
 
         stats.genpareto.pdf(0, c=0.1)  # this changes genpareto.b
         assert_equal([rv.dist.a, rv.dist.b], [a, b])
+        assert_equal([rv.a, rv.b], [a, b])
 
         rv1 = stats.genpareto(c=0.1)
         assert_(rv1.dist is not rv.dist)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1291,6 +1291,20 @@ class TestFrozen(TestCase):
         # Regression test for gh-3522
         assert_(hasattr(stats.distributions, 'rv_frozen'))
 
+    def test_random_state(self):
+        # only check that the random_state attribute exists,
+        frozen = stats.norm()
+        assert_(hasattr(frozen, 'random_state'))
+
+        # ... that it can be set,
+        frozen.random_state = 42
+        assert_equal(frozen.random_state.get_state(),
+                     np.random.RandomState(42).get_state())
+
+        # ... and that .rvs method accepts it as an argument
+        rndm = np.random.RandomState(1234)
+        frozen.rvs(size=8, random_state=rndm)
+
 
 class TestExpect(TestCase):
     # Test for expect method.


### PR DESCRIPTION
Just some convenience wrappers. 
- add `a`, `b` attributes (support boundaries). 
- add `random_state` property
- add `expect` method.

All these were available with a bit of digging (if `f` is a frozen distribution, `f.dist` is a full-featured distribution instance, so that there always is `f.dist.a`, `f.dist.expect` etc), but it's IMO better to have them more easily discoverable.
