### PR TITLE
MAINT: sparse: non-canonical test cleanup and fixes

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -180,7 +180,7 @@ class spmatrix(object):
 
     def __bool__(self):  # Simple -- other ideas?
         if self.shape == (1, 1):
-            return True if self.nnz == 1 else False
+            return self.nnz != 0
         else:
             raise ValueError("The truth value of an array with more than one "
                              "element is ambiguous. Use a.any() or a.all().")

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -496,13 +496,14 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
 
         The is an *in place* operation
         """
+        if self.has_canonical_format:
+            return
         self.sort_indices()
         R, C = self.blocksize
         M, N = self.shape
 
         # port of _sparsetools.csr_sum_duplicates
         n_row = M // R
-        n_col = N // C
         nnz = 0
         row_end = 0
         for i in range(n_row):
@@ -521,6 +522,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
             self.indptr[i+1] = nnz
 
         self.prune()  # nnz may have changed
+        self.has_canonical_format = True
 
     def sort_indices(self):
         """Sort the indices of this matrix *in place*

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -486,20 +486,41 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
 
         self.data[:len(nonzero_blocks)] = self.data[nonzero_blocks]
 
-        from .csr import csr_matrix
-
         # modifies self.indptr and self.indices *in place*
-        # since CSR constructor may end up in making copies (in case
-        # our index arrays are invalid in some way), play it safe
-        proxy = csr_matrix((mask,self.indices,self.indptr),shape=(M//R,N//C))
-        proxy.indices = self.indices
-        proxy.indptr = self.indptr
-        proxy.eliminate_zeros()
-
+        _sparsetools.csr_eliminate_zeros(M//R, N//C, self.indptr,
+                                         self.indices, mask)
         self.prune()
 
     def sum_duplicates(self):
-        raise NotImplementedError
+        """Eliminate duplicate matrix entries by adding them together
+
+        The is an *in place* operation
+        """
+        self.sort_indices()
+        R, C = self.blocksize
+        M, N = self.shape
+
+        # port of _sparsetools.csr_sum_duplicates
+        n_row = M // R
+        n_col = N // C
+        nnz = 0
+        row_end = 0
+        for i in range(n_row):
+            jj = row_end
+            row_end = self.indptr[i+1]
+            while jj < row_end:
+                j = self.indices[jj]
+                x = self.data[jj]
+                jj += 1
+                while jj < row_end and self.indices[jj] == j:
+                    x += self.data[jj]
+                    jj += 1
+                self.indices[nnz] = j
+                self.data[nnz] = x
+                nnz += 1
+            self.indptr[i+1] = nnz
+
+        self.prune()  # nnz may have changed
 
     def sort_indices(self):
         """Sort the indices of this matrix *in place*

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -196,10 +196,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         """Scalar version of self._binopt, for cases in which no new nonzeros
         are added. Produces a new spmatrix in canonical form.
         """
-        try:
-            self.sum_duplicates()
-        except NotImplementedError:
-            pass
+        self.sum_duplicates()
         res = self._with_data(op(self.data, other), copy=True)
         res.eliminate_zeros()
         return res
@@ -533,10 +530,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 other_arr = self.__class__(other_arr)
                 return self._binopt(other_arr, op_name)
             else:
-                try:
-                    self.sum_duplicates()
-                except NotImplementedError:
-                    pass
+                self.sum_duplicates()
                 new_data = npop(self.data, np.asarray(other))
                 mat = self.__class__((new_data, self.indices, self.indptr),
                                      dtype=new_data.dtype, shape=self.shape)
@@ -948,10 +942,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         This is an *in place* operation
         """
-        fn = _sparsetools.csr_eliminate_zeros
-        M,N = self._swap(self.shape)
-        fn(M, N, self.indptr, self.indices, self.data)
-
+        M, N = self._swap(self.shape)
+        _sparsetools.csr_eliminate_zeros(M, N, self.indptr, self.indices,
+                                         self.data)
         self.prune()  # nnz may have changed
 
     def __get_has_canonical_format(self):
@@ -971,9 +964,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             # not sorted => not canonical
             self._has_canonical_format = False
         elif not hasattr(self, '_has_canonical_format'):
-            fn = _sparsetools.csr_has_canonical_format
-            self.has_canonical_format = \
-                    fn(len(self.indptr) - 1, self.indptr, self.indices)
+            self.has_canonical_format = _sparsetools.csr_has_canonical_format(
+                len(self.indptr) - 1, self.indptr, self.indices)
         return self._has_canonical_format
 
     def __set_has_canonical_format(self, val):
@@ -993,9 +985,9 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             return
         self.sort_indices()
 
-        fn = _sparsetools.csr_sum_duplicates
-        M,N = self._swap(self.shape)
-        fn(M, N, self.indptr, self.indices, self.data)
+        M, N = self._swap(self.shape)
+        _sparsetools.csr_sum_duplicates(M, N, self.indptr, self.indices,
+                                        self.data)
 
         self.prune()  # nnz may have changed
         self.has_canonical_format = True
@@ -1011,9 +1003,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         # first check to see if result was cached
         if not hasattr(self,'_has_sorted_indices'):
-            fn = _sparsetools.csr_has_sorted_indices
-            self._has_sorted_indices = \
-                    fn(len(self.indptr) - 1, self.indptr, self.indices)
+            self._has_sorted_indices = _sparsetools.csr_has_sorted_indices(
+                len(self.indptr) - 1, self.indptr, self.indices)
         return self._has_sorted_indices
 
     def __set_sorted(self, val):
@@ -1037,8 +1028,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         """
 
         if not self.has_sorted_indices:
-            fn = _sparsetools.csr_sort_indices
-            fn(len(self.indptr) - 1, self.indptr, self.indices, self.data)
+            _sparsetools.csr_sort_indices(len(self.indptr) - 1, self.indptr,
+                                          self.indices, self.data)
             self.has_sorted_indices = True
 
     def prune(self):

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -353,6 +353,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
     def todia(self):
         from .dia import dia_matrix
 
+        self.sum_duplicates()
         ks = self.col - self.row  # the diagonal for each nonzero
         diags, diag_idx = np.unique(ks, return_inverse=True)
 

--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -164,12 +164,17 @@ class csc_matrix(_cs_matrix, IndexMixin):
         # Get row and col indices, from _cs_matrix.tocoo
         major_dim, minor_dim = self._swap(self.shape)
         minor_indices = self.indices
-        major_indices = np.empty(len(minor_indices), dtype=self.indptr.dtype)
+        major_indices = np.empty(len(minor_indices), dtype=self.indices.dtype)
         _sparsetools.expandptr(major_dim, self.indptr, major_indices)
         row, col = self._swap((major_indices, minor_indices))
 
+        # Remove explicit zeros
+        nz_mask = self.data != 0
+        row = row[nz_mask]
+        col = col[nz_mask]
+
         # Sort them to be in C-style order
-        ind = np.lexsort((col, row))
+        ind = np.argsort(row, kind='mergesort')
         row = row[ind]
         col = col[ind]
 

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -135,8 +135,7 @@ class csr_matrix(_cs_matrix, IndexMixin):
         from .lil import lil_matrix
         lil = lil_matrix(self.shape,dtype=self.dtype)
 
-        self.sort_indices()  # lil_matrix needs sorted column indices
-
+        self.sum_duplicates()
         ptr,ind,dat = self.indptr,self.indices,self.data
         rows, data = lil.rows, lil.data
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3488,19 +3488,6 @@ class TestDOK(sparse_test_class(minmax=False, nnz_axis=False)):
         b[:,0] = 0
         assert_(len(b.keys()) == 0, "Unexpected entries in keys")
 
-    ##
-    ## TODO: The DOK matrix currently returns invalid results rather
-    ##       than raising errors in some indexing operations
-    ##
-
-    @dec.knownfailureif(True, "known deficiency in DOK")
-    def test_fancy_indexing(self):
-        pass
-
-    @dec.knownfailureif(True, "known deficiency in DOK")
-    def test_add_sub(self):
-        pass
-
 
 class TestLIL(sparse_test_class(minmax=False)):
     spmatrix = lil_matrix
@@ -3664,7 +3651,7 @@ class TestCOO(sparse_test_class(getset=False,
         coo = coo_matrix(mat)
         assert_array_equal(coo.todense(),mat.reshape(1,-1))
 
-    # COO does not have a __getitem__ to support iteration
+    @dec.knownfailureif(True, 'COO does not have a __getitem__')
     def test_iterator(self):
         pass
 
@@ -3707,7 +3694,7 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
         offsets = np.array([0,-1,2])
         assert_equal(dia_matrix((data,offsets), shape=(4,4)).todense(), D)
 
-    # DIA does not have a __getitem__ to support iteration
+    @dec.knownfailureif(True, 'DIA does not have a __getitem__')
     def test_iterator(self):
         pass
 
@@ -3799,11 +3786,11 @@ class TestBSR(sparse_test_class(getset=False,
         x = arange(A.shape[1]*6).reshape(-1,6)
         assert_equal(A*x, A.todense()*x)
 
-    @dec.knownfailureif(True, "BSR not implemented")
+    @dec.knownfailureif(True, 'BSR does not have a __getitem__')
     def test_iterator(self):
         pass
 
-    @dec.knownfailureif(True, "known deficiency in BSR")
+    @dec.knownfailureif(True, 'BSR does not have a __setitem__')
     def test_setdiag(self):
         pass
 
@@ -3874,32 +3861,20 @@ class _NonCanonicalMixin(object):
 
         return NC
 
-    @dec.knownfailureif(True, 'abs broken with non-canonical matrix')
-    def test_abs(self):
-        pass
-
-    @dec.knownfailureif(True, 'bool(matrix) broken with non-canonical matrix')
+    @dec.skipif(True, 'bool(matrix) counts explicit zeros')
     def test_bool(self):
         pass
 
-    @dec.knownfailureif(True, 'min/max broken with non-canonical matrix')
-    def test_minmax(self):
+    @dec.skipif(True, 'getnnz-axis counts explicit zeros')
+    def test_getnnz_axis(self):
         pass
 
-    @dec.knownfailureif(True, 'format conversion broken with non-canonical matrix')
-    def test_sparse_format_conversions(self):
+    @dec.skipif(True, 'nnz counts explicit zeros')
+    def test_empty(self):
         pass
 
     @dec.knownfailureif(True, 'unary ufunc overrides broken with non-canonical matrix')
     def test_unary_ufunc_overrides(self):
-        pass
-
-    @dec.knownfailureif(True, 'some binary ufuncs fail with scalars for noncanonical matrices')
-    def test_binary_ufunc_overrides(self):
-        pass
-
-    @dec.knownfailureif(True, 'getnnz-axis broken with non-canonical matrix')
-    def test_getnnz_axis(self):
         pass
 
 
@@ -3920,14 +3895,6 @@ class _NonCanonicalCompressedMixin(_NonCanonicalMixin):
 
 
 class _NonCanonicalCSMixin(_NonCanonicalCompressedMixin):
-    @dec.knownfailureif(True, '__getitem__ with non-canonical matrix broken for sparse boolean index due to __gt__')
-    def test_fancy_indexing_sparse_boolean(self):
-        pass
-
-    @dec.knownfailureif(True, 'broadcasting element-wise multiply broken with non-canonical matrix')
-    def test_elementwise_multiply_broadcast(self):
-        pass
-
     @dec.knownfailureif(True, 'inverse broken with non-canonical matrix')
     def test_inv(self):
         pass
@@ -3938,19 +3905,11 @@ class _NonCanonicalCSMixin(_NonCanonicalCompressedMixin):
 
 
 class TestCSRNonCanonical(_NonCanonicalCSMixin, TestCSR):
-    @dec.knownfailureif(True, 'nnz counts explicit zeros')
-    def test_empty(self):
-        pass
+    pass
 
 
 class TestCSCNonCanonical(_NonCanonicalCSMixin, TestCSC):
-    @dec.knownfailureif(True, 'nnz counts explicit zeros')
-    def test_empty(self):
-        pass
-
-    @dec.knownfailureif(True, 'nonzero reports explicit zeros')
-    def test_nonzero(self):
-        pass
+    pass
 
 
 class TestBSRNonCanonical(_NonCanonicalCompressedMixin, TestBSR):
@@ -3959,44 +3918,12 @@ class TestBSRNonCanonical(_NonCanonicalCompressedMixin, TestBSR):
         x[i,j] = 0
         return x.tobsr(blocksize=M.blocksize)
 
-    @dec.knownfailureif(True, 'unary ufunc overrides broken with non-canonical BSR')
+    @dec.knownfailureif(True, 'diagonal broken with non-canonical BSR')
     def test_diagonal(self):
         pass
 
-    @dec.knownfailureif(True, 'unary ufunc overrides broken with non-canonical BSR')
+    @dec.knownfailureif(True, 'expm broken with non-canonical BSR')
     def test_expm(self):
-        pass
-
-    @dec.knownfailureif(True, 'inequalities require sum_duplicates, not implemented for BSR')
-    def test_eq(self):
-        pass
-
-    @dec.knownfailureif(True, 'inequalities require sum_duplicates, not implemented for BSR')
-    def test_ne(self):
-        pass
-
-    @dec.knownfailureif(True, 'inequalities require sum_duplicates, not implemented for BSR')
-    def test_gt(self):
-        pass
-
-    @dec.knownfailureif(True, 'inequalities require sum_duplicates, not implemented for BSR')
-    def test_lt(self):
-        pass
-
-    @dec.knownfailureif(True, 'inequalities require sum_duplicates, not implemented for BSR')
-    def test_ge(self):
-        pass
-
-    @dec.knownfailureif(True, 'inequalities require sum_duplicates, not implemented for BSR')
-    def test_le(self):
-        pass
-
-    @dec.knownfailureif(True, 'maximum and minimum fail for non-canonical BSR')
-    def test_maximum_minimum(self):
-        pass
-
-    @dec.knownfailureif(True, 'nnz counts explicit zeros')
-    def test_empty(self):
         pass
 
 
@@ -4018,10 +3945,6 @@ class TestCOONonCanonical(_NonCanonicalMixin, TestCOO):
         m.setdiag([3, 2], k=1)
         m.sum_duplicates()
         assert_(np.all(np.diff(m.col) >= 0))
-
-    @dec.knownfailureif(True, 'nnz counts explicit zeros')
-    def test_empty(self):
-        pass
 
 
 class Test64Bit(object):


### PR DESCRIPTION
I noticed that there were a lot of tests for scipy.sparse marked as known failures, and a lot of confusion regarding what is actually supported vs. what is truly a bug (i.e., #3343, #4409, https://github.com/scipy/scipy/issues/4530#issuecomment-74897379).

This PR attempts to clean that up a bit, by:
- implementing `sum_duplicates()` for the BSR format. This means that all classes with a `sum_duplicates` method now actually sum their duplicates, which simplifies control flow and enables many useful operations for BSR matrices.
- removing all the `knownfailure` tests which actually pass, or could be easily fixed. This necessitated adding a calls to `sum_duplicates` in various methods, so we should be careful about the run-time impact of these changes.
- converting tests concerning counts of `nnz` for non-canonical matrices into skips, rather than known failures. Hopefully this will make it clearer that this behavior is not a bug (it's just annoying). 
