### PR TITLE
MAINT: fancy indexing of a sparse matrix now returns a sparse matrix

### DIFF
--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -320,9 +320,6 @@ class csr_matrix(_cs_matrix, IndexMixin):
         csr_sample_values(self.shape[0], self.shape[1],
                           self.indptr, self.indices, self.data,
                           num_samples, row.ravel(), col.ravel(), val)
-        if row.ndim == 1:
-            # row and col are 1d
-            return np.asmatrix(val)
         return self.__class__(val.reshape(row.shape))
 
     def getrow(self, i):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2329,11 +2329,11 @@ class _TestFancyIndexing:
         assert_equal(A[array([2,-5]),8:-1].todense(),B[[2,-5],8:-1])
 
         # [[1,2],[1,2]]
-        assert_equal(todense(A[[1,3],[2,4]]), B[[1,3],[2,4]])
-        assert_equal(todense(A[[-1,-3],[2,-4]]), B[[-1,-3],[2,-4]])
-        assert_equal(todense(A[array([-1,-3]),[2,-4]]), B[[-1,-3],[2,-4]])
-        assert_equal(todense(A[[-1,-3],array([2,-4])]), B[[-1,-3],[2,-4]])
-        assert_equal(todense(A[array([-1,-3]),array([2,-4])]), B[[-1,-3],[2,-4]])
+        assert_equal(A[[1,3],[2,4]].todense(), B[[1,3],[2,4]])
+        assert_equal(A[[-1,-3],[2,-4]].todense(), B[[-1,-3],[2,-4]])
+        assert_equal(A[array([-1,-3]),[2,-4]].todense(), B[[-1,-3],[2,-4]])
+        assert_equal(A[[-1,-3],array([2,-4])].todense(), B[[-1,-3],[2,-4]])
+        assert_equal(A[array([-1,-3]),array([2,-4])].todense(), B[[-1,-3],[2,-4]])
 
         # [[[1],[2]],[1,2]]
         assert_equal(A[[[1],[3]],[2,4]].todense(), B[[[1],[3]],[2,4]])


### PR DESCRIPTION
Improves consistency of the sparse matrix interface.  I'm not sure this is the right solution (or if the inconsistency is even a problem), so please wait for a few comments before merging.

Related issues are https://github.com/scipy/scipy/issues/5059 and https://github.com/numpy/numpy/issues/6060.
