### PR TITLE
BUG: sparse: fixing unbound local error

### DIFF
--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -162,7 +162,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                 raise TypeError('dimensions not understood')
             warn('coo_matrix(None, shape=(M,N)) is deprecated, '
                     'use coo_matrix( (M,N) ) instead', DeprecationWarning)
-            idx_dtype = get_index_dtype(maxval=max(M, N))
+            idx_dtype = get_index_dtype(maxval=max(shape))
             self.shape = shape
             self.data = np.array([], getdtype(dtype, default=float))
             self.row = np.array([], dtype=idx_dtype)


### PR DESCRIPTION
M and N aren't defined in this conditional branch, so the following happens (on current master):

``` python
In [1]: import scipy.sparse as ss

In [2]: ss.coo_matrix(None, (4,5))
---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
<ipython-input-2-62651dfca412> in <module>()
----> 1 ss.coo_matrix(None, (4,5))

/usr/local/lib/python2.7/dist-packages/scipy/sparse/coo.pyc in __init__(self, arg1, shape, dtype, copy)
    163             warn('coo_matrix(None, shape=(M,N)) is deprecated, '
    164                     'use coo_matrix( (M,N) ) instead', DeprecationWarning)
--> 165             idx_dtype = get_index_dtype(maxval=max(M, N))
    166             self.shape = shape
    167             self.data = np.array([], getdtype(dtype, default=float))

UnboundLocalError: local variable 'M' referenced before assignment
```

The deprecation warning indicates that this kind of constructor call isn't recommended, so another alternative would be to remove the special handling altogether. For now, this PR fixes the bug.
