### PR TITLE
Specify mismatched expected & observed shapes in minpack._check_func

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -35,7 +35,7 @@ def _check_func(checker, argname, thefunc, x0, args, numinputs,
                 msg += " '%s'." % func_name
             else:
                 msg += "."
-            msg += 'Shape should be %s but it is %s.'.format(output_shape, shape(res))
+            msg += 'Shape should be %s but it is %s.' % (output_shape, shape(res))
             raise TypeError(msg)
     if issubdtype(res.dtype, inexact):
         dt = res.dtype

--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -35,6 +35,7 @@ def _check_func(checker, argname, thefunc, x0, args, numinputs,
                 msg += " '%s'." % func_name
             else:
                 msg += "."
+            msg += 'Shape should be %s but it is %s.'.format(output_shape, shape(res))
             raise TypeError(msg)
     if issubdtype(res.dtype, inexact):
         dt = res.dtype


### PR DESCRIPTION
Specifying the expected and observed shapes, when they are in mismatch, is very useful for debugging the problem, especially when scipy is interacted through a 3rd party library rather than directly.
