### PR TITLE
Fix integrate.fixed_quad docstring to indicate None return value

### DIFF
--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -54,6 +54,9 @@ def fixed_quad(func,a,b,args=(),n=5):
     -------
     val : float
         Gaussian quadrature approximation to the integral
+    none : None
+        Statically returned value of None
+
 
     See Also
     --------


### PR DESCRIPTION
I noticed that `scipy.integrate.fixed_quad` return a tuple with the second element always equal to `None`, that is not documented (I had to look at the source code to realize why I was getting a tuple back instead of just a float). This has been in the code for a long time and it looks like previous versions of the docstring properly accounted for this, but the current version does not. 

I assume there is some legacy reason for always returning a None, and a quick search of Github shows that most people use it as something like:

``` python
val = scipy.integrate.fixed_quad(...)[0]
```

I'm not sure my proposed docstring is optimally worded, but I'm happy to adjust it if others have suggestions.
