### PR TITLE
CI: upgrade to pep8==1.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
         - PEP8=1
         - NUMPYSPEC=numpy
       before_install:
-        - pip install pep8==1.5.1
+        - pip install pep8==1.7.0
         - pip install pyflakes
       script:
         - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused' > test.out; cat test.out; test \! -s test.out

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ changedir={envdir}
 commands=python {toxinidir}/runtests.py -n -m full {posargs:}
 
 [pep8]
-max_line_length=79
+max_line_length = 79
 statistics = True
-ignore = E121,E122,E123,E125,E126,E127,E128,E226,E231,E265,E302,E501,E712,W291,W293,W391
-exclude = scipy/sparse/linalg/dsolve/umfpack/_umfpack.py,scipy/sparse/sparsetools/bsr.py,scipy/sparse/sparsetools/coo.py,scipy/sparse/sparsetools/csc.py,scipy/sparse/sparsetools/csgraph.py,scipy/sparse/sparsetools/csr.py,scipy/sparse/sparsetools/dia.py,scipy/__config__.py
+ignore = E121,E122,E123,E125,E126,E127,E128,E226,E231,E251,E265,E266,E302,E402,E501,E712,E721,E731,W291,W293,W391,W503
+exclude = scipy/__config__.py


### PR DESCRIPTION
Upgrade travis to a newer pep8 version, and silence new checks it adds.
Remove non-existing ignored files from tox.ini

Linux distributions and `pip install` nowadays give you a newer pep8 version than on travis that spews errors that are not silenced in tox.ini, which makes it annoying to check your code when running `pep8 scipy`
