### PR TITLE
MAINT: restore lost tail accuracy in genpareto.logsf

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1622,6 +1622,11 @@ class genpareto_gen(rv_continuous):
     def _sf(self, x, c):
         return inv_boxcox(-x, -c)
 
+    def _logsf(self, x, c):
+        return _lazywhere((x == x) & (c != 0), (x, c),
+            lambda x, c: -special.log1p(c*x) / c,
+            -x)
+
     def _ppf(self, q, c):
         return -boxcox1p(-q, -c)
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -639,6 +639,10 @@ class TestGenpareto(TestCase):
             assert_allclose(stats.genpareto.cdf(stats.genpareto.ppf(q, c), c),
                     q, atol=1e-15)
 
+    def test_logsf(self):
+        logp = stats.genpareto.logsf(1e10, .01, 0, 1)
+        assert_allclose(logp, -1842.0680753952365)
+
 
 class TestPearson3(TestCase):
     def test_rvs(self):


### PR DESCRIPTION
fixes a regression introduced in https://github.com/scipy/scipy/pull/4211
closes https://github.com/scipy/scipy/issues/5048
