### PR TITLE
Io savemat fixes

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -149,6 +149,7 @@ Fukumu Tsutsumi for bug fixes.
 J.J. Green for interpolation bug fixes.
 François Magimel for documentation improvements.
 Josh Levy-Kramer for the log survival function of the hypergeometric distribution
+Jamie Tsao for fixes and improvements to scipy.io.savemat
 
 
 Institutions

--- a/scipy/io/matlab/mio5.py
+++ b/scipy/io/matlab/mio5.py
@@ -421,7 +421,7 @@ def to_writeable(source):
         ndarray with contents for writing to matfile.
     '''
     if isinstance(source, np.ndarray):
-        return source
+        return np.asfortranarray(source)
     if source is None:
         return None
     # Objects that implement mappings
@@ -441,11 +441,11 @@ def to_writeable(source):
                 dtype.append((field, object))
                 values.append(value)
         if dtype:
-            return np.array([tuple(values)], dtype)
+            return np.array([tuple(values)], dtype, order='F')
         else:
             return EmptyStructMarker
     # Next try and convert to an array
-    narr = np.asanyarray(source)
+    narr = np.asanyarray(source, order='F')
     if narr.dtype.type in (object, np.object_) and \
        narr.shape == () and narr == source:
         # No interesting conversion possible
@@ -490,7 +490,9 @@ class VarWriter5(object):
         self.cur_arrname = None
 
     def write_bytes(self, arr):
-        self.file_stream.write(arr.tostring(order='F'))
+        if arr.flags['F_CONTIGUOUS']:
+            raise Exception("Not F contiguous: "+str(arr))
+        self.file_stream.write(arr.data) #arr.tostring(order='F'))
 
     def write_string(self, s):
         self.file_stream.write(s)


### PR DESCRIPTION
1. Pre-compute byte counting to write data sequentially.
2. Fix savemat OverflowError issue from compressing large matrices.
3. Optimization to decrease memory usage for Fortran-contiguous arrays.
