### PR TITLE
ENH: io: extend `to_writable` method to array-likes

### DIFF
--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -421,6 +421,11 @@ def to_writeable(source):
     '''
     if isinstance(source, np.ndarray):
         return source
+    # Objects that have an array representation
+    if hasattr(source,'__array__'):
+        ret = source.__array__()
+        if ret is not None:
+              return ret
     if source is None:
         return None
     # Objects that implement mappings


### PR DESCRIPTION
In casadi/casadi#1473, we use array-like objects that work transparently with numpy.
These objects may have a `__dict__` attribute, tricking the `to_writeable` method to interprete them wrongly as dictionaries even before an array-like conversion is attempted.
