### PR TITLE
ENH: improve rayleigh accuracy for large x.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3542,10 +3542,16 @@ class rayleigh_gen(rv_continuous):
         return r * exp(-0.5 * r**2)
 
     def _cdf(self, r):
-        return 1 - exp(-0.5 * r**2)
+        return -special.expm1(-0.5 * r**2)
 
     def _ppf(self, q):
-        return sqrt(-2 * log(1 - q))
+        return sqrt(-2 * special.log1p(-q))
+        
+    def _sf(self, r):
+        return exp(-0.5 * r**2)
+        
+    def _isf(self, q):
+        return sqrt(-2 * log(q))
 
     def _stats(self):
         val = 4 - pi

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2171,12 +2171,12 @@ def test_infinite_input():
 def test_lomax_accuracy():
     # regression test for gh-4033
     p = stats.lomax.ppf(stats.lomax.cdf(1e-100,1),1)
-    assert_almost_equal(p, 1e-100, decimal=15)
+    assert_allclose(p, 1e-100)
     
 def test_truncexpon_accuracy():
     # regression test for gh-4035
     p = stats.truncexpon.ppf(stats.truncexpon.cdf(1e-100,1),1)
-    assert_almost_equal(p, 1e-100, decimal=15)
+    assert_allclose(p, 1e-100)
 
 def test_rayleigh_accuracy():
     # regression test for gh-4034

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2171,12 +2171,17 @@ def test_infinite_input():
 def test_lomax_accuracy():
     # regression test for gh-4033
     p = stats.lomax.ppf(stats.lomax.cdf(1e-100,1),1)
-    assert_equal(p, 1e-100)
+    assert_almost_equal(p, 1e-100, decimal=15)
     
 def test_truncexpon_accuracy():
     # regression test for gh-4035
     p = stats.truncexpon.ppf(stats.truncexpon.cdf(1e-100,1),1)
     assert_almost_equal(p, 1e-100, decimal=15)
+
+def test_rayleigh_accuracy():
+    # regression test for gh-4034
+    p = stats.rayleigh.isf(stats.rayleigh.sf(9,1),1)
+    assert_almost_equal(p, 9.0, decimal=15)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Improve the accuracy of the rayleigh distribution for large x, by replacing exp(x)-1 with expm1(x) and log(1+x) with log1p(x). closes #4034
