### PR TITLE
MAINT: quiet warnings from cephes.

### DIFF
--- a/scipy/special/cephes/hyp2f1.c
+++ b/scipy/special/cephes/hyp2f1.c
@@ -67,8 +67,8 @@
  * Copyright 1984, 1987, 1992, 2000 by Stephen L. Moshier
  */
 
-#include <stdlib.h>
 #include "mconf.h"
+#include <stdlib.h>
 
 #ifdef DEC
 #define EPS 1.0e-14

--- a/scipy/special/cephes/kolmogorov.c
+++ b/scipy/special/cephes/kolmogorov.c
@@ -74,8 +74,7 @@ double smirnov(int n, double e)
  * or that max deviation > y/sqrt(n).
  * The approximation is useful for the tail of the distribution
  * when n is large.  */
-double kolmogorov(y)
-double y;
+double kolmogorov(double y)
 {
     double p, t, r, sign, x;
 
@@ -99,9 +98,7 @@ double y;
 
 /* Functional inverse of Smirnov distribution
  * finds e such that smirnov(n,e) = p.  */
-double smirnovi(n, p)
-int n;
-double p;
+double smirnovi(int n, double p)
 {
     double e, t, dpde;
     int iterations;
@@ -142,8 +139,7 @@ double p;
  * Finds y such that kolmogorov(y) = p.
  * If e = smirnovi (n,p), then kolmogi(2 * p) / sqrt(n) should
  * be close to e.  */
-double kolmogi(p)
-double p;
+double kolmogi(double p)
 {
     double y, t, dpdy;
     int iterations;

--- a/scipy/special/cephes/mtherr.c
+++ b/scipy/special/cephes/mtherr.c
@@ -54,8 +54,8 @@
  * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
  */
 
-#include <stdio.h>
 #include "mconf.h"
+#include <stdio.h>
 
 #include "sf_error.h"
 

--- a/scipy/special/cephes/polmisc.c
+++ b/scipy/special/cephes/polmisc.c
@@ -3,9 +3,9 @@
  * See polyn.c for data structures and discussion.
  */
 
+#include "mconf.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "mconf.h"
 
 /* Highest degree of polynomial to be handled
  * by the polyn.c subroutine package.  */

--- a/scipy/special/cephes/polrt.c
+++ b/scipy/special/cephes/polrt.c
@@ -65,6 +65,8 @@ cmplx root[];
     double mag, cofj;
     cmplx x0, x, xsav, dx, t, t1, u, ud;
 
+    xsav.r = 0;
+    xsav.i = 0;
     final = 0;
     n = m;
     if (n <= 0)

--- a/scipy/special/cephes/polyn.c
+++ b/scipy/special/cephes/polyn.c
@@ -59,9 +59,9 @@
  *
  */
 
+#include "mconf.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "mconf.h"
 
 /* near pointer version of malloc() */
 /*

--- a/scipy/special/cephes/scipy_iv.c
+++ b/scipy/special/cephes/scipy_iv.c
@@ -67,8 +67,8 @@
  *
  */
 
-#include <stdlib.h>
 #include "mconf.h"
+#include <stdlib.h>
 extern double MAXNUM, MACHEP;
 
 static double iv_asymptotic(double v, double x);


### PR DESCRIPTION
Kills the remaining warnings produced while building cephes.  It looks to me as though there are part there that we don't use and could probably drop.  For instance, polrt.c doesn't seem to be used anywhere.  I haven't done that here, but I could add it. 
