### PR TITLE
Rename imsave to imwrite while keeping backwards compatibility

### DIFF
--- a/scipy/misc/__init__.py
+++ b/scipy/misc/__init__.py
@@ -28,8 +28,9 @@ systems that don't have PIL installed.
    imread - Read an image file from a filename
    imresize - Resize an image
    imrotate - Rotate an image counter-clockwise
-   imsave - Save an array to an image file
+   imsave - Deprecated in favor of imwrite - Save an array to an image file
    imshow - Simple showing of an image through an external viewer
+   imwrite - Write an array to an image file
    info - Get help information for a function, class, or module
    lena - Get classic image processing example image Lena
    logsumexp - Compute the log of the sum of exponentials of input elements

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -25,7 +25,7 @@ except ImportError:
 if not hasattr(Image, 'frombytes'):
     Image.frombytes = Image.fromstring
 
-__all__ = ['fromimage', 'toimage', 'imsave', 'imread', 'bytescale',
+__all__ = ['fromimage', 'toimage', 'imread', 'imwrite', 'imsave', 'bytescale',
            'imrotate', 'imresize', 'imshow', 'imfilter']
 
 
@@ -126,10 +126,9 @@ def imread(name, flatten=0):
     im = Image.open(name)
     return fromimage(im, flatten=flatten)
 
-
-def imsave(name, arr, format=None):
+def imwrite(name, arr, format=None):
     """
-    Save an array as an image.
+    Write an array as an image.
 
     Parameters
     ----------
@@ -149,11 +148,11 @@ def imsave(name, arr, format=None):
     --------
     Construct an array of gradient intensity values and save to file:
 
-    >>> from scipy.misc import imsave
+    >>> from scipy.misc import imwrite
     >>> x = np.zeros((255, 255))
     >>> x = np.zeros((255, 255), dtype=np.uint8)
     >>> x[:] = np.arange(255)
-    >>> imsave('gradient.png', x)
+    >>> imwrite('gradient.png', x)
 
     Construct an array with three colour bands (R, G, B) and store to file:
 
@@ -161,7 +160,7 @@ def imsave(name, arr, format=None):
     >>> rgb[..., 0] = np.arange(255)
     >>> rgb[..., 1] = 55
     >>> rgb[..., 2] = 1 - np.arange(255)
-    >>> imsave('rgb_gradient.png', rgb)
+    >>> imwrite('rgb_gradient.png', rgb)
 
     """
     im = toimage(arr)
@@ -170,6 +169,15 @@ def imsave(name, arr, format=None):
     else:
         im.save(name, format)
     return
+
+def imsave(name, arr, format=None):
+    """ 
+
+    Deprecate in favor of imwrite to oppose to imread and similar to 
+    opencv and MATLAB
+
+    """
+    imwrite(name, arr, format)
 
 
 def fromimage(im, flatten=0):

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -65,7 +65,6 @@ class TestPILUtil(TestCase):
         assert_equal(res_lowhigh, [10, 16, 33, 56, 85, 143])
         res_cmincmax = misc.bytescale(x, cmin=60, cmax=300)
         assert_equal(res_cmincmax, [0, 0, 64, 149, 255, 255])
-
         assert_equal(misc.bytescale(np.array([3, 3, 3]), low=4), [4, 4, 4])
 
     def test_imsave(self):
@@ -78,6 +77,26 @@ class TestPILUtil(TestCase):
             with warnings.catch_warnings(record=True):  # PIL ResourceWarning
                 misc.imsave(fn1, img)
                 misc.imsave(fn2, img, 'PNG')
+
+            with warnings.catch_warnings(record=True):  # PIL ResourceWarning
+                data1 = misc.imread(fn1)
+                data2 = misc.imread(fn2)
+
+            assert_allclose(data1, img)
+            assert_allclose(data2, img)
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_imwrite(self):
+        with warnings.catch_warnings(record=True):  # PIL ResourceWarning
+            img = misc.imread(os.path.join(datapath, 'data', 'icon.png'))
+        tmpdir = tempfile.mkdtemp()
+        try:
+            fn1 = os.path.join(tmpdir, 'test.png')
+            fn2 = os.path.join(tmpdir, 'testimg')
+            with warnings.catch_warnings(record=True):  # PIL ResourceWarning
+                misc.imwrite(fn1, img)
+                misc.imwrite(fn2, img, 'PNG')
 
             with warnings.catch_warnings(record=True):  # PIL ResourceWarning
                 data1 = misc.imread(fn1)


### PR DESCRIPTION
First commit - renamed imsave to imwrite to be opposite imread and also similar to openCV and MATLAB

Second commit - added tests and used local packages instead of library package

Made a new branch to submit the pull request
