### PR TITLE
TST: stats: do not use the deprecated F attribute in tests

### DIFF
--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -110,7 +110,7 @@ def test_rvs_broadcast():
             distfunc = getattr(stats, dist)
         except TypeError:
             distfunc = dist
-            dist = 'rv_discrete(values=(%r, %r))' % (dist.F.keys(), dist.F.values)
+            dist = 'rv_discrete(values=(%r, %r))' % (dist.xk, dist.pk)
         loc = np.zeros(2)
         nargs = distfunc.numargs
         allargs = []


### PR DESCRIPTION
This avoids a DeprecationWarning noise when running the stats test suite.
