### PR TITLE
BUG: fix KDTree for input with many identical values

### DIFF
--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -299,8 +299,10 @@ class KDTree(object):
                 # _still_ zero? all must have the same value
                 if not np.all(data == data[0]):
                     raise ValueError("Troublesome data array: %s" % data)
-                maxes[d] = mins[d] = data[0]
-                return self.__build(idx, maxes, mins)
+                fixedmaxes = np.copy(maxes)
+                fixedmins = np.copy(mins)
+                fixedmaxes[d] = fixedmins[d] = data[0]
+                return self.__build(idx, fixedmaxes, fixedmins)
 
             lessmaxes = np.copy(maxes)
             lessmaxes[d] = split

--- a/scipy/spatial/kdtree.py
+++ b/scipy/spatial/kdtree.py
@@ -299,9 +299,8 @@ class KDTree(object):
                 # _still_ zero? all must have the same value
                 if not np.all(data == data[0]):
                     raise ValueError("Troublesome data array: %s" % data)
-                split = data[0]
-                less_idx = np.arange(len(data)-1)
-                greater_idx = np.array([len(data)-1])
+                maxes[d] = mins[d] = data[0]
+                return self.__build(idx, maxes, mins)
 
             lessmaxes = np.copy(maxes)
             lessmaxes[d] = split

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -883,6 +883,11 @@ def test_ball_point_ints():
     assert_equal(sorted([4, 8, 9, 12]),
                  sorted(tree.query_ball_point((2, 0), 1)))
 
+def test_two_big_groups():
+    points = [(1.0,) for i in xrange(100000)] + [(2.0,) for i in xrange(100000)]
+    tree = KDTree(points)
+    # It just must not fall
+
 
 def test_kdtree_comparisons():
     # Regression test: node comparisons were done wrong in 0.12 w/Py3.

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -884,7 +884,7 @@ def test_ball_point_ints():
                  sorted(tree.query_ball_point((2, 0), 1)))
 
 def test_two_big_groups():
-    points = [(1.0,)] * 100000 + [(2.0,)] * 100000
+    points = np.zeros((200000, 1)); points[100000:] = 2.0;
     tree = KDTree(points)
     # It just must not fall
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -884,7 +884,8 @@ def test_ball_point_ints():
                  sorted(tree.query_ball_point((2, 0), 1)))
 
 def test_two_big_groups():
-    points = np.zeros((200000, 1)); points[100000:] = 2.0;
+    points = np.zeros((200000, 1))
+    points[100000:] = 2.0
     tree = KDTree(points)
     # It just must not fall
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -884,7 +884,7 @@ def test_ball_point_ints():
                  sorted(tree.query_ball_point((2, 0), 1)))
 
 def test_two_big_groups():
-    points = [(1.0,) for i in xrange(100000)] + [(2.0,) for i in xrange(100000)]
+    points = [(1.0,)] * 100000 + [(2.0,)] * 100000
     tree = KDTree(points)
     # It just must not fall
 


### PR DESCRIPTION
I found bug when running kdtree on my data. And I fixed it. I think so...
It was segfault when it's a lot of objects with few coordinate values 
