### PR TITLE
WIP - BUG: scipy.signal.lsim overflow error

### DIFF
--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -4,12 +4,13 @@ import warnings
 
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_equal, assert_allclose,
+                           assert_approx_equal,
                            assert_, assert_raises, TestCase, run_module_suite)
 from scipy.signal.ltisys import (ss2tf, tf2ss, lsim2, impulse2, step2, lti,
                                  bode, freqresp, lsim, impulse, step,
                                  abcd_normalize, place_poles,
                                  TransferFunction, StateSpace, ZerosPolesGain)
-from scipy.signal.filter_design import BadCoefficients
+from scipy.signal.filter_design import BadCoefficients, butter
 import scipy.linalg as linalg
 
 
@@ -396,6 +397,14 @@ class TestLsim(object):
         expected_y = np.exp(-tout)
         assert_almost_equal(y, expected_y)
 
+    def test_07(self):
+        # Test chances of overflow in lsim
+        (z, p, k) = butter(22, 22029, analog=True, output='zpk')
+        t = np.linspace(0,10E-3,num=10000)
+        x1 = np.cos(2*np.pi*3500*t)
+        (t2, y2, x2) = lsim((z, p, k), x1, t)
+        assert_approx_equal(np.max(y2), 0.72, significant=2)
+
 
 class Test_lsim2(object):
 
@@ -471,6 +480,13 @@ class Test_lsim2(object):
         expected_x = (1.0 - tout) * np.exp(-tout)
         assert_almost_equal(x[:,0], expected_x)
 
+    def test_07(self):
+        # Test chances of overflow in lsim2
+        (z, p, k) = butter(22, 22029, analog=True, output='zpk')
+        t = np.linspace(0,10E-3,num=10000)
+        x1 = np.cos(2*np.pi*3500*t)
+        (t2, y2, x2) = lsim2((z, p, k), x1, t)
+        assert_approx_equal(np.max(y2), 0.72, significant=2)
 
 class _TestImpulseFuncs(object):
     # Common tests for impulse/impulse2 (= self.func)


### PR DESCRIPTION
The `scipy.signal.lsim` function raises an `OverflowError` on the new test committed here, whereas the same test using `lsim2` does not. `lsim2` returns a similar output to MATLAB. Given that #5676 aims to deprecate `lsim2` I believe it would be good to fix this issue. Unfortunately I do not have the skills to properly address it.

This is the error log:

```
ERROR: test_ltisys.TestLsim.test_07
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.5.0/lib/python3.5/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/home/travis/virtualenv/python3.5.0/lib/python3.5/site-packages/scipy/signal/tests/test_ltisys.py", line 405, in test_07
    (t2, y2, x2) = lsim((z, p, k), x1, t)
  File "/home/travis/virtualenv/python3.5.0/lib/python3.5/site-packages/scipy/signal/ltisys.py", line 1325, in lsim
    expMT = linalg.expm(transpose(M))
  File "/home/travis/virtualenv/python3.5.0/lib/python3.5/site-packages/scipy/linalg/matfuncs.py", line 261, in expm
    return scipy.sparse.linalg.expm(A)
  File "/home/travis/virtualenv/python3.5.0/lib/python3.5/site-packages/scipy/sparse/linalg/matfuncs.py", line 582, in expm
    return _expm(A, use_exact_onenorm='auto')
  File "/home/travis/virtualenv/python3.5.0/lib/python3.5/site-packages/scipy/sparse/linalg/matfuncs.py", line 643, in _expm
    s = s + _ell(2**-s * h.A, 13)
  File "/home/travis/virtualenv/python3.5.0/lib/python3.5/site-packages/scipy/sparse/linalg/matfuncs.py", line 832, in _ell
    value = int(np.ceil(log2_alpha_div_u / (2 * m)))
OverflowError: cannot convert float infinity to integer
```
