### PR TITLE
ENH: Improve accuracy of truncexpon for small x

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3764,16 +3764,16 @@ class truncexpon_gen(rv_continuous):
         return (b > 0)
 
     def _pdf(self, x, b):
-        return exp(-x)/(1-exp(-b))
+        return exp(-x)/(-special.expm1(-b))
 
     def _logpdf(self, x, b):
-        return -x - log(1-exp(-b))
+        return -x - log(-special.expm1(-b))
 
     def _cdf(self, x, b):
-        return (1.0-exp(-x))/(1-exp(-b))
+        return special.expm1(-x)/special.expm1(-b)
 
     def _ppf(self, q, b):
-        return -log(1-q+q*exp(-b))
+        return -special.log1p(q*special.expm1(-b))
 
     def _munp(self, n, b):
         # wrong answer with formula, same as in continuous.pdf

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2172,6 +2172,11 @@ def test_lomax_accuracy():
     # regression test for gh-4033
     p = stats.lomax.ppf(stats.lomax.cdf(1e-100,1),1)
     assert_equal(p, 1e-100)
+    
+def test_truncexpon_accuracy():
+    # regression test for gh-4035
+    p = stats.truncexpon.ppf(stats.truncexpon.cdf(1e-100,1),1)
+    assert_almost_equal(p, 1e-100, decimal=15)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
By replacing exp(x)-1 with expm1(x) and log(1+x) with log1p(x), improve the accuracy of the truncexpon distribution (_pdf, _logpdf, _cdf and _ppf) for small x. closes #4035.
