### PR TITLE
WIP: remove use of inspect.getargspec for Python 3.x (deprecated in 3.5)

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
+import sys
 import warnings
 from . import _minpack
 
@@ -294,9 +295,9 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
         in x0, otherwise the default `maxfev` is 200*(N+1).
     epsfcn : float, optional
         A variable used in determining a suitable step length for the forward-
-        difference approximation of the Jacobian (for Dfun=None). 
+        difference approximation of the Jacobian (for Dfun=None).
         Normally the actual step length will be sqrt(epsfcn)*x
-        If epsfcn is less than the machine precision, it is assumed that the 
+        If epsfcn is less than the machine precision, it is assumed that the
         relative errors are of the order of the machine precision.
     factor : float, optional
         A parameter determining the initial step bound
@@ -542,8 +543,8 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     """
     if p0 is None:
         # determine number of parameters by inspecting the function
-        import inspect
-        args, varargs, varkw, defaults = inspect.getargspec(f)
+        from scipy._lib._util import inspect_args
+        args, _ = inspect_args(f)
         if len(args) < 2:
             msg = "Unable to determine number of fit parameters."
             raise ValueError(msg)

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -1498,8 +1498,8 @@ def _nonlin_wrapper(name, jac):
     keyword arguments of `nonlin_solve`
 
     """
-    import inspect
-    args, varargs, varkw, defaults = inspect.getargspec(jac.__init__)
+    from scipy._lib._util import inspect_args
+    args, defaults = inspect_args(jac.__init__)
     kwargs = list(zip(args[-len(defaults):], defaults))
     kw_str = ", ".join(["%s=%r" % (k, v) for k, v in kwargs])
     if kw_str:

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -29,6 +29,8 @@ __docformat__ = "restructuredtext en"
 
 import warnings
 import sys
+from scipy._lib._util import inspect_args
+
 import numpy
 from scipy._lib.six import callable
 from numpy import (atleast_1d, eye, mgrid, argmin, zeros, shape, squeeze,
@@ -37,7 +39,6 @@ import numpy as np
 from .linesearch import (line_search_wolfe1, line_search_wolfe2,
                          line_search_wolfe2 as line_search,
                          LineSearchWarning)
-from inspect import getargspec
 
 
 # standard status messages of optimizers
@@ -2609,7 +2610,7 @@ def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
         xmin = xmin[0]
     if callable(finish):
         # set up kwargs for `finish` function
-        finish_args = getargspec(finish).args
+        finish_args, _= inspect_args(finish)
         finish_kwargs = dict()
         if 'full_output' in finish_args:
             finish_kwargs['full_output'] = 1


### PR DESCRIPTION
Not quite finished yet, but already filing a PR to ensure not forgetting this for 0.16.x. That's the only thing that seems to need fixing with Python 3.5.0b2

Didn't touch `doc/source/scipyoptdoc.py` and `scipy/_lib/decorator.py` yet, did file an issue on the `decorator` issue tracker.
