### PR TITLE
BF: use UTF16 for saving unicode to mat files

### DIFF
--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -659,7 +659,25 @@ class VarWriter5(object):
         arr : ndarray
             ndarray of dtype.type ``string_`` or ``unicode_``
         codec : {'ascii', 'utf8', 'utf16', 'utf32'}, optional
-            String identifying codec with which to save unicode data.
+            String identifying codec with which to save unicode data.  In
+            practice you will nearly always want 'utf16' (see Notes).
+
+        Notes
+        -----
+        MATLAB claims to support UTF8, UTF16 and UTF32, but in practice, the
+        MATLAB application does not seem to be able to read multi-byte encoded
+        characters in UTF8 or UTF16. It also appears to be unable to read UTF32
+        strings with unicode characters (code-points) greater than 16 bits
+        (outside the unicode Basic Multilingual Plane - BMP).  This makes UTF32
+        completely useless compared to UTF16, and leaves UTF8 only able to
+        encode ASCII.
+
+        See: http://blog.omega-prime.co.uk/?p=150 for an analysis.
+
+        Although this method supports unicode output in MATLAB's UTF8, UTF16,
+        UTF32 formats, in practice we always call this method with ``utf16`` as
+        value for `codec`, accepting that, if there are any code points outside
+        the BMP, MATLAB won't be able to read the output file.
         '''
         if arr.size == 0 or np.all(arr == ''):
             # This an empty string array or a string array containing

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1198,17 +1198,21 @@ def test_empty_mat_error():
 def test_unicode_utf16():
     # Test we save unicode data as utf16, not utf8
     # See https://github.com/scipy/scipy/issues/4431
-    sio = BytesIO()
-    savemat(sio, {'char': u('Python')})
-    reader = MatFile5Reader(sio)
-    reader.initialize_read()
-    reader.read_file_header()
-    hdr, _ = reader.read_var_header()
-    # Confirm this is a string matrix
-    assert_equal(hdr.mclass, mio5p.mxCHAR_CLASS)
-    # Get the mdtype of the string, check its miUTF16
-    mdtype, byte_count, tag_data = reader._matrix_reader.read_tag()
-    assert_equal(mdtype, mio5p.miUTF16)
+    for in_str in (u('Python'),  # ASCII
+                   u("Hello to China 你好"),  # BMP, not ASCII
+                   u("G-clef: \U0001D11E F-clef: \U0001D122")  # non BMP
+                  ):
+        sio = BytesIO()
+        savemat(sio, {'char': in_str})
+        reader = MatFile5Reader(sio)
+        reader.initialize_read()
+        reader.read_file_header()
+        hdr, _ = reader.read_var_header()
+        # Confirm this is a string matrix
+        assert_equal(hdr.mclass, mio5p.mxCHAR_CLASS)
+        # Get the mdtype of the string, check its miUTF16
+        mdtype, byte_count, tag_data = reader._matrix_reader.read_tag()
+        assert_equal(mdtype, mio5p.miUTF16)
 
 
 if __name__ == "__main__":

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: latin-1 -*-
+# -*- coding: utf-8 -*-
 ''' Nose test generators
 
 Need function load / save / roundtrip tests

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1195,5 +1195,21 @@ def test_empty_mat_error():
     assert_raises(MatReadError, loadmat, sio)
 
 
+def test_unicode_utf16():
+    # Test we save unicode data as utf16, not utf8
+    # See https://github.com/scipy/scipy/issues/4431
+    sio = BytesIO()
+    savemat(sio, {'char': u('Python')})
+    reader = MatFile5Reader(sio)
+    reader.initialize_read()
+    reader.read_file_header()
+    hdr, _ = reader.read_var_header()
+    # Confirm this is a string matrix
+    assert_equal(hdr.mclass, mio5p.mxCHAR_CLASS)
+    # Get the mdtype of the string, check its miUTF16
+    mdtype, byte_count, tag_data = reader._matrix_reader.read_tag()
+    assert_equal(mdtype, mio5p.miUTF16)
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
It turns out that MATLAB (and Octave) do not tolerate UTF8 strings with 
multibyte characters.

Save unicode strings with UTF16.

Closes gh-4431.
