### PR TITLE
TST: sparse: silence warnings about boolean indexing

### DIFF
--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2405,7 +2405,8 @@ class _TestFancyIndexing:
         assert_equal(todense(A[B > 9]), B[B > 9])
 
         I = np.array([True, False, True, True, False])
-        J = np.array([False, True, True, False, True])
+        J = np.array([False, True, True, False, True,
+                      False, False, False, False, False])
 
         assert_equal(todense(A[I, J]), B[I, J])
 


### PR DESCRIPTION
Using numpy master, the boolean indexing tests raise many instances of:

```
VisibleDeprecationWarning: boolean index did not match indexed array along dimension 1; dimension is 10 but corresponding boolean dimension is 5
```

This change pads the index array for dimension 1 to length 10, silencing the warning.

As an aside, I noticed that boolean indexing with two 1-d arrays is really brittle: if they have different numbers of True elements, the indexing will fail. Would there be any support for changing sparse indexing to match `np.matrix`?

```
In [2]: A = np.matrix(np.random.random((4,2)))

In [3]: B = ss.csr_matrix(A)

In [4]: i, j = [1], [0,1]

In [6]: A[i,j]
Out[6]: matrix([[ 0.51929,  0.53164]])

In [7]: B[i,j]
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-7-492ed56fa418> in <module>()
----> 1 B[i,j]

/usr/local/lib/python2.7/dist-packages/scipy/sparse/csr.pyc in __getitem__(self, key)
    317         col = asindices(col)
    318         if row.shape != col.shape:
--> 319             raise IndexError('number of row and column indices differ')
    320         assert row.ndim <= 2
    321

IndexError: number of row and column indices differ
```
