### PR TITLE
DOC: add poch to the list of scipy special function descriptions

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -277,6 +277,7 @@ Gamma and Related Functions
    polygamma    -- Nth derivative of psi function.
    multigammaln -- Log of the multivariate gamma.
    digamma      -- Digamma function (derivative of the logarithm of gamma).
+   poch         -- The Pochhammer symbol (rising factorial).
 
 
 Error Function and Fresnel Integrals


### PR DESCRIPTION
Implemented in https://github.com/scipy/scipy/pull/2735.  Used, for example, in https://github.com/scipy/scipy/pull/4725.
