### PR TITLE
MAINT: rayleigh accuracy

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3978,7 +3978,10 @@ class rayleigh_gen(rv_continuous):
         return chi.rvs(2, size=self._size, random_state=self._random_state)
 
     def _pdf(self, r):
-        return r * exp(-0.5 * r**2)
+        return exp(self._logpdf(r))
+
+    def _logpdf(self, r):
+        return log(r) - 0.5 * r * r
 
     def _cdf(self, r):
         return -special.expm1(-0.5 * r**2)
@@ -3987,7 +3990,10 @@ class rayleigh_gen(rv_continuous):
         return sqrt(-2 * special.log1p(-q))
 
     def _sf(self, r):
-        return exp(-0.5 * r**2)
+        return exp(self._logsf(r))
+
+    def _logsf(self, r):
+        return -0.5 * r * r
 
     def _isf(self, q):
         return sqrt(-2 * log(q))

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1813,6 +1813,17 @@ class TestErlang(TestCase):
             assert_allclose(result_erlang, result_gamma, rtol=1e-3)
 
 
+class TestRayleigh(TestCase):
+    # gh-6227
+    def test_logpdf(self):
+        y = stats.rayleigh.logpdf(50)
+        assert_allclose(y, -1246.0879769945718)
+
+    def test_logsf(self):
+        y = stats.rayleigh.logsf(50)
+        assert_allclose(y, -1250)
+
+
 class TestExponWeib(TestCase):
 
     def test_pdf_logpdf(self):


### PR DESCRIPTION
closes https://github.com/scipy/scipy/issues/6227.

This PR does not use the exact approach suggested in the original issue. It's a little simpler, and I think the difference is only at extreme edge cases like `logpdf(np.inf)`. Could support for those extremes be added later?
