### PR TITLE
WIP: add a unified interface for scalar root-finding.

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -123,15 +123,34 @@ Root finding
 
 Scalar functions
 ----------------
+
 .. autosummary::
    :toctree: generated/
 
-   root_scalar - Unified interface for finding roots of scalar functions
-   brentq - quadratic interpolation Brent method
-   brenth - Brent method, modified by Harris with hyperbolic extrapolation
-   ridder - Ridder's method
-   bisect - Bisection method
+   root_scalar - Unified interface for finding roots of scalar
+                 functions on an interval
    newton - Secant method or Newton's method
+
+The `root_scalar` function supports the following methods:
+
+.. toctree::
+
+   :ref:`brentq <root-scalar-brentq>`
+   :ref:`brenth <root-scalar-brenth>`
+   :ref:`ridder <root-scalar-ridder>`
+   :ref:`bisect <root-scalar-bisect>`
+
+The specific optimization method interfaces below in this subsection are
+not recommended for use in new scripts; all of these methods are accessible
+via the newer interface provided by `root_scalar`.
+
+.. autosummary::
+   :toctree: generated/
+
+   brentq - Brent's method
+   brenth - Brent's method, modified by Harris to use hyperbolic extrapolation
+   ridder - Ridders' method
+   bisect - Bisection method
 
 Fixed point finding:
 

--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -126,6 +126,7 @@ Scalar functions
 .. autosummary::
    :toctree: generated/
 
+   root_scalar - Unified interface for finding roots of scalar functions
    brentq - quadratic interpolation Brent method
    brenth - Brent method, modified by Harris with hyperbolic extrapolation
    ridder - Ridder's method

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -647,7 +647,8 @@ _rtol = np.finfo(float).eps * 2
 
 def root_scalar(f, a, b, args=(), method='brentq', xtol=_xtol, rtol=_rtol,
                 maxiter=_iter, disp=True):
-    """Find a root of a function in a sign-changing interval.
+    """
+    Find a root of a function in a sign-changing interval.
 
     Parameters
     ----------
@@ -768,7 +769,8 @@ def root_scalar(f, a, b, args=(), method='brentq', xtol=_xtol, rtol=_rtol,
     >>> def f(x):
     ...     return (x - 0.1)**3
 
-    >>> sol = root_scalar(f, -1, 1, method='bisect')
+    >>> from scipy import optimize
+    >>> sol = optimize.root_scalar(f, -1, 1, method='bisect')
     >>> sol.x
     0.0999999999994543
 

--- a/scipy/optimize/tests/test__root.py
+++ b/scipy/optimize/tests/test__root.py
@@ -3,10 +3,10 @@ Unit tests for optimization routines from _root.py.
 """
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import assert_
+from numpy.testing import assert_, assert_almost_equal, assert_raises
 import numpy as np
 
-from scipy.optimize import root
+from scipy.optimize import root, root_scalar
 
 
 class TestRoot(object):
@@ -45,3 +45,15 @@ class TestRoot(object):
             x, y = z
             return np.array([x**3 - 1, y**3 - f])
         root(func, [1.1, 1.1], args=1.5)
+
+    def test_root_scalar(self):
+        f = lambda x : x**3
+        a, b = -1, 1
+        # These should work
+        for method in ['brentq', 'brenth', 'ridder', 'bisect']:
+            x, r = root_scalar(f, a, b, method=method, full_output=True)
+            msg = "Failed to find a root for %s" % method
+            assert_(r.converged, msg)
+            assert_(np.allclose(x, 0), msg)
+        # Make sure it catches a bogus method
+        assert_raises(ValueError, root_scalar, f, a, b, method=None)

--- a/scipy/optimize/tests/test__root.py
+++ b/scipy/optimize/tests/test__root.py
@@ -3,7 +3,7 @@ Unit tests for optimization routines from _root.py.
 """
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import assert_, assert_raises
+from numpy.testing import assert_, assert_equal, assert_raises, assert_allclose
 import numpy as np
 
 from scipy.optimize import root, root_scalar
@@ -52,9 +52,9 @@ class TestRoot(object):
         a, b = -1, 1
         # These should work
         for method in ['brentq', 'brenth', 'ridder', 'bisect']:
-            x, r = root_scalar(f, a, b, method=method, full_output=True)
+            sol = root_scalar(f, a, b, method=method)
             msg = "Failed to find a root for %s" % method
-            assert_(r.converged, msg)
-            assert_(np.allclose(x, 0), msg)
+            assert_(sol.success, msg)
+            assert_allclose(sol.x, 0, err_msg=msg)
         # Make sure it catches a bogus method
         assert_raises(ValueError, root_scalar, f, a, b, method=None)

--- a/scipy/optimize/tests/test__root.py
+++ b/scipy/optimize/tests/test__root.py
@@ -3,7 +3,7 @@ Unit tests for optimization routines from _root.py.
 """
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import assert_, assert_almost_equal, assert_raises
+from numpy.testing import assert_, assert_raises
 import numpy as np
 
 from scipy.optimize import root, root_scalar
@@ -47,7 +47,8 @@ class TestRoot(object):
         root(func, [1.1, 1.1], args=1.5)
 
     def test_root_scalar(self):
-        f = lambda x : x**3
+        def f(x):
+            return x**3
         a, b = -1, 1
         # These should work
         for method in ['brentq', 'brenth', 'ridder', 'bisect']:

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -234,7 +234,7 @@ def bisect(f, a, b, args=(),
 
     See Also
     --------
-    brentq, brenth, bisect, newton
+    brentq, brenth, ridder, newton
     fixed_point : scalar fixed-point finder
     fsolve : n-dimensional root-finding
 
@@ -406,7 +406,7 @@ def brentq(f, a, b, args=(),
     n-dimensional root-finding
       `fsolve`
     one-dimensional root-finding
-      `brentq`, `brenth`, `ridder`, `bisect`, `newton`
+      `brenth`, `ridder`, `bisect`, `newton`
     scalar fixed-point finder
       `fixed_point`
 
@@ -448,7 +448,7 @@ def brenth(f, a, b, args=(),
     between the arguments a and b that uses hyperbolic extrapolation instead of
     inverse quadratic extrapolation. There was a paper back in the 1980's ...
     f(a) and f(b) cannot have the same signs. Generally on a par with the
-    brent routine, but not as heavily tested.  It is a safe version of the
+    brentq routine, but not as heavily tested.  It is a safe version of the
     secant method that uses hyperbolic extrapolation. The version here is by
     Chuck Harris.
 
@@ -505,7 +505,7 @@ def brenth(f, a, b, args=(),
 
     fsolve : n-dimensional root-finding
 
-    brentq, brenth, ridder, bisect, newton : one-dimensional root-finding
+    brentq, ridder, bisect, newton : one-dimensional root-finding
 
     fixed_point : scalar fixed-point finder
 


### PR DESCRIPTION
Creates a new function, root_scalar, which provides a common interface
to the four routines (brentq, brenth, ridder, bisect) which find a
root of a scalar function in an interval. This was first proposed in
gh-5481.

Just testing the waters to see if people think this is a good idea or not. The goal is to provide an interface like `root` for scalar functions. Almost all of the code is taken from `brentq`/`brenth`/`ridder`/`bisect`.
