### PR TITLE
do not ignore invalid kwargs in distributions fit method

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -419,8 +419,10 @@ class beta_gen(rv_continuous):
         # Override rv_continuous.fit, so we can more efficiently handle the
         # case where floc and fscale are given.
 
-        f0 = kwds.get('f0', None) or kwds.get('fa', None)
-        f1 = kwds.get('f1', None) or kwds.get('fb', None)
+        f0 = (kwds.get('f0', None) or kwds.get('fa', None) or
+              kwds.get('fix_a', None))
+        f1 = (kwds.get('f1', None) or kwds.get('fb', None) or
+              kwds.get('fix_b', None))
         floc = kwds.get('floc', None)
         fscale = kwds.get('fscale', None)
 
@@ -1885,7 +1887,8 @@ class gamma_gen(rv_continuous):
 
     @inherit_docstring_from(rv_continuous)
     def fit(self, data, *args, **kwds):
-        f0 = kwds.get('f0', None) or kwds.get('fa', None)
+        f0 = (kwds.get('f0', None) or kwds.get('fa', None) or
+              kwds.get('fix_a', None))
         floc = kwds.get('floc', None)
         fscale = kwds.get('fscale', None)
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -419,8 +419,8 @@ class beta_gen(rv_continuous):
         # Override rv_continuous.fit, so we can more efficiently handle the
         # case where floc and fscale are given.
 
-        f0 = kwds.get('f0', None)
-        f1 = kwds.get('f1', None)
+        f0 = kwds.get('f0', None) or kwds.get('fa', None)
+        f1 = kwds.get('f1', None) or kwds.get('fb', None)
         floc = kwds.get('floc', None)
         fscale = kwds.get('fscale', None)
 
@@ -1885,7 +1885,7 @@ class gamma_gen(rv_continuous):
 
     @inherit_docstring_from(rv_continuous)
     def fit(self, data, *args, **kwds):
-        f0 = kwds.get('f0', None)
+        f0 = kwds.get('f0', None) or kwds.get('fa', None)
         floc = kwds.get('floc', None)
         fscale = kwds.get('fscale', None)
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2043,8 +2043,9 @@ class rv_continuous(rv_generic):
 
             - f0...fn : hold respective shape parameters fixed.
               Alternatively, shape parameters to fix can be specified by name.
-              For example, if ``self.shapes == "a, b"``, ``fa`` is equivalent to
-              ``f0`` and ``fb`` is equivalent to ``f1``.
+              For example, if ``self.shapes == "a, b"``, ``fa``and ``fix_a``
+              are equivalent to ``f0``, and ``fb`` and ``fix_b`` are
+              equivalent to ``f1``.
 
             - floc : hold location parameter fixed to specified value.
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1967,15 +1967,15 @@ class rv_continuous(rv_generic):
         # shapes='a, b'. To fix `a`, can specify either `f1` or `fa`.
         # Convert the latter into the former.
         if self.shapes:
-            fshapes = ['f%s' % s for s in self.shapes.replace(',', ' ').split()]
-            for j, fs in enumerate(fshapes):
-                if fs in kwds:
+            shapes = self.shapes.replace(',', ' ').split()
+            for j, s in enumerate(shapes):
+                val = kwds.pop('f' + s, None) or kwds.pop('fix_' + s, None)
+                if val is not None:
                     key = 'f%d' % j
                     if key in kwds:
-                        raise ValueError("Cannot specify both %s and %s" %
-                                         (fs, key))
+                        raise ValueError("Duplicate entry for %s." % key)
                     else:
-                        kwds[key] = kwds.pop(fs)
+                        kwds[key] = val
 
         args = list(args)
         Nargs = len(args)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1249,8 +1249,14 @@ class TestFitMethod(object):
         res_2 = stats.beta.fit(x, fa=3.)
         assert_allclose(res_1, res_2, atol=1e-12, rtol=1e-12)
 
+        res_2 = stats.beta.fit(x, fix_a=3.)
+        assert_allclose(res_1, res_2, atol=1e-12, rtol=1e-12)
+
         res_3 = stats.beta.fit(x, f1=4.)
         res_4 = stats.beta.fit(x, fb=4.)
+        assert_allclose(res_3, res_4, atol=1e-12, rtol=1e-12)
+
+        res_4 = stats.beta.fit(x, fix_b=4.)
         assert_allclose(res_3, res_4, atol=1e-12, rtol=1e-12)
 
         # cannot specify both positional and named args at the same time

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1272,6 +1272,13 @@ class TestFitMethod(object):
         aa, ll, ss = stats.gamma.fit(data, fa=a)
         assert_equal(aa, a)
 
+    def test_extra_params(self):
+        # unknown parameters should raise rather than be silently ignored
+        dist = stats.exponnorm
+        data = dist.rvs(K=2, size=100)
+        dct = dict(enikibeniki=-101)
+        assert_raises(TypeError, dist.fit, data, **dct)
+
 
 class TestFrozen(TestCase):
     # Test that a frozen distribution gives the same results as the original object.

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1260,6 +1260,18 @@ class TestFitMethod(object):
         assert_raises(ValueError, stats.beta.fit, x, fa=0, f1=1,
                                                      floc=2, fscale=3)
 
+        # check that specifying floc, fscale and fshapes works for
+        # beta and gamma which override the generic fit method
+        res_5 = stats.beta.fit(x, fa=3., floc=0, fscale=1)
+        aa, bb, ll, ss = res_5
+        assert_equal([aa, ll, ss], [3., 0, 1])
+
+        # gamma distribution
+        a = 3.
+        data = stats.gamma.rvs(a, size=100)
+        aa, ll, ss = stats.gamma.fit(data, fa=a)
+        assert_equal(aa, a)
+
 
 class TestFrozen(TestCase):
     # Test that a frozen distribution gives the same results as the original object.


### PR DESCRIPTION
closes gh-4932.

Also fix an unrelated bug where the fit method of gamma and beta distributions did not understand `fa` or `fb` keyword arguments. The issue was that `gamma` and `beta` override the generic `fit` method, so that the generic handling of the keyword args was not used.

And while I'm at it, add an option of specifying shape parameters to fix during fitting as `fix_a`, `fix_b` etc, following the suggestion in  https://github.com/scipy/scipy/pull/4718#issuecomment-93979359. With this PR, 
for example, these all are equivalent for the gamma distribution which has shape parameters `a, b`: `stats.gamma.fit(data, f0=1)`, `stats.gamma.fit(data, fa=1)` and `stats.gamma.fit(data, fix_a=1)`
