### PR TITLE
BUG: Fix dendrogram labeling, per #3822 

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1667,20 +1667,11 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_xticklabels([])
         else:
             ax.set_xticks(ivticks)
-            ax.set_xticklabels(ivl)
-        ax.xaxis.set_ticks_position('bottom')
+            ax.set_xticklabels(ivl,
+                               rotation=(leaf_rotation or float(_get_tick_rotation(len(ivl)))),
+                               size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
 
-        lbls = ax.get_xticklabels()
-        if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
-        else:
-            leaf_rot = float(_get_tick_rotation(len(ivl)))
-            map(lambda lbl: lbl.set_rotation(leaf_rot), lbls)
-        if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
-        else:
-            leaf_fs = float(_get_tick_text_size(len(ivl)))
-            map(lambda lbl: lbl.set_rotation(leaf_fs), lbls)
+        ax.xaxis.set_ticks_position('bottom')
 
         # Make the tick marks invisible because they cover up the links
         for line in ax.get_xticklines():
@@ -1695,20 +1686,9 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_xticklabels([])
         else:
             ax.set_xticks(ivticks)
-            ax.set_xticklabels(ivl)
-
-        lbls = ax.get_xticklabels()
-        if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
-        else:
-            leaf_rot = float(_get_tick_rotation(p))
-            map(lambda lbl: lbl.set_rotation(leaf_rot), lbls)
-
-        if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
-        else:
-            leaf_fs = float(_get_tick_text_size(p))
-            map(lambda lbl: lbl.set_rotation(leaf_fs), lbls)
+            ax.set_xticklabels(ivl,
+                               rotation=(leaf_rotation or float(_get_tick_rotation(p))),
+                               size=(leaf_font_size or float(_get_tick_text_size(p))))
 
         ax.xaxis.set_ticks_position('top')
         # Make the tick marks invisible because they cover up the links
@@ -1724,13 +1704,14 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_yticklabels([])
         else:
             ax.set_yticks(ivticks)
-            ax.set_yticklabels(ivl)
-
-        lbls = ax.get_yticklabels()
-        if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
-        if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
+            if leaf_rotation and leaf_font_size:
+               ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font_size)
+            elif leaf_rotation:
+               ax.set_yticklabels(ivl, rotation=leaf_rotation)
+            elif leaf_font_size:
+               ax.set_yticklabels(ivl, size=leaf_font_size)
+            else:
+               ax.set_yticklabels(ivl)
 
         ax.yaxis.set_ticks_position('left')
         # Make the tick marks invisible because they cover up the
@@ -1747,13 +1728,14 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_yticklabels([])
         else:
             ax.set_yticks(ivticks)
-            ax.set_yticklabels(ivl)
-
-        lbls = ax.get_yticklabels()
-        if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
-        if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
+            if leaf_rotation and leaf_font_size:
+               ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font_size)
+            elif leaf_rotation:
+               ax.set_yticklabels(ivl, rotation=leaf_rotation)
+            elif leaf_font_size:
+               ax.set_yticklabels(ivl, size=leaf_font_size)
+            else:
+               ax.set_yticklabels(ivl)
 
         ax.yaxis.set_ticks_position('right')
         # Make the tick marks invisible because they cover up the links

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1667,15 +1667,14 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_xticklabels([])
         else:
             ax.set_xticks(ivticks)
+            ax.xaxis.set_ticks_position('bottom')
+
+            # Make the tick marks invisible because they cover up the links
+            for line in ax.get_xticklines():
+                line.set_visible(False)
             ax.set_xticklabels(ivl,
                                rotation=(leaf_rotation or float(_get_tick_rotation(len(ivl)))),
                                size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
-
-        ax.xaxis.set_ticks_position('bottom')
-
-        # Make the tick marks invisible because they cover up the links
-        for line in ax.get_xticklines():
-            line.set_visible(False)
     elif orientation == 'bottom':
         ax.set_ylim([dvw, 0])
         ax.set_xlim([0, ivw])
@@ -1686,14 +1685,14 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_xticklabels([])
         else:
             ax.set_xticks(ivticks)
-            ax.set_xticklabels(ivl,
-                               rotation=(leaf_rotation or float(_get_tick_rotation(p))),
-                               size=(leaf_font_size or float(_get_tick_text_size(p))))
+            ax.xaxis.set_ticks_position('top')
 
-        ax.xaxis.set_ticks_position('top')
-        # Make the tick marks invisible because they cover up the links
-        for line in ax.get_xticklines():
-            line.set_visible(False)
+            # Make the tick marks invisible because they cover up the links
+            for line in ax.get_xticklines():
+                line.set_visible(False)
+            ax.set_xticklabels(ivl,
+                               rotation=(leaf_rotation or float(_get_tick_rotation(len(ivl)))),
+                               size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
     elif orientation == 'left':
         ax.set_xlim([0, dvw])
         ax.set_ylim([0, ivw])
@@ -1704,20 +1703,15 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_yticklabels([])
         else:
             ax.set_yticks(ivticks)
-            if leaf_rotation and leaf_font_size:
-               ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font_size)
-            elif leaf_rotation:
-               ax.set_yticklabels(ivl, rotation=leaf_rotation)
-            elif leaf_font_size:
-               ax.set_yticklabels(ivl, size=leaf_font_size)
-            else:
-               ax.set_yticklabels(ivl)
+            ax.yaxis.set_ticks_position('left')
+            # Make the tick marks invisible because they cover up the
+            # links
+            for line in ax.get_yticklines():
+                line.set_visible(False)
 
-        ax.yaxis.set_ticks_position('left')
-        # Make the tick marks invisible because they cover up the
-        # links
-        for line in ax.get_yticklines():
-            line.set_visible(False)
+            ax.set_yticklabels(ivl,
+                               rotation=(leaf_rotation or float(_get_tick_rotation(len(ivl)))),
+                               size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
     elif orientation == 'right':
         ax.set_xlim([dvw, 0])
         ax.set_ylim([0, ivw])
@@ -1728,19 +1722,14 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_yticklabels([])
         else:
             ax.set_yticks(ivticks)
-            if leaf_rotation and leaf_font_size:
-               ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font_size)
-            elif leaf_rotation:
-               ax.set_yticklabels(ivl, rotation=leaf_rotation)
-            elif leaf_font_size:
-               ax.set_yticklabels(ivl, size=leaf_font_size)
-            else:
-               ax.set_yticklabels(ivl)
+            ax.yaxis.set_ticks_position('right')
+            # Make the tick marks invisible because they cover up the links
+            for line in ax.get_yticklines():
+                line.set_visible(False)
 
-        ax.yaxis.set_ticks_position('right')
-        # Make the tick marks invisible because they cover up the links
-        for line in ax.get_yticklines():
-            line.set_visible(False)
+            ax.set_yticklabels(ivl,
+                               rotation=(leaf_rotation or float(_get_tick_rotation(len(ivl)))),
+                               size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
 
     # Let's use collections instead. This way there is a separate legend
     # item for each tree grouping, rather than stupidly one for each line

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1709,9 +1709,13 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             for line in ax.get_yticklines():
                 line.set_visible(False)
 
-            ax.set_yticklabels(ivl,
-                               rotation=(leaf_rotation or float(_get_tick_rotation(len(ivl)))),
-                               size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
+            if leaf_rotation:
+               ax.set_yticklabels(ivl, rotation=leaf_rotation,
+                                  size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
+            else:
+               ax.set_yticklabels(ivl,
+                                  size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
+
     elif orientation == 'right':
         ax.set_xlim([dvw, 0])
         ax.set_ylim([0, ivw])
@@ -1727,9 +1731,12 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             for line in ax.get_yticklines():
                 line.set_visible(False)
 
-            ax.set_yticklabels(ivl,
-                               rotation=(leaf_rotation or float(_get_tick_rotation(len(ivl)))),
-                               size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
+            if leaf_rotation:
+               ax.set_yticklabels(ivl, rotation=leaf_rotation,
+                                  size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
+            else:
+               ax.set_yticklabels(ivl,
+                                  size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
 
     # Let's use collections instead. This way there is a separate legend
     # item for each tree grouping, rather than stupidly one for each line

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1714,9 +1714,9 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
             
             if leaf_rotation is not None:
-               ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font)
+                ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font)
             else:
-               ax.set_yticklabels(ivl, size=leaf_font)
+                ax.set_yticklabels(ivl, size=leaf_font)
 
     elif orientation == 'right':
         ax.set_xlim([dvw, 0])
@@ -1736,9 +1736,9 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
             
             if leaf_rotation is not None:
-               ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font)
+                ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font)
             else:
-               ax.set_yticklabels(ivl, size=leaf_font)
+                ax.set_yticklabels(ivl, size=leaf_font)
 
     # Let's use collections instead. This way there is a separate legend
     # item for each tree grouping, rather than stupidly one for each line

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1672,9 +1672,10 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             # Make the tick marks invisible because they cover up the links
             for line in ax.get_xticklines():
                 line.set_visible(False)
-            ax.set_xticklabels(ivl,
-                               rotation=(leaf_rotation or float(_get_tick_rotation(len(ivl)))),
-                               size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
+
+            leaf_rot = float(_get_tick_rotation(len(ivl))) if (leaf_rotation is None) else leaf_rotation
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
+            ax.set_xticklabels(ivl, rotation=leaf_rot, size=leaf_font)
     elif orientation == 'bottom':
         ax.set_ylim([dvw, 0])
         ax.set_xlim([0, ivw])
@@ -1690,9 +1691,10 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             # Make the tick marks invisible because they cover up the links
             for line in ax.get_xticklines():
                 line.set_visible(False)
-            ax.set_xticklabels(ivl,
-                               rotation=(leaf_rotation or float(_get_tick_rotation(len(ivl)))),
-                               size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
+
+            leaf_rot = float(_get_tick_rotation(len(ivl))) if (leaf_rotation is None) else leaf_rotation
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
+            ax.set_xticklabels(ivl, rotation=leaf_rot, size=leaf_font)
     elif orientation == 'left':
         ax.set_xlim([0, dvw])
         ax.set_ylim([0, ivw])
@@ -1709,12 +1711,12 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             for line in ax.get_yticklines():
                 line.set_visible(False)
 
-            if leaf_rotation:
-               ax.set_yticklabels(ivl, rotation=leaf_rotation,
-                                  size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
+            
+            if leaf_rotation is not None:
+               ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font)
             else:
-               ax.set_yticklabels(ivl,
-                                  size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
+               ax.set_yticklabels(ivl, size=leaf_font)
 
     elif orientation == 'right':
         ax.set_xlim([dvw, 0])
@@ -1731,12 +1733,12 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             for line in ax.get_yticklines():
                 line.set_visible(False)
 
-            if leaf_rotation:
-               ax.set_yticklabels(ivl, rotation=leaf_rotation,
-                                  size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
+            
+            if leaf_rotation is not None:
+               ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font)
             else:
-               ax.set_yticklabels(ivl,
-                                  size=(leaf_font_size or float(_get_tick_text_size(len(ivl)))))
+               ax.set_yticklabels(ivl, size=leaf_font)
 
     # Let's use collections instead. This way there is a separate legend
     # item for each tree grouping, rather than stupidly one for each line


### PR DESCRIPTION
Fixing a bug (#3822) in which label formatting arguments to scipy.cluster.hierarchy.dendrogram were being ignored. Also, made the behavior of the formatting more consistent across the four orientation options. Unless user-specified, label size will be autoscaled based on the number of labels. For "top" and "bottom" oriented dendrograms, the labels will be rotated if there are a lot of them.

In my own tests this version has the desired behavior. Unfortunately plot outputs are a pain to write tests for, otherwise I would add one in.
