### PR TITLE
TST: signal: use assert_allclose for testing near-equality in FP

### DIFF
--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1296,7 +1296,7 @@ class TestFiltFilt(TestCase):
     def test_basic(self):
         zpk = tf2zpk([1, 2, 3], [1, 2, 3])
         out = self.filtfilt(zpk, np.arange(12))
-        assert_equal(out, arange(12))
+        assert_allclose(out, arange(12), atol=1e-14)
 
     def test_sine(self):
         rate = 2000


### PR DESCRIPTION
This should address two test failures out of three reported in https://github.com/scipy/scipy/issues/6286#issuecomment-229060664
