### PR TITLE
ENH: Nearest-neighbor chain algorithm for hierarchical clustering

### DIFF
--- a/benchmarks/benchmarks/cluster.py
+++ b/benchmarks/benchmarks/cluster.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from .common import Benchmark
+
+try:
+    from scipy.cluster.hierarchy import linkage
+except ImportError:
+    pass
+
+
+class HierarchyLinkage(Benchmark):
+    params = ['single', 'complete', 'average', 'weighted', 'centroid',
+              'median', 'ward']
+    param_names = ['method']
+
+    def __init__(self):
+        rnd = np.random.RandomState(0)
+        self.X = rnd.randn(2000, 2)
+
+    def time_linkage(self, method):
+        linkage(self.X, method=method)

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -621,19 +621,19 @@ def linkage(y, method='single', metric='euclidean'):
     Notes
     -----
     1. For method 'single' an optimized algorithm called SLINK is implemented,
-       which has :math:`O(n^2)` time complexity and :math:`O(n)` memory
-       complexity.
+       which has :math:`O(n^2)` time complexity.
        For methods 'complete', 'average', 'weighted' and 'ward' an algorithm
-       called nearest-neighbors chain is implemented, which has both time and
-       memory complexity as :math:`O(n^2)`.
+       called nearest-neighbors chain is implemented, which too has time
+       complexity :math:`O(n^2)`.
        For other methods a naive algorithm is implemented with :math:`O(n^3)`
-       and :math:`O(n^2)` time and memory complexity respectively.
+       time complexity.
+       All algorithms use :math:`O(n^2)` memory.
        Refer to [1]_ for details about the algorithms.
     2. Methods 'centroid', 'median' and 'ward' are correctly defined only if
        Euclidean pairwise metric is used. If `y` is passed as precomputed
-       pairwise distances, then it is user responsibility to assure that
+       pairwise distances, then it is a user responsibility to assure that
        these distances are in fact Euclidean, otherwise the produced result
-       will be meaningless.
+       will be incorrect.
 
     References
     ----------

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -91,6 +91,11 @@ class TestLinkage(object):
         expectedZ = getattr(hierarchy_test_data, 'linkage_X_' + method)
         assert_allclose(Z, expectedZ, atol=1e-06)
 
+        y = scipy.spatial.distance.pdist(hierarchy_test_data.X,
+                                         metric="euclidean")
+        Z = linkage(y, method)
+        assert_allclose(Z, expectedZ, atol=1e-06)
+
 
 class TestInconsistent(object):
     def test_inconsistent_tdist(self):

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -894,9 +894,9 @@ def calculate_maximum_inconsistencies(Z, R, k=3):
 
 
 def test_euclidean_linkage_value_error():
-    for method in scipy.cluster.hierarchy._cpy_euclid_methods:
-        assert_raises(ValueError,
-                linkage, [[1, 1], [1, 1]], method=method, metric='cityblock')
+    for method in scipy.cluster.hierarchy._EUCLIDEAN_METHODS:
+        assert_raises(ValueError, linkage, [[1, 1], [1, 1]],
+                      method=method, metric='cityblock')
 
 
 def test_2x2_linkage():


### PR DESCRIPTION
Hi, I implemented a new algorithm https://en.wikipedia.org/wiki/Nearest-neighbor_chain_algorithm

Going from O(n^3) to O(n^2) is clearly visible. Note, that it is not applicable to `median` and `centroid` schemas, thus no improvement there. I will investigate if it's possible to achieve speed up for these schemas too. Single linkage was already efficient by SLINK algorithm.

I didn't add any tests, because there is already a very good test suite and the algorithm works as a substitution with the equivalent outcome (which is really convenient).

Below a small benchmarking script. Comments are very welcome.

``` Python
from __future__ import print_function
from time import time
import numpy as np
from scipy.cluster.hierarchy import _LINKAGE_METHODS
from scipy.cluster.hierarchy import linkage as linkage_new
from scipy_.cluster.hierarchy import linkage as linkage_orig  # Version from anaconda
from sklearn.datasets import make_blobs


X, _ = make_blobs(n_samples=3000, centers=100, random_state=0)
print("{:^10} {:^10} {:^10} {:^10}".format(
    'Method', 'Time orig.', 'Time new', 'Match'))
print("-" * 40)
for method in _LINKAGE_METHODS:
    t0 = time()
    Z_orig = linkage_orig(X, method=method)
    t1 = time()
    Z_new = linkage_new(X, method=method)
    t2 = time()
    print("{:^10} {:^10.3f} {:^10.3f} {:^10}".format(
        method, t1 - t0, t2 - t1, np.allclose(Z_orig, Z_new)))
```

Output:

```
  Method   Time orig.  Time new    Match   
----------------------------------------
  median     10.966     9.784        1     
   ward      10.802     0.267        1     
  single     0.094      0.096        1     
 centroid    11.501     10.215       1     
 complete    10.996     0.252        1     
 average     11.557     0.264        1     
 weighted    11.163     0.238        1     
[Finished in 88.8s]
```
