### PR TITLE
BUG: gaussian_filter, BPoly.from_derivatives fail on numpy int types

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -16,7 +16,7 @@ import warnings
 import functools
 import operator
 
-from scipy._lib.six import xrange, integer_types
+from scipy._lib.six import xrange
 
 from . import fitpack
 from . import dfitpack
@@ -1393,7 +1393,9 @@ class BPoly(_PPolyBase):
         if orders is None:
             orders = [None] * m
         else:
-            if isinstance(orders, integer_types):
+            if hasattr(orders, '__iter__'):
+                pass
+            else:
                 orders = [orders] * m
             k = max(k, max(orders))
 

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -16,7 +16,7 @@ import warnings
 import functools
 import operator
 
-from scipy._lib.six import xrange
+from scipy._lib.six import xrange, integer_types
 
 from . import fitpack
 from . import dfitpack
@@ -1393,9 +1393,7 @@ class BPoly(_PPolyBase):
         if orders is None:
             orders = [None] * m
         else:
-            if hasattr(orders, '__iter__'):
-                pass
-            else:
+            if isinstance(orders, (integer_types, np.integer)):
                 orders = [orders] * m
             k = max(k, max(orders))
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1342,10 +1342,21 @@ class TestBPolyFromDerivatives(TestCase):
         assert_equal(pp.c.shape, (2*k, m, 6, 7, 8))
 
     def test_gh_5430(self):
-        orders = np.int64(1)
-        # The following raises an error unless gh-5430 is fixed
+        # At least one of these raises an error unless gh-5430 is
+        # fixed. In py2k an int is implemented using a C long, so
+        # which one fails depends on your system. In py3k there is only
+        # one arbitrary precision integer type, so both should fail.
+        orders = np.int32(1)
         p = BPoly.from_derivatives([0, 1], [[0], [0]], orders=orders)
         assert_almost_equal(p(0), 0)
+        orders = np.int64(1)
+        p = BPoly.from_derivatives([0, 1], [[0], [0]], orders=orders)
+        assert_almost_equal(p(0), 0)
+        orders = 1
+        # This worked before; make sure it still works
+        p = BPoly.from_derivatives([0, 1], [[0], [0]], orders=orders)
+        assert_almost_equal(p(0), 0)
+        orders = 1
 
 
 class TestPpform(TestCase):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1341,6 +1341,12 @@ class TestBPolyFromDerivatives(TestCase):
         pp = BPoly.from_derivatives(xi, yi)
         assert_equal(pp.c.shape, (2*k, m, 6, 7, 8))
 
+    def test_gh_5430(self):
+        orders = np.int64(1)
+        # The following raises an error unless gh-5430 is fixed
+        p = BPoly.from_derivatives([0, 1], [[0], [0]], orders=orders)
+        assert_almost_equal(p(0), 0)
+
 
 class TestPpform(TestCase):
     def test_shape(self):

--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -32,7 +32,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy
 
-from scipy._lib.six import integer_types, string_types
+from scipy._lib.six import string_types
 
 
 def _extend_mode_to_code(mode):
@@ -57,13 +57,13 @@ def _normalize_sequence(input, rank, array_type=None):
     rank by duplicating the input. If input is a sequence,
     check if its length is equal to the length of array.
     """
-    if isinstance(input, integer_types + (float,)):
-        normalized = [input] * rank
-    else:
+    if hasattr(input, '__iter__'):
         normalized = list(input)
         if len(normalized) != rank:
             err = "sequence argument must have length equal to input rank"
             raise RuntimeError(err)
+    else:
+        normalized = [input] * rank
     return normalized
 
 

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -21,9 +21,24 @@ def test_ticket_701():
 
 
 def test_gh_5430():
+    # At least one of these raises an error unless gh-5430 is
+    # fixed. In py2k an int is implemented using a C long, so
+    # which one fails depends on your system. In py3k there is only
+    # one arbitrary precision integer type, so both should fail.
     x = np.zeros(1)
+    sigma = np.int32(1)
+    y = sndi.gaussian_filter(x, sigma)
+    assert_allclose(x, y)
     sigma = np.int64(1)
-    # The following raises an error unless gh-5430 is fixed
+    y = sndi.gaussian_filter(x, sigma)
+    assert_allclose(x, y)
+    sigma = 1
+    # This worked before; make sure it still works
+    y = sndi.gaussian_filter(x, sigma)
+    assert_allclose(x, y)
+    # This worked before; make sure it still works
+    x = np.zeros((2, 2))
+    sigma = [1, 1]
     y = sndi.gaussian_filter(x, sigma)
     assert_allclose(x, y)
 

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -25,22 +25,28 @@ def test_gh_5430():
     # fixed. In py2k an int is implemented using a C long, so
     # which one fails depends on your system. In py3k there is only
     # one arbitrary precision integer type, so both should fail.
-    x = np.zeros(1)
     sigma = np.int32(1)
-    y = sndi.gaussian_filter(x, sigma)
-    assert_allclose(x, y)
+    out = sndi._ni_support._normalize_sequence(sigma, 1)
+    assert_equal(out, [sigma])
     sigma = np.int64(1)
-    y = sndi.gaussian_filter(x, sigma)
-    assert_allclose(x, y)
+    out = sndi._ni_support._normalize_sequence(sigma, 1)
+    assert_equal(out, [sigma])
+    # This worked before; make sure it still works
     sigma = 1
+    out = sndi._ni_support._normalize_sequence(sigma, 1)
+    assert_equal(out, [sigma])
     # This worked before; make sure it still works
-    y = sndi.gaussian_filter(x, sigma)
-    assert_allclose(x, y)
-    # This worked before; make sure it still works
-    x = np.zeros((2, 2))
     sigma = [1, 1]
-    y = sndi.gaussian_filter(x, sigma)
-    assert_allclose(x, y)
+    out = sndi._ni_support._normalize_sequence(sigma, 2)
+    assert_equal(out, sigma)
+    # Also include the OPs original example to make sure we fixed the issue
+    x = np.random.normal(size=(256, 256))
+    perlin = np.zeros_like(x)
+    for i in 2**np.arange(6):
+        perlin += sndi.filters.gaussian_filter(x, i, mode="wrap") * i**2
+    # This also fixes gh-4106, show that the OPs example now runs.
+    x = np.int64(21)
+    sndi._ni_support._normalize_sequence(x, 0)
 
 
 def test_orders_gauss():

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -4,7 +4,7 @@ from __future__ import division, print_function, absolute_import
 import sys
 import numpy as np
 
-from numpy.testing import (assert_equal, assert_raises,
+from numpy.testing import (assert_equal, assert_raises, assert_allclose,
                            assert_array_equal, TestCase, run_module_suite)
 
 import scipy.ndimage as sndi
@@ -18,6 +18,14 @@ def test_ticket_701():
     # The following raises an error unless ticket 701 is fixed
     res2 = sndi.generic_filter(arr, func, size=1)
     assert_equal(res, res2)
+
+
+def test_gh_5430():
+    x = np.zeros(1)
+    sigma = np.int64(1)
+    # The following raises an error unless gh-5430 is fixed
+    y = sndi.gaussian_filter(x, sigma)
+    assert_allclose(x, y)
 
 
 def test_orders_gauss():


### PR DESCRIPTION
The function ndimage.filters.gaussian_filter has a parameter sigma
which expects a scalar or sequence of scalars. But when passed a numpy
int type it fails. The same happens for BPoly.from_derivatives with
the parameter orders. See the discussion on gh-5290; closes gh-5290.
