### PR TITLE
BUG: fix generator in io._loadarff to comply with PEP 0479

### DIFF
--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -614,22 +614,16 @@ def _loadarff(ofile):
         #   by % should be enough and faster, and for empty lines, same thing
         #   --> this does not seem to change anything.
 
-        # We do not abstract skipping comments and empty lines for performances
-        # reason.
-        raw = next(row_iter)
-        while r_empty.match(raw) or r_comment.match(raw):
-            raw = next(row_iter)
-
         # 'compiling' the range since it does not change
         # Note, I have already tried zipping the converters and
         # row elements and got slightly worse performance.
         elems = list(range(ni))
 
-        row = raw.split(delim)
-        yield tuple([convertors[i](row[i]) for i in elems])
         for raw in row_iter:
-            while r_comment.match(raw) or r_empty.match(raw):
-                raw = next(row_iter)
+            # We do not abstract skipping comments and empty lines for
+            # performance reasons.
+            if r_comment.match(raw) or r_empty.match(raw):
+                continue
             row = raw.split(delim)
             yield tuple([convertors[i](row[i]) for i in elems])
 


### PR DESCRIPTION
In the function _loadarff a generator is created which yields the data
from an arff file. If given a file with no data, it tries to yield
after EOF, which raises StopIteration and violates PEP 0479. This
commit moves all of the parsing inside a for loop which correctly
handles the no-data file case.
