### PR TITLE
ENH: interpolate: add rational interpolation

### DIFF
--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -116,6 +116,17 @@ Low-level interface to FITPACK functions:
    bisplrep
    bisplev
 
+Rational interpolation
+======================
+
+.. autosummary::
+   :toctree: generated/
+
+   floater_hormann
+   lsq_rational
+   RationalBarycentricInterpolation
+   RationalInterpolationWarning
+
 Additional tools
 ================
 
@@ -155,6 +166,8 @@ from .polyint import *
 from ._monotone import *
 
 from .ndgriddata import *
+
+from ._ratinterp import *
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 from numpy.testing import Tester

--- a/scipy/interpolate/_ratinterp.py
+++ b/scipy/interpolate/_ratinterp.py
@@ -1,0 +1,435 @@
+"""
+Rational interpolation in barycentric form
+"""
+from __future__ import division, print_function, absolute_import
+
+import sys
+import warnings
+import itertools
+
+import numpy as np
+from numpy import linspace, pi
+import scipy.linalg
+
+try:
+    from scipy._lib.six import xrange
+except ImportError:
+    from scipy.lib.six import xrange
+
+
+__all__ = ['floater_hormann', 'lsq_rational',
+           'RationalInterpolationWarning', 'RationalBarycentricInterpolation']
+
+
+class RationalInterpolationWarning(Warning):
+    pass
+
+
+class RationalBarycentricInterpolation(object):
+    r"""
+    Rational function interpolator in barycentric form
+
+    .. math::
+
+       Q(z) = \frac{\sum_j \frac{u_j y_j}{x_j - z}}{\sum_j \frac{u_j}{x_j - z}}
+
+    Parameters
+    ----------
+    x : array_like, shape (N,)
+        Interpolation points
+    y : array_like, shape (..., N)
+        Data at interpolation points
+    u : array_like, shape (..., N)
+        Weights of interpolation points
+
+    See Also
+    --------
+    floater_hormann, lsq_rational
+
+    Methods
+    -------
+    __call__
+    get_numerator
+    get_denominator
+
+    Attributes
+    ----------
+    x
+    y
+    u
+    numerator_roots
+    denominator_roots
+    """
+
+    def __init__(self, x, y, u):
+        self.x = np.asarray(x)
+        self.y = np.asarray(y)
+        self.u = np.asarray(u)
+        self._dtype = np.find_common_type([self.x.dtype, self.y.dtype, self.u.dtype, np.inexact], [])
+        if self.x.ndim != 1 or self.x.size != self.y.shape[-1]:
+            raise ValueError("x and y have incompatible shapes")
+        if self.u.shape[-1] != self.y.shape[-1]:
+            raise ValueError("y and u have incompatible shapes")
+        self._numerator_roots = None
+        self._denominator_roots = None
+
+    def __call__(self, xp):
+        xp = np.asarray(xp)
+        xp_shape = xp.shape
+        xp = xp.ravel()
+
+        x = self.x
+        y = self.y
+
+        r = np.empty(y.shape[:-1] + (xp.size,), dtype=self._dtype)
+
+        qs = xp - x[:,None]
+
+        # Deal with exact zeros
+        k = np.argmin(abs(qs), axis=0)
+        j = np.arange(len(xp))
+        m = (qs[k,j] == 0)
+        r[...,m] = y[...,k[m]]
+
+        # Other points: barycentric interpolation
+        qs = qs[...,~m]
+        np.reciprocal(qs, out=qs)
+        numerator = np.einsum('...i,...i,...ij->...j', y, self.u, qs)
+        denominator = np.einsum('...i,...ij->...j', self.u, qs)
+        r[...,~m] = numerator/denominator
+
+        return r.reshape(y.shape[:-1] + xp_shape)
+
+    @staticmethod
+    def _polyroots(x, u, dtype):
+        r"""
+        Find the roots of the polynomial
+
+        .. math::
+
+           p(z) = [\prod_n (z - x_n)] \sum_n \frac{u_n}{z - x_n}
+
+        References
+        ----------
+        [1] R. M. Corless, Generalized companion matrices in the Lagrange basis,
+            in Proceedings EACA, L. Gonzalez-Vega and T. Recio, eds., June 2004,
+            pp. 317-322.
+        """
+        n = len(x)
+        uv = u.reshape(-1, u.shape[-1])
+        j = np.arange(1, n+1)
+        z = np.empty((uv.shape[0], n-1), dtype=complex)
+
+        for k in xrange(uv.shape[0]):
+            A = np.zeros((n+1, n+1), dtype=dtype, order="F")
+            A[0,1:] = -1
+            A[1:,0] = u
+            A[j,j] = x
+
+            B = np.zeros((n+1, n+1), dtype=dtype, order="F")
+            B[j,j] = 1
+
+            with np.errstate(divide='ignore', invalid='ignore'):
+                w = scipy.linalg.eig(A, B, right=False, overwrite_a=True, overwrite_b=True)
+
+            # lexicographic sort puts infs to the end
+            w[~np.isfinite(w)] = np.inf
+            w.sort()
+            z[k] = w[:-2]
+
+        return z.reshape(u.shape[:-1] + (n-1,))
+
+    def get_numerator(self, format='poly1d'):
+        """
+        Compute the numerator polynomial
+
+        Parameters
+        ----------
+        format : {'poly1d'}
+            Format of returned polynomial, see below.
+            Currently only 'poly1d' is available
+
+        Returns
+        -------
+        p
+            Numerator polynomial
+
+        Notes
+        -----
+        Format 'poly1d' polynomials are numerically unstable, and
+        will return mostly noise at orders => 20.
+
+        """
+        if format == 'poly1d':
+            return _lagpoly(self.x, self.u * self.y / abs(self.u).max())
+        else:
+            raise ValueError("Invalid polynomial format")
+
+    def get_denominator(self, format='poly1d'):
+        """
+        Compute the denominator polynomial
+
+        Parameters
+        ----------
+        format : {'poly1d'}
+            Format of returned polynomial, see below.
+            Currently only 'poly1d' is available
+
+        Returns
+        -------
+        p
+            Denominator polynomial
+
+        Notes
+        -----
+        Format 'poly1d' polynomials are numerically unstable, and
+        will return mostly noise at orders => 20.
+
+        """
+        if format == 'poly1d':
+            return _lagpoly(self.x, self.u / abs(self.u).max())
+        else:
+            raise ValueError("Invalid polynomial format")
+
+    @property
+    def numerator_roots(self):
+        """
+        Roots of the numerator polynomial.
+
+        Notes
+        -----
+        Note that if these roots coincide exactly with the roots of
+        the denominator polynomial, the rational function may not
+        have a root at that point.
+        """
+        if self._numerator_roots is None:
+            self._numerator_roots = RationalBarycentricInterpolation._polyroots(
+                self.x, self.y * self.u, self._dtype)
+        return self._numerator_roots
+
+    @property
+    def denominator_roots(self):
+        """
+        Roots of the denominator polynomial.
+
+        Notes
+        -----
+        Note that if these roots coincide exactly with the roots of
+        the numerator polynomial, the rational function does not have
+        a pole at that point.
+        """
+        if self._denominator_roots is None:
+            self._denominator_roots = RationalBarycentricInterpolation._polyroots(
+                self.x, self.u, self._dtype)
+        return self._denominator_roots
+
+
+def _lagpoly(x, u):
+    """
+    poly1d power-basis representation of the polynomial
+
+    .. math:: p(z) = [\prod_n (z - x_n)] \sum_n \frac{u_n}{z - x_n}
+    """
+    M = len(x)
+    p = np.poly1d(0.0)
+    for j in xrange(M):
+        pt = np.poly1d(u[j])
+        for k in xrange(M):
+            if k == j:
+                continue
+            pt *= np.poly1d([1.0, -x[k]])
+        p += pt
+    return p
+
+
+def floater_hormann(x, y, d=3):
+    """
+    Compute Floater-Hormann barycentric rational interpolant of data
+
+    Parameters
+    ----------
+    x : array_like, shape (n,)
+        Interpolation points
+    y : array_like, shape (n,)
+        Function values at interpolation points
+    d : int, optional
+        Floater-Hormann interpolant order
+
+    Returns
+    -------
+    ip : RationalBarycentricInterpolation
+        Rational barycentric interpolator of data
+
+    Notes
+    -----
+    The Floater-Hormann interpolant is a rational function that
+    interpolates the data with approximation order
+    :math:`O(h^{d+1})`. The interpolant contains no poles on the real
+    axis, unlike in typical rational interpolants.
+
+    References
+    ----------
+    [1] M.S. Floater and K. Hormann, ''Barycentric rational interpolation
+        with no poles and high rates of approximation'',
+        Numer. Math. **107**, 315 (2007).
+        http://dx.doi.org/10.1007/s00211-007-0093-y
+
+    """
+
+    x = np.asarray(x)
+    y = np.asarray(y)
+    n = len(x)
+
+    if x.ndim != 1 or x.shape[0] != y.shape[-1]:
+        raise ValueError("x and y do not have matching shape")
+
+    d = min(x.size-1, d)
+    if not d >= 0:
+        raise ValueError("d not >= 0")
+
+    x, y = _sort_and_average_duplicates(x, y)
+
+    # Floater-Hormann weights
+    u = np.zeros((n,), dtype=np.find_common_type([x.dtype, np.inexact], []))
+
+    # Evaluate the start and end ranges with explicit for loops
+    for i in itertools.chain(xrange(d), xrange(max(d, n - d), n)):
+        for k in xrange(max(i-d, 0), min(i+1, n-d)):
+            c = 1.0
+            for p in xrange(k, k+d+1):
+                if p != i:
+                    c /= abs(x[i] - x[p])
+            u[i] += c
+
+    # Vectorize the evaluation for the center part
+    if d < n-d:
+        for k in xrange(-d, 1):
+            c = 1.0
+            for p in xrange(k, k+d+1):
+                if p != 0:
+                    c /= abs(x[d:n-d] - x[d+p:n+p-d])
+            u[d:n-d] += c
+
+    u[((d+1)%2)::2] *= -1
+
+    return RationalBarycentricInterpolation(x, y, u)
+
+
+def lsq_rational(x, y, m=None, tol=1e-14):
+    """
+    Compute least-squares classical barycentric rational interpolant of data
+
+    Parameters
+    ----------
+    x : array_like, shape (N,)
+        Interpolation points
+    y : array_like, shape (..., N)
+        Data at interpolation points
+    m : int, optional
+        Degree of the numerator polynomial, must be ``N-1 >= m >= (N-1)/2``.
+        Default: max(N//2, (N-1)//2)
+
+    Returns
+    -------
+    ip : RationalBarycentricInterpolation
+        Rational barycentric interpolator of data
+
+    Warns
+    -----
+    RationalInterpolationWarning
+        Emitted if the computed interpolant does not pass through data
+        points, to relative accuracy specified by `tol`.
+
+    Notes
+    -----
+    The fitting does not constrain locations of the poles of the rational
+    interpolant. The following caveats apply, as usual in classical rational
+    interpolation:
+
+    - The interpolant may contain divergences
+
+    - The constraints on ``m`` may mean it is impossible for the
+      interpolant to pass through all data points. If this occurs,
+      this routine emits a warning.
+
+    References
+    ----------
+    [1] J.-P. Berrut, R. Baltensperger, H.D. Mittelmann, ''Recent
+        developments in barycentric rational interpolation'',
+        ISNM International Series of Numerical Mathematics **151**, 27
+        (2005). http://dx.doi.org/10.1007/3-7643-7356-3_3
+
+    """
+
+    x = np.asarray(x)
+    y = np.asarray(y)
+    N = len(x)
+
+    if x.ndim != 1 or N != y.shape[-1]:
+        raise ValueError("x and y do not have matching shape")
+
+    if N <= 1:
+        return RationalBarycentricInterpolation(x, y, np.array([1.0]))
+
+    if m is None:
+        m = max(N//2, (N-1)//2)
+
+    if 2*m < N - 1:
+        raise ValueError("m must be >= (N-1)/2")
+    if m > N - 1:
+        raise ValueError("m must be < N - 1")
+
+    dtype = np.find_common_type([x.dtype, y.dtype, np.inexact], [])
+
+    # Shift and scale the fitting problem
+    x0 = x
+    x = x - x.mean()
+    x_scale = x.ptp()
+    if x_scale != 0:
+        x /= x_scale
+
+    y0 = y
+    vy = y.reshape(-1, N)
+    vy = vy - vy.mean()
+    y_scale = vy.ptp(axis=-1)
+    y_scale[y_scale==0] = 1
+    vy /= y_scale
+
+    # Solve interpolation conditions
+    u = np.empty((vy.shape[0], N), dtype=dtype)
+    for k in xrange(vy.shape[0]):
+        V = np.vander(x, m).T[::-1]
+        F = vy[k][None,:] * np.vander(x, N - m - 1).T[::-1]
+        A = np.concatenate((V, F), axis=0)
+
+        # Appropriate weights are in the null space of A
+        _, s, vh = scipy.linalg.svd(A, full_matrices=True, overwrite_a=True)
+        u[k,:] = vh.T[:,-1].conj()
+
+    u = u.reshape(y.shape)
+
+    # Check interpolation
+    if abs(u).min() <= tol*abs(u).max():
+        warnings.warn("Rational interpolant may not fit all points",
+                      RationalInterpolationWarning)
+
+    return RationalBarycentricInterpolation(x0, y0, u)
+
+
+def _sort_and_average_duplicates(x, y):
+    x = np.atleast_1d(x)
+    y = np.asarray(y)
+
+    # Sort
+    j = np.argsort(x)
+    x = x[j]
+    y = y[...,j]
+
+    # Average duplicates
+    m = np.flatnonzero((x[1:] != x[:-1]))
+    if m.size < x.size:
+        j = np.r_[0, 1 + m]
+        y = np.add.reduceat(y, j, axis=-1) / np.diff(np.r_[j, x.size])
+        x = x[j]
+
+    return x, y

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -504,7 +504,7 @@ class BarycentricInterpolator(_Interpolator1D):
         self.set_yi(yi)
         self.n = len(self.xi)
 
-        self.wi = np.zeros(self.n)
+        self.wi = np.zeros(self.n, dtype=np.find_common_type([self.xi.dtype, np.inexact], []))
         self.wi[0] = 1
         for j in xrange(1,self.n):
             self.wi[:j] *= (self.xi[j]-self.xi[:j])

--- a/scipy/interpolate/tests/test__ratinterp.py
+++ b/scipy/interpolate/tests/test__ratinterp.py
@@ -1,0 +1,147 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_less, assert_equal
+
+from scipy.interpolate._ratinterp import floater_hormann, lsq_rational, _sort_and_average_duplicates
+from scipy.special import factorial
+
+
+def test_floater_hormann_weights():
+    # Check that the vectorized computation for the weights is done
+    # correctly
+
+    def weights(x, d):
+        # Non-vectorized computation
+        n = len(x)
+        u = np.zeros((n,), dtype=float)
+        for i in range(n):
+            for k in xrange(max(i-d, 0), min(i+1, n-d)):
+                c = 1.0
+                for p in xrange(k, k+d+1):
+                    if p != i:
+                        c /= abs(x[i] - x[p])
+                u[i] += c
+        u *= (-1)**(np.arange(n) - d)
+        return u
+
+    np.random.seed(1234)
+    x = np.random.rand(31)
+    y = np.random.rand(31)
+    x.sort()
+
+    for d in range(0, x.size+1):
+        # Check weights
+        u0 = weights(x, min(d, x.size-1))
+        ip = floater_hormann(x, y, d=d)
+        assert_allclose(ip.u, u0, rtol=1e-13,
+                        err_msg="d=%d" % (d,))
+
+        # Check interpolation
+        assert_allclose(ip(x), y)
+
+
+def test_floater_hormann_weights_uniform():
+    # Check against explicit results on an uniform grid
+    x = np.arange(11)
+
+    def scale(d):
+        return (-1)**(np.arange(len(x)) + d) * factorial(d)
+
+    ip = floater_hormann(x, 0*x, d=0)
+    assert_allclose(ip.u*scale(0), [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+
+    ip = floater_hormann(x, 0*x, d=1)
+    assert_allclose(ip.u*scale(1), [1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1])
+
+    ip = floater_hormann(x, 0*x, d=2)
+    assert_allclose(ip.u*scale(2), [1, 3, 4, 4, 4, 4, 4, 4, 4, 3, 1])
+
+    ip = floater_hormann(x, 0*x, d=3)
+    assert_allclose(ip.u*scale(3), [1, 4, 7, 8, 8, 8, 8, 8, 7, 4, 1])
+
+    ip = floater_hormann(x, 0*x, d=4)
+    assert_allclose(ip.u*scale(4), [1, 5, 11, 15, 16, 16, 16, 15, 11, 5, 1])
+
+
+def test_lsq_rational_order():
+    # Check that the order conditions for the polynomials apply
+    np.random.seed(1234)
+    x = np.random.rand(11)
+    y = np.random.rand(11)
+
+    for m in range(5, 11):
+        ip = lsq_rational(x, y, m=m)
+        denom = ip.get_denominator()
+        numer = ip.get_numerator()
+
+        # Check that the numerator polynomial is (approximatively) of order m
+        assert_array_less(abs(numer.coeffs[:-(m+1)]), 1e-14 + 1e-6*abs(numer.coeffs[-(m+1):]).max(), repr(m))
+
+        # Check that the denominator polynomial is (approximatively) of order 10-m
+        k = 10 - m
+        assert_array_less(abs(denom.coeffs[:-(k+1)]), 1e-14 + 1e-6*abs(denom.coeffs[-(k+1):]).max(), repr(m))
+
+        # Check interpolation
+        assert_allclose(ip(x), y)
+
+
+def test_lsq_interpolation():
+    np.random.seed(1234)
+
+    f = lambda x: np.sin(x) / (1 + x**2)
+
+    x = np.random.rand(31) + 1j*np.random.rand(31)
+    y = f(x)
+
+    ip = lsq_rational(x, y)
+    xx = np.random.rand(1001) + 1j*np.random.rand(1001)
+
+    # Interpolation of analytic functions converges fast, even for a
+    # fairly small number of points.
+    assert_allclose(ip(xx), f(xx), rtol=1e-5)
+
+
+def test_floater_hormann_interpolation():
+    np.random.seed(1234)
+
+    x = np.linspace(0, 1, 51)
+    y = 1 / (1 + x**2)
+    h = x[1] - x[0]
+
+    xx = np.random.rand(1001)
+    yy = 1 / (1 + xx**2)
+
+    # Check convergence order
+    for d in range(0, 10):
+        ip = floater_hormann(x, y, d=d)
+        tol = 10*h**(d+1)
+        msg = repr((d, abs(ip(xx)/yy - 1).max(), tol))
+        assert_allclose(ip(xx), yy, atol=1e-10, rtol=tol, err_msg=msg)
+
+
+def test_sort_and_average_duplicates():
+    x, y = _sort_and_average_duplicates([1, 0, 2, 3, 4], [2, 1, 3, 4, 5])
+    assert_equal(x, [0, 1, 2, 3, 4])
+    assert_equal(y, [1, 2, 3, 4, 5])
+
+    x, y = _sort_and_average_duplicates([2, 1, 1, 3, 4], [3, 1, 2, 4, 5])
+    assert_equal(x, [1, 2, 3, 4])
+    assert_allclose(y, [1.5, 3, 4, 5])
+
+    x, y = _sort_and_average_duplicates([2, 1, 1, 1, 4], [3, 1, 2, 4, 5])
+    assert_equal(x, [1, 2, 4])
+    assert_allclose(y, [(1+2+4)/3, 3, 5])
+
+    x, y = _sort_and_average_duplicates([4, 1, 1, 1, 4], [3, 1, 2, 4, 5])
+    assert_equal(x, [1, 4])
+    assert_allclose(y, [(1+2+4)/3, (3+5)/2])
+
+    x, y = _sort_and_average_duplicates([1, 1, 1, 1, 1], [3, 1, 2, 4, 5])
+    assert_equal(x, [1])
+    assert_allclose(y, [(1+2+3+4+5)/5])
+
+    x, y = _sort_and_average_duplicates([2, 1, 1, 1, 4], [[3, 1, 2, 4, 5]]*4)
+    assert_equal(x, [1, 2, 4])
+    assert_allclose(y, [[(1+2+4)/3, 3, 5]]*4)
+


### PR DESCRIPTION
Implement rational function interpolation in barycentric basis.
These may be useful when interpolating analytic functions.

One remaining question:
- [ ] Should the barycentric formula be written including the node polynomial `l(x) = [\sum u_j/(x-x_j)]^-1`? This is important for barycentric polynomial interpolation, but I'm not sure whether it matters for rational interpolants, cf. http://www.damtp.cam.ac.uk/user/mdw42/webb2012stability.pdf   The denominator in a rational interpolant in general does not sum to `1/l(x)`, so it seems to me there's no way to fix things as suggested in that paper here.
- [ ] add a way to fit low-order rational functions
