### PR TITLE
ENH: Add cut tree function to scipy.cluster.hierarchy

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -170,6 +170,8 @@ from __future__ import division, print_function, absolute_import
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import warnings
+import bisect
+from collections import deque
 
 import numpy as np
 from . import _hierarchy
@@ -854,6 +856,34 @@ class ClusterNode:
 
 _cnode_bare = ClusterNode(0)
 _cnode_type = type(ClusterNode)
+
+
+def _order_cluster_tree(Z):
+    """
+    Returns clustering nodes in bottom-up order by distance.
+
+    Parameters
+    ----------
+    Z : scipy.cluster.linkage array
+        The linkage matrix.
+
+    Returns
+    -------
+    nodes : list
+        A list of ClusterNode objects.
+    """
+    q = deque()
+    tree = to_tree(Z)
+    q.append(tree)
+    nodes = []
+
+    while q:
+        node = q.popleft()
+        if not node.is_leaf():
+            bisect.insort_left(nodes, node)
+            q.append(node.get_right())
+            q.append(node.get_left())
+    return nodes
 
 
 def to_tree(Z, rd=False):

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -605,7 +605,7 @@ def linkage(y, method='single', metric='euclidean'):
         The linkage algorithm to use. See the ``Linkage Methods`` section below
         for full descriptions.
     metric : str or function, optional
-        The distance metric to use in the case that y is a collection of 
+        The distance metric to use in the case that y is a collection of
         observation vectors; ignored otherwise. See the ``distance.pdist``
         function for a list of valid distance metrics. A custom distance
         function can also be used. See the ``distance.pdist`` function for
@@ -703,6 +703,24 @@ class ClusterNode:
             self.count = count
         else:
             self.count = left.count + right.count
+
+    def __lt__(self, node):
+        if not isinstance(node, ClusterNode):
+            raise ValueError("Can't compare ClusterNode "
+                             "to type {}".format(type(node)))
+        return self.dist < node.dist
+
+    def __gt__(self, node):
+        if not isinstance(node, ClusterNode):
+            raise ValueError("Can't compare ClusterNode "
+                             "to type {}".format(type(node)))
+        return self.dist > node.dist
+
+    def __eq__(self, node):
+        if not isinstance(node, ClusterNode):
+            raise ValueError("Can't compare ClusterNode "
+                             "to type {}".format(type(node)))
+        return self.dist == node.dist
 
     def get_id(self):
         """

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -874,6 +874,18 @@ def test_2x2_linkage():
     assert_allclose(Z1, Z2)
 
 
+def test_node_compare():
+    np.random.seed(23)
+    nobs = 50
+    X = np.random.randn(nobs, 4)
+    Z = scipy.cluster.hierarchy.ward(X)
+    tree = to_tree(Z)
+    assert_(tree > tree.get_left())
+    assert_(tree.get_right() > tree.get_left())
+    assert_(tree.get_right() == tree.get_right())
+    assert_(tree.get_right() != tree.get_left())
+
+
 def test_cut_tree():
     np.random.seed(23)
     nobs = 50
@@ -898,8 +910,6 @@ def test_cut_tree():
                  cut_tree(Z, height=[5, 10]))
     assert_equal(cutree[:, np.searchsorted(heights, [10, 5])],
                  cut_tree(Z, height=[10, 5]))
-
-
 
 
 if __name__ == "__main__":

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -46,7 +46,7 @@ from scipy.cluster.hierarchy import (
     cophenet, fclusterdata, fcluster, is_isomorphic, single, leaders,
     correspond, is_monotonic, maxdists, maxinconsts, maxRstat,
     is_valid_linkage, is_valid_im, to_tree, leaves_list, dendrogram,
-    set_link_color_palette)
+    set_link_color_palette, cut_tree, _order_cluster_tree)
 from scipy.spatial.distance import pdist
 
 import hierarchy_test_data
@@ -872,6 +872,34 @@ def test_2x2_linkage():
     Z1 = linkage([1], method='single', metric='euclidean')
     Z2 = linkage([[0, 1], [0, 0]], method='single', metric='euclidean')
     assert_allclose(Z1, Z2)
+
+
+def test_cut_tree():
+    np.random.seed(23)
+    nobs = 50
+    X = np.random.randn(nobs, 4)
+    Z = scipy.cluster.hierarchy.ward(X)
+    cutree = cut_tree(Z)
+
+    assert_equal(cutree[:, 0], np.arange(nobs))
+    assert_equal(cutree[:, -1], np.zeros(nobs))
+    assert_equal(cutree.max(0), np.arange(nobs - 1, -1, -1))
+
+    assert_equal(cutree[:, [-5]], cut_tree(Z, n_clusters=5))
+    assert_equal(cutree[:, [-5, -10]], cut_tree(Z, n_clusters=[5, 10]))
+    assert_equal(cutree[:, [-10, -5]], cut_tree(Z, n_clusters=[10, 5]))
+
+    nodes = _order_cluster_tree(Z)
+    heights = np.array([node.dist for node in nodes])
+
+    assert_equal(cutree[:, np.searchsorted(heights, [5])],
+                 cut_tree(Z, height=5))
+    assert_equal(cutree[:, np.searchsorted(heights, [5, 10])],
+                 cut_tree(Z, height=[5, 10]))
+    assert_equal(cutree[:, np.searchsorted(heights, [10, 5])],
+                 cut_tree(Z, height=[10, 5]))
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a function similar to R's [cutree](https://stat.ethz.ch/R-manual/R-patched/library/stats/html/cutree.html). 
