### PR TITLE
Issue #4550: `scipy.stats.mode` - UnboundLocalError on empty sequence

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -140,6 +140,7 @@ Clark Fitzgerald for namedtuple outputs in scipy.stats.
 Florian Wilhelm for usage of RandomState in scipy.stats distributions.
 Robert T. McGibbon for Levinson-Durbin Toeplitz solver.
 Alex Conley for the Exponentially Modified Normal distribution.
+Abraham Escalante for contributions to scipy.stats
 
 
 Institutions

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -611,20 +611,23 @@ def mode(a, axis=0):
                       [4, 7, 5, 9]])
     >>> from scipy import stats
     >>> stats.mode(a)
-    (array([[ 3.,  1.,  0.,  0.]]), array([[ 1.,  1.,  1.,  1.]]))
+    (array([[3, 1, 0, 0]]), array([[1, 1, 1, 1]]))
 
     To get mode of whole array, specify axis=None:
 
     >>> stats.mode(a, axis=None)
-    (array([ 3.]), array([ 3.]))
+    (array([3]), array([3]))
 
     """
     a, axis = _chk_asarray(a, axis)
+    if a.size == 0:
+        return np.array([]), np.array([])
+
     scores = np.unique(np.ravel(a))       # get ALL unique values
     testshape = list(a.shape)
     testshape[axis] = 1
     oldmostfreq = np.zeros(testshape, dtype=a.dtype)
-    oldcounts = np.zeros(testshape)
+    oldcounts = np.zeros(testshape, dtype=int)
     for score in scores:
         template = (a == score)
         counts = np.expand_dims(np.sum(template, axis), axis)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1177,36 +1177,40 @@ class TestItemfreq(object):
 
 
 class TestMode(TestCase):
+    def test_empty(self):
+        vals, counts = stats.mode([])
+        assert_equal(vals, np.array([]))
+        assert_equal(counts, np.array([]))
+
     def test_basic(self):
-        data1 = [3,5,1,10,23,3,2,6,8,6,10,6]
+        data1 = [3, 5, 1, 10, 23, 3, 2, 6, 8, 6, 10, 6]
         vals = stats.mode(data1)
-        assert_almost_equal(vals[0][0],6)
-        assert_almost_equal(vals[1][0],3)
+        assert_equal(vals[0][0], 6)
+        assert_equal(vals[1][0], 3)
 
     def test_axes(self):
-        data1 = [10,10,30,40]
-        data2 = [10,10,10,10]
-        data3 = [20,10,20,20]
-        data4 = [30,30,30,30]
-        data5 = [40,30,30,30]
+        data1 = [10, 10, 30, 40]
+        data2 = [10, 10, 10, 10]
+        data3 = [20, 10, 20, 20]
+        data4 = [30, 30, 30, 30]
+        data5 = [40, 30, 30, 30]
         arr = np.array([data1, data2, data3, data4, data5])
 
         vals = stats.mode(arr, axis=None)
-        assert_almost_equal(vals[0],np.array([30]))
-        assert_almost_equal(vals[1],np.array([8]))
+        assert_equal(vals[0], np.array([30]))
+        assert_equal(vals[1], np.array([8]))
 
         vals = stats.mode(arr, axis=0)
-        assert_almost_equal(vals[0],np.array([[10,10,30,30]]))
-        assert_almost_equal(vals[1],np.array([[2,3,3,2]]))
+        assert_equal(vals[0], np.array([[10, 10, 30, 30]]))
+        assert_equal(vals[1], np.array([[2, 3, 3, 2]]))
 
         vals = stats.mode(arr, axis=1)
-        assert_almost_equal(vals[0],np.array([[10],[10],[20],[30],[30]]))
-        assert_almost_equal(vals[1],np.array([[2],[4],[3],[4],[3]]))
+        assert_equal(vals[0], np.array([[10], [10], [20], [30], [30]]))
+        assert_equal(vals[1], np.array([[2], [4], [3], [4], [3]]))
 
     def test_strings(self):
         data1 = ['rain', 'showers', 'showers']
         vals = stats.mode(data1)
-        expected = ['showers']
         assert_equal(vals[0][0], 'showers')
         assert_equal(vals[1][0], 2)
 
@@ -1239,7 +1243,7 @@ class TestMode(TestCase):
             def __hash__(self):
                 return hash(self.x)
 
-        points = [Point(x) for x in [1,2,3,4,3,2,2,2]]
+        points = [Point(x) for x in [1, 2, 3, 4, 3, 2, 2, 2]]
         arr = np.empty((8,), dtype=object)
         arr[:] = points
         assert len(set(points)) == 4


### PR DESCRIPTION
@rgommers 

This includes the change to the `stats.mode` to handle empty arrays and the `dtype` of `counts` is now `int`. A unit test has been added for the empty arrays case and other test cases have been corrected for clarity. The docstring for `stats.mode` has been corrected and updated to reflect the change to the `dtype` of `counts`.

There are a few changes to `_chk_asarray` which have been discussed in the thread for this issue that do not directly pertain the original issue and are yet to be implemented.
