### PR TITLE
DOC/ENH fixes and micro-optimizations for scipy.linalg

### DIFF
--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -22,7 +22,7 @@ __all__ = ['solve_sylvester', 'solve_lyapunov', 'solve_discrete_lyapunov',
 
 def solve_sylvester(a,b,q):
     """
-    Computes a solution (X) to the Sylvester equation (AX + XB = Q).
+    Computes a solution (X) to the Sylvester equation :math:`AX + XB = Q`.
 
     Parameters
     ----------
@@ -82,8 +82,9 @@ def solve_sylvester(a,b,q):
 
 def solve_lyapunov(a, q):
     """
-    Solves the continuous Lyapunov equation (AX + XA^H = Q) given the values
-    of A and Q using the Bartels-Stewart algorithm.
+    Solves the continuous Lyapunov equation :math:`AX + XA^H = Q`.
+
+    Uses the Bartels-Stewart algorithm to find :math:`X`.
 
     Parameters
     ----------
@@ -147,7 +148,7 @@ def _solve_discrete_lyapunov_bilinear(a, q):
 
 def solve_discrete_lyapunov(a, q, method=None):
     """
-    Solves the discrete Lyapunov equation :math:`(A'XA-X=-Q)`.
+    Solves the discrete Lyapunov equation :math:`A'XA-X=-Q`.
 
     Parameters
     ----------
@@ -225,9 +226,14 @@ def solve_discrete_lyapunov(a, q, method=None):
 
 def solve_continuous_are(a, b, q, r):
     """
-    Solves the continuous algebraic Riccati equation, or CARE, defined
-    as (A'X + XA - XBR^-1B'X+Q=0) directly using a Schur decomposition
-    method.
+    Solves the continuous algebraic Riccati equation (CARE).
+
+    The CARE is defined as
+
+    .. math::
+        (A'X + XA - XBR^-1B'X+Q=0)
+
+    It is solved directly using a Schur decomposition method.
 
     Parameters
     ----------
@@ -277,7 +283,7 @@ def solve_continuous_are(a, b, q, r):
 
     # Note: we need to sort the upper left of s to have negative real parts,
     #       while the lower right is positive real components (Laub, p. 7)
-    [s, u, sorted] = schur(z, sort='lhp')
+    s, u, _ = schur(z, sort='lhp')
 
     (m, n) = u.shape
 
@@ -290,9 +296,14 @@ def solve_continuous_are(a, b, q, r):
 
 def solve_discrete_are(a, b, q, r):
     """
-    Solves the disctrete algebraic Riccati equation, or DARE, defined as
-    (X = A'XA-(A'XB)(R+B'XB)^-1(B'XA)+Q), directly using a Schur decomposition
-    method.
+    Solves the discrete algebraic Riccati equation (DARE).
+
+    The DARE is defined as
+
+    .. math::
+        X = A'XA-(A'XB)(R+B'XB)^-1(B'XA)+Q
+
+    It is solved directly using a Schur decomposition method.
 
     Parameters
     ----------
@@ -347,7 +358,7 @@ def solve_discrete_are(a, b, q, r):
 
     # Note: we need to sort the upper left of s to lie within the unit circle,
     #       while the lower right is outside (Laub, p. 7)
-    [s, u, sorted] = schur(z, sort='iuc')
+    s, u, _ = schur(z, sort='iuc')
 
     (m,n) = u.shape
 

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -957,10 +957,10 @@ def pinv2(a, cond=None, rcond=None, return_rank=False, check_finite=True):
         cond = factor[t] * np.finfo(t).eps
 
     rank = np.sum(s > cond * np.max(s))
-    psigma_diag = 1.0 / s[: rank]
 
-    B = np.transpose(np.conjugate(np.dot(u[:, : rank] *
-                                         psigma_diag, vh[: rank])))
+    u = u[:, :rank]
+    u /= s[:rank]
+    B = np.transpose(np.conjugate(np.dot(u, vh[:rank])))
 
     if return_rank:
         return B, rank


### PR DESCRIPTION
- Docstring fixes to `scipy/linalg/_solvers.py`
- Code cosmetics
- Use in-place operations to prevent allocating big temporaries in `pinv2`

`pinv2` is now a few percent faster as well. Before:

``` py
>>> A = np.random.RandomState(42).randn(1000, 1000)
>>> %timeit pinv2(A)
1 loops, best of 3: 1.52 s per loop
```

After:

``` py
>>> %timeit pinv2(A)
1 loops, best of 3: 1.47 s per loop
```
