### PR TITLE
MAINT: svd-based mahalanobis distance

### DIFF
--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -4,6 +4,7 @@ import numpy as np
 
 try:
     from scipy.spatial import cKDTree, KDTree
+    from scipy.spatial.distance import pdist, cdist
 except ImportError:
     pass
 
@@ -132,3 +133,22 @@ class Neighbors(Benchmark):
         dim | # points T1 | # points T2 | probe radius |  KDTree  | cKDTree
         """
         self.T1.count_neighbors(self.T2, probe_radius)
+
+
+class Distance(Benchmark):
+    params = [
+            [(10, 2), (100, 2), (100, 20), (400, 2), (400, 20), (400, 200)],
+            ['euclidean', 'mahalanobis'],
+            ]
+    param_names = ['shape', 'metric']
+
+    def setup(self, shape, function_string):
+        np.random.seed(1234)
+        self.XA = np.random.randn(*shape)
+        self.XB = np.random.randn(*shape)
+
+    def time_pdist(self, shape, metric):
+        pdist(self.XA, metric=metric)
+
+    def time_cdist(self, shape, metric):
+        cdist(self.XA, self.XB, metric=metric)

--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -152,3 +152,9 @@ class Distance(Benchmark):
 
     def time_cdist(self, shape, metric):
         cdist(self.XA, self.XB, metric=metric)
+
+    def peakmem_pdist(self, shape, metric):
+        pdist(self.XA, metric=metric)
+
+    def peakmem_cdist(self, shape, metric):
+        cdist(self.XA, self.XB, metric=metric)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1323,7 +1323,6 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
                 _distance_wrap.pdist_mahalanobis_wrap(_convert_to_double(X),
                                                       VI, dm)
             else:
-                # Compute the distances without using an explicit nxn matrix.
                 ddof = 1
                 X = X - np.mean(X, axis=0)
                 H = _hat_matrix(X)
@@ -2180,16 +2179,12 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
                                                       _convert_to_double(XB),
                                                       VI, dm)
             else:
-                # Compute the distances without using an explicit nxn matrix.
                 ddof = 1
                 X = np.vstack([XA, XB])
                 X = X - np.mean(X, axis=0)
                 XW = _hat_matrix_helper(X)
                 d = (XW * XW).sum(axis=1)
-                D = XW[:mA].dot(XW[mA:].T)
-                D *= -2
-                D += d[:mA, None]
-                D += d[None, mA:]
+                D = d[:mA, None] + d[None, mA:] - 2*XW[:mA].dot(XW[mA:].T)
                 dm = np.sqrt(D * (mA + mB - ddof))
         elif mstr == 'canberra':
             _distance_wrap.cdist_canberra_wrap(_convert_to_double(XA),

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1327,7 +1327,10 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
                 X = X - np.mean(X, axis=0)
                 H = _hat_matrix(X)
                 D = _gram_form_edm_operator(H)
-                dm = np.sqrt(squareform(D) * (m - ddof))
+                # The D matrix is mathematically symmetric by construction
+                # but not necessarily numerically symmetric.
+                checks = False
+                dm = np.sqrt(squareform(D, checks=checks) * (m - ddof))
         elif mstr == 'canberra':
             _distance_wrap.pdist_canberra_wrap(_convert_to_double(X), dm)
         elif mstr == 'braycurtis':

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -73,7 +73,7 @@ from scipy._lib.six import callable, string_types
 from scipy._lib.six import xrange
 
 from . import _distance_wrap
-from ..linalg import norm
+from ..linalg import norm, pinvh, svd
 import collections
 
 
@@ -124,6 +124,30 @@ def _validate_vector(u, dtype=None):
     if u.ndim > 1:
         raise ValueError("Input vector should be 1-D.")
     return u
+
+
+def _gram_form_edm_operator(G):
+    d = np.diag(G)
+    D = d[:, None] + d[None, :] - 2*G
+    return D
+
+
+def _psd_pseudo_reciprocal(x, tol=1e-14):
+    i = (x < tol)
+    return np.where(i, 0, 1/np.where(i, 1, x))
+
+
+def _hat_matrix_helper(X, tol=1e-14):
+    U, s, Vt = svd(X.T, full_matrices=False)
+    return X.dot(U * _psd_pseudo_reciprocal(s, tol=tol))
+
+
+def _hat_matrix(X, tol=1e-14):
+    # Compute X * (X.T * X).I * X.T using the SVD,
+    # where .T is the transpose, .I is the Moore-Penrose pseudo-inverse,
+    # and * is matrix multiplication.
+    H = _hat_matrix_helper(X, tol=tol)
+    return H.dot(H.T)
 
 
 def minkowski(u, v, p):
@@ -1282,6 +1306,11 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
                                              _convert_to_double(dm),
                                              _convert_to_double(norms))
         elif mstr in set(['mahalanobis', 'mahal', 'mah']):
+            if w is not None:
+                raise NotImplementedError('The weighted Mahalanobis distance '
+                                          'is not implemented.')
+            if VI is None and V is not None:
+                VI = pinvh(V)
             if VI is not None:
                 VI = _convert_to_double(np.asarray(VI, order='c'))
                 if type(VI) != np.ndarray:
@@ -1289,20 +1318,15 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
                 if VI.dtype != np.double:
                     raise TypeError('The array must contain 64-bit floats.')
                 [VI] = _copy_arrays_if_base_present([VI])
+                # (u-v)V^(-1)(u-v)^T
+                _distance_wrap.pdist_mahalanobis_wrap(_convert_to_double(X),
+                                                      VI, dm)
             else:
-                if m <= n:
-                    # There are fewer observations than the dimension of
-                    # the observations.
-                    raise ValueError("The number of observations (%d) is too "
-                                     "small; the covariance matrix is "
-                                     "singular. For observations with %d "
-                                     "dimensions, at least %d observations "
-                                     "are required." % (m, n, n + 1))
-                V = np.atleast_2d(np.cov(X.T))
-                VI = _convert_to_double(np.linalg.inv(V).T.copy())
-            # (u-v)V^(-1)(u-v)^T
-            _distance_wrap.pdist_mahalanobis_wrap(_convert_to_double(X),
-                                                  VI, dm)
+                # Compute the distances without using an explicit nxn matrix.
+                ddof = 1
+                X = X - np.mean(X, axis=0)
+                D = _gram_form_edm_operator(_hat_matrix(X))
+                dm = np.sqrt(squareform(D) * (m - ddof))
         elif mstr == 'canberra':
             _distance_wrap.pdist_canberra_wrap(_convert_to_double(X), dm)
         elif mstr == 'braycurtis':
@@ -2146,24 +2170,14 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
                     raise TypeError('The array must contain 64-bit floats.')
                 [VI] = _copy_arrays_if_base_present([VI])
             else:
-                m = mA + mB
-                if m <= n:
-                    # There are fewer observations than the dimension of
-                    # the observations.
-                    raise ValueError("The number of observations (%d) is too "
-                                     "small; the covariance matrix is "
-                                     "singular. For observations with %d "
-                                     "dimensions, at least %d observations "
-                                     "are required." % (m, n, n + 1))
+                # Compute the distances without using an explicit nxn matrix.
+                ddof = 1
                 X = np.vstack([XA, XB])
-                V = np.atleast_2d(np.cov(X.T))
-                X = None
-                del X
-                VI = _convert_to_double(np.linalg.inv(V).T.copy())
-            # (u-v)V^(-1)(u-v)^T
-            _distance_wrap.cdist_mahalanobis_wrap(_convert_to_double(XA),
-                                                  _convert_to_double(XB),
-                                                  VI, dm)
+                X = X - np.mean(X, axis=0)
+                XW = _hat_matrix_helper(X)
+                d = np.square(np.linalg.norm(XW, axis=1))
+                D = d[:mA, None] + d[None, mA:] - 2 * XW[:mA].dot(XW[mA:].T)
+                dm = np.sqrt(D * (mA + mB - ddof))
         elif mstr == 'canberra':
             _distance_wrap.cdist_canberra_wrap(_convert_to_double(XA),
                                                _convert_to_double(XB), dm)

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -713,6 +713,8 @@ class TestPdist(TestCase):
         assert_allclose(dist1, dist2, rtol=1e-14)
 
     def test_pdist_mahalanobis(self):
+        np.random.seed(1234)
+
         # 1-dimensional observations
         x = np.array([2.0, 2.0, 3.0, 5.0]).reshape(-1, 1)
         dist = pdist(x, metric='mahalanobis')
@@ -725,8 +727,11 @@ class TestPdist(TestCase):
         rt2 = np.sqrt(2)
         assert_allclose(dist, [rt2, rt2, rt2, rt2, 2, 2*rt2, 2, 2, 2*rt2, 2])
 
+        # smoke test
+        x = np.random.randn(10, 2)
+        pdist(x, metric='mahalanobis')
+
         # It is OK to have a relatively small number of observations.
-        np.random.seed(1234)
         for x in (
                 [[1], [2]],
                 [[0, 1], [2, 3]],

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -293,9 +293,15 @@ class TestCdist(TestCase):
         rt2 = np.sqrt(2)
         assert_allclose(dist, [[rt2, rt2, rt2], [2, 2*rt2, 2]])
 
-        # Too few observations
-        assert_raises(ValueError,
-                      cdist, [[0, 1]], [[2, 3]], metric='mahalanobis')
+        # It is OK to have a relatively small number of observations.
+        np.random.seed(1234)
+        for XA, XB in (
+                ([[1]], [[2]]),
+                ([[0, 1]], [[2, 3]]),
+                (np.random.randn(1, 4), np.random.randn(1, 4)),
+                ):
+            dist = cdist(XA, XB, metric='mahalanobis')
+            assert_allclose(dist, np.sqrt(2))
 
     def test_cdist_canberra_random(self):
         eps = 1e-07
@@ -719,9 +725,15 @@ class TestPdist(TestCase):
         rt2 = np.sqrt(2)
         assert_allclose(dist, [rt2, rt2, rt2, rt2, 2, 2*rt2, 2, 2, 2*rt2, 2])
 
-        # Too few observations
-        assert_raises(ValueError,
-                      pdist, [[0, 1], [2, 3]], metric='mahalanobis')
+        # It is OK to have a relatively small number of observations.
+        np.random.seed(1234)
+        for x in (
+                [[1], [2]],
+                [[0, 1], [2, 3]],
+                np.random.randn(2, 4),
+                ):
+            dist = pdist(x, metric='mahalanobis')
+            assert_allclose(dist, np.sqrt(2))
 
     def test_pdist_hamming_random(self):
         eps = 1e-07


### PR DESCRIPTION
Compute the Mahalanobis distance in a more general way, allowing fewer observations than dimensions, and allowing colinear observations.
Addresses some issues in https://github.com/scipy/scipy/issues/4815.
