### PR TITLE
[GSoC] WIP: Bounded LSQ algorithms

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -82,7 +82,6 @@ Equation (Local) Minimizers
 
 .. autosummary::
    :toctree: generated/
-
    leastsq - Minimize the sum of squares of M equations in N unknowns
    nnls - Linear least-squares problem with non-negativity constraint
 
@@ -232,7 +231,7 @@ from .nnls import nnls
 from ._basinhopping import basinhopping
 from ._linprog import linprog, linprog_verbose_callback
 from ._differentialevolution import differential_evolution
-
+from .least_squares import least_squares
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 from numpy.testing import Tester

--- a/scipy/optimize/_lsq_bounds.py
+++ b/scipy/optimize/_lsq_bounds.py
@@ -16,40 +16,41 @@ def prepare_bounds(bounds, x0):
 
 
 def in_bounds(x, lb, ub):
-    """Check if the point lies within the bounds."""
+    """Check if a point lies within bounds."""
     return np.all((x >= lb) & (x <= ub))
 
 
-def step_size_to_bound(x, d, lb, ub):
-    """Compute a step size required to reach the bounds.
+def step_size_to_bound(x, s, lb, ub):
+    """Compute a min_step size required to reach a bound.
 
-    The function computes a positive scalar t, such that x + t * d is on
+    The function computes a positive scalar t, such that x + s * t is on
     the bound.
 
     Returns
     -------
     step : float
-        Computed step.
-    hit : array of int with shape of x
-        Each component shows whether a corresponding variable reaches the
+        Computed step. Non-negative value.
+    hits : ndarray of int with shape of x
+        Each element indicates whether a corresponding variable reaches the
         bound:
-             0 - the bound was not hit.
-            -1 - the lower bound was hit.
-             1 - the upper bound was hit.
+
+             *  0 - the bound was not hit.
+             * -1 - the lower bound was hit.
+             *  1 - the upper bound was hit.
     """
-    non_zero = np.nonzero(d)
-    d_nz = d[non_zero]
+    non_zero = np.nonzero(s)
+    s_non_zero = s[non_zero]
     steps = np.empty_like(x)
     steps.fill(np.inf)
     with np.errstate(over='ignore'):
-        steps[non_zero] = np.maximum((lb - x)[non_zero] / d_nz,
-                                     (ub - x)[non_zero] / d_nz)
-    step = np.min(steps)
-    return step, np.equal(steps, step) * np.sign(d).astype(int)
+        steps[non_zero] = np.maximum((lb - x)[non_zero] / s_non_zero,
+                                     (ub - x)[non_zero] / s_non_zero)
+    min_step = np.min(steps)
+    return min_step, np.equal(steps, min_step) * np.sign(s).astype(int)
 
 
-def find_active_constraints(x, lb, ub, rtol=1e-12):
-    """Determine which constraints are active in the given point.
+def find_active_constraints(x, lb, ub, rtol=1e-10):
+    """Determine which constraints are active in a given point.
 
     The threshold is computed using `rtol` and the absolute value of the
     closest bound.
@@ -58,73 +59,85 @@ def find_active_constraints(x, lb, ub, rtol=1e-12):
     ------
     active : ndarray of int with shape of x
         Each component shows whether the corresponding constraint is active:
-             0 - a constraint is not active.
-            -1 - a lower bound is active.
-             1 - a upper bound is active.
+
+             *  0 - a constraint is not active.
+             * -1 - a lower bound is active.
+             *  1 - a upper bound is active.
     """
     active = np.zeros_like(x, dtype=int)
+
+    if rtol == 0:
+        active[x <= lb] = -1
+        active[x >= ub] = 1
+        return active
 
     lower_dist = x - lb
     upper_dist = ub - x
 
-    mask = lower_dist < upper_dist
-    value = lower_dist[mask] < rtol * np.maximum(1, np.abs(lb[mask]))
-    active[mask] = -value.astype(int)
-    value = upper_dist[~mask] < rtol * np.maximum(1, np.abs(ub[~mask]))
-    active[~mask] = value.astype(int)
+    lower_threshold = rtol * np.maximum(1, np.abs(lb))
+    upper_threshold = rtol * np.maximum(1, np.abs(ub))
+
+    lower_active = (np.isfinite(lb) &
+                    (lower_dist <= np.minimum(upper_dist, lower_threshold)))
+    active[lower_active] = -1
+
+    upper_active = (np.isfinite(ub) &
+                    (upper_dist <= np.minimum(lower_dist, upper_threshold)))
+    active[upper_active] = 1
 
     return active
 
 
-def make_strictly_feasible(x, lb, ub, rstep=0):
-    """Shift the point in the slightest possible way to the interior.
+def make_strictly_feasible(x, lb, ub, rstep=1e-10):
+    """Shift a point to the interior of a feasible region.
 
-    If ``rstep=0`` the function uses np.nextafter, otherwise `rstep` is
-    multiplied by absolute value of the bound.
-
-    The utility of this function is questionable to me. Maybe bigger shifts
-    should be used, or maybe this function is not necessary at all despite
-    theoretical requirement of our interior point algorithm.
+    Each element of the returned vector is at least at a relative distance
+    `rstep` from the closest bound. If ``rstep=0`` then `np.nextafter` is used.
     """
     x_new = x.copy()
 
-    m = x <= lb
-    if rstep == 0:
-        x_new[m] = np.nextafter(lb[m], ub[m])
-    else:
-        x_new[m] = lb[m] + rstep * (1 + np.abs(lb[m]))
+    active = find_active_constraints(x, lb, ub, rstep)
+    lower_mask = np.equal(active, -1)
+    upper_mask = np.equal(active, 1)
 
-    m = x >= ub
     if rstep == 0:
-        x_new[m] = np.nextafter(ub[m], lb[m])
+        x_new[lower_mask] = np.nextafter(lb[lower_mask], ub[lower_mask])
+        x_new[upper_mask] = np.nextafter(ub[upper_mask], lb[upper_mask])
     else:
-        x_new[m] = ub[m] - rstep * (1 + np.abs(ub[m]))
+        x_new[lower_mask] = (lb[lower_mask] +
+                             rstep * np.maximum(1, np.abs(lb[lower_mask])))
+        x_new[upper_mask] = (ub[upper_mask] -
+                             rstep * np.maximum(1, np.abs(ub[upper_mask])))
+
+    tight_bounds = (x_new < lb) | (x_new > ub)
+    x_new[tight_bounds] = 0.5 * (lb[tight_bounds] + ub[tight_bounds])
 
     return x_new
 
 
 def scaling_vector(x, g, lb, ub):
     """Compute a scaling vector and its derivatives as described in papers
-    of Coleman and Li.
+    of Coleman and Li [1]_.
 
-    We define components of a vector v as follows:
+    Components of a vector v are defined as follows:
+    ::
 
-           | u[i] - x[i], if g[i] < 0 and u[i] < np.inf
-    v[i] = | x[i] - l[i], if g[i] > 0 and l[i] > -np.inf
-           | 1,           otherwise
+               | ub[i] - x[i], if g[i] < 0 and ub[i] < np.inf
+        v[i] = | x[i] - lb[i], if g[i] > 0 and lb[i] > -np.inf
+               | 1,           otherwise
 
     According to this definition v[i] >= 0 for all i. It differs from the
-    definition in paper [1]_ (eq. (2.2)). where they use the absolute value
-    of v. Both definitions are equivalent down the line.
+    definition in paper [1]_ (eq. (2.2)), where the absolute value of v is
+    used. Both definitions are equivalent down the line.
 
-    Also we need its derivatives with respect to x which take
-    values 1, -1 or 0 depending on a case.
+    Derivatives of v with respect to x take value 1, -1 or 0 depending on a
+    case.
 
     Returns
     -------
     v : ndarray with shape of x
         Scaling vector.
-    jv : ndarray with shape of x
+    dv : ndarray with shape of x
         Derivatives of v[i] with respect to x[i], diagonal elements of v's
         Jacobian.
 
@@ -136,21 +149,14 @@ def scaling_vector(x, g, lb, ub):
            Vol. 21, Number 1, pp 1-23, 1999.
     """
     v = np.ones_like(x)
-    jv = np.zeros_like(x)
+    dv = np.zeros_like(x)
 
     mask = (g < 0) & np.isfinite(ub)
     v[mask] = ub[mask] - x[mask]
-    jv[mask] = -1
+    dv[mask] = -1
 
     mask = (g > 0) & np.isfinite(lb)
     v[mask] = x[mask] - lb[mask]
-    jv[mask] = 1
+    dv[mask] = 1
 
-    return v, jv
-
-
-def CL_optimality(x, g, lb, ub):
-    lb = np.resize(lb, x.shape)
-    ub = np.resize(ub, x.shape)
-    v, _ = scaling_vector(x, g, lb, ub)
-    return np.linalg.norm(v * g, ord=np.inf)
+    return v, dv

--- a/scipy/optimize/_lsq_bounds.py
+++ b/scipy/optimize/_lsq_bounds.py
@@ -1,0 +1,156 @@
+"""Utility functions to work with bound constraints."""
+
+import numpy as np
+
+
+def prepare_bounds(bounds, x0):
+    """Prepare bounds for usage in algorithms."""
+    lb, ub = [np.asarray(b, dtype=float) for b in bounds]
+    if lb.ndim == 0:
+        lb = np.resize(lb, x0.shape)
+
+    if ub.ndim == 0:
+        ub = np.resize(ub, x0.shape)
+
+    return lb, ub
+
+
+def in_bounds(x, lb, ub):
+    """Check if the point lies within the bounds."""
+    return np.all((x >= lb) & (x <= ub))
+
+
+def step_size_to_bound(x, d, lb, ub):
+    """Compute a step size required to reach the bounds.
+
+    The function computes a positive scalar t, such that x + t * d is on
+    the bound.
+
+    Returns
+    -------
+    step : float
+        Computed step.
+    hit : array of int with shape of x
+        Each component shows whether a corresponding variable reaches the
+        bound:
+             0 - the bound was not hit.
+            -1 - the lower bound was hit.
+             1 - the upper bound was hit.
+    """
+    non_zero = np.nonzero(d)
+    d_nz = d[non_zero]
+    steps = np.empty_like(x)
+    steps.fill(np.inf)
+    with np.errstate(over='ignore'):
+        steps[non_zero] = np.maximum((lb - x)[non_zero] / d_nz,
+                                     (ub - x)[non_zero] / d_nz)
+    step = np.min(steps)
+    return step, np.equal(steps, step) * np.sign(d).astype(int)
+
+
+def find_active_constraints(x, lb, ub, rtol=1e-12):
+    """Determine which constraints are active in the given point.
+
+    The threshold is computed using `rtol` and the absolute value of the
+    closest bound.
+
+    Returns
+    ------
+    active : ndarray of int with shape of x
+        Each component shows whether the corresponding constraint is active:
+             0 - a constraint is not active.
+            -1 - a lower bound is active.
+             1 - a upper bound is active.
+    """
+    active = np.zeros_like(x, dtype=int)
+
+    lower_dist = x - lb
+    upper_dist = ub - x
+
+    mask = lower_dist < upper_dist
+    value = lower_dist[mask] < rtol * np.maximum(1, np.abs(lb[mask]))
+    active[mask] = -value.astype(int)
+    value = upper_dist[~mask] < rtol * np.maximum(1, np.abs(ub[~mask]))
+    active[~mask] = value.astype(int)
+
+    return active
+
+
+def make_strictly_feasible(x, lb, ub, rstep=0):
+    """Shift the point in the slightest possible way to the interior.
+
+    If ``rstep=0`` the function uses np.nextafter, otherwise `rstep` is
+    multiplied by absolute value of the bound.
+
+    The utility of this function is questionable to me. Maybe bigger shifts
+    should be used, or maybe this function is not necessary at all despite
+    theoretical requirement of our interior point algorithm.
+    """
+    x_new = x.copy()
+
+    m = x <= lb
+    if rstep == 0:
+        x_new[m] = np.nextafter(lb[m], ub[m])
+    else:
+        x_new[m] = lb[m] + rstep * (1 + np.abs(lb[m]))
+
+    m = x >= ub
+    if rstep == 0:
+        x_new[m] = np.nextafter(ub[m], lb[m])
+    else:
+        x_new[m] = ub[m] - rstep * (1 + np.abs(ub[m]))
+
+    return x_new
+
+
+def scaling_vector(x, g, lb, ub):
+    """Compute a scaling vector and its derivatives as described in papers
+    of Coleman and Li.
+
+    We define components of a vector v as follows:
+
+           | u[i] - x[i], if g[i] < 0 and u[i] < np.inf
+    v[i] = | x[i] - l[i], if g[i] > 0 and l[i] > -np.inf
+           | 1,           otherwise
+
+    According to this definition v[i] >= 0 for all i. It differs from the
+    definition in paper [1]_ (eq. (2.2)). where they use the absolute value
+    of v. Both definitions are equivalent down the line.
+
+    Also we need its derivatives with respect to x which take
+    values 1, -1 or 0 depending on a case.
+
+    Returns
+    -------
+    v : ndarray with shape of x
+        Scaling vector.
+    jv : ndarray with shape of x
+        Derivatives of v[i] with respect to x[i], diagonal elements of v's
+        Jacobian.
+
+    References
+    ----------
+    .. [1] Branch, M.A., T.F. Coleman, and Y. Li, "A Subspace, Interior,
+           and Conjugate Gradient Method for Large-Scale Bound-Constrained
+           Minimization Problems," SIAM Journal on Scientific Computing,
+           Vol. 21, Number 1, pp 1-23, 1999.
+    """
+    v = np.ones_like(x)
+    jv = np.zeros_like(x)
+
+    mask = (g < 0) & np.isfinite(ub)
+    v[mask] = ub[mask] - x[mask]
+    jv[mask] = -1
+
+    mask = (g > 0) & np.isfinite(lb)
+    v[mask] = x[mask] - lb[mask]
+    jv[mask] = 1
+
+    return v, jv
+
+
+def CL_optimality(x, g, lb, ub):
+    lb = np.resize(lb, x.shape)
+    ub = np.resize(ub, x.shape)
+    v, _ = scaling_vector(x, g, lb, ub)
+    return np.linalg.norm(v * g, ord=np.inf)

--- a/scipy/optimize/_lsq_dogbox.py
+++ b/scipy/optimize/_lsq_dogbox.py
@@ -1,0 +1,274 @@
+from __future__ import division
+
+import numpy as np
+from numpy.linalg import lstsq, norm
+from scipy.optimize import OptimizeResult
+
+from ._lsq_bounds import step_size_to_bound, in_bounds
+
+
+def find_intersection(x, tr_bounds, lb, ub):
+    """Find intersection of trust-region bounds and initial bounds.
+
+    Returns
+    -------
+    lb_total, ub_total : ndarray with shape of x
+        Lower and upper bounds of the intersection region.
+    orig_l, orig_u : ndarray of bool with shape of x
+        True means that an original bound is taken as a corresponding bound
+        in the intersection region.
+    tr_l, tr_u : ndarray of bool with shape of x
+        True means that a trust-region bound is taken as a corresponding bound
+        in the intersection region.
+    """
+    lb_centered = lb - x
+    ub_centered = ub - x
+
+    lb_total = np.maximum(lb_centered, -tr_bounds)
+    ub_total = np.minimum(ub_centered, tr_bounds)
+
+    orig_l = np.equal(lb_total, lb_centered)
+    orig_u = np.equal(ub_total, ub_centered)
+
+    tr_l = np.equal(lb_total, -tr_bounds)
+    tr_u = np.equal(ub_total, tr_bounds)
+
+    return lb_total, ub_total, orig_l, orig_u, tr_l, tr_u
+
+
+def dogleg_step(x, cauchy_step, newton_step, tr_bounds, l, u):
+    """Find dogleg step in rectangular constraints.
+
+    Returns
+    -------
+    step : ndarray, shape (n,)
+        Computed dogleg step.
+    bound_hits : ndarray of int, shape (n,)
+        Each component shows whether a corresponding variable reaches the
+        initial bound after the step is taken:
+             0 - a variable doesn't reach the bound.
+            -1 - `l` is reached.
+             1 - `u` is reached.
+    tr_hit : bool
+        Whether the step reaches the boundary of the trust-region.
+    """
+    lb_total, ub_total, orig_l, orig_u, tr_l, tr_u = find_intersection(
+        x, tr_bounds, l, u
+    )
+
+    bound_hits = np.zeros_like(x, dtype=int)
+
+    if in_bounds(newton_step, lb_total, ub_total):
+        return newton_step, bound_hits, False
+
+    if not in_bounds(cauchy_step, lb_total, ub_total):
+        alpha, _ = step_size_to_bound(
+            np.zeros_like(cauchy_step), cauchy_step, lb_total, ub_total)
+        cauchy_step = alpha * cauchy_step
+
+    step_diff = newton_step - cauchy_step
+    alpha, hits = step_size_to_bound(cauchy_step, step_diff,
+                                     lb_total, ub_total)
+    bound_hits[(hits < 0) & orig_l] = -1
+    bound_hits[(hits > 0) & orig_u] = 1
+    tr_hit = np.any((hits < 0) & tr_l | (hits > 0) & tr_u)
+
+    return cauchy_step + alpha * step_diff, bound_hits, tr_hit
+
+
+def constrained_cauchy_step(x, cauchy_step, tr_bounds, l, u):
+    """Find constrained Cauchy step.
+
+    Returns are the same as in dogleg_step function.
+    """
+    lb_total, ub_total, orig_l, orig_u, tr_l, tr_u = find_intersection(
+        x, tr_bounds, l, u
+    )
+    bound_hits = np.zeros_like(x, dtype=int)
+    if in_bounds(cauchy_step, lb_total, ub_total):
+        return cauchy_step, bound_hits, False
+
+    beta, hits = step_size_to_bound(
+        np.zeros_like(cauchy_step), cauchy_step, lb_total, ub_total)
+
+    bound_hits[(hits < 0) & orig_l] = -1
+    bound_hits[(hits > 0) & orig_u] = 1
+    tr_hit = np.any((hits < 0) & tr_l | (hits > 0) & tr_u)
+
+    return beta * cauchy_step, bound_hits, tr_hit
+
+
+def dogbox(fun, jac, x0, lb, ub, ftol, xtol, gtol, max_nfev, scaling):
+    """Minimize the sum of squares of nonlinear functions subject to bounds on
+    independent variables by dogleg method applied to a rectangular trust
+    region.
+
+    Options
+    -------
+    ftol : float
+        The optimization process is stopped when ``dF < ftol * F`` and
+        dF_actual / dF_predicted > 0.25, where F is the objective function
+        value (the sum of squares), dF_actual is its change in the last
+        iteration, dF_predicted is predicted change from a local quadratic
+        model.
+    xtol : float
+        The optimization process is stopped when
+        ``Delta < xtol * max(EPS**0.5, norm(scaled_x))``, where Delta is a
+        trust-region radius, scaled_x is a scaled value of x according
+        to `scaling` parameter, EPS is machine epsilon.
+    gtol : float
+        The optimization process is stopped when
+        ``norm(g_free, ord=np.inf) < gtol``, where g_free is the gradient
+        with respect to the variables which aren't in the optimal state
+        on the boundary. If all variables reach optimum on the boundary,
+        then g_free is effectively assigned to zero and the algorithm
+        terminates.
+    max_nfev : None or int
+        Maximum number of function evaluations before the termination.
+        If None (default), it is assigned to 100 * n.
+    """
+    EPS = np.finfo(float).eps
+
+    f = fun(x0)
+    nfev = 1
+
+    J = jac(x0, f)
+    njev = 1
+
+    if f.shape[0] != J.shape[0]:
+        raise RuntimeError("Inconsistent dimensions between the returns of "
+                           "`fun` and `jac` on the first iteration.")
+
+    if scaling == 'jac':
+        J_norm = np.sum(J**2, axis=0)**0.5
+        J_norm[J_norm == 0] = 1
+        scale = 1 / J_norm
+    else:
+        scale = 1 / scaling
+
+    Delta = norm(x0 / scale, ord=np.inf)
+    if Delta == 0:
+        Delta = 1.0
+
+    on_bound = np.zeros_like(x0, dtype=int)
+    on_bound[np.equal(x0, lb)] = -1
+    on_bound[np.equal(x0, ub)] = 1
+
+    x = x0.copy()
+    step = np.empty_like(x0)
+    obj_value = np.dot(f, f)
+
+    if max_nfev is None:
+        max_nfev = x0.size * 100
+
+    termination_status = None
+    while nfev < max_nfev:
+        if scaling == 'jac':
+            # Where is norm(..., axis=0) in numpy 1.6.2?
+            J_norm = np.sum(J**2, axis=0)**0.5
+            with np.errstate(divide='ignore'):
+                scale = np.minimum(scale, 1 / J_norm)
+
+        g = J.T.dot(f)
+
+        active_set = on_bound * g < 0
+        free_set = ~active_set
+
+        J_free = J[:, free_set]
+        g_free = g[free_set]
+        x_free = x[free_set]
+        l_free = lb[free_set]
+        u_free = ub[free_set]
+        scale_free = scale[free_set]
+
+        if np.all(active_set):
+            g_norm = 0.0
+            termination_status = 1
+        else:
+            g_norm = norm(g_free, ord=np.inf)
+            if g_norm < gtol:
+                termination_status = 1
+
+        if termination_status is not None:
+            return OptimizeResult(
+                x=x, fun=f, jac=J, obj_value=obj_value, optimality=g_norm,
+                active_mask=on_bound, nfev=nfev, njev=njev,
+                status=termination_status, x_covariance=None)
+
+        # Compute (Gauss-)Newton and Cauchy steps
+        newton_step = lstsq(J_free, -f)[0]
+        Jg = J_free.dot(g_free)
+        cauchy_step = -np.dot(g_free, g_free) / np.dot(Jg, Jg) * g_free
+
+        actual_reduction = -1.0
+        while actual_reduction <= 0 and nfev < max_nfev:
+            tr_bounds = Delta * scale_free
+
+            step_free, on_bound_free, tr_hit = dogleg_step(
+                x_free, cauchy_step, newton_step, tr_bounds, l_free, u_free)
+
+            Js = J_free.dot(step_free)
+            predicted_reduction = -np.dot(Js, Js) - 2 * np.dot(Js, f)
+
+            # In (nearly) rank deficient case Newton (and thus dogleg) step
+            # can be inadequate, in this case use (constrained) Cauchy step.
+            if predicted_reduction <= 0:
+                step_free, on_bound_free, tr_hit = constrained_cauchy_step(
+                    x_free, cauchy_step, tr_bounds, l_free, u_free)
+                predicted_reduction = -np.dot(Js, Js) - 2 * np.dot(Js, f)
+
+            step.fill(0.0)
+            step[free_set] = step_free
+            x_new = x + step
+
+            f_new = fun(x_new)
+            nfev += 1
+
+            # Usual trust-region step quality estimation.
+            obj_value_new = np.dot(f_new, f_new)
+            actual_reduction = obj_value - obj_value_new
+
+            if predicted_reduction > 0:
+                ratio = actual_reduction / predicted_reduction
+            else:
+                ratio = 0
+
+            if ratio < 0.25:
+                Delta = 0.25 * norm(step / scale, ord=np.inf)
+            elif ratio > 0.75 and tr_hit:
+                Delta *= 2.0
+
+            ftol_satisfied = (abs(actual_reduction) < ftol * obj_value and
+                              ratio > 0.25)
+            xtol_satisfied = Delta < xtol * max(EPS**0.5,
+                                                norm(x / scale, ord=np.inf))
+
+            if ftol_satisfied and xtol_satisfied:
+                termination_status = 4
+            elif ftol_satisfied:
+                termination_status = 2
+            elif xtol_satisfied:
+                termination_status = 3
+            if termination_status is not None:
+                break
+
+        if actual_reduction > 0:
+            on_bound[free_set] = on_bound_free
+
+            x = x_new
+            # Set variables exactly at the boundary.
+            mask = on_bound == -1
+            x[mask] = lb[mask]
+            mask = on_bound == 1
+            x[mask] = ub[mask]
+
+            f = f_new
+            obj_value = obj_value_new
+
+            J = jac(x, f)
+            njev += 1
+
+    return OptimizeResult(
+        x=x, fun=f, jac=J, obj_value=obj_value, optimality=g_norm,
+        active_mask=on_bound, nfev=nfev, njev=njev, status=0,
+        x_covariance=None)

--- a/scipy/optimize/_lsq_dogbox.py
+++ b/scipy/optimize/_lsq_dogbox.py
@@ -215,6 +215,7 @@ def dogbox(fun, jac, x0, lb, ub, ftol, xtol, gtol, max_nfev, scaling):
             if predicted_reduction <= 0:
                 step_free, on_bound_free, tr_hit = constrained_cauchy_step(
                     x_free, cauchy_step, tr_bounds, l_free, u_free)
+                Js = J_free.dot(step_free)
                 predicted_reduction = -np.dot(Js, Js) - 2 * np.dot(Js, f)
 
             step.fill(0.0)

--- a/scipy/optimize/_lsq_trf.py
+++ b/scipy/optimize/_lsq_trf.py
@@ -7,8 +7,8 @@ from numpy.linalg import norm
 from scipy.linalg import svd
 
 from .optimize import OptimizeResult
-from ._lsq_bounds  import (step_size_to_bound, make_strictly_feasible,
-                           find_active_constraints, scaling_vector)
+from ._lsq_bounds import (step_size_to_bound, make_strictly_feasible,
+                          find_active_constraints, scaling_vector)
 from ._lsq_trust_region import intersect_trust_region, solve_lsq_trust_region
 
 

--- a/scipy/optimize/_lsq_trf.py
+++ b/scipy/optimize/_lsq_trf.py
@@ -1,0 +1,358 @@
+"""Trust Region Reflective algorithm for least-squares optimization."""
+
+from __future__ import division
+
+import numpy as np
+from numpy.linalg import norm
+from scipy.linalg import svd
+
+from .optimize import OptimizeResult
+from ._lsq_bounds  import (step_size_to_bound, make_strictly_feasible,
+                           find_active_constraints, scaling_vector)
+from ._lsq_trust_region import intersect_trust_region, solve_lsq_trust_region
+
+
+def minimize_quadratic(a, b, l, u):
+    """Minimize a 1-d quadratic function subject to bounds.
+
+    The free term is omitted, that is we consider y = a * t**2 + b * t.
+
+    Returns
+    -------
+    t : float
+        The minimum point.
+    y : float
+        The minimum value.
+    """
+    t = np.array([l, u])
+    if a != 0:
+        extremum = -0.5 * b / a
+        if l <= extremum <= u:
+            t = np.hstack((t, extremum))
+    y = a * t**2 + b * t
+    i = np.argmin(y)
+    return t[i], y[i]
+
+
+def build_1d_quadratic_function(J, diag, g, s, s0=None):
+    """Compute coefficients of a 1-d quadratic function for the line search
+    from the multidimensional quadratic function.
+
+    The function is given as follows:
+    ``f(t) = 0.5 * (s0 + t*s).T * (J.T*J + diag) * (s0 + t*s) +
+             g.T * (s0 + t*s)``.
+
+    Parameters
+    ----------
+    J : ndarray, shape (m, n)
+        Jacobian matrix.
+    diag : ndarray, shape (n,)
+        Addition diagonal term in a quadratic part.
+    g : ndarray, shape (n,)
+        Gradient, defines a linear term.
+    s : ndarray, shape (n,)
+        Direction of search.
+    s0 : None or ndarray with shape (n,), optional
+        Initial point. If None assumed to be 0.
+
+    Returns
+    ------
+    a : float
+        Coefficient for t**2.
+    b : float
+        Coefficient for t.
+
+    Notes
+    -----
+    The free term "c" is not returned as it is not usually required.
+    """
+    v = J.dot(s)
+    a = 0.5 * (np.dot(v, v) + np.dot(s * diag, s))
+    b = np.dot(g, s)
+    if s0 is not None:
+        u = J.dot(s0)
+        b += np.dot(u, v) + np.dot(s0 * diag, s)
+
+    return a, b
+
+
+def evaluate_quadratic_function(J, diag, g, steps):
+    """Compute values of a quadratic function arising in least-squares.
+
+    The function is 0.5 * s.T * (J.T * J + diag) * s + g.T * s.
+
+    Parameters
+    ----------
+    J : ndarray, shape (m, n)
+        Jacobian matrix.
+    diag : ndarray, shape (n,)
+        Additional diagonal term.
+    f : ndarray, shape (m,)
+        Vector of residuals.
+    steps : ndarray, shape (k, m)
+        Array containing k steps as rows.
+
+    Returns
+    -------
+    values : ndarray, shape (k,)
+        Array containing k values of the function.
+    """
+    Js = J.dot(steps.T)
+    return 0.5 * (np.sum(Js**2, axis=0) +
+                  np.sum(diag * steps**2, axis=1)) + np.dot(steps, g)
+
+
+def find_reflected_step(x, J_h, diag_h, g_h, p, p_h, d, Delta, l, u, theta):
+    """Find a single reflection step for Trust Region Reflective algorithm.
+
+    Also corrects the initial step p/p_h. This function must be called only
+    if x + p is not within the bounds.
+    """
+    # Use term "stride" for scalar step length.
+    p_stride, hits = step_size_to_bound(x, p, l, u)
+
+    # Compute the reflected direction.
+    r_h = np.copy(p_h)
+    r_h[hits.astype(bool)] *= -1
+    r = d * r_h
+
+    # Restrict the p step to exactly the bound.
+    p *= p_stride
+    p_h *= p_stride
+    x_on_bound = x + p
+
+    # Reflected direction will cross first either feasible region or trust
+    # region boundary.
+    _, to_tr = intersect_trust_region(p_h, r_h, Delta)
+    to_bound, _ = step_size_to_bound(x_on_bound, r, l, u)
+    to_bound *= theta  # Stay strictly interior.
+
+    r_stride_u = min(to_bound, to_tr)
+
+    # We want a reflected step be at the same theta distance from the bound,
+    # so we introduce a lower bound on the allowed stride.
+    # The formula below is correct as p_h and r_h has the same norm.
+
+    if r_stride_u > 0:
+        r_stride_l = (1 - theta) * p_stride / r_stride_u
+    else:
+        r_stride_l = -1
+
+    # Check if no reflection step is available.
+    if r_stride_l <= r_stride_u:
+        a, b = build_1d_quadratic_function(J_h, diag_h, g_h, r_h, s0=p_h)
+        r_stride, _ = minimize_quadratic(a, b, r_stride_l, r_stride_u)
+        r_h = p_h + r_h * r_stride
+    else:
+        r_h = None
+
+    # Now we want to correct p_h to make it strictly interior.
+    p_h *= theta
+
+    # If no reflection step just return p_h for convenience.
+    if r_h is None:
+        return p_h, p_h
+    else:
+        return p_h, r_h
+
+
+def find_gradient_step(x, J_h, diag_h, g_h, d, Delta, l, u, theta):
+    """Find a minimizer of a quadratic model along the scaled gradient."""
+    to_bound, _ = step_size_to_bound(x, -g_h * d, l, u)
+    to_bound *= theta
+
+    to_tr = Delta / norm(g_h)
+    g_stride = min(to_bound, to_tr)
+
+    a, b = build_1d_quadratic_function(J_h, diag_h, g_h, -g_h)
+    g_stride, _ = minimize_quadratic(a, b, 0.0, g_stride)
+
+    return -g_stride * g_h
+
+
+def trf(fun, jac, x0, lb, ub, ftol, xtol, gtol, max_nfev, scaling):
+    """Minimize the sum of squares of nonlinear functions subject to bounds on
+    independent variables by Trust Region Reflective algorithm.
+
+    Options
+    -------
+    ftol : float
+        The optimization process is stopped when ``dF < ftol * F`` and
+        dF_actual / dF_predicted > 0.25, where F is the objective function
+        value (the sum of squares), dF_actual is its change in the last
+        iteration, dF_predicted is predicted change from a local quadratic
+        model.
+    xtol : float, optional
+        The optimization process is stopped when
+        ``norm(dx) < xtol * max(EPS**0.5, norm(x))``, where dx is a step taken
+        in the last iteration and EPS is machine epsilon.
+    gtol : float, optional
+        The optimization process is stopped when
+        ``norm(g_scaled, ord=np.inf) < gtol``, where g_scaled is properly
+        scaled gradient to account for the presence of bounds.
+        The scaling imposed by `scaling` parameter is not considered.
+    max_nfev : None or int, optional
+        Maximum number of function evaluations before the termination.
+        If None (default), it is assigned to 100 * n.
+    """
+    EPS = np.finfo(float).eps
+
+    # We need strictly feasible guess to start with
+    x = make_strictly_feasible(x0, lb, ub, rstep=1e-10)
+
+    f = fun(x)
+    nfev = 1
+
+    J = jac(x, f)
+    njev = 1
+
+    if f.shape[0] != J.shape[0]:
+        raise RuntimeError("Inconsistent dimensions between the returns of "
+                           "`fun` and `jac` on the first iteration.")
+
+    g = J.T.dot(f)
+    m, n = J.shape
+
+    if scaling == 'jac':
+        J_norm = np.sum(J**2, axis=0)**0.5
+        J_norm[J_norm == 0] = 1
+        scale = 1 / J_norm
+    else:
+        scale = 1 / scaling
+
+    v, jv = scaling_vector(x, g, lb, ub)
+    Delta = norm(x0 / (scale * v**0.5))
+    if Delta == 0:
+        Delta = 1.0
+
+    J_augmented = np.empty((m + n, n))
+    f_augmented = np.zeros((m + n))
+
+    obj_value = np.dot(f, f)
+    alpha = 0.0  # "Levenberg-Marquardt" parameter
+
+    if max_nfev is None:
+        max_nfev = x0.size * 100
+
+    termination_status = None
+    while nfev < max_nfev:
+        if scaling == 'jac':
+            J_norm = np.sum(J**2, axis=0)**0.5
+            with np.errstate(divide='ignore'):
+                scale = np.minimum(scale, 1 / J_norm)
+
+        g = J.T.dot(f)
+
+        # Compute Coleman-Li scaling parameters and "hat" variables.
+        v, jv = scaling_vector(x, g, lb, ub)
+        d = v**0.5 * scale
+        g_h = d * g
+        diag_h = g * jv * scale**2
+
+        g_norm = norm(g * v, ord=np.inf)
+        if g_norm < gtol:
+            termination_status = 1
+
+        if termination_status is not None:
+            active_mask = find_active_constraints(x, lb, ub, rtol=xtol)
+            return OptimizeResult(
+                x=x, fun=f, jac=J, obj_value=obj_value, optimality=g_norm,
+                active_mask=active_mask, nfev=nfev, njev=njev,
+                status=termination_status, x_covariance=None)
+
+        # Jacobian in "hat" space.
+        J_h = J * d
+
+        # J_augmented is used to solve a trust-region subproblem with
+        # diagonal term diag_h.
+        J_augmented[:m] = J_h
+        J_augmented[m:] = np.diag(diag_h**0.5)
+        f_augmented[:m] = f
+
+        U, s, V = svd(J_augmented, full_matrices=False)
+        V = V.T
+        uf = U.T.dot(f_augmented)
+
+        # theta controls step back size from the bounds.
+        theta = max(0.995, 1 - g_norm)
+        actual_reduction = -1
+
+        # In the following: p - trust-region solution, r - reflected solution,
+        # c - minimizer along the scaled gradient, _h means the variable
+        # is computed in "hat" space.
+        while actual_reduction <= 0 and nfev < max_nfev:
+            p_h, alpha, n_iter = solve_lsq_trust_region(
+                n, m, uf, s, V, Delta, initial_alpha=alpha)
+            p = d * p_h
+
+            to_bound, _ = step_size_to_bound(x, p, lb, ub)
+            if to_bound >= 1:  # Trust region step is feasible.
+                # Still step back from the bounds
+                p_h *= min(theta * to_bound, 1)
+                steps_h = np.atleast_2d(p_h)
+            else:  # Otherwise consider a reflected and gradient steps.
+                p_h, r_h = find_reflected_step(x, J_h, diag_h, g_h, p, p_h,
+                                               d, Delta, lb, ub, theta)
+                c_h = find_gradient_step(x, J_h, diag_h, g_h,
+                                         d, Delta, lb, ub, theta)
+                steps_h = np.array([p_h, r_h, c_h])
+
+            qp_values = evaluate_quadratic_function(J_h, diag_h, g_h, steps_h)
+            min_index = np.argmin(qp_values)
+            step_h = steps_h[min_index]
+
+            # qp-values are negative, also need to double it
+            predicted_reduction = -2 * qp_values[min_index]
+
+            step = d * step_h
+            x_new = make_strictly_feasible(x + step, lb, ub)
+
+            f_new = fun(x_new)
+            nfev += 1
+
+            # Usual trust-region step quality estimation.
+            obj_value_new = np.dot(f_new, f_new)
+            actual_reduction = obj_value - obj_value_new
+            # Correction term is specific to the algorithm,
+            # vanishes in unbounded case.
+            correction = np.dot(step_h * diag_h, step_h)
+
+            if predicted_reduction > 0:
+                ratio = (actual_reduction - correction) / predicted_reduction
+            else:
+                ratio = 0
+
+            if ratio < 0.25:
+                Delta_new = 0.25 * norm(step_h)
+                alpha *= Delta / Delta_new
+                Delta = Delta_new
+            elif ratio > 0.75 and norm(step_h) > 0.95 * Delta:
+                Delta *= 2.0
+                alpha *= 0.5
+
+            ftol_satisfied = (abs(actual_reduction) < ftol * obj_value and
+                              ratio > 0.25)
+            xtol_satisfied = norm(step) < xtol * max(EPS**0.5, norm(x))
+
+            if ftol_satisfied and xtol_satisfied:
+                termination_status = 4
+            elif ftol_satisfied:
+                termination_status = 2
+            elif xtol_satisfied:
+                termination_status = 3
+            if termination_status is not None:
+                break
+
+        if actual_reduction > 0:
+            x = x_new
+            f = f_new
+            obj_value = obj_value_new
+
+            J = jac(x, f)
+            njev += 1
+
+    active_mask = find_active_constraints(x, lb, ub, rtol=xtol)
+    return OptimizeResult(
+        x=x, fun=f, jac=J, obj_value=obj_value, optimality=g_norm,
+        active_mask=active_mask, nfev=nfev, njev=njev, status=0,
+        x_covariance=None)

--- a/scipy/optimize/_lsq_trf.py
+++ b/scipy/optimize/_lsq_trf.py
@@ -305,7 +305,7 @@ def trf(fun, jac, x0, lb, ub, ftol, xtol, gtol, max_nfev, scaling):
             predicted_reduction = -2 * qp_values[min_index]
 
             step = d * step_h
-            x_new = make_strictly_feasible(x + step, lb, ub)
+            x_new = make_strictly_feasible(x + step, lb, ub, rstep=0)
 
             f_new = fun(x_new)
             nfev += 1

--- a/scipy/optimize/_lsq_trust_region.py
+++ b/scipy/optimize/_lsq_trust_region.py
@@ -135,15 +135,15 @@ def solve_lsq_trust_region(n, m, uf, s, V, Delta, initial_alpha=None,
 
         phi, phi_prime = _phi_and_derivative(alpha, suf, s, Delta)
 
-        if np.abs(phi) < rtol * Delta:
-            break
-
         if phi < 0:
             alpha_upper = alpha
 
         ratio = phi / phi_prime
         alpha_lower = max(alpha_lower, alpha - ratio)
         alpha -= (phi + Delta) * ratio / Delta
+
+        if np.abs(phi) < rtol * Delta:
+            break
 
     p = -V.dot(suf / (s**2 + alpha))
     if phi > 0:

--- a/scipy/optimize/_lsq_trust_region.py
+++ b/scipy/optimize/_lsq_trust_region.py
@@ -1,0 +1,152 @@
+"""Functions related to a trust-region problem."""
+
+from __future__ import division
+
+from math import copysign
+
+import numpy as np
+from numpy.linalg import norm
+
+
+def intersect_trust_region(x, s, Delta):
+    """Find the intersection of a line with a spherical trust region.
+
+    The function just solves the quadratic equation with respect to t
+    ||(x + s*t)||**2 = Delta**2.
+
+    Returns
+    -------
+    t_neg, t_pos : tuple of float
+        The negative and positive roots.
+
+    Raises
+    ------
+    ValueError
+        If `s` is zero or `x` is not within the trust region.
+    """
+    a = np.dot(s, s)
+    if a == 0:
+        raise ValueError("`s` is zero.")
+
+    b = np.dot(x, s)
+
+    c = np.dot(x, x) - Delta**2
+    if c > 0:
+        raise ValueError("`x` is not within the trust region.")
+
+    delta = np.sqrt(b*b - a*c)
+    q = -(b + copysign(delta, b))
+    t1 = q / a
+    t2 = c / q
+    if t1 < t2:
+        return t1, t2
+    else:
+        return t2, t1
+
+
+def _phi_and_derivative(alpha, suf, s, Delta):
+    """Used by solve_lsq_trust_region."""
+    denom = s**2 + alpha
+    p_norm = norm(suf / denom)
+    phi = p_norm - Delta
+    phi_prime = -np.sum(suf ** 2 / denom**3) / p_norm
+    return phi, phi_prime
+
+
+def solve_lsq_trust_region(n, m, uf, s, V, Delta, initial_alpha=None,
+                           rtol=0.01, max_iter=10):
+    """Solve a trust-region problem arising in least-squares minimization by
+    MINPACK approach.
+
+    This function implements a method described by J. J. More [1]_, but it
+    relies on SVD of Jacobian. Before running this function we compute:
+    ``U, s, VT = svd(J, full_matrices=False)``.
+
+    Parameters
+    ----------
+    n : int
+        Number of variables.
+    m : int
+        Number of residuals.
+    uf : ndarray
+        Should be computed as U.T.dot(f).
+    s : ndarray
+        Singular values of J.
+    V : ndarray
+        Transpose of VT.
+    Delta : float
+        Radius of a trust region.
+    initial_alpha : float, optional
+        Initial guess for alpha, which might be available from a previous
+        iteration.
+    rtol : float, optional
+        Stopping tolerance for the root-finding procedure. Namely, the
+        solution p must satisfy ``abs(norm(p) - Delta) < rtol * Delta``.
+    max_iter : int, optional
+        Maximum allowed number of iterations for the root-finding procedure.
+
+    Returns
+    -------
+    p : array, shape (n,)
+        The solution of a trust-region problem
+    alpha : float
+        Positive value such that (J.T*J + alpha*I)*p = -J.T*f.
+        Sometimes called Levenberg-Marquardt parameter.
+    n_iter : int
+        The number of iterations made by root-finding procedure. Zero means
+        that Gauss-Newton step was selected as the solution.
+
+    References
+    ----------
+    .. [1] More, J. J., "The Levenberg-Marquardt Algorithm: Implementation
+           and Theory," Numerical Analysis, ed. G. A. Watson, Lecture Notes
+           in Mathematics 630, Springer Verlag, pp. 105-116, 1977.
+    """
+    suf = s * uf
+
+    # Check if J has full rank and try Gauss-Newton step.
+    if m >= n:
+        threshold = np.finfo(float).eps * m * s[0]
+        full_rank = s[-1] > threshold
+    else:
+        full_rank = False
+
+    if full_rank:
+        p = -V.dot(uf / s)
+        if norm(p) <= Delta:
+            return p, 0.0, 0
+
+    alpha_upper = norm(suf) / Delta
+
+    if full_rank:
+        phi, phi_prime = _phi_and_derivative(0.0, suf, s, Delta)
+        alpha_lower = -phi / phi_prime
+    else:
+        alpha_lower = 0.0
+
+    if initial_alpha is None or not full_rank and initial_alpha == 0:
+        alpha = max(0.001 * alpha_upper, (alpha_lower * alpha_upper)**0.5)
+    else:
+        alpha = initial_alpha
+
+    for it in range(max_iter):
+        if alpha < alpha_lower or alpha > alpha_upper:
+            alpha = max(0.001 * alpha_upper, (alpha_lower * alpha_upper)**0.5)
+
+        phi, phi_prime = _phi_and_derivative(alpha, suf, s, Delta)
+
+        if np.abs(phi) < rtol * Delta:
+            break
+
+        if phi < 0:
+            alpha_upper = alpha
+
+        ratio = phi / phi_prime
+        alpha_lower = max(alpha_lower, alpha - ratio)
+        alpha -= (phi + Delta) * ratio / Delta
+
+    p = -V.dot(suf / (s**2 + alpha))
+    if phi > 0:
+        p *= Delta / norm(p)
+
+    return p, alpha, it + 1

--- a/scipy/optimize/least_squares.py
+++ b/scipy/optimize/least_squares.py
@@ -1,0 +1,389 @@
+"""Generic interface for least-square minimization."""
+
+from warnings import warn
+
+import numpy as np
+from numpy.linalg import norm
+
+from .minpack import leastsq
+from .optimize import OptimizeResult
+from ._numdiff import approx_derivative
+
+from ._lsq_bounds import in_bounds, prepare_bounds
+from ._lsq_trf import trf
+from ._lsq_dogbox import dogbox
+
+__all__ = ['least_squares']
+
+EPS = np.finfo(float).eps
+
+
+def check_tolerance(ftol, xtol, gtol):
+    message = "{} is too low, setting to machine epsilon {}."
+    if ftol < EPS:
+        warn(message.format("`ftol`", EPS))
+        ftol = EPS
+    if xtol < EPS:
+        warn(message.format("`xtol`", EPS))
+        xtol = EPS
+    if gtol < EPS:
+        warn(message.format("`gtol`", EPS))
+        gtol = EPS
+
+    return ftol, xtol, gtol
+
+
+TERMINATION_MESSAGES = {
+    -1: "Improper input parameters status returned from `leastsq`",
+    0: "The maximum number of function evaluations is exceeded.",
+    1: "`gtol` termination condition is satisfied.",
+    2: "`ftol` termination condition is satisfied.",
+    3: "`xtol` termination condition is satisfied.",
+    4: "Both `ftol` and `xtol` termination conditions are satisfied."
+}
+
+
+FROM_MINPACK_TO_COMMON = {
+    0: -1,  # 0 improper input parameters for MINPACK.
+    1: 2,
+    2: 3,
+    3: 4,
+    4: 1,
+    5: 0
+    # There are 6, 7, 8 for too small tolerance parameters,
+    # but we guard against them by checking ftol, xtol, gtol beforehand.
+}
+
+
+def call_leastsq(fun, x0, jac, ftol, xtol, gtol, max_nfev, scaling,
+                 diff_step, args, options):
+    if jac == '3-point':
+        warn("jac='3-point' works equivalently to '2-point' "
+             "for 'lm' method.")
+
+    if jac in ['2-point', '3-point']:
+        jac = None
+
+    if max_nfev is None:
+        max_nfev = 0
+
+    if diff_step is None:
+        epsfcn = None
+    else:
+        epsfcn = diff_step**2
+
+    if scaling == 'jac':
+        scaling = None
+
+    x, cov_x, info, message, status = leastsq(
+        fun, x0, args=args, Dfun=jac, full_output=True, ftol=ftol, xtol=xtol,
+        gtol=gtol, maxfev=max_nfev, epsfcn=epsfcn, diag=scaling, **options)
+
+    f = info['fvec']
+
+    if callable(jac):
+        J = jac(x, *args)
+    else:
+        J = approx_derivative(fun, x, args=args)
+    J = np.atleast_2d(J)
+
+    obj_value = np.dot(f, f)
+    g = J.T.dot(f)
+    g_norm = norm(g, ord=np.inf)
+
+    nfev = info['nfev']
+    njev = info.get('njev', None)
+
+    status = FROM_MINPACK_TO_COMMON[status]
+    active_mask = np.zeros_like(x0, dtype=int)
+
+    return OptimizeResult(
+        x=x, fun=f, jac=J, obj_value=obj_value, optimality=g_norm,
+        active_mask=active_mask, nfev=nfev, njev=njev, status=status,
+        message=message, success=status > 0, x_covariance=cov_x)
+
+
+def check_scaling(scaling, x0):
+    if scaling == 'jac':
+        return scaling
+    try:
+        scaling = np.asarray(scaling, dtype=float)
+    except ValueError:
+        raise ValueError("`scaling` must be 'jac' or array-like with numbers.")
+
+    if np.any(scaling <= 0):
+        raise ValueError("`scaling` must contain only positive values.")
+
+    if scaling.ndim == 0:
+        scaling = np.resize(scaling, x0.shape)
+
+    if scaling.shape != x0.shape:
+        raise ValueError("Inconsistent shapes between `scaling` and `x0`.")
+
+    return scaling
+
+
+def least_squares(fun, x0, jac='2-point', bounds=(-np.inf, np.inf),
+                  method='trf', ftol=EPS**0.5, xtol=EPS**0.5, gtol=EPS**0.5,
+                  max_nfev=None, scaling=1.0, diff_step=None,
+                  args=(), kwargs={}, options={}):
+    """Minimize the sum of squares of nonlinear functions subject to bounds on
+    independent variables.
+
+    Let f(x) maps from R^n to R^m, the function finds a local minimum of
+    F(x) = ||f(x)||**2 = sum(f_i(x)**2, i = 1, ..., m),
+    subject to bound constraints lb <= x <= ub
+
+    Parameters
+    ----------
+    fun : callable
+        Function which computes a vector of residuals. The argument x passed
+        to this function is ndarray of shape (n,) (never a scalar, even
+        if n=1). It must return 1-d array-like of shape (m,) or a scalar.
+    x0 : array_like of shape (n,) or float
+        Initial guess on the independent variables. If float, for internal
+        usage it will be converted to 1-d array.
+    jac : '2-point', '3-point' or callable, optional
+        Method of computing partial derivatives of f with respect to x,
+        which form m-by-n array called the Jacobian matrix. If set to '2-point'
+        or '3-point', the Jacobian matrix is estimated by the corresponding
+        finite difference scheme. The '3-point' scheme is more accurate,
+        but requires twice as much operations compared to '2-point' (default).
+        If callable then it should return a reasonable approximation of the
+        Jacobian as array_like with at most 2 dimensions (transformed by
+        np.atleast_2d in 'trf' and 'dogbox' methods). In 'lm' method: callable
+        must return 2-d ndarray, if you set ``col_deriv=1`` in `options` then
+        a callable must return transposed Jacobian.
+    bounds : 2-tuple of array_like, optional
+        Lower and upper bounds on independent variables. Defaults to no bounds.
+        Each bound must match the size of `x0` or be a scalar, in the latter
+        case the bound will be the same for all variables. Use ``np.inf``
+        with an appropriate sign to disable bounds on all or some of the
+        variables.
+    method : {'trf', 'dogbox', 'lm'}, optional
+        Determines the algorithm to perform optimization. Default is 'trf.
+        See Notes and algorithm options to get information about each
+        algorithm.
+    ftol : float, optional
+        Tolerance for termination by the change of the objective value.
+        Default is square root of machine epsilon. See the exact meaning in
+        documentation for a particular method.
+    xtol : float, optional
+        Tolerance for termination by the change of the independent variables.
+        Default is square root of machine epsilon. See the exact meaning in
+        documentation for a particular method.
+    gtol : float, optional
+        Tolerance for termination by the norm of gradient. Default is
+        square root of machine epsilon. In presence of bounds more correctly
+        to call it first-order optimality threshold, as raw gradient
+        itself doesn't measure optimality. See the exact meaning in
+        documentation for a particular method.
+    max_nfev : None or int, optional
+        Maximum number of function evaluations before the termination.
+        If None (default) each algorithm uses its own default value.
+    scaling : array_like or 'jac', optional
+        Applies variables scaling to potentially improve algorithm convergence.
+        Default is 1.0 which means no scaling. Scaling should be used to
+        equalize the influence of each variable on the objective function.
+        Alternatively you can think of `scaling` as diagonal elements of
+        a matrix which determines the shape of a trust-region.
+        Use smaller values for variables which have bigger characteristic
+        scale compared to others. A scalar value won't affect the algorithm
+        (except maybe fixing/introducing numerical issues and changing
+        termination criteria). If 'jac', then scaling is proportional to the
+        norms of Jacobian columns. The latter option is often helpful in
+        unconstrained problems, but not so much in constrained ones.
+        From experience usage of 'jac'-scaling is not recommended for bounded
+        problems with 'trf' method.
+    diff_step : None or array_like, optional
+        Determines the step size for finite difference Jacobian approximation.
+        The actual step is computed as ``x * diff_step``. If None (default),
+        `diff_step` is assigned to a conventional "optimal" power of machine
+        epsilon depending on finite difference approximation method [NR]_.
+    args, kwargs : tuple and dict, optional
+        Additional arguments passed to `fun` and `jac`. Both empty by default.
+        The calling signature is ``fun(x, *args, **kwargs)`` and the same for
+        `jac`. Method 'lm' can't handle `kwargs`.
+    options : dict, optional
+        Additional options passed to a chosen algorithm. Empty by default.
+        The calling sequence is ``method(..., **options)``. Look for relative
+        options in documentation for a particular method.
+
+    Returns
+    -------
+    OptimizeResult with the following fields defined.
+    x : ndarray, shape (n,)
+        Found solution.
+    obj_value : float
+        Sum of squares at the solution.
+    fun : ndarray, shape (m,)
+        Vector of residuals at the solution.
+    jac : ndarray, shape (m, n)
+        Jacobian at the solution.
+    optimality : float
+        First-order optimality measure. In unconstrained problems it is always
+        the uniform norm of the gradient. In constrained problems this is the
+        quantity which was compared with `gtol` during iterations, refer
+        to method options.
+    active_mask : ndarray of int, shape (n,)
+        Each component shows whether the corresponding constraint is active:
+             0 - a constraint is not active.
+            -1 - a lower bound is active.
+             1 - an upper bound is active.
+        Might be somewhat arbitrary as the algorithm does strictly feasible
+        iterates, thus `active_mask` is determined with tolerance threshold.
+    nfev : int
+        Number of function evaluations done. Methods 'trf' and 'dogbox' don't
+        count function calls for numerical Jacobian approximation, opposed to
+        'lm' method.
+    njev : int
+        Number of Jacobian evaluations done. If numerical Jacobian
+        approximation is used in 'lm' method it is set to None.
+    status : int
+        Reason for algorithm termination:
+            -1 - improper input parameters status returned from `leastsq`.
+             0 - the maximum number of function evaluations is exceeded.
+             1 - `gtol` termination condition is satisfied.
+             2 - `ftol` termination condition is satisfied.
+             3 - `xtol` convergence test is satisfied.
+             4 - Both `ftol` and `xtol` termination conditions are satisfied.
+    message : string
+        Verbal description of the termination reason.
+    success : int
+        True if one of the convergence criteria is satisfied.
+    x_covariance : ndarray, shape (m, m)
+        Estimate of `x` covariance assuming that residuals are uncorrelated
+        and have unity variance. It is computed as inverse of J.T*J where J
+        is Jacobian matrix. If 'trf' or 'dogbox' method is used or the inverse
+        doesn't exist this field is set to None.
+
+    Notes
+    -----
+    Method 'lm' (Levenberg-Marquardt) calls a wrapper over least-squares
+    algorithms implemented in MINPACK (lmder, lmdif). It runs
+    Levenberg-Marquadrd algorithm formulated as a trust-region type algorithm.
+    The implementation is based on paper [JJMore]_, it is very robust and
+    efficient with a lot of smart tricks. It should be your first choice
+    for unconstrained problems. Note that it doesn't support bounds.
+
+    Method 'trf' (Trust Region Reflective) is motivated by the process of
+    solving the equation, which constitutes the first-order optimality
+    condition for a bound-constrained minimization problem as formulated in
+    [STIR]_. The algorithm iteratively solves trust-region subproblems
+    augmented by special diagonal quadratic term with trust-region shape
+    determined by the distance from the bounds and the direction of the
+    gradient. This enhancements help not to take steps directly into bounds
+    and explore the whole variable space. To improve convergence speed the
+    reflected from the first bound search direction is considered. To obey
+    theoretical requirements the algorithm keeps iterates strictly feasible.
+    Trust-region subproblems are solved by exact method very similar to one
+    described in [JJMore]_ and implemented in MINPACK, but with the help of
+    one per iteration singular value decomposition of Jacobian.
+    The algorithm's performance is generally comparable to MINPACK in
+    unbounded case. The algorithm works quite robust in unbounded and bounded
+    problems, thus it is chosen as default algorithm.
+
+    Method 'dogbox' operates in a trust-region framework, but considers
+    rectangular trust regions as opposed to conventional elliptical [Voglis]_.
+    The intersection of the current trust region and initial bounds is again
+    rectangular, so on each iteration a quadratic minimization problem subject
+    to bounds is solved. Powell's dogleg method [NumOpt]_ is applied to solve
+    these subproblems. The algorithm is likely to exhibit slow convergence
+    when the rank of Jacobian is less than the number of variables. For some
+    problems though it performs better than 'trf' and 'lm', so you might want
+    to try it. Although it's hard to say generally which problems are suitable
+    for this method.
+
+    References
+    ----------
+    .. [NR] William H. Press et. al. "Numerical Recipes. The Art of Scientific
+            Computing. 3rd edition", sec. 5.7
+    .. [JJMore] More, J. J., "The Levenberg-Marquardt Algorithm: Implementation
+                and Theory," Numerical Analysis, ed. G. A. Watson, Lecture Notes
+                in Mathematics 630, Springer Verlag, pp. 105-116, 1977.
+    .. [STIR] Branch, M.A., T.F. Coleman, and Y. Li, "A Subspace, Interior,
+              and Conjugate Gradient Method for Large-Scale Bound-Constrained
+              Minimization Problems," SIAM Journal on Scientific Computing,
+              Vol. 21, Number 1, pp 1-23, 1999.
+    .. [Voglis] C. Voglis and I. E. Lagaris, "A Rectangular Trust Region
+                Dogleg Approach for Unconstrained and Bound Constrained
+                Nonlinear Optimization", WSEAS International Conference on
+                Applied Mathematics, Corfu, Greece, 2004.
+    .. [NumOpt] J. Nocedal and S. J. Wright, "Numerical optimization,
+                2nd edition", Chapter 4.
+    """
+    if method not in ['trf', 'dogbox', 'lm']:
+        raise ValueError("`method` must be 'trf', 'dogbox' or 'lm'.")
+
+    if len(bounds) != 2:
+        raise ValueError("`bounds` must contain 2 elements.")
+
+    x0 = np.atleast_1d(x0).astype(float)
+
+    if x0.ndim > 1:
+        raise ValueError("`x0` must have at most 1 dimension.")
+
+    lb, ub = prepare_bounds(bounds, x0)
+
+    if lb.shape != x0.shape or ub.shape != x0.shape:
+        raise ValueError("Inconsistent shapes between bounds and `x0`.")
+
+    if np.any(lb >= ub):
+        raise ValueError("Each lower bound mush be strictly less than each "
+                         "upper bound.")
+
+    if method == 'lm':
+        if not np.all((lb == -np.inf) & (ub == np.inf)):
+            raise ValueError("Method 'lm' doesn't support bounds.")
+
+        if len(kwargs) > 0:
+            raise ValueError("Method 'lm' doesn't support kwargs.")
+
+    if jac not in ['2-point', '3-point'] and not callable(jac):
+        raise ValueError("`jac` must be '2-point', '3-point' or callable.")
+
+    scaling = check_scaling(scaling, x0)
+
+    ftol, xtol, gtol = check_tolerance(ftol, xtol, gtol)
+
+    # Handle 'lm' separately
+    if method == 'lm':
+        return call_leastsq(fun, x0, jac, ftol, xtol, gtol, max_nfev,
+                            scaling, diff_step, args, options)
+
+    if not in_bounds(x0, lb, ub):
+        raise ValueError("`x0` is infeasible.")
+
+    def fun_wrapped(x):
+        f = np.atleast_1d(fun(x, *args, **kwargs))
+        if f.ndim > 1:
+            raise RuntimeError("`fun` must return at most 1-d array_like.")
+        return f
+
+    if jac in ['2-point', '3-point']:
+        def jac_wrapped(x, f):
+            J = approx_derivative(
+                fun, x, rel_step=diff_step, method=jac, f0=f,
+                bounds=bounds, args=args, kwargs=kwargs)
+            J = np.atleast_2d(J)
+            if J.ndim > 2:
+                raise RuntimeError("`jac` must return at most 2-d array_like.")
+            return J
+    else:
+        def jac_wrapped(x, f):
+            J = np.atleast_2d(jac(x, *args, **kwargs))
+            if J.ndim > 2:
+                raise RuntimeError("`jac` must return at most 2-d array_like.")
+            return J
+
+    if method == 'trf':
+        result = trf(fun_wrapped, jac_wrapped, x0, lb, ub,
+                     ftol, xtol, gtol, max_nfev, scaling, **options)
+
+    elif method == 'dogbox':
+        result = dogbox(fun_wrapped, jac_wrapped, x0, lb, ub,
+                        ftol, xtol, gtol, max_nfev, scaling, **options)
+
+    result.message = TERMINATION_MESSAGES[result.status]
+    result.success = result.status > 0
+    return result

--- a/scipy/optimize/least_squares.py
+++ b/scipy/optimize/least_squares.py
@@ -130,54 +130,57 @@ def least_squares(fun, x0, jac='2-point', bounds=(-np.inf, np.inf),
     """Minimize the sum of squares of nonlinear functions subject to bounds on
     independent variables.
 
-    Let f(x) maps from R^n to R^m, the function finds a local minimum of
-    F(x) = ||f(x)||**2 = sum(f_i(x)**2, i = 1, ..., m),
-    subject to bound constraints lb <= x <= ub
+    Let f(x) maps from R^n to R^m, this function finds a local minimum of::
+
+        F(x) = ||f(x)||**2 = sum(f_i(x)**2, i = 1, ..., m),
+        subject to bound constraints lb <= x <= ub
+
+    Partial derivatives of f with respect to x form m-by-n matrix called
+    Jacobian, where an element (i, j) equals a partial derivative of f[i]
+    with respect to x[j].
 
     Parameters
     ----------
     fun : callable
         Function which computes a vector of residuals. The argument x passed
         to this function is ndarray of shape (n,) (never a scalar, even
-        if n=1). It must return 1-d array-like of shape (m,) or a scalar.
+        if n=1). It must return 1-d array_like of shape (m,) or a scalar.
     x0 : array_like of shape (n,) or float
-        Initial guess on the independent variables. If float, for internal
-        usage it will be converted to 1-d array.
+        Initial guess on independent variables. If float, for internal usage
+        it will be converted to 1-d array.
     jac : '2-point', '3-point' or callable, optional
-        Method of computing partial derivatives of f with respect to x,
-        which form m-by-n array called the Jacobian matrix. If set to '2-point'
-        or '3-point', the Jacobian matrix is estimated by the corresponding
-        finite difference scheme. The '3-point' scheme is more accurate,
-        but requires twice as much operations compared to '2-point' (default).
-        If callable then it should return a reasonable approximation of the
-        Jacobian as array_like with at most 2 dimensions (transformed by
-        np.atleast_2d in 'trf' and 'dogbox' methods). In 'lm' method: callable
-        must return 2-d ndarray, if you set ``col_deriv=1`` in `options` then
-        a callable must return transposed Jacobian.
+        Method of computing the Jacobian matrix. If set to '2-point' or
+        '3-point', the Jacobian matrix is estimated by the corresponding
+        finite difference scheme. The scheme '3-point' is more accurate, but
+        requires twice as much operations compared to '2-point' (default).
+        If callable then it should return a reasonable approximation of
+        Jacobian as array_like with shape (m, n) (although np.atleast_2d
+        is applied in 'trf' and 'dogbox' methods). In 'lm' method: callable
+        must return 2-d ndarray, if you set ``col_deriv=1`` in `options`
+        then a callable must return transposed Jacobian.
     bounds : 2-tuple of array_like, optional
         Lower and upper bounds on independent variables. Defaults to no bounds.
-        Each bound must match the size of `x0` or be a scalar, in the latter
-        case the bound will be the same for all variables. Use ``np.inf``
-        with an appropriate sign to disable bounds on all or some of the
-        variables.
+        Each array must match the size of `x0` or be a scalar, in the latter
+        case a bound will be the same for all variables. Use ``np.inf`` with
+        an appropriate sign to disable bounds on all or some of the variables.
     method : {'trf', 'dogbox', 'lm'}, optional
-        Determines the algorithm to perform optimization. Default is 'trf.
+        Determines the method to perform optimization. Default is 'trf'.
         See Notes and algorithm options to get information about each
-        algorithm.
+        method.
     ftol : float, optional
         Tolerance for termination by the change of the objective value.
         Default is square root of machine epsilon. See the exact meaning in
-        documentation for a particular method.
+        documentation for a selected `method`.
     xtol : float, optional
         Tolerance for termination by the change of the independent variables.
         Default is square root of machine epsilon. See the exact meaning in
-        documentation for a particular method.
+        documentation for a selected `method`.
     gtol : float, optional
         Tolerance for termination by the norm of gradient. Default is
         square root of machine epsilon. In presence of bounds more correctly
-        to call it first-order optimality threshold, as raw gradient
+        to call it first-order optimality threshold, as a raw gradient
         itself doesn't measure optimality. See the exact meaning in
-        documentation for a particular method.
+        documentation for a selected `method`.
     max_nfev : None or int, optional
         Maximum number of function evaluations before the termination.
         If None (default) each algorithm uses its own default value.
@@ -199,15 +202,15 @@ def least_squares(fun, x0, jac='2-point', bounds=(-np.inf, np.inf),
         Determines the step size for finite difference Jacobian approximation.
         The actual step is computed as ``x * diff_step``. If None (default),
         `diff_step` is assigned to a conventional "optimal" power of machine
-        epsilon depending on finite difference approximation method [NR]_.
+        epsilon depending on a finite difference approximation method [NR]_.
     args, kwargs : tuple and dict, optional
         Additional arguments passed to `fun` and `jac`. Both empty by default.
         The calling signature is ``fun(x, *args, **kwargs)`` and the same for
         `jac`. Method 'lm' can't handle `kwargs`.
     options : dict, optional
-        Additional options passed to a chosen algorithm. Empty by default.
-        The calling sequence is ``method(..., **options)``. Look for relative
-        options in documentation for a particular method.
+        Additional options passed to a chosen method. Empty by default.
+        The calling sequence is ``method(..., **options)``. Look for relevant
+        options in documentation for a selected method.
 
     Returns
     -------
@@ -224,14 +227,15 @@ def least_squares(fun, x0, jac='2-point', bounds=(-np.inf, np.inf),
         First-order optimality measure. In unconstrained problems it is always
         the uniform norm of the gradient. In constrained problems this is the
         quantity which was compared with `gtol` during iterations, refer
-        to method options.
+        to options of a selected method.
     active_mask : ndarray of int, shape (n,)
         Each component shows whether the corresponding constraint is active:
              0 - a constraint is not active.
             -1 - a lower bound is active.
              1 - an upper bound is active.
-        Might be somewhat arbitrary as the algorithm does strictly feasible
-        iterates, thus `active_mask` is determined with tolerance threshold.
+        Might be somewhat arbitrary for 'trf' method as it does strictly
+        feasible iterates and `active_mask` is determined with tolerance
+        threshold.
     nfev : int
         Number of function evaluations done. Methods 'trf' and 'dogbox' don't
         count function calls for numerical Jacobian approximation, opposed to
@@ -251,11 +255,11 @@ def least_squares(fun, x0, jac='2-point', bounds=(-np.inf, np.inf),
         Verbal description of the termination reason.
     success : int
         True if one of the convergence criteria is satisfied.
-    x_covariance : ndarray, shape (m, m)
+    x_covariance : ndarray, shape (n, n)
         Estimate of `x` covariance assuming that residuals are uncorrelated
         and have unity variance. It is computed as inverse of J.T*J where J
-        is Jacobian matrix. If 'trf' or 'dogbox' method is used or the inverse
-        doesn't exist this field is set to None.
+        is Jacobian matrix. If 'trf' or 'dogbox' method are used or the
+        inverse doesn't exist this field is set to None.
 
     Notes
     -----

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -1,15 +1,10 @@
-import warnings
-
 import numpy as np
 from numpy.testing import (run_module_suite, assert_, assert_allclose,
-                           assert_warns, TestCase, assert_raises, assert_equal,
-                           assert_almost_equal)
+                           assert_warns, TestCase, assert_raises,
+                           assert_equal, assert_almost_equal)
 
 from scipy.optimize import least_squares
 from scipy.optimize._minpack import error as MinpackError
-
-
-warnings.simplefilter('ignore')
 
 
 def fun_trivial(x, a=0):
@@ -133,14 +128,15 @@ class BaseMixin(object):
         assert_raises(TypeError, least_squares, fun_trivial, 2.0,
                       method=self.method, options={'max_nfev': 100})
 
-    def test_tolerance_thresholds(self):
-        warnings.simplefilter('always', UserWarning)  # For numpy 1.6.2
-        assert_warns(UserWarning, least_squares, fun_trivial, 2.0,
-                     ftol=0.0, method=self.method)
-        res = least_squares(fun_trivial, 2.0, ftol=1e-20, xtol=-1.0, gtol=0.0,
-                            method=self.method)
-        assert_allclose(res.x, 0, atol=1e-4)
-        warnings.simplefilter('ignore')
+    # Removed because numpy 1.6.2 testing utils doesn't handle repeating
+    # warnings correctly.
+
+    # def test_tolerance_thresholds(self):
+    #     assert_warns(UserWarning, least_squares, fun_trivial, 2.0,
+    #                  ftol=0.0, method=self.method)
+    #     res = least_squares(fun_trivial, 2.0, ftol=1e-20, xtol=-1.0,
+    #                         gtol=0.0, method=self.method)
+    #     assert_allclose(res.x, 0, atol=1e-4)
 
     def test_full_result(self):
         res = least_squares(fun_trivial, 2.0, method=self.method)

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -1,0 +1,310 @@
+import warnings
+
+import numpy as np
+from numpy.testing import (run_module_suite, assert_, assert_allclose,
+                           assert_warns, TestCase, assert_raises, assert_equal,
+                           assert_almost_equal)
+
+from scipy.optimize import least_squares
+from scipy.optimize._minpack import error as MinpackError
+
+
+warnings.simplefilter('ignore')
+
+
+def fun_trivial(x, a=0):
+    return (x - a)**2 + 5.0
+
+def jac_trivial(x, a=0.0):
+    return 2 * (x - a)
+
+
+def fun_2d_trivial(x):
+    return np.array([x[0], x[1]])
+
+def jac_2d_trivial(x):
+    return np.identity(2)
+
+
+def fun_rosenbrock(x):
+    return np.array([10 * (x[1] - x[0]**2), (1 - x[0])])
+
+def jac_rosenbrock(x):
+    return np.array([
+        [-20 * x[0], 10],
+        [-1, 0]
+    ])
+
+
+def jac_rosenbrock_bad_dim(x):
+    return np.array([
+        [-20 * x[0], 10],
+        [-1, 0],
+        [0.0, 0.0]
+    ])
+
+
+# When x 1-d array, return is 2-d array..
+def fun_wrong_dimensions(x):
+    return np.array([x, x**2, x**3])
+
+
+def jac_wrong_dimensions(x, a=0.0):
+    return np.atleast_3d(jac_trivial(x, a=a))
+
+#
+# Parametrize basic smoke tests across methods
+#
+
+
+class BaseMixin(object):
+    def test_basic(self):
+        # Test that the basic calling sequence works.
+        res = least_squares(fun_trivial, 2., method=self.method)
+        assert_allclose(res.x, 0, atol=1e-4)
+        assert_allclose(res.fun, fun_trivial(res.x))
+
+    def test_args_kwargs(self):
+        # Test that args and kwargs are passed correctly to the functions.
+        # And that kwargs are not supported by 'lm'.
+        a = 3.0
+        for jac in ['2-point', '3-point', jac_trivial]:
+            res = least_squares(fun_trivial, 2.0, jac, args=(a,),
+                                method=self.method)
+            assert_allclose(res.x, a, rtol=1e-4)
+            assert_allclose(res.fun, fun_trivial(res.x, a))
+
+            assert_raises(TypeError, least_squares, fun_trivial, 2.0,
+                          args=(3, 4,), method=self.method)
+        
+            # Test that kwargs works for everything except 'lm.
+            if self.method == 'lm':
+                assert_raises(ValueError, least_squares, fun_trivial, 2.0,
+                              kwargs={'a': a}, method=self.method)
+            else:
+                res = least_squares(fun_trivial, 2.0, jac, kwargs={'a': a},
+                                    method=self.method)
+                assert_allclose(res.x, a, rtol=1e-4)
+                assert_allclose(res.fun, fun_trivial(res.x, a))
+                assert_raises(TypeError, least_squares, fun_trivial, 2.0,
+                              kwargs={'kaboom': 3}, method=self.method)
+
+    def test_jac_options(self):
+        for jac in ['2-point', '3-point', jac_trivial]:
+            res = least_squares(fun_trivial, 2.0, jac, method=self.method)
+            assert_allclose(res.x, 0, atol=1e-4)
+        assert_raises(ValueError, least_squares, fun_trivial, 2.0, jac='oops',
+                      method=self.method)
+
+    def test_nfev_options(self):
+        for max_nfev in [None, 20]:
+            res = least_squares(fun_trivial, 2.0, max_nfev=max_nfev,
+                                method=self.method)
+            assert_allclose(res.x, 0, atol=1e-4)
+
+    def test_scaling_options(self):
+        for scaling in [1.0, np.array([2.0]), 'jac']:
+            res = least_squares(fun_trivial, 2.0, scaling=scaling)
+            assert_allclose(res.x, 0)
+        assert_raises(ValueError, least_squares, fun_trivial,
+                      2.0, scaling='auto', method=self.method)
+        assert_raises(ValueError, least_squares, fun_trivial,
+                      2.0, scaling=-1.0, method=self.method)
+
+    def test_diff_step(self):
+        # res1 and res2 should be equivalent.
+        # res2 and res3 should be different.
+        res1 = least_squares(fun_trivial, 2.0, diff_step=1e-2,
+                             method=self.method)
+        res2 = least_squares(fun_trivial, 2.0, diff_step=-1e-2,
+                             method=self.method)
+        res3 = least_squares(fun_trivial, 2.0,
+                             diff_step=None, method=self.method)
+        assert_allclose(res1.x, 0, atol=1e-4)
+        assert_allclose(res2.x, 0, atol=1e-4)
+        assert_allclose(res3.x, 0, atol=1e-4)
+        assert_equal(res1.x, res2.x)
+        assert_equal(res1.nfev, res2.nfev)
+        assert_(res2.nfev != res3.nfev)
+
+    def test_incorrect_options_usage(self):
+        assert_raises(TypeError, least_squares, fun_trivial, 2.0,
+                      method=self.method, options={'no_such_option': 100})
+        assert_raises(TypeError, least_squares, fun_trivial, 2.0,
+                      method=self.method, options={'max_nfev': 100})
+
+    def test_tolerance_thresholds(self):
+        warnings.simplefilter('always', UserWarning)  # For numpy 1.6.2
+        assert_warns(UserWarning, least_squares, fun_trivial, 2.0,
+                     ftol=0.0, method=self.method)
+        res = least_squares(fun_trivial, 2.0, ftol=1e-20, xtol=-1.0, gtol=0.0,
+                            method=self.method)
+        assert_allclose(res.x, 0, atol=1e-4)
+        warnings.simplefilter('ignore')
+
+    def test_full_result(self):
+        res = least_squares(fun_trivial, 2.0, method=self.method)
+        # Use assert_almost_equal to check shapes of arrays too.
+        assert_almost_equal(res.x, np.array([0]), decimal=1)
+        assert_almost_equal(res.obj_value, 25)
+        assert_almost_equal(res.fun, np.array([5]))
+        assert_almost_equal(res.jac, np.array([[0.0]]), decimal=2)
+        # 'lm' works weired on this problem
+        assert_almost_equal(res.optimality, 0, decimal=3)
+        assert_equal(res.active_mask, np.array([0]))
+        if self.method == 'lm':
+            assert_(res.nfev < 25)
+        else:
+            assert_(res.nfev < 10)
+        if self.method == 'lm':
+            assert_(res.njev is None)
+        else:
+            assert_(res.njev < 10)
+        assert_(res.status > 0)
+        assert_(res.success)
+
+    def test_rosenbrock(self):
+        x0 = [-2, 1]
+        x_opt = [1, 1]
+        for scaling in [1.0, np.array([1.0, 5.0]), 'jac']:
+            for jac in ['2-point', '3-point', jac_rosenbrock]:
+                res = least_squares(fun_rosenbrock, x0, jac, scaling=scaling,
+                                    method=self.method)
+                assert_allclose(res.x, x_opt)
+
+    def test_fun_wrong_dimensions(self):
+        if self.method == 'lm':
+            error = MinpackError
+        else:
+            error = RuntimeError
+        assert_raises(error, least_squares, fun_wrong_dimensions,
+                      2.0, method=self.method)
+
+    def test_jac_wrong_dimensions(self):
+        if self.method == 'lm':
+            error = MinpackError
+        else:
+            error = RuntimeError
+        assert_raises(error, least_squares, fun_trivial,
+                      2.0, jac_wrong_dimensions, method=self.method)
+
+    def test_fun_and_jac_inconsistent_dimensions(self):
+        x0 = [1, 2]
+        if self.method == 'lm':
+            error = TypeError
+        else:
+            error = RuntimeError
+        assert_raises(error, least_squares, fun_rosenbrock, x0,
+                      jac_rosenbrock_bad_dim, method=self.method)
+
+    def test_x0_multidimensional(self):
+        x0 = np.ones(4).reshape(2, 2)
+        assert_raises(ValueError, least_squares, fun_trivial, x0,
+                      method=self.method)
+
+
+class BoundsMixin(object):
+    def test_inconsistent(self):
+        assert_raises(ValueError, least_squares, fun_trivial, 2.0,
+                      bounds=(10.0, 0.0), method=self.method)
+
+    def test_infeasible(self):
+        assert_raises(ValueError, least_squares, fun_trivial, 2.0,
+                      bounds=(3., 4), method=self.method)
+                                                 
+    def test_wrong_number(self):
+        assert_raises(ValueError, least_squares, fun_trivial, 2.,
+                      bounds=(1., 2, 3), method=self.method)
+
+    def test_inconsistent_shape(self):
+        assert_raises(ValueError, least_squares, fun_trivial, 2.0,
+                      bounds=(1.0, [2.0, 3.0]), method=self.method)
+        # 1-D array can't be broadcasted
+        assert_raises(ValueError, least_squares, fun_rosenbrock, [1.0, 2.0],
+                      bounds=([0.0], [3.0, 4.0]), method=self.method)
+
+    def test_in_bounds(self):
+        for jac in ['2-point', '3-point', jac_trivial]:
+            res = least_squares(fun_trivial, 2.0, jac=jac,
+                                bounds=(-1.0, 3.0), method=self.method)
+            assert_allclose(res.x, 0.0, atol=1e-4)
+            assert_equal(res.active_mask, [0])
+            assert_(-1 <= res.x <= 3)
+            res = least_squares(fun_trivial, 2.0, jac=jac,
+                                bounds=(0.5, 3.0), method=self.method)
+            assert_allclose(res.x, 0.5, atol=1e-4)
+            assert_equal(res.active_mask, [-1])
+            assert_(0.5 <= res.x <= 3)
+
+    def test_bounds_shape(self):
+        for jac in ['2-point', '3-point', jac_2d_trivial]:
+            x0 = [1.0, 1.0]
+            res = least_squares(fun_2d_trivial, x0, jac=jac)
+            assert_allclose(res.x, [0.0, 0.0])
+            res = least_squares(fun_2d_trivial, x0, jac=jac,
+                                bounds=(0.5, [2.0, 2.0]), method=self.method)
+            assert_allclose(res.x, [0.5, 0.5])
+            res = least_squares(fun_2d_trivial, x0, jac=jac,
+                                bounds=([0.3, 0.2], 3.0), method=self.method)
+            assert_allclose(res.x, [0.3, 0.2])
+            res = least_squares(
+                fun_2d_trivial, x0, jac=jac, bounds=([-1, 0.5], [1.0, 3.0]),
+                method=self.method)
+            assert_allclose(res.x, [0.0, 0.5], atol=1e-5)
+
+    def test_rosenbrock_bounds(self):
+        x0_1 = np.array([-2.0, 1.0])
+        x0_2 = np.array([2.0, 2.0])
+        x0_3 = np.array([-2.0, 2.0])
+        x0_4 = np.array([0.0, 2.0])
+        x0_5 = np.array([-1.2, 1.0])
+        problems = [
+            (x0_1, ([-np.inf, -1.5], np.inf)),
+            (x0_2, ([-np.inf, 1.5], np.inf)),
+            (x0_3, ([-np.inf, 1.5], np.inf)),
+            (x0_4, ([-np.inf, 1.5], [1.0, np.inf])),
+            (x0_2, ([1.0, 1.5], [3.0, 3.0])),
+            (x0_5, ([-50.0, 0.0], [0.5, 100]))
+        ]
+        for x0, bounds in problems:
+            for scaling in [1.0, [1.0, 2.0], 'jac']:
+                for jac in ['2-point', '3-point', jac_rosenbrock]:
+                    res = least_squares(fun_rosenbrock, x0, jac, bounds,
+                                        method=self.method, scaling=scaling)
+                    assert_allclose(res.optimality, 0.0, atol=1e-5)
+
+
+class TestDogbox(BaseMixin, BoundsMixin, TestCase):
+    method = 'dogbox'
+
+
+class TestTRF(BaseMixin, BoundsMixin, TestCase):
+    method = 'trf'
+
+
+class TestLM(BaseMixin, TestCase):
+    method = 'lm'
+
+    def test_bounds_not_supported(self):
+        assert_raises(ValueError, least_squares, fun_trivial,
+                      2.0, bounds=(-3.0, 3.0), method='lm')
+
+    def test_repeated_options_errors(self):
+        assert_raises(TypeError, least_squares, fun_trivial,
+                      2.0, options={'diag': 1.0}, method='lm')
+        assert_raises(TypeError, least_squares, fun_trivial,
+                      2.0, options={'epsfcn': 1e-10}, method='lm')
+
+
+#
+# One-off tests which do not need parameterization or are method-specific
+#
+def test_basic():
+    # test that 'method' arg is really optional
+    res = least_squares(fun_trivial, 2.0)
+    assert_allclose(res.x, 0, atol=1e-10)
+    assert_allclose(res.fun, fun_trivial(res.x))
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -31,6 +31,10 @@ def jac_rosenbrock(x):
     ])
 
 
+def jac_rosenbrock_transposed(x):
+    return jac_rosenbrock(x).T
+
+
 def jac_rosenbrock_bad_dim(x):
     return np.array([
         [-20 * x[0], 10],
@@ -291,6 +295,13 @@ class TestLM(BaseMixin, TestCase):
         assert_raises(TypeError, least_squares, fun_trivial,
                       2.0, options={'epsfcn': 1e-10}, method='lm')
 
+    def test_colderiv(self):
+        x0 = [-2, 1]
+        x_opt = [1, 1]
+        res = least_squares(fun_rosenbrock, x0, jac_rosenbrock_transposed,
+                            method='lm', options={'col_deriv': True})
+        assert_allclose(res.obj_value, 0)
+        assert_allclose(res.x, x_opt)
 
 #
 # One-off tests which do not need parameterization or are method-specific

--- a/scipy/optimize/tests/test_lsq_utils.py
+++ b/scipy/optimize/tests/test_lsq_utils.py
@@ -1,0 +1,132 @@
+import numpy as np
+from numpy.testing import run_module_suite, assert_, assert_equal
+
+from scipy.optimize._lsq_bounds import (
+    prepare_bounds, in_bounds, step_size_to_bound, find_active_constraints,
+    make_strictly_feasible, scaling_vector)
+
+
+class TestBounds(object):
+    def test_prepare_bounds(self):
+        bounds = (
+            1.0,
+            [2.0, 3.0, 4.0]
+        )
+        x0 = np.zeros(3)
+        lb, ub = prepare_bounds(bounds, x0)
+        assert_equal(lb, np.ones(3))
+        assert_equal(ub, np.array([2.0, 3.0, 4.0]))
+
+    def test_in_bounds(self):
+        lb = -np.ones(3)
+        ub = np.ones(3)
+        x1 = np.array([-0.1, 1.0, 0.0])
+        x2 = np.array([1.5, 0.1, -0.5])
+        assert_(in_bounds(x1, lb, ub))
+        assert_(not in_bounds(x2, lb, ub))
+
+    def test_step_size_to_bounds(self):
+        lb = np.array([-1.0, 2.5, 10.0])
+        ub = np.array([1.0, 5.0, 100.0])
+        x = np.array([0.0, 2.5, 12.0])
+
+        s = np.array([0.1, 0.0, 0.0])
+        step, hits = step_size_to_bound(x, s, lb, ub)
+        assert_equal(step, 10)
+        assert_equal(hits, [1, 0, 0])
+
+        s = np.array([0.01, 0.05, -1.0])
+        step, hits = step_size_to_bound(x, s, lb, ub)
+        assert_equal(step, 2)
+        assert_equal(hits, [0, 0, -1])
+
+        s = np.array([10.0, -0.0001, 100.0])
+        step, hits = step_size_to_bound(x, s, lb, ub)
+        assert_equal(step, np.array(-0))
+        assert_equal(hits, [0, -1, 0])
+
+        s = np.array([1.0, 0.5, -2.0])
+        step, hits = step_size_to_bound(x, s, lb, ub)
+        assert_equal(step, 1.0)
+        assert_equal(hits, [1, 0, -1])
+
+        s = np.zeros(3)
+        step, hits = step_size_to_bound(x, s, lb, ub)
+        assert_equal(step, np.inf)
+        assert_equal(hits, [0, 0, 0])
+
+    def test_find_active_constraints(self):
+        lb = np.array([0.0, -10.0, 1.0])
+        ub = np.array([1.0, 0.0, 100.0])
+
+        x = np.array([0.5, -5.0, 2.0])
+        active = find_active_constraints(x, lb, ub)
+        assert_equal(active, [0, 0, 0])
+
+        x = np.array([0.0, 0.0, 10.0])
+        active = find_active_constraints(x, lb, ub)
+        assert_equal(active, [-1, 1, 0])
+
+        active = find_active_constraints(x, lb, ub, rtol=0)
+        assert_equal(active, [-1, 1, 0])
+
+        x = np.array([1e-9, -1e-8, 100 - 1e-9])
+        active = find_active_constraints(x, lb, ub)
+        assert_equal(active, [0, 0, 1])
+
+        active = find_active_constraints(x, lb, ub, rtol=1.5e-9)
+        assert_equal(active, [-1, 0, 1])
+
+        lb = np.array([1.0, -np.inf, -np.inf])
+        ub = np.array([np.inf, 10.0, np.inf])
+
+        x = np.ones(3)
+        active = find_active_constraints(x, lb, ub)
+        assert_equal(active, [-1, 0, 0])
+
+        # Handles out-of-bound cases.
+        x = np.array([0.0, 11.0, 0.0])
+        active = find_active_constraints(x, lb, ub)
+        assert_equal(active, [-1, 1, 0])
+
+        active = find_active_constraints(x, lb, ub, rtol=0)
+        assert_equal(active, [-1, 1, 0])
+
+    def test_make_strictly_feasible(self):
+        lb = np.array([-0.5, -0.8, 2.0])
+        ub = np.array([0.8, 1.0, 3.0])
+
+        x = np.array([-0.5, 0.0, 2 + 1e-10])
+
+        x_new = make_strictly_feasible(x, lb, ub, rstep=0)
+        assert_(x_new[0] > -0.5)
+        assert_equal(x_new[1:], x[1:])
+
+        x_new = make_strictly_feasible(x, lb, ub, rstep=1e-4)
+        assert_equal(x_new, [-0.5 + 1e-4, 0.0, 2 * (1 + 1e-4)])
+
+        x = np.array([-0.5, -1, 3.1])
+        x_new = make_strictly_feasible(x, lb, ub)
+        assert_(np.all((x_new >= lb) & (x_new <= ub)))
+
+        x_new = make_strictly_feasible(x, lb, ub, rstep=0)
+        assert_(np.all((x_new >= lb) & (x_new <= ub)))
+
+        lb = np.array([-1, 100.0])
+        ub = np.array([1, 100.0 + 1e-10])
+        x = np.array([0, 100.0])
+        x_new = make_strictly_feasible(x, lb, ub, rstep=1e-8)
+        assert_equal(x_new, [0, 100.0 + 0.5e-10])
+
+    def test_scaling_vector(self):
+        lb = np.array([-np.inf, -5.0, 1.0, -np.inf])
+        ub = np.array([1.0, np.inf, 10.0, np.inf])
+        x = np.array([0.5, 2.0, 5.0, 0.0])
+        g = np.array([1.0, 0.1, -10.0, 0.0])
+        v, dv = scaling_vector(x, g, lb, ub)
+        assert_equal(v, [1.0, 7.0, 5.0, 1.0])
+        assert_equal(dv, [0.0, 1.0, -1.0, 0.0])
+
+
+if __name__ == '__main__':
+    run_module_suite()


### PR DESCRIPTION
Hi!

I finally prepared code for PR. It is based on not yet merged #4884 So the first commit related to least squares is e908f76

The main (and only public) function is `scipy.optimize.least_squares` which wraps `scipy.optimize.leastsq` (as `method='lm'`) and two new algorithms I was working on `'dogbox'` and `'trf'`. The docstring is in a reasonable shape so I encourage you to try `least_squares` on your problems. Here is the [link](https://nmayorov.wordpress.com/2015/06/19/algorithm-benchmarks/) to benchmarks I done with algorithms.

The issues at the moment:
1. Rendering of html documentation. We wanted to do the same as in `scipy.optimize.minimize`, where general documentation is accompanied with specific methods documentation, like http://docs.scipy.org/doc/scipy-dev/reference/optimize.minimize-neldermead.html But currently I don't know how to do that and not sure if it is the best decision in general.
2. How to wrap `leastsq`. I think `least_squares` might feel more solid and homogeneous if I write a new wrapper to MINPACK functions, instead of calling `leastsq`.
3. The need to wrap `leastsq`. Now it seems OK to wrap it, but I'm working on extension to sparse Jacobians which will add quite a bit of additional options, which apply to both of the new algorithms, but not at all to `leastsq`. So the tempting solution is to drop `leastsq` (it will be still available after all) and make a very clean interface (without `options`, additional doc pages, etc.)
4. As I said I'm working on supporting sparse Jacobians with an appropriate iterative solver (LSMR), so the interface may change significantly. This PR is likely to be not final, but I'm not going to add sparse-support features here anyway.
