### PR TITLE
ENH: Significantly faster moment function

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1441,7 +1441,7 @@ def moment(a, moment=1, axis=0):
             n_list.append(current_n)
         
         # Starting point for exponentiation by squares
-        a_zero_mean = a - np.expand_dims(np.mean(a, axis), axis)
+        a_zero_mean = a - ma.expand_dims(a.mean(axis), axis)
         if n_list[-1] == 1:
             s = a_zero_mean.copy()
         else:
@@ -1452,7 +1452,7 @@ def moment(a, moment=1, axis=0):
             s = s**2
             if n % 2:
                 s *= a_zero_mean
-        return np.mean(s, axis)
+        return s.mean(axis)
 moment.__doc__ = stats.moment.__doc__
 
 

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1430,9 +1430,29 @@ def moment(a, moment=1, axis=0):
             # the input was 1D, so return a scalar instead of a rank-0 array
             return np.float64(0.0)
     else:
-        mn = ma.expand_dims(a.mean(axis=axis), axis)
-        s = ma.power((a-mn), moment)
-        return s.mean(axis=axis)
+        # Exponentiation by squares: form exponent sequence
+        n_list = [moment]
+        current_n = moment
+        while current_n > 2:
+            if current_n % 2:
+                current_n = (current_n-1)/2
+            else:
+                current_n /= 2
+            n_list.append(current_n)
+        
+        # Starting point for exponentiation by squares
+        a_zero_mean = a - np.expand_dims(np.mean(a, axis), axis)
+        if n_list[-1] == 1:
+            s = a_zero_mean.copy()
+        else:
+            s = a_zero_mean**2
+        
+        # Perform multiplications
+        for n in n_list[-2::-1]:
+            s = s**2
+            if n % 2:
+                s *= a_zero_mean
+        return np.mean(s, axis)
 moment.__doc__ = stats.moment.__doc__
 
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -945,15 +945,15 @@ def moment(a, moment=1, axis=0):
             return np.float64(0.0)
     else:
         # Subtract mean along the axis, compute element-wise square
-        a_zero_mean = a - np.expand_dims(np.mean(a, axis), axis)
+        a_zero_mean = np.float64(a - np.expand_dims(np.mean(a, axis), axis))
         a_zero_mean_2 = a_zero_mean**2
         
         s = a_zero_mean_2.copy()
-        for k in range(1, mom // 2):
-            s *= x_zero_mean_2
+        for k in range(1, moment // 2):
+            s *= a_zero_mean_2
         
-        if mom % 2:
-            s *= x_zero_mean
+        if moment % 2:
+            s *= a_zero_mean
         
         return np.mean(s, axis)
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -944,17 +944,28 @@ def moment(a, moment=1, axis=0):
             # the input was 1D, so return a scalar instead of a rank-0 array
             return np.float64(0.0)
     else:
-        # Subtract mean along the axis, compute element-wise square
+        # Exponentiation by squares: form exponent sequence
+        n_list = [moment]
+        current_n = moment
+        while current_n > 2:
+            if current_n % 2:
+                current_n = (current_n-1)/2
+            else:
+                current_n /= 2
+            n_list.append(current_n)
+        
+        # Starting point for exponentiation by squares
         a_zero_mean = a - np.expand_dims(np.mean(a, axis), axis)
-        a_zero_mean_2 = a_zero_mean**2
+        if n_list[-1] == 1:
+            s = a_zero_mean.copy()
+        else:
+            s = a_zero_mean**2
         
-        s = a_zero_mean_2.copy()
-        for k in range(1, moment // 2):
-            s *= a_zero_mean_2
-        
-        if moment % 2:
-            s *= a_zero_mean
-        
+        # Perform multiplications
+        for n in n_list[-2::-1]:
+            s = s**2
+            if n % 2:
+                s *= a_zero_mean
         return np.mean(s, axis)
 
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -944,8 +944,17 @@ def moment(a, moment=1, axis=0):
             # the input was 1D, so return a scalar instead of a rank-0 array
             return np.float64(0.0)
     else:
-        mn = np.expand_dims(np.mean(a, axis), axis)
-        s = np.power((a - mn), moment)
+        # Subtract mean along the axis, compute element-wise square
+        a_zero_mean = a - np.expand_dims(np.mean(a, axis), axis)
+        a_zero_mean_2 = a_zero_mean**2
+        
+        s = a_zero_mean_2.copy()
+        for k in range(1, mom // 2):
+            s *= x_zero_mean_2
+        
+        if mom % 2:
+            s *= x_zero_mean
+        
         return np.mean(s, axis)
 
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -945,7 +945,7 @@ def moment(a, moment=1, axis=0):
             return np.float64(0.0)
     else:
         # Subtract mean along the axis, compute element-wise square
-        a_zero_mean = np.float64(a - np.expand_dims(np.mean(a, axis), axis))
+        a_zero_mean = a - np.expand_dims(np.mean(a, axis), axis)
         a_zero_mean_2 = a_zero_mean**2
         
         s = a_zero_mean_2.copy()

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1370,6 +1370,8 @@ class TestMoments(TestCase):
         Note that both test cases came from here.
     """
     testcase = [1,2,3,4]
+    np.random.seed(1234)
+    testcase_moment_accuracy = np.random.rand(42)
     testmathworks = [1.165, 0.6268, 0.0751, 0.3516, -0.6965]
 
     def test_moment(self):
@@ -1421,6 +1423,14 @@ class TestMoments(TestCase):
 
     def test_kurtosis_array_scalar(self):
         assert_equal(type(stats.kurtosis([1,2,3])), float)
+    
+    def test_moment_accuracy(self):
+        # 'moment' must have a small enough error compared to the slower
+        #  but very accurate numpy.power() implementation.
+        tc_no_mean = self.testcase_moment_accuracy - \
+                     np.mean(self.testcase_moment_accuracy)
+        assert_allclose(np.power(tc_no_mean, 42).mean(), 
+                            stats.moment(self.testcase_moment_accuracy, 42))
 
 
 class TestThreshold(TestCase):


### PR DESCRIPTION
This speeds up central moment computation by ~10x. Compared to the previous method, there are some rounding errors. For all reasonable order moments (mom < 10), these are insignificant. For very high order moments (mom > 18 or so), they may become quite large by value, but are still insignificant in relation to the true moment.

Exponentiation by squares adds even more speed and reduces rounding errors slightly for mom > 7, but the extra overhead actually worsens the performance for commonly used moments.
