### PR TITLE
BUG: special: fixed violation of strict aliasing rules.

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -159,6 +159,8 @@ Philip DeBoer for wrapping random SO(N) and adding random O(N) and
     correlation matrices in scipy.stats.
 Tyler Reddy and Nikolai Nowaczyk for scipy.spatial.SphericalVoronoi
 Bill Sacks for fixes to netcdf i/o.
+Kolja Glogowski for a bug fix in scipy.special.
+
 
 Institutions
 ------------

--- a/scipy/special/_complexstuff.pxd
+++ b/scipy/special/_complexstuff.pxd
@@ -31,6 +31,22 @@ ctypedef fused number_t:
     double
     double_complex
 
+ctypedef union _complex_pun:
+    np.npy_cdouble npy
+    double_complex c99
+
+cdef inline np.npy_cdouble npy_cdouble_from_double_complex(
+        double_complex x) nogil:
+    cdef _complex_pun z
+    z.c99 = x
+    return z.npy
+
+cdef inline double_complex double_complex_from_npy_cdouble(
+        np.npy_cdouble x) nogil:
+    cdef _complex_pun z
+    z.npy = x
+    return z.c99
+
 cdef inline bint zisnan(number_t x) nogil:
     if number_t is double_complex:
         return npy_isnan(x.real) or npy_isnan(x.imag)
@@ -51,42 +67,42 @@ cdef inline bint zisinf(number_t x) nogil:
 
 cdef inline double zabs(number_t x) nogil:
     if number_t is double_complex:
-        return npy_cabs((<np.npy_cdouble*>&x)[0])
+        return npy_cabs(npy_cdouble_from_double_complex(x))
     else:
         return libc.math.fabs(x)
 
 cdef inline double zarg(double complex x) nogil:
-    return npy_carg((<np.npy_cdouble*>&x)[0])
+    return npy_carg(npy_cdouble_from_double_complex(x))
 
 cdef inline number_t zlog(number_t x) nogil:
     cdef np.npy_cdouble r
     if number_t is double_complex:
-        r = npy_clog((<np.npy_cdouble*>&x)[0])
-        return (<double_complex*>&r)[0]
+        r = npy_clog(npy_cdouble_from_double_complex(x))
+        return double_complex_from_npy_cdouble(r)
     else:
         return libc.math.log(x)
 
 cdef inline number_t zexp(number_t x) nogil:
     cdef np.npy_cdouble r
     if number_t is double_complex:
-        r = npy_cexp((<np.npy_cdouble*>&x)[0])
-        return (<double_complex*>&r)[0]
+        r = npy_cexp(npy_cdouble_from_double_complex(x))
+        return double_complex_from_npy_cdouble(r)
     else:
         return libc.math.exp(x)
 
 cdef inline number_t zsin(number_t x) nogil:
     cdef np.npy_cdouble r
     if number_t is double_complex:
-        r = npy_csin((<np.npy_cdouble*>&x)[0])
-        return (<double_complex*>&r)[0]
+        r = npy_csin(npy_cdouble_from_double_complex(x))
+        return double_complex_from_npy_cdouble(r)
     else:
         return libc.math.sin(x)
 
 cdef inline number_t zsqrt(number_t x) nogil:
     cdef np.npy_cdouble r
     if number_t is double_complex:
-        r = npy_csqrt((<np.npy_cdouble*>&x)[0])
-        return (<double_complex*>&r)[0]
+        r = npy_csqrt(npy_cdouble_from_double_complex(x))
+        return double_complex_from_npy_cdouble(r)
     else:
         return libc.math.sqrt(x)
 
@@ -96,8 +112,8 @@ cdef inline number_t zpow(number_t x, double y) nogil:
     if number_t is double_complex:
         z.real = y
         z.imag = 0.0
-        r = npy_cpow((<np.npy_cdouble*>&x)[0], z)
-        return (<double_complex*>&r)[0]
+        r = npy_cpow(npy_cdouble_from_double_complex(x), z)
+        return double_complex_from_npy_cdouble(r)
     else:
         return libc.math.pow(x, y)
 
@@ -105,7 +121,7 @@ cdef inline double_complex zpack(double zr, double zi) nogil:
     cdef np.npy_cdouble z
     z.real = zr
     z.imag = zi
-    return (<double_complex*>&z)[0]
+    return double_complex_from_npy_cdouble(z)
 
 @cython.cdivision(True)
 cdef inline double complex zdiv(double complex x, double complex y) nogil:

--- a/scipy/special/_cunity.pxd
+++ b/scipy/special/_cunity.pxd
@@ -1,6 +1,8 @@
 cimport numpy as np
 from libc.math cimport fabs, sin, cos, exp
-from _complexstuff cimport zisfinite, zabs, zpack
+from _complexstuff cimport (
+    zisfinite, zabs, zpack, npy_cdouble_from_double_complex,
+    double_complex_from_npy_cdouble)
 
 cdef extern from "_complexstuff.h":
     double npy_atan2(double y, double x) nogil
@@ -42,8 +44,8 @@ cdef inline double complex clog1p(double complex z) nogil:
 
     if not zisfinite(z):
         z = z + 1 
-        ret = npy_clog((<np.npy_cdouble*>&z)[0])
-        return (<double complex*>&ret)[0]
+        ret = npy_clog(npy_cdouble_from_double_complex(z))
+        return double_complex_from_npy_cdouble(ret)
 
     zr = z.real
     zi = z.imag
@@ -62,8 +64,8 @@ cdef inline double complex clog1p(double complex z) nogil:
             return zpack(x, y)
 
     z = z + 1.0
-    ret = npy_clog((<np.npy_cdouble*>&z)[0])
-    return (<double complex*>&ret)[0]
+    ret = npy_clog(npy_cdouble_from_double_complex(z))
+    return double_complex_from_npy_cdouble(ret)
 
 cdef inline double complex clog1p_ddouble(double zr, double zi) nogil:
     cdef double x, y
@@ -95,8 +97,8 @@ cdef inline double complex cexpm1(double complex z) nogil:
     cdef np.npy_cdouble ret
 
     if not zisfinite(z):
-        ret = npy_cexp((<np.npy_cdouble*>&z)[0])
-        return (<double complex*>&ret)[0] - 1.0
+        ret = npy_cexp(npy_cdouble_from_double_complex(z))
+        return double_complex_from_npy_cdouble(ret) - 1.0
 
     zr = z.real
     zi = z.imag

--- a/scipy/special/_hyp0f1.pxd
+++ b/scipy/special/_hyp0f1.pxd
@@ -3,7 +3,9 @@ from numpy.math cimport NAN, isinf
 cimport numpy as np
 
 from _xlogy cimport xlogy
-from _complexstuff cimport zsqrt, zpow, zabs
+from _complexstuff cimport (
+    zsqrt, zpow, zabs, npy_cdouble_from_double_complex,
+    double_complex_from_npy_cdouble)
 
 cdef extern from "float.h":
     double DBL_MAX, DBL_MIN
@@ -102,7 +104,7 @@ cdef inline double _hyp0f1_asy(double v, double z) nogil:
 #
 cdef inline double complex _hyp0f1_cmplx(double v, double complex z) nogil:
     cdef:
-        np.npy_cdouble zz = (<np.npy_cdouble*>&z)[0]
+        np.npy_cdouble zz = npy_cdouble_from_double_complex(z)
         np.npy_cdouble r
         double complex arg, s
 
@@ -119,11 +121,11 @@ cdef inline double complex _hyp0f1_cmplx(double v, double complex z) nogil:
     if zz.real > 0:
         arg = zsqrt(z)
         s = 2.0 * arg
-        r = cbesi_wrap(v-1.0, (<np.npy_cdouble*>&s)[0] )
+        r = cbesi_wrap(v-1.0, npy_cdouble_from_double_complex(s))
     else:
         arg = zsqrt(-z)
         s = 2.0 * arg
-        r = cbesj_wrap(v-1.0, (<np.npy_cdouble*>&s)[0] )
+        r = cbesj_wrap(v-1.0, npy_cdouble_from_double_complex(s))
 
-    return (<double complex*>&r)[0] * Gamma(v) * zpow(arg, 1.0 - v)
+    return double_complex_from_npy_cdouble(r) * Gamma(v) * zpow(arg, 1.0 - v)
 

--- a/scipy/special/_spherical_bessel.pxd
+++ b/scipy/special/_spherical_bessel.pxd
@@ -50,24 +50,24 @@ cdef inline number_t cbesj(double v, number_t z) nogil:
     if number_t is double:
         return cbesj_wrap_real(v, z)
     else:
-        r = cbesj_wrap(v, (<npy_cdouble*>&z)[0])
-        return (<number_t*>&r)[0]
+        r = cbesj_wrap(v, npy_cdouble_from_double_complex(z))
+        return double_complex_from_npy_cdouble(r)
 
 cdef inline number_t cbesy(double v, number_t z) nogil:
     cdef npy_cdouble r
     if number_t is double:
         return cbesy_wrap_real(v, z)
     else:
-        r = cbesy_wrap(v, (<npy_cdouble*>&z)[0])
-        return (<number_t*>&r)[0]
+        r = cbesy_wrap(v, npy_cdouble_from_double_complex(z))
+        return double_complex_from_npy_cdouble(r)
 
 cdef inline number_t cbesk(double v, number_t z) nogil:
     cdef npy_cdouble r
     if number_t is double:
         return cbesk_wrap_real(v, z)
     else:
-        r = cbesk_wrap(v, (<npy_cdouble*>&z)[0])
-        return (<number_t*>&r)[0]
+        r = cbesk_wrap(v, npy_cdouble_from_double_complex(z))
+        return double_complex_from_npy_cdouble(r)
 
 
 # Spherical Bessel functions
@@ -245,8 +245,8 @@ cdef inline double complex spherical_in_complex(long n, double complex z) nogil:
         else:
             return nan
 
-    s = cbesi_wrap(n + 0.5, (<npy_cdouble*>&z)[0])
-    return zsqrt(M_PI_2/z)*(<double complex*>&s)[0]
+    s = cbesi_wrap(n + 0.5, npy_cdouble_from_double_complex(z))
+    return zsqrt(M_PI_2/z)*double_complex_from_npy_cdouble(s)
 
 
 @cython.cdivision(True)

--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -26,7 +26,9 @@ cimport cython
 from libc.math cimport sqrt, exp, floor, fabs, log, sin, M_PI as pi
 
 from numpy cimport npy_cdouble
-from _complexstuff cimport nan, inf, number_t
+from _complexstuff cimport (
+    nan, inf, number_t, npy_cdouble_from_double_complex,
+    double_complex_from_npy_cdouble)
 
 cimport sf_error
 
@@ -52,16 +54,16 @@ cdef inline number_t hyp2f1(double a, double b, double c, number_t z) nogil:
     if number_t is double:
         return hyp2f1_wrap(a, b, c, z)
     else:
-        r = chyp2f1_wrap(a, b, c, (<npy_cdouble*>&z)[0])
-        return (<number_t*>&r)[0]
+        r = chyp2f1_wrap(a, b, c, npy_cdouble_from_double_complex(z))
+        return double_complex_from_npy_cdouble(r)
 
 cdef inline number_t hyp1f1(double a, double b, number_t z) nogil:
     cdef npy_cdouble r
     if number_t is double:
         return hyp1f1_wrap(a, b, z)
     else:
-        r = chyp1f1_wrap(a, b, (<npy_cdouble*>&z)[0])
-        return (<number_t*>&r)[0]
+        r = chyp1f1_wrap(a, b, npy_cdouble_from_double_complex(z))
+        return double_complex_from_npy_cdouble(r)
 
 #-----------------------------------------------------------------------------
 # Binomial coefficient


### PR DESCRIPTION
The Cython code in `scipy.special`, contains many conversions between NumPy's `npy_cdouble` and Cython's `double complex`. The data type `npy_cdouble` is defined as structure with two double fields, while the data type `double complex` in Cython is usually defined as the corresponding C99 complex type or `std::complex<double>` for C++ extension modules.

The conversion is currently done by derefencing a reinterpreted pointer, like

```
cdef double complex a
cdef npy_cdouble b = (<npy_cdouble *>&a)[0]
```

This does not generate valid C code because `double complex` and `npy_cdouble` are not compatible data types and therefore break the strict aliasing rules.

I fixed this problem in this PR by using a union for the type conversion, a practice which is, for example, described in the `-fstrict-aliasing` section of the [GCC manual](https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Optimize-Options.html#index-fstrict-aliasing-1049).

The current Cython code apparently does not produce erroneous results with all compilers. Some GCC versions (I tested it for example on Arch Linux with GCC 5.3.0 and on CentOS 7.2 with GCC 4.8.5) produce warnings, but the compiled code seems to produce correct results. Other GCC versions (like GCC 4.4.7, which comes with CentOS 5.11 and CentOS 6.7 for example), produce binaries that give invalid results for some functions in `scipy.special`.

This PR fixes a couple of bug reports, like
- https://github.com/scipy/scipy/issues/3568
- https://github.com/scipy/scipy/issues/5376
- https://github.com/ContinuumIO/anaconda-issues/issues/425
- https://github.com/ContinuumIO/anaconda-issues/issues/479

and possibly a few more.
