### PR TITLE
Patch to compute the volume and area of convex hulls

### DIFF
--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -124,6 +124,8 @@ cdef extern from "qhull/src/libqhull.h":
         realT max_outside
         realT MINoutside
         realT DISTround
+        realT totvol
+        realT totarea
         jmp_buf errexit
         setT *other_points
         unsigned int visit_id
@@ -178,6 +180,9 @@ cdef extern from "qhull/src/io.h":
 
 cdef extern from "qhull/src/geom.h":
     pointT *qh_facetcenter(setT *vertices) nogil
+
+cdef extern from "qhull/src/geom.h":
+    double qh_getarea(facetT *facetlist) nogil
 
 cdef extern from "qhull/src/poly.h":
     void qh_check_maxout() nogil
@@ -331,6 +336,22 @@ cdef class _Qhull:
                 raise QhullError("Qhull error")
         finally:
             _qhull_lock.release()
+
+    @cython.final
+    def volume_area(self):
+        cdef double volume
+        cdef double area
+
+        _qhull_lock.acquire()
+        try:
+            self._activate()
+            qh_getarea(qh_qh.facet_list)
+            volume = qh_qh.totvol
+            area = qh_qh.totarea
+        finally:
+            _qhull_lock.release()
+
+        return volume, area
 
     @cython.final
     def close(self):
@@ -2241,6 +2262,8 @@ class ConvexHull(_QhullUser):
 
         self.simplices, self.neighbors, self.equations, self.coplanar = \
                        qhull.get_simplex_facet_array()
+
+        self.volume, self.area = qhull.volume_area()
 
         if qhull.ndim == 2:
             self._vertices = qhull.get_extremes_2d()

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -231,13 +231,13 @@ class TestUtilities(object):
         assert_equal(tri.convex_hull, [[3, 2], [1, 2], [1, 0], [3, 0]])
 
     def test_volume_area(self):
-      #Basic check that we get back the correct volume and area for a cube
-      points = np.array([(0, 0, 0), (0, 1, 0), (1, 0, 0), (1, 1, 0),
-                         (0, 0, 1), (0, 1, 1), (1, 0, 1), (1, 1, 1)])
-      tri = qhull.ConvexHull(points)
+        #Basic check that we get back the correct volume and area for a cube
+        points = np.array([(0, 0, 0), (0, 1, 0), (1, 0, 0), (1, 1, 0),
+                           (0, 0, 1), (0, 1, 1), (1, 0, 1), (1, 1, 1)])
+        tri = qhull.ConvexHull(points)
 
-      assert_equal(tri.volume, 1., "Volume of cube is incorrect")
-      assert_equal(tri.area, 6., "Area of cube is incorrect")
+        assert_equal(tri.volume, 1., "Volume of cube is incorrect")
+        assert_equal(tri.area, 6., "Area of cube is incorrect")
 
     def _check_barycentric_transforms(self, tri, err_msg="",
                                       unit_cube=False,

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -230,6 +230,15 @@ class TestUtilities(object):
 
         assert_equal(tri.convex_hull, [[3, 2], [1, 2], [1, 0], [3, 0]])
 
+    def test_volume_area(self):
+      #Basic check that we get back the correct volume and area for a cube
+      points = np.array([(0, 0, 0), (0, 1, 0), (1, 0, 0), (1, 1, 0),
+                         (0, 0, 1), (0, 1, 1), (1, 0, 1), (1, 1, 1)])
+      tri = qhull.ConvexHull(points)
+
+      assert_equal(tri.volume, 1., "Volume of cube is incorrect")
+      assert_equal(tri.area, 6., "Area of cube is incorrect")
+
     def _check_barycentric_transforms(self, tri, err_msg="",
                                       unit_cube=False,
                                       unit_cube_tol=0):


### PR DESCRIPTION
As mentioned in issue #5013 , I would like to be able to contribute a small patch enabling the volume and area computation of convex hulls.

As this is already implemented in qhull, I added the correct bindings and a simple unit test. Unfortunately, I don't have Cython 0.22 on my Ubuntu machine, meaning that I could not build against the most recent version of scipy but test passed on older versions and I don't think qhull has changed much since.

Please tell me if I can improve this in any way.

Hervé Audren
