### PR TITLE
ENH: optionally disable fixed-point acceleration

### DIFF
--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -520,6 +520,20 @@ class TestFixedPoint(TestCase):
         assert_allclose(xxroot, np.exp(-2.0*xxroot)/2.0)
         assert_allclose(xxroot, lambertw(1)/2)
 
+    def test_no_acceleration(self):
+        # github issue 5460
+        ks = 2
+        kl = 6
+        m = 1.3
+        n0 = 1.001
+        i0 = ((m-1)/m)*(kl/ks/m)**(1/(m-1))
+
+        def func(n):
+            return np.log(kl/ks/n) / np.log((i0*n/(n - 1))) + 1
+
+        n = fixed_point(func, n0, method='iteration')
+        assert_allclose(n, m)
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -15,7 +15,8 @@ import warnings
 
 from scipy.misc import doccer
 from ._distr_params import distcont, distdiscrete
-from scipy._lib._util import check_random_state
+from scipy._lib._util import check_random_state, _lazywhere
+from scipy._lib._util import _valarray as valarray
 
 from scipy.special import (comb, chndtr, gammaln, entr, kl_div, xlogy, ive)
 
@@ -514,53 +515,6 @@ class rv_frozen(object):
         else:
             return self.dist.expect(func, a, loc, scale, lb, ub,
                                     conditional, **kwds)
-
-
-def valarray(shape, value=nan, typecode=None):
-    """Return an array of all value.
-    """
-
-    out = ones(shape, dtype=bool) * value
-    if typecode is not None:
-        out = out.astype(typecode)
-    if not isinstance(out, ndarray):
-        out = asarray(out)
-    return out
-
-
-def _lazywhere(cond, arrays, f, fillvalue=None, f2=None):
-    """
-    np.where(cond, x, fillvalue) always evaluates x even where cond is False.
-    This one only evaluates f(arr1[cond], arr2[cond], ...).
-    For example,
-    >>> a, b = np.array([1, 2, 3, 4]), np.array([5, 6, 7, 8])
-    >>> def f(a, b):
-        return a*b
-    >>> _lazywhere(a > 2, (a, b), f, np.nan)
-    array([ nan,  nan,  21.,  32.])
-
-    Notice it assumes that all `arrays` are of the same shape, or can be
-    broadcasted together.
-
-    """
-    if fillvalue is None:
-        if f2 is None:
-            raise ValueError("One of (fillvalue, f2) must be given.")
-        else:
-            fillvalue = np.nan
-    else:
-        if f2 is not None:
-            raise ValueError("Only one of (fillvalue, f2) can be given.")
-
-    arrays = np.broadcast_arrays(*arrays)
-    temp = tuple(np.extract(cond, arr) for arr in arrays)
-    out = valarray(shape(arrays[0]), value=fillvalue)
-    np.place(out, cond, f(*temp))
-    if f2 is not None:
-        temp = tuple(np.extract(~cond, arr) for arr in arrays)
-        np.place(out, ~cond, f2(*temp))
-
-    return out
 
 
 # This should be rewritten


### PR DESCRIPTION
This PR is intended to close https://github.com/scipy/scipy/issues/5460 and includes a test for the problem motivating that issue. Another effect of this PR is to move the `_lazywhere` and `valarray` definitions out of a stats-specific module and into `_lib`.
