### PR TITLE
ignore zero-length edges for default epsilon

### DIFF
--- a/scipy/interpolate/rbf.py
+++ b/scipy/interpolate/rbf.py
@@ -200,11 +200,14 @@ class Rbf(object):
         r = self._call_norm(self.xi, self.xi)
         self.epsilon = kwargs.pop('epsilon', None)
         if self.epsilon is None:
-            # default epsilon is the "the average distance between nodes"
+            # default epsilon is the "the average distance between nodes" based
+            # on a bounding hypercube
             dim = self.xi.shape[0]
             ximax = np.amax(self.xi, axis=1)
             ximin = np.amin(self.xi, axis=1)
-            self.epsilon = np.power(np.prod(ximax - ximin)/self.N, 1.0/dim)
+            edges = ximax-ximin
+            edges = edges[np.nonzero(edges)]
+            self.epsilon = np.power(np.prod(edges)/self.N, 1.0/edges.size)
         self.smooth = kwargs.pop('smooth', 0.0)
 
         self.function = kwargs.pop('function', 'multiquadric')

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -146,5 +146,14 @@ def test_rbf_epsilon_none():
     rbf = Rbf(x, y, epsilon=None)
 
 
+def test_rbf_epsilon_none_collinear():
+    # Check that collinear points in one dimension doesn't cause an error
+    # due to epsilon = 0
+    x = [1, 2, 3]
+    y = [4, 4, 4]
+    z = [5, 6, 7]
+    rbf = Rbf(x, y, z, epsilon=None)
+    assert_(rbf.epsilon > 0)
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
possible fix for #5263
