### PR TITLE
MNT: Suppress LineSearchWarning's in scipy.optimize tests

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -35,7 +35,8 @@ from numpy import (atleast_1d, eye, mgrid, argmin, zeros, shape, squeeze,
                    vectorize, asarray, sqrt, Inf, asfarray, isinf)
 import numpy as np
 from .linesearch import (line_search_wolfe1, line_search_wolfe2,
-                         line_search_wolfe2 as line_search)
+                         line_search_wolfe2 as line_search,
+                         LineSearchWarning)
 
 
 # standard status messages of optimizers
@@ -693,8 +694,10 @@ def _line_search_wolfe12(f, fprime, xk, pk, gfk, old_fval, old_old_fval,
 
     if ret[0] is None:
         # line search failed: try different one.
-        ret = line_search_wolfe2(f, fprime, xk, pk, gfk,
-                                 old_fval, old_old_fval)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', LineSearchWarning)
+            ret = line_search_wolfe2(f, fprime, xk, pk, gfk,
+                                     old_fval, old_old_fval)
 
     if ret[0] is None:
         raise _LineSearchError()

--- a/scipy/optimize/tests/test_linesearch.py
+++ b/scipy/optimize/tests/test_linesearch.py
@@ -3,9 +3,12 @@ Tests for line search routines
 """
 from __future__ import division, print_function, absolute_import
 
+import warnings
+
 from numpy.testing import assert_, assert_equal, \
      assert_array_almost_equal, assert_array_almost_equal_nulp
 import scipy.optimize.linesearch as ls
+from scipy.optimize.linesearch import LineSearchWarning
 import numpy as np
 
 
@@ -190,9 +193,11 @@ class TestLineSearch(object):
             f0 = f(x)
             g0 = fprime(x)
             self.fcount = 0
-            s, fc, gc, fv, ofv, gv = ls.line_search_wolfe2(f, fprime, x, p,
-                                                           g0, f0, old_f,
-                                                           amax=smax)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', LineSearchWarning)
+                s, fc, gc, fv, ofv, gv = ls.line_search_wolfe2(f, fprime, x, p,
+                                                               g0, f0, old_f,
+                                                               amax=smax)
             assert_equal(self.fcount, fc+gc)
             assert_fp_equal(ofv, f(x))
             assert_fp_equal(fv, f(x + s*p))

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -527,9 +527,9 @@ class TestOptimize(object):
             else:
                 jac = dfunc
 
-            sol1 = optimize.minimize(func, [1,1], jac=jac, tol=1e-10,
+            sol1 = optimize.minimize(func, [1, 1], jac=jac, tol=1e-10,
                                      method=method)
-            sol2 = optimize.minimize(func, [1,1], jac=jac, tol=1.0,
+            sol2 = optimize.minimize(func, [1, 1], jac=jac, tol=1.0,
                                      method=method)
             assert_(func(sol1.x) < func(sol2.x),
                     "%s: %s vs. %s" % (method, func(sol1.x), func(sol2.x)))
@@ -915,4 +915,3 @@ class TestOptimizeResultAttributes(TestCase):
 
 if __name__ == "__main__":
     run_module_suite()
-


### PR DESCRIPTION
I tried to fix #4554. 

Tell me if I did it correctly.
