### PR TITLE
fix a typo in the expit docstring

### DIFF
--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -4828,7 +4828,7 @@ cdef char *ufunc_expit_doc = (
     "\n"
     "Notes\n"
     "-----\n"
-    "As a ufunc logit takes a number of optional\n"
+    "As a ufunc expit takes a number of optional\n"
     "keyword arguments. For more information\n"
     "see `ufuncs <http://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_\n"
     "\n"

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1040,7 +1040,7 @@ add_newdoc('scipy.special', 'expit',
 
     Notes
     -----
-    As a ufunc logit takes a number of optional
+    As a ufunc expit takes a number of optional
     keyword arguments. For more information
     see `ufuncs <http://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_
 


### PR DESCRIPTION
fixes https://github.com/scipy/scipy/issues/4445

[ci skip]
