### PR TITLE
ENH symmetrise in-place in scipy.spatial.distance.squareform to avoid MemoryError

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1475,7 +1475,7 @@ def squareform(X, force="no", checks=True):
         _distance_wrap.to_squareform_from_vector_wrap(M, X)
 
         # Return the distance matrix.
-        M = M + M.transpose()
+        M += M.transpose()
         return M
     elif len(s) == 2:
         if s[0] != s[1]:


### PR DESCRIPTION
The current copying approach in `squareform` is slower and prone to using all available memory for large distance matrices.
