### PR TITLE
DOC: Clarify the computation of weighted minkowski

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -200,7 +200,7 @@ def wminkowski(u, v, p, w):
 
     .. math::
 
-       \\left(\\sum{(w_i |u_i - v_i|^p)}\\right)^{1/p}.
+       \\left(\\sum{(|w_i (u_i - v_i)|^p)}\\right)^{1/p}.
 
     Parameters
     ----------


### PR DESCRIPTION
Clarify that the weights are powered in the computation of weighted minkowski distance in cdist. closes gh-5718
