### PR TITLE
ENH: sparse: Loosen input validation for `diags` with empty inputs

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from scipy._lib.six import xrange
 
-from .sputils import upcast, get_index_dtype
+from .sputils import upcast, get_index_dtype, isscalarlike
 
 from .csr import csr_matrix
 from .csc import csc_matrix
@@ -134,18 +134,15 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
            [ 0.,  0.,  0.,  0.]])
     """
     # if offsets is not a sequence, assume that there's only one diagonal
-    try:
-        iter(offsets)
-    except TypeError:
+    if isscalarlike(offsets):
         # now check that there's actually only one diagonal
-        try:
-            iter(diagonals[0])
-        except TypeError:
+        if len(diagonals) == 0 or isscalarlike(diagonals[0]):
             diagonals = [np.atleast_1d(diagonals)]
         else:
             raise ValueError("Different number of diagonals and offsets.")
     else:
         diagonals = list(map(np.atleast_1d, diagonals))
+
     offsets = np.atleast_1d(offsets)
 
     # Basic check
@@ -175,11 +172,8 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
         offset = offsets[j]
         k = max(0, offset)
         length = min(m + offset, n - offset, K)
-        if length <= 0:
+        if length < 0:
             raise ValueError("Offset %d (index %d) out of bounds" % (offset, j))
-        diagonal = np.asarray(diagonal)
-        if diagonal.ndim == 0:
-            diagonal = diagonal[None]
         try:
             data_arr[j, k:k+length] = diagonal[...,:length]
         except ValueError:

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -168,8 +168,7 @@ class TestConstructUtils(TestCase):
         cases.append(([a[:2],c,b[:3]], [-4,2,-1], (6, 5)))
         cases.append(([a[:2],c,b[:3]], [-4,2,-1], None))
         cases.append(([], [-4,2,-1], None))
-        cases.append(([1], [-4], (4, 4)))
-        cases.append(([a[:0]], [-1], (1, 2)))
+        cases.append(([1], [-5], (4, 4)))
         cases.append(([a], 0, None))
 
         for d, o, shape in cases:
@@ -218,6 +217,10 @@ class TestConstructUtils(TestCase):
         for k in range(-5, 6):
             assert_equal(construct.diags(d, k).toarray(),
                          construct.diags([d], [k]).toarray())
+
+    def test_diags_empty(self):
+        x = construct.diags([])
+        assert_equal(x.shape, (0, 0))
 
     def test_identity(self):
         assert_equal(construct.identity(1).toarray(), [[1]])


### PR DESCRIPTION
Prompted by gh-6232, this PR allows for empty inputs to `scipy.sparse.diags`. It also loosens some internal checks, which I find to be more consistent. Here's the existing behavior:

```
ss.diags([1], -3, shape=(2,2))  # ValueError
ss.diags([1], -2, shape=(2,2))  # ValueError
ss.diags([1], -1, shape=(2,2))  # [[0,0],[1,0]]
ss.diags([1], 0, shape=(2,2))   # [[1,0],[0,1]]
ss.diags([1], 1, shape=(2,2))   # [[0,1],[0,0]]
ss.diags([1], 2, shape=(2,2))   # [[0,0],[0,0]]
ss.diags([1], 3, shape=(2,2))   # ValueError
```

With these changes, the `-2` offset case will now match the `+2` offset case and return an empty 2x2 sparse matrix.

This is technically a breaking change, in that some cases which threw errors before will now succeed (see the changes to the test suite).
