### PR TITLE
add keywords to control the summation in discrete distributions expect method

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -115,11 +115,11 @@ _doc_fit = """\
     Parameter estimates for generic data.
 """
 _doc_expect = """\
-``expect(func, %(shapes)s, loc=0, scale=1, lb=None, ub=None, conditional=False, **kwds)``
+``expect(func, args=(%(shapes_)s), loc=0, scale=1, lb=None, ub=None, conditional=False, **kwds)``
     Expected value of a function (of one argument) with respect to the distribution.
 """
 _doc_expect_discrete = """\
-``expect(func, %(shapes)s, loc=0, lb=None, ub=None, conditional=False)``
+``expect(func, args=(%(shapes_)s), loc=0, lb=None, ub=None, conditional=False)``
     Expected value of a function (of one argument) with respect to the distribution.
 """
 _doc_median = """\
@@ -747,6 +747,10 @@ class rv_generic(object):
             shapes_vals = ()
         vals = ', '.join('%.3g' % val for val in shapes_vals)
         tempdict['vals'] = vals
+
+        tempdict['shapes_'] = self.shapes or ''
+        if self.shapes and self.numargs == 1:
+            tempdict['shapes_'] += ','
 
         if self.shapes:
             tempdict['set_vals_stmt'] = '>>> %s = %s' % (self.shapes, vals)
@@ -3186,7 +3190,7 @@ class rv_discrete(rv_generic):
         slowly, the accuracy of the result may be rather low. For instance, for
         ``zipf(4)``, accuracy for mean, variance in example is only 1e-5.
         increasing `maxcount` and/or `chunksize` may improve the result, but may also
-        makes zipf very slow.
+        make zipf very slow.
 
         The function is not vectorized.
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9,7 +9,7 @@ import sys
 
 from numpy.testing import (TestCase, run_module_suite, assert_equal,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
-    assert_allclose, assert_, assert_raises, rand, dec)
+    assert_allclose, assert_, assert_raises, assert_warns, rand, dec)
 from nose import SkipTest
 
 import numpy
@@ -1600,6 +1600,47 @@ class TestExpect(TestCase):
         assert_(np.isfinite(stats.rice.expect(lambda x: 1, args=(0.74,))))
         assert_(np.isfinite(stats.rice.expect(lambda x: 2, args=(0.74,))))
         assert_(np.isfinite(stats.rice.expect(lambda x: 3, args=(0.74,))))
+
+    def test_logser(self):
+        # test a discrete distribution with infinite support and loc
+        p, loc = 0.3, 3
+        res_0 = stats.logser.expect(lambda k: k, args=(p,))
+        # check against the correct answer (sum of a geom series)
+        assert_allclose(res_0,
+                        p / (p - 1.) / np.log(1. - p), atol=1e-15)
+
+        # now check it with `loc` 
+        res_l = stats.logser.expect(lambda k: k, args=(p,), loc=loc)
+        assert_allclose(res_l, res_0 + loc, atol=1e-15)
+
+    def test_skellam(self):
+        # Use a discrete distribution w/ bi-infinite support. Compute two first
+        # moments and compare to known values (cf skellam.stats)
+        p1, p2 = 18, 22
+        m1 = stats.skellam.expect(lambda x: x, args=(p1, p2))
+        m2 = stats.skellam.expect(lambda x: x**2, args=(p1, p2))
+        assert_allclose(m1, p1 - p2, atol=1e-12)
+        assert_allclose(m2 - m1**2, p1 + p2, atol=1e-12)
+
+    def test_randint(self):
+        # Use a discrete distribution w/ parameter-dependent support, which
+        # is larger than the default chunksize
+        lo, hi = 0, 113
+        res = stats.randint.expect(lambda x: x, (lo, hi))
+        assert_allclose(res,
+            sum(_ for _ in range(lo, hi)) / (hi - lo), atol=1e-15)
+
+    def test_zipf(self):
+        # Test that there is no infinite loop even if the sum diverges
+        assert_warns(RuntimeWarning, stats.zipf.expect,
+            lambda x: x**2, (2,))
+
+    def test_discrete_kwds(self):
+        # check that discrete expect accepts keywords to control the summation
+        n0 = stats.poisson.expect(lambda x: 1, args=(2,))
+        n1 = stats.poisson.expect(lambda x: 1, args=(2,),
+            maxcount=1001, chunksize=32, tolerance=1e-8)
+        assert_almost_equal(n0, n1, decimal=14)
 
 
 class TestNct(TestCase):


### PR DESCRIPTION
(This is a second version of https://github.com/scipy/scipy/pull/4488.)

This PR changes the summation in the expect method of discrete distributions:
- compute the sum in chunks (likely a bit faster and more accurate)
- expose parameters which control the summation as keyword args

Note that this somewhat changes the convergence criteria. Results in the test suite do not change, at least with the accuracy things are tested. 

closes gh-2197

What this PR does not do, it does not fix the issue with heavy-tailed distributions, notably zipf, https://github.com/scipy/scipy/issues/2983.

Also, while I'm looking at it, try to address gh-4858: the signature of `expect` in the docs was simply inconsistent with the actual signature. The latter is inconsistent with the calling conventions of all other methods of distributions in its handling of shape parameters. This discrepancy is a tad annoying, but I don't see a way of fixing it in a backwards-compatible way. Thus I'm just trying to fix the docs to match the actual signature.
