### PR TITLE
BLD: fix a build issue in special/Faddeeva.cc with isnan. 

### DIFF
--- a/scipy/special/Faddeeva.cc
+++ b/scipy/special/Faddeeva.cc
@@ -125,7 +125,7 @@ extern "C" {
 #include <cfloat>
 #include <cmath>
 
-using namespace std;
+#define complex std::complex
 
 /////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Closes gh-5607.

This happens when a build flag `std=c++11` is defined.

To test, compile Scipy inplace with default flags, and then:

```
$ export CFLAGS -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -std=c++11 -L/usr/local/boost/lib -fPIC
$ touch scipy/special/Faddeeva.cc
$ python setup.py build_ext -i
```

This will fail on master, and pass with this PR. This is because C and C++ have incompatibly defined `isnan`s (see http://stackoverflow.com/questions/19022561/porting-isnan-to-c11), and the C++ version becomes visible with `using namespace std`.
