### PR TITLE
DOC: change a few floats to integers in docstring examples

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1863,7 +1863,7 @@ def detrend(data, axis=-1, type='linear', bp=0):
     --------
     >>> from scipy import signal
     >>> randgen = np.random.RandomState(9)
-    >>> npoints = 1e3
+    >>> npoints = 1000
     >>> noise = randgen.randn(npoints)
     >>> x = 3 + 2*np.linspace(0, 1, npoints) + noise
     >>> (signal.detrend(x) - noise).max() < 0.01

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -106,7 +106,7 @@ def bayes_mvs(data, alpha=0.90):
     mean and standard deviation with 95% confidence intervals for those
     estimates:
 
-    >>> n_samples = 1e5
+    >>> n_samples = 100000
     >>> data = stats.norm.rvs(size=n_samples)
     >>> res_mean, res_var, res_std = stats.bayes_mvs(data, alpha=0.95)
 
@@ -510,7 +510,7 @@ def probplot(x, sparams=(), dist='norm', fit=True, plot=None):
 
     >>> ax3 = plt.subplot(223)
     >>> x = stats.norm.rvs(loc=[0,5], scale=[1,1.5],
-    ...                    size=(nsample/2.,2)).ravel()
+    ...                    size=(nsample//2,2)).ravel()
     >>> res = stats.probplot(x, plot=plt)
 
     A standard normal distribution:


### PR DESCRIPTION
Before this PR, the scipy refguide check fails when I use the numpy development branch. After this PR, the refguide check passes.
