### PR TITLE
implement cdf for betaprime distribution

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -525,10 +525,8 @@ class betaprime_gen(rv_continuous):
         return (special.xlogy(a-1.0, x) - special.xlog1py(a+b, x) -
                 special.betaln(a, b))
 
-    def _cdf_skip(self, x, a, b):
-        # remove for now: special.hyp2f1 is incorrect for large a
-        x = where(x == 1.0, 1.0-1e-6, x)
-        return pow(x, a)*special.hyp2f1(a+b, a, 1+a, -x)/a/special.beta(a, b)
+    def _cdf(self, x, a, b):
+        return special.betainc(a, b, x/(1.+x))
 
     def _munp(self, n, a, b):
         if (n == 1.0):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -863,6 +863,12 @@ class TestBetaPrime(TestCase):
         assert_(np.isfinite(b.logpdf(x)).all())
         assert_allclose(b.pdf(x), np.exp(b.logpdf(x)))
 
+    def test_cdf(self):
+        # regression test for issue 4030: Implentation of 
+        # scipy.stats.betaprime.cdf()
+        x = stats.betaprime.cdf(0,0.2,0.3)
+        assert_equal(x,0.0)
+
 
 class TestGamma(TestCase):
     def test_pdf(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -864,11 +864,20 @@ class TestBetaPrime(TestCase):
         assert_allclose(b.pdf(x), np.exp(b.logpdf(x)))
 
     def test_cdf(self):
-        # regression test for issue 4030: Implentation of 
+        # regression test for gh-4030: Implementation of 
         # scipy.stats.betaprime.cdf()
-        x = stats.betaprime.cdf(0,0.2,0.3)
-        assert_equal(x,0.0)
+        x = stats.betaprime.cdf(0, 0.2, 0.3)
+        assert_equal(x, 0.0)
 
+        alpha, beta = 267, 1472
+        x = np.array([0.2, 0.5, 0.6])
+        cdfs = stats.betaprime.cdf(x, alpha, beta)
+        assert_(np.isfinite(cdfs).all())
+        
+        # check the new cdf implementation vs generic one:
+        gen_cdf = stats.rv_continuous._cdf_single
+        cdfs_g = [gen_cdf(stats.betaprime, val, alpha, beta) for val in x]
+        assert_allclose(cdfs, cdfs_g, atol=0, rtol=2e-12)
 
 class TestGamma(TestCase):
     def test_pdf(self):


### PR DESCRIPTION
cleaned-up/rebased version of gh-4328
supersedes and closes gh-4328, closes gh-4030.
