### PR TITLE
MAINT: io: micro-optimize Matlab reading code for size

### DIFF
--- a/scipy/io/matlab/mio_utils.pxd
+++ b/scipy/io/matlab/mio_utils.pxd
@@ -1,0 +1,4 @@
+cimport numpy as np
+
+cpdef object squeeze_element(np.ndarray)
+cpdef np.ndarray chars_to_strings(object)

--- a/scipy/io/matlab/mio_utils.pyx
+++ b/scipy/io/matlab/mio_utils.pyx
@@ -6,14 +6,6 @@ import numpy as np
 cimport numpy as cnp
 
 
-def cproduct(tup):
-    cdef size_t res = 1
-    cdef int i
-    for i in range(len(tup)):
-        res *= tup[i]
-    return res
-
-
 cpdef object squeeze_element(cnp.ndarray arr):
     ''' Return squeezed element
 
@@ -21,9 +13,9 @@ cpdef object squeeze_element(cnp.ndarray arr):
     ``arr.item`` to return a ``mat_struct`` object from a struct array '''
     if not arr.size:
         return np.array([])
-    arr2 = np.squeeze(arr)
+    cdef cnp.ndarray arr2 = np.squeeze(arr)
     # We want to squeeze 0d arrays, unless they are record arrays
-    if (not arr2.shape) and arr2.dtype.kind != 'V':
+    if arr2.ndim == 0 and arr2.dtype.kind != 'V':
         return arr2.item()
     return arr2
 

--- a/scipy/io/matlab/tests/test_mio_utils.py
+++ b/scipy/io/matlab/tests/test_mio_utils.py
@@ -9,15 +9,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal, \
      run_module_suite, assert_
 
-from scipy.io.matlab.mio_utils import cproduct, squeeze_element, \
-    chars_to_strings
-
-
-def test_cproduct():
-    assert_(cproduct(()) == 1)
-    assert_(cproduct((1,)) == 1)
-    assert_(cproduct((1,3)) == 3)
-    assert_(cproduct([1,3]) == 3)
+from scipy.io.matlab.mio_utils import squeeze_element, chars_to_strings
 
 
 def test_squeeze_element():


### PR DESCRIPTION
- Using a `cpdef` function from another module requires a `.pxd`.
- Removed the unused function `cproduct`.
- `cdef np.ndarray`, without a `dtype` fixed at compile time, sometimes slows code down as it inserts additional checks for arrayness while not bypassing CPython APIs.
