### PR TITLE
ENH: sparse: add eliminate_zeros() to coo_matrix

### DIFF
--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -461,6 +461,16 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         self.data = np.add.reduceat(self.data, unique_inds, dtype=self.dtype)
         self.has_canonical_format = True
 
+    def eliminate_zeros(self):
+        """Remove zero entries from the matrix
+
+        This is an *in place* operation
+        """
+        mask = self.data != 0
+        self.data = self.data[mask]
+        self.row = self.row[mask]
+        self.col = self.col[mask]
+
     ###########################
     # Multiplication handlers #
     ###########################

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3691,6 +3691,16 @@ class TestCOO(sparse_test_class(getset=False,
         dok = coo.todok()
         assert_array_equal(dok.A, coo.A)
 
+    def test_eliminate_zeros(self):
+        data = array([1, 0, 0, 0, 2, 0, 3, 0])
+        row = array([0, 0, 0, 1, 1, 1, 1, 1])
+        col = array([1, 2, 3, 4, 5, 6, 7, 8])
+        asp = coo_matrix((data, (row, col)), shape=(2,10))
+        bsp = asp.copy()
+        asp.eliminate_zeros()
+        assert_((asp.data != 0).all())
+        assert_array_equal(asp.A, bsp.A)
+
 
 class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=False,
                                 fancy_indexing=False, fancy_assign=False,


### PR DESCRIPTION
This is a simple addition, but it's a common-enough operation that I think it merits inclusion. Similar `eliminate_zeros` methods are already present in CSR, CSC, and BSR formats.
