### PR TITLE
MAINT: lib: don't export "partial" from decorator

### DIFF
--- a/scipy/lib/decorator.py
+++ b/scipy/lib/decorator.py
@@ -32,7 +32,7 @@ from __future__ import division, print_function, absolute_import
 
 __version__ = '3.3.2'
 
-__all__ = ["decorator", "FunctionMaker", "partial"]
+__all__ = ["decorator", "FunctionMaker"]
 
 import sys
 import re


### PR DESCRIPTION
Follow-up to 037236e74153cfff3a3c99a06d108d762345d5f2, which removed the custom implementation of partial.
