### PR TITLE
ENH: Added transfer function estimation

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -156,6 +156,7 @@ Alexander Grigorevskiy for adding extra LAPACK least-square solvers and
 Sam Lewis for enhancements to the basinhopping module.
 Tadeusz Pudlik for documentation and vectorizing spherical Bessel functions.
 Philip DeBoer for wrapping random SO(N) matrix code in scipy.stats.
+Aaron Voelker for adding transfer function estimation.
 
 Institutions
 ------------

--- a/doc/release/0.18.0-notes.rst
+++ b/doc/release/0.18.0-notes.rst
@@ -21,6 +21,13 @@ This release requires Python 2.6, 2.7 or 3.2-3.4 and NumPy 1.6.2 or greater.
 New features
 ============
 
+`scipy.signal` improvements
+---------------------------
+
+Transfer function estimation is now available via `scipy.signal.tfestimate`.
+This class estimates the transfer function from an input signal ``x`` to an
+output signal ``y``, using Welch's method.
+
 
 Deprecated features
 ===================
@@ -36,6 +43,7 @@ Other changes
 
 Authors
 =======
+
 
 Issues closed
 -------------

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -187,7 +187,7 @@ LTI Representations
    sos2tf        -- second-order-sections to transfer function.
    cont2discrete -- continuous-time to discrete-time LTI conversion.
    place_poles   -- pole placement.
-   
+
 Waveforms
 =========
 
@@ -263,6 +263,7 @@ Spectral Analysis
    periodogram    -- Compute a (modified) periodogram
    welch          -- Compute a periodogram using Welch's method
    csd            -- Compute the cross spectral density, using Welch's method
+   tfestimate     -- Compute the transfer function estimate, using Welch's method
    coherence      -- Compute the magnitude squared coherence, using Welch's method
    spectrogram    -- Compute the spectrogram
    lombscargle    -- Computes the Lomb-Scargle periodogram

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -814,7 +814,8 @@ class TestTfestimate:
 
 class TestCoherence:
     def test_identical_input(self):
-        x = np.random.randn(20)
+        rng = np.random.RandomState(1234)
+        x = rng.randn(20)
         y = np.copy(x)  # So `y is x` -> False
 
         f = np.linspace(0, 0.5, 6)
@@ -825,7 +826,8 @@ class TestCoherence:
         assert_allclose(C, C1)
 
     def test_phase_shifted_input(self):
-        x = np.random.randn(20)
+        rng = np.random.RandomState(1234)
+        x = rng.randn(20)
         y = -x
 
         f = np.linspace(0, 0.5, 6)
@@ -838,7 +840,8 @@ class TestCoherence:
 
 class TestSpectrogram:
     def test_average_all_segments(self):
-        x = np.random.randn(1024)
+        rng = np.random.RandomState(1234)
+        x = rng.randn(1024)
 
         fs = 1.0
         window = ('tukey', 0.25)
@@ -865,8 +868,8 @@ class TestLombscargle:
         p = 0.7  # Fraction of points to select
 
         # Randomly select a fraction of an array with timesteps
-        np.random.seed(2353425)
-        r = np.random.rand(nin)
+        rng = np.random.RandomState(2353425)
+        r = rng.rand(nin)
         t = np.linspace(0.01*np.pi, 10.*np.pi, nin)[r >= p]
 
         # Plot a sine wave for the selected times
@@ -897,8 +900,8 @@ class TestLombscargle:
         p = 0.7  # Fraction of points to select
 
         # Randomly select a fraction of an array with timesteps
-        np.random.seed(2353425)
-        r = np.random.rand(nin)
+        rng = np.random.RandomState(2353425)
+        r = rng.rand(nin)
         t = np.linspace(0.01*np.pi, 10.*np.pi, nin)[r >= p]
 
         # Plot a sine wave for the selected times


### PR DESCRIPTION
Added `scipy.signal.tfestimate`, which is available in Matlab under the same name. The implementation is consistent with, and similar in nature to, `scipy.signal.coherence`. 

The doc example demonstrates how this can be used to reverse-engineer a Butterworth filter from the (x, y) signals, and the second test case verifies that this produces approximately the same filter.
