### PR TITLE
MAINT: fix a number of special test failures

### DIFF
--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -97,7 +97,7 @@ def diric(x, n):
     mask1 = (n <= 0) | (n != floor(n))
     place(y, mask1, nan)
 
-    x /= 2.0
+    x = x / 2
     denom = sin(x)
     mask2 = (1-mask1) & (abs(denom) < minval)
     xsub = extract(mask2, x)

--- a/scipy/special/tests/test_data.py
+++ b/scipy/special/tests/test_data.py
@@ -5,6 +5,7 @@ import warnings
 
 import numpy as np
 from numpy import arccosh, arcsinh, arctanh
+from numpy.testing import run_module_suite
 from scipy.special import (
     lpn, lpmn, lpmv, lqn, lqmn, sph_harm, eval_legendre, eval_hermite,
     eval_laguerre, eval_genlaguerre, binom, cbrt, expm1, log1p, zeta,
@@ -224,17 +225,17 @@ def test_boost():
         data(betainc, 'ibeta_small_data_ipp-ibeta_small_data', (0,1,2), 5, rtol=6e-15),
         data(betainc, 'ibeta_data_ipp-ibeta_data', (0,1,2), 5, rtol=5e-13),
         data(betainc, 'ibeta_int_data_ipp-ibeta_int_data', (0,1,2), 5, rtol=2e-14),
-        data(betainc, 'ibeta_large_data_ipp-ibeta_large_data', (0,1,2), 5, rtol=3e-10),
+        data(betainc, 'ibeta_large_data_ipp-ibeta_large_data', (0,1,2), 5, rtol=4e-10),
 
         data(betaincinv, 'ibeta_inv_data_ipp-ibeta_inv_data', (0,1,2), 3, rtol=1e-5),
 
         data(btdtr, 'ibeta_small_data_ipp-ibeta_small_data', (0,1,2), 5, rtol=6e-15),
         data(btdtr, 'ibeta_data_ipp-ibeta_data', (0,1,2), 5, rtol=4e-13),
         data(btdtr, 'ibeta_int_data_ipp-ibeta_int_data', (0,1,2), 5, rtol=2e-14),
-        data(btdtr, 'ibeta_large_data_ipp-ibeta_large_data', (0,1,2), 5, rtol=3e-10),
+        data(btdtr, 'ibeta_large_data_ipp-ibeta_large_data', (0,1,2), 5, rtol=4e-10),
 
         data(btdtri, 'ibeta_inv_data_ipp-ibeta_inv_data', (0,1,2), 3, rtol=1e-5),
-        data(btdtri_comp, 'ibeta_inv_data_ipp-ibeta_inv_data', (0,1,2), 4, rtol=6e-7),
+        data(btdtri_comp, 'ibeta_inv_data_ipp-ibeta_inv_data', (0,1,2), 4, rtol=8e-7),
 
         data(btdtria, 'ibeta_inva_data_ipp-ibeta_inva_data', (2,0,1), 3, rtol=5e-9),
         data(btdtria_comp, 'ibeta_inva_data_ipp-ibeta_inva_data', (2,0,1), 4, rtol=5e-9),
@@ -244,7 +245,7 @@ def test_boost():
 
         data(binom, 'binomial_data_ipp-binomial_data', (0,1), 2, rtol=1e-15),
         data(binom, 'binomial_large_data_ipp-binomial_large_data', (0,1), 2, rtol=5e-13),
-        
+
         data(bdtrik, 'binomial_quantile_ipp-binomial_quantile_data', (2,0,1), 3, rtol=5e-9),
         data(bdtrik_comp, 'binomial_quantile_ipp-binomial_quantile_data', (2,0,1), 4, rtol=5e-9),
 
@@ -315,7 +316,7 @@ def test_boost():
         data(gammainc, 'igamma_med_data_ipp-igamma_med_data', (0,1), 5, rtol=2e-13),
         data(gammainc, 'igamma_int_data_ipp-igamma_int_data', (0,1), 5, rtol=2e-13),
         data(gammainc, 'igamma_big_data_ipp-igamma_big_data', (0,1), 5, rtol=2e-9),
-        
+
         data(gdtr_, 'igamma_small_data_ipp-igamma_small_data', (0,1), 5, rtol=1e-13),
         data(gdtr_, 'igamma_med_data_ipp-igamma_med_data', (0,1), 5, rtol=2e-13),
         data(gdtr_, 'igamma_int_data_ipp-igamma_int_data', (0,1), 5, rtol=2e-13),
@@ -410,7 +411,7 @@ def test_boost():
              param_filter=(lambda p: np.ones(p.shape, '?'),
                            lambda p: np.ones(p.shape, '?'),
                            lambda p: np.logical_and(p < 2*np.pi, p >= 0),
-                           lambda p: np.logical_and(p < np.pi, p >= 0))), 
+                           lambda p: np.logical_and(p < np.pi, p >= 0))),
 
         # -- not used yet (function does not exist in scipy):
         # 'ellint_pi2_data_ipp-ellint_pi2_data',
@@ -480,3 +481,7 @@ def _test_factory(test, dtype=np.double):
         test.check(dtype=dtype)
     finally:
         np.seterr(**olderr)
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1015,14 +1015,16 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
             return mpmath.ellippi(0, phi, m)
         assert_mpmath_equal(sc.ellipkinc,
                             ellipkinc,
-                            [Arg(-1e3, 1e3), Arg(b=1.0)])
+                            [Arg(-1e3, 1e3), Arg(b=1.0)],
+                            ignore_inf_sign=True)
 
     def test_ellipkinc_largephi(self):
         def ellipkinc(phi, m):
             return mpmath.ellippi(0, phi, m)
         assert_mpmath_equal(sc.ellipkinc,
                             ellipkinc,
-                            [Arg(), Arg(b=1.0)])
+                            [Arg(), Arg(b=1.0)],
+                            ignore_inf_sign=True)
 
     def test_ellipfun_sn(self):
         # Oscillating function --- limit range of first argument; the

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -1,13 +1,14 @@
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import (rand, TestCase, assert_array_almost_equal, 
-        assert_almost_equal, assert_allclose, assert_raises)
+from numpy.testing import (rand, TestCase, assert_array_almost_equal,
+                           assert_almost_equal, assert_allclose, assert_raises,
+                           run_module_suite)
 
 from scipy.lib.six import xrange
 import numpy as np
 from numpy import array, sqrt
 import scipy.special.orthogonal as orth
-from scipy.special import gamma, eval_hermite
+from scipy.special import gamma
 
 
 class TestCheby(TestCase):
@@ -310,7 +311,7 @@ def test_j_roots():
     verify_gauss_quad(roots(18.24, 27.3), evalf(18.24, 27.3), 100, atol=1e-13)
 
     verify_gauss_quad(roots(47.1, -0.2), evalf(47.1, -0.2), 5, atol=1e-13)
-    verify_gauss_quad(roots(47.1, -0.2), evalf(47.1, -0.2), 25, atol=1e-13)
+    verify_gauss_quad(roots(47.1, -0.2), evalf(47.1, -0.2), 25, atol=2e-13)
     verify_gauss_quad(roots(47.1, -0.2), evalf(47.1, -0.2), 100, atol=1e-11)
 
     verify_gauss_quad(roots(2.25, 68.9), evalf(2.25, 68.9), 5)
@@ -433,7 +434,7 @@ def test_cg_roots():
     verify_gauss_quad(root_func(50), eval_func(50), 25, atol=1e-12)
     verify_gauss_quad(root_func(50), eval_func(50), 100, atol=1e-11)
 
-    # this is a special case that the old code supported. 
+    # this is a special case that the old code supported.
     # when alpha = 0, the gegenbauer polynomial is uniformly 0. but it goes
     # to a scaled down copy of T_n(x) there.
     verify_gauss_quad(root_func(0), orth.eval_chebyt, 5)
@@ -598,3 +599,7 @@ def test_la_roots():
     assert_raises(ValueError, orth.la_roots, 0, 2)
     assert_raises(ValueError, orth.la_roots, 3.3, 2)
     assert_raises(ValueError, orth.la_roots, 3, -1.1)
+
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
The `special.diric` bug was just introduced in gh-4001, only fails with numpy 1.10-dev.

The test failures have been there for quite a while on 32-bit linux.
