### PR TITLE
WIP, ENH: Improve FIR path of signal.decimate

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2914,6 +2914,9 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=None):
     if not isinstance(q, int):
         raise TypeError("q must be an integer")
 
+    if n is not None and not isinstance(n, int):
+        raise TypeError("n must be an integer")
+
     if ftype == 'fir':
         if n is None:
             n = 30
@@ -2929,12 +2932,11 @@ def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=None):
         raise ValueError('invalid ftype')
 
     if zero_phase is None:
-        warnings.warn("""
-                      Note: Decimate's zero_phase keyword argument will default
-                      to True in a future release.  Until then, decimate
-                      defaults to one-way filtering for backwards
-                      compatibility. Ideally, always set this argument
-                      explicitly.""", FutureWarning)
+        warnings.warn(" Note: Decimate's zero_phase keyword argument will "
+                      "default to True in a future release.  Until then, "
+                      "decimate defaults to 'one-way filtering for backwards "
+                      "compatibility. Ideally, always set this argument "
+                      "explicitly.", FutureWarning)
         zero_phase = False
 
     if zero_phase and ftype == 'fir':

--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -7,7 +7,7 @@ import warnings
 import threading
 import sys
 
-from . import sigtools
+from . import sigtools, lti
 from ._upfirdn import _UpFIRDn, _output_len
 from scipy._lib.six import callable
 from scipy._lib._version import NumpyVersion
@@ -23,8 +23,8 @@ import numpy as np
 from scipy.special import factorial
 from .windows import get_window
 from ._arraytools import axis_slice, axis_reverse, odd_ext, even_ext, const_ext
-from scipy.signal.filter_design import cheby1
-from scipy.signal.fir_filter_design import firwin
+from .filter_design import cheby1
+from .fir_filter_design import firwin
 
 if sys.version_info.major >= 3 and sys.version_info.minor >= 5:
     from math import gcd
@@ -2864,7 +2864,7 @@ def sosfilt(sos, x, axis=-1, zi=None):
     return out
 
 
-def decimate(x, q, n=None, ftype='iir', axis=-1):
+def decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=None):
     """
     Downsample the signal by using a filter.
 
@@ -2876,13 +2876,23 @@ def decimate(x, q, n=None, ftype='iir', axis=-1):
     x : ndarray
         The signal to be downsampled, as an N-dimensional array.
     q : int
-        The downsampling factor.
+        The downsampling factor. For downsampling factors higher than 13, it is
+        recommended to call `decimate` multiple times.
     n : int, optional
-        The order of the filter (1 less than the length for 'fir').
-    ftype : str {'iir', 'fir'}, optional
-        The type of the lowpass filter.
+        The order of the filter (1 less than the length for 'fir'). Defaults to
+        8 for 'iir' and 30 for 'fir'.
+    ftype : str {'iir', 'fir'} or ``lti`` instance, optional
+        If 'iir' or 'fir', specifies the type of lowpass filter. If an instance
+        of an `lti` object, uses that object to filter before downsampling.
     axis : int, optional
         The axis along which to decimate.
+    zero_phase : bool, optional
+        Prevent phase shift by filtering with `filtfilt` instead of `lfilter`
+        when `ftype` is not 'fir'.  A value of `True` is recommended, since a
+        phase shift is generally not desired. Using `None` defaults to `False`
+        for backwards compatibility.
+
+        .. versionadded:: 0.18.0
 
     Returns
     -------
@@ -2893,24 +2903,49 @@ def decimate(x, q, n=None, ftype='iir', axis=-1):
     --------
     resample
     resample_poly
+
+    Notes
+    -----
+    The ``zero_phase`` keyword was added in 0.18.0.
+    The possibility to use instances of ``lti`` as ``ftype`` was added in
+    0.18.0.
     """
 
     if not isinstance(q, int):
         raise TypeError("q must be an integer")
 
-    if n is None:
-        if ftype == 'fir':
-            n = 30
-        else:
-            n = 8
-
     if ftype == 'fir':
-        b = firwin(n + 1, 1. / q, window='hamming')
-        a = 1.
-    else:
-        b, a = cheby1(n, 0.05, 0.8 / q)
+        if n is None:
+            n = 30
+        system = lti(firwin(n + 1, 1. / q, window='hamming'), 1.)
 
-    y = lfilter(b, a, x, axis=axis)
+    elif ftype == 'iir':
+        if n is None:
+            n = 8
+        system = lti(*cheby1(n, 0.05, 0.8 / q))
+    elif isinstance(ftype, lti):
+        system = ftype
+    else:
+        raise ValueError('invalid ftype')
+
+    if zero_phase is None:
+        warnings.warn("""
+                      Note: Decimate's zero_phase keyword argument will default
+                      to True in a future release.  Until then, decimate
+                      defaults to one-way filtering for backwards
+                      compatibility. Ideally, always set this argument
+                      explicitly.""", FutureWarning)
+        zero_phase = False
+
+    if zero_phase and ftype == 'fir':
+        warnings.warn('zero_phase is not implemented for FIR downsampling, '
+                      'using zero_phase=False.')
+        zero_phase = False
+
+    if zero_phase:
+        y = filtfilt(system.num, system.den, x, axis=axis)
+    else:
+        y = lfilter(system.num, system.den, x, axis=axis)
 
     sl = [slice(None)] * y.ndim
     sl[axis] = slice(None, None, q)


### PR DESCRIPTION
This PR aims to relieve the phase shift due to the group delay of an FIR downsampling filter in signal.decimate (see gh-4929). It is not ready to go, but I wanted to get the ball rolling.

At first, I tried to be clever. Since an FIR filter only needs the input signal (not past outputs), and we only keep every q'th point, we don't need to calculate the output points that get thrown away. So, I tried implementing the downsampling and filtering via some strided array multiplication. 

It works, but it turns out that the multiplication in `np.dot` is twice as slow as a simple call to `lfilter` and throwing points away. Good job `lfilter`! In principle, it should save memory, since it doesn't have to copy the input signal, but I haven't really verified this. [Here is the code for anyone interested.](https://gist.github.com/e-q/e8b5e02dadee14e64ee0)

Anyways, all this PR does is use an odd extension to minimize edge effects (much as `filtfilt` does internally), and accounts for the filter's linear group delay when choosing the output point indices. 

Really, this isn't "zero_phase" in the way that the use of `filtfilt` is, but it is less phase shift, to be sure. The argument against using `filtfilt` with FIR downsampling would be the memory requirements, but it might be moot, since I think the implementation in this PR makes a copy of the input when calling `odd_ext`...
- [ ] gh-5392 needs to be merged
- [ ] Investigate memory implications of using `filtfilt`
- [ ] New tests
