### PR TITLE
BUG: Ensure scipy's _asfarray returns ndarray

### DIFF
--- a/scipy/fftpack/basic.py
+++ b/scipy/fftpack/basic.py
@@ -125,7 +125,10 @@ def _asfarray(x):
     already an array with a float dtype, and do not cast complex types to
     real."""
     if hasattr(x, "dtype") and x.dtype.char in numpy.typecodes["AllFloat"]:
-        return x
+        # 'dtype' attribute does not ensure that the
+        # object is an ndarray (e.g. Series class
+        # from the pandas library)
+        return numpy.asarray(x, dtype=x.dtype)
     else:
         # We cannot use asfarray directly because it converts sequences of
         # complex to sequence of real

--- a/scipy/fftpack/tests/test_basic.py
+++ b/scipy/fftpack/tests/test_basic.py
@@ -324,6 +324,29 @@ class _TestRFFTBase(TestCase):
         assert_raises(ValueError, rfft, [])
         assert_raises(ValueError, rfft, [[1,1],[2,2]], -5)
 
+    # See gh-5790
+    class MockSeries(object):
+        def __init__(self, data):
+            self.data = np.asarray(data)
+
+        def __getattr__(self, item):
+            try:
+                return getattr(self.data, item)
+            except AttributeError:
+                raise AttributeError(("'MockSeries' object "
+                                      "has no attribute '{attr}'".
+                                      format(attr=item)))
+
+    def test_non_ndarray_with_dtype(self):
+        x = np.array([1., 2., 3., 4., 5.])
+        xs = _TestRFFTBase.MockSeries(x)
+
+        expected = [1, 2, 3, 4, 5]
+        out = rfft(xs)
+
+        # Data should not have been overwritten
+        assert_equal(x, expected)
+        assert_equal(xs.data, expected)
 
 class TestRFFTDouble(_TestRFFTBase):
     def setUp(self):


### PR DESCRIPTION
Addresses issue in #5790 in which non-`ndarray` "array" objects (e.g. `pandas.Series`) with `dtype` attributes were having their data overwritten when calling methods like `fftpack.rfft` by `_asfarray` falsely assumed that having a `dtype` attribute implies being an `ndarray`.
