### PR TITLE
ENH: expose lapack's ilaver to python to allow lapack verion queries

### DIFF
--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -2897,6 +2897,12 @@ subroutine <prefix2c>rot(n,x,offx,incx,y,offy,incy,c,s)
     check(len(x)-offx>(n-1)*abs(incx)) :: n
     check(len(y)-offy>(n-1)*abs(incy)) :: n
 end subroutine <prefix2c>rot
+
+subroutine ilaver(major, minor, patch)
+    integer intent(out) :: major
+    integer intent(out) :: minor
+    integer intent(out) :: patch
+end subroutine ilaver
  
 end interface
 

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -343,6 +343,8 @@ All functions
    clange
    zlange
 
+   ilaver
+
 """
 #
 # Author: Pearu Peterson, March 2002


### PR DESCRIPTION
Seems like it might be useful...
