### PR TITLE
optimize: fix up cg/bfgs initial step sizes

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -313,9 +313,9 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     ...                options={'gtol': 1e-6, 'disp': True})
     Optimization terminated successfully.
              Current function value: 0.000000
-             Iterations: 52
-             Function evaluations: 64
-             Gradient evaluations: 64
+             Iterations: 26
+             Function evaluations: 31
+             Gradient evaluations: 31
     >>> res.x
     array([ 1.,  1.,  1.,  1.,  1.])
     >>> print(res.message)

--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -164,7 +164,7 @@ def scalar_search_wolfe1(phi, derphi, phi0=None, old_phi0=None, derphi0=None,
     dsave = np.zeros((13,), float)
     task = b'START'
 
-    maxiter = 30
+    maxiter = 100
     for i in xrange(maxiter):
         stp, phi1, derphi1, task = minpack2.dcsrch(alpha1, phi1, derphi1,
                                                    c1, c2, xtol, task,

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -1077,9 +1077,9 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
     >>> res1 = optimize.fmin_cg(f, x0, fprime=gradf, args=args)
     Optimization terminated successfully.
              Current function value: 1.617021
-             Iterations: 2
-             Function evaluations: 5
-             Gradient evaluations: 5
+             Iterations: 4
+             Function evaluations: 8
+             Gradient evaluations: 8
     >>> res1
     array([-1.80851064, -0.25531915])
 
@@ -1097,9 +1097,9 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
     ...                          method='CG', options=opts)
     Optimization terminated successfully.
             Current function value: 1.617021
-            Iterations: 2
-            Function evaluations: 5
-            Gradient evaluations: 5
+            Iterations: 4
+            Function evaluations: 8
+            Gradient evaluations: 8
     >>> res2.x  # minimum found
     array([-1.80851064, -0.25531915])
 

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -853,10 +853,9 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     I = numpy.eye(N, dtype=int)
     Hk = I
 
-    # Sets the initial step guess to dx ~ 5000/|g|
-    # XXX: doesn't give scaling invariance
+    # Sets the initial step guess to dx ~ 1
     old_fval = f(x0)
-    old_old_fval = old_fval + 5000
+    old_old_fval = old_fval + np.linalg.norm(gfk) / 2
 
     xk = x0
     if retall:
@@ -1167,10 +1166,9 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
     k = 0
     xk = x0
 
-    # Sets the initial step guess to dx ~ 5000/|g|
-    # XXX: doesn't give scaling invariance
+    # Sets the initial step guess to dx ~ 1
     old_fval = f(xk)
-    old_old_fval = old_fval + 5000
+    old_old_fval = old_fval + np.linalg.norm(gfk) / 2
 
     if retall:
         allvecs = [xk]

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -853,7 +853,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     I = numpy.eye(N, dtype=int)
     Hk = I
     old_fval = f(x0)
-    old_old_fval = None
+    old_old_fval = old_fval + 5000
     xk = x0
     if retall:
         allvecs = [x0]
@@ -1163,7 +1163,7 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
     k = 0
     xk = x0
     old_fval = f(xk)
-    old_old_fval = None
+    old_old_fval = old_fval + 5000
 
     if retall:
         allvecs = [xk]

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -868,7 +868,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
         try:
             alpha_k, fc, gc, old_fval, old_old_fval, gfkp1 = \
                      _line_search_wolfe12(f, myfprime, xk, pk, gfk,
-                                          old_fval, old_old_fval)
+                                          old_fval, old_old_fval, amin=1e-100, amax=1e100)
         except _LineSearchError:
             # Line search failed to find a better solution.
             warnflag = 2
@@ -1181,7 +1181,7 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
         try:
             alpha_k, fc, gc, old_fval, old_old_fval, gfkp1 = \
                      _line_search_wolfe12(f, myfprime, xk, pk, gfk, old_fval,
-                                          old_old_fval, c2=0.4)
+                                          old_old_fval, c2=0.4, amin=1e-100, amax=1e100)
         except _LineSearchError:
             # Line search failed to find a better solution.
             warnflag = 2

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -852,8 +852,12 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     N = len(x0)
     I = numpy.eye(N, dtype=int)
     Hk = I
+
+    # Sets the initial step guess to dx ~ 5000/|g|
+    # XXX: doesn't give scaling invariance
     old_fval = f(x0)
     old_old_fval = old_fval + 5000
+
     xk = x0
     if retall:
         allvecs = [x0]
@@ -1162,6 +1166,9 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
     gfk = myfprime(x0)
     k = 0
     xk = x0
+
+    # Sets the initial step guess to dx ~ 5000/|g|
+    # XXX: doesn't give scaling invariance
     old_fval = f(xk)
     old_old_fval = old_fval + 5000
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -633,11 +633,11 @@ class TestOptimizeSimple(CheckOptimize):
         sol_4 = optimize.minimize(f, x0, constraints=[{'type': 'ineq', 'fun': cons}], bounds=[(1, 10)])
         for sol in [sol_0, sol_1, sol_2, sol_3, sol_4]:
             assert_(sol.success)
-        assert_allclose(sol_0.x, 0, atol=1e-8)
-        assert_allclose(sol_1.x, 2, atol=1e-8)
-        assert_allclose(sol_2.x, 5, atol=1e-8)
-        assert_allclose(sol_3.x, 5, atol=1e-8)
-        assert_allclose(sol_4.x, 2, atol=1e-8)
+        assert_allclose(sol_0.x, 0, atol=1e-7)
+        assert_allclose(sol_1.x, 2, atol=1e-7)
+        assert_allclose(sol_2.x, 5, atol=1e-7)
+        assert_allclose(sol_3.x, 5, atol=1e-7)
+        assert_allclose(sol_4.x, 2, atol=1e-7)
 
     def test_minimize_coerce_args_param(self):
         # Regression test for gh-3503
@@ -654,16 +654,19 @@ class TestOptimizeSimple(CheckOptimize):
     def test_initial_step_scaling(self):
         # Check that optimizer initial step is not huge even if the
         # function and gradients are
+
+        scale = 1e50
+
         def f(x):
             if abs(x).max() > 1e4:
                 raise AssertionError("Optimization stepped far away!")
-            return 1e8*(x[0] - 1)**2
+            return scale*(x[0] - 1)**2
         def g(x):
-            return np.array([1e8*(x[0] - 1)])
+            return np.array([scale*(x[0] - 1)])
 
         for method in ['CG', 'BFGS', 'L-BFGS-B', 'Newton-CG', 'TNC']:
             if method == 'CG':
-                options = dict(gtol=1e8*1e-6)
+                options = dict(gtol=scale*1e-8)
             else:
                 options = dict()
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -661,6 +661,7 @@ class TestOptimizeSimple(CheckOptimize):
             if abs(x).max() > 1e4:
                 raise AssertionError("Optimization stepped far away!")
             return scale*(x[0] - 1)**2
+
         def g(x):
             return np.array([scale*(x[0] - 1)])
 


### PR DESCRIPTION
Change the initial step size in CG/BFGS so that it is |dx0| ~ 1 regardless of the scaling of the function, similarly to L-BFGS-B. Previously, it was |dx0| ~ |grad| which is just wrong.

Also, prior to Scipy 0.12.0 it used to be |dx0| ~ 1/|grad|. This also makes some sense, if you assume typical values of the function are of order 1.
- [x] The step size handling in CG/BFGS is somewhat problematic also because the line search step size is bounded to [1e-8, 50] and these bounds become too restrictive if the gradients are very large/small. Something could be done to this.
- [x] Maybe test the initial step is actually close to norm 1

See gh-3581 and https://stackoverflow.com/questions/33853929/fmin-cg-desired-error-not-necessarily-achieved-due-to-precision-loss for a problem this causes
