### PR TITLE
MAINT: cauchy moments are undefined

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -730,7 +730,7 @@ class cauchy_gen(rv_continuous):
         return tan(pi/2.0-pi*q)
 
     def _stats(self):
-        return inf, inf, nan, nan
+        return nan, nan, nan, nan
 
     def _entropy(self):
         return log(4*pi)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -228,9 +228,9 @@ def test_moments():
 
 def check_sample_meanvar_(distfn, arg, m, v, sm, sv, sn, msg):
     # this did not work, skipped silently by nose
-    if not np.isinf(m):
+    if np.isfinite(m):
         check_sample_mean(sm, sv, sn, m)
-    if not np.isinf(v):
+    if np.isfinite(v):
         check_sample_var(sv, sn, v)
 
 


### PR DESCRIPTION
See https://github.com/scipy/scipy/issues/2055#issuecomment-17031455.

This PR could weaken some tests by not failing moment calculations that mistakenly return `nan`.
