### PR TITLE
BUG: Fix/test invalid lwork param in qr

### DIFF
--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -15,7 +15,7 @@ def safecall(f, name, *args, **kwargs):
     """Call a LAPACK routine, determining lwork automatically and handling
     error return values"""
     lwork = kwargs.get("lwork", None)
-    if lwork is None:
+    if lwork in (None, -1):
         kwargs['lwork'] = -1
         ret = f(*args, **kwargs)
         kwargs['lwork'] = ret[-2][0].real.astype(numpy.int)

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -374,14 +374,8 @@ def rq(a, overwrite_a=False, lwork=None, mode='full', check_finite=True):
     overwrite_a = overwrite_a or (_datacopied(a1, a))
 
     gerqf, = get_lapack_funcs(('gerqf',), (a1,))
-    if lwork is None or lwork == -1:
-        # get optimal work array
-        rq, tau, work, info = gerqf(a1, lwork=-1, overwrite_a=1)
-        lwork = work[0].real.astype(numpy.int)
-    rq, tau, work, info = gerqf(a1, lwork=lwork, overwrite_a=overwrite_a)
-    if info < 0:
-        raise ValueError('illegal value in %d-th argument of internal gerqf'
-                                                                    % -info)
+    rq, tau = safecall(gerqf, 'gerqf', a1, lwork=lwork,
+                       overwrite_a=overwrite_a)
     if not mode == 'economic' or N < M:
         R = numpy.triu(rq, N-M)
     else:
@@ -393,24 +387,15 @@ def rq(a, overwrite_a=False, lwork=None, mode='full', check_finite=True):
     gor_un_grq, = get_lapack_funcs(('orgrq',), (rq,))
 
     if N < M:
-        # get optimal work array
-        Q, work, info = gor_un_grq(rq[-N:], tau, lwork=-1, overwrite_a=1)
-        lwork = work[0].real.astype(numpy.int)
-        Q, work, info = gor_un_grq(rq[-N:], tau, lwork=lwork, overwrite_a=1)
+        Q, = safecall(gor_un_grq, "gorgrq/gungrq", rq[-N:], tau, lwork=lwork,
+                      overwrite_a=1)
     elif mode == 'economic':
-        # get optimal work array
-        Q, work, info = gor_un_grq(rq, tau, lwork=-1, overwrite_a=1)
-        lwork = work[0].real.astype(numpy.int)
-        Q, work, info = gor_un_grq(rq, tau, lwork=lwork, overwrite_a=1)
+        Q, = safecall(gor_un_grq, "gorgrq/gungrq", rq, tau, lwork=lwork,
+                      overwrite_a=1)
     else:
         rq1 = numpy.empty((N, N), dtype=rq.dtype)
         rq1[-M:] = rq
-        # get optimal work array
-        Q, work, info = gor_un_grq(rq1, tau, lwork=-1, overwrite_a=1)
-        lwork = work[0].real.astype(numpy.int)
-        Q, work, info = gor_un_grq(rq1, tau, lwork=lwork, overwrite_a=1)
+        Q, = safecall(gor_un_grq, "gorgrq/gungrq", rq1, tau, lwork=lwork,
+                      overwrite_a=1)
 
-    if info < 0:
-        raise ValueError("illegal value in %d-th argument of internal orgrq"
-                                                                    % -info)
     return R, Q

--- a/scipy/linalg/decomp_qr.py
+++ b/scipy/linalg/decomp_qr.py
@@ -14,7 +14,7 @@ __all__ = ['qr', 'qr_multiply', 'rq']
 def safecall(f, name, *args, **kwargs):
     """Call a LAPACK routine, determining lwork automatically and handling
     error return values"""
-    lwork = kwargs.pop("lwork", None)
+    lwork = kwargs.get("lwork", None)
     if lwork is None:
         kwargs['lwork'] = -1
         ret = f(*args, **kwargs)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1473,6 +1473,24 @@ class TestQR(TestCase):
         assert_array_almost_equal(dot(transpose(q),q),identity(3))
         assert_array_almost_equal(dot(q,r),a)
 
+    def test_lwork(self):
+        a = [[8,2,3],[2,9,3],[5,3,6]]
+        # Get comparison values
+        q,r = qr(a, lwork=None)
+
+        # Test against minimum valid lwork
+        q2,r2 = qr(a, lwork=3)
+        assert_array_almost_equal(q2,q)
+        assert_array_almost_equal(r2,r)
+
+        # Test against larger lwork
+        q3,r3 = qr(a, lwork=10)
+        assert_array_almost_equal(q3,q)
+        assert_array_almost_equal(r3,r)
+
+        # Test against invalid lwork
+        assert_raises(Exception, qr, (a,), {'lwork':0})
+        assert_raises(Exception, qr, (a,), {'lwork':2})
 
 class TestRQ(TestCase):
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1488,6 +1488,11 @@ class TestQR(TestCase):
         assert_array_almost_equal(q3,q)
         assert_array_almost_equal(r3,r)
 
+        # Test against explicit lwork=-1
+        q4,r4 = qr(a, lwork=-1)
+        assert_array_almost_equal(q4,q)
+        assert_array_almost_equal(r4,r)
+
         # Test against invalid lwork
         assert_raises(Exception, qr, (a,), {'lwork':0})
         assert_raises(Exception, qr, (a,), {'lwork':2})


### PR DESCRIPTION
Fixes `lwork` parameter in qr being overwritten by `lwork=-1`. Adds tests for valid and invalid `lwork` parameters.

See issue #4100.
