### PR TITLE
Added atleast_1d around poly in invres and invresz

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1295,7 +1295,7 @@ def invres(r, p, k, tol=1e-3, rtype='avg'):
         for m in range(mult[k]):
             t2 = temp[:]
             t2.extend([pout[k]] * (mult[k] - m - 1))
-            b = polyadd(b, r[indx] * poly(t2))
+            b = polyadd(b, r[indx] * atleast_1d(poly(t2)))
             indx += 1
     b = real_if_close(b)
     while allclose(b[0], 0, rtol=1e-14) and (b.shape[-1] > 1):
@@ -1495,7 +1495,7 @@ def invresz(r, p, k, tol=1e-3, rtype='avg'):
         for m in range(mult[k]):
             t2 = temp[:]
             t2.extend([pout[k]] * (mult[k] - m - 1))
-            brev = polyadd(brev, (r[indx] * poly(t2))[::-1])
+            brev = polyadd(brev, (r[indx] * atleast_1d(poly(t2)))[::-1])
             indx += 1
     b = real_if_close(brev[::-1])
     return b, a

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -15,7 +15,7 @@ from scipy import signal
 from scipy.signal import (
     correlate, convolve, convolve2d, fftconvolve,
     hilbert, hilbert2, lfilter, lfilter_zi, filtfilt, butter, tf2zpk,
-    invres, vectorstrength, signaltools, lfiltic, tf2sos, sosfilt, sosfilt_zi)
+    invres, invresz, vectorstrength, signaltools, lfiltic, tf2sos, sosfilt, sosfilt_zi)
 from scipy.signal.signaltools import _filtfilt_gust
 
 
@@ -1332,7 +1332,20 @@ class TestHilbert2(object):
 
 
 class TestPartialFractionExpansion(TestCase):
-
+    def test_invresz_one_coefficient_bug(self):
+        # This test was inspired by github issue 4646.
+        r = [1]
+        p = [2]
+        k = [0]
+        
+        a_expected = [1.0, 0.0]
+        b_expected = [1.0, -2.0]
+        
+        a_observed, b_observed = invresz(r, p, k)
+        
+        assert_allclose(a_observed, a_expected)
+        assert_allclose(b_observed, b_expected)
+        
     def test_invres_distinct_roots(self):
         # This test was inspired by github issue 2496.
         r = [3 / 10, -1 / 6, -2 / 15]


### PR DESCRIPTION
Those changes prevent the following bug:

import scipy.signal
scipy.signal.invresz([2], [1],[0.])

... line 1496, in invresz
brev = polyadd(brev, (r[indx] \* poly(t2))[::-1])
IndexError: invalid index to scalar variable.
