### PR TITLE
BENCH: Add benchmarks for stats module

### DIFF
--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -5,12 +5,11 @@ import warnings
 import numpy as np
 
 try:
-    from scipy.stats import anderson_ksamp
+    import scipy.stats as stats
 except ImportError:
     pass
 
 from .common import Benchmark
-
 
 class Anderson_KSamp(Benchmark):
     def setup(self, *args):
@@ -19,4 +18,79 @@ class Anderson_KSamp(Benchmark):
     def time_anderson_ksamp(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', UserWarning)
-            anderson_ksamp(self.rand)
+            stats.anderson_ksamp(self.rand)
+
+
+class CorrelationFunctions(Benchmark):
+    param_names = ['alternative']
+    params = [
+        ['two-sided', 'less', 'greater']
+    ]
+
+    def setup(self, mode):
+        a = np.random.rand(2,2)*10
+        self.a = a
+
+    def time_fisher_exact(self, alternative):   
+        oddsratio, pvalue = stats.fisher_exact(self.a, alternative=alternative)
+
+
+class InferentialStats(Benchmark):
+    def setup(self):
+        np.random.seed(12345678)
+        self.a = stats.norm.rvs(loc=5, scale=10, size=500)
+        self.b = stats.norm.rvs(loc=8, scale=10, size=20)
+        self.c = stats.norm.rvs(loc=8, scale=20, size=20)
+
+    def time_ttest_ind_same_var(self):
+        # test different sized sample with variances
+        stats.ttest_ind(self.a, self.b)
+        stats.ttest_ind(self.a, self.b, equal_var=False)
+
+    def time_ttest_ind_diff_var(self):
+        # test different sized sample with different variances
+        stats.ttest_ind(self.a, self.c)
+        stats.ttest_ind(self.a, self.c, equal_var=False)
+
+
+class Distribution(Benchmark):
+    param_names = ['distribution', 'properties']    
+    params = [
+        ['cauchy', 'gamma', 'beta'],
+        ['pdf', 'cdf', 'rvs', 'fit']
+    ]
+    
+    def setup(self, distribution, properties):
+        np.random.seed(12345678)
+        self.x = np.random.rand(100)
+
+    def time_distribution(self, distribution, properties):
+        if distribution == 'gamma':
+            if properties == 'pdf':
+                stats.gamma.pdf(self.x, a=5, loc=4, scale=10)
+            elif properties == 'cdf':
+                stats.gamma.cdf(self.x, a=5, loc=4, scale=10)
+            elif properties == 'rvs':
+                stats.gamma.rvs(size=1000, a=5, loc=4, scale=10)
+            elif properties == 'fit':
+                stats.gamma.fit(self.x, a=5, loc=4, scale=10)
+        elif distribution == 'cauchy':
+            if properties == 'pdf':
+                stats.cauchy.pdf(self.x, loc=4, scale=10)
+            elif properties == 'cdf':
+                stats.cauchy.cdf(self.x, loc=4, scale=10)
+            elif properties == 'rvs':
+                stats.cauchy.rvs(size=1000, loc=4, scale=10)
+            elif properties == 'fit':
+                stats.cauchy.fit(self.x, loc=4, scale=10)
+        elif distribution == 'beta':
+            if properties == 'pdf':
+                stats.beta.pdf(self.x, a=5, b=3, loc=4, scale=10)
+            elif properties == 'cdf':
+                stats.beta.cdf(self.x, a=5, b=3, loc=4, scale=10)
+            elif properties == 'rvs':
+                stats.beta.rvs(size=1000, a=5, b=3, loc=4, scale=10)
+            elif properties == 'fit':
+                stats.beta.fit(self.x, a=5, b=3, loc=4, scale=10)
+        
+

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -28,7 +28,7 @@ class CorrelationFunctions(Benchmark):
     ]
 
     def setup(self, mode):
-        a = np.random.rand(2,2)*10
+        a = np.random.rand(2,2) * 10
         self.a = a
 
     def time_fisher_exact(self, alternative):   


### PR DESCRIPTION
Add some benchmarks for stats package
- [x] sample test for fischer_exact
- [x] similar benchmarks for other functions like ttest_ind
- [x] also one distribution with its methods(pdf, cdf and fit being the most important), maybe cauchy, gamma or beta distribution.

~~As of now, it is unable to run this file using `python runtests.py --bench stats` , which gives `No benchmarks selected` output. Any help appreciated.~~
