### PR TITLE
DOC: fix typos

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -27,7 +27,7 @@ submodules.
 Developer's Guide
 -----------------
 
-Explainations of how to start contributing to SciPy, and descriptions of
+Explanations of how to start contributing to SciPy, and descriptions of
 maintenance activities and policies.
 
 .. toctree::

--- a/doc/source/tutorial/csgraph.rst
+++ b/doc/source/tutorial/csgraph.rst
@@ -103,7 +103,7 @@ any two words in the graph::
 
 We need to check that these match, because if the words are not in the list
 that will not be the case.  Now all we need is to find the shortest path
-between these two indices in the graph.  We'll use dijkstra's algorithm,
+between these two indices in the graph.  We'll use Dijkstra's algorithm,
 because it allows us to find the path for just one node::
 
     >>> from scipy.sparse.csgraph import dijkstra

--- a/doc/source/tutorial/examples/5-1
+++ b/doc/source/tutorial/examples/5-1
@@ -72,7 +72,7 @@ Optimization Tools
                            instead of directly computing the inverse Jacobian,
                            it remembers how to construct it using vectors, and
                            when computing inv(J)*F, it uses those vectors to
-                           compute this product, thus avoding the expensive NxN
+                           compute this product, thus avoiding the expensive NxN
                            matrix multiplication.
    broyden_generalized --  Generalized Broyden's method, the same as broyden2,
                            but instead of approximating the full NxN Jacobian,

--- a/doc/source/tutorial/linalg.rst
+++ b/doc/source/tutorial/linalg.rst
@@ -156,7 +156,7 @@ Solving linear system
 Solving linear systems of equations is straightforward using the scipy
 command :obj:`linalg.solve`. This command expects an input matrix and
 a right-hand-side vector. The solution vector is then computed. An
-option for entering a symmetrix matrix is offered which can speed up
+option for entering a symmetric matrix is offered which can speed up
 the processing when applicable.  As an example, suppose it is desired
 to solve the following simultaneous equations:
 

--- a/doc/source/tutorial/ndimage.rst
+++ b/doc/source/tutorial/ndimage.rst
@@ -1095,7 +1095,7 @@ their binary counterparts:
 
     The :func:`black_tophat` function implements a black top-hat filter of
     arrays of arbitrary rank. The black top-hat is equal to the
-    difference of the a grey-scale closing and the input.
+    difference of a grey-scale closing and the input.
 
 
 .. _ndimage-distance-transforms:
@@ -1122,7 +1122,7 @@ Block, and Chessboard distances.
     structure is generated using :func:`generate_binary_structure` with a
     squared distance equal to the rank of the array. These choices
     correspond to the common interpretations of the cityblock and the
-    chessboard distancemetrics in two dimensions.
+    chessboard distance metrics in two dimensions.
 
     In addition to the distance transform, the feature transform can be
     calculated. In this case the index of the closest background

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -933,7 +933,7 @@ method which is implemented by the scipy function :func:`welch`.
 
 The example below estimates the spectrum using Welch's method and uses the
 same parameters as the example above. Note the much smoother noise floor of
-the spectogram.
+the spectrogram.
 
 
 .. plot::

--- a/doc/source/tutorial/stats/continuous.rst
+++ b/doc/source/tutorial/stats/continuous.rst
@@ -166,7 +166,7 @@ References
 
 -  Documentation for ranlib, rv2, cdflib
 
--  Eric Weisstein~s world of mathematics http://mathworld.wolfram.com/,
+-  Eric Weisstein's world of mathematics http://mathworld.wolfram.com/,
    http://mathworld.wolfram.com/topics/StatisticalDistributions.html
 
 -  Documentation to Regress+ by Michael McLaughlin item Engineering and


### PR DESCRIPTION
These misspellings were found using [mwic](http://jwilk.net/software/mwic).
