### PR TITLE
fix merge conflicts in 'option to avoid computing possibly unused svd matrix'

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -10,9 +10,9 @@ import warnings
 
 import numpy as np
 
-from numpy.testing import assert_allclose, \
-        assert_array_almost_equal_nulp, run_module_suite, \
-        assert_raises, assert_equal, assert_array_equal
+from numpy.testing import (assert_allclose, assert_,
+        assert_array_almost_equal_nulp, run_module_suite,
+        assert_raises, assert_equal, assert_array_equal)
 
 from numpy import dot, conj, random
 from scipy.linalg import eig, eigh
@@ -812,20 +812,22 @@ def test_svds_partial_return():
     z = csr_matrix(x)
     vh_full = svds(z, 2)[-1]
     vh_partial = svds(z, 2, return_singular_vectors='vh')[-1]
-    dvh = np.linalg.norm(np.abs(vh_full) - np.abs(vh_partial))
-    if dvh > 1e-10:
-        raise AssertionError('right eigenvector matrices differ when using return_singular_vectors parameter')
-    if svds(z, 2, return_singular_vectors='vh')[0] is not None:
-        raise AssertionError('left eigenvector matrix was computed when it should not have been')
+    assert_allclose(np.abs(vh_full), np.abs(vh_partial), atol=1e-10,
+            err_msg=('right eigenvector matrices differ '
+                     'when using return_singular_vectors parameter'))
+    assert_(svds(z, 2, return_singular_vectors='vh')[0] is None,
+            msg=('left eigenvector matrix was computed '
+                  'when it should not have been'))
     # test horizontal matrix
     z = csr_matrix(x.T)
     u_full = svds(z, 2)[0]
     u_partial = svds(z, 2, return_singular_vectors='vh')[0]
-    du = np.linalg.norm(np.abs(u_full) - np.abs(u_partial))
-    if du > 1e-10:
-        raise AssertionError('left eigenvector matrices differ when using return_singular_vectors parameter')
-    if svds(z, 2, return_singular_vectors='u')[-1] is not None:
-        raise AssertionError('right eigenvector matrix was computed when it should not have been')
+    assert_allclose(np.abs(u_full), np.abs(u_partial), atol=1e-10,
+            err_msg=('left eigenvector matrices differ '
+                     'when using return_singular_vectors parameter'))
+    assert_(svds(z, 2, return_singular_vectors='u')[-1] is None,
+            msg=('right eigenvector matrix was computed '
+                 'when it should not have been'))
 
 
 if __name__ == "__main__":

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -803,5 +803,30 @@ def test_linearoperator_deallocation():
         pass
 
 
+def test_svds_partial_return():
+    x = np.array([[1, 2, 3],
+                  [3, 4, 3],
+                  [1, 0, 2],
+                  [0, 0, 1]], np.float)
+    # test vertical matrix
+    z = csr_matrix(x)
+    vh_full = svds(z, 2)[-1]
+    vh_partial = svds(z, 2, return_singular_vectors='vh')[-1]
+    dvh = np.linalg.norm(np.abs(vh_full) - np.abs(vh_partial))
+    if dvh > 1e-10:
+        raise AssertionError('right eigenvector matrices differ when using return_singular_vectors parameter')
+    if svds(z, 2, return_singular_vectors='vh')[0] is not None:
+        raise AssertionError('left eigenvector matrix was computed when it should not have been')
+    # test horizontal matrix
+    z = csr_matrix(x.T)
+    u_full = svds(z, 2)[0]
+    u_partial = svds(z, 2, return_singular_vectors='vh')[0]
+    du = np.linalg.norm(np.abs(u_full) - np.abs(u_partial))
+    if du > 1e-10:
+        raise AssertionError('left eigenvector matrices differ when using return_singular_vectors parameter')
+    if svds(z, 2, return_singular_vectors='u')[-1] is not None:
+        raise AssertionError('right eigenvector matrix was computed when it should not have been')
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
The PR https://github.com/scipy/scipy/pull/4147 had merge conflicts with recent changes in the abstract linear operator interface, so I've manually resolved these in this PR.  The logic and tests should be the same as in the original PR.
