### PR TITLE
ENH: add Py3.5-style matmul operator (e.g. A @ B) to sparse linear algebra

### DIFF
--- a/doc/release/0.17.0-notes.rst
+++ b/doc/release/0.17.0-notes.rst
@@ -106,6 +106,8 @@ LAPACK's function ``*gelsd``. Users wanting to get the previous behavior
 can use a new keyword ``lapack_driver="gelss"`` (allowed values are 
 "gelss", "gelsd" and "gelsy").
 
+``scipy.sparse`` matrices and linear operators now support the matmul operator when available (Python 3.5+). See [PEP 465](http://legacy.python.org/dev/peps/pep-0465/)
+
 
 Deprecated features
 ===================

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -387,6 +387,22 @@ class spmatrix(object):
                 tr = np.asarray(other).transpose()
             return (self.transpose() * tr).transpose()
 
+    #####################################
+    # matmul (@) operator (Python 3.5+) #
+    #####################################
+
+    def __matmul__(self, other):
+        if isscalarlike(other):
+            raise ValueError("Scalar operands are not allowed, "
+                             "use '*' instead")
+        return self.__mul__(other)
+
+    def __rmatmul__(self, other):
+        if isscalarlike(other):
+            raise ValueError("Scalar operands are not allowed, "
+                             "use '*' instead")
+        return self.__rmul__(other)
+
     ####################
     # Other Arithmetic #
     ####################

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -367,6 +367,18 @@ class LinearOperator(object):
                 raise ValueError('expected 1-d or 2-d array or matrix, got %r'
                                  % x)
 
+    def __matmul__(self, other):
+        if np.isscalar(other):
+            raise ValueError("Scalar operands are not allowed, "
+                             "use '*' instead")
+        return self.__mul__(other)
+
+    def __rmatmul__(self, other):
+        if np.isscalar(other):
+            raise ValueError("Scalar operands are not allowed, "
+                             "use '*' instead")
+        return self.__rmul__(other)
+
     def __rmul__(self, x):
         if np.isscalar(x):
             return _ScaledLinearOperator(self, x)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -67,6 +67,10 @@ HAS_NUMPY_UFUNC = False
 np.add(_UFuncCheck(), np.array([1]))
 
 
+# Only test matmul operator (A @ B) when available (Python 3.5+)
+TEST_MATMUL = hasattr(operator, 'matmul')
+
+
 warnings.simplefilter('ignore', SparseEfficiencyWarning)
 warnings.simplefilter('ignore', ComplexWarning)
 
@@ -173,6 +177,12 @@ class BinopTester(object):
         return "matrix on the left"
 
     def __rsub__(self, mat):
+        return "matrix on the left"
+
+    def __matmul__(self, mat):
+        return "matrix on the right"
+
+    def __rmatmul__(self, mat):
         return "matrix on the left"
 
 
@@ -1215,6 +1225,34 @@ class _TestCommon:
         assert_equal(B + A, "matrix on the right")
         assert_equal(B - A, "matrix on the right")
         assert_equal(B * A, "matrix on the right")
+
+        if TEST_MATMUL:
+            assert_equal(eval('A @ B'), "matrix on the left")
+            assert_equal(eval('B @ A'), "matrix on the right")
+
+    def test_matmul(self):
+        if not TEST_MATMUL:
+            raise nose.SkipTest("matmul is only tested in Python 3.5+")
+
+        M = self.spmatrix(matrix([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))
+        B = self.spmatrix(matrix([[0,1],[1,0],[0,2]],'d'))
+        col = matrix([1,2,3]).T
+
+        # check matrix-vector
+        assert_array_almost_equal(operator.matmul(M, col),
+                                  M.todense() * col)
+
+        # check matrix-matrix
+        assert_array_almost_equal(operator.matmul(M, B).todense(),
+                                  (M * B).todense())
+        assert_array_almost_equal(operator.matmul(M.todense(), B),
+                                  (M * B).todense())
+        assert_array_almost_equal(operator.matmul(M, B.todense()),
+                                  (M * B).todense())
+
+        # check error on matrix-scalar
+        assert_raises(ValueError, operator.matmul, M, 1)
+        assert_raises(ValueError, operator.matmul, 1, M)
 
     def test_matvec(self):
         M = self.spmatrix(matrix([[3,0,0],[0,1,0],[2,0,3.0],[2,3,0]]))


### PR DESCRIPTION
Simple addition; fully backward compatible.
