### PR TITLE
TST: bump arccosh tolerance to allow for inaccurate numpy or libc

### DIFF
--- a/scipy/special/tests/test_data.py
+++ b/scipy/special/tests/test_data.py
@@ -191,7 +191,7 @@ def sph_harm_(m, n, theta, phi):
 def test_boost():
     TESTS = [
         data(arccosh, 'acosh_data_ipp-acosh_data', 0, 1, rtol=5e-13),
-        data(arccosh, 'acosh_data_ipp-acosh_data', 0j, 1, rtol=5e-14),
+        data(arccosh, 'acosh_data_ipp-acosh_data', 0j, 1, rtol=5e-13),
 
         data(arcsinh, 'asinh_data_ipp-asinh_data', 0, 1, rtol=1e-11),
         data(arcsinh, 'asinh_data_ipp-asinh_data', 0j, 1, rtol=1e-11),


### PR DESCRIPTION
This PR fixes a test that fails on TravisCI when numpy is built on that platform. The underlying numerical issue is in some versions of either numpy or the C standard library or both. Analogous scipy tests for arcsinh and arctanh already have high tolerance.
see https://github.com/scipy/scipy/pull/4729
