### PR TITLE
[TST] raise on warnings when running dev version tests

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -113,5 +113,10 @@ else:
     del _NumpyVersion
 
     from numpy.testing import Tester
-    test = Tester().test
-    bench = Tester().bench
+    if ".dev0" in __version__:
+        test = Tester(raise_warnings="develop").test
+        bench = Tester(raise_warnings="develop").bench
+    else:
+        test = Tester(raise_warnings="release").test
+        bench = Tester(raise_warnings="release").bench
+


### PR DESCRIPTION
We want CI tests to fail when they use deprecated functionality or
otherwise raise spurious warnings, so enable raise_warnings="develop"
for development builds.

See gh-5609 for related discussion, and numpy/numpy#6901 for a related
change in numpy.
