### PR TITLE
ENH: Periodic extrapolation for PPoly and BPoly

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -428,6 +428,9 @@ class CubicSpline(PPoly):
 
     Notes
     -----
+    Parameters `bc_type` and `interpolate` work independently, i.e. the former
+    controls only construction of a spline, and the latter only evaluation.
+
     When a boundary condition is 'not-a-knot' and n = 2, it is replaced by
     a condition that the first derivative is equal to the linear interpolant
     slope. When both boundary conditions are 'not-a-knot' and n = 3, the

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -361,10 +361,11 @@ class CubicSpline(PPoly):
         Axis along which `y` is assumed to be varying. Meaning that for
         ``x[i]`` the corresponding values are ``np.take(y, i, axis=axis)``.
         Default is 0.
-    extrapolate : bool or None, optional
-        Whether to extrapolate to out-of-bounds points based on first and last
-        intervals, or to return NaNs. If None (default), `extrapolate` is set
-        to False for ``bc_type='periodic'`` and to True otherwise (see Notes).
+    extrapolate : {bool, 'periodic', None}, optional
+        If bool, determines whether to extrapolate to out-of-bounds points
+        based on first and last intervals, or to return NaNs. If 'periodic',
+        periodic extrapolation is used. If None (default), `extrapolate` is
+        set to 'periodic' for ``bc_type='periodic'`` and to True otherwise.
     bc_type : string or 2-tuple, optional
         Boundary condition type. Two additional equations, given by the
         boundary conditions, are required to determine all coefficients of
@@ -434,17 +435,8 @@ class CubicSpline(PPoly):
 
     When 'not-a-knot' boundary conditions is applied to both ends, the
     resulting spline will be the same as returned by `splrep` (with ``s=0``)
-    and `InterpolatedUnivariateSpline`, but those two methods use a
+    and `InterpolatedUnivariateSpline`, but these two methods use a
     representation in B-spline basis.
-
-    Currently `PPoly` can't correctly evaluate periodic polynomials for
-    arbitrary x. To decrease possible confusion, `extrapolate` is set to False
-    by default when ``bc_type='periodic'``. Fow now you can achieve periodic
-    evaluation for any x as follows::
-
-        S(S.x[0] + (x - S.x[0]) % (S.x[-1] - S.x[0])),
-
-    where ``S`` is a `CubicSpline` instance.
 
     .. versionadded:: 0.18.0
 
@@ -545,7 +537,10 @@ class CubicSpline(PPoly):
         bc, y = self._validate_bc(bc_type, y, y.shape[1:], axis)
 
         if extrapolate is None:
-            extrapolate = bc_type[0] != 'periodic'
+            if bc[0] == 'periodic':
+                extrapolate = 'periodic'
+            else:
+                extrapolate = True
 
         dxr = dx.reshape([dx.shape[0]] + [1] * (y.ndim - 1))
         slope = np.diff(y, axis=0) / dxr

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -361,11 +361,6 @@ class CubicSpline(PPoly):
         Axis along which `y` is assumed to be varying. Meaning that for
         ``x[i]`` the corresponding values are ``np.take(y, i, axis=axis)``.
         Default is 0.
-    extrapolate : {bool, 'periodic', None}, optional
-        If bool, determines whether to extrapolate to out-of-bounds points
-        based on first and last intervals, or to return NaNs. If 'periodic',
-        periodic extrapolation is used. If None (default), `extrapolate` is
-        set to 'periodic' for ``bc_type='periodic'`` and to True otherwise.
     bc_type : string or 2-tuple, optional
         Boundary condition type. Two additional equations, given by the
         boundary conditions, are required to determine all coefficients of
@@ -398,6 +393,11 @@ class CubicSpline(PPoly):
           is 1D, then `deriv_value` must be a scalar. If `y` is 3D with the
           shape (n0, n1, n2) and axis=2, then `deriv_value` must be 2D
           and have the shape (n0, n1).
+    extrapolate : {bool, 'periodic', None}, optional
+        If bool, determines whether to extrapolate to out-of-bounds points
+        based on first and last intervals, or to return NaNs. If 'periodic',
+        periodic extrapolation is used. If None (default), `extrapolate` is
+        set to 'periodic' for ``bc_type='periodic'`` and to True otherwise.
 
     Attributes
     ----------
@@ -501,7 +501,7 @@ class CubicSpline(PPoly):
             on Wikiversity.
     .. [2] Carl de Boor, "A Practical Guide to Splines", Springer-Verlag, 1978.
     """
-    def __init__(self, x, y, axis=0, extrapolate=None, bc_type='not-a-knot'):
+    def __init__(self, x, y, axis=0, bc_type='not-a-knot', extrapolate=None):
         x, y = map(np.asarray, (x, y))
 
         if np.issubdtype(x.dtype, np.complexfloating):

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -626,11 +626,13 @@ class _PPolyBase(object):
     """Base class for piecewise polynomials."""
     __slots__ = ('c', 'x', 'extrapolate', 'axis')
 
-    def __init__(self, c, x, extrapolate=True, axis=0):
+    def __init__(self, c, x, extrapolate=None, axis=0):
         self.c = np.asarray(c)
         self.x = np.ascontiguousarray(x, dtype=np.float64)
 
-        if extrapolate != 'periodic':
+        if extrapolate is None:
+            extrapolate = True
+        elif extrapolate != 'periodic':
             extrapolate = bool(extrapolate)
         self.extrapolate = extrapolate
 
@@ -1156,7 +1158,7 @@ class PPoly(_PPolyBase):
         return self.solve(0, discontinuity, extrapolate)
 
     @classmethod
-    def from_spline(cls, tck, extrapolate=True):
+    def from_spline(cls, tck, extrapolate=None):
         """
         Construct a piecewise polynomial from a spline
 
@@ -1179,7 +1181,7 @@ class PPoly(_PPolyBase):
         return cls.construct_fast(cvals, t, extrapolate)
 
     @classmethod
-    def from_bernstein_basis(cls, bp, extrapolate=True):
+    def from_bernstein_basis(cls, bp, extrapolate=None):
         """
         Construct a piecewise polynomial in the power basis
         from a polynomial in Bernstein basis.
@@ -1482,7 +1484,7 @@ class BPoly(_PPolyBase):
     extend.__doc__ = _PPolyBase.extend.__doc__
 
     @classmethod
-    def from_power_basis(cls, pp, extrapolate=True):
+    def from_power_basis(cls, pp, extrapolate=None):
         """
         Construct a piecewise polynomial in Bernstein basis
         from a power basis polynomial.
@@ -1513,7 +1515,7 @@ class BPoly(_PPolyBase):
         return cls.construct_fast(c, pp.x, extrapolate, pp.axis)
 
     @classmethod
-    def from_derivatives(cls, xi, yi, orders=None, extrapolate=True):
+    def from_derivatives(cls, xi, yi, orders=None, extrapolate=None):
         """Construct a piecewise polynomial in the Bernstein basis,
         compatible with the specified values and derivatives at breakpoints.
 

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -887,8 +887,8 @@ class PPoly(_PPolyBase):
         Parameters
         ----------
         nu : int, optional
-            Order of derivative to evaluate. (Default: 1)
-            If negative, the antiderivative is returned.
+            Order of derivative to evaluate. Default is 1, i.e. compute the
+            first derivative. If negative, the antiderivative is returned.
 
         Returns
         -------
@@ -935,8 +935,8 @@ class PPoly(_PPolyBase):
         Parameters
         ----------
         nu : int, optional
-            Order of antiderivative to evaluate. (Default: 1)
-            If negative, the derivative is returned.
+            Order of antiderivative to evaluate. Default is 1, i.e. compute
+            the first integral. If negative, the derivative is returned.
 
         Returns
         -------
@@ -950,6 +950,10 @@ class PPoly(_PPolyBase):
         continuously differentiable to order n-1, up to floating point
         rounding error.
 
+        If antiderivative is computed and ``self.extrapolate='periodic'``,
+        it will be set to False for the returned instance. This is done because
+        the antiderivative is no longer periodic and its correct evaluation
+        outside of the initially given x interval is difficult.
         """
         if nu <= 0:
             return self.derivative(-nu)
@@ -967,8 +971,13 @@ class PPoly(_PPolyBase):
         _ppoly.fix_continuity(c.reshape(c.shape[0], c.shape[1], -1),
                               self.x, nu - 1)
 
+        if self.extrapolate == 'periodic':
+            extrapolate = False
+        else:
+            extrapolate = self.extrapolate
+
         # construct a compatible polynomial
-        return self.construct_fast(c, self.x, self.extrapolate, self.axis)
+        return self.construct_fast(c, self.x, extrapolate, self.axis)
 
     def integrate(self, a, b, extrapolate=None):
         """
@@ -1263,14 +1272,14 @@ class BPoly(_PPolyBase):
         Parameters
         ----------
         nu : int, optional
-            Order of derivative to evaluate. (Default: 1)
-            If negative, the antiderivative is returned.
+            Order of derivative to evaluate. Default is 1, i.e. compute the
+            first derivative. If negative, the antiderivative is returned.
 
         Returns
         -------
         bp : BPoly
-            Piecewise polynomial of order k2 = k - nu representing the derivative
-            of this polynomial.
+            Piecewise polynomial of order k - nu representing the derivative of
+            this polynomial.
 
         """
         if nu < 0:
@@ -1316,15 +1325,21 @@ class BPoly(_PPolyBase):
         Parameters
         ----------
         nu : int, optional
-            Order of derivative to evaluate. (Default: 1)
-            If negative, the derivative is returned.
+            Order of antiderivative to evaluate. Default is 1, i.e. compute
+            the first integral. If negative, the derivative is returned.
 
         Returns
         -------
         bp : BPoly
-            Piecewise polynomial of order k2 = k + nu representing the
+            Piecewise polynomial of order k + nu representing the
             antiderivative of this polynomial.
 
+        Notes
+        -----
+        If antiderivative is computed and ``self.extrapolate='periodic'``,
+        it will be set to False for the returned instance. This is done because
+        the antiderivative is no longer periodic and its correct evaluation
+        outside of the initially given x interval is difficult.
         """
         if nu <= 0:
             return self.derivative(-nu)
@@ -1352,7 +1367,12 @@ class BPoly(_PPolyBase):
         # Finally, use the fact that BPs form a partition of unity.
         c2[:,1:] += np.cumsum(c2[k,:], axis=0)[:-1]
 
-        return self.construct_fast(c2, x, self.extrapolate, axis=self.axis)
+        if self.extrapolate == 'periodic':
+            extrapolate = False
+        else:
+            extrapolate = self.extrapolate
+
+        return self.construct_fast(c2, x, extrapolate, axis=self.axis)
 
     def integrate(self, a, b, extrapolate=None):
         """

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1251,7 +1251,7 @@ class TestPPoly(TestCase):
         c = np.array([[-1, 0, 1]]).T
         x = np.array([0, 1])
 
-        for extrapolate in [True, False]:
+        for extrapolate in [True, False, None]:
             pp = PPoly(c, x, extrapolate=extrapolate)
             pp_d = pp.derivative()
             pp_i = pp.antiderivative()
@@ -1353,7 +1353,7 @@ class TestBPoly(TestCase):
         c = [[3], [1], [4]]
         bp = BPoly(c, x)
 
-        for extrapolate in (True, False):
+        for extrapolate in (True, False, None):
             bp = BPoly(c, x, extrapolate=extrapolate)
             bp_d = bp.derivative()
             if extrapolate is False:

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1088,6 +1088,30 @@ class TestPPoly(TestCase):
 
         assert_(np.isnan(pp.integrate(a, b, extrapolate=False)).all())
 
+    def test_integrate_periodic(self):
+        x = np.array([1, 2, 4])
+        c = np.array([[0., 0.], [-1., -1.], [2., -0.], [1., 2.]])
+
+        P = PPoly(c, x, extrapolate='periodic')
+        I = P.antiderivative()
+
+        period_int = I(4) - I(1)
+
+        assert_allclose(P.integrate(1, 4), period_int)
+        assert_allclose(P.integrate(-10, -7), period_int)
+        assert_allclose(P.integrate(-10, -4), 2 * period_int)
+
+        assert_allclose(P.integrate(1.5, 2.5), I(2.5) - I(1.5))
+        assert_allclose(P.integrate(3.5, 5), I(2) - I(1) + I(4) - I(3.5))
+        assert_allclose(P.integrate(3.5 + 12, 5 + 12),
+                        I(2) - I(1) + I(4) - I(3.5))
+        assert_allclose(P.integrate(3.5, 5 + 12),
+                        I(2) - I(1) + I(4) - I(3.5) + 4 * period_int)
+
+        assert_allclose(P.integrate(0, -1), I(2) - I(3))
+        assert_allclose(P.integrate(-9, -10), I(2) - I(3))
+        assert_allclose(P.integrate(0, -10), I(2) - I(3) - 3 * period_int)
+
     def test_roots(self):
         x = np.linspace(0, 1, 31)**2
         y = np.sin(30*x)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -876,6 +876,17 @@ class TestPPoly(TestCase):
         assert_allclose(p(0.3), 1*0.3**2 + 2*0.3 + 3)
         assert_allclose(p(0.7), 4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6)
 
+    def test_periodic(self):
+        c = np.array([[1, 4], [2, 5], [3, 6]])
+        x = np.array([0, 0.5, 1])
+        p = PPoly(c, x, extrapolate='periodic')
+
+        assert_allclose(p(1.3), 1 * 0.3 ** 2 + 2 * 0.3 + 3)
+        assert_allclose(p(-0.3), 4 * (0.7 - 0.5) ** 2 + 5 * (0.7 - 0.5) + 6)
+
+        assert_allclose(p(1.3, 1), 2 * 0.3 + 2)
+        assert_allclose(p(-0.3, 1), 8 * (0.7 - 0.5) + 5)
+
     def test_multi_shape(self):
         c = np.random.rand(6, 2, 1, 2, 3)
         x = np.array([0, 0.5, 1])
@@ -884,8 +895,7 @@ class TestPPoly(TestCase):
         assert_equal(p.c.shape, c.shape)
         assert_equal(p(0.3).shape, c.shape[2:])
 
-        assert_equal(p(np.random.rand(5,6)).shape,
-                     (5,6) + c.shape[2:])
+        assert_equal(p(np.random.rand(5, 6)).shape, (5, 6) + c.shape[2:])
 
         dp = p.derivative()
         assert_equal(dp.c.shape, (5, 2, 1, 2, 3))
@@ -1272,6 +1282,18 @@ class TestBPoly(TestCase):
                              8 * 6 * 0.7**2 * 0.3**2 +
                              2 * 4 * 0.7 * 0.3**3 +
                                  0.3**4)
+
+    def test_periodic(self):
+        x = [0, 1, 3]
+        c = [[3, 0], [0, 0], [0, 2]]
+        # [3*(1-x)**2, 2*((x-1)/2)**2]
+        bp = BPoly(c, x, extrapolate='periodic')
+
+        assert_allclose(bp(3.4), 3 * 0.6**2)
+        assert_allclose(bp(-1.3), 2 * (0.7/2)**2)
+
+        assert_allclose(bp(3.4, 1), -6 * 0.6)
+        assert_allclose(bp(-1.3, 1), 2 * (0.7/2))
 
     def test_multi_shape(self):
         c = np.random.rand(6, 2, 1, 2, 3)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1251,7 +1251,7 @@ class TestPPoly(TestCase):
         c = np.array([[-1, 0, 1]]).T
         x = np.array([0, 1])
 
-        for extrapolate in [True, False, None]:
+        for extrapolate in [True, False]:
             pp = PPoly(c, x, extrapolate=extrapolate)
             pp_d = pp.derivative()
             pp_i = pp.antiderivative()
@@ -1353,7 +1353,7 @@ class TestBPoly(TestCase):
         c = [[3], [1], [4]]
         bp = BPoly(c, x)
 
-        for extrapolate in (True, False, None):
+        for extrapolate in (True, False):
             bp = BPoly(c, x, extrapolate=extrapolate)
             bp_d = bp.derivative()
             if extrapolate is False:

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1481,6 +1481,30 @@ class TestBPolyCalculus(TestCase):
         assert_(np.isnan(b1.integrate(0, 2)))
         assert_allclose(b1.integrate(0, 2, extrapolate=True), 2., atol=1e-14)
 
+    def test_integrate_periodic(self):
+        x = np.array([1, 2, 4])
+        c = np.array([[0., 0.], [-1., -1.], [2., -0.], [1., 2.]])
+
+        P = BPoly.from_power_basis(PPoly(c, x), extrapolate='periodic')
+        I = P.antiderivative()
+
+        period_int = I(4) - I(1)
+
+        assert_allclose(P.integrate(1, 4), period_int)
+        assert_allclose(P.integrate(-10, -7), period_int)
+        assert_allclose(P.integrate(-10, -4), 2 * period_int)
+
+        assert_allclose(P.integrate(1.5, 2.5), I(2.5) - I(1.5))
+        assert_allclose(P.integrate(3.5, 5), I(2) - I(1) + I(4) - I(3.5))
+        assert_allclose(P.integrate(3.5 + 12, 5 + 12),
+                        I(2) - I(1) + I(4) - I(3.5))
+        assert_allclose(P.integrate(3.5, 5 + 12),
+                        I(2) - I(1) + I(4) - I(3.5) + 4 * period_int)
+
+        assert_allclose(P.integrate(0, -1), I(2) - I(3))
+        assert_allclose(P.integrate(-9, -10), I(2) - I(3))
+        assert_allclose(P.integrate(0, -10), I(2) - I(3) - 3 * period_int)
+
     def test_antider_neg(self):
         # .derivative(-nu) ==> .andiderivative(nu) and vice versa
         c = [[1]]

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -604,19 +604,19 @@ class TestCubicSpline(object):
                     'not-a-typo']
 
         for bc_type in wrong_bc:
-            assert_raises(ValueError, CubicSpline, x, y, 0, True, bc_type)
+            assert_raises(ValueError, CubicSpline, x, y, 0, bc_type, True)
 
         # Shapes mismatch when giving arbitrary derivative values:
         Y = np.c_[y, y]
         bc1 = ('clamped', (1, 0))
         bc2 = ('clamped', (1, [0, 0, 0]))
         bc3 = ('clamped', (1, [[0, 0]]))
-        assert_raises(ValueError, CubicSpline, x, Y, 0, True, bc1)
-        assert_raises(ValueError, CubicSpline, x, Y, 0, True, bc2)
-        assert_raises(ValueError, CubicSpline, x, Y, 0, True, bc3)
+        assert_raises(ValueError, CubicSpline, x, Y, 0, bc1, True)
+        assert_raises(ValueError, CubicSpline, x, Y, 0, bc2, True)
+        assert_raises(ValueError, CubicSpline, x, Y, 0, bc3, True)
 
         # periodic condition, y[-1] must be equal to y[0]:
-        assert_raises(ValueError, CubicSpline, x, y, 0, True, 'periodic')
+        assert_raises(ValueError, CubicSpline, x, y, 0, 'periodic', True)
 
 
 if __name__ == '__main__':

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -468,7 +468,7 @@ class TestCubicSpline(object):
             assert_allclose(S(x[0], 2), S(x[-1], 2), rtol=tol, atol=tol)
             return
 
-        # Check other boundary conditions
+        # Check other boundary conditions.
         if bc_start == 'not-a-knot':
             if x.size == 2:
                 slope = (S(x[1]) - S(x[0])) / dx[0]
@@ -547,6 +547,12 @@ class TestCubicSpline(object):
             Y[1, :, 1] = y + 5
             S = CubicSpline(x, Y, axis=1, bc_type='periodic')
             self.check_correctness(S, 'periodic', 'periodic')
+
+    def test_periodic_eval(self):
+        x = np.linspace(0, 2 * np.pi, 10)
+        y = np.cos(x)
+        S = CubicSpline(x, y, bc_type='periodic')
+        assert_almost_equal(S(1), S(1 + 2 * np.pi), decimal=15)
 
     def test_dtypes(self):
         x = np.array([0, 1, 2, 3], dtype=int)


### PR DESCRIPTION
As was discussed in #6181 an option to treat `PPoly` (or `BPoly`) as a periodic polynomial would be useful. A relatively nontrivial part was to implement definite integration with periodicity assumption. Note, that `antiderivative` remove the periodicity property.

I also changed `extrapolate=None` to True as the default in `__init__`, because I don't see any purpose to have None, which acts like True.
