### PR TITLE
ENH: sparse: Add copy parameter to all .toXXX() methods in sparse matrices

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -265,7 +265,7 @@ class spmatrix(object):
         """
         return self * other
 
-    def power(self, n, dtype=None):            
+    def power(self, n, dtype=None):
         return self.tocsr().power(n, dtype=dtype)
 
     def __eq__(self, other):
@@ -675,23 +675,75 @@ class spmatrix(object):
         """
         return self.tocoo().toarray(order=order, out=out)
 
-    def todok(self):
-        return self.tocoo().todok()
+    # In principle, providing a tocsr method will be sufficient for any
+    # sparse matrix format deriving from spmatrix.
+    def tocsr(self, copy=False):
+        """Convert this matrix to Compressed Sparse Row format.
 
-    def tocoo(self):
-        return self.tocsr().tocoo()
+        With copy=False, the data/indices may be shared between this matrix and
+        the resultant csr_matrix.
+        """
+        raise NotImplementedError("tocsr is not implemented for %s." %
+                                  self.__class__.__name__)
 
-    def tolil(self):
-        return self.tocsr().tolil()
+    def todok(self, copy=False):
+        """Convert this matrix to Dictionary Of Keys format.
 
-    def todia(self):
-        return self.tocoo().todia()
+        With copy=False, the data/indices may be shared between this matrix and
+        the resultant dok_matrix.
+        """
+        return self.tocoo(copy=False).todok(copy=copy)
 
-    def tobsr(self, blocksize=None):
-        return self.tocsr().tobsr(blocksize=blocksize)
+    def tocoo(self, copy=False):
+        """Convert this matrix to COOrdinate format.
+
+        With copy=False, the data/indices may be shared between this matrix and
+        the resultant coo_matrix.
+        """
+        return self.tocsr(copy=False).tocoo(copy=copy)
+
+    def tolil(self, copy=False):
+        """Convert this matrix to LInked List format.
+
+        With copy=False, the data/indices may be shared between this matrix and
+        the resultant lil_matrix.
+        """
+        return self.tocsr(copy=False).tolil(copy=copy)
+
+    def todia(self, copy=False):
+        """Convert this matrix to sparse DIAgonal format.
+
+        With copy=False, the data/indices may be shared between this matrix and
+        the resultant dia_matrix.
+        """
+        return self.tocoo(copy=False).todia(copy=copy)
+
+    def tobsr(self, blocksize=None, copy=False):
+        """Convert this matrix to Block Sparse Row format.
+
+        With copy=False, the data/indices may be shared between this matrix and
+        the resultant bsr_matrix.
+
+        When blocksize=(R, C) is provided, it will be used for construction of
+        the bsr_matrix.
+        """
+        return self.tocsr(copy=False).tobsr(blocksize=blocksize, copy=copy)
+
+    def tocsc(self, copy=False):
+        """Convert this matrix to Compressed Sparse Column format.
+
+        With copy=False, the data/indices may be shared between this matrix and
+        the resultant csc_matrix.
+        """
+        return self.tocsr(copy=False).tocsc(copy=copy)
 
     def copy(self):
-        return self.__class__(self,copy=True)
+        """Returns a copy of this matrix.
+
+        No data/indices will be shared between the returned value and current
+        matrix.
+        """
+        return self.__class__(self, copy=True)
 
     def sum(self, axis=None):
         """Sum the matrix over the given axis.  If the axis is None, sum

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -413,7 +413,15 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
     # Conversion methods #
     ######################
 
-    def tobsr(self,blocksize=None,copy=False):
+    def tobsr(self, blocksize=None, copy=False):
+        """Convert this matrix into Block Sparse Row Format.
+
+        With copy=False, the data/indices may be shared between this
+        matrix and the resultant bsr_matrix.
+
+        If blocksize=(R, C) is provided, it will be used for determining
+        block size of the bsr_matrix.
+        """
         if blocksize not in [None, self.blocksize]:
             return self.tocsr().tobsr(blocksize=blocksize)
         if copy:
@@ -421,14 +429,18 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         else:
             return self
 
-    def tocsr(self):
-        return self.tocoo(copy=False).tocsr()
+    def tocsr(self, copy=False):
+        return self.tocoo(copy=False).tocsr(copy=copy)
         # TODO make this more efficient
 
-    def tocsc(self):
-        return self.tocoo(copy=False).tocsc()
+    tocsr.__doc__ = spmatrix.tocsr.__doc__
 
-    def tocoo(self,copy=True):
+    def tocsc(self, copy=False):
+        return self.tocoo(copy=False).tocsc(copy=copy)
+
+    tocsc.__doc__ = spmatrix.tocsc.__doc__
+
+    def tocoo(self, copy=True):
         """Convert this matrix to COOrdinate format.
 
         When copy=False the data array will be shared between

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -250,10 +250,13 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                     B.ravel('A'), fortran)
         return B
 
-    def tocsc(self):
+    def tocsc(self, copy=False):
         """Return a copy of this matrix in Compressed Sparse Column format
 
         Duplicate entries will be summed together.
+
+        With copy=False, the data/indices may be shared between this matrix
+        and resultant csc_matrix.
 
         Examples
         --------
@@ -292,10 +295,13 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
             return A
 
-    def tocsr(self):
+    def tocsr(self, copy=False):
         """Return a copy of this matrix in Compressed Sparse Row format
 
         Duplicate entries will be summed together.
+
+        With copy=False, the data/indices may be shared between this matrix
+        and resultant csc_matrix.
 
         Examples
         --------
@@ -342,7 +348,9 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         else:
             return self
 
-    def todia(self):
+    tocoo.__doc__ = spmatrix.tocoo.__doc__
+
+    def todia(self, copy=False):
         from .dia import dia_matrix
 
         self.sum_duplicates()
@@ -363,7 +371,9 @@ class coo_matrix(_data_matrix, _minmax_mixin):
 
         return dia_matrix((data,diags), shape=self.shape)
 
-    def todok(self):
+    todia.__doc__ = spmatrix.todia.__doc__
+
+    def todok(self, copy=False):
         from .dok import dok_matrix
 
         self.sum_duplicates()
@@ -371,6 +381,8 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         dok.update(izip(izip(self.row,self.col),self.data))
 
         return dok
+
+    todok.__doc__ = spmatrix.todok.__doc__
 
     def diagonal(self):
         diag = np.zeros(min(self.shape), dtype=self.dtype)

--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -9,6 +9,7 @@ __all__ = ['csc_matrix', 'isspmatrix_csc']
 import numpy as np
 from scipy._lib.six import xrange
 
+from .base import spmatrix
 from ._sparsetools import csc_tocsr
 from . import _sparsetools
 from .sputils import upcast, isintlike, IndexMixin, get_index_dtype
@@ -124,7 +125,9 @@ class csc_matrix(_cs_matrix, IndexMixin):
         else:
             return self
 
-    def tocsr(self):
+    tocsc.__doc__ = spmatrix.tocsc.__doc__
+
+    def tocsr(self, copy=False):
         M,N = self.shape
         idx_dtype = get_index_dtype((self.indptr, self.indices),
                                     maxval=max(self.nnz, N))
@@ -144,6 +147,8 @@ class csc_matrix(_cs_matrix, IndexMixin):
         A = csr_matrix((data, indices, indptr), shape=self.shape)
         A.has_sorted_indices = True
         return A
+
+    tocsr.__doc__ = spmatrix.tocsr.__doc__
 
     def __getitem__(self, key):
         # Use CSR to implement fancy indexing.

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -10,6 +10,8 @@ __all__ = ['csr_matrix', 'isspmatrix_csr']
 import numpy as np
 from scipy._lib.six import xrange
 
+from .base import spmatrix
+
 from ._sparsetools import csr_tocsc, csr_tobsr, csr_count_blocks, \
         get_csr_submatrix, csr_sample_values
 from .sputils import (upcast, isintlike, IndexMixin, issequence,
@@ -131,7 +133,7 @@ class csr_matrix(_cs_matrix, IndexMixin):
         M,N = self.shape
         return csc_matrix((self.data,self.indices,self.indptr), shape=(N,M), copy=copy)
 
-    def tolil(self):
+    def tolil(self, copy=False):
         from .lil import lil_matrix
         lil = lil_matrix(self.shape,dtype=self.dtype)
 
@@ -147,13 +149,17 @@ class csr_matrix(_cs_matrix, IndexMixin):
 
         return lil
 
+    tolil.__doc__ = spmatrix.tolil.__doc__
+
     def tocsr(self, copy=False):
         if copy:
             return self.copy()
         else:
             return self
 
-    def tocsc(self):
+    tocsr.__doc__ = spmatrix.tocsr.__doc__
+
+    def tocsc(self, copy=False):
         idx_dtype = get_index_dtype((self.indptr, self.indices),
                                     maxval=max(self.nnz, self.shape[0]))
         indptr = np.empty(self.shape[1] + 1, dtype=idx_dtype)
@@ -172,6 +178,8 @@ class csr_matrix(_cs_matrix, IndexMixin):
         A = csc_matrix((data, indices, indptr), shape=self.shape)
         A.has_sorted_indices = True
         return A
+
+    tocsr.__doc__ = spmatrix.tocsr.__doc__
 
     def tobsr(self, blocksize=None, copy=True):
         from .bsr import bsr_matrix
@@ -206,6 +214,8 @@ class csr_matrix(_cs_matrix, IndexMixin):
                       indptr, indices, data.ravel())
 
             return bsr_matrix((data,indices,indptr), shape=self.shape)
+
+    tobsr.__doc__ = spmatrix.tobsr.__doc__
 
     # these functions are used by the parent class (_cs_matrix)
     # to remove redudancy between csc_matrix and csr_matrix

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -225,11 +225,13 @@ class dia_matrix(_data_matrix):
             data[-1, min_index:max_index] = values
             self.data = data
 
-    def todia(self,copy=False):
+    def todia(self, copy=False):
         if copy:
             return self.copy()
         else:
             return self
+
+    todia.__doc__ = spmatrix.todia.__doc__
 
     def transpose(self):
         num_rows, num_cols = self.shape
@@ -245,15 +247,19 @@ class dia_matrix(_data_matrix):
         data = data[r,c]
         return dia_matrix((data, offsets), shape=(num_cols,num_rows))
 
-    def tocsr(self):
+    def tocsr(self, copy=False):
         #this could be faster
-        return self.tocoo().tocsr()
+        return self.tocoo(copy=copy).tocsr()
 
-    def tocsc(self):
+    tocsr.__doc__ = spmatrix.tocsr.__doc__
+
+    def tocsc(self, copy=False):
         #this could be faster
-        return self.tocoo().tocsc()
+        return self.tocoo(copy=copy).tocsc()
 
-    def tocoo(self):
+    tocsc.__doc__ = spmatrix.tocsc.__doc__
+
+    def tocoo(self, copy=False):
         num_rows, num_cols = self.shape
         num_offsets, offset_len = self.data.shape
         offset_inds = np.arange(offset_len)
@@ -269,6 +275,8 @@ class dia_matrix(_data_matrix):
 
         from .coo import coo_matrix
         return coo_matrix((data,(row,col)), shape=self.shape)
+
+    tocoo.__doc__ = spmatrix.tocoo.__doc__
 
     # needed by _data_matrix
     def _with_data(self, data, copy=True):

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -437,6 +437,8 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         new.update(self)
         return new
 
+    copy.__doc__ = spmatrix.copy.__doc__
+
     def getrow(self, i):
         """Returns a copy of row i of the matrix as a (1 x n)
         DOK matrix.
@@ -455,8 +457,7 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             out[i, 0] = self[i, j]
         return out
 
-    def tocoo(self):
-        """ Return a copy of this matrix in COOrdinate format"""
+    def tocoo(self, copy=False):
         from .coo import coo_matrix
         if self.nnz == 0:
             return coo_matrix(self.shape, dtype=self.dtype)
@@ -466,19 +467,25 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             indices = np.asarray(_list(self.keys()), dtype=idx_dtype).T
             return coo_matrix((data,indices), shape=self.shape, dtype=self.dtype)
 
-    def todok(self,copy=False):
+    tocoo.__doc__ = spmatrix.tocoo.__doc__
+
+    def todok(self, copy=False):
         if copy:
             return self.copy()
         else:
             return self
 
-    def tocsr(self):
-        """ Return a copy of this matrix in Compressed Sparse Row format"""
-        return self.tocoo().tocsr()
+    todok.__doc__ = spmatrix.todok.__doc__
 
-    def tocsc(self):
-        """ Return a copy of this matrix in Compressed Sparse Column format"""
-        return self.tocoo().tocsc()
+    def tocsr(self, copy=False):
+        return self.tocoo(copy=False).tocsr(copy=copy)
+
+    tocsr.__doc__ = spmatrix.tocsr.__doc__
+
+    def tocsc(self, copy=False):
+        return self.tocoo(copy=False).tocsc(copy=copy)
+
+    tocsc.__doc__ = spmatrix.tocsc.__doc__
 
     def resize(self, shape):
         """ Resize the matrix in-place to dimensions given by 'shape'.

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -407,6 +407,8 @@ class lil_matrix(spmatrix, IndexMixin):
         new.rows = deepcopy(self.rows)
         return new
 
+    copy.__doc__ = spmatrix.copy.__doc__
+
     def reshape(self,shape):
         new = lil_matrix(shape, dtype=self.dtype)
         j_max = self.shape[1]
@@ -433,10 +435,9 @@ class lil_matrix(spmatrix, IndexMixin):
         else:
             return self
 
-    def tocsr(self):
-        """ Return Compressed Sparse Row format arrays for this matrix.
-        """
+    tolil.__doc__ = spmatrix.tolil.__doc__
 
+    def tocsr(self, copy=False):
         lst = [len(x) for x in self.rows]
         idx_dtype = get_index_dtype(maxval=max(self.shape[1], sum(lst)))
         indptr = np.asarray(lst, dtype=idx_dtype)
@@ -456,10 +457,12 @@ class lil_matrix(spmatrix, IndexMixin):
         from .csr import csr_matrix
         return csr_matrix((data, indices, indptr), shape=self.shape)
 
-    def tocsc(self):
-        """ Return Compressed Sparse Column format arrays for this matrix.
-        """
-        return self.tocsr().tocsc()
+    tocsr.__doc__ = spmatrix.tocsr.__doc__
+
+    def tocsc(self, copy=False):
+        return self.tocsr(copy=copy).tocsc()
+
+    tocsc.__doc__ = spmatrix.tocsc.__doc__
 
 
 def _prepare_index_for_memoryview(i, j, x=None):


### PR DESCRIPTION
This closes #5822.

I have added `copy=False` as the default arguments for all `.to???` conversion methods in sparse matrices. The only places where I left the defaults in place were `bsr.py` and `csr.py`'s `.tobsr` method.

All tests pass and no extra functionality has been added, requiring no additional unit-tests.
