### PR TITLE
BUG: Allow Processing of Zero Order State Space Models in signal.ss2tf

### DIFF
--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -121,10 +121,10 @@ def tf2ss(num, den):
     if num.shape[-1] > 0:
         D = num[:, 0]
     else:
-        D = array([], float)
+        D = array([0], float)
 
     if K == 1:
-        return array([], float), array([], float), array([], float), D
+        return array([0], float), array([0], float), array([0], float), D
 
     frow = -array([den[1:]])
     A = r_[frow, eye(K - 2, K - 1)]

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -121,6 +121,10 @@ def tf2ss(num, den):
     if num.shape[-1] > 0:
         D = num[:, 0]
     else:
+        # We don't assign it an empty array because this system
+        # is not 'null'. It just doesn't have a non-zero D
+        # matrix. Thus, it should have a non-zero shape so that
+        # it can be operated on by functions like 'ss2tf'
         D = array([0], float)
 
     if K == 1:
@@ -1248,9 +1252,9 @@ def lsim(system, U, T, X0=None, interp=True):
     else:
         raise ValueError("Initial time must be nonnegative")
 
-    no_input = (U is None
-                or (isinstance(U, (int, float)) and U == 0.)
-                or not np.any(U))
+    no_input = (U is None or
+                (isinstance(U, (int, float)) and U == 0.) or
+                not np.any(U))
 
     if n_steps == 1:
         yout = squeeze(dot(xout, transpose(C)))

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -17,7 +17,7 @@ def _assert_poles_close(P1,P2, rtol=1e-8, atol=1e-8):
     """
     Check each pole in P1 is close to a pole in P2 with a 1e-8
     relative tolerance or 1e-8 absolute tolerance (useful for zero poles).
-    These tolerance are very scrict but the systems tested are known to
+    These tolerances are very strict but the systems tested are known to
     accept these poles so we should not be far from what is requested.
     """
     P2 = P2.copy()
@@ -249,7 +249,7 @@ class TestSS2TF:
             yield self.tst_matrix_shapes, p, q, r
 
     def test_basic(self):
-        # Test a round trip through tf2ss and sst2f.
+        # Test a round trip through tf2ss and ss2tf.
         b = np.array([1.0, 3.0, 5.0])
         a = np.array([1.0, 2.0, 3.0])
 

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -264,6 +264,15 @@ class TestSS2TF:
         assert_allclose(bb[0], b, rtol=1e-13)
         assert_allclose(aa, a, rtol=1e-13)
 
+    def test_zero_order_round_trip(self):
+        # See Issue #5760
+        tf = (2, 1)
+        ss = tf2ss(*tf)
+        assert_equal(ss, [[0], [0], [0], [2]])
+
+        tf = ss2tf(*ss)
+        assert_equal(tf, [[[2, 0]], [1, 0]])
+
     def test_multioutput(self):
         # Regression test for gh-2669.
 


### PR DESCRIPTION
Addresses issue in #5760 by changing the output of `tf2ss` for zero-order transfer functions to return non-empty arrays, allowing them to be processed by `ss2tf` and not getting them confused with <a href="https://github.com/gfyoung/scipy/blob/zero_order_ss_fix/scipy/signal/ltisys.py#L114" target="_blank">null output</a>, which returns empty arrays.
