### PR TITLE
BUG: full_output option on scipy.optimize.root produces less output

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -146,11 +146,14 @@ def fsolve(func, x0, args=(), fprime=None, full_output=0,
     else:
         status = res['status']
         msg = res['message']
-        if status != 1:
-            if status in [2, 3, 4, 5]:
-                warnings.warn(msg, RuntimeWarning)
-            else:
-                raise TypeError(msg)
+        if status == 0:
+            raise TypeError(msg)
+        elif status == 1:
+            pass
+        elif status in [2, 3, 4, 5]:
+            warnings.warn(msg, RuntimeWarning)
+        else:
+            raise TypeError(msg)
         return res['x']
 
 

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -138,15 +138,15 @@ def fsolve(func, x0, args=(), fprime=None, full_output=0,
 
     res = _root_hybr(func, x0, args, jac=fprime, **options)
     if full_output:
-        if res['status'] != 1:
-            msg = res['message']
-            warnings.warn(msg, RuntimeWarning)
         x = res['x']
         info = dict((k, res.get(k))
                     for k in ('nfev', 'njev', 'fjac', 'r', 'qtf') if k in res)
         info['fvec'] = res['fun']
         return x, info, res['status'], res['message']
     else:
+        if res['status'] != 1:
+            msg = res['message']
+            warnings.warn(msg, RuntimeWarning)
         return res['x']
 
 

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -150,7 +150,7 @@ def fsolve(func, x0, args=(), fprime=None, full_output=0,
 
 def _root_hybr(func, x0, args=(), jac=None,
                col_deriv=0, xtol=1.49012e-08, maxfev=0, band=None, eps=None,
-               factor=100, diag=None, full_output=0, **unknown_options):
+               factor=100, diag=None, full_output=1, **unknown_options):
     """
     Find the roots of a multivariate function using MINPACK's hybrd and
     hybrj routines (modified Powell method).
@@ -184,6 +184,9 @@ def _root_hybr(func, x0, args=(), jac=None,
     diag : sequence
         N positive entries that serve as a scale factors for the
         variables.
+    full_output : bool
+        If true, produce additional warnings about the outcome of the
+        method.
 
     """
     _check_unknown_options(unknown_options)
@@ -230,7 +233,7 @@ def _root_hybr(func, x0, args=(), jac=None,
                   "ten iterations.", ValueError],
               'unknown': ["An error occurred.", TypeError]}
 
-    if status != 1 and not full_output:
+    if status != 1 and full_output:
         if status in [2, 3, 4, 5]:
             msg = errors[status][0]
             warnings.warn(msg, RuntimeWarning)

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -150,7 +150,7 @@ def fsolve(func, x0, args=(), fprime=None, full_output=0,
 
 def _root_hybr(func, x0, args=(), jac=None,
                col_deriv=0, xtol=1.49012e-08, maxfev=0, band=None, eps=None,
-               factor=100, diag=None, full_output=1, **unknown_options):
+               factor=100, diag=None, full_output=0, **unknown_options):
     """
     Find the roots of a multivariate function using MINPACK's hybrd and
     hybrj routines (modified Powell method).
@@ -184,9 +184,6 @@ def _root_hybr(func, x0, args=(), jac=None,
     diag : sequence
         N positive entries that serve as a scale factors for the
         variables.
-    full_output : bool
-        If true, produce additional warnings about the outcome of the
-        method.
 
     """
     _check_unknown_options(unknown_options)
@@ -233,7 +230,7 @@ def _root_hybr(func, x0, args=(), jac=None,
                   "ten iterations.", ValueError],
               'unknown': ["An error occurred.", TypeError]}
 
-    if status != 1 and full_output:
+    if status != 1 and not full_output:
         if status in [2, 3, 4, 5]:
             msg = errors[status][0]
             warnings.warn(msg, RuntimeWarning)


### PR DESCRIPTION
The function scipy.optimize.root(method='hybr') has an undocumented
full_output option. Counterintuitively, setting full_output to 0
produces less information than setting it to 1. Modified the code to
invert that behavior and added documentation. See #5309.

The problem can be seen with the following code:

``` python
from scipy.optimize import root

f = lambda x : x**2 + 1
x0 = 0

# Using the full output option actually produces *less* information

print "Warnings with full_output = 1:"
sol = root(f, x0, method='hybr', options={'full_output': 1})

print "********************"

print "Warnings with full_output = 0:"
sol = root(f, x0, method='hybr', options={'full_output': 0})
```
