### PR TITLE
Use solve() instead of inv() for gaussian_kde

### DIFF
--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -264,7 +264,7 @@ class gaussian_kde(object):
         sum_cov = self.covariance + cov
 
         diff = self.dataset - mean
-        tdiff = dot(linalg.inv(sum_cov), diff)
+        tdiff = linalg.solve(sum_cov, diff, sym_pos=True)
 
         energies = sum(diff * tdiff, axis=0) / 2.0
         result = sum(exp(-energies), axis=0) / sqrt(linalg.det(2 * pi *

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -263,12 +263,19 @@ class gaussian_kde(object):
 
         sum_cov = self.covariance + cov
 
+        # This will raise LinAlgError if the new cov matrix is not s.p.d
+        # cho_factor returns (ndarray, bool) where bool is a flag for whether
+        # or not ndarray is upper or lower triangular
+        sum_cov_chol = linalg.cho_factor(sum_cov)
+
         diff = self.dataset - mean
-        tdiff = linalg.solve(sum_cov, diff, sym_pos=True)
+        tdiff = linalg.cho_solve(sum_cov_chol, diff)
+
+        sqrt_det = np.prod(np.diagonal(sum_cov_chol[0]))
+        norm_const = power(2 * pi, sum_cov.shape[0] / 2.0) * sqrt_det
 
         energies = sum(diff * tdiff, axis=0) / 2.0
-        result = sum(exp(-energies), axis=0) / sqrt(linalg.det(2 * pi *
-                                                        sum_cov)) / self.n
+        result = sum(exp(-energies), axis=0) / norm_const / self.n
 
         return result
 
@@ -381,7 +388,10 @@ class gaussian_kde(object):
             energies = sum(diff * tdiff, axis=0) / 2.0
             result += sum(exp(-energies), axis=0)
 
-        result /= sqrt(linalg.det(2 * pi * sum_cov)) * large.n * small.n
+        sqrt_det = np.prod(np.diagonal(sum_cov_chol[0]))
+        norm_const = power(2 * pi, sum_cov.shape[0] / 2.0) * sqrt_det
+
+        result /= norm_const * large.n * small.n
 
         return result
 

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -37,6 +37,44 @@ def test_kde_1d():
                         (kdepdf*normpdf).sum()*intervall, decimal=2)
 
 
+def test_kde_2d():
+    #some basic tests comparing to normal distribution
+    np.random.seed(8765678)
+    n_basesample = 500
+
+    mean = np.array([1.0, 3.0])
+    covariance = np.array([[1.0, 2.0], [2.0, 6.0]])
+
+    # Need transpose (shape (2, 500)) for kde
+    xn = np.random.multivariate_normal(mean, covariance, size=n_basesample).T
+
+    # get kde for original sample
+    gkde = stats.gaussian_kde(xn)
+
+    # evaluate the density function for the kde for some points
+    x, y = np.mgrid[-7:7:500j, -7:7:500j]
+    grid_coords = np.vstack([x.ravel(), y.ravel()])
+    kdepdf = gkde.evaluate(grid_coords)
+    kdepdf = kdepdf.reshape(500, 500)
+
+    normpdf = stats.multivariate_normal.pdf(np.dstack([x, y]), mean=mean, cov=covariance)
+    intervall = y.ravel()[1] - y.ravel()[0]
+
+    assert_(np.sum((kdepdf - normpdf)**2) * (intervall**2) < 0.01)
+
+    small = -1e100
+    large = 1e100
+    prob1 = gkde.integrate_box([small, mean[1]], [large, large])
+    prob2 = gkde.integrate_box([small, small], [large, mean[1]])
+
+    assert_almost_equal(prob1, 0.5, decimal=1)
+    assert_almost_equal(prob2, 0.5, decimal=1)
+    assert_almost_equal(gkde.integrate_kde(gkde),
+                        (kdepdf**2).sum()*(intervall**2), decimal=2)
+    assert_almost_equal(gkde.integrate_gaussian(mean, covariance),
+                        (kdepdf*normpdf).sum()*(intervall**2), decimal=2)
+
+
 def test_kde_bandwidth_method():
     def scotts_factor(kde_obj):
         """Same as default, just check that it works."""


### PR DESCRIPTION
This will speed things up a little in higher dimensions.  There are other improvements to be made in this part of the codebase (there's another use of inv() that I haven't quite got fixed yet, and there's also a use of det() that I can definitely speed up) but I'll open a PR for those separately (unless others would like them as part of this PR).

Note:  There may be other parts of scipy that use inv() instead of solve(), but I shan't address those here.
