### PR TITLE
BUG: fix uninitialized use in lartg

### DIFF
--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -132,8 +132,10 @@ cdef inline void lartg(blas_t* a, blas_t* b, blas_t* c, blas_t* s) nogil:
     elif blas_t is double:
         lapack_pointers.dlartg(a, b, c, s, &g)
     elif blas_t is float_complex:
+        c[0] = 0. # init imag
         lapack_pointers.clartg(a, b, <float*>c, s, &g)
     else:
+        c[0] = 0. # init imag
         lapack_pointers.zlartg(a, b, <double*>c, s, &g)
     # make this function more like the BLAS drotg
     a[0] = g


### PR DESCRIPTION
lartg returns the cosine as a double leaving the imaginary part
uninitialized while the code assumes it is a valid complex number.
Fix this by initializing the number. This fixes test failures on i386
and removes a bunch of valgrind errors.
