### PR TITLE
CI: bump numpy version from 1.10.2 to 1.10.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
         - REFGUIDE_CHECK=1
         - COVERAGE=
         - NPY_RELAXED_STRIDES_CHECKING=1
-        - NUMPYSPEC="--upgrade git+git://github.com/numpy/numpy.git@v1.10.2"
+        - NUMPYSPEC="--upgrade git+git://github.com/numpy/numpy.git@v1.10.4"
       addons:
         apt:
           packages:


### PR DESCRIPTION
We should be testing against the last micro version of the numpy 1.10.x series.

(Originally, it was 1.10.1 when that was the last one, then it got bumped to 1.10.2, and then it was not updated when 1.10.4 came out).
