### PR TITLE
ENH: Vectorized computations in approx_derivative 

### DIFF
--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -456,6 +456,7 @@ def _dense_difference_vectorized(fun, x0, f0, h, use_one_sided, method):
             F = fun(X)
         F -= f0[:, None]
         F /= dx
+        J = F
     elif method == '3-point':
         n = x0.size
         one_sided = np.nonzero(use_one_sided)[0]
@@ -486,16 +487,16 @@ def _dense_difference_vectorized(fun, x0, f0, h, use_one_sided, method):
 
         F1[:, two_sided] -= F2[:, two_sided]
         F1 /= dx
-        F = F1
+        J = F1
     elif method == 'cs':
         X = x0 + h_vecs * 1j
         F = fun(X)
-        F = F.imag / h
+        J = F.imag / h
 
-    if F.shape[0] == 1:
-        F = np.ravel(F)
+    if J.shape[0] == 1:
+        J = np.ravel(J)
 
-    return F
+    return J
 
 
 def _sparse_difference(fun, x0, f0, h, use_one_sided,

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -123,7 +123,10 @@ class TestApproxDerivativesDense(object):
         return np.cosh(x)
 
     def fun_scalar_vector(self, x):
-        return np.array([x[0]**2, np.tan(x[0]), np.exp(x[0])])
+        if x.ndim == 1:
+            return np.array([x[0]**2, np.tan(x[0]), np.exp(x[0])])
+        else:
+            return np.vstack([x[0]**2, np.tan(x[0]), np.exp(x[0])])
 
     def jac_scalar_vector(self, x):
         return np.array(
@@ -143,11 +146,18 @@ class TestApproxDerivativesDense(object):
         ])
 
     def fun_vector_vector(self, x):
-        return np.array([
-            x[0] * np.sin(x[1]),
-            x[1] * np.cos(x[0]),
-            x[0] ** 3 * x[1] ** -0.5
-        ])
+        if x.ndim == 1:
+            return np.array([
+                x[0] * np.sin(x[1]),
+                x[1] * np.cos(x[0]),
+                x[0] ** 3 * x[1] ** -0.5
+            ])
+        else:
+            return np.vstack([
+                x[0] * np.sin(x[1]),
+                x[1] * np.cos(x[0]),
+                x[0] ** 3 * x[1] ** -0.5
+            ])
 
     def jac_vector_vector(self, x):
         return np.array([
@@ -157,7 +167,10 @@ class TestApproxDerivativesDense(object):
         ])
 
     def fun_parametrized(self, x, c0, c1=1.0):
-        return np.array([np.exp(c0 * x[0]), np.exp(c1 * x[1])])
+        if x.ndim == 1:
+            return np.array([np.exp(c0 * x[0]), np.exp(c1 * x[1])])
+        else:
+            return np.vstack([np.exp(c0 * x[0]), np.exp(c1 * x[1])])
 
     def jac_parametrized(self, x, c0, c1=0.1):
         return np.array([
@@ -166,13 +179,21 @@ class TestApproxDerivativesDense(object):
         ])
 
     def fun_with_nan(self, x):
-        return x if np.abs(x) <= 1e-8 else np.nan
+        if x.ndim == 1:
+            return x if np.abs(x) <= 1e-8 else np.nan
+        else:
+            f = x.copy()
+            f[x > 1e-8] = np.nan
+            return f
 
     def jac_with_nan(self, x):
         return 1.0 if np.abs(x) <= 1e-8 else np.nan
 
     def fun_zero_jacobian(self, x):
-        return np.array([x[0] * x[1], np.cos(x[0] * x[1])])
+        if x.ndim == 1:
+            return np.array([x[0] * x[1], np.cos(x[0] * x[1])])
+        else:
+            return np.vstack([x[0] * x[1], np.cos(x[0] * x[1])])
 
     def jac_zero_jacobian(self, x):
         return np.array([
@@ -188,69 +209,93 @@ class TestApproxDerivativesDense(object):
 
     def test_scalar_scalar(self):
         x0 = 1.0
-        jac_diff_2 = approx_derivative(self.fun_scalar_scalar, x0,
-                                       method='2-point')
-        jac_diff_3 = approx_derivative(self.fun_scalar_scalar, x0)
-        jac_diff_4 = approx_derivative(self.fun_scalar_scalar, x0,
-                                       method='cs')
         jac_true = self.jac_scalar_scalar(x0)
-        assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
-        assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
-        assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
+        for vectorized in [True, False]:
+            jac_diff_2 = approx_derivative(self.fun_scalar_scalar, x0,
+                                           method='2-point',
+                                           vectorized=vectorized)
+            jac_diff_3 = approx_derivative(self.fun_scalar_scalar, x0,
+                                           vectorized=vectorized)
+            jac_diff_4 = approx_derivative(self.fun_scalar_scalar, x0,
+                                           method='cs', vectorized=vectorized)
+
+            assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
+            assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
+            assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
 
     def test_scalar_vector(self):
         x0 = 0.5
-        jac_diff_2 = approx_derivative(self.fun_scalar_vector, x0,
-                                       method='2-point')
-        jac_diff_3 = approx_derivative(self.fun_scalar_vector, x0)
-        jac_diff_4 = approx_derivative(self.fun_scalar_vector, x0,
-                                       method='cs')
         jac_true = self.jac_scalar_vector(np.atleast_1d(x0))
-        assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
-        assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
-        assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
+        for vectorized in [False, True]:
+            jac_diff_2 = approx_derivative(self.fun_scalar_vector, x0,
+                                           method='2-point',
+                                           vectorized=vectorized)
+            jac_diff_3 = approx_derivative(self.fun_scalar_vector, x0,
+                                           vectorized=vectorized)
+            jac_diff_4 = approx_derivative(self.fun_scalar_vector, x0,
+                                           method='cs', vectorized=vectorized)
+
+            assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
+            assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
+            assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
 
     def test_vector_scalar(self):
         x0 = np.array([100.0, -0.5])
-        jac_diff_2 = approx_derivative(self.fun_vector_scalar, x0,
-                                       method='2-point')
-        jac_diff_3 = approx_derivative(self.fun_vector_scalar, x0)
-        jac_diff_4 = approx_derivative(self.fun_vector_scalar, x0,
-                                       method='cs')
         jac_true = self.jac_vector_scalar(x0)
-        assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
-        assert_allclose(jac_diff_3, jac_true, rtol=1e-7)
-        assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
+        for vectorized in [True, False]:
+            jac_diff_2 = approx_derivative(self.fun_vector_scalar, x0,
+                                           method='2-point',
+                                           vectorized=vectorized)
+            jac_diff_3 = approx_derivative(self.fun_vector_scalar, x0,
+                                           vectorized=vectorized)
+            jac_diff_4 = approx_derivative(self.fun_vector_scalar, x0,
+                                           method='cs', vectorized=vectorized)
+
+            assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
+            assert_allclose(jac_diff_3, jac_true, rtol=1e-7)
+            assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
 
     def test_vector_vector(self):
         x0 = np.array([-100.0, 0.2])
-        jac_diff_2 = approx_derivative(self.fun_vector_vector, x0,
-                                       method='2-point')
-        jac_diff_3 = approx_derivative(self.fun_vector_vector, x0)
-        jac_diff_4 = approx_derivative(self.fun_vector_vector, x0,
-                                       method='cs')
         jac_true = self.jac_vector_vector(x0)
-        assert_allclose(jac_diff_2, jac_true, rtol=1e-5)
-        assert_allclose(jac_diff_3, jac_true, rtol=1e-6)
-        assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
+
+        for vectotrized in [False, True]:
+            jac_diff_2 = approx_derivative(self.fun_vector_vector, x0,
+                                           method='2-point',
+                                           vectorized=vectotrized)
+            jac_diff_3 = approx_derivative(self.fun_vector_vector, x0,
+                                           vectorized=vectotrized)
+            jac_diff_4 = approx_derivative(self.fun_vector_vector, x0,
+                                           method='cs', vectorized=vectotrized)
+
+            assert_allclose(jac_diff_2, jac_true, rtol=1e-5)
+            assert_allclose(jac_diff_3, jac_true, rtol=1e-6)
+            assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
 
     def test_wrong_dimensions(self):
         x0 = 1.0
-        assert_raises(RuntimeError, approx_derivative,
-                      self.wrong_dimensions_fun, x0)
-        f0 = self.wrong_dimensions_fun(np.atleast_1d(x0))
-        assert_raises(ValueError, approx_derivative,
-                      self.wrong_dimensions_fun, x0, f0=f0)
+        for vectorized in [False, True]:
+            assert_raises(ValueError, approx_derivative,
+                          self.wrong_dimensions_fun, x0, vectorized=vectorized)
+            f0 = self.wrong_dimensions_fun(np.atleast_1d(x0))
+            assert_raises(ValueError, approx_derivative,
+                          self.wrong_dimensions_fun, x0, f0=f0,
+                          vectorized=vectorized)
 
     def test_custom_rel_step(self):
         x0 = np.array([-0.1, 0.1])
-        jac_diff_2 = approx_derivative(self.fun_vector_vector, x0,
-                                       method='2-point', rel_step=1e-4)
-        jac_diff_3 = approx_derivative(self.fun_vector_vector, x0,
-                                       rel_step=1e-4)
         jac_true = self.jac_vector_vector(x0)
-        assert_allclose(jac_diff_2, jac_true, rtol=1e-2)
-        assert_allclose(jac_diff_3, jac_true, rtol=1e-4)
+
+        for vectorized in [False, True]:
+            jac_diff_2 = approx_derivative(self.fun_vector_vector, x0,
+                                           method='2-point', rel_step=1e-4,
+                                           vectorized=vectorized)
+            jac_diff_3 = approx_derivative(self.fun_vector_vector, x0,
+                                           rel_step=1e-4,
+                                           vectorized=vectorized)
+
+            assert_allclose(jac_diff_2, jac_true, rtol=1e-2)
+            assert_allclose(jac_diff_3, jac_true, rtol=1e-4)
 
     def test_options(self):
         x0 = np.array([1.0, 1.0])
@@ -261,28 +306,34 @@ class TestApproxDerivativesDense(object):
         f0 = self.fun_parametrized(x0, c0, c1=c1)
         rel_step = np.array([-1e-6, 1e-7])
         jac_true = self.jac_parametrized(x0, c0, c1)
-        jac_diff_2 = approx_derivative(
-            self.fun_parametrized, x0, method='2-point', rel_step=rel_step,
-            f0=f0, args=(c0,), kwargs=dict(c1=c1), bounds=(lb, ub))
-        jac_diff_3 = approx_derivative(
-            self.fun_parametrized, x0, rel_step=rel_step,
-            f0=f0, args=(c0,), kwargs=dict(c1=c1), bounds=(lb, ub))
-        assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
-        assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
+        for vectorized in [False, True]:
+            jac_diff_2 = approx_derivative(
+                self.fun_parametrized, x0, method='2-point', rel_step=rel_step,
+                f0=f0, args=(c0,), kwargs=dict(c1=c1), bounds=(lb, ub),
+                vectorized=vectorized)
+            jac_diff_3 = approx_derivative(
+                self.fun_parametrized, x0, rel_step=rel_step,
+                f0=f0, args=(c0,), kwargs=dict(c1=c1), bounds=(lb, ub),
+                vectorized=vectorized)
+            assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
+            assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
 
     def test_with_bounds_2_point(self):
         lb = -np.ones(2)
         ub = np.ones(2)
 
-        x0 = np.array([-2.0, 0.2])
-        assert_raises(ValueError, approx_derivative,
-                      self.fun_vector_vector, x0, bounds=(lb, ub))
+        for vectorized in [False, True]:
+            x0 = np.array([-2.0, 0.2])
+            assert_raises(ValueError, approx_derivative,
+                          self.fun_vector_vector, x0, bounds=(lb, ub),
+                          vectorized=vectorized)
 
-        x0 = np.array([-1.0, 1.0])
-        jac_diff = approx_derivative(self.fun_vector_vector, x0,
-                                     method='2-point', bounds=(lb, ub))
-        jac_true = self.jac_vector_vector(x0)
-        assert_allclose(jac_diff, jac_true, rtol=1e-6)
+            x0 = np.array([-1.0, 1.0])
+            jac_diff = approx_derivative(self.fun_vector_vector, x0,
+                                         method='2-point', bounds=(lb, ub),
+                                         vectorized=vectorized)
+            jac_true = self.jac_vector_vector(x0)
+            assert_allclose(jac_diff, jac_true, rtol=1e-6)
 
     def test_with_bounds_3_point(self):
         lb = np.array([1.0, 1.0])
@@ -291,53 +342,64 @@ class TestApproxDerivativesDense(object):
         x0 = np.array([1.0, 2.0])
         jac_true = self.jac_vector_vector(x0)
 
-        jac_diff = approx_derivative(self.fun_vector_vector, x0)
-        assert_allclose(jac_diff, jac_true, rtol=1e-9)
+        for vectorized in [False, True]:
+            jac_diff = approx_derivative(self.fun_vector_vector, x0,
+                                         vectorized=vectorized)
+            assert_allclose(jac_diff, jac_true, rtol=1e-9)
 
-        jac_diff = approx_derivative(self.fun_vector_vector, x0,
-                                     bounds=(lb, np.inf))
-        assert_allclose(jac_diff, jac_true, rtol=1e-9)
+            jac_diff = approx_derivative(self.fun_vector_vector, x0,
+                                         bounds=(lb, np.inf),
+                                         vectorized=vectorized)
+            assert_allclose(jac_diff, jac_true, rtol=1e-9)
 
-        jac_diff = approx_derivative(self.fun_vector_vector, x0,
-                                     bounds=(-np.inf, ub))
-        assert_allclose(jac_diff, jac_true, rtol=1e-9)
+            jac_diff = approx_derivative(self.fun_vector_vector, x0,
+                                         bounds=(-np.inf, ub),
+                                         vectorized=vectorized)
+            assert_allclose(jac_diff, jac_true, rtol=1e-9)
 
-        jac_diff = approx_derivative(self.fun_vector_vector, x0,
-                                     bounds=(lb, ub))
-        assert_allclose(jac_diff, jac_true, rtol=1e-9)
+            jac_diff = approx_derivative(self.fun_vector_vector, x0,
+                                         bounds=(lb, ub),
+                                         vectorized=vectorized)
+            assert_allclose(jac_diff, jac_true, rtol=1e-9)
 
     def test_tight_bounds(self):
         x0 = np.array([10.0, 10.0])
         lb = x0 - 3e-9
         ub = x0 + 2e-9
         jac_true = self.jac_vector_vector(x0)
-        jac_diff = approx_derivative(
-            self.fun_vector_vector, x0, method='2-point', bounds=(lb, ub))
-        assert_allclose(jac_diff, jac_true, rtol=1e-6)
-        jac_diff = approx_derivative(
-            self.fun_vector_vector, x0, method='2-point',
-            rel_step=1e-6, bounds=(lb, ub))
-        assert_allclose(jac_diff, jac_true, rtol=1e-6)
+        for vectorized in [False, True]:
+            jac_diff = approx_derivative(
+                self.fun_vector_vector, x0, method='2-point', bounds=(lb, ub),
+                vectorized=vectorized)
+            assert_allclose(jac_diff, jac_true, rtol=1e-6)
+            jac_diff = approx_derivative(
+                self.fun_vector_vector, x0, method='2-point',
+                rel_step=1e-6, bounds=(lb, ub), vectorized=vectorized)
+            assert_allclose(jac_diff, jac_true, rtol=1e-6)
 
-        jac_diff = approx_derivative(
-            self.fun_vector_vector, x0, bounds=(lb, ub))
-        assert_allclose(jac_diff, jac_true, rtol=1e-6)
-        jac_diff = approx_derivative(
-            self.fun_vector_vector, x0, rel_step=1e-6, bounds=(lb, ub))
-        assert_allclose(jac_true, jac_diff, rtol=1e-6)
+            jac_diff = approx_derivative(
+                self.fun_vector_vector, x0, bounds=(lb, ub),
+                vectorized=vectorized)
+            assert_allclose(jac_diff, jac_true, rtol=1e-6)
+            jac_diff = approx_derivative(
+                self.fun_vector_vector, x0, rel_step=1e-6, bounds=(lb, ub),
+                vectorized=vectorized)
+            assert_allclose(jac_true, jac_diff, rtol=1e-6)
 
     def test_bound_switches(self):
         lb = -1e-8
         ub = 1e-8
         x0 = 0.0
         jac_true = self.jac_with_nan(x0)
-        jac_diff_2 = approx_derivative(
-            self.fun_with_nan, x0, method='2-point', rel_step=1e-6,
-            bounds=(lb, ub))
-        jac_diff_3 = approx_derivative(
-            self.fun_with_nan, x0, rel_step=1e-6, bounds=(lb, ub))
-        assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
-        assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
+        for vectorized in [False, True]:
+            jac_diff_2 = approx_derivative(
+                self.fun_with_nan, x0, method='2-point', rel_step=1e-6,
+                bounds=(lb, ub), vectorized=vectorized)
+            jac_diff_3 = approx_derivative(
+                self.fun_with_nan, x0, rel_step=1e-6, bounds=(lb, ub),
+                vectorized=vectorized)
+            assert_allclose(jac_diff_2, jac_true, rtol=1e-6)
+            assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
 
         x0 = 1e-8
         jac_true = self.jac_with_nan(x0)
@@ -360,24 +422,33 @@ class TestApproxDerivativesDense(object):
 
         # math.exp cannot handle complex arguments, hence this raises
         assert_raises(TypeError, approx_derivative, self.jac_non_numpy, x0,
-                                       **dict(method='cs'))
+                      **dict(method='cs'))
+
+        # Vectorization won't work because of non-numpy function usage.
+        assert_raises(TypeError, approx_derivative, self.jac_non_numpy, x0,
+                      vectorize=True)
 
     def test_check_derivative(self):
-        x0 = np.array([-10.0, 10])
-        accuracy = check_derivative(self.fun_vector_vector,
-                                    self.jac_vector_vector, x0)
-        assert_(accuracy < 1e-9)
-        accuracy = check_derivative(self.fun_vector_vector,
-                                    self.jac_vector_vector, x0)
-        assert_(accuracy < 1e-6)
+        for vectorized in [False, True]:
+            x0 = np.array([-10.0, 10])
+            accuracy = check_derivative(self.fun_vector_vector,
+                                        self.jac_vector_vector, x0,
+                                        vectorized=vectorized)
+            assert_(accuracy < 1e-9)
+            accuracy = check_derivative(self.fun_vector_vector,
+                                        self.jac_vector_vector, x0,
+                                        vectorized=vectorized)
+            assert_(accuracy < 1e-6)
 
-        x0 = np.array([0.0, 0.0])
-        accuracy = check_derivative(self.fun_zero_jacobian,
-                                    self.jac_zero_jacobian, x0)
-        assert_(accuracy == 0)
-        accuracy = check_derivative(self.fun_zero_jacobian,
-                                    self.jac_zero_jacobian, x0)
-        assert_(accuracy == 0)
+            x0 = np.array([0.0, 0.0])
+            accuracy = check_derivative(self.fun_zero_jacobian,
+                                        self.jac_zero_jacobian, x0,
+                                        vectorized=vectorized)
+            assert_(accuracy == 0)
+            accuracy = check_derivative(self.fun_zero_jacobian,
+                                        self.jac_zero_jacobian, x0,
+                                        vectorized=vectorized)
+            assert_(accuracy == 0)
 
 
 class TestApproxDerivativeSparse(object):
@@ -471,4 +542,6 @@ class TestApproxDerivativeSparse(object):
 
 
 if __name__ == '__main__':
-    run_module_suite()
+    # run_module_suite()
+    t = TestApproxDerivativesDense()
+    t.test_check_derivative()

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -553,5 +553,27 @@ class TestApproxDerivativeSparse(object):
             assert_(accuracy < 1e-9)
 
 
+def test_different_shapes():
+    def fun_scalar_scalar(x):
+        return np.sinh(x)
+
+    def jac_scalar_scalar(x):
+        return np.cosh(x)
+
+    x0 = 1.0
+
+    J = approx_derivative(fun_scalar_scalar, x0)
+    assert_allclose(J, jac_scalar_scalar(x0), rtol=1e-9)
+
+    J = approx_derivative(fun_scalar_scalar, np.atleast_1d(x0))
+    assert_allclose(J, jac_scalar_scalar(x0), rtol=1e-9)
+
+    J = approx_derivative(fun_scalar_scalar, np.atleast_2d(x0))
+    assert_allclose(J, jac_scalar_scalar(x0), rtol=1e-9)
+
+    assert_raises(ValueError, approx_derivative, fun_scalar_scalar,
+                  np.atleast_3d(x0))
+
+
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
Jacobian is estimated numerically for a function `fun(x)`. If `fun` is implemented such that it accepts and returns 2-d arrays (it is very easy to achieve using `vstack` when `fun` is coded in terms of numpy functions), then `fun` will be called only once to compute all necessary values. 

The idea is simple, but it can give substantial speed-ups for estimating Jacobians. Currently only `least_squares` uses `approx_derivative`. I will fill an issue that `least_squares` should be adjusted to allow vectorized Jacobian estimation (when this PR is in).

@ev-br @pv, please look when you have time.
