### PR TITLE
ENH: improve stats.kde density estimation near boundaries

### DIFF
--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -535,7 +535,7 @@ class gaussian_kde(object):
         self.inv_cov = self._data_inv_cov / self.factor**2
         self._norm_factor = sqrt(linalg.det(2*pi*self.covariance)) * self.n
 
-    def pdf(self, x):
+    def pdf(self, x, lb=None, ub=None):
         """
         Evaluate the estimated pdf on a provided set of points.
 
@@ -545,9 +545,9 @@ class gaussian_kde(object):
         docstring for more details.
 
         """
-        return self.evaluate(x)
+        return self.evaluate(x, lb, ub)
 
-    def logpdf(self, x):
+    def logpdf(self, x, lb=None, ub=None):
         """
         Evaluate the log of the estimated pdf on a provided set of points.
 
@@ -557,5 +557,5 @@ class gaussian_kde(object):
         returns ``np.log(gaussian_kde.evaluate(x))``.
 
         """
-        return np.log(self.evaluate(x))
+        return np.log(self.evaluate(x, lb, ub))
 

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -162,6 +162,7 @@ class gaussian_kde(object):
     >>> plt.show()
 
     """
+
     def __init__(self, dataset, bw_method=None):
         self.dataset = atleast_2d(dataset)
         if not self.dataset.size > 1:
@@ -179,6 +180,10 @@ class gaussian_kde(object):
         points : (# of dimensions, # of points)-array
             Alternatively, a (# of dimensions,) vector can be passed in and
             treated as a single point.
+        lb : Lower boundary for the estimated pdf, integer for unidimensional
+        distributions, array_like for multivariate ones
+        ub : Upper boundary for the estimated pdf, integer for unidimensional
+        distributions, array_like for multivariate ones
 
         Returns
         -------
@@ -192,6 +197,16 @@ class gaussian_kde(object):
 
         """
         points = atleast_2d(points)
+        if lb is not None:
+            lb = atleast_2d(lb)
+            f, s = lb.shape
+            if s > f:
+                lb = lb.T
+        if ub is not None:
+            ub = atleast_2d(ub)
+            f, s = ub.shape
+            if s > f:
+                ub = ub.T
 
         d, m = points.shape
         if d != self.d:
@@ -213,7 +228,7 @@ class gaussian_kde(object):
             for i in range(self.n):
                 diff_0 = self.dataset[:, i, newaxis] - points
                 tdiff_0 = dot(self.inv_cov, diff_0)
-                energy_0 = sum(diff_0 * tdiff_0,axis=0) / 2.0
+                energy_0 = sum(diff_0 * tdiff_0, axis=0) / 2.0
                 result = result + exp(-energy_0)
                 if lb is not None:
                     diff_l = self.dataset + points[:, i, newaxis] - 2*lb

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -171,7 +171,8 @@ class gaussian_kde(object):
         self.set_bandwidth(bw_method=bw_method)
 
     def evaluate(self, points):
-        """Evaluate the estimated pdf on a set of points.
+        """Evaluate the estimated pdf on a set of points using a Gaussian 
+        Kernel, boundary effects corrected using the reflection method.
 
         Parameters
         ----------
@@ -204,23 +205,51 @@ class gaussian_kde(object):
                 raise ValueError(msg)
 
         result = zeros((m,), dtype=float)
+        result_l = zeros((m,), dtype=float)
+        result_u = zeros((m,), dtype=float)
 
+        # define the boundaries
+        l = np.min((np.min(points), np.min(self.dataset)))
+        u = np.max((np.max(points), np.max(self.dataset)))
+        
         if m >= self.n:
             # there are more points than data, so loop over data
             for i in range(self.n):
-                diff = self.dataset[:, i, newaxis] - points
-                tdiff = dot(self.inv_cov, diff)
-                energy = sum(diff*tdiff,axis=0) / 2.0
-                result = result + exp(-energy)
+                diff_0 = self.dataset[:, i, newaxis] - points
+                tdiff_0 = dot(self.inv_cov, diff_0)
+                energy_0 = sum(diff_0 * tdiff_0, axis=0) / 2.0
+                result[i] = sum(exp(-energy_0), axis=0)
+                # reflected points, lower boundary
+                diff_l = self.dataset + points[:, i, newaxis] - 2*l                
+                tdiff_l = dot(self.inv_cov, diff_l)
+                energy_l = sum(diff_l * tdiff_l, axis=0) / 2.0
+                result_l[i] = sum(exp(-energy_l), axis=0)
+                # reflected points, upper boundary
+                diff_u = self.dataset + points[:, i, newaxis] - 2*u                
+                tdiff_u = dot(self.inv_cov, diff_u)
+                energy_u = sum(diff_u * tdiff_u, axis=0) / 2.0
+                result_u[i] = sum(exp(-energy_u), axis=0)
         else:
             # loop over points
             for i in range(m):
-                diff = self.dataset - points[:, i, newaxis]
-                tdiff = dot(self.inv_cov, diff)
-                energy = sum(diff * tdiff, axis=0) / 2.0
-                result[i] = sum(exp(-energy), axis=0)
+                # actual points
+                diff_0 = self.dataset - points[:, i, newaxis]
+                tdiff_0 = dot(self.inv_cov, diff_0)
+                energy_0 = sum(diff_0 * tdiff_0, axis=0) / 2.0
+                result[i] = sum(exp(-energy_0), axis=0)
+                # reflected points, lower boundary
+                diff_l = self.dataset + points[:, i, newaxis] - 2*l                
+                tdiff_l = dot(self.inv_cov, diff_l)
+                energy_l = sum(diff_l * tdiff_l, axis=0) / 2.0
+                result_l[i] = sum(exp(-energy_l), axis=0)
+                # reflected points, upper boundary
+                diff_u = self.dataset + points[:, i, newaxis] - 2*u                
+                tdiff_u = dot(self.inv_cov, diff_u)
+                energy_u = sum(diff_u * tdiff_u, axis=0) / 2.0
+                result_u[i] = sum(exp(-energy_u), axis=0)
+                
 
-        result = result / self._norm_factor
+        result = (result + result_l + result_u) / self._norm_factor
 
         return result
 

--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -172,18 +172,17 @@ class gaussian_kde(object):
         self.set_bandwidth(bw_method=bw_method)
 
     def evaluate(self, points, lb=None, ub=None):
-        """Evaluate the estimated pdf on a set of points using a Gaussian
-        Kernel, boundary effects corrected using the reflection method.
+        """Evaluate the estimated pdf on a set of points.
 
         Parameters
         ----------
         points : (# of dimensions, # of points)-array
             Alternatively, a (# of dimensions,) vector can be passed in and
             treated as a single point.
-        lb : Lower boundary for the estimated pdf, integer for unidimensional
-        distributions, array_like for multivariate ones
-        ub : Upper boundary for the estimated pdf, integer for unidimensional
-        distributions, array_like for multivariate ones
+        lb : float or array_like
+            Lower boundary for the estimated pdf
+        ub : float or array_like
+            Upper boundary for the estimated pdf
 
         Returns
         -------

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -51,7 +51,6 @@ def test_kde_1d_boundaries():
     uniformpdf = stats.beta.pdf(xs, 1, 1)
     intervall = xs[1] - xs[0]
 
-
     assert_(np.sum((kdepdf - uniformpdf)**2)*intervall < 0.01)
     prob1 = gkde.integrate_box_1d(0.5, 1)
     prob2 = gkde.integrate_box_1d(0, 0.5)
@@ -129,6 +128,7 @@ def test_kde_bandwidth_method():
 # to create these kinds of subclasses, or call _compute_covariance() directly.
 
 class _kde_subclass1(stats.gaussian_kde):
+
     def __init__(self, dataset):
         self.dataset = np.atleast_2d(dataset)
         self.d, self.n = self.dataset.shape
@@ -137,12 +137,14 @@ class _kde_subclass1(stats.gaussian_kde):
 
 
 class _kde_subclass2(stats.gaussian_kde):
+
     def __init__(self, dataset):
         self.covariance_factor = self.scotts_factor
         super(_kde_subclass2, self).__init__(dataset)
 
 
 class _kde_subclass3(stats.gaussian_kde):
+
     def __init__(self, dataset, covariance):
         self.covariance = covariance
         stats.gaussian_kde.__init__(self, dataset)
@@ -154,6 +156,7 @@ class _kde_subclass3(stats.gaussian_kde):
 
 
 class _kde_subclass4(stats.gaussian_kde):
+
     def covariance_factor(self):
         return 0.5 * self.silverman_factor()
 

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -36,6 +36,29 @@ def test_kde_1d():
     assert_almost_equal(gkde.integrate_gaussian(xnmean, xnstd**2),
                         (kdepdf*normpdf).sum()*intervall, decimal=2)
 
+def test_kde_1d_boundaries():
+    #some basic tests comparing to beta/uniform distribution
+    np.random.seed(8765678)
+    n_basesample = 1000
+    xn = stats.beta(1., 1.).rvs(n_basesample)
+
+    # get kde for original sample
+    gkde = stats.gaussian_kde(xn)
+
+    # evaluate the density function for the kde for some points using boundaries
+    xs = np.linspace(0, 1, 500)
+    kdepdf = gkde.evaluate(xs, lb=0, ub=1)
+    uniformpdf = stats.beta.pdf(xs, 1, 1)
+    intervall = xs[1] - xs[0]
+
+
+    assert_(np.sum((kdepdf - uniformpdf)**2)*intervall < 0.01)
+    prob1 = gkde.integrate_box_1d(0.5, 1)
+    prob2 = gkde.integrate_box_1d(0, 0.5)
+    assert_almost_equal(prob1, 0.5, decimal=1)
+    assert_almost_equal(prob2, 0.5, decimal=1)
+    assert_almost_equal(gkde.integrate_box(0.5, 1), prob1, decimal=13)
+    assert_almost_equal(gkde.integrate_box(0, 0.5), prob2, decimal=13)
 
 def test_kde_2d():
     #some basic tests comparing to normal distribution

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -74,6 +74,29 @@ def test_kde_2d():
     assert_almost_equal(gkde.integrate_gaussian(mean, covariance),
                         (kdepdf*normpdf).sum()*(intervall**2), decimal=2)
 
+def test_kde_1d_boundaries():
+    #some basic tests comparing to normal distribution
+    np.random.seed(8765678)
+    n_basesample = 1000
+    xn = stats.beta(1., 1.).rvs(n_basesample)
+
+    # get kde for original sample
+    gkde = stats.gaussian_kde(xn)
+
+    # evaluate the density function for the kde for some points
+    xs = np.linspace(0, 1, 500)
+    kdepdf = gkde.evaluate(xs, lb=0, ub=1)
+    uniformpdf = stats.beta.pdf(xs, 1, 1)
+    intervall = xs[1] - xs[0]
+
+    assert_(np.sum((kdepdf - uniformpdf)**2)*intervall < 0.01)
+    prob1 = gkde.integrate_box_1d(0.5, 1)
+    prob2 = gkde.integrate_box_1d(0, 0.5)
+    assert_almost_equal(prob1, 0.5, decimal=1)
+    assert_almost_equal(prob2, 0.5, decimal=1)
+    assert_almost_equal(gkde.integrate_box(0.5, 1), prob1, decimal=13)
+    assert_almost_equal(gkde.integrate_box(0, 0.5), prob2, decimal=13)
+
 def test_kde_2d_boundaries():
     #some basic tests comparing to normal distribution
     np.random.seed(8765678)

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -21,9 +21,9 @@ def test_kde_1d():
     xs = np.linspace(-7,7,501)
     kdepdf = gkde.evaluate(xs)
     normpdf = stats.norm.pdf(xs, loc=xnmean, scale=xnstd)
-    intervall = xs[1] - xs[0]
+    interval = xs[1] - xs[0]
 
-    assert_(np.sum((kdepdf - normpdf)**2)*intervall < 0.01)
+    assert_(np.sum((kdepdf - normpdf)**2)*interval < 0.01)
     prob1 = gkde.integrate_box_1d(xnmean, np.inf)
     prob2 = gkde.integrate_box_1d(-np.inf, xnmean)
     assert_almost_equal(prob1, 0.5, decimal=1)
@@ -32,9 +32,9 @@ def test_kde_1d():
     assert_almost_equal(gkde.integrate_box(-np.inf, xnmean), prob2, decimal=13)
 
     assert_almost_equal(gkde.integrate_kde(gkde),
-                        (kdepdf**2).sum()*intervall, decimal=2)
+                        (kdepdf**2).sum()*interval, decimal=2)
     assert_almost_equal(gkde.integrate_gaussian(xnmean, xnstd**2),
-                        (kdepdf*normpdf).sum()*intervall, decimal=2)
+                        (kdepdf*normpdf).sum()*interval, decimal=2)
 
 
 def test_kde_2d():
@@ -58,9 +58,9 @@ def test_kde_2d():
     kdepdf = kdepdf.reshape(500, 500)
 
     normpdf = stats.multivariate_normal.pdf(np.dstack([x, y]), mean=mean, cov=covariance)
-    intervall = y.ravel()[1] - y.ravel()[0]
+    interval = y.ravel()[1] - y.ravel()[0]
 
-    assert_(np.sum((kdepdf - normpdf)**2) * (intervall**2) < 0.01)
+    assert_(np.sum((kdepdf - normpdf)**2) * (interval**2) < 0.01)
 
     small = -1e100
     large = 1e100
@@ -70,9 +70,9 @@ def test_kde_2d():
     assert_almost_equal(prob1, 0.5, decimal=1)
     assert_almost_equal(prob2, 0.5, decimal=1)
     assert_almost_equal(gkde.integrate_kde(gkde),
-                        (kdepdf**2).sum()*(intervall**2), decimal=2)
+                        (kdepdf**2).sum()*(interval**2), decimal=2)
     assert_almost_equal(gkde.integrate_gaussian(mean, covariance),
-                        (kdepdf*normpdf).sum()*(intervall**2), decimal=2)
+                        (kdepdf*normpdf).sum()*(interval**2), decimal=2)
 
 def test_kde_1d_boundaries():
     #some basic tests comparing to normal distribution
@@ -87,9 +87,9 @@ def test_kde_1d_boundaries():
     xs = np.linspace(0, 1, 500)
     kdepdf = gkde.evaluate(xs, lb=0, ub=1)
     uniformpdf = stats.beta.pdf(xs, 1, 1)
-    intervall = xs[1] - xs[0]
+    interval = xs[1] - xs[0]
 
-    assert_(np.sum((kdepdf - uniformpdf)**2)*intervall < 0.01)
+    assert_(np.sum((kdepdf - uniformpdf)**2)*interval < 0.01)
     prob1 = gkde.integrate_box_1d(0.5, 1)
     prob2 = gkde.integrate_box_1d(0, 0.5)
     assert_almost_equal(prob1, 0.5, decimal=1)
@@ -118,9 +118,9 @@ def test_kde_2d_boundaries():
     kdepdf = kdepdf.reshape(500, 500)
 
     normpdf = stats.multivariate_normal.pdf(np.dstack([x, y]), mean=mean, cov=covariance)
-    intervall = y.ravel()[1] - y.ravel()[0]
+    interval = y.ravel()[1] - y.ravel()[0]
 
-    assert_(np.sum((kdepdf - normpdf)**2) * (intervall**2) < 0.01)
+    assert_(np.sum((kdepdf - normpdf)**2) * (interval**2) < 0.01)
 
     small = -1e100
     large = 1e100
@@ -130,9 +130,9 @@ def test_kde_2d_boundaries():
     assert_almost_equal(prob1, 0.5, decimal=1)
     assert_almost_equal(prob2, 0.5, decimal=1)
     assert_almost_equal(gkde.integrate_kde(gkde),
-                        (kdepdf**2).sum()*(intervall**2), decimal=2)
+                        (kdepdf**2).sum()*(interval**2), decimal=2)
     assert_almost_equal(gkde.integrate_gaussian(mean, covariance),
-                        (kdepdf*normpdf).sum()*(intervall**2), decimal=2)
+                        (kdepdf*normpdf).sum()*(interval**2), decimal=2)
 
 def test_kde_bandwidth_method():
     def scotts_factor(kde_obj):


### PR DESCRIPTION
When estimating a distribution that has boundaries like a uniform distribution or an exponential, or a beta(0.5, 0.5), etc a KDE has problems estimating the density close to that boundaries. There are many methods to deal with this problem. I have implemented the reflection method.
