### PR TITLE
DOC: Fix errors in docstring of pdist, squareform

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1153,7 +1153,8 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
     Y : ndarray
         Returns a condensed distance matrix Y.  For
         each :math:`i` and :math:`j` (where :math:`i<j<n`), the
-        metric ``dist(u=X[i], v=X[j])`` is computed and stored in entry ``ij``.
+        metric ``dist(u=X[i], v=X[j])`` is computed and stored 
+        in the :math:`ij` th entry.
 
     See Also
     --------
@@ -1420,10 +1421,10 @@ def squareform(X, force="no", checks=True):
 
     2. X = squareform(v)
 
-      Given a d*d(-1)/2 sized v for some integer d>=2 encoding distances
+      Given a d*(d-1)/2 sized v for some integer d>=2 encoding distances
       as described, X=squareform(v) returns a d by d distance matrix X. The
       X[i, j] and X[j, i] values are set to
-      v[{n \\choose 2}-{n-i \\choose 2} + (j-u-1)] and all
+      v[{n \\choose 2}-{n-i \\choose 2} + (j-i-1)] and all
       diagonal elements are zero.
 
     """


### PR DESCRIPTION
Fix some errors in the docstrings regarding the return value in pdist and notes section in squareform. Fixes issue #4472.
