### PR TITLE
WIP: add support for nan_policy to stats.median_test

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -20,7 +20,7 @@ from scipy import optimize
 from scipy import special
 from . import statlib
 from . import stats
-from .stats import find_repeats
+from .stats import find_repeats, _contains_nan
 from .contingency import chi2_contingency
 from . import distributions
 from ._distn_infrastructure import rv_generic
@@ -2453,6 +2453,10 @@ def median_test(*args, **kwds):
         Cressie-Read power divergence family to be used instead.  See
         `power_divergence` for details.
         Default is 1 (Pearson's chi-squared statistic).
+    nan_policy : {'propagate', 'raise', 'omit'}, optional
+        Defines how to handle when input contains nan. 'propagate' returns nan,
+        'raise' throws an error, 'omit' performs the calculations ignoring nan
+        values. Default is 'propagate'.
 
     Returns
     -------
@@ -2549,6 +2553,7 @@ def median_test(*args, **kwds):
     ties = kwds.pop('ties', 'below')
     correction = kwds.pop('correction', True)
     lambda_ = kwds.pop('lambda_', None)
+    nan_policy = kwds.pop('nan_policy', 'propagate')
 
     if len(kwds) > 0:
         bad_kwd = kwds.keys()[0]
@@ -2575,7 +2580,12 @@ def median_test(*args, **kwds):
                              "samples must be one-dimensional sequences." %
                              (k + 1, d.ndim))
 
-    grand_median = np.median(np.concatenate(data))
+    cdata = np.concatenate(data)
+    contains_nan, nan_policy = _contains_nan(cdata, nan_policy)
+    if contains_nan and nan_policy == 'omit':
+        grand_median = np.nanmedian(cdata)
+    else:
+        grand_median = np.median(cdata)
 
     # Create the contingency table.
     table = np.zeros((2, len(data)), dtype=np.int64)

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2582,14 +2582,16 @@ def median_test(*args, **kwds):
 
     cdata = np.concatenate(data)
     contains_nan, nan_policy = _contains_nan(cdata, nan_policy)
-    if contains_nan and nan_policy == 'omit':
-        grand_median = np.nanmedian(cdata)
-    else:
-        grand_median = np.median(cdata)
+    if contains_nan and nan_policy == 'propagate':
+        return (np.nan,)*4
+
+    grand_median = np.nanmedian(cdata)
 
     # Create the contingency table.
     table = np.zeros((2, len(data)), dtype=np.int64)
     for k, sample in enumerate(data):
+        sample = sample[~np.isnan(sample)]
+
         nabove = count_nonzero(sample > grand_median)
         nbelow = count_nonzero(sample < grand_median)
         nequal = sample.size - (nabove + nbelow)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1234,6 +1234,9 @@ class TestMedianTest(TestCase):
     def test_bad_ties(self):
         assert_raises(ValueError, stats.median_test, [1, 2, 3], [4, 5], ties="foo")
 
+    def test_bad_nan_policy(self):
+        assert_raises(ValueError, stats.median_test, [1, 2, 3], [4, 5], nan_policy='foobar')
+
     def test_bad_keyword(self):
         assert_raises(TypeError, stats.median_test, [1, 2, 3], [4, 5], foo="foo")
 
@@ -1271,6 +1274,16 @@ class TestMedianTest(TestCase):
         stat, p, m, tbl = stats.median_test(x, y, z, ties="above")
         assert_equal(m, 5)
         assert_equal(tbl, [[0, 2, 3], [4, 0, 0]])
+
+    def test_nan_policy_options(self):
+        x = [1, 2, np.nan]
+        y = [4, 5, 6]
+        _, _, med, _ = stats.median_test(x, y, nan_policy='propagate')
+        _, _, med2, _ = stats.median_test(x, y, nan_policy='omit')
+
+        assert_equal(med, np.nan)
+        assert_equal(med2, 4.)
+        assert_raises(ValueError, stats.median_test, x, y, nan_policy='raise')
 
     def test_basic(self):
         # median_test calls chi2_contingency to compute the test statistic

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1278,11 +1278,14 @@ class TestMedianTest(TestCase):
     def test_nan_policy_options(self):
         x = [1, 2, np.nan]
         y = [4, 5, 6]
-        _, _, med, _ = stats.median_test(x, y, nan_policy='propagate')
-        _, _, med2, _ = stats.median_test(x, y, nan_policy='omit')
+        mt1 = stats.median_test(x, y, nan_policy='propagate')
+        s, p, m, t = stats.median_test(x, y, nan_policy='omit')
 
-        assert_equal(med, np.nan)
-        assert_equal(med2, 4.)
+        assert_equal(mt1, (np.nan, np.nan, np.nan, np.nan))
+        assert_allclose(s, 0.31250000000000006)
+        assert_allclose(p, 0.57615012203057869)
+        assert_equal(m, 4.0)
+        assert_equal(t, np.array([[0, 2],[2, 1]]))
         assert_raises(ValueError, stats.median_test, x, y, nan_policy='raise')
 
     def test_basic(self):


### PR DESCRIPTION
PR for #5114.

I've made use of private method `stats._contains_nan` - my reasoning is that it didn't make sense to copy/paste same method into `morestats.py`, but it's not generally useful enough to make it public either.
