### PR TITLE
Add two fill_values to interp1d.

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -347,12 +347,17 @@ class interp1d(_Interpolator1D):
         a value outside of the range of x (where extrapolation is
         necessary). If False, out of bounds values are assigned `fill_value`.
         By default, an error is raised unless `fill_value="extrapolate"`.
-    fill_value : float or "extrapolate", optional
-        If provided, then this value will be used to fill in for requested
-        points outside of the data range. If not provided, then the default
-        is NaN.
-        If "extrapolate", then points outside the data range will be
-        extrapolated. ("nearest" and "linear" kinds only.)
+    fill_value : float or (float, float) or "extrapolate", optional
+        - if a single float, then this value will be used to fill in for requested
+          points outside of the data range. If not provided, then the default
+          is NaN.
+        - If a two-element tuple, then the first element is used as a fill value
+          for ``x_new < x[0]`` and the second element is used for
+          ``x_new > x[-1]``.
+          .. versionadded:: 0.17.0
+        - If "extrapolate", then points outside the data range will be
+          extrapolated. ("nearest" and "linear" kinds only.)
+          .. versionadded:: 0.17.0
     assume_sorted : bool, optional
         If False, values of `x` can be in any order and they are sorted first.
         If True, `x` has to be an array of monotonically increasing values.

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -308,6 +308,13 @@ class TestInterp1D(object):
                      'zero'):
             self._check_fill_value(kind)
 
+    def test_fill_value_writeable(self):
+        # backwards compat: fill_value is a public writeable attribute
+        interp = interp1d(self.x10, self.y10, fill_value=123.0)
+        assert_equal(interp.fill_value, 123.0)
+        interp.fill_value = 321.0
+        assert_equal(interp.fill_value, 321.0)
+
     def _nd_check_interp(self, kind='linear'):
         # Check the behavior when the inputs and outputs are multidimensional.
 


### PR DESCRIPTION
Add to `interp1d` two fill_values, one for `x_new < min(x)` and the other for `x_new > max(x)`. This is similar to what `numpy.interp` allows.

closes gh-3191.

A significant part of the ugliness here is maintaining strict backwards compat. Since `fill_value` was a public attribute, it is technically mutable, and this PR bends over a bit to maintain a mutable `fill_value` as a property. (I'd be happy to drop this actually.)
