### PR TITLE
ENH: Port upfirdn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,7 @@ scipy/optimize/slsqp/_slsqpmodule.c
 scipy/optimize/_lsq/givens_elimination.c
 scipy/signal/_spectral.c
 scipy/signal/_max_len_seq_inner.c
+scipy/signal/_upfirdn_apply.c
 scipy/signal/correlate_nd.c
 scipy/signal/lfilter.c
 scipy/sparse/_csparsetools.c

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -66,6 +66,7 @@ Filtering
    decimate      -- Downsample a signal.
    detrend       -- Remove linear and/or constant trends from data.
    resample      -- Resample using Fourier method.
+   upfirdn       -- Upsample, apply FIR filter, downsample.
 
 Filter design
 =============
@@ -274,6 +275,7 @@ from __future__ import division, print_function, absolute_import
 from . import sigtools
 from .waveforms import *
 from ._max_len_seq import max_len_seq
+from ._upfirdn import upfirdn
 
 # The spline module (a C extension) provides:
 #     cspline2d, qspline2d, sepfir2d, symiirord1, symiirord2

--- a/scipy/signal/_upfirdn.py
+++ b/scipy/signal/_upfirdn.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+
+# Code adapted from "upfirdn" python library with permission:
+#
+# Copyright (c) 2009, Motorola, Inc
+#
+# All Rights Reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of Motorola nor the names of its contributors may be
+# used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
+
+from ._upfirdn_apply import UpFIRDown, _output_len
+
+
+def upfirdn(x, h, up=1, down=1, axis=-1):
+    """Upsample, FIR filter, and downsample
+
+    Parameters
+    ----------
+    x : array-like
+        Input signal array.
+    h : array-like
+        1-dimensional FIR (finite-impulse response) filter coefficients.
+    up : int
+        Upsampling rate.
+    down : int
+        Downsampling rate.
+    axis : int
+        The axis of ``x`` to operate along.
+
+    Returns
+    -------
+    y : ndarray
+        The output signal array. Dimensions will be the same as ``x`` except
+        for along ``axis``, which will change size according to the ``h``,
+        ``up``,  and ``down`` parameters.
+
+    Notes
+    -----
+    The algorithm is an implementation of the block diagram shown on page 129
+    of the Vaidyanathan text [1]_ (Figure 4.3-8d).
+
+    .. [1] P. P. Vaidyanathan, Multirate Systems and Filter Banks,
+       Prentice Hall, 1993.
+
+    The direct approach of upsampling by factor of P with zero insertion,
+    FIR filtering of length ``N``, and downsampling by factor of Q is
+    O(N*Q) per output sample. The polyphase implementation used here is
+    O(N/P).
+
+    .. versionadded:: 0.17
+
+    Examples
+    --------
+    Simple operations:
+
+    >>> from scipy.signal import upfirdn
+    >>> upfirdn([1,1,1], [1,1,1])   # FIR filter
+    array([ 1.,  2.,  3.,  2.,  1.])
+    >>> upfirdn([1, 2, 3], [1], 3)  # upsampling with zeros insertion
+    array([ 1.,  0.,  0.,  2.,  0.,  0.,  3.,  0.,  0.])
+    >>> upfirdn([1,2,3], [1,1,1], 3)  # upsampling with sample-and-hold
+    array([ 1.,  1.,  1.,  2.,  2.,  2.,  3.,  3.,  3.])
+    >>> upfirdn([1,1,1], [.5,1,.5], 2)  # linear interpolation
+    array([ 0.5,  1. ,  1. ,  1. ,  1. ,  1. ,  0.5,  0. ])
+    >>> upfirdn(np.arange(10), [1], 1, 3)  # decimation by 3
+    array([ 0.,  3.,  6.,  9.])
+    >>> upfirdn(np.arange(10), [.5,1,.5], 2, 3)  # linear interp, rate 2/3
+    array([ 0. ,  1. ,  2.5,  4. ,  5.5,  7. ,  8.5,  0. ])
+
+    Apply a single filter to multiple signals:
+
+    >>> x = np.reshape(np.arange(8), (4,2))
+    >>> x
+    array([[0, 1],
+           [2, 3],
+           [4, 5],
+           [6, 7]])
+
+    Apply along the last dimension of ``x``:
+
+    >>> h = [1, 1]
+    >>> upfirdn(x, h, 2)
+    array([[ 0.,  0.,  1.,  1.],
+           [ 2.,  2.,  3.,  3.],
+           [ 4.,  4.,  5.,  5.],
+           [ 6.,  6.,  7.,  7.]])
+
+    Apply along the 0th dimension of ``x``:
+
+    >>> upfirdn(x, h, 2, axis=0)
+    array([[ 0.,  1.],
+           [ 0.,  1.],
+           [ 2.,  3.],
+           [ 2.,  3.],
+           [ 4.,  5.],
+           [ 4.,  5.],
+           [ 6.,  7.],
+           [ 6.,  7.]])
+
+    """
+    ufd = UpFIRDown(h, up, down)
+    return np.apply_along_axis(ufd.apply, axis, x)

--- a/scipy/signal/_upfirdn_apply.pyx
+++ b/scipy/signal/_upfirdn_apply.pyx
@@ -39,24 +39,26 @@ import numpy as np
 
 
 ctypedef double complex double_complex
+ctypedef float complex float_complex
 
 ctypedef fused DTYPE_t:
+    # Eventually we could add "object", too, but then we'd lose the "nogil"
+    # on the _apply_impl function.
+    float
+    float_complex
     double
     double_complex
 
 
-@cython.cdivision(True)
-def _output_len(Py_ssize_t in_len,
+def _output_len(Py_ssize_t len_h,
+                Py_ssize_t in_len,
                 Py_ssize_t up,
-                Py_ssize_t down,
-                Py_ssize_t len_h):
+                Py_ssize_t down):
     """The output length that results from a given input"""
     cdef Py_ssize_t np
-    if len_h != 0:  # figure out what the padding needs to be
-        # the modulo below is the C-equivalent of a Python modulo,
-        # i.e. -1 % 10 = 9
-        in_len = in_len + (len_h + ((-len_h % up) + up) % up) // up - 1
-    np = in_len * up
+    cdef Py_ssize_t in_len_copy
+    in_len_copy = in_len + (len_h + (-len_h % up)) // up - 1
+    np = in_len_copy * up
     cdef Py_ssize_t need = np // down
     if np % down > 0:
         need += 1

--- a/scipy/signal/_upfirdn_apply.pyx
+++ b/scipy/signal/_upfirdn_apply.pyx
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+
+# Code adapted from "upfirdn" python library with permission:
+#
+# Copyright (c) 2009, Motorola, Inc
+#
+# All Rights Reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of Motorola nor the names of its contributors may be
+# used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+cimport cython
+cimport numpy as np
+import numpy as np
+
+
+def _pad_h(h, up):
+    """Store coefficients in a transposed, flipped arrangement.
+
+    For example, suppose upRate is 3, and the
+    input number of coefficients is 10, represented as h[0], ..., h[9].
+
+    Then the internal buffer will look like this::
+
+       h[9], h[6], h[3], h[0],   // flipped phase 0 coefs
+       0,    h[7], h[4], h[1],   // flipped phase 1 coefs (zero-padded)
+       0,    h[8], h[5], h[2],   // flipped phase 2 coefs (zero-padded)
+
+    """
+    h_padlen = len(h) + (-len(h) % up)
+    h_full = np.zeros(h_padlen)
+    h_full[:len(h)] = h
+    h_full = h_full.reshape(-1, up).T[:, ::-1].ravel()
+    return h_full
+
+
+class UpFIRDown(object):
+    def __init__(self, h, up, down):
+        """Helper for resampling"""
+        h = np.asarray(h, np.float64)
+        if h.ndim != 1 or h.size == 0:
+            raise ValueError('h must be 1D with non-zero length')
+        self._up = int(up)
+        self._down = int(down)
+        if self._up < 1 or self._down < 1:
+            raise RuntimeError('Both up and down must be >= 1')
+        # This both transposes, and "flips" each phase for filtering
+        self._h_trans_flip = _pad_h(h, self._up)
+
+    def _output_len(self, len_x):
+        """Helper to get the output length given an input length"""
+        return _output_len(len_x + len(self._h_trans_flip) // self._up - 1,
+                           self._up, self._down, 0)
+
+    def apply(self, x):
+        """Apply the prepared filter to a 1D signal x"""
+        out = np.zeros(self._output_len(len(x)), dtype=np.float64)
+        _apply(np.asarray(x, np.float64), self._h_trans_flip, out,
+               self._up, self._down)
+        return out
+
+
+@cython.cdivision(True)
+def _output_len(Py_ssize_t in_len,
+                Py_ssize_t up,
+                Py_ssize_t down,
+                Py_ssize_t len_h):
+    """The output length that results from a given input"""
+    cdef Py_ssize_t np
+    if len_h != 0:  # figure out what the padding needs to be
+        # the modulo below is the C-equivalent of a Python modulo,
+        # i.e. -1 % 10 = 9
+        in_len = in_len + (len_h + ((-len_h % up) + up) % up) // up - 1
+    np = in_len * up
+    cdef Py_ssize_t need = np // down
+    if np % down > 0:
+        need += 1
+    return need
+
+
+ctypedef fused DTYPE_t:
+    np.float64_t
+
+
+@cython.cdivision(True)  # faster modulo
+@cython.boundscheck(False)  # designed to stay within bounds
+@cython.wraparound(False)  # we don't use negative indexing
+cdef void _apply(DTYPE_t [:] x, DTYPE_t [:] h_trans_flip, DTYPE_t [:] out,
+                 Py_ssize_t up, Py_ssize_t down) nogil:
+    cdef Py_ssize_t len_x = x.shape[0]
+    cdef Py_ssize_t h_per_phase = h_trans_flip.shape[0] / up
+    cdef Py_ssize_t padded_len = len_x + h_per_phase - 1
+    cdef Py_ssize_t x_idx = 0
+    cdef Py_ssize_t y_idx = 0
+    cdef Py_ssize_t h_idx = 0
+    cdef Py_ssize_t t = 0
+    cdef Py_ssize_t x_conv_idx = 0
+
+    while x_idx < len_x:
+        h_idx = t * h_per_phase
+        x_conv_idx = x_idx - h_per_phase + 1
+        if x_conv_idx < 0:
+            h_idx -= x_conv_idx
+            x_conv_idx = 0
+        for x_conv_idx in range(x_conv_idx, x_idx + 1):
+            out[y_idx] += x[x_conv_idx] * h_trans_flip[h_idx]
+            h_idx += 1
+        # store and increment
+        y_idx += 1
+        t += down
+        x_idx += t / up  # integer div
+        # which phase of the filter to use
+        t = t % up
+
+    # Use a second simplified loop to flush out the last bits
+    while x_idx < padded_len:
+        h_idx = t * h_per_phase
+        x_conv_idx = x_idx - h_per_phase + 1
+        for x_conv_idx in range(x_conv_idx, x_idx + 1):
+            if x_conv_idx < len_x and x_conv_idx > 0:
+                out[y_idx] += x[x_conv_idx] * h_trans_flip[h_idx]
+            h_idx += 1
+        y_idx += 1
+        t += down
+        x_idx += t / up  # integer div
+        t = t % up

--- a/scipy/signal/bento.info
+++ b/scipy/signal/bento.info
@@ -12,6 +12,8 @@ Library:
         Sources: _spectral.c
     Extension: _max_len_seq_inner
         Sources: _max_len_seq_inner.c
+    Extension: _upfirdn_apply
+        Sources: _upfirdn_apply.c
     Extension: spline
         Sources:
             splinemodule.c,

--- a/scipy/signal/setup.py
+++ b/scipy/signal/setup.py
@@ -21,7 +21,7 @@ def configuration(parent_package='', top_path=None):
 
     config.add_extension('_spectral', sources=['_spectral.c'])
     config.add_extension('_max_len_seq_inner', sources=['_max_len_seq_inner.c'])
-
+    config.add_extension('_upfirdn_apply', sources=['_upfirdn_apply.c'])
     spline_src = ['splinemodule.c', 'S_bspline_util.c', 'D_bspline_util.c',
                   'C_bspline_util.c', 'Z_bspline_util.c', 'bspline_util.c']
     config.add_extension('spline', sources=spline_src, **numpy_nodepr_api)

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+
+# Code adapted from "upfirdn" python library with permission:
+#
+# Copyright (c) 2009, Motorola, Inc
+#
+# All Rights Reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of Motorola nor the names of its contributors may be
+# used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from scipy.signal._upfirdn import upfirdn, _output_len
+
+
+def upfirdn_naive(x, h, up=1, down=1):
+    """Naive upfirdn processing in Python"""
+    out = np.zeros(len(x) * up)
+    out[::up] = x
+    out = np.convolve(h, out)[::down][:_output_len(len(x), up, down, len(h))]
+    return out
+
+
+# Try some trivial cases first
+random_state = np.random.RandomState(17)
+
+
+class UpFIRDownCase(object):
+    """Test UpFIRDown object"""
+    def __init__(self, up, down, h):
+        self.up = up
+        self.down = down
+        self.h = h
+
+    def __call__(self):
+        self.scrub(np.ones(1))  # tiny signal
+        self.scrub(np.ones(100))  # ones
+        self.scrub(random_state.randn(100))  # randn
+        self.scrub(np.arange(100))  # ramp
+        x = random_state.randn(25, 50)
+        self.scrub(x, axis=0)
+        self.scrub(x, axis=1)
+
+    def scrub(self, x, axis=-1):
+        yr = np.apply_along_axis(upfirdn_naive, axis, x,
+                                 self.h, self.up, self.down)
+        y = upfirdn(x, self.h, self.up, self.down, axis=axis)
+        assert_allclose(yr, y)
+
+
+def test_upfirdn():
+    # some trivial cases
+    yield UpFIRDownCase(1, 1, [1.])
+    yield UpFIRDownCase(3, 2, [1.])
+    yield UpFIRDownCase(2, 3, [1.])
+    # mixture of big, small, and both directions (net up and net down)
+    for p_max, q_max in ((100, 100), (10, 100), (100, 10), (10, 10)):
+        for i in range(10):
+            p_add = q_max if p_max > q_max else 1
+            q_add = p_max if q_max > p_max else 1
+            p = random_state.randint(p_max) + p_add
+            q = random_state.randint(q_max) + q_add
+            len_h = random_state.randint(200) + 1
+            h = np.atleast_1d(random_state.randint(len_h))  # can be singleton
+            yield UpFIRDownCase(p, q, h)
+
+
+if __name__ == '__main__':
+    # Execute the test suite
+    for t in test_upfirdn():
+        t()

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Code adapted from "upfirdn" python library with permission:
 #
 # Copyright (c) 2009, Motorola, Inc
@@ -35,61 +33,109 @@
 
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal, assert_raises
 
-from scipy.signal._upfirdn import upfirdn, _output_len
+from scipy.signal import upfirdn
+from scipy.signal._upfirdn import _output_len
 
 
 def upfirdn_naive(x, h, up=1, down=1):
-    """Naive upfirdn processing in Python"""
-    out = np.zeros(len(x) * up)
+    """Naive upfirdn processing in Python
+
+    Note: arg order (x, h) differs to facilitate apply_along_axis use.
+    """
+    h = np.asarray(h)
+    out = np.zeros(len(x) * up, x.dtype)
     out[::up] = x
-    out = np.convolve(h, out)[::down][:_output_len(len(x), up, down, len(h))]
+    out = np.convolve(h, out)[::down][:_output_len(len(h), len(x), up, down)]
     return out
 
 
-# Try some trivial cases first
-random_state = np.random.RandomState(17)
-
-
-class UpFIRDownCase(object):
-    """Test UpFIRDown object"""
-    def __init__(self, up, down, h):
+class _UpFIRDnCase(object):
+    """Test _UpFIRDn object"""
+    def __init__(self, up, down, h, x_dtype):
         self.up = up
         self.down = down
-        self.h = h
+        self.h = np.atleast_1d(h)
+        self.x_dtype = x_dtype
+        self.rng = np.random.RandomState(17)
 
     def __call__(self):
-        self.scrub(np.ones(1))  # tiny signal
-        self.scrub(np.ones(100))  # ones
-        self.scrub(random_state.randn(100))  # randn
-        self.scrub(np.arange(100))  # ramp
-        x = random_state.randn(25, 50)
-        self.scrub(x, axis=0)
-        self.scrub(x, axis=1)
+        # tiny signal
+        self.scrub(np.ones(1, self.x_dtype))
+        # ones
+        self.scrub(np.ones(10, self.x_dtype))  # ones
+        # randn
+        x = self.rng.randn(10).astype(self.x_dtype)
+        if self.x_dtype in (np.complex64, np.complex128):
+            x += 1j * self.rng.randn(10)
+        self.scrub(x)
+        # ramp
+        self.scrub(np.arange(10).astype(self.x_dtype))
+        # 3D, random
+        size = (2, 3, 5)
+        x = self.rng.randn(*size).astype(self.x_dtype)
+        if self.x_dtype in (np.complex64, np.complex128):
+            x += 1j * self.rng.randn(*size)
+        for axis in range(len(size)):
+            self.scrub(x, axis=axis)
+        x = x[:, ::2, 1::3].T
+        for axis in range(len(size)):
+            self.scrub(x, axis=axis)
 
     def scrub(self, x, axis=-1):
         yr = np.apply_along_axis(upfirdn_naive, axis, x,
                                  self.h, self.up, self.down)
-        y = upfirdn(x, self.h, self.up, self.down, axis=axis)
+        y = upfirdn(self.h, x, self.up, self.down, axis=axis)
+        dtypes = (self.h.dtype, x.dtype)
+        if all(d == np.complex64 for d in dtypes):
+            assert_equal(y.dtype, np.complex64)
+        elif np.complex64 in dtypes and np.float32 in dtypes:
+            assert_equal(y.dtype, np.complex64)
+        elif all(d == np.float32 for d in dtypes):
+            assert_equal(y.dtype, np.float32)
+        elif np.complex128 in dtypes or np.complex64 in dtypes:
+            assert_equal(y.dtype, np.complex128)
+        else:
+            assert_equal(y.dtype, np.float64)
         assert_allclose(yr, y)
 
 
 def test_upfirdn():
-    # some trivial cases
-    yield UpFIRDownCase(1, 1, [1.])
-    yield UpFIRDownCase(3, 2, [1.])
-    yield UpFIRDownCase(2, 3, [1.])
-    # mixture of big, small, and both directions (net up and net down)
-    for p_max, q_max in ((100, 100), (10, 100), (100, 10), (10, 10)):
-        for i in range(10):
-            p_add = q_max if p_max > q_max else 1
-            q_add = p_max if q_max > p_max else 1
-            p = random_state.randint(p_max) + p_add
-            q = random_state.randint(q_max) + q_add
-            len_h = random_state.randint(200) + 1
-            h = np.atleast_1d(random_state.randint(len_h))  # can be singleton
-            yield UpFIRDownCase(p, q, h)
+    """Test upfirdn"""
+    big, small = 100, 10  # up/down factors
+    longest_h = 25
+    n_rep = 3
+    try_types = (int, np.float32, np.complex64, float, complex)
+    random_state = np.random.RandomState(17)
+    for x_dtype in try_types:
+        # some trivial cases
+        for h in (1., 1j):
+            yield _UpFIRDnCase(1, 1, h, x_dtype)
+            yield _UpFIRDnCase(2, 2, h, x_dtype)
+            yield _UpFIRDnCase(3, 2, h, x_dtype)
+            yield _UpFIRDnCase(2, 3, h, x_dtype)
+        for h_dtype in try_types:
+            # mixture of big, small, and both directions (net up and net down)
+            for p_max, q_max in ((big, big),
+                                 (small, big),
+                                 (big, small),
+                                 (small, small)):
+                for _ in range(n_rep):
+                    p_add = q_max if p_max > q_max else 1
+                    q_add = p_max if q_max > p_max else 1
+                    p = random_state.randint(p_max) + p_add
+                    q = random_state.randint(q_max) + q_add
+                    len_h = random_state.randint(longest_h) + 1
+                    h = np.atleast_1d(random_state.randint(len_h))
+                    h = h.astype(h_dtype)
+                    if h_dtype == complex:
+                        h += 1j * random_state.randint(len_h)
+                    yield _UpFIRDnCase(p, q, h, x_dtype)
+    # Degenerate cases
+    assert_raises(ValueError, upfirdn, [1], [1], 1, 0)  # up or down < 1
+    assert_raises(ValueError, upfirdn, [], [1], 1, 1)  # h.ndim != 1
+    assert_raises(ValueError, upfirdn, [[1]], [1], 1, 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
PR to eventually add `upfirdn` polyphase filtering to scipy. Built off of BSD-licensed `upfirdn` Python package:

https://code.google.com/p/upfirdn/

Eventually this polyphase filtering approach be used to hopefully speed up resampling.

Opening WIP PR to get some feedback on how to `scipy`-ify this code. It **will not run as is**.

The original code used (and still uses) SWIG to compile C++ to `.so`. I don't really see that done anywhere else in `scipy`, so I'm assuming that's the wrong way to go. Should I change the code over to C instead? If so, right now it supports real and complex signals and filters -- should I make different functions for the four different combinations of inputs (RR, CR, RC, CC), or is there another approach I should follow (e.g., a nice example of "the right thing to do")? We could also just do RR for now, and leave the other cases for future work.

Let me know if I should put this to the `scipy-dev` listserv instead.

cc the original author @sirtom67, thanks for writing what appears to be very clear code!
