### PR TITLE
[BUG WIP] Single linkage handles ties incorrectly

### DIFF
--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -1029,7 +1029,7 @@ def slink(double[:] dists, int n):
                 M[Pi[j]] = min(M[Pi[j]], M[j])
 
         for j in range(i):
-            if Lambda[j] >= Lambda[Pi[j]]:
+            if Lambda[j] > Lambda[Pi[j]]:
                 Pi[j] = i
 
     from_pointer_representation(Z, Lambda, Pi, n)

--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -385,7 +385,7 @@ cdef from_pointer_representation(double[:, :] Z, double[:] Lambda, int[:] Pi,
         The number of observations.
     """
     cdef int i, current_leaf, pi
-    cdef np.intp_t[:] sorted_idx = np.argsort(Lambda)
+    cdef np.intp_t[:] sorted_idx = np.argsort(Lambda, kind='merge')
     cdef int[:] node_ids = np.ndarray(n, dtype=np.intc)
 
     for i in range(n):

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -97,6 +97,35 @@ class TestLinkage(object):
         assert_allclose(Z, expectedZ, atol=1e-06)
 
 
+class TestLinkageTies(object):
+    _expectations = {
+        'single': np.array([[0, 1, 1.41421356, 2],
+                            [2, 3, 1.41421356, 3]]),
+        'complete': np.array([[0, 1, 1.41421356, 2],
+                              [2, 3, 2.82842712, 3]]),
+        'average': np.array([[0, 1, 1.41421356, 2],
+                             [2, 3, 2.12132034, 3]]),
+        'weighted': np.array([[0, 1, 1.41421356, 2],
+                              [2, 3, 2.12132034, 3]]),
+        'centroid': np.array([[0, 1, 1.41421356, 2],
+                              [2, 3, 2.12132034, 3]]),
+        'median': np.array([[0, 1, 1.41421356, 2],
+                            [2, 3, 2.12132034, 3]]),
+        'ward': np.array([[0, 1, 1.41421356, 2],
+                          [2, 3, 2.44948974, 3]]),
+    }
+
+    def test_linkage_ties(self):
+        for method in ['single', 'complete', 'average', 'weighted', 'centroid', 'median', 'ward']:
+            yield self.check_linkage_ties, method
+
+    def check_linkage_ties(self, method):
+        X = np.array([[-1, -1], [0, 0], [1, 1]])
+        Z = linkage(X, method=method)
+        expectedZ = self._expectations[method]
+        assert_allclose(Z, expectedZ, atol=1e-06)
+
+
 class TestInconsistent(object):
     def test_inconsistent_tdist(self):
         for depth in hierarchy_test_data.inconsistent_ytdist:


### PR DESCRIPTION
As stated by [Müllner](http://arxiv.org/abs/1109.2378) the vanilla SLINK algorithm cannot handle ties and therefore current scipy implementation of single linkage can give plain wrong results in their presence. Consider the following simple example (which I have added as a new test case):

``` python
from __future__ import print_function
import numpy as np
from scipy.cluster import hierarchy

X = np.array([[-1, -1],
              [0, 0],
              [1, 1]])
Z = hierarchy.single(X)
print('This is the linkage matrix:\n%r' % Z)

first_cluster = tuple(Z[0, 0:2])
if first_cluster == (0, 2):
    print('In no case should (0, 2) be a cluster.')
    d02 = np.sqrt(np.sum((X[0] - X[2]) ** 2))
    if np.abs(Z[0, 3] - d02) > 1E-6:
        print('Moreover, the distance between 0 and 2 is wrongly assigned in the stepwise dendrogram.')
```

The output is like this.

```
This is the linkage matrix:
array([[ 0.        ,  2.        ,  1.41421356,  2.        ],
       [ 1.        ,  3.        ,  1.41421356,  3.        ]])
In no case should (0, 2) be a cluster.
Moreover, the distance between 0 and 2 is wrongly assigned in the stepwise dendrogram.
```

I think we have a couple of options to get this fully correct: either ditch slink in favor of the MST algorithm for single linkage (as in fastcluster) or adapt SLINK to "make all dissimilarities artificially distinct" (see Müller paper page 24). This pull requests tries to go the second way, but with an even simpler approach than the one in Müller, and I still need to get convinced that it is correct. I will do later but, since this is somehow related to #5549, it would be great if @richardtsai or @nmayorov could comment.
