### PR TITLE
fix python syntax errors in docstring examples

### DIFF
--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -390,6 +390,7 @@ def rfft(x, n=None, axis=-1, overwrite_x=False):
 
     Examples
     --------
+    >>> from scipy.fftpack import fft, rfft
     >>> a = [9, -9, 1, 3]
     >>> fft(a)
     array([  4. +0.j,   8.+12.j,  16. +0.j,   8.-12.j])
@@ -583,6 +584,7 @@ def fftn(x, shape=None, axes=None, overwrite_x=False):
 
     Examples
     --------
+    >>> from scipy.fftpack import fftn, ifftn
     >>> y = (-np.arange(16), 8 - np.arange(16), np.arange(16))
     >>> np.allclose(y, fftn(ifftn(y)))
     True

--- a/scipy/fftpack/realtransforms.py
+++ b/scipy/fftpack/realtransforms.py
@@ -126,9 +126,10 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     even-symmetrical inputs.  The output is also real and even-symmetrical.
     Half of the FFT input is used to generate half of the FFT output:
 
-    >>> fft(array([4., 3., 5., 10., 5., 3.])).real
+    >>> from scipy.fftpack import fft, dct
+    >>> fft(np.array([4., 3., 5., 10., 5., 3.])).real
     array([ 30.,  -8.,   6.,  -2.,   6.,  -8.])
-    >>> dct(array([4., 3., 5., 10.]), 1)
+    >>> dct(np.array([4., 3., 5., 10.]), 1)
     array([ 30.,  -8.,   6.,  -2.])
 
     """
@@ -186,9 +187,10 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False):
     inputs.  The output is also real and even-symmetrical.  Half of the IFFT
     input is used to generate half of the IFFT output:
 
-    >>> ifft(array([ 30.,  -8.,   6.,  -2.,   6.,  -8.])).real
+    >>> from scipy.fftpack import ifft, idct
+    >>> ifft(np.array([ 30.,  -8.,   6.,  -2.,   6.,  -8.])).real
     array([  4.,   3.,   5.,  10.,   5.,   3.])
-    >>> idct(array([ 30.,  -8.,   6.,  -2.]), 1) / 6
+    >>> idct(np.array([ 30.,  -8.,   6.,  -2.]), 1) / 6
     array([  4.,   3.,   5.,  10.])
 
     """

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -678,7 +678,7 @@ def nquad(func, ranges, args=None, opts=None):
     >>> def opts3(t0, t1):
     ...     return {}
     >>> integrate.nquad(func2, [lim0, lim1, lim2, lim3], args=(0,0),
-                        opts=[opts0, opts1, opts2, opts3])
+    ...                 opts=[opts0, opts1, opts2, opts3])
     (25.066666666666666, 2.7829590483937256e-13)
 
     """

--- a/scipy/interpolate/fitpack.py
+++ b/scipy/interpolate/fitpack.py
@@ -429,12 +429,15 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
     Examples
     --------
 
-    >>> x = linspace(0, 10, 10)
-    >>> y = sin(x)
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy.interpolate import splev, splrep
+    >>> x = np.linspace(0, 10, 10)
+    >>> y = np.sin(x)
     >>> tck = splrep(x, y)
-    >>> x2 = linspace(0, 10, 200)
+    >>> x2 = np.linspace(0, 10, 200)
     >>> y2 = splev(x2, tck)
-    >>> plot(x, y, 'o', x2, y2)
+    >>> plt.plot(x, y, 'o', x2, y2)
+    >>> plt.show()
 
     """
     if task <= 0:

--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1321,7 +1321,7 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
     >>> lats, lons = np.meshgrid(theta, phi)
     >>> from scipy.interpolate import SmoothSphereBivariateSpline
     >>> lut = SmoothSphereBivariateSpline(lats.ravel(), lons.ravel(),
-                                         data.T.ravel(),s=3.5)
+    ...                                   data.T.ravel(), s=3.5)
 
     As a first test, we'll see what the algorithm returns when run on the
     input coordinates
@@ -1335,6 +1335,7 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
 
     >>> data_smth = lut(fine_lats, fine_lons)
 
+    >>> import matplotlib.pyplot as plt
     >>> fig = plt.figure()
     >>> ax1 = fig.add_subplot(131)
     >>> ax1.imshow(data, interpolation='nearest')
@@ -1418,7 +1419,7 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
     >>> knotsp[-1] -= .0001
     >>> from scipy.interpolate import LSQSphereBivariateSpline
     >>> lut = LSQSphereBivariateSpline(lats.ravel(), lons.ravel(),
-                                       data.T.ravel(),knotst,knotsp)
+    ...                                data.T.ravel(), knotst, knotsp)
 
     As a first test, we'll see what the algorithm returns when run on the
     input coordinates
@@ -1432,6 +1433,7 @@ class LSQSphereBivariateSpline(SphereBivariateSpline):
 
     >>> data_lsq = lut(fine_lats, fine_lons)
 
+    >>> import matplotlib.pyplot as plt
     >>> fig = plt.figure()
     >>> ax1 = fig.add_subplot(131)
     >>> ax1.imshow(data, interpolation='nearest')
@@ -1559,7 +1561,7 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
     >>> lats = np.linspace(10, 170, 9) * np.pi / 180.
     >>> lons = np.linspace(0, 350, 18) * np.pi / 180.
     >>> data = np.dot(np.atleast_2d(90. - np.linspace(-80., 80., 18)).T,
-                      np.atleast_2d(180. - np.abs(np.linspace(0., 350., 9)))).T
+    ...               np.atleast_2d(180. - np.abs(np.linspace(0., 350., 9)))).T
 
     We want to interpolate it to a global one-degree grid
 
@@ -1581,6 +1583,7 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
     Looking at the original and the interpolated data, one can see that the
     interpolant reproduces the original data very well:
 
+    >>> import matplotlib.pyplot as plt
     >>> fig = plt.figure()
     >>> ax1 = fig.add_subplot(211)
     >>> ax1.imshow(data, interpolation='nearest')
@@ -1613,12 +1616,12 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
     >>> fig2 = plt.figure()
     >>> s = [3e9, 2e9, 1e9, 1e8]
     >>> for ii in xrange(len(s)):
-    >>>     lut = RectSphereBivariateSpline(lats, lons, data, s=s[ii])
-    >>>     data_interp = lut.ev(new_lats.ravel(),
+    ...     lut = RectSphereBivariateSpline(lats, lons, data, s=s[ii])
+    ...     data_interp = lut.ev(new_lats.ravel(),
     ...                          new_lons.ravel()).reshape((360, 180)).T
-    >>>     ax = fig2.add_subplot(2, 2, ii+1)
-    >>>     ax.imshow(data_interp, interpolation='nearest')
-    >>>     ax.set_title("s = %g" % s[ii])
+    ...     ax = fig2.add_subplot(2, 2, ii+1)
+    ...     ax.imshow(data_interp, interpolation='nearest')
+    ...     ax.set_title("s = %g" % s[ii])
     >>> plt.show()
 
     """

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -176,6 +176,7 @@ class interp2d(object):
 
     Now use the obtained interpolation function and plot the result:
 
+    >>> import matplotlib.pyplot as plt
     >>> xnew = np.arange(-5.01, 5.01, 1e-2)
     >>> ynew = np.arange(-5.01, 5.01, 1e-2)
     >>> znew = f(xnew, ynew)
@@ -1470,7 +1471,7 @@ class RegularGridInterpolator(object):
 
     >>> from scipy.interpolate import RegularGridInterpolator
     >>> def f(x,y,z):
-    >>>     return 2 * x**3 + 3 * y**2 - z
+    ...     return 2 * x**3 + 3 * y**2 - z
     >>> x = np.linspace(1, 4, 11)
     >>> y = np.linspace(4, 7, 22)
     >>> z = np.linspace(7, 9, 33)
@@ -1479,7 +1480,7 @@ class RegularGridInterpolator(object):
     ``data`` is now a 3D array with ``data[i,j,k] = f(x[i], y[j], z[k])``.
     Next, define an interpolating function from this data:
 
-    >>> my_interpolating_function = RegularGridInterpolator((x,y,z), data)
+    >>> my_interpolating_function = RegularGridInterpolator((x, y, z), data)
 
     Evaluate the interpolating function at the two points
     ``(x,y,z) = (2.1, 6.2, 8.3)`` and ``(3.3, 5.2, 7.1)``:

--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -137,7 +137,7 @@ def griddata(points, values, xi, method='linear', fill_value=np.nan,
     Suppose we want to interpolate the 2-D function
 
     >>> def func(x, y):
-    >>>     return x*(1-x)*np.cos(4*np.pi*x) * np.sin(4*np.pi*y**2)**2
+    ...     return x*(1-x)*np.cos(4*np.pi*x) * np.sin(4*np.pi*y**2)**2
 
     on a grid in [0, 1]x[0, 1]
 

--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -204,7 +204,7 @@ class netcdf_file(object):
 
         >>> from scipy.io import netcdf
         >>> with netcdf.netcdf_file('simple.nc', 'r') as f:
-        >>>     print(f.history)
+        ...     print(f.history)
         Created for a test
 
     """

--- a/scipy/linalg/_decomp_polar.py
+++ b/scipy/linalg/_decomp_polar.py
@@ -47,6 +47,7 @@ def polar(a, side="right"):
 
     Examples
     --------
+    >>> from scipy.linalg import polar
     >>> a = np.array([[1, -1], [2, 4]])
     >>> u, p = polar(a)
     >>> u

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1726,7 +1726,7 @@ def qr_insert(Q, R, u, k, which='row', rcond=None, overwrite_qru=False, check_fi
                       
     >>> u = np.array([[  6.,  -9.,  -3.], 
     ...               [ -3.,  10.,   1.]])
-    >>> q1, r1 = linalg.qr_insert(q, r, u, 2, 'row', False)
+    >>> q1, r1 = linalg.qr_insert(q, r, u, 2, 'row')
     >>> q1
     array([[-0.25445668,  0.02246245,  0.18146236, -0.72798806,  0.60979671],
            [-0.50891336,  0.23226178, -0.82836478, -0.02837033, -0.00828114],

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1500,10 +1500,10 @@ def qr_delete(Q, R, k, p=1, which='row', overwrite_qr=False, check_finite=True):
     --------
     >>> from scipy import linalg
     >>> a = np.array([[  3.,  -2.,  -2.],
-                      [  6.,  -9.,  -3.],
-                      [ -3.,  10.,   1.],
-                      [  6.,  -7.,   4.],
-                      [  7.,   8.,  -6.]])
+    ...               [  6.,  -9.,  -3.],
+    ...               [ -3.,  10.,   1.],
+    ...               [  6.,  -7.,   4.],
+    ...               [  7.,   8.,  -6.]])
     >>> q, r = linalg.qr(a)
 
     Given this QR decomposition, update q and r when 2 rows are removed.
@@ -1718,14 +1718,14 @@ def qr_insert(Q, R, u, k, which='row', rcond=None, overwrite_qru=False, check_fi
     --------
     >>> from scipy import linalg
     >>> a = np.array([[  3.,  -2.,  -2.],
-                      [  6.,  -7.,   4.],
-                      [  7.,   8.,  -6.]])
+    ...               [  6.,  -7.,   4.],
+    ...               [  7.,   8.,  -6.]])
     >>> q, r = linalg.qr(a)
 
     Given this QR decomposition, update q and r when 2 rows are inserted.
                       
     >>> u = np.array([[  6.,  -9.,  -3.], 
-                      [ -3.,  10.,   1.]])
+    ...               [ -3.,  10.,   1.]])
     >>> q1, r1 = linalg.qr_insert(q, r, u, 2, 'row', False)
     >>> q1
     array([[-0.25445668,  0.02246245,  0.18146236, -0.72798806,  0.60979671],
@@ -2105,10 +2105,10 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
     --------
     >>> from scipy import linalg
     >>> a = np.array([[  3.,  -2.,  -2.],
-                      [  6.,  -9.,  -3.],
-                      [ -3.,  10.,   1.],
-                      [  6.,  -7.,   4.],
-                      [  7.,   8.,  -6.]])
+    ...               [  6.,  -9.,  -3.],
+    ...               [ -3.,  10.,   1.],
+    ...               [  6.,  -7.,   4.],
+    ...               [  7.,   8.,  -6.]])
     >>> q, r = linalg.qr(a)
 
     Given this q, r decomposition, perform a rank 1 update.
@@ -2166,13 +2166,13 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
     Similarly to the above, perform a rank 2 update.
 
     >>> u2 = np.array([[ 7., -1,],
-                       [-2.,  4.],
-                       [ 4.,  2.],
-                       [ 3., -6.],
-                       [ 5.,  3.]])
+    ...                [-2.,  4.],
+    ...                [ 4.,  2.],
+    ...                [ 3., -6.],
+    ...                [ 5.,  3.]])
     >>> v2 = np.array([[ 1., 2.],
-                       [ 3., 4.],
-                       [-5., 2]])
+    ...                [ 3., 4.],
+    ...                [-5., 2]])
     >>> q_up2, r_up2 = linalg.qr_update(q, r, u, v, False)
     >>> q_up2
     array([[-0.33626508, -0.03477253,  0.61956287, -0.64352987, -0.29618884],

--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -143,6 +143,7 @@ def sqrtm(A, disp=True, blocksize=64):
 
     Examples
     --------
+    >>> from scipy.linalg import sqrtm
     >>> a = np.array([[1.0, 3.0], [1.0, 4.0]])
     >>> r = sqrtm(a)
     >>> r

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -552,7 +552,7 @@ def solve_circulant(c, b, singular='raise', tol=None,
 
     Check by solving one pair of `c` and `b` vectors (cf. ``x[1, 1, :]``):
 
-    >>> solve_circulant(c[1], b[:,1])
+    >>> solve_circulant(c[1], b[1, :])
     array([ 0.856,  0.758,  1.149, -0.412,  0.831])
 
     """

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -63,9 +63,10 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
     --------
     Given `a` and `b`, solve for `x`:
 
-    >>> a = np.array([[3,2,0],[1,-1,0],[0,5,1]])
-    >>> b = np.array([2,4,-1])
-    >>> x = linalg.solve(a,b)
+    >>> a = np.array([[3, 2, 0], [1, -1, 0], [0, 5, 1]])
+    >>> b = np.array([2, 4, -1])
+    >>> from scipy import linalg
+    >>> x = linalg.solve(a, b)
     >>> x
     array([ 2., -2.,  9.])
     >>> np.dot(a, x) == b
@@ -255,7 +256,7 @@ def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False,
         ab[u + i - j, j] == a[i,j]        (if upper form; i <= j)
         ab[    i - j, j] == a[i,j]        (if lower form; i >= j)
 
-    Example of `ab` (shape of a is (6,6), `u` =2)::
+    Example of `ab` (shape of a is (6, 6), `u` =2)::
 
         upper form:
         *   *   a02 a13 a24 a35
@@ -633,11 +634,12 @@ def inv(a, overwrite_a=False, check_finite=True):
 
     Examples
     --------
+    >>> from scipy import linalg
     >>> a = np.array([[1., 2.], [3., 4.]])
-    >>> sp.linalg.inv(a)
+    >>> linalg.inv(a)
     array([[-2. ,  1. ],
            [ 1.5, -0.5]])
-    >>> np.dot(a, sp.linalg.inv(a))
+    >>> np.dot(a, linalg.inv(a))
     array([[ 1.,  0.],
            [ 0.,  1.]])
 
@@ -718,10 +720,11 @@ def det(a, overwrite_a=False, check_finite=True):
 
     Examples
     --------
-    >>> a = np.array([[1,2,3],[4,5,6],[7,8,9]])
+    >>> from scipy import linalg
+    >>> a = np.array([[1,2,3], [4,5,6], [7,8,9]])
     >>> linalg.det(a)
     0.0
-    >>> a = np.array([[0,2,3],[4,5,6],[7,8,9]])
+    >>> a = np.array([[0,2,3], [4,5,6], [7,8,9]])
     >>> linalg.det(a)
     3.0
 
@@ -874,11 +877,12 @@ def pinv(a, cond=None, rcond=None, return_rank=False, check_finite=True):
 
     Examples
     --------
+    >>> from scipy import linalg
     >>> a = np.random.randn(9, 6)
     >>> B = linalg.pinv(a)
-    >>> np.allclose(a, dot(a, dot(B, a)))
+    >>> np.allclose(a, np.dot(a, np.dot(B, a)))
     True
-    >>> np.allclose(B, dot(B, dot(a, B)))
+    >>> np.allclose(B, np.dot(B, np.dot(a, B)))
     True
 
     """
@@ -933,11 +937,12 @@ def pinv2(a, cond=None, rcond=None, return_rank=False, check_finite=True):
 
     Examples
     --------
+    >>> from scipy import linalg
     >>> a = np.random.randn(9, 6)
     >>> B = linalg.pinv2(a)
-    >>> np.allclose(a, dot(a, dot(B, a)))
+    >>> np.allclose(a, np.dot(a, np.dot(B, a)))
     True
-    >>> np.allclose(B, dot(B, dot(a, B)))
+    >>> np.allclose(B, np.dot(B, np.dot(a, B)))
     True
 
     """
@@ -1006,7 +1011,7 @@ def pinvh(a, cond=None, rcond=None, lower=True, return_rank=False,
 
     Examples
     --------
-    >>> import numpy as np
+    >>> from scipy.linalg import pinvh
     >>> a = np.random.randn(9, 6)
     >>> a = np.dot(a, a.T)
     >>> B = pinvh(a)

--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -585,6 +585,7 @@ def funm(A, func, disp=True):
 
     Examples
     --------
+    >>> from scipy.linalg import funm
     >>> a = np.array([[1.0, 3.0], [1.0, 4.0]])
     >>> funm(a, lambda x: x*x)
     array([[  4.,  15.],

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -999,10 +999,11 @@ def dft(n, scale=None):
 
     Examples
     --------
+    >>> from scipy.linalg import dft
     >>> np.set_printoptions(precision=5, suppress=True)
     >>> x = np.array([1, 2, 3, 0, 3, 2, 1, 0])
     >>> m = dft(8)
-    >>> m.dot(x)   # Comute the DFT of x
+    >>> m.dot(x)   # Compute the DFT of x
     array([ 12.+0.j,  -2.-2.j,   0.-4.j,  -2.+2.j,   4.+0.j,  -2.-2.j,
             -0.+4.j,  -2.+2.j])
 

--- a/scipy/optimize/_basinhopping.py
+++ b/scipy/optimize/_basinhopping.py
@@ -456,7 +456,8 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     The following example is a one-dimensional minimization problem,  with many
     local minima superimposed on a parabola.
 
-    >>> func = lambda x: cos(14.5 * x - 0.3) + (x + 0.2) * x
+    >>> from scipy.optimize import basinhopping
+    >>> func = lambda x: np.cos(14.5 * x - 0.3) + (x + 0.2) * x
     >>> x0=[1.]
 
     Basinhopping, internally, uses a local minimization algorithm.  We will use
@@ -474,10 +475,10 @@ def basinhopping(func, x0, niter=100, T=1.0, stepsize=0.5,
     will use gradient information to significantly speed up the search.
 
     >>> def func2d(x):
-    ...     f = cos(14.5 * x[0] - 0.3) + (x[1] + 0.2) * x[1] + (x[0] +
-    ...                                                         0.2) * x[0]
+    ...     f = np.cos(14.5 * x[0] - 0.3) + (x[1] + 0.2) * x[1] + (x[0] +
+    ...                                                            0.2) * x[0]
     ...     df = np.zeros(2)
-    ...     df[0] = -14.5 * sin(14.5 * x[0] - 0.3) + 2. * x[0] + 0.2
+    ...     df[0] = -14.5 * np.sin(14.5 * x[0] - 0.3) + 2. * x[0] + 0.2
     ...     df[1] = 2. * x[1] + 0.2
     ...     return f, df
 

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -964,6 +964,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     >>> b = [6, 4]
     >>> x0_bounds = (None, None)
     >>> x1_bounds = (-3, None)
+    >>> from scipy.optimize import linprog
     >>> res = linprog(c, A_ub=A, b_ub=b, bounds=(x0_bounds, x1_bounds),
     ...               options={"disp": True})
     >>> print(res)

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -314,10 +314,10 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
              Function evaluations: 64
              Gradient evaluations: 64
     >>> res.x
-    [ 1.  1.  1.  1.  1.]
-    >>> print res.message
+    array([ 1.  1.  1.  1.  1.])
+    >>> print(res.message)
     Optimization terminated successfully.
-    >>> res.hess
+    >>> res.hess_inv
     [[ 0.00749589  0.01255155  0.02396251  0.04750988  0.09495377]
      [ 0.01255155  0.02510441  0.04794055  0.09502834  0.18996269]
      [ 0.02396251  0.04794055  0.09631614  0.19092151  0.38165151]

--- a/scipy/optimize/cobyla.py
+++ b/scipy/optimize/cobyla.py
@@ -129,6 +129,7 @@ def fmin_cobyla(func, x0, cons, args=(), consargs=None, rhobeg=1.0,
         >>> def constr2(x):
         ...     return x[1]
         ...
+        >>> from scipy.optimize import fmin_cobyla
         >>> fmin_cobyla(objective, [0.0, 0.1], [constr1, constr2], rhoend=1e-7)
 
            Normal return from subroutine COBYLA

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -669,7 +669,7 @@ def fixed_point(func, x0, args=(), xtol=1e-8, maxiter=500):
     --------
     >>> from scipy import optimize
     >>> def func(x, c1, c2):
-    ....    return np.sqrt(c1/(x+c2))
+    ...    return np.sqrt(c1/(x+c2))
     >>> c1 = np.array([10,12.])
     >>> c2 = np.array([3, 5.])
     >>> optimize.fixed_point(func, [1.2, 1.3], args=(c1,c2))

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -1350,7 +1350,7 @@ class KrylovJacobian(Jacobian):
         preconditioners. For example,
 
         >>> jac = BroydenFirst()
-        >>> kjac = KrylovJacobian(inner_M=jac.inverse).
+        >>> kjac = KrylovJacobian(inner_M=jac.inverse)
 
         If the preconditioner has a method named 'update', it will be called
         as ``update(x, f)`` after each nonlinear step, with ``x`` giving

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -1349,8 +1349,10 @@ class KrylovJacobian(Jacobian):
         Note that you can use also inverse Jacobians as (adaptive)
         preconditioners. For example,
 
+        >>> from scipy.optimize.nonlin import BroydenFirst, KrylovJacobian
+        >>> from scipy.optimize.nonlin import InverseJacobian
         >>> jac = BroydenFirst()
-        >>> kjac = KrylovJacobian(inner_M=jac.inverse)
+        >>> kjac = KrylovJacobian(inner_M=InverseJacobian(jac))
 
         If the preconditioner has a method named 'update', it will be called
         as ``update(x, f)`` after each nonlinear step, with ``x`` giving

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -651,9 +651,10 @@ def check_grad(func, grad, x0, *args, **kwargs):
     Examples
     --------
     >>> def func(x):
-            return x[0]**2 - 0.5 * x[1]**3
+    ...     return x[0]**2 - 0.5 * x[1]**3
     >>> def grad(x):
-            return [2 * x[0], -1.5 * x[1]**2]
+    ...     return [2 * x[0], -1.5 * x[1]**2]
+    >>> from scipy.optimize import check_grad
     >>> check_grad(func, grad, [1.5, -1.5])
     2.9802322387695312e-08
 
@@ -1059,7 +1060,7 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
     >>> x0 = np.asarray((0, 0))  # Initial guess.
     >>> from scipy import optimize
     >>> res1 = optimize.fmin_cg(f, x0, fprime=gradf, args=args)
-    >>> print 'res1 = ', res1
+    >>> print('res1 = ', res1)
     Optimization terminated successfully.
              Current function value: 1.617021
              Iterations: 2
@@ -2559,7 +2560,7 @@ def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
     >>> rranges = (slice(-4, 4, 0.25), slice(-4, 4, 0.25))
     >>> from scipy import optimize
     >>> resbrute = optimize.brute(f, rranges, args=params, full_output=True,
-                                  finish=optimize.fmin)
+    ...                           finish=optimize.fmin)
     >>> resbrute[0]  # global minimum
     array([-1.05665192,  1.80834843])
     >>> resbrute[1]  # function value at global minimum

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -58,6 +58,7 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
 
     Examples
     --------
+    >>> from scipy.signal import savgol_coeffs
     >>> savgol_coeffs(5, 2)
     array([-0.08571429,  0.34285714,  0.48571429,  0.34285714, -0.08571429])
     >>> savgol_coeffs(5, 2, deriv=1)
@@ -76,7 +77,7 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     derivative at the last position.  When dotted with `x` the result should
     be 6.
 
-    >>> x = array([1, 0, 1, 4, 9])
+    >>> x = np.array([1, 0, 1, 4, 9])
     >>> c = savgol_coeffs(5, 2, pos=4, deriv=1, use='dot')
     >>> c.dot(x)
     6.0000000000000018

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -48,8 +48,8 @@ def spdiags(data, diags, m, n, format=None):
 
     Examples
     --------
-    >>> data = array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]])
-    >>> diags = array([0, -1, 2])
+    >>> data = np.array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]])
+    >>> diags = np.array([0, -1, 2])
     >>> spdiags(data, diags, 4, 4).toarray()
     array([[1, 0, 3, 0],
            [1, 2, 0, 4],
@@ -290,15 +290,15 @@ def kron(A, B, format=None):
     Examples
     --------
     >>> from scipy import sparse
-    >>> A = sparse.csr_matrix(array([[0, 2], [5, 0]]))
-    >>> B = sparse.csr_matrix(array([[1, 2], [3, 4]]))
-    >>> kron(A, B).toarray()
+    >>> A = sparse.csr_matrix(np.array([[0, 2], [5, 0]]))
+    >>> B = sparse.csr_matrix(np.array([[1, 2], [3, 4]]))
+    >>> sparse.kron(A, B).toarray()
     array([[ 0,  0,  2,  4],
            [ 0,  0,  6,  8],
            [ 5, 10,  0,  0],
            [15, 20,  0,  0]])
 
-    >>> kron(A, [[1, 2], [3, 4]]).toarray()
+    >>> sparse.kron(A, [[1, 2], [3, 4]]).toarray()
     array([[ 0,  0,  2,  4],
            [ 0,  0,  6,  8],
            [ 5, 10,  0,  0],
@@ -703,9 +703,9 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     >>> from scipy.sparse import construct
     >>> from scipy import stats
     >>> class CustomRandomState(object):
-        ...     def randint(self, k):
-        ...         i = np.random.randint(k)
-        ...         return i - i % 2
+    ...     def randint(self, k):
+    ...         i = np.random.randint(k)
+    ...         return i - i % 2
     >>> rs = CustomRandomState()
     >>> rvs = stats.poisson(25, loc=10).rvs
     >>> S = construct.random(3, 4, density=0.25, random_state=rs, data_rvs=rvs)

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -71,8 +71,8 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     >>> from scipy.sparse import dok_matrix
     >>> S = dok_matrix((5, 5), dtype=np.float32)
     >>> for i in range(5):
-    >>>     for j in range(5):
-    >>>         S[i,j] = i+j    # Update element
+    ...     for j in range(5):
+    ...         S[i, j] = i + j    # Update element
 
     """
 

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -2203,7 +2203,7 @@ class ConvexHull(_QhullUser):
     >>> import matplotlib.pyplot as plt
     >>> plt.plot(points[:,0], points[:,1], 'o')
     >>> for simplex in hull.simplices:
-    >>>     plt.plot(points[simplex,0], points[simplex,1], 'k-')
+    ...     plt.plot(points[simplex, 0], points[simplex, 1], 'k-')
 
     We could also have directly used the vertices of the hull, which
     for 2-D are guaranteed to be in counterclockwise order:

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -1191,13 +1191,14 @@ def comb(N, k, exact=False, repetition=False):
 
     Examples
     --------
+    >>> from scipy.special import comb
     >>> k = np.array([3, 4])
     >>> n = np.array([10, 10])
-    >>> sc.comb(n, k, exact=False)
+    >>> comb(n, k, exact=False)
     array([ 120.,  210.])
-    >>> sc.comb(10, 3, exact=True)
+    >>> comb(10, 3, exact=True)
     120L
-    >>> sc.comb(10, 3, exact=True, repetition=True)
+    >>> comb(10, 3, exact=True, repetition=True)
     220L
 
     """
@@ -1251,6 +1252,7 @@ def perm(N, k, exact=False):
 
     Examples
     --------
+    >>> from scipy.special import perm
     >>> k = np.array([3, 4])
     >>> n = np.array([10, 10])
     >>> perm(n, k)
@@ -1304,10 +1306,11 @@ def factorial(n,exact=False):
 
     Examples
     --------
+    >>> from scipy.special import factorial
     >>> arr = np.array([3,4,5])
-    >>> sc.factorial(arr, exact=False)
+    >>> factorial(arr, exact=False)
     array([   6.,   24.,  120.])
-    >>> sc.factorial(5, exact=True)
+    >>> factorial(5, exact=True)
     120L
 
     """
@@ -1352,6 +1355,7 @@ def factorial2(n, exact=False):
 
     Examples
     --------
+    >>> from scipy.special import factorial2
     >>> factorial2(7, exact=False)
     array(105.00000000000001)
     >>> factorial2(7, exact=True)
@@ -1408,9 +1412,10 @@ def factorialk(n, k, exact=True):
 
     Examples
     --------
-    >>> sc.factorialk(5, 1, exact=True)
+    >>> from scipy.special import factorialk
+    >>> factorialk(5, 1, exact=True)
     120L
-    >>> sc.factorialk(5, 3, exact=True)
+    >>> factorialk(5, 3, exact=True)
     10L
 
     """

--- a/scipy/special/lambertw.py
+++ b/scipy/special/lambertw.py
@@ -73,7 +73,7 @@ def lambertw(z, k=0, tol=1e-8):
     >>> w = lambertw(1)
     >>> w
     (0.56714329040978384+0j)
-    >>> w*exp(w)
+    >>> w * np.exp(w)
     (1.0+0j)
 
     Any branch gives a valid inverse:

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1414,6 +1414,7 @@ class rv_continuous(rv_generic):
     --------
     To create a new Gaussian distribution, we would do the following:
 
+    >>> from scipy.stats import rv_continuous
     >>> class gaussian_gen(rv_continuous):
     ...     "Gaussian distribution"
     ...     def _pdf(self, x):
@@ -2593,10 +2594,11 @@ class rv_discrete(rv_generic):
 
     To create a new discrete distribution, we would do the following:
 
+    >>> from scipy.stats import rv_discrete
     >>> class poisson_gen(rv_discrete):
     ...     "Poisson distribution"
     ...     def _pmf(self, k, mu):
-    ...         return exp(-m) * mu**k / factorial(k)
+    ...         return exp(-mu) * mu**k / factorial(k)
 
     and create an instance::
 

--- a/scipy/stats/_rank.pyx
+++ b/scipy/stats/_rank.pyx
@@ -143,6 +143,7 @@ def rankdata(a, method='average'):
 
     Examples
     --------
+    >>> from scipy.stats import rankdata
     >>> rankdata([0, 2, 3, 2])
     array([ 1. ,  2.5,  4. ,  2.5])
     >>> rankdata([0, 2, 3, 2], method='min')
@@ -220,6 +221,7 @@ def tiecorrect(rankvals):
 
     Examples
     --------
+    >>> from scipy.stats import tiecorrect, rankdata
     >>> tiecorrect([1, 2.5, 2.5, 4])
     0.9
     >>> ranks = rankdata([1, 3, 2, 4, 5, 7, 2, 8, 4])

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -86,6 +86,7 @@ def expected_freq(observed):
     Examples
     --------
     >>> observed = np.array([[10, 10, 20],[20, 20, 20]])
+    >>> from scipy.stats import expected_freq
     >>> expected_freq(observed)
     array([[ 12.,  12.,  16.],
            [ 18.,  18.,  24.]])
@@ -197,6 +198,7 @@ def chi2_contingency(observed, correction=True, lambda_=None):
     --------
     A two-way example (2 x 3):
 
+    >>> from scipy.stats import chi2_contingency
     >>> obs = np.array([[10, 10, 20], [20, 20, 20]])
     >>> chi2_contingency(obs)
     (2.7777777777777777,

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -131,10 +131,10 @@ class gaussian_kde(object):
 
     >>> from scipy import stats
     >>> def measure(n):
-    >>>     "Measurement model, return two coupled measurements."
-    >>>     m1 = np.random.normal(size=n)
-    >>>     m2 = np.random.normal(scale=0.5, size=n)
-    >>>     return m1+m2, m1-m2
+    ...     "Measurement model, return two coupled measurements."
+    ...     m1 = np.random.normal(size=n)
+    ...     m2 = np.random.normal(scale=0.5, size=n)
+    ...     return m1+m2, m1-m2
 
     >>> m1, m2 = measure(2000)
     >>> xmin = m1.min()
@@ -153,8 +153,7 @@ class gaussian_kde(object):
     Plot the results:
 
     >>> import matplotlib.pyplot as plt
-    >>> fig = plt.figure()
-    >>> ax = fig.add_subplot(111)
+    >>> fig, ax = plt.subplots()
     >>> ax.imshow(np.rot90(Z), cmap=plt.cm.gist_earth_r,
     ...           extent=[xmin, xmax, ymin, ymax])
     >>> ax.plot(m1, m2, 'k.', markersize=2)
@@ -459,8 +458,7 @@ class gaussian_kde(object):
         >>> y3 = kde(xs)
 
         >>> import matplotlib.pyplot as plt
-        >>> fig = plt.figure()
-        >>> ax = fig.add_subplot(111)
+        >>> fig, ax = plt.subplots()
         >>> ax.plot(x1, np.ones(x1.shape) / (4. * x1.size), 'bo',
         ...         label='Data points (rescaled)')
         >>> ax.plot(xs, y1, label='Scott (default)')

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2154,6 +2154,7 @@ def median_test(*args, **kwds):
     >>> g1 = [10, 14, 14, 18, 20, 22, 24, 25, 31, 31, 32, 39, 43, 43, 48, 49]
     >>> g2 = [28, 30, 31, 33, 34, 35, 36, 40, 44, 55, 57, 61, 91, 92, 99]
     >>> g3 = [0, 3, 9, 22, 23, 25, 25, 33, 34, 34, 40, 45, 46, 48, 62, 67, 84]
+    >>> from scipy.stats import median_test
     >>> stat, p, med, tbl = median_test(g1, g2, g3)
 
     The median is

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -616,15 +616,15 @@ def mode(a, axis=0):
     Examples
     --------
     >>> a = np.array([[6, 8, 3, 0],
-                      [3, 2, 1, 7],
-                      [8, 1, 8, 4],
-                      [5, 3, 0, 5],
-                      [4, 7, 5, 9]])
+    ...               [3, 2, 1, 7],
+    ...               [8, 1, 8, 4],
+    ...               [5, 3, 0, 5],
+    ...               [4, 7, 5, 9]])
     >>> from scipy import stats
     >>> stats.mode(a)
     (array([[3, 1, 0, 0]]), array([[1, 1, 1, 1]]))
 
-    To get mode of whole array, specify axis=None:
+    To get mode of whole array, specify ``axis=None``:
 
     >>> stats.mode(a, axis=None)
     (array([3]), array([3]))
@@ -1896,6 +1896,7 @@ def obrientransform(*args):
 
     Apply the O'Brien transform to the data.
 
+    >>> from scipy.stats import obrientransform
     >>> tx, ty = obrientransform(x, y)
 
     Use `scipy.stats.f_oneway` to apply a one-way ANOVA test to the
@@ -2054,7 +2055,7 @@ def zscore(a, axis=0, ddof=0):
     Examples
     --------
     >>> a = np.array([ 0.7972,  0.0767,  0.4383,  0.7866,  0.8091,  0.1954,
-                       0.6307, 0.6599,  0.1065,  0.0508])
+    ...                0.6307, 0.6599,  0.1065,  0.0508])
     >>> from scipy import stats
     >>> stats.zscore(a)
     array([ 1.1273, -1.247 , -0.0552,  1.0923,  1.1664, -0.8559,  0.5786,
@@ -2064,10 +2065,10 @@ def zscore(a, axis=0, ddof=0):
     to calculate the standard deviation:
 
     >>> b = np.array([[ 0.3148,  0.0478,  0.6243,  0.4608],
-                      [ 0.7149,  0.0775,  0.6072,  0.9656],
-                      [ 0.6341,  0.1403,  0.9759,  0.4064],
-                      [ 0.5918,  0.6948,  0.904 ,  0.3721],
-                      [ 0.0921,  0.2481,  0.1188,  0.1366]])
+    ...               [ 0.7149,  0.0775,  0.6072,  0.9656],
+    ...               [ 0.6341,  0.1403,  0.9759,  0.4064],
+    ...               [ 0.5918,  0.6948,  0.904 ,  0.3721],
+    ...               [ 0.0921,  0.2481,  0.1188,  0.1366]])
     >>> stats.zscore(b, axis=1, ddof=1)
     array([[-0.19264823, -1.28415119,  1.07259584,  0.40420358],
            [ 0.33048416, -1.37380874,  0.04251374,  1.00081084],
@@ -2121,6 +2122,7 @@ def zmap(scores, compare, axis=0, ddof=0):
 
     Examples
     --------
+    >>> from scipy.stats import zmap
     >>> a = [0.5, 2.0, 2.5, 3]
     >>> b = [0, 1, 2, 3, 4]
     >>> zmap(a, b)
@@ -2217,7 +2219,9 @@ def sigmaclip(a, low=4., high=4.):
 
     Examples
     --------
-    >>> a = np.concatenate((np.linspace(9.5,10.5,31), np.linspace(0,20,5)))
+    >>> from scipy.stats import sigmaclip
+    >>> a = np.concatenate((np.linspace(9.5, 10.5, 31),
+    ...                     np.linspace(0, 20, 5)))
     >>> fact = 1.5
     >>> c, low, upp = sigmaclip(a, fact, fact)
     >>> c
@@ -2229,10 +2233,10 @@ def sigmaclip(a, low=4., high=4.):
     >>> upp, c.mean() + fact*c.std(), c.max()
     (10.035355339059327, 10.035355339059327, 10.033333333333333)
 
-    >>> a = np.concatenate((np.linspace(9.5,10.5,11),
-        np.linspace(-100,-50,3)))
+    >>> a = np.concatenate((np.linspace(9.5, 10.5, 11),
+    ...                     np.linspace(-100, -50, 3)))
     >>> c, low, upp = sigmaclip(a, 1.8, 1.8)
-    >>> (c == np.linspace(9.5,10.5,11)).all()
+    >>> (c == np.linspace(9.5, 10.5, 11)).all()
     True
 
     """
@@ -2577,6 +2581,7 @@ def fisher_exact(table, alternative='two-sided'):
 
     We use this table to find the p-value:
 
+    >>> import scipy.stats as stats
     >>> oddsratio, pvalue = stats.fisher_exact([[8, 2], [1, 5]])
     >>> pvalue
     0.0349...
@@ -3871,6 +3876,7 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
     are uniform and given by the mean of the observed frequencies.  Here we
     perform a G-test (i.e. use the log-likelihood ratio statistic):
 
+    >>> from scipy.stats import power_divergence
     >>> power_divergence([16, 18, 16, 14, 12, 12], lambda_='log-likelihood')
     (2.006573162632538, 0.84823476779463769)
 
@@ -4038,6 +4044,7 @@ def chisquare(f_obs, f_exp=None, ddof=0, axis=0):
     When just `f_obs` is given, it is assumed that the expected frequencies
     are uniform and given by the mean of the observed frequencies.
 
+    >>> from scipy.stats import chisquare
     >>> chisquare([16, 18, 16, 14, 12, 12])
     (2.0, 0.84914503608460956)
 


### PR DESCRIPTION
The objective is to make sure the code in docstrings is valid python, not to have docstrings doctestable. 
While I'm at it, I tried to tweak the code snippets so that play ball with the online JS thingy which toggles the output and python REPL prompt, so that it's easy for a user to copy-paste the code into their interactive console. 

I used a simple extension of `tools/refguide_check.py` script, here https://gist.github.com/ev-br/69cee8f232d49c609ba2
[Edit: relevant code is in tools/refguide_check.py]

Most of the diff is trivial, with only a couple of points of note, which I highlight below for the maintainers of the relevant modules. 
