### PR TITLE
MAINT: optimize: tighten _group_columns

### DIFF
--- a/scipy/optimize/_group_columns.pyx
+++ b/scipy/optimize/_group_columns.pyx
@@ -3,38 +3,43 @@ Cython implementation of columns grouping for finite difference Jacobian
 estimation. Used by ._numdiff.group_columns.
 """
 
+cimport cython
+
 import numpy as np
 
 cimport numpy as np
 from cpython cimport bool
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def group_dense(int m, int n, int [:, :] A):
     cdef int [:, :] B = A.T  # Transposed view for convenience.
 
-    groups = -np.ones(n, dtype=np.int32)
-    cdef int [:] groups_v = groups
+    cdef int [:] groups = -np.ones(n, dtype=np.int32)
     cdef int current_group = 0
 
     cdef int i, j, k
-    cdef bool intersect
 
     union = np.empty(m, dtype=np.int32)
     cdef int [:] union_v = union
 
     # Loop through all the columns.
     for i in range(n):
-        if groups_v[i] >= 0:  # A group was already assigned.
+        if groups[i] >= 0:  # A group was already assigned.
             continue
 
-        groups_v[i] = current_group
-        non_grouped, = np.nonzero(groups < 0)
-        if non_grouped.size == 0:  # All columns are grouped.
-            break
+        groups[i] = current_group
+        all_grouped = True
 
         union_v[:] = B[i]  # Here we store the union of grouped columns.
 
-        for j in non_grouped:
+        for j in range(groups.shape[0]):
+            if groups[j] < 0:
+                all_grouped = False
+            else:
+                continue
+
             # Determine if j-th column intersects with the union.
             intersect = False
             for k in range(m):
@@ -45,38 +50,43 @@ def group_dense(int m, int n, int [:, :] A):
             # If not, add it to the union and assign the group to it.
             if not intersect:
                 union += B[j]
-                groups_v[j] = current_group
+                groups[j] = current_group
+
+        if all_grouped:
+            break
 
         current_group += 1
 
-    return groups
+    return groups.base
 
 
+@cython.wraparound(False)
 def group_sparse(int m, int n, int [:] indices, int [:] indptr):
-    groups = -np.ones(n, dtype=np.int32)
-    cdef int [:] groups_v = groups
+    cdef int [:] groups = -np.ones(n, dtype=np.int32)
     cdef int current_group = 0
 
     cdef int i, j, k
-    cdef bool intersect
 
     union = np.empty(m, dtype=np.int32)
     cdef int [:] union_v = union
 
     for i in range(n):
-        if groups_v[i] >= 0:
+        if groups[i] >= 0:
             continue
 
-        groups_v[i] = current_group
-        non_grouped, = np.nonzero(groups < 0)
-        if non_grouped.size == 0:
-            break
+        groups[i] = current_group
+        all_grouped = True
 
         union.fill(0)
         for k in range(indptr[i], indptr[i + 1]):
             union_v[indices[k]] = 1
 
-        for j in non_grouped:
+        for j in range(groups.shape[0]):
+            if groups[j] < 0:
+                all_grouped = False
+            else:
+                continue
+
             intersect = False
             for k in range(indptr[j], indptr[j + 1]):
                 if union_v[indices[k]] == 1:
@@ -85,8 +95,11 @@ def group_sparse(int m, int n, int [:] indices, int [:] indptr):
             if not intersect:
                 for k in range(indptr[j], indptr[j + 1]):
                     union_v[indices[k]] = 1
-                groups_v[j] = current_group
+                groups[j] = current_group
+
+        if all_grouped:
+            break
 
         current_group += 1
 
-    return groups
+    return groups.base


### PR DESCRIPTION
Generates a few hundred lines fewer C code.

Interestingly, `cdef bool` is a pessimization, so I removed it. Cython is smart enough to figure out a variable is boolean, but `cdef bool` forces it to be a Python bool.
