### PR TITLE
Fix mpf_assert_allclose to handle iterable results, such as maps

### DIFF
--- a/scipy/special/_precompute/utils.py
+++ b/scipy/special/_precompute/utils.py
@@ -18,6 +18,11 @@ except ImportError:
 
 
 def mpf_assert_allclose(res, std, atol=0, rtol=1e-17):
+    try:
+        len(res)
+    except TypeError:
+        res = list(res)
+
     n = len(std)
     if len(res) != n:
         raise AssertionError("Lengths of inputs not equal.")


### PR DESCRIPTION
In Python 3, the result of operating on an iterator can be another iterator
instead of a list.  When mpf_assert_allclose tries to get the length of this
object, it fails.  The patch tries to determine the object's length, and if
that fails converts to list explicitly.

(This was caught by a failure in the test suite: `scipy/special/tests/test_precompute_gammainc.py:test_alpha`)
