### PR TITLE
Fix pchip_interpolate convenience function

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -186,10 +186,8 @@ def pchip_interpolate(xi, yi, x, der=0, axis=0):
     x : scalar or array_like
         Of length M.
     der : int or list, optional
-        How many derivatives to extract; None for all potentially
-        nonzero derivatives (that is a number equal to the number
-        of points), or a list of derivatives to extract. This number
-        includes the function value as 0th derivative.
+        Derivatives to extract.  The 0-th derivative can be included to
+        return the function value.
     axis : int, optional
         Axis in the yi array corresponding to the x-coordinate values.
 
@@ -204,12 +202,13 @@ def pchip_interpolate(xi, yi, x, der=0, axis=0):
 
     """
     P = PchipInterpolator(xi, yi, axis=axis)
+
     if der == 0:
         return P(x)
     elif _isscalar(der):
-        return P(x, der=der)
+        return P.derivative(der)(x)
     else:
-        return [P(x, nu) for nu in der]
+        return [P.derivative(nu)(x) for nu in der]
 
 
 # Backwards compatibility

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -5,14 +5,15 @@ import warnings
 import numpy as np
 
 from numpy.testing import (
-    assert_almost_equal, assert_array_equal, TestCase, run_module_suite,
-    assert_allclose, assert_equal, assert_, assert_raises)
+    assert_almost_equal, assert_array_equal, assert_array_almost_equal,
+    TestCase, run_module_suite, assert_allclose, assert_equal, assert_,
+    assert_raises)
 
 from scipy.interpolate import (
     KroghInterpolator, krogh_interpolate,
     BarycentricInterpolator, barycentric_interpolate,
     approximate_taylor_polynomial, pchip, PchipInterpolator,
-    Akima1DInterpolator, CubicSpline)
+    pchip_interpolate, Akima1DInterpolator, CubicSpline)
 from scipy._lib.six import xrange
 
 
@@ -415,6 +416,19 @@ class TestPCHIP(TestCase):
 
         xx = np.linspace(0, 9, 101)
         assert_equal(pch(xx), 0.)
+
+    def test_pchip_interpolate(self):
+        assert_array_almost_equal(
+            pchip_interpolate([1,2,3], [4,5,6], [0.5], der=1),
+            [1.])
+
+        assert_array_almost_equal(
+            pchip_interpolate([1,2,3], [4,5,6], [0.5], der=0),
+            [3.5])
+
+        assert_array_almost_equal(
+            pchip_interpolate([1,2,3], [4,5,6], [0.5], der=[0, 1]),
+            [[3.5], [1]])
 
 
 class TestCubicSpline(object):


### PR DESCRIPTION
Derivatives were not being passed correctly to the underlying
PChipInterpolator object.  The specification of derivative has been changed
slightly so that you now have to provide either an integer or a list of
integers, removing some of the magic of that parameter's interpretation.
