### PR TITLE
MAINT: use lapack for scipy.linalg.norm

### DIFF
--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -68,3 +68,15 @@ class Bench(Benchmark):
             nl.svd(self.a)
         else:
             sl.svd(self.a)
+
+    def time_1_norm(self, size, contig, module):
+        if module == 'numpy':
+            nl.norm(self.a, ord=1)
+        else:
+            sl.norm(self.a, ord=1)
+
+    def time_inf_norm(self, size, contig, module):
+        if module == 'numpy':
+            nl.norm(self.a, ord=np.inf)
+        else:
+            sl.norm(self.a, ord=np.inf)

--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -70,6 +70,22 @@ class Bench(Benchmark):
         else:
             sl.svd(self.a)
 
+
+class Norm(Benchmark):
+    params = [
+        [(20, 20), (100, 100), (1000, 1000), (20, 1000), (1000, 20)],
+        ['contig', 'nocont'],
+        ['numpy', 'scipy']
+    ]
+    param_names = ['shape', 'contiguous', 'module']
+
+    def setup(self, shape, contig, module):
+        a = np.random.randn(*shape)
+        if contig != 'contig':
+            a = a[-1::-1,-1::-1]  # turn into a non-contiguous array
+            assert_(not a.flags['CONTIGUOUS'])
+        self.a = a
+
     def time_1_norm(self, size, contig, module):
         if module == 'numpy':
             nl.norm(self.a, ord=1)

--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -97,3 +97,9 @@ class Norm(Benchmark):
             nl.norm(self.a, ord=np.inf)
         else:
             sl.norm(self.a, ord=np.inf)
+
+    def time_frobenius_norm(self, size, contig, module):
+        if module == 'numpy':
+            nl.norm(self.a)
+        else:
+            sl.norm(self.a)

--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -2,6 +2,7 @@ from __future__ import division, absolute_import, print_function
 
 import numpy.linalg as nl
 
+import numpy as np
 from numpy.testing import assert_
 from numpy.random import rand
 

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -121,8 +121,10 @@ def norm(a, ord=None):
             func_name = _nrm2_prefix.get(a.dtype.char, 'd') + 'nrm2'
             nrm2 = getattr(blas, func_name)
             return nrm2(a)
-        elif ord in (None, 'fro', 1, np.inf) and (a.ndim == 2):
-            # use lapack for a few fast matrix norms
+
+        if a.ndim == 2:
+            # Use lapack for a couple fast matrix norms.
+            # For some reason the *lange frobenius norm is slow.
             lange_args = None
             if ord == 1:
                 if np.isfortran(a):
@@ -134,15 +136,11 @@ def norm(a, ord=None):
                     lange_args = 'i', a
                 elif np.isfortran(a.T):
                     lange_args = '1', a.T
-            else:
-                if np.isfortran(a):
-                    lange_args = 'f', a
-                elif np.isfortran(a.T):
-                    lange_args = 'f', a.T
             if lange_args:
                 func_name = _lange_prefix.get(a.dtype.char, 'd') + 'lange'
                 lange = getattr(lapack, func_name)
                 return lange(*lange_args)
+
     return np.linalg.norm(a, ord=ord)
 
 

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -8,7 +8,7 @@ __all__ = ['LinAlgError', 'norm']
 
 _nrm2_prefix = {'f': 's', 'F': 'sc', 'D': 'dz'}
 _lange_prefix = {'f': 's', 'F': 'c', 'D': 'z'}
-_lange_norm_code = {1 : '1', np.inf : 'i'}
+_lange_norm_code = {1: '1', np.inf: 'i'}
 
 
 def norm(a, ord=None):

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -123,23 +123,26 @@ def norm(a, ord=None):
             return nrm2(a)
         elif ord in (None, 'fro', 1, np.inf) and (a.ndim == 2):
             # use lapack for a few fast matrix norms
-            func_name = _lange_prefix.get(a.dtype.char, 'd') + 'lange'
-            lange = getattr(lapack, func_name)
+            lange_args = None
             if ord == 1:
                 if np.isfortran(a):
-                    return lange('1', a)
+                    lange_args = '1', a
                 elif np.isfortran(a.T):
-                    return lange('i', a.T)
+                    lange_args = 'i', a.T
             elif ord == np.inf:
                 if np.isfortran(a):
-                    return lange('i', a)
+                    lange_args = 'i', a
                 elif np.isfortran(a.T):
-                    return lange('1', a.T)
+                    lange_args = '1', a.T
             else:
                 if np.isfortran(a):
-                    return lange('f', a)
+                    lange_args = 'f', a
                 elif np.isfortran(a.T):
-                    return lange('f', a.T)
+                    lange_args = 'f', a.T
+            if lange_args:
+                func_name = _lange_prefix.get(a.dtype.char, 'd') + 'lange'
+                lange = getattr(lapack, func_name)
+                return lange(*lange_args)
     return np.linalg.norm(a, ord=ord)
 
 

--- a/scipy/linalg/misc.py
+++ b/scipy/linalg/misc.py
@@ -2,12 +2,10 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.linalg import LinAlgError
-from . import blas, lapack
+from .blas import get_blas_funcs
+from .lapack import get_lapack_funcs
 
 __all__ = ['LinAlgError', 'norm']
-
-_nrm2_prefix = {'f': 's', 'F': 'sc', 'D': 'dz'}
-_lange_prefix = {'f': 's', 'F': 'c', 'D': 'z'}
 
 
 def norm(a, ord=None):
@@ -118,8 +116,7 @@ def norm(a, ord=None):
     if a.dtype.char in 'fdFD':
         if ord in (None, 2) and (a.ndim == 1):
             # use blas for fast and stable euclidean norm
-            func_name = _nrm2_prefix.get(a.dtype.char, 'd') + 'nrm2'
-            nrm2 = getattr(blas, func_name)
+            nrm2 = get_blas_funcs('nrm2', dtype=a.dtype)
             return nrm2(a)
 
         if a.ndim == 2:
@@ -137,8 +134,7 @@ def norm(a, ord=None):
                 elif np.isfortran(a.T):
                     lange_args = '1', a.T
             if lange_args:
-                func_name = _lange_prefix.get(a.dtype.char, 'd') + 'lange'
-                lange = getattr(lapack, func_name)
+                lange = get_lapack_funcs('lange', dtype=a.dtype)
                 return lange(*lange_args)
 
     return np.linalg.norm(a, ord=ord)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -872,7 +872,7 @@ class TestPinvSymmetric(TestCase):
         assert_array_almost_equal(np.dot(a, a_pinv), np.eye(3))
 
 
-class TestNorm(object):
+class TestVectorNorms(object):
 
     def test_types(self):
         for dtype in np.typecodes['AllFloat']:
@@ -909,6 +909,29 @@ class TestNorm(object):
     def test_zero_norm(self):
         assert_equal(norm([1,0,3], 0), 2)
         assert_equal(norm([1,2,3], 0), 3)
+
+
+class TestMatrixNorms(object):
+
+    def test_matrix_norms(self):
+        # Not all of these are matrix norms in the most technical sense.
+        np.random.seed(1234)
+        for n, m in (1, 1), (1, 3), (3, 1), (4, 4), (4, 5), (5, 4):
+            for t in np.single, np.double, np.csingle, np.cdouble, np.int64:
+                A = 10 * np.random.randn(n, m).astype(t)
+                if np.issubdtype(A.dtype, np.complexfloating):
+                    A = (A + 10j * np.random.randn(n, m)).astype(t)
+                    t_high = np.cdouble
+                else:
+                    t_high = np.double
+                for order in (None, 'fro', 1, -1, 2, -2, np.inf, -np.inf):
+                    actual = norm(A, ord=order)
+                    desired = np.linalg.norm(A, ord=order)
+                    # SciPy may return higher precision matrix norms.
+                    # This is a consequence of using LAPACK.
+                    if not np.allclose(actual, desired):
+                        desired = np.linalg.norm(A.astype(t_high), ord=order)
+                        np.assert_allclose(actual, desired)
 
 
 class TestOverwrite(object):


### PR DESCRIPTION
Use the `*lange` functions wrapped in https://github.com/scipy/scipy/pull/4603 for `scipy.linalg.norm`.  The scipy matrix norms appear to not have been tested (only vector norms) so I've added some tests.  I've also attempted to add `asv` benchmarks for the matrix `1-norm` and the matrix `inf-norm`.
