### PR TITLE
MAINT: generalize a sign function to do the right thing for complex numbers

### DIFF
--- a/scipy/sparse/linalg/_onenormest.py
+++ b/scipy/sparse/linalg/_onenormest.py
@@ -107,8 +107,19 @@ def onenormest(A, t=2, itmax=5, compute_v=False, compute_w=False):
 
 
 def sign_round_up(X):
-    # differs from numpy sign in the way it handles entries that are zero
-    return np.sign(np.sign(X) + 0.5)
+    """
+    This should do the right thing for both real and complex matrices.
+
+    From Higham and Tisseur:
+    "Everything in this section remains valid for complex matrices
+    provided that sign(A) is redefined as the matrix (aij / |aij|)
+    (and sign(0) = 1) transposes are replaced by conjugate transposes.
+
+    """
+    Y = X.copy()
+    Y[Y == 0] = 1
+    Y /= np.abs(Y)
+    return Y
 
 
 def elementary_vector(n, i):


### PR DESCRIPTION
When I implemented the sparse one-norm estimation code, I was not careful enough about complex matrices.  This PR fixes a subtle inefficiency.  One subtlety is that I think the existing code was technically correct in the sense of providing a pretty good estimate of the 1-norm which is guaranteed to be an under-estimate.  Another subtlety is that the one-norm estimation routine is probabilistic in the sense of using random number samples, so debugging is more complicated than usual.

The effect of this PR is to slightly improve the one-norm estimates for complex matrices on average, and more importantly to more closely follow the algorithm specified in the original publication by Higham and Tisseur.  I've tested this by (slowly and non-rigorously) comparing pseudospectrum visualizations, and also by checking the significance of the change using a (slow) paired t-test of 1-norm estimates of random complex matrices.
