### PR TITLE
ENH: use math.factorial for exact factorials

### DIFF
--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -7,6 +7,7 @@ from __future__ import division, print_function, absolute_import
 import warnings
 
 import numpy as np
+import math
 from scipy._lib.six import xrange
 from numpy import (pi, asarray, floor, isscalar, iscomplex, real, imag, sqrt,
                    where, mgrid, sin, place, issubdtype, extract,
@@ -2145,12 +2146,7 @@ def factorial(n, exact=False):
 
     """
     if exact:
-        if n < 0:
-            return 0
-        val = 1
-        for k in xrange(1, n+1):
-            val *= k
-        return val
+        return math.factorial(n)
     else:
         n = asarray(n)
         vals = gamma(n+1)


### PR DESCRIPTION
math.factorial is substantially faster than the naive multiplication algorithm. 

```
In [89]: timeit special.factorial(100, True)
100000 loops, best of 3: 9.1 µs per loop

In [90]: timeit math.factorial(100)
1000000 loops, best of 3: 1.43 µs per loop
```

Ideally i think that `special.factorial` wouldn't be a thing, but since it is, there isn't any good reason to use a poor algorithm when a better one already exists.

When `n` isn't an integer, this will still raise a `ValueError`, but the text will be different.
