### PR TITLE
BUG: fix issue in io/wavfile for float96 input.

### DIFF
--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -196,7 +196,7 @@ def read(filename, mmap=False):
     Returns
     -------
     rate : int
-        Sample rate of wav file. 
+        Sample rate of wav file.
     data : numpy array
         Data read from wav file.  Data-type is determined from the file;
         see Notes.
@@ -246,7 +246,7 @@ def read(filename, mmap=False):
                 fmt_chunk = _read_fmt_chunk(fid, is_big_endian)
                 format_tag, channels, fs = fmt_chunk[1:4]
                 bit_depth = fmt_chunk[6]
-                if bit_depth not in (8, 16, 32, 64, 128):
+                if bit_depth not in (8, 16, 32, 64, 96, 128):
                     raise ValueError("Unsupported bit depth: the wav file "
                                      "has {}-bit data.".format(bit_depth))
             elif chunk_id == b'fact':


### PR DESCRIPTION
This resulted in 24 test errors on my 32-bit Python install.
Introduced in gh-5990. @endolith could you please check this fix?
