### PR TITLE
BUG: read tries to handle 20-bit WAV files but shouldn't

### DIFF
--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -201,9 +201,9 @@ def read(filename, mmap=False):
             if chunk_id == b'fmt ':
                 fmt_chunk_received = True
                 size, comp, noc, rate, sbytes, ba, bits = _read_fmt_chunk(fid, is_big_endian=is_big_endian)
-                if bits == 24:
+                if bits not in (8, 16, 32, 64, 128):
                     raise ValueError("Unsupported bit depth: the wav file "
-                                     "has 24 bit data.")
+                                     "has {}-bit data.".format(bits))
             elif chunk_id == b'fact':
                 _skip_unknown_chunk(fid, is_big_endian=is_big_endian)
             elif chunk_id == b'data':


### PR DESCRIPTION
Audition can save WAV files as "24-bit packed int (type 1, 20-bit)" format where each sample is 3 bytes and BitsPerSample = 0x14 = 20.  SciPy tries to open it and interprets it as 16-bit and it's all screwed up.  Changed the handling to only accept bits per sample that align with numpy int types.

I guess it would be better if it read the byte lengths from numpy itself instead of a hardcoded list?

Though better yet would be to read _any_ bit depth of file and store it as the next-highest numpy int type.

(And should also have a `norm=True` or something option that converts every type to normalized floating point from -1 to +1 so you don't have to do that yourself, same as scikits.audiolab.)
