### PR TITLE
BUG: misspelled __dealloc__ in cKDTree.

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -548,7 +548,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         return 0
         
 
-    def __deallocate__(cKDTree self):
+    def __dealloc__(cKDTree self):
         if self.tree_buffer != NULL:
             del self.tree_buffer
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1072,7 +1072,11 @@ def simulate_periodic_box(kdtree, data, k, boxsize):
     
 def test_ckdtree_memuse():
     # unit test adaptation of gh-5630
-    import resource
+    try:
+        import resource
+    except ImportError:
+        # resource is not available on Windows with Python 2.6
+        return
     # Make some data
     dx, dy = 0.05, 0.05
     y, x = np.mgrid[slice(1, 5 + dy, dy),

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1069,5 +1069,39 @@ def simulate_periodic_box(kdtree, data, k, boxsize):
     result['dd'][:] = dd
     result.sort(order='dd')
     return result['dd'][:, :k], result['ii'][:,:k]
+    
+def test_ckdtree_memuse():
+    # unit test adaptation of gh-5630
+    import resource
+    # Make some data
+    dx, dy = 0.05, 0.05
+    y, x = np.mgrid[slice(1, 5 + dy, dy),
+                    slice(1, 5 + dx, dx)]
+    z = np.sin(x)**10 + np.cos(10 + y*x) * np.cos(x)
+    z_copy = np.empty_like(z)
+    z_copy[:] = z
+    # Place FILLVAL in z_copy at random number of random locations
+    FILLVAL = 99.
+    mask = np.random.random_integers(0, z.size - 1, np.random.randint(50) + 5)
+    z_copy.flat[mask] = FILLVAL
+    igood = np.vstack(np.where(x != FILLVAL)).T
+    ibad = np.vstack(np.where(x == FILLVAL)).T
+    mem_use = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    # burn-in
+    for i in range(10):
+        tree = cKDTree(igood)
+    # count memleaks while constructing and querying cKDTree
+    num_leaks = 0
+    for i in range(100):
+        mem_use = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        tree = cKDTree(igood)
+        dist, iquery = tree.query(ibad, k=4, p=2)
+        new_mem_use = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        if new_mem_use > mem_use:
+            num_leaks += 1
+    # ideally zero leaks, but errors might accidentally happen
+    # outside cKDTree
+    assert_(num_leaks < 10)
+    
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Fixes misspelling preventing destructor from being invoked.
