### PR TITLE
DEP: deprecate mstats.signaltonoise ...

### DIFF
--- a/doc/release/0.16.0-notes.rst
+++ b/doc/release/0.16.0-notes.rst
@@ -111,8 +111,9 @@ with ``statsmodels.distributions.ExpandedNormal``.
 ``scipy.stats.fastsort`` is deprecated.  This function is unnecessary,
 ``numpy.argsort`` can be used instead.
 
-``scipy.stats.signaltonoise`` is deprecated. This function did not belong in 
-``scipy.stats`` and is rarely used. See issue #609 for details.
+``scipy.stats.signaltonoise`` and ``scipy.stats.mstats.signaltonoise`` are
+deprecated.  These functions did not belong in ``scipy.stats`` and are rarely
+used.  See issue #609 for details.
 
 ``scipy.stats.histogram2`` is deprecated. This function is unnecessary, 
 ``numpy.histogram2d`` can be used instead.

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1439,14 +1439,14 @@ def moment(a, moment=1, axis=0):
             else:
                 current_n /= 2
             n_list.append(current_n)
-        
+
         # Starting point for exponentiation by squares
         a_zero_mean = a - ma.expand_dims(a.mean(axis), axis)
         if n_list[-1] == 1:
             s = a_zero_mean.copy()
         else:
             s = a_zero_mean**2
-        
+
         # Perform multiplications
         for n in n_list[-2::-1]:
             s = s**2
@@ -1889,6 +1889,7 @@ def obrientransform(*args):
     return data
 
 
+@np.deprecate(message="mstats.signaltonoise is deprecated in scipy 0.16.0")
 def signaltonoise(data, axis=0):
     """Calculates the signal-to-noise ratio, as the ratio of the mean over
     standard deviation along the given axis.

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -451,7 +451,9 @@ class TestVariability(TestCase):
     def test_signaltonoise(self):
         # This is not in R, so used:
         #     mean(testcase, axis=0) / (sqrt(var(testcase)*3/4))
-        y = mstats.signaltonoise(self.testcase)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            y = mstats.signaltonoise(self.testcase)
         assert_almost_equal(y, 2.236067977)
 
     def test_sem(self):
@@ -827,16 +829,18 @@ class TestCompareWithStats(TestCase):
             assert_almost_equal(r, rm, 10)
 
     def test_signaltonoise(self):
-        for n in self.get_n():
-            x, y, xm, ym = self.generate_xy_sample(n)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            for n in self.get_n():
+                x, y, xm, ym = self.generate_xy_sample(n)
 
-            r = stats.signaltonoise(x)
-            rm = stats.mstats.signaltonoise(xm)
-            assert_almost_equal(r, rm, 10)
+                r = stats.signaltonoise(x)
+                rm = stats.mstats.signaltonoise(xm)
+                assert_almost_equal(r, rm, 10)
 
-            r = stats.signaltonoise(y)
-            rm = stats.mstats.signaltonoise(ym)
-            assert_almost_equal(r, rm, 10)
+                r = stats.signaltonoise(y)
+                rm = stats.mstats.signaltonoise(ym)
+                assert_almost_equal(r, rm, 10)
 
     def test_betai(self):
         np.random.seed(12345)


### PR DESCRIPTION
... to match stats.signaltonoise deprecation.

The stats.signaltonoise deprecation was done in gh-4656.
This also cleans up some testsuite noise.
