### PR TITLE
MAINT: avoid bad fmin in l-bfgs-b due to maxfun interruption

### DIFF
--- a/scipy/optimize/lbfgsb.py
+++ b/scipy/optimize/lbfgsb.py
@@ -321,17 +321,18 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
                        isave, dsave, maxls)
         task_str = task.tostring()
         if task_str.startswith(b'FG'):
-            if n_function_evals[0] > maxfun:
-                task[:] = ('STOP: TOTAL NO. of f AND g EVALUATIONS '
-                           'EXCEEDS LIMIT')
-            else:
-                # minimization routine wants f and g at the current x
-                # Overwrite f and g:
-                f, g = func_and_grad(x)
+            # The minimization routine wants f and g at the current x.
+            # Note that interruptions due to maxfun are postponed
+            # until the completion of the current minimization iteration.
+            # Overwrite f and g:
+            f, g = func_and_grad(x)
         elif task_str.startswith(b'NEW_X'):
             # new iteration
             if n_iterations > maxiter:
                 task[:] = 'STOP: TOTAL NO. of ITERATIONS EXCEEDS LIMIT'
+            elif n_function_evals[0] > maxfun:
+                task[:] = ('STOP: TOTAL NO. of f AND g EVALUATIONS '
+                           'EXCEEDS LIMIT')
             else:
                 n_iterations += 1
                 if callback is not None:

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -595,30 +595,25 @@ class TestOptimizeSimple(CheckOptimize):
         # gh-6162
         f = optimize.rosen
         g = optimize.rosen_der
+        values = []
         x0 = np.ones(7) * 1000
 
-        class _F(object):
-
-            def __init__(self):
-                self.values = []
-
-            def __call__(self, x):
-                value = f(x)
-                self.values.append(value)
-                return value
+        def objfun(x):
+            value = f(x)
+            values.append(value)
+            return value
 
         # Look for an interesting test case.
         # Request a maxfun that stops at a particularly bad function
         # evaluation somewhere between 100 and 300 evaluations.
         low, medium, high = 30, 100, 300
-        obj = _F()
-        optimize.fmin_l_bfgs_b(obj, x0, fprime=g, maxfun=high)
-        v, k = max((y, i) for i, y in enumerate(obj.values[medium:]))
+        optimize.fmin_l_bfgs_b(objfun, x0, fprime=g, maxfun=high)
+        v, k = max((y, i) for i, y in enumerate(values[medium:]))
         maxfun = medium + k
         # If the minimization strategy is reasonable,
         # the minimize() result should not be worse than the best
         # of the first 30 function evaluations.
-        target = min(obj.values[:low])
+        target = min(values[:low])
         xmin, fmin, d = optimize.fmin_l_bfgs_b(f, x0, fprime=g, maxfun=maxfun)
         assert_array_less(fmin, target)
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -597,8 +597,10 @@ class TestOptimizeSimple(CheckOptimize):
         g = optimize.rosen_der
         x0 = np.ones(7) * 1000
         class _F(object):
+
             def __init__(self):
                 self.values = []
+
             def __call__(self, x):
                 value = f(x)
                 self.values.append(value)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -596,6 +596,7 @@ class TestOptimizeSimple(CheckOptimize):
         f = optimize.rosen
         g = optimize.rosen_der
         x0 = np.ones(7) * 1000
+
         class _F(object):
 
             def __init__(self):
@@ -605,6 +606,7 @@ class TestOptimizeSimple(CheckOptimize):
                 value = f(x)
                 self.values.append(value)
                 return value
+
         # Look for an interesting test case.
         # Request a maxfun that stops at a particularly bad function
         # evaluation somewhere between 100 and 300 evaluations.


### PR DESCRIPTION
In l-bfgs-b, wait until an iteration is complete before terminating due to maxfun.
Partially addresses https://github.com/scipy/scipy/issues/6162. The hardcoded `maxfun` of 115 in the minimal working example linked in that issue did not reproduce for me, but I've added a unit test with a softcoded `maxfun`; on my system the `maxfun` 168 is chosen instead of 115.

Note that this PR may cause l-bfgs-b to evaluate the objective more than `maxfun` times. An alternative approach would cache results from the most recently completed iteration and report those results if an iteration is interrupted due to `maxfun`.
