### PR TITLE
BUG: Fixed name of NumpyVersion.__repr__

### DIFF
--- a/scipy/_lib/_version.py
+++ b/scipy/_lib/_version.py
@@ -151,5 +151,5 @@ class NumpyVersion():
     def __ge__(self, other):
         return self._compare(other) >= 0
 
-    def __repr(self):
+    def __repr__(self):
         return "NumpyVersion(%s)" % self.vstring


### PR DESCRIPTION
The trailing double underscore was missing. Now printing will work fine.
