### PR TITLE
enh: made l-bfgs-b parameter for the maximum number of line search steps accessible in python

### DIFF
--- a/scipy/optimize/lbfgsb/lbfgsb.f
+++ b/scipy/optimize/lbfgsb/lbfgsb.f
@@ -40,11 +40,11 @@ c                        March  2011
 c                                                 
 c============================================================================= 
       subroutine setulb(n, m, x, l, u, nbd, f, g, factr, pgtol, wa, iwa,
-     +                 task, iprint, csave, lsave, isave, dsave)
+     +                 task, iprint, csave, lsave, isave, dsave, maxls)
  
       character*60     task, csave
       logical          lsave(4)
-      integer          n, m, iprint, 
+      integer          n, m, iprint, maxls,
      +                 nbd(n), iwa(3*n), isave(44)
       double precision f, factr, pgtol, x(n), l(n), u(n), g(n),
 c
@@ -271,7 +271,7 @@ c-jlm-jn
      +  wa(lwn),wa(lsnd),wa(lz),wa(lr),wa(ld),wa(lt),wa(lxp),
      +  wa(lwa),
      +  iwa(1),iwa(n+1),iwa(2*n+1),task,iprint, 
-     +  csave,lsave,isave(22),dsave)
+     +  csave,lsave,isave(22),dsave, maxls)
 
       return
 
@@ -282,12 +282,13 @@ c======================= The end of setulb =============================
       subroutine mainlb(n, m, x, l, u, nbd, f, g, factr, pgtol, ws, wy,
      +                  sy, ss, wt, wn, snd, z, r, d, t, xp, wa, 
      +                  index, iwhere, indx2, task,
-     +                  iprint, csave, lsave, isave, dsave)
+     +                  iprint, csave, lsave, isave, dsave, maxls)
       implicit none
       character*60     task, csave
       logical          lsave(4)
       integer          n, m, iprint, nbd(n), index(n),
-     +                 iwhere(n), indx2(n), isave(23)
+     +                 iwhere(n), indx2(n), isave(23),
+     +                 maxls
       double precision f, factr, pgtol,
      +                 x(n), l(n), u(n), g(n), z(n), r(n), d(n), t(n), 
 c-jlm-jn
@@ -784,7 +785,7 @@ c     Generate the search direction d:=z-x.
       call lnsrlb(n,l,u,nbd,x,f,fold,gd,gdold,g,d,r,t,z,stp,dnorm,
      +            dtd,xstep,stpmx,iter,ifun,iback,nfgv,info,task,
      +            boxed,cnstnd,csave,isave(22),dsave(17), iprint)
-      if (info .ne. 0 .or. iback .ge. 20) then
+      if (info .ne. 0 .or. iback .ge. maxls) then
 c          restore the previous iterate.
          call dcopy(n,t,1,x,1)
          call dcopy(n,r,1,g,1)

--- a/scipy/optimize/lbfgsb/lbfgsb.pyf
+++ b/scipy/optimize/lbfgsb/lbfgsb.pyf
@@ -1,7 +1,7 @@
 !    -*- f90 -*-
 python module _lbfgsb ! in 
     interface  ! in :_lbfgsb
-        subroutine setulb(n,m,x,l,u,nbd,f,g,factr,pgtol,wa,iwa,task,iprint,csave,lsave,isave,dsave) ! in :lbfgsb:lbfgsb.f
+        subroutine setulb(n,m,x,l,u,nbd,f,g,factr,pgtol,wa,iwa,task,iprint,csave,lsave,isave,dsave,maxls) ! in :lbfgsb:lbfgsb.f
             integer intent(in),optional,check(len(x)>=n),depend(x) :: n=len(x)
             integer intent(in) :: m
             double precision dimension(n),intent(inout) :: x
@@ -20,6 +20,7 @@ python module _lbfgsb ! in
             logical dimension(4),intent(inout) :: lsave
             integer dimension(44),intent(inout) :: isave
             double precision dimension(29),intent(inout) :: dsave
+            integer intent(in) :: maxls
         end subroutine setulb
     end interface 
 end python module _lbfgsb

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -484,6 +484,13 @@ class TestOptimizeSimple(CheckOptimize):
 
             assert_allclose(v, self.func(self.solution), rtol=tol)
 
+    def test_minimize_l_bfgs_maxls(self):
+        # check that the maxls is passed down to the Fortran routine
+        sol = optimize.minimize(optimize.rosen, np.array([-1.2,1.0]),
+                                method='L-BFGS-B', jac=optimize.rosen_der,
+                                options={'disp': False, 'maxls': 1})
+        assert_(not sol.success)
+
     def test_custom(self):
         # This function comes from the documentation example.
         def custmin(fun, x0, args=(), maxfev=None, stepsize=0.1,


### PR DESCRIPTION
I sometimes found it useful for my minimization problems to increase the maximum number of line searches in the l-bfgs-b algorithm. The parameter was hard-coded in the Fortran source. I made it accessible as an optional argument.
I found it a bit difficult to come up with a good unit test. It's hard to find a function that is at the same time simple and where the minimization requires more than 20 steps (the default). I would appreciate, if you could help me here. 
