### PR TITLE
ENH: make sparse `sum` cast dtypes like NumPy `sum` for 32-bit Python.

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -757,10 +757,11 @@ class spmatrix(object):
         # Mimic numpy's casting.
         if np.issubdtype(self.dtype, np.float_):
             res_dtype = np.float_
-        elif self.dtype.kind in 'ib':
-            res_dtype = np.int_
-        elif self.dtype.kind == 'u':
+        elif (self.dtype.kind == 'u' and
+              np.can_cast(self.dtype, np.uint)):
             res_dtype = np.uint
+        elif np.can_cast(self.dtype, np.int_):
+            res_dtype = np.int_
         else:
             res_dtype = self.dtype
 

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -567,10 +567,11 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             # Mimic numpy's casting.
             if np.issubdtype(self.dtype, np.float_):
                 res_dtype = np.float_
-            elif self.dtype.kind in 'ib':
-                res_dtype = np.int_
-            elif self.dtype.kind == 'u':
+            elif (self.dtype.kind == 'u' and
+                  np.can_cast(self.dtype, np.uint)):
                 res_dtype = np.uint
+            elif np.can_cast(self.dtype, np.int_):
+                res_dtype = np.int_
             else:
                 res_dtype = self.dtype
             ret = np.zeros(len(self.indptr) - 1, dtype=res_dtype)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -758,19 +758,22 @@ class _TestCommon:
         def check(dtype, j):
             dat = np.matrix(matrices[j], dtype=dtype)
             datsp = self.spmatrix(dat, dtype=dtype)
-            assert_array_almost_equal(dat.sum(), datsp.sum())
-            assert_equal(dat.sum().dtype, datsp.sum().dtype)
-            assert_(np.isscalar(datsp.sum(axis=None)))
-            assert_array_almost_equal(dat.sum(axis=None), datsp.sum(axis=None))
-            assert_equal(dat.sum(axis=None).dtype, datsp.sum(axis=None).dtype)
-            assert_array_almost_equal(dat.sum(axis=0), datsp.sum(axis=0))
-            assert_equal(dat.sum(axis=0).dtype, datsp.sum(axis=0).dtype)
-            assert_array_almost_equal(dat.sum(axis=1), datsp.sum(axis=1))
-            assert_equal(dat.sum(axis=1).dtype, datsp.sum(axis=1).dtype)
-            assert_array_almost_equal(dat.sum(axis=-2), datsp.sum(axis=-2))
-            assert_equal(dat.sum(axis=-2).dtype, datsp.sum(axis=-2).dtype)
-            assert_array_almost_equal(dat.sum(axis=-1), datsp.sum(axis=-1))
-            assert_equal(dat.sum(axis=-1).dtype, datsp.sum(axis=-1).dtype)
+            with np.errstate(over='ignore'):
+                assert_array_almost_equal(dat.sum(), datsp.sum())
+                assert_equal(dat.sum().dtype, datsp.sum().dtype)
+                assert_(np.isscalar(datsp.sum(axis=None)))
+                assert_array_almost_equal(dat.sum(axis=None),
+                                          datsp.sum(axis=None))
+                assert_equal(dat.sum(axis=None).dtype,
+                             datsp.sum(axis=None).dtype)
+                assert_array_almost_equal(dat.sum(axis=0), datsp.sum(axis=0))
+                assert_equal(dat.sum(axis=0).dtype, datsp.sum(axis=0).dtype)
+                assert_array_almost_equal(dat.sum(axis=1), datsp.sum(axis=1))
+                assert_equal(dat.sum(axis=1).dtype, datsp.sum(axis=1).dtype)
+                assert_array_almost_equal(dat.sum(axis=-2), datsp.sum(axis=-2))
+                assert_equal(dat.sum(axis=-2).dtype, datsp.sum(axis=-2).dtype)
+                assert_array_almost_equal(dat.sum(axis=-1), datsp.sum(axis=-1))
+                assert_equal(dat.sum(axis=-1).dtype, datsp.sum(axis=-1).dtype)
 
         for dtype in self.checked_dtypes:
             for j in range(len(matrices)):


### PR DESCRIPTION
This fix should ensure that sparse matrix sum behaves like NumPy dense
matrix sum in terms of dtype casting for 32-bit Python as well as
64-bit Python. Should fix #5972.
