### PR TITLE
DOC: Fixed description of linkage function

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -475,7 +475,7 @@ def linkage(y, method='single', metric='euclidean'):
     in the distance matrix. The behavior of this function is very
     similar to the MATLAB linkage function.
 
-    A 4 by :math:`(n-1)` matrix ``Z`` is returned. At the
+    An :math:`(n-1)` by 4  matrix ``Z`` is returned. At the
     :math:`i`-th iteration, clusters with indices ``Z[i, 0]`` and
     ``Z[i, 1]`` are combined to form cluster :math:`n + i`. A
     cluster with an index less than :math:`n` corresponds to one of


### PR DESCRIPTION
The documentation says that linkage returns a 4 by n-1 matrix, but it actually has n-1 rows  and 4 columns. The rest of the paragraph uses the correct dimensions.

```
In [6]:
from scipy.cluster.hierarchy import linkage
from scipy.spatial.distance import pdist, squareform
import numpy as np

n=11
X = np.array(range(22)).reshape(n,2)
dist_matrix = pdist(X)
linkage(dist_matrix).shape

Out[6]:
(10, 4)
```
