### PR TITLE
TST: spatial.qhull: skip a test on 32-bit platforms

### DIFF
--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -364,24 +364,25 @@ class TestUtilities(object):
                                                unit_cube=True,
                                                unit_cube_tol=2*eps)
 
-            # Check with larger perturbations
-            np.random.seed(4321)
-            m = (np.random.rand(grid.shape[0]) < 0.2)
-            grid[m,:] += 1000*eps*(np.random.rand(*grid[m,:].shape) - 0.5)
-
-            tri = qhull.Delaunay(grid)
-            self._check_barycentric_transforms(tri, err_msg=err_msg,
-                                               unit_cube=True,
-                                               unit_cube_tol=1500*eps)
-
-            # Check with yet larger perturbations
-            np.random.seed(4321)
-            m = (np.random.rand(grid.shape[0]) < 0.2)
-            grid[m,:] += 1e6*eps*(np.random.rand(*grid[m,:].shape) - 0.5)
-
             if not _is_32bit_platform:
                 # test numerically unstable, and reported to fail on 32-bit
                 # installs
+
+                # Check with larger perturbations
+                np.random.seed(4321)
+                m = (np.random.rand(grid.shape[0]) < 0.2)
+                grid[m,:] += 1000*eps*(np.random.rand(*grid[m,:].shape) - 0.5)
+
+                tri = qhull.Delaunay(grid)
+                self._check_barycentric_transforms(tri, err_msg=err_msg,
+                                                   unit_cube=True,
+                                                   unit_cube_tol=1500*eps)
+
+                # Check with yet larger perturbations
+                np.random.seed(4321)
+                m = (np.random.rand(grid.shape[0]) < 0.2)
+                grid[m,:] += 1e6*eps*(np.random.rand(*grid[m,:].shape) - 0.5)
+
                 tri = qhull.Delaunay(grid)
                 self._check_barycentric_transforms(tri, err_msg=err_msg,
                                                    unit_cube=True,


### PR DESCRIPTION
Test is (apparently) numerically unstable and is reported to fail on 32-bit systems. Intends to close gh-6101.
Note that a part of this test is already skipped on 32-bit platforms. 

It would be good to get to the bottom of the failure at some point: is it really a limitation of an upstream QHull, or is it a test which is too optimistic. I'll open a separate ticket for this. 
EDIT: gh-6348
