### PR TITLE
improve erf performance

### DIFF
--- a/scipy/special/cephes/mconf.h
+++ b/scipy/special/cephes/mconf.h
@@ -70,6 +70,7 @@
 
 #include "cephes_names.h"
 #include "protos.h"
+#include "polevl.h"
 
 /* Constant definitions for math error conditions
  */

--- a/scipy/special/cephes/ndtr.c
+++ b/scipy/special/cephes/ndtr.c
@@ -147,6 +147,16 @@
 #include <float.h>		/* DBL_EPSILON */
 #include "mconf.h"
 
+#if !defined(__clang__) && defined(__GNUC__) && defined(__GNUC_MINOR__)
+#if __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
+#pragma GCC optimize("unroll-loops")
+#define cephes_isnan(x) __builtin_isnan(x)
+#endif
+#endif
+#ifndef cephes_isnan
+#define cephes_isnan(x) npy_isnan(x)
+#endif
+
 
 extern double SQRTH;
 extern double MAXLOG;
@@ -408,7 +418,7 @@ double ndtr(double a)
 {
     double x, y, z;
 
-    if (npy_isnan(a)) {
+    if (cephes_isnan(a)) {
 	mtherr("ndtr", DOMAIN);
 	return (NPY_NAN);
     }
@@ -434,7 +444,7 @@ double erfc(double a)
 {
     double p, q, x, y, z;
 
-    if (npy_isnan(a)) {
+    if (cephes_isnan(a)) {
 	mtherr("erfc", DOMAIN);
 	return (NPY_NAN);
     }
@@ -485,7 +495,7 @@ double erf(double x)
 {
     double y, z;
 
-    if (npy_isnan(x)) {
+    if (cephes_isnan(x)) {
 	mtherr("erf", DOMAIN);
 	return (NPY_NAN);
     }

--- a/scipy/special/cephes/ndtr.c
+++ b/scipy/special/cephes/ndtr.c
@@ -147,6 +147,7 @@
 #include <float.h>		/* DBL_EPSILON */
 #include "mconf.h"
 
+
 extern double SQRTH;
 extern double MAXLOG;
 

--- a/scipy/special/cephes/polevl.h
+++ b/scipy/special/cephes/polevl.h
@@ -48,12 +48,14 @@
  * Copyright 1984, 1987, 1988 by Stephen L. Moshier
  * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
  */
-#include "protos.h"
 
-double polevl(x, coef, N)
-double x;
-double coef[];
-int N;
+#ifndef CEPHES_POLEV
+#define CEPHES_POLEV
+
+#include "protos.h"
+#include <numpy/npy_common.h>
+
+static NPY_INLINE double polevl(double x, double coef[], int N)
 {
     double ans;
     int i;
@@ -76,10 +78,7 @@ int N;
  * Otherwise same as polevl.
  */
 
-double p1evl(x, coef, N)
-double x;
-double coef[];
-int N;
+static NPY_INLINE double p1evl(double x, double coef[], int N)
 {
     double ans;
     double *p;
@@ -95,3 +94,5 @@ int N;
 
     return (ans);
 }
+
+#endif

--- a/scipy/special/cephes/protos.h
+++ b/scipy/special/cephes/protos.h
@@ -114,8 +114,6 @@ extern long lsqrt(long x);
 extern int minv(double A[], double X[], int n, double B[], int IPS[]);
 extern void mmmpy(int r, int c, double *A, double *B, double *Y);
 extern int mtherr(char *name, int code);
-extern double polevl(double x, double *P, int N);
-extern double p1evl(double x, double *P, int N);
 extern void mtransp(int n, double *A, double *T);
 extern void mvmpy(int r, int c, double *A, double *V, double *Y);
 extern double nbdtrc(int k, int n, double p);


### PR DESCRIPTION
as suggested by @pv allow inlining polynomials, combined with unrolling and isnan replace this bumps performance quite considerably:

```
import numpy as np
import scipy.special as sps
r=np.random.rand(int(1e5))
%timeit -n 1000 -r 5 sps.erf(r)
%timeit -n 1000 -r 5 sps.erf(r + 2.)
```

before:

```
1000 loops, best of 5: 2.7 ms per loop
1000 loops, best of 5: 9.56 ms per loop
```

after

```
1000 loops, best of 5: 1.17 ms per loop
1000 loops, best of 5: 6.42 ms per loop
```
