### PR TITLE
DOC: fix up sections in ToC in the pdf reference guide

### DIFF
--- a/doc/API.rst.txt
+++ b/doc/API.rst.txt
@@ -105,7 +105,9 @@ change is made.
 * scipy.linalg
 
   - scipy.linalg.blas
+  - scipy.linalg.cython_blas
   - scipy.linalg.lapack
+  - scipy.linalg.cython_lapack
   - scipy.linalg.interpolative
 
 * scipy.misc
@@ -134,5 +136,5 @@ change is made.
   - distributions
   - mstats
 
-* scipy.weave
+* scipy.weave (deprecated)
 

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -1,6 +1,6 @@
 """
-Low-level BLAS functions
-========================
+Low-level BLAS functions (:mod:`scipy.linalg.blas`)
+===================================================
 
 This module contains low-level functions from the BLAS library.
 
@@ -13,7 +13,7 @@ This module contains low-level functions from the BLAS library.
    so prefer using the higher-level routines in `scipy.linalg`.
 
 Finding functions
-=================
+-----------------
 
 .. autosummary::
    :toctree: generated/
@@ -22,7 +22,7 @@ Finding functions
    find_best_blas_type
 
 BLAS Level 1 functions
-======================
+----------------------
 
 .. autosummary::
    :toctree: generated/
@@ -77,7 +77,7 @@ BLAS Level 1 functions
    zswap
 
 BLAS Level 2 functions
-======================
+----------------------
 
 .. autosummary::
    :toctree: generated/
@@ -112,7 +112,7 @@ BLAS Level 2 functions
    zher2
 
 BLAS Level 3 functions
-======================
+----------------------
 
 .. autosummary::
    :toctree: generated/

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -1,6 +1,6 @@
 """
-Low-level LAPACK functions
-==========================
+Low-level LAPACK functions (:mod:`scipy.linalg.lapack`)
+=======================================================
 
 This module contains low-level functions from the LAPACK library.
 
@@ -13,14 +13,14 @@ This module contains low-level functions from the LAPACK library.
    so prefer using the higher-level routines in `scipy.linalg`.
 
 Finding functions
-=================
+-----------------
 
 .. autosummary::
 
    get_lapack_funcs
 
 All functions
-=============
+-------------
 
 .. autosummary::
    :toctree: generated/
@@ -80,22 +80,22 @@ All functions
    dgelss
    cgelss
    zgelss
-   
+
    sgelss_lwork
    dgelss_lwork
    cgelss_lwork
    zgelss_lwork
-   
+
    sgelsd
    dgelsd
    cgelsd
    zgelsd
-   
+
    sgelsd_lwork
    dgelsd_lwork
    cgelsd_lwork
    zgelsd_lwork
-   
+
    sgelsy
    dgelsy
    cgelsy
@@ -105,7 +105,7 @@ All functions
    dgelsy_lwork
    cgelsy_lwork
    zgelsy_lwork
-   
+
    sgeqp3
    dgeqp3
    cgeqp3
@@ -189,7 +189,7 @@ All functions
 
    chegvx
    zhegvx
-   
+
    slarf
    dlarf
    clarf

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -1,8 +1,7 @@
 r"""
 
-=================
 Nonlinear solvers
-=================
+-----------------
 
 .. currentmodule:: scipy.optimize
 
@@ -11,7 +10,7 @@ solvers.  These solvers find *x* for which *F(x) = 0*. Both *x*
 and *F* can be multidimensional.
 
 Routines
-========
+~~~~~~~~
 
 Large-scale nonlinear solvers:
 
@@ -37,10 +36,9 @@ Simple iterations:
 
 
 Examples
-========
+~~~~~~~~
 
-Small problem
--------------
+**Small problem**
 
 >>> def F(x):
 ...    return np.cos(x) + x[::-1] - [1, 2, 3, 4]
@@ -52,8 +50,7 @@ array([ 4.04674914,  3.91158389,  2.71791677,  1.61756251])
 array([ 1.,  2.,  3.,  4.])
 
 
-Large problem
--------------
+**Large problem**
 
 Suppose that we needed to solve the following integrodifferential
 equation on the square :math:`[0,1]\times[0,1]`:


### PR DESCRIPTION
There were too many sub-sections leaking into the main ToC, see page 4 of http://docs.scipy.org/doc/scipy-0.16.1/scipy-ref-0.16.1.pdf

Also update the public submodule listing in API.rst.txt
