### PR TITLE
fix behavior of scipy.linalg.block_diag for empty input

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -144,6 +144,8 @@ Abraham Escalante for contributions to scipy.stats
 Johannes Ballé for the generalized normal distribution.
 Irvin Probst (ENSTA Bretagne) for pole placement.
 Ian Henriksen for Cython wrappers for BLAS and LAPACK
+Fukumu Tsutsumi for bug fixes.
+
 
 
 Institutions

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -528,7 +528,7 @@ def block_diag(*arrs):
         raise ValueError("arguments in the following positions have dimension "
                          "greater than 2: %s" % bad_args)
 
-    shapes = np.array([a.shape for a in arrs])
+    shapes = np.array([a.shape if a.size > 0 else [0, 0] for a in arrs])
     out = np.zeros(np.sum(shapes, axis=0), dtype=arrs[0].dtype)
 
     r, c = 0, 0

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -259,6 +259,11 @@ class TestBlockDiag:
         a = block_diag()
         assert_equal(a.ndim, 2)
         assert_equal(a.nbytes, 0)
+    
+    def test_empty_matrix_arg(self):
+        # regression test for gh-4596: check the shape of the result for empty matrix inputs
+        a = block_diag([[1, 0], [0, 1]], [], [[2, 3], [4, 5], [6, 7]])
+        assert_array_equal(a, [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 2, 3], [0, 0, 4, 5], [0, 0, 6, 7]])
 
 
 class TestKron:


### PR DESCRIPTION
I fix the bug #4596. This bug happens because `np.array([[]]).shape` is actually `(1,0)`. The code expected `(0,0)`.
