### PR TITLE
Fix the behavior of discrete distributions at the right-hand edge of the support

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2990,7 +2990,7 @@ class rv_discrete(rv_generic):
         args = tuple(map(asarray, args))
         k = asarray(k-loc)
         cond0 = self._argcheck(*args)
-        cond1 = (k >= self.a) & (k <= self.b)
+        cond1 = (k >= self.a) & (k < self.b)
         cond2 = (k < self.a) & cond0
         cond = cond0 & cond1
         output = zeros(shape(cond), 'd')
@@ -3031,7 +3031,7 @@ class rv_discrete(rv_generic):
         args = tuple(map(asarray, args))
         k = asarray(k-loc)
         cond0 = self._argcheck(*args)
-        cond1 = (k >= self.a) & (k <= self.b)
+        cond1 = (k >= self.a) & (k < self.b)
         cond2 = (k < self.a) & cond0
         cond = cond0 & cond1
         output = empty(shape(cond), 'd')

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3227,11 +3227,7 @@ class rv_discrete(rv_generic):
         else:
             ub = ub - loc   # convert bound for standardized distribution
         if conditional:
-            if np.isposinf(ub)[()]:
-                # work around bug: stats.poisson.sf(stats.poisson.b, 2) is nan
-                invfac = 1 - self.cdf(lb-1, *args)
-            else:
-                invfac = 1 - self.cdf(lb-1, *args) - self.sf(ub, *args)
+            invfac = self.sf(lb-1, *args) - self.sf(ub, *args)
         else:
             invfac = 1.0
 

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -104,17 +104,17 @@ def check_private_entropy(distfn, args, superclass):
 
 
 def check_edge_support(distfn, args):
-    # Make sure the x=self.a and self.b are handled correctly.
+    # Make sure that x=self.a and self.b are handled correctly.
     x = [distfn.a, distfn.b]
-    if isinstance(distfn, stats.rv_continuous):
-        npt.assert_equal(distfn.cdf(x, *args), [0.0, 1.0])
-        npt.assert_equal(distfn.logcdf(x, *args), [-np.inf, 0.0])
-
-        npt.assert_equal(distfn.sf(x, *args), [1.0, 0.0])
-        npt.assert_equal(distfn.logsf(x, *args), [0.0, -np.inf])
-
     if isinstance(distfn, stats.rv_discrete):
         x = [distfn.a - 1, distfn.b]
+
+    npt.assert_equal(distfn.cdf(x, *args), [0.0, 1.0])
+    npt.assert_equal(distfn.logcdf(x, *args), [-np.inf, 0.0])
+
+    npt.assert_equal(distfn.sf(x, *args), [1.0, 0.0])
+    npt.assert_equal(distfn.logsf(x, *args), [0.0, -np.inf])
+
     npt.assert_equal(distfn.ppf([0.0, 1.0], *args), x)
     npt.assert_equal(distfn.isf([0.0, 1.0], *args), x[::-1])
 


### PR DESCRIPTION
Previously, the behavior of  discrete distributions at positive infinity depended on whether the corresponding special functions were or were not able to handle infinities. For instance,

```
In [3]: poisson.sf(np.inf, 0.5)
/home/br/scipy/build/testenv/lib/python2.7/site-packages/scipy/stats/_discrete_distns.py:463: RuntimeWarning: floating point number truncated to an integer
  return special.pdtrc(k, mu)
Out[3]: nan
```

(I was sure there was a ticket about this, but I cannot find it.)
