### PR TITLE
MAINT: stats: tweak the formula for ncx2.pdf

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2088,6 +2088,16 @@ def test_ncx2_tails_ticket_955():
     assert_allclose(a, b, rtol=1e-3, atol=0)
 
 
+def test_ncx2_tails_pdf():
+    # ncx2.pdf does not return nans in extreme tails(example from gh-1577)
+    # NB: this is to check that nan_to_num is not needed in ncx2.pdf
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        assert_equal(stats.ncx2.pdf(1, np.arange(340, 350), 2), 0)
+        logval = stats.ncx2.logpdf(1, np.arange(340, 350), 2)
+        assert_(np.isneginf(logval).all())
+
+
 def test_foldnorm_zero():
     # Parameter value c=0 was not enabled, see gh-2399.
     rv = stats.foldnorm(0, scale=1)


### PR DESCRIPTION
Simplify the formula for `ncx2.pdf`. In master, it uses hyp0f1 which overflows at large values of the argument, (see https://github.com/scipy/scipy/issues/1577), and ncx2 has to use nan_to_num.

This PR rewrites the pdf in terms of the modified Bessel function, and nan_to_num is no longer needed. 
