### PR TITLE
DOC: optimize: typo/import fix in linear_sum_assignment

### DIFF
--- a/scipy/optimize/_hungarian.py
+++ b/scipy/optimize/_hungarian.py
@@ -54,9 +54,10 @@ def linear_sum_assignment(cost_matrix):
     -----
     .. versionadded:: 0.17.0
 
-    Example
-    -------
+    Examples
+    --------
     >>> cost = np.array([[4, 1, 3], [2, 0, 5], [3, 2, 2]])
+    >>> from scipy.optimize import linear_sum_assignment
     >>> row_ind, col_ind = linear_sum_assignment(cost)
     >>> col_ind
     array([1, 0, 2])


### PR DESCRIPTION
Just a typo and a missing import in the docstring of `linear_sum_assignment`.
