### PR TITLE
STY: Some PEP8 and cleaning up imports in stats/_continuous_distns.py

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6,32 +6,21 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 
-from scipy.special import comb
+import numpy as np
+
 from scipy.misc.doccer import inherit_docstring_from
-from scipy import special
 from scipy import optimize
 from scipy import integrate
-from scipy.special import (gammaln as gamln, gamma as gam, boxcox, boxcox1p,
-                           inv_boxcox, inv_boxcox1p, erfc, chndtr, chndtrix,
-                           i0, i1, ndtr as _norm_cdf, log_ndtr as _norm_logcdf)
+import scipy.special as sc
 from scipy._lib._numpy_compat import broadcast_to
-
-from numpy import (where, arange, putmask, ravel, shape,
-                   log, sqrt, exp, arctanh, tan, sin, arcsin, arctan,
-                   tanh, cos, cosh, sinh)
-
-from numpy import polyval, place, extract, asarray, nan, inf, pi
-
-import numpy as np
 
 from . import _stats
 from ._tukeylambda_stats import (tukeylambda_variance as _tlvar,
                                  tukeylambda_kurtosis as _tlkurt)
-from ._distn_infrastructure import (
-        rv_continuous, valarray, _skew, _kurtosis, _lazywhere,
-        _ncx2_log_pdf, _ncx2_pdf, _ncx2_cdf, get_distribution_names,
-        _lazyselect
-        )
+from ._distn_infrastructure import (get_distribution_names, _kurtosis,
+                                    _lazyselect, _lazywhere, _ncx2_cdf,
+                                    _ncx2_log_pdf, _ncx2_pdf,
+                                    rv_continuous, _skew, valarray)
 from ._constants import _XMIN, _EULER, _ZETA3, _XMAX, _LOGXMAX
 
 
@@ -43,10 +32,10 @@ class ksone_gen(rv_continuous):
 
     """
     def _cdf(self, x, n):
-        return 1.0 - special.smirnov(n, x)
+        return 1.0 - sc.smirnov(n, x)
 
     def _ppf(self, q, n):
-        return special.smirnovi(n, 1.0 - q)
+        return sc.smirnovi(n, 1.0 - q)
 ksone = ksone_gen(a=0.0, name='ksone')
 
 
@@ -57,13 +46,13 @@ class kstwobign_gen(rv_continuous):
 
     """
     def _cdf(self, x):
-        return 1.0 - special.kolmogorov(x)
+        return 1.0 - sc.kolmogorov(x)
 
     def _sf(self, x):
-        return special.kolmogorov(x)
+        return sc.kolmogorov(x)
 
     def _ppf(self, q):
-        return special.kolmogi(1.0-q)
+        return sc.kolmogi(1.0 - q)
 kstwobign = kstwobign_gen(a=0.0, name='kstwobign')
 
 
@@ -72,20 +61,28 @@ kstwobign = kstwobign_gen(a=0.0, name='kstwobign')
 # loc = mu, scale = std
 # Keep these implementations out of the class definition so they can be reused
 # by other distributions.
-_norm_pdf_C = np.sqrt(2*pi)
+_norm_pdf_C = np.sqrt(2*np.pi)
 _norm_pdf_logC = np.log(_norm_pdf_C)
 
 
 def _norm_pdf(x):
-    return exp(-x**2/2.0) / _norm_pdf_C
+    return np.exp(-x**2/2.0) / _norm_pdf_C
 
 
 def _norm_logpdf(x):
     return -x**2 / 2.0 - _norm_pdf_logC
 
 
+def _norm_cdf(x):
+    return sc.ndtr(x)
+
+
+def _norm_logcdf(x):
+    return sc.log_ndtr(x)
+
+
 def _norm_ppf(q):
-    return special.ndtri(q)
+    return sc.ndtri(q)
 
 
 def _norm_sf(x):
@@ -97,7 +94,7 @@ def _norm_logsf(x):
 
 
 def _norm_isf(q):
-    return -special.ndtri(q)
+    return -_norm_ppf(q)
 
 
 class norm_gen(rv_continuous):
@@ -154,7 +151,7 @@ class norm_gen(rv_continuous):
         return 0.0, 1.0, 0.0, 0.0
 
     def _entropy(self):
-        return 0.5*(log(2*pi)+1)
+        return 0.5*(np.log(2*np.pi)+1)
 
     @inherit_docstring_from(rv_continuous)
     def fit(self, data, **kwds):
@@ -216,16 +213,16 @@ class alpha_gen(rv_continuous):
         return 1.0/(x**2)/_norm_cdf(a)*_norm_pdf(a-1.0/x)
 
     def _logpdf(self, x, a):
-        return -2*log(x) + _norm_logpdf(a-1.0/x) - log(_norm_cdf(a))
+        return -2*np.log(x) + _norm_logpdf(a-1.0/x) - np.log(_norm_cdf(a))
 
     def _cdf(self, x, a):
         return _norm_cdf(a-1.0/x) / _norm_cdf(a)
 
     def _ppf(self, q, a):
-        return 1.0/asarray(a-special.ndtri(q*special.ndtr(a)))
+        return 1.0/np.asarray(a-sc.ndtri(q*_norm_cdf(a)))
 
     def _stats(self, a):
-        return [inf]*2 + [nan]*2
+        return [np.inf]*2 + [np.nan]*2
 alpha = alpha_gen(a=0.0, name='alpha')
 
 
@@ -248,20 +245,20 @@ class anglit_gen(rv_continuous):
 
     """
     def _pdf(self, x):
-        return cos(2*x)
+        return np.cos(2*x)
 
     def _cdf(self, x):
-        return sin(x+pi/4)**2.0
+        return np.sin(x+np.pi/4)**2.0
 
     def _ppf(self, q):
-        return (arcsin(sqrt(q))-pi/4)
+        return np.arcsin(np.sqrt(q))-np.pi/4
 
     def _stats(self):
-        return 0.0, pi*pi/16-0.5, 0.0, -2*(pi**4 - 96)/(pi*pi-8)**2
+        return 0.0, np.pi*np.pi/16-0.5, 0.0, -2*(np.pi**4 - 96)/(np.pi*np.pi-8)**2
 
     def _entropy(self):
-        return 1-log(2)
-anglit = anglit_gen(a=-pi/4, b=pi/4, name='anglit')
+        return 1-np.log(2)
+anglit = anglit_gen(a=-np.pi/4, b=np.pi/4, name='anglit')
 
 
 class arcsine_gen(rv_continuous):
@@ -285,13 +282,13 @@ class arcsine_gen(rv_continuous):
     _support_mask = rv_continuous._open_support_mask
 
     def _pdf(self, x):
-        return 1.0/pi/sqrt(x*(1-x))
+        return 1.0/np.pi/np.sqrt(x*(1-x))
 
     def _cdf(self, x):
-        return 2.0/pi*arcsin(sqrt(x))
+        return 2.0/np.pi*np.arcsin(np.sqrt(x))
 
     def _ppf(self, q):
-        return sin(pi/2.0*q)**2.0
+        return np.sin(np.pi/2.0*q)**2.0
 
     def _stats(self):
         mu = 0.5
@@ -331,8 +328,8 @@ def _beta_mle_a(a, b, n, s1):
     # The zeros of this function give the MLE for `a`, with
     # `b`, `n` and `s1` given.  `s1` is the sum of the logs of
     # the data. `n` is the number of data points.
-    psiab = special.psi(a + b)
-    func = s1 - n * (-psiab + special.psi(a))
+    psiab = sc.psi(a + b)
+    func = s1 - n * (-psiab + sc.psi(a))
     return func
 
 
@@ -344,9 +341,9 @@ def _beta_mle_ab(theta, n, s1, s2):
     # and `s2` is the sum of the logs of 1 - data.  `n` is the number
     # of data points.
     a, b = theta
-    psiab = special.psi(a + b)
-    func = [s1 - n * (-psiab + special.psi(a)),
-            s2 - n * (-psiab + special.psi(b))]
+    psiab = sc.psi(a + b)
+    func = [s1 - n * (-psiab + sc.psi(a)),
+            s2 - n * (-psiab + sc.psi(b))]
     return func
 
 
@@ -380,20 +377,20 @@ class beta_gen(rv_continuous):
         return np.exp(self._logpdf(x, a, b))
 
     def _logpdf(self, x, a, b):
-        lPx = special.xlog1py(b-1.0, -x) + special.xlogy(a-1.0, x)
-        lPx -= special.betaln(a, b)
+        lPx = sc.xlog1py(b - 1.0, -x) + sc.xlogy(a - 1.0, x)
+        lPx -= sc.betaln(a, b)
         return lPx
 
     def _cdf(self, x, a, b):
-        return special.btdtr(a, b, x)
+        return sc.btdtr(a, b, x)
 
     def _ppf(self, q, a, b):
-        return special.btdtri(a, b, q)
+        return sc.btdtri(a, b, q)
 
     def _stats(self, a, b):
         mn = a*1.0 / (a + b)
         var = (a*b*1.0)/(a+b+1.0)/(a+b)**2.0
-        g1 = 2.0*(b-a)*sqrt((1.0+a+b)/(a*b)) / (2+a+b)
+        g1 = 2.0*(b-a)*np.sqrt((1.0+a+b)/(a*b)) / (2+a+b)
         g2 = 6.0*(a**3 + a**2*(1-2*b) + b**2*(1+b) - 2*a*b*(2+b))
         g2 /= a*b*(a+b+2)*(a+b+3)
         return mn, var, g1, g2
@@ -404,7 +401,7 @@ class beta_gen(rv_continuous):
 
         def func(x):
             a, b = x
-            sk = 2*(b-a)*sqrt(a + b + 1) / (a + b + 2) / sqrt(a*b)
+            sk = 2*(b-a)*np.sqrt(a + b + 1) / (a + b + 2) / np.sqrt(a*b)
             ku = a**3 - a**2*(2*b-1) + b**2*(b+1) - 2*a*b*(b+2)
             ku /= a*b*(a+b+2)*(a+b+3)
             ku *= 6
@@ -445,7 +442,7 @@ class beta_gen(rv_continuous):
         # the Wikipedia article on the Beta distribution for the formulas.)
 
         # Normalize the data to the interval [0, 1].
-        data = (ravel(data) - floc) / fscale
+        data = (np.ravel(data) - floc) / fscale
         if np.any(data <= 0) or np.any(data >= 1):
             raise FitDataError("beta", lower=floc, upper=floc + fscale)
         xbar = data.mean()
@@ -540,30 +537,35 @@ class betaprime_gen(rv_continuous):
         sz, rndm = self._size, self._random_state
         u1 = gamma.rvs(a, size=sz, random_state=rndm)
         u2 = gamma.rvs(b, size=sz, random_state=rndm)
-        return (u1 / u2)
+        return u1 / u2
 
     def _pdf(self, x, a, b):
         return np.exp(self._logpdf(x, a, b))
 
     def _logpdf(self, x, a, b):
-        return (special.xlogy(a-1.0, x) - special.xlog1py(a+b, x) -
-                special.betaln(a, b))
+        return sc.xlogy(a - 1.0, x) - sc.xlog1py(a + b, x) - sc.betaln(a, b)
 
     def _cdf(self, x, a, b):
-        return special.betainc(a, b, x/(1.+x))
+        return sc.betainc(a, b, x/(1.+x))
 
     def _munp(self, n, a, b):
-        if (n == 1.0):
-            return where(b > 1, a/(b-1.0), inf)
-        elif (n == 2.0):
-            return where(b > 2, a*(a+1.0)/((b-2.0)*(b-1.0)), inf)
-        elif (n == 3.0):
-            return where(b > 3, a*(a+1.0)*(a+2.0)/((b-3.0)*(b-2.0)*(b-1.0)),
-                         inf)
-        elif (n == 4.0):
-            return where(b > 4,
-                         a*(a+1.0)*(a+2.0)*(a+3.0)/((b-4.0)*(b-3.0)
-                                                    * (b-2.0)*(b-1.0)), inf)
+        if n == 1.0:
+            return np.where(b > 1,
+                            a/(b-1.0),
+                            np.inf)
+        elif n == 2.0:
+            return np.where(b > 2,
+                            a*(a+1.0)/((b-2.0)*(b-1.0)),
+                            np.inf)
+        elif n == 3.0:
+            return np.where(b > 3,
+                            a*(a+1.0)*(a+2.0)/((b-3.0)*(b-2.0)*(b-1.0)),
+                            np.inf)
+        elif n == 4.0:
+            return np.where(b > 4,
+                            (a*(a + 1.0)*(a + 2.0)*(a + 3.0) /
+                             ((b - 4.0)*(b - 3.0)*(b - 2.0)*(b - 1.0))),
+                            np.inf)
         else:
             raise NotImplementedError
 betaprime = betaprime_gen(a=0.0, name='betaprime')
@@ -590,23 +592,23 @@ class bradford_gen(rv_continuous):
 
     """
     def _pdf(self, x, c):
-        return c / (c*x + 1.0) / special.log1p(c)
+        return c / (c*x + 1.0) / sc.log1p(c)
 
     def _cdf(self, x, c):
-        return special.log1p(c * x) / special.log1p(c)
+        return sc.log1p(c*x) / sc.log1p(c)
 
     def _ppf(self, q, c):
-        return special.expm1(q * special.log1p(c)) / c
+        return sc.expm1(q * sc.log1p(c)) / c
 
     def _stats(self, c, moments='mv'):
-        k = log(1.0+c)
+        k = np.log(1.0+c)
         mu = (c-k)/(c*k)
         mu2 = ((c+2.0)*k-2.0*c)/(2*c*k*k)
         g1 = None
         g2 = None
         if 's' in moments:
-            g1 = sqrt(2)*(12*c*c-9*c*k*(c+2)+2*k*k*(c*(c+3)+3))
-            g1 /= sqrt(c*(c*(k-2)+2*k))*(3*c*(k-2)+6*k)
+            g1 = np.sqrt(2)*(12*c*c-9*c*k*(c+2)+2*k*k*(c*(c+3)+3))
+            g1 /= np.sqrt(c*(c*(k-2)+2*k))*(3*c*(k-2)+6*k)
         if 'k' in moments:
             g2 = (c**3*(k-3)*(k*(3*k-16)+24)+12*k*c*c*(k-4)*(k-3)
                   + 6*c*k*k*(3*k-14) + 12*k**3)
@@ -614,8 +616,8 @@ class bradford_gen(rv_continuous):
         return mu, mu2, g1, g2
 
     def _entropy(self, c):
-        k = log(1+c)
-        return k/2.0 - log(c/k)
+        k = np.log(1+c)
+        return k/2.0 - np.log(c/k)
 bradford = bradford_gen(a=0.0, b=1.0, name='bradford')
 
 
@@ -665,7 +667,7 @@ class burr_gen(rv_continuous):
 
     def _munp(self, n, c, d):
         nc = 1. * n / c
-        return d * special.beta(1.0 - nc, d + nc)
+        return d * sc.beta(1.0 - nc, d + nc)
 burr = burr_gen(a=0.0, name='burr')
 
 
@@ -713,26 +715,26 @@ class burr12_gen(rv_continuous):
         return np.exp(self._logpdf(x, c, d))
 
     def _logpdf(self, x, c, d):
-        return log(c) + log(d) + special.xlogy(c-1, x) + special.xlog1py(-d-1, x**c)
+        return np.log(c) + np.log(d) + sc.xlogy(c - 1, x) + sc.xlog1py(-d-1, x**c)
 
     def _cdf(self, x, c, d):
-        return -special.expm1(self._logsf(x, c, d))
+        return -sc.expm1(self._logsf(x, c, d))
 
     def _logcdf(self, x, c, d):
-        return special.log1p(-(1 + x**c)**(-d))
+        return sc.log1p(-(1 + x**c)**(-d))
 
     def _sf(self, x, c, d):
         return np.exp(self._logsf(x, c, d))
 
     def _logsf(self, x, c, d):
-        return special.xlog1py(-d, x**c)
+        return sc.xlog1py(-d, x**c)
 
     def _ppf(self, q, c, d):
         return ((1 - q)**(-1.0/d) - 1)**(1.0/c)
 
     def _munp(self, n, c, d):
         nc = 1. * n / c
-        return d * special.beta(1.0 + nc, d - nc)
+        return d * sc.beta(1.0 + nc, d - nc)
 burr12 = burr12_gen(a=0.0, name='burr12')
 
 
@@ -778,7 +780,7 @@ class fisk_gen(burr_gen):
         return burr_gen._munp(self, n, c, 1.0)
 
     def _entropy(self, c):
-        return 2 - log(c)
+        return 2 - np.log(c)
 fisk = fisk_gen(a=0.0, name='fisk')
 
 
@@ -800,25 +802,25 @@ class cauchy_gen(rv_continuous):
 
     """
     def _pdf(self, x):
-        return 1.0/pi/(1.0+x*x)
+        return 1.0/np.pi/(1.0+x*x)
 
     def _cdf(self, x):
-        return 0.5 + 1.0/pi*arctan(x)
+        return 0.5 + 1.0/np.pi*np.arctan(x)
 
     def _ppf(self, q):
-        return tan(pi*q-pi/2.0)
+        return np.tan(np.pi*q-np.pi/2.0)
 
     def _sf(self, x):
-        return 0.5 - 1.0/pi*arctan(x)
+        return 0.5 - 1.0/np.pi*np.arctan(x)
 
     def _isf(self, q):
-        return tan(pi/2.0-pi*q)
+        return np.tan(np.pi/2.0-np.pi*q)
 
     def _stats(self):
-        return nan, nan, nan, nan
+        return np.nan, np.nan, np.nan, np.nan
 
     def _entropy(self):
-        return log(4*pi)
+        return np.log(4*np.pi)
 
     def _fitstart(self, data, args=None):
         # Initialize ML guesses using quartiles instead of moments.
@@ -856,27 +858,27 @@ class chi_gen(rv_continuous):
 
     def _rvs(self, df):
         sz, rndm = self._size, self._random_state
-        return sqrt(chi2.rvs(df, size=sz, random_state=rndm))
+        return np.sqrt(chi2.rvs(df, size=sz, random_state=rndm))
 
     def _pdf(self, x, df):
         return np.exp(self._logpdf(x, df))
 
     def _logpdf(self, x, df):
-        l = np.log(2) - .5*np.log(2)*df - special.gammaln(.5*df)
-        return l + special.xlogy(df-1.,x) - .5*x**2
+        l = np.log(2) - .5*np.log(2)*df - sc.gammaln(.5*df)
+        return l + sc.xlogy(df - 1., x) - .5*x**2
 
     def _cdf(self, x, df):
-        return special.gammainc(.5*df, .5*x**2)
+        return sc.gammainc(.5*df, .5*x**2)
 
     def _ppf(self, q, df):
-        return sqrt(2*special.gammaincinv(.5*df, q))
+        return np.sqrt(2*sc.gammaincinv(.5*df, q))
 
     def _stats(self, df):
-        mu = sqrt(2)*special.gamma(df/2.0+0.5)/special.gamma(df/2.0)
+        mu = np.sqrt(2)*sc.gamma(df/2.0+0.5)/sc.gamma(df/2.0)
         mu2 = df - mu*mu
-        g1 = (2*mu**3.0 + mu*(1-2*df))/asarray(np.power(mu2, 1.5))
+        g1 = (2*mu**3.0 + mu*(1-2*df))/np.asarray(np.power(mu2, 1.5))
         g2 = 2*df*(1.0-df)-6*mu**4 + 4*mu**2 * (2*df-1)
-        g2 /= asarray(mu2**2.0)
+        g2 /= np.asarray(mu2**2.0)
         return mu, mu2, g1, g2
 chi = chi_gen(a=0.0, name='chi')
 
@@ -904,19 +906,19 @@ class chi2_gen(rv_continuous):
         return self._random_state.chisquare(df, self._size)
 
     def _pdf(self, x, df):
-        return exp(self._logpdf(x, df))
+        return np.exp(self._logpdf(x, df))
 
     def _logpdf(self, x, df):
-        return special.xlogy(df/2.-1, x) - x/2. - gamln(df/2.) - (log(2)*df)/2.
+        return sc.xlogy(df/2.-1, x) - x/2. - sc.gammaln(df/2.) - (np.log(2)*df)/2.
 
     def _cdf(self, x, df):
-        return special.chdtr(df, x)
+        return sc.chdtr(df, x)
 
     def _sf(self, x, df):
-        return special.chdtrc(df, x)
+        return sc.chdtrc(df, x)
 
     def _isf(self, p, df):
-        return special.chdtri(df, p)
+        return sc.chdtri(df, p)
 
     def _ppf(self, p, df):
         return self._isf(1.0-p, df)
@@ -924,7 +926,7 @@ class chi2_gen(rv_continuous):
     def _stats(self, df):
         mu = df
         mu2 = 2*df
-        g1 = 2*sqrt(2.0/df)
+        g1 = 2*np.sqrt(2.0/df)
         g2 = 12.0/df
         return mu, mu2, g1, g2
 chi2 = chi2_gen(a=0.0, name='chi2')
@@ -950,17 +952,17 @@ class cosine_gen(rv_continuous):
 
     """
     def _pdf(self, x):
-        return 1.0/2/pi*(1+cos(x))
+        return 1.0/2/np.pi*(1+np.cos(x))
 
     def _cdf(self, x):
-        return 1.0/2/pi*(pi + x + sin(x))
+        return 1.0/2/np.pi*(np.pi + x + np.sin(x))
 
     def _stats(self):
-        return 0.0, pi*pi/3.0-2.0, 0.0, -6.0*(pi**4-90)/(5.0*(pi*pi-6)**2)
+        return 0.0, np.pi*np.pi/3.0-2.0, 0.0, -6.0*(np.pi**4-90)/(5.0*(np.pi*np.pi-6)**2)
 
     def _entropy(self):
-        return log(4*pi)-1.0
-cosine = cosine_gen(a=-pi, b=pi, name='cosine')
+        return np.log(4*np.pi)-1.0
+cosine = cosine_gen(a=-np.pi, b=np.pi, name='cosine')
 
 
 class dgamma_gen(rv_continuous):
@@ -987,27 +989,27 @@ class dgamma_gen(rv_continuous):
         sz, rndm = self._size, self._random_state
         u = rndm.random_sample(size=sz)
         gm = gamma.rvs(a, size=sz, random_state=rndm)
-        return gm * where(u >= 0.5, 1, -1)
+        return gm * np.where(u >= 0.5, 1, -1)
 
     def _pdf(self, x, a):
         ax = abs(x)
-        return 1.0/(2*special.gamma(a))*ax**(a-1.0) * exp(-ax)
+        return 1.0/(2*sc.gamma(a))*ax**(a-1.0) * np.exp(-ax)
 
     def _logpdf(self, x, a):
         ax = abs(x)
-        return special.xlogy(a-1.0, ax) - ax - log(2) - gamln(a)
+        return sc.xlogy(a - 1.0, ax) - ax - np.log(2) - sc.gammaln(a)
 
     def _cdf(self, x, a):
-        fac = 0.5*special.gammainc(a, abs(x))
-        return where(x > 0, 0.5 + fac, 0.5 - fac)
+        fac = 0.5*sc.gammainc(a, abs(x))
+        return np.where(x > 0, 0.5 + fac, 0.5 - fac)
 
     def _sf(self, x, a):
-        fac = 0.5*special.gammainc(a, abs(x))
-        return where(x > 0, 0.5-fac, 0.5+fac)
+        fac = 0.5*sc.gammainc(a, abs(x))
+        return np.where(x > 0, 0.5-fac, 0.5+fac)
 
     def _ppf(self, q, a):
-        fac = special.gammainccinv(a, 1-abs(2*q-1))
-        return where(q > 0.5, fac, -fac)
+        fac = sc.gammainccinv(a, 1-abs(2*q-1))
+        return np.where(q > 0.5, fac, -fac)
 
     def _stats(self, a):
         mu2 = a*(a+1.0)
@@ -1037,28 +1039,28 @@ class dweibull_gen(rv_continuous):
         sz, rndm = self._size, self._random_state
         u = rndm.random_sample(size=sz)
         w = weibull_min.rvs(c, size=sz, random_state=rndm)
-        return w * (where(u >= 0.5, 1, -1))
+        return w * (np.where(u >= 0.5, 1, -1))
 
     def _pdf(self, x, c):
         ax = abs(x)
-        Px = c / 2.0 * ax**(c-1.0) * exp(-ax**c)
+        Px = c / 2.0 * ax**(c-1.0) * np.exp(-ax**c)
         return Px
 
     def _logpdf(self, x, c):
         ax = abs(x)
-        return log(c) - log(2.0) + special.xlogy(c - 1.0, ax) - ax**c
+        return np.log(c) - np.log(2.0) + sc.xlogy(c - 1.0, ax) - ax**c
 
     def _cdf(self, x, c):
-        Cx1 = 0.5 * exp(-abs(x)**c)
-        return where(x > 0, 1 - Cx1, Cx1)
+        Cx1 = 0.5 * np.exp(-abs(x)**c)
+        return np.where(x > 0, 1 - Cx1, Cx1)
 
     def _ppf(self, q, c):
-        fac = 2. * where(q <= 0.5, q, 1. - q)
-        fac = np.power(-log(fac), 1.0 / c)
-        return where(q > 0.5, fac, -fac)
+        fac = 2. * np.where(q <= 0.5, q, 1. - q)
+        fac = np.power(-np.log(fac), 1.0 / c)
+        return np.where(q > 0.5, fac, -fac)
 
     def _munp(self, n, c):
-        return (1 - (n % 2)) * special.gamma(1.0 + 1.0 * n / c)
+        return (1 - (n % 2)) * sc.gamma(1.0 + 1.0 * n / c)
 
     # since we know that all odd moments are zeros, return them at once.
     # returning Nones from _stats makes the public stats call _munp
@@ -1095,25 +1097,25 @@ class expon_gen(rv_continuous):
         return self._random_state.standard_exponential(self._size)
 
     def _pdf(self, x):
-        return exp(-x)
+        return np.exp(-x)
 
     def _logpdf(self, x):
         return -x
 
     def _cdf(self, x):
-        return -special.expm1(-x)
+        return -sc.expm1(-x)
 
     def _ppf(self, q):
-        return -special.log1p(-q)
+        return -sc.log1p(-q)
 
     def _sf(self, x):
-        return exp(-x)
+        return np.exp(-x)
 
     def _logsf(self, x):
         return -x
 
     def _isf(self, q):
-        return -log(q)
+        return -np.log(q)
 
     def _stats(self):
         return 1.0, 1.0, 2.0, 6.0
@@ -1135,7 +1137,8 @@ class exponnorm_gen(rv_continuous):
     -----
     The probability density function for `exponnorm` is::
 
-        exponnorm.pdf(x, K) = 1/(2*K) exp(1/(2 * K**2)) exp(-x / K) * erfc(-(x - 1/K) / sqrt(2))
+        exponnorm.pdf(x, K) =
+            1/(2*K) exp(1/(2 * K**2)) exp(-x / K) * erfc-(x - 1/K) / sqrt(2))
 
     where the shape parameter ``K > 0``.
 
@@ -1166,25 +1169,25 @@ class exponnorm_gen(rv_continuous):
     def _pdf(self, x, K):
         invK = 1.0 / K
         exparg = 0.5 * invK**2 - invK * x
-        # Avoid overflows; setting exp(exparg) to the max float works
+        # Avoid overflows; setting np.exp(exparg) to the max float works
         #  all right here
-        expval = _lazywhere(exparg < _LOGXMAX, (exparg,), exp, _XMAX)
-        return 0.5 * invK * expval * erfc(-(x - invK) / sqrt(2))
+        expval = _lazywhere(exparg < _LOGXMAX, (exparg,), np.exp, _XMAX)
+        return 0.5 * invK * expval * sc.erfc(-(x - invK) / np.sqrt(2))
 
     def _logpdf(self, x, K):
         invK = 1.0 / K
         exparg = 0.5 * invK**2 - invK * x
-        return exparg + log(0.5 * invK * erfc(-(x - invK) / sqrt(2)))
+        return exparg + np.log(0.5 * invK * sc.erfc(-(x - invK) / np.sqrt(2)))
 
     def _cdf(self, x, K):
         invK = 1.0 / K
         expval = invK * (0.5 * invK - x)
-        return _norm_cdf(x) - exp(expval) * _norm_cdf(x - invK)
+        return _norm_cdf(x) - np.exp(expval) * _norm_cdf(x - invK)
 
     def _sf(self, x, K):
         invK = 1.0 / K
         expval = invK * (0.5 * invK - x)
-        return _norm_cdf(-x) + exp(expval) * _norm_cdf(x - invK)
+        return _norm_cdf(-x) + np.exp(expval) * _norm_cdf(x - invK)
 
     def _stats(self, K):
         K2 = K * K
@@ -1217,21 +1220,21 @@ class exponweib_gen(rv_continuous):
 
     """
     def _pdf(self, x, a, c):
-        return exp(self._logpdf(x, a, c))
+        return np.exp(self._logpdf(x, a, c))
 
     def _logpdf(self, x, a, c):
         negxc = -x**c
-        exm1c = -special.expm1(negxc)
-        logp = (log(a) + log(c) + special.xlogy(a - 1.0, exm1c) +
-                negxc + special.xlogy(c - 1.0, x))
+        exm1c = -sc.expm1(negxc)
+        logp = (np.log(a) + np.log(c) + sc.xlogy(a - 1.0, exm1c) +
+                negxc + sc.xlogy(c - 1.0, x))
         return logp
 
     def _cdf(self, x, a, c):
-        exm1c = -special.expm1(-x**c)
+        exm1c = -sc.expm1(-x**c)
         return exm1c**a
 
     def _ppf(self, q, a, c):
-        return (-special.log1p(-q**(1.0/a)))**asarray(1.0/c)
+        return (-sc.log1p(-q**(1.0/a)))**np.asarray(1.0/c)
 exponweib = exponweib_gen(a=0.0, name='exponweib')
 
 
@@ -1262,24 +1265,24 @@ class exponpow_gen(rv_continuous):
 
     """
     def _pdf(self, x, b):
-        return exp(self._logpdf(x, b))
+        return np.exp(self._logpdf(x, b))
 
     def _logpdf(self, x, b):
         xb = x**b
-        f = 1 + log(b) + special.xlogy(b - 1.0, x) + xb - exp(xb)
+        f = 1 + np.log(b) + sc.xlogy(b - 1.0, x) + xb - np.exp(xb)
         return f
 
     def _cdf(self, x, b):
-        return -special.expm1(-special.expm1(x**b))
+        return -sc.expm1(-sc.expm1(x**b))
 
     def _sf(self, x, b):
-        return exp(-special.expm1(x**b))
+        return np.exp(-sc.expm1(x**b))
 
     def _isf(self, x, b):
-        return (special.log1p(-log(x)))**(1./b)
+        return (sc.log1p(-np.log(x)))**(1./b)
 
     def _ppf(self, q, b):
-        return pow(special.log1p(-special.log1p(-q)), 1.0/b)
+        return pow(sc.log1p(-sc.log1p(-q)), 1.0/b)
 exponpow = exponpow_gen(a=0.0, name='exponpow')
 
 
@@ -1315,22 +1318,22 @@ class fatiguelife_gen(rv_continuous):
         z = self._random_state.standard_normal(self._size)
         x = 0.5*c*z
         x2 = x*x
-        t = 1.0 + 2*x2 + 2*x*sqrt(1 + x2)
+        t = 1.0 + 2*x2 + 2*x*np.sqrt(1 + x2)
         return t
 
     def _pdf(self, x, c):
         return np.exp(self._logpdf(x, c))
 
     def _logpdf(self, x, c):
-        return (log(x+1) - (x-1)**2 / (2.0*x*c**2) - log(2*c) -
-                0.5*(log(2*pi) + 3*log(x)))
+        return (np.log(x+1) - (x-1)**2 / (2.0*x*c**2) - np.log(2*c) -
+                0.5*(np.log(2*np.pi) + 3*np.log(x)))
 
     def _cdf(self, x, c):
-        return _norm_cdf(1.0 / c * (sqrt(x) - 1.0/sqrt(x)))
+        return _norm_cdf(1.0 / c * (np.sqrt(x) - 1.0/np.sqrt(x)))
 
     def _ppf(self, q, c):
-        tmp = c*special.ndtri(q)
-        return 0.25 * (tmp + sqrt(tmp**2 + 4))**2
+        tmp = c*sc.ndtri(q)
+        return 0.25 * (tmp + np.sqrt(tmp**2 + 4))**2
 
     def _stats(self, c):
         # NB: the formula for kurtosis in wikipedia seems to have an error:
@@ -1371,13 +1374,13 @@ class foldcauchy_gen(rv_continuous):
                               random_state=self._random_state))
 
     def _pdf(self, x, c):
-        return 1.0/pi*(1.0/(1+(x-c)**2) + 1.0/(1+(x+c)**2))
+        return 1.0/np.pi*(1.0/(1+(x-c)**2) + 1.0/(1+(x+c)**2))
 
     def _cdf(self, x, c):
-        return 1.0/pi*(arctan(x-c) + arctan(x+c))
+        return 1.0/np.pi*(np.arctan(x-c) + np.arctan(x+c))
 
     def _stats(self, c):
-        return inf, inf, nan, nan
+        return np.inf, np.inf, np.nan, np.nan
 foldcauchy = foldcauchy_gen(a=0.0, name='foldcauchy')
 
 
@@ -1407,23 +1410,23 @@ class f_gen(rv_continuous):
         return self._random_state.f(dfn, dfd, self._size)
 
     def _pdf(self, x, dfn, dfd):
-        return exp(self._logpdf(x, dfn, dfd))
+        return np.exp(self._logpdf(x, dfn, dfd))
 
     def _logpdf(self, x, dfn, dfd):
         n = 1.0 * dfn
         m = 1.0 * dfd
-        lPx = m/2 * log(m) + n/2 * log(n) + (n/2 - 1) * log(x)
-        lPx -= ((n+m)/2) * log(m + n*x) + special.betaln(n/2, m/2)
+        lPx = m/2 * np.log(m) + n/2 * np.log(n) + (n/2 - 1) * np.log(x)
+        lPx -= ((n+m)/2) * np.log(m + n*x) + sc.betaln(n/2, m/2)
         return lPx
 
     def _cdf(self, x, dfn, dfd):
-        return special.fdtr(dfn, dfd, x)
+        return sc.fdtr(dfn, dfd, x)
 
     def _sf(self, x, dfn, dfd):
-        return special.fdtrc(dfn, dfd, x)
+        return sc.fdtrc(dfn, dfd, x)
 
     def _ppf(self, q, dfn, dfd):
-        return special.fdtri(dfn, dfd, q)
+        return sc.fdtri(dfn, dfd, q)
 
     def _stats(self, dfn, dfd):
         v1, v2 = 1. * dfn, 1. * dfd
@@ -1443,7 +1446,7 @@ class f_gen(rv_continuous):
         g1 = _lazywhere(
             v2 > 6, (v1, v2_2, v2_4, v2_6),
             lambda v1, v2_2, v2_4, v2_6:
-            (2 * v1 + v2_2) / v2_6 * sqrt(v2_4 / (v1 * (v1 + v2_2))),
+            (2 * v1 + v2_2) / v2_6 * np.sqrt(v2_4 / (v1 * (v1 + v2_2))),
             np.nan)
         g1 *= np.sqrt(8.)
 
@@ -1486,7 +1489,7 @@ class foldnorm_gen(rv_continuous):
 
     """
     def _argcheck(self, c):
-        return (c >= 0)
+        return c >= 0
 
     def _rvs(self, c):
         return abs(self._random_state.standard_normal(self._size) + c)
@@ -1502,9 +1505,9 @@ class foldnorm_gen(rv_continuous):
         # http://www.jstor.org/stable/1266561
         #
         c2 = c*c
-        expfac = np.exp(-0.5*c2) / np.sqrt(2.*pi)
+        expfac = np.exp(-0.5*c2) / np.sqrt(2.*np.pi)
 
-        mu = 2.*expfac + c * special.erf(c/sqrt(2))
+        mu = 2.*expfac + c * sc.erf(c/np.sqrt(2))
         mu2 = c2 + 1 - mu*mu
 
         g1 = 2. * (mu*mu*mu - c2*mu - expfac)
@@ -1549,29 +1552,28 @@ class frechet_r_gen(rv_continuous):
     """
 
     def _pdf(self, x, c):
-        return c*pow(x, c-1)*exp(-pow(x, c))
+        return c*pow(x, c-1)*np.exp(-pow(x, c))
 
     def _logpdf(self, x, c):
-        return log(c) + special.xlogy(c - 1, x) - pow(x, c)
+        return np.log(c) + sc.xlogy(c - 1, x) - pow(x, c)
 
     def _cdf(self, x, c):
-        return -special.expm1(-pow(x, c))
+        return -sc.expm1(-pow(x, c))
 
     def _sf(self, x, c):
-        return exp(-pow(x, c))
+        return np.exp(-pow(x, c))
 
     def _logsf(self, x, c):
         return -pow(x, c)
 
     def _ppf(self, q, c):
-        return pow(-special.log1p(-q), 1.0/c)
+        return pow(-sc.log1p(-q), 1.0/c)
 
     def _munp(self, n, c):
-        return special.gamma(1.0+n*1.0/c)
+        return sc.gamma(1.0+n*1.0/c)
 
     def _entropy(self, c):
-        return -_EULER / c - log(c) + _EULER + 1
-
+        return -_EULER / c - np.log(c) + _EULER + 1
 frechet_r = frechet_r_gen(a=0.0, name='frechet_r')
 weibull_min = frechet_r_gen(a=0.0, name='weibull_min')
 
@@ -1602,34 +1604,33 @@ class frechet_l_gen(rv_continuous):
 
     """
     def _pdf(self, x, c):
-        return c*pow(-x, c-1)*exp(-pow(-x, c))
+        return c*pow(-x, c-1)*np.exp(-pow(-x, c))
 
     def _logpdf(self, x, c):
-        return log(c) + special.xlogy(c-1, -x) - pow(-x, c)
+        return np.log(c) + sc.xlogy(c-1, -x) - pow(-x, c)
 
     def _cdf(self, x, c):
-        return exp(-pow(-x, c))
+        return np.exp(-pow(-x, c))
 
     def _logcdf(self, x, c):
         return -pow(-x, c)
 
     def _sf(self, x, c):
-        return -special.expm1(-pow(-x, c))
+        return -sc.expm1(-pow(-x, c))
 
     def _ppf(self, q, c):
-        return -pow(-log(q), 1.0/c)
+        return -pow(-np.log(q), 1.0/c)
 
     def _munp(self, n, c):
-        val = special.gamma(1.0+n*1.0/c)
-        if (int(n) % 2):
+        val = sc.gamma(1.0+n*1.0/c)
+        if int(n) % 2:
             sgn = -1
         else:
             sgn = 1
         return sgn * val
 
     def _entropy(self, c):
-        return -_EULER / c - log(c) + _EULER + 1
-
+        return -_EULER / c - np.log(c) + _EULER + 1
 frechet_l = frechet_l_gen(b=0.0, name='frechet_l')
 weibull_max = frechet_l_gen(b=0.0, name='weibull_max')
 
@@ -1655,26 +1656,25 @@ class genlogistic_gen(rv_continuous):
 
     """
     def _pdf(self, x, c):
-        return exp(self._logpdf(x, c))
+        return np.exp(self._logpdf(x, c))
 
     def _logpdf(self, x, c):
-        return log(c) - x - (c+1.0)*special.log1p(exp(-x))
+        return np.log(c) - x - (c+1.0)*sc.log1p(np.exp(-x))
 
     def _cdf(self, x, c):
-        Cx = (1+exp(-x))**(-c)
+        Cx = (1+np.exp(-x))**(-c)
         return Cx
 
     def _ppf(self, q, c):
-        vals = -log(pow(q, -1.0/c)-1)
+        vals = -np.log(pow(q, -1.0/c)-1)
         return vals
 
     def _stats(self, c):
-        zeta = special.zeta
-        mu = _EULER + special.psi(c)
-        mu2 = pi*pi/6.0 + zeta(2, c)
-        g1 = -2*zeta(3, c) + 2*_ZETA3
+        mu = _EULER + sc.psi(c)
+        mu2 = np.pi*np.pi/6.0 + sc.zeta(2, c)
+        g1 = -2*sc.zeta(3, c) + 2*_ZETA3
         g1 /= np.power(mu2, 1.5)
-        g2 = pi**4/15.0 + 6*zeta(4, c)
+        g2 = np.pi**4/15.0 + 6*sc.zeta(4, c)
         g2 /= mu2**2.0
         return mu, mu2, g1, g2
 genlogistic = genlogistic_gen(name='genlogistic')
@@ -1711,9 +1711,10 @@ class genpareto_gen(rv_continuous):
 
     """
     def _argcheck(self, c):
-        c = asarray(c)
+        c = np.asarray(c)
         self.b = _lazywhere(c < 0, (c,),
-                lambda c: -1. / c, np.inf)
+                            lambda c: -1. / c,
+                            np.inf)
         return True
 
     def _pdf(self, x, c):
@@ -1721,36 +1722,36 @@ class genpareto_gen(rv_continuous):
 
     def _logpdf(self, x, c):
         return _lazywhere((x == x) & (c != 0), (x, c),
-            lambda x, c: -special.xlog1py(c+1., c*x) / c,
-            -x)
+                          lambda x, c: -sc.xlog1py(c + 1., c*x) / c,
+                          -x)
 
     def _cdf(self, x, c):
-        return -inv_boxcox1p(-x, -c)
+        return -sc.inv_boxcox1p(-x, -c)
 
     def _sf(self, x, c):
-        return inv_boxcox(-x, -c)
+        return sc.inv_boxcox(-x, -c)
 
     def _logsf(self, x, c):
         return _lazywhere((x == x) & (c != 0), (x, c),
-            lambda x, c: -special.log1p(c*x) / c,
-            -x)
+                          lambda x, c: -sc.log1p(c*x) / c,
+                          -x)
 
     def _ppf(self, q, c):
-        return -boxcox1p(-q, -c)
+        return -sc.boxcox1p(-q, -c)
 
     def _isf(self, q, c):
-        return -boxcox(q, -c)
+        return -sc.boxcox(q, -c)
 
     def _munp(self, n, c):
         def __munp(n, c):
             val = 0.0
-            k = arange(0, n + 1)
-            for ki, cnk in zip(k, comb(n, k)):
+            k = np.arange(0, n + 1)
+            for ki, cnk in zip(k, sc.comb(n, k)):
                 val = val + cnk * (-1) ** ki / (1.0 - c * ki)
-            return where(c * n < 1, val * (-1.0 / c) ** n, inf)
+            return np.where(c * n < 1, val * (-1.0 / c) ** n, np.inf)
         return _lazywhere(c != 0, (c,),
-                lambda c: __munp(n, c),
-                gam(n + 1))
+                          lambda c: __munp(n, c),
+                          sc.gamma(n + 1))
 
     def _entropy(self, c):
         return 1. + c
@@ -1780,22 +1781,21 @@ class genexpon_gen(rv_continuous):
     H.K. Ryu, "An Extension of Marshall and Olkin's Bivariate Exponential
     Distribution", Journal of the American Statistical Association, 1993.
 
-     N. Balakrishnan, "The Exponential Distribution: Theory, Methods and
-     Applications", Asit P. Basu.
+    N. Balakrishnan, "The Exponential Distribution: Theory, Methods and
+    Applications", Asit P. Basu.
 
     %(example)s
 
     """
     def _pdf(self, x, a, b, c):
-        return (a + b*(-special.expm1(-c*x)))*exp((-a-b)*x +
-            b*(-special.expm1(-c*x))/c)
+        return (a + b*(-sc.expm1(-c*x)))*np.exp((-a-b)*x +
+                                                b*(-sc.expm1(-c*x))/c)
 
     def _cdf(self, x, a, b, c):
-        return -special.expm1((-a-b)*x + b*(-special.expm1(-c*x))/c)
+        return -sc.expm1((-a-b)*x + b*(-sc.expm1(-c*x))/c)
 
     def _logpdf(self, x, a, b, c):
-        return np.log(a+b*(-special.expm1(-c*x))) + \
-                (-a-b)*x+b*(-special.expm1(-c*x))/c
+        return np.log(a+b*(-sc.expm1(-c*x))) + (-a-b)*x+b*(-sc.expm1(-c*x))/c
 genexpon = genexpon_gen(a=0.0, name='genexpon')
 
 
@@ -1828,73 +1828,73 @@ class genextreme_gen(rv_continuous):
 
     """
     def _argcheck(self, c):
-        min = np.minimum
-        max = np.maximum
-        self.b = where(c > 0, 1.0 / max(c, _XMIN), inf)
-        self.a = where(c < 0, 1.0 / min(c, -_XMIN), -inf)
-        return where(abs(c) == inf, 0, 1)
+        self.b = np.where(c > 0, 1.0 / np.maximum(c, _XMIN), np.inf)
+        self.a = np.where(c < 0, 1.0 / np.minimum(c, -_XMIN), -np.inf)
+        return np.where(abs(c) == np.inf, 0, 1)
 
     def _loglogcdf(self, x, c):
         return _lazywhere((x == x) & (c != 0), (x, c),
-                          lambda x, c: special.log1p(-c*x)/c, -x)
+                          lambda x, c: sc.log1p(-c*x)/c, -x)
 
     def _pdf(self, x, c):
-        return exp(self._logpdf(x, c))
+        return np.exp(self._logpdf(x, c))
 
     def _logpdf(self, x, c):
         cx = _lazywhere((x == x) & (c != 0), (x, c), lambda x, c: c*x, 0.0)
-        logex2 = special.log1p(-cx)
+        logex2 = sc.log1p(-cx)
         logpex2 = self._loglogcdf(x, c)
-        pex2 = exp(logpex2)
+        pex2 = np.exp(logpex2)
         # Handle special cases
-        putmask(logpex2, (c == 0) & (x == -inf), 0.0)
-        logpdf = where((cx == 1) | (cx == -inf), -inf, -pex2+logpex2-logex2)
-        putmask(logpdf, (c == 1) & (x == 1), 0.0)
+        np.putmask(logpex2, (c == 0) & (x == -np.inf), 0.0)
+        logpdf = np.where((cx == 1) | (cx == -np.inf),
+                          -np.inf,
+                          -pex2+logpex2-logex2)
+        np.putmask(logpdf, (c == 1) & (x == 1), 0.0)
         return logpdf
 
     def _logcdf(self, x, c):
-        return -exp(self._loglogcdf(x, c))
+        return -np.exp(self._loglogcdf(x, c))
 
     def _cdf(self, x, c):
-        return exp(self._logcdf(x, c))
+        return np.exp(self._logcdf(x, c))
 
     def _sf(self, x, c):
-        return -special.expm1(self._logcdf(x, c))
+        return -sc.expm1(self._logcdf(x, c))
 
     def _ppf(self, q, c):
-        x = -log(-log(q))
+        x = -np.log(-np.log(q))
         return _lazywhere((x == x) & (c != 0), (x, c),
-                          lambda x, c: -special.expm1(-c * x) / c, x)
+                          lambda x, c: -sc.expm1(-c * x) / c, x)
 
     def _isf(self, q, c):
-        x = -log(-special.log1p(-q))
+        x = -np.log(-sc.log1p(-q))
         return _lazywhere((x == x) & (c != 0), (x, c),
-                          lambda x, c: -special.expm1(-c * x) / c, x)
+                          lambda x, c: -sc.expm1(-c * x) / c, x)
 
     def _stats(self, c):
-        g = lambda n: gam(n*c+1)
+        g = lambda n: sc.gamma(n*c + 1)
         g1 = g(1)
         g2 = g(2)
         g3 = g(3)
         g4 = g(4)
-        g2mg12 = where(abs(c) < 1e-7, (c*pi)**2.0/6.0, g2-g1**2.0)
-        gam2k = where(abs(c) < 1e-7, pi**2.0/6.0,
-                      special.expm1(gamln(2.0*c+1.0)-2*gamln(c+1.0))/c**2.0)
+        g2mg12 = np.where(abs(c) < 1e-7, (c*np.pi)**2.0/6.0, g2-g1**2.0)
+        gam2k = np.where(abs(c) < 1e-7, np.pi**2.0/6.0,
+                         sc.expm1(sc.gammaln(2.0*c+1.0)-2*sc.gammaln(c + 1.0))/c**2.0)
         eps = 1e-14
-        gamk = where(abs(c) < eps, -_EULER, special.expm1(gamln(c+1))/c)
+        gamk = np.where(abs(c) < eps, -_EULER, sc.expm1(sc.gammaln(c + 1))/c)
 
-        m = where(c < -1.0, nan, -gamk)
-        v = where(c < -0.5, nan, g1**2.0*gam2k)
+        m = np.where(c < -1.0, np.nan, -gamk)
+        v = np.where(c < -0.5, np.nan, g1**2.0*gam2k)
 
         # skewness
-        sk1 = where(c < -1./3, nan,
-                    np.sign(c)*(-g3+(g2+2*g2mg12)*g1)/((g2mg12)**(3./2.)))
-        sk = where(abs(c) <= eps**0.29, 12*sqrt(6)*_ZETA3/pi**3, sk1)
+        sk1 = np.where(c < -1./3, np.nan,
+                       np.sign(c)*(-g3+(g2+2*g2mg12)*g1)/((g2mg12)**(3./2.)))
+        sk = np.where(abs(c) <= eps**0.29, 12*np.sqrt(6)*_ZETA3/np.pi**3, sk1)
 
         # kurtosis
-        ku1 = where(c < -1./4, nan,
-                    (g4+(-4*g3+3*(g2+g2mg12)*g1)*g1)/((g2mg12)**2))
-        ku = where(abs(c) <= (eps)**0.23, 12.0/5.0, ku1-3.0)
+        ku1 = np.where(c < -1./4, np.nan,
+                       (g4+(-4*g3+3*(g2+g2mg12)*g1)*g1)/((g2mg12)**2))
+        ku = np.where(abs(c) <= (eps)**0.23, 12.0/5.0, ku1-3.0)
         return m, v, sk, ku
 
     def _fitstart(self, data):
@@ -1907,11 +1907,11 @@ class genextreme_gen(rv_continuous):
         return super(genextreme_gen, self)._fitstart(data, args=(a,))
 
     def _munp(self, n, c):
-        k = arange(0, n+1)
+        k = np.arange(0, n+1)
         vals = 1.0/c**n * np.sum(
-            comb(n, k) * (-1)**k * special.gamma(c*k + 1),
+            sc.comb(n, k) * (-1)**k * sc.gamma(c*k + 1),
             axis=0)
-        return where(c*n > -1, vals, inf)
+        return np.where(c*n > -1, vals, np.inf)
 
     def _entropy(self, c):
         return _EULER*(1 - c) + 1
@@ -1923,19 +1923,19 @@ def _digammainv(y):
     # Inverse of the digamma function (real positive arguments only).
     # This function is used in the `fit` method of `gamma_gen`.
     # The function uses either optimize.fsolve or optimize.newton
-    # to solve `digamma(x) - y = 0`.  There is probably room for
+    # to solve `sc.digamma(x) - y = 0`.  There is probably room for
     # improvement, but currently it works over a wide range of y:
     #    >>> y = 64*np.random.randn(1000000)
     #    >>> y.min(), y.max()
     #    (-311.43592651416662, 351.77388222276869)
     #    x = [_digammainv(t) for t in y]
-    #    np.abs(digamma(x) - y).max()
+    #    np.abs(sc.digamma(x) - y).max()
     #    1.1368683772161603e-13
     #
     _em = 0.5772156649015328606065120
-    func = lambda x: special.digamma(x) - y
+    func = lambda x: sc.digamma(x) - y
     if y > -0.125:
-        x0 = exp(y) + 0.5
+        x0 = np.exp(y) + 0.5
         if y < 10:
             # Some experimentation shows that newton reliably converges
             # must faster than fsolve in this y range.  For larger y,
@@ -1943,7 +1943,7 @@ def _digammainv(y):
             value = optimize.newton(func, x0, tol=1e-10)
             return value
     elif y > -3:
-        x0 = exp(y/2.332) + 0.08661
+        x0 = np.exp(y/2.332) + 0.08661
     else:
         x0 = 1.0 / (-y - _em)
 
@@ -1992,28 +1992,28 @@ class gamma_gen(rv_continuous):
         return self._random_state.standard_gamma(a, self._size)
 
     def _pdf(self, x, a):
-        return exp(self._logpdf(x, a))
+        return np.exp(self._logpdf(x, a))
 
     def _logpdf(self, x, a):
-        return special.xlogy(a-1.0, x) - x - gamln(a)
+        return sc.xlogy(a-1.0, x) - x - sc.gammaln(a)
 
     def _cdf(self, x, a):
-        return special.gammainc(a, x)
+        return sc.gammainc(a, x)
 
     def _sf(self, x, a):
-        return special.gammaincc(a, x)
+        return sc.gammaincc(a, x)
 
     def _ppf(self, q, a):
-        return special.gammaincinv(a, q)
+        return sc.gammaincinv(a, q)
 
     def _stats(self, a):
-        return a, a, 2.0/sqrt(a), 6.0/a
+        return a, a, 2.0/np.sqrt(a), 6.0/a
 
     def _entropy(self, a):
-        return special.psi(a)*(1-a) + a + gamln(a)
+        return sc.psi(a)*(1-a) + a + sc.gammaln(a)
 
     def _fitstart(self, data):
-        # The skewness of the gamma distribution is `4 / sqrt(a)`.
+        # The skewness of the gamma distribution is `4 / np.sqrt(a)`.
         # We invert that to estimate the shape `a` using the skewness
         # of the data.  The formula is regularized with 1e-8 in the
         # denominator to allow for degenerate data where the skewness
@@ -2064,9 +2064,9 @@ class gamma_gen(rv_continuous):
             else:
                 # shape and scale are both free.
                 # The MLE for the shape parameter `a` is the solution to:
-                # log(a) - special.digamma(a) - log(xbar) + log(data.mean) = 0
-                s = log(xbar) - log(data).mean()
-                func = lambda a: log(a) - special.digamma(a) - s
+                # np.log(a) - sc.digamma(a) - np.log(xbar) + np.log(data.mean) = 0
+                s = np.log(xbar) - np.log(data).mean()
+                func = lambda a: np.log(a) - sc.digamma(a) - s
                 aest = (3-s + np.sqrt((s-3)**2 + 24*s)) / (12*s)
                 xa = aest*(1-0.4)
                 xb = aest*(1+0.4)
@@ -2078,8 +2078,8 @@ class gamma_gen(rv_continuous):
         else:
             # scale is fixed, shape is free
             # The MLE for the shape parameter `a` is the solution to:
-            # special.digamma(a) - log(data).mean() + log(fscale) = 0
-            c = log(data).mean() - log(fscale)
+            # sc.digamma(a) - np.log(data).mean() + np.log(fscale) = 0
+            c = np.log(data).mean() - np.log(fscale)
             a = _digammainv(c)
             scale = fscale
 
@@ -2174,37 +2174,37 @@ class gengamma_gen(rv_continuous):
         return np.exp(self._logpdf(x, a, c))
 
     def _logpdf(self, x, a, c):
-        return np.log(abs(c)) + special.xlogy(c*a - 1, x) - x**c - special.gammaln(a)
+        return np.log(abs(c)) + sc.xlogy(c*a - 1, x) - x**c - sc.gammaln(a)
 
     def _cdf(self, x, a, c):
         xc = x**c
-        val1 = special.gammainc(a, xc)
-        val2 = special.gammaincc(a, xc)
+        val1 = sc.gammainc(a, xc)
+        val2 = sc.gammaincc(a, xc)
         return np.where(c > 0, val1, val2)
 
     def _sf(self, x, a, c):
         xc = x**c
-        val1 = special.gammainc(a, xc)
-        val2 = special.gammaincc(a, xc)
+        val1 = sc.gammainc(a, xc)
+        val2 = sc.gammaincc(a, xc)
         return np.where(c > 0, val2, val1)
 
     def _ppf(self, q, a, c):
-        val1 = special.gammaincinv(a, q)
-        val2 = special.gammainccinv(a, q)
+        val1 = sc.gammaincinv(a, q)
+        val2 = sc.gammainccinv(a, q)
         return np.where(c > 0, val1, val2)**(1.0/c)
 
     def _isf(self, q, a, c):
-        val1 = special.gammaincinv(a, q)
-        val2 = special.gammainccinv(a, q)
+        val1 = sc.gammaincinv(a, q)
+        val2 = sc.gammainccinv(a, q)
         return np.where(c > 0, val2, val1)**(1.0/c)
 
     def _munp(self, n, a, c):
-        # Pochhammer symbol: poch(a,n) = gamma(a+n)/gamma(a)
-        return special.poch(a, n*1.0/c)
+        # Pochhammer symbol: sc.pocha,n) = gamma(a+n)/gamma(a)
+        return sc.poch(a, n*1.0/c)
 
     def _entropy(self, a, c):
-        val = special.psi(a)
-        return a*(1-val) + 1.0/c*val + special.gammaln(a) - np.log(abs(c))
+        val = sc.psi(a)
+        return a*(1-val) + 1.0/c*val + sc.gammaln(a) - np.log(abs(c))
 gengamma = gengamma_gen(a=0.0, name='gengamma')
 
 
@@ -2217,7 +2217,8 @@ class genhalflogistic_gen(rv_continuous):
     -----
     The probability density function for `genhalflogistic` is::
 
-        genhalflogistic.pdf(x, c) = 2 * (1-c*x)**(1/c-1) / (1+(1-c*x)**(1/c))**2
+        genhalflogistic.pdf(x, c) =
+            2 * (1-c*x)**(1/c-1) / (1+(1-c*x)**(1/c))**2
 
     for ``0 <= x <= 1/c``, and ``c > 0``.
 
@@ -2230,18 +2231,18 @@ class genhalflogistic_gen(rv_continuous):
     """
     def _argcheck(self, c):
         self.b = 1.0 / c
-        return (c > 0)
+        return c > 0
 
     def _pdf(self, x, c):
         limit = 1.0/c
-        tmp = asarray(1-c*x)
+        tmp = np.asarray(1-c*x)
         tmp0 = tmp**(limit-1)
         tmp2 = tmp0*tmp
         return 2*tmp0 / (1+tmp2)**2
 
     def _cdf(self, x, c):
         limit = 1.0/c
-        tmp = asarray(1-c*x)
+        tmp = np.asarray(1-c*x)
         tmp2 = tmp**(limit)
         return (1.0-tmp2) / (1+tmp2)
 
@@ -2249,7 +2250,7 @@ class genhalflogistic_gen(rv_continuous):
         return 1.0/c*(1-((1.0-q)/(1.0+q))**c)
 
     def _entropy(self, c):
-        return 2 - (2*c+1)*log(2)
+        return 2 - (2*c+1)*np.log(2)
 genhalflogistic = genhalflogistic_gen(a=0.0, name='genhalflogistic')
 
 
@@ -2274,19 +2275,19 @@ class gompertz_gen(rv_continuous):
 
     """
     def _pdf(self, x, c):
-        return exp(self._logpdf(x, c))
+        return np.exp(self._logpdf(x, c))
 
     def _logpdf(self, x, c):
-        return log(c) + x - c * special.expm1(x)
+        return np.log(c) + x - c * sc.expm1(x)
 
     def _cdf(self, x, c):
-        return -special.expm1(-c * special.expm1(x))
+        return -sc.expm1(-c * sc.expm1(x))
 
     def _ppf(self, q, c):
-        return special.log1p(-1.0 / c * special.log1p(-q))
+        return sc.log1p(-1.0 / c * sc.log1p(-q))
 
     def _entropy(self, c):
-        return 1.0 - log(c) - exp(c)*special.expn(1, c)
+        return 1.0 - np.log(c) - np.exp(c)*sc.expn(1, c)
 gompertz = gompertz_gen(a=0.0, name='gompertz')
 
 
@@ -2315,22 +2316,22 @@ class gumbel_r_gen(rv_continuous):
 
     """
     def _pdf(self, x):
-        return exp(self._logpdf(x))
+        return np.exp(self._logpdf(x))
 
     def _logpdf(self, x):
-        return -x - exp(-x)
+        return -x - np.exp(-x)
 
     def _cdf(self, x):
-        return exp(-exp(-x))
+        return np.exp(-np.exp(-x))
 
     def _logcdf(self, x):
-        return -exp(-x)
+        return -np.exp(-x)
 
     def _ppf(self, q):
-        return -log(-log(q))
+        return -np.log(-np.log(q))
 
     def _stats(self):
-        return _EULER, pi*pi/6.0, 12*sqrt(6)/pi**3 * _ZETA3, 12.0/5
+        return _EULER, np.pi*np.pi/6.0, 12*np.sqrt(6)/np.pi**3 * _ZETA3, 12.0/5
 
     def _entropy(self):
         # http://en.wikipedia.org/wiki/Gumbel_distribution
@@ -2363,29 +2364,29 @@ class gumbel_l_gen(rv_continuous):
 
     """
     def _pdf(self, x):
-        return exp(self._logpdf(x))
+        return np.exp(self._logpdf(x))
 
     def _logpdf(self, x):
-        return x - exp(x)
+        return x - np.exp(x)
 
     def _cdf(self, x):
-        return -special.expm1(-exp(x))
+        return -sc.expm1(-np.exp(x))
 
     def _ppf(self, q):
-        return log(-special.log1p(-q))
+        return np.log(-sc.log1p(-q))
 
     def _logsf(self, x):
-        return -exp(x)
+        return -np.exp(x)
 
     def _sf(self, x):
-        return exp(-exp(x))
+        return np.exp(-np.exp(x))
 
     def _isf(self, x):
-        return log(-log(x))
+        return np.log(-np.log(x))
 
     def _stats(self):
-        return -_EULER, pi*pi/6.0, \
-               -12*sqrt(6)/pi**3 * _ZETA3, 12.0/5
+        return -_EULER, np.pi*np.pi/6.0, \
+               -12*np.sqrt(6)/np.pi**3 * _ZETA3, 12.0/5
 
     def _entropy(self):
         return _EULER + 1.
@@ -2411,22 +2412,22 @@ class halfcauchy_gen(rv_continuous):
 
     """
     def _pdf(self, x):
-        return 2.0/pi/(1.0+x*x)
+        return 2.0/np.pi/(1.0+x*x)
 
     def _logpdf(self, x):
-        return np.log(2.0/pi) - special.log1p(x*x)
+        return np.log(2.0/np.pi) - sc.log1p(x*x)
 
     def _cdf(self, x):
-        return 2.0/pi*arctan(x)
+        return 2.0/np.pi*np.arctan(x)
 
     def _ppf(self, q):
-        return tan(pi/2*q)
+        return np.tan(np.pi/2*q)
 
     def _stats(self):
-        return inf, inf, nan, nan
+        return np.inf, np.inf, np.nan, np.nan
 
     def _entropy(self):
-        return log(2*pi)
+        return np.log(2*np.pi)
 halfcauchy = halfcauchy_gen(a=0.0, name='halfcauchy')
 
 
@@ -2449,30 +2450,30 @@ class halflogistic_gen(rv_continuous):
 
     """
     def _pdf(self, x):
-        return exp(self._logpdf(x))
+        return np.exp(self._logpdf(x))
 
     def _logpdf(self, x):
-        return log(2) - x - 2. * special.log1p(exp(-x))
+        return np.log(2) - x - 2. * sc.log1p(np.exp(-x))
 
     def _cdf(self, x):
-        return tanh(x/2.0)
+        return np.tanh(x/2.0)
 
     def _ppf(self, q):
-        return 2*arctanh(q)
+        return 2*np.arctanh(q)
 
     def _munp(self, n):
         if n == 1:
-            return 2*log(2)
+            return 2*np.log(2)
         if n == 2:
-            return pi*pi/3.0
+            return np.pi*np.pi/3.0
         if n == 3:
             return 9*_ZETA3
         if n == 4:
-            return 7*pi**4 / 15.0
-        return 2*(1-pow(2.0, 1-n))*special.gamma(n+1)*special.zeta(n, 1)
+            return 7*np.pi**4 / 15.0
+        return 2*(1-pow(2.0, 1-n))*sc.gamma(n+1)*sc.zeta(n, 1)
 
     def _entropy(self):
-        return 2-log(2)
+        return 2-np.log(2)
 halflogistic = halflogistic_gen(a=0.0, name='halflogistic')
 
 
@@ -2500,23 +2501,23 @@ class halfnorm_gen(rv_continuous):
         return abs(self._random_state.standard_normal(size=self._size))
 
     def _pdf(self, x):
-        return sqrt(2.0/pi)*exp(-x*x/2.0)
+        return np.sqrt(2.0/np.pi)*np.exp(-x*x/2.0)
 
     def _logpdf(self, x):
-        return 0.5 * np.log(2.0/pi) - x*x/2.0
+        return 0.5 * np.log(2.0/np.pi) - x*x/2.0
 
     def _cdf(self, x):
         return _norm_cdf(x)*2-1.0
 
     def _ppf(self, q):
-        return special.ndtri((1+q)/2.0)
+        return sc.ndtri((1+q)/2.0)
 
     def _stats(self):
-        return (sqrt(2.0/pi), 1-2.0/pi, sqrt(2)*(4-pi)/(pi-2)**1.5,
-                8*(pi-3)/(pi-2)**2)
+        return (np.sqrt(2.0/np.pi), 1-2.0/np.pi, np.sqrt(2)*(4-np.pi)/(np.pi-2)**1.5,
+                8*(np.pi-3)/(np.pi-2)**2)
 
     def _entropy(self):
-        return 0.5*log(pi/2.0)+0.5
+        return 0.5*np.log(np.pi/2.0)+0.5
 halfnorm = halfnorm_gen(a=0.0, name='halfnorm')
 
 
@@ -2537,19 +2538,19 @@ class hypsecant_gen(rv_continuous):
 
     """
     def _pdf(self, x):
-        return 1.0/(pi*cosh(x))
+        return 1.0/(np.pi*np.cosh(x))
 
     def _cdf(self, x):
-        return 2.0/pi*arctan(exp(x))
+        return 2.0/np.pi*np.arctan(np.exp(x))
 
     def _ppf(self, q):
-        return log(tan(pi*q/2.0))
+        return np.log(np.tan(np.pi*q/2.0))
 
     def _stats(self):
-        return 0, pi*pi/4, 0, 2
+        return 0, np.pi*np.pi/4, 0, 2
 
     def _entropy(self):
-        return log(2*pi)
+        return np.log(2*np.pi)
 hypsecant = hypsecant_gen(name='hypsecant')
 
 
@@ -2579,13 +2580,13 @@ class gausshyper_gen(rv_continuous):
         return (a > 0) & (b > 0) & (c == c) & (z == z)
 
     def _pdf(self, x, a, b, c, z):
-        Cinv = gam(a)*gam(b)/gam(a+b)*special.hyp2f1(c, a, a+b, -z)
+        Cinv = sc.gamma(a)*sc.gamma(b)/sc.gamma(a+b)*sc.hyp2f1(c, a, a+b, -z)
         return 1.0/Cinv * x**(a-1.0) * (1.0-x)**(b-1.0) / (1.0+z*x)**c
 
     def _munp(self, n, a, b, c, z):
-        fac = special.beta(n+a, b) / special.beta(a, b)
-        num = special.hyp2f1(c, a+n, a+b+n, -z)
-        den = special.hyp2f1(c, a, a+b, -z)
+        fac = sc.beta(n+a, b) / sc.beta(a, b)
+        num = sc.hyp2f1(c, a+n, a+b+n, -z)
+        den = sc.hyp2f1(c, a, a+b, -z)
         return fac*num / den
 gausshyper = gausshyper_gen(a=0.0, b=1.0, name='gausshyper')
 
@@ -2615,22 +2616,22 @@ class invgamma_gen(rv_continuous):
     _support_mask = rv_continuous._open_support_mask
 
     def _pdf(self, x, a):
-        return exp(self._logpdf(x, a))
+        return np.exp(self._logpdf(x, a))
 
     def _logpdf(self, x, a):
-        return (-(a+1) * log(x) - gamln(a) - 1.0/x)
+        return -(a+1) * np.log(x) - sc.gammaln(a) - 1.0/x
 
     def _cdf(self, x, a):
-        return special.gammaincc(a, 1.0 / x)
+        return sc.gammaincc(a, 1.0 / x)
 
     def _ppf(self, q, a):
-        return 1.0 / special.gammainccinv(a, q)
+        return 1.0 / sc.gammainccinv(a, q)
 
     def _sf(self, x, a):
-        return special.gammainc(a, 1.0 / x)
+        return sc.gammainc(a, 1.0 / x)
 
     def _isf(self, q, a):
-        return 1.0 / special.gammaincinv(a, q)
+        return 1.0 / sc.gammaincinv(a, q)
 
     def _stats(self, a, moments='mvsk'):
         m1 = _lazywhere(a > 1, (a,), lambda x: 1. / (x - 1.), np.inf)
@@ -2649,7 +2650,7 @@ class invgamma_gen(rv_continuous):
         return m1, m2, g1, g2
 
     def _entropy(self, a):
-        return a - (a+1.0) * special.psi(a) + gamln(a)
+        return a - (a+1.0) * sc.psi(a) + sc.gammaln(a)
 invgamma = invgamma_gen(a=0.0, name='invgamma')
 
 
@@ -2684,20 +2685,20 @@ class invgauss_gen(rv_continuous):
         return self._random_state.wald(mu, 1.0, size=self._size)
 
     def _pdf(self, x, mu):
-        return 1.0/sqrt(2*pi*x**3.0)*exp(-1.0/(2*x)*((x-mu)/mu)**2)
+        return 1.0/np.sqrt(2*np.pi*x**3.0)*np.exp(-1.0/(2*x)*((x-mu)/mu)**2)
 
     def _logpdf(self, x, mu):
-        return -0.5*log(2*pi) - 1.5*log(x) - ((x-mu)/mu)**2/(2*x)
+        return -0.5*np.log(2*np.pi) - 1.5*np.log(x) - ((x-mu)/mu)**2/(2*x)
 
     def _cdf(self, x, mu):
-        fac = sqrt(1.0/x)
+        fac = np.sqrt(1.0/x)
         # Numerical accuracy for small `mu` is bad.  See #869.
         C1 = _norm_cdf(fac*(x-mu)/mu)
-        C1 += exp(1.0/mu) * _norm_cdf(-fac*(x+mu)/mu) * exp(1.0/mu)
+        C1 += np.exp(1.0/mu) * _norm_cdf(-fac*(x+mu)/mu) * np.exp(1.0/mu)
         return C1
 
     def _stats(self, mu):
-        return mu, mu**3.0, 3*sqrt(mu), 15*mu
+        return mu, mu**3.0, 3*np.sqrt(mu), 15*mu
 invgauss = invgauss_gen(a=0.0, name='invgauss')
 
 
@@ -2731,21 +2732,21 @@ class invweibull_gen(rv_continuous):
     def _pdf(self, x, c):
         xc1 = np.power(x, -c - 1.0)
         xc2 = np.power(x, -c)
-        xc2 = exp(-xc2)
+        xc2 = np.exp(-xc2)
         return c * xc1 * xc2
 
     def _cdf(self, x, c):
         xc1 = np.power(x, -c)
-        return exp(-xc1)
+        return np.exp(-xc1)
 
     def _ppf(self, q, c):
-        return np.power(-log(q), -1.0/c)
+        return np.power(-np.log(q), -1.0/c)
 
     def _munp(self, n, c):
-        return special.gamma(1 - n / c)
+        return sc.gamma(1 - n / c)
 
     def _entropy(self, c):
-        return 1+_EULER + _EULER / c - log(c)
+        return 1+_EULER + _EULER / c - np.log(c)
 invweibull = invweibull_gen(a=0, name='invweibull')
 
 
@@ -2779,14 +2780,14 @@ class johnsonsb_gen(rv_continuous):
         return (b > 0) & (a == a)
 
     def _pdf(self, x, a, b):
-        trm = _norm_pdf(a + b*log(x/(1.0-x)))
+        trm = _norm_pdf(a + b*np.log(x/(1.0-x)))
         return b*1.0/(x*(1-x))*trm
 
     def _cdf(self, x, a, b):
-        return _norm_cdf(a + b*log(x/(1.0-x)))
+        return _norm_cdf(a + b*np.log(x/(1.0-x)))
 
     def _ppf(self, q, a, b):
-        return 1.0 / (1 + exp(-1.0 / b * (_norm_ppf(q) - a)))
+        return 1.0 / (1 + np.exp(-1.0 / b * (_norm_ppf(q) - a)))
 johnsonsb = johnsonsb_gen(a=0.0, b=1.0, name='johnsonsb')
 
 
@@ -2820,14 +2821,14 @@ class johnsonsu_gen(rv_continuous):
 
     def _pdf(self, x, a, b):
         x2 = x*x
-        trm = _norm_pdf(a + b * log(x + sqrt(x2+1)))
-        return b*1.0/sqrt(x2+1.0)*trm
+        trm = _norm_pdf(a + b * np.log(x + np.sqrt(x2+1)))
+        return b*1.0/np.sqrt(x2+1.0)*trm
 
     def _cdf(self, x, a, b):
-        return _norm_cdf(a + b * log(x + sqrt(x*x + 1)))
+        return _norm_cdf(a + b * np.log(x + np.sqrt(x*x + 1)))
 
     def _ppf(self, q, a, b):
-        return sinh((_norm_ppf(q) - a) / b)
+        return np.sinh((_norm_ppf(q) - a) / b)
 johnsonsu = johnsonsu_gen(name='johnsonsu')
 
 
@@ -2851,19 +2852,19 @@ class laplace_gen(rv_continuous):
         return self._random_state.laplace(0, 1, size=self._size)
 
     def _pdf(self, x):
-        return 0.5*exp(-abs(x))
+        return 0.5*np.exp(-abs(x))
 
     def _cdf(self, x):
-        return where(x > 0, 1.0-0.5*exp(-x), 0.5*exp(x))
+        return np.where(x > 0, 1.0-0.5*np.exp(-x), 0.5*np.exp(x))
 
     def _ppf(self, q):
-        return where(q > 0.5, -log(2*(1-q)), log(2*q))
+        return np.where(q > 0.5, -np.log(2*(1-q)), np.log(2*q))
 
     def _stats(self):
         return 0, 2, 0, 3
 
     def _entropy(self):
-        return log(2)+1
+        return np.log(2)+1
 laplace = laplace_gen(name='laplace')
 
 
@@ -2894,19 +2895,19 @@ class levy_gen(rv_continuous):
     _support_mask = rv_continuous._open_support_mask
 
     def _pdf(self, x):
-        return 1 / sqrt(2*pi*x) / x * exp(-1/(2*x))
+        return 1 / np.sqrt(2*np.pi*x) / x * np.exp(-1/(2*x))
 
     def _cdf(self, x):
-        # Equivalent to 2*norm.sf(sqrt(1/x))
-        return special.erfc(sqrt(0.5 / x))
+        # Equivalent to 2*norm.sf(np.sqrt(1/x))
+        return sc.erfc(np.sqrt(0.5 / x))
 
     def _ppf(self, q):
         # Equivalent to 1.0/(norm.isf(q/2)**2) or 0.5/(erfcinv(q)**2)
-        val = -special.ndtri(q/2)
+        val = -sc.ndtri(q/2)
         return 1.0 / (val * val)
 
     def _stats(self):
-        return inf, inf, nan, nan
+        return np.inf, np.inf, np.nan, np.nan
 levy = levy_gen(a=0.0, name="levy")
 
 
@@ -2938,18 +2939,18 @@ class levy_l_gen(rv_continuous):
 
     def _pdf(self, x):
         ax = abs(x)
-        return 1/sqrt(2*pi*ax)/ax*exp(-1/(2*ax))
+        return 1/np.sqrt(2*np.pi*ax)/ax*np.exp(-1/(2*ax))
 
     def _cdf(self, x):
         ax = abs(x)
-        return 2 * _norm_cdf(1 / sqrt(ax)) - 1
+        return 2 * _norm_cdf(1 / np.sqrt(ax)) - 1
 
     def _ppf(self, q):
         val = _norm_ppf((q + 1.0) / 2)
         return -1.0 / (val * val)
 
     def _stats(self):
-        return inf, inf, nan, nan
+        return np.inf, np.inf, np.nan, np.nan
 levy_l = levy_l_gen(b=0.0, name="levy_l")
 
 
@@ -2976,20 +2977,20 @@ class levy_stable_gen(rv_continuous):
     def _rvs(self, alpha, beta):
 
         def alpha1func(alpha, beta, TH, aTH, bTH, cosTH, tanTH, W):
-            return (2/pi*(pi/2 + bTH)*tanTH -
-                    beta*log((pi/2*W*cosTH)/(pi/2 + bTH)))
+            return (2/np.pi*(np.pi/2 + bTH)*tanTH -
+                    beta*np.log((np.pi/2*W*cosTH)/(np.pi/2 + bTH)))
 
         def beta0func(alpha, beta, TH, aTH, bTH, cosTH, tanTH, W):
-            return (W/(cosTH/tan(aTH) + sin(TH)) *
-                    ((cos(aTH) + sin(aTH)*tanTH)/W)**(1.0/alpha))
+            return (W/(cosTH/np.tan(aTH) + np.sin(TH)) *
+                    ((np.cos(aTH) + np.sin(aTH)*tanTH)/W)**(1.0/alpha))
 
         def otherwise(alpha, beta, TH, aTH, bTH, cosTH, tanTH, W):
             # alpha is not 1 and beta is not 0
-            val0 = beta*tan(pi*alpha/2)
-            th0 = arctan(val0)/alpha
-            val3 = W/(cosTH/tan(alpha*(th0 + TH)) + sin(TH))
-            res3 = val3*((cos(aTH) + sin(aTH)*tanTH - val0*(sin(aTH) -
-                         cos(aTH)*tanTH))/W)**(1.0/alpha)
+            val0 = beta*np.tan(np.pi*alpha/2)
+            th0 = np.arctan(val0)/alpha
+            val3 = W/(cosTH/np.tan(alpha*(th0 + TH)) + np.sin(TH))
+            res3 = val3*((np.cos(aTH) + np.sin(aTH)*tanTH -
+                          val0*(np.sin(aTH) - np.cos(aTH)*tanTH))/W)**(1.0/alpha)
             return res3
 
         def alphanot1func(alpha, beta, TH, aTH, bTH, cosTH, tanTH, W):
@@ -3001,13 +3002,13 @@ class levy_stable_gen(rv_continuous):
         sz = self._size
         alpha = broadcast_to(alpha, sz)
         beta = broadcast_to(beta, sz)
-        TH = uniform.rvs(loc=-pi/2.0, scale=pi, size=sz,
+        TH = uniform.rvs(loc=-np.pi/2.0, scale=np.pi, size=sz,
                          random_state=self._random_state)
         W = expon.rvs(size=sz, random_state=self._random_state)
         aTH = alpha*TH
         bTH = beta*TH
-        cosTH = cos(TH)
-        tanTH = tan(TH)
+        cosTH = np.cos(TH)
+        tanTH = np.tan(TH)
         res = _lazywhere(alpha == 1, (alpha, beta, TH, aTH, bTH, cosTH, tanTH, W),
                          alpha1func, f2=alphanot1func)
         return res
@@ -3042,25 +3043,25 @@ class logistic_gen(rv_continuous):
         return self._random_state.logistic(size=self._size)
 
     def _pdf(self, x):
-        return exp(self._logpdf(x))
+        return np.exp(self._logpdf(x))
 
     def _logpdf(self, x):
-        return -x - 2. * special.log1p(exp(-x))
+        return -x - 2. * sc.log1p(np.exp(-x))
 
     def _cdf(self, x):
-        return special.expit(x)
+        return sc.expit(x)
 
     def _ppf(self, q):
-        return special.logit(q)
+        return sc.logit(q)
 
     def _sf(self, x):
-        return special.expit(-x)
+        return sc.expit(-x)
 
     def _isf(self, q):
-        return -special.logit(q)
+        return -sc.logit(q)
 
     def _stats(self):
-        return 0, pi*pi/3.0, 0, 6.0/5.0
+        return 0, np.pi*np.pi/3.0, 0, 6.0/5.0
 
     def _entropy(self):
         # http://en.wikipedia.org/wiki/Logistic_distribution
@@ -3089,24 +3090,24 @@ class loggamma_gen(rv_continuous):
 
     """
     def _rvs(self, c):
-        return log(self._random_state.gamma(c, size=self._size))
+        return np.log(self._random_state.gamma(c, size=self._size))
 
     def _pdf(self, x, c):
-        return exp(c*x-exp(x)-gamln(c))
+        return np.exp(c*x-np.exp(x)-sc.gammaln(c))
 
     def _cdf(self, x, c):
-        return special.gammainc(c, exp(x))
+        return sc.gammainc(c, np.exp(x))
 
     def _ppf(self, q, c):
-        return log(special.gammaincinv(c, q))
+        return np.log(sc.gammaincinv(c, q))
 
     def _stats(self, c):
         # See, for example, "A Statistical Study of Log-Gamma Distribution", by
         # Ping Shing Chan (thesis, McMaster University, 1993).
-        mean = special.digamma(c)
-        var = special.polygamma(1, c)
-        skewness = special.polygamma(2, c) / np.power(var, 1.5)
-        excess_kurtosis = special.polygamma(3, c) / (var*var)
+        mean = sc.digamma(c)
+        var = sc.polygamma(1, c)
+        skewness = sc.polygamma(2, c) / np.power(var, 1.5)
+        excess_kurtosis = sc.polygamma(3, c) / (var*var)
         return mean, var, skewness, excess_kurtosis
 
 loggamma = loggamma_gen(name='loggamma')
@@ -3140,26 +3141,26 @@ class loglaplace_gen(rv_continuous):
     """
     def _pdf(self, x, c):
         cd2 = c/2.0
-        c = where(x < 1, c, -c)
+        c = np.where(x < 1, c, -c)
         return cd2*x**(c-1)
 
     def _cdf(self, x, c):
-        return where(x < 1, 0.5*x**c, 1-0.5*x**(-c))
+        return np.where(x < 1, 0.5*x**c, 1-0.5*x**(-c))
 
     def _ppf(self, q, c):
-        return where(q < 0.5, (2.0*q)**(1.0/c), (2*(1.0-q))**(-1.0/c))
+        return np.where(q < 0.5, (2.0*q)**(1.0/c), (2*(1.0-q))**(-1.0/c))
 
     def _munp(self, n, c):
         return c**2 / (c**2 - n**2)
 
     def _entropy(self, c):
-        return log(2.0/c) + 1.0
+        return np.log(2.0/c) + 1.0
 loglaplace = loglaplace_gen(a=0.0, name='loglaplace')
 
 
 def _lognorm_logpdf(x, s):
     return _lazywhere(x != 0, (x, s),
-                      lambda x, s: -log(x)**2 / (2*s**2) - log(s*x*sqrt(2*pi)),
+                      lambda x, s: -np.log(x)**2 / (2*s**2) - np.log(s*x*np.sqrt(2*np.pi)),
                       -np.inf)
 
 
@@ -3192,39 +3193,39 @@ class lognorm_gen(rv_continuous):
     _support_mask = rv_continuous._open_support_mask
 
     def _rvs(self, s):
-        return exp(s * self._random_state.standard_normal(self._size))
+        return np.exp(s * self._random_state.standard_normal(self._size))
 
     def _pdf(self, x, s):
-        return exp(self._logpdf(x, s))
+        return np.exp(self._logpdf(x, s))
 
     def _logpdf(self, x, s):
         return _lognorm_logpdf(x, s)
 
     def _cdf(self, x, s):
-        return _norm_cdf(log(x) / s)
+        return _norm_cdf(np.log(x) / s)
 
     def _logcdf(self, x, s):
-        return _norm_logcdf(log(x) / s)
+        return _norm_logcdf(np.log(x) / s)
 
     def _ppf(self, q, s):
-        return exp(s * _norm_ppf(q))
+        return np.exp(s * _norm_ppf(q))
 
     def _sf(self, x, s):
-        return _norm_sf(log(x) / s)
+        return _norm_sf(np.log(x) / s)
 
     def _logsf(self, x, s):
-        return _norm_logsf(log(x) / s)
+        return _norm_logsf(np.log(x) / s)
 
     def _stats(self, s):
-        p = exp(s*s)
-        mu = sqrt(p)
+        p = np.exp(s*s)
+        mu = np.sqrt(p)
         mu2 = p*(p-1)
-        g1 = sqrt((p-1))*(2+p)
+        g1 = np.sqrt((p-1))*(2+p)
         g2 = np.polyval([1, 2, 3, 0, -6.0], p)
         return mu, mu2, g1, g2
 
     def _entropy(self, s):
-        return 0.5 * (1 + log(2*pi) + 2 * log(s))
+        return 0.5 * (1 + np.log(2*np.pi) + 2 * np.log(s))
 lognorm = lognorm_gen(a=0.0, name='lognorm')
 
 
@@ -3249,30 +3250,30 @@ class gilbrat_gen(rv_continuous):
     _support_mask = rv_continuous._open_support_mask
 
     def _rvs(self):
-        return exp(self._random_state.standard_normal(self._size))
+        return np.exp(self._random_state.standard_normal(self._size))
 
     def _pdf(self, x):
-        return exp(self._logpdf(x))
+        return np.exp(self._logpdf(x))
 
     def _logpdf(self, x):
         return _lognorm_logpdf(x, 1.0)
 
     def _cdf(self, x):
-        return _norm_cdf(log(x))
+        return _norm_cdf(np.log(x))
 
     def _ppf(self, q):
-        return exp(_norm_ppf(q))
+        return np.exp(_norm_ppf(q))
 
     def _stats(self):
         p = np.e
-        mu = sqrt(p)
+        mu = np.sqrt(p)
         mu2 = p * (p - 1)
-        g1 = sqrt((p - 1)) * (2 + p)
+        g1 = np.sqrt((p - 1)) * (2 + p)
         g2 = np.polyval([1, 2, 3, 0, -6.0], p)
         return mu, mu2, g1, g2
 
     def _entropy(self):
-        return 0.5 * log(2 * pi) + 0.5
+        return 0.5 * np.log(2 * np.pi) + 0.5
 gilbrat = gilbrat_gen(a=0.0, name='gilbrat')
 
 
@@ -3305,21 +3306,23 @@ class maxwell_gen(rv_continuous):
         return chi.rvs(3.0, size=self._size, random_state=self._random_state)
 
     def _pdf(self, x):
-        return sqrt(2.0/pi)*x*x*exp(-x*x/2.0)
+        return np.sqrt(2.0/np.pi)*x*x*np.exp(-x*x/2.0)
 
     def _cdf(self, x):
-        return special.gammainc(1.5, x*x/2.0)
+        return sc.gammainc(1.5, x*x/2.0)
 
     def _ppf(self, q):
-        return sqrt(2*special.gammaincinv(1.5, q))
+        return np.sqrt(2*sc.gammaincinv(1.5, q))
 
     def _stats(self):
-        val = 3*pi-8
-        return (2*sqrt(2.0/pi), 3-8/pi, sqrt(2)*(32-10*pi)/val**1.5,
-                (-12*pi*pi + 160*pi - 384) / val**2.0)
+        val = 3*np.pi-8
+        return (2*np.sqrt(2.0/np.pi),
+                3-8/np.pi,
+                np.sqrt(2)*(32-10*np.pi)/val**1.5,
+                (-12*np.pi*np.pi + 160*np.pi - 384) / val**2.0)
 
     def _entropy(self):
-        return _EULER + 0.5*log(2*pi)-0.5
+        return _EULER + 0.5*np.log(2*np.pi)-0.5
 maxwell = maxwell_gen(a=0.0, name='maxwell')
 
 
@@ -3455,11 +3458,11 @@ class kappa4_gen(rv_continuous):
             return (1.0 - h**(-k))/k
 
         def f1(h, k):
-            return log(h)
+            return np.log(h)
 
         def f3(h, k):
-            a = np.empty(shape(h))
-            a[:] = -inf
+            a = np.empty(np.shape(h))
+            a[:] = -np.inf
             return a
 
         def f5(h, k):
@@ -3468,24 +3471,24 @@ class kappa4_gen(rv_continuous):
         self.a = _lazyselect(condlist,
                              [f0, f1, f0, f3, f3, f5],
                              [h, k],
-                             default=nan)
+                             default=np.nan)
 
         def f0(h, k):
             return 1.0/k
 
         def f1(h, k):
-            a = np.empty(shape(h))
-            a[:] = inf
+            a = np.empty(np.shape(h))
+            a[:] = np.inf
             return a
 
         self.b = _lazyselect(condlist,
                              [f0, f1, f1, f0, f1, f1],
                              [h, k],
-                             default=nan)
-        return (h == h)
+                             default=np.nan)
+        return h == h
 
     def _pdf(self, x, h, k):
-        return exp(self._logpdf(x, h, k))
+        return np.exp(self._logpdf(x, h, k))
 
     def _logpdf(self, x, h, k):
         condlist = [np.logical_and(h != 0, k != 0),
@@ -3498,37 +3501,35 @@ class kappa4_gen(rv_continuous):
                       1.0 - h*(1.0 - k*x)**(1.0/k))**(1.0/h-1.0)
                logpdf = ...
             '''
-            return special.xlog1py(1.0/k-1.0,
-                                   -k*x
-                                   ) + special.xlog1py(1.0/h-1.0,
-                                                       -h*(1.0-k*x)**(1.0/k))
+            return (sc.xlog1py(1.0/k - 1.0, -k*x) +
+                    sc.xlog1py(1.0/h - 1.0, -h*(1.0 - k*x)**(1.0/k)))
 
         def f1(x, h, k):
-            '''pdf = (1.0 - k*x)**(1.0/k - 1.0)*exp(-(
+            '''pdf = (1.0 - k*x)**(1.0/k - 1.0)*np.exp(-(
                       1.0 - k*x)**(1.0/k))
                logpdf = ...
             '''
-            return special.xlog1py(1.0/k-1.0,-k*x)-(1.0-k*x)**(1.0/k)
+            return sc.xlog1py(1.0/k - 1.0, -k*x) - (1.0 - k*x)**(1.0/k)
 
         def f2(x, h, k):
-            '''pdf = exp(-x)*(1.0 - h*exp(-x))**(1.0/h - 1.0)
+            '''pdf = np.exp(-x)*(1.0 - h*np.exp(-x))**(1.0/h - 1.0)
                logpdf = ...
             '''
-            return -x + special.xlog1py(1.0/h-1.0, -h*exp(-x))
+            return -x + sc.xlog1py(1.0/h - 1.0, -h*np.exp(-x))
 
         def f3(x, h, k):
-            '''pdf = exp(-x-exp(-x))
+            '''pdf = np.exp(-x-np.exp(-x))
                logpdf = ...
             '''
-            return -x-exp(-x)
+            return -x - np.exp(-x)
 
         return _lazyselect(condlist,
                            [f0, f1, f2, f3],
                            [x, h, k],
-                           default=nan)
+                           default=np.nan)
 
     def _cdf(self, x, h, k):
-        return exp(self._logcdf(x, h, k))
+        return np.exp(self._logcdf(x, h, k))
 
     def _logcdf(self, x, h, k):
         condlist = [np.logical_and(h != 0, k != 0),
@@ -3540,30 +3541,30 @@ class kappa4_gen(rv_continuous):
             '''cdf = (1.0 - h*(1.0 - k*x)**(1.0/k))**(1.0/h)
                logcdf = ...
             '''
-            return (1.0/h)*special.log1p(-h*(1.0-k*x)**(1.0/k))
+            return (1.0/h)*sc.log1p(-h*(1.0 - k*x)**(1.0/k))
 
         def f1(x, h, k):
-            '''cdf = exp(-(1.0 - k*x)**(1.0/k))
+            '''cdf = np.exp(-(1.0 - k*x)**(1.0/k))
                logcdf = ...
             '''
             return -(1.0 - k*x)**(1.0/k)
 
         def f2(x, h, k):
-            '''cdf = (1.0 - h*exp(-x))**(1.0/h)
+            '''cdf = (1.0 - h*np.exp(-x))**(1.0/h)
                logcdf = ...
             '''
-            return (1.0/h)*special.log1p(-h*exp(-x))
+            return (1.0/h)*sc.log1p(-h*np.exp(-x))
 
         def f3(x, h, k):
-            '''cdf = exp(-exp(-x))
+            '''cdf = np.exp(-np.exp(-x))
                logcdf = ...
             '''
-            return -exp(-x)
+            return -np.exp(-x)
 
         return _lazyselect(condlist,
                            [f0, f1, f2, f3],
                            [x, h, k],
-                           default=nan)
+                           default=np.nan)
 
     def _ppf(self, q, h, k):
         condlist = [np.logical_and(h != 0, k != 0),
@@ -3575,20 +3576,20 @@ class kappa4_gen(rv_continuous):
             return 1.0/k*(1.0 - ((1.0 - (q**h))/h)**k)
 
         def f1(q, h, k):
-            return 1.0/k*(1.0 - (-log(q))**k)
+            return 1.0/k*(1.0 - (-np.log(q))**k)
 
         def f2(q, h, k):
-            '''ppf = -log((1.0 - (q**h))/h)
+            '''ppf = -np.log((1.0 - (q**h))/h)
             '''
-            return -special.log1p(-(q**h)) + log(h)
+            return -sc.log1p(-(q**h)) + np.log(h)
 
         def f3(q, h, k):
-            return -log(-log(q))
+            return -np.log(-np.log(q))
 
         return _lazyselect(condlist,
                            [f0, f1, f2, f3],
                            [q, h, k],
-                           default=nan)
+                           default=np.nan)
 
     def _stats(self, h, k):
         if h >= 0 and k >= 0:
@@ -3600,7 +3601,7 @@ class kappa4_gen(rv_continuous):
         else:
             maxr = 5
 
-        outputs = [None if r < maxr else nan for r in range(1, 5)]
+        outputs = [None if r < maxr else np.nan for r in range(1, 5)]
         return outputs[:]
 kappa4 = kappa4_gen(name='kappa4')
 
@@ -3650,7 +3651,7 @@ class kappa3_gen(rv_continuous):
         return (a/(q**-a - 1.0))**(1.0/a)
 
     def _stats(self, a):
-        outputs = [None if i < a else nan for i in range(1, 5)]
+        outputs = [None if i < a else np.nan for i in range(1, 5)]
         return outputs[:]
 kappa3 = kappa3_gen(a=0.0, name='kappa3')
 
@@ -3677,16 +3678,16 @@ class nakagami_gen(rv_continuous):
 
     """
     def _pdf(self, x, nu):
-        return 2*nu**nu/gam(nu)*(x**(2*nu-1.0))*exp(-nu*x*x)
+        return 2*nu**nu/sc.gamma(nu)*(x**(2*nu-1.0))*np.exp(-nu*x*x)
 
     def _cdf(self, x, nu):
-        return special.gammainc(nu, nu*x*x)
+        return sc.gammainc(nu, nu*x*x)
 
     def _ppf(self, q, nu):
-        return sqrt(1.0/nu*special.gammaincinv(nu, q))
+        return np.sqrt(1.0/nu*sc.gammaincinv(nu, q))
 
     def _stats(self, nu):
-        mu = gam(nu+0.5)/gam(nu)/sqrt(nu)
+        mu = sc.gamma(nu+0.5)/sc.gamma(nu)/np.sqrt(nu)
         mu2 = 1.0-mu*mu
         g1 = mu * (1 - 4*nu*mu2) / 2.0 / nu / np.power(mu2, 1.5)
         g2 = -6*mu**4*nu + (8*nu-2)*mu**2-2*nu + 1
@@ -3729,11 +3730,13 @@ class ncx2_gen(rv_continuous):
         return _ncx2_cdf(x, df, nc)
 
     def _ppf(self, q, df, nc):
-        return special.chndtrix(q, df, nc)
+        return sc.chndtrix(q, df, nc)
 
     def _stats(self, df, nc):
         val = df + 2.0*nc
-        return (df + nc, 2*val, sqrt(8)*(val+nc)/val**1.5,
+        return (df + nc,
+                2*val,
+                np.sqrt(8)*(val+nc)/val**1.5,
                 12.0*(val+2*nc)/val**2.0)
 ncx2 = ncx2_gen(a=0.0, name='ncx2')
 
@@ -3768,34 +3771,34 @@ class ncf_gen(rv_continuous):
 
     def _pdf_skip(self, x, dfn, dfd, nc):
         n1, n2 = dfn, dfd
-        term = -nc/2+nc*n1*x/(2*(n2+n1*x)) + gamln(n1/2.)+gamln(1+n2/2.)
-        term -= gamln((n1+n2)/2.0)
-        Px = exp(term)
+        term = -nc/2+nc*n1*x/(2*(n2+n1*x)) + sc.gammaln(n1/2.)+sc.gammaln(1+n2/2.)
+        term -= sc.gammaln((n1+n2)/2.0)
+        Px = np.exp(term)
         Px *= n1**(n1/2) * n2**(n2/2) * x**(n1/2-1)
         Px *= (n2+n1*x)**(-(n1+n2)/2)
-        Px *= special.assoc_laguerre(-nc*n1*x/(2.0*(n2+n1*x)), n2/2, n1/2-1)
-        Px /= special.beta(n1/2, n2/2)
+        Px *= sc.assoc_laguerre(-nc*n1*x/(2.0*(n2+n1*x)), n2/2, n1/2-1)
+        Px /= sc.beta(n1/2, n2/2)
         # This function does not have a return.  Drop it for now, the generic
         # function seems to work OK.
 
     def _cdf(self, x, dfn, dfd, nc):
-        return special.ncfdtr(dfn, dfd, nc, x)
+        return sc.ncfdtr(dfn, dfd, nc, x)
 
     def _ppf(self, q, dfn, dfd, nc):
-        return special.ncfdtri(dfn, dfd, nc, q)
+        return sc.ncfdtri(dfn, dfd, nc, q)
 
     def _munp(self, n, dfn, dfd, nc):
         val = (dfn * 1.0/dfd)**n
-        term = gamln(n+0.5*dfn) + gamln(0.5*dfd-n) - gamln(dfd*0.5)
-        val *= exp(-nc / 2.0+term)
-        val *= special.hyp1f1(n+0.5*dfn, 0.5*dfn, 0.5*nc)
+        term = sc.gammaln(n+0.5*dfn) + sc.gammaln(0.5*dfd-n) - sc.gammaln(dfd*0.5)
+        val *= np.exp(-nc / 2.0+term)
+        val *= sc.hyp1f1(n+0.5*dfn, 0.5*dfn, 0.5*nc)
         return val
 
     def _stats(self, dfn, dfd, nc):
-        mu = where(dfd <= 2, inf, dfd / (dfd-2.0)*(1+nc*1.0/dfn))
-        mu2 = where(dfd <= 4, inf, 2*(dfd*1.0/dfn)**2.0 *
-                    ((dfn+nc/2.0)**2.0 + (dfn+nc)*(dfd-2.0)) /
-                    ((dfd-2.0)**2.0 * (dfd-4.0)))
+        mu = np.where(dfd <= 2, np.inf, dfd / (dfd-2.0)*(1+nc*1.0/dfn))
+        mu2 = np.where(dfd <= 4, np.inf, 2*(dfd*1.0/dfn)**2.0 *
+                       ((dfn+nc/2.0)**2.0 + (dfn+nc)*(dfd-2.0)) /
+                       ((dfd-2.0)**2.0 * (dfd-4.0)))
         return mu, mu2, None, None
 ncf = ncf_gen(a=0.0, name='ncf')
 
@@ -3826,34 +3829,34 @@ class t_gen(rv_continuous):
         return self._random_state.standard_t(df, size=self._size)
 
     def _pdf(self, x, df):
-        r = asarray(df*1.0)
-        Px = exp(gamln((r+1)/2)-gamln(r/2))
-        Px /= sqrt(r*pi)*(1+(x**2)/r)**((r+1)/2)
+        r = np.asarray(df*1.0)
+        Px = np.exp(sc.gammaln((r+1)/2)-sc.gammaln(r/2))
+        Px /= np.sqrt(r*np.pi)*(1+(x**2)/r)**((r+1)/2)
         return Px
 
     def _logpdf(self, x, df):
         r = df*1.0
-        lPx = gamln((r+1)/2)-gamln(r/2)
-        lPx -= 0.5*log(r*pi) + (r+1)/2*log(1+(x**2)/r)
+        lPx = sc.gammaln((r+1)/2)-sc.gammaln(r/2)
+        lPx -= 0.5*np.log(r*np.pi) + (r+1)/2*np.log(1+(x**2)/r)
         return lPx
 
     def _cdf(self, x, df):
-        return special.stdtr(df, x)
+        return sc.stdtr(df, x)
 
     def _sf(self, x, df):
-        return special.stdtr(df, -x)
+        return sc.stdtr(df, -x)
 
     def _ppf(self, q, df):
-        return special.stdtrit(df, q)
+        return sc.stdtrit(df, q)
 
     def _isf(self, q, df):
-        return -special.stdtrit(df, q)
+        return -sc.stdtrit(df, q)
 
     def _stats(self, df):
         mu2 = _lazywhere(df > 2, (df,),
                          lambda df: df / (df-2.0),
                          np.inf)
-        g1 = where(df > 3, 0.0, np.nan)
+        g1 = np.where(df > 3, 0.0, np.nan)
         g2 = _lazywhere(df > 4, (df,),
                         lambda df: 6.0 / (df-4.0),
                         np.nan)
@@ -3890,7 +3893,7 @@ class nct_gen(rv_continuous):
         sz, rndm = self._size, self._random_state
         n = norm.rvs(loc=nc, size=sz, random_state=rndm)
         c2 = chi2.rvs(df, size=sz, random_state=rndm)
-        return n * sqrt(df) / sqrt(c2)
+        return n * np.sqrt(df) / np.sqrt(c2)
 
     def _pdf(self, x, df, nc):
         n = df*1.0
@@ -3898,22 +3901,22 @@ class nct_gen(rv_continuous):
         x2 = x*x
         ncx2 = nc*nc*x2
         fac1 = n + x2
-        trm1 = n/2.*log(n) + gamln(n+1)
-        trm1 -= n*log(2)+nc*nc/2.+(n/2.)*log(fac1)+gamln(n/2.)
-        Px = exp(trm1)
+        trm1 = n/2.*np.log(n) + sc.gammaln(n+1)
+        trm1 -= n*np.log(2)+nc*nc/2.+(n/2.)*np.log(fac1)+sc.gammaln(n/2.)
+        Px = np.exp(trm1)
         valF = ncx2 / (2*fac1)
-        trm1 = sqrt(2)*nc*x*special.hyp1f1(n/2+1, 1.5, valF)
-        trm1 /= asarray(fac1*special.gamma((n+1)/2))
-        trm2 = special.hyp1f1((n+1)/2, 0.5, valF)
-        trm2 /= asarray(sqrt(fac1)*special.gamma(n/2+1))
+        trm1 = np.sqrt(2)*nc*x*sc.hyp1f1(n/2+1, 1.5, valF)
+        trm1 /= np.asarray(fac1*sc.gamma((n+1)/2))
+        trm2 = sc.hyp1f1((n+1)/2, 0.5, valF)
+        trm2 /= np.asarray(np.sqrt(fac1)*sc.gamma(n/2+1))
         Px *= trm1+trm2
         return Px
 
     def _cdf(self, x, df, nc):
-        return special.nctdtr(df, nc, x)
+        return sc.nctdtr(df, nc, x)
 
     def _ppf(self, q, df, nc):
-        return special.nctdtrit(df, nc, q)
+        return sc.nctdtrit(df, nc, q)
 
     def _stats(self, df, nc, moments='mv'):
         #
@@ -3924,8 +3927,8 @@ class nct_gen(rv_continuous):
         #
         mu, mu2, g1, g2 = None, None, None, None
 
-        gfac = gam(df/2.-0.5) / gam(df/2.)
-        c11 = sqrt(df/2.) * gfac
+        gfac = sc.gamma(df/2.-0.5) / sc.gamma(df/2.)
+        c11 = np.sqrt(df/2.) * gfac
         c20 = df / (df-2.)
         c22 = c20 - c11*c11
         mu = np.where(df > 1, nc*c11, np.inf)
@@ -3983,31 +3986,31 @@ class pareto_gen(rv_continuous):
         mu, mu2, g1, g2 = None, None, None, None
         if 'm' in moments:
             mask = b > 1
-            bt = extract(mask, b)
-            mu = valarray(shape(b), value=inf)
-            place(mu, mask, bt / (bt-1.0))
+            bt = np.extract(mask, b)
+            mu = valarray(np.shape(b), value=np.inf)
+            np.place(mu, mask, bt / (bt-1.0))
         if 'v' in moments:
             mask = b > 2
-            bt = extract(mask, b)
-            mu2 = valarray(shape(b), value=inf)
-            place(mu2, mask, bt / (bt-2.0) / (bt-1.0)**2)
+            bt = np.extract(mask, b)
+            mu2 = valarray(np.shape(b), value=np.inf)
+            np.place(mu2, mask, bt / (bt-2.0) / (bt-1.0)**2)
         if 's' in moments:
             mask = b > 3
-            bt = extract(mask, b)
-            g1 = valarray(shape(b), value=nan)
-            vals = 2 * (bt + 1.0) * sqrt(bt - 2.0) / ((bt - 3.0) * sqrt(bt))
-            place(g1, mask, vals)
+            bt = np.extract(mask, b)
+            g1 = valarray(np.shape(b), value=np.nan)
+            vals = 2 * (bt + 1.0) * np.sqrt(bt - 2.0) / ((bt - 3.0) * np.sqrt(bt))
+            np.place(g1, mask, vals)
         if 'k' in moments:
             mask = b > 4
-            bt = extract(mask, b)
-            g2 = valarray(shape(b), value=nan)
-            vals = (6.0*polyval([1.0, 1.0, -6, -2], bt) /
-                    polyval([1.0, -7.0, 12.0, 0.0], bt))
-            place(g2, mask, vals)
+            bt = np.extract(mask, b)
+            g2 = valarray(np.shape(b), value=np.nan)
+            vals = (6.0*np.polyval([1.0, 1.0, -6, -2], bt) /
+                    np.polyval([1.0, -7.0, 12.0, 0.0], bt))
+            np.place(g2, mask, vals)
         return mu, mu2, g1, g2
 
     def _entropy(self, c):
-        return 1 + 1.0/c - log(c)
+        return 1 + 1.0/c - np.log(c)
 pareto = pareto_gen(a=1.0, name="pareto")
 
 
@@ -4038,26 +4041,26 @@ class lomax_gen(rv_continuous):
         return c*1.0/(1.0+x)**(c+1.0)
 
     def _logpdf(self, x, c):
-        return log(c) - (c+1)*special.log1p(x)
+        return np.log(c) - (c+1)*sc.log1p(x)
 
     def _cdf(self, x, c):
-        return -special.expm1(-c*special.log1p(x))
+        return -sc.expm1(-c*sc.log1p(x))
 
     def _sf(self, x, c):
-        return exp(-c*special.log1p(x))
+        return np.exp(-c*sc.log1p(x))
 
     def _logsf(self, x, c):
-        return -c*special.log1p(x)
+        return -c*sc.log1p(x)
 
     def _ppf(self, q, c):
-        return special.expm1(-special.log1p(-q)/c)
+        return sc.expm1(-sc.log1p(-q)/c)
 
     def _stats(self, c):
         mu, mu2, g1, g2 = pareto.stats(c, loc=-1.0, moments='mvsk')
         return mu, mu2, g1, g2
 
     def _entropy(self, c):
-        return 1+1.0/c-log(c)
+        return 1+1.0/c-np.log(c)
 lomax = lomax_gen(a=0.0, name="lomax")
 
 
@@ -4124,7 +4127,7 @@ class pearson3_gen(rv_continuous):
         zeta = loc - alpha / beta
 
         transx = beta * (x[invmask] - zeta)
-        return ans, x, transx, skew, mask, invmask, beta, alpha, zeta
+        return ans, x, transx, mask, invmask, beta, alpha, zeta
 
     def _argcheck(self, skew):
         # The _argcheck function in rv_continuous only allows positive
@@ -4134,7 +4137,7 @@ class pearson3_gen(rv_continuous):
         return np.ones(np.shape(skew), dtype=bool)
 
     def _stats(self, skew):
-        ans, x, transx, skew, mask, invmask, beta, alpha, zeta = (
+        _, _, _, _, _, beta, alpha, zeta = (
             self._preprocess([1], skew))
         m = zeta + alpha / beta
         v = alpha / (beta**2)
@@ -4145,7 +4148,7 @@ class pearson3_gen(rv_continuous):
     def _pdf(self, x, skew):
         # Do the calculation in _logpdf since helps to limit
         # overflow/underflow problems
-        ans = exp(self._logpdf(x, skew))
+        ans = np.exp(self._logpdf(x, skew))
         if ans.ndim == 0:
             if np.isnan(ans):
                 return 0.0
@@ -4156,18 +4159,18 @@ class pearson3_gen(rv_continuous):
     def _logpdf(self, x, skew):
         #   PEARSON3 logpdf                           GAMMA logpdf
         #   np.log(abs(beta))
-        # + (alpha - 1)*log(beta*(x - zeta))          + (a - 1)*log(x)
+        # + (alpha - 1)*np.log(beta*(x - zeta))          + (a - 1)*np.log(x)
         # - beta*(x - zeta)                           - x
-        # - gamln(alpha)                              - gamln(a)
-        ans, x, transx, skew, mask, invmask, beta, alpha, zeta = (
+        # - sc.gammalnalpha)                              - sc.gammalna)
+        ans, x, transx, mask, invmask, beta, alpha, _ = (
             self._preprocess(x, skew))
 
         ans[mask] = np.log(_norm_pdf(x[mask]))
-        ans[invmask] = log(abs(beta)) + gamma._logpdf(transx, alpha)
+        ans[invmask] = np.log(abs(beta)) + gamma._logpdf(transx, alpha)
         return ans
 
     def _cdf(self, x, skew):
-        ans, x, transx, skew, mask, invmask, beta, alpha, zeta = (
+        ans, x, transx, mask, invmask, _, alpha, _ = (
             self._preprocess(x, skew))
 
         ans[mask] = _norm_cdf(x[mask])
@@ -4176,7 +4179,7 @@ class pearson3_gen(rv_continuous):
 
     def _rvs(self, skew):
         skew = broadcast_to(skew, self._size)
-        ans, x, transx, skew, mask, invmask, beta, alpha, zeta = (
+        ans, _, _, mask, invmask, beta, alpha, zeta = (
             self._preprocess([0], skew))
 
         nsmall = mask.sum()
@@ -4190,10 +4193,10 @@ class pearson3_gen(rv_continuous):
         return ans
 
     def _ppf(self, q, skew):
-        ans, q, transq, skew, mask, invmask, beta, alpha, zeta = (
+        ans, q, _, mask, invmask, beta, alpha, zeta = (
             self._preprocess(q, skew))
         ans[mask] = _norm_ppf(q[mask])
-        ans[invmask] = special.gammaincinv(alpha, q[invmask])/beta + zeta
+        ans[invmask] = sc.gammaincinv(alpha, q[invmask])/beta + zeta
         return ans
 pearson3 = pearson3_gen(name="pearson3")
 
@@ -4224,13 +4227,13 @@ class powerlaw_gen(rv_continuous):
         return a*x**(a-1.0)
 
     def _logpdf(self, x, a):
-        return log(a) + special.xlogy(a - 1, x)
+        return np.log(a) + sc.xlogy(a - 1, x)
 
     def _cdf(self, x, a):
         return x**(a*1.0)
 
     def _logcdf(self, x, a):
-        return a*log(x)
+        return a*np.log(x)
 
     def _ppf(self, q, a):
         return pow(q, 1.0/a)
@@ -4238,11 +4241,11 @@ class powerlaw_gen(rv_continuous):
     def _stats(self, a):
         return (a / (a + 1.0),
                 a / (a + 2.0) / (a + 1.0) ** 2,
-                -2.0 * ((a - 1.0) / (a + 3.0)) * sqrt((a + 2.0) / a),
-                6 * polyval([1, -1, -6, 2], a) / (a * (a + 3.0) * (a + 4)))
+                -2.0 * ((a - 1.0) / (a + 3.0)) * np.sqrt((a + 2.0) / a),
+                6 * np.polyval([1, -1, -6, 2], a) / (a * (a + 3.0) * (a + 4)))
 
     def _entropy(self, a):
-        return 1 - 1.0/a - log(a)
+        return 1 - 1.0/a - np.log(a)
 powerlaw = powerlaw_gen(a=0.0, b=1.0, name="powerlaw")
 
 
@@ -4271,14 +4274,14 @@ class powerlognorm_gen(rv_continuous):
     _support_mask = rv_continuous._open_support_mask
 
     def _pdf(self, x, c, s):
-        return (c/(x*s) * _norm_pdf(log(x)/s) *
-                pow(_norm_cdf(-log(x)/s), c*1.0-1.0))
+        return (c/(x*s) * _norm_pdf(np.log(x)/s) *
+                pow(_norm_cdf(-np.log(x)/s), c*1.0-1.0))
 
     def _cdf(self, x, c, s):
-        return 1.0 - pow(_norm_cdf(-log(x)/s), c*1.0)
+        return 1.0 - pow(_norm_cdf(-np.log(x)/s), c*1.0)
 
     def _ppf(self, q, c, s):
-        return exp(-s * _norm_ppf(pow(1.0 - q, 1.0 / c)))
+        return np.exp(-s * _norm_ppf(pow(1.0 - q, 1.0 / c)))
 powerlognorm = powerlognorm_gen(a=0.0, name="powerlognorm")
 
 
@@ -4304,10 +4307,10 @@ class powernorm_gen(rv_continuous):
 
     """
     def _pdf(self, x, c):
-        return (c*_norm_pdf(x) * (_norm_cdf(-x)**(c-1.0)))
+        return c*_norm_pdf(x) * (_norm_cdf(-x)**(c-1.0))
 
     def _logpdf(self, x, c):
-        return log(c) + _norm_logpdf(x) + (c-1)*_norm_logcdf(-x)
+        return np.log(c) + _norm_logpdf(x) + (c-1)*_norm_logcdf(-x)
 
     def _cdf(self, x, c):
         return 1.0-_norm_cdf(-x)**(c*1.0)
@@ -4338,11 +4341,11 @@ class rdist_gen(rv_continuous):
 
     """
     def _pdf(self, x, c):
-        return np.power((1.0 - x**2), c / 2.0 - 1) / special.beta(0.5, c / 2.0)
+        return np.power((1.0 - x**2), c / 2.0 - 1) / sc.beta(0.5, c / 2.0)
 
     def _cdf(self, x, c):
-        term1 = x / special.beta(0.5, c / 2.0)
-        res = 0.5 + term1 * special.hyp2f1(0.5, 1 - c / 2.0, 1.5, x**2)
+        term1 = x / sc.beta(0.5, c / 2.0)
+        res = 0.5 + term1 * sc.hyp2f1(0.5, 1 - c / 2.0, 1.5, x**2)
         # There's an issue with hyp2f1, it returns nans near x = +-1, c > 100.
         # Use the generic implementation in that case.  See gh-1285 for
         # background.
@@ -4351,8 +4354,8 @@ class rdist_gen(rv_continuous):
         return res
 
     def _munp(self, n, c):
-        numerator = (1 - (n % 2)) * special.beta((n + 1.0) / 2, c / 2.0)
-        return numerator / special.beta(1. / 2, c / 2.)
+        numerator = (1 - (n % 2)) * sc.beta((n + 1.0) / 2, c / 2.0)
+        return numerator / sc.beta(1. / 2, c / 2.)
 rdist = rdist_gen(a=-1.0, b=1.0, name="rdist")
 
 
@@ -4382,33 +4385,35 @@ class rayleigh_gen(rv_continuous):
         return chi.rvs(2, size=self._size, random_state=self._random_state)
 
     def _pdf(self, r):
-        return exp(self._logpdf(r))
+        return np.exp(self._logpdf(r))
 
     def _logpdf(self, r):
-        return log(r) - 0.5 * r * r
+        return np.log(r) - 0.5 * r * r
 
     def _cdf(self, r):
-        return -special.expm1(-0.5 * r**2)
+        return -sc.expm1(-0.5 * r**2)
 
     def _ppf(self, q):
-        return sqrt(-2 * special.log1p(-q))
+        return np.sqrt(-2 * sc.log1p(-q))
 
     def _sf(self, r):
-        return exp(self._logsf(r))
+        return np.exp(self._logsf(r))
 
     def _logsf(self, r):
         return -0.5 * r * r
 
     def _isf(self, q):
-        return sqrt(-2 * log(q))
+        return np.sqrt(-2 * np.log(q))
 
     def _stats(self):
-        val = 4 - pi
-        return (np.sqrt(pi/2), val/2, 2*(pi-3)*sqrt(pi)/val**1.5,
-                6*pi/val-16/val**2)
+        val = 4 - np.pi
+        return (np.sqrt(np.pi/2),
+                val/2,
+                2*(np.pi-3)*np.sqrt(np.pi)/val**1.5,
+                6*np.pi/val-16/val**2)
 
     def _entropy(self):
-        return _EULER/2.0 + 1 - 0.5*log(2)
+        return _EULER/2.0 + 1 - 0.5*np.log(2)
 rayleigh = rayleigh_gen(a=0.0, name="rayleigh")
 
 
@@ -4435,17 +4440,17 @@ class reciprocal_gen(rv_continuous):
     def _argcheck(self, a, b):
         self.a = a
         self.b = b
-        self.d = log(b*1.0 / a)
+        self.d = np.log(b*1.0 / a)
         return (a > 0) & (b > 0) & (b > a)
 
     def _pdf(self, x, a, b):
         return 1.0 / (x * self.d)
 
     def _logpdf(self, x, a, b):
-        return -log(x) - log(self.d)
+        return -np.log(x) - np.log(self.d)
 
     def _cdf(self, x, a, b):
-        return (log(x)-log(a)) / self.d
+        return (np.log(x)-np.log(a)) / self.d
 
     def _ppf(self, q, a, b):
         return a*pow(b*1.0/a, q)
@@ -4454,7 +4459,7 @@ class reciprocal_gen(rv_continuous):
         return 1.0/self.d / n * (pow(b*1.0, n) - pow(a*1.0, n))
 
     def _entropy(self, a, b):
-        return 0.5*log(a*b)+log(log(b/a))
+        return 0.5*np.log(a*b)+np.log(np.log(b/a))
 reciprocal = reciprocal_gen(name="reciprocal")
 
 
@@ -4494,24 +4499,24 @@ class rice_gen(rv_continuous):
         return np.sqrt((t*t).sum(axis=0))
 
     def _cdf(self, x, b):
-        return chndtr(np.square(x), 2, np.square(b))
+        return sc.chndtr(np.square(x), 2, np.square(b))
 
     def _ppf(self, q, b):
-        return np.sqrt(chndtrix(q, 2, np.square(b)))
+        return np.sqrt(sc.chndtrix(q, 2, np.square(b)))
 
     def _pdf(self, x, b):
         # We use (x**2 + b**2)/2 = ((x-b)**2)/2 + xb.
-        # The factor of exp(-xb) is then included in the i0e function
+        # The factor of np.exp(-xb) is then included in the i0e function
         # in place of the modified Bessel function, i0, improving
         # numerical stability for large values of xb.
-        return x * exp(-(x-b)*(x-b)/2.0) * special.i0e(x*b)
+        return x * np.exp(-(x-b)*(x-b)/2.0) * sc.i0e(x*b)
 
     def _munp(self, n, b):
         nd2 = n/2.0
         n1 = 1 + nd2
         b2 = b*b/2.0
-        return (2.0**(nd2) * exp(-b2) * special.gamma(n1) *
-                special.hyp1f1(n1, 1, b2))
+        return (2.0**(nd2) * np.exp(-b2) * sc.gamma(n1) *
+                sc.hyp1f1(n1, 1, b2))
 rice = rice_gen(a=0.0, name="rice")
 
 
@@ -4536,20 +4541,21 @@ class recipinvgauss_gen(rv_continuous):
     %(example)s
 
     """
-    def _rvs(self, mu):
-        return 1.0/self._random_state.wald(mu, 1.0, size=self._size)
 
     def _pdf(self, x, mu):
-        return 1.0/sqrt(2*pi*x)*exp(-(1-mu*x)**2.0 / (2*x*mu**2.0))
+        return 1.0/np.sqrt(2*np.pi*x)*np.exp(-(1-mu*x)**2.0 / (2*x*mu**2.0))
 
     def _logpdf(self, x, mu):
-        return -(1-mu*x)**2.0 / (2*x*mu**2.0) - 0.5*log(2*pi*x)
+        return -(1-mu*x)**2.0 / (2*x*mu**2.0) - 0.5*np.log(2*np.pi*x)
 
     def _cdf(self, x, mu):
         trm1 = 1.0/mu - x
         trm2 = 1.0/mu + x
-        isqx = 1.0/sqrt(x)
-        return 1.0-_norm_cdf(isqx*trm1)-exp(2.0/mu)*_norm_cdf(-isqx*trm2)
+        isqx = 1.0/np.sqrt(x)
+        return 1.0-_norm_cdf(isqx*trm1)-np.exp(2.0/mu)*_norm_cdf(-isqx*trm2)
+
+    def _rvs(self, mu):
+        return 1.0/self._random_state.wald(mu, 1.0, size=self._size)
 recipinvgauss = recipinvgauss_gen(a=0.0, name='recipinvgauss')
 
 
@@ -4572,10 +4578,10 @@ class semicircular_gen(rv_continuous):
 
     """
     def _pdf(self, x):
-        return 2.0/pi*sqrt(1-x*x)
+        return 2.0/np.pi*np.sqrt(1-x*x)
 
     def _cdf(self, x):
-        return 0.5+1.0/pi*(x*sqrt(1-x*x) + arcsin(x))
+        return 0.5+1.0/np.pi*(x*np.sqrt(1-x*x) + np.arcsin(x))
 
     def _stats(self):
         return 0, 0.25, 0, -1.0
@@ -4628,16 +4634,16 @@ class skew_norm_gen(rv_continuous):
 
     def _stats(self, a, moments='mvsk'):
         output = [None, None, None, None]
-        const = np.sqrt(2/pi) * a/np.sqrt(1 + a**2)
+        const = np.sqrt(2/np.pi) * a/np.sqrt(1 + a**2)
 
         if 'm' in moments:
             output[0] = const
         if 'v' in moments:
             output[1] = 1 - const**2
         if 's' in moments:
-            output[2] = ((4 - pi)/2) * (const/np.sqrt(1 - const**2))**3
+            output[2] = ((4 - np.pi)/2) * (const/np.sqrt(1 - const**2))**3
         if 'k' in moments:
-            output[3] = (2*(pi - 3)) * (const**4/(1 - const**2)**2)
+            output[3] = (2*(np.pi - 3)) * (const**4/(1 - const**2)**2)
 
         return output
 
@@ -4688,7 +4694,7 @@ class trapz_gen(rv_continuous):
         condlist = [q < qc, q <= qd, q > qd]
         choicelist = [np.sqrt(q * c * (1 + d - c)),
                       0.5 * q * (1 + d - c) + 0.5 * c,
-                      1 - sqrt((1 - q) * (d - c + 1) * (1 - d))]
+                      1 - np.sqrt((1 - q) * (d - c + 1) * (1 - d))]
         return np.select(condlist, choicelist)
 trapz = trapz_gen(a=0.0, b=1.0, name="trapz")
 
@@ -4722,20 +4728,22 @@ class triang_gen(rv_continuous):
         return (c >= 0) & (c <= 1)
 
     def _pdf(self, x, c):
-        return where(x < c, 2*x/c, 2*(1-x)/(1-c))
+        return np.where(x < c, 2*x/c, 2*(1-x)/(1-c))
 
     def _cdf(self, x, c):
-        return where(x < c, x*x/c, (x*x-2*x+c)/(c-1))
+        return np.where(x < c, x*x/c, (x*x-2*x+c)/(c-1))
 
     def _ppf(self, q, c):
-        return where(q < c, sqrt(c*q), 1-sqrt((1-c)*(1-q)))
+        return np.where(q < c, np.sqrt(c*q), 1-np.sqrt((1-c)*(1-q)))
 
     def _stats(self, c):
-        return (c+1.0)/3.0, (1.0-c+c*c)/18, sqrt(2)*(2*c-1)*(c+1)*(c-2) / \
-               (5 * np.power((1.0-c+c*c), 1.5)), -3.0/5.0
+        return ((c+1.0)/3.0,
+                (1.0-c+c*c)/18,
+                np.sqrt(2)*(2*c-1)*(c+1)*(c-2) / (5*np.power((1.0-c+c*c), 1.5)),
+                -3.0/5.0)
 
     def _entropy(self, c):
-        return 0.5-log(2)
+        return 0.5-np.log(2)
 triang = triang_gen(a=0.0, b=1.0, name="triang")
 
 
@@ -4761,35 +4769,35 @@ class truncexpon_gen(rv_continuous):
     """
     def _argcheck(self, b):
         self.b = b
-        return (b > 0)
+        return b > 0
 
     def _pdf(self, x, b):
-        return exp(-x)/(-special.expm1(-b))
+        return np.exp(-x)/(-sc.expm1(-b))
 
     def _logpdf(self, x, b):
-        return -x - log(-special.expm1(-b))
+        return -x - np.log(-sc.expm1(-b))
 
     def _cdf(self, x, b):
-        return special.expm1(-x)/special.expm1(-b)
+        return sc.expm1(-x)/sc.expm1(-b)
 
     def _ppf(self, q, b):
-        return -special.log1p(q*special.expm1(-b))
+        return -sc.log1p(q*sc.expm1(-b))
 
     def _munp(self, n, b):
         # wrong answer with formula, same as in continuous.pdf
-        # return gam(n+1)-special.gammainc(1+n, b)
+        # return sc.gamman+1)-sc.gammainc1+n, b)
         if n == 1:
-            return (1-(b+1)*exp(-b))/(-special.expm1(-b))
+            return (1-(b+1)*np.exp(-b))/(-sc.expm1(-b))
         elif n == 2:
-            return 2*(1-0.5*(b*b+2*b+2)*exp(-b))/(-special.expm1(-b))
+            return 2*(1-0.5*(b*b+2*b+2)*np.exp(-b))/(-sc.expm1(-b))
         else:
             # return generic for higher moments
             # return rv_continuous._mom1_sc(self, n, b)
             return self._mom1_sc(n, b)
 
     def _entropy(self, b):
-        eB = exp(b)
-        return log(eB-1)+(1+eB*(b-1.0))/(1.0-eB)
+        eB = np.exp(b)
+        return np.log(eB-1)+(1+eB*(b-1.0))/(1.0-eB)
 truncexpon = truncexpon_gen(a=0.0, name='truncexpon')
 
 
@@ -4824,8 +4832,8 @@ class truncnorm_gen(rv_continuous):
         self._delta = np.where(self.a > 0,
                                -(self._sb - self._sa),
                                self._nb - self._na)
-        self._logdelta = log(self._delta)
-        return (a != b)
+        self._logdelta = np.log(self._delta)
+        return a != b
 
     def _pdf(self, x, a, b):
         return _norm_pdf(x) / self._delta
@@ -4881,23 +4889,23 @@ class tukeylambda_gen(rv_continuous):
         return np.ones(np.shape(lam), dtype=bool)
 
     def _pdf(self, x, lam):
-        Fx = asarray(special.tklmbda(x, lam))
-        Px = Fx**(lam-1.0) + (asarray(1-Fx))**(lam-1.0)
-        Px = 1.0/asarray(Px)
-        return where((lam <= 0) | (abs(x) < 1.0/asarray(lam)), Px, 0.0)
+        Fx = np.asarray(sc.tklmbda(x, lam))
+        Px = Fx**(lam-1.0) + (np.asarray(1-Fx))**(lam-1.0)
+        Px = 1.0/np.asarray(Px)
+        return np.where((lam <= 0) | (abs(x) < 1.0/np.asarray(lam)), Px, 0.0)
 
     def _cdf(self, x, lam):
-        return special.tklmbda(x, lam)
+        return sc.tklmbda(x, lam)
 
     def _ppf(self, q, lam):
-        return special.boxcox(q, lam) - special.boxcox1p(-q, lam)
+        return sc.boxcox(q, lam) - sc.boxcox1p(-q, lam)
 
     def _stats(self, lam):
         return 0, _tlvar(lam), 0, _tlkurt(lam)
 
     def _entropy(self, lam):
         def integ(p):
-            return log(pow(p, lam-1)+pow(1-p, lam-1))
+            return np.log(pow(p, lam-1)+pow(1-p, lam-1))
         return integrate.quad(integ, 0, 1)[0]
 tukeylambda = tukeylambda_gen(name='tukeylambda')
 
@@ -4964,7 +4972,7 @@ class vonmises_gen(rv_continuous):
         return self._random_state.vonmises(0.0, kappa, size=self._size)
 
     def _pdf(self, x, kappa):
-        return exp(kappa * cos(x)) / (2*pi*i0(kappa))
+        return np.exp(kappa * np.cos(x)) / (2*np.pi*sc.i0(kappa))
 
     def _cdf(self, x, kappa):
         return _stats.von_mises_cdf(kappa, x)
@@ -4973,8 +4981,8 @@ class vonmises_gen(rv_continuous):
         return 0, None, 0, None
 
     def _entropy(self, kappa):
-        return (-kappa * i1(kappa) / i0(kappa)
-                + np.log(2 * np.pi * i0(kappa)))
+        return (-kappa * sc.i1(kappa) / sc.i0(kappa) +
+                np.log(2 * np.pi * sc.i0(kappa)))
 vonmises = vonmises_gen(name='vonmises')
 vonmises_line = vonmises_gen(a=-np.pi, b=np.pi, name='vonmises_line')
 
@@ -5041,37 +5049,37 @@ class wrapcauchy_gen(rv_continuous):
         return (c > 0) & (c < 1)
 
     def _pdf(self, x, c):
-        return (1.0-c*c)/(2*pi*(1+c*c-2*c*cos(x)))
+        return (1.0-c*c)/(2*np.pi*(1+c*c-2*c*np.cos(x)))
 
     def _cdf(self, x, c):
         output = np.zeros(x.shape, dtype=x.dtype)
         val = (1.0+c)/(1.0-c)
-        c1 = x < pi
+        c1 = x < np.pi
         c2 = 1-c1
-        xp = extract(c1, x)
-        xn = extract(c2, x)
+        xp = np.extract(c1, x)
+        xn = np.extract(c2, x)
         if np.any(xn):
-            valn = extract(c2, np.ones_like(x)*val)
-            xn = 2*pi - xn
-            yn = tan(xn/2.0)
-            on = 1.0-1.0/pi*arctan(valn*yn)
-            place(output, c2, on)
+            valn = np.extract(c2, np.ones_like(x)*val)
+            xn = 2*np.pi - xn
+            yn = np.tan(xn/2.0)
+            on = 1.0-1.0/np.pi*np.arctan(valn*yn)
+            np.place(output, c2, on)
         if np.any(xp):
-            valp = extract(c1, np.ones_like(x)*val)
-            yp = tan(xp/2.0)
-            op = 1.0/pi*arctan(valp*yp)
-            place(output, c1, op)
+            valp = np.extract(c1, np.ones_like(x)*val)
+            yp = np.tan(xp/2.0)
+            op = 1.0/np.pi*np.arctan(valp*yp)
+            np.place(output, c1, op)
         return output
 
     def _ppf(self, q, c):
         val = (1.0-c)/(1.0+c)
-        rcq = 2*arctan(val*tan(pi*q))
-        rcmq = 2*pi-2*arctan(val*tan(pi*(1-q)))
-        return where(q < 1.0/2, rcq, rcmq)
+        rcq = 2*np.arctan(val*np.tan(np.pi*q))
+        rcmq = 2*np.pi-2*np.arctan(val*np.tan(np.pi*(1-q)))
+        return np.where(q < 1.0/2, rcq, rcmq)
 
     def _entropy(self, c):
-        return log(2*pi*(1-c*c))
-wrapcauchy = wrapcauchy_gen(a=0.0, b=2*pi, name='wrapcauchy')
+        return np.log(2*np.pi*(1-c*c))
+wrapcauchy = wrapcauchy_gen(a=0.0, b=2*np.pi, name='wrapcauchy')
 
 
 class gennorm_gen(rv_continuous):
@@ -5111,17 +5119,17 @@ class gennorm_gen(rv_continuous):
         return np.exp(self._logpdf(x, beta))
 
     def _logpdf(self, x, beta):
-        return np.log(.5 * beta) - special.gammaln(1. / beta) - abs(x)**beta
+        return np.log(0.5*beta) - sc.gammaln(1.0/beta) - abs(x)**beta
 
     def _cdf(self, x, beta):
-        c = .5 * np.sign(x)
+        c = 0.5 * np.sign(x)
         # evaluating (.5 + c) first prevents numerical cancellation
-        return (.5 + c) - c * special.gammaincc(1. / beta, abs(x)**beta)
+        return (0.5 + c) - c * sc.gammaincc(1.0/beta, abs(x)**beta)
 
     def _ppf(self, x, beta):
-        c = np.sign(x - .5)
+        c = np.sign(x - 0.5)
         # evaluating (1. + c) first prevents numerical cancellation
-        return c * special.gammainccinv(1. / beta, (1. + c) - 2.*c*x)**(1. / beta)
+        return c * sc.gammainccinv(1.0/beta, (1.0 + c) - 2.0*c*x)**(1.0/beta)
 
     def _sf(self, x, beta):
         return self._cdf(-x, beta)
@@ -5130,11 +5138,11 @@ class gennorm_gen(rv_continuous):
         return -self._ppf(x, beta)
 
     def _stats(self, beta):
-        c1, c3, c5 = special.gammaln([1./beta, 3./beta, 5./beta])
-        return 0., np.exp(c3 - c1), 0., np.exp(c5 + c1 - 2. * c3) - 3.
+        c1, c3, c5 = sc.gammaln([1.0/beta, 3.0/beta, 5.0/beta])
+        return 0., np.exp(c3 - c1), 0., np.exp(c5 + c1 - 2.0*c3) - 3.
 
     def _entropy(self, beta):
-        return 1. / beta - np.log(.5 * beta) + special.gammaln(1. / beta)
+        return 1. / beta - np.log(.5 * beta) + sc.gammaln(1. / beta)
 gennorm = gennorm_gen(name='gennorm')
 
 
@@ -5176,22 +5184,22 @@ class halfgennorm_gen(rv_continuous):
         return np.exp(self._logpdf(x, beta))
 
     def _logpdf(self, x, beta):
-        return np.log(beta) - special.gammaln(1. / beta) - x**beta
+        return np.log(beta) - sc.gammaln(1.0/beta) - x**beta
 
     def _cdf(self, x, beta):
-        return special.gammainc(1. / beta, x**beta)
+        return sc.gammainc(1.0/beta, x**beta)
 
     def _ppf(self, x, beta):
-        return special.gammaincinv(1. / beta, x)**(1. / beta)
+        return sc.gammaincinv(1.0/beta, x)**(1.0/beta)
 
     def _sf(self, x, beta):
-        return special.gammaincc(1. / beta, x**beta)
+        return sc.gammaincc(1.0/beta, x**beta)
 
     def _isf(self, x, beta):
-        return special.gammainccinv(1. / beta, x)**(1. / beta)
+        return sc.gammainccinv(1.0/beta, x)**(1.0/beta)
 
     def _entropy(self, beta):
-        return 1. / beta - np.log(beta) + special.gammaln(1. / beta)
+        return 1.0/beta - np.log(beta) + sc.gammaln(1.0/beta)
 halfgennorm = halfgennorm_gen(a=0, name='halfgennorm')
 
 


### PR DESCRIPTION
There were several places where a function would be imported from numpy
or scipy.special, yet not used uniformly throughout.  For example, 'from
numpy import exp', yet some places in the code would still use 'np.exp'.
Setup explicit import for all scipy.special functions.  This allowed for
shorter and readable equations.  Some PEP8 cleanups: removing
unnecessary parentheses, fixing indentation on continuation lines,
...etc.
