### PR TITLE
Explain coordinate mapping in `ndimage.affine_transform`

### DIFF
--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -339,6 +339,9 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     outside the boundaries of the input are filled according to the given
     mode.
 
+    Specifically, given an output image pixel index vector `o`, the pixel value
+    is determined from the input image at position `np.dot(matrix,o) + offset`.
+
     Parameters
     ----------
     input : ndarray

--- a/scipy/ndimage/interpolation.py
+++ b/scipy/ndimage/interpolation.py
@@ -339,8 +339,24 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     outside the boundaries of the input are filled according to the given
     mode.
 
-    Specifically, given an output image pixel index vector `o`, the pixel value
-    is determined from the input image at position `np.dot(matrix,o) + offset`.
+    A diagonal matrix can be specified by supplying a one-dimensional
+    array-like to the matrix parameter, in which case a more efficient
+    algorithm is applied.
+
+    .. warning::
+    Currently, the exact interpretation of the affine transformation
+    depends on weather the matrix is supplied as a one-dimensional or
+    two-dimensional array. This is considered a bug, and in a future
+    release, the behaviour for one-dimensional matrix arguments will
+    be modified to match the two-dimensional case.
+
+    If a two-dimensional array is supplied to the matrix parameter,
+    given an output image pixel index vector ``o``, the pixel value
+    is determined from the input image at position ``np.dot(matrix,o) + offset``.
+
+    If a one-dimensional array is supplied to the matrix parameter,
+    the output pixel value at index ``o`` is determined from the
+    input image at position ``matrix * (o + offset)``.
 
     Parameters
     ----------


### PR DESCRIPTION
Added description of the actual coordinate mapping at work in `scipy.ndimage.interpolation.affine_transform`
