### PR TITLE
ENH: add a new linalg special matrix: the Helmert matrix

### DIFF
--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -130,6 +130,7 @@ Special Matrices
    dft - Discrete Fourier transform matrix
    hadamard - Hadamard matrix of order 2**n
    hankel - Hankel matrix
+   helmert - Helmert matrix
    hilbert - Hilbert matrix
    invhilbert - Inverse Hilbert matrix
    leslie - Leslie matrix

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -8,7 +8,7 @@ from scipy._lib.six import string_types
 
 __all__ = ['tri', 'tril', 'triu', 'toeplitz', 'circulant', 'hankel',
            'hadamard', 'leslie', 'kron', 'block_diag', 'companion',
-           'hilbert', 'invhilbert', 'pascal', 'invpascal', 'dft']
+           'helmert', 'hilbert', 'invhilbert', 'pascal', 'invpascal', 'dft']
 
 
 #-----------------------------------------------------------------------------
@@ -601,6 +601,41 @@ def companion(a):
     c[0] = first_row
     c[list(range(1, n - 1)), list(range(0, n - 2))] = 1
     return c
+
+
+def helmert(n):
+    """
+    Create a Helmert matrix of order `n`.
+
+    This has applications in statistics, compositional or simplicial analysis,
+    and in Aitchison geometry.
+
+    Parameters
+    ----------
+    n : int
+        The size of the array to create.
+
+    Returns
+    -------
+    M : (n, n) ndarray
+        The Helmert matrix.
+
+    Examples
+    --------
+    >>> from scipy.linalg import helmert
+    >>> helmert(5)
+    array([[ 0.4472136 ,  0.4472136 ,  0.4472136 ,  0.4472136 ,  0.4472136 ],
+           [ 0.70710678, -0.70710678,  0.        ,  0.        ,  0.        ],
+           [ 0.40824829,  0.40824829, -0.81649658,  0.        ,  0.        ],
+           [ 0.28867513,  0.28867513,  0.28867513, -0.8660254 ,  0.        ],
+           [ 0.2236068 ,  0.2236068 ,  0.2236068 ,  0.2236068 , -0.89442719]])
+
+    """
+    H = np.tril(np.ones((n, n)), -1) - np.diag(np.arange(n))
+    d = np.arange(n) * np.arange(1, n+1)
+    H[0] = 1
+    d[0] = n
+    return H / np.sqrt(d)[:, np.newaxis]
 
 
 def hilbert(n):

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -603,7 +603,7 @@ def companion(a):
     return c
 
 
-def helmert(n):
+def helmert(n, full=False):
     """
     Create a Helmert matrix of order `n`.
 
@@ -614,16 +614,22 @@ def helmert(n):
     ----------
     n : int
         The size of the array to create.
+    full : bool, optional
+        If True the (n, n) ndarray will be returned.
+        Otherwise the submatrix that does not include the first
+        row will be returned.
+        Default: False.
 
     Returns
     -------
-    M : (n, n) ndarray
+    M : ndarray
         The Helmert matrix.
+        The shape is (n, n) or (n-1, n) depending on the `full` argument.
 
     Examples
     --------
     >>> from scipy.linalg import helmert
-    >>> helmert(5)
+    >>> helmert(5, full=True)
     array([[ 0.4472136 ,  0.4472136 ,  0.4472136 ,  0.4472136 ,  0.4472136 ],
            [ 0.70710678, -0.70710678,  0.        ,  0.        ,  0.        ],
            [ 0.40824829,  0.40824829, -0.81649658,  0.        ,  0.        ],
@@ -635,7 +641,11 @@ def helmert(n):
     d = np.arange(n) * np.arange(1, n+1)
     H[0] = 1
     d[0] = n
-    return H / np.sqrt(d)[:, np.newaxis]
+    H_full = H / np.sqrt(d)[:, np.newaxis]
+    if full:
+        return H_full
+    else:
+        return H_full[1:]
 
 
 def hilbert(n):

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -295,61 +295,6 @@ class TestHelmert(TestCase):
             assert_allclose(U.dot(U.T), C)
             assert_allclose(U.T.dot(U), np.eye(n-1), atol=1e-12)
 
-    def test_aitchison_geometry(self):
-
-        def _closure(w):
-            return w / w.sum()
-
-        def _perturbation(p, q):
-            return _closure(p*q)
-
-        def _powering(p, a):
-            return _closure(np.power(p, a))
-
-        def _inner(p, q):
-            L = len(p)
-            lp = np.log(p)
-            lq = np.log(q)
-            return lp.dot(lq) - L * np.mean(lp) * np.mean(lq)
-
-        def _norm(p):
-            return np.sqrt(_inner(p, p))
-
-        def _distance(p, q):
-            return _norm(_perturbation(p, _powering(q, -1)))
-
-        def _ilr_basis(L):
-            return helmert(L)[1:, :].T
-
-        def _ilr(p):
-            L = len(p)
-            U = _ilr_basis(L)
-            return U.T.dot(np.log(p))
-
-        def _iilr(v):
-            L = len(v) + 1
-            U = _ilr_basis(L)
-            return _closure(np.exp(U.dot(v)))
-
-        np.random.seed(1234)
-        for n in range(1, 5):
-            for i in range(3):
-                L = n + 1
-                p = _closure(np.exp(np.random.randn(L)))
-                q = _closure(np.exp(np.random.randn(L)))
-                u = _ilr(p)
-                v = _ilr(q)
-                assert_equal(p.shape, (L, ))
-                assert_equal(q.shape, (L, ))
-                assert_equal(u.shape, (n, ))
-                assert_equal(v.shape, (n, ))
-                assert_allclose(_iilr(u), p)
-                assert_allclose(_iilr(v), q)
-                for a in -1.2, 0.1, 3.0:
-                    assert_allclose(_powering(p, a), _iilr(u * a))
-                assert_allclose(_inner(p, q), u.dot(v))
-                assert_allclose(np.linalg.norm(u - v), _distance(p, q))
-
 
 class TestHilbert(TestCase):
 

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -283,17 +283,19 @@ class TestHelmert(TestCase):
 
     def test_orthogonality(self):
         for n in range(1, 7):
-            H = helmert(n)
+            H = helmert(n, full=True)
             I = np.eye(n)
             assert_allclose(H.dot(H.T), I, atol=1e-12)
             assert_allclose(H.T.dot(H), I, atol=1e-12)
 
     def test_subspace(self):
         for n in range(2, 7):
-            U = helmert(n)[1:, :].T
-            C = np.eye(n) - np.ones((n, n)) / n
-            assert_allclose(U.dot(U.T), C)
-            assert_allclose(U.T.dot(U), np.eye(n-1), atol=1e-12)
+            H_full = helmert(n, full=True)
+            H_partial = helmert(n)
+            for U in H_full[1:, :].T, H_partial.T:
+                C = np.eye(n) - np.ones((n, n)) / n
+                assert_allclose(U.dot(U.T), C)
+                assert_allclose(U.T.dot(U), np.eye(n-1), atol=1e-12)
 
 
 class TestHilbert(TestCase):


### PR DESCRIPTION
This is used in [compositional analysis](http://en.wikipedia.org/wiki/Compositional_data).

The clearest reference I've found consists of some lecture notes that says that it is taken from
Linear and Nonlinear Models: Fixed Effects, Random Effects, and Mixed Models
By Erik W. Grafarend

An older reference is
The Helmert Matrices
H. O. Lancaster
The American Mathematical Monthly
Vol. 72, No. 1 (Jan., 1965), pp. 4-12
