### PR TITLE
Vonmisesfix

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -122,6 +122,9 @@ def test_vonmises_line_support():
     assert_equal(stats.vonmises_line.a, -np.pi)
     assert_equal(stats.vonmises_line.b, np.pi)
 
+def test_vonmises_numerical():
+    vm = stats.vonmises(800)
+    assert_almost_equal(vm.cdf(0), 0.5)
 
 class TestRandInt(TestCase):
     def test_rvs(self):

--- a/scipy/stats/vonmises_cython.pyx
+++ b/scipy/stats/vonmises_cython.pyx
@@ -1,6 +1,6 @@
 import numpy as np
 import scipy.stats
-from scipy.special import i0
+from scipy.special import i0, i0e
 import numpy.testing
 
 cimport cython
@@ -30,7 +30,7 @@ cdef double von_mises_cdf_series(double k,double x,unsigned int p):
         return 0.5 + x / (2 * NPY_PI) + V / NPY_PI
 
 cdef von_mises_cdf_normalapprox(k, x):
-    b = sqrt(NPY_2_PI) * np.exp(k) / i0(k)
+    b = sqrt(NPY_2_PI) / i0e(k) # Check for negative k
     z = b*np.sin(x/2.)
     return scipy.stats.norm.cdf(z)
 


### PR DESCRIPTION
The von Mises distribution CDF doesn't work properly for narrow distributions because the exponential and the Bessel function it is divided by both underflow; scipy.special.i0e exists for this very reason. Wrote a test and fixed the problem.
