### PR TITLE
get brent's method to return `success`

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -1936,7 +1936,8 @@ def _minimize_scalar_brent(func, brack=None, args=(),
     brent.set_bracket(brack)
     brent.optimize()
     x, fval, nit, nfev = brent.get_result(full_output=True)
-    return OptimizeResult(fun=fval, x=x, nit=nit, nfev=nfev)
+    return OptimizeResult(fun=fval, x=x, nit=nit, nfev=nfev,
+                          success=nit < maxiter)
 
 
 def golden(func, args=(), brack=None, tol=_epsilon, full_output=0):

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -721,6 +721,16 @@ class TestOptimizeScalar(TestCase):
         x = optimize.minimize_scalar(self.fun).x
         assert_allclose(x, self.solution, atol=1e-6)
 
+        x = optimize.minimize_scalar(self.fun, method='Brent')
+        assert(x.success)
+
+        try:
+            x = optimize.minimize_scalar(self.fun, method='Brent',
+                                         options=dict(maxiter=3))
+        except:
+            self.fail("exception raised")
+        assert(not x.success)
+
         x = optimize.minimize_scalar(self.fun, bracket=(-3, -2),
                                     args=(1.5, ), method='Brent').x
         assert_allclose(x, self.solution, atol=1e-6)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -722,14 +722,11 @@ class TestOptimizeScalar(TestCase):
         assert_allclose(x, self.solution, atol=1e-6)
 
         x = optimize.minimize_scalar(self.fun, method='Brent')
-        assert(x.success)
+        assert_(x.success)
 
-        try:
-            x = optimize.minimize_scalar(self.fun, method='Brent',
-                                         options=dict(maxiter=3))
-        except:
-            self.fail("exception raised")
-        assert(not x.success)
+        x = optimize.minimize_scalar(self.fun, method='Brent',
+                                     options=dict(maxiter=3))
+        assert_(not x.success)
 
         x = optimize.minimize_scalar(self.fun, bracket=(-3, -2),
                                     args=(1.5, ), method='Brent').x


### PR DESCRIPTION
This is a potential fix for issues #4630, just does the obvious thing.

I've not committed to scipy before, so let me know if you want tests that would fail for older versions…
