### PR TITLE
ENH: Extract inverse hessian information from L-BFGS-B

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -34,7 +34,7 @@ Damian Eads for hierarchical clustering, dendrogram plotting,
 Anne Archibald for kd-trees and nearest neighbor in scipy.spatial.
 Pauli Virtanen for Sphinx documentation generation, online documentation
     framework and interpolation bugfixes.
-Josef Perktold for major improvements to scipy.stats and its test suite and 
+Josef Perktold for major improvements to scipy.stats and its test suite and
               fixes and tests to optimize.curve_fit and leastsq.
 David Morrill for getting the scoreboard test system up and running.
 Louis Luangkesorn for providing multiple tests for the stats module.
@@ -65,7 +65,7 @@ Ondrej Certik for Debian packaging.
 Paul Ivanov for porting Numeric-style C code to the new NumPy API.
 Ariel Rokem for contributions on percentileofscore fixes and tests.
 Yosef Meller for tests in the optimization module.
-Ralf Gommers for release management, code clean up and improvements 
+Ralf Gommers for release management, code clean up and improvements
     to doc-string generation.
 Bruce Southey for bug-fixes and improvements to scipy.stats.
 Ernest Adrogué for the Skellam distribution.
@@ -92,7 +92,7 @@ Thouis (Ray) Jones for bug fixes in ndimage.
 Yaroslav Halchenko for a bug fix in ndimage.
 Thomas Robitaille for the IDL 'save' reader.
 Fazlul Shahriar for fixes to the NetCDF3 I/O.
-Chris Jordan-Squire for bug fixes, documentation improvements and 
+Chris Jordan-Squire for bug fixes, documentation improvements and
     scipy.special.logit & expit.
 Christoph Gohlke for many bug fixes and help with Windows specific issues.
 Jacob Silterra for cwt-based peak finding in scipy.signal.
@@ -138,9 +138,9 @@ Alex Rothberg for stats.combine_pvalues.
 Brandon Liu for stats.combine_pvalues.
 Clark Fitzgerald for namedtuple outputs in scipy.stats.
 Florian Wilhelm for usage of RandomState in scipy.stats distributions.
-Robert T. McGibbon for Levinson-Durbin Toeplitz solver.
+Robert T. McGibbon for Levinson-Durbin Toeplitz solver, Hessian information
+    from L-BFGS-B.
 Alex Conley for the Exponentially Modified Normal distribution.
-
 
 Institutions
 ------------

--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -200,8 +200,8 @@ The `linprog` function supports the following methods:
    optimize.linprog-simplex
 
 
-Utility Functions
-=================
+Utilities
+=========
 
 .. autosummary::
    :toctree: generated/
@@ -212,6 +212,7 @@ Utility Functions
    line_search - Return a step that satisfies the strong Wolfe conditions
 
    show_options - Show specific options optimization solvers
+   LbfgsInvHessProduct - Linear operator for L-BFGS approximate inverse Hessian
 
 """
 
@@ -222,7 +223,7 @@ from ._minimize import *
 from ._root import *
 from .minpack import *
 from .zeros import *
-from .lbfgsb import fmin_l_bfgs_b
+from .lbfgsb import fmin_l_bfgs_b, LbfgsInvHessProduct
 from .tnc import fmin_tnc
 from .cobyla import fmin_cobyla
 from .nonlin import *

--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -41,6 +41,7 @@ from . import _lbfgsb
 from .optimize import (approx_fprime, MemoizeJac, OptimizeResult,
                        _check_unknown_options, wrap_function,
                        _approx_fprime_helper)
+from scipy.sparse.linalg import LinearOperator
 
 __all__ = ['fmin_l_bfgs_b']
 
@@ -338,9 +339,102 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
     else:
         warnflag = 2
 
+    # these two portions of the workspace are described in the mainlb
+    # subroutine in lbfgsb.f. See line 363.
+    s = wa[0: m*n].reshape(m, n)
+    y = wa[m*n: 2*m*n].reshape(m, n)
+    n_corrs = min(n_iterations-1, maxcor)
+    hess_inv = LbfgsInvHessProduct(s[:n_corrs], y[:n_corrs])
+
     return OptimizeResult(fun=f, jac=g, nfev=n_function_evals[0],
                           nit=n_iterations, status=warnflag, message=task_str,
-                          x=x, success=(warnflag == 0))
+                          x=x, success=(warnflag == 0), hess_inv=hess_inv)
+
+
+class LbfgsInvHessProduct(LinearOperator):
+    """Linear operator for the BFGS approximate inverse Hessian.
+
+    References
+    ----------
+    .. [1] Nocedal, Jorge. "Updating quasi-Newton matrices with limited
+       storage." Mathematics of computation 35.151 (1980): 773-782.
+    """
+    def __init__(self, sk, yk):
+        """Construct the operator
+
+        Parameters
+        ----------
+        sk : array_like, shape=(n_corr, n)
+            Array of `n_corr` most recent updates to the solution vector.
+            (See [1]).
+        yk : array_like, shape=(n_corr, n)
+            Array of `n_corr` most recent updates to the gradient. (See [1]).
+        """
+        if sk.shape != yk.shape or sk.ndim != 2:
+            raise ValueError('sk and yk must have matching shape, (n_corrs, n)')
+        n_corrs, n = sk.shape
+
+        super(LbfgsInvHessProduct, self).__init__(
+            dtype=np.float64, shape=(n, n))
+
+        self.sk = sk
+        self.yk = yk
+        self.n_corrs = n_corrs
+        self.rho = 1 / np.einsum('ij,ij->i', sk, yk)
+
+    def _matvec(self, x):
+        """Efficient matrix-vector multiply with the BFGS matrices.
+
+        This calculation is described in Section (4) of [1].
+
+        Parameters
+        ----------
+        x : ndarray
+            An array with shape (n,) or (n,1).
+
+        Returns
+        -------
+        y : ndarray
+            The matrix-vector product
+        """
+        s, y, n_corrs, rho = self.sk, self.yk, self.n_corrs, self.rho
+        q = np.array(x, dtype=self.dtype, copy=True)
+        if q.ndim == 2 and q.shape[1] == 1:
+            q = q.reshape(-1)
+
+        alpha = np.zeros(n_corrs)
+
+        for i in range(n_corrs-1, -1, -1):
+            alpha[i] = rho[i] * np.dot(s[i], q)
+            q = q - alpha[i]*y[i]
+
+        r = q
+        for i in range(n_corrs):
+            beta = rho[i] * np.dot(y[i], r)
+            r = r + s[i] * (alpha[i] - beta)
+
+        return r
+
+    def todense(self):
+        """Return a dense array representation of this operator.
+
+        Returns
+        -------
+        arr : ndarray, shape=(n, n)
+            A NumPy array with the same shape and containing
+            the same data represented by this LinearOperator.
+        """
+        s, y, n_corrs, rho = self.sk, self.yk, self.n_corrs, self.rho
+        I = np.eye(*self.shape, dtype=self.dtype)
+        Hk = I
+
+        for i in range(n_corrs):
+            A1 = I - s[i][:, np.newaxis] * y[i][np.newaxis, :] * rho[i]
+            A2 = I - y[i][:, np.newaxis] * s[i][np.newaxis, :] * rho[i]
+
+            Hk = np.dot(A1, np.dot(Hk, A2)) + (rho[i] * s[i][:, np.newaxis] *
+                                                        s[i][np.newaxis, :])
+        return Hk
 
 
 if __name__ == '__main__':

--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -43,7 +43,7 @@ from .optimize import (approx_fprime, MemoizeJac, OptimizeResult,
                        _approx_fprime_helper)
 from scipy.sparse.linalg import LinearOperator
 
-__all__ = ['fmin_l_bfgs_b']
+__all__ = ['fmin_l_bfgs_b', 'LbfgsInvHessProduct']
 
 
 def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
@@ -352,7 +352,12 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
 
 
 class LbfgsInvHessProduct(LinearOperator):
-    """Linear operator for the BFGS approximate inverse Hessian.
+    """Linear operator for the L-BFGS approximate inverse Hessian.
+
+    This operator computes the product of a vector with the approximate inverse
+    of the Hessian of the objective function, using the L-BFGS limited
+    memory approximation to the inverse Hessian, accumulated during the
+    optimization.
 
     References
     ----------

--- a/scipy/optimize/tests/test_lbfgsb_hessinv.py
+++ b/scipy/optimize/tests/test_lbfgsb_hessinv.py
@@ -1,0 +1,48 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+from numpy.testing import assert_, TestCase, run_module_suite, assert_allclose
+import scipy.linalg
+from scipy.optimize import minimize
+
+
+def test_1():
+    def f(x):
+        return x**4, 4*x**3
+
+    for gtol in [1e-8, 1e-12, 1e-20]:
+        for maxcor in range(20, 35):
+            result = minimize(fun=f, jac=True, method='L-BFGS-B', x0=20,
+                options={'gtol': gtol, 'maxcor': maxcor})
+
+            H1 = result.hess_inv(np.array([1])).reshape(1,1)
+            H2 = result.hess_inv.todense()
+
+            assert_allclose(H1, H2)
+
+
+def test_2():
+    H0 = [[3, 0], [1, 2]]
+
+    def f(x):
+        return np.dot(x, np.dot(scipy.linalg.inv(H0), x))
+
+    result1 = minimize(fun=f, method='L-BFGS-B', x0=[10, 20])
+    result2 = minimize(fun=f, method='BFGS', x0=[10, 20])
+
+    H1 = result1.hess_inv.todense()
+
+    H2 = np.vstack((
+        result1.hess_inv(np.array([1, 0])),
+        result1.hess_inv(np.array([0, 1]))))
+
+    assert_allclose(
+        result1.hess_inv(np.array([1, 0]).reshape(2,1)).reshape(-1),
+        result1.hess_inv(np.array([1, 0])))
+    assert_allclose(H1, H2)
+    assert_allclose(H1, result2.hess_inv, rtol=1e-2, atol=0.03)
+
+
+if __name__ == "__main__":
+    run_module_suite()
+


### PR DESCRIPTION
This is a first implementation of a feature to extract the limited-memory BFGS matrices (approximations to the inverse hessian of the objective function) from L-BFGS-B, which I proposed on the mailing list last week http://mail.scipy.org/pipermail/scipy-dev/2015-February/020375.html

Any feedback would be great.

From a couple experiments with the particular use case I'm interested in, the accuracy of this inverse Hessian approximation is sufficient to give estimates of the standard errors in model parameters that are within ~10-20%, which is better than I had expected (IMHO enough to make this of practical value).

cc #4545 
