### PR TITLE
Be more (or less) forgiving when user passes +-inf instead of None as a boundary.

### DIFF
--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -71,7 +71,7 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
         `func` returns only the function value).
     bounds : list
         ``(min, max)`` pairs for each element in ``x``, defining
-        the bounds on that parameter. Use None for one of ``min`` or
+        the bounds on that parameter. Use None or +-inf for one of ``min`` or
         ``max`` when there is no bound in that direction.
     m : int
         The maximum number of variable metric corrections

--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -173,7 +173,6 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
     # build options
     if disp is None:
         disp = iprint
-
     opts = {'disp': disp,
             'iprint': iprint,
             'maxcor': m,
@@ -252,9 +251,7 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
     if len(bounds) != n:
         raise ValueError('length of x0 != length of bounds')
     # unbounded variables must use None, not +-inf, for optimizer to work properly
-    l = [None if l == -np.inf else l for l, _ in bounds]
-    u = [None if u == np.inf else u for _, u in bounds]
-    bounds = zip(l, u)
+    bounds = [(None if l == -np.inf else l, None if u == np.inf else u) for l, u in bounds]
 
     if disp is not None:
         if disp == 0:

--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -173,6 +173,7 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
     # build options
     if disp is None:
         disp = iprint
+
     opts = {'disp': disp,
             'iprint': iprint,
             'maxcor': m,
@@ -250,6 +251,10 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
         bounds = [(None, None)] * n
     if len(bounds) != n:
         raise ValueError('length of x0 != length of bounds')
+    # unbounded variables must use None, not +-inf, for optimizer to work properly
+    l = [None if l == -np.inf else l for l, _ in bounds]
+    u = [None if u == np.inf else u for _, u in bounds]
+    bounds = zip(l, u)
 
     if disp is not None:
         if disp == 0:


### PR DESCRIPTION
Allow -inf, inf as boundaries in fmin_l_bfgs_b.
When passing (-inf, inf) instead of (None, None) as a boundary, the algorithm will run fine but behave differently.
For me, the results were really bad compared to when used properly and if my code was not a port from matlab I might have not noticed for lack of comparison.
So I propose to either be more forgiving when the user ignores the docs (as per this change), or to be less forgiving (i.e. fail) so that the user knows (s)he made a mistake.
