### PR TITLE
Extrapolate Anderson-Darling p-values linearly.

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1413,7 +1413,7 @@ def anderson_ksamp(samples, midrank=True):
     b1 = np.array([-0.245, 0.25, 0.678, 1.149, 1.822])
     b2 = np.array([-0.105, -0.305, -0.362, -0.391, -0.396])
     critical = b0 + b1 / math.sqrt(m) + b2 / m
-    pf = np.polyfit(critical, log(np.array([0.25, 0.1, 0.05, 0.025, 0.01])), 2)
+    pf = np.polyfit(critical, log(np.array([0.25, 0.1, 0.05, 0.025, 0.01])), 1)
     if A2 < critical.min() or A2 > critical.max():
         warnings.warn("approximate p-value will be computed by extrapolation")
 


### PR DESCRIPTION
Currently, for out-of-range values of the Anderson-Darling k-sample
statistic, the _p_-value is computed by extrapolation by a quadratic
polynomial.  The original paper (Scholz and Stephens, 1987) suggests
linear extrapolation (see Sec. 7).  Such a change would give very
similar results for values of the statistic between the limits and
avoids having very large (>>1) extrapolated _p_-values when the
statistic is huge (i.e. beyond the minimum of the polynomial).
