### PR TITLE
ENH: scipy.signal - Addition of CSD, coherence; Enhancement of welch

### DIFF
--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -5,11 +5,28 @@ from itertools import product
 import numpy as np
 
 try:
-    from scipy.signal import convolve2d, correlate2d, lti, lsim, lsim2
+    from scipy.signal import convolve2d, correlate2d, lti, lsim, lsim2, welch, 
+                             csd
 except ImportError:
     pass
 
 from .common import Benchmark
+
+
+class CalculateWindowedFFT(Benchmark):
+    def setup(self):
+        np.random.seed(5678)
+        # Create some long arrays for computation
+        x = np.random.randn(2**20)
+        y = np.random.randn(2**20)
+        self.x = x
+        self.y = y
+
+    def time_welch(self):
+        welch(self.x)
+    
+    def time_csd(self):
+        csd(self.x, self.y)
 
 
 class Convolve2D(Benchmark):

--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -5,8 +5,8 @@ from itertools import product
 import numpy as np
 
 try:
-    from scipy.signal import convolve2d, correlate2d, lti, lsim, lsim2, welch, 
-                             csd
+    from scipy.signal import (convolve2d, correlate2d, lti, lsim, lsim2, welch,
+                              csd)
 except ImportError:
     pass
 

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -436,7 +436,7 @@ def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
     the signal power, while not over counting any of the data.  Narrower
     windows may require a larger overlap.
     """
-    freqs, Pxx = welch(x, fs, window, nperseg, noverlap, nfft, detrend, 
+    freqs, Pxx = welch(x, fs, window, nperseg, noverlap, nfft, detrend,
                        axis=axis)
     _, Pyy = welch(y, fs, window, nperseg, noverlap, nfft, detrend, axis=axis)
     _, Pxy = csd(x, y, fs, window, nperseg, noverlap, nfft, detrend, axis=axis)
@@ -706,8 +706,8 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft):
     '''
     Calculate windowed FFT, for internal use by scipy.signal._spectral_helper
 
-    This is a helper function that does the main FFT calculation for 
-    _spectral helper. All input valdiation is performed there, and the data 
+    This is a helper function that does the main FFT calculation for
+    _spectral helper. All input valdiation is performed there, and the data
     axis is assumed to be the last axis of x. It is not designed to be called
     externally. The windows are not averaged over; the result from each window
     is returned.
@@ -733,7 +733,7 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft):
         step = nperseg - noverlap
         shape = x.shape[:-1]+((x.shape[-1]-noverlap)//step, nperseg)
         strides = x.strides[:-1]+(step*x.strides[-1], x.strides[-1])
-        result = np.lib.stride_tricks.as_strided(x, shape=shape, 
+        result = np.lib.stride_tricks.as_strided(x, shape=shape,
                                                  strides=strides)
 
     # Detrend each data segment individually
@@ -744,5 +744,5 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft):
 
     # Perform the fft. Acts on last axis by default. Zero-pads automatically
     result = fftpack.fft(result, n=nfft)
-    
+
     return result

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -738,25 +738,11 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft):
 
     # Detrend each data segment individually
     result = detrend_func(result)
-    
-    # Create strided array of window profiles, same shape as result
-    if result.shape[-1] == 1:
-        winrep = win
-    else:
-        win_strides = np.zeros(len(result.shape), dtype='int64')
-        win_strides[-1] = win.strides[0]
-        winrep = np.lib.stride_tricks.as_strided(win, shape=result.shape, 
-                                                 strides=win_strides)
 
     # Apply window by multiplication
-    result = winrep * result
+    result = win * result
 
-    # Zero pad here, now that windowing is done
-    pad_shape = list(result.shape)
-    pad_shape[-1] = nfft - pad_shape[-1]
-    result = np.concatenate((result, np.zeros(pad_shape)), axis=-1)
-
-    # Perform the fft
-    result = fftpack.fft(result, n=nfft, axis=-1)
+    # Perform the fft. Acts on last axis by default. Zero-pads automatically
+    result = fftpack.fft(result, n=nfft)
     
     return result

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -684,12 +684,16 @@ def _spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
         pass
 
     result *= scale
-    if mode == 'psd' and sides == 'onesided':
-        result[...,1:-1] *= 2
+    if sides == 'onesided':
+        if nfft % 2:
+            result[...,1:] *= 2
+        else:
+            # Last point is unpaired Nyquist freq point, don't double
+            result[...,1:-1] *= 2
 
     t = np.arange(nfft/2, x.shape[-1] - nfft/2 + 1, nfft - noverlap)/float(fs)
 
-    if sides != 'twosided' and not nperseg % 2:
+    if sides != 'twosided' and not nfft % 2:
         # get the last value correctly, it is negative otherwise
         freqs[-1] *= -1
 

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -542,6 +542,13 @@ def _spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
     else:
         outdtype = np.result_type(x,np.complex64)
 
+    if x.size == 0:
+        return np.empty(x.shape), np.empty(x.shape), np.empty(x.shape)
+
+    if not same_data:
+        if y.size == 0:
+            return np.empty(y.shape), np.empty(y.shape), np.empty(y.shape)
+
     if x.ndim > 1:
         if axis != -1:
             x = np.rollaxis(x, axis, len(x.shape))
@@ -551,13 +558,7 @@ def _spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
             if axis < 0:
                 axis = len(np.broadcast(x,y).shape)-axis
 
-    if x.size == 0:
-        return np.empty(x.shape), np.empty(x.shape), np.empty(x.shape)
-
     if not same_data:
-        if y.size == 0:
-            return np.empty(y.shape), np.empty(y.shape), np.empty(y.shape)
-
         # Check if we can broadcast the outer axes together
         for a, b in zip(x.shape[-2::-1],y.shape[-2::-1]):
             if a == 1 or b == 1 or a == b:

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -685,7 +685,7 @@ def _spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
     if mode == 'psd' and sides == 'onesided':
         result[...,1:-1] *= 2
 
-    t = np.arange(nfft//2, len(x) - nfft//2 + 1, nfft - noverlap)/fs
+    t = np.arange(nfft/2, x.shape[-1] - nfft/2 + 1, nfft - noverlap)/float(fs)
 
     if sides != 'twosided' and not nperseg % 2:
         # get the last value correctly, it is negative otherwise

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -347,16 +347,41 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
     the signal power, while not over counting any of the data.  Narrower
     windows may require a larger overlap.
 
-    If `noverlap` is 0, this method is equivalent to Bartlett's method [2]_.
-
     References
     ----------
     .. [1] P. Welch, "The use of the fast Fourier transform for the
            estimation of power spectra: A method based on time averaging
            over short, modified periodograms", IEEE Trans. Audio
            Electroacoust. vol. 15, pp. 70-73, 1967.
-    .. [2] M.S. Bartlett, "Periodogram Analysis and Continuous Spectra",
-           Biometrika, vol. 37, pp. 1-16, 1950.
+    .. [2] Rabiner, Lawrence R., and B. Gold. "Theory and Application of
+           Digital Signal Processing" Prentice-Hall, pp. 414-419, 1975
+
+    Examples
+    --------
+    >>> from scipy import signal
+    >>> import matplotlib.pyplot as plt
+
+    Generate two test signals with some common features.
+
+    >>> fs = 10e3
+    >>> N = 1e5
+    >>> amp = 20
+    >>> freq = 1234.0
+    >>> noise_power = 0.001 * fs / 2
+    >>> time = np.arange(N) / fs
+    >>> b, a = signal.butter(2, 0.25, 'low')
+    >>> x = np.random.normal(scale=np.sqrt(noise_power), size=time.shape)
+    >>> y = signal.lfilter(b, a, x)
+    >>> x += amp*np.sin(2*np.pi*freq*time)
+    >>> y += np.random.normal(scale=0.1*np.sqrt(noise_power), size=time.shape)
+
+    Compute and plot the magnitude of the cross spectral density.
+
+    >>> f, Pxy = signal.csd(x, y, fs, nperseg=1024)
+    >>> plt.semilogy(f, np.abs(Pxy))
+    >>> plt.xlabel('frequency [Hz]')
+    >>> plt.ylabel('CSD [V**2/Hz]')
+    >>> plt.show()
     """
 
     freqs, Pxy, _ = _spectral_helper(x, y, fs, window, nperseg, noverlap, nfft,
@@ -435,7 +460,44 @@ def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
     overlap of 50\% is a reasonable trade off between accurately estimating
     the signal power, while not over counting any of the data.  Narrower
     windows may require a larger overlap.
+
+    References
+    ----------
+    .. [1] P. Welch, "The use of the fast Fourier transform for the
+           estimation of power spectra: A method based on time averaging
+           over short, modified periodograms", IEEE Trans. Audio
+           Electroacoust. vol. 15, pp. 70-73, 1967.
+    .. [2] Stoica, Petre, and Randolph Moses, "Spectral Analysis of Signals"
+           Prentice Hall, 2005
+
+    Examples
+    --------
+    >>> from scipy import signal
+    >>> import matplotlib.pyplot as plt
+
+    Generate two test signals with some common features.
+
+    >>> fs = 10e3
+    >>> N = 1e5
+    >>> amp = 20
+    >>> freq = 1234.0
+    >>> noise_power = 0.001 * fs / 2
+    >>> time = np.arange(N) / fs
+    >>> b, a = signal.butter(2, 0.25, 'low')
+    >>> x = np.random.normal(scale=np.sqrt(noise_power), size=time.shape)
+    >>> y = signal.lfilter(b, a, x)
+    >>> x += amp*np.sin(2*np.pi*freq*time)
+    >>> y += np.random.normal(scale=0.1*np.sqrt(noise_power), size=time.shape)
+
+    Compute and plot the coherence.
+
+    >>> f, Cxy = signal.coherence(x, y, fs, nperseg=1024)
+    >>> plt.semilogy(f, Cxy)
+    >>> plt.xlabel('frequency [Hz]')
+    >>> plt.ylabel('Coherence')
+    >>> plt.show()
     """
+
     freqs, Pxx = welch(x, fs, window, nperseg, noverlap, nfft, detrend,
                        axis=axis)
     _, Pyy = welch(y, fs, window, nperseg, noverlap, nfft, detrend, axis=axis)

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -271,13 +271,13 @@ def welch(x, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
     freqs, Pxx = csd(x, x, fs, window, nperseg, noverlap, nfft, detrend,
                      return_onesided, scaling, axis)
 
-    return freqs, Pxx.real 
+    return freqs, Pxx.real
 
 
 def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
         detrend='constant', return_onesided=True, scaling='density', axis=-1):
     """
-    Estimate the cross power spectral density, Pxy, using Welch's method. 
+    Estimate the cross power spectral density, Pxy, using Welch's method.
 
     Parameters
     ----------
@@ -286,7 +286,7 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
     y : array_like
         Time series of measurement values
     fs : float, optional
-        Sampling frequency of the `x` and `y` time series in units of Hz. 
+        Sampling frequency of the `x` and `y` time series in units of Hz.
         Defaults to 1.0.
     window : str or tuple or array_like, optional
         Desired window to use. See `get_window` for a list of windows and
@@ -312,11 +312,11 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
         spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the power spectral density ('density')
-        where Pxy has units of V**2/Hz if x and y are measured in V and 
+        where Pxy has units of V**2/Hz if x and y are measured in V and
         computing the power spectrum ('spectrum') where Pxy has units of V**2
         if x and y are measured in V. Defaults to 'density'.
     axis : int, optional
-        Axis along which the CSD is computed for both inputs; the default is 
+        Axis along which the CSD is computed for both inputs; the default is
         over the last axis (i.e. ``axis=-1``).
 
     Returns
@@ -331,14 +331,14 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
     periodogram: Simple, optionally modified periodogram
     lombscargle: Lomb-Scargle periodogram for unevenly sampled data
     welch: Power spectral density by Welch's method. [Equivalent to csd(x,x)]
-    coherence: Magnitude squared coherence by Welch's method. 
+    coherence: Magnitude squared coherence by Welch's method.
 
     Notes
     --------
-    By convention, Pxy is computed with the conjugate FFT of X multiplied by 
-    the FFT of Y. 
+    By convention, Pxy is computed with the conjugate FFT of X multiplied by
+    the FFT of Y.
 
-    If the input series differ in length, the shorter series will be 
+    If the input series differ in length, the shorter series will be
     zero-padded to match.
 
     An appropriate amount of overlap will depend on the choice of window
@@ -359,7 +359,7 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
            Biometrika, vol. 37, pp. 1-16, 1950.
     """
 
-    freqs, Pxy, _ = spectral_helper(x, y, fs, window, nperseg, noverlap, nfft, 
+    freqs, Pxy, _ = _spectral_helper(x, y, fs, window, nperseg, noverlap, nfft,
                                     detrend, return_onesided, scaling, axis,
                                     mode='psd')
 
@@ -376,12 +376,12 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
 def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
               nfft=None, detrend='constant', axis=-1):
     """
-    Estimate the magnitude squared coherence estimate, Cxy, of discrete-time 
-    signals X and Y using Welch's method. 
-    
-    Cxy = abs(Pxy)**2/(Pxx*Pyy), where Pxx and Pyy are power spectral density 
-    estimates of X and Y, and Pxy is the cross spectral density estimate of X 
-    and Y. 
+    Estimate the magnitude squared coherence estimate, Cxy, of discrete-time
+    signals X and Y using Welch's method.
+
+    Cxy = abs(Pxy)**2/(Pxx*Pyy), where Pxx and Pyy are power spectral density
+    estimates of X and Y, and Pxy is the cross spectral density estimate of X
+    and Y.
 
     Parameters
     ----------
@@ -390,7 +390,7 @@ def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
     y : array_like
         Time series of measurement values
     fs : float, optional
-        Sampling frequency of the `x` and `y` time series in units of Hz. 
+        Sampling frequency of the `x` and `y` time series in units of Hz.
         Defaults to 1.0.
     window : str or tuple or array_like, optional
         Desired window to use. See `get_window` for a list of windows and
@@ -411,7 +411,7 @@ def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
         function, it takes a segment and returns a detrended segment.
         If `detrend` is False, no detrending is done.  Defaults to 'constant'.
     axis : int, optional
-        Axis along which the CSD is computed for both inputs; the default is 
+        Axis along which the CSD is computed for both inputs; the default is
         over the last axis (i.e. ``axis=-1``).
 
     Returns
@@ -426,7 +426,7 @@ def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
     periodogram: Simple, optionally modified periodogram
     lombscargle: Lomb-Scargle periodogram for unevenly sampled data
     welch: Power spectral density by Welch's method.
-    csd: Cross spectral density by Welch's method. 
+    csd: Cross spectral density by Welch's method.
 
     Notes
     --------
@@ -445,21 +445,89 @@ def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
     return ff, Cxy
 
 
-def spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256, 
-                    noverlap=None, nfft=None, detrend='constant', 
-                    return_onesided=True, scaling='spectrum', axis=-1, 
+def _spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
+                    noverlap=None, nfft=None, detrend='constant',
+                    return_onesided=True, scaling='spectrum', axis=-1,
                     mode='psd'):
     '''
+    Calculate various forms of windowed FFTs for PSD, CSD, etc.
+
     This is a helper function that implements the commonality between the
-    psd, csd, spectrogram and complex, magnitude, angle, and phase spectrums.
-    Assumes 1D input vectors. nfft<=nperseg (allow zero padding)
+    psd, csd, and spectrogram functions. It is not designed to be called
+    externally. The windows are not averaged over; the result from each window
+    is returned.
+
+    Parameters
+    ---------
+    x : array_like
+        Array or sequence containing the data to be analyzed.
+    y : array_like
+        Array or sequence containing the data to be analyzed. If this is
+        the same object in memoery as x (i.e. _spectral_helper(x, x, ...)),
+        the extra computations are spared.
+    fs : float, optional
+        Sampling frequency of the time series in units of Hz. Defaults
+        to 1.0.
+    window : str or tuple or array_like, optional
+        Desired window to use. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length will be used for nperseg.
+        Defaults to 'hanning'.
+    nperseg : int, optional
+        Length of each segment.  Defaults to 256.
+    noverlap : int, optional
+        Number of points to overlap between segments. If None,
+        ``noverlap = nperseg / 2``.  Defaults to None.
+    nfft : int, optional
+        Length of the FFT used, if a zero padded FFT is desired.  If None,
+        the FFT length is `nperseg`. Defaults to None.
+    detrend : str or function or False, optional
+        Specifies how to detrend each segment. If `detrend` is a string,
+        it is passed as the ``type`` argument to `detrend`.  If it is a
+        function, it takes a segment and returns a detrended segment.
+        If `detrend` is False, no detrending is done.  Defaults to 'constant'.
+    return_onesided : bool, optional
+        If True, return a one-sided spectrum for real data. If False return
+        a two-sided spectrum. Note that for complex data, a two-sided
+        spectrum is always returned.
+    scaling : { 'density', 'spectrum' }, optional
+        Selects between computing the power spectral density ('density')
+        where Pxx has units of V**2/Hz if x is measured in V and computing
+        the power spectrum ('spectrum') where Pxx has units of V**2 if x is
+        measured in V. Defaults to 'density'.
+    axis : int, optional
+        Axis along which the periodogram is computed; the default is over
+        the last axis (i.e. ``axis=-1``).
+    mode : str, optional
+        Defines what kind of return values are expected. Options are ['psd',
+        'complex', 'magnitude', 'angle', 'phase'].
+
+    Returns
+    -------
+    f : ndarray
+        Array of sample frequencies.
+    result : ndarray
+        Array of output data, contents dependant on *mode* kwarg.
+    t : ndarray
+        Array of times corresponding to each data segment
+
+    References
+    ----------
+    stackoverflow: Rolling window for 1D arrays in Numpy?
+    <http://stackoverflow.com/a/6811241>
+    stackoverflow: Using strides for an efficient moving average filter
+    <http://stackoverflow.com/a/4947453>
+
+    Notes
+    -----
+    Adapted from matplotlib.mlab
     '''
     if mode not in ['psd', 'complex', 'magnitude', 'angle', 'phase']:
         raise ValueError("Unknown value for mode %s, must be one of: "
                          "'default', 'psd', 'complex', "
                          "'magnitude', 'angle', 'phase'" % mode)
 
-    # If x and y are the same object we can save ourselves some computation. 
+    # If x and y are the same object we can save ourselves some computation.
     same_data = y is x
 
     if not same_data and mode != 'psd':
@@ -473,21 +541,21 @@ def spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
     else:
         outdtype = np.result_type(x,np.complex64)
 
-    if x.ndim > 1 or y.ndim > 1:
+    if x.ndim > 1:
         if axis != -1:
             x = np.rollaxis(x, axis, len(x.shape))
-            if not same_data:
+            if not same_data and y.ndim > 1:
                 y = np.rollaxis(y, axis, len(y.shape))
             # Output is going to have new last axis for window index
             if axis < 0:
                 axis = len(np.broadcast(x,y).shape)-axis
 
     if x.size == 0:
-        return np.empty(x.shape), np.empty(x.shape), np.empty(x.shape) 
+        return np.empty(x.shape), np.empty(x.shape), np.empty(x.shape)
 
     if not same_data:
         if y.size == 0:
-            return np.empty(y.shape), np.empty(y.shape), np.empty(y.shape) 
+            return np.empty(y.shape), np.empty(y.shape), np.empty(y.shape)
 
         # Check if we can broadcast the outer axes together
         for a, b in zip(x.shape[-2::-1],y.shape[-2::-1]):
@@ -580,9 +648,9 @@ def spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
             numFreqs = nfft//2 + 1
 
     # Stride, detrend, apply windows
-    result = stride_windows(x, nperseg, noverlap, axis=-1)
+    result = _stride_windows(x, nperseg, noverlap, axis=-1)
     result = detrend_func(result)
-    result = apply_window(result, win, axis=-1)
+    result = _apply_window(result, win, axis=-1)
 
     # Zero pad here, now that windowing is done
     padShape = list(result.shape)
@@ -595,9 +663,9 @@ def spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
 
     if not same_data:
         # All the same operations on the y data
-        resultY = stride_windows(y, nfft, noverlap, axis=-1)
+        resultY = _stride_windows(y, nfft, noverlap, axis=-1)
         resultY = detrend_func(resultY)
-        resultY = apply_window(resultY, win, axis=-1)
+        resultY = _apply_window(resultY, win, axis=-1)
         padShape = list(resultY.shape)
         padShape[-1] = nfft - padShape[-1]
         resultY = np.concatenate((resultY, np.zeros(padShape)), axis=-1)
@@ -631,10 +699,10 @@ def spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
         result = np.unwrap(result, axis=-1)
 
     result = result.astype(outdtype)
-    
+
     # All imaginary parts are zero anyways
     if same_data:
-        result = result.real 
+        result = result.real
 
     if axis != -1:
         result = np.rollaxis(result, -1, axis)
@@ -642,41 +710,48 @@ def spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
     return freqs, result, t
 
 
-def stride_windows(x, n, noverlap=0, axis=-1):
+def _stride_windows(x, n, noverlap=0, axis=-1):
     '''
-    Get all windows of x with length n as a single array,
-    using strides to avoid data duplication.
+    Return all subsegments of an array of data in a memory-efficient manner.
 
-    Last axis of result is the window index
+    Overlapping segments can be returned, using strides to avoid data
+    duplication. The output array contains a new axis, corresponding to the
+    window index.
 
-    .. warning::
-
-        It is not safe to write to the output array.  Multiple
-        elements may point to the same piece of memory,
-        so modifying one value may change others.
-
-    Call signature::
-
-        stride_windows(x, n, noverlap=0)
-
-      *x*: 1D array or sequence
+    Parameters
+    ---------
+    x : array_like
         Array or sequence containing the data.
 
-      *n*: integer
+    n : int
         The number of data points in each window.
 
-      *noverlap*: integer
-        The overlap between adjacent windows.
-        Default is 0 (no overlap)
+    noverlap : int, optional
+        The overlap between adjacent windows. Default is 0 (no overlap)
 
-      *axis*: integer
-        The axis along which to window the data, default is -1 (last axis)
+    axis : int, optional
+        The axis along which the data will be windowed. The default is the last
+        axis (-1).
 
-    Refs:
-        `stackoverflaw: Rolling window for 1D arrays in Numpy?
-        <http://stackoverflow.com/a/6811241>`_
-        `stackoverflaw: Using strides for an efficient moving average filter
-        <http://stackoverflow.com/a/4947453>`_
+    Returns
+    -------
+    xs : ndarray
+        Strided Array
+
+    References
+    ----------
+    stackoverflow: Rolling window for 1D arrays in Numpy?
+    <http://stackoverflow.com/a/6811241>
+    stackoverflow: Using strides for an efficient moving average filter
+    <http://stackoverflow.com/a/4947453>
+
+    Notes
+    -----
+    WARNING: It is not safe to write to the output array. Multiple elements
+    may point to the same piece of memory, so modifying one value may change
+    others.
+
+    Adapted from matplotlib.mlab
     '''
 
     if noverlap >= n:
@@ -711,32 +786,41 @@ def stride_windows(x, n, noverlap=0, axis=-1):
     return result
 
 
-def stride_repeat(x, shape, axis=-1):
+def _stride_repeat(x, shape, axis=-1):
     '''
-    Repeat the values in an array in a memory-efficient manner.
+    Repeat the values in a 1D array in a memory-efficient manner.
 
-    .. warning::
+    Parameters
+    ---------
+    x : array_like
+        1D array or sequence containing the data.
 
-        It is not safe to write to the output array.  Multiple
-        elements may point to the same piece of memory, so
-        modifying one value may change others.
+    shape : tuple
+        The shape to extend the array to. *shape*[*axis*] must equal
+        *x*.size
 
-    Call signature::
+    axis : int, optional
+        The axis along which the data will be strided. The default is the last
+        axis (-1).
 
-        stride_repeat(x, n, axis=0)
+    Returns
+    -------
+    xs : ndarray
+        Strided Array
 
-      *x*: 1D array or sequence
-        Array or sequence containing the data.
+    References
+    ----------
+    stackoverflow: Repeat NumPy array without replicating data?
+    <http://stackoverflow.com/a/5568169>
 
-      *shape*: tuple
-        The shape to extend the array to. 
+    Notes
+    -----
+    WARNING: It is not safe to write to the output array. Multiple elements
+    may point to the same piece of memory, so modifying one value may change
+    others.
 
-      *axis*: integer
-        The axis along which the data will run. 
+    Adapted from matplotlib.mlab
 
-    Refs:
-        `stackoverflaw: Repeat NumPy array without replicating data?
-        <http://stackoverflow.com/a/5568169>`_
     '''
 
     x = np.asarray(x)
@@ -755,22 +839,30 @@ def stride_repeat(x, shape, axis=-1):
     return np.lib.stride_tricks.as_strided(x, shape=shape, strides=strides)
 
 
-def apply_window(x, win, axis=-1):
+def _apply_window(x, win, axis=-1):
     '''
-    Apply the given window to the given 1D or 2D array along the given axis.
+    Apply the given window to a data array along the given axis.
 
-    Call signature::
+    Parameters
+    ---------
+    x : array_like
+        Array or sequence containing the data to be windowed.
 
-        apply_window(x, window, axis=0, return_window=False)
+    win : array_like
+        A 1D array with length *x*.shape[*axis*]
 
-      *x*: 1D or 2D array or sequence
-        Array or sequence containing the data.
+    axis : int, optional
+        Axis along which the window is applied; the default is over
+        the last axis (i.e. ``axis=-1``).
 
-      *win*: array.
-        An array with length *x*.shape[*axis*]
+    Returns
+    -------
+    wx : ndarray
+        Windowed Array
 
-      *axis*: integer
-        The axis over which to do the repetition.
+    Notes
+    -----
+    Adapted from matplotlib.mlab
 
     '''
     x = np.asarray(x)
@@ -787,5 +879,5 @@ def apply_window(x, win, axis=-1):
     if x.ndim == 1:
         return win * x
     else:
-        winRep = stride_repeat(win, x.shape, axis)
+        winRep = _stride_repeat(win, x.shape, axis)
         return winRep * x

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -368,7 +368,7 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
         if Pxy.shape[-1] > 1:
             Pxy = Pxy.mean(axis=-1)
         else:
-            Pxy = np.squeeze(Pxy, axis=-1)
+            Pxy = np.reshape(Pxy, Pxy.shape[:-1])
 
     return freqs, Pxy
 

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -608,9 +608,11 @@ def _spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
 
     # Handle detrending and window functions
     if not detrend:
-        detrend_func = lambda d: d
+        def detrend_func(d):
+            return d
     elif not hasattr(detrend, '__call__'):
-        detrend_func = lambda d: signaltools.detrend(d, type=detrend, axis=-1)
+        def detrend_func(d):
+            return signaltools.detrend(d, type=detrend, axis=-1)
     elif axis != -1:
         # Wrap this function so that it receives a shape that it could
         # reasonably expect to receive.

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -219,7 +219,7 @@ class TestWelch(TestCase):
         f, p = welch(x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
         assert_allclose(p, np.array([0.08333333, 0.15277778, 0.22222222,
-            0.22222222, 0.11111111]))
+                                     0.22222222, 0.11111111]))
 
     def test_real_onesided_odd(self):
         x = np.zeros(16)
@@ -228,7 +228,7 @@ class TestWelch(TestCase):
         f, p = welch(x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
         assert_allclose(p, np.array([0.15958226, 0.24193954, 0.24145223,
-            0.24100919, 0.12188675]))
+                                     0.24100919, 0.12188675]))
 
     def test_real_twosided(self):
         x = np.zeros(16)
@@ -237,7 +237,8 @@ class TestWelch(TestCase):
         f, p = welch(x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
         assert_allclose(p, np.array([0.08333333, 0.07638889, 0.11111111,
-            0.11111111, 0.11111111, 0.11111111, 0.11111111, 0.07638889]))
+                                     0.11111111, 0.11111111, 0.11111111, 
+                                     0.11111111, 0.07638889]))
 
     def test_real_spectrum(self):
         x = np.zeros(16)
@@ -246,7 +247,8 @@ class TestWelch(TestCase):
         f, p = welch(x, nperseg=8, scaling='spectrum')
         assert_allclose(f, np.linspace(0, 0.5, 5))
         assert_allclose(p, np.array([0.015625, 0.028645833333333332,
-            0.041666666666666664, 0.041666666666666664, 0.020833333333333332]))
+                                     0.041666666666666664, 0.041666666666666664,
+                                     0.020833333333333332]))
 
     def test_integer_onesided_even(self):
         x = np.zeros(16, dtype=np.int)
@@ -255,7 +257,7 @@ class TestWelch(TestCase):
         f, p = welch(x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
         assert_allclose(p, np.array([0.08333333, 0.15277778, 0.22222222,
-            0.22222222, 0.11111111]))
+                                     0.22222222, 0.11111111]))
 
     def test_integer_onesided_odd(self):
         x = np.zeros(16, dtype=np.int)
@@ -264,7 +266,7 @@ class TestWelch(TestCase):
         f, p = welch(x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
         assert_allclose(p, np.array([0.15958226, 0.24193954, 0.24145223,
-            0.24100919, 0.12188675]))
+                                     0.24100919, 0.12188675]))
 
     def test_integer_twosided(self):
         x = np.zeros(16, dtype=np.int)
@@ -273,7 +275,8 @@ class TestWelch(TestCase):
         f, p = welch(x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
         assert_allclose(p, np.array([0.08333333, 0.07638889, 0.11111111,
-            0.11111111, 0.11111111, 0.11111111, 0.11111111, 0.07638889]))
+                                     0.11111111, 0.11111111, 0.11111111, 
+                                     0.11111111, 0.07638889]))
 
     def test_complex(self):
         x = np.zeros(16, np.complex128)
@@ -282,11 +285,12 @@ class TestWelch(TestCase):
         f, p = welch(x, nperseg=8)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
         assert_allclose(p, np.array([0.41666667, 0.38194444, 0.55555556,
-            0.55555556, 0.55555556, 0.55555556, 0.55555556, 0.38194444]))
+                                     0.55555556, 0.55555556, 0.55555556, 
+                                     0.55555556, 0.38194444]))
 
     def test_unk_scaling(self):
         assert_raises(ValueError, welch, np.zeros(4, np.complex128),
-                scaling='foo', nperseg=4)
+                      scaling='foo', nperseg=4)
 
     def test_detrend_linear(self):
         x = np.arange(10, dtype=np.float64) + 0.04
@@ -303,14 +307,14 @@ class TestWelch(TestCase):
     def test_detrend_external(self):
         x = np.arange(10, dtype=np.float64) + 0.04
         f, p = welch(x, nperseg=10,
-                detrend=lambda seg: signal.detrend(seg, type='l'))
+                     detrend=lambda seg: signal.detrend(seg, type='l'))
         assert_allclose(p, np.zeros_like(p), atol=1e-15)
 
     def test_detrend_external_nd_m1(self):
         x = np.arange(40, dtype=np.float64) + 0.04
         x = x.reshape((2,2,10))
         f, p = welch(x, nperseg=10,
-                detrend=lambda seg: signal.detrend(seg, type='l'))
+                     detrend=lambda seg: signal.detrend(seg, type='l'))
         assert_allclose(p, np.zeros_like(p), atol=1e-15)
 
     def test_detrend_external_nd_0(self):
@@ -318,7 +322,7 @@ class TestWelch(TestCase):
         x = x.reshape((2,1,10))
         x = np.rollaxis(x, 2, 0)
         f, p = welch(x, nperseg=10, axis=0,
-                detrend=lambda seg: signal.detrend(seg, axis=0, type='l'))
+                     detrend=lambda seg: signal.detrend(seg, axis=0, type='l'))
         assert_allclose(p, np.zeros_like(p), atol=1e-15)
 
     def test_nd_axis_m1(self):
@@ -372,7 +376,8 @@ class TestWelch(TestCase):
     def test_window_long_or_nd(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', UserWarning)
-            assert_raises(ValueError, welch, np.zeros(4), 1, np.array([1,1,1,1,1]))
+            assert_raises(ValueError, welch, np.zeros(4), 1, 
+                          np.array([1,1,1,1,1]))
             assert_raises(ValueError, welch, np.zeros(4), 1,
                           np.arange(6).reshape((2,3)))
 
@@ -380,7 +385,8 @@ class TestWelch(TestCase):
         x = np.zeros(64)
         x[::8] = 1
         f, p = welch(x, nperseg=16, noverlap=4)
-        q = np.array([0, 1./12., 1./3., 1./5., 1./3., 1./5., 1./3., 1./5., 1./6.])
+        q = np.array([0, 1./12., 1./3., 1./5., 1./3., 1./5., 1./3., 1./5., 
+                      1./6.])
         assert_allclose(p, q, atol=1e-12)
 
     def test_bad_noverlap(self):
@@ -396,7 +402,7 @@ class TestWelch(TestCase):
         f, p = welch(x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
         q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
-            0.11111111], 'f') 
+                      0.11111111], 'f') 
         assert_allclose(p, q)
         assert_(p.dtype == q.dtype)
 
@@ -407,7 +413,7 @@ class TestWelch(TestCase):
         f, p = welch(x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
         q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
-            0.12188675], 'f')
+                      0.12188675], 'f')
         assert_allclose(p, q, atol=1e-7)
         assert_(p.dtype == q.dtype)
 
@@ -419,7 +425,8 @@ class TestWelch(TestCase):
         f, p = welch(x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
         q = np.array([0.08333333, 0.07638889, 0.11111111,
-            0.11111111, 0.11111111, 0.11111111, 0.11111111, 0.07638889], 'f')
+                      0.11111111, 0.11111111, 0.11111111, 0.11111111, 
+                      0.07638889], 'f')
         assert_allclose(p, q)
         assert_(p.dtype == q.dtype)
 
@@ -431,9 +438,10 @@ class TestWelch(TestCase):
         f, p = welch(x, nperseg=8)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
         q = np.array([0.41666666, 0.38194442, 0.55555552, 0.55555552, 
-            0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
+                      0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
         assert_allclose(p, q)
-        assert_(p.dtype == q.dtype, 'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
+        assert_(p.dtype == q.dtype,
+                'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
 
 class TestCSD:
     def test_pad_shorter_x(self):
@@ -465,7 +473,7 @@ class TestCSD:
         f, p = csd(x, x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
         assert_allclose(p, np.array([0.08333333, 0.15277778, 0.22222222,
-            0.22222222, 0.11111111]))
+                                     0.22222222, 0.11111111]))
 
     def test_real_onesided_odd(self):
         x = np.zeros(16)
@@ -474,7 +482,7 @@ class TestCSD:
         f, p = csd(x, x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
         assert_allclose(p, np.array([0.15958226, 0.24193954, 0.24145223,
-            0.24100919, 0.12188675]))
+                                     0.24100919, 0.12188675]))
 
     def test_real_twosided(self):
         x = np.zeros(16)
@@ -483,7 +491,8 @@ class TestCSD:
         f, p = csd(x, x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
         assert_allclose(p, np.array([0.08333333, 0.07638889, 0.11111111,
-            0.11111111, 0.11111111, 0.11111111, 0.11111111, 0.07638889]))
+                                     0.11111111, 0.11111111, 0.11111111, 
+                                     0.11111111, 0.07638889]))
 
     def test_real_spectrum(self):
         x = np.zeros(16)
@@ -492,7 +501,8 @@ class TestCSD:
         f, p = csd(x, x, nperseg=8, scaling='spectrum')
         assert_allclose(f, np.linspace(0, 0.5, 5))
         assert_allclose(p, np.array([0.015625, 0.028645833333333332,
-            0.041666666666666664, 0.041666666666666664, 0.020833333333333332]))
+                                     0.041666666666666664, 0.041666666666666664, 
+                                     0.020833333333333332]))
 
     def test_integer_onesided_even(self):
         x = np.zeros(16, dtype=np.int)
@@ -501,7 +511,7 @@ class TestCSD:
         f, p = csd(x, x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
         assert_allclose(p, np.array([0.08333333, 0.15277778, 0.22222222,
-            0.22222222, 0.11111111]))
+                                     0.22222222, 0.11111111]))
 
     def test_integer_onesided_odd(self):
         x = np.zeros(16, dtype=np.int)
@@ -510,7 +520,7 @@ class TestCSD:
         f, p = csd(x, x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
         assert_allclose(p, np.array([0.15958226, 0.24193954, 0.24145223,
-            0.24100919, 0.12188675]))
+                                     0.24100919, 0.12188675]))
 
     def test_integer_twosided(self):
         x = np.zeros(16, dtype=np.int)
@@ -519,7 +529,8 @@ class TestCSD:
         f, p = csd(x, x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
         assert_allclose(p, np.array([0.08333333, 0.07638889, 0.11111111,
-            0.11111111, 0.11111111, 0.11111111, 0.11111111, 0.07638889]))
+                                     0.11111111, 0.11111111, 0.11111111, 
+                                     0.11111111, 0.07638889]))
 
     def test_complex(self):
         x = np.zeros(16, np.complex128)
@@ -528,11 +539,12 @@ class TestCSD:
         f, p = csd(x, x, nperseg=8)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
         assert_allclose(p, np.array([0.41666667, 0.38194444, 0.55555556,
-            0.55555556, 0.55555556, 0.55555556, 0.55555556, 0.38194444]))
+                                     0.55555556, 0.55555556, 0.55555556, 
+                                     0.55555556, 0.38194444]))
 
     def test_unk_scaling(self):
         assert_raises(ValueError, csd, np.zeros(4, np.complex128),
-                np.ones(4, np.complex128), scaling='foo', nperseg=4)
+                      np.ones(4, np.complex128), scaling='foo', nperseg=4)
 
     def test_detrend_linear(self):
         x = np.arange(10, dtype=np.float64) + 0.04
@@ -549,14 +561,14 @@ class TestCSD:
     def test_detrend_external(self):
         x = np.arange(10, dtype=np.float64) + 0.04
         f, p = csd(x, x, nperseg=10,
-                detrend=lambda seg: signal.detrend(seg, type='l'))
+                   detrend=lambda seg: signal.detrend(seg, type='l'))
         assert_allclose(p, np.zeros_like(p), atol=1e-15)
 
     def test_detrend_external_nd_m1(self):
         x = np.arange(40, dtype=np.float64) + 0.04
         x = x.reshape((2,2,10))
         f, p = csd(x, x, nperseg=10,
-                detrend=lambda seg: signal.detrend(seg, type='l'))
+                   detrend=lambda seg: signal.detrend(seg, type='l'))
         assert_allclose(p, np.zeros_like(p), atol=1e-15)
 
     def test_detrend_external_nd_0(self):
@@ -564,7 +576,7 @@ class TestCSD:
         x = x.reshape((2,1,10))
         x = np.rollaxis(x, 2, 0)
         f, p = csd(x, x, nperseg=10, axis=0,
-                detrend=lambda seg: signal.detrend(seg, axis=0, type='l'))
+                   detrend=lambda seg: signal.detrend(seg, axis=0, type='l'))
         assert_allclose(p, np.zeros_like(p), atol=1e-15)
 
     def test_nd_axis_m1(self):
@@ -636,14 +648,17 @@ class TestCSD:
         x = np.zeros(64)
         x[::8] = 1
         f, p = csd(x, x, nperseg=16, noverlap=4)
-        q = np.array([0, 1./12., 1./3., 1./5., 1./3., 1./5., 1./3., 1./5., 1./6.])
+        q = np.array([0, 1./12., 1./3., 1./5., 1./3., 1./5., 1./3., 1./5., 
+                      1./6.])
         assert_allclose(p, q, atol=1e-12)
 
     def test_bad_noverlap(self):
-        assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1, 'hanning', 2, 7)
+        assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1, 'hanning', 
+                      2, 7)
 
     def test_nfft_too_short(self):
-        assert_raises(ValueError, csd, np.ones(12), np.zeros(12), nfft=3, nperseg=4)
+        assert_raises(ValueError, csd, np.ones(12), np.zeros(12), nfft=3, 
+                      nperseg=4)
 
     def test_real_onesided_even_32(self):
         x = np.zeros(16, 'f')
@@ -652,7 +667,7 @@ class TestCSD:
         f, p = csd(x, x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
         q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
-            0.11111111], 'f') 
+                      0.11111111], 'f') 
         assert_allclose(p, q)
         assert_(p.dtype == q.dtype)
 
@@ -663,7 +678,7 @@ class TestCSD:
         f, p = csd(x, x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
         q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
-            0.12188675], 'f')
+                      0.12188675], 'f')
         assert_allclose(p, q, atol=1e-7)
         assert_(p.dtype == q.dtype)
 
@@ -675,7 +690,8 @@ class TestCSD:
         f, p = csd(x, x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
         q = np.array([0.08333333, 0.07638889, 0.11111111,
-            0.11111111, 0.11111111, 0.11111111, 0.11111111, 0.07638889], 'f')
+                      0.11111111, 0.11111111, 0.11111111, 0.11111111, 
+                      0.07638889], 'f')
         assert_allclose(p, q)
         assert_(p.dtype == q.dtype)
 
@@ -687,9 +703,10 @@ class TestCSD:
         f, p = csd(x, x, nperseg=8)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
         q = np.array([0.41666666, 0.38194442, 0.55555552, 0.55555552, 
-            0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
+                      0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
-        assert_(p.dtype == q.dtype, 'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
+        assert_(p.dtype == q.dtype, 
+                'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
 
 
 class TestCoherence:

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -224,8 +224,9 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
-        assert_allclose(p, np.array([0.08333333, 0.15277778, 0.22222222,
-                                     0.22222222, 0.11111111]))
+        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222, 
+                      0.11111111])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_real_onesided_odd(self):
         x = np.zeros(16)
@@ -233,8 +234,9 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
-        assert_allclose(p, np.array([0.15958226, 0.24193954, 0.24145223,
-                                     0.24100919, 0.12188675]))
+        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919, 
+                      0.12188675])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_real_twosided(self):
         x = np.zeros(16)
@@ -242,9 +244,9 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        assert_allclose(p, np.array([0.08333333, 0.07638889, 0.11111111,
-                                     0.11111111, 0.11111111, 0.11111111, 
-                                     0.11111111, 0.07638889]))
+        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111, 
+                      0.11111111, 0.11111111, 0.11111111, 0.07638889])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_real_spectrum(self):
         x = np.zeros(16)
@@ -252,9 +254,9 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=8, scaling='spectrum')
         assert_allclose(f, np.linspace(0, 0.5, 5))
-        assert_allclose(p, np.array([0.015625, 0.028645833333333332,
-                                     0.041666666666666664, 0.041666666666666664,
-                                     0.020833333333333332]))
+        q = np.array([0.015625, 0.02864583, 0.04166667, 0.04166667, 
+                      0.02083333])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_integer_onesided_even(self):
         x = np.zeros(16, dtype=np.int)
@@ -262,8 +264,9 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
-        assert_allclose(p, np.array([0.08333333, 0.15277778, 0.22222222,
-                                     0.22222222, 0.11111111]))
+        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222, 
+                      0.11111111])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_integer_onesided_odd(self):
         x = np.zeros(16, dtype=np.int)
@@ -271,8 +274,9 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
-        assert_allclose(p, np.array([0.15958226, 0.24193954, 0.24145223,
-                                     0.24100919, 0.12188675]))
+        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919, 
+                      0.12188675])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_integer_twosided(self):
         x = np.zeros(16, dtype=np.int)
@@ -280,9 +284,9 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        assert_allclose(p, np.array([0.08333333, 0.07638889, 0.11111111,
-                                     0.11111111, 0.11111111, 0.11111111, 
-                                     0.11111111, 0.07638889]))
+        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111, 
+                      0.11111111, 0.11111111, 0.11111111, 0.07638889])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_complex(self):
         x = np.zeros(16, np.complex128)
@@ -290,9 +294,9 @@ class TestWelch(TestCase):
         x[8] = 1.0 + 2.0j
         f, p = welch(x, nperseg=8)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        assert_allclose(p, np.array([0.41666667, 0.38194444, 0.55555556,
-                                     0.55555556, 0.55555556, 0.55555556, 
-                                     0.55555556, 0.38194444]))
+        q = np.array([0.41666667, 0.38194444, 0.55555556, 0.55555556, 
+                      0.55555556, 0.55555556, 0.55555556, 0.38194444])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_unk_scaling(self):
         assert_raises(ValueError, welch, np.zeros(4, np.complex128),
@@ -415,7 +419,7 @@ class TestWelch(TestCase):
         assert_allclose(f, np.linspace(0, 0.5, 5))
         q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
                       0.11111111], 'f') 
-        assert_allclose(p, q)
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
     def test_real_onesided_odd_32(self):
@@ -426,7 +430,7 @@ class TestWelch(TestCase):
         assert_allclose(f, np.arange(5.0)/9.0)
         q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
                       0.12188675], 'f')
-        assert_allclose(p, q, atol=1e-7)
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
     @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
@@ -439,7 +443,7 @@ class TestWelch(TestCase):
         q = np.array([0.08333333, 0.07638889, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.11111111, 
                       0.07638889], 'f')
-        assert_allclose(p, q)
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
     @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
@@ -451,7 +455,7 @@ class TestWelch(TestCase):
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
         q = np.array([0.41666666, 0.38194442, 0.55555552, 0.55555552, 
                       0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
-        assert_allclose(p, q)
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype,
                 'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
 
@@ -484,8 +488,9 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
-        assert_allclose(p, np.array([0.08333333, 0.15277778, 0.22222222,
-                                     0.22222222, 0.11111111]))
+        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222, 
+                      0.11111111])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_real_onesided_odd(self):
         x = np.zeros(16)
@@ -493,8 +498,9 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
-        assert_allclose(p, np.array([0.15958226, 0.24193954, 0.24145223,
-                                     0.24100919, 0.12188675]))
+        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
+                      0.12188675])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_real_twosided(self):
         x = np.zeros(16)
@@ -502,9 +508,9 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        assert_allclose(p, np.array([0.08333333, 0.07638889, 0.11111111,
-                                     0.11111111, 0.11111111, 0.11111111, 
-                                     0.11111111, 0.07638889]))
+        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111, 
+                      0.11111111, 0.11111111, 0.11111111, 0.07638889])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_real_spectrum(self):
         x = np.zeros(16)
@@ -512,9 +518,9 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=8, scaling='spectrum')
         assert_allclose(f, np.linspace(0, 0.5, 5))
-        assert_allclose(p, np.array([0.015625, 0.028645833333333332,
-                                     0.041666666666666664, 0.041666666666666664, 
-                                     0.020833333333333332]))
+        q = np.array([0.015625, 0.02864583, 0.04166667, 0.04166667, 
+                      0.02083333])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_integer_onesided_even(self):
         x = np.zeros(16, dtype=np.int)
@@ -522,8 +528,9 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
-        assert_allclose(p, np.array([0.08333333, 0.15277778, 0.22222222,
-                                     0.22222222, 0.11111111]))
+        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222, 
+                      0.11111111])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_integer_onesided_odd(self):
         x = np.zeros(16, dtype=np.int)
@@ -531,8 +538,9 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
-        assert_allclose(p, np.array([0.15958226, 0.24193954, 0.24145223,
-                                     0.24100919, 0.12188675]))
+        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919, 
+                      0.12188675])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_integer_twosided(self):
         x = np.zeros(16, dtype=np.int)
@@ -540,9 +548,9 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        assert_allclose(p, np.array([0.08333333, 0.07638889, 0.11111111,
-                                     0.11111111, 0.11111111, 0.11111111, 
-                                     0.11111111, 0.07638889]))
+        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111, 
+                      0.11111111, 0.11111111, 0.11111111, 0.07638889])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_complex(self):
         x = np.zeros(16, np.complex128)
@@ -550,9 +558,9 @@ class TestCSD:
         x[8] = 1.0 + 2.0j
         f, p = csd(x, x, nperseg=8)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        assert_allclose(p, np.array([0.41666667, 0.38194444, 0.55555556,
-                                     0.55555556, 0.55555556, 0.55555556, 
-                                     0.55555556, 0.38194444]))
+        q = np.array([0.41666667, 0.38194444, 0.55555556, 0.55555556, 
+                      0.55555556, 0.55555556, 0.55555556, 0.38194444])
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_unk_scaling(self):
         assert_raises(ValueError, csd, np.zeros(4, np.complex128),
@@ -686,7 +694,7 @@ class TestCSD:
         assert_allclose(f, np.linspace(0, 0.5, 5))
         q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
                       0.11111111], 'f') 
-        assert_allclose(p, q)
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
     def test_real_onesided_odd_32(self):
@@ -697,7 +705,7 @@ class TestCSD:
         assert_allclose(f, np.arange(5.0)/9.0)
         q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
                       0.12188675], 'f')
-        assert_allclose(p, q, atol=1e-7)
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
     @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
@@ -710,7 +718,7 @@ class TestCSD:
         q = np.array([0.08333333, 0.07638889, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.11111111, 
                       0.07638889], 'f')
-        assert_allclose(p, q)
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
     @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_raises, assert_approx_equal, \
                           assert_array_almost_equal_nulp, dec
 from scipy import signal, fftpack
 from scipy._lib._version import NumpyVersion
-from scipy.signal import periodogram, welch, lombscargle
+from scipy.signal import periodogram, welch, lombscargle, csd, coherence
 
 
 class TestPeriodogram(TestCase):
@@ -434,6 +434,286 @@ class TestWelch(TestCase):
             0.55555556, 0.55555556, 0.55555556, 0.55555556, 0.38194444], 'f')
         assert_allclose(p, q)
         assert_(p.dtype == q.dtype, 'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
+
+class TestCSD:
+    def test_pad_shorter_x(self):
+        x = np.zeros(8)
+        y = np.zeros(12)
+
+        f = np.linspace(0, 0.5, 7)
+        c = np.zeros(7,dtype=np.complex128)
+        f1, c1 = csd(x, y, nperseg=12)
+
+        assert_allclose(f, f1)
+        assert_allclose(c, c1)
+
+    def test_pad_shorter_y(self):
+        x = np.zeros(12)
+        y = np.zeros(8)
+
+        f = np.linspace(0, 0.5, 7)
+        c = np.zeros(7,dtype=np.complex128)
+        f1, c1 = csd(x, y, nperseg=12)
+
+        assert_allclose(f, f1)
+        assert_allclose(c, c1)
+
+    def test_real_onesided_even(self):
+        x = np.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=8)
+        assert_allclose(f, np.linspace(0, 0.5, 5))
+        assert_allclose(p, np.array([0.08333333, 0.15277778, 0.22222222,
+            0.22222222, 0.11111111]))
+
+    def test_real_onesided_odd(self):
+        x = np.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=9)
+        assert_allclose(f, np.arange(5.0)/9.0)
+        assert_allclose(p, np.array([0.15958226, 0.24193954, 0.24145223,
+            0.24100919, 0.12188675]))
+
+    def test_real_twosided(self):
+        x = np.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=8, return_onesided=False)
+        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(p, np.array([0.08333333, 0.07638889, 0.11111111,
+            0.11111111, 0.11111111, 0.11111111, 0.11111111, 0.07638889]))
+
+    def test_real_spectrum(self):
+        x = np.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=8, scaling='spectrum')
+        assert_allclose(f, np.linspace(0, 0.5, 5))
+        assert_allclose(p, np.array([0.015625, 0.028645833333333332,
+            0.041666666666666664, 0.041666666666666664, 0.020833333333333332]))
+
+    def test_integer_onesided_even(self):
+        x = np.zeros(16, dtype=np.int)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=8)
+        assert_allclose(f, np.linspace(0, 0.5, 5))
+        assert_allclose(p, np.array([0.08333333, 0.15277778, 0.22222222,
+            0.22222222, 0.11111111]))
+
+    def test_integer_onesided_odd(self):
+        x = np.zeros(16, dtype=np.int)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=9)
+        assert_allclose(f, np.arange(5.0)/9.0)
+        assert_allclose(p, np.array([0.15958226, 0.24193954, 0.24145223,
+            0.24100919, 0.12188675]))
+
+    def test_integer_twosided(self):
+        x = np.zeros(16, dtype=np.int)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=8, return_onesided=False)
+        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(p, np.array([0.08333333, 0.07638889, 0.11111111,
+            0.11111111, 0.11111111, 0.11111111, 0.11111111, 0.07638889]))
+
+    def test_complex(self):
+        x = np.zeros(16, np.complex128)
+        x[0] = 1.0 + 2.0j
+        x[8] = 1.0 + 2.0j
+        f, p = csd(x, x, nperseg=8)
+        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        assert_allclose(p, np.array([0.41666667, 0.38194444, 0.55555556,
+            0.55555556, 0.55555556, 0.55555556, 0.55555556, 0.38194444]))
+
+    def test_unk_scaling(self):
+        assert_raises(ValueError, csd, np.zeros(4, np.complex128),
+                np.ones(4, np.complex128), scaling='foo', nperseg=4)
+
+    def test_detrend_linear(self):
+        x = np.arange(10, dtype=np.float64) + 0.04
+        f, p = csd(x, x, nperseg=10, detrend='linear')
+        assert_allclose(p, np.zeros_like(p), atol=1e-15)
+
+    def test_no_detrending(self):
+        x = np.arange(10, dtype=np.float64) + 0.04
+        f1, p1 = csd(x, x, nperseg=10, detrend=False)
+        f2, p2 = csd(x, x, nperseg=10, detrend=lambda x: x)
+        assert_allclose(f1, f2, atol=1e-15)
+        assert_allclose(p1, p2, atol=1e-15)
+
+    def test_detrend_external(self):
+        x = np.arange(10, dtype=np.float64) + 0.04
+        f, p = csd(x, x, nperseg=10,
+                detrend=lambda seg: signal.detrend(seg, type='l'))
+        assert_allclose(p, np.zeros_like(p), atol=1e-15)
+
+    def test_detrend_external_nd_m1(self):
+        x = np.arange(40, dtype=np.float64) + 0.04
+        x = x.reshape((2,2,10))
+        f, p = csd(x, x, nperseg=10,
+                detrend=lambda seg: signal.detrend(seg, type='l'))
+        assert_allclose(p, np.zeros_like(p), atol=1e-15)
+
+    def test_detrend_external_nd_0(self):
+        x = np.arange(20, dtype=np.float64) + 0.04
+        x = x.reshape((2,1,10))
+        x = np.rollaxis(x, 2, 0)
+        f, p = csd(x, x, nperseg=10, axis=0,
+                detrend=lambda seg: signal.detrend(seg, axis=0, type='l'))
+        assert_allclose(p, np.zeros_like(p), atol=1e-15)
+
+    def test_nd_axis_m1(self):
+        x = np.arange(20, dtype=np.float64) + 0.04
+        x = x.reshape((2,1,10))
+        f, p = csd(x, x, nperseg=10)
+        assert_array_equal(p.shape, (2, 1, 6))
+        assert_allclose(p[0,0,:], p[1,0,:], atol=1e-13, rtol=1e-13)
+        f0, p0 = csd(x[0,0,:], x[0,0,:], nperseg=10)
+        assert_allclose(p0[np.newaxis,:], p[1,:], atol=1e-13, rtol=1e-13)
+
+    def test_nd_axis_0(self):
+        x = np.arange(20, dtype=np.float64) + 0.04
+        x = x.reshape((10,2,1))
+        f, p = csd(x, x, nperseg=10, axis=0)
+        assert_array_equal(p.shape, (6,2,1))
+        assert_allclose(p[:,0,0], p[:,1,0], atol=1e-13, rtol=1e-13)
+        f0, p0 = csd(x[:,0,0], x[:,0,0], nperseg=10)
+        assert_allclose(p0, p[:,1,0], atol=1e-13, rtol=1e-13)
+
+    def test_window_external(self):
+        x = np.zeros(16)
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, 10, 'hanning', 8)
+        win = signal.get_window('hanning', 8)
+        fe, pe = csd(x, x, 10, win, 8)
+        assert_array_almost_equal_nulp(p, pe)
+        assert_array_almost_equal_nulp(f, fe)
+
+    def test_empty_input(self):
+        f, p = csd([],np.zeros(10))
+        assert_array_equal(f.shape, (0,))
+        assert_array_equal(p.shape, (0,))
+
+        f, p = csd(np.zeros(10),[])
+        assert_array_equal(f.shape, (0,))
+        assert_array_equal(p.shape, (0,))
+
+        for shape in [(0,), (3,0), (0,5,2)]:
+            f, p = csd(np.empty(shape), np.zeros(10))
+            assert_array_equal(f.shape, shape)
+            assert_array_equal(p.shape, shape)
+
+            f, p = csd(np.zeros(10), np.empty(shape))
+            assert_array_equal(f.shape, shape)
+            assert_array_equal(p.shape, shape)
+
+    def test_short_data(self):
+        x = np.zeros(8)
+        x[0] = 1
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            f, p = csd(x, x)
+
+        f1, p1 = csd(x, x, nperseg=8)
+        assert_allclose(f, f1)
+        assert_allclose(p, p1)
+
+    def test_window_long_or_nd(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1, 
+                          np.array([1,1,1,1,1]))
+            assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1,
+                          np.arange(6).reshape((2,3)))
+
+    def test_nondefault_noverlap(self):
+        x = np.zeros(64)
+        x[::8] = 1
+        f, p = csd(x, x, nperseg=16, noverlap=4)
+        q = np.array([0, 1./12., 1./3., 1./5., 1./3., 1./5., 1./3., 1./5., 1./6.])
+        assert_allclose(p, q, atol=1e-12)
+
+    def test_bad_noverlap(self):
+        assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1, 'hanning', 2, 7)
+
+    def test_nfft_too_short(self):
+        assert_raises(ValueError, csd, np.ones(12), np.zeros(12), nfft=3, nperseg=4)
+
+    def test_real_onesided_even_32(self):
+        x = np.zeros(16, 'f')
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=8)
+        assert_allclose(f, np.linspace(0, 0.5, 5))
+        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
+            0.11111111], 'f') 
+        assert_allclose(p, q)
+        assert_(p.dtype == q.dtype)
+
+    def test_real_onesided_odd_32(self):
+        x = np.zeros(16, 'f')
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=9)
+        assert_allclose(f, np.arange(5.0)/9.0)
+        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
+            0.12188675], 'f')
+        assert_allclose(p, q, atol=1e-7)
+        assert_(p.dtype == q.dtype)
+
+    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
+    def test_real_twosided_32(self):
+        x = np.zeros(16, 'f')
+        x[0] = 1
+        x[8] = 1
+        f, p = csd(x, x, nperseg=8, return_onesided=False)
+        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        q = np.array([0.08333333, 0.07638889, 0.11111111,
+            0.11111111, 0.11111111, 0.11111111, 0.11111111, 0.07638889], 'f')
+        assert_allclose(p, q)
+        assert_(p.dtype == q.dtype)
+
+    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
+    def test_complex_32(self):
+        x = np.zeros(16, 'F')
+        x[0] = 1.0 + 2.0j
+        x[8] = 1.0 + 2.0j
+        f, p = csd(x, x, nperseg=8)
+        assert_allclose(f, fftpack.fftfreq(8, 1.0))
+        q = np.array([0.41666667, 0.38194444, 0.55555556,
+            0.55555556, 0.55555556, 0.55555556, 0.55555556, 0.38194444], 'f')
+        assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        assert_(p.dtype == q.dtype, 'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
+
+
+class TestCoherence:
+    def test_identical_input(self):
+        x = np.random.randn(20)
+        y = np.copy(x)  # So `y is x` -> False
+
+        f = np.linspace(0, 0.5, 6)
+        C = np.ones(6)
+        f1, C1 = coherence(x, y, nperseg=10)
+
+        assert_allclose(f, f1)
+        assert_allclose(C, C1)
+
+    def test_phase_shifted_input(self):
+        x = np.random.randn(20)
+        y = -x 
+
+        f = np.linspace(0, 0.5, 6)
+        C = np.ones(6)
+        f1, C1 = coherence(x, y, nperseg=10)
+
+        assert_allclose(f, f1)
+        assert_allclose(C, C1)
 
 
 class TestLombscargle:

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -30,7 +30,6 @@ class TestPeriodogram(TestCase):
         assert_allclose(f, np.arange(8.0)/15.0)
         q = np.ones(8)
         q[0] = 0
-        q[-1] /= 2.0
         q *= 2.0/15.0
         assert_allclose(p, q, atol=1e-15)
 
@@ -69,7 +68,6 @@ class TestPeriodogram(TestCase):
         assert_allclose(f, np.arange(8.0)/15.0)
         q = np.ones(8)
         q[0] = 0
-        q[-1] /= 2.0
         q *= 2.0/15.0
         assert_allclose(p, q, atol=1e-15)
 
@@ -189,7 +187,6 @@ class TestPeriodogram(TestCase):
         assert_allclose(f, np.arange(8.0)/15.0)
         q = np.ones(8, 'f')
         q[0] = 0
-        q[-1] /= 2.0
         q *= 2.0/15.0
         assert_allclose(p, q, atol=1e-7)
         assert_(p.dtype == q.dtype)
@@ -234,8 +231,8 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
-        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
-                      0.12188675])
+        q = np.array([0.15958227, 0.24193957, 0.24145224, 0.24100919,
+                      0.24377353])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_real_twosided(self):
@@ -274,8 +271,8 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
-        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
-                      0.12188675])
+        q = np.array([0.15958227, 0.24193957, 0.24145224, 0.24100919,
+                      0.24377353])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_integer_twosided(self):
@@ -428,8 +425,8 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
-        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
-                      0.12188675], 'f')
+        q = np.array([0.15958227, 0.24193957, 0.24145224, 0.24100919,
+                      0.24377353], 'f')
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
@@ -498,8 +495,8 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
-        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
-                      0.12188675])
+        q = np.array([0.15958227, 0.24193957, 0.24145224, 0.24100919,
+                      0.24377353])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_real_twosided(self):
@@ -538,8 +535,8 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
-        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
-                      0.12188675])
+        q = np.array([0.15958227, 0.24193957, 0.24145224, 0.24100919,
+                      0.24377353])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_integer_twosided(self):
@@ -715,8 +712,8 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
-        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
-                      0.12188675], 'f')
+        q = np.array([0.15958227, 0.24193957, 0.24145224, 0.24100919,
+                      0.24377353], 'f')
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -637,19 +637,31 @@ class TestCSD:
         assert_array_equal(p.shape, (0,))
 
         for shape in [(0,), (3,0), (0,5,2)]:
-            f, p = csd(np.empty(shape), np.zeros(10))
+            f, p = csd(np.empty(shape), np.empty(shape))
             assert_array_equal(f.shape, shape)
             assert_array_equal(p.shape, shape)
 
-            f, p = csd(np.zeros(10), np.empty(shape))
-            assert_array_equal(f.shape, shape)
-            assert_array_equal(p.shape, shape)
+        f, p = csd(np.ones(10), np.empty((5,0)))
+        assert_array_equal(f.shape, (5,0))
+        assert_array_equal(p.shape, (5,0))
+
+        f, p = csd(np.empty((5,0)), np.ones(10))
+        assert_array_equal(f.shape, (5,0))
+        assert_array_equal(p.shape, (5,0))
 
     def test_empty_input_other_axis(self):
         for shape in [(3,0), (0,5,2)]:
-            f, p = welch(np.empty(shape), np.empty(shape), axis=1)
+            f, p = csd(np.empty(shape), np.empty(shape), axis=1)
             assert_array_equal(f.shape, shape)
             assert_array_equal(p.shape, shape)
+
+        f, p = csd(np.empty((10,10,3)), np.zeros((10,0,1)), axis=1)
+        assert_array_equal(f.shape, (10,0,3))
+        assert_array_equal(p.shape, (10,0,3))
+
+        f, p = csd(np.empty((10,0,1)), np.zeros((10,10,3)), axis=1)
+        assert_array_equal(f.shape, (10,0,3))
+        assert_array_equal(p.shape, (10,0,3))
 
     def test_short_data(self):
         x = np.zeros(8)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -142,6 +142,12 @@ class TestPeriodogram(TestCase):
             assert_array_equal(f.shape, shape)
             assert_array_equal(p.shape, shape)
 
+    def test_empty_input_other_axis(self):
+        for shape in [(3,0), (0,5,2)]:
+            f, p = periodogram(np.empty(shape), axis=1)
+            assert_array_equal(f.shape, shape)
+            assert_array_equal(p.shape, shape)
+
     def test_short_nfft(self):
         x = np.zeros(18)
         x[0] = 1
@@ -359,6 +365,12 @@ class TestWelch(TestCase):
         assert_array_equal(p.shape, (0,))
         for shape in [(0,), (3,0), (0,5,2)]:
             f, p = welch(np.empty(shape))
+            assert_array_equal(f.shape, shape)
+            assert_array_equal(p.shape, shape)
+
+    def test_empty_input_other_axis(self):
+        for shape in [(3,0), (0,5,2)]:
+            f, p = welch(np.empty(shape), axis=1)
             assert_array_equal(f.shape, shape)
             assert_array_equal(p.shape, shape)
 
@@ -622,6 +634,12 @@ class TestCSD:
             assert_array_equal(p.shape, shape)
 
             f, p = csd(np.zeros(10), np.empty(shape))
+            assert_array_equal(f.shape, shape)
+            assert_array_equal(p.shape, shape)
+
+    def test_empty_input_other_axis(self):
+        for shape in [(3,0), (0,5,2)]:
+            f, p = welch(np.empty(shape), np.empty(shape), axis=1)
             assert_array_equal(f.shape, shape)
             assert_array_equal(p.shape, shape)
 

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -224,7 +224,7 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
-        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222, 
+        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
                       0.11111111])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
@@ -234,7 +234,7 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
-        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919, 
+        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
                       0.12188675])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
@@ -244,7 +244,7 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111, 
+        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.07638889])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
@@ -254,7 +254,7 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=8, scaling='spectrum')
         assert_allclose(f, np.linspace(0, 0.5, 5))
-        q = np.array([0.015625, 0.02864583, 0.04166667, 0.04166667, 
+        q = np.array([0.015625, 0.02864583, 0.04166667, 0.04166667,
                       0.02083333])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
@@ -264,7 +264,7 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
-        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222, 
+        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
                       0.11111111])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
@@ -274,7 +274,7 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
-        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919, 
+        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
                       0.12188675])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
@@ -284,7 +284,7 @@ class TestWelch(TestCase):
         x[8] = 1
         f, p = welch(x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111, 
+        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.07638889])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
@@ -294,7 +294,7 @@ class TestWelch(TestCase):
         x[8] = 1.0 + 2.0j
         f, p = welch(x, nperseg=8)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        q = np.array([0.41666667, 0.38194444, 0.55555556, 0.55555556, 
+        q = np.array([0.41666667, 0.38194444, 0.55555556, 0.55555556,
                       0.55555556, 0.55555556, 0.55555556, 0.38194444])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
@@ -392,7 +392,7 @@ class TestWelch(TestCase):
     def test_window_long_or_nd(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', UserWarning)
-            assert_raises(ValueError, welch, np.zeros(4), 1, 
+            assert_raises(ValueError, welch, np.zeros(4), 1,
                           np.array([1,1,1,1,1]))
             assert_raises(ValueError, welch, np.zeros(4), 1,
                           np.arange(6).reshape((2,3)))
@@ -401,7 +401,7 @@ class TestWelch(TestCase):
         x = np.zeros(64)
         x[::8] = 1
         f, p = welch(x, nperseg=16, noverlap=4)
-        q = np.array([0, 1./12., 1./3., 1./5., 1./3., 1./5., 1./3., 1./5., 
+        q = np.array([0, 1./12., 1./3., 1./5., 1./3., 1./5., 1./3., 1./5.,
                       1./6.])
         assert_allclose(p, q, atol=1e-12)
 
@@ -418,7 +418,7 @@ class TestWelch(TestCase):
         f, p = welch(x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
         q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
-                      0.11111111], 'f') 
+                      0.11111111], 'f')
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
@@ -441,7 +441,7 @@ class TestWelch(TestCase):
         f, p = welch(x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
         q = np.array([0.08333333, 0.07638889, 0.11111111,
-                      0.11111111, 0.11111111, 0.11111111, 0.11111111, 
+                      0.11111111, 0.11111111, 0.11111111, 0.11111111,
                       0.07638889], 'f')
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
@@ -453,7 +453,7 @@ class TestWelch(TestCase):
         x[8] = 1.0 + 2.0j
         f, p = welch(x, nperseg=8)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        q = np.array([0.41666666, 0.38194442, 0.55555552, 0.55555552, 
+        q = np.array([0.41666666, 0.38194442, 0.55555552, 0.55555552,
                       0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype,
@@ -488,7 +488,7 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
-        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222, 
+        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
                       0.11111111])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
@@ -508,7 +508,7 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111, 
+        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.07638889])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
@@ -518,7 +518,7 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=8, scaling='spectrum')
         assert_allclose(f, np.linspace(0, 0.5, 5))
-        q = np.array([0.015625, 0.02864583, 0.04166667, 0.04166667, 
+        q = np.array([0.015625, 0.02864583, 0.04166667, 0.04166667,
                       0.02083333])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
@@ -528,7 +528,7 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
-        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222, 
+        q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
                       0.11111111])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
@@ -538,7 +538,7 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=9)
         assert_allclose(f, np.arange(5.0)/9.0)
-        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919, 
+        q = np.array([0.15958226, 0.24193954, 0.24145223, 0.24100919,
                       0.12188675])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
@@ -548,7 +548,7 @@ class TestCSD:
         x[8] = 1
         f, p = csd(x, x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111, 
+        q = np.array([0.08333333, 0.07638889, 0.11111111, 0.11111111,
                       0.11111111, 0.11111111, 0.11111111, 0.07638889])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
@@ -558,7 +558,7 @@ class TestCSD:
         x[8] = 1.0 + 2.0j
         f, p = csd(x, x, nperseg=8)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        q = np.array([0.41666667, 0.38194444, 0.55555556, 0.55555556, 
+        q = np.array([0.41666667, 0.38194444, 0.55555556, 0.55555556,
                       0.55555556, 0.55555556, 0.55555556, 0.38194444])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
@@ -665,7 +665,7 @@ class TestCSD:
     def test_window_long_or_nd(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', UserWarning)
-            assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1, 
+            assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1,
                           np.array([1,1,1,1,1]))
             assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1,
                           np.arange(6).reshape((2,3)))
@@ -674,16 +674,16 @@ class TestCSD:
         x = np.zeros(64)
         x[::8] = 1
         f, p = csd(x, x, nperseg=16, noverlap=4)
-        q = np.array([0, 1./12., 1./3., 1./5., 1./3., 1./5., 1./3., 1./5., 
+        q = np.array([0, 1./12., 1./3., 1./5., 1./3., 1./5., 1./3., 1./5.,
                       1./6.])
         assert_allclose(p, q, atol=1e-12)
 
     def test_bad_noverlap(self):
-        assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1, 'hanning', 
+        assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1, 'hanning',
                       2, 7)
 
     def test_nfft_too_short(self):
-        assert_raises(ValueError, csd, np.ones(12), np.zeros(12), nfft=3, 
+        assert_raises(ValueError, csd, np.ones(12), np.zeros(12), nfft=3,
                       nperseg=4)
 
     def test_real_onesided_even_32(self):
@@ -693,7 +693,7 @@ class TestCSD:
         f, p = csd(x, x, nperseg=8)
         assert_allclose(f, np.linspace(0, 0.5, 5))
         q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
-                      0.11111111], 'f') 
+                      0.11111111], 'f')
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
@@ -716,7 +716,7 @@ class TestCSD:
         f, p = csd(x, x, nperseg=8, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
         q = np.array([0.08333333, 0.07638889, 0.11111111,
-                      0.11111111, 0.11111111, 0.11111111, 0.11111111, 
+                      0.11111111, 0.11111111, 0.11111111, 0.11111111,
                       0.07638889], 'f')
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
@@ -728,10 +728,10 @@ class TestCSD:
         x[8] = 1.0 + 2.0j
         f, p = csd(x, x, nperseg=8)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        q = np.array([0.41666666, 0.38194442, 0.55555552, 0.55555552, 
+        q = np.array([0.41666666, 0.38194442, 0.55555552, 0.55555552,
                       0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
-        assert_(p.dtype == q.dtype, 
+        assert_(p.dtype == q.dtype,
                 'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
 
 
@@ -749,7 +749,7 @@ class TestCoherence:
 
     def test_phase_shifted_input(self):
         x = np.random.randn(20)
-        y = -x 
+        y = -x
 
         f = np.linspace(0, 0.5, 6)
         C = np.ones(6)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -430,8 +430,8 @@ class TestWelch(TestCase):
         x[8] = 1.0 + 2.0j
         f, p = welch(x, nperseg=8)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        q = np.array([0.41666667, 0.38194444, 0.55555556,
-            0.55555556, 0.55555556, 0.55555556, 0.55555556, 0.38194444], 'f')
+        q = np.array([0.41666666, 0.38194442, 0.55555552, 0.55555552, 
+            0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
         assert_allclose(p, q)
         assert_(p.dtype == q.dtype, 'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
 
@@ -686,8 +686,8 @@ class TestCSD:
         x[8] = 1.0 + 2.0j
         f, p = csd(x, x, nperseg=8)
         assert_allclose(f, fftpack.fftfreq(8, 1.0))
-        q = np.array([0.41666667, 0.38194444, 0.55555556,
-            0.55555556, 0.55555556, 0.55555556, 0.55555556, 0.38194444], 'f')
+        q = np.array([0.41666666, 0.38194442, 0.55555552, 0.55555552, 
+            0.55555558, 0.55555552, 0.55555552, 0.38194442], 'f')
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype, 'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
 


### PR DESCRIPTION
This is a new PR for adding Cross Spectral Density computations to scipy.signal. The previous PR (#4468), extended the existing welch algorithm for the CSD, but then I found that matplotlib.malb has an existing, much faster, version that uses strided arrays for efficiency. 

I have adapted the matplotlib.mlab code for use in scipy.signal. This required rewriting welch to use the same underlying stride algorithm. 

Some reworking of the matplotlib code was needed to make functions work for
multidimensional arrays, as the current scipy.signal.welch function allows.
Things were also adjusted to keep the same welch API.

Advantages of this code change include:
- A speedup of about 8x in welch
- A speedup of about 6x in csd compared to extending the current
  algorithm to cover the cross spectral density.
- Straightforward extensibility to add spectrogram functionality

There are probably still rough edges, but this seems to be working. Some
tests are included. (Known test failure : test_complex_32 in
test_spectral.TestWelch; effectively correct, but the tolerances are too
tight.)
