### PR TITLE
MAINT: stats: remove duplicated code

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1047,9 +1047,9 @@ class rv_generic(object):
         output = zeros(shape(cond0), 'd')
         place(output, (1-cond0), self.badvalue)
         goodargs = argsreduce(cond0, *args)
-        # I don't know when or why vecentropy got broken when numargs == 0
-        # 09.08.2013: is this still relevant? cf check_vecentropy test
-        # in tests/test_continuous_basic.py
+        # np.vectorize doesn't work when numargs == 0 in numpy 1.6.2.  Once the
+        # lowest supported numpy version is >= 1.7.0, this special case can be
+        # removed (see gh-4314).
         if self.numargs == 0:
             place(output, cond0, self._entropy() + log(scale))
         else:
@@ -2182,37 +2182,6 @@ class rv_continuous(rv_generic):
             else:
                 lower = self.a
             return integrate.quad(integ, lower, upper)[0]
-
-    def entropy(self, *args, **kwds):
-        """
-        Differential entropy of the RV.
-
-        Parameters
-        ----------
-        arg1, arg2, arg3,... : array_like
-            The shape parameter(s) for the distribution (see docstring of the
-            instance object for more information).
-        loc : array_like, optional
-            Location parameter (default=0).
-        scale : array_like, optional
-            Scale parameter (default=1).
-
-        """
-        args, loc, scale = self._parse_args(*args, **kwds)
-        args = tuple(map(asarray, args))
-        cond0 = self._argcheck(*args) & (scale > 0) & (loc == loc)
-        output = zeros(shape(cond0), 'd')
-        place(output, (1-cond0), self.badvalue)
-        goodargs = argsreduce(cond0, *args)
-        # np.vectorize doesn't work when numargs == 0 in numpy 1.6.2.  Once the
-        # lowest supported numpy version is >= 1.7.0, this special case can be
-        # removed (see gh-4314).
-        if self.numargs == 0:
-            place(output, cond0, self._entropy() + log(scale))
-        else:
-            place(output, cond0, self.vecentropy(*goodargs) + log(scale))
-
-        return output
 
     def expect(self, func=None, args=(), loc=0, scale=1, lb=None, ub=None,
                conditional=False, **kwds):


### PR DESCRIPTION
Distributions entropy method was duplicated in rv_generic and rv_continuous,
differing only in code comments and the docs. Compare: 
https://github.com/scipy/scipy/blob/master/scipy/stats/_distn_infrastructure.py#L1020
and
https://github.com/scipy/scipy/blob/master/scipy/stats/_distn_infrastructure.py#L2186

Consolidate comments, remove the rv_continuous copy.
