### PR TITLE
MAINT: don't fail large data tests on MemoryError

### DIFF
--- a/scipy/ndimage/tests/test_ndimage.py
+++ b/scipy/ndimage/tests/test_ndimage.py
@@ -39,6 +39,7 @@ from numpy import fft
 from numpy.testing import (assert_, assert_equal, assert_array_equal,
         run_module_suite, assert_array_almost_equal, assert_almost_equal, dec)
 import scipy.ndimage as ndimage
+from nose import SkipTest
 
 
 eps = 1e-12
@@ -1747,11 +1748,14 @@ class TestNdimage:
     @dec.skipif('win32' in sys.platform or numpy.intp(0).itemsize < 8)
     def test_map_coordinates_large_data(self):
         # check crash on large data
-        n = 30000
-        a = numpy.empty(n**2, dtype=numpy.float32).reshape(n, n)
-        # fill the part we might read
-        a[n - 3:,n - 3:] = 0
-        ndimage.map_coordinates(a, [[n - 1.5], [n - 1.5]], order=1)
+        try:
+            n = 30000
+            a = numpy.empty(n**2, dtype=numpy.float32).reshape(n, n)
+            # fill the part we might read
+            a[n - 3:,n - 3:] = 0
+            ndimage.map_coordinates(a, [[n - 1.5], [n - 1.5]], order=1)
+        except MemoryError:
+            raise SkipTest("Not enough memory available")
 
     def test_affine_transform01(self):
         data = numpy.array([1])


### PR DESCRIPTION
e.g. systems with overcommit disabled may fail the sparse allocation.
