### PR TITLE
improved stats mle fit

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1761,6 +1761,15 @@ class genextreme_gen(rv_continuous):
         ku = where(abs(c) <= (eps)**0.23, 12.0/5.0, ku1-3.0)
         return m, v, sk, ku
 
+    def _fitstart(self, data):
+        # This is better than the default shape of (1,).
+        g = _skew(data)
+        if g < 0:
+            a = 0.5
+        else:
+            a = -0.5
+        return super(genextreme_gen, self)._fitstart(data, args=(a,))
+
     def _munp(self, n, c):
         k = arange(0, n+1)
         vals = 1.0/c**n * sum(

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1956,7 +1956,8 @@ class rv_continuous(rv_generic):
     def _fitstart(self, data, args=None):
         if args is None:
             args = (1.0,)*self.numargs
-        return args + self.fit_loc_scale(data, *args)
+        loc, scale = self._fit_loc_scale_support(data, *args)
+        return args + (loc, scale)
 
     # Return the (possibly reduced) function to optimize in order to find MLE
     #  estimates for the .fit method
@@ -2082,6 +2083,70 @@ class rv_continuous(rv_generic):
             vals = restore(args, vals)
         vals = tuple(vals)
         return vals
+
+    def _fit_loc_scale_support(self, data, *args):
+        """
+        Estimate loc and scale parameters from data accounting for support.
+
+        Parameters
+        ----------
+        data : array_like
+            Data to fit.
+        arg1, arg2, arg3,... : array_like
+            The shape parameter(s) for the distribution (see docstring of the
+            instance object for more information).
+
+        Returns
+        -------
+        Lhat : float
+            Estimated location parameter for the data.
+        Shat : float
+            Estimated scale parameter for the data.
+
+        """
+        data = np.asarray(data)
+
+        # Estimate location and scale according to the method of moments.
+        loc_hat, scale_hat = self.fit_loc_scale(data, *args)
+
+        # Compute the support according to the shape parameters.
+        self._argcheck(*args)
+        a, b = self.a, self.b
+        support_width = b - a
+
+        # If the support is empty then return the moment-based estimates.
+        if support_width <= 0:
+            return loc_hat, scale_hat
+
+        # Compute the proposed support according to the loc and scale estimates.
+        a_hat = loc_hat + a * scale_hat
+        b_hat = loc_hat + b * scale_hat
+
+        # Use the moment-based estimates if they are compatible with the data.
+        data_a = np.min(data)
+        data_b = np.max(data)
+        if a_hat < data_a and data_b < b_hat:
+            return loc_hat, scale_hat
+
+        # Otherwise find other estimates that are compatible with the data.
+        data_width = data_b - data_a
+        rel_margin = 0.1
+        margin = data_width * rel_margin
+
+        # For a finite interval, both the location and scale
+        # should have interesting values.
+        if support_width < np.inf:
+            loc_hat = (data_a - a) - margin
+            scale_hat = (data_width + 2 * margin) / support_width
+            return loc_hat, scale_hat
+
+        # For a one-sided interval, use only an interesting location parameter.
+        if a > -np.inf:
+            return (data_a - a) - margin, 1
+        elif b < np.inf:
+            return (data_b - b) + margin, 1
+        else:
+            raise RuntimeError
 
     def fit_loc_scale(self, data, *args):
         """

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import os
 
 import numpy as np
-from numpy.testing import dec
+from numpy.testing import dec, assert_allclose
 
 from scipy import stats
 
@@ -13,6 +13,7 @@ from test_continuous_basic import distcont
 # verifies that the estimate and true values don't differ by too much
 
 fit_sizes = [1000, 5000]  # sample sizes to try
+
 thresh_percent = 0.25  # percent of true parameters for fail cut-off
 thresh_min = 0.75  # minimum difference estimate - true to fail test
 
@@ -95,6 +96,19 @@ def check_cont_fit(distname,arg):
         txt += 'estimated: %s\n' % str(est)
         txt += 'diff     : %s\n' % str(diff)
         raise AssertionError('fit not very good in %s\n' % distfn.name + txt)
+
+
+def _check_loc_scale_mle_fit(name, data, desired, atol=None):
+    d = getattr(stats, name)
+    actual = d.fit(data)[-2:]
+    assert_allclose(actual, desired, atol=atol,
+                    err_msg='poor mle fit of (loc, scale) in %s' % name)
+
+
+def test_non_default_loc_scale_mle_fit():
+    data = np.array([1.01, 1.78, 1.78, 1.78, 1.88, 1.88, 1.88, 2.00])
+    yield _check_loc_scale_mle_fit, 'uniform', data, [1.01, 0.99], 1e-3
+    yield _check_loc_scale_mle_fit, 'expon', data, [1.01, 0.73875], 1e-3
 
 
 if __name__ == "__main__":

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -19,7 +19,6 @@ thresh_min = 0.75  # minimum difference estimate - true to fail test
 
 failing_fits = [
         'burr',
-        'chi',
         'chi2',
         'gausshyper',
         'genexpon',


### PR DESCRIPTION
Currently stats mle `fit` functions do not know anything about the support of a distribution, except implicitly through a negative log likelihood penalty for data points that fall outside of the support.  This PR fixes that issue, at least when the location and scale parameters are both estimated and when the distribution has non-empty support under the default shape parameter guesses.

Closes https://github.com/scipy/scipy/issues/4752.
PR https://github.com/scipy/scipy/pull/462 lists related issues.

Future work could include implementing MLE formulas instead of using black-box optimization.
