### PR TITLE
BUG: Fix return dtype of lil_matrix.getnnz(axis=0)

### DIFF
--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -189,12 +189,12 @@ class lil_matrix(spmatrix, IndexMixin):
         if axis < 0:
             axis += 2
         if axis == 0:
-            out = np.zeros(self.shape[1])
+            out = np.zeros(self.shape[1], dtype=np.intp)
             for row in self.rows:
                 out[row] += 1
             return out
         elif axis == 1:
-            return np.array([len(rowvals) for rowvals in self.data])
+            return np.array([len(rowvals) for rowvals in self.data], dtype=np.intp)
         else:
             raise ValueError('axis out of bounds')
     nnz = property(fget=getnnz)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -47,6 +47,12 @@ from scipy._lib._version import NumpyVersion
 from scipy._lib.decorator import decorator
 
 import nose
+try:
+    from nose.tools import assert_in
+except ImportError:
+    def assert_in(member, collection, msg=None):
+        assert_(member in collection, msg=msg if msg is not None else "%r not found in %r" % (member, collection))
+
 
 # Check for __numpy_ufunc__
 class _UFuncCheck(object):
@@ -2937,14 +2943,20 @@ class _TestGetNnzAxis(object):
         bool_dat = dat.astype(bool).A
         datsp = self.spmatrix(dat)
 
+        accepted_return_dtypes = (np.int32, np.int64)
+
         assert_array_equal(bool_dat.sum(axis=None), datsp.getnnz(axis=None))
         assert_array_equal(bool_dat.sum(), datsp.getnnz())
         assert_array_equal(bool_dat.sum(axis=0), datsp.getnnz(axis=0))
+        assert_in(datsp.getnnz(axis=0).dtype, accepted_return_dtypes)
         assert_array_equal(bool_dat.sum(axis=1), datsp.getnnz(axis=1))
+        assert_in(datsp.getnnz(axis=1).dtype, accepted_return_dtypes)
         if NumpyVersion(np.__version__) >= '1.7.0':
             # np.matrix.sum with negative axis arg doesn't work for < 1.7
             assert_array_equal(bool_dat.sum(axis=-2), datsp.getnnz(axis=-2))
+            assert_in(datsp.getnnz(axis=-2).dtype, accepted_return_dtypes)
             assert_array_equal(bool_dat.sum(axis=-1), datsp.getnnz(axis=-1))
+            assert_in(datsp.getnnz(axis=-1).dtype, accepted_return_dtypes)
 
         assert_raises(ValueError, datsp.getnnz, axis=2)
 


### PR DESCRIPTION
Working with sparse matrices lately I encountered that the linked-list sparse matrix implementation's `getnnz()` function returns a float array for `axis=0`. Counts obviously should be integer typed; other sparse matrix classes perform correctly (e.g. `csr_matrix`).

Example:

``` python
import numpy
from scipy.sparse import lil_matrix

m = lil_matrix(numpy.eye(3))

print("LIL non-zero")

print(m.getnnz(axis=0))
print(m.getnnz(axis=1))

print("CSR non-zero")

m = m.tocsr()
print(m.getnnz(axis=0))
print(m.getnnz(axis=1))

# result:
# LIL non-zero
# [ 1.  1.  1.]
# [1 1 1]
# CSR non-zero
# [1 1 1]
# [1 1 1]
```

I've seen that there are some bigger PRs ongoing about the `nnz`/`getnnz` functions, but I think that this minor issue should be fixed nonetheless.

Regards,
Christian
