### PR TITLE
ENH: Descending order of x in PPoly

### DIFF
--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -1181,14 +1181,22 @@ def evaluate_bernstein(double_or_complex[:,:,::1] c,
         else:
             wrk = np.empty((c.shape[0]-nu, 1, 1), dtype=np.float_)
         
-    # evaluate
-    interval = 0
 
+    interval = 0
+    cdef bint ascending = x[x.shape[0] - 1] >= x[0]
+
+    # Evaluate.
     for ip in range(len(xp)):
         xval = xp[ip]
 
         # Find correct interval
-        i = find_interval_ascending(&x[0], x.shape[0], xval, interval, extrapolate)
+        if ascending:
+            i = find_interval_ascending(&x[0], x.shape[0], xval, interval,
+                                        extrapolate)
+        else:
+            i = find_interval_descending(&x[0], x.shape[0], xval, interval,
+                                         extrapolate)
+
         if i < 0:
             # xval was nan etc
             for jp in range(c.shape[2]):

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -712,7 +712,7 @@ class _PPolyBase(object):
         if not self.c.flags.c_contiguous:
             self.c = self.c.copy()
 
-    def extend(self, c, x):
+    def extend(self, c, x, right=None):
         """
         Add additional breakpoints and coefficients to the polynomial.
 
@@ -726,7 +726,14 @@ class _PPolyBase(object):
             Additional breakpoints. Must be sorted in the same order as
             `self.x` and either to the right or to the left of the current
             breakpoints.
+        right
+            Deprecated argument. Has no effect.
+
+            .. deprecated:: 0.19
         """
+        if right is not None:
+            warnings.warn("`right` is deprecated and will be removed.")
+
         c = np.asarray(c)
         x = np.asarray(x)
 
@@ -1505,7 +1512,10 @@ class BPoly(_PPolyBase):
         else:
             return ib(b) - ib(a)
 
-    def extend(self, c, x):
+    def extend(self, c, x, right):
+        if right is not None:
+            warnings.warn("`right` is deprecated and will be removed.")
+
         k = max(self.c.shape[0], c.shape[0])
         self.c = self._raise_degree(self.c, k - self.c.shape[0])
         c = self._raise_degree(c, k - c.shape[0])

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -846,20 +846,20 @@ class PPoly(_PPolyBase):
     """
     Piecewise polynomial in terms of coefficients and breakpoints
 
-    The polynomial in the ith interval is ``x[i] <= xp < x[i+1]``::
+    The polynomial between ``x[i]`` and ``x[i + 1]`` is written in the
+    local power basis::
 
         S = sum(c[m, i] * (xp - x[i])**(k-m) for m in range(k+1))
 
-    where ``k`` is the degree of the polynomial. This representation
-    is the local power basis.
+    where ``k`` is the degree of the polynomial.
 
     Parameters
     ----------
     c : ndarray, shape (k, m, ...)
         Polynomial coefficients, order `k` and `m` intervals
     x : ndarray, shape (m+1,)
-        Polynomial breakpoints. These must be sorted in
-        increasing order.
+        Polynomial breakpoints. Must be sorted in either increasing or
+        decreasing order.
     extrapolate : bool or 'periodic', optional
         If bool, determines whether to extrapolate to out-of-bounds points
         based on first and last intervals, or to return NaNs. If 'periodic',
@@ -1246,16 +1246,16 @@ class PPoly(_PPolyBase):
 class BPoly(_PPolyBase):
     """Piecewise polynomial in terms of coefficients and breakpoints.
 
-    The polynomial in the ``i``-th interval ``x[i] <= xp < x[i+1]`` is written
-    in the Bernstein polynomial basis::
+    The polynomial between ``x[i]`` and ``x[i + 1]`` is written in the
+    Bernstein polynomial basis::
 
         S = sum(c[a, i] * b(a, k; x) for a in range(k+1)),
 
     where ``k`` is the degree of the polynomial, and::
 
-        b(a, k; x) = binom(k, a) * t**k * (1 - t)**(k - a),
+        b(a, k; x) = binom(k, a) * t**a * (1 - t)**(k - a),
 
-    with ``t = (x - x[i]) / (x[i+1] - x[i])`` and ``binom`` is a binomial
+    with ``t = (x - x[i]) / (x[i+1] - x[i])`` and ``binom`` is the binomial
     coefficient.
 
     Parameters
@@ -1263,8 +1263,8 @@ class BPoly(_PPolyBase):
     c : ndarray, shape (k, m, ...)
         Polynomial coefficients, order `k` and `m` intervals
     x : ndarray, shape (m+1,)
-        Polynomial breakpoints. These must be sorted in
-        increasing order.
+        Polynomial breakpoints. Must be sorted in either increasing or
+        decreasing order.
     extrapolate : bool, optional
         If bool, determines whether to extrapolate to out-of-bounds points
         based on first and last intervals, or to return NaNs. If 'periodic',

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -1512,14 +1512,11 @@ class BPoly(_PPolyBase):
         else:
             return ib(b) - ib(a)
 
-    def extend(self, c, x, right):
-        if right is not None:
-            warnings.warn("`right` is deprecated and will be removed.")
-
+    def extend(self, c, x, right=None):
         k = max(self.c.shape[0], c.shape[0])
         self.c = self._raise_degree(self.c, k - self.c.shape[0])
         c = self._raise_degree(c, k - c.shape[0])
-        return _PPolyBase.extend(self, c, x)
+        return _PPolyBase.extend(self, c, x, right)
     extend.__doc__ = _PPolyBase.extend.__doc__
 
     @classmethod

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -24,6 +24,8 @@ from scipy._lib._gcutils import assert_deallocated
 
 from scipy.integrate import nquad
 
+from scipy.special import binom
+
 
 class TestInterp2D(TestCase):
     def test_interp2d(self):
@@ -729,8 +731,8 @@ class TestPPolyCommon(TestCase):
             pp = cls(c[:,:9], x[:10])
             pp.extend(c[:,9:], x[10:])
 
-            pp2 = cls(c[:,10:], x[10:])
-            pp2.extend(c[:,:10], x[:10], right=False)
+            pp2 = cls(c[:, 10:], x[10:])
+            pp2.extend(c[:, :10], x[:10])
 
             pp3 = cls(c, x)
 
@@ -763,6 +765,26 @@ class TestPPolyCommon(TestCase):
 
             assert_allclose(pp1(xi1), pp_comb(xi1))
             assert_allclose(pp2(xi2), pp_comb(xi2))
+
+    def test_extend_descending(self):
+        np.random.seed(0)
+
+        order = 3
+        x = np.sort(np.random.uniform(0, 10, 20))
+        c = np.random.rand(order + 1, x.shape[0] - 1, 2, 3)
+
+        p = PPoly(c, x)
+
+        p1 = PPoly(c[:, :9], x[:10])
+        p1.extend(c[:, 9:], x[10:])
+
+        p2 = PPoly(c[:, 10:], x[10:])
+        p2.extend(c[:, :10], x[:10])
+
+        assert_array_equal(p1.c, p.c)
+        assert_array_equal(p1.x, p.x)
+        assert_array_equal(p2.c, p.c)
+        assert_array_equal(p2.x, p.x)
 
     def test_shape(self):
         np.random.seed(1234)
@@ -891,6 +913,55 @@ class TestPPoly(TestCase):
 
         assert_allclose(p(1.3, 1), 2 * 0.3 + 2)
         assert_allclose(p(-0.3, 1), 8 * (0.7 - 0.5) + 5)
+
+    def test_descending(self):
+        def binom_matrix(power):
+            n = np.arange(power + 1).reshape(-1, 1)
+            k = np.arange(power + 1)
+            B = binom(n, k)
+            return B[::-1, ::-1]
+
+        np.random.seed(0)
+
+        power = 3
+        for m in [10, 20, 30]:
+            x = np.sort(np.random.uniform(0, 10, m + 1))
+            ca = np.random.uniform(-2, 2, size=(power + 1, m))
+
+            h = np.diff(x)
+            h_powers = h[None, :] ** np.arange(power + 1)[::-1, None]
+            B = binom_matrix(power)
+            cap = ca * h_powers
+            cdp = np.dot(B.T, cap)
+            cd = cdp / h_powers
+
+            pa = PPoly(ca, x, extrapolate=True)
+            pd = PPoly(cd[:, ::-1], x[::-1], extrapolate=True)
+
+            x_test = np.random.uniform(-10, 20, 100)
+            assert_allclose(pa(x_test), pd(x_test), rtol=1e-13)
+            assert_allclose(pa(x_test, 1), pd(x_test, 1), rtol=1e-13)
+
+            pa_d = pa.derivative()
+            pd_d = pd.derivative()
+
+            assert_allclose(pa_d(x_test), pd_d(x_test), rtol=1e-13)
+
+            # Antiderivatives won't be equal because fixing continuity is
+            # done in the reverse order, but surely the differences should be
+            # equal.
+            pa_i = pa.antiderivative()
+            pd_i = pd.antiderivative()
+            for a, b in np.random.uniform(-10, 20, (5, 2)):
+                int_a = pa.integrate(a, b)
+                int_d = pd.integrate(a, b)
+                assert_allclose(int_a, int_d, rtol=1e-13)
+                assert_allclose(pa_i(b) - pa_i(a), pd_i(b) - pd_i(a),
+                                rtol=1e-13)
+
+            roots_d = pd.roots()
+            roots_a = pa.roots()
+            assert_allclose(roots_a, np.sort(roots_d), rtol=1e-12)
 
     def test_multi_shape(self):
         c = np.random.rand(6, 2, 1, 2, 3)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -773,18 +773,19 @@ class TestPPolyCommon(TestCase):
         x = np.sort(np.random.uniform(0, 10, 20))
         c = np.random.rand(order + 1, x.shape[0] - 1, 2, 3)
 
-        p = PPoly(c, x)
+        for cls in (PPoly, BPoly):
+            p = cls(c, x)
 
-        p1 = PPoly(c[:, :9], x[:10])
-        p1.extend(c[:, 9:], x[10:])
+            p1 = cls(c[:, :9], x[:10])
+            p1.extend(c[:, 9:], x[10:])
 
-        p2 = PPoly(c[:, 10:], x[10:])
-        p2.extend(c[:, :10], x[:10])
+            p2 = cls(c[:, 10:], x[10:])
+            p2.extend(c[:, :10], x[:10])
 
-        assert_array_equal(p1.c, p.c)
-        assert_array_equal(p1.x, p.x)
-        assert_array_equal(p2.c, p.c)
-        assert_array_equal(p2.x, p.x)
+            assert_array_equal(p1.c, p.c)
+            assert_array_equal(p1.x, p.x)
+            assert_array_equal(p2.c, p.c)
+            assert_array_equal(p2.x, p.x)
 
     def test_shape(self):
         np.random.seed(1234)
@@ -1394,6 +1395,40 @@ class TestBPoly(TestCase):
 
         assert_allclose(bp(3.4, 1), -6 * 0.6)
         assert_allclose(bp(-1.3, 1), 2 * (0.7/2))
+
+    def test_descending(self):
+        np.random.seed(0)
+
+        power = 3
+        for m in [10, 20, 30]:
+            x = np.sort(np.random.uniform(0, 10, m + 1))
+            ca = np.random.uniform(-0.1, 0.1, size=(power + 1, m))
+            # We need only to flip coefficients to get it right!
+            cd = ca[::-1].copy()
+
+            pa = BPoly(ca, x, extrapolate=True)
+            pd = BPoly(cd[:, ::-1], x[::-1], extrapolate=True)
+
+            x_test = np.random.uniform(-10, 20, 100)
+            assert_allclose(pa(x_test), pd(x_test), rtol=1e-13)
+            assert_allclose(pa(x_test, 1), pd(x_test, 1), rtol=1e-13)
+
+            pa_d = pa.derivative()
+            pd_d = pd.derivative()
+
+            assert_allclose(pa_d(x_test), pd_d(x_test), rtol=1e-13)
+
+            # Antiderivatives won't be equal because fixing continuity is
+            # done in the reverse order, but surely the differences should be
+            # equal.
+            pa_i = pa.antiderivative()
+            pd_i = pd.antiderivative()
+            for a, b in np.random.uniform(-10, 20, (5, 2)):
+                int_a = pa.integrate(a, b)
+                int_d = pd.integrate(a, b)
+                assert_allclose(int_a, int_d, rtol=1e-12)
+                assert_allclose(pa_i(b) - pa_i(a), pd_i(b) - pd_i(a),
+                                rtol=1e-12)
 
     def test_multi_shape(self):
         c = np.random.rand(6, 2, 1, 2, 3)


### PR DESCRIPTION
Hi!

Currently `PPoly` requires `x` to be in ascending order, which is typically sufficient. But if you computed coefficients for breakpoints in descending order (say integrated ODE back it time), then it will be awkward  to recompute coefficients to the required format (it's not very difficult, but not obvious). 

On the other hand, ascending and descending orders are not different at all from a mathematical point of view. So it required only few modifications to support both.

@ev-br @pv please take a look.
