### PR TITLE
MAINT: Ignore spatial/ckdtree.cxx and .h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,8 +192,8 @@ scipy/sparse/sparsetools/csc_impl.h
 scipy/sparse/sparsetools/csr_impl.h
 scipy/sparse/sparsetools/other_impl.h
 scipy/sparse/sparsetools/sparsetools_impl.h
-scipy/spatial/ckdtree/ckdtree.cxx
-scipy/spatial/ckdtree/ckdtree.h
+scipy/spatial/ckdtree.cxx
+scipy/spatial/ckdtree.h
 scipy/spatial/qhull.c
 scipy/special/_ellip_harm_2.c
 scipy/special/_ellip_harm_2.h


### PR DESCRIPTION
Seems like that now `ckdtree.cxx` and `ckdtree.h` are generated in `scipy/spatial`folder. 

I modified .gitignore accordingly.
