### PR TITLE
loadmat variable_names: don't confuse [] and None.

### DIFF
--- a/doc/release/0.17.0-notes.rst
+++ b/doc/release/0.17.0-notes.rst
@@ -54,6 +54,8 @@ elements trimmed are the lowest and/or highest, depending on the case.
 Slicing without at least partial sorting was previously done, but didn't
 make sense for unsorted input.
 
+When ``variable_names`` is set to an empty list, ``scipy.io.loadmat`` now
+correctly returns no values instead of all the contents of the MAT file.
 
 Other changes
 =============

--- a/scipy/io/matlab/mio4.py
+++ b/scipy/io/matlab/mio4.py
@@ -393,12 +393,12 @@ class MatFile4Reader(MatFileReader):
         while not self.end_of_stream():
             hdr, next_position = self.read_var_header()
             name = asstr(hdr.name)
-            if variable_names and name not in variable_names:
+            if variable_names is not None and name not in variable_names:
                 self.mat_stream.seek(next_position)
                 continue
             mdict[name] = self.read_var_array(hdr)
             self.mat_stream.seek(next_position)
-            if variable_names:
+            if variable_names is not None:
                 variable_names.remove(name)
                 if len(variable_names) == 0:
                     break

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -285,7 +285,7 @@ class MatFile5Reader(MatFileReader):
                 process = False
             else:
                 process = True
-            if variable_names and name not in variable_names:
+            if variable_names is not None and name not in variable_names:
                 self.mat_stream.seek(next_position)
                 continue
             try:
@@ -300,7 +300,7 @@ class MatFile5Reader(MatFileReader):
             mdict[name] = res
             if hdr.is_global:
                 mdict['__globals__'].append(name)
-            if variable_names:
+            if variable_names is not None:
                 variable_names.remove(name)
                 if len(variable_names) == 0:
                     break

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1081,6 +1081,8 @@ def test_loadmat_varnames():
         assert_equal(set(vars.keys()), set(['theta'] + sys_v_names))
         vars = loadmat(eg_file, variable_names=('theta',))
         assert_equal(set(vars.keys()), set(['theta'] + sys_v_names))
+        vars = loadmat(eg_file, variable_names=[])
+        assert_equal(set(vars.keys()), set(sys_v_names))
         vnames = ['theta']
         vars = loadmat(eg_file, variable_names=vnames)
         assert_equal(vnames, ['theta'])


### PR DESCRIPTION
Fixes the first part of #5060.
