### PR TITLE
BUG: optimize: check for NaN optimum in BFGS

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -903,6 +903,11 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
                                                  sk[numpy.newaxis, :])
 
     fval = old_fval
+    if np.isnan(fval):
+        # This can happen if the first call to f returned NaN;
+        # the loop is then never entered.
+        warnflag = 2
+
     if warnflag == 2:
         msg = _status_message['pr_loss']
         if disp:

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -384,6 +384,22 @@ class TestOptimizeSimple(CheckOptimize):
             x = optimize.fmin_bfgs(func, x0, fprime, disp=False)
             assert_(np.isnan(func(x)))
 
+    def test_bfgs_nan_return(self):
+        # Test corner cases where fun returns NaN. See gh-4793.
+
+        # First case: NaN from first call.
+        func = lambda x: np.nan
+        result = optimize.minimize(func, 0)
+        assert_(np.isnan(result['fun']))
+        assert_(result['success'] is False)
+
+        # Second case: NaN from second call.
+        func = lambda x: 0 if x == 0 else np.nan
+        fprime = lambda x: np.ones_like(x)  # Steer away from zero.
+        result = optimize.minimize(func, 0, jac=fprime)
+        assert_(np.isnan(result['fun']))
+        assert_(result['success'] is False)
+
     def test_bfgs_numerical_jacobian(self):
         # BFGS with numerical jacobian and a vector epsilon parameter.
         # define the epsilon parameter using a random vector


### PR DESCRIPTION
New take on #5125 to fix #4793, at least for BFGS. Ping @pv, @josef-pkt. (GitHub wouldn't let me reopen the old PR after a force-push.) The solution turns out to be very simple.
