### PR TITLE
ENH: spatial: Add procrustes analysis

### DIFF
--- a/scipy/spatial/__init__.py
+++ b/scipy/spatial/__init__.py
@@ -81,6 +81,7 @@ Functions
    distance_matrix
    minkowski_distance
    minkowski_distance_p
+   procrustes
 
 """
 
@@ -90,6 +91,7 @@ from .kdtree import *
 from .ckdtree import *
 from .qhull import *
 from ._plotutils import *
+from .procrustes import procrustes
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 __all__ += ['distance']

--- a/scipy/spatial/procrustes.py
+++ b/scipy/spatial/procrustes.py
@@ -1,0 +1,162 @@
+"""
+This module provides functions to perform full Procrustes analysis.
+
+This code was originally written by Justin Kucynski and ported over from
+scikit-bio by Yoshiki Vazquez-Baeza.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+from scipy.linalg import orthogonal_procrustes
+
+
+__all__ = ['procrustes']
+
+
+def procrustes(data1, data2):
+    r"""Procrustes analysis, a similarity test for two data sets
+
+    Each input matrix is a set of points or vectors (the rows of the matrix).
+    The dimension of the space is the number of columns of each matrix. Given
+    two identically sized matrices, procrustes standardizes both such that:
+
+    - :math:`tr(AA^{T}) = 1`.
+
+    - Both sets of points are centered around the origin.
+
+    Procrustes ([1]_, [2]_) then applies the optimal transform to the second
+    matrix (including scaling/dilation, rotations, and reflections) to minimize
+    :math:`M^{2}=\sum(data1-data2)^{2}`, or the sum of the squares of the
+    pointwise differences between the two input datasets.
+
+    This function was not designed to handle datasets with different numbers of
+    datapoints (rows).  If two data sets have different dimensionality
+    (different number of columns), simply add columns of zeros the smaller of
+    the two.
+
+    Parameters
+    ----------
+    data1 : array_like
+        matrix, n rows represent points in k (columns) space data1 is the
+        reference data, after it is standardised, the data from data2 will
+        be transformed to fit the pattern in data1 (must have >1 unique
+        points).
+
+    data2 : array_like
+        n rows of data in k space to be fit to data1.  Must be the  same
+        shape (numrows, numcols) as data1 (must have >1 unique points).
+
+    Returns
+    -------
+    mtx1 : array_like
+        a standardized version of data1
+    mtx2 : array_like
+        the orientation of data2 that best fits data1. Centered, but not
+        necessarily :math:`tr(AA^{T}) = 1`.
+    disparity : float
+        :math:`M^{2}` as defined above.
+
+    See Also
+    --------
+    orthogonal_procrustes
+
+    Notes
+    -----
+    - The disparity should not depend on the order of the input matrices, but
+      the output matrices will, as only the first output matrix is guaranteed
+      to be scaled such that :math:`tr(AA^{T}) = 1`.
+
+    - Duplicate data points are generally ok, duplicating a data point will
+      increase its effect on the procrustes fit.
+
+    - The disparity scales as the number of points per input matrix.
+
+    References
+    ----------
+    .. [1] Krzanowski, W. J. (2000). "Principles of Multivariate analysis".
+    .. [2] Gower, J. C. (1975). "Generalized procrustes analysis".
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.spatial import procrustes
+    # the b matrix is a rotated, shifted, scaled and mirrored version of a
+    >>> a = np.array([[1, 3], [1, 2], [1, 1], [2, 1]], 'd')
+    >>> b = np.array([[4, -2], [4, -4], [4, -6], [2, -6]], 'd')
+    >>> mtx1, mtx2, disparity = procrustes(a, b)
+    >>> round(disparity)
+    0.0
+
+    """
+    num_rows, num_cols = np.shape(data1)
+    if (num_rows, num_cols) != np.shape(data2):
+        raise ValueError("Input matrices must be of same shape")
+    if num_rows == 0 or num_cols == 0:
+        raise ValueError("Input matrices must be >0 rows and >0 cols")
+
+    # standardize each matrix
+    mtx1 = _center(data1)
+    mtx2 = _center(data2)
+
+    if (not np.any(mtx1)) or (not np.any(mtx2)):
+        raise ValueError("input matrices must contain >1 unique points")
+
+    mtx1 = _normalize(mtx1)
+    mtx2 = _normalize(mtx2)
+
+    # transform mtx2 to minimize disparity (sum((mtx1[i,j] - mtx2[i,j])^2))
+    mtx2, disparity = orthogonal_procrustes(mtx1, mtx2)
+
+    # When mtx1 and mtx2 can match exactly, orthogonal_procrustes returns a
+    # matrix with:
+    #   |-1 0|
+    #   | 0 1|
+    # Thus we only really need to return mtx1 and a disparity of zero.
+    #
+    # Note: we check for shape first, because if the shape is not equal
+    # np.allclose will raise an error.
+    if mtx2.shape == (2, 2) and np.allclose(np.array([[-1, 0], [0, 1]]), mtx2,
+                                            atol=1e-8):
+        mtx2 = mtx1
+        disparity = 0
+
+    return mtx1, mtx2, disparity
+
+
+def _center(mtx):
+    """Translate all data (rows of the matrix) to center on the origin
+
+    Parameters
+    ----------
+    mtx : array_like
+        Matrix to translate the data for.
+
+    Returns
+    -------
+    result : array_like ('d') array
+        Shifted version of the input data.  The new matrix is such that the
+        center of mass of the row vectors is centered at the origin.
+
+    """
+    result = np.array(mtx, 'd')
+    result -= np.mean(result, 0)
+    # subtract each column's mean from each element in that column
+    return result
+
+
+def _normalize(mtx):
+    """change scaling of data (in rows) such that trace(mtx*mtx') = 1
+
+    Parameters
+    ----------
+    mtx : array_like
+        Matrix to scale the data for.
+
+    Notes
+    -----
+    mtx' denotes the transpose of mtx
+
+    """
+    mtx = np.asarray(mtx, dtype=float)
+    return mtx / np.linalg.norm(mtx)

--- a/scipy/spatial/procrustes.py
+++ b/scipy/spatial/procrustes.py
@@ -113,7 +113,7 @@ def procrustes(data1, data2):
     mtx2 = data2-np.mean(data2, 0)
 
     if (not np.any(mtx1)) or (not np.any(mtx2)):
-        raise ValueError("input matrices must contain >1 unique points")
+        raise ValueError("Input matrices must contain >1 unique points")
 
     # change scaling of data (in rows) such that trace(mtx*mtx') = 1
     mtx1 = mtx1/np.linalg.norm(mtx1)

--- a/scipy/spatial/procrustes.py
+++ b/scipy/spatial/procrustes.py
@@ -97,27 +97,29 @@ def procrustes(data1, data2):
 
     """
 
-    data1 = np.asarray(data1, dtype=np.double)
-    data2 = np.asarray(data2, dtype=np.double)
+    mtx1 = np.array(data1, dtype=np.double, copy=True)
+    mtx2 = np.array(data2, dtype=np.double, copy=True)
 
-    if data1.ndim != 2 or data2.ndim != 2:
+    if mtx1.ndim != 2 or mtx2.ndim != 2:
         raise ValueError("Input matrices must be two-dimensional")
-    num_rows, num_cols = np.shape(data1)
-    if (num_rows, num_cols) != np.shape(data2):
+    if mtx1.shape != mtx2.shape:
         raise ValueError("Input matrices must be of same shape")
-    if num_rows == 0 or num_cols == 0:
+    if mtx1.size == 0:
         raise ValueError("Input matrices must be >0 rows and >0 cols")
 
     # translate all the data to the origin
-    mtx1 = data1-np.mean(data1, 0)
-    mtx2 = data2-np.mean(data2, 0)
+    mtx1 -= np.mean(mtx1, 0)
+    mtx2 -= np.mean(mtx2, 0)
 
-    if (not np.any(mtx1)) or (not np.any(mtx2)):
+    norm1 = np.linalg.norm(mtx1)
+    norm2 = np.linalg.norm(mtx2)
+
+    if norm1 == 0 or norm2 == 0:
         raise ValueError("Input matrices must contain >1 unique points")
 
     # change scaling of data (in rows) such that trace(mtx*mtx') = 1
-    mtx1 = mtx1/np.linalg.norm(mtx1)
-    mtx2 = mtx2/np.linalg.norm(mtx2)
+    mtx1 /= norm1
+    mtx2 /= norm2
 
     # transform mtx2 to minimize disparity
     R, s = orthogonal_procrustes(mtx1, mtx2)

--- a/scipy/spatial/tests/test_procrustes.py
+++ b/scipy/spatial/tests/test_procrustes.py
@@ -1,0 +1,112 @@
+from __future__ import absolute_import, division, print_function
+
+from unittest import TestCase, main
+
+import numpy as np
+from scipy.spatial.procrustes import procrustes, _center, _normalize
+
+
+class ProcrustesTests(TestCase):
+    def setUp(self):
+        """creates inputs"""
+        # an L
+        self.data1 = np.array([[1, 3], [1, 2], [1, 1], [2, 1]], 'd')
+
+        # a larger, shifted, mirrored L
+        self.data2 = np.array([[4, -2], [4, -4], [4, -6], [2, -6]], 'd')
+
+        # an L shifted up 1, right 1, and with point 4 shifted an extra .5
+        # to the right
+        # pointwise distance disparity with data1: 3*(2) + (1 + 1.5^2)
+        self.data3 = np.array([[2, 4], [2, 3], [2, 2], [3, 2.5]], 'd')
+
+        # data4, data5 are standardized (trace(A*A') = 1).
+        # procrustes should return an identical copy if they are used
+        # as the first matrix argument.
+        shiftangle = np.pi / 8
+        self.data4 = np.array([[1, 0], [0, 1], [-1, 0],
+                              [0, -1]], 'd') / np.sqrt(4)
+        self.data5 = np.array([[np.cos(shiftangle), np.sin(shiftangle)],
+                              [np.cos(np.pi / 2 - shiftangle),
+                               np.sin(np.pi / 2 - shiftangle)],
+                              [-np.cos(shiftangle),
+                               -np.sin(shiftangle)],
+                              [-np.cos(np.pi / 2 - shiftangle),
+                               -np.sin(np.pi / 2 - shiftangle)]],
+                              'd') / np.sqrt(4)
+
+    def test_procrustes(self):
+        """tests procrustes' ability to match two matrices.
+
+        the second matrix is a rotated, shifted, scaled, and mirrored version
+        of the first, in two dimensions only
+        """
+        # can shift, mirror, and scale an 'L'?
+        a, b, disparity = procrustes(self.data1, self.data2)
+        np.testing.assert_allclose(b, a)
+        np.testing.assert_almost_equal(disparity, 0.)
+
+        # if first mtx is standardized, leaves first mtx unchanged?
+        m4, m5, disp45 = procrustes(self.data4, self.data5)
+        np.testing.assert_equal(m4, self.data4)
+
+        # at worst, data3 is an 'L' with one point off by .5
+        m1, m3, disp13 = procrustes(self.data1, self.data3)
+        #self.assertTrue(disp13 < 0.5 ** 2)
+
+    def test_procrustes2(self):
+        """procrustes disparity should not depend on order of matrices"""
+        m1, m3, disp13 = procrustes(self.data1, self.data3)
+        m3_2, m1_2, disp31 = procrustes(self.data3, self.data1)
+        np.testing.assert_almost_equal(disp13, disp31)
+
+        # try with 3d, 8 pts per
+        rand1 = np.array([[2.61955202, 0.30522265, 0.55515826],
+                         [0.41124708, -0.03966978, -0.31854548],
+                         [0.91910318, 1.39451809, -0.15295084],
+                         [2.00452023, 0.50150048, 0.29485268],
+                         [0.09453595, 0.67528885, 0.03283872],
+                         [0.07015232, 2.18892599, -1.67266852],
+                         [0.65029688, 1.60551637, 0.80013549],
+                         [-0.6607528, 0.53644208, 0.17033891]])
+
+        rand3 = np.array([[0.0809969, 0.09731461, -0.173442],
+                         [-1.84888465, -0.92589646, -1.29335743],
+                         [0.67031855, -1.35957463, 0.41938621],
+                         [0.73967209, -0.20230757, 0.52418027],
+                         [0.17752796, 0.09065607, 0.29827466],
+                         [0.47999368, -0.88455717, -0.57547934],
+                         [-0.11486344, -0.12608506, -0.3395779],
+                         [-0.86106154, -0.28687488, 0.9644429]])
+        res1, res3, disp13 = procrustes(rand1, rand3)
+        res3_2, res1_2, disp31 = procrustes(rand3, rand1)
+        np.testing.assert_almost_equal(disp13, disp31)
+
+    def test_procrustes_shape_mismatch(self):
+        np.testing.assert_raises(ValueError, procrustes,
+                                 np.array([[1, 2], [3, 4]]),
+                                 np.array([[5, 6, 7], [8, 9, 10]]))
+
+    def test_procrustes_empty_rows_or_cols(self):
+        empty = np.array([[]])
+        np.testing.assert_raises(ValueError, procrustes, empty, empty)
+
+    def test_procrustes_no_variation(self):
+        np.testing.assert_raises(ValueError, procrustes,
+                                 np.array([[42, 42], [42, 42]]),
+                                 np.array([[45, 45], [45, 45]]))
+
+    def test_center(self):
+        centered_mtx = _center(self.data1)
+        column_means = centered_mtx.mean(0)
+        for col_mean in column_means:
+            np.testing.assert_equal(col_mean, 0.)
+
+    def test_normalize(self):
+        norm_mtx = _normalize(self.data1)
+        np.testing.assert_equal(np.trace(np.dot(norm_mtx,
+                                                np.transpose(norm_mtx))), 1.)
+
+
+if __name__ == '__main__':
+    main()

--- a/scipy/spatial/tests/test_procrustes.py
+++ b/scipy/spatial/tests/test_procrustes.py
@@ -96,6 +96,25 @@ class ProcrustesTests(TestCase):
                                  np.array([[42, 42], [42, 42]]),
                                  np.array([[45, 45], [45, 45]]))
 
+    def test_procrustes_bad_number_of_dimensions(self):
+        # fewer dimensions in one dataset
+        np.testing.assert_raises(ValueError, procrustes,
+                                 np.array([1, 1, 2, 3, 5, 8]),
+                                 np.array([[1, 2], [3, 4]]))
+
+        # fewer dimensions in both datasets
+        np.testing.assert_raises(ValueError, procrustes,
+                                 np.array([1, 1, 2, 3, 5, 8]),
+                                 np.array([1, 1, 2, 3, 5, 8]))
+
+        # zero dimensions
+        np.testing.assert_raises(ValueError, procrustes, np.array(7),
+                                 np.array(11))
+
+        # extra dimensions
+        np.testing.assert_raises(ValueError, procrustes,
+                                 np.array([[[11], [7]]]),
+                                 np.array([[[5, 13]]]))
 
 if __name__ == '__main__':
     main()

--- a/scipy/spatial/tests/test_procrustes.py
+++ b/scipy/spatial/tests/test_procrustes.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 from unittest import TestCase, main
 
 import numpy as np
-from scipy.spatial.procrustes import procrustes, _center, _normalize
+from scipy.spatial.procrustes import procrustes
 
 
 class ProcrustesTests(TestCase):
@@ -36,11 +36,11 @@ class ProcrustesTests(TestCase):
                               'd') / np.sqrt(4)
 
     def test_procrustes(self):
-        """tests procrustes' ability to match two matrices.
-
-        the second matrix is a rotated, shifted, scaled, and mirrored version
-        of the first, in two dimensions only
-        """
+        # tests procrustes' ability to match two matrices.
+        #
+        # the second matrix is a rotated, shifted, scaled, and mirrored version
+        # of the first, in two dimensions only
+        #
         # can shift, mirror, and scale an 'L'?
         a, b, disparity = procrustes(self.data1, self.data2)
         np.testing.assert_allclose(b, a)
@@ -55,7 +55,7 @@ class ProcrustesTests(TestCase):
         #self.assertTrue(disp13 < 0.5 ** 2)
 
     def test_procrustes2(self):
-        """procrustes disparity should not depend on order of matrices"""
+        # procrustes disparity should not depend on order of matrices
         m1, m3, disp13 = procrustes(self.data1, self.data3)
         m3_2, m1_2, disp31 = procrustes(self.data3, self.data1)
         np.testing.assert_almost_equal(disp13, disp31)
@@ -95,17 +95,6 @@ class ProcrustesTests(TestCase):
         np.testing.assert_raises(ValueError, procrustes,
                                  np.array([[42, 42], [42, 42]]),
                                  np.array([[45, 45], [45, 45]]))
-
-    def test_center(self):
-        centered_mtx = _center(self.data1)
-        column_means = centered_mtx.mean(0)
-        for col_mean in column_means:
-            np.testing.assert_equal(col_mean, 0.)
-
-    def test_normalize(self):
-        norm_mtx = _normalize(self.data1)
-        np.testing.assert_equal(np.trace(np.dot(norm_mtx,
-                                                np.transpose(norm_mtx))), 1.)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add `scipy.spatial.procrustes` which includes a main function, `procrustes`, that translates, rotates and scales two sets of points to superimpose them in the best possible way.

This code is being ported from [scikit-bio](https://github.com/biocore/scikit-bio) in response to #3786.

~~@argriffing, `procrustes` is using `orthogonal_procrustes` under the hood, and it has a special case for points that match exactly (this is the issue I brought with #3994). Regrettably, I couldn't come up with a better solution than the `if` block in line 119 of `procrustes.py`, if you have any suggestions on how to deal with this, I am interested in hearing them!~~
