### PR TITLE
Allow for absolute finite difference step

### DIFF
--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -727,7 +727,7 @@ def least_squares(
         raise ValueError("method='lm' supports only 'linear' loss function.")
 
     if method == 'lm' and abs_step is None:
-         raise ValueError("'abs_step' not supported with method='lm'.") 
+        raise ValueError("'abs_step' not supported with method='lm'.") 
          
     if verbose not in [0, 1, 2]:
         raise ValueError("`verbose` must be in [0, 1, 2].")

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -726,6 +726,9 @@ def least_squares(
     if method == 'lm' and loss != 'linear':
         raise ValueError("method='lm' supports only 'linear' loss function.")
 
+    if method == 'lm' and abs_step is None:
+         raise ValueError("'abs_step' not supported with method='lm'.") 
+         
     if verbose not in [0, 1, 2]:
         raise ValueError("`verbose` must be in [0, 1, 2].")
 
@@ -868,11 +871,8 @@ def least_squares(
                 tr_solver = 'lsmr'
 
     if method == 'lm':
-        if abs_step is None:
-            result = call_minpack(fun_wrapped, x0, jac_wrapped, ftol, xtol, gtol,
-                                  max_nfev, x_scale, rel_step)
-        else:
-            raise ValueError("'abs_step' can't be used when method='lm'")
+        result = call_minpack(fun_wrapped, x0, jac_wrapped, ftol, xtol, gtol,
+                              max_nfev, x_scale, rel_step)
 
     elif method == 'trf':
         result = trf(fun_wrapped, jac_wrapped, x0, f0, J0, lb, ub, ftol, xtol,

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -726,7 +726,7 @@ def least_squares(
     if method == 'lm' and loss != 'linear':
         raise ValueError("method='lm' supports only 'linear' loss function.")
 
-    if method == 'lm' and abs_step is None:
+    if method == 'lm' and abs_step is not None:
         raise ValueError("'abs_step' not supported with method='lm'.") 
          
     if verbose not in [0, 1, 2]:

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -727,7 +727,7 @@ def least_squares(
         raise ValueError("method='lm' supports only 'linear' loss function.")
 
     if method == 'lm' and abs_step is not None:
-        raise ValueError("'abs_step' not supported with method='lm'.") 
+        raise ValueError("`abs_step` not supported with method='lm'.") 
          
     if verbose not in [0, 1, 2]:
         raise ValueError("`verbose` must be in [0, 1, 2].")

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -176,8 +176,8 @@ def group_columns(A, order=0):
     return groups
 
 
-def approx_derivative(fun, x0, method='3-point', rel_step=None, f0=None,
-                      args=(), kwargs={}, bounds=(-np.inf, np.inf),
+def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
+                      f0=None, args=(), kwargs={}, bounds=(-np.inf, np.inf),
                       sparsity=None):
     """Compute finite difference approximation of the derivatives of a
     vector-valued function.
@@ -334,7 +334,10 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, f0=None,
     if np.any((x0 < lb) | (x0 > ub)):
         raise ValueError("`x0` violates bound constraints.")
 
-    h = _compute_absolute_step(rel_step, x0, method)
+    if abs_step is None:
+        h = _compute_absolute_step(rel_step, x0, method)
+    else:
+        h = abs_step*np.sign(x0)
 
     if method == '2-point':
         h, use_one_sided = _adjust_scheme_to_bounds(

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -337,7 +337,9 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
     if abs_step is None:
         h = _compute_absolute_step(rel_step, x0, method)
     else:
-        h = abs_step*np.sign(x0)
+        # sign_x0 != 0 unlike np.sgn()
+        sign_x0 = (x0 >= 0).astype(float) * 2 - 1   
+        h = abs_step*sign_x0
 
     if method == '2-point':
         h, use_one_sided = _adjust_scheme_to_bounds(

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -231,12 +231,12 @@ class BaseMixin(object):
     def test_diff_step(self):
         # res1 and res2 should be equivalent.
         # res2 and res3 should be different.
-        res1 = least_squares(fun_trivial, 2.0, diff_step=1e-1,
+        res1 = least_squares(fun_trivial, 2.0, rel_step=1e-1,
                              method=self.method)
-        res2 = least_squares(fun_trivial, 2.0, diff_step=-1e-1,
+        res2 = least_squares(fun_trivial, 2.0, rel_step=-1e-1,
                              method=self.method)
         res3 = least_squares(fun_trivial, 2.0,
-                             diff_step=None, method=self.method)
+                             rel_step=None, method=self.method)
         assert_allclose(res1.x, 0, atol=1e-4)
         assert_allclose(res2.x, 0, atol=1e-4)
         assert_allclose(res3.x, 0, atol=1e-4)


### PR DESCRIPTION
Allow for absolute, rather than only relative, step in the finite difference approximation of the derivatives. 

This is useful to include an option for **absolute** finite-difference steps in scipy/optimize/_lsq /least_squares.py
