### PR TITLE
MAINT: work around lstsq driver selection issue

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -879,7 +879,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
                     
                     if lapack_driver is None:
                         # restart with gelss
-                        lstsq.default_lapack_driver='gelss'
+                        lstsq.default_lapack_driver = 'gelss'
                         mesg += "Falling back to 'gelss' driver."
                         warnings.warn(mesg, RuntimeWarning)
                         return lstsq(a, b, cond, overwrite_a, overwrite_b,

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -34,6 +34,7 @@ from scipy.linalg import (solve, inv, det, lstsq, pinv, pinv2, pinvh, norm,
         solve_banded, solveh_banded, solve_triangular, solve_circulant,
         circulant, LinAlgError)
 
+from scipy.linalg.basic import LstsqLapackError
 from scipy.linalg._testutils import assert_no_overwrite
 
 REAL_DTYPES = [np.float32, np.float64]
@@ -722,7 +723,7 @@ def direct_lstsq(a,b,cmplx=0):
 
 class TestLstsq(TestCase):
 
-    lapack_drivers = ('gelsd', 'gelss', 'gelsy')
+    lapack_drivers = ('gelsd', 'gelss', 'gelsy', None)
 
     def setUp(self):
         np.random.seed(1234)
@@ -738,16 +739,20 @@ class TestLstsq(TestCase):
                             a1 = a.copy()
                             b = np.array(bt, dtype=dtype)
                             b1 = b.copy()
-                            out = lstsq(a1, b1, lapack_driver=lapack_driver,
-                                        overwrite_a=overwrite,
-                                        overwrite_b=overwrite)
+                            try:
+                                out = lstsq(a1, b1, lapack_driver=lapack_driver,
+                                            overwrite_a=overwrite,
+                                            overwrite_b=overwrite)
+                            except LstsqLapackError:
+                                continue
+
                             x = out[0]
                             r = out[2]
                             assert_(r == 2, 'unexpected efficient rank')
                             assert_allclose(dot(a, x), b,
                                             atol=25 * np.finfo(a1.dtype).eps,
                                             rtol=25 * np.finfo(a1.dtype).eps,
-                                        err_msg="driver: %s" % lapack_driver)
+                                            err_msg="driver: %s" % lapack_driver)
 
     def test_simple_overdet(self):
         for dtype in REAL_DTYPES:
@@ -758,8 +763,11 @@ class TestLstsq(TestCase):
                     # Store values in case they are overwritten later
                     a1 = a.copy()
                     b1 = b.copy()
-                    out = lstsq(a1, b1, lapack_driver=lapack_driver,
-                                overwrite_a=overwrite, overwrite_b=overwrite)
+                    try:
+                        out = lstsq(a1, b1, lapack_driver=lapack_driver,
+                                    overwrite_a=overwrite, overwrite_b=overwrite)
+                    except LstsqLapackError:
+                        continue
                     x = out[0]
                     if lapack_driver == 'gelsy':
                         residuals = np.sum((b - a.dot(x))**2)
@@ -786,8 +794,11 @@ class TestLstsq(TestCase):
                     # Store values in case they are overwritten later
                     a1 = a.copy()
                     b1 = b.copy()
-                    out = lstsq(a1, b1, lapack_driver=lapack_driver,
-                                overwrite_a=overwrite, overwrite_b=overwrite)
+                    try:
+                        out = lstsq(a1, b1, lapack_driver=lapack_driver,
+                                    overwrite_a=overwrite, overwrite_b=overwrite)
+                    except LstsqLapackError:
+                        continue
                     x = out[0]
                     if lapack_driver == 'gelsy':
                         res = b - a.dot(x)
@@ -816,8 +827,11 @@ class TestLstsq(TestCase):
                     # Store values in case they are overwritten later
                     a1 = a.copy()
                     b1 = b.copy()
-                    out = lstsq(a1, b1, lapack_driver=lapack_driver,
-                                overwrite_a=overwrite, overwrite_b=overwrite)
+                    try:
+                        out = lstsq(a1, b1, lapack_driver=lapack_driver,
+                                    overwrite_a=overwrite, overwrite_b=overwrite)
+                    except LstsqLapackError:
+                        continue
                     x = out[0]
                     r = out[2]
                     assert_(r == 2, 'unexpected efficient rank')
@@ -840,9 +854,13 @@ class TestLstsq(TestCase):
                             # Store values in case they are overwritten later
                             a1 = a.copy()
                             b1 = b.copy()
-                            out = lstsq(a1, b1, lapack_driver=lapack_driver,
-                                        overwrite_a=overwrite,
-                                        overwrite_b=overwrite)
+                            try:
+                                out = lstsq(a1, b1,
+                                            lapack_driver=lapack_driver,
+                                            overwrite_a=overwrite,
+                                            overwrite_b=overwrite)
+                            except LstsqLapackError:
+                                continue
                             x = out[0]
                             r = out[2]
                             assert_(r == n, 'unexpected efficient rank')
@@ -901,9 +919,13 @@ class TestLstsq(TestCase):
                             # Store values in case they are overwritten later
                             a1 = a.copy()
                             b1 = b.copy()
-                            out = lstsq(a1, b1, lapack_driver=lapack_driver,
-                                        overwrite_a=overwrite,
-                                        overwrite_b=overwrite)
+                            try:
+                                out = lstsq(a1, b1,
+                                            lapack_driver=lapack_driver,
+                                            overwrite_a=overwrite,
+                                            overwrite_b=overwrite)
+                            except LstsqLapackError:
+                                continue
                             x = out[0]
                             r = out[2]
                             assert_(r == m, 'unexpected efficient rank')
@@ -951,11 +973,14 @@ class TestLstsq(TestCase):
                                 # later
                                 a1 = a.copy()
                                 b1 = b.copy()
-
-                                out = lstsq(a1, b1, lapack_driver=lapack_driver,
-                                            check_finite=check_finite,
-                                            overwrite_a=overwrite,
-                                            overwrite_b=overwrite)
+                                try:
+                                    out = lstsq(a1, b1,
+                                                lapack_driver=lapack_driver,
+                                                check_finite=check_finite,
+                                                overwrite_a=overwrite,
+                                                overwrite_b=overwrite)
+                                except LstsqLapackError:
+                                    continue
                                 x = out[0]
                                 r = out[2]
                                 assert_(r == 2, 'unexpected efficient rank')

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -744,7 +744,13 @@ class TestLstsq(TestCase):
                                             overwrite_a=overwrite,
                                             overwrite_b=overwrite)
                             except LstsqLapackError:
-                                continue
+                                if lapack_driver is None:
+                                    mesg = ('LstsqLapackError raised with '
+                                            'lapack_driver being None.')
+                                    raise AssertionError(mesg)
+                                else:
+                                    # can't proceed, skip to the next iteration
+                                    continue
 
                             x = out[0]
                             r = out[2]
@@ -767,7 +773,14 @@ class TestLstsq(TestCase):
                         out = lstsq(a1, b1, lapack_driver=lapack_driver,
                                     overwrite_a=overwrite, overwrite_b=overwrite)
                     except LstsqLapackError:
-                        continue
+                        if lapack_driver is None:
+                            mesg = ('LstsqLapackError raised with '
+                                    'lapack_driver being None.')
+                            raise AssertionError(mesg)
+                        else:
+                            # can't proceed, skip to the next iteration
+                            continue
+
                     x = out[0]
                     if lapack_driver == 'gelsy':
                         residuals = np.sum((b - a.dot(x))**2)
@@ -798,7 +811,14 @@ class TestLstsq(TestCase):
                         out = lstsq(a1, b1, lapack_driver=lapack_driver,
                                     overwrite_a=overwrite, overwrite_b=overwrite)
                     except LstsqLapackError:
-                        continue
+                        if lapack_driver is None:
+                            mesg = ('LstsqLapackError raised with '
+                                    'lapack_driver being None.')
+                            raise AssertionError(mesg)
+                        else:
+                            # can't proceed, skip to the next iteration
+                            continue
+
                     x = out[0]
                     if lapack_driver == 'gelsy':
                         res = b - a.dot(x)
@@ -831,7 +851,14 @@ class TestLstsq(TestCase):
                         out = lstsq(a1, b1, lapack_driver=lapack_driver,
                                     overwrite_a=overwrite, overwrite_b=overwrite)
                     except LstsqLapackError:
-                        continue
+                        if lapack_driver is None:
+                            mesg = ('LstsqLapackError raised with '
+                                    'lapack_driver being None.')
+                            raise AssertionError(mesg)
+                        else:
+                            # can't proceed, skip to the next iteration
+                            continue
+
                     x = out[0]
                     r = out[2]
                     assert_(r == 2, 'unexpected efficient rank')
@@ -860,7 +887,13 @@ class TestLstsq(TestCase):
                                             overwrite_a=overwrite,
                                             overwrite_b=overwrite)
                             except LstsqLapackError:
-                                continue
+                                if lapack_driver is None:
+                                    mesg = ('LstsqLapackError raised with '
+                                            'lapack_driver being None.')
+                                    raise AssertionError(mesg)
+                                else:
+                                    # can't proceed, skip to the next iteration
+                                    continue
                             x = out[0]
                             r = out[2]
                             assert_(r == n, 'unexpected efficient rank')
@@ -925,7 +958,14 @@ class TestLstsq(TestCase):
                                             overwrite_a=overwrite,
                                             overwrite_b=overwrite)
                             except LstsqLapackError:
-                                continue
+                                if lapack_driver is None:
+                                    mesg = ('LstsqLapackError raised with '
+                                            'lapack_driver being None.')
+                                    raise AssertionError(mesg)
+                                else:
+                                    # can't proceed, skip to the next iteration
+                                    continue
+
                             x = out[0]
                             r = out[2]
                             assert_(r == m, 'unexpected efficient rank')
@@ -980,7 +1020,13 @@ class TestLstsq(TestCase):
                                                 overwrite_a=overwrite,
                                                 overwrite_b=overwrite)
                                 except LstsqLapackError:
-                                    continue
+                                    if lapack_driver is None:
+                                        mesg = ('LstsqLapackError raised with '
+                                                'lapack_driver being None.')
+                                        raise AssertionError(mesg)
+                                    else:
+                                        # can't proceed, skip to the next iteration
+                                        continue
                                 x = out[0]
                                 r = out[2]
                                 assert_(r == 2, 'unexpected efficient rank')


### PR DESCRIPTION
Switch the default driver to gelss if gelsd is buggy. As suggested in https://github.com/scipy/scipy/issues/5539#issuecomment-159925122. Closes gh-5539.
