### PR TITLE
BUG: sparse.linalg: add locks to ensure ARPACK threadsafety

### DIFF
--- a/scipy/_lib/_threadsafety.py
+++ b/scipy/_lib/_threadsafety.py
@@ -1,0 +1,60 @@
+from __future__ import division, print_function, absolute_import
+
+import threading
+
+import scipy._lib.decorator
+
+
+__all__ = ['ReentrancyError', 'ReentrancyLock', 'non_reentrant']
+
+
+class ReentrancyError(RuntimeError):
+    pass
+
+
+class ReentrancyLock(object):
+    """
+    Threading lock that raises an exception for reentrant calls.
+
+    Calls from different threads are serialized, and nested calls from the
+    same thread result to an error.
+
+    The object can be used as a context manager, or to decorate functions
+    via the decorate() method.
+
+    """
+
+    def __init__(self, err_msg):
+        self._rlock = threading.RLock()
+        self._entered = False
+        self._err_msg = err_msg
+
+    def __enter__(self):
+        self._rlock.acquire()
+        if self._entered:
+            self._rlock.release()
+            raise ReentrancyError(self._err_msg)
+        self._entered = True
+
+    def __exit__(self, type, value, traceback):
+        self._entered = False
+        self._rlock.release()
+
+    def decorate(self, func):
+        def caller(func, *a, **kw):
+            with self:
+                return func(*a, **kw)
+        return scipy._lib.decorator.decorate(func, caller)
+
+
+def non_reentrant(err_msg=None):
+    """
+    Decorate a function with a threading lock and prevent reentrant calls.
+    """
+    def decorator(func):
+        msg = err_msg
+        if msg is None:
+            msg = "%s is not re-entrant" % func.__name__
+        lock = ReentrancyLock(msg)
+        return lock.decorate(func)
+    return decorator

--- a/scipy/_lib/tests/test__threadsafety.py
+++ b/scipy/_lib/tests/test__threadsafety.py
@@ -1,0 +1,36 @@
+from __future__ import division, print_function, absolute_import
+
+import threading
+import time
+
+from numpy.testing import assert_equal, assert_raises
+
+from scipy._lib._threadsafety import ReentrancyLock, non_reentrant, ReentrancyError
+
+
+def test_parallel_threads():
+    results = []
+
+    lock = ReentrancyLock("failure")
+
+    def worker(k):
+        with lock:
+            time.sleep(0.01*(3 - k))
+            results.append(k)
+
+    threads = [threading.Thread(target=lambda k=k: worker(k))
+               for k in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert_equal(results, sorted(results))
+
+
+def test_reentering():
+    @non_reentrant()
+    def func(x):
+        return func(x)
+
+    assert_raises(ReentrancyError, func, 0)

--- a/scipy/sparse/linalg/eigen/arpack/arpack.pyf.src
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.pyf.src
@@ -6,6 +6,7 @@ python module _arpack ! in
     <_cd=complex,double complex>
     interface  ! in :_arpack
         subroutine <s,d>saupd(ido,bmat,n,which,nev,tol,resid,ncv,v,ldv,iparam,ipntr,workd,workl,lworkl,info) ! in :_arpack:src/ssaupd.f
+            threadsafe   ! it's not really threadsafe, but we use a lock on the Python side, so keeping GIL is not needed
             integer intent(in,out):: ido
             character*1 :: bmat
             integer optional,check(len(resid)>=n),depend(resid) :: n=len(resid)
@@ -25,6 +26,7 @@ python module _arpack ! in
         end subroutine <s,d>saupd
 
         subroutine <s,d>seupd(rvec,howmny,select,d,z,ldz,sigma,bmat,n,which,nev,tol,resid,ncv,v,ldv,iparam,ipntr,workd,workl,lworkl,info) ! in :_arpack:src/sseupd.f
+            threadsafe   ! it's not really threadsafe, but we use a lock on the Python side, so keeping GIL is not needed
             logical :: rvec
             character :: howmny
             logical dimension(ncv) :: select
@@ -50,6 +52,7 @@ python module _arpack ! in
         end subroutine <s,d>seupd
 
         subroutine <s,d>naupd(ido,bmat,n,which,nev,tol,resid,ncv,v,ldv,iparam,ipntr,workd,workl,lworkl,info) ! in :_arpack:src/snaupd.f
+            threadsafe   ! it's not really threadsafe, but we use a lock on the Python side, so keeping GIL is not needed
             integer intent(in,out):: ido
             character*1 :: bmat
             integer optional,check(len(resid)>=n),depend(resid) :: n=len(resid)
@@ -69,6 +72,7 @@ python module _arpack ! in
         end subroutine <s,d>naupd
 
         subroutine <s,d>neupd(rvec,howmny,select,dr,di,z,ldz,sigmar,sigmai,workev,bmat,n,which,nev,tol,resid,ncv,v,ldv,iparam,ipntr,workd,workl,lworkl,info) ! in ARPACK/SRC/sneupd.f
+            threadsafe   ! it's not really threadsafe, but we use a lock on the Python side, so keeping GIL is not needed
             logical :: rvec
             character :: howmny
             logical dimension(ncv) :: select
@@ -97,6 +101,7 @@ python module _arpack ! in
         end subroutine <s,d>neupd
 
         subroutine <c,z>naupd(ido,bmat,n,which,nev,tol,resid,ncv,v,ldv,iparam,ipntr,workd,workl,lworkl,rwork,info) ! in :_arpack:src/snaupd.f
+            threadsafe   ! it's not really threadsafe, but we use a lock on the Python side, so keeping GIL is not needed
             integer intent(in,out):: ido
             character*1 :: bmat
             integer optional,check(len(resid)>=n),depend(resid) :: n=len(resid)
@@ -117,6 +122,7 @@ python module _arpack ! in
         end subroutine <c,z>naupd
 
         subroutine <c,z>neupd(rvec,howmny,select,d,z,ldz,sigma,workev,bmat,n,which,nev,tol,resid,ncv,v,ldv,iparam,ipntr,workd,workl,lworkl,rwork,info) ! in :_arpack:src/sneupd.f
+            threadsafe   ! it's not really threadsafe, but we use a lock on the Python side, so keeping GIL is not needed
             logical :: rvec
             character :: howmny
             logical dimension(ncv) :: select

--- a/scipy/sparse/linalg/isolve/iterative.py
+++ b/scipy/sparse/linalg/isolve/iterative.py
@@ -10,6 +10,7 @@ from scipy.sparse.linalg.interface import LinearOperator
 from scipy._lib.decorator import decorator
 from .utils import make_system
 from scipy._lib._util import _aligned_zeros
+from scipy._lib._threadsafety import non_reentrant
 
 _type_conv = {'f':'s', 'd':'d', 'F':'c', 'D':'z'}
 
@@ -75,23 +76,11 @@ def set_docstring(header, Ainfo, footer=''):
     return combine
 
 
-@decorator
-def non_reentrant(func, *a, **kw):
-    d = func.__dict__
-    if d.get('__entered'):
-        raise RuntimeError("%s is not re-entrant" % func.__name__)
-    try:
-        d['__entered'] = True
-        return func(*a, **kw)
-    finally:
-        d['__entered'] = False
-
-
 @set_docstring('Use BIConjugate Gradient iteration to solve A x = b',
                'The real or complex N-by-N matrix of the linear system\n'
                'It is required that the linear operator can produce\n'
                '``Ax`` and ``A^T x``.')
-@non_reentrant
+@non_reentrant()
 def bicg(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None):
     A,M,x,b,postprocess = make_system(A,M,x0,b,xtype)
 
@@ -157,7 +146,7 @@ def bicg(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=Non
 @set_docstring('Use BIConjugate Gradient STABilized iteration to solve A x = b',
                'The real or complex N-by-N matrix of the linear system\n'
                '``A`` must represent a hermitian, positive definite matrix')
-@non_reentrant
+@non_reentrant()
 def bicgstab(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None):
     A,M,x,b,postprocess = make_system(A,M,x0,b,xtype)
 
@@ -218,7 +207,7 @@ def bicgstab(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback
 @set_docstring('Use Conjugate Gradient iteration to solve A x = b',
                'The real or complex N-by-N matrix of the linear system\n'
                '``A`` must represent a hermitian, positive definite matrix')
-@non_reentrant
+@non_reentrant()
 def cg(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None):
     A,M,x,b,postprocess = make_system(A,M,x0,b,xtype)
 
@@ -278,7 +267,7 @@ def cg(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None)
 
 @set_docstring('Use Conjugate Gradient Squared iteration to solve A x = b',
                'The real-valued N-by-N matrix of the linear system')
-@non_reentrant
+@non_reentrant()
 def cgs(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None):
     A,M,x,b,postprocess = make_system(A,M,x0,b,xtype)
 
@@ -336,7 +325,7 @@ def cgs(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None, callback=None
     return postprocess(x), info
 
 
-@non_reentrant
+@non_reentrant()
 def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, xtype=None, M=None, callback=None, restrt=None):
     """
     Use Generalized Minimal RESidual iteration to solve A x = b.
@@ -500,7 +489,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, xtype=None, M=Non
     return postprocess(x), info
 
 
-@non_reentrant
+@non_reentrant()
 def qmr(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M1=None, M2=None, callback=None):
     """Use Quasi-Minimal Residual iteration to solve A x = b
 


### PR DESCRIPTION
The ARPACK fortran code uses SAVE variables, and is not threadsafe or
re-entrant. Add locks and reentrancy checks to the Python side to deal
with this issue --- previously the code used to segfault.

As we use an explicit lock, it is not necessary for the Fortran code to
hold the GIL, so adjust the .pyf file accordingly.

Fixes gh-5846
