### PR TITLE
ENH: Improve numerical accuracy of lognorm

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3105,8 +3105,17 @@ class lognorm_gen(rv_continuous):
     def _cdf(self, x, s):
         return _norm_cdf(log(x) / s)
 
+    def _logcdf(self, x, s):
+        return _norm_logcdf(log(x) / s)
+
     def _ppf(self, q, s):
         return exp(s * _norm_ppf(q))
+
+    def _sf(self, x, s):
+        return _norm_sf(log(x) / s)
+
+    def _log_sf(self, x, s):
+        return _norm_logsf(log(x) / s)
 
     def _stats(self, s):
         p = exp(s*s)


### PR DESCRIPTION
Explicitly define sf, logsf and logcdf of lognormal
distribution to improve numerical accuracy
solves gh-5940
