### PR TITLE
MAINT: fix lobpcg performance regression

### DIFF
--- a/scipy/sparse/linalg/eigen/lobpcg/benchmarks/bench_lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/benchmarks/bench_lobpcg.py
@@ -46,7 +46,7 @@ def _as2d(ar):
     if ar.ndim == 2:
         return ar
     else:  # Assume 1!
-        aux = nm.array(ar, copy=False)
+        aux = np.array(ar, copy=False)
         aux.shape = (ar.shape[0], 1)
         return aux
 

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -40,7 +40,7 @@ def save(ar, fileName):
 
 
 def _assert_symmetric(M, rtol=1e-5, atol=1e-8):
-    assert_allclose(M.T, M, rtol=rtol, atol=atol, err_msg=str(M.T - M))
+    assert_allclose(M.T, M, rtol=rtol, atol=atol)
 
 
 ##


### PR DESCRIPTION
Closes https://github.com/scipy/scipy/issues/4506

On the other hand, I think `lobpcg` is broken (https://github.com/scipy/scipy/issues/4174).

before:

```
               lobpcg benchmark sakurai et al.
==============================================================
      shape      | blocksize |    operation   |   time   
                                              | (seconds)
--------------------------------------------------------------
        (50, 50) |     3     |     lobpcg     |   0.99 
        (50, 50) |     3     |       eigh     |   0.01 
      (400, 400) |     3     |     lobpcg     |   9.98 
      (400, 400) |     3     |       eigh     |   0.10 
    (2400, 2400) |     3     |     lobpcg     |  18.56 
    (2400, 2400) |     3     |       eigh     |  14.83 
```

after:

```
                 lobpcg benchmark sakurai et al.
==============================================================
      shape      | blocksize |    operation   |   time   
                                              | (seconds)
--------------------------------------------------------------
        (50, 50) |     3     |     lobpcg     |   0.42 
        (50, 50) |     3     |       eigh     |   0.01 
      (400, 400) |     3     |     lobpcg     |   3.04 
      (400, 400) |     3     |       eigh     |   0.09 
    (2400, 2400) |     3     |     lobpcg     |   9.52 
    (2400, 2400) |     3     |       eigh     |  14.45 
```
