### PR TITLE
TST: do one of the test runs on TravisCI with latest numpy master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       env:
         - TESTMODE=fast
         - COVERAGE=
-        - NUMPYSPEC=numpy
+        - NUMPYSPEC="git+git://github.com/numpy/numpy.git@master"
     - python: 3.2
       env:
         - TESTMODE=fast


### PR DESCRIPTION
This should prevent build issues like gh-4719, as well as catch test errors/failures that are regularly introduced by PRs.

Note: this will fail on a number of test errors. Some of those are fixed by an open PR, some are to be fixed (maybe in this PR). Want to see already if this runs though, and if the errors and failures on TravisCI are the same as those I see locally.

Closes gh-4327
