### PR TITLE
MAINT: signal: import gcd from math and not fractions when on py3+

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -5,7 +5,11 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 import threading
-from fractions import gcd
+import sys
+if sys.version_info.major >= 3 and sys.version_info.minor >= 5:
+    from math import gcd
+else:
+    from fractions import gcd
 
 from . import sigtools
 from ._upfirdn import _UpFIRDn, _output_len


### PR DESCRIPTION
on python 3+ fraction is deprecated and throws DeprecationWarning
fixes #5874

I hope MAINT is the right tag. Was unsure, my first time on scipy.
