### PR TITLE
qr_insert fixes, closes #5149

### DIFF
--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1835,13 +1835,13 @@ def qr_insert_row(Q, R, u, k, overwrite_qru, check_finite):
         if u1.shape[1] != n:
             raise ValueError("'u' should be either (N,) or (p,N) when "
                              "inserting rows. Found %s." %
-                             str(getattr(u, 'shape')))
+                             str(getattr(u1, 'shape')))
     elif u1.ndim == 1:
         p = 1
         if u1.shape[0] != n:
             raise ValueError("'u' should be either (N,) or (p,N) when "
                              "inserting rows. Found %s." %
-                             str(getattr(u, 'shape')))
+                             str(getattr(u1, 'shape')))
     else:
         raise ValueError("'u' must be either 1- or 2-D")
 
@@ -1958,13 +1958,13 @@ def qr_insert_col(Q, R, u, k, rcond, overwrite_qru, check_finite):
         if u1.shape[0] != m:
             raise ValueError("'u' should be either (M,) or (M,p) when "
                              "inserting columns. Found %s." %
-                             str(getattr(u, 'shape')))
+                             str(getattr(u1, 'shape')))
     elif u1.ndim == 1:
         p = 1
         if u1.shape[0] != m:
             raise ValueError("'u' should be either (M,) or (M,p) when "
                              "inserting columns. Found %s." %
-                             str(getattr(u, 'shape')))
+                             str(getattr(u1, 'shape')))
     else:
         raise ValueError("'u' must be either 1- or 2-D")
 
@@ -1976,6 +1976,12 @@ def qr_insert_col(Q, R, u, k, rcond, overwrite_qru, check_finite):
     elif rcond is not None:
         raise ValueError("'rcond' is not used when updating full, (M,M) (M,N) "
                          "decompositions and must be None.")
+
+    # special case 1xN 
+    # if m == 1, Q is always 1x1 and abs(Q[0,0]) == 1.0
+    if m == 1:
+        rnew = np.insert(r1, k*np.ones(p, np.intp), q1.conjugate()*u1, 1)
+        return q1.copy(), rnew
 
     if economic:
         if n+p <= m:
@@ -2280,6 +2286,14 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
 
     u1 = validate_array(u1, check_finite)
     v1 = validate_array(v1, check_finite)
+
+    # special case 1xN 
+    # if m == 1, Q is always 1x1 and abs(Q[0,0]) == 1.0
+    # we only need consider rank 1 updates, since we have
+    # limited p to max(m,n) above.
+    if m == 1:
+        rnew = r1 + q1.conjugate()*u1.ravel()*v1.conjugate().ravel()
+        return q1.copy(), rnew
 
     if economic:
         ndim = 1

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1824,7 +1824,7 @@ def qr_insert_row(Q, R, u, k, overwrite_qru, check_finite):
     if cnp.PyArray_TYPE(u1) != typecode:
         raise ValueError("'u' must have the same type as 'Q' and 'R'")
 
-    if not (-m <= k1 < m):
+    if not (-m <= k1 <= m):
         raise ValueError("'k' is out of bounds")
 
     if k1 < 0:
@@ -1948,7 +1948,7 @@ def qr_insert_col(Q, R, u, k, rcond, overwrite_qru, check_finite):
         
     if cnp.PyArray_TYPE(u1) != typecode:
         raise ValueError("'u' must have the same type as Q and R")
-    if not (-n <= k1 < n):
+    if not (-n <= k1 <= n):
         raise ValueError("'k' is out of bounds")
     if k1 < 0:
         k1 += n

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -655,7 +655,7 @@ class BaseQRinsert(BaseQRdeltas):
 
     def test_sqr_1_row(self):
         a, q, r, u = self.generate('sqr', which='row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -663,14 +663,14 @@ class BaseQRinsert(BaseQRdeltas):
     def test_sqr_p_row(self):
         # sqr + rows --> fat always
         a, q, r, u = self.generate('sqr', which='row', p=3)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_sqr_1_col(self):
         a, q, r, u = self.generate('sqr', which='col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -678,14 +678,14 @@ class BaseQRinsert(BaseQRdeltas):
     def test_sqr_p_col(self):
         # sqr + cols --> fat always
         a, q, r, u = self.generate('sqr', which='col', p=3)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_tall_1_row(self):
         a, q, r, u = self.generate('tall', which='row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -693,14 +693,14 @@ class BaseQRinsert(BaseQRdeltas):
     def test_tall_p_row(self):
         # tall + rows --> tall always
         a, q, r, u = self.generate('tall', which='row', p=3)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_tall_1_col(self):
         a, q, r, u = self.generate('tall', which='col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -711,7 +711,7 @@ class BaseQRinsert(BaseQRdeltas):
     # tall + pcol --> fat
     def base_tall_p_col_xxx(self, p):
         a, q, r, u = self.generate('tall', which='col', p=p)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(p, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -730,7 +730,7 @@ class BaseQRinsert(BaseQRdeltas):
 
     def test_fat_1_row(self):
         a, q, r, u = self.generate('fat', which='row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -741,7 +741,7 @@ class BaseQRinsert(BaseQRdeltas):
     # fat + prow --> tall
     def base_fat_p_row_xxx(self, p):
         a, q, r, u = self.generate('fat', which='row', p=p)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row*np.ones(p, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -760,7 +760,7 @@ class BaseQRinsert(BaseQRdeltas):
 
     def test_fat_1_col(self):
         a, q, r, u = self.generate('fat', which='col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -768,14 +768,14 @@ class BaseQRinsert(BaseQRdeltas):
     def test_fat_p_col(self):
         # fat + cols --> fat always
         a, q, r, u = self.generate('fat', which='col', p=3)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_economic_1_row(self):
         a, q, r, u = self.generate('tall', 'economic', 'row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row, overwrite_qru=False)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
@@ -783,14 +783,14 @@ class BaseQRinsert(BaseQRdeltas):
     def test_economic_p_row(self):
         # tall + rows --> tall always
         a, q, r, u = self.generate('tall', 'economic', 'row', 3)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row, overwrite_qru=False)
             a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
 
     def test_economic_1_col(self):
         a, q, r, u = self.generate('tall', 'economic', which='col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u.copy(), col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
@@ -809,7 +809,7 @@ class BaseQRinsert(BaseQRdeltas):
     # eco + pcol --> fat
     def base_economic_p_col_xxx(self, p):
         a, q, r, u = self.generate('tall', 'economic', which='col', p=p)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(p, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
@@ -828,112 +828,112 @@ class BaseQRinsert(BaseQRdeltas):
 
     def test_Mx1_1_row(self):
         a, q, r, u = self.generate('Mx1', which='row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
     
     def test_Mx1_p_row(self):
         a, q, r, u = self.generate('Mx1', which='row', p=3)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_Mx1_1_col(self):
         a, q, r, u = self.generate('Mx1', which='col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_Mx1_p_col(self):
         a, q, r, u = self.generate('Mx1', which='col', p=3)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_Mx1_economic_1_row(self):
         a, q, r, u = self.generate('Mx1', 'economic', 'row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
     
     def test_Mx1_economic_p_row(self):
         a, q, r, u = self.generate('Mx1', 'economic', 'row', 3)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
 
     def test_Mx1_economic_1_col(self):
         a, q, r, u = self.generate('Mx1', 'economic', 'col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
 
     def test_Mx1_economic_p_col(self):
         a, q, r, u = self.generate('Mx1', 'full', 'col', 3)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
 
     def test_1xN_1_row(self):
         a, q, r, u = self.generate('1xN', which='row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
     
     def test_1xN_p_row(self):
         a, q, r, u = self.generate('1xN', which='row', p=3)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_1xN_1_col(self):
         a, q, r, u = self.generate('1xN', which='col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_1xN_p_col(self):
         a, q, r, u = self.generate('1xN', which='col', p=3)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_1x1_1_row(self):
         a, q, r, u = self.generate('1x1', which='row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
     
     def test_1x1_p_row(self):
         a, q, r, u = self.generate('1x1', which='row', p=3)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_1x1_1_col(self):
         a, q, r, u = self.generate('1x1', which='col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_1x1_p_col(self):
         a, q, r, u = self.generate('1x1', which='col', p=3)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -1642,7 +1642,7 @@ def test_form_qTu():
     # and F.
 
     q_order = ['F', 'C']
-    q_shape = [(8, 8), (1,1)]
+    q_shape = [(8, 8), ]
     u_order = ['F', 'C', 'A']  # here A means is not F not C
     u_shape = [1, 3]
     dtype = ['f', 'd', 'F', 'D']


### PR DESCRIPTION
This should close #5149, @WarrenWeckesser, could you test that it does?  The issue was passing garbage to `sgemv` when adding columns to the QR decomposition of `(1, 1)` or `(1, N)` matrices.  This showed up due to how the `sgemv` wrapper works.  That being said, it could have shown up somewhere else if one found a particularly pickly BLAS. 

The first commit fixes an oversight in this code.  One should be able to insert columns after the last column and the routine that actually perform the updates can do this just fine, however validation for the `k` parameter was too strict.    This fix doesn't really belong here, but I noticed this while looking at solving #5149 so here it is.
