### PR TITLE
Improve numerical stability of hyp0f1 for large orders

### DIFF
--- a/scipy/special/_complexstuff.pxd
+++ b/scipy/special/_complexstuff.pxd
@@ -10,6 +10,8 @@ cdef extern from "_complexstuff.h":
     double npy_cabs(np.npy_cdouble z) nogil
     np.npy_cdouble npy_clog(np.npy_cdouble z) nogil
     np.npy_cdouble npy_cexp(np.npy_cdouble z) nogil
+    np.npy_cdouble npy_csqrt(np.npy_cdouble z) nogil
+    np.npy_cdouble npy_cpow(np.npy_cdouble x, np.npy_cdouble y) nogil
     double npy_log1p(double x) nogil
     int npy_isnan(double x) nogil
     int npy_isinf(double x) nogil
@@ -63,6 +65,25 @@ cdef inline number_t zexp(number_t x) nogil:
         return (<double_complex*>&r)[0]
     else:
         return libc.math.exp(x)
+
+cdef inline number_t zsqrt(number_t x) nogil:
+    cdef np.npy_cdouble r
+    if number_t is double_complex:
+        r = npy_csqrt((<np.npy_cdouble*>&x)[0])
+        return (<double_complex*>&r)[0]
+    else:
+        return libc.math.sqrt(x)
+
+cdef inline number_t zpow(number_t x, double y) nogil:
+    cdef np.npy_cdouble r, z
+    # FIXME
+    if number_t is double_complex:
+        z.real = y
+        z.imag = 0.0
+        r = npy_cpow((<np.npy_cdouble*>&x)[0], z)
+        return (<double_complex*>&r)[0]
+    else:
+        return libc.math.pow(x, y)
 
 cdef inline double_complex zpack(double zr, double zi) nogil:
     cdef np.npy_cdouble z

--- a/scipy/special/_hyp0f1.pxd
+++ b/scipy/special/_hyp0f1.pxd
@@ -1,4 +1,4 @@
-from libc.math cimport pow, sqrt, floor, log, log1p, exp, M_PI, fabs, sin
+from libc.math cimport pow, sqrt, floor, log, log1p, exp, M_PI, fabs
 from numpy.math cimport NAN, isinf
 cimport numpy as np
 
@@ -19,7 +19,8 @@ cdef extern from "c_misc/misc.h":
 
 cdef extern from "amos_wrappers.h":
     np.npy_cdouble cbesi_wrap(double v, np.npy_cdouble z) nogil
-    np.npy_cdouble cbesj_wrap( double v, np.npy_cdouble z) nogil
+    np.npy_cdouble cbesj_wrap(double v, np.npy_cdouble z) nogil
+    double sin_pi(double x) nogil
 
 #
 # Real-valued kernel
@@ -91,7 +92,7 @@ cdef inline double _hyp0f1_asy(double v, double z) nogil:
     if v - 1 < 0:
         # DLMF 10.27.2: I_{-v} = I_{v} + (2/pi) sin(pi*v) K_v
         u_corr_k = 1.0 - u1/v1 + u2/(v1*v1) - u3/(v1*v1*v1)
-        result += exp(arg_exp_k + xlogy(v1, arg)) * gs * 2.0 * sin(M_PI*v1) * u_corr_k
+        result += exp(arg_exp_k + xlogy(v1, arg)) * gs * 2.0 * sin_pi(v1) * u_corr_k
 
     return result
 

--- a/scipy/special/_hyp0f1.pxd
+++ b/scipy/special/_hyp0f1.pxd
@@ -1,0 +1,128 @@
+from libc.math cimport pow, sqrt, floor, log, log1p, exp, M_PI, fabs, sin
+from numpy.math cimport NAN, isinf
+cimport numpy as np
+
+from _xlogy cimport xlogy
+from _complexstuff cimport zsqrt, zpow, zabs
+
+cdef extern from "float.h":
+    double DBL_MAX, DBL_MIN
+
+cdef extern from "cephes.h":
+    double iv(double v, double x) nogil
+    double jv(double n, double x) nogil
+    double Gamma(double x) nogil
+    double lgam(double x) nogil
+
+cdef extern from "c_misc/misc.h":
+    double gammasgn(double x) nogil
+
+cdef extern from "amos_wrappers.h":
+    np.npy_cdouble cbesi_wrap(double v, np.npy_cdouble z) nogil
+    np.npy_cdouble cbesj_wrap( double v, np.npy_cdouble z) nogil
+
+#
+# Real-valued kernel
+#
+cdef inline double _hyp0f1_real(double v, double z) nogil:
+    cdef double arg, v1, arg_exp, bess_val
+
+    # handle poles, zeros 
+    if v <= 0.0 and v == floor(v):
+        return NAN
+    if z == 0.0 and v != 0.0:
+        return 1.0
+
+    # both v and z small: truncate the Taylor series at O(z**2)
+    if fabs(z) < 1e-6*(1.0 + fabs(v)):
+        return 1.0 + z/v + z*z/(2.0*v*(v+1.0))
+
+    if z > 0:
+        arg = sqrt(z)
+        arg_exp = xlogy(1.0-v, arg) + lgam(v)
+        bess_val = iv(v-1, 2.0*arg)
+        
+        if (arg_exp > log(DBL_MAX) or bess_val == 0 or   # overflow
+            arg_exp < log(DBL_MIN) or isinf(bess_val)):  # underflow
+            return _hyp0f1_asy(v, z)
+        else:
+            return exp(arg_exp) * gammasgn(v) * bess_val
+    else:
+        arg = sqrt(-z)
+        return pow(arg, 1.0 - v) * Gamma(v) * jv(v - 1, 2*arg)
+
+
+cdef inline double _hyp0f1_asy(double v, double z) nogil:
+    r"""Asymptotic expansion for I_{v-1}(2*sqrt(z)) * Gamma(v) 
+    for real $z > 0$ and $v\to +\infty$.
+
+    Based off DLMF 10.41
+    """
+    cdef:
+        double arg = sqrt(z)
+        double v1 = fabs(v - 1)
+        double x = 2.0 * arg / v1
+        double p1 = sqrt(1.0 + x*x)
+        double eta = p1 + log(x) - log1p(p1)
+        double arg_exp_i, arg_exp_k
+        double pp, p2, p4, p6, u1, u2, u3, u_corr_i, u_corr_k
+        double result, gs
+
+    arg_exp_i = -0.5*log(p1)
+    arg_exp_i -= 0.5*log(2.0*M_PI*v1)
+    arg_exp_i += lgam(v)
+    gs = gammasgn(v)
+
+    arg_exp_k = arg_exp_i
+    arg_exp_i += v1 * eta
+    arg_exp_k -= v1 * eta
+
+    # large-v asymptotic correction, DLMF 10.41.10
+    pp = 1.0/p1
+    p2 = pp*pp
+    p4 = p2*p2
+    p6 = p4*p2
+    u1 = (3.0 - 5.0*p2) * pp / 24.0
+    u2 = (81.0 - 462.0*p2 + 385.0*p4) * p2 / 1152.0
+    u3 = (30375.0 - 369603.0*p2 + 765765.0*p4 - 425425.0*p6) * pp * p2 / 414720.0
+    u_corr_i = 1.0 + u1/v1 + u2/(v1*v1) + u3/(v1*v1*v1)
+
+    result = exp(arg_exp_i - xlogy(v1, arg)) * gs * u_corr_i
+    if v - 1 < 0:
+        # DLMF 10.27.2: I_{-v} = I_{v} + (2/pi) sin(pi*v) K_v
+        u_corr_k = 1.0 - u1/v1 + u2/(v1*v1) - u3/(v1*v1*v1)
+        result += exp(arg_exp_k + xlogy(v1, arg)) * gs * 2.0 * sin(M_PI*v1) * u_corr_k
+
+    return result
+
+
+#
+# Complex valued kernel
+#
+cdef inline double complex _hyp0f1_cmplx(double v, double complex z) nogil:
+    cdef:
+        np.npy_cdouble zz = (<np.npy_cdouble*>&z)[0]
+        np.npy_cdouble r
+        double complex arg, s
+
+    # handle poles, zeros 
+    if v <= 0.0 and v == floor(v):
+        return NAN
+    if z.real == 0.0 and z.imag == 0.0 and v != 0.0:
+        return 1.0
+
+    # both v and z small: truncate the Taylor series at O(z**2)
+    if zabs(z) < 1e-6*(1.0 + fabs(v)):
+        return 1.0 + z/v + z*z/(2.0*v*(v+1.0))
+
+    if zz.real > 0:
+        arg = zsqrt(z)
+        s = 2.0 * arg
+        r = cbesi_wrap(v-1.0, (<np.npy_cdouble*>&s)[0] )
+    else:
+        arg = zsqrt(-z)
+        s = 2.0 * arg
+        r = cbesj_wrap(v-1.0, (<np.npy_cdouble*>&s)[0] )
+
+    return (<double complex*>&r)[0] * Gamma(v) * zpow(arg, 1.0 - v)
+

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -1541,6 +1541,12 @@ cdef extern from "_ufuncs_defs.h":
 from _convex_analysis cimport huber as _func_huber
 ctypedef double _proto_huber_t(double, double) nogil
 cdef _proto_huber_t *_proto_huber_t_var = &_func_huber
+from _hyp0f1 cimport _hyp0f1_real as _func__hyp0f1_real
+ctypedef double _proto__hyp0f1_real_t(double, double) nogil
+cdef _proto__hyp0f1_real_t *_proto__hyp0f1_real_t_var = &_func__hyp0f1_real
+from _hyp0f1 cimport _hyp0f1_cmplx as _func__hyp0f1_cmplx
+ctypedef double complex _proto__hyp0f1_cmplx_t(double, double complex) nogil
+cdef _proto__hyp0f1_cmplx_t *_proto__hyp0f1_cmplx_t_var = &_func__hyp0f1_cmplx
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_hyp1f1_wrap "hyp1f1_wrap"(double, double, double) nogil
 cdef extern from "_ufuncs_defs.h":
@@ -6272,6 +6278,63 @@ ufunc_huber_ptr[2*1+1] = <void*>(<char*>"huber")
 ufunc_huber_data[0] = &ufunc_huber_ptr[2*0]
 ufunc_huber_data[1] = &ufunc_huber_ptr[2*1]
 huber = np.PyUFunc_FromFuncAndData(ufunc_huber_loops, ufunc_huber_data, ufunc_huber_types, 2, 2, 1, 0, "huber", ufunc_huber_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc_hyp0f1_loops[4]
+cdef void *ufunc_hyp0f1_ptr[8]
+cdef void *ufunc_hyp0f1_data[4]
+cdef char ufunc_hyp0f1_types[12]
+cdef char *ufunc_hyp0f1_doc = (
+    "hyp0f1(v, x)\n"
+    "\n"
+    "Confluent hypergeometric limit function 0F1.\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "v, z : array_like\n"
+    "    Input values.\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "hyp0f1 : ndarray\n"
+    "    The confluent hypergeometric limit function.\n"
+    "\n"
+    "Notes\n"
+    "-----\n"
+    "This function is defined as:\n"
+    "\n"
+    ".. math:: _0F_1(v, z) = \\sum_{k=0}^{\\infty}\\frac{z^k}{(v)_k k!}.\n"
+    "\n"
+    "It's also the limit as :math:`q \\to \\infty` of :math:`_1F_1(q; v; z/q)`,\n"
+    "and satisfies the differential equation :math:`f''(z) + vf'(z) = f(z)`.")
+ufunc_hyp0f1_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
+ufunc_hyp0f1_loops[1] = <np.PyUFuncGenericFunction>loop_D_dD__As_fF_F
+ufunc_hyp0f1_loops[2] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
+ufunc_hyp0f1_loops[3] = <np.PyUFuncGenericFunction>loop_D_dD__As_dD_D
+ufunc_hyp0f1_types[0] = <char>NPY_FLOAT
+ufunc_hyp0f1_types[1] = <char>NPY_FLOAT
+ufunc_hyp0f1_types[2] = <char>NPY_FLOAT
+ufunc_hyp0f1_types[3] = <char>NPY_FLOAT
+ufunc_hyp0f1_types[4] = <char>NPY_CFLOAT
+ufunc_hyp0f1_types[5] = <char>NPY_CFLOAT
+ufunc_hyp0f1_types[6] = <char>NPY_DOUBLE
+ufunc_hyp0f1_types[7] = <char>NPY_DOUBLE
+ufunc_hyp0f1_types[8] = <char>NPY_DOUBLE
+ufunc_hyp0f1_types[9] = <char>NPY_DOUBLE
+ufunc_hyp0f1_types[10] = <char>NPY_CDOUBLE
+ufunc_hyp0f1_types[11] = <char>NPY_CDOUBLE
+ufunc_hyp0f1_ptr[2*0] = <void*>_func__hyp0f1_real
+ufunc_hyp0f1_ptr[2*0+1] = <void*>(<char*>"hyp0f1")
+ufunc_hyp0f1_ptr[2*1] = <void*>_func__hyp0f1_cmplx
+ufunc_hyp0f1_ptr[2*1+1] = <void*>(<char*>"hyp0f1")
+ufunc_hyp0f1_ptr[2*2] = <void*>_func__hyp0f1_real
+ufunc_hyp0f1_ptr[2*2+1] = <void*>(<char*>"hyp0f1")
+ufunc_hyp0f1_ptr[2*3] = <void*>_func__hyp0f1_cmplx
+ufunc_hyp0f1_ptr[2*3+1] = <void*>(<char*>"hyp0f1")
+ufunc_hyp0f1_data[0] = &ufunc_hyp0f1_ptr[2*0]
+ufunc_hyp0f1_data[1] = &ufunc_hyp0f1_ptr[2*1]
+ufunc_hyp0f1_data[2] = &ufunc_hyp0f1_ptr[2*2]
+ufunc_hyp0f1_data[3] = &ufunc_hyp0f1_ptr[2*3]
+hyp0f1 = np.PyUFunc_FromFuncAndData(ufunc_hyp0f1_loops, ufunc_hyp0f1_data, ufunc_hyp0f1_types, 4, 2, 1, 0, "hyp0f1", ufunc_hyp0f1_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_hyp1f1_loops[4]
 cdef void *ufunc_hyp1f1_ptr[8]

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -2391,6 +2391,32 @@ add_newdoc("scipy.special", "huber",
 
     """)
 
+add_newdoc("scipy.special", "hyp0f1", 
+    r"""
+    hyp0f1(v, x)
+
+    Confluent hypergeometric limit function 0F1.
+
+    Parameters
+    ----------
+    v, z : array_like
+        Input values.
+
+    Returns
+    -------
+    hyp0f1 : ndarray
+        The confluent hypergeometric limit function.
+
+    Notes
+    -----
+    This function is defined as:
+
+    .. math:: _0F_1(v, z) = \sum_{k=0}^{\infty}\frac{z^k}{(v)_k k!}.
+
+    It's also the limit as :math:`q \to \infty` of :math:`_1F_1(q; v; z/q)`,
+    and satisfies the differential equation :math:`f''(z) + vf'(z) = f(z)`.
+    """)
+
 add_newdoc("scipy.special", "hyp1f1",
     """
     hyp1f1(a, b, x)

--- a/scipy/special/amos_wrappers.c
+++ b/scipy/special/amos_wrappers.c
@@ -69,7 +69,7 @@ void set_nan_if_no_computation_done(npy_cdouble *v, int ierr) {
   }
 }
 
-static double sin_pi(double x)
+double sin_pi(double x)
 {
     if (floor(x) == x && fabs(x) < 1e14) {
         /* Return 0 when at exact zero, as long as the floating point number is

--- a/scipy/special/amos_wrappers.h
+++ b/scipy/special/amos_wrappers.h
@@ -46,6 +46,7 @@ npy_cdouble cbesh_wrap1( double v, npy_cdouble z);
 npy_cdouble cbesh_wrap1_e( double v, npy_cdouble z);  
 npy_cdouble cbesh_wrap2( double v, npy_cdouble z);
 npy_cdouble cbesh_wrap2_e( double v, npy_cdouble z);
+double sin_pi(double x);
 /* 
 int cairy_(double *, int *, int *, doublecomplex *, int *, int *);
 int cbiry_(doublecomplex *, int *, int *, doublecomplex *, int *, int *);

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -13,8 +13,8 @@ from numpy import (pi, asarray, floor, isscalar, iscomplex, real, imag, sqrt,
                    where, mgrid, sin, place, issubdtype, extract,
                    less, inexact, nan, zeros, atleast_1d, sinc)
 from ._ufuncs import (ellipkm1, mathieu_a, mathieu_b, iv, jv, gamma, psi, zeta,
-                      hankel1, hankel2, yv, kv, gammaln, ndtri, errprint, poch,
-                      binom)
+                      hankel1, hankel2, yv, kv, gammaln, ndtri,
+                      errprint, poch, binom, hyp0f1)
 from . import specfun
 from . import orthogonal
 
@@ -1080,46 +1080,6 @@ def fresnel_zeros(nt):
     if (floor(nt) != nt) or (nt <= 0) or not isscalar(nt):
         raise ValueError("Argument must be positive scalar integer.")
     return specfun.fcszo(2, nt), specfun.fcszo(1, nt)
-
-
-def hyp0f1(v, z):
-    r"""Confluent hypergeometric limit function 0F1.
-
-    Parameters
-    ----------
-    v, z : array_like
-        Input values.
-
-    Returns
-    -------
-    hyp0f1 : ndarray
-        The confluent hypergeometric limit function.
-
-    Notes
-    -----
-    This function is defined as:
-
-    .. math:: _0F_1(v, z) = \sum_{k=0}^{\inf}\frac{z^k}{(v)_k k!}.
-
-    It's also the limit as q -> infinity of ``1F1(q;v;z/q)``, and satisfies
-    the differential equation :math:`f''(z) + vf'(z) = f(z)`.
-    """
-    v = atleast_1d(v)
-    z = atleast_1d(z)
-    v, z = np.broadcast_arrays(v, z)
-    if np.iscomplexobj(z):
-        res = np.empty_like(z)
-    else:
-        res = np.empty_like(z, dtype=np.float64)
-    poles = (v < 0) & (v == v.astype(int))
-    zeros = (z == 0)
-    pos = (z.real >= 0) & -zeros & -poles
-    neg = (z.real < 0) & -zeros & -poles
-    res[poles] = nan
-    res[zeros] = 1
-    res[pos] = z[pos]**((1.0 - v[pos])/2)*gamma(v[pos])*iv(v[pos] - 1, 2*sqrt(z[pos]))
-    res[neg] = (-z[neg])**((1.0 - v[neg])/2)*gamma(v[neg])*jv(v[neg] - 1, 2*sqrt(-z[neg]))
-    return res
 
 
 def assoc_laguerre(x, n, k=0.0):

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -97,6 +97,7 @@ fdtr -- fdtr: ddd->d                                       -- cephes.h
 fdtri -- fdtri: ddd->d                                     -- cephes.h
 gdtrc -- gdtrc: ddd->d                                     -- cephes.h
 gdtr -- gdtr: ddd->d                                       -- cephes.h
+hyp0f1 -- _hyp0f1_real: dd->d, _hyp0f1_cmplx: dD->D        -- _hyp0f1.pxd
 hyp2f1 -- hyp2f1: dddd->d, chyp2f1_wrap: dddD->D           -- cephes.h, specfun_wrappers.h
 hyp1f1 -- hyp1f1_wrap: ddd->d, chyp1f1_wrap: ddD->D        -- specfun_wrappers.h
 hyperu -- hypU_wrap: ddd->d                                -- specfun_wrappers.h


### PR DESCRIPTION
Avoid an underflow, do computations to the log space, and add an asymptotic form to further improve accuracy.

closes gh-1609.

<s>Given the mess this function evolves into, it seems cleaner to move it to cython and make it a ufunc, but that's for some other day.</s>

EDIT: moved the implementation to cython, made `hyp0f1` a ufunc, which also closes gh-2332.
