### PR TITLE
ENH: add axis to sparse norms

### DIFF
--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -15,7 +15,15 @@ from numpy.core import (
     )
 
 
-def norm(x, ord=None):
+def _sparse_frobenius_norm(x):
+    if np.issubdtype(x.dtype, np.complexfloating):
+        sqnorm = abs(x).power(2).sum()
+    else:
+        sqnorm = x.power(2).sum()
+    return sqrt(sqnorm)
+
+
+def norm(x, ord=None, axis=None):
     """
     Norm of a sparse matrix
 
@@ -29,6 +37,12 @@ def norm(x, ord=None):
     ord : {non-zero int, inf, -inf, 'fro'}, optional
         Order of the norm (see table under ``Notes``). inf means numpy's
         `inf` object.
+    axis : {int, 2-tuple of ints, None}, optional
+        If `axis` is an integer, it specifies the axis of `x` along which to
+        compute the vector norms.  If `axis` is a 2-tuple, it specifies the
+        axes that hold 2-D matrices, and the matrix norms of these matrices
+        are computed.  If `axis` is None then either a vector norm (when `x`
+        is 1-D) or a matrix norm (when `x` is 2-D) is returned.
 
     Returns
     -------
@@ -101,16 +115,25 @@ def norm(x, ord=None):
         raise TypeError("input is not sparse. use numpy.linalg.norm")
 
     # Check the default case first and handle it immediately.
-    if ord in (None, 'fro', 'f'):
-        if np.issubdtype(x.dtype, np.complexfloating):
-            sqnorm = abs(x).power(2).sum()
-        else:
-            sqnorm = x.power(2).sum()
-        return sqrt(sqnorm)
+    if axis is None and ord in (None, 'fro', 'f'):
+        return _sparse_frobenius_norm(x)
 
-    nd = x.ndim
-    axis = tuple(range(nd))
+    # Some norms require functions that are not implemented for all types.
+    x = x.tocsr()
 
+    if axis is None:
+        axis = (0, 1)
+    elif not isinstance(axis, tuple):
+        msg = "'axis' must be None, an integer or a tuple of integers"
+        try:
+            int_axis = int(axis)
+        except TypeError:
+            raise TypeError(msg)
+        if axis != int_axis:
+            raise TypeError(msg)
+        axis = (int_axis,)
+
+    nd = 2
     if len(axis) == 2:
         row_axis, col_axis = axis
         if not (-nd <= row_axis < nd and -nd <= col_axis < nd):
@@ -132,7 +155,34 @@ def norm(x, ord=None):
             return abs(x).sum(axis=row_axis).min(axis=col_axis)[0,0]
         elif ord == -Inf:
             return abs(x).sum(axis=col_axis).min(axis=row_axis)[0,0]
+        elif ord in (None, 'f', 'fro'):
+            # The axis order does not matter for this norm.
+            return _sparse_frobenius_norm(x)
         else:
             raise ValueError("Invalid norm order for matrices.")
+    elif len(axis) == 1:
+        a, = axis
+        if not (-nd <= a < nd):
+            raise ValueError('Invalid axis %r for an array with shape %r' %
+                             (axis, x.shape))
+        if ord == Inf:
+            M = abs(x).max(axis=a)
+        elif ord == -Inf:
+            M = abs(x).min(axis=a)
+        elif ord == 0:
+            # Zero norm
+            M = (x != 0).sum(axis=a)
+        elif ord == 1:
+            # special case for speedup
+            M = abs(x).sum(axis=a)
+        elif ord in (2, None):
+            M = sqrt(abs(x).power(2).sum(axis=a))
+        else:
+            try:
+                ord + 1
+            except TypeError:
+                raise ValueError('Invalid norm order for vectors.')
+            M = np.power(abs(x).power(ord).sum(axis=a), 1 / ord)
+        return M.A.ravel()
     else:
         raise ValueError("Improper number of dimensions to norm.")

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -46,7 +46,7 @@ def norm(x, ord=None, axis=None):
 
     Returns
     -------
-    n : float or matrix
+    n : float or ndarray
 
     Notes
     -----

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -6,8 +6,9 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from numpy.linalg import norm as npnorm
 from numpy.testing import (assert_raises, assert_equal, assert_allclose,
-        TestCase)
+        TestCase, dec)
 
+from scipy._lib._version import NumpyVersion
 import scipy.sparse
 from scipy.sparse.linalg import norm as spnorm
 
@@ -87,6 +88,7 @@ class TestVsNumpyNorm(TestCase):
                 [-1, 1, 4j]],
             )
 
+    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_sparse_matrix_norms(self):
         for sparse_type in self._sparse_types:
             for M in self._test_matrices:
@@ -98,6 +100,7 @@ class TestVsNumpyNorm(TestCase):
                 assert_allclose(spnorm(S, 1), npnorm(M, 1))
                 assert_allclose(spnorm(S, -1), npnorm(M, -1))
 
+    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_sparse_matrix_norms_with_axis(self):
         for sparse_type in self._sparse_types:
             for M in self._test_matrices:
@@ -115,6 +118,7 @@ class TestVsNumpyNorm(TestCase):
                     assert_allclose(spnorm(S, 'fro', axis=axis),
                                     npnorm(M, 'fro', axis=axis))
 
+    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_sparse_vector_norms(self):
         for sparse_type in self._sparse_types:
             for M in self._test_matrices:


### PR DESCRIPTION
This PR adds an `axis` keyword argument to sparse norms, using code from the numpy norm implementation and pieces of https://github.com/scipy/scipy/pull/3303.  The `keepdims` keyword argument is not yet implemented.

The sparse norm implementation in this PR returns scalars or 1d ndarrays.  This behavior is not standard for sparse matrices, and contributes to the following confusion:

``` python
>>> s = scipy.sparse.identity(4).tocsr()
>>> s.max(axis=0)
<1x4 sparse matrix of type '<type 'numpy.float64'>'
        with 4 stored elements in COOrdinate format>
>>> s.sum(axis=0)
matrix([[ 1.,  1.,  1.,  1.]])
>>> spnorm(s, axis=0)
array([ 1.,  1.,  1.,  1.])
```
