### PR TITLE
MAINT: sparse: fix usage of NotImplementedError

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -101,8 +101,9 @@ class spmatrix(object):
 
     shape = property(fget=get_shape, fset=set_shape)
 
-    def reshape(self,shape):
-        raise NotImplementedError
+    def reshape(self, shape):
+        raise NotImplementedError("Reshaping not implemented for %s." %
+                                  self.__class__.__name__)
 
     def astype(self, t):
         return self.tocsr().astype(t).asformat(self.format)
@@ -489,7 +490,7 @@ class spmatrix(object):
         elif isscalarlike(other):
             raise ValueError('exponent must be an integer')
         else:
-            raise NotImplementedError
+            return NotImplemented
 
     def __getattr__(self, attr):
         if attr == 'A':


### PR DESCRIPTION
Minor changes to fix the confusion between raising `NotImplementedError` and returning `NotImplemented`, as identified by https://github.com/scipy/scipy/pull/5411#discussion_r42933171.
