### PR TITLE
Rebase of PR 3303 (sparse matrix norms)

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -45,6 +45,7 @@ Building sparse matrices:
    hstack - Stack sparse matrices horizontally (column wise)
    vstack - Stack sparse matrices vertically (row wise)
    rand - Random values in a given shape
+   norm - Return norm of a sparse matrix
 
 Sparse matrix tools:
 

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -251,6 +251,9 @@ class spmatrix(object):
         """
         return self * other
 
+    def power(self, n, dtype=None):            
+        return self.tocsr().power(n, dtype=dtype)
+
     def __eq__(self, other):
         return self.tocsr().__eq__(other)
 

--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -197,11 +197,5 @@ class csc_matrix(_cs_matrix, IndexMixin):
         """
         return (x[1],x[0])
 
-    def power(self, n):
-        """
-        n is scalar
-        """
-        return csc_matrix((self.data ** n, self.indices, self.indptr), shape=self.shape)
-
 def isspmatrix_csc(x):
     return isinstance(x, csc_matrix)

--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -197,6 +197,11 @@ class csc_matrix(_cs_matrix, IndexMixin):
         """
         return (x[1],x[0])
 
+    def power(self, n):
+        """
+        n is scalar
+        """
+        return csc_matrix((self.data ** n, self.indices, self.indptr), shape=self.shape)
 
 def isspmatrix_csc(x):
     return isinstance(x, csc_matrix)

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -419,6 +419,11 @@ class csr_matrix(_cs_matrix, IndexMixin):
 
         return self.__class__((data,indices,indptr), shape=shape)
 
+    def power(self, n):
+        """
+        n is scalar
+        """
+        return csr_matrix((self.data ** n, self.indices, self.indptr), shape=self.shape)
 
 def isspmatrix_csr(x):
     return isinstance(x, csr_matrix)

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -419,11 +419,5 @@ class csr_matrix(_cs_matrix, IndexMixin):
 
         return self.__class__((data,indices,indptr), shape=shape)
 
-    def power(self, n):
-        """
-        n is scalar
-        """
-        return csr_matrix((self.data ** n, self.indices, self.indptr), shape=self.shape)
-
 def isspmatrix_csr(x):
     return isinstance(x, csr_matrix)

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -10,6 +10,7 @@ from __future__ import division, print_function, absolute_import
 
 __all__ = []
 
+
 import numpy as np
 
 from .base import spmatrix, _ufuncs_with_fixed_point_at_zero
@@ -71,24 +72,25 @@ class _data_matrix(spmatrix):
         
         Parameters
         ----------
-        n : n is either a scalar or a sparse matrix with the same shape
+        n : n is a scalar
         
         dtype : If dtype is not specified, the current dtype will be preserved.
         """
-        data = self.data
-        if dtype is not None:
-            data = data.astype(dtype)
-        
+                
         if isscalarlike(n):
-            return self._with_data(data ** n)
+            if hasattr(self, "tocsr"):                
+                m = self.tocsr()  
+                m.sum_duplicates()
+                data = m.data
+                if dtype is not None:
+                    data = data.astype(dtype)
+                
+                return m._with_data(data ** n)
+            else:
+                raise TypeError("matrix cannot be convert to csr")            
         else:
-            if not isinstance(n, spmatrix):
-                raise TypeError("input is not sparse")
-            
-            if n.shape != self.shape:
-                raise "shape is different"
-            
-            return self._with_data(data ** n.data)
+            raise NotImplementedError("input is not scalar")
+        
     ###########################
     # Multiplication handlers #
     ###########################

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -65,6 +65,30 @@ class _data_matrix(spmatrix):
     def copy(self):
         return self._with_data(self.data.copy(), copy=True)
 
+    def power(self, n, dtype=None):
+        """
+        This function performs element-wise power.
+        
+        Parameters
+        ----------
+        n : n is either a scalar or a sparse matrix with the same shape
+        
+        dtype : If dtype is not specified, the current dtype will be preserved.
+        """
+        data = self.data
+        if dtype is not None:
+            data = data.astype(dtype)
+        
+        if isscalarlike(n):
+            return self._with_data(data ** n)
+        else:
+            if not isinstance(n, spmatrix):
+                raise TypeError("input is not sparse")
+            
+            if n.shape != self.shape:
+                raise "shape is different"
+            
+            return self._with_data(data ** n.data)
     ###########################
     # Multiplication handlers #
     ###########################

--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -112,6 +112,7 @@ from .interface import *
 from .eigen import *
 from .matfuncs import *
 from ._onenormest import *
+from ._norm import *
 from ._expm_multiply import *
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -1,9 +1,3 @@
-
-"""
-    Parameters
-    ----------
-    A : ndarray or other linear operator
-"""
 import numpy as np
 from scipy.sparse import issparse
 
@@ -21,98 +15,98 @@ def isComplexType(t):
 
 def norm(x, ord=None, axis=None):
     """
-Sparse Matrix
+    Norm of a sparse matrix
 
-This function is able to return one of seven different matrix norms,
-or one of an infinite number of vector norms (described below), depending
-on the value of the ``ord`` parameter.
-
-Parameters
-----------
-x : array_like
-Input array. If `axis` is None, `x` must be 1-D or 2-D.
-ord : {non-zero int, inf, -inf, 'fro'}, optional
-Order of the norm (see table under ``Notes``). inf means numpy's
-`inf` object.
-axis : {int, None}, optional
-If `axis` is an integer, it specifies the axis of `x` along which to
-compute the vector norms. 
-
-Returns
--------
-n : float or matrix
-
-Notes
------
-For values of ``ord <= 0``, the result is, strictly speaking, not a
-mathematical 'norm', but it may still be useful for various numerical
-purposes.
-
-The following norms can be calculated:
-
-===== ============================ ==========================
-ord norm for matrices norm for vectors
-===== ============================ ==========================
-None Frobenius norm 2-norm
-'fro' Frobenius norm --
-inf max(sum(abs(x), axis=1)) max(abs(x))
--inf min(sum(abs(x), axis=1)) min(abs(x))
-0 -- sum(x != 0)
-1 max(sum(abs(x), axis=0)) as below
--1 min(sum(abs(x), axis=0)) as below
-2 2-norm (largest sing. value) as below
--2 smallest singular value as below
-other -- sum(abs(x)**ord)**(1./ord)
-===== ============================ ==========================
-
-The Frobenius norm is given by [1]_:
-
-:math:`||A||_F = [\\sum_{i,j} abs(a_{i,j})^2]^{1/2}`
-
-References
-----------
-.. [1] G. H. Golub and C. F. Van Loan, *Matrix Computations*,
-Baltimore, MD, Johns Hopkins University Press, 1985, pg. 15
-
-Examples
---------
->>> from scripy.sparse import *
->>> import numpy as np
->>> from scipy.sparse.linalg import norm
->>> a = np.arange(9) - 4
->>> a
-array([-4, -3, -2, -1, 0, 1, 2, 3, 4])
->>> b = a.reshape((3, 3))
->>> b
-array([[-4, -3, -2],
-[-1, 0, 1],
-[ 2, 3, 4]])
->>> b = csr_matrix(b)
->>> norm(b)
-7.745966692414834
->>> norm(b, 'fro')
-7.745966692414834
->>> norm(b, np.inf)
-9
->>> norm(b, -np.inf)
-2
->>> norm(b, 1)
-7
->>> norm(b, -1)
-6
-
-Using the `axis` argument to compute vector norms:
-
->>> c = np.array([[ 1, 2, 3],
-... [-1, 1, 4]])
->>> c = csr_matrix(c)
->>> norm(c, axis=0)
-matrix[[ 1.41421356, 2.23606798, 5. ]]
->>> norm(c, axis=1)
-matrix[[ 3.74165739, 4.24264069]]
->>> norm(c, ord=1, axis=1)
-matrix[[6]
-[6]]
+    This function is able to return one of seven different matrix norms,
+    or one of an infinite number of vector norms (described below), depending
+    on the value of the ``ord`` parameter.
+    
+    Parameters
+    ----------
+    x : array_like
+    Input array. If `axis` is None, `x` must be 1-D or 2-D.
+    ord : {non-zero int, inf, -inf, 'fro'}, optional
+    Order of the norm (see table under ``Notes``). inf means numpy's
+    `inf` object.
+    axis : {int, None}, optional
+    If `axis` is an integer, it specifies the axis of `x` along which to
+    compute the vector norms. 
+    
+    Returns
+    -------
+    n : float or matrix
+    
+    Notes
+    -----
+    Some of the ord is not implemented because some associated functions like, _multi_svd_norm, is not yet available for sparse matrix. 
+    
+    This docstring is modified based on numpy.linalg.norm. https://github.com/numpy/numpy/blob/master/numpy/linalg/linalg.py 
+    
+    The following norms can be calculated:
+    
+    =====  ============================  
+    ord    norm for sparse matrices             
+    =====  ============================  
+    None   Frobenius norm                
+    'fro'  Frobenius norm                
+    inf    max(sum(abs(x), axis=1))      
+    -inf   min(sum(abs(x), axis=1))      
+    0      abs(x).sum(axis=axis)                           
+    1      max(sum(abs(x), axis=0))      
+    -1     min(sum(abs(x), axis=0))      
+    2      Not implemented  
+    -2     Not implemented      
+    other  Not implemented                               
+    =====  ============================  
+    
+    The Frobenius norm is given by [1]_:
+    
+    :math:`||A||_F = [\\sum_{i,j} abs(a_{i,j})^2]^{1/2}`
+    
+    References
+    ----------
+    .. [1] G. H. Golub and C. F. Van Loan, *Matrix Computations*,
+    Baltimore, MD, Johns Hopkins University Press, 1985, pg. 15
+    
+    Examples
+    --------
+    >>> from scipy.sparse import *
+    >>> import numpy as np
+    >>> from scipy.sparse.linalg import norm
+    >>> a = np.arange(9) - 4
+    >>> a
+    array([-4, -3, -2, -1, 0, 1, 2, 3, 4])
+    >>> b = a.reshape((3, 3))
+    >>> b
+    array([[-4, -3, -2],
+    [-1, 0, 1],
+    [ 2, 3, 4]])
+    >>> b = csr_matrix(b)
+    >>> norm(b)
+    7.745966692414834
+    >>> norm(b, 'fro')
+    7.745966692414834
+    >>> norm(b, np.inf)
+    9
+    >>> norm(b, -np.inf)
+    2
+    >>> norm(b, 1)
+    7
+    >>> norm(b, -1)
+    6
+    
+    Using the `axis` argument to compute vector norms:
+    
+    >>> c = np.array([[ 1, 2, 3],
+    ... [-1, 1, 4]])
+    >>> c = csr_matrix(c)
+    >>> norm(c, axis=0)
+    matrix[[ 1.41421356, 2.23606798, 5. ]]
+    >>> norm(c, axis=1)
+    matrix[[ 3.74165739, 4.24264069]]
+    >>> norm(c, ord=1, axis=1)
+    matrix[[6]
+    [6]]
 
 """
     if not issparse(x):
@@ -133,38 +127,21 @@ matrix[[6]
     
     if np.isscalar(axis):
         if ord == Inf:
-            return abs(x).max(axis=axis)
+            return max(abs(x).sum(axis=axis))
         elif ord == -Inf:
-            return abs(x).min(axis=axis)
+            return min(abs(x).sum(axis=axis))
         elif ord == 0:
             # Zero norm
             return (x != 0).sum(axis=axis)
         elif ord == 1:
             # special case for speedup
             return abs(x).sum(axis=axis)
-        elif ord is None or ord == 2:
-            # special case for speedup
-            s = x.power(2)
-            return sqrt(s.sum(axis=axis))
+        elif ord == -1:
+            return min(abs(x).sum(axis=axis))             
+        elif ord is None:            
+            return sqrt(x.power(2).sum(axis=axis))        
         else:
-            try:
-                ord + 1
-            except TypeError:
-                raise ValueError("Invalid norm order for vectors.")
-            if x.dtype.type is longdouble:
-                # Convert to a float type, so integer arrays give
-                # float results. Don't apply asfarray to longdouble arrays,
-                # because it will downcast to float64.
-                absx = abs(x)
-            else:
-                absx = x if isComplexType(x.dtype.type) else asfarray(x)
-                if absx.dtype is x.dtype:
-                    absx = abs(absx)
-                else:
-                    # if the type changed, we can safely overwrite absx
-                    abs(absx, out=absx)
-            absx **= ord
-            return absx.sum(axis=axis) ** (1.0 / ord)
+            raise NotImplementedError
     elif len(axis) == 2:
         row_axis, col_axis = axis
         if not (-nd <= row_axis < nd and -nd <= col_axis < nd):

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -92,14 +92,14 @@ def norm(x, ord=None):
     >>> norm(b, -1)
     6
 
-"""
+    """
     if not issparse(x):
         raise TypeError("input is not sparse. use numpy.linalg.norm")
 
     # Check the default case first and handle it immediately.
     if ord in (None, 'fro', 'f'):
-        if np.iscomplexobj(x):
-            sqnorm = dot(x.real, x.real) + dot(x.imag, x.imag)
+        if np.issubdtype(x.dtype, np.complexfloating):
+            sqnorm = abs(x).power(2).sum()
         else:
             sqnorm = x.power(2).sum()
         return sqrt(sqnorm)
@@ -129,8 +129,6 @@ def norm(x, ord=None):
             return abs(x).sum(axis=row_axis).min(axis=col_axis)[0,0]
         elif ord == -Inf:
             return abs(x).sum(axis=col_axis).min(axis=row_axis)[0,0]
-        elif ord in [None, 'fro', 'f']:
-            return sqrt(x.power(2).sum(axis=axis))
         else:
             raise ValueError("Invalid norm order for matrices.")
     else:

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -5,9 +5,191 @@
     A : ndarray or other linear operator
 """
 import numpy as np
-def norm(A, axis = 1):   
-    if hasattr(A, "power"): 
-        new_A = A.power(2).sum(axis = axis)
-        return np.sqrt(new_A)
+from scipy.sparse import issparse
+
+from numpy.core import (
+    array, asarray, zeros, empty, empty_like, transpose, intc, single, double,
+    csingle, cdouble, inexact, complexfloating, newaxis, ravel, all, Inf, dot,
+    add, multiply, sqrt, maximum, fastCopyAndTranspose, sum, isfinite, size,
+    finfo, errstate, geterrobj, longdouble, rollaxis, amin, amax, product, abs,
+    broadcast
+    )
+
+
+def isComplexType(t):
+    return issubclass(t, complexfloating)
+
+def norm(x, ord=None, axis=None):
+    """
+Sparse Matrix
+
+This function is able to return one of seven different matrix norms,
+or one of an infinite number of vector norms (described below), depending
+on the value of the ``ord`` parameter.
+
+Parameters
+----------
+x : array_like
+Input array. If `axis` is None, `x` must be 1-D or 2-D.
+ord : {non-zero int, inf, -inf, 'fro'}, optional
+Order of the norm (see table under ``Notes``). inf means numpy's
+`inf` object.
+axis : {int, None}, optional
+If `axis` is an integer, it specifies the axis of `x` along which to
+compute the vector norms. 
+
+Returns
+-------
+n : float or matrix
+
+Notes
+-----
+For values of ``ord <= 0``, the result is, strictly speaking, not a
+mathematical 'norm', but it may still be useful for various numerical
+purposes.
+
+The following norms can be calculated:
+
+===== ============================ ==========================
+ord norm for matrices norm for vectors
+===== ============================ ==========================
+None Frobenius norm 2-norm
+'fro' Frobenius norm --
+inf max(sum(abs(x), axis=1)) max(abs(x))
+-inf min(sum(abs(x), axis=1)) min(abs(x))
+0 -- sum(x != 0)
+1 max(sum(abs(x), axis=0)) as below
+-1 min(sum(abs(x), axis=0)) as below
+2 2-norm (largest sing. value) as below
+-2 smallest singular value as below
+other -- sum(abs(x)**ord)**(1./ord)
+===== ============================ ==========================
+
+The Frobenius norm is given by [1]_:
+
+:math:`||A||_F = [\\sum_{i,j} abs(a_{i,j})^2]^{1/2}`
+
+References
+----------
+.. [1] G. H. Golub and C. F. Van Loan, *Matrix Computations*,
+Baltimore, MD, Johns Hopkins University Press, 1985, pg. 15
+
+Examples
+--------
+>>> from scripy.sparse import *
+>>> import numpy as np
+>>> from scipy.sparse.linalg import norm
+>>> a = np.arange(9) - 4
+>>> a
+array([-4, -3, -2, -1, 0, 1, 2, 3, 4])
+>>> b = a.reshape((3, 3))
+>>> b
+array([[-4, -3, -2],
+[-1, 0, 1],
+[ 2, 3, 4]])
+>>> b = csr_matrix(b)
+>>> norm(b)
+7.745966692414834
+>>> norm(b, 'fro')
+7.745966692414834
+>>> norm(b, np.inf)
+9
+>>> norm(b, -np.inf)
+2
+>>> norm(b, 1)
+7
+>>> norm(b, -1)
+6
+
+Using the `axis` argument to compute vector norms:
+
+>>> c = np.array([[ 1, 2, 3],
+... [-1, 1, 4]])
+>>> c = csr_matrix(c)
+>>> norm(c, axis=0)
+matrix[[ 1.41421356, 2.23606798, 5. ]]
+>>> norm(c, axis=1)
+matrix[[ 3.74165739, 4.24264069]]
+>>> norm(c, ord=1, axis=1)
+matrix[[6]
+[6]]
+
+"""
+    if not issparse(x):
+        raise TypeError("input is not sparse. use numpy.linalg.norm")
+
+    # Check the default case first and handle it immediately.
+    if ord in [None, 'fro', 'f'] and axis is None:
+        if isComplexType(x.dtype.type):
+            sqnorm = dot(x.real, x.real) + dot(x.imag, x.imag)
+        else:
+            sqnorm = x.power(2).sum()
+        return sqrt(sqnorm)
+
+    # Normalize the `axis` argument to a tuple.
+    nd = x.ndim
+    if axis is None:
+        axis = tuple(range(nd))
+    
+    if np.isscalar(axis):
+        if ord == Inf:
+            return abs(x).max(axis=axis)
+        elif ord == -Inf:
+            return abs(x).min(axis=axis)
+        elif ord == 0:
+            # Zero norm
+            return (x != 0).sum(axis=axis)
+        elif ord == 1:
+            # special case for speedup
+            return abs(x).sum(axis=axis)
+        elif ord is None or ord == 2:
+            # special case for speedup
+            s = x.power(2)
+            return sqrt(s.sum(axis=axis))
+        else:
+            try:
+                ord + 1
+            except TypeError:
+                raise ValueError("Invalid norm order for vectors.")
+            if x.dtype.type is longdouble:
+                # Convert to a float type, so integer arrays give
+                # float results. Don't apply asfarray to longdouble arrays,
+                # because it will downcast to float64.
+                absx = abs(x)
+            else:
+                absx = x if isComplexType(x.dtype.type) else asfarray(x)
+                if absx.dtype is x.dtype:
+                    absx = abs(absx)
+                else:
+                    # if the type changed, we can safely overwrite absx
+                    abs(absx, out=absx)
+            absx **= ord
+            return absx.sum(axis=axis) ** (1.0 / ord)
+    elif len(axis) == 2:
+        row_axis, col_axis = axis
+        if not (-nd <= row_axis < nd and -nd <= col_axis < nd):
+            raise ValueError('Invalid axis %r for an array with shape %r' %
+                             (axis, x.shape))
+        if row_axis % nd == col_axis % nd:
+            raise ValueError('Duplicate axes given.')
+        if ord == 2:
+            raise BaseException("Not implemented")
+            #return _multi_svd_norm(x, row_axis, col_axis, amax)
+        elif ord == -2:
+            raise BaseException("Not implemented")
+            #return _multi_svd_norm(x, row_axis, col_axis, amin)
+        elif ord == 1:
+            return abs(x).sum(axis=row_axis).max(axis=col_axis)[0,0]
+        elif ord == Inf:
+            return abs(x).sum(axis=col_axis).max(axis=row_axis)[0,0]
+        elif ord == -1:
+            return abs(x).sum(axis=row_axis).min(axis=col_axis)[0,0]
+        elif ord == -Inf:
+            return abs(x).sum(axis=col_axis).min(axis=row_axis)[0,0]
+        elif ord in [None, 'fro', 'f']:
+            return sqrt(x.power(2).sum(axis=axis))
+        else:
+            raise ValueError("Invalid norm order for matrices.")
     else:
-        raise "%s doesn't not support power(scalar)"%type(A)
+        raise ValueError("Improper number of dimensions to norm.")
+

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -20,7 +20,8 @@ def norm(x, ord=None):
     Parameters
     ----------
     x : a sparse matrix
-        Input sparse matrix. If `axis` is None, `x` must be 1-D or 2-D sparse matrix.
+        Input sparse matrix. If `axis` is None, `x` must be 1-D or 2-D
+        sparse matrix.
     ord : {non-zero int, inf, -inf, 'fro'}, optional
         Order of the norm (see table under ``Notes``). inf means numpy's
         `inf` object.

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -1,3 +1,8 @@
+"""Sparse matrix norms.
+
+"""
+from __future__ import division, print_function, absolute_import
+
 import numpy as np
 from scipy.sparse import issparse
 

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -25,8 +25,7 @@ def norm(x, ord=None):
     Parameters
     ----------
     x : a sparse matrix
-        Input sparse matrix. If `axis` is None, `x` must be 1-D or 2-D
-        sparse matrix.
+        Input sparse matrix.
     ord : {non-zero int, inf, -inf, 'fro'}, optional
         Order of the norm (see table under ``Notes``). inf means numpy's
         `inf` object.
@@ -109,7 +108,6 @@ def norm(x, ord=None):
             sqnorm = x.power(2).sum()
         return sqrt(sqnorm)
 
-    # Normalize the `axis` argument to a tuple.
     nd = x.ndim
     axis = tuple(range(nd))
 

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -10,7 +10,7 @@ from numpy.core import (
     )
 
 
-def norm(x, ord=None, axis=None):
+def norm(x, ord=None):
     """
     Norm of a sparse matrix
 
@@ -24,9 +24,6 @@ def norm(x, ord=None, axis=None):
     ord : {non-zero int, inf, -inf, 'fro'}, optional
         Order of the norm (see table under ``Notes``). inf means numpy's
         `inf` object.
-    axis : {int, None}, optional
-        If `axis` is an integer, it specifies the axis of `x` along which to
-        compute the vector norms. 
     
     Returns
     -------
@@ -94,25 +91,12 @@ def norm(x, ord=None, axis=None):
     >>> norm(b, -1)
     6
     
-    Using the `axis` argument to compute vector norms:
-    
-    >>> c = np.array([[ 1, 2, 3],
-    ...               [-1, 1, 4]])
-    >>> c = csr_matrix(c)
-    >>> norm(c, axis=0)
-    matrix[[ 1.41421356, 2.23606798, 5. ]]
-    >>> norm(c, axis=1)
-    matrix[[ 3.74165739, 4.24264069]]
-    >>> norm(c, ord=1, axis=1)
-    matrix[[6]
-           [6]]
-
 """
     if not issparse(x):
         raise TypeError("input is not sparse. use numpy.linalg.norm")
 
     # Check the default case first and handle it immediately.
-    if ord in [None, 'fro', 'f'] and axis is None:
+    if ord in (None, 'fro', 'f'):
         if np.iscomplexobj(x):
             sqnorm = dot(x.real, x.real) + dot(x.imag, x.imag)
         else:
@@ -121,27 +105,9 @@ def norm(x, ord=None, axis=None):
 
     # Normalize the `axis` argument to a tuple.
     nd = x.ndim
-    if axis is None:
-        axis = tuple(range(nd))
+    axis = tuple(range(nd))
     
-    if np.isscalar(axis):
-        if ord == Inf:
-            return max(abs(x).sum(axis=axis))
-        elif ord == -Inf:
-            return min(abs(x).sum(axis=axis))
-        elif ord == 0:
-            # Zero norm
-            return (x != 0).sum(axis=axis)
-        elif ord == 1:
-            # special case for speedup
-            return abs(x).sum(axis=axis)
-        elif ord == -1:
-            return min(abs(x).sum(axis=axis))             
-        elif ord is None:            
-            return sqrt(x.power(2).sum(axis=axis))        
-        else:
-            raise NotImplementedError
-    elif len(axis) == 2:
+    if len(axis) == 2:
         row_axis, col_axis = axis
         if not (-nd <= row_axis < nd and -nd <= col_axis < nd):
             raise ValueError('Invalid axis %r for an array with shape %r' %

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -18,19 +18,18 @@ def norm(x, ord=None, axis=None):
     Norm of a sparse matrix
 
     This function is able to return one of seven different matrix norms,
-    or one of an infinite number of vector norms (described below), depending
-    on the value of the ``ord`` parameter.
+    depending on the value of the ``ord`` parameter.
     
     Parameters
     ----------
-    x : array_like
-    Input array. If `axis` is None, `x` must be 1-D or 2-D.
+    x : a sparse matrix
+        Input sparse matrix. If `axis` is None, `x` must be 1-D or 2-D sparse matrix.
     ord : {non-zero int, inf, -inf, 'fro'}, optional
-    Order of the norm (see table under ``Notes``). inf means numpy's
-    `inf` object.
+        Order of the norm (see table under ``Notes``). inf means numpy's
+        `inf` object.
     axis : {int, None}, optional
-    If `axis` is an integer, it specifies the axis of `x` along which to
-    compute the vector norms. 
+        If `axis` is an integer, it specifies the axis of `x` along which to
+        compute the vector norms. 
     
     Returns
     -------
@@ -38,9 +37,11 @@ def norm(x, ord=None, axis=None):
     
     Notes
     -----
-    Some of the ord is not implemented because some associated functions like, _multi_svd_norm, is not yet available for sparse matrix. 
+    Some of the ord are not implemented because some associated functions like, 
+    _multi_svd_norm, are not yet available for sparse matrix. 
     
-    This docstring is modified based on numpy.linalg.norm. https://github.com/numpy/numpy/blob/master/numpy/linalg/linalg.py 
+    This docstring is modified based on numpy.linalg.norm. 
+    https://github.com/numpy/numpy/blob/master/numpy/linalg/linalg.py 
     
     The following norms can be calculated:
     
@@ -61,12 +62,12 @@ def norm(x, ord=None, axis=None):
     
     The Frobenius norm is given by [1]_:
     
-    :math:`||A||_F = [\\sum_{i,j} abs(a_{i,j})^2]^{1/2}`
+        :math:`||A||_F = [\\sum_{i,j} abs(a_{i,j})^2]^{1/2}`
     
     References
     ----------
     .. [1] G. H. Golub and C. F. Van Loan, *Matrix Computations*,
-    Baltimore, MD, Johns Hopkins University Press, 1985, pg. 15
+        Baltimore, MD, Johns Hopkins University Press, 1985, pg. 15
     
     Examples
     --------
@@ -79,8 +80,9 @@ def norm(x, ord=None, axis=None):
     >>> b = a.reshape((3, 3))
     >>> b
     array([[-4, -3, -2],
-    [-1, 0, 1],
-    [ 2, 3, 4]])
+           [-1, 0, 1],
+           [ 2, 3, 4]])
+           
     >>> b = csr_matrix(b)
     >>> norm(b)
     7.745966692414834
@@ -98,7 +100,7 @@ def norm(x, ord=None, axis=None):
     Using the `axis` argument to compute vector norms:
     
     >>> c = np.array([[ 1, 2, 3],
-    ... [-1, 1, 4]])
+    ...               [-1, 1, 4]])
     >>> c = csr_matrix(c)
     >>> norm(c, axis=0)
     matrix[[ 1.41421356, 2.23606798, 5. ]]
@@ -106,7 +108,7 @@ def norm(x, ord=None, axis=None):
     matrix[[ 3.74165739, 4.24264069]]
     >>> norm(c, ord=1, axis=1)
     matrix[[6]
-    [6]]
+           [6]]
 
 """
     if not issparse(x):

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -16,7 +16,7 @@ def norm(x, ord=None):
 
     This function is able to return one of seven different matrix norms,
     depending on the value of the ``ord`` parameter.
-    
+
     Parameters
     ----------
     x : a sparse matrix
@@ -24,21 +24,21 @@ def norm(x, ord=None):
     ord : {non-zero int, inf, -inf, 'fro'}, optional
         Order of the norm (see table under ``Notes``). inf means numpy's
         `inf` object.
-    
+
     Returns
     -------
     n : float or matrix
-    
+
     Notes
     -----
     Some of the ord are not implemented because some associated functions like, 
     _multi_svd_norm, are not yet available for sparse matrix. 
-    
+
     This docstring is modified based on numpy.linalg.norm. 
     https://github.com/numpy/numpy/blob/master/numpy/linalg/linalg.py 
-    
+
     The following norms can be calculated:
-    
+
     =====  ============================  
     ord    norm for sparse matrices             
     =====  ============================  
@@ -53,16 +53,16 @@ def norm(x, ord=None):
     -2     Not implemented      
     other  Not implemented                               
     =====  ============================  
-    
+
     The Frobenius norm is given by [1]_:
-    
+
         :math:`||A||_F = [\\sum_{i,j} abs(a_{i,j})^2]^{1/2}`
-    
+
     References
     ----------
     .. [1] G. H. Golub and C. F. Van Loan, *Matrix Computations*,
         Baltimore, MD, Johns Hopkins University Press, 1985, pg. 15
-    
+
     Examples
     --------
     >>> from scipy.sparse import *
@@ -76,7 +76,7 @@ def norm(x, ord=None):
     array([[-4, -3, -2],
            [-1, 0, 1],
            [ 2, 3, 4]])
-           
+
     >>> b = csr_matrix(b)
     >>> norm(b)
     7.745966692414834
@@ -90,7 +90,7 @@ def norm(x, ord=None):
     7
     >>> norm(b, -1)
     6
-    
+
 """
     if not issparse(x):
         raise TypeError("input is not sparse. use numpy.linalg.norm")
@@ -106,7 +106,7 @@ def norm(x, ord=None):
     # Normalize the `axis` argument to a tuple.
     nd = x.ndim
     axis = tuple(range(nd))
-    
+
     if len(axis) == 2:
         row_axis, col_axis = axis
         if not (-nd <= row_axis < nd and -nd <= col_axis < nd):
@@ -134,4 +134,3 @@ def norm(x, ord=None):
             raise ValueError("Invalid norm order for matrices.")
     else:
         raise ValueError("Improper number of dimensions to norm.")
-

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -1,0 +1,13 @@
+
+"""
+    Parameters
+    ----------
+    A : ndarray or other linear operator
+"""
+import numpy as np
+def norm(A, axis = 1):   
+    if hasattr(A, "power"): 
+        new_A = A.power(2).sum(axis = axis)
+        return np.sqrt(new_A)
+    else:
+        raise "%s doesn't not support power(scalar)"%type(A)

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -173,10 +173,10 @@ matrix[[6]
         if row_axis % nd == col_axis % nd:
             raise ValueError('Duplicate axes given.')
         if ord == 2:
-            raise BaseException("Not implemented")
+            raise NotImplementedError
             #return _multi_svd_norm(x, row_axis, col_axis, amax)
         elif ord == -2:
-            raise BaseException("Not implemented")
+            raise NotImplementedError
             #return _multi_svd_norm(x, row_axis, col_axis, amin)
         elif ord == 1:
             return abs(x).sum(axis=row_axis).max(axis=col_axis)[0,0]

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -10,9 +10,6 @@ from numpy.core import (
     )
 
 
-def isComplexType(t):
-    return issubclass(t, complexfloating)
-
 def norm(x, ord=None, axis=None):
     """
     Norm of a sparse matrix
@@ -116,7 +113,7 @@ def norm(x, ord=None, axis=None):
 
     # Check the default case first and handle it immediately.
     if ord in [None, 'fro', 'f'] and axis is None:
-        if isComplexType(x.dtype.type):
+        if np.iscomplexobj(x):
             sqnorm = dot(x.real, x.real) + dot(x.imag, x.imag)
         else:
             sqnorm = x.power(2).sum()

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -4,8 +4,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (assert_raises, assert_allclose, assert_equal, assert_,
-        decorators, TestCase, run_module_suite)
+from numpy.testing import assert_raises, assert_equal, TestCase
 
 from numpy import matrix, abs
 from scipy.sparse import *

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -29,28 +29,3 @@ class TestNorm(TestCase):
         #_multi_svd_norm is not implemented for sparse matrix
         assert_raises(NotImplementedError, norm, b, 2)
         assert_raises(NotImplementedError, norm, b, -2)
-                
-    def test_norm_axis(self):
-        a = np.array([[ 1, 2, 3],
-                      [-1, 1, 4]])
-                
-        c = csr_matrix(a)        
-        #Frobenius norm
-        assert_equal(norm(c, axis=0), np.sqrt(np.power(np.asmatrix(a), 2).sum(axis=0)))
-        assert_equal(norm(c, axis=1), np.sqrt(np.power(np.asmatrix(a), 2).sum(axis=1)))
-        
-        assert_equal(norm(c, np.inf, axis=0), max(abs(np.asmatrix(a)).sum(axis=0)))
-        assert_equal(norm(c, np.inf, axis=1), max(abs(np.asmatrix(a)).sum(axis=1)))
-                
-        assert_equal(norm(c, -np.inf, axis=0), min(abs(np.asmatrix(a)).sum(axis=0)))
-        assert_equal(norm(c, -np.inf, axis=1), min(abs(np.asmatrix(a)).sum(axis=1)))
-                        
-        assert_equal(norm(c, 1, axis=0), abs(np.asmatrix(a)).sum(axis=0))
-        assert_equal(norm(c, 1, axis=1), abs(np.asmatrix(a)).sum(axis=1))
-        
-        assert_equal(norm(c, -1, axis=0), min(abs(np.asmatrix(a)).sum(axis=0))  )
-        assert_equal(norm(c, -1, axis=1), min(abs(np.asmatrix(a)).sum(axis=1))  )
-        
-         #_multi_svd_norm is not implemented for sparse matrix
-        assert_raises(NotImplementedError, norm, c, 2, 0)
-        #assert_raises(NotImplementedError, norm, c, -2, 0)

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -4,27 +4,60 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_raises, assert_equal, TestCase
+from numpy.linalg import norm as npnorm
+from numpy.testing import (assert_raises, assert_equal, assert_allclose,
+        TestCase)
 
-from numpy import matrix, abs
-from scipy.sparse import *
-from scipy.sparse.linalg import norm
+import scipy.sparse
+from scipy.sparse.linalg import norm as spnorm
+
 
 class TestNorm(TestCase):
     def test_norm(self):
         a = np.arange(9) - 4
         b = a.reshape((3, 3))
-        b = csr_matrix(b)
+        b = scipy.sparse.csr_matrix(b)
 
         #Frobenius norm is the default
-        assert_equal(norm(b), 7.745966692414834)        
-        assert_equal(norm(b, 'fro'), 7.745966692414834)
+        assert_equal(spnorm(b), 7.745966692414834)        
+        assert_equal(spnorm(b, 'fro'), 7.745966692414834)
 
-        assert_equal(norm(b, np.inf), 9)
-        assert_equal(norm(b, -np.inf), 2)
-        assert_equal(norm(b, 1), 7)
-        assert_equal(norm(b, -1), 6)
+        assert_equal(spnorm(b, np.inf), 9)
+        assert_equal(spnorm(b, -np.inf), 2)
+        assert_equal(spnorm(b, 1), 7)
+        assert_equal(spnorm(b, -1), 6)
 
         #_multi_svd_norm is not implemented for sparse matrix
-        assert_raises(NotImplementedError, norm, b, 2)
-        assert_raises(NotImplementedError, norm, b, -2)
+        assert_raises(NotImplementedError, spnorm, b, 2)
+        assert_raises(NotImplementedError, spnorm, b, -2)
+
+
+class TestVsNumpyNorm(TestCase):
+    _sparse_types = (
+            scipy.sparse.bsr_matrix,
+            scipy.sparse.coo_matrix,
+            scipy.sparse.csc_matrix,
+            scipy.sparse.csr_matrix,
+            scipy.sparse.dia_matrix,
+            scipy.sparse.dok_matrix,
+            scipy.sparse.lil_matrix,
+            )
+    _test_matrices = (
+            (np.arange(9) - 4).reshape((3, 3)),
+            [
+                [ 1, 2, 3],
+                [-1, 1, 4]],
+            [
+                [ 1, 0, 3],
+                [-1, 1, 4j]],
+            )
+    def test_sparse_matrix_norms(self):
+        for sparse_type in self._sparse_types:
+            for M in self._test_matrices:
+                S = sparse_type(M)
+                assert_allclose(spnorm(S), npnorm(M))
+                assert_allclose(spnorm(S, 'fro'), npnorm(M, 'fro'))
+                assert_allclose(spnorm(S, np.inf), npnorm(M, np.inf))
+                assert_allclose(spnorm(S, -np.inf), npnorm(M, -np.inf))
+                assert_allclose(spnorm(S, 1), npnorm(M, 1))
+                assert_allclose(spnorm(S, -1), npnorm(M, -1))

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -1,0 +1,56 @@
+"""Test functions for the sparse.linalg.norm module
+"""
+
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+from numpy.testing import (assert_raises, assert_allclose, assert_equal, assert_,
+        decorators, TestCase, run_module_suite)
+
+from numpy import matrix, abs
+from scipy.sparse import *
+from scipy.sparse.linalg import norm
+
+class TestNorm(TestCase):
+    def test_norm(self):
+        a = np.arange(9) - 4
+        b = a.reshape((3, 3))
+        b = csr_matrix(b)
+        
+        #Frobenius norm is the default
+        assert_equal(norm(b), 7.745966692414834)        
+        assert_equal(norm(b, 'fro'), 7.745966692414834)
+        
+        assert_equal(norm(b, np.inf), 9)
+        assert_equal(norm(b, -np.inf), 2)
+        assert_equal(norm(b, 1), 7)
+        assert_equal(norm(b, -1), 6)
+        
+        #_multi_svd_norm is not implemented for sparse matrix
+        assert_raises(NotImplementedError, norm, b, 2)
+        assert_raises(NotImplementedError, norm, b, -2)
+                
+    def test_norm_axis(self):
+        a = np.array([[ 1, 2, 3],
+                      [-1, 1, 4]])
+                
+        c = csr_matrix(a)        
+        #Frobenius norm
+        assert_equal(norm(c, axis=0), np.sqrt(np.power(np.asmatrix(a), 2).sum(axis=0)))
+        assert_equal(norm(c, axis=1), np.sqrt(np.power(np.asmatrix(a), 2).sum(axis=1)))
+        
+        assert_equal(norm(c, np.inf, axis=0), max(abs(np.asmatrix(a)).sum(axis=0)))
+        assert_equal(norm(c, np.inf, axis=1), max(abs(np.asmatrix(a)).sum(axis=1)))
+                
+        assert_equal(norm(c, -np.inf, axis=0), min(abs(np.asmatrix(a)).sum(axis=0)))
+        assert_equal(norm(c, -np.inf, axis=1), min(abs(np.asmatrix(a)).sum(axis=1)))
+                        
+        assert_equal(norm(c, 1, axis=0), abs(np.asmatrix(a)).sum(axis=0))
+        assert_equal(norm(c, 1, axis=1), abs(np.asmatrix(a)).sum(axis=1))
+        
+        assert_equal(norm(c, -1, axis=0), min(abs(np.asmatrix(a)).sum(axis=0))  )
+        assert_equal(norm(c, -1, axis=1), min(abs(np.asmatrix(a)).sum(axis=1))  )
+        
+         #_multi_svd_norm is not implemented for sparse matrix
+        assert_raises(NotImplementedError, norm, c, 2, 0)
+        #assert_raises(NotImplementedError, norm, c, -2, 0)

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -16,16 +16,16 @@ class TestNorm(TestCase):
         a = np.arange(9) - 4
         b = a.reshape((3, 3))
         b = csr_matrix(b)
-        
+
         #Frobenius norm is the default
         assert_equal(norm(b), 7.745966692414834)        
         assert_equal(norm(b, 'fro'), 7.745966692414834)
-        
+
         assert_equal(norm(b, np.inf), 9)
         assert_equal(norm(b, -np.inf), 2)
         assert_equal(norm(b, 1), 7)
         assert_equal(norm(b, -1), 6)
-        
+
         #_multi_svd_norm is not implemented for sparse matrix
         assert_raises(NotImplementedError, norm, b, 2)
         assert_raises(NotImplementedError, norm, b, -2)

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -45,12 +45,13 @@ class TestVsNumpyNorm(TestCase):
     _test_matrices = (
             (np.arange(9) - 4).reshape((3, 3)),
             [
-                [ 1, 2, 3],
+                [1, 2, 3],
                 [-1, 1, 4]],
             [
-                [ 1, 0, 3],
+                [1, 0, 3],
                 [-1, 1, 4j]],
             )
+
     def test_sparse_matrix_norms(self):
         for sparse_type in self._sparse_types:
             for M in self._test_matrices:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -27,7 +27,7 @@ import numpy as np
 from scipy._lib.six import xrange, zip as izip
 from numpy import (arange, zeros, array, dot, matrix, asmatrix, asarray,
                    vstack, ndarray, transpose, diag, kron, inf, conjugate,
-                   int8, ComplexWarning)
+                   int8, ComplexWarning, power)
 
 import random
 from numpy.testing import (assert_raises, assert_equal, assert_array_equal,
@@ -586,6 +586,29 @@ class _TestCommon:
     def test_abs(self):
         A = matrix([[-1, 0, 17],[0, -5, 0],[1, -4, 0],[0,0,0]],'d')
         assert_equal(abs(A),abs(self.spmatrix(A)).todense())
+        
+    def test_elementwise_power(self):
+        i = array([[-4, -3, -2],[-1, 0, 1],[2, 3, 4]])
+        expected_matrix = matrix(power(i, 2))
+        A = matrix(i)
+        A = csr_matrix(A)
+        assert_equal(A.power(2).todense(), expected_matrix)
+        
+        #it's elementwise power function, input has to be a scalar
+        assert_raises(NotImplementedError, A.power, A)
+        
+        A = csc_matrix(A)
+        assert_equal(A.power(2).todense(), expected_matrix)
+        
+        A = bsr_matrix(A)
+        assert_equal(A.power(2).todense(), expected_matrix)
+        
+        A = coo_matrix(A)
+        assert_equal(A.power(2).todense(), expected_matrix)
+        
+        A = dia_matrix(A)
+        assert_equal(A.power(2).todense(), expected_matrix)
+        
 
     def test_neg(self):
         A = matrix([[-1, 0, 17],[0, -5, 0],[1, -4, 0],[0,0,0]],'d')
@@ -617,7 +640,7 @@ class _TestCommon:
         mats.append(kron(mats[3],[[1,2,3,4]]))
 
         for m in mats:
-            assert_equal(self.spmatrix(m).diagonal(),diag(m))
+            assert_equal(self.spmatrix(m).diagonal(),diag(m))        
 
     @dec.slow
     def test_setdiag(self):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -588,27 +588,11 @@ class _TestCommon:
         assert_equal(abs(A),abs(self.spmatrix(A)).todense())
         
     def test_elementwise_power(self):
-        i = array([[-4, -3, -2],[-1, 0, 1],[2, 3, 4]])
-        expected_matrix = matrix(power(i, 2))
-        A = matrix(i)
-        A = csr_matrix(A)
-        assert_equal(A.power(2).todense(), expected_matrix)
-        
-        #it's elementwise power function, input has to be a scalar
-        assert_raises(NotImplementedError, A.power, A)
-        
-        A = csc_matrix(A)
-        assert_equal(A.power(2).todense(), expected_matrix)
-        
-        A = bsr_matrix(A)
-        assert_equal(A.power(2).todense(), expected_matrix)
-        
-        A = coo_matrix(A)
-        assert_equal(A.power(2).todense(), expected_matrix)
-        
-        A = dia_matrix(A)
-        assert_equal(A.power(2).todense(), expected_matrix)
-        
+        A = matrix([[-4, -3, -2],[-1, 0, 1],[2, 3, 4]], 'd')        
+        assert_equal(np.power(A, 2), self.spmatrix(A).power(2).todense())
+                
+        #it's element-wise power function, input has to be a scalar
+        assert_raises(NotImplementedError, self.spmatrix(A).power, A)       
 
     def test_neg(self):
         A = matrix([[-1, 0, 17],[0, -5, 0],[1, -4, 0],[0,0,0]],'d')


### PR DESCRIPTION
Fixes merge conflicts that have accumulated over the last year.
https://github.com/scipy/scipy/pull/3303
~~The PR still needs work, especially with respect to `axis`-specific norms and complex-valued matrices.~~ The original authorship meta-data is intact.
