### PR TITLE
MAINT: special: make loggamma use zdiv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ site.cfg
 ehthumbs.db
 Icon?
 Thumbs.db
+*.dSYM
 
 # Documentation generated files #
 #################################

--- a/benchmarks/benchmarks/special.py
+++ b/benchmarks/benchmarks/special.py
@@ -13,6 +13,11 @@ try:
 except ImportError:
     pass
 
+try:
+    from scipy.special import loggamma
+except ImportError:
+    pass
+
 from .common import Benchmark, with_attributes
 
 
@@ -48,3 +53,14 @@ class Comb(Benchmark):
 
     def time_comb_float(self):
         comb(self.N[:,None], self.k[None,:])
+
+
+class Loggamma(Benchmark):
+
+    def setup(self):
+        x, y = np.logspace(3, 5, 10), np.logspace(3, 5, 10)
+        x, y = np.meshgrid(x, y)
+        self.large_z = x + 1j*y
+
+    def time_loggamma_asymptotic(self):
+        loggamma(self.large_z)

--- a/scipy/special/_loggamma.pxd
+++ b/scipy/special/_loggamma.pxd
@@ -10,7 +10,9 @@
 import cython
 cimport sf_error
 from libc.math cimport M_PI, ceil, sin, log
-from _complexstuff cimport nan, zisnan, zabs, zlog, zlog1, zsin, zarg, zexp
+from _complexstuff cimport (
+    nan, zisnan, zabs, zlog, zlog1, zsin, zarg, zexp, zlog, zdiv
+)
 from _trig cimport sinpi
 
 cdef extern from "numpy/npy_math.h":
@@ -225,13 +227,17 @@ cdef inline double complex asymptotic_series(double complex z) nogil:
                                601580873.900642368,
                                -15116315767.0921569]
         double complex res = (z - 0.5)*zlog(z) - z + HLOG2PI
-        double complex rsqz = 1/z**2
-        double complex coeff = 1.0/z
+        double complex coeff = zdiv(1.0, z)
+        double complex rsqz = zdiv(coeff, z)
+        double complex term
 
     res += coeff*bernoulli2k[n-1]/(2*n*(2*n - 1))
     for n in range(2, 17):
         coeff *= rsqz
-        res += coeff*bernoulli2k[n-1]/(2*n*(2*n - 1))
+        term = coeff*bernoulli2k[n-1]/(2*n*(2*n - 1))
+        res += term
+        if zabs(term) <= tol*zabs(res):
+            break
     return res
 
 

--- a/scipy/special/_mptestutils.py
+++ b/scipy/special/_mptestutils.py
@@ -121,7 +121,8 @@ class IntArg(object):
 class MpmathData(object):
     def __init__(self, scipy_func, mpmath_func, arg_spec, name=None,
                  dps=None, prec=None, n=5000, rtol=1e-7, atol=1e-300,
-                 ignore_inf_sign=False, nan_ok=True, param_filter=None):
+                 ignore_inf_sign=False, distinguish_nan_and_inf=True,
+                 nan_ok=True, param_filter=None):
         self.scipy_func = scipy_func
         self.mpmath_func = mpmath_func
         self.arg_spec = arg_spec
@@ -137,6 +138,7 @@ class MpmathData(object):
         else:
             self.is_complex = any([isinstance(arg, ComplexArg) for arg in self.arg_spec])
         self.ignore_inf_sign = ignore_inf_sign
+        self.distinguish_nan_and_inf = distinguish_nan_and_inf
         if not name or name == '<lambda>':
             name = getattr(scipy_func, '__name__', None)
         if not name or name == '<lambda>':
@@ -201,6 +203,7 @@ class MpmathData(object):
                                       vectorized=False,
                                       rtol=self.rtol, atol=self.atol,
                                       ignore_inf_sign=self.ignore_inf_sign,
+                                      distinguish_nan_and_inf=self.distinguish_nan_and_inf,
                                       nan_ok=self.nan_ok,
                                       param_filter=self.param_filter)
                     break

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1483,7 +1483,8 @@ class TestSystematic(with_metaclass(DecoratorMeta, object)):
     def test_loggamma_complex(self):
         assert_mpmath_equal(sc.loggamma,
                             exception_to_nan(lambda z: mpmath.loggamma(z, **HYPERKW)),
-                            [ComplexArg()], rtol=1e-13)
+                            [ComplexArg()], nan_ok=False, distinguish_nan_and_inf=False,
+                            rtol=1e-13)
 
     @knownfailure_overridable()
     def test_pcfd(self):


### PR DESCRIPTION
Otherwise it hits the Cython complex division bug and overflows
around 1e155. Also adds a break out condition for the asymptotic
series since this speeds up the benchmark a bit.
