### PR TITLE
DOC: Add documentation of PR #5640 to the 0.18.0 release notes

### DIFF
--- a/doc/release/0.18.0-notes.rst
+++ b/doc/release/0.18.0-notes.rst
@@ -68,6 +68,12 @@ or a two-dimensional array.
 ``stats.ks_2samp`` used to return nonsensical values if the input was
 not real or contained nans.  It now raises an exception for such inputs.
 
+`scipy.io.netcdf` masking now gives precedence to the ``_FillValue`` attribute
+over the ``missing_value`` attribute, if both are given. Also, data are only
+treated as missing if they match one of these attributes exactly: values that
+differ by roundoff from ``_FillValue`` or ``missing_value`` are no longer
+treated as missing values.
+
 Other changes
 =============
 


### PR DESCRIPTION
This probably should have been done along with PR #5640 , as was requested in the review of that PR. Better late than never.

I added these notes in the "backwards incompatible changes" section, because the changes potentially change behavior for users. I'm not positive that was the right place to put them, because I'm not sure what scipy's definition of "backwards incompatibility" is.
