### PR TITLE
BUG: fix sparse .mean to return a scalar instead of a matrix

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -792,9 +792,9 @@ class spmatrix(object):
             res_dtype = self.dtype
 
         if axis is None:
-            m, n = self.shape
-            return self.astype(res_dtype).sum() / np.matrix(m * n,
-                                                            dtype=res_dtype)
+            mean = self.astype(res_dtype).sum()
+            mean /= np.array(self.shape[0] * self.shape[1], dtype=res_dtype)
+            return mean
 
         if axis < 0:
             axis += 2

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -760,6 +760,7 @@ class _TestCommon:
             datsp = self.spmatrix(dat, dtype=dtype)
             assert_array_almost_equal(dat.sum(), datsp.sum())
             assert_equal(dat.sum().dtype, datsp.sum().dtype)
+            assert_(np.isscalar(datsp.sum(axis=None)))
             assert_array_almost_equal(dat.sum(axis=None), datsp.sum(axis=None))
             assert_equal(dat.sum(axis=None).dtype, datsp.sum(axis=None).dtype)
             assert_array_almost_equal(dat.sum(axis=0), datsp.sum(axis=0))
@@ -784,6 +785,7 @@ class _TestCommon:
 
             assert_array_almost_equal(dat.mean(), datsp.mean())
             assert_equal(dat.mean().dtype, datsp.mean().dtype)
+            assert_(np.isscalar(datsp.mean(axis=None)))
             assert_array_almost_equal(dat.mean(axis=None), datsp.mean(axis=None))
             assert_equal(dat.mean(axis=None).dtype, datsp.mean(axis=None).dtype)
             assert_array_almost_equal(dat.mean(axis=0), datsp.mean(axis=0))


### PR DESCRIPTION
Fix #5948.

Also added test to make sure that the output of .mean and .sum is a scalar
since this assert_array_equal does not make any difference between a
scalar and an array of any shape with a single element, e.g. this doesn't raise an error:

``` python
import numpy as np

np.testing.assert_array_equal(1, np.array([[1]]))
```
