### PR TITLE
BUG: Fixes #4594: optimize.linprog IndexError when a callback is provided

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -305,7 +305,6 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, callback=None,
     """
     nit = nit0
     complete = False
-    solution = np.zeros(T.shape[1]-1, dtype=np.float64)
 
     if phase == 1:
         m = T.shape[0]-2
@@ -313,6 +312,12 @@ def _solve_simplex(T, n, basis, maxiter=1000, phase=2, callback=None,
         m = T.shape[0]-1
     else:
         raise ValueError("Argument 'phase' to _solve_simplex must be 1 or 2")
+
+    if len(basis[:m]) == 0:
+        solution = np.zeros(T.shape[1] - 1, dtype=np.float64)
+    else:
+        solution = np.zeros(max(T.shape[1] - 1, max(basis[:m]) + 1),
+                            dtype=np.float64)
 
     while not complete:
         # Find the pivot column

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -213,7 +213,13 @@ def test_network_flow_limited_capacity():
             [0, p, p, 0, n],
             [0, 0, 0, p, p]]
     b_eq = [-4, 0, 0, 4]
-    res = linprog(c=cost, A_eq=A_eq, b_eq=b_eq, bounds=bounds)
+    # Including the callback here ensures the solution can be
+    # calculated correctly, even when phase 1 terminated
+    # with some of the artificial variables as pivots
+    # (i.e. basis[:m] contains elements corresponding to
+    # the artificial variables)
+    res = linprog(c=cost, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
+                  callback=lambda x, **kwargs: None)
     _assert_success(res, desired_fun=14)
 
 
@@ -257,7 +263,10 @@ def test_enzo_example_b():
             [0, 1, 0, 0, 1, 0],
             [0, 0, 1, 0, 0, 1]]
     b_eq = [-0.5, 0.4, 0.3, 0.3, 0.3]
-    res = linprog(c=c, A_eq=A_eq, b_eq=b_eq)
+    # Including the callback here ensures the solution can be
+    # calculated correctly.
+    res = linprog(c=c, A_eq=A_eq, b_eq=b_eq,
+                  callback=lambda x, **kwargs: None)
     _assert_success(res, desired_fun=-1.77,
                     desired_x=[0.3, 0.2, 0.0, 0.0, 0.1, 0.3])
 


### PR DESCRIPTION
The bug appeared at the beginning of Phase 2, if Phase 1 successfully terminated with some of the artificial variables as pivots. These artificial variables were zero because the corresponding element in the last column of T was zero, which allowed all artificial variables to be eliminated and Phase 1 to terminate successfully. However, basis[:m] contained elements that were greater than the length of solution, which resulted in IndexError at solution[basis[:m]]. The remaining true (non-artificial) variables that are not included in basis[:m] are also zero. Therefore simply setting the length of solution to be large enough solves the problem.
