### PR TITLE
In anderson test, added support for right skewed gumbel distribution.

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1368,9 +1368,10 @@ def anderson(x, dist='norm'):
     ----------
     x : array_like
         array of sample data
-    dist : {'norm','expon','logistic','gumbel','extreme1'}, optional
+    dist : {'norm','expon','logistic','gumbel','gumbel_l', gumbel_r',
+        'extreme1'}, optional
         the type of distribution to test against.  The default is 'norm'
-        and 'extreme1' is a synonym for 'gumbel'
+        and 'extreme1', 'gumbel_l' and 'gumbel' are synonyms.
 
     Returns
     -------
@@ -1418,7 +1419,8 @@ def anderson(x, dist='norm'):
            pp. 591-595.
 
     """
-    if dist not in ['norm', 'expon', 'gumbel', 'extreme1', 'logistic']:
+    if dist not in ['norm', 'expon', 'gumbel', 'gumbel_l',
+                    'gumbel_r', 'extreme1', 'logistic']:
         raise ValueError("Invalid distribution; dist must be 'norm', "
                          "'expon', 'gumbel', 'extreme1' or 'logistic'.")
     y = sort(x)
@@ -1453,7 +1455,14 @@ def anderson(x, dist='norm'):
         logsf = distributions.logistic.logsf(w)
         sig = array([25, 10, 5, 2.5, 1, 0.5])
         critical = around(_Avals_logistic / (1.0 + 0.25/N), 3)
-    else:  # (dist == 'gumbel') or (dist == 'extreme1'):
+    elif dist == 'gumbel_r':
+        xbar, s = distributions.gumbel_r.fit(x)
+        w = (y - xbar) / s
+        logcdf = distributions.gumbel_r.logcdf(w)
+        logsf = distributions.gumbel_r.logsf(w)
+        sig = array([25, 10, 5, 2.5, 1])
+        critical = around(_Avals_gumbel / (1.0 + 0.2/sqrt(N)), 3)
+    else:  # (dist == 'gumbel') or (dist == 'gumbel_l') or (dist == 'extreme1')
         xbar, s = distributions.gumbel_l.fit(x)
         w = (y - xbar) / s
         logcdf = distributions.gumbel_l.logcdf(w)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -231,6 +231,28 @@ class TestAnderson(TestCase):
         attributes = ('statistic', 'critical_values', 'significance_level')
         check_named_results(res, attributes)
 
+    def test_gumbel_l(self):
+        # gh-2592, gh-6337
+        # Adds support to 'gumbel_r' and 'gumbel_l' as valid inputs for dist.
+        rs = RandomState(1234567890)
+        x = rs.gumbel(size=100)
+        A1, crit1, sig1 = stats.anderson(x, 'gumbel')
+        A2, crit2, sig2 = stats.anderson(x, 'gumbel_l')
+
+        assert_allclose(A2, A1)
+
+    def test_gumbel_r(self):
+        # gh-2592, gh-6337
+        # Adds support to 'gumbel_r' and 'gumbel_l' as valid inputs for dist.
+        rs = RandomState(1234567890)
+        x1 = rs.gumbel(size=100)
+        x2 = np.ones(100)
+        A1, crit1, sig1 = stats.anderson(x1, 'gumbel_r')
+        A2, crit2, sig2 = stats.anderson(x2, 'gumbel_r')
+
+        assert_array_less(A1, crit1[-2:])
+        assert_(A2 > crit2[-1])
+
 
 class TestAndersonKSamp(TestCase):
     def test_example1a(self):


### PR DESCRIPTION
The default anderson tests with dist='gumbel' assumes a left skewed
gumbel distro, gumbel_l.

For compatibility with the distros available in scipy.stats, added
functionality for the user to test right skewed gumbel distributions,
gumbel_r.

If user input is dist='gumbel', then 'gumbel_l' is assumed, as before.
On the top of that, added possibility for user input dist='gumbel_r'.

PS: I'm new to github. Please let me know if I'm doing things as they should be done =)
