### PR TITLE
CI: use travis_retry to deal with network timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,10 +66,10 @@ before_install:
   - popd
   # End install gmpy2 dependencies
   # Speed up install by not compiling Cython
-  - pip install --install-option="--no-cython-compile" Cython
-  - pip install $NUMPYSPEC
-  - pip install nose mpmath argparse
-  - pip install gmpy2  # speeds up mpmath (scipy.special tests)
+  - travis_retry pip install --install-option="--no-cython-compile" Cython
+  - travis_retry pip install $NUMPYSPEC
+  - travis_retry pip install nose mpmath argparse
+  - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - if [ "${TESTMODE}" == "full" ]; then pip install coverage coveralls; fi
   - python -V
   - popd


### PR DESCRIPTION
Once in a while, one or more jobs fail on TravisCI because downloading this or that package times out. 

This PR follows the suggestion in http://docs.travis-ci.com/user/build-timeouts/ and http://docs.travis-ci.com/user/build-timeouts/ and tries to work around these intermittent network issues via `travis_retry`.

Note that I'm only retrying `pip installs` only because I do not remember any problems with either OS-level installs or gmpy2 dependencies, if my memory serves. 
