### PR TITLE
FIX: Clean warnings

### DIFF
--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -161,7 +161,8 @@ class TestLSQBivariateSpline(TestCase):
         s = 0.1
         tx = [1+s,3-s]
         ty = [1+s,3-s]
-        lut = LSQBivariateSpline(x,y,z,tx,ty,kx=1,ky=1)
+        with warnings.catch_warnings(record=True):  # coefficients of the ...
+            lut = LSQBivariateSpline(x,y,z,tx,ty,kx=1,ky=1)
 
         assert_almost_equal(lut(2,2), 3.)
 
@@ -198,14 +199,15 @@ class TestLSQBivariateSpline(TestCase):
         s = 0.1
         tx = [1+s,3-s]
         ty = [1+s,3-s]
-        lut = LSQBivariateSpline(x,y,z,tx,ty,kx=1,ky=1)
+        with warnings.catch_warnings(record=True):  # coefficients of the ...
+            lut = LSQBivariateSpline(x,y,z,tx,ty,kx=1,ky=1)
         tx, ty = lut.get_knots()
-
         tz = lut(tx, ty)
         trpz = .25*(diff(tx)[:,None]*diff(ty)[None,:]
                     * (tz[:-1,:-1]+tz[1:,:-1]+tz[:-1,1:]+tz[1:,1:])).sum()
 
-        assert_almost_equal(lut.integral(tx[0], tx[-1], ty[0], ty[-1]), trpz)
+        assert_almost_equal(lut.integral(tx[0], tx[-1], ty[0], ty[-1]),
+                            trpz)
 
     def test_empty_input(self):
         # Test whether empty inputs returns an empty output. Ticket 1014
@@ -215,7 +217,8 @@ class TestLSQBivariateSpline(TestCase):
         s = 0.1
         tx = [1+s,3-s]
         ty = [1+s,3-s]
-        lut = LSQBivariateSpline(x,y,z,tx,ty,kx=1,ky=1)
+        with warnings.catch_warnings(record=True):  # coefficients of the ...
+            lut = LSQBivariateSpline(x,y,z,tx,ty,kx=1,ky=1)
 
         assert_array_equal(lut([], []), np.zeros((0,0)))
         assert_array_equal(lut([], [], grid=False), np.zeros((0,)))

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -430,19 +430,19 @@ class CheckPiecewise(TestCase):
             warnings.filterwarnings('ignore', category=DeprecationWarning)
             P = PiecewisePolynomial(self.xi,self.yi)
 
-        assert_almost_equal(P(self.test_xs),
-                            piecewise_polynomial_interpolate(self.xi, self.yi,
-                                                             self.test_xs))
-        assert_almost_equal(P.derivative(self.test_xs,2),
-                            piecewise_polynomial_interpolate(self.xi,
-                                                             self.yi,
-                                                             self.test_xs,
-                                                             der=2))
-        assert_almost_equal(P.derivatives(self.test_xs,2),
-                            piecewise_polynomial_interpolate(self.xi,
-                                                             self.yi,
-                                                             self.test_xs,
-                                                             der=[0,1]))
+            assert_almost_equal(P(self.test_xs),
+                                piecewise_polynomial_interpolate(
+                                    self.xi, self.yi, self.test_xs))
+            assert_almost_equal(P.derivative(self.test_xs,2),
+                                piecewise_polynomial_interpolate(self.xi,
+                                                                 self.yi,
+                                                                 self.test_xs,
+                                                                 der=2))
+            assert_almost_equal(P.derivatives(self.test_xs,2),
+                                piecewise_polynomial_interpolate(self.xi,
+                                                                 self.yi,
+                                                                 self.test_xs,
+                                                                 der=[0,1]))
 
 
 class TestPCHIP(TestCase):

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1198,22 +1198,24 @@ def test_empty_mat_error():
 def test_miuint32_compromise():
     # Reader should accept miUINT32 for miINT32, but check signs
     # mat file with miUINT32 for miINT32, but OK values
-    filename = pjoin(test_data_path,'miuint32_for_miint32.mat')
+    filename = pjoin(test_data_path, 'miuint32_for_miint32.mat')
     res = loadmat(filename)
     assert_equal(res['an_array'], np.arange(10)[None, :])
     # mat file with miUINT32 for miINT32, with negative value
     filename = pjoin(test_data_path, 'bad_miuint32.mat')
-    assert_raises(ValueError, loadmat, filename)
+    with warnings.catch_warnings(record=True):  # Py3k ResourceWarning
+        assert_raises(ValueError, loadmat, filename)
 
 
 def test_miutf8_for_miint8_compromise():
     # Check reader accepts ascii as miUTF8 for array names
-    filename = pjoin(test_data_path,'miutf8_array_name.mat')
+    filename = pjoin(test_data_path, 'miutf8_array_name.mat')
     res = loadmat(filename)
     assert_equal(res['array_name'], [[1]])
     # mat file with non-ascii utf8 name raises error
     filename = pjoin(test_data_path, 'bad_miutf8_array_name.mat')
-    assert_raises(ValueError, loadmat, filename)
+    with warnings.catch_warnings(record=True):  # Py3k ResourceWarning
+        assert_raises(ValueError, loadmat, filename)
 
 
 def test_bad_utf8():

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -4,6 +4,7 @@ import os.path
 import tempfile
 import shutil
 import numpy as np
+import warnings
 
 from numpy.testing import (assert_, assert_equal, dec, decorate_methods,
                            TestCase, run_module_suite, assert_allclose)
@@ -68,16 +69,19 @@ class TestPILUtil(TestCase):
         assert_equal(misc.bytescale(np.array([3, 3, 3]), low=4), [4, 4, 4])
 
     def test_imsave(self):
-        img = misc.imread(os.path.join(datapath, 'data', 'icon.png'))
+        with warnings.catch_warnings(record=True):  # PIL ResourceWarning
+            img = misc.imread(os.path.join(datapath, 'data', 'icon.png'))
         tmpdir = tempfile.mkdtemp()
         try:
             fn1 = os.path.join(tmpdir, 'test.png')
             fn2 = os.path.join(tmpdir, 'testimg')
-            misc.imsave(fn1, img)
-            misc.imsave(fn2, img, 'PNG')
+            with warnings.catch_warnings(record=True):  # PIL ResourceWarning
+                misc.imsave(fn1, img)
+                misc.imsave(fn2, img, 'PNG')
 
-            data1 = misc.imread(fn1)
-            data2 = misc.imread(fn2)
+            with warnings.catch_warnings(record=True):  # PIL ResourceWarning
+                data1 = misc.imread(fn1)
+                data2 = misc.imread(fn2)
 
             assert_allclose(data1, img)
             assert_allclose(data2, img)

--- a/scipy/ndimage/tests/test_io.py
+++ b/scipy/ndimage/tests/test_io.py
@@ -4,6 +4,7 @@ from numpy.testing import assert_array_equal, dec, run_module_suite
 import scipy.ndimage as ndi
 
 import os
+import warnings
 
 try:
     from PIL import Image
@@ -15,12 +16,14 @@ except ImportError:
 @dec.skipif(pil_missing, msg="The Python Image Library could not be found.")
 def test_imread():
     lp = os.path.join(os.path.dirname(__file__), 'dots.png')
-    img = ndi.imread(lp, mode="RGB")
+    with warnings.catch_warnings(record=True):  # Py3k ResourceWarning
+        img = ndi.imread(lp, mode="RGB")
     assert_array_equal(img.shape, (300, 420, 3))
 
-    img = ndi.imread(lp, flatten=True)
+    with warnings.catch_warnings(record=True):  # PIL ResourceWarning
+        img = ndi.imread(lp, flatten=True)
     assert_array_equal(img.shape, (300, 420))
-    
+
     with open(lp, 'rb') as fobj:
         img = ndi.imread(fobj, mode="RGB")
         assert_array_equal(img.shape, (300, 420, 3))

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -948,7 +948,7 @@ class TestBrute:
 
         # test minimize
         resbrute = optimize.brute(self.func, self.rranges, args=self.params,
-                                  disp=True, full_output=True,
+                                  full_output=True,
                                   finish=optimize.minimize)
         assert_allclose(resbrute[0], self.solution, atol=1e-3)
         assert_allclose(resbrute[1], self.func(self.solution, *self.params),

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -1048,8 +1048,8 @@ class Test_bode(object):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", BadCoefficients)
             system = lti(A, B, C, D)
-
             w, mag, phase = bode(system, n=100)
+
         expected_magnitude = 20 * np.log10(np.sqrt(1.0 / (1.0 + w**6)))
         assert_almost_equal(mag, expected_magnitude)
 

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -1042,14 +1042,14 @@ class Test_bode(object):
         # frequency response.
         a = np.array([1.0, 2.0, 2.0, 1.0])
         A = linalg.companion(a).T
-        B = np.array([[0.0],[0.0],[1.0]])
+        B = np.array([[0.0], [0.0], [1.0]])
         C = np.array([[1.0, 0.0, 0.0]])
         D = np.array([[0.0]])
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", BadCoefficients)
             system = lti(A, B, C, D)
 
-        w, mag, phase = bode(system, n=100)
+            w, mag, phase = bode(system, n=100)
         expected_magnitude = 20 * np.log10(np.sqrt(1.0 / (1.0 + w**6)))
         assert_almost_equal(mag, expected_magnitude)
 
@@ -1134,8 +1134,7 @@ class Test_freqresp(object):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", BadCoefficients)
             system = lti(A, B, C, D)
-
-        w, H = freqresp(system, n=100)
+            w, H = freqresp(system, n=100)
         expected_magnitude = np.sqrt(1.0 / (1.0 + w**6))
         assert_almost_equal(np.abs(H), expected_magnitude)
 

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -205,12 +205,13 @@ class TestGetWindow(object):
 def test_windowfunc_basics():
     for window_name, params in window_funcs:
         window = getattr(signal, window_name)
-        w1 = window(7, *params, sym=True)
-        w2 = window(7, *params, sym=False)
-        assert_array_almost_equal(w1, w2)
-        # just check the below runs
-        window(6, *params, sym=True)
-        window(6, *params, sym=False)
+        with warnings.catch_warnings(record=True):  # window is not suitable...
+            w1 = window(7, *params, sym=True)
+            w2 = window(7, *params, sym=False)
+            assert_array_almost_equal(w1, w2)
+            # just check the below runs
+            window(6, *params, sym=True)
+            window(6, *params, sym=False)
 
 
 def test_needs_params():

--- a/scipy/special/tests/test_ellip_harm.py
+++ b/scipy/special/tests/test_ellip_harm.py
@@ -8,15 +8,14 @@ from __future__ import division, print_function, absolute_import
 import warnings
 
 import numpy as np
-from numpy.testing import assert_equal, assert_almost_equal, assert_allclose,\
- assert_
+from numpy.testing import (assert_equal, assert_almost_equal, assert_allclose,
+                           assert_, run_module_suite)
 from scipy.special._testutils import assert_func_equal
 from scipy.special import ellip_harm, ellip_harm_2, ellip_normal
-from scipy.integrate import quad, IntegrationWarning
-from numpy import array, sqrt, pi
-from scipy.special._testutils import FuncData
+from scipy.integrate import IntegrationWarning
+from numpy import sqrt, pi
 
-    
+
 def test_ellip_potential():
     def change_coefficient(lambda1, mu, nu, h2, k2):
         x = sqrt(lambda1**2*mu**2*nu**2/(h2*k2))
@@ -163,7 +162,7 @@ def test_ellip_norm():
         for p in range(1, 2*n+2):
             points.append((h2, k2, n*np.ones(h2.size), p*np.ones(h2.size)))
     points = np.array(points)
-    with warnings.catch_warnings(record=True):  # occerrence of roundoff ...
+    with warnings.catch_warnings(record=True):  # occurrence of roundoff ...
         assert_func_equal(ellip_normal, ellip_normal_known, points, rtol=1e-12)
 
 
@@ -269,3 +268,7 @@ def test_ellip_harm():
                 points.append((h2[i], k2[i], n, p, s[i]))
     points = np.array(points)
     assert_func_equal(ellip_harm, ellip_harm_known, points, rtol=1e-12)
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/scipy/special/tests/test_ellip_harm.py
+++ b/scipy/special/tests/test_ellip_harm.py
@@ -163,7 +163,9 @@ def test_ellip_norm():
         for p in range(1, 2*n+2):
             points.append((h2, k2, n*np.ones(h2.size), p*np.ones(h2.size)))
     points = np.array(points)
-    assert_func_equal(ellip_normal, ellip_normal_known, points, rtol=1e-12)
+    with warnings.catch_warnings(record=True):  # occerrence of roundoff ...
+        assert_func_equal(ellip_normal, ellip_normal_known, points, rtol=1e-12)
+
 
 def test_ellip_harm_2():
 
@@ -173,14 +175,16 @@ def test_ellip_harm_2():
         ellip_harm_2(h2, k2, 1, 3, s)/(3 * ellip_harm(h2, k2, 1, 3, s)))
         return res
 
-    assert_almost_equal(I1(5, 8, 10), 1/(10*sqrt((100-5)*(100-8))))
+    with warnings.catch_warnings(record=True):  # occurrence of roundoff ...
+        assert_almost_equal(I1(5, 8, 10), 1/(10*sqrt((100-5)*(100-8))))
 
-    # Values produced by code from arXiv:1204.0267
-    assert_almost_equal(ellip_harm_2(5, 8, 2, 1, 10), 0.00108056853382)
-    assert_almost_equal(ellip_harm_2(5, 8, 2, 2, 10), 0.00105820513809)
-    assert_almost_equal(ellip_harm_2(5, 8, 2, 3, 10), 0.00106058384743)
-    assert_almost_equal(ellip_harm_2(5, 8, 2, 4, 10), 0.00106774492306)
-    assert_almost_equal(ellip_harm_2(5, 8, 2, 5, 10), 0.00107976356454)
+        # Values produced by code from arXiv:1204.0267
+        assert_almost_equal(ellip_harm_2(5, 8, 2, 1, 10), 0.00108056853382)
+        assert_almost_equal(ellip_harm_2(5, 8, 2, 2, 10), 0.00105820513809)
+        assert_almost_equal(ellip_harm_2(5, 8, 2, 3, 10), 0.00106058384743)
+        assert_almost_equal(ellip_harm_2(5, 8, 2, 4, 10), 0.00106774492306)
+        assert_almost_equal(ellip_harm_2(5, 8, 2, 5, 10), 0.00107976356454)
+
 
 def test_ellip_harm():
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -240,7 +240,8 @@ class TestAnsari(TestCase):
     def test_small(self):
         x = [1,2,3,3,4]
         y = [3,2,6,1,6,1,4,1]
-        W, pval = stats.ansari(x,y)
+        with warnings.catch_warnings(record=True):  # Ties preclude use ...
+            W, pval = stats.ansari(x,y)
         assert_almost_equal(W,23.5,11)
         assert_almost_equal(pval,0.13499256881897437,11)
 
@@ -270,7 +271,8 @@ class TestAnsari(TestCase):
     def test_result_attributes(self):
         x = [1, 2, 3, 3, 4]
         y = [3, 2, 6, 1, 6, 1, 4, 1]
-        res = stats.ansari(x, y)
+        with warnings.catch_warnings(record=True):  # Ties preclude use ...
+            res = stats.ansari(x, y)
         attributes = ('statistic', 'pvalue')
         check_named_results(res, attributes)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -172,12 +172,16 @@ class TestNanFunc(TestCase):
         assert_(np.isnan(s))
 
     def test_nanstd_bias_kw(self):
-        s = stats.nanstd(self.X, bias=True)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=DeprecationWarning)
+            s = stats.nanstd(self.X, bias=True)
         assert_approx_equal(s, np.std(self.X, ddof=0))
 
     def test_nanstd_negative_axis(self):
         x = np.array([1, 2, 3])
-        res = stats.nanstd(x, -1)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=DeprecationWarning)
+            res = stats.nanstd(x, -1)
         assert_equal(res, 1)
 
     def test_nanmedian_none(self):
@@ -226,6 +230,7 @@ class TestNanFunc(TestCase):
         # Check nanmedian for scalar inputs. See ticket #1098.
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', category=RuntimeWarning)
+            warnings.filterwarnings('ignore', category=DeprecationWarning)
             assert_equal(stats.nanmedian(1), np.median(1))
             assert_equal(stats.nanmedian(True), np.median(True))
             assert_equal(stats.nanmedian(np.array(1)), np.median(np.array(1)))
@@ -1899,7 +1904,6 @@ def test_chisquare_masked_arrays():
     mat.assert_array_almost_equal(p,
                                   stats.chisqprob(expected_chisq,
                                                   mobs.T.count(axis=1) - 1))
-
     g, p = stats.power_divergence(mobs.T, axis=1, lambda_="log-likelihood")
     mat.assert_array_almost_equal(g, expected_g, decimal=15)
     mat.assert_array_almost_equal(p, stats.chisqprob(expected_g,
@@ -1923,7 +1927,8 @@ def test_chisquare_masked_arrays():
     # Empty arrays:
     # A data set with length 0 returns a masked scalar.
     with np.errstate(invalid='ignore'):
-        chisq, p = stats.chisquare(np.ma.array([]))
+        with warnings.catch_warnings(record=True):
+            chisq, p = stats.chisquare(np.ma.array([]))
     assert_(isinstance(chisq, np.ma.MaskedArray))
     assert_equal(chisq.shape, ())
     assert_(chisq.mask)
@@ -1939,7 +1944,8 @@ def test_chisquare_masked_arrays():
     # empty3.T is an array containing 3 data sets, each with length 0,
     # so an array of size (3,) is returned, with all values masked.
     with np.errstate(invalid='ignore'):
-        chisq, p = stats.chisquare(empty3.T)
+        with warnings.catch_warnings(record=True):
+            chisq, p = stats.chisquare(empty3.T)
     assert_(isinstance(chisq, np.ma.MaskedArray))
     assert_equal(chisq.shape, (3,))
     assert_(np.all(chisq.mask))


### PR DESCRIPTION
This fixes warnings for me on Py3k and Python2 @rgommers.

I do have 18 failures if I compile with MKL (even though `numpy` has no errors), are those to be expected?
