### PR TITLE
Fix build with Intel MKL on Linux

### DIFF
--- a/scipy/_build_utils/_fortran.py
+++ b/scipy/_build_utils/_fortran.py
@@ -33,7 +33,7 @@ def uses_accelerate(info):
 
 
 def uses_mkl(info):
-    r_mkl = re.compile("mkl_core")
+    r_mkl = re.compile("mkl")
     libraries = info.get('libraries', '')
     for library in libraries:
         if r_mkl.search(library):

--- a/scipy/_build_utils/_fortran.py
+++ b/scipy/_build_utils/_fortran.py
@@ -46,8 +46,7 @@ def needs_g77_abi_wrapper(info):
     """Returns True if g77 ABI wrapper must be used."""
     if uses_accelerate(info) or uses_veclib(info):
         return True
-    # XXX: is this really true only on Mac OS X ?
-    elif uses_mkl(info) and sys.platform == "darwin":
+    elif uses_mkl(info):
         return True
     else:
         return False


### PR DESCRIPTION
These commits fix issues #4520 and #4521 and I can successfully build SciPy on RHEL 6.6 with GCC 4.4.7.

There are no segfaults and only one test fails:

```
test_iterative.test_convergence:
AssertionError: residual (0.144597) not smaller than tolerance 0.142829
```
