### PR TITLE
MAINT: Future imports for optimize._lsq

### DIFF
--- a/scipy/optimize/_lsq/__init__.py
+++ b/scipy/optimize/_lsq/__init__.py
@@ -1,5 +1,4 @@
 """This module contains least-squares algorithms."""
-
 from __future__ import division, print_function, absolute_import
 
 from .least_squares import least_squares

--- a/scipy/optimize/_lsq/bvls.py
+++ b/scipy/optimize/_lsq/bvls.py
@@ -1,4 +1,6 @@
 """Bounded-Variable Least-Squares algorithm."""
+from __future__ import division, print_function, absolute_import
+
 import numpy as np
 from numpy.linalg import norm, lstsq
 from scipy.optimize import OptimizeResult

--- a/scipy/optimize/_lsq/common.py
+++ b/scipy/optimize/_lsq/common.py
@@ -1,4 +1,6 @@
 """Functions used by least-squares algorithms."""
+from __future__ import division, print_function, absolute_import
+
 from math import copysign
 
 import numpy as np

--- a/scipy/optimize/_lsq/dogbox.py
+++ b/scipy/optimize/_lsq/dogbox.py
@@ -40,6 +40,8 @@ References
             Mathematics, Corfu, Greece, 2004.
 .. [NumOpt] J. Nocedal and S. J. Wright, "Numerical optimization, 2nd edition".
 """
+from __future__ import division, print_function, absolute_import
+
 import numpy as np
 from numpy.linalg import lstsq, norm
 

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -1,4 +1,5 @@
 """Generic interface for least-square minimization."""
+from __future__ import division, print_function, absolute_import
 
 from warnings import warn
 

--- a/scipy/optimize/_lsq/lsq_linear.py
+++ b/scipy/optimize/_lsq/lsq_linear.py
@@ -1,4 +1,6 @@
 """Linear least squares with bound constraints on independent variables."""
+from __future__ import division, print_function, absolute_import
+
 import numpy as np
 from numpy.linalg import norm, lstsq
 from scipy.sparse import issparse, csr_matrix

--- a/scipy/optimize/_lsq/trf.py
+++ b/scipy/optimize/_lsq/trf.py
@@ -93,6 +93,8 @@ References
 .. [JJMore] More, J. J., "The Levenberg-Marquardt Algorithm: Implementation
     and Theory," Numerical Analysis, ed. G. A. Watson, Lecture
 """
+from __future__ import division, print_function, absolute_import
+
 import numpy as np
 from numpy.linalg import norm
 from scipy.linalg import svd, qr

--- a/scipy/optimize/_lsq/trf_linear.py
+++ b/scipy/optimize/_lsq/trf_linear.py
@@ -1,5 +1,7 @@
 """The adaptation of Trust Region Reflective algorithm for a linear
 least-squares problem."""
+from __future__ import division, print_function, absolute_import
+
 import numpy as np
 from numpy.linalg import norm
 from scipy.linalg import qr, solve_triangular


### PR DESCRIPTION
I just found out that all sources in `optimize._lsq` work without any future imports. 

It means that they don't need them. But for `print(...)` it is now what I assumed and it works properly only because all print statements have a single argument. I think it's better to make it explicitly correct. I also added division imports to clear any doubts (although they proved to be unnecessary).
