### PR TITLE
minimize_neldermead() stop at user requested maxiter or maxfev

### DIFF
--- a/doc/release/0.18.0-notes.rst
+++ b/doc/release/0.18.0-notes.rst
@@ -118,6 +118,11 @@ cases. See pull request gh-6024 for details.
 A large suite of global optimization benchmarks has been added to 
 ``scipy/benchmarks/go_benchmark_functions``. See pull request gh-4191 for details.
 
+Nelder-Mead and Powell minimization will now only set defaults for
+maximum iterations or function evaluations if neither limit is set by
+the caller. In some cases with a slow converging function and only 1
+limit set, the minimization may continue for longer than with previous
+versions and so is more likely to reach convergence. See issue gh-5966.
 
 `scipy.stats` improvements
 --------------------------

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2399,10 +2399,12 @@ def _minimize_powell(func, x0, args=(), callback=None,
         Relative error in solution `xopt` acceptable for convergence.
     ftol : float
         Relative error in ``fun(xopt)`` acceptable for convergence.
-    maxiter : int
-        Maximum number of iterations to perform.
-    maxfev : int
-        Maximum number of function evaluations to make.
+    maxiter, maxfev : int
+        Maximum allowed number of iterations and function evaluations.
+        Will default to ``N*1000``, where ``N`` is the number of
+        variables, if neither `maxiter` or `maxfev` is set. If both
+        `maxiter` and `maxfev` are set, minimization will stop at the
+        first reached.
     direc : ndarray
         Initial set of direction vectors for the Powell method.
 
@@ -2417,10 +2419,22 @@ def _minimize_powell(func, x0, args=(), callback=None,
     if retall:
         allvecs = [x]
     N = len(x)
-    if maxiter is None:
+    # If neither are set, then set both to default
+    if maxiter is None and maxfun is None:
         maxiter = N * 1000
-    if maxfun is None:
         maxfun = N * 1000
+    elif maxiter is None:
+        # Convert remaining Nones, to np.inf, unless the other is np.inf, in
+        # which case use the default to avoid unbounded iteration
+        if maxfun == np.inf:
+            maxiter = N * 1000
+        else:
+            maxiter = np.inf
+    elif maxfun is None:
+        if maxiter == np.inf:
+            maxfun = N * 1000
+        else:
+            maxfun = np.inf
 
     if direc is None:
         direc = eye(N, dtype=float)

--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -415,10 +415,12 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     -------
     disp : bool
         Set to True to print convergence messages.
-    maxiter : int
-        Maximum number of iterations to perform.
-    maxfev : int
-        Maximum number of function evaluations to make.
+    maxiter, maxfev : int
+        Maximum allowed number of iterations and function evaluations.
+        Will default to ``N*200``, where ``N`` is the number of
+        variables, if neither `maxiter` or `maxfev` is set. If both
+        `maxiter` and `maxfev` are set, minimization will stop at the
+        first reached.
     initial_simplex : array_like of shape (N + 1, N)
         Initial simplex. If given, overrides `x0`.
         ``initial_simplex[j,:]`` should contain the coordinates of
@@ -430,6 +432,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     fatol : number, optional
         Absolute error in func(xopt) between iterations that is acceptable for
         convergence.
+
     """
     if 'ftol' in unknown_options:
         warnings.warn("ftol is deprecated for Nelder-Mead,"
@@ -490,10 +493,22 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     if retall:
         allvecs = [sim[0]]
 
-    if maxiter is None:
+    # If neither are set, then set both to default
+    if maxiter is None and maxfun is None:
         maxiter = N * 200
-    if maxfun is None:
         maxfun = N * 200
+    elif maxiter is None:
+        # Convert remaining Nones, to np.inf, unless the other is np.inf, in
+        # which case use the default to avoid unbounded iteration
+        if maxfun == np.inf:
+            maxiter = N * 200
+        else:
+            maxiter = np.inf
+    elif maxfun is None:
+        if maxiter == np.inf:
+            maxfun = N * 200
+        else:
+            maxfun = np.inf
 
     one2np1 = list(range(1, N + 1))
     fsim = numpy.zeros((N + 1,), float)


### PR DESCRIPTION
If the user sets maxiter, then don't stop when the default maxfev is
reached, and vice versa. Only use the defaults if neither maxiter or
maxfev has been set.

Fixes #5966

Changes from https://github.com/scipy/scipy/pull/5968
Use np.inf to signify no limit on maxiter or maxfev
Add documentation

The following test program shows the change for a selection of function calls with a slow to converge function.

```
#!/usr/bin/env python
import numpy as np
from numpy import sqrt, sin, arctan2
import scipy
import scipy.optimize
print scipy.__version__

def test_func(v):
    x,y = v
    r,t = sqrt(x**2+y**2), arctan2(x,y)
    a,b  = 20, 0.5
    pen = sin(r*a + t)+r*b
    return pen

opts = [{},
{"maxiter":5000},
{"maxfev":50},
{"maxfev":5000},
{"maxiter":2000, "maxfev":2000},
{"maxiter":5000, "maxfev":5000},
{"maxiter":5000, "maxfev":None},
{"maxiter":5000, "maxfev":np.inf},
]

print "maxiter\tmaxfev\titers\tfevs\tsuccess"
for n, opt in enumerate(opts):
    res = scipy.optimize.minimize(test_func, [1,1], method='Nelder-Mead', options=opt)
    print opt.get("maxiter", "-"),"\t",opt.get("maxfev","-"),"\t", res["nit"],"\t", res["nfev"],"\t", res["success"]
```

With 0.17.0

```
maxiter maxfev  iters   fevs    success
-       -       217     400     False
5000    -       217     400     False
-       50      26      50      False
-       5000    400     731     False
2000    2000    1092    2000    False
5000    5000    2114    3902    True
5000    None    217     400     False
5000    inf     2114    3902    True
```

With the patch i get 

```
maxiter maxfev  iters   fevs    success
-       -       217     400     False
5000    -       2114    3902    True
-       50      26      50      False
-       5000    2114    3902    True
2000    2000    1092    2000    False
5000    5000    2114    3902    True
5000    None    2114    3902    True
5000    inf     2114    3902    True
```

The only changes are that if the user has requested a large maxiter, or a large maxfev, the minimizer will now run to that number, rather than stopping early. This makes it more likely to reach convergence, but may cause it to take more time.
