### PR TITLE
ENH: Add a unit impulse waveform function

### DIFF
--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -33,6 +33,9 @@ The callback function C API supports PyCapsules in Python 2.7
 The function `scipy.signal.sosfreqz` was added to compute the frequency
 response from second-order sections.
 
+The function `scipy.signal.unit_impulse` was added to conveniently
+generate an impulse function.
+
 
 Deprecated features
 ===================

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -199,19 +199,20 @@ LTI Representations
    sos2tf        -- second-order sections to transfer function.
    cont2discrete -- continuous-time to discrete-time LTI conversion.
    place_poles   -- pole placement.
-   
+
 Waveforms
 =========
 
 .. autosummary::
    :toctree: generated/
 
-   chirp       -- Frequency swept cosine signal, with several freq functions.
-   gausspulse  -- Gaussian modulated sinusoid
-   max_len_seq -- Maximum length sequence
-   sawtooth    -- Periodic sawtooth
-   square      -- Square wave
-   sweep_poly  -- Frequency swept cosine signal; freq is arbitrary polynomial
+   chirp        -- Frequency swept cosine signal, with several freq functions.
+   gausspulse   -- Gaussian modulated sinusoid
+   max_len_seq  -- Maximum length sequence
+   sawtooth     -- Periodic sawtooth
+   square       -- Square wave
+   sweep_poly   -- Frequency swept cosine signal; freq is arbitrary polynomial
+   unit_impulse -- Discrete unit impulse
 
 Window functions
 ================

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -3198,8 +3198,7 @@ def sosfilt(sos, x, axis=-1, zi=None):
     >>> from scipy import signal
     >>> b, a = signal.ellip(13, 0.009, 80, 0.05, output='ba')
     >>> sos = signal.ellip(13, 0.009, 80, 0.05, output='sos')
-    >>> x = np.zeros(700)
-    >>> x[0] = 1.
+    >>> x = signal.unit_impulse(700)
     >>> y_tf = signal.lfilter(b, a, x)
     >>> y_sos = signal.sosfilt(sos, x)
     >>> plt.plot(y_tf, 'r', label='TF')

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -331,10 +331,10 @@ class TestUnitImpulse(TestCase):
 
         # Broadcasting
         imp = waveforms.unit_impulse((4, 4), 2)
-        assert_array_equal(imp, np.array([[0.,  0.,  0.,  0.],
-                                          [0.,  0.,  0.,  0.],
-                                          [0.,  0.,  1.,  0.],
-                                          [0.,  0.,  0.,  0.]]))
+        assert_array_equal(imp, np.array([[0, 0, 0, 0],
+                                          [0, 0, 0, 0],
+                                          [0, 0, 1, 0],
+                                          [0, 0, 0, 0]]))
 
     def test_mid(self):
         assert_array_equal(waveforms.unit_impulse((3, 3), 'mid'),

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -335,5 +335,15 @@ class TestUnitImpulse(TestCase):
         assert_array_equal(waveforms.unit_impulse(9, 'mid'),
                            [0, 0, 0, 0, 1, 0, 0, 0, 0])
 
+    def test_dtype(self):
+        imp = waveforms.unit_impulse(7)
+        assert_(np.issubdtype(imp.dtype, np.float))
+
+        imp = waveforms.unit_impulse(5, 3, dtype=int)
+        assert_(np.issubdtype(imp.dtype, np.integer))
+
+        imp = waveforms.unit_impulse((5, 2), (3, 1), dtype=complex)
+        assert_(np.issubdtype(imp.dtype, np.complex))
+
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -329,6 +329,13 @@ class TestUnitImpulse(TestCase):
         assert_array_equal(waveforms.unit_impulse((3, 3), (1, 1)),
                            [[0, 0, 0], [0, 1, 0], [0, 0, 0]])
 
+        # Broadcasting
+        imp = waveforms.unit_impulse((4, 4), 2)
+        assert_array_equal(imp, np.array([[0.,  0.,  0.,  0.],
+                                          [0.,  0.,  0.,  0.],
+                                          [0.,  0.,  1.,  0.],
+                                          [0.,  0.,  0.,  0.]]))
+
     def test_mid(self):
         assert_array_equal(waveforms.unit_impulse((3, 3), 'mid'),
                            [[0, 0, 0], [0, 1, 0], [0, 0, 0]])

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy.testing import (TestCase, assert_almost_equal, assert_equal,
                            assert_, assert_raises, run_module_suite,
-                           assert_allclose)
+                           assert_allclose, assert_array_equal)
 
 import scipy.signal.waveforms as waveforms
 
@@ -35,7 +35,9 @@ def chirp_hyperbolic(t, f0, f1, t1):
 
 
 def compute_frequency(t, theta):
-    """Compute theta'(t)/(2*pi), where theta'(t) is the derivative of theta(t)."""
+    """
+    Compute theta'(t)/(2*pi), where theta'(t) is the derivative of theta(t).
+    """
     # Assume theta and t are 1D numpy arrays.
     # Assume that t is uniformly spaced.
     dt = t[1] - t[0]
@@ -313,6 +315,25 @@ class TestGaussPulse(TestCase):
         err_msg = "Integer input 'tpr=-60' gives wrong result"
         assert_equal(int_result, float_result, err_msg=err_msg)
 
+
+class TestUnitImpulse(TestCase):
+
+    def test_no_index(self):
+        assert_array_equal(waveforms.unit_impulse(7), [1, 0, 0, 0, 0, 0, 0])
+        assert_array_equal(waveforms.unit_impulse((3, 3)),
+                           [[1, 0, 0], [0, 0, 0], [0, 0, 0]])
+
+    def test_index(self):
+        assert_array_equal(waveforms.unit_impulse(10, 3),
+                           [0, 0, 0, 1, 0, 0, 0, 0, 0, 0])
+        assert_array_equal(waveforms.unit_impulse((3, 3), (1, 1)),
+                           [[0, 0, 0], [0, 1, 0], [0, 0, 0]])
+
+    def test_mid(self):
+        assert_array_equal(waveforms.unit_impulse((3, 3), 'mid'),
+                           [[0, 0, 0], [0, 1, 0], [0, 0, 0]])
+        assert_array_equal(waveforms.unit_impulse(9, 'mid'),
+                           [0, 0, 0, 0, 1, 0, 0, 0, 0])
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -489,12 +489,13 @@ def unit_impulse(shape, idx=None, dtype=float):
     Parameters
     ----------
     shape : int or tuple of int
-        Number of samples in the (1D) output, or a tuple that represents the
-        shape of the output.
-    idx : float or str or None, optional
+        Number of samples in the output (1-D), or a tuple that represents the
+        shape of the output (N-D).
+    idx : None or int or tuple of int or 'mid', optional
         Index at which the value is 1.  If None, defaults to the 0th element.
         If ``idx='mid'``, the impulse will be centered at ``shape // 2`` in
-        all dimensions.
+        all dimensions.  If an int, the impulse will be at `idx` in all
+        dimensions.
     dtype : data-type, optional
         The desired data-type for the array, e.g., `numpy.int8`.  Default is
         `numpy.float64`.
@@ -506,6 +507,8 @@ def unit_impulse(shape, idx=None, dtype=float):
 
     Notes
     -----
+    The 1D case is also known as the Kronecker delta.
+
     .. versionadded:: 0.19.0
 
     Examples
@@ -528,6 +531,14 @@ def unit_impulse(shape, idx=None, dtype=float):
            [ 0.,  1.,  0.],
            [ 0.,  0.,  0.]])
 
+    Impulse at (2, 2), using broadcasting:
+
+    >>> signal.unit_impulse((4, 4), 2)
+    array([[ 0.,  0.,  0.,  0.],
+           [ 0.,  0.,  0.,  0.],
+           [ 0.,  0.,  1.,  0.],
+           [ 0.,  0.,  0.,  0.]])
+
     Plot the impulse response of a 4th-order Butterworth lowpass filter:
 
     >>> imp = signal.unit_impulse(100, 'mid')
@@ -549,9 +560,11 @@ def unit_impulse(shape, idx=None, dtype=float):
     shape = np.atleast_1d(shape)
 
     if idx is None:
-        idx = tuple(np.zeros_like(shape))
+        idx = (0,) * len(shape)
     elif idx == 'mid':
         idx = tuple(shape // 2)
+    elif not hasattr(idx, "__iter__"):
+        idx = (idx,) * len(shape)
 
     out[idx] = 1
     return out

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -500,6 +500,10 @@ def unit_impulse(shape, idx=None):
     y : ndarray
         Output array containing an impulse signal.
 
+    Notes
+    -----
+    .. versionadded:: 0.19.0
+
     Examples
     --------
     An impulse at the 0th element (:math:`\delta[n]`):

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -10,7 +10,8 @@ import numpy as np
 from numpy import asarray, zeros, place, nan, mod, pi, extract, log, sqrt, \
     exp, cos, sin, polyval, polyint
 
-__all__ = ['sawtooth', 'square', 'gausspulse', 'chirp', 'sweep_poly']
+__all__ = ['sawtooth', 'square', 'gausspulse', 'chirp', 'sweep_poly',
+           'unit_impulse']
 
 
 def sawtooth(t, width=1):
@@ -479,3 +480,66 @@ def _sweep_poly_phase(t, poly):
     intpoly = polyint(poly)
     phase = 2 * pi * polyval(intpoly, t)
     return phase
+
+
+def unit_impulse(shape, idx=None):
+    """
+    Unit impulse signal (discrete delta function) or unit basis vector.
+
+    Parameters
+    ----------
+    shape : int or tuple of int
+        Number of samples in the (1D) output, or a tuple that represents the
+        shape of the output.
+    idx : float or str, optional
+        Index at which the value is 1.  Defaults to the 0th element.
+        If ``idx='mid'``, the impulse will be centered at ``shape // 2``.
+
+    Returns
+    -------
+    y : ndarray
+        Output array containing an impulse signal.
+
+    Examples
+    --------
+    An impulse at the 0th element (:math:`\delta[n]`):
+
+    >>> from scipy import signal
+    >>> signal.unit_impulse(8)
+    array([ 1.,  0.,  0.,  0.,  0.,  0.,  0.,  0.])
+
+    Impulse offset by 2 samples (:math:`\delta[n-2]`):
+
+    >>> signal.unit_impulse(7, 2)
+    array([ 0.,  0.,  1.,  0.,  0.,  0.,  0.])
+
+    2-dimensional impulse, centered:
+
+    >>> signal.unit_impulse((3, 3), 'mid')
+    array([[ 0.,  0.,  0.],
+           [ 0.,  1.,  0.],
+           [ 0.,  0.,  0.]])
+
+    Plot the impulse response of a 4th-order Butterworth lowpass filter:
+
+    >>> imp = signal.unit_impulse(100, 'mid')
+    >>> b, a = signal.butter(4, 0.2)
+    >>> response = signal.lfilter(b, a, imp)
+
+    >>> import matplotlib.pyplot as plt
+    >>> plt.plot(np.arange(-50, 50), imp)
+    >>> plt.plot(np.arange(-50, 50), response)
+    >>> plt.margins(0.1, 0.1)
+
+    """
+    out = zeros(shape)
+
+    shape = np.atleast_1d(shape)
+
+    if idx is None:
+        idx = tuple(np.zeros_like(shape))
+    elif idx == 'mid':
+        idx = tuple(shape // 2)
+
+    out[idx] = 1
+    return out

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -491,9 +491,10 @@ def unit_impulse(shape, idx=None):
     shape : int or tuple of int
         Number of samples in the (1D) output, or a tuple that represents the
         shape of the output.
-    idx : float or str, optional
-        Index at which the value is 1.  Defaults to the 0th element.
-        If ``idx='mid'``, the impulse will be centered at ``shape // 2``.
+    idx : float or str or None, optional
+        Index at which the value is 1.  If None, defaults to the 0th element.
+        If ``idx='mid'``, the impulse will be centered at ``shape // 2`` in
+        all dimensions.
 
     Returns
     -------
@@ -534,6 +535,10 @@ def unit_impulse(shape, idx=None):
     >>> plt.plot(np.arange(-50, 50), imp)
     >>> plt.plot(np.arange(-50, 50), response)
     >>> plt.margins(0.1, 0.1)
+    >>> plt.xlabel('Time [samples]')
+    >>> plt.ylabel('Amplitude')
+    >>> plt.grid(True)
+    >>> plt.show()
 
     """
     out = zeros(shape)

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -482,7 +482,7 @@ def _sweep_poly_phase(t, poly):
     return phase
 
 
-def unit_impulse(shape, idx=None):
+def unit_impulse(shape, idx=None, dtype=float):
     """
     Unit impulse signal (discrete delta function) or unit basis vector.
 
@@ -495,6 +495,9 @@ def unit_impulse(shape, idx=None):
         Index at which the value is 1.  If None, defaults to the 0th element.
         If ``idx='mid'``, the impulse will be centered at ``shape // 2`` in
         all dimensions.
+    dtype : data-type, optional
+        The desired data-type for the array, e.g., `numpy.int8`.  Default is
+        `numpy.float64`.
 
     Returns
     -------
@@ -541,7 +544,7 @@ def unit_impulse(shape, idx=None):
     >>> plt.show()
 
     """
-    out = zeros(shape)
+    out = zeros(shape, dtype)
 
     shape = np.atleast_1d(shape)
 


### PR DESCRIPTION
This was just going to be a convenience function because `delta(8)` is shorter than `x = zeros(8); x[0] = 1` or `(arange(8) == 0).astype(int)`, but then I realized the interpolated intersample impulse would be useful, too.

Called it `delta` because `impulse` was taken.
