### PR TITLE
TST: skip tests of linalg.norm axis keyword on numpy <= 1.7.x

### DIFF
--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1151,7 +1151,7 @@ class TestVectorNorms(object):
         assert_equal(norm([1,0,3], 0), 2)
         assert_equal(norm([1,2,3], 0), 3)
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.7.0')
+    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_axis_kwd(self):
         a = np.array([[[2, 1], [3, 4]]] * 2, 'd')
         assert_allclose(norm(a, axis=1), [[3.60555128, 4.12310563]] * 2)
@@ -1188,7 +1188,7 @@ class TestMatrixNorms(object):
                         desired = np.linalg.norm(A.astype(t_high), ord=order)
                         np.assert_allclose(actual, desired)
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.7.0')
+    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_axis_kwd(self):
         a = np.array([[[2, 1], [3, 4]]] * 2, 'd')
         b = norm(a, ord=np.inf, axis=(1, 0))


### PR DESCRIPTION
Fixes two trivial failures in https://github.com/scipy/scipy/issues/5578
 Looks like the axis keyword was only added in numpy 1.8: https://github.com/numpy/numpy/blob/v1.7.2/numpy/linalg/linalg.py#L1868
