### PR TITLE
ENH: add PPoly.solve(y) for solving ``p(x) == y``

### DIFF
--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -38,7 +38,7 @@ def evaluate(double_or_complex[:,:,::1] c,
              double[::1] x,
              double[::1] xp,
              int dx,
-             int extrapolate,
+             bint extrapolate,
              double_or_complex[:,::1] out):
     """
     Evaluate a piecewise polynomial.
@@ -56,8 +56,8 @@ def evaluate(double_or_complex[:,:,::1] c,
     dx : int
         Order of derivative to evaluate.  The derivative is evaluated
         piecewise and may have discontinuities.
-    extrapolate : int, optional
-        Whether to extrapolate to out-of-bounds points based on first
+    extrapolate : bint, optional
+        Whether to extrapolate to ouf-of-bounds points based on first
         and last intervals, or to return NaNs.
     out : ndarray, shape (r, n)
         Value of each polynomial at each of the input points.
@@ -171,7 +171,7 @@ def integrate(double_or_complex[:,:,::1] c,
               double[::1] x,
               double a,
               double b,
-              int extrapolate,
+              bint extrapolate,
               double_or_complex[::1] out):
     """
     Compute integral over a piecewise polynomial.
@@ -186,8 +186,8 @@ def integrate(double_or_complex[:,:,::1] c,
         Start point of integration.
     b : double
         End point of integration.
-    extrapolate : int, optional
-        Whether to extrapolate to out-of-bounds points based on first
+    extrapolate : bint, optional
+        Whether to extrapolate to ouf-of-bounds points based on first
         and last intervals, or to return NaNs.
     out : ndarray, shape (n,)
         Integral of the piecewise polynomial, assuming the polynomial
@@ -246,8 +246,8 @@ def integrate(double_or_complex[:,:,::1] c,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision(True)
-def real_roots(double[:,:,::1] c, double[::1] x, double y, int report_discont,
-               int extrapolate):
+def real_roots(double[:,:,::1] c, double[::1] x, double y, bint report_discont,
+               bint extrapolate):
     """
     Compute real roots of a real-valued piecewise polynomial function.
 
@@ -264,10 +264,10 @@ def real_roots(double[:,:,::1] c, double[::1] x, double y, int report_discont,
         Polynomial coefficients, as above
     y : float
         Find roots of ``pp(x) == y``.
-    report_discont : int, optional
+    report_discont : bint, optional
         Whether to report discontinuities across zero at breakpoints
         as roots
-    extrapolate : int, optional
+    extrapolate : bint, optional
         Whether to consider roots obtained by extrapolating based
         on first and last intervals.
 
@@ -387,7 +387,7 @@ def real_roots(double[:,:,::1] c, double[::1] x, double y, int report_discont,
 cdef int find_interval(double[::1] x,
                        double xval,
                        int prev_interval=0,
-                       int extrapolate=1) nogil:
+                       bint extrapolate=1) nogil:
     """
     Find an interval such that x[interval] <= xval < x[interval+1]
     or interval == 0 and xval < x[0]
@@ -401,7 +401,7 @@ cdef int find_interval(double[::1] x,
         Point to find
     prev_interval : int, optional
         Interval where a previous point was found
-    extrapolate : int, optional
+    extrapolate : bint, optional
         Whether to return the last of the first interval if the
         point is out-of-bounds. 
 
@@ -853,7 +853,7 @@ def evaluate_bernstein(double_or_complex[:,:,::1] c,
              double[::1] x,
              double[::1] xp,
              int nu,
-             int extrapolate,
+             bint extrapolate,
              double_or_complex[:,::1] out):
     """
     Evaluate a piecewise polynomial in the Bernstein basis.
@@ -871,8 +871,8 @@ def evaluate_bernstein(double_or_complex[:,:,::1] c,
     nu : int
         Order of derivative to evaluate.  The derivative is evaluated
         piecewise and may have discontinuities.
-    extrapolate : int, optional
-        Whether to extrapolate to out-of-bounds points based on first
+    extrapolate : bint, optional
+        Whether to extrapolate to ouf-of-bounds points based on first
         and last intervals, or to return NaNs.
     out : ndarray, shape (r, n)
         Value of each polynomial at each of the input points.

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -846,6 +846,7 @@ class PPoly(_PPolyBase):
     derivative
     antiderivative
     integrate
+    solve
     roots
     extend
     from_spline
@@ -998,12 +999,14 @@ class PPoly(_PPolyBase):
         range_int *= sign
         return range_int.reshape(self.c.shape[2:])
 
-    def roots(self, discontinuity=True, extrapolate=None):
+    def solve(self, y=0., discontinuity=True, extrapolate=None):
         """
-        Find real roots of the piecewise polynomial.
+        Find real solutions of the the equation ``pp(x) == y``.
 
         Parameters
         ----------
+        y : float, optional
+            Right-hand side. Default is zero.
         discontinuity : bool, optional
             Whether to report sign changes across discontinuities at
             breakpoints as roots.
@@ -1053,8 +1056,9 @@ class PPoly(_PPolyBase):
             raise ValueError("Root finding is only for "
                              "real-valued polynomials")
 
+        y = float(y)
         r = _ppoly.real_roots(self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
-                              self.x, bool(discontinuity),
+                              self.x, y, bool(discontinuity),
                               bool(extrapolate))
         if self.c.ndim == 2:
             return r[0]
@@ -1066,6 +1070,35 @@ class PPoly(_PPolyBase):
                 r2[ii] = root
 
             return r2.reshape(self.c.shape[2:])
+
+    def roots(self, discontinuity=True, extrapolate=None):
+        """
+        Find real roots of the the piecewise polynomial.
+
+        Parameters
+        ----------
+        discontinuity : bool, optional
+            Whether to report sign changes across discontinuities at
+            breakpoints as roots.
+        extrapolate : bool, optional
+            Whether to return roots from the polynomial extrapolated
+            based on first and last intervals.
+
+        Returns
+        -------
+        roots : ndarray
+            Roots of the polynomial(s).
+
+            If the PPoly object describes multiple polynomials, the
+            return value is an object array whose each element is an
+            ndarray containing the roots.
+
+        See Also
+        --------
+        PPoly.solve
+
+        """
+        return self.solve(0, discontinuity, extrapolate)
 
     @classmethod
     def from_spline(cls, tck, extrapolate=None):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1070,6 +1070,31 @@ class TestPPoly(TestCase):
         assert_array_equal(pp.roots(),
                            [0.25, 0.4, np.nan, 0.6 + 0.25])
 
+        # ditto for p.solve(const) with sections identically equal const
+        const = 2.
+        c1 = c.copy()
+        c1[1, :] += const
+        pp1 = PPoly(c1, x)
+
+        assert_array_equal(pp1.solve(const),
+                           [0.25, 0.4, np.nan, 0.6 + 0.25])
+
+    def test_roots_all_zero(self):
+        # test the code path for the polynomial being identically zero everywhere
+        c = [[0], [0]]
+        x = [0, 1]
+        p = PPoly(c, x)
+        assert_array_equal(p.roots(), [0, np.nan])
+        assert_array_equal(p.solve(0), [0, np.nan])
+        assert_array_equal(p.solve(1), [])
+
+        c = [[0, 0], [0, 0]]
+        x = [0, 1, 2]
+        p = PPoly(c, x)
+        assert_array_equal(p.roots(), [0, np.nan, 1, np.nan])
+        assert_array_equal(p.solve(0), [0, np.nan, 1, np.nan])
+        assert_array_equal(p.solve(1), [])
+
     def test_roots_repeated(self):
         # Check roots repeated in multiple sections are reported only
         # once.
@@ -1089,6 +1114,13 @@ class TestPPoly(TestCase):
         pp = PPoly(c, x)
         assert_array_equal(pp.roots(), [0.5])
         assert_array_equal(pp.roots(discontinuity=False), [])
+
+        # ditto for a discontinuity across y:
+        assert_array_equal(pp.solve(0.5), [0.5])
+        assert_array_equal(pp.solve(0.5, discontinuity=False), [])
+
+        assert_array_equal(pp.solve(1.5), [])
+        assert_array_equal(pp.solve(1.5, discontinuity=False), [])
 
     def test_roots_random(self):
         # Check high-order polynomials with random coefficients

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1102,19 +1102,21 @@ class TestPPoly(TestCase):
                 c = 2*np.random.rand(order+1, len(x)-1, 2, 3) - 1
 
                 pp = PPoly(c, x)
-                r = pp.roots(discontinuity=False, extrapolate=extrapolate)
+                for y in [0, np.random.random()]:
+                    r = pp.solve(y, discontinuity=False, extrapolate=extrapolate)
 
-                for i in range(2):
-                    for j in range(3):
-                        rr = r[i,j]
-                        if rr.size > 0:
-                            # Check that the reported roots indeed are roots
-                            num += rr.size
-                            val = pp(rr, extrapolate=extrapolate)[:,i,j]
-                            cmpval = pp(rr, nu=1, extrapolate=extrapolate)[:,i,j]
-                            assert_allclose(val/cmpval, 0, atol=1e-7,
-                                            err_msg="(%r) r = %s" % (extrapolate,
-                                                                     repr(rr),))
+                    for i in range(2):
+                        for j in range(3):
+                            rr = r[i,j]
+                            if rr.size > 0:
+                                # Check that the reported roots indeed are roots
+                                num += rr.size
+                                val = pp(rr, extrapolate=extrapolate)[:,i,j]
+                                cmpval = pp(rr, nu=1,
+                                            extrapolate=extrapolate)[:,i,j]
+                                msg = "(%r) r = %s" % (extrapolate, repr(rr),)
+                                assert_allclose((val-y) / cmpval, 0, atol=1e-7,
+                                                err_msg=msg)
 
         # Check that we checked a number of roots
         assert_(num > 100, repr(num))
@@ -1130,23 +1132,24 @@ class TestPPoly(TestCase):
                 # add a case with zero discriminant
                 c[:,0,0] = 1, 2, 1
 
-            w = np.empty(c.shape, dtype=complex)
-            _ppoly._croots_poly1(c, w)
+            for y in [0, np.random.random()]:
+                w = np.empty(c.shape, dtype=complex)
+                _ppoly._croots_poly1(c, w)
 
-            if k == 1:
-                assert_(np.isnan(w).all())
-                continue
+                if k == 1:
+                    assert_(np.isnan(w).all())
+                    continue
 
-            res = 0
-            cres = 0
-            for i in range(k):
-                res += c[i,None] * w**(k-1-i)
-                cres += abs(c[i,None] * w**(k-1-i))
-            with np.errstate(invalid='ignore'):
-                res /= cres
-            res = res.ravel()
-            res = res[~np.isnan(res)]
-            assert_allclose(res, 0, atol=1e-10)
+                res = 0
+                cres = 0
+                for i in range(k):
+                    res += c[i,None] * w**(k-1-i)
+                    cres += abs(c[i,None] * w**(k-1-i))
+                with np.errstate(invalid='ignore'):
+                    res /= cres
+                res = res.ravel()
+                res = res[~np.isnan(res)]
+                assert_allclose(res, 0, atol=1e-10)
 
     def test_extrapolate_attr(self):
         # [ 1 - x**2 ]


### PR DESCRIPTION
closes gh-3261

Regarding the API, I don't have a strong opinion with respect to whether to have a separate method, `PPoly.solve(y)` or to fold the offset parameter to the `roots` method. At the moment it's implemented as a separate method, but it might be still OK to break backwards compat and make the `roots` signature be
`PPoly.roots(y=0, discontinuity=True, extrap=False)`.
