### PR TITLE
WIP: add SQUAREM for fixed point problems

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -110,7 +110,8 @@ Fixed point finding:
 .. autosummary::
    :toctree: generated/
 
-   fixed_point - Single-variable fixed-point solver
+   fixpoint - Single-variable fixed-point solver
+   fixed_point - Steffensen's method for fixed points
 
 Multidimensional
 ----------------

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -17,7 +17,7 @@ from warnings import warn
 
 from .optimize import MemoizeJac, OptimizeResult, _check_unknown_options
 from .minpack import _root_hybr, leastsq, _fixpoint_steffensen
-from ._spectral import _root_df_sane
+from ._spectral import _root_df_sane, _fixpoint_squarem
 from . import nonlin
 
 
@@ -224,7 +224,7 @@ def fixpoint(fun, x0, args=(), method=None, jac=None, tol=None, callback=None,
         Initial guess for the fixed point.
     args : tuple, optional
         Extra arguments to `func`.
-    method : {'steffensen'}, optional
+    method : {'steffensen', 'squarem'}, optional
         Method to use to solve for the fixed point.
     jac : callable, optional
         Method returning Jacobian of the function.
@@ -245,6 +245,9 @@ def fixpoint(fun, x0, args=(), method=None, jac=None, tol=None, callback=None,
     -----
     Method *steffensen* uses Steffensen's Method with Aitken's
     ``Del^2`` convergence acceleration. [1]_
+
+    Method *squarem* uses the SQUAREM [2]_ spectral acceleration
+    approach.
 
     See Also
     --------
@@ -270,12 +273,15 @@ def fixpoint(fun, x0, args=(), method=None, jac=None, tol=None, callback=None,
     # set default tolerances
     if tol is not None:
         options = dict(options)
-        if meth in ('steffensen',):
+        if meth in ('steffensen', 'squarem'):
             options.setdefault('xtol', tol)
 
     if meth == 'steffensen':
         _warn_jac_unused(jac, method)
         sol = _fixpoint_steffensen(fun, x0, args=args, callback=callback, **options)
+    elif meth == 'squarem':
+        _warn_jac_unused(jac, method)
+        sol = _fixpoint_squarem(fun, x0, args=args, callback=callback, **options)
     else:
         raise ValueError('Unknown solver %s' % method)
 

--- a/scipy/optimize/_spectral.py
+++ b/scipy/optimize/_spectral.py
@@ -96,8 +96,8 @@ def _root_df_sane(func, x0, args=(), ftol=1e-8, fatol=1e-300, maxfev=1000,
             # Obtain squared 2-norm of the current residual from the outer scope
             return f_k**(1.0/nexp)
 
-    def fmerit(F):
-        return np.linalg.norm(F)**nexp
+    def fmerit(x, F):
+        return np.linalg.norm(F.ravel())**nexp
 
     nfev = [0]
     f, x_k, x_shape, f_k, F_k, is_complex = _wrap_func(func, x0, fmerit, nfev, maxfev, args)
@@ -125,6 +125,12 @@ def _root_df_sane(func, x0, args=(), ftol=1e-8, fatol=1e-300, maxfev=1000,
     while True:
         F_k_norm = fnorm(F_k)
 
+        # Control spectral parameter, from [2]
+        if abs(sigma_k) > 1/sigma_eps:
+            sigma_k = 1/sigma_eps * np.sign(sigma_k)
+        elif abs(sigma_k) < sigma_eps:
+            sigma_k = sigma_eps
+
         if disp:
             print("iter %d: ||F|| = %g, sigma = %g" % (k, F_k_norm, sigma_k))
 
@@ -145,12 +151,6 @@ def _root_df_sane(func, x0, args=(), ftol=1e-8, fatol=1e-300, maxfev=1000,
             message = "convergence stagnated"
             converged = False
             break
-
-        # Control spectral parameter, from [2]
-        if abs(sigma_k) > 1/sigma_eps:
-            sigma_k = 1/sigma_eps * np.sign(sigma_k)
-        elif abs(sigma_k) < sigma_eps:
-            sigma_k = sigma_eps
 
         # Line search direction
         d = -sigma_k * F_k
@@ -178,6 +178,150 @@ def _root_df_sane(func, x0, args=(), ftol=1e-8, fatol=1e-300, maxfev=1000,
         # Store function value
         if line_search == 'cruz':
             prev_fs.append(fp)
+
+        k += 1
+
+    x = _wrap_result(x_k, is_complex, shape=x_shape)
+    F = _wrap_result(F_k, is_complex)
+
+    result = OptimizeResult(x=x, success=converged,
+                            message=message,
+                            fun=F, nfev=nfev[0], nit=k)
+
+    return result
+
+
+def _fixpoint_squarem(func, x0, args=(), xtol=1e-8, xatol=1e-300,
+                      maxfev=1000, fnorm=None, callback=None, disp=False,
+                      fmerit=None, step_rule=3, **unknown_options):
+    r"""
+    Solve a fixed-point equation with the SQUAREM method.
+
+    Parameters
+    ----------
+    func : callable
+        Function whose fixed point to find
+    x0 : ndarray
+        Initial guess
+    args : tuple
+        Extra parameters to `func`
+    callback : callable, optional
+        Callback function to call on each iteration. Called as
+        ``callable(x, f)`` where ``x`` is the current iterate and
+        ``f`` the residual.
+    xtol : float, optional
+        Relative norm tolerance.
+    xatol : float, optional
+        Absolute norm tolerance.
+        Algorithm terminates when ``||func(x) - x|| < xtol ||x|| + xatol``.
+    fnorm : callable, optional
+        Norm to use in the convergence check. If None, 2-norm is used.
+    maxfev : int, optional
+        Maximum number of function evaluations.
+    disp : bool, optional
+        Whether to print convergence process to stdout.
+    step_rule : {1, 2, 3}, optional
+        Which of the SQUAREM step length rules to use, see below.
+        Default: 2
+    fmerit : callable, optional
+        Merit function to be minimized in the globalization step;
+        called as ``fmerit(x, F)``. For EM, take the negative of
+        the likelihood function. Default: ||F - x||**2
+
+    Notes
+    -----
+    The convergence result for the algorithm in [1] assumes that the function
+    is a contraction in the norm specified by the merit function.
+
+    There are three possible choices for the step length, see [1]_::
+
+        (1)  alpha_k = vdot(r, v) / vdot(v, v)
+        (2)  alpha_k = vdot(r, r) / vdot(r, v)
+        (3)  alpha_k = -sqrt(vdot(r, r) / vdot(v, v))
+
+    The different choices minimize different step length model objective functions.
+
+    References
+    ----------
+    .. [1] R. Varadhan, C. Roland. Scand. J. Statistics, 35, 335 (2008).
+
+    """
+    _check_unknown_options(unknown_options)
+
+    if step_rule not in (1, 2, 3):
+        raise ValueError("Invalid step_rule %r; shoul be one of (1, 2, 3)" % (step_rule,))
+
+    if fmerit is None:
+        def fmerit(x, F):
+            return np.linalg.norm((x - F).ravel())**2
+
+    nfev = [0]
+    f, x_k, x_shape, f_k, F_k, is_complex = _wrap_func(func, x0, fmerit, nfev, maxfev, args)
+
+    k = 0
+    alpha_k = 1.0
+    backtrack_theta = 0.1
+
+    if fnorm is None:
+        def fnorm(z):
+            return np.linalg.norm(z)
+
+    converged = False
+    message = "Too many function evaluations required"
+
+    while True:
+        dx_norm = fnorm(F_k - x_k)
+
+        try:
+            _, FF_k = f(F_k)
+        except _NoConvergence:
+            break
+
+        # SQUAREM spectral parameter
+        r_k = F_k - x_k
+        v_k = (FF_k - F_k) - r_k
+
+        with np.errstate(invalid='ignore', over='ignore'):
+            if step_rule == 1:
+                alpha_k = np.vdot(r_k, v_k) / np.vdot(v_k, v_k)
+            elif step_rule == 2:
+                alpha_k = np.vdot(r_k, r_k) / np.vdot(r_k, v_k)
+            elif step_rule == 3:
+                alpha_k = -np.linalg.norm(r_k) / np.linalg.norm(v_k)
+
+        if disp:
+            print("iter %d: ||dx|| = %g, sigma = %g" % (k, dx_norm, alpha_k))
+
+        if callback is not None:
+            callback(x_k)
+
+        if dx_norm < xtol * fnorm(x_k) + xatol:
+            # Converged!
+            message = "Converged successfully"
+            converged = True
+            break
+
+        # Backtracking
+        try:
+            # The approach from [1]
+            if not (alpha_k <= -1):
+                alpha_k = -1
+
+            while True:
+                xp = x_k - 2 * alpha_k * r_k + alpha_k**2 * v_k
+                fp, Fp = f(xp)
+                if fp < f_k or not (alpha_k < -1):
+                    break
+                alpha_k = backtrack_theta * alpha_k + (-1)*(1 - backtrack_theta)
+        except _NoConvergence:
+            break
+
+        # Stabilization
+        xp = Fp
+
+        # Take step
+        x_k = xp
+        f_k, F_k = f(xp)
 
         k += 1
 
@@ -246,8 +390,8 @@ def _wrap_func(func, x0, fmerit, nfev_list, maxfev, args=()):
             nfev_list[0] += 1
             z = _real2complex(x).reshape(x0_shape)
             v = np.asarray(func(z, *args)).ravel()
+            f = fmerit(z, v)
             F = _complex2real(v)
-            f = fmerit(F)
             return f, F
 
         x0 = _complex2real(x0)
@@ -257,12 +401,13 @@ def _wrap_func(func, x0, fmerit, nfev_list, maxfev, args=()):
             if nfev_list[0] >= maxfev:
                 raise _NoConvergence()
             nfev_list[0] += 1
-            x = x.reshape(x0_shape)
-            F = np.asarray(func(x, *args)).ravel()
-            f = fmerit(F)
+            z = x.reshape(x0_shape)
+            F = np.asarray(func(z, *args))
+            f = fmerit(z, F)
+            F = F.ravel()
             return f, F
 
-    return wrap_func, x0, x0_shape, fmerit(F), F, is_complex
+    return wrap_func, x0, x0_shape, fmerit(x0, F), F, is_complex
 
 
 def _wrap_result(result, is_complex, shape=None):

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -701,7 +701,7 @@ def _fixpoint_steffensen(func, x0, args=(), xtol=1e-8, xatol=1e-300, maxiter=500
         if callback is not None:
             callback(p0.reshape(x0_shape))
         p1 = np.asarray(func(p0.reshape(x0_shape), *args)).ravel()
-        p2 = np.asarray(func(p1.reshape(x0_shape), *args)).flatten() # make a copy
+        p2 = np.asarray(func(p1.reshape(x0_shape), *args)).flatten()  # make a copy
         d = p2 - 2.0 * p1 + p0
         m = (d == 0)
         p = p2

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3179,11 +3179,16 @@ def show_options(solver=None, method=None):
             Number of iterates to include in the nonmonotonic line search.
             Default: 10
 
-        line_search : {'cruz', 'cheng'}
+        line_search : {'cruz', 'cheng'}, optional
             Type of line search to employ. 'cruz' is the original one defined in
             [Martinez & Raydan. Math. Comp. 75, 1429 (2006)], 'cheng' is
             a modified search defined in [Cheng & Li. IMA J. Numer. Anal. 29, 814 (2009)].
             Default: 'cruz'
+
+        stagnation_limit : int, optional
+            If merit function does not decrease in `stagnation_limit` iterations,
+            terminate with failure.
+            Default: 100
 
     **linprog options**
 

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -3208,6 +3208,47 @@ def show_options(solver=None, method=None):
             fail to converge due to cycling, using Bland's rule can provide
             convergence at the expense of a less optimal path about the simplex.
 
+
+    **fixpoint options**
+
+    *steffensen* options:
+
+        maxiter : int, optional
+            Maximum number of iterations to make.
+
+        xtol : float, optional
+            Relative tolerance. Default: 1e-8
+
+        xatol : float, optional
+            Absolute tolerance. Default: 0
+
+    *squarem* options:
+
+        xtol : float, optional
+            Relative norm tolerance.
+
+        xatol : float, optional
+            Absolute norm tolerance.
+            Algorithm terminates when ``||func(x) - x|| < xtol ||x|| + xatol``.
+
+        fnorm : callable, optional
+            Norm to use in the convergence check. If None, 2-norm is used.
+
+        maxfev : int, optional
+            Maximum number of function evaluations.
+
+        disp : bool, optional
+            Whether to print convergence process to stdout.
+
+        step_rule : {1, 2, 3}, optional
+            Which of the SQUAREM step length rules to use.
+            Default: 3 if is_contraction, otherwise 2
+
+        fmerit : callable, optional
+            Merit function to be minimized in the globalization step;
+            called as ``fmerit(x, F)``. For EM, take the negative of
+            the likelihood function. Default: ||F - x||**2
+
     """
     import textwrap
 
@@ -3227,7 +3268,7 @@ def show_options(solver=None, method=None):
         return
 
     solver = solver.lower()
-    if solver not in ('minimize', 'minimize_scalar', 'root', 'linprog'):
+    if solver not in ('minimize', 'minimize_scalar', 'root', 'linprog', 'fixpoint'):
         raise ValueError('Unknown solver.')
 
     solvers_doc = [s.strip()

--- a/scipy/optimize/tests/test__root.py
+++ b/scipy/optimize/tests/test__root.py
@@ -3,10 +3,11 @@ Unit tests for optimization routines from _root.py.
 """
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import assert_
+from numpy.testing import assert_, assert_allclose
 import numpy as np
 
-from scipy.optimize import root
+from scipy.optimize import root, fixpoint
+from scipy.special import lambertw
 
 
 class TestRoot(object):
@@ -45,3 +46,87 @@ class TestRoot(object):
             x, y = z
             return np.array([x**3 - 1, y**3 - f])
         root(func, [1.1, 1.1], args=1.5)
+
+
+class TestFixPoint(object):
+
+    def _check_scalar_trivial(self, method):
+        # f(x) = 2x; fixed point should be x=0
+        def func(x):
+            return 2.0*x
+        x0 = 1.0
+        sol = fixpoint(func, x0, method=method)
+        assert_(sol.success)
+        assert_allclose(sol.x, 0.0, atol=1e-15)
+
+    def _check_scalar_basic1(self, method):
+        # f(x) = x**2; x0=1.05; fixed point should be x=1
+        def func(x):
+            return x**2
+        x0 = 1.05
+        sol = fixpoint(func, x0, method=method)
+        assert_(sol.success)
+        assert_allclose(sol.x, 1.0)
+
+    def _check_scalar_basic2(self, method):
+        # f(x) = x**0.5; x0=1.05; fixed point should be x=1
+        def func(x):
+            return x**0.5
+        x0 = 1.05
+        sol = fixpoint(func, x0, method=method)
+        assert_(sol.success)
+        assert_allclose(sol.x, 1.0)
+
+    def _check_array_trivial(self, method):
+        def func(x):
+            return 2.0*x
+        x0 = [0.3, 0.15]
+        olderr = np.seterr(all='ignore')
+        try:
+            sol = fixpoint(func, x0, method=method)
+        finally:
+            np.seterr(**olderr)
+        assert_(sol.success)
+        assert_allclose(sol.x, [0.0, 0.0], atol=1e-15)
+
+    def _check_array_basic1(self, method):
+        # f(x) = c * x**2; fixed point should be x=1/c
+        def func(x, c):
+            return c * x**2
+        c = np.array([0.75, 1.0, 1.25])
+        x0 = [1.1, 1.15, 0.9]
+        olderr = np.seterr(all='ignore')
+        try:
+            sol = fixpoint(func, x0, args=(c,), method=method)
+        finally:
+            np.seterr(**olderr)
+        assert_(sol.success)
+        assert_allclose(sol.x, 1.0/c)
+
+    def _check_array_basic2(self, method):
+        # f(x) = c * x**0.5; fixed point should be x=c**2
+        def func(x, c):
+            return c * x**0.5
+        c = np.array([0.75, 1.0, 1.25])
+        x0 = [0.8, 1.1, 1.1]
+        sol = fixpoint(func, x0, args=(c,), method=method)
+        assert_(sol.success)
+        assert_allclose(sol.x, c**2)
+
+    def _check_lambertw(self, method):
+        # python-list/2010-December/594592.html
+        sol = fixpoint(lambda xx: np.exp(-2.0*xx)/2.0, 1.0,
+                       method=method, args=(), options=dict(xtol=1e-12, maxiter=500))
+        assert_(sol.success)
+        assert_allclose(sol.x, np.exp(-2.0*sol.x)/2.0)
+        assert_allclose(sol.x, lambertw(1)/2)
+
+    def test_methods(self):
+        for method in ['steffensen']:
+            yield self._check_scalar_trivial, method
+            yield self._check_scalar_basic1, method
+            yield self._check_scalar_basic2, method
+            yield self._check_array_trivial, method
+            yield self._check_array_basic1, method
+            yield self._check_array_basic2, method
+            yield self._check_lambertw, method

--- a/scipy/optimize/tests/test__root.py
+++ b/scipy/optimize/tests/test__root.py
@@ -92,8 +92,10 @@ class TestFixPoint(object):
     def _check_array_basic1(self, method):
         # f(x) = c * x**2; fixed point should be x=1/c or x=0
         opts = dict()
+
         def func(x, c):
             return c * x**2
+
         c = np.array([0.75, 1.0, 1.25])
         x0 = [1.1, 1.15, 0.9]
         olderr = np.seterr(all='ignore')

--- a/scipy/optimize/tests/test__spectral.py
+++ b/scipy/optimize/tests/test__spectral.py
@@ -4,9 +4,9 @@ import itertools
 
 import numpy as np
 from numpy import exp
-from numpy.testing import assert_, assert_equal
+from numpy.testing import assert_, assert_equal, assert_allclose
 
-from scipy.optimize import root
+from scipy.optimize import root, fixpoint
 
 
 def test_performance():
@@ -134,6 +134,22 @@ def test_stagnation():
     assert_(not sol.success)
     assert_equal(sol.message, "convergence stagnated")
     assert_(sol.nfev < 1000, repr(sol.nfev))
+
+
+def test_squarem():
+    # fixed point should be sqrt(c)
+    def func(x, c):
+        return 0.5*(x + c/x)
+
+    c = np.array([0.75, 1.0, 1.25])
+    x0 = [1.1, 1.15, 0.9]
+    olderr = np.seterr(all='ignore')
+    try:
+        sol = fixpoint(func, x0, args=(c,), method='squarem')
+    finally:
+        np.seterr(**olderr)
+    assert_(sol.success)
+    assert_allclose(sol.x, np.sqrt(c))
 
 
 # Some of the test functions and initial guesses listed in

--- a/scipy/optimize/tests/test__spectral.py
+++ b/scipy/optimize/tests/test__spectral.py
@@ -124,6 +124,18 @@ def test_shape():
         assert_equal(sol.x.shape, x.shape)
 
 
+def test_stagnation():
+    def f(x):
+        return 1 + np.random.rand()
+
+    np.random.seed(1234)
+    sol = root(f, [0], options=dict(fatol=1e-6, ftol=0, maxfev=10000, stagnation_limit=20),
+               method='df-sane')
+    assert_(not sol.success)
+    assert_equal(sol.message, "convergence stagnated")
+    assert_(sol.nfev < 1000, repr(sol.nfev))
+
+
 # Some of the test functions and initial guesses listed in
 # [W. La Cruz, M. Raydan. Optimization Methods and Software, 18, 583 (2003)]
 


### PR DESCRIPTION
This adds the SQUAREM algorithm plus a root() like interface for fixed point problems.

There's probably stuff to discuss on the interface side, but also on the algorithm side: The backtracking is as suggested in the paper, but I'm not so sure if that's a very good choice in general, as it probably requires the mapping is a contraction. Also, someone who actually does EM would probably need to comment whether this would be useful for them or not.

I think there's room for adding more fixed point solvers --- although the problem can always be mapped to root finding and vice versa, they're not exactly the same thing. Besides, the steffensen/aitken method offered by Scipy currently looks a bit naive...
