### PR TITLE
clarify dirichlet distribution error handling

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -776,6 +776,10 @@ class dirichlet_gen(multi_rv_generic):
     concentration parameters and :math:`K` is the dimension of the space
     where :math:`x` takes values.
 
+    Note that the dirichlet interface is somewhat inconsistent.
+    The array returned by the rvs function is transposed
+    with respect to the format expected by the pdf and logpdf.
+
     """
 
     def __init__(self, seed=None):

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -663,10 +663,9 @@ def _dirichlet_check_input(alpha, x):
     x = np.asarray(x)
 
     if x.shape[0] + 1 != alpha.shape[0] and x.shape[0] != alpha.shape[0]:
-        raise ValueError("Vector 'x' must have one entry less than the" +
-                         " parameter vector 'a', but alpha.shape = " +
-                         "%s and " % alpha.shape +
-                         "x.shape = %s." % x.shape)
+        raise ValueError("Vector 'x' must have one entry less than the "
+                         "parameter vector 'a', but alpha.shape = %s "
+                         "and x.shape = %s." % (alpha.shape, x.shape))
 
     if x.shape[0] != alpha.shape[0]:
         xk = np.array([1 - np.sum(x, 0)])

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -663,7 +663,7 @@ def _dirichlet_check_input(alpha, x):
     x = np.asarray(x)
 
     if x.shape[0] + 1 != alpha.shape[0] and x.shape[0] != alpha.shape[0]:
-        raise ValueError("Vector 'x' must have one entry less then the" +
+        raise ValueError("Vector 'x' must have one entry less than the" +
                          " parameter vector 'a', but alpha.shape = " +
                          "%s and " % alpha.shape +
                          "x.shape = %s." % x.shape)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -648,14 +648,13 @@ dirichlet_docdict_noparams = {
     '_doc_random_state': _doc_random_state
 }
 
-
 def _dirichlet_check_parameters(alpha):
     alpha = np.asarray(alpha)
     if np.min(alpha) <= 0:
         raise ValueError("All parameters must be greater than 0")
     elif alpha.ndim != 1:
-        raise ValueError("Parameter vector 'a' must be one dimensional, " +
-                         "but a.shape = %s." % str(alpha.shape))
+        raise ValueError("Parameter vector 'a' must be one dimensional, "
+                       "but a.shape = %s." % (alpha.shape, ))
     return alpha
 
 
@@ -677,15 +676,15 @@ def _dirichlet_check_input(alpha, x):
             raise ValueError("The input must be one dimensional or a two "
                              "dimensional matrix containing the entries.")
 
-    if np.min(x) < 0:
-        raise ValueError("Each entry in 'x' must be greater or equal zero.")
+    if np.min(x) <= 0:
+        raise ValueError("Each entry in 'x' must be greater than zero.")
 
     if np.max(x) > 1:
         raise ValueError("Each entry in 'x' must be smaller or equal one.")
 
     if (np.abs(np.sum(x, 0) - 1.0) > 10e-10).any():
-        raise ValueError("The input vector 'x' must lie within the normal " +
-                         "simplex. but sum(x)=%f." % np.sum(x, 0))
+        raise ValueError("The input vector 'x' must lie within the normal "
+                       "simplex. but np.sum(x, 0) = %s." % np.sum(x, 0))
 
     return x
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -662,7 +662,8 @@ def _dirichlet_check_input(alpha, x):
     x = np.asarray(x)
 
     if x.shape[0] + 1 != alpha.shape[0] and x.shape[0] != alpha.shape[0]:
-        raise ValueError("Vector 'x' must have one entry less than the "
+        raise ValueError("Vector 'x' must have either the same number "
+                         "of entries as, or one entry fewer than, "
                          "parameter vector 'a', but alpha.shape = %s "
                          "and x.shape = %s." % (alpha.shape, x.shape))
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -345,6 +345,7 @@ class TestMultivariateNormal(TestCase):
 
 
 class TestDirichlet(TestCase):
+
     def test_frozen_dirichlet(self):
         np.random.seed(2846)
 
@@ -362,6 +363,14 @@ class TestDirichlet(TestCase):
             x /= np.sum(x)
             assert_equal(d.pdf(x[:-1]), dirichlet.pdf(x[:-1], alpha))
             assert_equal(d.logpdf(x[:-1]), dirichlet.logpdf(x[:-1], alpha))
+
+    def test_numpy_rvs_shape_compatibility(self):
+        np.random.seed(2846)
+        alpha = np.array([1.0, 2.0, 3.0])
+        x = np.random.dirichlet(alpha, size=7)
+        assert_equal(x.shape, (7, 3))
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_simple_values(self):
         alpha = np.array([1, 1])

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -371,6 +371,78 @@ class TestDirichlet(TestCase):
         assert_equal(x.shape, (7, 3))
         assert_raises(ValueError, dirichlet.pdf, x, alpha)
         assert_raises(ValueError, dirichlet.logpdf, x, alpha)
+        dirichlet.pdf(x.T, alpha)
+        dirichlet.pdf(x.T[:-1], alpha)
+        dirichlet.logpdf(x.T, alpha)
+        dirichlet.logpdf(x.T[:-1], alpha)
+
+    def test_alpha_with_zeros(self):
+        np.random.seed(2846)
+        alpha = [1.0, 0.0, 3.0]
+        x = np.random.dirichlet(alpha, size=7).T
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
+
+    def test_alpha_with_negative_entries(self):
+        np.random.seed(2846)
+        alpha = [1.0, -2.0, 3.0]
+        x = np.random.dirichlet(alpha, size=7).T
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
+
+    def test_data_with_zeros(self):
+        alpha = np.array([1.0, 2.0, 3.0, 4.0])
+        x = np.array([0.1, 0.0, 0.2, 0.7])
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
+
+    def test_data_with_negative_entries(self):
+        alpha = np.array([1.0, 2.0, 3.0, 4.0])
+        x = np.array([0.1, -0.1, 0.3, 0.7])
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
+
+    def test_data_with_too_large_entries(self):
+        alpha = np.array([1.0, 2.0, 3.0, 4.0])
+        x = np.array([0.1, 1.1, 0.3, 0.7])
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
+
+    def test_data_too_deep_c(self):
+        alpha = np.array([1.0, 2.0, 3.0])
+        x = np.ones((2, 7, 7)) / 14
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
+
+    def test_alpha_too_deep(self):
+        alpha = np.array([[1.0, 2.0], [3.0, 4.0]])
+        x = np.ones((2, 2, 7)) / 4
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
+
+    def test_alpha_correct_depth(self):
+        alpha = np.array([1.0, 2.0, 3.0])
+        x = np.ones((3, 7)) / 3
+        dirichlet.pdf(x, alpha)
+        dirichlet.logpdf(x, alpha)
+
+    def test_non_simplex_data(self):
+        alpha = np.array([1.0, 2.0, 3.0])
+        x = np.ones((3, 7)) / 2
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
+
+    def test_data_vector_too_short(self):
+        alpha = np.array([1.0, 2.0, 3.0, 4.0])
+        x = np.ones((2, 7)) / 2
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
+
+    def test_data_vector_too_long(self):
+        alpha = np.array([1.0, 2.0, 3.0, 4.0])
+        x = np.ones((5, 7)) / 5
+        assert_raises(ValueError, dirichlet.pdf, x, alpha)
+        assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_simple_values(self):
         alpha = np.array([1, 1])


### PR DESCRIPTION
An inconsistency in the interface of the scipy dirichlet distribution is that if you sample some data using dirichlet.rvs or using np.random.dirichlet, the returned array needs to be transposed before computing dirichlet.pdf or dirichlet.logpdf.
