### PR TITLE
Update sparse.csgraph.laplacian docstring

### DIFF
--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -34,8 +34,9 @@ def laplacian(csgraph, normed=False, return_diag=False, use_out_degree=False):
 
     Returns
     -------
-    lap : ndarray
-        The N x N laplacian matrix of graph.
+    lap : ndarray or coo_matrix
+        The N x N laplacian matrix of csgraph. It will be a numpy array (dense)
+        if the input was dense, sparse (COO format) otherwise.
     diag : ndarray, optional
         The length-N diagonal of the Laplacian matrix.
         For the normalized Laplacian, this is the array of square roots

--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -34,9 +34,9 @@ def laplacian(csgraph, normed=False, return_diag=False, use_out_degree=False):
 
     Returns
     -------
-    lap : ndarray or coo_matrix
+    lap : ndarray or sparse matrix
         The N x N laplacian matrix of csgraph. It will be a numpy array (dense)
-        if the input was dense, sparse (COO format) otherwise.
+        if the input was dense, or a sparse matrix otherwise.
     diag : ndarray, optional
         The length-N diagonal of the Laplacian matrix.
         For the normalized Laplacian, this is the array of square roots


### PR DESCRIPTION
The return type is incorrectly documented when the input is sparse,
making it seem as though the function cannot work efficiently with
sparse inputs, when in fact it can.
