### PR TITLE
MAINT: sparse: optimize DIA sum/diagonal, csgraph.laplacian

### DIFF
--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -304,7 +304,7 @@ class NullSlice(Benchmark):
 
 
 class Diagonal(Benchmark):
-    params = [[0.01, 0.1, 0.5], ['csr', 'csc', 'coo', 'lil', 'dok']]
+    params = [[0.01, 0.1, 0.5], ['csr', 'csc', 'coo', 'lil', 'dok', 'dia']]
     param_names = ['density', 'format']
 
     def setup(self, density, format):
@@ -316,3 +316,24 @@ class Diagonal(Benchmark):
 
     def time_diagonal(self, density, format):
         self.X.diagonal()
+
+
+class Sum(Benchmark):
+    params = [[0.01, 0.1, 0.5], ['csr', 'csc', 'coo', 'lil', 'dok', 'dia']]
+    param_names = ['density', 'format']
+
+    def setup(self, density, format):
+        n = 1000
+        if format == 'dok' and n * density >= 500:
+            raise NotImplementedError()
+
+        self.X = sparse.rand(n, n, format=format, density=density)
+
+    def time_sum(self, density, format):
+        self.X.sum()
+
+    def time_sum_axis0(self, density, format):
+        self.X.sum(axis=0)
+
+    def time_sum_axis1(self, density, format):
+        self.X.sum(axis=1)

--- a/benchmarks/benchmarks/sparse_csgraph.py
+++ b/benchmarks/benchmarks/sparse_csgraph.py
@@ -1,0 +1,33 @@
+"""benchmarks for the scipy.sparse.csgraph module"""
+from __future__ import print_function, absolute_import
+import numpy as np
+import scipy.sparse
+
+try:
+    from scipy.sparse.csgraph import laplacian
+except ImportError:
+    pass
+
+from .common import Benchmark
+
+
+class Laplacian(Benchmark):
+    params = [
+        [30, 300, 900],
+        ['dense', 'coo', 'csc', 'csr', 'dia'],
+        [True, False]
+    ]
+    param_names = ['n', 'format', 'normed']
+
+    def setup(self, n, format, normed):
+        data = scipy.sparse.rand(9, n, density=0.5, random_state=42).toarray()
+        data = np.vstack((data, data))
+        diags = list(range(-9, 0)) + list(range(1, 10))
+        A = scipy.sparse.spdiags(data, diags, n, n)
+        if format == 'dense':
+            self.A = A.toarray()
+        else:
+            self.A = A.asformat(format)
+
+    def time_laplacian(self, n, format, normed):
+        laplacian(self.A, normed=normed)

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -9,7 +9,7 @@ import sys
 import numpy as np
 
 from scipy._lib.six import xrange
-from .sputils import isdense, isscalarlike, isintlike
+from .sputils import isdense, isscalarlike, isintlike, get_sum_dtype
 
 
 class SparseWarning(Warning):
@@ -755,15 +755,7 @@ class spmatrix(object):
         m, n = self.shape
 
         # Mimic numpy's casting.
-        if np.issubdtype(self.dtype, np.float_):
-            res_dtype = np.float_
-        elif (self.dtype.kind == 'u' and
-              np.can_cast(self.dtype, np.uint)):
-            res_dtype = np.uint
-        elif np.can_cast(self.dtype, np.int_):
-            res_dtype = np.int_
-        else:
-            res_dtype = self.dtype
+        res_dtype = get_sum_dtype(self.dtype)
 
         if axis is None:
             # sum over rows and columns

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -15,7 +15,7 @@ from .dia import dia_matrix
 from . import _sparsetools
 from .sputils import (upcast, upcast_char, to_native, isdense, isshape,
                       getdtype, isscalarlike, IndexMixin, get_index_dtype,
-                      downcast_intp_index)
+                      downcast_intp_index, get_sum_dtype)
 
 
 class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
@@ -564,16 +564,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         elif (not hasattr(self, 'blocksize') and
               axis in self._swap(((1, -1), (0, 2)))[0]):
             # faster than multiplication for large minor axis in CSC/CSR
-            # Mimic numpy's casting.
-            if np.issubdtype(self.dtype, np.float_):
-                res_dtype = np.float_
-            elif (self.dtype.kind == 'u' and
-                  np.can_cast(self.dtype, np.uint)):
-                res_dtype = np.uint
-            elif np.can_cast(self.dtype, np.int_):
-                res_dtype = np.int_
-            else:
-                res_dtype = self.dtype
+            res_dtype = get_sum_dtype(self.dtype)
             ret = np.zeros(len(self.indptr) - 1, dtype=res_dtype)
 
             major_index, value = self._minor_reduce(np.add)

--- a/scipy/sparse/csgraph/tests/test_graph_laplacian.py
+++ b/scipy/sparse/csgraph/tests/test_graph_laplacian.py
@@ -128,5 +128,12 @@ def test_asymmetric_laplacian():
     _check_laplacian(A, L, d, normed=True, use_out_degree=False)
 
 
+def test_sparse_formats():
+    for fmt in ('csr', 'csc', 'coo', 'lil', 'dok', 'dia', 'bsr'):
+        mat = sparse.diags([1, 1], [-1, 1], shape=(4,4), format=fmt)
+        for normed in True, False:
+            yield _check_symmetric_graph_laplacian, mat, normed
+
+
 if __name__ == '__main__':
     run_module_suite()

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -3,8 +3,10 @@
 
 from __future__ import division, print_function, absolute_import
 
-__all__ = ['upcast','getdtype','isscalarlike','isintlike',
-            'isshape','issequence','isdense','ismatrix']
+__all__ = [
+    'upcast', 'getdtype', 'isscalarlike', 'isintlike', 'isshape', 'issequence',
+    'isdense', 'ismatrix', 'get_sum_dtype'
+]
 
 import warnings
 import numpy as np
@@ -171,6 +173,17 @@ def get_index_dtype(arrays=(), maxval=None, check_contents=False):
             dtype = np.int64
             break
 
+    return dtype
+
+
+def get_sum_dtype(dtype):
+    """Mimic numpy's casting for np.sum"""
+    if np.issubdtype(dtype, np.float_):
+        return np.float_
+    if dtype.kind == 'u' and np.can_cast(dtype, np.uint):
+        return np.uint
+    if np.can_cast(dtype, np.int_):
+        return np.int_
     return dtype
 
 


### PR DESCRIPTION
This PR adds specialized `sum` and `diagonal` methods for DIA sparse matrices. It also defers the conversion to COO format in `csgraph.laplacian` where possible, which yields a pretty nice speedup for DIA inputs without harming other cases.

I've also added benchmarks to document the performance increase. Here are the significant changes:

```
BENCHMARK                                    BEFORE      AFTER     FACTOR
...cian.time_laplacian(30, 'dia', False)   372.06μs   171.08μs   0.45982349x
...ian.time_laplacian(300, 'dia', False)   593.68μs   227.67μs   0.38348440x
...ian.time_laplacian(900, 'dia', False)     1.04ms   330.61μs   0.31713714x
sparse.Sum.time_sum_axis0(0.5, 'dia')      124.03ms    15.37ms   0.12388698x
sparse.Sum.time_sum_axis0(0.1, 'dia')      130.85ms    15.54ms   0.11876036x
sparse.Sum.time_sum_axis0(0.01, 'dia')     124.67ms    13.94ms   0.11180419x
...e.Diagonal.time_diagonal(0.01, 'dia')    21.53ms    17.11μs   0.00079465x
...se.Diagonal.time_diagonal(0.1, 'dia')    30.09ms    17.94μs   0.00059623x
...se.Diagonal.time_diagonal(0.5, 'dia')    50.90ms    18.32μs   0.00035993x
```
