### PR TITLE
MAINT: move a sample distribution to a subclass of rv_discrete

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2316,16 +2316,6 @@ class rv_continuous(rv_generic):
 ## Handlers for generic case where xk and pk are given
 ## The _drv prefix probably means discrete random variable.
 
-def _drv_moment(self, n, *args):
-    n = asarray(n)
-    return np.sum(self.xk**n[np.newaxis, ...] * self.pk, axis=0)
-
-
-def _drv_moment_gen(self, t, *args):
-    t = asarray(t)
-    return np.sum(exp(self.xk * t[np.newaxis, ...]) * self.pk, axis=0)
-
-
 def _drv2_moment(self, n, *args):
     """Non-central moment of discrete distribution."""
     def fun(x):
@@ -3253,10 +3243,6 @@ class rv_sample(rv_discrete):
         self.F = dict(zip(self.xk, self.qvals))
         decreasing_keys = sorted(self.F.keys(), reverse=True)
         self.Finv = dict((self.F[k], k) for k in decreasing_keys)
-        self.generic_moment = instancemethod(_drv_moment,
-                                             self, rv_discrete)
-        self.moment_gen = instancemethod(_drv_moment_gen,
-                                         self, rv_discrete)
 
         self.shapes = ' '   # bypass inspection
         self._construct_argparser(meths_to_inspect=[self._pmf],
@@ -3315,6 +3301,17 @@ class rv_sample(rv_discrete):
         else:
             Y = self._ppf(U)
         return Y
+
+    def generic_moment(self, n):
+        n = asarray(n)
+        return np.sum(self.xk**n[np.newaxis, ...] * self.pk, axis=0)
+
+
+    def moment_gen(self, t):
+        t = asarray(t)
+        return np.sum(exp(self.xk * t[np.newaxis, ...]) * self.pk, axis=0)
+
+
 
 
 def get_distribution_names(namespace_pairs, rv_base_class):

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2316,10 +2316,6 @@ class rv_continuous(rv_generic):
 ## Handlers for generic case where xk and pk are given
 ## The _drv prefix probably means discrete random variable.
 
-def _drv_nonzero(self, k, *args):
-    return 1
-
-
 def _drv_moment(self, n, *args):
     n = asarray(n)
     return np.sum(self.xk**n[np.newaxis, ...] * self.pk, axis=0)
@@ -3257,7 +3253,6 @@ class rv_sample(rv_discrete):
         self.F = dict(zip(self.xk, self.qvals))
         decreasing_keys = sorted(self.F.keys(), reverse=True)
         self.Finv = dict((self.F[k], k) for k in decreasing_keys)
-        self._nonzero = instancemethod(_drv_nonzero, self, rv_discrete)
         self.generic_moment = instancemethod(_drv_moment,
                                              self, rv_discrete)
         self.moment_gen = instancemethod(_drv_moment_gen,

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3221,28 +3221,22 @@ class rv_sample(rv_discrete):
         if name is None:
             name = 'Distribution'
         self.badvalue = badvalue
-        self.a = a
-        self.b = b
         self.name = name
         self.moment_tol = moment_tol
         self.inc = inc
         self._cdfvec = vectorize(self._cdf_single, otypes='d')
-        self.return_integers = 1
         self.vecentropy = vectorize(self._entropy)
         self.shapes = shapes
         self.extradoc = extradoc
 
         self.xk, self.pk = values
         self.return_integers = 0
-        indx = argsort(ravel(self.xk))
-        self.xk = take(ravel(self.xk), indx, 0)
-        self.pk = take(ravel(self.pk), indx, 0)
+        indx = np.argsort(np.ravel(self.xk))
+        self.xk = np.take(np.ravel(self.xk), indx, 0)
+        self.pk = np.take(np.ravel(self.pk), indx, 0)
         self.a = self.xk[0]
         self.b = self.xk[-1]
         self.qvals = np.cumsum(self.pk, axis=0)
-        self.F = dict(zip(self.xk, self.qvals))
-        decreasing_keys = sorted(self.F.keys(), reverse=True)
-        self.Finv = dict((self.F[k], k) for k in decreasing_keys)
 
         self.shapes = ' '   # bypass inspection
         self._construct_argparser(meths_to_inspect=[self._pmf],
@@ -3306,12 +3300,24 @@ class rv_sample(rv_discrete):
         n = asarray(n)
         return np.sum(self.xk**n[np.newaxis, ...] * self.pk, axis=0)
 
-
+    @np.deprecate(message="moment_gen method is not used anywhere any more "
+                          "and is deprecated in scipy 0.18.")
     def moment_gen(self, t):
         t = asarray(t)
         return np.sum(exp(self.xk * t[np.newaxis, ...]) * self.pk, axis=0)
 
+    @property
+    @np.deprecate(message="F attribute is not used anywhere any longer and "
+                          "is deprecated in scipy 0.18.")
+    def F(self):
+        return dict(zip(self.xk, self.qvals))
 
+    @property
+    @np.deprecate(message="Finv attribute is not used anywhere any longer and "
+                          "is deprecated in scipy 0.18.")
+    def Finv(self):
+        decreasing_keys = sorted(self.F.keys(), reverse=True)
+        return dict((self.F[k], k) for k in decreasing_keys)
 
 
 def get_distribution_names(namespace_pairs, rv_base_class):

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2590,7 +2590,6 @@ class rv_discrete(rv_generic):
         self.moment_tol = moment_tol
         self.inc = inc
         self._cdfvec = vectorize(self._cdf_single, otypes='d')
-        self.return_integers = 1
         self.vecentropy = vectorize(self._entropy)
         self.shapes = shapes
 
@@ -2649,6 +2648,12 @@ class rv_discrete(rv_generic):
             self.__doc__ = self.__doc__.replace(
                 '\n    scale : array_like, '
                 'optional\n        scale parameter (default=1)', '')
+
+    @property
+    @np.deprecate(message="`return_integers` attribute is not used anywhere any "
+                          " longer and is deprecated in scipy 0.18.")
+    def return_integers(self):
+        return 1
 
     def _updated_ctor_param(self):
         """ Return the current version of _ctor_param, possibly updated by user.
@@ -3226,11 +3231,10 @@ class rv_sample(rv_discrete):
         self.shapes = shapes
         self.vecentropy = self._entropy
 
-        self.xk, self.pk = values
-        self.return_integers = 0
-        indx = np.argsort(np.ravel(self.xk))
-        self.xk = np.take(np.ravel(self.xk), indx, 0)
-        self.pk = np.take(np.ravel(self.pk), indx, 0)
+        xk, pk = values
+        indx = np.argsort(np.ravel(xk))
+        self.xk = np.take(np.ravel(xk), indx, 0)
+        self.pk = np.take(np.ravel(pk), indx, 0)
         self.a = self.xk[0]
         self.b = self.xk[-1]
         self.qvals = np.cumsum(self.pk, axis=0)
@@ -3242,6 +3246,12 @@ class rv_sample(rv_discrete):
                                   locscale_out='loc, 1')
 
         self._construct_docstrings(name, longname, extradoc)
+
+    @property
+    @np.deprecate(message="`return_integers` attribute is not used anywhere any "
+                          " longer and is deprecated in scipy 0.18.")
+    def return_integers(self):
+        return 0
 
     def _pmf(self, x):
         return np.select([x == k for k in self.xk],
@@ -3259,7 +3269,7 @@ class rv_sample(rv_discrete):
 
     def _rvs(self):
         # Need to define it explicitly, otherwise .rvs() with size=None
-        # fails due to explicit broadcasting 
+        # fails due to explicit broadcasting in _ppf
         U = self._random_state.random_sample(self._size)
         if self._size is None:
             U = np.array(U, ndmin=1)

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3232,6 +3232,12 @@ class rv_sample(rv_discrete):
         self.vecentropy = self._entropy
 
         xk, pk = values
+
+        if len(xk) != len(pk):
+            raise ValueError("xk and pk need to have the same length.")
+        if not np.allclose(np.sum(pk), 1):
+            raise ValueError("The sum of provided pk is not 1.")
+
         indx = np.argsort(np.ravel(xk))
         self.xk = np.take(np.ravel(xk), indx, 0)
         self.pk = np.take(np.ravel(pk), indx, 0)
@@ -3248,7 +3254,7 @@ class rv_sample(rv_discrete):
         self._construct_docstrings(name, longname, extradoc)
 
     @property
-    @np.deprecate(message="`return_integers` attribute is not used anywhere any "
+    @np.deprecate(message="`return_integers` attribute is not used anywhere any"
                           " longer and is deprecated in scipy 0.18.")
     def return_integers(self):
         return 0

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3224,8 +3224,6 @@ class rv_sample(rv_discrete):
         self.name = name
         self.moment_tol = moment_tol
         self.inc = inc
-        self._cdfvec = vectorize(self._cdf_single, otypes='d')
-        self.vecentropy = vectorize(self._entropy)
         self.shapes = shapes
         self.extradoc = extradoc
 
@@ -3244,8 +3242,7 @@ class rv_sample(rv_discrete):
                                   # scale=1 for discrete RVs
                                   locscale_out='loc, 1')
 
-        # now that self.numargs is defined, we can adjust nin
-        self._cdfvec.nin = self.numargs + 1
+        self.vecentropy = self._entropy
 
         # generate docstring for subclass instances
         if longname is None:
@@ -3295,6 +3292,9 @@ class rv_sample(rv_discrete):
         else:
             Y = self._ppf(U)
         return Y
+
+    def _entropy(self):
+        return entropy(self.pk)
 
     def generic_moment(self, n):
         n = asarray(n)

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -98,15 +98,20 @@ def check_cdf_ppf(distfn, arg, supp, msg):
                            supp, msg + '-roundtrip')
     npt.assert_array_equal(distfn.ppf(distfn.cdf(supp, *arg) - 1e-8, *arg),
                            supp, msg + '-roundtrip')
-    supp1 = supp[supp < distfn.b]
-    npt.assert_array_equal(distfn.ppf(distfn.cdf(supp1, *arg) + 1e-8, *arg),
-                           supp1 + distfn.inc, msg + 'ppf-cdf-next')
-    # -1e-8 could cause an error if pmf < 1e-8
+
+    if not hasattr(distfn, 'xk'):
+        supp1 = supp[supp < distfn.b]
+        npt.assert_array_equal(distfn.ppf(distfn.cdf(supp1, *arg) + 1e-8, *arg),
+                               supp1 + distfn.inc, msg + ' ppf-cdf-next')
+        # -1e-8 could cause an error if pmf < 1e-8
 
 
 def check_pmf_cdf(distfn, arg, distname):
-    startind = int(distfn.ppf(0.01, *arg) - 1)
-    index = list(range(startind, startind + 10))
+    if hasattr(distfn, 'xk'):
+        index = distfn.xk
+    else:
+        startind = int(distfn.ppf(0.01, *arg) - 1)
+        index = list(range(startind, startind + 10))
     cdfs = distfn.cdf(index, *arg)
     pmfs_cum = distfn.pmf(index, *arg).cumsum()
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -925,6 +925,13 @@ class TestRvDiscrete(TestCase):
         assert_array_equal(rv.ppf(rv.cdf(rv.xk[:-1]) + 1e-8),
                            rv.xk[1:])
 
+    def test_expect(self):
+        xk = [1, 2, 4, 6, 7, 11]
+        pk = [0.1, 0.2, 0.2, 0.2, 0.2, 0.1]
+        rv = stats.rv_discrete(values=(xk, pk))
+
+        assert_allclose(rv.expect(), np.sum(rv.xk * rv.pk), atol=1e-14)
+
 
 class TestSkewNorm(TestCase):
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -932,6 +932,14 @@ class TestRvDiscrete(TestCase):
 
         assert_allclose(rv.expect(), np.sum(rv.xk * rv.pk), atol=1e-14)
 
+    def test_bad_input(self):
+        xk = [1, 2, 3]
+        pk = [0.5, 0.5]
+        assert_raises(ValueError, stats.rv_discrete, **dict(values=(xk, pk)))
+
+        pk = [1, 2, 3]
+        assert_raises(ValueError, stats.rv_discrete, **dict(values=(xk, pk)))
+
 
 class TestSkewNorm(TestCase):
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -880,6 +880,51 @@ class TestRvDiscrete(TestCase):
         h = p.entropy()
         assert_equal(h, 0.0)
 
+    def test_pmf(self):
+        xk = [1, 2, 4]
+        pk = [0.5, 0.3, 0.2]
+        rv = stats.rv_discrete(values=(xk, pk))
+
+        x = [[1., 4.],
+             [3., 2]]
+        assert_allclose(rv.pmf(x),
+                        [[0.5, 0.2],
+                         [0., 0.3]], atol=1e-14)
+
+    def test_cdf(self):
+        xk = [1, 2, 4]
+        pk = [0.5, 0.3, 0.2]
+        rv = stats.rv_discrete(values=(xk, pk))
+
+        x_values = [-2, 1., 1.1, 1.5, 2.0, 3.0, 4, 5]
+        expected = [0, 0.5, 0.5, 0.5, 0.8, 0.8, 1, 1]
+        assert_allclose(rv.cdf(x_values), expected, atol=1e-14)
+
+        # also check scalar arguments
+        assert_allclose([rv.cdf(xx) for xx in x_values],
+                        expected, atol=1e-14)
+
+    def test_ppf(self):
+        xk = [1, 2, 4]
+        pk = [0.5, 0.3, 0.2]
+        rv = stats.rv_discrete(values=(xk, pk))
+
+        q_values = [0.1, 0.5, 0.6, 0.8, 0.9, 1.]
+        expected = [1, 1, 2, 2, 4, 4]
+        assert_allclose(rv.ppf(q_values), expected, atol=1e-14)
+
+        # also check scalar arguments
+        assert_allclose([rv.ppf(q) for q in q_values],
+                        expected, atol=1e-14)
+
+    def test_cdf_ppf_next(self):
+        # copied and special cased from test_discrete_basic
+        vals = ([1, 2, 4, 7, 8], [0.1, 0.2, 0.3, 0.3, 0.1])
+        rv = stats.rv_discrete(values=vals)
+
+        assert_array_equal(rv.ppf(rv.cdf(rv.xk[:-1]) + 1e-8),
+                           rv.xk[1:])
+
 
 class TestSkewNorm(TestCase):
 


### PR DESCRIPTION
Move the branching on `if values is not None:` from the `__init__` method of `rv_discrete`, so that a sample distribution constructed from the lists of values and probabilities is a subclass of `rv_discrete`. This way, 
- one can fix long-standing bugs like gh-3758.
- the ugliness is contained in one place, `rv_discrete.__new__`
- one can stop attaching a bunch of `instancemethod`s depending on the constructor arguments.
