### PR TITLE
BUG: optimize/slsqp: don't overwrite an array out of bounds

### DIFF
--- a/scipy/optimize/slsqp/slsqp_optmz.f
+++ b/scipy/optimize/slsqp/slsqp_optmz.f
@@ -743,11 +743,13 @@ c   restore Lagrange multipliers (only for user-defined variables)
 
 c   set rest of the multipliers to nan (they are not used)
 
-          y(m+1) = 0
-          y(m+1) = 0 / y(m+1)
-          do 60 i=m+2,m+n+n
-             y(i) = y(m+1)
- 60       continue
+          IF (n3 .GT. 0) THEN
+             y(m+1) = 0
+             y(m+1) = 0 / y(m+1)
+             do 60 i=m+2,m+n3+n3
+                y(i) = y(m+1)
+ 60          continue
+          ENDIF
 
       ENDIF
       call bound(n, x, xl, xu)

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -7,6 +7,7 @@ from numpy.testing import (assert_, assert_array_almost_equal, TestCase,
                            assert_allclose, assert_equal, run_module_suite)
 import numpy as np
 
+from scipy._lib._testutils import knownfailure_overridable
 from scipy.optimize import fmin_slsqp, minimize
 
 
@@ -313,8 +314,34 @@ class TestSLSQP(TestCase):
         assert_(callback.been_called)
         assert_equal(callback.ncalls, res['nit'])
 
+    def test_inconsistent_linearization(self):
+        # SLSQP must be able to solve this problem, even if the
+        # linearized problem at the starting point is infeasible.
+
+        # Linearized constraints are
+        #
+        #    2*x0[0]*x[0] >= 1
+        #
+        # At x0 = [0, 1], the second constraint is clearly infeasible.
+        # This triggers a call with n2==1 in the LSQ subroutine.
+        x = [0, 1]
+        f1 = lambda x: x[0] + x[1] - 2
+        f2 = lambda x: x[0]**2 - 1
+        sol = minimize(
+            lambda x: x[0]**2 + x[1]**2,
+            x,
+            constraints=({'type':'eq','fun': f1},
+                         {'type':'ineq','fun': f2}),
+            bounds=((0,None), (0,None)),
+            method='SLSQP')
+        x = sol.x
+
+        assert_allclose(f1(x), 0, atol=1e-8)
+        assert_(f2(x) >= -1e-8)
+        assert_(sol.success, sol)
+
+    @knownfailure_overridable("This bug is not fixed")
     def test_regression_5743(self):
-        # Check that gh-5743 is fixed.
         # SLSQP must not indicate success for this problem,
         # which is infeasible.
         x = [1, 2]


### PR DESCRIPTION
Although the array `y` is declared in the subroutine to be of size
`m+2*n`, the actually allocated size on line 251 before call to SLSQPB
is smaller.  Before db343b85053f in the original code ([see here](https://github.com/scipy/scipy/blob/819f58f161f07105ec9281644913e063751a9365/scipy/optimize/slsqp/slsqp_optmz.f#L726)), only `m+2*n3` 
multipliers were copied into y, so change the nan writing to match that.  
Add a test that triggers the condition n3 < n where nans would be written
out of bounds.

Fixes a bug introduced in gh-6024.

The bug gh-5743 (failure to report infeasible problems) appears to be a separate bug.

gh-6024 should be reverted in 0.18.0 (or this change should be backported).
