### PR TITLE
ENH: linalg: add improved Pinv, `pinv3`

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -130,7 +130,7 @@ Jörg Dietrich for the k-sample Anderson Darling test.
 Blake Griffith for improvements to scipy.sparse.
 Andrew Nelson for scipy.optimize.differential_evolution.
 Brian Newsom for work on ctypes multivariate integration.
-Nathan Woods for work on multivariate integration. 
+Nathan Woods for work on multivariate integration.
 Brianna Laugher for bug fixes.
 Johannes Kulick for the Dirichlet distribution.
 Bastian Venthur for bug fixes.
@@ -160,6 +160,7 @@ Philip DeBoer for wrapping random SO(N) and adding random O(N) and
 Tyler Reddy and Nikolai Nowaczyk for scipy.spatial.SphericalVoronoi
 Bill Sacks for fixes to netcdf i/o.
 Kolja Glogowski for a bug fix in scipy.special.
+Joshua Chin for scipy.linalg.pinv3
 
 
 Institutions

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -33,6 +33,7 @@ Basics
    lstsq - Solve a linear least-squares problem
    pinv - Pseudo-inverse (Moore-Penrose) using lstsq
    pinv2 - Pseudo-inverse using svd
+   pinv3 - Pseudo-inverse using hermitian matrix
    pinvh - Pseudo-inverse of hermitian matrix
    kron - Kronecker product of two arrays
    tril - Construct a lower-triangular matrix from a given matrix

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -8,7 +8,7 @@ from __future__ import division, print_function, absolute_import
 
 __all__ = ['solve', 'solve_triangular', 'solveh_banded', 'solve_banded',
            'solve_toeplitz', 'solve_circulant', 'inv', 'det', 'lstsq',
-           'pinv', 'pinv2', 'pinvh']
+           'pinv', 'pinv2', 'pinv3', 'pinvh']
 
 import warnings
 import numpy as np
@@ -876,7 +876,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
                            "This is likely the result of LAPACK bug "
                            "0038, fixed in LAPACK 3.2.2 (released "
                            "July 21, 2010). ")
-                    
+
                     if lapack_driver is None:
                         # restart with gelss
                         lstsq.default_lapack_driver = 'gelss'
@@ -1045,6 +1045,66 @@ def pinv2(a, cond=None, rcond=None, return_rank=False, check_finite=True):
     u /= s[:rank]
     B = np.transpose(np.conjugate(np.dot(u, vh[:rank])))
 
+    if return_rank:
+        return B, rank
+    else:
+        return B
+
+
+def pinv3(a, cond=None, rcond=None, return_rank=False, check_finite=True):
+    """
+    Compute the (Moore-Penrose) pseudo-inverse of a matrix.
+
+    Calculate a generalized inverse of a matrix using a Hermitian matrix.
+
+    Parameters
+    ----------
+    a : (N, N) array_like
+        Real symmetric or complex hermetian matrix to be pseudo-inverted
+    cond, rcond : float or None
+        Cutoff for 'small' eigenvalues.
+        Singular values smaller than rcond * largest_eigenvalue are considered
+        zero.
+        If None or -1, suitable machine precision is used.
+    return_rank : bool, optional
+        if True, return the effective rank of the matrix
+    check_finite : bool, optional
+        Whether to check that the input matrix contains only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination) if the inputs do contain infinities or NaNs.
+
+    Returns
+    -------
+    B : (N, N) ndarray
+        The pseudo-inverse of matrix `a`.
+    rank : int
+        The effective rank of the matrix.  Returned if return_rank == True
+
+    Raises
+    ------
+    LinAlgError
+        If eigenvalue does not converge
+
+    Examples
+    --------
+    >>> from scipy import linalg
+    >>> a = np.random.randn(9, 6)
+    >>> B = linalg.pinv3(a)
+    >>> np.allclose(a, np.dot(a, np.dot(B, a)))
+    True
+    >>> np.allclose(B, np.dot(B, np.dot(a, B)))
+    True
+    """
+    a = _asarray_validated(a, check_finite=check_finite)
+    transpose = a.shape[0] < a.shape[1]
+    a = a.T if transpose else a
+
+    aH = a.conj().T
+    aHa_inv, rank = pinvh(aH.dot(a), cond, rcond, return_rank=True,
+                          check_finite=False)
+    B = aHa_inv.dot(aH)
+
+    B = B.T if transpose else B
     if return_rank:
         return B, rank
     else:

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -31,8 +31,8 @@ from numpy.testing import (TestCase, run_module_suite, assert_raises,
     assert_equal, assert_almost_equal, assert_array_almost_equal, assert_,
     assert_allclose, assert_array_equal, dec)
 
-from scipy.linalg import (solve, inv, det, lstsq, pinv, pinv2, pinvh, norm,
-        solve_banded, solveh_banded, solve_triangular, solve_circulant,
+from scipy.linalg import (solve, inv, det, lstsq, pinv, pinv2, pinv3, pinvh,
+        norm, solve_banded, solveh_banded, solve_triangular, solve_circulant,
         circulant, LinAlgError)
 
 from scipy.linalg.basic import LstsqLapackError
@@ -1060,6 +1060,8 @@ class TestPinv(TestCase):
         assert_array_almost_equal(dot(a,a_pinv), np.eye(3))
         a_pinv = pinv2(a)
         assert_array_almost_equal(dot(a,a_pinv), np.eye(3))
+        a_pinv = pinv3(a)
+        assert_array_almost_equal(dot(a,a_pinv), np.eye(3))
 
     def test_simple_complex(self):
         a = (array([[1, 2, 3], [4, 5, 6], [7, 8, 10]], dtype=float)
@@ -1068,30 +1070,40 @@ class TestPinv(TestCase):
         assert_array_almost_equal(dot(a, a_pinv), np.eye(3))
         a_pinv = pinv2(a)
         assert_array_almost_equal(dot(a, a_pinv), np.eye(3))
+        a_pinv = pinv3(a)
+        assert_array_almost_equal(dot(a, a_pinv), np.eye(3))
 
     def test_simple_singular(self):
         a = array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=float)
         a_pinv = pinv(a)
         a_pinv2 = pinv2(a)
+        a_pinv3 = pinv3(a)
         assert_array_almost_equal(a_pinv,a_pinv2)
+        assert_array_almost_equal(a_pinv,a_pinv3)
 
     def test_simple_cols(self):
         a = array([[1, 2, 3], [4, 5, 6]], dtype=float)
         a_pinv = pinv(a)
         a_pinv2 = pinv2(a)
+        a_pinv3 = pinv3(a)
         assert_array_almost_equal(a_pinv,a_pinv2)
+        assert_array_almost_equal(a_pinv,a_pinv3)
 
     def test_simple_rows(self):
         a = array([[1, 2], [3, 4], [5, 6]], dtype=float)
         a_pinv = pinv(a)
         a_pinv2 = pinv2(a)
+        a_pinv3 = pinv3(a)
         assert_array_almost_equal(a_pinv,a_pinv2)
+        assert_array_almost_equal(a_pinv,a_pinv3)
 
     def test_check_finite(self):
         a = array([[1,2,3],[4,5,6.],[7,8,10]])
         a_pinv = pinv(a, check_finite=False)
         assert_array_almost_equal(dot(a,a_pinv),[[1,0,0],[0,1,0],[0,0,1]])
         a_pinv = pinv2(a, check_finite=False)
+        assert_array_almost_equal(dot(a,a_pinv),[[1,0,0],[0,1,0],[0,0,1]])
+        a_pinv = pinv3(a, check_finite=False)
         assert_array_almost_equal(dot(a,a_pinv),[[1,0,0],[0,1,0],[0,0,1]])
 
 


### PR DESCRIPTION
This PR adds `linalg.pinv3`, which is faster than either `linalg.pinv` or `linalg.pinv2`.

This function takes advantage of the property `pinv(A) = pinv(A.H @ A) @ A.H`. The matrix `A.H @ A` is hermitian, so it can be inverted quickly, using `pinvh`.

Here are some benchmarks:

```
In [1]: import numpy as np
In [2]: from scipy.linalg import pinv, pinv2, pinv3

In [3]: x = np.random.randn(1000, 1000)

In [4]: %timeit pinv(x)
1 loop, best of 3: 660 ms per loop
In [5]: %timeit pinv2(x)
1 loop, best of 3: 408 ms per loop
In [6]: %timeit pinv3(x)
1 loop, best of 3: 288 ms per loop

In [7]: x = np.random.randn(10000, 100)

In [8]: %timeit pinv(x)
1 loop, best of 3: 2.4 s per loop
In [9]: %timeit pinv2(x)
10 loops, best of 3: 95 ms per loop
In [10]: %timeit pinv3(x)
10 loops, best of 3: 23.7 ms per loop
```
