### PR TITLE
Enhancement to binned_statistic: option to unraveled returned bin-number mappings, and able to pass multiple data arrays at once

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 import warnings
+import __builtin__
 
 import numpy as np
 from scipy._lib.six import callable
@@ -473,17 +474,17 @@ def binned_statistic_dd(sample, values, statistic='mean',
     else:
         smin = np.zeros(Ndim)
         smax = np.zeros(Ndim)
-        for i in np.arange(Ndim):
+        for i in __builtin__.range(Ndim):
             smin[i], smax[i] = range[i]
 
     # Make sure the bins have a finite width.
-    for i in np.arange(len(smin)):
+    for i in __builtin__.range(len(smin)):
         if smin[i] == smax[i]:
             smin[i] = smin[i] - .5
             smax[i] = smax[i] + .5
 
     # Create edge arrays
-    for i in np.arange(Ndim):
+    for i in __builtin__.range(Ndim):
         if np.isscalar(bins[i]):
             nbin[i] = bins[i] + 2  # +2 for outlier bins
             edges[i] = np.linspace(smin[i], smax[i], nbin[i] - 1)
@@ -496,13 +497,13 @@ def binned_statistic_dd(sample, values, statistic='mean',
 
     # Compute the bin number each sample falls into, in each dimension
     sampBin = {}
-    for i in np.arange(Ndim):
+    for i in __builtin__.range(Ndim):
         sampBin[i] = np.digitize(sample[:, i], edges[i])
 
     # Using `digitize`, values that fall on an edge are put in the right bin.
     # For the rightmost bin, we want values equal to the right
     # edge to be counted in the last bin, and not as an outlier.
-    for i in np.arange(Ndim):
+    for i in __builtin__.range(Ndim):
         # Find the rounding precision
         decimal = int(-np.log10(dedges[i].min())) + 6
         # Find which points are on the rightmost edge.
@@ -515,7 +516,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
     ni = nbin.argsort()
     # `binnumbers` is which bin (in linearized `Ndim` space) each sample goes
     binnumbers = np.zeros(Dlen, int)
-    for i in np.arange(0, Ndim - 1):
+    for i in __builtin__.range(0, Ndim - 1):
         binnumbers += sampBin[ni[i]] * nbin[ni[i + 1:]].prod()
     binnumbers += sampBin[ni[-1]]
 
@@ -525,14 +526,14 @@ def binned_statistic_dd(sample, values, statistic='mean',
         result.fill(np.nan)
         flatcount = np.bincount(binnumbers, None)
         a = flatcount.nonzero()
-        for vv in range(Vdim):
+        for vv in __builtin__.range(Vdim):
             flatsum = np.bincount(binnumbers, values[vv])
             result[vv, a] = flatsum[a] / flatcount[a]
     elif statistic == 'std':
         result.fill(0)
         flatcount = np.bincount(binnumbers, None)
         a = flatcount.nonzero()
-        for vv in range(Vdim):
+        for vv in __builtin__.range(Vdim):
             flatsum = np.bincount(binnumbers, values[vv])
             flatsum2 = np.bincount(binnumbers, values[vv] ** 2)
             result[vv, a] = np.sqrt(flatsum2[a] / flatcount[a] -
@@ -544,14 +545,14 @@ def binned_statistic_dd(sample, values, statistic='mean',
         result[:, a] = flatcount[np.newaxis, :]
     elif statistic == 'sum':
         result.fill(0)
-        for vv in range(Vdim):
+        for vv in __builtin__.range(Vdim):
             flatsum = np.bincount(binnumbers, values[vv])
             a = np.arange(len(flatsum))
             result[vv, a] = flatsum
     elif statistic == 'median':
         result.fill(np.nan)
         for i in np.unique(binnumbers):
-            for vv in range(Vdim):
+            for vv in __builtin__.range(Vdim):
                 result[vv, i] = np.median(values[vv, binnumbers == i])
     elif callable(statistic):
         with warnings.catch_warnings():
@@ -565,13 +566,13 @@ def binned_statistic_dd(sample, values, statistic='mean',
             np.seterr(**old)
         result.fill(null)
         for i in np.unique(binnumbers):
-            for vv in range(Vdim):
+            for vv in __builtin__.range(Vdim):
                 result[vv, i] = statistic(values[vv, binnumbers == i])
 
     # Shape into a proper matrix
     result = result.reshape(np.append(Vdim, np.sort(nbin)))
 
-    for i in np.arange(nbin.size):
+    for i in __builtin__.range(nbin.size):
         j = ni.argsort()[i]
         # Accomodate the extra `Vdim` dimension-zero with `+1`
         result = result.swapaxes(i+1, j+1)

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -460,7 +460,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
 
     # Store initial shape of `values` to preserve it in the output
     values = np.asarray(values)
-    inValuesShape = list(values.shape)
+    input_shape = list(values.shape)
     # Make sure that `values` is 2D to iterate over rows
     values = np.atleast_2d(values)
     Vdim, Vlen = values.shape
@@ -606,6 +606,6 @@ def binned_statistic_dd(sample, values, statistic='mean',
         raise RuntimeError('Internal Shape Error')
 
     # Reshape to have output (`reulst`) match input (`values`) shape
-    result = result.reshape(inValuesShape[:-1] + list(nbin-2))
+    result = result.reshape(input_shape[:-1] + list(nbin-2))
 
     return BinnedStatisticddResult(result, edges, binnumbers)

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -12,26 +12,28 @@ __all__ = ['binned_statistic',
 
 
 BinnedStatisticResult = namedtuple('BinnedStatisticResult',
-                                   ('statistic', 'bin_edges', 'binnumber'))
+                                   ('statistic', 'bin_edges', 'binnumbers))
 
 
 def binned_statistic(x, values, statistic='mean',
                      bins=10, range=None):
     """
-    Compute a binned statistic for a set of data.
+    Compute a binned statistic for one or more sets of data.
 
     This is a generalization of a histogram function.  A histogram divides
     the space into bins, and returns the count of the number of points in
     each bin.  This function allows the computation of the sum, mean, median,
-    or other statistic of the values within each bin.
+    or other statistic of the values (or set of values) within each bin.
 
     Parameters
     ----------
-    x : array_like
+    x : (N,) array_like
         A sequence of values to be binned.
-    values : array_like
-        The values on which the statistic will be computed.  This must be
-        the same shape as `x`.
+    values : (N,) array_like or list of (N,) array_like
+        The data on which the statistic will be computed.  This must be
+        the same shape as `x`, or a list of sequences - each the same shape as
+        `x`.  If `values` is a list of sequences, the statistic will be computed
+        on each independently.
     statistic : string or callable, optional
         The statistic to compute (default is 'mean').
         The following statistics are available:
@@ -56,7 +58,8 @@ def binned_statistic(x, values, statistic='mean',
         bin edges, including the rightmost edge, allowing for non-uniform bin
         widths.  Values in `x` that are smaller than lowest bin edge are
         assigned to bin number 0, values beyond the highest bin are assigned to
-        ``bins[-1]``.
+        ``bins[-1]``.  If the bin edges are specified, the number of bins will
+        be, (nx = len(bins)-1).
     range : (float, float) or [(float, float)], optional
         The lower and upper range of the bins.  If not provided, range
         is simply ``(x.min(), x.max())``.  Values outside the range are
@@ -68,7 +71,7 @@ def binned_statistic(x, values, statistic='mean',
         The values of the selected statistic in each bin.
     bin_edges : array of dtype float
         Return the bin edges ``(length(statistic)+1)``.
-    binnumber : 1-D ndarray of ints
+    binnumbers: 1-D ndarray of ints
         Indices of the bins (corresponding to `bin_edges`) in which each value
         of `x` belongs.  Same length as `values`.
 
@@ -102,7 +105,7 @@ def binned_statistic(x, values, statistic='mean',
 
     >>> windspeed = 8 * np.random.rand(500)
     >>> boatspeed = .3 * windspeed**.5 + .2 * np.random.rand(500)
-    >>> bin_means, bin_edges, binnumber = stats.binned_statistic(windspeed,
+    >>> bin_means, bin_edges, binnumbers= stats.binned_statistic(windspeed,
     ...                 boatspeed, statistic='median', bins=[1,2,3,4,5,6,7])
     >>> plt.figure()
     >>> plt.plot(windspeed, boatspeed, 'b.', label='raw data')
@@ -110,12 +113,12 @@ def binned_statistic(x, values, statistic='mean',
     ...            label='binned statistic of data')
     >>> plt.legend()
 
-    Now we can use ``binnumber`` to select all datapoints with a windspeed
+    Now we can use ``binnumbers`` to select all datapoints with a windspeed
     below 1:
 
-    >>> low_boatspeed = boatspeed[binnumber == 0]
+    >>> low_boatspeed = boatspeed[binnumbers == 0]
 
-    As a final example, we will use ``bin_edges`` and ``binnumber`` to make a
+    As a final example, we will use ``bin_edges`` and ``binnumbers`` to make a
     plot of a distribution that shows the mean and distribution around that
     mean per bin, on top of a regular histogram and the probability
     distribution function:
@@ -124,7 +127,7 @@ def binned_statistic(x, values, statistic='mean',
     >>> x_pdf = stats.maxwell.pdf(x)
     >>> samples = stats.maxwell.rvs(size=10000)
 
-    >>> bin_means, bin_edges, binnumber = stats.binned_statistic(x, x_pdf,
+    >>> bin_means, bin_edges, binnumbers = stats.binned_statistic(x, x_pdf,
     ...         statistic='mean', bins=25)
     >>> bin_width = (bin_edges[1] - bin_edges[0])
     >>> bin_centers = bin_edges[1:] - bin_width/2
@@ -135,7 +138,7 @@ def binned_statistic(x, values, statistic='mean',
     >>> plt.plot(x, x_pdf, 'r-', label='analytical pdf')
     >>> plt.hlines(bin_means, bin_edges[:-1], bin_edges[1:], colors='g', lw=2,
     ...            label='binned statistic of data')
-    >>> plt.plot((binnumber - 0.5) * bin_width, x_pdf, 'g.', alpha=0.5)
+    >>> plt.plot((binnumbers - 0.5) * bin_width, x_pdf, 'g.', alpha=0.5)
     >>> plt.legend(fontsize=10)
     >>> plt.show()
 
@@ -152,26 +155,26 @@ def binned_statistic(x, values, statistic='mean',
         if len(range) == 2:
             range = [range]
 
-    medians, edges, binnumber = binned_statistic_dd([x], values, statistic,
+    medians, edges, binnumbers = binned_statistic_dd([x], values, statistic,
                                                     bins, range)
 
-    return BinnedStatisticResult(medians, edges[0], binnumber)
+    return BinnedStatisticResult(medians, edges[0], binnumbers)
 
 
 BinnedStatistic2dResult = namedtuple('BinnedStatistic2dResult',
-                                     ('statistic', 'x_edge', 'y_edge',
-                                      'binnumber'))
+                                     ('statistic', 'x_edges', 'y_edges',
+                                      'binnumbers'))
 
 
 def binned_statistic_2d(x, y, values, statistic='mean',
-                        bins=10, range=None):
+                        bins=10, range=None, expand_binnumbers=False):
     """
-    Compute a bidimensional binned statistic for a set of data.
+    Compute a bidimensional binned statistic for one or more sets of data.
 
     This is a generalization of a histogram2d function.  A histogram divides
     the space into bins, and returns the count of the number of points in
     each bin.  This function allows the computation of the sum, mean, median,
-    or other statistic of the values within each bin.
+    or other statistic of the values (or set of values) within each bin.
 
     Parameters
     ----------
@@ -179,9 +182,11 @@ def binned_statistic_2d(x, y, values, statistic='mean',
         A sequence of values to be binned along the first dimension.
     y : (N,) array_like
         A sequence of values to be binned along the second dimension.
-    values : (N,) array_like
-        The values on which the statistic will be computed.  This must be
-        the same shape as `x`.
+    values : (N,) array_like or list of (N,) array_like
+        The data on which the statistic will be computed.  This must be
+        the same shape as `x`, or a list of sequences - each with the same
+        shape as `x`.  If `values` is such a list, the statistic will be
+        computed on each independently.
     statistic : string or callable, optional
         The statistic to compute (default is 'mean').
         The following statistics are available:
@@ -216,21 +221,34 @@ def binned_statistic_2d(x, y, values, statistic='mean',
         (if not specified explicitly in the `bins` parameters):
         [[xmin, xmax], [ymin, ymax]]. All values outside of this range will be
         considered outliers and not tallied in the histogram.
+    expand_binnumbers : bool, optional
+        .. versionadded:: 0.17.0
+        'False' (default): the returned `binnumbers` is a shape (N,) array of
+        linearized bin indices.
+        'True': the returned `binnumbers` is 'unraveled' into a shape (2,N)
+        ndarray, where each row gives the bin numbers in the corresponding
+        dimension.
+        See the `binnumbers` returned value.
 
     Returns
     -------
     statistic : (nx, ny) ndarray
-        The values of the selected statistic in each two-dimensional bin
+        The values of the selected statistic in each two-dimensional bin.
     x_edges : (nx + 1) ndarray
         The bin edges along the first dimension.
     y_edges : (ny + 1) ndarray
         The bin edges along the second dimension.
-    x_bins : 1-D ndarray of ints
-        Indices of the bins in the first dimension (bins with `x_edges`) in
-        which each value of `x` belongs.  Same length as `values`.
-    y_bins : 1-D ndarray of ints
-        Indices of the bins in the second dimension (bins with `y_edges`) in
-        which each value of `y` belongs.  Same length as `values`.
+    binnumbers : (N,) array of ints or (D,N) ndarray of ints
+        This assigns to each element of `sample` an integer that represents the
+        bin in which this observation falls.  The representation depends on the
+        `expand_binnumbers` argument.
+        If 'False' (default): The returned `binnumbers` is a shape (N,) array
+        of linearized indices mapping each element of `sample` to its
+        corresponding bin (using row-major ordering).
+        If 'True': The returned `binnumbers` is a shape (2,N) ndarray where
+        each row indicates where the elements of `sample` should be inserted,
+        into the `x_edges` and `y_edges` arrays respectively, so as to keep
+        the arrays sorted.
 
 
     See Also
@@ -254,19 +272,19 @@ def binned_statistic_2d(x, y, values, statistic='mean',
         xedges = yedges = np.asarray(bins, float)
         bins = [xedges, yedges]
 
-    medians, edges, binnumber = binned_statistic_dd([x, y], values, statistic,
+    medians, edges, binnumbers = binned_statistic_dd([x, y], values, statistic,
                                                     bins, range)
 
-    return BinnedStatistic2dResult(medians, edges[0], edges[1], binnumber)
+    return BinnedStatistic2dResult(medians, edges[0], edges[1], binnumbers)
 
 
 BinnedStatisticddResult = namedtuple('BinnedStatisticddResult',
                                      ('statistic', 'bin_edges',
-                                      'binnumber'))
+                                      'binnumbers'))
 
 
 def binned_statistic_dd(sample, values, statistic='mean',
-                        bins=10, range=None):
+                        bins=10, range=None, expand_binnumbers=False):
     """
     Compute a multidimensional binned statistic for a set of data.
 
@@ -302,7 +320,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
             represented by function([]), or NaN if this returns an error.
 
     bins : sequence or int, optional
-        The bin specification:
+        The bin specification must be in one of the following forms:
 
           * A sequence of arrays describing the bin edges along each dimension.
           * The number of bins for each dimension (nx, ny, ... = bins).
@@ -312,6 +330,14 @@ def binned_statistic_dd(sample, values, statistic='mean',
         A sequence of lower and upper bin edges to be used if the edges are
         not given explicitely in `bins`. Defaults to the minimum and maximum
         values along each dimension.
+    expand_binnumbers : bool, optional
+        .. versionadded:: 0.17.0
+        'False' (default): the returned `binnumbers` is a shape (N,) array of
+        linearized bin indices.
+        'True': the returned `binnumbers` is 'unraveled' into a shape (D,N)
+        ndarray, where each row gives the bin numbers in the corresponding
+        dimension.
+        See the `binnumbers` returned value.
 
     Returns
     -------
@@ -320,10 +346,17 @@ def binned_statistic_dd(sample, values, statistic='mean',
     bin_edges : list of ndarrays
         A list of D arrays describing the (nxi + 1) bin edges for each
         dimension.
-    binnumber : list of ndarrays of ints
-        A list of D arrays indicating in each dimension where the elements of
-        `sample` should be inserted into the corresponding `bin_edges` array
-        so as to keep the array sorted.
+    binnumbers : (N,) array of ints or (D,N) ndarray of ints
+        This assigns to each element of `sample` an integer that represents the
+        bin in which this observation falls.  The representation depends on the
+        `expand_binnumbers` argument.
+        If 'False' (default): The returned `binnumbers` is a shape (N,) array
+        of linearized indices mapping each element of `sample` to its
+        corresponding bin (using row-major ordering).
+        If 'True': The returned `binnumbers` is a shape (D,N) ndarray where
+        each row indicates where the elements of `sample` should be inserted
+        into the corresponding `bin_edges` array so as to keep the array
+        sorted.
 
     See Also
     --------
@@ -343,12 +376,25 @@ def binned_statistic_dd(sample, values, statistic='mean',
     # `Dlen` is the length of elements along each dimension.
     # This code is based on np.histogramdd
     try:
-        # Sample is an ND-array.
+        # `sample` is an ND-array.
         Dlen, Ndim = sample.shape
     except (AttributeError, ValueError):
-        # Sample is a sequence of 1D arrays.
+        # `sample` is a sequence of 1D arrays.
         sample = np.atleast_2d(sample).T
         Dlen, Ndim = sample.shape
+
+    try:
+        # `values` is an ND-array.
+        Vdim, Vlen = values.shape
+    except (AttributeError, ValueError):
+        # Sample is a sequence of 1D arrays.
+        values = np.atleast_2d(values)
+        Vdim, Vlen = values.shape
+
+    # Make sure `values` match `sample`
+    if(Vlen != Dlen):
+        raise AttributeError('The number of `values` elements must match the'
+                             'length of each `sample` dimension.')
 
     nbin = np.empty(Ndim, int)    # Number of bins in each dimension
     edges = Ndim * [None]         # Bin edges for each dim (will be 2D array)
@@ -410,42 +456,46 @@ def binned_statistic_dd(sample, values, statistic='mean',
 
     # Compute the sample indices in the flattened statistic matrix.
     ni = nbin.argsort()
-    # `xy` is which bin (in `Ndim` space) each sample goes
-    xy = np.zeros(Dlen, int)
+    # `binnumbers` is which bin (in linearized `Ndim` space) each sample goes
+    binnumbers = np.zeros(Dlen, int)
     for i in np.arange(0, Ndim - 1):
-        xy += sampBin[ni[i]] * nbin[ni[i + 1:]].prod()
-    xy += sampBin[ni[-1]]
+        binnumbers += sampBin[ni[i]] * nbin[ni[i + 1:]].prod()
+    binnumbers += sampBin[ni[-1]]
 
-    result = np.empty(nbin.prod(), float)
+    result = np.empty([Vdim, nbin.prod()], float)
 
     if statistic == 'mean':
         result.fill(np.nan)
-        flatcount = np.bincount(xy, None)
-        flatsum = np.bincount(xy, values)
+        flatcount = np.bincount(binnumbers, None)
         a = flatcount.nonzero()
-        result[a] = flatsum[a] / flatcount[a]
+        for vv in xrange(Vdim):
+            flatsum = np.bincount(binnumbers, values[vv])
+            result[vv, a] = flatsum[a] / flatcount[a]
     elif statistic == 'std':
         result.fill(0)
-        flatcount = np.bincount(xy, None)
-        flatsum = np.bincount(xy, values)
-        flatsum2 = np.bincount(xy, values ** 2)
+        flatcount = np.bincount(binnumbers, None)
         a = flatcount.nonzero()
-        result[a] = np.sqrt(flatsum2[a] / flatcount[a] -
-                            (flatsum[a] / flatcount[a]) ** 2)
+        for vv in xrange(Vdim):
+            flatsum = np.bincount(binnumbers, values[vv])
+            flatsum2 = np.bincount(binnumbers, values[vv] ** 2)
+            result[vv, a] = np.sqrt(flatsum2[a] / flatcount[a] -
+                                    (flatsum[a] / flatcount[a]) ** 2)
     elif statistic == 'count':
         result.fill(0)
-        flatcount = np.bincount(xy, None)
+        flatcount = np.bincount(binnumbers, None)
         a = np.arange(len(flatcount))
-        result[a] = flatcount
+        result[:, a] = flatcount[np.newaxis, :]
     elif statistic == 'sum':
         result.fill(0)
-        flatsum = np.bincount(xy, values)
-        a = np.arange(len(flatsum))
-        result[a] = flatsum
+        for vv in xrange(Vdim):
+            flatsum = np.bincount(binnumbers, values[vv])
+            a = np.arange(len(flatsum))
+            result[vv, a] = flatsum
     elif statistic == 'median':
         result.fill(np.nan)
-        for i in np.unique(xy):
-            result[i] = np.median(values[xy == i])
+        for i in np.unique(binnumbers):
+            for vv in xrange(Vdim):
+                result[vv, i] = np.median(values[vv, binnumbers == i])
     elif callable(statistic):
         with warnings.catch_warnings():
             # Numpy generates a warnings for mean/std/... with empty list
@@ -457,24 +507,31 @@ def binned_statistic_dd(sample, values, statistic='mean',
                 null = np.nan
             np.seterr(**old)
         result.fill(null)
-        for i in np.unique(xy):
-            result[i] = statistic(values[xy == i])
+        for i in np.unique(binnumbers):
+            for vv in xrange(Vdim):
+                result[vv, i] = statistic(values[vv, binnumbers == i])
 
     # Shape into a proper matrix
-    result = result.reshape(np.sort(nbin))
+    result = result.reshape(np.append(Vdim, np.sort(nbin)))
+
     for i in np.arange(nbin.size):
         j = ni.argsort()[i]
-        result = result.swapaxes(i, j)
+        # Accomodate the extra `Vdim` dimension-zero with `+1`
+        result = result.swapaxes(i+1, j+1)
         ni[i], ni[j] = ni[j], ni[i]
 
     # Remove outliers (indices 0 and -1 for each dimension).
-    core = Ndim * [slice(1, -1)]
+    core = [slice(None)] + Ndim * [slice(1, -1)]
     result = result[core]
 
-    # Unravel binnumbers into list, with a binnumber array for each dimension
-    binnumber = np.asarray(np.unravel_index(xy, nbin))
+    # Unravel binnumbers into an ndarray, each row the bins for each dimension
+    if(expand_binnumbers and Ndim > 1):
+        binnumbers = np.asarray(np.unravel_index(binnumbers, nbin))
 
-    if (result.shape != nbin - 2).any():
+    if np.any(result.shape[1:] != nbin - 2):
         raise RuntimeError('Internal Shape Error')
 
-    return BinnedStatisticddResult(result, edges, binnumber)
+    # Remove excess dimension-zero if ``Vdim == 1``
+    result = result.squeeze()
+
+    return BinnedStatisticddResult(result, edges, binnumbers)

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -13,7 +13,7 @@ __all__ = ['binned_statistic',
 
 
 BinnedStatisticResult = namedtuple('BinnedStatisticResult',
-                                   ('statistic', 'bin_edges', 'binnumbers'))
+                                   ('statistic', 'bin_edges', 'binnumber'))
 
 
 def binned_statistic(x, values, statistic='mean',
@@ -114,7 +114,8 @@ def binned_statistic(x, values, statistic='mean',
 
     >>> stats.binned_statistic([1, 2, 1, 2, 4], np.arange(5), statistic='mean',
     ...                        bins=3)
-    (array([ 1.,  2.,  4.]), array([ 1.,  2.,  3.,  4.]), array([1, 2, 1, 2, 3]))
+    (array([ 1.,  2.,  4.]), array([ 1.,  2.,  3.,  4.]),
+        array([1, 2, 1, 2, 3]))
 
     As a second example, we now generate some random data of sailing boat speed
     as a function of wind speed, and then determine how fast our boat is for
@@ -150,8 +151,8 @@ def binned_statistic(x, values, statistic='mean',
     >>> bin_centers = bin_edges[1:] - bin_width/2
 
     >>> plt.figure()
-    >>> plt.hist(samples, bins=50, normed=True, histtype='stepfilled', alpha=0.2,
-    ...          label='histogram of data')
+    >>> plt.hist(samples, bins=50, normed=True, histtype='stepfilled',
+    ...          alpha=0.2, label='histogram of data')
     >>> plt.plot(x, x_pdf, 'r-', label='analytical pdf')
     >>> plt.hlines(bin_means, bin_edges[:-1], bin_edges[1:], colors='g', lw=2,
     ...            label='binned statistic of data')
@@ -179,8 +180,8 @@ def binned_statistic(x, values, statistic='mean',
 
 
 BinnedStatistic2dResult = namedtuple('BinnedStatistic2dResult',
-                                     ('statistic', 'x_edges', 'y_edges',
-                                      'binnumbers'))
+                                     ('statistic', 'x_edge', 'y_edge',
+                                      'binnumber'))
 
 
 def binned_statistic_2d(x, y, values, statistic='mean',
@@ -227,11 +228,11 @@ def binned_statistic_2d(x, y, values, statistic='mean',
 
           * the number of bins for the two dimensions (nx = ny = bins),
           * the number of bins in each dimension (nx, ny = bins),
-          * the bin edges for the two dimensions (x_edges = y_edges = bins),
-          * the bin edges in each dimension (x_edges, y_edges = bins).
+          * the bin edges for the two dimensions (x_edge = y_edge = bins),
+          * the bin edges in each dimension (x_edge, y_edge = bins).
 
         If the bin edges are specified, the number of bins will be,
-        (nx = len(x_edges)-1, ny = len(y_edges)-1).
+        (nx = len(x_edge)-1, ny = len(y_edge)-1).
 
     range : (2,2) array_like, optional
         The leftmost and rightmost edges of the bins along each dimension
@@ -251,9 +252,9 @@ def binned_statistic_2d(x, y, values, statistic='mean',
     -------
     statistic : (nx, ny) ndarray
         The values of the selected statistic in each two-dimensional bin.
-    x_edges : (nx + 1) ndarray
+    x_edge : (nx + 1) ndarray
         The bin edges along the first dimension.
-    y_edges : (ny + 1) ndarray
+    y_edge : (ny + 1) ndarray
         The bin edges along the second dimension.
     binnumbers : (N,) array of ints or (D,N) ndarray of ints
         This assigns to each element of `sample` an integer that represents the
@@ -264,9 +265,9 @@ def binned_statistic_2d(x, y, values, statistic='mean',
         corresponding bin (using row-major ordering).
         If 'True': The returned `binnumbers` is a shape (2,N) ndarray where
         each row indicates where the elements of `sample` should be inserted,
-        into the `x_edges` and `y_edges` arrays respectively, so as to keep
+        into the `x_edge` and `y_edge` arrays respectively, so as to keep
         the arrays sorted.  In each dimension, a binnumber of `i` means the
-        corresponding value is between (D_edges[i-1], D_edges[i]), where 'D' is
+        corresponding value is between (D_edge[i-1], D_edge[i]), where 'D' is
         either 'x' or 'y'.
 
 
@@ -333,7 +334,7 @@ def binned_statistic_2d(x, y, values, statistic='mean',
 
 BinnedStatisticddResult = namedtuple('BinnedStatisticddResult',
                                      ('statistic', 'bin_edges',
-                                      'binnumbers'))
+                                      'binnumber'))
 
 
 def binned_statistic_dd(sample, values, statistic='mean',

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -71,7 +71,7 @@ def binned_statistic(x, values, statistic='mean',
         The values of the selected statistic in each bin.
     bin_edges : array of dtype float
         Return the bin edges ``(length(statistic)+1)``.
-    binnumbers: 1-D ndarray of ints
+    binnumber: 1-D ndarray of ints
         Indices of the bins (corresponding to `bin_edges`) in which each value
         of `x` belongs.  Same length as `values`.  A binnumber of `i` means the
         corresponding value is between (bin_edges[i-1], bin_edges[i]).
@@ -122,7 +122,7 @@ def binned_statistic(x, values, statistic='mean',
 
     >>> windspeed = 8 * np.random.rand(500)
     >>> boatspeed = .3 * windspeed**.5 + .2 * np.random.rand(500)
-    >>> bin_means, bin_edges, binnumbers= stats.binned_statistic(windspeed,
+    >>> bin_means, bin_edges, binnumber = stats.binned_statistic(windspeed,
     ...                 boatspeed, statistic='median', bins=[1,2,3,4,5,6,7])
     >>> plt.figure()
     >>> plt.plot(windspeed, boatspeed, 'b.', label='raw data')
@@ -130,12 +130,12 @@ def binned_statistic(x, values, statistic='mean',
     ...            label='binned statistic of data')
     >>> plt.legend()
 
-    Now we can use ``binnumbers`` to select all datapoints with a windspeed
+    Now we can use ``binnumber`` to select all datapoints with a windspeed
     below 1:
 
-    >>> low_boatspeed = boatspeed[binnumbers == 0]
+    >>> low_boatspeed = boatspeed[binnumber == 0]
 
-    As a final example, we will use ``bin_edges`` and ``binnumbers`` to make a
+    As a final example, we will use ``bin_edges`` and ``binnumber`` to make a
     plot of a distribution that shows the mean and distribution around that
     mean per bin, on top of a regular histogram and the probability
     distribution function:
@@ -144,7 +144,7 @@ def binned_statistic(x, values, statistic='mean',
     >>> x_pdf = stats.maxwell.pdf(x)
     >>> samples = stats.maxwell.rvs(size=10000)
 
-    >>> bin_means, bin_edges, binnumbers = stats.binned_statistic(x, x_pdf,
+    >>> bin_means, bin_edges, binnumber = stats.binned_statistic(x, x_pdf,
     ...         statistic='mean', bins=25)
     >>> bin_width = (bin_edges[1] - bin_edges[0])
     >>> bin_centers = bin_edges[1:] - bin_width/2
@@ -155,7 +155,7 @@ def binned_statistic(x, values, statistic='mean',
     >>> plt.plot(x, x_pdf, 'r-', label='analytical pdf')
     >>> plt.hlines(bin_means, bin_edges[:-1], bin_edges[1:], colors='g', lw=2,
     ...            label='binned statistic of data')
-    >>> plt.plot((binnumbers - 0.5) * bin_width, x_pdf, 'g.', alpha=0.5)
+    >>> plt.plot((binnumber - 0.5) * bin_width, x_pdf, 'g.', alpha=0.5)
     >>> plt.legend(fontsize=10)
     >>> plt.show()
 
@@ -240,12 +240,12 @@ def binned_statistic_2d(x, y, values, statistic='mean',
         considered outliers and not tallied in the histogram.
     expand_binnumbers : bool, optional
         .. versionadded:: 0.17.0
-        'False' (default): the returned `binnumbers` is a shape (N,) array of
+        'False' (default): the returned `binnumber` is a shape (N,) array of
         linearized bin indices.
-        'True': the returned `binnumbers` is 'unraveled' into a shape (2,N)
+        'True': the returned `binnumber` is 'unraveled' into a shape (2,N)
         ndarray, where each row gives the bin numbers in the corresponding
         dimension.
-        See the `binnumbers` returned value, and the `Examples` section.
+        See the `binnumber` returned value, and the `Examples` section.
 
     Returns
     -------
@@ -255,7 +255,7 @@ def binned_statistic_2d(x, y, values, statistic='mean',
         The bin edges along the first dimension.
     y_edge : (ny + 1) ndarray
         The bin edges along the second dimension.
-    binnumbers : (N,) array of ints or (2,N) ndarray of ints
+    binnumber : (N,) array of ints or (2,N) ndarray of ints
         This assigns to each element of `sample` an integer that represents the
         bin in which this observation falls.  The representation depends on the
         `expand_binnumbers` argument.  See `Notes` for details.
@@ -273,13 +273,13 @@ def binned_statistic_2d(x, y, values, statistic='mean',
     but excluding 2) and the second ``[2, 3)``.  The last bin, however, is
     ``[3, 4]``, which *includes* 4.
 
-    `binnumbers`:
+    `binnumber`:
     This returned argument assigns to each element of `sample` an integer that
     represents the bin in which it belongs.  The representation depends on the
     `expand_binnumbers` argument. If 'False' (default): The returned
-    `binnumbers` is a shape (N,) array of linearized indices mapping each
+    `binnumber` is a shape (N,) array of linearized indices mapping each
     element of `sample` to its corresponding bin (using row-major ordering).
-    If 'True': The returned `binnumbers` is a shape (2,N) ndarray where
+    If 'True': The returned `binnumber` is a shape (2,N) ndarray where
     each row indicates bin placements for each dimension respectively.  In each
     dimension, a binnumber of `i` means the corresponding value is between
     (D_edge[i-1], D_edge[i]), where 'D' is either 'x' or 'y'.
@@ -301,10 +301,10 @@ def binned_statistic_2d(x, y, values, statistic='mean',
     array([[ 2.,  1.],
            [ 1.,  0.]])
 
-    The bin in which each sample is placed is given by the `binnumbers`
+    The bin in which each sample is placed is given by the `binnumber`
     returned parameter.  By default, these are the linearized bin indices:
 
-    >>> ret.binnumbers
+    >>> ret.binnumber
     array([5, 6, 5, 9])
 
     The bin indices can also be expanded into separate entries for each
@@ -312,7 +312,7 @@ def binned_statistic_2d(x, y, values, statistic='mean',
 
     >>> ret = stats.binned_statistic_2d(x, y, None, 'count', bins=[binx,biny],
     ...                                 expand_binnumbers=True)
-    >>> ret.binnumbers
+    >>> ret.binnumber
     array([[1, 1, 1, 2],
            [1, 2, 1, 1]])
 
@@ -394,12 +394,12 @@ def binned_statistic_dd(sample, values, statistic='mean',
         values along each dimension.
     expand_binnumbers : bool, optional
         .. versionadded:: 0.17.0
-        'False' (default): the returned `binnumbers` is a shape (N,) array of
+        'False' (default): the returned `binnumber` is a shape (N,) array of
         linearized bin indices.
-        'True': the returned `binnumbers` is 'unraveled' into a shape (D,N)
+        'True': the returned `binnumber` is 'unraveled' into a shape (D,N)
         ndarray, where each row gives the bin numbers in the corresponding
         dimension.
-        See the `binnumbers` returned value, and the `Examples` section of
+        See the `binnumber` returned value, and the `Examples` section of
         `binned_statistic_2d`.
 
     Returns
@@ -409,7 +409,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
     bin_edges : list of ndarrays
         A list of D arrays describing the (nxi + 1) bin edges for each
         dimension.
-    binnumbers : (N,) array of ints or (D,N) ndarray of ints
+    binnumber : (N,) array of ints or (D,N) ndarray of ints
         This assigns to each element of `sample` an integer that represents the
         bin in which this observation falls.  The representation depends on the
         `expand_binnumbers` argument.  See `Notes` for details.
@@ -427,13 +427,13 @@ def binned_statistic_dd(sample, values, statistic='mean',
     ``[1, 2)`` (including 1, but excluding 2) and the second ``[2, 3)``.  The
     last bin, however, is ``[3, 4]``, which *includes* 4.
 
-    `binnumbers`:
+    `binnumber`:
     This returned argument assigns to each element of `sample` an integer that
     represents the bin in which it belongs.  The representation depends on the
     `expand_binnumbers` argument. If 'False' (default): The returned
-    `binnumbers` is a shape (N,) array of linearized indices mapping each
+    `binnumber` is a shape (N,) array of linearized indices mapping each
     element of `sample` to its corresponding bin (using row-major ordering).
-    If 'True': The returned `binnumbers` is a shape (D,N) ndarray where
+    If 'True': The returned `binnumber` is a shape (D,N) ndarray where
     each row indicates bin placements for each dimension respectively.  In each
     dimension, a binnumber of `i` means the corresponding value is between
     (bin_edges[D][i-1], bin_edges[D][i]), for each dimension 'D'.

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -104,8 +104,8 @@ def binned_statistic(x, values, statistic='mean',
     >>> stats.binned_statistic([1, 1, 2, 5, 7], values, 'sum', bins=2)
     (array([ 4. ,  4.5]), array([ 1.,  4.,  7.]), array([1, 1, 1, 2, 2]))
 
-    Multiple arrays of values can also be passed.  The statistic is calculated on
-    each set independently:
+    Multiple arrays of values can also be passed.  The statistic is calculated
+    on each set independently:
 
     >>> values = [[1.0, 1.0, 2.0, 1.5, 3.0], [2.0, 2.0, 4.0, 3.0, 6.0]]
     >>> stats.binned_statistic([1, 1, 2, 5, 7], values, 'sum', bins=2)
@@ -457,6 +457,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
         sample = np.atleast_2d(sample).T
         Dlen, Ndim = sample.shape
 
+    initVdim = np.ndim(values)
     values = np.atleast_2d(values)
     Vdim, Vlen = values.shape
 
@@ -600,7 +601,8 @@ def binned_statistic_dd(sample, values, statistic='mean',
     if np.any(result.shape[1:] != nbin - 2):
         raise RuntimeError('Internal Shape Error')
 
-    # Remove excess dimension-zero if ``Vdim == 1``
-    result = result.squeeze()
+    # Remove excess dimension-zero if `values` was 1-D
+    if(initVdim == 1):
+        result = result.reshape(*(nbin-2))
 
     return BinnedStatisticddResult(result, edges, binnumbers)

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -1,10 +1,9 @@
 from __future__ import division, print_function, absolute_import
 
 import warnings
-import __builtin__
 
 import numpy as np
-from scipy._lib.six import callable
+from scipy._lib.six import callable, xrange
 from collections import namedtuple
 
 __all__ = ['binned_statistic',
@@ -486,17 +485,17 @@ def binned_statistic_dd(sample, values, statistic='mean',
     else:
         smin = np.zeros(Ndim)
         smax = np.zeros(Ndim)
-        for i in __builtin__.range(Ndim):
+        for i in xrange(Ndim):
             smin[i], smax[i] = range[i]
 
     # Make sure the bins have a finite width.
-    for i in __builtin__.range(len(smin)):
+    for i in xrange(len(smin)):
         if smin[i] == smax[i]:
             smin[i] = smin[i] - .5
             smax[i] = smax[i] + .5
 
     # Create edge arrays
-    for i in __builtin__.range(Ndim):
+    for i in xrange(Ndim):
         if np.isscalar(bins[i]):
             nbin[i] = bins[i] + 2  # +2 for outlier bins
             edges[i] = np.linspace(smin[i], smax[i], nbin[i] - 1)
@@ -509,13 +508,13 @@ def binned_statistic_dd(sample, values, statistic='mean',
 
     # Compute the bin number each sample falls into, in each dimension
     sampBin = {}
-    for i in __builtin__.range(Ndim):
+    for i in xrange(Ndim):
         sampBin[i] = np.digitize(sample[:, i], edges[i])
 
     # Using `digitize`, values that fall on an edge are put in the right bin.
     # For the rightmost bin, we want values equal to the right
     # edge to be counted in the last bin, and not as an outlier.
-    for i in __builtin__.range(Ndim):
+    for i in xrange(Ndim):
         # Find the rounding precision
         decimal = int(-np.log10(dedges[i].min())) + 6
         # Find which points are on the rightmost edge.
@@ -528,7 +527,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
     ni = nbin.argsort()
     # `binnumbers` is which bin (in linearized `Ndim` space) each sample goes
     binnumbers = np.zeros(Dlen, int)
-    for i in __builtin__.range(0, Ndim - 1):
+    for i in xrange(0, Ndim - 1):
         binnumbers += sampBin[ni[i]] * nbin[ni[i + 1:]].prod()
     binnumbers += sampBin[ni[-1]]
 
@@ -538,14 +537,14 @@ def binned_statistic_dd(sample, values, statistic='mean',
         result.fill(np.nan)
         flatcount = np.bincount(binnumbers, None)
         a = flatcount.nonzero()
-        for vv in __builtin__.range(Vdim):
+        for vv in xrange(Vdim):
             flatsum = np.bincount(binnumbers, values[vv])
             result[vv, a] = flatsum[a] / flatcount[a]
     elif statistic == 'std':
         result.fill(0)
         flatcount = np.bincount(binnumbers, None)
         a = flatcount.nonzero()
-        for vv in __builtin__.range(Vdim):
+        for vv in xrange(Vdim):
             flatsum = np.bincount(binnumbers, values[vv])
             flatsum2 = np.bincount(binnumbers, values[vv] ** 2)
             result[vv, a] = np.sqrt(flatsum2[a] / flatcount[a] -
@@ -557,14 +556,14 @@ def binned_statistic_dd(sample, values, statistic='mean',
         result[:, a] = flatcount[np.newaxis, :]
     elif statistic == 'sum':
         result.fill(0)
-        for vv in __builtin__.range(Vdim):
+        for vv in xrange(Vdim):
             flatsum = np.bincount(binnumbers, values[vv])
             a = np.arange(len(flatsum))
             result[vv, a] = flatsum
     elif statistic == 'median':
         result.fill(np.nan)
         for i in np.unique(binnumbers):
-            for vv in __builtin__.range(Vdim):
+            for vv in xrange(Vdim):
                 result[vv, i] = np.median(values[vv, binnumbers == i])
     elif callable(statistic):
         with warnings.catch_warnings():
@@ -578,13 +577,13 @@ def binned_statistic_dd(sample, values, statistic='mean',
             np.seterr(**old)
         result.fill(null)
         for i in np.unique(binnumbers):
-            for vv in __builtin__.range(Vdim):
+            for vv in xrange(Vdim):
                 result[vv, i] = statistic(values[vv, binnumbers == i])
 
     # Shape into a proper matrix
     result = result.reshape(np.append(Vdim, np.sort(nbin)))
 
-    for i in __builtin__.range(nbin.size):
+    for i in xrange(nbin.size):
         j = ni.argsort()[i]
         # Accomodate the extra `Vdim` dimension-zero with `+1`
         result = result.swapaxes(i+1, j+1)

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -12,7 +12,7 @@ __all__ = ['binned_statistic',
 
 
 BinnedStatisticResult = namedtuple('BinnedStatisticResult',
-                                   ('statistic', 'bin_edges', 'binnumbers))
+                                   ('statistic', 'bin_edges', 'binnumbers'))
 
 
 def binned_statistic(x, values, statistic='mean',
@@ -155,8 +155,8 @@ def binned_statistic(x, values, statistic='mean',
         if len(range) == 2:
             range = [range]
 
-    medians, edges, binnumbers = binned_statistic_dd([x], values, statistic,
-                                                    bins, range)
+    medians, edges, binnumbers = binned_statistic_dd(
+        [x], values, statistic, bins, range)
 
     return BinnedStatisticResult(medians, edges[0], binnumbers)
 
@@ -272,8 +272,9 @@ def binned_statistic_2d(x, y, values, statistic='mean',
         xedges = yedges = np.asarray(bins, float)
         bins = [xedges, yedges]
 
-    medians, edges, binnumbers = binned_statistic_dd([x, y], values, statistic,
-                                                    bins, range)
+    medians, edges, binnumbers = binned_statistic_dd(
+        [x, y], values, statistic, bins, range,
+        expand_binnumbers=expand_binnumbers)
 
     return BinnedStatistic2dResult(medians, edges[0], edges[1], binnumbers)
 

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -525,14 +525,14 @@ def binned_statistic_dd(sample, values, statistic='mean',
         result.fill(np.nan)
         flatcount = np.bincount(binnumbers, None)
         a = flatcount.nonzero()
-        for vv in xrange(Vdim):
+        for vv in range(Vdim):
             flatsum = np.bincount(binnumbers, values[vv])
             result[vv, a] = flatsum[a] / flatcount[a]
     elif statistic == 'std':
         result.fill(0)
         flatcount = np.bincount(binnumbers, None)
         a = flatcount.nonzero()
-        for vv in xrange(Vdim):
+        for vv in range(Vdim):
             flatsum = np.bincount(binnumbers, values[vv])
             flatsum2 = np.bincount(binnumbers, values[vv] ** 2)
             result[vv, a] = np.sqrt(flatsum2[a] / flatcount[a] -
@@ -544,14 +544,14 @@ def binned_statistic_dd(sample, values, statistic='mean',
         result[:, a] = flatcount[np.newaxis, :]
     elif statistic == 'sum':
         result.fill(0)
-        for vv in xrange(Vdim):
+        for vv in range(Vdim):
             flatsum = np.bincount(binnumbers, values[vv])
             a = np.arange(len(flatsum))
             result[vv, a] = flatsum
     elif statistic == 'median':
         result.fill(np.nan)
         for i in np.unique(binnumbers):
-            for vv in xrange(Vdim):
+            for vv in range(Vdim):
                 result[vv, i] = np.median(values[vv, binnumbers == i])
     elif callable(statistic):
         with warnings.catch_warnings():
@@ -565,7 +565,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
             np.seterr(**old)
         result.fill(null)
         for i in np.unique(binnumbers):
-            for vv in xrange(Vdim):
+            for vv in range(Vdim):
                 result[vv, i] = statistic(values[vv, binnumbers == i])
 
     # Shape into a proper matrix

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -457,13 +457,8 @@ def binned_statistic_dd(sample, values, statistic='mean',
         sample = np.atleast_2d(sample).T
         Dlen, Ndim = sample.shape
 
-    try:
-        # `values` is an ND-array.
-        Vdim, Vlen = values.shape
-    except (AttributeError, ValueError):
-        # Sample is a sequence of 1D arrays.
-        values = np.atleast_2d(values)
-        Vdim, Vlen = values.shape
+    values = np.atleast_2d(values)
+    Vdim, Vlen = values.shape
 
     # Make sure `values` match `sample`
     if(statistic is not 'count' and Vlen != Dlen):

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -30,7 +30,7 @@ def binned_statistic(x, values, statistic='mean',
     ----------
     x : (N,) array_like
         A sequence of values to be binned.
-    values : (N,) array_like or set of (N,) array_like
+    values : (N,) array_like or list of (N,) array_like
         The data on which the statistic will be computed.  This must be
         the same shape as `x`, or a set of sequences - each the same shape as
         `x`.  If `values` is a set of sequences, the statistic will be computed
@@ -104,7 +104,7 @@ def binned_statistic(x, values, statistic='mean',
     >>> stats.binned_statistic([1, 1, 2, 5, 7], values, 'sum', bins=2)
     (array([ 4. ,  4.5]), array([ 1.,  4.,  7.]), array([1, 1, 1, 2, 2]))
 
-    Multiple sets of values can also be passed.  The statistic is calculated on
+    Multiple arrays of values can also be passed.  The statistic is calculated on
     each set independently:
 
     >>> values = [[1.0, 1.0, 2.0, 1.5, 3.0], [2.0, 2.0, 4.0, 3.0, 6.0]]
@@ -256,19 +256,10 @@ def binned_statistic_2d(x, y, values, statistic='mean',
         The bin edges along the first dimension.
     y_edge : (ny + 1) ndarray
         The bin edges along the second dimension.
-    binnumbers : (N,) array of ints or (D,N) ndarray of ints
+    binnumbers : (N,) array of ints or (2,N) ndarray of ints
         This assigns to each element of `sample` an integer that represents the
         bin in which this observation falls.  The representation depends on the
-        `expand_binnumbers` argument.
-        If 'False' (default): The returned `binnumbers` is a shape (N,) array
-        of linearized indices mapping each element of `sample` to its
-        corresponding bin (using row-major ordering).
-        If 'True': The returned `binnumbers` is a shape (2,N) ndarray where
-        each row indicates where the elements of `sample` should be inserted,
-        into the `x_edge` and `y_edge` arrays respectively, so as to keep
-        the arrays sorted.  In each dimension, a binnumber of `i` means the
-        corresponding value is between (D_edge[i-1], D_edge[i]), where 'D' is
-        either 'x' or 'y'.
+        `expand_binnumbers` argument.  See `Notes` for details.
 
 
     See Also
@@ -277,6 +268,22 @@ def binned_statistic_2d(x, y, values, statistic='mean',
 
     Notes
     -----
+    Binedges:
+    All but the last (righthand-most) bin is half-open.  In other words, if
+    `bins` is ``[1, 2, 3, 4]``, then the first bin is ``[1, 2)`` (including 1,
+    but excluding 2) and the second ``[2, 3)``.  The last bin, however, is
+    ``[3, 4]``, which *includes* 4.
+
+    `binnumbers`:
+    This returned argument assigns to each element of `sample` an integer that
+    represents the bin in which it belongs.  The representation depends on the
+    `expand_binnumbers` argument. If 'False' (default): The returned
+    `binnumbers` is a shape (N,) array of linearized indices mapping each
+    element of `sample` to its corresponding bin (using row-major ordering).
+    If 'True': The returned `binnumbers` is a shape (2,N) ndarray where
+    each row indicates bin placements for each dimension respectively.  In each
+    dimension, a binnumber of `i` means the corresponding value is between
+    (D_edge[i-1], D_edge[i]), where 'D' is either 'x' or 'y'.
 
     .. versionadded:: 0.11.0
 
@@ -406,16 +413,8 @@ def binned_statistic_dd(sample, values, statistic='mean',
     binnumbers : (N,) array of ints or (D,N) ndarray of ints
         This assigns to each element of `sample` an integer that represents the
         bin in which this observation falls.  The representation depends on the
-        `expand_binnumbers` argument.
-        If 'False' (default): The returned `binnumbers` is a shape (N,) array
-        of linearized indices mapping each element of `sample` to its
-        corresponding bin (using row-major ordering).
-        If 'True': The returned `binnumbers` is a shape (D,N) ndarray where
-        each row indicates where the elements of `sample` should be inserted
-        into the corresponding `bin_edges` array so as to keep the array
-        sorted.  In each dimension, a binnumber of `i` means the
-        corresponding value is between (D_edges[i-1], D_edges[i]), where 'D' is
-        either 'x' or 'y'.
+        `expand_binnumbers` argument.  See `Notes` for details.
+
 
     See Also
     --------
@@ -423,6 +422,22 @@ def binned_statistic_dd(sample, values, statistic='mean',
 
     Notes
     -----
+    Binedges:
+    All but the last (righthand-most) bin is half-open in each dimension.  In
+    other words, if `bins` is ``[1, 2, 3, 4]``, then the first bin is
+    ``[1, 2)`` (including 1, but excluding 2) and the second ``[2, 3)``.  The
+    last bin, however, is ``[3, 4]``, which *includes* 4.
+
+    `binnumbers`:
+    This returned argument assigns to each element of `sample` an integer that
+    represents the bin in which it belongs.  The representation depends on the
+    `expand_binnumbers` argument. If 'False' (default): The returned
+    `binnumbers` is a shape (N,) array of linearized indices mapping each
+    element of `sample` to its corresponding bin (using row-major ordering).
+    If 'True': The returned `binnumbers` is a shape (D,N) ndarray where
+    each row indicates bin placements for each dimension respectively.  In each
+    dimension, a binnumber of `i` means the corresponding value is between
+    (bin_edges[D][i-1], bin_edges[D][i]), for each dimension 'D'.
 
     .. versionadded:: 0.11.0
 

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -177,7 +177,7 @@ def binned_statistic_2d(x, y, values, statistic='mean',
     ----------
     x : (N,) array_like
         A sequence of values to be binned along the first dimension.
-    y : (M,) array_like
+    y : (N,) array_like
         A sequence of values to be binned along the second dimension.
     values : (N,) array_like
         The values on which the statistic will be computed.  This must be

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -458,7 +458,10 @@ def binned_statistic_dd(sample, values, statistic='mean',
         sample = np.atleast_2d(sample).T
         Dlen, Ndim = sample.shape
 
-    initVdim = np.ndim(values)
+    # Store initial shape of `values` to preserve it in the output
+    values = np.asarray(values)
+    inValuesShape = list(values.shape)
+    # Make sure that `values` is 2D to iterate over rows
     values = np.atleast_2d(values)
     Vdim, Vlen = values.shape
 
@@ -591,7 +594,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
         result = result.swapaxes(i+1, j+1)
         ni[i], ni[j] = ni[j], ni[i]
 
-    # Remove outliers (indices 0 and -1 for each dimension).
+    # Remove outliers (indices 0 and -1 for each bin-dimension).
     core = [slice(None)] + Ndim * [slice(1, -1)]
     result = result[core]
 
@@ -602,8 +605,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
     if np.any(result.shape[1:] != nbin - 2):
         raise RuntimeError('Internal Shape Error')
 
-    # Remove excess dimension-zero if `values` was 1-D
-    if(initVdim == 1):
-        result = result.reshape(*(nbin-2))
+    # Reshape to have output (`reulst`) match input (`values`) shape
+    result = result.reshape(inValuesShape[:-1] + list(nbin-2))
 
     return BinnedStatisticddResult(result, edges, binnumbers)

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -239,13 +239,14 @@ def binned_statistic_2d(x, y, values, statistic='mean',
         [[xmin, xmax], [ymin, ymax]]. All values outside of this range will be
         considered outliers and not tallied in the histogram.
     expand_binnumbers : bool, optional
-        .. versionadded:: 0.17.0
         'False' (default): the returned `binnumber` is a shape (N,) array of
         linearized bin indices.
         'True': the returned `binnumber` is 'unraveled' into a shape (2,N)
         ndarray, where each row gives the bin numbers in the corresponding
         dimension.
         See the `binnumber` returned value, and the `Examples` section.
+
+        .. versionadded:: 0.17.0
 
     Returns
     -------
@@ -393,7 +394,6 @@ def binned_statistic_dd(sample, values, statistic='mean',
         not given explicitely in `bins`. Defaults to the minimum and maximum
         values along each dimension.
     expand_binnumbers : bool, optional
-        .. versionadded:: 0.17.0
         'False' (default): the returned `binnumber` is a shape (N,) array of
         linearized bin indices.
         'True': the returned `binnumber` is 'unraveled' into a shape (D,N)
@@ -401,6 +401,8 @@ def binned_statistic_dd(sample, values, statistic='mean',
         dimension.
         See the `binnumber` returned value, and the `Examples` section of
         `binned_statistic_2d`.
+
+        .. versionadded:: 0.17.0
 
     Returns
     -------

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -35,7 +35,7 @@ class TestBinnedStatistic(object):
         v = self.v
 
         res = binned_statistic(x, v, 'count', bins=10)
-        attributes = ('statistic', 'bin_edges', 'binnumbers')
+        attributes = ('statistic', 'bin_edges', 'binnumber')
         check_named_results(res, attributes)
 
     def test_1d_sum(self):
@@ -138,7 +138,7 @@ class TestBinnedStatistic(object):
         v = self.v
 
         res = binned_statistic_2d(x, y, v, 'count', bins=5)
-        attributes = ('statistic', 'x_edges', 'y_edges', 'binnumbers')
+        attributes = ('statistic', 'x_edge', 'y_edge', 'binnumber')
         check_named_results(res, attributes)
 
     def test_2d_sum(self):
@@ -280,7 +280,7 @@ class TestBinnedStatistic(object):
         v = self.v
 
         res = binned_statistic_dd(X, v, 'count', bins=3)
-        attributes = ('statistic', 'bin_edges', 'binnumbers')
+        attributes = ('statistic', 'bin_edges', 'binnumber')
         check_named_results(res, attributes)
 
     def test_dd_sum(self):

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal, run_module_suite
+from numpy.testing import assert_allclose, run_module_suite
 from scipy.stats import (binned_statistic, binned_statistic_2d,
                          binned_statistic_dd)
 
@@ -27,8 +27,8 @@ class TestBinnedStatistic(object):
         count1, edges1, bc = binned_statistic(x, v, 'count', bins=10)
         count2, edges2 = np.histogram(x, bins=10)
 
-        assert_array_almost_equal(count1, count2)
-        assert_array_almost_equal(edges1, edges2)
+        assert_allclose(count1, count2)
+        assert_allclose(edges1, edges2)
 
     def test_1d_result_attributes(self):
         x = self.x
@@ -45,8 +45,8 @@ class TestBinnedStatistic(object):
         sum1, edges1, bc = binned_statistic(x, v, 'sum', bins=10)
         sum2, edges2 = np.histogram(x, bins=10, weights=v)
 
-        assert_array_almost_equal(sum1, sum2)
-        assert_array_almost_equal(edges1, edges2)
+        assert_allclose(sum1, sum2)
+        assert_allclose(edges1, edges2)
 
     def test_1d_mean(self):
         x = self.x
@@ -55,8 +55,8 @@ class TestBinnedStatistic(object):
         stat1, edges1, bc = binned_statistic(x, v, 'mean', bins=10)
         stat2, edges2, bc = binned_statistic(x, v, np.mean, bins=10)
 
-        assert_array_almost_equal(stat1, stat2)
-        assert_array_almost_equal(edges1, edges2)
+        assert_allclose(stat1, stat2)
+        assert_allclose(edges1, edges2)
 
     def test_1d_std(self):
         x = self.x
@@ -65,8 +65,8 @@ class TestBinnedStatistic(object):
         stat1, edges1, bc = binned_statistic(x, v, 'std', bins=10)
         stat2, edges2, bc = binned_statistic(x, v, np.std, bins=10)
 
-        assert_array_almost_equal(stat1, stat2)
-        assert_array_almost_equal(edges1, edges2)
+        assert_allclose(stat1, stat2)
+        assert_allclose(edges1, edges2)
 
     def test_1d_median(self):
         x = self.x
@@ -75,8 +75,8 @@ class TestBinnedStatistic(object):
         stat1, edges1, bc = binned_statistic(x, v, 'median', bins=10)
         stat2, edges2, bc = binned_statistic(x, v, np.median, bins=10)
 
-        assert_array_almost_equal(stat1, stat2)
-        assert_array_almost_equal(edges1, edges2)
+        assert_allclose(stat1, stat2)
+        assert_allclose(edges1, edges2)
 
     def test_1d_bincode(self):
         x = self.x[:20]
@@ -88,8 +88,8 @@ class TestBinnedStatistic(object):
 
         bcount = [(bc == i).sum() for i in np.unique(bc)]
 
-        assert_array_almost_equal(bc, bc2)
-        assert_array_almost_equal(bcount, count1)
+        assert_allclose(bc, bc2)
+        assert_allclose(bcount, count1)
 
     def test_1d_range_keyword(self):
         # Regression test for gh-3063, range can be (min, max) or [(min, max)]
@@ -101,10 +101,10 @@ class TestBinnedStatistic(object):
         mean_range, bins_range, _ = binned_statistic(x, data, range=[(0, 14)])
         mean_range2, bins_range2, _ = binned_statistic(x, data, range=(0, 14))
 
-        assert_array_almost_equal(mean, mean_range)
-        assert_array_almost_equal(bins, bins_range)
-        assert_array_almost_equal(mean, mean_range2)
-        assert_array_almost_equal(bins, bins_range2)
+        assert_allclose(mean, mean_range)
+        assert_allclose(bins, bins_range)
+        assert_allclose(mean, mean_range2)
+        assert_allclose(bins, bins_range2)
 
     def test_1d_multi_values(self):
         x = self.x
@@ -115,22 +115,23 @@ class TestBinnedStatistic(object):
         stat1w, edges1w, bc1w = binned_statistic(x, w, 'mean', bins=10)
         stat2, edges2, bc2 = binned_statistic(x, [v, w], 'mean', bins=10)
 
-        assert_array_almost_equal(stat2[0], stat1v)
-        assert_array_almost_equal(stat2[1], stat1w)
-        assert_array_almost_equal(edges1v, edges2)
-        assert_array_almost_equal(bc1v, bc2)
+        assert_allclose(stat2[0], stat1v)
+        assert_allclose(stat2[1], stat1w)
+        assert_allclose(edges1v, edges2)
+        assert_allclose(bc1v, bc2)
 
     def test_2d_count(self):
         x = self.x
         y = self.y
         v = self.v
 
-        count1, binx1, biny1, bc = binned_statistic_2d(x, y, v, 'count', bins=5)
+        count1, binx1, biny1, bc = binned_statistic_2d(
+            x, y, v, 'count', bins=5)
         count2, binx2, biny2 = np.histogram2d(x, y, bins=5)
 
-        assert_array_almost_equal(count1, count2)
-        assert_array_almost_equal(binx1, binx2)
-        assert_array_almost_equal(biny1, biny2)
+        assert_allclose(count1, count2)
+        assert_allclose(binx1, binx2)
+        assert_allclose(biny1, biny2)
 
     def test_2d_result_attributes(self):
         x = self.x
@@ -149,9 +150,9 @@ class TestBinnedStatistic(object):
         sum1, binx1, biny1, bc = binned_statistic_2d(x, y, v, 'sum', bins=5)
         sum2, binx2, biny2 = np.histogram2d(x, y, bins=5, weights=v)
 
-        assert_array_almost_equal(sum1, sum2)
-        assert_array_almost_equal(binx1, binx2)
-        assert_array_almost_equal(biny1, biny2)
+        assert_allclose(sum1, sum2)
+        assert_allclose(binx1, binx2)
+        assert_allclose(biny1, biny2)
 
     def test_2d_mean(self):
         x = self.x
@@ -161,19 +162,20 @@ class TestBinnedStatistic(object):
         stat1, binx1, biny1, bc = binned_statistic_2d(x, y, v, 'mean', bins=5)
         stat2, binx2, biny2, bc = binned_statistic_2d(x, y, v, np.mean, bins=5)
 
-        assert_array_almost_equal(stat1, stat2)
-        assert_array_almost_equal(binx1, binx2)
-        assert_array_almost_equal(biny1, biny2)
+        assert_allclose(stat1, stat2)
+        assert_allclose(binx1, binx2)
+        assert_allclose(biny1, biny2)
 
     def test_2d_mean_unicode(self):
         x = self.x
         y = self.y
         v = self.v
-        stat1, binx1, biny1, bc = binned_statistic_2d(x, y, v, u('mean'), bins=5)
+        stat1, binx1, biny1, bc = binned_statistic_2d(
+            x, y, v, u('mean'), bins=5)
         stat2, binx2, biny2, bc = binned_statistic_2d(x, y, v, np.mean, bins=5)
-        assert_array_almost_equal(stat1, stat2)
-        assert_array_almost_equal(binx1, binx2)
-        assert_array_almost_equal(biny1, biny2)
+        assert_allclose(stat1, stat2)
+        assert_allclose(binx1, binx2)
+        assert_allclose(biny1, biny2)
 
     def test_2d_std(self):
         x = self.x
@@ -183,36 +185,39 @@ class TestBinnedStatistic(object):
         stat1, binx1, biny1, bc = binned_statistic_2d(x, y, v, 'std', bins=5)
         stat2, binx2, biny2, bc = binned_statistic_2d(x, y, v, np.std, bins=5)
 
-        assert_array_almost_equal(stat1, stat2)
-        assert_array_almost_equal(binx1, binx2)
-        assert_array_almost_equal(biny1, biny2)
+        assert_allclose(stat1, stat2)
+        assert_allclose(binx1, binx2)
+        assert_allclose(biny1, biny2)
 
     def test_2d_median(self):
         x = self.x
         y = self.y
         v = self.v
 
-        stat1, binx1, biny1, bc = binned_statistic_2d(x, y, v, 'median', bins=5)
-        stat2, binx2, biny2, bc = binned_statistic_2d(x, y, v, np.median, bins=5)
+        stat1, binx1, biny1, bc = binned_statistic_2d(
+            x, y, v, 'median', bins=5)
+        stat2, binx2, biny2, bc = binned_statistic_2d(
+            x, y, v, np.median, bins=5)
 
-        assert_array_almost_equal(stat1, stat2)
-        assert_array_almost_equal(binx1, binx2)
-        assert_array_almost_equal(biny1, biny2)
+        assert_allclose(stat1, stat2)
+        assert_allclose(binx1, binx2)
+        assert_allclose(biny1, biny2)
 
     def test_2d_bincode(self):
         x = self.x[:20]
         y = self.y[:20]
         v = self.v[:20]
 
-        count1, binx1, biny1, bc = binned_statistic_2d(x, y, v, 'count', bins=3)
+        count1, binx1, biny1, bc = binned_statistic_2d(
+            x, y, v, 'count', bins=3)
         bc2 = np.array([17, 11, 6, 16, 11, 17, 18, 17, 17, 7, 6, 18, 16,
                         6, 11, 16, 6, 6, 11, 8])
 
         bcount = [(bc == i).sum() for i in np.unique(bc)]
 
-        assert_array_almost_equal(bc, bc2)
+        assert_allclose(bc, bc2)
         count1adj = count1[count1.nonzero()]
-        assert_array_almost_equal(bcount, count1adj)
+        assert_allclose(bcount, count1adj)
 
     def test_2d_multi_values(self):
         x = self.x
@@ -227,11 +232,11 @@ class TestBinnedStatistic(object):
         stat2, binx2, biny2, bc2 = binned_statistic_2d(
             x, y, [v, w], 'mean', bins=8)
 
-        assert_array_almost_equal(stat2[0], stat1v)
-        assert_array_almost_equal(stat2[1], stat1w)
-        assert_array_almost_equal(binx1v, binx2)
-        assert_array_almost_equal(biny1w, biny2)
-        assert_array_almost_equal(bc1v, bc2)
+        assert_allclose(stat2[0], stat1v)
+        assert_allclose(stat2[1], stat1w)
+        assert_allclose(binx1v, binx2)
+        assert_allclose(biny1w, biny2)
+        assert_allclose(bc1v, bc2)
 
     def test_2d_binnumbers_unraveled(self):
         x = self.x
@@ -258,12 +263,12 @@ class TestBinnedStatistic(object):
         bcx4[x == x.min()] += 1
         bcy4[y == y.min()] += 1
 
-        assert_array_almost_equal(bcx, bc2[0])
-        assert_array_almost_equal(bcy, bc2[1])
-        assert_array_almost_equal(bcx4, bc2[0])
-        assert_array_almost_equal(bcy4, bc2[1])
-        assert_array_almost_equal(bcx3, bc2[0])
-        assert_array_almost_equal(bcy3, bc2[1])
+        assert_allclose(bcx, bc2[0])
+        assert_allclose(bcy, bc2[1])
+        assert_allclose(bcx4, bc2[0])
+        assert_allclose(bcy4, bc2[1])
+        assert_allclose(bcx3, bc2[0])
+        assert_allclose(bcy3, bc2[1])
 
     def test_dd_count(self):
         X = self.X
@@ -272,8 +277,8 @@ class TestBinnedStatistic(object):
         count1, edges1, bc = binned_statistic_dd(X, v, 'count', bins=3)
         count2, edges2 = np.histogramdd(X, bins=3)
 
-        assert_array_almost_equal(count1, count2)
-        assert_array_almost_equal(edges1, edges2)
+        assert_allclose(count1, count2)
+        assert_allclose(edges1, edges2)
 
     def test_dd_result_attributes(self):
         X = self.X
@@ -290,8 +295,8 @@ class TestBinnedStatistic(object):
         sum1, edges1, bc = binned_statistic_dd(X, v, 'sum', bins=3)
         sum2, edges2 = np.histogramdd(X, bins=3, weights=v)
 
-        assert_array_almost_equal(sum1, sum2)
-        assert_array_almost_equal(edges1, edges2)
+        assert_allclose(sum1, sum2)
+        assert_allclose(edges1, edges2)
 
     def test_dd_mean(self):
         X = self.X
@@ -300,8 +305,8 @@ class TestBinnedStatistic(object):
         stat1, edges1, bc = binned_statistic_dd(X, v, 'mean', bins=3)
         stat2, edges2, bc = binned_statistic_dd(X, v, np.mean, bins=3)
 
-        assert_array_almost_equal(stat1, stat2)
-        assert_array_almost_equal(edges1, edges2)
+        assert_allclose(stat1, stat2)
+        assert_allclose(edges1, edges2)
 
     def test_dd_std(self):
         X = self.X
@@ -310,8 +315,8 @@ class TestBinnedStatistic(object):
         stat1, edges1, bc = binned_statistic_dd(X, v, 'std', bins=3)
         stat2, edges2, bc = binned_statistic_dd(X, v, np.std, bins=3)
 
-        assert_array_almost_equal(stat1, stat2)
-        assert_array_almost_equal(edges1, edges2)
+        assert_allclose(stat1, stat2)
+        assert_allclose(edges1, edges2)
 
     def test_dd_median(self):
         X = self.X
@@ -320,8 +325,8 @@ class TestBinnedStatistic(object):
         stat1, edges1, bc = binned_statistic_dd(X, v, 'median', bins=3)
         stat2, edges2, bc = binned_statistic_dd(X, v, np.median, bins=3)
 
-        assert_array_almost_equal(stat1, stat2)
-        assert_array_almost_equal(edges1, edges2)
+        assert_allclose(stat1, stat2)
+        assert_allclose(edges1, edges2)
 
     def test_dd_bincode(self):
         X = self.X[:20]
@@ -333,9 +338,9 @@ class TestBinnedStatistic(object):
 
         bcount = [(bc == i).sum() for i in np.unique(bc)]
 
-        assert_array_almost_equal(bc, bc2)
+        assert_allclose(bc, bc2)
         count1adj = count1[count1.nonzero()]
-        assert_array_almost_equal(bcount, count1adj)
+        assert_allclose(bcount, count1adj)
 
     def test_dd_multi_values(self):
         X = self.X
@@ -346,11 +351,11 @@ class TestBinnedStatistic(object):
         stat1w, edges1w, bc1w = binned_statistic_dd(X, w, np.std, bins=8)
         stat2, edges2, bc2 = binned_statistic_dd(X, [v, w], np.std, bins=8)
 
-        assert_array_almost_equal(stat2[0], stat1v)
-        assert_array_almost_equal(stat2[1], stat1w)
-        assert_array_almost_equal(edges1v, edges2)
-        assert_array_almost_equal(edges1w, edges2)
-        assert_array_almost_equal(bc1v, bc2)
+        assert_allclose(stat2[0], stat1v)
+        assert_allclose(stat2[1], stat1w)
+        assert_allclose(edges1v, edges2)
+        assert_allclose(edges1w, edges2)
+        assert_allclose(bc1v, bc2)
 
     def test_dd_binnumbers_unraveled(self):
         X = self.X
@@ -363,9 +368,9 @@ class TestBinnedStatistic(object):
         stat2, edges2, bc2 = binned_statistic_dd(
             X, v, 'mean', bins=10, expand_binnumbers=True)
 
-        assert_array_almost_equal(bcx, bc2[0])
-        assert_array_almost_equal(bcy, bc2[1])
-        assert_array_almost_equal(bcz, bc2[2])
+        assert_allclose(bcx, bc2[0])
+        assert_allclose(bcy, bc2[1])
+        assert_allclose(bcz, bc2[2])
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -120,8 +120,6 @@ class TestBinnedStatistic(object):
         assert_array_almost_equal(edges1v, edges2)
         assert_array_almost_equal(bc1v, bc2)
 
-
-
     def test_2d_count(self):
         x = self.x
         y = self.y
@@ -266,7 +264,6 @@ class TestBinnedStatistic(object):
         assert_array_almost_equal(bcy4, bc2[1])
         assert_array_almost_equal(bcx3, bc2[0])
         assert_array_almost_equal(bcy3, bc2[1])
-
 
     def test_dd_count(self):
         X = self.X

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -256,17 +256,8 @@ class TestBinnedStatistic(object):
         bcx3[x == x.max()] -= 1
         bcy3[y == y.max()] -= 1
 
-        bcx4 = np.digitize(x, edgesx, right=True)
-        bcy4 = np.digitize(y, edgesy, right=True)
-
-        # `numpy.digitize` is non-inclusive on left-edge, compensate
-        bcx4[x == x.min()] += 1
-        bcy4[y == y.min()] += 1
-
         assert_allclose(bcx, bc2[0])
         assert_allclose(bcy, bc2[1])
-        assert_allclose(bcx4, bc2[0])
-        assert_allclose(bcy4, bc2[1])
         assert_allclose(bcx3, bc2[0])
         assert_allclose(bcy3, bc2[1])
 


### PR DESCRIPTION
This PR addresses two issues:  
-   [Scipy 5449](https://github.com/scipy/scipy/issues/5449): `binned_statistic_2d` and `binned_statistic_dd` return mappings from the input data arrays to the bins they are placed in.  The mapping used (row-major) linearized bin indices, without documentation.  The enhancements in this PR both improve the documentation for the same behavior, and provide an input argument (`expand_binnumbers = False`) which, when True, unravels the bin-number mapping into an ndarray where each row gives the bins for each corresponding dimension.
-   [Numpy 4718](https://github.com/numpy/numpy/issues/4718): It was suggested that it would be useful for histogram to operate on numerous 'weightings' simulataneously (e.g. when calculating histogrammed moments).  For example, Previously:
  `stats_v, edges, bins = scipy.stats.binned_statisic(x, v, statistic='mean')`
  `stats_w, edges, bins = scipy.stats.binned_statisic(x, w, statistic='mean')`
  New:
  `(stats_v, stats_w), edges, bins = scipy.stats.binned_statisic(x, (v, w), statistic='mean')`

The documentation has been expanded to reflect the new functionality, and tests have been added.  Additionally, I've changed some of the variable names for consistency (e.g. using `x_edges` instead of `x_edge` to be consistent with `bin_edges`, etc), and for clarity (e.g. changed `sampBin` instead of `Ncount` for a variable which stores which bin each sample belongs in).
