### PR TITLE
BUG: Fix sparse multiply by single-element zero

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -149,6 +149,7 @@ Fukumu Tsutsumi for bug fixes.
 J.J. Green for interpolation bug fixes.
 François Magimel for documentation improvements.
 Josh Levy-Kramer for the log survival function of the hypergeometric distribution
+Will Monroe for bug fixes.
 
 
 Institutions

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -405,9 +405,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 return self._binopt(other, '_elmul_')
             # Single element.
             elif other.shape == (1,1):
-                return self.__mul__(other.tocsc().data[0])
+                return self._mul_scalar(other.toarray()[0, 0])
             elif self.shape == (1,1):
-                return other.__mul__(self.tocsc().data[0])
+                return other._mul_scalar(self.toarray()[0, 0])
             # A row times a column.
             elif self.shape[1] == other.shape[0] and self.shape[1] == 1:
                 return self._mul_sparse_matrix(other.tocsc())

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1103,6 +1103,7 @@ class _TestCommon:
         G = [1, 2, 3]
         H = np.ones((3, 4))
         J = H.T
+        K = array([[0]])
 
         # Rank 1 arrays can't be cast as spmatrices (A and C) so leave
         # them out.
@@ -1114,9 +1115,10 @@ class _TestCommon:
         Hspp = self.spmatrix(H[0,None])
         Jsp = self.spmatrix(J)
         Jspp = self.spmatrix(J[:,0,None])
+        Ksp = self.spmatrix(K)
 
-        matrices = [A, B, C, D, E, F, G, H, J]
-        spmatrices = [Bsp, Dsp, Esp, Fsp, Hsp, Hspp, Jsp, Jspp]
+        matrices = [A, B, C, D, E, F, G, H, J, K]
+        spmatrices = [Bsp, Dsp, Esp, Fsp, Hsp, Hspp, Jsp, Jspp, Ksp]
 
         # sparse/sparse
         for i in spmatrices:


### PR DESCRIPTION
Element-wise multiply of a sparse matrix by another sparse matrix
with a single element that is an unstored zero would previously
attempt to access the first element of an empty list/array and
raise `IndexError`:

```
>>> from scipy.sparse import csr_matrix
>>> csr_matrix([[1, 2, 3]]).multiply(csr_matrix([[0]]))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../scipy/sparse/compressed.py", line 410, in multiply
    return self.__mul__(other.tocsc().data[0])
IndexError: index 0 is out of bounds for axis 0 with size 0
```

Now this operation correctly returns an empty 1x3 CSR matrix.

In general, the resulting matrix in this case will be of the same format
as the original non-single-element matrix, and it will have no stored
elements. (The case in which both matrices are single-element was
already working and is not part of this pull request; the matrix returned
in this case has the format of the matrix on which `multiply` is called.)
