### PR TITLE
BUG: slow down with p=np.inf in 0.17 cKDTree.query

### DIFF
--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -40,49 +40,46 @@ class Build(Benchmark):
         else:
             self.cls(self.data)
 
-
+LeafSize = [8, 128]
+BoxSize = [None, 1.0]
 class Query(Benchmark):
     params = [
         [(3,10000,1000), (8,10000,1000), (16,10000,1000)],
-        ['KDTree', 'cKDTree', 'cKDTree_flat'],
+        [1, 2, np.inf],
+        BoxSize, LeafSize,
     ]
-    param_names = ['(m, n, r)', 'class']
+    param_names = ['(m, n, r)', 'p', 'boxsize', 'leafsize']
 
     @staticmethod
-    def do_setup(self, mnr, cls_name):
-        self.cls = KDTree if cls_name == 'KDTree' else cKDTree
+    def do_setup(self, mnr, p, boxsize, leafsize):
         m, n, r = mnr
 
         np.random.seed(1234)
-        self.data = np.concatenate((np.random.randn(n//2,m),
-                                    np.random.randn(n-n//2,m)+np.ones(m)))
 
-        self.queries = np.concatenate((np.random.randn(r//2,m),
-                                       np.random.randn(r-r//2,m)+np.ones(m)))
+        self.data = np.random.uniform(size=(n, m))
+        self.queries = np.random.uniform(size=(r, m))
 
-        if cls_name == 'cKDTree_flat':
-            self.T = self.cls(self.data, leafsize=n)
-        else:
-            self.T = self.cls(self.data)
+        self.T = cKDTree(self.data, leafsize=leafsize, boxsize=boxsize)
 
-    def setup(self, mnr, cls_name):
-        Query.do_setup(self, mnr, cls_name)
+    def setup(self, mnr, p, boxsize, leafsize):
+        Query.do_setup(self, mnr, p, boxsize, leafsize)
 
-    def time_query(self, mnr, cls_name):
+    def time_query(self, mnr, p, boxsize, leafsize):
         """
         Querying kd-tree
         dim | # points | # queries |  KDTree  | cKDTree | flat cKDTree
         """
-        self.T.query(self.queries)
+        self.T.query(self.queries, p=p)
 
 
 class Radius(Benchmark):
     params = [
         [(3,10000,1000)],
+        [1, 2, np.inf],
         [0.2, 0.5],
-        ['KDTree', 'cKDTree', 'cKDTree_flat'],
+        BoxSize, LeafSize,
     ]
-    param_names = ['(m, n, r)', 'probe radius', 'class']
+    param_names = ['(m, n, r)', 'p', 'probe radius', 'boxsize', 'leafsize']
 
     def __init__(self):
         self.time_query_pairs.__func__.params = list(self.params)
@@ -90,14 +87,14 @@ class Radius(Benchmark):
                                                     (8,1000,30),
                                                     (16,1000,30)]
 
-    def setup(self, mnr, probe_radius, cls_name):
-        Query.do_setup(self, mnr, cls_name)
+    def setup(self, mnr, p, probe_radius, boxsize, leafsize):
+        Query.do_setup(self, mnr, p, boxsize, leafsize)
 
-    def time_query_ball_point(self, mnr, probe_radius, cls_name):
-        self.T.query_ball_point(self.queries, probe_radius)
+    def time_query_ball_point(self, mnr, p, probe_radius, boxsize, leafsize):
+        self.T.query_ball_point(self.queries, probe_radius, p=p)
 
-    def time_query_pairs(self, mnr, probe_radius, cls_name):
-        self.T.query_pairs(probe_radius)
+    def time_query_pairs(self, mnr, p, probe_radius, boxsize, leafsize):
+        self.T.query_pairs(probe_radius, p=p)
 
 
 class Neighbors(Benchmark):
@@ -105,30 +102,27 @@ class Neighbors(Benchmark):
         [(3,1000,1000),
          (8,1000,1000),
          (16,1000,1000)],
+        [1, 2, np.inf],
         [0.2, 0.5],
-        ['KDTree', 'cKDTree'],
+        BoxSize, LeafSize,
     ]
-    param_names = ['(m, n1, n2)', 'probe radius', 'class']
+    param_names = ['(m, n1, n2)', 'p', 'probe radius', 'boxsize', 'leafsize']
 
-    def setup(self, mn1n2, probe_radius, cls_str):
+    def setup(self, mn1n2, p, probe_radius, boxsize, leafsize):
         m, n1, n2 = mn1n2
 
-        cls = KDTree if cls_str == 'KDTree' else cKDTree
+        self.data1 = np.random.uniform(size=(n1, m))
+        self.data2 = np.random.uniform(size=(n2, m))
 
-        data1 = np.concatenate((np.random.randn(n1//2,m),
-                                np.random.randn(n1-n1//2,m)+np.ones(m)))
-        data2 = np.concatenate((np.random.randn(n2//2,m),
-                                np.random.randn(n2-n2//2,m)+np.ones(m)))
+        self.T1 = cKDTree(self.data1, boxsize=boxsize, leafsize=leafsize)
+        self.T2 = cKDTree(self.data2, boxsize=boxsize, leafsize=leafsize)
 
-        self.T1 = cls(data1)
-        self.T2 = cls(data2)
+    def time_sparse_distance_matrix(self, mn1n2, p, probe_radius, boxsize, leafsize):
+        self.T1.sparse_distance_matrix(self.T2, probe_radius, p=p)
 
-    def time_sparse_distance_matrix(self, mn1n2, probe_radius, cls_str):
-        self.T1.sparse_distance_matrix(self.T2, probe_radius)
-
-    def time_count_neighbors(self, mn1n2, probe_radius, cls_str):
+    def time_count_neighbors(self, mn1n2, p, probe_radius, boxsize, leafsize):
         """
         Count neighbors kd-tree
-        dim | # points T1 | # points T2 | probe radius |  KDTree  | cKDTree
+        dim | # points T1 | # points T2 | p | probe radius |  BoxSize | LeafSize
         """
-        self.T1.count_neighbors(self.T2, probe_radius)
+        self.T1.count_neighbors(self.T2, probe_radius, p=p)

--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -40,13 +40,14 @@ class Build(Benchmark):
         else:
             self.cls(self.data)
 
-LeafSize = [8, 128]
-BoxSize = [None, 1.0]
+LEAF_SIZES = [8, 128]
+BOX_SIZES = [None, 1.0]
+
 class Query(Benchmark):
     params = [
         [(3,10000,1000), (8,10000,1000), (16,10000,1000)],
         [1, 2, np.inf],
-        BoxSize, LeafSize,
+        BOX_SIZES, LEAF_SIZES,
     ]
     param_names = ['(m, n, r)', 'p', 'boxsize', 'leafsize']
 
@@ -77,7 +78,7 @@ class Radius(Benchmark):
         [(3,10000,1000)],
         [1, 2, np.inf],
         [0.2, 0.5],
-        BoxSize, LeafSize,
+        BOX_SIZES, LEAF_SIZES,
     ]
     param_names = ['(m, n, r)', 'p', 'probe radius', 'boxsize', 'leafsize']
 
@@ -104,7 +105,7 @@ class Neighbors(Benchmark):
          (16,1000,1000)],
         [1, 2, np.inf],
         [0.2, 0.5],
-        BoxSize, LeafSize,
+        BOX_SIZES, LEAF_SIZES,
     ]
     param_names = ['(m, n1, n2)', 'p', 'probe radius', 'boxsize', 'leafsize']
 

--- a/scipy/spatial/ckdtree/src/query.cxx
+++ b/scipy/spatial/ckdtree/src/query.cxx
@@ -381,6 +381,12 @@ query_single_point(const ckdtree *self,
                 npy_float64 tmp = x[split_dim] - split; 
                 if(NPY_LIKELY(p == 2)) {
                     inf2->side_distances()[split_dim] = tmp * tmp;
+                } else
+                if(NPY_LIKELY(p == 1)) {
+                    inf2->side_distances()[split_dim] = dabs(tmp);
+                } else
+                if(NPY_LIKELY(ckdtree_isinf(p))) {
+                    inf2->side_distances()[split_dim] = dabs(tmp);
                 } else {
                     inf2->side_distances()[split_dim] = std::pow(dabs(tmp), p);
                 }


### PR DESCRIPTION
np.inf was not properly special cased, and pow(x, inf)
[ very slow on most libm, apparently] is used.
