### PR TITLE
TST: Fix TestCtypesQuad failure on Python 3.5 for Windows

### DIFF
--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -34,7 +34,10 @@ class TestCtypesQuad(TestCase):
     @dec.skipif(_ctypes_missing, msg="Ctypes library could not be found")
     def setUp(self):
         if sys.platform == 'win32':
-            file = ctypes.util.find_msvcrt()
+            if sys.version_info < (3, 5):
+                file = ctypes.util.find_msvcrt()
+            else:
+                file = 'api-ms-win-crt-math-l1-1-0.dll'
         elif sys.platform == 'darwin':
             file = 'libm.dylib'
         else:


### PR DESCRIPTION
This fixes two test errors on Python 3.5 for Windows. 

Python 3.5 is now using the Universal CRT. `ctypes.util.find_msvcrt()` returns None. See http://bugs.python.org/issue23606. 

Please backport to 0.16.x.

```
======================================================================
ERROR: test_improvement (test_quadpack.TestCtypesQuad)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python35\lib\site-packages\numpy\testing\decorators.py", line 146, in skipper_func
    return f(*args, **kwargs)
  File "X:\Python35\lib\site-packages\scipy\integrate\tests\test_quadpack.py", line 42, in setUp
    self.lib = ctypes.CDLL(file)
  File "X:\Python35\lib\ctypes\__init__.py", line 347, in __init__
    self._handle = _dlopen(self._name, mode)
TypeError: bad argument type for built-in operation

======================================================================
ERROR: test_typical (test_quadpack.TestCtypesQuad)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python35\lib\site-packages\numpy\testing\decorators.py", line 146, in skipper_func
    return f(*args, **kwargs)
  File "X:\Python35\lib\site-packages\scipy\integrate\tests\test_quadpack.py", line 42, in setUp
    self.lib = ctypes.CDLL(file)
  File "X:\Python35\lib\ctypes\__init__.py", line 347, in __init__
    self._handle = _dlopen(self._name, mode)
TypeError: bad argument type for built-in operation
```
