### PR TITLE
MAINT: spatial: remove matching distance implementation

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -746,36 +746,11 @@ def yule(u, v):
 
 def matching(u, v):
     """
-    Computes the Matching dissimilarity between two boolean 1-D arrays.
+    Computes the Hamming distance between two boolean 1-D arrays.
 
-    The Matching dissimilarity between two boolean 1-D arrays
-    `u` and `v`, is defined as
-
-    .. math::
-
-       \\frac{c_{TF} + c_{FT}}{n}
-
-    where :math:`c_{ij}` is the number of occurrences of
-    :math:`\\mathtt{u[k]} = i` and :math:`\\mathtt{v[k]} = j` for
-    :math:`k < n`.
-
-    Parameters
-    ----------
-    u : (N,) array_like, bool
-        Input array.
-    v : (N,) array_like, bool
-        Input array.
-
-    Returns
-    -------
-    matching : double
-        The Matching dissimilarity between vectors `u` and `v`.
-
+    This is a deprecated synonym for :func:`hamming`.
     """
-    u = _validate_vector(u)
-    v = _validate_vector(v)
-    (nft, ntf) = _nbool_correspond_ft_tf(u, v)
-    return float(nft + ntf) / float(len(u))
+    return hamming(u, v)
 
 
 def dice(u, v):
@@ -1100,8 +1075,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
 
     15. ``Y = pdist(X, 'matching')``
 
-       Computes the matching distance between each pair of boolean
-       vectors. (see matching function documentation)
+       Synonym for 'hamming'.
 
     16. ``Y = pdist(X, 'dice')``
 
@@ -1343,7 +1317,7 @@ def pdist(X, metric='euclidean', p=2, w=None, V=None, VI=None):
         elif mstr == 'yule':
             _distance_wrap.pdist_yule_bool_wrap(_convert_to_bool(X), dm)
         elif mstr == 'matching':
-            _distance_wrap.pdist_matching_bool_wrap(_convert_to_bool(X), dm)
+            _distance_wrap.pdist_hamming_bool_wrap(_convert_to_bool(X), dm)
         elif mstr == 'kulsinski':
             _distance_wrap.pdist_kulsinski_bool_wrap(_convert_to_bool(X), dm)
         elif mstr == 'dice':
@@ -1902,8 +1876,7 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
 
     15. ``Y = cdist(XA, XB, 'matching')``
 
-       Computes the matching distance between the boolean
-       vectors. (see `matching` function documentation)
+       Synonym for 'hamming'.
 
     16. ``Y = cdist(XA, XB, 'dice')``
 
@@ -2207,8 +2180,8 @@ def cdist(XA, XB, metric='euclidean', p=2, V=None, VI=None, w=None):
             _distance_wrap.cdist_yule_bool_wrap(_convert_to_bool(XA),
                                                 _convert_to_bool(XB), dm)
         elif mstr == 'matching':
-            _distance_wrap.cdist_matching_bool_wrap(_convert_to_bool(XA),
-                                                    _convert_to_bool(XB), dm)
+            _distance_wrap.cdist_hamming_bool_wrap(_convert_to_bool(XA),
+                                                   _convert_to_bool(XB), dm)
         elif mstr == 'kulsinski':
             _distance_wrap.cdist_kulsinski_bool_wrap(_convert_to_bool(XA),
                                                      _convert_to_bool(XB), dm)

--- a/scipy/spatial/src/distance_impl.h
+++ b/scipy/spatial/src/distance_impl.h
@@ -176,19 +176,6 @@ yule_bool_distance_char(const char *u, const char *v, npy_intp n)
 }
 
 static NPY_INLINE double
-matching_distance_char(const char *u, const char *v, npy_intp n)
-{
-    npy_intp i;
-    npy_intp nft = 0, ntf = 0;
-
-    for (i = 0; i < n; i++) {
-        ntf += (u[i] && !v[i]);
-        nft += (!u[i] && v[i]);
-    }
-    return (double)(ntf + nft) / (double)(n);
-}
-
-static NPY_INLINE double
 dice_distance_char(const char *u, const char *v, npy_intp n)
 {
     npy_intp i;
@@ -610,7 +597,6 @@ DEFINE_CDIST(dice, char)
 DEFINE_CDIST(hamming, char)
 DEFINE_CDIST(jaccard, char)
 DEFINE_CDIST(kulsinski, char)
-DEFINE_CDIST(matching, char)
 DEFINE_CDIST(rogerstanimoto, char)
 DEFINE_CDIST(russellrao, char)
 DEFINE_CDIST(sokalmichener, char)
@@ -647,7 +633,6 @@ DEFINE_PDIST(dice, char)
 DEFINE_PDIST(hamming, char)
 DEFINE_PDIST(jaccard, char)
 DEFINE_PDIST(kulsinski, char)
-DEFINE_PDIST(matching, char)
 DEFINE_PDIST(rogerstanimoto, char)
 DEFINE_PDIST(russellrao, char)
 DEFINE_PDIST(sokalmichener, char)

--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -268,31 +268,6 @@ static PyObject *cdist_weighted_minkowski_wrap(PyObject *self, PyObject *args) {
   return Py_BuildValue("d", 0.0);
 }
 
-static PyObject *cdist_matching_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *XA_, *XB_, *dm_;
-  int mA, mB, n;
-  double *dm;
-  const char *XA, *XB;
-  if (!PyArg_ParseTuple(args, "O!O!O!",
-			&PyArray_Type, &XA_, &PyArray_Type, &XB_, 
-			&PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    XA = (const char*)XA_->data;
-    XB = (const char*)XB_->data;
-    dm = (double*)dm_->data;
-    mA = XA_->dimensions[0];
-    mB = XB_->dimensions[0];
-    n = XA_->dimensions[1];
-
-    cdist_matching_char(XA, XB, dm, mA, mB, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("");
-}
-
 static PyObject *cdist_dice_bool_wrap(PyObject *self, PyObject *args) {
   PyArrayObject *XA_, *XB_, *dm_;
   int mA, mB, n;
@@ -684,29 +659,6 @@ static PyObject *pdist_yule_bool_wrap(PyObject *self, PyObject *args) {
   return Py_BuildValue("");
 }
 
-static PyObject *pdist_matching_bool_wrap(PyObject *self, PyObject *args) {
-  PyArrayObject *X_, *dm_;
-  int m, n;
-  double *dm;
-  const char *X;
-  if (!PyArg_ParseTuple(args, "O!O!",
-			&PyArray_Type, &X_,
-			&PyArray_Type, &dm_)) {
-    return 0;
-  }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    X = (const char*)X_->data;
-    dm = (double*)dm_->data;
-    m = X_->dimensions[0];
-    n = X_->dimensions[1];
-
-    pdist_matching_char(X, dm, m, n);
-    NPY_END_ALLOW_THREADS;
-  }
-  return Py_BuildValue("");
-}
-
 static PyObject *pdist_dice_bool_wrap(PyObject *self, PyObject *args) {
   PyArrayObject *X_, *dm_;
   int m, n;
@@ -902,7 +854,6 @@ static PyMethodDef _distanceWrapMethods[] = {
   {"cdist_jaccard_bool_wrap", cdist_jaccard_bool_wrap, METH_VARARGS},
   {"cdist_kulsinski_bool_wrap", cdist_kulsinski_bool_wrap, METH_VARARGS},
   {"cdist_mahalanobis_wrap", cdist_mahalanobis_wrap, METH_VARARGS},
-  {"cdist_matching_bool_wrap", cdist_matching_bool_wrap, METH_VARARGS},
   {"cdist_minkowski_wrap", cdist_minkowski_wrap, METH_VARARGS},
   {"cdist_weighted_minkowski_wrap", cdist_weighted_minkowski_wrap, METH_VARARGS},
   {"cdist_rogerstanimoto_bool_wrap", cdist_rogerstanimoto_bool_wrap, METH_VARARGS},
@@ -925,7 +876,6 @@ static PyMethodDef _distanceWrapMethods[] = {
   {"pdist_jaccard_bool_wrap", pdist_jaccard_bool_wrap, METH_VARARGS},
   {"pdist_kulsinski_bool_wrap", pdist_kulsinski_bool_wrap, METH_VARARGS},
   {"pdist_mahalanobis_wrap", pdist_mahalanobis_wrap, METH_VARARGS},
-  {"pdist_matching_bool_wrap", pdist_matching_bool_wrap, METH_VARARGS},
   {"pdist_minkowski_wrap", pdist_minkowski_wrap, METH_VARARGS},
   {"pdist_weighted_minkowski_wrap", pdist_weighted_minkowski_wrap, METH_VARARGS},
   {"pdist_rogerstanimoto_bool_wrap", pdist_rogerstanimoto_bool_wrap, METH_VARARGS},


### PR DESCRIPTION
While trying to optimize the boolean distance metrics, I discovered that matching distance is the exact same thing as Hamming distance.
