### PR TITLE
Netcdf append

### DIFF
--- a/scipy/io/netcdf.py
+++ b/scipy/io/netcdf.py
@@ -509,7 +509,12 @@ class netcdf_file(object):
             # Handle rec vars with shape[0] < nrecs.
             if self._recs > len(var.data):
                 shape = (self._recs,) + var.data.shape[1:]
-                var.data.resize(shape)
+                # Resize in-place does not always work since 
+                # the array might not be single-segment                              
+                try:
+                    var.data.resize(shape)
+                except ValueError:
+                    var.__dict__['data'] = np.resize(var.data, shape).astype(var.data.dtype)
 
             pos0 = pos = self.fp.tell()
             for rec in var.data:
@@ -980,7 +985,12 @@ class netcdf_variable(object):
                 recs = rec_index + 1
             if recs > len(self.data):
                 shape = (recs,) + self._shape[1:]
-                self.data.resize(shape)
+                # Resize in-place does not always work since 
+                # the array might not be single-segment                              
+                try:
+                    self.data.resize(shape)
+                except ValueError:
+                    self.__dict__['data'] = np.resize(self.data, shape).astype(self.data.dtype)
         self.data[index] = data
 
     def _get_missing_value(self):

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -317,6 +317,46 @@ def test_open_append():
         f.close()
 
 
+def test_append_recordDimension(): 
+    dataSize = 100   
+    
+    with in_tempdir():
+        # Create file with record time dimension
+        with netcdf_file('withRecordDimension.nc', 'w') as f:
+            f.createDimension('time', None)
+            f.createVariable('time', 'd', ('time',))
+            f.createDimension('x', dataSize)
+            x = f.createVariable('x', 'd', ('x',))
+            x[:] = np.array(range(dataSize))
+            f.createDimension('y', dataSize)
+            y = f.createVariable('y', 'd', ('y',))
+            y[:] = np.array(range(dataSize))
+            f.createVariable('testData', 'i', ('time', 'x', 'y'))  
+            f.flush()
+            f.close()        
+        
+        for i in range(2): 
+            # Open the file in append mode and add data 
+            with netcdf_file('withRecordDimension.nc', 'a') as f:
+                f.variables['time'].data = np.append(f.variables["time"].data, i)
+                f.variables['testData'][i, :, :] = np.ones((dataSize, dataSize))*i
+                f.flush()
+                
+            # Read the file and check that append worked
+            with netcdf_file('withRecordDimension.nc') as f:            
+                assert_equal(f.variables['time'][-1], i)
+                assert_equal(f.variables['testData'][-1, :, :].copy(), np.ones((dataSize, dataSize))*i)
+                assert_equal(f.variables['time'].data.shape[0], i+1)
+                assert_equal(f.variables['testData'].data.shape[0], i+1)
+                
+        # Read the file and check that 'data' was not saved as user defined
+        # attribute of testData variable during append operation
+        with netcdf_file('withRecordDimension.nc') as f:
+            with assert_raises(KeyError) as ar:            
+                f.variables['testData']._attributes['data']
+            ex = ar.exception
+            assert_equal(ex.args[0], 'data')
+
 def test_maskandscale():
     t = np.linspace(20, 30, 15)
     t[3] = 100


### PR DESCRIPTION
Follow on from https://github.com/scipy/scipy/pull/4960

Fixes two issues which were present when appending to an existing NetCDF file.

First commit fixes the ValueError which appears when in-place resize is used on a numpy array storing a NetCDF record variable. The exception is raised since the array might not be single-segment. The in-place resize is still tried first since it is probably faster than copy resize, whenever it is possible.

Second commit ensures that "data" field is not saved as a user defined attribute, since it is used to access the variable data.

In reply to pv comments in https://github.com/scipy/scipy/pull/4960, .astype is needed at least on line 994 but I would prefer to as well keep it on line 517 just in case.
