### PR TITLE
WIP: ENH: add exact=True factorial for vectors

### DIFF
--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -2229,29 +2229,58 @@ def perm(N, k, exact=False):
         return vals
 
 
+# http://stackoverflow.com/a/16327037/125507
+def _range_prod(lo, hi):
+    """
+    Product of a range of numbers
+
+    Returns the product of
+    lo * (lo+1) * (lo+2) * ... * (hi-2) * (hi-1) * hi
+    = hi! / (lo-1)!
+    """
+    if lo + 1 < hi:
+        mid = (hi + lo) // 2
+        return _range_prod(lo, mid) * _range_prod(mid + 1, hi)
+    if lo == hi:
+        return lo
+    return lo * hi
+
+
 def factorial(n, exact=False):
-    """The factorial function, n! = special.gamma(n+1).
+    """
+    The factorial of a number or array of numbers
 
-    If exact is 0, then floating point precision is used, otherwise
-    exact long integer is computed.
+    The factorial of non-negative integer `n` is the product of all
+    positive integers less than or equal to `n`:
 
-    - Array argument accepted only for exact=False case.
-    - If n<0, the return value is 0.
+    n! = n * (n - 1) * (n - 2) * ... * 1
 
     Parameters
     ----------
     n : int or array_like of ints
-        Calculate ``n!``.  Arrays are only supported with `exact` set
-        to False.  If ``n < 0``, the return value is 0.
+        Input values, which must be non-negative integers.
     exact : bool, optional
-        The result can be approximated rapidly using the gamma-formula
-        above.  If `exact` is set to True, calculate the
-        answer exactly using integer arithmetic. Default is False.
+        If True, calculate the answer exactly using long integer arithmetic.
+        If False, result is approximated in floating point rapidly using the
+        `gamma` function.
+        Default is False.
 
     Returns
     -------
-    nf : float or int
-        Factorial of `n`, as an integer or a float depending on `exact`.
+    nf : float or int or ndarray
+        Factorial of `n`, as integer or float depending on `exact`.
+
+    Notes
+    -----
+    For arrays with ``exact=True``, the factorial is computed only once, for
+    the largest input, with each other result computed in the process. If any
+    input is greater than 12, the output is an object array of Python long
+    ints.
+
+    With ``exact=False`` the factorial is approximated using the gamma
+    function:
+
+    .. math:: n! = \Gamma(n+1)
 
     Examples
     --------
@@ -2259,15 +2288,41 @@ def factorial(n, exact=False):
     >>> arr = np.array([3, 4, 5])
     >>> factorial(arr, exact=False)
     array([   6.,   24.,  120.])
+    >>> factorial(arr, exact=True)
+    array([  6,  24, 120])
     >>> factorial(5, exact=True)
     120L
 
     """
     if exact:
-        return math.factorial(n)
+        if np.ndim(n) == 0:
+            return math.factorial(n)
+        else:
+            n = asarray(n)
+            un = np.unique(n)
+
+            if any(abs(un.astype(int)) != un):
+                raise ValueError("Input must be non-negative integers for "
+                                 "'exact' mode.")
+
+            # Anything greater than 12! requires long ints
+            out = np.empty_like(n, dtype=object if un[-1] > 12 else int)
+
+            out[n < 2] = 1
+            un = np.concatenate(([1], un[un > 1]))
+
+            # Calculate products of each range of numbers
+            val = 1
+            for i in xrange(len(un) - 1):
+                # Use Python ints instead of np.int32, which would overflow
+                prev = int(un[i] + 1)
+                current = int(un[i + 1])
+                val *= _range_prod(prev, current)
+                out[n == current] = val
+            return out
     else:
         n = asarray(n)
-        vals = gamma(n+1)
+        vals = gamma(n + 1)
         return where(n >= 0, vals, 0)
 
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -301,7 +301,7 @@ class TestCephes(TestCase):
         assert_equal(cephes.expm1(np.inf), np.inf)
         assert_equal(cephes.expm1(-np.inf), -1)
         assert_equal(cephes.expm1(np.nan), np.nan)
-    
+
     # Earlier numpy version don't guarantee that npy_cexp conforms to C99.
     @dec.skipif(NumpyVersion(np.__version__) < '1.9.0')
     def test_expm1_complex(self):
@@ -322,7 +322,7 @@ class TestCephes(TestCase):
         assert_equal(expm1(complex(1, np.nan)), complex(np.nan, np.nan))
         assert_equal(expm1(complex(np.nan, 1)), complex(np.nan, np.nan))
         assert_equal(expm1(complex(np.nan, np.nan)), complex(np.nan, np.nan))
- 
+
     @dec.knownfailureif(True, 'The real part of expm1(z) bad at these points')
     def test_expm1_complex_hard(self):
         # The real part of this function is difficult to evaluate when
@@ -330,7 +330,7 @@ class TestCephes(TestCase):
         y = np.array([0.1, 0.2, 0.3, 5, 11, 20])
         x = -np.log(np.cos(y))
         z = x + 1j*y
-        
+
         # evaluate using mpmath.expm1 with dps=1000
         expected = np.array([-5.5507901846769623e-17+0.10033467208545054j,
                               2.4289354732893695e-18+0.20271003550867248j,
@@ -1715,13 +1715,35 @@ class TestExp(TestCase):
 
 class TestFactorialFunctions(TestCase):
     def test_factorial(self):
+        assert_array_almost_equal(special.factorial(0), 1)
+        assert_array_almost_equal(special.factorial(1), 1)
+        assert_array_almost_equal(special.factorial(2), 2)
         assert_array_almost_equal([6., 24., 120.],
-                special.factorial([3, 4, 5], exact=False))
+                                  special.factorial([3, 4, 5], exact=False))
+        assert_array_almost_equal(special.factorial([[5, 3], [4, 3]]),
+                                  [[120, 6], [24, 6]])
+
+        assert_equal(special.factorial(0, exact=True), 1)
+        assert_equal(special.factorial(1, exact=True), 1)
+        assert_equal(special.factorial(2, exact=True), 2)
         assert_equal(special.factorial(5, exact=True), 120)
+        assert_equal(special.factorial(15, exact=True), 1307674368000)
+
+        assert_equal(special.factorial([0], exact=True), 1)
+        assert_equal(special.factorial([1], exact=True), 1)
+        assert_equal(special.factorial([2], exact=True), 2)
+        assert_equal(special.factorial([5], exact=True), 120)
+        assert_equal(special.factorial([15], exact=True), 1307674368000)
+
+        assert_equal(special.factorial([7, 4, 15, 10], exact=True),
+                     [5040, 24, 1307674368000, 3628800])
+
+        assert_equal(special.factorial([[5, 3], [4, 3]], True),
+                     [[120, 6], [24, 6]])
 
     def test_factorial2(self):
         assert_array_almost_equal([105., 384., 945.],
-                special.factorial2([7, 8, 9], exact=False))
+                                  special.factorial2([7, 8, 9], exact=False))
         assert_equal(special.factorial2(7, exact=True), 105)
 
     def test_factorialk(self):


### PR DESCRIPTION
Recursively breaks up factorial into small pieces that can use regular ints.

Uses fact that all factorials are multiples of lesser factorials to avoid doing duplicate computations for each input, so `factorial([n]*1000, True)` doesn't take 1000 times as long as `factorial([n], True)`, and:

```
timeit map(math.factorial, arange(1000))
10 loops, best of 3: 130 ms per loop

timeit factorial(arange(1000), True)
100 loops, best of 3: 10.9 ms per loop

all(map(math.factorial, arange(1000)) == factorial(arange(1000), True))
Out[186]: True
```

This could probably be written more elegantly, and I haven't written tests yet.  Suggestions?

Also planning to add `falling_factorial` and `rising_factorial`
