### PR TITLE
CI: test against NumPy 1.10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
         - REFGUIDE_CHECK=1
         - COVERAGE=
         - NPY_RELAXED_STRIDES_CHECKING=1
-        - NUMPYSPEC="--upgrade git+git://github.com/numpy/numpy.git@v1.9.1"
+        - NUMPYSPEC="--upgrade git+git://github.com/numpy/numpy.git@v1.10.1"
       addons:
         apt:
           packages:


### PR DESCRIPTION
Convert the relaxed strides checking run to install numpy 1.10.1.

This should (hopefully) expose a host of FutureWarnings, https://github.com/scipy/scipy/pull/5147#issuecomment-148625130
