### PR TITLE
MAINT: io/arff: remove unused variable

### DIFF
--- a/scipy/io/arff/arffread.py
+++ b/scipy/io/arff/arffread.py
@@ -44,8 +44,6 @@ r_attribute = re.compile(r'^@[Aa][Tt][Tt][Rr][Ii][Bb][Uu][Tt][Ee]\s*(..*$)')
 
 # To get attributes name enclosed with ''
 r_comattrval = re.compile(r"'(..+)'\s+(..+$)")
-# To get attributes name enclosed with '', possibly spread across multilines
-r_mcomattrval = re.compile(r"'([..\n]+)'\s+(..+$)")
 # To get normal attributes
 r_wcomattrval = re.compile(r"(\S+)\s+(..+$)")
 


### PR DESCRIPTION
`scipy/io/arff/arffread.py` has the following code:

``` python
r_mcomattrval = re.compile(r"'([..\n]+)'\s+(..+$)")
```

This regexp looks very suspicious, because it allows only newlines and dots between apostrophes.
But the code that used this variable was removed in 7ad596f5c0ab, so instead of trying to figure out what the correct regexp should be, we can just remove this variable.

The dubious regexp construct was found using [pydiatra](https://github.com/jwilk/pydiatra).
