### PR TITLE
DOC: Fix io.loadmat docstring for mdict param

### DIFF
--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -75,7 +75,7 @@ def loadmat(file_name, mdict=None, appendmat=True, **kwargs):
     ----------
     file_name : str
        Name of the mat file (do not need .mat extension if
-       appendmat==True) Can also pass open file-like object.
+       appendmat==True). Can also pass open file-like object.
     mdict : dict, optional
         Dictionary in which to insert matfile variables.
     appendmat : bool, optional

--- a/scipy/io/matlab/mio.py
+++ b/scipy/io/matlab/mio.py
@@ -76,7 +76,7 @@ def loadmat(file_name, mdict=None, appendmat=True, **kwargs):
     file_name : str
        Name of the mat file (do not need .mat extension if
        appendmat==True) Can also pass open file-like object.
-    m_dict : dict, optional
+    mdict : dict, optional
         Dictionary in which to insert matfile variables.
     appendmat : bool, optional
        True to append the .mat extension to the end of the given


### PR DESCRIPTION
The docs spell the parameter as `m_dict`; it is `mdict`.

~~Another issue: I think the parameter is weirdly explained. Instead of "Dictionary from which to save matfile variables.", shouldn't it be "Dictionary to which to save matfile variables."?~~
