### PR TITLE
Document that imresize converts the input to a PIL image

### DIFF
--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -403,17 +403,22 @@ def imresize(arr, size, interp='bilinear', mode=None):
         * float - Fraction of current size.
         * tuple - Size of the output image.
 
-    interp : str
+    interp : str, optional
         Interpolation to use for re-sizing ('nearest', 'bilinear', 'bicubic'
         or 'cubic').
 
-    mode : str
-        The PIL image mode ('P', 'L', etc.).
+    mode : str, optional
+        The PIL image mode ('P', 'L', etc.) to convert `arr` before resizing.
 
     Returns
     -------
     imresize : ndarray
         The resized array of image.
+    
+    See Also
+    --------
+    toimage : Implicitly used to convert `arr` according to `mode`.
+    scipy.ndimage.zoom : More generic implementation that does not use PIL.
 
     """
     im = toimage(arr, mode=mode)


### PR DESCRIPTION
I just got tricked by `scipy.misc.imresize` implicitly converting my 2D float array to `uint8` values from 0 to 255 without mentioning it. This updates the documentation to hint users at `scipy.misc.toimage` for understanding the conversion, and at `scipy.ndimage.zoom` as a more generic alternative that's not obvious to look for when you don't suspect it exists.
