### PR TITLE
MAINT: more data validation for boxcox transformation

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -850,8 +850,8 @@ def boxcox(x, lmbda=None, alpha=None):
 
     Parameters
     ----------
-    x : ndarray
-        Input array.  Should be 1-dimensional.
+    x : array_like
+        One-dimensional input array.
     lmbda : {None, scalar}, optional
         If `lmbda` is not None, do the transformation for that value.
 
@@ -931,6 +931,11 @@ def boxcox(x, lmbda=None, alpha=None):
 
     """
     x = np.asarray(x)
+
+    # For backward compatibility, only do this validation when lmbda is None.
+    if lmbda is None and len(x.shape) != 1:
+        raise ValueError("Data must be 1-dimensional.")
+
     if x.size == 0:
         return x
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -915,6 +915,10 @@ class TestBoxcox(TestCase):
     def test_empty(self):
         assert_(stats.boxcox([]).shape == (0,))
 
+    def test_data_dimensionality_validation(self):
+        for x in np.array(3), [[1.0]], np.array([[1.0, 2.0, 3.0]]):
+            assert_raises(ValueError, stats.boxcox, x)
+
 
 class TestBoxcoxNormmax(TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR requires the `boxcox` input data to be 1d.  But this requirement is relaxed when `lmbda` is provided, for backwards compatibility reasons: according to a note in `test_morestats` it's important to allow `boxcox_llf` to work with 2d input.  When `boxcox_llf` gets 2d input, it calls `boxcox` with 2d input but only with an explicit `lmbda` parameter.

``` python
# Note: boxcox_llf() was already working with 2-D input (sort of), so
# keep it like that.  boxcox() doesn't work with 2-D input though, due
# to brent() returning a scalar.
```
