### PR TITLE
ENH: Wrap LAPACK *lange functions for matrix norms

### DIFF
--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -8,8 +8,8 @@
 ! Additions by Travis Oliphant, Tiziano Zito, Collin RM Stocks, Fabian Pedregosa
 !              Skipper Seabold
 !
-! <prefix2=s,d> <ctype2=float,double> <ftype2=real,double precision>
-! <prefix2c=c,z> <ftype2c=complex,double complex> <ctype2c=complex_float,complex_double>
+! <prefix2=s,d> <ctype2=float,double> <ftype2=real,double precision> <wrap2=ws,d>
+! <prefix2c=c,z> <ftype2c=complex,double complex> <ctype2c=complex_float,complex_double> <wrap2c=wc,z>
 
 python module _flapack
 interface
@@ -89,28 +89,28 @@ interface
    end subroutine <prefix2c>gges
 
    subroutine <prefix2>pbtrf(lower,n,kd,ab,ldab,info)
-   
+
      ! Compute Cholesky decomposition of banded symmetric positive definite
      ! matrix:
      ! A = U^T * U, C = U if lower = 0
      ! A = L * L^T, C = L if lower = 1
      ! C is triangular matrix of the corresponding Cholesky decomposition.
 
-     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,ab,&ldab,&info); 
+     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,ab,&ldab,&info);
      callprotoargument char*,int*,int*,<ctype2>*,int*,int*
 
      integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
      integer intent(hide),depend(ab) :: n=shape(ab,1)
      integer intent(hide),depend(ab) :: kd=shape(ab,0)-1
-     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0   
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
      <ftype2> dimension(ldab,n),intent(in,out,copy,out=c) :: ab
      integer intent(out) :: info
-     
+
    end subroutine <prefix2>pbtrf
 
    subroutine <prefix2c>pbtrf(lower,n,kd,ab,ldab,info)
-   
+
 
      ! Compute Cholesky decomposition of banded symmetric positive definite
      ! matrix:
@@ -118,17 +118,17 @@ interface
      ! A = L * L^H, C = L if lower = 1
      ! C is triangular matrix of the corresponding Cholesky decomposition.
 
-     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,ab,&ldab,&info); 
+     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,ab,&ldab,&info);
      callprotoargument char*,int*,int*,<ctype2c>*,int*,int*
 
      integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
      integer intent(hide),depend(ab) :: n=shape(ab,1)
      integer intent(hide),depend(ab) :: kd=shape(ab,0)-1
-     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0   
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
      <ftype2c> dimension(ldab,n),intent(in,out,copy,out=c) :: ab
      integer intent(out) :: info
-     
+
    end subroutine <prefix2c>pbtrf
 
 
@@ -141,7 +141,7 @@ interface
      ! A = U^T * U, AB = U if lower = 0
      ! A = L * L^T, AB = L if lower = 1
 
-     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,&nrhs,ab,&ldab,b,&ldb,&info); 
+     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,&nrhs,ab,&ldab,b,&ldb,&info);
      callprotoargument char*,int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
 
      integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
@@ -149,12 +149,12 @@ interface
      integer intent(hide),depend(ab) :: kd=shape(ab,0)-1
      integer intent(hide),depend(b) :: ldb=shape(b,0)
      integer intent(hide),depend(b) :: nrhs=shape(b,1)
-     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0   
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
      <ftype2> dimension(ldb, nrhs),intent(in,out,copy,out=x) :: b
      <ftype2> dimension(ldab,n),intent(in) :: ab
      integer intent(out) :: info
-     
+
    end subroutine <tchar=s,d>pbtrs
 
    subroutine <prefix2c>pbtrs(lower, n, kd, nrhs, ab, ldab, b, ldb, info)
@@ -166,7 +166,7 @@ interface
      ! A = U^T * U, AB = U if lower = 0
      ! A = L * L^T, AB = L if lower = 1
 
-     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,&nrhs,ab,&ldab,b,&ldb,&info); 
+     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,&nrhs,ab,&ldab,b,&ldb,&info);
      callprotoargument char*,int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*
 
      integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
@@ -179,7 +179,7 @@ interface
      <ftype2c> dimension(ldb, nrhs),intent(in,out,copy,out=x) :: b
      <ftype2c> dimension(ldab,n),intent(in) :: ab
      integer intent(out) :: info
-     
+
    end subroutine <prefix2c>pbtrs
 
 
@@ -188,7 +188,7 @@ interface
      ! Solve a system of linear equations A*X = B with a triangular
      ! matrix A.
 
-     callstatement (*f2py_func)((lower?"L":"U"),(trans?(trans==2?"C":"T"):"N"),(unitdiag?"U":"N"),&n,&nrhs,a,&lda,b,&ldb,&info); 
+     callstatement (*f2py_func)((lower?"L":"U"),(trans?(trans==2?"C":"T"):"N"),(unitdiag?"U":"N"),&n,&nrhs,a,&lda,b,&ldb,&info);
      callprotoargument char*,char*,char*,int*,int*,<ctype>*,int*,<ctype>*,int*,int*
 
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
@@ -206,7 +206,7 @@ interface
 
 
    subroutine <prefix2>pbsv(lower,n,kd,nrhs,ab,ldab,b,ldb,info)
-   
+
      !
      ! Computes the solution to a real system of linear equations
      ! A * X = B,
@@ -221,7 +221,7 @@ interface
      !  subdiagonals as A.  The factored form of A is then used to solve the
      !  system of equations A * X = B.
 
-     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,&nrhs,ab,&ldab,b,&ldb,&info); 
+     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,&nrhs,ab,&ldab,b,&ldb,&info);
      callprotoargument char*,int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
 
      integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
@@ -229,16 +229,16 @@ interface
      integer intent(hide),depend(ab) :: kd=shape(ab,0)-1
      integer intent(hide),depend(b) :: ldb=shape(b,0)
      integer intent(hide),depend(b) :: nrhs=shape(b,1)
-     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0   
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
      <ftype2> dimension(ldb, nrhs),intent(in,out,copy,out=x) :: b
      <ftype2> dimension(ldab,n),intent(in,out,copy,out=c) :: ab
      integer intent(out) :: info
-     
+
    end subroutine <prefix2>pbsv
 
    subroutine <prefix2c>pbsv(lower,n,kd,nrhs,ab,ldab,b,ldb,info)
-   
+
      !
      ! Computes the solution to a real system of linear equations
      ! A * X = B,
@@ -253,7 +253,7 @@ interface
      !  subdiagonals as A.  The factored form of A is then used to solve the
      !  system of equations A * X = B.
 
-     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,&nrhs,ab,&ldab,b,&ldb,&info); 
+     callstatement (*f2py_func)((lower?"L":"U"),&n,&kd,&nrhs,ab,&ldab,b,&ldb,&info);
      callprotoargument char*,int*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*
 
      integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
@@ -261,12 +261,12 @@ interface
      integer intent(hide),depend(ab) :: kd=shape(ab,0)-1
      integer intent(hide),depend(b) :: ldb=shape(b,0)
      integer intent(hide),depend(b) :: nrhs=shape(b,1)
-     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0   
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
      <ftype2c> dimension(ldb, nrhs),intent(in,out,copy,out=x) :: b
      <ftype2c> dimension(ldab,n),intent(in,out,copy,out=c) :: ab
      integer intent(out) :: info
-     
+
    end subroutine <prefix2c>pbsv
 
    subroutine <prefix>ptsv(n, nrhs, d, e, b, info)
@@ -286,7 +286,7 @@ interface
    ! Balance general matrix a.
    ! hi,lo are such that ba[i][j]==0 if i>j and j=0...lo-1 or i=hi+1..n-1
    ! pivscale([0:lo], [lo:hi+1], [hi:n+1]) = (p1,d,p2) where (p1,p2)[j] is
-   ! the index of the row and column interchanged with row and column j. 
+   ! the index of the row and column interchanged with row and column j.
    ! d[j] is the scaling factor applied to row and column j.
    ! The order in which the interchanges are made is n-1 to hi+1, then 0 to lo-1.
    !
@@ -424,7 +424,7 @@ interface
    end subroutine <prefix2c>unghr_lwork
 
    subroutine <prefix>gbsv(n,kl,ku,nrhs,ab,piv,b,info)
-   ! 
+   !
    ! lub,piv,x,info = gbsv(kl,ku,ab,b,overwrite_ab=0,overwrite_b=0)
    ! Solve A * X = B
    ! A = P * L * U
@@ -1074,7 +1074,7 @@ interface
 
      <ftype2c>  dimension(ldvr,n),depend(ldvr),intent(out) :: vr
      integer intent(hide),depend(compute_vr,n) :: ldvr=(compute_vr?n:1)
-     
+
      integer optional,intent(in),depend(n) :: lwork=2*n
      check(lwork>=2*n) :: lwork
      <ftype2c> dimension(lwork),intent(hide),depend(lwork) :: work
@@ -1210,7 +1210,7 @@ interface
 
      integer optional,intent(in):: compute_v = 1
      check(compute_v==1||compute_v==0) compute_v
-     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0   
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
      integer intent(hide),depend(a):: n = shape(a,0)
      <ftype2> dimension(n,n),check(shape(a,0)==shape(a,1)) :: a
@@ -1239,7 +1239,7 @@ interface
 
      integer optional,intent(in):: compute_v = 1
      check(compute_v==1||compute_v==0) compute_v
-     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0   
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
      integer intent(hide),depend(a):: n = shape(a,0)
      <ftype2c> dimension(n,n),check(shape(a,0)==shape(a,1)) :: a
@@ -1270,7 +1270,7 @@ interface
 
      integer optional,intent(in):: compute_v = 1
      check(compute_v==1||compute_v==0) compute_v
-     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0   
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
      integer intent(hide),depend(a):: n = shape(a,0)
      <ftype2> dimension(n,n),check(shape(a,0)==shape(a,1)) :: a
@@ -1301,7 +1301,7 @@ interface
 
      integer optional,intent(in):: compute_v = 1
      check(compute_v==1||compute_v==0) compute_v
-     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0   
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
      integer intent(hide),depend(a):: n = shape(a,0)
      <ftype2c> dimension(n,n),check(shape(a,0)==shape(a,1)) :: a
@@ -1346,9 +1346,9 @@ interface
      integer intent(out) :: info
 
    end subroutine <prefix>posv
-        
+
    subroutine <prefix2>potrf(n,a,info,lower,clean)
-   
+
      ! c,info = potrf(a,lower=0,clean=1,overwrite_a=0)
      ! Compute Cholesky decomposition of symmetric positive defined matrix:
      ! A = U^T * U, C = U if lower = 0
@@ -1365,11 +1365,11 @@ interface
      <ftype2> dimension(n,n),intent(in,out,copy,out=c) :: a
      check(shape(a,0)==shape(a,1)) :: a
      integer intent(out) :: info
-     
+
    end subroutine <prefix2>potrf
 
    subroutine <prefix2c>potrf(n,a,info,lower,clean)
-   
+
      ! c,info = potrf(a,lower=0,clean=1,overwrite_a=0)
      ! Compute Cholesky decomposition of symmetric positive defined matrix:
      ! A = U^H * U, C = U if lower = 0
@@ -1386,7 +1386,7 @@ interface
      <ftype2c> dimension(n,n),intent(in,out,copy,out=c) :: a
      check(shape(a,0)==shape(a,1)) :: a
      integer intent(out) :: info
-     
+
    end subroutine <prefix2c>potrf
 
    subroutine <prefix>potrs(n,nrhs,c,b,info,lower)
@@ -1433,7 +1433,7 @@ interface
 
 
    subroutine <prefix>lauum(n,c,info,lower)
-   
+
      ! a,info = lauum(c,lower=0,overwrite_c=0)
      ! Compute product
      ! U^T * U, C = U if lower = 0
@@ -1444,16 +1444,16 @@ interface
      callprotoargument char*,int*,<ctype>*,int*,int*
 
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
-     
+
      integer depend(c),intent(hide):: n = shape(c,0)
      <ftype> dimension(n,n),intent(in,out,copy,out=a) :: c
      check(shape(c,0)==shape(c,1)) :: c
      integer intent(out) :: info
-     
+
    end subroutine <prefix>lauum
 
    subroutine <prefix>trtri(n,c,info,lower,unitdiag)
-   
+
      ! inv_c,info = trtri(c,lower=0,unitdiag=1,overwrite_c=0)
      ! Compute C inverse C^-1 where
      ! C = U if lower = 0
@@ -1466,27 +1466,27 @@ interface
 
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
      integer optional,intent(in),check(unitdiag==0||unitdiag==1) :: unitdiag = 0
-     
+
      integer depend(c),intent(hide):: n = shape(c,0)
      <ftype> dimension(n,n),intent(in,out,copy,out=inv_c) :: c
      check(shape(c,0)==shape(c,1)) :: c
      integer intent(out) :: info
-     
+
    end subroutine <prefix>trtri
 
    subroutine <prefix>trsyl(trana, tranb, isgn, m, n, a, lda, b, ldb, c, ldc, scale, info)
-   
+
      ! x,scale,info = trsyl(trana='N', tranb='N', isgn, a, b, c)
      !
      ! Solves the real Sylvester matrix equation:
      !
      !    op(A)*X + X*op(B) = scale*C or op(A)*X - X*op(B) = scale*C
      !
-     ! where A and B are both quasi-triangular matrices.  A and B must be in 
+     ! where A and B are both quasi-triangular matrices.  A and B must be in
      ! Schur canonical form.  op(A) and op(B) are specified via trana and tranb
      ! respectively, and may take the forms 'N' (no transpose), 'T' (transpose),
      ! or 'C' (conjugate transpose, where applicable) to indicate the operation
-     ! to be performed.  The value of isgn (1 or -1) specifies the sign of the 
+     ! to be performed.  The value of isgn (1 or -1) specifies the sign of the
      ! X*op(B) term in the equation.
      !
      ! Upon exit, x contains the solution, scale represnets scale factor, set
@@ -1495,9 +1495,9 @@ interface
      !
      !      0: success
      !      < 0: if info = -i, the i-th argument had an illegal value
-     !      1: A and B have common or very close eigenvalues; perturbed values 
+     !      1: A and B have common or very close eigenvalues; perturbed values
      !         were used to solve the equation
-     
+
      callstatement (*f2py_func)(trana,tranb,&isgn,&m,&n,a,&lda,b,&ldb,c,&ldc,&scale,&info)
      callprotoargument char*,char*,int*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctype>*,int*,<ctypereal>*,int*
 
@@ -1505,32 +1505,32 @@ interface
      character optional,intent(in),check(*tranb=='N'||*tranb=='T'||*tranb=='C'):: tranb='N'
 
      integer optional,intent(in),check(isgn==1||isgn==-1)::isgn=1
-     
+
      integer depend(a),intent(hide):: m = shape(a,0)
      integer depend(b),intent(hide):: n = shape(b,0)
-     
+
      <ftype> dimension(m,m),intent(in) :: a
      check(shape(a,0)==shape(a,1)) :: a
      integer depend(a),intent(hide):: lda = shape(a,0)
-     
+
      <ftype> dimension(n,n),intent(in) :: b
      check(shape(b,0)==shape(b,1)) :: b
      integer depend(b),intent(hide):: ldb = shape(b,0)
-     
+
      <ftype> dimension(m,n),intent(in,out,copy,out=x) :: c
      integer depend(c),intent(hide):: ldc = shape(c,0)
-     
+
      <ftypereal> intent(out) :: scale
-     
+
      integer intent(out) :: info
-     
+
    end subroutine <prefix>trsyl
 
    subroutine <prefix>laswp(n,a,nrows,k1,k2,piv,off,inc,m)
 
    ! a = laswp(a,piv,k1=0,k2=len(piv)-1,off=0,inc=1,overwrite_a=0)
    ! Perform row interchanges on the matrix A for each of row k1 through k2
-   ! 
+   !
    ! piv pivots rows.
 
      callstatement {int i;m=len(piv);for(i=0;i<m;++piv[i++]);++k1;++k2; (*f2py_func)(&n,a,&nrows,&k1,&k2,piv+off,&inc); for(i=0;i<m;--piv[i++]);}
@@ -1561,8 +1561,8 @@ interface
 
      ! t,sdim,w,vs,work,info=gees(compute_v=1,sort_t=0,select,a,lwork=3*n)
      ! For an NxN matrix compute the eigenvalues, the schur form T, and optionally
-     !  the matrix of Schur vectors Z.  This gives the Schur factorization 
-     !  A = Z * T * Z^H  -- a complex matrix is in Schur form if it is upper 
+     !  the matrix of Schur vectors Z.  This gives the Schur factorization
+     !  A = Z * T * Z^H  -- a complex matrix is in Schur form if it is upper
      !  triangular
 
      callstatement (*f2py_func)((compute_v?"V":"N"),(sort_t?"S":"N"),cb_<prefix2c>select_in_gees__user__routines,&n,a,&nrows,&sdim,w,vs,&ldvs,work,&lwork,rwork,bwork,&info,1,1)
@@ -1591,7 +1591,7 @@ interface
 
      ! t,sdim,w,vs,work,info=gees(compute_v=1,sort_t=0,select,a,lwork=3*n)
      ! For an NxN matrix compute the eigenvalues, the schur form T, and optionally
-     !  the matrix of Schur vectors Z.  This gives the Schur factorization 
+     !  the matrix of Schur vectors Z.  This gives the Schur factorization
      !  A = Z * T * Z^H  -- a real matrix is in Schur form if it is upper quasi-
      !  triangular with 1x1 and 2x2 blocks.
 
@@ -1619,7 +1619,7 @@ interface
 end subroutine <prefix2>gees
 
 
-subroutine <prefix2>ggev(compute_vl,compute_vr,n,a,b,alphar,alphai,beta,vl,ldvl,vr,ldvr,work,lwork,info) 
+subroutine <prefix2>ggev(compute_vl,compute_vr,n,a,b,alphar,alphai,beta,vl,ldvl,vr,ldvr,work,lwork,info)
 
      callstatement {(*f2py_func)((compute_vl?"V":"N"),(compute_vr?"V":"N"),&n,a,&n,b,&n,alphar,alphai,beta,vl,&ldvl,vr,&ldvr,work,&lwork,&info);}
      callprotoargument char*,char*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,int*
@@ -1642,10 +1642,10 @@ subroutine <prefix2>ggev(compute_vl,compute_vr,n,a,b,alphar,alphai,beta,vl,ldvl,
 
     <ftype2>  depend(ldvl,n), dimension(ldvl,n),intent(out) :: vl
     integer intent(hide),depend(n,compute_vl) :: ldvl=(compute_vl?n:1)
-    
+
     <ftype2>  depend(ldvr,n), dimension(ldvr,n),intent(out) :: vr
     integer intent(hide),depend(n,compute_vr) :: ldvr=(compute_vr?n:1)
-    
+
     integer optional,intent(in),depend(n,compute_vl,compute_vr) :: lwork=8*n
     check((lwork==-1) || (lwork>=MAX(1,8*n))) :: lwork
     <ftype2> intent(out), dimension(MAX(lwork,1)), depend(lwork) :: work
@@ -1654,7 +1654,7 @@ subroutine <prefix2>ggev(compute_vl,compute_vr,n,a,b,alphar,alphai,beta,vl,ldvl,
 
 end subroutine <prefix2>ggev
 
-subroutine <prefix2c>ggev(compute_vl,compute_vr,n,a,b,alpha,beta,vl,ldvl,vr,ldvr,work,lwork,rwork,info) 
+subroutine <prefix2c>ggev(compute_vl,compute_vr,n,a,b,alpha,beta,vl,ldvl,vr,ldvr,work,lwork,rwork,info)
 
      callstatement {(*f2py_func)((compute_vl?"V":"N"),(compute_vr?"V":"N"),&n,a,&n,b,&n,alpha,beta,vl,&ldvl,vr,&ldvr,work,&lwork,rwork,&info);}
      callprotoargument char*,char*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,<ctype2c>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*
@@ -1676,10 +1676,10 @@ subroutine <prefix2c>ggev(compute_vl,compute_vr,n,a,b,alpha,beta,vl,ldvl,vr,ldvr
 
     <ftype2c>  depend(ldvl,n), dimension(ldvl,n),intent(out) :: vl
     integer intent(hide),depend(n,compute_vl) :: ldvl=(compute_vl?n:1)
-    
+
     <ftype2c>  depend(ldvr,n), dimension(ldvr,n),intent(out) :: vr
     integer intent(hide),depend(n,compute_vr) :: ldvr=(compute_vr?n:1)
-    
+
     integer optional,intent(in),depend(n,compute_vl,compute_vr) :: lwork=2*n
     check((lwork==-1) || (lwork>=MAX(1,2*n))) :: lwork
     <ftype2c> intent(out), dimension(MAX(lwork,1)), depend(lwork) :: work
@@ -1689,7 +1689,7 @@ subroutine <prefix2c>ggev(compute_vl,compute_vr,n,a,b,alpha,beta,vl,ldvl,vr,ldvr
 
 end subroutine <prefix2>ggev
 
-! if anything is wrong with the following wrappers (until *gbtrs) 
+! if anything is wrong with the following wrappers (until *gbtrs)
 ! blame Arnd Baecker and Johannes Loehnert and not Pearu
 subroutine <prefix2>sbev(ab,compute_v,lower,n,ldab,kd,w,z,ldz,work,info) ! in :Band:dsbev.f
   ! principally <s,d>sbevd does the same, and are recommended for use.
@@ -1699,24 +1699,24 @@ subroutine <prefix2>sbev(ab,compute_v,lower,n,ldab,kd,w,z,ldz,work,info) ! in :B
 
   callprotoargument char*,char*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*
 
-  ! Remark: if ab is fortran contigous on input 
+  ! Remark: if ab is fortran contigous on input
   !         and overwrite_ab=1  ab will be overwritten.
   <ftype2> dimension(ldab,*), intent(in,overwrite) :: ab
 
   integer optional,intent(in):: compute_v = 1
   check(compute_v==1||compute_v==0) compute_v
-  integer optional,intent(in),check(lower==0||lower==1) :: lower = 0   
+  integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
   integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
   integer intent(hide),depend(ab) :: n=shape(ab,1)
   integer intent(hide),depend(ab) :: kd=shape(ab,0)-1
 
   <ftype2> dimension(n),intent(out),depend(n) :: w
-  
-  ! For compute_v=1 z is used and contains the eigenvectors 
+
+  ! For compute_v=1 z is used and contains the eigenvectors
   integer intent(hide),depend(n) :: ldz=(compute_v?n:1)
   <ftype2> dimension(ldz,ldz),intent(out),depend(ldz) :: z
-  
+
   <ftype2> dimension(MAX(1,3*n-1)),intent(hide),depend(n) :: work
   integer intent(out)::info
 end subroutine <prefix2>sbev
@@ -1729,13 +1729,13 @@ subroutine <prefix2>sbevd(ab,compute_v,lower,n,ldab,kd,w,z,ldz,work,lwork,iwork,
 
   callprotoargument char*,char*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*,int*
 
-  ! Remark: if ab is fortran contigous on input 
+  ! Remark: if ab is fortran contigous on input
   !         and overwrite_ab=1  ab will be overwritten.
   <ftype2> dimension(ldab,*), intent(in, overwrite) :: ab
 
   integer optional,intent(in):: compute_v = 1
   check( compute_v==1||compute_v==0) compute_v
-  integer optional,intent(in),check(lower==0||lower==1) :: lower = 0   
+  integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
   integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
   integer intent(hide),depend(ab) :: n=shape(ab,1)
@@ -1743,11 +1743,11 @@ subroutine <prefix2>sbevd(ab,compute_v,lower,n,ldab,kd,w,z,ldz,work,lwork,iwork,
 
   <ftype2> dimension(n),intent(out),depend(n) :: w
   <ftype2> dimension(ldz,ldz),intent(out),depend(ldz) :: z
-  
-  ! For compute_v=1 z is used and contains the eigenvectors 
+
+  ! For compute_v=1 z is used and contains the eigenvectors
   integer intent(hide),depend(n) :: ldz=(compute_v?n:1)
   <ftype2> dimension(ldz,ldz),depend(ldz) :: z
-  
+
   integer intent(hide),depend(n) :: lwork=(compute_v?1+5*n+2*n*n:2*n)
   <ftype2> dimension(lwork),intent(hide),depend(lwork) :: work
   integer intent(out)::info
@@ -1761,12 +1761,12 @@ end subroutine <prefix2>sbevd
 subroutine <prefix2>sbevx(ab,ldab,compute_v,range,lower,n,kd,q,ldq,vl,vu,il,iu,abstol,w,z,m,mmax,ldz,work,iwork,ifail,info) ! in :Band:dsbevx.f
 
   callstatement (*f2py_func)((compute_v?"V":"N"),(range>0?(range==1?"V":"I"):"A"),(lower?"L":"U"),&n,&kd,ab,&ldab,q,&ldq,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,iwork,ifail,&info)
-                             
+
   callprotoargument char*,char*,char*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*, int*,int*,int*
 
   integer optional,intent(in):: compute_v = 1
   check(compute_v==1||compute_v==0) compute_v
-  integer optional,intent(in),check(lower==0||lower==1) :: lower = 0   
+  integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
   integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
   integer intent(hide),depend(ab) :: n=shape(ab,1)
@@ -1776,7 +1776,7 @@ subroutine <prefix2>sbevx(ab,ldab,compute_v,range,lower,n,kd,q,ldq,vl,vu,il,iu,a
   check(range==2||range==1||range==0) range
 
 
-  ! Remark: if ab is fortran contigous on input 
+  ! Remark: if ab is fortran contigous on input
   !         and overwrite_ab=1  ab will be overwritten.
   <ftype2> dimension(ldab,*),intent(in, overwrite) :: ab
 
@@ -1805,7 +1805,7 @@ subroutine <prefix2>sbevx(ab,ldab,compute_v,range,lower,n,kd,q,ldq,vl,vu,il,iu,a
   ! Remark:
   ! Eigenvalues will be computed most accurately when ABSTOL is
   ! set to twice the underflow threshold 2*DLAMCH('S'), not zero.
-  ! 
+  !
   ! The easiest is to wrap DLAMCH (done below)
   ! and let the user provide the value.
   <ftype2> optional,intent(in):: abstol=0.0
@@ -1819,7 +1819,7 @@ subroutine <prefix2>sbevx(ab,ldab,compute_v,range,lower,n,kd,q,ldq,vl,vu,il,iu,a
   ! (only if eigenvalues are requested)
   ! Otherwise we would allocate a (possibly) huge
   ! region of memory for the eigenvectors, even
-  ! in cases where only a few are requested. 
+  ! in cases where only a few are requested.
   ! If RANGE = 'V' (range=1) we a priori don't know the
   ! number of eigenvalues in the interval in advance.
   ! As default we use the maximum value
@@ -1880,13 +1880,13 @@ end subroutine <prefix2c>hbevd
 subroutine <prefix2c>hbevx(ab,ldab,compute_v,range,lower,n,kd,q,ldq,vl,vu,il,iu,abstol,w,z,m,mmax,ldz,work,rwork,iwork,ifail,info) ! in :Band:dsbevx.f
 
   callstatement (*f2py_func)((compute_v?"V":"N"),(range>0?(range==1?"V":"I"):"A"),(lower?"L":"U"),&n,&kd,ab,&ldab,q,&ldq,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,work,rwork,iwork,ifail,&info)
-                             
+
   callprotoargument
   char*,char*,char*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,<ctype2>*,int*,int*,int*
-  
+
   integer optional,intent(in):: compute_v = 1
   check(compute_v==1||compute_v==0) compute_v
-  integer optional,intent(in),check(lower==0||lower==1) :: lower = 0   
+  integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
 
   integer optional,check(shape(ab,0)==ldab),depend(ab) :: ldab=shape(ab,0)
   integer intent(hide),depend(ab) :: n=shape(ab,1)
@@ -1896,7 +1896,7 @@ subroutine <prefix2c>hbevx(ab,ldab,compute_v,range,lower,n,kd,q,ldq,vl,vu,il,iu,
   check(range==2||range==1||range==0) range
 
 
-  ! Remark: if ab is fortran contigous on input 
+  ! Remark: if ab is fortran contigous on input
   !         and overwrite_ab=1  ab will be overwritten.
   <ftype2c> dimension(ldab,*),intent(in, overwrite) :: ab
 
@@ -1925,7 +1925,7 @@ subroutine <prefix2c>hbevx(ab,ldab,compute_v,range,lower,n,kd,q,ldq,vl,vu,il,iu,
   ! Remark:
   ! Eigenvalues will be computed most accurately when ABSTOL is
   ! set to twice the underflow threshold 2*DLAMCH('S'), not zero.
-  ! 
+  !
   ! The easiest is to wrap DLAMCH (done below)
   ! and let the user provide the value.
   <ftype2> optional,intent(in):: abstol=0.0
@@ -1939,7 +1939,7 @@ subroutine <prefix2c>hbevx(ab,ldab,compute_v,range,lower,n,kd,q,ldq,vl,vu,il,iu,
   ! (only if eigenvalues are requested)
   ! Otherwise we would allocate a (possibly) huge
   ! region of memory for the eigenvectors, even
-  ! in cases where only a few are requested. 
+  ! in cases where only a few are requested.
   ! If RANGE = 'V' (range=1) we a priori don't know the
   ! number of eigenvalues in the interval in advance.
   ! As default we use the maximum value
@@ -1955,7 +1955,7 @@ subroutine <prefix2c>hbevx(ab,ldab,compute_v,range,lower,n,kd,q,ldq,vl,vu,il,iu,
 end subroutine <prefix2c>hbevx
 
 
-! dlamch = dlamch(cmach)     
+! dlamch = dlamch(cmach)
 !
 ! determine double precision machine parameters
 !  CMACH   (input) CHARACTER*1
@@ -1996,14 +1996,14 @@ end function slamch
 
 
 ! lu,ipiv,info = dgbtrf(ab,kl,ku,[m,n,ldab,overwrite_ab])
-! Compute  an  LU factorization of a real m-by-n band matrix 
+! Compute  an  LU factorization of a real m-by-n band matrix
 subroutine <prefix>gbtrf(m,n,ab,kl,ku,ldab,ipiv,info) ! in :Band:dgbtrf.f
   ! threadsafe  ! FIXME: should this be added ?
 
   callstatement {int i;(*f2py_func)(&m,&n,&kl,&ku,ab,&ldab,ipiv,&info); for(i=0,n=MIN(m,n);i\<n;--ipiv[i++]);}
-                             
+
   callprotoargument int*,int*,int*,int*,<ctype>*,int*,int*,int*
-  
+
     ! let the default be a square matrix:
     integer optional,depend(ab) :: m=shape(ab,1)
     integer optional,depend(ab) :: n=shape(ab,1)
@@ -2021,10 +2021,10 @@ end subroutine <prefix>gbtrf
 subroutine <prefix>gbtrs(ab,kl,ku,b,ipiv,trans,n,nrhs,ldab,ldb,info) ! in :Band:dgbtrs.f
 ! x,info = dgbtrs(ab,kl,ku,b,ipiv,[trans,n,ldab,ldb,overwrite_b])
 ! solve a system of linear equations A * X = B or A' * X = B
-! with a general band matrix A using the  LU  factorization  
-! computed by DGBTRF 
+! with a general band matrix A using the  LU  factorization
+! computed by DGBTRF
 !
-! TRANS   Specifies the form of the system of equations.  
+! TRANS   Specifies the form of the system of equations.
 !  0  = 'N':  A * X =B  (No transpose)
 !  1  = 'T':  A'* X = B  (Transpose)
 !  2  = 'C':  A'* X = B  (Conjugate transpose = Transpose)
@@ -2460,6 +2460,40 @@ subroutine zhegvx(itype,jobz,range,uplo,n,a,lda,b,ldb,vl,vu,il,iu,abstol,m,w,z,l
     integer intent(out),dimension(n),depend(n) :: ifail
     integer intent(out) :: info
 end subroutine zhegvx
+
+
+function <prefix2>lange(norm,m,n,a,lda,work) result(n2)
+    ! the one norm, or the Frobenius norm, or the  infinity norm, or the
+    ! element of largest absolute value of a real matrix A.
+    <ftype2> <prefix2>lange, n2
+    fortranname <wrap2>lange
+    callstatement (*f2py_func)(&<prefix2>lange,norm,&m,&n,a,&m,work)
+    callprotoargument <ctype2>*,char*,int*,int*,<ctype2>*,int*,<ctype2>*
+
+    character intent(in),check(*norm=='M'||*norm=='m'||*norm=='1'||*norm=='O'||*norm=='o'||*norm=='I'||*norm=='i'||*norm=='F'||*norm=='f'||*norm=='E'||*norm=='e'):: norm
+    integer intent(hide),depend(a,n) :: m = shape(a,0)
+    integer intent(hide),depend(a) :: lda = shape(a,0)
+    integer intent(hide),depend(a) :: n = shape(a,1)
+    <ftype2> dimension(m,n),intent(in) :: a
+    <ftype2> dimension(MAX(m,1)),intent(cache,hide) :: work
+end function <prefix2>lange
+
+function <prefix2c>lange(norm,m,n,a,lda,work) result(n2)
+    ! the one norm, or the Frobenius norm, or the  infinity norm, or the
+    ! element of largest absolute value of a complex matrix A.
+    <ftype2> <prefix2c>lange, n2
+    fortranname <wrap2c>lange
+    callstatement (*f2py_func)(&<prefix2c>lange,norm,&m,&n,a,&m,work)
+    callprotoargument <ctype2>*,char*,int*,int*,<ctype2c>*,int*,<ctype2>*
+
+    character intent(in),check(*norm=='M'||*norm=='m'||*norm=='1'||*norm=='O'||*norm=='o'||*norm=='I'||*norm=='i'||*norm=='F'||*norm=='f'||*norm=='E'||*norm=='e'):: norm
+    integer intent(hide),depend(a,n) :: m = shape(a,0)
+    integer intent(hide),depend(a) :: lda = shape(a,0)
+    integer intent(hide),depend(a) :: n = shape(a,1)
+    <ftype2c> dimension(m,n),intent(in) :: a
+    <ftype2> dimension(MAX(m,1)),intent(cache,hide) :: work
+end function <prefix2c>lange
+
 
 
 end interface

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -292,6 +292,11 @@ All functions
    ssygvx
    dsygvx
 
+   slange
+   dlange
+   clange
+   zlange
+
 """
 #
 # Author: Pearu Peterson, March 2002


### PR DESCRIPTION
I was feeling masochistic, so tried to learn f2c and implement the f2c part of #4098.

I believe this correctly handles the insane differences between the g77/gfortran ABIs by calling the wrapped versions of the functions for single precision. Tested on OS X (Accelerate) and Ubuntu 14.04 (MKL).
