### PR TITLE
DOC: zpk2sos can't do analog, array_like, etc.

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -805,8 +805,7 @@ def zpk2sos(z, p, k, pairing='nearest'):
     *Algorithms*
 
     The current algorithms are designed specifically for use with digital
-    filters. Although they can operate on analog filters, the results may
-    be sub-optimal.
+    filters. (The output coefficents are not correct for analog filters.)
 
     The steps in the ``pairing='nearest'`` and ``pairing='keep_odd'``
     algorithms are mostly shared. The ``nearest`` algorithm attempts to

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -32,7 +32,7 @@ abs = absolute
 
 def findfreqs(num, den, N):
     """
-    Find an array of frequencies for computing the response of a filter.
+    Find array of frequencies for computing the response of an analog filter.
 
     Parameters
     ----------
@@ -94,9 +94,9 @@ def freqs(b, a, worN=None, plot=None):
 
     Parameters
     ----------
-    b : ndarray
+    b : array_like
         Numerator of a linear filter.
-    a : ndarray
+    a : array_like
         Denominator of a linear filter.
     worN : {None, int}, optional
         If None, then compute at 200 frequencies around the interesting parts
@@ -111,7 +111,7 @@ def freqs(b, a, worN=None, plot=None):
     Returns
     -------
     w : ndarray
-        The angular frequencies at which h was computed.
+        The angular frequencies at which `h` was computed.
     h : ndarray
         The frequency response.
 
@@ -172,9 +172,9 @@ def freqz(b, a=1, worN=None, whole=0, plot=None):
 
     Parameters
     ----------
-    b : ndarray
+    b : array_like
         numerator of a linear filter
-    a : ndarray
+    a : array_like
         denominator of a linear filter
     worN : {None, int, array_like}, optional
         If None (default), then compute at 512 frequencies equally spaced
@@ -194,7 +194,8 @@ def freqz(b, a=1, worN=None, whole=0, plot=None):
     Returns
     -------
     w : ndarray
-        The normalized frequencies at which h was computed, in radians/sample.
+        The normalized frequencies at which `h` was computed, in
+        radians/sample.
     h : ndarray
         The frequency response.
 
@@ -881,7 +882,7 @@ def zpk2sos(z, p, k, pairing='nearest'):
 
     >>> sos = signal.zpk2sos(z, p, k)
 
-    The coefficents of the numerators of the sections:
+    The coefficients of the numerators of the sections:
 
     >>> sos[:, :3]
     array([[ 0.0014154 ,  0.00248707,  0.0014154 ],
@@ -1523,9 +1524,9 @@ def _zpkbilinear(z, p, k, fs):
 
     Parameters
     ----------
-    z : ndarray
+    z : array_like
         Zeros of the analog IIR filter transfer function.
-    p : ndarray
+    p : array_like
         Poles of the analog IIR filter transfer function.
     k : float
         System gain of the analog IIR filter transfer function.
@@ -1573,9 +1574,9 @@ def _zpklp2lp(z, p, k, wo=1.0):
 
     Parameters
     ----------
-    z : ndarray
+    z : array_like
         Zeros of the analog IIR filter transfer function.
-    p : ndarray
+    p : array_like
         Poles of the analog IIR filter transfer function.
     k : float
         System gain of the analog IIR filter transfer function.
@@ -1626,9 +1627,9 @@ def _zpklp2hp(z, p, k, wo=1.0):
 
     Parameters
     ----------
-    z : ndarray
+    z : array_like
         Zeros of the analog IIR filter transfer function.
-    p : ndarray
+    p : array_like
         Poles of the analog IIR filter transfer function.
     k : float
         System gain of the analog IIR filter transfer function.
@@ -1685,9 +1686,9 @@ def _zpklp2bp(z, p, k, wo=1.0, bw=1.0):
 
     Parameters
     ----------
-    z : ndarray
+    z : array_like
         Zeros of the analog IIR filter transfer function.
-    p : ndarray
+    p : array_like
         Poles of the analog IIR filter transfer function.
     k : float
         System gain of the analog IIR filter transfer function.
@@ -1757,9 +1758,9 @@ def _zpklp2bs(z, p, k, wo=1.0, bw=1.0):
 
     Parameters
     ----------
-    z : ndarray
+    z : array_like
         Zeros of the analog IIR filter transfer function.
-    p : ndarray
+    p : array_like
         Poles of the analog IIR filter transfer function.
     k : float
         System gain of the analog IIR filter transfer function.

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -22,8 +22,8 @@ from __future__ import division, print_function, absolute_import
 import warnings
 import numpy as np
 
-#np.linalg.qr fails on some tests with LinAlgError: zgeqrf returns -7
-#use scipy's qr until this is solved
+# np.linalg.qr fails on some tests with LinAlgError: zgeqrf returns -7
+# use scipy's qr until this is solved
 
 from scipy.linalg import qr as s_qr
 
@@ -1655,7 +1655,7 @@ def freqresp(system, w=None, n=10000):
 
     w : array_like, optional
         Array of frequencies (in rad/s). Magnitude and phase data is
-        calculated for every value in this array. If not given a reasonable
+        calculated for every value in this array. If not given, a reasonable
         set will be calculated.
     n : int, optional
         Number of frequency points to compute if `w` is not given. The `n`

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -1319,7 +1319,7 @@ def _default_response_times(A, n):
 
     Parameters
     ----------
-    A : ndarray
+    A : array_like
         The system matrix, which is square.
     n : int
         The number of time samples to generate.


### PR DESCRIPTION
note that zpk2sos doesn't currently work for analog filters  (fixes documentation for https://github.com/scipy/scipy/issues/5668)

change `ndarray` to `array_like` where possible.

also some typos, PEP8, variable formatting, etc.
