### PR TITLE
Implemented Kaiser-Bessel derived window

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -118,7 +118,8 @@ Gustav Larsson for a bug fix in convolve2d.
 Alex Griffing for expm 2009, expm_multiply, expm_frechet,
     trust region optimization methods, and sparse matrix onenormest
     implementations, plus bugfixes.
-Nils Werner for signal windowing and wavfile-writing improvements.
+Nils Werner for signal windowing (cosine and Kaiser-Bessel derived)
+    and wavfile-writing improvements.
 Kenneth L. Ho for the wrapper around the Interpolative Decomposition code.
 Juan Luis Cano for refactorings in lti, sparse docs improvements and some
     trivial fixes.

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -242,6 +242,7 @@ Window functions
    hann              -- Hann window
    hanning           -- Hann window
    kaiser            -- Kaiser window
+   kaiser_derived    -- Kaiser-Bessel derived window
    nuttall           -- Nuttall's minimum 4-term Blackman-Harris window
    parzen            -- Parzen window
    slepian           -- Slepian window

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -520,6 +520,5 @@ def test_kaiser_derived():
     assert_raises(ValueError, signal.kaiser_derived, M + 1, beta=4.)
 
 
-
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -527,6 +527,18 @@ def test_kaiser_derived():
     # Test for Princen-Bradley condition
     assert_allclose(w[:M//2]**2 + w[-M//2:]**2, 1.)
 
+    assert_allclose(
+        signal.kaiser_derived(2, beta=np.pi/2)[:1],
+        np.sqrt(2) / 2)
+
+    assert_allclose(
+        signal.kaiser_derived(4, beta=np.pi/2)[:2],
+        [0.518562710536, 0.855039598640])
+
+    assert_allclose(
+        signal.kaiser_derived(6, beta=np.pi/2)[:3],
+        [0.436168993154, 0.707106781187, 0.899864772847])
+
     # Assert ValueError for odd window length
     assert_raises(ValueError, signal.kaiser_derived, M + 1, beta=4.)
 

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -508,6 +508,16 @@ def test_windowfunc_basics():
                             0, atol=1e-14)
 
 
+def test_needs_params():
+    for winstr in ['kaiser', 'ksr', 'gaussian', 'gauss', 'gss',
+                   'general gaussian', 'general_gaussian',
+                   'general gauss', 'general_gauss', 'ggs',
+                   'slepian', 'optimal', 'slep', 'dss', 'dpss',
+                   'chebwin', 'cheb', 'exponential', 'poisson', 'tukey',
+                   'tuk']:
+        assert_raises(ValueError, signal.get_window, winstr, 7)
+
+
 def test_kaiser_derived():
     M = 100
     w = signal.kaiser_derived(M, beta=4.)
@@ -522,7 +532,6 @@ def test_kaiser_derived():
 
     # Assert ValueError for odd window length
     assert_raises(ValueError, signal.kaiser_derived, M, beta=4., sym=False)
-
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -520,5 +520,6 @@ def test_kaiser_derived():
     assert_raises(ValueError, signal.kaiser_derived, M + 1, beta=4.)
 
 
+
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -23,7 +23,6 @@ window_funcs = [
     ('barthann', ()),
     ('hamming', ()),
     ('kaiser', (1,)),
-    ('kaiser_derived', (1,)),
     ('gaussian', (0.5,)),
     ('general_gaussian', (1.5, 2)),
     ('chebwin', (1,)),
@@ -512,12 +511,17 @@ def test_windowfunc_basics():
 def test_kaiser_derived():
     M = 100
     w = signal.kaiser_derived(M, beta=4.)
+    w2 = signal.get_window(('kaiser_derived', 4.), M, fftbins=False)
+    assert_allclose(w, w2)
 
     # Test for Princen-Bradley condition
     assert_allclose(w[:M//2]**2 + w[-M//2:]**2, 1.)
 
     # Assert ValueError for odd window length
     assert_raises(ValueError, signal.kaiser_derived, M + 1, beta=4.)
+
+    # Assert ValueError for odd window length
+    assert_raises(ValueError, signal.kaiser_derived, M, beta=4., sym=False)
 
 
 if __name__ == "__main__":

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -23,6 +23,7 @@ window_funcs = [
     ('barthann', ()),
     ('hamming', ()),
     ('kaiser', (1,)),
+    ('kaiser_derived', (1,)),
     ('gaussian', (0.5,)),
     ('general_gaussian', (1.5, 2)),
     ('chebwin', (1,)),
@@ -508,14 +509,16 @@ def test_windowfunc_basics():
                             0, atol=1e-14)
 
 
-def test_needs_params():
-    for winstr in ['kaiser', 'ksr', 'gaussian', 'gauss', 'gss',
-                   'general gaussian', 'general_gaussian',
-                   'general gauss', 'general_gauss', 'ggs',
-                   'slepian', 'optimal', 'slep', 'dss', 'dpss',
-                   'chebwin', 'cheb', 'exponential', 'poisson', 'tukey',
-                   'tuk']:
-        assert_raises(ValueError, signal.get_window, winstr, 7)
+def test_kaiser_derived():
+    M = 100
+    w = signal.kaiser_derived(M, beta=4.)
+
+    # Test for Princen-Bradley condition
+    assert_allclose(w[:M//2]**2 + w[-M//2:]**2, 1.)
+
+    # Assert ValueError for odd window length
+    assert_raises(ValueError, signal.kaiser_derived, M + 1, beta=4.)
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -1172,8 +1172,7 @@ def kaiser_derived(M, beta=4.):
     Returns
     -------
     w : ndarray
-        The window, with the maximum value normalized to 1. The window also
-        fulfils the Princen-Bradley condition.
+        The window, normalized to fulfil the Princen-Bradley condition.
 
     Notes
     -----

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -1158,7 +1158,7 @@ def kaiser(M, beta, sym=True):
     return _truncate(w, needs_trunc)
 
 
-def kaiser_derived(M, beta=4.):
+def kaiser_derived(M, beta):
     """ Return a Kaiser-Bessel derived window.
 
     Parameters
@@ -1216,7 +1216,7 @@ def kaiser_derived(M, beta=4.):
 
     if M % 2:
         raise ValueError(
-            "Kaiser Bessel Derived windows are only defined for even number ",
+            "Kaiser Bessel Derived windows are only defined for even number "
             "of taps"
         )
 

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -1178,6 +1178,10 @@ def kaiser_derived(M, beta):
     -----
     This window is only defined for an even number of taps.
 
+    It is designed to be suitable for use with the modified discrete cosine
+    transform (MDCT) and is mainly used in audio signal processing and
+    audio coding.
+
     .. versionadded:: 0.16.0
 
     References
@@ -1782,7 +1786,8 @@ def get_window(window, Nx, fftbins=True):
         `barthann`, `kaiser` (needs beta), `gaussian` (needs standard
         deviation), `general_gaussian` (needs power, width), `slepian`
         (needs width), `chebwin` (needs attenuation), `exponential`
-        (needs decay scale), `tukey` (needs taper fraction)
+        (needs decay scale), `tukey` (needs taper fraction),
+        `kaiser_derived` (needs beta)
 
     If the window requires no parameters, then `window` can be a string.
 

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -1158,7 +1158,7 @@ def kaiser(M, beta, sym=True):
     return _truncate(w, needs_trunc)
 
 
-def kaiser_derived(M, beta):
+def kaiser_derived(M, beta, sym=True):
     """ Return a Kaiser-Bessel derived window.
 
     Parameters
@@ -1168,6 +1168,12 @@ def kaiser_derived(M, beta):
         array is returned.
     beta : float
         Kaiser-Bessel window shape parameter.
+    sym : bool, optional
+        This parameter only exists to comply with the interface offered by
+        the other window functions and to be callable by `get_window`.
+        When True (default), generates a symmetric window, for use in filter
+        design.
+        Will raise `ValueError` otherwise.
 
     Returns
     -------
@@ -1215,6 +1221,12 @@ def kaiser_derived(M, beta):
     >>> plt.show()
 
     """
+    if not sym:
+        raise ValueError(
+            "Kaiser Bessel Derived windows are only defined for symmetric "
+            "shapes"
+        )
+
     if M < 1:
         return np.array([])
 
@@ -1735,7 +1747,7 @@ _win_equiv_raw = {
     ('hamming', 'hamm', 'ham'): (hamming, False),
     ('hanning', 'hann', 'han'): (hann, False),
     ('kaiser', 'ksr'): (kaiser, True),
-    ('kaiser_derived', 'kd', 'kbd'): (kaiser, True),
+    ('kaiser_derived', 'kd', 'kbd'): (kaiser_derived, True),
     ('nuttall', 'nutl', 'nut'): (nuttall, False),
     ('parzen', 'parz', 'par'): (parzen, False),
     ('slepian', 'slep', 'optimal', 'dpss', 'dss'): (slepian, True),

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -1159,7 +1159,7 @@ def kaiser(M, beta, sym=True):
 
 
 def kaiser_derived(M, beta, sym=True):
-    """ Return a Kaiser-Bessel derived window.
+    """Return a Kaiser-Bessel derived window.
 
     Parameters
     ----------
@@ -1188,7 +1188,7 @@ def kaiser_derived(M, beta, sym=True):
     transform (MDCT) and is mainly used in audio signal processing and
     audio coding.
 
-    .. versionadded:: 0.16.0
+    .. versionadded:: 0.18.0
 
     References
     ----------
@@ -1203,7 +1203,7 @@ def kaiser_derived(M, beta, sym=True):
     >>> from scipy.fftpack import fft, fftshift
     >>> import matplotlib.pyplot as plt
 
-    >>> window = signal.kaiser_derived(50)
+    >>> window = signal.kaiser_derived(50, 4.0)
     >>> plt.plot(window)
     >>> plt.title("Kaiser-Bessel derived window")
     >>> plt.ylabel("Amplitude")
@@ -1224,8 +1224,7 @@ def kaiser_derived(M, beta, sym=True):
     if not sym:
         raise ValueError(
             "Kaiser Bessel Derived windows are only defined for symmetric "
-            "shapes"
-        )
+            "shapes")
 
     if M < 1:
         return np.array([])
@@ -1233,8 +1232,7 @@ def kaiser_derived(M, beta, sym=True):
     if M % 2:
         raise ValueError(
             "Kaiser Bessel Derived windows are only defined for even number "
-            "of taps"
-        )
+            "of taps")
 
     w = np.zeros(M)
     kaiserw = kaiser(M // 2 + 1, beta)

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -1172,7 +1172,8 @@ def kaiser_derived(M, beta=4.):
     Returns
     -------
     w : ndarray
-        The window, normalized to fulfil the Princen-Bradley condition.
+        The window, with the maximum value normalized to 1. The window also
+        fulfils the Princen-Bradley condition.
 
     Notes
     -----

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -1214,8 +1214,6 @@ def kaiser_derived(M, beta=4.):
     """
     if M < 1:
         return np.array([])
-    if M == 1:
-        return np.ones(1, 'd')
 
     if M % 2:
         raise ValueError(


### PR DESCRIPTION
This PR implements a new window in `scipy.signal`: The Kaiser-Bessel derived window, mainly used with the MDCT transform.

This window is somewhat special as it is only defined for an even number of taps: Requesting a window for an odd number of taps will raise a `ValueError` and the `sym` keyword argument is not defined.
