### PR TITLE
Hypergeometric distribution log survival function

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -147,7 +147,7 @@ Irvin Probst (ENSTA Bretagne) for pole placement.
 Ian Henriksen for Cython wrappers for BLAS and LAPACK
 Fukumu Tsutsumi for bug fixes.
 J.J. Green for interpolation bug fixes.
-François Magimel for documentation improvements.
+Josh Levy-Kramer for the log survival function of the hypergeometric distribution
 
 
 Institutions

--- a/THANKS.txt
+++ b/THANKS.txt
@@ -147,6 +147,7 @@ Irvin Probst (ENSTA Bretagne) for pole placement.
 Ian Henriksen for Cython wrappers for BLAS and LAPACK
 Fukumu Tsutsumi for bug fixes.
 J.J. Green for interpolation bug fixes.
+François Magimel for documentation improvements.
 Josh Levy-Kramer for the log survival function of the hypergeometric distribution
 
 

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -6,6 +6,7 @@ from __future__ import division, print_function, absolute_import
 
 from scipy import special
 from scipy.special import entr, gammaln as gamln
+from scipy.misc import logsumexp
 
 from numpy import floor, ceil, log, exp, sqrt, log1p, expm1, tanh, cosh, sinh
 
@@ -360,6 +361,19 @@ class hypergeom_gen(rv_discrete):
             k2 = np.arange(quant + 1, draw + 1)
             res.append(np.sum(self._pmf(k2, tot, good, draw)))
         return np.asarray(res)
+        
+    def _logsf(self, k, M, n, N):
+        """
+        More precise calculation than log(sf)
+        """
+        res = []
+        for quant, tot, good, draw in zip(k, M, n, N):
+            # Integration over probability mass function using logsumexp
+            k2 = np.arange(quant + 1, draw + 1)
+            res.append(logsumexp(self._logpmf(k2, tot, good, draw)))
+        return np.asarray(res)
+        
+        
 hypergeom = hypergeom_gen(name='hypergeom')
 
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -433,6 +433,21 @@ class TestHypergeom(TestCase):
         hg = stats.hypergeom(1, 1, 1)
         h = hg.entropy()
         assert_equal(h, 0.0)
+        
+    def test_logsf(self):
+        # Test logsf for very large numbers. See issue #4982
+        # Results compare with those from R (v3.2.0):
+        # phyper(k, n, M-n, N, lower.tail=FALSE, log.p=TRUE)
+        #-2239.771
+        
+        k = 1e4
+        M = 1e7
+        n = 1e6
+        N = 5e4
+        
+        result = stats.hypergeom.logsf(k, M, n, N)
+        exspected = -2239.771   # From R
+        assert_almost_equal(result, exspected, decimal=3)
 
 
 class TestLoggamma(TestCase):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -438,7 +438,7 @@ class TestHypergeom(TestCase):
         # Test logsf for very large numbers. See issue #4982
         # Results compare with those from R (v3.2.0):
         # phyper(k, n, M-n, N, lower.tail=FALSE, log.p=TRUE)
-        #-2239.771
+        # -2239.771
         
         k = 1e4
         M = 1e7


### PR DESCRIPTION
Changed the hypergeometric distribution log survival function so that you integrate using the logpmf instead of just taking the log of the sf

This commit fixes #4982
