### PR TITLE
MAINT: special: add tests for cdflib

### DIFF
--- a/scipy/special/_testutils.py
+++ b/scipy/special/_testutils.py
@@ -160,9 +160,9 @@ class FuncData(object):
     ignore_inf_sign : bool, optional
         Whether to ignore signs of infinities.
         (Doesn't matter for complex-valued functions.)
-    distinguish_nonfinite : bool, optional
-        Whether to distinguish between nans and infinities. If true
-        also ignores the signs of infinities.
+    distinguish_nan_and_inf : bool, optional
+        If True, treat numbers which contain nans or infs as as
+        equal. Sets ignore_inf_sign to be True.
 
     """
 

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -1,0 +1,313 @@
+"""
+Test cdflib functions versus mpmath, if available.
+
+The following functions still need tests:
+
+- ncfdtr
+- ncfdtri
+- ncfdtridfn
+- ncfdtridfd
+- ncfdtrinc
+- nbdtrik
+- nbdtrin
+- nrdtrimn
+- nrdtrisd
+- pdtrik
+- nctdtr
+- nctdtrit
+- nctdtridf
+- nctdtrinc
+
+"""
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+from numpy.testing import dec
+
+import scipy.special as sp
+from scipy._lib.six import with_metaclass
+from scipy._lib._testutils import knownfailure_overridable
+from scipy.special._testutils import (
+    MissingModule, check_version, DecoratorMeta, FuncData)
+from scipy.special._mptestutils import (
+    Arg, IntArg, get_args, mpf2float, assert_mpmath_equal)
+
+try:
+    import mpmath
+except ImportError:
+    try:
+        import sympy.mpmath as mpmath
+    except ImportError:
+        mpmath = MissingModule('mpmath')
+
+
+class ProbArg(object):
+    """Generate a set of probabilities on [0, 1]."""
+    
+    def values(self, n):
+        """Return an array containing approximatively n numbers."""
+        m = max(1, n//3)
+        v1 = np.logspace(-30, np.log10(0.3), m)
+        v2 = np.linspace(0.3, 0.7, m + 1, endpoint=False)[1:]
+        v3 = 1 - np.logspace(np.log10(0.3), -15, m)
+        v = np.r_[v1, v2, v3]
+        return np.unique(v)
+
+
+class _CDFData():
+    def __init__(self, spfunc, mpfunc, index, argspec, spfunc_first=True,
+                 dps=20, n=5000, rtol=None, atol=None):
+        self.spfunc = spfunc
+        self.mpfunc = mpfunc
+        self.index = index
+        self.argspec = argspec
+        self.spfunc_first = spfunc_first
+        self.dps = dps
+        self.n = n
+        self.rtol = rtol
+        self.atol = atol
+
+    def idmap(self, *args):
+        if self.spfunc_first:
+            res = self.spfunc(*args)
+            if np.isnan(res):
+                return np.nan
+            args = list(args)
+            args[self.index] = res
+            with mpmath.workdps(self.dps):
+                res = self.mpfunc(*tuple(args))
+                # Imaginary parts are spurious
+                res = mpf2float(res.real)
+        else:
+            with mpmath.workdps(self.dps):
+                res = self.mpfunc(*args)
+                res = mpf2float(res.real)
+            args = list(args)
+            args[self.index] = res
+            res = self.spfunc(*tuple(args))
+        return res
+        
+    def check(self):
+        # Generate values for the arguments
+        args = get_args(self.argspec, self.n)
+        param_columns = tuple(range(args.shape[1]))
+        result_columns = args.shape[1]
+        args = np.hstack((args, args[:,self.index].reshape(args.shape[0], 1)))
+        FuncData(self.idmap, args,
+                 param_columns=param_columns, result_columns=result_columns,
+                 rtol=self.rtol, atol=self.atol, vectorized=False).check()
+
+
+def _assert_inverts(*a, **kw):
+    d = _CDFData(*a, **kw)
+    d.check()
+
+
+def _binomial_cdf(k, n, p):
+    if k <= 0:
+        return mpmath.mpf(0)
+    elif k >= n:
+        return mpmath.mpf(1)
+    res = 0
+    k = int(k)
+    for j in range(k + 1):
+        res += mpmath.binomial(n, j)*p**j*(1 - p)**(n - j)
+    return res
+
+
+def _f_cdf(dfn, dfd, x):
+    dfn, dfd, x = mpmath.mpf(dfn), mpmath.mpf(dfd), mpmath.mpf(x)
+    ub = dfn*x/(dfn*x + dfd)
+    res = mpmath.betainc(dfn/2, dfd/2, x2=ub, regularized=True)
+    return res
+    
+
+def _student_t_cdf(df, t, dps=None):
+    if dps is None:
+        dps = mpmath.mp.dps
+    with mpmath.workdps(dps):
+        df, t = mpmath.mpf(df), mpmath.mpf(t)
+        fac = mpmath.hyp2f1(0.5, 0.5*(df + 1), 1.5, -t**2/df)
+        fac *= t*mpmath.gamma(0.5*(df + 1))
+        fac /= mpmath.sqrt(mpmath.pi*df)*mpmath.gamma(0.5*df)
+        return 0.5 + fac
+
+
+def _noncentral_chi_pdf(t, df, nc):
+    res = mpmath.besseli(df/2 - 1, mpmath.sqrt(nc*t))
+    res *= mpmath.exp(-(t + nc)/2)*(t/nc)**(df/4 - 1/2)/2
+    return res
+
+
+def _noncentral_chi_cdf(x, df, nc, dps=None):
+    if dps is None:
+        dps = mpmath.mp.dps
+    x, df, nc = mpmath.mpf(x), mpmath.mpf(df), mpmath.mpf(nc)
+    with mpmath.workdps(dps):
+        res = mpmath.quad(lambda t: _noncentral_chi_pdf(t, df, nc), [0, x])
+        return res
+
+
+def _tukey_lmbda_quantile(p, lmbda):
+    # For lmbda != 0
+    return (p**lmbda - (1 - p)**lmbda)/lmbda
+
+    
+class TestCDFlib(with_metaclass(DecoratorMeta, object)):
+    decorators = [(dec.slow, None),
+                  (check_version, (mpmath, '0.19'))]
+
+    @knownfailure_overridable()
+    def test_bdtrik(self):
+        _assert_inverts(
+            sp.bdtrik,
+            _binomial_cdf,
+            0, [ProbArg(), IntArg(1, 1000), ProbArg()],
+            rtol=1e-4)
+
+    @knownfailure_overridable()
+    def test_bdtrin(self):
+        _assert_inverts(
+            sp.bdtrin,
+            _binomial_cdf,
+            1, [IntArg(1, 1000), ProbArg(), ProbArg()],
+            rtol=1e-4)
+    
+    def test_btdtria(self):
+        _assert_inverts(
+            sp.btdtria,
+            lambda a, b, x: mpmath.betainc(a, b, x2=x, regularized=True),
+            0, [ProbArg(), Arg(0, 1e3, inclusive_a=False),
+                Arg(0, 1, inclusive_a=False, inclusive_b=False)],
+            rtol=1e-6)
+
+    @knownfailure_overridable()
+    def test_btdtrib(self):
+        # Use small values of a or mpmath doesn't converge
+        _assert_inverts(
+            sp.btdtrib,
+            lambda a, b, x: mpmath.betainc(a, b, x2=x, regularized=True),
+            1, [Arg(0, 1e2, inclusive_a=False), ProbArg(),
+             Arg(0, 1, inclusive_a=False, inclusive_b=False)],
+            rtol=1e-7)
+
+    @knownfailure_overridable()
+    def test_fdtridfd(self):
+        _assert_inverts(
+            sp.fdtridfd,
+            _f_cdf,
+            1, [IntArg(1, 100), ProbArg(), Arg(0, 100, inclusive_a=False)],
+            rtol=1e-7)
+        
+    @knownfailure_overridable()
+    def test_gdtria(self):
+        _assert_inverts(
+            sp.gdtria,
+            lambda a, b, x: mpmath.gammainc(b, b=a*x, regularized=True),
+            0, [ProbArg(), Arg(0, 1e3, inclusive_a=False),
+                Arg(0, 1e4, inclusive_a=False)], rtol=1e-7)
+
+    def test_gdtrib(self):
+        # Use small values of a and x or mpmath doesn't converge
+        _assert_inverts(
+            sp.gdtrib,
+            lambda a, b, x: mpmath.gammainc(b, b=a*x, regularized=True),
+            1, [Arg(0, 1e2, inclusive_a=False), ProbArg(),
+                Arg(0, 1e3, inclusive_a=False)], rtol=1e-5)
+
+    @knownfailure_overridable()
+    def test_gdtrix(self):
+        _assert_inverts(
+            sp.gdtrix,
+            lambda a, b, x: mpmath.gammainc(b, b=a*x, regularized=True),
+            2, [Arg(0, 1e3, inclusive_a=False), Arg(0, 1e3, inclusive_a=False),
+                ProbArg()], rtol=1e-7)
+
+    @knownfailure_overridable()
+    def test_stdtr(self):
+        assert_mpmath_equal(
+            sp.stdtr,
+            _student_t_cdf,
+            [IntArg(1, 100), Arg()], rtol=1e-7)
+
+    @knownfailure_overridable()
+    def test_stdtridf(self):
+        _assert_inverts(
+            sp.stdtridf,
+            _student_t_cdf,
+            0, [ProbArg(), Arg()], rtol=1e-7)
+
+    @knownfailure_overridable()
+    def test_stdtrit(self):
+        _assert_inverts(
+            sp.stdtrit,
+            _student_t_cdf,
+            1, [IntArg(1, 100), ProbArg()], rtol=1e-7)
+
+    @knownfailure_overridable()
+    def test_chdtriv(self):
+        _assert_inverts(
+            sp.chdtriv,
+            lambda v, x: mpmath.gammainc(v/2, b=x/2, regularized=True),
+            0, [ProbArg(), IntArg(1, 100)], rtol=1e-4)
+
+    def test_chndtr(self):
+        # Use a larger atol since mpmath is doing numerical integration
+        assert_mpmath_equal(
+            sp.chndtr,
+            _noncentral_chi_cdf,
+            [Arg(0, 100), IntArg(1, 100), Arg(0, 100, inclusive_a=False)],
+            n=1000, rtol=1e-4, atol=1e-15)
+
+    @knownfailure_overridable()
+    def test_chndtridf(self):
+        # Use a larger atol since mpmath is doing numerical integration
+        _assert_inverts(
+            sp.chndtridf,
+            _noncentral_chi_cdf,
+            1, [Arg(0, 100, inclusive_a=False), ProbArg(),
+                Arg(0, 100, inclusive_a=False)],
+            n=1000, rtol=1e-4, atol=1e-15)
+
+    @knownfailure_overridable()
+    def test_chndtrinc(self):
+        # Use a larger atol since mpmath is doing numerical integration
+        _assert_inverts(
+            sp.chndtrinc,
+            _noncentral_chi_cdf,
+            2, [Arg(0, 100, inclusive_a=False), IntArg(1, 100),
+                ProbArg()],
+            n=1000, rtol=1e-4, atol=1e-15)
+        
+    @knownfailure_overridable()
+    def test_chndtrix(self):
+        # Use a larger atol since mpmath is doing numerical integration
+        _assert_inverts(
+            sp.chndtrix,
+            _noncentral_chi_cdf,
+            0, [ProbArg(), IntArg(1, 100), Arg(0, 100, inclusive_a=False)],
+            n=1000, rtol=1e-4, atol=1e-15)
+
+    def test_tklmbda_zero_shape(self):
+        # When lmbda = 0 the CDF has a simple closed form
+        one = mpmath.mpf(1)
+        assert_mpmath_equal(
+            lambda x: sp.tklmbda(x, 0),
+            lambda x: one/(mpmath.exp(-x) + one),
+            [Arg()], rtol=1e-7)
+
+    @knownfailure_overridable()
+    def test_tklmbda_neg_shape(self):
+        _assert_inverts(
+            sp.tklmbda,
+            _tukey_lmbda_quantile,
+            0, [ProbArg(), Arg(-np.inf, 0, inclusive_b=False)],
+            spfunc_first=False, rtol=1e-5)
+
+    @knownfailure_overridable()
+    def test_tklmbda_pos_shape(self):
+        _assert_inverts(
+            sp.tklmbda,
+            _tukey_lmbda_quantile,
+            0, [ProbArg(), Arg(0, np.inf, inclusive_a=False)],
+            spfunc_first=False, rtol=1e-5)


### PR DESCRIPTION
Add roundtrip tests for cdflib functions. Use mpmath for one direction
to ensure that the functions are correct and not just consistent.
