### PR TITLE
ENH: Improve accuracy of lomax for small x.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3227,19 +3227,19 @@ class lomax_gen(rv_continuous):
         return c*1.0/(1.0+x)**(c+1.0)
 
     def _logpdf(self, x, c):
-        return log(c) - (c+1)*log(1+x)
+        return log(c) - (c+1)*special.log1p(x)
 
     def _cdf(self, x, c):
-        return 1.0-1.0/(1.0+x)**c
+        return -special.expm1(-c*special.log1p(x))
 
     def _sf(self, x, c):
-        return 1.0/(1.0+x)**c
+        return exp(-c*special.log1p(x))
 
     def _logsf(self, x, c):
-        return -c*log(1+x)
+        return -c*special.log1p(x)
 
     def _ppf(self, q, c):
-        return pow(1.0-q, -1.0/c)-1
+        return special.expm1(-special.log1p(-q)/c)
 
     def _stats(self, c):
         mu, mu2, g1, g2 = pareto.stats(c, loc=-1.0, moments='mvsk')

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2168,6 +2168,10 @@ def test_infinite_input():
     assert_almost_equal(stats.skellam.sf(np.inf, 10, 11), 0)
     assert_almost_equal(stats.ncx2._cdf(np.inf, 8, 0.1), 1)
 
+def test_lomax_accuracy():
+    # regression test for gh-4033
+    p = stats.lomax.ppf(stats.lomax.cdf(1e-100,1),1)
+    assert_equal(p, 1e-100)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Improve the accuracy of the lomax distribution for small x, by replacing(1+x) with exp(log1p(x), exp(x)-1 with expm1(x) and log(1+x) with log1p(x).
