### PR TITLE
MAINT: benchmarks: make benchmark suite importable on all scipy versions

### DIFF
--- a/benchmarks/benchmarks/fftpack_basic.py
+++ b/benchmarks/benchmarks/fftpack_basic.py
@@ -3,7 +3,6 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
-from scipy.fftpack import ifft, fft, fftn, irfft, rfft
 
 from numpy.testing import assert_array_almost_equal
 
@@ -11,6 +10,11 @@ from numpy import arange, asarray, zeros, dot, exp, pi, double, cdouble
 import numpy.fft
 
 from numpy.random import rand
+
+try:
+    from scipy.fftpack import ifft, fft, fftn, irfft, rfft
+except ImportError:
+    pass
 
 
 def random(size):

--- a/benchmarks/benchmarks/fftpack_pseudo_diffs.py
+++ b/benchmarks/benchmarks/fftpack_pseudo_diffs.py
@@ -5,7 +5,11 @@ from __future__ import division, absolute_import, print_function
 import sys
 
 from numpy import arange, sin, cos, pi, exp, tanh, sign
-from scipy.fftpack import diff, fft, ifft, tilbert, hilbert, shift, fftfreq
+
+try:
+    from scipy.fftpack import diff, fft, ifft, tilbert, hilbert, shift, fftfreq
+except ImportError:
+    pass
 
 
 def random(size):

--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -1,7 +1,10 @@
 from __future__ import division, absolute_import, print_function
 from .common import run_monitored, set_mem_rlimit
 
-from scipy.stats import spearmanr
+try:
+    from scipy.stats import spearmanr
+except ImportError:
+    pass
 
 
 class Leaks(object):

--- a/benchmarks/benchmarks/io_matlab.py
+++ b/benchmarks/benchmarks/io_matlab.py
@@ -12,7 +12,11 @@ import collections
 from io import BytesIO
 
 import numpy as np
-from scipy.io import savemat, loadmat
+
+try:
+    from scipy.io import savemat, loadmat
+except ImportError:
+    pass
 
 
 class MemUsage(object):

--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -2,10 +2,14 @@ from __future__ import division, absolute_import, print_function
 
 import sys
 import numpy.linalg as nl
-import scipy.linalg as sl
 
 from numpy.testing import assert_
 from numpy.random import rand
+
+try:
+    import scipy.linalg as sl
+except ImportError:
+    pass
 
 
 def random(size):

--- a/benchmarks/benchmarks/linalg_solve_toeplitz.py
+++ b/benchmarks/benchmarks/linalg_solve_toeplitz.py
@@ -4,7 +4,11 @@ from __future__ import division, absolute_import, print_function
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal
-import scipy.linalg
+
+try:
+    import scipy.linalg
+except ImportError:
+    pass
 
 
 class SolveToeplitz(object):

--- a/benchmarks/benchmarks/linalg_sqrtm.py
+++ b/benchmarks/benchmarks/linalg_sqrtm.py
@@ -5,7 +5,11 @@ from __future__ import division, absolute_import, print_function
 
 import numpy as np
 from numpy.testing import assert_allclose
-import scipy.linalg
+
+try:
+    import scipy.linalg
+except ImportError:
+    pass
 
 
 class Sqrtm(object):

--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -5,8 +5,11 @@ from collections import defaultdict
 
 import numpy as np
 
-import scipy.optimize
-from scipy.optimize.optimize import rosen, rosen_der, rosen_hess
+try:
+    import scipy.optimize
+    from scipy.optimize.optimize import rosen, rosen_der, rosen_hess
+except ImportError:
+    pass
 
 from . import test_functions as funcs
 

--- a/benchmarks/benchmarks/optimize_zeros.py
+++ b/benchmarks/benchmarks/optimize_zeros.py
@@ -3,8 +3,11 @@ from __future__ import division, print_function, absolute_import
 from math import sqrt
 
 # Import testing parameters
-from scipy.optimize._tstutils import (methods, mstrings, functions,
-     fstrings, description)
+try:
+    from scipy.optimize._tstutils import (methods, mstrings, functions,
+                                          fstrings, description)
+except ImportError:
+    pass
 
 
 class Zeros(object):

--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -3,7 +3,11 @@ from __future__ import division, absolute_import, print_function
 from itertools import product
 
 import numpy as np
-from scipy.signal import convolve2d, correlate2d
+
+try:
+    from scipy.signal import convolve2d, correlate2d
+except ImportError:
+    pass
 
 
 class Convolve2D(object):

--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -6,17 +6,19 @@ from __future__ import division, print_function, absolute_import
 import warnings
 import time
 import collections
+import sys
 
 import numpy
 import numpy as np
 from numpy import ones, array, asarray, empty, random, zeros
 
-from scipy import sparse
-from scipy.sparse import (csr_matrix, coo_matrix, dia_matrix, lil_matrix,
-                          dok_matrix, rand, SparseEfficiencyWarning)
-
-import scipy
-import sys
+try:
+    import scipy
+    from scipy import sparse
+    from scipy.sparse import (csr_matrix, coo_matrix, dia_matrix, lil_matrix,
+                              dok_matrix, rand, SparseEfficiencyWarning)
+except ImportError:
+    pass
 
 
 def random_sparse(m,n,nnz_per_row):

--- a/benchmarks/benchmarks/sparse_linalg_expm.py
+++ b/benchmarks/benchmarks/sparse_linalg_expm.py
@@ -7,8 +7,8 @@ import math
 import numpy as np
 from numpy.testing import assert_allclose
 
-import scipy.linalg
 try:
+    import scipy.linalg
     from scipy.sparse.linalg import expm_multiply
 except ImportError:
     pass

--- a/benchmarks/benchmarks/sparse_linalg_lobpcg.py
+++ b/benchmarks/benchmarks/sparse_linalg_lobpcg.py
@@ -6,11 +6,15 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 import time
-from scipy import array, r_, ones, arange, sort, diag, cos, rand, pi
-from scipy.linalg import eigh, orth, cho_factor, cho_solve
-import scipy.sparse
-from scipy.sparse.linalg import lobpcg
-from scipy.sparse.linalg.interface import LinearOperator
+
+try:
+    from scipy import array, r_, ones, arange, sort, diag, cos, rand, pi
+    from scipy.linalg import eigh, orth, cho_factor, cho_solve
+    import scipy.sparse
+    from scipy.sparse.linalg import lobpcg
+    from scipy.sparse.linalg.interface import LinearOperator
+except ImportError:
+    pass
 
 
 def _sakurai(n):

--- a/benchmarks/benchmarks/sparse_linalg_onenormest.py
+++ b/benchmarks/benchmarks/sparse_linalg_onenormest.py
@@ -6,7 +6,10 @@ import time
 
 import numpy as np
 
-import scipy.sparse.linalg
+try:
+    import scipy.sparse.linalg
+except ImportError:
+    pass
 
 
 class BenchmarkOneNormEst(object):

--- a/benchmarks/benchmarks/sparse_linalg_solve.py
+++ b/benchmarks/benchmarks/sparse_linalg_solve.py
@@ -8,8 +8,11 @@ import time
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
-from scipy import linalg, sparse
-import scipy.sparse.linalg
+try:
+    from scipy import linalg, sparse
+    import scipy.sparse.linalg
+except ImportError:
+    pass
 
 
 def _create_sparse_poisson1d(n):

--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -1,8 +1,12 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
-from scipy.spatial import cKDTree, KDTree
 import numpy as np
+
+try:
+    from scipy.spatial import cKDTree, KDTree
+except ImportError:
+    pass
 
 
 class Build(object):


### PR DESCRIPTION
ASV currently sometimes tries to run benchmark discovery with old Scipy
version installed. To make sure this always succeeds, just guard all
Scipy imports.

Going to merge this without waiting...
It's a bit ugly that this is required currently, but this may be subject to change.
