### PR TITLE
ENH: scipy.signal - Cross Spectral Density and Coherence functions

### DIFF
--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -267,138 +267,75 @@ def welch(x, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
     2.0077340678640727
 
     """
-    x = np.asarray(x)
-
-    if x.size == 0:
-        return np.empty(x.shape), np.empty(x.shape)
-
-    if axis != -1:
-        x = np.rollaxis(x, axis, len(x.shape))
-
-    if x.shape[-1] < nperseg:
-        warnings.warn('nperseg = %d, is greater than x.shape[%d] = %d, using '
-                      'nperseg = x.shape[%d]'
-                      % (nperseg, axis, x.shape[axis], axis))
-        nperseg = x.shape[-1]
-
-    if isinstance(window, string_types) or type(window) is tuple:
-        win = get_window(window, nperseg)
-    else:
-        win = np.asarray(window)
-        if len(win.shape) != 1:
-            raise ValueError('window must be 1-D')
-        if win.shape[0] > x.shape[-1]:
-            raise ValueError('window is longer than x.')
-        nperseg = win.shape[0]
-
-    # numpy 1.5.1 doesn't have result_type.
-    outdtype = (np.array([x[0]]) * np.array([1], 'f')).dtype.char.lower()
-    if win.dtype != outdtype:
-        win = win.astype(outdtype)
- 
-    if scaling == 'density':
-        scale = 1.0 / (fs * (win*win).sum())
-    elif scaling == 'spectrum':
-        scale = 1.0 / win.sum()**2
-    else:
-        raise ValueError('Unknown scaling: %r' % scaling)
-
-    if noverlap is None:
-        noverlap = nperseg // 2
-    elif noverlap >= nperseg:
-        raise ValueError('noverlap must be less than nperseg.')
-
-    if nfft is None:
-        nfft = nperseg
-    elif nfft < nperseg:
-        raise ValueError('nfft must be greater than or equal to nperseg.')
-
-    if not detrend:
-        detrend_func = lambda seg: seg
-    elif not hasattr(detrend, '__call__'):
-        detrend_func = lambda seg: signaltools.detrend(seg, type=detrend)
-    elif axis != -1:
-        # Wrap this function so that it receives a shape that it could
-        # reasonably expect to receive.
-        def detrend_func(seg):
-            seg = np.rollaxis(seg, -1, axis)
-            seg = detrend(seg)
-            return np.rollaxis(seg, axis, len(seg.shape))
-    else:
-        detrend_func = detrend
-
-    step = nperseg - noverlap
-    indices = np.arange(0, x.shape[-1]-nperseg+1, step)
-
-    if np.isrealobj(x) and return_onesided:
-        outshape = list(x.shape)
-        if nfft % 2 == 0:  # even
-            outshape[-1] = nfft // 2 + 1
-            Pxx = np.empty(outshape, outdtype)
-            for k, ind in enumerate(indices):
-                x_dt = detrend_func(x[..., ind:ind+nperseg])
-                xft = fftpack.rfft(x_dt*win, nfft)
-                # fftpack.rfft returns the positive frequency part of the fft
-                # as real values, packed r r i r i r i ...
-                # this indexing is to extract the matching real and imaginary
-                # parts, while also handling the pure real zero and nyquist
-                # frequencies.
-                if k == 0:
-                    Pxx[..., (0,-1)] = xft[..., (0,-1)]**2
-                    Pxx[..., 1:-1] = xft[..., 1:-1:2]**2 + xft[..., 2::2]**2
-                else:
-                    Pxx *= k/(k+1.0)
-                    Pxx[..., (0,-1)] += xft[..., (0,-1)]**2 / (k+1.0)
-                    Pxx[..., 1:-1] += (xft[..., 1:-1:2]**2 + xft[..., 2::2]**2) \
-                                    / (k+1.0)
-        else:  # odd
-            outshape[-1] = (nfft+1) // 2
-            Pxx = np.empty(outshape, outdtype)
-            for k, ind in enumerate(indices):
-                x_dt = detrend_func(x[..., ind:ind+nperseg])
-                xft = fftpack.rfft(x_dt*win, nfft)
-                if k == 0:
-                    Pxx[..., 0] = xft[..., 0]**2
-                    Pxx[..., 1:] = xft[..., 1::2]**2 + xft[..., 2::2]**2
-                else:
-                    Pxx *= k/(k+1.0)
-                    Pxx[..., 0] += xft[..., 0]**2 / (k+1)
-                    Pxx[..., 1:] += (xft[..., 1::2]**2 + xft[..., 2::2]**2) \
-                                  / (k+1.0)
-
-        Pxx[..., 1:-1] *= 2*scale
-        Pxx[..., (0,-1)] *= scale
-        f = np.arange(Pxx.shape[-1]) * (fs/nfft)
-    else:
-        for k, ind in enumerate(indices):
-            x_dt = detrend_func(x[..., ind:ind+nperseg])
-            xft = fftpack.fft(x_dt*win, nfft)
-            if k == 0:
-                Pxx = (xft * xft.conj()).real
-            else:
-                Pxx *= k/(k+1.0)
-                Pxx += (xft * xft.conj()).real / (k+1.0)
-        Pxx *= scale
-        f = fftpack.fftfreq(nfft, 1.0/fs)
-
-    if axis != -1:
-        Pxx = np.rollaxis(Pxx, -1, axis)
+    [f, Pxx] = csd(x, x, fs, window, nperseg, noverlap, nfft, detrend, 
+                   return_onesided, scaling, axis)
 
     return f, Pxx
 
 def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
-              nfft=None, detrend='constant', axis=-1, axisX=None, axisY=None):
+              nfft=None, detrend='constant', axis=-1):
+    """
+    Estimate the magnitude squared coherence estimate, Cxy, of discrete-time 
+    signals X and Y Welch's method. Cxy = abs(Pxy)**2/(Pxx*Pyy), where Pxx and 
+    Pyy are power spectral density estimates of X and Y, and Pxy is the cross
+    spectral density estimate of X and Y. 
 
-    if axisX is None: axisX = axis
-    if axisY is None: axisY = axis
+    Parameters
+    ----------
+    x : array_like
+        Time series of measurement values
+    y : array_like
+        Time series of measurement values
+    fs : float, optional
+        Sampling frequency of the `x` and `y` time series in units of Hz. 
+        Defaults to 1.0.
+    window : str or tuple or array_like, optional
+        Desired window to use. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length will be used for nperseg.
+        Defaults to 'hanning'.
+    nperseg : int, optional
+        Length of each segment.  Defaults to 256.
+    noverlap: int, optional
+        Number of points to overlap between segments. If None,
+        ``noverlap = nperseg / 2``.  Defaults to None.
+    nfft : int, optional
+        Length of the FFT used, if a zero padded FFT is desired.  If None,
+        the FFT length is `nperseg`. Defaults to None.
+    detrend : str or function or False, optional
+        Specifies how to detrend each segment. If `detrend` is a string,
+        it is passed as the ``type`` argument to `detrend`.  If it is a
+        function, it takes a segment and returns a detrended segment.
+        If `detrend` is False, no detrending is done.  Defaults to 'constant'.
+    axis : int, optional
+        Axis along which the CSD is computed for both inputs; the default is 
+        over the last axis (i.e. ``axis=-1``).
 
-    [ff,Pxx] = welch(x, fs=fs, window=window, nperseg=nperseg,
-                     noverlap=noverlap, nfft=nfft, detrend=detrend, axis=axisX)
-    [_, Pyy] = welch(y, fs=fs, window=window, nperseg=nperseg,
-                     noverlap=noverlap, nfft=nfft, detrend=detrend, axis=axisY)
-    [_, Pxy] = csd(x, y, fs=fs, window=window, nperseg=nperseg,
-                   noverlap=noverlap, nfft=nfft, detrend=detrend, axis=axis,
-                   axisX=axisX, axisY=axisY)
+    Returns
+    -------
+    f : ndarray
+        Array of sample frequencies.
+    Cxy : ndarray
+        Magnitude squared coherence of x and y.
+
+    See Also
+    --------
+    periodogram: Simple, optionally modified periodogram
+    lombscargle: Lomb-Scargle periodogram for unevenly sampled data
+    welch: Power spectral density by Welch's method.
+    csd: Cross spectral density by Welch's method. 
+
+    Notes
+    --------
+    An appropriate amount of overlap will depend on the choice of window
+    and on your requirements.  For the default 'hanning' window an
+    overlap of 50% is a reasonable trade off between accurately estimating
+    the signal power, while not over counting any of the data.  Narrower
+    windows may require a larger overlap.
+    """
+    [ff,Pxx] = welch(x, fs, window, nperseg, noverlap, nfft, detrend, axis)
+    [_, Pyy] = welch(y, fs, window, nperseg, noverlap, nfft, detrend, axis)
+    [_, Pxy] = csd(x, y, fs, window, nperseg, noverlap, nfft, detrend, axis)
 
     Cxy = np.abs(Pxy)**2/Pxx/Pyy
 
@@ -406,10 +343,9 @@ def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
 
 
 def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
-        detrend='constant', return_onesided=True, scaling='density', axis=-1,
-        axisX=None, axisY=None):
+        detrend='constant', return_onesided=True, scaling='density', axis=-1):
     """
-    Estimate the cross spectral density using Welch's method. 
+    Estimate the cross power spectral density, Pxy, using Welch's method. 
 
     Parameters
     ----------
@@ -448,25 +384,45 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
         computing the power spectrum ('spectrum') where Pxy has units of V**2
         if x and y are measured in V. Defaults to 'density'.
     axis : int, optional
-        Axis along which the periodogram is computed; the default is over
-        the last axis (i.e. ``axis=-1``).
-    axisX : int, optional
-        Axis along which the CSD is computed for the X data; defaults to the
-        'axis' keyword argument.
-    axisY : int, optional
-        Axis along which the CSD is computed for the Y data; defaults to the
-        'axis' keywrd argument.
+        Axis along which the CSD is computed for both inputs; the default is 
+        over the last axis (i.e. ``axis=-1``).
 
     Returns
     -------
     f : ndarray
         Array of sample frequencies.
     Pxy : ndarray
-        Power spectral density or power spectrum of x.
+        Cross spectral density or cross power spectrum of x,y.
 
+    See Also
+    --------
+    periodogram: Simple, optionally modified periodogram
+    lombscargle: Lomb-Scargle periodogram for unevenly sampled data
+    welch: Power spectral density by Welch's method. [Equivalent to csd(x,x)]
+    coherence: Magnitude squred coherence by Welch's method. 
+
+    Notes
+    --------
+    By convention, Pxy is computed with the conjugate FFT of X multiplied by 
+    the FFT of Y. 
+
+    An appropriate amount of overlap will depend on the choice of window
+    and on your requirements.  For the default 'hanning' window an
+    overlap of 50% is a reasonable trade off between accurately estimating
+    the signal power, while not over counting any of the data.  Narrower
+    windows may require a larger overlap.
+
+    If `noverlap` is 0, this method is equivalent to Bartlett's method [2]_.
+
+    References
+    ----------
+    .. [1] P. Welch, "The use of the fast Fourier transform for the
+           estimation of power spectra: A method based on time averaging
+           over short, modified periodograms", IEEE Trans. Audio
+           Electroacoust. vol. 15, pp. 70-73, 1967.
+    .. [2] M.S. Bartlett, "Periodogram Analysis and Continuous Spectra",
+           Biometrika, vol. 37, pp. 1-16, 1950.
     """
-    if axisX is None: axisX = axis
-    if axisY is None: axisY = axis
 
     if y is x: 
         psd = True
@@ -476,30 +432,32 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
         x = np.asarray(x)
         y = np.asarray(y)
 
-    if x.size == 0 or y.size == 0:
+    if x.size == 0:
         return np.empty(x.shape), np.empty(x.shape)
+    if y.size == 0:
+        return np.empty(y.shape), np.empty(y.shape)
 
-    if axisX != -1:
-        x = np.rollaxis(x, axisX, len(x.shape))
-    if axisY != -1:
-        y = np.rollaxis(y, axisY, len(y.shape))
+    if axis != -1:
+        x = np.rollaxis(x, axis, len(x.shape))
+        y = np.rollaxis(y, axis, len(y.shape))
 
     if x.shape[-1] < nperseg:
         warnings.warn('nperseg = %d, is greater than x.shape[%d] = %d, using '
                       'nperseg = x.shape[%d]'
-                      % (nperseg, axisX, x.shape[axisX], axisX))
+                      % (nperseg, axis, x.shape[axis], axis))
         nperseg = x.shape[-1]
 
-    if psd is False:
+    # These checks only neccesary if x!=y
+    if not psd:
         if y.shape[-1] < nperseg:
             warnings.warn('nperseg = %d, is greater than y.shape[%d] = %d, '
                           'using nperseg = y.shape[%d]'
-                          % (nperseg, axisY, y.shape[axisY], axisY))
+                          % (nperseg, axis, y.shape[axis], axis))
             nperseg = y.shape[-1]
 
         # Check if we can broadcast the remaining axes together
         for a, b in zip(x.shape[-2::-1],y.shape[-2::-1]):
-            if a==1 or b==1 or a==b:
+            if a == 1 or b == 1 or a == b:
                 pass
             else:
                 raise ValueError('x and y cannot be broadcast together.')
@@ -581,8 +539,8 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
         for k, ind in enumerate(indices):
             x_dt = detrend_func(x[..., ind:ind+nperseg])
             xft = fftpack.rfft(x_dt*win, nfft)
-            if psd is True:
-                yft=xft
+            if psd:
+                yft = xft
             else:
                 y_dt = detrend_func(y[..., ind:ind+nperseg])
                 yft = fftpack.rfft(y_dt*win, nfft)
@@ -593,29 +551,29 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
             # parts, while also handling the pure real zero and nyquist
             # frequencies.
             if k == 0:
-                Pxy[...,0] = xft[0]*yft[0]
+                Pxy[...,0] = xft[...,0]*yft[...,0]
                 if nfft % 2 == 0:
-                    centralProduct = ((xft[1:-1:2] - 1j*xft[2:-1:2]) 
-                                      * (yft[1:-1:2] + 1j*yft[2:-1:2]))
-                    Pxy[...,-1] = xft[-1]*yft[-1]
+                    product = ((xft[...,1:-1:2] - 1j*xft[...,2:-1:2]) 
+                                      * (yft[...,1:-1:2] + 1j*yft[...,2:-1:2]))
+                    Pxy[...,-1] = xft[...,-1]*yft[...,-1]
                 else:
-                    centralProduct = ((xft[1::2] - 1j*xft[2::2]) 
-                                      * (yft[1::2] + 1j*yft[2::2]))
+                    product = ((xft[...,1::2] - 1j*xft[...,2::2]) 
+                                      * (yft[...,1::2] + 1j*yft[...,2::2]))
 
-                Pxy[...,1:1+len(centralProduct)] = centralProduct
+                Pxy[...,1:1+product.shape[-1]] = product
 
             else:
                 Pxy *= k/(k+1.0)
                 Pxy[...,0] += xft[0]*yft[0] / (k+1.0)
                 if nfft % 2 == 0:
-                    centralProduct = ((xft[1:-1:2] - 1j*xft[2:-1:2]) 
-                                      * (yft[1:-1:2] + 1j*yft[2:-1:2]))
-                    Pxy[...,-1] += xft[-1]*yft[-1] / (k+1.0)
+                    product = ((xft[...,1:-1:2] - 1j*xft[...,2:-1:2]) 
+                                      * (yft[...,1:-1:2] + 1j*yft[...,2:-1:2]))
+                    Pxy[...,-1] += xft[...,-1]*yft[...,-1] / (k+1.0)
                 else:
-                    centralProduct = ((xft[1::2] - 1j*xft[2::2]) 
-                                      * (yft[1::2] + 1j*yft[2::2]))
+                    product = ((xft[...,1::2] - 1j*xft[...,2::2]) 
+                                      * (yft[...,1::2] + 1j*yft[...,2::2]))
 
-                Pxy[...,1:1+len(centralProduct)] += centralProduct / (k+1.0)
+                Pxy[...,1:1+product.shape[-1]] += product / (k+1.0)
 
         Pxy[..., 1:-1] *= 2*scale
         Pxy[..., (0,-1)] *= scale
@@ -624,8 +582,8 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
         for k, ind in enumerate(indices):
             x_dt = detrend_func(x[..., ind:ind+nperseg])
             xft = fftpack.fft(x_dt*win, nfft)
-            if psd is True:
-                yft=xft
+            if psd:
+                yft = xft
             else:
                 y_dt = detrend_func(y[..., ind:ind+nperseg])
                 yft = fftpack.fft(y_dt*win, nfft)
@@ -635,10 +593,12 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
             else:
                 Pxy *= k/(k+1.0)
                 Pxy += (xft.conj() * yft) / (k+1.0)
+
         Pxy *= scale
+        Pxy = Pxy.astype(outdtype)
         f = fftpack.fftfreq(nfft, 1.0/fs)
 
-    if psd is True:
+    if psd:
         Pxy = Pxy.real
 
     if axis != -1:

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -408,6 +408,9 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
     By convention, Pxy is computed with the conjugate FFT of X multiplied by 
     the FFT of Y. 
 
+    If the input series differ in length, the shorter series will be 
+    zero-padded to match.
+
     An appropriate amount of overlap will depend on the choice of window
     and on your requirements.  For the default 'hanning' window an
     overlap of 50\% is a reasonable trade off between accurately estimating
@@ -464,17 +467,13 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
             else:
                 raise ValueError('x and y cannot be broadcast together.')
 
-        # Check if x and y are the same length
+        # Check if x and y are the same length, pad if neccesary
         if x.shape[-1] != y.shape[-1]:
-            warnings.warn('Inputs x and y have different lengths along chosen '
-                          'axes.')
             if x.shape[-1] < y.shape[-1]:
-                warnings.warn('x will be zero-padded to match.')
                 padShape = x.shape
                 padShape[-1] = y.shape[-1] - x.shape[-1]
                 x = np.concatenate((x, np.zeros(padShape)), -1)
             else:
-                warnings.warn('y will be zero-padded to match.')
                 padShape = y.shape
                 padShape[-1] = x.shape[-1] - y.shape[-1]
                 y = np.concatenate((y, np.zeros(padShape)), -1)

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -488,9 +488,9 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
             raise ValueError('Window is longer than input data.')
         nperseg = win.shape[0]
 
-    outdtype = np.result_type(np.array([x[0]*y[0]]) * np.array([1], 'F'))
+    outdtype = np.result_type(x,y,np.complex64)
 
-    if np.result_type(np.array(win[0]*np.array([1], 'F'))) != outdtype:
+    if np.result_type(win,np.complex64) != outdtype:
         win = win.astype(outdtype)
  
     if scaling == 'density':

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -448,11 +448,6 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
 
     # These checks only neccesary if x!=y
     if not psd:
-        #if y.shape[-1] < nperseg:
-            #warnings.warn('nperseg = %d, is greater than y.shape[%d] = %d, '
-                          #'using nperseg = y.shape[%d]'
-                          #% (nperseg, axis, y.shape[axis], axis))
-            #nperseg = y.shape[-1]
 
         # Check if we can broadcast the remaining axes together
         for a, b in zip(x.shape[-2::-1],y.shape[-2::-1]):
@@ -473,9 +468,9 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
                 y = np.concatenate((y, np.zeros(padShape)), -1)
 
     if x.shape[-1] < nperseg:
-        warnings.warn('nperseg = %d, is greater than x.shape[%d] = %d, using '
-                      'nperseg = x.shape[%d]'
-                      % (nperseg, axis, x.shape[axis], axis))
+        warnings.warn('nperseg = %d, is greater than input length = %d, using '
+                      'nperseg = %d'
+                      % (nperseg, x.shape[axis], x.shape[axis]))
         nperseg = x.shape[-1]
 
     if isinstance(window, string_types) or type(window) is tuple:

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -203,7 +203,7 @@ def welch(x, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
     -----
     An appropriate amount of overlap will depend on the choice of window
     and on your requirements.  For the default 'hanning' window an
-    overlap of 50% is a reasonable trade off between accurately estimating
+    overlap of 50\% is a reasonable trade off between accurately estimating
     the signal power, while not over counting any of the data.  Narrower
     windows may require a larger overlap.
 
@@ -276,9 +276,11 @@ def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
               nfft=None, detrend='constant', axis=-1):
     """
     Estimate the magnitude squared coherence estimate, Cxy, of discrete-time 
-    signals X and Y Welch's method. Cxy = abs(Pxy)**2/(Pxx*Pyy), where Pxx and 
-    Pyy are power spectral density estimates of X and Y, and Pxy is the cross
-    spectral density estimate of X and Y. 
+    signals X and Y using Welch's method. 
+    
+    Cxy = abs(Pxy)**2/(Pxx*Pyy), where Pxx and Pyy are power spectral density 
+    estimates of X and Y, and Pxy is the cross spectral density estimate of X 
+    and Y. 
 
     Parameters
     ----------
@@ -329,7 +331,7 @@ def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
     --------
     An appropriate amount of overlap will depend on the choice of window
     and on your requirements.  For the default 'hanning' window an
-    overlap of 50% is a reasonable trade off between accurately estimating
+    overlap of 50\% is a reasonable trade off between accurately estimating
     the signal power, while not over counting any of the data.  Narrower
     windows may require a larger overlap.
     """
@@ -399,7 +401,7 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
     periodogram: Simple, optionally modified periodogram
     lombscargle: Lomb-Scargle periodogram for unevenly sampled data
     welch: Power spectral density by Welch's method. [Equivalent to csd(x,x)]
-    coherence: Magnitude squred coherence by Welch's method. 
+    coherence: Magnitude squared coherence by Welch's method. 
 
     Notes
     --------
@@ -408,7 +410,7 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
 
     An appropriate amount of overlap will depend on the choice of window
     and on your requirements.  For the default 'hanning' window an
-    overlap of 50% is a reasonable trade off between accurately estimating
+    overlap of 50\% is a reasonable trade off between accurately estimating
     the signal power, while not over counting any of the data.  Narrower
     windows may require a larger overlap.
 

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -446,19 +446,13 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
         x = np.rollaxis(x, axis, len(x.shape))
         y = np.rollaxis(y, axis, len(y.shape))
 
-    if x.shape[-1] < nperseg:
-        warnings.warn('nperseg = %d, is greater than x.shape[%d] = %d, using '
-                      'nperseg = x.shape[%d]'
-                      % (nperseg, axis, x.shape[axis], axis))
-        nperseg = x.shape[-1]
-
     # These checks only neccesary if x!=y
     if not psd:
-        if y.shape[-1] < nperseg:
-            warnings.warn('nperseg = %d, is greater than y.shape[%d] = %d, '
-                          'using nperseg = y.shape[%d]'
-                          % (nperseg, axis, y.shape[axis], axis))
-            nperseg = y.shape[-1]
+        #if y.shape[-1] < nperseg:
+            #warnings.warn('nperseg = %d, is greater than y.shape[%d] = %d, '
+                          #'using nperseg = y.shape[%d]'
+                          #% (nperseg, axis, y.shape[axis], axis))
+            #nperseg = y.shape[-1]
 
         # Check if we can broadcast the remaining axes together
         for a, b in zip(x.shape[-2::-1],y.shape[-2::-1]):
@@ -470,13 +464,19 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
         # Check if x and y are the same length, pad if neccesary
         if x.shape[-1] != y.shape[-1]:
             if x.shape[-1] < y.shape[-1]:
-                padShape = x.shape
+                padShape = list(x.shape)
                 padShape[-1] = y.shape[-1] - x.shape[-1]
                 x = np.concatenate((x, np.zeros(padShape)), -1)
             else:
-                padShape = y.shape
+                padShape = list(y.shape)
                 padShape[-1] = x.shape[-1] - y.shape[-1]
                 y = np.concatenate((y, np.zeros(padShape)), -1)
+
+    if x.shape[-1] < nperseg:
+        warnings.warn('nperseg = %d, is greater than x.shape[%d] = %d, using '
+                      'nperseg = x.shape[%d]'
+                      % (nperseg, axis, x.shape[axis], axis))
+        nperseg = x.shape[-1]
 
     if isinstance(window, string_types) or type(window) is tuple:
         win = get_window(window, nperseg)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_raises, assert_approx_equal, \
                           assert_array_almost_equal_nulp, dec
 from scipy import signal, fftpack
 from scipy._lib._version import NumpyVersion
-from scipy.signal import periodogram, welch, lombscargle
+from scipy.signal import periodogram, welch, lombscargle, csd, coherence
 
 
 class TestPeriodogram(TestCase):
@@ -434,6 +434,290 @@ class TestWelch(TestCase):
             0.55555556, 0.55555556, 0.55555556, 0.55555556, 0.38194444], 'f')
         assert_allclose(p, q)
         assert_(p.dtype == q.dtype, 'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
+
+class TestCSD:
+    def test_pad_shorter_x(self):
+        x = np.zeros(8)
+        y = np.zeros(12)
+
+        f = np.linspace(0, 0.5, 7)
+        c = np.zeros(7,dtype=np.complex128)
+        f1, c1 = csd(x, y, nperseg=12)
+
+        assert_allclose(f, f1)
+        assert_allclose(c, c1)
+
+
+    def test_pad_shorter_y(self):
+        x = np.zeros(12)
+        y = np.zeros(8)
+
+        f = np.linspace(0, 0.5, 7)
+        c = np.zeros(7,dtype=np.complex128)
+        f1, c1 = csd(x, y, nperseg=12)
+
+        assert_allclose(f, f1)
+        assert_allclose(c, c1)
+
+
+    def test_real_onesided_even(self):
+        x = np.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=8)
+        assert_allclose(f, np.linspace(0, 0.5, 5))
+        assert_allclose(p, np.array([0.08333333, 0.15277778, 0.22222222,
+            0.22222222, 0.11111111]))
+
+    def test_real_onesided_odd(self):
+        x = np.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=9)
+        assert_allclose(f, np.arange(5.0)/9.0)
+        assert_allclose(p, np.array([0.15958226, 0.24193954, 0.24145223,
+            0.24100919, 0.12188675]))
+
+    def test_real_twosided(self):
+        x = np.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=8, return_onesided=False)
+        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(p, np.array([0.08333333, 0.07638889, 0.11111111,
+            0.11111111, 0.11111111, 0.11111111, 0.11111111, 0.07638889]))
+
+    def test_real_spectrum(self):
+        x = np.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=8, scaling='spectrum')
+        assert_allclose(f, np.linspace(0, 0.5, 5))
+        assert_allclose(p, np.array([0.015625, 0.028645833333333332,
+            0.041666666666666664, 0.041666666666666664, 0.020833333333333332]))
+
+    def test_integer_onesided_even(self):
+        x = np.zeros(16, dtype=np.int)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=8)
+        assert_allclose(f, np.linspace(0, 0.5, 5))
+        assert_allclose(p, np.array([0.08333333, 0.15277778, 0.22222222,
+            0.22222222, 0.11111111]))
+
+    def test_integer_onesided_odd(self):
+        x = np.zeros(16, dtype=np.int)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=9)
+        assert_allclose(f, np.arange(5.0)/9.0)
+        assert_allclose(p, np.array([0.15958226, 0.24193954, 0.24145223,
+            0.24100919, 0.12188675]))
+
+    def test_integer_twosided(self):
+        x = np.zeros(16, dtype=np.int)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=8, return_onesided=False)
+        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(p, np.array([0.08333333, 0.07638889, 0.11111111,
+            0.11111111, 0.11111111, 0.11111111, 0.11111111, 0.07638889]))
+
+    def test_complex(self):
+        x = np.zeros(16, np.complex128)
+        x[0] = 1.0 + 2.0j
+        x[8] = 1.0 + 2.0j
+        f, p = csd(x, x, nperseg=8)
+        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(p, np.array([0.41666667, 0.38194444, 0.55555556,
+            0.55555556, 0.55555556, 0.55555556, 0.55555556, 0.38194444]))
+
+    def test_unk_scaling(self):
+        assert_raises(ValueError, csd, np.zeros(4, np.complex128),
+                np.ones(4, np.complex128), scaling='foo', nperseg=4)
+
+    def test_detrend_linear(self):
+        x = np.arange(10, dtype=np.float64) + 0.04
+        f, p = csd(x, x, nperseg=10, detrend='linear')
+        assert_allclose(p, np.zeros_like(p), atol=1e-15)
+
+    def test_no_detrending(self):
+        x = np.arange(10, dtype=np.float64) + 0.04
+        f1, p1 = csd(x, x, nperseg=10, detrend=False)
+        f2, p2 = csd(x, x, nperseg=10, detrend=lambda x: x)
+        assert_allclose(f1, f2, atol=1e-15)
+        assert_allclose(p1, p2, atol=1e-15)
+
+    def test_detrend_external(self):
+        x = np.arange(10, dtype=np.float64) + 0.04
+        f, p = csd(x, x, nperseg=10,
+                detrend=lambda seg: signal.detrend(seg, type='l'))
+        assert_allclose(p, np.zeros_like(p), atol=1e-15)
+
+    def test_detrend_external_nd_m1(self):
+        x = np.arange(40, dtype=np.float64) + 0.04
+        x = x.reshape((2,2,10))
+        f, p = csd(x, x, nperseg=10,
+                detrend=lambda seg: signal.detrend(seg, type='l'))
+        assert_allclose(p, np.zeros_like(p), atol=1e-15)
+
+    def test_detrend_external_nd_0(self):
+        x = np.arange(20, dtype=np.float64) + 0.04
+        x = x.reshape((2,1,10))
+        x = np.rollaxis(x, 2, 0)
+        f, p = csd(x, x, nperseg=10, axis=0,
+                detrend=lambda seg: signal.detrend(seg, axis=0, type='l'))
+        assert_allclose(p, np.zeros_like(p), atol=1e-15)
+
+    def test_nd_axis_m1(self):
+        x = np.arange(20, dtype=np.float64) + 0.04
+        x = x.reshape((2,1,10))
+        f, p = csd(x, x, nperseg=10)
+        assert_array_equal(p.shape, (2, 1, 6))
+        assert_allclose(p[0,0,:], p[1,0,:], atol=1e-13, rtol=1e-13)
+        f0, p0 = csd(x[0,0,:], x[0,0,:], nperseg=10)
+        assert_allclose(p0[np.newaxis,:], p[1,:], atol=1e-13, rtol=1e-13)
+
+    def test_nd_axis_0(self):
+        x = np.arange(20, dtype=np.float64) + 0.04
+        x = x.reshape((10,2,1))
+        f, p = csd(x, x, nperseg=10, axis=0)
+        assert_array_equal(p.shape, (6,2,1))
+        assert_allclose(p[:,0,0], p[:,1,0], atol=1e-13, rtol=1e-13)
+        f0, p0 = csd(x[:,0,0], x[:,0,0], nperseg=10)
+        assert_allclose(p0, p[:,1,0], atol=1e-13, rtol=1e-13)
+
+    def test_window_external(self):
+        x = np.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, 10, 'hanning', 8)
+        win = signal.get_window('hanning', 8)
+        fe, pe = csd(x, x, 10, win, 8)
+        assert_array_almost_equal_nulp(p, pe)
+        assert_array_almost_equal_nulp(f, fe)
+
+    def test_empty_input(self):
+        f, p = csd([],np.zeros(10))
+        assert_array_equal(f.shape, (0,))
+        assert_array_equal(p.shape, (0,))
+
+        f, p = csd(np.zeros(10),[])
+        assert_array_equal(f.shape, (0,))
+        assert_array_equal(p.shape, (0,))
+
+        for shape in [(0,), (3,0), (0,5,2)]:
+            f, p = csd(np.empty(shape), np.zeros(10))
+            assert_array_equal(f.shape, shape)
+            assert_array_equal(p.shape, shape)
+
+            f, p = csd(np.zeros(10), np.empty(shape))
+            assert_array_equal(f.shape, shape)
+            assert_array_equal(p.shape, shape)
+
+
+    def test_short_data(self):
+        x = np.zeros(8)
+        x[0] = 1
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            f, p = csd(x, x)
+
+        f1, p1 = csd(x, x, nperseg=8)
+        assert_allclose(f, f1)
+        assert_allclose(p, p1)
+
+    def test_window_long_or_nd(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1, 
+                          np.array([1,1,1,1,1]))
+            assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1,
+                          np.arange(6).reshape((2,3)))
+
+    def test_nondefault_noverlap(self):
+        x = np.zeros(64)
+        x[::8] = 1
+        f, p = csd(x, x, nperseg=16, noverlap=4)
+        q = np.array([0, 1./12., 1./3., 1./5., 1./3., 1./5., 1./3., 1./5., 1./6.])
+        assert_allclose(p, q, atol=1e-12)
+
+    def test_bad_noverlap(self):
+        assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1, 'hanning', 2, 7)
+
+    def test_nfft_too_short(self):
+        assert_raises(ValueError, csd, np.ones(12), np.zeros(12), nfft=3, nperseg=4)
+
+    def test_real_onesided_even_32(self):
+        x = np.zeros(16, 'f')
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=8)
+        assert_allclose(f, np.linspace(0, 0.5, 5))
+        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
+            0.11111111], 'f') 
+        assert_allclose(p, q)
+        assert_(p.dtype == q.dtype)
+
+    def test_real_onesided_odd_32(self):
+        x = np.zeros(16, 'f')
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=9)
+        assert_allclose(f, np.arange(5.0)/9.0)
+        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
+            0.12188675], 'f')
+        assert_allclose(p, q, atol=1e-7)
+        assert_(p.dtype == q.dtype)
+
+    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
+    def test_real_twosided_32(self):
+        x = np.zeros(16, 'f')
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=8, return_onesided=False)
+        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        q = np.array([0.08333333, 0.07638889, 0.11111111,
+            0.11111111, 0.11111111, 0.11111111, 0.11111111, 0.07638889], 'f')
+        assert_allclose(p, q)
+        assert_(p.dtype == q.dtype)
+
+    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
+    def test_complex_32(self):
+        x = np.zeros(16, 'F')
+        x[0] = 1.0 + 2.0j
+        x[8] = 1.0 + 2.0j
+        f, p = csd(x, x, nperseg=8)
+        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        q = np.array([0.41666667, 0.38194444, 0.55555556,
+            0.55555556, 0.55555556, 0.55555556, 0.55555556, 0.38194444], 'f')
+        assert_allclose(p, q)
+        assert_(p.dtype == q.dtype, 'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
+
+
+class TestCoherence:
+    def test_identical_input(self):
+        x = np.random.randn(20)
+        y = np.copy(x) # So `y is x` -> False
+
+        f = np.linspace(0, 0.5, 6)
+        C = np.ones(6)
+        f1, C1 = coherence(x, y, nperseg=10)
+
+        assert_allclose(f, f1)
+        assert_allclose(C, C1)
+
+
+    def test_phase_shifted_input(self):
+        x = np.random.randn(20)
+        y = -x 
+
+        f = np.linspace(0, 0.5, 6)
+        C = np.ones(6)
+        f1, C1 = coherence(x, y, nperseg=10)
+
+        assert_allclose(f, f1)
+        assert_allclose(C, C1)
 
 
 class TestLombscargle:

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -447,7 +447,6 @@ class TestCSD:
         assert_allclose(f, f1)
         assert_allclose(c, c1)
 
-
     def test_pad_shorter_y(self):
         x = np.zeros(12)
         y = np.zeros(8)
@@ -458,7 +457,6 @@ class TestCSD:
 
         assert_allclose(f, f1)
         assert_allclose(c, c1)
-
 
     def test_real_onesided_even(self):
         x = np.zeros(16)
@@ -615,7 +613,6 @@ class TestCSD:
             assert_array_equal(f.shape, shape)
             assert_array_equal(p.shape, shape)
 
-
     def test_short_data(self):
         x = np.zeros(8)
         x[0] = 1
@@ -698,7 +695,7 @@ class TestCSD:
 class TestCoherence:
     def test_identical_input(self):
         x = np.random.randn(20)
-        y = np.copy(x) # So `y is x` -> False
+        y = np.copy(x)  # So `y is x` -> False
 
         f = np.linspace(0, 0.5, 6)
         C = np.ones(6)
@@ -706,7 +703,6 @@ class TestCoherence:
 
         assert_allclose(f, f1)
         assert_allclose(C, C1)
-
 
     def test_phase_shifted_input(self):
         x = np.random.randn(20)


### PR DESCRIPTION
I've modified/extended the existing code for `scipy.signal.welch` to compute cross spectral densities, and a small function to compute coherence. The underlying algorithm is essentially unchanged from the existing `welch` code.

Since PSDs are a subset of CSDs, I've replaced the `welch` function with a call to `csd` with the input repeated. On my machine this increases the run time for `welch` on the order of 2% (~10us on a 1024 element array, out of 500us on average). Is limiting the code's redundancy worth this performance hit?

In any case, I have not yet written any new tests for the CSD or coherence functions, but all of the current `scipy.signal` tests pass. The docstrings probably need some examples / additional information too. 

I appreciate everyone's feedback!
