### PR TITLE
ENH: Split signal.lti into subclasses, part of #2912

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -145,15 +145,18 @@ Continuous-Time Linear Systems
 .. autosummary::
    :toctree: generated/
 
-   freqresp -- frequency response of a continuous-time LTI system.
-   lti      -- linear time invariant system object.
-   lsim     -- continuous-time simulation of output to linear system.
-   lsim2    -- like lsim, but `scipy.integrate.odeint` is used.
-   impulse  -- impulse response of linear, time-invariant (LTI) system.
-   impulse2 -- like impulse, but `scipy.integrate.odeint` is used.
-   step     -- step response of continous-time LTI system.
-   step2    -- like step, but `scipy.integrate.odeint` is used.
-   bode     -- Calculate Bode magnitude and phase data.
+   freqresp         -- frequency response of a continuous-time LTI system.
+   lti              -- Linear time invariant system base class.
+   StateSpace       -- Linear time invariant system in state space form.
+   TransferFunction -- Linear time invariant system in tranfer function form.
+   ZerosPolesGain   -- Linear time invariant system in zeros, poles, gain form.
+   lsim             -- continuous-time simulation of output to linear system.
+   lsim2            -- like lsim, but `scipy.integrate.odeint` is used.
+   impulse          -- impulse response of linear, time-invariant (LTI) system.
+   impulse2         -- like impulse, but `scipy.integrate.odeint` is used.
+   step             -- step response of continous-time LTI system.
+   step2            -- like step, but `scipy.integrate.odeint` is used.
+   bode             -- Calculate Bode magnitude and phase data.
 
 Discrete-Time Linear Systems
 ============================

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -148,7 +148,7 @@ Continuous-Time Linear Systems
    freqresp         -- frequency response of a continuous-time LTI system.
    lti              -- Linear time invariant system base class.
    StateSpace       -- Linear time invariant system in state space form.
-   TransferFunction -- Linear time invariant system in tranfer function form.
+   TransferFunction -- Linear time invariant system in transfer function form.
    ZerosPolesGain   -- Linear time invariant system in zeros, poles, gain form.
    lsim             -- continuous-time simulation of output to linear system.
    lsim2            -- like lsim, but `scipy.integrate.odeint` is used.

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -443,13 +443,6 @@ class lti(object):
         """
         return impulse(self, X0=X0, T=T, N=N)
 
-    def impulse2(self, X0=None, T=None, N=None, **kwargs):
-        """
-        Return the impulse response of a continuous-time system.
-        See `scipy.signal.impulse2` for details.
-        """
-        return impulse2(self, X0=X0, T=T, N=N, **kwargs)
-
     def step(self, X0=None, T=None, N=None):
         """
         Return the step response of a continuous-time system.
@@ -457,26 +450,12 @@ class lti(object):
         """
         return step(self, X0=X0, T=T, N=N)
 
-    def step2(self, X0=None, T=None, N=None, **kwargs):
-        """
-        Return the step response of a continuous-time system.
-        See `scipy.signal.step2` for details.
-        """
-        return step2(self, X0=X0, T=T, N=N, **kwargs)
-
     def output(self, U, T, X0=None):
         """
         Return the response of a continuous-time system to input `U`.
         See `scipy.signal.lsim` for details.
         """
         return lsim(self, U, T, X0=X0)
-
-    def output2(self, U, T, X0=None, **kwargs):
-        """
-        Return the response of a continuous-time system to input `U`.
-        See `scipy.signal.lsim2` for details.
-        """
-        return lsim2(self, U, T, X0=X0, **kwargs)
 
     def bode(self, w=None, n=100):
         """

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -690,7 +690,7 @@ class ZerosPolesGain(lti):
 
     @zeros.setter
     def zeros(self, zeros):
-        self._zeros = numpy.asarray(zeros)
+        self._zeros = atleast_1d(zeros)
 
         # Update dimensions
         if len(self.zeros.shape) > 1:
@@ -705,7 +705,7 @@ class ZerosPolesGain(lti):
 
     @poles.setter
     def poles(self, poles):
-        self._poles = numpy.asarray(poles)
+        self._poles = atleast_1d(poles)
 
     @property
     def gain(self):

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -1028,9 +1028,9 @@ def lsim2(system, U=None, T=None, X0=None, **kwargs):
 
     """
     if isinstance(system, lti):
-        sys = system
+        sys = system.to_ss()
     else:
-        sys = lti(*system)
+        sys = lti(*system).to_ss()
 
     if X0 is None:
         X0 = zeros(sys.B.shape[0], sys.A.dtype)
@@ -1145,9 +1145,9 @@ def lsim(system, U, T, X0=None, interp=True):
     >>> plt.plot(t, y)
     """
     if isinstance(system, lti):
-        sys = system
+        sys = system.to_ss()
     else:
-        sys = lti(*system)
+        sys = lti(*system).to_ss()
     T = atleast_1d(T)
     if len(T.shape) != 1:
         raise ValueError("T must be a rank-1 array.")
@@ -1313,9 +1313,9 @@ def impulse(system, X0=None, T=None, N=None):
 
     """
     if isinstance(system, lti):
-        sys = system
+        sys = system.to_ss()
     else:
-        sys = lti(*system)
+        sys = lti(*system).to_ss()
     if X0 is None:
         X = squeeze(sys.B)
     else:
@@ -1391,9 +1391,9 @@ def impulse2(system, X0=None, T=None, N=None, **kwargs):
 
     """
     if isinstance(system, lti):
-        sys = system
+        sys = system.to_ss()
     else:
-        sys = lti(*system)
+        sys = lti(*system).to_ss()
     B = sys.B
     if B.shape[-1] != 1:
         raise ValueError("impulse2() requires a single-input system.")
@@ -1446,9 +1446,9 @@ def step(system, X0=None, T=None, N=None):
 
     """
     if isinstance(system, lti):
-        sys = system
+        sys = system.to_ss()
     else:
-        sys = lti(*system)
+        sys = lti(*system).to_ss()
     if N is None:
         N = 100
     if T is None:
@@ -1506,9 +1506,9 @@ def step2(system, X0=None, T=None, N=None, **kwargs):
     .. versionadded:: 0.8.0
     """
     if isinstance(system, lti):
-        sys = system
+        sys = system.to_ss()
     else:
-        sys = lti(*system)
+        sys = lti(*system).to_ss()
     if N is None:
         N = 100
     if T is None:
@@ -1627,9 +1627,9 @@ def freqresp(system, w=None, n=10000):
     >>> plt.show()
     """
     if isinstance(system, lti):
-        sys = system
+        sys = system.to_tf()
     else:
-        sys = lti(*system)
+        sys = lti(*system).to_tf()
 
     if sys.inputs != 1 or sys.outputs != 1:
         raise ValueError("freqresp() requires a SISO (single input, single "

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -319,99 +319,99 @@ class lti(object):
 
     @property
     def num(self):
-        return self.tf().num
+        return self.to_tf().num
 
     @num.setter
     def num(self, num):
-        obj = self.tf()
+        obj = self.to_tf()
         obj.num = num
         source_class = type(self)
         self.copy(source_class(obj), copy=False)
 
     @property
     def den(self):
-        return self.tf().den
+        return self.to_tf().den
 
     @den.setter
     def den(self, den):
-        obj = self.tf()
+        obj = self.to_tf()
         obj.den = den
         source_class = type(self)
         self.copy(source_class(obj), copy=False)
 
     @property
     def zeros(self):
-        return self.zpk().zeros
+        return self.to_zpk().zeros
 
     @zeros.setter
     def zeros(self, zeros):
-        obj = self.zpk()
+        obj = self.to_zpk()
         obj.zeros = zeros
         source_class = type(self)
         self.copy(source_class(obj), copy=False)
 
     @property
     def poles(self):
-        return self.zpk().poles
+        return self.to_zpk().poles
 
     @poles.setter
     def poles(self, poles):
-        obj = self.zpk()
+        obj = self.to_zpk()
         obj.poles = poles
         source_class = type(self)
         self.copy(source_class(obj), copy=False)
 
     @property
     def gain(self):
-        return self.zpk().gain
+        return self.to_zpk().gain
 
     @gain.setter
     def gain(self, gain):
-        obj = self.zpk()
+        obj = self.to_zpk()
         obj.gain = gain
         source_class = type(self)
         self.copy(source_class(obj), copy=False)
 
     @property
     def A(self):
-        return self.ss().A
+        return self.to_ss().A
 
     @A.setter
     def A(self, A):
-        obj = self.ss()
+        obj = self.to_ss()
         obj.A = A
         source_class = type(self)
         self.copy(source_class(obj), copy=False)
 
     @property
     def B(self):
-        return self.ss().B
+        return self.to_ss().B
 
     @B.setter
     def B(self, B):
-        obj = self.ss()
+        obj = self.to_ss()
         obj.B = B
         source_class = type(self)
         self.copy(source_class(obj), copy=False)
 
     @property
     def C(self):
-        return self.ss().C
+        return self.to_ss().C
 
     @C.setter
     def C(self, C):
-        obj = self.ss()
+        obj = self.to_ss()
         obj.C = C
         source_class = type(self)
         self.copy(source_class(obj), copy=False)
 
     @property
     def D(self):
-        return self.ss().D
+        return self.to_ss().D
 
     @D.setter
     def D(self, D):
-        obj = self.ss()
+        obj = self.to_ss()
         obj.D = D
         source_class = type(self)
         self.copy(source_class(obj), copy=False)
@@ -509,7 +509,7 @@ class tf(lti):
         self._den = None
 
         if len(args) == 1:  # Input is an lti system
-            self.copy(args[0].tf())
+            self.copy(args[0].to_tf())
         else:  # Input is (num, den)
             self.num, self.den = normalize(*args)
 
@@ -561,7 +561,7 @@ class tf(lti):
             self.num = self.num.copy()
             self.den = self.den.copy()
 
-    def tf(self):
+    def to_tf(self):
         """Convert system representation to transfer function.
 
         Returns
@@ -572,7 +572,7 @@ class tf(lti):
         """
         return self
 
-    def zpk(self):
+    def to_zpk(self):
         """Convert system representation to zero, pole, gain.
 
         Returns
@@ -583,7 +583,7 @@ class tf(lti):
         """
         return zpk(*tf2zpk(self.num, self.den))
 
-    def ss(self):
+    def to_ss(self):
         """Convert system representation to state space.
 
         Returns
@@ -627,7 +627,7 @@ class zpk(lti):
         self._gain = None
 
         if len(args) == 1:
-            self.copy(args[0].zpk())
+            self.copy(args[0].to_zpk())
         else:
             self.zeros, self.poles, self.gain = args
 
@@ -691,7 +691,7 @@ class zpk(lti):
             self.poles = self.poles.copy()
             self.zeros = self.zeros.copy()
 
-    def tf(self):
+    def to_tf(self):
         """Convert system representation to transfer function.
 
         Returns
@@ -702,7 +702,7 @@ class zpk(lti):
         """
         return tf(*zpk2tf(self.zeros, self.poles, self.gain))
 
-    def zpk(self):
+    def to_zpk(self):
         """Convert system representation to zero, pole, gain.
 
         Returns
@@ -713,7 +713,7 @@ class zpk(lti):
         """
         return self
 
-    def ss(self):
+    def to_ss(self):
         """Convert system representation to state space.
 
         Returns
@@ -758,7 +758,7 @@ class ss(lti):
         self._D = None
 
         if len(args) == 1:
-            self.copy(args[0].ss())
+            self.copy(args[0].to_ss())
         else:
             self.A, self.B, self.C, self.D = abcd_normalize(*args)
 
@@ -827,7 +827,7 @@ class ss(lti):
             self.C = self.C.copy()
             self.D = self.D.copy()
 
-    def tf(self, **kwargs):
+    def to_tf(self, **kwargs):
         """Convert system representation to transfer function.
 
         Parameters
@@ -843,7 +843,7 @@ class ss(lti):
         """
         return tf(*ss2tf(self._A, self._B, self._C, self._D, **kwargs))
 
-    def zpk(self, **kwargs):
+    def to_zpk(self, **kwargs):
         """Convert system representation to zero, pole, gain.
 
         Parameters
@@ -859,7 +859,7 @@ class ss(lti):
         """
         return zpk(*ss2zpk(self._A, self._B, self._C, self._D, **kwargs))
 
-    def ss(self):
+    def to_ss(self):
         """Convert system representation to state space.
 
         Returns

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -279,21 +279,21 @@ class lti(object):
 
     Parameters
     ----------
-    args : arguments
+    system : lti system arguments
         The `lti` class can be instantiated with either 2, 3 or 4 arguments.
-        The following gives the number of elements in the tuple and the
-        corresponding subclass that is created:
+        The following gives the number of arguments and the corresponding
+        subclass that is created:
 
-            * 2: tf:  (numerator, denominator)
-            * 3: zpk: (zeros, poles, gain)
-            * 4: ss:  (A, B, C, D)
+            * 2: TransferFunction:  (numerator, denominator)
+            * 3: ZerosPolesGain: (zeros, poles, gain)
+            * 4: StateSpace:  (A, B, C, D)
 
         Each argument can be an array or sequence.
 
     Notes
     -----
-    `lti` instances do not exist directly. Instead `lti` creates an instance of
-    one of its subclasses: SateSpace, TransferFunction or ZerosPolesGain.
+    `lti` instances do not exist directly. Instead, `lti` creates an instance
+    of one of its subclasses: SateSpace, TransferFunction or ZerosPolesGain.
 
     """
     def __new__(cls, *system):
@@ -506,12 +506,12 @@ class TransferFunction(lti):
 
     Parameters
     ----------
-    args : arguments
+    system : arguments
         The `TransferFunction` class can be instantiated with 1 or 2 arguments.
-        The following gives the number of elements in the tuple and the
+        The following gives the number of input arguments and their
         interpretation:
 
-            * 1: (lti system: SateSpace, TransferFunction or ZeroPoleGain)
+            * 1: (lti system: SateSpace, TransferFunction or ZerosPolesGain)
             * 2: (numerator, denominator)
 
     """
@@ -531,7 +531,7 @@ class TransferFunction(lti):
 
         Parameters
         ----------
-        args : arguments
+        system : arguments
             The following arguments are possible
             * an instance of the lti class (SateSpace, TransferFunction
               or ZerosPolesGain)
@@ -631,9 +631,9 @@ class ZerosPolesGain(lti):
 
     Parameters
     ----------
-    args : arguments
+    system : arguments
         The `ZerosPolesGain` class can be instantiated with 1 or 3 arguments.
-        The following gives the number of elements in the tuple and the
+        The following gives the number of input arguments and their
         interpretation:
 
             * 1: (lti system: SateSpace, TransferFunction or ZerosPolesGain)
@@ -652,11 +652,11 @@ class ZerosPolesGain(lti):
         return super(ZerosPolesGain, cls).__new__(cls)
 
     def __init__(self, *system):
-        """Initialize the zero, pole, gain LTI system
+        """Initialize the zeros, poles, gain LTI system
 
         Parameters
         ----------
-        args : arguments
+        systen : arguments
             The following arguments are possible
             * an instance of the lti class (SateSpace, TransferFunction,
               ZerosPolesGain)
@@ -767,9 +767,9 @@ class StateSpace(lti):
 
     Parameters
     ----------
-    args : arguments
+    system : arguments
         The `StateSpace` class can be instantiated with 1 or 4 arguments.
-        The following gives the number of elements in the tuple and the
+        The following gives the number of input arguments and their
         interpretation:
 
             * 1: (lti system: SateSpace, TransferFunction or ZerosPolesGain)
@@ -792,7 +792,7 @@ class StateSpace(lti):
 
         Parameters
         ----------
-        args : arguments
+        system : arguments
             The following arguments are possible
             * an instance of the lti class (SateSpace, TransferFunction,
               ZerosPolesGain)

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -548,11 +548,8 @@ class TransferFunction(lti):
     """
     def __new__(cls, *system):
         """Handle object conversion if input is an instance of lti."""
-        if len(system) == 1:
-            if isinstance(system[0], TransferFunction):
-                return copy.deepcopy(system[0])
-            if isinstance(system[0], lti):
-                return system[0].to_tf()
+        if len(system) == 1 and isinstance(system[0], lti):
+            return system[0].to_tf()
 
         # No special conversion needed
         return super(TransferFunction, cls).__new__(cls)
@@ -634,7 +631,7 @@ class TransferFunction(lti):
             The current system (copy)
 
         """
-        return self
+        return copy.deepcopy(self)
 
     def to_zpk(self):
         """
@@ -690,11 +687,8 @@ class ZerosPolesGain(lti):
     """
     def __new__(cls, *system):
         """Handle object conversion if input is an instance of `lti`"""
-        if len(system) == 1:
-            if isinstance(system[0], ZerosPolesGain):
-                return copy.deepcopy(system[0])
-            if isinstance(system[0], lti):
-                return system[0].to_zpk()
+        if len(system) == 1 and isinstance(system[0], lti):
+            return system[0].to_zpk()
 
         # No special conversion needed
         return super(ZerosPolesGain, cls).__new__(cls)
@@ -800,7 +794,7 @@ class ZerosPolesGain(lti):
             The current system (copy)
 
         """
-        return self
+        return copy.deepcopy(self)
 
     def to_ss(self):
         """
@@ -844,11 +838,8 @@ class StateSpace(lti):
     """
     def __new__(cls, *system):
         """Handle object conversion if input is an instance of `lti`"""
-        if len(system) == 1:
-            if isinstance(system[0], StateSpace):
-                return copy.deepcopy(system[0])
-            if isinstance(system[0], lti):
-                return system[0].to_ss()
+        if len(system) == 1 and isinstance(system[0], lti):
+            return system[0].to_ss()
 
         # No special conversion needed
         return super(StateSpace, cls).__new__(cls)
@@ -984,7 +975,7 @@ class StateSpace(lti):
             The current system (copy)
 
         """
-        return self
+        return copy.deepcopy(self)
 
 
 def lsim2(system, U=None, T=None, X0=None, **kwargs):

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -39,8 +39,9 @@ from .filter_design import tf2zpk, zpk2tf, normalize, freqs
 
 
 __all__ = ['tf2ss', 'ss2tf', 'abcd_normalize', 'zpk2ss', 'ss2zpk', 'lti',
-           'TransferFunction', 'ZerosPolesGain', 'StateSpace', 'lsim', 'lsim2', 'impulse', 'impulse2', 'step',
-           'step2', 'bode', 'freqresp', 'place_poles']
+           'TransferFunction', 'ZerosPolesGain', 'StateSpace', 'lsim',
+           'lsim2', 'impulse', 'impulse2', 'step', 'step2', 'bode',
+           'freqresp', 'place_poles']
 
 
 def tf2ss(num, den):

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -15,6 +15,8 @@ from __future__ import division, print_function, absolute_import
 #   Added pole placement
 # Mar 2015: Clancy Rowley
 #   Rewrote lsim
+# Mai 2015: Felix Berkenkamp
+#   Split lti class into subclasses
 #
 
 import warnings
@@ -293,11 +295,11 @@ class lti(object):
     Notes
     -----
     `lti` instances do not exist directly. Instead, `lti` creates an instance
-    of one of its subclasses: SateSpace, TransferFunction or ZerosPolesGain.
+    of one of its subclasses: StateSpace, TransferFunction or ZerosPolesGain.
 
     """
     def __new__(cls, *system):
-        """Create an instance of a the appropriate subclass."""
+        """Create an instance of the appropriate subclass."""
         if cls is lti:
             N = len(system)
             if N == 2:

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -441,7 +441,7 @@ class lti(object):
     def step2(self, X0=None, T=None, N=None, **kwargs):
         """
         Return the step response of a continuous-time system.
-        See `scipy.signal.step` for details.
+        See `scipy.signal.step2` for details.
         """
         return step2(self, X0=X0, T=T, N=N, **kwargs)
 

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -517,7 +517,10 @@ class TransferFunction(lti):
     """
     def __new__(cls, *args, **kwargs):
         """Handle object conversion if input is an instance of lti"""
-        if len(args) == 1 and isinstance(args[0], lti):
+        if len(args) == 1:
+            if isinstance(args[0], TransferFunction):
+                return copy.deepcopy(args[0])
+            if isinstance(args[0], lti):
                 return args[0].to_tf()
 
         # No special conversion needed
@@ -595,10 +598,10 @@ class TransferFunction(lti):
         Returns
         -------
         sys : instance of TransferFunction
-            Copy of current system
+            The current system (self)
 
         """
-        return copy.deepcopy(self)
+        return self
 
     def to_zpk(self):
         """Convert system representation to zeros, poles, gain.
@@ -639,7 +642,10 @@ class ZerosPolesGain(lti):
     """
     def __new__(cls, *args, **kwargs):
         """Handle object conversion if input is an instance of lti"""
-        if len(args) == 1 and isinstance(args[0], lti):
+        if len(args) == 1:
+            if isinstance(args[0], ZerosPolesGain):
+                return copy.deepcopy(args[0])
+            if isinstance(args[0], lti):
                 return args[0].to_zpk()
 
         # No special conversion needed
@@ -739,10 +745,10 @@ class ZerosPolesGain(lti):
         Returns
         -------
         sys : instance of ZerosPolesGain
-            Copy of the current system
+            The current system (self)
 
         """
-        return copy.deepcopy(self)
+        return self
 
     def to_ss(self):
         """Convert system representation to state space.
@@ -772,7 +778,10 @@ class StateSpace(lti):
     """
     def __new__(cls, *args, **kwargs):
         """Handle object conversion if input is an instance of lti"""
-        if len(args) == 1 and isinstance(args[0], lti):
+        if len(args) == 1:
+            if isinstance(args[0], StateSpace):
+                return copy.deepcopy(args[0])
+            if isinstance(args[0], lti):
                 return args[0].to_ss()
 
         # No special conversion needed
@@ -899,10 +908,10 @@ class StateSpace(lti):
         Returns
         -------
         sys : instance of StateSpace
-            Copy of the current system
+            The current system (self)
 
         """
-        return copy.deepcopy(self)
+        return self
 
 
 def lsim2(system, U=None, T=None, X0=None, **kwargs):

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -513,7 +513,7 @@ class TransferFunction(lti):
         The following gives the number of input arguments and their
         interpretation:
 
-            * 1: (lti system: SateSpace, TransferFunction or ZerosPolesGain)
+            * 1: (lti system: StateSpace, TransferFunction or ZerosPolesGain)
             * 2: (numerator, denominator)
 
     """
@@ -535,7 +535,7 @@ class TransferFunction(lti):
         ----------
         system : arguments
             The following arguments are possible
-            * an instance of the lti class (SateSpace, TransferFunction
+            * an instance of the lti class (StateSpace, TransferFunction
               or ZerosPolesGain)
             * (numerator, denominator)
 
@@ -638,7 +638,7 @@ class ZerosPolesGain(lti):
         The following gives the number of input arguments and their
         interpretation:
 
-            * 1: (lti system: SateSpace, TransferFunction or ZerosPolesGain)
+            * 1: (lti system: StateSpace, TransferFunction or ZerosPolesGain)
             * 3: (zeros, poles, gain)
 
     """
@@ -658,9 +658,9 @@ class ZerosPolesGain(lti):
 
         Parameters
         ----------
-        systen : arguments
+        system : arguments
             The following arguments are possible
-            * an instance of the lti class (SateSpace, TransferFunction,
+            * an instance of the lti class (StateSpace, TransferFunction,
               ZerosPolesGain)
             * (zeros, poles, gain)
 
@@ -678,7 +678,7 @@ class ZerosPolesGain(lti):
         self.zeros, self.poles, self.gain = system
 
     def __repr__(self):
-        """Return representation of the ZerosPolesGain systen"""
+        """Return representation of the ZerosPolesGain system"""
         return '{0}(\n{1},\n{2},\n{3}\n)'.format(
             self.__class__.__name__,
             repr(self.zeros),
@@ -718,7 +718,7 @@ class ZerosPolesGain(lti):
         self._gain = gain
 
     def _copy(self, system):
-        """Copy the parameters of another ZerosPolesGains system
+        """Copy the parameters of another ZerosPolesGain system
 
         Parameters
         ----------
@@ -774,7 +774,7 @@ class StateSpace(lti):
         The following gives the number of input arguments and their
         interpretation:
 
-            * 1: (lti system: SateSpace, TransferFunction or ZerosPolesGain)
+            * 1: (lti system: StateSpace, TransferFunction or ZerosPolesGain)
             * 4: (A, B, C, D)
 
     """
@@ -796,7 +796,7 @@ class StateSpace(lti):
         ----------
         system : arguments
             The following arguments are possible
-            * an instance of the lti class (SateSpace, TransferFunction,
+            * an instance of the lti class (StateSpace, TransferFunction,
               ZerosPolesGain)
             * (A, B, C, D) state-space matrices
 
@@ -815,7 +815,7 @@ class StateSpace(lti):
         self.A, self.B, self.C, self.D = abcd_normalize(*system)
 
     def __repr__(self):
-        """Return representation of the state space systen"""
+        """Return representation of the state space system"""
         return '{0}(\n{1},\n{2},\n{3},\n{4}\n)'.format(
             self.__class__.__name__,
             repr(self.A),

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -15,7 +15,7 @@ from __future__ import division, print_function, absolute_import
 #   Added pole placement
 # Mar 2015: Clancy Rowley
 #   Rewrote lsim
-# Mai 2015: Felix Berkenkamp
+# May 2015: Felix Berkenkamp
 #   Split lti class into subclasses
 #
 

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -527,7 +527,7 @@ class tf(lti):
 
     @num.setter
     def num(self, num):
-        self._num = num
+        self._num = atleast_1d(num)
 
         # Update dimensions
         if len(self.num.shape) > 1:
@@ -542,7 +542,7 @@ class tf(lti):
 
     @den.setter
     def den(self, den):
-        self._den = den
+        self._den = atleast_1d(den)
 
     def copy(self, system, copy=True):
         """Copy the parameters of another tf system
@@ -646,8 +646,7 @@ class zpk(lti):
 
     @zeros.setter
     def zeros(self, zeros):
-        zeros = numpy.asarray(zeros)
-        self._zeros = zeros
+        self._zeros = numpy.asarray(zeros)
 
         # Update dimensions
         if len(self.zeros.shape) > 1:
@@ -662,8 +661,7 @@ class zpk(lti):
 
     @poles.setter
     def poles(self, poles):
-        poles = numpy.asarray(poles)
-        self._poles = poles
+        self._poles = numpy.asarray(poles)
 
     @property
     def gain(self):
@@ -778,7 +776,7 @@ class ss(lti):
 
     @A.setter
     def A(self, A):
-        self._A = A
+        self._A = _atleast_2d_or_none(A)
 
     @property
     def B(self):
@@ -786,7 +784,7 @@ class ss(lti):
 
     @B.setter
     def B(self, B):
-        self._B = B
+        self._B = _atleast_2d_or_none(B)
         self.inputs = self.B.shape[-1]
 
     @property
@@ -795,7 +793,7 @@ class ss(lti):
 
     @C.setter
     def C(self, C):
-        self._C = C
+        self._C = _atleast_2d_or_none(C)
         self.outputs = self.C.shape[0]
 
     @property
@@ -804,7 +802,7 @@ class ss(lti):
 
     @D.setter
     def D(self, D):
-        self._D = D
+        self._D = _atleast_2d_or_none(D)
 
     def copy(self, system, copy=True):
         """Copy the parameters of another ss system

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -282,7 +282,7 @@ class lti(object):
 
     Parameters
     ----------
-    system : lti system arguments
+    *system : arguments
         The `lti` class can be instantiated with either 2, 3 or 4 arguments.
         The following gives the number of arguments and the corresponding
         subclass that is created:
@@ -503,12 +503,12 @@ class TransferFunction(lti):
 
     Represents the system as the transfer function
     :math:`H(s)=\sum_i b[i] s^i / \sum_j a[j] s^i`, where :math:`a` are
-    elements of the numerator `num` and :math:`b` are the element of the
+    elements of the numerator `num` and :math:`b` are the elements of the
     denominator `den`.
 
     Parameters
     ----------
-    system : arguments
+    *system : arguments
         The `TransferFunction` class can be instantiated with 1 or 2 arguments.
         The following gives the number of input arguments and their
         interpretation:
@@ -534,17 +534,7 @@ class TransferFunction(lti):
         return super(TransferFunction, cls).__new__(cls)
 
     def __init__(self, *system):
-        """Initialize the state space LTI system.
-
-        Parameters
-        ----------
-        system : arguments
-            The following arguments are possible
-                * an instance of the lti class (`StateSpace`, `TransferFunction`
-                  or `ZerosPolesGain`)
-                * (numerator, denominator)
-
-        """
+        """Initialize the state space LTI system."""
         # Conversion of lti instances is handled in __new__
         if isinstance(system[0], lti):
             return
@@ -647,7 +637,7 @@ class ZerosPolesGain(lti):
 
     Parameters
     ----------
-    system : arguments
+    *system : arguments
         The `ZerosPolesGain` class can be instantiated with 1 or 3 arguments.
         The following gives the number of input arguments and their
         interpretation:
@@ -673,18 +663,7 @@ class ZerosPolesGain(lti):
         return super(ZerosPolesGain, cls).__new__(cls)
 
     def __init__(self, *system):
-        """
-        Initialize the zeros, poles, gain LTI system
-
-        Parameters
-        ----------
-        system : arguments
-            The following arguments are possible
-                * an instance of the `lti` class (`StateSpace`,
-                  `TransferFunction`, `ZerosPolesGain`)
-                * (zeros, poles, gain)
-
-        """
+        """Initialize the zeros, poles, gain LTI system."""
         # Conversion of lti instances is handled in __new__
         if isinstance(system[0], lti):
             return
@@ -795,11 +774,9 @@ class StateSpace(lti):
     Represents the system as the first order differential equation
     :math:`\dot{x} = A x + B u`.
 
-
-
     Parameters
     ----------
-    system : arguments
+    *system : arguments
         The `StateSpace` class can be instantiated with 1 or 4 arguments.
         The following gives the number of input arguments and their
         interpretation:
@@ -824,18 +801,7 @@ class StateSpace(lti):
         return super(StateSpace, cls).__new__(cls)
 
     def __init__(self, *system):
-        """
-        Initialize the state space LTI system.
-
-        Parameters
-        ----------
-        system : arguments
-            The following arguments are possible
-                * an instance of the `lti` class (`StateSpace`,
-                  `TransferFunction`, `ZerosPolesGain`)
-                * (A, B, C, D) state-space matrices
-
-        """
+        """Initialize the state space LTI system."""
         # Conversion of lti instances is handled in __new__
         if isinstance(system[0], lti):
             return

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -424,6 +424,13 @@ class lti(object):
         """
         return impulse(self, X0=X0, T=T, N=N)
 
+    def impulse2(self, X0=None, T=None, N=None, **kwargs):
+        """
+        Return the impulse response of a continuous-time system.
+        See `scipy.signal.impulse2` for details.
+        """
+        return impulse2(self, X0=X0, T=T, N=N, **kwargs)
+
     def step(self, X0=None, T=None, N=None):
         """
         Return the step response of a continuous-time system.
@@ -431,12 +438,26 @@ class lti(object):
         """
         return step(self, X0=X0, T=T, N=N)
 
+    def step2(self, X0=None, T=None, N=None, **kwargs):
+        """
+        Return the step response of a continuous-time system.
+        See `scipy.signal.step` for details.
+        """
+        return step2(self, X0=X0, T=T, N=N, **kwargs)
+
     def output(self, U, T, X0=None):
         """
         Return the response of a continuous-time system to input `U`.
         See `scipy.signal.lsim` for details.
         """
         return lsim(self, U, T, X0=X0)
+
+    def output2(self, U, T, X0=None, **kwargs):
+        """
+        Return the response of a continuous-time system to input `U`.
+        See `scipy.signal.lsim2` for details.
+        """
+        return lsim2(self, U, T, X0=X0, **kwargs)
 
     def bode(self, w=None, n=100):
         """

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -479,7 +479,7 @@ class lti(object):
 
 
 class tf(lti):
-    """Linear Time Invariant system class in state-space form.
+    """Linear Time Invariant system class in transfer function form.
 
     Parameters
     ----------

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -296,10 +296,10 @@ class lti(object):
     one of its subclasses: SateSpace, TransferFunction or ZerosPolesGain.
 
     """
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *system):
         """Create an instance of a the appropriate subclass."""
         if cls is lti:
-            N = len(args)
+            N = len(system)
             if N == 2:
                 return super(lti, cls).__new__(TransferFunction)
             elif N == 3:
@@ -311,7 +311,7 @@ class lti(object):
         # __new__ was called from a subclass, let it call its own functions
         return super(lti, cls).__new__(cls)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *system):
         """Initialize the `lti` baseclass.
 
         The heavy lifting is done by the subclasses.
@@ -515,18 +515,18 @@ class TransferFunction(lti):
             * 2: (numerator, denominator)
 
     """
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *system):
         """Handle object conversion if input is an instance of lti"""
-        if len(args) == 1:
-            if isinstance(args[0], TransferFunction):
-                return copy.deepcopy(args[0])
-            if isinstance(args[0], lti):
-                return args[0].to_tf()
+        if len(system) == 1:
+            if isinstance(system[0], TransferFunction):
+                return copy.deepcopy(system[0])
+            if isinstance(system[0], lti):
+                return system[0].to_tf()
 
         # No special conversion needed
         return super(TransferFunction, cls).__new__(cls)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *system):
         """Initialize the state space LTI system
 
         Parameters
@@ -539,15 +539,15 @@ class TransferFunction(lti):
 
         """
         # Conversion of lti instances is handled in __new__
-        if isinstance(args[0], lti):
+        if isinstance(system[0], lti):
             return
 
-        super(TransferFunction, self).__init__(self, *args, **kwargs)
+        super(TransferFunction, self).__init__(self, *system)
 
         self._num = None
         self._den = None
 
-        self.num, self.den = normalize(*args)
+        self.num, self.den = normalize(*system)
 
     def __repr__(self):
         """Return representation of the system's transfer function"""
@@ -640,18 +640,18 @@ class ZerosPolesGain(lti):
             * 3: (zeros, poles, gain)
 
     """
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *system):
         """Handle object conversion if input is an instance of lti"""
-        if len(args) == 1:
-            if isinstance(args[0], ZerosPolesGain):
-                return copy.deepcopy(args[0])
-            if isinstance(args[0], lti):
-                return args[0].to_zpk()
+        if len(system) == 1:
+            if isinstance(system[0], ZerosPolesGain):
+                return copy.deepcopy(system[0])
+            if isinstance(system[0], lti):
+                return system[0].to_zpk()
 
         # No special conversion needed
         return super(ZerosPolesGain, cls).__new__(cls)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *system):
         """Initialize the zero, pole, gain LTI system
 
         Parameters
@@ -664,16 +664,16 @@ class ZerosPolesGain(lti):
 
         """
         # Conversion of lti instances is handled in __new__
-        if isinstance(args[0], lti):
+        if isinstance(system[0], lti):
             return
 
-        super(ZerosPolesGain, self).__init__(self, *args, **kwargs)
+        super(ZerosPolesGain, self).__init__(self, *system)
 
         self._zeros = None
         self._poles = None
         self._gain = None
 
-        self.zeros, self.poles, self.gain = args
+        self.zeros, self.poles, self.gain = system
 
     def __repr__(self):
         """Return representation of the ZerosPolesGain systen"""
@@ -776,18 +776,18 @@ class StateSpace(lti):
             * 4: (A, B, C, D)
 
     """
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *system):
         """Handle object conversion if input is an instance of lti"""
-        if len(args) == 1:
-            if isinstance(args[0], StateSpace):
-                return copy.deepcopy(args[0])
-            if isinstance(args[0], lti):
-                return args[0].to_ss()
+        if len(system) == 1:
+            if isinstance(system[0], StateSpace):
+                return copy.deepcopy(system[0])
+            if isinstance(system[0], lti):
+                return system[0].to_ss()
 
         # No special conversion needed
         return super(StateSpace, cls).__new__(cls)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *system):
         """Initialize the state space LTI system
 
         Parameters
@@ -800,17 +800,17 @@ class StateSpace(lti):
 
         """
         # Conversion of lti instances is handled in __new__
-        if isinstance(args[0], lti):
+        if isinstance(system[0], lti):
             return
 
-        super(StateSpace, self).__init__(self, *args, **kwargs)
+        super(StateSpace, self).__init__(self, *system)
 
         self._A = None
         self._B = None
         self._C = None
         self._D = None
 
-        self.A, self.B, self.C, self.D = abcd_normalize(*args)
+        self.A, self.B, self.C, self.D = abcd_normalize(*system)
 
     def __repr__(self):
         """Return representation of the state space systen"""

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -327,7 +327,7 @@ class lti(object):
         obj = self.to_tf()
         obj.num = num
         source_class = type(self)
-        self.copy(source_class(obj))
+        self._copy(source_class(obj))
 
     @property
     def den(self):
@@ -338,7 +338,7 @@ class lti(object):
         obj = self.to_tf()
         obj.den = den
         source_class = type(self)
-        self.copy(source_class(obj))
+        self._copy(source_class(obj))
 
     @property
     def zeros(self):
@@ -349,7 +349,7 @@ class lti(object):
         obj = self.to_zpk()
         obj.zeros = zeros
         source_class = type(self)
-        self.copy(source_class(obj))
+        self._copy(source_class(obj))
 
     @property
     def poles(self):
@@ -360,7 +360,7 @@ class lti(object):
         obj = self.to_zpk()
         obj.poles = poles
         source_class = type(self)
-        self.copy(source_class(obj))
+        self._copy(source_class(obj))
 
     @property
     def gain(self):
@@ -371,7 +371,7 @@ class lti(object):
         obj = self.to_zpk()
         obj.gain = gain
         source_class = type(self)
-        self.copy(source_class(obj))
+        self._copy(source_class(obj))
 
     @property
     def A(self):
@@ -382,7 +382,7 @@ class lti(object):
         obj = self.to_ss()
         obj.A = A
         source_class = type(self)
-        self.copy(source_class(obj))
+        self._copy(source_class(obj))
 
     @property
     def B(self):
@@ -393,7 +393,7 @@ class lti(object):
         obj = self.to_ss()
         obj.B = B
         source_class = type(self)
-        self.copy(source_class(obj))
+        self._copy(source_class(obj))
 
     @property
     def C(self):
@@ -404,7 +404,7 @@ class lti(object):
         obj = self.to_ss()
         obj.C = C
         source_class = type(self)
-        self.copy(source_class(obj))
+        self._copy(source_class(obj))
 
     @property
     def D(self):
@@ -415,7 +415,7 @@ class lti(object):
         obj = self.to_ss()
         obj.D = D
         source_class = type(self)
-        self.copy(source_class(obj))
+        self._copy(source_class(obj))
 
     def impulse(self, X0=None, T=None, N=None):
         """
@@ -554,7 +554,7 @@ class tf(lti):
     def den(self, den):
         self._den = atleast_1d(den)
 
-    def copy(self, system):
+    def _copy(self, system):
         """Copy the parameters of another tf system
 
         Parameters
@@ -685,7 +685,7 @@ class zpk(lti):
     def gain(self, gain):
         self._gain = gain
 
-    def copy(self, system):
+    def _copy(self, system):
         """Copy the parameters of another zpk system
 
         Parameters
@@ -822,7 +822,7 @@ class ss(lti):
     def D(self, D):
         self._D = _atleast_2d_or_none(D)
 
-    def copy(self, system):
+    def _copy(self, system):
         """Copy the parameters of another ss system
 
         Parameters

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -7,7 +7,8 @@ from numpy.testing import (assert_almost_equal, assert_equal, assert_allclose,
                            assert_, assert_raises, TestCase, run_module_suite)
 from scipy.signal.ltisys import (ss2tf, tf2ss, lsim2, impulse2, step2, lti,
                                  bode, freqresp, lsim, impulse, step,
-                                 abcd_normalize, place_poles)
+                                 abcd_normalize, place_poles,
+                                 TransferFunction, StateSpace, ZerosPolesGain)
 from scipy.signal.filter_design import BadCoefficients
 import scipy.linalg as linalg
 
@@ -640,12 +641,198 @@ class TestStep(_TestStepFuncs):
         step(([], [-1], 1+0j))
 
 
-def test_lti_instantiation():
-    # Test that lti can be instantiated with sequences, scalars.  See PR-225.
-    lti([1], [-1])
-    lti(np.array([]), np.array([-1]), 1)
-    lti([], [-1], 1)
-    lti([1], [-1], 1, 3)
+class TestLti(object):
+    """Test the lti base class"""
+    def test_lti_instantiation(self):
+        """
+        Test that lti can be instantiated with sequences, scalars.
+
+        See PR-225.
+        """
+        # TransferFunction
+        s = lti([1], [-1])
+        assert_(isinstance(s, TransferFunction))
+        assert_(isinstance(s, lti))
+
+        # ZerosPolesGain
+        s = lti(np.array([]), np.array([-1]), 1)
+        assert_(isinstance(s, ZerosPolesGain))
+        assert_(isinstance(s, lti))
+
+        # StateSpace
+        s = lti([], [-1], 1)
+        s = lti([1], [-1], 1, 3)
+        assert_(isinstance(s, StateSpace))
+        assert_(isinstance(s, lti))
+
+
+class TestStateSpace(object):
+    """Test StateSpace class"""
+
+    def test_initialization(self):
+        """Check that all initializations work"""
+        s = StateSpace(1, 1, 1, 1)
+        s = StateSpace([1], [2], [3], [4])
+        s = StateSpace(np.array([[1, 2], [3, 4]]), np.array([[1], [2]]),
+                       np.array([[1, 0]]), np.array([[0]]))
+
+    def _compare_systems(self, sys1, sys2):
+        """Compare the contents of two systems"""
+        assert_equal(sys1.A, sys2.A)
+        assert_equal(sys1.B, sys2.B)
+        assert_equal(sys1.C, sys2.C)
+        assert_equal(sys1.D, sys2.D)
+
+    def test_conversion(self):
+        """Check the conversion functions"""
+        s = StateSpace(1, 2, 3, 4)
+        assert_(isinstance(s.to_ss(), StateSpace))
+        assert_(isinstance(s.to_tf(), TransferFunction))
+        assert_(isinstance(s.to_zpk(), ZerosPolesGain))
+
+        # Make sure copies work
+        assert_(StateSpace(s) is not s)
+        assert_(s.to_ss() is not s)
+
+    def test_properties(self):
+        """
+        Test setters/getters for cross class properties.
+
+        This implicitly tests to_tf() and to_zpk()
+        """
+        # Getters
+        s = StateSpace(1, 1, 1, 1)
+        assert_equal(s.num, [1, 0])
+        assert_equal(s.den, [1, -1])
+        assert_equal(s.poles, [1])
+        assert_equal(s.zeros, [0])
+        assert_equal(s.gain, 1)
+
+        # transfer function setters
+        s2 = StateSpace(2, 2, 2, 2)
+        s2.num = [1, 0]
+        s2.den = [1, -1]
+        self._compare_systems(s, s2)
+
+        # zpk setters
+        s2 = StateSpace(2, 2, 2, 2)
+        s2.poles = 1
+        s2.zeros = 0
+        s2.gain = 1
+        self._compare_systems(s, s2)
+
+
+class TestTransferFunction(object):
+    """Test TransferFunction class"""
+
+    def test_initialization(self):
+        """Check that all initializations work"""
+        s = TransferFunction(1, 1)
+        s = TransferFunction([1], [2])
+        s = TransferFunction(np.array([1]), np.array([2]))
+
+    def _compare_systems(self, sys1, sys2):
+        """Compare the contents of two systems"""
+        assert_equal(sys1.num, sys2.num)
+        assert_equal(sys1.den, sys2.den)
+
+    def test_conversion(self):
+        """Check the conversion functions"""
+        s = TransferFunction([1, 0], [1, -1])
+        assert_(isinstance(s.to_ss(), StateSpace))
+        assert_(isinstance(s.to_tf(), TransferFunction))
+        assert_(isinstance(s.to_zpk(), ZerosPolesGain))
+
+        # Make sure copies work
+        assert_(TransferFunction(s) is not s)
+        assert_(s.to_tf() is not s)
+
+    def test_properties(self):
+        """
+        Test setters/getters for cross class properties.
+
+        This implicitly tests to_ss() and to_zpk()
+        """
+        # Getters
+        s = TransferFunction([1, 0], [1, -1])
+        assert_equal(s.poles, [1])
+        assert_equal(s.zeros, [0])
+        assert_equal(s.gain, 1)
+        assert_equal(s.A, 1)
+        assert_equal(s.B, 1)
+        assert_equal(s.C, 1)
+        assert_equal(s.D, 1)
+
+        # state space setters
+        s2 = TransferFunction([2, 3], [4, 5])
+        s2.A = 1
+        s2.B = 1
+        s2.C = 1
+        s2.D = 1
+        self._compare_systems(s, s2)
+
+        # zpk setters
+        s2 = TransferFunction([2, 3], [4, 5])
+        s2.poles = 1
+        s2.zeros = 0
+        s2.gain = 1
+        self._compare_systems(s, s2)
+
+
+class TestZerosPolesGain(object):
+    """Test ZerosPolesGain class"""
+
+    def test_initialization(self):
+        """Check that all initializations work"""
+        s = ZerosPolesGain(1, 1, 1)
+        s = ZerosPolesGain([1], [2], 1)
+        s = ZerosPolesGain(np.array([1]), np.array([2]), 1)
+
+    def _compare_systems(self, sys1, sys2):
+        """Compare the contents of two systems"""
+        assert_equal(sys1.poles, sys2.poles)
+        assert_equal(sys1.zeros, sys2.zeros)
+        assert_equal(sys1.gain, sys2.gain)
+
+    def test_conversion(self):
+        """Check the conversion functions"""
+        s = ZerosPolesGain(1, 2, 3)
+        assert_(isinstance(s.to_ss(), StateSpace))
+        assert_(isinstance(s.to_tf(), TransferFunction))
+        assert_(isinstance(s.to_zpk(), ZerosPolesGain))
+
+        # Make sure copies work
+        assert_(ZerosPolesGain(s) is not s)
+        assert_(s.to_zpk() is not s)
+
+    def test_properties(self):
+        """
+        Test setters/getters for cross class properties.
+
+        This implicitly tests to_ss() and to_tf()
+        """
+        # Getters
+        s = ZerosPolesGain(0, 1, 1)
+        assert_equal(s.num, [1, 0])
+        assert_equal(s.den, [1, -1])
+        assert_equal(s.A, 1)
+        assert_equal(s.B, 1)
+        assert_equal(s.C, 1)
+        assert_equal(s.D, 1)
+
+        # state space setters
+        s2 = ZerosPolesGain([2], [6], 3)
+        s2.A = 1
+        s2.B = 1
+        s2.C = 1
+        s2.D = 1
+        self._compare_systems(s, s2)
+
+        # tf setters
+        s2 = ZerosPolesGain([2], [5], 3)
+        s2.num = [1, 0]
+        s2.den = [1, -1]
+        self._compare_systems(s, s2)
 
 
 class Test_abcd_normalize(object):

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -642,13 +642,10 @@ class TestStep(_TestStepFuncs):
 
 
 class TestLti(object):
-    """Test the lti base class"""
     def test_lti_instantiation(self):
-        """
-        Test that lti can be instantiated with sequences, scalars.
+        # Test that lti can be instantiated with sequences, scalars.
+        # See PR-225.
 
-        See PR-225.
-        """
         # TransferFunction
         s = lti([1], [-1])
         assert_(isinstance(s, TransferFunction))
@@ -667,24 +664,22 @@ class TestLti(object):
 
 
 class TestStateSpace(object):
-    """Test StateSpace class"""
-
     def test_initialization(self):
-        """Check that all initializations work"""
+        # Check that all initializations work
         s = StateSpace(1, 1, 1, 1)
         s = StateSpace([1], [2], [3], [4])
         s = StateSpace(np.array([[1, 2], [3, 4]]), np.array([[1], [2]]),
                        np.array([[1, 0]]), np.array([[0]]))
 
     def _compare_systems(self, sys1, sys2):
-        """Compare the contents of two systems"""
+        # Compare the contents of two systems
         assert_equal(sys1.A, sys2.A)
         assert_equal(sys1.B, sys2.B)
         assert_equal(sys1.C, sys2.C)
         assert_equal(sys1.D, sys2.D)
 
     def test_conversion(self):
-        """Check the conversion functions"""
+        # Check the conversion functions
         s = StateSpace(1, 2, 3, 4)
         assert_(isinstance(s.to_ss(), StateSpace))
         assert_(isinstance(s.to_tf(), TransferFunction))
@@ -695,11 +690,9 @@ class TestStateSpace(object):
         assert_(s.to_ss() is not s)
 
     def test_properties(self):
-        """
-        Test setters/getters for cross class properties.
+        # Test setters/getters for cross class properties.
+        # This implicitly tests to_tf() and to_zpk()
 
-        This implicitly tests to_tf() and to_zpk()
-        """
         # Getters
         s = StateSpace(1, 1, 1, 1)
         assert_equal(s.num, [1, 0])
@@ -723,21 +716,19 @@ class TestStateSpace(object):
 
 
 class TestTransferFunction(object):
-    """Test TransferFunction class"""
-
     def test_initialization(self):
-        """Check that all initializations work"""
+        # Check that all initializations work
         s = TransferFunction(1, 1)
         s = TransferFunction([1], [2])
         s = TransferFunction(np.array([1]), np.array([2]))
 
     def _compare_systems(self, sys1, sys2):
-        """Compare the contents of two systems"""
+        # Compare the contents of two systems
         assert_equal(sys1.num, sys2.num)
         assert_equal(sys1.den, sys2.den)
 
     def test_conversion(self):
-        """Check the conversion functions"""
+        # Check the conversion functions
         s = TransferFunction([1, 0], [1, -1])
         assert_(isinstance(s.to_ss(), StateSpace))
         assert_(isinstance(s.to_tf(), TransferFunction))
@@ -748,11 +739,9 @@ class TestTransferFunction(object):
         assert_(s.to_tf() is not s)
 
     def test_properties(self):
-        """
-        Test setters/getters for cross class properties.
+        # Test setters/getters for cross class properties.
+        # This implicitly tests to_ss() and to_zpk()
 
-        This implicitly tests to_ss() and to_zpk()
-        """
         # Getters
         s = TransferFunction([1, 0], [1, -1])
         assert_equal(s.poles, [1])
@@ -780,22 +769,20 @@ class TestTransferFunction(object):
 
 
 class TestZerosPolesGain(object):
-    """Test ZerosPolesGain class"""
-
     def test_initialization(self):
-        """Check that all initializations work"""
+        # Check that all initializations work
         s = ZerosPolesGain(1, 1, 1)
         s = ZerosPolesGain([1], [2], 1)
         s = ZerosPolesGain(np.array([1]), np.array([2]), 1)
 
     def _compare_systems(self, sys1, sys2):
-        """Compare the contents of two systems"""
+        #Compare the contents of two systems
         assert_equal(sys1.poles, sys2.poles)
         assert_equal(sys1.zeros, sys2.zeros)
         assert_equal(sys1.gain, sys2.gain)
 
     def test_conversion(self):
-        """Check the conversion functions"""
+        #Check the conversion functions
         s = ZerosPolesGain(1, 2, 3)
         assert_(isinstance(s.to_ss(), StateSpace))
         assert_(isinstance(s.to_tf(), TransferFunction))
@@ -806,11 +793,9 @@ class TestZerosPolesGain(object):
         assert_(s.to_zpk() is not s)
 
     def test_properties(self):
-        """
-        Test setters/getters for cross class properties.
+        # Test setters/getters for cross class properties.
+        # This implicitly tests to_ss() and to_tf()
 
-        This implicitly tests to_ss() and to_tf()
-        """
         # Getters
         s = ZerosPolesGain(0, 1, 1)
         assert_equal(s.num, [1, 0])


### PR DESCRIPTION
new classes: ss, tf, zpk
- backwards compatible
- Remove redundant information in lti
- Make internal transformations more transparent
