### PR TITLE
ENH: special: change zeta signature to zeta(x, q=1)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@ scipy/io/matlab/tests/data/japanese_utf8.txt binary
 scipy/special/_ufuncs_cxx.pyx binary
 scipy/special/_ufuncs_cxx.pxd binary
 scipy/special/_ufuncs.pyx binary
+scipy/special/_ufuncs_defs.h binary
 scipy/linalg/_blas_subroutine_wrappers.f binary
 scipy/linalg/_blas_subroutines.h binary
 scipy/linalg/_lapack_subroutine_wrappers.f binary

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -1314,6 +1314,8 @@ cdef extern from "_ufuncs_defs.h":
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_struve_power_series "struve_power_series"(double, double, int, double *) nogil
 cdef extern from "_ufuncs_defs.h":
+    cdef double _func_zeta "zeta"(double, double) nogil
+cdef extern from "_ufuncs_defs.h":
     cdef int _func_airy_wrap "airy_wrap"(double, double *, double *, double *, double *) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef int _func_cairy_wrap "cairy_wrap"(double complex, double complex *, double complex *, double complex *, double complex *) nogil
@@ -1959,8 +1961,6 @@ cdef extern from "_ufuncs_defs.h":
 cdef extern from "_ufuncs_defs.h":
     cdef double complex _func_cbesy_wrap_e "cbesy_wrap_e"(double, double complex) nogil
 cdef extern from "_ufuncs_defs.h":
-    cdef double _func_zeta "zeta"(double, double) nogil
-cdef extern from "_ufuncs_defs.h":
     cdef double _func_zetac "zetac"(double) nogil
 cdef np.PyUFuncGenericFunction ufunc__cospi_loops[4]
 cdef void *ufunc__cospi_ptr[8]
@@ -2368,6 +2368,30 @@ ufunc__struve_power_series_ptr[2*0] = <void*>_func_struve_power_series
 ufunc__struve_power_series_ptr[2*0+1] = <void*>(<char*>"_struve_power_series")
 ufunc__struve_power_series_data[0] = &ufunc__struve_power_series_ptr[2*0]
 _struve_power_series = np.PyUFunc_FromFuncAndData(ufunc__struve_power_series_loops, ufunc__struve_power_series_data, ufunc__struve_power_series_types, 1, 3, 2, 0, "_struve_power_series", ufunc__struve_power_series_doc, 0)
+
+cdef np.PyUFuncGenericFunction ufunc__zeta_loops[2]
+cdef void *ufunc__zeta_ptr[4]
+cdef void *ufunc__zeta_data[2]
+cdef char ufunc__zeta_types[6]
+cdef char *ufunc__zeta_doc = (
+    "_zeta(x, q)\n"
+    "\n"
+    "Internal function, Hurwitz zeta.")
+ufunc__zeta_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
+ufunc__zeta_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
+ufunc__zeta_types[0] = <char>NPY_FLOAT
+ufunc__zeta_types[1] = <char>NPY_FLOAT
+ufunc__zeta_types[2] = <char>NPY_FLOAT
+ufunc__zeta_types[3] = <char>NPY_DOUBLE
+ufunc__zeta_types[4] = <char>NPY_DOUBLE
+ufunc__zeta_types[5] = <char>NPY_DOUBLE
+ufunc__zeta_ptr[2*0] = <void*>_func_zeta
+ufunc__zeta_ptr[2*0+1] = <void*>(<char*>"_zeta")
+ufunc__zeta_ptr[2*1] = <void*>_func_zeta
+ufunc__zeta_ptr[2*1+1] = <void*>(<char*>"_zeta")
+ufunc__zeta_data[0] = &ufunc__zeta_ptr[2*0]
+ufunc__zeta_data[1] = &ufunc__zeta_ptr[2*1]
+_zeta = np.PyUFunc_FromFuncAndData(ufunc__zeta_loops, ufunc__zeta_data, ufunc__zeta_types, 2, 2, 1, 0, "_zeta", ufunc__zeta_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_airy_loops[4]
 cdef void *ufunc_airy_ptr[8]
@@ -11177,31 +11201,31 @@ cdef char *ufunc_psi_doc = (
     "\n"
     "The digamma function.\n"
     "\n"
-    "The logarithmic derivative of the gamma function evaluated at `z`.\n"
+    "The logarithmic derivative of the gamma function evaluated at ``z``.\n"
     "\n"
     "Parameters\n"
     "----------\n"
     "z : array_like\n"
     "    Real or complex argument.\n"
     "out : ndarray, optional\n"
-    "    Array for the computed values of `psi`.\n"
+    "    Array for the computed values of ``psi``.\n"
     "\n"
     "Returns\n"
     "-------\n"
     "digamma : ndarray\n"
-    "    Computed values of `psi`.\n"
+    "    Computed values of ``psi``.\n"
     "\n"
     "Notes\n"
     "-----\n"
-    "For large values not close to the negative real axis `psi` is\n"
+    "For large values not close to the negative real axis ``psi`` is\n"
     "computed using the asymptotic series (5.11.2) from [1]_. For small\n"
     "arguments not close to the negative real axis the recurrence\n"
     "relation (5.5.2) from [1]_ is used until the argument is large\n"
     "enough to use the asymptotic series. For values close to the\n"
     "negative real axis the reflection formula (5.5.4) from [1]_ is\n"
-    "used first.  Note that `psi` has a family of zeros on the negative\n"
-    "real axis which occur between the poles at :math:`0, -1, -2,\n"
-    "\\ldots`. Around the zeros the reflection formula suffers from\n"
+    "used first.  Note that ``psi`` has a family of zeros on the\n"
+    "negative real axis which occur between the poles at nonpositive\n"
+    "integers. Around the zeros the reflection formula suffers from\n"
     "cancellation and the implementation loses precision. The sole\n"
     "positive zero and the first negative zero, however, are handled\n"
     "separately by precomputing series expansions using [2]_, so the\n"
@@ -12331,43 +12355,6 @@ ufunc_yve_data[1] = &ufunc_yve_ptr[2*1]
 ufunc_yve_data[2] = &ufunc_yve_ptr[2*2]
 ufunc_yve_data[3] = &ufunc_yve_ptr[2*3]
 yve = np.PyUFunc_FromFuncAndData(ufunc_yve_loops, ufunc_yve_data, ufunc_yve_types, 4, 2, 1, 0, "yve", ufunc_yve_doc, 0)
-
-cdef np.PyUFuncGenericFunction ufunc_zeta_loops[2]
-cdef void *ufunc_zeta_ptr[4]
-cdef void *ufunc_zeta_data[2]
-cdef char ufunc_zeta_types[6]
-cdef char *ufunc_zeta_doc = (
-    "zeta(x, q)\n"
-    "\n"
-    "Hurwitz zeta function\n"
-    "\n"
-    "The Riemann zeta function of two arguments (also known as the\n"
-    "Hurwitz zeta function).\n"
-    "\n"
-    "This function is defined as\n"
-    "\n"
-    ".. math:: \\zeta(x, q) = \\sum_{k=0}^{\\infty} 1 / (k+q)^x,\n"
-    "\n"
-    "where ``x > 1`` and ``q > 0``.\n"
-    "\n"
-    "See also\n"
-    "--------\n"
-    "zetac")
-ufunc_zeta_loops[0] = <np.PyUFuncGenericFunction>loop_d_dd__As_ff_f
-ufunc_zeta_loops[1] = <np.PyUFuncGenericFunction>loop_d_dd__As_dd_d
-ufunc_zeta_types[0] = <char>NPY_FLOAT
-ufunc_zeta_types[1] = <char>NPY_FLOAT
-ufunc_zeta_types[2] = <char>NPY_FLOAT
-ufunc_zeta_types[3] = <char>NPY_DOUBLE
-ufunc_zeta_types[4] = <char>NPY_DOUBLE
-ufunc_zeta_types[5] = <char>NPY_DOUBLE
-ufunc_zeta_ptr[2*0] = <void*>_func_zeta
-ufunc_zeta_ptr[2*0+1] = <void*>(<char*>"zeta")
-ufunc_zeta_ptr[2*1] = <void*>_func_zeta
-ufunc_zeta_ptr[2*1+1] = <void*>(<char*>"zeta")
-ufunc_zeta_data[0] = &ufunc_zeta_ptr[2*0]
-ufunc_zeta_data[1] = &ufunc_zeta_ptr[2*1]
-zeta = np.PyUFunc_FromFuncAndData(ufunc_zeta_loops, ufunc_zeta_data, ufunc_zeta_types, 2, 2, 1, 0, "zeta", ufunc_zeta_doc, 0)
 
 cdef np.PyUFuncGenericFunction ufunc_zetac_loops[2]
 cdef void *ufunc_zetac_ptr[4]

--- a/scipy/special/_ufuncs_defs.h
+++ b/scipy/special/_ufuncs_defs.h
@@ -8,6 +8,7 @@ npy_cdouble clngamma_wrap(npy_cdouble);
 npy_double struve_asymp_large_z(npy_double, npy_double, npy_int, npy_double *);
 npy_double struve_bessel_series(npy_double, npy_double, npy_int, npy_double *);
 npy_double struve_power_series(npy_double, npy_double, npy_int, npy_double *);
+npy_double zeta(npy_double, npy_double);
 #include "amos_wrappers.h"
 npy_int airy_wrap(npy_double, npy_double *, npy_double *, npy_double *, npy_double *);
 npy_int cairy_wrap(npy_cdouble, npy_cdouble *, npy_cdouble *, npy_cdouble *, npy_cdouble *);
@@ -209,6 +210,5 @@ npy_double cbesy_wrap_real(npy_double, npy_double);
 npy_cdouble cbesy_wrap(npy_double, npy_cdouble);
 npy_double cbesy_wrap_e_real(npy_double, npy_double);
 npy_cdouble cbesy_wrap_e(npy_double, npy_cdouble);
-npy_double zeta(npy_double, npy_double);
 npy_double zetac(npy_double);
 #endif

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -5409,24 +5409,11 @@ add_newdoc("scipy.special", "yve",
            http://netlib.org/amos/
     """)
 
-add_newdoc("scipy.special", "zeta",
+add_newdoc("scipy.special", "_zeta",
     """
-    zeta(x, q)
+    _zeta(x, q)
 
-    Hurwitz zeta function
-
-    The Riemann zeta function of two arguments (also known as the
-    Hurwitz zeta function).
-
-    This function is defined as
-
-    .. math:: \\zeta(x, q) = \\sum_{k=0}^{\\infty} 1 / (k+q)^x,
-
-    where ``x > 1`` and ``q > 0``.
-
-    See also
-    --------
-    zetac
+    Internal function, Hurwitz zeta.
 
     """)
 

--- a/scipy/special/basic.py
+++ b/scipy/special/basic.py
@@ -13,7 +13,7 @@ from numpy import (pi, asarray, floor, isscalar, iscomplex, real, imag, sqrt,
                    where, mgrid, sin, place, issubdtype, extract,
                    less, inexact, nan, zeros, atleast_1d, sinc)
 from ._ufuncs import (ellipkm1, mathieu_a, mathieu_b, iv, jv, gamma,
-                      psi, zeta, hankel1, hankel2, yv, kv, _gammaln,
+                      psi, _zeta, hankel1, hankel2, yv, kv, _gammaln,
                       ndtri, errprint, poch, binom, hyp0f1)
 from . import specfun
 from . import orthogonal
@@ -2444,3 +2444,23 @@ def factorialk(n, k, exact=True):
         return val
     else:
         raise NotImplementedError
+
+
+def zeta(x, q=None, out=None):
+    r"""
+    Riemann zeta function.
+
+    The two-argument version is the Hurwitz zeta function:
+
+    .. math:: \zeta(x, q) = \sum_{k=0}^{\infty} \frac{1}{(k + q)^x},
+
+    Riemann zeta function corresponds to ``q = 1``.
+
+    See also
+    --------
+    zetac
+
+    """
+    if q is None:
+        q = 1
+    return _zeta(x, q, out)

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -221,7 +221,7 @@ berp -- berp_wrap: d->d                                    -- specfun_wrappers.h
 beip -- beip_wrap: d->d                                    -- specfun_wrappers.h
 kerp -- kerp_wrap: d->d                                    -- specfun_wrappers.h
 keip -- keip_wrap: d->d                                    -- specfun_wrappers.h
-zeta -- zeta: dd->d                                        -- cephes.h
+_zeta -- zeta: dd->d                                       -- cephes.h
 kolmogorov -- kolmogorov: d->d                             -- cephes.h
 kolmogi -- kolmogi: d->d                                   -- cephes.h
 besselpoly -- besselpoly: ddd->d                           -- c_misc/misc.h

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -36,7 +36,7 @@ from numpy.testing import (assert_equal, assert_almost_equal,
 
 from scipy import special
 import scipy.special._ufuncs as cephes
-from scipy.special import ellipk
+from scipy.special import ellipk, zeta
 
 from scipy.special._testutils import assert_tol_equal, with_special_errors, \
      assert_func_equal
@@ -899,10 +899,14 @@ class TestCephes(TestCase):
         cephes.yve(1,1)
 
     def test_zeta(self):
-        cephes.zeta(2,2)
+        assert_allclose(zeta(2,2), pi**2/6 - 1, rtol=1e-12)
 
     def test_zetac(self):
         assert_equal(cephes.zetac(0),-1.5)
+
+    def test_zeta_1arg(self):
+        assert_allclose(zeta(2), pi**2/6, rtol=1e-12)
+        assert_allclose(zeta(4), pi**4/90, rtol=1e-12)
 
     def test_wofz(self):
         z = [complex(624.2,-0.26123), complex(-0.4,3.), complex(0.6,2.),


### PR DESCRIPTION
Make the second argument of zeta(x,q) default to q=1. This makes the one-argument zeta(x) be the Riemann zeta function if the second argument is not given. 

Previously, you had to write zeta(x,1) which is somewhat annoying since the Riemann zeta function is more often needed than the Hurwitz one.
