### PR TITLE
ENH disable GIL during C distance caluclations

### DIFF
--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -59,7 +59,9 @@
             mA = XA_->dimensions[0];                                    \
             mB = XB_->dimensions[0];                                    \
             n = XA_->dimensions[1];                                     \
+            Py_BEGIN_ALLOW_THREADS                                      \
             cdist_ ## name ## _ ## type(XA, XB, dm, mA, mB, n);         \
+            Py_END_ALLOW_THREADS                                        \
         }                                                               \
         return Py_BuildValue("d", 0.);                                  \
     }
@@ -113,7 +115,9 @@ static PyObject *cdist_mahalanobis_wrap(PyObject *self, PyObject *args) {
     if (!dimbuf) {
       return NULL;
     }
+    Py_BEGIN_ALLOW_THREADS
     cdist_mahalanobis(XA, XB, covinv, dimbuf, dm, mA, mB, n);
+    Py_END_ALLOW_THREADS
     free(dimbuf);
   }
   return Py_BuildValue("d", 0.0);
@@ -141,7 +145,9 @@ static PyObject *cdist_cosine_wrap(PyObject *self, PyObject *args) {
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     cdist_cosine(XA, XB, dm, mA, mB, n, normsA, normsB);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("d", 0.0);
 }
@@ -166,7 +172,9 @@ static PyObject *cdist_seuclidean_wrap(PyObject *self, PyObject *args) {
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     cdist_seuclidean(XA, XB, var, dm, mA, mB, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("d", 0.0);
 }
@@ -189,7 +197,9 @@ static PyObject *cdist_hamming_bool_wrap(PyObject *self, PyObject *args) {
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     cdist_hamming_char(XA, XB, dm, mA, mB, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("d", 0.0);
 }
@@ -212,7 +222,9 @@ static PyObject *cdist_jaccard_bool_wrap(PyObject *self, PyObject *args) {
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     cdist_jaccard_char(XA, XB, dm, mA, mB, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("d", 0.0);
 }
@@ -236,7 +248,9 @@ static PyObject *cdist_minkowski_wrap(PyObject *self, PyObject *args) {
     mA = XA_->dimensions[0];
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
+    Py_BEGIN_ALLOW_THREADS
     cdist_minkowski(XA, XB, dm, mA, mB, n, p);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("d", 0.0);
 }
@@ -262,7 +276,9 @@ static PyObject *cdist_weighted_minkowski_wrap(PyObject *self, PyObject *args) {
     mA = XA_->dimensions[0];
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
+    Py_BEGIN_ALLOW_THREADS
     cdist_weighted_minkowski(XA, XB, dm, mA, mB, n, p, w);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("d", 0.0);
 }
@@ -285,7 +301,9 @@ static PyObject *cdist_matching_bool_wrap(PyObject *self, PyObject *args) {
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     cdist_matching_char(XA, XB, dm, mA, mB, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("");
 }
@@ -308,7 +326,9 @@ static PyObject *cdist_dice_bool_wrap(PyObject *self, PyObject *args) {
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     cdist_dice_char(XA, XB, dm, mA, mB, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("");
 }
@@ -331,7 +351,9 @@ static PyObject *cdist_rogerstanimoto_bool_wrap(PyObject *self, PyObject *args) 
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     cdist_rogerstanimoto_char(XA, XB, dm, mA, mB, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("");
 }
@@ -354,7 +376,9 @@ static PyObject *cdist_russellrao_bool_wrap(PyObject *self, PyObject *args) {
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     cdist_russellrao_char(XA, XB, dm, mA, mB, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("");
 }
@@ -377,7 +401,9 @@ static PyObject *cdist_kulsinski_bool_wrap(PyObject *self, PyObject *args) {
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     cdist_kulsinski_char(XA, XB, dm, mA, mB, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("");
 }
@@ -400,7 +426,9 @@ static PyObject *cdist_sokalmichener_bool_wrap(PyObject *self, PyObject *args) {
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     cdist_sokalmichener_char(XA, XB, dm, mA, mB, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("");
 }
@@ -423,7 +451,9 @@ static PyObject *cdist_sokalsneath_bool_wrap(PyObject *self, PyObject *args) {
     mB = XB_->dimensions[0];
     n = XA_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     cdist_sokalsneath_char(XA, XB, dm, mA, mB, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("");
 }
@@ -447,7 +477,9 @@ static PyObject *cdist_sokalsneath_bool_wrap(PyObject *self, PyObject *args) {
             dm = (double *)dm_->data;                                   \
             m = X_->dimensions[0];                                      \
             n = X_->dimensions[1];                                      \
+            Py_BEGIN_ALLOW_THREADS                                      \
             pdist_ ## name ## _double(X, dm, m, n);                     \
+            Py_END_ALLOW_THREADS                                        \
         }                                                               \
         return Py_BuildValue("d", 0.);                                  \
     }
@@ -486,7 +518,9 @@ static PyObject *pdist_mahalanobis_wrap(PyObject *self, PyObject *args) {
         return NULL;
     }
 
+    Py_BEGIN_ALLOW_THREADS
     pdist_mahalanobis(X, covinv, dimbuf, dm, m, n);
+    Py_END_ALLOW_THREADS
     free(dimbuf);
   }
   return Py_BuildValue("d", 0.0);
@@ -511,7 +545,9 @@ static PyObject *pdist_cosine_wrap(PyObject *self, PyObject *args) {
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     pdist_cosine(X, dm, m, n, norms);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("d", 0.0);
 }
@@ -534,7 +570,9 @@ static PyObject *pdist_seuclidean_wrap(PyObject *self, PyObject *args) {
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     pdist_seuclidean(X, var, dm, m, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("d", 0.0);
 }
@@ -555,7 +593,9 @@ static PyObject *pdist_hamming_bool_wrap(PyObject *self, PyObject *args) {
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     pdist_hamming_char(X, dm, m, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("d", 0.0);
 }
@@ -576,7 +616,9 @@ static PyObject *pdist_jaccard_bool_wrap(PyObject *self, PyObject *args) {
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     pdist_jaccard_char(X, dm, m, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("d", 0.0);
 }
@@ -598,7 +640,9 @@ static PyObject *pdist_minkowski_wrap(PyObject *self, PyObject *args) {
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     pdist_minkowski(X, dm, m, n, p);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("d", 0.0);
 }
@@ -622,7 +666,9 @@ static PyObject *pdist_weighted_minkowski_wrap(PyObject *self, PyObject *args) {
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     pdist_weighted_minkowski(X, dm, m, n, p, w);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("d", 0.0);
 }
@@ -644,7 +690,9 @@ static PyObject *pdist_yule_bool_wrap(PyObject *self, PyObject *args) {
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     pdist_yule_bool_char(X, dm, m, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("");
 }
@@ -665,7 +713,9 @@ static PyObject *pdist_matching_bool_wrap(PyObject *self, PyObject *args) {
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     pdist_matching_char(X, dm, m, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("");
 }
@@ -686,7 +736,9 @@ static PyObject *pdist_dice_bool_wrap(PyObject *self, PyObject *args) {
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     pdist_dice_char(X, dm, m, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("");
 }
@@ -707,7 +759,9 @@ static PyObject *pdist_rogerstanimoto_bool_wrap(PyObject *self, PyObject *args) 
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     pdist_rogerstanimoto_char(X, dm, m, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("");
 }
@@ -728,7 +782,9 @@ static PyObject *pdist_russellrao_bool_wrap(PyObject *self, PyObject *args) {
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     pdist_russellrao_char(X, dm, m, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("");
 }
@@ -749,7 +805,9 @@ static PyObject *pdist_kulsinski_bool_wrap(PyObject *self, PyObject *args) {
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     pdist_kulsinski_char(X, dm, m, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("");
 }
@@ -770,7 +828,9 @@ static PyObject *pdist_sokalmichener_bool_wrap(PyObject *self, PyObject *args) {
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     pdist_sokalmichener_char(X, dm, m, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("");
 }
@@ -791,7 +851,9 @@ static PyObject *pdist_sokalsneath_bool_wrap(PyObject *self, PyObject *args) {
     m = X_->dimensions[0];
     n = X_->dimensions[1];
 
+    Py_BEGIN_ALLOW_THREADS
     pdist_sokalsneath_char(X, dm, m, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("");
 }
@@ -810,7 +872,9 @@ static PyObject *to_squareform_from_vector_wrap(PyObject *self, PyObject *args) 
     M = (double*)M_->data;
     v = (const double*)v_->data;
     n = M_->dimensions[0];
+    Py_BEGIN_ALLOW_THREADS
     dist_to_squareform_from_vector(M, v, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("d", 0.0);
 }
@@ -829,7 +893,9 @@ static PyObject *to_vector_from_squareform_wrap(PyObject *self, PyObject *args) 
     M = (const double*)M_->data;
     v = (double*)v_->data;
     n = M_->dimensions[0];
+    Py_BEGIN_ALLOW_THREADS
     dist_to_vector_from_squareform(M, v, n);
+    Py_END_ALLOW_THREADS
   }
   return Py_BuildValue("d", 0.0);
 }


### PR DESCRIPTION
It seems it should be safe to disable the GIL during C-extension-based distance calculations, which would allow multithreaded `cdist` calculation with one of the arguments split up.
