### PR TITLE
DOC: Add warnings of inversed order of y and t in f = dy/dt for ode a…

### DIFF
--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -104,7 +104,9 @@ class ode(object):
     """
     A generic interface class to numeric integrators.
 
-    Solve an equation system :math:`y'(t) = f(t,y)` with (optional) ``jac = df/dy``.
+    Solve an equation system :math:`y'(t) = f(t,y)` with (optional)
+    ``jac = df/dy``. ("Buyer Beware": the odeint interface takes `f(y,t)`
+    with parameters `y` and `t` in reversed order!)
 
     Parameters
     ----------

--- a/scipy/integrate/odepack.py
+++ b/scipy/integrate/odepack.py
@@ -42,7 +42,8 @@ def odeint(func, y0, t, args=(), Dfun=None, col_deriv=0, full_output=0,
     Parameters
     ----------
     func : callable(y, t0, ...)
-        Computes the derivative of y at t0.
+        Computes the derivative of y at t0. ("Buyer Beware": the ode class
+        takes a `func(t0,y)` with parameters `y` and `t0` in reversed order!)
     y0 : array
         Initial condition on y (can be a vector).
     t : array


### PR DESCRIPTION
…nd odeint.

Add warning to the parameter description in the "entry level interface" odeint
and more prominently to the more sophisticated ode interface, on which users
fall back when needing more control.

This has been discussed in #1446.
