### PR TITLE
BUG: fix stats.ttest_ind_from_stats to handle arrays.

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3506,8 +3506,8 @@ def _unequal_var_ttest_denom(v1, n1, v2, n2):
 
 
 def _equal_var_ttest_denom(v1, n1, v2, n2):
-    df = n1 + n2 - 2
-    svar = ((n1 - 1) * v1 + (n2 - 1) * v2) / float(df)
+    df = n1 + n2 - 2.0
+    svar = ((n1 - 1) * v1 + (n2 - 1) * v2) / df
     denom = np.sqrt(svar * (1.0 / n1 + 1.0 / n2))
     return df, denom
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2456,6 +2456,14 @@ def test_ttest_ind_with_uneq_var():
         np.seterr(**olderr)
 
 
+def test_gh5686():
+    mean1, mean2 = np.array([1, 2]), np.array([3, 4])
+    std1, std2 = np.array([5, 3]), np.array([4, 5])
+    nobs1, nobs2 = np.array([130, 140]), np.array([100, 150])
+    # This will raise a TypeError unless gh-5686 is fixed.
+    stats.ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2)
+
+
 def test_ttest_1samp_new():
     n1, n2, n3 = (10,15,20)
     rvn1 = stats.norm.rvs(loc=5,scale=10,size=(n1,n2,n3))


### PR DESCRIPTION
Closes gh-5686.
