### PR TITLE
ENH: optimize, returning True from callback function halts minimization

### DIFF
--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -6,6 +6,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy import cos, sin
 import scipy.optimize
+from scipy.optimize.optimize import _status_message
 import collections
 
 __all__ = ['basinhopping']
@@ -617,8 +618,7 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
             val = callback(bh.xtrial, bh.energy_trial, bh.accept)
             if val is not None:
                 if val:
-                    message = ["callback function requested stop early by"
-                               "returning True"]
+                    message = _status_message['halted']
                     break
 
         count += 1

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -519,8 +519,7 @@ class DifferentialEvolutionSolver(object):
                                   convergence=self.tol / convergence) is True):
 
                 warning_flag = True
-                status_message = ('callback function requested stop early '
-                                  'by returning True')
+                status_message = _status_message['halted']
                 break
 
             if convergence < self.tol or warning_flag:

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -115,7 +115,8 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         For method-specific options, see :func:`show_options()`.
     callback : callable, optional
         Called after each iteration, as ``callback(xk)``, where ``xk`` is the
-        current parameter vector.
+        current parameter vector.  If ``callback`` returns `True` then the
+        minimization is halted.
 
     Returns
     -------

--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -205,9 +205,13 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
         # append the best guess, call back, increment the iteration count
         if return_all:
             allvecs.append(x)
-        if callback is not None:
-            callback(x)
         k += 1
+
+        if callback is not None:
+            ret = callback(x)
+            if ret is True:
+                warnflag = 4
+                break
 
         # check if the gradient is small enough to stop
         if m.jac_mag < gtol:
@@ -225,6 +229,7 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
             _status_message['maxiter'],
             'A bad approximation caused failure to predict improvement.',
             'A linalg error occurred, such as a non-psd Hessian.',
+            _status_message['halted']
             )
     if disp:
         if warnflag == 0:

--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -300,7 +300,7 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
     task[:] = 'START'
 
     n_iterations = 0
-    warnflag=0
+    warnflag = 0
     while 1:
         # x, f, g, wa, iwa, task, csave, lsave, isave, dsave = \
         _lbfgsb.setulb(m, x, low_bnd, upper_bnd, nbd, f, g, factr,

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -454,7 +454,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     sim = numpy.take(sim, ind, 0)
 
     iterations = 1
-    msg=''
+    msg = ''
 
     while (fcalls[0] < maxfun and iterations < maxiter):
         if (numpy.max(numpy.ravel(numpy.abs(sim[1:] - sim[0]))) <= xtol and
@@ -2361,7 +2361,7 @@ def _minimize_powell(func, x0, args=(), callback=None,
     x1 = x.copy()
     iter = 0
     ilist = list(range(N))
-    msg=''
+    msg = ''
     while True:
         fx = fval
         bigind = 0

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -10,6 +10,7 @@ import numpy as np
 from numpy import cos, sin
 
 from scipy.optimize import basinhopping
+from scipy.optimize.optimize import _status_message
 from scipy.optimize._basinhopping import (
     Storage, RandomDisplacement, Metropolis, AdaptiveStepsize)
 
@@ -237,7 +238,7 @@ class TestBasinHopping(TestCase):
         res = basinhopping(func2d, self.x0[i], minimizer_kwargs=self.kwargs,
                            niter=30, disp=self.disp, callback=callback)
         assert_(callback.been_called)
-        assert_("callback" in res.message[0])
+        assert_(res.message, _status_message['halted'])
         assert_equal(res.nit, 10)
 
     def test_minimizer_fail(self):

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -6,6 +6,7 @@ from scipy.optimize._differentialevolution import DifferentialEvolutionSolver
 from scipy.optimize import differential_evolution
 import numpy as np
 from scipy.optimize import rosen
+from scipy.optimize.optimize import _status_message
 from numpy.testing import (assert_equal, TestCase, assert_allclose,
                            run_module_suite, assert_almost_equal,
                            assert_string_equal)
@@ -211,8 +212,7 @@ class TestDifferentialEvolutionSolver(TestCase):
         result = differential_evolution(rosen, bounds, callback=callback)
 
         assert_string_equal(result.message,
-                                'callback function requested stop early '
-                                'by returning True')
+                            _status_message['halted'])
 
     def test_args_tuple_is_passed(self):
         # test that the args tuple is passed to the cost function properly.

--- a/scipy/optimize/tests/test_callback_halts.py
+++ b/scipy/optimize/tests/test_callback_halts.py
@@ -1,0 +1,67 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+from scipy.optimize import (rosen, differential_evolution, basinhopping,
+                            minimize, rosen_der, rosen_hess, rosen_hess_prod)
+from scipy.optimize.optimize import _status_message
+from numpy.testing import (TestCase, run_module_suite, assert_)
+import warnings
+
+halt_message = _status_message['halted']
+methods = ['Nelder-Mead', 'Powell', 'CG', 'BFGS', 'Newton-CG', 'L-BFGS-B',
+           'TNC', 'COBYLA', 'SLSQP', 'dogleg', 'trust-ncg']
+
+class Callback(object):
+    def __init__(self):
+        self.iter = 0
+
+    def callback(self, x0, *args, **kwds):
+        self.iter += 1
+        if self.iter == 2:
+            return True
+        else:
+            return False
+
+
+class TestCallbackHaltsMinimizer(TestCase):
+    #check that returning True from the callback stops all the minimizers
+
+    def setUp(self):
+        self.x0 = [5, 5]
+        self.func = rosen
+        self.jac = rosen_der
+        self.hess = rosen_hess
+        self.bounds = [(0., 10.), (0., 10.)]
+        self.Tcallback = Callback()
+        self.callback = self.Tcallback.callback
+
+    def test_diffev(self):
+        res = differential_evolution(self.func, self.bounds,
+                                     callback=self.callback)
+        assert_(res.message == halt_message)
+        assert_(self.Tcallback.iter == 2)
+
+    def test_basin(self):
+        res = basinhopping(self.func, self.x0,
+                                     callback=self.callback)
+        assert_(res.message == halt_message)
+        assert_(self.Tcallback.iter == 2)
+
+    def test_minimizer(self):
+        for method in methods:
+            #TODO TNC
+            if method in ['TNC', 'COBYLA']:
+                continue
+
+            self.Tcallback.iter = 0
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                res = minimize(self.func, self.x0, method=method,
+                               callback=self.callback, jac=self.jac,
+                               hess=rosen_hess, hessp=rosen_hess_prod)
+            assert_(res.message == halt_message)
+            assert_(self.Tcallback.iter == 2)
+
+
+if __name__ == '__main__':
+    run_module_suite()


### PR DESCRIPTION
If the `callback` functions in scipy.optimize return `True`, then the minimization halts.
I have not modified `optimize.TNC` because the `callback` function is called in the Fortran somewhere.
