### PR TITLE
DOC: fix optimize.fmin convergence docstring

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -418,9 +418,12 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     # set default tolerances
     if tol is not None:
         options = dict(options)
-        if meth in ['nelder-mead', 'newton-cg', 'powell', 'tnc']:
+        if meth == 'nelder-mead':
+            options.setdefault('xatol', tol)
+            options.setdefault('fatol', tol)
+        if meth in ['newton-cg', 'powell', 'tnc']:
             options.setdefault('xtol', tol)
-        if meth in ['nelder-mead', 'powell', 'l-bfgs-b', 'tnc', 'slsqp']:
+        if meth in ['powell', 'l-bfgs-b', 'tnc', 'slsqp']:
             options.setdefault('ftol', tol)
         if meth in ['bfgs', 'cg', 'l-bfgs-b', 'tnc', 'dogleg', 'trust-ncg']:
             options.setdefault('gtol', tol)

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -432,7 +432,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         convergence.
     """
     if 'ftol' in unknown_options:
-        warnings.warn("ftol is deprecated for _minimize_neldermead,"
+        warnings.warn("ftol is deprecated for Nelder-Mead,"
                       " use fatol instead. If you specified both, only"
                       " fatol is used.",
                       DeprecationWarning)
@@ -442,7 +442,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
             fatol = unknown_options['ftol']
         unknown_options.pop('ftol')
     if 'xtol' in unknown_options:
-        warnings.warn("xtol is deprecated for _minimize_neldermead,"
+        warnings.warn("xtol is deprecated for Nelder-Mead,"
                       " use xatol instead. If you specified both, only"
                       " xatol is used.",
                       DeprecationWarning)

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -29,6 +29,7 @@ __docformat__ = "restructuredtext en"
 
 import warnings
 import sys
+from functools import wraps
 import numpy
 from scipy._lib.six import callable
 from numpy import (atleast_1d, eye, mgrid, argmin, zeros, shape, squeeze,
@@ -404,13 +405,14 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
 
 
 def __deprecate_ftol_xtol(func):
-    def inner(*args, **kwds):
+    @wraps(func)
+    def _wrapper(*args, **kwds):
         if 'ftol' in kwds:
             warnings.warn("ftol is deprecated for _minimize_neldermead,"
                           " use fatol instead. If you specified both, only"
                           " fatol is used.",
                           DeprecationWarning)
-            if not 'fatol' in kwds:
+            if 'fatol' not in kwds:
                 kwds['fatol'] = kwds['ftol']
             kwds.pop('ftol')
         if 'xtol' in kwds:
@@ -418,13 +420,12 @@ def __deprecate_ftol_xtol(func):
                           " use xatol instead. If you specified both, only"
                           " xatol is used.",
                           DeprecationWarning)
-            if not 'xatol' in kwds:
+            if 'xatol' not in kwds:
                 kwds['xatol'] = kwds['xtol']
             kwds.pop('xtol')
 
         return func(*args, **kwds)
-    return inner
-
+    return _wrapper
 
 @__deprecate_ftol_xtol
 def _minimize_neldermead(func, x0, args=(), callback=None,

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -311,9 +311,11 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
     args : tuple, optional
         Extra arguments passed to func, i.e. ``f(x,*args)``.
     xtol : float, optional
-        Relative error in xopt acceptable for convergence.
+        Absolute error in xopt between iterations that is acceptable for
+        convergence.
     ftol : number, optional
-        Relative error in func(xopt) acceptable for convergence.
+        Absolute error in func(xopt) between iterations that is acceptable for
+        convergence.
     maxiter : int, optional
         Maximum number of iterations to perform.
     maxfun : number, optional
@@ -365,7 +367,8 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
     performance in high-dimensional problems and is not robust to
     minimizing complicated functions. Additionally, there currently is no
     complete theory describing when the algorithm will successfully
-    converge to the minimum, or how fast it will if it does.
+    converge to the minimum, or how fast it will if it does. Both the ftol and
+    xtol criteria must be met for convergence.
 
     References
     ----------
@@ -412,10 +415,12 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     -------
     disp : bool
         Set to True to print convergence messages.
-    xtol : float
-        Relative error in solution `xopt` acceptable for convergence.
-    ftol : float
-        Relative error in ``fun(xopt)`` acceptable for convergence.
+    xtol : float, optional
+        Absolute error in xopt between iterations that is acceptable for
+        convergence.
+    ftol : number, optional
+        Absolute error in func(xopt) between iterations that is acceptable for
+        convergence.
     maxiter : int
         Maximum number of iterations to perform.
     maxfev : int

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -382,8 +382,8 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
            Harlow, UK, pp. 191-208.
 
     """
-    opts = {'xtol': xtol,
-            'ftol': ftol,
+    opts = {'xatol': xtol,
+            'fatol': ftol,
             'maxiter': maxiter,
             'maxfev': maxfun,
             'disp': disp,
@@ -404,9 +404,9 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
 
 
 def _minimize_neldermead(func, x0, args=(), callback=None,
-                         xtol=1e-4, ftol=1e-4, maxiter=None, maxfev=None,
-                         disp=False, return_all=False, initial_simplex=None,
-                         **unknown_options):
+                         maxiter=None, maxfev=None, disp=False,
+                         return_all=False, initial_simplex=None,
+                         xatol=1e-4, fatol=1e-4, **unknown_options):
     """
     Minimization of scalar function of one or more variables using the
     Nelder-Mead algorithm.
@@ -415,12 +415,6 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     -------
     disp : bool
         Set to True to print convergence messages.
-    xtol : float, optional
-        Absolute error in xopt between iterations that is acceptable for
-        convergence.
-    ftol : number, optional
-        Absolute error in func(xopt) between iterations that is acceptable for
-        convergence.
     maxiter : int
         Maximum number of iterations to perform.
     maxfev : int
@@ -430,8 +424,26 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         ``initial_simplex[j,:]`` should contain the coordinates of
         the j-th vertex of the ``N+1`` vertices in the simplex, where
         ``N`` is the dimension.
-
+    xatol : float, optional
+        Absolute error in xopt between iterations that is acceptable for
+        convergence.
+    fatol : number, optional
+        Absolute error in func(xopt) between iterations that is acceptable for
+        convergence.
     """
+    if 'xtol' in unknown_options:
+        xatol = unknown_options['xtol']
+        warnings.warn("xtol is deprecated for _minimize_neldermead,"
+                      " use xatol instead.",
+                      DeprecationWarning)
+        unknown_options.pop('xtol')
+    if 'ftol' in unknown_options:
+        fatol = unknown_options['ftol']
+        unknown_options.pop('ftol')
+        warnings.warn("ftol is deprecated for _minimize_neldermead,"
+                      " use fatol instead.",
+                      DeprecationWarning)
+
     _check_unknown_options(unknown_options)
     maxfun = maxfev
     retall = return_all
@@ -489,8 +501,8 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     iterations = 1
 
     while (fcalls[0] < maxfun and iterations < maxiter):
-        if (numpy.max(numpy.ravel(numpy.abs(sim[1:] - sim[0]))) <= xtol and
-                numpy.max(numpy.abs(fsim[0] - fsim[1:])) <= ftol):
+        if (numpy.max(numpy.ravel(numpy.abs(sim[1:] - sim[0]))) <= xatol and
+                numpy.max(numpy.abs(fsim[0] - fsim[1:])) <= fatol):
             break
 
         xbar = numpy.add.reduce(sim[:-1], 0) / N

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -403,6 +403,30 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
             return res['x']
 
 
+def __deprecate_ftol_xtol(func):
+    def inner(*args, **kwds):
+        if 'ftol' in kwds:
+            warnings.warn("ftol is deprecated for _minimize_neldermead,"
+                          " use fatol instead. If you specified both, only"
+                          " fatol is used.",
+                          DeprecationWarning)
+            if not 'fatol' in kwds:
+                kwds['fatol'] = kwds['ftol']
+            kwds.pop('ftol')
+        if 'xtol' in kwds:
+            warnings.warn("xtol is deprecated for _minimize_neldermead,"
+                          " use xatol instead. If you specified both, only"
+                          " xatol is used.",
+                          DeprecationWarning)
+            if not 'xatol' in kwds:
+                kwds['xatol'] = kwds['xtol']
+            kwds.pop('xtol')
+
+        return func(*args, **kwds)
+    return inner
+
+
+@__deprecate_ftol_xtol
 def _minimize_neldermead(func, x0, args=(), callback=None,
                          maxiter=None, maxfev=None, disp=False,
                          return_all=False, initial_simplex=None,
@@ -431,19 +455,6 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         Absolute error in func(xopt) between iterations that is acceptable for
         convergence.
     """
-    if 'xtol' in unknown_options:
-        xatol = unknown_options['xtol']
-        warnings.warn("xtol is deprecated for _minimize_neldermead,"
-                      " use xatol instead.",
-                      DeprecationWarning)
-        unknown_options.pop('xtol')
-    if 'ftol' in unknown_options:
-        fatol = unknown_options['ftol']
-        unknown_options.pop('ftol')
-        warnings.warn("ftol is deprecated for _minimize_neldermead,"
-                      " use fatol instead.",
-                      DeprecationWarning)
-
     _check_unknown_options(unknown_options)
     maxfun = maxfev
     retall = return_all

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -17,7 +17,7 @@ import itertools
 import numpy as np
 from numpy.testing import (assert_raises, assert_allclose, assert_equal,
                            assert_, TestCase, run_module_suite, dec,
-                           assert_almost_equal)
+                           assert_almost_equal, assert_warns)
 
 from scipy._lib._testutils import suppressed_stdout
 from scipy import optimize
@@ -418,6 +418,18 @@ class CheckOptimizeParameterized(CheckOptimize):
                         [[-4.35700753e-07, -5.24869435e-01, 4.87527480e-01],
                          [-4.35700753e-07, -5.24869401e-01, 4.87527774e-01]],
                         atol=1e-6, rtol=1e-7)
+
+
+def test_neldermead_xatol_fatol():
+    # gh4484
+    # test we can call with fatol, xatol specified
+    func = lambda x: x[0]**2 + x[1]**2
+
+    optimize._minimize._minimize_neldermead(func, [1, 1], maxiter=2,
+                                            xatol=1e-3, fatol=1e-3)
+    assert_warns(DeprecationWarning,
+                 optimize._minimize._minimize_neldermead,
+                 func, [1, 1], xtol=1e-3, ftol=1e-3, maxiter=2)
 
 
 class TestOptimizeWrapperDisp(CheckOptimizeParameterized):


### PR DESCRIPTION
@dlax this should hopefully address #4484, #5707 and also #5051. @pv made some comments in #5051 about ftol and xtol being relative (rather than absolute) in the other minimizers. I do agree that that's confusing. Not quite sure how to go about doing the deprecation he mentions.  In any case the docstring for `fmin` (and _minimize_neldermead`) is definitely incorrect at the moment.
