### PR TITLE
ENH: Change sparse `.sum` and `.mean` dtype casting to match NumPy.

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -705,11 +705,10 @@ class spmatrix(object):
         # Mimic numpy's casting.
         if np.issubdtype(self.dtype, np.float_):
             res_dtype = np.float_
-        elif (np.issubdtype(self.dtype, np.int_) or
-              np.issubdtype(self.dtype, np.bool_)):
-                res_dtype = np.int_
-        elif np.issubdtype(self.dtype, np.complex_):
-            res_dtype = np.complex_
+        elif self.dtype.kind in 'ib':
+            res_dtype = np.int_
+        elif self.dtype.kind == 'u':
+            res_dtype = np.uint
         else:
             res_dtype = self.dtype
 
@@ -734,16 +733,16 @@ class spmatrix(object):
         """
         # Mimic numpy's casting.
         if (np.issubdtype(self.dtype, np.float_) or
-                np.issubdtype(self.dtype, np.integer) or
-                np.issubdtype(self.dtype, np.bool_)):
+            np.issubdtype(self.dtype, np.integer) or
+            np.issubdtype(self.dtype, np.bool_)):
             res_dtype = np.float_
-        elif np.issubdtype(self.dtype, np.complex_):
-            res_dtype = np.complex_
         else:
             res_dtype = self.dtype
 
         if axis is None:
-            return self.sum(None) * 1.0 / (self.shape[0]*self.shape[1])
+            m, n = self.shape
+            return self.astype(res_dtype).sum() / np.matrix(m * n,
+                                                            dtype=res_dtype)
 
         if axis < 0:
             axis += 2

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -733,8 +733,8 @@ class spmatrix(object):
         """
         # Mimic numpy's casting.
         if (np.issubdtype(self.dtype, np.float_) or
-            np.issubdtype(self.dtype, np.integer) or
-            np.issubdtype(self.dtype, np.bool_)):
+                np.issubdtype(self.dtype, np.integer) or
+                np.issubdtype(self.dtype, np.bool_)):
             res_dtype = np.float_
         else:
             res_dtype = self.dtype

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -564,10 +564,17 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         elif (not hasattr(self, 'blocksize') and
               axis in self._swap(((1, -1), (0, 2)))[0]):
             # faster than multiplication for large minor axis in CSC/CSR
-            dtype = self.dtype
-            if np.issubdtype(dtype, np.bool_):
-                dtype = np.int_
-            ret = np.zeros(len(self.indptr) - 1, dtype=dtype)
+            # Mimic numpy's casting.
+            if np.issubdtype(self.dtype, np.float_):
+                res_dtype = np.float_
+            elif self.dtype.kind in 'ib':
+                res_dtype = np.int_
+            elif self.dtype.kind == 'u':
+                res_dtype = np.uint
+            else:
+                res_dtype = self.dtype
+            ret = np.zeros(len(self.indptr) - 1, dtype=res_dtype)
+
             major_index, value = self._minor_reduce(np.add)
             ret[major_index] = value
             ret = np.asmatrix(ret)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -3972,7 +3972,11 @@ class _NonCanonicalMixin(object):
 
         # check that result is valid
         if NC.dtype in [np.float32, np.complex64]:
-            rtol = 1e-04
+            # For single-precision floats, the differences between M and NC
+            # that are introduced by the extra operations involved in the
+            # construction of NC necessitate a more lenient tolerance level
+            # than the default.
+            rtol = 1e-05
         else:
             rtol = 1e-07
         assert_allclose(NC.A, M.A, rtol=rtol)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -749,43 +749,26 @@ class _TestCommon:
         dat_1 = np.matrix([[0, 1, 2],
                            [3, -4, 5],
                            [-6, 7, 9]])
-        dat_2 = np.random.rand(40, 40)
+        dat_2 = np.random.rand(5, 5)
         dat_3 = np.array([[]])
         dat_4 = np.zeros((40, 40))
-        dat_5 = sparse.rand(40, 40, density=1e-2).A
+        dat_5 = sparse.rand(5, 5, density=1e-2).A
         matrices = [dat_1, dat_2, dat_3, dat_4, dat_5]
 
         def check(dtype, j):
-            if j == 1:
-                # At the lowest tested precision for floats and complex
-                # numbers, the sparse matrix sum method can lead to different
-                # results in the lower decimals from the dense matrix sum
-                # method. This necessitaties a more lenient comparison between
-                # the resulting matrices.
-                if dtype == np.complex64:
-                    decimal = 4
-                else:
-                    decimal = 5
-            else:
-                decimal = 7
             dat = np.matrix(matrices[j], dtype=dtype)
             datsp = self.spmatrix(dat, dtype=dtype)
-            assert_array_almost_equal(dat.sum(), datsp.sum(), decimal=decimal)
+            assert_array_almost_equal(dat.sum(), datsp.sum())
             assert_equal(dat.sum().dtype, datsp.sum().dtype)
-            assert_array_almost_equal(dat.sum(axis=None), datsp.sum(axis=None),
-                                      decimal=decimal)
+            assert_array_almost_equal(dat.sum(axis=None), datsp.sum(axis=None))
             assert_equal(dat.sum(axis=None).dtype, datsp.sum(axis=None).dtype)
-            assert_array_almost_equal(dat.sum(axis=0), datsp.sum(axis=0),
-                                      decimal=decimal)
+            assert_array_almost_equal(dat.sum(axis=0), datsp.sum(axis=0))
             assert_equal(dat.sum(axis=0).dtype, datsp.sum(axis=0).dtype)
-            assert_array_almost_equal(dat.sum(axis=1), datsp.sum(axis=1),
-                                      decimal=decimal)
+            assert_array_almost_equal(dat.sum(axis=1), datsp.sum(axis=1))
             assert_equal(dat.sum(axis=1).dtype, datsp.sum(axis=1).dtype)
-            assert_array_almost_equal(dat.sum(axis=-2), datsp.sum(axis=-2),
-                                      decimal=decimal)
+            assert_array_almost_equal(dat.sum(axis=-2), datsp.sum(axis=-2))
             assert_equal(dat.sum(axis=-2).dtype, datsp.sum(axis=-2).dtype)
-            assert_array_almost_equal(dat.sum(axis=-1), datsp.sum(axis=-1),
-                                      decimal=decimal)
+            assert_array_almost_equal(dat.sum(axis=-1), datsp.sum(axis=-1))
             assert_equal(dat.sum(axis=-1).dtype, datsp.sum(axis=-1).dtype)
 
         for dtype in self.checked_dtypes:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -798,7 +798,6 @@ class _TestCommon:
         for dtype in self.checked_dtypes:
             yield check, dtype
 
-
     def test_expm(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=SparseEfficiencyWarning)


### PR DESCRIPTION
Change the sparse `.sum` and `.mean` methods to behave like their NumPy
matrix counterparts in terms of dtype casting, and update the
corresponding tests in scipy/sparse/test_base.py. This should resolve #2534.
