### PR TITLE
COMPAT: Expand compatibility fromnumeric.py

### DIFF
--- a/doc/release/0.18.0-notes.rst
+++ b/doc/release/0.18.0-notes.rst
@@ -49,6 +49,14 @@ zero-phase low-pass FIR filter, and downsamples using `scipy.signal.upfirdn`.
 This method can be faster than FFT-based filtering provided by
 `scipy.signal.resample` for some signals.
 
+`scipy.sparse` compatibility improvements
+-----------------------------------------
+
+The functions `sum`, `max`, `mean`, `min`, `transpose`, and `reshape` in
+`scipy.sparse` have had their signatures augmented with additional arguments
+and functionality so as to improve compatibility with analogously defined
+functions in `numpy`.
+
 Deprecated features
 ===================
 

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -103,9 +103,16 @@ There are seven available sparse matrix types:
     7. dia_matrix: DIAgonal format
 
 To construct a matrix efficiently, use either dok_matrix or lil_matrix.
-The lil_matrix class supports basic slicing and fancy
-indexing with a similar syntax to NumPy arrays.  As illustrated below,
-the COO format may also be used to efficiently construct matrices.
+The lil_matrix class supports basic slicing and fancy indexing with a
+similar syntax to NumPy arrays. As illustrated below, the COO format
+may also be used to efficiently construct matrices. Despite their
+similarity to NumPy arrays, it is **strongly discouraged** to use NumPy
+functions directly on these matrices because NumPy may not properly convert
+them for computations, leading to unexpected (and incorrect) results. If you
+do want to apply a NumPy function to these matrices, first check if SciPy has
+its own implementation for the given sparse matrix class, or **convert the
+sparse matrix to a NumPy array** (e.g. using the `toarray()` method of the
+class) first before applying the method.
 
 To perform manipulations such as multiplication or inversion, first
 convert the matrix to either CSC or CSR format. The lil_matrix format is

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -235,9 +235,17 @@ class coo_matrix(_data_matrix, _minmax_mixin):
             if self.col.min() < 0:
                 raise ValueError('negative column index found')
 
-    def transpose(self, copy=False):
-        M,N = self.shape
-        return coo_matrix((self.data, (self.col, self.row)), shape=(N,M), copy=copy)
+    def transpose(self, axes=None, copy=False):
+        if axes is not None:
+            raise ValueError(("Sparse matrices do not support "
+                              "an 'axes' parameter because swapping "
+                              "dimensions is the only logical permutation."))
+
+        M, N = self.shape
+        return coo_matrix((self.data, (self.col, self.row)),
+                          shape=(N, M), copy=copy)
+
+    transpose.__doc__ = spmatrix.transpose.__doc__
 
     def toarray(self, order=None, out=None):
         """See the docstring for `spmatrix.toarray`."""

--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -109,10 +109,19 @@ class csc_matrix(_cs_matrix, IndexMixin):
     """
     format = 'csc'
 
-    def transpose(self, copy=False):
+    def transpose(self, axes=None, copy=False):
+        if axes is not None:
+            raise ValueError(("Sparse matrices do not support "
+                              "an 'axes' parameter because swapping "
+                              "dimensions is the only logical permutation."))
+
+        M, N = self.shape
+
         from .csr import csr_matrix
-        M,N = self.shape
-        return csr_matrix((self.data,self.indices,self.indptr),(N,M),copy=copy)
+        return csr_matrix((self.data, self.indices,
+                           self.indptr), (N, M), copy=copy)
+
+    transpose.__doc__ = spmatrix.transpose.__doc__
 
     def __iter__(self):
         csr = self.tocsr()

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -128,10 +128,19 @@ class csr_matrix(_cs_matrix, IndexMixin):
     """
     format = 'csr'
 
-    def transpose(self, copy=False):
+    def transpose(self, axes=None, copy=False):
+        if axes is not None:
+            raise ValueError(("Sparse matrices do not support "
+                              "an 'axes' parameter because swapping "
+                              "dimensions is the only logical permutation."))
+
+        M, N = self.shape
+
         from .csc import csc_matrix
-        M,N = self.shape
-        return csc_matrix((self.data,self.indices,self.indptr), shape=(N,M), copy=copy)
+        return csc_matrix((self.data, self.indices,
+                           self.indptr), shape=(N, M), copy=copy)
+
+    transpose.__doc__ = spmatrix.transpose.__doc__
 
     def tolil(self, copy=False):
         from .lil import lil_matrix

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -8,13 +8,12 @@
 
 from __future__ import division, print_function, absolute_import
 
-__all__ = []
-
-
 import numpy as np
 
 from .base import spmatrix, _ufuncs_with_fixed_point_at_zero
-from .sputils import isscalarlike
+from .sputils import isscalarlike, validateaxis
+
+__all__ = []
 
 
 # TODO implement all relevant operations
@@ -26,9 +25,9 @@ class _data_matrix(spmatrix):
     def _get_dtype(self):
         return self.data.dtype
 
-    def _set_dtype(self,newtype):
+    def _set_dtype(self, newtype):
         self.data.dtype = newtype
-    dtype = property(fget=_get_dtype,fset=_set_dtype)
+    dtype = property(fget=_get_dtype, fset=_set_dtype)
 
     def _deduped_data(self):
         if hasattr(self, 'sum_duplicates'):
@@ -79,11 +78,11 @@ class _data_matrix(spmatrix):
     def power(self, n, dtype=None):
         """
         This function performs element-wise power.
-        
+
         Parameters
         ----------
         n : n is a scalar
-        
+
         dtype : If dtype is not specified, the current dtype will be preserved.
         """
         if not isscalarlike(n):
@@ -152,7 +151,13 @@ class _minmax_mixin(object):
             return coo_matrix((value, (major_index, np.zeros(len(value)))),
                               dtype=self.dtype, shape=(M, 1))
 
-    def _min_or_max(self, axis, min_or_max):
+    def _min_or_max(self, axis, out, min_or_max):
+        if out is not None:
+            raise ValueError(("Sparse matrices do not support "
+                              "an 'out' parameter."))
+
+        validateaxis(axis)
+
         if axis is None:
             if 0 in self.shape:
                 raise ValueError("zero-size array to reduction operation")
@@ -167,31 +172,72 @@ class _minmax_mixin(object):
 
         if axis < 0:
             axis += 2
+
         if (axis == 0) or (axis == 1):
             return self._min_or_max_axis(axis, min_or_max)
         else:
-            raise ValueError("invalid axis, use 0 for rows, or 1 for columns")
+            raise ValueError("axis out of range")
 
-    def max(self, axis=None):
-        """Maximum of the elements of this matrix.
-
+    def max(self, axis=None, out=None):
+        """
+        Return the maximum of the matrix or maximum along an axis.
         This takes all elements into account, not just the non-zero ones.
+
+        Parameters
+        ----------
+        axis : {-2, -1, 0, 1, None} optional
+            Axis along which the sum is computed. The default is to
+            compute the maximum over all the matrix elements, returning
+            a scalar (i.e. `axis` = `None`).
+
+        out : None, optional
+            This argument is in the signature *solely* for NumPy
+            compatibility reasons. Do not pass in anything except
+            for the default value, as this argument is not used.
 
         Returns
         -------
-        amax : self.dtype
-            Maximum element.
+        amax : coo_matrix or scalar
+            Maximum of `a`. If `axis` is None, the result is a scalar value.
+            If `axis` is given, the result is a sparse.coo_matrix of dimension
+            ``a.ndim - 1``.
+
+        See Also
+        --------
+        min : The minimum value of a sparse matrix along a given axis.
+        np.matrix.max : NumPy's implementation of 'max' for matrices
+
         """
-        return self._min_or_max(axis, np.maximum)
+        return self._min_or_max(axis, out, np.maximum)
 
-    def min(self, axis=None):
-        """Minimum of the elements of this matrix.
-
+    def min(self, axis=None, out=None):
+        """
+        Return the minimum of the matrix or maximum along an axis.
         This takes all elements into account, not just the non-zero ones.
+
+        Parameters
+        ----------
+        axis : {-2, -1, 0, 1, None} optional
+            Axis along which the sum is computed. The default is to
+            compute the minimum over all the matrix elements, returning
+            a scalar (i.e. `axis` = `None`).
+
+        out : None, optional
+            This argument is in the signature *solely* for NumPy
+            compatibility reasons. Do not pass in anything except for
+            the default value, as this argument is not used.
 
         Returns
         -------
-        amin : self.dtype
-            Minimum element.
+        amin : coo_matrix or scalar
+            Minimum of `a`. If `axis` is None, the result is a scalar value.
+            If `axis` is given, the result is a sparse.coo_matrix of dimension
+            ``a.ndim - 1``.
+
+        See Also
+        --------
+        max : The maximum value of a sparse matrix along a given axis.
+        np.matrix.min : NumPy's implementation of 'min' for matrices
+
         """
-        return self._min_or_max(axis, np.minimum)
+        return self._min_or_max(axis, out, np.minimum)

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -414,14 +414,21 @@ class dok_matrix(spmatrix, IndexMixin, dict):
     # perhaps it should be the number of rows?  For now it returns the number
     # of non-zeros.
 
-    def transpose(self):
-        """ Return the transpose
-        """
+    def transpose(self, axes=None, copy=False):
+        if axes is not None:
+            raise ValueError(("Sparse matrices do not support "
+                              "an 'axes' parameter because swapping "
+                              "dimensions is the only logical permutation."))
+
         M, N = self.shape
-        new = dok_matrix((N, M), dtype=self.dtype)
+        new = dok_matrix((N, M), dtype=self.dtype, copy=copy)
+
         for key, value in iteritems(self):
             new[key[1], key[0]] = value
+
         return new
+
+    transpose.__doc__ = spmatrix.transpose.__doc__
 
     def conjtransp(self):
         """ Return the conjugate transpose

--- a/scipy/sparse/sputils.py
+++ b/scipy/sparse/sputils.py
@@ -3,23 +3,15 @@
 
 from __future__ import division, print_function, absolute_import
 
-__all__ = [
-    'upcast', 'getdtype', 'isscalarlike', 'isintlike', 'isshape', 'issequence',
-    'isdense', 'ismatrix', 'get_sum_dtype'
-]
-
 import warnings
 import numpy as np
 
-from scipy._lib._version import NumpyVersion
+__all__ = ['upcast', 'getdtype', 'isscalarlike', 'isintlike',
+           'isshape', 'issequence', 'isdense', 'ismatrix', 'get_sum_dtype']
 
-# keep this list syncronized with sparsetools
-#supported_dtypes = ['bool', 'int8', 'uint8', 'int16', 'uint16', 'int32', 'uint32',
-#        'int64', 'uint64', 'float32', 'float64',
-#        'complex64', 'complex128']
-supported_dtypes = ['bool', 'int8','uint8','short','ushort','intc','uintc',
-        'longlong','ulonglong','single','double','longdouble',
-        'csingle','cdouble','clongdouble']
+supported_dtypes = ['bool', 'int8', 'uint8', 'short', 'ushort', 'intc',
+                    'uintc', 'longlong', 'ulonglong', 'single', 'double',
+                    'longdouble', 'csingle', 'cdouble', 'clongdouble']
 supported_dtypes = [np.typeDict[x] for x in supported_dtypes]
 
 _upcast_memo = {}
@@ -97,7 +89,7 @@ def downcast_intp_index(arr):
 
 
 def to_native(A):
-    return np.asarray(A,dtype=A.dtype.newbyteorder('native'))
+    return np.asarray(A, dtype=A.dtype.newbyteorder('native'))
 
 
 def getdtype(dtype, a=None, default=None):
@@ -107,7 +99,7 @@ def getdtype(dtype, a=None, default=None):
     are both None, construct a data type out of the 'default' parameter.
     Furthermore, 'dtype' must be in 'allowed' set.
     """
-    #TODO is this really what we want?
+    # TODO is this really what we want?
     if dtype is None:
         try:
             newdtype = a.dtype
@@ -166,7 +158,8 @@ def get_index_dtype(arrays=(), maxval=None, check_contents=False):
                 elif np.issubdtype(arr.dtype, np.integer):
                     maxval = arr.max()
                     minval = arr.min()
-                    if minval >= np.iinfo(np.int32).min and maxval <= np.iinfo(np.int32).max:
+                    if (minval >= np.iinfo(np.int32).min and
+                            maxval <= np.iinfo(np.int32).max):
                         # a bigger type not needed
                         continue
 
@@ -220,17 +213,42 @@ def isshape(x):
 
 
 def issequence(t):
-    return (isinstance(t, (list, tuple)) and (len(t) == 0 or np.isscalar(t[0]))) \
-           or (isinstance(t, np.ndarray) and (t.ndim == 1))
+    return ((isinstance(t, (list, tuple)) and
+            (len(t) == 0 or np.isscalar(t[0]))) or
+            (isinstance(t, np.ndarray) and (t.ndim == 1)))
 
 
 def ismatrix(t):
-    return ((isinstance(t, (list, tuple)) and len(t) > 0 and issequence(t[0]))
-            or (isinstance(t, np.ndarray) and t.ndim == 2))
+    return ((isinstance(t, (list, tuple)) and
+             len(t) > 0 and issequence(t[0])) or
+            (isinstance(t, np.ndarray) and t.ndim == 2))
 
 
 def isdense(x):
     return isinstance(x, np.ndarray)
+
+
+def validateaxis(axis):
+    if axis is not None:
+        axis_type = type(axis)
+
+        # In NumPy, you can pass in tuples for 'axis', but they are
+        # not very useful for sparse matrices given their limited
+        # dimensions, so let's make it explicit that they are not
+        # allowed to be passed in
+        if axis_type == tuple:
+            raise TypeError(("Tuples are not accepted for the 'axis' "
+                             "parameter. Please pass in one of the "
+                             "following: {-2, -1, 0, 1, None}."))
+
+        # If not a tuple, check that the provided axis is actually
+        # an integer and raise a TypeError similar to NumPy's
+        if not np.issubdtype(np.dtype(axis_type), np.integer):
+            raise TypeError("axis must be an integer, not {name}"
+                            .format(name=axis_type.__name__))
+
+        if not (-2 <= axis <= 1):
+            raise ValueError("axis out of range")
 
 
 class IndexMixin(object):
@@ -315,9 +333,10 @@ class IndexMixin(object):
         # Supporting sparse boolean indexing with both row and col does
         # not work because spmatrix.ndim is always 2.
         if isspmatrix(row) or isspmatrix(col):
-            raise IndexError("Indexing with sparse matrices is not supported"
-                    " except boolean indexing where matrix and index are equal"
-                    " shapes.")
+            raise IndexError(
+                "Indexing with sparse matrices is not supported "
+                "except boolean indexing where matrix and index "
+                "are equal shapes.")
         if isinstance(row, np.ndarray) and row.dtype.kind == 'b':
             row = self._boolean_index_to_array(row)
         if isinstance(col, np.ndarray) and col.dtype.kind == 'b':
@@ -334,14 +353,14 @@ class IndexMixin(object):
 
         i_slice = isinstance(i, slice)
         if i_slice:
-            i = self._slicetoarange(i, self.shape[0])[:,None]
+            i = self._slicetoarange(i, self.shape[0])[:, None]
         else:
             i = np.atleast_1d(i)
 
         if isinstance(j, slice):
-            j = self._slicetoarange(j, self.shape[1])[None,:]
+            j = self._slicetoarange(j, self.shape[1])[None, :]
             if i.ndim == 1:
-                i = i[:,None]
+                i = i[:, None]
             elif not i_slice:
                 raise IndexError('index returns 3-dim structure')
         elif isscalarlike(j):
@@ -361,8 +380,8 @@ class IndexMixin(object):
 
         if i.ndim == 1:
             # return column vectors for 1-D indexing
-            i = i[None,:]
-            j = j[None,:]
+            i = i[None, :]
+            j = j[None, :]
         elif i.ndim > 2:
             raise IndexError("Index dimension must be <= 2")
 

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -4,80 +4,90 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import (TestCase, run_module_suite, assert_equal,
-                           assert_array_equal)
+                           assert_raises)
 from scipy.sparse import sputils
 
 
 class TestSparseUtils(TestCase):
 
     def test_upcast(self):
-        assert_equal(sputils.upcast('intc'),np.intc)
-        assert_equal(sputils.upcast('int32','float32'),np.float64)
-        assert_equal(sputils.upcast('bool',complex,float),np.complex128)
-        assert_equal(sputils.upcast('i','d'),np.float64)
+        assert_equal(sputils.upcast('intc'), np.intc)
+        assert_equal(sputils.upcast('int32', 'float32'), np.float64)
+        assert_equal(sputils.upcast('bool', complex, float), np.complex128)
+        assert_equal(sputils.upcast('i', 'd'), np.float64)
 
     def test_getdtype(self):
-        A = np.array([1],dtype='int8')
+        A = np.array([1], dtype='int8')
 
-        assert_equal(sputils.getdtype(None,default=float),float)
-        assert_equal(sputils.getdtype(None,a=A),np.int8)
+        assert_equal(sputils.getdtype(None, default=float), float)
+        assert_equal(sputils.getdtype(None, a=A), np.int8)
 
     def test_isscalarlike(self):
-        assert_equal(sputils.isscalarlike(3.0),True)
-        assert_equal(sputils.isscalarlike(-4),True)
-        assert_equal(sputils.isscalarlike(2.5),True)
-        assert_equal(sputils.isscalarlike(1 + 3j),True)
-        assert_equal(sputils.isscalarlike(np.array(3)),True)
+        assert_equal(sputils.isscalarlike(3.0), True)
+        assert_equal(sputils.isscalarlike(-4), True)
+        assert_equal(sputils.isscalarlike(2.5), True)
+        assert_equal(sputils.isscalarlike(1 + 3j), True)
+        assert_equal(sputils.isscalarlike(np.array(3)), True)
         assert_equal(sputils.isscalarlike("16"), True)
 
         assert_equal(sputils.isscalarlike(np.array([3])), False)
         assert_equal(sputils.isscalarlike([[3]]), False)
         assert_equal(sputils.isscalarlike((1,)), False)
-        assert_equal(sputils.isscalarlike((1,2)), False)
+        assert_equal(sputils.isscalarlike((1, 2)), False)
 
     def test_isintlike(self):
-        assert_equal(sputils.isintlike(3.0),True)
-        assert_equal(sputils.isintlike(-4),True)
-        assert_equal(sputils.isintlike(np.array(3)),True)
+        assert_equal(sputils.isintlike(3.0), True)
+        assert_equal(sputils.isintlike(-4), True)
+        assert_equal(sputils.isintlike(np.array(3)), True)
         assert_equal(sputils.isintlike(np.array([3])), False)
 
-        assert_equal(sputils.isintlike(2.5),False)
-        assert_equal(sputils.isintlike(1 + 3j),False)
+        assert_equal(sputils.isintlike(2.5), False)
+        assert_equal(sputils.isintlike(1 + 3j), False)
         assert_equal(sputils.isintlike((1,)), False)
-        assert_equal(sputils.isintlike((1,2)), False)
+        assert_equal(sputils.isintlike((1, 2)), False)
 
     def test_isshape(self):
-        assert_equal(sputils.isshape((1,2)),True)
-        assert_equal(sputils.isshape((5,2)),True)
+        assert_equal(sputils.isshape((1, 2)), True)
+        assert_equal(sputils.isshape((5, 2)), True)
 
-        assert_equal(sputils.isshape((1.5,2)),False)
-        assert_equal(sputils.isshape((2,2,2)),False)
-        assert_equal(sputils.isshape(([2],2)),False)
+        assert_equal(sputils.isshape((1.5, 2)), False)
+        assert_equal(sputils.isshape((2, 2, 2)), False)
+        assert_equal(sputils.isshape(([2], 2)), False)
 
     def test_issequence(self):
-        assert_equal(sputils.issequence((1,)),True)
-        assert_equal(sputils.issequence((1,2,3)),True)
-        assert_equal(sputils.issequence([1]),True)
-        assert_equal(sputils.issequence([1,2,3]),True)
-        assert_equal(sputils.issequence(np.array([1,2,3])),True)
+        assert_equal(sputils.issequence((1,)), True)
+        assert_equal(sputils.issequence((1, 2, 3)), True)
+        assert_equal(sputils.issequence([1]), True)
+        assert_equal(sputils.issequence([1, 2, 3]), True)
+        assert_equal(sputils.issequence(np.array([1, 2, 3])), True)
 
-        assert_equal(sputils.issequence(np.array([[1],[2],[3]])),False)
-        assert_equal(sputils.issequence(3),False)
+        assert_equal(sputils.issequence(np.array([[1], [2], [3]])), False)
+        assert_equal(sputils.issequence(3), False)
 
     def test_ismatrix(self):
         assert_equal(sputils.ismatrix(((),)), True)
-        assert_equal(sputils.ismatrix([[1],[2]]), True)
+        assert_equal(sputils.ismatrix([[1], [2]]), True)
         assert_equal(sputils.ismatrix(np.arange(3)[None]), True)
 
-        assert_equal(sputils.ismatrix([1,2]), False)
+        assert_equal(sputils.ismatrix([1, 2]), False)
         assert_equal(sputils.ismatrix(np.arange(3)), False)
         assert_equal(sputils.ismatrix([[[1]]]), False)
         assert_equal(sputils.ismatrix(3), False)
 
     def test_isdense(self):
-        assert_equal(sputils.isdense(np.array([1])),True)
-        assert_equal(sputils.isdense(np.matrix([1])),True)
+        assert_equal(sputils.isdense(np.array([1])), True)
+        assert_equal(sputils.isdense(np.matrix([1])), True)
 
+    def test_validateaxis(self):
+        func = sputils.validateaxis
+
+        assert_raises(TypeError, func, (0, 1))
+        assert_raises(TypeError, func, 1.5)
+        assert_raises(ValueError, func, 3)
+
+        # These function calls should not raise errors
+        for axis in (-2, -1, 0, 1, None):
+            func(axis)
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Addresses issues in #5987 by fixing signature incompatibilities between functions defined in `numpy.core.fromnumeric` and similarly defined ones for `scipy.sparse` matrices by expanding the signatures in `scipy.sparse` to accommodate (and also implement) some of the functionality offered in `numpy`, in particular, these four functions:

1) `sum`
2) `mean`
3) `reshape`
4) `transpose`

cc @perimosocordiae 
