### PR TITLE
ENH: Add codecov coverage check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ before_install:
   # Speed up install by not compiling Cython
   - travis_retry pip install --install-option="--no-cython-compile" Cython==0.22
   - travis_retry pip install $NUMPYSPEC
-  - travis_retry pip install nose mpmath argparse Pillow
+  - travis_retry pip install nose mpmath argparse Pillow codecov
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - if [ "${TESTMODE}" == "full" ]; then pip install coverage; fi
   - if [ "${USE_WHEEL}" == "1" ]; then pip install wheel; fi
@@ -172,6 +172,13 @@ after_success:
         pip install wheelhouse_uploader
         python -m wheelhouse_uploader upload --local-folder \
           ${TRAVIS_BUILD_DIR}/wheelhouse/ travis-dev-wheels
+    fi
+  # Upload coverage information
+  - if [ "${COVERAGE}" == "--coverage" ]; then
+        pushd build/testenv/lib/python*/site-packages/;
+        cp ../../../../test/.coverage .;
+        codecov;
+        popd;
     fi
 notifications:
   # Perhaps we should have status emails sent to the mailing list, but


### PR DESCRIPTION
Following some discussion on #5009, this would add `codecov` coverage reporting. `codecov`:
1. Can be configured to comment on a PR, and it will update its comment to provide the latest stats
2. Can be configured to "fail" a PR like Travis when coverage drops by a certain amount.
3. Provides nicely formatted diffs.

See the following example on my `scipy` fork:

https://github.com/Eric89GXL/scipy/pull/7
