### PR TITLE
BUG: handle corner cases for correlation

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -360,6 +360,12 @@ def correlation(u, v):
     """
     u = _validate_vector(u)
     v = _validate_vector(v)
+
+    # Deal with the corner cases at first
+    # Avoid to output nan in any case
+    if np.ptp(u) == 0.0 or np.ptp(v) == 0.0:
+        return 1.0
+
     umu = u.mean()
     vmu = v.mean()
     um = u - umu

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1246,6 +1246,14 @@ class TestSomeDistanceFunctions(TestCase):
         Y2 = 1.
         _assert_within_tol(Y1, Y2, eps, verbose > 2)
 
+        # almost constant
+        X1 = np.array([1, 1, 1])
+        noise = np.array([.5, 0, -.01])
+        X2 = np.array([2, 4, 6])
+        for eps in np.linspace(-1e-15, .0, 50):
+            Y1 = correlation(X1 + eps * noise, X2)
+            assert_(Y1 is not np.nan)
+
 
 class TestSquareForm(TestCase):
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1203,6 +1203,49 @@ class TestSomeDistanceFunctions(TestCase):
             dist = mahalanobis(x, y, vi)
             assert_almost_equal(dist, np.sqrt(6.0))
 
+    def test_correlation_corner_cases(self):
+        eps = 1e-15
+
+        # correlation +1
+        X1 = np.array([1, 2, 3])
+        X2 = np.array([2, 4, 6])
+        Y1 = correlation(X1, X2)
+        Y2 = 0.
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+        # correlation -1
+        Y1 = correlation(X1, -X2)
+        Y2 = 2.
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+        # constant
+        X2 = np.array([1, 1, 1])
+        Y1 = correlation(X1, X2)
+        Y2 = 1.
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+        # constant with negative
+        Y1 = correlation(X1, -X2)
+        Y2 = 1.
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+        # both same constant => correlation +1
+        Y1 = correlation(X2, X2)
+        Y2 = 1.
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+        # opposite constant => correlation -1
+        Y1 = correlation(X2, -X2)
+        Y2 = 1.
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
+        # zeros
+        X1 = np.zeros(3)
+        X2 = -X1
+        Y1 = correlation(X1, X2)
+        Y2 = 1.
+        _assert_within_tol(Y1, Y2, eps, verbose > 2)
+
 
 class TestSquareForm(TestCase):
 


### PR DESCRIPTION
Following discussion from [/scikit-learn#4475](https://github.com/scikit-learn/scikit-learn/issues/4475), it would be nice to have corner cases handled inside scipy's `correlation` directly. Although correlation is not mathematically defined for constant input vector, it makes sense to complete the definition at the limits of vectors with zero variance as 1, the middle point for the domain of the correlation distance. One vector's lack of variance does not say anything about any other vector variation.

The choice [is also justified](http://stats.stackexchange.com/questions/18333/what-is-the-correlation-if-the-standard-deviation-of-one-variable-is-0) by the fact that if one's variance is zero, it follows that the covariance is also 0, and therefore correlation distance is 1.

I did not observe issues with other distance functions, except `yule`.
