### PR TITLE
BUG: io: Stop guessing the data delimiter in ARFF files.

### DIFF
--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -23,7 +23,8 @@ __all__ = ['MetaData', 'loadarff', 'ArffError', 'ParseArffError']
 # the keyword (attribute of relation, for now).
 
 # TODO:
-#   - both integer and reals are treated as numeric -> the integer info is lost !
+#   - both integer and reals are treated as numeric -> the integer info
+#    is lost!
 #   - Replace ValueError by ParseError or something
 
 # We know can handle the following:
@@ -201,7 +202,8 @@ def get_date_format(atrv):
             pattern = pattern.replace("ss", "%S")
             datetime_unit = "s"
         if "z" in pattern or "Z" in pattern:
-            raise ValueError("Date type attributes with time zone not supported, yet")
+            raise ValueError("Date type attributes with time zone not "
+                             "supported, yet")
 
         if datetime_unit is None:
             raise ValueError("Invalid or unsupported date format")
@@ -570,7 +572,9 @@ def _loadarff(ofile):
     # This can be used once we want to support integer as integer values and
     # not as numeric anymore (using masked arrays ?).
     acls2dtype = {'real': float, 'integer': float, 'numeric': float}
-    acls2conv = {'real': safe_float, 'integer': safe_float, 'numeric': safe_float}
+    acls2conv = {'real': safe_float,
+                 'integer': safe_float,
+                 'numeric': safe_float}
     descr = []
     convertors = []
     if not hasstr:
@@ -579,7 +583,8 @@ def _loadarff(ofile):
             if type == 'date':
                 date_format, datetime_unit = get_date_format(value)
                 descr.append((name, "datetime64[%s]" % datetime_unit))
-                convertors.append(partial(safe_date, date_format=date_format, datetime_unit=datetime_unit))
+                convertors.append(partial(safe_date, date_format=date_format,
+                                          datetime_unit=datetime_unit))
             elif type == 'nominal':
                 n = maxnomlen(value)
                 descr.append((name, 'S%d' % n))
@@ -661,7 +666,7 @@ def test_weka(filename):
     print(len(data.dtype))
     print(data.size)
     for i in meta:
-        print_attribute(i,meta[i],data[i])
+        print_attribute(i, meta[i], data[i])
 
 # make sure nose does not find this as a test
 test_weka.__test__ = False

--- a/scipy/io/arff/tests/data/nodata.arff
+++ b/scipy/io/arff/tests/data/nodata.arff
@@ -1,0 +1,11 @@
+@RELATION iris
+
+@ATTRIBUTE sepallength  REAL
+@ATTRIBUTE sepalwidth   REAL
+@ATTRIBUTE petallength  REAL
+@ATTRIBUTE petalwidth   REAL
+@ATTRIBUTE class    {Iris-setosa,Iris-versicolor,Iris-virginica}
+
+@DATA
+
+% This file has no data

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -13,8 +13,9 @@ else:
 
 import numpy as np
 
-from numpy.testing import (TestCase, assert_array_almost_equal, assert_array_equal, assert_equal,
-        assert_, assert_raises, dec, run_module_suite)
+from numpy.testing import (TestCase, assert_array_almost_equal,
+                           assert_array_equal, assert_equal, assert_,
+                           assert_raises, dec, run_module_suite)
 
 from scipy.io.arff.arffread import loadarff
 from scipy.io.arff.arffread import read_header, parse_type, ParseArffError
@@ -33,8 +34,8 @@ test6 = pjoin(data_path, 'test6.arff')
 test7 = pjoin(data_path, 'test7.arff')
 test8 = pjoin(data_path, 'test8.arff')
 expect4_data = [(0.1, 0.2, 0.3, 0.4, 'class1'),
-        (-0.1, -0.2, -0.3, -0.4, 'class2'),
-        (1, 2, 3, 4, 'class3')]
+                (-0.1, -0.2, -0.3, -0.4, 'class2'),
+                (1, 2, 3, 4, 'class3')]
 expected_types = ['numeric', 'numeric', 'numeric', 'numeric', 'nominal']
 
 missing = pjoin(data_path, 'missing.arff')
@@ -179,11 +180,13 @@ class HeaderTest(TestCase):
 
 
 class DateAttributeTest(TestCase):
-    @dec.skipif(NumpyVersion(np.__version__) < '1.7.0', "No np.datetime64 in Numpy < 1.7.0")
+    @dec.skipif(NumpyVersion(np.__version__) < '1.7.0',
+                "No np.datetime64 in Numpy < 1.7.0")
     def setUp(self):
         self.data, self.meta = loadarff(test7)
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.7.0', "No np.datetime64 in Numpy < 1.7.0")
+    @dec.skipif(NumpyVersion(np.__version__) < '1.7.0',
+                "No np.datetime64 in Numpy < 1.7.0")
     def test_year_attribute(self):
         expected = np.array([
             '1999',
@@ -196,7 +199,8 @@ class DateAttributeTest(TestCase):
 
         assert_array_equal(self.data["attr_year"], expected)
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.7.0', "No np.datetime64 in Numpy < 1.7.0")
+    @dec.skipif(NumpyVersion(np.__version__) < '1.7.0',
+                "No np.datetime64 in Numpy < 1.7.0")
     def test_month_attribute(self):
         expected = np.array([
             '1999-01',
@@ -209,7 +213,8 @@ class DateAttributeTest(TestCase):
 
         assert_array_equal(self.data["attr_month"], expected)
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.7.0', "No np.datetime64 in Numpy < 1.7.0")
+    @dec.skipif(NumpyVersion(np.__version__) < '1.7.0',
+                "No np.datetime64 in Numpy < 1.7.0")
     def test_date_attribute(self):
         expected = np.array([
             '1999-01-31',
@@ -222,7 +227,8 @@ class DateAttributeTest(TestCase):
 
         assert_array_equal(self.data["attr_date"], expected)
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.7.0', "No np.datetime64 in Numpy < 1.7.0")
+    @dec.skipif(NumpyVersion(np.__version__) < '1.7.0',
+                "No np.datetime64 in Numpy < 1.7.0")
     def test_datetime_local_attribute(self):
         expected = np.array([
             datetime.datetime(year=1999, month=1, day=31, hour=0, minute=1),
@@ -235,7 +241,8 @@ class DateAttributeTest(TestCase):
 
         assert_array_equal(self.data["attr_datetime_local"], expected)
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.7.0', "No np.datetime64 in Numpy < 1.7.0")
+    @dec.skipif(NumpyVersion(np.__version__) < '1.7.0',
+                "No np.datetime64 in Numpy < 1.7.0")
     def test_datetime_missing(self):
         expected = np.array([
             'nat',

--- a/scipy/io/arff/tests/test_arffread.py
+++ b/scipy/io/arff/tests/test_arffread.py
@@ -83,6 +83,21 @@ class MissingDataTest(TestCase):
             assert_array_almost_equal(data[i], expect_missing[i])
 
 
+class NoDataTest(TestCase):
+    def test_nodata(self):
+        # The file nodata.arff has no data in the @DATA section.
+        # Reading it should result in an array with length 0.
+        nodata_filename = os.path.join(data_path, 'nodata.arff')
+        data, meta = loadarff(nodata_filename)
+        expected_dtype = np.dtype([('sepallength', '<f8'),
+                                   ('sepalwidth', '<f8'),
+                                   ('petallength', '<f8'),
+                                   ('petalwidth', '<f8'),
+                                   ('class', 'S15')])
+        assert_equal(data.dtype, expected_dtype)
+        assert_equal(data.size, 0)
+
+
 class HeaderTest(TestCase):
     def test_type_parsing(self):
         # Test parsing type of attribute from their value.


### PR DESCRIPTION
From the main commit message:

```
In the ARFF reader, there were several dozen lines of code that
determined whether the delimiter in the @DATA section of the ARFF
file was a comma or a space.  This code has been removed.  The ARFF
file format specification says the delimiter must be a comma.

As a side effect, this closes gh-5276.  'loadarff' can now handle
a file with no data in the @DATA section.
```
