### PR TITLE
Change to fully PEP440 compliant dev version numbers (always .dev0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ def get_version_info():
         GIT_REVISION = "Unknown"
 
     if not ISRELEASED:
-        FULLVERSION += '.dev+' + GIT_REVISION[:7]
+        FULLVERSION += '.dev0+' + GIT_REVISION[:7]
 
     return FULLVERSION, GIT_REVISION
 


### PR DESCRIPTION
A small improvement to the issue in https://github.com/scipy/scipy/issues/4301, first fix in https://github.com/scipy/scipy/pull/4307
