### PR TITLE
make logsumexp error out on a masked array

### DIFF
--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -11,6 +11,7 @@ from numpy import (exp, log, asarray, arange, newaxis, hstack, product, array,
                    zeros, eye, poly1d, r_, fromstring, isfinite,
                    squeeze, amax, reshape, sign, broadcast_arrays)
 
+from scipy._lib._util import _asarray_validated
 
 __all__ = ['logsumexp', 'central_diff_weights', 'derivative', 'pade', 'lena',
            'ascent', 'face']
@@ -91,8 +92,17 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     >>> logsumexp([1,2],b=[1,-1],return_sign=True)
     (1.5413248546129181, -1.0)
 
+    Notice that `logsumexp` does not directly support masked arrays. To use it
+    on a masked array, convert the mask into zero weights:
+
+    >>> a = np.ma.array([np.log(2), 2, np.log(3)],
+    ...                  mask=[False, True, False])
+    >>> b = (~a.mask).astype(int)
+    >>> logsumexp(a.data, b=b), np.log(5)
+    1.6094379124341005, 1.6094379124341005
+
     """
-    a = asarray(a)
+    a = _asarray_validated(a, check_finite=False)
     if b is not None:
         a, b = broadcast_arrays(a,b)
         if np.any(b == 0):

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -8,7 +8,7 @@ from __future__ import division, print_function, absolute_import
 import numpy
 import numpy as np
 from numpy import (exp, log, asarray, arange, newaxis, hstack, product, array,
-                   zeros, eye, poly1d, r_, sum, fromstring, isfinite,
+                   zeros, eye, poly1d, r_, fromstring, isfinite,
                    squeeze, amax, reshape, sign, broadcast_arrays)
 
 
@@ -114,7 +114,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
 
     # suppress warnings about log of zero
     with np.errstate(divide='ignore'):
-        s = sum(tmp, axis=axis, keepdims=keepdims)
+        s = np.sum(tmp, axis=axis, keepdims=keepdims)
         if return_sign:
             sgn = sign(s)
             s *= sgn  # /= makes more sense but we need zero -> zero


### PR DESCRIPTION
TL;DR: This is an alternative to gh-3036. That PR was proposing to pass all array subclasses to logsumexp. Here I instead propose to error out and give a workaround in the docstring.

On master, `logsumexp` simply ignores the mask and does the calculation with both masked and non-masked data:

```
In [45]: a = np.ma.array([np.log(2), 2, np.log(3)], mask=[False, True, False])

In [46]: logsumexp(a.data)
Out[46]: 2.5168135102475446

In [47]: logsumexp(a)
Out[47]: 2.5168135102475446
```

In this PR, `logsumexp(a)` errors out instead of returning garbage. Also, the docstring now lists a workaround:

```
 >>> a = np.ma.array([np.log(2), 2, np.log(3)],
...                  mask=[False, True, False])
>>> b = (~a.mask).astype(int)
>>> logsumexp(a.data, b=b), np.log(5)
1.6094379124341005, 1.6094379124341005
```

closes gh-3036, closes gh-3034.
