### PR TITLE
ENH: Improve FIR path of signal.decimate

### DIFF
--- a/benchmarks/benchmarks/signal_filtering.py
+++ b/benchmarks/benchmarks/signal_filtering.py
@@ -3,11 +3,28 @@ from __future__ import division, absolute_import, print_function
 import numpy as np
 
 try:
-    from scipy.signal import lfilter, firwin
+    from scipy.signal import lfilter, firwin, decimate
 except ImportError:
     pass
 
 from .common import Benchmark
+
+class Decimate(Benchmark):
+    param_names = ['q', 'ftype', 'zero_phase']
+    params = [
+        [2, 10, 30],
+        ['iir', 'fir'],
+        [True, False]
+    ]
+
+    def setup(self, q, ftype, zero_phase):
+        np.random.seed(123456)
+        sample_rate = 10000.
+        t = np.arange(int(1e6), dtype=np.float64) / sample_rate
+        self.sig = np.sin(2*np.pi*500*t) + 0.3 * np.sin(2*np.pi*4e3*t)
+
+    def time_decimate(self, q, ftype, zero_phase):
+        decimate(self.sig, q, ftype=ftype, zero_phase=zero_phase)
 
 
 class Lfilter(Benchmark):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1,5 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
+import sys
+
 from decimal import Decimal
 from itertools import product
 
@@ -19,6 +21,10 @@ from scipy.signal import (
     sosfilt_zi)
 from scipy.signal.signaltools import _filtfilt_gust
 
+if sys.version_info.major >= 3 and sys.version_info.minor >= 5:
+    from math import gcd
+else:
+    from fractions import gcd
 
 class _TestConvolve(TestCase):
 
@@ -583,7 +589,11 @@ class TestResample(TestCase):
         # Test polyphase resampling
         self._test_data(method='polyphase')
 
-    def _test_data(self, method):
+    def test_polyphase_extfilter(self):
+        # Test external specification of downsampling filter
+        self._test_data(method='polyphase', ext=True)
+
+    def _test_data(self, method, ext=False):
         # Test resampling of sinusoids and random noise (1-sec)
         rate = 100
         rates_to = [49, 50, 51, 99, 100, 101, 199, 200, 201]
@@ -599,7 +609,23 @@ class TestResample(TestCase):
             if method == 'fft':
                 y_resamps = signal.resample(x, rate_to, axis=-1)
             else:
-                y_resamps = signal.resample_poly(x, rate_to, rate, axis=-1)
+                if ext and rate_to != rate:
+                    # Match default window design
+                    g = gcd(rate_to, rate)
+                    up = rate_to // g
+                    down = rate // g
+                    max_rate = max(up, down)
+                    f_c = 1. / max_rate
+                    half_len = 10 * max_rate
+                    window = signal.firwin(2 * half_len + 1, f_c,
+                                           window=('kaiser', 5.0))
+                    polyargs = {'window': window}
+                else:
+                    polyargs = {}
+
+                y_resamps = signal.resample_poly(x, rate_to, rate, axis=-1,
+                                                 **polyargs)
+
             for y_to, y_resamp, freq in zip(y_tos, y_resamps, freqs):
                 if freq >= 0.5 * rate_to:
                     y_to.fill(0.)  # mostly low-passed away
@@ -607,7 +633,7 @@ class TestResample(TestCase):
                 else:
                     assert_array_equal(y_to.shape, y_resamp.shape)
                     corr = np.corrcoef(y_to, y_resamp)[0, 1]
-                    assert_(corr > 0.99, msg=corr)
+                    assert_(corr > 0.99, msg=(corr, rate, rate_to))
 
         # Random data
         rng = np.random.RandomState(0)
@@ -1536,6 +1562,9 @@ class TestDecimate(TestCase):
 
     def test_phaseshift_FIR(self):
         self._test_phaseshift(method='fir', zero_phase=False)
+
+    def test_zero_phase_FIR(self):
+        self._test_phaseshift(method='fir', zero_phase=True)
 
     def test_phaseshift_IIR(self):
         self._test_phaseshift(method='iir', zero_phase=False)


### PR DESCRIPTION
This PR aims to relieve the phase shift due to the group delay of an FIR downsampling filter in signal.decimate through the use of `resample_poly`.

This requires modifying `resample_poly` to accept arbitrary FIR filter coefficients, as `decimate` itself advertises that capability. A test for `resample_poly` has been added for this capability. Hopefully this isn't too much of a hack. (Thoughts, @Eric89GXL ?)
