### PR TITLE
ENH: signal: implement `signal.planck` (Planck-taper window)

### DIFF
--- a/doc/release/0.18.0-notes.rst
+++ b/doc/release/0.18.0-notes.rst
@@ -49,6 +49,9 @@ zero-phase low-pass FIR filter, and downsamples using `scipy.signal.upfirdn`.
 This method can be faster than FFT-based filtering provided by
 `scipy.signal.resample` for some signals.
 
+The Planck-taper window function has been implemented and is now available as
+`scipy.signal.planck`.
+
 Deprecated features
 ===================
 

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -228,6 +228,7 @@ Window functions
    kaiser            -- Kaiser window
    nuttall           -- Nuttall's minimum 4-term Blackman-Harris window
    parzen            -- Parzen window
+   planck            -- Planck-taper window
    slepian           -- Slepian window
    triang            -- Triangular window
    tukey             -- Tukey window

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -30,6 +30,7 @@ window_funcs = [
     ('hann', ()),
     ('exponential', ()),
     ('tukey', (0.5,)),
+    ('planck', (0.3,)),
     ]
 
 
@@ -175,6 +176,34 @@ def test_tukey():
     assert_array_almost_equal(tuk1, han1)
 
 
+planck_data = {
+    # degenerate cases
+    (1, 0.1, False): array([1.0]),
+    (2, 0.1, False): array([1.0, 1.0]),
+    (3, 0.1, False): array([0.0, 1.0, 0.0]),
+    # check falloff at extreme epsilon
+    (5, 0.0, False): array([0., 1., 1., 1., 0.]),
+    (5, 0.5, False): array([0., 0.5, 1., 0.5, 0.]),
+    # symmetry
+    (6, 0.0, True): array([0., 1., 1., 1., 1., 0.]),
+    (6, 0.0, False): array([0., 1., 1., 1., 1., 1.]),
+    # regular values
+    (21, 0.3, False): array([0., 0.0081625711531599, 0.18242552380635635, 0.5, 0.81757447619364365,
+                             0.99183742884684012, 1., 1., 1., 1., 1., 1., 1., 1., 1.,
+                             0.99183742884684012, 0.81757447619364365, 0.5, 0.18242552380635635,
+                             0.0081625711531599, 0.])
+}
+
+def test_planck():
+    # Test against hardcoded data
+    for k, v in planck_data.items():
+        if v is None:
+            assert_raises(ValueError, signal.planck, *k)
+        else:
+            win = signal.planck(*k)
+            assert_allclose(win, v, rtol=1e-14)
+
+
 class TestGetWindow(object):
 
     def test_boxcar(self):
@@ -220,7 +249,7 @@ def test_needs_params():
                    'general gauss', 'general_gauss', 'ggs',
                    'slepian', 'optimal', 'slep', 'dss', 'dpss',
                    'chebwin', 'cheb', 'exponential', 'poisson', 'tukey',
-                   'tuk']:
+                   'tuk', 'planck']:
         assert_raises(ValueError, signal.get_window, winstr, 7)
 
 if __name__ == "__main__":

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -10,7 +10,8 @@ from scipy._lib.six import string_types
 __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
            'blackmanharris', 'flattop', 'bartlett', 'hanning', 'barthann',
            'hamming', 'kaiser', 'gaussian', 'general_gaussian', 'chebwin',
-           'slepian', 'cosine', 'hann', 'exponential', 'tukey', 'get_window']
+           'slepian', 'cosine', 'hann', 'exponential', 'tukey', 'get_window',
+           'planck']
 
 
 def boxcar(M, sym=True):
@@ -791,6 +792,86 @@ def tukey(M, alpha=0.5, sym=True):
     w3 = 0.5 * (1 + np.cos(np.pi * (-2.0/alpha + 1 + 2.0*n3/alpha/(M-1))))
 
     w = np.concatenate((w1, w2, w3))
+
+    if not sym and not odd:
+        w = w[:-1]
+    return w
+
+
+def planck(M, e, sym=True):
+    r"""Return a Planck-taper window.
+
+    The Planck-taper is a window which is smooth and differentiable everywhere.
+    It's designed to minimize leakage outside of a frequency of interest
+    without supressing signals which might contain the most power at the edges
+    of the waveform.
+
+    Parameters
+    ----------
+    M : int
+        Number of points in the output window. If zero or less, an empty
+        array is returned. The Planck-taper is defined for 3 points onward
+        (with M<3 returning a boxcar window instead).
+    e : float
+        Epsilon parameter (0<e<0.5). Values of e>=0.5 result in no flat region.
+    sym : bool, optional
+        When True (default), generates a symmetric window, for use in filter
+        design.
+        When False, generates a periodic window, for use in spectral analysis.
+
+    Returns
+    -------
+    w : ndarray
+        The window, with the maximum value normalized to 1 (though the value 1
+        does not appear for e>=0.5 if `M` is even and `sym` is True).
+
+    References
+    ----------
+    .. [1] DJA McKechan, C Robinson and BS Sathyaprakash, (2010) A tapering
+           window for time-domain templates and simulated signals in the
+           detection of gravitational waves from coalescing compact binaries;
+           Classical and Quantum Gravity 27 (8): 084020. arXiv:1003.2939.
+
+    Examples
+    --------
+    Plot the window and its frequency response:
+
+    >>> from scipy import signal
+    >>> from scipy.fftpack import fft, fftshift
+    >>> import matplotlib.pyplot as plt
+
+    >>> window = signal.planck(51, 0.1)
+    >>> plt.plot(window)
+    >>> plt.title("Planck-taper window ($\epsilon = 0.1$)")
+    >>> plt.ylabel("Amplitude")
+    >>> plt.xlabel("Sample")
+
+    >>> plt.figure()
+    >>> A = fft(window, 2048) / (len(window)/2.0)
+    >>> freq = np.linspace(-0.5, 0.5, len(A))
+    >>> response = 20 * np.log10(np.abs(fftshift(A / abs(A).max())))
+    >>> plt.plot(freq, response)
+    >>> plt.axis([-0.5, 0.5, -120, 0])
+    >>> plt.title("Frequency response of the Planck-taper window ($\epsilon = 0.1$)")
+    >>> plt.ylabel("Normalized magnitude [dB]")
+    >>> plt.xlabel("Normalized frequency [cycles per sample]")
+
+    """
+    if M < 1:
+        return np.array([])
+    if M < 3:
+        return np.ones(M, 'd')
+    odd = M % 2
+    if not sym and not odd:
+        M = M + 1
+
+    t2 = min(M//2, int(np.floor(e * (M-1))))
+    w1 = np.arange(1, t2)
+    w1 = t2/w1 + t2/(w1-t2)
+    w1 = 1/(np.exp(w1)+1)
+    w2 = np.ones(M-2 - len(w1)*2)
+    w3 = w1[::-1]
+    w = np.concatenate(([0.], w1, w2, w3, [0.]))
 
     if not sym and not odd:
         w = w[:-1]
@@ -1637,7 +1718,8 @@ def get_window(window, Nx, fftbins=True):
         `barthann`, `kaiser` (needs beta), `gaussian` (needs standard
         deviation), `general_gaussian` (needs power, width), `slepian`
         (needs width), `chebwin` (needs attenuation), `exponential`
-        (needs decay scale), `tukey` (needs taper fraction)
+        (needs decay scale), `tukey` (needs taper fraction), `planck`
+        (needs taper fraction).
 
     If the window requires no parameters, then `window` can be a string.
 


### PR DESCRIPTION
This is my tentative implementation of the Planck-taper window (added as `signal.planck`). See http://arxiv.org/pdf/1003.2939

Window and resulting spectra match the paper as expected, although I need to double-check the boundary conditions for very low samples to check my understanding that the first and last sample are always 0. If nobody chimes in, I'll mail the author.

Meanwhile, anything missing?
