### PR TITLE
MAINT: stats: remove est_loc_scale method

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -2224,12 +2224,6 @@ class rv_continuous(rv_generic):
             Shat = 1
         return Lhat, Shat
 
-    @np.deprecate
-    def est_loc_scale(self, data, *args):
-        """This function is deprecated, use self.fit_loc_scale(data) instead.
-        """
-        return self.fit_loc_scale(data, *args)
-
     def _entropy(self, *args):
         def integ(x):
             val = self._pdf(x, *args)


### PR DESCRIPTION
Which has been deprecated since at least scipy 0.9:
https://github.com/scipy/scipy/blob/maintenance/0.9.x/scipy/stats/distributions.py#L1740.
