### PR TITLE
BUG: (ordqz) always increase parameter lwork by 1.

### DIFF
--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -316,12 +316,10 @@ def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
 
     if lwork is None or lwork == -1:
         result = tgsen(select, AA, BB, Q, Z, lwork=-1)
-        if typ in 'cz':
-            lwork = result[-3][0].real.astype(np.int)  # not complex
-            # looks like wrong value passed to ZTGSYL if not
-            lwork += 1
-        else:
-            lwork = result[-3][0]
+        lwork = result[-3][0].real.astype(np.int)
+        # looks like wrong value passed to ZTGSYL if not
+        lwork += 1
+
     liwork = None
     if liwork is None or liwork == -1:
         result = tgsen(select, AA, BB, Q, Z, liwork=-1)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2153,9 +2153,6 @@ class TestOrdQZWorkspaceSize(TestCase):
 
     def test_decompose(self):
 
-        import numpy.random
-        from scipy.linalg import ordqz
-
         N = 202
 
         # raises error if lwork parameter to dtrsen is too small

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2157,15 +2157,15 @@ class TestOrdQZWorkspaceSize(TestCase):
 
         # raises error if lwork parameter to dtrsen is too small
         for ddtype in [np.float32, np.float64]:
-            A = numpy.random.random((N,N)).astype(ddtype)
-            B = numpy.random.random((N,N)).astype(ddtype)
+            A = random((N,N)).astype(ddtype)
+            B = random((N,N)).astype(ddtype)
             # sort = lambda alphar, alphai, beta: alphar**2 + alphai**2< beta**2
             sort = lambda alpha, beta: alpha < beta
             [S,T,alpha,beta,U,V] = ordqz(A,B,sort=sort, output='real')
 
         for ddtype in [np.complex, np.complex64]:
-            A = numpy.random.random((N,N)).astype(ddtype)
-            B = numpy.random.random((N,N)).astype(ddtype)
+            A = random((N,N)).astype(ddtype)
+            B = random((N,N)).astype(ddtype)
             sort = lambda alpha, beta: alpha < beta
             [S,T,alpha,beta,U,V] = ordqz(A,B,sort=sort, output='complex')
 
@@ -2176,8 +2176,8 @@ class TestOrdQZWorkspaceSize(TestCase):
 
         # segfaults if lwork parameter to dtrsen is too small
         for ddtype in [np.float32, np.float64, np.complex, np.complex64]:
-            A = numpy.random.random((N,N)).astype(ddtype)
-            B = numpy.random.random((N,N)).astype(ddtype)
+            A = random((N,N)).astype(ddtype)
+            B = random((N,N)).astype(ddtype)
             [S,T,alpha,beta,U,V] = ordqz(A,B,sort='ouc')
 
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2157,11 +2157,26 @@ class TestOrdQZWorkspaceSize(TestCase):
         from scipy.linalg import ordqz
 
         N = 202
-        for dtype in [np.float32, np.float64, np.complex, np.complex64]:
-            A = numpy.random.random((N,N)).astype(dtype)
-            B = numpy.random.random((N,N)).astype(dtype)
-            # this should not segfault or raise an error
-            [S,T,alpha,beta,U,V] = ordqz(A,B,sort='ouc')
+
+        # raises error if lwork parameter to dtrsen is too small
+        for ddtype in [np.float32, np.float64]:
+            A = numpy.random.random((N,N)).astype(ddtype)
+            B = numpy.random.random((N,N)).astype(ddtype)
+            # sort = lambda alphar, alphai, beta: alphar**2 + alphai**2< beta**2
+            sort = lambda alpha, beta: alpha<beta
+            [S,T,alpha,beta,U,V] = ordqz(A,B,sort=sort, output='real')
+
+        for ddtype in [np.complex, np.complex64]:
+            A = numpy.random.random((N,N)).astype(ddtype)
+            B = numpy.random.random((N,N)).astype(ddtype)
+            sort = lambda alpha, beta: alpha<beta
+            [S,T,alpha,beta,U,V] = ordqz(A,B,sort=sort, output='complex')
+
+        # # segfaults if lwork parameter to dtrsen is too small
+        # for ddtype in [np.float32, np.float64, np.complex, np.complex64]:
+        #     A = numpy.random.random((N,N)).astype(ddtype)
+        #     B = numpy.random.random((N,N)).astype(ddtype)
+        #     [S,T,alpha,beta,U,V] = ordqz(A,B,sort='ouc')
 
 
 class TestDatacopied(TestCase):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2169,11 +2169,16 @@ class TestOrdQZWorkspaceSize(TestCase):
             sort = lambda alpha, beta: alpha < beta
             [S,T,alpha,beta,U,V] = ordqz(A,B,sort=sort, output='complex')
 
-        # # segfaults if lwork parameter to dtrsen is too small
-        # for ddtype in [np.float32, np.float64, np.complex, np.complex64]:
-        #     A = numpy.random.random((N,N)).astype(ddtype)
-        #     B = numpy.random.random((N,N)).astype(ddtype)
-        #     [S,T,alpha,beta,U,V] = ordqz(A,B,sort='ouc')
+    @dec.slow
+    def test_decompose_ouc(self):
+
+        N = 202
+
+        # segfaults if lwork parameter to dtrsen is too small
+        for ddtype in [np.float32, np.float64, np.complex, np.complex64]:
+            A = numpy.random.random((N,N)).astype(ddtype)
+            B = numpy.random.random((N,N)).astype(ddtype)
+            [S,T,alpha,beta,U,V] = ordqz(A,B,sort='ouc')
 
 
 class TestDatacopied(TestCase):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2146,6 +2146,24 @@ class TestOrdQZ(TestCase):
         ret = ordqz(self.B2, self.A1, sort='lhp')
         self.check(self.B2, self.A1, 'lhp', *ret)
 
+class TestOrdQZWorkspaceSize(TestCase):
+
+    def setUp(self):
+        seed(12345)
+
+    def test_decompose(self):
+
+        import numpy.random
+        from scipy.linalg import ordqz
+
+        N = 202
+        for dtype in [np.float32, np.float64, np.complex, np.complex64]:
+            A = numpy.random.random((N,N)).astype(dtype)
+            B = numpy.random.random((N,N)).astype(dtype)
+            # this should not segfault or raise an error
+            [S,T,alpha,beta,U,V] = ordqz(A,B,sort='ouc')
+
+
 class TestDatacopied(TestCase):
 
     def test_datacopied(self):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2163,13 +2163,13 @@ class TestOrdQZWorkspaceSize(TestCase):
             A = numpy.random.random((N,N)).astype(ddtype)
             B = numpy.random.random((N,N)).astype(ddtype)
             # sort = lambda alphar, alphai, beta: alphar**2 + alphai**2< beta**2
-            sort = lambda alpha, beta: alpha<beta
+            sort = lambda alpha, beta: alpha < beta
             [S,T,alpha,beta,U,V] = ordqz(A,B,sort=sort, output='real')
 
         for ddtype in [np.complex, np.complex64]:
             A = numpy.random.random((N,N)).astype(ddtype)
             B = numpy.random.random((N,N)).astype(ddtype)
-            sort = lambda alpha, beta: alpha<beta
+            sort = lambda alpha, beta: alpha < beta
             [S,T,alpha,beta,U,V] = ordqz(A,B,sort=sort, output='complex')
 
         # # segfaults if lwork parameter to dtrsen is too small


### PR DESCRIPTION
I have a testcase where the qz decomposition with reordering (`ordqz`) fails as follows: 

```
  File "/home/pablo/.local/opt/anaconda3/lib/python3.5/site-packages/scipy/linalg/_decomp_qz.py", line 330, in ordqz
    result = tgsen(select, AA, BB, Q, Z, lwork=lwork, liwork=liwork)
ValueError: On entry to DTGSYL parameter number 20 had an illegal value
```

After some investigation, I found out that the parameter lwork given to tgsen, was too small, and that increasing it by one was the minimum to make it work. This is already done when AA and BB are complex.
This PR proposes to do the same when AA and BB are real.

The zip file contains a minimal example to reproduce the bug:
[ordqz_bug.zip](https://github.com/scipy/scipy/files/209137/ordqz_bug.zip)
