### PR TITLE
BUG: sparse.linalg: fix bug in LGMRES breakdown handling

### DIFF
--- a/scipy/sparse/linalg/isolve/lgmres.py
+++ b/scipy/sparse/linalg/isolve/lgmres.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from scipy._lib.six import xrange
-from scipy.linalg import get_blas_funcs, get_lapack_funcs, qr_insert
+from scipy.linalg import get_blas_funcs, get_lapack_funcs, qr_insert, lstsq
 from .utils import make_system
 
 __all__ = ['lgmres']
@@ -155,6 +155,8 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
 
         eps = np.finfo(vs0.dtype).eps
 
+        breakdown = False
+
         for j in xrange(1, 1 + inner_m + len(outer_v)):
             # -- Arnoldi process:
             #
@@ -203,6 +205,8 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
                 v_new = v_new.copy()
 
             #     ++ orthogonalize
+            v_new_norm = nrm2(v_new)
+
             hcur = np.zeros(j+1, dtype=Q.dtype)
             for i, v in enumerate(vs):
                 alpha = dot(v, v_new)
@@ -216,14 +220,12 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
 
             if np.isfinite(alpha):
                 v_new = scal(alpha, v_new)
-            else:
-                # v_new either zero (solution in span of previous
-                # vectors) or we have nans.  If we already have
-                # previous vectors in R, we can discard the current
-                # vector and bail out.
-                if j > 1:
-                    j -= 1
-                    break
+
+            if not (hcur[-1] > eps * v_new_norm):
+                # v_new essentially in the span of previous vectors,
+                # or we have nans. Bail out after updating the QR
+                # solution.
+                breakdown = True
 
             vs.append(v_new)
             ws.append(z)
@@ -250,14 +252,19 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
             inner_res = abs(Q[0,-1]) * inner_res_0
 
             # -- check for termination
-            if inner_res <= tol * inner_res_0:
+            if inner_res <= tol * inner_res_0 or breakdown:
                 break
 
+        if not np.isfinite(R[j-1,j-1]):
+            # nans encountered, bail out
+            return postprocess(x), k_outer + 1
+
         # -- Get the LSQ problem solution
-        y, info = trtrs(R[:j,:j], Q[0,:j].conj())
-        if info != 0:
-            # Zero diagonal -> exact solution, but we handled that above
-            raise RuntimeError("QR solution failed")
+        #
+        # The problem is triangular, but the condition number may be
+        # bad (or in case of breakdown the last diagonal entry may be
+        # zero), so use lstsq instead of trtrs.
+        y, _, _, _, = lstsq(R[:j,:j], Q[0,:j].conj(), lapack_driver='gelsy')
         y *= inner_res_0
 
         if not np.isfinite(y).all():

--- a/scipy/sparse/linalg/isolve/lgmres.py
+++ b/scipy/sparse/linalg/isolve/lgmres.py
@@ -264,7 +264,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
         # The problem is triangular, but the condition number may be
         # bad (or in case of breakdown the last diagonal entry may be
         # zero), so use lstsq instead of trtrs.
-        y, _, _, _, = lstsq(R[:j,:j], Q[0,:j].conj(), lapack_driver='gelsy')
+        y, _, _, _, = lstsq(R[:j,:j], Q[0,:j].conj())
         y *= inner_res_0
 
         if not np.isfinite(y).all():

--- a/scipy/sparse/linalg/isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lgmres.py
@@ -131,6 +131,59 @@ class TestLGMRES(TestCase):
         x, info = lgmres(A, b, tol=0, maxiter=10)
         assert_equal(info, 1)
 
+    def test_breakdown_with_outer_v(self):
+        A = np.array([[1, 2], [3, 4]], dtype=float)
+        b = np.array([1, 2])
+
+        x = np.linalg.solve(A, b)
+        v0 = np.array([1, 0])
+
+        # The inner iteration should converge to the correct solution,
+        # since it's in the outer vector list
+        xp, info = lgmres(A, b, outer_v=[(v0, None), (x, None)], maxiter=1)
+
+        assert_allclose(xp, x, atol=1e-12)
+
+    def test_breakdown_underdetermined(self):
+        # Should find LSQ solution in the Krylov span in one inner
+        # iteration, despite solver breakdown from nilpotent A.
+        A = np.array([[0, 1, 1, 1],
+                      [0, 0, 1, 1],
+                      [0, 0, 0, 1],
+                      [0, 0, 0, 0]], dtype=float)
+
+        bs = [
+            np.array([1, 1, 1, 1]),
+            np.array([1, 1, 1, 0]),
+            np.array([1, 1, 0, 0]),
+            np.array([1, 0, 0, 0]),
+        ]
+
+        for b in bs:
+            xp, info = lgmres(A, b, maxiter=1)
+            resp = np.linalg.norm(A.dot(xp) - b)
+
+            K = np.c_[b, A.dot(b), A.dot(A.dot(b)), A.dot(A.dot(A.dot(b)))]
+            y, _, _, _ = np.linalg.lstsq(A.dot(K), b)
+            x = K.dot(y)
+            res = np.linalg.norm(A.dot(x) - b)
+
+            assert_allclose(resp, res)
+
+    def test_denormals(self):
+        # Check that no warnings are emitted if the matrix contains
+        # numbers for which 1/x has no float representation, and that
+        # the solver behaves properly.
+        A = np.array([[1, 2], [3, 4]], dtype=float)
+        A *= 100 * np.nextafter(0, 1)
+
+        b = np.array([1, 1])
+
+        xp, info = lgmres(A, b)
+
+        if info == 0:
+            assert_allclose(A.dot(xp), b)
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/sparse/linalg/isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lgmres.py
@@ -168,7 +168,7 @@ class TestLGMRES(TestCase):
             x = K.dot(y)
             res = np.linalg.norm(A.dot(x) - b)
 
-            assert_allclose(resp, res)
+            assert_allclose(resp, res, err_msg=repr(b))
 
     def test_denormals(self):
         # Check that no warnings are emitted if the matrix contains


### PR DESCRIPTION
gh-5472 introduced a bug in lgmres breakdown handling, where on breakdown the inner solver ignored the last basis vector and so failed to solve the least squares problem correctly (even though the exact solution existed). Add tests and fix.

Likely fixes also gh-6136
