### PR TITLE
MAINT: interpolate: no need to pass dtype around if it can be inferred

### DIFF
--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -6,7 +6,6 @@ local power basis.
 
 from .polyint import _Interpolator1D
 import numpy as np
-cimport numpy as cnp
 
 cimport cython
 
@@ -848,8 +847,7 @@ def evaluate_bernstein(double_or_complex[:,:,::1] c,
              double[::1] xp,
              int nu,
              int extrapolate,
-             double_or_complex[:,::1] out,
-             cnp.dtype dt):
+             double_or_complex[:,::1] out):
     """
     Evaluate a piecewise polynomial in the Bernstein basis.
 
@@ -894,8 +892,11 @@ def evaluate_bernstein(double_or_complex[:,:,::1] c,
         raise ValueError("x and c have incompatible shapes")
 
     if nu > 0:
-        wrk = np.empty((c.shape[0]-nu, 1, 1), dtype=dt)
-
+        if double_or_complex is double_complex:
+            wrk = np.empty((c.shape[0]-nu, 1, 1), dtype=np.complex_)
+        else:
+            wrk = np.empty((c.shape[0]-nu, 1, 1), dtype=np.float_)
+        
     # evaluate
     interval = 0
 

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1087,7 +1087,7 @@ class BPoly(_PPolyBase):
     def _evaluate(self, x, nu, extrapolate, out):
         _ppoly.evaluate_bernstein(
             self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
-            self.x, x, nu, bool(extrapolate), out, self.c.dtype)
+            self.x, x, nu, bool(extrapolate), out)
 
     def derivative(self, nu=1):
         """

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1005,11 +1005,13 @@ class TestBPolyCalculus(TestCase):
         m, k = 5, 8   # number of intervals, order
         x = np.sort(np.random.random(m))
         c = np.random.random((k, m-1))
-        bp = BPoly(c, x)
 
-        xp = np.linspace(x[0], x[-1], 21)
-        for i in range(k):
-            assert_allclose(bp(xp, i), bp.derivative(i)(xp))
+        # test both real and complex coefficients
+        for cc in [c.copy(), c*(1. + 2.j)]:
+            bp = BPoly(cc, x)
+            xp = np.linspace(x[0], x[-1], 21)
+            for i in range(k):
+                assert_allclose(bp(xp, i), bp.derivative(i)(xp))
 
 
 class TestPolyConversions(TestCase):


### PR DESCRIPTION
Follow the "Type checking specializations" section of http://docs.cython.org/src/userguide/fusedtypes.html
and stop passing dtype around.
