### PR TITLE
FIX: Fix interpolate

### DIFF
--- a/doc/release/0.17.0-notes.rst
+++ b/doc/release/0.17.0-notes.rst
@@ -124,9 +124,20 @@ several new features were added to it:
 
 Out-of-bounds behavior of `scipy.interpolate.interp1d` has been improved.
 Use a two-element tuple for the ``fill_value`` argument to specify separate
-fill values for input above and below the interpolation range.
+fill values for input below and above the interpolation range.
 Linear and nearest interpolation kinds of `scipy.interpolate.interp1d` support
 extrapolation via the ``fill_value="extrapolate"`` keyword.
+
+``fill_value`` can also be set to an array-like (or a two-element tuple of
+array-likes for separate below and above values) so long as it broadcasts
+properly to the non-interpolated dimensions of an array. This was implicitly
+supported by previous versions of scipy, but support has now been formalized
+and gets compatibility-checked before use. For example, a set of ``y`` values
+to interpolate with shape ``(2, 3, 5)`` interpolated along the last axis (2)
+could accept a ``fill_value`` array with shape ``()`` (singleton), ``(1,)``,
+``(2, 1)``, ``(1, 3)``, ``(3,)``, or ``(2, 3)``; or it can be a 2-element tuple
+to specify separate below and above bounds, where each of the two tuple
+elements obeys proper broadcasting rules.
 
 `scipy.linalg` improvements
 ---------------------------


### PR DESCRIPTION
@ev-br this fixes a cryptic error I was getting:

```
  File "/home/larsoner/.local/lib/python2.7/site-packages/scipy/interpolate/interpolate.py", line 410, in __init__
    self._fill_value_below, self._fill_value_above = _duplicate(fill_value)
  File "/home/larsoner/.local/lib/python2.7/site-packages/scipy/interpolate/interpolate.py", line 311, in _duplicate
    a, b = ab
ValueError: too many values to unpack
```

Turns out that doing e.g. `a, b = np.array([1.])` raises `ValueError`, not `TypeError` like `a, b = 1.` would.
