### PR TITLE
MAINT: collection of small fixes to test suite

### DIFF
--- a/bento.info
+++ b/bento.info
@@ -38,7 +38,6 @@ DataFiles: tests
     SourceDir: scipy
     Files:
         **/tests/*.py,
-        cluster/tests/*.txt,
         fftpack/tests/*.npz,
         io/arff/tests/data/*.arff,
         io/matlab/tests/data/*.txt,

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -540,7 +540,7 @@ class LossFunctionMixin(object):
         for loss in LOSSES:
             res = least_squares(fun_trivial, 2.0, loss=loss,
                                 method=self.method)
-            assert_allclose(res.x, 0)
+            assert_allclose(res.x, 0, atol=1e-15)
 
         assert_raises(ValueError, least_squares, fun_trivial, 2.0,
                       loss='hinge', method=self.method)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -389,14 +389,18 @@ class TestOptimizeSimple(CheckOptimize):
 
         # First case: NaN from first call.
         func = lambda x: np.nan
-        result = optimize.minimize(func, 0)
+        with np.errstate(invalid='ignore'):
+            result = optimize.minimize(func, 0)
+
         assert_(np.isnan(result['fun']))
         assert_(result['success'] is False)
 
         # Second case: NaN from second call.
         func = lambda x: 0 if x == 0 else np.nan
         fprime = lambda x: np.ones_like(x)  # Steer away from zero.
-        result = optimize.minimize(func, 0, jac=fprime)
+        with np.errstate(invalid='ignore'):
+            result = optimize.minimize(func, 0, jac=fprime)
+
         assert_(np.isnan(result['fun']))
         assert_(result['success'] is False)
 

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -335,6 +335,7 @@ class TestUtilities(object):
 
         npoints = {2: 70, 3: 11, 4: 5, 5: 3}
 
+        _is_32bit_platform = np.intp(0).itemsize < 8
         for ndim in xrange(2, 6):
             # Generate an uniform grid in n-d unit cube
             x = np.linspace(0, 1, npoints[ndim])
@@ -378,10 +379,13 @@ class TestUtilities(object):
             m = (np.random.rand(grid.shape[0]) < 0.2)
             grid[m,:] += 1e6*eps*(np.random.rand(*grid[m,:].shape) - 0.5)
 
-            tri = qhull.Delaunay(grid)
-            self._check_barycentric_transforms(tri, err_msg=err_msg,
-                                               unit_cube=True,
-                                               unit_cube_tol=1e7*eps)
+            if not _is_32bit_platform:
+                # test numerically unstable, and reported to fail on 32-bit
+                # installs
+                tri = qhull.Delaunay(grid)
+                self._check_barycentric_transforms(tri, err_msg=err_msg,
+                                                   unit_cube=True,
+                                                   unit_cube_tol=1e7*eps)
 
 
 class TestVertexNeighborVertices(object):

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -735,9 +735,14 @@ class TestTtest_rel():
 
     def test_fully_masked(self):
         np.random.seed(1234567)
-        outcome = ma.masked_array(np.random.randn(3, 2), mask=[[1, 1, 1], [0, 0, 0]])
-        assert_array_equal(mstats.ttest_rel(outcome[:, 0], outcome[:, 1]), (np.nan, np.nan))
-        assert_array_equal(mstats.ttest_rel([np.nan, np.nan], [1.0, 2.0]), (np.nan, np.nan))
+        outcome = ma.masked_array(np.random.randn(3, 2),
+                                  mask=[[1, 1, 1], [0, 0, 0]])
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore')
+            assert_array_equal(mstats.ttest_rel(outcome[:, 0], outcome[:, 1]),
+                               (np.nan, np.nan))
+            assert_array_equal(mstats.ttest_rel([np.nan, np.nan], [1.0, 2.0]),
+                               (np.nan, np.nan))
 
     def test_result_attributes(self):
         np.random.seed(1234567)
@@ -762,8 +767,11 @@ class TestTtest_rel():
 
     def test_zero_division(self):
         t, p = mstats.ttest_ind([0, 0, 0], [1, 1, 1])
-        assert_equal((np.abs(t), p), (np.inf, 0))
-        assert_array_equal(mstats.ttest_ind([0, 0, 0], [0, 0, 0]), (np.nan, np.nan))
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore')
+            assert_equal((np.abs(t), p), (np.inf, 0))
+            assert_array_equal(mstats.ttest_ind([0, 0, 0], [0, 0, 0]),
+                               (np.nan, np.nan))
 
 class TestTtest_ind():
     def test_vs_nonmasked(self):
@@ -798,8 +806,12 @@ class TestTtest_ind():
     def test_fully_masked(self):
         np.random.seed(1234567)
         outcome = ma.masked_array(np.random.randn(3, 2), mask=[[1, 1, 1], [0, 0, 0]])
-        assert_array_equal(mstats.ttest_ind(outcome[:, 0], outcome[:, 1]), (np.nan, np.nan))
-        assert_array_equal(mstats.ttest_ind([np.nan, np.nan], [1.0, 2.0]), (np.nan, np.nan))
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore')
+            assert_array_equal(mstats.ttest_ind(outcome[:, 0], outcome[:, 1]),
+                               (np.nan, np.nan))
+            assert_array_equal(mstats.ttest_ind([np.nan, np.nan], [1.0, 2.0]),
+                               (np.nan, np.nan))
 
     def test_result_attributes(self):
         np.random.seed(1234567)
@@ -815,12 +827,19 @@ class TestTtest_ind():
 
     def test_zero_division(self):
         t, p = mstats.ttest_ind([0, 0, 0], [1, 1, 1])
-        assert_equal((np.abs(t), p), (np.inf, 0))
-        assert_array_equal(mstats.ttest_ind([0, 0, 0], [0, 0, 0]), (np.nan, np.nan))
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore')
+            assert_equal((np.abs(t), p), (np.inf, 0))
+            assert_array_equal(mstats.ttest_ind([0, 0, 0], [0, 0, 0]),
+                               (np.nan, np.nan))
 
         t, p = mstats.ttest_ind([0, 0, 0], [1, 1, 1], equal_var=False)
-        assert_equal((np.abs(t), p), (np.inf, 0))
-        assert_array_equal(mstats.ttest_ind([0, 0, 0], [0, 0, 0], equal_var=False), (np.nan, np.nan))
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore')
+            assert_equal((np.abs(t), p), (np.inf, 0))
+            assert_array_equal(mstats.ttest_ind([0, 0, 0], [0, 0, 0],
+                                                equal_var=False),
+                               (np.nan, np.nan))
 
 
 class TestTtest_1samp():
@@ -848,8 +867,12 @@ class TestTtest_1samp():
     def test_fully_masked(self):
         np.random.seed(1234567)
         outcome = ma.masked_array(np.random.randn(3), mask=[1, 1, 1])
-        assert_array_equal(mstats.ttest_1samp(outcome, 0.0), (np.nan, np.nan))
-        assert_array_equal(mstats.ttest_1samp((np.nan, np.nan), 0.0), (np.nan, np.nan))
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore')
+            assert_array_equal(mstats.ttest_1samp(outcome, 0.0),
+                               (np.nan, np.nan))
+            assert_array_equal(mstats.ttest_1samp((np.nan, np.nan), 0.0),
+                               (np.nan, np.nan))
 
     def test_result_attributes(self):
         np.random.seed(1234567)
@@ -865,8 +888,11 @@ class TestTtest_1samp():
 
     def test_zero_division(self):
         t, p = mstats.ttest_1samp([0, 0, 0], 1)
-        assert_equal((np.abs(t), p), (np.inf, 0))
-        assert_array_equal(mstats.ttest_1samp([0, 0, 0], 0), (np.nan, np.nan))
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore')
+            assert_equal((np.abs(t), p), (np.inf, 0))
+            assert_array_equal(mstats.ttest_1samp([0, 0, 0], 0),
+                               (np.nan, np.nan))
 
 
 class TestCompareWithStats(TestCase):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1737,13 +1737,15 @@ class TestStudentTest(TestCase):
         np.random.seed(7654567)
         x = stats.norm.rvs(loc=5, scale=10, size=51)
         x[50] = np.nan
-        assert_array_equal(stats.ttest_1samp(x, 5.0), (np.nan, np.nan))
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=RuntimeWarning)
+            assert_array_equal(stats.ttest_1samp(x, 5.0), (np.nan, np.nan))
 
-        assert_array_almost_equal(stats.ttest_1samp(x, 5.0, nan_policy='omit'),
-                                  (-1.6412624074367159, 0.107147027334048005))
-        assert_raises(ValueError, stats.ttest_1samp, x, 5.0, nan_policy='raise')
-        assert_raises(ValueError, stats.ttest_1samp, x, 5.0,
-                      nan_policy='foobar')
+            assert_array_almost_equal(stats.ttest_1samp(x, 5.0, nan_policy='omit'),
+                                      (-1.6412624074367159, 0.107147027334048005))
+            assert_raises(ValueError, stats.ttest_1samp, x, 5.0, nan_policy='raise')
+            assert_raises(ValueError, stats.ttest_1samp, x, 5.0,
+                          nan_policy='foobar')
 
 
 def test_percentileofscore():
@@ -2351,17 +2353,19 @@ def test_ttest_rel():
     y = (stats.norm.rvs(loc=5, scale=10, size=501) +
          stats.norm.rvs(scale=0.2, size=501))
     y[500] = np.nan
-    assert_array_equal(stats.ttest_rel(x, x), (np.nan, np.nan))
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=RuntimeWarning)
+        assert_array_equal(stats.ttest_rel(x, x), (np.nan, np.nan))
 
-    assert_array_almost_equal(stats.ttest_rel(x, y, nan_policy='omit'),
-                              (0.25299925303978066, 0.8003729814201519))
-    assert_raises(ValueError, stats.ttest_rel, x, y, nan_policy='raise')
-    assert_raises(ValueError, stats.ttest_rel, x, y, nan_policy='foobar')
+        assert_array_almost_equal(stats.ttest_rel(x, y, nan_policy='omit'),
+                                  (0.25299925303978066, 0.8003729814201519))
+        assert_raises(ValueError, stats.ttest_rel, x, y, nan_policy='raise')
+        assert_raises(ValueError, stats.ttest_rel, x, y, nan_policy='foobar')
 
-    # test zero division problem
-    t, p = stats.ttest_rel([0, 0, 0], [1, 1, 1])
-    assert_equal((np.abs(t), p), (np.inf, 0))
-    assert_equal(stats.ttest_rel([0, 0, 0], [0, 0, 0]), (np.nan, np.nan))
+        # test zero division problem
+        t, p = stats.ttest_rel([0, 0, 0], [1, 1, 1])
+        assert_equal((np.abs(t), p), (np.inf, 0))
+        assert_equal(stats.ttest_rel([0, 0, 0], [0, 0, 0]), (np.nan, np.nan))
 
     olderr = np.seterr(all='ignore')
     try:
@@ -2442,17 +2446,19 @@ def test_ttest_ind():
     x[500] = np.nan
     y = stats.norm.rvs(loc=5, scale=10, size=500)
 
-    assert_array_equal(stats.ttest_ind(x, y), (np.nan, np.nan))
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=RuntimeWarning)
+        assert_array_equal(stats.ttest_ind(x, y), (np.nan, np.nan))
 
-    assert_array_almost_equal(stats.ttest_ind(x, y, nan_policy='omit'),
-                              (0.24779670949091914, 0.80434267337517906))
-    assert_raises(ValueError, stats.ttest_ind, x, y, nan_policy='raise')
-    assert_raises(ValueError, stats.ttest_ind, x, y, nan_policy='foobar')
+        assert_array_almost_equal(stats.ttest_ind(x, y, nan_policy='omit'),
+                                  (0.24779670949091914, 0.80434267337517906))
+        assert_raises(ValueError, stats.ttest_ind, x, y, nan_policy='raise')
+        assert_raises(ValueError, stats.ttest_ind, x, y, nan_policy='foobar')
 
-    # test zero division problem
-    t, p = stats.ttest_ind([0, 0, 0], [1, 1, 1])
-    assert_equal((np.abs(t), p), (np.inf, 0))
-    assert_equal(stats.ttest_ind([0, 0, 0], [0, 0, 0]), (np.nan, np.nan))
+        # test zero division problem
+        t, p = stats.ttest_ind([0, 0, 0], [1, 1, 1])
+        assert_equal((np.abs(t), p), (np.inf, 0))
+        assert_equal(stats.ttest_ind([0, 0, 0], [0, 0, 0]), (np.nan, np.nan))
 
     olderr = np.seterr(all='ignore')
     try:
@@ -2558,9 +2564,12 @@ def test_ttest_ind_with_uneq_var():
     assert_equal(t.shape, (3, 2))
 
     # test zero division problem
-    t, p = stats.ttest_ind([0, 0, 0], [1, 1, 1], equal_var=False)
-    assert_equal((np.abs(t), p), (np.inf, 0))
-    assert_equal(stats.ttest_ind([0, 0, 0], [0, 0, 0], equal_var=False), (np.nan, np.nan))
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=RuntimeWarning)
+        t, p = stats.ttest_ind([0, 0, 0], [1, 1, 1], equal_var=False)
+        assert_equal((np.abs(t), p), (np.inf, 0))
+        assert_equal(stats.ttest_ind([0, 0, 0], [0, 0, 0], equal_var=False),
+                     (np.nan, np.nan))
 
     olderr = np.seterr(all='ignore')
     try:
@@ -2600,9 +2609,11 @@ def test_ttest_1samp_new():
     assert_equal(t1.shape, (n1,n2))
 
     # test zero division problem
-    t, p = stats.ttest_1samp([0, 0, 0], 1)
-    assert_equal((np.abs(t), p), (np.inf, 0))
-    assert_equal(stats.ttest_1samp([0, 0, 0], 0), (np.nan, np.nan))
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=RuntimeWarning)
+        t, p = stats.ttest_1samp([0, 0, 0], 1)
+        assert_equal((np.abs(t), p), (np.inf, 0))
+        assert_equal(stats.ttest_1samp([0, 0, 0], 0), (np.nan, np.nan))
 
     olderr = np.seterr(all='ignore')
     try:


### PR DESCRIPTION
This fixes several 32-bit-specific problems, as well as the current test errors with numpy 1.10.1 on TravisCI. 
