### PR TITLE
BUG: Fixes #4408: Vector-valued constraints in minimize() et al

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -37,7 +37,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
              hessp=None, bounds=None, constraints=(), tol=None,
              callback=None, options=None):
     """Minimization of scalar function of one or more variables.
-     
+    
     In general, the optimization problems are of the form:
     
     minimize f(x)
@@ -215,7 +215,9 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     Constrained Optimization BY Linear Approximation (COBYLA) method
     [9]_, [10]_, [11]_. The algorithm is based on linear
     approximations to the objective function and each constraint. The
-    method wraps a FORTRAN implementation of the algorithm.
+    method wraps a FORTRAN implementation of the algorithm. The
+    constraints functions 'fun' may return either a single number
+    or an array or list of numbers.
 
     Method :ref:`SLSQP <optimize.minimize-slsqp>` uses Sequential
     Least SQuares Programming to minimize a function of several

--- a/scipy/optimize/tests/test_cobyla.py
+++ b/scipy/optimize/tests/test_cobyla.py
@@ -11,7 +11,7 @@ from scipy.optimize import fmin_cobyla, minimize
 
 class TestCobyla(TestCase):
     def setUp(self):
-        self.x0 = [4.95,0.66]
+        self.x0 = [4.95, 0.66]
         self.solution = [math.sqrt(25 - (2.0/3)**2), 2.0/3]
         self.opts = {'disp': False, 'rhobeg': 1, 'tol': 1e-5,
                      'maxiter': 100}
@@ -70,6 +70,48 @@ class TestCobyla(TestCase):
                        options={'catol': 1e-6})
         assert_(sol.maxcv > 1e-6)
         assert_(not sol.success)
+
+
+def test_vector_constraints():
+    # test that fmin_cobyla and minimize can take a combination
+    # of constraints, some returning a number and others an array
+    def fun(x):
+        return (x[0] - 1)**2 + (x[1] - 2.5)**2
+
+    def fmin(x):
+        return fun(x) - 1
+
+    def cons1(x):
+        a = np.array([[1, -2, 2], [-1, -2, 6], [-1, 2, 2]])
+        return np.array([a[i, 0] * x[0] + a[i, 1] * x[1] +
+                         a[i, 2] for i in range(len(a))])
+
+    def cons2(x):
+        return x     # identity, acts as bounds x > 0
+
+    x0 = np.array([2, 0])
+    cons_list = [fun, cons1, cons2]
+
+    xsol = [1.4, 1.7]
+    fsol = 0.8
+
+    # testing fmin_cobyla
+    sol = fmin_cobyla(fun, x0, cons_list, iprint=0)
+    assert_allclose(sol, xsol, atol=1e-4)
+
+    sol = fmin_cobyla(fun, x0, fmin, iprint=0)
+    assert_allclose(fun(sol), 1, atol=1e-4)
+
+    # testing minimize
+    constraints = [{'type': 'ineq', 'fun': cons} for cons in cons_list]
+    sol = minimize(fun, x0, constraints=constraints)
+    assert_allclose(sol.x, xsol, atol=1e-4)
+    assert_(sol.success, sol.message)
+    assert_allclose(sol.fun, fsol, atol=1e-4)
+
+    constraints = {'type': 'ineq', 'fun': fmin}
+    sol = minimize(fun, x0, constraints=constraints)
+    assert_allclose(sol.fun, 1, atol=1e-4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Using optimize.fmin_cobyla or optimize.minimize with method 'Cobyla' with vector-valued constraints used to throw a ValueError "setting an array element with a sequence" at line 240 in cobyla.py. The constraints functions could only return numbers for Cobyla, while SLSQP was able to take in vector constraints. Now Cobyla can take either a single constraint or a sequence of constraints, where each constraint function can return either a number or a sequence of numbers. This is true for both fmin_cobyla and minimize. 
