### PR TITLE
BLD: fix missing Python include for Homebrew builds.

### DIFF
--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -6,6 +6,7 @@ from os.path import join
 
 
 def configuration(parent_package='', top_path=None):
+    from distutils.sysconfig import get_python_inc
     from numpy.distutils.system_info import get_info, NotFoundError, numpy_info
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
     from scipy._build_utils import (get_sgemv_fix, get_g77_abi_wrappers,
@@ -136,7 +137,7 @@ def configuration(parent_package='', top_path=None):
     sources = ['_blas_subroutine_wrappers.f', '_lapack_subroutine_wrappers.f']
     sources += get_g77_abi_wrappers(lapack_opt)
     sources += get_sgemv_fix(lapack_opt)
-    includes = numpy_info().get_include_dirs()
+    includes = numpy_info().get_include_dirs() + [get_python_inc()]
     config.add_library('fwrappers', sources=sources, include_dirs=includes)
 
     config.add_extension('cython_blas',


### PR DESCRIPTION
Doesn't show up for older Homebrew installs because that didn't used to use
`distutils.cfg`.  Closes gh-5154.
