### PR TITLE
Fix misleading wavelets/cwt example

### DIFF
--- a/scipy/signal/wavelets.py
+++ b/scipy/signal/wavelets.py
@@ -350,7 +350,7 @@ def cwt(data, wavelet, widths):
     >>> sig  = np.cos(2 * np.pi * 7 * t) + signal.gausspulse(t - 0.4, fc=2)
     >>> widths = np.arange(1, 31)
     >>> cwtmatr = signal.cwt(sig, signal.ricker, widths)
-    >>> plt.imshow(cwtmatr, extent=[-1, 1, 1, 31], cmap='PRGn', aspect='auto',
+    >>> plt.imshow(cwtmatr, extent=[-1, 1, 31, 1], cmap='PRGn', aspect='auto',
     ...            vmax=abs(cwtmatr).max(), vmin=-abs(cwtmatr).max())
     >>> plt.show()
 


### PR DESCRIPTION
extent is in the wrong order. if used as before the change, the
resulting image suggests that the best matching ricker wavelet
width (i.e. it's scale) is in (27, 28).
The widths, however, are related to the number of samples on the
time axis - in the examples case the time axis is 200 entries long
spanning from (-1, 1) seconds and contain a 7Hz signal.
This amounts 1 second being represented by 100 points on the t axis,
which - in turn - means a period covers 14.28 dots on the t axis.
According to the defintion of ricker wavelet the optimal scale
to match this signal would be 0.25 \* period lenght or - in
this case - 3.57 as opposed to between 27 and 28

Reversing the axis conveys exactly this putting the best match
between 3 and 4
