### PR TITLE
BUG: integrate: Fixed issue 4118

### DIFF
--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -441,6 +441,8 @@ class ode(object):
         """
         if self._integrator.supports_solout:
             self._integrator.set_solout(solout)
+            if self._y is not None:
+                self._integrator.reset(len(self._y), self.jac is not None)
         else:
             raise ValueError("selected integrator does not support solout,"
                             + " choose another one")

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -241,6 +241,34 @@ class TestSolout(TestCase):
         for integrator in ('dopri5', 'dop853'):
             self._run_solout_test(integrator)
 
+    def _run_solout_after_initial_test(self, integrator):
+        # Check if solout works even if it is set after the initial value.
+        ts = []
+        ys = []
+        t0 = 0.0
+        tend = 10.0
+        y0 = [1.0, 2.0]
+
+        def solout(t, y):
+            ts.append(t)
+            ys.append(y.copy())
+
+        def rhs(t, y):
+            return [y[0] + y[1], -y[1]**2]
+
+        ig = ode(rhs).set_integrator(integrator)
+        ig.set_initial_value(y0, t0)
+        ig.set_solout(solout)
+        ret = ig.integrate(tend)
+        assert_array_equal(ys[0], y0)
+        assert_array_equal(ys[-1], ret)
+        assert_equal(ts[0], t0)
+        assert_equal(ts[-1], tend)
+
+    def test_solout_after_initial(self):
+        for integrator in ('dopri5', 'dop853'):
+            self._run_solout_after_initial_test(integrator)
+
     def _run_solout_break_test(self, integrator):
         # Check correct usage of stopping via solout
         ts = []


### PR DESCRIPTION
Fixes [issue 4118](https://github.com/scipy/scipy/issues/4118): `ode.set_solout` can now be called after `ode.set_initial_value`, as well as before.
