### PR TITLE
BUG: scipy.signal - fix num_freqs logic in spectral_helper

### DIFF
--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -838,7 +838,7 @@ def _spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
     if sides == 'twosided':
         num_freqs = nfft
     elif sides == 'onesided':
-        if nperseg % 2:
+        if nfft % 2:
             num_freqs = (nfft + 1)//2
         else:
             num_freqs = nfft//2 + 1

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -457,6 +457,24 @@ class TestWelch(TestCase):
         assert_(p.dtype == q.dtype,
                 'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
 
+    def test_padded_freqs(self):
+        x = np.zeros(12)
+
+        nfft = 24
+        f = fftpack.fftfreq(nfft, 1.0)[:nfft//2+1]
+        f[-1] *= -1
+        fodd, _ = welch(x, nperseg=5, nfft=nfft)
+        feven, _ = welch(x, nperseg=6, nfft=nfft)
+        assert_allclose(f, fodd)
+        assert_allclose(f, feven)
+
+        nfft = 25
+        f = fftpack.fftfreq(nfft, 1.0)[:(nfft + 1)//2]
+        fodd, _ = welch(x, nperseg=5, nfft=nfft)
+        feven, _ = welch(x, nperseg=6, nfft=nfft)
+        assert_allclose(f, fodd)
+        assert_allclose(f, feven)
+
 class TestCSD:
     def test_pad_shorter_x(self):
         x = np.zeros(8)
@@ -744,6 +762,24 @@ class TestCSD:
         assert_(p.dtype == q.dtype,
                 'dtype mismatch, %s, %s' % (p.dtype, q.dtype))
 
+    def test_padded_freqs(self):
+        x = np.zeros(12)
+        y = np.ones(12)
+
+        nfft = 24
+        f = fftpack.fftfreq(nfft, 1.0)[:nfft//2+1]
+        f[-1] *= -1
+        fodd, _ = csd(x, y, nperseg=5, nfft=nfft)
+        feven, _ = csd(x, y, nperseg=6, nfft=nfft)
+        assert_allclose(f, fodd)
+        assert_allclose(f, feven)
+
+        nfft = 25
+        f = fftpack.fftfreq(nfft, 1.0)[:(nfft + 1)//2]
+        fodd, _ = csd(x, y, nperseg=5, nfft=nfft)
+        feven, _ = csd(x, y, nperseg=6, nfft=nfft)
+        assert_allclose(f, fodd)
+        assert_allclose(f, feven)
 
 class TestCoherence:
     def test_identical_input(self):


### PR DESCRIPTION
Closes gh-4962, which occurred when `nperseg` and `nfft` were not the same sign. I've also added a test for this case. 
