### PR TITLE
BUG: fix ttest zero division handling

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3680,7 +3680,8 @@ def ttest_1samp(a, popmean, axis=0, nan_policy='propagate'):
     v = np.var(a, axis, ddof=1)
     denom = np.sqrt(v / float(n))
 
-    t = np.divide(d, denom)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        t = np.divide(d, denom)
     t, prob = _ttest_finish(df, t)
 
     return Ttest_1sampResult(t, prob)
@@ -3698,7 +3699,8 @@ def _ttest_finish(df, t):
 def _ttest_ind_from_stats(mean1, mean2, denom, df):
 
     d = mean1 - mean2
-    t = np.divide(d, denom)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        t = np.divide(d, denom)
     t, prob = _ttest_finish(df, t)
 
     return (t, prob)
@@ -3707,7 +3709,8 @@ def _ttest_ind_from_stats(mean1, mean2, denom, df):
 def _unequal_var_ttest_denom(v1, n1, v2, n2):
     vn1 = v1 / n1
     vn2 = v2 / n2
-    df = ((vn1 + vn2)**2) / ((vn1**2) / (n1 - 1) + (vn2**2) / (n2 - 1))
+    with np.errstate(divide='ignore', invalid='ignore'):
+        df = (vn1 + vn2)**2 / (vn1**2 / (n1 - 1) + vn2**2 / (n2 - 1))
 
     # If df is undefined, variances are zero (assumes n1 > 0 & n2 > 0).
     # Hence it doesn't matter what df is as long as it's not NaN.
@@ -3990,7 +3993,8 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate'):
     dm = np.mean(d, axis)
     denom = np.sqrt(v / float(n))
 
-    t = np.divide(dm, denom)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        t = np.divide(dm, denom)
     t, prob = _ttest_finish(df, t)
 
     return Ttest_relResult(t, prob)

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -17,7 +17,7 @@ from numpy.testing import TestCase, run_module_suite
 from numpy.testing.decorators import skipif
 from numpy.ma.testutils import (assert_equal, assert_almost_equal,
     assert_array_almost_equal, assert_array_almost_equal_nulp, assert_,
-    assert_allclose, assert_raises)
+    assert_allclose, assert_raises, assert_array_equal)
 
 
 class TestMquantiles(TestCase):
@@ -733,6 +733,12 @@ class TestTtest_rel():
         res3 = mstats.ttest_rel(outcome[:, :2], outcome[:, 2:])
         assert_allclose(res2, res3)
 
+    def test_fully_masked(self):
+        np.random.seed(1234567)
+        outcome = ma.masked_array(np.random.randn(3, 2), mask=[[1, 1, 1], [0, 0, 0]])
+        assert_array_equal(mstats.ttest_rel(outcome[:, 0], outcome[:, 1]), (np.nan, np.nan))
+        assert_array_equal(mstats.ttest_rel([np.nan, np.nan], [1.0, 2.0]), (np.nan, np.nan))
+
     def test_result_attributes(self):
         np.random.seed(1234567)
         outcome = np.random.randn(20, 4) + [0, 0, 1, 2]
@@ -754,6 +760,10 @@ class TestTtest_rel():
         res1 = mstats.ttest_rel([], [])
         assert_(np.all(np.isnan(res1)))
 
+    def test_zero_division(self):
+        t, p = mstats.ttest_ind([0, 0, 0], [1, 1, 1])
+        assert_equal((np.abs(t), p), (np.inf, 0))
+        assert_array_equal(mstats.ttest_ind([0, 0, 0], [0, 0, 0]), (np.nan, np.nan))
 
 class TestTtest_ind():
     def test_vs_nonmasked(self):
@@ -785,6 +795,12 @@ class TestTtest_ind():
         res5 = mstats.ttest_ind(outcome[:, 0], outcome[:, 1], equal_var=False)
         assert_allclose(res4, res5)
 
+    def test_fully_masked(self):
+        np.random.seed(1234567)
+        outcome = ma.masked_array(np.random.randn(3, 2), mask=[[1, 1, 1], [0, 0, 0]])
+        assert_array_equal(mstats.ttest_ind(outcome[:, 0], outcome[:, 1]), (np.nan, np.nan))
+        assert_array_equal(mstats.ttest_ind([np.nan, np.nan], [1.0, 2.0]), (np.nan, np.nan))
+
     def test_result_attributes(self):
         np.random.seed(1234567)
         outcome = np.random.randn(20, 4) + [0, 0, 1, 2]
@@ -796,6 +812,15 @@ class TestTtest_ind():
     def test_empty(self):
         res1 = mstats.ttest_ind([], [])
         assert_(np.all(np.isnan(res1)))
+
+    def test_zero_division(self):
+        t, p = mstats.ttest_ind([0, 0, 0], [1, 1, 1])
+        assert_equal((np.abs(t), p), (np.inf, 0))
+        assert_array_equal(mstats.ttest_ind([0, 0, 0], [0, 0, 0]), (np.nan, np.nan))
+
+        t, p = mstats.ttest_ind([0, 0, 0], [1, 1, 1], equal_var=False)
+        assert_equal((np.abs(t), p), (np.inf, 0))
+        assert_array_equal(mstats.ttest_ind([0, 0, 0], [0, 0, 0], equal_var=False), (np.nan, np.nan))
 
 
 class TestTtest_1samp():
@@ -820,6 +845,12 @@ class TestTtest_1samp():
         res3 = mstats.ttest_1samp(outcome[:, :2], outcome[:, 2:])
         assert_allclose(res2, res3)
 
+    def test_fully_masked(self):
+        np.random.seed(1234567)
+        outcome = ma.masked_array(np.random.randn(3), mask=[1, 1, 1])
+        assert_array_equal(mstats.ttest_1samp(outcome, 0.0), (np.nan, np.nan))
+        assert_array_equal(mstats.ttest_1samp((np.nan, np.nan), 0.0), (np.nan, np.nan))
+
     def test_result_attributes(self):
         np.random.seed(1234567)
         outcome = np.random.randn(20, 4) + [0, 0, 1, 2]
@@ -831,6 +862,11 @@ class TestTtest_1samp():
     def test_empty(self):
         res1 = mstats.ttest_1samp([], 1)
         assert_(np.all(np.isnan(res1)))
+
+    def test_zero_division(self):
+        t, p = mstats.ttest_1samp([0, 0, 0], 1)
+        assert_equal((np.abs(t), p), (np.inf, 0))
+        assert_array_equal(mstats.ttest_1samp([0, 0, 0], 0), (np.nan, np.nan))
 
 
 class TestCompareWithStats(TestCase):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2358,13 +2358,13 @@ def test_ttest_rel():
     assert_raises(ValueError, stats.ttest_rel, x, y, nan_policy='raise')
     assert_raises(ValueError, stats.ttest_rel, x, y, nan_policy='foobar')
 
+    # test zero division problem
+    t, p = stats.ttest_rel([0, 0, 0], [1, 1, 1])
+    assert_equal((np.abs(t), p), (np.inf, 0))
+    assert_equal(stats.ttest_rel([0, 0, 0], [0, 0, 0]), (np.nan, np.nan))
+
     olderr = np.seterr(all='ignore')
     try:
-        # test zero division problem
-        t,p = stats.ttest_rel([0,0,0],[1,1,1])
-        assert_equal((np.abs(t),p), (np.inf, 0))
-        assert_equal(stats.ttest_rel([0,0,0], [0,0,0]), (np.nan, np.nan))
-
         # check that nan in input array result in nan output
         anan = np.array([[1, np.nan], [-1, 1]])
         assert_equal(stats.ttest_rel(anan, np.zeros((2, 2))),
@@ -2436,8 +2436,6 @@ def test_ttest_ind():
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (3, 2))
 
-    olderr = np.seterr(all='ignore')
-
     # check nan policy
     np.random.seed(12345678)
     x = stats.norm.rvs(loc=5, scale=10, size=501)
@@ -2451,14 +2449,15 @@ def test_ttest_ind():
     assert_raises(ValueError, stats.ttest_ind, x, y, nan_policy='raise')
     assert_raises(ValueError, stats.ttest_ind, x, y, nan_policy='foobar')
 
-    try:
-        # test zero division problem
-        t,p = stats.ttest_ind([0,0,0],[1,1,1])
-        assert_equal((np.abs(t),p), (np.inf, 0))
-        assert_equal(stats.ttest_ind([0,0,0], [0,0,0]), (np.nan, np.nan))
+    # test zero division problem
+    t, p = stats.ttest_ind([0, 0, 0], [1, 1, 1])
+    assert_equal((np.abs(t), p), (np.inf, 0))
+    assert_equal(stats.ttest_ind([0, 0, 0], [0, 0, 0]), (np.nan, np.nan))
 
+    olderr = np.seterr(all='ignore')
+    try:
         # check that nan in input array result in nan output
-        anan = np.array([[1,np.nan],[-1,1]])
+        anan = np.array([[1, np.nan], [-1, 1]])
         assert_equal(stats.ttest_ind(anan, np.zeros((2, 2))),
                      ([0, np.nan], [1, np.nan]))
     finally:
@@ -2558,15 +2557,15 @@ def test_ttest_ind_with_uneq_var():
     assert_array_almost_equal(np.abs(p), pr)
     assert_equal(t.shape, (3, 2))
 
+    # test zero division problem
+    t, p = stats.ttest_ind([0, 0, 0], [1, 1, 1], equal_var=False)
+    assert_equal((np.abs(t), p), (np.inf, 0))
+    assert_equal(stats.ttest_ind([0, 0, 0], [0, 0, 0], equal_var=False), (np.nan, np.nan))
+
     olderr = np.seterr(all='ignore')
     try:
-        # test zero division problem
-        t,p = stats.ttest_ind([0,0,0],[1,1,1], equal_var=False)
-        assert_equal((np.abs(t),p), (np.inf, 0))
-        assert_equal(stats.ttest_ind([0,0,0], [0,0,0], equal_var=False), (np.nan, np.nan))
-
         # check that nan in input array result in nan output
-        anan = np.array([[1,np.nan],[-1,1]])
+        anan = np.array([[1, np.nan], [-1, 1]])
         assert_equal(stats.ttest_ind(anan, np.zeros((2, 2)), equal_var=False),
                      ([0, np.nan], [1, np.nan]))
     finally:
@@ -2600,15 +2599,15 @@ def test_ttest_1samp_new():
     assert_almost_equal(t1[0,0],t3, decimal=14)
     assert_equal(t1.shape, (n1,n2))
 
+    # test zero division problem
+    t, p = stats.ttest_1samp([0, 0, 0], 1)
+    assert_equal((np.abs(t), p), (np.inf, 0))
+    assert_equal(stats.ttest_1samp([0, 0, 0], 0), (np.nan, np.nan))
+
     olderr = np.seterr(all='ignore')
     try:
-        # test zero division problem
-        t,p = stats.ttest_1samp([0,0,0], 1)
-        assert_equal((np.abs(t),p), (np.inf, 0))
-        assert_equal(stats.ttest_1samp([0,0,0], 0), (np.nan, np.nan))
-
         # check that nan in input array result in nan output
-        anan = np.array([[1,np.nan],[-1,1]])
+        anan = np.array([[1, np.nan],[-1, 1]])
         assert_equal(stats.ttest_1samp(anan, 0), ([0, np.nan], [1, np.nan]))
     finally:
         np.seterr(**olderr)


### PR DESCRIPTION
The ttest function in `scipy.stats` currently do not check for zero division caused by variances being zero. The behavior of a function call thus depends on the numpy error state. Depending on this state their might either be annoying warnings or exceptions will be raised.

This PR fixes these issues by performing explicit checks before division.
