### PR TITLE
Fix crash on kmeans2

### DIFF
--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -214,6 +214,13 @@ class TestKMean(TestCase):
         data1 = data[:, 0]
         kmeans2(data1, 2, iter=1)
 
+    def test_kmeans2_high_dim(self):
+        # test kmeans2 when the number of dimensions exceeds the number
+        # of input points
+        data = np.fromfile(DATAFILE1, sep=", ")
+        data = data.reshape((20, 20))[:10]
+        kmeans2(data, 2)
+
     def test_kmeans2_init(self):
         data = np.fromfile(DATAFILE1, sep=", ")
         data = data.reshape((200, 2))

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -13,7 +13,7 @@ from numpy.testing import (assert_array_equal, assert_array_almost_equal,
     assert_)
 
 from scipy.cluster.vq import (kmeans, kmeans2, py_vq, py_vq2, vq, whiten,
-    ClusterError)
+    ClusterError, _krandinit)
 from scipy.cluster import _vq
 
 # Optional:
@@ -234,6 +234,17 @@ class TestKMean(TestCase):
                         message="One of the clusters is empty. Re-run")
             kmeans2(data, 3, minit='random')
             kmeans2(data[:, :1], 3, minit='random')  # special case (1-D)
+
+    def test_krandinit(self):
+        data = np.fromfile(DATAFILE1, sep=", ")
+        datas = [data.reshape((200, 2)), data.reshape((20, 20))[:10]]
+        k = int(1e6)
+        for data in datas:
+            np.random.seed(1234)
+            init = _krandinit(data, k)
+            orig_cov = np.cov(data, rowvar=0)
+            init_cov = np.cov(init, rowvar=0)
+            assert_allclose(orig_cov, init_cov, atol=1e-2)
 
     def test_kmeans2_empty(self):
         # Regression test for gh-1032.

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -639,7 +639,7 @@ def _krandinit(data, k):
         mu = np.mean(data, axis=0)
         _, s, vh = np.linalg.svd(data - mu, full_matrices=False)
         x = np.random.randn(k, s.size)
-        sVh = s[:,None] * vh
+        sVh = s[:, None] * vh / np.sqrt(data.shape[0] - 1)
         x = np.dot(x, sVh) + mu
         return x
 

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -634,9 +634,20 @@ def _krandinit(data, k):
         x = np.dot(x, np.linalg.cholesky(cov).T) + mu
         return x
 
+    def init_rank_def(data):
+        # initialize when the covariance matrix is rank deficient
+        mu = np.mean(data, axis=0)
+        _, s, vh = np.linalg.svd(data - mu, full_matrices=False)
+        x = np.random.randn(k, s.size)
+        sVh = s[:,None] * vh
+        x = np.dot(x, sVh) + mu
+        return x
+
     nd = np.ndim(data)
     if nd == 1:
         return init_rank1(data)
+    elif data.shape[1] > data.shape[0]:
+        return init_rank_def(data)
     else:
         return init_rankn(data)
 


### PR DESCRIPTION
scipy.cluster.vq.kmeans2 would crash on random initialization when its data argument contains less data points than dimensions.

This pull request adds a test, test_kmeans2_high_dim, which highlights the issue, and fixes the random initialization procedure to use pca instead of cholesky factorization of the covariance matrix when the number of data points is less than the dimension.
