### PR TITLE
avoid a spurious divide-by-zero in Student t stats

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3361,9 +3361,13 @@ class t_gen(rv_continuous):
         return -special.stdtrit(df, q)
 
     def _stats(self, df):
-        mu2 = where(df > 2, df / (df-2.0), inf)
-        g1 = where(df > 3, 0.0, nan)
-        g2 = where(df > 4, 6.0/(df-4.0), nan)
+        mu2 = _lazywhere(df > 2, (df,),
+                         lambda df: df / (df-2.0),
+                         np.inf)
+        g1 = where(df > 3, 0.0, np.nan)
+        g2 = _lazywhere(df > 4, (df,),
+                        lambda df: 6.0 / (df-4.0),
+                        np.nan)
         return 0, mu2, g1, g2
 t = t_gen(name='t')
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -91,6 +91,13 @@ class TestMvsdist(TestCase):
         data = [1]
         assert_raises(ValueError, stats.mvsdist, data)
 
+    def test_warns(self):
+        # regression test for gh-5270
+        # make sure there are no spurious divide-by-zero warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', RuntimeWarning)
+            [x.mean() for x in stats.mvsdist([1, 2, 3])]
+            [x.mean() for x in stats.mvsdist([1, 2, 3, 4, 5])]
 
 class TestShapiro(TestCase):
     def test_basic(self):


### PR DESCRIPTION
Use _lazywhere to avoid dividing by zero.

closes gh-5270
