### PR TITLE
BENCH: add signal.lsim benchmark

### DIFF
--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -5,7 +5,7 @@ from itertools import product
 import numpy as np
 
 try:
-    from scipy.signal import convolve2d, correlate2d
+    from scipy.signal import convolve2d, correlate2d, lti, lsim
 except ImportError:
     pass
 
@@ -36,3 +36,13 @@ class Convolve2D(Benchmark):
                     if b.shape[0] > a.shape[0] or b.shape[1] > a.shape[1]:
                         continue
                 fn(a, b, mode=mode, boundary=boundary)
+
+
+class LTI(Benchmark):
+    def setup(self):
+        self.system = lti(1.0, [1, 0, 1])
+        self.t = np.arange(0, 1000, 0.5)
+        self.u = np.sin(2 * self.t)
+
+    def time_lsim(self):
+        lsim(self.system, self.u, self.t)

--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -41,7 +41,7 @@ class Convolve2D(Benchmark):
 class LTI(Benchmark):
     def setup(self):
         self.system = lti(1.0, [1, 0, 1])
-        self.t = np.arange(0, 1000, 0.5)
+        self.t = np.arange(0, 100, 0.5)
         self.u = np.sin(2 * self.t)
 
     def time_lsim(self):

--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -5,7 +5,7 @@ from itertools import product
 import numpy as np
 
 try:
-    from scipy.signal import convolve2d, correlate2d, lti, lsim
+    from scipy.signal import convolve2d, correlate2d, lti, lsim, lsim2
 except ImportError:
     pass
 
@@ -46,3 +46,6 @@ class LTI(Benchmark):
 
     def time_lsim(self):
         lsim(self.system, self.u, self.t)
+
+    def time_lsim2(self):
+        lsim2(self.system, self.u, self.t)


### PR DESCRIPTION
Add the benchmark from https://github.com/python-control/python-control/issues/48.

~~On my system the new `lsim` is not faster. But it can deal with less-nice matrices.~~

Sorry I was comparing to the wrong branch. The new `lsim` is a bit faster than the old `lsim` in this benchmark, and the new `lsim` is also less picky about properties like diagonalizability.
