### PR TITLE
Fixed leaf_rotation and leaf_font_size in Python 3

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -605,7 +605,7 @@ def linkage(y, method='single', metric='euclidean'):
         The linkage algorithm to use. See the ``Linkage Methods`` section below
         for full descriptions.
     metric : str or function, optional
-        The distance metric to use in the case that y is a collection of 
+        The distance metric to use in the case that y is a collection of
         observation vectors; ignored otherwise. See the ``distance.pdist``
         function for a list of valid distance metrics. A custom distance
         function can also be used. See the ``distance.pdist`` function for
@@ -1674,15 +1674,15 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
 
         lbls = ax.get_xticklabels()
         if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
+            list(map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls))
         else:
             leaf_rot = float(_get_tick_rotation(len(ivl)))
-            map(lambda lbl: lbl.set_rotation(leaf_rot), lbls)
+            list(map(lambda lbl: lbl.set_rotation(leaf_rot), lbls))
         if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
+            list(map(lambda lbl: lbl.set_size(leaf_font_size), lbls))
         else:
             leaf_fs = float(_get_tick_text_size(len(ivl)))
-            map(lambda lbl: lbl.set_size(leaf_fs), lbls)
+            list(map(lambda lbl: lbl.set_size(leaf_fs), lbls))
 
         # Make the tick marks invisible because they cover up the links
         for line in ax.get_xticklines():
@@ -1701,16 +1701,16 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
 
         lbls = ax.get_xticklabels()
         if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
+            list(map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls))
         else:
             leaf_rot = float(_get_tick_rotation(p))
-            map(lambda lbl: lbl.set_rotation(leaf_rot), lbls)
+            list(map(lambda lbl: lbl.set_rotation(leaf_rot), lbls))
 
         if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
+            list(map(lambda lbl: lbl.set_size(leaf_font_size), lbls))
         else:
             leaf_fs = float(_get_tick_text_size(p))
-            map(lambda lbl: lbl.set_size(leaf_fs), lbls)
+            list(map(lambda lbl: lbl.set_size(leaf_fs), lbls))
 
         ax.xaxis.set_ticks_position('top')
         # Make the tick marks invisible because they cover up the links
@@ -1730,9 +1730,9 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
 
         lbls = ax.get_yticklabels()
         if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
+            list(map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls))
         if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
+            list(map(lambda lbl: lbl.set_size(leaf_font_size), lbls))
 
         ax.yaxis.set_ticks_position('left')
         # Make the tick marks invisible because they cover up the
@@ -1753,9 +1753,9 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
 
         lbls = ax.get_yticklabels()
         if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
+            list(map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls))
         if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
+            list(map(lambda lbl: lbl.set_size(leaf_font_size), lbls))
 
         ax.yaxis.set_ticks_position('right')
         # Make the tick marks invisible because they cover up the links

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -1674,15 +1674,19 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
 
         lbls = ax.get_xticklabels()
         if leaf_rotation:
-            list(map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls))
+            for lbl in lbls:
+                lbl.set_rotation(leaf_rotation)
         else:
             leaf_rot = float(_get_tick_rotation(len(ivl)))
-            list(map(lambda lbl: lbl.set_rotation(leaf_rot), lbls))
+            for lbl in lbls:
+                lbl.set_rotation(leaf_rot)
         if leaf_font_size:
-            list(map(lambda lbl: lbl.set_size(leaf_font_size), lbls))
+            for lbl in lbls:
+                lbl.set_size(leaf_font_size)
         else:
             leaf_fs = float(_get_tick_text_size(len(ivl)))
-            list(map(lambda lbl: lbl.set_size(leaf_fs), lbls))
+            for lbl in lbls:
+                lbl.set_size(leaf_fs)
 
         # Make the tick marks invisible because they cover up the links
         for line in ax.get_xticklines():
@@ -1701,16 +1705,20 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
 
         lbls = ax.get_xticklabels()
         if leaf_rotation:
-            list(map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls))
+            for lbl in lbls:
+                lbl.set_rotation(leaf_rotation)
         else:
             leaf_rot = float(_get_tick_rotation(p))
-            list(map(lambda lbl: lbl.set_rotation(leaf_rot), lbls))
+            for lbl in lbls:
+                lbl.set_rotation(leaf_rot)
 
         if leaf_font_size:
-            list(map(lambda lbl: lbl.set_size(leaf_font_size), lbls))
+            for lbl in lbls:
+                lbl.set_size(leaf_font_size)
         else:
             leaf_fs = float(_get_tick_text_size(p))
-            list(map(lambda lbl: lbl.set_size(leaf_fs), lbls))
+            for lbl in lbls:
+                lbl.set_size(leaf_fs)
 
         ax.xaxis.set_ticks_position('top')
         # Make the tick marks invisible because they cover up the links
@@ -1730,9 +1738,11 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
 
         lbls = ax.get_yticklabels()
         if leaf_rotation:
-            list(map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls))
+            for lbl in lbls:
+                lbl.set_rotation(leaf_rotation)
         if leaf_font_size:
-            list(map(lambda lbl: lbl.set_size(leaf_font_size), lbls))
+            for lbl in lbls:
+                lbl.set_size(leaf_font_size)
 
         ax.yaxis.set_ticks_position('left')
         # Make the tick marks invisible because they cover up the
@@ -1753,9 +1763,11 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
 
         lbls = ax.get_yticklabels()
         if leaf_rotation:
-            list(map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls))
+            for lbl in lbls:
+                lbl.set_rotation(leaf_rotation)
         if leaf_font_size:
-            list(map(lambda lbl: lbl.set_size(leaf_font_size), lbls))
+            for lbl in lbls:
+                lbl.set_size(leaf_font_size)
 
         ax.yaxis.set_ticks_position('right')
         # Make the tick marks invisible because they cover up the links

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -775,12 +775,40 @@ class TestDendrogram(object):
                     'leaves': [2, 5, 1, 0, 3, 4]}
 
         fig = plt.figure()
-        ax = fig.add_subplot(111)
+        ax = fig.add_subplot(221)
 
         # test that dendrogram accepts ax keyword
         R1 = dendrogram(Z, ax=ax, orientation=orientation)
-        plt.close()
         assert_equal(R1, expected)
+
+        # test that dendrogram accepts and handle the leaf_font_size and
+        # leaf_rotation keywords
+        R1a = dendrogram(Z, ax=ax, orientation=orientation,
+                         leaf_font_size=20, leaf_rotation=90)
+        testlabel = (
+            ax.get_xticklabels()[0]
+            if orientation in ['top', 'bottom']
+            else ax.get_yticklabels()[0]
+        )
+        assert_equal(testlabel.get_rotation(), 90)
+        assert_equal(testlabel.get_size(), 20)
+        R1a = dendrogram(Z, ax=ax, orientation=orientation,
+                         leaf_rotation=90)
+        testlabel = (
+            ax.get_xticklabels()[0]
+            if orientation in ['top', 'bottom']
+            else ax.get_yticklabels()[0]
+        )
+        assert_equal(testlabel.get_rotation(), 90)
+        R1a = dendrogram(Z, ax=ax, orientation=orientation,
+                         leaf_font_size=20)
+        testlabel = (
+            ax.get_xticklabels()[0]
+            if orientation in ['top', 'bottom']
+            else ax.get_yticklabels()[0]
+        )
+        assert_equal(testlabel.get_size(), 20)
+        plt.close()
 
         # test plotting to gca (will import pylab)
         R2 = dendrogram(Z, orientation=orientation)


### PR DESCRIPTION
The arguments leaf_rotation and leaf_font_size in scipy.cluster.hierarchy.dendrogram() did not apply their values to the final plot in Python 3 since map() now returns a generator instead of a list. This change forces the lambda function to be applied by converting the generator to a list.

I also added a check for this problem in the dendrogram plotting test.
