### PR TITLE
DOC: stats: describe loc and scale parameters in the docstring example

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1043,14 +1043,23 @@ class exponnorm_gen(rv_continuous):
     -----
     The probability density function for `exponnorm` is::
 
-        exponnorm.pdf(x, K) = 1/(2*K) exp(1/(2 * K**2)) exp(-x / K) * erfc(- (x - 1/K) / sqrt(2))
-
+        exponnorm.pdf(x, K) = 1/(2*K) exp(1/(2 * K**2)) exp(-x / K) * erfc(-(x - 1/K) / sqrt(2))
+           
     where the shape parameter ``K > 0``.
 
     It can be thought of as the sum of a normally distributed random
     value with mean ``loc`` and sigma ``scale`` and an exponentially
     distributed random number with a pdf proportional to ``exp(-lambda * x)``
     where ``lambda = (K * scale)**(-1)``.
+
+    %(after_notes)s
+
+    An alternative parameterization of this distribution (for example, in
+    `Wikipedia <http://en.wikipedia.org/wiki/Exponentially_modified_Gaussian_distribution>`_)
+    involves three parameters, :math:`\mu`, :math:`\lambda` and :math:`\sigma`.
+    In the present parameterization this corresponds to having ``loc`` and
+    ``scale`` equal to :math:`\mu` and :math:`\sigma`, respectively, and
+    shape parameter :math:`K = 1/\sigma\lambda`.
 
     .. versionadded:: 0.16.0
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -645,6 +645,16 @@ class fisk_gen(burr_gen):
 
     %(before_notes)s
 
+    Notes
+    -----
+    The probability density function for `fisk` is::
+
+        fisk.pdf(x, c) = c * x**(-c-1) * (1 + x**(-c))**(-2)
+
+    for ``x > 0``.
+
+    `fisk` takes ``c`` as a shape parameters.
+
     See Also
     --------
     burr

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -119,6 +119,8 @@ class norm_gen(rv_continuous):
 
         norm.pdf(x) = exp(-x**2/2)/sqrt(2*pi)
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -204,6 +206,8 @@ class alpha_gen(rv_continuous):
 
     `alpha` takes ``a`` as a shape parameter.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -237,6 +241,8 @@ class anglit_gen(rv_continuous):
 
     for ``-pi/4 <= x <= pi/4``.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -269,6 +275,8 @@ class arcsine_gen(rv_continuous):
         arcsine.pdf(x) = 1/(pi*sqrt(x*(1-x)))
 
     for ``0 < x < 1``.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -356,6 +364,8 @@ class beta_gen(rv_continuous):
     function (`scipy.special.gamma`).
 
     `beta` takes ``a`` and ``b`` as shape parameters.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -514,6 +524,8 @@ class betaprime_gen(rv_continuous):
 
     `betaprime` takes ``a`` and ``b`` as shape parameters.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -564,6 +576,8 @@ class bradford_gen(rv_continuous):
     for ``0 < x < 1``, ``c > 0`` and ``k = log(1+c)``.
 
     `bradford` takes ``c`` as a shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -617,6 +631,8 @@ class burr_gen(rv_continuous):
 
     `burr` takes ``c`` and ``d`` as shape parameters.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -655,6 +671,8 @@ class fisk_gen(burr_gen):
 
     `fisk` takes ``c`` as a shape parameters.
 
+    %(after_notes)s
+
     See Also
     --------
     burr
@@ -690,6 +708,8 @@ class cauchy_gen(rv_continuous):
     The probability density function for `cauchy` is::
 
         cauchy.pdf(x) = 1 / (pi * (1 + x**2))
+
+    %(after_notes)s
 
     %(example)s
 
@@ -741,6 +761,8 @@ class chi_gen(rv_continuous):
 
     `chi` takes ``df`` as a shape parameter.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -780,6 +802,8 @@ class chi2_gen(rv_continuous):
         chi2.pdf(x, df) = 1 / (2*gamma(df/2)) * (x/2)**(df/2-1) * exp(-x/2)
 
     `chi2` takes ``df`` as a shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -828,6 +852,8 @@ class cosine_gen(rv_continuous):
 
     for ``-pi <= x <= pi``.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -859,6 +885,8 @@ class dgamma_gen(rv_continuous):
     for ``a > 0``.
 
     `dgamma` takes ``a`` as a shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -907,6 +935,8 @@ class dweibull_gen(rv_continuous):
         dweibull.pdf(x, c) = c / 2 * abs(x)**(c-1) * exp(-abs(x)**c)
 
     `dweibull` takes ``d`` as a shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -1078,6 +1108,8 @@ class exponweib_gen(rv_continuous):
 
     `exponweib` takes ``a`` and ``c`` as shape parameters.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -1116,6 +1148,8 @@ class exponpow_gen(rv_continuous):
     "generalized normal" or "generalized Gaussian".
 
     `exponpow` takes ``b`` as a shape parameter.
+
+    %(after_notes)s
 
     References
     ----------
@@ -1161,6 +1195,8 @@ class fatiguelife_gen(rv_continuous):
     for ``x > 0``.
 
     `fatiguelife` takes ``c`` as a shape parameter.
+
+    %(after_notes)s
 
     References
     ----------
@@ -1257,6 +1293,8 @@ class f_gen(rv_continuous):
 
     `f` takes ``dfn`` and ``dfd`` as shape parameters.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -1337,6 +1375,8 @@ class foldnorm_gen(rv_continuous):
 
     `foldnorm` takes ``c`` as a shape parameter.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -1397,6 +1437,8 @@ class frechet_r_gen(rv_continuous):
 
     `frechet_r` takes ``c`` as a shape parameter.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -1441,6 +1483,8 @@ class frechet_l_gen(rv_continuous):
 
     `frechet_l` takes ``c`` as a shape parameter.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -1481,6 +1525,8 @@ class genlogistic_gen(rv_continuous):
     for ``x > 0``, ``c > 0``.
 
     `genlogistic` takes ``c`` as a shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -1535,6 +1581,8 @@ class genpareto_gen(rv_continuous):
     For ``c == -1``, `genpareto` is uniform on ``[0, 1]``::
 
         genpareto.cdf(x, c=-1) = x
+
+    %(after_notes)s
 
     %(example)s
 
@@ -1597,6 +1645,8 @@ class genexpon_gen(rv_continuous):
 
     `genexpon` takes ``a``, ``b`` and ``c`` as shape parameters.
 
+    %(after_notes)s
+
     References
     ----------
     H.K. Ryu, "An Extension of Marshall and Olkin's Bivariate Exponential
@@ -1643,6 +1693,8 @@ class genextreme_gen(rv_continuous):
     convention for the sign of the shape parameter ``c``.
 
     `genextreme` takes ``c`` as a shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -1956,6 +2008,8 @@ class gengamma_gen(rv_continuous):
 
     `gengamma` takes ``a`` and ``c`` as shape parameters.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -2004,6 +2058,8 @@ class genhalflogistic_gen(rv_continuous):
 
     `genhalflogistic` takes ``c`` as a shape parameter.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -2047,6 +2103,8 @@ class gompertz_gen(rv_continuous):
 
     `gompertz` takes ``c`` as a shape parameter.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -2085,6 +2143,8 @@ class gumbel_r_gen(rv_continuous):
     The Gumbel distribution is sometimes referred to as a type I Fisher-Tippett
     distribution.  It is also related to the extreme value distribution,
     log-Weibull and Gompertz distributions.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -2132,6 +2192,8 @@ class gumbel_l_gen(rv_continuous):
     distribution.  It is also related to the extreme value distribution,
     log-Weibull and Gompertz distributions.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -2169,6 +2231,8 @@ class halfcauchy_gen(rv_continuous):
 
     for ``x >= 0``.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -2204,6 +2268,8 @@ class halflogistic_gen(rv_continuous):
         halflogistic.pdf(x) = 2 * exp(-x) / (1+exp(-x))**2 = 1/2 * sech(x/2)**2
 
     for ``x >= 0``.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -2251,6 +2317,8 @@ class halfnorm_gen(rv_continuous):
 
     `halfnorm` is a special case of `chi` with ``df == 1``.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -2289,6 +2357,8 @@ class hypsecant_gen(rv_continuous):
 
         hypsecant.pdf(x) = 1/pi * sech(x)
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -2326,6 +2396,8 @@ class gausshyper_gen(rv_continuous):
 
     `gausshyper` takes ``a``, ``b``, ``c`` and ``z`` as shape parameters.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -2360,6 +2432,8 @@ class invgamma_gen(rv_continuous):
     `invgamma` takes ``a`` as a shape parameter.
 
     `invgamma` is a special case of `gengamma` with ``c == -1``.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -2413,6 +2487,8 @@ class invgauss_gen(rv_continuous):
 
     `invgauss` takes ``mu`` as a shape parameter.
 
+    %(after_notes)s
+
     When `mu` is too small, evaluating the cumulative density function will be
     inaccurate due to ``cdf(mu -> 0) = inf * 0``.
     NaNs are returned for ``mu <= 0.0028``.
@@ -2455,6 +2531,8 @@ class invweibull_gen(rv_continuous):
     for ``x > 0``, ``c > 0``.
 
     `invweibull` takes ``c`` as a shape parameter.
+
+    %(after_notes)s
 
     References
     ----------
@@ -2504,6 +2582,8 @@ class johnsonsb_gen(rv_continuous):
 
     `johnsonsb` takes ``a`` and ``b`` as shape parameters.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -2542,6 +2622,8 @@ class johnsonsu_gen(rv_continuous):
 
     `johnsonsu` takes ``a`` and ``b`` as shape parameters.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -2571,6 +2653,8 @@ class laplace_gen(rv_continuous):
     The probability density function for `laplace` is::
 
         laplace.pdf(x) = 1/2 * exp(-abs(x))
+
+    %(after_notes)s
 
     %(example)s
 
@@ -2614,6 +2698,8 @@ class levy_gen(rv_continuous):
 
     This is the same as the Levy-stable distribution with a=1/2 and b=1.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -2653,6 +2739,8 @@ class levy_l_gen(rv_continuous):
 
     This is the same as the Levy-stable distribution with a=1/2 and b=-1.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -2686,6 +2774,8 @@ class levy_stable_gen(rv_continuous):
     -----
     Levy-stable distribution (only random variates available -- ignore other
     docs)
+
+    %(after_notes)s
 
     %(example)s
 
@@ -2733,6 +2823,8 @@ class logistic_gen(rv_continuous):
 
     `logistic` is a special case of `genlogistic` with ``c == 1``.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -2774,6 +2866,8 @@ class loggamma_gen(rv_continuous):
     for all ``x, c > 0``.
 
     `loggamma` takes ``c`` as a shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -2817,6 +2911,8 @@ class loglaplace_gen(rv_continuous):
     for ``c > 0``.
 
     `loglaplace` takes ``c`` as a shape parameter.
+
+    %(after_notes)s
 
     References
     ----------
@@ -2863,6 +2959,8 @@ class lognorm_gen(rv_continuous):
     for ``x > 0``, ``s > 0``.
 
     `lognorm` takes ``s`` as a shape parameter.
+
+    %(after_notes)s
 
     If ``log(x)`` is normally distributed with mean ``mu`` and variance
     ``sigma**2``, then ``x`` is log-normally distributed with shape parameter
@@ -2912,6 +3010,8 @@ class gilbrat_gen(rv_continuous):
 
     `gilbrat` is a special case of `lognorm` with ``s = 1``.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -2960,6 +3060,8 @@ class maxwell_gen(rv_continuous):
 
     for ``x > 0``.
 
+    %(after_notes)s
+
     References
     ----------
     .. [1] http://mathworld.wolfram.com/MaxwellDistribution.html
@@ -3003,6 +3105,8 @@ class mielke_gen(rv_continuous):
 
     `mielke` takes ``k`` and ``s`` as shape parameters.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -3033,6 +3137,8 @@ class nakagami_gen(rv_continuous):
     for ``x > 0``, ``nu > 0``.
 
     `nakagami` takes ``nu`` as a shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -3071,6 +3177,8 @@ class ncx2_gen(rv_continuous):
     for ``x > 0``.
 
     `ncx2` takes ``df`` and ``nc`` as shape parameters.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -3116,6 +3224,8 @@ class ncf_gen(rv_continuous):
     for ``df1, df2, nc > 0``.
 
     `ncf` takes ``df1``, ``df2`` and ``nc`` as shape parameters.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -3174,6 +3284,8 @@ class t_gen(rv_continuous):
 
     `t` takes ``df`` as a shape parameter.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -3228,6 +3340,8 @@ class nct_gen(rv_continuous):
     for ``df > 0``.
 
     `nct` takes ``df`` and ``nc`` as shape parameters.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -3314,6 +3428,8 @@ class pareto_gen(rv_continuous):
 
     `pareto` takes ``b`` as a shape parameter.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -3376,6 +3492,8 @@ class lomax_gen(rv_continuous):
 
     `lomax` takes ``c`` as a shape parameter.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -3425,6 +3543,8 @@ class pearson3_gen(rv_continuous):
             zeta = loc - alpha / beta
 
     `pearson3` takes ``skew`` as a shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -3550,6 +3670,8 @@ class powerlaw_gen(rv_continuous):
 
     `powerlaw` takes ``a`` as a shape parameter.
 
+    %(after_notes)s
+
     `powerlaw` is a special case of `beta` with ``b == 1``.
 
     %(example)s
@@ -3598,6 +3720,8 @@ class powerlognorm_gen(rv_continuous):
 
     `powerlognorm` takes ``c`` and ``s`` as shape parameters.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -3628,6 +3752,8 @@ class powernorm_gen(rv_continuous):
     and ``x > 0``, ``c > 0``.
 
     `powernorm` takes ``c`` as a shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -3660,6 +3786,8 @@ class rdist_gen(rv_continuous):
     for ``-1 <= x <= 1``, ``c > 0``.
 
     `rdist` takes ``c`` as a shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -3697,6 +3825,8 @@ class rayleigh_gen(rv_continuous):
     for ``x >= 0``.
 
     `rayleigh` is a special case of `chi` with ``df == 2``.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -3744,6 +3874,8 @@ class reciprocal_gen(rv_continuous):
 
     `reciprocal` takes ``a`` and ``b`` as shape parameters.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -3787,6 +3919,8 @@ class rice_gen(rv_continuous):
     for ``x > 0``, ``b > 0``.
 
     `rice` takes ``b`` as a shape parameter.
+
+    %(after_notes)s
 
     The Rice distribution describes the length, ``r``, of a 2-D vector
     with components ``(U+u, V+v)``, where ``U, V`` are constant, ``u, v``
@@ -3838,6 +3972,8 @@ class recipinvgauss_gen(rv_continuous):
 
     `recipinvgauss` takes ``mu`` as a shape parameter.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -3871,6 +4007,8 @@ class semicircular_gen(rv_continuous):
 
     for ``-1 <= x <= 1``.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -3900,6 +4038,8 @@ class triang_gen(rv_continuous):
     to ``(loc+scale)``.
 
     `triang` takes ``c`` as a shape parameter.
+
+    %(after_notes)s
 
     The standard form is in the range [0, 1] with c the mode.
     The location parameter shifts the start to `loc`.
@@ -3946,6 +4086,8 @@ class truncexpon_gen(rv_continuous):
     for ``0 < x < b``.
 
     `truncexpon` takes ``b`` as a shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -3999,6 +4141,8 @@ class truncnorm_gen(rv_continuous):
         a, b = (myclip_a - my_mean) / my_std, (myclip_b - my_mean) / my_std
 
     `truncnorm` takes ``a`` and ``b`` as shape parameters.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -4060,6 +4204,8 @@ class tukeylambda_gen(rv_continuous):
         - uniform from -1 to 1  (lam = 1)
 
     `tukeylambda` takes ``lam`` as a shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -4140,6 +4286,8 @@ class vonmises_gen(rv_continuous):
 
     `vonmises` takes ``kappa`` as a shape parameter.
 
+    %(after_notes)s
+
     See Also
     --------
     vonmises_line : The same distribution, defined on a [-pi, pi] segment
@@ -4178,6 +4326,8 @@ class wald_gen(invgauss_gen):
 
     `wald` is a special case of `invgauss` with ``mu == 1``.
 
+    %(after_notes)s
+
     %(example)s
     """
     def _rvs(self):
@@ -4211,6 +4361,8 @@ class wrapcauchy_gen(rv_continuous):
     for ``0 <= x <= 2*pi``, ``0 < c < 1``.
 
     `wrapcauchy` takes ``c`` as a shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -986,13 +986,11 @@ class expon_gen(rv_continuous):
     -----
     The probability density function for `expon` is::
 
-        expon.pdf(x) = lambda * exp(- lambda*x)
+        expon.pdf(x) = exp(-x)
 
     for ``x >= 0``.
 
-    The scale parameter is equal to ``scale = 1.0 / lambda``.
-
-    `expon` does not have shape parameters.
+    %(after_notes)s
 
     %(example)s
 
@@ -1814,23 +1812,16 @@ class gamma_gen(rv_continuous):
     -----
     The probability density function for `gamma` is::
 
-        gamma.pdf(x, a) = lambda**a * x**(a-1) * exp(-lambda*x) / gamma(a)
+        gamma.pdf(x, a) = x**(a-1) * exp(-x) / gamma(a)
 
     for ``x >= 0``, ``a > 0``. Here ``gamma(a)`` refers to the gamma function.
 
-    The scale parameter is equal to ``scale = 1.0 / lambda``.
-
-    `gamma` has a shape parameter `a` which needs to be set explicitly. For
-    instance:
-
-        >>> from scipy.stats import gamma
-        >>> rv = gamma(3., loc = 0., scale = 2.)
-
-    produces a frozen form of `gamma` with shape ``a = 3.``, ``loc =0.``
-    and ``lambda = 1./scale = 1./2.``.
+    `gamma` has a shape parameter `a` which needs to be set explicitly.
 
     When ``a`` is an integer, `gamma` reduces to the Erlang
     distribution, and when ``a=1`` to the exponential distribution.
+
+    %(after_notes)s
 
     %(example)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -991,6 +991,10 @@ class expon_gen(rv_continuous):
     for ``x >= 0``.
 
     %(after_notes)s
+    
+    A common parameterization for `expon` is in terms of the rate parameter
+    ``lambda``, such that ``pdf = lambda * exp(-lambda * x)``. This
+    parameterization corresponds to using ``scale = 1 / lambda``.
 
     %(example)s
 

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -30,6 +30,8 @@ class binom_gen(rv_discrete):
 
     `binom` takes ``n`` and ``p`` as shape parameters.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -97,6 +99,8 @@ class bernoulli_gen(binom_gen):
 
     `bernoulli` takes ``p`` as shape parameter.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -143,6 +147,8 @@ class nbinom_gen(rv_discrete):
     for ``k >= 0``.
 
     `nbinom` takes ``n`` and ``p`` as shape parameters.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -201,6 +207,8 @@ class geom_gen(rv_discrete):
 
     `geom` takes ``p`` as shape parameter.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -258,6 +266,8 @@ class hypergeom_gen(rv_discrete):
 
         pmf(k, M, n, N) = choose(n, k) * choose(M - n, N - k) / choose(M, N),
                                        for max(0, N - (M-n)) <= k <= min(n, N)
+
+    %(after_notes)s
 
     Examples
     --------
@@ -369,6 +379,8 @@ class logser_gen(rv_discrete):
 
     `logser` takes ``p`` as shape parameter.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -414,6 +426,8 @@ class poisson_gen(rv_discrete):
     for ``k >= 0``.
 
     `poisson` takes ``mu`` as shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -465,6 +479,8 @@ class planck_gen(rv_discrete):
     for ``k*lambda_ >= 0``.
 
     `planck` takes ``lambda_`` as shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -524,6 +540,8 @@ class boltzmann_gen(rv_discrete):
 
     `boltzmann` takes ``lambda_`` and ``N`` as shape parameters.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -575,6 +593,8 @@ class randint_gen(rv_discrete):
 
     Note the difference to the numpy ``random_integers`` which
     returns integers on a *closed* interval ``[low, high]``.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -636,6 +656,8 @@ class zipf_gen(rv_discrete):
 
     `zipf` takes ``a`` as shape parameter.
 
+    %(after_notes)s
+
     %(example)s
 
     """
@@ -671,6 +693,8 @@ class dlaplace_gen(rv_discrete):
     for ``a > 0``.
 
     `dlaplace` takes ``a`` as shape parameter.
+
+    %(after_notes)s
 
     %(example)s
 
@@ -725,6 +749,8 @@ class skellam_gen(rv_discrete):
     For details see: http://en.wikipedia.org/wiki/Skellam_distribution
 
     `skellam` takes ``mu1`` and ``mu2`` as shape parameters.
+
+    %(after_notes)s
 
     %(example)s
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -211,7 +211,7 @@ And compare the histogram:
 """
 
 _doc_default_locscale = """\  
-The probability density above is defined in the "standartized" form. To shift
+The probability density above is defined in the "standardized" form. To shift
 and/or scale the distribution use the ``loc`` and ``scale`` parameters.
 Specifically, ``%(name)s.pdf(x, %(shapes)s, loc, scale)`` is identically
 equivalent to ``%(name)s.pdf(y, %(shapes)s) / scale`` with
@@ -329,7 +329,7 @@ Generate random numbers:
 
 
 _doc_default_discrete_locscale = """\
-The probability mass function above is defined in the "standartized" form.
+The probability mass function above is defined in the "standardized" form.
 To shift distribution use the ``loc`` parameter.
 Specifically, ``%(name)s.pmf(k, %(shapes)s, loc)`` is identically
 equivalent to ``%(name)s.pmf(k - loc, %(shapes)s)``.

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -150,30 +150,6 @@ _doc_allmethods = ''.join([docheaders['methods'], _doc_rvs, _doc_pdf,
                            _doc_expect, _doc_median,
                            _doc_mean, _doc_var, _doc_std, _doc_interval])
 
-# Note that the two lines for %(shapes) are searched for and replaced in
-# rv_continuous and rv_discrete - update there if the exact string changes
-_doc_default_callparams = """
-Parameters
-----------
-x : array_like
-    quantiles
-q : array_like
-    lower or upper tail probability
-%(shapes)s : array_like
-    shape parameters
-loc : array_like, optional
-    location parameter (default=0)
-scale : array_like, optional
-    scale parameter (default=1)
-size : int or tuple of ints, optional
-    shape of random variates (default computed from input arguments )
-moments : str, optional
-    composed of letters ['mvsk'] specifying which moments to compute where
-    'm' = mean, 'v' = variance, 's' = (Fisher's) skew and
-    'k' = (Fisher's) kurtosis.
-    Default is 'mv'.
-"""
-
 _doc_default_longsummary = """\
 As an instance of the `rv_continuous` class, `%(name)s` object inherits from it
 a collection of generic methods (see below for the full list),
@@ -247,8 +223,6 @@ And compare the histogram:
 
 _doc_default = ''.join([_doc_default_longsummary,
                         _doc_allmethods,
-                        _doc_default_callparams,
-                        _doc_default_frozen_note,
                         _doc_default_example])
 
 _doc_default_before_notes = ''.join([_doc_default_longsummary,
@@ -275,7 +249,6 @@ docdict = {
     'var': _doc_var,
     'median': _doc_median,
     'allmethods': _doc_allmethods,
-    'callparams': _doc_default_callparams,
     'longsummary': _doc_default_longsummary,
     'frozennote': _doc_default_frozen_note,
     'example': _doc_default_example,
@@ -782,7 +755,7 @@ class rv_generic(object):
 
         if self.shapes is None:
             # remove shapes from call parameters if there are none
-            for item in ['callparams', 'default', 'before_notes']:
+            for item in ['default', 'before_notes']:
                 tempdict[item] = tempdict[item].replace(
                     "\n%(shapes)s : array_like\n    shape parameters", "")
         for i in range(2):

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -175,7 +175,7 @@ moments : str, optional
 """
 
 _doc_default_longsummary = """\
-As an instance of `rv_continuous` class, `%(name)s` object inherits from it
+As an instance of the `rv_continuous` class, `%(name)s` object inherits from it
 a collection of generic methods (see below for the full list),
 and completes them with details specific for this particular distribution.
 """
@@ -207,6 +207,17 @@ Display the probability density function (``pdf``):
 >>> ax.plot(x, %(name)s.pdf(x, %(shapes)s),
 ...        'r-', lw=5, alpha=0.6, label='%(name)s pdf')
 
+To shift and/or scale the distribution use the ``loc`` and ``scale`` parameters.
+For example, 
+
+>>> loc, scale = 4, 5
+>>> %(name)s.cdf(x, %(shapes)s, loc, scale)
+
+is equivalent to
+
+>>> y = (x - loc) / scale
+>>> %(name)s.cdf(y, %(shapes)s)
+
 Alternatively, the distribution object can be called (as a function)
 to fix the shape, location and scale parameters. This returns a "frozen"
 RV object holding the given parameters fixed. 
@@ -231,6 +242,7 @@ And compare the histogram:
 >>> ax.hist(r, normed=True, histtype='stepfilled', alpha=0.2)
 >>> ax.legend(loc='best', frameon=False)
 >>> plt.show()
+
 """
 
 _doc_default = ''.join([_doc_default_longsummary,
@@ -314,12 +326,24 @@ Calculate a few first moments:
 %(set_vals_stmt)s
 >>> mean, var, skew, kurt = %(name)s.stats(%(shapes)s, moments='mvsk')
 
+
 Display the probability mass function (``pmf``):
 
 >>> x = np.arange(%(name)s.ppf(0.01, %(shapes)s),
 ...               %(name)s.ppf(0.99, %(shapes)s))
 >>> ax.plot(x, %(name)s.pmf(x, %(shapes)s), 'bo', ms=8, label='%(name)s pmf')
 >>> ax.vlines(x, 0, %(name)s.pmf(x, %(shapes)s), colors='b', lw=5, alpha=0.5)
+
+To shift the distribution use the ``loc`` parameter. For example,
+
+>>> loc = 4
+>>> %(name)s.cdf(x, %(shapes)s, loc)
+
+is equivalent to
+
+>>> y = (x - loc)
+>>> %(name)s.cdf(y, %(shapes)s)
+
 
 Alternatively, the distribution object can be called (as a function)
 to fix the shape and location. This returns a "frozen" RV object holding 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -297,7 +297,6 @@ Calculate a few first moments:
 %(set_vals_stmt)s
 >>> mean, var, skew, kurt = %(name)s.stats(%(shapes)s, moments='mvsk')
 
-
 Display the probability mass function (``pmf``):
 
 >>> x = np.arange(%(name)s.ppf(0.01, %(shapes)s),
@@ -305,23 +304,11 @@ Display the probability mass function (``pmf``):
 >>> ax.plot(x, %(name)s.pmf(x, %(shapes)s), 'bo', ms=8, label='%(name)s pmf')
 >>> ax.vlines(x, 0, %(name)s.pmf(x, %(shapes)s), colors='b', lw=5, alpha=0.5)
 
-To shift the distribution use the ``loc`` parameter. For example,
-
->>> loc = 4
->>> %(name)s.cdf(x, %(shapes)s, loc)
-
-is equivalent to
-
->>> y = (x - loc)
->>> %(name)s.cdf(y, %(shapes)s)
-
-
 Alternatively, the distribution object can be called (as a function)
 to fix the shape and location. This returns a "frozen" RV object holding 
 the given parameters fixed. 
 
 Freeze the distribution and display the frozen ``pmf``:
-
 
 >>> rv = %(name)s(%(shapes)s)
 >>> ax.vlines(x, 0, rv.pmf(x), colors='k', linestyles='-', lw=1,
@@ -339,7 +326,17 @@ Generate random numbers:
 
 >>> r = %(name)s.rvs(%(shapes)s, size=1000)
 """
+
+
+_doc_default_discrete_locscale = """\
+The probability mass function above is defined in the "standartized" form.
+To shift distribution use the ``loc`` parameter.
+Specifically, ``%(name)s.pmf(k, %(shapes)s, loc)`` is identically
+equivalent to ``%(name)s.pmf(k - loc, %(shapes)s)``.
+"""
+
 docdict_discrete['example'] = _doc_default_discrete_example
+docdict_discrete['after_notes'] = _doc_default_discrete_locscale
 
 _doc_default_before_notes = ''.join([docdict_discrete['longsummary'],
                                      docdict_discrete['allmethods']])

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -183,17 +183,6 @@ Display the probability density function (``pdf``):
 >>> ax.plot(x, %(name)s.pdf(x, %(shapes)s),
 ...        'r-', lw=5, alpha=0.6, label='%(name)s pdf')
 
-To shift and/or scale the distribution use the ``loc`` and ``scale`` parameters.
-For example, 
-
->>> loc, scale = 4, 5
->>> %(name)s.cdf(x, %(shapes)s, loc, scale)
-
-is equivalent to
-
->>> y = (x - loc) / scale
->>> %(name)s.cdf(y, %(shapes)s)
-
 Alternatively, the distribution object can be called (as a function)
 to fix the shape, location and scale parameters. This returns a "frozen"
 RV object holding the given parameters fixed. 
@@ -219,6 +208,14 @@ And compare the histogram:
 >>> ax.legend(loc='best', frameon=False)
 >>> plt.show()
 
+"""
+
+_doc_default_locscale = """\  
+The probability density above is defined in the "standartized" form. To shift
+and/or scale the distribution use the ``loc`` and ``scale`` parameters.
+Specifically, ``%(name)s.pdf(x, %(shapes)s, loc, scale)`` is identically
+equivalent to ``%(name)s.pdf(y, %(shapes)s) / scale`` with
+``y = (x - loc) / scale``.
 """
 
 _doc_default = ''.join([_doc_default_longsummary,
@@ -253,7 +250,8 @@ docdict = {
     'frozennote': _doc_default_frozen_note,
     'example': _doc_default_example,
     'default': _doc_default,
-    'before_notes': _doc_default_before_notes
+    'before_notes': _doc_default_before_notes,
+    'after_notes': _doc_default_locscale
 }
 
 # Reuse common content between continuous and discrete docs, change some


### PR DESCRIPTION
so that each distribution has a magic formula `y = (x - loc) / scale` in its docstring.
As suggested in gh-4538.

[ci skip]
