### PR TITLE
MAINT: sparse: fix COO ctor

### DIFF
--- a/doc/release/0.17.0-notes.rst
+++ b/doc/release/0.17.0-notes.rst
@@ -63,6 +63,11 @@ array would return a dense matrix.
 
 The function ``misc.lena`` has been removed due to license incompatibility.
 
+The constructor for ``sparse.coo_matrix`` no longer accepts ``(None, (m,n))``
+to construct an all-zero matrix of shape ``(m,n)``. This functionality was
+deprecated since at least 2007 and was already broken in the previous SciPy
+release. Use ``coo_matrix((m,n))`` instead.
+
 Other changes
 =============
 

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -156,18 +156,6 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                 self.data = np.array(obj, copy=copy)
                 self.has_canonical_format = False
 
-        elif arg1 is None:
-            # Initialize an empty matrix.
-            if not isinstance(shape, tuple) or not isintlike(shape[0]):
-                raise TypeError('dimensions not understood')
-            warn('coo_matrix(None, shape=(M,N)) is deprecated, '
-                    'use coo_matrix( (M,N) ) instead', DeprecationWarning)
-            idx_dtype = get_index_dtype(maxval=max(shape))
-            self.shape = shape
-            self.data = np.array([], getdtype(dtype, default=float))
-            self.row = np.array([], dtype=idx_dtype)
-            self.col = np.array([], dtype=idx_dtype)
-            self.has_canonical_format = True
         else:
             if isspmatrix(arg1):
                 if isspmatrix_coo(arg1) and copy:

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -172,10 +172,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                 self.has_canonical_format = False
             else:
                 #dense argument
-                try:
-                    M = np.atleast_2d(np.asarray(arg1))
-                except:
-                    raise TypeError('invalid input format')
+                M = np.atleast_2d(np.asarray(arg1))
 
                 if M.ndim != 2:
                     raise TypeError('expected dimension <= 2 array or matrix')


### PR DESCRIPTION
Removed a code path that was deprecated since 2007. Follow-up to #5216.

Also included a patch for a different problem in the same function that I spotted while hacking on it.
