### PR TITLE
Clarified pearson correlation return value

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2764,8 +2764,10 @@ def pearsonr(x, y):
 
     Returns
     -------
-    (Pearson's correlation coefficient,
-     2-tailed p-value)
+    r : float
+        Pearson's correlation coefficient
+    p-value : float
+        2-tailed p-value
 
     References
     ----------


### PR DESCRIPTION
As title. It wasn't obvious to me (by the docs) that this function returned two values. It's return value doc format also didn't seem consistent with the other functions in the library.
