### PR TITLE
BUG: optimize: linear_sum_assignment doesn't transpose correctly

### DIFF
--- a/scipy/optimize/_hungarian.py
+++ b/scipy/optimize/_hungarian.py
@@ -83,6 +83,13 @@ def linear_sum_assignment(cost_matrix):
         raise ValueError("expected a matrix (2-d array), got a %r array"
                          % (cost_matrix.shape,))
 
+    # The algorithm expects more columns than rows in the cost matrix.
+    if cost_matrix.shape[1] < cost_matrix.shape[0]:
+        cost_matrix = cost_matrix.T
+        transposed = True
+    else:
+        transposed = False
+
     state = _Hungary(cost_matrix)
 
     # No need to bother with assignments if one of the dimensions
@@ -92,7 +99,11 @@ def linear_sum_assignment(cost_matrix):
     while step is not None:
         step = step(state)
 
-    return np.where(state.marked == 1)
+    if transposed:
+        marked = state.marked.T
+    else:
+        marked = state.marked
+    return np.where(marked == 1)
 
 
 class _Hungary(object):
@@ -101,17 +112,12 @@ class _Hungary(object):
     Parameters
     ----------
     cost_matrix : 2D matrix
-        The cost matrix. Does not have to be square.
+        The cost matrix. Must have shape[1] >= shape[0].
     """
 
     def __init__(self, cost_matrix):
-        # The algorithm expects more columns than rows in the cost matrix.
-        if cost_matrix.shape[1] < cost_matrix.shape[0]:
-            self.C = (cost_matrix.T).copy()
-        else:
-            self.C = cost_matrix.copy()
+        self.C = cost_matrix.copy()
 
-        # At this point, m >= n.
         n, m = self.C.shape
         self.row_uncovered = np.ones(n, dtype=bool)
         self.col_uncovered = np.ones(m, dtype=bool)

--- a/scipy/optimize/tests/test_hungarian.py
+++ b/scipy/optimize/tests/test_hungarian.py
@@ -44,9 +44,11 @@ def test_linear_sum_assignment():
         assert_array_equal(row_ind, np.sort(row_ind))
         assert_array_equal(expected_cost, cost_matrix[row_ind, col_ind])
 
-        row_ind, col_ind = linear_sum_assignment(cost_matrix.T)
+        cost_matrix = cost_matrix.T
+        row_ind, col_ind = linear_sum_assignment(cost_matrix)
         assert_array_equal(row_ind, np.sort(row_ind))
-        assert_array_equal(expected_cost, cost_matrix[row_ind, col_ind])
+        assert_array_equal(np.sort(expected_cost),
+                           np.sort(cost_matrix[row_ind, col_ind]))
 
 
 def test_linear_sum_assignment_input_validation():


### PR DESCRIPTION
Should fix an issue spotted by @jnothman at #5158: `linear_sum_assignment` doesn't work correctly when the input is a tall matrix. The output would be indices into the transpose of the input instead of the actual input.
