### PR TITLE
extend normal distribution cdf to complex domain

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -49,7 +49,8 @@ def _lazywhere(cond, arrays, f, fillvalue=None, f2=None):
 
     arrays = np.broadcast_arrays(*arrays)
     temp = tuple(np.extract(cond, arr) for arr in arrays)
-    out = _valarray(np.shape(arrays[0]), value=fillvalue)
+    tcode = np.mintypecode([a.dtype.char for a in arrays])
+    out = _valarray(np.shape(arrays[0]), value=fillvalue, typecode=tcode)
     np.place(out, cond, f(*temp))
     if f2 is not None:
         temp = tuple(np.extract(~cond, arr) for arr in arrays)

--- a/scipy/special/_faddeeva.cxx
+++ b/scipy/special/_faddeeva.cxx
@@ -87,6 +87,14 @@ npy_cdouble faddeeva_log_ndtr(npy_cdouble zp)
 {
 
     complex<double> z(zp.real, zp.imag);
+    if (zp.real > 6) {
+        // Underflow. Close to the real axis, expand the log in log(1 - ndtr(-z)).
+        complex<double> w = -0.5 * Faddeeva::erfc(z*NPY_SQRT1_2);
+        if (abs(w) < 1e-8) {
+            return npy_cpack(real(w), imag(w));
+        }
+    }
+
     z *= -NPY_SQRT1_2;
     double x = real(z), y = imag(z);
 

--- a/scipy/special/_faddeeva.cxx
+++ b/scipy/special/_faddeeva.cxx
@@ -63,4 +63,56 @@ npy_cdouble faddeeva_dawsn_complex(npy_cdouble zp)
     return npy_cpack(real(w), imag(w));
 }
 
+/*
+ * A wrapper for a normal CDF for complex argument
+ */
+
+npy_cdouble faddeeva_ndtr(npy_cdouble zp)
+{
+    complex<double> z(zp.real, zp.imag);
+    z *= NPY_SQRT1_2;
+    complex<double> w = 0.5 * Faddeeva::erfc(-z);
+    return npy_cpack(real(w), imag(w));
+}
+
+/*
+ * Log of the normal CDF for complex arguments.
+ * 
+ * This is equivalent to log(ndtr(z)), but is more robust to overflow at $z\to\infty$.
+ * This implementation uses the Faddeva computation, $\erfc(z) = \exp(-z^2) w(iz)$,
+ * taking special care to select the principal branch of the log function
+ *           log( exp(-z^2) w(i z) )
+ */
+npy_cdouble faddeeva_log_ndtr(npy_cdouble zp)
+{
+
+    complex<double> z(zp.real, zp.imag);
+    z *= -NPY_SQRT1_2;
+    double x = real(z), y = imag(z);
+
+    /* Compute the principal branch of $log(exp(-z^2))$, using the fact that
+     * $log(e^t) = log|e^t| + i Arg(e^t)$, and that if $t = r + is$, then
+     * $e^t = e^r (\cos(s) + i \sin(s))$. 
+     */
+    double mRe_z2 = (y - x) * (x + y); // Re(-z^2), being careful of overflow
+    double mIm_z2 = -2*x*y; // Im(-z^2)
+
+    double im = fmod(mIm_z2, 2.0*NPY_PI);
+    if (im > NPY_PI) {im -= 2.0*NPY_PI;}
+
+    complex<double> val1 = complex<double>(mRe_z2, im);
+
+    complex<double> val2 = log(Faddeeva::w(complex<double>(-y, x)));
+    complex<double> result = val1 + val2 - NPY_LOGE2;
+
+    /* Again, select the principal branch: log(z) = log|z| + i arg(z), thus
+     * the imaginary part of the result should belong to [-pi, pi].
+     */
+    im = imag(result);
+    if (im >= NPY_PI){ im -= 2*NPY_PI; }
+    if (im < -NPY_PI){ im += 2*NPY_PI; }
+
+    return npy_cpack(real(result), im);
+}
+
 EXTERN_C_END

--- a/scipy/special/_faddeeva.h
+++ b/scipy/special/_faddeeva.h
@@ -31,6 +31,9 @@ npy_cdouble faddeeva_erfi_complex(npy_cdouble zp);
 double faddeeva_dawsn(double zp);
 npy_cdouble faddeeva_dawsn_complex(npy_cdouble zp);
 
+npy_cdouble faddeeva_ndtr(npy_cdouble zp);
+npy_cdouble faddeeva_log_ndtr(npy_cdouble zp);
+
 EXTERN_C_END
 
 #endif

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -66,41 +66,7 @@ def errprint(inflag=None):
         return sf_error.set_print(int(bool(inflag)))
     else:
         return sf_error.get_print()
-cdef void loop_d_dddd__As_ffff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(double, double, double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0])
-        (<float *>op0)[0] = <float>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_f_f__As_f_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef float ov0
-    for i in range(n):
-        ov0 = (<float(*)(float) nogil>func)(<float>(<float*>ip0)[0])
-        (<float *>op0)[0] = <float>ov0
-        ip0 += steps[0]
-        op0 += steps[1]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_ddi_d_As_ddl_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_i_ddd_dd_As_fff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
@@ -112,19 +78,148 @@ cdef void loop_d_ddi_d_As_ddl_dd(char **args, np.npy_intp *dims, np.npy_intp *st
     cdef double ov0
     cdef double ov1
     for i in range(n):
-        if <int>(<long*>ip2)[0] == (<long*>ip2)[0]:
-            ov0 = (<double(*)(double, double, int, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <int>(<long*>ip2)[0], &ov1)
-        else:
-            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
-            ov0 = <double>NPY_NAN
-            ov1 = <double>NPY_NAN
-        (<double *>op0)[0] = <double>ov0
-        (<double *>op1)[0] = <double>ov1
+        (<int(*)(double, double, double, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], &ov0, &ov1)
+        (<float *>op0)[0] = <float>ov0
+        (<float *>op1)[0] = <float>ov1
         ip0 += steps[0]
         ip1 += steps[1]
         ip2 += steps[2]
         op0 += steps[3]
         op1 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_DD__As_DD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double complex, double complex) nogil>func)(<double complex>(<double complex*>ip0)[0], <double complex>(<double complex*>ip1)[0])
+        (<double complex *>op0)[0] = <double complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_g_g__As_g_g(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef long double ov0
+    for i in range(n):
+        ov0 = (<long double(*)(long double) nogil>func)(<long double>(<long double*>ip0)[0])
+        (<long double *>op0)[0] = <long double>ov0
+        ip0 += steps[0]
+        op0 += steps[1]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_dd_dd_As_ff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef char *op1 = args[3]
+    cdef double ov0
+    cdef double ov1
+    for i in range(n):
+        (<int(*)(double, double, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], &ov0, &ov1)
+        (<float *>op0)[0] = <float>ov0
+        (<float *>op1)[0] = <float>ov1
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
+        op1 += steps[3]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_dddd__As_dddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(double, double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_dd__As_dd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0])
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_lD__As_lD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(long, double complex) nogil>func)(<long>(<long*>ip0)[0], <double complex>(<double complex*>ip1)[0])
+        (<double complex *>op0)[0] = <double complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_d__As_d_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(double) nogil>func)(<double>(<double*>ip0)[0])
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        op0 += steps[1]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_d_DD_As_d_DD(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef double complex ov0
+    cdef double complex ov1
+    for i in range(n):
+        (<int(*)(double, double complex *, double complex *) nogil>func)(<double>(<double*>ip0)[0], &ov0, &ov1)
+        (<double complex *>op0)[0] = <double complex>ov0
+        (<double complex *>op1)[0] = <double complex>ov1
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
     sf_error.check_fpe(func_name)
 
 cdef void loop_i_ddddd_dd_As_ddddd_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -169,6 +264,26 @@ cdef void loop_D_dD__As_dD_D(char **args, np.npy_intp *dims, np.npy_intp *steps,
         op0 += steps[2]
     sf_error.check_fpe(func_name)
 
+cdef void loop_D_dddd__As_dddd_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double, double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
+        (<double complex *>op0)[0] = <double complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+    sf_error.check_fpe(func_name)
+
 cdef void loop_d_d__As_f_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
@@ -183,39 +298,7 @@ cdef void loop_d_d__As_f_f(char **args, np.npy_intp *dims, np.npy_intp *steps, v
         op0 += steps[1]
     sf_error.check_fpe(func_name)
 
-cdef void loop_i_d_dd_As_d_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef double ov0
-    cdef double ov1
-    for i in range(n):
-        (<int(*)(double, double *, double *) nogil>func)(<double>(<double*>ip0)[0], &ov0, &ov1)
-        (<double *>op0)[0] = <double>ov0
-        (<double *>op1)[0] = <double>ov1
-        ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_D__As_D_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double complex) nogil>func)(<double complex>(<double complex*>ip0)[0])
-        (<double complex *>op0)[0] = <double complex>ov0
-        ip0 += steps[0]
-        op0 += steps[1]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_iidd__As_lldd_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_d_lddd__As_lddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
@@ -224,136 +307,15 @@ cdef void loop_D_iidd__As_lldd_D(char **args, np.npy_intp *dims, np.npy_intp *st
     cdef char *ip2 = args[2]
     cdef char *ip3 = args[3]
     cdef char *op0 = args[4]
-    cdef double complex ov0
+    cdef double ov0
     for i in range(n):
-        if <int>(<long*>ip0)[0] == (<long*>ip0)[0] and <int>(<long*>ip1)[0] == (<long*>ip1)[0]:
-            ov0 = (<double complex(*)(int, int, double, double) nogil>func)(<int>(<long*>ip0)[0], <int>(<long*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
-        else:
-            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
-            ov0 = <double complex>NPY_NAN
-        (<double complex *>op0)[0] = <double complex>ov0
+        ov0 = (<double(*)(long, double, double, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
+        (<double *>op0)[0] = <double>ov0
         ip0 += steps[0]
         ip1 += steps[1]
         ip2 += steps[2]
         ip3 += steps[3]
         op0 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_D_DD_As_F_FF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef double complex ov0
-    cdef double complex ov1
-    for i in range(n):
-        (<int(*)(double complex, double complex *, double complex *) nogil>func)(<double complex>(<float complex*>ip0)[0], &ov0, &ov1)
-        (<float complex *>op0)[0] = <float complex>ov0
-        (<float complex *>op1)[0] = <float complex>ov1
-        ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_d_DDDD_As_f_FFFF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef char *op2 = args[3]
-    cdef char *op3 = args[4]
-    cdef double complex ov0
-    cdef double complex ov1
-    cdef double complex ov2
-    cdef double complex ov3
-    for i in range(n):
-        (<int(*)(double, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
-        (<float complex *>op0)[0] = <float complex>ov0
-        (<float complex *>op1)[0] = <float complex>ov1
-        (<float complex *>op2)[0] = <float complex>ov2
-        (<float complex *>op3)[0] = <float complex>ov3
-        ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
-        op2 += steps[3]
-        op3 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_D_DDDD_As_F_FFFF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef char *op2 = args[3]
-    cdef char *op3 = args[4]
-    cdef double complex ov0
-    cdef double complex ov1
-    cdef double complex ov2
-    cdef double complex ov3
-    for i in range(n):
-        (<int(*)(double complex, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double complex>(<float complex*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
-        (<float complex *>op0)[0] = <float complex>ov0
-        (<float complex *>op1)[0] = <float complex>ov1
-        (<float complex *>op2)[0] = <float complex>ov2
-        (<float complex *>op3)[0] = <float complex>ov3
-        ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
-        op2 += steps[3]
-        op3 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_dddi_d_As_dddl_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef char *op1 = args[5]
-    cdef double ov0
-    cdef double ov1
-    for i in range(n):
-        if <int>(<long*>ip3)[0] == (<long*>ip3)[0]:
-            ov0 = (<double(*)(double, double, double, int, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <int>(<long*>ip3)[0], &ov1)
-        else:
-            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
-            ov0 = <double>NPY_NAN
-            ov1 = <double>NPY_NAN
-        (<double *>op0)[0] = <double>ov0
-        (<double *>op1)[0] = <double>ov1
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-        op1 += steps[5]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_ldd__As_ldd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *op0 = args[3]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(long, double, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0])
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        op0 += steps[3]
     sf_error.check_fpe(func_name)
 
 cdef void loop_d_ddd__As_fff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -374,111 +336,23 @@ cdef void loop_d_ddd__As_fff_f(char **args, np.npy_intp *dims, np.npy_intp *step
         op0 += steps[3]
     sf_error.check_fpe(func_name)
 
-cdef void loop_d_dd__As_ff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_D_DD__As_FF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
     cdef char *ip0 = args[0]
     cdef char *ip1 = args[1]
     cdef char *op0 = args[2]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0])
-        (<float *>op0)[0] = <float>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_dd_dddd_As_ff_ffff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef char *op1 = args[3]
-    cdef char *op2 = args[4]
-    cdef char *op3 = args[5]
-    cdef double ov0
-    cdef double ov1
-    cdef double ov2
-    cdef double ov3
-    for i in range(n):
-        (<int(*)(double, double, double *, double *, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], &ov0, &ov1, &ov2, &ov3)
-        (<float *>op0)[0] = <float>ov0
-        (<float *>op1)[0] = <float>ov1
-        (<float *>op2)[0] = <float>ov2
-        (<float *>op3)[0] = <float>ov3
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-        op1 += steps[3]
-        op2 += steps[4]
-        op3 += steps[5]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_dd_dd_As_dd_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef char *op1 = args[3]
-    cdef double ov0
-    cdef double ov1
-    for i in range(n):
-        (<int(*)(double, double, double *, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], &ov0, &ov1)
-        (<double *>op0)[0] = <double>ov0
-        (<double *>op1)[0] = <double>ov1
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-        op1 += steps[3]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_ddd_dd_As_fff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *op0 = args[3]
-    cdef char *op1 = args[4]
-    cdef double ov0
-    cdef double ov1
-    for i in range(n):
-        (<int(*)(double, double, double, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], &ov0, &ov1)
-        (<float *>op0)[0] = <float>ov0
-        (<float *>op1)[0] = <float>ov1
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        op0 += steps[3]
-        op1 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_ddD__As_ddD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *op0 = args[3]
     cdef double complex ov0
     for i in range(n):
-        ov0 = (<double complex(*)(double, double, double complex) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double complex>(<double complex*>ip2)[0])
-        (<double complex *>op0)[0] = <double complex>ov0
+        ov0 = (<double complex(*)(double complex, double complex) nogil>func)(<double complex>(<float complex*>ip0)[0], <double complex>(<float complex*>ip1)[0])
+        (<float complex *>op0)[0] = <float complex>ov0
         ip0 += steps[0]
         ip1 += steps[1]
-        ip2 += steps[2]
-        op0 += steps[3]
+        op0 += steps[2]
     sf_error.check_fpe(func_name)
 
-cdef void loop_D_dddD__As_dddD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_d_dddd__As_ffff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
@@ -487,10 +361,10 @@ cdef void loop_D_dddD__As_dddD_D(char **args, np.npy_intp *dims, np.npy_intp *st
     cdef char *ip2 = args[2]
     cdef char *ip3 = args[3]
     cdef char *op0 = args[4]
-    cdef double complex ov0
+    cdef double ov0
     for i in range(n):
-        ov0 = (<double complex(*)(double, double, double, double complex) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double complex>(<double complex*>ip3)[0])
-        (<double complex *>op0)[0] = <double complex>ov0
+        ov0 = (<double(*)(double, double, double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0])
+        (<float *>op0)[0] = <float>ov0
         ip0 += steps[0]
         ip1 += steps[1]
         ip2 += steps[2]
@@ -498,56 +372,18 @@ cdef void loop_D_dddD__As_dddD_D(char **args, np.npy_intp *dims, np.npy_intp *st
         op0 += steps[4]
     sf_error.check_fpe(func_name)
 
-cdef void loop_i_d_dddd_As_d_dddd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_f_f__As_f_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
     cdef char *ip0 = args[0]
     cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef char *op2 = args[3]
-    cdef char *op3 = args[4]
-    cdef double ov0
-    cdef double ov1
-    cdef double ov2
-    cdef double ov3
+    cdef float ov0
     for i in range(n):
-        (<int(*)(double, double *, double *, double *, double *) nogil>func)(<double>(<double*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
-        (<double *>op0)[0] = <double>ov0
-        (<double *>op1)[0] = <double>ov1
-        (<double *>op2)[0] = <double>ov2
-        (<double *>op3)[0] = <double>ov3
+        ov0 = (<float(*)(float) nogil>func)(<float>(<float*>ip0)[0])
+        (<float *>op0)[0] = <float>ov0
         ip0 += steps[0]
         op0 += steps[1]
-        op1 += steps[2]
-        op2 += steps[3]
-        op3 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_ddddd_dd_As_fffff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *ip4 = args[4]
-    cdef char *op0 = args[5]
-    cdef char *op1 = args[6]
-    cdef double ov0
-    cdef double ov1
-    for i in range(n):
-        (<int(*)(double, double, double, double, double, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0], <double>(<float*>ip4)[0], &ov0, &ov1)
-        (<float *>op0)[0] = <float>ov0
-        (<float *>op1)[0] = <float>ov1
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        ip4 += steps[4]
-        op0 += steps[5]
-        op1 += steps[6]
     sf_error.check_fpe(func_name)
 
 cdef void loop_D_D__As_F_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -564,30 +400,70 @@ cdef void loop_D_D__As_F_F(char **args, np.npy_intp *dims, np.npy_intp *steps, v
         op0 += steps[1]
     sf_error.check_fpe(func_name)
 
-cdef void loop_i_d_DDDD_As_d_DDDD(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_d_ddiiddd__As_ddllddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *ip4 = args[4]
+    cdef char *ip5 = args[5]
+    cdef char *ip6 = args[6]
+    cdef char *op0 = args[7]
+    cdef double ov0
+    for i in range(n):
+        if <int>(<long*>ip2)[0] == (<long*>ip2)[0] and <int>(<long*>ip3)[0] == (<long*>ip3)[0]:
+            ov0 = (<double(*)(double, double, int, int, double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <int>(<long*>ip2)[0], <int>(<long*>ip3)[0], <double>(<double*>ip4)[0], <double>(<double*>ip5)[0], <double>(<double*>ip6)[0])
+        else:
+            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
+            ov0 = <double>NPY_NAN
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        ip4 += steps[4]
+        ip5 += steps[5]
+        ip6 += steps[6]
+        op0 += steps[7]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_D_DD_As_D_DD(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
     cdef char *ip0 = args[0]
     cdef char *op0 = args[1]
     cdef char *op1 = args[2]
-    cdef char *op2 = args[3]
-    cdef char *op3 = args[4]
     cdef double complex ov0
     cdef double complex ov1
-    cdef double complex ov2
-    cdef double complex ov3
     for i in range(n):
-        (<int(*)(double, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double>(<double*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
+        (<int(*)(double complex, double complex *, double complex *) nogil>func)(<double complex>(<double complex*>ip0)[0], &ov0, &ov1)
         (<double complex *>op0)[0] = <double complex>ov0
         (<double complex *>op1)[0] = <double complex>ov1
-        (<double complex *>op2)[0] = <double complex>ov2
-        (<double complex *>op3)[0] = <double complex>ov3
         ip0 += steps[0]
         op0 += steps[1]
         op1 += steps[2]
-        op2 += steps[3]
-        op3 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_ddd__As_ddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0])
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        op0 += steps[3]
     sf_error.check_fpe(func_name)
 
 cdef void loop_i_ddd_dd_As_ddd_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -610,176 +486,6 @@ cdef void loop_i_ddd_dd_As_ddd_dd(char **args, np.npy_intp *dims, np.npy_intp *s
         ip2 += steps[2]
         op0 += steps[3]
         op1 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_dddd__As_ffff_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double, double, double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0])
-        (<float complex *>op0)[0] = <float complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_Dld__As_Dld_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *op0 = args[3]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double complex, long, double) nogil>func)(<double complex>(<double complex*>ip0)[0], <long>(<long*>ip1)[0], <double>(<double*>ip2)[0])
-        (<double complex *>op0)[0] = <double complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        op0 += steps[3]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_DD__As_DD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double complex, double complex) nogil>func)(<double complex>(<double complex*>ip0)[0], <double complex>(<double complex*>ip1)[0])
-        (<double complex *>op0)[0] = <double complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_dd_dd_As_ff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef char *op1 = args[3]
-    cdef double ov0
-    cdef double ov1
-    for i in range(n):
-        (<int(*)(double, double, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], &ov0, &ov1)
-        (<float *>op0)[0] = <float>ov0
-        (<float *>op1)[0] = <float>ov1
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-        op1 += steps[3]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_dddD__As_fffF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double, double, double, double complex) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double complex>(<float complex*>ip3)[0])
-        (<float complex *>op0)[0] = <float complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_dddd__As_dddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(double, double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_DD__As_FF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double complex, double complex) nogil>func)(<double complex>(<float complex*>ip0)[0], <double complex>(<float complex*>ip1)[0])
-        (<float complex *>op0)[0] = <float complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_iid__As_lld_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *op0 = args[3]
-    cdef double ov0
-    for i in range(n):
-        if <int>(<long*>ip0)[0] == (<long*>ip0)[0] and <int>(<long*>ip1)[0] == (<long*>ip1)[0]:
-            ov0 = (<double(*)(int, int, double) nogil>func)(<int>(<long*>ip0)[0], <int>(<long*>ip1)[0], <double>(<double*>ip2)[0])
-        else:
-            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
-            ov0 = <double>NPY_NAN
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        op0 += steps[3]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_d_DD_As_d_DD(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef double complex ov0
-    cdef double complex ov1
-    for i in range(n):
-        (<int(*)(double, double complex *, double complex *) nogil>func)(<double>(<double*>ip0)[0], &ov0, &ov1)
-        (<double complex *>op0)[0] = <double complex>ov0
-        (<double complex *>op1)[0] = <double complex>ov1
-        ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
     sf_error.check_fpe(func_name)
 
 cdef void loop_d_ddddddd__As_ddddddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -808,126 +514,32 @@ cdef void loop_d_ddddddd__As_ddddddd_d(char **args, np.npy_intp *dims, np.npy_in
         op0 += steps[7]
     sf_error.check_fpe(func_name)
 
-cdef void loop_d_d__As_d_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(double) nogil>func)(<double>(<double*>ip0)[0])
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        op0 += steps[1]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_dddd_d_As_ffff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_i_dd_dddd_As_ff_ffff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
     cdef char *ip0 = args[0]
     cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef char *op1 = args[5]
-    cdef double ov0
-    cdef double ov1
-    for i in range(n):
-        ov0 = (<double(*)(double, double, double, double, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0], &ov1)
-        (<float *>op0)[0] = <float>ov0
-        (<float *>op1)[0] = <float>ov1
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-        op1 += steps[5]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_dddd__As_dddd_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double, double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
-        (<double complex *>op0)[0] = <double complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_lddd__As_lddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(long, double, double, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_ddD__As_ffF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *op0 = args[3]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double, double, double complex) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double complex>(<float complex*>ip2)[0])
-        (<float complex *>op0)[0] = <float complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        op0 += steps[3]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_d_dddd_As_f_ffff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef char *op2 = args[3]
-    cdef char *op3 = args[4]
+    cdef char *op0 = args[2]
+    cdef char *op1 = args[3]
+    cdef char *op2 = args[4]
+    cdef char *op3 = args[5]
     cdef double ov0
     cdef double ov1
     cdef double ov2
     cdef double ov3
     for i in range(n):
-        (<int(*)(double, double *, double *, double *, double *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
+        (<int(*)(double, double, double *, double *, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], &ov0, &ov1, &ov2, &ov3)
         (<float *>op0)[0] = <float>ov0
         (<float *>op1)[0] = <float>ov1
         (<float *>op2)[0] = <float>ov2
         (<float *>op3)[0] = <float>ov3
         ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
-        op2 += steps[3]
-        op3 += steps[4]
+        ip1 += steps[1]
+        op0 += steps[2]
+        op1 += steps[3]
+        op2 += steps[4]
+        op3 += steps[5]
     sf_error.check_fpe(func_name)
 
 cdef void loop_d_ddddddd__As_fffffff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -980,7 +592,49 @@ cdef void loop_d_dddd_d_As_dddd_dd(char **args, np.npy_intp *dims, np.npy_intp *
         op1 += steps[5]
     sf_error.check_fpe(func_name)
 
-cdef void loop_i_D_DD_As_D_DD(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_i_d_dddd_As_d_dddd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
+    cdef double ov0
+    cdef double ov1
+    cdef double ov2
+    cdef double ov3
+    for i in range(n):
+        (<int(*)(double, double *, double *, double *, double *) nogil>func)(<double>(<double*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
+        (<double *>op0)[0] = <double>ov0
+        (<double *>op1)[0] = <double>ov1
+        (<double *>op2)[0] = <double>ov2
+        (<double *>op3)[0] = <double>ov3
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+        op2 += steps[3]
+        op3 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_ld__As_ld_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(long, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<double*>ip1)[0])
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_d_DD_As_f_FF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
@@ -990,15 +644,391 @@ cdef void loop_i_D_DD_As_D_DD(char **args, np.npy_intp *dims, np.npy_intp *steps
     cdef double complex ov0
     cdef double complex ov1
     for i in range(n):
-        (<int(*)(double complex, double complex *, double complex *) nogil>func)(<double complex>(<double complex*>ip0)[0], &ov0, &ov1)
-        (<double complex *>op0)[0] = <double complex>ov0
-        (<double complex *>op1)[0] = <double complex>ov1
+        (<int(*)(double, double complex *, double complex *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1)
+        (<float complex *>op0)[0] = <float complex>ov0
+        (<float complex *>op1)[0] = <float complex>ov1
         ip0 += steps[0]
         op0 += steps[1]
         op1 += steps[2]
     sf_error.check_fpe(func_name)
 
-cdef void loop_d_ddiiddd__As_ddllddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_i_d_dddd_As_f_ffff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
+    cdef double ov0
+    cdef double ov1
+    cdef double ov2
+    cdef double ov3
+    for i in range(n):
+        (<int(*)(double, double *, double *, double *, double *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
+        (<float *>op0)[0] = <float>ov0
+        (<float *>op1)[0] = <float>ov1
+        (<float *>op2)[0] = <float>ov2
+        (<float *>op3)[0] = <float>ov3
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+        op2 += steps[3]
+        op3 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_dddD__As_fffF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double, double, double, double complex) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double complex>(<float complex*>ip3)[0])
+        (<float complex *>op0)[0] = <float complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_dddd_d_As_ffff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef char *op1 = args[5]
+    cdef double ov0
+    cdef double ov1
+    for i in range(n):
+        ov0 = (<double(*)(double, double, double, double, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0], &ov1)
+        (<float *>op0)[0] = <float>ov0
+        (<float *>op1)[0] = <float>ov1
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+        op1 += steps[5]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_dddd__As_ffff_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double, double, double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0])
+        (<float complex *>op0)[0] = <float complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_D__As_D_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double complex) nogil>func)(<double complex>(<double complex*>ip0)[0])
+        (<double complex *>op0)[0] = <double complex>ov0
+        ip0 += steps[0]
+        op0 += steps[1]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_ddD__As_ffF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double, double, double complex) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double complex>(<float complex*>ip2)[0])
+        (<float complex *>op0)[0] = <float complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        op0 += steps[3]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_d_DDDD_As_f_FFFF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
+    cdef double complex ov0
+    cdef double complex ov1
+    cdef double complex ov2
+    cdef double complex ov3
+    for i in range(n):
+        (<int(*)(double, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
+        (<float complex *>op0)[0] = <float complex>ov0
+        (<float complex *>op1)[0] = <float complex>ov1
+        (<float complex *>op2)[0] = <float complex>ov2
+        (<float complex *>op3)[0] = <float complex>ov3
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+        op2 += steps[3]
+        op3 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_iidd__As_lldd_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef double complex ov0
+    for i in range(n):
+        if <int>(<long*>ip0)[0] == (<long*>ip0)[0] and <int>(<long*>ip1)[0] == (<long*>ip1)[0]:
+            ov0 = (<double complex(*)(int, int, double, double) nogil>func)(<int>(<long*>ip0)[0], <int>(<long*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
+        else:
+            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
+            ov0 = <double complex>NPY_NAN
+        (<double complex *>op0)[0] = <double complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_d_DDDD_As_d_DDDD(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
+    cdef double complex ov0
+    cdef double complex ov1
+    cdef double complex ov2
+    cdef double complex ov3
+    for i in range(n):
+        (<int(*)(double, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double>(<double*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
+        (<double complex *>op0)[0] = <double complex>ov0
+        (<double complex *>op1)[0] = <double complex>ov1
+        (<double complex *>op2)[0] = <double complex>ov2
+        (<double complex *>op3)[0] = <double complex>ov3
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+        op2 += steps[3]
+        op3 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_ddD__As_ddD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double, double, double complex) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double complex>(<double complex*>ip2)[0])
+        (<double complex *>op0)[0] = <double complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        op0 += steps[3]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_Dld__As_Dld_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double complex, long, double) nogil>func)(<double complex>(<double complex*>ip0)[0], <long>(<long*>ip1)[0], <double>(<double*>ip2)[0])
+        (<double complex *>op0)[0] = <double complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        op0 += steps[3]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_D_DDDD_As_D_DDDD(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
+    cdef double complex ov0
+    cdef double complex ov1
+    cdef double complex ov2
+    cdef double complex ov3
+    for i in range(n):
+        (<int(*)(double complex, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double complex>(<double complex*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
+        (<double complex *>op0)[0] = <double complex>ov0
+        (<double complex *>op1)[0] = <double complex>ov1
+        (<double complex *>op2)[0] = <double complex>ov2
+        (<double complex *>op3)[0] = <double complex>ov3
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+        op2 += steps[3]
+        op3 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_d_dd_As_d_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef double ov0
+    cdef double ov1
+    for i in range(n):
+        (<int(*)(double, double *, double *) nogil>func)(<double>(<double*>ip0)[0], &ov0, &ov1)
+        (<double *>op0)[0] = <double>ov0
+        (<double *>op1)[0] = <double>ov1
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_dddi_d_As_dddl_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef char *op1 = args[5]
+    cdef double ov0
+    cdef double ov1
+    for i in range(n):
+        if <int>(<long*>ip3)[0] == (<long*>ip3)[0]:
+            ov0 = (<double(*)(double, double, double, int, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <int>(<long*>ip3)[0], &ov1)
+        else:
+            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
+            ov0 = <double>NPY_NAN
+            ov1 = <double>NPY_NAN
+        (<double *>op0)[0] = <double>ov0
+        (<double *>op1)[0] = <double>ov1
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+        op1 += steps[5]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_ddi_d_As_ddl_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef char *op1 = args[4]
+    cdef double ov0
+    cdef double ov1
+    for i in range(n):
+        if <int>(<long*>ip2)[0] == (<long*>ip2)[0]:
+            ov0 = (<double(*)(double, double, int, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <int>(<long*>ip2)[0], &ov1)
+        else:
+            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
+            ov0 = <double>NPY_NAN
+            ov1 = <double>NPY_NAN
+        (<double *>op0)[0] = <double>ov0
+        (<double *>op1)[0] = <double>ov1
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        op0 += steps[3]
+        op1 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_dddD__As_dddD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double, double, double, double complex) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double complex>(<double complex*>ip3)[0])
+        (<double complex *>op0)[0] = <double complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_iid__As_lld_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef double ov0
+    for i in range(n):
+        if <int>(<long*>ip0)[0] == (<long*>ip0)[0] and <int>(<long*>ip1)[0] == (<long*>ip1)[0]:
+            ov0 = (<double(*)(int, int, double) nogil>func)(<int>(<long*>ip0)[0], <int>(<long*>ip1)[0], <double>(<double*>ip2)[0])
+        else:
+            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
+            ov0 = <double>NPY_NAN
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        op0 += steps[3]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_ddddd_dd_As_fffff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
@@ -1007,25 +1037,75 @@ cdef void loop_d_ddiiddd__As_ddllddd_d(char **args, np.npy_intp *dims, np.npy_in
     cdef char *ip2 = args[2]
     cdef char *ip3 = args[3]
     cdef char *ip4 = args[4]
-    cdef char *ip5 = args[5]
-    cdef char *ip6 = args[6]
-    cdef char *op0 = args[7]
+    cdef char *op0 = args[5]
+    cdef char *op1 = args[6]
+    cdef double ov0
+    cdef double ov1
+    for i in range(n):
+        (<int(*)(double, double, double, double, double, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0], <double>(<float*>ip4)[0], &ov0, &ov1)
+        (<float *>op0)[0] = <float>ov0
+        (<float *>op1)[0] = <float>ov1
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        ip4 += steps[4]
+        op0 += steps[5]
+        op1 += steps[6]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_D_DD_As_F_FF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef double complex ov0
+    cdef double complex ov1
+    for i in range(n):
+        (<int(*)(double complex, double complex *, double complex *) nogil>func)(<double complex>(<float complex*>ip0)[0], &ov0, &ov1)
+        (<float complex *>op0)[0] = <float complex>ov0
+        (<float complex *>op1)[0] = <float complex>ov1
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_id__As_ld_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
     cdef double ov0
     for i in range(n):
-        if <int>(<long*>ip2)[0] == (<long*>ip2)[0] and <int>(<long*>ip3)[0] == (<long*>ip3)[0]:
-            ov0 = (<double(*)(double, double, int, int, double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <int>(<long*>ip2)[0], <int>(<long*>ip3)[0], <double>(<double*>ip4)[0], <double>(<double*>ip5)[0], <double>(<double*>ip6)[0])
+        if <int>(<long*>ip0)[0] == (<long*>ip0)[0]:
+            ov0 = (<double(*)(int, double) nogil>func)(<int>(<long*>ip0)[0], <double>(<double*>ip1)[0])
         else:
             sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
             ov0 = <double>NPY_NAN
         (<double *>op0)[0] = <double>ov0
         ip0 += steps[0]
         ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        ip4 += steps[4]
-        ip5 += steps[5]
-        ip6 += steps[6]
-        op0 += steps[7]
+        op0 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_dd__As_ff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0])
+        (<float *>op0)[0] = <float>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
     sf_error.check_fpe(func_name)
 
 cdef void loop_i_dd_dddd_As_dd_dddd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -1054,6 +1134,24 @@ cdef void loop_i_dd_dddd_As_dd_dddd(char **args, np.npy_intp *dims, np.npy_intp 
         op1 += steps[3]
         op2 += steps[4]
         op3 += steps[5]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_ldd__As_ldd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(long, double, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0])
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        op0 += steps[3]
     sf_error.check_fpe(func_name)
 
 cdef void loop_D_dD__As_fF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -1090,75 +1188,7 @@ cdef void loop_i_d_dd_As_f_ff(char **args, np.npy_intp *dims, np.npy_intp *steps
         op1 += steps[2]
     sf_error.check_fpe(func_name)
 
-cdef void loop_d_ld__As_ld_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(long, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<double*>ip1)[0])
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_dd__As_dd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0])
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_d_DD_As_f_FF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef double complex ov0
-    cdef double complex ov1
-    for i in range(n):
-        (<int(*)(double, double complex *, double complex *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1)
-        (<float complex *>op0)[0] = <float complex>ov0
-        (<float complex *>op1)[0] = <float complex>ov1
-        ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_ddd__As_ddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *op0 = args[3]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0])
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        op0 += steps[3]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_D_DDDD_As_D_DDDD(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_i_D_DDDD_As_F_FFFF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
@@ -1172,11 +1202,11 @@ cdef void loop_i_D_DDDD_As_D_DDDD(char **args, np.npy_intp *dims, np.npy_intp *s
     cdef double complex ov2
     cdef double complex ov3
     for i in range(n):
-        (<int(*)(double complex, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double complex>(<double complex*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
-        (<double complex *>op0)[0] = <double complex>ov0
-        (<double complex *>op1)[0] = <double complex>ov1
-        (<double complex *>op2)[0] = <double complex>ov2
-        (<double complex *>op3)[0] = <double complex>ov3
+        (<int(*)(double complex, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double complex>(<float complex*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
+        (<float complex *>op0)[0] = <float complex>ov0
+        (<float complex *>op1)[0] = <float complex>ov1
+        (<float complex *>op2)[0] = <float complex>ov2
+        (<float complex *>op3)[0] = <float complex>ov3
         ip0 += steps[0]
         op0 += steps[1]
         op1 += steps[2]
@@ -1184,62 +1214,26 @@ cdef void loop_i_D_DDDD_As_D_DDDD(char **args, np.npy_intp *dims, np.npy_intp *s
         op3 += steps[4]
     sf_error.check_fpe(func_name)
 
-cdef void loop_d_id__As_ld_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_i_dd_dd_As_dd_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
     cdef char *ip0 = args[0]
     cdef char *ip1 = args[1]
     cdef char *op0 = args[2]
+    cdef char *op1 = args[3]
     cdef double ov0
+    cdef double ov1
     for i in range(n):
-        if <int>(<long*>ip0)[0] == (<long*>ip0)[0]:
-            ov0 = (<double(*)(int, double) nogil>func)(<int>(<long*>ip0)[0], <double>(<double*>ip1)[0])
-        else:
-            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
-            ov0 = <double>NPY_NAN
+        (<int(*)(double, double, double *, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], &ov0, &ov1)
         (<double *>op0)[0] = <double>ov0
+        (<double *>op1)[0] = <double>ov1
         ip0 += steps[0]
         ip1 += steps[1]
         op0 += steps[2]
+        op1 += steps[3]
     sf_error.check_fpe(func_name)
 
-cdef void loop_g_g__As_g_g(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef long double ov0
-    for i in range(n):
-        ov0 = (<long double(*)(long double) nogil>func)(<long double>(<long double*>ip0)[0])
-        (<long double *>op0)[0] = <long double>ov0
-        ip0 += steps[0]
-        op0 += steps[1]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_lD__As_lD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(long, double complex) nogil>func)(<long>(<long*>ip0)[0], <double complex>(<double complex*>ip1)[0])
-        (<double complex *>op0)[0] = <double complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-    sf_error.check_fpe(func_name)
-
-from _trig cimport cospi as _func_cospi
-ctypedef double _proto_cospi_double__t(double) nogil
-cdef _proto_cospi_double__t *_proto_cospi_double__t_var = &_func_cospi[double]
-from _trig cimport cospi as _func_cospi
-ctypedef double complex _proto_cospi_double_complex__t(double complex) nogil
-cdef _proto_cospi_double_complex__t *_proto_cospi_double_complex__t_var = &_func_cospi[double_complex]
 from _ellip_harm cimport ellip_harmonic as _func_ellip_harmonic
 ctypedef double _proto_ellip_harmonic_t(double, double, int, int, double, double, double) nogil
 cdef _proto_ellip_harmonic_t *_proto_ellip_harmonic_t_var = &_func_ellip_harmonic
@@ -1253,12 +1247,6 @@ cdef extern from "_ufuncs_defs.h":
 from lambertw cimport lambertw_scalar as _func_lambertw_scalar
 ctypedef double complex _proto_lambertw_scalar_t(double complex, long, double) nogil
 cdef _proto_lambertw_scalar_t *_proto_lambertw_scalar_t_var = &_func_lambertw_scalar
-from _trig cimport sinpi as _func_sinpi
-ctypedef double _proto_sinpi_double__t(double) nogil
-cdef _proto_sinpi_double__t *_proto_sinpi_double__t_var = &_func_sinpi[double]
-from _trig cimport sinpi as _func_sinpi
-ctypedef double complex _proto_sinpi_double_complex__t(double complex) nogil
-cdef _proto_sinpi_double_complex__t *_proto_sinpi_double_complex__t_var = &_func_sinpi[double_complex]
 from _spherical_bessel cimport spherical_in_real as _func_spherical_in_real
 ctypedef double _proto_spherical_in_real_t(long, double) nogil
 cdef _proto_spherical_in_real_t *_proto_spherical_in_real_t_var = &_func_spherical_in_real
@@ -1313,8 +1301,6 @@ cdef extern from "_ufuncs_defs.h":
     cdef double _func_struve_bessel_series "struve_bessel_series"(double, double, int, double *) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_struve_power_series "struve_power_series"(double, double, int, double *) nogil
-cdef extern from "_ufuncs_defs.h":
-    cdef double _func_zeta "zeta"(double, double) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef int _func_airy_wrap "airy_wrap"(double, double *, double *, double *, double *) nogil
 cdef extern from "_ufuncs_defs.h":
@@ -1874,12 +1860,10 @@ cdef extern from "_ufuncs_defs.h":
 from _convex_analysis cimport pseudo_huber as _func_pseudo_huber
 ctypedef double _proto_pseudo_huber_t(double, double) nogil
 cdef _proto_pseudo_huber_t *_proto_pseudo_huber_t_var = &_func_pseudo_huber
-from _digamma cimport digamma as _func_digamma
-ctypedef double _proto_digamma_t(double) nogil
-cdef _proto_digamma_t *_proto_digamma_t_var = &_func_digamma
-from _digamma cimport cdigamma as _func_cdigamma
-ctypedef double complex _proto_cdigamma_t(double complex) nogil
-cdef _proto_cdigamma_t *_proto_cdigamma_t_var = &_func_cdigamma
+cdef extern from "_ufuncs_defs.h":
+    cdef double _func_psi "psi"(double) nogil
+cdef extern from "_ufuncs_defs.h":
+    cdef double complex _func_cpsi_wrap "cpsi_wrap"(double complex) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_radian "radian"(double, double, double) nogil
 from _convex_analysis cimport rel_entr as _func_rel_entr
@@ -1961,39 +1945,9 @@ cdef extern from "_ufuncs_defs.h":
 cdef extern from "_ufuncs_defs.h":
     cdef double complex _func_cbesy_wrap_e "cbesy_wrap_e"(double, double complex) nogil
 cdef extern from "_ufuncs_defs.h":
+    cdef double _func_zeta "zeta"(double, double) nogil
+cdef extern from "_ufuncs_defs.h":
     cdef double _func_zetac "zetac"(double) nogil
-cdef np.PyUFuncGenericFunction ufunc__cospi_loops[4]
-cdef void *ufunc__cospi_ptr[8]
-cdef void *ufunc__cospi_data[4]
-cdef char ufunc__cospi_types[8]
-cdef char *ufunc__cospi_doc = (
-    "Internal function, do not use.")
-ufunc__cospi_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
-ufunc__cospi_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
-ufunc__cospi_loops[2] = <np.PyUFuncGenericFunction>loop_D_D__As_F_F
-ufunc__cospi_loops[3] = <np.PyUFuncGenericFunction>loop_D_D__As_D_D
-ufunc__cospi_types[0] = <char>NPY_FLOAT
-ufunc__cospi_types[1] = <char>NPY_FLOAT
-ufunc__cospi_types[2] = <char>NPY_DOUBLE
-ufunc__cospi_types[3] = <char>NPY_DOUBLE
-ufunc__cospi_types[4] = <char>NPY_CFLOAT
-ufunc__cospi_types[5] = <char>NPY_CFLOAT
-ufunc__cospi_types[6] = <char>NPY_CDOUBLE
-ufunc__cospi_types[7] = <char>NPY_CDOUBLE
-ufunc__cospi_ptr[2*0] = <void*>_func_cospi[double]
-ufunc__cospi_ptr[2*0+1] = <void*>(<char*>"_cospi")
-ufunc__cospi_ptr[2*1] = <void*>_func_cospi[double]
-ufunc__cospi_ptr[2*1+1] = <void*>(<char*>"_cospi")
-ufunc__cospi_ptr[2*2] = <void*>_func_cospi[double_complex]
-ufunc__cospi_ptr[2*2+1] = <void*>(<char*>"_cospi")
-ufunc__cospi_ptr[2*3] = <void*>_func_cospi[double_complex]
-ufunc__cospi_ptr[2*3+1] = <void*>(<char*>"_cospi")
-ufunc__cospi_data[0] = &ufunc__cospi_ptr[2*0]
-ufunc__cospi_data[1] = &ufunc__cospi_ptr[2*1]
-ufunc__cospi_data[2] = &ufunc__cospi_ptr[2*2]
-ufunc__cospi_data[3] = &ufunc__cospi_ptr[2*3]
-_cospi = np.PyUFunc_FromFuncAndData(ufunc__cospi_loops, ufunc__cospi_data, ufunc__cospi_types, 4, 1, 1, 0, "_cospi", ufunc__cospi_doc, 0)
-
 cdef np.PyUFuncGenericFunction ufunc__ellip_harm_loops[3]
 cdef void *ufunc__ellip_harm_ptr[6]
 cdef void *ufunc__ellip_harm_data[3]
@@ -2085,38 +2039,6 @@ ufunc__lambertw_ptr[2*0] = <void*>_func_lambertw_scalar
 ufunc__lambertw_ptr[2*0+1] = <void*>(<char*>"_lambertw")
 ufunc__lambertw_data[0] = &ufunc__lambertw_ptr[2*0]
 _lambertw = np.PyUFunc_FromFuncAndData(ufunc__lambertw_loops, ufunc__lambertw_data, ufunc__lambertw_types, 1, 3, 1, 0, "_lambertw", ufunc__lambertw_doc, 0)
-
-cdef np.PyUFuncGenericFunction ufunc__sinpi_loops[4]
-cdef void *ufunc__sinpi_ptr[8]
-cdef void *ufunc__sinpi_data[4]
-cdef char ufunc__sinpi_types[8]
-cdef char *ufunc__sinpi_doc = (
-    "Internal function, do not use.")
-ufunc__sinpi_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
-ufunc__sinpi_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
-ufunc__sinpi_loops[2] = <np.PyUFuncGenericFunction>loop_D_D__As_F_F
-ufunc__sinpi_loops[3] = <np.PyUFuncGenericFunction>loop_D_D__As_D_D
-ufunc__sinpi_types[0] = <char>NPY_FLOAT
-ufunc__sinpi_types[1] = <char>NPY_FLOAT
-ufunc__sinpi_types[2] = <char>NPY_DOUBLE
-ufunc__sinpi_types[3] = <char>NPY_DOUBLE
-ufunc__sinpi_types[4] = <char>NPY_CFLOAT
-ufunc__sinpi_types[5] = <char>NPY_CFLOAT
-ufunc__sinpi_types[6] = <char>NPY_CDOUBLE
-ufunc__sinpi_types[7] = <char>NPY_CDOUBLE
-ufunc__sinpi_ptr[2*0] = <void*>_func_sinpi[double]
-ufunc__sinpi_ptr[2*0+1] = <void*>(<char*>"_sinpi")
-ufunc__sinpi_ptr[2*1] = <void*>_func_sinpi[double]
-ufunc__sinpi_ptr[2*1+1] = <void*>(<char*>"_sinpi")
-ufunc__sinpi_ptr[2*2] = <void*>_func_sinpi[double_complex]
-ufunc__sinpi_ptr[2*2+1] = <void*>(<char*>"_sinpi")
-ufunc__sinpi_ptr[2*3] = <void*>_func_sinpi[double_complex]
-ufunc__sinpi_ptr[2*3+1] = <void*>(<char*>"_sinpi")
-ufunc__sinpi_data[0] = &ufunc__sinpi_ptr[2*0]
-ufunc__sinpi_data[1] = &ufunc__sinpi_ptr[2*1]
-ufunc__sinpi_data[2] = &ufunc__sinpi_ptr[2*2]
-ufunc__sinpi_data[3] = &ufunc__sinpi_ptr[2*3]
-_sinpi = np.PyUFunc_FromFuncAndData(ufunc__sinpi_loops, ufunc__sinpi_data, ufunc__sinpi_types, 4, 1, 1, 0, "_sinpi", ufunc__sinpi_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc__spherical_in_loops[2]
 cdef void *ufunc__spherical_in_ptr[4]
@@ -2368,30 +2290,6 @@ ufunc__struve_power_series_ptr[2*0] = <void*>_func_struve_power_series
 ufunc__struve_power_series_ptr[2*0+1] = <void*>(<char*>"_struve_power_series")
 ufunc__struve_power_series_data[0] = &ufunc__struve_power_series_ptr[2*0]
 _struve_power_series = np.PyUFunc_FromFuncAndData(ufunc__struve_power_series_loops, ufunc__struve_power_series_data, ufunc__struve_power_series_types, 1, 3, 2, 0, "_struve_power_series", ufunc__struve_power_series_doc, 0)
-
-cdef np.PyUFuncGenericFunction ufunc__zeta_loops[2]
-cdef void *ufunc__zeta_ptr[4]
-cdef void *ufunc__zeta_data[2]
-cdef char ufunc__zeta_types[6]
-cdef char *ufunc__zeta_doc = (
-    "_zeta(x, q)\n"
-    "\n"
-    "Internal function, Hurwitz zeta.")
-ufunc__zeta_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
-ufunc__zeta_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
-ufunc__zeta_types[0] = <char>NPY_FLOAT
-ufunc__zeta_types[1] = <char>NPY_FLOAT
-ufunc__zeta_types[2] = <char>NPY_FLOAT
-ufunc__zeta_types[3] = <char>NPY_DOUBLE
-ufunc__zeta_types[4] = <char>NPY_DOUBLE
-ufunc__zeta_types[5] = <char>NPY_DOUBLE
-ufunc__zeta_ptr[2*0] = <void*>_func_zeta
-ufunc__zeta_ptr[2*0+1] = <void*>(<char*>"_zeta")
-ufunc__zeta_ptr[2*1] = <void*>_func_zeta
-ufunc__zeta_ptr[2*1+1] = <void*>(<char*>"_zeta")
-ufunc__zeta_data[0] = &ufunc__zeta_ptr[2*0]
-ufunc__zeta_data[1] = &ufunc__zeta_ptr[2*1]
-_zeta = np.PyUFunc_FromFuncAndData(ufunc__zeta_loops, ufunc__zeta_data, ufunc__zeta_types, 2, 2, 1, 0, "_zeta", ufunc__zeta_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_airy_loops[4]
 cdef void *ufunc_airy_ptr[8]
@@ -8733,32 +8631,61 @@ ufunc_log1p_data[2] = &ufunc_log1p_ptr[2*2]
 ufunc_log1p_data[3] = &ufunc_log1p_ptr[2*3]
 log1p = np.PyUFunc_FromFuncAndData(ufunc_log1p_loops, ufunc_log1p_data, ufunc_log1p_types, 4, 1, 1, 0, "log1p", ufunc_log1p_doc, 0)
 
-cdef np.PyUFuncGenericFunction ufunc_log_ndtr_loops[2]
-cdef void *ufunc_log_ndtr_ptr[4]
-cdef void *ufunc_log_ndtr_data[2]
-cdef char ufunc_log_ndtr_types[4]
+cdef np.PyUFuncGenericFunction ufunc_log_ndtr_loops[4]
+cdef void *ufunc_log_ndtr_ptr[8]
+cdef void *ufunc_log_ndtr_data[4]
+cdef char ufunc_log_ndtr_types[8]
 cdef char *ufunc_log_ndtr_doc = (
     "log_ndtr(x)\n"
     "\n"
-    "Logarithm of Gaussian cumulative distribution function\n"
+    "Logarithm of Gaussian cumulative distribution function.\n"
     "\n"
     "Returns the log of the area under the standard Gaussian probability\n"
     "density function, integrated from minus infinity to `x`::\n"
     "\n"
-    "    log(1/sqrt(2*pi) * integral(exp(-t**2 / 2), t=-inf..x))")
+    "    log(1/sqrt(2*pi) * integral(exp(-t**2 / 2), t=-inf..x))\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "x : array_like, real or complex\n"
+    "    Argument\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "ndarray\n"
+    "    The value of the log of the normal CDF evaluated at `x`\n"
+    "\n"
+    "See Also\n"
+    "--------\n"
+    "erf\n"
+    "erfc\n"
+    "scipy.stats.norm\n"
+    "ndtr")
 ufunc_log_ndtr_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_log_ndtr_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
+ufunc_log_ndtr_loops[2] = <np.PyUFuncGenericFunction>loop_D_D__As_F_F
+ufunc_log_ndtr_loops[3] = <np.PyUFuncGenericFunction>loop_D_D__As_D_D
 ufunc_log_ndtr_types[0] = <char>NPY_FLOAT
 ufunc_log_ndtr_types[1] = <char>NPY_FLOAT
 ufunc_log_ndtr_types[2] = <char>NPY_DOUBLE
 ufunc_log_ndtr_types[3] = <char>NPY_DOUBLE
+ufunc_log_ndtr_types[4] = <char>NPY_CFLOAT
+ufunc_log_ndtr_types[5] = <char>NPY_CFLOAT
+ufunc_log_ndtr_types[6] = <char>NPY_CDOUBLE
+ufunc_log_ndtr_types[7] = <char>NPY_CDOUBLE
 ufunc_log_ndtr_ptr[2*0] = <void*>_func_log_ndtr
 ufunc_log_ndtr_ptr[2*0+1] = <void*>(<char*>"log_ndtr")
 ufunc_log_ndtr_ptr[2*1] = <void*>_func_log_ndtr
 ufunc_log_ndtr_ptr[2*1+1] = <void*>(<char*>"log_ndtr")
+ufunc_log_ndtr_ptr[2*2] = <void*>scipy.special._ufuncs_cxx._export_faddeeva_log_ndtr
+ufunc_log_ndtr_ptr[2*2+1] = <void*>(<char*>"log_ndtr")
+ufunc_log_ndtr_ptr[2*3] = <void*>scipy.special._ufuncs_cxx._export_faddeeva_log_ndtr
+ufunc_log_ndtr_ptr[2*3+1] = <void*>(<char*>"log_ndtr")
 ufunc_log_ndtr_data[0] = &ufunc_log_ndtr_ptr[2*0]
 ufunc_log_ndtr_data[1] = &ufunc_log_ndtr_ptr[2*1]
-log_ndtr = np.PyUFunc_FromFuncAndData(ufunc_log_ndtr_loops, ufunc_log_ndtr_data, ufunc_log_ndtr_types, 2, 1, 1, 0, "log_ndtr", ufunc_log_ndtr_doc, 0)
+ufunc_log_ndtr_data[2] = &ufunc_log_ndtr_ptr[2*2]
+ufunc_log_ndtr_data[3] = &ufunc_log_ndtr_ptr[2*3]
+log_ndtr = np.PyUFunc_FromFuncAndData(ufunc_log_ndtr_loops, ufunc_log_ndtr_data, ufunc_log_ndtr_types, 4, 1, 1, 0, "log_ndtr", ufunc_log_ndtr_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_loggamma_loops[2]
 cdef void *ufunc_loggamma_ptr[4]
@@ -10163,32 +10090,63 @@ ufunc_nctdtrit_data[0] = &ufunc_nctdtrit_ptr[2*0]
 ufunc_nctdtrit_data[1] = &ufunc_nctdtrit_ptr[2*1]
 nctdtrit = np.PyUFunc_FromFuncAndData(ufunc_nctdtrit_loops, ufunc_nctdtrit_data, ufunc_nctdtrit_types, 2, 3, 1, 0, "nctdtrit", ufunc_nctdtrit_doc, 0)
 
-cdef np.PyUFuncGenericFunction ufunc_ndtr_loops[2]
-cdef void *ufunc_ndtr_ptr[4]
-cdef void *ufunc_ndtr_data[2]
-cdef char ufunc_ndtr_types[4]
+cdef np.PyUFuncGenericFunction ufunc_ndtr_loops[4]
+cdef void *ufunc_ndtr_ptr[8]
+cdef void *ufunc_ndtr_data[4]
+cdef char ufunc_ndtr_types[8]
 cdef char *ufunc_ndtr_doc = (
     "ndtr(x)\n"
     "\n"
-    "Gaussian cumulative distribution function\n"
+    "Gaussian cumulative distribution function.\n"
     "\n"
     "Returns the area under the standard Gaussian probability\n"
-    "density function, integrated from minus infinity to `x`::\n"
+    "density function, integrated from minus infinity to `x`\n"
     "\n"
-    "    1/sqrt(2*pi) * integral(exp(-t**2 / 2), t=-inf..x)")
+    ".. math::\n"
+    "\n"
+    "   \\frac{1}{\\sqrt{2\\pi}} \\int_{-\\infty}^x \\exp(-t^2/2) dt\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "x : array_like, real or complex\n"
+    "    Argument\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "ndarray\n"
+    "    The value of the normal CDF evaluated at `x`\n"
+    "\n"
+    "See Also\n"
+    "--------\n"
+    "erf\n"
+    "erfc\n"
+    "scipy.stats.norm\n"
+    "log_ndtr")
 ufunc_ndtr_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_ndtr_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
+ufunc_ndtr_loops[2] = <np.PyUFuncGenericFunction>loop_D_D__As_F_F
+ufunc_ndtr_loops[3] = <np.PyUFuncGenericFunction>loop_D_D__As_D_D
 ufunc_ndtr_types[0] = <char>NPY_FLOAT
 ufunc_ndtr_types[1] = <char>NPY_FLOAT
 ufunc_ndtr_types[2] = <char>NPY_DOUBLE
 ufunc_ndtr_types[3] = <char>NPY_DOUBLE
+ufunc_ndtr_types[4] = <char>NPY_CFLOAT
+ufunc_ndtr_types[5] = <char>NPY_CFLOAT
+ufunc_ndtr_types[6] = <char>NPY_CDOUBLE
+ufunc_ndtr_types[7] = <char>NPY_CDOUBLE
 ufunc_ndtr_ptr[2*0] = <void*>_func_ndtr
 ufunc_ndtr_ptr[2*0+1] = <void*>(<char*>"ndtr")
 ufunc_ndtr_ptr[2*1] = <void*>_func_ndtr
 ufunc_ndtr_ptr[2*1+1] = <void*>(<char*>"ndtr")
+ufunc_ndtr_ptr[2*2] = <void*>scipy.special._ufuncs_cxx._export_faddeeva_ndtr
+ufunc_ndtr_ptr[2*2+1] = <void*>(<char*>"ndtr")
+ufunc_ndtr_ptr[2*3] = <void*>scipy.special._ufuncs_cxx._export_faddeeva_ndtr
+ufunc_ndtr_ptr[2*3+1] = <void*>(<char*>"ndtr")
 ufunc_ndtr_data[0] = &ufunc_ndtr_ptr[2*0]
 ufunc_ndtr_data[1] = &ufunc_ndtr_ptr[2*1]
-ndtr = np.PyUFunc_FromFuncAndData(ufunc_ndtr_loops, ufunc_ndtr_data, ufunc_ndtr_types, 2, 1, 1, 0, "ndtr", ufunc_ndtr_doc, 0)
+ufunc_ndtr_data[2] = &ufunc_ndtr_ptr[2*2]
+ufunc_ndtr_data[3] = &ufunc_ndtr_ptr[2*3]
+ndtr = np.PyUFunc_FromFuncAndData(ufunc_ndtr_loops, ufunc_ndtr_data, ufunc_ndtr_types, 4, 1, 1, 0, "ndtr", ufunc_ndtr_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_ndtri_loops[2]
 cdef void *ufunc_ndtri_ptr[4]
@@ -11197,47 +11155,12 @@ cdef void *ufunc_psi_ptr[8]
 cdef void *ufunc_psi_data[4]
 cdef char ufunc_psi_types[8]
 cdef char *ufunc_psi_doc = (
-    "psi(z, out=None)\n"
+    "psi(z)\n"
     "\n"
-    "The digamma function.\n"
+    "Digamma function\n"
     "\n"
-    "The logarithmic derivative of the gamma function evaluated at ``z``.\n"
-    "\n"
-    "Parameters\n"
-    "----------\n"
-    "z : array_like\n"
-    "    Real or complex argument.\n"
-    "out : ndarray, optional\n"
-    "    Array for the computed values of ``psi``.\n"
-    "\n"
-    "Returns\n"
-    "-------\n"
-    "digamma : ndarray\n"
-    "    Computed values of ``psi``.\n"
-    "\n"
-    "Notes\n"
-    "-----\n"
-    "For large values not close to the negative real axis ``psi`` is\n"
-    "computed using the asymptotic series (5.11.2) from [1]_. For small\n"
-    "arguments not close to the negative real axis the recurrence\n"
-    "relation (5.5.2) from [1]_ is used until the argument is large\n"
-    "enough to use the asymptotic series. For values close to the\n"
-    "negative real axis the reflection formula (5.5.4) from [1]_ is\n"
-    "used first.  Note that ``psi`` has a family of zeros on the\n"
-    "negative real axis which occur between the poles at nonpositive\n"
-    "integers. Around the zeros the reflection formula suffers from\n"
-    "cancellation and the implementation loses precision. The sole\n"
-    "positive zero and the first negative zero, however, are handled\n"
-    "separately by precomputing series expansions using [2]_, so the\n"
-    "function should maintain full accuracy around the origin.\n"
-    "\n"
-    "References\n"
-    "----------\n"
-    ".. [1] NIST Digital Library of Mathematical Functions\n"
-    "       http://dlmf.nist.gov/5\n"
-    ".. [2] Fredrik Johansson and others.\n"
-    "       \"mpmath: a Python library for arbitrary-precision floating-point arithmetic\"\n"
-    "       (Version 0.19) http://mpmath.org/")
+    "The derivative of the logarithm of the gamma function evaluated at\n"
+    "`z` (also called the digamma function).")
 ufunc_psi_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_psi_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_psi_loops[2] = <np.PyUFuncGenericFunction>loop_D_D__As_F_F
@@ -11250,13 +11173,13 @@ ufunc_psi_types[4] = <char>NPY_CFLOAT
 ufunc_psi_types[5] = <char>NPY_CFLOAT
 ufunc_psi_types[6] = <char>NPY_CDOUBLE
 ufunc_psi_types[7] = <char>NPY_CDOUBLE
-ufunc_psi_ptr[2*0] = <void*>_func_digamma
+ufunc_psi_ptr[2*0] = <void*>_func_psi
 ufunc_psi_ptr[2*0+1] = <void*>(<char*>"psi")
-ufunc_psi_ptr[2*1] = <void*>_func_digamma
+ufunc_psi_ptr[2*1] = <void*>_func_psi
 ufunc_psi_ptr[2*1+1] = <void*>(<char*>"psi")
-ufunc_psi_ptr[2*2] = <void*>_func_cdigamma
+ufunc_psi_ptr[2*2] = <void*>_func_cpsi_wrap
 ufunc_psi_ptr[2*2+1] = <void*>(<char*>"psi")
-ufunc_psi_ptr[2*3] = <void*>_func_cdigamma
+ufunc_psi_ptr[2*3] = <void*>_func_cpsi_wrap
 ufunc_psi_ptr[2*3+1] = <void*>(<char*>"psi")
 ufunc_psi_data[0] = &ufunc_psi_ptr[2*0]
 ufunc_psi_data[1] = &ufunc_psi_ptr[2*1]
@@ -12355,6 +12278,43 @@ ufunc_yve_data[1] = &ufunc_yve_ptr[2*1]
 ufunc_yve_data[2] = &ufunc_yve_ptr[2*2]
 ufunc_yve_data[3] = &ufunc_yve_ptr[2*3]
 yve = np.PyUFunc_FromFuncAndData(ufunc_yve_loops, ufunc_yve_data, ufunc_yve_types, 4, 2, 1, 0, "yve", ufunc_yve_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc_zeta_loops[2]
+cdef void *ufunc_zeta_ptr[4]
+cdef void *ufunc_zeta_data[2]
+cdef char ufunc_zeta_types[6]
+cdef char *ufunc_zeta_doc = (
+    "zeta(x, q)\n"
+    "\n"
+    "Hurwitz zeta function\n"
+    "\n"
+    "The Riemann zeta function of two arguments (also known as the\n"
+    "Hurwitz zeta function).\n"
+    "\n"
+    "This function is defined as\n"
+    "\n"
+    ".. math:: \\zeta(x, q) = \\sum_{k=0}^{\\infty} 1 / (k+q)^x,\n"
+    "\n"
+    "where ``x > 1`` and ``q > 0``.\n"
+    "\n"
+    "See also\n"
+    "--------\n"
+    "zetac")
+ufunc_zeta_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
+ufunc_zeta_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
+ufunc_zeta_types[0] = <char>NPY_FLOAT
+ufunc_zeta_types[1] = <char>NPY_FLOAT
+ufunc_zeta_types[2] = <char>NPY_FLOAT
+ufunc_zeta_types[3] = <char>NPY_DOUBLE
+ufunc_zeta_types[4] = <char>NPY_DOUBLE
+ufunc_zeta_types[5] = <char>NPY_DOUBLE
+ufunc_zeta_ptr[2*0] = <void*>_func_zeta
+ufunc_zeta_ptr[2*0+1] = <void*>(<char*>"zeta")
+ufunc_zeta_ptr[2*1] = <void*>_func_zeta
+ufunc_zeta_ptr[2*1+1] = <void*>(<char*>"zeta")
+ufunc_zeta_data[0] = &ufunc_zeta_ptr[2*0]
+ufunc_zeta_data[1] = &ufunc_zeta_ptr[2*1]
+zeta = np.PyUFunc_FromFuncAndData(ufunc_zeta_loops, ufunc_zeta_data, ufunc_zeta_types, 2, 2, 1, 0, "zeta", ufunc_zeta_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_zetac_loops[2]
 cdef void *ufunc_zetac_ptr[4]

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -66,79 +66,7 @@ def errprint(inflag=None):
         return sf_error.set_print(int(bool(inflag)))
     else:
         return sf_error.get_print()
-cdef void loop_i_ddd_dd_As_fff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *op0 = args[3]
-    cdef char *op1 = args[4]
-    cdef double ov0
-    cdef double ov1
-    for i in range(n):
-        (<int(*)(double, double, double, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], &ov0, &ov1)
-        (<float *>op0)[0] = <float>ov0
-        (<float *>op1)[0] = <float>ov1
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        op0 += steps[3]
-        op1 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_DD__As_DD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double complex, double complex) nogil>func)(<double complex>(<double complex*>ip0)[0], <double complex>(<double complex*>ip1)[0])
-        (<double complex *>op0)[0] = <double complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_g_g__As_g_g(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef long double ov0
-    for i in range(n):
-        ov0 = (<long double(*)(long double) nogil>func)(<long double>(<long double*>ip0)[0])
-        (<long double *>op0)[0] = <long double>ov0
-        ip0 += steps[0]
-        op0 += steps[1]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_dd_dd_As_ff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef char *op1 = args[3]
-    cdef double ov0
-    cdef double ov1
-    for i in range(n):
-        (<int(*)(double, double, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], &ov0, &ov1)
-        (<float *>op0)[0] = <float>ov0
-        (<float *>op1)[0] = <float>ov1
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-        op1 += steps[3]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_dddd__As_dddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_d_dddd_d_As_ffff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
@@ -147,10 +75,172 @@ cdef void loop_d_dddd__As_dddd_d(char **args, np.npy_intp *dims, np.npy_intp *st
     cdef char *ip2 = args[2]
     cdef char *ip3 = args[3]
     cdef char *op0 = args[4]
+    cdef char *op1 = args[5]
+    cdef double ov0
+    cdef double ov1
+    for i in range(n):
+        ov0 = (<double(*)(double, double, double, double, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0], &ov1)
+        (<float *>op0)[0] = <float>ov0
+        (<float *>op1)[0] = <float>ov1
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+        op1 += steps[5]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_iidd__As_lldd_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef double complex ov0
+    for i in range(n):
+        if <int>(<long*>ip0)[0] == (<long*>ip0)[0] and <int>(<long*>ip1)[0] == (<long*>ip1)[0]:
+            ov0 = (<double complex(*)(int, int, double, double) nogil>func)(<int>(<long*>ip0)[0], <int>(<long*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
+        else:
+            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
+            ov0 = <double complex>NPY_NAN
+        (<double complex *>op0)[0] = <double complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_dd_dddd_As_dd_dddd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef char *op1 = args[3]
+    cdef char *op2 = args[4]
+    cdef char *op3 = args[5]
+    cdef double ov0
+    cdef double ov1
+    cdef double ov2
+    cdef double ov3
+    for i in range(n):
+        (<int(*)(double, double, double *, double *, double *, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], &ov0, &ov1, &ov2, &ov3)
+        (<double *>op0)[0] = <double>ov0
+        (<double *>op1)[0] = <double>ov1
+        (<double *>op2)[0] = <double>ov2
+        (<double *>op3)[0] = <double>ov3
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
+        op1 += steps[3]
+        op2 += steps[4]
+        op3 += steps[5]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_ld__As_ld_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
     cdef double ov0
     for i in range(n):
-        ov0 = (<double(*)(double, double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
+        ov0 = (<double(*)(long, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<double*>ip1)[0])
         (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_DD__As_FF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double complex, double complex) nogil>func)(<double complex>(<float complex*>ip0)[0], <double complex>(<float complex*>ip1)[0])
+        (<float complex *>op0)[0] = <float complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_d_dddd_As_f_ffff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
+    cdef double ov0
+    cdef double ov1
+    cdef double ov2
+    cdef double ov3
+    for i in range(n):
+        (<int(*)(double, double *, double *, double *, double *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
+        (<float *>op0)[0] = <float>ov0
+        (<float *>op1)[0] = <float>ov1
+        (<float *>op2)[0] = <float>ov2
+        (<float *>op3)[0] = <float>ov3
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+        op2 += steps[3]
+        op3 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_dd_dddd_As_ff_ffff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef char *op1 = args[3]
+    cdef char *op2 = args[4]
+    cdef char *op3 = args[5]
+    cdef double ov0
+    cdef double ov1
+    cdef double ov2
+    cdef double ov3
+    for i in range(n):
+        (<int(*)(double, double, double *, double *, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], &ov0, &ov1, &ov2, &ov3)
+        (<float *>op0)[0] = <float>ov0
+        (<float *>op1)[0] = <float>ov1
+        (<float *>op2)[0] = <float>ov2
+        (<float *>op3)[0] = <float>ov3
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
+        op1 += steps[3]
+        op2 += steps[4]
+        op3 += steps[5]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_dddD__As_fffF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double, double, double, double complex) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double complex>(<float complex*>ip3)[0])
+        (<float complex *>op0)[0] = <float complex>ov0
         ip0 += steps[0]
         ip1 += steps[1]
         ip2 += steps[2]
@@ -174,6 +264,82 @@ cdef void loop_d_dd__As_dd_d(char **args, np.npy_intp *dims, np.npy_intp *steps,
         op0 += steps[2]
     sf_error.check_fpe(func_name)
 
+cdef void loop_d_iid__As_lld_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef double ov0
+    for i in range(n):
+        if <int>(<long*>ip0)[0] == (<long*>ip0)[0] and <int>(<long*>ip1)[0] == (<long*>ip1)[0]:
+            ov0 = (<double(*)(int, int, double) nogil>func)(<int>(<long*>ip0)[0], <int>(<long*>ip1)[0], <double>(<double*>ip2)[0])
+        else:
+            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
+            ov0 = <double>NPY_NAN
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        op0 += steps[3]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_d_dd_As_d_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef double ov0
+    cdef double ov1
+    for i in range(n):
+        (<int(*)(double, double *, double *) nogil>func)(<double>(<double*>ip0)[0], &ov0, &ov1)
+        (<double *>op0)[0] = <double>ov0
+        (<double *>op1)[0] = <double>ov1
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_ddD__As_ddD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double, double, double complex) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double complex>(<double complex*>ip2)[0])
+        (<double complex *>op0)[0] = <double complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        op0 += steps[3]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_D_DD_As_F_FF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef double complex ov0
+    cdef double complex ov1
+    for i in range(n):
+        (<int(*)(double complex, double complex *, double complex *) nogil>func)(<double complex>(<float complex*>ip0)[0], &ov0, &ov1)
+        (<float complex *>op0)[0] = <float complex>ov0
+        (<float complex *>op1)[0] = <float complex>ov1
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+    sf_error.check_fpe(func_name)
+
 cdef void loop_D_lD__As_lD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
@@ -190,6 +356,130 @@ cdef void loop_D_lD__As_lD_D(char **args, np.npy_intp *dims, np.npy_intp *steps,
         op0 += steps[2]
     sf_error.check_fpe(func_name)
 
+cdef void loop_i_dd_dd_As_ff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef char *op1 = args[3]
+    cdef double ov0
+    cdef double ov1
+    for i in range(n):
+        (<int(*)(double, double, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], &ov0, &ov1)
+        (<float *>op0)[0] = <float>ov0
+        (<float *>op1)[0] = <float>ov1
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
+        op1 += steps[3]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_dddD__As_dddD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double, double, double, double complex) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double complex>(<double complex*>ip3)[0])
+        (<double complex *>op0)[0] = <double complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_ddd_dd_As_ddd_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef char *op1 = args[4]
+    cdef double ov0
+    cdef double ov1
+    for i in range(n):
+        (<int(*)(double, double, double, double *, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], &ov0, &ov1)
+        (<double *>op0)[0] = <double>ov0
+        (<double *>op1)[0] = <double>ov1
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        op0 += steps[3]
+        op1 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_d_DDDD_As_f_FFFF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
+    cdef double complex ov0
+    cdef double complex ov1
+    cdef double complex ov2
+    cdef double complex ov3
+    for i in range(n):
+        (<int(*)(double, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
+        (<float complex *>op0)[0] = <float complex>ov0
+        (<float complex *>op1)[0] = <float complex>ov1
+        (<float complex *>op2)[0] = <float complex>ov2
+        (<float complex *>op3)[0] = <float complex>ov3
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+        op2 += steps[3]
+        op3 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_d_DD_As_f_FF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef double complex ov0
+    cdef double complex ov1
+    for i in range(n):
+        (<int(*)(double, double complex *, double complex *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1)
+        (<float complex *>op0)[0] = <float complex>ov0
+        (<float complex *>op1)[0] = <float complex>ov1
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_ldd__As_ldd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(long, double, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0])
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        op0 += steps[3]
+    sf_error.check_fpe(func_name)
+
 cdef void loop_d_d__As_d_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
@@ -202,6 +492,88 @@ cdef void loop_d_d__As_d_d(char **args, np.npy_intp *dims, np.npy_intp *steps, v
         (<double *>op0)[0] = <double>ov0
         ip0 += steps[0]
         op0 += steps[1]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_dddd_d_As_dddd_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef char *op1 = args[5]
+    cdef double ov0
+    cdef double ov1
+    for i in range(n):
+        ov0 = (<double(*)(double, double, double, double, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0], &ov1)
+        (<double *>op0)[0] = <double>ov0
+        (<double *>op1)[0] = <double>ov1
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+        op1 += steps[5]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_D_DD_As_D_DD(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef double complex ov0
+    cdef double complex ov1
+    for i in range(n):
+        (<int(*)(double complex, double complex *, double complex *) nogil>func)(<double complex>(<double complex*>ip0)[0], &ov0, &ov1)
+        (<double complex *>op0)[0] = <double complex>ov0
+        (<double complex *>op1)[0] = <double complex>ov1
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_dddd__As_ffff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(double, double, double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0])
+        (<float *>op0)[0] = <float>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_id__As_ld_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef double ov0
+    for i in range(n):
+        if <int>(<long*>ip0)[0] == (<long*>ip0)[0]:
+            ov0 = (<double(*)(int, double) nogil>func)(<int>(<long*>ip0)[0], <double>(<double*>ip1)[0])
+        else:
+            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
+            ov0 = <double>NPY_NAN
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
     sf_error.check_fpe(func_name)
 
 cdef void loop_i_d_DD_As_d_DD(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -222,7 +594,39 @@ cdef void loop_i_d_DD_As_d_DD(char **args, np.npy_intp *dims, np.npy_intp *steps
         op1 += steps[2]
     sf_error.check_fpe(func_name)
 
-cdef void loop_i_ddddd_dd_As_ddddd_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_d_ddd__As_fff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(double, double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0])
+        (<float *>op0)[0] = <float>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        op0 += steps[3]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_f_f__As_f_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef float ov0
+    for i in range(n):
+        ov0 = (<float(*)(float) nogil>func)(<float>(<float*>ip0)[0])
+        (<float *>op0)[0] = <float>ov0
+        ip0 += steps[0]
+        op0 += steps[1]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_dddd__As_dddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
@@ -230,22 +634,91 @@ cdef void loop_i_ddddd_dd_As_ddddd_dd(char **args, np.npy_intp *dims, np.npy_int
     cdef char *ip1 = args[1]
     cdef char *ip2 = args[2]
     cdef char *ip3 = args[3]
-    cdef char *ip4 = args[4]
-    cdef char *op0 = args[5]
-    cdef char *op1 = args[6]
+    cdef char *op0 = args[4]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(double, double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_dddi_d_As_dddl_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef char *op1 = args[5]
     cdef double ov0
     cdef double ov1
     for i in range(n):
-        (<int(*)(double, double, double, double, double, double *, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0], <double>(<double*>ip4)[0], &ov0, &ov1)
+        if <int>(<long*>ip3)[0] == (<long*>ip3)[0]:
+            ov0 = (<double(*)(double, double, double, int, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <int>(<long*>ip3)[0], &ov1)
+        else:
+            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
+            ov0 = <double>NPY_NAN
+            ov1 = <double>NPY_NAN
         (<double *>op0)[0] = <double>ov0
         (<double *>op1)[0] = <double>ov1
         ip0 += steps[0]
         ip1 += steps[1]
         ip2 += steps[2]
         ip3 += steps[3]
-        ip4 += steps[4]
-        op0 += steps[5]
-        op1 += steps[6]
+        op0 += steps[4]
+        op1 += steps[5]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_D_DDDD_As_F_FFFF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
+    cdef double complex ov0
+    cdef double complex ov1
+    cdef double complex ov2
+    cdef double complex ov3
+    for i in range(n):
+        (<int(*)(double complex, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double complex>(<float complex*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
+        (<float complex *>op0)[0] = <float complex>ov0
+        (<float complex *>op1)[0] = <float complex>ov1
+        (<float complex *>op2)[0] = <float complex>ov2
+        (<float complex *>op3)[0] = <float complex>ov3
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+        op2 += steps[3]
+        op3 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_lddd__As_lddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *op0 = args[4]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(long, double, double, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
     sf_error.check_fpe(func_name)
 
 cdef void loop_D_dD__As_dD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -284,41 +757,7 @@ cdef void loop_D_dddd__As_dddd_D(char **args, np.npy_intp *dims, np.npy_intp *st
         op0 += steps[4]
     sf_error.check_fpe(func_name)
 
-cdef void loop_d_d__As_f_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(double) nogil>func)(<double>(<float*>ip0)[0])
-        (<float *>op0)[0] = <float>ov0
-        ip0 += steps[0]
-        op0 += steps[1]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_lddd__As_lddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(long, double, double, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_ddd__As_fff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_D_Dld__As_Dld_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
@@ -326,434 +765,14 @@ cdef void loop_d_ddd__As_fff_f(char **args, np.npy_intp *dims, np.npy_intp *step
     cdef char *ip1 = args[1]
     cdef char *ip2 = args[2]
     cdef char *op0 = args[3]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(double, double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0])
-        (<float *>op0)[0] = <float>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        op0 += steps[3]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_DD__As_FF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
     cdef double complex ov0
     for i in range(n):
-        ov0 = (<double complex(*)(double complex, double complex) nogil>func)(<double complex>(<float complex*>ip0)[0], <double complex>(<float complex*>ip1)[0])
-        (<float complex *>op0)[0] = <float complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_dddd__As_ffff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(double, double, double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0])
-        (<float *>op0)[0] = <float>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_f_f__As_f_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef float ov0
-    for i in range(n):
-        ov0 = (<float(*)(float) nogil>func)(<float>(<float*>ip0)[0])
-        (<float *>op0)[0] = <float>ov0
-        ip0 += steps[0]
-        op0 += steps[1]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_D__As_F_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double complex) nogil>func)(<double complex>(<float complex*>ip0)[0])
-        (<float complex *>op0)[0] = <float complex>ov0
-        ip0 += steps[0]
-        op0 += steps[1]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_ddiiddd__As_ddllddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *ip4 = args[4]
-    cdef char *ip5 = args[5]
-    cdef char *ip6 = args[6]
-    cdef char *op0 = args[7]
-    cdef double ov0
-    for i in range(n):
-        if <int>(<long*>ip2)[0] == (<long*>ip2)[0] and <int>(<long*>ip3)[0] == (<long*>ip3)[0]:
-            ov0 = (<double(*)(double, double, int, int, double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <int>(<long*>ip2)[0], <int>(<long*>ip3)[0], <double>(<double*>ip4)[0], <double>(<double*>ip5)[0], <double>(<double*>ip6)[0])
-        else:
-            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
-            ov0 = <double>NPY_NAN
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        ip4 += steps[4]
-        ip5 += steps[5]
-        ip6 += steps[6]
-        op0 += steps[7]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_D_DD_As_D_DD(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef double complex ov0
-    cdef double complex ov1
-    for i in range(n):
-        (<int(*)(double complex, double complex *, double complex *) nogil>func)(<double complex>(<double complex*>ip0)[0], &ov0, &ov1)
-        (<double complex *>op0)[0] = <double complex>ov0
-        (<double complex *>op1)[0] = <double complex>ov1
-        ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_ddd__As_ddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *op0 = args[3]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0])
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        op0 += steps[3]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_ddd_dd_As_ddd_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *op0 = args[3]
-    cdef char *op1 = args[4]
-    cdef double ov0
-    cdef double ov1
-    for i in range(n):
-        (<int(*)(double, double, double, double *, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], &ov0, &ov1)
-        (<double *>op0)[0] = <double>ov0
-        (<double *>op1)[0] = <double>ov1
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        op0 += steps[3]
-        op1 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_ddddddd__As_ddddddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *ip4 = args[4]
-    cdef char *ip5 = args[5]
-    cdef char *ip6 = args[6]
-    cdef char *op0 = args[7]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(double, double, double, double, double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0], <double>(<double*>ip4)[0], <double>(<double*>ip5)[0], <double>(<double*>ip6)[0])
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        ip4 += steps[4]
-        ip5 += steps[5]
-        ip6 += steps[6]
-        op0 += steps[7]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_dd_dddd_As_ff_ffff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef char *op1 = args[3]
-    cdef char *op2 = args[4]
-    cdef char *op3 = args[5]
-    cdef double ov0
-    cdef double ov1
-    cdef double ov2
-    cdef double ov3
-    for i in range(n):
-        (<int(*)(double, double, double *, double *, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], &ov0, &ov1, &ov2, &ov3)
-        (<float *>op0)[0] = <float>ov0
-        (<float *>op1)[0] = <float>ov1
-        (<float *>op2)[0] = <float>ov2
-        (<float *>op3)[0] = <float>ov3
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-        op1 += steps[3]
-        op2 += steps[4]
-        op3 += steps[5]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_ddddddd__As_fffffff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *ip4 = args[4]
-    cdef char *ip5 = args[5]
-    cdef char *ip6 = args[6]
-    cdef char *op0 = args[7]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(double, double, double, double, double, double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0], <double>(<float*>ip4)[0], <double>(<float*>ip5)[0], <double>(<float*>ip6)[0])
-        (<float *>op0)[0] = <float>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        ip4 += steps[4]
-        ip5 += steps[5]
-        ip6 += steps[6]
-        op0 += steps[7]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_dddd_d_As_dddd_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef char *op1 = args[5]
-    cdef double ov0
-    cdef double ov1
-    for i in range(n):
-        ov0 = (<double(*)(double, double, double, double, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0], &ov1)
-        (<double *>op0)[0] = <double>ov0
-        (<double *>op1)[0] = <double>ov1
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-        op1 += steps[5]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_d_dddd_As_d_dddd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef char *op2 = args[3]
-    cdef char *op3 = args[4]
-    cdef double ov0
-    cdef double ov1
-    cdef double ov2
-    cdef double ov3
-    for i in range(n):
-        (<int(*)(double, double *, double *, double *, double *) nogil>func)(<double>(<double*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
-        (<double *>op0)[0] = <double>ov0
-        (<double *>op1)[0] = <double>ov1
-        (<double *>op2)[0] = <double>ov2
-        (<double *>op3)[0] = <double>ov3
-        ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
-        op2 += steps[3]
-        op3 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_ld__As_ld_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(long, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<double*>ip1)[0])
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_d_DD_As_f_FF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef double complex ov0
-    cdef double complex ov1
-    for i in range(n):
-        (<int(*)(double, double complex *, double complex *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1)
-        (<float complex *>op0)[0] = <float complex>ov0
-        (<float complex *>op1)[0] = <float complex>ov1
-        ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_d_dddd_As_f_ffff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef char *op2 = args[3]
-    cdef char *op3 = args[4]
-    cdef double ov0
-    cdef double ov1
-    cdef double ov2
-    cdef double ov3
-    for i in range(n):
-        (<int(*)(double, double *, double *, double *, double *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
-        (<float *>op0)[0] = <float>ov0
-        (<float *>op1)[0] = <float>ov1
-        (<float *>op2)[0] = <float>ov2
-        (<float *>op3)[0] = <float>ov3
-        ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
-        op2 += steps[3]
-        op3 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_dddD__As_fffF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double, double, double, double complex) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double complex>(<float complex*>ip3)[0])
-        (<float complex *>op0)[0] = <float complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_dddd_d_As_ffff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef char *op1 = args[5]
-    cdef double ov0
-    cdef double ov1
-    for i in range(n):
-        ov0 = (<double(*)(double, double, double, double, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0], &ov1)
-        (<float *>op0)[0] = <float>ov0
-        (<float *>op1)[0] = <float>ov1
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-        op1 += steps[5]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_dddd__As_ffff_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double, double, double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0])
-        (<float complex *>op0)[0] = <float complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_D__As_D_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double complex) nogil>func)(<double complex>(<double complex*>ip0)[0])
+        ov0 = (<double complex(*)(double complex, long, double) nogil>func)(<double complex>(<double complex*>ip0)[0], <long>(<long*>ip1)[0], <double>(<double*>ip2)[0])
         (<double complex *>op0)[0] = <double complex>ov0
         ip0 += steps[0]
-        op0 += steps[1]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        op0 += steps[3]
     sf_error.check_fpe(func_name)
 
 cdef void loop_D_ddD__As_ffF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -774,83 +793,7 @@ cdef void loop_D_ddD__As_ffF_F(char **args, np.npy_intp *dims, np.npy_intp *step
         op0 += steps[3]
     sf_error.check_fpe(func_name)
 
-cdef void loop_i_d_DDDD_As_f_FFFF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef char *op2 = args[3]
-    cdef char *op3 = args[4]
-    cdef double complex ov0
-    cdef double complex ov1
-    cdef double complex ov2
-    cdef double complex ov3
-    for i in range(n):
-        (<int(*)(double, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
-        (<float complex *>op0)[0] = <float complex>ov0
-        (<float complex *>op1)[0] = <float complex>ov1
-        (<float complex *>op2)[0] = <float complex>ov2
-        (<float complex *>op3)[0] = <float complex>ov3
-        ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
-        op2 += steps[3]
-        op3 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_iidd__As_lldd_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef double complex ov0
-    for i in range(n):
-        if <int>(<long*>ip0)[0] == (<long*>ip0)[0] and <int>(<long*>ip1)[0] == (<long*>ip1)[0]:
-            ov0 = (<double complex(*)(int, int, double, double) nogil>func)(<int>(<long*>ip0)[0], <int>(<long*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0])
-        else:
-            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
-            ov0 = <double complex>NPY_NAN
-        (<double complex *>op0)[0] = <double complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_d_DDDD_As_d_DDDD(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef char *op2 = args[3]
-    cdef char *op3 = args[4]
-    cdef double complex ov0
-    cdef double complex ov1
-    cdef double complex ov2
-    cdef double complex ov3
-    for i in range(n):
-        (<int(*)(double, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double>(<double*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
-        (<double complex *>op0)[0] = <double complex>ov0
-        (<double complex *>op1)[0] = <double complex>ov1
-        (<double complex *>op2)[0] = <double complex>ov2
-        (<double complex *>op3)[0] = <double complex>ov3
-        ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
-        op2 += steps[3]
-        op3 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_ddD__As_ddD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_d_ddd__As_ddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
@@ -858,28 +801,10 @@ cdef void loop_D_ddD__As_ddD_D(char **args, np.npy_intp *dims, np.npy_intp *step
     cdef char *ip1 = args[1]
     cdef char *ip2 = args[2]
     cdef char *op0 = args[3]
-    cdef double complex ov0
+    cdef double ov0
     for i in range(n):
-        ov0 = (<double complex(*)(double, double, double complex) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double complex>(<double complex*>ip2)[0])
-        (<double complex *>op0)[0] = <double complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        op0 += steps[3]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_Dld__As_Dld_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *op0 = args[3]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double complex, long, double) nogil>func)(<double complex>(<double complex*>ip0)[0], <long>(<long*>ip1)[0], <double>(<double*>ip2)[0])
-        (<double complex *>op0)[0] = <double complex>ov0
+        ov0 = (<double(*)(double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0])
+        (<double *>op0)[0] = <double>ov0
         ip0 += steps[0]
         ip1 += steps[1]
         ip2 += steps[2]
@@ -912,7 +837,49 @@ cdef void loop_i_D_DDDD_As_D_DDDD(char **args, np.npy_intp *dims, np.npy_intp *s
         op3 += steps[4]
     sf_error.check_fpe(func_name)
 
-cdef void loop_i_d_dd_As_d_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_D_dD__As_fF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double, double complex) nogil>func)(<double>(<float*>ip0)[0], <double complex>(<float complex*>ip1)[0])
+        (<float complex *>op0)[0] = <float complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_d_dddd_As_d_dddd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
+    cdef double ov0
+    cdef double ov1
+    cdef double ov2
+    cdef double ov3
+    for i in range(n):
+        (<int(*)(double, double *, double *, double *, double *) nogil>func)(<double>(<double*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
+        (<double *>op0)[0] = <double>ov0
+        (<double *>op1)[0] = <double>ov1
+        (<double *>op2)[0] = <double>ov2
+        (<double *>op3)[0] = <double>ov3
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+        op2 += steps[3]
+        op3 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_d_dd_As_f_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
@@ -922,15 +889,121 @@ cdef void loop_i_d_dd_As_d_dd(char **args, np.npy_intp *dims, np.npy_intp *steps
     cdef double ov0
     cdef double ov1
     for i in range(n):
-        (<int(*)(double, double *, double *) nogil>func)(<double>(<double*>ip0)[0], &ov0, &ov1)
-        (<double *>op0)[0] = <double>ov0
-        (<double *>op1)[0] = <double>ov1
+        (<int(*)(double, double *, double *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1)
+        (<float *>op0)[0] = <float>ov0
+        (<float *>op1)[0] = <float>ov1
         ip0 += steps[0]
         op0 += steps[1]
         op1 += steps[2]
     sf_error.check_fpe(func_name)
 
-cdef void loop_d_dddi_d_As_dddl_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+cdef void loop_d_ddiiddd__As_ddllddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *ip4 = args[4]
+    cdef char *ip5 = args[5]
+    cdef char *ip6 = args[6]
+    cdef char *op0 = args[7]
+    cdef double ov0
+    for i in range(n):
+        if <int>(<long*>ip2)[0] == (<long*>ip2)[0] and <int>(<long*>ip3)[0] == (<long*>ip3)[0]:
+            ov0 = (<double(*)(double, double, int, int, double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <int>(<long*>ip2)[0], <int>(<long*>ip3)[0], <double>(<double*>ip4)[0], <double>(<double*>ip5)[0], <double>(<double*>ip6)[0])
+        else:
+            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
+            ov0 = <double>NPY_NAN
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        ip4 += steps[4]
+        ip5 += steps[5]
+        ip6 += steps[6]
+        op0 += steps[7]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_D__As_D_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double complex) nogil>func)(<double complex>(<double complex*>ip0)[0])
+        (<double complex *>op0)[0] = <double complex>ov0
+        ip0 += steps[0]
+        op0 += steps[1]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_DD__As_DD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double complex, double complex) nogil>func)(<double complex>(<double complex*>ip0)[0], <double complex>(<double complex*>ip1)[0])
+        (<double complex *>op0)[0] = <double complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_d_DDDD_As_d_DDDD(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef char *op1 = args[2]
+    cdef char *op2 = args[3]
+    cdef char *op3 = args[4]
+    cdef double complex ov0
+    cdef double complex ov1
+    cdef double complex ov2
+    cdef double complex ov3
+    for i in range(n):
+        (<int(*)(double, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double>(<double*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
+        (<double complex *>op0)[0] = <double complex>ov0
+        (<double complex *>op1)[0] = <double complex>ov1
+        (<double complex *>op2)[0] = <double complex>ov2
+        (<double complex *>op3)[0] = <double complex>ov3
+        ip0 += steps[0]
+        op0 += steps[1]
+        op1 += steps[2]
+        op2 += steps[3]
+        op3 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_dd_dd_As_dd_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef char *op1 = args[3]
+    cdef double ov0
+    cdef double ov1
+    for i in range(n):
+        (<int(*)(double, double, double *, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], &ov0, &ov1)
+        (<double *>op0)[0] = <double>ov0
+        (<double *>op1)[0] = <double>ov1
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
+        op1 += steps[3]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_dddd__As_ffff_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]
     cdef char *func_name = <char*>(<void**>data)[1]
@@ -939,24 +1012,199 @@ cdef void loop_d_dddi_d_As_dddl_dd(char **args, np.npy_intp *dims, np.npy_intp *
     cdef char *ip2 = args[2]
     cdef char *ip3 = args[3]
     cdef char *op0 = args[4]
-    cdef char *op1 = args[5]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double, double, double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0])
+        (<float complex *>op0)[0] = <float complex>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        op0 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_ddddd_dd_As_fffff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *ip4 = args[4]
+    cdef char *op0 = args[5]
+    cdef char *op1 = args[6]
     cdef double ov0
     cdef double ov1
     for i in range(n):
-        if <int>(<long*>ip3)[0] == (<long*>ip3)[0]:
-            ov0 = (<double(*)(double, double, double, int, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <int>(<long*>ip3)[0], &ov1)
-        else:
-            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
-            ov0 = <double>NPY_NAN
-            ov1 = <double>NPY_NAN
+        (<int(*)(double, double, double, double, double, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0], <double>(<float*>ip4)[0], &ov0, &ov1)
+        (<float *>op0)[0] = <float>ov0
+        (<float *>op1)[0] = <float>ov1
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        ip4 += steps[4]
+        op0 += steps[5]
+        op1 += steps[6]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_ddddddd__As_ddddddd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *ip4 = args[4]
+    cdef char *ip5 = args[5]
+    cdef char *ip6 = args[6]
+    cdef char *op0 = args[7]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(double, double, double, double, double, double, double) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0], <double>(<double*>ip4)[0], <double>(<double*>ip5)[0], <double>(<double*>ip6)[0])
+        (<double *>op0)[0] = <double>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        ip4 += steps[4]
+        ip5 += steps[5]
+        ip6 += steps[6]
+        op0 += steps[7]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_ddddd_dd_As_ddddd_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *ip4 = args[4]
+    cdef char *op0 = args[5]
+    cdef char *op1 = args[6]
+    cdef double ov0
+    cdef double ov1
+    for i in range(n):
+        (<int(*)(double, double, double, double, double, double *, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double>(<double*>ip3)[0], <double>(<double*>ip4)[0], &ov0, &ov1)
         (<double *>op0)[0] = <double>ov0
         (<double *>op1)[0] = <double>ov1
         ip0 += steps[0]
         ip1 += steps[1]
         ip2 += steps[2]
         ip3 += steps[3]
-        op0 += steps[4]
-        op1 += steps[5]
+        ip4 += steps[4]
+        op0 += steps[5]
+        op1 += steps[6]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_ddddddd__As_fffffff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *ip3 = args[3]
+    cdef char *ip4 = args[4]
+    cdef char *ip5 = args[5]
+    cdef char *ip6 = args[6]
+    cdef char *op0 = args[7]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(double, double, double, double, double, double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0], <double>(<float*>ip4)[0], <double>(<float*>ip5)[0], <double>(<float*>ip6)[0])
+        (<float *>op0)[0] = <float>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        ip3 += steps[3]
+        ip4 += steps[4]
+        ip5 += steps[5]
+        ip6 += steps[6]
+        op0 += steps[7]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_i_ddd_dd_As_fff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *ip2 = args[2]
+    cdef char *op0 = args[3]
+    cdef char *op1 = args[4]
+    cdef double ov0
+    cdef double ov1
+    for i in range(n):
+        (<int(*)(double, double, double, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], &ov0, &ov1)
+        (<float *>op0)[0] = <float>ov0
+        (<float *>op1)[0] = <float>ov1
+        ip0 += steps[0]
+        ip1 += steps[1]
+        ip2 += steps[2]
+        op0 += steps[3]
+        op1 += steps[4]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_g_g__As_g_g(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef long double ov0
+    for i in range(n):
+        ov0 = (<long double(*)(long double) nogil>func)(<long double>(<long double*>ip0)[0])
+        (<long double *>op0)[0] = <long double>ov0
+        ip0 += steps[0]
+        op0 += steps[1]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_dd__As_ff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *ip1 = args[1]
+    cdef char *op0 = args[2]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0])
+        (<float *>op0)[0] = <float>ov0
+        ip0 += steps[0]
+        ip1 += steps[1]
+        op0 += steps[2]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_D_D__As_F_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef double complex ov0
+    for i in range(n):
+        ov0 = (<double complex(*)(double complex) nogil>func)(<double complex>(<float complex*>ip0)[0])
+        (<float complex *>op0)[0] = <float complex>ov0
+        ip0 += steps[0]
+        op0 += steps[1]
+    sf_error.check_fpe(func_name)
+
+cdef void loop_d_d__As_f_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
+    cdef np.npy_intp i, n = dims[0]
+    cdef void *func = (<void**>data)[0]
+    cdef char *func_name = <char*>(<void**>data)[1]
+    cdef char *ip0 = args[0]
+    cdef char *op0 = args[1]
+    cdef double ov0
+    for i in range(n):
+        ov0 = (<double(*)(double) nogil>func)(<double>(<float*>ip0)[0])
+        (<float *>op0)[0] = <float>ov0
+        ip0 += steps[0]
+        op0 += steps[1]
     sf_error.check_fpe(func_name)
 
 cdef void loop_d_ddi_d_As_ddl_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
@@ -986,254 +1234,12 @@ cdef void loop_d_ddi_d_As_ddl_dd(char **args, np.npy_intp *dims, np.npy_intp *st
         op1 += steps[4]
     sf_error.check_fpe(func_name)
 
-cdef void loop_D_dddD__As_dddD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *op0 = args[4]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double, double, double, double complex) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0], <double complex>(<double complex*>ip3)[0])
-        (<double complex *>op0)[0] = <double complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        op0 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_iid__As_lld_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *op0 = args[3]
-    cdef double ov0
-    for i in range(n):
-        if <int>(<long*>ip0)[0] == (<long*>ip0)[0] and <int>(<long*>ip1)[0] == (<long*>ip1)[0]:
-            ov0 = (<double(*)(int, int, double) nogil>func)(<int>(<long*>ip0)[0], <int>(<long*>ip1)[0], <double>(<double*>ip2)[0])
-        else:
-            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
-            ov0 = <double>NPY_NAN
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        op0 += steps[3]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_ddddd_dd_As_fffff_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *ip3 = args[3]
-    cdef char *ip4 = args[4]
-    cdef char *op0 = args[5]
-    cdef char *op1 = args[6]
-    cdef double ov0
-    cdef double ov1
-    for i in range(n):
-        (<int(*)(double, double, double, double, double, double *, double *) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0], <double>(<float*>ip2)[0], <double>(<float*>ip3)[0], <double>(<float*>ip4)[0], &ov0, &ov1)
-        (<float *>op0)[0] = <float>ov0
-        (<float *>op1)[0] = <float>ov1
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        ip3 += steps[3]
-        ip4 += steps[4]
-        op0 += steps[5]
-        op1 += steps[6]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_D_DD_As_F_FF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef double complex ov0
-    cdef double complex ov1
-    for i in range(n):
-        (<int(*)(double complex, double complex *, double complex *) nogil>func)(<double complex>(<float complex*>ip0)[0], &ov0, &ov1)
-        (<float complex *>op0)[0] = <float complex>ov0
-        (<float complex *>op1)[0] = <float complex>ov1
-        ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_id__As_ld_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef double ov0
-    for i in range(n):
-        if <int>(<long*>ip0)[0] == (<long*>ip0)[0]:
-            ov0 = (<double(*)(int, double) nogil>func)(<int>(<long*>ip0)[0], <double>(<double*>ip1)[0])
-        else:
-            sf_error.error(func_name, sf_error.DOMAIN, "invalid input argument")
-            ov0 = <double>NPY_NAN
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_dd__As_ff_f(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(double, double) nogil>func)(<double>(<float*>ip0)[0], <double>(<float*>ip1)[0])
-        (<float *>op0)[0] = <float>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_dd_dddd_As_dd_dddd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef char *op1 = args[3]
-    cdef char *op2 = args[4]
-    cdef char *op3 = args[5]
-    cdef double ov0
-    cdef double ov1
-    cdef double ov2
-    cdef double ov3
-    for i in range(n):
-        (<int(*)(double, double, double *, double *, double *, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], &ov0, &ov1, &ov2, &ov3)
-        (<double *>op0)[0] = <double>ov0
-        (<double *>op1)[0] = <double>ov1
-        (<double *>op2)[0] = <double>ov2
-        (<double *>op3)[0] = <double>ov3
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-        op1 += steps[3]
-        op2 += steps[4]
-        op3 += steps[5]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_d_ldd__As_ldd_d(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *ip2 = args[2]
-    cdef char *op0 = args[3]
-    cdef double ov0
-    for i in range(n):
-        ov0 = (<double(*)(long, double, double) nogil>func)(<long>(<long*>ip0)[0], <double>(<double*>ip1)[0], <double>(<double*>ip2)[0])
-        (<double *>op0)[0] = <double>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        ip2 += steps[2]
-        op0 += steps[3]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_D_dD__As_fF_F(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef double complex ov0
-    for i in range(n):
-        ov0 = (<double complex(*)(double, double complex) nogil>func)(<double>(<float*>ip0)[0], <double complex>(<float complex*>ip1)[0])
-        (<float complex *>op0)[0] = <float complex>ov0
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_d_dd_As_f_ff(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef double ov0
-    cdef double ov1
-    for i in range(n):
-        (<int(*)(double, double *, double *) nogil>func)(<double>(<float*>ip0)[0], &ov0, &ov1)
-        (<float *>op0)[0] = <float>ov0
-        (<float *>op1)[0] = <float>ov1
-        ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_D_DDDD_As_F_FFFF(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *op0 = args[1]
-    cdef char *op1 = args[2]
-    cdef char *op2 = args[3]
-    cdef char *op3 = args[4]
-    cdef double complex ov0
-    cdef double complex ov1
-    cdef double complex ov2
-    cdef double complex ov3
-    for i in range(n):
-        (<int(*)(double complex, double complex *, double complex *, double complex *, double complex *) nogil>func)(<double complex>(<float complex*>ip0)[0], &ov0, &ov1, &ov2, &ov3)
-        (<float complex *>op0)[0] = <float complex>ov0
-        (<float complex *>op1)[0] = <float complex>ov1
-        (<float complex *>op2)[0] = <float complex>ov2
-        (<float complex *>op3)[0] = <float complex>ov3
-        ip0 += steps[0]
-        op0 += steps[1]
-        op1 += steps[2]
-        op2 += steps[3]
-        op3 += steps[4]
-    sf_error.check_fpe(func_name)
-
-cdef void loop_i_dd_dd_As_dd_dd(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
-    cdef np.npy_intp i, n = dims[0]
-    cdef void *func = (<void**>data)[0]
-    cdef char *func_name = <char*>(<void**>data)[1]
-    cdef char *ip0 = args[0]
-    cdef char *ip1 = args[1]
-    cdef char *op0 = args[2]
-    cdef char *op1 = args[3]
-    cdef double ov0
-    cdef double ov1
-    for i in range(n):
-        (<int(*)(double, double, double *, double *) nogil>func)(<double>(<double*>ip0)[0], <double>(<double*>ip1)[0], &ov0, &ov1)
-        (<double *>op0)[0] = <double>ov0
-        (<double *>op1)[0] = <double>ov1
-        ip0 += steps[0]
-        ip1 += steps[1]
-        op0 += steps[2]
-        op1 += steps[3]
-    sf_error.check_fpe(func_name)
-
+from _trig cimport cospi as _func_cospi
+ctypedef double _proto_cospi_double__t(double) nogil
+cdef _proto_cospi_double__t *_proto_cospi_double__t_var = &_func_cospi[double]
+from _trig cimport cospi as _func_cospi
+ctypedef double complex _proto_cospi_double_complex__t(double complex) nogil
+cdef _proto_cospi_double_complex__t *_proto_cospi_double_complex__t_var = &_func_cospi[double_complex]
 from _ellip_harm cimport ellip_harmonic as _func_ellip_harmonic
 ctypedef double _proto_ellip_harmonic_t(double, double, int, int, double, double, double) nogil
 cdef _proto_ellip_harmonic_t *_proto_ellip_harmonic_t_var = &_func_ellip_harmonic
@@ -1247,6 +1253,12 @@ cdef extern from "_ufuncs_defs.h":
 from lambertw cimport lambertw_scalar as _func_lambertw_scalar
 ctypedef double complex _proto_lambertw_scalar_t(double complex, long, double) nogil
 cdef _proto_lambertw_scalar_t *_proto_lambertw_scalar_t_var = &_func_lambertw_scalar
+from _trig cimport sinpi as _func_sinpi
+ctypedef double _proto_sinpi_double__t(double) nogil
+cdef _proto_sinpi_double__t *_proto_sinpi_double__t_var = &_func_sinpi[double]
+from _trig cimport sinpi as _func_sinpi
+ctypedef double complex _proto_sinpi_double_complex__t(double complex) nogil
+cdef _proto_sinpi_double_complex__t *_proto_sinpi_double_complex__t_var = &_func_sinpi[double_complex]
 from _spherical_bessel cimport spherical_in_real as _func_spherical_in_real
 ctypedef double _proto_spherical_in_real_t(long, double) nogil
 cdef _proto_spherical_in_real_t *_proto_spherical_in_real_t_var = &_func_spherical_in_real
@@ -1301,6 +1313,8 @@ cdef extern from "_ufuncs_defs.h":
     cdef double _func_struve_bessel_series "struve_bessel_series"(double, double, int, double *) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_struve_power_series "struve_power_series"(double, double, int, double *) nogil
+cdef extern from "_ufuncs_defs.h":
+    cdef double _func_zeta "zeta"(double, double) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef int _func_airy_wrap "airy_wrap"(double, double *, double *, double *, double *) nogil
 cdef extern from "_ufuncs_defs.h":
@@ -1860,10 +1874,12 @@ cdef extern from "_ufuncs_defs.h":
 from _convex_analysis cimport pseudo_huber as _func_pseudo_huber
 ctypedef double _proto_pseudo_huber_t(double, double) nogil
 cdef _proto_pseudo_huber_t *_proto_pseudo_huber_t_var = &_func_pseudo_huber
-cdef extern from "_ufuncs_defs.h":
-    cdef double _func_psi "psi"(double) nogil
-cdef extern from "_ufuncs_defs.h":
-    cdef double complex _func_cpsi_wrap "cpsi_wrap"(double complex) nogil
+from _digamma cimport digamma as _func_digamma
+ctypedef double _proto_digamma_t(double) nogil
+cdef _proto_digamma_t *_proto_digamma_t_var = &_func_digamma
+from _digamma cimport cdigamma as _func_cdigamma
+ctypedef double complex _proto_cdigamma_t(double complex) nogil
+cdef _proto_cdigamma_t *_proto_cdigamma_t_var = &_func_cdigamma
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_radian "radian"(double, double, double) nogil
 from _convex_analysis cimport rel_entr as _func_rel_entr
@@ -1945,9 +1961,39 @@ cdef extern from "_ufuncs_defs.h":
 cdef extern from "_ufuncs_defs.h":
     cdef double complex _func_cbesy_wrap_e "cbesy_wrap_e"(double, double complex) nogil
 cdef extern from "_ufuncs_defs.h":
-    cdef double _func_zeta "zeta"(double, double) nogil
-cdef extern from "_ufuncs_defs.h":
     cdef double _func_zetac "zetac"(double) nogil
+cdef np.PyUFuncGenericFunction ufunc__cospi_loops[4]
+cdef void *ufunc__cospi_ptr[8]
+cdef void *ufunc__cospi_data[4]
+cdef char ufunc__cospi_types[8]
+cdef char *ufunc__cospi_doc = (
+    "Internal function, do not use.")
+ufunc__cospi_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
+ufunc__cospi_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
+ufunc__cospi_loops[2] = <np.PyUFuncGenericFunction>loop_D_D__As_F_F
+ufunc__cospi_loops[3] = <np.PyUFuncGenericFunction>loop_D_D__As_D_D
+ufunc__cospi_types[0] = <char>NPY_FLOAT
+ufunc__cospi_types[1] = <char>NPY_FLOAT
+ufunc__cospi_types[2] = <char>NPY_DOUBLE
+ufunc__cospi_types[3] = <char>NPY_DOUBLE
+ufunc__cospi_types[4] = <char>NPY_CFLOAT
+ufunc__cospi_types[5] = <char>NPY_CFLOAT
+ufunc__cospi_types[6] = <char>NPY_CDOUBLE
+ufunc__cospi_types[7] = <char>NPY_CDOUBLE
+ufunc__cospi_ptr[2*0] = <void*>_func_cospi[double]
+ufunc__cospi_ptr[2*0+1] = <void*>(<char*>"_cospi")
+ufunc__cospi_ptr[2*1] = <void*>_func_cospi[double]
+ufunc__cospi_ptr[2*1+1] = <void*>(<char*>"_cospi")
+ufunc__cospi_ptr[2*2] = <void*>_func_cospi[double_complex]
+ufunc__cospi_ptr[2*2+1] = <void*>(<char*>"_cospi")
+ufunc__cospi_ptr[2*3] = <void*>_func_cospi[double_complex]
+ufunc__cospi_ptr[2*3+1] = <void*>(<char*>"_cospi")
+ufunc__cospi_data[0] = &ufunc__cospi_ptr[2*0]
+ufunc__cospi_data[1] = &ufunc__cospi_ptr[2*1]
+ufunc__cospi_data[2] = &ufunc__cospi_ptr[2*2]
+ufunc__cospi_data[3] = &ufunc__cospi_ptr[2*3]
+_cospi = np.PyUFunc_FromFuncAndData(ufunc__cospi_loops, ufunc__cospi_data, ufunc__cospi_types, 4, 1, 1, 0, "_cospi", ufunc__cospi_doc, 0)
+
 cdef np.PyUFuncGenericFunction ufunc__ellip_harm_loops[3]
 cdef void *ufunc__ellip_harm_ptr[6]
 cdef void *ufunc__ellip_harm_data[3]
@@ -2039,6 +2085,38 @@ ufunc__lambertw_ptr[2*0] = <void*>_func_lambertw_scalar
 ufunc__lambertw_ptr[2*0+1] = <void*>(<char*>"_lambertw")
 ufunc__lambertw_data[0] = &ufunc__lambertw_ptr[2*0]
 _lambertw = np.PyUFunc_FromFuncAndData(ufunc__lambertw_loops, ufunc__lambertw_data, ufunc__lambertw_types, 1, 3, 1, 0, "_lambertw", ufunc__lambertw_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc__sinpi_loops[4]
+cdef void *ufunc__sinpi_ptr[8]
+cdef void *ufunc__sinpi_data[4]
+cdef char ufunc__sinpi_types[8]
+cdef char *ufunc__sinpi_doc = (
+    "Internal function, do not use.")
+ufunc__sinpi_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
+ufunc__sinpi_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
+ufunc__sinpi_loops[2] = <np.PyUFuncGenericFunction>loop_D_D__As_F_F
+ufunc__sinpi_loops[3] = <np.PyUFuncGenericFunction>loop_D_D__As_D_D
+ufunc__sinpi_types[0] = <char>NPY_FLOAT
+ufunc__sinpi_types[1] = <char>NPY_FLOAT
+ufunc__sinpi_types[2] = <char>NPY_DOUBLE
+ufunc__sinpi_types[3] = <char>NPY_DOUBLE
+ufunc__sinpi_types[4] = <char>NPY_CFLOAT
+ufunc__sinpi_types[5] = <char>NPY_CFLOAT
+ufunc__sinpi_types[6] = <char>NPY_CDOUBLE
+ufunc__sinpi_types[7] = <char>NPY_CDOUBLE
+ufunc__sinpi_ptr[2*0] = <void*>_func_sinpi[double]
+ufunc__sinpi_ptr[2*0+1] = <void*>(<char*>"_sinpi")
+ufunc__sinpi_ptr[2*1] = <void*>_func_sinpi[double]
+ufunc__sinpi_ptr[2*1+1] = <void*>(<char*>"_sinpi")
+ufunc__sinpi_ptr[2*2] = <void*>_func_sinpi[double_complex]
+ufunc__sinpi_ptr[2*2+1] = <void*>(<char*>"_sinpi")
+ufunc__sinpi_ptr[2*3] = <void*>_func_sinpi[double_complex]
+ufunc__sinpi_ptr[2*3+1] = <void*>(<char*>"_sinpi")
+ufunc__sinpi_data[0] = &ufunc__sinpi_ptr[2*0]
+ufunc__sinpi_data[1] = &ufunc__sinpi_ptr[2*1]
+ufunc__sinpi_data[2] = &ufunc__sinpi_ptr[2*2]
+ufunc__sinpi_data[3] = &ufunc__sinpi_ptr[2*3]
+_sinpi = np.PyUFunc_FromFuncAndData(ufunc__sinpi_loops, ufunc__sinpi_data, ufunc__sinpi_types, 4, 1, 1, 0, "_sinpi", ufunc__sinpi_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc__spherical_in_loops[2]
 cdef void *ufunc__spherical_in_ptr[4]
@@ -2290,6 +2368,30 @@ ufunc__struve_power_series_ptr[2*0] = <void*>_func_struve_power_series
 ufunc__struve_power_series_ptr[2*0+1] = <void*>(<char*>"_struve_power_series")
 ufunc__struve_power_series_data[0] = &ufunc__struve_power_series_ptr[2*0]
 _struve_power_series = np.PyUFunc_FromFuncAndData(ufunc__struve_power_series_loops, ufunc__struve_power_series_data, ufunc__struve_power_series_types, 1, 3, 2, 0, "_struve_power_series", ufunc__struve_power_series_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc__zeta_loops[2]
+cdef void *ufunc__zeta_ptr[4]
+cdef void *ufunc__zeta_data[2]
+cdef char ufunc__zeta_types[6]
+cdef char *ufunc__zeta_doc = (
+    "_zeta(x, q)\n"
+    "\n"
+    "Internal function, Hurwitz zeta.")
+ufunc__zeta_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
+ufunc__zeta_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
+ufunc__zeta_types[0] = <char>NPY_FLOAT
+ufunc__zeta_types[1] = <char>NPY_FLOAT
+ufunc__zeta_types[2] = <char>NPY_FLOAT
+ufunc__zeta_types[3] = <char>NPY_DOUBLE
+ufunc__zeta_types[4] = <char>NPY_DOUBLE
+ufunc__zeta_types[5] = <char>NPY_DOUBLE
+ufunc__zeta_ptr[2*0] = <void*>_func_zeta
+ufunc__zeta_ptr[2*0+1] = <void*>(<char*>"_zeta")
+ufunc__zeta_ptr[2*1] = <void*>_func_zeta
+ufunc__zeta_ptr[2*1+1] = <void*>(<char*>"_zeta")
+ufunc__zeta_data[0] = &ufunc__zeta_ptr[2*0]
+ufunc__zeta_data[1] = &ufunc__zeta_ptr[2*1]
+_zeta = np.PyUFunc_FromFuncAndData(ufunc__zeta_loops, ufunc__zeta_data, ufunc__zeta_types, 2, 2, 1, 0, "_zeta", ufunc__zeta_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_airy_loops[4]
 cdef void *ufunc_airy_ptr[8]
@@ -11155,12 +11257,47 @@ cdef void *ufunc_psi_ptr[8]
 cdef void *ufunc_psi_data[4]
 cdef char ufunc_psi_types[8]
 cdef char *ufunc_psi_doc = (
-    "psi(z)\n"
+    "psi(z, out=None)\n"
     "\n"
-    "Digamma function\n"
+    "The digamma function.\n"
     "\n"
-    "The derivative of the logarithm of the gamma function evaluated at\n"
-    "`z` (also called the digamma function).")
+    "The logarithmic derivative of the gamma function evaluated at ``z``.\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "z : array_like\n"
+    "    Real or complex argument.\n"
+    "out : ndarray, optional\n"
+    "    Array for the computed values of ``psi``.\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "digamma : ndarray\n"
+    "    Computed values of ``psi``.\n"
+    "\n"
+    "Notes\n"
+    "-----\n"
+    "For large values not close to the negative real axis ``psi`` is\n"
+    "computed using the asymptotic series (5.11.2) from [1]_. For small\n"
+    "arguments not close to the negative real axis the recurrence\n"
+    "relation (5.5.2) from [1]_ is used until the argument is large\n"
+    "enough to use the asymptotic series. For values close to the\n"
+    "negative real axis the reflection formula (5.5.4) from [1]_ is\n"
+    "used first.  Note that ``psi`` has a family of zeros on the\n"
+    "negative real axis which occur between the poles at nonpositive\n"
+    "integers. Around the zeros the reflection formula suffers from\n"
+    "cancellation and the implementation loses precision. The sole\n"
+    "positive zero and the first negative zero, however, are handled\n"
+    "separately by precomputing series expansions using [2]_, so the\n"
+    "function should maintain full accuracy around the origin.\n"
+    "\n"
+    "References\n"
+    "----------\n"
+    ".. [1] NIST Digital Library of Mathematical Functions\n"
+    "       http://dlmf.nist.gov/5\n"
+    ".. [2] Fredrik Johansson and others.\n"
+    "       \"mpmath: a Python library for arbitrary-precision floating-point arithmetic\"\n"
+    "       (Version 0.19) http://mpmath.org/")
 ufunc_psi_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_psi_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_psi_loops[2] = <np.PyUFuncGenericFunction>loop_D_D__As_F_F
@@ -11173,13 +11310,13 @@ ufunc_psi_types[4] = <char>NPY_CFLOAT
 ufunc_psi_types[5] = <char>NPY_CFLOAT
 ufunc_psi_types[6] = <char>NPY_CDOUBLE
 ufunc_psi_types[7] = <char>NPY_CDOUBLE
-ufunc_psi_ptr[2*0] = <void*>_func_psi
+ufunc_psi_ptr[2*0] = <void*>_func_digamma
 ufunc_psi_ptr[2*0+1] = <void*>(<char*>"psi")
-ufunc_psi_ptr[2*1] = <void*>_func_psi
+ufunc_psi_ptr[2*1] = <void*>_func_digamma
 ufunc_psi_ptr[2*1+1] = <void*>(<char*>"psi")
-ufunc_psi_ptr[2*2] = <void*>_func_cpsi_wrap
+ufunc_psi_ptr[2*2] = <void*>_func_cdigamma
 ufunc_psi_ptr[2*2+1] = <void*>(<char*>"psi")
-ufunc_psi_ptr[2*3] = <void*>_func_cpsi_wrap
+ufunc_psi_ptr[2*3] = <void*>_func_cdigamma
 ufunc_psi_ptr[2*3+1] = <void*>(<char*>"psi")
 ufunc_psi_data[0] = &ufunc_psi_ptr[2*0]
 ufunc_psi_data[1] = &ufunc_psi_ptr[2*1]
@@ -12278,43 +12415,6 @@ ufunc_yve_data[1] = &ufunc_yve_ptr[2*1]
 ufunc_yve_data[2] = &ufunc_yve_ptr[2*2]
 ufunc_yve_data[3] = &ufunc_yve_ptr[2*3]
 yve = np.PyUFunc_FromFuncAndData(ufunc_yve_loops, ufunc_yve_data, ufunc_yve_types, 4, 2, 1, 0, "yve", ufunc_yve_doc, 0)
-
-cdef np.PyUFuncGenericFunction ufunc_zeta_loops[2]
-cdef void *ufunc_zeta_ptr[4]
-cdef void *ufunc_zeta_data[2]
-cdef char ufunc_zeta_types[6]
-cdef char *ufunc_zeta_doc = (
-    "zeta(x, q)\n"
-    "\n"
-    "Hurwitz zeta function\n"
-    "\n"
-    "The Riemann zeta function of two arguments (also known as the\n"
-    "Hurwitz zeta function).\n"
-    "\n"
-    "This function is defined as\n"
-    "\n"
-    ".. math:: \\zeta(x, q) = \\sum_{k=0}^{\\infty} 1 / (k+q)^x,\n"
-    "\n"
-    "where ``x > 1`` and ``q > 0``.\n"
-    "\n"
-    "See also\n"
-    "--------\n"
-    "zetac")
-ufunc_zeta_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
-ufunc_zeta_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
-ufunc_zeta_types[0] = <char>NPY_FLOAT
-ufunc_zeta_types[1] = <char>NPY_FLOAT
-ufunc_zeta_types[2] = <char>NPY_FLOAT
-ufunc_zeta_types[3] = <char>NPY_DOUBLE
-ufunc_zeta_types[4] = <char>NPY_DOUBLE
-ufunc_zeta_types[5] = <char>NPY_DOUBLE
-ufunc_zeta_ptr[2*0] = <void*>_func_zeta
-ufunc_zeta_ptr[2*0+1] = <void*>(<char*>"zeta")
-ufunc_zeta_ptr[2*1] = <void*>_func_zeta
-ufunc_zeta_ptr[2*1+1] = <void*>(<char*>"zeta")
-ufunc_zeta_data[0] = &ufunc_zeta_ptr[2*0]
-ufunc_zeta_data[1] = &ufunc_zeta_ptr[2*1]
-zeta = np.PyUFunc_FromFuncAndData(ufunc_zeta_loops, ufunc_zeta_data, ufunc_zeta_types, 2, 2, 1, 0, "zeta", ufunc_zeta_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_zetac_loops[2]
 cdef void *ufunc_zetac_ptr[4]

--- a/scipy/special/_ufuncs_cxx.pxd
+++ b/scipy/special/_ufuncs_cxx.pxd
@@ -7,4 +7,6 @@ cdef void *_export_faddeeva_erfcx
 cdef void *_export_faddeeva_erfcx_complex
 cdef void *_export_faddeeva_erfi
 cdef void *_export_faddeeva_erfi_complex
+cdef void *_export_faddeeva_log_ndtr
+cdef void *_export_faddeeva_ndtr
 cdef void *_export_faddeeva_w

--- a/scipy/special/_ufuncs_cxx.pyx
+++ b/scipy/special/_ufuncs_cxx.pyx
@@ -64,6 +64,12 @@ cdef extern from "_ufuncs_cxx_defs.h":
     cdef double complex _func_faddeeva_erfi_complex "faddeeva_erfi_complex"(double complex) nogil
 cdef void *_export_faddeeva_erfi_complex = <void*>_func_faddeeva_erfi_complex
 cdef extern from "_ufuncs_cxx_defs.h":
+    cdef double complex _func_faddeeva_log_ndtr "faddeeva_log_ndtr"(double complex) nogil
+cdef void *_export_faddeeva_log_ndtr = <void*>_func_faddeeva_log_ndtr
+cdef extern from "_ufuncs_cxx_defs.h":
+    cdef double complex _func_faddeeva_ndtr "faddeeva_ndtr"(double complex) nogil
+cdef void *_export_faddeeva_ndtr = <void*>_func_faddeeva_ndtr
+cdef extern from "_ufuncs_cxx_defs.h":
     cdef double complex _func_faddeeva_w "faddeeva_w"(double complex) nogil
 cdef void *_export_faddeeva_w = <void*>_func_faddeeva_w
 # distutils: language = c++

--- a/scipy/special/_ufuncs_cxx_defs.h
+++ b/scipy/special/_ufuncs_cxx_defs.h
@@ -9,5 +9,7 @@ npy_double faddeeva_erfcx(npy_double);
 npy_cdouble faddeeva_erfcx_complex(npy_cdouble);
 npy_double faddeeva_erfi(npy_double);
 npy_cdouble faddeeva_erfi_complex(npy_cdouble);
+npy_cdouble faddeeva_log_ndtr(npy_cdouble);
+npy_cdouble faddeeva_ndtr(npy_cdouble);
 npy_cdouble faddeeva_w(npy_cdouble);
 #endif

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -4355,17 +4355,37 @@ add_newdoc("scipy.special", "nctdtrit",
     """)
 
 add_newdoc("scipy.special", "ndtr",
-    """
+    r"""
     ndtr(x)
 
-    Gaussian cumulative distribution function
+    Gaussian cumulative distribution function.
 
     Returns the area under the standard Gaussian probability
-    density function, integrated from minus infinity to `x`::
+    density function, integrated from minus infinity to `x`
 
-        1/sqrt(2*pi) * integral(exp(-t**2 / 2), t=-inf..x)
+    .. math::
+
+       \frac{1}{\sqrt{2\pi}} \int_{-\infty}^x \exp(-t^2/2) dt
+
+    Parameters
+    ----------
+    x : array_like, real or complex
+        Argument
+
+    Returns
+    -------
+    ndarray
+        The value of the normal CDF evaluated at `x`
+
+    See Also
+    --------
+    erf
+    erfc
+    scipy.stats.norm
+    log_ndtr
 
     """)
+
 
 add_newdoc("scipy.special", "nrdtrimn",
     """
@@ -4423,12 +4443,30 @@ add_newdoc("scipy.special", "log_ndtr",
     """
     log_ndtr(x)
 
-    Logarithm of Gaussian cumulative distribution function
+    Logarithm of Gaussian cumulative distribution function.
 
     Returns the log of the area under the standard Gaussian probability
     density function, integrated from minus infinity to `x`::
 
         log(1/sqrt(2*pi) * integral(exp(-t**2 / 2), t=-inf..x))
+
+    Parameters
+    ----------
+    x : array_like, real or complex
+        Argument
+
+    Returns
+    -------
+    ndarray
+        The value of the log of the normal CDF evaluated at `x`
+
+    See Also
+    --------
+    erf
+    erfc
+    scipy.stats.norm
+    ndtr
+
     """)
 
 add_newdoc("scipy.special", "ndtri",

--- a/scipy/special/cephes/ndtr.c
+++ b/scipy/special/cephes/ndtr.c
@@ -320,6 +320,9 @@ double log_ndtr(double a)
 	denom_cons = 1.0 / (a * a);	/* the precomputed division we use to adjust the denominator */
     long sign = 1, i = 0;
 
+    if (a > 6) {
+	return -ndtr(-a);     /* log(1+x) \approx x */
+    }
     if (a > -20) {
 	return log(ndtr(a));
     }

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -946,36 +946,31 @@ def generate(filename, cxx_fn_prefix, ufuncs):
     # Produce output
     toplevel = "\n".join(list(all_loops.values()) + defs + [toplevel])
 
-    f = open(filename, 'wb')
-    f.write(EXTRA_CODE_COMMON)
-    f.write(EXTRA_CODE)
-    f.write(toplevel)
-    f.write(EXTRA_CODE_BOTTOM)
-    f.close()
+    with open(filename, 'w') as f:
+        f.write(EXTRA_CODE_COMMON)
+        f.write(EXTRA_CODE)
+        f.write(toplevel)
+        f.write(EXTRA_CODE_BOTTOM)
 
     defs_h = unique(defs_h)
-    f = open(proto_h_filename, 'wb')
-    f.write("#ifndef UFUNCS_PROTO_H\n#define UFUNCS_PROTO_H 1\n")
-    f.write("\n".join(defs_h))
-    f.write("\n#endif\n")
-    f.close()
+    with open(proto_h_filename, 'w') as f:
+        f.write("#ifndef UFUNCS_PROTO_H\n#define UFUNCS_PROTO_H 1\n")
+        f.write("\n".join(defs_h))
+        f.write("\n#endif\n")
 
     cxx_defs_h = unique(cxx_defs_h)
-    f = open(cxx_proto_h_filename, 'wb')
-    f.write("#ifndef UFUNCS_PROTO_H\n#define UFUNCS_PROTO_H 1\n")
-    f.write("\n".join(cxx_defs_h))
-    f.write("\n#endif\n")
-    f.close()
+    with open(cxx_proto_h_filename, 'w') as f:
+        f.write("#ifndef UFUNCS_PROTO_H\n#define UFUNCS_PROTO_H 1\n")
+        f.write("\n".join(cxx_defs_h))
+        f.write("\n#endif\n")
 
-    f = open(cxx_pyx_filename, 'wb')
-    f.write(EXTRA_CODE_COMMON)
-    f.write("\n".join(cxx_defs))
-    f.write("\n# distutils: language = c++\n")
-    f.close()
+    with open(cxx_pyx_filename, 'w') as f:
+        f.write(EXTRA_CODE_COMMON)
+        f.write("\n".join(cxx_defs))
+        f.write("\n# distutils: language = c++\n")
 
-    f = open(cxx_pxd_filename, 'wb')
-    f.write("\n".join(cxx_pxd_defs))
-    f.close()
+    with open(cxx_pxd_filename, 'w') as f:
+        f.write("\n".join(cxx_pxd_defs))
 
 
 def unique(lst):

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -188,8 +188,8 @@ hankel1 -- cbesh_wrap1: dD->D                              -- amos_wrappers.h
 hankel1e -- cbesh_wrap1_e: dD->D                           -- amos_wrappers.h
 hankel2 -- cbesh_wrap2: dD->D                              -- amos_wrappers.h
 hankel2e -- cbesh_wrap2_e: dD->D                           -- amos_wrappers.h
-ndtr -- ndtr: d->d                                         -- cephes.h
-log_ndtr -- log_ndtr: d->d                                 -- cephes.h
+ndtr -- ndtr: d->d, faddeeva_ndtr: D->D                    -- cephes.h, _faddeeva.h++
+log_ndtr -- log_ndtr: d->d, faddeeva_log_ndtr: D->D        -- cephes.h, _faddeeva.h++
 ndtri -- ndtri: d->d                                       -- cephes.h
 psi -- digamma: d->d, cdigamma: D->D                       -- _digamma.pxd, _digamma.pxd
 rgamma -- rgamma: d->d, crgamma: D->D                      -- cephes.h, _loggamma.pxd

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1338,6 +1338,32 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             mpmath.erfi,
                             [ComplexArg()], n=200)
 
+    def test_ndtr(self):
+        assert_mpmath_equal(sc.ndtr,
+                            _exception_to_nan(lambda z: mpmath.erfc(-mpmath.mpmathify(z/np.sqrt(2.)))/2.),
+                            [Arg()], n=200)
+
+    def test_ndtr_complex(self):
+        assert_mpmath_equal(sc.ndtr,
+                            lambda z: mpmath.erfc(-z/np.sqrt(2.))/2.,
+                            [ComplexArg(a=complex(-10000, -10000), b=complex(10000, 10000))], n=200)
+
+    def test_log_ndtr(self):
+        # limit the range of z > 0: in this regime log_ndtr(z) = log(1 - exponentially_small_correct),
+        # and this underflows. Use ndtrc / _norm_logsf directly to avoid loss of precision.
+        assert_mpmath_equal(sc.log_ndtr,
+                            _exception_to_nan(lambda z: mpmath.log(mpmath.erfc(-mpmath.mpmathify(z/np.sqrt(2.)))/2.)),
+                            [Arg(-10000, 6)], n=200)
+
+    def test_log_ndtr_complex(self):
+        # limit the range of Re(z)\to\infty and small Im(z): in this regime
+        # ndtr(z) = 1 - exponentially_small_correction, which underflows.
+        # Better use ndtrc to avoid loss of precision.
+        # Note that regime of Re(z)\to\infty and Im(z) > Re(z) is fine.
+        assert_mpmath_equal(sc.log_ndtr,
+                            lambda z: mpmath.log(mpmath.erfc(-z/np.sqrt(2.))/2.),
+                           [ComplexArg(a=complex(-10000, -10000), b=complex(5, 10000))])
+
     def test_eulernum(self):
         assert_mpmath_equal(lambda n: sc.euler(n)[-1],
                             mpmath.eulernum,

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1340,29 +1340,24 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
 
     def test_ndtr(self):
         assert_mpmath_equal(sc.ndtr,
-                            _exception_to_nan(lambda z: mpmath.erfc(-mpmath.mpmathify(z/np.sqrt(2.)))/2.),
+                            _exception_to_nan(lambda z: mpmath.ncdf(z)),
                             [Arg()], n=200)
 
     def test_ndtr_complex(self):
         assert_mpmath_equal(sc.ndtr,
                             lambda z: mpmath.erfc(-z/np.sqrt(2.))/2.,
-                            [ComplexArg(a=complex(-10000, -10000), b=complex(10000, 10000))], n=200)
+                            [ComplexArg(a=complex(-10000, -10000), b=complex(10000, 10000))], n=400)
 
     def test_log_ndtr(self):
-        # limit the range of z > 0: in this regime log_ndtr(z) = log(1 - exponentially_small_correct),
-        # and this underflows. Use ndtrc / _norm_logsf directly to avoid loss of precision.
         assert_mpmath_equal(sc.log_ndtr,
-                            _exception_to_nan(lambda z: mpmath.log(mpmath.erfc(-mpmath.mpmathify(z/np.sqrt(2.)))/2.)),
-                            [Arg(-10000, 6)], n=200)
+                            _exception_to_nan(lambda z: mpmath.log(mpmath.ncdf(z))),
+                            [Arg()], n=600, dps=300)
 
     def test_log_ndtr_complex(self):
-        # limit the range of Re(z)\to\infty and small Im(z): in this regime
-        # ndtr(z) = 1 - exponentially_small_correction, which underflows.
-        # Better use ndtrc to avoid loss of precision.
-        # Note that regime of Re(z)\to\infty and Im(z) > Re(z) is fine.
         assert_mpmath_equal(sc.log_ndtr,
-                            lambda z: mpmath.log(mpmath.erfc(-z/np.sqrt(2.))/2.),
-                           [ComplexArg(a=complex(-10000, -10000), b=complex(5, 10000))])
+                            _exception_to_nan(lambda z: mpmath.log(mpmath.erfc(-z/np.sqrt(2.))/2.)),
+                            [ComplexArg(a=complex(-10000, -100),
+                                        b=complex(10000, 100))], n=200, dps=300)
 
     def test_eulernum(self):
         assert_mpmath_equal(lambda n: sc.euler(n)[-1],

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -58,16 +58,13 @@ distslow = ['rdist', 'gausshyper', 'recipinvgauss', 'ksone', 'genexpon',
 # Here 'fail' mean produce wrong results and/or raise exceptions, depending
 # on the implementation details of corresponding special functions.
 # cf https://github.com/scipy/scipy/pull/4979 for a discussion.
-fails_cmplx = set(['alpha', 'beta', 'betaprime', 'chi', 'chi2', 'dgamma',
-                   'dweibull', 'erlang', 'exponnorm', 'f', 'fatiguelife',
-                   'foldnorm', 'gamma', 'gausshyper', 'gengamma',
-                   'gennorm', 'genpareto', 'gilbrat', 'halfgennorm',
-                   'halfnorm', 'invgamma', 'invgauss', 'johnsonsb', 'johnsonsu',
+fails_cmplx = set(['beta', 'betaprime', 'chi', 'chi2', 'dgamma', 'dweibull',
+                   'erlang', 'f', 'gamma', 'gausshyper', 'gengamma',
+                   'gennorm', 'genpareto', 'halfgennorm', 'invgamma',
                    'ksone', 'kstwobign', 'levy_l', 'loggamma', 'logistic',
-                   'lognorm', 'maxwell', 'nakagami', 'ncf', 'nct', 'ncx2',
-                   'norm', 'pearson3', 'powerlognorm', 'powernorm',
-                   'recipinvgauss', 'rice', 'skewnorm', 't', 'truncnorm',
-                   'tukeylambda', 'vonmises', 'vonmises_line', 'wald'])
+                   'maxwell', 'nakagami', 'ncf', 'nct', 'ncx2',
+                   'pearson3', 'rice', 't', 'skewnorm', 'tukeylambda',
+                   'vonmises', 'vonmises_line',])
 
 def test_cont_basic():
     # this test skips slow distributions

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2188,11 +2188,15 @@ def test_norm_logcdf():
                 -4613.48339520, -5005.52420869, -5413.56342187, -5837.60115548,
                 -6277.63751711, -6733.67260303]
 
-    olderr = np.seterr(divide='ignore')
-    try:
-        assert_allclose(stats.norm().logcdf(x), expected, atol=1e-8)
-    finally:
-        np.seterr(**olderr)
+    assert_allclose(stats.norm().logcdf(x), expected, atol=1e-8)
+
+    # also test the complex-valued code path
+    assert_allclose(stats.norm().logcdf(x + 1e-14j).real, expected, atol=1e-8)
+
+    # test the accuracy: d(logcdf)/dx = pdf / cdf \equiv exp(logpdf - logcdf)
+    deriv = (stats.norm.logcdf(x + 1e-10j)/1e-10).imag
+    deriv_expected = np.exp(stats.norm.logpdf(x) - stats.norm.logcdf(x))
+    assert_allclose(deriv, deriv_expected, atol=1e-10)
 
 
 def test_levy_cdf_ppf():


### PR DESCRIPTION
This enables the complex-step differentiation of normal distribution and several others which depend on the  normal CDF. To make sure that there's no slowing down for the real arguments, the dispatch on the dtype is pushed to the ufunc level. 
