### PR TITLE
More efficient median binned stat calculation and new min & max binned stats

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -425,7 +425,9 @@ def binned_statistic_dd(sample, values, statistic='mean',
     elif statistic == 'median':
         result.fill(np.nan)
         for i in np.unique(xy):
-            result[i] = np.median(values[xy == i])
+            bin_values = values[xy == i]
+            if bin_values.size > 0:
+                result[i] = np.median(bin_values)
     elif callable(statistic):
         with warnings.catch_warnings():
             # Numpy generates a warnings for mean/std/... with empty list

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -280,6 +280,10 @@ def binned_statistic_dd(sample, values, statistic='mean',
             referenced.
           * 'sum' : compute the sum of values for points within each bin.
             This is identical to a weighted histogram.
+          * 'max' : compute the maximum value for points within each bin.
+            Empty bins will be represented by NaN.
+          * 'min' : compute the minimum value for points within each bin.
+            Empty bins will be represented by NaN.
           * function : a user-defined function which takes a 1D array of
             values, and outputs a single numerical statistic. This function
             will be called on the values in each bin.  Empty bins will be
@@ -318,7 +322,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
     .. versionadded:: 0.11.0
 
     """
-    known_stats = ['mean', 'median', 'count', 'sum', 'std']
+    known_stats = ['mean', 'median', 'count', 'sum', 'std', 'min', 'max']
     if not callable(statistic) and statistic not in known_stats:
         raise ValueError('invalid statistic %r' % (statistic,))
 
@@ -428,6 +432,18 @@ def binned_statistic_dd(sample, values, statistic='mean',
             bin_values = values[xy == i]
             if bin_values.size > 0:
                 result[i] = np.median(bin_values)
+    elif statistic == 'max':
+        result.fill(np.nan)
+        for i in np.unique(xy):
+            bin_values = values[xy == i]
+            if bin_values.size > 0:
+                result[i] = np.max(bin_values)
+    elif statistic == 'min':
+        result.fill(np.nan)
+        for i in np.unique(xy):
+            bin_values = values[xy == i]
+            if bin_values.size > 0:
+                result[i] = np.min(bin_values)
     elif callable(statistic):
         with warnings.catch_warnings():
             # Numpy generates a warnings for mean/std/... with empty list

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -77,6 +77,26 @@ class TestBinnedStatistic(object):
         assert_array_almost_equal(stat1, stat2)
         assert_array_almost_equal(edges1, edges2)
 
+    def test_1d_max(self):
+        x = self.x
+        v = self.v
+
+        stat1, edges1, bc = binned_statistic(x, v, 'max', bins=10)
+        stat2, edges2, bc = binned_statistic(x, v, np.max, bins=10)
+
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(edges1, edges2)
+
+    def test_1d_min(self):
+        x = self.x
+        v = self.v
+
+        stat1, edges1, bc = binned_statistic(x, v, 'min', bins=10)
+        stat2, edges2, bc = binned_statistic(x, v, np.min, bins=10)
+
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(edges1, edges2)
+
     def test_1d_bincode(self):
         x = self.x[:20]
         v = self.v[:20]
@@ -184,6 +204,30 @@ class TestBinnedStatistic(object):
         assert_array_almost_equal(binx1, binx2)
         assert_array_almost_equal(biny1, biny2)
 
+    def test_2d_max(self):
+        x = self.x
+        y = self.y
+        v = self.v
+
+        stat1, binx1, biny1, bc = binned_statistic_2d(x, y, v, 'max', bins=5)
+        stat2, binx2, biny2, bc = binned_statistic_2d(x, y, v, np.max, bins=5)
+
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(binx1, binx2)
+        assert_array_almost_equal(biny1, biny2)
+
+    def test_2d_min(self):
+        x = self.x
+        y = self.y
+        v = self.v
+
+        stat1, binx1, biny1, bc = binned_statistic_2d(x, y, v, 'min', bins=5)
+        stat2, binx2, biny2, bc = binned_statistic_2d(x, y, v, np.min, bins=5)
+
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(binx1, binx2)
+        assert_array_almost_equal(biny1, biny2)
+
     def test_2d_bincode(self):
         x = self.x[:20]
         y = self.y[:20]
@@ -253,6 +297,26 @@ class TestBinnedStatistic(object):
 
         stat1, edges1, bc = binned_statistic_dd(X, v, 'median', bins=3)
         stat2, edges2, bc = binned_statistic_dd(X, v, np.median, bins=3)
+
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(edges1, edges2)
+
+    def test_dd_max(self):
+        X = self.X
+        v = self.v
+
+        stat1, edges1, bc = binned_statistic_dd(X, v, 'max', bins=3)
+        stat2, edges2, bc = binned_statistic_dd(X, v, np.max, bins=3)
+
+        assert_array_almost_equal(stat1, stat2)
+        assert_array_almost_equal(edges1, edges2)
+
+    def test_dd_min(self):
+        X = self.X
+        v = self.v
+
+        stat1, edges1, bc = binned_statistic_dd(X, v, 'min', bins=3)
+        stat2, edges2, bc = binned_statistic_dd(X, v, np.min, bins=3)
 
         assert_array_almost_equal(stat1, stat2)
         assert_array_almost_equal(edges1, edges2)


### PR DESCRIPTION
- Prevent calculating the median on bins where count == 0.
- Add min/max options to `binned_statistic` function
- Closes #5100
