### PR TITLE
MAINT: stats: fix incorrect deprecation warnings and test noise

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1992,6 +1992,13 @@ HistogramResult = namedtuple('HistogramResult',
 @np.deprecate(message=("scipy.stats.histogram is deprecated in scipy 0.17.0; "
                        "use np.histogram instead"))
 def histogram(a, numbins=10, defaultlimits=None, weights=None, printextras=False):
+    # _histogram is used in relfreq/cumfreq, so need to keep it
+    res = _histogram(a, numbins=numbins, defaultlimits=defaultlimits,
+                     weights=weights, printextras=printextras)
+    return res
+
+
+def _histogram(a, numbins=10, defaultlimits=None, weights=None, printextras=False):
     """
     Separates the range into several bins and returns the number of instances
     in each bin.
@@ -2143,7 +2150,7 @@ def cumfreq(a, numbins=10, defaultreallimits=None, weights=None):
     >>> plt.show()
 
     """
-    h, l, b, e = histogram(a, numbins, defaultreallimits, weights=weights)
+    h, l, b, e = _histogram(a, numbins, defaultreallimits, weights=weights)
     cumhist = np.cumsum(h * 1, axis=0)
     return CumfreqResult(cumhist, l, b, e)
 
@@ -2222,7 +2229,7 @@ def relfreq(a, numbins=10, defaultreallimits=None, weights=None):
 
     """
     a = np.asanyarray(a)
-    h, l, b, e = histogram(a, numbins, defaultreallimits, weights=weights)
+    h, l, b, e = _histogram(a, numbins, defaultreallimits, weights=weights)
     h = h / float(a.shape[0])
 
     return RelfreqResult(h, l, b, e)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1373,9 +1373,8 @@ class TestMode(TestCase):
         assert_equal(vals[1][0], 2)
 
     def test_objects(self):
-        """Python objects must be sortable (le + eq) and have ne defined
-        for np.unique to work. hash is for set.
-        """
+        # Python objects must be sortable (le + eq) and have ne defined
+        # for np.unique to work. hash is for set.
         class Point(object):
             def __init__(self, x):
                 self.x = x
@@ -1395,9 +1394,12 @@ class TestMode(TestCase):
         points = [Point(x) for x in [1, 2, 3, 4, 3, 2, 2, 2]]
         arr = np.empty((8,), dtype=object)
         arr[:] = points
-        assert len(set(points)) == 4
+        assert_(len(set(points)) == 4)
         assert_equal(np.unique(arr).shape, (4,))
-        vals = stats.mode(arr)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=RuntimeWarning)
+            vals = stats.mode(arr)
+
         assert_equal(vals[0][0], Point(2))
         assert_equal(vals[1][0], 4)
 
@@ -2097,7 +2099,8 @@ def test_chisquare_masked_arrays():
     # Empty arrays:
     # A data set with length 0 returns a masked scalar.
     with np.errstate(invalid='ignore'):
-        with warnings.catch_warnings(record=True):
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore')
             chisq, p = stats.chisquare(np.ma.array([]))
     assert_(isinstance(chisq, np.ma.MaskedArray))
     assert_equal(chisq.shape, ())
@@ -2114,8 +2117,10 @@ def test_chisquare_masked_arrays():
     # empty3.T is an array containing 3 data sets, each with length 0,
     # so an array of size (3,) is returned, with all values masked.
     with np.errstate(invalid='ignore'):
-        with warnings.catch_warnings(record=True):
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore')
             chisq, p = stats.chisquare(empty3.T)
+
     assert_(isinstance(chisq, np.ma.MaskedArray))
     assert_equal(chisq.shape, (3,))
     assert_(np.all(chisq.mask))


### PR DESCRIPTION
Closes gh-5426. There were ~5 test errors with Python 3.4 + Numpy 1.10.1
