### PR TITLE
BUG: ndimage: Fix memory leak in ni_interpolation.c

### DIFF
--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -695,7 +695,6 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
     /* if the mode is 'constant' we need some temps later: */
     if (mode == NI_EXTEND_CONSTANT) {
         zeros = malloc(rank * sizeof(npy_intp*));
-        zeros = (npy_intp**)malloc(rank * sizeof(npy_intp*));
         if (NI_UNLIKELY(!zeros)) {
             NPY_END_THREADS;
             PyErr_NoMemory();


### PR DESCRIPTION
Fixes a small memory leak introduced by f774507.
