### PR TITLE
BUG: interpolate: BPoly.antiderivative keeps the axis

### DIFF
--- a/scipy/interpolate/_monotone.py
+++ b/scipy/interpolate/_monotone.py
@@ -37,6 +37,7 @@ class PchipInterpolator(BPoly):
     -------
     __call__
     derivative
+    antiderivative
 
     See Also
     --------
@@ -202,15 +203,18 @@ class Akima1DInterpolator(PPoly):
     x : ndarray, shape (m, )
         1-D array of monotonically increasing real values.
     y : ndarray, shape (m, ...)
-        N-D array of real values. The length of *y* along the first axis must
-        be equal to the length of *x*.
+        N-D array of real values. The length of `y` along the first axis must
+        be equal to the length of `x`.
     axis : int, optional
-        Specifies the axis of *y* along which to interpolate. Interpolation
-        defaults to the first axis of *y*.
+        Specifies the axis of `y` along which to interpolate. Interpolation
+        defaults to the first axis of `y`.
 
     Methods
     -------
     __call__
+    derivative
+    antiderivative
+    roots
 
     See Also
     --------

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -747,6 +747,8 @@ class PPoly(_PPolyBase):
         Coefficients of the polynomials. They are reshaped
         to a 3-dimensional array with the last dimension representing
         the trailing dimensions of the original coefficient array.
+    axis : int
+        Interpolation axis.
 
     Methods
     -------
@@ -1067,6 +1069,8 @@ class BPoly(_PPolyBase):
         Coefficients of the polynomials. They are reshaped
         to a 3-dimensional array with the last dimension representing
         the trailing dimensions of the original coefficient array.
+    axis : int
+        Interpolation axis.
 
     Methods
     -------
@@ -1213,7 +1217,7 @@ class BPoly(_PPolyBase):
         # Finally, use the fact that BPs form a partition of unity.
         c2[:,1:] += np.cumsum(c2[k,:], axis=0)[:-1]
 
-        return self.construct_fast(c2, x, self.extrapolate)
+        return self.construct_fast(c2, x, self.extrapolate, axis=self.axis)
 
     def integrate(self, a, b, extrapolate=None):
         """

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -537,6 +537,13 @@ class TestPPolyCommon(TestCase):
                 targ_shape = c_s[:axis] + xp.shape + c_s[2+axis:]
                 assert_equal(res.shape, targ_shape)
 
+                # deriv/antideriv does not drop the axis
+                for p1 in [cls(c, x, axis=axis).derivative(),
+                           cls(c, x, axis=axis).derivative(2),
+                           cls(c, x, axis=axis).antiderivative(),
+                           cls(c, x, axis=axis).antiderivative(2)]:
+                    assert_equal(p1.axis, p.axis)
+
         # c array needs two axes for the coefficients and intervals, so
         # 0 <= axis < c.ndim-1; raise otherwise
         for axis in (-1, 4, 5, 6):

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -79,6 +79,12 @@ def test_deriv_shapes():
     def pchip_deriv2(x, y, axis=0):
         return pchip(x, y, axis).derivative(2)
 
+    def pchip_antideriv(x, y, axis=0):
+        return pchip(x, y, axis).derivative()
+
+    def pchip_antideriv2(x, y, axis=0):
+        return pchip(x, y, axis).derivative(2)
+
     def pchip_deriv_inplace(x, y, axis=0):
         class P(PchipInterpolator):
             def __call__(self, x):
@@ -93,7 +99,7 @@ def test_deriv_shapes():
         return Akima1DInterpolator(x, y, axis).antiderivative()
 
     for ip in [krogh_deriv, pchip_deriv, pchip_deriv2, pchip_deriv_inplace,
-               akima_deriv, akima_antideriv]:
+               pchip_antideriv, pchip_antideriv2, akima_deriv, akima_antideriv]:
         for s1 in SHAPES:
             for s2 in SHAPES:
                 for axis in range(-len(s2), len(s2)):


### PR DESCRIPTION
closes https://github.com/scipy/scipy/issues/4843

Marking it as milestone 0.16 because both BPoly.antiderivative and BPoly.axis were added in 0.16. This PR makes sure that the former is not broken when the latter does not take the default value. 
