### PR TITLE
Added 'lanczos' to the image interpolation function list.

### DIFF
--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -384,7 +384,8 @@ def imrotate(arr, angle, interp='bilinear'):
 
         - 'nearest' :  for nearest neighbor
         - 'bilinear' : for bilinear
-        - 'cubic' : cubic
+        - 'lanczos' : for lanczos
+        - 'cubic' : for bicubic
         - 'bicubic' : for bicubic
 
     Returns
@@ -394,7 +395,7 @@ def imrotate(arr, angle, interp='bilinear'):
 
     """
     arr = asarray(arr)
-    func = {'nearest': 0, 'bilinear': 2, 'bicubic': 3, 'cubic': 3}
+    func = {'nearest': 0, 'lanczos': 1, 'bilinear': 2, 'bicubic': 3, 'cubic': 3}
     im = toimage(arr)
     im = im.rotate(angle, resample=func[interp])
     return fromimage(im)
@@ -457,7 +458,7 @@ def imresize(arr, size, interp='bilinear', mode=None):
         * tuple - Size of the output image.
 
     interp : str, optional
-        Interpolation to use for re-sizing ('nearest', 'bilinear', 'bicubic'
+        Interpolation to use for re-sizing ('nearest', 'lanczos', 'bilinear', 'bicubic'
         or 'cubic').
 
     mode : str, optional
@@ -483,7 +484,7 @@ def imresize(arr, size, interp='bilinear', mode=None):
         size = tuple((array(im.size)*size).astype(int))
     else:
         size = (size[1], size[0])
-    func = {'nearest': 0, 'bilinear': 2, 'bicubic': 3, 'cubic': 3}
+    func = {'nearest': 0, 'lanczos': 1, 'bilinear': 2, 'bicubic': 3, 'cubic': 3}
     imnew = im.resize(size, resample=func[interp])
     return fromimage(imnew)
 

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -55,6 +55,11 @@ class TestPILUtil(TestCase):
         assert_equal(im2, im3)
         assert_equal(im2, im4)
 
+    def test_imresize5(self):
+        im = np.random.random((25, 15))
+        im2 = misc.imresize(im, (30, 60), interp='lanczos')
+        assert_equal(im2.shape, (30, 60))
+
     def test_bytescale(self):
         x = np.array([0, 1, 2], np.uint8)
         y = np.array([0, 1, 2])


### PR DESCRIPTION
I fixed the scipy.misc.imresize function to add 'lanczos' interpolation. This was just a case of adding the option that PIL already supports. Unit test also added to confirm the fix.
