### PR TITLE
MAINT: differential_evolution changes to default keywords break back compat closes #5731

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -360,7 +360,11 @@ class DifferentialEvolutionSolver(object):
                              'real valued (min, max) pairs for each value'
                              ' in x')
 
+        if maxiter is None:  # the default used to be None
+            maxiter = 1000
         self.maxiter = maxiter
+        if maxfun is None:  # the default used to be None
+            maxfun = np.inf
         self.maxfun = maxfun
 
         # population is scaled to between [0, 1].

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -408,6 +408,15 @@ class TestDifferentialEvolutionSolver(TestCase):
         solver.solve()
         assert_(solver.convergence < 0.2)
 
+    def test_maxiter_none_GH5731(self):
+        # Pre 0.17 the previous default for maxiter and maxfun was None.
+        # the numerical defaults are now 1000 and np.inf. However, some scripts
+        # will still supply None for both of those, this will raise a TypeError
+        # in the solve method.
+        solver = DifferentialEvolutionSolver(rosen, self.bounds, maxiter=None,
+                                             maxfun=None)
+        solver.solve()
+
 
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
See #5731.
