### PR TITLE
DOC: special: Remove a potentially misleading example from the diric docstring

### DIFF
--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -105,22 +105,6 @@ def diric(x, n):
     >>> k * special.diric(theta, k)
     array([ 3.        ,  2.41421356,  1.        , -0.41421356, -1.        ,
            -0.41421356,  1.        ,  2.41421356])
-
-    We get the exact Fourier transform if we multiply by the phase
-    factors ``np.exp(-1j*theta)``:
-
-    >>> np.fft.fft(x)
-    array([ 3.00000000+0.j        ,  1.70710678-1.70710678j,
-            0.00000000-1.j        ,  0.29289322+0.29289322j,
-            1.00000000+0.j        ,  0.29289322-0.29289322j,
-            0.00000000+1.j        ,  1.70710678+1.70710678j])
-
-    >>> np.exp(-1j*theta) * k * special.diric(theta, k)
-    array([ 3.00000000+0.j        ,  1.70710678-1.70710678j,
-            0.00000000-1.j        ,  0.29289322+0.29289322j,
-            1.00000000+0.j        ,  0.29289322-0.29289322j,
-           -0.00000000+1.j        ,  1.70710678+1.70710678j])
-
     """
     x, n = asarray(x), asarray(n)
     n = asarray(n + (x-x))


### PR DESCRIPTION
The final part of the last example in the diric docstring shows a calculation
that produces the same result as an FFT.  The example is misleading, because
it only works in special cases. (E.g. it doesn't work if k is changed from 3
to 2.)  This commit removes that part of the example.

[ci skip]
