### PR TITLE
Fix singleton expansion in lfilter.

### DIFF
--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -131,7 +131,7 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
 {
     PyObject *b, *a, *X, *Vi;
     PyArrayObject *arY, *arb, *ara, *arX, *arVi, *arVf;
-    int axis, typenum, theaxis, st;
+    int axis, typenum, theaxis, st, Vi_needs_broadcasted = 0;
     char *ara_ptr, input_flag = 0, *azero;
     intp na, nb, nal, zi_size;
     intp zf_shape[NPY_MAXDIMS];
@@ -230,8 +230,11 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
             Xk = PyArray_DIM(arX, k);
             if (k == theaxis && Vik == zi_size) {
                 zf_shape[k] = zi_size;
-            } else if (k != theaxis && (Vik == Xk || Vik == 1)) {
+            } else if (k != theaxis && Vik == Xk) {
                 zf_shape[k] = Xk;
+            } else if (k != theaxis && Vik == 1) { 
+                zf_shape[k] = Xk;
+                Vi_needs_broadcasted = 1;
             } else {
                 PyObject *msg = convert_shape_to_errmsg(PyArray_NDIM(arX),
                         PyArray_DIMS(arX), PyArray_DIMS(arVi),
@@ -244,15 +247,45 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
                 goto fail;
             }
         }
-    }
+        
+        if (Vi_needs_broadcasted) {
+            /* Expand the singleton dimensions of arVi without copying by
+             * creating a new view of arVi with the expanded dimensions
+             * but the corresponding stride = 0.
+             */
+            PyArrayObject *arVi_view;
+            PyArray_Descr *view_dtype;
+            npy_intp *arVi_shape = PyArray_DIMS(arVi);
+            npy_intp *arVi_strides = PyArray_STRIDES(arVi);
+            npy_intp ndim = PyArray_NDIM(arVi);
+            npy_intp strides[NPY_MAXDIMS];
+            npy_intp k;
 
-    arY = (PyArrayObject *) PyArray_SimpleNew(PyArray_NDIM(arX),
-                                              PyArray_DIMS(arX), typenum);
-    if (arY == NULL) {
-        goto fail;
-    }
+            for (k = 0; k < ndim; ++k) {
+                if (arVi_shape[k] == 1) {
+                    strides[k] = 0;
+                } else {
+                    strides[k] = arVi_strides[k];
+                }
+            }
+            
+            /* PyArray_DESCR borrows a reference, but it will be stolen
+             * by PyArray_NewFromDescr below, so increment it.
+             */
+            view_dtype = PyArray_DESCR(arVi);
+            Py_INCREF(view_dtype);
+            
+            arVi_view = (PyArrayObject *)PyArray_NewFromDescr(&PyArray_Type,
+                            view_dtype, ndim, zf_shape, strides,
+                            PyArray_BYTES(arVi), 0, NULL);
+            if (!arVi_view) {
+                goto fail;
+            }
+            /* Give our reference to arVi to arVi_view */
+            PyArray_BASE(arVi_view) = arVi;
+            arVi = arVi_view;
+        }
 
-    if (input_flag) {
         arVf = (PyArrayObject *) PyArray_SimpleNew(PyArray_NDIM(arVi),
                                                    zf_shape,
                                                    typenum);
@@ -260,6 +293,13 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
             goto fail;
         }
     }
+    
+    arY = (PyArrayObject *) PyArray_SimpleNew(PyArray_NDIM(arX),
+                                              PyArray_DIMS(arX), typenum);
+    if (arY == NULL) {
+        goto fail;
+    }
+
 
     st = RawFilter(arb, ara, arX, arVi, arVf, arY, theaxis, basic_filter);
     if (st) {

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -896,8 +896,7 @@ def lfilter(b, a, x, axis=-1, zi=None):
                  a[0] + a[1]z  + ... + a[na] z
 
     """
-    if isscalar(a):
-        a = [a]
+    a = np.atleast_1d(a)
     if zi is None:
         return sigtools._linear_filter(b, a, x, axis)
     else:

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -666,7 +666,17 @@ class _TestLinearFilter(TestCase):
 
         # lfilter does not prepend ones 
         assert_raises(ValueError, lfilter, b, a, x, -1, np.ones(zi_size))
-    
+
+    def test_scalar_a(self):
+        # a can be a scalar.  
+        x = self.generate(6)
+        b = self.convert_dtype([1, 0, -1])
+        a = self.convert_dtype([1])
+        y_r = self.convert_dtype([0, 1, 2, 2, 2, 2])
+
+        y = lfilter(b, a[0], x)
+        assert_array_almost_equal(y, y_r)
+
     def base_bad_size_zi(self, b, a, x, axis, zi):
         b = self.convert_dtype(b)
         a = self.convert_dtype(a)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -677,6 +677,33 @@ class _TestLinearFilter(TestCase):
         y = lfilter(b, a[0], x)
         assert_array_almost_equal(y, y_r)
 
+    def test_zi_some_singleton_dims(self):
+        # lfilter doesn't really broadcast (no prepending of 1's).  But does
+        # do singleton expansion if x and zi have the same ndim.  This was 
+        # broken only if a subset of the axes were singletons (gh-4681).
+        x = self.convert_dtype(np.zeros((3,2,5), 'l'))
+        b = self.convert_dtype(np.ones(5, 'l'))
+        a = self.convert_dtype(np.array([1,0,0]))
+        zi = np.ones((3,1,4), 'l')
+        zi[1,:,:] *= 2
+        zi[2,:,:] *= 3
+        zi = self.convert_dtype(zi)
+
+        zf_expected = self.convert_dtype(np.zeros((3,2,4), 'l'))
+        y_expected = np.zeros((3,2,5), 'l')
+        y_expected[:,:,:4] = [[[1]], [[2]], [[3]]]
+        y_expected = self.convert_dtype(y_expected)
+        
+        # IIR
+        y_iir, zf_iir = lfilter(b, a, x, -1, zi)
+        assert_array_almost_equal(y_iir, y_expected)
+        assert_array_almost_equal(zf_iir, zf_expected)
+
+        # FIR
+        y_fir, zf_fir = lfilter(b, a[0], x, -1, zi)
+        assert_array_almost_equal(y_fir, y_expected)
+        assert_array_almost_equal(zf_fir, zf_expected)
+     
     def base_bad_size_zi(self, b, a, x, axis, zi):
         b = self.convert_dtype(b)
         a = self.convert_dtype(a)


### PR DESCRIPTION
Fixes gh-4681.  Additionally fixes the conversion of scalar `a` to be less fragile.  `np.isscalar` fails for things like `Decimal(1)` or `Fraction(1)`. 

Its worth noting that gh-4681 has been there since the current version of `lfilter` was added in 2008/2009..
