### PR TITLE
BUG: Fix of dlsim when the system is characterized has no dynamic.

### DIFF
--- a/scipy/signal/dltisys.py
+++ b/scipy/signal/dltisys.py
@@ -89,6 +89,13 @@ def dlsim(system, u, t=None, x0=None):
     A, B, C, D, dt = _system_to_statespace(system)
     u = np.asarray(u)
 
+    # Check for the statespace realization
+    # Case of system y=u
+    if A.shape[0] == 0:
+        A = np.asarray([0])
+        B = np.asarray([0])
+        C = np.asarray([0])
+
     if u.ndim == 1:
         u = np.atleast_2d(u).T
 
@@ -106,7 +113,7 @@ def dlsim(system, u, t=None, x0=None):
 
     # Check initial condition
     if x0 is None:
-        xout[0, :] = np.zeros((A.shape[1],))
+        xout[0, :] = np.zeros((A.shape[0],))
     else:
         xout[0, :] = np.asarray(x0)
 

--- a/scipy/signal/tests/test_dltisys.py
+++ b/scipy/signal/tests/test_dltisys.py
@@ -66,7 +66,7 @@ class TestDLTI(TestCase):
                                   23.0370370370370]).transpose()
 
         # Assume use of the first column of the control input built earlier
-        tout, yout = dlsim((num, den, 0.5), u[:, 0], t_in)
+        tout, yout = dlsim((num, den, dt), u[:, 0], t_in)
 
         assert_array_almost_equal(yout, yout_truth)
         assert_array_almost_equal(t_in, tout)
@@ -89,6 +89,18 @@ class TestDLTI(TestCase):
 
         assert_array_almost_equal(yout, yout_truth)
         assert_array_almost_equal(t_in, tout)
+
+        # System characterized by no dynamics.
+        # The function tf2ss function gives A=[], B=[], C=[], D=[1]
+        # The output must follow the input
+        num = np.asarray([1.0])
+        den = np.asarray([1.0])
+
+        # Assume use of the first column of the control input built earlier
+        t_out, y_out = dlsim((num, den, dt), u[:, 0], t_in)
+        assert_array_almost_equal(y_out, u[:,0])
+        assert_array_almost_equal(t_in, t_out)
+
 
     def test_dstep(self):
 


### PR DESCRIPTION
See #4970 for more details. 
When the system is characterized by A=[], B=[], C=[], D=[1] the function generate an error. 
I've added a check on the value of the matrix A.
