### PR TITLE
DOC: Correcting references for scipy.stats.normaltest

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1379,7 +1379,8 @@ def normaltest(a, axis=0, nan_policy='propagate'):
     .. [1] D'Agostino, R. B. (1971), "An omnibus test of normality for
            moderate and large sample size", Biometrika, 58, 341-348
 
-    .. [2] D'Agostino, R. and Pearson, E. S. (1973), "Tests for departure from normality. Empirical results for the distributions of b2 and ...", Biometrika, 60, 613-622
+    .. [2] D'Agostino, R. and Pearson, E. S. (1973), "Tests for departure from
+           normality", Biometrika, 60, 613-622
 
     """
     a, axis = _chk_asarray(a, axis)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1379,7 +1379,7 @@ def normaltest(a, axis=0, nan_policy='propagate'):
     .. [1] D'Agostino, R. B. (1971), "An omnibus test of normality for
            moderate and large sample size", Biometrika, 58, 341-348
 
-    .. [2] D'Agostino, R. and Pearson, E. S. (1973), "Tests for departure from normality. Empirical results for the distributions of b2 and √b1" Biometrika, 60, 613-622
+    .. [2] D'Agostino, R. and Pearson, E. S. (1973), "Tests for departure from normality. Empirical results for the distributions of b2 and √b1", Biometrika, 60, 613-622
 
     """
     a, axis = _chk_asarray(a, axis)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1379,7 +1379,7 @@ def normaltest(a, axis=0, nan_policy='propagate'):
     .. [1] D'Agostino, R. B. (1971), "An omnibus test of normality for
            moderate and large sample size", Biometrika, 58, 341-348
 
-    .. [2] D'Agostino, R. and Pearson, E. S. (1973), "Tests for departure from normality. Empirical results for the distributions of b2 and √b1", Biometrika, 60, 613-622
+    .. [2] D'Agostino, R. and Pearson, E. S. (1973), "Tests for departure from normality. Empirical results for the distributions of b2 and ...", Biometrika, 60, 613-622
 
     """
     a, axis = _chk_asarray(a, axis)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -1377,10 +1377,9 @@ def normaltest(a, axis=0, nan_policy='propagate'):
     References
     ----------
     .. [1] D'Agostino, R. B. (1971), "An omnibus test of normality for
-           moderate and large sample size," Biometrika, 58, 341-348
+           moderate and large sample size", Biometrika, 58, 341-348
 
-    .. [2] D'Agostino, R. and Pearson, E. S. (1973), "Testing for
-           departures from normality," Biometrika, 60, 613-622
+    .. [2] D'Agostino, R. and Pearson, E. S. (1973), "Tests for departure from normality. Empirical results for the distributions of b2 and √b1" Biometrika, 60, 613-622
 
     """
     a, axis = _chk_asarray(a, axis)


### PR DESCRIPTION
I corrected the references of normaltest. According to http://biomet.oxfordjournals.org/content/60/3/613.abstract?sid=623906f0-c204-4c5c-b07c-5aaa7cb2511b the title of the second reference was not correct.
