### PR TITLE
Define LinregressResult outside of linregress

### DIFF
--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -7,6 +7,9 @@ from . import distributions
 
 __all__ = ['_find_repeats', 'linregress', 'theilslopes']
 
+LinregressResult = namedtuple('LinregressResult', ('slope', 'intercept',
+                                                   'rvalue', 'pvalue',
+                                                   'stderr'))
 
 def linregress(x, y=None):
     """
@@ -96,9 +99,6 @@ def linregress(x, y=None):
     intercept = ymean - slope*xmean
     sterrest = np.sqrt((1 - r**2) * ssym / ssxm / df)
 
-    LinregressResult = namedtuple('LinregressResult', ('slope', 'intercept',
-                                                       'rvalue', 'pvalue',
-                                                       'stderr'))
     return LinregressResult(slope, intercept, r, prob, sterrest)
 
 


### PR DESCRIPTION
Creating a new LinregressResult class on each call to linregress is bad
for performance because:
- nametuple evals a new class object on each call, and
- The garbage collector will have to be activated to
  collect that class when it's no longer being used.
