### PR TITLE
MAINT: impove the error message in validate_runtests_log

### DIFF
--- a/tools/validate_runtests_log.py
+++ b/tools/validate_runtests_log.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     # OK (SKIP=X, KNOWNFAIL=Y) or FAILED (errors=X, failures=Y)
     r = re.compile("Ran (?P<num_tests>\d+) tests in (?P<time>\d+\S+)")
 
-    status = False
+    status, found_it = False, False
     while True:
         line = sys.stdin.readline()
         if not line:


### PR DESCRIPTION
Avoid the use of an unitialized variable if build failed before the nose printout.

Thanks @argriffing, https://github.com/scipy/scipy/pull/4852#issuecomment-112613023

[ci skip]
