### PR TITLE
BUG: Don't overwrite b in lfilter's FIR path

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -938,7 +938,7 @@ def lfilter(b, a, x, axis=-1, zi=None):
         if dtype.char not in 'fdgFDGO':
             raise NotImplementedError("input type '%s' not supported" % dtype)
 
-        b = np.array(b, dtype=dtype, copy=False)
+        b = np.array(b, dtype=dtype)
         a = np.array(a, dtype=dtype, copy=False)
         b /= a[0]
         x = np.array(x, dtype=dtype, copy=False)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -856,6 +856,30 @@ class _TestLinearFilter(TestCase):
         assert_array_almost_equal(y, ye)
         assert_array_almost_equal(zf, zfe)
 
+    def test_do_not_modify_a_b_IIR(self):
+        x = self.generate((6,))
+        b = self.convert_dtype([1, -1])
+        b0 = b.copy()
+        a = self.convert_dtype([0.5, -0.5])
+        a0 = a.copy()
+        y_r = self.convert_dtype([0, 2, 4, 6, 8, 10.])
+        y_f = lfilter(b, a, x)
+        assert_array_almost_equal(y_f, y_r)
+        assert_equal(b, b0)
+        assert_equal(a, a0)
+
+    def test_do_not_modify_a_b_FIR(self):
+        x = self.generate((6,))
+        b = self.convert_dtype([1, 0, 1])
+        b0 = b.copy()
+        a = self.convert_dtype([2])
+        a0 = a.copy()
+        y_r = self.convert_dtype([0, 0.5, 1, 2, 3, 4.])
+        y_f = lfilter(b, a, x)
+        assert_array_almost_equal(y_f, y_r)
+        assert_equal(b, b0)
+        assert_equal(a, a0)
+
 
 class TestLinearFilterFloat32(_TestLinearFilter):
     dtype = np.dtype('f')


### PR DESCRIPTION
Fixes a small bug introduced in #4628.  I've left it unmarked, but this would be good to backport if a 0.16.1 were going to happen.  It could potentially break things and is a regression from 0.15.
