### PR TITLE
BLD: use setuptools when building.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ dist
 MANIFEST
 # distutils configuration
 site.cfg
+setup.cfg
 # other temporary files
 .coverage
 .deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ before_install:
   # Speed up install by not compiling Cython
   - travis_retry pip install --install-option="--no-cython-compile" Cython==0.22
   - travis_retry pip install $NUMPYSPEC
-  - travis_retry pip install nose mpmath argparse Pillow codecov
+  - travis_retry pip install nose mpmath argparse Pillow codecov setuptools
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - if [ "${TESTMODE}" == "full" ]; then pip install coverage; fi
   - if [ "${USE_WHEEL}" == "1" ]; then pip install wheel; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ matrix:
         - TESTMODE=fast
         - COVERAGE=
         - NUMPYSPEC="numpy==1.7.2"
+        - USE_SDIST=1
     - python: 2.7
       env:
         - TESTMODE=full
@@ -116,6 +117,13 @@ script:
         # Need verbose output or TravisCI will terminate after 10 minutes
         pip wheel . -v
         pip install wheelhouse/* -v
+        USE_WHEEL_BUILD="--no-build"
+    elif [ "${USE_SDIST}" == "1" ]; then
+        python setup.py sdist
+        # Move out of source directory to avoid finding local scipy
+        pushd dist
+        pip install scipy*
+        popd
         USE_WHEEL_BUILD="--no-build"
     fi
   - python -u $OPTIMIZE runtests.py -g -m $TESTMODE $COVERAGE $USE_WHEEL_BUILD |& tee runtests.log

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -39,11 +39,15 @@ __ http://www.python.org
 
 __ http://www.numpy.org/
 
-3) If you want to build the documentation: Sphinx__ >= 1.2.1
+3) For building from source: setuptools__
+
+__ https://github.com/pypa/setuptools
+
+4) If you want to build the documentation: Sphinx__ >= 1.2.1
 
 __ http://sphinx-doc.org/
 
-4) If you want to build SciPy master or other unreleased version from source
+5) If you want to build SciPy master or other unreleased version from source
    (Cython-generated C sources are included in official releases):
    Cython__ >= 0.22
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include MANIFEST.in
 include *.txt
 # Top-level build scripts
-include setup.py setupegg.py bscript bento.info
+include setup.py bscript bento.info
 # All source files
 recursive-include scipy *
 # All documentation

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -74,7 +74,7 @@ real-dist: dist-build html html-scipyorg
 
 dist-build:
 	rm -f ../dist/*.egg
-	cd .. && $(PYTHON) setupegg.py bdist_egg
+	cd .. && $(PYTHON) setup.py bdist_egg
 	install -d $(subst :, ,$(INSTALL_PPH))
 	$(PYTHON) `which easy_install` --prefix=$(INSTALL_DIR) ../dist/*.egg
 

--- a/doc/release/0.18.0-notes.rst
+++ b/doc/release/0.18.0-notes.rst
@@ -99,8 +99,15 @@ treated as missing if they match one of these attributes exactly: values that
 differ by roundoff from ``_FillValue`` or ``missing_value`` are no longer
 treated as missing values.
 
+
 Other changes
 =============
+
+Scipy now uses ``setuptools`` for its builds instead of plain distutils.  This
+fixes usage of ``install_requires='scipy'`` in the ``setup.py`` files of
+projects that depend on Scipy (see Numpy issue gh-6551 for details).  It
+potentially affects the way that build/install methods for Scipy itself behave
+though.  Please report any unexpected behavior on the Scipy issue tracker.
 
 PR `#6240 <https://github.com/scipy/scipy/pull/6240>`__
 changes the interpretation of the `maxfun` option in `L-BFGS-B` based routines

--- a/pavement.py
+++ b/pavement.py
@@ -560,7 +560,7 @@ def _build_mpkg(pyver):
         ldflags = "-undefined dynamic_lookup -bundle -arch i386 -arch ppc -Wl,-search_paths_first"
     ldflags += " -L%s" % os.path.join(os.path.dirname(__file__), "build")
 
-    sh("LDFLAGS='%s' %s setupegg.py bdist_mpkg" % (ldflags, MPKG_PYTHON[pyver]))
+    sh("LDFLAGS='%s' %s setup.py bdist_mpkg" % (ldflags, MPKG_PYTHON[pyver]))
 
 
 @task

--- a/scipy/_build_utils/tests/test_scipy_version.py
+++ b/scipy/_build_utils/tests/test_scipy_version.py
@@ -1,0 +1,24 @@
+from __future__ import division, absolute_import, print_function
+
+import re
+
+import scipy
+from numpy.testing import assert_, run_module_suite
+
+
+def test_valid_scipy_version():
+    # Verify that the scipy version is a valid one (no .post suffix or other
+    # nonsense).  See numpy issue gh-6431 for an issue caused by an invalid
+    # version.
+    version_pattern = r"^[0-9]+\.[0-9]+\.[0-9]+(|a[0-9]|b[0-9]|rc[0-9])"
+    dev_suffix = r"(\.dev0\+([0-9a-f]{7}|Unknown))"
+    if scipy.version.release:
+        res = re.match(version_pattern, scipy.__version__)
+    else:
+        res = re.match(version_pattern + dev_suffix, scipy.__version__)
+
+    assert_(res is not None, scipy.__version__)
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ DOCLINES = __doc__.split("\n")
 import os
 import sys
 import subprocess
+import textwrap
 
 
 if sys.version_info[:2] < (2, 6) or (3, 0) <= sys.version_info[0:2] < (3, 2):
@@ -160,6 +161,37 @@ if HAVE_SPHINX:
             BuildDoc.run(self)
 
 
+def check_submodules():
+    """ verify that the submodules are checked out and clean
+        use `git submodule update --init`; on failure
+    """
+    if not os.path.exists('.git'):
+        return
+    with open('.gitmodules') as f:
+        for l in f:
+            if 'path' in l:
+                p = l.split('=')[-1].strip()
+                if not os.path.exists(p):
+                    raise ValueError('Submodule %s missing' % p)
+
+
+    proc = subprocess.Popen(['git', 'submodule', 'status'],
+                            stdout=subprocess.PIPE)
+    status, _ = proc.communicate()
+    status = status.decode("ascii", "replace")
+    for line in status.splitlines():
+        if line.startswith('-') or line.startswith('+'):
+            raise ValueError('Submodule not clean: %s' % line)
+
+
+from distutils.command.sdist import sdist
+class sdist_checked(sdist):
+    """ check submodules on sdist to prevent incomplete tarballs """
+    def run(self):
+        check_submodules()
+        sdist.run(self)
+
+
 def generate_cython():
     cwd = os.path.abspath(os.path.dirname(__file__))
     print("Cythonizing sources")
@@ -169,6 +201,126 @@ def generate_cython():
                         cwd=cwd)
     if p != 0:
         raise RuntimeError("Running cythonize failed!")
+
+
+def parse_setuppy_commands():
+    """Check the commands and respond appropriately.  Disable broken commands.
+
+    Return a boolean value for whether or not to run the build or not (avoid
+    parsing Cython and template files if False).
+    """
+    if len(sys.argv) < 2:
+        # User forgot to give an argument probably, let setuptools handle that.
+        return True
+
+    info_commands = ['--help-commands', '--name', '--version', '-V',
+                     '--fullname', '--author', '--author-email',
+                     '--maintainer', '--maintainer-email', '--contact',
+                     '--contact-email', '--url', '--license', '--description',
+                     '--long-description', '--platforms', '--classifiers',
+                     '--keywords', '--provides', '--requires', '--obsoletes']
+    # Add commands that do more than print info, but also don't need Cython and
+    # template parsing.
+    info_commands.extend(['egg_info', 'install_egg_info', 'rotate'])
+
+    for command in info_commands:
+        if command in sys.argv[1:]:
+            return False
+
+    # Note that 'alias', 'saveopts' and 'setopt' commands also seem to work
+    # fine as they are, but are usually used together with one of the commands
+    # below and not standalone.  Hence they're not added to good_commands.
+    good_commands = ('develop', 'sdist', 'build', 'build_ext', 'build_py',
+                     'build_clib', 'build_scripts', 'bdist_wheel', 'bdist_rpm',
+                     'bdist_wininst', 'bdist_msi', 'bdist_mpkg',
+                     'build_sphinx')
+
+    for command in good_commands:
+        if command in sys.argv[1:]:
+            return True
+
+    # The following commands are supported, but we need to show more
+    # useful messages to the user
+    if 'install' in sys.argv[1:]:
+        print(textwrap.dedent("""
+            Note: if you need reliable uninstall behavior, then install
+            with pip instead of using `setup.py install`:
+
+              - `pip install .`       (from a git repo or downloaded source
+                                       release)
+              - `pip install scipy`   (last SciPy release on PyPI)
+
+            """))
+        return True
+
+    if '--help' in sys.argv[1:] or '-h' in sys.argv[1]:
+        print(textwrap.dedent("""
+            SciPy-specific help
+            -------------------
+
+            To install SciPy from here with reliable uninstall, we recommend
+            that you use `pip install .`. To install the latest SciPy release
+            from PyPI, use `pip install scipy`.
+
+            For help with build/installation issues, please ask on the
+            scipy-user mailing list.  If you are sure that you have run
+            into a bug, please report it at https://github.com/scipy/scipy/issues.
+
+            Setuptools commands help
+            ------------------------
+            """))
+        return False
+
+    # The following commands aren't supported.  They can only be executed when
+    # the user explicitly adds a --force command-line argument.
+    bad_commands = dict(
+        test="""
+            `setup.py test` is not supported.  Use one of the following
+            instead:
+
+              - `python runtests.py`              (to build and test)
+              - `python runtests.py --no-build`   (to test installed scipy)
+              - `>>> scipy.test()`           (run tests for installed scipy
+                                              from within an interpreter)
+            """,
+        upload="""
+            `setup.py upload` is not supported, because it's insecure.
+            Instead, build what you want to upload and upload those files
+            with `twine upload -s <filenames>` instead.
+            """,
+        upload_docs="`setup.py upload_docs` is not supported",
+        easy_install="`setup.py easy_install` is not supported",
+        clean="""
+            `setup.py clean` is not supported, use one of the following instead:
+
+              - `git clean -xdf` (cleans all files)
+              - `git clean -Xdf` (cleans all versioned files, doesn't touch
+                                  files that aren't checked into the git repo)
+            """,
+        check="`setup.py check` is not supported",
+        register="`setup.py register` is not supported",
+        bdist_dumb="`setup.py bdist_dumb` is not supported",
+        bdist="`setup.py bdist` is not supported",
+        flake8="`setup.py flake8` is not supported, use flake8 standalone",
+        )
+    bad_commands['nosetests'] = bad_commands['test']
+    for command in ('upload_docs', 'easy_install', 'bdist', 'bdist_dumb',
+                     'register', 'check', 'install_data', 'install_headers',
+                     'install_lib', 'install_scripts', ):
+        bad_commands[command] = "`setup.py %s` is not supported" % command
+
+    for command in bad_commands.keys():
+        if command in sys.argv[1:]:
+            print(textwrap.dedent(bad_commands[command]) +
+                  "\nAdd `--force` to your command to use it anyway if you "
+                  "must (unsupported).\n")
+            sys.exit(1)
+
+    # If we got here, we didn't detect what setup.py command was given
+    import warnings
+    warnings.warn("Unrecognized setuptools command, proceeding with "
+                  "generating Cython sources and expanding templates")
+    return True
 
 
 def configuration(parent_package='', top_path=None):
@@ -188,14 +340,12 @@ def configuration(parent_package='', top_path=None):
 
 
 def setup_package():
-
     # Rewrite the version file every time
     write_version_py()
 
+    cmdclass = {'sdist': sdist_checked}
     if HAVE_SPHINX:
-        cmdclass = {'build_sphinx': ScipyBuildDoc}
-    else:
-        cmdclass = {}
+        cmdclass['build_sphinx'] = ScipyBuildDoc
 
     # Figure out whether to add ``*_requires = ['numpy']``.
     # We don't want to do that unconditionally, because we risk updating
@@ -229,37 +379,32 @@ def setup_package():
         install_requires=build_requires,
     )
 
-    if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or
-            sys.argv[1] in ('--help-commands', 'egg_info', '--version',
-                            'clean')):
-        # For these actions, NumPy is not required.
-        #
-        # They are required to succeed without Numpy for example when
-        # pip is used to install Scipy when Numpy is not yet present in
-        # the system.
-        try:
-            from setuptools import setup
-        except ImportError:
-            from distutils.core import setup
-
-        FULLVERSION, GIT_REVISION = get_version_info()
-        metadata['version'] = FULLVERSION
+    if "--force" in sys.argv:
+        run_build = True
     else:
-        if (len(sys.argv) >= 2 and sys.argv[1] in ('bdist_wheel', 'bdist_egg')) or (
-                    'develop' in sys.argv):
-            # bdist_wheel/bdist_egg needs setuptools
-            import setuptools
+        # Raise errors for unsupported commands, improve help output, etc.
+        run_build = parse_setuppy_commands()
 
+    from setuptools import setup
+    if run_build:
         from numpy.distutils.core import setup
-
         cwd = os.path.abspath(os.path.dirname(__file__))
         if not os.path.exists(os.path.join(cwd, 'PKG-INFO')):
             # Generate Cython sources, unless building from source release
             generate_cython()
 
         metadata['configuration'] = configuration
+    else:
+        # Don't import numpy here - non-build actions are required to succeed
+        # without Numpy for example when pip is used to install Scipy when
+        # Numpy is not yet present in the system.
+
+        # Version number is added to metadata inside configuration() if build
+        # is run.
+        metadata['version'] = get_version_info()[0]
 
     setup(**metadata)
+
 
 if __name__ == '__main__':
     setup_package()

--- a/setup.py
+++ b/setup.py
@@ -88,8 +88,9 @@ def git_version():
     return GIT_REVISION
 
 
-# BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
-# update it when the contents of directories change.
+# BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
+# properly updated when the contents of directories change (true for distutils,
+# not sure about setuptools).
 if os.path.exists('MANIFEST'):
     os.remove('MANIFEST')
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ import os
 import sys
 import subprocess
 import textwrap
+import warnings
 
 
 if sys.version_info[:2] < (2, 6) or (3, 0) <= sys.version_info[0:2] < (3, 2):
@@ -318,7 +319,6 @@ def parse_setuppy_commands():
             sys.exit(1)
 
     # If we got here, we didn't detect what setup.py command was given
-    import warnings
     warnings.warn("Unrecognized setuptools command, proceeding with "
                   "generating Cython sources and expanding templates")
     return True
@@ -386,7 +386,11 @@ def setup_package():
         # Raise errors for unsupported commands, improve help output, etc.
         run_build = parse_setuppy_commands()
 
+    # This import is here because it needs to be done before importing setup()
+    # from numpy.distutils, but after the MANIFEST removing and sdist import
+    # higher up in this file.
     from setuptools import setup
+
     if run_build:
         from numpy.distutils.core import setup
         cwd = os.path.abspath(os.path.dirname(__file__))

--- a/setupegg.py
+++ b/setupegg.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-"""
-A setup.py script to use setuptools, which gives egg goodness, etc.
-"""
-
-from setuptools import setup
-exec(compile(open('setup.py').read(), 'setup.py', 'exec'))

--- a/tools/osx/build.py
+++ b/tools/osx/build.py
@@ -36,7 +36,7 @@ def remove_dirs():
 
 def build_dist():
     print 'Building distribution... (using sudo)'
-    cmd = 'sudo python setupegg.py bdist_mpkg'
+    cmd = 'sudo python setup.py bdist_mpkg'
     shellcmd(cmd)
 
 def build_dmg():


### PR DESCRIPTION
Approach taken over from https://github.com/numpy/numpy/pull/6895. Without `setuptools` we don't get PEP 440 compliant names, this is a way to get that fixed. Other than that, `setuptools` doesn't bring too much. Risk should be fairly low though, given that this was all taken over from numpy and didn't cause too many issues there.

Closes gh-5745.

The change to build via `sdist` for one of the TravisCI builds isn't directly related to `setuptools` - good to have in this PR for test coverage though.
