### PR TITLE
BUG: Fixed compilation with more recent versions of Cython.

### DIFF
--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -610,7 +610,7 @@ cdef int thin_qr_col_insert(int m, int n, blas_t* q, int* qs, blas_t* r,
     # here q and r will always be fortran ordered since we have to allocate them
     cdef int i, j, info
     cdef blas_t c, sn 
-    cdef blas_t rc0, rc;
+    cdef blas_t rc0, rc
     cdef blas_t* s
     cdef char* N = 'N'
     cdef char* T = 'T'
@@ -1357,8 +1357,7 @@ cdef validate_array(cnp.ndarray a, bint chkfinite):
     cdef int j
 
     for j in range(a.ndim):
-        if a.strides[j] <= 0 or \
-                (a.strides[j] / a.descr.itemsize) >= libc.limits.INT_MAX:
+        if a.strides[j] <= 0 or (a.strides[j] / a.descr.itemsize) >= libc.limits.INT_MAX:
             copy = True
         if a.shape[j] >= libc.limits.INT_MAX:
             raise ValueError('Input array too large for use with BLAS')

--- a/scipy/scipy.pxd
+++ b/scipy/scipy.pxd
@@ -1,0 +1,1 @@
+cimport linalg


### PR DESCRIPTION
This adds the file `scipy.pxd` to fix a compile error with recent versions of Cython.
The other changes are to address other idiosyncrasies within Cython. I haven't been able to get minimum working examples for the other two bugs, but both changes are necessary to compile with the latest master.
