### PR TITLE
BUG: fix typo in query_pairs

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -1059,7 +1059,7 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
 
         """
                  
-        cdef ordered_pairs c
+        cdef ordered_pairs results
 
         results = ordered_pairs()
         query_pairs(<ckdtree*> self, r, p, eps, results.buf)


### PR DESCRIPTION
Fix silent typo in `cKDTree.query_pairs`. It seems Cython's type inference can handle it, but correct static typing is preferred.
