### PR TITLE
ENH: sparse: avoid setitem densification

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -620,6 +620,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                     (broadcast_col or x.shape[1] == i.shape[1])):
                 raise ValueError("shape mismatch in assignment")
 
+            # clear entries that will be overwritten
+            ci, cj = self._swap((i.ravel(), j.ravel()))
+            self._zero_many(ci, cj)
+
             x = x.tocoo()
             r, c = x.row, x.col
             x = np.asarray(x.data, dtype=self.dtype)
@@ -631,6 +635,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                 r = np.repeat(r, i.shape[1])
                 c = np.tile(np.arange(i.shape[1]), len(c))
                 x = np.repeat(x, i.shape[1])
+            # only assign entries in the new sparsity structure
             i = i[r, c]
             j = j[r, c]
         else:
@@ -676,11 +681,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         self[i, j] = values
 
-    def _set_many(self, i, j, x):
-        """Sets value at each (i, j) to x
-
-        Here (i,j) index major and minor respectively.
-        """
+    def _prepare_indices(self, i, j):
         M, N = self._swap(self.shape)
 
         def check_bounds(indices, bound):
@@ -698,6 +699,14 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         i = np.asarray(i, dtype=self.indices.dtype)
         j = np.asarray(j, dtype=self.indices.dtype)
+        return i, j, M, N
+
+    def _set_many(self, i, j, x):
+        """Sets value at each (i, j) to x
+
+        Here (i,j) index major and minor respectively.
+        """
+        i, j, M, N = self._prepare_indices(i, j)
 
         n_samples = len(x)
         offsets = np.empty(n_samples, dtype=self.indices.dtype)
@@ -729,6 +738,27 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             j = j[mask]
             j[j < 0] += N
             self._insert_many(i, j, x[mask])
+
+    def _zero_many(self, i, j):
+        """Sets value at each (i, j) to zero, preserving sparsity structure.
+
+        Here (i,j) index major and minor respectively.
+        """
+        i, j, M, N = self._prepare_indices(i, j)
+
+        n_samples = len(i)
+        offsets = np.empty(n_samples, dtype=self.indices.dtype)
+        ret = _sparsetools.csr_sample_offsets(M, N, self.indptr, self.indices,
+                                              n_samples, i, j, offsets)
+        if ret == 1:
+            # rinse and repeat
+            self.sum_duplicates()
+            _sparsetools.csr_sample_offsets(M, N, self.indptr,
+                                            self.indices, n_samples, i, j,
+                                            offsets)
+
+        # only assign zeros to the existing sparsity structure
+        self.data[offsets[offsets > -1]] = 0
 
     def _insert_many(self, i, j, x):
         """Inserts new nonzero at each (i, j) with value x

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2415,10 +2415,11 @@ class _TestSlicingAssign:
             A = B / 10
             B[0,:] = A[0,:]
             assert_array_equal(A[0,:].A, B[0,:].A)
+            assert_equal(A.nnz, B.nnz)
 
             A = B / 10
             B[:,:] = A[:1,:1]
-            assert_equal(A[0,0], B[3,2])
+            assert_array_equal(np.zeros((4,3)) + A[0,0], B.A)
 
             A = B / 10
             B[:-1,0] = A[0,:].T

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2445,6 +2445,19 @@ class _TestSlicingAssign:
             B[:2,:2] = csc_matrix(array(block))
             assert_array_equal(B.todense()[:2,:2],block)
 
+    def test_sparsity_modifying_assignment(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=SparseEfficiencyWarning)
+            B = self.spmatrix((4,3))
+            B[0,0] = 5
+            B[1,2] = 3
+            B[2,1] = 7
+            B[3,0] = 10
+
+            expected = array([[1,0,0],[0,1,0],[0,0,1],[10,0,0]])
+            B[:3] = csr_matrix(np.eye(3))
+            assert_array_equal(B.toarray(), expected)
+
     def test_set_slice(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=SparseEfficiencyWarning)


### PR DESCRIPTION
Previously, assigning a sparse matrix would densify it. This had some unfortunate side-effects:

``` python
a = csr_matrix(np.eye(3))
# a.nnz == 3
a[0] = a[0]
# a.nnz == 5
```

This PR avoids densifying sparse arguments and improves the tests to make sure the previous behavior resulted in failure.
