### PR TITLE
MAINT: interpolate: Tweak declaration to avoid cython warning about mix of pointers and values.

### DIFF
--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -150,7 +150,8 @@ def evaluate_nd(double_or_complex[:,:,::1] c,
     cdef double[::1] y
     cdef double_or_complex[:,:,::1] c2
     cdef int ip, jp, k, ndim
-    cdef int interval[MAX_DIMS], pos, kpos, koutpos
+    cdef int interval[MAX_DIMS]
+    cdef int pos, kpos, koutpos
     cdef int out_of_range
     cdef double xval
 


### PR DESCRIPTION
Including a scalar and an array in a single `cdef` declaration results in the following warning (using cython 0.23.4):

```
Processing scipy/interpolate/_ppoly.pyx
warning: _ppoly.pyx:153:21: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
warning: _ppoly.pyx:153:21: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
```

This PR moves the declaration of an array to its own `cdef`.
