### PR TITLE
MAINT: remove uses of np.testing.rand

### DIFF
--- a/scipy/fftpack/tests/test_helper.py
+++ b/scipy/fftpack/tests/test_helper.py
@@ -12,15 +12,12 @@ Run tests if fftpack is not installed:
   python tests/test_helper.py [<level>]
 """
 
-from numpy.testing import (TestCase, assert_array_almost_equal, rand,
+from numpy.testing import (TestCase, assert_array_almost_equal,
                            run_module_suite)
 from scipy.fftpack import fftshift,ifftshift,fftfreq,rfftfreq
 
 from numpy import pi
-
-
-def random(size):
-    return rand(*size)
+from numpy.random import random
 
 
 class TestFFTShift(TestCase):

--- a/scipy/fftpack/tests/test_pseudo_diffs.py
+++ b/scipy/fftpack/tests/test_pseudo_diffs.py
@@ -13,17 +13,14 @@ Run tests if fftpack is not installed:
 """
 
 from numpy.testing import (TestCase, assert_equal, assert_almost_equal,
-                           assert_array_almost_equal, rand, run_module_suite)
+                           assert_array_almost_equal, run_module_suite)
 from scipy.fftpack import (diff, fft, ifft, tilbert, itilbert, hilbert,
                            ihilbert, shift, fftfreq, cs_diff, sc_diff,
                            ss_diff, cc_diff)
 
 import numpy as np
 from numpy import arange, sin, cos, pi, exp, tanh, sum, sign
-
-
-def random(size):
-    return rand(*size)
+from numpy.random import random
 
 
 def direct_diff(x,k=1,period=None):

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -5,9 +5,10 @@ from tempfile import mkdtemp, mktemp
 import os
 import shutil
 
+import numpy as np
 from numpy import array,transpose, pi
 from numpy.testing import (TestCase, run_module_suite, assert_equal,
-                           assert_array_equal, assert_array_almost_equal, rand)
+                           assert_array_equal, assert_array_almost_equal)
 
 import scipy.sparse
 from scipy.io.mmio import mminfo, mmread, mmwrite
@@ -73,13 +74,13 @@ class TestMMIOArray(TestCase):
 
     def test_random_symmetric_float(self):
         sz = (20, 20)
-        a = rand(*sz)
+        a = np.random.random(sz)
         a = a + transpose(a)
         self.check(a, (20, 20, 400, 'array', 'real', 'symmetric'))
 
     def test_random_rectangular_float(self):
         sz = (20, 15)
-        a = rand(*sz)
+        a = np.random.random(sz)
         self.check(a, (20, 15, 300, 'array', 'real', 'general'))
 
 
@@ -144,14 +145,14 @@ class TestMMIOSparseCSR(TestMMIOArray):
 
     def test_random_symmetric_float(self):
         sz = (20, 20)
-        a = rand(*sz)
+        a = np.random.random(sz)
         a = a + transpose(a)
         a = scipy.sparse.csr_matrix(a)
         self.check(a, (20, 20, 210, 'coordinate', 'real', 'symmetric'))
 
     def test_random_rectangular_float(self):
         sz = (20, 15)
-        a = rand(*sz)
+        a = np.random.random(sz)
         a = scipy.sparse.csr_matrix(a)
         self.check(a, (20, 15, 300, 'coordinate', 'real', 'general'))
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -25,8 +25,9 @@ import numpy as np
 from numpy import (arange, array, dot, zeros, identity, conjugate, transpose,
         float32)
 import numpy.linalg as linalg
+from numpy.random import random
 
-from numpy.testing import (TestCase, rand, run_module_suite, assert_raises,
+from numpy.testing import (TestCase, run_module_suite, assert_raises,
     assert_equal, assert_almost_equal, assert_array_almost_equal, assert_,
     assert_allclose, assert_array_equal, dec)
 
@@ -42,9 +43,6 @@ from scipy._lib._version import NumpyVersion
 REAL_DTYPES = [np.float32, np.float64]
 COMPLEX_DTYPES = [np.complex64, np.complex128]
 DTYPES = REAL_DTYPES + COMPLEX_DTYPES
-
-def random(size):
-    return rand(*size)
 
 
 class TestSolveBanded(TestCase):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -33,7 +33,7 @@ from numpy import array, transpose, sometrue, diag, ones, linalg, \
      asarray, matrix, isfinite, all, ndarray, outer, eye, dtype, empty,\
      triu, tril
 
-from numpy.random import rand, normal, seed
+from numpy.random import normal, seed, random
 
 from scipy.linalg._testutils import assert_no_overwrite
 
@@ -71,7 +71,7 @@ def symrand(dim_or_eigv):
     """
     if isinstance(dim_or_eigv, int):
         dim = dim_or_eigv
-        d = (rand(dim)*2)-1
+        d = random(dim)*2 - 1
     elif (isinstance(dim_or_eigv, ndarray) and
           len(dim_or_eigv.shape) == 1):
         dim = dim_or_eigv.shape[0]
@@ -114,10 +114,6 @@ def random_rot(dim):
     D[-1] = -D.prod()
     H = (D*H.T).T
     return H
-
-
-def random(size):
-    return rand(*size)
 
 
 class TestEigVals(TestCase):
@@ -685,8 +681,8 @@ class TestLU(TestCase):
         self.cvrect = 1.j * array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 12, 12]])
 
         # Medium sizes matrices
-        self.med = rand(30, 40)
-        self.cmed = rand(30, 40) + 1.j * rand(30, 40)
+        self.med = random((30, 40))
+        self.cmed = random((30, 40)) + 1.j * random((30, 40))
 
     def _test_common(self, data):
         p,l,u = lu(data)

--- a/scipy/linalg/tests/test_decomp_cholesky.py
+++ b/scipy/linalg/tests/test_decomp_cholesky.py
@@ -3,15 +3,11 @@ from __future__ import division, print_function, absolute_import
 from numpy.testing import TestCase, assert_array_almost_equal
 
 from numpy import array, transpose, dot, conjugate, zeros_like
-from numpy.random import rand
+from numpy.random import random
 from scipy.linalg import cholesky, cholesky_banded, cho_solve_banded, \
      cho_factor, cho_solve
 
 from scipy.linalg._testutils import assert_no_overwrite
-
-
-def random(size):
-    return rand(*size)
 
 
 class TestCholesky(TestCase):

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -26,13 +26,13 @@ import itertools
 import warnings
 
 import numpy as np
-from numpy import array, isnan, r_, arange, finfo, pi, sin, cos, tan, exp, \
-        log, zeros, sqrt, asarray, inf, nan_to_num, real, arctan, float_
+from numpy import (array, isnan, r_, arange, finfo, pi, sin, cos, tan, exp,
+        log, zeros, sqrt, asarray, inf, nan_to_num, real, arctan, float_)
 
-from numpy.testing import assert_equal, assert_almost_equal, \
-        assert_array_equal, assert_array_almost_equal, assert_approx_equal, \
-        assert_, rand, dec, TestCase, run_module_suite, assert_allclose, \
-        assert_raises, assert_array_almost_equal_nulp
+from numpy.testing import (assert_equal, assert_almost_equal,
+        assert_array_equal, assert_array_almost_equal, assert_approx_equal,
+        assert_, dec, TestCase, run_module_suite, assert_allclose,
+        assert_raises, assert_array_almost_equal_nulp)
 
 from scipy import special
 import scipy.special._ufuncs as cephes
@@ -2170,8 +2170,8 @@ class TestBessel(TestCase):
         assert_almost_equal(o1ke,o1ker,8)
 
     def test_jacobi(self):
-        a = 5*rand() - 1
-        b = 5*rand() - 1
+        a = 5*np.random.random() - 1
+        b = 5*np.random.random() - 1
         P0 = special.jacobi(0,a,b)
         P1 = special.jacobi(1,a,b)
         P2 = special.jacobi(2,a,b)
@@ -2576,7 +2576,7 @@ class TestLaguerre(TestCase):
         assert_array_almost_equal(lag5.c,array([-1,25,-200,600,-600,120])/120.0,13)
 
     def test_genlaguerre(self):
-        k = 5*rand()-0.9
+        k = 5*np.random.random() - 0.9
         lag0 = special.genlaguerre(0,k)
         lag1 = special.genlaguerre(1,k)
         lag2 = special.genlaguerre(2,k)

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import (rand, TestCase, assert_array_almost_equal,
+from numpy.testing import (TestCase, assert_array_almost_equal,
                            assert_almost_equal, assert_allclose, assert_raises,
                            run_module_suite)
 
@@ -78,7 +78,7 @@ class TestCheby(TestCase):
 class TestGegenbauer(TestCase):
 
     def test_gegenbauer(self):
-        a = 5*rand()-0.5
+        a = 5*np.random.random() - 0.5
         if np.any(a == 0):
             a = -0.2
         Ca0 = orth.gegenbauer(0,a)
@@ -218,8 +218,8 @@ class _test_sh_jacobi(TestCase):
         # G^(p,q)_n(x) = n! gamma(n+p)/gamma(2*n+p) * P^(p-q,q-1)_n(2*x-1)
         conv = lambda n,p: gamma(n+1)*gamma(n+p)/gamma(2*n+p)
         psub = np.poly1d([2,-1])
-        q = 4*rand()
-        p = q-1 + 2*rand()
+        q = 4 * np.random.random()
+        p = q-1 + 2*np.random.random()
         #print "shifted jacobi p,q = ", p, q
         G0 = orth.sh_jacobi(0,p,q)
         G1 = orth.sh_jacobi(1,p,q)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -10,7 +10,7 @@ import pickle
 
 from numpy.testing import (TestCase, run_module_suite, assert_equal,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
-    assert_allclose, assert_, assert_raises, assert_warns, rand, dec)
+    assert_allclose, assert_, assert_raises, assert_warns, dec)
 from nose import SkipTest
 
 import numpy
@@ -81,19 +81,19 @@ def test_all_distributions():
             alpha = 0.001
 
         if dist == 'frechet':
-            args = tuple(2*rand(1))+(0,)+tuple(2*rand(2))
+            args = tuple(2*np.random.random(1)) + (0,) + tuple(2*np.random.random(2))
         elif dist == 'triang':
-            args = tuple(rand(nargs))
+            args = tuple(np.random.random(nargs))
         elif dist == 'reciprocal':
-            vals = rand(nargs)
+            vals = np.random.random(nargs)
             vals[1] = vals[0] + 1.0
             args = tuple(vals)
         elif dist == 'vonmises':
             yield check_distribution, dist, (10,), alpha
             yield check_distribution, dist, (101,), alpha
-            args = tuple(1.0+rand(nargs))
+            args = tuple(1.0 + np.random.random(nargs))
         else:
-            args = tuple(1.0+rand(nargs))
+            args = tuple(1.0 + np.random.random(nargs))
 
         yield check_distribution, dist, args, alpha
 


### PR DESCRIPTION
a follow-up to https://github.com/scipy/scipy/pull/5661.

Having `np.testing.rand` likely made sense in 2002 (was it scipy_core.testing.rand then?), but not so much now that we rely on `numpy.random` _almost_ everywhere.

These have not been reported as causing immediate trouble, so these probably can be just treated as a regular maintenance, unlike gh-5661 which is a backport material.
