### PR TITLE
Speed up signal.lfilter and add a convolution path for FIR filters

### DIFF
--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -551,12 +551,19 @@ static void @NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
                        intp stride_Y)
 {
     char *ptr_x = x, *ptr_y = y;
-    @type@ *ptr_Z, *ptr_b;
-    @type@ *ptr_a;
+    @type@ *ptr_Z;
+    @type@ *ptr_b = (@type@*)b;
+    @type@ *ptr_a = (@type@*)a;
     @type@ *xn, *yn;
     const @type@ a0 = *((@type@ *) a);
     intp n;
     uintp k;
+
+    /* normalize the filter coefs only once. */
+    for (n = 0; n < len_b; ++n) {
+        ptr_b[n] /= a0;
+        ptr_a[n] /= a0;
+    }
 
     for (k = 0; k < len_x; k++) {
         ptr_b = (@type@ *) b;   /* Reset a and b pointers */
@@ -565,21 +572,21 @@ static void @NAME@_filt(char *b, char *a, char *x, char *y, char *Z,
         yn = (@type@ *) ptr_y;
         if (len_b > 1) {
             ptr_Z = ((@type@ *) Z);
-            *yn = *ptr_Z + *ptr_b / a0 * *xn;   /* Calculate first delay (output) */
+            *yn = *ptr_Z + *ptr_b  * *xn;   /* Calculate first delay (output) */
             ptr_b++;
             ptr_a++;
             /* Fill in middle delays */
             for (n = 0; n < len_b - 2; n++) {
                 *ptr_Z =
-                    ptr_Z[1] + *xn * (*ptr_b / a0) - *yn * (*ptr_a / a0);
+                    ptr_Z[1] + *xn * (*ptr_b) - *yn * (*ptr_a);
                 ptr_b++;
                 ptr_a++;
                 ptr_Z++;
             }
             /* Calculate last delay */
-            *ptr_Z = *xn * (*ptr_b / a0) - *yn * (*ptr_a / a0);
+            *ptr_Z = *xn * (*ptr_b) - *yn * (*ptr_a);
         } else {
-            *yn = *xn * (*ptr_b / a0);
+            *yn = *xn * (*ptr_b);
         }
 
         ptr_y += stride_Y;      /* Move to next input/output point */


### PR DESCRIPTION
`signal.lfilter` was doing a large number of unnecessary, repetitious divisions in the main filter loop.  Doing them once at the beginning gives about a 3x speed up.  I'm willing to concede that there might be cases where we don't want to normalize the filter coefficients, but those cases were broken before too.  I'd say that should be a future improvement. Its also not clear to me that this is such a problem for doubles.

As I suggested in #3454, when `a = [1]` we can recognize that we are using an FIR filter and do somewhat less work.  I've tried to make the interface and the errors produced as close as possible between the two paths.  

This sort of goes on top of #4614, but the changes are orthogonal to those so I made a separate PR.

Filtering 1,000,000 points with a 51 tap FIR filter drops from 237 ms to 56 ms for me.  A 51 tap IIR filter drops to 83 ms.  These improvements hold up for much smaller signal lengths as well.

I guess we should add some `lfilter` benchmarks?

I haven't looked at the complex filter loops, there might be something to do there too.
