### PR TITLE
MAINT: backports for 0.16.1 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ matrix:
       script:
         - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused' > test.out; cat test.out; test \! -s test.out
         - pep8 scipy benchmarks/benchmarks
+    - python: 3.5
+      env:
+        - TESTMODE=fast
+        - COVERAGE=
+        - NUMPYSPEC=numpy
     - python: 3.4
       env:
         - TESTMODE=fast

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -5,6 +5,8 @@ import operator
 import sys
 import warnings
 import numbers
+from collections import namedtuple
+import inspect
 
 import numpy as np
 
@@ -148,3 +150,96 @@ def _asarray_validated(a, check_finite=True,
                 a = toarray(a).astype(np.float_)
     return a
 
+
+# Add a replacement for inspect.getargspec() which is deprecated in python 3.5
+# The version below is borrowed from Django,
+# https://github.com/django/django/pull/4846
+
+# Note an inconsistency between inspect.getargspec(func) and
+# inspect.signature(func). If `func` is a bound method, the latter does *not* 
+# list `self` as a first argument, while the former *does*.
+# Hence cook up a common ground replacement: `getargspec_no_self` which
+# mimics `inspect.getargspec` but does not list `self`.
+#
+# This way, the caller code does not need to know whether it uses a legacy
+# .getargspec or bright and shiny .signature.
+
+try:
+    # is it python 3.3 or higher?
+    inspect.signature
+
+    # Apparently, yes. Wrap inspect.signature
+
+    ArgSpec = namedtuple('ArgSpec', ['args', 'varargs', 'keywords', 'defaults'])
+
+    def getargspec_no_self(func):
+        """inspect.getargspec replacement using inspect.signature.
+
+        inspect.getargspec is deprecated in python 3. This is a replacement
+        based on the (new in python 3.3) `inspect.signature`.
+
+        Parameters
+        ----------
+        func : callable
+            A callable to inspect
+
+        Returns
+        -------
+        argspec : ArgSpec(args, varargs, varkw, defaults)
+            This is similar to the result of inspect.getargspec(func) under
+            python 2.x.
+            NOTE: if the first argument of `func` is self, it is *not*, I repeat
+            *not* included in argspec.args.
+            This is done for consistency between inspect.getargspec() under
+            python 2.x, and inspect.signature() under python 3.x.
+        """
+        sig = inspect.signature(func)
+        args = [
+            p.name for p in sig.parameters.values()
+            if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+        ]
+        varargs = [
+            p.name for p in sig.parameters.values()
+            if p.kind == inspect.Parameter.VAR_POSITIONAL
+        ]
+        varargs = varargs[0] if varargs else None
+        varkw = [
+            p.name for p in sig.parameters.values()
+            if p.kind == inspect.Parameter.VAR_KEYWORD
+        ]
+        varkw = varkw[0] if varkw else None
+        defaults = [
+            p.default for p in sig.parameters.values()
+            if (p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD and
+               p.default is not p.empty)
+        ] or None
+        return ArgSpec(args, varargs, varkw, defaults)
+
+except AttributeError:
+    # python 2.x
+    def getargspec_no_self(func):
+        """inspect.getargspec replacement for compatibility with python 3.x.
+
+        inspect.getargspec is deprecated in python 3. This wraps it, and
+        *removes* `self` from the argument list of `func`, if present.
+        This is done for forward compatibility with python 3.
+
+        Parameters
+        ----------
+        func : callable
+            A callable to inspect
+
+        Returns
+        -------
+        argspec : ArgSpec(args, varargs, varkw, defaults)
+            This is similar to the result of inspect.getargspec(func) under
+            python 2.x.
+            NOTE: if the first argument of `func` is self, it is *not*, I repeat
+            *not* included in argspec.args.
+            This is done for consistency between inspect.getargspec() under
+            python 2.x, and inspect.signature() under python 3.x.
+        """
+        argspec = inspect.getargspec(func)
+        if argspec.args[0] == 'self':
+            argspec.args.pop(0)
+        return argspec

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -606,7 +606,7 @@ def linkage(y, method='single', metric='euclidean'):
         for full descriptions.
     metric : str or function, optional
         The distance metric to use. See the ``distance.pdist`` function for a
-        list of valid distance metrics. The customized distance can also be 
+        list of valid distance metrics. The customized distance can also be
         used. See the ``distance.pdist`` function for details.
 
     Returns
@@ -1667,24 +1667,15 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_xticklabels([])
         else:
             ax.set_xticks(ivticks)
-            ax.set_xticklabels(ivl)
-        ax.xaxis.set_ticks_position('bottom')
+            ax.xaxis.set_ticks_position('bottom')
 
-        lbls = ax.get_xticklabels()
-        if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
-        else:
-            leaf_rot = float(_get_tick_rotation(len(ivl)))
-            map(lambda lbl: lbl.set_rotation(leaf_rot), lbls)
-        if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
-        else:
-            leaf_fs = float(_get_tick_text_size(len(ivl)))
-            map(lambda lbl: lbl.set_rotation(leaf_fs), lbls)
+            # Make the tick marks invisible because they cover up the links
+            for line in ax.get_xticklines():
+                line.set_visible(False)
 
-        # Make the tick marks invisible because they cover up the links
-        for line in ax.get_xticklines():
-            line.set_visible(False)
+            leaf_rot = float(_get_tick_rotation(len(ivl))) if (leaf_rotation is None) else leaf_rotation
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
+            ax.set_xticklabels(ivl, rotation=leaf_rot, size=leaf_font)
     elif orientation == 'bottom':
         ax.set_ylim([dvw, 0])
         ax.set_xlim([0, ivw])
@@ -1695,25 +1686,15 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_xticklabels([])
         else:
             ax.set_xticks(ivticks)
-            ax.set_xticklabels(ivl)
+            ax.xaxis.set_ticks_position('top')
 
-        lbls = ax.get_xticklabels()
-        if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
-        else:
-            leaf_rot = float(_get_tick_rotation(p))
-            map(lambda lbl: lbl.set_rotation(leaf_rot), lbls)
+            # Make the tick marks invisible because they cover up the links
+            for line in ax.get_xticklines():
+                line.set_visible(False)
 
-        if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
-        else:
-            leaf_fs = float(_get_tick_text_size(p))
-            map(lambda lbl: lbl.set_rotation(leaf_fs), lbls)
-
-        ax.xaxis.set_ticks_position('top')
-        # Make the tick marks invisible because they cover up the links
-        for line in ax.get_xticklines():
-            line.set_visible(False)
+            leaf_rot = float(_get_tick_rotation(len(ivl))) if (leaf_rotation is None) else leaf_rotation
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
+            ax.set_xticklabels(ivl, rotation=leaf_rot, size=leaf_font)
     elif orientation == 'left':
         ax.set_xlim([0, dvw])
         ax.set_ylim([0, ivw])
@@ -1724,19 +1705,19 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_yticklabels([])
         else:
             ax.set_yticks(ivticks)
-            ax.set_yticklabels(ivl)
+            ax.yaxis.set_ticks_position('left')
+            # Make the tick marks invisible because they cover up the
+            # links
+            for line in ax.get_yticklines():
+                line.set_visible(False)
 
-        lbls = ax.get_yticklabels()
-        if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
-        if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
 
-        ax.yaxis.set_ticks_position('left')
-        # Make the tick marks invisible because they cover up the
-        # links
-        for line in ax.get_yticklines():
-            line.set_visible(False)
+            if leaf_rotation is not None:
+                ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font)
+            else:
+                ax.set_yticklabels(ivl, size=leaf_font)
+
     elif orientation == 'right':
         ax.set_xlim([dvw, 0])
         ax.set_ylim([0, ivw])
@@ -1747,18 +1728,17 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
             ax.set_yticklabels([])
         else:
             ax.set_yticks(ivticks)
-            ax.set_yticklabels(ivl)
+            ax.yaxis.set_ticks_position('right')
+            # Make the tick marks invisible because they cover up the links
+            for line in ax.get_yticklines():
+                line.set_visible(False)
 
-        lbls = ax.get_yticklabels()
-        if leaf_rotation:
-            map(lambda lbl: lbl.set_rotation(leaf_rotation), lbls)
-        if leaf_font_size:
-            map(lambda lbl: lbl.set_size(leaf_font_size), lbls)
+            leaf_font = float(_get_tick_text_size(len(ivl))) if (leaf_font_size is None) else leaf_font_size
 
-        ax.yaxis.set_ticks_position('right')
-        # Make the tick marks invisible because they cover up the links
-        for line in ax.get_yticklines():
-            line.set_visible(False)
+            if leaf_rotation is not None:
+                ax.set_yticklabels(ivl, rotation=leaf_rotation, size=leaf_font)
+            else:
+                ax.set_yticklabels(ivl, size=leaf_font)
 
     # Let's use collections instead. This way there is a separate legend
     # item for each tree grouping, rather than stupidly one for each line

--- a/scipy/interpolate/rbf.py
+++ b/scipy/interpolate/rbf.py
@@ -195,11 +195,14 @@ class Rbf(object):
         r = self._call_norm(self.xi, self.xi)
         self.epsilon = kwargs.pop('epsilon', None)
         if self.epsilon is None:
-            # default epsilon is the "the average distance between nodes"
+            # default epsilon is the "the average distance between nodes" based
+            # on a bounding hypercube
             dim = self.xi.shape[0]
             ximax = np.amax(self.xi, axis=1)
             ximin = np.amin(self.xi, axis=1)
-            self.epsilon = np.power(np.prod(ximax - ximin)/self.N, 1.0/dim)
+            edges = ximax-ximin
+            edges = edges[np.nonzero(edges)]
+            self.epsilon = np.power(np.prod(edges)/self.N, 1.0/edges.size)
         self.smooth = kwargs.pop('smooth', 0.0)
 
         self.function = kwargs.pop('function', 'multiquadric')

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -146,5 +146,14 @@ def test_rbf_epsilon_none():
     rbf = Rbf(x, y, epsilon=None)
 
 
+def test_rbf_epsilon_none_collinear():
+    # Check that collinear points in one dimension doesn't cause an error
+    # due to epsilon = 0
+    x = [1, 2, 3]
+    y = [4, 4, 4]
+    z = [5, 6, 7]
+    rbf = Rbf(x, y, z, epsilon=None)
+    assert_(rbf.epsilon > 0)
+
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1819,7 +1819,7 @@ def qr_insert_row(Q, R, u, k, overwrite_qru, check_finite):
     if cnp.PyArray_TYPE(u1) != typecode:
         raise ValueError("'u' must have the same type as 'Q' and 'R'")
 
-    if not (-m <= k1 < m):
+    if not (-m <= k1 <= m):
         raise ValueError("'k' is out of bounds")
 
     if k1 < 0:
@@ -1943,7 +1943,7 @@ def qr_insert_col(Q, R, u, k, rcond, overwrite_qru, check_finite):
         
     if cnp.PyArray_TYPE(u1) != typecode:
         raise ValueError("'u' must have the same type as Q and R")
-    if not (-n <= k1 < n):
+    if not (-n <= k1 <= n):
         raise ValueError("'k' is out of bounds")
     if k1 < 0:
         k1 += n

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1830,13 +1830,13 @@ def qr_insert_row(Q, R, u, k, overwrite_qru, check_finite):
         if u1.shape[1] != n:
             raise ValueError("'u' should be either (N,) or (p,N) when "
                              "inserting rows. Found %s." %
-                             str(getattr(u, 'shape')))
+                             str(getattr(u1, 'shape')))
     elif u1.ndim == 1:
         p = 1
         if u1.shape[0] != n:
             raise ValueError("'u' should be either (N,) or (p,N) when "
                              "inserting rows. Found %s." %
-                             str(getattr(u, 'shape')))
+                             str(getattr(u1, 'shape')))
     else:
         raise ValueError("'u' must be either 1- or 2-D")
 
@@ -1953,13 +1953,13 @@ def qr_insert_col(Q, R, u, k, rcond, overwrite_qru, check_finite):
         if u1.shape[0] != m:
             raise ValueError("'u' should be either (M,) or (M,p) when "
                              "inserting columns. Found %s." %
-                             str(getattr(u, 'shape')))
+                             str(getattr(u1, 'shape')))
     elif u1.ndim == 1:
         p = 1
         if u1.shape[0] != m:
             raise ValueError("'u' should be either (M,) or (M,p) when "
                              "inserting columns. Found %s." %
-                             str(getattr(u, 'shape')))
+                             str(getattr(u1, 'shape')))
     else:
         raise ValueError("'u' must be either 1- or 2-D")
 
@@ -1971,6 +1971,12 @@ def qr_insert_col(Q, R, u, k, rcond, overwrite_qru, check_finite):
     elif rcond is not None:
         raise ValueError("'rcond' is not used when updating full, (M,M) (M,N) "
                          "decompositions and must be None.")
+
+    # special case 1xN 
+    # if m == 1, Q is always 1x1 and abs(Q[0,0]) == 1.0
+    if m == 1:
+        rnew = np.insert(r1, k*np.ones(p, np.intp), q1.conjugate()*u1, 1)
+        return q1.copy(), rnew
 
     if economic:
         if n+p <= m:
@@ -2274,6 +2280,14 @@ def qr_update(Q, R, u, v, overwrite_qruv=False, check_finite=True):
 
     u1 = validate_array(u1, check_finite)
     v1 = validate_array(v1, check_finite)
+
+    # special case 1xN 
+    # if m == 1, Q is always 1x1 and abs(Q[0,0]) == 1.0
+    # we only need consider rank 1 updates, since we have
+    # limited p to max(m,n) above.
+    if m == 1:
+        rnew = r1 + q1.conjugate()*u1.ravel()*v1.conjugate().ravel()
+        return q1.copy(), rnew
 
     if economic:
         ndim = 1

--- a/scipy/linalg/setup.py
+++ b/scipy/linalg/setup.py
@@ -5,7 +5,8 @@ import os
 from os.path import join
 
 
-def configuration(parent_package='',top_path=None):
+def configuration(parent_package='', top_path=None):
+    from distutils.sysconfig import get_python_inc
     from numpy.distutils.system_info import get_info, NotFoundError, numpy_info
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
     from scipy._build_utils import (get_sgemv_fix, get_g77_abi_wrappers,
@@ -137,7 +138,7 @@ def configuration(parent_package='',top_path=None):
     sources = ['_blas_subroutine_wrappers.f', '_lapack_subroutine_wrappers.f']
     sources += get_g77_abi_wrappers(lapack_opt)
     sources += get_sgemv_fix(lapack_opt)
-    includes = numpy_info().get_include_dirs()
+    includes = numpy_info().get_include_dirs() + [get_python_inc()]
     config.add_library('fwrappers', sources=sources, include_dirs=includes)
 
     config.add_extension('cython_blas',

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -655,7 +655,7 @@ class BaseQRinsert(BaseQRdeltas):
 
     def test_sqr_1_row(self):
         a, q, r, u = self.generate('sqr', which='row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -663,14 +663,14 @@ class BaseQRinsert(BaseQRdeltas):
     def test_sqr_p_row(self):
         # sqr + rows --> fat always
         a, q, r, u = self.generate('sqr', which='row', p=3)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_sqr_1_col(self):
         a, q, r, u = self.generate('sqr', which='col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -678,14 +678,14 @@ class BaseQRinsert(BaseQRdeltas):
     def test_sqr_p_col(self):
         # sqr + cols --> fat always
         a, q, r, u = self.generate('sqr', which='col', p=3)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_tall_1_row(self):
         a, q, r, u = self.generate('tall', which='row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -693,14 +693,14 @@ class BaseQRinsert(BaseQRdeltas):
     def test_tall_p_row(self):
         # tall + rows --> tall always
         a, q, r, u = self.generate('tall', which='row', p=3)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_tall_1_col(self):
         a, q, r, u = self.generate('tall', which='col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -711,7 +711,7 @@ class BaseQRinsert(BaseQRdeltas):
     # tall + pcol --> fat
     def base_tall_p_col_xxx(self, p):
         a, q, r, u = self.generate('tall', which='col', p=p)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(p, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -730,7 +730,7 @@ class BaseQRinsert(BaseQRdeltas):
 
     def test_fat_1_row(self):
         a, q, r, u = self.generate('fat', which='row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -741,7 +741,7 @@ class BaseQRinsert(BaseQRdeltas):
     # fat + prow --> tall
     def base_fat_p_row_xxx(self, p):
         a, q, r, u = self.generate('fat', which='row', p=p)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row*np.ones(p, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -760,7 +760,7 @@ class BaseQRinsert(BaseQRdeltas):
 
     def test_fat_1_col(self):
         a, q, r, u = self.generate('fat', which='col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
@@ -768,14 +768,14 @@ class BaseQRinsert(BaseQRdeltas):
     def test_fat_p_col(self):
         # fat + cols --> fat always
         a, q, r, u = self.generate('fat', which='col', p=3)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_economic_1_row(self):
         a, q, r, u = self.generate('tall', 'economic', 'row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row, overwrite_qru=False)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
@@ -783,14 +783,14 @@ class BaseQRinsert(BaseQRdeltas):
     def test_economic_p_row(self):
         # tall + rows --> tall always
         a, q, r, u = self.generate('tall', 'economic', 'row', 3)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row, overwrite_qru=False)
             a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
 
     def test_economic_1_col(self):
         a, q, r, u = self.generate('tall', 'economic', which='col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u.copy(), col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
@@ -809,7 +809,7 @@ class BaseQRinsert(BaseQRdeltas):
     # eco + pcol --> fat
     def base_economic_p_col_xxx(self, p):
         a, q, r, u = self.generate('tall', 'economic', which='col', p=p)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(p, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
@@ -828,112 +828,112 @@ class BaseQRinsert(BaseQRdeltas):
 
     def test_Mx1_1_row(self):
         a, q, r, u = self.generate('Mx1', which='row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
     
     def test_Mx1_p_row(self):
         a, q, r, u = self.generate('Mx1', which='row', p=3)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_Mx1_1_col(self):
         a, q, r, u = self.generate('Mx1', which='col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_Mx1_p_col(self):
         a, q, r, u = self.generate('Mx1', which='col', p=3)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_Mx1_economic_1_row(self):
         a, q, r, u = self.generate('Mx1', 'economic', 'row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
     
     def test_Mx1_economic_p_row(self):
         a, q, r, u = self.generate('Mx1', 'economic', 'row', 3)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
 
     def test_Mx1_economic_1_col(self):
         a, q, r, u = self.generate('Mx1', 'economic', 'col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
 
     def test_Mx1_economic_p_col(self):
         a, q, r, u = self.generate('Mx1', 'full', 'col', 3)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol, False)
 
     def test_1xN_1_row(self):
         a, q, r, u = self.generate('1xN', which='row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
     
     def test_1xN_p_row(self):
         a, q, r, u = self.generate('1xN', which='row', p=3)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_1xN_1_col(self):
         a, q, r, u = self.generate('1xN', which='col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_1xN_p_col(self):
         a, q, r, u = self.generate('1xN', which='col', p=3)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_1x1_1_row(self):
         a, q, r, u = self.generate('1x1', which='row')
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row, u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
     
     def test_1x1_p_row(self):
         a, q, r, u = self.generate('1x1', which='row', p=3)
-        for row in range(r.shape[0]):
+        for row in range(r.shape[0] + 1):
             q1, r1 = qr_insert(q, r, u, row)
             a1 = np.insert(a, row*np.ones(3, np.intp), u, 0)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_1x1_1_col(self):
         a, q, r, u = self.generate('1x1', which='col')
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col, u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)
 
     def test_1x1_p_col(self):
         a, q, r, u = self.generate('1x1', which='col', p=3)
-        for col in range(r.shape[1]):
+        for col in range(r.shape[1] + 1):
             q1, r1 = qr_insert(q, r, u, col, 'col', overwrite_qru=False)
             a1 = np.insert(a, col*np.ones(3, np.intp), u, 1)
             check_qr(q1, r1, a1, self.rtol, self.atol)

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -1642,7 +1642,7 @@ def test_form_qTu():
     # and F.
 
     q_order = ['F', 'C']
-    q_shape = [(8, 8), (1,1)]
+    q_shape = [(8, 8), ]
     u_order = ['F', 'C', 'A']  # here A means is not F not C
     u_shape = [1, 3]
     dtype = ['f', 'd', 'F', 'D']

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -542,15 +542,12 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     """
     if p0 is None:
         # determine number of parameters by inspecting the function
-        import inspect
-        args, varargs, varkw, defaults = inspect.getargspec(f)
+        from scipy._lib._util import getargspec_no_self as _getargspec
+        args, varargs, varkw, defaults = _getargspec(f)
         if len(args) < 2:
             msg = "Unable to determine number of fit parameters."
             raise ValueError(msg)
-        if 'self' in args:
-            p0 = [1.0] * (len(args)-2)
-        else:
-            p0 = [1.0] * (len(args)-1)
+        p0 = [1.0] * (len(args)-1)
 
     # Check input arguments
     if isscalar(p0):

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -114,14 +114,14 @@ from __future__ import division, print_function, absolute_import
 
 import sys
 import numpy as np
-from scipy._lib.six import callable, exec_
-from scipy._lib.six import xrange
+from scipy._lib.six import callable, exec_, xrange
 from scipy.linalg import norm, solve, inv, qr, svd, LinAlgError
 from numpy import asarray, dot, vdot
 import scipy.sparse.linalg
 import scipy.sparse
 from scipy.linalg import get_blas_funcs
 import inspect
+from scipy._lib._util import getargspec_no_self as _getargspec
 from .linesearch import scalar_search_wolfe1, scalar_search_armijo
 
 
@@ -1498,8 +1498,7 @@ def _nonlin_wrapper(name, jac):
     keyword arguments of `nonlin_solve`
 
     """
-    import inspect
-    args, varargs, varkw, defaults = inspect.getargspec(jac.__init__)
+    args, varargs, varkw, defaults = _getargspec(jac.__init__)
     kwargs = list(zip(args[-len(defaults):], defaults))
     kw_str = ", ".join(["%s=%r" % (k, v) for k, v in kwargs])
     if kw_str:

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -37,7 +37,7 @@ import numpy as np
 from .linesearch import (line_search_wolfe1, line_search_wolfe2,
                          line_search_wolfe2 as line_search,
                          LineSearchWarning)
-from inspect import getargspec
+from scipy._lib._util import getargspec_no_self as _getargspec
 
 
 # standard status messages of optimizers
@@ -2609,7 +2609,7 @@ def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
         xmin = xmin[0]
     if callable(finish):
         # set up kwargs for `finish` function
-        finish_args = getargspec(finish).args
+        finish_args = _getargspec(finish).args
         finish_kwargs = dict()
         if 'full_output' in finish_args:
             finish_kwargs['full_output'] = 1

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -945,15 +945,18 @@ def lfilter(b, a, x, axis=-1, zi=None):
 
         out_full = np.apply_along_axis(lambda y: np.convolve(b, y), axis, x)
         ind = out_full.ndim * [slice(None)]
+        if zi is not None:
+            ind[axis] = slice(zi.shape[axis])
+            out_full[ind] += zi
+
         ind[axis] = slice(out_full.shape[axis] - len(b) + 1)
         out = out_full[ind]
+
         if zi is None:
             return out
         else:
             ind[axis] = slice(out_full.shape[axis] - len(b) + 1, None)
             zf = out_full[ind]
-            ind[axis] = slice(zi.shape[axis])
-            out[ind] += zi
             return out, zf
     else:
         if zi is None:

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -854,6 +854,32 @@ class _TestLinearFilter(TestCase):
         assert_equal(b, b0)
         assert_equal(a, a0)
 
+    def test_short_x_FIR(self):
+        # regression test for #5116
+        # x shorter than b, with non None zi fails
+        a = self.convert_dtype([1])
+        b = self.convert_dtype([1, 0, -1])
+        zi = self.convert_dtype([2, 7])
+        x = self.convert_dtype([72])
+        ye = self.convert_dtype([74])
+        zfe = self.convert_dtype([7, -72])
+        y, zf = lfilter(b, a, x, zi=zi)
+        assert_array_almost_equal(y, ye)
+        assert_array_almost_equal(zf, zfe)
+
+    def test_short_x_IIR(self):
+        # regression test for #5116
+        # x shorter than b, with non None zi fails
+        a = self.convert_dtype([1, 1])
+        b = self.convert_dtype([1, 0, -1])
+        zi = self.convert_dtype([2, 7])
+        x = self.convert_dtype([72])
+        ye = self.convert_dtype([74])
+        zfe = self.convert_dtype([-67, -72])
+        y, zf = lfilter(b, a, x, zi=zi)
+        assert_array_almost_equal(y, ye)
+        assert_array_almost_equal(zf, zfe)
+
 
 class TestLinearFilterFloat32(_TestLinearFilter):
     dtype = np.dtype('f')

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2405,7 +2405,8 @@ class _TestFancyIndexing:
         assert_equal(todense(A[B > 9]), B[B > 9])
 
         I = np.array([True, False, True, True, False])
-        J = np.array([False, True, True, False, True])
+        J = np.array([False, True, True, False, True,
+                      False, False, False, False, False])
 
         assert_equal(todense(A[I, J]), B[I, J])
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -616,8 +616,15 @@ class test_sparse_distance_matrix_compiled:
     def test_consistency_with_python(self):
         M1 = self.T1.sparse_distance_matrix(self.T2, self.r)
         M2 = self.ref_T1.sparse_distance_matrix(self.ref_T2, self.r)
-
         assert_array_almost_equal(M1.todense(), M2.todense(), decimal=14)
+        
+    def test_against_logic_error_regression(self):
+        # regression test for gh-5077 logic error
+        np.random.seed(0)
+        too_many = np.array(np.random.randn(18, 2), dtype=int)
+        tree = cKDTree(too_many, balanced_tree=False, compact_nodes=False)
+        d = tree.sparse_distance_matrix(tree, 3).todense()
+        assert_array_almost_equal(d, d.T, decimal=14)
 
 
 def test_distance_matrix():

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2692,6 +2692,8 @@ class rv_discrete(rv_generic):
                                                  self, rv_discrete)
             self.moment_gen = instancemethod(_drv_moment_gen,
                                              self, rv_discrete)
+
+            self.shapes = ' '   # bypass inspection 
             self._construct_argparser(meths_to_inspect=[self._pmf],
                                       locscale_in='loc=0',
                                       # scale=1 for discrete RVs

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -5,11 +5,11 @@
 from __future__ import division, print_function, absolute_import
 
 from scipy._lib.six import string_types, exec_
+from scipy._lib._util import getargspec_no_self as _getargspec
 
 import sys
 import keyword
 import re
-import inspect
 import types
 import warnings
 
@@ -633,7 +633,7 @@ class rv_generic(object):
         super(rv_generic, self).__init__()
 
         # figure out if _stats signature has 'moments' keyword
-        sign = inspect.getargspec(self._stats)
+        sign = _getargspec(self._stats)
         self._stats_has_moments = ((sign[2] is not None) or
                                    ('moments' in sign[0]))
         self._random_state = check_random_state(seed)
@@ -686,15 +686,17 @@ class rv_generic(object):
                         'shapes must be valid python identifiers')
         else:
             # find out the call signatures (_pdf, _cdf etc), deduce shape
-            # arguments
+            # arguments. Generic methods only have 'self, x', any further args
+            # are shapes.
             shapes_list = []
             for meth in meths_to_inspect:
-                shapes_args = inspect.getargspec(meth)
-                shapes_list.append(shapes_args.args)
+                shapes_args = _getargspec(meth)   # NB: does not contain self
+                args = shapes_args.args[1:]       # peel off 'x', too
 
-                # *args or **kwargs are not allowed w/automatic shapes
-                # (generic methods have 'self, x' only)
-                if len(shapes_args.args) > 2:
+                if args:
+                    shapes_list.append(args)
+
+                    # *args or **kwargs are not allowed w/automatic shapes
                     if shapes_args.varargs is not None:
                         raise TypeError(
                             '*args are not allowed w/out explicit shapes')
@@ -704,14 +706,15 @@ class rv_generic(object):
                     if shapes_args.defaults is not None:
                         raise TypeError('defaults are not allowed for shapes')
 
-            shapes = max(shapes_list, key=lambda x: len(x))
-            shapes = shapes[2:]  # remove self, x,
+            if shapes_list:
+                shapes = shapes_list[0]
 
-            # make sure the signatures are consistent
-            # (generic methods have 'self, x' only)
-            for item in shapes_list:
-                if len(item) > 2 and item[2:] != shapes:
-                    raise TypeError('Shape arguments are inconsistent.')
+                # make sure the signatures are consistent
+                for item in shapes_list:
+                    if item != shapes:
+                        raise TypeError('Shape arguments are inconsistent.')
+            else:
+                shapes = []
 
         # have the arguments, construct the method from template
         shapes_str = ', '.join(shapes) + ', ' if shapes else ''  # NB: not None
@@ -2689,7 +2692,7 @@ class rv_discrete(rv_generic):
                                                  self, rv_discrete)
             self.moment_gen = instancemethod(_drv_moment_gen,
                                              self, rv_discrete)
-            self._construct_argparser(meths_to_inspect=[_drv_pmf],
+            self._construct_argparser(meths_to_inspect=[self._pmf],
                                       locscale_in='loc=0',
                                       # scale=1 for discrete RVs
                                       locscale_out='loc, 1')

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -1,6 +1,5 @@
 from __future__ import division, print_function, absolute_import
 
-import inspect
 import warnings
 
 import numpy as np
@@ -8,6 +7,7 @@ import numpy.testing as npt
 import numpy.ma.testutils as ma_npt
 
 from scipy._lib._version import NumpyVersion
+from scipy._lib._util import getargspec_no_self as _getargspec
 from scipy import stats
 
 
@@ -126,12 +126,12 @@ def check_named_args(distfn, x, shape_args, defaults, meths):
     ## Check calling w/ named arguments.
 
     # check consistency of shapes, numargs and _parse signature
-    signature = inspect.getargspec(distfn._parse_args)
+    signature = _getargspec(distfn._parse_args)
     npt.assert_(signature.varargs is None)
     npt.assert_(signature.keywords is None)
-    npt.assert_(signature.defaults == defaults)
+    npt.assert_(list(signature.defaults) == list(defaults))
 
-    shape_argnames = signature.args[1:-len(defaults)]  # self, a, b, loc=0, scale=1
+    shape_argnames = signature.args[:-len(defaults)]  # a, b, loc=0, scale=1
     if distfn.shapes:
         shapes_ = distfn.shapes.replace(',', ' ').split()
     else:


### PR DESCRIPTION
- gh-5088 cKDTree fix
- gh-5118 signal.lfilter fix
- gh-5155 OS X build issue
- gh-5164 cluster.dendrogram bug (fix for biggest issue only)
- gh-5241 linalg.qr_insert fix
- gh-5248 test Python 3.5 on TravisCI, getargspec deprecation fix
- gh-5264 stats.rbf fix
- gh-5352 silence boolean indexing test warnings
