### PR TITLE
interp1d: add option for fill_value to 'extrapolate'

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -339,8 +339,8 @@ class interp1d(_Interpolator1D):
     fill_value : float or str, optional
         If provided, then this value will be used to fill in for requested
         points outside of the data range. If not provided, then the default
-        is NaN. If set to 'extrapolate' then points outside the data range
-        will be extrapolated.
+        is NaN. For kind 'nearest' this value can be set to 'extrapolate' then
+        points outside the data range will be extrapolated.
     assume_sorted : bool, optional
         If False, values of `x` can be in any order and they are sorted first.
         If True, `x` has to be an array of monotonically increasing values.
@@ -379,6 +379,10 @@ class interp1d(_Interpolator1D):
 
         self.copy = copy
         self.bounds_error = bounds_error
+        # extrapolation only works for nearest neighbor method
+        if fill_value == "extrapolate" and kind != 'nearest':
+            raise ValueError("Extrapolation only works with method 'nearest'.")
+
         self.fill_value = fill_value
 
         if kind in ['zero', 'slinear', 'quadratic', 'cubic']:

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -336,10 +336,11 @@ class interp1d(_Interpolator1D):
         a value outside of the range of x (where extrapolation is
         necessary). If False, out of bounds values are assigned `fill_value`.
         By default, an error is raised.
-    fill_value : float, optional
+    fill_value : float or str, optional
         If provided, then this value will be used to fill in for requested
         points outside of the data range. If not provided, then the default
-        is NaN.
+        is NaN. If set to 'extrapolate' then points outside the data range
+        will be extrapolated.
     assume_sorted : bool, optional
         If False, values of `x` can be in any order and they are sorted first.
         If True, `x` has to be an array of monotonically increasing values.
@@ -494,10 +495,11 @@ class interp1d(_Interpolator1D):
         #    or return a list of mask array indicating the outofbounds values.
         #    The behavior is set by the bounds_error variable.
         x_new = asarray(x_new)
-        out_of_bounds = self._check_bounds(x_new)
         y_new = self._call(self, x_new)
-        if len(y_new) > 0:
-            y_new[out_of_bounds] = self.fill_value
+        if self.fill_value != 'extrapolate':
+            out_of_bounds = self._check_bounds(x_new)
+            if len(y_new) > 0:
+                y_new[out_of_bounds] = self.fill_value
         return y_new
 
     def _check_bounds(self, x_new):

--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -197,6 +197,8 @@ def griddata(points, values, xi, method='linear', fill_value=np.nan,
         idx = np.argsort(points)
         points = points[idx]
         values = values[idx]
+        if method == 'nearest':
+            fill_value = 'extrapolate'
         ip = interp1d(points, values, kind=method, axis=0, bounds_error=False,
                       fill_value=fill_value)
         return ip(xi)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -130,10 +130,17 @@ class TestInterp1D(object):
         interp1d(self.x10, self.y10, kind='quadratic')
         interp1d(self.x10, self.y10, kind='zero')
         interp1d(self.x10, self.y10, kind='nearest')
+        interp1d(self.x10, self.y10, kind='nearest', fill_value="extrapolate")
         interp1d(self.x10, self.y10, kind=0)
         interp1d(self.x10, self.y10, kind=1)
         interp1d(self.x10, self.y10, kind=2)
         interp1d(self.x10, self.y10, kind=3)
+
+        # extrapolation only allowed for nearest method
+        for kind in ('linear', 'cubic',
+                     'slinear', 'zero', 'quadratic'):
+            assert_raises(ValueError, interp1d, self.x10, self.y10, kind=kind,
+                          fill_value="extrapolate")
 
         # x array must be 1D.
         assert_raises(ValueError, interp1d, self.x25, self.y10)

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -88,6 +88,30 @@ class TestGriddata(object):
             assert_allclose(griddata((x,), y, (x,), method=method), y,
                             err_msg=method, atol=1e-14)
 
+    def test_1d_borders(self):
+        """
+        Test for nearest neighbor case with xi outside
+        the range of the values.
+        """
+        x = np.array([1, 2.5, 3, 4.5, 5, 6])
+        y = np.array([1, 2, 0, 3.9, 2, 1])
+        xi = np.array([0.9, 6.5])
+        yi_should = np.array([1.0, 1.0])
+
+        method = 'nearest'
+        assert_allclose(griddata(x, y, xi,
+                                 method=method), yi_should,
+                        err_msg=method,
+                        atol=1e-14)
+        assert_allclose(griddata(x.reshape(6, 1), y, xi,
+                                 method=method), yi_should,
+                        err_msg=method,
+                        atol=1e-14)
+        assert_allclose(griddata((x, ), y, (xi, ),
+                                 method=method), yi_should,
+                        err_msg=method,
+                        atol=1e-14)
+
     def test_1d_unsorted(self):
         x = np.array([2.5, 1, 4.5, 5, 6, 3])
         y = np.array([1, 2, 0, 3.9, 2, 1])


### PR DESCRIPTION
I'm not sure if this is too harsh a change but it would remove the bounds checking for nearest neighbor interpolation. This leads to consistent behavior of 1D and ND nearest neighbor interpolation. 

In light of the discussion in https://github.com/scipy/scipy/issues/4304 about deprecation of interp1d another solution might be to use another 1D interpolator or cKDTree directly (although the performance of that is probably not as good as a special 1D case)

fix #4233
