### PR TITLE
ENH: stats: Add support for nan_policy to stats.median_test

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2479,7 +2479,8 @@ def median_test(*args, **kwds):
         of the values below the grand median.  The table allows further
         analysis with, for example, `scipy.stats.chi2_contingency`, or with
         `scipy.stats.fisher_exact` if there are two samples, without having
-        to recompute the table.
+        to recompute the table.  If ``nan_policy`` is "propagate" and there
+        are nans in the input, the return value for ``table`` is ``None``.
 
     See Also
     --------
@@ -2588,9 +2589,15 @@ def median_test(*args, **kwds):
     cdata = np.concatenate(data)
     contains_nan, nan_policy = _contains_nan(cdata, nan_policy)
     if contains_nan and nan_policy == 'propagate':
-        return (np.nan,)*4
+        return np.nan, np.nan, np.nan, None
 
-    grand_median = np.nanmedian(cdata)
+    if contains_nan:
+        grand_median = np.median(cdata[~np.isnan(cdata)])
+    else:
+        grand_median = np.median(cdata)
+    # When the minimum version of numpy supported by scipy is 1.9.0,
+    # the above if/else statement can be replaced by the single line:
+    #     grand_median = np.nanmedian(cdata)
 
     # Create the contingency table.
     table = np.zeros((2, len(data)), dtype=np.int64)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1290,7 +1290,7 @@ class TestMedianTest(TestCase):
         mt1 = stats.median_test(x, y, nan_policy='propagate')
         s, p, m, t = stats.median_test(x, y, nan_policy='omit')
 
-        assert_equal(mt1, (np.nan, np.nan, np.nan, np.nan))
+        assert_equal(mt1, (np.nan, np.nan, np.nan, None))
         assert_allclose(s, 0.31250000000000006)
         assert_allclose(p, 0.57615012203057869)
         assert_equal(m, 4.0)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1243,6 +1243,9 @@ class TestMedianTest(TestCase):
     def test_bad_ties(self):
         assert_raises(ValueError, stats.median_test, [1, 2, 3], [4, 5], ties="foo")
 
+    def test_bad_nan_policy(self):
+        assert_raises(ValueError, stats.median_test, [1, 2, 3], [4, 5], nan_policy='foobar')
+
     def test_bad_keyword(self):
         assert_raises(TypeError, stats.median_test, [1, 2, 3], [4, 5], foo="foo")
 
@@ -1280,6 +1283,19 @@ class TestMedianTest(TestCase):
         stat, p, m, tbl = stats.median_test(x, y, z, ties="above")
         assert_equal(m, 5)
         assert_equal(tbl, [[0, 2, 3], [4, 0, 0]])
+
+    def test_nan_policy_options(self):
+        x = [1, 2, np.nan]
+        y = [4, 5, 6]
+        mt1 = stats.median_test(x, y, nan_policy='propagate')
+        s, p, m, t = stats.median_test(x, y, nan_policy='omit')
+
+        assert_equal(mt1, (np.nan, np.nan, np.nan, np.nan))
+        assert_allclose(s, 0.31250000000000006)
+        assert_allclose(p, 0.57615012203057869)
+        assert_equal(m, 4.0)
+        assert_equal(t, np.array([[0, 2],[2, 1]]))
+        assert_raises(ValueError, stats.median_test, x, y, nan_policy='raise')
 
     def test_basic(self):
         # median_test calls chi2_contingency to compute the test statistic


### PR DESCRIPTION
I merged @Inoryy's two commits from https://github.com/scipy/scipy/pull/5723, and added a couple tweaks in a new commit:
- When 'propagating' a `nan`, it doesn't make sense for the fourth return value (which is usually the contingency table) to be `nan`, so I changed it to return None.  (`nan` only makes sense for the return values that are normally floating point scalars.)
- numpy.nanmedian was added to numpy in version 1.9.0, so until that is the minimum version supported by scipy, the grand median is calculated using
  
  ```
    grand_median = np.median(cdata[~np.isnan(cdata)])
  ```
  
  when there are nans in the input.

(The above description was edited to reflect the updated changes in 3408e60.)
