### PR TITLE
DOC: correct recommendation for minimize (trivial change)

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -159,10 +159,11 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     **Unconstrained minimization**
 
     Method :ref:`Nelder-Mead <optimize.minimize-neldermead>` uses the
-    Simplex algorithm [1]_, [2]_. This algorithm has been successful
-    in many applications but other algorithms using the first and/or
-    second derivatives information might be preferred for their better
-    performances and robustness in general.
+    Simplex algorithm [1]_, [2]_. This algorithm is robust in many
+    applications. However, if numerical computation of derivative can be
+    trusted, other algorithms using the first and/or second derivatives
+    information might be preferred for their better performance in
+    general.
 
     Method :ref:`Powell <optimize.minimize-powell>` is a modification
     of Powell's method [3]_, [4]_ which is a conjugate direction


### PR DESCRIPTION
The docstring of minimize is a bit too negative on the Nelder-Mead.
Unlike what this docstring claims, the Nelder-Mead algorithm is very robust, in the sense that it doesn't break easily. It is less fast than a gradient-best method. However, those can easily be broken by a vanishing gradient. This is actually the reason that the recommended routine in
Matlab optimization does not use a gradient-based solver (it actually uses the Simplex, aka Nelder-Mead). For people who do not understand at all what they do, and want a black box optimizer, it might be dangerous to push too much toward gradient-based solver.

I think that the docstring is scipy downplays too much Nelder-Mead, and I am proposing a small rewording.

See the second exercise on http://www.scipy-lectures.org/advanced/mathematical_optimization/index.html#synthetic-exercices for a simple example that breaks gradient-based solvers.
