### PR TITLE
DEP: deprecate `stats.betai` and `stats.chisqprob`

### DIFF
--- a/doc/release/0.17.0-notes.rst
+++ b/doc/release/0.17.0-notes.rst
@@ -37,16 +37,11 @@ are deprecated. These are related to ANOVA, for which ``scipy.stats`` provides
 quite limited functionality and these functions are not very useful standalone.
 See issues #660 and #650 for details.
 
-``scipy.stats.chisqprob`` is deprecated. This is a delegator function and it is
-deprecated in favor of the convention, which is to call the distribution from 
-``scipy.stats.distribution`` or calling ``scipy.special.chdtrc`` directly.
-See issues #2741 and #641 for details.
+``scipy.stats.chisqprob`` is deprecated. This is an alias. ``stats.chi2.sf`` 
+should be used instead. 
 
-
-``scipy.stats.betai`` is deprecated. This is delegator function and it is 
-deprecated in favor of the convention, which is to call the distribution from 
-``scipy.stats.distribution`` or calling ``scipy.special.betainc`` directly. 
-See issues #2741 and #642 for details.
+``scipy.stats.betai`` is deprecated. This is an alias for ``special.betainc`` 
+which should be used instead.
 
 Backwards incompatible changes
 ==============================

--- a/doc/release/0.17.0-notes.rst
+++ b/doc/release/0.17.0-notes.rst
@@ -37,6 +37,17 @@ are deprecated. These are related to ANOVA, for which ``scipy.stats`` provides
 quite limited functionality and these functions are not very useful standalone.
 See issues #660 and #650 for details.
 
+``scipy.stats.chisqprob`` is deprecated. This is a delegator function and it is
+deprecated in favor of the convention, which is to call the distribution from 
+``scipy.stats.distribution`` or calling ``scipy.special.chdtrc`` directly.
+See issues #2741 and #641 for details.
+
+
+``scipy.stats.betai`` is deprecated. This is delegator function and it is 
+deprecated in favor of the convention, which is to call the distribution from 
+``scipy.stats.distribution`` or calling ``scipy.special.betainc`` directly. 
+See issues #2741 and #642 for details.
+
 Backwards incompatible changes
 ==============================
 

--- a/scipy/stats/mstats.py
+++ b/scipy/stats/mstats.py
@@ -16,7 +16,6 @@ is a relatively new package, some API changes are still possible.
    :toctree: generated/
 
    argstoarray
-   betai
    chisquare
    count_tied_groups
    describe

--- a/scipy/stats/mstats.py
+++ b/scipy/stats/mstats.py
@@ -16,6 +16,7 @@ is a relatively new package, some API changes are still possible.
    :toctree: generated/
 
    argstoarray
+   betai
    chisquare
    count_tied_groups
    describe

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -12,6 +12,7 @@ from __future__ import division, print_function, absolute_import
 
 
 __all__ = ['argstoarray',
+           'betai',
            'chisquare','count_tied_groups',
            'describe',
            'f_oneway','f_value_wilks_lambda','find_repeats','friedmanchisquare',
@@ -289,12 +290,17 @@ def mode(a, axis=0):
 mode.__doc__ = stats.mode.__doc__
 
 
-@np.deprecate(message="mstats.betai is deprecated in scipy 0.17.0")
+@np.deprecate(message="mstats.betai is deprecated in scipy 0.17.0; "
+              "use special.betainc instead.")
 def betai(a, b, x):
+    return _betai(a, b, x)
+betai.__doc__ = stats.betai.__doc__
+
+
+def _betai(a, b, x):
     x = np.asanyarray(x)
     x = ma.where(x < 1.0, x, 1.0)  # if x > 1 then return 1.0
     return special.betainc(a, b, x)
-betai.__doc__ = stats.betai.__doc__
 
 
 def msign(x):
@@ -362,9 +368,7 @@ def pearsonr(x,y):
         prob = 0.
     else:
         t_squared = (df / ((1.0 - r) * (1.0 + r))) * r * r
-        tmp = df / (df + t_squared)
-        tmp = np.where(tmp < 1.0, tmp, 1.0)
-        prob = special.betainc(0.5*df, 0.5, tmp)
+        prob = betai(0.5*df, 0.5, df/(df + t_squared))
 
     return r, prob
 
@@ -448,9 +452,7 @@ def spearmanr(x, y, use_ties=True):
     if t is masked:
         prob = 0.
     else:
-        tmp = df/(df + t * t)
-        tmp = np.where(tmp < 1.0, tmp, 1.0)
-        prob = special.betainc(0.5*df, 0.5, tmp)
+        prob = betai(0.5*df, 0.5, df/(df + t * t))
 
     SpearmanrResult = namedtuple('SpearmanrResult', ('correlation', 'pvalue'))
     return SpearmanrResult(rho, prob)
@@ -622,9 +624,7 @@ def pointbiserialr(x, y):
 
     df = n-2
     t = rpb*ma.sqrt(df/(1.0-rpb**2))
-    tmp = df/(df + t * t)
-    tmp = np.where(tmp < 1.0, tmp, 1.0)
-    prob = special.betainc(0.5*df, 0.5, tmp)
+    prob = betai(0.5*df, 0.5, df/(df+t*t))
 
     PointbiserialrResult = namedtuple('PointbiserialrResult', ('correlation',
                                                                'pvalue'))
@@ -719,9 +719,7 @@ def ttest_1samp(a, popmean, axis=0):
     df = n - 1.
     svar = ((n - 1) * v) / df
     t = (x - popmean) / ma.sqrt(svar / n)
-    tmp = df/(df + t * t)
-    tmp = np.where(tmp < 1.0, tmp, 1.0)
-    prob = special.betainc(0.5*df, 0.5, tmp)
+    prob = betai(0.5*df, 0.5, df/(df + t*t))
 
     Ttest_1sampResult = namedtuple('Ttest_1sampResult', ('statistic', 'pvalue'))
     return Ttest_1sampResult(t, prob)
@@ -743,9 +741,7 @@ def ttest_ind(a, b, axis=0):
     svar = ((n1-1)*v1+(n2-1)*v2) / df
     t = (x1-x2)/ma.sqrt(svar*(1.0/n1 + 1.0/n2))  # n-D computation here!
     t = ma.filled(t, 1)           # replace NaN t-values with 1.0
-    tmp = df/(df + t * t)
-    tmp = np.where(tmp < 1.0, tmp, 1.0)
-    probs = special.betainc(0.5*df, 0.5, tmp).reshape(t.shape)
+    probs = betai(0.5*df, 0.5, df/(df + t*t)).reshape(t.shape)
 
     return Ttest_indResult(t, probs.squeeze())
 ttest_ind.__doc__ = stats.ttest_ind.__doc__
@@ -766,9 +762,7 @@ def ttest_rel(a, b, axis=0):
     denom = ma.sqrt((n*ma.add.reduce(d*d,axis) - ma.add.reduce(d,axis)**2) / df)
     t = ma.add.reduce(d, axis) / denom
     t = ma.filled(t, 1)
-    tmp = df/(df + t * t)
-    tmp = np.where(tmp < 1.0, tmp, 1.0)
-    probs = special.betainc(0.5*df, 0.5, tmp).reshape(t.shape).squeeze()
+    probs = betai(0.5*df, 0.5, df/(df + t*t)).reshape(t.shape).squeeze()
 
     return Ttest_relResult(t, probs)
 ttest_rel.__doc__ = stats.ttest_rel.__doc__

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -368,7 +368,7 @@ def pearsonr(x,y):
         prob = 0.
     else:
         t_squared = (df / ((1.0 - r) * (1.0 + r))) * r * r
-        prob = betai(0.5*df, 0.5, df/(df + t_squared))
+        prob = _betai(0.5*df, 0.5, df/(df + t_squared))
 
     return r, prob
 
@@ -452,7 +452,7 @@ def spearmanr(x, y, use_ties=True):
     if t is masked:
         prob = 0.
     else:
-        prob = betai(0.5*df, 0.5, df/(df + t * t))
+        prob = _betai(0.5*df, 0.5, df/(df + t * t))
 
     SpearmanrResult = namedtuple('SpearmanrResult', ('correlation', 'pvalue'))
     return SpearmanrResult(rho, prob)
@@ -624,7 +624,7 @@ def pointbiserialr(x, y):
 
     df = n-2
     t = rpb*ma.sqrt(df/(1.0-rpb**2))
-    prob = betai(0.5*df, 0.5, df/(df+t*t))
+    prob = _betai(0.5*df, 0.5, df/(df+t*t))
 
     PointbiserialrResult = namedtuple('PointbiserialrResult', ('correlation',
                                                                'pvalue'))
@@ -719,7 +719,7 @@ def ttest_1samp(a, popmean, axis=0):
     df = n - 1.
     svar = ((n - 1) * v) / df
     t = (x - popmean) / ma.sqrt(svar / n)
-    prob = betai(0.5*df, 0.5, df/(df + t*t))
+    prob = _betai(0.5*df, 0.5, df/(df + t*t))
 
     Ttest_1sampResult = namedtuple('Ttest_1sampResult', ('statistic', 'pvalue'))
     return Ttest_1sampResult(t, prob)
@@ -741,7 +741,7 @@ def ttest_ind(a, b, axis=0):
     svar = ((n1-1)*v1+(n2-1)*v2) / df
     t = (x1-x2)/ma.sqrt(svar*(1.0/n1 + 1.0/n2))  # n-D computation here!
     t = ma.filled(t, 1)           # replace NaN t-values with 1.0
-    probs = betai(0.5*df, 0.5, df/(df + t*t)).reshape(t.shape)
+    probs = _betai(0.5*df, 0.5, df/(df + t*t)).reshape(t.shape)
 
     return Ttest_indResult(t, probs.squeeze())
 ttest_ind.__doc__ = stats.ttest_ind.__doc__
@@ -762,7 +762,7 @@ def ttest_rel(a, b, axis=0):
     denom = ma.sqrt((n*ma.add.reduce(d*d,axis) - ma.add.reduce(d,axis)**2) / df)
     t = ma.add.reduce(d, axis) / denom
     t = ma.filled(t, 1)
-    probs = betai(0.5*df, 0.5, df/(df + t*t)).reshape(t.shape).squeeze()
+    probs = _betai(0.5*df, 0.5, df/(df + t*t)).reshape(t.shape).squeeze()
 
     return Ttest_relResult(t, probs)
 ttest_rel.__doc__ = stats.ttest_rel.__doc__
@@ -840,7 +840,7 @@ def kruskalwallis(*args):
 
     H /= T
     df = len(output) - 1
-    prob = special.chdtrc(df, H)
+    prob = stats.distributions.chi2.sf(H, df)
 
     KruskalResult = namedtuple('KruskalResult', ('statistic', 'pvalue'))
     return KruskalResult(H, prob)
@@ -1706,7 +1706,7 @@ def normaltest(a, axis=0):
     k2 = s*s + k*k
 
     NormaltestResult = namedtuple('NormaltestResult', ('statistic', 'pvalue'))
-    return NormaltestResult(k2, special.chdtrc(2, k2))
+    return NormaltestResult(k2, stats.distributions.chi2.sf(k2, 2))
 normaltest.__doc__ = stats.normaltest.__doc__
 
 
@@ -2110,4 +2110,5 @@ def friedmanchisquare(*args):
 
     FriedmanchisquareResult = namedtuple('FriedmanchisquareResult',
                                          ('statistic', 'pvalue'))
-    return FriedmanchisquareResult(chisq, special.chdtrc(k-1, chisq))
+    return FriedmanchisquareResult(chisq,
+                                   stats.distributions.chi2.sf(chisq, k-1))

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -12,7 +12,6 @@ from __future__ import division, print_function, absolute_import
 
 
 __all__ = ['argstoarray',
-           'betai',
            'chisquare','count_tied_groups',
            'describe',
            'f_oneway','f_value_wilks_lambda','find_repeats','friedmanchisquare',
@@ -290,6 +289,7 @@ def mode(a, axis=0):
 mode.__doc__ = stats.mode.__doc__
 
 
+@np.deprecate(message="mstats.betai is deprecated in scipy 0.17.0")
 def betai(a, b, x):
     x = np.asanyarray(x)
     x = ma.where(x < 1.0, x, 1.0)  # if x > 1 then return 1.0
@@ -362,7 +362,9 @@ def pearsonr(x,y):
         prob = 0.
     else:
         t_squared = (df / ((1.0 - r) * (1.0 + r))) * r * r
-        prob = betai(0.5*df, 0.5, df/(df + t_squared))
+        tmp = df / (df + t_squared)
+        tmp = np.where(tmp < 1.0, tmp, 1.0)
+        prob = special.betainc(0.5*df, 0.5, tmp)
 
     return r, prob
 
@@ -446,7 +448,9 @@ def spearmanr(x, y, use_ties=True):
     if t is masked:
         prob = 0.
     else:
-        prob = betai(0.5*df,0.5,df/(df+t*t))
+        tmp = df/(df + t * t)
+        tmp = np.where(tmp < 1.0, tmp, 1.0)
+        prob = special.betainc(0.5*df, 0.5, tmp)
 
     SpearmanrResult = namedtuple('SpearmanrResult', ('correlation', 'pvalue'))
     return SpearmanrResult(rho, prob)
@@ -618,7 +622,9 @@ def pointbiserialr(x, y):
 
     df = n-2
     t = rpb*ma.sqrt(df/(1.0-rpb**2))
-    prob = betai(0.5*df, 0.5, df/(df+t*t))
+    tmp = df/(df + t * t)
+    tmp = np.where(tmp < 1.0, tmp, 1.0)
+    prob = special.betainc(0.5*df, 0.5, tmp)
 
     PointbiserialrResult = namedtuple('PointbiserialrResult', ('correlation',
                                                                'pvalue'))
@@ -713,7 +719,9 @@ def ttest_1samp(a, popmean, axis=0):
     df = n - 1.
     svar = ((n - 1) * v) / df
     t = (x - popmean) / ma.sqrt(svar / n)
-    prob = betai(0.5 * df, 0.5, df / (df + t*t))
+    tmp = df/(df + t * t)
+    tmp = np.where(tmp < 1.0, tmp, 1.0)
+    prob = special.betainc(0.5*df, 0.5, tmp)
 
     Ttest_1sampResult = namedtuple('Ttest_1sampResult', ('statistic', 'pvalue'))
     return Ttest_1sampResult(t, prob)
@@ -735,7 +743,9 @@ def ttest_ind(a, b, axis=0):
     svar = ((n1-1)*v1+(n2-1)*v2) / df
     t = (x1-x2)/ma.sqrt(svar*(1.0/n1 + 1.0/n2))  # n-D computation here!
     t = ma.filled(t, 1)           # replace NaN t-values with 1.0
-    probs = betai(0.5 * df, 0.5, df/(df + t*t)).reshape(t.shape)
+    tmp = df/(df + t * t)
+    tmp = np.where(tmp < 1.0, tmp, 1.0)
+    probs = special.betainc(0.5*df, 0.5, tmp).reshape(t.shape)
 
     return Ttest_indResult(t, probs.squeeze())
 ttest_ind.__doc__ = stats.ttest_ind.__doc__
@@ -756,7 +766,9 @@ def ttest_rel(a, b, axis=0):
     denom = ma.sqrt((n*ma.add.reduce(d*d,axis) - ma.add.reduce(d,axis)**2) / df)
     t = ma.add.reduce(d, axis) / denom
     t = ma.filled(t, 1)
-    probs = betai(0.5*df,0.5,df/(df+t*t)).reshape(t.shape).squeeze()
+    tmp = df/(df + t * t)
+    tmp = np.where(tmp < 1.0, tmp, 1.0)
+    probs = special.betainc(0.5*df, 0.5, tmp).reshape(t.shape).squeeze()
 
     return Ttest_relResult(t, probs)
 ttest_rel.__doc__ = stats.ttest_rel.__doc__
@@ -834,7 +846,7 @@ def kruskalwallis(*args):
 
     H /= T
     df = len(output) - 1
-    prob = stats.chisqprob(H,df)
+    prob = special.chdtrc(df, H)
 
     KruskalResult = namedtuple('KruskalResult', ('statistic', 'pvalue'))
     return KruskalResult(H, prob)
@@ -1700,7 +1712,7 @@ def normaltest(a, axis=0):
     k2 = s*s + k*k
 
     NormaltestResult = namedtuple('NormaltestResult', ('statistic', 'pvalue'))
-    return NormaltestResult(k2, stats.chisqprob(k2, 2))
+    return NormaltestResult(k2, special.chdtrc(2, k2))
 normaltest.__doc__ = stats.normaltest.__doc__
 
 
@@ -2104,4 +2116,4 @@ def friedmanchisquare(*args):
 
     FriedmanchisquareResult = namedtuple('FriedmanchisquareResult',
                                          ('statistic', 'pvalue'))
-    return FriedmanchisquareResult(chisq, stats.chisqprob(chisq, k-1))
+    return FriedmanchisquareResult(chisq, special.chdtrc(k-1, chisq))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -138,8 +138,8 @@ Probability Calculations
 .. autosummary::
    :toctree: generated/
 
-    chisqprob
-    betai
+   chisqprob
+   betai
 
 ANOVA Functions
 ---------------
@@ -1449,7 +1449,7 @@ def normaltest(a, axis=0):
     k2 = s*s + k*k
 
     NormaltestResult = namedtuple('NormaltestResult', ('statistic', 'pvalue'))
-    return NormaltestResult(k2, special.chdtrc(2, k2))
+    return NormaltestResult(k2, distributions.chi2.sf(k2, 2))
 
 
 def jarque_bera(x):
@@ -2703,7 +2703,7 @@ def pearsonr(x, y):
         prob = 0.0
     else:
         t_squared = r**2 * (df / ((1.0 - r) * (1.0 + r)))
-        prob = betai(0.5*df, 0.5, df/(df+t_squared))
+        prob = _betai(0.5*df, 0.5, df/(df+t_squared))
 
     return r, prob
 
@@ -3054,7 +3054,7 @@ def pointbiserialr(x, y):
     # fixme: see comment about TINY in pearsonr()
     TINY = 1e-20
     t = rpb * np.sqrt(df / ((1.0 - rpb + TINY)*(1.0 + rpb + TINY)))
-    prob = betai(0.5*df, 0.5, df/(df + t*t))
+    prob = _betai(0.5*df, 0.5, df/(df + t*t))
 
     PointbiserialrResult = namedtuple('PointbiserialrResult', ('correlation',
                                                                'pvalue'))
@@ -4175,7 +4175,7 @@ def power_divergence(f_obs, f_exp=None, ddof=0, axis=0, lambda_=None):
 
     num_obs = _count(terms, axis=axis)
     ddof = asarray(ddof)
-    p = special.chdtrc(num_obs - 1 - ddof, stat)
+    p = distributions.chi2.sf(stat, num_obs - 1 - ddof)
 
     Power_divergenceResult = namedtuple('Power_divergenceResult', ('statistic',
                                                                    'pvalue'))
@@ -4552,7 +4552,7 @@ def kruskal(*args):
     h /= ties
 
     KruskalResult = namedtuple('KruskalResult', ('statistic', 'pvalue'))
-    return KruskalResult(h, special.chdtrc(df, h))
+    return KruskalResult(h, distributions.chi2.sf(h, df))
 
 
 def friedmanchisquare(*args):
@@ -4619,7 +4619,7 @@ def friedmanchisquare(*args):
 
     FriedmanchisquareResult = namedtuple('FriedmanchisquareResult',
                                          ('statistic', 'pvalue'))
-    return FriedmanchisquareResult(chisq, special.chdtrc(k - 1, chisq))
+    return FriedmanchisquareResult(chisq, distributions.chi2.sf(chisq, k - 1))
 
 
 def combine_pvalues(pvalues, method='fisher', weights=None):
@@ -4710,7 +4710,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
 
 
 @np.deprecate(message="stats.chisqprob is deprecated in scipy 0.17.0; "
-              "use special.chdtrc instead.")
+              "use stats.distributions.chi2.sf instead.")
 def chisqprob(chisq, df):
     """
     Probability value (1-tail) for the Chi^2 probability distribution.
@@ -4730,7 +4730,7 @@ def chisqprob(chisq, df):
         distribution with degrees of freedom `df`.
 
     """
-    return special.chdtrc(df, chisq)
+    return distributions.chi2.sf(chisq, df)
 
 
 @np.deprecate(message="stats.betai is deprecated in scipy 0.17.0; "

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -138,6 +138,9 @@ Probability Calculations
 .. autosummary::
    :toctree: generated/
 
+    chisqprob
+    betai
+
 ANOVA Functions
 ---------------
 .. autosummary::
@@ -196,6 +199,7 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'mode', 'tmean', 'tvar',
            'ttest_ind', 'ttest_ind_from_stats', 'ttest_rel', 'kstest',
            'chisquare', 'power_divergence', 'ks_2samp', 'mannwhitneyu',
            'tiecorrect', 'ranksums', 'kruskal', 'friedmanchisquare',
+           'chisqprob', 'betai',
            'f_value_wilks_lambda', 'f_value', 'f_value_multivariate',
            'ss', 'square_of_sums', 'fastsort', 'rankdata', 'nanmean',
            'nanstd', 'nanmedian', 'combine_pvalues', ]
@@ -2699,9 +2703,7 @@ def pearsonr(x, y):
         prob = 0.0
     else:
         t_squared = r**2 * (df / ((1.0 - r) * (1.0 + r)))
-        tmp = df/(df+t_squared)
-        tmp = np.where(tmp < 1.0, tmp, 1.0)
-        prob = special.betainc(0.5*df, 0.5, tmp)
+        prob = betai(0.5*df, 0.5, df/(df+t_squared))
 
     return r, prob
 
@@ -3052,9 +3054,7 @@ def pointbiserialr(x, y):
     # fixme: see comment about TINY in pearsonr()
     TINY = 1e-20
     t = rpb * np.sqrt(df / ((1.0 - rpb + TINY)*(1.0 + rpb + TINY)))
-    tmp = df/(df+t*t)
-    tmp = np.where(tmp < 1.0, tmp, 1.0)
-    prob = special.betainc(0.5*df, 0.5, tmp)
+    prob = betai(0.5*df, 0.5, df/(df + t*t))
 
     PointbiserialrResult = namedtuple('PointbiserialrResult', ('correlation',
                                                                'pvalue'))
@@ -4708,7 +4708,9 @@ def combine_pvalues(pvalues, method='fisher', weights=None):
 #      PROBABILITY CALCULATIONS     #
 #####################################
 
-@np.deprecate(message="stats.chisqprob is deprecated in scipy 0.17.0")
+
+@np.deprecate(message="stats.chisqprob is deprecated in scipy 0.17.0; "
+              "use special.chdtrc instead.")
 def chisqprob(chisq, df):
     """
     Probability value (1-tail) for the Chi^2 probability distribution.
@@ -4731,7 +4733,8 @@ def chisqprob(chisq, df):
     return special.chdtrc(df, chisq)
 
 
-@np.deprecate(message="stats.betai is deprecated in scipy 0.17.0")
+@np.deprecate(message="stats.betai is deprecated in scipy 0.17.0; "
+              "use special.betainc instead")
 def betai(a, b, x):
     """
     Returns the incomplete beta function.
@@ -4758,6 +4761,10 @@ def betai(a, b, x):
         Incomplete beta function.
 
     """
+    return _betai(a, b, x)
+
+
+def _betai(a, b, x):
     x = np.asarray(x)
     x = np.where(x < 1.0, x, 1.0)  # if x > 1 then return 1.0
     return special.betainc(a, b, x)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 
 from scipy import integrate
 from scipy import stats
-from scipy.special import chdtrc
+from scipy.special import betainc
 from common_tests import (check_normalization, check_moment, check_mean_expect,
         check_var_expect, check_skew_expect, check_kurt_expect,
         check_entropy, check_private_entropy, NUMPY_BELOW_1_7,
@@ -244,7 +244,7 @@ def check_sample_mean(sm,v,n, popmean):
     df = n-1
     svar = ((n-1)*v) / float(df)    # looks redundant
     t = (sm-popmean) / np.sqrt(svar*(1.0/n))
-    prob = stats.betai(0.5*df, 0.5, df/(df + t*t))
+    prob = betainc(0.5*df, 0.5, df/(df + t*t))
 
     # return t,prob
     npt.assert_(prob > 0.01, 'mean fail, t,prob = %f, %f, m, sm=%f,%f' %
@@ -255,7 +255,7 @@ def check_sample_var(sv,n, popvar):
     # two-sided chisquare test for sample variance equal to hypothesized variance
     df = n-1
     chi2 = (n-1)*popvar/float(popvar)
-    pval = chdtrc(df, chi2) * 2
+    pval = stats.distributions.chi2.sf(chi2, df) * 2
     npt.assert_(pval > 0.01, 'var fail, t, pval = %f, %f, v, sv=%f, %f' %
                 (chi2, pval, popvar, sv))
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 
 from scipy import integrate
 from scipy import stats
-from scipy.special import chdtrc, betainc
+from scipy.special import chdtrc
 from common_tests import (check_normalization, check_moment, check_mean_expect,
         check_var_expect, check_skew_expect, check_kurt_expect,
         check_entropy, check_private_entropy, NUMPY_BELOW_1_7,
@@ -244,9 +244,7 @@ def check_sample_mean(sm,v,n, popmean):
     df = n-1
     svar = ((n-1)*v) / float(df)    # looks redundant
     t = (sm-popmean) / np.sqrt(svar*(1.0/n))
-    tmp = df/(df + t * t)
-    tmp = np.where(tmp < 1.0, tmp, 1.0)
-    prob = betainc(0.5*df, 0.5, tmp)
+    prob = stats.betai(0.5*df, 0.5, df/(df + t*t))
 
     # return t,prob
     npt.assert_(prob > 0.01, 'mean fail, t,prob = %f, %f, m, sm=%f,%f' %
@@ -259,7 +257,7 @@ def check_sample_var(sv,n, popvar):
     chi2 = (n-1)*popvar/float(popvar)
     pval = chdtrc(df, chi2) * 2
     npt.assert_(pval > 0.01, 'var fail, t, pval = %f, %f, v, sv=%f, %f' %
-            (chi2,pval,popvar,sv))
+                (chi2, pval, popvar, sv))
 
 
 def check_cdf_ppf(distfn,arg,msg):

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -7,6 +7,7 @@ import numpy.testing as npt
 
 from scipy import integrate
 from scipy import stats
+from scipy.special import chdtrc, betainc
 from common_tests import (check_normalization, check_moment, check_mean_expect,
         check_var_expect, check_skew_expect, check_kurt_expect,
         check_entropy, check_private_entropy, NUMPY_BELOW_1_7,
@@ -243,7 +244,9 @@ def check_sample_mean(sm,v,n, popmean):
     df = n-1
     svar = ((n-1)*v) / float(df)    # looks redundant
     t = (sm-popmean) / np.sqrt(svar*(1.0/n))
-    prob = stats.betai(0.5*df, 0.5, df/(df+t*t))
+    tmp = df/(df + t * t)
+    tmp = np.where(tmp < 1.0, tmp, 1.0)
+    prob = betainc(0.5*df, 0.5, tmp)
 
     # return t,prob
     npt.assert_(prob > 0.01, 'mean fail, t,prob = %f, %f, m, sm=%f,%f' %
@@ -254,7 +257,7 @@ def check_sample_var(sv,n, popvar):
     # two-sided chisquare test for sample variance equal to hypothesized variance
     df = n-1
     chi2 = (n-1)*popvar/float(popvar)
-    pval = stats.chisqprob(chi2,df)*2
+    pval = chdtrc(df, chi2) * 2
     npt.assert_(pval > 0.01, 'var fail, t, pval = %f, %f, v, sv=%f, %f' %
             (chi2,pval,popvar,sv))
 

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -966,19 +966,6 @@ class TestCompareWithStats(TestCase):
                 rm = stats.mstats.signaltonoise(ym)
                 assert_almost_equal(r, rm, 10)
 
-    def test_betai(self):
-        np.random.seed(12345)
-        for i in range(10):
-            a = np.random.rand() * 5.
-            b = np.random.rand() * 200.
-            assert_equal(stats.betai(a, b, 0.), 0.)
-            assert_equal(stats.betai(a, b, 1.), 1.)
-            assert_equal(stats.mstats.betai(a, b, 0.), 0.)
-            assert_equal(stats.mstats.betai(a, b, 1.), 1.)
-            x = np.random.rand()
-            assert_almost_equal(stats.betai(a, b, x),
-                                stats.mstats.betai(a, b, x), decimal=13)
-
     def test_zscore(self):
         for n in self.get_n():
             x, y, xm, ym = self.generate_xy_sample(n)

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -966,6 +966,19 @@ class TestCompareWithStats(TestCase):
                 rm = stats.mstats.signaltonoise(ym)
                 assert_almost_equal(r, rm, 10)
 
+    def test_betai(self):
+        np.random.seed(12345)
+        for i in range(10):
+            a = np.random.rand() * 5.
+            b = np.random.rand() * 200.
+            assert_equal(stats.betai(a, b, 0.), 0.)
+            assert_equal(stats.betai(a, b, 1.), 1.)
+            assert_equal(stats.mstats.betai(a, b, 0.), 0.)
+            assert_equal(stats.mstats.betai(a, b, 1.), 1.)
+            x = np.random.rand()
+            assert_almost_equal(stats.betai(a, b, x),
+                                stats.mstats.betai(a, b, x), decimal=13)
+
     def test_zscore(self):
         for n in self.get_n():
             x, y, xm, ym = self.generate_xy_sample(n)

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -971,13 +971,16 @@ class TestCompareWithStats(TestCase):
         for i in range(10):
             a = np.random.rand() * 5.
             b = np.random.rand() * 200.
-            assert_equal(stats.betai(a, b, 0.), 0.)
-            assert_equal(stats.betai(a, b, 1.), 1.)
-            assert_equal(stats.mstats.betai(a, b, 0.), 0.)
-            assert_equal(stats.mstats.betai(a, b, 1.), 1.)
-            x = np.random.rand()
-            assert_almost_equal(stats.betai(a, b, x),
-                                stats.mstats.betai(a, b, x), decimal=13)
+
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore', category=DeprecationWarning)
+                assert_equal(stats.betai(a, b, 0.), 0.)
+                assert_equal(stats.betai(a, b, 1.), 1.)
+                assert_equal(stats.mstats.betai(a, b, 0.), 0.)
+                assert_equal(stats.mstats.betai(a, b, 1.), 1.)
+                x = np.random.rand()
+                assert_almost_equal(stats.betai(a, b, x),
+                                    stats.mstats.betai(a, b, x), decimal=13)
 
     def test_zscore(self):
         for n in self.get_n():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -22,6 +22,7 @@ from numpy import array, arange, float32, float64, power
 import numpy as np
 
 import scipy.stats as stats
+from scipy import special
 from common_tests import check_named_results
 
 """ Numbers in docstrings beginning with 'W' refer to the section numbers
@@ -1761,7 +1762,7 @@ class TestPowerDivergence(object):
             assert_allclose(stat, expected_stat)
 
         ddof = np.asarray(ddof)
-        expected_p = stats.chisqprob(expected_stat, num_obs - 1 - ddof)
+        expected_p = special.chdtrc(num_obs - 1 - ddof, expected_stat)
         assert_allclose(p, expected_p)
 
     def test_basic(self):
@@ -1907,23 +1908,22 @@ def test_chisquare_masked_arrays():
 
     chisq, p = stats.chisquare(mobs)
     mat.assert_array_equal(chisq, expected_chisq)
-    mat.assert_array_almost_equal(p, stats.chisqprob(expected_chisq,
-                                                     mobs.count(axis=0) - 1))
+    mat.assert_array_almost_equal(p, special.chdtrc(mobs.count(axis=0) - 1,
+                                                    expected_chisq))
 
     g, p = stats.power_divergence(mobs, lambda_='log-likelihood')
     mat.assert_array_almost_equal(g, expected_g, decimal=15)
-    mat.assert_array_almost_equal(p, stats.chisqprob(expected_g,
-                                                     mobs.count(axis=0) - 1))
+    mat.assert_array_almost_equal(p, special.chdtrc(mobs.count(axis=0) - 1,
+                                                    expected_g))
 
     chisq, p = stats.chisquare(mobs.T, axis=1)
     mat.assert_array_equal(chisq, expected_chisq)
-    mat.assert_array_almost_equal(p,
-                                  stats.chisqprob(expected_chisq,
-                                                  mobs.T.count(axis=1) - 1))
+    mat.assert_array_almost_equal(p, special.chdtrc(mobs.T.count(axis=1) - 1,
+                                                    expected_chisq))
     g, p = stats.power_divergence(mobs.T, axis=1, lambda_="log-likelihood")
     mat.assert_array_almost_equal(g, expected_g, decimal=15)
-    mat.assert_array_almost_equal(p, stats.chisqprob(expected_g,
-                                                     mobs.count(axis=0) - 1))
+    mat.assert_array_almost_equal(p, special.chdtrc(mobs.count(axis=0) - 1,
+                                                    expected_g))
 
     obs1 = np.ma.array([3, 5, 6, 99, 10], mask=[0, 0, 0, 1, 0])
     exp1 = np.ma.array([2, 4, 8, 10, 99], mask=[0, 0, 0, 0, 1])
@@ -1938,7 +1938,7 @@ def test_chisquare_masked_arrays():
     assert_(isinstance(chisq, np.float64))
     assert_(isinstance(p, np.float64))
     assert_equal(chisq, 1.0)
-    assert_almost_equal(p, stats.chisqprob(1.0, 2))
+    assert_almost_equal(p, special.chdtrc(2, 1.0))
 
     # Empty arrays:
     # A data set with length 0 returns a masked scalar.
@@ -3230,20 +3230,20 @@ class TestKruskal(TestCase):
         y = [2]
         h, p = stats.kruskal(x, y)
         assert_equal(h, 1.0)
-        assert_approx_equal(p, stats.chisqprob(h, 1))
+        assert_approx_equal(p, special.chdtrc(1, h))
         h, p = stats.kruskal(np.array(x), np.array(y))
         assert_equal(h, 1.0)
-        assert_approx_equal(p, stats.chisqprob(h, 1))
+        assert_approx_equal(p, special.chdtrc(1, h))
 
     def test_basic(self):
         x = [1, 3, 5, 7, 9]
         y = [2, 4, 6, 8, 10]
         h, p = stats.kruskal(x, y)
         assert_approx_equal(h, 3./11, significant=10)
-        assert_approx_equal(p, stats.chisqprob(3./11, 1))
+        assert_approx_equal(p, special.chdtrc(1, 3./11))
         h, p = stats.kruskal(np.array(x), np.array(y))
         assert_approx_equal(h, 3./11, significant=10)
-        assert_approx_equal(p, stats.chisqprob(3./11, 1))
+        assert_approx_equal(p, special.chdtrc(1, 3./11))
 
     def test_simple_tie(self):
         x = [1]
@@ -3275,7 +3275,7 @@ class TestKruskal(TestCase):
         expected = h_uncorr / corr  # 7.0
         h, p = stats.kruskal(x, y, z)
         assert_approx_equal(h, expected)
-        assert_approx_equal(p, stats.chisqprob(h, 2))
+        assert_approx_equal(p, special.chdtrc(2, h))
 
     def test_kruskal_result_attributes(self):
         x = [1, 3, 5, 7, 9]

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1762,7 +1762,8 @@ class TestPowerDivergence(object):
             assert_allclose(stat, expected_stat)
 
         ddof = np.asarray(ddof)
-        expected_p = special.chdtrc(num_obs - 1 - ddof, expected_stat)
+        expected_p = stats.distributions.chi2.sf(expected_stat,
+                                                 num_obs - 1 - ddof)
         assert_allclose(p, expected_p)
 
     def test_basic(self):
@@ -1906,24 +1907,26 @@ def test_chisquare_masked_arrays():
     expected_g = np.array([2*(2*8*np.log(0.5) + 32*np.log(2.0)),
                            2*(3*np.log(0.75) + 5*np.log(1.25))])
 
+    chi2 = stats.distributions.chi2
+
     chisq, p = stats.chisquare(mobs)
     mat.assert_array_equal(chisq, expected_chisq)
-    mat.assert_array_almost_equal(p, special.chdtrc(mobs.count(axis=0) - 1,
-                                                    expected_chisq))
+    mat.assert_array_almost_equal(p, chi2.sf(expected_chisq,
+                                             mobs.count(axis=0) - 1))
 
     g, p = stats.power_divergence(mobs, lambda_='log-likelihood')
     mat.assert_array_almost_equal(g, expected_g, decimal=15)
-    mat.assert_array_almost_equal(p, special.chdtrc(mobs.count(axis=0) - 1,
-                                                    expected_g))
+    mat.assert_array_almost_equal(p, chi2.sf(expected_g,
+                                             mobs.count(axis=0) - 1))
 
     chisq, p = stats.chisquare(mobs.T, axis=1)
     mat.assert_array_equal(chisq, expected_chisq)
-    mat.assert_array_almost_equal(p, special.chdtrc(mobs.T.count(axis=1) - 1,
-                                                    expected_chisq))
+    mat.assert_array_almost_equal(p, chi2.sf(expected_chisq,
+                                             mobs.T.count(axis=1) - 1))
     g, p = stats.power_divergence(mobs.T, axis=1, lambda_="log-likelihood")
     mat.assert_array_almost_equal(g, expected_g, decimal=15)
-    mat.assert_array_almost_equal(p, special.chdtrc(mobs.count(axis=0) - 1,
-                                                    expected_g))
+    mat.assert_array_almost_equal(p, chi2.sf(expected_g,
+                                             mobs.count(axis=0) - 1))
 
     obs1 = np.ma.array([3, 5, 6, 99, 10], mask=[0, 0, 0, 1, 0])
     exp1 = np.ma.array([2, 4, 8, 10, 99], mask=[0, 0, 0, 0, 1])
@@ -1938,7 +1941,7 @@ def test_chisquare_masked_arrays():
     assert_(isinstance(chisq, np.float64))
     assert_(isinstance(p, np.float64))
     assert_equal(chisq, 1.0)
-    assert_almost_equal(p, special.chdtrc(2, 1.0))
+    assert_almost_equal(p, stats.distributions.chi2.sf(1.0, 2))
 
     # Empty arrays:
     # A data set with length 0 returns a masked scalar.
@@ -3230,20 +3233,20 @@ class TestKruskal(TestCase):
         y = [2]
         h, p = stats.kruskal(x, y)
         assert_equal(h, 1.0)
-        assert_approx_equal(p, special.chdtrc(1, h))
+        assert_approx_equal(p, stats.distributions.chi2.sf(h, 1))
         h, p = stats.kruskal(np.array(x), np.array(y))
         assert_equal(h, 1.0)
-        assert_approx_equal(p, special.chdtrc(1, h))
+        assert_approx_equal(p, stats.distributions.chi2.sf(h, 1))
 
     def test_basic(self):
         x = [1, 3, 5, 7, 9]
         y = [2, 4, 6, 8, 10]
         h, p = stats.kruskal(x, y)
         assert_approx_equal(h, 3./11, significant=10)
-        assert_approx_equal(p, special.chdtrc(1, 3./11))
+        assert_approx_equal(p, stats.distributions.chi2.sf(3./11, 1))
         h, p = stats.kruskal(np.array(x), np.array(y))
         assert_approx_equal(h, 3./11, significant=10)
-        assert_approx_equal(p, special.chdtrc(1, 3./11))
+        assert_approx_equal(p, stats.distributions.chi2.sf(3./11, 1))
 
     def test_simple_tie(self):
         x = [1]
@@ -3275,7 +3278,7 @@ class TestKruskal(TestCase):
         expected = h_uncorr / corr  # 7.0
         h, p = stats.kruskal(x, y, z)
         assert_approx_equal(h, expected)
-        assert_approx_equal(p, special.chdtrc(2, h))
+        assert_approx_equal(p, stats.distributions.chi2.sf(h, 2))
 
     def test_kruskal_result_attributes(self):
         x = [1, 3, 5, 7, 9]


### PR DESCRIPTION
closes gh-641: closes gh-642
