### PR TITLE
EHN: Make primary diag the default for sparse.diags

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -61,7 +61,7 @@ def spdiags(data, diags, m, n, format=None):
     return dia_matrix((data, diags), shape=(m,n)).asformat(format)
 
 
-def diags(diagonals, offsets=None, shape=None, format=None, dtype=None):
+def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
     """
     Construct a sparse matrix from diagonals.
 
@@ -70,7 +70,7 @@ def diags(diagonals, offsets=None, shape=None, format=None, dtype=None):
     diagonals : sequence of array_like
         Sequence of arrays containing the matrix diagonals,
         corresponding to `offsets`.
-    offsets : sequence of int, optional
+    offsets : sequence of int or an int, optional
         Diagonals to set:
           - k = 0  the main diagonal (default)
           - k > 0  the k-th upper diagonal
@@ -133,10 +133,6 @@ def diags(diagonals, offsets=None, shape=None, format=None, dtype=None):
            [ 0.,  0.,  0.,  3.],
            [ 0.,  0.,  0.,  0.]])
     """
-    # assume the primary diagonal was the intended diagonal
-    if offsets is None:
-        offsets = 0
-
     # if offsets is not a sequence, assume that there's only one diagonal
     try:
         iter(offsets)

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -61,7 +61,7 @@ def spdiags(data, diags, m, n, format=None):
     return dia_matrix((data, diags), shape=(m,n)).asformat(format)
 
 
-def diags(diagonals, offsets, shape=None, format=None, dtype=None):
+def diags(diagonals, offsets=None, shape=None, format=None, dtype=None):
     """
     Construct a sparse matrix from diagonals.
 
@@ -70,9 +70,9 @@ def diags(diagonals, offsets, shape=None, format=None, dtype=None):
     diagonals : sequence of array_like
         Sequence of arrays containing the matrix diagonals,
         corresponding to `offsets`.
-    offsets : sequence of int
+    offsets : sequence of int, optional
         Diagonals to set:
-          - k = 0  the main diagonal
+          - k = 0  the main diagonal (default)
           - k > 0  the k-th upper diagonal
           - k < 0  the k-th lower diagonal
     shape : tuple of int, optional
@@ -133,6 +133,10 @@ def diags(diagonals, offsets, shape=None, format=None, dtype=None):
            [ 0.,  0.,  0.,  3.],
            [ 0.,  0.,  0.,  0.]])
     """
+    # assume the primary diagonal was the intended diagonal
+    if offsets is None:
+        offsets = 0
+
     # if offsets is not a sequence, assume that there's only one diagonal
     try:
         iter(offsets)

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -131,6 +131,14 @@ class TestConstructUtils(TestCase):
                 print("%r %r %r" % (d, o, shape))
                 raise
 
+    def test_diags_default(self):
+        a = array([1, 2, 3, 4, 5])
+        assert_equal(construct.diags(a).todense(), np.diag(a))
+
+    def test_diags_default_bad(self):
+        a = array([[1, 2, 3, 4, 5], [2, 3, 4, 5, 6]])
+        assert_raises(ValueError, construct.diags, a)
+
     def test_diags_bad(self):
         a = array([1, 2, 3, 4, 5])
         b = array([6, 7, 8, 9, 10])


### PR DESCRIPTION
`numpy.diag` picks the primary diagonal by default if the second
argument is not provided. `scipy.sparse.diags` now mimics that
behaviour.
