### PR TITLE
ENH: scipy.sparse: add save and load functions for sparse matrices

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -48,6 +48,14 @@ Building sparse matrices:
    rand - Random values in a given shape
    random - Random values in a given shape
 
+Save and load sparse matrices:
+
+.. autosummary::
+   :toctree: generated/
+
+   save_npz - Save a sparse matrix to a file using ``.npz`` format.
+   load_npz - Load a sparse matrix from a file using ``.npz`` format.
+
 Sparse matrix tools:
 
 .. autosummary::
@@ -227,6 +235,7 @@ from .dia import *
 from .bsr import *
 from .construct import *
 from .extract import *
+from ._matrix_io import *
 
 # for backward compatibility with v0.10.  This function is marked as deprecated
 from .csgraph import cs_graph_components

--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -1,0 +1,109 @@
+import numpy as np
+import scipy.sparse
+
+
+def save_npz(file, matrix, compressed=True):
+    """ Save a sparse matrix to a file using ``.npz`` format.
+
+    Parameters
+    ----------
+    file : str or file-like object
+        Either the file name (string) or an open file (file-like object)
+        where the data will be saved. If file is a string, the ``.npz``
+        extension will be appended to the file name if it is not already
+        there.
+    matrix: spmatrix (format: ``csc``, ``csr``, ``bsr``, ``dia`` or coo``)
+        The sparse matrix to save.
+    compressed : bool, optional
+        Allow compressing the file. Default: True
+
+    See Also
+    --------
+    scipy.sparse.load_npz: Load a sparse matrix from a file using ``.npz`` format.
+    numpy.savez: Save several arrays into a ``.npz`` archive.
+    numpy.savez_compressed : Save several arrays into a compressed ``.npz`` archive.
+
+    Examples
+    --------
+    Store sparse matrix to disk, and load it again:
+
+    >>> import scipy.sparse
+    >>> sparse_matrix = scipy.sparse.csc_matrix(np.array([[0, 0, 3], [4, 0, 0]]))
+    >>> sparse_matrix
+    <2x3 sparse matrix of type '<type 'numpy.int64'>'
+       with 2 stored elements in Compressed Sparse Column format>
+    >>> sparse_matrix.todense()
+    matrix([[0, 0, 3],
+            [4, 0, 0]], dtype=int64)
+
+    >>> scipy.sparse.save_npz('/tmp/sparse_matrix.npz', sparse_matrix)
+    >>> sparse_matrix = scipy.sparse.load_npz('/tmp/sparse_matrix.npz')
+
+    >>> sparse_matrix
+    <2x3 sparse matrix of type '<type 'numpy.int64'>'
+       with 2 stored elements in Compressed Sparse Column format>
+    >>> sparse_matrix.todense()
+    matrix([[0, 0, 3],
+            [4, 0, 0]], dtype=int64)
+    """
+
+    arrays_dict = dict(format=matrix.format, shape=matrix.shape, data=matrix.data)
+    if matrix.format in ('csc', 'csr', 'bsr'):
+        arrays_dict.update(indices=matrix.indices, indptr=matrix.indptr)
+    elif matrix.format == 'dia':
+        arrays_dict.update(offsets=matrix.offsets)
+    elif matrix.format == 'coo':
+        arrays_dict.update(row=matrix.row, col=matrix.col)
+    else:
+        raise NotImplementedError('Save is not implemented for sparse matrix of format {}.'.format(matrix.format))
+
+    if compressed:
+        np.savez_compressed(file, **arrays_dict)
+    else:
+        np.savez(file, **arrays_dict)
+
+
+def load_npz(file):
+    """ Load a sparse matrix from a file using ``.npz`` format.
+
+    Parameters
+    ----------
+    file : str or file-like object
+        Either the file name (string) or an open file (file-like object)
+        where the data will be loaded.
+
+    Returns
+    -------
+    result : csc_matrix, csr_matrix, bsr_matrix, dia_matrix or coo_matrix
+        A sparse matrix containing the loaded data.
+
+    Raises
+    ------
+    IOError
+        If the input file does not exist or cannot be read.
+
+    See Also
+    --------
+    scipy.sparse.save_npz: Save a sparse matrix to a file using ``.npz`` format.
+    numpy.load: Load several arrays from a ``.npz`` archive.
+    """
+
+    loaded = np.load(file)
+    try:
+        matrix_format = loaded['format']
+    except KeyError:
+        raise ValueError('The file {} does not contain a sparse matrix.'.format(file))
+
+    try:
+        cls = getattr(scipy.sparse, '{}_matrix'.format(matrix_format))
+    except AttributeError:
+        raise ValueError('Unknown matrix format "{}"'.format(matrix_format))
+
+    if matrix_format in ('csc', 'csr', 'bsr'):
+        return cls((loaded['data'], loaded['indices'], loaded['indptr']), shape=loaded['shape'])
+    elif matrix_format == 'dia':
+        return cls((loaded['data'], loaded['offsets']), shape=loaded['shape'])
+    elif matrix_format == 'coo':
+        return cls((loaded['data'], (loaded['row'], loaded['col'])), shape=loaded['shape'])
+    else:
+        raise NotImplementedError('Load is not implemented for sparse matrix of format {}.'.format(matrix_format))

--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -1,0 +1,43 @@
+import numpy as np
+import tempfile
+
+from numpy.testing import assert_array_almost_equal, run_module_suite, assert_
+
+from scipy.sparse import csc_matrix, csr_matrix, bsr_matrix, dia_matrix, coo_matrix, save_npz, load_npz
+
+
+def _save_and_load(matrix):        
+    with tempfile.NamedTemporaryFile(suffix='.npz') as file:
+        file = file.name
+        save_npz(file, matrix)
+        loaded_matrix = load_npz(file)
+    return loaded_matrix
+
+def _check_save_and_load(dense_matrix):
+    for matrix_class in [csc_matrix, csr_matrix, bsr_matrix, dia_matrix, coo_matrix]:
+        matrix = matrix_class(dense_matrix)
+        loaded_matrix = _save_and_load(matrix)
+        assert_(type(loaded_matrix) is matrix_class)
+        assert_(loaded_matrix.shape == dense_matrix.shape)
+        assert_(loaded_matrix.dtype == dense_matrix.dtype)
+        assert_array_almost_equal(loaded_matrix.toarray(), dense_matrix)
+
+def test_save_and_load_random():
+    N = 10
+    np.random.seed(0)
+    dense_matrix = np.random.random((N, N))
+    dense_matrix[dense_matrix > 0.7] = 0
+    _check_save_and_load(dense_matrix)
+
+def test_save_and_load_empty():
+    dense_matrix = np.zeros((4,6))
+    _check_save_and_load(dense_matrix)
+
+def test_save_and_load_one_entry():
+    dense_matrix = np.zeros((4,6))
+    dense_matrix[1,2] = 1
+    _check_save_and_load(dense_matrix)
+
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
This enhancements allows the save and load sparse matrices (of type `csc`, `csr` and `bsr`).

Numpys `savez` and `savez_compressed` functions are used to store the `data`, `indices` and `indptr` arrays of the sparse (`csc`, `csr` or `bsr`) matrices together with the matrix `format` in one file. Numpys ability to compress the resulting file can be used thereby. The saved information is reassembled accordingly when loading.

The `save` and `load` functions are made available in the `scipy.sparse` package.
