### PR TITLE
Issue #5592- Speeding up signal.resample by using rfft, which halves the size of arrays handled by resample

### DIFF
--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -11,8 +11,19 @@ except ImportError:
 
 from .common import Benchmark
 
+class Resample(Benchmark):
 
+    def setup(self):
+        x = np.linspace(0, 10, 1e6, endpoint=False)
+        self.y = np.cos(-x**2/6.0)
+
+    def time_complex(self):
+        signal.resample(self.y+complex(0,0), 1e7)
+
+    def time_real(self):
+        signal.resample(self.y, 1e7)
 class CalculateWindowedFFT(Benchmark):
+
     def setup(self):
         np.random.seed(5678)
         # Create some long arrays for computation
@@ -23,7 +34,7 @@ class CalculateWindowedFFT(Benchmark):
 
     def time_welch(self):
         signal.welch(self.x)
-    
+
     def time_csd(self):
         signal.csd(self.x, self.y)
 
@@ -122,6 +133,7 @@ class Convolve(Benchmark):
 
 
 class LTI(Benchmark):
+
     def setup(self):
         self.system = signal.lti(1.0, [1, 0, 1])
         self.t = np.arange(0, 100, 0.5)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -1760,8 +1760,6 @@ def resample(x, num, t=None, axis=0, window=None):
                     # X[-1] is only the real part
                     sl[axis] = slice(0, Nx-1)
                     Y[sl] = X[sl]
-                    
-                    # Do something with np.take here
                     sl = [slice(None)] * len(x.shape)
                     sl[axis] = slice(Nx-1, Nx)
                     Y[sl] = 0.5*X[sl]
@@ -1792,6 +1790,9 @@ def resample(x, num, t=None, axis=0, window=None):
         y = fftpack.ifft(Y, axis=axis, overwrite_x=True) 
         y *= (float(num) / float(Nx))
 
+        if not np.issubdtype(x.dtype, complex):
+            y = y.real
+              
     if t is None:
         return y
     else:

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -483,6 +483,46 @@ class TestResample(TestCase):
         win = signal.get_window(('kaiser', 8.0), 160)
         assert_raises(ValueError, signal.resample, sig, num, window=win)
 
+    def test_rfft(self):
+        # Make sure the speed up using rfft gives the same result as the normal 
+        # way using fft
+
+        x = np.linspace(0, 10, 20, endpoint=False)
+        y = np.cos(-x**2/6.0)
+        y_complex = y.copy()+complex(0,0)
+        # Upsample
+        assert_array_almost_equal(signal.resample(y, 100), signal.resample(y_complex, 100).real)
+        assert_array_almost_equal(signal.resample(y, 101), signal.resample(y_complex, 101).real)
+        # Downsample
+        assert_array_almost_equal(signal.resample(y, 11), signal.resample(y_complex, 11).real)
+        assert_array_almost_equal(signal.resample(y, 10), signal.resample(y_complex, 10).real)
+
+    def test_rfft_window(self):
+        # Make sure the speed up using rfft gives the same result as the normal 
+        # way using fft
+
+        x = np.linspace(0, 10, 20, endpoint=False)
+        y = np.cos(-x**2/6.0)
+        y_complex = y.copy()+complex(0,0)
+        # Upsample
+        assert_array_almost_equal(signal.resample(y, 100, window='hamming'), signal.resample(y_complex, 100, window='hamming').real)
+        assert_array_almost_equal(signal.resample(y, 101, window='hamming'), signal.resample(y_complex, 101, window='hamming').real)
+        # Downsample
+        assert_array_almost_equal(signal.resample(y, 11, window='hamming'), signal.resample(y_complex, 11, window='hamming').real)
+        assert_array_almost_equal(signal.resample(y, 10, window='hamming'), signal.resample(y_complex, 10, window='hamming').real)
+
+    def test_axis(self):
+        # Make sure the speed up using rfft gives the same result as the normal 
+        # way using fft
+
+        x = np.linspace(0, 10, 20, endpoint=False)
+        y1 = np.cos(-x**2/6.0)
+        y2 = np.sin(-x**2/6.0)
+        y = np.vstack((y1,y2))
+        y_complex = y.copy()+complex(0,0)
+        # Upsample
+        assert_array_almost_equal(signal.resample(y, 100,axis=1), signal.resample(y_complex, 100, axis=1).real)
+        assert_array_almost_equal(signal.resample(y, 101,axis=1), signal.resample(y_complex, 101, axis=1).real)
 
 class TestCSpline1DEval(TestCase):
 
@@ -507,6 +547,7 @@ class TestOrderFilt(TestCase):
 
 
 class _TestLinearFilter(TestCase):
+
     def generate(self, shape):
         x = np.linspace(0, np.prod(shape) - 1, np.prod(shape)).reshape(shape)
         return self.convert_dtype(x)
@@ -1444,6 +1485,7 @@ class TestHilbert2(object):
 
 
 class TestPartialFractionExpansion(TestCase):
+
     def test_invresz_one_coefficient_bug(self):
         # Regression test for issue in gh-4646.
         r = [1]

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -514,7 +514,7 @@ class TestResample(TestCase):
     def test_axis(self):
         # Make sure the speed up using rfft gives the same result as the normal 
         # way using fft
-
+        
         x = np.linspace(0, 10, 20, endpoint=False)
         y1 = np.cos(-x**2/6.0)
         y2 = np.sin(-x**2/6.0)
@@ -523,6 +523,7 @@ class TestResample(TestCase):
         # Upsample
         assert_array_almost_equal(signal.resample(y, 100,axis=1), signal.resample(y_complex, 100, axis=1).real)
         assert_array_almost_equal(signal.resample(y, 101,axis=1), signal.resample(y_complex, 101, axis=1).real)
+
 
 class TestCSpline1DEval(TestCase):
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -489,13 +489,13 @@ class TestResample(TestCase):
 
         x = np.linspace(0, 10, 20, endpoint=False)
         y = np.cos(-x**2/6.0)
-        y_complex = y.copy()+complex(0,0)
+        y_complex = y.copy()+0j
         # Upsample
-        assert_array_almost_equal(signal.resample(y, 100), signal.resample(y_complex, 100).real)
-        assert_array_almost_equal(signal.resample(y, 101), signal.resample(y_complex, 101).real)
+        assert_allclose(signal.resample(y, 100), signal.resample(y_complex, 100).real)
+        assert_allclose(signal.resample(y, 101), signal.resample(y_complex, 101).real)
         # Downsample
-        assert_array_almost_equal(signal.resample(y, 11), signal.resample(y_complex, 11).real)
-        assert_array_almost_equal(signal.resample(y, 10), signal.resample(y_complex, 10).real)
+        assert_allclose(signal.resample(y, 11), signal.resample(y_complex, 11).real)
+        assert_allclose(signal.resample(y, 10), signal.resample(y_complex, 10).real)
 
     def test_rfft_window(self):
         # Make sure the speed up using rfft gives the same result as the normal 
@@ -503,13 +503,13 @@ class TestResample(TestCase):
 
         x = np.linspace(0, 10, 20, endpoint=False)
         y = np.cos(-x**2/6.0)
-        y_complex = y.copy()+complex(0,0)
+        y_complex = y.copy()+0j
         # Upsample
-        assert_array_almost_equal(signal.resample(y, 100, window='hamming'), signal.resample(y_complex, 100, window='hamming').real)
-        assert_array_almost_equal(signal.resample(y, 101, window='hamming'), signal.resample(y_complex, 101, window='hamming').real)
+        assert_allclose(signal.resample(y, 100, window='hamming'), signal.resample(y_complex, 100, window='hamming').real)
+        assert_allclose(signal.resample(y, 101, window='hamming'), signal.resample(y_complex, 101, window='hamming').real)
         # Downsample
-        assert_array_almost_equal(signal.resample(y, 11, window='hamming'), signal.resample(y_complex, 11, window='hamming').real)
-        assert_array_almost_equal(signal.resample(y, 10, window='hamming'), signal.resample(y_complex, 10, window='hamming').real)
+        assert_allclose(signal.resample(y, 11, window='hamming'), signal.resample(y_complex, 11, window='hamming').real)
+        assert_allclose(signal.resample(y, 10, window='hamming'), signal.resample(y_complex, 10, window='hamming').real)
 
     def test_axis(self):
         # Make sure the speed up using rfft gives the same result as the normal 
@@ -519,10 +519,10 @@ class TestResample(TestCase):
         y1 = np.cos(-x**2/6.0)
         y2 = np.sin(-x**2/6.0)
         y = np.vstack((y1,y2))
-        y_complex = y.copy()+complex(0,0)
+        y_complex = y.copy()+0j
         # Upsample
-        assert_array_almost_equal(signal.resample(y, 100,axis=1), signal.resample(y_complex, 100, axis=1).real)
-        assert_array_almost_equal(signal.resample(y, 101,axis=1), signal.resample(y_complex, 101, axis=1).real)
+        assert_allclose(signal.resample(y, 100,axis=1), signal.resample(y_complex, 100, axis=1).real, atol=1e-9)
+        assert_allclose(signal.resample(y, 101,axis=1), signal.resample(y_complex, 101, axis=1).real, atol=1e-9)
 
 
 class TestCSpline1DEval(TestCase):

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -199,7 +199,7 @@ class TestGetWindow(object):
         sig = np.arange(128)
 
         win = signal.get_window(('kaiser', 8.0), osfactor // 2)
-        assert_raises(ValueError, signal.resample, (sig, len(sig) * osfactor), {'window': win})
+        assert_raises(ValueError, signal.resample, sig, len(sig) * osfactor, window=win)
 
 
 def test_windowfunc_basics():


### PR DESCRIPTION
Closes #5592 Modifies signal.resample to use rfft where possible to achieve ~2x speed up.
Add test to make sure the method using rfft gives the same result as the original method with fft
