### PR TITLE
add a fast path to interp1d

### DIFF
--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -93,16 +93,23 @@ class GridData(Benchmark):
 class Interpolate1d(Benchmark):
     param_names = ['n_samples', 'method']
     params = [
-        [10, 50, 100],
+        [10, 50, 100, 1000, 10000],
         ['linear', 'nearest', 'zero', 'slinear', 'quadratic', 'cubic'],
     ]
 
     def setup(self, n_samples, method):
         self.x = np.arange(n_samples)
         self.y = np.exp(-self.x/3.0)
+        self.interpolator = interpolate.interp1d(self.x, self.y, kind=method)
+        self.xp = np.linspace(self.x[0], self.x[-1], 4*n_samples)
 
     def time_interpolate(self, n_samples, method):
+        """Time the construction overhead."""
         interpolate.interp1d(self.x, self.y, kind=method)
+
+    def time_interpolate_eval(self, n_samples, method):
+        """Time the evaluation."""
+        self.interpolator(self.xp)
 
 
 class Interpolate2d(Benchmark):


### PR DESCRIPTION
As compared to `interp1d(.., kind='linear')`,  `numpy.interp` is 2x-10x faster, especially for sorted input. Hence delegate the former to the latter, in cases where numpy can handle it (specifically, `y` array must be real-valued and 1D).

The added complexity (and interp1d _is_ a bit of a mess) seems small and the perf boost is IMO worth it.

Also modify the interp1d benchmark to actually measure evaluation time.

I've checked the test coverage and there seems to be no need for any additional tests, the functionality added here is already covered.
