### PR TITLE
Fix parameter type in doc.

### DIFF
--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -44,7 +44,7 @@ def connected_components(csgraph, directed=True, connection='weak',
         from i to j and from j to i.  Nodes i and j are weakly connected if
         only one of these paths exists.  If directed == False, this keyword
         is not referenced.
-    return_labels : str, optional
+    return_labels : bool, optional
         If True (default), then return the labels for each of the connected
         components.
 


### PR DESCRIPTION
In scipy.sparse.csgraph.[connected_components](http://docs.scipy.org/doc/scipy-0.16.0/reference/generated/scipy.sparse.csgraph.connected_components.html),
change parameter `return_label` type from str to bool in documentation string.
