### PR TITLE
MAINT: sparse: set `format` attr explicitly

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -67,11 +67,10 @@ class spmatrix(object):
     ndim = 2
 
     def __init__(self, maxprint=MAXPRINT):
-        self.format = self.__class__.__name__[:3]
         self._shape = None
-        if self.format == 'spm':
+        if self.__class__.__name__ == 'spmatrix':
             raise ValueError("This class is not intended"
-                            " to be instantiated directly.")
+                             " to be instantiated directly.")
         self.maxprint = maxprint
 
     def set_shape(self,shape):
@@ -148,18 +147,14 @@ class spmatrix(object):
             raise AttributeError("nnz not defined")
 
     def getformat(self):
-        try:
-            format = self.format
-        except AttributeError:
-            format = 'und'
-        return format
+        return getattr(self, 'format', 'und')
 
     def __repr__(self):
         nnz = self.getnnz()
-        format = self.getformat()
+        _, format_name = _formats[self.getformat()]
         return "<%dx%d sparse matrix of type '%s'\n" \
                "\twith %d stored elements in %s format>" % \
-               (self.shape + (self.dtype.type, nnz, _formats[format][1]))
+               (self.shape + (self.dtype.type, nnz, format_name))
 
     def __str__(self):
         maxprint = self.getmaxprint()

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -115,6 +115,8 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
            [4, 4, 5, 5, 6, 6]])
 
     """
+    format = 'bsr'
+
     def __init__(self, arg1, shape=None, dtype=None, copy=False, blocksize=None):
         _data_matrix.__init__(self)
 

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -113,6 +113,8 @@ class coo_matrix(_data_matrix, _minmax_mixin):
            [0, 0, 0, 1]])
 
     """
+    format = 'coo'
+
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         _data_matrix.__init__(self)
 

--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -106,6 +106,7 @@ class csc_matrix(_cs_matrix, IndexMixin):
            [2, 3, 6]])
 
     """
+    format = 'csc'
 
     def transpose(self, copy=False):
         from .csr import csr_matrix

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -124,6 +124,7 @@ class csr_matrix(_cs_matrix, IndexMixin):
            [0, 1, 1, 1]])
 
     """
+    format = 'csr'
 
     def transpose(self, copy=False):
         from .csc import csc_matrix

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -72,6 +72,7 @@ class dia_matrix(_data_matrix):
            [0, 0, 3, 4]])
 
     """
+    format = 'dia'
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         _data_matrix.__init__(self)

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -75,6 +75,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     ...         S[i, j] = i + j    # Update element
 
     """
+    format = 'dok'
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         dict.__init__(self)

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -79,6 +79,7 @@ class lil_matrix(spmatrix, IndexMixin):
 
 
     """
+    format = 'lil'
 
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         spmatrix.__init__(self)


### PR DESCRIPTION
Refer to issue #5520 for discussion.

In addition to setting `format` explicitly in each concrete sparse matrix class, this PR does a tiny bit of cleanup in how the `spmatrix` base class deals with format strings.
