### PR TITLE
ENH: scipy.sparse.coo.coo_matrix.__init__: less memory needed

### DIFF
--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -142,8 +142,8 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                     if len(row) == 0 or len(col) == 0:
                         raise ValueError('cannot infer dimensions from zero '
                                          'sized index arrays')
-                    M = max(row) + 1
-                    N = max(col) + 1
+                    M = np.max(row) + 1
+                    N = np.max(col) + 1
                     self.shape = (M, N)
                 else:
                     # Use 2 steps to ensure shape has length 2.

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -137,16 +137,13 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                 except TypeError:
                     raise TypeError('invalid input format')
 
-                self.row = np.array(ij[0], copy=copy)
-                self.col = np.array(ij[1], copy=copy)
-                self.data = np.array(obj, copy=copy)
-
+                row, col = ij
                 if shape is None:
-                    if len(self.row) == 0 or len(self.col) == 0:
+                    if len(row) == 0 or len(col) == 0:
                         raise ValueError('cannot infer dimensions from zero '
                                          'sized index arrays')
-                    M = self.row.max() + 1
-                    N = self.col.max() + 1
+                    M = max(row) + 1
+                    N = max(col) + 1
                     self.shape = (M, N)
                 else:
                     # Use 2 steps to ensure shape has length 2.
@@ -154,8 +151,9 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                     self.shape = (M, N)
 
                 idx_dtype = get_index_dtype(maxval=max(self.shape))
-                self.row = self.row.astype(idx_dtype)
-                self.col = self.col.astype(idx_dtype)
+                self.row = np.array(row, copy=copy, dtype=idx_dtype)
+                self.col = np.array(col, copy=copy, dtype=idx_dtype)
+                self.data = np.array(obj, copy=copy)
                 self.has_canonical_format = False
 
         elif arg1 is None:


### PR DESCRIPTION
During the creation of a coo matrix with row, column and data sequences the row and column arrays are created twice. They only have to be created once with this enhancement. As a consequence, memory and execution time can be saved. This is crucial for large amounts of data.
