### PR TITLE
linregress calculations

### DIFF
--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -95,7 +95,7 @@ def linregress(x, y=None):
     intercept = ymean - (slope * xmean)
     stderr_est = np.sqrt((1 - r**2) * vary / df)
     stderr_slope = stderr_est * np.sqrt(1 / varx)
-    stderr_intercept = stderr_est * np.sqrt((1 / n) + (xmean**2 / varx)
+    stderr_intercept = stderr_est * np.sqrt((1 / n) + (xmean**2 / varx))
 
     LinregressResult = namedtuple('LinregressResult', ('slope', 'intercept',
                                                        'rvalue', 'pvalue',

--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -93,9 +93,10 @@ def linregress(x, y=None):
     prob = 2 * distributions.t.sf(np.abs(t), df)
     slope = covxy / varx
     intercept = ymean - (slope * xmean)
-    stderr_est = np.sqrt((1 - r**2) * vary / df)
-    stderr_slope = stderr_est * np.sqrt(1 / varx)
-    stderr_intercept = stderr_est * np.sqrt((1 / n) + (xmean**2 / varx))
+    mse = (1 - r**2) * vary / df
+    stderr_est = np.sqrt(mse)
+    stderr_slope =  np.sqrt(mse / varx)
+    stderr_intercept = np.sqrt(mse * (1/n + xmean**2/varx))
 
     LinregressResult = namedtuple('LinregressResult', ('slope', 'intercept',
                                                        'rvalue', 'pvalue',

--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -23,16 +23,16 @@ def linregress(x, y=None):
     Returns
     -------
     slope : float
-        slope of the regression line
+        Slope of the regression line.
     intercept : float
-        intercept of the regression line
+        Intercept of the regression line.
     rvalue : float
-        correlation coefficient
+        Correlation coefficient.
     pvalue : float
-        two-sided p-value for a hypothesis test whose null hypothesis is
+        Two-sided p-value for a hypothesis test of which null hypothesis is
         that the slope is zero.
     stderr : float
-        Standard error of the estimated gradient.
+        Standard error of the estimated slope.
 
     See also
     --------

--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -76,13 +76,12 @@ def linregress(x, y=None):
     ymean = np.mean(y, None)
 
     # average sum of squares:
-    ssxm, ssxym, ssyxm, ssym = np.cov(x, y, bias=1).flat
-    r_num = ssxym
-    r_den = np.sqrt(ssxm * ssym)
+    varx, covxy, covyx, vary = np.cov(x, y, bias=1).flat
+    r_den = np.sqrt(varx * vary)
     if r_den == 0.0:
         r = 0.0
     else:
-        r = r_num / r_den
+        r = covxy / r_den
         # test for numerical error propagation
         if r > 1.0:
             r = 1.0
@@ -92,9 +91,9 @@ def linregress(x, y=None):
     df = n - 2
     t = r * np.sqrt(df / ((1.0 - r + TINY)*(1.0 + r + TINY)))
     prob = 2 * distributions.t.sf(np.abs(t), df)
-    slope = r_num / ssxm
+    slope = covxy / varx
     intercept = ymean - slope*xmean
-    sterrest = np.sqrt((1 - r**2) * ssym / ssxm / df)
+    sterrest = np.sqrt((1 - r**2) * vary / varx / df)
 
     LinregressResult = namedtuple('LinregressResult', ('slope', 'intercept',
                                                        'rvalue', 'pvalue',

--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -92,13 +92,15 @@ def linregress(x, y=None):
     t = r * np.sqrt(df / ((1.0 - r + TINY)*(1.0 + r + TINY)))
     prob = 2 * distributions.t.sf(np.abs(t), df)
     slope = covxy / varx
-    intercept = ymean - slope*xmean
-    sterrest = np.sqrt((1 - r**2) * vary / varx / df)
+    intercept = ymean - (slope * xmean)
+    stderr_est = np.sqrt((1 - r**2) * vary / df)
+    stderr_slope = stderr_est * np.sqrt(1 / varx)
+    stderr_intercept = stderr_est * np.sqrt((1 / n) + (xmean**2 / varx)
 
     LinregressResult = namedtuple('LinregressResult', ('slope', 'intercept',
                                                        'rvalue', 'pvalue',
                                                        'stderr'))
-    return LinregressResult(slope, intercept, r, prob, sterrest)
+    return LinregressResult(slope, intercept, r, prob, stderr_slope)
 
 
 def theilslopes(y, x=None, alpha=0.95):


### PR DESCRIPTION
I cleaned up the variable names for clarity and also added/updated the error calculations according to #2962 (comment), cross-checked on [here](http://onlinestatbook.com/2/regression/accuracy.html) and [here](https://en.wikipedia.org/wiki/Regression_analysis#Linear_regression).

I have yet to add the extra calculations to return for backwards compatibility reasons. #3665 (comment) shows a possible way for functions to add extra return values without breaking backwards compatibility, but so far I have not seen this implemented in any functions.

Another issue is that the current return value stderr is inappropriately named, as it currently returns the error of the slope, instead of the error of the estimate.
