### PR TITLE
MAINT: stats: do not allow non-integer xk for rv_discrete

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3237,6 +3237,9 @@ class rv_sample(rv_discrete):
             raise ValueError("xk and pk need to have the same length.")
         if not np.allclose(np.sum(pk), 1):
             raise ValueError("The sum of provided pk is not 1.")
+        if np.any(np.asarray(xk).astype(int) != xk):
+            raise ValueError("xk must be integers. If you really want floats, "
+                             "use xk as integer indices into the float array.")
 
         indx = np.argsort(np.ravel(xk))
         self.xk = np.take(np.ravel(xk), indx, 0)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -940,6 +940,11 @@ class TestRvDiscrete(TestCase):
         pk = [1, 2, 3]
         assert_raises(ValueError, stats.rv_discrete, **dict(values=(xk, pk)))
 
+    def test_float_xk(self):
+        xk = [1.5, 2.0, 3.6]
+        pk = [0.5, 0.5, 0.0]
+        assert_raises(ValueError, stats.rv_discrete, **dict(values=(xk, pk)))
+
 
 class TestSkewNorm(TestCase):
 


### PR DESCRIPTION
This is a follow-up to gh-5672, intending to close gh-3758. Here this is the simplest fix: it just raises an error if the support,  `xk`, is not integer. See gh-3578 for discussion and possible issues due to non-integer xk.
cc @fuglede 
