### PR TITLE
BUG: integrate: builtin name no longer shadowed

### DIFF
--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -312,8 +312,8 @@ def _basic_simps(y, start, stop, x, dx, axis):
         # Account for possibly different spacings.
         #    Simpson's rule changes a bit.
         h = np.diff(x, axis=axis)
-        sl0 = tupleset(all, axis, slice(start, stop, step))
-        sl1 = tupleset(all, axis, slice(start+1, stop+1, step))
+        sl0 = tupleset(slice_all, axis, slice(start, stop, step))
+        sl1 = tupleset(slice_all, axis, slice(start+1, stop+1, step))
         h0 = h[sl0]
         h1 = h[sl1]
         hsum = h0 + h1

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -7,7 +7,7 @@ from numpy.testing import TestCase, run_module_suite, assert_equal, \
     assert_almost_equal, assert_allclose, assert_
 
 from scipy.integrate import (quadrature, romberg, romb, newton_cotes,
-                             cumtrapz, quad)
+                             cumtrapz, quad, simps)
 from scipy.integrate.quadrature import AccuracyWarning
 
 
@@ -126,6 +126,18 @@ class TestQuadrature(TestCase):
         exact_integral = 9.0
         numeric_integral = np.dot(wts, y)
         assert_almost_equal(numeric_integral, exact_integral)
+
+    def test_simps(self):
+        y = np.arange(17)
+        assert_equal(simps(y), 128)
+        assert_equal(simps(y, dx=0.5), 64)
+        assert_equal(simps(y, x=np.linspace(0, 4, 17)), 32)
+
+        y = np.arange(4)
+        x = 2**y
+        assert_equal(simps(y, x=x, even='avg'), 13.875)
+        assert_equal(simps(y, x=x, even='first'), 13.75)
+        assert_equal(simps(y, x=x, even='last'), 14)
 
 
 class TestCumtrapz(TestCase):


### PR DESCRIPTION
This slipped through the cracks in #5334, which is troubling. I did a quick check to make sure that no other bugs were introduced by those changes, and it seems okay now.
