### PR TITLE
MAINT: Minor changes in solve_bvp

### DIFF
--- a/scipy/integrate/_bvp.py
+++ b/scipy/integrate/_bvp.py
@@ -788,7 +788,7 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
         Solution values at the mesh nodes.
     yp : ndarray, shape (n, m)
         Solution derivatives at the mesh nodes.
-    rms_res : ndarray, shape (m - 1,)
+    rms_residuals : ndarray, shape (m - 1,)
         RMS values of the relative residuals over each mesh interval (see the
         description of `tol` parameter).
     niter : int
@@ -1087,6 +1087,6 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
     if p.size == 0:
         p = None
 
-    return BVPResult(sol=sol, p=p, x=x, y=y, yp=f, rms_res=rms_res,
+    return BVPResult(sol=sol, p=p, x=x, y=y, yp=f, rms_residuals=rms_res,
                      niter=iteration, status=status,
                      message=TERMINATION_MESSAGES[status], success=status == 0)

--- a/scipy/integrate/_bvp.py
+++ b/scipy/integrate/_bvp.py
@@ -681,7 +681,7 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
     (n + k)-dimensional function.
 
     The last singular term in the right-hand side of the system is optional.
-    It is defined by a n-by-n matrix S, such that the solution must satisfy
+    It is defined by an n-by-n matrix S, such that the solution must satisfy
     S y(a) = 0. This condition will be forced during iterations, so it must not
     contradict boundary conditions. See [2]_ for the explanation how this term
     is handled when solving BVPs numerically.
@@ -724,7 +724,7 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
         solved without the singular term.
     fun_jac : callable or None, optional
         Function computing derivatives of f with respect to y and p. The
-        calling signature is ``fun_jac(x, y)``, or ``fun(x, y, p)`` if
+        calling signature is ``fun_jac(x, y)``, or ``fun_jac(x, y, p)`` if
         parameters are present. The return must contain 1 or 2 elements in the
         following order:
 
@@ -738,7 +738,7 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
         parameters df_dp should not be returned.
 
         If `fun_jac` is None (default), the derivatives will be estimated
-        using forward finite differences.
+        by the forward finite differences.
     bc_jac : callable or None, optional
         Function computing derivatives of bc with respect to ya, yb and p.
         The calling signature is ``bc_jac(ya, yb)``, or ``bc_jac(ya, yb, p)``
@@ -755,8 +755,8 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
         If the problem is solved without unknown parameters dbc_dp should not
         be returned.
 
-        If `bc_jac` is None (default), the derivatives will be estimated using
-        forward finite differences.
+        If `bc_jac` is None (default), the derivatives will be estimated by
+        the forward finite differences.
     tol : float, optional
         Desired tolerance of the solution. If we define ``r = y' - f(x, y)``
         where y is the found solution, then the solver tries to achieve on each

--- a/scipy/integrate/tests/test_bvp.py
+++ b/scipy/integrate/tests/test_bvp.py
@@ -366,7 +366,7 @@ def test_no_params():
             norm_res = np.sum(rel_res**2, axis=0)**0.5
             assert_(np.all(norm_res < 1e-3))
 
-            assert_(np.all(sol.rms_res < 1e-3))
+            assert_(np.all(sol.rms_residuals < 1e-3))
             assert_allclose(sol.sol(sol.x), sol.y, rtol=1e-10, atol=1e-10)
             assert_allclose(sol.sol(sol.x, 1), sol.yp, rtol=1e-10, atol=1e-10)
 
@@ -399,7 +399,7 @@ def test_with_params():
             norm_res = np.sum(rel_res ** 2, axis=0) ** 0.5
             assert_(np.all(norm_res < 1e-3))
 
-            assert_(np.all(sol.rms_res < 1e-3))
+            assert_(np.all(sol.rms_residuals < 1e-3))
             assert_allclose(sol.sol(sol.x), sol.y, rtol=1e-10, atol=1e-10)
             assert_allclose(sol.sol(sol.x, 1), sol.yp, rtol=1e-10, atol=1e-10)
 
@@ -461,7 +461,7 @@ def test_complex():
                               axis=0) ** 0.5
             assert_(np.all(norm_res < 1e-3))
 
-            assert_(np.all(sol.rms_res < 1e-3))
+            assert_(np.all(sol.rms_residuals < 1e-3))
             assert_allclose(sol.sol(sol.x), sol.y, rtol=1e-10, atol=1e-10)
             assert_allclose(sol.sol(sol.x, 1), sol.yp, rtol=1e-10, atol=1e-10)
 
@@ -499,7 +499,7 @@ def test_big_problem():
     norm_res = np.sum(np.real(rel_res * np.conj(rel_res)), axis=0) ** 0.5
     assert_(np.all(norm_res < 1e-3))
 
-    assert_(np.all(sol.rms_res < 1e-3))
+    assert_(np.all(sol.rms_residuals < 1e-3))
     assert_allclose(sol.sol(sol.x), sol.y, rtol=1e-10, atol=1e-10)
     assert_allclose(sol.sol(sol.x, 1), sol.yp, rtol=1e-10, atol=1e-10)
 

--- a/scipy/integrate/tests/test_bvp.py
+++ b/scipy/integrate/tests/test_bvp.py
@@ -361,12 +361,12 @@ def test_no_params():
             assert_allclose(sol_test[0], exp_sol(x_test), atol=1e-5)
 
             f_test = exp_fun(x_test, sol_test)
-            res = sol.sol(x_test, 1) - f_test
-            rel_res = res / (1 + np.abs(f_test))
+            r = sol.sol(x_test, 1) - f_test
+            rel_res = r / (1 + np.abs(f_test))
             norm_res = np.sum(rel_res**2, axis=0)**0.5
             assert_(np.all(norm_res < 1e-3))
 
-            assert_(np.all(sol.res < 1e-3))
+            assert_(np.all(sol.rms_res < 1e-3))
             assert_allclose(sol.sol(sol.x), sol.y, rtol=1e-10, atol=1e-10)
             assert_allclose(sol.sol(sol.x, 1), sol.yp, rtol=1e-10, atol=1e-10)
 
@@ -394,12 +394,12 @@ def test_with_params():
                             rtol=1e-4, atol=1e-4)
 
             f_test = sl_fun(x_test, sol_test, [1])
-            res = sol.sol(x_test, 1) - f_test
-            rel_res = res / (1 + np.abs(f_test))
+            r = sol.sol(x_test, 1) - f_test
+            rel_res = r / (1 + np.abs(f_test))
             norm_res = np.sum(rel_res ** 2, axis=0) ** 0.5
             assert_(np.all(norm_res < 1e-3))
 
-            assert_(np.all(sol.res < 1e-3))
+            assert_(np.all(sol.rms_res < 1e-3))
             assert_allclose(sol.sol(sol.x), sol.y, rtol=1e-10, atol=1e-10)
             assert_allclose(sol.sol(sol.x, 1), sol.yp, rtol=1e-10, atol=1e-10)
 
@@ -426,8 +426,8 @@ def test_singular_term():
             assert_allclose(sol_test[0], emden_sol(x_test), atol=1e-6)
 
             f_test = emden_fun(x_test, sol_test) + S.dot(sol_test) / x_test
-            res = sol.sol(x_test, 1) - f_test
-            rel_res = res / (1 + np.abs(f_test))
+            r = sol.sol(x_test, 1) - f_test
+            rel_res = r / (1 + np.abs(f_test))
             norm_res = np.sum(rel_res ** 2, axis=0) ** 0.5
 
             assert_(np.all(norm_res < 1e-3))
@@ -455,13 +455,13 @@ def test_complex():
             assert_allclose(sol_test[0].imag, exp_sol(x_test), atol=1e-5)
 
             f_test = exp_fun(x_test, sol_test)
-            res = sol.sol(x_test, 1) - f_test
-            rel_res = res / (1 + np.abs(f_test))
+            r = sol.sol(x_test, 1) - f_test
+            rel_res = r / (1 + np.abs(f_test))
             norm_res = np.sum(np.real(rel_res * np.conj(rel_res)),
                               axis=0) ** 0.5
             assert_(np.all(norm_res < 1e-3))
 
-            assert_(np.all(sol.res < 1e-3))
+            assert_(np.all(sol.rms_res < 1e-3))
             assert_allclose(sol.sol(sol.x), sol.y, rtol=1e-10, atol=1e-10)
             assert_allclose(sol.sol(sol.x, 1), sol.yp, rtol=1e-10, atol=1e-10)
 
@@ -494,12 +494,12 @@ def test_big_problem():
     assert_allclose(sol_test[0], big_sol(x, n))
 
     f_test = big_fun(x, sol_test)
-    res = sol.sol(x, 1) - f_test
-    rel_res = res / (1 + np.abs(f_test))
+    r = sol.sol(x, 1) - f_test
+    rel_res = r / (1 + np.abs(f_test))
     norm_res = np.sum(np.real(rel_res * np.conj(rel_res)), axis=0) ** 0.5
     assert_(np.all(norm_res < 1e-3))
 
-    assert_(np.all(sol.res < 1e-3))
+    assert_(np.all(sol.rms_res < 1e-3))
     assert_allclose(sol.sol(sol.x), sol.y, rtol=1e-10, atol=1e-10)
     assert_allclose(sol.sol(sol.x, 1), sol.yp, rtol=1e-10, atol=1e-10)
 
@@ -519,8 +519,8 @@ def test_shock_layer():
     assert_allclose(sol_test[0], shock_sol(x_test), rtol=1e-5, atol=1e-5)
 
     f_test = shock_fun(x_test, sol_test)
-    res = sol.sol(x_test, 1) - f_test
-    rel_res = res / (1 + np.abs(f_test))
+    r = sol.sol(x_test, 1) - f_test
+    rel_res = r / (1 + np.abs(f_test))
     norm_res = np.sum(rel_res ** 2, axis=0) ** 0.5
 
     assert_(np.all(norm_res < 1e-3))
@@ -548,6 +548,7 @@ def test_verbose():
             assert_("Solved in" in text, text)
         if verbose >= 2:
             assert_("Max residual" in text, text)
+
 
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
1. Renamed 'res' to 'rms_res' in the return bunch. The name 'res' bothered me because of its ambiguity. Very minor, but still.
2. Several fixes in the docstring.

Another thing to consider: whether to allow `*args, **kwargs` parameters to pass into `fun`, `bc`, `fun_jac`, `bc_jac`. Four different callables and the optional parameter `p` make it somewhat clumsy to introduce. So I'm neutral about this addition. @pv @ev-br can you help to decide?
