### PR TITLE
ENH: optimize: add DF-SANE nonlinear derivative-free solver

### DIFF
--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -17,6 +17,7 @@ from warnings import warn
 
 from .optimize import MemoizeJac, OptimizeResult, _check_unknown_options
 from .minpack import _root_hybr, leastsq
+from ._spectral import _root_df_sane
 from . import nonlin
 
 
@@ -45,6 +46,7 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
             - 'diagbroyden'
             - 'excitingmixing'
             - 'krylov'
+            - 'df-sane'
 
     jac : bool or callable, optional
         If `jac` is a Boolean and is True, `fun` is assumed to return the
@@ -88,6 +90,8 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
     sense using a modification of the Levenberg-Marquardt algorithm as
     implemented in MINPACK [1]_.
 
+    Method *df-sane* is a derivative-free spectral method. [3]_
+
     Methods *broyden1*, *broyden2*, *anderson*, *linearmixing*,
     *diagbroyden*, *excitingmixing*, *krylov* are inexact Newton methods,
     with backtracking or full line searches [2]_. Each method corresponds
@@ -121,6 +125,7 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
     .. [2] C. T. Kelley. 1995. Iterative Methods for Linear and Nonlinear
         Equations. Society for Industrial and Applied Mathematics.
         <http://www.siam.org/books/kelley/>
+    .. [3] W. La Cruz, J.M. Martinez, M. Raydan. Math. Comp. 75, 1429 (2006).
 
     Examples
     --------
@@ -168,6 +173,8 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
         options = dict(options)
         if meth in ('hybr', 'lm'):
             options.setdefault('xtol', tol)
+        elif meth in ('df-sane',):
+            options.setdefault('ftol', tol)
         elif meth in ('broyden1', 'broyden2', 'anderson', 'linearmixing',
                       'diagbroyden', 'excitingmixing', 'krylov'):
             options.setdefault('xtol', tol)
@@ -179,6 +186,8 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
         sol = _root_hybr(fun, x0, args=args, jac=jac, **options)
     elif meth == 'lm':
         sol = _root_leastsq(fun, x0, args=args, jac=jac, **options)
+    elif meth == 'df-sane':
+        sol = _root_df_sane(fun, x0, args=args, jac=jac, **options)
     elif meth in ('broyden1', 'broyden2', 'anderson', 'linearmixing',
                   'diagbroyden', 'excitingmixing', 'krylov'):
         if jac is not None:

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -187,12 +187,12 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
     elif meth == 'lm':
         sol = _root_leastsq(fun, x0, args=args, jac=jac, **options)
     elif meth == 'df-sane':
-        sol = _root_df_sane(fun, x0, args=args, jac=jac, **options)
+        _warn_jac_unused(jac, method)
+        sol = _root_df_sane(fun, x0, args=args, callback=callback,
+                            **options)
     elif meth in ('broyden1', 'broyden2', 'anderson', 'linearmixing',
                   'diagbroyden', 'excitingmixing', 'krylov'):
-        if jac is not None:
-            warn('Method %s does not use the jacobian (jac).' % method,
-                 RuntimeWarning)
+        _warn_jac_unused(jac, method)
         sol = _root_nonlin_solve(fun, x0, args=args, jac=jac,
                                  _method=meth, _callback=callback,
                                  **options)
@@ -200,6 +200,12 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
         raise ValueError('Unknown solver %s' % method)
 
     return sol
+
+
+def _warn_jac_unused(jac, method):
+    if jac is not None:
+        warn('Method %s does not use the jacobian (jac).' % (method,),
+             RuntimeWarning)
 
 
 def _root_leastsq(func, x0, args=(), jac=None,

--- a/scipy/optimize/_spectral.py
+++ b/scipy/optimize/_spectral.py
@@ -44,7 +44,7 @@ def _root_df_sane(func, x0, args=(), jac=None, ftol=1e-8, fatol=1e-300, maxfev=1
         Maximum number of function evaluations.
     disp : bool, optional
         Whether to print convergence process to stdout.
-    eta_stragegy : callable, optional
+    eta_strategy : callable, optional
         Choice of the ``eta_k`` parameter, which gives slack for growth
         of ``||F||**2``.  Called as ``eta_k = eta_strategy(k, x, F)`` with
         `k` the iteration number, `x` the current iterate and `F` the current
@@ -83,6 +83,7 @@ def _root_df_sane(func, x0, args=(), jac=None, ftol=1e-8, fatol=1e-300, maxfev=1
         #
         # Now, prod(1 + 1/(1 + k)**2, k=0..inf) = sinh(pi)/(2*pi) < inf.
         def eta_strategy(k, x, F):
+            # Avoid recomputing 2-norm of F by reusing f_k from the outer scope
             return f_k / (1 + k)**2
 
     func, x0, x0_shape, F_k, is_complex = _wrap_func(func, x0, args)

--- a/scipy/optimize/_spectral.py
+++ b/scipy/optimize/_spectral.py
@@ -3,19 +3,20 @@ Spectral Algorithm for Nonlinear Equations
 """
 from __future__ import division, absolute_import, print_function
 
-import warnings
+import collections
+
 import numpy as np
 from scipy.optimize import OptimizeResult
-from scipy.optimize.optimize import _check_unknown_options, OptimizeWarning
-from .linesearch import _nonmonotone_line_search_cruz
+from scipy.optimize.optimize import _check_unknown_options
+from .linesearch import _nonmonotone_line_search_cruz, _nonmonotone_line_search_cheng
 
 class _NoConvergence(Exception):
     pass
 
 
-def _root_df_sane(func, x0, args=(), jac=None, ftol=1e-8, fatol=1e-300, maxfev=1000,
+def _root_df_sane(func, x0, args=(), ftol=1e-8, fatol=1e-300, maxfev=1000,
                   fnorm=None, callback=None, disp=False, M=10, eta_strategy=None,
-                  sigma_eps=1e-10, sigma_0=1.0, **unknown_options):
+                  sigma_eps=1e-10, sigma_0=1.0, line_search='cruz', **unknown_options):
     r"""
     Solve nonlinear equation with the DF-SANE method
 
@@ -27,8 +28,6 @@ def _root_df_sane(func, x0, args=(), jac=None, ftol=1e-8, fatol=1e-300, maxfev=1
         Initial guess
     args : tuple
         Extra parameters to `func`
-    jac
-        Unused, this is a derivative-free solver
     ftol : float, optional
         Relative norm tolerance.
     fatol : float, optional
@@ -57,8 +56,12 @@ def _root_df_sane(func, x0, args=(), jac=None, ftol=1e-8, fatol=1e-300, maxfev=1
         Initial spectral coefficient.
         Default: 1.0
     M : int, optional
-        Number of iterates to include in the nonmonotonic line search.
+        Number of iterates to include in the 'cruz' nonmonotonic line search.
         Default: 10
+    line_search : {'cruz', 'cheng'}
+        Type of line search to employ. 'cruz' is the original one defined in [1],
+        'cheng' is a modified search defined in [3].
+        Default: 'cruz'
 
     References
     ----------
@@ -66,11 +69,13 @@ def _root_df_sane(func, x0, args=(), jac=None, ftol=1e-8, fatol=1e-300, maxfev=1
            large-scale nonlinear systems of equations." W. La Cruz,
            J.M. Martinez, M. Raydan. Math. Comp. **75**, 1429 (2006).
     .. [2] W. La Cruz, Opt. Meth. Software, 29, 24 (2014).
+    .. [3] W. Cheng, D.-H. Li. IMA J. Numer. Anal. **29**, 814 (2009).
 
     """
     _check_unknown_options(unknown_options)
-    if jac is not None:
-        warnings.warn("DF-SANE solver does not use a Jacobian", category=OptimizeWarning)
+
+    if line_search not in ('cheng', 'cruz'):
+        raise ValueError("Invalid value %r for 'line_search'" % (line_search,))
 
     nexp = 2
 
@@ -81,31 +86,29 @@ def _root_df_sane(func, x0, args=(), jac=None, ftol=1e-8, fatol=1e-300, maxfev=1
             # Obtain squared 2-norm of the initial residual from the outer scope
             return f_0 / (1 + k)**2
 
-    func, x0, x0_shape, F_k, is_complex = _wrap_func(func, x0, args)
+    if fnorm is None:
+        def fnorm(F):
+            # Obtain squared 2-norm of the current residual from the outer scope
+            return f_k**(1.0/nexp)
 
-    def f(x):
-        if nfev[0] >= maxfev:
-            raise _NoConvergence()
+    def fmerit(F):
+        return np.linalg.norm(F)**nexp
 
-        F = func(x)
-        f = np.linalg.norm(F)**nexp
-        nfev[0] += 1
-        return f, F
-
-    nfev = [1]
+    nfev = [0]
+    f, x_k, x_shape, f_k, F_k, is_complex = _wrap_func(func, x0, fmerit, nfev, maxfev, args)
 
     k = 0
-    x_k = x0
-    f_k = np.linalg.norm(F_k)**nexp
     f_0 = f_k
     sigma_k = sigma_0
 
-    if fnorm is None:
-        def fnorm(F):
-            return f_k**(1.0/nexp)
-
-    prev_fs = [f_k]
     F_0_norm = fnorm(F_k)
+
+    # For the 'cruz' line search
+    prev_fs = collections.deque([f_k], M)
+
+    # For the 'cheng' line search
+    Q = 1.0
+    C = f_0
 
     converged = False
     message = "too many function evaluations required"
@@ -137,7 +140,10 @@ def _root_df_sane(func, x0, args=(), jac=None, ftol=1e-8, fatol=1e-300, maxfev=1
         # Nonmonotone line search
         eta = eta_strategy(k, x_k, F_k)
         try:
-            alpha, xp, fp, Fp = _nonmonotone_line_search_cruz(f, x_k, d, prev_fs, eta=eta)
+            if line_search == 'cruz':
+                alpha, xp, fp, Fp = _nonmonotone_line_search_cruz(f, x_k, d, prev_fs, eta=eta)
+            elif line_search == 'cheng':
+                alpha, xp, fp, Fp, C, Q = _nonmonotone_line_search_cheng(f, x_k, d, f_k, C, Q, eta=eta)
         except _NoConvergence:
             break
 
@@ -152,14 +158,13 @@ def _root_df_sane(func, x0, args=(), jac=None, ftol=1e-8, fatol=1e-300, maxfev=1
         f_k = fp
 
         # Store function value
-        prev_fs.append(fp)
-        if len(prev_fs) > M:
-            prev_fs.pop(0)
+        if line_search == 'cruz':
+            prev_fs.append(fp)
 
         k += 1
 
-    x = _wrap_complex_result(x_k, is_complex, shape=x0_shape)
-    F = _wrap_complex_result(F_k, is_complex)
+    x = _wrap_result(x_k, is_complex, shape=x_shape)
+    F = _wrap_result(F_k, is_complex)
 
     result = OptimizeResult(x=x, success=converged,
                             message=message,
@@ -168,38 +173,84 @@ def _root_df_sane(func, x0, args=(), jac=None, ftol=1e-8, fatol=1e-300, maxfev=1
     return result
 
 
-def _real2complex(x):
-    return np.ascontiguousarray(x, dtype=float).view(np.complex128)
+def _wrap_func(func, x0, fmerit, nfev_list, maxfev, args=()):
+    """
+    Wrap a function and an initial value so that (i) complex values
+    are wrapped to reals, and (ii) value for a merit function
+    fmerit(x, f) is computed at the same time, (iii) iteration count
+    is maintained and an exception is raised if it is exceeded.
 
+    Parameters
+    ----------
+    func : callable
+        Function to wrap
+    x0 : ndarray
+        Initial value
+    fmerit : callable
+        Merit function fmerit(f) for computing merit value from residual.
+    nfev_list : list
+        List to store number of evaluations in. Should be [0] in the beginning.
+    maxfev : int
+        Maximum number of evaluations before _NoConvergence is raised.
+    args : tuple
+        Extra arguments to func
 
-def _complex2real(z):
-    return np.ascontiguousarray(z, dtype=complex).view(np.float64)
+    Returns
+    -------
+    wrap_func : callable
+        Wrapped function, to be called as
+        ``F, fp = wrap_func(x0)``
+    x0_wrap : ndarray of float
+        Wrapped initial value; raveled to 1D and complex
+        values mapped to reals.
+    x0_shape : tuple
+        Shape of the initial value array
+    f : float
+        Merit function at F
+    F : ndarray of float
+        Residual at x0_wrap
+    is_complex : bool
+        Whether complex values were mapped to reals
 
-
-def _wrap_func(func, x0, args=()):
+    """
     x0 = np.asarray(x0)
     x0_shape = x0.shape
     F = np.asarray(func(x0, *args)).ravel()
     is_complex = np.iscomplexobj(x0) or np.iscomplexobj(F)
     x0 = x0.ravel()
 
+    nfev_list[0] = 1
+
     if is_complex:
         def wrap_func(x):
+            if nfev_list[0] >= maxfev:
+                raise _NoConvergence()
+            nfev_list[0] += 1
             z = _real2complex(x).reshape(x0_shape)
             v = np.asarray(func(z, *args)).ravel()
-            return _complex2real(v)
+            F = _complex2real(v)
+            f = fmerit(F)
+            return f, F
 
         x0 = _complex2real(x0)
         F = _complex2real(F)
     else:
-        def wrap_func(x, *a, **kw):
+        def wrap_func(x):
+            if nfev_list[0] >= maxfev:
+                raise _NoConvergence()
+            nfev_list[0] += 1
             x = x.reshape(x0_shape)
-            return np.asarray(func(x, *args)).ravel()
+            F = np.asarray(func(x, *args)).ravel()
+            f = fmerit(F)
+            return f, F
 
-    return wrap_func, x0, x0_shape, F, is_complex
+    return wrap_func, x0, x0_shape, fmerit(F), F, is_complex
 
 
-def _wrap_complex_result(result, is_complex, shape=None):
+def _wrap_result(result, is_complex, shape=None):
+    """
+    Convert from real to complex and reshape result arrays.
+    """
     if is_complex:
         z = _real2complex(result)
     else:
@@ -207,3 +258,11 @@ def _wrap_complex_result(result, is_complex, shape=None):
     if shape is not None:
         z = z.reshape(shape)
     return z
+
+
+def _real2complex(x):
+    return np.ascontiguousarray(x, dtype=float).view(np.complex128)
+
+
+def _complex2real(z):
+    return np.ascontiguousarray(z, dtype=complex).view(np.float64)

--- a/scipy/optimize/_spectral.py
+++ b/scipy/optimize/_spectral.py
@@ -1,0 +1,212 @@
+"""
+Spectral Algorithm for Nonlinear Equations
+"""
+from __future__ import division, absolute_import, print_function
+
+import warnings
+import numpy as np
+from scipy.optimize import OptimizeResult
+from scipy.optimize.optimize import _check_unknown_options, OptimizeWarning
+from .linesearch import _nonmonotone_line_search_cruz
+
+class _NoConvergence(Exception):
+    pass
+
+
+def _root_df_sane(func, x0, args=(), jac=None, ftol=1e-8, fatol=1e-300, maxfev=1000,
+                  fnorm=None, callback=None, disp=False, M=None, eta_strategy=None,
+                  **unknown_options):
+    r"""
+    Solve nonlinear equation with the DF-SANE method
+
+    Parameters
+    ----------
+    func : callable
+        Function whose root to find
+    x0 : ndarray
+        Initial guess
+    args : tuple
+        Extra parameters to `func`
+    jac
+        Unused, this is a derivative-free solver
+    ftol : float, optional
+        Relative norm tolerance.
+    fatol : float, optional
+        Absolute norm tolerance.
+        Algorithm terminates when ``||func(x)|| < fatol + ftol ||func(x_0)||``.
+    fnorm : callable, optional
+        Norm to use in the convergence check. If None, 2-norm is used.
+    callback : callable, optional
+        Callback function to call on each iteration. Called as
+        ``callable(x, f)`` where ``x`` is the current iterate and
+        ``f`` the residual.
+    maxfev : int, optional
+        Maximum number of function evaluations.
+    disp : bool, optional
+        Whether to print convergence process to stdout.
+    eta_stragegy : callable, optional
+        Choice of the ``eta_k`` parameter, which gives slack for growth
+        of ``||F||**2``.  Called as ``eta_k = eta_strategy(k, x, F)`` with
+        `k` the iteration number, `x` the current iterate and `F` the current
+        residual. Should satisfy ``eta_k > 0`` and ``sum(eta, k=0..inf) < inf``.
+        Default: ``||F||**2 / (1 + k)**2``.
+    M : int, optional
+        Number of iterates to include in the nonmonotonic line search.
+        Default: 10
+
+    References
+    ----------
+    .. [1] "Spectral residual method without gradient information for solving
+           large-scale nonlinear systems of equations." W. La Cruz,
+           J.M. Martinez, M. Raydan. Math. Comp. **75**, 1429 (2006).
+    .. [2] W. La Cruz, Opt. Meth. Software, 29, 24 (2014).
+
+    """
+    _check_unknown_options(unknown_options)
+    if jac is not None:
+        warnings.warn("DF-SANE solver does not use a Jacobian", category=OptimizeWarning)
+
+    nexp = 2
+    sigma_eps = 1e-10
+
+    if M is None:
+        M = 10
+
+    if eta_strategy is None:
+        # Different choice from [1], as their eta is not invariant
+        # vs. scaling of F.
+        #
+        # This choice satisfies the requirements in the paper.  f_k is
+        # bounded: the maximum allowed by the line search is
+        #
+        #     f_{k+1} = f_k * [1 + 1 / (1 + k)**2]
+        #
+        # Now, prod(1 + 1/(1 + k)**2, k=0..inf) = sinh(pi)/(2*pi) < inf.
+        def eta_strategy(k, x, F):
+            return f_k / (1 + k)**2
+
+    func, x0, x0_shape, F_k, is_complex = _wrap_func(func, x0, args)
+
+    def f(x):
+        if nfev[0] >= maxfev:
+            raise _NoConvergence()
+
+        F = func(x)
+        f = np.linalg.norm(F)**nexp
+        nfev[0] += 1
+        return f, F
+
+    nfev = [1]
+
+    k = 0
+    x_k = x0
+    f_k = np.linalg.norm(F_k)**nexp
+    sigma_k = 1.0
+
+    if fnorm is None:
+        def fnorm(F):
+            return f_k**(1.0/nexp)
+
+    prev_fs = [f_k]
+    F_0_norm = fnorm(F_k)
+
+    converged = False
+    message = "too many function evaluations required"
+
+    while True:
+        F_k_norm = fnorm(F_k)
+
+        if disp:
+            print("iter %d: ||F|| = %g, sigma = %g" % (k, F_k_norm, sigma_k))
+
+        if callback is not None:
+            callback(x_k, F_k)
+
+        if F_k_norm < ftol * F_0_norm + fatol:
+            # Converged!
+            message = "successful convergence"
+            converged = True
+            break
+
+        # Control spectral parameter, from [2]
+        if abs(sigma_k) > 1/sigma_eps:
+            sigma_k = 1/sigma_eps * np.sign(sigma_k)
+        elif abs(sigma_k) < sigma_eps:
+            sigma_k = sigma_eps
+
+        # Line search direction
+        d = -sigma_k * F_k
+
+        # Nonmonotone line search
+        eta = eta_strategy(k, x_k, F_k)
+        try:
+            alpha, xp, fp, Fp = _nonmonotone_line_search_cruz(f, x_k, d, prev_fs, eta=eta)
+        except _NoConvergence:
+            break
+
+        # Update spectral parameter
+        s_k = xp - x_k
+        y_k = Fp - F_k
+        sigma_k = np.vdot(s_k, s_k) / np.vdot(s_k, y_k)
+
+        # Take step
+        x_k = xp
+        F_k = Fp
+        f_k = fp
+
+        # Store function value
+        prev_fs.append(fp)
+        if len(prev_fs) > M:
+            prev_fs.pop(0)
+
+        k += 1
+
+    x = _wrap_complex_result(x_k, is_complex, shape=x0_shape)
+    F = _wrap_complex_result(F_k, is_complex)
+
+    result = OptimizeResult(x=x, success=converged,
+                            message=message,
+                            fun=F, nfev=nfev[0], nit=k)
+
+    return result
+
+
+def _real2complex(x):
+    return np.ascontiguousarray(x, dtype=float).view(np.complex128)
+
+
+def _complex2real(z):
+    return np.ascontiguousarray(z, dtype=complex).view(np.float64)
+
+
+def _wrap_func(func, x0, args=()):
+    x0 = np.asarray(x0)
+    x0_shape = x0.shape
+    F = np.asarray(func(x0, *args)).ravel()
+    is_complex = np.iscomplexobj(x0) or np.iscomplexobj(F)
+    x0 = x0.ravel()
+
+    if is_complex:
+        def wrap_func(x):
+            z = _real2complex(x).reshape(x0_shape)
+            v = np.asarray(func(z, *args)).ravel()
+            return _complex2real(v)
+
+        x0 = _complex2real(x0)
+        F = _complex2real(F)
+    else:
+        def wrap_func(x, *a, **kw):
+            x = x.reshape(x0_shape)
+            return np.asarray(func(x, *args)).ravel()
+
+    return wrap_func, x0, x0_shape, F, is_complex
+
+
+def _wrap_complex_result(result, is_complex, shape=None):
+    if is_complex:
+        z = _real2complex(result)
+    else:
+        z = result
+    if shape is not None:
+        z = z.reshape(shape)
+    return z

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -734,3 +734,84 @@ def _nonmonotone_line_search_cruz(f, x_k, d, prev_fs, eta,
         alpha_m = np.clip(alpha_tm, tau_min * alpha_m, tau_max * alpha_m)
 
     return alpha, xp, fp, Fp
+
+
+def _nonmonotone_line_search_cheng(f, x_k, d, f_k, C, Q, eta,
+                                   gamma=1e-4, tau_min=0.1, tau_max=0.5,
+                                   nu=0.85):
+    """
+    Nonmonotone line search from [1]
+
+    Parameters
+    ----------
+    f : callable
+        Function returning a tuple ``(f, F)`` where ``f`` is the value
+        of a merit function and ``F`` the residual.
+    x_k : ndarray
+        Initial position
+    d : ndarray
+        Search direction
+    f_k : float
+        Initial merit function value
+    C, Q : float
+        Control parameters. On the first iteration, give values
+        Q=1.0, C=f_k
+    eta : float
+        Allowed merit function increase, see [1]_
+    nu, gamma, tau_min, tau_max : float, optional
+        Search parameters, see [1]_
+
+    Returns
+    -------
+    alpha : float
+        Step length
+    xp : ndarray
+        Next position
+    fp : float
+        Merit function value at next position
+    Fp : ndarray
+        Residual at next position
+    C : float
+        New value for the control parameter C
+    Q : float
+        New value for the control parameter Q
+
+    References
+    ----------
+    .. [1] W. Cheng & D.-H. Li, ''A derivative-free nonmonotone line
+           search and its application to the spectral residual
+           method'', IMA J. Numer. Anal. 29, 814 (2009).
+
+    """
+    alpha_p = 1
+    alpha_m = 1
+    alpha = 1
+
+    while True:
+        xp = x_k + alpha_p * d
+        fp, Fp = f(xp)
+
+        if fp <= C + eta - gamma * alpha_p**2 * f_k:
+            alpha = alpha_p
+            break
+
+        alpha_tp = alpha_p**2 * f_k / (fp + (2*alpha_p - 1)*f_k)
+
+        xp = x_k - alpha_m * d
+        fp, Fp = f(xp)
+
+        if fp <= C + eta - gamma * alpha_m**2 * f_k:
+            alpha = -alpha_m
+            break
+
+        alpha_tm = alpha_m**2 * f_k / (fp + (2*alpha_m - 1)*f_k)
+
+        alpha_p = np.clip(alpha_tp, tau_min * alpha_p, tau_max * alpha_p)
+        alpha_m = np.clip(alpha_tm, tau_min * alpha_m, tau_max * alpha_m)
+
+    # Update C and Q
+    Q_next = nu * Q + 1
+    C = (nu * Q * (C + eta) + fp) / Q_next
+    Q = Q_next
+
+    return alpha, xp, fp, Fp, C, Q

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -658,3 +658,79 @@ def scalar_search_armijo(phi, phi0, derphi0, c1=1e-4, alpha0=1, amin=0):
 
     # Failed to find a suitable step length
     return None, phi_a1
+
+
+#------------------------------------------------------------------------------
+# Non-monotone line search for DF-SANE
+#------------------------------------------------------------------------------
+
+def _nonmonotone_line_search_cruz(f, x_k, d, prev_fs, eta,
+                                  gamma=1e-4, tau_min=0.1, tau_max=0.5):
+    """
+    Nonmonotone backtracking line search as described in [1]_
+
+    Parameters
+    ----------
+    f : callable
+        Function returning a tuple ``(f, F)`` where ``f`` is the value
+        of a merit function and ``F`` the residual.
+    x_k : ndarray
+        Initial position
+    d : ndarray
+        Search direction
+    prev_fs : float
+        List of previous merit function values. Should have ``len(prev_fs) <= M``
+        where ``M`` is the nonmonotonicity window parameter.
+    eta : float
+        Allowed merit function increase, see [1]_
+    gamma, tau_min, tau_max : float, optional
+        Search parameters, see [1]_
+
+    Returns
+    -------
+    alpha : float
+        Step length
+    xp : ndarray
+        Next position
+    fp : float
+        Merit function value at next position
+    Fp : ndarray
+        Residual at next position
+
+    References
+    ----------
+    [1] "Spectral residual method without gradient information for solving
+        large-scale nonlinear systems of equations." W. La Cruz,
+        J.M. Martinez, M. Raydan. Math. Comp. **75**, 1429 (2006).
+
+    """
+    f_k = prev_fs[-1]
+    f_bar = max(prev_fs)
+
+    alpha_p = 1
+    alpha_m = 1
+    alpha = 1
+
+    while True:
+        xp = x_k + alpha_p * d
+        fp, Fp = f(xp)
+
+        if fp <= f_bar + eta - gamma * alpha_p**2 * f_k:
+            alpha = alpha_p
+            break
+
+        alpha_tp = alpha_p**2 * f_k / (fp + (2*alpha_p - 1)*f_k)
+
+        xp = x_k - alpha_m * d
+        fp, Fp = f(xp)
+
+        if fp <= f_bar + eta - gamma * alpha_m**2 * f_k:
+            alpha = -alpha_m
+            break
+
+        alpha_tm = alpha_m**2 * f_k / (fp + (2*alpha_m - 1)*f_k)
+
+        alpha_p = np.clip(alpha_tp, tau_min * alpha_p, tau_max * alpha_p)
+        alpha_m = np.clip(alpha_tm, tau_min * alpha_m, tau_max * alpha_m)
+
+    return alpha, xp, fp, Fp

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3160,7 +3160,7 @@ def show_options(solver=None, method=None):
         disp : bool, optional
             Whether to print convergence process to stdout.
 
-        eta_stragegy : callable, optional
+        eta_strategy : callable, optional
             Choice of the ``eta_k`` parameter, which gives slack for growth
             of ``||F||**2``.  Called as ``eta_k = eta_strategy(k, x, F)`` with
             `k` the iteration number, `x` the current iterate and `F` the current

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3167,6 +3167,14 @@ def show_options(solver=None, method=None):
             residual. Should satisfy ``eta_k > 0`` and ``sum(eta, k=0..inf) < inf``.
             Default: ``||F||**2 / (1 + k)**2``.
 
+        sigma_eps : float, optional
+            The spectral coefficient is constrained to ``sigma_eps < sigma < 1/sigma_eps``.
+            Default: 1e-10
+
+        sigma_0 : float, optional
+            Initial spectral coefficient.
+            Default: 1.0
+
         M : int, optional
             Number of iterates to include in the nonmonotonic line search.
             Default: 10

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3179,6 +3179,11 @@ def show_options(solver=None, method=None):
             Number of iterates to include in the nonmonotonic line search.
             Default: 10
 
+        line_search : {'cruz', 'cheng'}
+            Type of line search to employ. 'cruz' is the original one defined in
+            [Martinez & Raydan. Math. Comp. 75, 1429 (2006)], 'cheng' is
+            a modified search defined in [Cheng & Li. IMA J. Numer. Anal. 29, 814 (2009)].
+            Default: 'cruz'
 
     **linprog options**
 

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3142,6 +3142,36 @@ def show_options(solver=None, method=None):
 
                 See `scipy.sparse.linalg.lgmres` for details.
 
+    *df-sane* options:
+
+        ftol : float, optional
+            Relative norm tolerance.
+
+        fatol : float, optional
+            Absolute norm tolerance.
+            Algorithm terminates when ``||func(x)|| < fatol + ftol ||func(x_0)||``.
+
+        fnorm : callable, optional
+            Norm to use in the convergence check. If None, 2-norm is used.
+
+        maxfev : int, optional
+            Maximum number of function evaluations.
+
+        disp : bool, optional
+            Whether to print convergence process to stdout.
+
+        eta_stragegy : callable, optional
+            Choice of the ``eta_k`` parameter, which gives slack for growth
+            of ``||F||**2``.  Called as ``eta_k = eta_strategy(k, x, F)`` with
+            `k` the iteration number, `x` the current iterate and `F` the current
+            residual. Should satisfy ``eta_k > 0`` and ``sum(eta, k=0..inf) < inf``.
+            Default: ``||F||**2 / (1 + k)**2``.
+
+        M : int, optional
+            Number of iterates to include in the nonmonotonic line search.
+            Default: 10
+
+
     **linprog options**
 
     *simplex* options:

--- a/scipy/optimize/tests/test__spectral.py
+++ b/scipy/optimize/tests/test__spectral.py
@@ -1,0 +1,197 @@
+from __future__ import division, absolute_import, print_function
+
+import numpy as np
+from numpy import exp
+from numpy.testing import assert_
+
+from scipy.optimize import root
+
+
+def test_performance():
+    # Compare performance results to those listed in
+    # [Cheng & Li, IMA J. Num. An. 29, 814 (2008)]
+    # and
+    # [W. La Cruz, J.M. Martinez, M. Raydan, Math. Comp. 75, 1429 (2006)].
+    # and those produced by dfsane.f from M. Raydan's website.
+    #
+    # Where the results disagree, the largest limits are taken.
+
+    e_a = 1e-5
+    e_r = 1e-4
+
+    table_1 = [
+        dict(F=F_1, x0=x0_1, n=1000, nit=5, nfev=5),
+        dict(F=F_1, x0=x0_1, n=10000, nit=2, nfev=2),
+        dict(F=F_2, x0=x0_2, n=500, nit=11, nfev=11),
+        dict(F=F_2, x0=x0_2, n=2000, nit=11, nfev=11),
+        dict(F=F_4, x0=x0_4, n=999, nit=243, nfev=1188),
+        dict(F=F_6, x0=x0_6, n=100, nit=6, nfev=6),   # Results from dfsane.f; papers list nit=3, nfev=3
+        dict(F=F_7, x0=x0_7, n=99, nit=23, nfev=29),  # Must have n%3==0, typo in papers?
+        dict(F=F_7, x0=x0_7, n=999, nit=23, nfev=29), # Must have n%3==0, typo in papers?
+        dict(F=F_9, x0=x0_9, n=100, nit=12, nfev=18), # Results from dfsane.f; papers list nit=nfev=6?
+        dict(F=F_9, x0=x0_9, n=1000, nit=12, nfev=18),
+        dict(F=F_10, x0=x0_10, n=1000, nit=5, nfev=5), # Results from dfsane.f; papers list nit=2, nfev=12
+    ]
+
+    for problem in table_1:
+        n = problem['n']
+        func = problem['F']
+        args = (n,)
+        x0 = problem['x0'](n)
+
+        fatol = np.sqrt(n) * e_a + e_r * np.linalg.norm(func(x0, n))
+
+        with np.errstate(over='ignore'):
+            sol = root(func, x0, args=args,
+                       options=dict(ftol=0, fatol=fatol, maxfev=problem['nfev'] + 1),
+                       method='DF-SANE')
+
+        err_msg = repr([problem, np.linalg.norm(func(sol.x, n)), fatol,
+                        sol.success, sol.nit, sol.nfev])
+        assert_(sol.success, err_msg)
+        assert_(sol.nfev <= problem['nfev'] + 1, err_msg)  # nfev+1: dfsane.f doesn't count first eval
+        assert_(sol.nit <= problem['nit'], err_msg)
+        assert_(np.linalg.norm(func(sol.x, n)) <= fatol, err_msg)
+
+
+def test_complex():
+    def func(z):
+        return z**2 - 1 + 2j
+    x0 = 2.0j
+
+    ftol = 1e-4
+    sol = root(func, x0, tol=ftol, method='DF-SANE')
+
+    assert_(sol.success)
+
+    f0 = np.linalg.norm(func(x0))
+    fx = np.linalg.norm(func(sol.x))
+    assert_(fx <= ftol*f0)
+
+
+def test_linear_definite():
+    # The DF-SANE paper proves convergence for "strongly isolated"
+    # solutions.
+    #
+    # For linear systems F(x) = A x - b = 0, with A positive or
+    # negative definite, the solution is strongly isolated.
+
+    def check_solvability(A, b):
+        func = lambda x: A.dot(x) - b
+        xp = np.linalg.solve(A, b)
+        eps = np.linalg.norm(func(xp)) * 1e3
+        sol = root(func, b, options=dict(fatol=eps, ftol=0, maxfev=17523), method='DF-SANE')
+        assert_(sol.success)
+        assert_(np.linalg.norm(func(sol.x)) <= eps)
+
+    n = 90
+
+    # Test linear pos.def. system
+    np.random.seed(1234)
+    A = np.arange(n*n).reshape(n, n)
+    A = A + n*n * np.diag(1 + np.arange(n))
+    assert np.linalg.eigvals(A).min() > 0
+    b = np.arange(n) * 1.0
+    check_solvability(A, b)
+
+    # Test linear neg.def. system
+    check_solvability(-A, b)
+
+
+def test_shape():
+    def f(x, arg):
+        return x - arg
+
+    for dt in [float, complex]:
+        x = np.zeros([2,2])
+        arg = np.ones([2,2], dtype=dt)
+
+        sol = root(f, x, args=(arg,), method='DF-SANE')
+        assert_(sol.success)
+        assert_(sol.x.shape == x.shape)
+
+
+# Some of the test functions and initial guesses listed in
+# [W. La Cruz, M. Raydan. Optimization Methods and Software, 18, 583 (2003)]
+
+def F_1(x, n):
+    g = np.zeros([n])
+    i = np.arange(2, n+1)
+    g[0] = exp(x[0] - 1) - 1
+    g[1:] = i*(exp(x[1:] - 1) - x[1:])
+    return g
+
+def x0_1(n):
+    x0 = np.empty([n])
+    x0.fill(n/(n-1))
+    return x0
+
+def F_2(x, n):
+    g = np.zeros([n])
+    i = np.arange(2, n+1)
+    g[0] = exp(x[0]) - 1
+    g[1:] = 0.1*i*(exp(x[1:]) + x[:-1] - 1)
+    return g
+
+def x0_2(n):
+    x0 = np.empty([n])
+    x0.fill(1/n**2)
+    return x0
+
+def F_4(x, n):
+    assert n % 3 == 0
+    g = np.zeros([n])
+    # Note: the first line is typoed in some of the references;
+    # correct in original [Gasparo, Optimization Meth. 13, 79 (2000)]
+    g[::3] = 0.6 * x[::3] + 1.6 * x[1::3]**3 - 7.2 * x[1::3]**2 + 9.6 * x[1::3] - 4.8
+    g[1::3] = 0.48 * x[::3] - 0.72 * x[1::3]**3 + 3.24 * x[1::3]**2 - 4.32 * x[1::3] - x[2::3] + 0.2 * x[2::3]**3 + 2.16
+    g[2::3] = 1.25 * x[2::3] - 0.25*x[2::3]**3
+    return g
+
+def x0_4(n):
+    assert n % 3 == 0
+    x0 = np.array([-1, 1/2, -1] * (n//3))
+    return x0
+
+def F_6(x, n):
+    c = 0.9
+    mu = (np.arange(1, n+1) - 0.5)/n
+    return x - 1/(1 - c/(2*n) * (mu[:,None]*x / (mu[:,None] + mu)).sum(axis=1))
+
+def x0_6(n):
+    return np.ones([n])
+
+def F_7(x, n):
+    assert n % 3 == 0
+
+    def phi(t):
+        v = 0.5*t - 2
+        v[t > -1] = ((-592*t**3 + 888*t**2 + 4551*t - 1924)/1998)[t > -1]
+        v[t >= 2] = (0.5*t + 2)[t >= 2]
+        return v
+    g = np.zeros([n])
+    g[::3] = 1e4 * x[1::3]**2 - 1
+    g[1::3] = exp(-x[::3]) + exp(-x[1::3]) - 1.0001
+    g[2::3] = phi(x[2::3])
+    return g
+
+def x0_7(n):
+    assert n % 3 == 0
+    return np.array([1e-3, 18, 1] * (n//3))
+
+def F_9(x, n):
+    g = np.zeros([n])
+    i = np.arange(2, n)
+    g[0] = x[0]**3/3 + x[1]**2/2
+    g[1:-1] = -x[1:-1]**2/2 + i*x[1:-1]**3/3 + x[2:]**2/2
+    g[-1] = -x[-1]**2/2 + n*x[-1]**3/3
+    return g
+
+def x0_9(n):
+    return np.ones([n])
+
+def F_10(x, n):
+    return np.log(1 + x) - x/n
+
+def x0_10(n):
+    return np.ones([n])

--- a/scipy/optimize/tests/test__spectral.py
+++ b/scipy/optimize/tests/test__spectral.py
@@ -25,12 +25,12 @@ def test_performance():
         dict(F=F_2, x0=x0_2, n=500, nit=11, nfev=11),
         dict(F=F_2, x0=x0_2, n=2000, nit=11, nfev=11),
         dict(F=F_4, x0=x0_4, n=999, nit=243, nfev=1188),
-        dict(F=F_6, x0=x0_6, n=100, nit=6, nfev=6),   # Results from dfsane.f; papers list nit=3, nfev=3
+        dict(F=F_6, x0=x0_6, n=100, nit=6, nfev=6),  # Results from dfsane.f; papers list nit=3, nfev=3
         dict(F=F_7, x0=x0_7, n=99, nit=23, nfev=29),  # Must have n%3==0, typo in papers?
-        dict(F=F_7, x0=x0_7, n=999, nit=23, nfev=29), # Must have n%3==0, typo in papers?
-        dict(F=F_9, x0=x0_9, n=100, nit=12, nfev=18), # Results from dfsane.f; papers list nit=nfev=6?
+        dict(F=F_7, x0=x0_7, n=999, nit=23, nfev=29),  # Must have n%3==0, typo in papers?
+        dict(F=F_9, x0=x0_9, n=100, nit=12, nfev=18),  # Results from dfsane.f; papers list nit=nfev=6?
         dict(F=F_9, x0=x0_9, n=1000, nit=12, nfev=18),
-        dict(F=F_10, x0=x0_10, n=1000, nit=5, nfev=5), # Results from dfsane.f; papers list nit=2, nfev=12
+        dict(F=F_10, x0=x0_10, n=1000, nit=5, nfev=5),  # Results from dfsane.f; papers list nit=2, nfev=12
     ]
 
     for problem in table_1:

--- a/scipy/optimize/tests/test__spectral.py
+++ b/scipy/optimize/tests/test__spectral.py
@@ -4,7 +4,7 @@ import itertools
 
 import numpy as np
 from numpy import exp
-from numpy.testing import assert_
+from numpy.testing import assert_, assert_equal
 
 from scipy.optimize import root
 
@@ -116,7 +116,7 @@ def test_shape():
 
         sol = root(f, x, args=(arg,), method='DF-SANE')
         assert_(sol.success)
-        assert_(sol.x.shape == x.shape)
+        assert_equal(sol.x.shape, x.shape)
 
 
 # Some of the test functions and initial guesses listed in

--- a/scipy/optimize/tests/test__spectral.py
+++ b/scipy/optimize/tests/test__spectral.py
@@ -98,7 +98,7 @@ def test_linear_definite():
     np.random.seed(1234)
     A = np.arange(n*n).reshape(n, n)
     A = A + n*n * np.diag(1 + np.arange(n))
-    assert np.linalg.eigvals(A).min() > 0
+    assert_(np.linalg.eigvals(A).min() > 0)
     b = np.arange(n) * 1.0
     check_solvability(A, b)
 
@@ -147,7 +147,7 @@ def x0_2(n):
     return x0
 
 def F_4(x, n):
-    assert n % 3 == 0
+    assert_equal(n % 3, 0)
     g = np.zeros([n])
     # Note: the first line is typoed in some of the references;
     # correct in original [Gasparo, Optimization Meth. 13, 79 (2000)]
@@ -157,7 +157,7 @@ def F_4(x, n):
     return g
 
 def x0_4(n):
-    assert n % 3 == 0
+    assert_equal(n % 3, 0)
     x0 = np.array([-1, 1/2, -1] * (n//3))
     return x0
 
@@ -170,7 +170,7 @@ def x0_6(n):
     return np.ones([n])
 
 def F_7(x, n):
-    assert n % 3 == 0
+    assert_equal(n % 3, 0)
 
     def phi(t):
         v = 0.5*t - 2
@@ -184,7 +184,7 @@ def F_7(x, n):
     return g
 
 def x0_7(n):
-    assert n % 3 == 0
+    assert_equal(n % 3, 0)
     return np.array([1e-3, 18, 1] * (n//3))
 
 def F_9(x, n):


### PR DESCRIPTION
Add DF-SANE, a derivative-free nonlinear equation system solving method.

Currently, the other large-scale derivative-free method offered in Scipy are Newton-Krylov and the Broyden/Anderson family. As one data point, solving a certain fixed-point integrodifferential equation problem, DF-SANE performed significantly better than the above solvers (NK was very slow as the Jacobian was 'difficult', Broyden/Anderson had problems in late-stage convergence).

In R, dfsane is implemented in the BB package, not sure how many other numerical computing environments include it.

Comments welcome.
