### PR TITLE
MAINT: Fix for future imp module deprecation.

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -57,7 +57,7 @@ sys.path.pop(0)
 import shutil
 import subprocess
 import time
-import imp
+import types
 from argparse import ArgumentParser, REMAINDER
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__)))
@@ -145,7 +145,7 @@ def main(argv):
             sys.argv = extra_argv
             with open(extra_argv[0], 'r') as f:
                 script = f.read()
-            sys.modules['__main__'] = imp.new_module('__main__')
+            sys.modules['__main__'] = types.ModuleType('__main__')
             ns = dict(__name__='__main__',
                       __file__=extra_argv[0])
             exec_(script, ns)

--- a/setup.py
+++ b/setup.py
@@ -102,8 +102,13 @@ def get_version_info():
     elif os.path.exists('scipy/version.py'):
         # must be a source distribution, use existing version file
         # load it as a separate module to not load scipy/__init__.py
-        import imp
-        version = imp.load_source('scipy.version', 'scipy/version.py')
+        if sys.version_info[:2] >= (3, 4):
+            from importlib.machinery import SourceFileLoader
+            loader = SourceFileLoader('scipy.version', 'scipy/version.py')
+            version = loader.load_module()
+        else:
+            import imp
+            version = imp.load_source('scipy.version', 'scipy/version.py')
         GIT_REVISION = version.git_revision
     else:
         GIT_REVISION = "Unknown"


### PR DESCRIPTION
The imp module in Python 3.4 issues a PendingDeprecationWarning on
import.  The fix is to use importlib for Python versions >= 3.4.
