### PR TITLE
MAINT: remove uses of deprecated np.random.random_integers

### DIFF
--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -24,7 +24,7 @@ from .common import Benchmark
 
 def random_sparse(m, n, nnz_per_row):
     rows = numpy.arange(m).repeat(nnz_per_row)
-    cols = numpy.random.random_integers(low=0, high=n-1, size=nnz_per_row*m)
+    cols = numpy.random.randint(0, n, size=nnz_per_row*m)
     vals = numpy.random.random_sample(m*nnz_per_row)
     return coo_matrix((vals, (rows, cols)), (m, n)).tocsr()
 

--- a/benchmarks/benchmarks/sparse_linalg_expm.py
+++ b/benchmarks/benchmarks/sparse_linalg_expm.py
@@ -17,7 +17,7 @@ from .common import Benchmark
 def random_sparse_csr(m, n, nnz_per_row):
     # Copied from the scipy.sparse benchmark.
     rows = np.arange(m).repeat(nnz_per_row)
-    cols = np.random.random_integers(low=0, high=n-1, size=nnz_per_row*m)
+    cols = np.random.randint(0, n, size=nnz_per_row*m)
     vals = np.random.random_sample(m*nnz_per_row)
     M = scipy.sparse.coo_matrix((vals,(rows,cols)), (m,n), dtype=float)
     return M.tocsr()
@@ -26,7 +26,7 @@ def random_sparse_csr(m, n, nnz_per_row):
 def random_sparse_csc(m, n, nnz_per_row):
     # Copied from the scipy.sparse benchmark.
     rows = np.arange(m).repeat(nnz_per_row)
-    cols = np.random.random_integers(low=0, high=n-1, size=nnz_per_row*m)
+    cols = np.random.randint(0, n, size=nnz_per_row*m)
     vals = np.random.random_sample(m*nnz_per_row)
     M = scipy.sparse.coo_matrix((vals,(rows,cols)), (m,n), dtype=float)
     # Use csc instead of csr, because sparse LU decomposition

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2418,8 +2418,8 @@ class _TestFancyIndexing:
         D = np.asmatrix(np.random.rand(M,N))
         D = np.multiply(D, D > 0.5)
 
-        I = np.random.random_integers(-M + 1, M - 1, size=NUM_SAMPLES)
-        J = np.random.random_integers(-N + 1, N - 1, size=NUM_SAMPLES)
+        I = np.random.randint(-M + 1, M, size=NUM_SAMPLES)
+        J = np.random.randint(-N + 1, N, size=NUM_SAMPLES)
 
         S = self.spmatrix(D)
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1120,7 +1120,7 @@ def test_ckdtree_memuse():
     z_copy[:] = z
     # Place FILLVAL in z_copy at random number of random locations
     FILLVAL = 99.
-    mask = np.random.random_integers(0, z.size - 1, np.random.randint(50) + 5)
+    mask = np.random.randint(0, z.size, np.random.randint(50) + 5)
     z_copy.flat[mask] = FILLVAL
     igood = np.vstack(np.where(x != FILLVAL)).T
     ibad = np.vstack(np.where(x == FILLVAL)).T

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -610,9 +610,6 @@ class randint_gen(rv_discrete):
 
     `randint` takes ``low`` and ``high`` as shape parameters.
 
-    Note the difference to the numpy ``random_integers`` which
-    returns integers on a *closed* interval ``[low, high]``.
-
     %(after_notes)s
 
     %(example)s


### PR DESCRIPTION
See numpy/numpy#6931.
The replacement with `np.random.randint` is pretty straightforward.
