### PR TITLE
ENH: special: faster way for calculating comb() for exact=True

### DIFF
--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -89,3 +89,11 @@ def set_mem_rlimit(max_mem=None):
         max_mem = min(max_mem, cur_limit[0])
 
     resource.setrlimit(resource.RLIMIT_AS, (max_mem, cur_limit[1]))
+
+
+def with_attributes(**attrs):
+    def decorator(func):
+        for key, value in attrs.items():
+            setattr(func, key, value)
+        return func
+    return decorator

--- a/benchmarks/benchmarks/special.py
+++ b/benchmarks/benchmarks/special.py
@@ -41,7 +41,7 @@ class Comb(Benchmark):
         self.N = np.arange(1, 1000, 50)
         self.k = np.arange(1, 1000, 50)
 
-    @with_attributes(params=[(10, 1000, 10000), (5, 50, 500)],
+    @with_attributes(params=[(10, 100, 1000, 10000), (1, 10, 100)],
                      param_names=['N', 'k'])
     def time_comb_exact(self, N, k):
         comb(N, k, exact=True)

--- a/benchmarks/benchmarks/special.py
+++ b/benchmarks/benchmarks/special.py
@@ -7,7 +7,13 @@ try:
 except ImportError:
     pass
 
-from .common import Benchmark
+try:
+    # wasn't always in scipy.special, so import separately
+    from scipy.special import comb
+except ImportError:
+    pass
+
+from .common import Benchmark, with_attributes
 
 
 class Airy(Benchmark):
@@ -27,3 +33,18 @@ class Erf(Benchmark):
 
     time_real.params = [0.0, 2.0]
     time_real.param_names = ['offset']
+
+
+class Comb(Benchmark):
+
+    def setup(self, *args):
+        self.N = np.arange(1, 1000, 50)
+        self.k = np.arange(1, 1000, 50)
+
+    @with_attributes(params=[(10, 1000, 10000), (5, 50, 500)],
+                     param_names=['N', 'k'])
+    def time_comb_exact(self, N, k):
+        comb(N, k, exact=True)
+
+    def time_comb_float(self):
+        comb(self.N[:,None], self.k[None,:])

--- a/scipy/special/_comb.pyx
+++ b/scipy/special/_comb.pyx
@@ -1,29 +1,25 @@
 cdef extern from "limits.h":
-    long LONG_MAX
+    unsigned long ULONG_MAX
 
-# Compute N choose k in integer arithmetic.
-def _comb(N, k):
-    cdef:
-        object numerator, denominator
-        object j, M, nterms
-    
-    if (k > N) or (N < 0) or (k < 0):
+
+def _comb_int(N, k):
+    # Fast path with machine integers
+    try:
+        r = _comb_int_long(N, k)
+        if r != 0:
+            return r
+    except (OverflowError, TypeError):
+        pass
+
+    # Fallback
+    N = int(N)
+    k = int(k)
+
+    if k > N or N < 0 or k < 0:
         return 0
 
     M = N + 1
     nterms = min(k, N - k)
-    
-    if nterms == 0:
-        return 1
-
-    if M < pow(LONG_MAX, 1./nterms):
-        # delegate to a fully typed version unless overflow
-        # The condition is rather loose: numerator < M**nterms
-        return _comb_int_unsafe(N, k)
-    elif M < LONG_MAX:
-        # both N and k fit into a C long, (but
-        # intermediaries would overflow)
-        return _comb_interm_obj(N, k)
 
     numerator = 1
     denominator = 1
@@ -34,44 +30,27 @@ def _comb(N, k):
     return numerator // denominator
 
 
-# N and k fit into a C long, use object intermediaries
-cdef object _comb_interm_obj(long N, long k):
-    cdef:
-        object numerator, denominator
-        long j, M, nterms
-    
-    if (k > N) or (N < 0) or (k < 0):
+cdef unsigned long _comb_int_long(unsigned long N, unsigned long k):
+    """
+    Compute binom(N, k) for integers.
+    Returns 0 if error/overflow encountered.
+    """
+    cdef unsigned long val, j, M, nterms
+
+    if k > N or N == ULONG_MAX:
         return 0
 
     M = N + 1
     nterms = min(k, N - k)
-    
-    numerator = 1
-    denominator = 1
+
+    val = 1
+
     for j in xrange(1, nterms + 1):
-        numerator *= M - j
-        denominator *= j
-        
-    return numerator // denominator
+        # Overflow check
+        if val > ULONG_MAX // (M - j):
+            return 0
 
+        val *= M - j
+        val //= j
 
-# not only N and k but also intermediaries fit into a C long
-cdef long _comb_int_unsafe(long N, long k):
-    cdef:
-        long numerator, denominator
-        long j, M, nterms
-    
-    if (k > N) or (N < 0) or (k < 0):
-        return 0
-
-    M = N + 1
-    nterms = min(k, N - k)  
-    
-    numerator = 1
-    denominator = 1
-    for j in xrange(1, nterms + 1):
-        numerator *= M - j
-        denominator *= j
-        
-    return numerator // denominator
-
+    return val

--- a/scipy/special/_comb.pyx
+++ b/scipy/special/_comb.pyx
@@ -1,0 +1,77 @@
+cdef extern from "limits.h":
+    long LONG_MAX
+
+# Compute N choose k in integer arithmetic.
+def _comb(N, k):
+    cdef:
+        object numerator, denominator
+        object j, M, nterms
+    
+    if (k > N) or (N < 0) or (k < 0):
+        return 0
+
+    M = N + 1
+    nterms = min(k, N - k)
+    
+    if nterms == 0:
+        return 1
+
+    if M < pow(LONG_MAX, 1./nterms):
+        # delegate to a fully typed version unless overflow
+        # The condition is rather loose: numerator < M**nterms
+        return _comb_int_unsafe(N, k)
+    elif M < LONG_MAX:
+        # both N and k fit into a C long, (but
+        # intermediaries would overflow)
+        return _comb_interm_obj(N, k)
+
+    numerator = 1
+    denominator = 1
+    for j in xrange(1, nterms + 1):
+        numerator *= M - j
+        denominator *= j
+
+    return numerator // denominator
+
+
+# N and k fit into a C long, use object intermediaries
+cdef object _comb_interm_obj(long N, long k):
+    cdef:
+        object numerator, denominator
+        long j, M, nterms
+    
+    if (k > N) or (N < 0) or (k < 0):
+        return 0
+
+    M = N + 1
+    nterms = min(k, N - k)
+    
+    numerator = 1
+    denominator = 1
+    for j in xrange(1, nterms + 1):
+        numerator *= M - j
+        denominator *= j
+        
+    return numerator // denominator
+
+
+# not only N and k but also intermediaries fit into a C long
+cdef long _comb_int_unsafe(long N, long k):
+    cdef:
+        long numerator, denominator
+        long j, M, nterms
+    
+    if (k > N) or (N < 0) or (k < 0):
+        return 0
+
+    M = N + 1
+    nterms = min(k, N - k)  
+    
+    numerator = 1
+    denominator = 1
+    for j in xrange(1, nterms + 1):
+        numerator *= M - j
+        denominator *= j
+        
+    return numerator // denominator
+

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -2125,10 +2125,13 @@ def comb(N, k, exact=False, repetition=False):
         k = int(k)
         if (k > N) or (N < 0) or (k < 0):
             return 0
-        val = 1
-        for j in xrange(min(k, N-k)):
-            val = (val*(N-j))//(j+1)
-        return val
+        numerator = 1
+        denominator = 1
+        M = N + 1
+        for j in xrange(1, min(k, N - k) + 1):
+            numerator *= M - j
+            denominator *= j
+        return numerator//denominator
     else:
         k, N = asarray(k), asarray(N)
         cond = (k <= N) & (N >= 0) & (k >= 0)

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -17,7 +17,7 @@ from ._ufuncs import (ellipkm1, mathieu_a, mathieu_b, iv, jv, gamma, psi, zeta,
                       errprint, poch, binom, hyp0f1)
 from . import specfun
 from . import orthogonal
-from ._comb import _comb
+from ._comb import _comb_int
 
 __all__ = ['agm', 'ai_zeros', 'assoc_laguerre', 'bei_zeros', 'beip_zeros',
            'ber_zeros', 'bernoulli', 'berp_zeros', 'bessel_diff_formula',
@@ -2122,9 +2122,7 @@ def comb(N, k, exact=False, repetition=False):
     if repetition:
         return comb(N + k - 1, k, exact)
     if exact:
-        N = int(N)
-        k = int(k)
-        return _comb(N, k)
+        return _comb_int(N, k)
     else:
         k, N = asarray(k), asarray(N)
         cond = (k <= N) & (N >= 0) & (k >= 0)

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -17,6 +17,7 @@ from ._ufuncs import (ellipkm1, mathieu_a, mathieu_b, iv, jv, gamma, psi, zeta,
                       errprint, poch, binom, hyp0f1)
 from . import specfun
 from . import orthogonal
+from ._comb import _comb
 
 __all__ = ['agm', 'ai_zeros', 'assoc_laguerre', 'bei_zeros', 'beip_zeros',
            'ber_zeros', 'bernoulli', 'berp_zeros', 'bessel_diff_formula',
@@ -2123,15 +2124,7 @@ def comb(N, k, exact=False, repetition=False):
     if exact:
         N = int(N)
         k = int(k)
-        if (k > N) or (N < 0) or (k < 0):
-            return 0
-        numerator = 1
-        denominator = 1
-        M = N + 1
-        for j in xrange(1, min(k, N - k) + 1):
-            numerator *= M - j
-            denominator *= j
-        return numerator//denominator
+        return _comb(N, k)
     else:
         k, N = asarray(k), asarray(N)
         cond = (k <= N) & (N >= 0) & (k >= 0)

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -104,6 +104,10 @@ def configuration(parent_package='',top_path=None):
                          **cfg
                          )
 
+    # combinatoris
+    config.add_extension('_comb',
+                         sources=['_comb.c'])
+
     config.add_data_files('tests/*.py')
     config.add_data_files('tests/data/README')
     config.add_data_files('tests/data/*.npz')

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1262,6 +1262,12 @@ class TestCombinatorics(TestCase):
         assert_equal(special.comb(10, 3, exact=True), 120)
         assert_equal(special.comb(10, 3, exact=True, repetition=True), 220)
 
+        assert_allclose([special.comb(20, k, exact=True) for k in range(21)],
+                        special.comb(20, list(range(21))), atol=1e-15)
+
+        ii = np.iinfo(int).max + 1
+        assert_equal(special.comb(ii, ii-1, exact=True), ii)
+
     def test_comb_with_np_int64(self):
         n = 70
         k = 30

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1268,6 +1268,9 @@ class TestCombinatorics(TestCase):
         ii = np.iinfo(int).max + 1
         assert_equal(special.comb(ii, ii-1, exact=True), ii)
 
+        expected = 100891344545564193334812497256
+        assert_equal(special.comb(100, 50, exact=True), expected)
+
     def test_comb_with_np_int64(self):
         n = 70
         k = 30


### PR DESCRIPTION
Cythonize the exact=True path for scipy.special.comb
Fixes gh-3449

```
  [3d938751] [ab1daa2f]
-  560.17ns   382.63ns      0.68  special.Comb.time_comb_exact(10, 100)
-    2.11μs     1.35μs      0.64  special.Comb.time_comb_exact(1000, 10)
-    2.39μs     1.42μs      0.59  special.Comb.time_comb_exact(10000, 10)
-   28.63μs    14.42μs      0.50  special.Comb.time_comb_exact(1000, 100)
-  818.32ns   400.76ns      0.49  special.Comb.time_comb_exact(100, 100)
-  913.81ns   422.43ns      0.46  special.Comb.time_comb_exact(1000, 1)
-  814.77ns   369.88ns      0.45  special.Comb.time_comb_exact(10, 10)
-  893.73ns   378.32ns      0.42  special.Comb.time_comb_exact(10000, 1)
-  896.24ns   378.52ns      0.42  special.Comb.time_comb_exact(100, 1)
-  936.60ns   378.86ns      0.40  special.Comb.time_comb_exact(10, 1)
-   38.90μs    15.29μs      0.39  special.Comb.time_comb_exact(10000, 100)
-    1.66μs   520.53ns      0.31  special.Comb.time_comb_exact(100, 10)
SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```
