### PR TITLE
BUG: special: avoid precision loss in hyp0f1 on 32 bit linux

### DIFF
--- a/scipy/special/_hyp0f1.pxd
+++ b/scipy/special/_hyp0f1.pxd
@@ -107,6 +107,7 @@ cdef inline double complex _hyp0f1_cmplx(double v, double complex z) nogil:
         np.npy_cdouble zz = npy_cdouble_from_double_complex(z)
         np.npy_cdouble r
         double complex arg, s
+        double complex t1, t2
 
     # handle poles, zeros 
     if v <= 0.0 and v == floor(v):
@@ -115,8 +116,10 @@ cdef inline double complex _hyp0f1_cmplx(double v, double complex z) nogil:
         return 1.0
 
     # both v and z small: truncate the Taylor series at O(z**2)
-    if zabs(z) < 1e-6*(1.0 + fabs(v)):
-        return 1.0 + z/v + z*z/(2.0*v*(v+1.0))
+    if zabs(z) < 1e-6*(1.0 + zabs(v)):
+        t1 = 1.0 + z/v
+        t2 = z*z / (2.0*v*(v+1.0))
+        return t1 + t2
 
     if zz.real > 0:
         arg = zsqrt(z)


### PR DESCRIPTION
Forcing the order of evaluations seems to be enough to avoid the hyp0f1 failure of gh-6365.
The fix follows from noticing that the failing point is v = -z = 1e-30, so that the computation is `1.0 - 1.0 + 5e-31` and that is sensitive to the order of additions. 

Why exactly the problem only shows up on 32 bit linux and only for complex values with zero imaginary parts, I've no idea and I'm not very interested in spending too much effort trying to figure it out.

At any rate, fixing the order of evaluations seems reasonable: either the sum of first two terms is of the order unity and then the quadratic term is only an insignificant correction, or first two terms cancel and then they should be summed first.
