### PR TITLE
BUG, TST: Several issues with scipy.signal.residue

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2380,7 +2380,7 @@ def residue(b, a, tol=1e-3, rtype='avg'):
     r : ndarray
         Residues.
     p : ndarray
-        Poles.
+        Poles order by magnitude in ascending order.
     k : ndarray
         Coefficients of the direct polynomial term.
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2160,13 +2160,9 @@ def cmplx_sort(p):
     array([1.+0.j, 1.+1.j, 3.+0.j, 4.+0.j])
     >>> indx
     array([0, 2, 3, 1])
-
     """
     p = asarray(p)
-    if iscomplexobj(p):
-        indx = argsort(abs(p))
-    else:
-        indx = argsort(p)
+    indx = argsort(abs(p))
     return take(p, indx, 0), indx
 
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2389,11 +2389,18 @@ def residue(b, a, tol=1e-3, rtype='avg'):
     invres, residuez, numpy.poly, unique_roots
 
     """
+    b = np.trim_zeros(np.atleast_1d(b), 'f')
+    a = np.trim_zeros(np.atleast_1d(a), 'f')
 
-    b, a = map(asarray, (b, a))
+    if a.size == 0:
+        raise ValueError("Denominator `a` is zero.")
+
+    p = roots(a)
+    if b.size == 0:
+        return np.zeros(p.shape), p, np.array([])
+
     rscale = a[0]
     k, b = polydiv(b, a)
-    p = roots(a)
     r = p * 0.0
     pout, mult = unique_roots(p, tol=tol, rtype=rtype)
     p = []
@@ -2422,7 +2429,7 @@ def residue(b, a, tol=1e-3, rtype='avg'):
             r[indx + m - 1] = (polyval(bn, pout[n]) / polyval(an, pout[n]) /
                                factorial(sig - m))
         indx += sig
-    return r / rscale, p, k
+    return r / rscale, p, np.trim_zeros(k, 'f')
 
 
 def residuez(b, a, tol=1e-3, rtype='avg'):

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2403,6 +2403,9 @@ def residue(b, a, tol=1e-3, rtype='avg'):
     k, b = polydiv(b, a)
     r = p * 0.0
     pout, mult = unique_roots(p, tol=tol, rtype=rtype)
+    pout, order = cmplx_sort(pout)
+    mult = mult[order]
+
     p = []
     for n in range(len(pout)):
         p.extend([pout[n]] * mult[n])

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -25,7 +25,7 @@ from scipy.signal import (
     fftconvolve, oaconvolve, choose_conv_method,
     hilbert, hilbert2, lfilter, lfilter_zi, filtfilt, butter, zpk2tf, zpk2sos,
     invres, invresz, vectorstrength, lfiltic, tf2sos, sosfilt, sosfiltfilt,
-    sosfilt_zi, tf2zpk, BadCoefficients, detrend, unique_roots)
+    sosfilt_zi, tf2zpk, BadCoefficients, detrend, unique_roots, residue)
 from scipy.signal.windows import hann
 from scipy.signal.signaltools import _filtfilt_gust
 
@@ -2507,6 +2507,108 @@ class TestHilbert2(object):
 
 
 class TestPartialFractionExpansion(object):
+    def test_residue_general(self):
+        # Test are taken from issue #4464, note that poles in scipy are
+        # in increasing by absolute value order, opposite to MATLAB.
+        r, p, k = residue([5, 3, -2, 7], [-4, 0, 8, 3])
+        assert_almost_equal(r, [1.3320, -0.6653, -1.4167], decimal=4)
+        assert_almost_equal(p, [-0.4093, -1.1644, 1.5737], decimal=4)
+        assert_almost_equal(k, [-1.2500], decimal=4)
+
+        r, p, k = residue([-4, 8], [1, 6, 8])
+        assert_almost_equal(r, [8, -12])
+        assert_almost_equal(p, [-2, -4])
+        assert_equal(k.size, 0)
+
+        r, p, k = residue([4, 1], [1, -1, -2])
+        assert_almost_equal(r, [1, 3])
+        assert_almost_equal(p, [-1, 2])
+        assert_equal(k.size, 0)
+
+        r, p, k = residue([4, 3], [2, -3.4, 1.98, -0.406])
+        order = np.argsort(p)
+        assert_almost_equal(r[order],
+                            [-18.125 - 13.125j, -18.125 + 13.125j, 36.25])
+        assert_almost_equal(p[order], [0.5 - 0.2j, 0.5 + 0.2j, 0.7])
+        assert_equal(k.size, 0)
+
+        r, p, k = residue([2, 1], [1, 5, 8, 4])
+        assert_almost_equal(np.sort(r), [-1, 1, 3])
+        assert_almost_equal(np.sort(p), [-2, -2, -1])
+        assert_equal(k.size, 0)
+
+        r, p, k = residue([3, -1.1, 0.88, -2.396, 1.348],
+                          [1, -0.7, -0.14, 0.048])
+        assert_almost_equal(r, [-3, 4, 1])
+        assert_almost_equal(p, [0.2, -0.3, 0.8])
+        assert_almost_equal(k, [3, 1])
+
+        r, p, k = residue([1], [1, 2, -3])
+        assert_almost_equal(r, [0.25, -0.25])
+        assert_almost_equal(p, [1, -3])
+        assert_equal(k.size, 0)
+
+        r, p, k = residue([1, 0, -5], [1, 0, 0, 0, -1])
+        order = np.argsort(p)
+        assert_almost_equal(r[order], [1, 1.5j, -1.5j, -1])
+        assert_almost_equal(p[order], [-1, -1j, 1j, 1])
+        assert_equal(k.size, 0)
+
+        r, p, k = residue([3, 8, 6], [1, 3, 3, 1])
+        assert_almost_equal(np.sort(r), [1, 2, 3])
+        assert_allclose(p, -1)
+        assert_equal(k.size, 0)
+
+        r, p, k = residue([3, -1], [1, -3, 2])
+        assert_almost_equal(r, [-2, 5])
+        assert_almost_equal(p, [1, 2])
+        assert_equal(k.size, 0)
+
+        r, p, k = residue([2, 3, -1], [1, -3, 2])
+        assert_almost_equal(r, [-4, 13])
+        assert_almost_equal(p, [1, 2])
+        assert_almost_equal(k, [2])
+
+        r, p, k = residue([7, 2, 3, -1], [1, -3, 2])
+        assert_almost_equal(r, [-11, 69])
+        assert_almost_equal(p, [1, 2])
+        assert_almost_equal(k, [7, 23])
+
+        r, p, k = residue([2, 3, -1], [1, -3, 4, -2])
+        order = np.argsort(p)
+        assert_almost_equal(r[order], [4, -1 + 3.5j, -1 - 3.5j])
+        assert_almost_equal(p[order], [1, 1 - 1j, 1 + 1j])
+        assert_almost_equal(k.size, 0)
+
+    def test_residue_leading_zeros(self):
+        # Leading zeros in numerator or denominator must not affect the answer.
+        r0, p0, k0 = residue([5, 3, -2, 7], [-4, 0, 8, 3])
+        r1, p1, k1 = residue([0, 5, 3, -2, 7], [-4, 0, 8, 3])
+        r2, p2, k2 = residue([5, 3, -2, 7], [0, -4, 0, 8, 3])
+        r3, p3, k3 = residue([0, 0, 5, 3, -2, 7], [0, 0, 0, -4, 0, 8, 3])
+        assert_almost_equal(r0, r1)
+        assert_almost_equal(r0, r2)
+        assert_almost_equal(r0, r3)
+        assert_almost_equal(p0, p1)
+        assert_almost_equal(p0, p2)
+        assert_almost_equal(p0, p3)
+        assert_almost_equal(k0, k1)
+        assert_almost_equal(k0, k2)
+        assert_almost_equal(k0, k3)
+
+    def test_resiude_degenerate(self):
+        # Several tests for zero numerator and denominator.
+        r, p, k = residue([0, 0], [1, 6, 8])
+        assert_almost_equal(r, [0, 0])
+        assert_almost_equal(p, [-4, -2])
+        assert_equal(k.size, 0)
+
+        r, p, k = residue(0, 1)
+        assert_equal(r.size, 0)
+        assert_equal(p.size, 0)
+        assert_equal(k.size, 0)
+
+        assert_raises(ValueError, residue, 1, 0)
 
     def test_invresz_one_coefficient_bug(self):
         # Regression test for issue in gh-4646.


### PR DESCRIPTION
Hi! 

This is the partial fix of #4562, #4464, #4561. So far I worked only with `residue`. But if you generally approve I'll also take care of `residuez`.

Some notes:
1. If `k` (direct polynomial term) is zero, an empty array is returned.
2. All poles and residuals are returned, even if residuals are zero.
3. I changed `cmplx_sort` such that it always sorts by the magnitude, i.e. absolute value. This is consistent with the docstring and makes more sense from mathematical point of view. Previously it sorted complex arrays by absolute value, and real arrays by the values itself.
