### PR TITLE
DEP: deprecate ``stats.f_value*`` and ``mstats.f_value*`` functions.

### DIFF
--- a/doc/release/0.17.0-notes.rst
+++ b/doc/release/0.17.0-notes.rst
@@ -31,6 +31,11 @@ be exposed to the user. Also, the name is unclear. See issue #663 for details.
 ``scipy.stats.square_of_sums`` is deprecated. This too is a support function 
 not meant to be exposed to the user. See issues #665 and #663 for details.
 
+``scipy.stats.f_value``, ``scipy.stats.f_value_multivariate``,
+``scipy.stats.f_value_wilks_lambda``, and ``scipy.mstats.f_value_wilks_lambda`` 
+are deprecated. These are related to ANOVA, for which ``scipy.stats`` provides 
+quite limited functionality and these functions are not very useful standalone.
+See issues #660 and #650 for details.
 
 Backwards incompatible changes
 ==============================

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -2040,6 +2040,7 @@ def f_oneway(*args):
     return F_onewayResult(f, prob)
 
 
+@np.deprecate(message="mstats.f_value_wilks_lambda deprecated in scipy 0.17.0")
 def f_value_wilks_lambda(ER, EF, dfnum, dfden, a, b):
     """Calculation of Wilks lambda F-statistic for multivariate data, per
     Maxwell & Delaney p.657.

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -4604,6 +4604,7 @@ def betai(a, b, x):
 #         ANOVA CALCULATIONS        #
 #####################################
 
+@np.deprecate(message="stats.f_value_wilks_lambda deprecated in scipy 0.17.0")
 def f_value_wilks_lambda(ER, EF, dfnum, dfden, a, b):
     """Calculation of Wilks lambda F-statistic for multivarite data, per
     Maxwell & Delaney p.657.
@@ -4623,6 +4624,7 @@ def f_value_wilks_lambda(ER, EF, dfnum, dfden, a, b):
     return n_um / d_en
 
 
+@np.deprecate(message="stats.f_value deprecated in scipy 0.17.0")
 def f_value(ER, EF, dfR, dfF):
     """
     Returns an F-statistic for a restricted vs. unrestricted model.
@@ -4651,6 +4653,7 @@ def f_value(ER, EF, dfR, dfF):
     return (ER - EF) / float(dfR - dfF) / (EF / float(dfF))
 
 
+@np.deprecate(message="stats.f_value_multivariate deprecated in scipy 0.17.0")
 def f_value_multivariate(ER, EF, dfnum, dfden):
     """
     Returns a multivariate F-statistic.


### PR DESCRIPTION
closes gh-650; closes gh-660; closes gh-662
