### PR TITLE
DOC: cluster.hierarchy.linkage and sparse.linalg.spilu

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -604,9 +604,10 @@ def linkage(y, method='single', metric='euclidean'):
     method : str, optional
         The linkage algorithm to use. See the ``Linkage Methods`` section below
         for full descriptions.
-    metric : str, optional
+    metric : str or function, optional
         The distance metric to use. See the ``distance.pdist`` function for a
-        list of valid distance metrics.
+        list of valid distance metrics. The customized distance can also be 
+        used. See the ``distance.pdist`` function for details.
 
     Returns
     -------

--- a/scipy/sparse/linalg/dsolve/linsolve.py
+++ b/scipy/sparse/linalg/dsolve/linsolve.py
@@ -273,9 +273,6 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
         ``secondary``, ``dynamic``, ``interp``. (Default: ``basic,area``)
 
         See SuperLU documentation for details.
-    milu : str, optional
-        Which version of modified ILU to use. (Choices: ``silu``,
-        ``smilu_1``, ``smilu_2`` (default), ``smilu_3``.)
 
     Remaining other options
         Same as for `splu`


### PR DESCRIPTION
Indicated the ability to use customized metric in cluster.hierarchy.linkage.

Removed the outdated parameter "milu" from the doc of sparse.linalg.spilu.
