### PR TITLE
Fix crash for unknown chunks at the end of file

### DIFF
--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -87,6 +87,10 @@ def _skip_unknown_chunk(fid):
         fmt = '<i'
 
     data = fid.read(4)
+    # call unpack() and seek() only if we have really read data from file
+    # otherwise empty read at the end of the file would trigger 
+    # unnecessary exception at unpack() call
+    # in case data equals somehow to 0, there is no need for seek() anyway
     if data:
         size = struct.unpack(fmt, data)[0]
         fid.seek(size, 1)

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -87,8 +87,9 @@ def _skip_unknown_chunk(fid):
         fmt = '<i'
 
     data = fid.read(4)
-    size = struct.unpack(fmt, data)[0]
-    fid.seek(size, 1)
+    if data:
+        size = struct.unpack(fmt, data)[0]
+        fid.seek(size, 1)
 
 
 def _read_riff_chunk(fid):


### PR DESCRIPTION
Protect against crash in scipy.io.read() in case there are unknown chunks at the end of file

Real life case: _skip_unknown_chunk was called when fid.tell() == fsize condition was true
in this case reading of 4 bytes failed and call to struct.unpack() throws exception (and thus crashing the application)
