### PR TITLE
BUG: optimize: check for NaN in minimize with BFGS

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -930,9 +930,10 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
             print("         Function evaluations: %d" % func_calls[0])
             print("         Gradient evaluations: %d" % grad_calls[0])
 
+    success = (warnflag == 0 and not np.isnan(fval))
     result = OptimizeResult(fun=fval, jac=gfk, hess_inv=Hk, nfev=func_calls[0],
                             njev=grad_calls[0], status=warnflag,
-                            success=(warnflag == 0), message=msg, x=xk,
+                            success=success, message=msg, x=xk,
                             nit=k)
     if retall:
         result['allvecs'] = allvecs

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -384,6 +384,13 @@ class TestOptimizeSimple(CheckOptimize):
             x = optimize.fmin_bfgs(func, x0, fprime, disp=False)
             assert_(np.isnan(func(x)))
 
+    def test_bfgs_nan_return(self):
+        # Test corner case where fun returns NaN. See gh-4793.
+        # XXX This means optimize.minimize is inconsistent with fmin_bfgs.
+        func = lambda x: np.nan
+        result = optimize.minimize(func, 0)
+        assert_(np.isnan(result['fun']) and result['success'] is False)
+
     def test_bfgs_numerical_jacobian(self):
         # BFGS with numerical jacobian and a vector epsilon parameter.
         # define the epsilon parameter using a random vector


### PR DESCRIPTION
Fixes gh-4793.

However, this introduces an inconsistency: `optimize.minimize` now has BFGS check for NaN, while `fmin_bfgs` doesn't because the regression test for #2067 wants it not too. Should I change that test and check for NaN everywhere?
