### PR TITLE
ENH: sparse.linalg: add GCROT(m,k)

### DIFF
--- a/benchmarks/benchmarks/sparse_linalg_solve.py
+++ b/benchmarks/benchmarks/sparse_linalg_solve.py
@@ -8,12 +8,17 @@ from numpy.testing import assert_equal
 
 try:
     from scipy import linalg, sparse
-    from scipy.sparse.linalg import cg, minres, spsolve
+    from scipy.sparse.linalg import cg, minres, gmres, spsolve
 except ImportError:
     pass
 
 try:
     from scipy.sparse.linalg import lgmres
+except ImportError:
+    pass
+
+try:
+    from scipy.sparse.linalg import gcrotmk
 except ImportError:
     pass
 
@@ -38,7 +43,7 @@ def _create_sparse_poisson2d(n):
 class Bench(Benchmark):
     params = [
         [4, 6, 10, 16, 25, 40, 64, 100],
-        ['dense', 'spsolve', 'cg', 'minres', 'lgmres']
+        ['dense', 'spsolve', 'cg', 'minres', 'gmres', 'lgmres', 'gcrotmk']
     ]
     param_names = ['(n,n)', 'solver']
 
@@ -59,8 +64,12 @@ class Bench(Benchmark):
             cg(self.P_sparse, self.b)
         elif solver == 'minres':
             minres(self.P_sparse, self.b)
+        elif solver == 'gmres':
+            gmres(self.P_sparse, self.b)
         elif solver == 'lgmres':
             lgmres(self.P_sparse, self.b)
+        elif solver == 'gcrotmk':
+            gcrotmk(self.P_sparse, self.b)
         elif solver == 'spsolve':
             spsolve(self.P_sparse, self.b)
         else:

--- a/scipy/optimize/nonlin.py
+++ b/scipy/optimize/nonlin.py
@@ -1422,6 +1422,7 @@ class KrylovJacobian(Jacobian):
             self.method_kw['maxiter'] = 1
             # Carry LGMRES's `outer_v` vectors across nonlinear iterations
             self.method_kw.setdefault('outer_v', [])
+            self.method_kw.setdefault('prepend_outer_v', True)
             # But don't carry the corresponding Jacobian*v products, in case
             # the Jacobian changes a lot in the nonlinear step
             #

--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -60,6 +60,7 @@ Iterative methods for linear equation systems:
    lgmres -- Solve a matrix equation using the LGMRES algorithm
    minres -- Use MINimum RESidual iteration to solve Ax = b
    qmr -- Use Quasi-Minimal Residual iteration to solve A x = b
+   gcrotmk -- Solve a matrix equation using the GCROT(m,k) algorithm
 
 Iterative methods for least-squares problems:
 

--- a/scipy/sparse/linalg/isolve/__init__.py
+++ b/scipy/sparse/linalg/isolve/__init__.py
@@ -8,6 +8,7 @@ from .minres import minres
 from .lgmres import lgmres
 from .lsqr import lsqr
 from .lsmr import lsmr
+from ._gcrotmk import gcrotmk
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 from numpy.testing import Tester

--- a/scipy/sparse/linalg/isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/_gcrotmk.py
@@ -13,7 +13,8 @@ from scipy.sparse.linalg.isolve.utils import make_system
 __all__ = ['gcrotmk']
 
 
-def _fgmres(matvec, v0, m, atol, lpsolve=None, rpsolve=None, cs=(), outer_v=()):
+def _fgmres(matvec, v0, m, atol, lpsolve=None, rpsolve=None, cs=(), outer_v=(),
+            prepend_outer_v=False):
     """
     FGMRES Arnoldi process, with optional projection or augmentation
 
@@ -35,6 +36,9 @@ def _fgmres(matvec, v0, m, atol, lpsolve=None, rpsolve=None, cs=(), outer_v=()):
         Columns of matrices C and U in GCROT
     outer_v : list of ndarrays
         Augmentation vectors in LGMRES
+    prepend_outer_v : bool, optional
+        Whether augmentation vectors come before or after 
+        Krylov iterates
 
     Raises
     ------
@@ -84,11 +88,13 @@ def _fgmres(matvec, v0, m, atol, lpsolve=None, rpsolve=None, cs=(), outer_v=()):
     for j in xrange(m):
         # L A Z = C B + V H
 
-        if j < len(outer_v):
+        if prepend_outer_v and j < len(outer_v):
             z, w = outer_v[j]
-        elif j == len(outer_v):
+        elif prepend_outer_v and j == len(outer_v):
             z = rpsolve(v0)
             w = None
+        elif not prepend_outer_v and j >= m - len(outer_v):
+            z, w = outer_v[j - (m - len(outer_v))]
         else:
             z = rpsolve(vs[-1])
             w = None

--- a/scipy/sparse/linalg/isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/_gcrotmk.py
@@ -1,0 +1,383 @@
+# Copyright (C) 2015, Pauli Virtanen <pav@iki.fi>
+# Distributed under the same license as Scipy.
+
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+from six.moves import xrange
+from scipy.linalg import (get_blas_funcs, get_lapack_funcs, qr, solve, svd,
+                          qr_insert)
+from scipy.sparse.linalg.isolve.utils import make_system
+
+
+__all__ = ['gcrotmk']
+
+
+def _inner_gmres():
+    """
+    (F)GMRES Arnoldi process
+    """
+    pass
+
+
+def gcrotmk(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
+            m=20, k=None, CU=None, discard_C=False, truncate='oldest'):
+    """
+    Solve a matrix equation using flexible GCROT(m,k) algorithm.
+
+    Parameters
+    ----------
+    A : {sparse matrix, dense matrix, LinearOperator}
+        The real or complex N-by-N matrix of the linear system.
+    b : {array, matrix}
+        Right hand side of the linear system. Has shape (N,) or (N,1).
+    x0  : {array, matrix}
+        Starting guess for the solution.
+    tol : float, optional
+        Tolerance to achieve. The algorithm terminates when either the relative
+        or the absolute residual is below `tol`.
+    maxiter : int, optional
+        Maximum number of iterations.  Iteration will stop after maxiter
+        steps even if the specified tolerance has not been achieved.
+    M : {sparse matrix, dense matrix, LinearOperator}, optional
+        Preconditioner for A.  The preconditioner should approximate the
+        inverse of A. gcrotmk is a 'flexible' algorithm and the preconditioner
+        can vary from iteration to iteration. Effective preconditioning
+        dramatically improves the rate of convergence, which implies that
+        fewer iterations are needed to reach a given error tolerance.
+    callback : function, optional
+        User-supplied function to call after each iteration.  It is called
+        as callback(xk), where xk is the current solution vector.
+    m : int, optional
+        Number of inner FGMRES iterations per each outer iteration.
+        Default: 20
+    k : int, optional
+        Number of vectors to carry between inner FGMRES iterations.
+        According to [1]_, good values are around m.
+        Default: m
+    CU : list of tuples, optional
+        List of tuples ``(c, u)`` which contain the columns of the matrices
+        C and U in the GCROT(m,k) algorithm. For details, see [1]_.
+        The list given is modified in-place. If not given, start from empty
+        matrices. The ``c`` elements in the tuples can be ``None``,
+        in which case the vectors are recomputed via ``c = A u``
+        on start and orthogonalized as described in [3]_.
+    discard_C : bool, optional
+        Discard the C-vectors at the end. Useful if recycling Krylov subspaces
+        for different linear systems.
+    truncate : {'oldest', 'smallest'}, optional
+        Truncation scheme to use. Drop: oldest vectors, or vectors with
+        smallest singular values. See [1]_ for details.
+
+    Returns
+    -------
+    x : array or matrix
+        The solution found.
+    info : int
+        Provides convergence information:
+
+        * 0  : successful exit
+        * >0 : convergence to tolerance not achieved, number of iterations
+
+    References
+    ----------
+    .. [1] J.E. Hicken and D.W. Zingg, ''A simplified and flexible variant
+           of GCROT for solving nonsymmetric linear systems'',
+           SIAM J. Sci. Comput. 32, 172 (2010).
+    .. [2] E. de Sturler, ''Truncation strategies for optimal Krylov subspace
+           methods'', SIAM J. Numer. Anal. 36, 864 (1999).
+    .. [3] M.L. Parks, E. de Sturler, G. Mackey, D.D. Johnson, S. Maiti,
+           ''Recycling Krylov subspaces for sequences of linear systems'',
+           SIAM J. Sci. Comput. 28, 1651 (2006).
+
+    """
+    A,M,x,b,postprocess = make_system(A,M,x0,b)
+
+    if not np.isfinite(b).all():
+        raise ValueError("RHS must contain only finite numbers")
+
+    if truncate not in ('oldest', 'smallest'):
+        raise ValueError("Invalid value for 'truncate': %r" % (truncate,))
+
+    matvec = A.matvec
+    psolve = M.matvec
+    nfev = 0
+
+    if CU is None:
+        CU = []
+
+    if k is None:
+        k = m
+
+    axpy, dot, scal = None, None, None
+
+    r = b - matvec(x)
+    nfev += 1
+
+    axpy, dot, scal, nrm2 = get_blas_funcs(['axpy', 'dot', 'scal', 'nrm2'], (x, r))
+    trtrs = get_lapack_funcs('trtrs', (x, r))
+
+    b_norm = nrm2(b)
+    if b_norm == 0:
+        b_norm = 1
+
+    if discard_C:
+        CU[:] = [(None, u) for c, u in CU]
+
+    # Reorthogonalize old vectors
+    if CU:
+        # Sort already existing vectors to the front
+        CU.sort(key=lambda cu: cu[0] is not None)
+
+        # Fill-in missing ones
+        C = np.empty((A.shape[0], len(CU)), dtype=r.dtype, order='F')
+        us = []
+        j = 0
+        while CU:
+            # More memory-efficient: throw away old vectors as we go
+            c, u = CU.pop(0)
+            if c is None:
+                c = matvec(u)
+                nfev += 1
+            C[:,j] = c
+            j += 1
+            us.append(u)
+
+        # Orthogonalize
+        Q, R, P = qr(C, overwrite_a=True, mode='economic', pivoting=True)
+        del C
+
+        # C := Q
+        cs = list(Q.T)
+
+        # U := U P R^-1,  back-substitution
+        new_us = []
+        for j in xrange(len(cs)):
+            u = us[P[j]]
+            for i in xrange(j):
+                u = axpy(us[P[i]], u, u.shape[0], -R[i,j])
+            if abs(R[j,j]) < 1e-12 * abs(R[0,0]):
+                # discard rest of the vectors
+                break
+            u = scal(1.0/R[j,j], u)
+            new_us.append(u)
+
+        # Form the new CU lists
+        CU[:] = list(zip(cs, new_us))[::-1]
+
+    if CU:
+        axpy, dot = get_blas_funcs(['axpy', 'dot'], (r,))
+
+        # Solve first the projection operation with respect to the CU
+        # vectors. This corresponds to modifying the initial guess to
+        # be
+        #
+        #     x' = x + U y
+        #     y = argmin_y || b - A (x + U y) ||^2
+        #
+        # The solution is y = C^H (b - A x)
+        for c, u in CU:
+            yc = dot(c, r)
+            x = axpy(u, x, x.shape[0], yc)
+            r = axpy(c, r, r.shape[0], -yc)
+
+    # GCROT main iteration
+    for j_outer in xrange(maxiter):
+        # -- callback
+        if callback is not None:
+            callback(x)
+
+        beta = nrm2(r)
+
+        # -- check stopping condition
+        if beta <= tol * b_norm:
+            break
+
+        v0 = r/beta
+        vs = [v0]
+        zs = []
+        y = None
+
+        ml = m + max(k - len(CU), 0)
+
+        # Orthogonal projection coefficients
+        B = np.zeros((len(CU), ml), dtype=r.dtype)
+
+        # H is stored in QR factorized form
+        Q = np.ones((1, 1), dtype=r.dtype)
+        R = np.zeros((1, 0), dtype=r.dtype)
+
+        # FGMRES Arnoldi process
+        for j in xrange(ml):
+            zj = psolve(vs[-1])
+            w = matvec(zj)
+            nfev += 1
+
+            # GCROT: A -> (1 - C C^H) A
+            # i.e. orthogonalize against C
+            for i, cu in enumerate(CU):
+                c, u = cu
+                alpha = dot(c, w)
+                B[i,j] = alpha
+                w = axpy(c, w, c.shape[0], -alpha)  # w -= alpha*c
+
+            # Orthogonalize against V
+            hcur = np.zeros(j+2, dtype=Q.dtype)
+            for i, v in enumerate(vs):
+                alpha = dot(v, w)
+                hcur[i] = alpha
+                w = axpy(v, w, v.shape[0], -alpha)  # w -= alpha*v
+            hcur[i+1] = nrm2(w)
+
+            with np.errstate(over='ignore', divide='ignore'):
+                # Careful with denormals
+                alpha = 1/hcur[-1]
+
+            if np.isfinite(alpha):
+                w = scal(alpha, w)
+            else:
+                # v_new either zero (solution in span of previous
+                # vectors) or we have nans.  If we already have
+                # previous vectors in R, we can discard the current
+                # vector and bail out.
+                if j > 0:
+                    j -= 1
+                    break
+
+            vs.append(w)
+            zs.append(zj)
+
+            # Arnoldi LSQ problem
+
+            # Add new column to H=Q*R, padding other columns with zeros
+            Q2 = np.zeros((j+2, j+2), dtype=Q.dtype, order='F')
+            Q2[:j+1,:j+1] = Q
+            Q2[j+1,j+1] = 1
+
+            R2 = np.zeros((j+2, j), dtype=R.dtype, order='F')
+            R2[:j+1,:] = R
+
+            Q, R = qr_insert(Q2, R2, hcur, j, which='col',
+                             overwrite_qru=True, check_finite=False)
+
+            # Transformed least squares problem
+            # || Q R y - inner_res_0 * e_1 ||_2 = min!
+            # Since R = [R'; 0], solution is y = inner_res_0 (R')^{-1} (Q^H)[:j,0]
+
+            # Residual is immediately known
+            res = abs(Q[0,-1]) * beta
+
+            # Check for termination
+            if res < tol * b_norm:
+                break
+
+        # -- Get the LSQ problem solution
+        y, info = trtrs(R[:j+1,:j+1], Q[0,:j+1].conj())
+        if info != 0:
+            # Zero diagonal -> exact solution, but we handled that above
+            raise RuntimeError("QR solution failed")
+        y *= beta
+
+        if not np.isfinite(y).all():
+            # Floating point over/underflow, non-finite result from
+            # matmul etc. -- report failure.
+            return postprocess(x), k_outer + 1
+
+        B = B[:,:j+1]
+
+        #
+        # At this point,
+        #
+        #     [A U, A Z] = [C, V] G;   G =  [ I  B ]
+        #                                   [ 0  H ]
+        #
+        # where [C, V] has orthonormal columns, and r = beta v_0. Moreover,
+        #
+        #     || b - A (x + Z y + U q) ||_2 = || r - C B y - V H y - C q ||_2 = min!
+        #
+        # from which y = argmin_y || beta e_1 - H y ||_2, and q = -B y
+        #
+
+        #
+        # GCROT(m,k) update
+        #
+
+        # Define new outer vectors
+
+        # ux := (Z - U B) y
+        ux = zs[0]*y[0]
+        for z, yc in zip(zs[1:], y[1:]):
+            ux = axpy(z, ux, ux.shape[0], yc)  # ux += z*yc
+        by = B.dot(y)
+        for cu, byc in zip(CU, by):
+            c, u = cu
+            ux = axpy(u, ux, ux.shape[0], -byc)  # ux -= u*byc
+
+        # cx := V H y
+        hy = Q.dot(R.dot(y))
+        cx = vs[0] * hy[0]
+        for v, hyc in zip(vs[1:], hy[1:]):
+            cx = axpy(v, cx, cx.shape[0], hyc)  # cx += v*hyc
+
+        # Normalize cx, maintaining cx = A ux
+        # This new cx is orthogonal to the previous C, by construction
+        alpha = nrm2(cx)
+        cx = scal(1.0/alpha, cx)
+        ux = scal(1.0/alpha, ux)
+
+        # Update residual and solution
+        gamma = dot(cx, r)
+        r = axpy(cx, r, r.shape[0], -gamma)  # r -= gamma*cx
+        x = axpy(ux, x, x.shape[0], gamma)  # x += gamma*ux
+
+        # Truncate CU
+        if truncate == 'oldest':
+            while len(CU) >= k:
+                del CU[0]
+        elif truncate == 'smallest':
+            if len(CU) >= k:
+                # cf. [1]
+                Q, R = qr(hess, mode='economic')
+                D = solve(R.T, B.T).T
+                W, sigma, V = svd(D)
+
+                # C := C W[:,:-1],  U := U W[:,:-1]
+                new_CU = []
+                for j, w in enumerate(W[:,:k-1].T):
+                    c, u = CU[0]
+                    c = c * w[0]
+                    u = u * w[0]
+                    for cup, wp in zip(CU[1:], w[1:]):
+                        cp, up = cup
+                        c = axpy(cp, c, c.shape[0], wp)
+                        u = axpy(up, u, u.shape[0], wp)
+
+                    # Reorthogonalize at the same time; not necessary
+                    # in exact arithmetic, but floating point error
+                    # tends to accumulate here
+                    for cp, up in new_CU:
+                        alpha = dot(cp, c)
+                        c = axpy(cp, c, c.shape[0], -alpha)
+                        u = axpy(up, u, u.shape[0], -alpha)
+                    alpha = nrm2(c)
+                    c = scal(1.0/alpha, c)
+                    u = scal(1.0/alpha, u)
+
+                    new_CU.append((c, u))
+                CU[:] = new_CU
+
+        # Add new vector to CU
+        CU.append((cx, ux))
+    else:
+        # didn't converge ...
+        CU.append((None, x))
+        if discard_C:
+            CU[:] = [(None, u) for c, u in CU]
+        return postprocess(x), maxiter
+
+    # Include the solution vector to the span
+    CU.append((None, x))
+    if discard_C:
+        CU[:] = [(None, uz) for cz, uz in CU]
+
+    return postprocess(x), 0

--- a/scipy/sparse/linalg/isolve/lgmres.py
+++ b/scipy/sparse/linalg/isolve/lgmres.py
@@ -15,7 +15,8 @@ __all__ = ['lgmres']
 
 
 def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
-           inner_m=30, outer_k=3, outer_v=None, store_outer_Av=True):
+           inner_m=30, outer_k=3, outer_v=None, store_outer_Av=True,
+           prepend_outer_v=False):
     """
     Solve a matrix equation using the LGMRES algorithm.
 
@@ -64,6 +65,9 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
     store_outer_Av : bool, optional
         Whether LGMRES should store also A*v in addition to vectors `v`
         in the `outer_v` list. Default is True.
+    prepend_outer_v : bool, optional 
+        Whether to put outer_v augmentation vectors before Krylov iterates.
+        In standard LGMRES, prepend_outer_v=False.
 
     Returns
     -------
@@ -155,7 +159,8 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
                                          inner_m,
                                          lpsolve=psolve,
                                          atol=tol*b_norm/r_norm,
-                                         outer_v=outer_v)
+                                         outer_v=outer_v,
+                                         prepend_outer_v=prepend_outer_v)
             y *= inner_res_0
         except LinAlgError:
             # Floating point over/underflow, non-finite result from

--- a/scipy/sparse/linalg/isolve/lgmres.py
+++ b/scipy/sparse/linalg/isolve/lgmres.py
@@ -4,9 +4,12 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
+from numpy.linalg import LinAlgError
 from scipy._lib.six import xrange
-from scipy.linalg import get_blas_funcs, get_lapack_funcs, qr_insert, lstsq
+from scipy.linalg import get_blas_funcs, get_lapack_funcs
 from .utils import make_system
+
+from ._gcrotmk import _fgmres
 
 __all__ = ['lgmres']
 
@@ -136,145 +139,32 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
             break
 
         # -- inner LGMRES iteration
-        vs0 = -psolve(r_outer)
-        inner_res_0 = nrm2(vs0)
+        v0 = -psolve(r_outer)
+        inner_res_0 = nrm2(v0)
 
         if inner_res_0 == 0:
             rnorm = nrm2(r_outer)
             raise RuntimeError("Preconditioner returned a zero vector; "
                                "|v| ~ %.1g, |M v| = 0" % rnorm)
 
-        vs0 = scal(1.0/inner_res_0, vs0)
-        vs = [vs0]
-        ws = []
-        y = None
+        v0 = scal(1.0/inner_res_0, v0)
 
-        # H is stored in QR factorized form
-        Q = np.ones((1, 1), dtype=vs0.dtype)
-        R = np.zeros((1, 0), dtype=vs0.dtype)
-
-        eps = np.finfo(vs0.dtype).eps
-
-        breakdown = False
-
-        for j in xrange(1, 1 + inner_m + len(outer_v)):
-            # -- Arnoldi process:
-            #
-            #    Build an orthonormal basis V and matrices W and H such that
-            #        A W = V H
-            #    Columns of W, V, and H are stored in `ws`, `vs` and `hs`.
-            #
-            #    The first column of V is always the residual vector, `vs0`;
-            #    V has *one more column* than the other of the three matrices.
-            #
-            #    The other columns in V are built by feeding in, one
-            #    by one, some vectors `z` and orthonormalizing them
-            #    against the basis so far. The trick here is to
-            #    feed in first some augmentation vectors, before
-            #    starting to construct the Krylov basis on `v0`.
-            #
-            #    It was shown in [BJM]_ that a good choice (the LGMRES choice)
-            #    for these augmentation vectors are the `dx` vectors obtained
-            #    from a couple of the previous restart cycles.
-            #
-            #    Note especially that while `vs0` is always the first
-            #    column in V, there is no reason why it should also be
-            #    the first column in W. (In fact, below `vs0` comes in
-            #    W only after the augmentation vectors.)
-            #
-            #    The rest of the algorithm then goes as in GMRES, one
-            #    solves a minimization problem in the smaller subspace
-            #    spanned by W (range) and V (image).
-            #
-
-            #     ++ evaluate
-            v_new = None
-            if j < len(outer_v) + 1:
-                z, v_new = outer_v[j-1]
-            elif j == len(outer_v) + 1:
-                z = vs0
-            else:
-                z = vs[-1]
-
-            if v_new is None:
-                v_new = psolve(matvec(z))
-            else:
-                # Note: v_new is modified in-place below. Must make a
-                # copy to ensure that the outer_v vectors are not
-                # clobbered.
-                v_new = v_new.copy()
-
-            #     ++ orthogonalize
-            v_new_norm = nrm2(v_new)
-
-            hcur = np.zeros(j+1, dtype=Q.dtype)
-            for i, v in enumerate(vs):
-                alpha = dot(v, v_new)
-                hcur[i] = alpha
-                v_new = axpy(v, v_new, v.shape[0], -alpha)  # v_new -= alpha*v
-            hcur[-1] = nrm2(v_new)
-
-            with np.errstate(over='ignore', divide='ignore'):
-                # Careful with denormals
-                alpha = 1/hcur[-1]
-
-            if np.isfinite(alpha):
-                v_new = scal(alpha, v_new)
-
-            if not (hcur[-1] > eps * v_new_norm):
-                # v_new essentially in the span of previous vectors,
-                # or we have nans. Bail out after updating the QR
-                # solution.
-                breakdown = True
-
-            vs.append(v_new)
-            ws.append(z)
-
-            # -- GMRES optimization problem
-
-            # Add new column to H=Q*R, padding other columns with zeros
-
-            Q2 = np.zeros((j+1, j+1), dtype=Q.dtype, order='F')
-            Q2[:j,:j] = Q
-            Q2[j,j] = 1
-
-            R2 = np.zeros((j+1, j-1), dtype=R.dtype, order='F')
-            R2[:j,:] = R
-
-            Q, R = qr_insert(Q2, R2, hcur, j-1, which='col',
-                             overwrite_qru=True, check_finite=False)
-
-            # Transformed least squares problem
-            # || Q R y - inner_res_0 * e_1 ||_2 = min!
-            # Since R = [R'; 0], solution is y = inner_res_0 (R')^{-1} (Q^H)[:j,0]
-
-            # Residual is immediately known
-            inner_res = abs(Q[0,-1]) * inner_res_0
-
-            # -- check for termination
-            if inner_res <= tol * inner_res_0 or breakdown:
-                break
-
-        if not np.isfinite(R[j-1,j-1]):
-            # nans encountered, bail out
-            return postprocess(x), k_outer + 1
-
-        # -- Get the LSQ problem solution
-        #
-        # The problem is triangular, but the condition number may be
-        # bad (or in case of breakdown the last diagonal entry may be
-        # zero), so use lstsq instead of trtrs.
-        y, _, _, _, = lstsq(R[:j,:j], Q[0,:j].conj())
-        y *= inner_res_0
-
-        if not np.isfinite(y).all():
+        try:
+            Q, R, B, vs, zs, y = _fgmres(matvec,
+                                         v0,
+                                         inner_m,
+                                         lpsolve=psolve,
+                                         atol=tol*b_norm/r_norm,
+                                         outer_v=outer_v)
+            y *= inner_res_0
+        except LinAlgError:
             # Floating point over/underflow, non-finite result from
             # matmul etc. -- report failure.
             return postprocess(x), k_outer + 1
 
         # -- GMRES terminated: eval solution
-        dx = ws[0]*y[0]
-        for w, yc in zip(ws[1:], y[1:]):
+        dx = zs[0]*y[0]
+        for w, yc in zip(zs[1:], y[1:]):
             dx = axpy(w, dx, dx.shape[0], yc)  # dx += w*yc
 
         # -- Store LGMRES augmentation vectors

--- a/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
+++ b/scipy/sparse/linalg/isolve/tests/test_gcrotmk.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+"""Tests for the linalg.isolve.gcrotmk module
+"""
+
+from __future__ import division, print_function, absolute_import
+
+from numpy.testing import TestCase, assert_, assert_allclose, assert_equal, run_module_suite
+
+import numpy as np
+from numpy import zeros, array, allclose
+from scipy.linalg import norm
+from scipy.sparse import csr_matrix, eye, rand
+
+from scipy.sparse.linalg.interface import LinearOperator
+from scipy.sparse.linalg import splu
+from scipy.sparse.linalg.isolve import gcrotmk, gmres
+
+
+Am = csr_matrix(array([[-2,1,0,0,0,9],
+                       [1,-2,1,0,5,0],
+                       [0,1,-2,1,0,0],
+                       [0,0,1,-2,1,0],
+                       [0,3,0,1,-2,1],
+                       [1,0,0,0,1,-2]]))
+b = array([1,2,3,4,5,6])
+count = [0]
+
+
+def matvec(v):
+    count[0] += 1
+    return Am*v
+A = LinearOperator(matvec=matvec, shape=Am.shape, dtype=Am.dtype)
+
+
+def do_solve(**kw):
+    count[0] = 0
+    x0, flag = gcrotmk(A, b, x0=zeros(A.shape[0]), tol=1e-14, **kw)
+    count_0 = count[0]
+    assert_(allclose(A*x0, b, rtol=1e-12, atol=1e-12), norm(A*x0-b))
+    return x0, count_0
+
+
+class TestGCROTMK(object):
+    def test_preconditioner(self):
+        # Check that preconditioning works
+        pc = splu(Am.tocsc())
+        M = LinearOperator(matvec=pc.solve, shape=A.shape, dtype=A.dtype)
+
+        x0, count_0 = do_solve()
+        x1, count_1 = do_solve(M=M)
+
+        assert_equal(count_1, 2)
+        assert_(count_1 < count_0/2)
+        assert_(allclose(x1, x0, rtol=1e-14))
+
+    def test_arnoldi(self):
+        np.random.rand(1234)
+
+        A = eye(10000) + rand(10000,10000,density=1e-4)
+        b = np.random.rand(10000)
+
+        # The inner arnoldi should be equivalent to gmres
+        x0, flag0 = gcrotmk(A, b, x0=zeros(A.shape[0]), m=15, k=0, maxiter=1)
+        x1, flag1 = gmres(A, b, x0=zeros(A.shape[0]), restart=15, maxiter=1)
+
+        assert_equal(flag0, 1)
+        assert_equal(flag1, 1)
+        assert_(np.linalg.norm(A.dot(x0) - b) > 1e-3)
+
+        assert_allclose(x0, x1)
+
+    def test_cornercase(self):
+        np.random.seed(1234)
+
+        # Rounding error may prevent convergence with tol=0 --- ensure
+        # that the return values in this case are correct, and no
+        # exceptions are raised
+
+        for n in [3, 5, 10, 100]:
+            A = 2*eye(n)
+
+            b = np.ones(n)
+            x, info = gcrotmk(A, b, maxiter=10)
+            assert_equal(info, 0)
+            assert_allclose(A.dot(x) - b, 0, atol=1e-14)
+
+            x, info = gcrotmk(A, b, tol=0, maxiter=10)
+            if info == 0:
+                assert_allclose(A.dot(x) - b, 0, atol=1e-14)
+
+            b = np.random.rand(n)
+            x, info = gcrotmk(A, b, maxiter=10)
+            assert_equal(info, 0)
+            assert_allclose(A.dot(x) - b, 0, atol=1e-14)
+
+            x, info = gcrotmk(A, b, tol=0, maxiter=10)
+            if info == 0:
+                assert_allclose(A.dot(x) - b, 0, atol=1e-14)
+
+    def test_nans(self):
+        A = eye(3, format='lil')
+        A[1,1] = np.nan
+        b = np.ones(3)
+
+        x, info = gcrotmk(A, b, tol=0, maxiter=10)
+        assert_equal(info, 1)
+
+    def test_truncate(self):
+        np.random.seed(1234)
+        A = np.random.rand(30, 30) + np.eye(30)
+        b = np.random.rand(30)
+
+        for truncate in ['oldest', 'smallest']:
+            x, info = gcrotmk(A, b, m=10, k=10, truncate=truncate, tol=1e-4,
+                              maxiter=200)
+            assert_equal(info, 0)
+            assert_allclose(A.dot(x) - b, 0, atol=1e-3)
+
+    def test_CU(self):
+        for discard_C in (True, False):
+            # Check that C,U behave as expected
+            CU = []
+            x0, count_0 = do_solve(CU=CU, discard_C=discard_C)
+            assert_(len(CU) > 0)
+            assert_(len(CU) <= 6)
+
+            if discard_C:
+                for c, u in CU:
+                    assert_(c is None)
+
+            # should converge immediately
+            x1, count_1 = do_solve(CU=CU, discard_C=discard_C)
+            if discard_C:
+                assert_equal(count_1, 1 + len(CU))
+            else:
+                assert_equal(count_1, 2)
+            assert_(count_1 < count_0/2)
+            assert_allclose(x1, x0, atol=1e-14)
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/scipy/sparse/linalg/isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/isolve/tests/test_iterative.py
@@ -15,7 +15,7 @@ from scipy.linalg import norm
 from scipy.sparse import spdiags, csr_matrix, SparseEfficiencyWarning
 
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
-from scipy.sparse.linalg.isolve import cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres
+from scipy.sparse.linalg.isolve import cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk
 
 # TODO check that method preserve shape and type
 # TODO test both preconditioner methods
@@ -37,7 +37,7 @@ class Case(object):
 class IterativeParams(object):
     def __init__(self):
         # list of tuples (solver, symmetric, positive_definite )
-        solvers = [cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres]
+        solvers = [cg, cgs, bicg, bicgstab, gmres, qmr, minres, lgmres, gcrotmk]
         sym_solvers = [minres, cg]
         posdef_solvers = [cg]
         real_solvers = [minres]
@@ -157,10 +157,10 @@ def check_maxiter(solver, case):
     def callback(x):
         residuals.append(norm(b - case.A*x))
 
-    x, info = solver(A, b, x0=x0, tol=tol, maxiter=3, callback=callback)
+    x, info = solver(A, b, x0=x0, tol=tol, maxiter=1, callback=callback)
 
-    assert_equal(len(residuals), 3)
-    assert_equal(info, 3)
+    assert_equal(len(residuals), 1)
+    assert_equal(info, 1)
 
 
 def test_maxiter():
@@ -258,7 +258,7 @@ def test_gmres_basic():
 
 def test_reentrancy():
     non_reentrant = [cg, cgs, bicg, bicgstab, gmres, qmr]
-    reentrant = [lgmres, minres]
+    reentrant = [lgmres, minres, gcrotmk]
     for solver in reentrant + non_reentrant:
         yield _check_reentrancy, solver, solver in reentrant
 

--- a/scipy/sparse/linalg/isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lgmres.py
@@ -60,7 +60,7 @@ class TestLGMRES(TestCase):
         assert_(len(outer_v) > 0)
         assert_(len(outer_v) <= 6)
 
-        x1, count_1 = do_solve(outer_k=6, outer_v=outer_v)
+        x1, count_1 = do_solve(outer_k=6, outer_v=outer_v, prepend_outer_v=True)
         assert_(count_1 == 2, count_1)
         assert_(count_1 < count_0/2)
         assert_(allclose(x1, x0, rtol=1e-14))
@@ -73,7 +73,7 @@ class TestLGMRES(TestCase):
         assert_(len(outer_v) > 0)
         assert_(len(outer_v) <= 6)
 
-        x1, count_1 = do_solve(outer_k=6, outer_v=outer_v)
+        x1, count_1 = do_solve(outer_k=6, outer_v=outer_v, prepend_outer_v=True)
         assert_(count_1 == 3, count_1)
         assert_(count_1 < count_0/2)
         assert_(allclose(x1, x0, rtol=1e-14))


### PR DESCRIPTION
Add one of the variants of GCROT, following [E. de Sturler, ''Truncation strategies for optimal Krylov subspace methods'', SIAM J. Numer. Anal. 36, 864 (1999)] and [J.E. Hicken and D.W. Zingg, ''A simplified and flexible variant of GCROT for solving nonsymmetric linear systems'', SIAM J. Sci. Comput. 32, 172 (2010)].

The truncation is here done following Hicken&Zingg, which differs from Sturler's.

Refactors the inner iteration out from lgmres (and fixes a deviation from the paper in the implementation, on top bugfixes of gh-5905).
- [x] May still need some testing + rereading the papers.

Performance profiles [(code)](https://gist.github.com/pv/c87650ff0cff9a3b5710):

![profiles](https://cloud.githubusercontent.com/assets/35046/24084304/8c2a0fa6-0cdf-11e7-9397-ef8c5a92e1f3.png)
