### PR TITLE
DOC: update PyPi trove classifiers.  Beta -> Stable.  Add license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,13 +32,20 @@ else:
     import builtins
 
 CLASSIFIERS = """\
-Development Status :: 4 - Beta
+Development Status :: 5 - Production/Stable
 Intended Audience :: Science/Research
 Intended Audience :: Developers
-License :: OSI Approved
+License :: OSI Approved :: BSD License
 Programming Language :: C
 Programming Language :: Python
+Programming Language :: Python :: 2
+Programming Language :: Python :: 2.6
+Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
+Programming Language :: Python :: 3.2
+Programming Language :: Python :: 3.3
+Programming Language :: Python :: 3.4
+Programming Language :: Python :: 3.5
 Topic :: Software Development
 Topic :: Scientific/Engineering
 Operating System :: Microsoft :: Windows


### PR DESCRIPTION
Imho the change to "Production/Stable" is long overdue. We still need to get the version number to match, but Scipy is stable and relied on by a lot of people and companies.
