### PR TITLE
MAINT: sparse.linalg/superlu: add explicit casts to resolve compiler warnings

### DIFF
--- a/scipy/sparse/linalg/dsolve/_superlu_utils.c
+++ b/scipy/sparse/linalg/dsolve/_superlu_utils.c
@@ -20,7 +20,7 @@
 static SuperLUGlobalObject superlu_py_global = {0};
 #endif
 
-static SuperLUGlobalObject *get_tls_global()
+static SuperLUGlobalObject *get_tls_global(void)
 {
 #ifndef WITH_THREAD
     if (superlu_py_global.memory_dict == NULL) {
@@ -39,8 +39,8 @@ static SuperLUGlobalObject *get_tls_global()
         return NULL;
     }
 
-    obj = PyDict_GetItemString(thread_dict, key);
-    if (obj) {
+    obj = (SuperLUGlobalObject*)PyDict_GetItemString(thread_dict, key);
+    if (obj && Py_TYPE(obj) == &SuperLUGlobalType) {
         return obj;
     }
 
@@ -57,7 +57,7 @@ static SuperLUGlobalObject *get_tls_global()
 #endif
 }
 
-jmp_buf *superlu_python_jmpbuf()
+jmp_buf *superlu_python_jmpbuf(void)
 {
     SuperLUGlobalObject *g;
 

--- a/scipy/sparse/linalg/dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/dsolve/_superlumodule.c
@@ -14,7 +14,7 @@
 #include <Python.h>
 
 #define PY_ARRAY_UNIQUE_SYMBOL _scipy_sparse_superlu_ARRAY_API
-#include <numpy/arrayobject.h>
+#include <numpy/ndarrayobject.h>
 
 #include "_superluobject.h"
 #include "numpy/npy_3kcompat.h"
@@ -107,7 +107,7 @@ static PyObject *Py_gssv(PyObject * self, PyObject * args,
 	return NULL;
     }
 
-    type = PyArray_TYPE(nzvals);
+    type = PyArray_TYPE((PyArrayObject*)nzvals);
     if (!CHECK_SLU_TYPE(type)) {
 	PyErr_SetString(PyExc_TypeError,
 			"nzvals is not of a type supported by SuperLU");
@@ -122,11 +122,11 @@ static PyObject *Py_gssv(PyObject * self, PyObject * args,
     /* Create Space for output */
     Py_X = (PyArrayObject*)PyArray_FROMANY(
         (PyObject*)Py_B, type, 1, 2,
-        NPY_F_CONTIGUOUS | NPY_ENSURECOPY);
+        NPY_ARRAY_F_CONTIGUOUS | NPY_ARRAY_ENSURECOPY);
     if (Py_X == NULL)
 	return NULL;
 
-    if (Py_X->dimensions[0] != N) {
+    if (PyArray_DIM((PyArrayObject*)Py_X, 0) != N) {
         PyErr_SetString(PyExc_ValueError,
                         "b array has invalid shape");
         Py_DECREF(Py_X);
@@ -160,7 +160,7 @@ static PyObject *Py_gssv(PyObject * self, PyObject * args,
 
     /* Setup options */
 
-    jmpbuf_ptr = superlu_python_jmpbuf();
+    jmpbuf_ptr = (volatile jmp_buf *)superlu_python_jmpbuf();
     SLU_BEGIN_THREADS;
     if (setjmp(*(jmp_buf*)jmpbuf_ptr)) {
         SLU_END_THREADS;
@@ -235,7 +235,7 @@ static PyObject *Py_gstrf(PyObject * self, PyObject * args,
 	return NULL;
     }
 
-    type = PyArray_TYPE(nzvals);
+    type = PyArray_TYPE((PyArrayObject*)nzvals);
     if (!CHECK_SLU_TYPE(type)) {
 	PyErr_SetString(PyExc_TypeError,
 			"nzvals is not of a type supported by SuperLU");

--- a/scipy/sparse/linalg/dsolve/_superluobject.h
+++ b/scipy/sparse/linalg/dsolve/_superluobject.h
@@ -17,13 +17,13 @@
 #endif
 
 #include "SuperLU/SRC/slu_zdefs.h"
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "SuperLU/SRC/slu_util.h"
 #include "SuperLU/SRC/slu_dcomplex.h"
 #include "SuperLU/SRC/slu_scomplex.h"
 
 
-#define _CHECK_INTEGER(x) (PyArray_ISINTEGER(x) && (x)->descr->elsize == sizeof(int))
+#define _CHECK_INTEGER(x) (PyArray_ISINTEGER((PyArrayObject*)x) && PyArray_ITEMSIZE((PyArrayObject*)x) == sizeof(int))
 
 /*
  * SuperLUObject definition

--- a/scipy/sparse/linalg/dsolve/_superluobject.h
+++ b/scipy/sparse/linalg/dsolve/_superluobject.h
@@ -69,7 +69,7 @@ void XDestroy_CompCol_Matrix(SuperMatrix *);
 void XDestroy_CompCol_Permuted(SuperMatrix *);
 void XStatFree(SuperLUStat_t *);
 
-jmp_buf *superlu_python_jmpbuf();
+jmp_buf *superlu_python_jmpbuf(void);
 
 
 /* Custom thread begin/end statements: Numpy versions < 1.9 are not safe
@@ -78,7 +78,7 @@ jmp_buf *superlu_python_jmpbuf();
  */
 #define SLU_BEGIN_THREADS_DEF volatile PyThreadState *_save = NULL
 #define SLU_BEGIN_THREADS do { if (_save == NULL) _save = PyEval_SaveThread(); } while (0)
-#define SLU_END_THREADS   do { if (_save) { PyEval_RestoreThread(_save); _save = NULL;} } while (0)
+#define SLU_END_THREADS   do { if (_save) { PyEval_RestoreThread((PyThreadState*)_save); _save = NULL;} } while (0)
 
 /*
  * Definitions for other SuperLU data types than Z,

--- a/scipy/sparse/linalg/dsolve/setup.py
+++ b/scipy/sparse/linalg/dsolve/setup.py
@@ -11,6 +11,7 @@ def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     from numpy.distutils.system_info import get_info
     from scipy._build_utils import get_sgemv_fix
+    from scipy._build_utils import numpy_nodepr_api
 
     config = Configuration('dsolve',parent_package,top_path)
     config.add_data_dir('tests')
@@ -47,6 +48,7 @@ def configuration(parent_package='',top_path=None):
                          libraries=['superlu_src'],
                          depends=(sources + headers),
                          extra_info=lapack_opt,
+                         **numpy_nodepr_api
                          )
 
     return config


### PR DESCRIPTION
Get rid of some compiler warnings in superlu module.

A further cleanup would be to wrap all of the superlu functions with small helpers that deal with the setjmp error handling, but that's for later.
