### PR TITLE
BUG: stats: Fix broadcasting in the rvs() method of the distributions. 

### DIFF
--- a/doc/release/0.18.0-notes.rst
+++ b/doc/release/0.18.0-notes.rst
@@ -218,23 +218,26 @@ plus to/from the Rankine temperature scale.
 Backwards incompatible changes
 ==============================
 
+`scipy.optimize`
+----------------
+
 The convergence criterion for ``optimize.bisect``,
 ``optimize.brentq``, ``optimize.brenth``, and ``optimize.ridder`` now
 works the same as ``numpy.allclose``.
+
+`scipy.ndimage`
+---------------
 
 The offset in ``ndimage.iterpolation.affine_transform``
 is now consistently added after the matrix is applied,
 independent of if the matrix is specified using a one-dimensional
 or a two-dimensional array.
 
+`scipy.stats`
+-------------
+
 ``stats.ks_2samp`` used to return nonsensical values if the input was
 not real or contained nans.  It now raises an exception for such inputs.
-
-`scipy.io.netcdf` masking now gives precedence to the ``_FillValue`` attribute
-over the ``missing_value`` attribute, if both are given. Also, data are only
-treated as missing if they match one of these attributes exactly: values that
-differ by roundoff from ``_FillValue`` or ``missing_value`` are no longer
-treated as missing values.
 
 Several deprecated methods of `scipy.stats` distributions have been removed:
 ``est_loc_scale``, ``vecfunc``, ``veccdf`` and ``vec_generic_moment``.
@@ -242,6 +245,37 @@ Several deprecated methods of `scipy.stats` distributions have been removed:
 Deprecated functions ``nanmean``, ``nanstd`` and ``nanmedian`` have been removed
 from `scipy.stats`. These functions were deprecated in scipy 0.15.0 in favor
 of their `numpy` equivalents.
+
+A bug in the ``rvs()`` method of the distributions in `scipy.stats` has
+been fixed.  When arguments to ``rvs()`` were given that were shaped for
+broadcasting, in many cases the returned random samples were not random.
+A simple example of the problem is ``stats.norm.rvs(loc=np.zeros(10))``.
+Because of the bug, that call would return 10 identical values.  The bug
+only affected code that relied on the broadcasting of the shape, location
+and scale parameters.
+
+The ``rvs()`` method also accepted some arguments that it should not have.
+There is a potential for backwards incompatibility in cases where ``rvs()``
+accepted arguments that are not, in fact, compatible with broadcasting.
+An example is
+
+    stats.gamma.rvs([2, 5, 10, 15], size=(2,2))
+
+The shape of the first argument is not compatible with the requested size,
+but the function still returned an array with shape (2, 2).  In scipy 0.18,
+that call generates a ``ValueError``.
+
+`scipy.io`
+----------
+
+`scipy.io.netcdf` masking now gives precedence to the ``_FillValue`` attribute
+over the ``missing_value`` attribute, if both are given. Also, data are only
+treated as missing if they match one of these attributes exactly: values that
+differ by roundoff from ``_FillValue`` or ``missing_value`` are no longer
+treated as missing values.
+
+`scipy.interpolate`
+-------------------
 
 `scipy.interpolate.PiecewisePolynomial` class has been removed. It has been
 deprecated in scipy 0.14.0, and `scipy.interpolate.BPoly.from_derivatives` serves

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2979,8 +2979,9 @@ class levy_stable_gen(rv_continuous):
         sz = self._size
         alpha = broadcast_to(alpha, sz)
         beta = broadcast_to(beta, sz)
-        TH = uniform.rvs(loc=-pi/2.0, scale=pi, size=sz)
-        W = expon.rvs(size=sz)
+        TH = uniform.rvs(loc=-pi/2.0, scale=pi, size=sz,
+                         random_state=self._random_state)
+        W = expon.rvs(size=sz, random_state=self._random_state)
         aTH = alpha*TH
         bTH = beta*TH
         cosTH = cos(TH)

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -550,7 +550,7 @@ def _parse_args(self, %(shape_arg_str)s %(locscale_in)s):
     return (%(shape_arg_str)s), %(locscale_out)s
 
 def _parse_args_rvs(self, %(shape_arg_str)s %(locscale_in)s, size=None):
-    return (%(shape_arg_str)s), %(locscale_out)s, size
+    return self._argcheck_rvs(%(shape_arg_str)s %(locscale_out)s, size=size)
 
 def _parse_args_stats(self, %(shape_arg_str)s %(locscale_in)s, moments='mv'):
     return (%(shape_arg_str)s), %(locscale_out)s, moments
@@ -782,6 +782,77 @@ class rv_generic(object):
         np.seterr(**olderr)
         return vals
 
+    def _argcheck_rvs(self, *args, **kwargs):
+        # Handle broadcasting and size validation of the rvs method.
+        # Subclasses should not have to override this method.
+        # The rule is that if `size` is not None, then `size` gives the
+        # shape of the result (integer values of `size` are treated as
+        # tuples with length 1; i.e. `size=3` is the same as `size=(3,)`.)
+        #
+        # `args` is expected to contain the shape parameters (if any), the
+        # location and the scale in a flat tuple (e.g. if there are two
+        # shape parameters `a` and `b`, `args` will be `(a, b, loc, scale)`).
+        # The only keyword argument expected is 'size'.
+        size = kwargs.get('size', None)
+        all_bcast = np.broadcast_arrays(*args)
+
+        def squeeze_left(a):
+            while a.ndim > 0 and a.shape[0] == 1:
+                a = a[0]
+            return a
+
+        # Eliminate trivial leading dimensions.  In the convention
+        # used by numpy's random variate generators, trivial leading
+        # dimensions are effectively ignored.  In other words, when `size`
+        # is given, trivial leading dimensions of the broadcast parameters
+        # in excess of the number of dimensions  in size are ignored, e.g.
+        #   >>> np.random.normal([[1, 3, 5]], [[[[0.01]]]], size=3)
+        #   array([ 1.00104267,  3.00422496,  4.99799278])
+        # If `size` is not given, the exact broadcast shape is preserved:
+        #   >>> np.random.normal([[1, 3, 5]], [[[[0.01]]]])
+        #   array([[[[ 1.00862899,  3.00061431,  4.99867122]]]])
+        #
+        all_bcast = [squeeze_left(a) for a in all_bcast]
+        bcast_shape = all_bcast[0].shape
+        bcast_ndim = all_bcast[0].ndim
+
+        if size is None:
+            size_ = bcast_shape
+        else:
+            size_ = tuple(np.atleast_1d(size))
+
+        # Check compatibility of size_ with the broadcast shape of all
+        # the parameters.  This check is intended to be consistent with
+        # how the numpy random variate generators (e.g. np.random.normal,
+        # np.random.beta) handle their arguments.   The rule is that, if size
+        # is given, it determines the shape of the output.  Broadcasting
+        # can't change the output size.
+
+        # This is the standard broadcasting convention of extending the
+        # shape with fewer dimensions with enough dimensions of length 1
+        # so that the two shapes have the same number of dimensions.
+        ndiff = bcast_ndim - len(size_)
+        if ndiff < 0:
+            bcast_shape = (1,)*(-ndiff) + bcast_shape
+        elif ndiff > 0:
+            size_ = (1,)*ndiff + size_
+
+        # This compatibility test is not standard.  In "regular" broadcasting,
+        # two shapes are compatible if for each dimension, the lengths are the
+        # same or one of the lengths is 1.  Here, the length of a dimension in
+        # size_ must not be less than the corresponding length in bcast_shape.
+        ok = all([bcdim == 1 or bcdim == szdim
+                  for (bcdim, szdim) in zip(bcast_shape, size_)])
+        if not ok:
+            raise ValueError("size does not match the broadcast shape of "
+                             "the parameters.")
+
+        param_bcast = all_bcast[:-2]
+        loc_bcast = all_bcast[-2]
+        scale_bcast = all_bcast[-1]
+
+        return param_bcast, loc_bcast, scale_bcast, size_
+
     ## These are the methods you must define (standard form functions)
     ## NB: generic _pdf, _logpdf, _cdf are different for
     ## rv_continuous and rv_discrete hence are defined in there
@@ -803,8 +874,12 @@ class rv_generic(object):
     def _open_support_mask(self, x):
         return (self.a < x) & (x < self.b)
 
-    ##(return 1-d using self._size to get number)
     def _rvs(self, *args):
+        # This method must handle self._size being a tuple, and it must
+        # properly broadcast *args and self._size.  self._size might be
+        # an empty tuple, which means a scalar random variate is to be
+        # generated.
+
         ## Use basic inverse cdf algorithm for RV generation as default.
         U = self._random_state.random_sample(self._size)
         Y = self._ppf(U, *args)
@@ -860,11 +935,6 @@ class rv_generic(object):
         if not np.all(cond):
             raise ValueError("Domain error in arguments.")
 
-        # self._size is total size of all output values
-        self._size = product(size, axis=0)
-        if self._size is not None and self._size > 1:
-            size = np.array(size, ndmin=1)
-
         if np.all(scale == 0):
             return loc*ones(size, 'd')
 
@@ -873,9 +943,11 @@ class rv_generic(object):
             random_state_saved = self._random_state
             self._random_state = check_random_state(rndm)
 
+        # `size` should just be an argument to _rvs(), but for, um,
+        # historical reasons, it is made an attribute that is read
+        # by _rvs().
+        self._size = size
         vals = self._rvs(*args)
-        if self._size is not None:
-            vals = reshape(vals, size)
 
         vals = vals * scale + loc
 
@@ -885,7 +957,7 @@ class rv_generic(object):
 
         # Cast to int if discrete
         if discrete:
-            if np.isscalar(vals):
+            if size == ():
                 vals = int(vals)
             else:
                 vals = vals.astype(int)
@@ -1430,7 +1502,6 @@ class rv_continuous(rv_generic):
         if b is None:
             self.b = inf
         self.xtol = xtol
-        self._size = 1
         self.moment_type = momtype
         self.shapes = shapes
         self._construct_argparser(meths_to_inspect=[self._pdf, self._cdf],
@@ -3274,7 +3345,7 @@ class rv_sample(rv_discrete):
         return self.qvals[indx]
 
     def _ppf(self, q):
-        qq, sqq = np.broadcast_arrays(q[:, None], self.qvals)
+        qq, sqq = np.broadcast_arrays(q[..., None], self.qvals)
         indx = argmax(sqq >= qq, axis=-1)
         return self.xk[indx]
 

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -5,7 +5,7 @@ import pickle
 
 import numpy as np
 import numpy.testing as npt
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 import numpy.ma.testutils as ma_npt
 
 from scipy._lib._util import getargspec_no_self as _getargspec
@@ -273,3 +273,14 @@ def check_pickling(distfn, args):
 
     # restore the random_state
     distfn.random_state = rndm
+
+
+def check_rvs_broadcast(distfunc, distname, allargs, shape, shape_only, otype):
+    np.random.seed(123)
+    sample = distfunc.rvs(*allargs)
+    assert_equal(sample.shape, shape, "%s: rvs failed to broadcast" % distname)
+    if not shape_only:
+        rvs = np.vectorize(lambda *allargs: distfunc.rvs(*allargs), otypes=otype)
+        np.random.seed(123)
+        expected = rvs(*allargs)
+        assert_allclose(sample, expected, rtol=1e-15)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -126,6 +126,13 @@ def test_cont_basic():
                    arg, distname)
 
 
+def test_levy_stable_random_state_property():
+    # levy_stable only implements rvs(), so it is skipped in the
+    # main loop in test_cont_basic(). Here we apply just the test
+    # check_random_state_property to levy_stable.
+    check_random_state_property(stats.levy_stable, (0.5, 0.1))
+
+
 @npt.dec.slow
 def test_cont_basic_slow():
     # same as above for slow distributions

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -15,8 +15,7 @@ from common_tests import (check_normalization, check_moment, check_mean_expect,
                           check_edge_support, check_named_args,
                           check_random_state_property,
                           check_meth_dtype, check_ppf_dtype, check_cmplx_deriv,
-                          check_pickling)
-
+                          check_pickling, check_rvs_broadcast)
 from scipy.stats._distr_params import distcont
 
 """
@@ -215,6 +214,67 @@ def test_moments():
                    distname)
             yield check_loc_scale, distfn, arg, m, v, distname
             yield check_moment, distfn, arg, m, v, distname
+
+
+def test_rvs_broadcast():
+    for dist, shape_args in distcont:
+        # If shape_only is True, it means the _rvs method of the
+        # distribution uses more than one random number to generate a random
+        # variate.  That means the result of using rvs with broadcasting or
+        # with a nontrivial size will not necessarily be the same as using the
+        # numpy.vectorize'd version of rvs(), so we can only compare the shapes
+        # of the results, not the values.
+        # Whether or not a distribution is in the following list is an
+        # implementation detail of the distribution, not a requirement.  If
+        # the implementation the rvs() method of a distribution changes, this
+        # test might also have to be changed.
+        shape_only = dist in ['betaprime', 'dgamma', 'exponnorm',
+                              'nct', 'dweibull', 'rice', 'levy_stable',
+                              'skewnorm']
+
+        distfunc = getattr(stats, dist)
+        loc = np.zeros(2)
+        scale = np.ones((3, 1))
+        nargs = distfunc.numargs
+        allargs = []
+        bshape = [3, 2]
+        # Generate shape parameter arguments...
+        for k in range(nargs):
+            shp = (k + 4,) + (1,)*(k + 2)
+            allargs.append(shape_args[k]*np.ones(shp))
+            bshape.insert(0, k + 4)
+        allargs.extend([loc, scale])
+        # bshape holds the expected shape when loc, scale, and the shape
+        # parameters are all broadcast together.
+        yield check_rvs_broadcast, distfunc, dist, allargs, bshape, shape_only, 'd'
+
+
+def test_rvs_gh2069_regression():
+    # Regression tests for gh-2069.  In scipy 0.17 and earlier,
+    # these tests would fail.
+    #
+    # A typical example of the broken behavior:
+    # >>> norm.rvs(loc=np.zeros(5), scale=np.ones(5))
+    # array([-2.49613705, -2.49613705, -2.49613705, -2.49613705, -2.49613705])
+    np.random.seed(123)
+    vals = stats.norm.rvs(loc=np.zeros(5), scale=1)
+    d = np.diff(vals)
+    npt.assert_(np.all(d != 0), "All the values are equal, but they shouldn't be!")
+    vals = stats.norm.rvs(loc=0, scale=np.ones(5))
+    d = np.diff(vals)
+    npt.assert_(np.all(d != 0), "All the values are equal, but they shouldn't be!")
+    vals = stats.norm.rvs(loc=np.zeros(5), scale=np.ones(5))
+    d = np.diff(vals)
+    npt.assert_(np.all(d != 0), "All the values are equal, but they shouldn't be!")
+    vals = stats.norm.rvs(loc=np.array([[0], [0]]), scale=np.ones(5))
+    d = np.diff(vals.ravel())
+    npt.assert_(np.all(d != 0), "All the values are equal, but they shouldn't be!")
+
+    npt.assert_raises(ValueError, stats.norm.rvs, [[0, 0], [0, 0]],
+                  [[1, 1], [1, 1]], 1)
+    npt.assert_raises(ValueError, stats.gamma.rvs, [2, 3, 4, 5], 0, 1, (2, 2))
+    npt.assert_raises(ValueError, stats.gamma.rvs, [1, 1, 1, 1], [0, 0, 0, 0],
+                     [[1], [2]], (4,))
 
 
 def check_sample_meanvar_(distfn, arg, m, v, sm, sv, sn, msg):

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -10,7 +10,7 @@ from common_tests import (check_normalization, check_moment, check_mean_expect,
                           check_kurt_expect, check_entropy,
                           check_private_entropy, check_edge_support,
                           check_named_args, check_random_state_property,
-                          check_pickling)
+                          check_pickling, check_rvs_broadcast)
 from scipy.stats._distr_params import distdiscrete
 knf = npt.dec.knownfailureif
 
@@ -92,6 +92,42 @@ def test_moments():
         yield check_moment_frozen, distfn, arg, v+m*m, 2
 
 
+def test_rvs_broadcast():
+    for dist, shape_args in distdiscrete:
+        # If shape_only is True, it means the _rvs method of the
+        # distribution uses more than one random number to generate a random
+        # variate.  That means the result of using rvs with broadcasting or
+        # with a nontrivial size will not necessarily be the same as using the
+        # numpy.vectorize'd version of rvs(), so we can only compare the shapes
+        # of the results, not the values.
+        # Whether or not a distribution is in the following list is an
+        # implementation detail of the distribution, not a requirement.  If
+        # the implementation the rvs() method of a distribution changes, this
+        # test might also have to be changed.
+        shape_only = dist in ['skellam']
+
+        try:
+            distfunc = getattr(stats, dist)
+        except TypeError:
+            distfunc = dist
+            dist = 'rv_discrete(values=(%r, %r))' % (dist.F.keys(), dist.F.values)
+        loc = np.zeros(2)
+        nargs = distfunc.numargs
+        allargs = []
+        bshape = []
+        # Generate shape parameter arguments...
+        for k in range(nargs):
+            shp = (k + 3,) + (1,)*(k + 1)
+            param_val = shape_args[k]
+            allargs.append(param_val*np.ones(shp, dtype=np.array(param_val).dtype))
+            bshape.insert(0, shp[0])
+        allargs.append(loc)
+        bshape.append(loc.size)
+        # bshape holds the expected shape when loc, scale, and the shape
+        # parameters are all broadcast together.
+        yield check_rvs_broadcast, distfunc, dist, allargs, bshape, shape_only, [np.int_]
+
+
 def check_cdf_ppf(distfn, arg, supp, msg):
     # cdf is a step function, and ppf(q) = min{k : cdf(k) >= q, k integer}
     npt.assert_array_equal(distfn.ppf(distfn.cdf(supp, *arg), *arg),
@@ -163,8 +199,8 @@ def check_discrete_chisquare(distfn, arg, rvs, alpha, msg):
 
     # construct intervals with minimum mass `wsupp`.
     # intervals are left-half-open as in a cdf difference
-    lo = max(distfn.a, -1000)
-    distsupport = xrange(lo, min(distfn.b, 1000) + 1)
+    lo = int(max(distfn.a, -1000))
+    distsupport = xrange(lo, int(min(distfn.b, 1000)) + 1)
     last = 0
     distsupp = [lo]
     distmass = []

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -42,7 +42,7 @@ dists = ['uniform', 'norm', 'lognorm', 'expon', 'beta',
          'genlogistic', 'logistic', 'gumbel_l', 'gumbel_r', 'gompertz',
          'hypsecant', 'laplace', 'reciprocal', 'trapz', 'triang', 'tukeylambda',
          'vonmises', 'vonmises_line', 'pearson3', 'gennorm', 'halfgennorm',
-         'rice', 'kappa4', 'kappa3']
+         'rice', 'kappa4', 'kappa3', 'truncnorm']
 
 
 def _assert_hasattr(a, b, msg=None):
@@ -79,7 +79,7 @@ def test_all_distributions():
             args = tuple(np.sort(np.random.random(nargs)))
         elif dist == 'triang':
             args = tuple(np.random.random(nargs))
-        elif dist == 'reciprocal':
+        elif dist == 'reciprocal' or dist == 'truncnorm':
             vals = np.random.random(nargs)
             vals[1] = vals[0] + 1.0
             args = tuple(vals)


### PR DESCRIPTION
This is a fix for https://github.com/scipy/scipy/issues/2069

I haven't added any new tests yet, but the existing stats test suite passes on my system (Mac OS X 10.9.5, python 2.7.10, numpy 1.10.1).  Here are some examples using the updated `rvs` method:

```
In [1]: from scipy.stats import norm

In [2]: norm.rvs(loc=np.zeros(5))
Out[2]: array([-0.98069527, -0.75010438,  0.22639067, -0.49124641,  1.29047549])

In [3]: norm.rvs(loc=[1, 10, 100], scale=[0.1, 0.01, 1])
Out[3]: array([  1.06500076,   9.99321314,  99.47675459])

In [4]: norm.rvs(loc=[1, 10, 100], scale=[0.1, 0.01, 1], size=3)
Out[4]: array([  1.04240551,   9.9775307 ,  99.0535618 ])

In [5]: norm.rvs(loc=[1, 10, 100], scale=[0.1, 0.01, 1], size=(3,))
Out[5]: array([   1.16531601,    9.99863233,  100.38931409])

In [6]: norm.rvs(loc=[1, 10, 100], scale=[0.1, 0.01, 1], size=(2, 3))
Out[6]: 
array([[   1.01646612,    9.98911665,  100.43066246],
       [   1.11037045,   10.01307627,  102.03790766]])
```

Argument with incompatible shapes (e.g. `norm.rvs([1, 2, 3], [4, 5])`, `gamma.rvs(array([2.0, 5.0, 10.0, 15.0]), size=(2,2))`) will raise a ValueError.  The compatibility test is the same as that used by the random variate generators in `numpy.random`.  The rule is that, if `size` is given, it determines the shape of the output--broadcasting can not change the output size.
