### PR TITLE
MAINT: basinhopping: fix error in tests, silence /0 warning, fix docstring

### DIFF
--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -364,22 +364,22 @@ class LbfgsInvHessProduct(LinearOperator):
     memory approximation to the inverse Hessian, accumulated during the
     optimization.
 
+    Parameters
+    ----------
+    sk : array_like, shape=(n_corr, n)
+        Array of `n_corr` most recent updates to the solution vector.
+        (See [1]).
+    yk : array_like, shape=(n_corr, n)
+        Array of `n_corr` most recent updates to the gradient. (See [1]).
+
     References
     ----------
     .. [1] Nocedal, Jorge. "Updating quasi-Newton matrices with limited
        storage." Mathematics of computation 35.151 (1980): 773-782.
+
     """
     def __init__(self, sk, yk):
-        """Construct the operator
-
-        Parameters
-        ----------
-        sk : array_like, shape=(n_corr, n)
-            Array of `n_corr` most recent updates to the solution vector.
-            (See [1]).
-        yk : array_like, shape=(n_corr, n)
-            Array of `n_corr` most recent updates to the gradient. (See [1]).
-        """
+        """Construct the operator."""
         if sk.shape != yk.shape or sk.ndim != 2:
             raise ValueError('sk and yk must have matching shape, (n_corrs, n)')
         n_corrs, n = sk.shape
@@ -406,6 +406,7 @@ class LbfgsInvHessProduct(LinearOperator):
         -------
         y : ndarray
             The matrix-vector product
+
         """
         s, y, n_corrs, rho = self.sk, self.yk, self.n_corrs, self.rho
         q = np.array(x, dtype=self.dtype, copy=True)
@@ -431,8 +432,9 @@ class LbfgsInvHessProduct(LinearOperator):
         Returns
         -------
         arr : ndarray, shape=(n, n)
-            A NumPy array with the same shape and containing
-            the same data represented by this LinearOperator.
+            An array with the same shape and containing
+            the same data represented by this `LinearOperator`.
+
         """
         s, y, n_corrs, rho = self.sk, self.yk, self.n_corrs, self.rho
         I = np.eye(*self.shape, dtype=self.dtype)

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -180,17 +180,34 @@ class TestBasinHopping(TestCase):
         assert_almost_equal(res.x, self.sol[i], self.tol)
 
     def test_all_minimizers(self):
-        # test 2d minimizations with gradient
+        # test 2d minimizations with gradient.  Nelder-Mead, Powell and COBYLA
+        # don't accept jac=True, so aren't included here.
         i = 1
-        methods = ['Nelder-Mead', 'Powell', 'CG', 'BFGS', 'Newton-CG',
-                   'L-BFGS-B', 'TNC', 'COBYLA', 'SLSQP']
+        methods = ['CG', 'BFGS', 'Newton-CG', 'L-BFGS-B', 'TNC', 'SLSQP']
         minimizer_kwargs = copy.copy(self.kwargs)
         for method in methods:
             minimizer_kwargs["method"] = method
             res = basinhopping(func2d, self.x0[i],
-                               minimizer_kwargs=self.kwargs,
+                               minimizer_kwargs=minimizer_kwargs,
                                niter=self.niter, disp=self.disp)
             assert_almost_equal(res.x, self.sol[i], self.tol)
+
+    def test_all_nograd_minimizers(self):
+        # test 2d minimizations without gradient.  Newton-CG requires jac=True,
+        # so not included here.
+        i = 1
+        methods = ['CG', 'BFGS', 'L-BFGS-B', 'TNC', 'SLSQP',
+                   'Nelder-Mead', 'Powell', 'COBYLA']
+        minimizer_kwargs = copy.copy(self.kwargs_nograd)
+        for method in methods:
+            minimizer_kwargs["method"] = method
+            res = basinhopping(func2d_nograd, self.x0[i],
+                               minimizer_kwargs=minimizer_kwargs,
+                               niter=self.niter, disp=self.disp)
+            tol = self.tol
+            if method == 'COBYLA':
+                tol = 2
+            assert_almost_equal(res.x, self.sol[i], decimal=tol)
 
     def test_pass_takestep(self):
         # test that passing a custom takestep works


### PR DESCRIPTION
All tests pass, so the `RuntimeWarning` seems harmless. If anyone wants to investigate more however, here is a snippet to reproduce it:

```
import numpy as np
from scipy import optimize


def func2d(x):
    f = np.cos(14.5 * x[0] - 0.3) + (x[1] + 0.2) * x[1] + (x[0] + 0.2) * x[0]
    df = np.zeros(2)
    df[0] = -14.5 * np.sin(14.5 * x[0] - 0.3) + 2. * x[0] + 0.2
    df[1] = 2. * x[1] + 0.2
    return f, df


x0 = (1.0, [1.0, 1.0])
sol = (-0.195, np.array([-0.195, -0.1]))

# This will give a divide-by-zero RuntimeWarning on the second iteration,
# for this random seed.  From TestBasinhopping.test_all_minimizers.
np.random.seed(1234)
i = 1
kwargs = {"method": "L-BFGS-B", "jac": True}
for counter in range(2):
    print(counter)
    res = optimize.basinhopping(func2d, x0[i],
                                minimizer_kwargs=kwargs,
                                niter=100, disp=False)
    np.testing.assert_almost_equal(res.x, sol[i], decimal=3)
```
