### PR TITLE
pchip should work for length-2 arrays

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -145,6 +145,14 @@ class PchipInterpolator(BPoly):
 
         hk = x[1:] - x[:-1]
         mk = (y[1:] - y[:-1]) / hk
+
+        if y.shape[0] == 2:
+            # edge case: only have two points, use linear interpolation
+            dk = np.zeros_like(y)
+            dk[0] = mk
+            dk[1] = mk
+            return dk.reshape(y_shape)
+
         smk = np.sign(mk)
         condition = (smk[1:] != smk[:-1]) | (mk[1:] == 0) | (mk[:-1] == 0)
 

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -422,6 +422,15 @@ class TestPCHIP(TestCase):
         xx = np.linspace(0, 9, 101)
         assert_equal(pch(xx), 0.)
 
+    def test_two_points(self):
+        # regression test for gh-6222: pchip([0, 1], [0, 1]) fails because
+        # it tries to use a three-point scheme to estimate edge derivatives,
+        # while there are only two points available.
+        # Instead, it should construct a linear interpolator.
+        x = np.linspace(0, 1, 11)
+        p = pchip([0, 1], [0, 2])
+        assert_allclose(p(x), 2*x, atol=1e-15)
+
     def test_pchip_interpolate(self):
         assert_array_almost_equal(
             pchip_interpolate([1,2,3], [4,5,6], [0.5], der=1),


### PR DESCRIPTION
In which case it constructs a linear interpolator.
This is consistent with e.g. Octave.

In scipy 0.17, it would error out. In scipy <=0.16.1 it used to construct some nonsence (OK, a cubic with
zero derivatives at the edges).

closes gh-6222
