### PR TITLE
fix a performance issue with a sparse solver

### DIFF
--- a/scipy/sparse/linalg/dsolve/__init__.py
+++ b/scipy/sparse/linalg/dsolve/__init__.py
@@ -64,3 +64,4 @@ from . import _add_newdocs
 __all__ = [s for s in dir() if not s.startswith('_')]
 from numpy.testing import Tester
 test = Tester().test
+bench = Tester().bench

--- a/scipy/sparse/linalg/dsolve/benchmarks/bench_spsolve.py
+++ b/scipy/sparse/linalg/dsolve/benchmarks/bench_spsolve.py
@@ -28,7 +28,7 @@ def _create_sparse_poisson2d(n):
     return P2d
 
 
-class BenchmarkConjuateGradientSolver(TestCase):
+class BenchmarkSparseLinearSolver(TestCase):
 
     def bench_spsolve(self):
         np.random.seed(1234)

--- a/scipy/sparse/linalg/dsolve/benchmarks/bench_spsolve.py
+++ b/scipy/sparse/linalg/dsolve/benchmarks/bench_spsolve.py
@@ -32,7 +32,7 @@ class BenchmarkConjuateGradientSolver(TestCase):
 
     def bench_spsolve(self):
         np.random.seed(1234)
-        n = 40
+        n = 30
         P_sparse = _create_sparse_poisson2d(n).tocsc()
         P_dense = P_sparse.A
         rows = P_dense.shape[0]
@@ -51,10 +51,11 @@ class BenchmarkConjuateGradientSolver(TestCase):
         # vary between (n*n, 1) and (n*n, 1000).
         # The time to construct these matrices will not count
         # towards the time reported in the benchmarks.
-        b_column_counts = (10, 30, 100, 300, 1000)
-        b_full = np.random.randn(rows, max(b_column_counts))
-        b_dense_list = [b_full[:, :c] for c in b_column_counts]
-        b_sparse_list = [sparse.csr_matrix(b) for b in b_dense_list]
+        b_column_counts = (10, 30, 100, 300, 1000, 3000)
+        max_cols = max(b_column_counts)
+        b_max = sparse.rand(rows, max_cols, density=0.05, format='csc')
+        b_sparse_list = [b_max[:, :c] for c in b_column_counts]
+        b_dense_list = [b.A for b in b_sparse_list]
         repeats = 10
         for i, b_column_count in enumerate(b_column_counts):
             b_dense = b_dense_list[i]

--- a/scipy/sparse/linalg/dsolve/benchmarks/bench_spsolve.py
+++ b/scipy/sparse/linalg/dsolve/benchmarks/bench_spsolve.py
@@ -1,0 +1,87 @@
+"""
+Check the speed of the sparse solver.
+
+"""
+from __future__ import division, print_function, absolute_import
+
+import time
+
+import numpy as np
+from numpy.testing import Tester, TestCase, assert_allclose, assert_equal
+
+from scipy import linalg, sparse
+from scipy.sparse.linalg import spsolve
+
+
+def _create_sparse_poisson1d(n):
+    # Make Gilbert Strang's favorite matrix
+    # http://www-math.mit.edu/~gs/PIX/cupcakematrix.jpg
+    P1d = sparse.diags([[-1]*(n-1), [2]*n, [-1]*(n-1)], [-1, 0, 1])
+    assert_equal(P1d.shape, (n, n))
+    return P1d
+
+
+def _create_sparse_poisson2d(n):
+    P1d = _create_sparse_poisson1d(n)
+    P2d = sparse.kronsum(P1d, P1d)
+    assert_equal(P2d.shape, (n*n, n*n))
+    return P2d
+
+
+class BenchmarkConjuateGradientSolver(TestCase):
+
+    def bench_spsolve(self):
+        np.random.seed(1234)
+        n = 40
+        P_sparse = _create_sparse_poisson2d(n).tocsc()
+        P_dense = P_sparse.A
+        rows = P_dense.shape[0]
+
+        # print headers and define the column formats
+        print()
+        print('    dense vs. sparse solve of Ax=b with %d rows' % rows)
+        print('==============================================================')
+        print('   columns | repeats |      operation     |   time   ')
+        print('           |         |                    | (seconds)')
+        print('--------------------------------------------------------------')
+        fmt = '   %5s   |   %3d   | %18s | %6.2f '
+
+        # Define the sizes of A and b in the equation Ax=b.
+        # The shape of A will be (n*n, n*n), and the shape of b will
+        # vary between (n*n, 1) and (n*n, 1000).
+        # The time to construct these matrices will not count
+        # towards the time reported in the benchmarks.
+        b_column_counts = (10, 30, 100, 300, 1000)
+        b_full = np.random.randn(rows, max(b_column_counts))
+        b_dense_list = [b_full[:, :c] for c in b_column_counts]
+        b_sparse_list = [sparse.csr_matrix(b) for b in b_dense_list]
+        repeats = 10
+        for i, b_column_count in enumerate(b_column_counts):
+            b_dense = b_dense_list[i]
+            b_sparse = b_sparse_list[i]
+
+            # Use the generic dense solver.
+            tm_start = time.clock()
+            for i in range(repeats):
+                x_dense = linalg.solve(P_dense, b_dense)
+            tm_end = time.clock()
+            tm_dense = tm_end - tm_start
+            print(fmt % (b_column_count, repeats, 'dense solve', tm_dense))
+
+            # Use the sparse solver.
+            tm_start = time.clock()
+            for i in range(repeats):
+                x_sparse = spsolve(P_sparse, b_sparse)
+            tm_end = time.clock()
+            tm_sparse = tm_end - tm_start
+            print(fmt % (b_column_count, repeats, 'sparse solve', tm_sparse))
+
+            # Check that the solutions are close to each other.
+            assert_allclose(x_dense, x_sparse.A, rtol=1e-4)
+
+        print()
+
+
+if __name__ == '__main__':
+    Tester().bench()
+

--- a/scipy/sparse/linalg/dsolve/setup.py
+++ b/scipy/sparse/linalg/dsolve/setup.py
@@ -14,6 +14,7 @@ def configuration(parent_package='',top_path=None):
 
     config = Configuration('dsolve',parent_package,top_path)
     config.add_data_dir('tests')
+    config.add_data_dir('benchmarks')
 
     lapack_opt = get_info('lapack_opt',notfound_action=2)
     if sys.platform == 'win32':

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -5,16 +5,16 @@ import warnings
 import numpy as np
 from numpy import array, finfo, arange, eye, all, unique, ones, dot, matrix
 import numpy.random as random
-from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal, \
-    assert_raises, assert_almost_equal, assert_equal, assert_array_equal, assert_, \
-    assert_allclose
+from numpy.testing import (TestCase, run_module_suite,
+        assert_array_almost_equal, assert_raises, assert_almost_equal,
+        assert_equal, assert_array_equal, assert_, assert_allclose)
 
 import scipy.linalg
 from scipy.linalg import norm, inv
-from scipy.sparse import spdiags, SparseEfficiencyWarning, csc_matrix, csr_matrix, \
-     isspmatrix, dok_matrix, lil_matrix, bsr_matrix
-from scipy.sparse.linalg.dsolve import spsolve, use_solver, splu, spilu, \
-     MatrixRankWarning, _superlu
+from scipy.sparse import (spdiags, SparseEfficiencyWarning, csc_matrix,
+        csr_matrix, isspmatrix, dok_matrix, lil_matrix, bsr_matrix)
+from scipy.sparse.linalg.dsolve import (spsolve, use_solver, splu, spilu,
+        MatrixRankWarning, _superlu)
 
 warnings.simplefilter('ignore',SparseEfficiencyWarning)
 
@@ -226,6 +226,21 @@ class TestLinsolve(TestCase):
                 assert_raises((ValueError, TypeError), _superlu.gssv,
                               N, A.nnz, A.data, A.indices, badop(A.indptr),
                               b, int(spmatrix == csc_matrix), err_msg=msg)
+
+    def test_sparsity_preservation(self):
+        ident = csc_matrix([
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1]])
+        b = csc_matrix([
+            [0, 1],
+            [1, 0],
+            [0, 0]])
+        x = spsolve(ident, b)
+        assert_equal(ident.nnz, 3)
+        assert_equal(b.nnz, 2)
+        assert_equal(x.nnz, 2)
+        assert_allclose(x.A, b.A, atol=1e-12, rtol=1e-12)
 
 
 class TestSplu(object):


### PR DESCRIPTION
This is intended to close https://github.com/scipy/scipy/issues/4391, but it could use more scrutiny because I've only tested it with toy matrices, not with the matrices used in the reported issue.

Although the sparse solver has many unit tests, there are also many possible combinations of sizes, shapes, sparsities, dtypes, array-like variants, and sparse matrix types for `A` and for `b` in the equation `Ax=b`, and some of these combinations may have less coverage than others in the `spsolve` tests.

Original performance:

```
   dense vs. sparse solve of Ax=b with 900 rows
==============================================================
   columns | repeats |      operation     |   time   
           |         |                    | (seconds)
--------------------------------------------------------------
      10   |    10   |        dense solve |   1.32 
      10   |    10   |       sparse solve |   0.99 
      30   |    10   |        dense solve |   1.46 
      30   |    10   |       sparse solve |   2.27 
     100   |    10   |        dense solve |   1.61 
     100   |    10   |       sparse solve |   5.53 
     300   |    10   |        dense solve |   1.85 
     300   |    10   |       sparse solve |   8.50 
    1000   |    10   |        dense solve |   3.34 
    1000   |    10   |       sparse solve |  29.61 
    3000   |    10   |        dense solve |   6.99 
    3000   |    10   |       sparse solve | 185.54 
```

Performance after these changes:

```
    dense vs. sparse solve of Ax=b with 900 rows
==============================================================
   columns | repeats |      operation     |   time   
           |         |                    | (seconds)
--------------------------------------------------------------
      10   |    10   |        dense solve |   1.52 
      10   |    10   |       sparse solve |   0.69 
      30   |    10   |        dense solve |   1.54 
      30   |    10   |       sparse solve |   1.55 
     100   |    10   |        dense solve |   1.53 
     100   |    10   |       sparse solve |   4.21 
     300   |    10   |        dense solve |   1.85 
     300   |    10   |       sparse solve |   6.20 
    1000   |    10   |        dense solve |   3.44 
    1000   |    10   |       sparse solve |  10.48 
    3000   |    10   |        dense solve |   6.35 
    3000   |    10   |       sparse solve |  22.55 
```
