### PR TITLE
Add SO(N) rotation matrix generator

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -151,10 +151,11 @@ François Magimel for documentation improvements.
 Josh Levy-Kramer for the log survival function of the hypergeometric distribution
 Will Monroe for bug fixes.
 Bernardo Sulzbach for bug fixes.
-Alexander Grigorevskiy for adding extra LAPACK least-square solvers and 
+Alexander Grigorevskiy for adding extra LAPACK least-square solvers and
     modifying linalg.lstsq function accordingly.
 Sam Lewis for enhancements to the basinhopping module.
 Tadeusz Pudlik for documentation and vectorizing spherical Bessel functions.
+Philip DeBoer for wrapping random SO(N) matrix code in scipy.stats.
 
 Institutions
 ------------

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -126,6 +126,7 @@ Multivariate distributions
    dirichlet             -- Dirichlet
    wishart               -- Wishart
    invwishart            -- Inverse Wishart
+   special_ortho_group   -- SO(N) group
 
 Discrete distributions
 ======================

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -8,7 +8,8 @@ import pickle
 
 from numpy.testing import (assert_allclose, assert_almost_equal,
                            assert_array_almost_equal, assert_equal,
-                           assert_raises, run_module_suite, TestCase)
+                           assert_array_less, assert_raises,
+                           run_module_suite, TestCase)
 
 from test_continuous_basic import check_distribution_rvs
 
@@ -19,9 +20,11 @@ import scipy.linalg
 from scipy.stats._multivariate import _PSD, _lnB
 from scipy.stats import multivariate_normal
 from scipy.stats import matrix_normal
+from scipy.stats import special_ortho_group
 from scipy.stats import dirichlet, beta
 from scipy.stats import wishart, invwishart, chi2, invgamma
 from scipy.stats import norm
+from scipy.stats import ks_2samp
 
 from scipy.integrate import romb
 
@@ -1023,6 +1026,70 @@ class TestInvwishart(TestCase):
         assert_allclose(iw_rvs, manual_iw_rvs)
         assert_allclose(frozen_iw_rvs, manual_iw_rvs)
 
+
+class TestSpecialOrthoGroup(TestCase):
+    def test_reproducibility(self):
+        np.random.seed(514)
+        x = special_ortho_group.rvs(3)
+        expected = np.array([[0.99394515, -0.04527879, 0.10011432],
+                             [-0.04821555, 0.63900322, 0.76769144],
+                             [-0.09873351, -0.76787024, 0.63295101]])
+        assert_array_almost_equal(x, expected)
+
+    def test_invalid_dim(self):
+        assert_raises(ValueError, special_ortho_group.rvs, None)
+        assert_raises(ValueError, special_ortho_group.rvs, (2, 2))
+        assert_raises(ValueError, special_ortho_group.rvs, 1)
+
+    def test_frozen_matrix(self):
+        dim = 7
+        frozen = special_ortho_group(dim)
+
+        rvs1 = frozen.rvs(random_state=1234)
+        rvs2 = special_ortho_group.rvs(dim, random_state=1234)
+
+        assert_equal(rvs1, rvs2)
+
+    def test_det_and_ortho(self):
+        xs = [special_ortho_group.rvs(dim)
+              for dim in range(2,12)
+              for i in range(3)]
+
+        # Test that determinants are always +1
+        dets = [np.linalg.det(x) for x in xs]
+        assert_allclose(dets, [1.]*30, rtol=1e-13)
+
+        # Test that these are orthogonal matrices
+        for x in xs:
+            assert_array_almost_equal(np.dot(x, x.T),
+                                      np.eye(x.shape[0]))
+
+    def test_haar(self):
+        # Test that the distribution is constant under rotation
+        # Every column should have the same distribution
+        # Additionally, the distribution should be invariant under another rotation
+
+        # Generate samples
+        dim = 5
+        samples = 1000  # Not too many, or the test takes too long
+        ks_prob = 0.39  # ...so don't expect much precision
+        np.random.seed(514)
+        xs = special_ortho_group.rvs(dim, size=samples)
+
+        # Dot a few rows (0, 1, 2) with unit vectors (0, 2, 4, 3),
+        #   effectively picking off entries in the matrices of xs.
+        #   These projections should all have the same disribution,
+        #     establishing rotational invariance. We use the two-sided
+        #     KS test to confirm this.
+        #   We could instead test that angles between random vectors
+        #     are uniformly distributed, but the below is sufficient.
+        #   It is not feasible to consider all pairs, so pick a few.
+        els = ((0,0), (0,2), (1,4), (2,3))
+        #proj = {(er, ec): [x[er][ec] for x in xs] for er, ec in els}
+        proj = dict(((er, ec), sorted([x[er][ec] for x in xs])) for er, ec in els)
+        pairs = [(e0, e1) for e0 in els for e1 in els if e0 > e1]
+        ks_tests = [ks_2samp(proj[p0], proj[p1])[1] for (p0, p1) in pairs]
+        assert_array_less([ks_prob]*len(pairs), ks_tests)
 
 def check_pickling(distfn, args):
     # check that a distribution instance pickles and unpickles


### PR DESCRIPTION
I am looking for feedback on this code. It generates random rotations, ie elements of SO(N). I plan to add O(N) as well, but I'd like to be sure of the format first as the two algorithms are very similar.

I have only implemented rvs. The N is specified by dim. You can ask for multiple samples using size, and I return those in a list. Is that acceptable? Mathematically the natural way to embed n results would be as diagonal matrices in an n*N space. Would that be preferable to a list? One argument against it is that it is easier to construct the block-diagonal matrix than to decompose it.

Is it important to have a frozen version as well?

I have not submitted any tests. What are some good ones? A good test that this is generating the samples from the Haar distribution is to
a. generate n samples from SO(N)
b. compute the eigenvalues (N*n of them) and describe their distribution
c. then rotate all n samples by another element of SO(N)
d. update the eigenvalue distribution
e. show that the two eigenvalue distributions are similar
You could repeat step c, but I would find a single sample convincing.

Would we fix n and N? N = 5, n = 1000? Are there timing benchmarks to keep beneath?

Additional tests:
2. Show determinant == 1 for a single sample in each N in range(10)
3. Show x x.T == eye(N) for each sample in test 2
