### PR TITLE
ENH: spatial: vectorize some distances, alternative to #4379

### DIFF
--- a/scipy/spatial/src/simd.h
+++ b/scipy/spatial/src/simd.h
@@ -1,0 +1,25 @@
+/*
+ * SIMD definitions. This file defines types for SIMD (SSE, Neon, AVX)
+ * operations, using the GCC vector extensions. These are supported by GCC
+ * and Clang, are architecture-independent, and work even when no SIMD
+ * instructions are available (e.g., ia32 with default GCC options).
+ *
+ * This header defines the macro SCIPY_SIMD if SIMD types are enabled.
+ *
+ * TODO move to scipy/_lib and reuse in other modules!
+ */
+
+#ifndef SCIPY_SIMD_H
+#define SCIPY_SIMD_H
+
+/* XXX earlier versions of GCC and Clang might work */
+#if defined(__GNUC__) && __GNUC__ > 4 \
+    || defined(__clang__) && __clang_major__ >= 3 && __clang_minor >= 4
+#define SCIPY_SIMD
+
+typedef double Double2 __attribute__((vector_size(2 * sizeof(double))));
+typedef double Double4 __attribute__((vector_size(4 * sizeof(double))));
+
+#endif
+
+#endif


### PR DESCRIPTION
Vectorized distance functions using GCC vector extensions. I think these are much more readable than SSE intrinsics, and they're potentially more portable. The main downside is that they don't work on MSVC, but `INSTALL.rst.txt` recommends MinGW anyway (and they're ifdef'd out for compilers that don't support them).

Documentation for these vector extensions is at https://gcc.gnu.org/onlinedocs/gcc/Vector-Extensions.html
