### PR TITLE
Fixed differential evolution bug

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -399,7 +399,8 @@ class DifferentialEvolutionSolver(object):
 
         # Fill points uniformly in each interval
         rdrange = rng.rand(samples, N) * segsize
-        rdrange += np.atleast_2d(np.arange(0., 1., segsize)).T
+        rdrange += np.atleast_2d(
+            np.linspace(0., 1., samples, endpoint=False)).T
 
         # Make the random pairings
         self.population = np.zeros_like(rdrange)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -357,6 +357,20 @@ class TestDifferentialEvolutionSolver(TestCase):
         self.assertRaises(
             ValueError, _differentialevolution._make_random_gen, 'a')
 
+    def test_gh_4511_regression(self):
+        # This modification of the differential evolution docstring example
+        # uses a custom popsize that had triggered an off-by-one error.
+        # Because we do not care about solving the optimization problem in
+        # this test, we use maxiter=1 to reduce the testing time.
+
+        def ackley(x):
+            arg1 = -0.2 * np.sqrt(0.5 * (x[0] ** 2 + x[1] ** 2))
+            arg2 = 0.5 * (np.cos(2. * np.pi * x[0]) + np.cos(2. * np.pi * x[1]))
+            return -20. * np.exp(arg1) - np.exp(arg2) + 20. + np.e
+
+        bounds = [(-5, 5), (-5, 5)]
+        result = differential_evolution(ackley, bounds, popsize=1815, maxiter=1)
+
 
 if __name__ == '__main__':
     run_module_suite()

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -362,14 +362,8 @@ class TestDifferentialEvolutionSolver(TestCase):
         # uses a custom popsize that had triggered an off-by-one error.
         # Because we do not care about solving the optimization problem in
         # this test, we use maxiter=1 to reduce the testing time.
-
-        def ackley(x):
-            arg1 = -0.2 * np.sqrt(0.5 * (x[0] ** 2 + x[1] ** 2))
-            arg2 = 0.5 * (np.cos(2. * np.pi * x[0]) + np.cos(2. * np.pi * x[1]))
-            return -20. * np.exp(arg1) - np.exp(arg2) + 20. + np.e
-
         bounds = [(-5, 5), (-5, 5)]
-        result = differential_evolution(ackley, bounds, popsize=1815, maxiter=1)
+        result = differential_evolution(rosen, bounds, popsize=1815, maxiter=1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Running the algorithm gave me an error about incompatible arrays shape. 
The reason is that using numpy.arange accumulates rounding error, returning an array of size `samples + 1`, insted of size `samples`.

```
In [1]: import numpy as np                                                                                                                                                                       
In [2]: samples = 1815                                                                                                                                                                                                    
In [3]: segsize = 1.0 / samples                                                                                                                                                                                                              
In [4]: np.arange(0., 1., segsize).shape                                                                                                                                                                                                     
Out[4]: (1816,)                                                                                                                                                                                                                              
In [5]: np.linspace(0., 1., samples, endpoint=False).shape                                                                                                                                                                                   
Out[5]: (1815,)                                               
```
