### PR TITLE
Clarify language of survival function documentation

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -85,7 +85,7 @@ _doc_logcdf = """\
 """
 _doc_sf = """\
 ``sf(x, %(shapes)s, loc=0, scale=1)``
-    Survival function (``1 - cdf`` --- sometimes more accurate).
+    Survival function  (also defined as ``1 - cdf``, but `sf` is sometimes more accurate).
 """
 _doc_logsf = """\
 ``logsf(x, %(shapes)s, loc=0, scale=1)``


### PR DESCRIPTION
Current survival function (`sf`) documentation is unclear which is more accurate: `sf` or `1-cdf`. This PR aims to clarify the language.
