### PR TITLE
Adds keyword argument to choose faster convolution method

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -332,11 +332,11 @@ enhancing, and edge-detection for an image.
    >>> plt.show()
 
 
-Using :func:`convolve` in the above example would take quite long to run.
 Calculating the convolution in the time domain as above is mainly used for
 filtering when one of the signals is much smaller than the other ( :math:`K\gg
 M` ), otherwise linear filtering is more efficiently calculated in the
-frequency domain provided by the function :func:`fftconvolve`.
+frequency domain provided by the function :func:`fftconvolve`. By default,
+:func:`convolve` estimates the fastest method using :func:`choose_conv_method`.
 
 If the filter function :math:`w[n,m]` can be factored according to
 

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -212,17 +212,29 @@ Thus, the full discrete convolution of two finite sequences of lengths
 
 One dimensional convolution is implemented in SciPy with the function
 :func:`convolve`. This function takes as inputs the signals :math:`x,`
-:math:`h` , and an optional flag and returns the signal :math:`y.` The
-optional flag allows for specification of which part of the output signal to
-return. The default value of 'full' returns the entire signal. If the flag has
-a value of 'same' then only the middle :math:`K` values are returned starting
-at :math:`y\left[\left\lfloor \frac{M-1}{2}\right\rfloor \right]` so that the
-output has the same length as the first input. If the flag has a value of
-'valid' then only the middle :math:`K-M+1=\left(K+1\right)-\left(M+1\right)+1`
-output values are returned where :math:`z` depends on all of the values of the
-smallest input from :math:`h\left[0\right]` to :math:`h\left[M\right].` In
-other words only the values :math:`y\left[M\right]` to :math:`y\left[K\right]`
-inclusive are returned.
+:math:`h` , and two optional flags 'mode' and 'method' and returns the signal
+:math:`y.` 
+
+The first optional flag 'mode' allows for specification of which part of the
+output signal to return. The default value of 'full' returns the entire signal.
+If the flag has a value of 'same' then only the middle :math:`K` values are
+returned starting at :math:`y\left[\left\lfloor \frac{M-1}{2}\right\rfloor
+\right]` so that the output has the same length as the first input. If the flag
+has a value of 'valid' then only the middle
+:math:`K-M+1=\left(K+1\right)-\left(M+1\right)+1` output values are returned
+where :math:`z` depends on all of the values of the smallest input from
+:math:`h\left[0\right]` to :math:`h\left[M\right].` In other words only the
+values :math:`y\left[M\right]` to :math:`y\left[K\right]` inclusive are
+returned.
+
+The second optional flag 'method' determines how the convolution is computed,
+either through the Fourier Transform approach with :func:`fftconvolve` or
+through the direct method. The Fourier Transform method has order
+:math:`O(N\log N)` while the direct method has order :math:`O(N^2)`. Depending
+on the big O constant and the value of :math:`N`, one of these two methods may
+be faster. The default value 'auto' performs a rough calculation and chooses
+the faster method, while the values 'direct' and 'fft' force computation with
+the other two methods.
 
 The code below shows a simple example for convolution of 2 sequences
 

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -228,13 +228,13 @@ values :math:`y\left[M\right]` to :math:`y\left[K\right]` inclusive are
 returned.
 
 The second optional flag 'method' determines how the convolution is computed,
-either through the Fourier Transform approach with :func:`fftconvolve` or
-through the direct method. The Fourier Transform method has order
-:math:`O(N\log N)` while the direct method has order :math:`O(N^2)`. Depending
-on the big O constant and the value of :math:`N`, one of these two methods may
-be faster. The default value 'auto' performs a rough calculation and chooses
-the faster method, while the values 'direct' and 'fft' force computation with
-the other two methods.
+either through the Fourier transform approach with :func:`fftconvolve` or
+through the direct method. By default, it selects the expected faster method.
+The Fourier transform method has order :math:`O(N\log N)` while the direct
+method has order :math:`O(N^2)`. Depending on the big O constant and the value
+of :math:`N`, one of these two methods may be faster. The default value 'auto'
+performs a rough calculation and chooses the expected faster method, while the
+values 'direct' and 'fft' force computation with the other two methods.
 
 The code below shows a simple example for convolution of 2 sequences
 

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -9,12 +9,13 @@ Convolution
 .. autosummary::
    :toctree: generated/
 
-   convolve    -- N-dimensional convolution.
-   correlate   -- N-dimensional correlation.
-   fftconvolve -- N-dimensional convolution using the FFT.
-   convolve2d  -- 2-dimensional convolution (more options).
-   correlate2d -- 2-dimensional correlation (more options).
-   sepfir2d    -- Convolve with a 2-D separable FIR filter.
+   convolve           -- N-dimensional convolution.
+   correlate          -- N-dimensional correlation.
+   fftconvolve        -- N-dimensional convolution using the FFT.
+   convolve2d         -- 2-dimensional convolution (more options).
+   correlate2d        -- 2-dimensional correlation (more options).
+   sepfir2d           -- Convolve with a 2-D separable FIR filter.
+   choose_conv_method -- Chooses faster of FFT and direct convolution methods.
 
 B-splines
 =========

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -147,7 +147,7 @@ def correlate(in1, in2, mode='full', method='auto'):
            Automatically chooses direct or Fourier method based on an estimate
            of which is faster (default).  See `convolve` Notes for more detail.
 
-           .. versionadded:: 0.18.0
+           .. versionadded:: 0.19.0
 
     Returns
     -------
@@ -157,7 +157,7 @@ def correlate(in1, in2, mode='full', method='auto'):
 
     See Also
     --------
-    convolve : contains more documentation on `method`.
+    choose_conv_method : contains more documentation on `method`.
 
     Notes
     -----
@@ -278,7 +278,7 @@ def fftconvolve(in1, in2, mode="full"):
     but can be slower when only a few output values are needed, and can only
     output float arrays (int or object array inputs will be cast to float).
 
-    As of v0.18, `convolve` automatically chooses this method or the direct
+    As of v0.19, `convolve` automatically chooses this method or the direct
     method based on an estimation of which is faster.
 
     Parameters
@@ -612,9 +612,11 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     returns `direct` (e.g., to protect against floating point integer
     precision).
 
+    .. versionadded:: 0.19
+
     Examples
     --------
-    Determine the faster method for a given input:
+    Estimate the fastest method for a given input:
 
     >>> from scipy import signal
     >>> a = np.random.randn(1000)
@@ -627,8 +629,11 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
 
     >>> c = np.random.randn(1000)
     >>> d = np.random.randn(1000000)
+    >>> # `method` works with correlate and convolve
     >>> corr1 = signal.correlate(a, b, mode='same', method=method)
     >>> corr2 = signal.correlate(c, d, mode='same', method=method)
+    >>> conv1 = signal.convolve(a, b, mode='same', method=method)
+    >>> conv2 = signal.convolve(c, d, mode='same', method=method)
 
     """
     volume = asarray(in1)
@@ -703,7 +708,7 @@ def convolve(in1, in2, mode='full', method='auto'):
            Automatically chooses direct or Fourier method based on an estimate
            of which is faster (default).  See Notes for more detail.
 
-           .. versionadded:: 0.18.0
+           .. versionadded:: 0.19.0
 
     Returns
     -------

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -493,9 +493,10 @@ def _np_conv_ok(volume, kernel, mode):
 
 def _fftconvolve_valid(volume, kernel):
     # fftconvolve doesn't support complex256
-    if hasattr(np, "complex256"):
-        if volume.dtype == 'complex256' or kernel.dtype == 'complex256':
-            return False
+    for not_fft_conv_supp in ["complex256", "complex192"]:
+        if hasattr(np, not_fft_conv_supp):
+            if volume.dtype == not_fft_conv_supp or kernel.dtype == not_fft_conv_supp:
+                return False
 
     # for integer input,
     # catch when more precision required than float provides (representing a
@@ -649,8 +650,9 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
         return chosen_method, times
 
     # fftconvolve doesn't support complex256
-    if hasattr(np, "complex256"):
-        if volume.dtype == 'complex256' or kernel.dtype == 'complex256':
+    fftconv_unsup = "complex256" if sys.maxsize > 2**32 else "complex192"
+    if hasattr(np, fftconv_unsup):
+        if volume.dtype == fftconv_unsup or kernel.dtype == fftconv_unsup:
             return 'direct'
 
     # for integer input,

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -514,10 +514,10 @@ def _fftconvolve_valid(volume, kernel):
 
 def _timeit_fast(stmt="pass", setup="pass", repeat=3):
     """
-    Returns a time the function took, in seconds.
+    Returns the time the statement/function took, in seconds.
 
-    Faster, less precise version of IPython's timeit. It can string to time but
-    can also take a callable as input.
+    Faster, less precise version of IPython's timeit. `stmt` can be a statement
+    written as a string or a callable.
 
     Will do only 1 loop (like IPython's timeit) with no repetitions
     (unlike IPython) for very slow functions.  For fast functions, only does
@@ -526,13 +526,13 @@ def _timeit_fast(stmt="pass", setup="pass", repeat=3):
     measured.
 
     """
-    t = timeit.Timer(stmt, setup)
+    timer = timeit.Timer(stmt, setup)
 
-    # determine number so that 5 ms <= total time
+    # determine number of calls per rep so total time for 1 rep >= 5 ms
     x = 0
-    for i in range(0, 10):
-        number = 10**i
-        x = t.timeit(number)  # seconds
+    for p in range(0, 10):
+        number = 10**p
+        x = timer.timeit(number)  # seconds
         if x >= 5e-3 / 10:  # 5 ms for final test, 1/10th that for this one
             break
     if x > 1:  # second
@@ -540,7 +540,7 @@ def _timeit_fast(stmt="pass", setup="pass", repeat=3):
         best = x
     else:
         number *= 10
-        r = t.repeat(repeat, number)
+        r = timer.repeat(repeat, number)
         best = min(r)
 
     sec = best / number
@@ -611,6 +611,24 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
     There are cases when `fftconvolve` supports the inputs but this function
     returns `direct` (e.g., to protect against floating point integer
     precision).
+
+    Examples
+    --------
+    Determine the faster method for a given input:
+
+    >>> from scipy import signal
+    >>> a = np.random.randn(1000)
+    >>> b = np.random.randn(1000000)
+    >>> method = signal.choose_conv_method(a, b, mode='same')
+    >>> method
+    'fft'
+
+    This can then be applied to other arrays of the same dtype and shape:
+
+    >>> c = np.random.randn(1000)
+    >>> d = np.random.randn(1000000)
+    >>> corr1 = signal.correlate(a, b, mode='same', method=method)
+    >>> corr2 = signal.correlate(c, d, mode='same', method=method)
 
     """
     volume = asarray(in1)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2,11 +2,12 @@
 # 1999 -- 2002
 
 from __future__ import division, print_function, absolute_import
+sum_builtin = sum
 
 import warnings
 import threading
 import sys
-from timeit import Timer
+import timeit
 
 from . import sigtools, dlti
 from ._upfirdn import upfirdn, _UpFIRDn, _output_len
@@ -32,7 +33,6 @@ if sys.version_info.major >= 3 and sys.version_info.minor >= 5:
     from math import gcd
 else:
     from fractions import gcd
-sum_builtin = sum
 
 
 __all__ = ['correlate', 'fftconvolve', 'convolve', 'convolve2d', 'correlate2d',
@@ -521,7 +521,7 @@ def _timeit_fast(stmt="pass", setup="pass", repeat=3):
     to take 5 ms, which seems to produce similar results on Windows at
     least, and avoids doing an extraneous cycle that isn't measured.
     """
-    t = Timer(stmt, setup)
+    t = timeit.Timer(stmt, setup)
 
     # determine number so that 5 ms <= total time
     x = 0

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -112,6 +112,12 @@ class _TestConvolve(TestCase):
         assert_array_equal(convolve(big, small, 'valid'),
                            out_array[1:3, 1:3, 1:3])
 
+    def test_convolve_method(self):
+        x = np.random.rand(10)
+        h = np.random.rand(5)
+
+        assert_allclose(convolve(x, h, method='direct'), convolve(x, h, method='fft'))
+
 
 class TestConvolve(_TestConvolve):
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -165,8 +165,11 @@ class TestConvolve(_TestConvolve):
                     x = (0.5 + np.random.rand(100)).astype(dtype)
                     h = (0.5 + np.random.rand(50)).astype(dtype)
 
-                    if x.dtype.kind not in 'buifc' or dtype == np.complex256:
+                    if x.dtype.kind not in 'buifc' \
+                            or np.dtype(dtype).name in {'complex256', 'complex192'}:
                         assert_equal(choose_conv_method(x, h, mode=mode), 'direct')
+                        # continues the for-loop; it will throw an error
+                        # because fftconv doesn't support the dtype
                         continue
 
                     if x.dtype.kind != 'b':
@@ -1544,9 +1547,11 @@ def test_choose_conv_method():
             assert_('fft' in times.keys() and 'direct' in times.keys())
 
         n = 10
-        x = np.ones(n, dtype='complex256')
-        h = x.copy()
-        assert_equal(choose_conv_method(x, h, mode=mode), 'direct')
+        for not_fft_conv_supp in ["complex256", "complex192"]:
+            if hasattr(np, not_fft_conv_supp):
+                x = np.ones(n, dtype=not_fft_conv_supp)
+                h = x.copy()
+                assert_equal(choose_conv_method(x, h, mode=mode), 'direct')
 
         x = np.array([2**51], dtype=int)
         h = x.copy()

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -112,13 +112,6 @@ class _TestConvolve(TestCase):
         assert_array_equal(convolve(big, small, 'valid'),
                            out_array[1:3, 1:3, 1:3])
 
-    def test_convolve_method(self):
-        x = np.random.rand(10)
-        h = np.random.rand(5)
-
-        assert_allclose(convolve(x, h, method='direct'), convolve(x, h, method='fft'))
-
-
 class TestConvolve(_TestConvolve):
 
     def test_valid_mode2(self):
@@ -161,6 +154,16 @@ class TestConvolve(_TestConvolve):
 
         self.assertRaises(ValueError, convolve, *(a, b), **{'mode': 'valid'})
         self.assertRaises(ValueError, convolve, *(b, a), **{'mode': 'valid'})
+
+    def test_convolve_method(self):
+        np.random.seed(42)
+        x = np.random.rand(100)
+        h = np.random.rand(50)
+
+        for mode in ['full', 'valid', 'same']:
+            assert_allclose(convolve(x, h, mode=mode, method='direct'),
+                            convolve(x, h, mode=mode, method='fft'))
+        assert_raises(ValueError, convolve, Decimal(3), Decimal(4), method='fft')
 
 
 class _TestConvolve2d(TestCase):
@@ -1050,6 +1053,20 @@ class _TestCorrelateReal(TestCase):
 
         y_r = np.array([0, 2, 5, 8, 3]).astype(self.dt)
         return a, b, y_r
+
+    def test_method(self):
+        if self.dt == Decimal:
+            assert_raises(ValueError, correlate, 2*[Decimal(3)], 
+                          2*[Decimal(4)], method='fft')
+        else:
+            a, b, y_r = self._setup_rank3()
+            y_fft = correlate(a, b, method='fft')
+            y_direct = correlate(a, b, method='direct')
+
+        assert_array_almost_equal(y_r, y_fft)
+        assert_array_almost_equal(y_r, y_direct)
+        assert_equal(y_fft.dtype, self.dt)
+        assert_equal(y_direct.dtype, self.dt)
 
     def test_rank1_valid(self):
         a, b, y_r = self._setup_rank1()

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -156,15 +156,51 @@ class TestConvolve(_TestConvolve):
         self.assertRaises(ValueError, convolve, *(b, a), **{'mode': 'valid'})
 
     def test_convolve_method(self):
-        np.random.seed(42)
-        x = np.random.rand(100)
-        h = np.random.rand(50)
-
         for mode in ['full', 'valid', 'same']:
-            assert_allclose(convolve(x, h, mode=mode, method='direct'),
-                            convolve(x, h, mode=mode, method='fft'))
-        assert_raises(ValueError, convolve, Decimal(3), Decimal(4), method='fft')
+            for _, dtype_list in np.sctypes.items():
+                np.random.seed(42)
+                for dtype in dtype_list:
+                    if dtype == np.void or dtype == str:
+                        continue
+                    x = (0.5 + np.random.rand(100)).astype(dtype)
+                    h = (0.5 + np.random.rand(50)).astype(dtype)
 
+                    if x.dtype.kind not in 'buifc':
+                        assert_raises(ValueError, convolve, x, h, method='fft')
+                        continue
+
+                    if x.dtype.kind != 'b':
+                        x += 1
+                        h += 1
+
+                    if x.dtype.kind == 'c':
+                        x += 1j * np.random.rand(*x.shape).astype(dtype)
+                        h += 1j * np.random.rand(*h.shape).astype(dtype)
+
+                    results = {'direct':convolve(x, h, mode=mode,
+                                                 method='direct'),
+                               'fft':convolve(x, h, mode=mode, method='fft')}
+
+                    rtol = {'rtol': 2.0e-5} if dtype in {np.complex64,
+                                                         np.float32} else {}
+                    assert_allclose(results['fft'], results['direct'], **rtol)
+                    assert_equal(results['direct'].dtype, results['fft'].dtype)
+
+        # This is really a test that convolving two large integers goes to the
+        # direct method even if they're in the fft method.
+        for n in [10, 20, 50, 51, 52, 53, 54, 60, 63]:
+            fft = convolve([2**n], [2**n], method='fft')
+            direct = convolve([2**n], [2**n], method='direct')
+            assert_equal(fft, direct)
+
+            # this is the case when integer precision gets to us
+            if n < 50:
+                assert_equal(fft, 2**(2*n))
+                assert_equal(direct, 2**(2*n))
+
+        assert_equal(convolve([4], [5], 'valid', 'fft'), 20)
+        assert_raises(ValueError, convolve, 2 * [Decimal(3)], 2 * [Decimal(4)],
+                      method='fft')
 
 class _TestConvolve2d(TestCase):
 
@@ -1063,10 +1099,10 @@ class _TestCorrelateReal(TestCase):
             y_fft = correlate(a, b, method='fft')
             y_direct = correlate(a, b, method='direct')
 
-        assert_array_almost_equal(y_r, y_fft)
-        assert_array_almost_equal(y_r, y_direct)
-        assert_equal(y_fft.dtype, self.dt)
-        assert_equal(y_direct.dtype, self.dt)
+            assert_array_almost_equal(y_r, y_fft)
+            assert_array_almost_equal(y_r, y_direct)
+            assert_equal(y_fft.dtype, self.dt)
+            assert_equal(y_direct.dtype, self.dt)
 
     def test_rank1_valid(self):
         a, b, y_r = self._setup_rank1()

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -183,7 +183,7 @@ class TestConvolve(_TestConvolve):
 
                     rtol = {'rtol': 2.0e-3} if dtype in {np.complex64,
                                                          np.float32} else {}
-                    if type(results['direct']) is np.ndarray:
+                    if isinstance(results['direct'], np.ndarray):
                         assert_allclose(results['fft'], results['direct'], **rtol)
                         assert_equal(results['direct'].dtype, results['fft'].dtype)
 


### PR DESCRIPTION
As mentioned in #2651, this PR adds the keyword argument `method` to `scipy.signal.convolve` to choose the choose the convolution method. `method` can take vales `'auto'`, `'fft'` or `'direct'`.

In [scikit-image PR 1792](https://github.com/scikit-image/scikit-image/pull/1792) we chose the faster convolution method, either the direct method or with fftconvolve. We merged these changes in, and I am merging these changes upstream.
### Timing comparison

In the plot below, the ratio `fft_time / direct_time` is plotted with a log scaling. (more detail can be found in the [scikit-image PR](https://github.com/scikit-image/scikit-image/pull/1792)). These plots are lifted from [the scikit-image PR](https://github.com/scikit-image/scikit-image/pull/1792).

![06ad4864-9f78-11e5-99a4-abbd7a5f63ed](https://cloud.githubusercontent.com/assets/1320475/11801224/77b9f1ae-a2a9-11e5-92ee-6b0bfda0bf4d.png)

In the plot below, the fit values to this ratio are shown. If this ratio is less than 1, this PR chooses to use fftconvolve.

![7cfdbe20-a1aa-11e5-918c-cfd2f187b560](https://cloud.githubusercontent.com/assets/1320475/11801211/630dad2c-a2a9-11e5-846f-0af1712e1954.png)

The complete code and data to generate these plots are in [a gist](https://gist.github.com/scottsievert/01ba818e2b16fcdec34d). These timings were performed on a Mid-2012 Macbook Air.
### Tests

Tests on my machine failed to build. However, my own test passes:

``` python
for pwr in [4, 5, 6, 7, 8, 9, 10, 11, 12]:
    for _ in range(int(1e3)):
        x = np.random.rand(2**pwr)
        h = np.random.rand((2**pwr)//10)

        y1 = convolve(x, h, method='fft')
        y2 = convolve(x, h, method='direct')

        assert np.allclose(y1, y2), "convolve should give equivalent answers"
```
### Documentation

This PR includes documentation of this keyword argument in the docstring. I tried to follow the form of the `mode` keyword argument.
