### PR TITLE
Avoid extra copy for sparse compressed [:, seq] and [seq, :] slices.

### DIFF
--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -283,14 +283,22 @@ class csr_matrix(_cs_matrix, IndexMixin):
                 # col is int or slice with step 1, row is slice with step 1.
                 return self._get_submatrix(row, col)
             elif issequence(col):
-                P = extractor(col,self.shape[1]).T        # [1:2,[1,2]]
                 # row is slice, col is sequence.
-                return self[row,:]*P
+                P = extractor(col,self.shape[1]).T        # [1:2,[1,2]]
+                sliced = self
+                if row != slice(None, None, None):
+                    sliced = sliced[row,:]
+                return sliced * P
+
         elif issequence(row):
             # [[1,2],??]
             if isintlike(col) or isinstance(col,slice):
                 P = extractor(row, self.shape[0])     # [[1,2],j] or [[1,2],1:2]
-                return (P*self)[:,col]
+                extracted = P * self
+                if col == slice(None, None, None):
+                    return extracted
+                else:
+                    return extracted[:,col]
 
         if not (issequence(col) and issequence(row)):
             # Sample elementwise


### PR DESCRIPTION
The current slicing implementation performs an unnecessary copy when indexing a sparse compressed matrix with `slice(None, None, None)` and a sequence. This PR adds a small amount of conditional logic to the callsites to avoid the unnecessary copy. 

Although it would be cleaner, this logic could not be put in `_get_submatrix` because  `_get_submatrix` always must return a newly copied matrix (even when the submatrix is the full matrix). This means that the only way to avoid these copies is to avoid calling `_get_submatrix`.

Performance numbers where `X = sp.rand(100000, 1000, format='csr', density=0.05)`:

| Slice | HEAD | This PR |
| --- | --- | --- |
| `X[[0, 100, 105], :]` | 395 us | 302 us |
| `X[np.arange(10000), :]` | 11.5 ms | 5.28 ms |
| `X[:, [0, 100, 105]]` | 119 ms | 19.1 ms |
| `X[:, np.arange(100)]` | 125 ms | 26 ms |

This type of slicing is likely a common pattern (I had a use case of it that caused me to look into its performance), so these performance improvements are meaningful, especially when slicing along the minor axis.
