### PR TITLE
moved imsave to imwrite while keeping backwards capability

### DIFF
--- a/scipy/misc/__init__.py
+++ b/scipy/misc/__init__.py
@@ -28,8 +28,9 @@ systems that don't have PIL installed.
    imread - Read an image file from a filename
    imresize - Resize an image
    imrotate - Rotate an image counter-clockwise
-   imsave - Save an array to an image file
+   imsave - Deprecated in favor of imwrite - Save an array to an image file
    imshow - Simple showing of an image through an external viewer
+   imwrite - Write an array to an image file
    info - Get help information for a function, class, or module
    lena - Get classic image processing example image Lena
    logsumexp - Compute the log of the sum of exponentials of input elements

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -25,7 +25,7 @@ except ImportError:
 if not hasattr(Image, 'frombytes'):
     Image.frombytes = Image.fromstring
 
-__all__ = ['fromimage', 'toimage', 'imsave', 'imread', 'bytescale',
+__all__ = ['fromimage', 'toimage', 'imread', 'imwrite', 'imsave', 'bytescale',
            'imrotate', 'imresize', 'imshow', 'imfilter']
 
 
@@ -126,10 +126,9 @@ def imread(name, flatten=0):
     im = Image.open(name)
     return fromimage(im, flatten=flatten)
 
-
-def imsave(name, arr, format=None):
+def imwrite(name, arr, format=None):
     """
-    Save an array as an image.
+    Write an array as an image.
 
     Parameters
     ----------
@@ -149,11 +148,11 @@ def imsave(name, arr, format=None):
     --------
     Construct an array of gradient intensity values and save to file:
 
-    >>> from scipy.misc import imsave
+    >>> from scipy.misc import imwrite
     >>> x = np.zeros((255, 255))
     >>> x = np.zeros((255, 255), dtype=np.uint8)
     >>> x[:] = np.arange(255)
-    >>> imsave('gradient.png', x)
+    >>> imwrite('gradient.png', x)
 
     Construct an array with three colour bands (R, G, B) and store to file:
 
@@ -161,7 +160,7 @@ def imsave(name, arr, format=None):
     >>> rgb[..., 0] = np.arange(255)
     >>> rgb[..., 1] = 55
     >>> rgb[..., 2] = 1 - np.arange(255)
-    >>> imsave('rgb_gradient.png', rgb)
+    >>> imwrite('rgb_gradient.png', rgb)
 
     """
     im = toimage(arr)
@@ -170,6 +169,15 @@ def imsave(name, arr, format=None):
     else:
         im.save(name, format)
     return
+
+def imsave(name, arr, format=None):
+    """ 
+
+    Deprecate in favor of imwrite to oppose to imread and similar to 
+    opencv and MATLAB
+
+    """
+    imwrite(name, arr, format)
 
 
 def fromimage(im, flatten=0):

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -9,7 +9,7 @@ import warnings
 from numpy.testing import (assert_, assert_equal, dec, decorate_methods,
                            TestCase, run_module_suite, assert_allclose)
 
-from scipy import misc
+from pilutil import fromimage, imread, imresize, imsave, bytescale, imwrite
 
 try:
     import PIL.Image
@@ -30,58 +30,80 @@ class TestPILUtil(TestCase):
         im = np.random.random((10,20))
         for T in np.sctypes['float'] + [float]:
             # 1.1 rounds to below 1.1 for float16, 1.101 works
-            im1 = misc.imresize(im,T(1.101))
+            im1 = imresize(im,T(1.101))
             assert_equal(im1.shape,(11,22))
 
     def test_imresize2(self):
         im = np.random.random((20,30))
-        im2 = misc.imresize(im, (30,40), interp='bicubic')
+        im2 = imresize(im, (30,40), interp='bicubic')
         assert_equal(im2.shape, (30,40))
 
     def test_imresize3(self):
         im = np.random.random((15,30))
-        im2 = misc.imresize(im, (30,60), interp='nearest')
+        im2 = imresize(im, (30,60), interp='nearest')
         assert_equal(im2.shape, (30,60))
 
     def test_imresize4(self):
         im = np.array([[1, 2],
                        [3, 4]])
         # Check that resizing by target size, float and int are the same
-        im2 = misc.imresize(im, (4,4), mode='F')  # output size
-        im3 = misc.imresize(im, 2., mode='F')  # fraction
-        im4 = misc.imresize(im, 200, mode='F')  # percentage
+        im2 = imresize(im, (4,4), mode='F')  # output size
+        im3 = imresize(im, 2., mode='F')  # fraction
+        im4 = imresize(im, 200, mode='F')  # percentage
         assert_equal(im2, im3)
         assert_equal(im2, im4)
 
     def test_bytescale(self):
         x = np.array([0,1,2], np.uint8)
         y = np.array([0,1,2])
-        assert_equal(misc.bytescale(x), x)
-        assert_equal(misc.bytescale(y), [0,127,255])
+        assert_equal(bytescale(x), x)
+        assert_equal(bytescale(y), [0,127,255])
 
     def test_bytescale_keywords(self):
         x = np.array([40, 60, 120, 200, 300, 500])
-        res_lowhigh = misc.bytescale(x, low=10, high=143)
+        res_lowhigh = bytescale(x, low=10, high=143)
         assert_equal(res_lowhigh, [10, 16, 33, 56, 85, 143])
-        res_cmincmax = misc.bytescale(x, cmin=60, cmax=300)
+        res_cmincmax = bytescale(x, cmin=60, cmax=300)
         assert_equal(res_cmincmax, [0, 0, 64, 149, 255, 255])
 
-        assert_equal(misc.bytescale(np.array([3, 3, 3]), low=4), [4, 4, 4])
+        assert_equal(bytescale(np.array([3, 3, 3]), low=4), [4, 4, 4])
+
+
 
     def test_imsave(self):
         with warnings.catch_warnings(record=True):  # PIL ResourceWarning
-            img = misc.imread(os.path.join(datapath, 'data', 'icon.png'))
+            img = imread(os.path.join(datapath, 'data', 'icon.png'))
         tmpdir = tempfile.mkdtemp()
         try:
             fn1 = os.path.join(tmpdir, 'test.png')
             fn2 = os.path.join(tmpdir, 'testimg')
             with warnings.catch_warnings(record=True):  # PIL ResourceWarning
-                misc.imsave(fn1, img)
-                misc.imsave(fn2, img, 'PNG')
+                imsave(fn1, img)
+                imsave(fn2, img, 'PNG')
 
             with warnings.catch_warnings(record=True):  # PIL ResourceWarning
-                data1 = misc.imread(fn1)
-                data2 = misc.imread(fn2)
+                data1 = imread(fn1)
+                data2 = imread(fn2)
+
+            assert_allclose(data1, img)
+            assert_allclose(data2, img)
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_imwrite(self):
+        with warnings.catch_warnings(record=True):  # PIL ResourceWarning
+            img = imread(os.path.join(datapath, 'data', 'icon.png'))
+        tmpdir = tempfile.mkdtemp()
+        try:
+            fn1 = os.path.join(tmpdir, 'test.png')
+            fn2 = os.path.join(tmpdir, 'testimg')
+            with warnings.catch_warnings(record=True):  # PIL ResourceWarning
+                imwrite(fn1, img)
+                imwrite(fn2, img, 'PNG')
+
+            with warnings.catch_warnings(record=True):  # PIL ResourceWarning
+                data1 = imread(fn1)
+                data2 = imread(fn2)
 
             assert_allclose(data1, img)
             assert_allclose(data2, img)
@@ -91,7 +113,7 @@ class TestPILUtil(TestCase):
 
 def tst_fromimage(filename, irange):
     fp = open(filename, "rb")
-    img = misc.fromimage(PIL.Image.open(fp))
+    img = fromimage(PIL.Image.open(fp))
     fp.close()
     imin,imax = irange
     assert_(img.min() >= imin)


### PR DESCRIPTION
The first commit - imsave should be renamed imwrite since imread is used.  imwrite is also what OpenCV and MATLAB uses.  

The second commit - The test added and also moved the scipy.misc call to use local packages rather than the existing library.
