### PR TITLE
Clarify metric parameter in linkage docstring

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -605,9 +605,11 @@ def linkage(y, method='single', metric='euclidean'):
         The linkage algorithm to use. See the ``Linkage Methods`` section below
         for full descriptions.
     metric : str or function, optional
-        The distance metric to use. See the ``distance.pdist`` function for a
-        list of valid distance metrics. The customized distance can also be
-        used. See the ``distance.pdist`` function for details.
+        The distance metric to use in the case that y is a collection of 
+        observation vectors; ignored otherwise. See the ``distance.pdist``
+        function for a list of valid distance metrics. A custom distance
+        function can also be used. See the ``distance.pdist`` function for
+        details.
 
     Returns
     -------


### PR DESCRIPTION
- Make clear that the metric parameter is only used in the case that linkages has been passed
  a collection of observation vectors and is ignored otherwise.
- Change "the customized distance function" (which wrongly implies there is a specific function)
  to "a custom distance function"

This change is motivated by my confusion on why there seemed to be two possible custom distance functions in the linkage workflow, as indicated by [this Stack Overfow question](http://stackoverflow.com/questions/32059711/in-scipy-whats-the-point-of-the-two-different-distance-functions-used-in-hiera) I asked. I had to inspect the source to understand what was going on. Hopefully this documentation clarification will prevent confusion for others.
