### PR TITLE
ENH: Circular statistic optimization

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -12,7 +12,7 @@ import numpy as np
 from numpy import (isscalar, r_, log, around, unique, asarray,
                    zeros, arange, sort, amin, amax, any, atleast_1d,
                    sqrt, ceil, floor, array, poly1d, compress,
-                   pi, exp, ravel, angle, count_nonzero)
+                   pi, exp, ravel, count_nonzero, sin, cos, arctan2, hypot)
 from numpy.testing.decorators import setastest
 
 from scipy._lib.six import string_types
@@ -1930,7 +1930,7 @@ def levene(*args, **kwds):
 
     if center not in ['mean', 'median', 'trimmed']:
         raise ValueError("Keyword argument <center> must be 'mean', 'median'"
-                         + "or 'trimmed'.")
+                        " or 'trimmed'.")
 
     if center == 'median':
         func = lambda x: np.median(x, axis=0)
@@ -2151,7 +2151,7 @@ def fligner(*args, **kwds):
 
     if center not in ['mean', 'median', 'trimmed']:
         raise ValueError("Keyword argument <center> must be 'mean', 'median'"
-                         + "or 'trimmed'.")
+                        " or 'trimmed'.")
 
     if center == 'median':
         func = lambda x: np.median(x, axis=0)
@@ -2692,15 +2692,13 @@ def circmean(samples, high=2*pi, low=0, axis=None):
 
     """
     samples, ang = _circfuncs_common(samples, high, low)
-    res = angle(np.mean(exp(1j * ang), axis=axis))
-    mask = res < 0
+    S = sin(ang).sum(axis=axis)
+    C = cos(ang).sum(axis=axis)
+    res = arctan2(S, C)*(high - low)/2.0/pi + low
+    mask = (S == .0) * (C == .0)
     if mask.ndim > 0:
-        res[mask] += 2*pi
-    elif mask:
-        res += 2*pi
-
-    return res*(high - low)/2.0/pi + low
-
+        res[mask] = np.nan
+    return res 
 
 def circvar(samples, high=2*pi, low=0, axis=None):
     """
@@ -2730,8 +2728,9 @@ def circvar(samples, high=2*pi, low=0, axis=None):
 
     """
     samples, ang = _circfuncs_common(samples, high, low)
-    res = np.mean(exp(1j * ang), axis=axis)
-    R = abs(res)
+    S = sin(ang).mean(axis=axis)
+    C = cos(ang).mean(axis=axis)
+    R = hypot(S, C)
     return ((high - low)/2.0/pi)**2 * 2 * log(1/R)
 
 
@@ -2765,8 +2764,9 @@ def circstd(samples, high=2*pi, low=0, axis=None):
 
     """
     samples, ang = _circfuncs_common(samples, high, low)
-    res = np.mean(exp(1j * ang), axis=axis)
-    R = abs(res)
+    S = sin(ang).mean(axis=axis)
+    C = cos(ang).mean(axis=axis)
+    R = hypot(S, C)
     return ((high - low)/2.0/pi) * sqrt(-2*log(R))
 
 


### PR DESCRIPTION
Hi, 
this pull request concerns 3 functions of circular statistics in the `stats` module: 
- `circmean`
- `circvar`
- `circstd`

The method used until now calls `exp(1j*ang)` in order to calculate `sin` and `cos` of `ang`.
However, calculating the `sin` and `cos` is significantly faster (see below) and also requires half the
RAM at peak usage (really import in the case of large arrays).

Here is a comparison between old (`circmean`) and new (`cirmean2`) methods:

```
In [1]: from scipy import stats

In [2]: import numpy as np

In [3]: phases=np.random.randn(1000)                                      

In [4]: timeit stats.circmean(phases)                                     
1000 loops, best of 3: 357 µs per loop

In [5]: timeit stats.circmean2(phases)
10000 loops, best of 3: 220 µs per loop

In [6]: phases=np.random.randn(1e8)                                       

In [7]: timeit stats.circmean(phases)                                     
1 loops, best of 3: 17.3 s per loop

In [8]: timeit stats.circmean2(phases)
1 loops, best of 3: 12.8 s per loop`
```

This is my first pull request, hope that it's not too messed up. Comments are highly appreciated.
