### PR TITLE
ENH: scipy.signal - Add stft and istft

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -285,6 +285,9 @@ Spectral Analysis
    spectrogram    -- Compute the spectrogram
    lombscargle    -- Computes the Lomb-Scargle periodogram
    vectorstrength -- Computes the vector strength
+   stft           -- Compute the Short Time Fourier Transform
+   istft          -- Compute the Inverse Short Time Fourier Transform
+   check_COLA     -- Check the COLA constraint for iSTFT reconstruction
 
 """
 from __future__ import division, print_function, absolute_import

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -143,7 +143,8 @@ def periodogram(x, fs=1.0, window=None, nfft=None, detrend='constant',
 
 
 def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
-          detrend='constant', return_onesided=True, scaling='density', axis=-1):
+          detrend='constant', return_onesided=True, scaling='density',
+          axis=-1):
     """
     Estimate power spectral density using Welch's method.
 
@@ -523,8 +524,8 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=None, noverlap=None,
         noverlap = nperseg // 8
 
     freqs, time, Sxx = _spectral_helper(x, x, fs, window, nperseg, noverlap,
-                                        nfft, detrend, return_onesided, scaling,
-                                        axis, mode='psd')
+                                        nfft, detrend, return_onesided,
+                                        scaling, axis, mode='psd')
 
     return freqs, time, Sxx
 
@@ -610,7 +611,7 @@ def check_COLA(window, nperseg, noverlap, tol=1e-10):
 
     step = nperseg - noverlap
     binsums = np.sum((win[ii*step:(ii+1)*step] for ii in range(nperseg//step)),
-                      axis=0)
+                     axis=0)
 
     if nperseg % step != 0:
         binsums[:nperseg % step] += win[-(nperseg % step):]
@@ -781,9 +782,9 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         Otherwise, ``nperseg=Zxx.shape[freq_axis]``.
     noverlap : int, optional
         Number of points to overlap between segments. If ``None``, half of the
-        segment length. Defaults to ``None``. When specified, the COLA constraint
-        must be met (see Notes below), and should match the parameter used to
-        generate the STFT.
+        segment length. Defaults to ``None``. When specified, the COLA
+        constraint must be met (see Notes below), and should match the
+        parameter used to generate the STFT.
     nfft : int, optional
         Number of FFT points corresponding to each STFT segment. This parameter
         must be specified if the STFT was padded via ``nfft > nperseg``. If
@@ -1038,8 +1039,8 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         function, it takes a segment and returns a detrended segment.
         If `detrend` is False, no detrending is done.  Defaults to 'constant'.
     axis : int, optional
-        Axis along which the coherence is computed for both inputs; the default is
-        over the last axis (i.e. ``axis=-1``).
+        Axis along which the coherence is computed for both inputs; the default
+        is over the last axis (i.e. ``axis=-1``).
 
     Returns
     -------
@@ -1112,10 +1113,10 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     return freqs, Cxy
 
 
-def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None,
-                    noverlap=None, nfft=None, detrend='constant',
-                    return_onesided=True, scaling='spectrum', axis=-1,
-                    mode='psd', padded=False, centered=False):
+def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
+                     nfft=None, detrend='constant', return_onesided=True,
+                     scaling='spectrum', axis=-1, mode='psd', padded=False,
+                     centered=False):
     """
     Calculate various forms of windowed FFTs for PSD, CSD, etc.
 
@@ -1216,9 +1217,9 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None,
     x = np.asarray(x)
     if not same_data:
         y = np.asarray(y)
-        outdtype = np.result_type(x,y,np.complex64)
+        outdtype = np.result_type(x, y, np.complex64)
     else:
-        outdtype = np.result_type(x,np.complex64)
+        outdtype = np.result_type(x, np.complex64)
 
     if not same_data:
         # Check if we can broadcast the outer axes together
@@ -1329,8 +1330,8 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None,
     if return_onesided is True:
         if np.iscomplexobj(x):
             sides = 'twosided'
-            warnings.warn('Input data is complex, switching to return_onesided='
-                          'False')
+            warnings.warn('Input data is complex, switching to '
+                          'return_onesided=False')
         else:
             sides = 'onesided'
             if not same_data:
@@ -1360,10 +1361,10 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None,
     result *= scale
     if sides == 'onesided' and mode == 'psd':
         if nfft % 2:
-            result[...,1:] *= 2
+            result[..., 1:] *= 2
         else:
             # Last point is unpaired Nyquist freq point, don't double
-            result[...,1:-1] *= 2
+            result[..., 1:-1] *= 2
 
     time = np.arange(nperseg/2, x.shape[-1] - nperseg/2 + 1,
                      nperseg - noverlap)/float(fs)

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -150,7 +150,7 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
 def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
           detrend='constant', return_onesided=True, scaling='density',
           axis=-1):
-    """
+    r"""
     Estimate power spectral density using Welch's method.
 
     Welch's method [1]_ computes an estimate of the power spectral
@@ -291,7 +291,7 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
 
 def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         detrend='constant', return_onesided=True, scaling='density', axis=-1):
-    """
+    r"""
     Estimate the cross power spectral density, Pxy, using Welch's
     method.
 
@@ -363,7 +363,7 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
 
     An appropriate amount of overlap will depend on the choice of window
     and on your requirements. For the default 'hann' window an overlap
-    of 50\\% is a reasonable trade off between accurately estimating the
+    of 50% is a reasonable trade off between accurately estimating the
     signal power, while not over counting any of the data. Narrower
     windows may require a larger overlap.
 
@@ -580,7 +580,7 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=None, noverlap=None,
 
 
 def check_COLA(window, nperseg, noverlap, tol=1e-10):
-    """
+    r"""
     Check whether the Constant OverLap Add (COLA) constraint is met
 
     Parameters
@@ -704,7 +704,7 @@ def check_COLA(window, nperseg, noverlap, tol=1e-10):
 def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
          detrend=False, return_onesided=True, centered=True, padded=True,
          axis=-1):
-    """
+    r"""
     Compute the Short Time Fourier Transform (STFT).
 
     STFTs can be used as a way of quantifying the change of a
@@ -845,7 +845,7 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
 
 def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
           input_onesided=True, centered=True, time_axis=-1, freq_axis=-2):
-    """
+    r"""
     Perform the inverse Short Time Fourier transform (iSTFT).
 
     Parameters
@@ -1107,7 +1107,7 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
 
 def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
               nfft=None, detrend='constant', axis=-1):
-    """
+    r"""
     Estimate the magnitude squared coherence estimate, Cxy, of
     discrete-time signals X and Y using Welch's method.
 
@@ -1167,7 +1167,7 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     --------
     An appropriate amount of overlap will depend on the choice of window
     and on your requirements. For the default 'hann' window an overlap
-    of 50\\% is a reasonable trade off between accurately estimating the
+    of 50% is a reasonable trade off between accurately estimating the
     signal power, while not over counting any of the data. Narrower
     windows may require a larger overlap.
 

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -789,7 +789,7 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     >>> mod = 500*np.cos(2*np.pi*0.25*time)
     >>> carrier = amp * np.sin(2*np.pi*3e3*time + mod)
     >>> noise = np.random.normal(scale=np.sqrt(noise_power),
-    >>>                          size=time.shape)
+    ...                          size=time.shape)
     >>> noise *= np.exp(-time/5)
     >>> x = carrier + noise
 
@@ -924,7 +924,7 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     >>> time = np.arange(N) / float(fs)
     >>> carrier = amp * np.sin(2*np.pi*50*time)
     >>> noise = np.random.normal(scale=np.sqrt(noise_power),
-    >>>                          size=time.shape)
+    ...                          size=time.shape)
     >>> x = carrier + noise
 
     Compute the STFT, and plot its magnitude
@@ -959,6 +959,14 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
 
     # Make sure input is an ndarray of appropriate complex dtype
     Zxx = np.asarray(Zxx) + 0j
+    freq_axis = int(freq_axis)
+    time_axis = int(time_axis)
+
+    if Zxx.ndim < 2:
+        raise ValueError('Input stft must be at least 2d!')
+
+    if freq_axis == time_axis:
+        raise ValueError('Must specify differing time and frequency axes!')
 
     nseg = Zxx.shape[time_axis]
 
@@ -1000,24 +1008,16 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
                          'COLA constraint.')
 
     # Rearrange axes if neccessary
-    freq_axis = int(freq_axis)
-    time_axis = int(time_axis)
-    if freq_axis == time_axis:
-        raise ValueError('Must specify differing time and frequency axes!')
-
-    if Zxx.ndim >= 2:
-        if time_axis != Zxx.ndim-1 or freq_axis != Zxx.ndim-2:
-            # Turn negative indices to positive for the call to transpose
-            if freq_axis < 0:
-                freq_axis = Zxx.ndim + freq_axis
-            if time_axis < 0:
-                time = Zxx.ndim + time_axis
-            zouter = list(range(Zxx.ndim))
-            for ax in sorted([time_axis, freq_axis], reverse=True):
-                zouter.pop(ax)
-            Zxx = np.transpose(Zxx, zouter+[freq_axis, time_axis])
-    else:
-        raise ValueError('Input stft must be at least 2d!')
+    if time_axis != Zxx.ndim-1 or freq_axis != Zxx.ndim-2:
+        # Turn negative indices to positive for the call to transpose
+        if freq_axis < 0:
+            freq_axis = Zxx.ndim + freq_axis
+        if time_axis < 0:
+            time = Zxx.ndim + time_axis
+        zouter = list(range(Zxx.ndim))
+        for ax in sorted([time_axis, freq_axis], reverse=True):
+            zouter.pop(ax)
+        Zxx = np.transpose(Zxx, zouter+[freq_axis, time_axis])
 
     # Get window as array
     if isinstance(window, string_types) or type(window) is tuple:

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -569,14 +569,14 @@ def check_COLA(window, nperseg, noverlap, tol=1e-10):
     reconstruction.
 
     Some examples of windows that satisfy COLA:
-        - Rectangular window at 0% & 50% overlap
-        - Bartlett window at overlap of 1/2, 3/4, 5/6, 7/8, ...
-        - Hann window at 50% & 75% overlap
+        - Rectangular window at overlap of 0, 1/2, 2/3, 3/4, ...
+        - Bartlett window at overlap of 1/2, 3/4, 5/6, ...
+        - Hann window at 1/2, 2/3, 3/4, ...
         - Any Blackman family window at 2/3 overlap
         - Any window with ``noverlap = nperseg-1``
 
-    A very comprehensive of other windows may be found in [2]_, wherein the
-    COLA condition is satisfied when the "Amplitude Flatness" is unity.
+    A very comprehensive list of other windows may be found in [2]_, wherein
+    the COLA condition is satisfied when the "Amplitude Flatness" is unity.
 
     .. versionadded:: 0.18.0
 
@@ -589,6 +589,38 @@ def check_COLA(window, nperseg, noverlap, tol=1e-10):
            including a comprehensive list of window functions and some new
            at-top windows", 2002,
            http://hdl.handle.net/11858/00-001M-0000-0013-557A-5
+
+    Examples
+    --------
+    >>> from scipy import signal
+
+    Confirm COLA condition for rectangular window of 75% (3/4) overlap:
+
+    >>> signal.check_COLA(signal.boxcar(100), 100, 75)
+    True
+
+    COLA is not true for 25% (1/4) overlap, though:
+
+    >>> signal.check_COLA(signal.boxcar(100), 100, 25)
+    False
+
+    "Symmetrical" Hann window (for filter design) is not COLA:
+
+    >>> signal.check_COLA(signal.hann(120, sym=True), 120, 60)
+    False
+
+    "Periodic" or "DFT-even" Hann window (for FFT analysis) is COLA for
+    overlap of 1/2, 2/3, 3/4, etc.:
+
+    >>> signal.check_COLA(signal.hann(120, sym=False), 120, 60)
+    True
+
+    >>> signal.check_COLA(signal.hann(120, sym=False), 120, 80)
+    True
+
+    >>> signal.check_COLA(signal.hann(120, sym=False), 120, 90)
+    True
+
     """
 
     nperseg = int(nperseg)

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -17,7 +17,7 @@ __all__ = ['periodogram', 'welch', 'lombscargle', 'csd', 'coherence',
            'spectrogram', 'stft', 'istft', 'check_COLA']
 
 
-def periodogram(x, fs=1.0, window=None, nfft=None, detrend='constant',
+def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
                 return_onesided=True, scaling='density', axis=-1):
     """
     Estimate power spectral density using a periodogram.
@@ -29,28 +29,32 @@ def periodogram(x, fs=1.0, window=None, nfft=None, detrend='constant',
     fs : float, optional
         Sampling frequency of the `x` time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows and
-        required parameters. If `window` is an array it will be used
-        directly as the window. Defaults to None; equivalent to 'boxcar'.
+        Desired window to use. See `get_window` for a list of windows
+        and required parameters. If `window` is array_like it will be
+        used directly as the window and its length must be nperseg.
+        Defaults to 'boxcar'.
     nfft : int, optional
-        Length of the FFT used. If None the length of `x` will be used.
-    detrend : str or function or False, optional
-        Specifies how to detrend `x` prior to computing the spectrum. If
-        `detrend` is a string, it is passed as the ``type`` argument to
-        `detrend`.  If it is a function, it should return a detrended array.
-        If `detrend` is False, no detrending is done.  Defaults to 'constant'.
+        Length of the FFT used. If `None` the length of `x` will be
+        used.
+    detrend : str or function or `False`, optional
+        Specifies how to detrend each segment. If `detrend` is a
+        string, it is passed as the `type` argument to the `detrend`
+        function. If it is a function, it takes a segment and returns a
+        detrended segment. If `detrend` is `False`, no detrending is
+        done. Defaults to 'constant'.
     return_onesided : bool, optional
-        If True, return a one-sided spectrum for real data. If False return
-        a two-sided spectrum. Note that for complex data, a two-sided
-        spectrum is always returned.
+        If `True`, return a one-sided spectrum for real data. If
+        `False` return a two-sided spectrum. Note that for complex
+        data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the power spectral density ('density')
-        where `Pxx` has units of V**2/Hz and computing the power spectrum
-        ('spectrum') where `Pxx` has units of V**2, if `x` is measured in V
-        and fs is measured in Hz.  Defaults to 'density'
+        where `Pxx` has units of V**2/Hz and computing the power
+        spectrum ('spectrum') where `Pxx` has units of V**2, if `x`
+        is measured in V and `fs` is measured in Hz. Defaults to
+        'density'
     axis : int, optional
-        Axis along which the periodogram is computed; the default is over
-        the last axis (i.e. ``axis=-1``).
+        Axis along which the periodogram is computed; the default is
+        over the last axis (i.e. ``axis=-1``).
 
     Returns
     -------
@@ -111,7 +115,8 @@ def periodogram(x, fs=1.0, window=None, nfft=None, detrend='constant',
     >>> plt.ylabel('Linear spectrum [V RMS]')
     >>> plt.show()
 
-    The peak height in the power spectrum is an estimate of the RMS amplitude.
+    The peak height in the power spectrum is an estimate of the RMS
+    amplitude.
 
     >>> np.sqrt(Pxx_spec.max())
     2.0077340678640727
@@ -148,9 +153,10 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     """
     Estimate power spectral density using Welch's method.
 
-    Welch's method [1]_ computes an estimate of the power spectral density
-    by dividing the data into overlapping segments, computing a modified
-    periodogram for each segment and averaging the periodograms.
+    Welch's method [1]_ computes an estimate of the power spectral
+    density by dividing the data into overlapping segments, computing a
+    modified periodogram for each segment and averaging the
+    periodograms.
 
     Parameters
     ----------
@@ -159,37 +165,39 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     fs : float, optional
         Sampling frequency of the `x` time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows and
-        required parameters. If `window` is array_like it will be used
-        directly as the window and its length will be used for nperseg.
-        Defaults to 'hann'.
+        Desired window to use. See `get_window` for a list of windows
+        and required parameters. If `window` is array_like it will be
+        used directly as the window and its length must be nperseg.
+        Defaults to a Hann window.
     nperseg : int, optional
         Length of each segment. Defaults to None, but if window is str or
         tuple, is set to 256, and if window is array_like, is set to the
         length of the window.
     noverlap : int, optional
-        Number of points to overlap between segments. If None,
-        ``noverlap = nperseg // 2``.  Defaults to None.
+        Number of points to overlap between segments. If `None`,
+        ``noverlap = nperseg // 2``. Defaults to `None`.
     nfft : int, optional
-        Length of the FFT used, if a zero padded FFT is desired.  If None,
-        the FFT length is `nperseg`. Defaults to None.
-    detrend : str or function or False, optional
-        Specifies how to detrend each segment. If `detrend` is a string,
-        it is passed as the ``type`` argument to `detrend`.  If it is a
-        function, it takes a segment and returns a detrended segment.
-        If `detrend` is False, no detrending is done.  Defaults to 'constant'.
+        Length of the FFT used, if a zero padded FFT is desired. If
+        `None`, the FFT length is `nperseg`. Defaults to `None`.
+    detrend : str or function or `False`, optional
+        Specifies how to detrend each segment. If `detrend` is a
+        string, it is passed as the `type` argument to the `detrend`
+        function. If it is a function, it takes a segment and returns a
+        detrended segment. If `detrend` is `False`, no detrending is
+        done. Defaults to 'constant'.
     return_onesided : bool, optional
-        If True, return a one-sided spectrum for real data. If False return
-        a two-sided spectrum. Note that for complex data, a two-sided
-        spectrum is always returned.
+        If `True`, return a one-sided spectrum for real data. If
+        `False` return a two-sided spectrum. Note that for complex
+        data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the power spectral density ('density')
-        where `Pxx` has units of V**2/Hz and computing the power spectrum
-        ('spectrum') where `Pxx` has units of V**2, if `x` is measured in V
-        and fs is measured in Hz.  Defaults to 'density'
+        where `Pxx` has units of V**2/Hz and computing the power
+        spectrum ('spectrum') where `Pxx` has units of V**2, if `x`
+        is measured in V and `fs` is measured in Hz. Defaults to
+        'density'
     axis : int, optional
-        Axis along which the periodogram is computed; the default is over
-        the last axis (i.e. ``axis=-1``).
+        Axis along which the periodogram is computed; the default is
+        over the last axis (i.e. ``axis=-1``).
 
     Returns
     -------
@@ -206,12 +214,13 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     Notes
     -----
     An appropriate amount of overlap will depend on the choice of window
-    and on your requirements.  For the default 'hann' window an
-    overlap of 50% is a reasonable trade off between accurately estimating
-    the signal power, while not over counting any of the data.  Narrower
+    and on your requirements. For the default 'hann' window an overlap
+    of 50% is a reasonable trade off between accurately estimating the
+    signal power, while not over counting any of the data. Narrower
     windows may require a larger overlap.
 
-    If `noverlap` is 0, this method is equivalent to Bartlett's method [2]_.
+    If `noverlap` is 0, this method is equivalent to Bartlett's method
+    [2]_.
 
     .. versionadded:: 0.12.0
 
@@ -266,7 +275,8 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     >>> plt.ylabel('Linear spectrum [V RMS]')
     >>> plt.show()
 
-    The peak height in the power spectrum is an estimate of the RMS amplitude.
+    The peak height in the power spectrum is an estimate of the RMS
+    amplitude.
 
     >>> np.sqrt(Pxx_spec.max())
     2.0077340678640727
@@ -282,7 +292,8 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
 def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         detrend='constant', return_onesided=True, scaling='density', axis=-1):
     """
-    Estimate the cross power spectral density, Pxy, using Welch's method.
+    Estimate the cross power spectral density, Pxy, using Welch's
+    method.
 
     Parameters
     ----------
@@ -291,39 +302,41 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     y : array_like
         Time series of measurement values
     fs : float, optional
-        Sampling frequency of the `x` and `y` time series. Defaults to 1.0.
+        Sampling frequency of the `x` and `y` time series. Defaults
+        to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows and
-        required parameters. If `window` is array_like it will be used
-        directly as the window and its length will be used for nperseg.
-        Defaults to 'hann'.
+        Desired window to use. See `get_window` for a list of windows
+        and required parameters. If `window` is array_like it will be
+        used directly as the window and its length must be nperseg.
+        Defaults to a Hann window.
     nperseg : int, optional
         Length of each segment. Defaults to None, but if window is str or
         tuple, is set to 256, and if window is array_like, is set to the
         length of the window.
     noverlap: int, optional
-        Number of points to overlap between segments. If None,
-        ``noverlap = nperseg // 2``.  Defaults to None.
+        Number of points to overlap between segments. If `None`,
+        ``noverlap = nperseg // 2``. Defaults to `None`.
     nfft : int, optional
-        Length of the FFT used, if a zero padded FFT is desired. If None,
-        the FFT length is `nperseg`. Defaults to None.
-    detrend : str or function or False, optional
-        Specifies how to detrend each segment. If `detrend` is a string,
-        it is passed as the ``type`` argument to `detrend`.  If it is a
-        function, it takes a segment and returns a detrended segment.
-        If `detrend` is False, no detrending is done.  Defaults to 'constant'.
+        Length of the FFT used, if a zero padded FFT is desired. If
+        `None`, the FFT length is `nperseg`. Defaults to `None`.
+    detrend : str or function or `False`, optional
+        Specifies how to detrend each segment. If `detrend` is a
+        string, it is passed as the `type` argument to the `detrend`
+        function. If it is a function, it takes a segment and returns a
+        detrended segment. If `detrend` is `False`, no detrending is
+        done. Defaults to 'constant'.
     return_onesided : bool, optional
-        If True, return a one-sided spectrum for real data. If False return
-        a two-sided spectrum. Note that for complex data, a two-sided
-        spectrum is always returned.
+        If `True`, return a one-sided spectrum for real data. If
+        `False` return a two-sided spectrum. Note that for complex
+        data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the cross spectral density ('density')
         where `Pxy` has units of V**2/Hz and computing the cross spectrum
         ('spectrum') where `Pxy` has units of V**2, if `x` and `y` are
-        measured in V and fs is measured in Hz.  Defaults to 'density'
+        measured in V and `fs` is measured in Hz. Defaults to 'density'
     axis : int, optional
-        Axis along which the CSD is computed for both inputs; the default is
-        over the last axis (i.e. ``axis=-1``).
+        Axis along which the CSD is computed for both inputs; the
+        default is over the last axis (i.e. ``axis=-1``).
 
     Returns
     -------
@@ -336,21 +349,22 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     --------
     periodogram: Simple, optionally modified periodogram
     lombscargle: Lomb-Scargle periodogram for unevenly sampled data
-    welch: Power spectral density by Welch's method. [Equivalent to csd(x,x)]
+    welch: Power spectral density by Welch's method. [Equivalent to
+           csd(x,x)]
     coherence: Magnitude squared coherence by Welch's method.
 
     Notes
     --------
-    By convention, Pxy is computed with the conjugate FFT of X multiplied by
-    the FFT of Y.
+    By convention, Pxy is computed with the conjugate FFT of X
+    multiplied by the FFT of Y.
 
     If the input series differ in length, the shorter series will be
     zero-padded to match.
 
     An appropriate amount of overlap will depend on the choice of window
-    and on your requirements.  For the default 'hann' window an
-    overlap of 50\\% is a reasonable trade off between accurately estimating
-    the signal power, while not over counting any of the data.  Narrower
+    and on your requirements. For the default 'hann' window an overlap
+    of 50\\% is a reasonable trade off between accurately estimating the
+    signal power, while not over counting any of the data. Narrower
     windows may require a larger overlap.
 
     .. versionadded:: 0.16.0
@@ -422,34 +436,36 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=None, noverlap=None,
     fs : float, optional
         Sampling frequency of the `x` time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows and
-        required parameters. If `window` is array_like it will be used
-        directly as the window and its length will be used for nperseg.
+        Desired window to use. See `get_window` for a list of windows
+        and required parameters. If `window` is array_like it will be
+        used directly as the window and its length must be nperseg.
         Defaults to a Tukey window with shape parameter of 0.25.
     nperseg : int, optional
         Length of each segment. Defaults to None, but if window is str or
         tuple, is set to 256, and if window is array_like, is set to the
         length of the window.
     noverlap : int, optional
-        Number of points to overlap between segments. If None,
-        ``noverlap = nperseg // 8``.  Defaults to None.
+        Number of points to overlap between segments. If `None`,
+        ``noverlap = nperseg // 8``. Defaults to `None`.
     nfft : int, optional
-        Length of the FFT used, if a zero padded FFT is desired.  If None,
-        the FFT length is `nperseg`. Defaults to None.
-    detrend : str or function or False, optional
-        Specifies how to detrend each segment. If `detrend` is a string,
-        it is passed as the ``type`` argument to `detrend`.  If it is a
-        function, it takes a segment and returns a detrended segment.
-        If `detrend` is False, no detrending is done.  Defaults to 'constant'.
+        Length of the FFT used, if a zero padded FFT is desired. If
+        `None`, the FFT length is `nperseg`. Defaults to `None`.
+    detrend : str or function or `False`, optional
+        Specifies how to detrend each segment. If `detrend` is a
+        string, it is passed as the `type` argument to the `detrend`
+        function. If it is a function, it takes a segment and returns a
+        detrended segment. If `detrend` is `False`, no detrending is
+        done. Defaults to 'constant'.
     return_onesided : bool, optional
-        If True, return a one-sided spectrum for real data. If False return
-        a two-sided spectrum. Note that for complex data, a two-sided
-        spectrum is always returned.
+        If `True`, return a one-sided spectrum for real data. If
+        `False` return a two-sided spectrum. Note that for complex
+        data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the power spectral density ('density')
-        where `Pxx` has units of V**2/Hz and computing the power spectrum
-        ('spectrum') where `Pxx` has units of V**2, if `x` is measured in V
-        and fs is measured in Hz.  Defaults to 'density'
+        where `Sxx` has units of V**2/Hz and computing the power
+        spectrum ('spectrum') where `Sxx` has units of V**2, if `x`
+        is measured in V and `fs` is measured in Hz. Defaults to
+        'density'.
     axis : int, optional
         Axis along which the spectrogram is computed; the default is over
         the last axis (i.e. ``axis=-1``).
@@ -461,8 +477,8 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=None, noverlap=None,
     t : ndarray
         Array of segment times.
     Sxx : ndarray
-        Spectrogram of x. By default, the last axis of Sxx corresponds to the
-        segment times.
+        Spectrogram of x. By default, the last axis of Sxx corresponds
+        to the segment times.
 
     See Also
     --------
@@ -474,17 +490,19 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=None, noverlap=None,
     Notes
     -----
     An appropriate amount of overlap will depend on the choice of window
-    and on your requirements. In contrast to welch's method, where the entire
-    data stream is averaged over, one may wish to use a smaller overlap (or
-    perhaps none at all) when computing a spectrogram, to maintain some
-    statistical independence between individual segments.
+    and on your requirements. In contrast to welch's method, where the
+    entire data stream is averaged over, one may wish to use a smaller
+    overlap (or perhaps none at all) when computing a spectrogram, to
+    maintain some statistical independence between individual segments.
+    It is for this reason that the default window is a Tukey window with
+    1/8th of a window's length overlap at each end.
 
     .. versionadded:: 0.16.0
 
     References
     ----------
-    .. [1] Oppenheim, Alan V., Ronald W. Schafer, John R. Buck "Discrete-Time
-           Signal Processing", Prentice Hall, 1999.
+    .. [1] Oppenheim, Alan V., Ronald W. Schafer, John R. Buck
+           "Discrete-Time Signal Processing", Prentice Hall, 1999.
 
     Examples
     --------
@@ -492,8 +510,8 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=None, noverlap=None,
     >>> import matplotlib.pyplot as plt
 
     Generate a test signal, a 2 Vrms sine wave whose frequency is slowly
-    modulated around 3kHz, corrupted by white noise of exponentially decreasing
-    magnitude sampled at 10 kHz.
+    modulated around 3kHz, corrupted by white noise of exponentially
+    decreasing magnitude sampled at 10 kHz.
 
     >>> fs = 10e3
     >>> N = 1e5
@@ -537,10 +555,9 @@ def check_COLA(window, nperseg, noverlap, tol=1e-10):
     Parameters
     ----------
     window : str or tuple or array_like
-        Desired window to use. See `get_window` for a list of windows and
-        required parameters. If `window` is array_like it will be used directly
-        as the window. If `window` is an object with a length, `len(window)`
-        will override the value supplied in `nperseg`.
+        Desired window to use. See `get_window` for a list of windows
+        and required parameters. If `window` is array_like it will be
+        used directly as the window and its length must be `nperseg`.
     nperseg : int
         Length of each segment.
     noverlap : int
@@ -552,8 +569,8 @@ def check_COLA(window, nperseg, noverlap, tol=1e-10):
     Returns
     -------
     verdict : bool
-        `True` if chosen combination satisfies COLA within `tol`, `False`
-        otherwise
+        `True` if chosen combination satisfies COLA within `tol`,
+        `False` otherwise
 
     See Also
     --------
@@ -564,8 +581,8 @@ def check_COLA(window, nperseg, noverlap, tol=1e-10):
     -----
     In order to enable inversion of an STFT via the inverse STFT in
     `istft`, the signal windowing must obey the constraint of "Constant
-    OverLap Add" (COLA). This ensures that every point in the input data is
-    equally weighted, thereby avoiding aliasing and allowing full
+    OverLap Add" (COLA). This ensures that every point in the input data
+    is equally weighted, thereby avoiding aliasing and allowing full
     reconstruction.
 
     Some examples of windows that satisfy COLA:
@@ -575,19 +592,20 @@ def check_COLA(window, nperseg, noverlap, tol=1e-10):
         - Any Blackman family window at 2/3 overlap
         - Any window with ``noverlap = nperseg-1``
 
-    A very comprehensive list of other windows may be found in [2]_, wherein
-    the COLA condition is satisfied when the "Amplitude Flatness" is unity.
+    A very comprehensive list of other windows may be found in [2]_,
+    wherein the COLA condition is satisfied when the "Amplitude
+    Flatness" is unity.
 
-    .. versionadded:: 0.18.0
+    .. versionadded:: 0.19.0
 
     References
     ----------
     .. [1] Julius O. Smith III, "Spectral Audio Signal Processing", W3K
            Publishing, 2011,ISBN 978-0-9745607-3-1.
-    .. [2] G. Heinzel, A. Ruediger and R. Schilling, "Spectrum and spectral
-           density estimation by the Discrete Fourier transform (DFT),
-           including a comprehensive list of window functions and some new
-           at-top windows", 2002,
+    .. [2] G. Heinzel, A. Ruediger and R. Schilling, "Spectrum and
+           spectral density estimation by the Discrete Fourier transform
+           (DFT), including a comprehensive list of window functions and
+           some new at-top windows", 2002,
            http://hdl.handle.net/11858/00-001M-0000-0013-557A-5
 
     Examples
@@ -658,8 +676,8 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     """
     Compute the Short Time Fourier Transform (STFT).
 
-    STFTs can be used as a way of quantifying the change of a nonstationary
-    signal's frequency and phase content over time.
+    STFTs can be used as a way of quantifying the change of a
+    nonstationary signal's frequency and phase content over time.
 
     Parameters
     ----------
@@ -668,40 +686,44 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     fs : float, optional
         Sampling frequency of the `x` time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows and
-        required parameters. If `window` is array_like it will be used
-        directly as the window and its length will be used for nperseg.
+        Desired window to use. See `get_window` for a list of windows
+        and required parameters. If `window` is array_like it will be
+        used directly as the window and its length must be nperseg.
         Defaults to a Hann window.
     nperseg : int, optional
         Length of each segment. Defaults to 256.
     noverlap : int, optional
-        Number of points to overlap between segments. If None, ``noverlap =
-        nperseg // 2``. Defaults to None. When specified, the COLA
-        constraint must be met (see Notes below).
+        Number of points to overlap between segments. If `None`,
+        ``noverlap = nperseg // 2``. Defaults to `None`. When
+        specified, the COLA constraint must be met (see Notes below).
     nfft : int, optional
-        Length of the FFT used, if a zero padded FFT is desired.  If None,
-        the FFT length is `nperseg`. Defaults to None.
-    detrend : str or function or False, optional
-        Specifies how to detrend each segment. If `detrend` is a string, it is
-        passed as the ``type`` argument to `detrend`.  If it is a function, it
-        takes a segment and returns a detrended segment. If `detrend` is
-        ``False``, no detrending is done.  Defaults to ``False``.
+        Length of the FFT used, if a zero padded FFT is desired. If
+        `None`, the FFT length is `nperseg`. Defaults to `None`.
+    detrend : str or function or `False`, optional
+        Specifies how to detrend each segment. If `detrend` is a
+        string, it is passed as the `type` argument to the `detrend`
+        function. If it is a function, it takes a segment and returns a
+        detrended segment. If `detrend` is `False`, no detrending is
+        done. Defaults to `False`.
     return_onesided : bool, optional
-        If True, return a one-sided spectrum for real data. If False return
-        a two-sided spectrum. Note that for complex data, a two-sided
-        spectrum is always returned.
+        If `True`, return a one-sided spectrum for real data. If
+        `False` return a two-sided spectrum. Note that for complex
+        data, a two-sided spectrum is always returned. Defaults to
+        `True`.
     padded : bool, optional
         Specifies whether the input signal is zero-padded to make the
         signal fit exactly into an integer number of window segments, so
-        that all of the signal is included in the output.
+        that all of the signal is included in the output. Default to
+        `True`.
     centered : bool, optional
-        Specifies whether the input signal is padded via odd extension, to
-        center the first window segment on the first input point. This has
-        the benefit of enabling reconstruction of the first data point
-        when the employed window function starts at zero. Defaults to True.
+        Specifies whether the input signal is padded via odd extension,
+        to center the first window segment on the first input point.
+        This has the benefit of enabling reconstruction of the first
+        data point when the employed window function starts at zero.
+        Defaults to `True.`
     axis : int, optional
-        Axis along which the STFT is computed; the default is over the last
-        axis (i.e. ``axis=-1``).
+        Axis along which the STFT is computed; the default is over the
+        last axis (i.e. ``axis=-1``).
 
     Returns
     -------
@@ -710,13 +732,14 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     t : ndarray
         Array of segment times.
     Zxx : ndarray
-        STFT of ``x``. By default, the last axis of ``Zxx`` corresponds to the
-        segment times.
+        STFT of `x`. By default, the last axis of `Zxx` corresponds
+        to the segment times.
 
     See Also
     --------
     istft: Inverse Short Time Fourier Transform
-    check_COLA: Check whether the Constant OverLap Add (COLA) constraint is met
+    check_COLA: Check whether the Constant OverLap Add (COLA) constraint
+                is met
     welch: Power spectral density by Welch's method.
     spectrogram: Spectrogram by Welch's method.
     csd: Cross spectral density by Welch's method.
@@ -724,34 +747,37 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
 
     Notes
     -----
-    In order to enable inversion of an STFT via the inverse STFT in `istft`,
-    the signal windowing must obey the constraint of "Constant OverLap Add"
-    (COLA), and the input signal must have complete windowing coverage (i.e.
-    ``(x.shape[axis] - nperseg) % (nperseg-noverlap) == 0``).
+    In order to enable inversion of an STFT via the inverse STFT in
+    `istft`, the signal windowing must obey the constraint of "Constant
+    OverLap Add" (COLA), and the input signal must have complete
+    windowing coverage (i.e. ``(x.shape[axis] - nperseg) %
+    (nperseg-noverlap) == 0``). The `padded` argument may be used to
+    accomplish this.
 
-    The COLA constraint ensures that every point in the input data is equally
-    weighted, thereby avoiding aliasing and allowing full reconstruction.
-    Whether a choice of ``window``, ``nperseg``, and ``noverlap`` satisfy this
-    constraint can be tested with `check_COLA`.
+    The COLA constraint ensures that every point in the input data is
+    equally weighted, thereby avoiding aliasing and allowing full
+    reconstruction. Whether a choice of `window`, `nperseg`, and
+    `noverlap` satisfy this constraint can be tested with
+    `check_COLA`.
 
-    ..  versionadded:: 0.18.0
+    .. versionadded:: 0.19.0
 
     References
     ----------
     .. [1] Oppenheim, Alan V., Ronald W. Schafer, John R. Buck
            "Discrete-Time Signal Processing", Prentice Hall, 1999.
-    .. [2] Daniel W. Griffin, Jae S. Limdt "Signal Estimation from Modified
-           Short Fourier Transform", IEEE 1984, 10.1109/TASSP.1984.1164317
+    .. [2] Daniel W. Griffin, Jae S. Limdt "Signal Estimation from
+           Modified Short Fourier Transform", IEEE 1984,
+           10.1109/TASSP.1984.1164317
 
     Examples
     --------
     >>> from scipy import signal
-    >>> from scipy.fftpack import fftshift
     >>> import matplotlib.pyplot as plt
 
     Generate a test signal, a 2 Vrms sine wave whose frequency is slowly
-    modulated around 3kHz, corrupted by white noise of exponentially decreasing
-    magnitude sampled at 10 kHz.
+    modulated around 3kHz, corrupted by white noise of exponentially
+    decreasing magnitude sampled at 10 kHz.
 
     >>> fs = 10e3
     >>> N = 1e5
@@ -760,17 +786,15 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     >>> time = np.arange(N) / float(fs)
     >>> mod = 500*np.cos(2*np.pi*0.25*time)
     >>> carrier = amp * np.sin(2*np.pi*3e3*time + mod)
-    >>> noise = np.random.normal(scale=np.sqrt(noise_power), size=time.shape)
+    >>> noise = np.random.normal(scale=np.sqrt(noise_power),
+    >>>                          size=time.shape)
     >>> noise *= np.exp(-time/5)
     >>> x = carrier + noise
 
     Compute and plot the STFT's magnitude.
 
     >>> f, t, Zxx = signal.stft(x, fs, nperseg=1000)
-    >>> f = fftshift(f)
-    >>> Zxx = fftshift(Zxx, axes=0)
     >>> plt.pcolormesh(t, f, np.abs(Zxx), vmin=0, vmax=amp)
-    >>> plt.ylim([0, f[-1]])
     >>> plt.title('STFT Magnitude')
     >>> plt.ylabel('Frequency [Hz]')
     >>> plt.xlabel('Time [sec]')
@@ -791,93 +815,104 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     """
     Perform the inverse Short Time Fourier transform (iSTFT).
 
-
     Parameters
     ----------
     Zxx : array_like
-        STFT of the signal to be reconstructed. If a purely real array is
-        passed, it will be cast to a complex data type.
+        STFT of the signal to be reconstructed. If a purely real array
+        is passed, it will be cast to a complex data type.
     fs : float, optional
         Sampling frequency of the time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows and
-        required parameters. If ``window`` is array_like it will be used
-        directly as the window and its length will be used for nperseg.
-        Defaults to a Hann window. Must match the window used to generate
-        the STFT for faithful inversion.
+        Desired window to use. See `get_window` for a list of windows
+        and required parameters. If `window` is array_like it will be
+        used directly as the window and its length must be `nperseg`.
+        Defaults to a Hann window. Must match the window used to
+        generate the STFT for faithful inversion.
     nperseg : int, optional
         Number of data points corresponding to each STFT segment. This
-        parameter must be specified if the number of data points per segment is
-        odd, or if the STFT was padded via ``nfft > nperseg``. If ``None``, the
-        value depends on the shape of ``Zxx`` and ``input_onesided``. If
-        ``input_onesided=True``, ``nperseg=2*(Zxx.shape[freq_axis] - 1)``.
-        Otherwise, ``nperseg=Zxx.shape[freq_axis]``.
+        parameter must be specified if the number of data points per
+        segment is odd, or if the STFT was padded via ``nfft >
+        nperseg``. If `None`, the value depends on the shape of
+        `Zxx` and `input_onesided`. If `input_onesided` is True,
+        ``nperseg=2*(Zxx.shape[freq_axis] - 1)``. Otherwise,
+        ``nperseg=Zxx.shape[freq_axis]``. Defaults to `None`.
     noverlap : int, optional
-        Number of points to overlap between segments. If ``None``, half of the
-        segment length. Defaults to ``None``. When specified, the COLA
-        constraint must be met (see Notes below), and should match the
-        parameter used to generate the STFT.
+        Number of points to overlap between segments. If `None`, half
+        of the segment length. Defaults to `None`. When specified, the
+        COLA constraint must be met (see Notes below), and should match
+        the parameter used to generate the STFT. Defaults to `None`.
     nfft : int, optional
-        Number of FFT points corresponding to each STFT segment. This parameter
-        must be specified if the STFT was padded via ``nfft > nperseg``. If
-        ``None``, the default values are the same as for ``nperseg``, detailed
-        above, with one exception: if ``input_onesided`` is ``True`` and
-        ``nperseg==2*Zxx.shape[freq_axis] - 1``, ``nfft`` also takes on that
-        value. This case allows the proper inversion of an odd-length unpadded
-        STFT using ``nfft=None``.
+        Number of FFT points corresponding to each STFT segment. This
+        parameter must be specified if the STFT was padded via ``nfft >
+        nperseg``. If `None`, the default values are the same as for
+        `nperseg`, detailed above, with one exception: if
+        `input_onesided` is True and
+        ``nperseg==2*Zxx.shape[freq_axis] - 1``, `nfft` also takes on
+        that value. This case allows the proper inversion of an
+        odd-length unpadded STFT using ``nfft=None``. Defaults to
+        `None`.
     input_onesided : bool, optional
-        If ``True``, interpret the input array as one-sided FFTs, such as is
-        returned by `numpy.fft.rfft`. If ``False``, interpret the input as a a
-        two-sided FFT.
+        If `True`, interpret the input array as one-sided FFTs, such
+        as is returned by `stft` with ``return_onesided=True`` and
+        `numpy.fft.rfft`. If `False`, interpret the input as a a
+        two-sided FFT. Defaults to `True`.
     centered : bool, optional
-        Specifies whether the input signal was padded via odd extension, by
-        using ``centered=True`` in `stft`. Defaults to ``True``.
+        Specifies whether the input signal was padded via odd extension,
+        by using ``centered=True`` in `stft`. Defaults to `True`.
     time_axis : int, optional
-        Where the time segments of the STFT is located; the default is the
-        last axis (i.e. ``axis=-1``).
+        Where the time segments of the STFT is located; the default is
+        the last axis (i.e. ``axis=-1``).
     freq_axis : int, optional
-        Where the frequency axis of the STFT is located; the default is the
-        penultimate axis (i.e. ``axis=-2``).
+        Where the frequency axis of the STFT is located; the default is
+        the penultimate axis (i.e. ``axis=-2``).
 
     Returns
     -------
     t : ndarray
         Array of output data times.
     x : ndarray
-        iSTFT of ``Zxx``.
+        iSTFT of `Zxx`.
 
     See Also
     --------
     stft: Short Time Fourier Transform
-    check_COLA: Check whether the Constant OverLap Add (COLA) constraint is met
+    check_COLA: Check whether the Constant OverLap Add (COLA) constraint
+                is met
 
     Notes
     -----
-    In order to enable inversion of an STFT via the inverse STFT in `istft`,
-    the signal windowing must obey the constraint of "Constant OverLap Add"
-    (COLA). This ensures that every point in the input data is equally
-    weighted, thereby avoiding aliasing and allowing full reconstruction.
-    Whether a choice of ``window``, ``nperseg``, and ``noverlap`` satisfy this
-    constraint can be tested with `check_COLA`, by using ``nperseg =
-    Zxx.shape[freq_axis]``.
+    In order to enable inversion of an STFT via the inverse STFT with
+    `istft`, the signal windowing must obey the constraint of "Constant
+    OverLap Add" (COLA). This ensures that every point in the input data
+    is equally weighted, thereby avoiding aliasing and allowing full
+    reconstruction. Whether a choice of `window`, `nperseg`, and
+    `noverlap` satisfy this constraint can be tested with
+    `check_COLA`, by using ``nperseg = Zxx.shape[freq_axis]``.
 
-    .. versionadded:: 0.18.0
+    An STFT which has been modified (via masking or otherwise) is not
+    guaranteed to correspond to a exactly realizible signal. This
+    function implements the iSTFT via the least-squares esimation
+    algorithm detailed in [2]_, which produces a signal that minimizes
+    the mean squared error between the STFT of the returned signal and
+    the modified STFT.
+
+    .. versionadded:: 0.19.0
 
     References
     ----------
     .. [1] Oppenheim, Alan V., Ronald W. Schafer, John R. Buck
            "Discrete-Time Signal Processing", Prentice Hall, 1999.
-    .. [2] Daniel W. Griffin, Jae S. Limdt "Signal Estimation from Modified
-           Short Fourier Transform", IEEE 1984, 10.1109/TASSP.1984.1164317
+    .. [2] Daniel W. Griffin, Jae S. Limdt "Signal Estimation from
+           Modified Short Fourier Transform", IEEE 1984,
+           10.1109/TASSP.1984.1164317
 
     Examples
     --------
     >>> from scipy import signal
-    >>> from scipy.fftpack import fftshift
     >>> import matplotlib.pyplot as plt
 
-    Generate a test signal, a 2 Vrms sine wave at 100Hz corrupted by 0.001
-    V**2/Hz of white noise sampled at 1024 Hz.
+    Generate a test signal, a 2 Vrms sine wave at 50Hz corrupted by
+    0.001 V**2/Hz of white noise sampled at 1024 Hz.
 
     >>> fs = 1024
     >>> N = 10*fs
@@ -886,24 +921,24 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     >>> noise_power = 0.001 * fs / 2
     >>> time = np.arange(N) / float(fs)
     >>> carrier = amp * np.sin(2*np.pi*50*time)
-    >>> noise = np.random.normal(scale=np.sqrt(noise_power), size=time.shape)
+    >>> noise = np.random.normal(scale=np.sqrt(noise_power),
+    >>>                          size=time.shape)
     >>> x = carrier + noise
 
     Compute the STFT, and plot its magnitude
 
     >>> f, t, Zxx = signal.stft(x, fs=fs, nperseg=nperseg, centered=True)
-    >>> f = fftshift(f)
     >>> plt.figure()
-    >>> plt.pcolormesh(t, f, fftshift(np.abs(Zxx), axes=0), vmin=0, vmax=amp)
-    >>> plt.ylim([fs/nperseg, f[-1]])
+    >>> plt.pcolormesh(t, f, np.abs(Zxx), vmin=0, vmax=amp)
+    >>> plt.ylim([f[1], f[-1]])
     >>> plt.title('STFT Magnitude')
     >>> plt.ylabel('Frequency [Hz]')
     >>> plt.xlabel('Time [sec]')
     >>> plt.yscale('log')
     >>> plt.show()
 
-    Zero the components that are 10% or less of the carrier magnitude, then
-    convert back to a time series via inverse STFT
+    Zero the components that are 10% or less of the carrier magnitude,
+    then convert back to a time series via inverse STFT
 
     >>> Zxx = np.where(np.abs(Zxx) >= amp/10, Zxx, 0)
     >>> _, xrec = signal.istft(Zxx, fs, centered=True)
@@ -1040,12 +1075,12 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
 def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
               nfft=None, detrend='constant', axis=-1):
     """
-    Estimate the magnitude squared coherence estimate, Cxy, of discrete-time
-    signals X and Y using Welch's method.
+    Estimate the magnitude squared coherence estimate, Cxy, of
+    discrete-time signals X and Y using Welch's method.
 
-    Cxy = abs(Pxy)**2/(Pxx*Pyy), where Pxx and Pyy are power spectral density
-    estimates of X and Y, and Pxy is the cross spectral density estimate of X
-    and Y.
+    ``Cxy = abs(Pxy)**2/(Pxx*Pyy)``, where `Pxx` and `Pyy` are power
+    spectral density estimates of X and Y, and `Pxy` is the cross
+    spectral density estimate of X and Y.
 
     Parameters
     ----------
@@ -1054,30 +1089,32 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     y : array_like
         Time series of measurement values
     fs : float, optional
-        Sampling frequency of the `x` and `y` time series. Defaults to 1.0.
+        Sampling frequency of the `x` and `y` time series. Defaults
+        to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows and
-        required parameters. If `window` is array_like it will be used
-        directly as the window and its length will be used for nperseg.
-        Defaults to 'hann'.
+        Desired window to use. See `get_window` for a list of windows
+        and required parameters. If `window` is array_like it will be
+        used directly as the window and its length must be `nperseg`.
+        Defaults to a Hann window.
     nperseg : int, optional
         Length of each segment. Defaults to None, but if window is str or
         tuple, is set to 256, and if window is array_like, is set to the
         length of the window.
     noverlap: int, optional
-        Number of points to overlap between segments. If None,
-        ``noverlap = nperseg // 2``.  Defaults to None.
+        Number of points to overlap between segments. If `None`,
+        ``noverlap = nperseg // 2``. Defaults to `None`.
     nfft : int, optional
-        Length of the FFT used, if a zero padded FFT is desired.  If None,
-        the FFT length is `nperseg`. Defaults to None.
-    detrend : str or function or False, optional
-        Specifies how to detrend each segment. If `detrend` is a string,
-        it is passed as the ``type`` argument to `detrend`.  If it is a
-        function, it takes a segment and returns a detrended segment.
-        If `detrend` is False, no detrending is done.  Defaults to 'constant'.
+        Length of the FFT used, if a zero padded FFT is desired. If
+        `None`, the FFT length is `nperseg`. Defaults to `None`.
+    detrend : str or function or `False`, optional
+        Specifies how to detrend each segment. If `detrend` is a
+        string, it is passed as the `type` argument to the `detrend`
+        function. If it is a function, it takes a segment and returns a
+        detrended segment. If `detrend` is `False`, no detrending is
+        done. Defaults to 'constant'.
     axis : int, optional
-        Axis along which the coherence is computed for both inputs; the default
-        is over the last axis (i.e. ``axis=-1``).
+        Axis along which the coherence is computed for both inputs; the
+        default is over the last axis (i.e. ``axis=-1``).
 
     Returns
     -------
@@ -1096,9 +1133,9 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     Notes
     --------
     An appropriate amount of overlap will depend on the choice of window
-    and on your requirements.  For the default 'hann' window an
-    overlap of 50\\% is a reasonable trade off between accurately estimating
-    the signal power, while not over counting any of the data.  Narrower
+    and on your requirements. For the default 'hann' window an overlap
+    of 50\\% is a reasonable trade off between accurately estimating the
+    signal power, while not over counting any of the data. Narrower
     windows may require a larger overlap.
 
     .. versionadded:: 0.16.0
@@ -1109,8 +1146,8 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
            estimation of power spectra: A method based on time averaging
            over short, modified periodograms", IEEE Trans. Audio
            Electroacoust. vol. 15, pp. 70-73, 1967.
-    .. [2] Stoica, Petre, and Randolph Moses, "Spectral Analysis of Signals"
-           Prentice Hall, 2005
+    .. [2] Stoica, Petre, and Randolph Moses, "Spectral Analysis of
+           Signals" Prentice Hall, 2005
 
     Examples
     --------
@@ -1157,10 +1194,10 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     """
     Calculate various forms of windowed FFTs for PSD, CSD, etc.
 
-    This is a helper function that implements the commonality between the
-    psd, csd, and spectrogram functions. It is not designed to be called
-    externally. The windows are not averaged over; the result from each
-    window is returned.
+    This is a helper function that implements the commonality between
+    the stft, psd, csd, and spectrogram functions. It is not designed to
+    be called externally. The windows are not averaged over; the result
+    from each window is returned.
 
     Parameters
     ---------
@@ -1168,53 +1205,58 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         Array or sequence containing the data to be analyzed.
     y : array_like
         Array or sequence containing the data to be analyzed. If this is
-        the same object in memory as x (i.e. _spectral_helper(x, x, ...)),
-        the extra computations are spared.
+        the same object in memory as `x` (i.e. ``_spectral_helper(x,
+        x, ...)``), the extra computations are spared.
     fs : float, optional
         Sampling frequency of the time series. Defaults to 1.0.
     window : str or tuple or array_like, optional
-        Desired window to use. See `get_window` for a list of windows and
-        required parameters. If `window` is array_like it will be used
-        directly as the window and its length will be used for nperseg.
+        Desired window to use. See `get_window` for a list of windows
+        and required parameters. If `window` is array_like it will be
+        used directly as the window and its length must be `nperseg`.
         Defaults to 'hann'.
     nperseg : int, optional
         Length of each segment. Defaults to None, but if window is str or
         tuple, is set to 256, and if window is array_like, is set to the
         length of the window.
     noverlap : int, optional
-        Number of points to overlap between segments. If None, ``noverlap =
-        nperseg // 2``. Defaults to None.
+        Number of points to overlap between segments. If `None`,
+        ``noverlap = nperseg // 2``. Defaults to `None`.
     nfft : int, optional
-        Length of the FFT used, if a zero padded FFT is desired. If None,
-        the FFT length is `nperseg`. Defaults to None.
-    detrend : str or function or False, optional
-        Specifies how to detrend each segment. If `detrend` is a string, it
-        is passed as the ``type`` argument to `detrend`. If it is a
-        function, it takes a segment and returns a detrended segment. If
-        `detrend` is False, no detrending is done. Defaults to 'constant'.
+        Length of the FFT used, if a zero padded FFT is desired. If
+        `None`, the FFT length is `nperseg`. Defaults to `None`.
+    detrend : str or function or `False`, optional
+        Specifies how to detrend each segment. If `detrend` is a
+        string, it is passed as the `type` argument to the `detrend`
+        function. If it is a function, it takes a segment and returns a
+        detrended segment. If `detrend` is `False`, no detrending is
+        done. Defaults to 'constant'.
     return_onesided : bool, optional
-        If True, return a one-sided spectrum for real data. If False return
-        a two-sided spectrum. Note that for complex data, a two-sided
-        spectrum is always returned.
+        If `True`, return a one-sided spectrum for real data. If
+        `False` return a two-sided spectrum. Note that for complex
+        data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the cross spectral density ('density')
-        where `Pxy` has units of V**2/Hz and computing the cross spectrum
-        ('spectrum') where `Pxy` has units of V**2, if `x` and `y` are
-        measured in V and fs is measured in Hz. Defaults to 'density'
+        where `Pxy` has units of V**2/Hz and computing the cross
+        spectrum ('spectrum') where `Pxy` has units of V**2, if `x`
+        and `y` are measured in V and `fs` is measured in Hz.
+        Defaults to 'density'
     axis : int, optional
-        Axis along which the periodogram is computed; the default is over
-        the last axis (i.e. ``axis=-1``).
+        Axis along which the FFTs are computed; the default is over the
+        last axis (i.e. ``axis=-1``).
     mode: str {'psd', 'stft'}, optional
-        Defines what kind of return values are expected.
+        Defines what kind of return values are expected. Defaults to
+        'psd'.
     padded : bool, optional
         Specifies whether the input signal is zero-padded to make the
         signal fit exactly into an integer number of window segments, so
-        that all of the signal is included in the output.
+        that all of the signal is included in the output. Defaults to
+        `False`.
     centered : bool, optional
-        Specifies whether the input signal is padded via odd extension, to
-        center the first window segment on the first input point. This has
-        the benefit of enabling reconstruction of the first data point
-        when the employed window function starts at zero. Defaults to True.
+        Specifies whether the input signal is padded via odd extension,
+        to center the first window segment on the first input point.
+        This has the benefit of enabling reconstruction of the first
+        data point when the employed window function starts at zero.
+        Defaults to `False`.
 
     Returns
     -------
@@ -1229,8 +1271,8 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     ----------
     .. [1] Stack Overflow, "Rolling window for 1D arrays in Numpy?",
            http://stackoverflow.com/a/6811241
-    .. [2] Stack Overflow, "Using strides for an efficient moving average
-           filter", http://stackoverflow.com/a/4947453
+    .. [2] Stack Overflow, "Using strides for an efficient moving
+           average filter", http://stackoverflow.com/a/4947453
 
     Notes
     -----
@@ -1364,7 +1406,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     if mode == 'stft':
         scale = np.sqrt(scale)
 
-    if return_onesided is True:
+    if return_onesided:
         if np.iscomplexobj(x):
             sides = 'twosided'
             warnings.warn('Input data is complex, switching to '
@@ -1435,10 +1477,10 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft, sides):
     scipy.signal._spectral_helper
 
     This is a helper function that does the main FFT calculation for
-    _spectral helper. All input valdiation is performed there, and the data
-    axis is assumed to be the last axis of x. It is not designed to be
-    called externally. The windows are not averaged over; the result from
-    each window is returned.
+    `_spectral helper`. All input valdiation is performed there, and the
+    data axis is assumed to be the last axis of x. It is not designed to
+    be called externally. The windows are not averaged over; the result
+    from each window is returned.
 
     Returns
     -------
@@ -1447,8 +1489,8 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft, sides):
 
     References
     ----------
-    .. [1] Stack Overflow, "Repeat NumPy array without replicating data?",
-           http://stackoverflow.com/a/5568169
+    .. [1] Stack Overflow, "Repeat NumPy array without replicating
+           data?", http://stackoverflow.com/a/5568169
 
     Notes
     -----
@@ -1475,11 +1517,9 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft, sides):
     # Perform the fft. Acts on last axis by default. Zero-pads automatically
     if sides == 'twosided':
         func = fftpack.fft
-        #  result = fftpack.fft(result, n=nfft)
     else:
         result = result.real
         func = np.fft.rfft
-        #  result = np.fft.rfft(result, n=nfft)
     result = func(result, n=nfft)
 
     return result

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -984,6 +984,17 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
 
     >>> plt.figure()
     >>> plt.plot(time, x, time, xrec.real, time, carrier)
+    >>> plt.xlim([2, 2.1])
+    >>> plt.xlabel('Time [sec]')
+    >>> plt.ylabel('Signal')
+    >>> plt.legend(['Carrier + Noise', 'Filtered via STFT', 'True Carrier'])
+    >>> plt.show()
+
+    Note that the cleaned signal does not start as abruptly as the original,
+    since some of the coefficients of the transient were also removed:
+
+    >>> plt.figure()
+    >>> plt.plot(time, x, time, xrec.real, time, carrier)
     >>> plt.xlim([0, 0.1])
     >>> plt.xlabel('Time [sec]')
     >>> plt.ylabel('Signal')


### PR DESCRIPTION
These are some WIP functions for a Short Time Fourier Transform and its
inverse, which are like complex spectrograms, that retain magnitude and phase
information. Right now, the input validation is fairly strict, to ensure that
one can perform the iSTFT and recover the input signal, but there may be use
cases where it's ok to relax that constraint.

To do:
- [x] Tests
- [x] Examples
- [x] Check for typos, mistakes
- ~~Maybe implement oversampled FFTs (nfft > nperseg)? Is this desired?~~

This can be part of an `fftfilt` kind of function, where a complex transfer
function is applied to the columns of an STFT via complex multiplication, which
is then inverted to produce the filtered signal.

I've included a little bit of cleanup in `_spectral_helper` while I was there,
emitting a warning when complex data forces two-sidedness and silencing those
warnings in the tests.

Should (eventually) close gh-5757
