### PR TITLE
BUG: fix special.hyp0f1 to work correctly for complex inputs.

### DIFF
--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -1043,11 +1043,10 @@ def hyp0f1(v, z):
     v = atleast_1d(v)
     z = atleast_1d(z)
     v, z = np.broadcast_arrays(v, z)
-    if z.dtype == np.complex64 or z.dtype == np.complex128:
+    if np.iscomplexobj(z):
         res = np.empty_like(z)
     else:
         res = np.empty_like(z, dtype=np.float64)
-    # Poles when v is a negative integer
     poles = (v < 0) & (v == v.astype(int))
     zeros = (z == 0)
     pos = (z.real >= 0) & -zeros & -poles

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -1043,15 +1043,20 @@ def hyp0f1(v, z):
     v = atleast_1d(v)
     z = atleast_1d(z)
     v, z = np.broadcast_arrays(v, z)
-    arg = 2 * sqrt(abs(z))
-    old_err = np.seterr(all='ignore')  # for z=0, a<1 and num=inf, next lines
-    num = where(z.real >= 0, iv(v - 1, arg), jv(v - 1, arg))
-    den = abs(z)**((v - 1.0) / 2)
-    num *= gamma(v)
-    np.seterr(**old_err)
-    num[z == 0] = 1
-    den[z == 0] = 1
-    return num / den
+    if z.dtype == np.complex64 or z.dtype == np.complex128:
+        res = np.empty_like(z)
+    else:
+        res = np.empty_like(z, dtype=np.float64)
+    # Poles when v is a negative integer
+    poles = (v < 0) & (v == v.astype(int))
+    zeros = (z == 0)
+    pos = (z.real >= 0) & -zeros & -poles
+    neg = (z.real < 0) & -zeros & -poles
+    res[poles] = nan
+    res[zeros] = 1
+    res[pos] = z[pos]**((1.0 - v[pos])/2)*gamma(v[pos])*iv(v[pos] - 1, 2*sqrt(z[pos]))
+    res[neg] = (-z[neg])**((1.0 - v[neg])/2)*gamma(v[neg])*jv(v[neg] - 1, 2*sqrt(-z[neg]))
+    return res
 
 
 def assoc_laguerre(x, n, k=0.0):

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1848,6 +1848,13 @@ class TestHyper(TestCase):
         assert_raises(ValueError, special.hyp0f1,
                       np.row_stack([x1] * 3), [0, 1])
 
+    def test_hyp0f1_gh5764(self):
+        # Just checks the point that failed; there's a more systematic
+        # test in test_mpmath
+        res = special.hyp0f1(0.8, 0.5 + 0.5*1J)
+        # The expected value was generated using mpmath
+        assert_almost_equal(res, 1.6139719776441115 + 1J*0.80893054061790665)
+
     def test_hyp1f1(self):
         hyp1 = special.hyp1f1(.1,.1,.3)
         assert_almost_equal(hyp1, 1.3498588075760032,7)

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -10,7 +10,7 @@ import time
 from distutils.version import LooseVersion
 
 import numpy as np
-from numpy.testing import dec, run_module_suite, assert_
+from numpy.testing import dec, run_module_suite, assert_, assert_allclose
 from numpy import pi
 
 import scipy.special as sc
@@ -49,6 +49,21 @@ def test_expi_complex():
 
     FuncData(sc.expi, dataset, 0, 1).check()
 
+#------------------------------------------------------------------------------
+# hyp0f1
+#------------------------------------------------------------------------------
+
+def test_hyp0f1_gh5764():
+    # Do a small and somewhat systematic test that runs quickly.
+    axis = np.array([-99.5, -9.5, -0.5, 0.5, 9.5, 99.5])
+    v, x, y = np.meshgrid(axis, axis, axis)
+    z = x + 1J*y
+    res = sc.hyp0f1(v, z)
+    std = np.empty_like(z)
+    for index, z0 in np.ndenumerate(z):
+        v0 = v[index]
+        std[index] = complex(mpmath.hyp0f1(v0, z0))
+    assert_allclose(res, std, rtol=1e-13, atol=1e-13)
 
 #------------------------------------------------------------------------------
 # hyp2f1

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -54,16 +54,17 @@ def test_expi_complex():
 #------------------------------------------------------------------------------
 
 def test_hyp0f1_gh5764():
-    # Do a small and somewhat systematic test that runs quickly.
-    axis = np.array([-99.5, -9.5, -0.5, 0.5, 9.5, 99.5])
-    v, x, y = np.meshgrid(axis, axis, axis)
-    z = x + 1J*y
-    res = sc.hyp0f1(v, z)
-    std = np.empty_like(z)
-    for index, z0 in np.ndenumerate(z):
-        v0 = v[index]
-        std[index] = complex(mpmath.hyp0f1(v0, z0))
-    assert_allclose(res, std, rtol=1e-13, atol=1e-13)
+    # Do a small and somewhat systematic test that runs quickly
+    pts = []
+    axis = [-99.5, -9.5, -0.5, 0.5, 9.5, 99.5]
+    for v in axis:
+        for x in axis:
+            for y in axis:
+                pts.append((v, x + 1J*y))
+    std = np.array([(complex(mpmath.hyp0f1(*p)),) for p in pts])
+    # Can't use FuncData because v should be real and z complex
+    res = np.array([sc.hyp0f1(*p) for p in pts])
+    assert_allclose(res, std, atol=1e-13, rtol=1e-13)
 
 #------------------------------------------------------------------------------
 # hyp2f1


### PR DESCRIPTION
The current implementation computes hyp0f1 using two relations with
Bessel functions, but it applies those relations incorrectly. This
fixes that issue and restructures the code a bit to avoid calling the
Bessel functions more than is necessary. Closes gh-5764.
