### PR TITLE
BUG: scipy.io.mmio.write: error with big indices and low precision

### DIFF
--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -619,21 +619,20 @@ class MMFile (object):
             # write shape spec
             stream.write(asbytes('%i %i %i\n' % (rows, cols, coo.nnz)))
 
+            # make indices and data array
             if field == self.FIELD_PATTERN:
                 IJV = vstack((coo.row, coo.col)).T
-                data_columns = 0
             elif field in [self.FIELD_INTEGER, self.FIELD_REAL]:
                 IJV = vstack((coo.row, coo.col, coo.data)).T
-                data_columns = 1
             elif field == self.FIELD_COMPLEX:
                 IJV = vstack((coo.row, coo.col, coo.data.real, coo.data.imag)).T
-                data_columns = 2
             else:
                 raise TypeError('Unknown field type %s' % field)
-
             IJV[:,:2] += 1  # change base 0 -> base 1
 
-            fmt = ('%i',)*2 + ('%%.%dg' % precision,)*data_columns
+            # formats for row indices, col indices and data columns
+            fmt = ('%i', '%i') + ('%%.%dg' % precision,) * (IJV.shape[1]-2)
+            # save to file
             savetxt(stream, IJV, fmt=fmt)
 
 

--- a/scipy/io/mmio.py
+++ b/scipy/io/mmio.py
@@ -619,19 +619,21 @@ class MMFile (object):
             # write shape spec
             stream.write(asbytes('%i %i %i\n' % (rows, cols, coo.nnz)))
 
-            fmt = '%%.%dg' % precision
-
             if field == self.FIELD_PATTERN:
                 IJV = vstack((coo.row, coo.col)).T
+                data_columns = 0
             elif field in [self.FIELD_INTEGER, self.FIELD_REAL]:
                 IJV = vstack((coo.row, coo.col, coo.data)).T
+                data_columns = 1
             elif field == self.FIELD_COMPLEX:
                 IJV = vstack((coo.row, coo.col, coo.data.real, coo.data.imag)).T
+                data_columns = 2
             else:
                 raise TypeError('Unknown field type %s' % field)
 
             IJV[:,:2] += 1  # change base 0 -> base 1
 
+            fmt = ('%i',)*2 + ('%%.%dg' % precision,)*data_columns
             savetxt(stream, IJV, fmt=fmt)
 
 

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -389,25 +389,17 @@ class TestMMIOCoordinate(TestCase):
 
     def test_precision_indices(self):
         for precision in range(1,5):
-            
-            # construct sparse matrix with one entry at last main diagonal index
+            # construct sparse matrix with 1 as last main diagonal entry
             n = 10**precision + 1
             A = scipy.sparse.lil_matrix((n, n))
             A[n-1, n-1] = 1
-            
             # write matrix with low precision and read again
             mmwrite(self.fn, A, precision=precision)
             A = scipy.io.mmread(self.fn)
-            
-            # check for right number of entries in matrix
-            assert_equal(len(A.row), 1)
-            assert_equal(len(A.col), 1)
-            assert_equal(len(A.data), 1)
-            
-            # check for right entries
-            assert_equal(A.row[0], n-1)
-            assert_equal(A.col[0], n-1)
-            assert_equal(A.data[0], 1)
+            # check for right entries in matrix
+            assert_array_equal(A.row, [n-1])
+            assert_array_equal(A.col, [n-1])
+            assert_array_equal(A.data, [1])
 
 
 if __name__ == "__main__":

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -5,8 +5,8 @@ from tempfile import mkdtemp, mktemp
 import os
 import shutil
 from numpy import array,transpose
-from numpy.testing import TestCase, run_module_suite, assert_array_almost_equal, \
-            assert_equal, rand
+from numpy.testing import TestCase, run_module_suite, assert_equal,\
+    assert_array_equal, assert_array_almost_equal, rand
 
 import scipy.sparse
 from scipy.io.mmio import mminfo,mmread,mmwrite

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -388,18 +388,22 @@ class TestMMIOCoordinate(TestCase):
                 assert_array_almost_equal(result, expected)
 
     def test_precision(self):
-        for precision in range(1, 8):
-            # construct sparse matrix with pi as last main diagonal entry
-            n = 10**precision + 1
-            A = scipy.sparse.lil_matrix((n, n))
-            A[n-1, n-1] = pi
-            # write matrix with low precision and read again
-            mmwrite(self.fn, A, precision=precision)
-            A = scipy.io.mmread(self.fn)
-            # check for right entries in matrix
-            assert_array_equal(A.row, [n-1])
-            assert_array_equal(A.col, [n-1])
-            assert_array_almost_equal(A.data, [pi], decimal=precision-1)
+        test_values = [pi] + [10**(i) for i in range(0, -10, -1)]
+        test_precisions = range(1, 10)
+        for value in test_values:
+            for precision in test_precisions:
+                # construct sparse matrix with test value at last main diagonal
+                n = 10**precision + 1
+                A = scipy.sparse.lil_matrix((n, n))
+                A[n-1, n-1] = value
+                # write matrix with test precision and read again
+                mmwrite(self.fn, A, precision=precision)
+                A = scipy.io.mmread(self.fn)
+                # check for right entries in matrix
+                assert_array_equal(A.row, [n-1])
+                assert_array_equal(A.col, [n-1])
+                assert_array_almost_equal(A.data, 
+                    [float('%%.%dg' % precision % value)])
 
 
 if __name__ == "__main__":

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -4,7 +4,7 @@ from __future__ import division, print_function, absolute_import
 from tempfile import mkdtemp, mktemp
 import os
 import shutil
-from numpy import array,transpose
+from numpy import array,transpose, pi
 from numpy.testing import (TestCase, run_module_suite, assert_equal,
     assert_array_equal, assert_array_almost_equal, rand)
 
@@ -392,14 +392,14 @@ class TestMMIOCoordinate(TestCase):
             # construct sparse matrix with pi as last main diagonal entry
             n = 10**precision + 1
             A = scipy.sparse.lil_matrix((n, n))
-            A[n-1, n-1] = np.pi
+            A[n-1, n-1] = pi
             # write matrix with low precision and read again
             mmwrite(self.fn, A, precision=precision)
             A = scipy.io.mmread(self.fn)
             # check for right entries in matrix
             assert_array_equal(A.row, [n-1])
             assert_array_equal(A.col, [n-1])
-            assert_array_almost_equa(A.data, [np.pi], decimal=precision-1)
+            assert_array_almost_equa(A.data, [pi], decimal=precision-1)
 
 
 if __name__ == "__main__":

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -394,7 +394,7 @@ class TestMMIOCoordinate(TestCase):
             for precision in test_precisions:
                 # construct sparse matrix with test value at last main diagonal
                 n = 10**precision + 1
-                A = scipy.sparse.lil_matrix((n, n))
+                A = scipy.sparse.dok_matrix((n, n))
                 A[n-1, n-1] = value
                 # write matrix with test precision and read again
                 mmwrite(self.fn, A, precision=precision)
@@ -402,7 +402,7 @@ class TestMMIOCoordinate(TestCase):
                 # check for right entries in matrix
                 assert_array_equal(A.row, [n-1])
                 assert_array_equal(A.col, [n-1])
-                assert_array_almost_equal(A.data, 
+                assert_array_almost_equal(A.data,
                     [float('%%.%dg' % precision % value)])
 
 

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -399,7 +399,7 @@ class TestMMIOCoordinate(TestCase):
             # check for right entries in matrix
             assert_array_equal(A.row, [n-1])
             assert_array_equal(A.col, [n-1])
-            assert_array_almost_equa(A.data, [pi], decimal=precision-1)
+            assert_array_almost_equal(A.data, [pi], decimal=precision-1)
 
 
 if __name__ == "__main__":

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -387,6 +387,28 @@ class TestMMIOCoordinate(TestCase):
                 result = mmread(fn).todense()
                 assert_array_almost_equal(result, expected)
 
+    def test_precision_indices(self):
+        for precision in range(1,5):
+            
+            # construct sparse matrix with one entry at last main diagonal index
+            n = 10**precision + 1
+            A = scipy.sparse.lil_matrix((n, n))
+            A[n-1, n-1] = 1
+            
+            # write matrix with low precision and read again
+            mmwrite(self.fn, A, precision=precision)
+            A = scipy.io.mmread(self.fn)
+            
+            # check for right number of entries in matrix
+            assert_equal(len(A.row), 1)
+            assert_equal(len(A.col), 1)
+            assert_equal(len(A.data), 1)
+            
+            # check for right entries
+            assert_equal(A.row[0], n-1)
+            assert_equal(A.col[0], n-1)
+            assert_equal(A.data[0], 1)
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -5,8 +5,8 @@ from tempfile import mkdtemp, mktemp
 import os
 import shutil
 from numpy import array,transpose
-from numpy.testing import TestCase, run_module_suite, assert_equal,\
-    assert_array_equal, assert_array_almost_equal, rand
+from numpy.testing import (TestCase, run_module_suite, assert_equal,
+    assert_array_equal, assert_array_almost_equal, rand)
 
 import scipy.sparse
 from scipy.io.mmio import mminfo,mmread,mmwrite
@@ -387,19 +387,19 @@ class TestMMIOCoordinate(TestCase):
                 result = mmread(fn).todense()
                 assert_array_almost_equal(result, expected)
 
-    def test_precision_indices(self):
-        for precision in range(1,5):
-            # construct sparse matrix with 1 as last main diagonal entry
+    def test_precision(self):
+        for precision in range(1, 8):
+            # construct sparse matrix with pi as last main diagonal entry
             n = 10**precision + 1
             A = scipy.sparse.lil_matrix((n, n))
-            A[n-1, n-1] = 1
+            A[n-1, n-1] = np.pi
             # write matrix with low precision and read again
             mmwrite(self.fn, A, precision=precision)
             A = scipy.io.mmread(self.fn)
             # check for right entries in matrix
             assert_array_equal(A.row, [n-1])
             assert_array_equal(A.col, [n-1])
-            assert_array_equal(A.data, [1])
+            assert_array_almost_equa(A.data, [np.pi], decimal=precision-1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`scipy.io.mmio.write` does not work correctly if indices are greater than 10**precision. A test which demonstrates the problem is added together with a fix. Here, formatting with the precision is only applied to the data not to the indices.
