### PR TITLE
MAINT: construct csr and csc matrices from integer lists

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -53,7 +53,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                     idx_dtype = get_index_dtype((indices, indptr), check_contents=True)
                     self.indices = np.array(indices, copy=copy, dtype=idx_dtype)
                     self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)
-                    self.data = np.array(data, copy=copy, dtype=getdtype(dtype, data))
+                    self.data = np.array(data, copy=copy, dtype=dtype)
                 else:
                     raise ValueError("unrecognized %s_matrix constructor usage" %
                             self.format)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3096,6 +3096,15 @@ class TestCSR(sparse_test_class()):
         csr = csr_matrix((data, indices, indptr))
         assert_array_equal(csr.shape,(3,6))
 
+    def test_constructor6(self):
+        # infer dimensions and dtype from lists
+        indptr = [0, 1, 3, 3]
+        indices = [0, 5, 1, 2]
+        data = [1, 2, 3, 4]
+        csr = csr_matrix((data, indices, indptr))
+        assert_array_equal(csr.shape, (3,6))
+        assert_(np.issubdtype(csr.dtype, int))
+
     def test_sort_indices(self):
         data = arange(5)
         indices = array([7, 2, 1, 5, 4])
@@ -3257,6 +3266,15 @@ class TestCSC(sparse_test_class()):
         data = array([1,2,3,4])
         csc = csc_matrix((data, indices, indptr))
         assert_array_equal(csc.shape,(6,3))
+
+    def test_constructor6(self):
+        # infer dimensions and dtype from lists
+        indptr = [0, 1, 3, 3]
+        indices = [0, 5, 1, 2]
+        data = [1, 2, 3, 4]
+        csc = csc_matrix((data, indices, indptr))
+        assert_array_equal(csc.shape,(6,3))
+        assert_(np.issubdtype(csc.dtype, int))
 
     def test_eliminate_zeros(self):
         data = array([1, 0, 0, 0, 2, 0, 3, 0])


### PR DESCRIPTION
closes https://github.com/scipy/scipy/issues/5353
