### PR TITLE
DOC: clarified parameterization of stats.lognorm

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2986,9 +2986,11 @@ class lognorm_gen(rv_continuous):
 
     %(after_notes)s
 
-    If ``log(x)`` is normally distributed with mean ``mu`` and variance
-    ``sigma**2``, then ``x`` is log-normally distributed with shape parameter
-    sigma and scale parameter ``exp(mu)``.
+    A common parametrization for a lognormal random variable ``Y`` is in
+    terms of the mean, ``mu``, and standard deviation, ``sigma``, of the
+    unique normally distributed random variable ``X`` such that exp(X) = Y.
+    This parametrization corresponds to setting ``s = sigma`` and ``scale =
+    exp(mu)``.
 
     %(example)s
 


### PR DESCRIPTION
The parametrization of scipy.stats.lognorm appears to have been justified a desire for a uniform interface across random variates. 

The existing phrasing of the documentation did not make it clear to new users how this translates into the standard parametrization (in particular, as a new SciPy user, it required looking through multiple docstrings and finally quitting and checking stackoverflow before I figured it out). 

I added a note similar to the one under scipy.stats.expon to make it easy for new (and existing) users to translate the standard parametrization into the one required by SciPy without undue mental strain.

This addresses bug #2027. (TRAC#1502).
