### PR TITLE
TST: Patch failed merge of gh-5859

### DIFF
--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1193,9 +1193,7 @@ class TestRandomCorrelation(TestCase):
         np.random.seed(123)
 
         eigs = [norm(i, np.random.uniform(size=i)) for i in range(2, 6)]
-        eigs.append([4,0,0,0])
-
-        ones = [[1.]*len(e) for e in eigs]
+        ones = [[1.]*i for i in range(2, 6)]
         xs = [random_correlation.rvs(e) for e in eigs]
 
         # Test that determinants are products of eigenvalues


### PR DESCRIPTION
Merge of #5859 failed in a strange way that caused one of the newly added tests to fail on `master`.  If you compare what was in the PR <a href="https://github.com/philipdeboer/scipy/blob/f58229e34b8fdcb5da33e60a7fb016c5e8f2b25c/scipy/stats/tests/test_multivariate.py#L1195-L1197">here</a> to what was actually merged in <a href="https://github.com/scipy/scipy/blob/30e0c4b253e31685b97f188c1b12c725375b8ae5/scipy/stats/tests/test_multivariate.py#L1195-L1199">here</a>, they don't match.  One of the strangest Git failures I have ever seen.  <b>PLEASE MERGE ASAP.</b>
