### PR TITLE
signal.lti: deprecate cross-class properties/setters

### DIFF
--- a/doc/release/0.18.0-notes.rst
+++ b/doc/release/0.18.0-notes.rst
@@ -77,6 +77,13 @@ functions in `numpy`.
 Deprecated features
 ===================
 
+The cross-class properties of `lti` systems have been deprecated. The
+following properties/setters will raise a `DeprecationWarning`:
+
+Name - (accessing/setting raises warning) - (setting raises warning)
+* StateSpace - (`num`, `den`, `gain`) - (`zeros`, `poles`)
+* TransferFunction (`A`, `B`, `C`, `D`, `gain`) - (`zeros`, `poles`)
+* ZerosPolesGain (`A`, `B`, `C`, `D`, `num`, `den`) - ()
 
 Backwards incompatible changes
 ==============================

--- a/scipy/signal/ltisys.py
+++ b/scipy/signal/ltisys.py
@@ -26,6 +26,8 @@ import warnings
 # np.linalg.qr fails on some tests with LinAlgError: zgeqrf returns -7
 # use scipy's qr until this is solved
 
+import warnings
+
 from scipy.linalg import qr as s_qr
 from scipy import integrate, interpolate, linalg
 from scipy.interpolate import interp1d
@@ -82,10 +84,19 @@ class LinearTimeInvariant(object):
     @property
     def num(self):
         """Numerator of the `TransferFunction` system."""
+        warnings.warn('Cross-class properties have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please use `sys.to_tf().num`instead.',
+                      DeprecationWarning)
         return self.to_tf().num
 
     @num.setter
     def num(self, num):
+        warnings.warn('Cross-class setters have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please convert your system with `sys.to_tf()` '
+                      'before setting `num`.',
+                      DeprecationWarning)
         obj = self.to_tf()
         obj.num = num
         source_class = type(self)
@@ -94,10 +105,19 @@ class LinearTimeInvariant(object):
     @property
     def den(self):
         """Denominator of the `TransferFunction` system."""
+        warnings.warn('Cross-class properties have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please use `sys.to_tf().den`instead.',
+                      DeprecationWarning)
         return self.to_tf().den
 
     @den.setter
     def den(self, den):
+        warnings.warn('Cross-class setters have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please convert your system with `sys.to_tf()` '
+                      'before setting `den`.',
+                      DeprecationWarning)
         obj = self.to_tf()
         obj.den = den
         source_class = type(self)
@@ -105,11 +125,16 @@ class LinearTimeInvariant(object):
 
     @property
     def zeros(self):
-        """Zeros of the `ZerosPolesGain` system."""
+        """Zeros of the system."""
         return self.to_zpk().zeros
 
     @zeros.setter
     def zeros(self, zeros):
+        warnings.warn('Cross-class setters have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please convert your system with `sys.to_zpk()` '
+                      'before setting `zeros`.',
+                      DeprecationWarning)
         obj = self.to_zpk()
         obj.zeros = zeros
         source_class = type(self)
@@ -117,11 +142,16 @@ class LinearTimeInvariant(object):
 
     @property
     def poles(self):
-        """Poles of the `ZerosPolesGain` system."""
+        """Poles of the system."""
         return self.to_zpk().poles
 
     @poles.setter
     def poles(self, poles):
+        warnings.warn('Cross-class setters have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please convert your system with `sys.to_zpk()` '
+                      'before setting `poles`.',
+                      DeprecationWarning)
         obj = self.to_zpk()
         obj.poles = poles
         source_class = type(self)
@@ -130,10 +160,19 @@ class LinearTimeInvariant(object):
     @property
     def gain(self):
         """Gain of the `ZerosPolesGain` system."""
+        warnings.warn('Cross-class properties have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please use `sys.to_zpk().gain`instead.',
+                      DeprecationWarning)
         return self.to_zpk().gain
 
     @gain.setter
     def gain(self, gain):
+        warnings.warn('Cross-class setters have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please convert your system with `sys.to_zpk()` '
+                      'before setting `gain`.',
+                      DeprecationWarning)
         obj = self.to_zpk()
         obj.gain = gain
         source_class = type(self)
@@ -142,10 +181,19 @@ class LinearTimeInvariant(object):
     @property
     def A(self):
         """State matrix of the `StateSpace` system."""
+        warnings.warn('Cross-class properties have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please use `sys.to_ss().A`instead.',
+                      DeprecationWarning)
         return self.to_ss().A
 
     @A.setter
     def A(self, A):
+        warnings.warn('Cross-class setters have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please convert your system with `sys.to_ss()` '
+                      'before setting `A`.',
+                      DeprecationWarning)
         obj = self.to_ss()
         obj.A = A
         source_class = type(self)
@@ -154,10 +202,19 @@ class LinearTimeInvariant(object):
     @property
     def B(self):
         """Input matrix of the `StateSpace` system."""
+        warnings.warn('Cross-class properties have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please use `sys.to_ss().B`instead.',
+                      DeprecationWarning)
         return self.to_ss().B
 
     @B.setter
     def B(self, B):
+        warnings.warn('Cross-class setters have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please convert your system with `sys.to_ss()` '
+                      'before setting `B`.',
+                      DeprecationWarning)
         obj = self.to_ss()
         obj.B = B
         source_class = type(self)
@@ -166,10 +223,19 @@ class LinearTimeInvariant(object):
     @property
     def C(self):
         """Output matrix of the `StateSpace` system."""
+        warnings.warn('Cross-class properties have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please use `sys.to_ss().C`instead.',
+                      DeprecationWarning)
         return self.to_ss().C
 
     @C.setter
     def C(self, C):
+        warnings.warn('Cross-class setters have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please convert your system with `sys.to_ss()` '
+                      'before setting `C`.',
+                      DeprecationWarning)
         obj = self.to_ss()
         obj.C = C
         source_class = type(self)
@@ -178,10 +244,19 @@ class LinearTimeInvariant(object):
     @property
     def D(self):
         """Feedthrough matrix of the `StateSpace` system."""
+        warnings.warn('Cross-class properties have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please use `sys.to_ss().D`instead.',
+                      DeprecationWarning)
         return self.to_ss().D
 
     @D.setter
     def D(self, D):
+        warnings.warn('Cross-class setters have been deprecated in scipy '
+                      '0.18.0 and will be removed in a future version of '
+                      'scipy. Please convert your system with `sys.to_ss()` '
+                      'before setting `D`.',
+                      DeprecationWarning)
         obj = self.to_ss()
         obj.D = D
         source_class = type(self)

--- a/scipy/signal/tests/test_dltisys.py
+++ b/scipy/signal/tests/test_dltisys.py
@@ -348,24 +348,30 @@ class TestStateSpaceDisc(object):
 
         # Getters
         s = StateSpace(1, 1, 1, 1, dt=0.05)
-        assert_equal(s.num, [1, 0])
-        assert_equal(s.den, [1, -1])
         assert_equal(s.poles, [1])
         assert_equal(s.zeros, [0])
-        assert_equal(s.gain, 1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            assert_equal(s.gain, 1)
+            assert_equal(s.num, [1, 0])
+            assert_equal(s.den, [1, -1])
 
         # transfer function setters
         s2 = StateSpace(2, 2, 2, 2, dt=0.05)
-        s2.num = [1, 0]
-        s2.den = [1, -1]
-        self._compare_systems(s, s2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            s2.num = [1, 0]
+            s2.den = [1, -1]
+            self._compare_systems(s, s2)
 
         # zpk setters
         s2 = StateSpace(2, 2, 2, 2, dt=0.05)
-        s2.poles = 1
-        s2.zeros = 0
-        s2.gain = 1
-        self._compare_systems(s, s2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            s2.poles = 1
+            s2.zeros = 0
+            s2.gain = 1
+            self._compare_systems(s, s2)
 
 
 class TestTransferFunction(object):
@@ -401,26 +407,32 @@ class TestTransferFunction(object):
         s = TransferFunction([1, 0], [1, -1], dt=0.05)
         assert_equal(s.poles, [1])
         assert_equal(s.zeros, [0])
-        assert_equal(s.gain, 1)
-        assert_equal(s.A, 1)
-        assert_equal(s.B, 1)
-        assert_equal(s.C, 1)
-        assert_equal(s.D, 1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            assert_equal(s.gain, 1)
+            assert_equal(s.A, 1)
+            assert_equal(s.B, 1)
+            assert_equal(s.C, 1)
+            assert_equal(s.D, 1)
 
         # state space setters
         s2 = TransferFunction([2, 3], [4, 5], dt=0.05)
-        s2.A = 1
-        s2.B = 1
-        s2.C = 1
-        s2.D = 1
-        self._compare_systems(s, s2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            s2.A = 1
+            s2.B = 1
+            s2.C = 1
+            s2.D = 1
+            self._compare_systems(s, s2)
 
         # zpk setters
         s2 = TransferFunction([2, 3], [4, 5], dt=0.05)
-        s2.poles = 1
-        s2.zeros = 0
-        s2.gain = 1
-        self._compare_systems(s, s2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            s2.poles = 1
+            s2.zeros = 0
+            s2.gain = 1
+            self._compare_systems(s, s2)
 
 
 class TestZerosPolesGain(object):
@@ -455,26 +467,32 @@ class TestZerosPolesGain(object):
 
         # Getters
         s = ZerosPolesGain(0, 1, 1, dt=0.05)
-        assert_equal(s.num, [1, 0])
-        assert_equal(s.den, [1, -1])
-        assert_equal(s.A, 1)
-        assert_equal(s.B, 1)
-        assert_equal(s.C, 1)
-        assert_equal(s.D, 1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            assert_equal(s.num, [1, 0])
+            assert_equal(s.den, [1, -1])
+            assert_equal(s.A, 1)
+            assert_equal(s.B, 1)
+            assert_equal(s.C, 1)
+            assert_equal(s.D, 1)
 
         # state space setters
         s2 = ZerosPolesGain([2], [6], 3, dt=0.05)
-        s2.A = 1
-        s2.B = 1
-        s2.C = 1
-        s2.D = 1
-        self._compare_systems(s, s2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            s2.A = 1
+            s2.B = 1
+            s2.C = 1
+            s2.D = 1
+            self._compare_systems(s, s2)
 
         # tf setters
         s2 = ZerosPolesGain([2], [5], 3, dt=0.05)
-        s2.num = [1, 0]
-        s2.den = [1, -1]
-        self._compare_systems(s, s2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            s2.num = [1, 0]
+            s2.den = [1, -1]
+            self._compare_systems(s, s2)
 
 
 class Test_dfreqresp(TestCase):

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -781,25 +781,31 @@ class TestStateSpace(object):
 
         # Getters
         s = StateSpace(1, 1, 1, 1)
-        assert_equal(s.num, [1, 0])
-        assert_equal(s.den, [1, -1])
-        assert_equal(s.poles, [1])
-        assert_equal(s.zeros, [0])
-        assert_equal(s.gain, 1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            assert_equal(s.num, [1, 0])
+            assert_equal(s.den, [1, -1])
+            assert_equal(s.poles, [1])
+            assert_equal(s.zeros, [0])
+            assert_equal(s.gain, 1)
 
         # transfer function setters
         s2 = StateSpace(2, 2, 2, 2)
-        s2.num = [1, 0]
-        s2.den = [1, -1]
-        self._compare_systems(s, s2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            s2.num = [1, 0]
+            s2.den = [1, -1]
+            self._compare_systems(s, s2)
 
         # zpk setters
         s2 = StateSpace(2, 2, 2, 2)
-        assert_(s.dt is None)
-        s2.poles = 1
-        s2.zeros = 0
-        s2.gain = 1
-        self._compare_systems(s, s2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            assert_(s.dt is None)
+            s2.poles = 1
+            s2.zeros = 0
+            s2.gain = 1
+            self._compare_systems(s, s2)
 
 
 class TestTransferFunction(object):
@@ -831,28 +837,34 @@ class TestTransferFunction(object):
 
         # Getters
         s = TransferFunction([1, 0], [1, -1])
-        assert_equal(s.poles, [1])
-        assert_equal(s.zeros, [0])
-        assert_equal(s.gain, 1)
-        assert_equal(s.A, 1)
-        assert_equal(s.B, 1)
-        assert_equal(s.C, 1)
-        assert_equal(s.D, 1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            assert_equal(s.poles, [1])
+            assert_equal(s.zeros, [0])
+            assert_equal(s.gain, 1)
+            assert_equal(s.A, 1)
+            assert_equal(s.B, 1)
+            assert_equal(s.C, 1)
+            assert_equal(s.D, 1)
 
         # state space setters
         s2 = TransferFunction([2, 3], [4, 5])
-        s2.A = 1
-        s2.B = 1
-        s2.C = 1
-        s2.D = 1
-        self._compare_systems(s, s2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            s2.A = 1
+            s2.B = 1
+            s2.C = 1
+            s2.D = 1
+            self._compare_systems(s, s2)
 
         # zpk setters
         s2 = TransferFunction([2, 3], [4, 5])
-        s2.poles = 1
-        s2.zeros = 0
-        s2.gain = 1
-        self._compare_systems(s, s2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            s2.poles = 1
+            s2.zeros = 0
+            s2.gain = 1
+            self._compare_systems(s, s2)
 
 
 class TestZerosPolesGain(object):
@@ -864,9 +876,11 @@ class TestZerosPolesGain(object):
 
     def _compare_systems(self, sys1, sys2):
         #Compare the contents of two systems
-        assert_equal(sys1.poles, sys2.poles)
-        assert_equal(sys1.zeros, sys2.zeros)
-        assert_equal(sys1.gain, sys2.gain)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            assert_equal(sys1.poles, sys2.poles)
+            assert_equal(sys1.zeros, sys2.zeros)
+            assert_equal(sys1.gain, sys2.gain)
 
     def test_conversion(self):
         #Check the conversion functions
@@ -885,26 +899,32 @@ class TestZerosPolesGain(object):
 
         # Getters
         s = ZerosPolesGain(0, 1, 1)
-        assert_equal(s.num, [1, 0])
-        assert_equal(s.den, [1, -1])
-        assert_equal(s.A, 1)
-        assert_equal(s.B, 1)
-        assert_equal(s.C, 1)
-        assert_equal(s.D, 1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            assert_equal(s.num, [1, 0])
+            assert_equal(s.den, [1, -1])
+            assert_equal(s.A, 1)
+            assert_equal(s.B, 1)
+            assert_equal(s.C, 1)
+            assert_equal(s.D, 1)
 
         # state space setters
         s2 = ZerosPolesGain([2], [6], 3)
-        s2.A = 1
-        s2.B = 1
-        s2.C = 1
-        s2.D = 1
-        self._compare_systems(s, s2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            s2.A = 1
+            s2.B = 1
+            s2.C = 1
+            s2.D = 1
+            self._compare_systems(s, s2)
 
         # tf setters
         s2 = ZerosPolesGain([2], [5], 3)
-        s2.num = [1, 0]
-        s2.den = [1, -1]
-        self._compare_systems(s, s2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            s2.num = [1, 0]
+            s2.den = [1, -1]
+            self._compare_systems(s, s2)
 
 
 class Test_abcd_normalize(object):


### PR DESCRIPTION
Previously, the `lti` class used to maintain three different representations of the system at the same time. When these classes were split up into `StateSpace`, `TransferFunction` and `ZerosPolesGain`, these three representations where kept around via properties that convert to the corresponding system representation; that is, `StateSpace(1,1,1,1).num` internally calls `to_tf()` and then returns the numerator of the transfer function.

These additional properties do not make sense in the current framework, since the numerator of a state space system does not have any meaning. Moreove, setting the setters for these properties encourages extremely bad and inefficient behavior with lots of numerically inaccurate transformations.

As a consequence, this PR deprecates these cross-class properties/setters.

A notable exception are the `poles` and `zeros` properties, which are generally meaningful for any representation. However, they could in future be computed in more efficient ways.
