### PR TITLE
MAINT: if the imaginary part of logm of a real matrix is small, the output is now converted to a real matrix

### DIFF
--- a/scipy/linalg/matfuncs.py
+++ b/scipy/linalg/matfuncs.py
@@ -198,6 +198,7 @@ def logm(A, disp=True):
     # Avoid circular import ... this is OK, right?
     import scipy.linalg._matfuncs_inv_ssq
     F = scipy.linalg._matfuncs_inv_ssq._logm(A)
+    F = _maybe_real(A, F)
     errtol = 1000*eps
     #TODO use a better error approximation
     errest = norm(expm(F)-A,1) / norm(A,1)


### PR DESCRIPTION
Closes https://github.com/scipy/scipy/issues/4923.

This changes the behavior a bit. The old behavior was encoded in the unit tests, so these have been changed too.
