### PR TITLE
ENH: ndimage: separate the creation of a Gaussian kernel from the filtering

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -160,7 +160,7 @@ Philip DeBoer for wrapping random SO(N) and adding random O(N) and
 Tyler Reddy and Nikolai Nowaczyk for scipy.spatial.SphericalVoronoi
 Bill Sacks for fixes to netcdf i/o.
 Kolja Glogowski for a bug fix in scipy.special.
-
+Stuart Mumford for custom Gaussian kernels in ndimage.filter.
 
 Institutions
 ------------

--- a/scipy/ndimage/__init__.py
+++ b/scipy/ndimage/__init__.py
@@ -21,6 +21,7 @@ Filters
    correlate1d - 1-D correlation along the given axis
    gaussian_filter
    gaussian_filter1d
+   calculate_gaussian_kernel
    gaussian_gradient_magnitude
    gaussian_laplace
    generic_filter - Multi-dimensional filter using a given function

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -212,7 +212,7 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
 
 @docfiller
 def calculate_gaussian_kernel(sigma, order=0, truncate=4.0):
-    """One-dimensional Gaussian filter.
+    """Calculate a 1D gaussian kernel
 
     Parameters
     ----------
@@ -232,6 +232,7 @@ def calculate_gaussian_kernel(sigma, order=0, truncate=4.0):
     weights : ndarray
         The gaussian kernel.
 
+    .. versionadded:: 0.17.0
     """
     if order not in range(4):
         raise ValueError('Order outside 0..3 not implemented')

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -37,7 +37,8 @@ from . import _nd_image
 from scipy.misc import doccer
 from scipy._lib._version import NumpyVersion
 
-__all__ = ['correlate1d', 'convolve1d', 'gaussian_filter1d', 'gaussian_filter',
+__all__ = ['correlate1d', 'convolve1d', 'calculate_gaussian_kernel',
+           'gaussian_filter1d', 'gaussian_filter',
            'prewitt', 'sobel', 'generic_laplace', 'laplace',
            'gaussian_laplace', 'generic_gradient_magnitude',
            'gaussian_gradient_magnitude', 'correlate', 'convolve',
@@ -210,7 +211,7 @@ def gaussian_filter1d(input, sigma, axis=-1, order=0, output=None,
 
 
 @docfiller
-def calculate_gaussian_kernel(sigma, order, truncate=4.0):
+def calculate_gaussian_kernel(sigma, order=0, truncate=4.0):
     """One-dimensional Gaussian filter.
 
     Parameters

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -232,7 +232,7 @@ def calculate_gaussian_kernel(sigma, order=0, truncate=4.0):
     weights : ndarray
         The gaussian kernel.
 
-    .. versionadded:: 0.17.0
+    .. versionadded:: 0.18.0
     """
     if order not in range(4):
         raise ValueError('Order outside 0..3 not implemented')
@@ -280,8 +280,7 @@ def calculate_gaussian_kernel(sigma, order=0, truncate=4.0):
 
 @docfiller
 def gaussian_filter(input, sigma=None, order=0, output=None,
-                    mode="reflect", cval=0.0, truncate=4.0,
-                    weights=None):
+                    mode="reflect", cval=0.0, truncate=4.0):
     """Multidimensional Gaussian filter.
 
     Parameters
@@ -305,9 +304,6 @@ def gaussian_filter(input, sigma=None, order=0, output=None,
     truncate : float
         Truncate the filter at this many standard deviations.
         Default is 4.0.
-    weights : ndarray
-        A kernel to convolve the input array with, if specified the ``sigma``,
-        ``order`` and ``truncate`` arguments will be ignored.
 
     Returns
     -------
@@ -348,22 +344,17 @@ def gaussian_filter(input, sigma=None, order=0, output=None,
         raise ValueError('Order outside 0..4 not implemented')
     sigmas = _ni_support._normalize_sequence(sigma, input.ndim)
 
-    if not weights:
-        axes = list(range(input.ndim))
-        axes = [(axes[ii], sigmas[ii], orders[ii])
-                            for ii in range(len(axes)) if sigmas[ii] > 1e-15]
+    axes = list(range(input.ndim))
+    axes = [(axes[ii], sigmas[ii], orders[ii])
+                        for ii in range(len(axes)) if sigmas[ii] > 1e-15]
 
-        if len(axes) > 0:
-            for axis, sigma, order in axes:
-                weights = calculate_gaussian_kernel(sigma, order, truncate=truncate)
-                correlate1d(input, weights, axis, output, mode, cval, 0)
-                input = output
-        else:
-            output[...] = input[...]
+    if len(axes) > 0:
+        for axis, sigma, order in axes:
+            weights = calculate_gaussian_kernel(sigma, order, truncate=truncate)
+            correlate1d(input, weights, axis, output, mode, cval, 0)
+            input = output
     else:
-        for axis in list(range(input.ndim)):
-                correlate1d(input, weights, axis, output, mode, cval, 0)
-                input = output
+        output[...] = input[...]
 
     return return_value
 

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -86,6 +86,25 @@ def test_valid_origins():
         assert_raises(ValueError, filter, data, 3, origin=2)
 
 
+def test_gaussian_kernel_truncate():
+    # Test that Gaussian filters can be truncated at different widths.
+    # These tests only check that the result has the expected number
+    # of nonzero elements.
+    num_nonzeros_2 = sndi.calculate_gaussian_kernel(5, truncate=2)
+    assert len(num_nonzeros_2) == 2* int(2 * 5. + 0.5) + 1
+    num_nonzeros_5 = sndi.calculate_gaussian_kernel(5, truncate=5)
+    assert len(num_nonzeros_5) == 2* int(5 * 5. + 0.5) + 1
+
+def test_manual_filter():
+    arr = np.ones([20, 20])
+    sigma = 10
+    truncate = 5
+
+    result1 = sndi.gaussian_filter(arr, sigma, truncate=truncate)
+
+    weights = sndi.calculate_gaussian_kernel(sigma, truncate=truncate)
+    result2 = sndi.gaussian_filter(arr, weights=weights)
+
 def test_gaussian_truncate():
     # Test that Gaussian filters can be truncated at different widths.
     # These tests only check that the result has the expected number

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -87,9 +87,7 @@ def test_valid_origins():
 
 
 def test_gaussian_kernel_truncate():
-    # Test that Gaussian filters can be truncated at different widths.
-    # These tests only check that the result has the expected number
-    # of nonzero elements.
+    # Test that Gaussian kernels can be truncated at different widths.
     num_nonzeros_2 = sndi.calculate_gaussian_kernel(5, truncate=2)
     assert len(num_nonzeros_2) == 2* int(2 * 5. + 0.5) + 1
     num_nonzeros_5 = sndi.calculate_gaussian_kernel(5, truncate=5)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -89,9 +89,9 @@ def test_valid_origins():
 def test_gaussian_kernel_truncate():
     # Test that Gaussian kernels can be truncated at different widths.
     num_nonzeros_2 = sndi.calculate_gaussian_kernel(5, truncate=2)
-    assert len(num_nonzeros_2) == 2 * int(2 * 5. + 0.5) + 1
+    assert_equal(len(num_nonzeros_2), 2 * int(2 * 5. + 0.5) + 1)
     num_nonzeros_5 = sndi.calculate_gaussian_kernel(5, truncate=5)
-    assert len(num_nonzeros_5) == 2 * int(5 * 5. + 0.5) + 1
+    assert_equal(len(num_nonzeros_5), 2 * int(5 * 5. + 0.5) + 1)
 
 
 def test_manual_filter():
@@ -102,9 +102,13 @@ def test_manual_filter():
     result1 = sndi.gaussian_filter(arr, sigma, truncate=truncate)
 
     weights = sndi.calculate_gaussian_kernel(sigma, truncate=truncate)
-    result2 = sndi.gaussian_filter(arr, weights=weights)
 
-    assert_equal(result1, result2)
+    output = arr.copy()
+    for axis in list(range(arr.ndim)):
+            sndi.correlate1d(output, weights, axis, output, "reflect", 0.0, 0)
+
+    assert_equal(result1, output)
+
 
 def test_gaussian_truncate():
     # Test that Gaussian filters can be truncated at different widths.

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -89,9 +89,10 @@ def test_valid_origins():
 def test_gaussian_kernel_truncate():
     # Test that Gaussian kernels can be truncated at different widths.
     num_nonzeros_2 = sndi.calculate_gaussian_kernel(5, truncate=2)
-    assert len(num_nonzeros_2) == 2* int(2 * 5. + 0.5) + 1
+    assert len(num_nonzeros_2) == 2 * int(2 * 5. + 0.5) + 1
     num_nonzeros_5 = sndi.calculate_gaussian_kernel(5, truncate=5)
-    assert len(num_nonzeros_5) == 2* int(5 * 5. + 0.5) + 1
+    assert len(num_nonzeros_5) == 2 * int(5 * 5. + 0.5) + 1
+
 
 def test_manual_filter():
     arr = np.ones([20, 20])

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -103,6 +103,8 @@ def test_manual_filter():
     weights = sndi.calculate_gaussian_kernel(sigma, truncate=truncate)
     result2 = sndi.gaussian_filter(arr, weights=weights)
 
+    assert_equal(result1, result2)
+
 def test_gaussian_truncate():
     # Test that Gaussian filters can be truncated at different widths.
     # These tests only check that the result has the expected number


### PR DESCRIPTION
The objective of this change is to allow the convolution of an array with a custom gaussian kernel. Specifically, for my usecase to create a kernel which is the sum of many different sigmas, and then only do the convolution operation once, rather than many times.

I hope this change makes sense, and that I haven't missed any steps.
