### PR TITLE
MAINT: spatial: standard infinity handling in ckdtree

### DIFF
--- a/scipy/spatial/ckdtree/src/ckdtree_cpp_methods.h
+++ b/scipy/spatial/ckdtree/src/ckdtree_cpp_methods.h
@@ -1,4 +1,3 @@
-
 #ifndef CKDTREE_CPP_METHODS
 #define CKDTREE_CPP_METHODS
 
@@ -9,7 +8,6 @@
 struct ckdtree;
 #endif 
 
-extern npy_float64 infinity;
 extern int number_of_processors;
 
 #ifndef NPY_LIKELY
@@ -17,6 +15,7 @@ extern int number_of_processors;
 #endif
 
 #include <cmath>
+#include <numpy/npy_math.h>
 
 #if defined(__GNUC__)
 inline void 
@@ -136,7 +135,7 @@ _distance_p(const npy_float64 *x, const npy_float64 *y,
         }*/
         return sqeuclidean_distance_double(x,y,k);
     } 
-    else if (p==infinity) {
+    else if (npy_isinf(p)) {
         for (i=0; i<k; ++i) {
             r = dmax(r,dabs(x[i]-y[i]));
             if (r>upperbound)

--- a/scipy/spatial/ckdtree/src/ckdtree_globals.cxx
+++ b/scipy/spatial/ckdtree/src/ckdtree_globals.cxx
@@ -1,13 +1,1 @@
-/*
- * This would break SciPy with NumPy 1.6 so just accept the compiler
- * warning for now.
- * #define NPY_NO_DEPRECATED_API NPY_1_9_API_VERSION 
- *
- */
- 
-#include <Python.h>
-#include "numpy/arrayobject.h"
-
-npy_float64 infinity;
 int number_of_processors;
-


### PR DESCRIPTION
Use NumPy's `NPY_INFINITY` and `npy_isinf` instead of a custom global variable. Should fix #5281.
