### PR TITLE
[ENH] linalg.hessenberg: use orghr - rebase

### DIFF
--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -875,7 +875,8 @@ def hessenberg(a, calc_q=False, overwrite_a=False, check_finite=True):
 
     lwork, info = gehrd_lwork(ba.shape[0], lo=lo, hi=hi)
     if info != 0:
-        raise ValueError('failed to compute internal gehrd work array size')
+        raise ValueError('failed to compute internal gehrd work array size. '
+                            'LAPACK info = %d ' % info)
     lwork = int(lwork.real)
 
     hq, tau, info = gehrd(ba, lo=lo, hi=hi, lwork=lwork, overwrite_a=1)
@@ -890,7 +891,8 @@ def hessenberg(a, calc_q=False, overwrite_a=False, check_finite=True):
     orghr, orghr_lwork = get_lapack_funcs(('orghr', 'orghr_lwork'), (a1,))
     lwork, info = orghr_lwork(n, lo=lo, hi=hi)
     if info != 0:
-        raise ValueError('failed to compute internal orghr work array size')
+        raise ValueError('failed to compute internal orghr work array size. '
+                            'LAPACK info = %d ' % info)
     lwork = int(lwork.real)
     q, info = orghr(a=hq, tau=tau, lo=lo, hi=hi, lwork=lwork, overwrite_a=1)
     if info < 0:

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -859,6 +859,13 @@ def hessenberg(a, calc_q=False, overwrite_a=False, check_finite=True):
     if len(a1.shape) != 2 or (a1.shape[0] != a1.shape[1]):
         raise ValueError('expected square matrix')
     overwrite_a = overwrite_a or (_datacopied(a1, a))
+
+    # if 2x2 or smaller: already in Hessenberg
+    if a1.shape[0] <= 2:
+        if calc_q:
+            return a1, numpy.eye(a1.shape[0])
+        return a1
+
     gehrd, gebal, gehrd_lwork = get_lapack_funcs(('gehrd','gebal', 'gehrd_lwork'), (a1,))
     ba, lo, hi, pivscale, info = gebal(a1, permute=0, overwrite_a=overwrite_a)
     if info < 0:

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -875,7 +875,7 @@ def hessenberg(a, calc_q=False, overwrite_a=False, check_finite=True):
 
     lwork, info = gehrd_lwork(ba.shape[0], lo=lo, hi=hi)
     if info != 0:
-        raise ValueError('failed to compute internal gehrd work array size' % info)
+        raise ValueError('failed to compute internal gehrd work array size')
     lwork = int(lwork.real)
 
     hq, tau, info = gehrd(ba, lo=lo, hi=hi, lwork=lwork, overwrite_a=1)
@@ -887,8 +887,11 @@ def hessenberg(a, calc_q=False, overwrite_a=False, check_finite=True):
         return h
 
     # use orghr/unghr to compute q
-    orghr, = get_lapack_funcs(('orghr',), (a1,))
-    lwork = calc_lwork.orghr(orghr.typecode, n, lo, hi)
+    orghr, orghr_lwork = get_lapack_funcs(('orghr', 'orghr_lwork'), (a1,))
+    lwork, info = orghr_lwork(n, lo=lo, hi=hi)
+    if info != 0:
+        raise ValueError('failed to compute internal orghr work array size')
+    lwork = int(lwork.real)
     q, info = orghr(a=hq, tau=tau, lo=lo, hi=hi, lwork=lwork, overwrite_a=1)
     if info < 0:
         raise ValueError('illegal value in %d-th argument of internal orghr '

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -377,6 +377,20 @@ interface
 
    end subroutine <prefix2>orghr
 
+   subroutine <prefix2>orghr_lwork(n,lo,hi,a,tau,work,lwork,info)
+     ! LWORK computation ofr orghr
+     fortranname <prefix2>orghr
+     callstatement { hi++; lo++; (*f2py_func)(&n,&lo,&hi,&a,&n,&tau,&work,&lwork,&info); }
+     integer intent(in) :: n
+     <ftype2> intent(hide) :: a
+     integer intent(in), optional :: lo = 0
+     integer intent(in), optional, depend(n) :: hi = n-1
+     <ftype2> intent(hide) :: tau
+     <ftype2> intent(out) :: work
+     integer intent(hide) :: lwork = -1
+     integer intent(out) :: info
+   end subroutine <prefix2>orghr_lwork
+
    subroutine <prefix2c>unghr(n,lo,hi,a,tau,work,lwork,info)
    !
    ! q,info = orghr(a,tau,lo=0,hi=n-1,lwork=n,overwrite_a=0)
@@ -393,8 +407,21 @@ interface
      <ftype2c> dimension(lwork),intent(cache,hide),depend(lwork) :: work
      integer intent(in),optional,depend(n),check(lwork>=hi-lo) :: lwork = hi-lo
      integer intent(out) :: info
-
    end subroutine <prefix2c>unghr
+
+   subroutine <prefix2c>unghr_lwork(n,lo,hi,a,tau,work,lwork,info)
+     ! LWORK computation ofr orghr
+     fortranname <prefix2c>unghr
+     callstatement { hi++; lo++; (*f2py_func)(&n,&lo,&hi,&a,&n,&tau,&work,&lwork,&info); }
+     integer intent(in) :: n
+     <ftype2c> intent(hide) :: a
+     integer intent(in), optional :: lo = 0
+     integer intent(in), optional, depend(n) :: hi = n-1
+     <ftype2c> intent(hide) :: tau
+     <ftype2c> intent(out) :: work
+     integer intent(hide) :: lwork = -1
+     integer intent(out) :: info
+   end subroutine <prefix2c>unghr_lwork
 
    subroutine <prefix>gbsv(n,kl,ku,nrhs,ab,piv,b,info)
    ! 

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -358,6 +358,44 @@ interface
      integer intent(out) :: info
    end subroutine <prefix>gehrd_lwork
 
+   subroutine <prefix2>orghr(n,lo,hi,a,tau,work,lwork,info)
+   !
+   ! q,info = orghr(a,tau,lo=0,hi=n-1,lwork=n,overwrite_a=0)
+   ! Compute orthogonal matrix Q for Hessenberg reduction from the matrix
+   ! that was computed by gehrd
+   !
+     callstatement { hi++; lo++; (*f2py_func)(&n,&lo,&hi,a,&n,tau,work,&lwork,&info); }
+     callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*
+     integer intent(hide),depend(a) :: n = shape(a,0)
+     <ftype2> dimension(n,n),intent(in,out,copy,out=ht,aligned8),check(shape(a,0)==shape(a,1)) :: a
+     integer intent(in),optional :: lo = 0
+     integer intent(in),optional,depend(n) :: hi = n-1
+     <ftype2> dimension(n-1),intent(in),depend(n) :: tau
+     <ftype2> dimension(lwork),intent(cache,hide),depend(lwork) :: work
+     integer intent(in),optional,depend(n),check(lwork>=hi-lo) :: lwork = hi-lo
+     integer intent(out) :: info
+
+   end subroutine <prefix2>orghr
+
+   subroutine <prefix2c>unghr(n,lo,hi,a,tau,work,lwork,info)
+   !
+   ! q,info = orghr(a,tau,lo=0,hi=n-1,lwork=n,overwrite_a=0)
+   ! Compute orthogonal matrix Q for Hessenberg reduction from the matrix
+   ! that was computed by gehrd
+   !
+     callstatement { hi++; lo++; (*f2py_func)(&n,&lo,&hi,a,&n,tau,work,&lwork,&info); }
+     callprotoargument int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,<ctype2c>*,int*,int*
+     integer intent(hide),depend(a) :: n = shape(a,0)
+     <ftype2c> dimension(n,n),intent(in,out,copy,out=ht,aligned8),check(shape(a,0)==shape(a,1)) :: a
+     integer intent(in),optional :: lo = 0
+     integer intent(in),optional,depend(n) :: hi = n-1
+     <ftype2c> dimension(n-1),intent(in),depend(n) :: tau
+     <ftype2c> dimension(lwork),intent(cache,hide),depend(lwork) :: work
+     integer intent(in),optional,depend(n),check(lwork>=hi-lo) :: lwork = hi-lo
+     integer intent(out) :: info
+
+   end subroutine <prefix2c>unghr
+
    subroutine <prefix>gbsv(n,kl,ku,nrhs,ab,piv,b,info)
    ! 
    ! lub,piv,x,info = gbsv(kl,ku,ab,b,overwrite_ab=0,overwrite_b=0)

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -322,6 +322,7 @@ del empty_module
 # some convenience alias for complex functions
 _lapack_alias = {
     'corghr': 'cunghr', 'zorghr': 'zunghr',
+    'corghr_lwork': 'cunghr_lwork', 'zorghr_lwork': 'zunghr_lwork',
     'corgqr': 'cungqr', 'zorgqr': 'zungqr',
     'cormqr': 'cunmqr', 'zormqr': 'zunmqr',
     'corgrq': 'cungrq', 'zorgrq': 'zungrq',

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -225,6 +225,9 @@ All functions
    ctrtrs
    ztrtrs
 
+   cunghr
+   zunghr
+
    cungqr
    zungqr
 
@@ -246,6 +249,9 @@ All functions
 
    slamch
    dlamch
+
+   sorghr
+   dorghr
 
    sorgqr
    dorgqr
@@ -315,6 +321,7 @@ del empty_module
 
 # some convenience alias for complex functions
 _lapack_alias = {
+    'corghr': 'cunghr', 'zorghr': 'zunghr',
     'corgqr': 'cungqr', 'zorgqr': 'zungqr',
     'cormqr': 'cunmqr', 'zormqr': 'zunmqr',
     'corgrq': 'cungrq', 'zorgrq': 'zungrq',

--- a/scipy/linalg/src/calc_lwork.f
+++ b/scipy/linalg/src/calc_lwork.f
@@ -2,7 +2,7 @@
       integer min_lwork,max_lwork,n,lo,hi
       character prefix
 c
-c     Returned maxwrk is acctually optimal lwork.
+c     Returned maxwrk is actually optimal lwork.
 c
 cf2py intent(out,out=minwrk) :: min_lwork
 cf2py intent(out,out=maxwrk) :: max_lwork
@@ -23,7 +23,7 @@ cf2py intent(in) :: n,lo,hi
       integer min_lwork,max_lwork,n,lo,hi
       character prefix
 c
-c     Returned maxwrk is acctually optimal lwork.
+c     Returned maxwrk is actually optimal lwork.
 c
 cf2py intent(out,out=minwrk) :: min_lwork
 cf2py intent(out,out=maxwrk) :: max_lwork

--- a/scipy/linalg/src/calc_lwork.f
+++ b/scipy/linalg/src/calc_lwork.f
@@ -19,27 +19,6 @@ cf2py intent(in) :: n,lo,hi
 
       end
 
-      subroutine orghr(min_lwork,max_lwork,prefix,n,lo,hi)
-      integer min_lwork,max_lwork,n,lo,hi
-      character prefix
-c
-c     Returned maxwrk is actually optimal lwork.
-c
-cf2py intent(out,out=minwrk) :: min_lwork
-cf2py intent(out,out=maxwrk) :: max_lwork
-cf2py intent(in) :: prefix
-cf2py intent(in) :: n,lo,hi
-
-      INTEGER NB
-      EXTERNAL ILAENV
-      INTRINSIC MIN, MAX
-
-      NB = MIN( 64, ILAENV( 1, prefix // 'ORGHR', ' ', n, lo, hi, -1 ) )
-      max_lwork = MAX(1, (hi - lo) * NB)
-      min_lwork = MAX(1, hi - lo)
-
-      end
-
       subroutine gesdd(min_lwork,max_lwork,prefix,m,n,compute_uv)
       integer min_lwork,max_lwork,m,n,compute_uv
       character prefix

--- a/scipy/linalg/src/calc_lwork.f
+++ b/scipy/linalg/src/calc_lwork.f
@@ -19,6 +19,27 @@ cf2py intent(in) :: n,lo,hi
 
       end
 
+      subroutine orghr(min_lwork,max_lwork,prefix,n,lo,hi)
+      integer min_lwork,max_lwork,n,lo,hi
+      character prefix
+c
+c     Returned maxwrk is acctually optimal lwork.
+c
+cf2py intent(out,out=minwrk) :: min_lwork
+cf2py intent(out,out=maxwrk) :: max_lwork
+cf2py intent(in) :: prefix
+cf2py intent(in) :: n,lo,hi
+
+      INTEGER NB
+      EXTERNAL ILAENV
+      INTRINSIC MIN, MAX
+
+      NB = MIN( 64, ILAENV( 1, prefix // 'ORGHR', ' ', n, lo, hi, -1 ) )
+      max_lwork = MAX(1, (hi - lo) * NB)
+      min_lwork = MAX(1, hi - lo)
+
+      end
+
       subroutine gesdd(min_lwork,max_lwork,prefix,m,n,compute_uv)
       integer min_lwork,max_lwork,m,n,compute_uv
       character prefix

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1760,6 +1760,18 @@ class TestHessenberg(TestCase):
         assert_array_almost_equal(dot(transp(q),dot(a,q)),h)
         assert_array_almost_equal(h,h1,decimal=4)
 
+    def test_2x2(self):
+        a = [[2, 1], [7, 12]]
+
+        h, q = hessenberg(a, calc_q=1)
+        assert_array_almost_equal(q, np.eye(2))
+        assert_array_almost_equal(h, a)
+
+        b = [[2-7j, 1+2j], [7+3j, 12-2j]]
+        h2, q2 = hessenberg(b, calc_q=1)
+        assert_array_almost_equal(q2, np.eye(2))
+        assert_array_almost_equal(h2, b)
+
 
 class TestQZ(TestCase):
     def setUp(self):


### PR DESCRIPTION
This is a continuation of #3506, rebased and fixed up.  

My primary remaining question is about the `aligned8` flag in the lapack wrappers.  We don't need it anywhere else, so I doubt we need it here.
