### PR TITLE
Fix for scipy.cluster.hierarchy.is_isomorphic

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2635,7 +2635,7 @@ def is_isomorphic(T1, T2):
     for i in xrange(0, n):
         if T1[i] in d1:
             if not T2[i] in d2:
-               return False
+                return False
             if d1[T1[i]] != T2[i] or d2[T2[i]] != T1[i]:
                 return False
         elif T2[i] in d2:

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2630,13 +2630,15 @@ def is_isomorphic(T1, T2):
     if T1S[0] != T2S[0]:
         raise ValueError('T1 and T2 must have the same number of elements.')
     n = T1S[0]
-    d = {}
+    d1 = {}
+    d2 = {}
     for i in xrange(0, n):
-        if T1[i] in d:
-            if d[T1[i]] != T2[i]:
+        if T1[i] in d1:
+            if d1[T1[i]] != T2[i] or d2[T2[i]] != T1[i]:
                 return False
         else:
-            d[T1[i]] = T2[i]
+            d1[T1[i]] = T2[i]
+            d2[T2[i]] = T1[i]
     return True
 
 

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2634,8 +2634,12 @@ def is_isomorphic(T1, T2):
     d2 = {}
     for i in xrange(0, n):
         if T1[i] in d1:
+            if not T2[i] in d2:
+               return False
             if d1[T1[i]] != T2[i] or d2[T2[i]] != T1[i]:
                 return False
+        elif T2[i] in d2:
+            return False
         else:
             d1[T1[i]] = T2[i]
             d2[T2[i]] = T1[i]

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -272,7 +272,11 @@ class TestIsIsomorphic(object):
         # nonisomorphic.)
         for nc in [2, 3, 5]:
             yield self.help_is_isomorphic_randperm, 1000, nc, True, 5
-
+            
+    def test_is_isomorphic_7(self):
+        # Regression test for gh-6271
+        assert_(not is_isomorphic([1, 2, 3], [1, 1, 1]))
+    
     def help_is_isomorphic_randperm(self, nobs, nclusters, noniso=False, nerrors=0):
         for k in range(3):
             a = np.int_(np.random.rand(nobs) * nclusters)


### PR DESCRIPTION
Hello maintainers,

This is a proposed fix for the following bug:

Problem: 
is_isomorphic returning True for non-isomorphic arguments. 

Example:

```
>>> import scipy
>>> from scipy.cluster.hierarchy import *
>>> is_isomorphic([1,2,3],[1,1,1]) #Not isomorphic assignments
True
>>> scipy.__version__
'0.17.0'
```

With this change, the above should return False, as expected.

Cheers,
Tim
