### PR TITLE
Accelerate major axis sequence slicing for compressed sparse matrices.

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -143,6 +143,7 @@ Alex Conley for the Exponentially Modified Normal distribution.
 Abraham Escalante for contributions to scipy.stats
 Johannes Ballé for the generalized normal distribution.
 Irvin Probst (ENSTA Bretagne) for pole placement.
+Eric Martin for performance improvements on sparse matrix indexing.
 
 
 Institutions

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -289,8 +289,49 @@ class csr_matrix(_cs_matrix, IndexMixin):
         elif issequence(row):
             # [[1,2],??]
             if isintlike(col) or isinstance(col,slice):
-                P = extractor(row, self.shape[0])     # [[1,2],j] or [[1,2],1:2]
-                return (P*self)[:,col]
+                row_indices = np.asarray(row)
+                shape = (row_indices.size, self.shape[1])
+
+                # The output array is going to have a bunch of contiguous
+                # slices of the data and indices arrays. Let's compute the
+                # endpoints of these slices.
+                starts = self.indptr[row_indices]
+                ends = self.indptr[row_indices + 1]
+                lens = ends - starts
+
+                range_starts = lens.cumsum()
+
+                # indptr of output
+                indptr = np.hstack((0, range_starts))
+
+                # data and indices are only nonzero if we are slicing any data
+                data = np.array([], dtype=self.data.dtype)
+                indices = np.array([], dtype=np.intp)
+                if np.count_nonzero(lens) != 0:
+                    # data and indices aren't affected by empty rows, so we can
+                    # only consider non-zero rows and columns
+                    range_starts, uniq_idx = np.unique(range_starts,
+                                                       return_index=True)
+                    starts = starts[uniq_idx]
+                    ends = ends[uniq_idx]
+
+                    # we'll modify idxs to refer to the elements we want from data
+                    # and indices.
+                    idxs = np.ones(range_starts[-1], dtype=np.intp)
+                    idxs[0] = starts[0]
+                    idxs[range_starts[:-1]] += starts[1:] - ends[:-1]
+                    idxs = idxs.cumsum()
+
+                    data = self.data[idxs]
+                    indices = self.indices[idxs]
+
+                sliced = csr_matrix((data, indices, indptr), shape=shape)
+
+                # avoid extra copy when possible
+                if col == slice(None, None, None):
+                    return sliced
+                else:
+                    return sliced[:, col]
 
         if not (issequence(col) and issequence(row)):
             # Sample elementwise

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -289,7 +289,11 @@ class csr_matrix(_cs_matrix, IndexMixin):
         elif issequence(row):
             # [[1,2],??]
             if isintlike(col) or isinstance(col,slice):
-                row_indices = np.asarray(row)
+                row_indices = asindices(row)
+
+                # make all indices in [0, self.shape[0])
+                row_indices += (row_indices < 0) * self.shape[0]
+
                 shape = (row_indices.size, self.shape[1])
 
                 # The output array is going to have a bunch of contiguous

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -2,6 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal, run_module_suite, assert_
+from scipy._lib.six import xrange
 from scipy.sparse import csr_matrix
 
 

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -28,6 +28,25 @@ def test_csr_rowslice():
         for sl in slices:
             yield _check_csr_rowslice, i, sl, X, Xcsr
 
+def test_csr_getrowsequence():
+    N = 3
+    np.random.seed(0)
+    X = np.random.random((N, N))
+
+    # test over all 2 ** (N ** 2) sparsity patterns on NxN matrix
+    for i in xrange(2 ** (N ** 2)):
+        bits = [int(c) for c in bin(i)[2:]]
+        if len(bits) < (N ** 2):
+            bits = ([0] * (N ** 2 - len(bits))) + bits
+
+        Z = X * np.array(bits, dtype=np.int).reshape((N, N))
+        Zcsr = csr_matrix(Z)
+
+        assert_array_almost_equal(Z[[0], :], Zcsr[[0], :].toarray())
+        assert_array_almost_equal(Z[[2], :], Zcsr[[2], :].toarray())
+        assert_array_almost_equal(Z[[0, 2], :], Zcsr[[0, 2], :].toarray())
+        assert_array_almost_equal(Z[[1, 2], :], Zcsr[[1, 2], :].toarray())
+        assert_array_almost_equal(Z[[2, 0], :], Zcsr[[2, 1], :].toarray())
 
 def test_csr_getrow():
     N = 10

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -46,7 +46,7 @@ def test_csr_getrowsequence():
         assert_array_almost_equal(Z[[2], :], Zcsr[[2], :].toarray())
         assert_array_almost_equal(Z[[0, 2], :], Zcsr[[0, 2], :].toarray())
         assert_array_almost_equal(Z[[1, 2], :], Zcsr[[1, 2], :].toarray())
-        assert_array_almost_equal(Z[[2, 0], :], Zcsr[[2, 1], :].toarray())
+        assert_array_almost_equal(Z[[2, 0], :], Zcsr[[2, 0], :].toarray())
 
 def test_csr_getrow():
     N = 10


### PR DESCRIPTION
Indexing a CSR matrix with a slice such as X[[1, 100, 105], :] is
between 2x and 75x faster, with the greater performance improvements
coming when the size of the indexing list is small. This performance
improvements also apply to slicing a CSC matrix with a sequence of
columns.

Tests were added to ensure correct sequence slicing behavior.

This is my resolution to #4573. I incorporated @jaimefrio's suggestion, which did lead to significant performance increases.
