### PR TITLE
remove dead code from stats tests

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -47,12 +47,6 @@ distcont_extra = [
     ['genextreme', (3.3184017469423535,)],
 ]
 
-distmissing = ['wald', 'gausshyper', 'genexpon', 'rv_continuous',
-               'loglaplace', 'rdist', 'semicircular', 'invweibull', 'ksone',
-               'cosine', 'kstwobign', 'truncnorm', 'mielke', 'recipinvgauss',
-               'levy', 'johnsonsu', 'levy_l', 'powernorm', 'wrapcauchy',
-               'johnsonsb', 'truncexpon', 'invgauss', 'invgamma',
-               'powerlognorm']
 
 distslow = ['rdist', 'gausshyper', 'recipinvgauss', 'ksone', 'genexpon',
             'vonmises', 'vonmises_line', 'mielke', 'semicircular',
@@ -106,9 +100,9 @@ def test_cont_basic():
             yield check_pdf_logpdf, distfn, arg, distname
             yield check_cdf_logcdf, distfn, arg, distname
             yield check_sf_logsf, distfn, arg, distname
-            if distname in distmissing:
-                alpha = 0.01
-                yield check_distribution_rvs, distname, arg, alpha, rvs
+
+            alpha = 0.01
+            yield check_distribution_rvs, distname, arg, alpha, rvs
 
             locscale_defaults = (0, 1)
             meths = [distfn.pdf, distfn.logpdf, distfn.cdf, distfn.logcdf,
@@ -168,9 +162,9 @@ def test_cont_basic_slow():
             yield check_cdf_logcdf, distfn, arg, distname
             yield check_sf_logsf, distfn, arg, distname
             # yield check_oth, distfn, arg # is still missing
-            if distname in distmissing:
-                alpha = 0.01
-                yield check_distribution_rvs, distname, arg, alpha, rvs
+
+            alpha = 0.01
+            yield check_distribution_rvs, distname, arg, alpha, rvs
 
             locscale_defaults = (0, 1)
             meths = [distfn.pdf, distfn.logpdf, distfn.cdf, distfn.logcdf,

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -54,7 +54,6 @@ distmissing = ['wald', 'gausshyper', 'genexpon', 'rv_continuous',
                'johnsonsb', 'truncexpon', 'invgauss', 'invgamma',
                'powerlognorm']
 
-distmiss = [[dist, args] for dist, args in distcont if dist in distmissing]
 distslow = ['rdist', 'gausshyper', 'recipinvgauss', 'ksone', 'genexpon',
             'vonmises', 'vonmises_line', 'mielke', 'semicircular',
             'cosine', 'invweibull', 'powerlognorm', 'johnsonsu', 'kstwobign']
@@ -79,19 +78,6 @@ fails_cmplx = set(['alpha', 'beta', 'betaprime', 'burr12', 'chi', 'chi2', 'dgamm
                    'recipinvgauss', 'rice', 'skewnorm', 't', 'truncexpon', 'truncnorm',
                    'tukeylambda', 'vonmises', 'vonmises_line', 'wald',
                    'weibull_min'])
-
-
-# NB: not needed anymore?
-def _silence_fp_errors(func):
-    # warning: don't apply to test_ functions as is, then those will be skipped
-    def wrap(*a, **kw):
-        olderr = np.seterr(all='ignore')
-        try:
-            return func(*a, **kw)
-        finally:
-            np.seterr(**olderr)
-    wrap.__name__ = func.__name__
-    return wrap
 
 
 def test_cont_basic():

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -57,20 +57,15 @@ def test_api_regression():
 
 
 # check function for test generator
-
-
 def check_distribution(dist, args, alpha):
     D, pval = stats.kstest(dist, '', args=args, N=1000)
     if (pval < alpha):
         D, pval = stats.kstest(dist, '', args=args, N=1000)
-        # if (pval < alpha):
-        #    D,pval = stats.kstest(dist,'',args=args, N=1000)
         assert_(pval > alpha, msg="D = " + str(D) + "; pval = " + str(pval) +
                 "; alpha = " + str(alpha) + "\nargs = " + str(args))
 
+
 # nose test generator
-
-
 def test_all_distributions():
     for dist in dists:
         distfunc = getattr(stats, dist)
@@ -79,9 +74,7 @@ def test_all_distributions():
         if dist == 'fatiguelife':
             alpha = 0.001
 
-        if dist == 'frechet':
-            args = tuple(2*np.random.random(1)) + (0,) + tuple(2*np.random.random(2))
-        elif dist == 'triang':
+        if dist == 'triang':
             args = tuple(np.random.random(nargs))
         elif dist == 'reciprocal':
             vals = np.random.random(nargs)


### PR DESCRIPTION
Remove a couple of lines of dead code from tests of stats.ditributions: we no longer silence fp errors, there is no "frechet" distribution in scipy. While I'm at it, also extend the KS test to all distributions, not only "missing" ones. Test coverage does not get worse.

All this is just rather trivial maintenance.
