### PR TITLE
MAINT: sparse: clean up format conversion methods

### DIFF
--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -5,7 +5,6 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 import time
-import collections
 import timeit
 
 import numpy
@@ -195,7 +194,7 @@ class Conversion(Benchmark):
     param_names = ['from_format', 'to_format']
 
     def setup(self, fromfmt, tofmt):
-        base = poisson2d(100).asformat(fromfmt)
+        base = poisson2d(100, format=fromfmt)
 
         try:
             self.fn = getattr(base, 'to' + tofmt)

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -673,18 +673,18 @@ class spmatrix(object):
             returned after being modified in-place to contain the
             appropriate values.
         """
-        return self.tocoo().toarray(order=order, out=out)
+        return self.tocoo(copy=False).toarray(order=order, out=out)
 
-    # In principle, providing a tocsr method will be sufficient for any
-    # sparse matrix format deriving from spmatrix.
+    # Any sparse matrix format deriving from spmatrix must define one of
+    # tocsr or tocoo. The other conversion methods may be implemented for
+    # efficiency, but are not required.
     def tocsr(self, copy=False):
         """Convert this matrix to Compressed Sparse Row format.
 
         With copy=False, the data/indices may be shared between this matrix and
         the resultant csr_matrix.
         """
-        raise NotImplementedError("tocsr is not implemented for %s." %
-                                  self.__class__.__name__)
+        return self.tocoo(copy=copy).tocsr(copy=False)
 
     def todok(self, copy=False):
         """Convert this matrix to Dictionary Of Keys format.
@@ -692,7 +692,7 @@ class spmatrix(object):
         With copy=False, the data/indices may be shared between this matrix and
         the resultant dok_matrix.
         """
-        return self.tocoo(copy=False).todok(copy=copy)
+        return self.tocoo(copy=copy).todok(copy=False)
 
     def tocoo(self, copy=False):
         """Convert this matrix to COOrdinate format.
@@ -716,7 +716,7 @@ class spmatrix(object):
         With copy=False, the data/indices may be shared between this matrix and
         the resultant dia_matrix.
         """
-        return self.tocoo(copy=False).todia(copy=copy)
+        return self.tocoo(copy=copy).todia(copy=False)
 
     def tobsr(self, blocksize=None, copy=False):
         """Convert this matrix to Block Sparse Row format.
@@ -735,7 +735,7 @@ class spmatrix(object):
         With copy=False, the data/indices may be shared between this matrix and
         the resultant csc_matrix.
         """
-        return self.tocsr(copy=False).tocsc(copy=copy)
+        return self.tocsr(copy=copy).tocsc(copy=False)
 
     def copy(self):
         """Returns a copy of this matrix.

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -856,34 +856,18 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     # Conversion methods #
     ######################
 
-    def todia(self):
-        return self.tocoo(copy=False).todia()
-
-    def todok(self):
-        return self.tocoo(copy=False).todok()
-
-    def tocoo(self,copy=True):
-        """Return a COOrdinate representation of this matrix
-
-        When copy=False the index and data arrays are not copied.
-        """
-        major_dim,minor_dim = self._swap(self.shape)
-
-        data = self.data
+    def tocoo(self, copy=True):
+        major_dim, minor_dim = self._swap(self.shape)
         minor_indices = self.indices
-
-        if copy:
-            data = data.copy()
-            minor_indices = minor_indices.copy()
-
         major_indices = np.empty(len(minor_indices), dtype=self.indices.dtype)
-
-        _sparsetools.expandptr(major_dim,self.indptr,major_indices)
-
-        row,col = self._swap((major_indices,minor_indices))
+        _sparsetools.expandptr(major_dim, self.indptr, major_indices)
+        row, col = self._swap((major_indices, minor_indices))
 
         from .coo import coo_matrix
-        return coo_matrix((data,(row,col)), self.shape)
+        return coo_matrix((self.data, (row, col)), self.shape, copy=copy,
+                          dtype=self.dtype)
+
+    tocoo.__doc__ = spmatrix.tocoo.__doc__
 
     def toarray(self, order=None, out=None):
         """See the docstring for `spmatrix.toarray`."""

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -179,7 +179,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                 self.has_canonical_format = True
 
         if dtype is not None:
-            self.data = self.data.astype(dtype)
+            self.data = self.data.astype(dtype, copy=False)
 
         self._check()
 
@@ -251,12 +251,9 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         return B
 
     def tocsc(self, copy=False):
-        """Return a copy of this matrix in Compressed Sparse Column format
+        """Convert this matrix to Compressed Sparse Column format
 
         Duplicate entries will be summed together.
-
-        With copy=False, the data/indices may be shared between this matrix
-        and resultant csc_matrix.
 
         Examples
         --------
@@ -278,30 +275,25 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             return csc_matrix(self.shape, dtype=self.dtype)
         else:
             M,N = self.shape
+            self.sum_duplicates()
             idx_dtype = get_index_dtype((self.col, self.row),
                                         maxval=max(self.nnz, M))
-            indptr = np.empty(N + 1, dtype=idx_dtype)
-            indices = np.empty(self.nnz, dtype=idx_dtype)
-            data = np.empty(self.nnz, dtype=upcast(self.dtype))
+            row = self.row.astype(idx_dtype, copy=False)
+            col = self.col.astype(idx_dtype, copy=False)
 
-            coo_tocsr(N, M, self.nnz,
-                      self.col.astype(idx_dtype),
-                      self.row.astype(idx_dtype),
-                      self.data,
+            indptr = np.empty(N + 1, dtype=idx_dtype)
+            indices = np.empty_like(row)
+            data = np.empty_like(self.data, dtype=upcast(self.dtype))
+
+            coo_tocsr(N, M, self.nnz, col, row, self.data,
                       indptr, indices, data)
 
-            A = csc_matrix((data, indices, indptr), shape=self.shape)
-            A.sum_duplicates()
-
-            return A
+            return csc_matrix((data, indices, indptr), shape=self.shape)
 
     def tocsr(self, copy=False):
-        """Return a copy of this matrix in Compressed Sparse Row format
+        """Convert this matrix to Compressed Sparse Row format
 
         Duplicate entries will be summed together.
-
-        With copy=False, the data/indices may be shared between this matrix
-        and resultant csc_matrix.
 
         Examples
         --------
@@ -323,24 +315,20 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             return csr_matrix(self.shape, dtype=self.dtype)
         else:
             M,N = self.shape
+            self.sum_duplicates()
             idx_dtype = get_index_dtype((self.row, self.col),
                                         maxval=max(self.nnz, N))
+            row = self.row.astype(idx_dtype, copy=False)
+            col = self.col.astype(idx_dtype, copy=False)
+
             indptr = np.empty(M + 1, dtype=idx_dtype)
-            indices = np.empty(self.nnz, dtype=idx_dtype)
-            data = np.empty(self.nnz, dtype=upcast(self.dtype))
+            indices = np.empty_like(col)
+            data = np.empty_like(self.data, dtype=upcast(self.dtype))
 
-            coo_tocsr(M, N, self.nnz,
-                      self.row.astype(idx_dtype),
-                      self.col.astype(idx_dtype),
-                      self.data,
-                      indptr,
-                      indices,
-                      data)
+            coo_tocsr(M, N, self.nnz, row, col, self.data,
+                      indptr, indices, data)
 
-            A = csr_matrix((data, indices, indptr), shape=self.shape)
-            A.sum_duplicates()
-
-            return A
+            return csr_matrix((data, indices, indptr), shape=self.shape)
 
     def tocoo(self, copy=False):
         if copy:

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -282,7 +282,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             col = self.col.astype(idx_dtype, copy=False)
 
             indptr = np.empty(N + 1, dtype=idx_dtype)
-            indices = np.empty_like(row)
+            indices = np.empty_like(row, dtype=idx_dtype)
             data = np.empty_like(self.data, dtype=upcast(self.dtype))
 
             coo_tocsr(N, M, self.nnz, col, row, self.data,
@@ -322,7 +322,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             col = self.col.astype(idx_dtype, copy=False)
 
             indptr = np.empty(M + 1, dtype=idx_dtype)
-            indices = np.empty_like(col)
+            indices = np.empty_like(col, dtype=idx_dtype)
             data = np.empty_like(self.data, dtype=upcast(self.dtype))
 
             coo_tocsr(M, N, self.nnz, row, col, self.data,

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -262,10 +262,11 @@ class dia_matrix(_data_matrix):
         mask &= (offset_inds < num_cols)
         mask &= (self.data != 0)
 
-        indptr = np.zeros(num_cols + 1, dtype=row.dtype)
+        idx_dtype = get_index_dtype(maxval=max(self.shape))
+        indptr = np.zeros(num_cols + 1, dtype=idx_dtype)
         indptr[1:offset_len+1] = np.cumsum(mask.sum(axis=0))
         indptr[offset_len+1:] = indptr[offset_len]
-        indices = row.T[mask.T]
+        indices = row.T[mask.T].astype(idx_dtype, copy=False)
         data = self.data.T[mask.T]
         return csc_matrix((data, indices, indptr), shape=self.shape,
                           dtype=self.dtype)

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -461,11 +461,13 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         from .coo import coo_matrix
         if self.nnz == 0:
             return coo_matrix(self.shape, dtype=self.dtype)
-        else:
-            idx_dtype = get_index_dtype(maxval=max(self.shape[0], self.shape[1]))
-            data = np.asarray(_list(self.values()), dtype=self.dtype)
-            indices = np.asarray(_list(self.keys()), dtype=idx_dtype).T
-            return coo_matrix((data,indices), shape=self.shape, dtype=self.dtype)
+
+        idx_dtype = get_index_dtype(maxval=max(self.shape))
+        data = np.asarray(_list(self.values()), dtype=self.dtype)
+        indices = np.asarray(_list(self.keys()), dtype=idx_dtype).T
+        A = coo_matrix((data, indices), shape=self.shape, dtype=self.dtype)
+        A.has_canonical_format = True
+        return A
 
     tocoo.__doc__ = spmatrix.tocoo.__doc__
 
@@ -476,11 +478,6 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             return self
 
     todok.__doc__ = spmatrix.todok.__doc__
-
-    def tocsr(self, copy=False):
-        return self.tocoo(copy=False).tocsr(copy=copy)
-
-    tocsr.__doc__ = spmatrix.tocsr.__doc__
 
     def tocsc(self, copy=False):
         return self.tocoo(copy=False).tocsc(copy=copy)

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -459,11 +459,6 @@ class lil_matrix(spmatrix, IndexMixin):
 
     tocsr.__doc__ = spmatrix.tocsr.__doc__
 
-    def tocsc(self, copy=False):
-        return self.tocsr(copy=copy).tocsc()
-
-    tocsc.__doc__ = spmatrix.tocsc.__doc__
-
 
 def _prepare_index_for_memoryview(i, j, x=None):
     """


### PR DESCRIPTION
This PR removes a bunch of redundant subclass overrides,
and adds some small enhancements to existing conversion methods.

It also provides:
- `spmatrix.tocsr`, based on `spmatrix.tocoo`
- `dia_matrix.tocsc`, which avoids a conversion through COO
