### PR TITLE
DOC: detect unprintable characters in docstrings

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -575,7 +575,7 @@ class lti(object):
 
 
 class TransferFunction(lti):
-    """Linear Time Invariant system class in transfer function form.
+    r"""Linear Time Invariant system class in transfer function form.
 
     Represents the system as the transfer function
     :math:`H(s)=\sum_{i=0}^N b[N-i] s^i / \sum_{j=0}^M a[M-j] s^j`, where :math:`b` are

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -215,7 +215,7 @@ def mvsdist(data):
 
 
 def kstat(data, n=2):
-    """
+    r"""
     Return the nth k-statistic (1<=n<=4 so far).
 
     The nth k-statistic k_n is the unique symmetric unbiased estimator of the
@@ -310,7 +310,7 @@ def kstat(data, n=2):
 
 
 def kstatvar(data, n=2):
-    """
+    r"""
     Returns an unbiased estimator of the variance of the k-statistic.
 
     See `kstat` for more details of the k-statistic.

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1029,7 +1029,7 @@ def tsem(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
 #####################################
 
 def moment(a, moment=1, axis=0, nan_policy='propagate'):
-    """
+    r"""
     Calculates the nth moment about the mean for a sample.
 
     A moment is a specific quantitative measure of the shape of a set of points.
@@ -3327,7 +3327,7 @@ PointbiserialrResult = namedtuple('PointbiserialrResult',
 
 
 def pointbiserialr(x, y):
-    """
+    r"""
     Calculates a point biserial correlation coefficient and its p-value.
 
     The point biserial correlation is used to measure the relationship

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -393,6 +393,13 @@ def check_rest(module, names, dots=True):
                                 traceback.format_exc()))
                 continue
 
+        m = re.search("([\x00-\x09\x0b-\x1f])", text)
+        if m:
+            msg = ("Docstring contains a non-printable character %r! "
+                   "Maybe forgot r\"\"\"?" % (m.group(1),))
+            results.append((full_name, False, msg))
+            continue
+
         try:
             src_file = short_path(inspect.getsourcefile(obj))
         except TypeError:


### PR DESCRIPTION
The `r"""` is easy to forget when writing Latex.
Detect this in `refguide_check.py`.
