### PR TITLE
FIX pdist bug where wminkowski's w.dtype != double

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1240,8 +1240,9 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
         elif mstr in set(['minkowski', 'mi', 'm']):
             _distance_wrap.pdist_minkowski_wrap(_convert_to_double(X), dm, p)
         elif mstr in wmink_names:
+            w = _convert_to_double(np.asarray(w))
             _distance_wrap.pdist_weighted_minkowski_wrap(_convert_to_double(X),
-                                                         dm, p, np.asarray(w))
+                                                         dm, p, w)
         elif mstr in set(['seuclidean', 'se', 's']):
             if V is not None:
                 V = np.asarray(V, order='c')

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -211,6 +211,16 @@ class TestCdist(TestCase):
         Y2 = cdist(X1, X2, 'test_wminkowski', p=3.8, w=w)
         _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
+    def test_cdist_wminkowski_int_weights(self):
+        # regression test when using integer weights
+        eps = 1e-07
+        X1 = eo['cdist-X1']
+        X2 = eo['cdist-X2']
+        w = np.arange(X1.shape[1])
+        Y1 = cdist(X1, X2, 'wminkowski', p=3.8, w=w)
+        Y2 = cdist(X1, X2, 'test_wminkowski', p=3.8, w=w)
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
     def test_cdist_wminkowski_random_p4d6(self):
         eps = 1e-07
         X1 = eo['cdist-X1']
@@ -659,6 +669,16 @@ class TestPdist(TestCase):
 
         dist = pdist(x, metric='wminkowski', w=[0.5, 1.0, 2.0], p=1)
         assert_allclose(dist, p1_expected, rtol=1e-14)
+
+    def test_pdist_wminkowski_int_weights(self):
+        # regression test for int weights
+        x = np.array([[0.0, 0.0, 0.0],
+                      [1.0, 0.0, 0.0],
+                      [0.0, 1.0, 0.0],
+                      [1.0, 1.0, 1.0]])
+        dist1 = pdist(x, metric='wminkowski', w=np.arange(3), p=1)
+        dist2 = pdist(x, metric='wminkowski', w=[0., 1., 2.], p=1)
+        assert_allclose(dist1, dist2, rtol=1e-14)
 
     def test_pdist_hamming_random(self):
         eps = 1e-07


### PR DESCRIPTION
The type of a pointer was being silently reinterpreted when loading data in `_distance_wrap` (perhaps it's time to rewrite that in Cython to get free type checking). The faulty code was very tricky to find ...
