### PR TITLE
DOC, MAINT: inversion of rows and columns in sp.sparse.eye docstring

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -147,6 +147,7 @@ Irvin Probst (ENSTA Bretagne) for pole placement.
 Ian Henriksen for Cython wrappers for BLAS and LAPACK
 Fukumu Tsutsumi for bug fixes.
 J.J. Green for interpolation bug fixes.
+François Magimel for documentation improvements.
 
 
 Institutions

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -223,14 +223,14 @@ def eye(m, n=None, k=0, dtype=float, format=None):
 
     Parameters
     ----------
-    n : int
+    m : int
         Number of rows in the matrix.
-    m : int, optional
-        Number of columns. Default: n
+    n : int, optional
+        Number of columns. Default: `m`.
     k : int, optional
-        Diagonal to place ones on. Default: 0 (main diagonal)
+        Diagonal to place ones on. Default: 0 (main diagonal).
     dtype : dtype, optional
-        Data type of the matrix
+        Data type of the matrix.
     format : str, optional
         Sparse format of the result, e.g. format="csr", etc.
 


### PR DESCRIPTION
Fix the doc (inversion & typo) for the `sp.sparse.eye` function.
Add myself to THANKS.txt for my first commit in SciPy.
