### PR TITLE
MAINT: Fix convergence message for remez

### DIFF
--- a/scipy/signal/sigtoolsmodule.c
+++ b/scipy/signal/sigtoolsmodule.c
@@ -1242,9 +1242,7 @@ static PyObject *sigtools_remez(PyObject *NPY_UNUSED(dummy), PyObject *args) {
                       type, maxiter, grid_density);
         if (err < 0) {
 	  if (err == -1) {
-            sprintf(mystr, "Failure to converge after %d iterations.\n      " \
-                           "Design may still be correct.",
-                    maxiter);
+            sprintf(mystr, "Failure to converge after %d iterations.\n", maxiter);
 	    PyErr_SetString(PyExc_ValueError, mystr);
 	    goto fail;
 	  }


### PR DESCRIPTION
Correctly print the error message so as to describe the failure of convergence. Removes the "Design may still be correct" from the error message. Fixes #4569.
