### PR TITLE
Update info/URL for octave-maintainers discussion

### DIFF
--- a/scipy/io/matlab/mio5_params.py
+++ b/scipy/io/matlab/mio5_params.py
@@ -50,7 +50,10 @@ mxUINT64_CLASS = 15
 mxFUNCTION_CLASS = 16
 # Not doing anything with these at the moment.
 mxOPAQUE_CLASS = 17  # This appears to be a function workspace
-# https://www-old.cae.wisc.edu/pipermail/octave-maintainers/2007-May/002824.html
+# Thread 'saveing/loading symbol table of annymous functions', octave-maintainers, April-May 2007
+# https://lists.gnu.org/archive/html/octave-maintainers/2007-04/msg00031.html
+# https://lists.gnu.org/archive/html/octave-maintainers/2007-05/msg00032.html
+# (Was/Deprecated: https://www-old.cae.wisc.edu/pipermail/octave-maintainers/2007-May/002824.html)
 mxOBJECT_CLASS_FROM_MATRIX_H = 18
 
 mdtypes_template = {


### PR DESCRIPTION
MATLAB array class 17 (0x11) still lacks documentation. The reference to a useful octave-matainers discussion in a comment of this source file was broken.  I've tracked it down their new list hosted at lists.gnu.org.  The reason for the two URLs is because the thread is spread out in their archive; the first URL provide the original post and the second the informative discussion.
