### PR TITLE
BUG: stats: Inconsistency in the multivariate_normal docstring #6263

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -453,7 +453,7 @@ class multivariate_normal_gen(multi_rv_generic):
         maha = np.sum(np.square(np.dot(dev, prec_U)), axis=-1)
         return -0.5 * (rank * _LOG_2PI + log_det_cov + maha)
 
-    def logpdf(self, x, mean, cov, allow_singular=False):
+    def logpdf(self, x, mean=None, cov=1, allow_singular=False):
         """
         Log of the multivariate normal probability density function.
 
@@ -479,7 +479,7 @@ class multivariate_normal_gen(multi_rv_generic):
         out = self._logpdf(x, mean, psd.U, psd.log_pdet, psd.rank)
         return _squeeze_output(out)
 
-    def pdf(self, x, mean, cov, allow_singular=False):
+    def pdf(self, x, mean=None, cov=1, allow_singular=False):
         """
         Multivariate normal probability density function.
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -64,6 +64,15 @@ class TestMultivariateNormal(TestCase):
         d2 = multivariate_normal.pdf(x, mean, cov)
         assert_allclose(d1, np.log(d2))
 
+    def test_logpdf_default_values(self):
+        # Check that the log of the pdf is in fact the logpdf
+        # with default parameters Mean=None and cov = 1
+        np.random.seed(1234)
+        x = np.random.randn(5)
+        d1 = multivariate_normal.logpdf(x)
+        d2 = multivariate_normal.pdf(x)
+        assert_allclose(d1, np.log(d2))
+
     def test_rank(self):
         # Check that the rank is detected correctly.
         np.random.seed(1234)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -71,7 +71,11 @@ class TestMultivariateNormal(TestCase):
         x = np.random.randn(5)
         d1 = multivariate_normal.logpdf(x)
         d2 = multivariate_normal.pdf(x)
+        # check whether default values are being used
+        d3 = multivariate_normal.logpdf(x, None, 1)
+        d4 = multivariate_normal.pdf(x, None, 1)
         assert_allclose(d1, np.log(d2))
+        assert_allclose(d3, np.log(d4))
 
     def test_rank(self):
         # Check that the rank is detected correctly.


### PR DESCRIPTION
Attempting to close [#6263](https://github.com/scipy/scipy/issues/6263).

I've added a test that covers `logpdf` tests using the `mean` and `cov` values specified in the docstring for `multivariate_normal_gen`. 
