### PR TITLE
BUG: interpolate: make interp1d handle np.float128 again

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -366,9 +366,11 @@ class interp1d(_Interpolator1D):
           list or ndarray, regardless of shape) is taken to be a single
           array-like argument meant to be used for both bounds as
           ``below, above = fill_value, fill_value``.
+
           .. versionadded:: 0.17.0
         - If "extrapolate", then points outside the data range will be
           extrapolated. ("nearest" and "linear" kinds only.)
+
           .. versionadded:: 0.17.0
     assume_sorted : bool, optional
         If False, values of `x` can be in any order and they are sorted first.
@@ -460,9 +462,11 @@ class interp1d(_Interpolator1D):
                 self._call = self.__class__._call_nearest
             else:
                 # Check if we can delegate to numpy.interp (2x-10x faster).
-                if (not np.issubdtype(self.y.dtype, np.complexfloating) and
-                   self.y.ndim == 1 and
-                   not _do_extrapolate(fill_value)):
+                cond = self.x.dtype == np.float_ and self.y.dtype == np.float_
+                cond = cond and self.y.ndim == 1
+                cond = cond and not _do_extrapolate(fill_value)
+
+                if cond:
                     self._call = self.__class__._call_linear_np
                 else:
                     self._call = self.__class__._call_linear

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -269,6 +269,17 @@ class TestInterp1D(object):
                     bounds_error=True)
         assert_raises(ValueError, interp1d, self.x10, self.y10, **opts)
 
+    def test_linear_dtypes(self):
+        # regression test for gh-5898, where 1D linear interpolation has been
+        # delegated to numpy.interp for all float dtypes, and the latter was
+        # not handling e.g. np.float128.
+        for dtyp in np.sctypes["float"]:
+            x = np.arange(8, dtype=dtyp)
+            y = x
+            yp = interp1d(x, y, kind='linear')(x)
+            assert_equal(yp.dtype, dtyp)
+            assert_allclose(yp, y, atol=1e-15)
+
     def test_cubic(self):
         # Check the actual implementation of spline interpolation.
         interp10 = interp1d(self.x10, self.y10, kind='cubic')


### PR DESCRIPTION
In scipy 0.17.0, `interp1d` delegates to `np.interp` for 1D arrays. However, `np.interp` casts everything to `np.float64`, which fails e.g. for `np.float128` (and upcasts e.g. `float16` which may or may not be intended).

Therefore, only delegate to `np.interp` if the input arrays are `np.float_` only.

closes gh-5898
