### PR TITLE
[MRG] test against numpy dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,16 @@ matrix:
       env:
         - TESTMODE=fast
         - COVERAGE=
-        - NUMPYSPEC=numpy
+        # We do not have a TLS cert for the Rackspace CDN that hosts travis-dev-wheels.scipy.org
+        - NUMPYSPEC="--pre --upgrade --no-index --timeout=60 --trusted-host travis-dev-wheels.scipy.org -f http://travis-dev-wheels.scipy.org/ numpy"
         - USE_WHEEL=1
+        - UPLOAD_DEV_WHEEL=1
+        - WHEELHOUSE_UPLOADER_USERNAME=travis.numpy
+        # The following is generated with the command:
+        # travis encrypt -r scipy/scipy WHEELHOUSE_UPLOADER_SECRET=tH3AP1KeY
+        - secure: "cZtB3kMSAY4iYN60SF/Euw2YJvd7FjrjDAkPjQnr8DUxobgjYsdVxtLu2l\
+                   KPt5ZfX5poTFI4kDnPoI6zjvbDvMvVhxp8L9psi19h6mVS+BjAfQ06HYfz\
+                   jdPPiyTOhxfxRQ60SC+617kZSLrP6AeIiPdb+IFcM/987oYBDYOoVb0="
     - python: 3.4
       env:
         - TESTMODE=fast
@@ -154,6 +162,16 @@ after_success:
         git commit -m "Docs build of $TRAVIS_COMMIT"
         git push --set-upstream origin gh-pages --force
         popd
+    fi
+  # Try to upload the generated wheel to a rackspace container
+  # for downstream project to run their CI tests against scipy master
+  - |
+    if [[ ( "${UPLOAD_DEV_WHEEL}" == "1" ) \
+          && ( "${TRAVIS_BRANCH}" == "master" ) \
+          && ( "${TRAVIS_PULL_REQUEST}" == "false" ) ]]; then
+        pip install wheelhouse_uploader
+        python -m wheelhouse_uploader upload --local-folder \
+          ${TRAVIS_BUILD_DIR}/wheelhouse/ travis-dev-wheels
     fi
 notifications:
   # Perhaps we should have status emails sent to the mailing list, but

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3311,7 +3311,9 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
 
     olderr = np.seterr(divide='ignore')  # rs can have elements equal to 1
     try:
-        t = rs * np.sqrt((n-2) / ((rs+1.0)*(1.0-rs)))
+        # clip the small negative values possibly caused by rounding
+        # errors before taking the square root
+        t = rs * np.sqrt(((n-2)/((rs+1.0)*(1.0-rs))).clip(0))
     finally:
         np.seterr(**olderr)
 


### PR DESCRIPTION
This is work in progress for a fix for #5379 building upon the work done for numpy/numpy#6493.

<del>/The current scipy test fails with:<del>

```
======================================================================
ERROR: test_spearmanr (test_mstats_basic.TestCompareWithStats)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.5.0/lib/python3.5/site-packages/scipy/stats/tests/test_mstats_basic.py", line 974, in test_spearmanr
    r, p = stats.spearmanr(x, y)
  File "/home/travis/virtualenv/python3.5.0/lib/python3.5/site-packages/scipy/stats/stats.py", line 3314, in spearmanr
    t = rs * np.sqrt((n-2) / ((rs+1.0)*(1.0-rs)))
RuntimeWarning: invalid value encountered in sqrt

======================================================================
ERROR: test_tie1 (test_stats.TestCorrSpearmanrTies)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.5.0/lib/python3.5/site-packages/scipy/stats/tests/test_stats.py", line 673, in test_tie1
    sr = stats.spearmanr(x, y)
  File "/home/travis/virtualenv/python3.5.0/lib/python3.5/site-packages/scipy/stats/stats.py", line 3314, in spearmanr
    t = rs * np.sqrt((n-2) / ((rs+1.0)*(1.0-rs)))
RuntimeWarning: invalid value encountered in sqrt

----------------------------------------------------------------------
```

<del>It might be revealing a regression in numpy master or it might be caused by something that I don't understand.</del>


<del>I am wondering if we should put this numpy dev entry of the scipy build matrix in allow_failure.</del>


<del>I have not had the opportunity to test the upload section of this PR yet as the tests fail.</del>
