### PR TITLE
MAINT: PyArray_BASE is not an lvalue unless the deprecated API is used.

### DIFF
--- a/scipy/signal/lfilter.c.src
+++ b/scipy/signal/lfilter.c.src
@@ -282,7 +282,14 @@ scipy_signal_sigtools_linear_filter(PyObject * NPY_UNUSED(dummy), PyObject * arg
                 goto fail;
             }
             /* Give our reference to arVi to arVi_view */
+#if NPY_API_VERSION >= 0x00000007
+            if (PyArray_SetBaseObject(arVi_view, arVi) == -1) {
+                Py_DECREF(arVi_view);
+                goto fail;
+            }
+#else
             PyArray_BASE(arVi_view) = arVi;
+#endif
             arVi = arVi_view;
         }
 


### PR DESCRIPTION
Use PyArray_SetBaseObject for numpy 1.7 and up and use the older
API for numpy 1.6.2.

fixes gh-4719
