### PR TITLE
Corrected definition of pearsonr for masked arrays

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -382,9 +382,10 @@ def pearsonr(x,y):
     df = n-2
     if df < 0:
         return (masked, masked)
-
-    (mx, my) = (x.mean(), y.mean())
-    (xm, ym) = (x-mx, y-my)
+        
+    # Mask arrays to make same size
+    (xm, ym) = (ma.MaskedArray(x, m), ma.MaskedArray(y, m))
+    (xm, ym) = (x - x.mean(), y - y.mean())
 
     r_num = ma.add.reduce(xm*ym)
     r_den = ma.sqrt(ma.dot(xm,xm) * ma.dot(ym,ym))

--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -385,7 +385,7 @@ def pearsonr(x,y):
         
     # Mask arrays to make same size
     (xm, ym) = (ma.MaskedArray(x, m), ma.MaskedArray(y, m))
-    (xm, ym) = (x - x.mean(), y - y.mean())
+    (xm, ym) = (xm - xm.mean(), ym - ym.mean())
 
     r_num = ma.add.reduce(xm*ym)
     r_den = ma.sqrt(ma.dot(xm,xm) * ma.dot(ym,ym))


### PR DESCRIPTION
The given formula was incorrect. The t-statistic will only follow a students-t distribution if you ignore each PAIR of values (x_i, y_i) for which at least one of x_i, y_i is masked. This was not done in the denominator, so returning p-values based on that formula is misleading.

Let x' denote the (smaller) array obtained by removing masked values from x, and y' denote y with masked values removed. Further let x'' be x with values removed if they are masked in either x or y, and similarly y''. The old formula, which equated to
    ( len(x'')  / sqrt(len(x') \* len(y')) ) \* cov(x'', y'') / (var(x') \* var(y')),
does not relate to any other definition of correlation.
This version is simply:
   cov(x'', y'') / (std(x'') \* std(y'')),
which gives the correctly distributed t-statistic.
