### PR TITLE
PEP8: relax whitespace requirements

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,5 +38,5 @@ commands=python {toxinidir}/runtests.py -n -m full {posargs:}
 [pep8]
 max_line_length=79
 statistics = True
-ignore = E121,E122,E123,E125,E126,E127,E128,E226,E231,E265,E302,E501,E712,W291,W293,W391
+ignore = E121,E122,E123,E125,E126,E127,E128,E201,E202,E221,E222,E225,E226,E231,E265,E302,E501,E712,W291,W293,W391
 exclude = scipy/sparse/linalg/dsolve/umfpack/_umfpack.py,scipy/sparse/sparsetools/bsr.py,scipy/sparse/sparsetools/coo.py,scipy/sparse/sparsetools/csc.py,scipy/sparse/sparsetools/csgraph.py,scipy/sparse/sparsetools/csr.py,scipy/sparse/sparsetools/dia.py,scipy/__config__.py


### PR DESCRIPTION
This PR ignores the pep8 violations that may have been false positives in https://github.com/scipy/scipy/pull/4587.  This is just an option, and I don't necessarily expect this PR to be merged.  The intention is to seek a balance encouraging contributions by domain experts like @raoulbq.
