### PR TITLE
Fix win-64 bug in solve_toeplitz

### DIFF
--- a/scipy/linalg/_solve_toeplitz.pyx
+++ b/scipy/linalg/_solve_toeplitz.pyx
@@ -53,7 +53,7 @@ def levinson(dz[::1] a, dz[::1] b):
     else:
         dtype = complex128
 
-    cdef npy_intp n, m, j, nmj, k, m2
+    cdef npy_intp n, m, j, nmj, k, m2, m_j_1
     n = b.shape[0]
     cdef dz x_num, g_num, h_num, x_den, g_den
     cdef dz gj, gk, hj, hk, c1, c2
@@ -91,7 +91,8 @@ def levinson(dz[::1] a, dz[::1] b):
 
         # Compute x
         for j in range(m):
-            x[j] = x[j] - x[m] * g[m-j-1]
+            m_j_1 = m - j - 1
+            x[j] = x[j] - x[m] * g[m_j_1]
         if m == n-1:
             return asarray(x), asarray(reflection_coeff)
 

--- a/scipy/linalg/_solve_toeplitz.pyx
+++ b/scipy/linalg/_solve_toeplitz.pyx
@@ -3,7 +3,7 @@
 # cython: boundscheck=False, wraparound=False, cdivision=True
 from numpy import zeros, asarray, complex128, float64
 from numpy.linalg import LinAlgError
-from numpy cimport npy_intp, complex128_t, float64_t
+from numpy cimport complex128_t, float64_t
 
 
 cdef fused dz:
@@ -53,7 +53,7 @@ def levinson(dz[::1] a, dz[::1] b):
     else:
         dtype = complex128
 
-    cdef npy_intp n, m, j, nmj, k, m2, m_j_1
+    cdef ssize_t n, m, j, nmj, k, m2
     n = b.shape[0]
     cdef dz x_num, g_num, h_num, x_den, g_den
     cdef dz gj, gk, hj, hk, c1, c2
@@ -91,8 +91,7 @@ def levinson(dz[::1] a, dz[::1] b):
 
         # Compute x
         for j in range(m):
-            m_j_1 = m - j - 1
-            x[j] = x[j] - x[m] * g[m_j_1]
+            x[j] = x[j] - x[m] * g[m-j-1]
         if m == n-1:
             return asarray(x), asarray(reflection_coeff)
 


### PR DESCRIPTION
This PR fixes the bug in #4907.

Believe it or not, the problem is, I'm pretty sure, a bug in VC10's 64-bit compilers. I made a minimal example to trigger the bug here: https://gist.github.com/rmcgibbo/acfb56a43aad804fda7a. On VC2010 64-bit, that code essentially computes 2-1-1 and gets -1, not 0. In this routine, that leads to a buffer underrun.
