### PR TITLE
ENH: New LAPACK drivers are added to the least-squares solvers linalg.lstsq

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -139,7 +139,8 @@ Brandon Liu for stats.combine_pvalues.
 Clark Fitzgerald for namedtuple outputs in scipy.stats.
 Florian Wilhelm for usage of RandomState in scipy.stats distributions.
 Robert T. McGibbon for Levinson-Durbin Toeplitz solver.
-
+Alexander Grigorevskiy for adding extra LAPACK least-square solvers and 
+    modifying linalg.lstsq function accordingly.
 
 Institutions
 ------------

--- a/doc/release/0.16.0-notes.rst
+++ b/doc/release/0.16.0-notes.rst
@@ -26,6 +26,9 @@ New features
 
 The function `scipy.linalg.invpascal` computes the inverse of a Pascal matrix.
 
+Added two extra wrappers for LAPACK least-square solvers. Namely, they are 
+*gelsd and *gelsy.
+
 `scipy.signal` improvements
 ---------------------------
 

--- a/doc/release/0.16.0-notes.rst
+++ b/doc/release/0.16.0-notes.rst
@@ -27,7 +27,7 @@ New features
 The function `scipy.linalg.invpascal` computes the inverse of a Pascal matrix.
 
 Added two extra wrappers for LAPACK least-square solvers. Namely, they are 
-*gelsd and *gelsy. Added new parameter to linalg.lstsq which sets the
+`*gelsd` and `*gelsy`. Added new parameter to `linalg.lstsq` which sets the
 appropriate LAPACK wrapper.
 
 `scipy.signal` improvements

--- a/doc/release/0.16.0-notes.rst
+++ b/doc/release/0.16.0-notes.rst
@@ -27,7 +27,8 @@ New features
 The function `scipy.linalg.invpascal` computes the inverse of a Pascal matrix.
 
 Added two extra wrappers for LAPACK least-square solvers. Namely, they are 
-*gelsd and *gelsy.
+*gelsd and *gelsy. Added new parameter to linalg.lstsq which sets the
+appropriate LAPACK wrapper.
 
 `scipy.signal` improvements
 ---------------------------

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -643,7 +643,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     
     if lapack_driver in ('gelss', 'gelsd'):
         if cond is None:
-            cond = -1  # The numerical precision will be used i nthis case 
+            cond = np.finfo(lapack_func.dtype).eps * 100
             
         if lapack_driver == 'gelss':
 
@@ -687,7 +687,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
             raise LinAlgError("SVD did not converge in Linear Least Squares")
         if info < 0:
             raise ValueError('illegal value in %d-th argument of internal %s'
-                                                    % (lapack_driver, -info))
+                                                    % (-info,lapack_driver))
         resids = np.asarray([], dtype=x.dtype)
         if m > n:
             x1 = x[:n]
@@ -698,7 +698,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
         
     elif lapack_driver == 'gelsy':
         if cond is None:
-            cond = np.finfo(lapack_func.dtype).eps * 10
+            cond = np.finfo(lapack_func.dtype).eps * 100
             
         # Request of sizes
         work,info = lapack_func_lwork_query(m,n,nrhs,cond)        

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -300,7 +300,7 @@ def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False,
 
     overwrite_b = overwrite_b or _datacopied(b1, b)
     overwrite_ab = overwrite_ab or _datacopied(a1, ab)
-    
+
     if a1.shape[0] == 2:
         ptsv, = get_lapack_funcs(('ptsv',), (a1, b1))
         if lower:
@@ -560,14 +560,14 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
         Disabling may give a performance gain, but may result in problems
         (crashes, non-termination) if the inputs do contain infinities or NaNs.
     lapack_driver: string, optional
-        Options are 'gelsd', 'gelsy', 'gelss'. Which LAPACK driver is used to 
-        solve the least-squares problem. Default is good choice. However, 
+        Options are 'gelsd', 'gelsy', 'gelss'. Which LAPACK driver is used to
+        solve the least-squares problem. Default is good choice. However,
         'gelsy' can work slightly faster on many problems. 'gelss' was used
         used historically. It is generally slow but uses less memory.
     Returns
     -------
     if lapack_driver is 'gelsd' or 'gelss':
-    
+
     x : (N,) or (N, K) ndarray
         Least-squares solution.  Return shape matches shape of `b`.
     residues : () or (1,) or (K,) ndarray
@@ -579,21 +579,21 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     s : (min(M,N),) ndarray
         Singular values of `a`. The condition number of a is
         ``abs(s[0]/s[-1])``.
-        
-        
+
+
     if lapack_driver is 'gelsy':
-    
+
     x : (N,) or (N, K) ndarray
     Least-squares solution.  Return shape matches shape of `b`.
-    
+
     j : (N,) ndarray of integer
     The or columns obtained from the column pivoting in complete orthogonal
     factorization least-squares solver.
-    
+
     rank : int
     Effective rank of matrix `a`.
-    
-    
+
+
     Raises
     ------
     LinAlgError :
@@ -601,13 +601,18 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
 
     ValueError :
         When parameters are wrong.
-        
+
     See Also
     --------
     optimize.nnls : linear least squares with non-negativity constraint
 
+    Notes
+    -----
+    .. versionadded:: 0.16.0
+
+
     """
-    
+
     a1 = _asarray_validated(a, check_finite=check_finite)
     b1 = _asarray_validated(b, check_finite=check_finite)
     if len(a1.shape) != 2:
@@ -619,14 +624,14 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
         nrhs = 1
     if m != b1.shape[0]:
         raise ValueError('incompatible dimensions')
-        
+
     if lapack_driver not in ('gelsd','gelsy','gelss'):
         raise ValueError('LAPACK driver "%s"is not found' % lapack_driver)
-        
+
     lapack_func, lapack_func_lwork_query = get_lapack_funcs((lapack_driver,
                                         '%s_lwork' % lapack_driver), (a1, b1))
     real_data = True if (lapack_func.dtype.kind == 'f') else False
-    
+
     if m < n:
         # need to extend b matrix as it will be filled with
         # a larger solution matrix
@@ -640,24 +645,24 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
 
     overwrite_a = overwrite_a or _datacopied(a1, a)
     overwrite_b = overwrite_b or _datacopied(b1, b)
-    
+
     if lapack_driver in ('gelss', 'gelsd'):
         if cond is None:
             cond = np.finfo(lapack_func.dtype).eps * 100
-            
+
         if lapack_driver == 'gelss':
 
             # Request of sizes
-            work,info = lapack_func_lwork_query(m,n,nrhs,cond)            
+            work,info = lapack_func_lwork_query(m,n,nrhs,cond)
             lwork = np.int(np.real(work))
             if info != 0:
                 raise ValueError("internal gelss driver lwork query \
                                     error, info is %i " % info)
-    
+
             v, x, s, rank, work, info = lapack_func(
                 a1, b1, cond, lwork, overwrite_a=overwrite_a,
                 overwrite_b=overwrite_b)
-     
+
         elif lapack_driver == 'gelsd':
             if real_data:
 
@@ -668,8 +673,8 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
                 if info != 0:
                     raise ValueError("internal gelsd driver lwork query error,\
                                         info is %i " % info)
-                    
-                x, s, rank, work, iwork, info = lapack_func(a1, b1, lwork, 
+
+                x, s, rank, work, iwork, info = lapack_func(a1, b1, lwork,
                                             iwork_size, cond, False, False)
             else:  # complex data
                 # Request of sizes
@@ -680,8 +685,8 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
                 if info != 0:
                     raise ValueError("internal gelsd driver lwork query error,\
                                             info is %i " % info)
-                    
-                x, s, rank, work, rwork, iwork, info = lapack_func(a1, b1, 
+
+                x, s, rank, work, rwork, iwork, info = lapack_func(a1, b1,
                             lwork,rwork_size, iwork_size, cond, False, False)
         if info > 0:
             raise LinAlgError("SVD did not converge in Linear Least Squares")
@@ -695,32 +700,32 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
                 resids = np.sum(np.abs(x[n:])**2, axis=0)
             x = x1
         return x, resids, rank, s
-        
+
     elif lapack_driver == 'gelsy':
         if cond is None:
             cond = np.finfo(lapack_func.dtype).eps * 100
-            
+
         # Request of sizes
-        work,info = lapack_func_lwork_query(m,n,nrhs,cond)        
+        work,info = lapack_func_lwork_query(m,n,nrhs,cond)
         lwork = np.int(np.real(work))
         if info != 0:
             raise ValueError("internal gelsy driver lwork query error, \
                                 info is %i " % info)
-                    
+
         jptv = np.zeros((a1.shape[1],1), dtype=np.int32)
-        
+
         v,x,j,rank,work,info = lapack_func(a1, b1, jptv, cond,
                                          lwork, False, False)
-        
+
         if info < 0:
             raise ValueError('illegal value in %d-th argument of internal \
                                 gelsy' % -info)
-            
+
         if m > n:
             x1 = x[:n]
             x = x1
         return x,j,rank
-        
+
 def pinv(a, cond=None, rcond=None, return_rank=False, check_finite=True):
     """
     Compute the (Moore-Penrose) pseudo-inverse of a matrix.

--- a/scipy/linalg/benchmarks/bench_lstsq.py
+++ b/scipy/linalg/benchmarks/bench_lstsq.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+""" Benchmark linalg.lstsq for various LAPACK drivers
+
+"""
+
+from __future__ import division, print_function, absolute_import
+
+import time
+import math
+
+import numpy as np
+from numpy.testing import assert_allclose
+import scipy.linalg as la
+import numpy.random as rnd
+
+def bench_lstsq_1():
+    """
+    Test the speed of four least-squares solvers on not full rank matrices.
+    Also check the difference in the solutions.
+
+    The matrix has the size (m,2/3*m) the rank is 1/2*m.
+    Matrix values are random in the range (-5, 5), the same is for the right 
+    hand side. The complex matrix is the sum of real and imaginary matrices.
+    """
+    np.random.seed(1234)
+    print()
+    print('                       Least-Squares Solver')
+    print('==============================================================')
+    print('      shape      |   LAPACK   |        dtype       |   time   ')
+    print('                 |   driver   |                    | (seconds)')
+    print('--------------------------------------------------------------')
+    fmt = ' %15s |   %6s  | %18s | %6.2f '
+    m_steps = range(500, 3500, 500)
+    for (i,m) in enumerate(m_steps):
+        for dtype in (np.float64, np.complex128):
+
+            n = math.ceil(2./3. * m)
+            k = math.ceil(1./2. * m)
+
+            if (dtype == np.complex128):
+                A = (10 * rnd.rand(m,k) - 5) + 1j*(10 * rnd.rand(m,k) - 5)
+                Temp = (10 * rnd.rand(k,n) - 5) + 1j*(10 * rnd.rand(k,n) - 5)
+                b = (10 * rnd.rand(m,1) - 5) + 1j*(10 * rnd.rand(m,1) - 5) 
+            else:
+                A = (10 * rnd.rand(m,k) - 5)
+                Temp = 10 * rnd.rand(k,n) - 5
+                b = 10 * rnd.rand(m,1) - 5
+                
+            A = A.dot(Temp)
+            
+            A1 = A.copy() 
+            b1 = b.copy()
+            t1 = time.time()
+            res1 = la.lstsq(A1, b1, cond=None, overwrite_a=False, 
+                            overwrite_b=False, check_finite=False, 
+                            lapack_driver='gelss')
+            t1 = time.time() - t1
+            x1 = res1[0]
+            print(fmt % (A.shape, '*gelss', A.dtype, t1))
+    
+            A2 = A.copy() 
+            b2 = b.copy()
+            t2 = time.time()
+            res2 = la.lstsq(A2, b2, cond=None, overwrite_a=False, 
+                         overwrite_b=False, check_finite=False, 
+                         lapack_driver='gelsy')
+            t2 = time.time() - t2
+            x2 = res2[0]
+            print(fmt % (A.shape, '*gelsy', A.dtype, t2))
+    
+            A3 = A.copy()
+            b3 = b.copy()
+            t3 = time.time()
+            res3 = la.lstsq(A3, b3, cond=None, overwrite_a=False, 
+                         overwrite_b=False, check_finite=False, 
+                         lapack_driver='gelsd')
+            t3 = time.time() - t3
+            x3 = res3[0]
+            print(fmt % (A.shape, '*gelsd', A.dtype, t3))
+            
+            A4 = A.copy()
+            b4 = b.copy()
+            t4 = time.time()
+            res4 = np.linalg.lstsq(A4,b4,rcond=np.finfo(A4.dtype).eps*100)
+            t4 = time.time() - t4
+            x4 = res4[0]
+            print(fmt % (A.shape, ' Numpy', A.dtype, t4))
+
+            # Check that the results are the same for all drivers
+            assert_allclose(x4,x1,atol=1000*np.finfo(A1.dtype).eps,
+                            rtol=1000*np.finfo(A1.dtype).eps)
+            assert_allclose(x4,x2,atol=1000*np.finfo(A2.dtype).eps,
+                            rtol=1000*np.finfo(A2.dtype).eps)
+            assert_allclose(x4,x3,atol=1000*np.finfo(A3.dtype).eps,
+                            rtol=1000*np.finfo(A3.dtype).eps)
+                            
+def bench_lstsq_2():
+    """
+    Test the scaling of least-squares solvers only with respect to one dimesion, 
+    Another dimension is fixed. The rank is k.
+
+    The matrix has size (m,n) the rank is k.
+    Matrix values are random in the range (-5, 5), the same is for right hand
+    side. The complex matrix is the sum of real and imaginary matrices.
+    """
+
+    np.random.seed(1234)
+    print()
+    print('                       Least-Squares Solver')
+    print('==============================================================')
+    print('      shape      |   LAPACK   |        dtype       |   time   ')
+    print('                 |   driver   |                    | (seconds)')
+    print('--------------------------------------------------------------')
+    fmt = ' %15s |   %6s  | %18s | %6.2f '
+    m_steps = range(10000, 120000, 10000)
+    for (i,m) in enumerate(m_steps):
+        for dtype in (np.float64, np.complex128):
+  
+            n = 100
+            k = 80
+
+            if (dtype == np.complex128):
+                A = (10 * rnd.rand(m,k) - 5) + 1j*(10 * rnd.rand(m,k) - 5)
+                Temp = (10 * rnd.rand(k,n) - 5) + 1j*(10 * rnd.rand(k,n) - 5)
+                b = (10 * rnd.rand(m,1) - 5) + 1j*(10 * rnd.rand(m,1) - 5) 
+            else:
+                A = (10 * rnd.rand(m,k) - 5)
+                Temp = 10 * rnd.rand(k,n) - 5
+                b = 10 * rnd.rand(m,1) - 5
+                
+            A = A.dot(Temp)
+
+            A1 = A.copy()
+            b1 = b.copy()
+            t1 = time.time()
+            res1 = la.lstsq(A1, b1, cond=None, overwrite_a=False, 
+                            overwrite_b=False, check_finite=False, 
+                            lapack_driver='gelss')
+            t1 = time.time() - t1
+            x1 = res1[0]
+            print(fmt % (A.shape, '*gelss', A.dtype, t1))
+    
+            A2 = A.copy()
+            b2 = b.copy()
+            t2 = time.time()
+            res2 = la.lstsq(A2, b2, cond=None, overwrite_a=False, 
+                         overwrite_b=False, check_finite=False, 
+                         lapack_driver='gelsy')
+            t2 = time.time() - t2
+            x2 = res2[0]
+            print(fmt % (A.shape, '*gelsy', A.dtype, t2))
+    
+            A3 = A.copy()
+            b3 = b.copy()
+            t3 = time.time()
+            res3 = la.lstsq(A3, b3, cond=None, overwrite_a=False, 
+                         overwrite_b=False, check_finite=False, 
+                         lapack_driver='gelsd')
+            t3 = time.time() - t3
+            x3 = res3[0]
+            print(fmt % (A.shape, '*gelsd', A.dtype, t3))
+            
+            A4 = A.copy()
+            b4 = b.copy()
+            t4 = time.time()
+            res4 = np.linalg.lstsq(A4,b4,rcond=np.finfo(A4.dtype).eps * 100)
+            t4 = time.time() - t4
+            x4 = res4[0]
+            print(fmt % (A.shape, ' Numpy', A.dtype, t4))
+
+            # Check that the results are the same for all drivers
+            assert_allclose(x4,x1,atol=1000*np.finfo(A1.dtype).eps,
+                            rtol=1000*np.finfo(A1.dtype).eps)
+            assert_allclose(x4,x2,atol=1000*np.finfo(A2.dtype).eps,
+                            rtol=1000*np.finfo(A2.dtype).eps)
+            assert_allclose(x4,x3,atol=1000*np.finfo(A3.dtype).eps,
+                            rtol=1000*np.finfo(A3.dtype).eps)
+
+if __name__ == '__main__':
+    bench_lstsq_1()
+    bench_lstsq_2()
+

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -708,6 +708,34 @@ interface
 
    end subroutine <prefix2>gelss
 
+    subroutine <prefix2>gelss_lwork(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,lwork,info)
+
+   ! work,info = gelss_lwork(m,n,nrhs,cond=-1.0)
+   ! Query for optimal lwork size
+
+     fortranname <prefix2>gelss
+     callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&s,&cond,&r,&work,&lwork,&info)
+     callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*
+
+     integer intent(in):: m 
+     integer intent(in):: n
+     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
+     integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
+     <ftype2> intent(hide) :: a
+
+     integer intent(in):: nrhs
+     <ftype2> intent(hide) :: b
+     
+     <ftype2> intent(in),optional :: cond = -1.0
+     integer intent(hide) :: r
+     <ftype2> intent(hide) :: s
+
+     integer optional,intent(in) :: lwork=-1
+     <ftype2> intent(out) :: work
+     integer intent(out)::info
+
+   end subroutine <prefix2>gelss_lwork
+
    subroutine <prefix2c>gelss(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,rwork,lwork,info)
 
    ! v,x,s,rank,work,info = gelss(a,b,cond=-1.0,overwrite_a=0,overwrite_b=0)
@@ -735,10 +763,39 @@ interface
           :: lwork=2*minmn+MAX(maxmn,nrhs)
           ! check(lwork>=2*minmn+MAX(maxmn,nrhs))
      <ftype2c> dimension(MAX(lwork,1)),intent(out),depend(lwork) :: work
-     <ftype2> dimension(5*minmn-1),intent(hide),depend(lwork) :: rwork
+     <ftype2> dimension(5*minmn),intent(hide),depend(lwork) :: rwork
      integer intent(out)::info
 
    end subroutine <prefix2c>gelss
+
+   subroutine <prefix2c>gelss_lwork(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,rwork,lwork,info)
+
+   ! work,info = gelss_lwork(m,n,nrhs,cond=-1.0)
+   ! Query for optimal lwork size
+
+     fortranname <prefix2c>gelss
+     callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&s,&cond,&r,&work,&lwork,&rwork,&info)
+     callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2c>*,int*,<ctype2>*,int*
+
+     integer intent(in):: m
+     integer intent(in):: n
+     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
+     integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
+     <ftype2c> intent(hide) :: a
+
+     integer intent(in):: nrhs
+     <ftype2c> intent(hide) :: b
+     
+     <ftype2> intent(in),optional :: cond = -1.0
+     integer intent(hide) :: r
+     <ftype2> intent(hide) :: s
+
+     integer optional,intent(in) :: lwork=-1
+     <ftype2c> intent(out) :: work
+    <ftype2> intent(hide) :: rwork
+     integer intent(out)::info
+
+   end subroutine <prefix2>gelss_lwork
 
    subroutine <prefix2>gelsy(m,n,minmn,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,info)
 
@@ -769,6 +826,35 @@ interface
 
    end subroutine <prefix2>gelsy
 
+   subroutine <prefix2>gelsy_lwork(m,n,minmn,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,info)
+
+   ! work,info = dgelsy_lwork(m,n,nrhs,cond)
+   ! Query for optimal lwork size
+
+     fortranname <prefix2>gelsy
+     callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&jptv,&cond,&r,&work,&lwork,&info)
+     callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
+
+     integer intent(in) :: m
+     integer intent(in) :: n
+     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
+     integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
+     <ftype2> intent(hide) :: a
+
+     integer intent(in):: nrhs
+     <ftype2> intent(hide):: b
+
+     <ftype2> intent(in) :: cond
+     integer intent(hide) :: r
+     integer intent(hide):: jptv
+
+     ! LWORK is obtained by the query call
+     integer intent(in),optional :: lwork = -1
+     <ftype2> intent(out) :: work
+     integer intent(out)::info
+
+   end subroutine <prefix2>gelsy_lwork
+
    subroutine <prefix2c>gelsy(m,n,minmn,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,rwork,info)
 
    ! v,x,j,rank,work,rwork,info = zgelsy(a,b,jptv,cond,lwork,overwrite_a=True,overwrite_b=True)
@@ -794,10 +880,40 @@ interface
      ! LWORK is obtained by the query call
      integer intent(in),depend(nrhs,m,n),check(lwork>=1||lwork==-1) :: lwork
      <ftype2c> dimension(MAX(lwork,1)),intent(out),depend(lwork) :: work
-     <ftype2> dimension(2*n),intent(out),depend(n) :: rwork
+     <ftype2> dimension(2*n),intent(hide),depend(n) :: rwork
      integer intent(out)::info
 
    end subroutine <prefix2c>gelsy
+
+   subroutine <prefix2c>gelsy_lwork(m,n,minmn,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,rwork,info)
+
+   ! work,info = zgelsy_lwork(m,n,nrhs,cond)
+   ! Query for optimal lwork size
+
+    fortranname <prefix2c>gelsy
+     callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&jptv,&cond,&r,&work,&lwork,&rwork,&info)
+     callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,<ctype2>*,int*,<ctype2c>*,int*,<ctype2>*,int*
+
+     integer intent(in) :: m
+     integer intent(in)):: n
+     integer intent(hide) :: minmn = MIN(m,n)
+     integer intent(hide) :: maxmn = MAX(m,n)
+     <ftype2c> intent(hide) :: a
+
+     integer intent(in):: nrhs
+     <ftype2c> intent(hide) :: b
+
+     <ftype2> intent(in) :: cond
+     integer intent(hide) :: r
+     integer intent(hide) :: jptv
+
+     ! LWORK is obtained by the query call
+     integer intent(in),optional :: lwork = -1
+     <ftype2c> intent(out) :: work
+     <ftype2> intent(hide) :: rwork
+     integer intent(out)::info
+
+   end subroutine <prefix2c>gelsy_lwork
 
    subroutine <prefix2>gelsd(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,lwork,size_iwork,iwork,info)
 
@@ -831,6 +947,39 @@ interface
      integer intent(out)::info
 
    end subroutine <prefix2>gelsd
+
+   subroutine <prefix2>gelsd_lwork(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,lwork,size_iwork,iwork,info)
+
+   ! work,iwork,info = dgelsd_lwork(m,n,nrhs,cond=-1.0)
+   ! Query for optimal lwork size
+    
+     fortranname <prefix2>gelsd
+     callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&s,&cond,&r,&work,&lwork,&iwork,&info)
+     callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+
+     integer intent(in) :: m
+     integer intent(in) :: n
+     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
+     integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
+     <ftype2> intent(hide) :: a
+
+     integer intent(in):: nrhs
+     <ftype2> intent(hide) :: b
+
+     <ftype2> intent(in),optional :: cond=-1.0
+     integer intent(hide) :: r
+     <ftype2> intent(hide) :: s
+	
+     integer intent(in),optional :: lwork = -1
+     ! Impossible to calculate lwork explicitly, need to obtain it from query call first
+     ! Same for size_iwork
+     <ftype2> intent(out) :: work
+
+     integer intent(hide) :: size_iwork
+     integer intent(out) :: iwork	
+     integer intent(out)::info
+
+   end subroutine <prefix2>gelsd_lwork
 
    subroutine <prefix2c>gelsd(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,lwork,size_rwork,rwork, size_iwork,iwork,info)
 
@@ -867,6 +1016,42 @@ interface
      integer intent(out)::info
 
    end subroutine <prefix2c>gelsd
+
+   subroutine <prefix2c>gelsd_lwork(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,lwork,size_rwork,rwork, size_iwork,iwork,info)
+
+   ! work,rwork,iwork,info = zgelsd_lwork(m,n,nrhs,lwork=-1.0,cond=-1.0)
+   ! Query for optimal lwork size
+
+     fortranname <prefix2c>gelsd
+     callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&s,&cond,&r,&work,&lwork, &rwork, &iwork,&info)
+     callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*, <ctype2c>*,int*,<ctype2>*,int*,int*
+
+     integer intent(in) :: m
+     integer intent(in) :: n
+     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
+     integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
+     <ftype2c> intent(hide) :: a
+
+     integer intent(in):: nrhs
+     <ftype2c> intent(hide) :: b
+
+     <ftype2> intent(in),optional :: cond=-1.0
+     integer intent(hide) :: r
+     <ftype2> intent(hide) :: s
+	
+     integer intent(in),optional :: lwork = -1
+     ! Impossible to calculate lwork explicitly, need to obtain it from query call first
+     ! Same for size_rwork, size_iwork
+     <ftype2c> intent(out) :: work
+
+     integer intent(hide) :: size_rwork
+     <ftype2> intent(out) :: rwork
+
+     integer intent(hide) :: size_iwork
+     integer intent(out) :: iwork	
+     integer intent(out)::info
+
+   end subroutine <prefix2c>gelsd_lwork
 
    subroutine <prefix2>geqp3(m,n,a,jpvt,tau,work,lwork,info)
 

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -708,7 +708,7 @@ interface
 
    end subroutine <prefix2>gelss
 
-    subroutine <prefix2>gelss_lwork(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,lwork,info)
+    subroutine <prefix2>gelss_lwork(m,n,maxmn,nrhs,a,b,s,cond,r,work,lwork,info)
 
    ! work,info = gelss_lwork(m,n,nrhs,cond=-1.0)
    ! Query for optimal lwork size
@@ -719,7 +719,6 @@ interface
 
      integer intent(in):: m 
      integer intent(in):: n
-     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
      integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
      <ftype2> intent(hide) :: a
 
@@ -768,7 +767,7 @@ interface
 
    end subroutine <prefix2c>gelss
 
-   subroutine <prefix2c>gelss_lwork(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,rwork,lwork,info)
+   subroutine <prefix2c>gelss_lwork(m,n,maxmn,nrhs,a,b,s,cond,r,work,rwork,lwork,info)
 
    ! work,info = gelss_lwork(m,n,nrhs,cond=-1.0)
    ! Query for optimal lwork size
@@ -779,7 +778,6 @@ interface
 
      integer intent(in):: m
      integer intent(in):: n
-     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
      integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
      <ftype2c> intent(hide) :: a
 
@@ -797,7 +795,7 @@ interface
 
    end subroutine <prefix2>gelss_lwork
 
-   subroutine <prefix2>gelsy(m,n,minmn,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,info)
+   subroutine <prefix2>gelsy(m,n,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,info)
 
    ! v,x,j,rank,work,info = dgelsy(a,b,jptv,cond,lwork,overwrite_a=True,overwrite_b=True)
    ! Solve Minimize 2-norm(A * X - B).
@@ -807,7 +805,6 @@ interface
 
      integer intent(hide),depend(a):: m = shape(a,0)
      integer intent(hide),depend(a):: n = shape(a,1)
-     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
      integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
      <ftype2> dimension(m,n),intent(in,out,copy,out=v) :: a
 
@@ -826,7 +823,7 @@ interface
 
    end subroutine <prefix2>gelsy
 
-   subroutine <prefix2>gelsy_lwork(m,n,minmn,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,info)
+   subroutine <prefix2>gelsy_lwork(m,n,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,info)
 
    ! work,info = dgelsy_lwork(m,n,nrhs,cond)
    ! Query for optimal lwork size
@@ -837,7 +834,6 @@ interface
 
      integer intent(in) :: m
      integer intent(in) :: n
-     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
      integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
      <ftype2> intent(hide) :: a
 
@@ -848,14 +844,13 @@ interface
      integer intent(hide) :: r
      integer intent(hide):: jptv
 
-     ! LWORK is obtained by the query call
      integer intent(in),optional :: lwork = -1
      <ftype2> intent(out) :: work
      integer intent(out)::info
 
    end subroutine <prefix2>gelsy_lwork
 
-   subroutine <prefix2c>gelsy(m,n,minmn,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,rwork,info)
+   subroutine <prefix2c>gelsy(m,n,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,rwork,info)
 
    ! v,x,j,rank,work,rwork,info = zgelsy(a,b,jptv,cond,lwork,overwrite_a=True,overwrite_b=True)
    ! Solve Minimize 2-norm(A * X - B).
@@ -865,7 +860,6 @@ interface
 
      integer intent(hide),depend(a):: m = shape(a,0)
      integer intent(hide),depend(a):: n = shape(a,1)
-     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
      integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
      <ftype2c> dimension(m,n),intent(in,out,copy,out=v) :: a
 
@@ -885,7 +879,7 @@ interface
 
    end subroutine <prefix2c>gelsy
 
-   subroutine <prefix2c>gelsy_lwork(m,n,minmn,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,rwork,info)
+   subroutine <prefix2c>gelsy_lwork(m,n,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,rwork,info)
 
    ! work,info = zgelsy_lwork(m,n,nrhs,cond)
    ! Query for optimal lwork size
@@ -896,7 +890,6 @@ interface
 
      integer intent(in) :: m
      integer intent(in)):: n
-     integer intent(hide) :: minmn = MIN(m,n)
      integer intent(hide) :: maxmn = MAX(m,n)
      <ftype2c> intent(hide) :: a
 
@@ -907,7 +900,6 @@ interface
      integer intent(hide) :: r
      integer intent(hide) :: jptv
 
-     ! LWORK is obtained by the query call
      integer intent(in),optional :: lwork = -1
      <ftype2c> intent(out) :: work
      <ftype2> intent(hide) :: rwork
@@ -948,7 +940,7 @@ interface
 
    end subroutine <prefix2>gelsd
 
-   subroutine <prefix2>gelsd_lwork(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,lwork,size_iwork,iwork,info)
+   subroutine <prefix2>gelsd_lwork(m,n,maxmn,nrhs,a,b,s,cond,r,work,lwork,iwork,info)
 
    ! work,iwork,info = dgelsd_lwork(m,n,nrhs,cond=-1.0)
    ! Query for optimal lwork size
@@ -959,7 +951,6 @@ interface
 
      integer intent(in) :: m
      integer intent(in) :: n
-     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
      integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
      <ftype2> intent(hide) :: a
 
@@ -971,11 +962,8 @@ interface
      <ftype2> intent(hide) :: s
 	
      integer intent(in),optional :: lwork = -1
-     ! Impossible to calculate lwork explicitly, need to obtain it from query call first
-     ! Same for size_iwork
      <ftype2> intent(out) :: work
 
-     integer intent(hide) :: size_iwork
      integer intent(out) :: iwork	
      integer intent(out)::info
 
@@ -1017,7 +1005,7 @@ interface
 
    end subroutine <prefix2c>gelsd
 
-   subroutine <prefix2c>gelsd_lwork(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,lwork,size_rwork,rwork, size_iwork,iwork,info)
+   subroutine <prefix2c>gelsd_lwork(m,n,maxmn,nrhs,a,b,s,cond,r,work,lwork,rwork,iwork,info)
 
    ! work,rwork,iwork,info = zgelsd_lwork(m,n,nrhs,lwork=-1.0,cond=-1.0)
    ! Query for optimal lwork size
@@ -1028,7 +1016,6 @@ interface
 
      integer intent(in) :: m
      integer intent(in) :: n
-     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
      integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
      <ftype2c> intent(hide) :: a
 
@@ -1040,14 +1027,9 @@ interface
      <ftype2> intent(hide) :: s
 	
      integer intent(in),optional :: lwork = -1
-     ! Impossible to calculate lwork explicitly, need to obtain it from query call first
-     ! Same for size_rwork, size_iwork
      <ftype2c> intent(out) :: work
-
-     integer intent(hide) :: size_rwork
      <ftype2> intent(out) :: rwork
 
-     integer intent(hide) :: size_iwork
      integer intent(out) :: iwork	
      integer intent(out)::info
 

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -763,7 +763,7 @@ interface
      integer intent(in,out,out=j),dimension(n),depend(n) :: jptv
 
      ! LWORK is obtained by the query call
-     integer intent(in),depend(nrhs,m,n),check(lwork>=1||lwork==-1) :: lwork!=MAX(m*n+3*n+1,2*m*n+nrhs
+     integer intent(in),depend(nrhs,m,n),check(lwork>=1||lwork==-1) :: lwork
      <ftype2> dimension(MAX(lwork,1)),intent(out),depend(lwork) :: work
      integer intent(out)::info
 
@@ -792,7 +792,7 @@ interface
      integer intent(in,out,out=j),dimension(n),depend(n) :: jptv
 
      ! LWORK is obtained by the query call
-     integer intent(in),depend(nrhs,m,n),check(lwork>=1||lwork==-1) :: lwork !=MAX(m*n+3*n+1,2*m*n+nrhs
+     integer intent(in),depend(nrhs,m,n),check(lwork>=1||lwork==-1) :: lwork
      <ftype2c> dimension(MAX(lwork,1)),intent(out),depend(lwork) :: work
      <ftype2> dimension(2*n),intent(out),depend(n) :: rwork
      integer intent(out)::info
@@ -822,7 +822,7 @@ interface
      <ftype2> intent(out),dimension(minmn),depend(minmn) :: s
 	
      integer intent(in),check(lwork>=1||lwork==-1) :: lwork
-     ! Impossible to calculate lwork explicitely, need to obtain it from query call first
+     ! Impossible to calculate lwork explicitly, need to obtain it from query call first
      ! Same for size_iwork
      <ftype2> dimension(MAX(lwork,1)),intent(out),depend(lwork) :: work
 
@@ -855,7 +855,7 @@ interface
      <ftype2> intent(out),dimension(minmn),depend(minmn) :: s
 	
      integer intent(in),check(lwork>=1||lwork==-1) :: lwork
-     ! Impossible to calculate lwork explicitely, need to obtain it from query call first
+     ! Impossible to calculate lwork explicitly, need to obtain it from query call first
      ! Same for size_rwork, size_iwork
      <ftype2c> dimension(MAX(lwork,1)),intent(out),depend(lwork) :: work
 

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -740,6 +740,134 @@ interface
 
    end subroutine <prefix2c>gelss
 
+   subroutine <prefix2>gelsy(m,n,minmn,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,info)
+
+   ! v,x,j,rank,work,info = dgelsy(a,b,jptv,cond,lwork,overwrite_a=True,overwrite_b=True)
+   ! Solve Minimize 2-norm(A * X - B).
+
+     callstatement (*f2py_func)(&m,&n,&nrhs,a,&m,b,&maxmn,jptv,&cond,&r,work,&lwork,&info)
+     callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
+
+     integer intent(hide),depend(a):: m = shape(a,0)
+     integer intent(hide),depend(a):: n = shape(a,1)
+     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
+     integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
+     <ftype2> dimension(m,n),intent(in,out,copy,out=v) :: a
+
+     integer depend(b),intent(hide):: nrhs = shape(b,1)
+     <ftype2> dimension(maxmn,nrhs),check(maxmn==shape(b,0)),depend(maxmn) :: b
+     intent(in,out,copy,out=x) b
+
+     <ftype2> intent(in) :: cond
+     integer intent(out,out=rank) :: r
+     integer intent(in,out,out=j),dimension(n),depend(n) :: jptv
+
+     ! LWORK is obtained by the query call
+     integer intent(in),depend(nrhs,m,n),check(lwork>=1||lwork==-1) :: lwork!=MAX(m*n+3*n+1,2*m*n+nrhs
+     <ftype2> dimension(MAX(lwork,1)),intent(out),depend(lwork) :: work
+     integer intent(out)::info
+
+   end subroutine <prefix2>gelsy
+
+   subroutine <prefix2c>gelsy(m,n,minmn,maxmn,nrhs,a,b,jptv,cond,r,work,lwork,rwork,info)
+
+   ! v,x,j,rank,work,rwork,info = zgelsy(a,b,jptv,cond,lwork,overwrite_a=True,overwrite_b=True)
+   ! Solve Minimize 2-norm(A * X - B).
+
+     callstatement (*f2py_func)(&m,&n,&nrhs,a,&m,b,&maxmn,jptv,&cond,&r,work,&lwork,rwork,&info)
+     callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,<ctype2>*,int*,<ctype2c>*,int*,<ctype2>*,int*
+
+     integer intent(hide),depend(a):: m = shape(a,0)
+     integer intent(hide),depend(a):: n = shape(a,1)
+     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
+     integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
+     <ftype2c> dimension(m,n),intent(in,out,copy,out=v) :: a
+
+     integer depend(b),intent(hide):: nrhs = shape(b,1)
+     <ftype2c> dimension(maxmn,nrhs),check(maxmn==shape(b,0)),depend(maxmn) :: b
+     intent(in,out,copy,out=x) b
+
+     <ftype2> intent(in) :: cond
+     integer intent(out,out=rank) :: r
+     integer intent(in,out,out=j),dimension(n),depend(n) :: jptv
+
+     ! LWORK is obtained by the query call
+     integer intent(in),depend(nrhs,m,n),check(lwork>=1||lwork==-1) :: lwork !=MAX(m*n+3*n+1,2*m*n+nrhs
+     <ftype2c> dimension(MAX(lwork,1)),intent(out),depend(lwork) :: work
+     <ftype2> dimension(2*n),intent(out),depend(n) :: rwork
+     integer intent(out)::info
+
+   end subroutine <prefix2c>gelsy
+
+   subroutine <prefix2>gelsd(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,lwork,size_iwork,iwork,info)
+
+   ! x,s,rank,work,iwork,info = dgelsd(a,b,lwork,size_iwork,cond=-1.0,overwrite_a=True,overwrite_b=True)
+   ! Solve Minimize 2-norm(A * X - B).
+    
+     callstatement (*f2py_func)(&m,&n,&nrhs,a,&m,b,&maxmn,s,&cond,&r,work,&lwork,iwork,&info)
+     callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
+
+     integer intent(hide),depend(a):: m = shape(a,0)
+     integer intent(hide),depend(a):: n = shape(a,1)
+     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
+     integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
+     <ftype2> dimension(m,n),intent(in,copy) :: a
+
+     integer depend(b),intent(hide):: nrhs = shape(b,1)
+     <ftype2> dimension(maxmn,nrhs),check(maxmn==shape(b,0)),depend(maxmn) :: b
+     intent(in,out,copy,out=x) b
+
+     <ftype2> intent(in),optional :: cond=-1.0
+     integer intent(out,out=rank) :: r
+     <ftype2> intent(out),dimension(minmn),depend(minmn) :: s
+	
+     integer intent(in),check(lwork>=1||lwork==-1) :: lwork
+     ! Impossible to calculate lwork explicitely, need to obtain it from query call first
+     ! Same for size_iwork
+     <ftype2> dimension(MAX(lwork,1)),intent(out),depend(lwork) :: work
+
+     integer intent(in) :: size_iwork
+     integer intent(out),dimension(size_iwork),depend(size_iwork) :: iwork	
+     integer intent(out)::info
+
+   end subroutine <prefix2>gelsd
+
+   subroutine <prefix2c>gelsd(m,n,minmn,maxmn,nrhs,a,b,s,cond,r,work,lwork,size_rwork,rwork, size_iwork,iwork,info)
+
+   ! x,s,rank,work,rwork,iwork,info = zgelsd(a,b,lwork,size_rwork,size_iwork,cond=-1.0,overwrite_a=True,overwrite_b=True)
+   ! Solve Minimize 2-norm(A * X - B).
+
+     callstatement (*f2py_func)(&m,&n,&nrhs,a,&m,b,&maxmn,s,&cond,&r,work,&lwork, rwork, iwork,&info)
+     callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*, <ctype2c>*,int*,<ctype2>*,int*,int*
+
+     integer intent(hide),depend(a):: m = shape(a,0)
+     integer intent(hide),depend(a):: n = shape(a,1)
+     integer intent(hide),depend(m,n):: minmn = MIN(m,n)
+     integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
+     <ftype2c> dimension(m,n),intent(in,copy) :: a
+
+     integer depend(b),intent(hide):: nrhs = shape(b,1)
+     <ftype2c> dimension(maxmn,nrhs),check(maxmn==shape(b,0)),depend(maxmn) :: b
+     intent(in,out,copy,out=x) b
+
+     <ftype2> intent(in),optional :: cond=-1.0
+     integer intent(out,out=rank) :: r
+     <ftype2> intent(out),dimension(minmn),depend(minmn) :: s
+	
+     integer intent(in),check(lwork>=1||lwork==-1) :: lwork
+     ! Impossible to calculate lwork explicitely, need to obtain it from query call first
+     ! Same for size_rwork, size_iwork
+     <ftype2c> dimension(MAX(lwork,1)),intent(out),depend(lwork) :: work
+
+     integer intent(in) :: size_rwork
+     <ftype2> intent(out),dimension(size_rwork),depend(size_rwork) :: rwork
+
+     integer intent(in) :: size_iwork
+     integer intent(out),dimension(size_iwork),depend(size_iwork) :: iwork	
+     integer intent(out)::info
+
+   end subroutine <prefix2c>gelsd
+
    subroutine <prefix2>geqp3(m,n,a,jpvt,tau,work,lwork,info)
 
    ! qr_a,jpvt,tau,work,info = geqp3(a,lwork=3*(n+1),overwrite_a=0)

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -81,6 +81,16 @@ All functions
    cgelss
    zgelss
 
+   sgelsd
+   dgelsd
+   cgelsd
+   zgelsd
+
+   sgelsy
+   dgelsy
+   cgelsy
+   zgelsy
+
    sgeqp3
    dgeqp3
    cgeqp3

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -80,22 +80,22 @@ All functions
    dgelss
    cgelss
    zgelss
-   
+
    sgelss_lwork
    dgelss_lwork
    cgelss_lwork
    zgelss_lwork
-   
+
    sgelsd
    dgelsd
    cgelsd
    zgelsd
-   
+
    sgelsd_lwork
    dgelsd_lwork
    cgelsd_lwork
    zgelsd_lwork
-   
+
    sgelsy
    dgelsy
    cgelsy
@@ -105,7 +105,7 @@ All functions
    dgelsy_lwork
    cgelsy_lwork
    zgelsy_lwork
-   
+
    sgeqp3
    dgeqp3
    cgeqp3
@@ -189,6 +189,9 @@ All functions
 
    chegvx
    zhegvx
+
+   slasd4
+   dlasd4
 
    slaswp
    dlaswp

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -80,17 +80,32 @@ All functions
    dgelss
    cgelss
    zgelss
-
+   
+   sgelss_lwork
+   dgelss_lwork
+   cgelss_lwork
+   zgelss_lwork
+   
    sgelsd
    dgelsd
    cgelsd
    zgelsd
-
+   
+   sgelsd_lwork
+   dgelsd_lwork
+   cgelsd_lwork
+   zgelsd_lwork
+   
    sgelsy
    dgelsy
    cgelsy
    zgelsy
 
+   sgelsy_lwork
+   dgelsy_lwork
+   cgelsy_lwork
+   zgelsy_lwork
+   
    sgeqp3
    dgeqp3
    cgeqp3

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -104,14 +104,20 @@ class TestLeastSquaresSolvers(TestCase):
                           [7.0,8.0]], dtype=dtype)
             b1 = np.array([16.0, 17.0, 20.0], dtype=dtype)
             gelsd, = get_lapack_funcs(('gelsd',), (a1, b1))
-            #x,s,rank,work,iwork,info = *gelsd(a,b,lwork,size_iwork,[cond,overwrite_a,overwrite_b])
-            x, s, rank, work, iwork, info = gelsd(a1, b1, -1, 1)  # Request of sizes
+
+            # Request of sizes
+            x, s, rank, work, iwork, info = gelsd(a1, b1, -1, 1)
             lwork = work[0].real.astype(np.int)
             iwork_size = iwork[0].real.astype(np.int)
 
-            x, s, rank, work, iwork, info = gelsd(a1, b1, lwork, iwork_size, -1, False, False)
-            assert_allclose(x[:-1], np.array([-14.333333333333323, 14.999999999999991], dtype=dtype), rtol=10*np.finfo(dtype).eps)
-            assert_allclose(s, np.array([12.596017180511966, 0.583396253199685], dtype=dtype), rtol=10*np.finfo(dtype).eps)
+            x, s, rank, work, iwork, info = gelsd(a1, b1, lwork, iwork_size,
+                                                  -1, False, False)
+            assert_allclose(x[:-1], np.array([-14.333333333333323,
+                                            14.999999999999991], dtype=dtype),
+                                            rtol=25*np.finfo(dtype).eps)
+            assert_allclose(s, np.array([12.596017180511966,
+                                         0.583396253199685], dtype=dtype),
+                                         rtol=25*np.finfo(dtype).eps)
 
         for dtype in COMPLEX_DTYPES:
             a1 = np.array([[1.0+4.0j,2.0],
@@ -119,16 +125,22 @@ class TestLeastSquaresSolvers(TestCase):
                           [7.0-2.0j,8.0+0.7j]], dtype=dtype)
             b1 = np.array([16.0, 17.0+2.0j, 20.0-4.0j], dtype=dtype)
             gelsd, = get_lapack_funcs(('gelsd',), (a1, b1))
-            #x,s,rank,work,rwork,iwork,info = cgelsd(a,b,lwork,size_rwork,size_iwork,[cond,overwrite_a,overwrite_b])
-            x, s, rank, work, rwork, iwork, info = gelsd(a1, b1, -1, 1,1)  # Request of sizes
+
+            # Request of sizes
+            x, s, rank, work, rwork, iwork, info = gelsd(a1, b1, -1, 1,1)
             lwork = work[0].real.astype(np.int)
             rwork_size = rwork[0].real.astype(np.int)
             iwork_size = iwork[0].real.astype(np.int)
 
-            x, s, rank, work, rwork, iwork, info = gelsd(a1, b1, lwork, rwork_size, iwork_size, -1, False, False)
-            assert_allclose(x[:-1], np.array([1.161753632288328-1.901075709391912j, 1.735882340522193+1.521240901196909j],
-                            dtype=dtype), rtol=10*np.finfo(dtype).eps)
-            assert_allclose(s, np.array([13.035514762572043, 4.337666985231382], dtype=dtype), rtol=10*np.finfo(dtype).eps)
+            x, s, rank, work, rwork, iwork, info = gelsd(a1, b1, lwork,
+                                    rwork_size, iwork_size, -1, False, False)
+            assert_allclose(x[:-1],
+                            np.array([1.161753632288328-1.901075709391912j,
+                                      1.735882340522193+1.521240901196909j],
+                            dtype=dtype), rtol=25*np.finfo(dtype).eps)
+            assert_allclose(s,
+                            np.array([13.035514762572043, 4.337666985231382],
+                                     dtype=dtype), rtol=25*np.finfo(dtype).eps)
 
     def test_gelss(self):
 
@@ -138,13 +150,18 @@ class TestLeastSquaresSolvers(TestCase):
                           [7.0,8.0]], dtype=dtype)
             b1 = np.array([16.0, 17.0, 20.0], dtype=dtype)
             gelss, = get_lapack_funcs(('gelss',), (a1, b1))
-            #v,x,s,rank,work,info = dgelss(a,b,[cond,lwork,overwrite_a,overwrite_b])
-            v,x,s,rank,work,info = gelss(a1, b1,-1, -1, False, False)  # Request of sizes
+
+            # Request of sizes
+            v,x,s,rank,work,info = gelss(a1, b1,-1, -1, False, False)
             lwork = work[0].real.astype(np.int)
 
             v,x,s,rank,work,info = gelss(a1, b1,-1,lwork, False, False)
-            assert_allclose(x[:-1], np.array([-14.333333333333323, 14.999999999999991], dtype=dtype),rtol=10*np.finfo(dtype).eps)
-            assert_allclose(s, np.array([12.596017180511966, 0.583396253199685], dtype=dtype), rtol=10*np.finfo(dtype).eps)
+            assert_allclose(x[:-1], np.array([-14.333333333333323,
+                            14.999999999999991], dtype=dtype),
+                            rtol=25*np.finfo(dtype).eps)
+            assert_allclose(s, np.array([12.596017180511966,
+                                         0.583396253199685], dtype=dtype),
+                                         rtol=25*np.finfo(dtype).eps)
 
         for dtype in COMPLEX_DTYPES:
             a1 = np.array([[1.0+4.0j,2.0],
@@ -152,14 +169,19 @@ class TestLeastSquaresSolvers(TestCase):
                           [7.0-2.0j,8.0+0.7j]], dtype=dtype)
             b1 = np.array([16.0, 17.0+2.0j, 20.0-4.0j], dtype=dtype)
             gelss, = get_lapack_funcs(('gelss',), (a1, b1))
-            #v,x,s,rank,work,info = cgelss(a,b,[cond,lwork,overwrite_a,overwrite_b])
-            v, x, s, rank, work, info = gelss(a1, b1,-1, -1, False, False)  # Request of sizes
+
+            # Request of sizes
+            v, x, s, rank, work, info = gelss(a1, b1,-1, -1, False, False)
             lwork = work[0].real.astype(np.int)
 
             v,x,s,rank,work,info = gelss(a1, b1,-1,lwork, False, False)
-            assert_allclose(x[:-1], np.array([1.161753632288328-1.901075709391912j, 1.735882340522193+1.521240901196909j],
-                            dtype=dtype), rtol=10*np.finfo(dtype).eps)
-            assert_allclose(s, np.array([13.035514762572043, 4.337666985231382], dtype=dtype), rtol=10*np.finfo(dtype).eps)
+            assert_allclose(x[:-1],
+                            np.array([1.161753632288328-1.901075709391912j,
+                                      1.735882340522193+1.521240901196909j],
+                            dtype=dtype), rtol=25*np.finfo(dtype).eps)
+            assert_allclose(s, np.array([13.035514762572043,
+                                         4.337666985231382], dtype=dtype),
+                                         rtol=25*np.finfo(dtype).eps)
 
     def test_gelsy(self):
 
@@ -169,15 +191,18 @@ class TestLeastSquaresSolvers(TestCase):
                           [7.0,8.0]], dtype=dtype)
             b1 = np.array([16.0, 17.0, 20.0], dtype=dtype)
             gelsy, = get_lapack_funcs(('gelsy',), (a1, b1))
-            #x,s,rank,work,iwork,info = *gelsd(a,b,lwork,size_iwork,[cond,overwrite_a,overwrite_b])
+
             jptv = np.zeros((a1.shape[1],1), dtype=np.int32)
-            v,x,j,rank,work,info = gelsy(a1, b1, jptv, np.finfo(dtype).eps,-1)  # Request of sizes
+            # Request of sizes
+            v,x,j,rank,work,info = gelsy(a1, b1, jptv, np.finfo(dtype).eps,-1)
             lwork = work[0].real.astype(np.int)
 
             jptv = np.zeros((a1.shape[1],1), dtype=np.int32)
-            v,x,j,rank,work,info = gelsy(a1, b1, jptv, np.finfo(dtype).eps, lwork, False, False)
-            assert_allclose(x[:-1], np.array([-14.333333333333323, 14.999999999999991], dtype=dtype),rtol=10*np.finfo(dtype).eps)
-            #assert_allclose(s, np.array([ 0.66666669,], dtype=dtype ) )
+            v,x,j,rank,work,info = gelsy(a1, b1, jptv, np.finfo(dtype).eps,
+                                         lwork, False, False)
+            assert_allclose(x[:-1], np.array([-14.333333333333323,
+                                            14.999999999999991], dtype=dtype),
+                                            rtol=25*np.finfo(dtype).eps)
 
         for dtype in COMPLEX_DTYPES:
             a1 = np.array([[1.0+4.0j,2.0],
@@ -185,16 +210,22 @@ class TestLeastSquaresSolvers(TestCase):
                           [7.0-2.0j,8.0+0.7j]], dtype=dtype)
             b1 = np.array([16.0, 17.0+2.0j, 20.0-4.0j], dtype=dtype)
             gelsy, = get_lapack_funcs(('gelsy',), (a1, b1))
-            #x,s,rank,work,rwork,iwork,info = cgelsd(a,b,lwork,size_rwork,size_iwork,[cond,overwrite_a,overwrite_b])
+
             jptv = np.zeros((a1.shape[1],1), dtype=np.int32)
-            v,x,j,rank,work,rwork,info = gelsy(a1, b1, jptv, np.finfo(dtype).eps,-1)  # Request of sizes
+            # Request of sizes
+            v,x,j,rank,work,rwork,info = gelsy(a1, b1, jptv,
+                                               np.finfo(dtype).eps,-1)
             lwork = work[0].real.astype(np.int)
 
             jptv = np.zeros((a1.shape[1],1), dtype=np.int32)
-            v,x,j,rank,work,rwork,info = gelsy(a1, b1, jptv, np.finfo(dtype).eps, lwork, False, False)
-            assert_allclose(x[:-1], np.array([1.161753632288328-1.901075709391912j, 1.735882340522193+1.521240901196909j],
-                            dtype=dtype), rtol=10*np.finfo(dtype).eps)
-            #assert_allclose( s, np.array([ 106.12267169], dtype=dtype ) )
+            v,x,j,rank,work,rwork,info = gelsy(a1, b1, jptv,
+                                               np.finfo(dtype).eps,
+                                                lwork, False, False)
+            assert_allclose(x[:-1],
+                            np.array([1.161753632288328-1.901075709391912j,
+                                      1.735882340522193+1.521240901196909j],
+                            dtype=dtype), rtol=25*np.finfo(dtype).eps)
+
 
 class TestRegression(TestCase):
 

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -103,12 +103,19 @@ class TestLeastSquaresSolvers(TestCase):
                           [4.0,5.0],
                           [7.0,8.0]], dtype=dtype)
             b1 = np.array([16.0, 17.0, 20.0], dtype=dtype)
-            gelsd, = get_lapack_funcs(('gelsd',), (a1, b1))
+            gelsd, gelsd_lwork = get_lapack_funcs(('gelsd','gelsd_lwork'),
+                                                  (a1, b1))
+
+            m, n = a1.shape
+            if len(b1.shape) == 2:
+                nrhs = b1.shape[1]
+            else:
+                nrhs = 1
 
             # Request of sizes
-            x, s, rank, work, iwork, info = gelsd(a1, b1, -1, 1)
-            lwork = work[0].real.astype(np.int)
-            iwork_size = iwork[0].real.astype(np.int)
+            work,iwork,info = gelsd_lwork(m,n,nrhs,-1)
+            lwork = np.int(np.real(work))
+            iwork_size = iwork
 
             x, s, rank, work, iwork, info = gelsd(a1, b1, lwork, iwork_size,
                                                   -1, False, False)
@@ -124,13 +131,20 @@ class TestLeastSquaresSolvers(TestCase):
                           [4.0+0.5j,5.0-3.0j],
                           [7.0-2.0j,8.0+0.7j]], dtype=dtype)
             b1 = np.array([16.0, 17.0+2.0j, 20.0-4.0j], dtype=dtype)
-            gelsd, = get_lapack_funcs(('gelsd',), (a1, b1))
+            gelsd, gelsd_lwork = get_lapack_funcs(('gelsd','gelsd_lwork'),
+                                                  (a1, b1))
+
+            m, n = a1.shape
+            if len(b1.shape) == 2:
+                nrhs = b1.shape[1]
+            else:
+                nrhs = 1
 
             # Request of sizes
-            x, s, rank, work, rwork, iwork, info = gelsd(a1, b1, -1, 1,1)
-            lwork = work[0].real.astype(np.int)
-            rwork_size = rwork[0].real.astype(np.int)
-            iwork_size = iwork[0].real.astype(np.int)
+            work,rwork,iwork,info = gelsd_lwork(m,n,nrhs,-1)
+            lwork = np.int(np.real(work))
+            rwork_size = np.int(rwork)
+            iwork_size = iwork
 
             x, s, rank, work, rwork, iwork, info = gelsd(a1, b1, lwork,
                                     rwork_size, iwork_size, -1, False, False)
@@ -149,11 +163,18 @@ class TestLeastSquaresSolvers(TestCase):
                           [4.0,5.0],
                           [7.0,8.0]], dtype=dtype)
             b1 = np.array([16.0, 17.0, 20.0], dtype=dtype)
-            gelss, = get_lapack_funcs(('gelss',), (a1, b1))
+            gelss, gelss_lwork = get_lapack_funcs(('gelss','gelss_lwork'),
+                                                  (a1, b1))
+
+            m, n = a1.shape
+            if len(b1.shape) == 2:
+                nrhs = b1.shape[1]
+            else:
+                nrhs = 1
 
             # Request of sizes
-            v,x,s,rank,work,info = gelss(a1, b1,-1, -1, False, False)
-            lwork = work[0].real.astype(np.int)
+            work,info = gelss_lwork(m,n,nrhs,-1)
+            lwork = np.int(np.real(work))
 
             v,x,s,rank,work,info = gelss(a1, b1,-1,lwork, False, False)
             assert_allclose(x[:-1], np.array([-14.333333333333323,
@@ -168,11 +189,18 @@ class TestLeastSquaresSolvers(TestCase):
                           [4.0+0.5j,5.0-3.0j],
                           [7.0-2.0j,8.0+0.7j]], dtype=dtype)
             b1 = np.array([16.0, 17.0+2.0j, 20.0-4.0j], dtype=dtype)
-            gelss, = get_lapack_funcs(('gelss',), (a1, b1))
+            gelss, gelss_lwork = get_lapack_funcs(('gelss','gelss_lwork'),
+                                                  (a1, b1))
+
+            m, n = a1.shape
+            if len(b1.shape) == 2:
+                nrhs = b1.shape[1]
+            else:
+                nrhs = 1
 
             # Request of sizes
-            v, x, s, rank, work, info = gelss(a1, b1,-1, -1, False, False)
-            lwork = work[0].real.astype(np.int)
+            work,info = gelss_lwork(m,n,nrhs,-1)
+            lwork = np.int(np.real(work))
 
             v,x,s,rank,work,info = gelss(a1, b1,-1,lwork, False, False)
             assert_allclose(x[:-1],
@@ -190,12 +218,17 @@ class TestLeastSquaresSolvers(TestCase):
                           [4.0,5.0],
                           [7.0,8.0]], dtype=dtype)
             b1 = np.array([16.0, 17.0, 20.0], dtype=dtype)
-            gelsy, = get_lapack_funcs(('gelsy',), (a1, b1))
+            gelsy, gelsy_lwork = get_lapack_funcs(('gelsy','gelss_lwork'), (a1, b1))
 
-            jptv = np.zeros((a1.shape[1],1), dtype=np.int32)
+            m, n = a1.shape
+            if len(b1.shape) == 2:
+                nrhs = b1.shape[1]
+            else:
+                nrhs = 1
+
             # Request of sizes
-            v,x,j,rank,work,info = gelsy(a1, b1, jptv, np.finfo(dtype).eps,-1)
-            lwork = work[0].real.astype(np.int)
+            work,info = gelsy_lwork(m,n,nrhs,10*np.finfo(dtype).eps)
+            lwork = np.int(np.real(work))
 
             jptv = np.zeros((a1.shape[1],1), dtype=np.int32)
             v,x,j,rank,work,info = gelsy(a1, b1, jptv, np.finfo(dtype).eps,
@@ -209,16 +242,20 @@ class TestLeastSquaresSolvers(TestCase):
                           [4.0+0.5j,5.0-3.0j],
                           [7.0-2.0j,8.0+0.7j]], dtype=dtype)
             b1 = np.array([16.0, 17.0+2.0j, 20.0-4.0j], dtype=dtype)
-            gelsy, = get_lapack_funcs(('gelsy',), (a1, b1))
+            gelsy, gelsy_lwork = get_lapack_funcs(('gelsy','gelss_lwork'), (a1, b1))
 
-            jptv = np.zeros((a1.shape[1],1), dtype=np.int32)
+            m, n = a1.shape
+            if len(b1.shape) == 2:
+                nrhs = b1.shape[1]
+            else:
+                nrhs = 1
+
             # Request of sizes
-            v,x,j,rank,work,rwork,info = gelsy(a1, b1, jptv,
-                                               np.finfo(dtype).eps,-1)
-            lwork = work[0].real.astype(np.int)
+            work,info = gelsy_lwork(m,n,nrhs,10*np.finfo(dtype).eps)
+            lwork = np.int(np.real(work))
 
             jptv = np.zeros((a1.shape[1],1), dtype=np.int32)
-            v,x,j,rank,work,rwork,info = gelsy(a1, b1, jptv,
+            v,x,j,rank,work,info = gelsy(a1, b1, jptv,
                                                np.finfo(dtype).eps,
                                                 lwork, False, False)
             assert_allclose(x[:-1],


### PR DESCRIPTION
This is a continuation of the pull request #4478. Now the function linalg.lstsq is modified to use extra LAPACK drivers. 
Sorry, but I do not know how to satisfy these requirements, could you give a hint:

-Is the new functionality tagged with .. versionadded:: X.Y.Z (with X.Y.Z the version number of the next release can be found in setup.py)?
-Is the new functionality added to the reference guide?
