### PR TITLE
ENH: Added iqr function to compute IQR metric in scipy/stats/stats.py

### DIFF
--- a/doc/release/0.18.0-notes.rst
+++ b/doc/release/0.18.0-notes.rst
@@ -22,7 +22,7 @@ New features
 ============
 
 Random matrices
-~~~~~~~~~~~~~~~
+---------------
 
 `scipy.stats.special_ortho_group` and `scipy.stats.ortho_group` provide
 generators of random matrices in the SO(N) and O(N) groups, respectively. They
@@ -64,6 +64,11 @@ The functions `sum`, `max`, `mean`, `min`, `transpose`, and `reshape` in
 `scipy.sparse` have had their signatures augmented with additional arguments
 and functionality so as to improve compatibility with analogously defined
 functions in `numpy`.
+
+new `scipy.stats.iqr` function
+------------------------------
+
+Computes the interquartile region of a distribution.
 
 Deprecated features
 ===================

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -210,6 +210,7 @@ which work for masked arrays.
    sem
    zmap
    zscore
+   iqr
 
 .. autosummary::
    :toctree: generated/

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1434,7 +1434,7 @@ class TestVariability(TestCase):
         assert_array_almost_equal(z[1], z1_expected)
 
 
-class _numpy_version_warn_context_mgr:
+class _numpy_version_warn_context_mgr(object):
     """
     A simple context maneger class to avoid retyping the same code for
     different versions of numpy when the only difference is that older
@@ -1471,8 +1471,8 @@ def _check_warnings(warn_list, expected_type, expected_len):
     contains expected number of warnings. 
     """
     assert_equal(len(warn_list), expected_len, "number of warnings")
-    for i in range(len(warn_list)):
-        assert_(warn_list[i].category is expected_type)
+    for warn_ in warn_list:
+        assert_(warn_.category is expected_type)
 
 
 class TestIQR(TestCase):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -24,6 +24,8 @@ import numpy as np
 
 import scipy.stats as stats
 import scipy.stats.mstats as mstats
+from scipy._lib._version import NumpyVersion
+from scipy._lib.six import xrange
 from common_tests import check_named_results
 
 """ Numbers in docstrings beginning with 'W' refer to the section numbers
@@ -49,7 +51,6 @@ LITTLE = array([0.99999991,0.99999992,0.99999993,0.99999994,0.99999995,0.9999999
 HUGE = array([1e+12,2e+12,3e+12,4e+12,5e+12,6e+12,7e+12,8e+12,9e+12], float)
 TINY = array([1e-12,2e-12,3e-12,4e-12,5e-12,6e-12,7e-12,8e-12,9e-12], float)
 ROUND = array([0.5,1.5,2.5,3.5,4.5,5.5,6.5,7.5,8.5], float)
-
 
 class TestTrimmedStats(TestCase):
     # TODO: write these tests to handle missing values properly
@@ -1431,6 +1432,372 @@ class TestVariability(TestCase):
         z1_expected = np.array([-1.5, -0.5, 0.5, 1.5])/(np.sqrt(5./3))
         assert_array_almost_equal(z[0], z0_expected)
         assert_array_almost_equal(z[1], z1_expected)
+
+
+class _numpy_version_warn_context_mgr:
+    """
+    A simple context maneger class to avoid retyping the same code for
+    different versions of numpy when the only difference is that older
+    versions raise warnings.
+
+    This manager does not apply for cases where the old code returns
+    different values. 
+    """
+    def __init__(self, min_numpy_version, warning_type, num_warnings):
+        if NumpyVersion(np.__version__) < min_numpy_version:
+            self.numpy_is_old = True
+            self.warning_type = warning_type
+            self.num_warnings = num_warnings
+            self.delegate = warnings.catch_warnings(record = True)
+        else:
+            self.numpy_is_old = False
+
+    def __enter__(self):
+        if self.numpy_is_old:
+            self.warn_list = self.delegate.__enter__()
+            warnings.simplefilter("always")
+        return None
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.numpy_is_old:
+            self.delegate.__exit__(exc_type, exc_value, traceback)
+            _check_warnings(self.warn_list, self.warning_type, self.num_warnings) 
+
+
+def _check_warnings(warn_list, expected_type, expected_len):
+    """
+    Checks that all of the warnings from a list returned by
+    `warnings.catch_all(record=True)` are of the required type and that the list
+    contains expected number of warnings. 
+    """
+    assert_equal(len(warn_list), expected_len, "number of warnings")
+    for i in range(len(warn_list)):
+        assert_(warn_list[i].category is expected_type)
+
+
+class TestIQR(TestCase):
+
+    def test_basic(self):
+        x = np.arange(8) * 0.5
+        np.random.shuffle(x)
+        assert_equal(stats.iqr(x), 1.75)
+
+    def test_api(self):
+        d = np.ones((5, 5))
+        stats.iqr(d)
+        stats.iqr(d, None)
+        stats.iqr(d, 1)
+        stats.iqr(d, (0, 1))
+        stats.iqr(d, None, (10, 90))
+        stats.iqr(d, None, (30, 20), 'raw')
+        stats.iqr(d, None, (25, 75), 1.5, 'propagate')
+        if NumpyVersion(np.__version__) >= '1.9.0a':
+            stats.iqr(d, None, (50, 50), 'normal', 'raise', 'linear')
+            stats.iqr(d, None, (25, 75), -0.4, 'omit', 'lower', True)
+
+    def test_empty(self):
+        assert_equal(stats.iqr([]), np.nan)
+        assert_equal(stats.iqr(np.arange(0)), np.nan)
+
+    def test_constant(self):
+        # Constant array always gives 0
+        x = np.ones((7, 4))
+        assert_equal(stats.iqr(x), 0.0)
+        assert_array_equal(stats.iqr(x, axis=0), np.zeros(4))
+        assert_array_equal(stats.iqr(x, axis=1), np.zeros(7))
+        # Even for older versions, 'linear' does not raise a warning
+        with _numpy_version_warn_context_mgr('1.9.0a', RuntimeWarning, 4):
+            assert_equal(stats.iqr(x, interpolation='linear'), 0.0)
+            assert_equal(stats.iqr(x, interpolation='midpoint'), 0.0)
+            assert_equal(stats.iqr(x, interpolation='nearest'), 0.0)
+            assert_equal(stats.iqr(x, interpolation='lower'), 0.0)
+            assert_equal(stats.iqr(x, interpolation='higher'), 0.0)
+
+        # 0 only along constant dimensions 
+        # This also tests much of `axis`
+        y = np.ones((4, 5, 6)) * np.arange(6)
+        assert_array_equal(stats.iqr(y, axis=0), np.zeros((5, 6)))
+        assert_array_equal(stats.iqr(y, axis=1), np.zeros((4, 6)))
+        assert_array_equal(stats.iqr(y, axis=2), 2.5 * np.ones((4, 5)))
+        assert_array_equal(stats.iqr(y, axis=(0, 1)), np.zeros(6))
+        assert_array_equal(stats.iqr(y, axis=(0, 2)), 3. * np.ones(5))
+        assert_array_equal(stats.iqr(y, axis=(1, 2)), 3. * np.ones(4))
+
+    def test_scalarlike(self):
+        x = np.arange(1) + 7.0
+        assert_equal(stats.iqr(x[0]), 0.0)
+        assert_equal(stats.iqr(x), 0.0)
+        if NumpyVersion(np.__version__) >= '1.9.0a':
+            assert_array_equal(stats.iqr(x, keepdims=True), [0.0])
+        else:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                assert_array_equal(stats.iqr(x, keepdims=True), 0.0)
+                _check_warnings(w, RuntimeWarning, 1)
+
+    def test_2D(self):
+        x = np.arange(15).reshape((3, 5))
+        assert_equal(stats.iqr(x), 7.0)
+        assert_array_equal(stats.iqr(x, axis=0), 5. * np.ones(5))
+        assert_array_equal(stats.iqr(x, axis=1), 2. * np.ones(3))
+        assert_array_equal(stats.iqr(x, axis=(0, 1)), 7.0)
+        assert_array_equal(stats.iqr(x, axis=(1, 0)), 7.0)
+
+    def test_axis(self):
+        # The `axis` keyword is also put through its paces in `test_keepdims`.
+        o = np.random.normal(size=(71, 23))
+        x = np.dstack([o] * 10)                 # x.shape = (71, 23, 10)
+        q = stats.iqr(o)
+
+        assert_equal(stats.iqr(x, axis=(0, 1)), q)
+        x = np.rollaxis(x, -1, 0)               # x.shape = (10, 71, 23)
+        assert_equal(stats.iqr(x, axis=(2, 1)), q)
+        x = x.swapaxes(0, 1)                    # x.shape = (71, 10, 23)
+        assert_equal(stats.iqr(x, axis=(0, 2)), q)
+        x = x.swapaxes(0, 1)                    # x.shape = (10, 71, 23)
+
+        assert_equal(stats.iqr(x, axis=(0, 1, 2)),
+                     stats.iqr(x, axis=None))
+        assert_equal(stats.iqr(x, axis=(0,)),
+                     stats.iqr(x, axis=0))
+
+        d = np.arange(3 * 5 * 7 * 11)
+        # Older versions of numpy only shuffle along axis=0.
+        # Not sure about newer, don't care.
+        np.random.shuffle(d)
+        d = d.reshape((3, 5, 7, 11))
+        assert_equal(stats.iqr(d, axis=(0, 1, 2))[0],
+                     stats.iqr(d[:,:,:, 0].ravel()))
+        assert_equal(stats.iqr(d, axis=(0, 1, 3))[1],
+                     stats.iqr(d[:,:, 1,:].ravel()))
+        assert_equal(stats.iqr(d, axis=(3, 1, -4))[2],
+                     stats.iqr(d[:,:, 2,:].ravel()))
+        assert_equal(stats.iqr(d, axis=(3, 1, 2))[2],
+                     stats.iqr(d[2,:,:,:].ravel()))
+        assert_equal(stats.iqr(d, axis=(3, 2))[2, 1],
+                     stats.iqr(d[2, 1,:,:].ravel()))
+        assert_equal(stats.iqr(d, axis=(1, -2))[2, 1],
+                     stats.iqr(d[2, :, :, 1].ravel()))
+        assert_equal(stats.iqr(d, axis=(1, 3))[2, 2],
+                     stats.iqr(d[2, :, 2,:].ravel()))
+
+        if NumpyVersion(np.__version__) >= '1.9.0a':
+            assert_raises(IndexError, stats.iqr, d, axis=4)
+        else:
+            assert_raises(ValueError, stats.iqr, d, axis=4)
+        assert_raises(ValueError, stats.iqr, d, axis=(0, 0))
+
+    def test_rng(self):
+        x = np.arange(5)
+        assert_equal(stats.iqr(x), 2)
+        assert_equal(stats.iqr(x, rng=(25, 87.5)), 2.5)
+        assert_equal(stats.iqr(x, rng=(12.5, 75)), 2.5)
+        assert_almost_equal(stats.iqr(x, rng=(10, 50)), 1.6)  # 3-1.4
+
+        assert_raises(ValueError, stats.iqr, x, rng=(0, 101))
+        assert_raises(ValueError, stats.iqr, x, rng=(np.nan, 25))
+        assert_raises(TypeError, stats.iqr, x, rng=(0, 50, 60))
+
+    def test_interpolation(self):
+        x = np.arange(5)
+        y = np.arange(4)
+        # Default
+        assert_equal(stats.iqr(x), 2)
+        assert_equal(stats.iqr(y), 1.5)
+        if NumpyVersion(np.__version__) >= '1.9.0a':
+            # Linear
+            assert_equal(stats.iqr(x, interpolation='linear'), 2)
+            assert_equal(stats.iqr(y, interpolation='linear'), 1.5)
+            # Higher
+            assert_equal(stats.iqr(x, interpolation='higher'), 2)
+            assert_equal(stats.iqr(x, rng=(25, 80), interpolation='higher'), 3)
+            assert_equal(stats.iqr(y, interpolation='higher'), 2)
+            # Lower (will generally, but not always be the same as higher)
+            assert_equal(stats.iqr(x, interpolation='lower'), 2)
+            assert_equal(stats.iqr(x, rng=(25, 80), interpolation='lower'), 2)
+            assert_equal(stats.iqr(y, interpolation='lower'), 2)
+            # Nearest
+            assert_equal(stats.iqr(x, interpolation='nearest'), 2)
+            assert_equal(stats.iqr(y, interpolation='nearest'), 1)
+            # Midpoint
+            if NumpyVersion(np.__version__) >= '1.11.0a':
+                assert_equal(stats.iqr(x, interpolation='midpoint'), 2)
+                assert_equal(stats.iqr(x, rng=(25, 80), interpolation='midpoint'), 2.5)
+                assert_equal(stats.iqr(y, interpolation='midpoint'), 2)
+            else:
+                # midpoint did not work correctly before numpy 1.11.0
+                assert_equal(stats.iqr(x, interpolation='midpoint'), 2)
+                assert_equal(stats.iqr(x, rng=(25, 80), interpolation='midpoint'), 2)
+                assert_equal(stats.iqr(y, interpolation='midpoint'), 2)
+        else:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                # Linear
+                assert_equal(stats.iqr(x, interpolation='linear'), 2)
+                assert_equal(stats.iqr(y, interpolation='linear'), 1.5)
+                # Higher
+                assert_equal(stats.iqr(x, interpolation='higher'), 2)
+                assert_almost_equal(stats.iqr(x, rng=(25, 80), interpolation='higher'), 2.2)
+                assert_equal(stats.iqr(y, interpolation='higher'), 1.5)
+                # Lower
+                assert_equal(stats.iqr(x, interpolation='lower'), 2)
+                assert_almost_equal(stats.iqr(x, rng=(25, 80), interpolation='lower'), 2.2)
+                assert_equal(stats.iqr(y, interpolation='lower'), 1.5)
+                # Nearest
+                assert_equal(stats.iqr(x, interpolation='nearest'), 2)
+                assert_equal(stats.iqr(y, interpolation='nearest'), 1.5)
+                # Midpoint
+                assert_equal(stats.iqr(x, interpolation='midpoint'), 2)
+                assert_almost_equal(stats.iqr(x, rng=(25, 80), interpolation='midpoint'), 2.2)
+                assert_equal(stats.iqr(y, interpolation='midpoint'), 1.5)
+                _check_warnings(w, RuntimeWarning, 11)
+
+        if NumpyVersion(np.__version__) >= '1.9.0a':
+            assert_raises(ValueError, stats.iqr, x, interpolation='foobar')
+        else:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                assert_equal(stats.iqr(x, interpolation='foobar'), 2)
+                _check_warnings(w, RuntimeWarning, 1)
+
+    def test_keepdims(self):
+        numpy_version = NumpyVersion(np.__version__)
+
+        # Also tests most of `axis`
+        x = np.ones((3, 5, 7, 11))
+        assert_equal(stats.iqr(x, axis=None, keepdims=False).shape, ())
+        assert_equal(stats.iqr(x, axis=2, keepdims=False).shape, (3, 5, 11))
+        assert_equal(stats.iqr(x, axis=(0, 1), keepdims=False).shape, (7, 11))
+        assert_equal(stats.iqr(x, axis=(0, 3), keepdims=False).shape, (5, 7))
+        assert_equal(stats.iqr(x, axis=(1,), keepdims=False).shape, (3, 7, 11))
+        assert_equal(stats.iqr(x, (0, 1, 2, 3), keepdims=False).shape, ())
+        assert_equal(stats.iqr(x, axis=(0, 1, 3), keepdims=False).shape, (7,))
+
+        if numpy_version >= '1.9.0a':
+            assert_equal(stats.iqr(x, axis=None, keepdims=True).shape, (1, 1, 1, 1))
+            assert_equal(stats.iqr(x, axis=2, keepdims=True).shape, (3, 5, 1, 11))
+            assert_equal(stats.iqr(x, axis=(0, 1), keepdims=True).shape, (1, 1, 7, 11))
+            assert_equal(stats.iqr(x, axis=(0, 3), keepdims=True).shape, (1, 5, 7, 1))
+            assert_equal(stats.iqr(x, axis=(1,), keepdims=True).shape, (3, 1, 7, 11))
+            assert_equal(stats.iqr(x, (0, 1, 2, 3), keepdims=True).shape, (1, 1, 1, 1))
+            assert_equal(stats.iqr(x, axis=(0, 1, 3), keepdims=True).shape, (1, 1, 7, 1))
+        else:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                assert_equal(stats.iqr(x, axis=None, keepdims=True).shape, ())
+                assert_equal(stats.iqr(x, axis=2, keepdims=True).shape, (3, 5, 11))
+                assert_equal(stats.iqr(x, axis=(0, 1), keepdims=True).shape, (7, 11))
+                assert_equal(stats.iqr(x, axis=(0, 3), keepdims=True).shape, (5, 7))
+                assert_equal(stats.iqr(x, axis=(1,), keepdims=True).shape, (3, 7, 11))
+                assert_equal(stats.iqr(x, (0, 1, 2, 3), keepdims=True).shape, ())
+                assert_equal(stats.iqr(x, axis=(0, 1, 3), keepdims=True).shape, (7,))
+                _check_warnings(w, RuntimeWarning, 7)
+
+    def test_nanpolicy(self):
+        numpy_version = NumpyVersion(np.__version__)
+        x = np.arange(15.0).reshape((3, 5))
+
+        # No NaNs
+        assert_equal(stats.iqr(x, nan_policy='propagate'), 7)
+        assert_equal(stats.iqr(x, nan_policy='omit'), 7)
+        assert_equal(stats.iqr(x, nan_policy='raise'), 7)
+
+        # Yes NaNs
+        x[1, 2] = np.nan
+        if numpy_version < '1.10.0a':
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                # Fails over to mishmash of omit/propagate, but mostly omit
+                # The first case showcases the "incorrect" behavior of np.percentile
+                assert_equal(stats.iqr(x, nan_policy='propagate'), 8)
+                assert_equal(stats.iqr(x, axis=0, nan_policy='propagate'), [5, 5, np.nan, 5, 5])
+                if numpy_version < '1.9.0a':
+                    assert_equal(stats.iqr(x, axis=1, nan_policy='propagate'), [2, 3, 2])
+                else:
+                    # some fixes to percentile nan handling in 1.9
+                    assert_equal(stats.iqr(x, axis=1, nan_policy='propagate'), [2, np.nan, 2])
+                _check_warnings(w, RuntimeWarning, 3)
+        else:
+            assert_equal(stats.iqr(x, nan_policy='propagate'), np.nan)
+            assert_equal(stats.iqr(x, axis=0, nan_policy='propagate'), [5, 5, np.nan, 5, 5])
+            assert_equal(stats.iqr(x, axis=1, nan_policy='propagate'), [2, np.nan, 2])
+
+        if numpy_version < '1.9.0a':
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                # Fails over to mishmash of omit/propagate, but mostly omit
+                assert_equal(stats.iqr(x, nan_policy='omit'), 8)
+                assert_equal(stats.iqr(x, axis=0, nan_policy='omit'), [5, 5, np.nan, 5, 5])
+                assert_equal(stats.iqr(x, axis=1, nan_policy='omit'), [2, 3, 2])
+                _check_warnings(w, RuntimeWarning, 3)
+        else:
+            assert_equal(stats.iqr(x, nan_policy='omit'), 7.5)
+            assert_equal(stats.iqr(x, axis=0, nan_policy='omit'), 5 * np.ones(5))
+            assert_equal(stats.iqr(x, axis=1, nan_policy='omit'), [2, 2.5, 2])
+
+        assert_raises(ValueError, stats.iqr, x, nan_policy='raise')
+        assert_raises(ValueError, stats.iqr, x, axis=0, nan_policy='raise')
+        assert_raises(ValueError, stats.iqr, x, axis=1, nan_policy='raise')
+
+        # Bad policy
+        assert_raises(ValueError, stats.iqr, x, nan_policy='barfood')
+
+    def test_scale(self):
+        numpy_version = NumpyVersion(np.__version__)
+        x = np.arange(15.0).reshape((3, 5))
+
+        # No NaNs
+        assert_equal(stats.iqr(x, scale='raw'), 7)
+        assert_almost_equal(stats.iqr(x, scale='normal'), 7 / 1.3489795)
+        assert_equal(stats.iqr(x, scale=2.0), 3.5)
+
+        # Yes NaNs
+        x[1, 2] = np.nan
+        if numpy_version < '1.10.0a':
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                # Fails over to mishmash of omit/propagate, but mostly omit
+                assert_equal(stats.iqr(x, scale='raw', nan_policy='propagate'), 8)
+                assert_almost_equal(stats.iqr(x, scale='normal', nan_policy='propagate'), 8 / 1.3489795)
+                assert_equal(stats.iqr(x, scale=2.0, nan_policy='propagate'), 4)
+                # axis=1 chosen to show behavior with both nans and without
+                if numpy_version < '1.9.0a':
+                    assert_equal(stats.iqr(x, axis=1, nan_policy='propagate'), [2, 3, 2])
+                    assert_almost_equal(stats.iqr(x, axis=1, scale='normal', nan_policy='propagate'), np.array([2, 3, 2]) / 1.3489795)
+                    assert_equal(stats.iqr(x, axis=1, scale=2.0, nan_policy='propagate'), [1, 1.5, 1])
+                else:
+                    # some fixes to percentile nan handling in 1.9
+                    assert_equal(stats.iqr(x, axis=1, nan_policy='propagate'), [2, np.nan, 2])
+                    assert_almost_equal(stats.iqr(x, axis=1, scale='normal', nan_policy='propagate'), np.array([2, np.nan, 2]) / 1.3489795)
+                    assert_equal(stats.iqr(x, axis=1, scale=2.0, nan_policy='propagate'), [1, np.nan, 1])
+                _check_warnings(w, RuntimeWarning, 6)
+        else:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                assert_equal(stats.iqr(x, scale='raw', nan_policy='propagate'), np.nan)
+                assert_equal(stats.iqr(x, scale='normal', nan_policy='propagate'), np.nan)
+                assert_equal(stats.iqr(x, scale=2.0, nan_policy='propagate'), np.nan)
+                # axis=1 chosen to show behavior with both nans and without
+                assert_equal(stats.iqr(x, axis=1, scale='raw', nan_policy='propagate'), [2, np.nan, 2])
+                assert_almost_equal(stats.iqr(x, axis=1, scale='normal', nan_policy='propagate'), np.array([2, np.nan, 2]) / 1.3489795)
+                assert_equal(stats.iqr(x, axis=1, scale=2.0, nan_policy='propagate'), [1, np.nan, 1])
+                _check_warnings(w, RuntimeWarning, 6)
+
+        if numpy_version < '1.9.0a':
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                # Fails over to mishmash of omit/propagate, but mostly omit
+                assert_equal(stats.iqr(x, scale='raw', nan_policy='omit'), 8)
+                assert_almost_equal(stats.iqr(x, scale='normal', nan_policy='omit'), 8 / 1.3489795)
+                assert_equal(stats.iqr(x, scale=2.0, nan_policy='omit'), 4)
+                _check_warnings(w, RuntimeWarning, 3)
+        else:
+            assert_equal(stats.iqr(x, scale='raw', nan_policy='omit'), 7.5)
+            assert_almost_equal(stats.iqr(x, scale='normal', nan_policy='omit'), 7.5 / 1.3489795)
+            assert_equal(stats.iqr(x, scale=2.0, nan_policy='omit'), 3.75)
+
+        # Bad scale
+        assert_raises(ValueError, stats.iqr, x, scale='foobar')
 
 
 class TestMoments(TestCase):


### PR DESCRIPTION
Transfer of numpy PR https://github.com/numpy/numpy/pull/7137.

This function is different from the IQR in statsmodels. It appears to have different inputs (one array versus two), which actually makes this version more general.

As per @rgommers's [request](https://github.com/numpy/numpy/pull/7137#issuecomment-176633198), I have added `nan_policy`, which basically just selects between `np.percentile` and `np.nanpercentile`. Since there were some bugs in the shape of arrays returned by `np.nanpercentile`, I have added a workaround that should eventually be removed.

As per @josef-pkt's [request](https://github.com/numpy/numpy/pull/7137#issuecomment-176522779), I have added a 'scale' argument that accepts the values `'raw'` or `1.0`, `'normal'` or `sp.special.erfinv(0.5) * 2 * sp.sqrt(2) ~= 1.349`, or any other number. The result is divided by the scale. The default is `'raw'`.

The tests have been transferred almost as-is from numpy. However, if the numpy version being used is < 1.11.0, tests involving `interpolation='midpoint'` are turned off because bug-fix https://github.com/numpy/numpy/pull/7129 and its backport https://github.com/numpy/numpy/pull/7166 would not be in effect.
