### PR TITLE
MAINT: Use a dictionary for function name synonyms

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -213,5 +213,14 @@ def test_windowfunc_basics():
         window(6, *params, sym=False)
 
 
+def test_needs_params():
+    for winstr in ['kaiser', 'ksr', 'gaussian', 'gauss', 'gss',
+                   'general gaussian', 'general_gaussian',
+                   'general gauss', 'general_gauss', 'ggs',
+                   'slepian', 'optimal', 'slep', 'dss', 'dpss',
+                   'chebwin', 'cheb', 'exponential', 'poisson', 'tukey',
+                   'tuk']:
+        assert_raises(ValueError, signal.get_window, winstr, 7)
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Gets rid of duplication of information and long elif chain, minimizing future problems like https://github.com/e-q/scipy/commit/55c2ca84381214759c26589013e38cc95a0b02ec

(also some minor PEP8 fixes)
