### PR TITLE
use int, float, bool instead of np.int, np.float, np.bool

### DIFF
--- a/doc/source/tutorial/stats/plots/kde_plot2.py
+++ b/doc/source/tutorial/stats/plots/kde_plot2.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from scipy import stats
 
-x1 = np.array([-7, -5, 1, 4, 5], dtype=np.float)
+x1 = np.array([-7, -5, 1, 4, 5], dtype=float)
 x_eval = np.linspace(-10, 10, num=200)
 kde1 = stats.gaussian_kde(x1)
 kde2 = stats.gaussian_kde(x1, bw_method='silverman')

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -917,8 +917,8 @@ def to_tree(Z, rd=False):
 
 
 def _convert_to_bool(X):
-    if X.dtype != np.bool:
-        X = X.astype(np.bool)
+    if X.dtype != bool:
+        X = X.astype(bool)
     if not X.flags.contiguous:
         X = X.copy()
     return X

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -301,7 +301,7 @@ class TestIsValidLinkage(object):
     def test_is_valid_linkage_int_type(self):
         # Tests is_valid_linkage(Z) with integer type.
         Z = np.asarray([[0, 1, 3.0, 2],
-                        [3, 2, 4.0, 3]], dtype=np.int)
+                        [3, 2, 4.0, 3]], dtype=int)
         assert_(is_valid_linkage(Z) == False)
         assert_raises(TypeError, is_valid_linkage, Z, throw=True)
 
@@ -364,7 +364,7 @@ class TestIsValidInconsistent(object):
     def test_is_valid_im_int_type(self):
         # Tests is_valid_im(R) with integer type.
         R = np.asarray([[0, 1, 3.0, 2],
-                        [3, 2, 4.0, 3]], dtype=np.int)
+                        [3, 2, 4.0, 3]], dtype=int)
         assert_(is_valid_im(R) == False)
         assert_raises(TypeError, is_valid_im, R, throw=True)
 

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -120,7 +120,7 @@ class TestVq(TestCase):
         assert_raises(TypeError, _vq.vq, a, b)
 
     def test__vq_invalid_type(self):
-        a = np.array([1, 2], dtype=np.int)
+        a = np.array([1, 2], dtype=int)
         assert_raises(TypeError, _vq.vq, a, a)
 
     def test_vq_large_nfeat(self):

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -673,7 +673,7 @@ class TestLongDoubleFailure(TestCase):
         np.random.seed(1234)
 
     def test_complex(self):
-        if np.dtype(np.longcomplex).itemsize == np.dtype(np.complex).itemsize:
+        if np.dtype(np.longcomplex).itemsize == np.dtype(complex).itemsize:
             # longdouble == double; so fft is supported
             return
 

--- a/scipy/fftpack/tests/test_real_transforms.py
+++ b/scipy/fftpack/tests/test_real_transforms.py
@@ -156,7 +156,7 @@ class TestDCTIFloat(_TestDCTBase):
 
 class TestDCTIInt(_TestDCTBase):
     def setUp(self):
-        self.rdt = np.int
+        self.rdt = int
         self.dec = 5
         self.type = 1
 
@@ -177,7 +177,7 @@ class TestDCTIIFloat(_TestDCTIIBase):
 
 class TestDCTIIInt(_TestDCTIIBase):
     def setUp(self):
-        self.rdt = np.int
+        self.rdt = int
         self.dec = 5
         self.type = 2
 
@@ -198,7 +198,7 @@ class TestDCTIIIFloat(_TestDCTIIIBase):
 
 class TestDCTIIIInt(_TestDCTIIIBase):
     def setUp(self):
-        self.rdt = np.int
+        self.rdt = int
         self.dec = 5
         self.type = 3
 
@@ -242,7 +242,7 @@ class TestIDCTIFloat(_TestIDCTBase):
 
 class TestIDCTIInt(_TestIDCTBase):
     def setUp(self):
-        self.rdt = np.int
+        self.rdt = int
         self.dec = 4
         self.type = 1
 
@@ -263,7 +263,7 @@ class TestIDCTIIFloat(_TestIDCTBase):
 
 class TestIDCTIIInt(_TestIDCTBase):
     def setUp(self):
-        self.rdt = np.int
+        self.rdt = int
         self.dec = 5
         self.type = 2
 
@@ -284,7 +284,7 @@ class TestIDCTIIIFloat(_TestIDCTBase):
 
 class TestIDCTIIIInt(_TestIDCTBase):
     def setUp(self):
-        self.rdt = np.int
+        self.rdt = int
         self.dec = 5
         self.type = 3
 
@@ -324,7 +324,7 @@ class TestDSTIFloat(_TestDSTBase):
 
 class TestDSTIInt(_TestDSTBase):
     def setUp(self):
-        self.rdt = np.int
+        self.rdt = int
         self.dec = 5
         self.type = 1
 
@@ -345,7 +345,7 @@ class TestDSTIIFloat(_TestDSTBase):
 
 class TestDSTIIInt(_TestDSTBase):
     def setUp(self):
-        self.rdt = np.int
+        self.rdt = int
         self.dec = 6
         self.type = 2
 
@@ -366,7 +366,7 @@ class TestDSTIIIFloat(_TestDSTBase):
 
 class TestDSTIIIInt(_TestDSTBase):
     def setUp(self):
-        self.rdt = np.int
+        self.rdt = int
         self.dec = 7
         self.type = 3
 
@@ -410,7 +410,7 @@ class TestIDSTIFloat(_TestIDSTBase):
 
 class TestIDSTIInt(_TestIDSTBase):
     def setUp(self):
-        self.rdt = np.int
+        self.rdt = int
         self.dec = 4
         self.type = 1
 
@@ -431,7 +431,7 @@ class TestIDSTIIFloat(_TestIDSTBase):
 
 class TestIDSTIIInt(_TestIDSTBase):
     def setUp(self):
-        self.rdt = np.int
+        self.rdt = int
         self.dec = 6
         self.type = 2
 
@@ -452,7 +452,7 @@ class TestIDSTIIIFloat(_TestIDSTBase):
 
 class TestIDSTIIIInt(_TestIDSTBase):
     def setUp(self):
-        self.rdt = np.int
+        self.rdt = int
         self.dec = 6
         self.type = 3
 

--- a/scipy/interpolate/interpolate_wrapper.py
+++ b/scipy/interpolate/interpolate_wrapper.py
@@ -37,7 +37,7 @@ def nearest(x, y, new_x):
 
     TINY = 1e-10
     indices = np.searchsorted(midpoints_of_x, new_x+TINY)-1
-    indices = np.atleast_1d(np.clip(indices, 0, np.Inf).astype(np.int))
+    indices = np.atleast_1d(np.clip(indices, 0, np.Inf).astype(int))
     new_y = np.take(y, indices, axis=-1)
 
     return new_y
@@ -177,6 +177,6 @@ def block(x, y, new_x):
     # If the value is at the front of the list, it'll have -1.
     # In this case, we will use the first (0), element in the array.
     # take requires the index array to be an Int
-    indices = np.atleast_1d(np.clip(indices, 0, np.Inf).astype(np.int))
+    indices = np.atleast_1d(np.clip(indices, 0, np.Inf).astype(int))
     new_y = np.take(y, indices, axis=-1)
     return new_y

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -82,7 +82,7 @@ class TestUnivariateSpline(TestCase):
 
     def test_out_of_range_regression(self):
         # Test different extrapolation modes. See ticket 3557
-        x = np.arange(5, dtype=np.float)
+        x = np.arange(5, dtype=float)
         y = x**3
 
         xp = linspace(-8, 13, 100)

--- a/scipy/interpolate/tests/test_interpolate_wrapper.py
+++ b/scipy/interpolate/tests/test_interpolate_wrapper.py
@@ -36,8 +36,8 @@ class Test(unittest.TestCase):
 
     def test_block_average_above(self):
         N = 3000
-        x = arange(N, dtype=np.float)
-        y = arange(N, dtype=np.float)
+        x = arange(N, dtype=float)
+        y = arange(N, dtype=float)
 
         new_x = arange(N // 2) * 2
         new_y = block_average_above(x, y, new_x)
@@ -45,7 +45,7 @@ class Test(unittest.TestCase):
 
     def test_linear2(self):
         N = 3000
-        x = arange(N, dtype=np.float)
+        x = arange(N, dtype=float)
         y = ones((100,N)) * arange(N)
         new_x = arange(N) + 0.5
         new_y = linear(x, y, new_x)

--- a/scipy/io/_fortran.py
+++ b/scipy/io/_fortran.py
@@ -66,7 +66,7 @@ class FortranFile(object):
     >>> f = FortranFile('test.unf', 'r')
     >>> print(f.read_ints(dtype=np.int32))
     [1 2 3 4 5]
-    >>> print(f.read_reals(dtype=np.float).reshape((5,-1)))
+    >>> print(f.read_reals(dtype=float).reshape((5,-1)))
     [[ 0.          0.05263158  0.10526316  0.15789474]
      [ 0.21052632  0.26315789  0.31578947  0.36842105]
      [ 0.42105263  0.47368421  0.52631579  0.57894737]

--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -376,7 +376,7 @@ def safe_float(x):
     if '?' in x:
         return np.nan
     else:
-        return np.float(x)
+        return float(x)
 
 
 def safe_nominal(value, pvalue):
@@ -575,7 +575,7 @@ def _loadarff(ofile):
 
     # This can be used once we want to support integer as integer values and
     # not as numeric anymore (using masked arrays ?).
-    acls2dtype = {'real': np.float, 'integer': np.float, 'numeric': np.float}
+    acls2dtype = {'real': float, 'integer': float, 'numeric': float}
     acls2conv = {'real': safe_float, 'integer': safe_float, 'numeric': safe_float}
     descr = []
     convertors = []

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -39,7 +39,7 @@ expected_types = ['numeric', 'numeric', 'numeric', 'numeric', 'nominal']
 
 missing = pjoin(data_path, 'missing.arff')
 expect_missing_raw = np.array([[1, 5], [2, 4], [np.nan, np.nan]])
-expect_missing = np.empty(3, [('yop', np.float), ('yap', np.float)])
+expect_missing = np.empty(3, [('yop', float), ('yap', float)])
 expect_missing['yop'] = expect_missing_raw[:, 0]
 expect_missing['yap'] = expect_missing_raw[:, 1]
 

--- a/scipy/io/harwell_boeing/hb.py
+++ b/scipy/io/harwell_boeing/hb.py
@@ -253,7 +253,7 @@ class HBInfo(object):
                 raise ValueError("Inconsistency between matrix type %s and "
                                  "value type %s" % (mxtype, values_format))
             # XXX: fortran int -> dtype association ?
-            values_dtype = np.int
+            values_dtype = int
         else:
             raise ValueError("Unsupported format for values %r" % (values_format,))
 
@@ -313,12 +313,12 @@ def _read_hb_data(content, header):
     ptr_string = "".join([content.read(header.pointer_nbytes_full),
                            content.readline()])
     ptr = np.fromstring(ptr_string,
-            dtype=np.int, sep=' ')
+            dtype=int, sep=' ')
 
     ind_string = "".join([content.read(header.indices_nbytes_full),
                        content.readline()])
     ind = np.fromstring(ind_string,
-            dtype=np.int, sep=' ')
+            dtype=int, sep=' ')
 
     val_string = "".join([content.read(header.values_nbytes_full),
                           content.readline()])

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -445,7 +445,7 @@ def to_writeable(source):
             return EmptyStructMarker
     # Next try and convert to an array
     narr = np.asanyarray(source)
-    if narr.dtype.type in (np.object, np.object_) and \
+    if narr.dtype.type in (object, np.object_) and \
        narr.shape == () and narr == source:
         # No interesting conversion possible
         return None

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -455,7 +455,7 @@ def test_regression_653():
     back = loadmat(sio)['d']
     # Check we got an empty struct equivalent
     assert_equal(back.shape, (1,1))
-    assert_equal(back.dtype, np.dtype(np.object))
+    assert_equal(back.dtype, np.dtype(object))
     assert_(back[0,0] is None)
 
 
@@ -678,7 +678,7 @@ def test_empty_struct():
     d = loadmat(filename, struct_as_record=True)
     a = d['a']
     assert_equal(a.shape, (1,1))
-    assert_equal(a.dtype, np.dtype(np.object))
+    assert_equal(a.dtype, np.dtype(object))
     assert_(a[0,0] is None)
     stream = BytesIO()
     arr = np.array((), dtype='U')
@@ -696,7 +696,7 @@ def test_save_empty_dict():
     d = loadmat(stream)
     a = d['arr']
     assert_equal(a.shape, (1,1))
-    assert_equal(a.dtype, np.dtype(np.object))
+    assert_equal(a.dtype, np.dtype(object))
     assert_(a[0,0] is None)
 
 
@@ -905,7 +905,7 @@ def test_read_both_endian():
         fp.close()
         assert_array_equal(d['strings'],
                            np.array([['hello'],
-                                     ['world']], dtype=np.object))
+                                     ['world']], dtype=object))
         assert_array_equal(d['floats'],
                            np.array([[2., 3.],
                                      [3., 4.]], dtype=np.float32))

--- a/scipy/io/matlab/tests/test_mio_utils.py
+++ b/scipy/io/matlab/tests/test_mio_utils.py
@@ -24,7 +24,7 @@ def test_squeeze_element():
     a = np.zeros((1,3))
     assert_array_equal(np.squeeze(a), squeeze_element(a))
     # 0d output from squeeze gives scalar
-    sq_int = squeeze_element(np.zeros((1,1), dtype=np.float))
+    sq_int = squeeze_element(np.zeros((1,1), dtype=float))
     assert_(isinstance(sq_int, float))
     # Unless it's a structured array
     sq_sa = squeeze_element(np.zeros((1,1),dtype=[('f1', 'f')]))

--- a/scipy/io/tests/test_idl.py
+++ b/scipy/io/tests/test_idl.py
@@ -14,7 +14,7 @@ from scipy.io.idl import readsav
 
 def object_array(*args):
     """Constructs a numpy array of objects"""
-    array = np.empty(len(args), dtype=np.object)
+    array = np.empty(len(args), dtype=object)
     for i in range(len(args)):
         array[i] = args[i]
     return array
@@ -23,7 +23,7 @@ def object_array(*args):
 def assert_identical(a, b):
     """Assert whether value AND type are the same"""
     assert_equal(a, b)
-    if type(b) is np.str:
+    if type(b) is str:
         assert_equal(type(a), type(b))
     else:
         assert_equal(np.asarray(a).dtype.type, np.asarray(b).dtype.type)
@@ -125,7 +125,7 @@ class TestCompressed(TestScalars):
         assert_identical(s.arrays.a[0], np.array([1, 2, 3], dtype=np.int16))
         assert_identical(s.arrays.b[0], np.array([4., 5., 6., 7.], dtype=np.float32))
         assert_identical(s.arrays.c[0], np.array([np.complex64(1+2j), np.complex64(7+8j)]))
-        assert_identical(s.arrays.d[0], np.array([b"cheese", b"bacon", b"spam"], dtype=np.object))
+        assert_identical(s.arrays.d[0], np.array([b"cheese", b"bacon", b"spam"], dtype=object))
 
 
 class TestArrayDimensions:
@@ -172,7 +172,7 @@ class TestStructures:
         assert_identical(s.scalars.b, np.array(np.int32(2)))
         assert_identical(s.scalars.c, np.array(np.float32(3.)))
         assert_identical(s.scalars.d, np.array(np.float64(4.)))
-        assert_identical(s.scalars.e, np.array([b"spam"], dtype=np.object))
+        assert_identical(s.scalars.e, np.array([b"spam"], dtype=object))
         assert_identical(s.scalars.f, np.array(np.complex64(-1.+3j)))
 
     def test_scalars_replicated(self):
@@ -181,7 +181,7 @@ class TestStructures:
         assert_identical(s.scalars_rep.b, np.repeat(np.int32(2), 5))
         assert_identical(s.scalars_rep.c, np.repeat(np.float32(3.), 5))
         assert_identical(s.scalars_rep.d, np.repeat(np.float64(4.), 5))
-        assert_identical(s.scalars_rep.e, np.repeat(b"spam", 5).astype(np.object))
+        assert_identical(s.scalars_rep.e, np.repeat(b"spam", 5).astype(object))
         assert_identical(s.scalars_rep.f, np.repeat(np.complex64(-1.+3j), 5))
 
     def test_scalars_replicated_3d(self):
@@ -190,7 +190,7 @@ class TestStructures:
         assert_identical(s.scalars_rep.b, np.repeat(np.int32(2), 24).reshape(4, 3, 2))
         assert_identical(s.scalars_rep.c, np.repeat(np.float32(3.), 24).reshape(4, 3, 2))
         assert_identical(s.scalars_rep.d, np.repeat(np.float64(4.), 24).reshape(4, 3, 2))
-        assert_identical(s.scalars_rep.e, np.repeat(b"spam", 24).reshape(4, 3, 2).astype(np.object))
+        assert_identical(s.scalars_rep.e, np.repeat(b"spam", 24).reshape(4, 3, 2).astype(object))
         assert_identical(s.scalars_rep.f, np.repeat(np.complex64(-1.+3j), 24).reshape(4, 3, 2))
 
     def test_arrays(self):
@@ -198,7 +198,7 @@ class TestStructures:
         assert_array_identical(s.arrays.a[0], np.array([1, 2, 3], dtype=np.int16))
         assert_array_identical(s.arrays.b[0], np.array([4., 5., 6., 7.], dtype=np.float32))
         assert_array_identical(s.arrays.c[0], np.array([np.complex64(1+2j), np.complex64(7+8j)]))
-        assert_array_identical(s.arrays.d[0], np.array([b"cheese", b"bacon", b"spam"], dtype=np.object))
+        assert_array_identical(s.arrays.d[0], np.array([b"cheese", b"bacon", b"spam"], dtype=object))
 
     def test_arrays_replicated(self):
         s = readsav(path.join(DATA_PATH, 'struct_arrays_replicated.sav'), verbose=False)
@@ -226,7 +226,7 @@ class TestStructures:
                                              np.complex64(7+8j)]))
             assert_array_identical(s.arrays_rep.d[i],
                                    np.array([b"cheese", b"bacon", b"spam"],
-                                            dtype=np.object))
+                                            dtype=object))
 
     def test_arrays_replicated_3d(self):
         s = readsav(path.join(DATA_PATH, 'struct_arrays_replicated_3d.sav'), verbose=False)
@@ -257,7 +257,7 @@ class TestStructures:
                                                      np.complex64(7+8j)]))
                     assert_array_identical(s.arrays_rep.d[i, j, k],
                                            np.array([b"cheese", b"bacon", b"spam"],
-                                                    dtype=np.object))
+                                                    dtype=object))
 
     def test_inheritance(self):
         s = readsav(path.join(DATA_PATH, 'struct_inherit.sav'), verbose=False)

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -206,7 +206,7 @@ def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
     if lwork is None or lwork == -1:
         # get optimal work array size
         result = gges(lambda x: None, a1, b1, lwork=-1)
-        lwork = result[-2][0].real.astype(np.int)
+        lwork = result[-2][0].real.astype(int)
 
     if sort is None:
         sort_t = 0

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -822,7 +822,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
 
     # get optimal work array
     work = gelss(a1, b1, lwork=-1)[4]
-    lwork = work[0].real.astype(np.int)
+    lwork = work[0].real.astype(int)
     v, x, s, rank, work, info = gelss(
         a1, b1, cond=cond, lwork=lwork, overwrite_a=overwrite_a,
         overwrite_b=overwrite_b)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2046,7 +2046,7 @@ def test_lapack_misaligned():
     R = np.arange(100)
     R.shape = 10,10
     S = np.arange(20000,dtype=np.uint8)
-    S = np.frombuffer(S.data, offset=4, count=100, dtype=np.float)
+    S = np.frombuffer(S.data, offset=4, count=100, dtype=float)
     S.shape = 10, 10
     b = np.ones(10)
     LU, piv = lu_factor(S)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -151,7 +151,7 @@ class TestLeastSquaresSolvers(TestCase):
 
             # Request of sizes
             work,iwork,info = gelsd_lwork(m,n,nrhs,-1)
-            lwork = np.int(np.real(work))
+            lwork = int(np.real(work))
             iwork_size = iwork
 
             x, s, rank, info = gelsd(a1, b1, lwork, iwork_size,
@@ -179,8 +179,8 @@ class TestLeastSquaresSolvers(TestCase):
 
             # Request of sizes
             work, rwork, iwork, info = gelsd_lwork(m,n,nrhs,-1)
-            lwork = np.int(np.real(work))
-            rwork_size = np.int(rwork)
+            lwork = int(np.real(work))
+            rwork_size = int(rwork)
             iwork_size = iwork
 
             x, s, rank, info = gelsd(a1, b1, lwork, rwork_size, iwork_size,
@@ -211,7 +211,7 @@ class TestLeastSquaresSolvers(TestCase):
 
             # Request of sizes
             work,info = gelss_lwork(m,n,nrhs,-1)
-            lwork = np.int(np.real(work))
+            lwork = int(np.real(work))
 
             v,x,s,rank,work,info = gelss(a1, b1,-1,lwork, False, False)
             assert_allclose(x[:-1], np.array([-14.333333333333323,
@@ -237,7 +237,7 @@ class TestLeastSquaresSolvers(TestCase):
 
             # Request of sizes
             work,info = gelss_lwork(m,n,nrhs,-1)
-            lwork = np.int(np.real(work))
+            lwork = int(np.real(work))
 
             v,x,s,rank,work,info = gelss(a1, b1,-1,lwork, False, False)
             assert_allclose(x[:-1],
@@ -265,7 +265,7 @@ class TestLeastSquaresSolvers(TestCase):
 
             # Request of sizes
             work, info = gelsy_lwork(m,n,nrhs,10*np.finfo(dtype).eps)
-            lwork = np.int(np.real(work))
+            lwork = int(np.real(work))
 
             jptv = np.zeros((a1.shape[1],1), dtype=np.int32)
             v, x, j, rank, info = gelsy(a1, b1, jptv, np.finfo(dtype).eps,
@@ -289,7 +289,7 @@ class TestLeastSquaresSolvers(TestCase):
 
             # Request of sizes
             work, info = gelsy_lwork(m,n,nrhs,10*np.finfo(dtype).eps)
-            lwork = np.int(np.real(work))
+            lwork = int(np.real(work))
 
             jptv = np.zeros((a1.shape[1],1), dtype=np.int32)
             v, x, j, rank, info = gelsy(a1, b1, jptv, np.finfo(dtype).eps,

--- a/scipy/ndimage/measurements.py
+++ b/scipy/ndimage/measurements.py
@@ -234,7 +234,7 @@ def find_objects(input, max_label=0):
 
     Examples
     --------
-    >>> a = np.zeros((6,6), dtype=np.int)
+    >>> a = np.zeros((6,6), dtype=int)
     >>> a[2:4, 2:4] = 1
     >>> a[4, 4] = 1
     >>> a[:2, :3] = 2

--- a/scipy/ndimage/morphology.py
+++ b/scipy/ndimage/morphology.py
@@ -342,7 +342,7 @@ def binary_erosion(input, structure=None, iterations=1, mask=None,
 
     Examples
     --------
-    >>> a = np.zeros((7,7), dtype=np.int)
+    >>> a = np.zeros((7,7), dtype=int)
     >>> a[1:6, 2:5] = 1
     >>> a
     array([[0, 0, 0, 0, 0, 0, 0],
@@ -555,7 +555,7 @@ def binary_opening(input, structure=None, iterations=1, output=None,
 
     Examples
     --------
-    >>> a = np.zeros((5,5), dtype=np.int)
+    >>> a = np.zeros((5,5), dtype=int)
     >>> a[1:4, 1:4] = 1; a[4, 4] = 1
     >>> a
     array([[0, 0, 0, 0, 0],
@@ -564,27 +564,27 @@ def binary_opening(input, structure=None, iterations=1, output=None,
            [0, 1, 1, 1, 0],
            [0, 0, 0, 0, 1]])
     >>> # Opening removes small objects
-    >>> ndimage.binary_opening(a, structure=np.ones((3,3))).astype(np.int)
+    >>> ndimage.binary_opening(a, structure=np.ones((3,3))).astype(int)
     array([[0, 0, 0, 0, 0],
            [0, 1, 1, 1, 0],
            [0, 1, 1, 1, 0],
            [0, 1, 1, 1, 0],
            [0, 0, 0, 0, 0]])
     >>> # Opening can also smooth corners
-    >>> ndimage.binary_opening(a).astype(np.int)
+    >>> ndimage.binary_opening(a).astype(int)
     array([[0, 0, 0, 0, 0],
            [0, 0, 1, 0, 0],
            [0, 1, 1, 1, 0],
            [0, 0, 1, 0, 0],
            [0, 0, 0, 0, 0]])
     >>> # Opening is the dilation of the erosion of the input
-    >>> ndimage.binary_erosion(a).astype(np.int)
+    >>> ndimage.binary_erosion(a).astype(int)
     array([[0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0],
            [0, 0, 1, 0, 0],
            [0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0]])
-    >>> ndimage.binary_dilation(ndimage.binary_erosion(a)).astype(np.int)
+    >>> ndimage.binary_dilation(ndimage.binary_erosion(a)).astype(int)
     array([[0, 0, 0, 0, 0],
            [0, 0, 1, 0, 0],
            [0, 1, 1, 1, 0],
@@ -660,7 +660,7 @@ def binary_closing(input, structure=None, iterations=1, output=None,
 
     Examples
     --------
-    >>> a = np.zeros((5,5), dtype=np.int)
+    >>> a = np.zeros((5,5), dtype=int)
     >>> a[1:-1, 1:-1] = 1; a[2,2] = 0
     >>> a
     array([[0, 0, 0, 0, 0],
@@ -669,20 +669,20 @@ def binary_closing(input, structure=None, iterations=1, output=None,
            [0, 1, 1, 1, 0],
            [0, 0, 0, 0, 0]])
     >>> # Closing removes small holes
-    >>> ndimage.binary_closing(a).astype(np.int)
+    >>> ndimage.binary_closing(a).astype(int)
     array([[0, 0, 0, 0, 0],
            [0, 1, 1, 1, 0],
            [0, 1, 1, 1, 0],
            [0, 1, 1, 1, 0],
            [0, 0, 0, 0, 0]])
     >>> # Closing is the erosion of the dilation of the input
-    >>> ndimage.binary_dilation(a).astype(np.int)
+    >>> ndimage.binary_dilation(a).astype(int)
     array([[0, 1, 1, 1, 0],
            [1, 1, 1, 1, 1],
            [1, 1, 1, 1, 1],
            [1, 1, 1, 1, 1],
            [0, 1, 1, 1, 0]])
-    >>> ndimage.binary_erosion(ndimage.binary_dilation(a)).astype(np.int)
+    >>> ndimage.binary_erosion(ndimage.binary_dilation(a)).astype(int)
     array([[0, 0, 0, 0, 0],
            [0, 1, 1, 1, 0],
            [0, 1, 1, 1, 0],
@@ -690,7 +690,7 @@ def binary_closing(input, structure=None, iterations=1, output=None,
            [0, 0, 0, 0, 0]])
 
 
-    >>> a = np.zeros((7,7), dtype=np.int)
+    >>> a = np.zeros((7,7), dtype=int)
     >>> a[1:6, 2:5] = 1; a[1:3,3] = 0
     >>> a
     array([[0, 0, 0, 0, 0, 0, 0],
@@ -702,7 +702,7 @@ def binary_closing(input, structure=None, iterations=1, output=None,
            [0, 0, 0, 0, 0, 0, 0]])
     >>> # In addition to removing holes, closing can also
     >>> # coarsen boundaries with fine hollows.
-    >>> ndimage.binary_closing(a).astype(np.int)
+    >>> ndimage.binary_closing(a).astype(int)
     array([[0, 0, 0, 0, 0, 0, 0],
            [0, 0, 1, 0, 1, 0, 0],
            [0, 0, 1, 1, 1, 0, 0],
@@ -710,7 +710,7 @@ def binary_closing(input, structure=None, iterations=1, output=None,
            [0, 0, 1, 1, 1, 0, 0],
            [0, 0, 1, 1, 1, 0, 0],
            [0, 0, 0, 0, 0, 0, 0]])
-    >>> ndimage.binary_closing(a, structure=np.ones((2,2))).astype(np.int)
+    >>> ndimage.binary_closing(a, structure=np.ones((2,2))).astype(int)
     array([[0, 0, 0, 0, 0, 0, 0],
            [0, 0, 1, 1, 1, 0, 0],
            [0, 0, 1, 1, 1, 0, 0],
@@ -778,7 +778,7 @@ def binary_hit_or_miss(input, structure1=None, structure2=None,
 
     Examples
     --------
-    >>> a = np.zeros((7,7), dtype=np.int)
+    >>> a = np.zeros((7,7), dtype=int)
     >>> a[1, 1] = 1; a[2:4, 2:4] = 1; a[4:6, 4:6] = 1
     >>> a
     array([[0, 0, 0, 0, 0, 0, 0],
@@ -794,7 +794,7 @@ def binary_hit_or_miss(input, structure1=None, structure2=None,
            [0, 1, 1],
            [0, 1, 1]])
     >>> # Find the matches of structure1 in the array a
-    >>> ndimage.binary_hit_or_miss(a, structure1=structure1).astype(np.int)
+    >>> ndimage.binary_hit_or_miss(a, structure1=structure1).astype(int)
     array([[0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0],
            [0, 0, 1, 0, 0, 0, 0],
@@ -805,7 +805,7 @@ def binary_hit_or_miss(input, structure1=None, structure2=None,
     >>> # Change the origin of the filter
     >>> # origin1=1 is equivalent to origin1=(1,1) here
     >>> ndimage.binary_hit_or_miss(a, structure1=structure1,\\
-    ... origin1=1).astype(np.int)
+    ... origin1=1).astype(int)
     array([[0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0],
@@ -887,9 +887,9 @@ def binary_propagation(input, structure=None, mask=None,
 
     Examples
     --------
-    >>> input = np.zeros((8, 8), dtype=np.int)
+    >>> input = np.zeros((8, 8), dtype=int)
     >>> input[2, 2] = 1
-    >>> mask = np.zeros((8, 8), dtype=np.int)
+    >>> mask = np.zeros((8, 8), dtype=int)
     >>> mask[1:4, 1:4] = mask[4, 4]  = mask[6:8, 6:8] = 1
     >>> input
     array([[0, 0, 0, 0, 0, 0, 0, 0],
@@ -909,7 +909,7 @@ def binary_propagation(input, structure=None, mask=None,
            [0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 1, 1],
            [0, 0, 0, 0, 0, 0, 1, 1]])
-    >>> ndimage.binary_propagation(input, mask=mask).astype(np.int)
+    >>> ndimage.binary_propagation(input, mask=mask).astype(int)
     array([[0, 0, 0, 0, 0, 0, 0, 0],
            [0, 1, 1, 1, 0, 0, 0, 0],
            [0, 1, 1, 1, 0, 0, 0, 0],
@@ -919,7 +919,7 @@ def binary_propagation(input, structure=None, mask=None,
            [0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0]])
     >>> ndimage.binary_propagation(input, mask=mask,\\
-    ... structure=np.ones((3,3))).astype(np.int)
+    ... structure=np.ones((3,3))).astype(int)
     array([[0, 0, 0, 0, 0, 0, 0, 0],
            [0, 1, 1, 1, 0, 0, 0, 0],
            [0, 1, 1, 1, 0, 0, 0, 0],
@@ -930,7 +930,7 @@ def binary_propagation(input, structure=None, mask=None,
            [0, 0, 0, 0, 0, 0, 0, 0]])
 
     >>> # Comparison between opening and erosion+propagation
-    >>> a = np.zeros((6,6), dtype=np.int)
+    >>> a = np.zeros((6,6), dtype=int)
     >>> a[2:5, 2:5] = 1; a[0, 0] = 1; a[5, 5] = 1
     >>> a
     array([[1, 0, 0, 0, 0, 0],
@@ -939,7 +939,7 @@ def binary_propagation(input, structure=None, mask=None,
            [0, 0, 1, 1, 1, 0],
            [0, 0, 1, 1, 1, 0],
            [0, 0, 0, 0, 0, 1]])
-    >>> ndimage.binary_opening(a).astype(np.int)
+    >>> ndimage.binary_opening(a).astype(int)
     array([[0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0],
            [0, 0, 0, 1, 0, 0],
@@ -954,7 +954,7 @@ def binary_propagation(input, structure=None, mask=None,
            [0, 0, 0, 1, 0, 0],
            [0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0]])
-    >>> ndimage.binary_propagation(b, mask=a).astype(np.int)
+    >>> ndimage.binary_propagation(b, mask=a).astype(int)
     array([[0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0],
            [0, 0, 1, 1, 1, 0],
@@ -1117,7 +1117,7 @@ def grey_erosion(input, size=None, footprint=None, structure=None,
 
     Examples
     --------
-    >>> a = np.zeros((7,7), dtype=np.int)
+    >>> a = np.zeros((7,7), dtype=int)
     >>> a[1:6, 1:6] = 3
     >>> a[4,4] = 2; a[2,3] = 1
     >>> a
@@ -1226,7 +1226,7 @@ def grey_dilation(input, size=None, footprint=None, structure=None,
 
     Examples
     --------
-    >>> a = np.zeros((7,7), dtype=np.int)
+    >>> a = np.zeros((7,7), dtype=int)
     >>> a[2:5, 2:5] = 1
     >>> a[4,4] = 2; a[2,3] = 3
     >>> a
@@ -1526,7 +1526,7 @@ def morphological_gradient(input, size=None, footprint=None,
 
     Examples
     --------
-    >>> a = np.zeros((7,7), dtype=np.int)
+    >>> a = np.zeros((7,7), dtype=int)
     >>> a[2:5, 2:5] = 1
     >>> ndimage.morphological_gradient(a, size=(3,3))
     array([[0, 0, 0, 0, 0, 0, 0],
@@ -1547,7 +1547,7 @@ def morphological_gradient(input, size=None, footprint=None,
            [0, 1, 1, 1, 1, 1, 0],
            [0, 1, 1, 1, 1, 1, 0],
            [0, 0, 0, 0, 0, 0, 0]])
-    >>> a = np.zeros((7,7), dtype=np.int)
+    >>> a = np.zeros((7,7), dtype=int)
     >>> a[2:5, 2:5] = 1
     >>> a[4,4] = 2; a[2,3] = 3
     >>> a

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -61,7 +61,7 @@ def test_gaussian_truncate():
     # Test that Gaussian filters can be truncated at different widths.
     # These tests only check that the result has the expected number
     # of nonzero elements.
-    arr = np.zeros((100, 100), np.float)
+    arr = np.zeros((100, 100), float)
     arr[50, 50] = 1
     num_nonzeros_2 = (sndi.gaussian_filter(arr, 5, truncate=2) > 0).sum()
     assert_equal(num_nonzeros_2, 21**2)

--- a/scipy/ndimage/utils/generate_label_testvectors.py
+++ b/scipy/ndimage/utils/generate_label_testvectors.py
@@ -31,8 +31,8 @@ def generate_test_vecs(infile, strelfile, resultfile):
               bitimage(["110", "111", "011"])]
     strels = strels + [np.flipud(s) for s in strels]
     strels = strels + [np.rot90(s) for s in strels]
-    strels = [np.fromstring(s, dtype=np.int).reshape((3, 3))
-              for s in set(t.astype(np.int).tostring() for t in strels)]
+    strels = [np.fromstring(s, dtype=int).reshape((3, 3))
+              for s in set(t.astype(int).tostring() for t in strels)]
     inputs = np.vstack(data)
     results = np.vstack([label(d, s)[0] for d in data for s in strels])
     strels = np.vstack(strels)

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -610,7 +610,7 @@ def approx_fprime(xk, f, epsilon, *args):
 
     >>> x = np.ones(2)
     >>> c0, c1 = (1, 200)
-    >>> eps = np.sqrt(np.finfo(np.float).eps)
+    >>> eps = np.sqrt(np.finfo(float).eps)
     >>> optimize.approx_fprime(x, func, [eps, np.sqrt(200) * eps], c0, c1)
     array([   2.        ,  400.00004198])
 

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -117,7 +117,7 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     # from -pos to window_length - pos - 1.  The powers (i.e. rows) range
     # from 0 to polyorder.  (That is, A is a vandermonde matrix, but not
     # necessarily square.)
-    x = np.arange(-pos, window_length - pos, dtype=np.float)
+    x = np.arange(-pos, window_length - pos, dtype=float)
     if use == "conv":
         # Reverse so that result can be used in a convolution.
         x = x[::-1]

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -1600,7 +1600,7 @@ def _zpklp2lp(z, p, k, wo=1.0):
     """
     z = atleast_1d(z)
     p = atleast_1d(p)
-    wo = float(wo)  # Avoid np.int wraparound
+    wo = float(wo)  # Avoid int wraparound
 
     degree = _relative_degree(z, p)
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -343,8 +343,8 @@ def fftconvolve(in1, in2, mode="full"):
 
     s1 = array(in1.shape)
     s2 = array(in2.shape)
-    complex_result = (np.issubdtype(in1.dtype, np.complex) or
-                      np.issubdtype(in2.dtype, np.complex))
+    complex_result = (np.issubdtype(in1.dtype, complex) or
+                      np.issubdtype(in2.dtype, complex))
     shape = s1 + s2 - 1
 
     if mode == "valid":

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -418,7 +418,7 @@ class TestMedFilt(TestCase):
              [32, 61, 88, 7, 39, 4, 92, 64, 45, 61]]
 
         d = signal.medfilt(f, [7, 3])
-        e = signal.medfilt2d(np.array(f, np.float), [7, 3])
+        e = signal.medfilt2d(np.array(f, float), [7, 3])
         assert_array_equal(d, [[0, 50, 50, 50, 42, 15, 15, 18, 27, 0],
                                [0, 50, 50, 50, 50, 42, 19, 21, 29, 0],
                                [50, 50, 50, 50, 50, 47, 34, 34, 46, 35],

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -138,7 +138,7 @@ class _TestConvolve2d(TestCase):
 
     def test_valid_mode_complx(self):
         e = [[2, 3, 4, 5, 6, 7, 8], [4, 5, 6, 7, 8, 9, 10]]
-        f = np.array([[1, 2, 3], [3, 4, 5]], dtype=np.complex) + 1j
+        f = np.array([[1, 2, 3], [3, 4, 5]], dtype=complex) + 1j
         g = convolve2d(e, f, 'valid')
         h = array([[62.+24.j, 80.+30.j, 98.+36.j, 116.+42.j, 134.+48.j]])
         assert_array_almost_equal(g, h)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -959,7 +959,7 @@ def _get_testcorrelate_class(datatype, base):
     return TestCorrelateX
 
 
-for datatype in [np.ubyte, np.byte, np.ushort, np.short, np.uint, np.int,
+for datatype in [np.ubyte, np.byte, np.ushort, np.short, np.uint, int,
                  np.ulonglong, np.ulonglong, np.float32, np.float64,
                  np.longdouble, Decimal]:
     cls = _get_testcorrelate_class(datatype, _TestCorrelateReal)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -52,7 +52,7 @@ class TestPeriodogram(TestCase):
         assert_allclose(p, q/16.0)
 
     def test_integer_even(self):
-        x = np.zeros(16, dtype=np.int)
+        x = np.zeros(16, dtype=int)
         x[0] = 1
         f, p = periodogram(x)
         assert_allclose(f, np.linspace(0, 0.5, 9))
@@ -63,7 +63,7 @@ class TestPeriodogram(TestCase):
         assert_allclose(p, q)
 
     def test_integer_odd(self):
-        x = np.zeros(15, dtype=np.int)
+        x = np.zeros(15, dtype=int)
         x[0] = 1
         f, p = periodogram(x)
         assert_allclose(f, np.arange(8.0)/15.0)
@@ -73,7 +73,7 @@ class TestPeriodogram(TestCase):
         assert_allclose(p, q, atol=1e-15)
 
     def test_integer_twosided(self):
-        x = np.zeros(16, dtype=np.int)
+        x = np.zeros(16, dtype=int)
         x[0] = 1
         f, p = periodogram(x, return_onesided=False)
         assert_allclose(f, fftpack.fftfreq(16, 1.0))
@@ -257,7 +257,7 @@ class TestWelch(TestCase):
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_integer_onesided_even(self):
-        x = np.zeros(16, dtype=np.int)
+        x = np.zeros(16, dtype=int)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8)
@@ -267,7 +267,7 @@ class TestWelch(TestCase):
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_integer_onesided_odd(self):
-        x = np.zeros(16, dtype=np.int)
+        x = np.zeros(16, dtype=int)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=9)
@@ -277,7 +277,7 @@ class TestWelch(TestCase):
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_integer_twosided(self):
-        x = np.zeros(16, dtype=np.int)
+        x = np.zeros(16, dtype=int)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8, return_onesided=False)
@@ -539,7 +539,7 @@ class TestCSD:
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_integer_onesided_even(self):
-        x = np.zeros(16, dtype=np.int)
+        x = np.zeros(16, dtype=int)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=8)
@@ -549,7 +549,7 @@ class TestCSD:
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_integer_onesided_odd(self):
-        x = np.zeros(16, dtype=np.int)
+        x = np.zeros(16, dtype=int)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=9)
@@ -559,7 +559,7 @@ class TestCSD:
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
 
     def test_integer_twosided(self):
-        x = np.zeros(16, dtype=np.int)
+        x = np.zeros(16, dtype=int)
         x[0] = 1
         x[8] = 1
         f, p = csd(x, x, nperseg=8, return_onesided=False)

--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -150,7 +150,7 @@ def cascade(hk, J=7):
     m *= s2
 
     # construct the grid of points
-    x = np.arange(0, N * (1 << J), dtype=np.float) / (1 << J)
+    x = np.arange(0, N * (1 << J), dtype=float) / (1 << J)
     phi = 0 * x
 
     psi = 0 * x

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -554,7 +554,7 @@ def bmat(blocks, format=None, dtype=None):
             A = A.astype(dtype)
         return A
 
-    block_mask = np.zeros(blocks.shape, dtype=np.bool)
+    block_mask = np.zeros(blocks.shape, dtype=bool)
     brow_lengths = np.zeros(M, dtype=np.int64)
     bcol_lengths = np.zeros(N, dtype=np.int64)
 

--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -68,7 +68,7 @@ def laplacian(csgraph, normed=False, return_diag=False, use_out_degree=False):
     if csgraph.ndim != 2 or csgraph.shape[0] != csgraph.shape[1]:
         raise ValueError('csgraph must be a square matrix or array')
 
-    if normed and (np.issubdtype(csgraph.dtype, np.int)
+    if normed and (np.issubdtype(csgraph.dtype, int)
                    or np.issubdtype(csgraph.dtype, np.uint)):
         csgraph = csgraph.astype(np.float)
 

--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -70,7 +70,7 @@ def laplacian(csgraph, normed=False, return_diag=False, use_out_degree=False):
 
     if normed and (np.issubdtype(csgraph.dtype, int)
                    or np.issubdtype(csgraph.dtype, np.uint)):
-        csgraph = csgraph.astype(np.float)
+        csgraph = csgraph.astype(float)
 
     create_lap = _laplacian_sparse if isspmatrix(csgraph) else _laplacian_dense
     degree_axis = 1 if use_out_degree else 0

--- a/scipy/sparse/csgraph/tests/test_graph_components.py
+++ b/scipy/sparse/csgraph/tests/test_graph_components.py
@@ -8,7 +8,7 @@ from scipy.sparse import csr_matrix, csgraph
 
 
 def test_cs_graph_components():
-    D = np.eye(4, dtype=np.bool)
+    D = np.eye(4, dtype=bool)
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore",

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -560,11 +560,11 @@ def test_svd_simple_real():
     x = np.array([[1, 2, 3],
                   [3, 4, 3],
                   [1, 0, 2],
-                  [0, 0, 1]], np.float)
+                  [0, 0, 1]], float)
     y = np.array([[1, 2, 3, 8],
                   [3, 4, 3, 5],
                   [1, 0, 2, 3],
-                  [0, 0, 1, 0]], np.float)
+                  [0, 0, 1, 0]], float)
     z = csc_matrix(x)
 
     for m in [x.T, x, y, z, z.T]:
@@ -807,7 +807,7 @@ def test_svds_partial_return():
     x = np.array([[1, 2, 3],
                   [3, 4, 3],
                   [1, 0, 2],
-                  [0, 0, 1]], np.float)
+                  [0, 0, 1]], float)
     # test vertical matrix
     z = csr_matrix(x)
     vh_full = svds(z, 2)[-1]
@@ -835,7 +835,7 @@ def test_svds_wrong_eigen_type():
     x = np.array([[1, 2, 3],
                   [3, 4, 3],
                   [1, 0, 2],
-                  [0, 0, 1]], np.float)
+                  [0, 0, 1]], float)
     assert_raises(ValueError, svds, x, 1, which='LA')
 
 

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -582,11 +582,11 @@ def test_svd_simple_complex():
     x = np.array([[1, 2, 3],
                   [3, 4, 3],
                   [1 + 1j, 0, 2],
-                  [0, 0, 1]], np.complex)
+                  [0, 0, 1]], complex)
     y = np.array([[1, 2, 3, 8 + 5j],
                   [3 - 2j, 4, 3, 5],
                   [1, 0, 2, 3],
-                  [0, 0, 1, 0]], np.complex)
+                  [0, 0, 1, 0]], complex)
     z = csc_matrix(x)
 
     for m in [x, x.T.conjugate(), x.T, y, y.conjugate(), z, z.T]:

--- a/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/lobpcg.py
@@ -368,7 +368,7 @@ def lobpcg(A, X,
 
     ##
     # Active index set.
-    activeMask = np.ones((sizeX,), dtype=np.bool)
+    activeMask = np.ones((sizeX,), dtype=bool)
 
     lambdaHistory = [_lambda]
     residualNormsHistory = []

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -47,10 +47,10 @@ def upcast(*args):
     if t is not None:
         return t
 
-    if np.all([np.issubdtype(np.bool, arg) for arg in args]):
+    if np.all([np.issubdtype(bool, arg) for arg in args]):
         # numpy 1.5.x compat - it gives int8 for
-        # np.find_common_type([np.bool, np.bool)
-        upcast = np.bool
+        # np.find_common_type([bool, bool)
+        upcast = bool
     else:
         upcast = np.find_common_type(args, [])
 
@@ -382,9 +382,9 @@ def _compat_unique_impl(ar, return_index=False, return_inverse=False):
 
     if ar.size == 0:
         if return_inverse and return_index:
-            return ar, np.empty(0, np.bool), np.empty(0, np.bool)
+            return ar, np.empty(0, bool), np.empty(0, bool)
         elif return_inverse or return_index:
-            return ar, np.empty(0, np.bool)
+            return ar, np.empty(0, bool)
         else:
             return ar
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -302,7 +302,7 @@ class _TestCommon:
             dat2 = dat.copy()
             dat2[:,0] = 0
             datsp2 = self.spmatrix(dat2)
-            datcomplex = dat.astype(np.complex)
+            datcomplex = dat.astype(complex)
             datcomplex[:,0] = 1 + 1j
             datspcomplex = self.spmatrix(datcomplex)
             datbsr = bsr_matrix(dat)
@@ -368,7 +368,7 @@ class _TestCommon:
             dat2 = dat.copy()
             dat2[:,0] = 0
             datsp2 = self.spmatrix(dat2)
-            datcomplex = dat.astype(np.complex)
+            datcomplex = dat.astype(complex)
             datcomplex[:,0] = 1 + 1j
             datspcomplex = self.spmatrix(datcomplex)
             datbsr = bsr_matrix(dat)
@@ -433,7 +433,7 @@ class _TestCommon:
             dat2 = dat.copy()
             dat2[:,0] = 0
             datsp2 = self.spmatrix(dat2)
-            datcomplex = dat.astype(np.complex)
+            datcomplex = dat.astype(complex)
             datcomplex[:,0] = 1 + 1j
             datspcomplex = self.spmatrix(datcomplex)
             datbsr = bsr_matrix(dat)
@@ -494,7 +494,7 @@ class _TestCommon:
             dat2 = dat.copy()
             dat2[:,0] = 0
             datsp2 = self.spmatrix(dat2)
-            datcomplex = dat.astype(np.complex)
+            datcomplex = dat.astype(complex)
             datcomplex[:,0] = 1 + 1j
             datspcomplex = self.spmatrix(datcomplex)
             datbsr = bsr_matrix(dat)

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -19,7 +19,7 @@ class TestSparseUtils(TestCase):
     def test_getdtype(self):
         A = np.array([1],dtype='int8')
 
-        assert_equal(sputils.getdtype(None,default=float),np.float)
+        assert_equal(sputils.getdtype(None,default=float),float)
         assert_equal(sputils.getdtype(None,a=A),np.int8)
 
     def test_isscalarlike(self):

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -101,8 +101,8 @@ def _copy_arrays_if_base_present(T):
 
 
 def _convert_to_bool(X):
-    if X.dtype != np.bool:
-        X = X.astype(np.bool)
+    if X.dtype != bool:
+        X = X.astype(bool)
     if not X.flags.contiguous:
         X = X.copy()
     return X
@@ -651,7 +651,7 @@ def _nbool_correspond_all(u, v):
         nft = (not_u * v).sum()
         ntf = (u * not_v).sum()
         ntt = (u * v).sum()
-    elif u.dtype == np.bool:
+    elif u.dtype == bool:
         not_u = ~u
         not_v = ~v
         nff = (not_u & not_v).sum()
@@ -775,7 +775,7 @@ def dice(u, v):
     """
     u = _validate_vector(u)
     v = _validate_vector(v)
-    if u.dtype == np.bool:
+    if u.dtype == bool:
         ntt = (u & v).sum()
     else:
         ntt = (u * v).sum()
@@ -849,7 +849,7 @@ def russellrao(u, v):
     """
     u = _validate_vector(u)
     v = _validate_vector(v)
-    if u.dtype == np.bool:
+    if u.dtype == bool:
         ntt = (u & v).sum()
     else:
         ntt = (u * v).sum()
@@ -888,7 +888,7 @@ def sokalmichener(u, v):
     """
     u = _validate_vector(u)
     v = _validate_vector(v)
-    if u.dtype == np.bool:
+    if u.dtype == bool:
         ntt = (u & v).sum()
         nff = (~u & ~v).sum()
     else:
@@ -928,7 +928,7 @@ def sokalsneath(u, v):
     """
     u = _validate_vector(u)
     v = _validate_vector(v)
-    if u.dtype == np.bool:
+    if u.dtype == bool:
         ntt = (u & v).sum()
     else:
         ntt = (u * v).sum()
@@ -1226,12 +1226,12 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
         elif mstr in set(['cityblock', 'cblock', 'cb', 'c']):
             _distance_wrap.pdist_city_block_wrap(X, dm)
         elif mstr in set(['hamming', 'hamm', 'ha', 'h']):
-            if X.dtype == np.bool:
+            if X.dtype == bool:
                 _distance_wrap.pdist_hamming_bool_wrap(_convert_to_bool(X), dm)
             else:
                 _distance_wrap.pdist_hamming_wrap(_convert_to_double(X), dm)
         elif mstr in set(['jaccard', 'jacc', 'ja', 'j']):
-            if X.dtype == np.bool:
+            if X.dtype == bool:
                 _distance_wrap.pdist_jaccard_bool_wrap(_convert_to_bool(X), dm)
             else:
                 _distance_wrap.pdist_jaccard_wrap(_convert_to_double(X), dm)
@@ -2080,7 +2080,7 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
             _distance_wrap.cdist_city_block_wrap(_convert_to_double(XA),
                                                  _convert_to_double(XB), dm)
         elif mstr in set(['hamming', 'hamm', 'ha', 'h']):
-            if XA.dtype == np.bool:
+            if XA.dtype == bool:
                 _distance_wrap.cdist_hamming_bool_wrap(_convert_to_bool(XA),
                                                        _convert_to_bool(XB),
                                                        dm)
@@ -2088,7 +2088,7 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
                 _distance_wrap.cdist_hamming_wrap(_convert_to_double(XA),
                                                   _convert_to_double(XB), dm)
         elif mstr in set(['jaccard', 'jacc', 'ja', 'j']):
-            if XA.dtype == np.bool:
+            if XA.dtype == bool:
                 _distance_wrap.cdist_jaccard_bool_wrap(_convert_to_bool(XA),
                                                        _convert_to_bool(XB),
                                                        dm)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -644,7 +644,7 @@ def _nbool_correspond_all(u, v):
     if u.dtype != v.dtype:
         raise TypeError("Arrays being compared must be of the same data type.")
 
-    if u.dtype == np.int or u.dtype == np.float_ or u.dtype == np.double:
+    if u.dtype == int or u.dtype == np.float_ or u.dtype == np.double:
         not_u = 1.0 - u
         not_v = 1.0 - v
         nff = (not_u * not_v).sum()
@@ -665,7 +665,7 @@ def _nbool_correspond_all(u, v):
 
 
 def _nbool_correspond_ft_tf(u, v):
-    if u.dtype == np.int or u.dtype == np.float_ or u.dtype == np.double:
+    if u.dtype == int or u.dtype == np.float_ or u.dtype == np.double:
         not_u = 1.0 - u
         not_v = 1.0 - v
         nft = (not_u * v).sum()

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -482,8 +482,8 @@ class KDTree(object):
         retshape = np.shape(x)[:-1]
         if retshape != ():
             if k is None:
-                dd = np.empty(retshape,dtype=np.object)
-                ii = np.empty(retshape,dtype=np.object)
+                dd = np.empty(retshape,dtype=object)
+                ii = np.empty(retshape,dtype=object)
             elif k > 1:
                 dd = np.empty(retshape+(k,),dtype=float)
                 dd.fill(np.inf)
@@ -604,7 +604,7 @@ class KDTree(object):
             return self.__query_ball_point(x, r, p, eps)
         else:
             retshape = x.shape[:-1]
-            result = np.empty(retshape, dtype=np.object)
+            result = np.empty(retshape, dtype=object)
             for c in np.ndindex(retshape):
                 result[c] = self.__query_ball_point(x[c], r, p=p, eps=eps)
             return result

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -487,12 +487,12 @@ class KDTree(object):
             elif k > 1:
                 dd = np.empty(retshape+(k,),dtype=np.float)
                 dd.fill(np.inf)
-                ii = np.empty(retshape+(k,),dtype=np.int)
+                ii = np.empty(retshape+(k,),dtype=int)
                 ii.fill(self.n)
             elif k == 1:
                 dd = np.empty(retshape,dtype=np.float)
                 dd.fill(np.inf)
-                ii = np.empty(retshape,dtype=np.int)
+                ii = np.empty(retshape,dtype=int)
                 ii.fill(self.n)
             else:
                 raise ValueError("Requested %s nearest neighbors; acceptable numbers are integers greater than or equal to one, or None")
@@ -523,7 +523,7 @@ class KDTree(object):
             elif k > 1:
                 dd = np.empty(k,dtype=np.float)
                 dd.fill(np.inf)
-                ii = np.empty(k,dtype=np.int)
+                ii = np.empty(k,dtype=int)
                 ii.fill(self.n)
                 for j in range(len(hits)):
                     dd[j], ii[j] = hits[j]

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -79,8 +79,8 @@ class Rectangle(object):
     """
     def __init__(self, maxes, mins):
         """Construct a hyperrectangle."""
-        self.maxes = np.maximum(maxes,mins).astype(np.float)
-        self.mins = np.minimum(maxes,mins).astype(np.float)
+        self.maxes = np.maximum(maxes,mins).astype(float)
+        self.mins = np.minimum(maxes,mins).astype(float)
         self.m, = self.maxes.shape
 
     def __repr__(self):
@@ -485,12 +485,12 @@ class KDTree(object):
                 dd = np.empty(retshape,dtype=np.object)
                 ii = np.empty(retshape,dtype=np.object)
             elif k > 1:
-                dd = np.empty(retshape+(k,),dtype=np.float)
+                dd = np.empty(retshape+(k,),dtype=float)
                 dd.fill(np.inf)
                 ii = np.empty(retshape+(k,),dtype=int)
                 ii.fill(self.n)
             elif k == 1:
-                dd = np.empty(retshape,dtype=np.float)
+                dd = np.empty(retshape,dtype=float)
                 dd.fill(np.inf)
                 ii = np.empty(retshape,dtype=int)
                 ii.fill(self.n)
@@ -521,7 +521,7 @@ class KDTree(object):
                 else:
                     return np.inf, self.n
             elif k > 1:
-                dd = np.empty(k,dtype=np.float)
+                dd = np.empty(k,dtype=float)
                 dd.fill(np.inf)
                 ii = np.empty(k,dtype=int)
                 ii.fill(self.n)
@@ -958,7 +958,7 @@ def distance_matrix(x, y, p=2, threshold=1000000):
     if m*n*k <= threshold:
         return minkowski_distance(x[:,np.newaxis,:],y[np.newaxis,:,:],p)
     else:
-        result = np.empty((m,n),dtype=np.float)  # FIXME: figure out the best dtype
+        result = np.empty((m,n),dtype=float)  # FIXME: figure out the best dtype
         if m < n:
             for i in range(m):
                 result[i,:] = minkowski_distance(x[i],y,p)

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -853,8 +853,8 @@ class TestPdist(TestCase):
         # Test matching(*,*) with mtica example #1 (nums).
         m = matching(np.array([1, 0, 1, 1, 0]),
                      np.array([1, 1, 0, 1, 1]))
-        m2 = matching(np.array([1, 0, 1, 1, 0], dtype=np.bool),
-                      np.array([1, 1, 0, 1, 1], dtype=np.bool))
+        m2 = matching(np.array([1, 0, 1, 1, 0], dtype=bool),
+                      np.array([1, 1, 0, 1, 1], dtype=bool))
         assert_allclose(m, 0.6, rtol=0, atol=1e-10)
         assert_allclose(m2, 0.6, rtol=0, atol=1e-10)
 
@@ -862,8 +862,8 @@ class TestPdist(TestCase):
         # Test matching(*,*) with mtica example #2.
         m = matching(np.array([1, 0, 1]),
                      np.array([1, 1, 0]))
-        m2 = matching(np.array([1, 0, 1], dtype=np.bool),
-                      np.array([1, 1, 0], dtype=np.bool))
+        m2 = matching(np.array([1, 0, 1], dtype=bool),
+                      np.array([1, 1, 0], dtype=bool))
         assert_allclose(m, 2/3, rtol=0, atol=1e-10)
         assert_allclose(m2, 2/3, rtol=0, atol=1e-10)
 
@@ -887,16 +887,16 @@ class TestPdist(TestCase):
     def test_pdist_jaccard_mtica1(self):
         m = jaccard(np.array([1, 0, 1, 1, 0]),
                     np.array([1, 1, 0, 1, 1]))
-        m2 = jaccard(np.array([1, 0, 1, 1, 0], dtype=np.bool),
-                     np.array([1, 1, 0, 1, 1], dtype=np.bool))
+        m2 = jaccard(np.array([1, 0, 1, 1, 0], dtype=bool),
+                     np.array([1, 1, 0, 1, 1], dtype=bool))
         assert_allclose(m, 0.6, rtol=0, atol=1e-10)
         assert_allclose(m2, 0.6, rtol=0, atol=1e-10)
 
     def test_pdist_jaccard_mtica2(self):
         m = jaccard(np.array([1, 0, 1]),
                     np.array([1, 1, 0]))
-        m2 = jaccard(np.array([1, 0, 1], dtype=np.bool),
-                     np.array([1, 1, 0], dtype=np.bool))
+        m2 = jaccard(np.array([1, 0, 1], dtype=bool),
+                     np.array([1, 1, 0], dtype=bool))
         assert_allclose(m, 2/3, rtol=0, atol=1e-10)
         assert_allclose(m2, 2/3, rtol=0, atol=1e-10)
 
@@ -919,8 +919,8 @@ class TestPdist(TestCase):
     def test_pdist_yule_mtica1(self):
         m = yule(np.array([1, 0, 1, 1, 0]),
                  np.array([1, 1, 0, 1, 1]))
-        m2 = yule(np.array([1, 0, 1, 1, 0], dtype=np.bool),
-                  np.array([1, 1, 0, 1, 1], dtype=np.bool))
+        m2 = yule(np.array([1, 0, 1, 1, 0], dtype=bool),
+                  np.array([1, 1, 0, 1, 1], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 2, rtol=0, atol=1e-10)
@@ -929,8 +929,8 @@ class TestPdist(TestCase):
     def test_pdist_yule_mtica2(self):
         m = yule(np.array([1, 0, 1]),
                  np.array([1, 1, 0]))
-        m2 = yule(np.array([1, 0, 1], dtype=np.bool),
-                  np.array([1, 1, 0], dtype=np.bool))
+        m2 = yule(np.array([1, 0, 1], dtype=bool),
+                  np.array([1, 1, 0], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 2, rtol=0, atol=1e-10)
@@ -953,8 +953,8 @@ class TestPdist(TestCase):
     def test_pdist_dice_mtica1(self):
         m = dice(np.array([1, 0, 1, 1, 0]),
                  np.array([1, 1, 0, 1, 1]))
-        m2 = dice(np.array([1, 0, 1, 1, 0], dtype=np.bool),
-                  np.array([1, 1, 0, 1, 1], dtype=np.bool))
+        m2 = dice(np.array([1, 0, 1, 1, 0], dtype=bool),
+                  np.array([1, 1, 0, 1, 1], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 3/7, rtol=0, atol=1e-10)
@@ -963,8 +963,8 @@ class TestPdist(TestCase):
     def test_pdist_dice_mtica2(self):
         m = dice(np.array([1, 0, 1]),
                  np.array([1, 1, 0]))
-        m2 = dice(np.array([1, 0, 1], dtype=np.bool),
-                  np.array([1, 1, 0], dtype=np.bool))
+        m2 = dice(np.array([1, 0, 1], dtype=bool),
+                  np.array([1, 1, 0], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 0.5, rtol=0, atol=1e-10)
@@ -987,8 +987,8 @@ class TestPdist(TestCase):
     def test_pdist_sokalsneath_mtica1(self):
         m = sokalsneath(np.array([1, 0, 1, 1, 0]),
                         np.array([1, 1, 0, 1, 1]))
-        m2 = sokalsneath(np.array([1, 0, 1, 1, 0], dtype=np.bool),
-                         np.array([1, 1, 0, 1, 1], dtype=np.bool))
+        m2 = sokalsneath(np.array([1, 0, 1, 1, 0], dtype=bool),
+                         np.array([1, 1, 0, 1, 1], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 3/4, rtol=0, atol=1e-10)
@@ -997,8 +997,8 @@ class TestPdist(TestCase):
     def test_pdist_sokalsneath_mtica2(self):
         m = sokalsneath(np.array([1, 0, 1]),
                         np.array([1, 1, 0]))
-        m2 = sokalsneath(np.array([1, 0, 1], dtype=np.bool),
-                         np.array([1, 1, 0], dtype=np.bool))
+        m2 = sokalsneath(np.array([1, 0, 1], dtype=bool),
+                         np.array([1, 1, 0], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 4/5, rtol=0, atol=1e-10)
@@ -1021,8 +1021,8 @@ class TestPdist(TestCase):
     def test_pdist_rogerstanimoto_mtica1(self):
         m = rogerstanimoto(np.array([1, 0, 1, 1, 0]),
                            np.array([1, 1, 0, 1, 1]))
-        m2 = rogerstanimoto(np.array([1, 0, 1, 1, 0], dtype=np.bool),
-                            np.array([1, 1, 0, 1, 1], dtype=np.bool))
+        m2 = rogerstanimoto(np.array([1, 0, 1, 1, 0], dtype=bool),
+                            np.array([1, 1, 0, 1, 1], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 3/4, rtol=0, atol=1e-10)
@@ -1031,8 +1031,8 @@ class TestPdist(TestCase):
     def test_pdist_rogerstanimoto_mtica2(self):
         m = rogerstanimoto(np.array([1, 0, 1]),
                            np.array([1, 1, 0]))
-        m2 = rogerstanimoto(np.array([1, 0, 1], dtype=np.bool),
-                            np.array([1, 1, 0], dtype=np.bool))
+        m2 = rogerstanimoto(np.array([1, 0, 1], dtype=bool),
+                            np.array([1, 1, 0], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 4/5, rtol=0, atol=1e-10)
@@ -1055,8 +1055,8 @@ class TestPdist(TestCase):
     def test_pdist_russellrao_mtica1(self):
         m = russellrao(np.array([1, 0, 1, 1, 0]),
                        np.array([1, 1, 0, 1, 1]))
-        m2 = russellrao(np.array([1, 0, 1, 1, 0], dtype=np.bool),
-                        np.array([1, 1, 0, 1, 1], dtype=np.bool))
+        m2 = russellrao(np.array([1, 0, 1, 1, 0], dtype=bool),
+                        np.array([1, 1, 0, 1, 1], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 3/5, rtol=0, atol=1e-10)
@@ -1065,8 +1065,8 @@ class TestPdist(TestCase):
     def test_pdist_russellrao_mtica2(self):
         m = russellrao(np.array([1, 0, 1]),
                        np.array([1, 1, 0]))
-        m2 = russellrao(np.array([1, 0, 1], dtype=np.bool),
-                        np.array([1, 1, 0], dtype=np.bool))
+        m2 = russellrao(np.array([1, 0, 1], dtype=bool),
+                        np.array([1, 1, 0], dtype=bool))
         if verbose > 2:
             print(m)
         assert_allclose(m, 2/3, rtol=0, atol=1e-10)
@@ -1232,7 +1232,7 @@ class TestSquareForm(TestCase):
     def test_squareform_one_binary_vector(self):
         # Tests squareform on a 1x1 binary matrix; conversion to double was
         # causing problems (see pull request 73).
-        v = np.ones((1,), dtype=np.bool)
+        v = np.ones((1,), dtype=bool)
         rv = squareform(v)
         assert_equal(rv.shape, (2,2))
         assert_(rv[0,1])

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -710,7 +710,7 @@ def test_ball_point_ints():
     tree = KDTree(points)
     assert_equal(sorted([4, 8, 9, 12]),
                  sorted(tree.query_ball_point((2, 0), 1)))
-    points = np.asarray(points, dtype=np.float)
+    points = np.asarray(points, dtype=float)
     tree = KDTree(points)
     assert_equal(sorted([4, 8, 9, 12]),
                  sorted(tree.query_ball_point((2, 0), 1)))

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -268,7 +268,7 @@ class ball_consistency:
             assert_(distance(self.data[i],self.x,self.p) <= self.d*(1.+self.eps))
 
     def test_found_all(self):
-        c = np.ones(self.T.n,dtype=np.bool)
+        c = np.ones(self.T.n,dtype=bool)
         l = self.T.query_ball_point(self.x, self.d, p=self.p, eps=self.eps)
         c[l] = False
         assert_(np.all(distance(self.data[c],self.x,self.p) >= self.d/(1.+self.eps)))
@@ -392,7 +392,7 @@ class two_trees_consistency:
     def test_found_all(self):
         r = self.T1.query_ball_tree(self.T2, self.d, p=self.p, eps=self.eps)
         for i, l in enumerate(r):
-            c = np.ones(self.T2.n,dtype=np.bool)
+            c = np.ones(self.T2.n,dtype=bool)
             c[l] = False
             assert_(np.all(distance(self.data2[c],self.data1[i],self.p) >= self.d/(1.+self.eps)))
 

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -408,8 +408,8 @@ class TestDelaunay(object):
 
             tri.vertices.sort()
 
-            assert_equal(tri.vertices, np.arange(nd+1, dtype=np.int)[None,:])
-            assert_equal(tri.neighbors, -1 + np.zeros((nd+1), dtype=np.int)[None,:])
+            assert_equal(tri.vertices, np.arange(nd+1, dtype=int)[None,:])
+            assert_equal(tri.neighbors, -1 + np.zeros((nd+1), dtype=int)[None,:])
 
     def test_2d_square(self):
         # simple smoke test: 2d square

--- a/scipy/special/_testutils.py
+++ b/scipy/special/_testutils.py
@@ -196,7 +196,7 @@ class FuncData(object):
         for j in self.param_columns:
             if np.iscomplexobj(j):
                 j = int(j.imag)
-                params.append(data[:,j].astype(np.complex))
+                params.append(data[:,j].astype(complex))
             else:
                 params.append(data[:,j])
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1786,7 +1786,7 @@ class TestHyper(TestCase):
 
         # complex input
         x = special.hyp0f1(3.0, np.array([-1.5, -1, 0, 1, 1.5]) + 0.j)
-        assert_allclose(x, expected.astype(np.complex), rtol=1e-12)
+        assert_allclose(x, expected.astype(complex), rtol=1e-12)
 
         # test broadcasting
         x1 = [0.5, 1.5, 2.5]

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -203,7 +203,7 @@ class gaussian_kde(object):
                     self.d)
                 raise ValueError(msg)
 
-        result = zeros((m,), dtype=np.float)
+        result = zeros((m,), dtype=float)
 
         if m >= self.n:
             # there are more points than data, so loop over data

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -710,7 +710,7 @@ def boxcox_llf(lmb, data):
 
     >>> x = stats.loggamma.rvs(5, loc=10, size=1000)
     >>> lmbdas = np.linspace(-2, 10)
-    >>> llf = np.zeros(lmbdas.shape, dtype=np.float)
+    >>> llf = np.zeros(lmbdas.shape, dtype=float)
     >>> for ii, lmbda in enumerate(lmbdas):
     ...     llf[ii] = stats.boxcox_llf(lmbda, x)
 
@@ -990,7 +990,7 @@ def boxcox_normmax(x, brack=(-2.0, 2.0), method='pearsonr'):
         return optimize.brent(_eval_mle, brack=brack, args=(x,))
 
     def _all(x, brack):
-        maxlog = np.zeros(2, dtype=np.float)
+        maxlog = np.zeros(2, dtype=float)
         maxlog[0] = _pearsonr(x, brack)
         maxlog[1] = _mle(x, brack)
         return maxlog
@@ -1316,7 +1316,7 @@ def _anderson_ksamp_midrank(samples, Z, Zstar, k, n, N):
     for i in arange(0, k):
         s = np.sort(samples[i])
         s_ssorted_right = s.searchsorted(Zstar, side='right')
-        Mij = s_ssorted_right.astype(np.float)
+        Mij = s_ssorted_right.astype(float)
         fij = s_ssorted_right - s.searchsorted(Zstar, 'left')
         Mij -= fij / 2.
         inner = lj / float(N) * (N*Mij - Bj*n[i])**2 / (Bj*(N - Bj) - N*lj/4.)

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -86,7 +86,7 @@ def check_cdf_ppf(distfn, arg, supp, msg):
 
 
 def check_pmf_cdf(distfn, arg, distname):
-    startind = np.int(distfn.ppf(0.01, *arg) - 1)
+    startind = int(distfn.ppf(0.01, *arg) - 1)
     index = list(range(startind, startind + 10))
     cdfs, pmfs_cum = distfn.cdf(index,*arg), distfn.pmf(index, *arg).cumsum()
 

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -98,7 +98,7 @@ class _kde_subclass4(stats.gaussian_kde):
 
 
 def test_gaussian_kde_subclassing():
-    x1 = np.array([-7, -5, 1, 4, 5], dtype=np.float)
+    x1 = np.array([-7, -5, 1, 4, 5], dtype=float)
     xs = np.linspace(-10, 10, num=50)
 
     # gaussian_kde itself
@@ -136,7 +136,7 @@ def test_gaussian_kde_subclassing():
 
 
 def test_gaussian_kde_covariance_caching():
-    x1 = np.array([-7, -5, 1, 4, 5], dtype=np.float)
+    x1 = np.array([-7, -5, 1, 4, 5], dtype=float)
     xs = np.linspace(-10, 10, num=5)
     # These expected values are from scipy 0.10, before some changes to
     # gaussian_kde.  They were not compared with any external reference.
@@ -156,7 +156,7 @@ def test_gaussian_kde_monkeypatch():
     specifically the linked ML thread "Width of the Gaussian in stats.kde".
     If it is necessary to break this later on, that is to be discussed on ML.
     """
-    x1 = np.array([-7, -5, 1, 4, 5], dtype=np.float)
+    x1 = np.array([-7, -5, 1, 4, 5], dtype=float)
     xs = np.linspace(-10, 10, num=50)
 
     # The old monkeypatched version to get at Silverman's Rule.

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -351,7 +351,7 @@ class TestMoments(TestCase):
            [True, True, True, False, True],
            [False, False, False, False, False],
            [True, True, True, True, True],
-           [False, False, True, False, False]], dtype=np.bool))
+           [False, False, True, False, False]], dtype=bool))
 
     def test_moment(self):
         y = mstats.moment(self.testcase,1)
@@ -393,7 +393,7 @@ class TestMoments(TestCase):
         correct_2d = ma.array(np.array([-1.5, -3., -1.47247052385, 0.,
                                         -1.26979517952]),
                               mask=np.array([False, False, False, True,
-                                             False], dtype=np.bool))
+                                             False], dtype=bool))
         assert_array_almost_equal(mstats.kurtosis(self.testcase_2d, 1),
                                   correct_2d)
         for i, row in enumerate(self.testcase_2d):
@@ -401,7 +401,7 @@ class TestMoments(TestCase):
 
         correct_2d_bias_corrected = ma.array(
             np.array([-1.5, -3., -1.88988209538, 0., -0.5234638463918877]),
-            mask=np.array([False, False, False, True, False], dtype=np.bool))
+            mask=np.array([False, False, False, True, False], dtype=bool))
         assert_array_almost_equal(mstats.kurtosis(self.testcase_2d, 1,
                                                   bias=False),
                                   correct_2d_bias_corrected)

--- a/scipy/stats/tests/test_rank.py
+++ b/scipy/stats/tests/test_rank.py
@@ -70,7 +70,7 @@ class TestRankData(TestCase):
 
     def test_empty(self):
         """stats.rankdata([]) should return an empty array."""
-        a = np.array([], dtype=np.int)
+        a = np.array([], dtype=int)
         r = rankdata(a)
         assert_array_equal(r, np.array([], dtype=np.float64))
         r = rankdata([])
@@ -79,7 +79,7 @@ class TestRankData(TestCase):
     def test_one(self):
         """Check stats.rankdata with an array of length 1."""
         data = [100]
-        a = np.array(data, dtype=np.int)
+        a = np.array(data, dtype=int)
         r = rankdata(a)
         assert_array_equal(r, np.array([1.0], dtype=np.float64))
         r = rankdata(data)
@@ -89,7 +89,7 @@ class TestRankData(TestCase):
         """Basic tests of stats.rankdata."""
         data = [100, 10, 50]
         expected = np.array([3.0, 1.0, 2.0], dtype=np.float64)
-        a = np.array(data, dtype=np.int)
+        a = np.array(data, dtype=int)
         r = rankdata(a)
         assert_array_equal(r, expected)
         r = rankdata(data)
@@ -97,7 +97,7 @@ class TestRankData(TestCase):
 
         data = [40, 10, 30, 10, 50]
         expected = np.array([4.0, 1.5, 3.0, 1.5, 5.0], dtype=np.float64)
-        a = np.array(data, dtype=np.int)
+        a = np.array(data, dtype=int)
         r = rankdata(a)
         assert_array_equal(r, expected)
         r = rankdata(data)
@@ -105,7 +105,7 @@ class TestRankData(TestCase):
 
         data = [20, 20, 20, 10, 10, 10]
         expected = np.array([5.0, 5.0, 5.0, 2.0, 2.0, 2.0], dtype=np.float64)
-        a = np.array(data, dtype=np.int)
+        a = np.array(data, dtype=int)
         r = rankdata(a)
         assert_array_equal(r, expected)
         r = rankdata(data)


### PR DESCRIPTION
This is just some ~~wiki~~ github gnome activity. See https://github.com/numpy/numpy/pull/6103.

``` shell
$ find . -name "*.py" -print0 | xargs -0 sed -i "s/\bnp.int\b/int/g"
$ find . -name "*.py" -print0 | xargs -0 sed -i "s/\bnp.float\b/float/g"
$ find . -name "*.py" -print0 | xargs -0 sed -i "s/\bnp.bool\b/bool/g"
```
