### PR TITLE
Move lil_matrix storage to array.array for compatible data types.

### DIFF
--- a/scipy/sparse/_csparsetools.pyx.in
+++ b/scipy/sparse/_csparsetools.pyx.in
@@ -60,6 +60,7 @@ def define_dispatch_map2(map_name, prefix, types, types2):
     return "\n".join(result)
 }}
 
+from cpython cimport array as c_array
 cimport cython
 cimport numpy as cnp
 import numpy as np
@@ -89,7 +90,7 @@ cpdef lil_get1(cnp.npy_intp M, cnp.npy_intp N, object[:] rows, object[:] datas,
         Value at indices.
 
     """
-    cdef list row, data
+    cdef c_array.array row
 
     if i < -M or i >= M:
         raise IndexError('row index (%d) out of bounds' % (i,))
@@ -130,7 +131,7 @@ cpdef int lil_insert(cnp.npy_intp M, cnp.npy_intp N, object[:] rows,
         Value to insert.
 
     """
-    cdef list row, data
+    cdef c_array.array row
 
     if i < -M or i >= M:
         raise IndexError('row index (%d) out of bounds' % (i,))
@@ -167,7 +168,8 @@ def lil_fancy_get(cnp.npy_intp M, cnp.npy_intp N,
                   object[:] new_rows,
                   object[:] new_datas,
                   cnp.ndarray i_idx,
-                  cnp.ndarray j_idx):
+                  cnp.ndarray j_idx,
+                  typecode):
     """
     Get multiple items at given indices in LIL matrix and store to
     another LIL.
@@ -183,7 +185,7 @@ def lil_fancy_get(cnp.npy_intp M, cnp.npy_intp N,
         Indices of elements to insert to the new LIL matrix.
 
     """
-    return _LIL_FANCY_GET_DISPATCH[i_idx.dtype](M, N, rows, datas, new_rows, new_datas, i_idx, j_idx)
+    return _LIL_FANCY_GET_DISPATCH[i_idx.dtype](M, N, rows, datas, new_rows, new_datas, i_idx, j_idx, typecode)
 
 
 {{for NAME, IDX_T in get_dispatch(IDX_TYPES)}}
@@ -193,16 +195,19 @@ def _lil_fancy_get_{{NAME}}(cnp.npy_intp M, cnp.npy_intp N,
                             object[:] new_rows,
                             object[:] new_datas,
                             {{IDX_T}}[:,:] i_idx,
-                            {{IDX_T}}[:,:] j_idx):
+                            {{IDX_T}}[:,:] j_idx,
+                            typecode):
     cdef cnp.npy_intp x, y
     cdef cnp.npy_intp i, j
     cdef object value
-    cdef list new_row
-    cdef list new_data
+    cdef c_array.array new_row
 
     for x in range(i_idx.shape[0]):
-        new_row = []
-        new_data = []
+        new_row = c_array.array('i')
+        if typecode is not None:
+            new_data = c_array.array(typecode)
+        else:
+            new_data = []
 
         for y in range(i_idx.shape[1]):
             i = i_idx[x,y]
@@ -278,7 +283,7 @@ def _lil_fancy_set_{{PYIDX}}_{{PYVALUE}}(cnp.npy_intp M, cnp.npy_intp N,
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline cnp.npy_intp bisect_left(list a, cnp.npy_intp x) except -1:
+cdef inline cnp.npy_intp bisect_left(int[::1] a, cnp.npy_intp x) except -1:
     """
     Bisection search in a sorted list.
 

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -6,7 +6,7 @@ __docformat__ = "restructuredtext en"
 
 __all__ = ['csr_matrix', 'isspmatrix_csr']
 
-
+import array
 import numpy as np
 from scipy._lib.six import xrange
 
@@ -141,8 +141,11 @@ class csr_matrix(_cs_matrix, IndexMixin):
         for n in xrange(self.shape[0]):
             start = ptr[n]
             end = ptr[n+1]
-            rows[n] = ind[start:end].tolist()
-            data[n] = dat[start:end].tolist()
+            rows[n] = array.array('i', ind[start:end])
+            if lil.typecode is not None:
+                data[n] = array.array(lil.typecode, dat[start:end])
+            else:
+                data[n] = dat[start:end].tolist()
 
         return lil
 

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -231,7 +231,9 @@ class lil_matrix(spmatrix, IndexMixin):
         if axis == 0:
             out = np.zeros(self.shape[1])
             for row in self.rows:
-                out[row] += 1
+                # Turn into a list for compatibility
+                # with Python 2.6
+                out[list(row)] += 1
             return out
         elif axis == 1:
             return np.array([len(rowvals) for rowvals in self.data])

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -7,6 +7,7 @@ __docformat__ = "restructuredtext en"
 
 __all__ = ['lil_matrix','isspmatrix_lil']
 
+import array
 import numpy as np
 
 from .base import spmatrix, isspmatrix
@@ -14,6 +15,32 @@ from .sputils import (getdtype, isshape, isscalarlike, IndexMixin,
                       upcast_scalar, get_index_dtype)
 
 from . import _csparsetools
+
+
+def _dtype_to_typecode(dtype):
+
+    if dtype == np.int32:
+        type_flag = 'i'
+    elif dtype == np.uint32:
+        type_flag = 'I'
+    elif dtype == np.int64:
+        type_flag = 'l'
+    elif dtype == np.int8:
+        type_flag = 'b'
+    elif dtype == np.uint8:
+        type_flag = 'B'
+    elif dtype == np.int16:
+        type_flag = 'h'
+    elif dtype == np.uint16:
+        type_flag = 'H'
+    elif dtype == np.float32:
+        type_flag = 'f'
+    elif dtype == np.float64:
+        type_flag = 'd'
+    else:
+        raise Exception('Dtype not supported.')
+
+    return type_flag
 
 
 class lil_matrix(spmatrix, IndexMixin):
@@ -83,6 +110,15 @@ class lil_matrix(spmatrix, IndexMixin):
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         spmatrix.__init__(self)
         self.dtype = getdtype(dtype, arg1, default=float)
+        if self.dtype in (np.complex,
+                          np.complex64,
+                          np.complex256,
+                          np.bool,
+                          np.uint64,
+                          np.float128):
+            self.typecode = None
+        else:
+            self.typecode = _dtype_to_typecode(self.dtype)
 
         # First get the shape
         if isspmatrix(arg1):
@@ -106,9 +142,13 @@ class lil_matrix(spmatrix, IndexMixin):
                 self.shape = (M,N)
                 self.rows = np.empty((M,), dtype=object)
                 self.data = np.empty((M,), dtype=object)
+
                 for i in range(M):
-                    self.rows[i] = []
-                    self.data[i] = []
+                    self.rows[i] = array.array('i')
+                    if self.typecode:
+                        self.data[i] = array.array(self.typecode)
+                    else:
+                        self.data[i] = []
             else:
                 raise TypeError('unrecognized lil_matrix constructor usage')
         else:
@@ -261,7 +301,7 @@ class lil_matrix(spmatrix, IndexMixin):
         _csparsetools.lil_fancy_get(self.shape[0], self.shape[1],
                                     self.rows, self.data,
                                     new.rows, new.data,
-                                    i, j)
+                                    i, j, self.typecode)
         return new
 
     def __setitem__(self, index, x):


### PR DESCRIPTION
This PR changes the underlying storage of `lil_matrix` from Python `list` to `array.array` objects for compatible data types. For remaining data types, I continue to use plain lists.

This drastically reduces the amount of memory required for constructing a large `lil_matrix`.

With the current implementation:

```
Line #    Mem usage    Increment   Line Contents                
================================================                
     6     28.4 MiB      0.0 MiB   @profile                     
     7                             def example():               
     8                                                          
     9     28.4 MiB      0.0 MiB       shape = 1000, 1000       
    10                                                          
    11     36.0 MiB      7.6 MiB       arr = np.ones(shape)     
    12    104.0 MiB     67.9 MiB       mat = sp.lil_matrix(arr) 
```

Using arrays:

```
Line #    Mem usage    Increment   Line Contents               
================================================               
     6                             @profile                    
     7                             def example():              
     8    26.078 MB     0.000 MB                               
     9    26.078 MB     0.000 MB       shape = 1000, 1000      
    10                                                         
    11    33.723 MB     7.645 MB       arr = np.ones(shape)    
    12    57.246 MB    23.523 MB       mat = sp.lil_matrix(arr)
```

Since `list` and `array.array` support the same operations, this change should not break sensible user code that touches the `rows` and `data` attributes.
