### PR TITLE
DOC: Fix mistaken variable name in sawtooth

### DIFF
--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -32,7 +32,7 @@ def sawtooth(t, width=1):
     width : array_like, optional
         Width of the rising ramp as a proportion of the total cycle.
         Default is 1, producing a rising ramp, while 0 produces a falling
-        ramp.  `t` = 0.5 produces a triangle wave.
+        ramp.  `width` = 0.5 produces a triangle wave.
         If an array, causes wave shape to change over time, and must be the
         same length as t.
 


### PR DESCRIPTION
Should be width, not t
