### PR TITLE
ENH: Make DCT and DST accept int and complex types like fft

### DIFF
--- a/scipy/fftpack/tests/test_real_transforms.py
+++ b/scipy/fftpack/tests/test_real_transforms.py
@@ -25,6 +25,7 @@ FFTWDATA_SIZES = FFTWDATA_DOUBLE['sizes']
 
 def fftw_dct_ref(type, size, dt):
     x = np.linspace(0, size-1, size).astype(dt)
+    dt = np.result_type(np.float32, dt)
     if dt == np.double:
         data = FFTWDATA_DOUBLE
     elif dt == np.float32:
@@ -32,11 +33,12 @@ def fftw_dct_ref(type, size, dt):
     else:
         raise ValueError()
     y = (data['dct_%d_%d' % (type, size)]).astype(dt)
-    return x, y
+    return x, y, dt
 
 
 def fftw_dst_ref(type, size, dt):
     x = np.linspace(0, size-1, size).astype(dt)
+    dt = np.result_type(np.float32, dt)
     if dt == np.double:
         data = FFTWDATA_DOUBLE
     elif dt == np.float32:
@@ -44,7 +46,39 @@ def fftw_dst_ref(type, size, dt):
     else:
         raise ValueError()
     y = (data['dst_%d_%d' % (type, size)]).astype(dt)
-    return x, y
+    return x, y, dt
+
+
+class TestComplex(TestCase):
+    def test_dct_complex64(self):
+        y = dct(1j*np.arange(5, dtype=np.complex64))
+        x = 1j*dct(np.arange(5))
+        assert_array_almost_equal(x, y)
+
+    def test_dct_complex(self):
+        y = dct(np.arange(5)*1j)
+        x = 1j*dct(np.arange(5))
+        assert_array_almost_equal(x, y)
+
+    def test_idct_complex(self):
+        y = idct(np.arange(5)*1j)
+        x = 1j*idct(np.arange(5))
+        assert_array_almost_equal(x, y)
+
+    def test_dst_complex64(self):
+        y = dst(np.arange(5, dtype=np.complex64)*1j)
+        x = 1j*dst(np.arange(5))
+        assert_array_almost_equal(x, y)
+
+    def test_dst_complex(self):
+        y = dst(np.arange(5)*1j)
+        x = 1j*dst(np.arange(5))
+        assert_array_almost_equal(x, y)
+
+    def test_idst_complex(self):
+        y = idst(np.arange(5)*1j)
+        x = 1j*idst(np.arange(5))
+        assert_array_almost_equal(x, y)
 
 
 class _TestDCTBase(TestCase):
@@ -55,9 +89,9 @@ class _TestDCTBase(TestCase):
 
     def test_definition(self):
         for i in FFTWDATA_SIZES:
-            x, yr = fftw_dct_ref(self.type, i, self.rdt)
+            x, yr, dt = fftw_dct_ref(self.type, i, self.rdt)
             y = dct(x, type=self.type)
-            assert_equal(y.dtype, self.rdt)
+            assert_equal(y.dtype, dt)
             # XXX: we divide by np.max(y) because the tests fail otherwise. We
             # should really use something like assert_array_approx_equal. The
             # difference is due to fftw using a better algorithm w.r.t error
@@ -85,10 +119,12 @@ class _TestDCTIIBase(_TestDCTBase):
     def test_definition_matlab(self):
         # Test correspondance with matlab (orthornomal mode).
         for i in range(len(X)):
-            x = np.array(X[i], dtype=self.rdt)
+            dt = np.result_type(np.float32, self.rdt)
+            x = np.array(X[i], dtype=dt)
+
             yr = Y[i]
             y = dct(x, norm="ortho", type=2)
-            assert_equal(y.dtype, self.rdt)
+            assert_equal(y.dtype, dt)
             assert_array_almost_equal(y, yr, decimal=self.dec)
 
 
@@ -97,9 +133,10 @@ class _TestDCTIIIBase(_TestDCTBase):
         # Test orthornomal mode.
         for i in range(len(X)):
             x = np.array(X[i], dtype=self.rdt)
+            dt = np.result_type(np.float32, self.rdt)
             y = dct(x, norm='ortho', type=2)
             xi = dct(y, norm="ortho", type=3)
-            assert_equal(xi.dtype, self.rdt)
+            assert_equal(xi.dtype, dt)
             assert_array_almost_equal(xi, x, decimal=self.dec)
 
 
@@ -113,6 +150,13 @@ class TestDCTIDouble(_TestDCTBase):
 class TestDCTIFloat(_TestDCTBase):
     def setUp(self):
         self.rdt = np.float32
+        self.dec = 5
+        self.type = 1
+
+
+class TestDCTIInt(_TestDCTBase):
+    def setUp(self):
+        self.rdt = np.int
         self.dec = 5
         self.type = 1
 
@@ -131,6 +175,13 @@ class TestDCTIIFloat(_TestDCTIIBase):
         self.type = 2
 
 
+class TestDCTIIInt(_TestDCTIIBase):
+    def setUp(self):
+        self.rdt = np.int
+        self.dec = 5
+        self.type = 2
+
+
 class TestDCTIIIDouble(_TestDCTIIIBase):
     def setUp(self):
         self.rdt = np.double
@@ -145,6 +196,13 @@ class TestDCTIIIFloat(_TestDCTIIIBase):
         self.type = 3
 
 
+class TestDCTIIIInt(_TestDCTIIIBase):
+    def setUp(self):
+        self.rdt = np.int
+        self.dec = 5
+        self.type = 3
+
+
 class _TestIDCTBase(TestCase):
     def setUp(self):
         self.rdt = None
@@ -153,13 +211,13 @@ class _TestIDCTBase(TestCase):
 
     def test_definition(self):
         for i in FFTWDATA_SIZES:
-            xr, yr = fftw_dct_ref(self.type, i, self.rdt)
+            xr, yr, dt = fftw_dct_ref(self.type, i, self.rdt)
             x = idct(yr, type=self.type)
             if self.type == 1:
                 x /= 2 * (i-1)
             else:
                 x /= 2 * i
-            assert_equal(x.dtype, self.rdt)
+            assert_equal(x.dtype, dt)
             # XXX: we divide by np.max(y) because the tests fail otherwise. We
             # should really use something like assert_array_approx_equal. The
             # difference is due to fftw using a better algorithm w.r.t error
@@ -182,6 +240,13 @@ class TestIDCTIFloat(_TestIDCTBase):
         self.type = 1
 
 
+class TestIDCTIInt(_TestIDCTBase):
+    def setUp(self):
+        self.rdt = np.int
+        self.dec = 4
+        self.type = 1
+
+
 class TestIDCTIIDouble(_TestIDCTBase):
     def setUp(self):
         self.rdt = np.double
@@ -192,6 +257,13 @@ class TestIDCTIIDouble(_TestIDCTBase):
 class TestIDCTIIFloat(_TestIDCTBase):
     def setUp(self):
         self.rdt = np.float32
+        self.dec = 5
+        self.type = 2
+
+
+class TestIDCTIIInt(_TestIDCTBase):
+    def setUp(self):
+        self.rdt = np.int
         self.dec = 5
         self.type = 2
 
@@ -210,6 +282,13 @@ class TestIDCTIIIFloat(_TestIDCTBase):
         self.type = 3
 
 
+class TestIDCTIIIInt(_TestIDCTBase):
+    def setUp(self):
+        self.rdt = np.int
+        self.dec = 5
+        self.type = 3
+
+
 class _TestDSTBase(TestCase):
     def setUp(self):
         self.rdt = None  # dtype
@@ -218,9 +297,9 @@ class _TestDSTBase(TestCase):
 
     def test_definition(self):
         for i in FFTWDATA_SIZES:
-            xr, yr = fftw_dst_ref(self.type, i, self.rdt)
+            xr, yr, dt = fftw_dst_ref(self.type, i, self.rdt)
             y = dst(xr, type=self.type)
-            assert_equal(y.dtype, self.rdt)
+            assert_equal(y.dtype, dt)
             # XXX: we divide by np.max(y) because the tests fail otherwise. We
             # should really use something like assert_array_approx_equal. The
             # difference is due to fftw using a better algorithm w.r.t error
@@ -243,6 +322,13 @@ class TestDSTIFloat(_TestDSTBase):
         self.type = 1
 
 
+class TestDSTIInt(_TestDSTBase):
+    def setUp(self):
+        self.rdt = np.int
+        self.dec = 5
+        self.type = 1
+
+
 class TestDSTIIDouble(_TestDSTBase):
     def setUp(self):
         self.rdt = np.double
@@ -253,6 +339,13 @@ class TestDSTIIDouble(_TestDSTBase):
 class TestDSTIIFloat(_TestDSTBase):
     def setUp(self):
         self.rdt = np.float32
+        self.dec = 6
+        self.type = 2
+
+
+class TestDSTIIInt(_TestDSTBase):
+    def setUp(self):
+        self.rdt = np.int
         self.dec = 6
         self.type = 2
 
@@ -271,6 +364,13 @@ class TestDSTIIIFloat(_TestDSTBase):
         self.type = 3
 
 
+class TestDSTIIIInt(_TestDSTBase):
+    def setUp(self):
+        self.rdt = np.int
+        self.dec = 7
+        self.type = 3
+
+
 class _TestIDSTBase(TestCase):
     def setUp(self):
         self.rdt = None
@@ -279,13 +379,13 @@ class _TestIDSTBase(TestCase):
 
     def test_definition(self):
         for i in FFTWDATA_SIZES:
-            xr, yr = fftw_dst_ref(self.type, i, self.rdt)
+            xr, yr, dt = fftw_dst_ref(self.type, i, self.rdt)
             x = idst(yr, type=self.type)
             if self.type == 1:
                 x /= 2 * (i+1)
             else:
                 x /= 2 * i
-            assert_equal(x.dtype, self.rdt)
+            assert_equal(x.dtype, dt)
             # XXX: we divide by np.max(x) because the tests fail otherwise. We
             # should really use something like assert_array_approx_equal. The
             # difference is due to fftw using a better algorithm w.r.t error
@@ -308,6 +408,13 @@ class TestIDSTIFloat(_TestIDSTBase):
         self.type = 1
 
 
+class TestIDSTIInt(_TestIDSTBase):
+    def setUp(self):
+        self.rdt = np.int
+        self.dec = 4
+        self.type = 1
+
+
 class TestIDSTIIDouble(_TestIDSTBase):
     def setUp(self):
         self.rdt = np.double
@@ -322,6 +429,13 @@ class TestIDSTIIFloat(_TestIDSTBase):
         self.type = 2
 
 
+class TestIDSTIIInt(_TestIDSTBase):
+    def setUp(self):
+        self.rdt = np.int
+        self.dec = 6
+        self.type = 2
+
+
 class TestIDSTIIIDouble(_TestIDSTBase):
     def setUp(self):
         self.rdt = np.double
@@ -332,6 +446,13 @@ class TestIDSTIIIDouble(_TestIDSTBase):
 class TestIDSTIIIFloat(_TestIDSTBase):
     def setUp(self):
         self.rdt = np.float32
+        self.dec = 6
+        self.type = 3
+
+
+class TestIDSTIIIInt(_TestIDSTBase):
+    def setUp(self):
+        self.rdt = np.int
         self.dec = 6
         self.type = 3
 


### PR DESCRIPTION
The dct and dst functions should upcast int types to float automatically.

This is similar to #2776, but with tests.

Also replaced if/elif chains with a dict in the _dst and _dct functions in order to make the code more compact and added the padding/truncation option which was missing. The code now also supports complex input.
