### PR TITLE
DOC:fix error in scipy.signal.cwt documentation.

### DIFF
--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -332,7 +332,7 @@ def cwt(data, wavelet, widths):
     Returns
     -------
     cwt: (M, N) ndarray
-        Will have shape of (len(data), len(widths)).
+        Will have shape of (len(widths), len(data)).
 
     Notes
     -----


### PR DESCRIPTION
Fix the error in the documentation of continuous wavelet transform ( scipy.signal.cwt). Closes issue #4412
