### PR TITLE
DOC and BUG: Bessel function docstring improvements, fix array_like, general formatting

### DIFF
--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -6581,6 +6581,11 @@ cdef char *ufunc_kn_doc = (
     "out : ndarray\n"
     "    The results\n"
     "\n"
+    "See Also\n"
+    "--------\n"
+    "kv : Same function, but accepts real order and complex argument\n"
+    "kvp : Derivative of this function\n"
+    "\n"
     "Examples\n"
     "--------\n"
     "Plot the function of several orders for real input:\n"
@@ -6597,8 +6602,8 @@ cdef char *ufunc_kn_doc = (
     "\n"
     "Calculate for a single value at multiple orders:\n"
     "\n"
-    ">>> print(kn([4, 5, 6], 1))\n"
-    "[   44.23241425   360.96060181  3653.83837891]")
+    ">>> kn([4, 5, 6], 1)\n"
+    "array([   44.2324,   360.9606,  3653.8384], dtype=float32)")
 ufunc_kn_loops[0] = <np.PyUFuncGenericFunction>loop_d_id__As_ld_d
 ufunc_kn_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_kn_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
@@ -6718,8 +6723,8 @@ cdef char *ufunc_kv_doc = (
     "\n"
     "    Calculate for a single value at multiple orders:\n"
     "\n"
-    "    >>> print(kv([4, 4.5, 5], 1+2j))\n"
-    "    [ 0.19920848+2.38918114j  2.34926017+3.59995073j  7.28267680+3.81037734j]")
+    "    >>> kv([4, 4.5, 5], 1+2j)\n"
+    "    array([ 0.1992+2.3892j,  2.3493+3.6j   ,  7.2827+3.8104j])")
 ufunc_kv_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_kv_loops[1] = <np.PyUFuncGenericFunction>loop_D_dD__As_fF_F
 ufunc_kv_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -1928,7 +1928,7 @@ cdef char ufunc__struve_asymp_large_z_types[5]
 cdef char *ufunc__struve_asymp_large_z_doc = (
     "_struve_asymp_large_z(v, z, is_h)\n"
     "\n"
-    "Internal function for testing struve & modstruve\n"
+    "Internal function for testing `struve` & `modstruve`\n"
     "\n"
     "Evaluates using asymptotic expansion\n"
     "\n"
@@ -1953,7 +1953,7 @@ cdef char ufunc__struve_bessel_series_types[5]
 cdef char *ufunc__struve_bessel_series_doc = (
     "_struve_bessel_series(v, z, is_h)\n"
     "\n"
-    "Internal function for testing struve & modstruve\n"
+    "Internal function for testing `struve` & `modstruve`\n"
     "\n"
     "Evaluates using Bessel function series\n"
     "\n"
@@ -1978,7 +1978,7 @@ cdef char ufunc__struve_power_series_types[5]
 cdef char *ufunc__struve_power_series_doc = (
     "_struve_power_series(v, z, is_h)\n"
     "\n"
-    "Internal function for testing struve & modstruve\n"
+    "Internal function for testing `struve` & `modstruve`\n"
     "\n"
     "Evaluates using power series\n"
     "\n"
@@ -2128,11 +2128,11 @@ cdef char *ufunc_bdtr_doc = (
     "\n"
     "Binomial distribution cumulative distribution function.\n"
     "\n"
-    "Sum of the terms 0 through k of the Binomial probability density.\n"
+    "Sum of the terms 0 through `k` of the Binomial probability density.\n"
     "\n"
     "::\n"
     "\n"
-    "    y = sum(nCj p**j (1-p)**(n-j),j=0..k)\n"
+    "    y = sum(nCj p**j (1-p)**(n-j), j=0..k)\n"
     "\n"
     "Parameters\n"
     "----------\n"
@@ -2180,7 +2180,7 @@ cdef char *ufunc_bdtrc_doc = (
     "\n"
     "Binomial distribution survival function.\n"
     "\n"
-    "Sum of the terms k+1 through n of the Binomial probability density\n"
+    "Sum of the terms k+1 through `n` of the Binomial probability density\n"
     "\n"
     "::\n"
     "\n"
@@ -2230,7 +2230,7 @@ cdef char ufunc_bdtri_types[12]
 cdef char *ufunc_bdtri_doc = (
     "bdtri(k, n, y)\n"
     "\n"
-    "Inverse function to bdtr vs. p\n"
+    "Inverse function to `bdtr` vs. `p`\n"
     "\n"
     "Finds probability `p` such that for the cumulative binomial\n"
     "probability ``bdtr(k, n, p) == y``.")
@@ -2267,7 +2267,7 @@ cdef char ufunc_bdtrik_types[8]
 cdef char *ufunc_bdtrik_doc = (
     "bdtrik(y, n, p)\n"
     "\n"
-    "Inverse function to bdtr vs k")
+    "Inverse function to `bdtr` vs `k`")
 ufunc_bdtrik_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_bdtrik_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_bdtrik_types[0] = <char>NPY_FLOAT
@@ -2293,7 +2293,7 @@ cdef char ufunc_bdtrin_types[8]
 cdef char *ufunc_bdtrin_doc = (
     "bdtrin(k, y, p)\n"
     "\n"
-    "Inverse function to bdtr vs n")
+    "Inverse function to `bdtr` vs `n`")
 ufunc_bdtrin_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_bdtrin_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_bdtrin_types[0] = <char>NPY_FLOAT
@@ -2341,7 +2341,7 @@ cdef char ufunc_beip_types[4]
 cdef char *ufunc_beip_doc = (
     "beip(x)\n"
     "\n"
-    "Derivative of the Kelvin function bei")
+    "Derivative of the Kelvin function `bei`")
 ufunc_beip_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_beip_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_beip_types[0] = <char>NPY_FLOAT
@@ -2385,7 +2385,7 @@ cdef char ufunc_berp_types[4]
 cdef char *ufunc_berp_doc = (
     "berp(x)\n"
     "\n"
-    "Derivative of the Kelvin function ber")
+    "Derivative of the Kelvin function `ber`")
 ufunc_berp_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_berp_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_berp_types[0] = <char>NPY_FLOAT
@@ -2444,7 +2444,7 @@ cdef char *ufunc_beta_doc = (
     "\n"
     "::\n"
     "\n"
-    "    beta(a,b) =  gamma(a) * gamma(b) / gamma(a+b)")
+    "    beta(a, b) =  gamma(a) * gamma(b) / gamma(a+b)")
 ufunc_beta_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_beta_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
 ufunc_beta_types[0] = <char>NPY_FLOAT
@@ -2471,7 +2471,7 @@ cdef char *ufunc_betainc_doc = (
     "Incomplete beta integral.\n"
     "\n"
     "Compute the incomplete beta integral of the arguments, evaluated\n"
-    "from zero to x::\n"
+    "from zero to `x`::\n"
     "\n"
     "    gamma(a+b) / (gamma(a)*gamma(b)) * integral(t**(a-1) (1-t)**(b-1), t=0..x).\n"
     "\n"
@@ -2508,7 +2508,7 @@ cdef char *ufunc_betaincinv_doc = (
     "\n"
     "Inverse function to beta integral.\n"
     "\n"
-    "Compute x such that betainc(a,b,x) = y.")
+    "Compute `x` such that betainc(a, b, x) = y.")
 ufunc_betaincinv_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_betaincinv_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_betaincinv_types[0] = <char>NPY_FLOAT
@@ -2696,11 +2696,11 @@ cdef void *ufunc_btdtr_ptr[4]
 cdef void *ufunc_btdtr_data[2]
 cdef char ufunc_btdtr_types[8]
 cdef char *ufunc_btdtr_doc = (
-    "btdtr(a,b,x)\n"
+    "btdtr(a, b, x)\n"
     "\n"
     "Cumulative beta distribution.\n"
     "\n"
-    "Returns the area from zero to x under the beta density function::\n"
+    "Returns the area from zero to `x` under the beta density function::\n"
     "\n"
     "    gamma(a+b)/(gamma(a)*gamma(b)))*integral(t**(a-1) (1-t)**(b-1), t=0..x)\n"
     "\n"
@@ -2730,12 +2730,12 @@ cdef void *ufunc_btdtri_ptr[4]
 cdef void *ufunc_btdtri_data[2]
 cdef char ufunc_btdtri_types[8]
 cdef char *ufunc_btdtri_doc = (
-    "btdtri(a,b,p)\n"
+    "btdtri(a, b, p)\n"
     "\n"
     "p-th quantile of the beta distribution.\n"
     "\n"
-    "This is effectively the inverse of btdtr returning the value of x for which\n"
-    "``btdtr(a,b,x) = p``\n"
+    "This is effectively the inverse of `btdtr` returning the value of `x` for which\n"
+    "``btdtr(a, b, x) = p``\n"
     "\n"
     "See Also\n"
     "--------\n"
@@ -2765,7 +2765,7 @@ cdef char ufunc_btdtria_types[8]
 cdef char *ufunc_btdtria_doc = (
     "btdtria(p, b, x)\n"
     "\n"
-    "Inverse of btdtr vs a")
+    "Inverse of `btdtr` vs `a`")
 ufunc_btdtria_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_btdtria_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_btdtria_types[0] = <char>NPY_FLOAT
@@ -2791,7 +2791,7 @@ cdef char ufunc_btdtrib_types[8]
 cdef char *ufunc_btdtrib_doc = (
     "btdtria(a, p, x)\n"
     "\n"
-    "Inverse of btdtr vs b")
+    "Inverse of `btdtr` vs `b`")
 ufunc_btdtrib_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_btdtrib_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_btdtrib_types[0] = <char>NPY_FLOAT
@@ -2817,7 +2817,7 @@ cdef char ufunc_cbrt_types[4]
 cdef char *ufunc_cbrt_doc = (
     "cbrt(x)\n"
     "\n"
-    "Cube root of x")
+    "Cube root of `x`")
 ufunc_cbrt_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_cbrt_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_cbrt_types[0] = <char>NPY_FLOAT
@@ -2841,8 +2841,8 @@ cdef char *ufunc_chdtr_doc = (
     "\n"
     "Chi square cumulative distribution function\n"
     "\n"
-    "Returns the area under the left hand tail (from 0 to x) of the Chi\n"
-    "square probability density function with v degrees of freedom::\n"
+    "Returns the area under the left hand tail (from 0 to `x`) of the Chi\n"
+    "square probability density function with `v` degrees of freedom::\n"
     "\n"
     "    1/(2**(v/2) * gamma(v/2)) * integral(t**(v/2-1) * exp(-t/2), t=0..x)")
 ufunc_chdtr_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
@@ -2866,12 +2866,12 @@ cdef void *ufunc_chdtrc_ptr[4]
 cdef void *ufunc_chdtrc_data[2]
 cdef char ufunc_chdtrc_types[6]
 cdef char *ufunc_chdtrc_doc = (
-    "chdtrc(v,x)\n"
+    "chdtrc(v, x)\n"
     "\n"
     "Chi square survival function\n"
     "\n"
-    "Returns the area under the right hand tail (from x to\n"
-    "infinity) of the Chi square probability density function with v\n"
+    "Returns the area under the right hand tail (from `x` to\n"
+    "infinity) of the Chi square probability density function with `v`\n"
     "degrees of freedom::\n"
     "\n"
     "    1/(2**(v/2) * gamma(v/2)) * integral(t**(v/2-1) * exp(-t/2), t=x..inf)")
@@ -2896,11 +2896,11 @@ cdef void *ufunc_chdtri_ptr[4]
 cdef void *ufunc_chdtri_data[2]
 cdef char ufunc_chdtri_types[6]
 cdef char *ufunc_chdtri_doc = (
-    "chdtri(v,p)\n"
+    "chdtri(v, p)\n"
     "\n"
-    "Inverse to chdtrc\n"
+    "Inverse to `chdtrc`\n"
     "\n"
-    "Returns the argument x such that ``chdtrc(v,x) == p``.")
+    "Returns the argument x such that ``chdtrc(v, x) == p``.")
 ufunc_chdtri_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_chdtri_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
 ufunc_chdtri_types[0] = <char>NPY_FLOAT
@@ -2924,7 +2924,7 @@ cdef char ufunc_chdtriv_types[6]
 cdef char *ufunc_chdtriv_doc = (
     "chdtri(p, x)\n"
     "\n"
-    "Inverse to chdtr vs v\n"
+    "Inverse to `chdtr` vs `v`\n"
     "\n"
     "Returns the argument v such that ``chdtr(v, x) == p``.")
 ufunc_chdtriv_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
@@ -2976,7 +2976,7 @@ cdef char ufunc_chndtridf_types[8]
 cdef char *ufunc_chndtridf_doc = (
     "chndtridf(x, p, nc)\n"
     "\n"
-    "Inverse to chndtr vs df")
+    "Inverse to `chndtr` vs `df`")
 ufunc_chndtridf_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_chndtridf_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_chndtridf_types[0] = <char>NPY_FLOAT
@@ -3002,7 +3002,7 @@ cdef char ufunc_chndtrinc_types[8]
 cdef char *ufunc_chndtrinc_doc = (
     "chndtrinc(x, df, p)\n"
     "\n"
-    "Inverse to chndtr vs nc")
+    "Inverse to `chndtr` vs `nc`")
 ufunc_chndtrinc_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_chndtrinc_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_chndtrinc_types[0] = <char>NPY_FLOAT
@@ -3028,7 +3028,7 @@ cdef char ufunc_chndtrix_types[8]
 cdef char *ufunc_chndtrix_doc = (
     "chndtrix(p, df, nc)\n"
     "\n"
-    "Inverse to chndtr vs x")
+    "Inverse to `chndtr` vs `x`")
 ufunc_chndtrix_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_chndtrix_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_chndtrix_types[0] = <char>NPY_FLOAT
@@ -3054,7 +3054,7 @@ cdef char ufunc_cosdg_types[4]
 cdef char *ufunc_cosdg_doc = (
     "cosdg(x)\n"
     "\n"
-    "Cosine of the angle x given in degrees.")
+    "Cosine of the angle `x` given in degrees.")
 ufunc_cosdg_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_cosdg_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_cosdg_types[0] = <char>NPY_FLOAT
@@ -3076,7 +3076,7 @@ cdef char ufunc_cosm1_types[4]
 cdef char *ufunc_cosm1_doc = (
     "cosm1(x)\n"
     "\n"
-    "cos(x) - 1 for use when x is near zero.")
+    "cos(x) - 1 for use when `x` is near zero.")
 ufunc_cosm1_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_cosm1_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_cosm1_types[0] = <char>NPY_FLOAT
@@ -3098,7 +3098,7 @@ cdef char ufunc_cotdg_types[4]
 cdef char *ufunc_cotdg_doc = (
     "cotdg(x)\n"
     "\n"
-    "Cotangent of the angle x given in degrees.")
+    "Cotangent of the angle `x` given in degrees.")
 ufunc_cotdg_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_cotdg_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_cotdg_types[0] = <char>NPY_FLOAT
@@ -3124,7 +3124,7 @@ cdef char *ufunc_dawsn_doc = (
     "\n"
     "Computes::\n"
     "\n"
-    "    exp(-x**2) * integral(exp(t**2),t=0..x).\n"
+    "    exp(-x**2) * integral(exp(t**2), t=0..x).\n"
     "\n"
     "References\n"
     "----------\n"
@@ -3181,7 +3181,7 @@ cdef char *ufunc_ellipe_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "ellipkm1 : Complete elliptic integral of the first kind, near  m = 1\n"
+    "ellipkm1 : Complete elliptic integral of the first kind, near `m` = 1\n"
     "ellipk : Complete elliptic integral of the first kind\n"
     "ellipkinc : Incomplete elliptic integral of the first kind\n"
     "ellipeinc : Incomplete elliptic integral of the second kind")
@@ -3227,7 +3227,7 @@ cdef char *ufunc_ellipeinc_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "ellipkm1 : Complete elliptic integral of the first kind, near m = 1\n"
+    "ellipkm1 : Complete elliptic integral of the first kind, near `m` = 1\n"
     "ellipk : Complete elliptic integral of the first kind\n"
     "ellipkinc : Incomplete elliptic integral of the first kind\n"
     "ellipe : Complete elliptic integral of the second kind")
@@ -3256,8 +3256,8 @@ cdef char *ufunc_ellipj_doc = (
     "\n"
     "Jacobian elliptic functions\n"
     "\n"
-    "Calculates the Jacobian elliptic functions of parameter m between\n"
-    "0 and 1, and real u.\n"
+    "Calculates the Jacobian elliptic functions of parameter `m` between\n"
+    "0 and 1, and real `u`.\n"
     "\n"
     "Parameters\n"
     "----------\n"
@@ -3327,7 +3327,7 @@ cdef char *ufunc_ellipkinc_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "ellipkm1 : Complete elliptic integral of the first kind, near  m = 1\n"
+    "ellipkm1 : Complete elliptic integral of the first kind, near `m` = 1\n"
     "ellipk : Complete elliptic integral of the first kind\n"
     "ellipe : Complete elliptic integral of the second kind\n"
     "ellipeinc : Incomplete elliptic integral of the second kind")
@@ -3354,7 +3354,7 @@ cdef char ufunc_ellipkm1_types[4]
 cdef char *ufunc_ellipkm1_doc = (
     "ellipkm1(p)\n"
     "\n"
-    "Complete elliptic integral of the first kind around m = 1\n"
+    "Complete elliptic integral of the first kind around `m` = 1\n"
     "\n"
     "This function is defined as\n"
     "\n"
@@ -3365,7 +3365,7 @@ cdef char *ufunc_ellipkm1_doc = (
     "Parameters\n"
     "----------\n"
     "p : array_like\n"
-    "    Defines the parameter of the elliptic integral as m = 1 - p.\n"
+    "    Defines the parameter of the elliptic integral as `m` = 1 - p.\n"
     "\n"
     "Returns\n"
     "-------\n"
@@ -3411,7 +3411,7 @@ cdef char *ufunc_entr_doc = (
     "Returns\n"
     "-------\n"
     "res : ndarray\n"
-    "    The value of the elementwise entropy function at the given points x.\n"
+    "    The value of the elementwise entropy function at the given points `x`.\n"
     "\n"
     "See Also\n"
     "--------\n"
@@ -3455,7 +3455,7 @@ cdef char *ufunc_erf_doc = (
     "Returns\n"
     "-------\n"
     "res : ndarray\n"
-    "    The values of the error function at the given points x.\n"
+    "    The values of the error function at the given points `x`.\n"
     "\n"
     "See Also\n"
     "--------\n"
@@ -4291,7 +4291,7 @@ cdef char *ufunc_exp1_doc = (
     "\n"
     "::\n"
     "\n"
-    "    integral(exp(-z*t)/t,t=1..inf).")
+    "    integral(exp(-z*t)/t, t=1..inf).")
 ufunc_exp1_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_exp1_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_exp1_loops[2] = <np.PyUFuncGenericFunction>loop_D_D__As_F_F
@@ -4373,7 +4373,7 @@ cdef char *ufunc_expi_doc = (
     "\n"
     "Defined as::\n"
     "\n"
-    "    integral(exp(t)/t,t=-inf..x)\n"
+    "    integral(exp(t)/t, t=-inf..x)\n"
     "\n"
     "See `expn` for a different exponential integral.")
 ufunc_expi_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
@@ -4459,7 +4459,7 @@ cdef char ufunc_expm1_types[4]
 cdef char *ufunc_expm1_doc = (
     "expm1(x)\n"
     "\n"
-    "exp(x) - 1 for use when x is near zero.")
+    "exp(x) - 1 for use when `x` is near zero.")
 ufunc_expm1_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_expm1_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_expm1_types[0] = <char>NPY_FLOAT
@@ -4483,7 +4483,8 @@ cdef char *ufunc_expn_doc = (
     "\n"
     "Exponential integral E_n\n"
     "\n"
-    "Returns the exponential integral for integer n and non-negative x and n::\n"
+    "Returns the exponential integral for integer `n` and non-negative `x` and\n"
+    "`n`::\n"
     "\n"
     "    integral(exp(-x*t) / t**n, t=1..inf).")
 ufunc_expn_loops[0] = <np.PyUFuncGenericFunction>loop_d_id__As_ld_d
@@ -4516,7 +4517,7 @@ cdef char ufunc_exprel_types[4]
 cdef char *ufunc_exprel_doc = (
     "exprel(x)\n"
     "\n"
-    "Relative error exponential, (exp(x)-1)/x, for use when x is near zero.\n"
+    "Relative error exponential, (exp(x)-1)/x, for use when `x` is near zero.\n"
     "\n"
     "Parameters\n"
     "----------\n"
@@ -4556,7 +4557,7 @@ cdef char *ufunc_fdtr_doc = (
     "\n"
     "F cumulative distribution function\n"
     "\n"
-    "Returns the area from zero to x under the F density function (also\n"
+    "Returns the area from zero to `x` under the F density function (also\n"
     "known as Snedcor's density or the variance ratio density).  This\n"
     "is the density of X = (unum/dfn)/(uden/dfd), where unum and uden\n"
     "are random variables having Chi square distributions with dfn and\n"
@@ -4614,9 +4615,9 @@ cdef char ufunc_fdtri_types[8]
 cdef char *ufunc_fdtri_doc = (
     "fdtri(dfn, dfd, p)\n"
     "\n"
-    "Inverse to fdtr vs x\n"
+    "Inverse to `fdtr` vs x\n"
     "\n"
-    "Finds the F density argument x such that ``fdtr(dfn, dfd, x) == p``.")
+    "Finds the F density argument `x` such that ``fdtr(dfn, dfd, x) == p``.")
 ufunc_fdtri_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_fdtri_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_fdtri_types[0] = <char>NPY_FLOAT
@@ -4642,9 +4643,9 @@ cdef char ufunc_fdtridfd_types[8]
 cdef char *ufunc_fdtridfd_doc = (
     "fdtridfd(dfn, p, x)\n"
     "\n"
-    "Inverse to fdtr vs dfd\n"
+    "Inverse to `fdtr` vs dfd\n"
     "\n"
-    "Finds the F density argument dfd such that ``fdtr(dfn,dfd,x) == p``.")
+    "Finds the F density argument dfd such that ``fdtr(dfn, dfd, x) == p``.")
 ufunc_fdtridfd_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_fdtridfd_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_fdtridfd_types[0] = <char>NPY_FLOAT
@@ -4674,8 +4675,8 @@ cdef char *ufunc_fresnel_doc = (
     "\n"
     "Defined as::\n"
     "\n"
-    "    ssa = integral(sin(pi/2 * t**2),t=0..z)\n"
-    "    csa = integral(cos(pi/2 * t**2),t=0..z)\n"
+    "    ssa = integral(sin(pi/2 * t**2), t=0..z)\n"
+    "    csa = integral(cos(pi/2 * t**2), t=0..z)\n"
     "\n"
     "Parameters\n"
     "----------\n"
@@ -4789,13 +4790,13 @@ cdef void *ufunc_gammaincc_ptr[4]
 cdef void *ufunc_gammaincc_data[2]
 cdef char ufunc_gammaincc_types[6]
 cdef char *ufunc_gammaincc_doc = (
-    "gammaincc(a,x)\n"
+    "gammaincc(a, x)\n"
     "\n"
     "Complemented incomplete gamma integral\n"
     "\n"
     "Defined as::\n"
     "\n"
-    "    1 / gamma(a) * integral(exp(-t) * t**(a-1), t=x..inf) = 1 - gammainc(a,x)\n"
+    "    1 / gamma(a) * integral(exp(-t) * t**(a-1), t=x..inf) = 1 - gammainc(a, x)\n"
     "\n"
     "`a` must be positive and `x` must be >= 0.")
 ufunc_gammaincc_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
@@ -4819,11 +4820,11 @@ cdef void *ufunc_gammainccinv_ptr[4]
 cdef void *ufunc_gammainccinv_data[2]
 cdef char ufunc_gammainccinv_types[6]
 cdef char *ufunc_gammainccinv_doc = (
-    "gammainccinv(a,y)\n"
+    "gammainccinv(a, y)\n"
     "\n"
-    "Inverse to gammaincc\n"
+    "Inverse to `gammaincc`\n"
     "\n"
-    "Returns `x` such that ``gammaincc(a,x) == y``.")
+    "Returns `x` such that ``gammaincc(a, x) == y``.")
 ufunc_gammainccinv_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_gammainccinv_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
 ufunc_gammainccinv_types[0] = <char>NPY_FLOAT
@@ -4847,7 +4848,7 @@ cdef char ufunc_gammaincinv_types[6]
 cdef char *ufunc_gammaincinv_doc = (
     "gammaincinv(a, y)\n"
     "\n"
-    "Inverse to gammainc\n"
+    "Inverse to `gammainc`\n"
     "\n"
     "Returns `x` such that ``gammainc(a, x) = y``.")
 ufunc_gammaincinv_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
@@ -4939,16 +4940,16 @@ cdef void *ufunc_gdtr_ptr[4]
 cdef void *ufunc_gdtr_data[2]
 cdef char ufunc_gdtr_types[8]
 cdef char *ufunc_gdtr_doc = (
-    "gdtr(a,b,x)\n"
+    "gdtr(a, b, x)\n"
     "\n"
     "Gamma distribution cumulative density function.\n"
     "\n"
-    "Returns the integral from zero to x of the gamma probability\n"
+    "Returns the integral from zero to `x` of the gamma probability\n"
     "density function::\n"
     "\n"
-    "    a**b / gamma(b) * integral(t**(b-1) exp(-at),t=0..x).\n"
+    "    a**b / gamma(b) * integral(t**(b-1) exp(-at), t=0..x).\n"
     "\n"
-    "The arguments a and b are used differently here than in other\n"
+    "The arguments `a` and `b` are used differently here than in other\n"
     "definitions.")
 ufunc_gdtr_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_gdtr_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
@@ -4973,11 +4974,11 @@ cdef void *ufunc_gdtrc_ptr[4]
 cdef void *ufunc_gdtrc_data[2]
 cdef char ufunc_gdtrc_types[8]
 cdef char *ufunc_gdtrc_doc = (
-    "gdtrc(a,b,x)\n"
+    "gdtrc(a, b, x)\n"
     "\n"
     "Gamma distribution survival function.\n"
     "\n"
-    "Integral from x to infinity of the gamma probability density\n"
+    "Integral from `x` to infinity of the gamma probability density\n"
     "function.\n"
     "\n"
     "See Also\n"
@@ -5008,7 +5009,7 @@ cdef char ufunc_gdtria_types[8]
 cdef char *ufunc_gdtria_doc = (
     "gdtria(p, b, x, out=None)\n"
     "\n"
-    "Inverse of gdtr vs a.\n"
+    "Inverse of `gdtr` vs a.\n"
     "\n"
     "Returns the inverse with respect to the parameter `a` of ``p =\n"
     "gdtr(a, b, x)``, the cumulative distribution function of the gamma\n"
@@ -5078,7 +5079,7 @@ cdef char ufunc_gdtrib_types[8]
 cdef char *ufunc_gdtrib_doc = (
     "gdtrib(a, p, x, out=None)\n"
     "\n"
-    "Inverse of gdtr vs b.\n"
+    "Inverse of `gdtr` vs b.\n"
     "\n"
     "Returns the inverse with respect to the parameter `b` of ``p =\n"
     "gdtr(a, b, x)``, the cumulative distribution function of the gamma\n"
@@ -5148,7 +5149,7 @@ cdef char ufunc_gdtrix_types[8]
 cdef char *ufunc_gdtrix_doc = (
     "gdtrix(a, b, p, out=None)\n"
     "\n"
-    "Inverse of gdtr vs x.\n"
+    "Inverse of `gdtr` vs x.\n"
     "\n"
     "Returns the inverse with respect to the parameter `x` of ``p =\n"
     "gdtr(a, b, x)``, the cumulative distribution function of the gamma\n"
@@ -5254,7 +5255,7 @@ cdef char *ufunc_hankel1e_doc = (
     "\n"
     "Defined as::\n"
     "\n"
-    "    hankel1e(v,z) = hankel1(v,z) * exp(-1j * z)\n"
+    "    hankel1e(v, z) = hankel1(v, z) * exp(-1j * z)\n"
     "\n"
     "Parameters\n"
     "----------\n"
@@ -5320,7 +5321,7 @@ cdef char *ufunc_hankel2e_doc = (
     "\n"
     "Defined as::\n"
     "\n"
-    "    hankel1e(v,z) = hankel1(v,z) * exp(1j * z)\n"
+    "    hankel1e(v, z) = hankel1(v, z) * exp(1j * z)\n"
     "\n"
     "Parameters\n"
     "----------\n"
@@ -5842,7 +5843,7 @@ cdef char *ufunc_it2i0k0_doc = (
     "ii0\n"
     "    ``integral((i0(t)-1)/t, t=0..x)``\n"
     "ik0\n"
-    "    ``int(k0(t)/t,t=x..inf)``")
+    "    ``int(k0(t)/t, t=x..inf)``")
 ufunc_it2i0k0_loops[0] = <np.PyUFuncGenericFunction>loop_i_d_dd_As_f_ff
 ufunc_it2i0k0_loops[1] = <np.PyUFuncGenericFunction>loop_i_d_dd_As_d_dd
 ufunc_it2i0k0_types[0] = <char>NPY_FLOAT
@@ -5924,9 +5925,9 @@ cdef char ufunc_itairy_types[10]
 cdef char *ufunc_itairy_doc = (
     "itairy(x)\n"
     "\n"
-    "Integrals of Airy functios\n"
+    "Integrals of Airy functions\n"
     "\n"
-    "Calculates the integral of Airy functions from 0 to x\n"
+    "Calculates the integral of Airy functions from 0 to `x`\n"
     "\n"
     "Returns\n"
     "-------\n"
@@ -5963,8 +5964,8 @@ cdef char *ufunc_iti0k0_doc = (
     "\n"
     "Integrals of modified Bessel functions of order 0\n"
     "\n"
-    "Returns simple integrals from 0 to x of the zeroth order modified\n"
-    "Bessel functions i0 and k0.\n"
+    "Returns simple integrals from 0 to `x` of the zeroth order modified\n"
+    "Bessel functions `i0` and `k0`.\n"
     "\n"
     "Returns\n"
     "-------\n"
@@ -5994,8 +5995,8 @@ cdef char *ufunc_itj0y0_doc = (
     "\n"
     "Integrals of Bessel functions of order 0\n"
     "\n"
-    "Returns simple integrals from 0 to x of the zeroth order Bessel\n"
-    "functions j0 and y0.\n"
+    "Returns simple integrals from 0 to `x` of the zeroth order Bessel\n"
+    "functions `j0` and `y0`.\n"
     "\n"
     "Returns\n"
     "-------\n"
@@ -6075,14 +6076,14 @@ cdef void *ufunc_iv_ptr[8]
 cdef void *ufunc_iv_data[4]
 cdef char ufunc_iv_types[12]
 cdef char *ufunc_iv_doc = (
-    "iv(v,z)\n"
+    "iv(v, z)\n"
     "\n"
     "Modified Bessel function of the first kind  of real order\n"
     "\n"
     "Parameters\n"
     "----------\n"
     "v\n"
-    "    Order. If z is of real type and negative, v must be integer valued.\n"
+    "    Order. If `z` is of real type and negative, `v` must be integer valued.\n"
     "z\n"
     "    Argument.")
 ufunc_iv_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
@@ -6120,13 +6121,13 @@ cdef void *ufunc_ive_ptr[8]
 cdef void *ufunc_ive_data[4]
 cdef char ufunc_ive_types[12]
 cdef char *ufunc_ive_doc = (
-    "ive(v,z)\n"
+    "ive(v, z)\n"
     "\n"
     "Exponentially scaled modified Bessel function of the first kind\n"
     "\n"
     "Defined as::\n"
     "\n"
-    "    ive(v,z) = iv(v,z) * exp(-abs(z.real))")
+    "    ive(v, z) = iv(v, z) * exp(-abs(z.real))")
 ufunc_ive_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_ive_loops[1] = <np.PyUFuncGenericFunction>loop_D_dD__As_fF_F
 ufunc_ive_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
@@ -6208,7 +6209,7 @@ cdef char ufunc_jv_types[12]
 cdef char *ufunc_jv_doc = (
     "jv(v, z)\n"
     "\n"
-    "Bessel function of the first kind of real order v")
+    "Bessel function of the first kind of real order `v`")
 ufunc_jv_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_jv_loops[1] = <np.PyUFuncGenericFunction>loop_D_dD__As_fF_F
 ufunc_jv_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
@@ -6246,11 +6247,11 @@ cdef char ufunc_jve_types[12]
 cdef char *ufunc_jve_doc = (
     "jve(v, z)\n"
     "\n"
-    "Exponentially scaled Bessel function of order v\n"
+    "Exponentially scaled Bessel function of order `v`\n"
     "\n"
     "Defined as::\n"
     "\n"
-    "    jve(v,z) = jv(v,z) * exp(-abs(z.imag))")
+    "    jve(v, z) = jv(v, z) * exp(-abs(z.imag))")
 ufunc_jve_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_jve_loops[1] = <np.PyUFuncGenericFunction>loop_D_dD__As_fF_F
 ufunc_jve_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
@@ -6438,7 +6439,7 @@ cdef char *ufunc_kelvin_doc = (
     "Be, Ke, Bep, Kep\n"
     "    The tuple (Be, Ke, Bep, Kep) contains complex numbers\n"
     "    representing the real and imaginary Kelvin functions and their\n"
-    "    derivatives evaluated at x.  For example, kelvin(x)[0].real =\n"
+    "    derivatives evaluated at `x`.  For example, kelvin(x)[0].real =\n"
     "    ber x and kelvin(x)[0].imag = bei x with similar relationships\n"
     "    for ker and kei.")
 ufunc_kelvin_loops[0] = <np.PyUFuncGenericFunction>loop_i_d_DDDD_As_f_FFFF
@@ -6534,7 +6535,7 @@ cdef char *ufunc_kl_div_doc = (
     "\n"
     "Notes\n"
     "-----\n"
-    "This function is non-negative and is jointly convex in x and y.\n"
+    "This function is non-negative and is jointly convex in `x` and `y`.\n"
     "\n"
     ".. versionadded:: 0.14.0")
 ufunc_kl_div_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
@@ -6560,9 +6561,44 @@ cdef char ufunc_kn_types[9]
 cdef char *ufunc_kn_doc = (
     "kn(n, x)\n"
     "\n"
-    "Modified Bessel function of the second kind of integer order n\n"
+    "Modified Bessel function of the second kind of integer order `n`\n"
     "\n"
-    "These are also sometimes called functions of the third kind.")
+    "Returns the modified Bessel function of the second kind for integer order\n"
+    "`n` at real `z`.\n"
+    "\n"
+    "These are also sometimes called functions of the third kind, Basset\n"
+    "functions, or Macdonald functions.\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "n : array_like of int\n"
+    "    Order of Bessel functions (floats will truncate with a warning)\n"
+    "z : array_like of float\n"
+    "    Argument at which to evaluate the Bessel functions\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "out : ndarray\n"
+    "    The results\n"
+    "\n"
+    "Examples\n"
+    "--------\n"
+    "Plot the function of several orders for real input:\n"
+    "\n"
+    ">>> from scipy.special import kn\n"
+    ">>> import matplotlib.pyplot as plt\n"
+    ">>> x = np.linspace(0, 5, 1000)\n"
+    ">>> for N in range(6):\n"
+    "...     plt.plot(x, kn(N, x), label='$K_{}(x)$'.format(N))\n"
+    ">>> plt.ylim(0, 10)\n"
+    ">>> plt.legend()\n"
+    ">>> plt.title(r'Modified Bessel function of the second kind $K_n(x)$')\n"
+    ">>> plt.show()\n"
+    "\n"
+    "Calculate for a single value at multiple orders:\n"
+    "\n"
+    ">>> print(kn([4, 5, 6], 1))\n"
+    "[   44.23241425   360.96060181  3653.83837891]")
 ufunc_kn_loops[0] = <np.PyUFuncGenericFunction>loop_d_id__As_ld_d
 ufunc_kn_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_kn_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
@@ -6643,12 +6679,47 @@ cdef void *ufunc_kv_ptr[8]
 cdef void *ufunc_kv_data[4]
 cdef char ufunc_kv_types[12]
 cdef char *ufunc_kv_doc = (
-    "kv(v,z)\n"
+    "kv(v, z)\n"
     "\n"
-    "Modified Bessel function of the second kind of real order v\n"
+    "    Modified Bessel function of the second kind of real order `v`\n"
     "\n"
-    "Returns the modified Bessel function of the second kind (sometimes\n"
-    "called the third kind) for real order v at complex z.")
+    "    Returns the modified Bessel function of the second kind for real order\n"
+    "    `v` at complex `z`.\n"
+    "\n"
+    "    These are also sometimes called functions of the third kind, Basset\n"
+    "    functions, or Macdonald functions.\n"
+    "\n"
+    "    Parameters\n"
+    "    ----------\n"
+    "    v : array_like of float\n"
+    "        Order of Bessel functions\n"
+    "    z : array_like of complex\n"
+    "        Argument at which to evaluate the Bessel functions\n"
+    "\n"
+    "    Returns\n"
+    "    -------\n"
+    "    out : ndarray\n"
+    "        The results\n"
+    "\n"
+    "    Examples\n"
+    "    --------\n"
+    "    Plot the function of several orders for real input:\n"
+    "\n"
+    "    >>> from scipy.special import kv\n"
+    "    >>> import matplotlib.pyplot as plt\n"
+    "    >>> x = np.linspace(0, 5, 1000)\n"
+    "    >>> for N in np.linspace(0, 6, 5):\n"
+    "    ...     plt.plot(x, kv(N, x), label='$K_{{{}}}(x)$'.format(N))\n"
+    "    >>> plt.ylim(0, 10)\n"
+    "    >>> plt.legend()\n"
+    "    >>> plt.title(r'Modified Bessel function of the second kind $K_\n"
+    "u(x)$')\n"
+    "    >>> plt.show()\n"
+    "\n"
+    "    Calculate for a single value at multiple orders:\n"
+    "\n"
+    "    >>> print(kv([4, 4.5, 5], 1+2j))\n"
+    "    [ 0.19920848+2.38918114j  2.34926017+3.59995073j  7.28267680+3.81037734j]")
 ufunc_kv_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_kv_loops[1] = <np.PyUFuncGenericFunction>loop_D_dD__As_fF_F
 ufunc_kv_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
@@ -6684,15 +6755,15 @@ cdef void *ufunc_kve_ptr[8]
 cdef void *ufunc_kve_data[4]
 cdef char ufunc_kve_types[12]
 cdef char *ufunc_kve_doc = (
-    "kve(v,z)\n"
+    "kve(v, z)\n"
     "\n"
     "Exponentially scaled modified Bessel function of the second kind.\n"
     "\n"
     "Returns the exponentially scaled, modified Bessel function of the\n"
-    "second kind (sometimes called the third kind) for real order v at\n"
-    "complex z::\n"
+    "second kind (sometimes called the third kind) for real order `v` at\n"
+    "complex `z`::\n"
     "\n"
-    "    kve(v,z) = kv(v,z) * exp(z)")
+    "    kve(v, z) = kv(v, z) * exp(z)")
 ufunc_kve_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_kve_loops[1] = <np.PyUFuncGenericFunction>loop_D_dD__As_fF_F
 ufunc_kve_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
@@ -6730,7 +6801,7 @@ cdef char ufunc_log1p_types[4]
 cdef char *ufunc_log1p_doc = (
     "log1p(x)\n"
     "\n"
-    "Calculates log(1+x) for use when x is near zero")
+    "Calculates log(1+x) for use when `x` is near zero")
 ufunc_log1p_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_log1p_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_log1p_types[0] = <char>NPY_FLOAT
@@ -6755,7 +6826,7 @@ cdef char *ufunc_log_ndtr_doc = (
     "Logarithm of Gaussian cumulative distribution function\n"
     "\n"
     "Returns the log of the area under the standard Gaussian probability\n"
-    "density function, integrated from minus infinity to x::\n"
+    "density function, integrated from minus infinity to `x`::\n"
     "\n"
     "    log(1/sqrt(2*pi) * integral(exp(-t**2 / 2), t=-inf..x))")
 ufunc_log_ndtr_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
@@ -6863,12 +6934,12 @@ cdef void *ufunc_mathieu_a_ptr[4]
 cdef void *ufunc_mathieu_a_data[2]
 cdef char ufunc_mathieu_a_types[6]
 cdef char *ufunc_mathieu_a_doc = (
-    "mathieu_a(m,q)\n"
+    "mathieu_a(m, q)\n"
     "\n"
     "Characteristic value of even Mathieu functions\n"
     "\n"
     "Returns the characteristic value for the even solution,\n"
-    "``ce_m(z,q)``, of Mathieu's equation.")
+    "``ce_m(z, q)``, of Mathieu's equation.")
 ufunc_mathieu_a_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_mathieu_a_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
 ufunc_mathieu_a_types[0] = <char>NPY_FLOAT
@@ -6890,12 +6961,12 @@ cdef void *ufunc_mathieu_b_ptr[4]
 cdef void *ufunc_mathieu_b_data[2]
 cdef char ufunc_mathieu_b_types[6]
 cdef char *ufunc_mathieu_b_doc = (
-    "mathieu_b(m,q)\n"
+    "mathieu_b(m, q)\n"
     "\n"
     "Characteristic value of odd Mathieu functions\n"
     "\n"
     "Returns the characteristic value for the odd solution,\n"
-    "``se_m(z,q)``, of Mathieu's equation.")
+    "``se_m(z, q)``, of Mathieu's equation.")
 ufunc_mathieu_b_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_mathieu_b_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
 ufunc_mathieu_b_types[0] = <char>NPY_FLOAT
@@ -6917,13 +6988,13 @@ cdef void *ufunc_mathieu_cem_ptr[4]
 cdef void *ufunc_mathieu_cem_data[2]
 cdef char ufunc_mathieu_cem_types[10]
 cdef char *ufunc_mathieu_cem_doc = (
-    "mathieu_cem(m,q,x)\n"
+    "mathieu_cem(m, q, x)\n"
     "\n"
     "Even Mathieu function and its derivative\n"
     "\n"
-    "Returns the even Mathieu function, ``ce_m(x,q)``, of order m and\n"
-    "parameter q evaluated at x (given in degrees).  Also returns the\n"
-    "derivative with respect to x of ce_m(x,q)\n"
+    "Returns the even Mathieu function, ``ce_m(x, q)``, of order `m` and\n"
+    "parameter `q` evaluated at `x` (given in degrees).  Also returns the\n"
+    "derivative with respect to `x` of ce_m(x, q)\n"
     "\n"
     "Parameters\n"
     "----------\n"
@@ -6970,7 +7041,7 @@ cdef char *ufunc_mathieu_modcem1_doc = (
     "Even modified Mathieu function of the first kind and its derivative\n"
     "\n"
     "Evaluates the even modified Mathieu function of the first kind,\n"
-    "``Mc1m(x,q)``, and its derivative at `x` for order m and parameter\n"
+    "``Mc1m(x, q)``, and its derivative at `x` for order `m` and parameter\n"
     "`q`.\n"
     "\n"
     "Returns\n"
@@ -7009,8 +7080,8 @@ cdef char *ufunc_mathieu_modcem2_doc = (
     "Even modified Mathieu function of the second kind and its derivative\n"
     "\n"
     "Evaluates the even modified Mathieu function of the second kind,\n"
-    "Mc2m(x,q), and its derivative at x (given in degrees) for order m\n"
-    "and parameter q.\n"
+    "Mc2m(x, q), and its derivative at `x` (given in degrees) for order `m`\n"
+    "and parameter `q`.\n"
     "\n"
     "Returns\n"
     "-------\n"
@@ -7043,13 +7114,13 @@ cdef void *ufunc_mathieu_modsem1_ptr[4]
 cdef void *ufunc_mathieu_modsem1_data[2]
 cdef char ufunc_mathieu_modsem1_types[10]
 cdef char *ufunc_mathieu_modsem1_doc = (
-    "mathieu_modsem1(m,q,x)\n"
+    "mathieu_modsem1(m, q, x)\n"
     "\n"
     "Odd modified Mathieu function of the first kind and its derivative\n"
     "\n"
     "Evaluates the odd modified Mathieu function of the first kind,\n"
-    "Ms1m(x,q), and its derivative at x (given in degrees) for order m\n"
-    "and parameter q.\n"
+    "Ms1m(x, q), and its derivative at `x` (given in degrees) for order `m`\n"
+    "and parameter `q`.\n"
     "\n"
     "Returns\n"
     "-------\n"
@@ -7087,7 +7158,7 @@ cdef char *ufunc_mathieu_modsem2_doc = (
     "Odd modified Mathieu function of the second kind and its derivative\n"
     "\n"
     "Evaluates the odd modified Mathieu function of the second kind,\n"
-    "Ms2m(x,q), and its derivative at x (given in degrees) for order m\n"
+    "Ms2m(x, q), and its derivative at `x` (given in degrees) for order `m`\n"
     "and parameter q.\n"
     "\n"
     "Returns\n"
@@ -7125,9 +7196,9 @@ cdef char *ufunc_mathieu_sem_doc = (
     "\n"
     "Odd Mathieu function and its derivative\n"
     "\n"
-    "Returns the odd Mathieu function, se_m(x,q), of order m and\n"
-    "parameter q evaluated at x (given in degrees).  Also returns the\n"
-    "derivative with respect to x of se_m(x,q).\n"
+    "Returns the odd Mathieu function, se_m(x, q), of order `m` and\n"
+    "parameter `q` evaluated at `x` (given in degrees).  Also returns the\n"
+    "derivative with respect to `x` of se_m(x, q).\n"
     "\n"
     "Parameters\n"
     "----------\n"
@@ -7176,7 +7247,7 @@ cdef char *ufunc_modfresnelm_doc = (
     "Returns\n"
     "-------\n"
     "fm\n"
-    "    Integral ``F_-(x)``: ``integral(exp(-1j*t*t),t=x..inf)``\n"
+    "    Integral ``F_-(x)``: ``integral(exp(-1j*t*t), t=x..inf)``\n"
     "km\n"
     "    Integral ``K_-(x)``: ``1/sqrt(pi)*exp(1j*(x*x+pi/4))*fp``")
 ufunc_modfresnelm_loops[0] = <np.PyUFuncGenericFunction>loop_i_d_DD_As_f_FF
@@ -7207,7 +7278,7 @@ cdef char *ufunc_modfresnelp_doc = (
     "Returns\n"
     "-------\n"
     "fp\n"
-    "    Integral ``F_+(x)``: ``integral(exp(1j*t*t),t=x..inf)``\n"
+    "    Integral ``F_+(x)``: ``integral(exp(1j*t*t), t=x..inf)``\n"
     "kp\n"
     "    Integral ``K_+(x)``: ``1/sqrt(pi)*exp(-1j*(x*x+pi/4))*fp``")
 ufunc_modfresnelp_loops[0] = <np.PyUFuncGenericFunction>loop_i_d_DD_As_f_FF
@@ -7235,8 +7306,8 @@ cdef char *ufunc_modstruve_doc = (
     "\n"
     "Modified Struve function\n"
     "\n"
-    "Returns the modified Struve function Lv(x) of order v at x, x must\n"
-    "be positive unless v is an integer.")
+    "Returns the modified Struve function Lv(x) of order `v` at `x`, `x` must\n"
+    "be positive unless `v` is an integer.")
 ufunc_modstruve_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_modstruve_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
 ufunc_modstruve_types[0] = <char>NPY_FLOAT
@@ -7262,10 +7333,10 @@ cdef char *ufunc_nbdtr_doc = (
     "\n"
     "Negative binomial cumulative distribution function\n"
     "\n"
-    "Returns the sum of the terms 0 through k of the negative binomial\n"
+    "Returns the sum of the terms 0 through `k` of the negative binomial\n"
     "distribution::\n"
     "\n"
-    "    sum((n+j-1)Cj p**n (1-p)**j,j=0..k).\n"
+    "    sum((n+j-1)Cj p**n (1-p)**j, j=0..k).\n"
     "\n"
     "In a sequence of Bernoulli trials this is the probability that k\n"
     "or fewer failures precede the nth success.")
@@ -7300,7 +7371,7 @@ cdef void *ufunc_nbdtrc_ptr[6]
 cdef void *ufunc_nbdtrc_data[3]
 cdef char ufunc_nbdtrc_types[12]
 cdef char *ufunc_nbdtrc_doc = (
-    "nbdtrc(k,n,p)\n"
+    "nbdtrc(k, n, p)\n"
     "\n"
     "Negative binomial survival function\n"
     "\n"
@@ -7339,9 +7410,9 @@ cdef char ufunc_nbdtri_types[12]
 cdef char *ufunc_nbdtri_doc = (
     "nbdtri(k, n, y)\n"
     "\n"
-    "Inverse of nbdtr vs p\n"
+    "Inverse of `nbdtr` vs `p`\n"
     "\n"
-    "Finds the argument p such that ``nbdtr(k,n,p) = y``.")
+    "Finds the argument p such that ``nbdtr(k, n, p) = y``.")
 ufunc_nbdtri_loops[0] = <np.PyUFuncGenericFunction>loop_d_iid__As_lld_d
 ufunc_nbdtri_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_nbdtri_loops[2] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
@@ -7373,11 +7444,11 @@ cdef void *ufunc_nbdtrik_ptr[4]
 cdef void *ufunc_nbdtrik_data[2]
 cdef char ufunc_nbdtrik_types[8]
 cdef char *ufunc_nbdtrik_doc = (
-    "nbdtrik(y,n,p)\n"
+    "nbdtrik(y, n, p)\n"
     "\n"
-    "Inverse of nbdtr vs k\n"
+    "Inverse of `nbdtr` vs `k`\n"
     "\n"
-    "Finds the argument k such that ``nbdtr(k,n,p) = y``.")
+    "Finds the argument k such that ``nbdtr(k, n, p) = y``.")
 ufunc_nbdtrik_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_nbdtrik_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_nbdtrik_types[0] = <char>NPY_FLOAT
@@ -7401,11 +7472,11 @@ cdef void *ufunc_nbdtrin_ptr[4]
 cdef void *ufunc_nbdtrin_data[2]
 cdef char ufunc_nbdtrin_types[8]
 cdef char *ufunc_nbdtrin_doc = (
-    "nbdtrin(k,y,p)\n"
+    "nbdtrin(k, y, p)\n"
     "\n"
-    "Inverse of nbdtr vs n\n"
+    "Inverse of `nbdtr` vs `n`\n"
     "\n"
-    "Finds the argument n such that ``nbdtr(k,n,p) = y``.")
+    "Finds the argument `n` such that ``nbdtr(k, n, p) = y``.")
 ufunc_nbdtrin_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_nbdtrin_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_nbdtrin_types[0] = <char>NPY_FLOAT
@@ -7624,7 +7695,7 @@ cdef char ufunc_nctdtr_types[8]
 cdef char *ufunc_nctdtr_doc = (
     "nctdtr(df, nc, t)\n"
     "\n"
-    "Cumulative distribution function of the non-central t distribution.\n"
+    "Cumulative distribution function of the non-central `t` distribution.\n"
     "\n"
     "Parameters\n"
     "----------\n"
@@ -7805,9 +7876,9 @@ cdef char *ufunc_ndtr_doc = (
     "Gaussian cumulative distribution function\n"
     "\n"
     "Returns the area under the standard Gaussian probability\n"
-    "density function, integrated from minus infinity to x::\n"
+    "density function, integrated from minus infinity to `x`::\n"
     "\n"
-    "    1/sqrt(2*pi) * integral(exp(-t**2 / 2),t=-inf..x)")
+    "    1/sqrt(2*pi) * integral(exp(-t**2 / 2), t=-inf..x)")
 ufunc_ndtr_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_ndtr_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_ndtr_types[0] = <char>NPY_FLOAT
@@ -7829,10 +7900,10 @@ cdef char ufunc_ndtri_types[4]
 cdef char *ufunc_ndtri_doc = (
     "ndtri(y)\n"
     "\n"
-    "Inverse of ndtr vs x\n"
+    "Inverse of `ndtr` vs x\n"
     "\n"
     "Returns the argument x for which the area under the Gaussian\n"
-    "probability density function (integrated from minus infinity to x)\n"
+    "probability density function (integrated from minus infinity to `x`)\n"
     "is equal to y.")
 ufunc_ndtri_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_ndtri_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
@@ -7946,8 +8017,8 @@ cdef char *ufunc_obl_ang1_doc = (
     "Oblate spheroidal angular function of the first kind and its derivative\n"
     "\n"
     "Computes the oblate spheroidal angular function of the first kind\n"
-    "and its derivative (with respect to x) for mode parameters m>=0\n"
-    "and n>=m, spheroidal parameter c and ``|x| < 1.0``.\n"
+    "and its derivative (with respect to `x`) for mode parameters m>=0\n"
+    "and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.\n"
     "\n"
     "Returns\n"
     "-------\n"
@@ -7987,8 +8058,8 @@ cdef char *ufunc_obl_ang1_cv_doc = (
     "Oblate spheroidal angular function obl_ang1 for precomputed characteristic value\n"
     "\n"
     "Computes the oblate spheroidal angular function of the first kind\n"
-    "and its derivative (with respect to x) for mode parameters m>=0\n"
-    "and n>=m, spheroidal parameter c and ``|x| < 1.0``. Requires\n"
+    "and its derivative (with respect to `x`) for mode parameters m>=0\n"
+    "and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires\n"
     "pre-computed characteristic value.\n"
     "\n"
     "Returns\n"
@@ -8031,7 +8102,7 @@ cdef char *ufunc_obl_cv_doc = (
     "Characteristic value of oblate spheroidal function\n"
     "\n"
     "Computes the characteristic value of oblate spheroidal wave\n"
-    "functions of order m,n (n>=m) and spheroidal parameter c.")
+    "functions of order `m`, `n` (n>=m) and spheroidal parameter `c`.")
 ufunc_obl_cv_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_obl_cv_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_obl_cv_types[0] = <char>NPY_FLOAT
@@ -8055,13 +8126,13 @@ cdef void *ufunc_obl_rad1_ptr[4]
 cdef void *ufunc_obl_rad1_data[2]
 cdef char ufunc_obl_rad1_types[12]
 cdef char *ufunc_obl_rad1_doc = (
-    "obl_rad1(m,n,c,x)\n"
+    "obl_rad1(m, n, c, x)\n"
     "\n"
     "Oblate spheroidal radial function of the first kind and its derivative\n"
     "\n"
     "Computes the oblate spheroidal radial function of the first kind\n"
-    "and its derivative (with respect to x) for mode parameters m>=0\n"
-    "and n>=m, spheroidal parameter c and ``|x| < 1.0``.\n"
+    "and its derivative (with respect to `x`) for mode parameters m>=0\n"
+    "and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.\n"
     "\n"
     "Returns\n"
     "-------\n"
@@ -8096,13 +8167,13 @@ cdef void *ufunc_obl_rad1_cv_ptr[4]
 cdef void *ufunc_obl_rad1_cv_data[2]
 cdef char ufunc_obl_rad1_cv_types[14]
 cdef char *ufunc_obl_rad1_cv_doc = (
-    "obl_rad1_cv(m,n,c,cv,x)\n"
+    "obl_rad1_cv(m, n, c, cv, x)\n"
     "\n"
     "Oblate spheroidal radial function obl_rad1 for precomputed characteristic value\n"
     "\n"
     "Computes the oblate spheroidal radial function of the first kind\n"
-    "and its derivative (with respect to x) for mode parameters m>=0\n"
-    "and n>=m, spheroidal parameter c and ``|x| < 1.0``. Requires\n"
+    "and its derivative (with respect to `x`) for mode parameters m>=0\n"
+    "and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires\n"
     "pre-computed characteristic value.\n"
     "\n"
     "Returns\n"
@@ -8140,13 +8211,13 @@ cdef void *ufunc_obl_rad2_ptr[4]
 cdef void *ufunc_obl_rad2_data[2]
 cdef char ufunc_obl_rad2_types[12]
 cdef char *ufunc_obl_rad2_doc = (
-    "obl_rad2(m,n,c,x)\n"
+    "obl_rad2(m, n, c, x)\n"
     "\n"
     "Oblate spheroidal radial function of the second kind and its derivative.\n"
     "\n"
     "Computes the oblate spheroidal radial function of the second kind\n"
-    "and its derivative (with respect to x) for mode parameters m>=0\n"
-    "and n>=m, spheroidal parameter c and ``|x| < 1.0``.\n"
+    "and its derivative (with respect to `x`) for mode parameters m>=0\n"
+    "and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.\n"
     "\n"
     "Returns\n"
     "-------\n"
@@ -8181,13 +8252,13 @@ cdef void *ufunc_obl_rad2_cv_ptr[4]
 cdef void *ufunc_obl_rad2_cv_data[2]
 cdef char ufunc_obl_rad2_cv_types[14]
 cdef char *ufunc_obl_rad2_cv_doc = (
-    "obl_rad2_cv(m,n,c,cv,x)\n"
+    "obl_rad2_cv(m, n, c, cv, x)\n"
     "\n"
     "Oblate spheroidal radial function obl_rad2 for precomputed characteristic value\n"
     "\n"
     "Computes the oblate spheroidal radial function of the second kind\n"
-    "and its derivative (with respect to x) for mode parameters m>=0\n"
-    "and n>=m, spheroidal parameter c and ``|x| < 1.0``. Requires\n"
+    "and its derivative (with respect to `x`) for mode parameters m>=0\n"
+    "and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires\n"
     "pre-computed characteristic value.\n"
     "\n"
     "Returns\n"
@@ -8229,7 +8300,7 @@ cdef char *ufunc_pbdv_doc = (
     "\n"
     "Parabolic cylinder function D\n"
     "\n"
-    "Returns (d,dp) the parabolic cylinder function Dv(x) in d and the\n"
+    "Returns (d, dp) the parabolic cylinder function Dv(x) in d and the\n"
     "derivative, Dv'(x) in dp.\n"
     "\n"
     "Returns\n"
@@ -8261,7 +8332,7 @@ cdef void *ufunc_pbvv_ptr[4]
 cdef void *ufunc_pbvv_data[2]
 cdef char ufunc_pbvv_types[8]
 cdef char *ufunc_pbvv_doc = (
-    "pbvv(v,x)\n"
+    "pbvv(v, x)\n"
     "\n"
     "Parabolic cylinder function V\n"
     "\n"
@@ -8297,12 +8368,12 @@ cdef void *ufunc_pbwa_ptr[4]
 cdef void *ufunc_pbwa_data[2]
 cdef char ufunc_pbwa_types[8]
 cdef char *ufunc_pbwa_doc = (
-    "pbwa(a,x)\n"
+    "pbwa(a, x)\n"
     "\n"
     "Parabolic cylinder function W\n"
     "\n"
-    "Returns the parabolic cylinder function W(a,x) in w and the\n"
-    "derivative, W'(a,x) in wp.\n"
+    "Returns the parabolic cylinder function W(a, x) in w and the\n"
+    "derivative, W'(a, x) in wp.\n"
     "\n"
     ".. warning::\n"
     "\n"
@@ -8341,9 +8412,9 @@ cdef char *ufunc_pdtr_doc = (
     "\n"
     "Poisson cumulative distribution function\n"
     "\n"
-    "Returns the sum of the first k terms of the Poisson distribution:\n"
+    "Returns the sum of the first `k` terms of the Poisson distribution:\n"
     "sum(exp(-m) * m**j / j!, j=0..k) = gammaincc( k+1, m).  Arguments\n"
-    "must both be positive and k an integer.")
+    "must both be positive and `k` an integer.")
 ufunc_pdtr_loops[0] = <np.PyUFuncGenericFunction>loop_d_id__As_ld_d
 ufunc_pdtr_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_pdtr_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
@@ -8378,7 +8449,7 @@ cdef char *ufunc_pdtrc_doc = (
     "\n"
     "Returns the sum of the terms from k+1 to infinity of the Poisson\n"
     "distribution: sum(exp(-m) * m**j / j!, j=k+1..inf) = gammainc(\n"
-    "k+1, m).  Arguments must both be positive and k an integer.")
+    "k+1, m).  Arguments must both be positive and `k` an integer.")
 ufunc_pdtrc_loops[0] = <np.PyUFuncGenericFunction>loop_d_id__As_ld_d
 ufunc_pdtrc_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_pdtrc_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
@@ -8407,14 +8478,14 @@ cdef void *ufunc_pdtri_ptr[6]
 cdef void *ufunc_pdtri_data[3]
 cdef char ufunc_pdtri_types[9]
 cdef char *ufunc_pdtri_doc = (
-    "pdtri(k,y)\n"
+    "pdtri(k, y)\n"
     "\n"
-    "Inverse to pdtr vs m\n"
+    "Inverse to `pdtr` vs m\n"
     "\n"
-    "Returns the Poisson variable m such that the sum from 0 to k of\n"
-    "the Poisson density is equal to the given probability y:\n"
-    "calculated by gammaincinv(k+1, y).  k must be a nonnegative\n"
-    "integer and y between 0 and 1.")
+    "Returns the Poisson variable `m` such that the sum from 0 to `k` of\n"
+    "the Poisson density is equal to the given probability `y`:\n"
+    "calculated by gammaincinv(k+1, y). `k` must be a nonnegative\n"
+    "integer and `y` between 0 and 1.")
 ufunc_pdtri_loops[0] = <np.PyUFuncGenericFunction>loop_d_id__As_ld_d
 ufunc_pdtri_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_pdtri_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
@@ -8443,9 +8514,9 @@ cdef void *ufunc_pdtrik_ptr[4]
 cdef void *ufunc_pdtrik_data[2]
 cdef char ufunc_pdtrik_types[6]
 cdef char *ufunc_pdtrik_doc = (
-    "pdtrik(p,m)\n"
+    "pdtrik(p, m)\n"
     "\n"
-    "Inverse to pdtr vs k\n"
+    "Inverse to `pdtr` vs k\n"
     "\n"
     "Returns the quantile k such that ``pdtr(k, m) = p``")
 ufunc_pdtrik_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
@@ -8501,13 +8572,13 @@ cdef void *ufunc_pro_ang1_ptr[4]
 cdef void *ufunc_pro_ang1_data[2]
 cdef char ufunc_pro_ang1_types[12]
 cdef char *ufunc_pro_ang1_doc = (
-    "pro_ang1(m,n,c,x)\n"
+    "pro_ang1(m, n, c, x)\n"
     "\n"
     "Prolate spheroidal angular function of the first kind and its derivative\n"
     "\n"
     "Computes the prolate spheroidal angular function of the first kind\n"
-    "and its derivative (with respect to x) for mode parameters m>=0\n"
-    "and n>=m, spheroidal parameter c and ``|x| < 1.0``.\n"
+    "and its derivative (with respect to `x`) for mode parameters m>=0\n"
+    "and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.\n"
     "\n"
     "Returns\n"
     "-------\n"
@@ -8542,13 +8613,13 @@ cdef void *ufunc_pro_ang1_cv_ptr[4]
 cdef void *ufunc_pro_ang1_cv_data[2]
 cdef char ufunc_pro_ang1_cv_types[14]
 cdef char *ufunc_pro_ang1_cv_doc = (
-    "pro_ang1_cv(m,n,c,cv,x)\n"
+    "pro_ang1_cv(m, n, c, cv, x)\n"
     "\n"
     "Prolate spheroidal angular function pro_ang1 for precomputed characteristic value\n"
     "\n"
     "Computes the prolate spheroidal angular function of the first kind\n"
-    "and its derivative (with respect to x) for mode parameters m>=0\n"
-    "and n>=m, spheroidal parameter c and ``|x| < 1.0``. Requires\n"
+    "and its derivative (with respect to `x`) for mode parameters m>=0\n"
+    "and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires\n"
     "pre-computed characteristic value.\n"
     "\n"
     "Returns\n"
@@ -8586,12 +8657,12 @@ cdef void *ufunc_pro_cv_ptr[4]
 cdef void *ufunc_pro_cv_data[2]
 cdef char ufunc_pro_cv_types[8]
 cdef char *ufunc_pro_cv_doc = (
-    "pro_cv(m,n,c)\n"
+    "pro_cv(m, n, c)\n"
     "\n"
     "Characteristic value of prolate spheroidal function\n"
     "\n"
     "Computes the characteristic value of prolate spheroidal wave\n"
-    "functions of order m,n (n>=m) and spheroidal parameter c.")
+    "functions of order `m`, `n` (n>=m) and spheroidal parameter `c`.")
 ufunc_pro_cv_loops[0] = <np.PyUFuncGenericFunction>loop_d_ddd__As_fff_f
 ufunc_pro_cv_loops[1] = <np.PyUFuncGenericFunction>loop_d_ddd__As_ddd_d
 ufunc_pro_cv_types[0] = <char>NPY_FLOAT
@@ -8615,13 +8686,13 @@ cdef void *ufunc_pro_rad1_ptr[4]
 cdef void *ufunc_pro_rad1_data[2]
 cdef char ufunc_pro_rad1_types[12]
 cdef char *ufunc_pro_rad1_doc = (
-    "pro_rad1(m,n,c,x)\n"
+    "pro_rad1(m, n, c, x)\n"
     "\n"
     "Prolate spheroidal radial function of the first kind and its derivative\n"
     "\n"
     "Computes the prolate spheroidal radial function of the first kind\n"
-    "and its derivative (with respect to x) for mode parameters m>=0\n"
-    "and n>=m, spheroidal parameter c and ``|x| < 1.0``.\n"
+    "and its derivative (with respect to `x`) for mode parameters m>=0\n"
+    "and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.\n"
     "\n"
     "Returns\n"
     "-------\n"
@@ -8656,13 +8727,13 @@ cdef void *ufunc_pro_rad1_cv_ptr[4]
 cdef void *ufunc_pro_rad1_cv_data[2]
 cdef char ufunc_pro_rad1_cv_types[14]
 cdef char *ufunc_pro_rad1_cv_doc = (
-    "pro_rad1_cv(m,n,c,cv,x)\n"
+    "pro_rad1_cv(m, n, c, cv, x)\n"
     "\n"
     "Prolate spheroidal radial function pro_rad1 for precomputed characteristic value\n"
     "\n"
     "Computes the prolate spheroidal radial function of the first kind\n"
-    "and its derivative (with respect to x) for mode parameters m>=0\n"
-    "and n>=m, spheroidal parameter c and ``|x| < 1.0``. Requires\n"
+    "and its derivative (with respect to `x`) for mode parameters m>=0\n"
+    "and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires\n"
     "pre-computed characteristic value.\n"
     "\n"
     "Returns\n"
@@ -8700,13 +8771,13 @@ cdef void *ufunc_pro_rad2_ptr[4]
 cdef void *ufunc_pro_rad2_data[2]
 cdef char ufunc_pro_rad2_types[12]
 cdef char *ufunc_pro_rad2_doc = (
-    "pro_rad2(m,n,c,x)\n"
+    "pro_rad2(m, n, c, x)\n"
     "\n"
     "Prolate spheroidal radial function of the secon kind and its derivative\n"
     "\n"
     "Computes the prolate spheroidal radial function of the second kind\n"
-    "and its derivative (with respect to x) for mode parameters m>=0\n"
-    "and n>=m, spheroidal parameter c and ``|x| < 1.0``.\n"
+    "and its derivative (with respect to `x`) for mode parameters m>=0\n"
+    "and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.\n"
     "\n"
     "Returns\n"
     "-------\n"
@@ -8741,13 +8812,13 @@ cdef void *ufunc_pro_rad2_cv_ptr[4]
 cdef void *ufunc_pro_rad2_cv_data[2]
 cdef char ufunc_pro_rad2_cv_types[14]
 cdef char *ufunc_pro_rad2_cv_doc = (
-    "pro_rad2_cv(m,n,c,cv,x)\n"
+    "pro_rad2_cv(m, n, c, cv, x)\n"
     "\n"
     "Prolate spheroidal radial function pro_rad2 for precomputed characteristic value\n"
     "\n"
     "Computes the prolate spheroidal radial function of the second kind\n"
-    "and its derivative (with respect to x) for mode parameters m>=0\n"
-    "and n>=m, spheroidal parameter c and ``|x| < 1.0``. Requires\n"
+    "and its derivative (with respect to `x`) for mode parameters m>=0\n"
+    "and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires\n"
     "pre-computed characteristic value.\n"
     "\n"
     "Returns\n"
@@ -8834,7 +8905,7 @@ cdef char *ufunc_psi_doc = (
     "Digamma function\n"
     "\n"
     "The derivative of the logarithm of the gamma function evaluated at\n"
-    "z (also called the digamma function).")
+    "`z` (also called the digamma function).")
 ufunc_psi_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_psi_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_psi_loops[2] = <np.PyUFuncGenericFunction>loop_D_D__As_F_F
@@ -8983,8 +9054,8 @@ cdef char *ufunc_round_doc = (
     "\n"
     "Round to nearest integer\n"
     "\n"
-    "Returns the nearest integer to x as a double precision floating\n"
-    "point result.  If x ends in 0.5 exactly, the nearest even integer\n"
+    "Returns the nearest integer to `x` as a double precision floating\n"
+    "point result.  If `x` ends in 0.5 exactly, the nearest even integer\n"
     "is chosen.")
 ufunc_round_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_round_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
@@ -9099,7 +9170,7 @@ cdef char *ufunc_smirnov_doc = (
     "distribution function (Dn+ or Dn-) for a one-sided test of\n"
     "equality between an empirical and a theoretical distribution. It\n"
     "is equal to the probability that the maximum difference between a\n"
-    "theoretical distribution and an empirical one based on n samples\n"
+    "theoretical distribution and an empirical one based on `n` samples\n"
     "is greater than e.")
 ufunc_smirnov_loops[0] = <np.PyUFuncGenericFunction>loop_d_id__As_ld_d
 ufunc_smirnov_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
@@ -9131,7 +9202,7 @@ cdef char ufunc_smirnovi_types[9]
 cdef char *ufunc_smirnovi_doc = (
     "smirnovi(n, y)\n"
     "\n"
-    "Inverse to smirnov\n"
+    "Inverse to `smirnov`\n"
     "\n"
     "Returns ``e`` such that ``smirnov(n, e) = y``.")
 ufunc_smirnovi_loops[0] = <np.PyUFuncGenericFunction>loop_d_id__As_ld_d
@@ -9168,7 +9239,7 @@ cdef char *ufunc_spence_doc = (
     "\n"
     "Returns the dilogarithm integral::\n"
     "\n"
-    "    -integral(log t / (t-1),t=1..x)")
+    "    -integral(log t / (t-1), t=1..x)")
 ufunc_spence_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_spence_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_spence_types[0] = <char>NPY_FLOAT
@@ -9256,7 +9327,7 @@ cdef void *ufunc_stdtr_ptr[4]
 cdef void *ufunc_stdtr_data[2]
 cdef char ufunc_stdtr_types[6]
 cdef char *ufunc_stdtr_doc = (
-    "stdtr(df,t)\n"
+    "stdtr(df, t)\n"
     "\n"
     "Student t distribution cumulative density function\n"
     "\n"
@@ -9286,11 +9357,11 @@ cdef void *ufunc_stdtridf_ptr[4]
 cdef void *ufunc_stdtridf_data[2]
 cdef char ufunc_stdtridf_types[6]
 cdef char *ufunc_stdtridf_doc = (
-    "stdtridf(p,t)\n"
+    "stdtridf(p, t)\n"
     "\n"
-    "Inverse of stdtr vs df\n"
+    "Inverse of `stdtr` vs df\n"
     "\n"
-    "Returns the argument df such that stdtr(df,t) is equal to p.")
+    "Returns the argument df such that stdtr(df, t) is equal to `p`.")
 ufunc_stdtridf_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_stdtridf_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
 ufunc_stdtridf_types[0] = <char>NPY_FLOAT
@@ -9312,11 +9383,11 @@ cdef void *ufunc_stdtrit_ptr[4]
 cdef void *ufunc_stdtrit_data[2]
 cdef char ufunc_stdtrit_types[6]
 cdef char *ufunc_stdtrit_doc = (
-    "stdtrit(df,p)\n"
+    "stdtrit(df, p)\n"
     "\n"
-    "Inverse of stdtr vs t\n"
+    "Inverse of `stdtr` vs `t`\n"
     "\n"
-    "Returns the argument t such that stdtr(df,t) is equal to p.")
+    "Returns the argument `t` such that stdtr(df, t) is equal to `p`.")
 ufunc_stdtrit_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_stdtrit_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
 ufunc_stdtrit_types[0] = <char>NPY_FLOAT
@@ -9338,12 +9409,12 @@ cdef void *ufunc_struve_ptr[4]
 cdef void *ufunc_struve_data[2]
 cdef char ufunc_struve_types[6]
 cdef char *ufunc_struve_doc = (
-    "struve(v,x)\n"
+    "struve(v, x)\n"
     "\n"
     "Struve function\n"
     "\n"
-    "Computes the struve function Hv(x) of order v at x, x must be\n"
-    "positive unless v is an integer.")
+    "Computes the struve function Hv(x) of order `v` at `x`, `x` must be\n"
+    "positive unless `v` is an integer.")
 ufunc_struve_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_struve_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
 ufunc_struve_types[0] = <char>NPY_FLOAT
@@ -9444,7 +9515,7 @@ cdef char ufunc_xlog1py_types[6]
 cdef char *ufunc_xlog1py_doc = (
     "xlog1py(x, y)\n"
     "\n"
-    "Compute ``x*log1p(y)`` so that the result is 0 if `x = 0`.\n"
+    "Compute ``x*log1p(y)`` so that the result is 0 if ``x = 0``.\n"
     "\n"
     "Parameters\n"
     "----------\n"
@@ -9485,7 +9556,7 @@ cdef char ufunc_xlogy_types[12]
 cdef char *ufunc_xlogy_doc = (
     "xlogy(x, y)\n"
     "\n"
-    "Compute ``x*log(y)`` so that the result is 0 if `x = 0`.\n"
+    "Compute ``x*log(y)`` so that the result is 0 if ``x = 0``.\n"
     "\n"
     "Parameters\n"
     "----------\n"
@@ -9542,7 +9613,7 @@ cdef char *ufunc_y0_doc = (
     "\n"
     "Bessel function of the second kind of order 0\n"
     "\n"
-    "Returns the Bessel function of the second kind of order 0 at x.")
+    "Returns the Bessel function of the second kind of order 0 at `x`.")
 ufunc_y0_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_y0_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_y0_types[0] = <char>NPY_FLOAT
@@ -9566,7 +9637,7 @@ cdef char *ufunc_y1_doc = (
     "\n"
     "Bessel function of the second kind of order 1\n"
     "\n"
-    "Returns the Bessel function of the second kind of order 1 at x.")
+    "Returns the Bessel function of the second kind of order 1 at `x`.")
 ufunc_y1_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_y1_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_y1_types[0] = <char>NPY_FLOAT
@@ -9586,12 +9657,12 @@ cdef void *ufunc_yn_ptr[6]
 cdef void *ufunc_yn_data[3]
 cdef char ufunc_yn_types[9]
 cdef char *ufunc_yn_doc = (
-    "yn(n,x)\n"
+    "yn(n, x)\n"
     "\n"
     "Bessel function of the second kind of integer order\n"
     "\n"
-    "Returns the Bessel function of the second kind of integer order n\n"
-    "at x.")
+    "Returns the Bessel function of the second kind of integer order `n`\n"
+    "at `x`.")
 ufunc_yn_loops[0] = <np.PyUFuncGenericFunction>loop_d_id__As_ld_d
 ufunc_yn_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_yn_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
@@ -9620,12 +9691,12 @@ cdef void *ufunc_yv_ptr[8]
 cdef void *ufunc_yv_data[4]
 cdef char ufunc_yv_types[12]
 cdef char *ufunc_yv_doc = (
-    "yv(v,z)\n"
+    "yv(v, z)\n"
     "\n"
     "Bessel function of the second kind of real order\n"
     "\n"
-    "Returns the Bessel function of the second kind of real order v at\n"
-    "complex z.")
+    "Returns the Bessel function of the second kind of real order `v` at\n"
+    "complex `z`.")
 ufunc_yv_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_yv_loops[1] = <np.PyUFuncGenericFunction>loop_D_dD__As_fF_F
 ufunc_yv_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
@@ -9661,14 +9732,14 @@ cdef void *ufunc_yve_ptr[8]
 cdef void *ufunc_yve_data[4]
 cdef char ufunc_yve_types[12]
 cdef char *ufunc_yve_doc = (
-    "yve(v,z)\n"
+    "yve(v, z)\n"
     "\n"
     "Exponentially scaled Bessel function of the second kind of real order\n"
     "\n"
     "Returns the exponentially scaled Bessel function of the second\n"
-    "kind of real order v at complex z::\n"
+    "kind of real order `v` at complex `z`::\n"
     "\n"
-    "    yve(v,z) = yv(v,z) * exp(-abs(z.imag))")
+    "    yve(v, z) = yv(v, z) * exp(-abs(z.imag))")
 ufunc_yve_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
 ufunc_yve_loops[1] = <np.PyUFuncGenericFunction>loop_D_dD__As_fF_F
 ufunc_yve_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
@@ -9709,7 +9780,7 @@ cdef char *ufunc_zeta_doc = (
     "Hurwitz zeta function\n"
     "\n"
     "The Riemann zeta function of two arguments (also known as the\n"
-    "Hurwitz zeta funtion).\n"
+    "Hurwitz zeta function).\n"
     "\n"
     "This function is defined as\n"
     "\n"

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -129,7 +129,7 @@ add_newdoc("scipy.special", "bdtr",
 
     ::
 
-        y = sum(nCj p**j (1-p)**(n-j),j=0..k)
+        y = sum(nCj p**j (1-p)**(n-j), j=0..k)
 
     Parameters
     ----------
@@ -269,7 +269,7 @@ add_newdoc("scipy.special", "beta",
 
     ::
 
-        beta(a,b) =  gamma(a) * gamma(b) / gamma(a+b)
+        beta(a, b) =  gamma(a) * gamma(b) / gamma(a+b)
     """)
 
 add_newdoc("scipy.special", "betainc",
@@ -298,7 +298,7 @@ add_newdoc("scipy.special", "betaincinv",
 
     Inverse function to beta integral.
 
-    Compute x such that betainc(a,b,x) = y.
+    Compute x such that betainc(a, b, x) = y.
     """)
 
 add_newdoc("scipy.special", "betaln",
@@ -464,7 +464,7 @@ add_newdoc("scipy.special", "inv_boxcox1p",
 
 add_newdoc("scipy.special", "btdtr",
     """
-    btdtr(a,b,x)
+    btdtr(a, b, x)
 
     Cumulative beta distribution.
 
@@ -479,12 +479,12 @@ add_newdoc("scipy.special", "btdtr",
 
 add_newdoc("scipy.special", "btdtri",
     """
-    btdtri(a,b,p)
+    btdtri(a, b, p)
 
     p-th quantile of the beta distribution.
 
     This is effectively the inverse of btdtr returning the value of x for which
-    ``btdtr(a,b,x) = p``
+    ``btdtr(a, b, x) = p``
 
     See Also
     --------
@@ -512,7 +512,7 @@ add_newdoc("scipy.special", "chdtr",
 
 add_newdoc("scipy.special", "chdtrc",
     """
-    chdtrc(v,x)
+    chdtrc(v, x)
 
     Chi square survival function
 
@@ -525,11 +525,11 @@ add_newdoc("scipy.special", "chdtrc",
 
 add_newdoc("scipy.special", "chdtri",
     """
-    chdtri(v,p)
+    chdtri(v, p)
 
     Inverse to chdtrc
 
-    Returns the argument x such that ``chdtrc(v,x) == p``.
+    Returns the argument x such that ``chdtrc(v, x) == p``.
     """)
 
 add_newdoc("scipy.special", "chdtriv",
@@ -599,7 +599,7 @@ add_newdoc("scipy.special", "dawsn",
 
     Computes::
 
-        exp(-x**2) * integral(exp(t**2),t=0..x).
+        exp(-x**2) * integral(exp(t**2), t=0..x).
 
     References
     ----------
@@ -992,7 +992,7 @@ add_newdoc("scipy.special", "exp1",
 
     ::
 
-        integral(exp(-z*t)/t,t=1..inf).
+        integral(exp(-z*t)/t, t=1..inf).
     """)
 
 add_newdoc("scipy.special", "exp10",
@@ -1017,7 +1017,7 @@ add_newdoc("scipy.special", "expi",
 
     Defined as::
 
-        integral(exp(t)/t,t=-inf..x)
+        integral(exp(t)/t, t=-inf..x)
 
     See `expn` for a different exponential integral.
     """)
@@ -1130,7 +1130,7 @@ add_newdoc("scipy.special", "fdtridfd",
 
     Inverse to fdtr vs dfd
 
-    Finds the F density argument dfd such that ``fdtr(dfn,dfd,x) == p``.
+    Finds the F density argument dfd such that ``fdtr(dfn, dfd, x) == p``.
     """)
 
 add_newdoc("scipy.special", "fdtridfn",
@@ -1139,7 +1139,7 @@ add_newdoc("scipy.special", "fdtridfn",
 
     Inverse to fdtr vs dfn
 
-    finds the F density argument dfn such that ``fdtr(dfn,dfd,x) == p``.
+    finds the F density argument dfn such that ``fdtr(dfn, dfd, x) == p``.
     """)
 
 add_newdoc("scipy.special", "fresnel",
@@ -1150,8 +1150,8 @@ add_newdoc("scipy.special", "fresnel",
 
     Defined as::
 
-        ssa = integral(sin(pi/2 * t**2),t=0..z)
-        csa = integral(cos(pi/2 * t**2),t=0..z)
+        ssa = integral(sin(pi/2 * t**2), t=0..z)
+        csa = integral(cos(pi/2 * t**2), t=0..z)
 
     Parameters
     ----------
@@ -1191,24 +1191,24 @@ add_newdoc("scipy.special", "gammainc",
 
 add_newdoc("scipy.special", "gammaincc",
     """
-    gammaincc(a,x)
+    gammaincc(a, x)
 
     Complemented incomplete gamma integral
 
     Defined as::
 
-        1 / gamma(a) * integral(exp(-t) * t**(a-1), t=x..inf) = 1 - gammainc(a,x)
+        1 / gamma(a) * integral(exp(-t) * t**(a-1), t=x..inf) = 1 - gammainc(a, x)
 
     `a` must be positive and `x` must be >= 0.
     """)
 
 add_newdoc("scipy.special", "gammainccinv",
     """
-    gammainccinv(a,y)
+    gammainccinv(a, y)
 
     Inverse to gammaincc
 
-    Returns `x` such that ``gammaincc(a,x) == y``.
+    Returns `x` such that ``gammaincc(a, x) == y``.
     """)
 
 add_newdoc("scipy.special", "gammaincinv",
@@ -1248,14 +1248,14 @@ add_newdoc("scipy.special", "gammasgn",
 
 add_newdoc("scipy.special", "gdtr",
     """
-    gdtr(a,b,x)
+    gdtr(a, b, x)
 
     Gamma distribution cumulative density function.
 
     Returns the integral from zero to x of the gamma probability
     density function::
 
-        a**b / gamma(b) * integral(t**(b-1) exp(-at),t=0..x).
+        a**b / gamma(b) * integral(t**(b-1) exp(-at), t=0..x).
 
     The arguments a and b are used differently here than in other
     definitions.
@@ -1263,7 +1263,7 @@ add_newdoc("scipy.special", "gdtr",
 
 add_newdoc("scipy.special", "gdtrc",
     """
-    gdtrc(a,b,x)
+    gdtrc(a, b, x)
 
     Gamma distribution survival function.
 
@@ -1452,7 +1452,7 @@ add_newdoc("scipy.special", "hankel1e",
 
     Defined as::
 
-        hankel1e(v,z) = hankel1(v,z) * exp(-1j * z)
+        hankel1e(v, z) = hankel1(v, z) * exp(-1j * z)
 
     Parameters
     ----------
@@ -1485,7 +1485,7 @@ add_newdoc("scipy.special", "hankel2e",
 
     Defined as::
 
-        hankel1e(v,z) = hankel1(v,z) * exp(1j * z)
+        hankel1e(v, z) = hankel1(v, z) * exp(1j * z)
 
     Parameters
     ----------
@@ -1636,7 +1636,7 @@ add_newdoc("scipy.special", "it2i0k0",
     ii0
         ``integral((i0(t)-1)/t, t=0..x)``
     ik0
-        ``int(k0(t)/t,t=x..inf)``
+        ``int(k0(t)/t, t=x..inf)``
     """)
 
 add_newdoc("scipy.special", "it2j0y0",
@@ -1736,7 +1736,7 @@ add_newdoc("scipy.special", "itstruve0",
 
 add_newdoc("scipy.special", "iv",
     """
-    iv(v,z)
+    iv(v, z)
 
     Modified Bessel function of the first kind  of real order
 
@@ -1751,13 +1751,13 @@ add_newdoc("scipy.special", "iv",
 
 add_newdoc("scipy.special", "ive",
     """
-    ive(v,z)
+    ive(v, z)
 
     Exponentially scaled modified Bessel function of the first kind
 
     Defined as::
 
-        ive(v,z) = iv(v,z) * exp(-abs(z.real))
+        ive(v, z) = iv(v, z) * exp(-abs(z.real))
     """)
 
 add_newdoc("scipy.special", "j0",
@@ -1801,7 +1801,7 @@ add_newdoc("scipy.special", "jve",
 
     Defined as::
 
-        jve(v,z) = jv(v,z) * exp(-abs(z.imag))
+        jve(v, z) = jv(v, z) * exp(-abs(z.imag))
     """)
 
 add_newdoc("scipy.special", "k0",
@@ -1952,7 +1952,7 @@ add_newdoc("scipy.special", "kolmogorov",
 
 add_newdoc("scipy.special", "kv",
     """
-    kv(v,z)
+    kv(v, z)
 
     Modified Bessel function of the second kind of real order v
 
@@ -1962,7 +1962,7 @@ add_newdoc("scipy.special", "kv",
 
 add_newdoc("scipy.special", "kve",
     """
-    kve(v,z)
+    kve(v, z)
 
     Exponentially scaled modified Bessel function of the second kind.
 
@@ -1970,7 +1970,7 @@ add_newdoc("scipy.special", "kve",
     second kind (sometimes called the third kind) for real order v at
     complex z::
 
-        kve(v,z) = kv(v,z) * exp(z)
+        kve(v, z) = kv(v, z) * exp(z)
     """)
 
 add_newdoc("scipy.special", "log1p",
@@ -2030,33 +2030,33 @@ add_newdoc("scipy.special", "lpmv",
 
 add_newdoc("scipy.special", "mathieu_a",
     """
-    mathieu_a(m,q)
+    mathieu_a(m, q)
 
     Characteristic value of even Mathieu functions
 
     Returns the characteristic value for the even solution,
-    ``ce_m(z,q)``, of Mathieu's equation.
+    ``ce_m(z, q)``, of Mathieu's equation.
     """)
 
 add_newdoc("scipy.special", "mathieu_b",
     """
-    mathieu_b(m,q)
+    mathieu_b(m, q)
 
     Characteristic value of odd Mathieu functions
 
     Returns the characteristic value for the odd solution,
-    ``se_m(z,q)``, of Mathieu's equation.
+    ``se_m(z, q)``, of Mathieu's equation.
     """)
 
 add_newdoc("scipy.special", "mathieu_cem",
     """
-    mathieu_cem(m,q,x)
+    mathieu_cem(m, q, x)
 
     Even Mathieu function and its derivative
 
-    Returns the even Mathieu function, ``ce_m(x,q)``, of order m and
+    Returns the even Mathieu function, ``ce_m(x, q)``, of order m and
     parameter q evaluated at x (given in degrees).  Also returns the
-    derivative with respect to x of ce_m(x,q)
+    derivative with respect to x of ce_m(x, q)
 
     Parameters
     ----------
@@ -2082,7 +2082,7 @@ add_newdoc("scipy.special", "mathieu_modcem1",
     Even modified Mathieu function of the first kind and its derivative
 
     Evaluates the even modified Mathieu function of the first kind,
-    ``Mc1m(x,q)``, and its derivative at `x` for order m and parameter
+    ``Mc1m(x, q)``, and its derivative at `x` for order m and parameter
     `q`.
 
     Returns
@@ -2100,7 +2100,7 @@ add_newdoc("scipy.special", "mathieu_modcem2",
     Even modified Mathieu function of the second kind and its derivative
 
     Evaluates the even modified Mathieu function of the second kind,
-    Mc2m(x,q), and its derivative at x (given in degrees) for order m
+    Mc2m(x, q), and its derivative at x (given in degrees) for order m
     and parameter q.
 
     Returns
@@ -2113,12 +2113,12 @@ add_newdoc("scipy.special", "mathieu_modcem2",
 
 add_newdoc("scipy.special", "mathieu_modsem1",
     """
-    mathieu_modsem1(m,q,x)
+    mathieu_modsem1(m, q, x)
 
     Odd modified Mathieu function of the first kind and its derivative
 
     Evaluates the odd modified Mathieu function of the first kind,
-    Ms1m(x,q), and its derivative at x (given in degrees) for order m
+    Ms1m(x, q), and its derivative at x (given in degrees) for order m
     and parameter q.
 
     Returns
@@ -2136,7 +2136,7 @@ add_newdoc("scipy.special", "mathieu_modsem2",
     Odd modified Mathieu function of the second kind and its derivative
 
     Evaluates the odd modified Mathieu function of the second kind,
-    Ms2m(x,q), and its derivative at x (given in degrees) for order m
+    Ms2m(x, q), and its derivative at x (given in degrees) for order m
     and parameter q.
 
     Returns
@@ -2153,9 +2153,9 @@ add_newdoc("scipy.special", "mathieu_sem",
 
     Odd Mathieu function and its derivative
 
-    Returns the odd Mathieu function, se_m(x,q), of order m and
+    Returns the odd Mathieu function, se_m(x, q), of order m and
     parameter q evaluated at x (given in degrees).  Also returns the
-    derivative with respect to x of se_m(x,q).
+    derivative with respect to x of se_m(x, q).
 
     Parameters
     ----------
@@ -2183,7 +2183,7 @@ add_newdoc("scipy.special", "modfresnelm",
     Returns
     -------
     fm
-        Integral ``F_-(x)``: ``integral(exp(-1j*t*t),t=x..inf)``
+        Integral ``F_-(x)``: ``integral(exp(-1j*t*t), t=x..inf)``
     km
         Integral ``K_-(x)``: ``1/sqrt(pi)*exp(1j*(x*x+pi/4))*fp``
     """)
@@ -2197,7 +2197,7 @@ add_newdoc("scipy.special", "modfresnelp",
     Returns
     -------
     fp
-        Integral ``F_+(x)``: ``integral(exp(1j*t*t),t=x..inf)``
+        Integral ``F_+(x)``: ``integral(exp(1j*t*t), t=x..inf)``
     kp
         Integral ``K_+(x)``: ``1/sqrt(pi)*exp(-1j*(x*x+pi/4))*fp``
     """)
@@ -2221,7 +2221,7 @@ add_newdoc("scipy.special", "nbdtr",
     Returns the sum of the terms 0 through k of the negative binomial
     distribution::
 
-        sum((n+j-1)Cj p**n (1-p)**j,j=0..k).
+        sum((n+j-1)Cj p**n (1-p)**j, j=0..k).
 
     In a sequence of Bernoulli trials this is the probability that k
     or fewer failures precede the nth success.
@@ -2229,7 +2229,7 @@ add_newdoc("scipy.special", "nbdtr",
 
 add_newdoc("scipy.special", "nbdtrc",
     """
-    nbdtrc(k,n,p)
+    nbdtrc(k, n, p)
 
     Negative binomial survival function
 
@@ -2243,25 +2243,25 @@ add_newdoc("scipy.special", "nbdtri",
 
     Inverse of nbdtr vs p
 
-    Finds the argument p such that ``nbdtr(k,n,p) = y``.
+    Finds the argument p such that ``nbdtr(k, n, p) = y``.
     """)
 
 add_newdoc("scipy.special", "nbdtrik",
     """
-    nbdtrik(y,n,p)
+    nbdtrik(y, n, p)
 
     Inverse of nbdtr vs k
 
-    Finds the argument k such that ``nbdtr(k,n,p) = y``.
+    Finds the argument k such that ``nbdtr(k, n, p) = y``.
     """)
 
 add_newdoc("scipy.special", "nbdtrin",
     """
-    nbdtrin(k,y,p)
+    nbdtrin(k, y, p)
 
     Inverse of nbdtr vs n
 
-    Finds the argument n such that ``nbdtr(k,n,p) = y``.
+    Finds the argument n such that ``nbdtr(k, n, p) = y``.
     """)
 
 add_newdoc("scipy.special", "ncfdtr",
@@ -2472,7 +2472,7 @@ add_newdoc("scipy.special", "ndtr",
     Returns the area under the standard Gaussian probability
     density function, integrated from minus infinity to x::
 
-        1/sqrt(2*pi) * integral(exp(-t**2 / 2),t=-inf..x)
+        1/sqrt(2*pi) * integral(exp(-t**2 / 2), t=-inf..x)
 
     """)
 
@@ -2595,12 +2595,12 @@ add_newdoc("scipy.special", "obl_cv",
     Characteristic value of oblate spheroidal function
 
     Computes the characteristic value of oblate spheroidal wave
-    functions of order m,n (n>=m) and spheroidal parameter c.
+    functions of order m, n (n>=m) and spheroidal parameter c.
     """)
 
 add_newdoc("scipy.special", "obl_rad1",
     """
-    obl_rad1(m,n,c,x)
+    obl_rad1(m, n, c, x)
 
     Oblate spheroidal radial function of the first kind and its derivative
 
@@ -2618,7 +2618,7 @@ add_newdoc("scipy.special", "obl_rad1",
 
 add_newdoc("scipy.special", "obl_rad1_cv",
     """
-    obl_rad1_cv(m,n,c,cv,x)
+    obl_rad1_cv(m, n, c, cv, x)
 
     Oblate spheroidal radial function obl_rad1 for precomputed characteristic value
 
@@ -2637,7 +2637,7 @@ add_newdoc("scipy.special", "obl_rad1_cv",
 
 add_newdoc("scipy.special", "obl_rad2",
     """
-    obl_rad2(m,n,c,x)
+    obl_rad2(m, n, c, x)
 
     Oblate spheroidal radial function of the second kind and its derivative.
 
@@ -2655,7 +2655,7 @@ add_newdoc("scipy.special", "obl_rad2",
 
 add_newdoc("scipy.special", "obl_rad2_cv",
     """
-    obl_rad2_cv(m,n,c,cv,x)
+    obl_rad2_cv(m, n, c, cv, x)
 
     Oblate spheroidal radial function obl_rad2 for precomputed characteristic value
 
@@ -2678,7 +2678,7 @@ add_newdoc("scipy.special", "pbdv",
 
     Parabolic cylinder function D
 
-    Returns (d,dp) the parabolic cylinder function Dv(x) in d and the
+    Returns (d, dp) the parabolic cylinder function Dv(x) in d and the
     derivative, Dv'(x) in dp.
 
     Returns
@@ -2691,7 +2691,7 @@ add_newdoc("scipy.special", "pbdv",
 
 add_newdoc("scipy.special", "pbvv",
     """
-    pbvv(v,x)
+    pbvv(v, x)
 
     Parabolic cylinder function V
 
@@ -2708,12 +2708,12 @@ add_newdoc("scipy.special", "pbvv",
 
 add_newdoc("scipy.special", "pbwa",
     """
-    pbwa(a,x)
+    pbwa(a, x)
 
     Parabolic cylinder function W
 
-    Returns the parabolic cylinder function W(a,x) in w and the
-    derivative, W'(a,x) in wp.
+    Returns the parabolic cylinder function W(a, x) in w and the
+    derivative, W'(a, x) in wp.
 
     .. warning::
 
@@ -2751,7 +2751,7 @@ add_newdoc("scipy.special", "pdtrc",
 
 add_newdoc("scipy.special", "pdtri",
     """
-    pdtri(k,y)
+    pdtri(k, y)
 
     Inverse to pdtr vs m
 
@@ -2763,7 +2763,7 @@ add_newdoc("scipy.special", "pdtri",
 
 add_newdoc("scipy.special", "pdtrik",
     """
-    pdtrik(p,m)
+    pdtrik(p, m)
 
     Inverse to pdtr vs k
 
@@ -2787,7 +2787,7 @@ add_newdoc("scipy.special", "poch",
 
 add_newdoc("scipy.special", "pro_ang1",
     """
-    pro_ang1(m,n,c,x)
+    pro_ang1(m, n, c, x)
 
     Prolate spheroidal angular function of the first kind and its derivative
 
@@ -2805,7 +2805,7 @@ add_newdoc("scipy.special", "pro_ang1",
 
 add_newdoc("scipy.special", "pro_ang1_cv",
     """
-    pro_ang1_cv(m,n,c,cv,x)
+    pro_ang1_cv(m, n, c, cv, x)
 
     Prolate spheroidal angular function pro_ang1 for precomputed characteristic value
 
@@ -2824,17 +2824,17 @@ add_newdoc("scipy.special", "pro_ang1_cv",
 
 add_newdoc("scipy.special", "pro_cv",
     """
-    pro_cv(m,n,c)
+    pro_cv(m, n, c)
 
     Characteristic value of prolate spheroidal function
 
     Computes the characteristic value of prolate spheroidal wave
-    functions of order m,n (n>=m) and spheroidal parameter c.
+    functions of order m, n (n>=m) and spheroidal parameter c.
     """)
 
 add_newdoc("scipy.special", "pro_rad1",
     """
-    pro_rad1(m,n,c,x)
+    pro_rad1(m, n, c, x)
 
     Prolate spheroidal radial function of the first kind and its derivative
 
@@ -2852,7 +2852,7 @@ add_newdoc("scipy.special", "pro_rad1",
 
 add_newdoc("scipy.special", "pro_rad1_cv",
     """
-    pro_rad1_cv(m,n,c,cv,x)
+    pro_rad1_cv(m, n, c, cv, x)
 
     Prolate spheroidal radial function pro_rad1 for precomputed characteristic value
 
@@ -2871,7 +2871,7 @@ add_newdoc("scipy.special", "pro_rad1_cv",
 
 add_newdoc("scipy.special", "pro_rad2",
     """
-    pro_rad2(m,n,c,x)
+    pro_rad2(m, n, c, x)
 
     Prolate spheroidal radial function of the secon kind and its derivative
 
@@ -2889,7 +2889,7 @@ add_newdoc("scipy.special", "pro_rad2",
 
 add_newdoc("scipy.special", "pro_rad2_cv",
     """
-    pro_rad2_cv(m,n,c,cv,x)
+    pro_rad2_cv(m, n, c, cv, x)
 
     Prolate spheroidal radial function pro_rad2 for precomputed characteristic value
 
@@ -3074,12 +3074,12 @@ add_newdoc("scipy.special", "spence",
 
     Returns the dilogarithm integral::
 
-        -integral(log t / (t-1),t=1..x)
+        -integral(log t / (t-1), t=1..x)
     """)
 
 add_newdoc("scipy.special", "stdtr",
     """
-    stdtr(df,t)
+    stdtr(df, t)
 
     Student t distribution cumulative density function
 
@@ -3093,25 +3093,25 @@ add_newdoc("scipy.special", "stdtr",
 
 add_newdoc("scipy.special", "stdtridf",
     """
-    stdtridf(p,t)
+    stdtridf(p, t)
 
     Inverse of stdtr vs df
 
-    Returns the argument df such that stdtr(df,t) is equal to p.
+    Returns the argument df such that stdtr(df, t) is equal to p.
     """)
 
 add_newdoc("scipy.special", "stdtrit",
     """
-    stdtrit(df,p)
+    stdtrit(df, p)
 
     Inverse of stdtr vs t
 
-    Returns the argument t such that stdtr(df,t) is equal to p.
+    Returns the argument t such that stdtr(df, t) is equal to p.
     """)
 
 add_newdoc("scipy.special", "struve",
     """
-    struve(v,x)
+    struve(v, x)
 
     Struve function
 
@@ -3220,7 +3220,7 @@ add_newdoc("scipy.special", "y1",
 
 add_newdoc("scipy.special", "yn",
     """
-    yn(n,x)
+    yn(n, x)
 
     Bessel function of the second kind of integer order
 
@@ -3230,7 +3230,7 @@ add_newdoc("scipy.special", "yn",
 
 add_newdoc("scipy.special", "yv",
     """
-    yv(v,z)
+    yv(v, z)
 
     Bessel function of the second kind of real order
 
@@ -3240,14 +3240,14 @@ add_newdoc("scipy.special", "yv",
 
 add_newdoc("scipy.special", "yve",
     """
-    yve(v,z)
+    yve(v, z)
 
     Exponentially scaled Bessel function of the second kind of real order
 
     Returns the exponentially scaled Bessel function of the second
     kind of real order v at complex z::
 
-        yve(v,z) = yv(v,z) * exp(-abs(z.imag))
+        yve(v, z) = yv(v, z) * exp(-abs(z.imag))
 
     """)
 

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1926,7 +1926,39 @@ add_newdoc("scipy.special", "kn",
 
     Modified Bessel function of the second kind of integer order `n`
 
-    These are also sometimes called functions of the third kind.
+    Returns the modified Bessel function of the second kind for integer order
+    `n` at real `z`.
+
+    These are also sometimes called functions of the third kind, Basset
+    functions, or Macdonald functions.
+
+    Parameters
+    ----------
+    n : array_like of int
+        Order of Bessel functions (floats will truncate with a warning)
+    z : array_like of float
+        Argument at which to evaluate the Bessel functions
+
+    Returns
+    -------
+    out : ndarray
+        The results
+
+    Examples
+    --------
+    Plot the function of several orders for real input:
+
+    >>> import matplotlib.pyplot as plt
+    >>> for N in range(6):
+    >>>     plot(x, kn(N, x), label='$K_{}(x)$'.format(N))
+    >>> plt.ylim(0, 10)
+    >>> plt.legend()
+    >>> plt.title(r'Modified Bessel function of the second kind $K_n(x)$')
+
+    Calculate for a single value at multiple orders:
+
+    >>> print(kn([4, 5, 6], 1))
+    [   44.23241425   360.96060181  3653.83837891]
     """)
 
 add_newdoc("scipy.special", "kolmogi",
@@ -1957,8 +1989,40 @@ add_newdoc("scipy.special", "kv",
 
     Modified Bessel function of the second kind of real order `v`
 
-    Returns the modified Bessel function of the second kind (sometimes
-    called the third kind) for real order v at complex z.
+    Returns the modified Bessel function of the second kind for real order
+    `v` at complex `z`.
+
+    These are also sometimes called functions of the third kind, Basset
+    functions, or Macdonald functions.
+
+    Parameters
+    ----------
+    v : array_like of float
+        Order of Bessel functions
+    z : array_like of complex
+        Argument at which to evaluate the Bessel functions
+
+    Returns
+    -------
+    out : ndarray
+        The results
+
+    Examples
+    --------
+    Plot the function of several orders for real input:
+
+    >>> import matplotlib.pyplot as plt
+    >>> for N in linspace(0, 2, 5):
+    >>>     plot(x, kv(N, x), label='$K_{{{}}}(x)$'.format(N))
+    >>> plt.ylim(0, 10)
+    >>> plt.legend()
+    >>> plt.title(r'Modified Bessel function of the second kind $K_\nu(x)$')
+
+    Calculate for a single value at multiple orders:
+
+    >>> print(kv([4, 4.5, 5], 1+2j))
+    [ 0.19920848+2.38918114j  2.34926017+3.59995073j  7.28267680+3.81037734j]
+
     """)
 
 add_newdoc("scipy.special", "kve",

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1954,6 +1954,7 @@ add_newdoc("scipy.special", "kn",
     >>> plt.ylim(0, 10)
     >>> plt.legend()
     >>> plt.title(r'Modified Bessel function of the second kind $K_n(x)$')
+    >>> plt.show()
 
     Calculate for a single value at multiple orders:
 
@@ -2017,6 +2018,7 @@ add_newdoc("scipy.special", "kv",
     >>> plt.ylim(0, 10)
     >>> plt.legend()
     >>> plt.title(r'Modified Bessel function of the second kind $K_\nu(x)$')
+    >>> plt.show()
 
     Calculate for a single value at multiple orders:
 

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1944,6 +1944,11 @@ add_newdoc("scipy.special", "kn",
     out : ndarray
         The results
 
+    See Also
+    --------
+    kv : Same function, but accepts real order and complex argument
+    kvp : Derivative of this function
+
     Examples
     --------
     Plot the function of several orders for real input:
@@ -1960,8 +1965,8 @@ add_newdoc("scipy.special", "kn",
 
     Calculate for a single value at multiple orders:
 
-    >>> print(kn([4, 5, 6], 1))
-    [   44.23241425   360.96060181  3653.83837891]
+    >>> kn([4, 5, 6], 1)
+    array([   44.2324,   360.9606,  3653.8384], dtype=float32)
     """)
 
 add_newdoc("scipy.special", "kolmogi",
@@ -2026,8 +2031,8 @@ add_newdoc("scipy.special", "kv",
 
     Calculate for a single value at multiple orders:
 
-    >>> print(kv([4, 4.5, 5], 1+2j))
-    [ 0.19920848+2.38918114j  2.34926017+3.59995073j  7.28267680+3.81037734j]
+    >>> kv([4, 4.5, 5], 1+2j)
+    array([ 0.1992+2.3892j,  2.3493+3.6j   ,  7.2827+3.8104j])
 
     """)
 

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1948,9 +1948,11 @@ add_newdoc("scipy.special", "kn",
     --------
     Plot the function of several orders for real input:
 
+    >>> from scipy.special import kn
     >>> import matplotlib.pyplot as plt
+    >>> x = np.linspace(0, 5, 1000)
     >>> for N in range(6):
-    >>>     plot(x, kn(N, x), label='$K_{}(x)$'.format(N))
+    ...     plt.plot(x, kn(N, x), label='$K_{}(x)$'.format(N))
     >>> plt.ylim(0, 10)
     >>> plt.legend()
     >>> plt.title(r'Modified Bessel function of the second kind $K_n(x)$')
@@ -2012,9 +2014,11 @@ add_newdoc("scipy.special", "kv",
     --------
     Plot the function of several orders for real input:
 
+    >>> from scipy.special import kv
     >>> import matplotlib.pyplot as plt
-    >>> for N in linspace(0, 2, 5):
-    >>>     plot(x, kv(N, x), label='$K_{{{}}}(x)$'.format(N))
+    >>> x = np.linspace(0, 5, 1000)
+    >>> for N in np.linspace(0, 6, 5):
+    ...     plt.plot(x, kv(N, x), label='$K_{{{}}}(x)$'.format(N))
     >>> plt.ylim(0, 10)
     >>> plt.legend()
     >>> plt.title(r'Modified Bessel function of the second kind $K_\nu(x)$')

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -125,7 +125,7 @@ add_newdoc("scipy.special", "bdtr",
 
     Binomial distribution cumulative distribution function.
 
-    Sum of the terms 0 through k of the Binomial probability density.
+    Sum of the terms 0 through `k` of the Binomial probability density.
 
     ::
 
@@ -151,7 +151,7 @@ add_newdoc("scipy.special", "bdtrc",
 
     Binomial distribution survival function.
 
-    Sum of the terms k+1 through n of the Binomial probability density
+    Sum of the terms k+1 through `n` of the Binomial probability density
 
     ::
 
@@ -175,7 +175,7 @@ add_newdoc("scipy.special", "bdtri",
     """
     bdtri(k, n, y)
 
-    Inverse function to bdtr vs. p
+    Inverse function to `bdtr` vs. `p`
 
     Finds probability `p` such that for the cumulative binomial
     probability ``bdtr(k, n, p) == y``.
@@ -185,14 +185,14 @@ add_newdoc("scipy.special", "bdtrik",
     """
     bdtrik(y, n, p)
 
-    Inverse function to bdtr vs k
+    Inverse function to `bdtr` vs `k`
     """)
 
 add_newdoc("scipy.special", "bdtrin",
     """
     bdtrin(k, y, p)
 
-    Inverse function to bdtr vs n
+    Inverse function to `bdtr` vs `n`
     """)
 
 add_newdoc("scipy.special", "binom",
@@ -206,7 +206,7 @@ add_newdoc("scipy.special", "btdtria",
     """
     btdtria(p, b, x)
 
-    Inverse of btdtr vs a
+    Inverse of `btdtr` vs `a`
 
     """)
 
@@ -214,7 +214,7 @@ add_newdoc("scipy.special", "btdtrib",
     """
     btdtria(a, p, x)
 
-    Inverse of btdtr vs b
+    Inverse of `btdtr` vs `b`
 
     """)
 
@@ -229,7 +229,7 @@ add_newdoc("scipy.special", "beip",
     """
     beip(x)
 
-    Derivative of the Kelvin function bei
+    Derivative of the Kelvin function `bei`
     """)
 
 add_newdoc("scipy.special", "ber",
@@ -243,7 +243,7 @@ add_newdoc("scipy.special", "berp",
     """
     berp(x)
 
-    Derivative of the Kelvin function ber
+    Derivative of the Kelvin function `ber`
     """)
 
 add_newdoc("scipy.special", "besselpoly",
@@ -279,7 +279,7 @@ add_newdoc("scipy.special", "betainc",
     Incomplete beta integral.
 
     Compute the incomplete beta integral of the arguments, evaluated
-    from zero to x::
+    from zero to `x`::
 
         gamma(a+b) / (gamma(a)*gamma(b)) * integral(t**(a-1) (1-t)**(b-1), t=0..x).
 
@@ -298,7 +298,7 @@ add_newdoc("scipy.special", "betaincinv",
 
     Inverse function to beta integral.
 
-    Compute x such that betainc(a, b, x) = y.
+    Compute `x` such that betainc(a, b, x) = y.
     """)
 
 add_newdoc("scipy.special", "betaln",
@@ -468,7 +468,7 @@ add_newdoc("scipy.special", "btdtr",
 
     Cumulative beta distribution.
 
-    Returns the area from zero to x under the beta density function::
+    Returns the area from zero to `x` under the beta density function::
 
         gamma(a+b)/(gamma(a)*gamma(b)))*integral(t**(a-1) (1-t)**(b-1), t=0..x)
 
@@ -483,7 +483,7 @@ add_newdoc("scipy.special", "btdtri",
 
     p-th quantile of the beta distribution.
 
-    This is effectively the inverse of btdtr returning the value of x for which
+    This is effectively the inverse of `btdtr` returning the value of `x` for which
     ``btdtr(a, b, x) = p``
 
     See Also
@@ -495,7 +495,7 @@ add_newdoc("scipy.special", "cbrt",
     """
     cbrt(x)
 
-    Cube root of x
+    Cube root of `x`
     """)
 
 add_newdoc("scipy.special", "chdtr",
@@ -504,8 +504,8 @@ add_newdoc("scipy.special", "chdtr",
 
     Chi square cumulative distribution function
 
-    Returns the area under the left hand tail (from 0 to x) of the Chi
-    square probability density function with v degrees of freedom::
+    Returns the area under the left hand tail (from 0 to `x`) of the Chi
+    square probability density function with `v` degrees of freedom::
 
         1/(2**(v/2) * gamma(v/2)) * integral(t**(v/2-1) * exp(-t/2), t=0..x)
     """)
@@ -516,8 +516,8 @@ add_newdoc("scipy.special", "chdtrc",
 
     Chi square survival function
 
-    Returns the area under the right hand tail (from x to
-    infinity) of the Chi square probability density function with v
+    Returns the area under the right hand tail (from `x` to
+    infinity) of the Chi square probability density function with `v`
     degrees of freedom::
 
         1/(2**(v/2) * gamma(v/2)) * integral(t**(v/2-1) * exp(-t/2), t=x..inf)
@@ -527,7 +527,7 @@ add_newdoc("scipy.special", "chdtri",
     """
     chdtri(v, p)
 
-    Inverse to chdtrc
+    Inverse to `chdtrc`
 
     Returns the argument x such that ``chdtrc(v, x) == p``.
     """)
@@ -536,7 +536,7 @@ add_newdoc("scipy.special", "chdtriv",
     """
     chdtri(p, x)
 
-    Inverse to chdtr vs v
+    Inverse to `chdtr` vs `v`
 
     Returns the argument v such that ``chdtr(v, x) == p``.
     """)
@@ -553,42 +553,42 @@ add_newdoc("scipy.special", "chndtrix",
     """
     chndtrix(p, df, nc)
 
-    Inverse to chndtr vs x
+    Inverse to `chndtr` vs `x`
     """)
 
 add_newdoc("scipy.special", "chndtridf",
     """
     chndtridf(x, p, nc)
 
-    Inverse to chndtr vs df
+    Inverse to `chndtr` vs `df`
     """)
 
 add_newdoc("scipy.special", "chndtrinc",
     """
     chndtrinc(x, df, p)
 
-    Inverse to chndtr vs nc
+    Inverse to `chndtr` vs `nc`
     """)
 
 add_newdoc("scipy.special", "cosdg",
     """
     cosdg(x)
 
-    Cosine of the angle x given in degrees.
+    Cosine of the angle `x` given in degrees.
     """)
 
 add_newdoc("scipy.special", "cosm1",
     """
     cosm1(x)
 
-    cos(x) - 1 for use when x is near zero.
+    cos(x) - 1 for use when `x` is near zero.
     """)
 
 add_newdoc("scipy.special", "cotdg",
     """
     cotdg(x)
 
-    Cotangent of the angle x given in degrees.
+    Cotangent of the angle `x` given in degrees.
     """)
 
 add_newdoc("scipy.special", "dawsn",
@@ -629,7 +629,7 @@ add_newdoc("scipy.special", "ellipe",
 
     See Also
     --------
-    ellipkm1 : Complete elliptic integral of the first kind, near  m = 1
+    ellipkm1 : Complete elliptic integral of the first kind, near `m` = 1
     ellipk : Complete elliptic integral of the first kind
     ellipkinc : Incomplete elliptic integral of the first kind
     ellipeinc : Incomplete elliptic integral of the second kind
@@ -660,7 +660,7 @@ add_newdoc("scipy.special", "ellipeinc",
 
     See Also
     --------
-    ellipkm1 : Complete elliptic integral of the first kind, near m = 1
+    ellipkm1 : Complete elliptic integral of the first kind, near `m` = 1
     ellipk : Complete elliptic integral of the first kind
     ellipkinc : Incomplete elliptic integral of the first kind
     ellipe : Complete elliptic integral of the second kind
@@ -672,8 +672,8 @@ add_newdoc("scipy.special", "ellipj",
 
     Jacobian elliptic functions
 
-    Calculates the Jacobian elliptic functions of parameter m between
-    0 and 1, and real u.
+    Calculates the Jacobian elliptic functions of parameter `m` between
+    0 and 1, and real `u`.
 
     Parameters
     ----------
@@ -696,7 +696,7 @@ add_newdoc("scipy.special", "ellipkm1",
     """
     ellipkm1(p)
 
-    Complete elliptic integral of the first kind around m = 1
+    Complete elliptic integral of the first kind around `m` = 1
 
     This function is defined as
 
@@ -707,7 +707,7 @@ add_newdoc("scipy.special", "ellipkm1",
     Parameters
     ----------
     p : array_like
-        Defines the parameter of the elliptic integral as m = 1 - p.
+        Defines the parameter of the elliptic integral as `m` = 1 - p.
 
     Returns
     -------
@@ -751,7 +751,7 @@ add_newdoc("scipy.special", "ellipkinc",
 
     See Also
     --------
-    ellipkm1 : Complete elliptic integral of the first kind, near  m = 1
+    ellipkm1 : Complete elliptic integral of the first kind, near `m` = 1
     ellipk : Complete elliptic integral of the first kind
     ellipe : Complete elliptic integral of the second kind
     ellipeinc : Incomplete elliptic integral of the second kind
@@ -774,7 +774,7 @@ add_newdoc("scipy.special", "entr",
     Returns
     -------
     res : ndarray
-        The value of the elementwise entropy function at the given points x.
+        The value of the elementwise entropy function at the given points `x`.
 
     See Also
     --------
@@ -804,7 +804,7 @@ add_newdoc("scipy.special", "erf",
     Returns
     -------
     res : ndarray
-        The values of the error function at the given points x.
+        The values of the error function at the given points `x`.
 
     See Also
     --------
@@ -1056,7 +1056,7 @@ add_newdoc("scipy.special", "expm1",
     """
     expm1(x)
 
-    exp(x) - 1 for use when x is near zero.
+    exp(x) - 1 for use when `x` is near zero.
     """)
 
 add_newdoc("scipy.special", "expn",
@@ -1065,7 +1065,8 @@ add_newdoc("scipy.special", "expn",
 
     Exponential integral E_n
 
-    Returns the exponential integral for integer n and non-negative x and n::
+    Returns the exponential integral for integer `n` and non-negative `x` and
+    `n`::
 
         integral(exp(-x*t) / t**n, t=1..inf).
     """)
@@ -1074,7 +1075,7 @@ add_newdoc("scipy.special", "exprel",
     r"""
     exprel(x)
 
-    Relative error exponential, (exp(x)-1)/x, for use when x is near zero.
+    Relative error exponential, (exp(x)-1)/x, for use when `x` is near zero.
 
     Parameters
     ----------
@@ -1099,7 +1100,7 @@ add_newdoc("scipy.special", "fdtr",
 
     F cumulative distribution function
 
-    Returns the area from zero to x under the F density function (also
+    Returns the area from zero to `x` under the F density function (also
     known as Snedcor's density or the variance ratio density).  This
     is the density of X = (unum/dfn)/(uden/dfd), where unum and uden
     are random variables having Chi square distributions with dfn and
@@ -1119,16 +1120,16 @@ add_newdoc("scipy.special", "fdtri",
     """
     fdtri(dfn, dfd, p)
 
-    Inverse to fdtr vs x
+    Inverse to `fdtr` vs x
 
-    Finds the F density argument x such that ``fdtr(dfn, dfd, x) == p``.
+    Finds the F density argument `x` such that ``fdtr(dfn, dfd, x) == p``.
     """)
 
 add_newdoc("scipy.special", "fdtridfd",
     """
     fdtridfd(dfn, p, x)
 
-    Inverse to fdtr vs dfd
+    Inverse to `fdtr` vs dfd
 
     Finds the F density argument dfd such that ``fdtr(dfn, dfd, x) == p``.
     """)
@@ -1137,7 +1138,7 @@ add_newdoc("scipy.special", "fdtridfn",
     """
     fdtridfn(p, dfd, x)
 
-    Inverse to fdtr vs dfn
+    Inverse to `fdtr` vs dfn
 
     finds the F density argument dfn such that ``fdtr(dfn, dfd, x) == p``.
     """)
@@ -1206,7 +1207,7 @@ add_newdoc("scipy.special", "gammainccinv",
     """
     gammainccinv(a, y)
 
-    Inverse to gammaincc
+    Inverse to `gammaincc`
 
     Returns `x` such that ``gammaincc(a, x) == y``.
     """)
@@ -1215,7 +1216,7 @@ add_newdoc("scipy.special", "gammaincinv",
     """
     gammaincinv(a, y)
 
-    Inverse to gammainc
+    Inverse to `gammainc`
 
     Returns `x` such that ``gammainc(a, x) = y``.
     """)
@@ -1252,12 +1253,12 @@ add_newdoc("scipy.special", "gdtr",
 
     Gamma distribution cumulative density function.
 
-    Returns the integral from zero to x of the gamma probability
+    Returns the integral from zero to `x` of the gamma probability
     density function::
 
         a**b / gamma(b) * integral(t**(b-1) exp(-at), t=0..x).
 
-    The arguments a and b are used differently here than in other
+    The arguments `a` and `b` are used differently here than in other
     definitions.
     """)
 
@@ -1267,7 +1268,7 @@ add_newdoc("scipy.special", "gdtrc",
 
     Gamma distribution survival function.
 
-    Integral from x to infinity of the gamma probability density
+    Integral from `x` to infinity of the gamma probability density
     function.
 
     See Also
@@ -1279,7 +1280,7 @@ add_newdoc("scipy.special", "gdtria",
     """
     gdtria(p, b, x, out=None)
 
-    Inverse of gdtr vs a.
+    Inverse of `gdtr` vs a.
 
     Returns the inverse with respect to the parameter `a` of ``p =
     gdtr(a, b, x)``, the cumulative distribution function of the gamma
@@ -1330,7 +1331,7 @@ add_newdoc("scipy.special", "gdtrib",
     """
     gdtrib(a, p, x, out=None)
 
-    Inverse of gdtr vs b.
+    Inverse of `gdtr` vs b.
 
     Returns the inverse with respect to the parameter `b` of ``p =
     gdtr(a, b, x)``, the cumulative distribution function of the gamma
@@ -1381,7 +1382,7 @@ add_newdoc("scipy.special", "gdtrix",
     """
     gdtrix(a, b, p, out=None)
 
-    Inverse of gdtr vs x.
+    Inverse of `gdtr` vs x.
 
     Returns the inverse with respect to the parameter `x` of ``p =
     gdtr(a, b, x)``, the cumulative distribution function of the gamma
@@ -1671,7 +1672,7 @@ add_newdoc("scipy.special", "itairy",
 
     Integrals of Airy functions
 
-    Calculates the integral of Airy functions from 0 to x
+    Calculates the integral of Airy functions from 0 to `x`
 
     Returns
     -------
@@ -1688,8 +1689,8 @@ add_newdoc("scipy.special", "iti0k0",
 
     Integrals of modified Bessel functions of order 0
 
-    Returns simple integrals from 0 to x of the zeroth order modified
-    Bessel functions i0 and k0.
+    Returns simple integrals from 0 to `x` of the zeroth order modified
+    Bessel functions `i0` and `k0`.
 
     Returns
     -------
@@ -1702,8 +1703,8 @@ add_newdoc("scipy.special", "itj0y0",
 
     Integrals of Bessel functions of order 0
 
-    Returns simple integrals from 0 to x of the zeroth order Bessel
-    functions j0 and y0.
+    Returns simple integrals from 0 to `x` of the zeroth order Bessel
+    functions `j0` and `y0`.
 
     Returns
     -------
@@ -1743,7 +1744,7 @@ add_newdoc("scipy.special", "iv",
     Parameters
     ----------
     v
-        Order. If z is of real type and negative, v must be integer valued.
+        Order. If `z` is of real type and negative, `v` must be integer valued.
     z
         Argument.
 
@@ -1778,7 +1779,7 @@ add_newdoc("scipy.special", "jn",
     """
     jn(n, x)
 
-    Bessel function of the first kind of integer order n.
+    Bessel function of the first kind of integer order `n`.
 
     Notes
     -----
@@ -1790,14 +1791,14 @@ add_newdoc("scipy.special", "jv",
     """
     jv(v, z)
 
-    Bessel function of the first kind of real order v
+    Bessel function of the first kind of real order `v`
     """)
 
 add_newdoc("scipy.special", "jve",
     """
     jve(v, z)
 
-    Exponentially scaled Bessel function of order v
+    Exponentially scaled Bessel function of order `v`
 
     Defined as::
 
@@ -1868,7 +1869,7 @@ add_newdoc("scipy.special", "kelvin",
     Be, Ke, Bep, Kep
         The tuple (Be, Ke, Bep, Kep) contains complex numbers
         representing the real and imaginary Kelvin functions and their
-        derivatives evaluated at x.  For example, kelvin(x)[0].real =
+        derivatives evaluated at `x`.  For example, kelvin(x)[0].real =
         ber x and kelvin(x)[0].imag = bei x with similar relationships
         for ker and kei.
     """)
@@ -1913,7 +1914,7 @@ add_newdoc("scipy.special", "kl_div",
 
     Notes
     -----
-    This function is non-negative and is jointly convex in x and y.
+    This function is non-negative and is jointly convex in `x` and `y`.
 
     .. versionadded:: 0.14.0
 
@@ -1923,7 +1924,7 @@ add_newdoc("scipy.special", "kn",
     """
     kn(n, x)
 
-    Modified Bessel function of the second kind of integer order n
+    Modified Bessel function of the second kind of integer order `n`
 
     These are also sometimes called functions of the third kind.
     """)
@@ -1954,7 +1955,7 @@ add_newdoc("scipy.special", "kv",
     """
     kv(v, z)
 
-    Modified Bessel function of the second kind of real order v
+    Modified Bessel function of the second kind of real order `v`
 
     Returns the modified Bessel function of the second kind (sometimes
     called the third kind) for real order v at complex z.
@@ -1967,8 +1968,8 @@ add_newdoc("scipy.special", "kve",
     Exponentially scaled modified Bessel function of the second kind.
 
     Returns the exponentially scaled, modified Bessel function of the
-    second kind (sometimes called the third kind) for real order v at
-    complex z::
+    second kind (sometimes called the third kind) for real order `v` at
+    complex `z`::
 
         kve(v, z) = kv(v, z) * exp(z)
     """)
@@ -1977,7 +1978,7 @@ add_newdoc("scipy.special", "log1p",
     """
     log1p(x)
 
-    Calculates log(1+x) for use when x is near zero
+    Calculates log(1+x) for use when `x` is near zero
     """)
 
 add_newdoc('scipy.special', 'logit',
@@ -2054,9 +2055,9 @@ add_newdoc("scipy.special", "mathieu_cem",
 
     Even Mathieu function and its derivative
 
-    Returns the even Mathieu function, ``ce_m(x, q)``, of order m and
-    parameter q evaluated at x (given in degrees).  Also returns the
-    derivative with respect to x of ce_m(x, q)
+    Returns the even Mathieu function, ``ce_m(x, q)``, of order `m` and
+    parameter `q` evaluated at `x` (given in degrees).  Also returns the
+    derivative with respect to `x` of ce_m(x, q)
 
     Parameters
     ----------
@@ -2082,7 +2083,7 @@ add_newdoc("scipy.special", "mathieu_modcem1",
     Even modified Mathieu function of the first kind and its derivative
 
     Evaluates the even modified Mathieu function of the first kind,
-    ``Mc1m(x, q)``, and its derivative at `x` for order m and parameter
+    ``Mc1m(x, q)``, and its derivative at `x` for order `m` and parameter
     `q`.
 
     Returns
@@ -2100,8 +2101,8 @@ add_newdoc("scipy.special", "mathieu_modcem2",
     Even modified Mathieu function of the second kind and its derivative
 
     Evaluates the even modified Mathieu function of the second kind,
-    Mc2m(x, q), and its derivative at x (given in degrees) for order m
-    and parameter q.
+    Mc2m(x, q), and its derivative at `x` (given in degrees) for order `m`
+    and parameter `q`.
 
     Returns
     -------
@@ -2118,8 +2119,8 @@ add_newdoc("scipy.special", "mathieu_modsem1",
     Odd modified Mathieu function of the first kind and its derivative
 
     Evaluates the odd modified Mathieu function of the first kind,
-    Ms1m(x, q), and its derivative at x (given in degrees) for order m
-    and parameter q.
+    Ms1m(x, q), and its derivative at `x` (given in degrees) for order `m`
+    and parameter `q`.
 
     Returns
     -------
@@ -2136,7 +2137,7 @@ add_newdoc("scipy.special", "mathieu_modsem2",
     Odd modified Mathieu function of the second kind and its derivative
 
     Evaluates the odd modified Mathieu function of the second kind,
-    Ms2m(x, q), and its derivative at x (given in degrees) for order m
+    Ms2m(x, q), and its derivative at `x` (given in degrees) for order `m`
     and parameter q.
 
     Returns
@@ -2153,9 +2154,9 @@ add_newdoc("scipy.special", "mathieu_sem",
 
     Odd Mathieu function and its derivative
 
-    Returns the odd Mathieu function, se_m(x, q), of order m and
-    parameter q evaluated at x (given in degrees).  Also returns the
-    derivative with respect to x of se_m(x, q).
+    Returns the odd Mathieu function, se_m(x, q), of order `m` and
+    parameter `q` evaluated at `x` (given in degrees).  Also returns the
+    derivative with respect to `x` of se_m(x, q).
 
     Parameters
     ----------
@@ -2208,8 +2209,8 @@ add_newdoc("scipy.special", "modstruve",
 
     Modified Struve function
 
-    Returns the modified Struve function Lv(x) of order v at x, x must
-    be positive unless v is an integer.
+    Returns the modified Struve function Lv(x) of order `v` at `x`, `x` must
+    be positive unless `v` is an integer.
     """)
 
 add_newdoc("scipy.special", "nbdtr",
@@ -2218,7 +2219,7 @@ add_newdoc("scipy.special", "nbdtr",
 
     Negative binomial cumulative distribution function
 
-    Returns the sum of the terms 0 through k of the negative binomial
+    Returns the sum of the terms 0 through `k` of the negative binomial
     distribution::
 
         sum((n+j-1)Cj p**n (1-p)**j, j=0..k).
@@ -2241,7 +2242,7 @@ add_newdoc("scipy.special", "nbdtri",
     """
     nbdtri(k, n, y)
 
-    Inverse of nbdtr vs p
+    Inverse of `nbdtr` vs `p`
 
     Finds the argument p such that ``nbdtr(k, n, p) = y``.
     """)
@@ -2250,7 +2251,7 @@ add_newdoc("scipy.special", "nbdtrik",
     """
     nbdtrik(y, n, p)
 
-    Inverse of nbdtr vs k
+    Inverse of `nbdtr` vs `k`
 
     Finds the argument k such that ``nbdtr(k, n, p) = y``.
     """)
@@ -2259,9 +2260,9 @@ add_newdoc("scipy.special", "nbdtrin",
     """
     nbdtrin(k, y, p)
 
-    Inverse of nbdtr vs n
+    Inverse of `nbdtr` vs `n`
 
-    Finds the argument n such that ``nbdtr(k, n, p) = y``.
+    Finds the argument `n` such that ``nbdtr(k, n, p) = y``.
     """)
 
 add_newdoc("scipy.special", "ncfdtr",
@@ -2361,7 +2362,7 @@ add_newdoc("scipy.special", "nctdtr",
     """
     nctdtr(df, nc, t)
 
-    Cumulative distribution function of the non-central t distribution.
+    Cumulative distribution function of the non-central `t` distribution.
 
     Parameters
     ----------
@@ -2470,7 +2471,7 @@ add_newdoc("scipy.special", "ndtr",
     Gaussian cumulative distribution function
 
     Returns the area under the standard Gaussian probability
-    density function, integrated from minus infinity to x::
+    density function, integrated from minus infinity to `x`::
 
         1/sqrt(2*pi) * integral(exp(-t**2 / 2), t=-inf..x)
 
@@ -2535,7 +2536,7 @@ add_newdoc("scipy.special", "log_ndtr",
     Logarithm of Gaussian cumulative distribution function
 
     Returns the log of the area under the standard Gaussian probability
-    density function, integrated from minus infinity to x::
+    density function, integrated from minus infinity to `x`::
 
         log(1/sqrt(2*pi) * integral(exp(-t**2 / 2), t=-inf..x))
     """)
@@ -2544,10 +2545,10 @@ add_newdoc("scipy.special", "ndtri",
     """
     ndtri(y)
 
-    Inverse of ndtr vs x
+    Inverse of `ndtr` vs x
 
     Returns the argument x for which the area under the Gaussian
-    probability density function (integrated from minus infinity to x)
+    probability density function (integrated from minus infinity to `x`)
     is equal to y.
     """)
 
@@ -2558,8 +2559,8 @@ add_newdoc("scipy.special", "obl_ang1",
     Oblate spheroidal angular function of the first kind and its derivative
 
     Computes the oblate spheroidal angular function of the first kind
-    and its derivative (with respect to x) for mode parameters m>=0
-    and n>=m, spheroidal parameter c and ``|x| < 1.0``.
+    and its derivative (with respect to `x`) for mode parameters m>=0
+    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
 
     Returns
     -------
@@ -2576,8 +2577,8 @@ add_newdoc("scipy.special", "obl_ang1_cv",
     Oblate spheroidal angular function obl_ang1 for precomputed characteristic value
 
     Computes the oblate spheroidal angular function of the first kind
-    and its derivative (with respect to x) for mode parameters m>=0
-    and n>=m, spheroidal parameter c and ``|x| < 1.0``. Requires
+    and its derivative (with respect to `x`) for mode parameters m>=0
+    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
     pre-computed characteristic value.
 
     Returns
@@ -2595,7 +2596,7 @@ add_newdoc("scipy.special", "obl_cv",
     Characteristic value of oblate spheroidal function
 
     Computes the characteristic value of oblate spheroidal wave
-    functions of order m, n (n>=m) and spheroidal parameter c.
+    functions of order `m`, `n` (n>=m) and spheroidal parameter `c`.
     """)
 
 add_newdoc("scipy.special", "obl_rad1",
@@ -2605,8 +2606,8 @@ add_newdoc("scipy.special", "obl_rad1",
     Oblate spheroidal radial function of the first kind and its derivative
 
     Computes the oblate spheroidal radial function of the first kind
-    and its derivative (with respect to x) for mode parameters m>=0
-    and n>=m, spheroidal parameter c and ``|x| < 1.0``.
+    and its derivative (with respect to `x`) for mode parameters m>=0
+    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
 
     Returns
     -------
@@ -2623,8 +2624,8 @@ add_newdoc("scipy.special", "obl_rad1_cv",
     Oblate spheroidal radial function obl_rad1 for precomputed characteristic value
 
     Computes the oblate spheroidal radial function of the first kind
-    and its derivative (with respect to x) for mode parameters m>=0
-    and n>=m, spheroidal parameter c and ``|x| < 1.0``. Requires
+    and its derivative (with respect to `x`) for mode parameters m>=0
+    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
     pre-computed characteristic value.
 
     Returns
@@ -2642,8 +2643,8 @@ add_newdoc("scipy.special", "obl_rad2",
     Oblate spheroidal radial function of the second kind and its derivative.
 
     Computes the oblate spheroidal radial function of the second kind
-    and its derivative (with respect to x) for mode parameters m>=0
-    and n>=m, spheroidal parameter c and ``|x| < 1.0``.
+    and its derivative (with respect to `x`) for mode parameters m>=0
+    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
 
     Returns
     -------
@@ -2660,8 +2661,8 @@ add_newdoc("scipy.special", "obl_rad2_cv",
     Oblate spheroidal radial function obl_rad2 for precomputed characteristic value
 
     Computes the oblate spheroidal radial function of the second kind
-    and its derivative (with respect to x) for mode parameters m>=0
-    and n>=m, spheroidal parameter c and ``|x| < 1.0``. Requires
+    and its derivative (with respect to `x`) for mode parameters m>=0
+    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
     pre-computed characteristic value.
 
     Returns
@@ -2733,9 +2734,9 @@ add_newdoc("scipy.special", "pdtr",
 
     Poisson cumulative distribution function
 
-    Returns the sum of the first k terms of the Poisson distribution:
+    Returns the sum of the first `k` terms of the Poisson distribution:
     sum(exp(-m) * m**j / j!, j=0..k) = gammaincc( k+1, m).  Arguments
-    must both be positive and k an integer.
+    must both be positive and `k` an integer.
     """)
 
 add_newdoc("scipy.special", "pdtrc",
@@ -2746,26 +2747,26 @@ add_newdoc("scipy.special", "pdtrc",
 
     Returns the sum of the terms from k+1 to infinity of the Poisson
     distribution: sum(exp(-m) * m**j / j!, j=k+1..inf) = gammainc(
-    k+1, m).  Arguments must both be positive and k an integer.
+    k+1, m).  Arguments must both be positive and `k` an integer.
     """)
 
 add_newdoc("scipy.special", "pdtri",
     """
     pdtri(k, y)
 
-    Inverse to pdtr vs m
+    Inverse to `pdtr` vs m
 
-    Returns the Poisson variable m such that the sum from 0 to k of
-    the Poisson density is equal to the given probability y:
-    calculated by gammaincinv(k+1, y).  k must be a nonnegative
-    integer and y between 0 and 1.
+    Returns the Poisson variable `m` such that the sum from 0 to `k` of
+    the Poisson density is equal to the given probability `y`:
+    calculated by gammaincinv(k+1, y). `k` must be a nonnegative
+    integer and `y` between 0 and 1.
     """)
 
 add_newdoc("scipy.special", "pdtrik",
     """
     pdtrik(p, m)
 
-    Inverse to pdtr vs k
+    Inverse to `pdtr` vs k
 
     Returns the quantile k such that ``pdtr(k, m) = p``
     """)
@@ -2792,8 +2793,8 @@ add_newdoc("scipy.special", "pro_ang1",
     Prolate spheroidal angular function of the first kind and its derivative
 
     Computes the prolate spheroidal angular function of the first kind
-    and its derivative (with respect to x) for mode parameters m>=0
-    and n>=m, spheroidal parameter c and ``|x| < 1.0``.
+    and its derivative (with respect to `x`) for mode parameters m>=0
+    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
 
     Returns
     -------
@@ -2810,8 +2811,8 @@ add_newdoc("scipy.special", "pro_ang1_cv",
     Prolate spheroidal angular function pro_ang1 for precomputed characteristic value
 
     Computes the prolate spheroidal angular function of the first kind
-    and its derivative (with respect to x) for mode parameters m>=0
-    and n>=m, spheroidal parameter c and ``|x| < 1.0``. Requires
+    and its derivative (with respect to `x`) for mode parameters m>=0
+    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
     pre-computed characteristic value.
 
     Returns
@@ -2829,7 +2830,7 @@ add_newdoc("scipy.special", "pro_cv",
     Characteristic value of prolate spheroidal function
 
     Computes the characteristic value of prolate spheroidal wave
-    functions of order m, n (n>=m) and spheroidal parameter c.
+    functions of order `m`, `n` (n>=m) and spheroidal parameter `c`.
     """)
 
 add_newdoc("scipy.special", "pro_rad1",
@@ -2839,8 +2840,8 @@ add_newdoc("scipy.special", "pro_rad1",
     Prolate spheroidal radial function of the first kind and its derivative
 
     Computes the prolate spheroidal radial function of the first kind
-    and its derivative (with respect to x) for mode parameters m>=0
-    and n>=m, spheroidal parameter c and ``|x| < 1.0``.
+    and its derivative (with respect to `x`) for mode parameters m>=0
+    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
 
     Returns
     -------
@@ -2857,8 +2858,8 @@ add_newdoc("scipy.special", "pro_rad1_cv",
     Prolate spheroidal radial function pro_rad1 for precomputed characteristic value
 
     Computes the prolate spheroidal radial function of the first kind
-    and its derivative (with respect to x) for mode parameters m>=0
-    and n>=m, spheroidal parameter c and ``|x| < 1.0``. Requires
+    and its derivative (with respect to `x`) for mode parameters m>=0
+    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
     pre-computed characteristic value.
 
     Returns
@@ -2876,8 +2877,8 @@ add_newdoc("scipy.special", "pro_rad2",
     Prolate spheroidal radial function of the secon kind and its derivative
 
     Computes the prolate spheroidal radial function of the second kind
-    and its derivative (with respect to x) for mode parameters m>=0
-    and n>=m, spheroidal parameter c and ``|x| < 1.0``.
+    and its derivative (with respect to `x`) for mode parameters m>=0
+    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``.
 
     Returns
     -------
@@ -2894,8 +2895,8 @@ add_newdoc("scipy.special", "pro_rad2_cv",
     Prolate spheroidal radial function pro_rad2 for precomputed characteristic value
 
     Computes the prolate spheroidal radial function of the second kind
-    and its derivative (with respect to x) for mode parameters m>=0
-    and n>=m, spheroidal parameter c and ``|x| < 1.0``. Requires
+    and its derivative (with respect to `x`) for mode parameters m>=0
+    and n>=m, spheroidal parameter `c` and ``|x| < 1.0``. Requires
     pre-computed characteristic value.
 
     Returns
@@ -2941,7 +2942,7 @@ add_newdoc("scipy.special", "psi",
     Digamma function
 
     The derivative of the logarithm of the gamma function evaluated at
-    z (also called the digamma function).
+    `z` (also called the digamma function).
     """)
 
 add_newdoc("scipy.special", "radian",
@@ -3001,8 +3002,8 @@ add_newdoc("scipy.special", "round",
 
     Round to nearest integer
 
-    Returns the nearest integer to x as a double precision floating
-    point result.  If x ends in 0.5 exactly, the nearest even integer
+    Returns the nearest integer to `x` as a double precision floating
+    point result.  If `x` ends in 0.5 exactly, the nearest even integer
     is chosen.
     """)
 
@@ -3053,7 +3054,7 @@ add_newdoc("scipy.special", "smirnov",
     distribution function (Dn+ or Dn-) for a one-sided test of
     equality between an empirical and a theoretical distribution. It
     is equal to the probability that the maximum difference between a
-    theoretical distribution and an empirical one based on n samples
+    theoretical distribution and an empirical one based on `n` samples
     is greater than e.
     """)
 
@@ -3061,7 +3062,7 @@ add_newdoc("scipy.special", "smirnovi",
     """
     smirnovi(n, y)
 
-    Inverse to smirnov
+    Inverse to `smirnov`
 
     Returns ``e`` such that ``smirnov(n, e) = y``.
     """)
@@ -3095,18 +3096,18 @@ add_newdoc("scipy.special", "stdtridf",
     """
     stdtridf(p, t)
 
-    Inverse of stdtr vs df
+    Inverse of `stdtr` vs df
 
-    Returns the argument df such that stdtr(df, t) is equal to p.
+    Returns the argument df such that stdtr(df, t) is equal to `p`.
     """)
 
 add_newdoc("scipy.special", "stdtrit",
     """
     stdtrit(df, p)
 
-    Inverse of stdtr vs t
+    Inverse of `stdtr` vs `t`
 
-    Returns the argument t such that stdtr(df, t) is equal to p.
+    Returns the argument `t` such that stdtr(df, t) is equal to `p`.
     """)
 
 add_newdoc("scipy.special", "struve",
@@ -3115,8 +3116,8 @@ add_newdoc("scipy.special", "struve",
 
     Struve function
 
-    Computes the struve function Hv(x) of order v at x, x must be
-    positive unless v is an integer.
+    Computes the struve function Hv(x) of order `v` at `x`, `x` must be
+    positive unless `v` is an integer.
     """)
 
 add_newdoc("scipy.special", "tandg",
@@ -3154,7 +3155,7 @@ add_newdoc("scipy.special", "xlogy",
     """
     xlogy(x, y)
 
-    Compute ``x*log(y)`` so that the result is 0 if `x = 0`.
+    Compute ``x*log(y)`` so that the result is 0 if ``x = 0``.
 
     Parameters
     ----------
@@ -3179,7 +3180,7 @@ add_newdoc("scipy.special", "xlog1py",
     """
     xlog1py(x, y)
 
-    Compute ``x*log1p(y)`` so that the result is 0 if `x = 0`.
+    Compute ``x*log1p(y)`` so that the result is 0 if ``x = 0``.
 
     Parameters
     ----------
@@ -3206,7 +3207,7 @@ add_newdoc("scipy.special", "y0",
 
     Bessel function of the second kind of order 0
 
-    Returns the Bessel function of the second kind of order 0 at x.
+    Returns the Bessel function of the second kind of order 0 at `x`.
     """)
 
 add_newdoc("scipy.special", "y1",
@@ -3215,7 +3216,7 @@ add_newdoc("scipy.special", "y1",
 
     Bessel function of the second kind of order 1
 
-    Returns the Bessel function of the second kind of order 1 at x.
+    Returns the Bessel function of the second kind of order 1 at `x`.
     """)
 
 add_newdoc("scipy.special", "yn",
@@ -3224,8 +3225,8 @@ add_newdoc("scipy.special", "yn",
 
     Bessel function of the second kind of integer order
 
-    Returns the Bessel function of the second kind of integer order n
-    at x.
+    Returns the Bessel function of the second kind of integer order `n`
+    at `x`.
     """)
 
 add_newdoc("scipy.special", "yv",
@@ -3234,8 +3235,8 @@ add_newdoc("scipy.special", "yv",
 
     Bessel function of the second kind of real order
 
-    Returns the Bessel function of the second kind of real order v at
-    complex z.
+    Returns the Bessel function of the second kind of real order `v` at
+    complex `z`.
     """)
 
 add_newdoc("scipy.special", "yve",
@@ -3245,7 +3246,7 @@ add_newdoc("scipy.special", "yve",
     Exponentially scaled Bessel function of the second kind of real order
 
     Returns the exponentially scaled Bessel function of the second
-    kind of real order v at complex z::
+    kind of real order `v` at complex `z`::
 
         yve(v, z) = yv(v, z) * exp(-abs(z.imag))
 
@@ -3258,7 +3259,7 @@ add_newdoc("scipy.special", "zeta",
     Hurwitz zeta function
 
     The Riemann zeta function of two arguments (also known as the
-    Hurwitz zeta funtion).
+    Hurwitz zeta function).
 
     This function is defined as
 
@@ -3294,7 +3295,7 @@ add_newdoc("scipy.special", "_struve_asymp_large_z",
     """
     _struve_asymp_large_z(v, z, is_h)
 
-    Internal function for testing struve & modstruve
+    Internal function for testing `struve` & `modstruve`
 
     Evaluates using asymptotic expansion
 
@@ -3307,7 +3308,7 @@ add_newdoc("scipy.special", "_struve_power_series",
     """
     _struve_power_series(v, z, is_h)
 
-    Internal function for testing struve & modstruve
+    Internal function for testing `struve` & `modstruve`
 
     Evaluates using power series
 
@@ -3320,7 +3321,7 @@ add_newdoc("scipy.special", "_struve_bessel_series",
     """
     _struve_bessel_series(v, z, is_h)
 
-    Internal function for testing struve & modstruve
+    Internal function for testing `struve` & `modstruve`
 
     Evaluates using Bessel function series
 

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -49,7 +49,7 @@ def diric(x, n):
 
         diric(x) = sin(x * n/2) / (n * sin(x / 2)),
 
-    where n is a positive integer.
+    where `n` is a positive integer.
 
     Parameters
     ----------
@@ -203,7 +203,7 @@ def jnjnp_zeros(nt):
 def jnyn_zeros(n, nt):
     """Compute nt zeros of Bessel functions Jn(x), Jn'(x), Yn(x), and Yn'(x).
 
-    Returns 4 arrays of length nt, corresponding to the first nt zeros of
+    Returns 4 arrays of length `nt`, corresponding to the first `nt` zeros of
     Jn(x), Jn'(x), Yn(x), and Yn'(x), respectively.
 
     Parameters
@@ -437,7 +437,7 @@ bessel_diff_formula = np.deprecate(_bessel_diff_formula,
 
 
 def jvp(v, z, n=1):
-    """Compute nth derivative of Bessel function Jv(z) with respect to z.
+    """Compute nth derivative of Bessel function Jv(z) with respect to `z`.
 
     Parameters
     ----------
@@ -464,7 +464,7 @@ def jvp(v, z, n=1):
 
 
 def yvp(v, z, n=1):
-    """Compute nth derivative of Bessel function Yv(z) with respect to z.
+    """Compute nth derivative of Bessel function Yv(z) with respect to `z`.
 
     Parameters
     ----------
@@ -518,7 +518,8 @@ def kvp(v, z, n=1):
 
 
 def ivp(v, z, n=1):
-    """Compute nth derivative of modified Bessel function Iv(z) with respect to z.
+    """Compute nth derivative of modified Bessel function Iv(z) with respect
+    to `z`.
 
     Parameters
     ----------
@@ -545,7 +546,7 @@ def ivp(v, z, n=1):
 
 
 def h1vp(v, z, n=1):
-    """Compute nth derivative of Hankel function H1v(z) with respect to z.
+    """Compute nth derivative of Hankel function H1v(z) with respect to `z`.
 
     Parameters
     ----------
@@ -572,7 +573,7 @@ def h1vp(v, z, n=1):
 
 
 def h2vp(v, z, n=1):
-    """Compute nth derivative of Hankel function H2v(z) with respect to z.
+    """Compute nth derivative of Hankel function H2v(z) with respect to `z`.
 
     Parameters
     ----------
@@ -1525,9 +1526,10 @@ def ai_zeros(nt):
     """
     Compute `nt` zeros and values of the Airy function Ai and its derivative.
 
-    Computes the first nt zeros, a, of the Airy function Ai(x); first nt zeros,
-    a', of the derivative of the Airy function Ai'(x); the corresponding values
-    Ai(a'); and the corresponding values Ai'(a).
+    Computes the first `nt` zeros, `a`, of the Airy function Ai(x);
+    first `nt` zeros, `ap`, of the derivative of the Airy function Ai'(x);
+    the corresponding values Ai(a');
+    and the corresponding values Ai'(a).
 
     Parameters
     ----------
@@ -1537,13 +1539,13 @@ def ai_zeros(nt):
     Returns
     -------
     a : ndarray
-        First nt zeros of Ai(x)
+        First `nt` zeros of Ai(x)
     ap : ndarray
-        First nt zeros of Ai'(x)
+        First `nt` zeros of Ai'(x)
     ai : ndarray
-        Values of Ai(x) evaluated at first nt zeros of Ai'(x)
+        Values of Ai(x) evaluated at first `nt` zeros of Ai'(x)
     aip : ndarray
-        Values of Ai'(x) evaluated at first nt zeros of Ai(x)
+        Values of Ai'(x) evaluated at first `nt` zeros of Ai(x)
 
     References
     ----------
@@ -1562,9 +1564,10 @@ def bi_zeros(nt):
     """
     Compute `nt` zeros and values of the Airy function Bi and its derivative.
 
-    Computes the first nt zeros, b, of the Airy function Bi(x); first nt zeros,
-    b', of the derivative of the Airy function Bi'(x); the corresponding values
-    Bi(b'); and the corresponding values Bi'(b).
+    Computes the first `nt` zeros, b, of the Airy function Bi(x);
+    first `nt` zeros, b', of the derivative of the Airy function Bi'(x);
+    the corresponding values Bi(b');
+    and the corresponding values Bi'(b).
 
     Parameters
     ----------
@@ -1574,13 +1577,13 @@ def bi_zeros(nt):
     Returns
     -------
     b : ndarray
-        First nt zeros of Bi(x)
+        First `nt` zeros of Bi(x)
     bp : ndarray
-        First nt zeros of Bi'(x)
+        First `nt` zeros of Bi'(x)
     bi : ndarray
-        Values of Bi(x) evaluated at first nt zeros of Bi'(x)
+        Values of Bi(x) evaluated at first `nt` zeros of Bi'(x)
     bip : ndarray
-        Values of Bi'(x) evaluated at first nt zeros of Bi(x)
+        Values of Bi'(x) evaluated at first `nt` zeros of Bi(x)
 
     References
     ----------

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -522,14 +522,13 @@ def kvp(v, z, n=1):
     Calculate multiple values at order 5:
 
     >>> from scipy.special import kvp
-    >>> print(kvp(5, (1, 2, 3+5j)))
-    [ -1.84903536e+03+0.j          -2.57735387e+01+0.j
-      -3.06627741e-02+0.08750845j]
+    >>> kvp(5, (1, 2, 3+5j))
+    array([-1849.0354+0.j    ,   -25.7735+0.j    ,    -0.0307+0.0875j])
 
     Calculate for a single value at multiple orders:
 
-    >>> print(kvp((4, 4.5, 5), 1))
-    [ -184.03092621  -568.95853449 -1849.03536385]
+    >>> kvp((4, 4.5, 5), 1)
+    array([ -184.0309,  -568.9585, -1849.0354])
 
     """
     if not isinstance(n, int) or (n < 0):

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -491,22 +491,43 @@ def yvp(v, z, n=1):
 
 
 def kvp(v, z, n=1):
-    """Compute nth derivative of modified Bessel function Kv(z) with respect to z.
+    """Compute nth derivative of real-order modified Bessel function Kv(z)
+
+    Kv(z) is the modified Bessel function of the second kind.
+    Derivative is calculated with respect to `z`.
 
     Parameters
     ----------
-    v : float
+    v : array_like of float
         Order of Bessel function
-    z : complex
+    z : array_like of complex
         Argument at which to evaluate the derivative
-    n : int, default 1
-        Order of derivative
+    n : int
+        Order of derivative.  Default is first derivative.
+
+    Returns
+    -------
+    out : ndarray
+        The results
 
     References
     ----------
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996, chapter 6.
            http://jin.ece.illinois.edu/specfunc.html
+
+    Examples
+    --------
+    Calculate multiple values at order 5:
+
+    >>> print(kvp(5, (1, 2, 3+5j)))
+    [ -1.84903536e+03+0.j          -2.57735387e+01+0.j
+      -3.06627741e-02+0.08750845j]
+
+    Calculate for a single value at multiple orders:
+
+    >>> print(kvp((4, 4.5, 5), 1))
+    [ -184.03092621  -568.95853449 -1849.03536385]
 
     """
     if not isinstance(n, int) or (n < 0):
@@ -523,9 +544,9 @@ def ivp(v, z, n=1):
 
     Parameters
     ----------
-    v : float
+    v : array_like of float
         Order of Bessel function
-    z : complex
+    z : array_like of complex
         Argument at which to evaluate the derivative
     n : int, default 1
         Order of derivative

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -160,7 +160,7 @@ def diric(x, n):
 
 
 def jnjnp_zeros(nt):
-    """Compute nt zeros of Bessel functions Jn and Jn'.
+    """Compute zeros of integer-order Bessel functions Jn and Jn'.
 
     Results are arranged in order of the magnitudes of the zeros.
 
@@ -232,7 +232,7 @@ def jnyn_zeros(n, nt):
 
 
 def jn_zeros(n, nt):
-    """Compute nt zeros of Bessel function Jn(x).
+    """Compute zeros of integer-order Bessel function Jn(x).
 
     Parameters
     ----------
@@ -252,7 +252,7 @@ def jn_zeros(n, nt):
 
 
 def jnp_zeros(n, nt):
-    """Compute nt zeros of Bessel function derivative Jn'(x).
+    """Compute zeros of integer-order Bessel function derivative Jn'(x).
 
     Parameters
     ----------
@@ -272,7 +272,7 @@ def jnp_zeros(n, nt):
 
 
 def yn_zeros(n, nt):
-    """Compute nt zeros of Bessel function Yn(x).
+    """Compute zeros of integer-order Bessel function Yn(x).
 
     Parameters
     ----------
@@ -292,7 +292,7 @@ def yn_zeros(n, nt):
 
 
 def ynp_zeros(n, nt):
-    """Compute nt zeros of Bessel function derivative Yn'(x).
+    """Compute zeros of integer-order Bessel function derivative Yn'(x).
 
     Parameters
     ----------

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -424,6 +424,7 @@ def _bessel_diff_formula(v, z, n, L, phase):
     # L(v, z) = J(v, z), Y(v, z), H1(v, z), H2(v, z), phase = -1
     # L(v, z) = I(v, z) or exp(v*pi*i)K(v, z), phase = 1
     # For K, you can pull out the exp((v-k)*pi*i) into the caller
+    v = asarray(v)
     p = 1.0
     s = L(v-n, z)
     for i in xrange(1, n+1):

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -68,8 +68,8 @@ def diric(x, n):
     >>> import matplotlib.pyplot as plt
 
     >>> x = np.linspace(-8*np.pi, 8*np.pi, num=201)
-    >>> plt.figure(figsize=(8,8));
-    >>> for idx, n in enumerate([2,3,4,9]):
+    >>> plt.figure(figsize=(8, 8));
+    >>> for idx, n in enumerate([2, 3, 4, 9]):
     ...     plt.subplot(2, 2, idx+1)
     ...     plt.plot(x, special.diric(x, n))
     ...     plt.title('diric, n={}'.format(n))
@@ -421,8 +421,8 @@ def y1p_zeros(nt, complex=0):
 
 def _bessel_diff_formula(v, z, n, L, phase):
     # from AMS55.
-    # L(v,z) = J(v,z), Y(v,z), H1(v,z), H2(v,z), phase = -1
-    # L(v,z) = I(v,z) or exp(v*pi*i)K(v,z), phase = 1
+    # L(v, z) = J(v, z), Y(v, z), H1(v, z), H2(v, z), phase = -1
+    # L(v, z) = I(v, z) or exp(v*pi*i)K(v, z), phase = 1
     # For K, you can pull out the exp((v-k)*pi*i) into the caller
     p = 1.0
     s = L(v-n, z)
@@ -1027,7 +1027,7 @@ def hyp0f1(v, z):
     -----
     This function is defined as:
 
-    .. math:: _0F_1(v,z) = \sum_{k=0}^{\inf}\frac{z^k}{(v)_k k!}.
+    .. math:: _0F_1(v, z) = \sum_{k=0}^{\inf}\frac{z^k}{(v)_k k!}.
 
     It's also the limit as q -> infinity of ``1F1(q;v;z/q)``, and satisfies
     the differential equation :math:`f''(z) + vf'(z) = f(z)`.
@@ -1974,11 +1974,11 @@ def agm(a, b):
     a_{n+1} = (a_n+b_n)/2
     b_{n+1} = sqrt(a_n*b_n)
 
-    until a_n=b_n.   The result is agm(a,b)
+    until a_n=b_n.   The result is agm(a, b)
 
-    agm(a,b)=agm(b,a)
-    agm(a,a) = a
-    min(a,b) < agm(a,b) < max(a,b)
+    agm(a, b)=agm(b, a)
+    agm(a, a) = a
+    min(a, b) < agm(a, b) < max(a, b)
     """
     s = a + b + 0.0
     return (pi / 4) * s / ellipkm1(4 * a * b / s ** 2)
@@ -2128,7 +2128,7 @@ def factorial(n, exact=False):
     Examples
     --------
     >>> from scipy.special import factorial
-    >>> arr = np.array([3,4,5])
+    >>> arr = np.array([3, 4, 5])
     >>> factorial(arr, exact=False)
     array([   6.,   24.,  120.])
     >>> factorial(5, exact=True)

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -521,6 +521,7 @@ def kvp(v, z, n=1):
     --------
     Calculate multiple values at order 5:
 
+    >>> from scipy.special import kvp
     >>> print(kvp(5, (1, 2, 3+5j)))
     [ -1.84903536e+03+0.j          -2.57735387e+01+0.j
       -3.06627741e-02+0.08750845j]


### PR DESCRIPTION
1. General formatting like spaces after commas, italicize variables, link function names
2. Added examples, parameters, returns for Bessel K functions
3. Bessel derivatives should handle array_like for function orders, but only accept true arrays, fixed that
