### PR TITLE
DOC: set mathjax cdn to https

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -141,8 +141,7 @@ html_file_suffix = '.html'
 
 htmlhelp_basename = 'scipy'
 
-pngmath_use_preview = True
-pngmath_dvipng_args = ['-gamma', '1.5', '-D', '96', '-bg', 'Transparent']
+mathjax_path = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This enables the documentation to show math formulas also on https
sites with hsts policy.
