### PR TITLE
ENH: More accurate signal.freqresp for zpk systems

### DIFF
--- a/scipy/_lib/_numpy_compat.py
+++ b/scipy/_lib/_numpy_compat.py
@@ -205,3 +205,95 @@ else:
                 idx = np.concatenate(np.nonzero(flag) + ([ar.size],))
                 ret += (np.diff(idx),)
         return ret
+
+
+if NumpyVersion(np.__version__) > '1.12.0.dev':
+    polyvalfromroots = np.polynomial.polynomial.polyvalfromroots
+else:
+    def polyvalfromroots(x, r, tensor=True):
+        """
+        Evaluate a polynomial specified by its roots at points x.
+
+        This function is copypasted from numpy 1.12.0.dev.
+
+        If `r` is of length `N`, this function returns the value
+
+        .. math:: p(x) = \prod_{n=1}^{N} (x - r_n)
+
+        The parameter `x` is converted to an array only if it is a tuple or a
+        list, otherwise it is treated as a scalar. In either case, either `x`
+        or its elements must support multiplication and addition both with
+        themselves and with the elements of `r`.
+
+        If `r` is a 1-D array, then `p(x)` will have the same shape as `x`.  If
+        `r` is multidimensional, then the shape of the result depends on the
+        value of `tensor`. If `tensor is ``True`` the shape will be r.shape[1:]
+        + x.shape; that is, each polynomial is evaluated at every value of `x`.
+        If `tensor` is ``False``, the shape will be r.shape[1:]; that is, each
+        polynomial is evaluated only for the corresponding broadcast value of
+        `x`. Note that scalars have shape (,).
+
+        Parameters
+        ----------
+        x : array_like, compatible object
+            If `x` is a list or tuple, it is converted to an ndarray, otherwise
+            it is left unchanged and treated as a scalar. In either case, `x`
+            or its elements must support addition and multiplication with with
+            themselves and with the elements of `r`.
+        r : array_like
+            Array of roots. If `r` is multidimensional the first index is the
+            root index, while the remaining indices enumerate multiple
+            polynomials. For instance, in the two dimensional case the roots of
+            each polynomial may be thought of as stored in the columns of `r`.
+        tensor : boolean, optional
+            If True, the shape of the roots array is extended with ones on the
+            right, one for each dimension of `x`. Scalars have dimension 0 for
+            this action. The result is that every column of coefficients in `r`
+            is evaluated for every element of `x`. If False, `x` is broadcast
+            over the columns of `r` for the evaluation.  This keyword is useful
+            when `r` is multidimensional. The default value is True.
+
+        Returns
+        -------
+        values : ndarray, compatible object
+            The shape of the returned array is described above.
+
+        See Also
+        --------
+        polyroots, polyfromroots, polyval
+
+        Examples
+        --------
+        >>> from numpy.polynomial.polynomial import polyvalfromroots
+        >>> polyvalfromroots(1, [1,2,3])
+        0.0
+        >>> a = np.arange(4).reshape(2,2)
+        >>> a
+        array([[0, 1],
+               [2, 3]])
+        >>> polyvalfromroots(a, [-1, 0, 1])
+        array([[ -0.,   0.],
+               [  6.,  24.]])
+        >>> r = np.arange(-2, 2).reshape(2,2) # multidimensional coefficients
+        >>> r # each column of r defines one polynomial
+        array([[-2, -1],
+               [ 0,  1]])
+        >>> b = [-2, 1]
+        >>> polyvalfromroots(b, r, tensor=True)
+        array([[-0.,  3.],
+               [ 3., 0.]])
+        >>> polyvalfromroots(b, r, tensor=False)
+        array([-0.,  0.])
+        """
+        r = np.array(r, ndmin=1, copy=0)
+        if r.dtype.char in '?bBhHiIlLqQpP':
+            r = r.astype(np.double)
+        if isinstance(x, (tuple, list)):
+            x = np.asarray(x)
+        if isinstance(x, np.ndarray):
+            if tensor:
+                r = r.reshape(r.shape + (1,)*x.ndim)
+            elif x.ndim >= r.ndim:
+                raise ValueError("x.ndim must be < r.ndim when tensor == "
+                                 "False")
+        return np.prod(x - r, axis=0)

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -85,8 +85,10 @@ Filter design
                     -- defined as pass and stop bands.
    firwin2       -- Windowed FIR filter design, with arbitrary frequency
                     -- response.
-   freqs         -- Analog filter frequency response.
-   freqz         -- Digital filter frequency response.
+   freqs         -- Analog filter frequency response from TF coefficients.
+   freqs_zpk     -- Analog filter frequency response from ZPK coefficients.
+   freqz         -- Digital filter frequency response from TF coefficients.
+   freqz_zpk     -- Digital filter frequency response from ZPK coefficients.
    sosfreqz      -- Digital filter frequency response for SOS format filter.
    group_delay   -- Digital filter group delay.
    iirdesign     -- IIR filter design given bands and gains.

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -30,7 +30,8 @@ from scipy.linalg import qr as s_qr
 from scipy import integrate, interpolate, linalg
 from scipy.interpolate import interp1d
 from scipy._lib.six import xrange
-from .filter_design import tf2zpk, zpk2tf, normalize, freqs, freqz
+from .filter_design import (tf2zpk, zpk2tf, normalize, freqs, freqz, freqs_zpk,
+                            freqz_zpk)
 from .lti_conversion import (tf2ss, abcd_normalize, ss2tf, zpk2ss, ss2zpk,
                              cont2discrete)
 
@@ -2457,12 +2458,15 @@ def freqresp(system, w=None, n=10000):
     >>> plt.show()
     """
     if isinstance(system, lti):
-        sys = system._as_tf()
+        if isinstance(system, (TransferFunction, ZerosPolesGain)):
+            sys = system
+        else:
+            sys = system._as_zpk()
     elif isinstance(system, dlti):
         raise AttributeError('freqresp can only be used with continuous-time '
                              'systems.')
     else:
-        sys = lti(*system)._as_tf()
+        sys = lti(*system)._as_zpk()
 
     if sys.inputs != 1 or sys.outputs != 1:
         raise ValueError("freqresp() requires a SISO (single input, single "
@@ -2473,9 +2477,13 @@ def freqresp(system, w=None, n=10000):
     else:
         worN = n
 
-    # In the call to freqs(), sys.num.ravel() is used because there are
-    # cases where sys.num is a 2-D array with a single row.
-    w, h = freqs(sys.num.ravel(), sys.den, worN=worN)
+    if isinstance(sys, TransferFunction):
+        # In the call to freqs(), sys.num.ravel() is used because there are
+        # cases where sys.num is a 2-D array with a single row.
+        w, h = freqs(sys.num.ravel(), sys.den, worN=worN)
+
+    elif isinstance(sys, ZerosPolesGain):
+        w, h = freqs_zpk(sys.zeros, sys.poles, sys.gain, worN=worN)
 
     return w, h
 
@@ -3548,14 +3556,17 @@ def dfreqresp(system, w=None, n=10000, whole=False):
 
     """
     if isinstance(system, dlti):
-        system = system._as_tf()
+        if isinstance(system, (TransferFunction, ZerosPolesGain)):
+            sys = system
+        else:
+            sys = system._as_zpk()
     elif isinstance(system, lti):
         raise AttributeError('dfreqresp can only be used with discrete-time '
                              'systems.')
     else:
-        system = dlti(*system[:-1], dt=system[-1])._as_tf()
+        sys = dlti(*system[:-1], dt=system[-1])._as_zpk()
 
-    if system.inputs != 1 or system.outputs != 1:
+    if sys.inputs != 1 or sys.outputs != 1:
         raise ValueError("dfreqresp requires a SISO (single input, single "
                          "output) system.")
 
@@ -3564,11 +3575,17 @@ def dfreqresp(system, w=None, n=10000, whole=False):
     else:
         worN = n
 
-    # Convert numerator and denominator from polynomials in the variable 'z'
-    # to polynomials in the variable 'z^-1', as freqz expects.
-    num, den = TransferFunction._z_to_zinv(system.num.ravel(), system.den)
+    if isinstance(sys, TransferFunction):
+        # Convert numerator and denominator from polynomials in the variable
+        # 'z' to polynomials in the variable 'z^-1', as freqz expects.
+        num, den = TransferFunction._z_to_zinv(sys.num.ravel(), sys.den)
+        w, h = freqz(num, den, worN=worN, whole=whole)
 
-    return freqz(num, den, worN=worN, whole=whole)
+    elif isinstance(system, ZerosPolesGain):
+        w, h = freqz_zpk(sys.zeros, sys.poles, sys.gain, worN=worN,
+                         whole=whole)
+
+    return w, h
 
 
 def dbode(system, w=None, n=100):

--- a/scipy/signal/tests/test_dltisys.py
+++ b/scipy/signal/tests/test_dltisys.py
@@ -554,6 +554,15 @@ class Test_dfreqresp(TestCase):
         system = lti([1], [1, 1])
         assert_raises(AttributeError, dfreqresp, system)
 
+    def test_from_zpk(self):
+        # 1st order low-pass filter: H(s) = 0.3 / (z - 0.2),
+        system_ZPK = dlti([],[0.2],0.3)
+        system_TF = dlti(0.3, [1, -0.2])
+        w = [0.1, 1, 10, 100]
+        w1, H1 = dfreqresp(system_ZPK, w=w)
+        w2, H2 = dfreqresp(system_TF, w=w)
+        assert_almost_equal(H1, H2)
+
 
 class Test_bode(object):
 

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -1163,8 +1163,8 @@ class Test_bode(object):
 
 class Test_freqresp(object):
 
-    def test_real_part_manual(self):
-        # Test freqresp() real part calculation (manual sanity check).
+    def test_output_manual(self):
+        # Test freqresp() output calculation (manual sanity check).
         # 1st order low-pass filter: H(s) = 1 / (s + 1),
         #   re(H(s=0.1)) ~= 0.99
         #   re(H(s=1)) ~= 0.5
@@ -1173,41 +1173,20 @@ class Test_freqresp(object):
         w = [0.1, 1, 10]
         w, H = freqresp(system, w=w)
         expected_re = [0.99, 0.5, 0.0099]
-        assert_almost_equal(H.real, expected_re, decimal=1)
-
-    def test_imag_part_manual(self):
-        # Test freqresp() imaginary part calculation (manual sanity check).
-        # 1st order low-pass filter: H(s) = 1 / (s + 1),
-        #   im(H(s=0.1)) ~= -0.099
-        #   im(H(s=1)) ~= -0.5
-        #   im(H(s=10)) ~= -0.099
-        system = lti([1], [1, 1])
-        w = [0.1, 1, 10]
-        w, H = freqresp(system, w=w)
         expected_im = [-0.099, -0.5, -0.099]
+        assert_almost_equal(H.real, expected_re, decimal=1)
         assert_almost_equal(H.imag, expected_im, decimal=1)
 
-    def test_real_part(self):
-        # Test freqresp() real part calculation.
+    def test_output(self):
+        # Test freqresp() output calculation.
         # 1st order low-pass filter: H(s) = 1 / (s + 1)
         system = lti([1], [1, 1])
         w = [0.1, 1, 10, 100]
         w, H = freqresp(system, w=w)
-        jw = w * 1j
-        y = np.polyval(system.num, jw) / np.polyval(system.den, jw)
-        expected_re = y.real
-        assert_almost_equal(H.real, expected_re)
-
-    def test_imag_part(self):
-        # Test freqresp() imaginary part calculation.
-        # 1st order low-pass filter: H(s) = 1 / (s + 1)
-        system = lti([1], [1, 1])
-        w = [0.1, 1, 10, 100]
-        w, H = freqresp(system, w=w)
-        jw = w * 1j
-        y = np.polyval(system.num, jw) / np.polyval(system.den, jw)
-        expected_im = y.imag
-        assert_almost_equal(H.imag, expected_im)
+        s = w * 1j
+        expected = np.polyval(system.num, s) / np.polyval(system.den, s)
+        assert_almost_equal(H.real, expected.real)
+        assert_almost_equal(H.imag, expected.imag)
 
     def test_freq_range(self):
         # Test that freqresp() finds a reasonable frequency range.
@@ -1242,8 +1221,20 @@ class Test_freqresp(object):
             warnings.simplefilter("ignore", BadCoefficients)
             system = lti(A, B, C, D)
             w, H = freqresp(system, n=100)
-        expected_magnitude = np.sqrt(1.0 / (1.0 + w**6))
-        assert_almost_equal(np.abs(H), expected_magnitude)
+        s = w * 1j
+        expected = (1.0 / (1.0 + 2*s + 2*s**2 + s**3))
+        assert_almost_equal(H.real, expected.real)
+        assert_almost_equal(H.imag, expected.imag)
+
+    def test_from_zpk(self):
+        # 4th order low-pass filter: H(s) = 1 / (s + 1)
+        system = lti([],[-1]*4,[1])
+        w = [0.1, 1, 10, 100]
+        w, H = freqresp(system, w=w)
+        s = w * 1j
+        expected = 1 / (s + 1)**4
+        assert_almost_equal(H.real, expected.real)
+        assert_almost_equal(H.imag, expected.imag)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR addresses part of #5648, making higher order zpk frequency responses
more accurate. The SOS part still needs analog zpk<->sos conversion (see
gh-5668).

This consists of:
- Modifying `findfreqs` to accept zeros and poles directly
- A new function `freqs_zpk`, analogous to `freqs`
- A new function `_polyrootval`, which evaluates the s-plane polynomials
  without the lossy polynomial expansion. (I plan to submit a PR with this
  function to numpy, but it would be a while before we can expect users to have
  it, I imagine)
- New logic in `freqresp` that detects when the input is in ZPK form, and calls
  `freqs_zpk` if appropriate. (SS systems still go to tf, since we don't have a
  direct SS<->zpk translator [gh-5912])
- Tests:
  - Basic tests for `freqs`, which were nonexistent
  - Basic tests for `freqs_zpk`
  - New test for `freqresp` on ZPK input
  - Consolidation of some redundant `freqresp` tests
