### PR TITLE
BLD: fix issue in linalg ``*lange`` wrappers for g77 builds.

### DIFF
--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -2772,7 +2772,7 @@ function <prefix2>lange(norm,m,n,a,lda,work) result(n2)
     integer intent(hide),depend(a) :: lda = shape(a,0)
     integer intent(hide),depend(a) :: n = shape(a,1)
     <ftype2> dimension(m,n),intent(in) :: a
-    <ftype2> dimension(MAX(m,1)),intent(cache,hide) :: work
+    <ftype2> dimension(m+1),intent(cache,hide) :: work
 end function <prefix2>lange
 
 function <prefix2c>lange(norm,m,n,a,lda,work) result(n2)
@@ -2788,7 +2788,7 @@ function <prefix2c>lange(norm,m,n,a,lda,work) result(n2)
     integer intent(hide),depend(a) :: lda = shape(a,0)
     integer intent(hide),depend(a) :: n = shape(a,1)
     <ftype2c> dimension(m,n),intent(in) :: a
-    <ftype2> dimension(MAX(m,1)),intent(cache,hide) :: work
+    <ftype2> dimension(m+1),intent(cache,hide) :: work
 end function <prefix2c>lange
 
 subroutine <prefix>larfg(n, alpha, x, incx, tau)


### PR DESCRIPTION
Fixes the first issue identified in gh-4829.
