### PR TITLE
TST: increase scipy.optimize test coverage for disp=True

### DIFF
--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -28,17 +28,15 @@ def knownfailure_overridable(msg=None):
     return deco
 
 
-def suppressed_stdout():
-    def suppressed_stdout_decorator(f):
-        import nose
+def suppressed_stdout(f):
+    import nose
 
-        def pwrapper(*arg, **kwargs):
-            oldstdout = sys.stdout
-            sys.stdout = open(os.devnull, 'w')
-            try:
-                return f(*arg, **kwargs)
-            finally:
-                sys.stdout.close()
-                sys.stdout = oldstdout
-        return nose.tools.make_decorator(f)(pwrapper)
-    return suppressed_stdout_decorator
+    def pwrapper(*arg, **kwargs):
+        oldstdout = sys.stdout
+        sys.stdout = open(os.devnull, 'w')
+        try:
+            return f(*arg, **kwargs)
+        finally:
+            sys.stdout.close()
+            sys.stdout = oldstdout
+    return nose.tools.make_decorator(f)(pwrapper)

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -6,10 +6,11 @@ Generic test utilities and decorators.
 from __future__ import division, print_function, absolute_import
 
 import os
+import sys
 from numpy.testing import dec
 
 
-__all__ = ['knownfailure_overridable']
+__all__ = ['knownfailure_overridable', 'suppressed_stdout']
 
 
 def knownfailure_overridable(msg=None):
@@ -25,3 +26,18 @@ def knownfailure_overridable(msg=None):
             pass
         return dec.knownfailureif(True, msg)(func)
     return deco
+
+
+def suppressed_stdout():
+    def suppressed_stdout_decorator(f):
+        import nose
+        def pwrapper(*arg, **kwargs):
+            oldstdout = sys.stdout
+            sys.stdout = open(os.devnull, 'w')
+            try:
+                return f(*arg, **kwargs)
+            finally:
+                sys.stdout.close()
+                sys.stdout = oldstdout
+        return nose.tools.make_decorator(f)(pwrapper)
+    return suppressed_stdout_decorator

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -31,6 +31,7 @@ def knownfailure_overridable(msg=None):
 def suppressed_stdout():
     def suppressed_stdout_decorator(f):
         import nose
+
         def pwrapper(*arg, **kwargs):
             oldstdout = sys.stdout
             sys.stdout = open(os.devnull, 'w')

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -90,7 +90,7 @@ class CheckOptimize(object):
 
 class CheckOptimizeParameterized(CheckOptimize):
 
-    @suppressed_stdout()
+    @suppressed_stdout
     def test_cg(self):
         # conjugate gradient optimization routine
         if self.use_wrapper:
@@ -122,7 +122,7 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [0, -5.05700028e-01, 4.95985862e-01]],
                         atol=1e-14, rtol=1e-7)
 
-    @suppressed_stdout()
+    @suppressed_stdout
     def test_bfgs(self):
         # Broyden-Fletcher-Goldfarb-Shanno optimization routine
         if self.use_wrapper:
@@ -156,7 +156,7 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [0, -5.24885582e-01, 4.87530347e-01]],
                         atol=1e-14, rtol=1e-7)
 
-    @suppressed_stdout()
+    @suppressed_stdout
     def test_bfgs_infinite(self):
         # Test corner case where -Inf is the minimum.  See gh-2019.
         func = lambda x: -np.e**-x
@@ -174,7 +174,7 @@ class CheckOptimizeParameterized(CheckOptimize):
         finally:
             np.seterr(**olderr)
 
-    @suppressed_stdout()
+    @suppressed_stdout
     def test_powell(self):
         # Powell (direction set) optimization routine
         if self.use_wrapper:
@@ -216,7 +216,7 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [1.72949016, -0.44156936, 0.47576729]],
                         atol=1e-14, rtol=1e-7)
 
-    @suppressed_stdout()
+    @suppressed_stdout
     def test_neldermead(self):
         # Nelder-Mead simplex algorithm
         if self.use_wrapper:
@@ -248,7 +248,7 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [0.19572515, -0.63648426, 0.35838135]],
                         atol=1e-14, rtol=1e-7)
 
-    @suppressed_stdout()
+    @suppressed_stdout
     def test_ncg(self):
         # line-search Newton conjugate gradient optimization routine
         if self.use_wrapper:
@@ -282,7 +282,7 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [-4.35700753e-07, -5.24869401e-01, 4.87527774e-01]],
                         atol=1e-6, rtol=1e-7)
 
-    @suppressed_stdout()
+    @suppressed_stdout
     def test_ncg_hess(self):
         # Newton conjugate gradient with Hessian
         if self.use_wrapper:
@@ -317,7 +317,7 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [-4.35700753e-07, -5.24869401e-01, 4.87527774e-01]],
                         atol=1e-6, rtol=1e-7)
 
-    @suppressed_stdout()
+    @suppressed_stdout
     def test_ncg_hessp(self):
         # Newton conjugate gradient with Hessian times a vector p.
         if self.use_wrapper:
@@ -951,7 +951,7 @@ class TestBrute:
     def func(self, z, *params):
         return self.f1(z, *params) + self.f2(z, *params) + self.f3(z, *params)
 
-    @suppressed_stdout()
+    @suppressed_stdout
     def test_brute(self):
         # test fmin
         resbrute = optimize.brute(self.func, self.rranges, args=self.params,


### PR DESCRIPTION
This includes a new decorator in `_lib._testutils` for silencing output of specific tests, inspired by https://github.com/numpy/numpy/blob/master/numpy/testing/decorators.py and https://github.com/numpy/numpy/blob/maintenance/1.9.x/numpy/lib/tests/test_regression.py#L171, and it reorganizes the optimization tests by adding an object oriented hierarchy inspired by the `scipy.sparse` test framework, replacing

``` python
    def test_minimize(self):
        # Tests for the minimize wrapper.
        self.setUp()
        self.test_bfgs(True)
        self.setUp()
        self.test_bfgs_infinite(True)
        self.setUp()
        self.test_cg(True)
        self.setUp()
        self.test_ncg(True)
        self.setUp()
        self.test_ncg_hess(True)
        self.setUp()
        self.test_ncg_hessp(True)
        self.setUp()
        self.test_neldermead(True)
        self.setUp()
        self.test_powell(True)
        self.setUp()
        self.test_custom()
```

closes https://github.com/scipy/scipy/issues/4804
