### PR TITLE
BUG: _CustomLinearOperator unpickalable in python3.5

### DIFF
--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -139,7 +139,6 @@ class LinearOperator(object):
                 raise TypeError("LinearOperator subclass should implement"
                                 " at least one of _matvec and _matmat.")
 
-            obj.__init__(*args, **kwargs)
             return obj
 
     def __init__(self, dtype, shape):

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -284,6 +284,20 @@ def test_attributes():
         assert_(hasattr(op, "shape"))
         assert_(hasattr(op, "_matvec"))
 
+def matvec(x):
+    """ Needed for test_pickle as local functions are not pickleable """
+    return np.zeros(3)
+
+def test_pickle():
+    import pickle
+
+    for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
+        A = interface.LinearOperator((3, 3), matvec)
+        s = pickle.dumps(A, protocol=protocol)
+        B = pickle.loads(s)
+
+        for k in A.__dict__:
+            assert_equal(getattr(A, k), getattr(B, k))
 
 def test_inheritance():
     class Empty(interface.LinearOperator):


### PR DESCRIPTION
This adds the needed `__getnewargs__` method to `_CustomLinearOperator`
to enable it to be pickleable with protocol 2 and newer.

Fixes #5891 

I'm having a small issue writing the test for this. I would guess the cleanest way
do write it would be to have a test along the lines of

```
def test_pickle():
    import pickle
    M = N = 3

    def matvec(x):
        return np.zeros(N)

    A = interface.LinearOperator(shape=(M, N), matvec=matvec)
    s = pickle.dumps(A)
    B = pickle.loads(s)
```

However that has the issue that `matvec` is a local function and is therefore unpickleable. Any pointers on that would be much appreciated!
