### PR TITLE
DOC: resample slow for prime output too

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1684,8 +1684,8 @@ def resample(x, num, t=None, axis=0, window=None):
     samples.
 
     As noted, `resample` uses FFT transformations, which can be very
-    slow if the number of input samples is large and prime, see
-    `scipy.fftpack.fft`.
+    slow if the number of input or output samples is large and prime;
+    see `scipy.fftpack.fft`.
 
     Examples
     --------


### PR DESCRIPTION
Add note that resample is slow for prime-size input OR output:

```
x = rand(10000)

timeit resample(x, 10007)
1 loops, best of 3: 326 ms per loop

timeit resample(x, 10000)
1000 loops, best of 3: 0.664 ms per loop

timeit resample(x, 10000*3)
1000 loops, best of 3: 1.83 ms per loop


x = rand(10007)

timeit resample(x, 10007)
1 loops, best of 3: 485 ms per loop

timeit resample(x, 10000)
10 loops, best of 3: 158 ms per loop

timeit resample(x, 10000*3)
10 loops, best of 3: 160 ms per loop
```
