### PR TITLE
DOC: stats: explain rice scaling; add a note to the tutorial about scaling

### DIFF
--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -133,7 +133,8 @@ function ``ppf``, which is the inverse of the ``cdf``:
     >>> norm.ppf(0.5)
     0.0
 
-To generate a set of random variates: 
+To generate a sequence of random variates, use the ``size`` keyword
+argument:
 
     >>> norm.rvs(size=5)
     array([-0.35687759,  1.34347647, -0.11710531, -1.00725181, -0.51275702])
@@ -143,7 +144,10 @@ Don't think that ``norm.rvs(5)`` generates 5 variates:
     >>> norm.rvs(5)
     7.131624370075814
 
-This brings us, in fact, to the topic of the next subsection.
+Here, ``5`` with no keyword is being interpreted as the first possible
+keyword argument, ``loc``, which is the first of a pair of keyword arguments
+taken by all continuous distributions.
+This brings us to the topic of the next subsection.
 
 
 Shifting and Scaling
@@ -152,12 +156,12 @@ Shifting and Scaling
 All continuous distributions take ``loc`` and ``scale`` as keyword
 parameters to adjust the location and scale of the distribution,
 e.g. for the standard normal distribution the location is the mean and
-the scale is the standard deviation. 
+the scale is the standard deviation.
 
     >>> norm.stats(loc = 3, scale = 4, moments = "mv")
     (array(3.0), array(16.0))
 
-In general the standardized distribution for a random variable ``X``
+In many cases the standardized distribution for a random variable ``X``
 is obtained through the transformation ``(X - loc) / scale``.  The
 default values are ``loc = 0`` and ``scale = 1``.
 
@@ -177,6 +181,15 @@ taking ``scale  = 1./lambda`` we get the proper scale.
     >>> expon.mean(scale=3.)
     3.0
 
+.. note:: Distributions that take shape parameters may
+   require more than simple application of ``loc`` and/or
+   ``scale`` to achieve the desired form.  For example, the
+   distribution of 2-D vector lengths given a constant vector
+   of length :math:`R` perturbed by independent N(0, :math:`\sigma^2`)
+   deviations in each component is
+   rice(:math:`R/\sigma`, scale= :math:`\sigma`).  The first argument
+   is a shape parameter that needs to be scaled along with :math:`x`.
+
 The uniform distribution is also interesting:
 
     >>> from scipy.stats import uniform
@@ -193,26 +206,26 @@ to set the ``loc`` parameter. Let's see:
     4.983550784784704
 
 Thus, to explain the output of the example of the last section:
-``norm.rvs(5)`` generates a normally distributed random variate with
-mean ``loc=5``.
+``norm.rvs(5)`` generates a single normally distributed random variate with
+mean ``loc=5``, because of the default ``size=1``.
 
-I prefer to set the ``loc`` and ``scale`` parameter explicitly, by
-passing the values as keywords rather than as arguments. This is less
-of a hassle as it may seem. We clarify this below when we explain the
-topic of `freezing a RV`.
+We recommend that you set ``loc`` and ``scale`` parameters explicitly, by
+passing the values as keywords rather than as arguments. Repetition
+can be minimized when calling more than one method of a given RV by
+using the technique of `Freezing a Distribution`_, as explained below.
 
 
 Shape Parameters
 ^^^^^^^^^^^^^^^^
 
 While a general continuous random variable can be shifted and scaled
-with the ``loc`` and ``scale`` parameters, some distributions require 
+with the ``loc`` and ``scale`` parameters, some distributions require
 additional shape parameters. For instance, the gamma distribution, with density
 
 .. math::
 
     \gamma(x, a) = \frac{\lambda (\lambda x)^{a-1}}{\Gamma(a)} e^{-\lambda x}\;,
- 
+
 requires the shape parameter :math:`a`. Observe that setting
 :math:`\lambda` can be obtained by setting the ``scale`` keyword to
 :math:`1/\lambda`.
@@ -244,7 +257,7 @@ Freezing a Distribution
 
 Passing the ``loc`` and ``scale`` keywords time and again can become
 quite bothersome. The concept of `freezing` a RV is used to
-solve such problems. 
+solve such problems.
 
     >>> rv = gamma(1, scale=2.)
 
@@ -257,7 +270,7 @@ instance of the distribution. Let us check this:
     >>> rv.mean(), rv.std()
     (2.0, 2.0)
 
-This is indeed what we should get. 
+This is indeed what we should get.
 
 
 Broadcasting
@@ -307,7 +320,7 @@ of continuous distribution the cumulative distribution function is in
 most standard cases strictly monotonic increasing in the bounds (a,b)
 and has therefore a unique inverse. The cdf of a discrete
 distribution, however, is a step function, hence the inverse cdf,
-i.e., the percent point function, requires a different definition: 
+i.e., the percent point function, requires a different definition:
 
 ::
 
@@ -411,7 +424,7 @@ tests.
 Making a Continuous Distribution, i.e., Subclassing ``rv_continuous``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Making continuous distributions is fairly simple. 
+Making continuous distributions is fairly simple.
 
     >>> from scipy import stats
     >>> class deterministic_gen(stats.rv_continuous):
@@ -444,7 +457,7 @@ information about the distribution. Thus, as a cautionary example:
     (4.163336342344337e-13, 0.0)
 
 But this is not correct: the integral over this pdf should be 1. Let's make the
-integration interval smaller: 
+integration interval smaller:
 
     >>> quad(deterministic.pdf, -1e-3, 1e-3)  # warning removed
     (1.000076872229173, 0.0010625571718182458)
@@ -463,7 +476,7 @@ intervals centered around the integers.
 
 **General Info**
 
-From the docstring of rv_discrete, i.e., 
+From the docstring of rv_discrete, i.e.,
 
     >>> from scipy.stats import rv_discrete
     >>> help(rv_discrete)
@@ -479,8 +492,8 @@ Next to this, there are some further requirements for this approach to
 work:
 
 * The keyword `name` is required.
-* The support points of the distribution xk have to be integers. 
-* The number of significant digits (decimals) needs to be specified. 
+* The support points of the distribution xk have to be integers.
+* The number of significant digits (decimals) needs to be specified.
 
 In fact, if the last two requirements are not satisfied an exception
 may be raised or the resulting numbers may be incorrect.

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1002,7 +1002,7 @@ class exponnorm_gen(rv_continuous):
     The probability density function for `exponnorm` is::
 
         exponnorm.pdf(x, K) = 1/(2*K) exp(1/(2 * K**2)) exp(-x / K) * erfc(- (x - 1/K) / sqrt(2))
-           
+
     where the shape parameter ``K > 0``.
 
     It can be thought of as the sum of a normally distributed random
@@ -1032,7 +1032,7 @@ class exponnorm_gen(rv_continuous):
         invK = 1.0 / K
         exparg = 0.5 * invK**2 - invK * x
         return exparg + log(0.5 * invK * erfc(-(x - invK) / sqrt(2)))
-    
+
     def _cdf(self, x, K):
         invK = 1.0 / K
         expval = invK * (0.5 * invK - x)
@@ -3702,10 +3702,10 @@ class rayleigh_gen(rv_continuous):
 
     def _ppf(self, q):
         return sqrt(-2 * special.log1p(-q))
-        
+
     def _sf(self, r):
         return exp(-0.5 * r**2)
-        
+
     def _isf(self, q):
         return sqrt(-2 * log(q))
 
@@ -3762,8 +3762,7 @@ class reciprocal_gen(rv_continuous):
         return 0.5*log(a*b)+log(log(b/a))
 reciprocal = reciprocal_gen(name="reciprocal")
 
-
-# FIXME: PPF does not work.
+# FIXME: add _cdf, _ppf methods?
 class rice_gen(rv_continuous):
     """A Rice continuous random variable.
 
@@ -3779,6 +3778,12 @@ class rice_gen(rv_continuous):
 
     `rice` takes ``b`` as a shape parameter.
 
+    The Rice distribution describes the length, ``r``, of a 2-D vector
+    with components ``(U+u, V+v)``, where ``U, V`` are constant, ``u, v``
+    are independent Gaussian random variables with standard deviation
+    ``s``.  Let ``R = (U**2 + V**2)**0.5``. Then the pdf of ``r`` is
+    ``rice.pdf(x, R/s, scale=s)``.
+
     %(example)s
 
     """
@@ -3792,6 +3797,10 @@ class rice_gen(rv_continuous):
         return np.sqrt((t*t).sum(axis=0))
 
     def _pdf(self, x, b):
+        # We use (x**2 + b**2)/2 = ((x-b)**2)/2 + xb.
+        # The factor of exp(-xb) is then included in the i0e function
+        # in place of the modified Bessel function, i0, improving
+        # numerical stability for large values of xb.
         return x * exp(-(x-b)*(x-b)/2.0) * special.i0e(x*b)
 
     def _munp(self, n, b):


### PR DESCRIPTION
While in the vicinity I made a few other edits, and there are a few trailing whitespace deletions. This documention suggestion is related to #4559 and #4538, and follows on my ill-conceived and closed #4605. It is largely an attempt to prevent a future scipy user from getting as confused as I was.
