### PR TITLE
BUG: solve_banded failed when solving 1x1 systems

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -213,8 +213,8 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
         shape of `b`.
 
     """
-    a1 = _asarray_validated(ab, check_finite=check_finite)
-    b1 = _asarray_validated(b, check_finite=check_finite)
+    a1 = _asarray_validated(ab, check_finite=check_finite, as_inexact=True)
+    b1 = _asarray_validated(b, check_finite=check_finite, as_inexact=True)
     # Validate shapes.
     if a1.shape[-1] != b1.shape[0]:
         raise ValueError("shapes of ab and b are not compatible.")
@@ -224,13 +224,17 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
                 " l+u+1 (%d) does not equal ab.shape[0] (%d)" % (l+u+1, ab.shape[0]))
 
     overwrite_b = overwrite_b or _datacopied(b1, b)
+    if a1.shape[-1] == 1:
+        b2 = np.array(b1, copy=overwrite_b)
+        b2 /= a1[1,0]
+        return b2
     if l == u == 1:
-        overwrite_ab = overwrite_ab or _datacopied(b1, b)
+        overwrite_ab = overwrite_ab or _datacopied(a1, ab)
         gtsv, = get_lapack_funcs(('gtsv',), (a1, b1))
         du = a1[0,1:]
         d = a1[1,:]
         dl = a1[2,:-1]
-        du2, d, du, x, info = gtsv(dl, d, du, b, overwrite_ab, overwrite_ab,
+        du2, d, du, x, info = gtsv(dl, d, du, b1, overwrite_ab, overwrite_ab,
                                    overwrite_ab, overwrite_b)
     else:
         gbsv, = get_lapack_funcs(('gbsv',), (a1, b1))

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -22,17 +22,17 @@ Run tests if linalg is not installed:
 """
 
 import numpy as np
-from numpy import arange, array, dot, zeros, identity, conjugate, transpose, \
-        float32
+from numpy import (arange, array, dot, zeros, identity, conjugate, transpose,
+        float32)
 import numpy.linalg as linalg
 
-from numpy.testing import TestCase, rand, run_module_suite, assert_raises, \
-    assert_equal, assert_almost_equal, assert_array_almost_equal, assert_, \
-    assert_allclose
+from numpy.testing import (TestCase, rand, run_module_suite, assert_raises,
+    assert_equal, assert_almost_equal, assert_array_almost_equal, assert_,
+    assert_allclose, assert_array_equal)
 
-from scipy.linalg import solve, inv, det, lstsq, pinv, pinv2, pinvh, norm,\
-        solve_banded, solveh_banded, solve_triangular, solve_circulant, \
-        circulant, LinAlgError
+from scipy.linalg import (solve, inv, det, lstsq, pinv, pinv2, pinvh, norm,
+        solve_banded, solveh_banded, solve_triangular, solve_circulant,
+        circulant, LinAlgError)
 
 from scipy.linalg._testutils import assert_no_overwrite
 
@@ -155,6 +155,11 @@ class TestSolveBanded(TestCase):
 
         # Values of (l,u) are not compatible with ab.
         assert_raises(ValueError, solve_banded, (1, 1), ab, [1.0, 2.0])
+
+    def test_1x1(self):
+        x = solve_banded((1, 1), [[0], [1], [0]], [[1, 2, 3]])
+        assert_array_equal(x, [[1.0, 2.0, 3.0]])
+        assert_equal(x.dtype, np.dtype('f8'))
 
 
 class TestSolveHBanded(TestCase):
@@ -456,6 +461,11 @@ class TestSolveHBanded(TestCase):
         assert_raises(ValueError, solveh_banded, ab, b)
         assert_raises(ValueError, solveh_banded, ab, [1.0, 2.0])
         assert_raises(ValueError, solveh_banded, ab, [1.0])
+
+    def test_1x1(self):
+        x = solveh_banded([[1]], [[1, 2, 3]])
+        assert_array_equal(x, [[1.0, 2.0, 3.0]])
+        assert_equal(x.dtype, np.dtype('f8'))
 
 
 class TestSolve(TestCase):


### PR DESCRIPTION
This fixes a regression introduced when solve_banded was taught
about tridiagonal systems in gh-4373.

fixes gh-5127
