### PR TITLE
MAINT: Fixed typos in documentation

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -685,8 +685,8 @@ class burr12_gen(rv_continuous):
     This is the PDF corresponding to the twelfth CDF given in Burr's list;
     specifically, it is equation (20) in Burr's paper [1]_.
 
-    %(after_notes)s 
-    
+    %(after_notes)s
+
     The Burr type 12 distribution is also sometimes referred to as
     the Singh-Maddala distribution from NIST [2]_.
 
@@ -694,7 +694,7 @@ class burr12_gen(rv_continuous):
     ----------
     .. [1] Burr, I. W. "Cumulative frequency functions", Annals of
        Mathematical Statistics, 13(2), pp 215-232 (1942).
-       
+
     .. [2] http://www.itl.nist.gov/div898/software/dataplot/refman2/auxillar/b12pdf.htm
 
     %(example)s
@@ -702,21 +702,21 @@ class burr12_gen(rv_continuous):
     """
     def _pdf(self, x, c, d):
         return np.exp(self._logpdf(x, c, d))
-        
+
     def _logpdf(self, x, c, d):
         return log(c) + log(d) + special.xlogy(c-1, x) + special.xlog1py(-d-1, x**c)
 
     def _cdf(self, x, c, d):
         return 1 - self._sf(x, c, d)
-        
+
     def _logcdf(self, x, c, d):
         return special.log1p(-(1 + x**c)**(-d))
-        
+
     def _sf(self, x, c, d):
         return np.exp(self._logsf(x, c, d))
-        
+
     def _logsf(self, x, c, d):
-        return special.xlog1py(-d, x**c)    
+        return special.xlog1py(-d, x**c)
 
     def _ppf(self, q, c, d):
         return ((1 - q)**(-1.0/d) - 1)**(1.0/c)
@@ -2605,7 +2605,7 @@ class invgauss_gen(rv_continuous):
 
     %(after_notes)s
 
-    When `mu` is too small, evaluating the cumulative density function will be
+    When `mu` is too small, evaluating the cumulative distribution function will be
     inaccurate due to ``cdf(mu -> 0) = inf * 0``.
     NaNs are returned for ``mu <= 0.0028``.
 
@@ -4157,27 +4157,27 @@ semicircular = semicircular_gen(a=-1.0, b=1.0, name="semicircular")
 
 class skew_norm_gen(rv_continuous):
     """A skew-normal random variable.
-    
+
     %(before_notes)s
-    
+
     Notes
     -----
     The pdf is
 
     skewnorm.pdf(x, a) = 2*norm.pdf(x)*norm.cdf(ax)
-    
+
     `skewnorm` takes ``a`` as a skewness parameter
     When a=0 the distribution is identical to a normal distribution.
     rvs implements the method of [1].
-   
+
     %(after_notes)s
-    
+
     %(example)s
-    
-    
+
+
     References
     ----------
-    
+
     [1] A. Azzalini and A. Capitanio (1999). Statistical applications of the
         multivariate skew-normal distribution. J. Roy. Statist. Soc., B 61, 579-602.
         http://azzalini.stat.unipd.it/SN/faq-r.html
@@ -4185,32 +4185,32 @@ class skew_norm_gen(rv_continuous):
 
     def _argcheck(self, a):
         return np.isfinite(a)
-        
+
     def _pdf(self, x, a):
         return 2.*_norm_pdf(x)*_norm_cdf(a*x)
-        
+
     def _rvs(self, a):
         u0 = self._random_state.normal(size=self._size)
         v = self._random_state.normal(size=self._size)
         d = a/np.sqrt(1 + a**2)
         u1 = d*u0 + v*np.sqrt(1 - d**2)
         return np.where(u0 >= 0, u1, -u1)
-        
+
     def _stats(self, a, moments='mvsk'):
         output = [None, None, None, None]
         const = np.sqrt(2/pi) * a/np.sqrt(1 + a**2)
-        
+
         if 'm' in moments:
             output[0] = const
         if 'v' in moments:
-            output[1] = 1 - const**2 
+            output[1] = 1 - const**2
         if 's' in moments:
-            output[2] = ((4 - pi)/2) * (const/np.sqrt(1 - const**2))**3         
+            output[2] = ((4 - pi)/2) * (const/np.sqrt(1 - const**2))**3
         if 'k' in moments:
-            output[3] = (2*(pi - 3)) * (const**4/(1 - const**2)**2)   
-            
+            output[3] = (2*(pi - 3)) * (const**4/(1 - const**2)**2)
+
         return output
-        
+
 skewnorm = skew_norm_gen(name='skewnorm')
 
 class triang_gen(rv_continuous):

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -76,11 +76,11 @@ _doc_logpmf = """\
 """
 _doc_cdf = """\
 ``cdf(x, %(shapes)s, loc=0, scale=1)``
-    Cumulative density function.
+    Cumulative distribution function.
 """
 _doc_logcdf = """\
 ``logcdf(x, %(shapes)s, loc=0, scale=1)``
-    Log of the cumulative density function.
+    Log of the cumulative distribution function.
 """
 _doc_sf = """\
 ``sf(x, %(shapes)s, loc=0, scale=1)``


### PR DESCRIPTION
Closes #5841 (Thanks to @Energya for bringing it up)

I fixed three typos in scipy/stats/_continuous_distns.py and scipy/stats/_distn_infrastructure.py where cdf was wrongly described as the "cumulative density function" as opposed to the proper name, "cumulative distribution function". 
