### PR TITLE
minor addition to pearson's documentation.

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2963,11 +2963,11 @@ def pearsonr(x, y):
 
     The Pearson correlation coefficient measures the linear relationship
     between two datasets. Strictly speaking, Pearson's correlation requires
-    that each dataset be normally distributed. Like other correlation
-    coefficients, this one varies between -1 and +1 with 0 implying no
-    correlation. Correlations of -1 or +1 imply an exact linear
-    relationship. Positive correlations imply that as x increases, so does
-    y. Negative correlations imply that as x increases, y decreases.
+    that each dataset be normally distributed, and not necessarily zero-mean.
+    Like other correlation coefficients, this one varies between -1 and +1
+    with 0 implying no correlation. Correlations of -1 or +1 imply an exact
+    linear relationship. Positive correlations imply that as x increases, so
+    does y. Negative correlations imply that as x increases, y decreases.
 
     The p-value roughly indicates the probability of an uncorrelated system
     producing datasets that have a Pearson correlation at least as extreme


### PR DESCRIPTION
As I was about to use `pearsonr`, I wondered whether I had to subtract the mean from the data myself. A quick reading of the source code revealed that scipy’s `pearsonr` does it automatically, but I thought it would have been nice for it to be in the documentation. So, I added this information to the docstring in what seems to me is the appropriate place.
