### PR TITLE
MAINT: Replace calls to `hanning` with `hann`

### DIFF
--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -141,7 +141,7 @@ def periodogram(x, fs=1.0, window=None, nfft=None, detrend='constant',
                  scaling, axis)
 
 
-def welch(x, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
+def welch(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
           detrend='constant', return_onesided=True, scaling='density', axis=-1):
     """
     Estimate power spectral density using Welch's method.
@@ -160,7 +160,7 @@ def welch(x, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length will be used for nperseg.
-        Defaults to 'hanning'.
+        Defaults to 'hann'.
     nperseg : int, optional
         Length of each segment.  Defaults to 256.
     noverlap : int, optional
@@ -202,7 +202,7 @@ def welch(x, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
     Notes
     -----
     An appropriate amount of overlap will depend on the choice of window
-    and on your requirements.  For the default 'hanning' window an
+    and on your requirements.  For the default 'hann' window an
     overlap of 50% is a reasonable trade off between accurately estimating
     the signal power, while not over counting any of the data.  Narrower
     windows may require a larger overlap.
@@ -275,7 +275,7 @@ def welch(x, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
     return freqs, Pxx.real
 
 
-def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
+def csd(x, y, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
         detrend='constant', return_onesided=True, scaling='density', axis=-1):
     """
     Estimate the cross power spectral density, Pxy, using Welch's method.
@@ -292,7 +292,7 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length will be used for nperseg.
-        Defaults to 'hanning'.
+        Defaults to 'hann'.
     nperseg : int, optional
         Length of each segment.  Defaults to 256.
     noverlap: int, optional
@@ -342,7 +342,7 @@ def csd(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None, nfft=None,
     zero-padded to match.
 
     An appropriate amount of overlap will depend on the choice of window
-    and on your requirements.  For the default 'hanning' window an
+    and on your requirements.  For the default 'hann' window an
     overlap of 50\% is a reasonable trade off between accurately estimating
     the signal power, while not over counting any of the data.  Narrower
     windows may require a larger overlap.
@@ -518,7 +518,7 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=256, noverlap=None,
     return freqs, time, Pxy
 
 
-def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
+def coherence(x, y, fs=1.0, window='hann', nperseg=256, noverlap=None,
               nfft=None, detrend='constant', axis=-1):
     """
     Estimate the magnitude squared coherence estimate, Cxy, of discrete-time
@@ -540,7 +540,7 @@ def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length will be used for nperseg.
-        Defaults to 'hanning'.
+        Defaults to 'hann'.
     nperseg : int, optional
         Length of each segment.  Defaults to 256.
     noverlap: int, optional
@@ -575,7 +575,7 @@ def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
     Notes
     --------
     An appropriate amount of overlap will depend on the choice of window
-    and on your requirements.  For the default 'hanning' window an
+    and on your requirements.  For the default 'hann' window an
     overlap of 50\% is a reasonable trade off between accurately estimating
     the signal power, while not over counting any of the data.  Narrower
     windows may require a larger overlap.
@@ -629,7 +629,7 @@ def coherence(x, y, fs=1.0, window='hanning', nperseg=256, noverlap=None,
     return freqs, Cxy
 
 
-def _spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
+def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=256,
                     noverlap=None, nfft=None, detrend='constant',
                     return_onesided=True, scaling='spectrum', axis=-1,
                     mode='psd'):
@@ -655,7 +655,7 @@ def _spectral_helper(x, y, fs=1.0, window='hanning', nperseg=256,
         Desired window to use. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length will be used for nperseg.
-        Defaults to 'hanning'.
+        Defaults to 'hann'.
     nperseg : int, optional
         Length of each segment.  Defaults to 256.
     noverlap : int, optional

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -13,7 +13,7 @@ import numpy as np
 from scipy.optimize import fmin
 from scipy import signal
 from scipy.signal import (
-    correlate, convolve, convolve2d, fftconvolve,
+    correlate, convolve, convolve2d, fftconvolve, hann,
     hilbert, hilbert2, lfilter, lfilter_zi, filtfilt, butter, tf2zpk,
     invres, invresz, vectorstrength, signaltools, lfiltic, tf2sos, sosfilt,
     sosfilt_zi)
@@ -591,11 +591,11 @@ class TestResample(TestCase):
         # Sinusoids, windowed to avoid edge artifacts
         t = np.arange(rate) / float(rate)
         freqs = np.array((1., 10., 40.))[:, np.newaxis]
-        x = np.sin(2 * np.pi * freqs * t) * np.hanning(rate)
+        x = np.sin(2 * np.pi * freqs * t) * hann(rate)
 
         for rate_to in rates_to:
             t_to = np.arange(rate_to) / float(rate_to)
-            y_tos = np.sin(2 * np.pi * freqs * t_to) * np.hanning(rate_to)
+            y_tos = np.sin(2 * np.pi * freqs * t_to) * hann(rate_to)
             if method == 'fft':
                 y_resamps = signal.resample(x, rate_to, axis=-1)
             else:
@@ -611,7 +611,7 @@ class TestResample(TestCase):
 
         # Random data
         rng = np.random.RandomState(0)
-        x = np.hanning(rate) * np.cumsum(rng.randn(rate))  # low-pass, wind
+        x = hann(rate) * np.cumsum(rng.randn(rate))  # low-pass, wind
         for rate_to in rates_to:
             # random data
             t_to = np.arange(rate_to) / float(rate_to)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -117,8 +117,8 @@ class TestPeriodogram(TestCase):
     def test_window_external(self):
         x = np.zeros(16)
         x[0] = 1
-        f, p = periodogram(x, 10, 'hanning')
-        win = signal.get_window('hanning', 16)
+        f, p = periodogram(x, 10, 'hann')
+        win = signal.get_window('hann', 16)
         fe, pe = periodogram(x, 10, win)
         assert_array_almost_equal_nulp(p, pe)
         assert_array_almost_equal_nulp(f, fe)
@@ -355,8 +355,8 @@ class TestWelch(TestCase):
         x = np.zeros(16)
         x[0] = 1
         x[8] = 1
-        f, p = welch(x, 10, 'hanning', 8)
-        win = signal.get_window('hanning', 8)
+        f, p = welch(x, 10, 'hann', 8)
+        win = signal.get_window('hann', 8)
         fe, pe = welch(x, 10, win, 8)
         assert_array_almost_equal_nulp(p, pe)
         assert_array_almost_equal_nulp(f, fe)
@@ -404,7 +404,7 @@ class TestWelch(TestCase):
         assert_allclose(p, q, atol=1e-12)
 
     def test_bad_noverlap(self):
-        assert_raises(ValueError, welch, np.zeros(4), 1, 'hanning', 2, 7)
+        assert_raises(ValueError, welch, np.zeros(4), 1, 'hann', 2, 7)
 
     def test_nfft_too_short(self):
         assert_raises(ValueError, welch, np.ones(12), nfft=3, nperseg=4)
@@ -637,8 +637,8 @@ class TestCSD:
         x = np.zeros(16)
         x[0] = 1
         x[8] = 1
-        f, p = csd(x, x, 10, 'hanning', 8)
-        win = signal.get_window('hanning', 8)
+        f, p = csd(x, x, 10, 'hann', 8)
+        win = signal.get_window('hann', 8)
         fe, pe = csd(x, x, 10, win, 8)
         assert_array_almost_equal_nulp(p, pe)
         assert_array_almost_equal_nulp(f, fe)
@@ -707,7 +707,7 @@ class TestCSD:
         assert_allclose(p, q, atol=1e-12)
 
     def test_bad_noverlap(self):
-        assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1, 'hanning',
+        assert_raises(ValueError, csd, np.zeros(4), np.ones(4), 1, 'hann',
                       2, 7)
 
     def test_nfft_too_short(self):


### PR DESCRIPTION
This is just a nitpick over internal calls to the hann window. Users who request `hanning` still get the expected result.

Quoting the hann window docsctring:

```
The window was named for Julius von Hann, an Austrian meteorologist. [...] It
is sometimes erroneously referred to as the "Hanning" window, from the use of
"hann" as a verb in the original paper and confusion with the very similar
Hamming window.
```
