### PR TITLE
BUG: special: fix a number of edge cases related to `x = np.inf`.

### DIFF
--- a/scipy/special/cephes/fresnl.c
+++ b/scipy/special/cephes/fresnl.c
@@ -165,6 +165,12 @@ double xxa, *ssa, *cca;
     double f, g, cc, ss, c, s, t, u;
     double x, x2;
 
+    if (cephes_isinf(xxa)) {
+    cc = 0.5;
+    ss = 0.5;
+    goto done;
+    }
+
     x = fabs(xxa);
     x2 = x * x;
     if (x2 < 2.5625) {

--- a/scipy/special/cephes/igam.c
+++ b/scipy/special/cephes/igam.c
@@ -102,6 +102,9 @@ double a, x;
 
     if ((x < 1.0) || (x < a))
 	return (1.0 - igam(a, x));
+    
+    if (cephes_isinf(x))
+    return 0.0;
 
     ax = a * log(x) - x - lgam(a);
     if (ax < -MAXLOG) {

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -337,6 +337,9 @@ class TestCephes(TestCase):
     def test_gdtr(self):
         assert_equal(cephes.gdtr(1,1,0),0.0)
 
+    def test_gdtr_inf(self):
+        assert_equal(cephes.gdtr(1,1,np.inf),1.0)
+
     def test_gdtrc(self):
         assert_equal(cephes.gdtrc(1,1,0),1.0)
 
@@ -1623,6 +1626,14 @@ class TestFresnel(TestCase):
         frs = array(special.fresnel(.5))
         assert_array_almost_equal(frs,array([0.064732432859999287, 0.49234422587144644]),8)
 
+    def test_fresnel_inf1(self):
+        frs = special.fresnel(np.inf)
+        assert_equal(frs, (0.5, 0.5))
+
+    def test_fresnel_inf2(self):
+        frs = special.fresnel(-np.inf)
+        assert_equal(frs, (-0.5, -0.5))
+
     # values from pg 329  Table 7.11 of A & S
     #  slightly corrected in 4th decimal place
     def test_fresnel_zeros(self):
@@ -1678,6 +1689,10 @@ class TestGamma(TestCase):
         gama = special.gammainc(-1,0)
         assert_equal(gama,0.0)
 
+    def test_gammaincinf(self):
+        gama = special.gammainc(0.5, np.inf)
+        assert_equal(gama,1.0)
+
     def test_gammaincc(self):
         gicc = special.gammaincc(.5,.5)
         greal = 1 - special.gammainc(.5,.5)
@@ -1686,6 +1701,10 @@ class TestGamma(TestCase):
     def test_gammainccnan(self):
         gama = special.gammaincc(-1,1)
         assert_(isnan(gama))
+
+    def test_gammainccinf(self):
+        gama = special.gammaincc(0.5,np.inf)
+        assert_equal(gama,0.0)
 
     def test_gammainccinv(self):
         gccinv = special.gammainccinv(.5,.5)
@@ -3038,6 +3057,10 @@ class TestStruve(object):
 
 def test_chi2_smalldf():
     assert_almost_equal(special.chdtr(0.6,3), 0.957890536704110)
+
+
+def test_ch2_inf():
+    assert_equal(special.chdtr(0.7,np.inf), 1.0)
 
 
 def test_chi2c_smalldf():


### PR DESCRIPTION
Fixes issue [4934](https://github.com/scipy/scipy/issues/4834).  Specifically, now,
-   `special.gammainc(np.inf) = 1.0`, not `nan`.
-   `special.gammaincc(np.inf) = 0.0`, not `nan`.
-   `special.fresnel(np.inf) = (0.5, 0.5)`, not `(nan, nan)`.
-   `special.gdtr(np.inf) = 1.0`, not `nan`.
-   `special.chdtr(np.inf) = 1.0`, not `nan`.

These changes were produced by updating `igamc` and `fresnl` in `cephes`,
which the other functions above call.
