### PR TITLE
remove coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ before_install:
   - travis_retry pip install $NUMPYSPEC
   - travis_retry pip install nose mpmath argparse
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
-  - if [ "${TESTMODE}" == "full" ]; then pip install coverage coveralls; fi
+  - if [ "${TESTMODE}" == "full" ]; then pip install coverage; fi
   - python -V
   - popd
   - set -o pipefail
@@ -84,5 +84,3 @@ notifications:
   # Perhaps we should have status emails sent to the mailing list, but
   # let's wait to see what people think before turning that on.
   email: false
-after_success:
-    - if [ "${TESTMODE}" == "full" ]; then pushd build/testenv/lib/python*/site-packages/ && cp ../../../../test/.coverage . && coveralls && popd; fi


### PR DESCRIPTION
It's disabled for a while now anyway (I wonder how). The full test suite regularly times out on submission to coveralls. Full suite runtime fluctuates from 35 to 50 minutes, but this likely out of our control, and this change is less intrusive than alternatives based on splitting the test suite into several runs.

Note that this only disables coveralls.io, not coverage itself. The latter still reports its findings in the CI log.
