### PR TITLE
Fixed a problem (#4590) with svds accepting wrong eigenvalue parameters

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1768,7 +1768,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
         u = _augmented_orthonormal_cols(ularge, nsmall) if ularge is not None else None
         vh = _augmented_orthonormal_rows(vhlarge, nsmall) if vhlarge is not None else None
 
-    else:
+    elif which == 'SM':
 
         s = np.sqrt(eigvals)
         if not return_singular_vectors:
@@ -1781,5 +1781,9 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
         else:
             u = eigvec
             vh = _herm(X_matmat(u) / s) if return_singular_vectors != 'u' else None
+
+    else:
+
+        raise ValueError("which must be either 'LM' or 'SM'.")
 
     return u, s, vh

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -827,6 +827,17 @@ def test_svds_partial_return():
     if svds(z, 2, return_singular_vectors='u')[-1] is not None:
         raise AssertionError('right eigenvector matrix was computed when it should not have been')
 
+def test_svds_wrong_eigen_type():
+    # Regression test for a github issue.
+    # https://github.com/scipy/scipy/issues/4590
+    # Function was not checking for eigenvalue type and unintended
+    # values could be returned.
+    x = np.array([[1, 2, 3],
+                  [3, 4, 3],
+                  [1, 0, 2],
+                  [0, 0, 1]], np.float)
+    assert_raises(ValueError, svds, x, 1, which='LA')
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
The `svds` function in `arpack.py` did not check for the appropriate eigenvalue parameter.  Added a ValueError exception if an unsupported eigenvalue type is not provided.
