### PR TITLE
Implement OptimizeResult.__dir__

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -126,6 +126,9 @@ class OptimizeResult(dict):
         else:
             return self.__class__.__name__ + "()"
 
+    def __dir__(self):
+        return super(OptimizeResult, self).__dir__() + list(self.keys())
+
 
 class OptimizeWarning(UserWarning):
     pass

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -127,7 +127,7 @@ class OptimizeResult(dict):
             return self.__class__.__name__ + "()"
 
     def __dir__(self):
-        return super(OptimizeResult, self).__dir__() + list(self.keys())
+        return list(self.keys())
 
 
 class OptimizeWarning(UserWarning):

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -958,6 +958,7 @@ class TestOptimizeResultAttributes(TestCase):
                     continue
 
                 assert_(hasattr(res, attribute))
+                assert_(attribute in dir(res))
 
 
 class TestBrute:


### PR DESCRIPTION
This lets tab-completion of OptimizeResult objects suggest the actual fields set, rather than the fairly irrelevant methods of the underlying dict object.

In fact before this gets merged I'd like to get people's opinion on whether to include dict methods at all in the result, given that the goal is mostly interactive use; cf the Python docs regarding `dir`:

> Because dir() is supplied primarily as a convenience for use at an interactive prompt, it tries to supply an interesting set of names more than it tries to supply a rigorously or consistently defined set of names, and its detailed behavior may change across releases. For example, metaclass attributes are not in the result list when the argument is a class.
