### PR TITLE
BUG: misspelled __dealloc__ in cKDTree

### DIFF
--- a/scipy/spatial/ckdtree/ckdtree.pyx
+++ b/scipy/spatial/ckdtree/ckdtree.pyx
@@ -949,7 +949,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
         return 0
         
 
-    def __deallocate__(cKDTree self):
+    def __dealloc__(cKDTree self):
         if self.tree_buffer != NULL:
             del self.tree_buffer
 


### PR DESCRIPTION
Fix for #5630 in 0.16.x.
