### PR TITLE
BUG: Fix #4018 `reconstruct_path` for trivial graph

### DIFF
--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -345,7 +345,7 @@ def reconstruct_path(csgraph, predecessors, directed=True):
 
     if not directed:
         data2 = csgraph[indices, pind]
-        if isspmatrix(data):
+        if isspmatrix(data2):
             data2 = data2.todense()
         data2 = data2.getA1()
         data[data == 0] = np.inf

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -339,17 +339,15 @@ def reconstruct_path(csgraph, predecessors, directed=True):
     # Fix issue #4018:
     # If `pind` and `indices` are empty arrays, `data` is a sparse matrix
     # (it is a numpy.matrix otherwise); handle this case separately.
-    try:
-        data = data.getA1()
-    except:
-        data = data.todense().getA1()
+    if isspmatrix(data):
+        data = data.todense()
+    data = data.getA1()
 
-    if directed is False:
+    if not directed:
         data2 = csgraph[indices, pind]
-        try:
-            data2 = data2.getA1()
-        except:
-            data2 = data2.todense().getA1()
+        if isspmatrix(data):
+            data2 = data2.todense()
+        data2 = data2.getA1()
         data[data == 0] = np.inf
         data2[data2 == 0] = np.inf
         data = np.minimum(data, data2)

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -29,7 +29,7 @@ def csgraph_from_masked(graph):
     Returns
     -------
     csgraph : csr_matrix
-        Compressed sparse representation of graph, 
+        Compressed sparse representation of graph,
     """
     # check that graph is a square matrix
     graph = np.ma.asarray(graph)
@@ -97,14 +97,14 @@ def csgraph_masked_from_dense(graph,
 
     # check whether null_value is infinity or NaN
     if null_value is not None:
-        null_value = DTYPE(null_value)        
+        null_value = DTYPE(null_value)
         if np.isnan(null_value):
             nan_null = True
             null_value = None
         elif np.isinf(null_value):
             infinity_null = True
             null_value = None
-    
+
     # flag all the null edges
     if null_value is None:
         mask = np.zeros(graph.shape, dtype='bool')
@@ -147,7 +147,7 @@ def csgraph_from_dense(graph,
     Returns
     -------
     csgraph : csr_matrix
-        Compressed sparse representation of graph, 
+        Compressed sparse representation of graph,
     """
     return csgraph_from_masked(csgraph_masked_from_dense(graph,
                                                          null_value,
@@ -334,16 +334,25 @@ def reconstruct_path(csgraph, predecessors, directed=True):
     pind = predecessors[indices]
     indptr = pind.searchsorted(np.arange(N + 1)).astype(ITYPE)
 
-    if directed == True:
-        data = csgraph[pind, indices]
-    else:
-        data1 = csgraph[pind, indices]
-        data2 = csgraph[indices, pind]
-        data1[data1 == 0] = np.inf
-        data2[data2 == 0] = np.inf
-        data = np.minimum(data1, data2)
+    data = csgraph[pind, indices]
 
-    data = np.asarray(data).ravel()
+    # Fix issue #4018:
+    # If `pind` and `indices` are empty arrays, `data` is a sparse matrix
+    # (it is a numpy.matrix otherwise); handle this case separately.
+    try:
+        data = data.getA1()
+    except:
+        data = data.todense().getA1()
+
+    if directed is False:
+        data2 = csgraph[indices, pind]
+        try:
+            data2 = data2.getA1()
+        except:
+            data2 = data2.todense().getA1()
+        data[data == 0] = np.inf
+        data2[data2 == 0] = np.inf
+        data = np.minimum(data, data2)
 
     return csr_matrix((data, indices, indptr), shape=(N, N))
 
@@ -402,7 +411,7 @@ def construct_dist_matrix(graph,
     dist_matrix = np.zeros(graph.shape, dtype=DTYPE)
     _construct_dist_matrix(graph, predecessors, dist_matrix,
                            directed, null_value)
-    
+
     return dist_matrix
 
 

--- a/scipy/sparse/csgraph/tests/test_traversal.py
+++ b/scipy/sparse/csgraph/tests/test_traversal.py
@@ -44,3 +44,27 @@ def test_graph_depth_first():
         dfirst_test = depth_first_tree(csgraph, 0, directed)
         assert_array_almost_equal(csgraph_to_dense(dfirst_test),
                                   dfirst)
+
+
+def test_graph_breadth_first_trivial_graph():
+    csgraph = np.array([[0]])
+    csgraph = csgraph_from_dense(csgraph, null_value=0)
+
+    bfirst = np.array([[0]])
+
+    for directed in [True, False]:
+        bfirst_test = breadth_first_tree(csgraph, 0, directed)
+        assert_array_almost_equal(csgraph_to_dense(bfirst_test),
+                                  bfirst)
+
+
+def test_graph_depth_first_trivial_graph():
+    csgraph = np.array([[0]])
+    csgraph = csgraph_from_dense(csgraph, null_value=0)
+
+    bfirst = np.array([[0]])
+
+    for directed in [True, False]:
+        bfirst_test = depth_first_tree(csgraph, 0, directed)
+        assert_array_almost_equal(csgraph_to_dense(bfirst_test),
+                                  bfirst)


### PR DESCRIPTION
Fix #4018, and add tests with a trivial graph.
- Use `np.matrix.getA1` instead of `np.asarray().ravel()`; it raises an exception if `data` is a sparse matrix, which it is the case when the input graph is a trivial graph (a graph with a single node).
- Add tests for `breadth_first_tree` and `depth_first_tree` for the case where the input graph is a trivial graph.
