### PR TITLE
CI: pin pyflakes to a recent version + update ignores

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ matrix:
         - NUMPYSPEC=numpy
       before_install:
         - pip install pep8==1.7.0
-        - pip install pyflakes
+        - pip install pyflakes==1.1.0
       script:
-        - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused' > test.out; cat test.out; test \! -s test.out
+        - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports' > test.out; cat test.out; test \! -s test.out
         - pep8 scipy benchmarks/benchmarks
     - python: 2.7
       env:


### PR DESCRIPTION
New pyflakes version causes spurious failures.
Pin version and update skipped warnings.

Will merge asap.
