### PR TITLE
CI: try to avoid the pip failure on python 3.5 on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,8 @@ script:
     if [ "${USE_WHEEL}" == "1" ]; then
         # Need verbose output or TravisCI will terminate after 10 minutes
         pip wheel . -v
-        pip install wheelhouse/* -v
+        pip --version
+        pip install wheelhouse -v
         USE_WHEEL_BUILD="--no-build"
     elif [ "${USE_SDIST}" == "1" ]; then
         python setup.py sdist


### PR DESCRIPTION
At least I can replicate the error locally with pip 8.1.2 on master and with this change `pip install wheelhouse` succeeds locally.
Other than that, I've no clue what I'm doing.
