### PR TITLE
BUG: modify optimize.bisect to achieve desired tolerance

### DIFF
--- a/doc/release/0.18.0-notes.rst
+++ b/doc/release/0.18.0-notes.rst
@@ -29,6 +29,9 @@ Deprecated features
 Backwards incompatible changes
 ==============================
 
+The convergence criterion for ``optimize.bisect``,
+``optimize.brentq``, ``optimize.brenth``, and ``optimize.ridder`` now
+works the same as ``numpy.allclose``.
 
 Other changes
 =============

--- a/scipy/optimize/Zeros/bisect.c
+++ b/scipy/optimize/Zeros/bisect.c
@@ -8,9 +8,7 @@ bisect(callback_type f, double xa, double xb, double xtol, double rtol,
        int iter, default_parameters *params)
 {
     int i;
-    double dm,xm,fm,fa,fb,tol;
-
-    tol = xtol + rtol*(fabs(xa) + fabs(xb));
+    double dm,xm,fm,fa,fb;
 
     fa = (*f)(xa,params);
     fb = (*f)(xb,params);
@@ -36,7 +34,7 @@ bisect(callback_type f, double xa, double xb, double xtol, double rtol,
         if (fm*fa >= 0) {
             xa = xm;
         }
-        if (fm == 0 || fabs(dm) < tol) {
+        if (fm == 0 || fabs(dm) < xtol + rtol*fabs(xm)) {
             return xm;
         }
     }

--- a/scipy/optimize/Zeros/brenth.c
+++ b/scipy/optimize/Zeros/brenth.c
@@ -39,7 +39,9 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
        int iter, default_parameters *params)
 {
     double xpre = xa, xcur = xb;
-    double xblk = 0., fpre, fcur, fblk = 0., spre = 0., scur = 0., sbis, tol;
+    double xblk = 0., fpre, fcur, fblk = 0., spre = 0., scur = 0., sbis;
+    /* the tolerance is 2*delta */
+    double delta;
     double stry, dpre, dblk;
     int i;
 
@@ -74,13 +76,13 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
             fblk = fpre;
         }
 
-        tol = xtol + rtol*fabs(xcur);
+        delta = (xtol + rtol*fabs(xcur))/2;
         sbis = (xblk - xcur)/2;
-        if (fcur == 0 || fabs(sbis) < tol) {
+        if (fcur == 0 || fabs(sbis) < delta) {
             return xcur;
         }
 
-        if (fabs(spre) > tol && fabs(fcur) < fabs(fpre)) {
+        if (fabs(spre) > delta && fabs(fcur) < fabs(fpre)) {
             if (xpre == xblk) {
                 /* interpolate */
                 stry = -fcur*(xcur - xpre)/(fcur - fpre);
@@ -92,7 +94,7 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
                 stry = -fcur*(fblk - fpre)/(fblk*dpre - fpre*dblk);
             }
 
-            if (2*fabs(stry) < MIN(fabs(spre), 3*fabs(sbis) - tol)) {
+            if (2*fabs(stry) < MIN(fabs(spre), 3*fabs(sbis) - delta)) {
                 /* accept step */
                 spre = scur;
                 scur = stry;
@@ -111,11 +113,11 @@ brenth(callback_type f, double xa, double xb, double xtol, double rtol,
 
         xpre = xcur;
         fpre = fcur;
-        if (fabs(scur) > tol) {
+        if (fabs(scur) > delta) {
             xcur += scur;
         }
         else {
-            xcur += (sbis > 0 ? tol : -tol);
+            xcur += (sbis > 0 ? delta : -delta);
         }
 
         fcur = (*f)(xcur, params);

--- a/scipy/optimize/Zeros/brentq.c
+++ b/scipy/optimize/Zeros/brentq.c
@@ -38,7 +38,9 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
        int iter, default_parameters *params)
 {
     double xpre = xa, xcur = xb;
-    double xblk = 0., fpre, fcur, fblk = 0., spre = 0., scur = 0., sbis, tol;
+    double xblk = 0., fpre, fcur, fblk = 0., spre = 0., scur = 0., sbis;
+    /* the tolerance is 2*delta */
+    double delta;
     double stry, dpre, dblk;
     int i;
 
@@ -74,13 +76,13 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
             fblk = fpre;
         }
 
-        tol = xtol + rtol*fabs(xcur);
+        delta = (xtol + rtol*fabs(xcur))/2;
         sbis = (xblk - xcur)/2;
-        if (fcur == 0 || fabs(sbis) < tol) {
+        if (fcur == 0 || fabs(sbis) < delta) {
             return xcur;
         }
 
-        if (fabs(spre) > tol && fabs(fcur) < fabs(fpre)) {
+        if (fabs(spre) > delta && fabs(fcur) < fabs(fpre)) {
             if (xpre == xblk) {
                 /* interpolate */
                 stry = -fcur*(xcur - xpre)/(fcur - fpre);
@@ -92,7 +94,7 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
                 stry = -fcur*(fblk*dblk - fpre*dpre)
                     /(dblk*dpre*(fblk - fpre));
             }
-            if (2*fabs(stry) < MIN(fabs(spre), 3*fabs(sbis) - tol)) {
+            if (2*fabs(stry) < MIN(fabs(spre), 3*fabs(sbis) - delta)) {
                 /* good short step */
                 spre = scur;
                 scur = stry;
@@ -109,11 +111,11 @@ brentq(callback_type f, double xa, double xb, double xtol, double rtol,
         }
 
         xpre = xcur; fpre = fcur;
-        if (fabs(scur) > tol) {
+        if (fabs(scur) > delta) {
             xcur += scur;
         }
         else {
-            xcur += (sbis > 0 ? tol : -tol);
+            xcur += (sbis > 0 ? delta : -delta);
         }
 
         fcur = (*f)(xcur, params);

--- a/scipy/optimize/Zeros/ridder.c
+++ b/scipy/optimize/Zeros/ridder.c
@@ -20,7 +20,7 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
     int i;
     double dm,dn,xm,xn=0.0,fn,fm,fa,fb,tol;
 
-    tol = xtol + rtol*(fabs(xa) + fabs(xb));
+    tol = xtol + rtol*MIN(fabs(xa), fabs(xb));
     fa = (*f)(xa,params);
     fb = (*f)(xb,params);
     params->funcalls = 2;
@@ -54,6 +54,7 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
         else {
             xa = xn; fa = fn;
         }
+        tol = xtol + rtol*xn;
         if (fn == 0.0 || fabs(xb - xa) < tol) {
             return xn;
         }

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -78,6 +78,30 @@ def test_gh_5555():
                         err_msg='method %s' % method.__name__)
 
 
+def test_gh_5557():
+    # Show that without the changes in 5557 brentq and brenth might
+    # only achieve a tolerance of 2*(xtol + rtol*|res|).
+
+    # f linearly interpolates (0, -0.1), (0.5, -0.1), and (1,
+    # 0.4). The important parts are that |f(0)| < |f(1)| (so that
+    # brent takes 0 as the initial guess), |f(0)| < atol (so that
+    # brent accepts 0 as the root), and that the exact root of f lies
+    # more than atol away from 0 (so that brent doesn't achieve the
+    # desired tolerance).
+    def f(x):
+        if x < 0.5:
+            return -0.1
+        else:
+            return x - 0.6
+
+    atol = 0.51
+    rtol = 4*finfo(float).eps
+    methods = [cc.brentq, cc.brenth]
+    for method in methods:
+        res = method(f, 0, 1, xtol=atol, rtol=rtol)
+        assert_allclose(0.6, res, atol=atol, rtol=rtol)
+
+
 class TestRootResults:
     def test_repr(self):
         r = zeros.RootResults(root=1.0,

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -3,9 +3,10 @@ from __future__ import division, print_function, absolute_import
 
 from math import sqrt, exp, sin, cos
 
-from numpy.testing import (TestCase, assert_almost_equal, assert_warns,
-                           assert_, run_module_suite, assert_allclose,
+from numpy.testing import (TestCase, assert_warns, assert_, 
+                           run_module_suite, assert_allclose,
                            assert_equal)
+from numpy import finfo
 
 from scipy.optimize import zeros as cc
 from scipy.optimize import zeros
@@ -18,10 +19,13 @@ class TestBasic(TestCase):
     def run_check(self, method, name):
         a = .5
         b = sqrt(3)
+        xtol = 4*finfo(float).eps
+        rtol = 4*finfo(float).eps
         for function, fname in zip(functions, fstrings):
-            zero, r = method(function, a, b, xtol=0.1e-12, full_output=True)
+            zero, r = method(function, a, b, xtol=xtol, rtol=rtol,
+                             full_output=True)
             assert_(r.converged)
-            assert_almost_equal(zero, 1.0, decimal=12,
+            assert_allclose(zero, 1.0, atol=xtol, rtol=rtol,
                 err_msg='method %s, function %s' % (name, fname))
 
     def test_bisect(self):
@@ -57,6 +61,21 @@ class TestBasic(TestCase):
         func = lambda x: x**2
         dfunc = lambda x: 2*x
         assert_warns(RuntimeWarning, cc.newton, func, 0.0, dfunc)
+
+
+def test_gh_5555():
+    root = 0.1
+
+    def f(x):
+        return x - root
+
+    methods = [cc.bisect, cc.ridder]
+    xtol = 4*finfo(float).eps
+    rtol = 4*finfo(float).eps
+    for method in methods:
+        res = method(f, -1e8, 1e7, xtol=xtol, rtol=rtol)
+        assert_allclose(root, res, atol=xtol, rtol=rtol,
+                        err_msg='method %s' % method.__name__)
 
 
 class TestRootResults:

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -6,8 +6,8 @@ from . import _zeros
 from numpy import finfo, sign, sqrt
 
 _iter = 100
-_xtol = 1e-12
-_rtol = finfo(float).eps * 2
+_xtol = 2e-12
+_rtol = 4*finfo(float).eps
 
 __all__ = ['newton', 'bisect', 'ridder', 'brentq', 'brenth']
 
@@ -204,13 +204,14 @@ def bisect(f, a, b, args=(),
     b : number
         The other end of the bracketing interval [a,b].
     xtol : number, optional
-        The routine converges when a root is known to lie within `xtol` of the
-        value return. Should be >= 0.  The routine modifies this to take into
-        account the relative precision of doubles.
+        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
+        parameter must be nonnegative.
     rtol : number, optional
-        The routine converges when a root is known to lie within `rtol` times
-        the value returned of the value returned. Should be >= 0. Defaults to
-        ``np.finfo(float).eps * 2``.
+        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
+        parameter cannot be smaller than its default value of
+        ``4*np.finfo(float).eps``.
     maxiter : number, optional
         if convergence is not achieved in `maxiter` iterations, an error is
         raised.  Must be >= 0.
@@ -265,13 +266,14 @@ def ridder(f, a, b, args=(),
     b : number
         The other end of the bracketing interval [a,b].
     xtol : number, optional
-        The routine converges when a root is known to lie within xtol of the
-        value return. Should be >= 0.  The routine modifies this to take into
-        account the relative precision of doubles.
+        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
+        parameter must be nonnegative.
     rtol : number, optional
-        The routine converges when a root is known to lie within `rtol` times
-        the value returned of the value returned. Should be >= 0. Defaults to
-        ``np.finfo(float).eps * 2``.
+        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
+        parameter cannot be smaller than its default value of
+        ``4*np.finfo(float).eps``.
     maxiter : number, optional
         if convergence is not achieved in maxiter iterations, an error is
         raised.  Must be >= 0.
@@ -331,13 +333,9 @@ def brentq(f, a, b, args=(),
            xtol=_xtol, rtol=_rtol, maxiter=_iter,
            full_output=False, disp=True):
     """
-    Find a root of a function in given interval.
+    Find a root of a function in a bracketing interval using Brent's method.
 
-    Return float, a zero of `f` between `a` and `b`.  `f` must be a continuous
-    function, and [a,b] must be a sign changing interval.
-
-    Description:
-    Uses the classic Brent (1973) method to find a zero of the function `f` on
+    Uses the classic Brent's method to find a zero of the function `f` on
     the sign changing interval [a , b].  Generally considered the best of the
     rootfinding routines here.  It is a safe version of the secant method that
     uses inverse quadratic extrapolation.  Brent's method combines root
@@ -356,20 +354,26 @@ def brentq(f, a, b, args=(),
     Parameters
     ----------
     f : function
-        Python function returning a number.  f must be continuous, and f(a) and
-        f(b) must have opposite signs.
+        Python function returning a number.  The function :math:`f`
+        must be continuous, and :math:`f(a)` and :math:`f(b)` must
+        have opposite signs.
     a : number
-        One end of the bracketing interval [a,b].
+        One end of the bracketing interval :math:`[a, b]`.
     b : number
-        The other end of the bracketing interval [a,b].
+        The other end of the bracketing interval :math:`[a, b]`.
     xtol : number, optional
-        The routine converges when a root is known to lie within xtol of the
-        value return. Should be >= 0.  The routine modifies this to take into
-        account the relative precision of doubles.
+        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
+        parameter must be nonnegative. For nice functions, Brent's
+        method will often satisfy the above condition will ``xtol/2``
+        and ``rtol/2``. [Brent1973]_
     rtol : number, optional
-        The routine converges when a root is known to lie within `rtol` times
-        the value returned of the value returned. Should be >= 0. Defaults to
-        ``np.finfo(float).eps * 2``.
+        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
+        parameter cannot be smaller than its default value of
+        ``4*np.finfo(float).eps``. For nice functions, Brent's
+        method will often satisfy the above condition will ``xtol/2``
+        and ``rtol/2``. [Brent1973]_
     maxiter : number, optional
         if convergence is not achieved in maxiter iterations, an error is
         raised.  Must be >= 0.
@@ -462,13 +466,18 @@ def brenth(f, a, b, args=(),
     b : number
         The other end of the bracketing interval [a,b].
     xtol : number, optional
-        The routine converges when a root is known to lie within xtol of the
-        value return. Should be >= 0.  The routine modifies this to take into
-        account the relative precision of doubles.
+        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
+        parameter must be nonnegative. As with `brentq`, for nice
+        functions the method will often satisfy the above condition
+        will ``xtol/2`` and ``rtol/2``.
     rtol : number, optional
-        The routine converges when a root is known to lie within `rtol` times
-        the value returned of the value returned. Should be >= 0. Defaults to
-        ``np.finfo(float).eps * 2``.
+        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
+        parameter cannot be smaller than its default value of
+        ``4*np.finfo(float).eps``. As with `brentq`, for nice functions
+        the method will often satisfy the above condition will
+        ``xtol/2`` and ``rtol/2``.
     maxiter : number, optional
         if convergence is not achieved in maxiter iterations, an error is
         raised.  Must be >= 0.


### PR DESCRIPTION
The functions optimize.{brentq, brenth, ridder} all achieve a tolerance of `xtol + rtol*res`, where xtol is the absolute tolerance, rtol is the relative tolerance, and res is the computed root. The function optimize.bisect, on the other hand, does not achieve this tolerance because the routine fixes the tolerance to be `xtol + rtol*(|a| + |b|)`, where [a, b] is the initial interval. This pull request modifies optimize.bisect to update the tolerance along with improved guesses for res so that it achieves the same tolerance as optimize.{brentq, brenth, ridder}. Closes gh-5555.
