### PR TITLE
FIX: Raise error when window length != data length

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1567,7 +1567,9 @@ def resample(x, num, t=None, axis=0, window=None):
     if window is not None:
         if callable(window):
             W = window(fftfreq(Nx))
-        elif isinstance(window, ndarray) and window.shape == (Nx,):
+        elif isinstance(window, ndarray):
+            if window.shape != (Nx,):
+                raise ValueError('window must have the same length as data')
             W = window
         else:
             W = ifftshift(get_window(window, Nx))

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -460,6 +460,17 @@ class TestWiener(TestCase):
         assert_array_almost_equal(signal.wiener(g, mysize=3), h, decimal=6)
 
 
+class TestResample(TestCase):
+
+    def test_basic(self):
+        # Regression test for issue #3603.
+        # window.shape must equal to sig.shape[0]
+        sig = np.arange(128)
+        num = 256
+        win = signal.get_window(('kaiser', 8.0), 160)
+        assert_raises(ValueError, signal.resample, sig, num, window=win)
+
+
 class TestCSpline1DEval(TestCase):
 
     def test_basic(self):


### PR DESCRIPTION
Raise ValueError when length of the window passed to signal.resample()
as array differs from length of the data to be resampled. Fixes #3603.
