### PR TITLE
Refactored multivariate normal example (trivial)

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -398,8 +398,7 @@ class multivariate_normal_gen(multi_rv_generic):
     follows:
 
     >>> x, y = np.mgrid[-1:1:.01, -1:1:.01]
-    >>> pos = np.empty(x.shape + (2,))
-    >>> pos[:, :, 0] = x; pos[:, :, 1] = y
+    >>> pos = np.dstack((x, y))
     >>> rv = multivariate_normal([0.5, -0.2], [[2.0, 0.3], [0.3, 0.5]])
     >>> fig2 = plt.figure()
     >>> ax2 = fig2.add_subplot(111)


### PR DESCRIPTION
Use of `dstack` seems slightly more concise than declaring empty array with tuple concatenation, etc.
