### PR TITLE
Change some HTTP links to HTTPS

### DIFF
--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -446,9 +446,9 @@ various assert functions.
 
 .. _pyflakes: http://pypi.python.org/pypi/pyflakes
 
-.. _SciPy API: http://docs.scipy.org/doc/scipy/reference/api.html
+.. _SciPy API: https://docs.scipy.org/doc/scipy/reference/api.html
 
-.. _git workflow: http://docs.scipy.org/doc/numpy/dev/gitwash/index.html
+.. _git workflow: https://docs.scipy.org/doc/numpy/dev/gitwash/index.html
 
 .. _Github help pages: https://help.github.com/articles/set-up-git/
 
@@ -458,17 +458,17 @@ various assert functions.
 
 .. _Github: https://github.com/scipy/scipy
 
-.. _scipy.org: http://scipy.org/
+.. _scipy.org: https://scipy.org/
 
 .. _scipy.github.com: http://scipy.github.com/
 
 .. _scipy.org-new: https://github.com/scipy/scipy.org-new
 
-.. _documentation wiki: http://docs.scipy.org/scipy/Front%20Page/
+.. _documentation wiki: https://docs.scipy.org/scipy/Front%20Page/
 
 .. _SciPy Central: http://scipy-central.org/
 
-.. _license compatibility: http://www.scipy.org/License_Compatibility
+.. _license compatibility: https://www.scipy.org/License_Compatibility
 
 .. _doctest: http://www.doughellmann.com/PyMOTW/doctest/
 

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -1,7 +1,7 @@
 Building and installing SciPy
 +++++++++++++++++++++++++++++
 
-See http://www.scipy.org/Installing_SciPy/
+See https://www.scipy.org/Installing_SciPy/
 for more extensive (and possibly more up-to-date) build instructions.
 
 .. Contents::
@@ -126,7 +126,7 @@ GETTING SCIPY
 
 For the latest information, see the web site:
 
-  http://www.scipy.org
+  https://www.scipy.org
 
 
 Development version from Git

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Documentation
 
 Scipy documentation is available on the web:
 
-    http://docs.scipy.org
+    https://docs.scipy.org
 
 How to generate the HTML documentation, see ``doc/README.txt``.
 
@@ -51,7 +51,7 @@ Web sites
 
 The user's site is:
 
-    http://www.scipy.org/
+    https://www.scipy.org/
 
 
 Mailing Lists

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -7,7 +7,7 @@
     "project": "scipy",
 
     // The project's homepage
-    "project_url": "http://scipy.org/scipylib/",
+    "project_url": "https://scipy.org/scipylib/",
 
     // The URL of the source code repository for the project being
     // benchmarked

--- a/bento.info
+++ b/bento.info
@@ -1,7 +1,7 @@
 Name: scipy
 Version: 0.18.0.dev0
 Summary: SciPy: Scientific Library for Python
-Url: http://www.scipy.org
+Url: https://www.scipy.org
 DownloadUrl: https://github.com/scipy/scipy/releases
 Description:
     SciPy (pronounced "Sigh Pie") is open-source software for mathematics,

--- a/doc/release/0.7.0-notes.rst
+++ b/doc/release/0.7.0-notes.rst
@@ -58,7 +58,7 @@ Major documentation improvements
 ================================
 
 SciPy documentation is greatly improved; you can view a HTML reference
-manual `online <http://docs.scipy.org/>`__ or download it as a PDF
+manual `online <https://docs.scipy.org/>`__ or download it as a PDF
 file. The new reference guide was built using the popular `Sphinx tool
 <http://sphinx.pocoo.org/>`__.
 
@@ -72,7 +72,7 @@ Nevertheless, more effort is needed on the documentation front.
 Luckily, contributing to Scipy documentation is now easier than
 before: if you find that a part of it requires improvements, and want
 to help us out, please register a user name in our web-based
-documentation editor at http://docs.scipy.org/ and correct the issues.
+documentation editor at https://docs.scipy.org/ and correct the issues.
 
 Running Tests
 =============

--- a/doc/source/_templates/indexsidebar.html
+++ b/doc/source/_templates/indexsidebar.html
@@ -1,5 +1,5 @@
             <h3>Resources</h3>
             <ul>
-              <li><a href="http://scipy.org/">Scipy.org website</a></li>
+              <li><a href="https://scipy.org/">Scipy.org website</a></li>
               <li>&nbsp;</li>
             </ul>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -107,8 +107,8 @@ if os.path.isdir(themedir):
             "edit_link": True,
             "sidebar": "right",
             "scipy_org_logo": True,
-            "rootlinks": [("http://scipy.org/", "Scipy.org"),
-                          ("http://docs.scipy.org/", "Docs")]
+            "rootlinks": [("https://scipy.org/", "Scipy.org"),
+                          ("https://docs.scipy.org/", "Docs")]
         }
     else:
         # Default build
@@ -218,7 +218,7 @@ latex_use_modindex = False
 # -----------------------------------------------------------------------------
 intersphinx_mapping = {
         'http://docs.python.org/dev': None,
-        'http://docs.scipy.org/doc/numpy': None,
+        'https://docs.scipy.org/doc/numpy': None,
 }
 
 

--- a/doc/source/tutorial/general.rst
+++ b/doc/source/tutorial/general.rst
@@ -86,7 +86,7 @@ Finding Documentation
 ---------------------
 
 SciPy and NumPy have documentation versions in both HTML and PDF format
-available at http://docs.scipy.org/, that cover nearly
+available at https://docs.scipy.org/, that cover nearly
 all available functionality. However, this documentation is still
 work-in-progress and some parts may be incomplete or sparse. As
 we are a volunteer organization and depend on the community for

--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -471,4 +471,4 @@ References
 
 .. [WPR] http://en.wikipedia.org/wiki/Romberg's_method
 
-.. [NPT] http://docs.scipy.org/doc/numpy/reference/generated/numpy.trapz.html
+.. [NPT] https://docs.scipy.org/doc/numpy/reference/generated/numpy.trapz.html

--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -11,7 +11,7 @@ Introduction
 In this tutorial we discuss many, but certainly not all, features of
 ``scipy.stats``. The intention here is to provide a user with a
 working knowledge of this package. We refer to the `reference manual
-<http://docs.scipy.org/doc/scipy/reference/stats.html>`_ for further
+<https://docs.scipy.org/doc/scipy/reference/stats.html>`_ for further
 details.
 
 
@@ -347,7 +347,7 @@ i.e., the percent point function, requires a different definition:
     ppf(q) = min{x : cdf(x) >= q, x integer}
 
 For further info, see the docs `here
-<http://docs.scipy.org/doc/scipy/reference/tutorial/stats/discrete.html#percent-point-function-inverse-cdf>`__.
+<https://docs.scipy.org/doc/scipy/reference/tutorial/stats/discrete.html#percent-point-function-inverse-cdf>`__.
 
 
 We can look at the hypergeometric distribution as an example

--- a/doc/source/tutorial/weave.rst
+++ b/doc/source/tutorial/weave.rst
@@ -2520,10 +2520,10 @@ cryptic error report due to the fact that ``stdio.h`` also defines the name.
 ``weave`` should probably try and handle this in some way. Other things...
 
 .. _PyInline: http://pyinline.sourceforge.net/
-.. _SciPy: http://www.scipy.org
+.. _SciPy: https://www.scipy.org
 .. _mingw32: http://www.mingw.org%3Ewww.mingw.org
 .. _NumPy: http://numeric.scipy.org/
-.. _here: http://www.scipy.org/Weave
+.. _here: https://www.scipy.org/Weave
 .. _Python Cookbook: http://aspn.activestate.com/ASPN/Cookbook/Python
 .. _binary_search():
     http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/81188

--- a/doc/source/tutorial/weave.rst
+++ b/doc/source/tutorial/weave.rst
@@ -2524,12 +2524,12 @@ cryptic error report due to the fact that ``stdio.h`` also defines the name.
 .. _mingw32: http://www.mingw.org%3Ewww.mingw.org
 .. _NumPy: http://numeric.scipy.org/
 .. _here: https://www.scipy.org/Weave
-.. _Python Cookbook: http://aspn.activestate.com/ASPN/Cookbook/Python
+.. _Python Cookbook: https://code.activestate.com/recipes/langs/python/
 .. _binary_search():
-    http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/81188
+    https://code.activestate.com/recipes/81188/
 .. _website: http://cxx.sourceforge.net/
 .. _This submission:
-    http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/52306
+    https://code.activestate.com/recipes/52306/
 .. _blitz++ home page: http://www.oonumerics.org/blitz/
 
 ..

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -3,7 +3,7 @@ SciPy: A scientific computing package for Python
 ================================================
 
 Documentation is available in the docstrings and
-online at http://docs.scipy.org.
+online at https://docs.scipy.org.
 
 Contents
 --------

--- a/scipy/cluster/setup.py
+++ b/scipy/cluster/setup.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
           author="Eric Jones",
           maintainer_email="scipy-dev@scipy.org",
           description="Clustering Algorithms (Information Theory)",
-          url="http://www.scipy.org",
+          url="https://www.scipy.org",
           license="SciPy License (BSD Style)",
           **configuration(top_path='').todict()
           )

--- a/scipy/odr/__init__.py
+++ b/scipy/odr/__init__.py
@@ -71,7 +71,7 @@ ODRPACK, in addition to the low-level `odr` function.
 
 Additional background information about ODRPACK can be found in the
 `ODRPACK User's Guide
-<http://docs.scipy.org/doc/external/odrpack_guide.pdf>`_, reading
+<https://docs.scipy.org/doc/external/odrpack_guide.pdf>`_, reading
 which is recommended.
 
 Basic usage

--- a/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/eigen/lobpcg/tests/test_lobpcg.py
@@ -80,7 +80,7 @@ def test_trivial():
 
 
 def test_regression():
-    # http://mail.scipy.org/pipermail/scipy-user/2010-October/026944.html
+    # https://mail.scipy.org/pipermail/scipy-user/2010-October/026944.html
     n = 10
     X = np.ones((n, 1))
     A = np.identity(n)

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -77,7 +77,7 @@ if __name__ == '__main__':
           author="Anne Archibald",
           maintainer_email="scipy-dev@scipy.org",
           description="Spatial algorithms and data structures",
-          url="http://www.scipy.org",
+          url="https://www.scipy.org",
           license="SciPy License (BSD Style)",
           **configuration(top_path='').todict()
           )

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -4429,7 +4429,7 @@ cdef char *ufunc_expit_doc = (
     "-----\n"
     "As a ufunc expit takes a number of optional\n"
     "keyword arguments. For more information\n"
-    "see `ufuncs <http://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_\n"
+    "see `ufuncs <https://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_\n"
     "\n"
     ".. versionadded:: 0.10.0")
 ufunc_expit_loops[0] = <np.PyUFuncGenericFunction>loop_f_f__As_f_f
@@ -6880,7 +6880,7 @@ cdef char *ufunc_logit_doc = (
     "-----\n"
     "As a ufunc logit takes a number of optional\n"
     "keyword arguments. For more information\n"
-    "see `ufuncs <http://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_\n"
+    "see `ufuncs <https://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_\n"
     "\n"
     ".. versionadded:: 0.10.0")
 ufunc_logit_loops[0] = <np.PyUFuncGenericFunction>loop_f_f__As_f_f

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1046,7 +1046,7 @@ add_newdoc('scipy.special', 'expit',
     -----
     As a ufunc expit takes a number of optional
     keyword arguments. For more information
-    see `ufuncs <http://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_
+    see `ufuncs <https://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_
 
     .. versionadded:: 0.10.0
 
@@ -2102,7 +2102,7 @@ add_newdoc('scipy.special', 'logit',
     -----
     As a ufunc logit takes a number of optional
     keyword arguments. For more information
-    see `ufuncs <http://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_
+    see `ufuncs <https://docs.scipy.org/doc/numpy/reference/ufuncs.html>`_
 
     .. versionadded:: 0.10.0
 

--- a/scipy/weave/doc/tutorial.txt
+++ b/scipy/weave/doc/tutorial.txt
@@ -2513,10 +2513,10 @@ cryptic error report due to the fact that ``stdio.h`` also defines the name.
 ``weave`` should probably try and handle this in some way. Other things...
 
 .. _PyInline: http://pyinline.sourceforge.net/
-.. _SciPy: http://www.scipy.org
+.. _SciPy: https://www.scipy.org
 .. _mingw32: http://www.mingw.org%3Ewww.mingw.org
 .. _NumPy: http://numeric.scipy.org/
-.. _here: http://www.scipy.org/Weave
+.. _here: https://www.scipy.org/Weave
 .. _Python Cookbook: http://aspn.activestate.com/ASPN/Cookbook/Python
 .. _binary_search():
     http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/81188

--- a/scipy/weave/doc/tutorial_original.html
+++ b/scipy/weave/doc/tutorial_original.html
@@ -165,7 +165,7 @@ some conversions, reference counting, etc.
 </p>
 <p><em>
 Note: </em><code>weave</code><em> is actually part of the <a
- href="http://www.scipy.org">SciPy</a> package. However, it also works
+ href="https://www.scipy.org">SciPy</a> package. However, it also works
 fine as a standalone package (you can install as ``python setup.py install``)
 in the scipy/weave directory.  The examples here are given as if it is used
 as a stand alone package. If you are using from within scipy, you can
@@ -221,7 +221,7 @@ is useful outside of the scientific community, it has been setup so
 that it can be
 used as a stand-alone module. </p>
 <p>The stand-alone version can be downloaded from <a
- href="http://www.scipy.org/Weave">here</a>.&nbsp; Instructions for
+ href="https://www.scipy.org/Weave">here</a>.&nbsp; Instructions for
 installing should be found there as well.&nbsp; setup.py file to
 simplify
 installation. </p>

--- a/scipy/weave/setup.py
+++ b/scipy/weave/setup.py
@@ -22,5 +22,5 @@ if __name__ == '__main__':
           author="Eric Jones",
           author_email="eric@enthought.com",
           licence="SciPy License (BSD Style)",
-          url='http://www.scipy.org',
+          url='https://www.scipy.org',
           **configuration(top_path='').todict())

--- a/setup.py
+++ b/setup.py
@@ -218,7 +218,7 @@ def setup_package():
         maintainer_email="scipy-dev@scipy.org",
         description=DOCLINES[0],
         long_description="\n".join(DOCLINES[2:]),
-        url="http://www.scipy.org",
+        url="https://www.scipy.org",
         download_url="https://github.com/scipy/scipy/releases",
         license='BSD',
         cmdclass=cmdclass,


### PR DESCRIPTION
Several subdomains of scipy.org support SSL/TLS connections, so those may as well be used.
