### PR TITLE
MAINT: stats: avoid spurious warnings in lognorm.pdf(0, s)

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2984,7 +2984,9 @@ loglaplace = loglaplace_gen(a=0.0, name='loglaplace')
 
 
 def _lognorm_logpdf(x, s):
-    return -log(x)**2 / (2*s**2) + np.where(x == 0, 0, -log(s*x*sqrt(2*pi)))
+    return _lazywhere(x != 0, (x, s),
+                      lambda x, s: -log(x)**2 / (2*s**2) - log(s*x*sqrt(2*pi)),
+                      -np.inf)
 
 
 class lognorm_gen(rv_continuous):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -943,7 +943,9 @@ class TestSkellam(TestCase):
 class TestLognorm(TestCase):
     def test_pdf(self):
         # Regression test for Ticket #1471: avoid nan with 0/0 situation
-        with np.errstate(divide='ignore'):
+        # Also make sure there are no warnings at x=0, cf gh-5202
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', RuntimeWarning)
             pdf = stats.lognorm.pdf([0, 0.5, 1], 1)
             assert_array_almost_equal(pdf, [0.0, 0.62749608, 0.39894228])
 


### PR DESCRIPTION
addresses a small part of gh-5202
