### PR TITLE
ENH: sparse: add count_nonzero method

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -134,36 +134,59 @@ class spmatrix(object):
 
         np.count_nonzero(a.toarray())
 
-        Unlike getnnz and the nnz property, which return the number of stored
+        Unlike getnnz() and the nnz property, which return the number of stored
         entries (the length of the data attribute), this method counts the
         actual number of non-zero entries in data.
         """
-        # Subclasses may implement more efficient versions of this method,
-        # but this acts as a generic fallback in case they do not.
-        return np.count_nonzero(self.toarray())
+        raise NotImplementedError("count_nonzero not implemented for %s." %
+                                  self.__class__.__name__)
+
+    def getnnz(self, axis=None):
+        """Number of stored values, including explicit zeros.
+
+        Parameters
+        ----------
+        axis : None, 0, or 1
+            Select between the number of values across the whole matrix, in
+            each column, or in each row.
+
+        See also
+        --------
+        count_nonzero : Number of non-zero entries
+        """
+        raise NotImplementedError("getnnz not implemented for %s." %
+                                  self.__class__.__name__)
+
+    @property
+    def nnz(self):
+        """Number of stored values, including explicit zeros.
+
+        See also
+        --------
+        count_nonzero : Number of non-zero entries
+        """
+        return self.getnnz()
 
     def getformat(self):
         return getattr(self, 'format', 'und')
 
     def __repr__(self):
-        nnz = self.getnnz()
         _, format_name = _formats[self.getformat()]
         return "<%dx%d sparse matrix of type '%s'\n" \
                "\twith %d stored elements in %s format>" % \
-               (self.shape + (self.dtype.type, nnz, format_name))
+               (self.shape + (self.dtype.type, self.nnz, format_name))
 
     def __str__(self):
         maxprint = self.getmaxprint()
 
         A = self.tocoo()
-        nnz = self.getnnz()
 
         # helper function, outputs "(i,j)  v"
         def tostr(row,col,data):
             triples = zip(list(zip(row,col)),data)
             return '\n'.join([('  %s\t%s' % t) for t in triples])
 
-        if nnz > maxprint:
+        if self.nnz > maxprint:
             half = maxprint // 2
             out = tostr(A.row[:half], A.col[:half], A.data[:half])
             out += "\n  :\t:\n"
@@ -186,9 +209,8 @@ class spmatrix(object):
     # perhaps it should be the number of rows?  But for some uses the number of
     # non-zeros is more important.  For now, raise an exception!
     def __len__(self):
-        # return self.getnnz()
         raise TypeError("sparse matrix length is ambiguous; use getnnz()"
-                         " or shape[0]")
+                        " or shape[0]")
 
     def asformat(self, format):
         """Return this matrix in a given sparse format

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -129,6 +129,19 @@ class spmatrix(object):
     def getmaxprint(self):
         return self.maxprint
 
+    def count_nonzero(self):
+        """Number of non-zero entries, equivalent to
+
+        np.count_nonzero(a.toarray())
+
+        Unlike getnnz and the nnz property, which return the number of stored
+        entries (the length of the data attribute), this method counts the
+        actual number of non-zero entries in data.
+        """
+        # Subclasses may implement more efficient versions of this method,
+        # but this acts as a generic fallback in case they do not.
+        return np.count_nonzero(self.toarray())
+
     def getformat(self):
         return getattr(self, 'format', 'und')
 

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from .data import _data_matrix, _minmax_mixin
 from .compressed import _cs_matrix
-from .base import isspmatrix, _formats
+from .base import isspmatrix, _formats, spmatrix
 from .sputils import isshape, getdtype, to_native, upcast, get_index_dtype
 from . import _sparsetools
 from ._sparsetools import (bsr_matvec, bsr_matvecs, csr_matmat_pass1,
@@ -266,18 +266,21 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         return self.data.shape[1:]
     blocksize = property(fget=_get_blocksize)
 
-    def getnnz(self):
+    def getnnz(self, axis=None):
+        if axis is not None:
+            raise NotImplementedError("getnnz over an axis is not implemented "
+                                      "for BSR format")
         R,C = self.blocksize
         return int(self.indptr[-1] * R * C)
-    nnz = property(fget=getnnz)
+
+    getnnz.__doc__ = spmatrix.getnnz.__doc__
 
     def __repr__(self):
-        nnz = self.getnnz()
-        format = self.getformat()
-        return "<%dx%d sparse matrix of type '%s'\n" \
-               "\twith %d stored elements (blocksize = %dx%d) in %s format>" % \
-               (self.shape + (self.dtype.type, nnz) + self.blocksize +
-                 (_formats[format][1],))
+        format = _formats[self.getformat()][1]
+        return ("<%dx%d sparse matrix of type '%s'\n"
+                "\twith %d stored elements (blocksize = %dx%d) in %s format>" %
+                (self.shape + (self.dtype.type, self.nnz) + self.blocksize +
+                 (format,)))
 
     def diagonal(self):
         """Returns the main diagonal of the matrix

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -7,15 +7,15 @@ from warnings import warn
 import operator
 
 import numpy as np
-from scipy._lib.six import xrange, zip as izip
+from scipy._lib.six import zip as izip
 
 from .base import spmatrix, isspmatrix, SparseEfficiencyWarning
 from .data import _data_matrix, _minmax_mixin
 from .dia import dia_matrix
 from . import _sparsetools
 from .sputils import (upcast, upcast_char, to_native, isdense, isshape,
-     getdtype, isscalarlike, isintlike, IndexMixin, get_index_dtype,
-     downcast_intp_index)
+                      getdtype, isscalarlike, IndexMixin, get_index_dtype,
+                      downcast_intp_index)
 
 
 class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
@@ -88,14 +88,6 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         self.check_format(full_check=False)
 
     def getnnz(self, axis=None):
-        """Get the count of explicitly-stored values (nonzeros)
-
-        Parameters
-        ----------
-        axis : {None, 0, 1}, optional
-            Select between the number of values across the whole matrix, in
-            each column, or in each row.
-        """
         if axis is None:
             return int(self.indptr[-1])
         else:
@@ -110,7 +102,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 return np.diff(self.indptr)
             raise ValueError('axis out of bounds')
 
-    nnz = property(fget=getnnz)
+    getnnz.__doc__ = spmatrix.getnnz.__doc__
 
     def _set_self(self, other, copy=False):
         """take the member variables of other and assign them to self"""

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -9,13 +9,13 @@ from warnings import warn
 
 import numpy as np
 
-from scipy._lib.six import xrange, zip as izip
+from scipy._lib.six import zip as izip
 
 from ._sparsetools import coo_tocsr, coo_todense, coo_matvec
-from .base import isspmatrix, SparseEfficiencyWarning
+from .base import isspmatrix, SparseEfficiencyWarning, spmatrix
 from .data import _data_matrix, _minmax_mixin
 from .sputils import (upcast, upcast_char, to_native, isshape, getdtype,
-        isintlike, get_index_dtype, downcast_intp_index)
+                      get_index_dtype, downcast_intp_index)
 
 
 class coo_matrix(_data_matrix, _minmax_mixin):
@@ -184,14 +184,6 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         self._check()
 
     def getnnz(self, axis=None):
-        """Get the count of explicitly-stored values (nonzeros)
-
-        Parameters
-        ----------
-        axis : None, 0, or 1
-            Select between the number of values across the whole matrix, in
-            each column, or in each row.
-        """
         if axis is None:
             nnz = len(self.data)
             if nnz != len(self.row) or nnz != len(self.col):
@@ -214,11 +206,11 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                                minlength=self.shape[0])
         else:
             raise ValueError('axis out of bounds')
-    nnz = property(fget=getnnz)
+
+    getnnz.__doc__ = spmatrix.getnnz.__doc__
 
     def _check(self):
         """ Checks data structure for consistency """
-        nnz = self.nnz
 
         # index arrays should have integer data types
         if self.row.dtype.kind != 'i':
@@ -233,7 +225,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         self.col = np.asarray(self.col, dtype=idx_dtype)
         self.data = to_native(self.data)
 
-        if nnz > 0:
+        if self.nnz > 0:
             if self.row.max() >= self.shape[0]:
                 raise ValueError('row index exceeds matrix dimensions')
             if self.col.max() >= self.shape[1]:

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -73,7 +73,7 @@ class _data_matrix(spmatrix):
 
     def count_nonzero(self):
         if self.has_canonical_format:
-          return np.count_nonzero(self.data)
+            return np.count_nonzero(self.data)
         return spmatrix.count_nonzero(self)
 
     def power(self, n, dtype=None):

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -71,6 +71,11 @@ class _data_matrix(spmatrix):
     def copy(self):
         return self._with_data(self.data.copy(), copy=True)
 
+    def count_nonzero(self):
+        if self.has_canonical_format:
+          return np.count_nonzero(self.data)
+        return spmatrix.count_nonzero(self)
+
     def power(self, n, dtype=None):
         """
         This function performs element-wise power.

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -72,9 +72,9 @@ class _data_matrix(spmatrix):
         return self._with_data(self.data.copy(), copy=True)
 
     def count_nonzero(self):
-        if self.has_canonical_format:
-            return np.count_nonzero(self.data)
-        return spmatrix.count_nonzero(self)
+        return np.count_nonzero(self._deduped_data())
+
+    count_nonzero.__doc__ = spmatrix.count_nonzero.__doc__
 
     def power(self, n, dtype=None):
         """

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -152,6 +152,15 @@ class dia_matrix(_data_matrix):
                (self.shape + (self.dtype.type, nnz, self.data.shape[0],
                  _formats[format][1],))
 
+    def count_nonzero(self):
+        num_rows, num_cols = self.shape
+        offset_inds = np.arange(self.data.shape[1])
+        row = offset_inds - self.offsets[:,None]
+        mask = (row >= 0)
+        mask &= (row < num_rows)
+        mask &= (offset_inds < num_cols)
+        return np.count_nonzero(self.data[mask])
+
     def getnnz(self):
         """number of nonzero values
 

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -116,6 +116,9 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         return dict.__len__(self)
     nnz = property(fget=getnnz)
 
+    def count_nonzero(self):
+        return sum(x != 0 for x in self.values())
+
     def __len__(self):
         return dict.__len__(self)
 

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -11,8 +11,7 @@ import operator
 
 import numpy as np
 
-from scipy._lib.six import zip as izip, xrange
-from scipy._lib.six import iteritems
+from scipy._lib.six import zip as izip, xrange, iteritems, itervalues
 
 from .base import spmatrix, isspmatrix
 from .sputils import (isdense, getdtype, isshape, isintlike, isscalarlike,
@@ -112,12 +111,17 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             self.shape = arg1.shape
             self.dtype = d.dtype
 
-    def getnnz(self):
+    def getnnz(self, axis=None):
+        if axis is not None:
+            raise NotImplementedError("getnnz over an axis is not implemented "
+                                      "for DOK format")
         return dict.__len__(self)
-    nnz = property(fget=getnnz)
 
     def count_nonzero(self):
-        return sum(x != 0 for x in self.values())
+        return sum(x != 0 for x in itervalues(self))
+
+    getnnz.__doc__ = spmatrix.getnnz.__doc__
+    count_nonzero.__doc__ = spmatrix.count_nonzero.__doc__
 
     def __len__(self):
         return dict.__len__(self)

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -177,14 +177,6 @@ class lil_matrix(spmatrix, IndexMixin):
     # row
 
     def getnnz(self, axis=None):
-        """Get the count of explicitly-stored values (nonzeros)
-
-        Parameters
-        ----------
-        axis : None, 0, or 1
-            Select between the number of values across the whole matrix, in
-            each column, or in each row.
-        """
         if axis is None:
             return sum([len(rowvals) for rowvals in self.data])
         if axis < 0:
@@ -198,10 +190,12 @@ class lil_matrix(spmatrix, IndexMixin):
             return np.array([len(rowvals) for rowvals in self.data], dtype=np.intp)
         else:
             raise ValueError('axis out of bounds')
-    nnz = property(fget=getnnz)
 
     def count_nonzero(self):
         return sum(np.count_nonzero(rowvals) for rowvals in self.data)
+
+    getnnz.__doc__ = spmatrix.getnnz.__doc__
+    count_nonzero.__doc__ = spmatrix.count_nonzero.__doc__
 
     def __str__(self):
         val = ''

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -200,6 +200,9 @@ class lil_matrix(spmatrix, IndexMixin):
             raise ValueError('axis out of bounds')
     nnz = property(fget=getnnz)
 
+    def count_nonzero(self):
+        return sum(np.count_nonzero(rowvals) for rowvals in self.data)
+
     def __str__(self):
         val = ''
         for i, row in enumerate(self.rows):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -575,8 +575,9 @@ class _TestCommon:
         assert_equal(self.spmatrix((3,3)).count_nonzero(), 0)
 
     def test_count_nonzero(self):
-        assert_equal(self.datsp.count_nonzero(),
-                     np.count_nonzero(self.datsp.toarray()))
+        expected = np.count_nonzero(self.datsp.toarray())
+        assert_equal(self.datsp.count_nonzero(), expected)
+        assert_equal(self.datsp.T.count_nonzero(), expected)
 
     def test_invalid_shapes(self):
         assert_raises(ValueError, self.spmatrix, (-1,3))
@@ -3736,6 +3737,10 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
         assert_equal(m.offsets.dtype, np.int64)
         m.setdiag((3,), k=3)
         assert_equal(m.offsets.dtype, np.int64)
+
+    @dec.skipif(True, 'DIA stores extra zeros')
+    def test_getnnz_axis(self):
+        pass
 
 
 class TestBSR(sparse_test_class(getset=False,

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -572,6 +572,11 @@ class _TestCommon:
         # create empty matrices
         assert_equal(self.spmatrix((3,3)).todense(), np.zeros((3,3)))
         assert_equal(self.spmatrix((3,3)).nnz, 0)
+        assert_equal(self.spmatrix((3,3)).count_nonzero(), 0)
+
+    def test_count_nonzero(self):
+        assert_equal(self.datsp.count_nonzero(),
+                     np.count_nonzero(self.datsp.toarray()))
 
     def test_invalid_shapes(self):
         assert_raises(ValueError, self.spmatrix, (-1,3))


### PR DESCRIPTION
This is a followup of #3524 by @larsmans.

Tests cover all formats, including non-canonical cases. There are currently two problems I'd like some feedback on:
- <strike>Should I copy the docstring from the `spmatrix` implementation to each of the subclass' implementations? Also, is the docstring appropriate?</strike>
- <strike>Non-canonical matrices currently fall back to the `spmatrix` generic implementation, which performs densification. I did this because it seemed like a `count_nonzero` method shouldn't ever mutate state, and the CSR/CSC `eliminate_zeros` method is in-place. Perhaps this case could be handled by making a copy and eliminating zeros on that?</strike>
