### PR TITLE
allow extrapolation in interp1d 

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -2,10 +2,6 @@
 """
 from __future__ import division, print_function, absolute_import
 
-__all__ = ['interp1d', 'interp2d', 'spline', 'spleval', 'splmake', 'spltopp',
-           'ppform', 'lagrange', 'PPoly', 'BPoly', 'RegularGridInterpolator',
-           'interpn']
-
 import itertools
 
 from numpy import (shape, sometrue, array, transpose, searchsorted,
@@ -29,6 +25,11 @@ from .polyint import _Interpolator1D
 from . import _ppoly
 from .fitpack2 import RectBivariateSpline
 from .interpnd import _ndim_coords_from_arrays
+
+
+__all__ = ['interp1d', 'interp2d', 'spline', 'spleval', 'splmake', 'spltopp',
+           'ppform', 'lagrange', 'PPoly', 'BPoly', 'RegularGridInterpolator',
+           'interpn']
 
 
 def reduce_sometrue(a):
@@ -1474,8 +1475,8 @@ class BPoly(_PPolyBase):
             raise ValueError('ya and yb have incompatible dimensions.')
 
         dta, dtb = ya.dtype, yb.dtype
-        if (np.issubdtype(dta, np.complexfloating)
-               or np.issubdtype(dtb, np.complexfloating)):
+        if (np.issubdtype(dta, np.complexfloating) or
+               np.issubdtype(dtb, np.complexfloating)):
             dt = np.complex_
         else:
             dt = np.float_
@@ -1658,8 +1659,8 @@ class RegularGridInterpolator(object):
         self.fill_value = fill_value
         if fill_value is not None:
             fill_value_dtype = np.asarray(fill_value).dtype
-            if (hasattr(values, 'dtype')
-                    and not np.can_cast(fill_value_dtype, values.dtype,
+            if (hasattr(values, 'dtype') and not
+                    np.can_cast(fill_value_dtype, values.dtype,
                                         casting='same_kind')):
                 raise ValueError("fill_value must be either 'None' or "
                                  "of a type compatible with values")

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -372,17 +372,23 @@ class interp1d(_Interpolator1D):
     """
 
     def __init__(self, x, y, kind='linear', axis=-1,
-                 copy=True, bounds_error=True, fill_value=np.nan,
+                 copy=True, bounds_error=None, fill_value=np.nan,
                  assume_sorted=False):
         """ Initialize a 1D linear interpolation class."""
         _Interpolator1D.__init__(self, x, y, axis=axis)
 
-        self.copy = copy
-        self.bounds_error = bounds_error
         # extrapolation only works for nearest neighbor method
         if fill_value == "extrapolate" and kind != 'nearest':
             raise ValueError("Extrapolation only works with method 'nearest'.")
 
+        if fill_value == 'extrapolate' and bounds_error:
+            raise ValueError("Cannot extrapolate and raise at the same time.")
+
+        if bounds_error is None:
+            bounds_error = True
+        self.bounds_error = bounds_error
+
+        self.copy = copy
         self.fill_value = fill_value
 
         if kind in ['zero', 'slinear', 'quadratic', 'cubic']:

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -377,12 +377,15 @@ class interp1d(_Interpolator1D):
         """ Initialize a 1D linear interpolation class."""
         _Interpolator1D.__init__(self, x, y, axis=axis)
 
-        # extrapolation only works for nearest neighbor method
-        if fill_value == "extrapolate" and kind != 'nearest':
-            raise ValueError("Extrapolation only works with method 'nearest'.")
+        # extrapolation only works for nearest neighbor and linear methods
+        if fill_value == "extrapolate":       
+            if kind not in ('nearest', 'linear'):
+                raise ValueError("Extrapolation does not work with "
+                                 "kind=%s" % kind)
 
-        if fill_value == 'extrapolate' and bounds_error:
-            raise ValueError("Cannot extrapolate and raise at the same time.")
+            if bounds_error:
+                raise ValueError("Cannot extrapolate and raise at the same time.")
+            bounds_error = False
 
         if bounds_error is None:
             bounds_error = True

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -336,12 +336,13 @@ class interp1d(_Interpolator1D):
         If True, a ValueError is raised any time interpolation is attempted on
         a value outside of the range of x (where extrapolation is
         necessary). If False, out of bounds values are assigned `fill_value`.
-        By default, an error is raised.
-    fill_value : float or str, optional
+        By default, an error is raised unless `fill_value="extrapolate"`.
+    fill_value : float or "extrapolate", optional
         If provided, then this value will be used to fill in for requested
         points outside of the data range. If not provided, then the default
-        is NaN. For kind 'nearest' this value can be set to 'extrapolate' then
-        points outside the data range will be extrapolated.
+        is NaN.
+        If "extrapolate", then points outside the data range will be
+        extrapolated. ("nearest" and "linear" kinds only.)
     assume_sorted : bool, optional
         If False, values of `x` can be in any order and they are sorted first.
         If True, `x` has to be an array of monotonically increasing values.

--- a/scipy/interpolate/ndgriddata.py
+++ b/scipy/interpolate/ndgriddata.py
@@ -197,6 +197,8 @@ def griddata(points, values, xi, method='linear', fill_value=np.nan,
         idx = np.argsort(points)
         points = points[idx]
         values = values[idx]
+        if method == 'nearest':
+            fill_value = 'extrapolate'
         ip = interp1d(points, values, kind=method, axis=0, bounds_error=False,
                       fill_value=fill_value)
         return ip(xi)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -227,6 +227,17 @@ class TestInterp1D(object):
         assert_array_almost_equal(interp10([2.4, 5.6, 6.0]),
                                   np.array([2., 6., 6.]),)
 
+        # test fill_value="extrapolate"
+        extrapolator = interp1d(self.x10, self.y10, kind='nearest',
+                                fill_value='extrapolate')
+        assert_allclose(extrapolator([-1., 0, 9, 11]),
+                        [0, 0, 9, 9], rtol=1e-14)
+
+        opts = dict(kind='nearest',
+                    fill_value='extrapolate',
+                    bounds_error=True)
+        assert_raises(ValueError, interp1d, self.x10, self.y10, **opts)
+
     @dec.knownfailureif(True, "zero-order splines fail for the last point")
     def test_zero(self):
         # Check the actual implementation of zero-order spline interpolation.

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -131,14 +131,14 @@ class TestInterp1D(object):
         interp1d(self.x10, self.y10, kind='zero')
         interp1d(self.x10, self.y10, kind='nearest')
         interp1d(self.x10, self.y10, kind='nearest', fill_value="extrapolate")
+        interp1d(self.x10, self.y10, kind='linear', fill_value="extrapolate")
         interp1d(self.x10, self.y10, kind=0)
         interp1d(self.x10, self.y10, kind=1)
         interp1d(self.x10, self.y10, kind=2)
         interp1d(self.x10, self.y10, kind=3)
 
-        # extrapolation only allowed for nearest method
-        for kind in ('linear', 'cubic',
-                     'slinear', 'zero', 'quadratic'):
+        # extrapolation is only allowed for nearest & linear methods
+        for kind in ('cubic', 'slinear', 'zero', 'quadratic'):
             assert_raises(ValueError, interp1d, self.x10, self.y10, kind=kind,
                           fill_value="extrapolate")
 
@@ -210,6 +210,17 @@ class TestInterp1D(object):
         assert_array_almost_equal(interp10(1.2), np.array([1.2]))
         assert_array_almost_equal(interp10([2.4, 5.6, 6.0]),
                                   np.array([2.4, 5.6, 6.0]))
+
+        # test fill_value="extrapolate"
+        extrapolator = interp1d(self.x10, self.y10, kind='linear',
+                                fill_value='extrapolate')
+        assert_allclose(extrapolator([-1., 0, 9, 11]),
+                        [-1, 0, 9, 11], rtol=1e-14)
+
+        opts = dict(kind='linear',
+                    fill_value='extrapolate',
+                    bounds_error=True)
+        assert_raises(ValueError, interp1d, self.x10, self.y10, **opts)
 
     def test_cubic(self):
         # Check the actual implementation of spline interpolation.

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -130,10 +130,17 @@ class TestInterp1D(object):
         interp1d(self.x10, self.y10, kind='quadratic')
         interp1d(self.x10, self.y10, kind='zero')
         interp1d(self.x10, self.y10, kind='nearest')
+        interp1d(self.x10, self.y10, kind='nearest', fill_value="extrapolate")
         interp1d(self.x10, self.y10, kind=0)
         interp1d(self.x10, self.y10, kind=1)
         interp1d(self.x10, self.y10, kind=2)
         interp1d(self.x10, self.y10, kind=3)
+
+        # extrapolation only allowed for nearest method
+        for kind in ('linear', 'cubic',
+                     'slinear', 'zero', 'quadratic'):
+            assert_raises(ValueError, interp1d, self.x10, self.y10, kind=kind,
+                          fill_value="extrapolate")
 
         # x array must be 1D.
         assert_raises(ValueError, interp1d, self.x25, self.y10)

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -88,6 +88,28 @@ class TestGriddata(object):
             assert_allclose(griddata((x,), y, (x,), method=method), y,
                             err_msg=method, atol=1e-14)
 
+    def test_1d_borders(self):
+        # Test for nearest neighbor case with xi outside
+        # the range of the values.
+        x = np.array([1, 2.5, 3, 4.5, 5, 6])
+        y = np.array([1, 2, 0, 3.9, 2, 1])
+        xi = np.array([0.9, 6.5])
+        yi_should = np.array([1.0, 1.0])
+
+        method = 'nearest'
+        assert_allclose(griddata(x, y, xi,
+                                 method=method), yi_should,
+                        err_msg=method,
+                        atol=1e-14)
+        assert_allclose(griddata(x.reshape(6, 1), y, xi,
+                                 method=method), yi_should,
+                        err_msg=method,
+                        atol=1e-14)
+        assert_allclose(griddata((x, ), y, (xi, ),
+                                 method=method), yi_should,
+                        err_msg=method,
+                        atol=1e-14)
+
     def test_1d_unsorted(self):
         x = np.array([2.5, 1, 4.5, 5, 6, 3])
         y = np.array([1, 2, 0, 3.9, 2, 1])


### PR DESCRIPTION
This is a rebased and updated version of gh-5045.

Allow extrapolation in `interp1d`, reusing the `fill_value` parameter, so that the signature is `interp1d(x, y, kind=..., fill_value='extrapolate')`, and everything is backwards compatible. This PR only enables extrapolation for nearest and linear kinds because of https://github.com/scipy/scipy/pull/5045#issuecomment-125273786.

Supersedes and closes gh-5045. Fixes gh-4233.

attn @cpaulik
