### PR TITLE
DOC:Fix error in ode docstring example

### DIFF
--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -319,8 +319,7 @@ class ode(object):
     >>> t1 = 10
     >>> dt = 1
     >>> while r.successful() and r.t < t1:
-    ...     r.integrate(r.t+dt)
-    ...     print("%g %g" % (r.t, r.y))
+    ...     print(r.t, r.integrate(r.t+dt))
 
     References
     ----------


### PR DESCRIPTION
Fixes choking on the string formatting of a complex-valued ndarray in the docstring example for Integrate.ODE.
