### PR TITLE
DOC: stats: Add a note that stats.burr is the Type III Burr distribution.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -615,7 +615,7 @@ bradford = bradford_gen(a=0.0, b=1.0, name='bradford')
 
 
 class burr_gen(rv_continuous):
-    """A Burr continuous random variable.
+    """A Burr (Type III) continuous random variable.
 
     %(before_notes)s
 
@@ -633,7 +633,15 @@ class burr_gen(rv_continuous):
 
     `burr` takes ``c`` and ``d`` as shape parameters.
 
+    This is the PDF corresponding to the third CDF given in Burr's list;
+    specifically, it is equation (11) in Burr's paper [1]_.
+
     %(after_notes)s
+
+    References
+    ----------
+    .. [1] Burr, I. W. "Cumulative frequency functions", Annals of
+       Mathematical Statistics, 13(2), pp 215-232 (1942).
 
     %(example)s
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -210,7 +210,7 @@ And compare the histogram:
 
 """
 
-_doc_default_locscale = """\  
+_doc_default_locscale = """\
 The probability density above is defined in the "standardized" form. To shift
 and/or scale the distribution use the ``loc`` and ``scale`` parameters.
 Specifically, ``%(name)s.pdf(x, %(shapes)s, loc, scale)`` is identically


### PR DESCRIPTION
Also removed some trailing whitespace from the first line of the
string _doc_default_locscale in _distn_infrastructure.py that was
resulting in a spurious backslash in the distribution docstrings.

Closes gh-5560.
