### PR TITLE
MAINT: sparse: inherit dok_matrix.toarray from spmatrix

### DIFF
--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -470,10 +470,6 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         """ Return a copy of this matrix in Compressed Sparse Column format"""
         return self.tocoo().tocsc()
 
-    def toarray(self, order=None, out=None):
-        """See the docstring for `spmatrix.toarray`."""
-        return self.tocoo().toarray(order=order, out=out)
-
     def resize(self, shape):
         """ Resize the matrix in-place to dimensions given by 'shape'.
 


### PR DESCRIPTION
`dok_matrix.toarray` method is a copy-paste of `spmatrix.toarray`; remove it from the former, so that it's inherited from the latter. The upshot is that the docstring is inherited as well. 
So the net effect is that `dok_matrix.toarray` gets a useful docstring.
