### PR TITLE
BUG: sparse: Fix COO dot with zero columns

### DIFF
--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -496,7 +496,11 @@ class coo_matrix(_data_matrix, _minmax_mixin):
         return result
 
     def _mul_multivector(self, other):
-        return np.hstack([self._mul_vector(col).reshape(-1,1) for col in other.T])
+        result = np.zeros((other.shape[1], self.shape[0]),
+                          dtype=upcast_char(self.dtype.char, other.dtype.char))
+        for i, col in enumerate(other.T):
+            coo_matvec(self.nnz, self.row, self.col, self.data, col, result[i])
+        return np.matrix(result.T)
 
 
 def isspmatrix_coo(x):

--- a/scipy/sparse/coo.py
+++ b/scipy/sparse/coo.py
@@ -500,7 +500,7 @@ class coo_matrix(_data_matrix, _minmax_mixin):
                           dtype=upcast_char(self.dtype.char, other.dtype.char))
         for i, col in enumerate(other.T):
             coo_matvec(self.nnz, self.row, self.col, self.data, col, result[i])
-        return np.matrix(result.T)
+        return result.T.view(type=type(other))
 
 
 def isspmatrix_coo(x):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1354,13 +1354,14 @@ class _TestCommon:
         assert_array_almost_equal(row*M, row*M.todense())
 
     def test_small_multiplication(self):
-        # test that A*x works for x with shape () (1,) and (1,1)
+        # test that A*x works for x with shape () (1,) (1,1) and (1,0)
         A = self.spmatrix([[1],[2],[3]])
 
         assert_(isspmatrix(A * array(1)))
         assert_equal((A * array(1)).todense(), [[1],[2],[3]])
         assert_equal(A * array([1]), array([1,2,3]))
         assert_equal(A * array([[1]]), array([[1],[2],[3]]))
+        assert_equal(A * np.ones((1,0)), np.ones((3,0)))
 
     def test_binop_custom_type(self):
         # Non-regression test: previously, binary operations would raise


### PR DESCRIPTION
Fixes #6128, with the side-effect of slightly optimizing `_mul_multivector`.
Also adds a simple regression test.
