### PR TITLE
MAINT: simplify some indexing code in sparse matrix sampling

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -761,8 +761,7 @@ greater than %d - this is not supported on this machine
             selected.add(j)
             ind[i] = j
 
-    j = np.floor(ind * 1. / m).astype(tp)
-    i = (ind - j * m).astype(tp)
+    j, i = np.unravel_index(ind, (n, m))
     vals = data_rvs(k).astype(dtype)
     return coo_matrix((vals, (i, j)), shape=(m, n)).asformat(format)
 


### PR DESCRIPTION
This will possibly cause regressions on other platforms due to integer widths, so this may require testing outside of TravisCI.  I've tried to be careful about backwards compatible random sampling.  A possibly related issue is https://github.com/scipy/scipy/issues/4557.
