### PR TITLE
ENH: Added matrix_normal method to return equivalent multivariate_normal

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -716,7 +716,7 @@ class matrix_normal_gen(multi_rv_generic):
     where :math:`M` is the mean, :math:`U` the among-row covariance matrix,
     :math:`V` the among-column covariance matrix.
 
-    The ``allow_singular'' behaviour of the ``multivariate_normal''
+    The `allow_singular` behaviour of the `multivariate_normal`
     distribution is not currently supported. Covariance matrices must be
     full rank.
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -475,6 +475,27 @@ class TestMatrixNormal(TestCase):
                 assert_allclose(pdf1, pdf2, rtol=1E-10)
                 assert_allclose(logpdf1, logpdf2, rtol=1E-10)
 
+    def test_equivalent_multivariate(self):
+        # Check that the equivalent multivariate distribution matches
+        for i in range(1,5):
+            for j in range(1,5):
+                M = 0.3 * np.ones((i,j))
+                U = 0.5 * np.identity(i) + 0.5 * np.ones((i,i))
+                V = 0.7 * np.identity(j) + 0.3 * np.ones((j,j))
+
+                frozen = matrix_normal(mean=M, rowcov=U, colcov=V)
+                X = frozen.rvs(random_state=1234)
+                pdf1 = frozen.pdf(X)
+                logpdf1 = frozen.logpdf(X)
+
+                mvn = frozen.equivalent_multivariate_normal()
+                vecX = X.T.flatten()
+                pdf2 = mvn.pdf(vecX)
+                logpdf2 = mvn.logpdf(vecX)
+
+                assert_allclose(pdf1, pdf2, rtol=1E-10)
+                assert_allclose(logpdf1, logpdf2, rtol=1E-10)
+
     def test_array_input(self):
         # Check array of inputs has the same output as the separate entries.
         num_rows = 4


### PR DESCRIPTION
For #5478 
- A method which returns the equivalent multivariate normal distribution
- Some additions/improvements to the documentation
