### PR TITLE
MAINT: small cleanups related to loggamma

### DIFF
--- a/scipy/special/_loggamma.pxd
+++ b/scipy/special/_loggamma.pxd
@@ -8,6 +8,7 @@
 # Distributed under the same license as Scipy.
 
 import cython
+cimport sf_error
 from libc.math cimport M_PI, ceil, sin, log
 from _complexstuff cimport nan, zisnan, zabs, zlog, zlog1, zsin, zarg, zexp
 
@@ -62,6 +63,7 @@ cdef inline double complex loggamma(double complex z) nogil:
         return z
     elif rz <= 0 and z == ceil(rz):
         # Poles
+        sf_error.error("loggamma", sf_error.SINGULAR, NULL)
         return nan + 1J*nan
 
     if rz < 0 and -smallimag <= iz and iz <= smallimag:
@@ -290,6 +292,10 @@ cdef inline double complex taylor(double complex z) nogil:
 
 cdef inline double complex cgamma(double complex z) nogil:
     """Compute Gamma(z) using loggamma."""
+    if z.real <= 0 and z == ceil(z.real):
+        # Poles
+        sf_error.error("gamma", sf_error.SINGULAR, NULL)
+        return nan + 1J*nan
     return zexp(loggamma(z))
 
 

--- a/scipy/special/specfun_wrappers.c
+++ b/scipy/special/specfun_wrappers.c
@@ -26,7 +26,6 @@
 extern double cephes_psi(double);
 extern double cephes_struve(double, double);
 
-extern void F_FUNC(cgama,CGAMA)(double*,double*,int*,double*,double*);
 extern void F_FUNC(cpsi,CPSI)(double*,double*,double*,double*);
 extern void F_FUNC(hygfz,HYGFZ)(double*,double*,double*,npy_cdouble*,npy_cdouble*);
 extern void F_FUNC(cchg,CCHG)(double*,double*,npy_cdouble*,npy_cdouble*);
@@ -70,14 +69,6 @@ extern void F_FUNC(ffk,FFK)(int*,double*,double*,double*,double*,double*,double*
 /* This must be linked with fortran
  */
 
-npy_cdouble cgamma_wrap( npy_cdouble z) {
-  int kf = 1;
-  npy_cdouble cy;
-
-  F_FUNC(cgama,CGAMA)(CADDR(z), &kf, CADDR(cy));
-  return cy;
-}
-
 npy_cdouble clngamma_wrap( npy_cdouble z) {
   int kf = 0;
   npy_cdouble cy;
@@ -97,19 +88,6 @@ npy_cdouble cpsi_wrap( npy_cdouble z) {
     F_FUNC(cpsi,CPSI)(CADDR(z), CADDR(cy));
   }
   return cy;
-}
-
-npy_cdouble crgamma_wrap( npy_cdouble z) {
-  int kf = 1;
-  npy_cdouble cy;
-  npy_cdouble cy2;
-  double magsq;
-
-  F_FUNC(cgama,CGAMA)(CADDR(z), &kf, CADDR(cy));
-  magsq = ABSQ(cy);
-  REAL(cy2) = REAL(cy) / magsq;
-  IMAG(cy2) = -IMAG(cy) / magsq;
-  return cy2;
 }
 
 npy_cdouble chyp2f1_wrap( double a, double b, double c, npy_cdouble z) {

--- a/scipy/special/specfun_wrappers.h
+++ b/scipy/special/specfun_wrappers.h
@@ -42,10 +42,8 @@
     } while (0)
 #define ABS(x) ((x)<0 ? -(x) : (x))
 
-npy_cdouble cgamma_wrap( npy_cdouble z);
 npy_cdouble clngamma_wrap( npy_cdouble z);
 npy_cdouble cpsi_wrap( npy_cdouble z);
-npy_cdouble crgamma_wrap( npy_cdouble z);
 npy_cdouble chyp2f1_wrap( double a, double b, double c, npy_cdouble z);
 npy_cdouble chyp1f1_wrap( double a, double b, npy_cdouble z);
 double hyp1f1_wrap( double a, double b, double x);

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -323,6 +323,7 @@ def test_beta():
 # loggamma
 # ------------------------------------------------------------------------------
 
+@mpmath_check('0.19')
 def test_loggamma_taylor1():
     """
     Make sure there isn't a big jump in accuracy when we move from
@@ -341,12 +342,13 @@ def test_loggamma_taylor1():
     FuncData(sc.loggamma, dataset, 0, 1, rtol=1e-13).check()
 
 
+@mpmath_check('0.19')
 def test_loggamma_taylor2():
     """
     Test around the zeros at z = 1, 2.
 
     """
-    dx = np.r_[-np.logspace(-1, -30, 10), np.logspace(-30, -1, 10)]
+    dx = np.r_[-np.logspace(-1, -16, 10), np.logspace(-16, -1, 10)]
     dy = dx.copy()
     dx, dy = np.meshgrid(dx, dy)
     dz = dx + 1j*dy
@@ -363,6 +365,7 @@ def test_loggamma_taylor2():
 # rgamma
 # ------------------------------------------------------------------------------
 
+@mpmath_check('0.19')
 def test_rgamma_zeros():
     """
     Test around the zeros at z = 0, -1, -2, ...,  -169. (After -169 we
@@ -371,7 +374,7 @@ def test_rgamma_zeros():
 
     """
     # Can't use too many points here or the test takes forever.
-    dx = np.r_[-np.logspace(-1, -30, 3), 0, np.logspace(-30, -1, 3)]
+    dx = np.r_[-np.logspace(-1, -13, 3), 0, np.logspace(-13, -1, 3)]
     dy = dx.copy()
     dx, dy = np.meshgrid(dx, dy)
     dz = dx + 1j*dy
@@ -1634,7 +1637,7 @@ class TestSystematic(with_metaclass(_SystematicMeta, object)):
                             [IntArg(0, 100), IntArg(0, 100), ComplexArg()],
                             n=100)
 
-    def test_loggamma_real(self):
+    def test_loggamma(self):
         assert_mpmath_equal(sc.loggamma,
                             _exception_to_nan(lambda x: mpmath.loggamma(x, **HYPERKW)),
                             [Arg()], rtol=1e-13)


### PR DESCRIPTION
This contains a number of small cleanups related to loggamma:
- The old wrappers for cgamma and rgamma are removed.
- Singularities in loggamma and gamma are correctly signaled using
  `sf_error`.
- `mpmath_check` decorators are added to loggamma and rgamma tests.
- The tested points in a few tests are adjusted so as to not be
  trivial. (i.e. testing around the zero for rgamma at z = -1 by testing
  z = -1 + 1e-30 is not interesting since these two numbers are equal in
  double precision.
