### PR TITLE
MAINT: interpolate: fix a few inconsistencies between docstrings and signatures

### DIFF
--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -33,9 +33,9 @@ class NearestNDInterpolator(NDInterpolatorBase):
 
     Parameters
     ----------
-    points : (Npoints, Ndims) ndarray of floats
+    x : (Npoints, Ndims) ndarray of floats
         Data point coordinates.
-    values : (Npoints,) ndarray of float or complex
+    y : (Npoints,) ndarray of float or complex
         Data values.
     rescale : boolean, optional
         Rescale points to unit cube before performing interpolation.

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -679,31 +679,34 @@ class PiecewisePolynomial(_Interpolator1DWithDerivatives):
     Parameters
     ----------
     xi : array_like
-        a sorted 1-d array of x-coordinates
+        A sorted 1-d array of x-coordinates.
     yi : array_like or list of array_likes
-        yi[i][j] is the j-th derivative known at xi[i]   (for axis=0)
+        ``yi[i][j]`` is the j-th derivative known at ``xi[i]`` (for ``axis=0``).
     orders : list of int, or int, optional
-        a list of polynomial orders, or a single universal order
+        A list of polynomial orders, or a single universal order.
     direction : {None, 1, -1}, optional
-        indicates whether the xi are increasing or decreasing
-        +1 indicates increasing
-        -1 indicates decreasing
-        None indicates that it should be deduced from the first two xi
+        Indicates whether the `xi` are increasing or decreasing:
+
+          +1 : increasing values
+
+          -1 : decreasing values
+
+          None : direction will be deduced from the first two elements of `xi`
+
     axis : int, optional
-        Axis in the yi array corresponding to the x-coordinate values.
+        Axis in the `yi` array corresponding to the x-coordinate values.
 
     Notes
     -----
-    If orders is None, or orders[i] is None, then the degree of the
-    polynomial segment is exactly the degree required to match all i
-    available derivatives at both endpoints. If orders[i] is not None,
+    If orders is None, or ``orders[i]`` is None, then the degree of the
+    polynomial segment is exactly the degree required to match all ``i``
+    available derivatives at both endpoints.  If ``orders[i]`` is not None,
     then some derivatives will be ignored. The code will try to use an
     equal number of derivatives from each end; if the total number of
     derivatives needed is odd, it will prefer the rightmost endpoint. If
     not enough derivatives are available, an exception is raised.
 
     """
-
     def __init__(self, xi, yi, orders=None, direction=None, axis=0):
         _Interpolator1DWithDerivatives.__init__(self, axis=axis)
 
@@ -753,7 +756,10 @@ class PiecewisePolynomial(_Interpolator1DWithDerivatives):
         n2 = min(n-n1,len(y2))
         n1 = min(n-n2,len(y1))
         if n1+n2 != n:
-            raise ValueError("Point %g has %d derivatives, point %g has %d derivatives, but order %d requested" % (x1, len(y1), x2, len(y2), order))
+            raise ValueError("Point %g has %d derivatives, point %g has %d "
+                             "derivatives, but order %d requested" % (x1,
+                             len(y1), x2, len(y2), order))
+
         if not (n1 <= len(y1) and n2 <= len(y2)):
             raise ValueError("`order` input incompatible with length y1 or y2.")
 
@@ -774,12 +780,12 @@ class PiecewisePolynomial(_Interpolator1DWithDerivatives):
         Parameters
         ----------
         xi : float
-            Input
+            Point to add.
         yi : array_like
-            `yi` is the list of derivatives known at `xi`
+            `yi` is the list of derivatives known at `xi`.
         order : int or None, optional
-            a polynomial order, or instructions to use the highest
-            possible order
+            A polynomial order, or instructions to use the highest possible
+            order.
 
         """
         yi = self._reshape_yi(yi, check=True)
@@ -788,7 +794,8 @@ class PiecewisePolynomial(_Interpolator1DWithDerivatives):
         if self.direction is None:
             self.direction = np.sign(xi-self.xi[-1])
         elif (xi-self.xi[-1])*self.direction < 0:
-            raise ValueError("x coordinates must be in the %d direction: %s" % (self.direction, self.xi))
+            raise ValueError("x coordinates must be in the %d direction: %s" % (
+                             self.direction, self.xi))
 
         self.xi.append(xi)
         self.yi.append(yi)
@@ -819,14 +826,6 @@ class PiecewisePolynomial(_Interpolator1DWithDerivatives):
             at ``xi[i]``.
         orders : int or list of ints, optional
             A list of polynomial orders, or a single universal order.
-        direction : {None, 1, -1}
-            Indicates whether the `xi` are increasing or decreasing.
-
-                +1 indicates increasing
-
-                -1 indicates decreasing
-
-            None indicates that it should be deduced from the first two `xi`.
 
         """
         if self._y_axis == 0:


### PR DESCRIPTION
- remove non-existing keyword from PiecewisePolynomial.extend docstring.
- rename parameters (points, values) to (x, y) in NearestNDInterpolator.
- also includes a few style and doc formatting cleanups.

Addresses some issues identified by @rmcgibbo in gh-4578.
