### PR TITLE
Enhancements and cleanup in scipy.integrate

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -28,3 +28,13 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
+
+LANL changes are copyright 2016.  Los Alamos National Security,
+LLC. This material was produced under U.S. Government contract DE-AC52-06NA25396
+for Los Alamos National Laboratory (LANL), which is operated by Los Alamos
+National Security, LLC for the U.S. Department of Energy. The U.S. Government
+has rights to use, reproduce, and distribute this software.  NEITHER THE
+GOVERNMENT NOR LOS ALAMOS NATIONAL SECURITY, LLC MAKES ANY WARRANTY, EXPRESS OR
+IMPLIED, OR ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+modified to produce derivative works, such modified software should be clearly
+marked, so as not to confuse it with the version available from LANL.

--- a/THANKS.txt
+++ b/THANKS.txt
@@ -130,9 +130,7 @@ Jörg Dietrich for the k-sample Anderson Darling test.
 Blake Griffith for improvements to scipy.sparse.
 Andrew Nelson for scipy.optimize.differential_evolution.
 Brian Newsom for work on ctypes multivariate integration.
-Nathan Woods for work on multivariate integration. His work from 31 Aug 2015
-    to the present is subject to the disclaimer at:
-    https://github.com/losalamos/Gazebo/blob/master/LICENSE.
+Nathan Woods for work on multivariate integration. 
 Brianna Laugher for bug fixes.
 Johannes Kulick for the Dirichlet distribution.
 Bastian Venthur for bug fixes.

--- a/THANKS.txt
+++ b/THANKS.txt
@@ -130,7 +130,9 @@ Jörg Dietrich for the k-sample Anderson Darling test.
 Blake Griffith for improvements to scipy.sparse.
 Andrew Nelson for scipy.optimize.differential_evolution.
 Brian Newsom for work on ctypes multivariate integration.
-Nathan Woods for advising on multivariate integration and building unit tests.
+Nathan Woods for work on multivariate integration. His work from 31 Aug 2015
+    to the present is subject to the disclaimer at:
+    https://github.com/losalamos/Gazebo/blob/master/LICENSE.
 Brianna Laugher for bug fixes.
 Johannes Kulick for the Dirichlet distribution.
 Bastian Venthur for bug fixes.

--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -152,11 +152,11 @@ An example of using double integration to compute several values of
     ...     return dblquad(lambda t, x: np.exp(-x*t)/t**n, 0, np.inf, lambda x: 1, lambda x: np.inf)
 
     >>> print(I(4))
-    (0.25000000000435768, 1.0518245707751597e-09)
+    (0.2500000000043577, 1.29830334693681e-08)
     >>> print(I(3))
-    (0.33333333325010883, 2.8604069919261191e-09)
+    (0.33333333325010883, 1.3888461883425516e-08)
     >>> print(I(2))
-    (0.49999999999857514, 1.8855523253868967e-09)
+    (0.4999999999985751, 1.3894083651858995e-08)
 
 
 As example for non-constant limits consider the integral

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -557,10 +557,13 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
     # nquad will hand (y, x, t0, ...) to ranges0
     # nquad will hand (x, t0, ...) to ranges1
     # Stupid different API...
+
     def ranges0(*args):
         return [qfun(args[1], args[0]), rfun(args[1], args[0])]
+
     def ranges1(*args):
         return [gfun(args[0]), hfun(args[0])]
+
     ranges = [ranges0, ranges1, [a, b]]
     return nquad(func, ranges, args=args)
 
@@ -601,18 +604,21 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
         Each element of ranges may be either a sequence  of 2 numbers, or else
         a callable that returns such a sequence.  ``ranges[0]`` corresponds to
         integration over x0, and so on.  If an element of ranges is a callable,
-        then it will be called with all of the integration arguments available.
-        e.g. if ``func = f(x0, x1, x2)``, then ``ranges[0]`` may be defined as
-        either ``(a, b)`` or else as ``(a, b) = range0(x1, x2)``.
+        then it will be called with all of the integration arguments available,
+        as well as any parametric arguments. e.g. if 
+        ``func = f(x0, x1, x2, t0, t1)``, then ``ranges[0]`` may be defined as
+        either ``(a, b)`` or else as ``(a, b) = range0(x1, x2, t0, t1)``.
     args : iterable object, optional
-        Additional arguments ``t0, ..., tn``, required by `func`.
+        Additional arguments ``t0, ..., tn``, required by `func`, `ranges`, and
+        ``opts``.
     opts : iterable object or dict, optional
         Options to be passed to `quad`.  May be empty, a dict, or
         a sequence of dicts or functions that return a dict.  If empty, the
-        default options from scipy.integrate.quadare used.  If a dict, the same
+        default options from scipy.integrate.quad are used.  If a dict, the same
         options are used for all levels of integraion.  If a sequence, then each
         element of the sequence corresponds to a particular integration. e.g.
-        opts[0] corresponds to integration over x0, and so on. The available
+        opts[0] corresponds to integration over x0, and so on. If a callable, 
+        the signature must be the same as for ``ranges``. The available
         options together with their default values are:
 
           - epsabs = 1.49e-08

--- a/scipy/integrate/quadpack.py
+++ b/scipy/integrate/quadpack.py
@@ -628,10 +628,12 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
           - wvar   = None
           - wopts  = None
 
-        The ``full_output`` option from `quad` is unavailable, due to the
-        complexity of handling the large amount of data such an option would
-        return for this kind of nested integration.  For more information on
-        these options, see `quad` and `quad_explain`.
+        For more information on these options, see `quad` and `quad_explain`.
+
+    full_output : bool, optional
+        Preliminary implementation of ``full_output`` is now available. At
+        present, the number of evaluations ``neval`` can be obtained by
+        setting ``full_output=True`` when calling nquad.
 
     Returns
     -------


### PR DESCRIPTION
Since the introduction of `nquad`, the integrate package has had two different ways of evaluating multivariate integrals. This PR removes the duplicate code, converting `scipy.integrate.dblquad` and `scipy.integrate.tplquad` to thin wrappers around `nquad`. The API for these (which is backward from the nquad API) is preserved.

Additionally, an option is added to return the total number of integrand function evaluations required by the integration. 

Finally, I had to add a link to my work's BSD license, disclaimer, and copyright assertion in the THANKS.txt. I hope this is an acceptable way to reconcile their need to assert copyright with the needs of scipy. 
