### PR TITLE
add as_inexact option to _lib._util._asarray_validated

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -141,6 +141,6 @@ def _asarray_validated(a, check_finite=True,
             raise ValueError('object arrays are not supported')
     if as_inexact:
         if not np.issubdtype(a.dtype, np.inexact):
-            a = toarray(x, dtype=np.float_)
+            a = toarray(a, dtype=np.float_)
     return a
 

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -141,6 +141,10 @@ def _asarray_validated(a, check_finite=True,
             raise ValueError('object arrays are not supported')
     if as_inexact:
         if not np.issubdtype(a.dtype, np.inexact):
-            a = toarray(a, dtype=np.float_)
+            try:
+                a = toarray(a, dtype=np.float_)
+            except TypeError:
+                # for compatibility with numpy 1.6
+                a = toarray(a).astype(np.float_)
     return a
 

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -90,7 +90,8 @@ def check_random_state(seed):
 
 
 def _asarray_validated(a, check_finite=True,
-                       sparse_ok=False, objects_ok=False, mask_ok=False):
+                       sparse_ok=False, objects_ok=False, mask_ok=False,
+                       as_inexact=False):
     """
     Helper function for scipy argument validation.
 
@@ -114,6 +115,8 @@ def _asarray_validated(a, check_finite=True,
         True if arrays with dype('O') are allowed.
     mask_ok : bool, optional
         True if masked arrays are allowed.
+    as_inexact : bool, optional
+        True to convert the input array to a np.inexact dtype.
 
     Returns
     -------
@@ -131,12 +134,13 @@ def _asarray_validated(a, check_finite=True,
     if not mask_ok:
         if np.ma.isMaskedArray(a):
             raise ValueError('masked arrays are not supported')
-    if check_finite:
-        a = np.asarray_chkfinite(a)
-    else:
-        a = np.asarray(a)
+    toarray = np.asarray_chkfinite if check_finite else np.asarray
+    a = toarray(a)
     if not objects_ok:
         if a.dtype is np.dtype('O'):
             raise ValueError('object arrays are not supported')
+    if as_inexact:
+        if not np.issubdtype(a.dtype, np.inexact):
+            a = toarray(x, dtype=np.float_)
     return a
 

--- a/scipy/interpolate/_monotone.py
+++ b/scipy/interpolate/_monotone.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from . import BPoly, PPoly
 from .polyint import _isscalar
+from scipy._lib import _asarray_validated
 
 
 __all__ = ["PchipInterpolator", "pchip_interpolate", "pchip",
@@ -64,13 +65,8 @@ class PchipInterpolator(BPoly):
 
     """
     def __init__(self, x, y, axis=0, extrapolate=None):
-        x = np.asarray(x)
-        if not np.issubdtype(x.dtype, np.inexact):
-            x = x.astype(float)
-
-        y = np.asarray(y)
-        if not np.issubdtype(y.dtype, np.inexact):
-            y = y.astype(float)
+        x = _asarray_validated(x, check_finite=False, as_inexact=True)
+        y = _asarray_validated(y, check_finite=False, as_inexact=True)
 
         axis = axis % y.ndim
 

--- a/scipy/interpolate/_monotone.py
+++ b/scipy/interpolate/_monotone.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from . import BPoly, PPoly
 from .polyint import _isscalar
-from scipy._lib import _asarray_validated
+from scipy._lib._util import _asarray_validated
 
 
 __all__ = ["PchipInterpolator", "pchip_interpolate", "pchip",

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -6,7 +6,7 @@ import numpy as np
 from scipy.special import factorial
 
 from scipy._lib.six import xrange
-from scipy._lib import _asarray_validated
+from scipy._lib._util import _asarray_validated
 
 
 __all__ = ["KroghInterpolator", "krogh_interpolate", "BarycentricInterpolator",

--- a/scipy/interpolate/polyint.py
+++ b/scipy/interpolate/polyint.py
@@ -6,6 +6,7 @@ import numpy as np
 from scipy.special import factorial
 
 from scipy._lib.six import xrange
+from scipy._lib import _asarray_validated
 
 
 __all__ = ["KroghInterpolator", "krogh_interpolate", "BarycentricInterpolator",
@@ -87,10 +88,7 @@ class _Interpolator1D(object):
 
     def _prepare_x(self, x):
         """Reshape input x array to 1-D"""
-        x = np.asarray(x)
-        if not np.issubdtype(x.dtype, np.inexact):
-            # Cast integers etc to floats
-            x = x.astype(float)
+        x = _asarray_validated(x, check_finite=False, as_inexact=True)
         x_shape = x.shape
         return x.ravel(), x_shape
 

--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -10,7 +10,7 @@ __all__ = ['sqrtm']
 
 import numpy as np
 
-from scipy._lib import _asarray_validated
+from scipy._lib._util import _asarray_validated
 
 
 # Local imports

--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -10,6 +10,8 @@ __all__ = ['sqrtm']
 
 import numpy as np
 
+from scipy._lib import _asarray_validated
+
 
 # Local imports
 from .misc import norm
@@ -154,7 +156,7 @@ def sqrtm(A, disp=True, blocksize=64):
            [ 1.,  4.]])
 
     """
-    A = np.asarray(A)
+    A = _asarray_validated(A, check_finite=True, as_inexact=True)
     if len(A.shape) != 2:
         raise ValueError("Non-matrix input to matrix function.")
     if blocksize < 1:

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -338,29 +338,31 @@ class TestSqrtM(TestCase):
 
     def test_strict_upper_triangular(self):
         # This matrix has no square root.
-        A = np.array([
-            [0, 3, 0, 0],
-            [0, 0, 3, 0],
-            [0, 0, 0, 3],
-            [0, 0, 0, 0]], dtype=float)
-        A_sqrtm, info = sqrtm(A, disp=False)
-        assert_(np.isnan(A_sqrtm).all())
+        for dt in int, float:
+            A = np.array([
+                [0, 3, 0, 0],
+                [0, 0, 3, 0],
+                [0, 0, 0, 3],
+                [0, 0, 0, 0]], dtype=dt)
+            A_sqrtm, info = sqrtm(A, disp=False)
+            assert_(np.isnan(A_sqrtm).all())
 
     def test_weird_matrix(self):
         # The square root of matrix B exists.
-        A = np.array([
-            [0, 0, 1],
-            [0, 0, 0],
-            [0, 1, 0]], dtype=float)
-        B = np.array([
-            [0, 1, 0],
-            [0, 0, 0],
-            [0, 0, 0]], dtype=float)
-        assert_array_equal(B, A.dot(A))
+        for dt in int, float:
+            A = np.array([
+                [0, 0, 1],
+                [0, 0, 0],
+                [0, 1, 0]], dtype=dt)
+            B = np.array([
+                [0, 1, 0],
+                [0, 0, 0],
+                [0, 0, 0]], dtype=dt)
+            assert_array_equal(B, A.dot(A))
 
-        # But scipy sqrtm is not clever enough to find it.
-        B_sqrtm, info = sqrtm(B, disp=False)
-        assert_(np.isnan(B_sqrtm).all())
+            # But scipy sqrtm is not clever enough to find it.
+            B_sqrtm, info = sqrtm(B, disp=False)
+            assert_(np.isnan(B_sqrtm).all())
 
     def test_disp(self):
         from io import StringIO

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -6,13 +6,9 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from scipy.sparse import issparse
 
-from numpy.core import (
-    array, asarray, zeros, empty, empty_like, transpose, intc, single, double,
-    csingle, cdouble, inexact, complexfloating, newaxis, ravel, all, Inf, dot,
-    add, multiply, sqrt, maximum, fastCopyAndTranspose, sum, isfinite, size,
-    finfo, errstate, geterrobj, longdouble, rollaxis, amin, amax, product, abs,
-    broadcast
-    )
+from numpy.core import Inf, sqrt, abs
+
+__all__ = ['norm']
 
 
 def norm(x, ord=None):


### PR DESCRIPTION
In general, SciPy linear algebra functions prefer input arrays that don't contain NaNs, that are not object arrays or masked arrays, and that are dense (not sparse).  Currently `_asarray_validated` checks all of those properties.  This PR adds the additional option to convert the input array to a dtype that is more palatable to BLAS/LAPACK functions, and it should address one of the complaints in https://github.com/scipy/scipy/issues/4866.
