### PR TITLE
TST: Expand Tests to Include NumPy Master Branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
         - REFGUIDE_CHECK=1
         - COVERAGE=
         - NPY_RELAXED_STRIDES_CHECKING=1
-        - NUMPYSPEC="--upgrade git+git://github.com/numpy/numpy.git@v1.10.2"
+        - NUMPYSPEC="--upgrade git+git://github.com/numpy/numpy.git@v1.10.4"
       addons:
         apt:
           packages:
@@ -60,6 +60,13 @@ matrix:
         - TESTMODE=full
         - COVERAGE=--coverage
         - NUMPYSPEC=numpy
+  allow_failures:
+    - python: 2.7
+      env:
+        - TESTMODE=fast
+        - COVERAGE=
+        - NUMPYSPEC="--upgrade git+git://github.com/numpy/numpy.git@master"
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
1) Update 'numpy' 'v1.10.2 to v.10.4'
2) Include allowed failure against 'numpy' master branch

I was "inspired" to do the second point because there was a 'pandas' library failure against the `master` branch of `numpy` due to a backwards-incompatible change.  I see no reason why `scipy` shouldn't check against the `master` branch too.
