### PR TITLE
ENH: scipy.signal - Addition of spectrogram function

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -259,6 +259,7 @@ Spectral Analysis
    welch          -- Compute a periodogram using Welch's method
    csd            -- Compute the cross spectral density, using Welch's method
    coherence      -- Compute the magnitude squared coherence, using Welch's method
+   spectrogram    -- Compute the spectrogram
    lombscargle    -- Computes the Lomb-Scargle periodogram
    vectorstrength -- Computes the vector strength
 

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -26,8 +26,7 @@ def periodogram(x, fs=1.0, window=None, nfft=None, detrend='constant',
     x : array_like
         Time series of measurement values
     fs : float, optional
-        Sampling frequency of the `x` time series in units of Hz. Defaults
-        to 1.0.
+        Sampling frequency of the `x` time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is an array it will be used
@@ -45,9 +44,9 @@ def periodogram(x, fs=1.0, window=None, nfft=None, detrend='constant',
         spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the power spectral density ('density')
-        where `Pxx` has units of V**2/Hz if `x` is measured in V and computing
-        the power spectrum ('spectrum') where `Pxx` has units of V**2 if `x` is
-        measured in V. Defaults to 'density'
+        where `Pxx` has units of V**2/Hz and computing the power spectrum
+        ('spectrum') where `Pxx` has units of V**2, if `x` is measured in V
+        and fs is measured in Hz.  Defaults to 'density'
     axis : int, optional
         Axis along which the periodogram is computed; the default is over
         the last axis (i.e. ``axis=-1``).
@@ -155,8 +154,7 @@ def welch(x, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
     x : array_like
         Time series of measurement values
     fs : float, optional
-        Sampling frequency of the `x` time series in units of Hz. Defaults
-        to 1.0.
+        Sampling frequency of the `x` time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
@@ -181,9 +179,9 @@ def welch(x, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
         spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the power spectral density ('density')
-        where Pxx has units of V**2/Hz if x is measured in V and computing
-        the power spectrum ('spectrum') where Pxx has units of V**2 if x is
-        measured in V. Defaults to 'density'.
+        where `Pxx` has units of V**2/Hz and computing the power spectrum
+        ('spectrum') where `Pxx` has units of V**2, if `x` is measured in V
+        and fs is measured in Hz.  Defaults to 'density'
     axis : int, optional
         Axis along which the periodogram is computed; the default is over
         the last axis (i.e. ``axis=-1``).
@@ -287,8 +285,7 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
     y : array_like
         Time series of measurement values
     fs : float, optional
-        Sampling frequency of the `x` and `y` time series in units of Hz.
-        Defaults to 1.0.
+        Sampling frequency of the `x` and `y` time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
@@ -312,10 +309,10 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
         a two-sided spectrum. Note that for complex data, a two-sided
         spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
-        Selects between computing the power spectral density ('density')
-        where Pxy has units of V**2/Hz if x and y are measured in V and
-        computing the power spectrum ('spectrum') where Pxy has units of V**2
-        if x and y are measured in V. Defaults to 'density'.
+        Selects between computing the cross spectral density ('density')
+        where `Pxy` has units of V**2/Hz and computing the cross spectrum
+        ('spectrum') where `Pxy` has units of V**2, if `x` and `y` are
+        measured in V and fs is measured in Hz.  Defaults to 'density'
     axis : int, optional
         Axis along which the CSD is computed for both inputs; the default is
         over the last axis (i.e. ``axis=-1``).
@@ -347,6 +344,8 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
     overlap of 50\% is a reasonable trade off between accurately estimating
     the signal power, while not over counting any of the data.  Narrower
     windows may require a larger overlap.
+
+    .. versionadded:: 0.16.0
 
     References
     ----------
@@ -413,8 +412,7 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
     x : array_like
         Time series of measurement values
     fs : float, optional
-        Sampling frequency of the `x` time series in units of Hz. Defaults
-        to 1.0.
+        Sampling frequency of the `x` time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
@@ -439,9 +437,9 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
         spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the power spectral density ('density')
-        where Sxx has units of ``V**2/Hz`` if x is measured in V and computing
-        the power spectrum ('spectrum') where Sxx has units of ``V**2`` if x is
-        measured in V. Defaults to 'density'.
+        where `Pxx` has units of V**2/Hz and computing the power spectrum
+        ('spectrum') where `Pxx` has units of V**2, if `x` is measured in V
+        and fs is measured in Hz.  Defaults to 'density'
     axis : int, optional
         Axis along which the spectrogram is computed; the default is over
         the last axis (i.e. ``axis=-1``).
@@ -471,6 +469,8 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
     perhaps none at all) when computing a spectrogram, to maintain some
     statistical independence between individual segments.
 
+    .. versionadded:: 0.16.0
+
     References
     ----------
     ...[1] Oppenheim, Alan V., Ronald W. Schafer, John R. Buck "Discrete-Time
@@ -482,7 +482,7 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
     >>> import matplotlib.pyplot as plt
 
     Generate a test signal, a 2 Vrms sine wave whose frequency linearly changes
-    with time from 1kHz to 2kHz, corrupted by 0.001 V**2/Hz of white noise 
+    with time from 1kHz to 2kHz, corrupted by 0.001 V**2/Hz of white noise
     sampled at 10 kHz.
 
     >>> fs = 10e3
@@ -530,8 +530,7 @@ def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
     y : array_like
         Time series of measurement values
     fs : float, optional
-        Sampling frequency of the `x` and `y` time series in units of Hz.
-        Defaults to 1.0.
+        Sampling frequency of the `x` and `y` time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
@@ -551,7 +550,7 @@ def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
         function, it takes a segment and returns a detrended segment.
         If `detrend` is False, no detrending is done.  Defaults to 'constant'.
     axis : int, optional
-        Axis along which the CSD is computed for both inputs; the default is
+        Axis along which the coherence is computed for both inputs; the default is
         over the last axis (i.e. ``axis=-1``).
 
     Returns
@@ -575,6 +574,8 @@ def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
     overlap of 50\% is a reasonable trade off between accurately estimating
     the signal power, while not over counting any of the data.  Narrower
     windows may require a larger overlap.
+
+    .. versionadded:: 0.16.0
 
     References
     ----------
@@ -644,8 +645,7 @@ def _spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
         the same object in memoery as x (i.e. _spectral_helper(x, x, ...)),
         the extra computations are spared.
     fs : float, optional
-        Sampling frequency of the time series in units of Hz. Defaults
-        to 1.0.
+        Sampling frequency of the time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
@@ -669,10 +669,10 @@ def _spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
         a two-sided spectrum. Note that for complex data, a two-sided
         spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
-        Selects between computing the power spectral density ('density')
-        where Pxx has units of V**2/Hz if x is measured in V and computing
-        the power spectrum ('spectrum') where Pxx has units of V**2 if x is
-        measured in V. Defaults to 'density'.
+        Selects between computing the cross spectral density ('density')
+        where `Pxy` has units of V**2/Hz and computing the cross spectrum
+        ('spectrum') where `Pxy` has units of V**2, if `x` and `y` are
+        measured in V and fs is measured in Hz.  Defaults to 'density'
     axis : int, optional
         Axis along which the periodogram is computed; the default is over
         the last axis (i.e. ``axis=-1``).
@@ -699,6 +699,8 @@ def _spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
     Notes
     -----
     Adapted from matplotlib.mlab
+
+    .. versionadded:: 0.16.0
     '''
     if mode not in ['psd', 'complex', 'magnitude', 'angle', 'phase']:
         raise ValueError("Unknown value for mode %s, must be one of: "
@@ -922,6 +924,8 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft):
     Notes
     -----
     Adapted from matplotlib.mlab
+
+    .. versionadded:: 0.16.0
     '''
     # Created strided array of data segments
     if nperseg == 1 and noverlap == 0:

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -12,7 +12,8 @@ import warnings
 
 from scipy._lib.six import string_types
 
-__all__ = ['periodogram', 'welch', 'lombscargle', 'csd', 'coherence']
+__all__ = ['periodogram', 'welch', 'lombscargle', 'csd', 'coherence',
+           'spectrogram']
 
 
 def periodogram(x, fs=1.0, window=None, nfft=None, detrend='constant',
@@ -396,6 +397,120 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
             Pxy = np.reshape(Pxy, Pxy.shape[:-1])
 
     return freqs, Pxy
+
+
+def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
+                nfft=None, detrend='constant', return_onesided=True,
+                scaling='density', axis=-1):
+    """
+    Compute a spectrogram with consecutive Fourier transforms.
+
+    Spectrograms can be used as a way of visualizing the change of a
+    nonstationary signal's frequency content over time.
+
+    Parameters
+    ----------
+    x : array_like
+        Time series of measurement values
+    fs : float, optional
+        Sampling frequency of the `x` time series in units of Hz. Defaults
+        to 1.0.
+    window : str or tuple or array_like, optional
+        Desired window to use. See `get_window` for a list of windows and
+        required parameters. If `window` is array_like it will be used
+        directly as the window and its length will be used for nperseg.
+        Defaults to a Tukey window with shape parameter of 0.25.
+    nperseg : int, optional
+        Length of each segment.  Defaults to 256.
+    noverlap : int, optional
+        Number of points to overlap between segments. If None,
+        ``noverlap = nperseg // 8``.  Defaults to None.
+    nfft : int, optional
+        Length of the FFT used, if a zero padded FFT is desired.  If None,
+        the FFT length is `nperseg`. Defaults to None.
+    detrend : str or function or False, optional
+        Specifies how to detrend each segment. If `detrend` is a string,
+        it is passed as the ``type`` argument to `detrend`.  If it is a
+        function, it takes a segment and returns a detrended segment.
+        If `detrend` is False, no detrending is done.  Defaults to 'constant'.
+    return_onesided : bool, optional
+        If True, return a one-sided spectrum for real data. If False return
+        a two-sided spectrum. Note that for complex data, a two-sided
+        spectrum is always returned.
+    scaling : { 'density', 'spectrum' }, optional
+        Selects between computing the power spectral density ('density')
+        where Sxx has units of ``V**2/Hz`` if x is measured in V and computing
+        the power spectrum ('spectrum') where Sxx has units of ``V**2`` if x is
+        measured in V. Defaults to 'density'.
+    axis : int, optional
+        Axis along which the spectrogram is computed; the default is over
+        the last axis (i.e. ``axis=-1``).
+
+    Returns
+    -------
+    f : ndarray
+        Array of sample frequencies.
+    t : ndarray
+        Array of segment times.
+    Sxx : ndarray
+        Spectrogram of x. By default, the last axis of Sxx corresponds to the
+        segment times.
+
+    See Also
+    --------
+    periodogram: Simple, optionally modified periodogram
+    lombscargle: Lomb-Scargle periodogram for unevenly sampled data
+    welch: Power spectral density by Welch's method.
+    csd: Cross spectral density by Welch's method.
+
+    Notes
+    -----
+    An appropriate amount of overlap will depend on the choice of window
+    and on your requirements. In contrast to welch's method, where the entire
+    data stream is averaged over, one may wish to use a smaller overlap (or
+    perhaps none at all) when computing a spectrogram, to maintain some
+    statistical independence between individual segments.
+
+    References
+    ----------
+    ...[1] Oppenheim, Alan V., Ronald W. Schafer, John R. Buck "Discrete-Time
+           Signal Processing", Prentice Hall, 1999.
+
+    Examples
+    --------
+    >>> from scipy import signal
+    >>> import matplotlib.pyplot as plt
+
+    Generate a test signal, a 2 Vrms sine wave whose frequency linearly changes
+    with time from 1kHz to 2kHz, corrupted by 0.001 V**2/Hz of white noise 
+    sampled at 10 kHz.
+
+    >>> fs = 10e3
+    >>> N = 1e5
+    >>> amp = 2 * np.sqrt(2)
+    >>> noise_power = 0.001 * fs / 2
+    >>> time = np.arange(N) / fs
+    >>> freq = np.linspace(1e3, 2e3, N)
+    >>> x = amp * np.sin(2*np.pi*freq*time)
+    >>> x += np.random.normal(scale=np.sqrt(noise_power), size=time.shape)
+
+    Compute and plot the spectrogram.
+
+    >>> t, f, Sxx = signal.spectrogram(x, fs)
+    >>> plt.pcolormesh(t, f, Sxx)
+    >>> plt.ylabel('Frequency [Hz]')
+    >>> plt.xlabel('Time [sec]')
+    >>> plt.show()
+    """
+    # Less overlap than welch, so samples are more statisically independent
+    if noverlap is None:
+        noverlap = nperseg // 8
+
+    freqs, Pxy, time = _spectral_helper(x, x, fs, window, nperseg, noverlap,
+                                        nfft, detrend, return_onesided, scaling,
+                                        axis, mode='psd')
+
+    return time, freqs, Pxy
 
 
 def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -8,7 +8,8 @@ from numpy.testing import assert_raises, assert_approx_equal, \
                           assert_array_almost_equal_nulp, dec
 from scipy import signal, fftpack
 from scipy._lib._version import NumpyVersion
-from scipy.signal import periodogram, welch, lombscargle, csd, coherence
+from scipy.signal import (periodogram, welch, lombscargle, csd, coherence,
+                          spectrogram)
 
 
 class TestPeriodogram(TestCase):
@@ -767,6 +768,20 @@ class TestCoherence:
         assert_allclose(f, f1)
         assert_allclose(C, C1)
 
+
+class TestSpectrogram:
+    def test_average_all_segments(self):
+        x = np.random.randn(1024)
+
+        fs = 1.0
+        window = ('tukey', 0.25)
+        nperseg = 16
+        noverlap = 2
+
+        f, _, P = spectrogram(x, fs, window, nperseg, noverlap)
+        fw, Pw = welch(x, fs, window, nperseg, noverlap)
+        assert_allclose(f, fw)
+        assert_allclose(np.mean(P, axis=-1), Pw)
 
 class TestLombscargle:
     def test_frequency(self):


### PR DESCRIPTION
Given #4682, a spectrogram function is effectively free; it's just welch
without the averaging. I've added one test to make sure that the average of
the spectrogram segments agrees with the output of welch. Should more
tests be written, given that the only code difference between welch and
spectrogram is the averaging?
