### PR TITLE
DOC: README: remove coveralls.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,6 @@
 .. image:: https://travis-ci.org/scipy/scipy.png?branch=master
    :target: https://travis-ci.org/scipy/scipy/
 
-.. image:: https://coveralls.io/repos/scipy/scipy/badge.png?branch=master
-   :target: https://coveralls.io/r/scipy/scipy?branch=master 
-
 =====
 SciPy
 =====


### PR DESCRIPTION
Leftover from gh-5009. Removes the ugly grey button from Github.

[CI skip]
