### PR TITLE
Fix to minor typo in documentation for scipy.integrate.ode

### DIFF
--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -119,7 +119,7 @@ class ode(object):
         `f` should return a scalar, array or list (not a tuple).
     jac : callable ``jac(t, y, *jac_args)``, optional
         Jacobian of the right-hand side, ``jac[i,j] = d f[i] / d y[j]``.
-        ``jac_args`` is set by calling ``set_f_params(*args)``.
+        ``jac_args`` is set by calling ``set_jac_params(*args)``.
 
     Attributes
     ----------


### PR DESCRIPTION
Minor fix to documentation . Fixes #5509 . Skip Ci since only documentation.
