### PR TITLE
Raise proper error if maxiter < 1

### DIFF
--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -119,6 +119,8 @@ def newton(func, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50,
     """
     if tol <= 0:
         raise ValueError("tol too small (%g <= 0)" % tol)
+    if maxiter < 1:
+        raise ValueError("maxiter must be greater than 0")
     if fprime is not None:
         # Newton-Rapheson method
         # Multiply by 1.0 to convert to floating point.  We don't use float(x0)


### PR DESCRIPTION
Currently raises an `UnboundError` if `maxiter < 1`:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.5/site-packages/scipy/optimize/zeros.py", line 174, in newton
    msg = "Failed to converge after %d iterations, value is %s" % (maxiter, p)
UnboundLocalError: local variable 'p' referenced before assignment
```
