### PR TITLE
MAINT: fix cluster.hierarchy.dendrogram issues and docs

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1825,10 +1825,10 @@ def set_link_color_palette(palette):
 def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
                get_leaves=True, orientation='top', labels=None,
                count_sort=False, distance_sort=False, show_leaf_counts=True,
-               no_plot=False, no_labels=False, color_list=None,
-               leaf_font_size=None, leaf_rotation=None, leaf_label_func=None,
-               no_leaves=False, show_contracted=False,
-               link_color_func=None, ax=None, above_threshold_color='b'):
+               no_plot=False, no_labels=False, leaf_font_size=None,
+               leaf_rotation=None, leaf_label_func=None, no_leaves=False,
+               show_contracted=False, link_color_func=None, ax=None,
+               above_threshold_color='b'):
     """
     Plots the hierarchical clustering as a dendrogram.
 

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1676,11 +1676,10 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
         else:
             ax.set_xticks(iv_ticks)
 
-        # FIXME: this is implemented asymmetrically with left/right!
-        if orientation == 'top':
-            ax.xaxis.set_ticks_position('bottom')
-        else:
-            ax.xaxis.set_ticks_position('top')
+            if orientation == 'top':
+                ax.xaxis.set_ticks_position('bottom')
+            else:
+                ax.xaxis.set_ticks_position('top')
 
             # Make the tick marks invisible because they cover up the links
             for line in ax.get_xticklines():
@@ -1694,10 +1693,10 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
 
     elif orientation in ('left', 'right'):
         if orientation == 'left':
-            ax.set_xlim([0, dvw])
+            ax.set_xlim([dvw, 0])
             ax.set_ylim([0, ivw])
         else:
-            ax.set_xlim([dvw, 0])
+            ax.set_xlim([0, dvw])
             ax.set_ylim([0, ivw])
 
         xlines = dcoords
@@ -1707,7 +1706,12 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_yticklabels([])
         else:
             ax.set_yticks(iv_ticks)
-            ax.yaxis.set_ticks_position(orientation)
+
+            if orientation == 'left':
+                ax.yaxis.set_ticks_position('right')
+            else:
+                ax.yaxis.set_ticks_position('left')
+
             # Make the tick marks invisible because they cover up the links
             for line in ax.get_yticklines():
                 line.set_visible(False)

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1674,19 +1674,15 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
 
         lbls = ax.get_xticklabels()
         if leaf_rotation:
-            for lbl in lbls:
-                lbl.set_rotation(leaf_rotation)
+            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
         else:
             leaf_rot = float(_get_tick_rotation(len(ivl)))
-            for lbl in lbls:
-                lbl.set_rotation(leaf_rot)
+            map(lambda lbl: lbl.set_rotation(leaf_rot), lbls)
         if leaf_font_size:
-            for lbl in lbls:
-                lbl.set_size(leaf_font_size)
+            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
         else:
             leaf_fs = float(_get_tick_text_size(len(ivl)))
-            for lbl in lbls:
-                lbl.set_size(leaf_fs)
+            map(lambda lbl: lbl.set_size(leaf_fs), lbls)
 
         # Make the tick marks invisible because they cover up the links
         for line in ax.get_xticklines():
@@ -1705,20 +1701,16 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
 
         lbls = ax.get_xticklabels()
         if leaf_rotation:
-            for lbl in lbls:
-                lbl.set_rotation(leaf_rotation)
+            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
         else:
             leaf_rot = float(_get_tick_rotation(p))
-            for lbl in lbls:
-                lbl.set_rotation(leaf_rot)
+            map(lambda lbl: lbl.set_rotation(leaf_rot), lbls)
 
         if leaf_font_size:
-            for lbl in lbls:
-                lbl.set_size(leaf_font_size)
+            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
         else:
             leaf_fs = float(_get_tick_text_size(p))
-            for lbl in lbls:
-                lbl.set_size(leaf_fs)
+            map(lambda lbl: lbl.set_size(leaf_fs), lbls)
 
         ax.xaxis.set_ticks_position('top')
         # Make the tick marks invisible because they cover up the links
@@ -1738,11 +1730,9 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
 
         lbls = ax.get_yticklabels()
         if leaf_rotation:
-            for lbl in lbls:
-                lbl.set_rotation(leaf_rotation)
+            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
         if leaf_font_size:
-            for lbl in lbls:
-                lbl.set_size(leaf_font_size)
+            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
 
         ax.yaxis.set_ticks_position('left')
         # Make the tick marks invisible because they cover up the
@@ -1763,11 +1753,9 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
 
         lbls = ax.get_yticklabels()
         if leaf_rotation:
-            for lbl in lbls:
-                lbl.set_rotation(leaf_rotation)
+            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
         if leaf_font_size:
-            for lbl in lbls:
-                lbl.set_size(leaf_font_size)
+            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
 
         ax.yaxis.set_ticks_position('right')
         # Make the tick marks invisible because they cover up the links

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -834,6 +834,7 @@ class ClusterNode:
 
         return preorder
 
+
 _cnode_bare = ClusterNode(0)
 _cnode_type = type(ClusterNode)
 
@@ -860,7 +861,6 @@ def to_tree(Z, rd=False):
     Z : ndarray
         The linkage matrix in proper form (see the ``linkage``
         function documentation).
-
     rd : bool, optional
         When False, a reference to the root ClusterNode object is
         returned.  Otherwise, a tuple (r,d) is returned. ``r`` is a
@@ -876,13 +876,10 @@ def to_tree(Z, rd=False):
         The pre-order traversal.
 
     """
-
     Z = np.asarray(Z, order='c')
-
     is_valid_linkage(Z, throw=True, name='Z')
 
-    # The number of original objects is equal to the number of rows minus
-    # 1.
+    # Number of original objects is equal to the number of rows minus 1.
     n = Z.shape[0] + 1
 
     # Create a list full of None's to store the node objects
@@ -950,8 +947,7 @@ def cophenet(Z, Y=None):
     ----------
     Z : ndarray
         The hierarchical clustering encoded as an array
-        (see ``linkage`` function).
-
+        (see `linkage` function).
     Y : ndarray (optional)
         Calculates the cophenetic correlation coefficient ``c`` of a
         hierarchical clustering defined by the linkage matrix `Z`
@@ -969,13 +965,12 @@ def cophenet(Z, Y=None):
         original observations :math:`i` and :math:`j`.
 
     """
-
     Z = np.asarray(Z, order='c')
     is_valid_linkage(Z, throw=True, name='Z')
     Zs = Z.shape
     n = Zs[0] + 1
 
-    zz = np.zeros((n * (n - 1)) // 2, dtype=np.double)
+    zz = np.zeros((n * (n-1)) // 2, dtype=np.double)
     # Since the C code does not support striding using strides.
     # The dimensions are used instead.
     Z = _convert_to_double(Z)
@@ -992,14 +987,14 @@ def cophenet(Z, Y=None):
     Yy = Y - y
     Zz = zz - z
     numerator = (Yy * Zz)
-    denomA = Yy ** 2
-    denomB = Zz ** 2
+    denomA = Yy**2
+    denomB = Zz**2
     c = numerator.sum() / np.sqrt((denomA.sum() * denomB.sum()))
     return (c, zz)
 
 
 def inconsistent(Z, d=2):
-    """
+    r"""
     Calculates inconsistency statistics on a linkage.
 
     Note: This function behaves similarly to the MATLAB(TM)
@@ -1008,26 +1003,24 @@ def inconsistent(Z, d=2):
     Parameters
     ----------
     Z : ndarray
-        The :math:`(n-1)` by 4 matrix encoding the linkage
-        (hierarchical clustering).  See ``linkage`` documentation
-        for more information on its form.
+        The :math:`(n-1)` by 4 matrix encoding the linkage (hierarchical
+        clustering).  See `linkage` documentation for more information on its
+        form.
     d : int, optional
-        The number of links up to `d` levels below each
-        non-singleton cluster.
+        The number of links up to `d` levels below each non-singleton cluster.
 
     Returns
     -------
     R : ndarray
-        A :math:`(n-1)` by 5 matrix where the ``i``'th row
-        contains the link statistics for the non-singleton cluster
-        ``i``. The link statistics are computed over the link
-        heights for links :math:`d` levels below the cluster
-        ``i``. ``R[i,0]`` and ``R[i,1]`` are the mean and standard
-        deviation of the link heights, respectively; ``R[i,2]`` is
-        the number of links included in the calculation; and
-        ``R[i,3]`` is the inconsistency coefficient,
+        A :math:`(n-1)` by 5 matrix where the ``i``'th row contains the link
+        statistics for the non-singleton cluster ``i``. The link statistics are
+        computed over the link heights for links :math:`d` levels below the
+        cluster ``i``. ``R[i,0]`` and ``R[i,1]`` are the mean and standard
+        deviation of the link heights, respectively; ``R[i,2]`` is the number
+        of links included in the calculation; and ``R[i,3]`` is the
+        inconsistency coefficient,
 
-        .. math:: \\frac{\\mathtt{Z[i,2]}-\\mathtt{R[i,0]}} {R[i,1]}
+        .. math:: \frac{\mathtt{Z[i,2]} - \mathtt{R[i,0]}} {R[i,1]}
 
     """
     Z = np.asarray(Z, order='c')
@@ -1094,6 +1087,7 @@ def from_mlab_linkage(Z):
     Zpart = Z.copy()
     if Zpart[:, 0:2].min() != 1.0 and Zpart[:, 0:2].max() != 2 * Zs[0]:
         raise ValueError('The format of the indices is not 1..N')
+
     Zpart[:, 0:2] -= 1.0
     CS = np.zeros((Zs[0],), dtype=np.double)
     _hierarchy.calculate_cluster_sizes(Zpart, CS, int(Zs[0]) + 1)
@@ -1223,6 +1217,7 @@ def is_valid_im(R, warning=False, throw=False, name=None):
         if warning:
             _warning(str(e))
         valid = False
+
     return valid
 
 
@@ -1230,14 +1225,18 @@ def is_valid_linkage(Z, warning=False, throw=False, name=None):
     """
     Checks the validity of a linkage matrix.
 
-    A linkage matrix is valid if it is a two dimensional
-    ndarray (type double) with :math:`n`
-    rows and 4 columns.  The first two columns must contain indices
-    between 0 and :math:`2n-1`. For a given row ``i``,
-    :math:`0 \\leq \\mathtt{Z[i,0]} \\leq i+n-1`
-    and :math:`0 \\leq Z[i,1] \\leq i+n-1`
-    (i.e. a cluster cannot join another cluster unless the cluster
-    being joined has been generated.)
+    A linkage matrix is valid if it is a two dimensional array (type double)
+    with :math:`n` rows and 4 columns.  The first two columns must contain
+    indices between 0 and :math:`2n-1`. For a given row ``i``, the following
+    two expressions have to hold:
+
+    .. math::
+
+        0 \\leq \\mathtt{Z[i,0]} \\leq i+n-1
+        0 \\leq Z[i,1] \\leq i+n-1
+
+    I.e. a cluster cannot join another cluster unless the cluster being joined
+    has been generated.
 
     Parameters
     ----------
@@ -1256,7 +1255,7 @@ def is_valid_linkage(Z, warning=False, throw=False, name=None):
     Returns
     -------
     b : bool
-        True iff the inconsistency matrix is valid.
+        True if the inconsistency matrix is valid.
 
     """
     Z = np.asarray(Z, order='c')
@@ -1299,6 +1298,7 @@ def is_valid_linkage(Z, warning=False, throw=False, name=None):
         if warning:
             _warning(str(e))
         valid = False
+
     return valid
 
 
@@ -1421,11 +1421,10 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
 
               For example, to threshold on the maximum mean distance
               as computed in the inconsistency matrix R with a
-              threshold of 0.8 do:
+              threshold of 0.8 do::
 
-                MR = maxRstat(Z, R, 3)
-
-                cluster(Z, t=0.8, criterion='monocrit', monocrit=MR)
+                  MR = maxRstat(Z, R, 3)
+                  cluster(Z, t=0.8, criterion='monocrit', monocrit=MR)
 
           ``maxclust_monocrit`` : Forms a flat cluster from a
               non-singleton cluster node ``c`` when ``monocrit[i] <=
@@ -1434,11 +1433,10 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
               flat clusters are formed. monocrit must be
               monotonic. For example, to minimize the threshold t on
               maximum inconsistency values so that no more than 3 flat
-              clusters are formed, do:
+              clusters are formed, do::
 
-                MI = maxinconsts(Z, R)
-
-                cluster(Z, t=3, criterion='maxclust_monocrit', monocrit=MI)
+                  MI = maxinconsts(Z, R)
+                  cluster(Z, t=3, criterion='maxclust_monocrit', monocrit=MI)
 
     depth : int, optional
         The maximum depth to perform the inconsistency calculation.
@@ -1451,7 +1449,7 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
         statistics upon which non-singleton i is thresholded. The
         monocrit vector must be monotonic, i.e. given a node c with
         index i, for all node indices j corresponding to nodes
-        below c, `monocrit[i] >= monocrit[j]`.
+        below c, ``monocrit[i] >= monocrit[j]``.
 
     Returns
     -------
@@ -1645,7 +1643,9 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
         import matplotlib.patches
         import matplotlib.collections
     except ImportError:
-        raise ImportError("You must install the matplotlib library to plot the dendrogram. Use no_plot=True to calculate the dendrogram without plotting.")
+        raise ImportError("You must install the matplotlib library to plot "
+                          "the dendrogram. Use no_plot=True to calculate the "
+                          "dendrogram without plotting.")
 
     if ax is None:
         ax = matplotlib.pylab.gca()
@@ -1656,7 +1656,7 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
 
     # Independent variable plot width
     ivw = len(ivl) * 10
-    # Depenendent variable plot height
+    # Dependent variable plot height
     dvw = mh + mh * 0.05
     ivticks = np.arange(5, len(ivl) * 10 + 5, 10)
     if orientation == 'top':
@@ -1675,8 +1675,10 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             for line in ax.get_xticklines():
                 line.set_visible(False)
 
-            leaf_rot = float(_get_tick_rotation(len(ivl))) if (leaf_rotation is None) else leaf_rotation
-            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
+            leaf_rot = float(_get_tick_rotation(len(ivl))) if (
+                                    leaf_rotation is None) else leaf_rotation
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (
+                                    leaf_font_size is None) else leaf_font_size
             ax.set_xticklabels(ivl, rotation=leaf_rot, size=leaf_font)
     elif orientation == 'bottom':
         ax.set_ylim([dvw, 0])
@@ -1694,8 +1696,10 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             for line in ax.get_xticklines():
                 line.set_visible(False)
 
-            leaf_rot = float(_get_tick_rotation(len(ivl))) if (leaf_rotation is None) else leaf_rotation
-            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
+            leaf_rot = float(_get_tick_rotation(len(ivl))) if (
+                                    leaf_rotation is None) else leaf_rotation
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (
+                                    leaf_font_size is None) else leaf_font_size
             ax.set_xticklabels(ivl, rotation=leaf_rot, size=leaf_font)
     elif orientation == 'left':
         ax.set_xlim([0, dvw])
@@ -1708,13 +1712,13 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
         else:
             ax.set_yticks(ivticks)
             ax.yaxis.set_ticks_position('left')
-            # Make the tick marks invisible because they cover up the
-            # links
+            # Make the tick marks invisible because they cover up the links
             for line in ax.get_yticklines():
                 line.set_visible(False)
 
-            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
-            
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (
+                                    leaf_font_size is None) else leaf_font_size
+
             if leaf_rotation is not None:
                 ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font)
             else:
@@ -1735,16 +1739,16 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             for line in ax.get_yticklines():
                 line.set_visible(False)
 
-            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
-            
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (
+                                    leaf_font_size is None) else leaf_font_size
+
             if leaf_rotation is not None:
                 ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font)
             else:
                 ax.set_yticklabels(ivl, size=leaf_font)
 
-    # Let's use collections instead. This way there is a separate legend
-    # item for each tree grouping, rather than stupidly one for each line
-    # segment.
+    # Let's use collections instead. This way there is a separate legend item
+    # for each tree grouping, rather than stupidly one for each line segment.
     colors_used = _remove_dups(color_list)
     color_to_lines = {}
     for color in colors_used:
@@ -1760,7 +1764,6 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
         colors_to_collections[color] = coll
 
     # Add all the groupings below the color threshold.
-
     for color in colors_used:
         if color != above_threshold_color:
             ax.add_collection(colors_to_collections[color])
@@ -1789,6 +1792,7 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
 
     if trigger_redraw:
         matplotlib.pylab.draw_if_interactive()
+
 
 _link_line_colors = ['g', 'r', 'c', 'm', 'y', 'k']
 
@@ -2033,7 +2037,7 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
           Otherwise, it corresponds to a non-singleton cluster.
 
     """
-    # Features under consideration.
+    # This feature was thought about but never implemented (still useful?):
     #
     #         ... = dendrogram(..., leaves_order=None)
     #
@@ -2082,10 +2086,10 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
     else:
         ivl = []
 
-    if color_threshold is None or \
-       (isinstance(color_threshold, string_types) and
-                           color_threshold == 'default'):
+    if color_threshold is None or (isinstance(color_threshold, string_types) and
+                                   color_threshold == 'default'):
         color_threshold = max(Z[:, 2]) * 0.7
+
     R = {'icoord': icoord_list, 'dcoord': dcoord_list, 'ivl': ivl,
          'leaves': lvs, 'color_list': color_list}
     if show_contracted:
@@ -2103,9 +2107,13 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
         count_sort=count_sort,
         distance_sort=distance_sort,
         show_leaf_counts=show_leaf_counts,
-        i=2 * n - 2, iv=0.0, ivl=ivl, n=n,
+        i=2*n - 2,
+        iv=0.0,
+        ivl=ivl,
+        n=n,
         icoord_list=icoord_list,
-        dcoord_list=dcoord_list, lvs=lvs,
+        dcoord_list=dcoord_list,
+        lvs=lvs,
         current_color=current_color,
         color_list=color_list,
         currently_below_threshold=currently_below_threshold,
@@ -2414,6 +2422,7 @@ def _dendrogram_calculate_info(Z, p, truncate_mode,
         color_list.append(v)
     else:
         color_list.append(c)
+
     return (((uiva + uivb) / 2), uwa + uwb, h, max_dist)
 
 
@@ -2535,8 +2544,8 @@ def maxRstat(Z, R, i):
     Parameters
     ----------
     Z : array_like
-        The hierarchical clustering encoded as a matrix. See
-        ``linkage`` for more information.
+        The hierarchical clustering encoded as a matrix. See `linkage` for more
+        information.
     R : array_like
         The inconsistency matrix.
     i : int
@@ -2642,40 +2651,3 @@ def leaders(Z, T):
         raise ValueError(('T is not a valid assignment vector. Error found '
                           'when examining linkage node %d (< 2n-1).') % s)
     return (L, M)
-
-
-# These are test functions to help me test the leaders function.
-
-def _leaders_test(Z, T):
-    tr = to_tree(Z)
-    _leaders_test_recurs_mark(tr, T)
-    return tr
-
-
-def _leader_identify(tr, T):
-    if tr.is_leaf():
-        return T[tr.id]
-    else:
-        left = tr.get_left()
-        right = tr.get_right()
-        lfid = _leader_identify(left, T)
-        rfid = _leader_identify(right, T)
-        print('ndid: %d lid: %d lfid: %d rid: %d rfid: %d'
-              % (tr.get_id(), left.get_id(), lfid, right.get_id(), rfid))
-        if lfid != rfid:
-            if lfid != -1:
-                print('leader: %d with tag %d' % (left.id, lfid))
-            if rfid != -1:
-                print('leader: %d with tag %d' % (right.id, rfid))
-            return -1
-        else:
-            return lfid
-
-
-def _leaders_test_recurs_mark(tr, T):
-    if tr.is_leaf():
-        tr.asgn = T[tr.id]
-    else:
-        tr.asgn = -1
-        _leaders_test_recurs_mark(tr.left, T)
-        _leaders_test_recurs_mark(tr.right, T)

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2064,6 +2064,34 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
           ``i``-th leaf node corresponds to an original observation.
           Otherwise, it corresponds to a non-singleton cluster.
 
+    See Also
+    --------
+    linkage, set_link_color_palette
+
+    Examples
+    --------
+    >>> from scipy.cluster import hierarchy
+    >>> import matplotlib.pyplot as plt
+
+    A very basic example:
+
+    >>> ytdist = np.array([662., 877., 255., 412., 996., 295., 468., 268.,
+    ...                    400., 754., 564., 138., 219., 869., 669.])
+    >>> Z = hierarchy.linkage(ytdist, 'single')
+    >>> plt.figure()
+    >>> dn = hierarchy.dendrogram(Z)
+
+    Now plot in given axes, improve the color scheme and use both vertical and
+    horizontal orientations:
+
+    >>> hierarchy.set_link_color_palette(['m', 'c', 'y', 'k'])
+    >>> fig, axes = plt.subplots(1, 2, figsize=(8, 3))
+    >>> dn1 = hierarchy.dendrogram(Z, ax=axes[0], above_threshold_color='y',
+    ...                            orientation='top')
+    >>> dn2 = hierarchy.dendrogram(Z, ax=axes[1], above_threshold_color='#bcbddc',
+    ...                            orientation='right')
+    >>> plt.show()
+
     """
     # This feature was thought about but never implemented (still useful?):
     #

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1799,17 +1799,45 @@ _link_line_colors = ['g', 'r', 'c', 'm', 'y', 'k']
 
 def set_link_color_palette(palette):
     """
-    Set list of matplotlib color codes for dendrogram color_threshold.
+    Set list of matplotlib color codes for use by dendrogram.
+
+    Note that this palette is global (i.e. setting it once changes the colors
+    for all subsequent calls to `dendrogram`) and that it affects only the
+    the colors below ``color_threshold``.
+
+    Note that `dendrogram` also accepts a custom coloring function through its
+    ``link_color_func`` keyword, which is more flexible and non-global.
 
     Parameters
     ----------
-    palette : list
-        A list of matplotlib color codes. The order of
-        the color codes is the order in which the colors are cycled
-        through when color thresholding in the dendrogram.
+    palette : list of str
+        A list of matplotlib color codes.  The order of the color codes is the
+        order in which the colors are cycled through when color thresholding in
+        the dendrogram.
+
+    Returns
+    -------
+    None
+
+    Examples
+    --------
+    >>> from scipy.cluster import hierarchy
+    >>> ytdist = np.array([662., 877., 255., 412., 996., 295., 468., 268., 400.,
+    ...                    754., 564., 138., 219., 869., 669.])
+    >>> Z = hierarchy.linkage(ytdist, 'single')
+    >>> dn = hierarchy.dendrogram(Z, no_plot=True)
+    >>> dn['color_list']
+    ['g', 'b', 'b', 'b', 'b']
+    >>> hierarchy.set_link_color_palette(['c', 'm', 'y', 'k'])
+    >>> dn = hierarchy.dendrogram(Z, no_plot=True)
+    >>> dn['color_list']
+    ['c', 'b', 'b', 'b', 'b']
+    >>> dn = hierarchy.dendrogram(Z, no_plot=True, color_threshold=267,
+    ...                           above_threshold_color='k')
+    >>> dn['color_list']
+    ['c', 'm', 'm', 'k', 'k']
 
     """
-
     if type(palette) not in (list, tuple):
         raise TypeError("palette must be a list or tuple")
     _ptypes = [isinstance(p, string_types) for p in palette]

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1669,24 +1669,15 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_xticklabels([])
         else:
             ax.set_xticks(ivticks)
-            ax.set_xticklabels(ivl)
-        ax.xaxis.set_ticks_position('bottom')
+            ax.xaxis.set_ticks_position('bottom')
 
-        lbls = ax.get_xticklabels()
-        if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
-        else:
-            leaf_rot = float(_get_tick_rotation(len(ivl)))
-            map(lambda lbl: lbl.set_rotation(leaf_rot), lbls)
-        if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
-        else:
-            leaf_fs = float(_get_tick_text_size(len(ivl)))
-            map(lambda lbl: lbl.set_size(leaf_fs), lbls)
+            # Make the tick marks invisible because they cover up the links
+            for line in ax.get_xticklines():
+                line.set_visible(False)
 
-        # Make the tick marks invisible because they cover up the links
-        for line in ax.get_xticklines():
-            line.set_visible(False)
+            leaf_rot = float(_get_tick_rotation(len(ivl))) if (leaf_rotation is None) else leaf_rotation
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
+            ax.set_xticklabels(ivl, rotation=leaf_rot, size=leaf_font)
     elif orientation == 'bottom':
         ax.set_ylim([dvw, 0])
         ax.set_xlim([0, ivw])
@@ -1697,25 +1688,15 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_xticklabels([])
         else:
             ax.set_xticks(ivticks)
-            ax.set_xticklabels(ivl)
+            ax.xaxis.set_ticks_position('top')
 
-        lbls = ax.get_xticklabels()
-        if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
-        else:
-            leaf_rot = float(_get_tick_rotation(p))
-            map(lambda lbl: lbl.set_rotation(leaf_rot), lbls)
+            # Make the tick marks invisible because they cover up the links
+            for line in ax.get_xticklines():
+                line.set_visible(False)
 
-        if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
-        else:
-            leaf_fs = float(_get_tick_text_size(p))
-            map(lambda lbl: lbl.set_size(leaf_fs), lbls)
-
-        ax.xaxis.set_ticks_position('top')
-        # Make the tick marks invisible because they cover up the links
-        for line in ax.get_xticklines():
-            line.set_visible(False)
+            leaf_rot = float(_get_tick_rotation(len(ivl))) if (leaf_rotation is None) else leaf_rotation
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
+            ax.set_xticklabels(ivl, rotation=leaf_rot, size=leaf_font)
     elif orientation == 'left':
         ax.set_xlim([0, dvw])
         ax.set_ylim([0, ivw])
@@ -1726,19 +1707,19 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_yticklabels([])
         else:
             ax.set_yticks(ivticks)
-            ax.set_yticklabels(ivl)
+            ax.yaxis.set_ticks_position('left')
+            # Make the tick marks invisible because they cover up the
+            # links
+            for line in ax.get_yticklines():
+                line.set_visible(False)
 
-        lbls = ax.get_yticklabels()
-        if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
-        if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
+            
+            if leaf_rotation is not None:
+                ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font)
+            else:
+                ax.set_yticklabels(ivl, size=leaf_font)
 
-        ax.yaxis.set_ticks_position('left')
-        # Make the tick marks invisible because they cover up the
-        # links
-        for line in ax.get_yticklines():
-            line.set_visible(False)
     elif orientation == 'right':
         ax.set_xlim([dvw, 0])
         ax.set_ylim([0, ivw])
@@ -1749,18 +1730,17 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_yticklabels([])
         else:
             ax.set_yticks(ivticks)
-            ax.set_yticklabels(ivl)
+            ax.yaxis.set_ticks_position('right')
+            # Make the tick marks invisible because they cover up the links
+            for line in ax.get_yticklines():
+                line.set_visible(False)
 
-        lbls = ax.get_yticklabels()
-        if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
-        if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
-
-        ax.yaxis.set_ticks_position('right')
-        # Make the tick marks invisible because they cover up the links
-        for line in ax.get_yticklines():
-            line.set_visible(False)
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
+            
+            if leaf_rotation is not None:
+                ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font)
+            else:
+                ax.set_yticklabels(ivl, size=leaf_font)
 
     # Let's use collections instead. This way there is a separate legend
     # item for each tree grouping, rather than stupidly one for each line

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1820,7 +1820,7 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
                get_leaves=True, orientation='top', labels=None,
                count_sort=False, distance_sort=False, show_leaf_counts=True,
                no_plot=False, no_labels=False, leaf_font_size=None,
-               leaf_rotation=None, leaf_label_func=None, no_leaves=False,
+               leaf_rotation=None, leaf_label_func=None,
                show_contracted=False, link_color_func=None, ax=None,
                above_threshold_color='b'):
     """
@@ -2103,10 +2103,7 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
     color_list = []
     current_color = [0]
     currently_below_threshold = [False]
-    if no_leaves:
-        ivl = None
-    else:
-        ivl = []
+    ivl = []  # list of leaves
 
     if color_threshold is None or (isinstance(color_threshold, string_types) and
                                    color_threshold == 'default'):

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1780,14 +1780,25 @@ def set_link_color_palette(palette):
 
     Parameters
     ----------
-    palette : list of str
+    palette : list of str or None
         A list of matplotlib color codes.  The order of the color codes is the
         order in which the colors are cycled through when color thresholding in
         the dendrogram.
 
+        If ``None``, resets the palette to its default (which is
+        ``['g', 'r', 'c', 'm', 'y', 'k']``).
+
     Returns
     -------
     None
+
+    See Also
+    --------
+    dendrogram
+
+    Notes
+    -----
+    Ability to reset the palette with ``None`` added in Scipy 0.17.0.
 
     Examples
     --------
@@ -1807,8 +1818,15 @@ def set_link_color_palette(palette):
     >>> dn['color_list']
     ['c', 'm', 'm', 'k', 'k']
 
+    Now reset the color palette to its default:
+
+    >>> hierarchy.set_link_color_palette(None)
+
     """
-    if type(palette) not in (list, tuple):
+    if palette is None:
+        # reset to its default
+        palette = ['g', 'r', 'c', 'm', 'y', 'k']
+    elif type(palette) not in (list, tuple):
         raise TypeError("palette must be a list or tuple")
     _ptypes = [isinstance(p, string_types) for p in palette]
 
@@ -2060,6 +2078,7 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
     ...                            orientation='top')
     >>> dn2 = hierarchy.dendrogram(Z, ax=axes[1], above_threshold_color='#bcbddc',
     ...                            orientation='right')
+    >>> hierarchy.set_link_color_palette(None)  # reset to default after use
     >>> plt.show()
 
     """

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -853,6 +853,9 @@ class TestDendrogram(object):
         color_list = R['color_list']
         assert_equal(color_list, ['c', 'm', 'g', 'g', 'g'])
 
+        # reset color palette (global list)
+        set_link_color_palette(None)
+
 
 def calculate_maximum_distances(Z):
     # Used for testing correctness of maxdists.


### PR DESCRIPTION
The first commit is gh-4920 (squashed) from @jamestwebber. The rest:
- BUG: dendrogram: fix reversal of left/right orientation
- MAINT: remove no_leaves kw from dendrogram. 
- MAINT: refactor cluster.hierarchy.dendrogram, reduce code duplication.
- DOC: add example to cluster.hierarchy.dendrogram docstring. 
- DOC: fix up docstring of cluster.hierarchy.set_link_color_palette.
- BUG: dendrogram: remove color_list kw from signature, it doesn't belong there. 
- STY: style changes and cleanups in cluster/hierarchy.py

Visual appearance is hard to test, therefore I created a notebook which exercises a lot of the options:
https://gist.github.com/rgommers/7d923b96884d3dbd9265
http://nbviewer.ipython.org/gist/rgommers/7d923b96884d3dbd9265

Supercedes gh-4920, closes gh-5163, gh-3822, gh-4926.

The backwards incompatible changes are the removal of the `color_list` and `no_leaves` keywords, but those should both be considered bugs.
