### PR TITLE
BLD: fix build failure with numpy 1.7.x and 1.8.x.

### DIFF
--- a/scipy/_build_utils/src/apple_sgemv_fix.c
+++ b/scipy/_build_utils/src/apple_sgemv_fix.c
@@ -20,7 +20,6 @@
  *
  */
 
-#define NPY_NO_DEPRECATED_API NPY_1_9_API_VERSION
 #include "Python.h"
 #include "numpy/arrayobject.h"
 


### PR DESCRIPTION
NPY_1_9_API_VERSION not defined.  See gh-4417 for details.
