### PR TITLE
MAINT: use an informed initial guess for cauchy fit

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -736,7 +736,9 @@ class cauchy_gen(rv_continuous):
         return log(4*pi)
 
     def _fitstart(self, data, args=None):
-        return (0, 1)
+        # Initialize ML guesses using quartiles instead of moments.
+        p25, p50, p75 = np.percentile(data, [25, 50, 75])
+        return p50, (p75 - p25)/2
 cauchy = cauchy_gen(name='cauchy')
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1793,6 +1793,16 @@ def test_regression_ticket_1530():
     assert_almost_equal(params, expected, decimal=1)
 
 
+def test_gh_pr_4806():
+    # Check starting values for Cauchy distribution fit.
+    np.random.seed(1234)
+    x = np.random.randn(42)
+    for offset in 10000.0, 1222333444.0:
+        loc, scale = stats.cauchy.fit(x + offset)
+        assert_allclose(loc, offset, atol=1.0)
+        assert_allclose(scale, 0.6, atol=1.0)
+
+
 def test_tukeylambda_stats_ticket_1545():
     # Some test for the variance and kurtosis of the Tukey Lambda distr.
     # See test_tukeylamdba_stats.py for more tests.


### PR DESCRIPTION
For most distributions `scipy.stats.*.fit` uses the [method of moments](http://en.wikipedia.org/wiki/Method_of_moments_%28statistics%29) to obtain initial guesses of the location and scale parameter values, and these guesses are subsequently refined with a black-box search for the maximum likelihood estimates.

This initialization strategy does not work for the [cauchy distribution](http://en.wikipedia.org/wiki/Cauchy_distribution) which is so [fat-tailed](http://en.wikipedia.org/wiki/Fat-tailed_distribution) that its moments are unbounded. Instead, the cauchy `fit` code currently uses 0 and 1 as the hardcoded starting points for its maximum likelihood search. This PR uses [quartiles](http://en.wikipedia.org/wiki/Quartile) instead: the median is used for the location, and half the [interquartile range](http://en.wikipedia.org/wiki/Interquartile_range) is used for the scale.
