### PR TITLE
BUG: Accept anything np.dtype can handle for a dtype in sparse.random

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -729,7 +729,8 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     """
     if density < 0 or density > 1:
         raise ValueError("density expected to be 0 <= density <= 1")
-    if dtype and (dtype not in [np.float32, np.float64, np.longdouble]):
+    dtype = np.dtype(dtype)
+    if dtype.char not in 'fdg':
         raise NotImplementedError("type %s not supported" % dtype)
 
     mn = m * n

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -433,6 +433,11 @@ class TestConstructUtils(TestCase):
             assert_(np.any(np.less(x.data, 0)))
             assert_(np.any(np.less(1, x.data)))
 
+    def test_random_accept_str_dtype(self):
+        # anything that np.dtype can convert to a dtype should be accepted
+        # for the dtype
+        a = construct.random(10, 10, dtype='d')
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Fix a tiny irritation. 
