### PR TITLE
differential_evolution with maxiter=0

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -360,7 +360,10 @@ class DifferentialEvolutionSolver(object):
                              'real valued (min, max) pairs for each value'
                              ' in x')
 
-        self.maxiter = maxiter or 1000
+        self.maxiter = 1000
+        if maxiter is not None:
+            self.maxiter = maxiter
+
         self.maxfun = (maxfun or ((self.maxiter + 1) * popsize *
                                   np.size(self.limits, 1)))
 

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -14,7 +14,7 @@ _MACHEPS = np.finfo(np.float64).eps
 
 
 def differential_evolution(func, bounds, args=(), strategy='best1bin',
-                           maxiter=None, popsize=15, tol=0.01,
+                           maxiter=1000, popsize=15, tol=0.01,
                            mutation=(0.5, 1), recombination=0.7, seed=None,
                            callback=None, disp=False, polish=True,
                            init='latinhypercube'):
@@ -313,7 +313,7 @@ class DifferentialEvolutionSolver(object):
                     'rand2exp': '_rand2'}
 
     def __init__(self, func, bounds, args=(),
-                 strategy='best1bin', maxiter=None, popsize=15,
+                 strategy='best1bin', maxiter=1000, popsize=15,
                  tol=0.01, mutation=(0.5, 1), recombination=0.7, seed=None,
                  maxfun=None, callback=None, disp=False, polish=True,
                  init='latinhypercube'):
@@ -360,9 +360,7 @@ class DifferentialEvolutionSolver(object):
                              'real valued (min, max) pairs for each value'
                              ' in x')
 
-        self.maxiter = 1000
-        if maxiter is not None:
-            self.maxiter = maxiter
+        self.maxiter = maxiter
 
         self.maxfun = (maxfun or ((self.maxiter + 1) * popsize *
                                   np.size(self.limits, 1)))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -365,6 +365,14 @@ class TestDifferentialEvolutionSolver(TestCase):
         bounds = [(-5, 5), (-5, 5)]
         result = differential_evolution(rosen, bounds, popsize=1815, maxiter=1)
 
+    def test_maxiter_zero(self):
+        # if you set maxiter to 0, then you can just get the energies of the
+        # initial population (a crude search).
+        bounds = [(-5, 5), (-5, 5)]
+        result = differential_evolution(rosen, bounds, popsize=10, maxiter=0,
+                                        polish=False)
+        assert_equal(result.nfev, 20)
+
 
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
It would be useful to initialise the population in `scipy.optimize.differential_evolution`, and calculate the energies of all the population members (to find the fittest member), without going through the evolution process. You could think of this as a quick and dirty brute force search.
It should be possible to do this within `DifferentialEvolutionSolver`, but setting `maxiter=0`.  However, the `__init__` method has the following code:

```
self.maxiter = maxiter or 1000
```

This means that `self.maxiter` can never be 0. I would like to change the code to:

```
self.maxiter = 1000
if maxiter is not None:
    self.maxiter = maxiter
```

This will permit initialisation and calculation of the initial population energies, without evolving the population.
