### PR TITLE
Include apparently-forgotten functions in docs

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -159,6 +159,8 @@ which work for masked arrays.
    normaltest        --
    skew              -- Skewness
    skewtest          --
+   kstat             --
+   kstatvar          --
    tmean             -- Truncated arithmetic mean
    tvar              -- Truncated variance
    tmin              --
@@ -194,6 +196,7 @@ which work for masked arrays.
    obrientransform
    signaltonoise
    bayes_mvs
+   mvsdist
    sem
    zmap
    zscore
@@ -260,6 +263,16 @@ which work for masked arrays.
 
    entropy
 
+Circular statistical functions
+==============================
+
+.. autosummary::
+   :toctree: generated/
+
+   circmean
+   circvar
+   circstd
+   
 Contingency table functions
 ===========================
 


### PR DESCRIPTION
Some functions in scipy.morestats are not mentioned in the giant table of functions and therefore do not show up in the online docs; people occasionally ask for them to be implemented. Added several. It'd be nice to have some kind of check that they all appear _somewhere_; an Sphinx do that?
