### PR TITLE
BUG: Allow expm for complex matrix with shape (1, 1)

### DIFF
--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -580,6 +580,27 @@ class TestExpM(TestCase):
             a = matrix([[3.,0],[0,-3.]])
             assert_array_almost_equal(expm(a), expm2(a))
 
+    def test_single_elt(self):
+        # See gh-5853
+        from scipy.sparse import csc_matrix
+
+        vOne = -2.02683397006j
+        vTwo = -2.12817566856j
+
+        mOne = csc_matrix([[vOne]], dtype='complex')
+        mTwo = csc_matrix([[vTwo]], dtype='complex')
+
+        outOne = expm(mOne)
+        outTwo = expm(mTwo)
+
+        assert_equal(type(outOne), type(mOne))
+        assert_equal(type(outTwo), type(mTwo))
+
+        assert_allclose(outOne[0, 0], complex(-0.44039415155949196,
+                                              -0.8978045395698304))
+        assert_allclose(outTwo[0, 0], complex(-0.52896401032626006,
+                                              -0.84864425749518878))
+
 
 class TestExpmFrechet(TestCase):
 

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -592,6 +592,17 @@ def _expm(A, use_exact_onenorm):
     if len(A.shape) != 2 or A.shape[0] != A.shape[1]:
         raise ValueError('expected a square matrix')
 
+    # Trivial case
+    if A.shape == (1, 1):
+        out = [[np.exp(A[0, 0])]]
+
+        # Avoid indiscriminate casting to ndarray to
+        # allow for sparse or other strange arrays
+        if isspmatrix(A):
+            return A.__class__(out)
+
+        return np.array(out)
+
     # Detect upper triangularity.
     structure = UPPER_TRIANGULAR if _is_upper_triangular(A) else None
 


### PR DESCRIPTION
Title is self-explanatory.  Closes #5853.
