### PR TITLE
Attribute kurtosistest() to Anscombe & Glynn (1983)

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1424,6 +1424,8 @@ def kurtosistest(a, axis=0):
     Notes
     -----
     Valid only for n>20.  The Z-score is set to 0 for bad entries.
+    This function uses the method of Anscombe & Glynn (1983).
+    See doi: 10.1093/biomet/70.1.227
 
     """
     a, axis = _chk_asarray(a, axis)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1424,8 +1424,12 @@ def kurtosistest(a, axis=0):
     Notes
     -----
     Valid only for n>20.  The Z-score is set to 0 for bad entries.
-    This function uses the method of Anscombe & Glynn (1983).
-    See doi: 10.1093/biomet/70.1.227
+    This function uses the method described in [1]_.
+    
+    References
+    ----------
+    .. [1] F. J. Anscombe, W. J. Glynn, "Distribution of the kurtosis statistic
+       b2 for normal samples", Biometrika, vol. 70, pp. 227-234, 1983.
 
     """
     a, axis = _chk_asarray(a, axis)
@@ -1440,16 +1444,18 @@ def kurtosistest(a, axis=0):
     b2 = kurtosis(a, axis, fisher=False)
 
     E = 3.0*(n-1) / (n+1)
-    varb2 = 24.0*n*(n-2)*(n-3) / ((n+1)*(n+1.)*(n+3)*(n+5))
-    x = (b2-E) / np.sqrt(varb2)
+    varb2 = 24.0*n*(n-2)*(n-3) / ((n+1)*(n+1.)*(n+3)*(n+5)) # [1]_ Eq. 1
+    x = (b2-E) / np.sqrt(varb2) # [1]_ Eq. 4
+    # [1]_ Eq. 2:
     sqrtbeta1 = 6.0*(n*n-5*n+2)/((n+7)*(n+9)) * np.sqrt((6.0*(n+3)*(n+5)) /
                                                         (n*(n-2)*(n-3)))
+    # [1]_ Eq. 3:
     A = 6.0 + 8.0/sqrtbeta1 * (2.0/sqrtbeta1 + np.sqrt(1+4.0/(sqrtbeta1**2)))
     term1 = 1 - 2/(9.0*A)
     denom = 1 + x*np.sqrt(2/(A-4.0))
     denom = np.where(denom < 0, 99, denom)
     term2 = np.where(denom < 0, term1, np.power((1-2.0/A)/denom, 1/3.0))
-    Z = (term1 - term2) / np.sqrt(2/(9.0*A))
+    Z = (term1 - term2) / np.sqrt(2/(9.0*A)) # [1]_ Eq. 5
     Z = np.where(denom == 99, 0, Z)
     if Z.ndim == 0:
         Z = Z[()]


### PR DESCRIPTION
It would be nice to be able to refer to this test by name when using it (such as when referring to it in a paper). From looking at the code, it seems to use the method of Anscombe & Glynn (1983):

http://biomet.oxfordjournals.org/content/70/1/227

See equations 2 through 5 in that paper.

Does anyone have any further insight? I tracked that reference down via the Wikipedia article on Agostino's K-squared test:

https://en.wikipedia.org/wiki/D%27Agostino%27s_K-squared_test
