### PR TITLE
MAINT: use reduction axis arguments in one-norm estimation

### DIFF
--- a/scipy/sparse/linalg/_onenormest.py
+++ b/scipy/sparse/linalg/_onenormest.py
@@ -152,16 +152,6 @@ def resample_column(i, X):
     X[:, i] = np.random.randint(0, 2, size=X.shape[0])*2 - 1
 
 
-def norm_1d_1(v):
-    # this is faster than calling the numpy/scipy norm function
-    return np.sum(np.abs(v))
-
-
-def norm_1d_inf(v):
-    # this is faster than calling the numpy/scipy norm function
-    return np.max(np.abs(v))
-
-
 def less_than_or_close(a, b):
     return np.allclose(a, b) or (a < b)
 
@@ -223,12 +213,12 @@ def _algorithm_2_2(A, AT, t):
     ind = range(t)
     while True:
         Y = np.asarray(A_linear_operator.matmat(X))
-        g = [norm_1d_1(Y[:, j]) for j in range(t)]
+        g = np.sum(np.abs(Y), axis=0)
         best_j = np.argmax(g)
         g = sorted(g, reverse=True)
         S = sign_round_up(Y)
         Z = np.asarray(AT_linear_operator.matmat(S))
-        h = [norm_1d_inf(row) for row in Z]
+        h = np.max(np.abs(Z), axis=1)
 
         # If this algorithm runs for fewer than two iterations,
         # then its return values do not have the properties indicated
@@ -351,7 +341,7 @@ def _onenormest_core(A, AT, t, itmax):
     while True:
         Y = np.asarray(A_linear_operator.matmat(X))
         nmults += 1
-        mags = [norm_1d_1(Y[:, j]) for j in range(t)]
+        mags = np.sum(np.abs(Y), axis=0)
         est = np.max(mags)
         best_j = np.argmax(mags)
         if est > est_old or k == 2:
@@ -380,7 +370,7 @@ def _onenormest_core(A, AT, t, itmax):
         # (3)
         Z = np.asarray(AT_linear_operator.matmat(S))
         nmults += 1
-        h = [norm_1d_inf(row) for row in Z]
+        h = np.max(np.abs(Z), axis=1)
         # (4)
         if k >= 2 and max(h) == h[ind_best]:
             break


### PR DESCRIPTION
This is a more focused subset of https://github.com/scipy/scipy/pull/4095.

benchmark information:

```
 ====== ========== ============
               --              solver        
               ------ -----------------------
                 n      exact     onenormest 
               ====== ========== ============
                 2      1.50ms      4.84ms   
                 3      1.74ms     43.26ms   
                 5      1.77ms     47.59ms   
                 10     1.82ms     51.76ms   
                 30     3.05ms     66.18ms   
                100    23.12ms     143.12ms  
                300    470.47ms    357.08ms  
                500     2.07s      638.53ms  
                1000     null       1.48s    


 ====== ========== ============
               --              solver        
               ------ -----------------------
                 n      exact     onenormest 
               ====== ========== ============
                 2      1.62ms      4.90ms   
                 3      1.62ms     37.43ms   
                 5      1.77ms     38.97ms   
                 10     1.84ms     39.22ms   
                 30     2.98ms     41.59ms   
                100    23.49ms     57.12ms   
                300    460.60ms    126.43ms  
                500     2.02s      237.10ms  
                1000     null      708.25ms  
               ====== ========== ============
```
