### PR TITLE
[DOC] Fix broken link to reference

### DIFF
--- a/scipy/optimize/_hungarian.py
+++ b/scipy/optimize/_hungarian.py
@@ -66,7 +66,7 @@ def linear_sum_assignment(cost_matrix):
 
     References
     ----------
-    1. http://www.public.iastate.edu/~ddoty/HungarianAlgorithm.html
+    1. http://csclab.murraystate.edu/bob.pilgrim/445/munkres.html
 
     2. Harold W. Kuhn. The Hungarian Method for the assignment problem.
        *Naval Research Logistics Quarterly*, 2:83-97, 1955.


### PR DESCRIPTION
The link being replaced [described itself](https://web.archive.org/web/20100401063425/http://www.public.iastate.edu/~ddoty/HungarianAlgorithm.html) as a plagiarised copy (at a time when the original was offline) of Bob Pilgrim's notes on the algorithm and its implementation.
