### PR TITLE
MAINT: Fix two spots that depend on ravel always being 1-D.

### DIFF
--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1652,7 +1652,7 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
 
         ider[1], ider[3] = pole_flat
 
-        u, v = np.ravel(u), np.ravel(v)
+        u, v = np.asarray(u).ravel(), np.asarray(v).ravel()
         if not np.all(np.diff(u) > 0.0):
             raise TypeError('u must be strictly increasing')
         if not np.all(np.diff(v) > 0.0):
@@ -1672,7 +1672,7 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
             raise TypeError('if pole_continuity is False, so must be '
                             'pole_flat')
 
-        r = np.ravel(r)
+        r = np.asarray(r).ravel()
         nu, tu, nv, tv, c, fp, ier = dfitpack.regrid_smth_spher(iopt, ider,
                                        u.copy(), v.copy(), r.copy(), r0, r1, s)
 

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -2172,8 +2172,9 @@ def spleval(xck, xnew, deriv=0):
 
     """
     (xj,cvals,k) = xck
+    xnew = np.asarray(xnew)
     oldshape = np.shape(xnew)
-    xx = np.ravel(xnew)
+    xx = xnew.ravel()
     sh = cvals.shape[1:]
     res = np.empty(xx.shape + sh, dtype=cvals.dtype)
     for index in np.ndindex(*sh):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1221,8 +1221,9 @@ def _ppoly_eval_2(coeffs, breaks, xnew, fill=np.nan):
     b = breaks[-1]
     K = coeffs.shape[0]
 
+    xnew = np.asarray(xnew)
     saveshape = np.shape(xnew)
-    xnew = np.ravel(xnew)
+    xnew = xnew.ravel()
     res = np.empty_like(xnew)
     mask = (xnew >= a) & (xnew <= b)
     res[~mask] = fill

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -518,8 +518,8 @@ def _linprog_simplex(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     # Convert the input arguments to arrays (sized to zero if not provided)
     Aeq = np.asarray(A_eq) if A_eq is not None else np.empty([0, len(cc)])
     Aub = np.asarray(A_ub) if A_ub is not None else np.empty([0, len(cc)])
-    beq = np.ravel(np.asarray(b_eq)) if b_eq is not None else np.empty([0])
-    bub = np.ravel(np.asarray(b_ub)) if b_ub is not None else np.empty([0])
+    beq = np.asarray(b_eq).ravel() if b_eq is not None else np.empty([0])
+    bub = np.asarray(b_ub).ravel() if b_ub is not None else np.empty([0])
 
     # Analyze the bounds and determine what modifications to me made to
     # the constraints in order to accommodate them.

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -332,7 +332,7 @@ class spmatrix(object):
             if other.shape != (N,) and other.shape != (N,1):
                 raise ValueError('dimension mismatch')
 
-            result = self._mul_vector(np.ravel(other))
+            result = self._mul_vector(np.asarray(other).ravel())
 
             if isinstance(other, np.matrix):
                 result = np.asmatrix(result)

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -285,7 +285,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         y = np.empty(min(M,N), dtype=upcast(self.dtype))
         _sparsetools.bsr_diagonal(M//R, N//C, R, C,
                                   self.indptr, self.indices,
-                                  np.ravel(self.data), y)
+                                  self.data.ravel(), y)
         return y
 
     ##########################
@@ -379,10 +379,10 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         bsr_matmat_pass2(M//R, N//C, R, C, n,
                          self.indptr.astype(idx_dtype),
                          self.indices.astype(idx_dtype),
-                         np.ravel(self.data),
+                         self.data.ravel(),
                          other.indptr.astype(idx_dtype),
                          other.indices.astype(idx_dtype),
-                         np.ravel(other.data),
+                         other.data.ravel(),
                          indptr,
                          indices,
                          data)
@@ -561,10 +561,10 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         fn(self.shape[0]//R, self.shape[1]//C, R, C,
            self.indptr.astype(idx_dtype),
            self.indices.astype(idx_dtype),
-           np.ravel(self.data),
+           self.data.ravel(),
            other.indptr.astype(idx_dtype),
            other.indices.astype(idx_dtype),
-           np.ravel(other.data),
+           other.data.ravel(),
            indptr,
            indices,
            data)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2427,7 +2427,7 @@ class _TestFancyIndexing:
 
     def test_fancy_indexing_regression_3087(self):
         mat = self.spmatrix(array([[1, 0, 0], [0,1,0], [1,0,0]]))
-        desired_cols = np.ravel(mat.sum(0)) > 0
+        desired_cols = np.asarray((mat.sum(0))).ravel() > 0
         assert_equal(mat[:, desired_cols].A, [[1, 0], [0, 1], [1, 0]])
 
     def test_fancy_indexing_seq_assign(self):

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -404,7 +404,7 @@ def _skew(data):
     """
     skew is third central moment / variance**(1.5)
     """
-    data = np.ravel(data)
+    data = np.asarray(data).ravel()
     mu = data.mean()
     m2 = ((data - mu)**2).mean()
     m3 = ((data - mu)**3).mean()
@@ -415,7 +415,7 @@ def _kurtosis(data):
     """
     kurtosis is fourth central moment / variance**2 - 3
     """
-    data = np.ravel(data)
+    data = np.asarray(data).ravel()
     mu = data.mean()
     m2 = ((data - mu)**2).mean()
     m4 = ((data - mu)**4).mean()

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -211,23 +211,23 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'mode', 'tmean', 'tvar',
 
 
 def _chk_asarray(a, axis):
+    a = np.asarray(a)
     if axis is None:
-        a = np.ravel(a)
+        a = a.ravel()
         outaxis = 0
     else:
-        a = np.asarray(a)
         outaxis = axis
     return a, outaxis
 
 
 def _chk2_asarray(a, b, axis):
+    a = np.asarray(a)
+    b = np.asarray(b)
     if axis is None:
-        a = np.ravel(a)
-        b = np.ravel(b)
+        a = a.ravel()
+        b = b.ravel()
         outaxis = 0
     else:
-        a = np.asarray(a)
-        b = np.asarray(b)
         outaxis = axis
     return a, b, outaxis
 
@@ -623,7 +623,7 @@ def mode(a, axis=0):
 
     """
     a, axis = _chk_asarray(a, axis)
-    scores = np.unique(np.ravel(a))       # get ALL unique values
+    scores = np.unique(a.ravel())       # get ALL unique values
     testshape = list(a.shape)
     testshape[axis] = 1
     oldmostfreq = np.zeros(testshape, dtype=a.dtype)
@@ -1177,7 +1177,7 @@ def skewtest(a, axis=0):
     """
     a, axis = _chk_asarray(a, axis)
     if axis is None:
-        a = np.ravel(a)
+        a = a.ravel()
         axis = 0
     b2 = skew(a, axis)
     n = float(a.shape[axis])
@@ -1691,7 +1691,7 @@ def histogram(a, numbins=10, defaultlimits=None, weights=None, printextras=False
     default if default limits is not set.
 
     """
-    a = np.ravel(a)
+    a = np.asarray(a).ravel()
     if defaultlimits is None:
         # no range given, so use values in `a`
         data_min = a.min()


### PR DESCRIPTION
These problems were revealed by tests against the numpy changes to ravel
to preserve subtypes.  That change will now be special cased for
matrices to avoid backward incompatibilities, but it might be good to
have these fixes in scipy as a guard against the future.

There may be other trouble spots, this only covers those revealed by the scipy tests.
