### PR TITLE
fix input check for sparse.linalg.svds

### DIFF
--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -1633,6 +1633,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
         Array to compute the SVD on, of shape (M, N)
     k : int, optional
         Number of singular values and vectors to compute.
+        Must be 1 <= k < min(A.shape).
     ncv : int, optional
         The number of Lanczos vectors generated
         ncv must be greater than k+1 and smaller than n;
@@ -1692,6 +1693,9 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
         A = np.asarray(A)
 
     n, m = A.shape
+
+    if k <= 0 or k >= min(n, m):
+        raise ValueError("k must be between 1 and min(A.shape), k=%d" % k)
 
     if isinstance(A, LinearOperator):
         if n > m:

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -556,6 +556,21 @@ def svd_estimate(u, s, vh):
     return np.dot(u, np.dot(np.diag(s), vh))
 
 
+def svd_test_input_check():
+    x = np.array([[1, 2, 3],
+                  [3, 4, 3],
+                  [1, 0, 2],
+                  [0, 0, 1]], float)
+
+    assert_raises(ValueError, svds, x, k=-1)
+    assert_raises(ValueError, svds, x, k=0)
+    assert_raises(ValueError, svds, x, k=10)
+    assert_raises(ValueError, svds, x, k=x.shape[0])
+    assert_raises(ValueError, svds, x, k=x.shape[1])
+    assert_raises(ValueError, svds, x.T, k=x.shape[0])
+    assert_raises(ValueError, svds, x.T, k=x.shape[1])
+
+
 def test_svd_simple_real():
     x = np.array([[1, 2, 3],
                   [3, 4, 3],


### PR DESCRIPTION
Error message does not reflect the behaviour of input checks. The behaviour for k=min(A.shape) is not documented in the docstring. The error cannot be raised consistently from `eigsh` because that function only works for symmetric matrices.

```
import numpy as np
from scipy.sparse import linalg

X = np.random.RandomState(0).uniform(-1, 1, size=(10, 15))
U, S, V = linalg.svds(X, k = 10)
```

```
/scipy/sparse/linalg/eigen/arpack/arpack.py in eigsh(A, k, M, sigma, which, v0, ncv, maxiter, tol, return_eigenvectors, Minv, OPinv, mode)
   1505 
   1506     if k <= 0 or k >= n:
-> 1507         raise ValueError("k must be between 1 and the order of the "
   1508                          "square input matrix.")
   1509 

ValueError: k must be between 1 and the order of the square input matrix.

```
