### PR TITLE
TST: NumpyVersion dev -> dev0

### DIFF
--- a/scipy/_lib/tests/test__version.py
+++ b/scipy/_lib/tests/test__version.py
@@ -44,16 +44,16 @@ def test_dev_a_b_rc_mixed():
 
 
 def test_dev0_version():
-    assert_(NumpyVersion('1.9.0.dev0-Unknown') < '1.9.0')
-    for ver in ['1.9.0', '1.9.0a1', '1.9.0b2', '1.9.0b2.dev0-ffffffff']:
-        assert_(NumpyVersion('1.9.0.dev0-f16acvda') < ver)
+    assert_(NumpyVersion('1.9.0.dev0+Unknown') < '1.9.0')
+    for ver in ['1.9.0', '1.9.0a1', '1.9.0b2', '1.9.0b2.dev0+ffffffff']:
+        assert_(NumpyVersion('1.9.0.dev0+f16acvda') < ver)
 
-    assert_(NumpyVersion('1.9.0.dev0-f16acvda') == '1.9.0.dev0-11111111')
+    assert_(NumpyVersion('1.9.0.dev0+f16acvda') == '1.9.0.dev0+11111111')
 
 
 def test_dev0_a_b_rc_mixed():
-    assert_(NumpyVersion('1.9.0a2.dev0-f16acvda') == '1.9.0a2.dev0-11111111')
-    assert_(NumpyVersion('1.9.0a2.dev0-6acvda54') < '1.9.0a2')
+    assert_(NumpyVersion('1.9.0a2.dev0+f16acvda') == '1.9.0a2.dev0+11111111')
+    assert_(NumpyVersion('1.9.0a2.dev0+6acvda54') < '1.9.0a2')
 
 
 def test_raises():

--- a/scipy/_lib/tests/test__version.py
+++ b/scipy/_lib/tests/test__version.py
@@ -43,6 +43,19 @@ def test_dev_a_b_rc_mixed():
     assert_(NumpyVersion('1.9.0a2.dev-6acvda54') < '1.9.0a2')
 
 
+def test_dev0_version():
+    assert_(NumpyVersion('1.9.0.dev0-Unknown') < '1.9.0')
+    for ver in ['1.9.0', '1.9.0a1', '1.9.0b2', '1.9.0b2.dev0-ffffffff']:
+        assert_(NumpyVersion('1.9.0.dev0-f16acvda') < ver)
+
+    assert_(NumpyVersion('1.9.0.dev0-f16acvda') == '1.9.0.dev0-11111111')
+
+
+def test_dev0_a_b_rc_mixed():
+    assert_(NumpyVersion('1.9.0a2.dev0-f16acvda') == '1.9.0a2.dev0-11111111')
+    assert_(NumpyVersion('1.9.0a2.dev0-6acvda54') < '1.9.0a2')
+
+
 def test_raises():
     for ver in ['1.9', '1,9.0', '1.7.x']:
         assert_raises(ValueError, NumpyVersion, ver)


### PR DESCRIPTION
Just a test that changing dev to dev0 doesn't bother NumpyVersion too much.  This is for https://github.com/scipy/scipy/pull/4512.
