### PR TITLE
BUG: sparse: fix logical comparison dtype conflicts

### DIFF
--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -560,7 +560,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
 
         data_dtype = self.dtype
         if not np.can_cast(other.dtype, self.dtype):
-           data_dtype = upcast(self.dtype, other.dtype)
+            data_dtype = upcast(self.dtype, other.dtype)
 
         fn(self.shape[0]//R, self.shape[1]//C, R, C,
            self.indptr.astype(idx_dtype),

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -558,10 +558,14 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         else:
             data = np.empty(R*C*max_bnnz, dtype=upcast(self.dtype,other.dtype))
 
+        data_dtype = self.dtype
+        if not np.can_cast(other.dtype, self.dtype):
+           data_dtype = upcast(self.dtype, other.dtype)
+
         fn(self.shape[0]//R, self.shape[1]//C, R, C,
            self.indptr.astype(idx_dtype),
            self.indices.astype(idx_dtype),
-           np.ravel(self.data),
+           np.asarray(self.data, dtype=data_dtype).ravel(),
            other.indptr.astype(idx_dtype),
            other.indices.astype(idx_dtype),
            np.ravel(other.data),

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -192,22 +192,17 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     # Boolean comparisons #
     #######################
 
-    def _copy_with_const(self, const):
-        """Copy data, with all nonzeros replaced with constant for binopt
-
-        Adopts a common dtype to avoid removing sign or magnitude before
-        comparison.
-
-        Warning: does not make a copy of indices and indptr
+    def _scalar_binopt(self, other, op):
+        """Scalar version of self._binopt, for cases in which no new nonzeros
+        are added. Produces a new spmatrix in canonical form.
         """
         try:
             self.sum_duplicates()
         except NotImplementedError:
             pass
-        dtype = upcast(self.dtype, np.result_type(const))
-        data = np.empty(self.data.shape, dtype=dtype)
-        data.fill(const)
-        return self.__class__((data, self.indices, self.indptr), shape=self.shape)
+        res = self._with_data(op(self.data, other), copy=True)
+        res.eliminate_zeros()
+        return res
 
     def __eq__(self, other):
         # Scalar other.
@@ -215,16 +210,14 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             if np.isnan(other):
                 return self.__class__(self.shape, dtype=np.bool_)
 
-            other_arr = self._copy_with_const(other)
-            res = self._binopt(other_arr,'_ne_')
             if other == 0:
                 warn("Comparing a sparse matrix with 0 using == is inefficient"
                         ", try using != instead.", SparseEfficiencyWarning)
                 all_true = self.__class__(np.ones(self.shape, dtype=np.bool_))
-                return all_true - res
+                inv = self._scalar_binopt(other, operator.ne)
+                return all_true - inv
             else:
-                sparsity_pattern = self._copy_with_const(True)
-                return sparsity_pattern - res
+                return self._scalar_binopt(other, operator.eq)
         # Dense other.
         elif isdense(other):
             return self.todense() == other
@@ -255,11 +248,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 warn("Comparing a sparse matrix with a nonzero scalar using !="
                      " is inefficient, try using == instead.", SparseEfficiencyWarning)
                 all_true = self.__class__(np.ones(self.shape), dtype=np.bool_)
-                res = (self == other)
-                return all_true - res
+                inv = self._scalar_binopt(other, operator.eq)
+                return all_true - inv
             else:
-                other_arr = self._copy_with_const(other)
-                return self._binopt(other_arr,'_ne_')
+                return self._scalar_binopt(other, operator.ne)
         # Dense other.
         elif isdense(other):
             return self.todense() != other
@@ -287,8 +279,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 other_arr = self.__class__(other_arr)
                 return self._binopt(other_arr, op_name)
             else:
-                other_arr = self._copy_with_const(other)
-                return self._binopt(other_arr, op_name)
+                return self._scalar_binopt(other, op)
         # Dense other.
         elif isdense(other):
             return op(self.todense(), other)

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -1106,7 +1106,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         data_dtype = self.dtype
         if not np.can_cast(other.dtype, self.dtype):
-           data_dtype = upcast(self.dtype, other.dtype)
+            data_dtype = upcast(self.dtype, other.dtype)
 
         fn(self.shape[0], self.shape[1],
            np.asarray(self.indptr, dtype=idx_dtype),

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -189,6 +189,8 @@ class _TestCommon:
 
         # Some sparse and dense matrices with data for every supported
         # dtype.
+        # This set union is a workaround for numpy#6295, which means that
+        # two np.int64 dtypes don't hash to the same value.
         self.checked_dtypes = set(supported_dtypes).union(self.math_dtypes)
         self.dat_dtypes = {}
         self.datsp_dtypes = {}

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -180,7 +180,7 @@ class BinopTester(object):
 # TODO test has_sorted_indices
 class _TestCommon:
     """test common functionality shared by all sparse formats"""
-    checked_dtypes = supported_dtypes
+    math_dtypes = supported_dtypes
 
     def __init__(self):
         # Canonical data.
@@ -189,6 +189,7 @@ class _TestCommon:
 
         # Some sparse and dense matrices with data for every supported
         # dtype.
+        self.checked_dtypes = set(supported_dtypes).union(self.math_dtypes)
         self.dat_dtypes = {}
         self.datsp_dtypes = {}
         for dtype in self.checked_dtypes:
@@ -746,7 +747,7 @@ class _TestCommon:
                 assert_array_almost_equal(dat.sum(axis=-1), datsp.sum(axis=-1))
                 assert_equal(dat.sum(axis=-1).dtype, datsp.sum(axis=-1).dtype)
 
-        for dtype in self.checked_dtypes:
+        for dtype in self.math_dtypes:
             for j in range(len(matrices)):
                 yield check, dtype, j
 
@@ -772,7 +773,7 @@ class _TestCommon:
                 assert_array_almost_equal(dat.mean(axis=-1), datsp.mean(axis=-1))
                 assert_equal(dat.mean(axis=-1).dtype, datsp.mean(axis=-1).dtype)
 
-        for dtype in self.checked_dtypes:
+        for dtype in self.math_dtypes:
             yield check, dtype
 
     def test_expm(self):
@@ -975,7 +976,7 @@ class _TestCommon:
             assert_array_equal(dat*2,(datsp*2).todense())
             assert_array_equal(dat*17.3,(datsp*17.3).todense())
 
-        for dtype in self.checked_dtypes:
+        for dtype in self.math_dtypes:
             yield check, dtype
 
     def test_rmul_scalar(self):
@@ -986,7 +987,7 @@ class _TestCommon:
             assert_array_equal(2*dat,(2*datsp).todense())
             assert_array_equal(17.3*dat,(17.3*datsp).todense())
 
-        for dtype in self.checked_dtypes:
+        for dtype in self.math_dtypes:
             yield check, dtype
 
     def test_add(self):
@@ -1004,7 +1005,7 @@ class _TestCommon:
             assert_array_equal(c.todense(),
                                b.todense() + b.todense())
 
-        for dtype in self.checked_dtypes:
+        for dtype in self.math_dtypes:
             yield check, dtype
 
     def test_radd(self):
@@ -1018,7 +1019,7 @@ class _TestCommon:
             c = a + b
             assert_array_equal(c, a + b.todense())
 
-        for dtype in self.checked_dtypes:
+        for dtype in self.math_dtypes:
             yield check, dtype
 
     def test_sub(self):
@@ -1032,7 +1033,7 @@ class _TestCommon:
             assert_array_equal((datsp - A).todense(),dat - A.todense())
             assert_array_equal((A - datsp).todense(),A.todense() - dat)
 
-        for dtype in self.checked_dtypes:
+        for dtype in self.math_dtypes:
             yield check, dtype
 
     def test_rsub(self):
@@ -1049,7 +1050,7 @@ class _TestCommon:
             assert_array_equal(A.todense() - datsp,A.todense() - dat)
             assert_array_equal(datsp - A.todense(),dat - A.todense())
 
-        for dtype in self.checked_dtypes:
+        for dtype in self.math_dtypes:
             if (dtype == np.dtype('bool')) and (
                     NumpyVersion(np.__version__) >= '1.9.0.dev'):
                 # boolean array subtraction deprecated in 1.9.0
@@ -1069,7 +1070,7 @@ class _TestCommon:
             sumD = sum([k * dat for k in range(1, 3)])
             assert_almost_equal(sumS.todense(), sumD)
 
-        for dtype in self.checked_dtypes:
+        for dtype in self.math_dtypes:
             yield check, dtype
 
     def test_elementwise_multiply(self):
@@ -1373,7 +1374,7 @@ class _TestCommon:
             sum2 = datsp + dat
             assert_array_equal(sum2, dat + dat)
 
-        for dtype in self.checked_dtypes:
+        for dtype in self.math_dtypes:
             yield check, dtype
 
     def test_sub_dense(self):
@@ -1396,7 +1397,7 @@ class _TestCommon:
                 sum2 = (datsp + datsp + datsp) - dat
                 assert_array_equal(sum2, dat + dat)
 
-        for dtype in self.checked_dtypes:
+        for dtype in self.math_dtypes:
             if (dtype == np.dtype('bool')) and (
                     NumpyVersion(np.__version__) >= '1.9.0.dev'):
                 # boolean array subtraction deprecated in 1.9.0
@@ -1436,7 +1437,7 @@ class _TestCommon:
             assert_array_equal(todense(min_s), min_d)
             assert_equal(min_s.dtype, min_d.dtype)
 
-        for dtype in self.checked_dtypes:
+        for dtype in self.math_dtypes:
             for dtype2 in [np.int8, np.float_, np.complex_]:
                 for btype in ['scalar', 'scalar2', 'dense', 'sparse']:
                     yield check, np.dtype(dtype), np.dtype(dtype2), btype
@@ -1799,7 +1800,7 @@ class _TestInplaceArithmetic:
                 b *= 17.3
                 assert_array_equal(b, a.todense())
 
-        for dtype in self.checked_dtypes:
+        for dtype in self.math_dtypes:
             yield check, dtype
 
     def test_idiv_scalar(self):
@@ -1821,7 +1822,7 @@ class _TestInplaceArithmetic:
                 b /= 17.3
                 assert_array_equal(b, a.todense())
 
-        for dtype in self.checked_dtypes:
+        for dtype in self.math_dtypes:
             # /= should only be used with float dtypes to avoid implicit
             # casting.
             if not np.can_cast(dtype, np.int_):
@@ -1910,7 +1911,7 @@ class _TestGetSet:
             A[0, -4] = 1
             assert_equal(A[0, -4], 1)
 
-        for dtype in self.checked_dtypes:
+        for dtype in self.math_dtypes:
             yield check, np.dtype(dtype)
 
     def test_scalar_assign_2(self):
@@ -3027,7 +3028,7 @@ def sparse_test_class(getset=True, slicing=True, slicing_assign=True,
 
 class TestCSR(sparse_test_class()):
     spmatrix = csr_matrix
-    checked_dtypes = [np.bool_, np.int_, np.float_, np.complex_]
+    math_dtypes = [np.bool_, np.int_, np.float_, np.complex_]
 
     def test_constructor1(self):
         b = matrix([[0,4,0],
@@ -3212,7 +3213,7 @@ class TestCSR(sparse_test_class()):
 
 class TestCSC(sparse_test_class()):
     spmatrix = csc_matrix
-    checked_dtypes = [np.bool_, np.int_, np.float_, np.complex_]
+    math_dtypes = [np.bool_, np.int_, np.float_, np.complex_]
 
     def test_constructor1(self):
         b = matrix([[1,0,0,0],[0,0,1,0],[0,2,0,3]],'d')
@@ -3319,7 +3320,7 @@ class TestCSC(sparse_test_class()):
 
 class TestDOK(sparse_test_class(minmax=False, nnz_axis=False)):
     spmatrix = dok_matrix
-    checked_dtypes = [np.int_, np.float_, np.complex_]
+    math_dtypes = [np.int_, np.float_, np.complex_]
 
     def test_mult(self):
         A = dok_matrix((10,10))
@@ -3445,7 +3446,7 @@ class TestDOK(sparse_test_class(minmax=False, nnz_axis=False)):
 
 class TestLIL(sparse_test_class(minmax=False)):
     spmatrix = lil_matrix
-    checked_dtypes = [np.int_, np.float_, np.complex_]
+    math_dtypes = [np.int_, np.float_, np.complex_]
 
     def test_dot(self):
         A = matrix(zeros((10,10)))
@@ -3558,7 +3559,7 @@ class TestCOO(sparse_test_class(getset=False,
                                 slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False)):
     spmatrix = coo_matrix
-    checked_dtypes = [np.int_, np.float_, np.complex_]
+    math_dtypes = [np.int_, np.float_, np.complex_]
 
     def test_constructor1(self):
         # unsorted triplet format
@@ -3637,7 +3638,7 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
                                 fancy_indexing=False, fancy_assign=False,
                                 minmax=False, nnz_axis=False)):
     spmatrix = dia_matrix
-    checked_dtypes = [np.int_, np.float_, np.complex_]
+    math_dtypes = [np.int_, np.float_, np.complex_]
 
     def test_constructor1(self):
         D = matrix([[1, 0, 3, 0],
@@ -3670,7 +3671,7 @@ class TestBSR(sparse_test_class(getset=False,
                                 fancy_indexing=False, fancy_assign=False,
                                 nnz_axis=False)):
     spmatrix = bsr_matrix
-    checked_dtypes = [np.int_, np.float_, np.complex_]
+    math_dtypes = [np.int_, np.float_, np.complex_]
 
     def test_constructor1(self):
         # check native BSR format constructor


### PR DESCRIPTION
This PR addresses some hidden deficiencies of the spmatrix comparison logic.

The first commit expands the set of dtypes that the non-math sparse matrix operations cover. This uncovered two bugs:
- scalar comparison was using the scalar's dtype, even when it was incompatible with the spmatrix dtype. (i.e., float32 spmatrix < scalar zero, as in #4973)
- sparse/sparse comparisons try to cast `other` to `self`'s dtype, which also fails at times. (i.e., float128 spmatrix < complex128 spmatrix)

The second commit fixes both issues with some judicious use of `upcast`.
