### PR TITLE
ENH: sparse: optimize CSR outer indexing

### DIFF
--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -12,7 +12,8 @@ from scipy._lib.six import xrange
 
 from ._sparsetools import csr_tocsc, csr_tobsr, csr_count_blocks, \
         get_csr_submatrix, csr_sample_values
-from .sputils import upcast, isintlike, IndexMixin, issequence, get_index_dtype
+from .sputils import (upcast, isintlike, IndexMixin, issequence,
+                      get_index_dtype, ismatrix)
 
 from .compressed import _cs_matrix
 
@@ -299,6 +300,14 @@ class csr_matrix(_cs_matrix, IndexMixin):
                     return extracted
                 else:
                     return extracted[:,col]
+
+        elif ismatrix(row) and issequence(col):
+            if len(row[0]) == 1 and isintlike(row[0][0]):
+                # [[[1],[2]], [1,2]], outer indexing
+                row = asindices(row)
+                P_row = extractor(row[:,0], self.shape[0])
+                P_col = extractor(col, self.shape[1]).T
+                return P_row * self * P_col
 
         if not (issequence(col) and issequence(row)):
             # Sample elementwise

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -221,7 +221,7 @@ def issequence(t):
 
 
 def ismatrix(t):
-    return ((issequence(t) and issequence(t[0]) and (len(t[0]) == 0 or np.isscalar(t[0][0])))
+    return ((isinstance(t, (list, tuple)) and len(t) > 0 and issequence(t[0]))
             or (isinstance(t, np.ndarray) and t.ndim == 2))
 
 

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -64,6 +64,16 @@ class TestSparseUtils(TestCase):
         assert_equal(sputils.issequence(np.array([[1],[2],[3]])),False)
         assert_equal(sputils.issequence(3),False)
 
+    def test_ismatrix(self):
+        assert_equal(sputils.ismatrix(((),)), True)
+        assert_equal(sputils.ismatrix([[1],[2]]), True)
+        assert_equal(sputils.ismatrix(np.arange(3)[None]), True)
+
+        assert_equal(sputils.ismatrix([1,2]), False)
+        assert_equal(sputils.ismatrix(np.arange(3)), False)
+        assert_equal(sputils.ismatrix([[[1]]]), False)
+        assert_equal(sputils.ismatrix(3), False)
+
     def test_isdense(self):
         assert_equal(sputils.isdense(np.array([1])),True)
         assert_equal(sputils.isdense(np.matrix([1])),True)


### PR DESCRIPTION
Takes advantage of a common case: "outer" fancy indexing.

Using the micro-benchmark from #5265 on my dev machine, before this PR:

```
R[sel_rows][:, sel_cols]  =>  100 loops, best of 3: 3.65 ms per loop
R[sel_rows[:,None], sel_cols]  =>  1 loops, best of 3: 1.05 s per loop
```

using this PR:

```
R[sel_rows][:, sel_cols]  =>  100 loops, best of 3: 3.53 ms per loop
R[sel_rows[:,None], sel_cols]  =>  100 loops, best of 3: 3.51 ms per loop
```

The `ismatrix` change fixes a bug in the logic. Previously, the `issequence(t) and issequence(t[0])` check would always fail, because `issequence` checks that its first element is a scalar.
