### PR TITLE
DOC: Fixed a typo in ward() help

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -435,14 +435,11 @@ def ward(y):
     The following are common calling conventions:
 
     1. ``Z = ward(y)``
-       Performs Ward's linkage on the condensed distance matrix ``Z``. See
-       linkage for more information on the return structure and
-       algorithm.
+       Performs Ward's linkage on the condensed distance matrix ``y``.
 
     2. ``Z = ward(X)``
        Performs Ward's linkage on the observation matrix ``X`` using
-       Euclidean distance as the distance metric. See linkage for more
-       information on the return structure and algorithm.
+       Euclidean distance as the distance metric.
 
     Parameters
     ----------
@@ -457,7 +454,9 @@ def ward(y):
     Returns
     -------
     Z : ndarray
-        The hierarchical clustering encoded as a linkage matrix.
+        The hierarchical clustering encoded as a linkage matrix. See
+       linkage for more information on the return structure and
+       algorithm.
 
     See Also
     --------


### PR DESCRIPTION
Correct argument name is y, not z.
