### PR TITLE
DOC: Fix documentation on solve_discrete_lyapunov

### DIFF
--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -150,15 +150,13 @@ def _solve_discrete_lyapunov_bilinear(a, q):
 
 def solve_discrete_lyapunov(a, q, method=None):
     """
-    Solves the discrete Lyapunov equation :math:`A'XA-X=-Q`.
+    Solves the discrete Lyapunov equation :math:`AXA^H - X + Q = 0`.
 
     Parameters
     ----------
-    a : (M, M) array_like
-        A square matrix
-
-    q : (M, M) array_like
-        Right-hand side square matrix
+    a, q : (M, M) array_like
+        Square matrices corresponding to A and Q in the equation
+        above respectively. Must have the same shape.
 
     method : {'direct', 'bilinear'}, optional
         Type of solver.
@@ -187,7 +185,7 @@ def solve_discrete_lyapunov(a, q, method=None):
     performance degrades rapidly for even moderately sized matrices.
 
     Method *bilinear* uses a bilinear transformation to convert the discrete
-    Lyapunov equation to a continuous Lyapunov equation :math:`(B'X+XB=-C)`
+    Lyapunov equation to a continuous Lyapunov equation :math:`(BX+XB'=-C)`
     where :math:`B=(A-I)(A+I)^{-1}` and
     :math:`C=2(A' + I)^{-1} Q (A + I)^{-1}`. The continuous equation can be
     efficiently solved since it is a special case of a Sylvester equation.


### PR DESCRIPTION
Addresses conjugate transpose symbol issue in #5752. Also changed the sign of `Q` to keep it consistent with other Lyapunov methods defined as well as the documentation itself, which describes `Q` as the "right-hand" matrix, in which case there is no minus per the equation definition.
