### PR TITLE
BUG: sparse: fix a bug in sparsetools input dtype resolution

### DIFF
--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -558,14 +558,10 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         else:
             data = np.empty(R*C*max_bnnz, dtype=upcast(self.dtype,other.dtype))
 
-        data_dtype = self.dtype
-        if not np.can_cast(other.dtype, self.dtype):
-            data_dtype = upcast(self.dtype, other.dtype)
-
         fn(self.shape[0]//R, self.shape[1]//C, R, C,
            self.indptr.astype(idx_dtype),
            self.indices.astype(idx_dtype),
-           np.asarray(self.data, dtype=data_dtype).ravel(),
+           self.data,
            other.indptr.astype(idx_dtype),
            other.indices.astype(idx_dtype),
            np.ravel(other.data),

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -273,8 +273,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 raise NotImplementedError(" >= and <= don't work with 0.")
             elif op(0, other):
                 warn(bad_scalar_msg, SparseEfficiencyWarning)
-                dtype = upcast(self.dtype, np.result_type(other))
-                other_arr = np.empty(self.shape, dtype=dtype)
+                other_arr = np.empty(self.shape, dtype=np.result_type(other))
                 other_arr.fill(other)
                 other_arr = self.__class__(other_arr)
                 return self._binopt(other_arr, op_name)
@@ -1094,14 +1093,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         else:
             data = np.empty(maxnnz, dtype=upcast(self.dtype, other.dtype))
 
-        data_dtype = self.dtype
-        if not np.can_cast(other.dtype, self.dtype):
-            data_dtype = upcast(self.dtype, other.dtype)
-
         fn(self.shape[0], self.shape[1],
            np.asarray(self.indptr, dtype=idx_dtype),
            np.asarray(self.indices, dtype=idx_dtype),
-           np.asarray(self.data, dtype=data_dtype),
+           self.data,
            np.asarray(other.indptr, dtype=idx_dtype),
            np.asarray(other.indices, dtype=idx_dtype),
            other.data,

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -8,7 +8,8 @@ import threading
 
 from nose import SkipTest
 import numpy as np
-from numpy.testing import assert_raises, assert_equal, dec, run_module_suite, assert_
+from numpy.testing import (assert_raises, assert_equal, dec, run_module_suite, assert_,
+                           assert_allclose)
 from scipy.sparse import (_sparsetools, coo_matrix, csr_matrix, csc_matrix,
                           bsr_matrix, dia_matrix)
 from scipy.sparse.sputils import supported_dtypes
@@ -244,6 +245,42 @@ def test_csr_matmat_int64_overflow():
     b = a.T
 
     assert_raises(RuntimeError, a.dot, b)
+
+
+def test_upcast():
+    a0 = csr_matrix([[np.pi, np.pi*1j], [3, 4]], dtype=complex)
+    b0 = np.array([256+1j, 2**32], dtype=complex)
+
+    for a_dtype in supported_dtypes:
+        for b_dtype in supported_dtypes:
+            msg = "(%r, %r)" % (a_dtype, b_dtype)
+
+            if np.issubdtype(a_dtype, np.complexfloating):
+                a = a0.copy().astype(a_dtype)
+            else:
+                a = a0.real.copy().astype(a_dtype)
+
+            if np.issubdtype(b_dtype, np.complexfloating):
+                b = b0.copy().astype(b_dtype)
+            else:
+                b = b0.real.copy().astype(b_dtype)
+
+            if not (a_dtype == np.bool_ and b_dtype == np.bool_):
+                c = np.zeros((2,), dtype=np.bool_)
+                assert_raises(ValueError, _sparsetools.csr_matvec,
+                              2, 2, a.indptr, a.indices, a.data, b, c)
+
+            if ((np.issubdtype(a_dtype, np.complexfloating) and
+                 not np.issubdtype(b_dtype, np.complexfloating)) or
+                (not np.issubdtype(a_dtype, np.complexfloating) and
+                 np.issubdtype(b_dtype, np.complexfloating))):
+                c = np.zeros((2,), dtype=np.float64)
+                assert_raises(ValueError, _sparsetools.csr_matvec,
+                              2, 2, a.indptr, a.indices, a.data, b, c)
+
+            c = np.zeros((2,), dtype=np.result_type(a_dtype, b_dtype))
+            _sparsetools.csr_matvec(2, 2, a.indptr, a.indices, a.data, b, c)
+            assert_allclose(c, np.dot(a.toarray(), b), err_msg=msg)
 
 
 def check_free_memory(free_mb):


### PR DESCRIPTION
Ensure the determined common input dtype for the c++ code is such that
all inputs can be safely cast into it. Also require that the common
dtype can be safely cast to output arguments.

Add tests. Remove some upcasts that this makes unnecessary.

Fixing up the issue mentioned in my comment at gh-5213
Typically, this bug was not triggered, since the sparse code Python side tends to be careful with the dtypes.
