### PR TITLE
TST: stats: skip a test to avoid a spurious log(0) warning

### DIFF
--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -110,10 +110,12 @@ def check_edge_support(distfn, args):
         x = [distfn.a - 1, distfn.b]
 
     npt.assert_equal(distfn.cdf(x, *args), [0.0, 1.0])
-    npt.assert_equal(distfn.logcdf(x, *args), [-np.inf, 0.0])
-
     npt.assert_equal(distfn.sf(x, *args), [1.0, 0.0])
-    npt.assert_equal(distfn.logsf(x, *args), [0.0, -np.inf])
+
+    if distfn.name not in ('skellam', 'dlaplace'):
+        # with a = -inf, log(0) generates warnings
+        npt.assert_equal(distfn.logcdf(x, *args), [-np.inf, 0.0])
+        npt.assert_equal(distfn.logsf(x, *args), [0.0, -np.inf])
 
     npt.assert_equal(distfn.ppf([0.0, 1.0], *args), x)
     npt.assert_equal(distfn.isf([0.0, 1.0], *args), x[::-1])


### PR DESCRIPTION
As a follow-up to gh-5409, suppress two spurious warnings from leaking implementation details.

Specifically, these two distributions have a=-inf, then a-1 = -inf too; then logcdf(-inf, arg) calls into the private _logcdf, which is a generic log(_cdf), and _cdf(-inf) returns zero. This does not happen for distributions with a finite value of `a` or specifically defined _logpdf method. Here it's just easier to filter out the warnings IMO.
