### PR TITLE
BUG: Fix dtype for sum of linear operators

### DIFF
--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -483,7 +483,9 @@ class _CustomLinearOperator(LinearOperator):
                                      dtype=self.dtype)
 
 
-def _get_dtype(operators, dtypes=[]):
+def _get_dtype(operators, dtypes=None):
+    if dtypes is None:
+        dtypes = []
     for obj in operators:
         if obj is not None and hasattr(obj, 'dtype'):
             dtypes.append(obj.dtype)

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -326,3 +326,18 @@ def test_inheritance():
 
     mm = MatmatOnly(np.random.randn(5, 3))
     assert_equal(mm.matvec(np.random.randn(3)).shape, (5,))
+
+def test_dtypes_of_operator_sum():
+    # gh-6078
+
+    mat_complex = np.random.rand(2,2) + 1j * np.random.rand(2,2)
+    mat_real = np.random.rand(2,2)
+
+    complex_operator = interface.aslinearoperator(mat_complex)
+    real_operator = interface.aslinearoperator(mat_real)
+
+    sum_complex = complex_operator + complex_operator
+    sum_real = real_operator + real_operator
+
+    assert_equal(sum_real.dtype, np.float64)
+    assert_equal(sum_complex.dtype, np.complex128)


### PR DESCRIPTION
A mutable argument in scipy.sparse.interface._get_dtypes
causes the inferred dtype of a sum or product of operators
to be inferred incorrectly sometimes.

This fixes it by removing the mutable argument.

Fixes #6078
