### PR TITLE
BUG: linalg: work around LAPACK single-precision lwork computation issues

### DIFF
--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -9,8 +9,12 @@ import os
 import sys
 from numpy.testing import dec
 
+from nose import SkipTest
 
-__all__ = ['knownfailure_overridable', 'suppressed_stdout']
+from scipy._lib.decorator import decorator
+
+
+__all__ = ['knownfailure_overridable', 'suppressed_stdout', 'xslow']
 
 
 def knownfailure_overridable(msg=None):
@@ -40,3 +44,15 @@ def suppressed_stdout(f):
             sys.stdout.close()
             sys.stdout = oldstdout
     return nose.tools.make_decorator(f)(pwrapper)
+
+
+@decorator
+def xslow(func, *a, **kw):
+    try:
+        v = int(os.environ.get('SCIPY_XSLOW', '0'))
+        if not v:
+            raise ValueError()
+    except ValueError:
+        raise SkipTest("very slow test; set environment variable "
+                       "SCIPY_XSLOW=1 to run it")
+    return func(*a, **kw)

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -13,7 +13,7 @@ __all__ = ['solve', 'solve_triangular', 'solveh_banded', 'solve_banded',
 import numpy as np
 
 from .flinalg import get_flinalg_funcs
-from .lapack import get_lapack_funcs
+from .lapack import get_lapack_funcs, _compute_lwork
 from .misc import LinAlgError, _datacopied
 from .decomp import _asarray_validated
 from . import decomp, decomp_svd
@@ -672,11 +672,7 @@ def inv(a, overwrite_a=False, check_finite=True):
                                                  (a1,))
     lu, piv, info = getrf(a1, overwrite_a=overwrite_a)
     if info == 0:
-        lwork, info = getri_lwork(a1.shape[0])
-        if info != 0:
-            raise ValueError('internal getri work space query failed: %d' %
-                             (info,))
-        lwork = int(lwork.real)
+        lwork = _compute_lwork(getri_lwork, a1.shape[0])
 
         # XXX: the following line fixes curious SEGFAULT when
         # benchmarking 500x500 matrix inverse. This seems to

--- a/scipy/linalg/decomp.py
+++ b/scipy/linalg/decomp.py
@@ -24,7 +24,7 @@ from numpy import (array, isfinite, inexact, nonzero, iscomplexobj, cast,
 from scipy._lib.six import xrange
 from scipy._lib._util import _asarray_validated
 from .misc import LinAlgError, _datacopied, norm
-from .lapack import get_lapack_funcs
+from .lapack import get_lapack_funcs, _compute_lwork
 
 
 _I = cast['F'](1j)
@@ -159,13 +159,9 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     geev, geev_lwork = get_lapack_funcs(('geev', 'geev_lwork'), (a1,))
     compute_vl, compute_vr = left, right
 
-    lwork, info = geev_lwork(a1.shape[0],
-                             compute_vl=compute_vl,
-                             compute_vr=compute_vr)
-    if info != 0:
-        raise LinAlgError("internal *geev work array calculation failed: %d" %
-                          (info,))
-    lwork = int(lwork.real)
+    lwork = _compute_lwork(geev_lwork, a1.shape[0],
+                           compute_vl=compute_vl,
+                           compute_vr=compute_vr)
 
     if geev.typecode in 'cz':
         w, vl, vr, info = geev(a1, lwork=lwork,
@@ -822,11 +818,7 @@ def hessenberg(a, calc_q=False, overwrite_a=False, check_finite=True):
                          '(hessenberg)' % -info)
     n = len(a1)
 
-    lwork, info = gehrd_lwork(ba.shape[0], lo=lo, hi=hi)
-    if info != 0:
-        raise ValueError('failed to compute internal gehrd work array size. '
-                         'LAPACK info = %d ' % info)
-    lwork = int(lwork.real)
+    lwork = _compute_lwork(gehrd_lwork, ba.shape[0], lo=lo, hi=hi)
 
     hq, tau, info = gehrd(ba, lo=lo, hi=hi, lwork=lwork, overwrite_a=1)
     if info < 0:
@@ -838,11 +830,8 @@ def hessenberg(a, calc_q=False, overwrite_a=False, check_finite=True):
 
     # use orghr/unghr to compute q
     orghr, orghr_lwork = get_lapack_funcs(('orghr', 'orghr_lwork'), (a1,))
-    lwork, info = orghr_lwork(n, lo=lo, hi=hi)
-    if info != 0:
-        raise ValueError('failed to compute internal orghr work array size. '
-                         'LAPACK info = %d ' % info)
-    lwork = int(lwork.real)
+    lwork = _compute_lwork(orghr_lwork, n, lo=lo, hi=hi)
+
     q, info = orghr(a=hq, tau=tau, lo=lo, hi=hi, lwork=lwork, overwrite_a=1)
     if info < 0:
         raise ValueError('illegal value in %d-th argument of internal orghr '

--- a/scipy/linalg/decomp_svd.py
+++ b/scipy/linalg/decomp_svd.py
@@ -6,7 +6,7 @@ from numpy import zeros, r_, diag
 
 # Local imports.
 from .misc import LinAlgError, _datacopied
-from .lapack import get_lapack_funcs
+from .lapack import get_lapack_funcs, _compute_lwork
 from .decomp import _asarray_validated
 
 __all__ = ['svd', 'svdvals', 'diagsvd', 'orth']
@@ -94,10 +94,8 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     gesdd, gesdd_lwork = get_lapack_funcs(('gesdd', 'gesdd_lwork'), (a1,))
 
     # compute optimal lwork
-    lwork, info = gesdd_lwork(a1.shape[0], a1.shape[1], compute_uv=compute_uv, full_matrices=full_matrices)
-    if info != 0:
-        raise ValueError('work array size computation for internal gesdd failed: %d' % info)
-    lwork = int(lwork.real)
+    lwork = _compute_lwork(gesdd_lwork, a1.shape[0], a1.shape[1],
+                           compute_uv=compute_uv, full_matrices=full_matrices)
 
     # perform decomposition
     u,s,v,info = gesdd(a1, compute_uv=compute_uv, lwork=lwork,

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -348,6 +348,8 @@ from __future__ import division, print_function, absolute_import
 
 __all__ = ['get_lapack_funcs']
 
+import numpy as _np
+
 from .blas import _get_funcs
 
 # Backward compatibility:
@@ -419,3 +421,33 @@ def get_lapack_funcs(names, arrays=(), dtype=None):
     return _get_funcs(names, arrays, dtype,
                       "LAPACK", _flapack, _clapack,
                       "flapack", "clapack", _lapack_alias)
+
+
+def _compute_lwork(routine, *args, **kwargs):
+    """
+    Round floating-point lwork returned by lapack to integer.
+
+    Several LAPACK routines compute optimal values for LWORK, which
+    they return in a floating-point variable. However, for large
+    values of LWORK, single-precision floating point is not sufficient
+    to hold the exact value --- some LAPACK versions (<= 3.5.0 at
+    least) truncate the returned integer to single precision and in
+    some cases this can be smaller than the required value.
+    """
+    lwork, info = routine(*args, **kwargs)
+    if info != 0:
+        raise ValueError("Internal work array size computation failed: %d" % (info,))
+
+    lwork = lwork.real
+
+    if getattr(routine, 'dtype', None) == _np.float32:
+        # Single-precision routine -- take next fp value to work
+        # around possible truncation in LAPACK code
+        lwork = _np.nextafter(_np.float32(lwork), _np.float32(_np.inf))
+
+    lwork = int(lwork)
+    if lwork < 0 or lwork > _np.iinfo(_np.int32).max:
+        raise ValueError("Too large work array required -- computation cannot "
+                         "be performed with standard 32-bit LAPACK.")
+
+    return lwork

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -12,19 +12,7 @@ from numpy.testing import assert_raises, assert_equal, dec, run_module_suite, as
 from scipy.sparse import (_sparsetools, coo_matrix, csr_matrix, csc_matrix,
                           bsr_matrix, dia_matrix)
 from scipy.sparse.sputils import supported_dtypes
-from scipy._lib.decorator import decorator
-
-
-@decorator
-def xslow(func, *a, **kw):
-    try:
-        v = int(os.environ.get('SCIPY_XSLOW', '0'))
-        if not v:
-            raise ValueError()
-    except ValueError:
-        raise SkipTest("very slow test; set environment variable "
-                       "SCIPY_XSLOW=1 to run it")
-    return func(*a, **kw)
+from scipy._lib._testutils import xslow
 
 
 def test_exception():


### PR DESCRIPTION
Lapack returns optimal lwork values in floating point variables.
However, single-precision mantissa is too small to hold accurate integer
values if they are too large. LAPACK <= 3.5.0 (at the least) return
truncated LWORK values, which can be smaller than the required values.
Work around this issue by taking the next larger fp value when dealing
with single-precision LWORK.

Fixes gh-5401
