### PR TITLE
MAINT: stats: avoid (a spurious) division-by-zero in skew

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -182,6 +182,7 @@ import scipy.linalg as linalg
 import numpy as np
 from . import futil
 from . import distributions
+from ._distn_infrastructure import _lazywhere
 
 from ._rank import rankdata, tiecorrect
 
@@ -1042,7 +1043,9 @@ def skew(a, axis=0, bias=True):
     m2 = moment(a, 2, axis)
     m3 = moment(a, 3, axis)
     zero = (m2 == 0)
-    vals = np.where(zero, 0, m3 / m2**1.5)
+    vals = _lazywhere(~zero, (m2, m3),
+                             lambda m2, m3: m3 / m2**1.5,
+                             0.)
     if not bias:
         can_correct = (n > 2) & (m2 > 0)
         if can_correct.any():


### PR DESCRIPTION
Use _lazywhere instead of `np.where(m2==0, 0, m3/m2**1.5)`

An alternative could be to just filter the division-by-zero warnings in the test suite. (FWIW, I prefer to fix a problem at the source)
