### PR TITLE
BUG: stats:  Improve calculation of the Anderson-Darling statistic.

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1427,12 +1427,14 @@ def anderson(x, dist='norm'):
     if dist == 'norm':
         s = np.std(x, ddof=1, axis=0)
         w = (y - xbar) / s
-        z = distributions.norm.cdf(w)
+        logcdf = distributions.norm.logcdf(w)
+        logsf = distributions.norm.logsf(w)
         sig = array([15, 10, 5, 2.5, 1])
         critical = around(_Avals_norm / (1.0 + 4.0/N - 25.0/N/N), 3)
     elif dist == 'expon':
         w = y / xbar
-        z = distributions.expon.cdf(w)
+        logcdf = distributions.expon.logcdf(w)
+        logsf = distributions.expon.logsf(w)
         sig = array([15, 10, 5, 2.5, 1])
         critical = around(_Avals_expon / (1.0 + 0.6/N), 3)
     elif dist == 'logistic':
@@ -1447,18 +1449,20 @@ def anderson(x, dist='norm'):
         sol0 = array([xbar, np.std(x, ddof=1, axis=0)])
         sol = optimize.fsolve(rootfunc, sol0, args=(x, N), xtol=1e-5)
         w = (y - sol[0]) / sol[1]
-        z = distributions.logistic.cdf(w)
+        logcdf = distributions.logistic.logcdf(w)
+        logsf = distributions.logistic.logsf(w)
         sig = array([25, 10, 5, 2.5, 1, 0.5])
         critical = around(_Avals_logistic / (1.0 + 0.25/N), 3)
     else:  # (dist == 'gumbel') or (dist == 'extreme1'):
         xbar, s = distributions.gumbel_l.fit(x)
         w = (y - xbar) / s
-        z = distributions.gumbel_l.cdf(w)
+        logcdf = distributions.gumbel_l.logcdf(w)
+        logsf = distributions.gumbel_l.logsf(w)
         sig = array([25, 10, 5, 2.5, 1])
         critical = around(_Avals_gumbel / (1.0 + 0.2/sqrt(N)), 3)
 
     i = arange(1, N + 1)
-    A2 = -N - np.sum((2*i - 1.0) / N * (log(z) + log(1 - z[::-1])), axis=0)
+    A2 = -N - np.sum((2*i - 1.0) / N * (logcdf + logsf[::-1]), axis=0)
 
     return AndersonResult(A2, critical, sig)
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -99,20 +99,21 @@ class TestMvsdist(TestCase):
             [x.mean() for x in stats.mvsdist([1, 2, 3])]
             [x.mean() for x in stats.mvsdist([1, 2, 3, 4, 5])]
 
+
 class TestShapiro(TestCase):
     def test_basic(self):
-        x1 = [0.11,7.87,4.61,10.14,7.95,3.14,0.46,
-              4.43,0.21,4.75,0.71,1.52,3.24,
-              0.93,0.42,4.97,9.53,4.55,0.47,6.66]
-        w,pw = stats.shapiro(x1)
-        assert_almost_equal(w,0.90047299861907959,6)
-        assert_almost_equal(pw,0.042089745402336121,6)
-        x2 = [1.36,1.14,2.92,2.55,1.46,1.06,5.27,-1.11,
-              3.48,1.10,0.88,-0.51,1.46,0.52,6.20,1.69,
-              0.08,3.67,2.81,3.49]
-        w,pw = stats.shapiro(x2)
-        assert_almost_equal(w,0.9590270,6)
-        assert_almost_equal(pw,0.52460,3)
+        x1 = [0.11, 7.87, 4.61, 10.14, 7.95, 3.14, 0.46,
+              4.43, 0.21, 4.75, 0.71, 1.52, 3.24,
+              0.93, 0.42, 4.97, 9.53, 4.55, 0.47, 6.66]
+        w, pw = stats.shapiro(x1)
+        assert_almost_equal(w, 0.90047299861907959, 6)
+        assert_almost_equal(pw, 0.042089745402336121, 6)
+        x2 = [1.36, 1.14, 2.92, 2.55, 1.46, 1.06, 5.27, -1.11,
+              3.48, 1.10, 0.88, -0.51, 1.46, 0.52, 6.20, 1.69,
+              0.08, 3.67, 2.81, 3.49]
+        w, pw = stats.shapiro(x2)
+        assert_almost_equal(w, 0.9590270, 6)
+        assert_almost_equal(pw, 0.52460, 3)
 
         # Verified against R
         np.random.seed(12345678)
@@ -172,9 +173,9 @@ class TestAnderson(TestCase):
         rs = RandomState(1234567890)
         x1 = rs.standard_exponential(size=50)
         x2 = rs.standard_normal(size=50)
-        A,crit,sig = stats.anderson(x1)
+        A, crit, sig = stats.anderson(x1)
         assert_array_less(crit[:-1], A)
-        A,crit,sig = stats.anderson(x2)
+        A, crit, sig = stats.anderson(x2)
         assert_array_less(A, crit[-2:])
 
         v = np.ones(10)
@@ -195,11 +196,11 @@ class TestAnderson(TestCase):
         rs = RandomState(1234567890)
         x1 = rs.standard_exponential(size=50)
         x2 = rs.standard_normal(size=50)
-        A,crit,sig = stats.anderson(x1,'expon')
+        A, crit, sig = stats.anderson(x1, 'expon')
         assert_array_less(A, crit[-2:])
         olderr = np.seterr(all='ignore')
         try:
-            A,crit,sig = stats.anderson(x2,'expon')
+            A, crit, sig = stats.anderson(x2, 'expon')
         finally:
             np.seterr(**olderr)
         assert_(A > crit[-1])
@@ -368,31 +369,32 @@ class TestAndersonKSamp(TestCase):
 class TestAnsari(TestCase):
 
     def test_small(self):
-        x = [1,2,3,3,4]
-        y = [3,2,6,1,6,1,4,1]
+        x = [1, 2, 3, 3, 4]
+        y = [3, 2, 6, 1, 6, 1, 4, 1]
         with warnings.catch_warnings(record=True):  # Ties preclude use ...
-            W, pval = stats.ansari(x,y)
-        assert_almost_equal(W,23.5,11)
-        assert_almost_equal(pval,0.13499256881897437,11)
+            W, pval = stats.ansari(x, y)
+        assert_almost_equal(W, 23.5, 11)
+        assert_almost_equal(pval, 0.13499256881897437, 11)
 
     def test_approx(self):
         ramsay = np.array((111, 107, 100, 99, 102, 106, 109, 108, 104, 99,
                            101, 96, 97, 102, 107, 113, 116, 113, 110, 98))
         parekh = np.array((107, 108, 106, 98, 105, 103, 110, 105, 104,
-                           100, 96, 108, 103, 104, 114, 114, 113, 108, 106, 99))
+                           100, 96, 108, 103, 104, 114, 114, 113, 108,
+                           106, 99))
 
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore',
                         message="Ties preclude use of exact statistic.")
             W, pval = stats.ansari(ramsay, parekh)
 
-        assert_almost_equal(W,185.5,11)
-        assert_almost_equal(pval,0.18145819972867083,11)
+        assert_almost_equal(W, 185.5, 11)
+        assert_almost_equal(pval, 0.18145819972867083, 11)
 
     def test_exact(self):
-        W,pval = stats.ansari([1,2,3,4],[15,5,20,8,10,12])
-        assert_almost_equal(W,10.0,11)
-        assert_almost_equal(pval,0.533333333333333333,7)
+        W, pval = stats.ansari([1, 2, 3, 4], [15, 5, 20, 8, 10, 12])
+        assert_almost_equal(W, 10.0, 11)
+        assert_almost_equal(pval, 0.533333333333333333, 7)
 
     def test_bad_arg(self):
         assert_raises(ValueError, stats.ansari, [], [1])
@@ -412,8 +414,8 @@ class TestBartlett(TestCase):
     def test_data(self):
         args = [g1, g2, g3, g4, g5, g6, g7, g8, g9, g10]
         T, pval = stats.bartlett(*args)
-        assert_almost_equal(T,20.78587342806484,7)
-        assert_almost_equal(pval,0.0136358632781,7)
+        assert_almost_equal(T, 20.78587342806484, 7)
+        assert_almost_equal(pval, 0.0136358632781, 7)
 
     def test_bad_arg(self):
         # Too few args raises ValueError.
@@ -435,14 +437,15 @@ class TestLevene(TestCase):
     def test_data(self):
         args = [g1, g2, g3, g4, g5, g6, g7, g8, g9, g10]
         W, pval = stats.levene(*args)
-        assert_almost_equal(W,1.7059176930008939,7)
-        assert_almost_equal(pval,0.0990829755522,7)
+        assert_almost_equal(W, 1.7059176930008939, 7)
+        assert_almost_equal(pval, 0.0990829755522, 7)
 
     def test_trimmed1(self):
         # Test that center='trimmed' gives the same result as center='mean'
         # when proportiontocut=0.
         W1, pval1 = stats.levene(g1, g2, g3, center='mean')
-        W2, pval2 = stats.levene(g1, g2, g3, center='trimmed', proportiontocut=0.0)
+        W2, pval2 = stats.levene(g1, g2, g3, center='trimmed',
+                                 proportiontocut=0.0)
         assert_almost_equal(W1, W2)
         assert_almost_equal(pval1, pval2)
 
@@ -453,8 +456,10 @@ class TestLevene(TestCase):
         x2 = np.random.permutation(x)
 
         # Use center='trimmed'
-        W0, pval0 = stats.levene(x, y, center='trimmed', proportiontocut=0.125)
-        W1, pval1 = stats.levene(x2, y, center='trimmed', proportiontocut=0.125)
+        W0, pval0 = stats.levene(x, y, center='trimmed',
+                                 proportiontocut=0.125)
+        W1, pval1 = stats.levene(x2, y, center='trimmed',
+                                 proportiontocut=0.125)
         # Trim the data here, and use center='mean'
         W2, pval2 = stats.levene(x[1:-1], y[1:-1], center='mean')
         # Result should be the same.
@@ -463,7 +468,7 @@ class TestLevene(TestCase):
         assert_almost_equal(pval1, pval2)
 
     def test_equal_mean_median(self):
-        x = np.linspace(-1,1,21)
+        x = np.linspace(-1, 1, 21)
         np.random.seed(1234)
         x2 = np.random.permutation(x)
         y = x**3
@@ -473,11 +478,11 @@ class TestLevene(TestCase):
         assert_almost_equal(pval1, pval2)
 
     def test_bad_keyword(self):
-        x = np.linspace(-1,1,21)
+        x = np.linspace(-1, 1, 21)
         assert_raises(TypeError, stats.levene, x, x, portiontocut=0.1)
 
     def test_bad_center_value(self):
-        x = np.linspace(-1,1,21)
+        x = np.linspace(-1, 1, 21)
         assert_raises(ValueError, stats.levene, x, x, center='trim')
 
     def test_too_few_args(self):
@@ -493,16 +498,16 @@ class TestLevene(TestCase):
 class TestBinomP(TestCase):
 
     def test_data(self):
-        pval = stats.binom_test(100,250)
-        assert_almost_equal(pval,0.0018833009350757682,11)
-        pval = stats.binom_test(201,405)
-        assert_almost_equal(pval,0.92085205962670713,11)
-        pval = stats.binom_test([682,243],p=3.0/4)
-        assert_almost_equal(pval,0.38249155957481695,11)
+        pval = stats.binom_test(100, 250)
+        assert_almost_equal(pval, 0.0018833009350757682, 11)
+        pval = stats.binom_test(201, 405)
+        assert_almost_equal(pval, 0.92085205962670713, 11)
+        pval = stats.binom_test([682, 243], p=3.0/4)
+        assert_almost_equal(pval, 0.38249155957481695, 11)
 
     def test_bad_len_x(self):
         # Length of x must be 1 or 2.
-        assert_raises(ValueError, stats.binom_test, [1,2,3])
+        assert_raises(ValueError, stats.binom_test, [1, 2, 3])
 
     def test_bad_n(self):
         # len(x) is 1, but n is invalid.
@@ -524,19 +529,22 @@ class TestBinomP(TestCase):
         res = stats.binom_test(51, 235, p=1./6, alternative='two-sided')
         assert_almost_equal(res, 0.0437479701823997)
 
+
 class TestFligner(TestCase):
 
     def test_data(self):
         # numbers from R: fligner.test in package stats
         x1 = np.arange(5)
-        assert_array_almost_equal(stats.fligner(x1,x1**2),
-                           (3.2282229927203536, 0.072379187848207877), 11)
+        assert_array_almost_equal(stats.fligner(x1, x1**2),
+                                  (3.2282229927203536, 0.072379187848207877),
+                                  11)
 
     def test_trimmed1(self):
         # Test that center='trimmed' gives the same result as center='mean'
         # when proportiontocut=0.
         Xsq1, pval1 = stats.fligner(g1, g2, g3, center='mean')
-        Xsq2, pval2 = stats.fligner(g1, g2, g3, center='trimmed', proportiontocut=0.0)
+        Xsq2, pval2 = stats.fligner(g1, g2, g3, center='trimmed',
+                                    proportiontocut=0.0)
         assert_almost_equal(Xsq1, Xsq2)
         assert_almost_equal(pval1, pval2)
 
@@ -544,7 +552,8 @@ class TestFligner(TestCase):
         x = [1.2, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 100.0]
         y = [0.0, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 200.0]
         # Use center='trimmed'
-        Xsq1, pval1 = stats.fligner(x, y, center='trimmed', proportiontocut=0.125)
+        Xsq1, pval1 = stats.fligner(x, y, center='trimmed',
+                                    proportiontocut=0.125)
         # Trim the data here, and use center='mean'
         Xsq2, pval2 = stats.fligner(x[1:-1], y[1:-1], center='mean')
         # Result should be the same.
@@ -566,11 +575,11 @@ class TestFligner(TestCase):
     #    assert_almost_equal(pval1, pval2)
 
     def test_bad_keyword(self):
-        x = np.linspace(-1,1,21)
+        x = np.linspace(-1, 1, 21)
         assert_raises(TypeError, stats.fligner, x, x, portiontocut=0.1)
 
     def test_bad_center_value(self):
-        x = np.linspace(-1,1,21)
+        x = np.linspace(-1, 1, 21)
         assert_raises(ValueError, stats.fligner, x, x, center='trim')
 
     def test_bad_num_args(self):
@@ -587,7 +596,8 @@ class TestMood(TestCase):
         # numbers from R: mood.test in package stats
         x1 = np.arange(5)
         assert_array_almost_equal(stats.mood(x1, x1**2),
-                                  (-1.3830857299399906, 0.16663858066771478), 11)
+                                  (-1.3830857299399906, 0.16663858066771478),
+                                  11)
 
     def test_mood_order_of_args(self):
         # z should change sign when the order of arguments changes, pvalue
@@ -600,7 +610,7 @@ class TestMood(TestCase):
         assert_array_almost_equal([z1, p1], [-z2, p2])
 
     def test_mood_with_axis_none(self):
-        #Test with axis = None, compare with results from R
+        # Test with axis = None, compare with results from R
         x1 = [-0.626453810742332, 0.183643324222082, -0.835628612410047,
                1.59528080213779, 0.329507771815361, -0.820468384118015,
                0.487429052428485, 0.738324705129217, 0.575781351653492,
@@ -679,7 +689,8 @@ class TestMood(TestCase):
                                               stats.mood(slice1, slice2))
 
     def test_mood_bad_arg(self):
-        # Raise ValueError when the sum of the lengths of the args is less than 3
+        # Raise ValueError when the sum of the lengths of the args is
+        # less than 3
         assert_raises(ValueError, stats.mood, [1], [])
 
 
@@ -784,8 +795,9 @@ class TestProbplot(TestCase):
 def test_wilcoxon_bad_arg():
     # Raise ValueError when two args of different lengths are given or
     # zero_method is unknown.
-    assert_raises(ValueError, stats.wilcoxon, [1], [1,2])
-    assert_raises(ValueError, stats.wilcoxon, [1,2], [1,2], "dummy")
+    assert_raises(ValueError, stats.wilcoxon, [1], [1, 2])
+    assert_raises(ValueError, stats.wilcoxon, [1, 2], [1, 2], "dummy")
+
 
 def test_wilcoxon_arg_type():
     # Should be able to accept list as arguments.
@@ -855,14 +867,16 @@ class TestPpccPlot(TestCase):
     def test_basic(self):
         N = 5
         svals, ppcc = stats.ppcc_plot(self.x, -10, 10, N=N)
-        ppcc_expected = [0.21139644, 0.21384059, 0.98766719, 0.97980182, 0.93519298]
+        ppcc_expected = [0.21139644, 0.21384059, 0.98766719, 0.97980182,
+                         0.93519298]
         assert_allclose(svals, np.linspace(-10, 10, num=N))
         assert_allclose(ppcc, ppcc_expected)
 
     def test_dist(self):
         # Test that we can specify distributions both by name and as objects.
         svals1, ppcc1 = stats.ppcc_plot(self.x, -10, 10, dist='tukeylambda')
-        svals2, ppcc2 = stats.ppcc_plot(self.x, -10, 10, dist=stats.tukeylambda)
+        svals2, ppcc2 = stats.ppcc_plot(self.x, -10, 10,
+                                        dist=stats.tukeylambda)
         assert_allclose(svals1, svals2, rtol=1e-20)
         assert_allclose(ppcc1, ppcc2, rtol=1e-20)
         # Test that 'tukeylambda' is the default dist
@@ -1093,7 +1107,7 @@ class TestBoxcoxNormplot(TestCase):
 
 class TestCircFuncs(TestCase):
     def test_circfuncs(self):
-        x = np.array([355,5,2,359,10,350])
+        x = np.array([355, 5, 2, 359, 10, 350])
         M = stats.circmean(x, high=360)
         Mval = 0.167690146
         assert_allclose(M, Mval, rtol=1e-7)
@@ -1107,7 +1121,7 @@ class TestCircFuncs(TestCase):
         assert_allclose(S, Sval, rtol=1e-7)
 
     def test_circfuncs_small(self):
-        x = np.array([20,21,22,18,19,20.5,19.2])
+        x = np.array([20, 21, 22, 18, 19, 20.5, 19.2])
         M1 = x.mean()
         M2 = stats.circmean(x, high=360)
         assert_allclose(M2, M1, rtol=1e-5)
@@ -1121,9 +1135,9 @@ class TestCircFuncs(TestCase):
         assert_allclose(S2, S1, rtol=1e-4)
 
     def test_circmean_axis(self):
-        x = np.array([[355,5,2,359,10,350],
-                      [351,7,4,352,9,349],
-                      [357,9,8,358,4,356]])
+        x = np.array([[355, 5, 2, 359, 10, 350],
+                      [351, 7, 4, 352, 9, 349],
+                      [357, 9, 8, 358, 4, 356]])
         M1 = stats.circmean(x, high=360)
         M2 = stats.circmean(x.ravel(), high=360)
         assert_allclose(M1, M2, rtol=1e-14)
@@ -1133,13 +1147,13 @@ class TestCircFuncs(TestCase):
         assert_allclose(M1, M2, rtol=1e-14)
 
         M1 = stats.circmean(x, high=360, axis=0)
-        M2 = [stats.circmean(x[:,i], high=360) for i in range(x.shape[1])]
+        M2 = [stats.circmean(x[:, i], high=360) for i in range(x.shape[1])]
         assert_allclose(M1, M2, rtol=1e-14)
 
     def test_circvar_axis(self):
-        x = np.array([[355,5,2,359,10,350],
-                      [351,7,4,352,9,349],
-                  [357,9,8,358,4,356]])
+        x = np.array([[355, 5, 2, 359, 10, 350],
+                      [351, 7, 4, 352, 9, 349],
+                      [357, 9, 8, 358, 4, 356]])
 
         V1 = stats.circvar(x, high=360)
         V2 = stats.circvar(x.ravel(), high=360)
@@ -1150,13 +1164,13 @@ class TestCircFuncs(TestCase):
         assert_allclose(V1, V2, rtol=1e-11)
 
         V1 = stats.circvar(x, high=360, axis=0)
-        V2 = [stats.circvar(x[:,i], high=360) for i in range(x.shape[1])]
+        V2 = [stats.circvar(x[:, i], high=360) for i in range(x.shape[1])]
         assert_allclose(V1, V2, rtol=1e-11)
 
     def test_circstd_axis(self):
-        x = np.array([[355,5,2,359,10,350],
-                      [351,7,4,352,9,349],
-                      [357,9,8,358,4,356]])
+        x = np.array([[355, 5, 2, 359, 10, 350],
+                      [351, 7, 4, 352, 9, 349],
+                      [357, 9, 8, 358, 4, 356]])
 
         S1 = stats.circstd(x, high=360)
         S2 = stats.circstd(x.ravel(), high=360)
@@ -1167,11 +1181,11 @@ class TestCircFuncs(TestCase):
         assert_allclose(S1, S2, rtol=1e-11)
 
         S1 = stats.circstd(x, high=360, axis=0)
-        S2 = [stats.circstd(x[:,i], high=360) for i in range(x.shape[1])]
+        S2 = [stats.circstd(x[:, i], high=360) for i in range(x.shape[1])]
         assert_allclose(S1, S2, rtol=1e-11)
 
     def test_circfuncs_array_like(self):
-        x = [355,5,2,359,10,350]
+        x = [355, 5, 2, 359, 10, 350]
         assert_allclose(stats.circmean(x, high=360), 0.167690146, rtol=1e-7)
         assert_allclose(stats.circvar(x, high=360), 42.51955609, rtol=1e-7)
         assert_allclose(stats.circstd(x, high=360), 6.520702116, rtol=1e-7)
@@ -1271,10 +1285,12 @@ class TestMedianTest(TestCase):
                       ties="above")
 
     def test_bad_ties(self):
-        assert_raises(ValueError, stats.median_test, [1, 2, 3], [4, 5], ties="foo")
+        assert_raises(ValueError, stats.median_test, [1, 2, 3], [4, 5],
+                      ties="foo")
 
     def test_bad_keyword(self):
-        assert_raises(TypeError, stats.median_test, [1, 2, 3], [4, 5], foo="foo")
+        assert_raises(TypeError, stats.median_test, [1, 2, 3], [4, 5],
+                      foo="foo")
 
     def test_simple(self):
         x = [1, 2, 3]
@@ -1286,8 +1302,8 @@ class TestMedianTest(TestCase):
 
         assert_array_equal(tbl, [[1, 1], [2, 2]])
 
-        # The expected values of the contingency table equal the contingency table,
-        # so the statistic should be 0 and the p-value should be 1.
+        # The expected values of the contingency table equal the contingency
+        # table, so the statistic should be 0 and the p-value should be 1.
         assert_equal(stat, 0)
         assert_equal(p, 1)
 


### PR DESCRIPTION
Replace `log(z) + log(1 - z[::-1])`, where `z` is `<dist>.cdf(w)`,
with `<dist>.logcdf(w) + <dist>.logsf(w)[::-1]`.  This avoids the
problem where the `cdf` method returns 1 for sufficiently large
values in `w`.

Closes gh-6306.
