### PR TITLE
ENH: Nelder-Mead to optionally return final simplex

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -541,7 +541,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
 
     result = OptimizeResult(fun=fval, nit=iterations, nfev=fcalls[0],
                             status=warnflag, success=(warnflag == 0),
-                            message=msg, x=x)
+                            message=msg, x=x, final_simplex=(sim, fsim))
     if retall:
         result['allvecs'] = allvecs
     return result

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -224,9 +224,9 @@ class CheckOptimizeParameterized(CheckOptimize):
                     'return_all': False}
             res = optimize.minimize(self.func, self.startparams, args=(),
                                     method='Nelder-mead', options=opts)
-            params, fopt, numiter, func_calls, warnflag = (
+            params, fopt, numiter, func_calls, warnflag, final_simplex = (
                     res['x'], res['fun'], res['nit'], res['nfev'],
-                    res['status'])
+                    res['status'], res['final_simplex'])
         else:
             retval = optimize.fmin(self.func, self.startparams,
                                         args=(), maxiter=self.maxiter,


### PR DESCRIPTION
Add the return_simplex option to
scipy.optimize.optimize._minimize_neldermead to also return all nodes of
the final simplex and their function values.
This is helpful for error estimation, see e.g.
http://www.scholarpedia.org/article/Nelder-Mead_algorithm#Postprocessing_in_parameter_estimation_problems
