### PR TITLE
ENH: sparse.csgraph: Pass indices to shortest_path

### DIFF
--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -34,10 +34,11 @@ def shortest_path(csgraph, method='auto',
                   directed=True,
                   return_predecessors=False,
                   unweighted=False,
-                  overwrite=False):
+                  overwrite=False,
+                  indices=None):
     """
     shortest_path(csgraph, method='auto', directed=True, return_predecessors=False,
-                  unweighted=False, overwrite=False)
+                  unweighted=False, overwrite=False, indices=None)
 
     Perform a shortest-path graph search on a positive directed or
     undirected graph.
@@ -92,6 +93,9 @@ def shortest_path(csgraph, method='auto',
         If True, overwrite csgraph with the result.  This applies only if
         method == 'FW' and csgraph is a dense, c-ordered array with
         dtype=float64.
+    indices : array_like or int, optional
+        If specified, only compute the paths for the points at the given
+        indices. Incompatible with method == 'FW'.
 
     Returns
     -------
@@ -138,7 +142,7 @@ def shortest_path(csgraph, method='auto',
         else:
             Nk = np.sum(csgraph > 0)
 
-        if Nk < N * N / 4:
+        if indices is not None or Nk < N * N / 4:
             if ((issparse and np.any(csgraph.data < 0))
                       or (not issparse and np.any(csgraph < 0))):
                 method = 'J'
@@ -148,6 +152,8 @@ def shortest_path(csgraph, method='auto',
             method = 'FW'
 
     if method == 'FW':
+        if indices is not None:
+            raise ValueError("Cannot specify indices with method == 'FW'.")
         return floyd_warshall(csgraph, directed,
                               return_predecessors=return_predecessors,
                               unweighted=unweighted,
@@ -156,17 +162,17 @@ def shortest_path(csgraph, method='auto',
     elif method == 'D':
         return dijkstra(csgraph, directed,
                         return_predecessors=return_predecessors,
-                        unweighted=unweighted)
+                        unweighted=unweighted, indices=indices)
 
     elif method == 'BF':
         return bellman_ford(csgraph, directed,
                             return_predecessors=return_predecessors,
-                            unweighted=unweighted)
+                            unweighted=unweighted, indices=indices)
 
     elif method == 'J':
         return johnson(csgraph, directed,
                        return_predecessors=return_predecessors,
-                       unweighted=unweighted)
+                       unweighted=unweighted, indices=indices)
 
     else:
         raise ValueError("unrecognized method '%s'" % method)

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -107,8 +107,11 @@ def test_shortest_path_indices():
         assert_array_almost_equal(SP, undirected_SP[indices].reshape(outshape))
 
     for indshape in [(4,), (4, 1), (2, 2)]:
-        for func in (dijkstra, bellman_ford, johnson):
+        for func in (dijkstra, bellman_ford, johnson, shortest_path):
             yield check, func, indshape
+
+    assert_raises(ValueError, shortest_path, directed_G, method='FW',
+                  indices=indices)
 
 
 def test_predecessors():


### PR DESCRIPTION
Most of the APSP methods support searching from a subset of vertices, but this option wasn't exposed through the `scipy.sparse.csgraph.shortest_path` wrapper function.

I added `indices` to the end of the kwargs to preserve back compat (in case any users are passing everything positionally).
