### PR TITLE
MAINT: sparse: simplify COO ctor

### DIFF
--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -128,7 +128,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             else:
                 try:
                     obj, (row, col) = arg1
-                except TypeError, ValueError:
+                except (TypeError, ValueError):
                     raise TypeError('invalid input format')
 
                 if shape is None:

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -127,17 +127,10 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                 self.has_canonical_format = True
             else:
                 try:
-                    obj, ij = arg1
-                except:
+                    obj, (row, col) = arg1
+                except TypeError, ValueError:
                     raise TypeError('invalid input format')
 
-                try:
-                    if len(ij) != 2:
-                        raise TypeError
-                except TypeError:
-                    raise TypeError('invalid input format')
-
-                row, col = ij
                 if shape is None:
                     if len(row) == 0 or len(col) == 0:
                         raise ValueError('cannot infer dimensions from zero '


### PR DESCRIPTION
This change unpacks the tuple in one go, catching `TypeError` for non-iterables and `ValueError` for invalid lengths. It also removes a bare `except` clause which was likely never triggered.

Related to a similar cleanup in #5222.
