### PR TITLE
Fixes for #2324 rankdata returns wrong results on masked arrays

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -236,7 +236,7 @@ def rankdata(data, axis=None, use_missing=False):
     def _rank1d(data, use_missing=False):
         n = data.count()
         rk = np.empty(data.size, dtype=float)
-        idx = data.argsort()
+        idx = data.argsort(fill_value=ma.minimum_fill_value(data))
         rk[idx[:n]] = np.arange(1,n+1)
 
         if use_missing:


### PR DESCRIPTION
Rank data did not work properly for masked arrays with large float values.  argsort has a "small" default float value.  Did not fix the issue with passing in NaN's.  Should we handle NaNs?
