### PR TITLE
BUG, API: Add `jac` parameter to curve_fit

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -465,7 +465,7 @@ def _wrap_jac(jac, xdata, weights):
             return jac(xdata, *params)
     else:
         def jac_wrapped(params):
-            return weights[:, np.newaxis] * jac(xdata, *params)
+            return weights[:, np.newaxis] * np.asarray(jac(xdata, *params))
     return jac_wrapped
 
 
@@ -548,11 +548,11 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         .. versionadded:: 0.17
     jac : callable, string or None, optional
         Function with signature ``jac(x, ...)`` which computes the Jacobian
-        matrix of the model function with respect to parameters. It will be
-        scaled according to provided `sigma`. If None (default), the Jacobian
-        will be estimated numerically. You may also use string keywords to
-        select a finite difference scheme for 'trf' and 'dogbox' methods,
-        see `least_squares`.
+        matrix of the model function with respect to parameters as a dense
+        array_like structure. It will be scaled according to provided `sigma`.
+        If None (default), the Jacobian will be estimated numerically.
+        String keywords for 'trf' and 'dogbox' methods can be used to select
+        a finite difference scheme, see `least_squares`.
 
         .. versionadded:: 0.18
     kwargs

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -470,6 +470,42 @@ class TestCurveFit(TestCase):
             # If the initial guess is ignored, then popt_2 would be close 0.
             assert_allclose(popt_1, popt_2)
 
+    def test_jac(self):
+        # Test that Jacobian callable is handled correctly and
+        # weighted if sigma is provided.
+        def f(x, a, b):
+            return a * np.exp(-b*x)
+
+        def jac(x, a, b):
+            e = np.exp(-b*x)
+            return np.vstack((e, -a * x * e)).T
+
+        xdata = np.linspace(0, 1, 11)
+        ydata = f(xdata, 2., 2.)
+
+        # Test numerical options for least_squares backend.
+        for method in ['trf', 'dogbox']:
+            for scheme in ['2-point', '3-point', 'cs']:
+                popt, pcov = curve_fit(f, xdata, ydata, jac=scheme,
+                                       method=method)
+                assert_allclose(popt, [2, 2])
+
+        # Test the analytic option.
+        for method in ['lm', 'trf', 'dogbox']:
+            popt, pcov = curve_fit(f, xdata, ydata, method=method, jac=jac)
+            assert_allclose(popt, [2, 2])
+
+        # Now add an outlier and provide sigma.
+        ydata[5] = 100
+        sigma = np.ones(xdata.shape[0])
+        sigma[5] = 200
+        for method in ['lm', 'trf', 'dogbox']:
+            popt, pcov = curve_fit(f, xdata, ydata, sigma=sigma, method=method,
+                                   jac=jac)
+            # Still the optimization process is influenced somehow,
+            # have to set rtol=1e-3.
+            assert_allclose(popt, [2, 2], rtol=1e-3)
+
 
 class TestFixedPoint(TestCase):
 


### PR DESCRIPTION
Hi!

This PR is motivated by #5068. I decided that it's cleaner to add `jac` parameter explicitly to API. The description of `jac` in docstring was kept rather short.
