### PR TITLE
BLD: avoid using NPY_API_VERSION to check not using deprecated Numpy API

### DIFF
--- a/scipy/_build_utils/src/apple_sgemv_fix.c
+++ b/scipy/_build_utils/src/apple_sgemv_fix.c
@@ -20,7 +20,7 @@
  *
  */
 
-#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_9_API_VERSION
 #include "Python.h"
 #include "numpy/arrayobject.h"
 


### PR DESCRIPTION
Using the latest Numpy version can break released Scipy versions if something gets deprecated in a newer Numpy version.

Needs to go also in 0.15.x and 0.14.x
