### PR TITLE
ENH: extend special.spence to complex arguments.

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -597,7 +597,7 @@ Other Special Functions
    factorialk   -- [+](...((n!)!)!...)! where there are k '!'
    shichi       -- Hyperbolic sine and cosine integrals.
    sici         -- Integral of the sinc and "cosinc" functions.
-   spence       -- Dilogarithm integral.
+   spence       -- Spence's function, also known as the dilogarithm.
    lambertw     -- Lambert W function
    zeta         -- Riemann zeta function of two arguments.
    zetac        -- Standard Riemann zeta function minus 1.

--- a/scipy/special/_complexstuff.pxd
+++ b/scipy/special/_complexstuff.pxd
@@ -3,6 +3,7 @@
 # Common functions required when doing complex arithmetic with Cython.
 #
 
+import cython
 cimport numpy as np
 cimport libc.math
 
@@ -103,3 +104,40 @@ cdef inline double_complex zpack(double zr, double zi) nogil:
     z.real = zr
     z.imag = zi
     return (<double_complex*>&z)[0]
+
+@cython.cdivision(True)
+cdef inline double complex zdiv(double complex x, double complex y) nogil:
+    """
+    Cython 0.24 uses the naive complex division algorithm which
+    overflows far before it should. See
+
+    https://groups.google.com/forum/#!topic/cython-users/1oSGbfiX7qw
+
+    This function implements Smith's method to get around the
+    problem. Smith's method can be further improved, see
+
+    http://arxiv.org/pdf/1210.4539v2.pdf
+
+    This is an UGLY HACK and should be removed as soon as the problem
+    is fixed upstream.
+
+    """
+    cdef:
+        double a = x.real
+        double b = x.imag
+        double c = y.real
+        double d = y.imag
+        double ratio, denom
+        double complex out
+
+    if libc.math.fabs(d) < libc.math.fabs(c):
+        ratio = d/c
+        denom = c + d*ratio
+        out.real = (a + b*ratio)/denom
+        out.imag = (b - a*ratio)/denom
+    else:
+        ratio = c/d
+        denom = c*ratio + d
+        out.real = (a*ratio + b)/denom
+        out.imag = (b*ratio - a)/denom
+    return out

--- a/scipy/special/_complexstuff.pxd
+++ b/scipy/special/_complexstuff.pxd
@@ -23,6 +23,8 @@ cdef extern from "_complexstuff.h":
     double pi "NPY_PI"
     double nan "NPY_NAN"
 
+DEF tol = 2.220446092504131e-16
+
 ctypedef double complex double_complex
 
 ctypedef fused number_t:
@@ -141,3 +143,28 @@ cdef inline double complex zdiv(double complex x, double complex y) nogil:
         out.real = (a*ratio + b)/denom
         out.imag = (b*ratio - a)/denom
     return out
+
+@cython.cdivision(True)
+cdef inline double complex zlog1(double complex z) nogil:
+    """
+    Compute log, paying special attention to accuracy around 1. We
+    implement this ourselves because some systems (most notably the
+    Travis CI machines) are weak in this regime.
+
+    """
+    cdef:
+        int n
+        double complex coeff = -1
+        double complex res = 0
+
+    if zabs(z - 1) > 0.1:
+        return zlog(z)
+    z = z - 1
+    if z == 0:
+        return 0
+    for n in range(1, 17):
+        coeff *= -z
+        res += coeff/n
+        if zabs(res/coeff) < tol:
+            break
+    return res

--- a/scipy/special/_loggamma.pxd
+++ b/scipy/special/_loggamma.pxd
@@ -9,7 +9,7 @@
 
 import cython
 from libc.math cimport M_PI, ceil, sin, log
-from _complexstuff cimport nan, zisnan, zabs, zlog, zsin, zarg, zexp
+from _complexstuff cimport nan, zisnan, zabs, zlog, zlog1, zsin, zarg, zexp
 
 cdef extern from "numpy/npy_math.h":
     double NPY_EULER
@@ -284,31 +284,6 @@ cdef inline double complex taylor(double complex z) nogil:
         coeff = zeta(n, 1)*zfac/n
         res += coeff
         if zabs(coeff/res) < tol:
-            break
-    return res
-
-
-@cython.cdivision(True)
-cdef inline double complex zlog1(double complex z) nogil:
-    """
-    Compute log around 1. We implement this ourselves because some
-    systems appear to be inaccurate around this point.
-
-    """
-    cdef:
-        int n
-        double complex coeff = -1
-        double complex res = 0
-
-    if zabs(z - 1) > 0.1:
-        return zlog(z)
-    z = z - 1
-    if z == 0:
-        return 0
-    for n in range(1, 17):
-        coeff *= -z
-        res += coeff/n
-        if zabs(res/coeff) < tol:
             break
     return res
 

--- a/scipy/special/_spence.pxd
+++ b/scipy/special/_spence.pxd
@@ -12,7 +12,7 @@
 # Released under the same license as Scipy.
 
 import cython
-from _complexstuff cimport zlog, zabs, zdiv
+from _complexstuff cimport zlog1, zabs, zdiv
 
 # Relative tolerance for the series
 DEF TOL = 2.220446092504131e-16
@@ -37,7 +37,7 @@ cdef inline double complex cspence(double complex z) nogil:
         return cspence_series0(z)
     elif zabs(1 - z) > 1:
         # Use of zdiv is an UGLY HACK.
-        return -cspence_series1(zdiv(z, z - 1)) - PISQ_6 - 0.5*zlog(z - 1)**2
+        return -cspence_series1(zdiv(z, z - 1)) - PISQ_6 - 0.5*zlog1(z - 1)**2
     else:
         return cspence_series1(z)
 
@@ -68,7 +68,7 @@ cdef inline double complex cspence_series0(double complex z) nogil:
         sum2 += term2
         if zabs(term1) <= TOL*zabs(sum1) and zabs(term2) <= TOL*zabs(sum2):
             break
-    return PISQ_6 - sum1 + zlog(z)*sum2
+    return PISQ_6 - sum1 + zlog1(z)*sum2
 
 
 @cython.cdivision(True)
@@ -97,6 +97,6 @@ cdef inline double complex cspence_series1(double complex z) nogil:
         if zabs(term) <= TOL*zabs(res):
             break
     res *= 4*zz
-    res += 4*z + 5.75*zz + 3*(1 - zz)*zlog(1 - z)
+    res += 4*z + 5.75*zz + 3*(1 - zz)*zlog1(1 - z)
     res /= 1 + 4*z + zz
     return res

--- a/scipy/special/_spence.pxd
+++ b/scipy/special/_spence.pxd
@@ -1,0 +1,102 @@
+# Implement Spence's function, a.k.a. the dilogarithm, for complex
+# arguments. Note that our definition differs from that in the sources
+# by the mapping z -> 1 - z.
+#
+# Sources
+# [1] Zagier, "The Dilogarithm Function"
+# [2] functions.wolfram.com
+# [3] Ginsberg, Zaborowski, "The Dilogarithm Function of a Real Argument"
+#
+# Author: Josh Wilson
+#
+# Released under the same license as Scipy.
+
+import cython
+from _complexstuff cimport zlog, zabs, zdiv
+
+# Relative tolerance for the series
+DEF TOL = 2.220446092504131e-16
+DEF PISQ_6 = 1.6449340668482264365
+
+
+@cython.cdivision(True)
+cdef inline double complex cspence(double complex z) nogil:
+    """
+    Compute Spence's function for complex arguments. The strategy is:
+    - If z is close to 0, use a series centered at 0.
+    - If z is far away from 1, use the reflection formula
+
+    spence(z) = -spence(z/(z - 1)) - pi**2/6 - ln(z - 1)**2/2
+
+    to move close to 1. See [1].
+    - If z is close to 1, use a series centered at 1.
+
+    """
+    if zabs(z) < 0.5:
+        # This step isn't necessary, but this series converges faster.
+        return cspence_series0(z)
+    elif zabs(1 - z) > 1:
+        # Use of zdiv is an UGLY HACK.
+        return -cspence_series1(zdiv(z, z - 1)) - PISQ_6 - 0.5*zlog(z - 1)**2
+    else:
+        return cspence_series1(z)
+
+
+@cython.cdivision(True)
+cdef inline double complex cspence_series0(double complex z) nogil:
+    """
+    A series centered at z = 0; see
+
+    http://functions.wolfram.com/10.07.06.0005.02
+
+    """
+    cdef:
+        int n
+        double complex zfac = 1
+        double complex sum1 = 0
+        double complex sum2 = 0
+        double complex term1, term2
+
+    if z == 0:
+        return PISQ_6
+
+    for n in range(1, 500):
+        zfac *= z
+        term1 = zfac/n**2
+        sum1 += term1
+        term2 = zfac/n
+        sum2 += term2
+        if zabs(term1) <= TOL*zabs(sum1) and zabs(term2) <= TOL*zabs(sum2):
+            break
+    return PISQ_6 - sum1 + zlog(z)*sum2
+
+
+@cython.cdivision(True)
+cdef inline double complex cspence_series1(double complex z) nogil:
+    """
+    A series centered at z = 1 which enjoys faster convergence than
+    the Taylor series. See [3]. The number of terms used comes from
+    bounding the absolute tolerance at the edge of the radius of
+    convergence where the sum is O(1).
+
+    """
+    cdef:
+        int n
+        double complex zfac = 1
+        double complex res = 0
+        double complex term, zz
+
+    if z == 1:
+        return 0
+    z = 1 - z
+    zz = z**2
+    for n in range(1, 500):
+        zfac *= z
+        term = zfac/(n*(n + 1)*(n + 2))**2
+        res += term
+        if zabs(term) <= TOL*zabs(res):
+            break
+    res *= 4*zz
+    res += 4*z + 5.75*zz + 3*(1 - zz)*zlog(1 - z)
+    res /= 1 + 4*z + zz
+    return res

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -11437,17 +11437,17 @@ cdef char *ufunc_spence_doc = (
     "  \\int_0^z \\frac{\\log(t)}{1 - t}dt\n"
     "\n"
     "for complex :math:`z`, where the contour of integration is taken\n"
-    "to avoid the branch cut of the logarithm on the negative real\n"
-    "axis. Spence's function is analytic everywhere except the negative\n"
-    "real axis where it has a branch cut.\n"
+    "to avoid the branch cut of the logarithm. Spence's function is\n"
+    "analytic everywhere except the negative real axis where it has a\n"
+    "branch cut.\n"
     "\n"
     "Note that there is a different convention which defines Spence's\n"
     "function by the integral\n"
     "\n"
     ".. math::\n"
-    "  -\\int_0^z \\frac{\\log(1 - t)}{t}dt,\n"
+    "  -\\int_0^z \\frac{\\log(1 - t)}{t}dt;\n"
     "\n"
-    "this function is our ``spence(1 - z)``.")
+    "this is our ``spence(1 - z)``.")
 ufunc_spence_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_spence_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
 ufunc_spence_loops[2] = <np.PyUFuncGenericFunction>loop_D_D__As_F_F

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -1894,6 +1894,9 @@ ctypedef double _proto_smirnovi_unsafe_t(double, double) nogil
 cdef _proto_smirnovi_unsafe_t *_proto_smirnovi_unsafe_t_var = &_func_smirnovi_unsafe
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_spence "spence"(double) nogil
+from _spence cimport cspence as _func_cspence
+ctypedef double complex _proto_cspence_t(double complex) nogil
+cdef _proto_cspence_t *_proto_cspence_t_var = &_func_cspence
 from sph_harm cimport sph_harmonic as _func_sph_harmonic
 ctypedef double complex _proto_sph_harmonic_t(int, int, double, double) nogil
 cdef _proto_sph_harmonic_t *_proto_sph_harmonic_t_var = &_func_sph_harmonic
@@ -11420,31 +11423,56 @@ ufunc_smirnovi_data[1] = &ufunc_smirnovi_ptr[2*1]
 ufunc_smirnovi_data[2] = &ufunc_smirnovi_ptr[2*2]
 smirnovi = np.PyUFunc_FromFuncAndData(ufunc_smirnovi_loops, ufunc_smirnovi_data, ufunc_smirnovi_types, 3, 2, 1, 0, "smirnovi", ufunc_smirnovi_doc, 0)
 
-cdef np.PyUFuncGenericFunction ufunc_spence_loops[2]
-cdef void *ufunc_spence_ptr[4]
-cdef void *ufunc_spence_data[2]
-cdef char ufunc_spence_types[4]
+cdef np.PyUFuncGenericFunction ufunc_spence_loops[4]
+cdef void *ufunc_spence_ptr[8]
+cdef void *ufunc_spence_data[4]
+cdef char ufunc_spence_types[8]
 cdef char *ufunc_spence_doc = (
-    "spence(x)\n"
+    "spence(z)\n"
     "\n"
-    "Dilogarithm integral\n"
+    "Spence's function, also known as the dilogarithm. It is defined to\n"
+    "be\n"
     "\n"
-    "Returns the dilogarithm integral::\n"
+    ".. math::\n"
+    "  \\int_0^z \\frac{\\log(t)}{1 - t}dt\n"
     "\n"
-    "    -integral(log t / (t-1), t=1..x)")
+    "for complex :math:`z`, where the contour of integration is taken\n"
+    "to avoid the branch cut of the logarithm on the negative real\n"
+    "axis. Spence's function is analytic everywhere except the negative\n"
+    "real axis where it has a branch cut.\n"
+    "\n"
+    "Note that there is a different convention which defines Spence's\n"
+    "function by the integral\n"
+    "\n"
+    ".. math::\n"
+    "  -\\int_0^z \\frac{\\log(1 - t)}{t}dt,\n"
+    "\n"
+    "this function is our ``spence(1 - z)``.")
 ufunc_spence_loops[0] = <np.PyUFuncGenericFunction>loop_d_d__As_f_f
 ufunc_spence_loops[1] = <np.PyUFuncGenericFunction>loop_d_d__As_d_d
+ufunc_spence_loops[2] = <np.PyUFuncGenericFunction>loop_D_D__As_F_F
+ufunc_spence_loops[3] = <np.PyUFuncGenericFunction>loop_D_D__As_D_D
 ufunc_spence_types[0] = <char>NPY_FLOAT
 ufunc_spence_types[1] = <char>NPY_FLOAT
 ufunc_spence_types[2] = <char>NPY_DOUBLE
 ufunc_spence_types[3] = <char>NPY_DOUBLE
+ufunc_spence_types[4] = <char>NPY_CFLOAT
+ufunc_spence_types[5] = <char>NPY_CFLOAT
+ufunc_spence_types[6] = <char>NPY_CDOUBLE
+ufunc_spence_types[7] = <char>NPY_CDOUBLE
 ufunc_spence_ptr[2*0] = <void*>_func_spence
 ufunc_spence_ptr[2*0+1] = <void*>(<char*>"spence")
 ufunc_spence_ptr[2*1] = <void*>_func_spence
 ufunc_spence_ptr[2*1+1] = <void*>(<char*>"spence")
+ufunc_spence_ptr[2*2] = <void*>_func_cspence
+ufunc_spence_ptr[2*2+1] = <void*>(<char*>"spence")
+ufunc_spence_ptr[2*3] = <void*>_func_cspence
+ufunc_spence_ptr[2*3+1] = <void*>(<char*>"spence")
 ufunc_spence_data[0] = &ufunc_spence_ptr[2*0]
 ufunc_spence_data[1] = &ufunc_spence_ptr[2*1]
-spence = np.PyUFunc_FromFuncAndData(ufunc_spence_loops, ufunc_spence_data, ufunc_spence_types, 2, 1, 1, 0, "spence", ufunc_spence_doc, 0)
+ufunc_spence_data[2] = &ufunc_spence_ptr[2*2]
+ufunc_spence_data[3] = &ufunc_spence_ptr[2*3]
+spence = np.PyUFunc_FromFuncAndData(ufunc_spence_loops, ufunc_spence_data, ufunc_spence_types, 4, 1, 1, 0, "spence", ufunc_spence_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_sph_harm_loops[3]
 cdef void *ufunc_sph_harm_ptr[6]

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -4958,14 +4958,28 @@ add_newdoc("scipy.special", "smirnovi",
     """)
 
 add_newdoc("scipy.special", "spence",
-    """
-    spence(x)
+    r"""
+    spence(z)
 
-    Dilogarithm integral
+    Spence's function, also known as the dilogarithm. It is defined to
+    be
 
-    Returns the dilogarithm integral::
+    .. math::
+      \int_0^z \frac{\log(t)}{1 - t}dt
 
-        -integral(log t / (t-1), t=1..x)
+    for complex :math:`z`, where the contour of integration is taken
+    to avoid the branch cut of the logarithm. Spence's function is
+    analytic everywhere except the negative real axis where it has a
+    branch cut.
+
+    Note that there is a different convention which defines Spence's
+    function by the integral
+
+    .. math::
+      -\int_0^z \frac{\log(1 - t)}{t}dt;
+
+    this is our ``spence(1 - z)``.
+
     """)
 
 add_newdoc("scipy.special", "stdtr",

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -202,7 +202,7 @@ cotdg -- cotdg: d->d                                       -- cephes.h
 log1p -- log1p: d->d, clog1p: D->D                         -- cephes.h, _cunity.pxd
 expm1 -- expm1: d->d, cexpm1: D->D                         -- cephes.h, _cunity.pxd
 cosm1 -- cosm1: d->d                                       -- cephes.h
-spence -- spence: d->d                                     -- cephes.h
+spence -- spence: d->d, cspence: D-> D                     -- cephes.h, _spence.pxd
 zetac -- zetac: d->d                                       -- cephes.h
 struve -- struve_h: dd->d                                  -- misc.h
 modstruve -- struve_l: dd->d                               -- misc.h

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -386,6 +386,31 @@ def test_rgamma_zeros():
 
 
 # ------------------------------------------------------------------------------
+# spence
+# ------------------------------------------------------------------------------
+
+@mpmath_check('0.19')
+def test_spence_circle():
+    """
+    The trickiest region for spence is around the circle |z - 1| = 1,
+    so test that region carefully.
+
+    """
+    def spence(z):
+        return complex(mpmath.polylog(2, 1 - z))
+
+    r = np.linspace(0.5, 1.5)
+    theta = np.linspace(0, 2*np.pi)
+    z = (1 + np.outer(r, np.exp(1j*theta))).flatten()
+    dataset = []
+    for z0 in z:
+        dataset.append((z0, spence(z0)))
+
+    dataset = np.array(dataset)
+    FuncData(sc.spence, dataset, 0, 1, rtol=1e-14).check()
+
+
+# ------------------------------------------------------------------------------
 # Machinery for systematic tests
 # ------------------------------------------------------------------------------
 
@@ -1692,6 +1717,22 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
         def si(x):
             return sc.sici(x)[0]
         assert_mpmath_equal(si, mpmath.si, [Arg()])
+
+    def test_spence(self):
+        # mpmath uses a different convention for the dilogarithm
+        def dilog(x):
+            return mpmath.polylog(2, 1 - x)
+        # Spence has a branch cut on the negative real axis
+        assert_mpmath_equal(sc.spence,
+                            _exception_to_nan(dilog),
+                            [Arg(0, np.inf)], rtol=1e-14)
+
+    def test_spence_complex(self):
+        def dilog(z):
+            return mpmath.polylog(2, 1 - z)
+        assert_mpmath_equal(sc.spence,
+                            _exception_to_nan(dilog),
+                            [ComplexArg()], rtol=1e-14)
 
     def test_spherharm(self):
         def spherharm(l, m, theta, phi):

--- a/scipy/special/tests/test_spence.py
+++ b/scipy/special/tests/test_spence.py
@@ -1,0 +1,33 @@
+import numpy as np
+from numpy import sqrt, log, pi
+from scipy.special._testutils import FuncData
+from scipy.special import spence
+
+
+def test_consistency():
+    """
+    Make sure the implementation of spence for real arguments
+    agrees with the implementation of spence for imaginary arguments.
+
+    """
+    x = np.logspace(-30, 300, 200)
+    dataset = np.vstack((x + 0j, spence(x))).T
+    FuncData(spence, dataset, 0, 1, rtol=1e-14).check()
+
+
+def test_special_points():
+    """Check against known values of Spence's function."""
+    phi = (1 + sqrt(5))/2
+    dataset = [(1, 0),
+               (2, -pi**2/12),
+               (0.5, pi**2/12 - log(2)**2/2),
+               (0, pi**2/6),
+               (-1, pi**2/4 - 1j*pi*log(2)),
+               ((-1 + sqrt(5))/2, pi**2/15 - log(phi)**2),
+               ((3 - sqrt(5))/2, pi**2/10 - log(phi)**2),
+               (phi, -pi**2/15 + log(phi)**2/2),
+               # Corrected from Zagier, "The Dilogarithm Function"
+               ((3 + sqrt(5))/2, -pi**2/10 - log(phi)**2)]
+
+    dataset = np.asarray(dataset)
+    FuncData(spence, dataset, 0, 1, rtol=1e-14).check()


### PR DESCRIPTION
Spence's function was only implemented for real arguments; this
extends it to the entire complex plane. It also adds tests for both
the real and complex versions. (Tests for the real version were
previously lacking.)
