### PR TITLE
ENH: sparse: faster `block_diag` when blocks are equally shaped

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -623,13 +623,14 @@ def bmat(blocks, format=None, dtype=None):
     return coo_matrix((data, (row, col)), shape=shape).asformat(format)
 
 def block_diag(mats, format=None, dtype=None):
-    """      
+    """
     Build a block diagonal sparse matrix from provided matrices.
 
     Parameters
     ----------
     mats : sequence of matrices
-        Input matrices. Can be any combination of lists, numpy.array, numpy.matrix or sparse matrix ("csr', 'coo"...)
+        Input matrices. Can be any combination of lists, numpy.array,
+         numpy.matrix or sparse matrix ("csr', 'coo"...)
     format : str, optional
         The sparse format of the result (e.g. "csr").  If not given, the matrix
         is returned in "coo" format.
@@ -643,7 +644,8 @@ def block_diag(mats, format=None, dtype=None):
 
     Notes
     -----
-    Providing a sequence of equally shaped matrices will provide marginally faster results
+    Providing a sequence of equally shaped matrices
+     will provide marginally faster results
 
     .. versionadded:: 0.18.0
 
@@ -657,7 +659,7 @@ def block_diag(mats, format=None, dtype=None):
     >>> A = coo_matrix([[1, 2], [3, 4]])
     >>> B = coo_matrix([[5, 6], [7, 8]])
     >>> C = coo_matrix([[9, 10], [11,12]])
-    >>> _block_diag((A, B, C)).toarray()
+    >>> block_diag((A, B, C)).toarray()
     array([[ 1,  2,  0,  0,  0,  0],
            [ 3,  4,  0,  0,  0,  0],
            [ 0,  0,  5,  6,  0,  0],
@@ -702,8 +704,10 @@ def block_diag(mats, format=None, dtype=None):
         shape = mats_[0].shape
         data = np.array(mats_, dtype).ravel()
         row_, col_ = np.indices(shape)
-        row = (np.tile(row_.ravel(), n) + np.arange(n).repeat(shape[0] * shape[1]) * shape[0]).ravel()
-        col = (np.tile(col_.ravel(), n) + np.arange(n).repeat(shape[0] * shape[1]) * shape[1]).ravel()
+        row = (np.tile(row_.ravel(), n) +
+               np.arange(n).repeat(shape[0] * shape[1]) * shape[0]).ravel()
+        col = (np.tile(col_.ravel(), n) +
+               np.arange(n).repeat(shape[0] * shape[1]) * shape[1]).ravel()
         total_shape = (shape[0] * n, shape[1] * n)
 
     return coo_matrix((data, (row, col)), shape=total_shape).asformat(format)

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -622,6 +622,7 @@ def bmat(blocks, format=None, dtype=None):
 
     return coo_matrix((data, (row, col)), shape=shape).asformat(format)
 
+
 def block_diag(mats, format=None, dtype=None):
     """
     Build a block diagonal sparse matrix from provided matrices.
@@ -711,8 +712,6 @@ def block_diag(mats, format=None, dtype=None):
         total_shape = (shape[0] * n, shape[1] * n)
 
     return coo_matrix((data, (row, col)), shape=total_shape).asformat(format)
-
-
 
 def random(m, n, density=0.01, format='coo', dtype=None,
            random_state=None, data_rvs=None):

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -667,25 +667,26 @@ def _block_diag(mats, format=None, dtype=None):
 
     
     """
+    
     n = len(mats)
     shape = mats[0].shape
-    
+
     if any([issparse(mat) for mat in mats]):
         mats_ = []
-        for mat in mats : 
-            if issparse(mat): 
+        for mat in mats:
+            if issparse(mat):
                 mats_.append(mat.todense())
-            else : 
+            else:
                 mats_.append(mat)
-    else : 
+    else:
         mats_ = mats
-        
-    data = np.array(mats_,dtype).ravel() 
-    row_, col_ = np.indices(shape)   
-    row = (np.tile(row_.ravel(),n)+np.arange(n).repeat(shape[0]*shape[1])*shape[0]).ravel()
-    col = (np.tile(col_.ravel(),n)+np.arange(n).repeat(shape[0]*shape[1])*shape[1]).ravel()
-    
-    return coo_matrix((data,(row, col)), shape=(shape[0]*n,shape[1]*n)).asformat(format)
+
+    data = np.array(mats_, dtype).ravel()
+    row_, col_ = np.indices(shape)
+    row = (np.tile(row_.ravel(), n) + np.arange(n).repeat(shape[0] * shape[1]) * shape[0]).ravel()
+    col = (np.tile(col_.ravel(), n) + np.arange(n).repeat(shape[0] * shape[1]) * shape[1]).ravel()
+
+    return coo_matrix((data, (row, col)), shape=(shape[0] * n, shape[1] * n)).asformat(format)
 
 def block_diag(mats, format=None, dtype=None):
     """
@@ -730,9 +731,9 @@ def block_diag(mats, format=None, dtype=None):
 
     """
     
-    if all( hasattr(mat,'shape')and(mat.shape == mats[-1].shape) for mat in mats ): 
-        return _block_diag(mats,format=format,dtype=dtype)
-        
+    if all(hasattr(mat, 'shape') and (mat.shape == mats[-1].shape) for mat in mats):
+        return _block_diag(mats, format=format, dtype=dtype)
+    
     nmat = len(mats)
     rows = []
     for ia, a in enumerate(mats):

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -680,7 +680,7 @@ def block_diag(mats, format=None, dtype=None):
         col = []
         row = []
         origin = np.array([0, 0], dtype=np.int)
-        for mat in mats:
+        for mat in mats_:
             if issparse(mat):
                 data.append(mat.data)
                 row.append(mat.row + origin[0])

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -730,7 +730,7 @@ def block_diag(mats, format=None, dtype=None):
 
     """
     
-    if all([mat.shape == mats[-1].shape for mat in mats[:-1]] ):
+    if all( hasattr(mat,'shape')and(mat.shape == mats[-1].shape) for mat in mats ): 
         return _block_diag(mats,format=format,dtype=dtype)
         
     nmat = len(mats)

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -386,6 +386,21 @@ class TestConstructUtils(TestCase):
         assert_equal(construct.block_diag([1]).todense(),
                      matrix([[1]]))
 
+    def test_block_diag_equally_shaped(self):
+        """ basic test for equally shaped matrices """
+        A = coo_matrix([[1,2],[3,4]])
+        B = [[5,6],[7,8]]
+        C = np.array([[9,10],[11,12]])
+
+        expected = matrix([[1, 2, 0, 0, 0,  0],
+                           [3, 4, 0, 0, 0,  0],
+                           [0, 0, 5, 6, 0,  0],
+                           [0, 0, 7, 8, 0,  0],
+                           [0, 0, 0, 0, 9, 10],
+                           [0, 0, 0, 0, 11,12]])
+
+        assert_equal(construct.block_diag((A, B, C)).todense(), expected)
+
     def test_random_sampling(self):
         # Simple sanity checks for sparse random sampling.
         for f in sprand, _sprandn:

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -356,8 +356,8 @@ class TestConstructUtils(TestCase):
 
     def test_block_diag_basic(self):
         """ basic test for block_diag """
-        A = coo_matrix([[1,2],[3,4]])
-        B = coo_matrix([[5],[6]])
+        A = coo_matrix([[1, 2], [3, 4]])
+        B = coo_matrix([[5], [6]])
         C = coo_matrix([[7]])
 
         expected = matrix([[1, 2, 0, 0],
@@ -371,7 +371,7 @@ class TestConstructUtils(TestCase):
     def test_block_diag_scalar_1d_args(self):
         """ block_diag with scalar and 1d arguments """
         # one 1d matrix and a scalar
-        assert_array_equal(construct.block_diag([[2,3], 4]).toarray(),
+        assert_array_equal(construct.block_diag([[2, 3], 4]).toarray(),
                            [[2, 3, 0], [0, 0, 4]])
 
     def test_block_diag_1(self):

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -388,16 +388,16 @@ class TestConstructUtils(TestCase):
 
     def test_block_diag_equally_shaped(self):
         """ basic test for equally shaped matrices """
-        A = coo_matrix([[1,2],[3,4]])
-        B = [[5,6],[7,8]]
-        C = np.array([[9,10],[11,12]])
+        A = coo_matrix([[1, 2], [3, 4]])
+        B = [[5, 6], [7, 8]]
+        C = np.array([[9, 10], [11, 12]])
 
-        expected = matrix([[1, 2, 0, 0, 0,  0],
-                           [3, 4, 0, 0, 0,  0],
-                           [0, 0, 5, 6, 0,  0],
-                           [0, 0, 7, 8, 0,  0],
+        expected = matrix([[1, 2, 0, 0, 0, 0],
+                           [3, 4, 0, 0, 0, 0],
+                           [0, 0, 5, 6, 0, 0],
+                           [0, 0, 7, 8, 0, 0],
                            [0, 0, 0, 0, 9, 10],
-                           [0, 0, 0, 0, 11,12]])
+                           [0, 0, 0, 0, 11, 12]])
 
         assert_equal(construct.block_diag((A, B, C)).todense(), expected)
 


### PR DESCRIPTION
Inspired from Severin Holzer-Graf : http://scipy-dev.scipy.narkive.com/wIFaUvms/sparse-block-diag-improvement

Vastly improve performances for small and big matrices
