### PR TITLE
BLD: make sure that relaxed strides checking is in effect on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,8 @@ before_install:
   - popd
 script:
   - python -c 'import numpy as np; print("relaxed strides checking:", np.ones((10,1),order="C").flags.f_contiguous)'
+  # Make sure that relaxed strides checking is actually in effect; otherwise fail loudly
+  - if [ "$NPY_RELAXED_STRIDES_CHECKING" = "1" ]; then python -c'import numpy as np; assert np.ones((10,1),order="C").flags.f_contiguous'; fi
   - python $OPTIMIZE runtests.py -g -m $TESTMODE $COVERAGE
 notifications:
   # Perhaps we should have status emails sent to the mailing list, but


### PR DESCRIPTION
This is an experimental follow-up to gh-4739. 

The idea is that python seems to propagate a failed assertion to the exit code:

```
$ python -c 'assert False'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AssertionError
$ echo $?
1
```
