### PR TITLE
BUG: check the requested approximation rank in interpolative.svd

### DIFF
--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -884,6 +884,9 @@ def svd(A, eps_or_k, rand=True):
                     U, V, S = backend.idzp_svd(eps, A)
         else:
             k = int(eps_or_k)
+            if k > min(A.shape):
+                raise ValueError("Approximation rank %s exceeds min(A.shape) = "
+                                 " %s " % (k, min(A.shape)))
             if rand:
                 if real:
                     U, V, S = backend.iddr_asvd(A, k)

--- a/scipy/linalg/tests/test_interpolative.py
+++ b/scipy/linalg/tests/test_interpolative.py
@@ -249,3 +249,9 @@ class TestInterpolativeDecomposition(object):
     def test_badcall(self):
         A = hilbert(5).astype(np.float32)
         assert_raises(ValueError, pymatrixid.interp_decomp, A, 1e-6, rand=False)
+
+    def test_rank_too_large(self):
+        # svd(array, k) should not segfault
+        a = np.ones((4, 3))
+        with assert_raises(ValueError):
+            pymatrixid.svd(a, 4)


### PR DESCRIPTION
`k > min(input.shape)` segfaults otherwise.

The condition is not checked in either Fortran code or .pyf wrappers. So we check it on the python side. 

closes gh-6016
