### PR TITLE
DOC: optimize: PEP8 minimize docstring

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -49,8 +49,8 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     ``g_i(x)`` are the inequality constraints.
     ``h_j(x)`` are the equality constrains.
 
-    Optionally, the lower and upper bounds for each element in x can also be specified 
-    using the `bounds` argument.
+    Optionally, the lower and upper bounds for each element in x can also be
+    specified using the `bounds` argument.
 
     Parameters
     ----------


### PR DESCRIPTION
80+ char line breaks IPython display of docstring.
