### PR TITLE
MAINT: signal: lift max_len_seq validation out of Cython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,7 +161,7 @@ scipy/optimize/minpack2/minpack2module.c
 scipy/optimize/nnls/_nnlsmodule.c
 scipy/optimize/slsqp/_slsqpmodule.c
 scipy/signal/_spectral.c
-scipy/signal/_max_len_seq.c
+scipy/signal/_max_len_seq_inner.c
 scipy/signal/correlate_nd.c
 scipy/signal/lfilter.c
 scipy/sparse/_csparsetools.c

--- a/scipy/signal/_max_len_seq.py
+++ b/scipy/signal/_max_len_seq.py
@@ -21,9 +21,7 @@ _mls_taps = {2: [1], 3: [2], 4: [3], 5: [3], 6: [5], 7: [6], 8: [7, 6, 1],
 
 def max_len_seq(nbits, state=None, length=None, taps=None):
     """
-    max_len_seq(nbits, state=None, length=None, taps=None)
-
-    Maximum Length Sequence (MLS) generator
+    Maximum length sequence (MLS) generator.
 
     Parameters
     ----------

--- a/scipy/signal/_max_len_seq_inner.pyx
+++ b/scipy/signal/_max_len_seq_inner.pyx
@@ -1,0 +1,31 @@
+# Author: Eric Larson
+# 2014
+
+import numpy as np
+cimport numpy as np
+cimport cython
+
+
+# Fast inner loop of max_len_seq.
+@cython.cdivision(True)  # faster modulo
+@cython.boundscheck(False)  # designed to stay within bounds
+@cython.wraparound(False)  # we don't use negative indexing
+def _max_len_seq_inner(np.ndarray[Py_ssize_t, ndim=1, mode='c'] taps,
+                       np.ndarray[np.int8_t, ndim=1, mode='c'] state,
+                       Py_ssize_t nbits, Py_ssize_t length,
+                       np.ndarray[np.int8_t, ndim=1, mode='c'] seq):
+    # Here we compute MLS using a shift register, indexed using a ring buffer
+    # technique (faster than using something like np.roll to shift)
+    cdef Py_ssize_t n_taps = taps.shape[0]
+    cdef Py_ssize_t idx = 0
+    cdef Py_ssize_t fidx = 0
+    cdef np.int8_t feedback
+    for i in range(length):
+        feedback = state[idx]
+        seq[i] = feedback
+        for ti in range(n_taps):
+            feedback ^= state[(taps[ti] + idx) % nbits]
+        state[idx] = feedback
+        idx = (idx + 1) % nbits
+    # state must be rolled s.t. next run, when idx==0, it's in the right place
+    return np.roll(state, -idx, axis=0)

--- a/scipy/signal/bento.info
+++ b/scipy/signal/bento.info
@@ -10,8 +10,8 @@ Library:
             medianfilter.c
     Extension: _spectral
         Sources: _spectral.c
-    Extension: _max_len_seq
-        Sources: _max_len_seq.c
+    Extension: _max_len_seq_inner
+        Sources: _max_len_seq_inner.c
     Extension: spline
         Sources:
             splinemodule.c,

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -20,7 +20,7 @@ def configuration(parent_package='', top_path=None):
                          **numpy_nodepr_api)
 
     config.add_extension('_spectral', sources=['_spectral.c'])
-    config.add_extension('_max_len_seq', sources=['_max_len_seq.c'])
+    config.add_extension('_max_len_seq_inner', sources=['_max_len_seq_inner.c'])
 
     spline_src = ['splinemodule.c', 'S_bspline_util.c', 'D_bspline_util.c',
                   'C_bspline_util.c', 'Z_bspline_util.c', 'bspline_util.c']


### PR DESCRIPTION
Intermediate C source code is ~1500 lines shorter, final `.so` almost half as small (on x64-64). Code is not noticeably slower:

```
>>> %timeit max_len_seq(4, None, 10)
10000 loops, best of 3: 28.3 µs per loop
```

Was 27 µs.
