### PR TITLE
ConvexHull should raise ValueError for NaNs.

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -150,6 +150,7 @@ J.J. Green for interpolation bug fixes.
 François Magimel for documentation improvements.
 Josh Levy-Kramer for the log survival function of the hypergeometric distribution
 Will Monroe for bug fixes.
+Bernardo Sulzbach for bug fixes.
 
 
 Institutions

--- a/scipy/spatial/qhull.pyx
+++ b/scipy/spatial/qhull.pyx
@@ -272,6 +272,8 @@ cdef class _Qhull:
             raise ValueError("No points given")
         if self.ndim < 2:
             raise ValueError("Need at least 2-D data")
+        if np.isnan(points).any():
+            raise ValueError("Points cannot contain NaN")
 
         # Process options
         option_set = set()

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -427,6 +427,10 @@ class TestDelaunay(object):
         masked_array = np.ma.masked_all(1)
         assert_raises(ValueError, qhull.Delaunay, masked_array)
 
+    def test_array_with_nans_fails(self):
+        points_with_nan = np.array([(0,0), (0,1), (1,1), (1,np.nan)], dtype=np.double)
+        assert_raises(ValueError, qhull.Delaunay, points_with_nan)
+
     def test_nd_simplex(self):
         # simple smoke test: triangulate a n-dimensional simplex
         for nd in xrange(2, 8):
@@ -604,6 +608,10 @@ class TestConvexHull:
     def test_masked_array_fails(self):
         masked_array = np.ma.masked_all(1)
         assert_raises(ValueError, qhull.ConvexHull, masked_array)
+
+    def test_array_with_nans_fails(self):
+        points_with_nan = np.array([(0,0), (1,1), (2,np.nan)], dtype=np.double)
+        assert_raises(ValueError, qhull.ConvexHull, points_with_nan)
 
     def test_hull_consistency_tri(self):
         # Check that a convex hull returned by qhull in ndim


### PR DESCRIPTION
It used to trigger a Segmentation Fault, which is not a very elegant
way to show that something is wrong. As it should not try to figure
something out of NaNs, it beautifully resigns with a ValueError now.

Fixes #5450
