### PR TITLE
Dynamic checking of BLAS/LAPACK routines

### DIFF
--- a/scipy/linalg/_check_blas_signatures.py
+++ b/scipy/linalg/_check_blas_signatures.py
@@ -10,6 +10,7 @@ from __future__ import division, print_function, absolute_import
 
 from _library_check import get_linking_signatures
 
+
 def run():
     from numpy.distutils.system_info import get_info, NotFoundError
 
@@ -25,5 +26,6 @@ def run():
     with open('cython_blas_signatures_actual.txt','w') as f:
         f.writelines(sigs)
 
+    
 if __name__ == '__main__':
     run()

--- a/scipy/linalg/_check_blas_signatures.py
+++ b/scipy/linalg/_check_blas_signatures.py
@@ -1,0 +1,29 @@
+"""
+Checks the signature file for BLAS entries in the actual
+local library.
+
+It does so by reading the cython_blas_signatures.txt
+file and tries to link all signatures to check their 
+existance.
+"""
+from __future__ import division, print_function, absolute_import
+
+from _library_check import get_linking_signatures
+
+def run():
+    from numpy.distutils.system_info import get_info, NotFoundError
+
+    lapack_opt = get_info('lapack_opt')
+    print('The LAPACK library option:')
+    print(lapack_opt)
+
+    if not lapack_opt:
+        raise NotFoundError('no lapack/blas resources found')
+
+    sigs = get_linking_signatures('cython_blas_signatures.txt',lapack_opt)
+
+    with open('cython_blas_signatures_actual.txt','w') as f:
+        f.writelines(sigs)
+
+if __name__ == '__main__':
+    run()

--- a/scipy/linalg/_check_lapack_signatures.py
+++ b/scipy/linalg/_check_lapack_signatures.py
@@ -1,0 +1,29 @@
+"""
+Checks the signature file for LAPACK entries in the actual
+local library.
+
+It does so by reading the cython_lapack_signatures.txt
+file and tries to link all signatures to check their 
+existance.
+"""
+from __future__ import division, print_function, absolute_import
+
+from _library_check import get_linking_signatures
+
+def run():
+    from numpy.distutils.system_info import get_info, NotFoundError
+
+    lapack_opt = get_info('lapack_opt')
+    print('The LAPACK library option:')
+    print(lapack_opt)
+
+    if not lapack_opt:
+        raise NotFoundError('no lapack/blas resources found')
+
+    sigs = get_linking_signatures('cython_lapack_signatures.txt',lapack_opt)
+
+    with open('cython_lapack_signatures_actual.txt','w') as f:
+        f.writelines(sigs)
+
+if __name__ == '__main__':
+    run()

--- a/scipy/linalg/_check_lapack_signatures.py
+++ b/scipy/linalg/_check_lapack_signatures.py
@@ -10,6 +10,7 @@ from __future__ import division, print_function, absolute_import
 
 from _library_check import get_linking_signatures
 
+
 def run():
     from numpy.distutils.system_info import get_info, NotFoundError
 
@@ -25,5 +26,6 @@ def run():
     with open('cython_lapack_signatures_actual.txt','w') as f:
         f.writelines(sigs)
 
+    
 if __name__ == '__main__':
     run()

--- a/scipy/linalg/_cython_signature_generator.py
+++ b/scipy/linalg/_cython_signature_generator.py
@@ -15,14 +15,14 @@ import os
 import os.path
 from numpy.f2py import crackfortran
 
-sig_types = {'integer':'int',
-             'complex':'c',
-             'double precision':'d',
-             'real':'s',
-             'complex*16':'z',
-             'double complex':'z',
-             'character':'char',
-             'logical':'bint'}
+sig_types = {'integer': 'int',
+             'complex': 'c',
+             'double precision': 'd',
+             'real': 's',
+             'complex*16': 'z',
+             'double complex': 'z',
+             'character': 'char',
+             'logical': 'bint'}
 
 
 def get_type(info, arg):
@@ -88,6 +88,9 @@ def sigs_from_dirs(dirs, outfile, manual_wrappers=None, exclusions=None):
 blas_manual_wrappers = '''void cgemm3m(char *transa, char *transb, int *m, int *n, int *k, c *alpha, c *a, int *lda, c *b, int *ldb, c *beta, c *c, int *ldc)
 void zgemm3m(char *transa, char *transb, int *m, int *n, int *k, z *alpha, z *a, int *lda, z *b, int *ldb, z *beta, z *c, int *ldc)
 '''
+# Currently we do not force the gemm3m kernels, however,
+# when dynamic checking they should definitely be added.
+blas_manual_wrappers = ''
 
 
 lapack_manual_wrappers = '''void cgees(char *jobvs, char *sort, cselect1 *select, int *n, c *a, int *lda, int *sdim, c *w, c *vs, int *ldvs, c *work, int *lwork, s *rwork, bint *bwork, int *info)

--- a/scipy/linalg/_cython_signature_generator.py
+++ b/scipy/linalg/_cython_signature_generator.py
@@ -4,23 +4,25 @@ the Cython BLAS and LAPACK wrappers from the fortran source code for
 LAPACK and the reference BLAS.
 
 To generate the BLAS wrapper signatures call:
-python _cython_signature_generator.py blas <blas_directory> <out_file>
+python _cython_signature_generator.py blas <blas_directory1> [<blas_directory2> [...]] <out_file>
 
 To generate the LAPACK wrapper signatures call:
-python _cython_signature_generator.py lapack <lapack_src_directory> <out_file>
+python _cython_signature_generator.py lapack <lapack_src_directory1> [<lapack_src_directory2> [...]] <out_file>
 """
 
 import glob
+import os
+import os.path
 from numpy.f2py import crackfortran
 
-sig_types = {'integer': 'int',
-             'complex': 'c',
-             'double precision': 'd',
-             'real': 's',
-             'complex*16': 'z',
-             'double complex': 'z',
-             'character': 'char',
-             'logical': 'bint'}
+sig_types = {'integer':'int',
+             'complex':'c',
+             'double precision':'d',
+             'real':'s',
+             'complex*16':'z',
+             'double complex':'z',
+             'character':'char',
+             'logical':'bint'}
 
 
 def get_type(info, arg):
@@ -48,20 +50,23 @@ def get_sig_name(line):
     return line.split('(')[0].split(' ')[-1]
 
 
-def sigs_from_dir(directory, outfile, manual_wrappers=None, exclusions=None):
-    if directory[-1] in ['/', '\\']:
-        directory = directory[:-1]
-    files = glob.glob(directory + '/*.f*')
+def sigs_from_dirs(dirs, outfile, manual_wrappers=None, exclusions=None):
     if exclusions is None:
         exclusions = []
     if manual_wrappers is not None:
         exclusions += [get_sig_name(l) for l in manual_wrappers.split('\n')]
     signatures = []
-    for filename in files:
-        name = filename.split('\\')[-1][:-2]
-        if name in exclusions:
-            continue
-        signatures.append(make_signature(filename))
+    for directory in dirs:
+        if directory[-len(os.sep)] == os.sep:
+            directory = directory[:-len(os.sep)]
+        files = glob.glob(os.path.join(directory,'*.f*'))
+        for filename in files:
+            # Get file-name
+            name = os.path.split(filename)[-1]
+            name = os.path.splitext(name)[0]
+            if name in exclusions:
+                continue
+            signatures.append(make_signature(filename))
     if manual_wrappers is not None:
         signatures += [l + '\n' for l in manual_wrappers.split('\n')]
     signatures.sort(key=get_sig_name)
@@ -71,6 +76,7 @@ def sigs_from_dir(directory, outfile, manual_wrappers=None, exclusions=None):
         f.writelines(comment)
         f.writelines(signatures)
 
+        
 # The signature that is used for zcgesv in lapack 3.1.0 and 3.1.1 changed
 # in version 3.2.0. The version included in the clapack on OSX has the
 # more recent signature though.
@@ -79,33 +85,49 @@ def sigs_from_dir(directory, outfile, manual_wrappers=None, exclusions=None):
 # The other manual signatures are used because the signature generating
 # functions don't work when function pointer arguments are used.
 
+blas_manual_wrappers = '''void cgemm3m(char *transa, char *transb, int *m, int *n, int *k, c *alpha, c *a, int *lda, c *b, int *ldb, c *beta, c *c, int *ldc)
+void zgemm3m(char *transa, char *transb, int *m, int *n, int *k, z *alpha, z *a, int *lda, z *b, int *ldb, z *beta, z *c, int *ldc)
+'''
+
+
 lapack_manual_wrappers = '''void cgees(char *jobvs, char *sort, cselect1 *select, int *n, c *a, int *lda, int *sdim, c *w, c *vs, int *ldvs, c *work, int *lwork, s *rwork, bint *bwork, int *info)
 void cgeesx(char *jobvs, char *sort, cselect1 *select, char *sense, int *n, c *a, int *lda, int *sdim, c *w, c *vs, int *ldvs, s *rconde, s *rcondv, c *work, int *lwork, s *rwork, bint *bwork, int *info)
 void cgges(char *jobvsl, char *jobvsr, char *sort, cselect2 *selctg, int *n, c *a, int *lda, c *b, int *ldb, int *sdim, c *alpha, c *beta, c *vsl, int *ldvsl, c *vsr, int *ldvsr, c *work, int *lwork, s *rwork, bint *bwork, int *info)
+void cgges3(char *jobvsl, char *jobvsr, char *sort, cselect2 *selctg, int *n, c *a, int *lda, c *b, int *ldb, int *sdim, c *alpha, c *beta, c *vsl, int *ldvsl, c *vsr, int *ldvsr, c *work, int *lwork, s *rwork, bint *bwork, int *info)
 void cggesx(char *jobvsl, char *jobvsr, char *sort, cselect2 *selctg, char *sense, int *n, c *a, int *lda, c *b, int *ldb, int *sdim, c *alpha, c *beta, c *vsl, int *ldvsl, c *vsr, int *ldvsr, s *rconde, s *rcondv, c *work, int *lwork, s *rwork, int *iwork, int *liwork, bint *bwork, int *info)
 void dgees(char *jobvs, char *sort, dselect2 *select, int *n, d *a, int *lda, int *sdim, d *wr, d *wi, d *vs, int *ldvs, d *work, int *lwork, bint *bwork, int *info)
 void dgeesx(char *jobvs, char *sort, dselect2 *select, char *sense, int *n, d *a, int *lda, int *sdim, d *wr, d *wi, d *vs, int *ldvs, d *rconde, d *rcondv, d *work, int *lwork, int *iwork, int *liwork, bint *bwork, int *info)
 void dgges(char *jobvsl, char *jobvsr, char *sort, dselect3 *selctg, int *n, d *a, int *lda, d *b, int *ldb, int *sdim, d *alphar, d *alphai, d *beta, d *vsl, int *ldvsl, d *vsr, int *ldvsr, d *work, int *lwork, bint *bwork, int *info)
+void dgges3(char *jobvsl, char *jobvsr, char *sort, dselect3 *selctg, int *n, d *a, int *lda, d *b, int *ldb, int *sdim, d *alphar, d *alphai, d *beta, d *vsl, int *ldvsl, d *vsr, int *ldvsr, d *work, int *lwork, bint *bwork, int *info)
 void dggesx(char *jobvsl, char *jobvsr, char *sort, dselect3 *selctg, char *sense, int *n, d *a, int *lda, d *b, int *ldb, int *sdim, d *alphar, d *alphai, d *beta, d *vsl, int *ldvsl, d *vsr, int *ldvsr, d *rconde, d *rcondv, d *work, int *lwork, int *iwork, int *liwork, bint *bwork, int *info)
 d dlamch(char *cmach)
 void ilaver(int *vers_major, int *vers_minor, int *vers_patch)
 void sgees(char *jobvs, char *sort, sselect2 *select, int *n, s *a, int *lda, int *sdim, s *wr, s *wi, s *vs, int *ldvs, s *work, int *lwork, bint *bwork, int *info)
 void sgeesx(char *jobvs, char *sort, sselect2 *select, char *sense, int *n, s *a, int *lda, int *sdim, s *wr, s *wi, s *vs, int *ldvs, s *rconde, s *rcondv, s *work, int *lwork, int *iwork, int *liwork, bint *bwork, int *info)
 void sgges(char *jobvsl, char *jobvsr, char *sort, sselect3 *selctg, int *n, s *a, int *lda, s *b, int *ldb, int *sdim, s *alphar, s *alphai, s *beta, s *vsl, int *ldvsl, s *vsr, int *ldvsr, s *work, int *lwork, bint *bwork, int *info)
+void sgges3(char *jobvsl, char *jobvsr, char *sort, sselect3 *selctg, int *n, s *a, int *lda, s *b, int *ldb, int *sdim, s *alphar, s *alphai, s *beta, s *vsl, int *ldvsl, s *vsr, int *ldvsr, s *work, int *lwork, bint *bwork, int *info)
 void sggesx(char *jobvsl, char *jobvsr, char *sort, sselect3 *selctg, char *sense, int *n, s *a, int *lda, s *b, int *ldb, int *sdim, s *alphar, s *alphai, s *beta, s *vsl, int *ldvsl, s *vsr, int *ldvsr, s *rconde, s *rcondv, s *work, int *lwork, int *iwork, int *liwork, bint *bwork, int *info)
 s slamch(char *cmach)
 void zgees(char *jobvs, char *sort, zselect1 *select, int *n, z *a, int *lda, int *sdim, z *w, z *vs, int *ldvs, z *work, int *lwork, d *rwork, bint *bwork, int *info)
 void zgeesx(char *jobvs, char *sort, zselect1 *select, char *sense, int *n, z *a, int *lda, int *sdim, z *w, z *vs, int *ldvs, d *rconde, d *rcondv, z *work, int *lwork, d *rwork, bint *bwork, int *info)
 void zgges(char *jobvsl, char *jobvsr, char *sort, zselect2 *selctg, int *n, z *a, int *lda, z *b, int *ldb, int *sdim, z *alpha, z *beta, z *vsl, int *ldvsl, z *vsr, int *ldvsr, z *work, int *lwork, d *rwork, bint *bwork, int *info)
-void zggesx(char *jobvsl, char *jobvsr, char *sort, zselect2 *selctg, char *sense, int *n, z *a, int *lda, z *b, int *ldb, int *sdim, z *alpha, z *beta, z *vsl, int *ldvsl, z *vsr, int *ldvsr, d *rconde, d *rcondv, z *work, int *lwork, d *rwork, int *iwork, int *liwork, bint *bwork, int *info)'''
+void zgges3(char *jobvsl, char *jobvsr, char *sort, zselect2 *selctg, int *n, z *a, int *lda, z *b, int *ldb, int *sdim, z *alpha, z *beta, z *vsl, int *ldvsl, z *vsr, int *ldvsr, z *work, int *lwork, d *rwork, bint *bwork, int *info)
+void zggesx(char *jobvsl, char *jobvsr, char *sort, zselect2 *selctg, char *sense, int *n, z *a, int *lda, z *b, int *ldb, int *sdim, z *alpha, z *beta, z *vsl, int *ldvsl, z *vsr, int *ldvsr, d *rconde, d *rcondv, z *work, int *lwork, d *rwork, int *iwork, int *liwork, bint *bwork, int *info)
+'''
+
 
 if __name__ == '__main__':
     from sys import argv
-    libname, src_dir, outfile = argv[1:]
+    src_dirs = argv[1:]
+    # Get last
+    outfile = src_dirs.pop()
+    # Get library name
+    libname = src_dirs.pop(0)
     # Exclude scabs and sisnan since they aren't currently included
     # in the scipy-specific ABI wrappers.
     if libname.lower() == 'blas':
-        sigs_from_dir(src_dir, outfile, exclusions=['scabs1', 'xerbla'])
+        sigs_from_dirs(src_dirs, outfile, manual_wrappers=blas_manual_wrappers,
+                      exclusions=['scabs1', 'xerbla'])
     elif libname.lower() == 'lapack':
         # Exclude all routines that do not have consistent interfaces from
         # LAPACK 3.1.0 through 3.5.0.
@@ -117,5 +139,5 @@ if __name__ == '__main__':
                       'xerbla', 'zcgesv', 'dlaisnan', 'slaisnan', 'dlazq3',
                       'dlazq4', 'slazq3', 'slazq4', 'dlasq3', 'dlasq4',
                       'slasq3', 'slasq4', 'dlasq5', 'slasq5', 'slaneg']
-        sigs_from_dir(src_dir, outfile, manual_wrappers=lapack_manual_wrappers,
+        sigs_from_dirs(src_dirs, outfile, manual_wrappers=lapack_manual_wrappers,
                       exclusions=exclusions)

--- a/scipy/linalg/_library_check.py
+++ b/scipy/linalg/_library_check.py
@@ -10,10 +10,12 @@ otherwise it is removed from the list.
 """
 from __future__ import division, print_function, absolute_import
 
-import distutils.ccompiler
+from os.path import join
+
+import os
 import tempfile
 import shutil
-from os.path import join
+import distutils.ccompiler
 
 __all__ = ['get_linking_signatures']
 

--- a/scipy/linalg/_library_check.py
+++ b/scipy/linalg/_library_check.py
@@ -1,0 +1,90 @@
+"""
+Helper function for checking signatures created by:
+ - _cython_blas_signatures.py
+ - _cython_lapack_signatures.py
+
+It does so by trying to link the signatures against 
+linker options passed.
+If the signature succeeds a linking step it is retained, 
+otherwise it is removed from the list.
+"""
+from __future__ import division, print_function, absolute_import
+
+import distutils.ccompiler
+import tempfile
+import shutil
+from os.path import join
+
+__all__ = ['get_linking_signatures']
+
+def get_linking_signatures(signature_file, lib_info):
+    """ Reads signature_file and loops on all entries checking for library
+
+    All lines that looks like a function in `signature_file` will be tested
+    against the lib_info data to determine whether it exist.
+    
+    Returns a string containing all the signatures "as-is" which exists.
+    """
+
+    # Create compiler
+    c = distutils.ccompiler.new_compiler()
+
+    # Create used directories and file names
+    tmpdir = tempfile.mkdtemp()
+    src = join(tmpdir, 'source.c')
+    out = join(tmpdir, 'a.out')
+    s = """void {0}();
+    int main(int argc, const char *argv[])
+    {{
+      {0}{1}();
+      return 0;
+    }}"""
+    
+    # Add the additional "extra" arguments if possible
+    try:
+        extra_args = lib_info['extra_link_args']
+    except:
+        extra_args = []
+
+    # Local function for actual linking
+    def check_sig_line(line, info, f_suffix='_'):
+        ret = False
+        # Retrieve signature routine name
+        try:
+            sig = line.split('(')[0].split(' ')[-1]
+        except:
+            return ret
+        with open(src, 'wt') as f:
+            f.write(s.format(sig, f_suffix))
+        obj = c.compile([src], output_dir=tmpdir)
+        try:
+            c.link_executable(obj, out, libraries=info['libraries'],
+                              library_dirs=info['library_dirs'],
+                              extra_postargs=extra_args)
+            ret = True
+        except:
+            pass
+        # Clean-up the library, this will ensure no overlapping time-stamps
+        try:
+            os.remove(out)
+        except:
+            pass
+        return ret
+
+    # Returned signature list
+    ret_sig = []
+
+    # Loop signatures in file 'signature_file'
+    with open(signature_file,'r') as f:
+        for line in f:
+            if line.startswith('#') or len(line.strip()) == 0:
+                # Simply append the comment or empty line
+                ret_sig += [line]
+            elif check_sig_line(line, lib_info):
+                ret_sig += [line]
+    
+    # Clean-up the temporary folder
+    shutil.rmtree(tmpdir)
+
+    # Return list of signatures _as-written_
+    return ret_sig


### PR DESCRIPTION
Per #5266 a request for doing dynamical checking of LAPACK (and BLAS) routines is needed.

This PR enables such dynamical checking, but does not implement the method as it requires additional cython calls.

However, the procedure for updating the wrappers (with the available linking methods) is:

```
cd scipy/linalg
python _check_blas_signatures.py
mv cython_blas_signatures_actual.txt cython_blas_signatures.txt
python _check_lapack_signatures.py
mv cython_lapack_signatures_actual.txt cython_lapack_signatures.txt
python _cython_wrapper_generators.py
cd ../../
python tools/cythonize.py
```

I have also updated the `_cython_signature_generator.py` to allow multiple directories while searching for sources and headers. This is useful because the deprecated routines in LAPACK are moved to SRC/DEPRECATED, and not entirely removed.

When adopting a dynamic check of the available routines one can do:

```
python _cython_signature_generator.py lapack lapack/SRC lapack/SRC/DEPRECATED cython_lapack_signatures.txt
```

where one should follow the before mentioned steps to actually check whether the LAPACK library has the deprecated routines in the table.

Lastly, I have added the signatures for the gemm3m routines to the `_cython_signature_generator.py` but haven't actually added them. Once the dynamic loading is in action, I would highly recommend to add them.
