### PR TITLE
Implement the multinomial distribution

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -124,6 +124,7 @@ Multivariate distributions
    multivariate_normal   -- Multivariate normal distribution
    matrix_normal         -- Matrix normal distribution
    dirichlet             -- Dirichlet
+   multinomial           -- Multinomial distribution
    wishart               -- Wishart
    invwishart            -- Inverse Wishart
    special_ortho_group   -- SO(N) group

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2914,8 +2914,8 @@ n : int
     Number of trials
 p : array_like, shape (k,)
     Probabilities. These should sum to one. If they do not, then
-    ``p[-1]`` is modified to account for the remaining probability so that
-    ``sum(p) == 1``.
+    the value of ``p[-1]`` is disregarded and assumed to account for the
+    remaining probability so that ``sum(p) == 1``.
 """
 
 multinom_docdict_params = {
@@ -2946,8 +2946,8 @@ class multinomial_gen(multi_rv_generic):
         Number of trials
     p : array_like, shape (k,)
         Probabilities. These should sum to one. If they do not, then
-        ``p[-1]`` is modified to account for the remaining probability so that
-        ``sum(p) == 1``.
+        the value of ``p[-1]`` is disregarded and assumed to account for the
+        remaining probability so that ``sum(p) == 1``.
 
     %(_doc_random_state)s
 
@@ -3018,7 +3018,7 @@ class multinomial_gen(multi_rv_generic):
         self.__doc__ = doccer.docformat(self.__doc__, multinom_docdict_params)
 
     def _argcheck(self, n, p):
-        p = np.asarray(p)
+        p = np.array(p, copy=True)
         p[-1] = 1. - p[:-1].sum()
         if p.ndim != 1:
             raise ValueError('p array must be 1D. Got p.ndim = %s' % p.ndim)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2938,7 +2938,7 @@ class multinomial_gen(multi_rv_generic):
 
         P(\mathbf{x}) = \frac{n!}{x_1! \cdots x_{k}!} p_1^{x_1} \cdots p_k^{x_k}
 
-    .. versionadded:: 0.17
+    .. versionadded:: 0.18.0
 
     Parameters
     ----------
@@ -2964,17 +2964,8 @@ class multinomial_gen(multi_rv_generic):
 
     Draw random numbers from a multinomial distribution:
 
-    >>> n, p = 4, [0.3, 0.4, 0.4]
+    >>> n, p = 4, [0.3, 0.4, 0.3]
     >>> from scipy.stats import multinomial
-    >>> r = multinomial.rvs(n, p, size=2, random_state=1234)
-    >>> r
-    array([[0, 2, 2],
-           [1, 1, 2]])
-
-    Note that if the probabilities do not sum to one, the last element of
-    the `p` array is assumed to account for the remaining probablity:
-
-    >>> n, p = 4, [0.3, 0.4, 0.0]
     >>> r = multinomial.rvs(n, p, size=2, random_state=1234)
     >>> r
     array([[0, 2, 2],
@@ -2993,9 +2984,22 @@ class multinomial_gen(multi_rv_generic):
     >>> multinomial.pmf(r, n, p).shape
     (4, 5, 6)
 
-    Alternatively, the distribution object can be called (as a function)
-    to fix the parameters `n` and `p`. This returns a "frozen" RV object
-    holding the given parameters fixed.
+    The input probabilities, `p`, should be normalized to sum to one. If they
+    do not, the last element of the `p` array is assumed to account for the
+    remaining probablity. For example, to simulate a biased coin which is
+    twice as likely to land on one side, you would use
+
+    >>> multinomial.rvs(n=100, p=[1./3, 2./3], random_state=1234)
+    array([[32, 68]])
+
+    and not
+
+    >>> multinomial.rvs(n=100, p=[1., 2.])    # Wrong!
+    array([[100, 0]])
+
+    The distribution object can be called (as a function) to fix the parameters
+    `n` and `p`. This returns a "frozen" RV object holding the given parameters
+    fixed.
 
     >>> dice = multinomial(n=20, p=[1./6]*6)
     >>> dice.rvs(size=3, random_state=123) 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1177,6 +1177,13 @@ class TestMultinom(object):
         assert_equal(multinomial.rvs(2, [1., 2], size=10000)[:, 1],
                      np.zeros(10000))
 
+        # modifying the last element of pvals does not clobber the original
+        n, pvals = 3, np.array([0.5, 0.4, 0.8])
+        p_ini = pvals.copy()
+        r = multinomial.rvs(n, pvals)
+        multinomial.pmf(r, n, pvals)
+        assert_allclose(pvals, p_ini, atol=1e-14)
+
     def test_rvs_ndim(self):
         # n-dim size argument is consistent with numpy
         n, p = 4, [1/2., 1/4., 1/4.]


### PR DESCRIPTION
This has been requested in gh-3160 and more recently in gh-4949.

The mathematical content here is rather straightforward, and this PR is mostly adding syntactic sugar. Also, this is the first multivariate discrete distribution in scipy. Thus I guess it makes sense to look a bit into the interface and the ease of use e.g. in conjunction with dirichlet.  

I tried to do the simplest thing possible, and mostly watched for consistency with numpy.random.multinomial (which does random variates) and stats.binom (which is a univariate limiting case). 
- A possibly confusing thing is the handling of probablities which do not sum to one. `numpy.random.multinomial` modifies the last element of the array of probabilities (so that p=[0.5, 0.5] and p=[0.5, 1.5] are exactly equivalent), so this PR does the same for all methods. R rescales the probabilities instead, but I think we're better off being consistent with numpy.
- One other constraint is that the support of pmf is a simplex, `sum(x) = N`. One can in principle also modify `x[-1]`, but I thought it's too much magic. So I just return `pmf(x)` being zero unless the elements of `x` sum up to N.
- Last but not least, what is the definition of `pmf(x)` for non-integer x. AFAIU, R decided to round the input to integers:

```
> dmultinom(c(1.3, 2, 3), prob=c(1, 2, 5))
[1] 0.1144409
> dmultinom(c(1, 2, 3), prob=c(1, 2, 5))
[1] 0.1144409
```

On the other hand, `binom`  just returns a zero:

```
In [19]: binom.pmf(1.5, n=2, p=0.5)
Out[19]: 0.0
```

A third sensible option could be to just extend the multinomial formula to the real axis. In the present form of this PR, I went for the consistency with `binom`, but I'd be fine to change it if something else is more convenient in typical usage.

closes gh-3160.
