### PR TITLE
ENH: return Jacobian/Hessian from BasinHopping

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -153,6 +153,7 @@ Will Monroe for bug fixes.
 Bernardo Sulzbach for bug fixes.
 Alexander Grigorevskiy for adding extra LAPACK least-square solvers and 
     modifying linalg.lstsq function accordingly.
+Sam Lewis for enhancements to the basinhopping module.
 
 Institutions
 ------------

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -179,12 +179,11 @@ class TestBasinHopping(TestCase):
 
     def test_jac(self):
         # test jacobian returned
-        i = 2
         minimizer_kwargs = self.kwargs.copy()
         # BFGS returns a Jacobian
         minimizer_kwargs["method"] = "BFGS"
 
-        res = basinhopping(func2d_easyderiv, np.array([0.0, 0.0]),
+        res = basinhopping(func2d_easyderiv, [0.0, 0.0],
                            minimizer_kwargs=minimizer_kwargs, niter=self.niter,
                            disp=self.disp)
 

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -113,9 +113,9 @@ class TestBasinHopping(TestCase):
 
         Run tests based on the 1-D and 2-D functions described above.
         """
-        self.x0 = (1.0, [1.0, 1.0], [0.0, 0.0])
-        self.sol = (-0.195, np.array([-0.195, -0.1]), np.array([2.0, -1.0]))
-
+        self.x0 = (1.0, [1.0, 1.0])
+        self.sol = (-0.195, np.array([-0.195, -0.1]))
+        
         self.tol = 3  # number of decimal places
 
         self.niter = 100
@@ -184,7 +184,7 @@ class TestBasinHopping(TestCase):
         # BFGS returns a Jacobian
         minimizer_kwargs["method"] = "BFGS"
 
-        res = basinhopping(func2d_easyderiv, self.x0[i],
+        res = basinhopping(func2d_easyderiv, np.array([0.0, 0.0]),
                            minimizer_kwargs=minimizer_kwargs, niter=self.niter,
                            disp=self.disp)
 


### PR DESCRIPTION
Returns the Jacobian and/or Hessian in the optimize.Basinhopping module, if it exists. Closes https://github.com/scipy/scipy/issues/5259. 

I've only written a unit test for the Jacobian part as I could not find any minimizers that returned a Hessian in the OptimizeResult object. Maybe I've overlooked something?

This is my first scipy contribution so I'd appreciate any feedback. Don't hold back if I've done something horribly wrong or if there's any suggestion of how I could do things better. :)
