### PR TITLE
ENH: spatial: faster 2D Voronoi and Convex Hull plotting

### DIFF
--- a/scipy/spatial/_plotutils.py
+++ b/scipy/spatial/_plotutils.py
@@ -104,8 +104,8 @@ def convex_hull_plot_2d(hull, ax=None):
     for simplex in hull.simplices:
         line_segments.append([(x, y) for x, y in hull.points[simplex]])
     ax.add_collection(LineCollection(line_segments,
-                                     colors = 'k',
-                                     linestyle = 'solid'))
+                                     colors='k',
+                                     linestyle='solid'))
     _adjust_bounds(ax, hull.points)
 
     return ax.figure
@@ -155,8 +155,8 @@ def voronoi_plot_2d(vor, ax=None, **kw):
             line_segments.append([(x, y) for x, y in vor.vertices[simplex]])
 
     ax.add_collection(LineCollection(line_segments,
-                                     colors = 'k',
-                                     linestyle = 'solid'))
+                                     colors='k',
+                                     linestyle='solid'))
     ptp_bound = vor.points.ptp(axis=0)
 
     line_segments = []
@@ -178,8 +178,8 @@ def voronoi_plot_2d(vor, ax=None, **kw):
                                   (far_point[0], far_point[1])])
 
     ax.add_collection(LineCollection(line_segments,
-                                     colors = 'k',
-                                     linestyle = 'dashed'))
+                                     colors='k',
+                                     linestyle='dashed'))
     _adjust_bounds(ax, vor.points)
 
     return ax.figure

--- a/scipy/spatial/_plotutils.py
+++ b/scipy/spatial/_plotutils.py
@@ -9,7 +9,6 @@ __all__ = ['delaunay_plot_2d', 'convex_hull_plot_2d', 'voronoi_plot_2d']
 @_decorator
 def _held_figure(func, obj, ax=None, **kw):
     import matplotlib.pyplot as plt
-    from matplotlib.collections import LineCollection
 
     if ax is None:
         fig = plt.figure()
@@ -95,6 +94,8 @@ def convex_hull_plot_2d(hull, ax=None):
     Requires Matplotlib.
 
     """
+    from matplotlib.collections import LineCollection
+
     if hull.points.shape[1] != 2:
         raise ValueError("Convex hull is not 2-D")
 
@@ -111,7 +112,7 @@ def convex_hull_plot_2d(hull, ax=None):
 
 
 @_held_figure
-def voronoi_plot_2d(vor, ax=None):
+def voronoi_plot_2d(vor, ax=None, **kw):
     """
     Plot the given Voronoi diagram in 2-D
 
@@ -121,6 +122,8 @@ def voronoi_plot_2d(vor, ax=None):
         Diagram to plot
     ax : matplotlib.axes.Axes instance, optional
         Axes to plot on
+    show_vertices : bool, optional
+        Add the Voronoi vertices to the plot.
 
     Returns
     -------
@@ -136,11 +139,14 @@ def voronoi_plot_2d(vor, ax=None):
     Requires Matplotlib.
 
     """
+    from matplotlib.collections import LineCollection
+
     if vor.points.shape[1] != 2:
         raise ValueError("Voronoi diagram is not 2-D")
 
     ax.plot(vor.points[:,0], vor.points[:,1], '.')
-    ax.plot(vor.vertices[:,0], vor.vertices[:,1], 'o')
+    if kw.get('show_vertices', True):
+        ax.plot(vor.vertices[:,0], vor.vertices[:,1], 'o')
 
     line_segments = []
     for simplex in vor.ridge_vertices:

--- a/scipy/spatial/_plotutils.py
+++ b/scipy/spatial/_plotutils.py
@@ -9,6 +9,7 @@ __all__ = ['delaunay_plot_2d', 'convex_hull_plot_2d', 'voronoi_plot_2d']
 @_decorator
 def _held_figure(func, obj, ax=None, **kw):
     import matplotlib.pyplot as plt
+    from matplotlib.collections import LineCollection
 
     if ax is None:
         fig = plt.figure()
@@ -98,9 +99,12 @@ def convex_hull_plot_2d(hull, ax=None):
         raise ValueError("Convex hull is not 2-D")
 
     ax.plot(hull.points[:,0], hull.points[:,1], 'o')
+    line_segments = []
     for simplex in hull.simplices:
-        ax.plot(hull.points[simplex,0], hull.points[simplex,1], 'k-')
-
+        line_segments.append([(x, y) for x, y in hull.points[simplex]])
+    ax.add_collection(LineCollection(line_segments,
+                                     colors = 'k',
+                                     linestyle = 'solid'))
     _adjust_bounds(ax, hull.points)
 
     return ax.figure
@@ -138,13 +142,18 @@ def voronoi_plot_2d(vor, ax=None):
     ax.plot(vor.points[:,0], vor.points[:,1], '.')
     ax.plot(vor.vertices[:,0], vor.vertices[:,1], 'o')
 
+    line_segments = []
     for simplex in vor.ridge_vertices:
         simplex = np.asarray(simplex)
         if np.all(simplex >= 0):
-            ax.plot(vor.vertices[simplex,0], vor.vertices[simplex,1], 'k-')
+            line_segments.append([(x, y) for x, y in vor.vertices[simplex]])
 
+    ax.add_collection(LineCollection(line_segments,
+                                     colors = 'k',
+                                     linestyle = 'solid'))
     ptp_bound = vor.points.ptp(axis=0)
 
+    line_segments = []
     center = vor.points.mean(axis=0)
     for pointidx, simplex in zip(vor.ridge_points, vor.ridge_vertices):
         simplex = np.asarray(simplex)
@@ -159,9 +168,12 @@ def voronoi_plot_2d(vor, ax=None):
             direction = np.sign(np.dot(midpoint - center, n)) * n
             far_point = vor.vertices[i] + direction * ptp_bound.max()
 
-            ax.plot([vor.vertices[i,0], far_point[0]],
-                    [vor.vertices[i,1], far_point[1]], 'k--')
+            line_segments.append([(vor.vertices[i, 0], vor.vertices[i, 1]),
+                                  (far_point[0], far_point[1])])
 
+    ax.add_collection(LineCollection(line_segments,
+                                     colors = 'k',
+                                     linestyle = 'dashed'))
     _adjust_bounds(ax, vor.points)
 
     return ax.figure

--- a/scipy/spatial/tests/test__plotutils.py
+++ b/scipy/spatial/tests/test__plotutils.py
@@ -6,6 +6,7 @@ try:
     import matplotlib
     matplotlib.rcParams['backend'] = 'Agg'
     import matplotlib.pyplot as plt
+    from matplotlib.collections import LineCollection
     has_matplotlib = True
 except:
     has_matplotlib = False
@@ -37,6 +38,7 @@ class TestPlotting:
         r = voronoi_plot_2d(obj, ax=fig.gca())
         assert_(r is fig)
         voronoi_plot_2d(obj)
+        voronoi_plot_2d(obj, show_vertices=False)
 
     @dec.skipif(not has_matplotlib, "Matplotlib not available")
     def test_convex_hull(self):


### PR DESCRIPTION
This pull request modifies `voronoi_plot_2d` and `convex_hull_plot_2d` to use `matplotlib.collections.LineCollection` objects.  This removes the need for repeatedly calling `ax.plot` on each individual line segment and speeds up plotting.  This improvement is especially dramatic for the Voronoi case (approximately 13 times faster for me in the example below!).

On my PC, for a set of 2000 randomly generated 2D points I got the following speedups
**voronoi_plot_2d** :        previously 8.45 s -> now 0.63 s
**convex_hull_plot_2d**:|  previously 111 ms -> now 83 ms

I also added an optional kwarg to `voronoi_plot_2d` that can be used to avoid adding the vertices to the plot.  To my eye this looks cleaner, especially when there are a large number of points, but I have left the old behavior as the default.
