### PR TITLE
Actually propagate nans through stats functions with nan_policy="propagate"

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1020,8 +1020,8 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
         a = ma.masked_invalid(a)
         return mstats_basic.skew(a, axis, bias)
 
-    if contains_nan and nan_policy == 'propagate':
-        return np.nan
+#    if contains_nan and nan_policy == 'propagate':
+#        return np.nan
 
     m2 = moment(a, 2, axis)
     m3 = moment(a, 3, axis)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1020,9 +1020,6 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
         a = ma.masked_invalid(a)
         return mstats_basic.skew(a, axis, bias)
 
-#    if contains_nan and nan_policy == 'propagate':
-#        return np.nan
-
     m2 = moment(a, 2, axis)
     m3 = moment(a, 3, axis)
     zero = (m2 == 0)
@@ -1093,9 +1090,6 @@ def kurtosis(a, axis=0, fisher=True, bias=True, nan_policy='propagate'):
     if contains_nan and nan_policy == 'omit':
         a = ma.masked_invalid(a)
         return mstats_basic.kurtosis(a, axis, fisher, bias)
-
-    if contains_nan and nan_policy == 'propagate':
-        return np.nan
 
     n = a.shape[axis]
     m2 = moment(a, 2, axis)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1187,10 +1187,6 @@ def describe(a, axis=0, ddof=1, bias=True, nan_policy='propagate'):
         a = ma.masked_invalid(a)
         return mstats_basic.describe(a, axis, ddof, bias)
 
-    if contains_nan and nan_policy == 'propagate':
-        res = np.zeros(6) * np.nan
-        return DescribeResult(*res)
-
     if a.size == 0:
         raise ValueError("The input must not be empty.")
     n = a.shape[axis]
@@ -1248,9 +1244,6 @@ def skewtest(a, axis=0, nan_policy='propagate'):
     if contains_nan and nan_policy == 'omit':
         a = ma.masked_invalid(a)
         return mstats_basic.skewtest(a, axis)
-
-    if contains_nan and nan_policy == 'propagate':
-        return SkewtestResult(np.nan, np.nan)
 
     if axis is None:
         a = np.ravel(a)
@@ -1320,9 +1313,6 @@ def kurtosistest(a, axis=0, nan_policy='propagate'):
     if contains_nan and nan_policy == 'omit':
         a = ma.masked_invalid(a)
         return mstats_basic.kurtosistest(a, axis)
-
-    if contains_nan and nan_policy == 'propagate':
-        return KurtosistestResult(np.nan, np.nan)
 
     n = float(a.shape[axis])
     if n < 5:
@@ -1402,9 +1392,6 @@ def normaltest(a, axis=0, nan_policy='propagate'):
     if contains_nan and nan_policy == 'omit':
         a = ma.masked_invalid(a)
         return mstats_basic.normaltest(a, axis)
-
-    if contains_nan and nan_policy == 'propagate':
-        return NormaltestResult(np.nan, np.nan)
 
     s, _ = skewtest(a, axis)
     k, _ = kurtosistest(a, axis)
@@ -2180,9 +2167,6 @@ def sem(a, axis=0, ddof=1, nan_policy='propagate'):
     if contains_nan and nan_policy == 'omit':
         a = ma.masked_invalid(a)
         return mstats_basic.sem(a, axis, ddof)
-
-    if contains_nan and nan_policy == 'propagate':
-        return np.nan
 
     n = a.shape[axis]
     s = np.std(a, axis=axis, ddof=ddof) / np.sqrt(n)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -970,9 +970,6 @@ def variation(a, axis=0, nan_policy='propagate'):
         a = ma.masked_invalid(a)
         return mstats_basic.variation(a, axis)
 
-    if contains_nan and nan_policy == 'propagate':
-        return np.nan
-
     return a.std(axis) / a.mean(axis)
 
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3040,9 +3040,6 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
         b = ma.masked_invalid(b)
         return mstats_basic.spearmanr(a, b, axis)
 
-    if contains_nan and nan_policy == 'propagate':
-        return SpearmanrResult(np.nan, np.nan)
-
     if a.size <= 1:
         return SpearmanrResult(np.nan, np.nan)
     ar = np.apply_along_axis(rankdata, axisout, a)
@@ -3056,9 +3053,6 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
         if contains_nan and nan_policy == 'omit':
             b = ma.masked_invalid(b)
             return mstats_basic.spearmanr(a, b, axis)
-
-        if contains_nan and nan_policy == 'propagate':
-            return SpearmanrResult(np.nan, np.nan)
 
         br = np.apply_along_axis(rankdata, axisout, b)
     n = a.shape[axisout]

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -868,9 +868,6 @@ def moment(a, moment=1, axis=0, nan_policy='propagate'):
         a = ma.masked_invalid(a)
         return mstats_basic.moment(a, moment, axis)
 
-    if contains_nan and nan_policy == 'propagate':
-        return np.nan
-
     if a.size == 0:
         # empty array, return nan(s) with shape matching `moment`
         if np.isscalar(moment):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1500,6 +1500,14 @@ class TestMoments(TestCase):
         assert_raises(ValueError, stats.variation, x, nan_policy='raise')
         assert_raises(ValueError, stats.variation, x, nan_policy='foobar')
 
+    def test_variation_propagate_nan(self):
+        # Check that the shape of the result is the same for inputs
+        # with and without nans, cf gh-5817
+        a = np.arange(8).reshape(2, -1).astype(float)
+        a[1, 0] = np.nan
+        vv = stats.variation(a, axis=1, nan_policy="propagate")
+        np.testing.assert_allclose(vv, [0.7453559924999299, np.nan], atol=1e-15)
+
     def test_skewness(self):
         # Scalar test case
         y = stats.skew(self.scalar_testcase)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -418,9 +418,6 @@ class TestCorrSpearmanr(TestCase):
     def test_nan_policy(self):
         x = np.arange(10.)
         x[9] = np.nan
-        assert_array_equal(stats.spearmanr(x, x), (np.nan, np.nan))
-        assert_array_equal(stats.spearmanr(X, x), (np.nan, np.nan))
-        assert_array_equal(stats.spearmanr(x, X), (np.nan, np.nan))
         assert_array_equal(stats.spearmanr(x, x, nan_policy='omit'),
                            (1.0, 0.0))
         assert_raises(ValueError, stats.spearmanr, x, x, nan_policy='raise')
@@ -2579,8 +2576,6 @@ class TestDescribe(TestCase):
 
         x = np.arange(10.)
         x[9] = np.nan
-        res = stats.describe(x)
-        assert_array_equal(res, np.zeros(6) * np.nan)
 
         nc, mmc = (9, (0.0, 8.0))
         mc = 4.0

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1570,6 +1570,14 @@ class TestMoments(TestCase):
     def test_kurtosis_array_scalar(self):
         assert_equal(type(stats.kurtosis([1,2,3])), float)
 
+    def test_kurtosis_propagate_nan(self):
+        # Check that the shape of the result is the same for inputs
+        # with and without nans, cf gh-5817
+        a = np.arange(8).reshape(2, -1).astype(float)
+        a[1, 0] = np.nan
+        k = stats.kurtosis(a, axis=1, nan_policy="propagate")
+        np.testing.assert_allclose(k, [-1.36, np.nan], atol=1e-15)
+
     def test_moment_accuracy(self):
         # 'moment' must have a small enough error compared to the slower
         #  but very accurate numpy.power() implementation.

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1532,6 +1532,14 @@ class TestMoments(TestCase):
         # `skew` must return a scalar for 1-dim input
         assert_equal(stats.skew(arange(10)), 0.0)
 
+    def test_skew_propagate_nan(self):
+        # Check that the shape of the result is the same for inputs
+        # with and without nans, cf gh-5817
+        a = np.arange(8).reshape(2, -1).astype(float)
+        a[1, 0] = np.nan
+        s = stats.skew(a, axis=1, nan_policy="propagate")
+        np.testing.assert_allclose(s, [0, np.nan], atol=1e-15)
+
     def test_kurtosis(self):
         # Scalar test case
         y = stats.kurtosis(self.scalar_testcase)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1472,10 +1472,18 @@ class TestMoments(TestCase):
 
         x = np.arange(10.)
         x[9] = np.nan
-        assert_equal(stats.moment(x), np.nan)
+        assert_equal(stats.moment(x, 2), np.nan)
         assert_almost_equal(stats.moment(x, nan_policy='omit'), 0.0)
         assert_raises(ValueError, stats.moment, x, nan_policy='raise')
         assert_raises(ValueError, stats.moment, x, nan_policy='foobar')
+
+    def test_moment_propagate_nan(self):
+        # Check that the shape of the result is the same for inputs
+        # with and without nans, cf gh-5817
+        a = np.arange(8).reshape(2, -1).astype(float)
+        a[1, 0] = np.nan
+        mm = stats.moment(a, 2, axis=1, nan_policy="propagate")
+        np.testing.assert_allclose(mm, [1.25, np.nan], atol=1e-15)
 
     def test_variation(self):
         # variation = samplestd / mean


### PR DESCRIPTION
Stop special-casing nan_policy="propagate" in reduction functions, so that the shape of the result does not depend on whether inputs contain nans or not.

closes gh-5817
