### PR TITLE
Online QR in LGMRES

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -171,10 +171,10 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
     if info == 0:
         return x
     if info > 0:
-        raise LinAlgError("singular matrix: resolution failed at diagonal %s" %
-                          info-1)
+        raise LinAlgError("singular matrix: resolution failed at diagonal %d" %
+                          (info-1))
     raise ValueError('illegal value in %d-th argument of internal trtrs' %
-                     -info)
+                     (-info))
 
 
 def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,


### PR DESCRIPTION
Now that Scipy has `qr_insert`, rewrite LGMRES via QR updating.

AFAICS, this is correct but maybe useful to recheck again another day.

There's still a performance factor of ~4x vs. GMRES, which might also come from the orthogonalization. However, at least now the Arnoldi is done in a non-silly way.

Benchmarks:

```
$ python runtests.py --bench-compare master sparse_linalg_solve
...
    before     after       ratio
  [ea1ac77b] [d4766bb1]
+  563.44μs   601.36μs      1.07  sparse_linalg_solve.Bench.time_lgmres(6, 'sparse')
-  994.52μs   944.45μs      0.95  sparse_linalg_solve.Bench.time_lgmres(16, 'dense')
-   36.22μs    34.31μs      0.95  sparse_linalg_solve.Bench.time_lgmres(4, 'dense')
-  805.06μs   735.11μs      0.91  sparse_linalg_solve.Lgmres.time_inner(50, 10)
-   48.81μs    44.48μs      0.91  sparse_linalg_solve.Bench.time_lgmres(6, 'dense')
-   36.71μs    33.33μs      0.91  sparse_linalg_solve.Bench.time_spsolve(4, 'dense')
-  205.15ms   180.15ms      0.88  sparse_linalg_solve.Lgmres.time_inner(10000, 90)
-   70.39ms    61.36ms      0.87  sparse_linalg_solve.Bench.time_lgmres(100, 'sparse')
-    1.30ms     1.13ms      0.87  sparse_linalg_solve.Lgmres.time_inner(1000, 10)
-    1.36ms     1.17ms      0.86  sparse_linalg_solve.Bench.time_lgmres(10, 'sparse')
-  873.87μs   753.05μs      0.86  sparse_linalg_solve.Lgmres.time_inner(50, 30)
-    1.01ms   859.73μs      0.85  sparse_linalg_solve.Lgmres.time_inner(100, 10)
-  890.74μs   758.19μs      0.85  sparse_linalg_solve.Lgmres.time_inner(50, 90)
-  885.41μs   742.38μs      0.84  sparse_linalg_solve.Lgmres.time_inner(50, 180)
-  590.71μs   484.36μs      0.82  sparse_linalg_solve.Bench.time_lgmres(4, 'sparse')
-   26.75ms    21.69ms      0.81  sparse_linalg_solve.Bench.time_lgmres(64, 'sparse')
-  882.27μs   705.57μs      0.80  sparse_linalg_solve.Lgmres.time_inner(50, 60)
-    1.31ms   998.28μs      0.76  sparse_linalg_solve.Lgmres.time_inner(100, 180)
-    2.64ms     2.00ms      0.76  sparse_linalg_solve.Bench.time_lgmres(16, 'sparse')
-    1.33ms     1.01ms      0.76  sparse_linalg_solve.Lgmres.time_inner(100, 60)
-    1.38ms     1.04ms      0.76  sparse_linalg_solve.Lgmres.time_inner(100, 90)
-   14.31ms    10.80ms      0.76  sparse_linalg_solve.Bench.time_lgmres(40, 'sparse')
-    1.32ms   986.23μs      0.75  sparse_linalg_solve.Lgmres.time_inner(100, 30)
-    4.85ms     3.44ms      0.71  sparse_linalg_solve.Lgmres.time_inner(1000, 30)
-    8.91ms     6.04ms      0.68  sparse_linalg_solve.Bench.time_lgmres(25, 'sparse')
-  462.84μs   284.05μs      0.61  sparse_linalg_solve.Lgmres.time_inner(10, 60)
-  465.60μs   276.64μs      0.59  sparse_linalg_solve.Lgmres.time_inner(10, 10)
-  788.87ms   468.44ms      0.59  sparse_linalg_solve.Lgmres.time_inner(10000, 180)
-  461.14μs   272.52μs      0.59  sparse_linalg_solve.Lgmres.time_inner(10, 90)
-  459.93μs   271.26μs      0.59  sparse_linalg_solve.Lgmres.time_inner(10, 30)
-  461.14μs   269.05μs      0.58  sparse_linalg_solve.Lgmres.time_inner(10, 180)
-   18.25ms     8.31ms      0.46  sparse_linalg_solve.Lgmres.time_inner(1000, 60)
-   47.55ms    14.77ms      0.31  sparse_linalg_solve.Lgmres.time_inner(1000, 90)
-  316.22ms    50.65ms      0.16  sparse_linalg_solve.Lgmres.time_inner(1000, 180)
```
