### PR TITLE
ENH: sparse: avoid densifying on sparse/dense elementwise mult

### DIFF
--- a/doc/release/0.17.0-notes.rst
+++ b/doc/release/0.17.0-notes.rst
@@ -57,6 +57,10 @@ make sense for unsorted input.
 When ``variable_names`` is set to an empty list, ``scipy.io.loadmat`` now
 correctly returns no values instead of all the contents of the MAT file.
 
+Element-wise multiplication of sparse matrices now returns a sparse result
+in all cases. Previously, multiplying a sparse matrix with a dense matrix or
+array would return a dense matrix.
+
 Other changes
 =============
 

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -397,7 +397,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         """
         # Scalar multiplication.
         if isscalarlike(other):
-            return self.__mul__(other)
+            return self._mul_scalar(other)
         # Sparse matrix or vector.
         if isspmatrix(other):
             if self.shape == other.shape:
@@ -441,11 +441,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 ret = self.tocoo()
                 ret.data = np.multiply(ret.data, other[ret.row, ret.col]
                                        ).view(np.ndarray).ravel()
-                # Current tests expect dense output.
-                return ret.todense()
+                return ret
             # Single element.
             elif other.size == 1:
-                return self.__mul__(other.flat[0])
+                return self._mul_scalar(other.flat[0])
         # Anything else.
         return np.multiply(self.todense(), other)
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1079,7 +1079,7 @@ class _TestCommon:
         Asp = self.spmatrix(A)
         Bsp = self.spmatrix(B)
         assert_almost_equal(Asp.multiply(Bsp).todense(), A*B)  # sparse/sparse
-        assert_almost_equal(Asp.multiply(B), A*B)  # sparse/dense
+        assert_almost_equal(Asp.multiply(B).todense(), A*B)  # sparse/dense
 
         # complex/complex
         C = array([[1-2j,0+5j,-1+0j],[4-3j,-3+6j,5]])
@@ -1087,11 +1087,11 @@ class _TestCommon:
         Csp = self.spmatrix(C)
         Dsp = self.spmatrix(D)
         assert_almost_equal(Csp.multiply(Dsp).todense(), C*D)  # sparse/sparse
-        assert_almost_equal(Csp.multiply(D), C*D)  # sparse/dense
+        assert_almost_equal(Csp.multiply(D).todense(), C*D)  # sparse/dense
 
         # real/complex
         assert_almost_equal(Asp.multiply(Dsp).todense(), A*D)  # sparse/sparse
-        assert_almost_equal(Asp.multiply(D), A*D)  # sparse/dense
+        assert_almost_equal(Asp.multiply(D).todense(), A*D)  # sparse/dense
 
     def test_elementwise_multiply_broadcast(self):
         A = array([4])


### PR DESCRIPTION
This is the long-awaited followup to #4133, which I lost track of and forgot about.
