### PR TITLE
MAINT: Silence Test noise from scipy.constants

### DIFF
--- a/scipy/constants/tests/test_constants.py
+++ b/scipy/constants/tests/test_constants.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
 from numpy.testing import run_module_suite, assert_equal, assert_allclose
+from numpy.testing.decorators import deprecated
 import scipy.constants as sc
 
 
@@ -27,28 +28,28 @@ def test_convert_temperature():
     assert_allclose(sc.convert_temperature([491.67, 0.], 'rankine', 'kelvin'),
                     [273.15, 0.], rtol=0., atol=1e-13)
 
-
+@deprecated
 def test_fahrenheit_to_celcius():
     assert_equal(sc.F2C(32), 0)
     assert_equal(sc.F2C([32, 32]), [0, 0])
 
-
+@deprecated
 def test_celcius_to_kelvin():
     assert_equal(sc.C2K([0, 0]), [273.15, 273.15])
 
-
+@deprecated
 def test_kelvin_to_celcius():
     assert_equal(sc.K2C([0, 0]), [-273.15, -273.15])
 
-
+@deprecated
 def test_fahrenheit_to_kelvin():
     assert_equal(sc.F2K([32, 32]), [273.15, 273.15])
 
-
+@deprecated
 def test_kelvin_to_fahrenheit():
     assert_equal(sc.K2F([273.15, 273.15]), [32, 32])
 
-
+@deprecated
 def test_celcius_to_fahrenheit():
     assert_equal(sc.C2F([0, 0]), [32, 32])
 


### PR DESCRIPTION
The temperature conversion functions have been superseded
by convert_temperature. This leads to some noisy DeprecationWarnings
when running the test suite. This silences them.
