### PR TITLE
BUG: msvc9 binaries crash when indexing std::vector of size 0

### DIFF
--- a/scipy/spatial/ckdtree/src/cpp_utils.h
+++ b/scipy/spatial/ckdtree/src/cpp_utils.h
@@ -23,7 +23,7 @@ inline void*
 tree_buffer_pointer(std::vector<ckdtreenode> *buf)
 {
     std::vector<ckdtreenode> &tmp = *buf;
-    if (tmp.size() == 0)
+    if (NPY_UNLIKELY(tmp.size() == 0))
         return NULL;
     return (void*)&tmp[0];
 }
@@ -33,7 +33,7 @@ inline ckdtreenode*
 tree_buffer_root(std::vector<ckdtreenode> *buf)
 {
     std::vector<ckdtreenode> &tmp = *buf;
-    if (tmp.size() == 0)
+    if (NPY_UNLIKELY(tmp.size() == 0))
         return NULL;
     return &tmp[0];
 }
@@ -42,7 +42,7 @@ inline ordered_pair *
 ordered_pair_vector_buf(std::vector<ordered_pair> *buf)
 {
     std::vector<ordered_pair> &tmp = *buf;
-    if (tmp.size() == 0)
+    if (NPY_UNLIKELY(tmp.size() == 0))
         return NULL;
     return &tmp[0];
 }
@@ -54,7 +54,7 @@ inline npy_intp *
 npy_intp_vector_buf(std::vector<npy_intp> *buf)
 {
     std::vector<npy_intp> &tmp = *buf;
-    if (tmp.size() == 0)
+    if (NPY_UNLIKELY(tmp.size() == 0))
         return NULL;
     return &tmp[0];
 }
@@ -63,7 +63,7 @@ inline npy_float64 *
 npy_float64_vector_buf(std::vector<npy_float64> *buf)
 {
     std::vector<npy_float64> &tmp = *buf;
-    if (tmp.size() == 0)
+    if (NPY_UNLIKELY(tmp.size() == 0))
         return NULL;
     return &tmp[0];
 }
@@ -72,7 +72,7 @@ inline coo_entry *
 coo_entry_vector_buf(std::vector<coo_entry> *buf)
 {
     std::vector<coo_entry> &tmp = *buf;
-    if (tmp.size() == 0)
+    if (NPY_UNLIKELY(tmp.size() == 0))
         return NULL;
     return &tmp[0];
 }

--- a/scipy/spatial/ckdtree/src/cpp_utils.h
+++ b/scipy/spatial/ckdtree/src/cpp_utils.h
@@ -23,6 +23,8 @@ inline void*
 tree_buffer_pointer(std::vector<ckdtreenode> *buf)
 {
     std::vector<ckdtreenode> &tmp = *buf;
+    if (tmp.size() == 0)
+        return NULL;
     return (void*)&tmp[0];
 }
 
@@ -31,6 +33,8 @@ inline ckdtreenode*
 tree_buffer_root(std::vector<ckdtreenode> *buf)
 {
     std::vector<ckdtreenode> &tmp = *buf;
+    if (tmp.size() == 0)
+        return NULL;
     return &tmp[0];
 }
 
@@ -38,6 +42,8 @@ inline ordered_pair *
 ordered_pair_vector_buf(std::vector<ordered_pair> *buf)
 {
     std::vector<ordered_pair> &tmp = *buf;
+    if (tmp.size() == 0)
+        return NULL;
     return &tmp[0];
 }
 
@@ -48,6 +54,8 @@ inline npy_intp *
 npy_intp_vector_buf(std::vector<npy_intp> *buf)
 {
     std::vector<npy_intp> &tmp = *buf;
+    if (tmp.size() == 0)
+        return NULL;
     return &tmp[0];
 }
 
@@ -55,6 +63,8 @@ inline npy_float64 *
 npy_float64_vector_buf(std::vector<npy_float64> *buf)
 {
     std::vector<npy_float64> &tmp = *buf;
+    if (tmp.size() == 0)
+        return NULL;
     return &tmp[0];
 }
 
@@ -62,6 +72,8 @@ inline coo_entry *
 coo_entry_vector_buf(std::vector<coo_entry> *buf)
 {
     std::vector<coo_entry> &tmp = *buf;
+    if (tmp.size() == 0)
+        return NULL;
     return &tmp[0];
 }
 


### PR DESCRIPTION
Fixes a crash during tests of msvc9, ifort, MKL builds:

```
NumPy version 1.9.3
NumPy is installed in X:\Python27\lib\site-packages\numpy
SciPy version 0.17.0rc1
SciPy is installed in X:\Python27\lib\site-packages\scipy
Python version 2.7.11 (v2.7.11:6d1b6a68f775, Dec  5 2015, 20:32:19) [MSC v.1500 32 bit (Intel)]
nose version 1.3.7
<snip>
test_kdtree.test_count_neighbors_compiled.test_one_radius ...<crash>
```
