### PR TITLE
DOC: typo in the docstring of least_squares

### DIFF
--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -328,7 +328,7 @@ def least_squares(
             * 'soft_l1' : ``rho(z) = 2 * ((1 + z)**0.5 - 1)``. The smooth
               approximation of l1 (absolute value) loss. Usually a good
               choice for robust least squares.
-            * 'huber' : ``rho(z) = z if z <= 1 else z**0.5 - 1``. Works
+            * 'huber' : ``rho(z) = z if z <= 1 else 2*z**0.5 - 1``. Works
               similarly to 'soft_l1'.
             * 'cauchy' : ``rho(z) = ln(1 + z)``. Severely weakens outliers
               influence, but may cause difficulties in optimization process.


### PR DESCRIPTION
Huber function is continuous at z=1.
C.f. https://github.com/scipy/scipy/blob/v0.17.0/scipy/optimize/_lsq/least_squares.py#L164

[ci skip]
