### PR TITLE
ENH: special: Add vectorized spherical Bessel functions.

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -151,6 +151,14 @@ Derivatives of Bessel Functions
 Spherical Bessel Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. autosummary::
+   :toctree: generated/
+
+   spherical_jn -- Spherical Bessel function of the first kind, jn(z)
+   spherical_yn -- Spherical Bessel function of the second kind, yn(z)
+   spherical_in -- Modified spherical Bessel function of the first kind, in(z)
+   spherical_kn -- Modified spherical Bessel function of the second kind, kn(z)
+
 These are not universal functions:
 
 .. autosummary::
@@ -633,6 +641,8 @@ from .orthogonal import *
 from .spfun_stats import multigammaln
 from ._ellip_harm import ellip_harm, ellip_harm_2, ellip_normal
 from .lambertw import lambertw
+from ._spherical_bessel import (spherical_jn, spherical_yn, spherical_in,
+                                spherical_kn)
 
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/scipy/special/_complexstuff.pxd
+++ b/scipy/special/_complexstuff.pxd
@@ -90,4 +90,3 @@ cdef inline double_complex zpack(double zr, double zi) nogil:
     z.real = zr
     z.imag = zi
     return (<double_complex*>&z)[0]
-

--- a/scipy/special/_spherical_bessel.pxd
+++ b/scipy/special/_spherical_bessel.pxd
@@ -1,0 +1,372 @@
+# -*-cython-*-
+#
+# Implementation of spherical Bessel functions and modified spherical Bessel
+# functions of the first and second kinds, as well as their derivatives.
+#
+# Author: Tadeusz Pudlik
+#
+# Distributed under the same license as SciPy.
+#
+# I attempt to correctly handle the edge cases (0 and infinity), but this is
+# tricky: the values of the functions often depend on the direction in which
+# the limit is taken. At zero, I follow the convention of numpy (1.9.2),
+# which treats zero differently depending on its type:
+#
+#   >>> np.cos(0)/0
+#   inf
+#   >>> np.cos(0+0j)/(0+0j)
+#   inf + nan*j
+#
+# So, real zero is assumed to be "positive zero", while complex zero has an
+# unspecified sign and produces nans.  Similarly, complex infinity is taken to
+# represent the "point at infinity", an ambiguity which for some functions
+# makes `nan` the correct return value.
+
+import cython
+from libc.math cimport cos, sin, sqrt, M_PI_2
+
+from numpy cimport npy_cdouble
+from _complexstuff cimport *
+
+cimport sf_error
+
+cdef extern from "amos_wrappers.h":
+    npy_cdouble cbesi_wrap( double v, npy_cdouble z) nogil
+    npy_cdouble cbesj_wrap(double v, npy_cdouble z) nogil
+    double cbesj_wrap_real(double v, double x) nogil
+    npy_cdouble cbesk_wrap(double v, npy_cdouble z) nogil
+    double cbesk_wrap_real(double v, double x) nogil
+    npy_cdouble cbesy_wrap(double v, npy_cdouble z) nogil
+    double cbesy_wrap_real(double v, double x) nogil
+
+cdef extern from "cephes.h":
+    double iv(double v, double x) nogil
+
+
+# Fused type wrappers
+
+cdef inline number_t cbesj(double v, number_t z) nogil:
+    cdef npy_cdouble r
+    if number_t is double:
+        return cbesj_wrap_real(v, z)
+    else:
+        r = cbesj_wrap(v, (<npy_cdouble*>&z)[0])
+        return (<number_t*>&r)[0]
+
+cdef inline number_t cbesy(double v, number_t z) nogil:
+    cdef npy_cdouble r
+    if number_t is double:
+        return cbesy_wrap_real(v, z)
+    else:
+        r = cbesy_wrap(v, (<npy_cdouble*>&z)[0])
+        return (<number_t*>&r)[0]
+
+cdef inline number_t cbesk(double v, number_t z) nogil:
+    cdef npy_cdouble r
+    if number_t is double:
+        return cbesk_wrap_real(v, z)
+    else:
+        r = cbesk_wrap(v, (<npy_cdouble*>&z)[0])
+        return (<number_t*>&r)[0]
+
+
+# Spherical Bessel functions
+
+@cython.cdivision(True)
+cdef inline double spherical_jn_real(long n, double x) nogil:
+    cdef double s0, s1, sn
+    cdef int idx
+
+    if npy_isnan(x):
+        return x
+    if n < 0:
+        sf_error.error("spherical_jn", sf_error.DOMAIN, NULL)
+        return nan
+    if x == inf or x == -inf:
+        return 0
+    if x == 0:
+        if n == 0:
+            return 1
+        else:
+            return 0
+
+    if n > 0 and n >= x:
+        return sqrt(M_PI_2/x)*cbesj(n + 0.5, x)
+
+    s0 = sin(x)/x
+    if n == 0:
+        return s0
+    s1 = (s0 - cos(x))/x
+    if n == 1:
+        return s1
+
+    for idx in range(n - 1):
+        sn = (2*idx + 3)*s1/x - s0
+        s0 = s1
+        s1 = sn
+        if npy_isinf(sn):
+            # Overflow occurred already: terminate recurrence.
+            return sn
+
+    return sn
+
+
+@cython.cdivision(True)
+cdef inline double complex spherical_jn_complex(long n, double complex z) nogil:
+    cdef double complex out
+    if zisnan(z):
+        return z
+    if n < 0:
+        sf_error.error("spherical_jn", sf_error.DOMAIN, NULL)
+        return nan
+    if z.real == inf or z.real == -inf:
+        # http://dlmf.nist.gov/10.52.E3
+        if z.imag == 0:
+            return 0
+        else:
+            return (1+1j)*inf
+    if z.real == 0 and z.imag == 0:
+        if n == 0:
+            return 1
+        else:
+            return 0
+
+    out = zsqrt(M_PI_2/z)*cbesj(n + 0.5, z)
+
+    if z.imag == 0:
+        # Small imaginary part is spurious
+        return out.real
+    else:
+        return out
+
+
+@cython.cdivision(True)
+cdef inline double spherical_yn_real(long n, double x) nogil:
+    cdef double s0, s1, sn
+    cdef int idx
+
+    if npy_isnan(x):
+        return x
+    if n < 0:
+        sf_error.error("spherical_yn", sf_error.DOMAIN, NULL)
+        return nan
+    if x < 0:
+        return (-1)**(n+1)*spherical_yn_real(n, -x)
+    if x == inf or x == -inf:
+        return 0
+    if x == 0:
+        return -inf
+
+    s0 = -cos(x)/x
+    if n == 0:
+        return s0
+    s1 = (s0 - sin(x))/x
+    if n == 1:
+        return s1
+
+    for idx in range(n - 1):
+        sn = (2*idx + 3)*s1/x - s0
+        s0 = s1
+        s1 = sn
+        if npy_isinf(sn):
+            # Overflow occurred already: terminate recurrence.
+            return sn
+
+    return sn
+
+
+@cython.cdivision(True)
+cdef inline double complex spherical_yn_complex(long n, double complex z) nogil:
+
+    if zisnan(z):
+        return z
+    if n < 0:
+        sf_error.error("spherical_yn", sf_error.DOMAIN, NULL)
+        return nan
+    if z.real == 0 and z.imag == 0:
+        # http://dlmf.nist.gov/10.52.E2
+        return nan
+    if z.real == inf or z.real == -inf:
+        # http://dlmf.nist.gov/10.52.E3
+        if z.imag == 0:
+            return 0
+        else:
+            return (1+1j)*inf
+
+    return zsqrt(M_PI_2/z)*cbesy(n + 0.5, z)
+
+
+@cython.cdivision(True)
+cdef inline double spherical_in_real(long n, double z) nogil:
+
+    if npy_isnan(z):
+        return z
+    if n < 0:
+        sf_error.error("spherical_in", sf_error.DOMAIN, NULL)
+        return nan
+    if z == 0:
+        # http://dlmf.nist.gov/10.52.E1
+        if n == 0:
+            return 1
+        else:
+            return 0
+    if npy_isinf(z):
+        # http://dlmf.nist.gov/10.49.E8
+        if z == -inf:
+            return (-1)**n*inf
+        else:
+            return inf
+
+    return sqrt(M_PI_2/z)*iv(n + 0.5, z)
+
+
+@cython.cdivision(True)
+cdef inline double complex spherical_in_complex(long n, double complex z) nogil:
+    cdef npy_cdouble s
+
+    if zisnan(z):
+        return z
+    if n < 0:
+        sf_error.error("spherical_in", sf_error.DOMAIN, NULL)
+        return nan
+    if zabs(z) == 0:
+        # http://dlmf.nist.gov/10.52.E1
+        if n == 0:
+            return 1
+        else:
+            return 0
+    if zisinf(z):
+        # http://dlmf.nist.gov/10.52.E5
+        if z.imag == 0:
+            if z.real == -inf:
+                return (-1)**n*inf
+            else:
+                return inf
+        else:
+            return nan
+
+    s = cbesi_wrap(n + 0.5, (<npy_cdouble*>&z)[0])
+    return zsqrt(M_PI_2/z)*(<double complex*>&s)[0]
+
+
+@cython.cdivision(True)
+cdef inline double spherical_kn_real(long n, double z) nogil:
+
+    if npy_isnan(z):
+        return z
+    if n < 0:
+        sf_error.error("spherical_kn", sf_error.DOMAIN, NULL)
+        return nan
+    if z == 0:
+        return inf
+    if npy_isinf(z):
+        # http://dlmf.nist.gov/10.52.E6
+        if z == inf:
+            return 0
+        else:
+            return -inf
+
+    return sqrt(M_PI_2/z)*cbesk(n + 0.5, z)
+
+
+@cython.cdivision(True)
+cdef inline double complex spherical_kn_complex(long n, double complex z) nogil:
+
+    if zisnan(z):
+        return z
+    if n < 0:
+        sf_error.error("spherical_kn", sf_error.DOMAIN, NULL)
+        return nan
+    if zabs(z) == 0:
+        return nan
+    if zisinf(z):
+        # http://dlmf.nist.gov/10.52.E6
+        if z.imag == 0:
+            if z.real == inf:
+                return 0
+            else:
+                return -inf
+        else:
+            return nan
+
+    return zsqrt(M_PI_2/z)*cbesk(n + 0.5, z)
+
+
+# Derivatives
+
+@cython.cdivision(True)
+cdef inline double spherical_jn_d_real(long n, double x) nogil:
+    if n == 0:
+        return -spherical_jn_real(1, x)
+    else:
+        if x == 0:
+            return 0
+        return (spherical_jn_real(n - 1, x) -
+                (n + 1)*spherical_jn_real(n, x)/x)
+
+
+@cython.cdivision(True)
+cdef inline double complex spherical_jn_d_complex(long n, double complex x) nogil:
+    if n == 0:
+        return -spherical_jn_complex(1, x)
+    else:
+        return (spherical_jn_complex(n - 1, x) -
+                (n + 1)*spherical_jn_complex(n, x)/x)
+
+
+@cython.cdivision(True)
+cdef inline double spherical_yn_d_real(long n, double x) nogil:
+    if n == 0:
+        return -spherical_yn_real(1, x)
+    else:
+        return (spherical_yn_real(n - 1, x) -
+                (n + 1)*spherical_yn_real(n, x)/x)
+
+
+@cython.cdivision(True)
+cdef inline double complex spherical_yn_d_complex(long n, double complex x) nogil:
+    if n == 0:
+        return -spherical_yn_complex(1, x)
+    else:
+        return (spherical_yn_complex(n - 1, x) -
+                (n + 1)*spherical_yn_complex(n, x)/x)
+
+
+@cython.cdivision(True)
+cdef inline double spherical_in_d_real(long n, double x) nogil:
+    if n == 0:
+        return spherical_in_real(1, x)
+    else:
+        if x == 0:
+            return 0
+        return (spherical_in_real(n - 1, x) -
+                (n + 1)*spherical_in_real(n, x)/x)
+
+
+@cython.cdivision(True)
+cdef inline double complex spherical_in_d_complex(long n, double complex x) nogil:
+    if n == 0:
+        return spherical_in_complex(1, x)
+    else:
+        if x == 0:
+            return 0
+        return (spherical_in_complex(n - 1, x) -
+                (n + 1)*spherical_in_complex(n, x)/x)
+
+
+@cython.cdivision(True)
+cdef inline double spherical_kn_d_real(long n, double x) nogil:
+    if n == 0:
+        return -spherical_kn_real(1, x)
+    else:
+        return (-spherical_kn_real(n - 1, x) -
+                (n + 1)*spherical_kn_real(n, x)/x)
+
+
+@cython.cdivision(True)
+cdef inline double complex spherical_kn_d_complex(long n, double complex x) nogil:
+    if n == 0:
+        return -spherical_kn_complex(1, x)
+    else:
+        return (-spherical_kn_complex(n - 1, x) -
+                (n + 1)*spherical_kn_complex(n, x)/x)

--- a/scipy/special/_spherical_bessel.py
+++ b/scipy/special/_spherical_bessel.py
@@ -1,0 +1,205 @@
+from __future__ import division, print_function, absolute_import
+
+from ._ufuncs import (_spherical_jn, _spherical_yn, _spherical_in,
+                      _spherical_kn, _spherical_jn_d, _spherical_yn_d,
+                      _spherical_in_d, _spherical_kn_d)
+
+def spherical_jn(n, z, derivative=False):
+    r"""Spherical Bessel function of the first kind or its derivative.
+
+    Defined as [1]_,
+
+    .. math:: j_n(z) = \sqrt{\frac{\pi}{2z}} J_{n + 1/2}(z),
+
+    where :math:`J_n` is the Bessel function of the first kind.
+
+    Parameters
+    ----------
+    n : int, array_like
+        Order of the Bessel function (n >= 0).
+    z : complex or float, array_like
+        Argument of the Bessel function.
+    derivative : bool, optional
+        If True, the value of the derivative (rather than the function
+        itself) is returned.
+
+    Returns
+    -------
+    jn : ndarray
+
+    Notes
+    -----
+    For real arguments greater than the order, the function is computed
+    using the ascending recurrence [2]_.  For small real or complex
+    arguments, the definitional relation to the cylindrical Bessel function
+    of the first kind is used.
+
+    The derivative is computed using the relations [3]_,
+
+    .. math::
+        j_n' = j_{n-1} - \frac{n + 1}{2} j_n.
+
+        j_0' = -j_1
+
+
+    .. versionadded:: 0.18.0
+
+    References
+    ----------
+    .. [1] http://dlmf.nist.gov/10.47.E3
+    .. [2] http://dlmf.nist.gov/10.51.E1
+    .. [3] http://dlmf.nist.gov/10.51.E2
+    """
+    if derivative:
+        return _spherical_jn_d(n, z)
+    else:
+        return _spherical_jn(n, z)
+
+
+def spherical_yn(n, z, derivative=False):
+    r"""Spherical Bessel function of the second kind or its derivative.
+
+    Defined as [1]_,
+
+    .. math:: y_n(z) = \sqrt{\frac{\pi}{2z}} Y_{n + 1/2}(z),
+
+    where :math:`Y_n` is the Bessel function of the second kind.
+
+    Parameters
+    ----------
+    n : int, array_like
+        Order of the Bessel function (n >= 0).
+    z : complex or float, array_like
+        Argument of the Bessel function.
+    derivative : bool, optional
+        If True, the value of the derivative (rather than the function
+        itself) is returned.
+
+    Returns
+    -------
+    yn : ndarray
+
+    Notes
+    -----
+    For real arguments, the function is computed using the ascending
+    recurrence [2]_.  For complex arguments, the definitional relation to
+    the cylindrical Bessel function of the second kind is used.
+
+    The derivative is computed using the relations [3]_,
+
+    .. math::
+        y_n' = y_{n-1} - \frac{n + 1}{2} y_n.
+
+        y_0' = -y_1
+
+
+    .. versionadded:: 0.18.0
+
+    References
+    ----------
+    .. [1] http://dlmf.nist.gov/10.47.E4
+    .. [2] http://dlmf.nist.gov/10.51.E1
+    .. [3] http://dlmf.nist.gov/10.51.E2
+    """
+    if derivative:
+        return _spherical_yn_d(n, z)
+    else:
+        return _spherical_yn(n, z)
+
+
+def spherical_in(n, z, derivative=False):
+    r"""Modified spherical Bessel function of the first kind or its derivative.
+
+    Defined as [1]_,
+
+    .. math:: i_n(z) = \sqrt{\frac{\pi}{2z}} I_{n + 1/2}(z),
+
+    where :math:`I_n` is the modified Bessel function of the first kind.
+
+    Parameters
+    ----------
+    n : int, array_like
+        Order of the Bessel function (n >= 0).
+    z : complex or float, array_like
+        Argument of the Bessel function.
+    derivative : bool, optional
+        If True, the value of the derivative (rather than the function
+        itself) is returned.
+
+    Returns
+    -------
+    in : ndarray
+
+    Notes
+    -----
+    The function is computed using its definitional relation to the
+    modified cylindrical Bessel function of the first kind.
+
+    The derivative is computed using the relations [2]_,
+
+    .. math::
+        i_n' = i_{n-1} - \frac{n + 1}{2} i_n.
+
+        i_1' = i_0
+
+
+    .. versionadded:: 0.18.0
+
+    References
+    ----------
+    .. [1] http://dlmf.nist.gov/10.47.E7
+    .. [2] http://dlmf.nist.gov/10.51.E5
+    """
+    if derivative:
+        return _spherical_in_d(n, z)
+    else:
+        return _spherical_in(n, z)
+
+
+def spherical_kn(n, z, derivative=False):
+    r"""Modified spherical Bessel function of the second kind or its derivative.
+
+    Defined as [1]_,
+
+    .. math:: k_n(z) = \sqrt{\frac{\pi}{2z}} K_{n + 1/2}(z),
+
+    where :math:`K_n` is the modified Bessel function of the second kind.
+
+    Parameters
+    ----------
+    n : int, array_like
+        Order of the Bessel function (n >= 0).
+    z : complex or float, array_like
+        Argument of the Bessel function.
+    derivative : bool, optional
+        If True, the value of the derivative (rather than the function
+        itself) is returned.
+
+    Returns
+    -------
+    kn : ndarray
+
+    Notes
+    -----
+    The function is computed using its definitional relation to the
+    modified cylindrical Bessel function of the second kind.
+
+    The derivative is computed using the relations [2]_,
+
+    .. math::
+        k_n' = -k_{n-1} - \frac{n + 1}{2} k_n.
+
+        k_0' = -k_1
+
+
+    .. versionadded:: 0.18.0
+
+    References
+    ----------
+    .. [1] http://dlmf.nist.gov/10.47.E9
+    .. [2] http://dlmf.nist.gov/10.51.E5
+    """
+    if derivative:
+        return _spherical_kn_d(n, z)
+    else:
+        return _spherical_kn(n, z)

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -1090,21 +1090,17 @@ cdef void loop_i_d_dd_As_f_ff(char **args, np.npy_intp *dims, np.npy_intp *steps
         op1 += steps[2]
     sf_error.check_fpe(func_name)
 
-cdef void loop_d_id__As_ld_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_D_lD__As_lD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
     cdef char *ip0 = args[0]
     cdef char *ip1 = args[1]
     cdef char *op0 = args[2]
-    cdef double ov0
+    cdef double complex ov0
     for i in range(n):
-        if <int>(<long*>ip0)[0] == (<long*>ip0)[0]:
-            ov0 = (<double(*)(int, double) nogil>func)(<int>(<long*>ip0)[0], <double>(<double*>ip1)[0])
-        else:
-            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
-            ov0 = <double>NPY_NAN
-        (<double *>op0)[0] = <double>ov0
+        ov0 = (<double complex(*)(long, double complex) nogil>func)(<long>(<long*>ip0)[0], <double complex>(<double complex*>ip1)[0])
+        (<double complex *>op0)[0] = <double complex>ov0
         ip0 += steps[0]
         ip1 += steps[1]
         op0 += steps[2]
@@ -1188,6 +1184,26 @@ cdef void loop_i_D_DDDD_As_D_DDDD(char **args, np.npy_intp *dims, np.npy_intp *s
         op3 += steps[4]
     sf_error.check_fpe(func_name)
 
+cdef void loop_d_id__As_ld_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef double ov0
+    for i in range(n):
+        if <int>(<long*>ip0)[0] == (<long*>ip0)[0]:
+            ov0 = (<double(*)(int, double) nogil>func)(<int>(<long*>ip0)[0], <double>(<double*>ip1)[0])
+        else:
+            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
+            ov0 = <double>NPY_NAN
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
+    sf_error.check_fpe(func_name)
+
 cdef void loop_g_g__As_g_g(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
@@ -1227,6 +1243,54 @@ cdef _proto_ellip_harmonic_unsafe_t *_proto_ellip_harmonic_unsafe_t_var = &_func
 from lambertw cimport lambertw_scalar as _func_lambertw_scalar
 ctypedef double complex _proto_lambertw_scalar_t(double complex, long, double) nogil
 cdef _proto_lambertw_scalar_t *_proto_lambertw_scalar_t_var = &_func_lambertw_scalar
+from _spherical_bessel cimport spherical_in_real as _func_spherical_in_real
+ctypedef double _proto_spherical_in_real_t(long, double) nogil
+cdef _proto_spherical_in_real_t *_proto_spherical_in_real_t_var = &_func_spherical_in_real
+from _spherical_bessel cimport spherical_in_complex as _func_spherical_in_complex
+ctypedef double complex _proto_spherical_in_complex_t(long, double complex) nogil
+cdef _proto_spherical_in_complex_t *_proto_spherical_in_complex_t_var = &_func_spherical_in_complex
+from _spherical_bessel cimport spherical_in_d_real as _func_spherical_in_d_real
+ctypedef double _proto_spherical_in_d_real_t(long, double) nogil
+cdef _proto_spherical_in_d_real_t *_proto_spherical_in_d_real_t_var = &_func_spherical_in_d_real
+from _spherical_bessel cimport spherical_in_d_complex as _func_spherical_in_d_complex
+ctypedef double complex _proto_spherical_in_d_complex_t(long, double complex) nogil
+cdef _proto_spherical_in_d_complex_t *_proto_spherical_in_d_complex_t_var = &_func_spherical_in_d_complex
+from _spherical_bessel cimport spherical_jn_real as _func_spherical_jn_real
+ctypedef double _proto_spherical_jn_real_t(long, double) nogil
+cdef _proto_spherical_jn_real_t *_proto_spherical_jn_real_t_var = &_func_spherical_jn_real
+from _spherical_bessel cimport spherical_jn_complex as _func_spherical_jn_complex
+ctypedef double complex _proto_spherical_jn_complex_t(long, double complex) nogil
+cdef _proto_spherical_jn_complex_t *_proto_spherical_jn_complex_t_var = &_func_spherical_jn_complex
+from _spherical_bessel cimport spherical_jn_d_real as _func_spherical_jn_d_real
+ctypedef double _proto_spherical_jn_d_real_t(long, double) nogil
+cdef _proto_spherical_jn_d_real_t *_proto_spherical_jn_d_real_t_var = &_func_spherical_jn_d_real
+from _spherical_bessel cimport spherical_jn_d_complex as _func_spherical_jn_d_complex
+ctypedef double complex _proto_spherical_jn_d_complex_t(long, double complex) nogil
+cdef _proto_spherical_jn_d_complex_t *_proto_spherical_jn_d_complex_t_var = &_func_spherical_jn_d_complex
+from _spherical_bessel cimport spherical_kn_real as _func_spherical_kn_real
+ctypedef double _proto_spherical_kn_real_t(long, double) nogil
+cdef _proto_spherical_kn_real_t *_proto_spherical_kn_real_t_var = &_func_spherical_kn_real
+from _spherical_bessel cimport spherical_kn_complex as _func_spherical_kn_complex
+ctypedef double complex _proto_spherical_kn_complex_t(long, double complex) nogil
+cdef _proto_spherical_kn_complex_t *_proto_spherical_kn_complex_t_var = &_func_spherical_kn_complex
+from _spherical_bessel cimport spherical_kn_d_real as _func_spherical_kn_d_real
+ctypedef double _proto_spherical_kn_d_real_t(long, double) nogil
+cdef _proto_spherical_kn_d_real_t *_proto_spherical_kn_d_real_t_var = &_func_spherical_kn_d_real
+from _spherical_bessel cimport spherical_kn_d_complex as _func_spherical_kn_d_complex
+ctypedef double complex _proto_spherical_kn_d_complex_t(long, double complex) nogil
+cdef _proto_spherical_kn_d_complex_t *_proto_spherical_kn_d_complex_t_var = &_func_spherical_kn_d_complex
+from _spherical_bessel cimport spherical_yn_real as _func_spherical_yn_real
+ctypedef double _proto_spherical_yn_real_t(long, double) nogil
+cdef _proto_spherical_yn_real_t *_proto_spherical_yn_real_t_var = &_func_spherical_yn_real
+from _spherical_bessel cimport spherical_yn_complex as _func_spherical_yn_complex
+ctypedef double complex _proto_spherical_yn_complex_t(long, double complex) nogil
+cdef _proto_spherical_yn_complex_t *_proto_spherical_yn_complex_t_var = &_func_spherical_yn_complex
+from _spherical_bessel cimport spherical_yn_d_real as _func_spherical_yn_d_real
+ctypedef double _proto_spherical_yn_d_real_t(long, double) nogil
+cdef _proto_spherical_yn_d_real_t *_proto_spherical_yn_d_real_t_var = &_func_spherical_yn_d_real
+from _spherical_bessel cimport spherical_yn_d_complex as _func_spherical_yn_d_complex
+ctypedef double complex _proto_spherical_yn_d_complex_t(long, double complex) nogil
+cdef _proto_spherical_yn_d_complex_t *_proto_spherical_yn_d_complex_t_var = &_func_spherical_yn_d_complex
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_struve_asymp_large_z "struve_asymp_large_z"(double, double, int, double *) nogil
 cdef extern from "_ufuncs_defs.h":
@@ -1935,6 +1999,182 @@ ufunc__lambertw_ptr[2*0] = <void*>_func_lambertw_scalar
 ufunc__lambertw_ptr[2*0+1] = <void*>(<char*>"_lambertw")
 ufunc__lambertw_data[0] = &ufunc__lambertw_ptr[2*0]
 _lambertw = np.PyUFunc_FromFuncAndData(ufunc__lambertw_loops, ufunc__lambertw_data, ufunc__lambertw_types, 1, 3, 1, 0, "_lambertw", ufunc__lambertw_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc__spherical_in_loops[2]
+cdef void *ufunc__spherical_in_ptr[4]
+cdef void *ufunc__spherical_in_data[2]
+cdef char ufunc__spherical_in_types[6]
+cdef char *ufunc__spherical_in_doc = (
+    "Internal function, use `spherical_in` instead.")
+ufunc__spherical_in_loops[0] = <np.PyUFuncGenericFunction>loop_d_ld__As_ld_d
+ufunc__spherical_in_loops[1] = <np.PyUFuncGenericFunction>loop_D_lD__As_lD_D
+ufunc__spherical_in_types[0] = <char>NPY_LONG
+ufunc__spherical_in_types[1] = <char>NPY_DOUBLE
+ufunc__spherical_in_types[2] = <char>NPY_DOUBLE
+ufunc__spherical_in_types[3] = <char>NPY_LONG
+ufunc__spherical_in_types[4] = <char>NPY_CDOUBLE
+ufunc__spherical_in_types[5] = <char>NPY_CDOUBLE
+ufunc__spherical_in_ptr[2*0] = <void*>_func_spherical_in_real
+ufunc__spherical_in_ptr[2*0+1] = <void*>(<char*>"_spherical_in")
+ufunc__spherical_in_ptr[2*1] = <void*>_func_spherical_in_complex
+ufunc__spherical_in_ptr[2*1+1] = <void*>(<char*>"_spherical_in")
+ufunc__spherical_in_data[0] = &ufunc__spherical_in_ptr[2*0]
+ufunc__spherical_in_data[1] = &ufunc__spherical_in_ptr[2*1]
+_spherical_in = np.PyUFunc_FromFuncAndData(ufunc__spherical_in_loops, ufunc__spherical_in_data, ufunc__spherical_in_types, 2, 2, 1, 0, "_spherical_in", ufunc__spherical_in_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc__spherical_in_d_loops[2]
+cdef void *ufunc__spherical_in_d_ptr[4]
+cdef void *ufunc__spherical_in_d_data[2]
+cdef char ufunc__spherical_in_d_types[6]
+cdef char *ufunc__spherical_in_d_doc = (
+    "Internal function, use `spherical_in` instead.")
+ufunc__spherical_in_d_loops[0] = <np.PyUFuncGenericFunction>loop_d_ld__As_ld_d
+ufunc__spherical_in_d_loops[1] = <np.PyUFuncGenericFunction>loop_D_lD__As_lD_D
+ufunc__spherical_in_d_types[0] = <char>NPY_LONG
+ufunc__spherical_in_d_types[1] = <char>NPY_DOUBLE
+ufunc__spherical_in_d_types[2] = <char>NPY_DOUBLE
+ufunc__spherical_in_d_types[3] = <char>NPY_LONG
+ufunc__spherical_in_d_types[4] = <char>NPY_CDOUBLE
+ufunc__spherical_in_d_types[5] = <char>NPY_CDOUBLE
+ufunc__spherical_in_d_ptr[2*0] = <void*>_func_spherical_in_d_real
+ufunc__spherical_in_d_ptr[2*0+1] = <void*>(<char*>"_spherical_in_d")
+ufunc__spherical_in_d_ptr[2*1] = <void*>_func_spherical_in_d_complex
+ufunc__spherical_in_d_ptr[2*1+1] = <void*>(<char*>"_spherical_in_d")
+ufunc__spherical_in_d_data[0] = &ufunc__spherical_in_d_ptr[2*0]
+ufunc__spherical_in_d_data[1] = &ufunc__spherical_in_d_ptr[2*1]
+_spherical_in_d = np.PyUFunc_FromFuncAndData(ufunc__spherical_in_d_loops, ufunc__spherical_in_d_data, ufunc__spherical_in_d_types, 2, 2, 1, 0, "_spherical_in_d", ufunc__spherical_in_d_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc__spherical_jn_loops[2]
+cdef void *ufunc__spherical_jn_ptr[4]
+cdef void *ufunc__spherical_jn_data[2]
+cdef char ufunc__spherical_jn_types[6]
+cdef char *ufunc__spherical_jn_doc = (
+    "Internal function, use `spherical_jn` instead.")
+ufunc__spherical_jn_loops[0] = <np.PyUFuncGenericFunction>loop_d_ld__As_ld_d
+ufunc__spherical_jn_loops[1] = <np.PyUFuncGenericFunction>loop_D_lD__As_lD_D
+ufunc__spherical_jn_types[0] = <char>NPY_LONG
+ufunc__spherical_jn_types[1] = <char>NPY_DOUBLE
+ufunc__spherical_jn_types[2] = <char>NPY_DOUBLE
+ufunc__spherical_jn_types[3] = <char>NPY_LONG
+ufunc__spherical_jn_types[4] = <char>NPY_CDOUBLE
+ufunc__spherical_jn_types[5] = <char>NPY_CDOUBLE
+ufunc__spherical_jn_ptr[2*0] = <void*>_func_spherical_jn_real
+ufunc__spherical_jn_ptr[2*0+1] = <void*>(<char*>"_spherical_jn")
+ufunc__spherical_jn_ptr[2*1] = <void*>_func_spherical_jn_complex
+ufunc__spherical_jn_ptr[2*1+1] = <void*>(<char*>"_spherical_jn")
+ufunc__spherical_jn_data[0] = &ufunc__spherical_jn_ptr[2*0]
+ufunc__spherical_jn_data[1] = &ufunc__spherical_jn_ptr[2*1]
+_spherical_jn = np.PyUFunc_FromFuncAndData(ufunc__spherical_jn_loops, ufunc__spherical_jn_data, ufunc__spherical_jn_types, 2, 2, 1, 0, "_spherical_jn", ufunc__spherical_jn_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc__spherical_jn_d_loops[2]
+cdef void *ufunc__spherical_jn_d_ptr[4]
+cdef void *ufunc__spherical_jn_d_data[2]
+cdef char ufunc__spherical_jn_d_types[6]
+cdef char *ufunc__spherical_jn_d_doc = (
+    "Internal function, use `spherical_jn` instead.")
+ufunc__spherical_jn_d_loops[0] = <np.PyUFuncGenericFunction>loop_d_ld__As_ld_d
+ufunc__spherical_jn_d_loops[1] = <np.PyUFuncGenericFunction>loop_D_lD__As_lD_D
+ufunc__spherical_jn_d_types[0] = <char>NPY_LONG
+ufunc__spherical_jn_d_types[1] = <char>NPY_DOUBLE
+ufunc__spherical_jn_d_types[2] = <char>NPY_DOUBLE
+ufunc__spherical_jn_d_types[3] = <char>NPY_LONG
+ufunc__spherical_jn_d_types[4] = <char>NPY_CDOUBLE
+ufunc__spherical_jn_d_types[5] = <char>NPY_CDOUBLE
+ufunc__spherical_jn_d_ptr[2*0] = <void*>_func_spherical_jn_d_real
+ufunc__spherical_jn_d_ptr[2*0+1] = <void*>(<char*>"_spherical_jn_d")
+ufunc__spherical_jn_d_ptr[2*1] = <void*>_func_spherical_jn_d_complex
+ufunc__spherical_jn_d_ptr[2*1+1] = <void*>(<char*>"_spherical_jn_d")
+ufunc__spherical_jn_d_data[0] = &ufunc__spherical_jn_d_ptr[2*0]
+ufunc__spherical_jn_d_data[1] = &ufunc__spherical_jn_d_ptr[2*1]
+_spherical_jn_d = np.PyUFunc_FromFuncAndData(ufunc__spherical_jn_d_loops, ufunc__spherical_jn_d_data, ufunc__spherical_jn_d_types, 2, 2, 1, 0, "_spherical_jn_d", ufunc__spherical_jn_d_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc__spherical_kn_loops[2]
+cdef void *ufunc__spherical_kn_ptr[4]
+cdef void *ufunc__spherical_kn_data[2]
+cdef char ufunc__spherical_kn_types[6]
+cdef char *ufunc__spherical_kn_doc = (
+    "Internal function, use `spherical_kn` instead.")
+ufunc__spherical_kn_loops[0] = <np.PyUFuncGenericFunction>loop_d_ld__As_ld_d
+ufunc__spherical_kn_loops[1] = <np.PyUFuncGenericFunction>loop_D_lD__As_lD_D
+ufunc__spherical_kn_types[0] = <char>NPY_LONG
+ufunc__spherical_kn_types[1] = <char>NPY_DOUBLE
+ufunc__spherical_kn_types[2] = <char>NPY_DOUBLE
+ufunc__spherical_kn_types[3] = <char>NPY_LONG
+ufunc__spherical_kn_types[4] = <char>NPY_CDOUBLE
+ufunc__spherical_kn_types[5] = <char>NPY_CDOUBLE
+ufunc__spherical_kn_ptr[2*0] = <void*>_func_spherical_kn_real
+ufunc__spherical_kn_ptr[2*0+1] = <void*>(<char*>"_spherical_kn")
+ufunc__spherical_kn_ptr[2*1] = <void*>_func_spherical_kn_complex
+ufunc__spherical_kn_ptr[2*1+1] = <void*>(<char*>"_spherical_kn")
+ufunc__spherical_kn_data[0] = &ufunc__spherical_kn_ptr[2*0]
+ufunc__spherical_kn_data[1] = &ufunc__spherical_kn_ptr[2*1]
+_spherical_kn = np.PyUFunc_FromFuncAndData(ufunc__spherical_kn_loops, ufunc__spherical_kn_data, ufunc__spherical_kn_types, 2, 2, 1, 0, "_spherical_kn", ufunc__spherical_kn_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc__spherical_kn_d_loops[2]
+cdef void *ufunc__spherical_kn_d_ptr[4]
+cdef void *ufunc__spherical_kn_d_data[2]
+cdef char ufunc__spherical_kn_d_types[6]
+cdef char *ufunc__spherical_kn_d_doc = (
+    "Internal function, use `spherical_kn` instead.")
+ufunc__spherical_kn_d_loops[0] = <np.PyUFuncGenericFunction>loop_d_ld__As_ld_d
+ufunc__spherical_kn_d_loops[1] = <np.PyUFuncGenericFunction>loop_D_lD__As_lD_D
+ufunc__spherical_kn_d_types[0] = <char>NPY_LONG
+ufunc__spherical_kn_d_types[1] = <char>NPY_DOUBLE
+ufunc__spherical_kn_d_types[2] = <char>NPY_DOUBLE
+ufunc__spherical_kn_d_types[3] = <char>NPY_LONG
+ufunc__spherical_kn_d_types[4] = <char>NPY_CDOUBLE
+ufunc__spherical_kn_d_types[5] = <char>NPY_CDOUBLE
+ufunc__spherical_kn_d_ptr[2*0] = <void*>_func_spherical_kn_d_real
+ufunc__spherical_kn_d_ptr[2*0+1] = <void*>(<char*>"_spherical_kn_d")
+ufunc__spherical_kn_d_ptr[2*1] = <void*>_func_spherical_kn_d_complex
+ufunc__spherical_kn_d_ptr[2*1+1] = <void*>(<char*>"_spherical_kn_d")
+ufunc__spherical_kn_d_data[0] = &ufunc__spherical_kn_d_ptr[2*0]
+ufunc__spherical_kn_d_data[1] = &ufunc__spherical_kn_d_ptr[2*1]
+_spherical_kn_d = np.PyUFunc_FromFuncAndData(ufunc__spherical_kn_d_loops, ufunc__spherical_kn_d_data, ufunc__spherical_kn_d_types, 2, 2, 1, 0, "_spherical_kn_d", ufunc__spherical_kn_d_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc__spherical_yn_loops[2]
+cdef void *ufunc__spherical_yn_ptr[4]
+cdef void *ufunc__spherical_yn_data[2]
+cdef char ufunc__spherical_yn_types[6]
+cdef char *ufunc__spherical_yn_doc = (
+    "Internal function, use `spherical_yn` instead.")
+ufunc__spherical_yn_loops[0] = <np.PyUFuncGenericFunction>loop_d_ld__As_ld_d
+ufunc__spherical_yn_loops[1] = <np.PyUFuncGenericFunction>loop_D_lD__As_lD_D
+ufunc__spherical_yn_types[0] = <char>NPY_LONG
+ufunc__spherical_yn_types[1] = <char>NPY_DOUBLE
+ufunc__spherical_yn_types[2] = <char>NPY_DOUBLE
+ufunc__spherical_yn_types[3] = <char>NPY_LONG
+ufunc__spherical_yn_types[4] = <char>NPY_CDOUBLE
+ufunc__spherical_yn_types[5] = <char>NPY_CDOUBLE
+ufunc__spherical_yn_ptr[2*0] = <void*>_func_spherical_yn_real
+ufunc__spherical_yn_ptr[2*0+1] = <void*>(<char*>"_spherical_yn")
+ufunc__spherical_yn_ptr[2*1] = <void*>_func_spherical_yn_complex
+ufunc__spherical_yn_ptr[2*1+1] = <void*>(<char*>"_spherical_yn")
+ufunc__spherical_yn_data[0] = &ufunc__spherical_yn_ptr[2*0]
+ufunc__spherical_yn_data[1] = &ufunc__spherical_yn_ptr[2*1]
+_spherical_yn = np.PyUFunc_FromFuncAndData(ufunc__spherical_yn_loops, ufunc__spherical_yn_data, ufunc__spherical_yn_types, 2, 2, 1, 0, "_spherical_yn", ufunc__spherical_yn_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc__spherical_yn_d_loops[2]
+cdef void *ufunc__spherical_yn_d_ptr[4]
+cdef void *ufunc__spherical_yn_d_data[2]
+cdef char ufunc__spherical_yn_d_types[6]
+cdef char *ufunc__spherical_yn_d_doc = (
+    "Internal function, use `spherical_yn` instead.")
+ufunc__spherical_yn_d_loops[0] = <np.PyUFuncGenericFunction>loop_d_ld__As_ld_d
+ufunc__spherical_yn_d_loops[1] = <np.PyUFuncGenericFunction>loop_D_lD__As_lD_D
+ufunc__spherical_yn_d_types[0] = <char>NPY_LONG
+ufunc__spherical_yn_d_types[1] = <char>NPY_DOUBLE
+ufunc__spherical_yn_d_types[2] = <char>NPY_DOUBLE
+ufunc__spherical_yn_d_types[3] = <char>NPY_LONG
+ufunc__spherical_yn_d_types[4] = <char>NPY_CDOUBLE
+ufunc__spherical_yn_d_types[5] = <char>NPY_CDOUBLE
+ufunc__spherical_yn_d_ptr[2*0] = <void*>_func_spherical_yn_d_real
+ufunc__spherical_yn_d_ptr[2*0+1] = <void*>(<char*>"_spherical_yn_d")
+ufunc__spherical_yn_d_ptr[2*1] = <void*>_func_spherical_yn_d_complex
+ufunc__spherical_yn_d_ptr[2*1+1] = <void*>(<char*>"_spherical_yn_d")
+ufunc__spherical_yn_d_data[0] = &ufunc__spherical_yn_d_ptr[2*0]
+ufunc__spherical_yn_d_data[1] = &ufunc__spherical_yn_d_ptr[2*1]
+_spherical_yn_d = np.PyUFunc_FromFuncAndData(ufunc__spherical_yn_d_loops, ufunc__spherical_yn_d_data, ufunc__spherical_yn_d_types, 2, 2, 1, 0, "_spherical_yn_d", ufunc__spherical_yn_d_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc__struve_asymp_large_z_loops[1]
 cdef void *ufunc__struve_asymp_large_z_ptr[2]

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -5461,3 +5461,43 @@ add_newdoc("scipy.special", "_struve_bessel_series",
     -------
     v, err
     """)
+
+add_newdoc("scipy.special", "_spherical_jn",
+    """
+    Internal function, use `spherical_jn` instead.
+    """)
+
+add_newdoc("scipy.special", "_spherical_jn_d",
+    """
+    Internal function, use `spherical_jn` instead.
+    """)
+
+add_newdoc("scipy.special", "_spherical_yn",
+    """
+    Internal function, use `spherical_yn` instead.
+    """)
+
+add_newdoc("scipy.special", "_spherical_yn_d",
+    """
+    Internal function, use `spherical_yn` instead.
+    """)
+
+add_newdoc("scipy.special", "_spherical_in",
+    """
+    Internal function, use `spherical_in` instead.
+    """)
+
+add_newdoc("scipy.special", "_spherical_in_d",
+    """
+    Internal function, use `spherical_in` instead.
+    """)
+
+add_newdoc("scipy.special", "_spherical_kn",
+    """
+    Internal function, use `spherical_kn` instead.
+    """)
+
+add_newdoc("scipy.special", "_spherical_kn_d",
+    """
+    Internal function, use `spherical_kn` instead.
+    """)

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -642,6 +642,9 @@ def h2vp(v, z, n=1):
         return _bessel_diff_formula(v, z, n, hankel2, -1)
 
 
+@np.deprecate(message="scipy.special.sph_jn is deprecated in scipy 0.18.0. "
+                      "Use scipy.special.spherical_jn instead. "
+                      "Note that the new function has a different signature.")
 def sph_jn(n, z):
     """Compute spherical Bessel function jn(z) and derivative.
 
@@ -661,6 +664,10 @@ def sph_jn(n, z):
         Value of j0(z), ..., jn(z)
     jnp : ndarray
         First derivative j0'(z), ..., jn'(z)
+
+    See also
+    --------
+    spherical_jn
 
     References
     ----------
@@ -684,6 +691,9 @@ def sph_jn(n, z):
     return jn[:(n+1)], jnp[:(n+1)]
 
 
+@np.deprecate(message="scipy.special.sph_yn is deprecated in scipy 0.18.0. "
+                      "Use scipy.special.spherical_yn instead. "
+                      "Note that the new function has a different signature.")
 def sph_yn(n, z):
     """Compute spherical Bessel function yn(z) and derivative.
 
@@ -703,6 +713,10 @@ def sph_yn(n, z):
         Value of y0(z), ..., yn(z)
     ynp : ndarray
         First derivative y0'(z), ..., yn'(z)
+
+    See also
+    --------
+    spherical_yn
 
     References
     ----------
@@ -726,6 +740,10 @@ def sph_yn(n, z):
     return yn[:(n+1)], ynp[:(n+1)]
 
 
+@np.deprecate(message="scipy.special.sph_jnyn is deprecated in scipy 0.18.0. "
+                      "Use scipy.special.spherical_jn and "
+                      "scipy.special.spherical_yn instead. "
+                      "Note that the new function has a different signature.")
 def sph_jnyn(n, z):
     """Compute spherical Bessel functions jn(z) and yn(z) and derivatives.
 
@@ -750,6 +768,11 @@ def sph_jnyn(n, z):
     ynp : ndarray
         First derivative y0'(z), ..., yn'(z)
 
+    See also
+    --------
+    spherical_jn
+    spherical_yn
+
     References
     ----------
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
@@ -773,6 +796,9 @@ def sph_jnyn(n, z):
     return jn[:(n+1)], jnp[:(n+1)], yn[:(n+1)], ynp[:(n+1)]
 
 
+@np.deprecate(message="scipy.special.sph_in is deprecated in scipy 0.18.0. "
+                      "Use scipy.special.spherical_in instead. "
+                      "Note that the new function has a different signature.")
 def sph_in(n, z):
     """Compute spherical Bessel function in(z) and derivative.
 
@@ -792,6 +818,10 @@ def sph_in(n, z):
         Value of i0(z), ..., in(z)
     inp : ndarray
         First derivative i0'(z), ..., in'(z)
+
+    See also
+    --------
+    spherical_in
 
     References
     ----------
@@ -815,6 +845,9 @@ def sph_in(n, z):
     return In[:(n+1)], Inp[:(n+1)]
 
 
+@np.deprecate(message="scipy.special.sph_kn is deprecated in scipy 0.18.0. "
+                      "Use scipy.special.spherical_kn instead. "
+                      "Note that the new function has a different signature.")
 def sph_kn(n, z):
     """Compute spherical Bessel function kn(z) and derivative.
 
@@ -834,6 +867,10 @@ def sph_kn(n, z):
         Value of k0(z), ..., kn(z)
     knp : ndarray
         First derivative k0'(z), ..., kn'(z)
+
+    See also
+    --------
+    spherical_kn
 
     References
     ----------
@@ -857,6 +894,10 @@ def sph_kn(n, z):
     return kn[:(n+1)], knp[:(n+1)]
 
 
+@np.deprecate(message="scipy.special.sph_inkn is deprecated in scipy 0.18.0. "
+                      "Use scipy.special.spherical_in and "
+                      "scipy.special.spherical_kn instead. "
+                      "Note that the new function has a different signature.")
 def sph_inkn(n, z):
     """Compute spherical Bessel functions in(z), kn(z), and derivatives.
 
@@ -880,6 +921,11 @@ def sph_inkn(n, z):
         Value of k0(z), ..., kn(z)
     knp : ndarray
         First derivative k0'(z), ..., kn'(z)
+
+    See also
+    --------
+    spherical_in
+    spherical_kn
 
     References
     ----------

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -303,6 +303,14 @@ rel_entr -- rel_entr: dd->d                                -- _convex_analysis.p
 huber -- huber: dd->d                                      -- _convex_analysis.pxd
 pseudo_huber -- pseudo_huber: dd->d                        -- _convex_analysis.pxd
 exprel -- exprel: d->d                                     -- _exprel.pxd
+_spherical_yn -- spherical_yn_real: ld->d, spherical_yn_complex: lD->D -- _spherical_bessel.pxd
+_spherical_jn -- spherical_jn_real: ld->d, spherical_jn_complex: lD->D -- _spherical_bessel.pxd
+_spherical_in -- spherical_in_real: ld->d, spherical_in_complex: lD->D -- _spherical_bessel.pxd
+_spherical_kn -- spherical_kn_real: ld->d, spherical_kn_complex: lD->D -- _spherical_bessel.pxd
+_spherical_yn_d -- spherical_yn_d_real: ld->d, spherical_yn_d_complex: lD->D -- _spherical_bessel.pxd
+_spherical_jn_d -- spherical_jn_d_real: ld->d, spherical_jn_d_complex: lD->D -- _spherical_bessel.pxd
+_spherical_in_d -- spherical_in_d_real: ld->d, spherical_in_d_complex: lD->D -- _spherical_bessel.pxd
+_spherical_kn_d -- spherical_kn_d_real: ld->d, spherical_kn_d_complex: lD->D -- _spherical_bessel.pxd
 """
 
 #---------------------------------------------------------------------------------

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2995,12 +2995,16 @@ class TestRadian(TestCase):
 
 class TestRiccati(TestCase):
     def test_riccati_jn(self):
-        jnrl = (special.sph_jn(1,.2)[0]*.2,special.sph_jn(1,.2)[0]+special.sph_jn(1,.2)[1]*.2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            jnrl = (special.sph_jn(1,.2)[0]*.2,special.sph_jn(1,.2)[0]+special.sph_jn(1,.2)[1]*.2)
         ricjn = special.riccati_jn(1,.2)
         assert_array_almost_equal(ricjn,jnrl,8)
 
     def test_riccati_yn(self):
-        ynrl = (special.sph_yn(1,.2)[0]*.2,special.sph_yn(1,.2)[0]+special.sph_yn(1,.2)[1]*.2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            ynrl = (special.sph_yn(1,.2)[0]*.2,special.sph_yn(1,.2)[0]+special.sph_yn(1,.2)[1]*.2)
         ricyn = special.riccati_yn(1,.2)
         assert_array_almost_equal(ricyn,ynrl,8)
 
@@ -3064,7 +3068,9 @@ class TestSpherical(TestCase):
         pass
 
     def test_sph_in(self):
-        i1n = special.sph_in(1,.2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            i1n = special.sph_in(1,.2)
         inp0 = (i1n[0][1])
         inp1 = (i1n[0][0] - 2.0/0.2 * i1n[0][1])
         assert_array_almost_equal(i1n[0],array([1.0066800127054699381,
@@ -3072,27 +3078,33 @@ class TestSpherical(TestCase):
         assert_array_almost_equal(i1n[1],[inp0,inp1],12)
 
     def test_sph_inkn(self):
-        spikn = r_[special.sph_in(1,.2) + special.sph_kn(1,.2)]
-        inkn = r_[special.sph_inkn(1,.2)]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            spikn = r_[special.sph_in(1,.2) + special.sph_kn(1,.2)]
+            inkn = r_[special.sph_inkn(1,.2)]
         assert_array_almost_equal(inkn,spikn,10)
 
     def test_sph_in_kn_order0(self):
         x = 1.
-        sph_i0 = special.sph_in(0, x)
-        sph_i0_expected = np.array([np.sinh(x)/x,
-                                    np.cosh(x)/x-np.sinh(x)/x**2])
-        assert_array_almost_equal(r_[sph_i0], sph_i0_expected)
-        sph_k0 = special.sph_kn(0, x)
-        sph_k0_expected = np.array([0.5*pi*exp(-x)/x,
-                                    -0.5*pi*exp(-x)*(1/x+1/x**2)])
-        assert_array_almost_equal(r_[sph_k0], sph_k0_expected)
-        sph_i0k0 = special.sph_inkn(0, x)
-        assert_array_almost_equal(r_[sph_i0+sph_k0],
-                                  r_[sph_i0k0],
-                                  10)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            sph_i0 = special.sph_in(0, x)
+            sph_i0_expected = np.array([np.sinh(x)/x,
+                                        np.cosh(x)/x-np.sinh(x)/x**2])
+            assert_array_almost_equal(r_[sph_i0], sph_i0_expected)
+            sph_k0 = special.sph_kn(0, x)
+            sph_k0_expected = np.array([0.5*pi*exp(-x)/x,
+                                        -0.5*pi*exp(-x)*(1/x+1/x**2)])
+            assert_array_almost_equal(r_[sph_k0], sph_k0_expected)
+            sph_i0k0 = special.sph_inkn(0, x)
+            assert_array_almost_equal(r_[sph_i0+sph_k0],
+                                      r_[sph_i0k0],
+                                      10)
 
     def test_sph_jn(self):
-        s1 = special.sph_jn(2,.2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            s1 = special.sph_jn(2,.2)
         s10 = -s1[0][1]
         s11 = s1[0][0]-2.0/0.2*s1[0][1]
         s12 = s1[0][1]-3.0/0.2*s1[0][2]
@@ -3102,12 +3114,16 @@ class TestSpherical(TestCase):
         assert_array_almost_equal(s1[1],[s10,s11,s12],12)
 
     def test_sph_jnyn(self):
-        jnyn = r_[special.sph_jn(1,.2) + special.sph_yn(1,.2)]  # tuple addition
-        jnyn1 = r_[special.sph_jnyn(1,.2)]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            jnyn = r_[special.sph_jn(1,.2) + special.sph_yn(1,.2)]  # tuple addition
+            jnyn1 = r_[special.sph_jnyn(1,.2)]
         assert_array_almost_equal(jnyn1,jnyn,9)
 
     def test_sph_kn(self):
-        kn = special.sph_kn(2,.2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            kn = special.sph_kn(2,.2)
         kn0 = -kn[0][1]
         kn1 = -kn[0][0]-2.0/0.2*kn[0][1]
         kn2 = -kn[0][1]-3.0/0.2*kn[0][2]
@@ -3117,9 +3133,11 @@ class TestSpherical(TestCase):
         assert_array_almost_equal(kn[1],[kn0,kn1,kn2],9)
 
     def test_sph_yn(self):
-        sy1 = special.sph_yn(2,.2)[0][2]
-        sy2 = special.sph_yn(0,.2)[0][0]
-        sphpy = (special.sph_yn(1,.2)[0][0]-2*special.sph_yn(2,.2)[0][2])/3  # correct derivative value
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            sy1 = special.sph_yn(2,.2)[0][2]
+            sy2 = special.sph_yn(0,.2)[0][0]
+            sphpy = (special.sph_yn(1,.2)[0][0]-2*special.sph_yn(2,.2)[0][2])/3  # correct derivative value
         assert_almost_equal(sy1,-377.52483,5)  # previous values in the system
         assert_almost_equal(sy2,-4.9003329,5)
         sy3 = special.sph_yn(1,.2)[1][1]

--- a/scipy/special/tests/test_data.py
+++ b/scipy/special/tests/test_data.py
@@ -18,7 +18,7 @@ from scipy.special import (
     nbdtrik, pdtrik,
     mathieu_a, mathieu_b, mathieu_cem, mathieu_sem, mathieu_modcem1,
     mathieu_modsem1, mathieu_modcem2, mathieu_modsem2,
-    ellip_harm, ellip_harm_2
+    ellip_harm, ellip_harm_2, spherical_jn, spherical_yn,
 )
 from scipy.integrate import IntegrationWarning
 
@@ -180,6 +180,12 @@ def poch_minus(z, m):
 
 def sph_jn_(n, x):
     return sph_jn(n.astype('l'), x)[0][-1]
+
+def spherical_jn_(n, x):
+    return spherical_jn(n.astype('l'), x)
+
+def spherical_yn_(n, x):
+    return spherical_yn(n.astype('l'), x)
 
 def sph_yn_(n, x):
     return sph_yn(n.astype('l'), x)[0][-1]
@@ -420,6 +426,9 @@ def test_boost():
                            lambda p: np.ones(p.shape, '?'),
                            lambda p: np.logical_and(p < 2*np.pi, p >= 0),
                            lambda p: np.logical_and(p < np.pi, p >= 0))),
+
+        data(spherical_jn_, 'sph_bessel_data_ipp-sph_bessel_data', (0,1), 2, rtol=1e-13),
+        data(spherical_yn_, 'sph_neumann_data_ipp-sph_neumann_data', (0,1), 2, rtol=8e-15),
 
         # -- not used yet (function does not exist in scipy):
         # 'ellint_pi2_data_ipp-ellint_pi2_data',

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1677,6 +1677,122 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             dps=60,
                             rtol=1e-13)
 
+    def test_spherical_jn(self):
+        def mp_spherical_jn(n, z):
+            arg = mpmath.mpmathify(z)
+            out = (mpmath.besselj(n + mpmath.mpf(1)/2, arg) /
+                   mpmath.sqrt(2*arg/mpmath.pi))
+            if arg.imag == 0:
+                return out.real
+            else:
+                return out
+
+        assert_mpmath_equal(lambda n, z: sc.spherical_jn(int(n), z),
+                            _exception_to_nan(mp_spherical_jn),
+                            [IntArg(0, 200), Arg(-1e8, 1e8)],
+                            dps=300)
+
+    def test_spherical_jn_complex(self):
+        def mp_spherical_jn(n, z):
+            arg = mpmath.mpmathify(z)
+            out = (mpmath.besselj(n + mpmath.mpf(1)/2, arg) /
+                   mpmath.sqrt(2*arg/mpmath.pi))
+            if arg.imag == 0:
+                return out.real
+            else:
+                return out
+
+        assert_mpmath_equal(lambda n, z: sc.spherical_jn(int(n.real), z),
+                            _exception_to_nan(mp_spherical_jn),
+                            [IntArg(0, 200), ComplexArg()])
+
+    def test_spherical_yn(self):
+        def mp_spherical_yn(n, z):
+            arg = mpmath.mpmathify(z)
+            out = (mpmath.bessely(n + mpmath.mpf(1)/2, arg) /
+                   mpmath.sqrt(2*arg/mpmath.pi))
+            if arg.imag == 0:
+                return out.real
+            else:
+                return out
+
+        assert_mpmath_equal(lambda n, z: sc.spherical_yn(int(n), z),
+                            _exception_to_nan(mp_spherical_yn),
+                            [IntArg(0, 200), Arg(-1e10, 1e10)],
+                            dps=100)
+
+    def test_spherical_yn_complex(self):
+        def mp_spherical_yn(n, z):
+            arg = mpmath.mpmathify(z)
+            out = (mpmath.bessely(n + mpmath.mpf(1)/2, arg) /
+                   mpmath.sqrt(2*arg/mpmath.pi))
+            if arg.imag == 0:
+                return out.real
+            else:
+                return out
+
+        assert_mpmath_equal(lambda n, z: sc.spherical_yn(int(n.real), z),
+                            _exception_to_nan(mp_spherical_yn),
+                            [IntArg(0, 200), ComplexArg()])
+
+    def test_spherical_in(self):
+        def mp_spherical_in(n, z):
+            arg = mpmath.mpmathify(z)
+            out = (mpmath.besseli(n + mpmath.mpf(1)/2, arg) /
+                   mpmath.sqrt(2*arg/mpmath.pi))
+            if arg.imag == 0:
+                return out.real
+            else:
+                return out
+
+        assert_mpmath_equal(lambda n, z: sc.spherical_in(int(n), z),
+                            _exception_to_nan(mp_spherical_in),
+                            [IntArg(0, 200), Arg()],
+                            dps=200, atol=10**(-278))
+
+    def test_spherical_in_complex(self):
+        def mp_spherical_in(n, z):
+            arg = mpmath.mpmathify(z)
+            out = (mpmath.besseli(n + mpmath.mpf(1)/2, arg) /
+                   mpmath.sqrt(2*arg/mpmath.pi))
+            if arg.imag == 0:
+                return out.real
+            else:
+                return out
+
+        assert_mpmath_equal(lambda n, z: sc.spherical_in(int(n.real), z),
+                            _exception_to_nan(mp_spherical_in),
+                            [IntArg(0, 200), ComplexArg()])
+
+    def test_spherical_kn(self):
+        def mp_spherical_kn(n, z):
+            out = (mpmath.besselk(n + mpmath.mpf(1)/2, z) *
+                   mpmath.sqrt(mpmath.pi/(2*mpmath.mpmathify(z))))
+            if mpmath.mpmathify(z).imag == 0:
+                return out.real
+            else:
+                return out
+
+        assert_mpmath_equal(lambda n, z: sc.spherical_kn(int(n), z),
+                            _exception_to_nan(mp_spherical_kn),
+                            [IntArg(0, 150), Arg()],
+                            dps=100)
+
+    @knownfailure_overridable("Accuracy issues near z = -1 inherited from kv.")
+    def test_spherical_kn_complex(self):
+        def mp_spherical_kn(n, z):
+            arg = mpmath.mpmathify(z)
+            out = (mpmath.besselk(n + mpmath.mpf(1)/2, arg) /
+                   mpmath.sqrt(2*arg/mpmath.pi))
+            if arg.imag == 0:
+                return out.real
+            else:
+                return out
+
+        assert_mpmath_equal(lambda n, z: sc.spherical_kn(int(n.real), z),
+                            _exception_to_nan(mp_spherical_kn),
+                            [IntArg(0, 200), ComplexArg()],
+                            dps=200)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/special/tests/test_spherical_bessel.py
+++ b/scipy/special/tests/test_spherical_bessel.py
@@ -1,0 +1,375 @@
+#
+# Tests of spherical Bessel functions.
+#
+
+import numpy as np
+from numpy.testing import (assert_almost_equal, assert_allclose, dec,
+                           assert_array_almost_equal)
+from numpy import sin, cos, sinh, cosh, exp, inf, nan, r_, pi
+
+from scipy.special import spherical_jn, spherical_yn, spherical_in, spherical_kn
+from scipy.integrate import quad
+
+
+class TestSphericalJn:
+    def test_spherical_jn_exact(self):
+        # http://dlmf.nist.gov/10.49.E3
+        # Note: exact expression is numerically stable only for small
+        # n or z >> n.
+        x = np.array([0.12, 1.23, 12.34, 123.45, 1234.5])
+        assert_allclose(spherical_jn(2, x),
+                        (-1/x + 3/x**3)*sin(x) - 3/x**2*cos(x))
+
+    def test_spherical_jn_recurrence_complex(self):
+        # http://dlmf.nist.gov/10.51.E1
+        n = np.array([1, 2, 3, 7, 12])
+        x = 1.1 + 1.5j
+        assert_allclose(spherical_jn(n - 1, x) + spherical_jn(n + 1, x),
+                        (2*n + 1)/x*spherical_jn(n, x))
+
+    def test_spherical_jn_recurrence_real(self):
+        # http://dlmf.nist.gov/10.51.E1
+        n = np.array([1, 2, 3, 7, 12])
+        x = 0.12
+        assert_allclose(spherical_jn(n - 1, x) + spherical_jn(n + 1,x),
+                        (2*n + 1)/x*spherical_jn(n, x))
+
+    def test_spherical_jn_inf_real(self):
+        # http://dlmf.nist.gov/10.52.E3
+        n = 6
+        x = np.array([-inf, inf])
+        assert_allclose(spherical_jn(n, x), np.array([0, 0]))
+
+    def test_spherical_jn_inf_complex(self):
+        # http://dlmf.nist.gov/10.52.E3
+        n = 7
+        x = np.array([-inf + 0j, inf + 0j, inf*(1+1j)])
+        assert_allclose(spherical_jn(n, x), np.array([0, 0, inf*(1+1j)]))
+
+    def test_spherical_jn_large_arg_1(self):
+        # https://github.com/scipy/scipy/issues/2165
+        # Reference value computed using mpmath, via
+        # besselj(n + mpf(1)/2, z)*sqrt(pi/(2*z))
+        assert_allclose(spherical_jn(2, 3350.507), -0.00029846226538040747)
+
+    def test_spherical_jn_large_arg_2(self):
+        # https://github.com/scipy/scipy/issues/1641
+        # Reference value computed using mpmath, via
+        # besselj(n + mpf(1)/2, z)*sqrt(pi/(2*z))
+        assert_allclose(spherical_jn(2, 10000), 3.0590002633029811e-05)
+
+    def test_spherical_jn_at_zero(self):
+        # http://dlmf.nist.gov/10.52.E1
+        # But note that n = 0 is a special case: j0 = sin(x)/x -> 1
+        n = np.array([0, 1, 2, 5, 10, 100])
+        x = 0
+        assert_allclose(spherical_jn(n, x), np.array([1, 0, 0, 0, 0, 0]))
+
+
+class TestSphericalYn:
+    def test_spherical_yn_exact(self):
+        # http://dlmf.nist.gov/10.49.E5
+        # Note: exact expression is numerically stable only for small
+        # n or z >> n.
+        x = np.array([0.12, 1.23, 12.34, 123.45, 1234.5])
+        assert_allclose(spherical_yn(2, x),
+                        (1/x - 3/x**3)*cos(x) - 3/x**2*sin(x))
+
+    def test_spherical_yn_recurrence_real(self):
+        # http://dlmf.nist.gov/10.51.E1
+        n = np.array([1, 2, 3, 7, 12])
+        x = 0.12
+        assert_allclose(spherical_yn(n - 1, x) + spherical_yn(n + 1,x),
+                        (2*n + 1)/x*spherical_yn(n, x))
+
+    def test_spherical_yn_recurrence_complex(self):
+        # http://dlmf.nist.gov/10.51.E1
+        n = np.array([1, 2, 3, 7, 12])
+        x = 1.1 + 1.5j
+        assert_allclose(spherical_yn(n - 1, x) + spherical_yn(n + 1, x),
+                        (2*n + 1)/x*spherical_yn(n, x))
+
+    def test_spherical_yn_inf_real(self):
+        # http://dlmf.nist.gov/10.52.E3
+        n = 6
+        x = np.array([-inf, inf])
+        assert_allclose(spherical_yn(n, x), np.array([0, 0]))
+
+    def test_spherical_yn_inf_complex(self):
+        # http://dlmf.nist.gov/10.52.E3
+        n = 7
+        x = np.array([-inf + 0j, inf + 0j, inf*(1+1j)])
+        assert_allclose(spherical_yn(n, x), np.array([0, 0, inf*(1+1j)]))
+
+    def test_spherical_yn_at_zero(self):
+        # http://dlmf.nist.gov/10.52.E2
+        n = np.array([0, 1, 2, 5, 10, 100])
+        x = 0
+        assert_allclose(spherical_yn(n, x), -inf*np.ones(shape=n.shape))
+
+    def test_spherical_yn_at_zero_complex(self):
+        # Consistently with numpy:
+        # >>> -np.cos(0)/0
+        # -inf
+        # >>> -np.cos(0+0j)/(0+0j)
+        # (-inf + nan*j)
+        n = np.array([0, 1, 2, 5, 10, 100])
+        x = 0 + 0j
+        assert_allclose(spherical_yn(n, x), nan*np.ones(shape=n.shape))
+
+
+class TestSphericalJnYnCrossProduct:
+    def test_spherical_jn_yn_cross_product_1(self):
+        # http://dlmf.nist.gov/10.50.E3
+        n = np.array([1, 5, 8])
+        x = np.array([0.1, 1, 10])
+        left = (spherical_jn(n + 1, x) * spherical_yn(n, x) -
+                spherical_jn(n, x) * spherical_yn(n + 1, x))
+        right = 1/x**2
+        assert_allclose(left, right)
+
+    def test_spherical_jn_yn_cross_product_2(self):
+        # http://dlmf.nist.gov/10.50.E3
+        n = np.array([1, 5, 8])
+        x = np.array([0.1, 1, 10])
+        left = (spherical_jn(n + 2, x) * spherical_yn(n, x) -
+                spherical_jn(n, x) * spherical_yn(n + 2, x))
+        right = (2*n + 3)/x**3
+        assert_allclose(left, right)
+
+
+class TestSphericalIn:
+    def test_spherical_in_exact(self):
+        # http://dlmf.nist.gov/10.49.E9
+        x = np.array([0.12, 1.23, 12.34, 123.45])
+        assert_allclose(spherical_in(2, x),
+                        (1/x + 3/x**3)*sinh(x) - 3/x**2*cosh(x))
+
+    def test_spherical_in_recurrence_real(self):
+        # http://dlmf.nist.gov/10.51.E4
+        n = np.array([1, 2, 3, 7, 12])
+        x = 0.12
+        assert_allclose(spherical_in(n - 1, x) - spherical_in(n + 1,x),
+                        (2*n + 1)/x*spherical_in(n, x))
+
+    def test_spherical_in_recurrence_complex(self):
+        # http://dlmf.nist.gov/10.51.E1
+        n = np.array([1, 2, 3, 7, 12])
+        x = 1.1 + 1.5j
+        assert_allclose(spherical_in(n - 1, x) - spherical_in(n + 1,x),
+                        (2*n + 1)/x*spherical_in(n, x))
+
+    def test_spherical_in_inf_real(self):
+        # http://dlmf.nist.gov/10.52.E3
+        n = 5
+        x = np.array([-inf, inf])
+        assert_allclose(spherical_in(n, x), np.array([-inf, inf]))
+
+    def test_spherical_in_inf_complex(self):
+        # http://dlmf.nist.gov/10.52.E5
+        # Ideally, i1n(n, 1j*inf) = 0 and i1n(n, (1+1j)*inf) = (1+1j)*inf, but
+        # this appears impossible to achieve because C99 regards any complex
+        # value with at least one infinite  part as a complex infinity, so
+        # 1j*inf cannot be distinguished from (1+1j)*inf.  Therefore, nan is
+        # the correct return value.
+        n = 7
+        x = np.array([-inf + 0j, inf + 0j, inf*(1+1j)])
+        assert_allclose(spherical_in(n, x), np.array([-inf, inf, nan]))
+
+    def test_spherical_in_at_zero(self):
+        # http://dlmf.nist.gov/10.52.E1
+        # But note that n = 0 is a special case: i0 = sinh(x)/x -> 1
+        n = np.array([0, 1, 2, 5, 10, 100])
+        x = 0
+        assert_allclose(spherical_in(n, x), np.array([1, 0, 0, 0, 0, 0]))
+
+
+class TestSphericalKn:
+    def test_spherical_kn_exact(self):
+        # http://dlmf.nist.gov/10.49.E13
+        x = np.array([0.12, 1.23, 12.34, 123.45])
+        assert_allclose(spherical_kn(2, x),
+                        pi/2*exp(-x)*(1/x + 3/x**2 + 3/x**3))
+
+    def test_spherical_kn_recurrence_real(self):
+        # http://dlmf.nist.gov/10.51.E4
+        n = np.array([1, 2, 3, 7, 12])
+        x = 0.12
+        assert_allclose((-1)**(n - 1)*spherical_kn(n - 1, x) - (-1)**(n + 1)*spherical_kn(n + 1,x),
+                        (-1)**n*(2*n + 1)/x*spherical_kn(n, x))
+
+    def test_spherical_kn_recurrence_complex(self):
+        # http://dlmf.nist.gov/10.51.E4
+        n = np.array([1, 2, 3, 7, 12])
+        x = 1.1 + 1.5j
+        assert_allclose((-1)**(n - 1)*spherical_kn(n - 1, x) - (-1)**(n + 1)*spherical_kn(n + 1,x),
+                        (-1)**n*(2*n + 1)/x*spherical_kn(n, x))
+
+    def test_spherical_kn_inf_real(self):
+        # http://dlmf.nist.gov/10.52.E6
+        n = 5
+        x = np.array([-inf, inf])
+        assert_allclose(spherical_kn(n, x), np.array([-inf, 0]))
+
+    def test_spherical_kn_inf_complex(self):
+        # http://dlmf.nist.gov/10.52.E6
+        # The behavior at complex infinity depends on the sign of the real
+        # part: if Re(z) >= 0, then the limit is 0; if Re(z) < 0, then it's
+        # z*inf.  This distinction cannot be captured, so we return nan.
+        n = 7
+        x = np.array([-inf + 0j, inf + 0j, inf*(1+1j)])
+        assert_allclose(spherical_kn(n, x), np.array([-inf, 0, nan]))
+
+    def test_spherical_kn_at_zero(self):
+        # http://dlmf.nist.gov/10.52.E2
+        n = np.array([0, 1, 2, 5, 10, 100])
+        x = 0
+        assert_allclose(spherical_kn(n, x), inf*np.ones(shape=n.shape))
+
+    def test_spherical_kn_at_zero_complex(self):
+        # http://dlmf.nist.gov/10.52.E2
+        n = np.array([0, 1, 2, 5, 10, 100])
+        x = 0 + 0j
+        assert_allclose(spherical_kn(n, x), nan*np.ones(shape=n.shape))
+
+
+class SphericalDerivativesTestCase:
+    def fundamental_theorem(self, n, a, b):
+        integral, tolerance = quad(lambda z: self.df(n, z), a, b)
+        assert_allclose(integral,
+                        self.f(n, b) - self.f(n, a),
+                        atol=tolerance)
+
+    @dec.slow
+    def test_fundamental_theorem_0(self):
+        self.fundamental_theorem(0, 3.0, 15.0)
+
+    @dec.slow
+    def test_fundamental_theorem_7(self):
+        self.fundamental_theorem(7, 0.5, 1.2)
+
+
+class TestSphericalJnDerivatives(SphericalDerivativesTestCase):
+    def f(self, n, z):
+        return spherical_jn(n, z)
+
+    def df(self, n, z):
+        return spherical_jn(n, z, derivative=True)
+
+    def test_spherical_jn_d_zero(self):
+        n = np.array([1, 2, 3, 7, 15])
+        assert_allclose(spherical_jn(n, 0, derivative=True),
+                        np.zeros(5))
+
+
+class TestSphericalYnDerivatives(SphericalDerivativesTestCase):
+    def f(self, n, z):
+        return spherical_yn(n, z)
+
+    def df(self, n, z):
+        return spherical_yn(n, z, derivative=True)
+
+
+class TestSphericalInDerivatives(SphericalDerivativesTestCase):
+    def f(self, n, z):
+        return spherical_in(n, z)
+
+    def df(self, n, z):
+        return spherical_in(n, z, derivative=True)
+
+    def test_spherical_in_d_zero(self):
+        n = np.array([1, 2, 3, 7, 15])
+        assert_allclose(spherical_in(n, 0, derivative=True),
+                        np.zeros(5))
+
+
+class TestSphericalKnDerivatives(SphericalDerivativesTestCase):
+    def f(self, n, z):
+        return spherical_kn(n, z)
+
+    def df(self, n, z):
+        return spherical_kn(n, z, derivative=True)
+
+
+class TestSphericalOld:
+    # These are tests from the TestSpherical class of test_basic.py,
+    # rewritten to use spherical_* instead of sph_* but otherwise unchanged.
+
+    def test_sph_in(self):
+        # This test reproduces test_basic.TestSpherical.test_sph_in.
+        i1n = np.empty((2,2))
+        x = 0.2
+
+        i1n[0][0] = spherical_in(0, x)
+        i1n[0][1] = spherical_in(1, x)
+        i1n[1][0] = spherical_in(0, x, derivative=True)
+        i1n[1][1] = spherical_in(1, x, derivative=True)
+
+        inp0 = (i1n[0][1])
+        inp1 = (i1n[0][0] - 2.0/0.2 * i1n[0][1])
+        assert_array_almost_equal(i1n[0],np.array([1.0066800127054699381,
+                                                0.066933714568029540839]),12)
+        assert_array_almost_equal(i1n[1],[inp0,inp1],12)
+
+    def test_sph_in_kn_order0(self):
+        x = 1.
+        sph_i0 = np.empty((2,))
+        sph_i0[0] = spherical_in(0, x)
+        sph_i0[1] = spherical_in(0, x, derivative=True)
+        sph_i0_expected = np.array([np.sinh(x)/x,
+                                    np.cosh(x)/x-np.sinh(x)/x**2])
+        assert_array_almost_equal(r_[sph_i0], sph_i0_expected)
+
+        sph_k0 = np.empty((2,))
+        sph_k0[0] = spherical_kn(0, x)
+        sph_k0[1] = spherical_kn(0, x, derivative=True)
+        sph_k0_expected = np.array([0.5*pi*exp(-x)/x,
+                                    -0.5*pi*exp(-x)*(1/x+1/x**2)])
+        assert_array_almost_equal(r_[sph_k0], sph_k0_expected)
+
+    def test_sph_jn(self):
+        s1 = np.empty((2,3))
+        x = 0.2
+
+        s1[0][0] = spherical_jn(0, x)
+        s1[0][1] = spherical_jn(1, x)
+        s1[0][2] = spherical_jn(2, x)
+        s1[1][0] = spherical_jn(0, x, derivative=True)
+        s1[1][1] = spherical_jn(1, x, derivative=True)
+        s1[1][2] = spherical_jn(2, x, derivative=True)
+
+        s10 = -s1[0][1]
+        s11 = s1[0][0]-2.0/0.2*s1[0][1]
+        s12 = s1[0][1]-3.0/0.2*s1[0][2]
+        assert_array_almost_equal(s1[0],[0.99334665397530607731,
+                                      0.066400380670322230863,
+                                      0.0026590560795273856680],12)
+        assert_array_almost_equal(s1[1],[s10,s11,s12],12)
+
+    def test_sph_kn(self):
+        kn = np.empty((2,3))
+        x = 0.2
+
+        kn[0][0] = spherical_kn(0, x)
+        kn[0][1] = spherical_kn(1, x)
+        kn[0][2] = spherical_kn(2, x)
+        kn[1][0] = spherical_kn(0, x, derivative=True)
+        kn[1][1] = spherical_kn(1, x, derivative=True)
+        kn[1][2] = spherical_kn(2, x, derivative=True)
+
+        kn0 = -kn[0][1]
+        kn1 = -kn[0][0]-2.0/0.2*kn[0][1]
+        kn2 = -kn[0][1]-3.0/0.2*kn[0][2]
+        assert_array_almost_equal(kn[0],[6.4302962978445670140,
+                                         38.581777787067402086,
+                                         585.15696310385559829],12)
+        assert_array_almost_equal(kn[1],[kn0,kn1,kn2],9)
+
+    def test_sph_yn(self):
+        sy1 = spherical_yn(2, 0.2)
+        sy2 = spherical_yn(0, 0.2)
+        assert_almost_equal(sy1,-377.52483,5)  # previous values in the system
+        assert_almost_equal(sy2,-4.9003329,5)
+        sphpy = (spherical_yn(0, 0.2) - 2*spherical_yn(2, 0.2))/3
+        sy3 = spherical_yn(1, 0.2, derivative=True)
+        assert_almost_equal(sy3,sphpy,4)  # compare correct derivative val. (correct =-system val).


### PR DESCRIPTION
This PR provides four new ufuncs,
-   `spherical_jn`
-   `spherical_yn`
-   `spherical_in`
-   `spherical_kn`

They are vectorized alternatives to the `specfun` wrappers `sph_jn`, `sph_yn`, `sph_in`, and  `sph_kn`, providing a nicer interface, slightly higher performance and (thanks to the use of different algorithms) better stability for large real inputs.  Derivatives of spherical Bessel functions, which are also computed by the `specfun` wrappers, are not yet implemented.

The performance improvement is not dramatic, at a little over an order of magnitude:

``` python
@np.vectorize
def old_way_kn(n, z):
    return sph_kn(n, z)[0][-1]

x = 10**np.linspace(-2, 3, 5000)
n = 15

>>> %timeit old_way_kn(n, x)
10 loops, best of 3: 72.4 ms per loop

>>> %timeit spherical_kn(n, x)
100 loops, best of 3: 2.57 ms per loop
```

Better stability, especially in `spherical_jn` and `spherical_in` for large (> 10**3) real argument values, is obtained by replacing the recursive `specfun` algorithms with calls to AMOS/CEPHES cylindrical Bessel function routines, using [these identities](http://dlmf.nist.gov/10.47).

Fixes #1641 and #2165, and (except for the still missing derivatives) implements #3113.
