### PR TITLE
BUG, TST: Fix output modes of signal.spectrogram

### DIFF
--- a/doc/release/0.18.0-notes.rst
+++ b/doc/release/0.18.0-notes.rst
@@ -53,14 +53,18 @@ Deprecated features
 Backwards incompatible changes
 ==============================
 
-The convergence criterion for ``optimize.bisect``,
-``optimize.brentq``, ``optimize.brenth``, and ``optimize.ridder`` now
-works the same as ``numpy.allclose``.
+The convergence criterion for `optimize.bisect`,
+`optimize.brentq`, `optimize.brenth`, and `optimize.ridder` now
+works the same as `numpy.allclose`.
 
-The offset in ``ndimage.iterpolation.affine_transform``
+The offset in `ndimage.iterpolation.affine_transform`
 is now consistently added after the matrix is applied,
 independent of if the matrix is specified using a one-dimensional
 or a two-dimensional array.
+
+The `mode` keyword argument in `signal.spectrogram` no longer supports the
+values of 'magnitude', 'angle', or 'phase', as the return values were not
+useful.
 
 Other changes
 =============


### PR DESCRIPTION
Remove `Phase` and `angle` modes from `_spectral_helper` and thereby
`spectrogram`, as they do not have much utility when signals are windowed and
averaged.

Make corrections for `mode=complex` due to windowing and two- vs.
one-sidedness.

Add clarifying language to `spectrogram`'s docstring explaining when complex
output may be desired, as well as an example.

Add tests to ensure complex output has the expected magnitude and phase, by
comparing to direct PSD and CSD calculations.

Closes #5757
