### PR TITLE
TST: Remove all permanent filter changes from tests

### DIFF
--- a/scipy/_lib/_numpy_compat.py
+++ b/scipy/_lib/_numpy_compat.py
@@ -5,7 +5,9 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 import sys
-
+from warnings import WarningMessage
+import re
+from functools import wraps
 import numpy as np
 from numpy.testing.nosetester import import_nose
 
@@ -297,3 +299,282 @@ else:
                 raise ValueError("x.ndim must be < r.ndim when tensor == "
                                  "False")
         return np.prod(x - r, axis=0)
+
+
+try:
+    from numpy.testing import suppress_warnings
+except ImportError:
+    class suppress_warnings(object):
+        """
+        Context manager and decorator doing much the same as
+        ``warnings.catch_warnings``.
+
+        However, it also provides a filter mechanism to work around
+        http://bugs.python.org/issue4180.
+
+        This bug causes Python before 3.4 to not reliably show warnings again
+        after they have been ignored once (even within catch_warnings). It
+        means that no "ignore" filter can be used easily, since following
+        tests might need to see the warning. Additionally it allows easier
+        specificity for testing warnings and can be nested.
+
+        Parameters
+        ----------
+        forwarding_rule : str, optional
+            One of "always", "once", "module", or "location". Analogous to
+            the usual warnings module filter mode, it is useful to reduce
+            noise mostly on the outmost level. Unsuppressed and unrecorded
+            warnings will be forwarded based on this rule. Defaults to "always".
+            "location" is equivalent to the warnings "default", match by exact
+            location the warning warning originated from.
+
+        Notes
+        -----
+        Filters added inside the context manager will be discarded again
+        when leaving it. Upon entering all filters defined outside a
+        context will be applied automatically.
+
+        When a recording filter is added, matching warnings are stored in the
+        ``log`` attribute as well as in the list returned by ``record``.
+
+        If filters are added and the ``module`` keyword is given, the
+        warning registry of this module will additionally be cleared when
+        applying it, entering the context, or exiting it. This could cause
+        warnings to appear a second time after leaving the context if they
+        were configured to be printed once (default) and were already
+        printed before the context was entered.
+
+        Nesting this context manager will work as expected when the
+        forwarding rule is "always" (default). Unfiltered and unrecorded
+        warnings will be passed out and be matched by the outer level.
+        On the outmost level they will be printed (or caught by another
+        warnings context). The forwarding rule argument can modify this
+        behaviour.
+
+        Like ``catch_warnings`` this context manager is not threadsafe.
+
+        Examples
+        --------
+        >>> with suppress_warnings() as sup:
+        ...     sup.filter(DeprecationWarning, "Some text")
+        ...     sup.filter(module=np.ma.core)
+        ...     log = sup.record(FutureWarning, "Does this occur?")
+        ...     command_giving_warnings()
+        ...     # The FutureWarning was given once, the filtered warnings were
+        ...     # ignored. All other warnings abide outside settings (may be
+        ...     # printed/error)
+        ...     assert_(len(log) == 1)
+        ...     assert_(len(sup.log) == 1)  # also stored in log attribute
+
+        Or as a decorator:
+
+        >>> sup = suppress_warnings()
+        >>> sup.filter(module=np.ma.core)  # module must match exact
+        >>> @sup
+        >>> def some_function():
+        ...     # do something which causes a warning in np.ma.core
+        ...     pass
+        """
+        def __init__(self, forwarding_rule="always"):
+            self._entered = False
+
+            # Suppressions are either instance or defined inside one with block:
+            self._suppressions = []
+
+            if forwarding_rule not in {"always", "module", "once", "location"}:
+                raise ValueError("unsupported forwarding rule.")
+            self._forwarding_rule = forwarding_rule
+
+        def _clear_registries(self):
+            if hasattr(warnings, "_filters_mutated"):
+                # clearing the registry should not be necessary on new pythons,
+                # instead the filters should be mutated.
+                warnings._filters_mutated()
+                return
+            # Simply clear the registry, this should normally be harmless,
+            # note that on new pythons it would be invalidated anyway.
+            for module in self._tmp_modules:
+                if hasattr(module, "__warningregistry__"):
+                    module.__warningregistry__.clear()
+
+        def _filter(self, category=Warning, message="", module=None, record=False):
+            if record:
+                record = []  # The log where to store warnings
+            else:
+                record = None
+            if self._entered:
+                if module is None:
+                    warnings.filterwarnings(
+                        "always", category=category, message=message)
+                else:
+                    module_regex = module.__name__.replace('.', r'\.') + '$'
+                    warnings.filterwarnings(
+                        "always", category=category, message=message,
+                        module=module_regex)
+                    self._tmp_modules.add(module)
+                    self._clear_registries()
+
+                self._tmp_suppressions.append(
+                    (category, message, re.compile(message, re.I), module, record))
+            else:
+                self._suppressions.append(
+                    (category, message, re.compile(message, re.I), module, record))
+
+            return record
+
+        def filter(self, category=Warning, message="", module=None):
+            """
+            Add a new suppressing filter or apply it if the state is entered.
+
+            Parameters
+            ----------
+            category : class, optional
+                Warning class to filter
+            message : string, optional
+                Regular expression matching the warning message.
+            module : module, optional
+                Module to filter for. Note that the module (and its file)
+                must match exactly and cannot be a submodule. This may make
+                it unreliable for external modules.
+
+            Notes
+            -----
+            When added within a context, filters are only added inside
+            the context and will be forgotten when the context is exited.
+            """
+            self._filter(category=category, message=message, module=module,
+                         record=False)
+
+        def record(self, category=Warning, message="", module=None):
+            """
+            Append a new recording filter or apply it if the state is entered.
+
+            All warnings matching will be appended to the ``log`` attribute.
+
+            Parameters
+            ----------
+            category : class, optional
+                Warning class to filter
+            message : string, optional
+                Regular expression matching the warning message.
+            module : module, optional
+                Module to filter for. Note that the module (and its file)
+                must match exactly and cannot be a submodule. This may make
+                it unreliable for external modules.
+
+            Returns
+            -------
+            log : list
+                A list which will be filled with all matched warnings.
+
+            Notes
+            -----
+            When added within a context, filters are only added inside
+            the context and will be forgotten when the context is exited.
+            """
+            return self._filter(category=category, message=message, module=module,
+                                record=True)
+
+        def __enter__(self):
+            if self._entered:
+                raise RuntimeError("cannot enter suppress_warnings twice.")
+
+            self._orig_show = warnings.showwarning
+            self._filters = warnings.filters
+            warnings.filters = self._filters[:]
+
+            self._entered = True
+            self._tmp_suppressions = []
+            self._tmp_modules = set()
+            self._forwarded = set()
+
+            self.log = []  # reset global log (no need to keep same list)
+
+            for cat, mess, _, mod, log in self._suppressions:
+                if log is not None:
+                    del log[:]  # clear the log
+                if mod is None:
+                    warnings.filterwarnings(
+                        "always", category=cat, message=mess)
+                else:
+                    module_regex = mod.__name__.replace('.', r'\.') + '$'
+                    warnings.filterwarnings(
+                        "always", category=cat, message=mess,
+                        module=module_regex)
+                    self._tmp_modules.add(mod)
+            warnings.showwarning = self._showwarning
+            self._clear_registries()
+
+            return self
+
+        def __exit__(self, *exc_info):
+            warnings.showwarning = self._orig_show
+            warnings.filters = self._filters
+            self._clear_registries()
+            self._entered = False
+            del self._orig_show
+            del self._filters
+
+        def _showwarning(self, message, category, filename, lineno,
+                         *args, **kwargs):
+            use_warnmsg = kwargs.pop("use_warnmsg", None)
+            for cat, _, pattern, mod, rec in (
+                    self._suppressions + self._tmp_suppressions)[::-1]:
+                if (issubclass(category, cat) and
+                        pattern.match(message.args[0]) is not None):
+                    if mod is None:
+                        # Message and category match, either recorded or ignored
+                        if rec is not None:
+                            msg = WarningMessage(message, category, filename,
+                                                 lineno, **kwargs)
+                            self.log.append(msg)
+                            rec.append(msg)
+                        return
+                    # Use startswith, because warnings strips the c or o from
+                    # .pyc/.pyo files.
+                    elif mod.__file__.startswith(filename):
+                        # The message and module (filename) match
+                        if rec is not None:
+                            msg = WarningMessage(message, category, filename,
+                                                 lineno, **kwargs)
+                            self.log.append(msg)
+                            rec.append(msg)
+                        return
+
+            # There is no filter in place, so pass to the outside handler
+            # unless we should only pass it once
+            if self._forwarding_rule == "always":
+                if use_warnmsg is None:
+                    self._orig_show(message, category, filename, lineno,
+                                    *args, **kwargs)
+                else:
+                    self._orig_showmsg(use_warnmsg)
+                return
+
+            if self._forwarding_rule == "once":
+                signature = (message.args, category)
+            elif self._forwarding_rule == "module":
+                signature = (message.args, category, filename)
+            elif self._forwarding_rule == "location":
+                signature = (message.args, category, filename, lineno)
+
+            if signature in self._forwarded:
+                return
+            self._forwarded.add(signature)
+            if use_warnmsg is None:
+                self._orig_show(message, category, filename, lineno, *args,
+                                **kwargs)
+            else:
+                self._orig_showmsg(use_warnmsg)
+
+        def __call__(self, func):
+            """
+            Function decorator to apply certain suppressions to a whole
+            function.
+            """
+            @wraps(func)
+            def new_func(*args, **kwargs):
+                with self:
+                    return func(*args, **kwargs)
+
+            return new_func

--- a/scipy/io/tests/test_idl.py
+++ b/scipy/io/tests/test_idl.py
@@ -432,6 +432,7 @@ def test_invalid_pointer():
     # Since it's difficult to artificially produce such files, the file used
     # here has been edited to force the pointer reference to be invalid.
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
         s = readsav(path.join(DATA_PATH, 'invalid_pointer.sav'), verbose=False)
     assert_(len(w) == 1)
     assert_(str(w[0].message) == ("Variable referenced by pointer not found in "

--- a/scipy/signal/tests/test_dltisys.py
+++ b/scipy/signal/tests/test_dltisys.py
@@ -9,6 +9,7 @@ from numpy.testing import (TestCase, run_module_suite, assert_equal,
                            assert_array_almost_equal, assert_array_equal,
                            assert_allclose, assert_, assert_raises,
                            assert_almost_equal)
+from scipy._lib._numpy_compat import suppress_warnings
 from scipy.signal import (dlsim, dstep, dimpulse, tf2zpk, lti, dlti,
                           StateSpace, TransferFunction, ZerosPolesGain,
                           dfreqresp, dbode, BadCoefficients)
@@ -445,8 +446,9 @@ class Test_dfreqresp(TestCase):
         # integrator, pole at zero: H(s) = 1 / s
         system = TransferFunction([1], [1, -1], dt=0.1)
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", RuntimeWarning)
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, message="divide by zero")
+            sup.filter(RuntimeWarning, message="invalid value encountered")
             w, H = dfreqresp(system, n=2)
         assert_equal(w[0], 0.)  # a fail would give not-a-number
 
@@ -469,8 +471,8 @@ class Test_dfreqresp(TestCase):
 
         system_SS = dlti(A, B, C, D)
         w = 10.0**np.arange(-3,0,.5)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", BadCoefficients)
+        with suppress_warnings() as sup:
+            sup.filter(BadCoefficients)
             w1, H1 = dfreqresp(system_TF, w=w)
             w2, H2 = dfreqresp(system_SS, w=w)
 
@@ -540,8 +542,9 @@ class Test_bode(object):
         # integrator, pole at zero: H(s) = 1 / s
         system = TransferFunction([1], [1, -1], dt=0.1)
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", RuntimeWarning)
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, message="divide by zero")
+            sup.filter(RuntimeWarning, message="invalid value encountered")
             w, mag, phase = dbode(system, n=2)
         assert_equal(w[0], 0.)  # a fail would give not-a-number
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -11,6 +11,7 @@ from numpy.testing import (TestCase, assert_array_almost_equal,
                            dec)
 from numpy import array, spacing, sin, pi, sort
 
+from scipy._lib._numpy_compat import suppress_warnings
 from scipy.signal import (BadCoefficients, bessel, besselap, bilinear, buttap,
                           butter, buttord, cheb1ap, cheb1ord, cheb2ap,
                           cheb2ord, cheby1, cheby2, ellip, ellipap, ellipord,
@@ -178,11 +179,9 @@ class TestTf2zpk(TestCase):
     def test_bad_filter(self):
         # Regression test for #651: better handling of badly conditioned
         # filter coefficients.
-        warnings.simplefilter("error", BadCoefficients)
-        try:
+        with suppress_warnings():
+            warnings.simplefilter("error", BadCoefficients)
             assert_raises(BadCoefficients, tf2zpk, [1e-15], [1.0, 1.0])
-        finally:
-            warnings.simplefilter("always", BadCoefficients)
 
 
 class TestZpk2Tf(TestCase):
@@ -2897,11 +2896,9 @@ class TestGroupDelay(TestCase):
         b = np.convolve([1, -z1], [1, -z2])
         a = np.convolve([1, -p1], [1, -p2])
         w = np.array([0.1 * pi, 0.25 * pi, -0.5 * pi, -0.8 * pi])
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            assert_warns(UserWarning, group_delay, (b, a), w=w)
-            w, gd = group_delay((b, a), w=w)
-            assert_allclose(gd, 0)
+
+        w, gd = assert_warns(UserWarning, group_delay, (b, a), w=w)
+        assert_allclose(gd, 0)
 
 
 if __name__ == "__main__":

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -175,7 +175,6 @@ class TestTf2zpk(TestCase):
         assert_array_almost_equal(z, z_r)
         assert_array_almost_equal(p, p_r)
 
-    @dec.skipif(True, "Problem with warning filters, to be fixed by gh-5796")
     def test_bad_filter(self):
         # Regression test for #651: better handling of badly conditioned
         # filter coefficients.

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -213,6 +213,7 @@ class TestPlacePoles(TestCase):
         # Should not raise ValueError as the poles can be placed but should
         # raise a warning as the convergence is not reached
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             fsf = place_poles(A, B, (-1,-2,-3,-4), rtol=1e-16, maxiter=42)
             assert_(len(w) == 1)
             assert_(issubclass(w[-1].category, UserWarning))

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -5,6 +5,7 @@ import warnings
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_equal, assert_allclose,
                            assert_, assert_raises, TestCase, run_module_suite)
+from scipy._lib._numpy_compat import suppress_warnings
 from scipy.signal import (ss2tf, tf2ss, lsim2, impulse2, step2, lti,
                           dlti, bode, freqresp, lsim, impulse, step,
                           abcd_normalize, place_poles,
@@ -386,8 +387,8 @@ class TestSS2TF:
 
 class TestLsim(object):
     def lti_nowarn(self, *args):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", BadCoefficients)
+        with suppress_warnings() as sup:
+            sup.filter(BadCoefficients)
             system = lti(*args)
         return system
 
@@ -523,8 +524,8 @@ class Test_lsim2(object):
         D = np.zeros((1, 2))
 
         t = np.linspace(0, 10.0, 101)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", BadCoefficients)
+        with suppress_warnings() as sup:
+            sup.filter(BadCoefficients)
             tout, y, x = lsim2((A,B,C,D), T=t, X0=[1.0, 1.0])
         expected_y = np.exp(-tout)
         expected_x0 = np.exp(-tout)
@@ -1052,8 +1053,8 @@ class Test_bode(object):
         B = np.array([[0.0], [0.0], [1.0]])
         C = np.array([[1.0, 0.0, 0.0]])
         D = np.array([[0.0]])
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", BadCoefficients)
+        with suppress_warnings() as sup:
+            sup.filter(BadCoefficients)
             system = lti(A, B, C, D)
             w, mag, phase = bode(system, n=100)
 
@@ -1117,8 +1118,8 @@ class Test_freqresp(object):
         B = np.array([[0.0],[0.0],[1.0]])
         C = np.array([[1.0, 0.0, 0.0]])
         D = np.array([[0.0]])
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", BadCoefficients)
+        with suppress_warnings() as sup:
+            sup.filter(BadCoefficients)
             system = lti(A, B, C, D)
             w, H = freqresp(system, n=100)
         s = w * 1j

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -11,6 +11,7 @@ from numpy.testing import (
     TestCase, run_module_suite, assert_equal,
     assert_almost_equal, assert_array_equal, assert_array_almost_equal,
     assert_raises, assert_allclose, assert_, dec)
+from scipy._lib._numpy_compat import suppress_warnings
 from numpy import array, arange
 import numpy as np
 
@@ -20,8 +21,9 @@ from scipy.signal import (
     correlate, convolve, convolve2d, fftconvolve, hann, choose_conv_method,
     hilbert, hilbert2, lfilter, lfilter_zi, filtfilt, butter, zpk2tf, zpk2sos,
     invres, invresz, vectorstrength, lfiltic, tf2sos, sosfilt, sosfiltfilt,
-    sosfilt_zi, tf2zpk)
+    sosfilt_zi, tf2zpk, BadCoefficients)
 from scipy.signal.signaltools import _filtfilt_gust
+
 
 if sys.version_info.major >= 3 and sys.version_info.minor >= 5:
     from math import gcd
@@ -1672,10 +1674,14 @@ class TestDecimate(TestCase):
         assert_equal(d1.shape, (30, 15))
 
     def test_phaseshift_FIR(self):
-        self._test_phaseshift(method='fir', zero_phase=False)
+        with suppress_warnings() as sup:
+            sup.filter(BadCoefficients, "Badly conditioned filter")
+            self._test_phaseshift(method='fir', zero_phase=False)
 
     def test_zero_phase_FIR(self):
-        self._test_phaseshift(method='fir', zero_phase=True)
+        with suppress_warnings() as sup:
+            sup.filter(BadCoefficients, "Badly conditioned filter")
+            self._test_phaseshift(method='fir', zero_phase=True)
 
     def test_phaseshift_IIR(self):
         self._test_phaseshift(method='iir', zero_phase=False)

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -310,6 +310,9 @@ class TestSplu(object):
 
     @sup_sparse_efficiency
     def test_splu_smoketest(self):
+        self._internal_test_splu_smoketest()
+
+    def _internal_test_splu_smoketest(self):
         # Check that splu works at all
         def check(A, b, x, msg=""):
             eps = np.finfo(A.dtype).eps
@@ -323,6 +326,9 @@ class TestSplu(object):
 
     @sup_sparse_efficiency
     def test_spilu_smoketest(self):
+        self._internal_test_spilu_smoketest()
+
+    def _internal_test_spilu_smoketest(self):
         errors = []
 
         def check(A, b, x, msg=""):
@@ -339,6 +345,7 @@ class TestSplu(object):
 
         assert_(max(errors) > 1e-5)
 
+    @sup_sparse_efficiency
     def test_spilu_drop_rule(self):
         # Test passing in the drop_rule argument to spilu.
         A = identity(2)
@@ -492,14 +499,15 @@ class TestSplu(object):
         check(np.complex64, True)
         check(np.complex128, True)
 
+    @sup_sparse_efficiency
     def test_threads_parallel(self):
         oks = []
 
         def worker():
             try:
                 self.test_splu_basic()
-                self.test_splu_smoketest()
-                self.test_spilu_smoketest()
+                self._internal_test_splu_smoketest()
+                self._internal_test_spilu_smoketest()
                 oks.append(True)
             except:
                 pass
@@ -523,6 +531,7 @@ class TestSpsolveTriangular(TestCase):
         for lower in (True, False):
             assert_raises(scipy.linalg.LinAlgError, spsolve_triangular, A, b, lower=lower)
 
+    @sup_sparse_efficiency
     def test_bad_shape(self):
         # A is not square.
         A = np.zeros((3, 4))
@@ -533,6 +542,7 @@ class TestSpsolveTriangular(TestCase):
         b2 = array([1.0, 2.0])
         assert_raises(ValueError, spsolve_triangular, A2, b2)
 
+    @sup_sparse_efficiency
     def test_input_types(self):
         A = array([[1., 0.], [1., 2.]])
         b = array([[2., 0.], [2., 2.]])
@@ -540,6 +550,7 @@ class TestSpsolveTriangular(TestCase):
             x = spsolve_triangular(matrix_type(A), b, lower=True)
             assert_array_almost_equal(A.dot(x), b)
 
+    @sup_sparse_efficiency
     def test_random(self):
         def random_triangle_matrix(n, lower=True):
             A = scipy.sparse.random(n, n, density=0.1, format='coo')

--- a/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/dsolve/tests/test_linsolve.py
@@ -18,7 +18,11 @@ from scipy.sparse.linalg import SuperLU
 from scipy.sparse.linalg.dsolve import (spsolve, use_solver, splu, spilu,
         MatrixRankWarning, _superlu, spsolve_triangular)
 
-warnings.simplefilter('ignore',SparseEfficiencyWarning)
+from scipy._lib._numpy_compat import suppress_warnings
+
+
+sup_sparse_efficiency = suppress_warnings()
+sup_sparse_efficiency.filter(SparseEfficiencyWarning)
 
 # TODO add more comprehensive tests
 use_solver(useUmfpack=False)
@@ -100,38 +104,37 @@ class TestLinsolve(TestCase):
         x2 = spsolve(As, Bs)
         assert_array_almost_equal(x, x2.todense())
 
+    @sup_sparse_efficiency
     def test_non_square(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=SparseEfficiencyWarning)
-            # A is not square.
-            A = ones((3, 4))
-            b = ones((4, 1))
-            assert_raises(ValueError, spsolve, A, b)
-            # A2 and b2 have incompatible shapes.
-            A2 = csc_matrix(eye(3))
-            b2 = array([1.0, 2.0])
-            assert_raises(ValueError, spsolve, A2, b2)
+        # A is not square.
+        A = ones((3, 4))
+        b = ones((4, 1))
+        assert_raises(ValueError, spsolve, A, b)
+        # A2 and b2 have incompatible shapes.
+        A2 = csc_matrix(eye(3))
+        b2 = array([1.0, 2.0])
+        assert_raises(ValueError, spsolve, A2, b2)
 
+    @sup_sparse_efficiency
     def test_example_comparison(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=SparseEfficiencyWarning)
-            row = array([0,0,1,2,2,2])
-            col = array([0,2,2,0,1,2])
-            data = array([1,2,3,-4,5,6])
-            sM = csr_matrix((data,(row,col)), shape=(3,3), dtype=float)
-            M = sM.todense()
+        row = array([0,0,1,2,2,2])
+        col = array([0,2,2,0,1,2])
+        data = array([1,2,3,-4,5,6])
+        sM = csr_matrix((data,(row,col)), shape=(3,3), dtype=float)
+        M = sM.todense()
 
-            row = array([0,0,1,1,0,0])
-            col = array([0,2,1,1,0,0])
-            data = array([1,1,1,1,1,1])
-            sN = csr_matrix((data, (row,col)), shape=(3,3), dtype=float)
-            N = sN.todense()
+        row = array([0,0,1,1,0,0])
+        col = array([0,2,1,1,0,0])
+        data = array([1,1,1,1,1,1])
+        sN = csr_matrix((data, (row,col)), shape=(3,3), dtype=float)
+        N = sN.todense()
 
-            sX = spsolve(sM, sN)
-            X = scipy.linalg.solve(M, N)
+        sX = spsolve(sM, sN)
+        X = scipy.linalg.solve(M, N)
 
-            assert_array_almost_equal(X, sX.todense())
+        assert_array_almost_equal(X, sX.todense())
 
+    @sup_sparse_efficiency
     def test_shape_compatibility(self):
         A = csc_matrix([[1., 0], [0, 2]])
         bs = [
@@ -186,6 +189,7 @@ class TestLinsolve(TestCase):
         b = csc_matrix((1, 3))
         assert_raises(ValueError, spsolve, A, b)
 
+    @sup_sparse_efficiency
     def test_ndarray_support(self):
         A = array([[1., 2.], [2., 0.]])
         x = array([[1., 1.], [0.5, -0.5]])
@@ -304,40 +308,36 @@ class TestSplu(object):
             x = lu.solve(b, 'H')
             check(A.T.conj(), b, x, msg)
 
+    @sup_sparse_efficiency
     def test_splu_smoketest(self):
         # Check that splu works at all
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=SparseEfficiencyWarning)
+        def check(A, b, x, msg=""):
+            eps = np.finfo(A.dtype).eps
+            r = A * x
+            assert_(abs(r - b).max() < 1e3*eps, msg)
 
-            def check(A, b, x, msg=""):
-                eps = np.finfo(A.dtype).eps
-                r = A * x
-                assert_(abs(r - b).max() < 1e3*eps, msg)
+        self._smoketest(splu, check, np.float32)
+        self._smoketest(splu, check, np.float64)
+        self._smoketest(splu, check, np.complex64)
+        self._smoketest(splu, check, np.complex128)
 
-            self._smoketest(splu, check, np.float32)
-            self._smoketest(splu, check, np.float64)
-            self._smoketest(splu, check, np.complex64)
-            self._smoketest(splu, check, np.complex128)
-
+    @sup_sparse_efficiency
     def test_spilu_smoketest(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=SparseEfficiencyWarning)
+        errors = []
 
-            errors = []
+        def check(A, b, x, msg=""):
+            r = A * x
+            err = abs(r - b).max()
+            assert_(err < 1e-2, msg)
+            if b.dtype in (np.float64, np.complex128):
+                errors.append(err)
 
-            def check(A, b, x, msg=""):
-                r = A * x
-                err = abs(r - b).max()
-                assert_(err < 1e-2, msg)
-                if b.dtype in (np.float64, np.complex128):
-                    errors.append(err)
+        self._smoketest(spilu, check, np.float32)
+        self._smoketest(spilu, check, np.float64)
+        self._smoketest(spilu, check, np.complex64)
+        self._smoketest(spilu, check, np.complex128)
 
-            self._smoketest(spilu, check, np.float32)
-            self._smoketest(spilu, check, np.float64)
-            self._smoketest(spilu, check, np.complex64)
-            self._smoketest(spilu, check, np.complex128)
-
-            assert_(max(errors) > 1e-5)
+        assert_(max(errors) > 1e-5)
 
     def test_spilu_drop_rule(self):
         # Test passing in the drop_rule argument to spilu.
@@ -440,6 +440,7 @@ class TestSplu(object):
             assert_raises(TypeError, lu.solve,
                           b.astype(np.complex128))
 
+    @sup_sparse_efficiency
     def test_superlu_dlamch_i386_nan(self):
         # SuperLU 4.3 calls some functions returning floats without
         # declaring them. On i386@linux call convention, this fails to
@@ -456,6 +457,7 @@ class TestSplu(object):
         B = A.A
         assert_(not np.isnan(B).any())
 
+    @sup_sparse_efficiency
     def test_lu_attr(self):
 
         def check(dtype, complex_2=False):

--- a/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/tests/test_arpack.py
@@ -6,6 +6,7 @@ To run tests locally:
 
 """
 
+
 import warnings
 import threading
 
@@ -25,19 +26,21 @@ from scipy.sparse.linalg.eigen.arpack import eigs, eigsh, svds, \
 from scipy.linalg import svd, hilbert
 
 from scipy._lib._gcutils import assert_deallocated
+from scipy._lib._numpy_compat import suppress_warnings
 
 
 # eigs() and eigsh() are called many times, so apply a filter for the warnings
 # they generate here.
-_eigs_warn_msg = "Single-precision types in `eigs` and `eighs`"
+sup = suppress_warnings()
+sup.filter(message="Single-precision types in `eigs` and `eighs`")
 
 
 def setup_module():
-    warnings.filterwarnings("ignore", message=_eigs_warn_msg)
+    sup.__enter__()
 
 
 def teardown_module():
-    warnings.filterwarnings("default", message=_eigs_warn_msg)
+    sup.__exit__()
 
 
 # precision for tests

--- a/scipy/spatial/tests/test__plotutils.py
+++ b/scipy/spatial/tests/test__plotutils.py
@@ -1,12 +1,14 @@
 from __future__ import division, print_function, absolute_import
 
 from numpy.testing import dec, assert_, assert_array_equal
+from scipy._lib._numpy_compat import suppress_warnings
 
 try:
     import matplotlib
     matplotlib.rcParams['backend'] = 'Agg'
     import matplotlib.pyplot as plt
     from matplotlib.collections import LineCollection
+    from matplotlib import MatplotlibDeprecationWarning
     has_matplotlib = True
 except:
     has_matplotlib = False
@@ -25,7 +27,10 @@ class TestPlotting:
         fig = plt.figure()
         obj = Delaunay(self.points)
         s_before = obj.simplices.copy()
-        r = delaunay_plot_2d(obj, ax=fig.gca())
+        with suppress_warnings as sup:
+            # filter can be removed when matplotlib 1.x is dropped
+            sup.filter(message="The ishold function was deprecated in version")
+            r = delaunay_plot_2d(obj, ax=fig.gca())
         assert_array_equal(obj.simplices, s_before)  # shouldn't modify
         assert_(r is fig)
         delaunay_plot_2d(obj, ax=fig.gca())
@@ -35,7 +40,10 @@ class TestPlotting:
         # Smoke test
         fig = plt.figure()
         obj = Voronoi(self.points)
-        r = voronoi_plot_2d(obj, ax=fig.gca())
+        with suppress_warnings as sup:
+            # filter can be removed when matplotlib 1.x is dropped
+            sup.filter(message="The ishold function was deprecated in version")
+            r = voronoi_plot_2d(obj, ax=fig.gca())
         assert_(r is fig)
         voronoi_plot_2d(obj)
         voronoi_plot_2d(obj, show_vertices=False)
@@ -45,6 +53,9 @@ class TestPlotting:
         # Smoke test
         fig = plt.figure()
         tri = ConvexHull(self.points)
-        r = convex_hull_plot_2d(tri, ax=fig.gca())
+        with suppress_warnings as sup:
+            # filter can be removed when matplotlib 1.x is dropped
+            sup.filter(message="The ishold function was deprecated in version")
+            r = convex_hull_plot_2d(tri, ax=fig.gca())
         assert_(r is fig)
         convex_hull_plot_2d(tri)


### PR DESCRIPTION
On my system there are two warnin changes remaining after running
the test. The Special function add an always filter during
import and one downstream package does the same.
## 

Relies on copy pasting suppress_warnings from numpy, this is not yet merged so there might be API flux, which would have to be copied over if merged.
