### PR TITLE
ENH: changes for convolution symmetry

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -748,6 +748,9 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
     in1 = asarray(in1)
     in2 = asarray(in2)
 
+    if not in1.ndim == in2.ndim == 2:
+        raise ValueError('convolve2d inputs must both be 2D arrays')
+
     if _inputs_swap_needed(mode, in1.shape, in2.shape):
         in1, in2 = in2, in1
 
@@ -841,6 +844,9 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
     """
     in1 = asarray(in1)
     in2 = asarray(in2)
+
+    if not in1.ndim == in2.ndim == 2:
+        raise ValueError('correlate2d inputs must both be 2D arrays')
 
     swapped_inputs = _inputs_swap_needed(mode, in1.shape, in2.shape)
     if swapped_inputs:

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -387,7 +387,9 @@ def fftconvolve(in1, in2, mode="full"):
                       np.issubdtype(in2.dtype, complex))
     shape = s1 + s2 - 1
 
+    # Check that input sizes are compatible with 'valid' mode
     if _inputs_swap_needed(mode, s1, s2):
+        # Convolution is commutative; order doesn't have any effect on output
         in1, s1, in2, s2 = in2, s2, in1, s1
 
     # Speed up FFT by padding to optimal size for FFTPACK
@@ -491,11 +493,12 @@ def convolve(in1, in2, mode='full'):
     volume = asarray(in1)
     kernel = asarray(in2)
 
-    if _inputs_swap_needed(mode, volume.shape, kernel.shape):
-        volume, kernel = kernel, volume
-
     if volume.ndim == kernel.ndim == 0:
         return volume * kernel
+
+    if _inputs_swap_needed(mode, volume.shape, kernel.shape):
+        # Convolution is commutative; order doesn't have any effect on output
+        volume, kernel = kernel, volume
 
     # fastpath to faster numpy 1d convolve (but numpy's 'same' mode uses the
     # size of the larger input, not the first.)

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -83,7 +83,8 @@ def _inputs_swap_needed(mode, shape1, shape2):
     is larger than shape1. This is important for some of the correlation and
     convolution implementations in this module, where the larger array input
     needs to come before the smaller array input when operating in this mode.
-    Note that if the mode provided is not 'valid', False is immediately returned.
+    Note that if the mode provided is not 'valid', False is immediately
+    returned.
 
     """
     if mode == 'valid':
@@ -117,8 +118,8 @@ def correlate(in1, in2, mode='full'):
         First input.
     in2 : array_like
         Second input. Should have the same number of dimensions as `in1`.
-        If operating in 'valid' mode, either `in1` or `in2` must have
-        dimensions that are at least as large as the other in every dimension.
+        If operating in 'valid' mode, either `in1` or `in2` must be
+        at least as large as the other in every dimension.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
 
@@ -307,8 +308,8 @@ def fftconvolve(in1, in2, mode="full"):
         First input.
     in2 : array_like
         Second input. Should have the same number of dimensions as `in1`.
-        If operating in 'valid' mode, either `in1` or `in2` must have
-        dimensions that are at least as large as the other in every dimension.
+        If operating in 'valid' mode, either `in1` or `in2` must be
+        at least as large as the other in every dimension.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
 
@@ -437,8 +438,8 @@ def convolve(in1, in2, mode='full'):
         First input.
     in2 : array_like
         Second input. Should have the same number of dimensions as `in1`.
-        If operating in 'valid' mode, either `in1` or `in2` must have
-        dimensions that are at least as large as the other in every dimension.
+        If operating in 'valid' mode, either `in1` or `in2` must be
+        at least as large as the other in every dimension.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
 
@@ -677,8 +678,8 @@ def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
         First input.
     in2 : array_like
         Second input. Should have the same number of dimensions as `in1`.
-        If operating in 'valid' mode, either `in1` or `in2` must have
-        dimensions that are at least as large as the other in every dimension.
+        If operating in 'valid' mode, either `in1` or `in2` must be
+        at least as large as the other in every dimension.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
 
@@ -770,8 +771,8 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
         First input.
     in2 : array_like
         Second input. Should have the same number of dimensions as `in1`.
-        If operating in 'valid' mode, either `in1` or `in2` must have
-        dimensions that are at least as large as the other in every dimension.
+        If operating in 'valid' mode, either `in1` or `in2` must be
+        at least as large as the other in every dimension.
     mode : str {'full', 'valid', 'same'}, optional
         A string indicating the size of the output:
 

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -496,10 +496,8 @@ def convolve(in1, in2, mode='full'):
 
     slice_obj = [slice(None, None, -1)] * len(kernel.shape)
 
-    if np.iscomplexobj(kernel):
-        return correlate(volume, kernel[slice_obj].conj(), mode)
-    else:
-        return correlate(volume, kernel[slice_obj], mode)
+    # .conj() does nothing to real arrays and is faster than iscomplexobj()
+    return correlate(volume, kernel[slice_obj].conj(), mode)
 
 
 def order_filter(a, domain, rank):
@@ -1807,12 +1805,12 @@ def resample(x, num, t=None, axis=0, window=None):
     sample of the next cycle:
 
     >>> from scipy import signal
-    
+
     >>> x = np.linspace(0, 10, 20, endpoint=False)
     >>> y = np.cos(-x**2/6.0)
     >>> f = signal.resample(y, 100)
     >>> xnew = np.linspace(0, 10, 100, endpoint=False)
-    
+
     >>> import matplotlib.pyplot as plt
     >>> plt.plot(x, y, 'go-', xnew, f, '.-', 10, y[0], 'ro')
     >>> plt.legend(['data', 'resampled'], loc='best')
@@ -1914,13 +1912,13 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0)):
     for the polyphase method:
 
     >>> from scipy import signal
-    
+
     >>> x = np.linspace(0, 10, 20, endpoint=False)
     >>> y = np.cos(-x**2/6.0)
     >>> f_fft = signal.resample(y, 100)
     >>> f_poly = signal.resample_poly(y, 100, 20)
     >>> xnew = np.linspace(0, 10, 100, endpoint=False)
-    
+
     >>> import matplotlib.pyplot as plt
     >>> plt.plot(xnew, f_fft, 'b.-', xnew, f_poly, 'r.-')
     >>> plt.plot(x, y, 'ko-')

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -187,8 +187,9 @@ def correlate(in1, in2, mode='full'):
     elif not in1.ndim == in2.ndim:
         raise ValueError("in1 and in2 should have the same dimensionality")
 
-    # numpy is significantly faster for 1d
-    if in1.ndim == in2.ndim == 1 and (in1.size >= in2.size):
+    # numpy is significantly faster for 1d (but numpy's 'same' mode uses
+    # the size of the larger input, not the first.)
+    if in1.ndim == in2.ndim == 1 and (in1.size >= in2.size or mode != 'same'):
         return np.correlate(in1, in2, mode)
 
     # _correlateND is far slower when in2.size > in1.size, so swap them
@@ -495,8 +496,10 @@ def convolve(in1, in2, mode='full'):
     if volume.ndim == kernel.ndim == 0:
         return volume * kernel
 
-    # fastpath to faster numpy 1d convolve
-    if volume.ndim == kernel.ndim == 1 and volume.size >= kernel.size:
+    # fastpath to faster numpy 1d convolve (but numpy's 'same' mode uses the
+    # size of the larger input, not the first.)
+    if volume.ndim == kernel.ndim == 1 and (volume.size >= kernel.size or
+                                            mode != 'same'):
         return np.convolve(volume, kernel, mode)
 
     # Reverse in all dimensions


### PR DESCRIPTION
I started to fix https://github.com/scipy/scipy/issues/5897 before I realized it had already been done in https://github.com/scipy/scipy/pull/5904, so these are the other changes I made in the process.

(I was going to change `slice_obj = [slice(None, None, -1)] * len(kernel.shape)` into `kernel[::-1]` before I remembered it's N-dimensional, so I added a comment and renamed the variable to clarify that for others.)

`real_array.conj()` does nothing and just returns `real_array`, faster than
`iscomplexobj(real_array)` tests whether it's real, so I changed it to just call `.conj()` in both cases.

```
a = rand(4)

a.conj() is a
Out[105]: True
```

also changed a bunch of `len(var.shape)` into `var.ndim`.
