### PR TITLE
BUG: special: add a fallback implementation of sqrt(z) for complex z

### DIFF
--- a/scipy/special/_complexstuff.pxd
+++ b/scipy/special/_complexstuff.pxd
@@ -24,6 +24,10 @@ cdef extern from "_complexstuff.h":
     double pi "NPY_PI"
     double nan "NPY_NAN"
 
+cdef extern from "_csqrt.h":
+    np.npy_cdouble npy_compat_csqrt(np.npy_cdouble z) nogil
+
+
 DEF tol = 2.220446092504131e-16
 
 ctypedef double complex double_complex
@@ -116,7 +120,7 @@ cdef inline number_t zcos(number_t x) nogil:
 cdef inline number_t zsqrt(number_t x) nogil:
     cdef np.npy_cdouble r
     if number_t is double_complex:
-        r = npy_csqrt(npy_cdouble_from_double_complex(x))
+        r = npy_compat_csqrt(npy_cdouble_from_double_complex(x))
         return double_complex_from_npy_cdouble(r)
     else:
         return libc.math.sqrt(x)

--- a/scipy/special/_csqrt.c.src
+++ b/scipy/special/_csqrt.c.src
@@ -1,0 +1,101 @@
+#include <Python.h>
+#include <float.h>
+
+#include <numpy/npy_math.h>
+
+/*
+ * Fallback implementation of sqrt(z) for double complex z.
+ *
+ * Copied from numpy/numpy/core/src/npymath/npy_math_complex.c.src
+ *
+ * Prompted by gh-6336, which reported that
+ * > Scipy 0.18.0rc1's test_hyp0f1 (test_basic.TestHyper) crashes on 64 bit Python 3.5 for Windows.
+ * > The crash is in the npy_csqrt function, which uses the csqrt function of the CRT. 
+ */
+
+
+/**begin repeat
+ * #type = npy_double#
+ * #ctype = npy_cdouble#
+ * #c = #
+ * #C = #
+ * #TMAX = DBL_MAX#
+ */
+
+
+/* We risk spurious overflow for components >= DBL_MAX / (1 + sqrt(2)). */
+#define THRESH  (@TMAX@ / (1 + NPY_SQRT2@c@))
+
+@ctype@
+npy_compat_csqrt(@ctype@ z)
+{
+    @ctype@ result;
+    @type@ a, b;
+    @type@ t;
+    int scale;
+
+    a = npy_creal@c@(z);
+    b = npy_cimag@c@(z);
+
+    /* Handle special cases. */
+    if (a == 0 && b == 0) {
+        return (npy_cpack@c@(0, b));
+    }
+    if (npy_isinf(b)) {
+        return (npy_cpack@c@(NPY_INFINITY@C@, b));
+    }
+    if (npy_isnan(a)) {
+        t = (b - b) / (b - b);  /* raise invalid if b is not a NaN */
+        return (npy_cpack@c@(a, t));    /* return NaN + NaN i */
+    }
+    if (npy_isinf(a)) {
+        /*
+         * csqrt(inf + NaN i)  = inf +  NaN i
+         * csqrt(inf + y i)    = inf +  0 i
+         * csqrt(-inf + NaN i) = NaN +- inf i
+         * csqrt(-inf + y i)   = 0   +  inf i
+         */
+        if (npy_signbit(a)) {
+            return (npy_cpack@c@(npy_fabs@c@(b - b), npy_copysign@c@(a, b)));
+        }
+        else {
+            return (npy_cpack@c@(a, npy_copysign@c@(b - b, b)));
+        }
+    }
+    /*
+     * The remaining special case (b is NaN) is handled just fine by
+     * the normal code path below.
+     */
+
+    /* Scale to avoid overflow. */
+    if (npy_fabs@c@(a) >= THRESH || npy_fabs@c@(b) >= THRESH) {
+        a *= 0.25;
+        b *= 0.25;
+        scale = 1;
+    }
+    else {
+        scale = 0;
+    }
+
+    /* Algorithm 312, CACM vol 10, Oct 1967. */
+    if (a >= 0) {
+        t = npy_sqrt@c@((a + npy_hypot@c@(a, b)) * 0.5@c@);
+        result = npy_cpack@c@(t, b / (2 * t));
+    }
+    else {
+        t = npy_sqrt@c@((-a + npy_hypot@c@(a, b)) * 0.5@c@);
+        result = npy_cpack@c@(npy_fabs@c@(b) / (2 * t), npy_copysign@c@(t, b));
+    }
+
+    /* Rescale. */
+    if (scale) {
+        return (npy_cpack@c@(npy_creal@c@(result) * 2, npy_cimag@c@(result)));
+    }
+    else {
+        return (result);
+    }
+}
+#undef THRESH
+
+
+/**end repeat**/

--- a/scipy/special/_csqrt.h
+++ b/scipy/special/_csqrt.h
@@ -1,0 +1,8 @@
+#ifndef __CSQRT_H__
+#define __CSQRT_H__
+
+#include <numpy/npy_math.h>
+
+npy_cdouble npy_compat_csqrt(npy_cdouble z);
+
+#endif

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -71,7 +71,7 @@ def configuration(parent_package='',top_path=None):
 
     # Extension _ufuncs
     headers = ['*.h', join('c_misc', '*.h'), join('cephes', '*.h')]
-    ufuncs_src = ['_ufuncs.c', 'sf_error.c', '_logit.c.src',
+    ufuncs_src = ['_ufuncs.c', 'sf_error.c', '_logit.c.src', "_csqrt.c.src",
                   "amos_wrappers.c", "cdf_wrappers.c", "specfun_wrappers.c"]
     ufuncs_dep = (headers + ufuncs_src + amos_src + c_misc_src + cephes_src
                   + mach_src + cdf_src + specfun_src)


### PR DESCRIPTION
Copy the implementation from numpy.

Attempts to fix gh-6336.

This probably needs some preprocessor magic to restrict the use of the fallback to CRTs where this actually matters (does gh-6336 fail on python < 3.5 on Windows?).

In fact, I'm not even sure if this fixes an upstream defect (i.e., the problem is in CRT) or just papers over the actual problem.
