### PR TITLE
MAINT: moves global benchmark run from setup_cache to track_all

### DIFF
--- a/benchmarks/benchmarks/go_benchmark_functions/go_benchmark.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_benchmark.py
@@ -86,7 +86,7 @@ class Benchmark(object):
             parameter.
         """
 
-        return asarray([np.random.uniform(l, u) for l, u in self._bounds])
+        return asarray([np.random.uniform(l, u) for l, u in self.bounds])
 
     def success(self, x, tol=1.e-5):
         """
@@ -156,7 +156,7 @@ class Benchmark(object):
         """
 
         if self.change_dimensionality:
-            self.dimensions = ndim
+            self._dimensions = ndim
         else:
             raise ValueError('dimensionality cannot be changed for this'
                              'problem')

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_A.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_A.py
@@ -35,7 +35,7 @@ class Ackley01(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-35.0] * self.N, [35.0] * self.N)
+        self._bounds = list(zip([-35.0] * self.N, [35.0] * self.N))
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = 0.0
         self.change_dimensionality = True
@@ -73,7 +73,7 @@ class Ackley02(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-32.0] * self.N, [32.0] * self.N)
+        self._bounds = list(zip([-32.0] * self.N, [32.0] * self.N))
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = -200.
 
@@ -112,7 +112,7 @@ class Ackley03(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-32.0] * self.N, [32.0] * self.N)
+        self._bounds = list(zip([-32.0] * self.N, [32.0] * self.N))
         self.global_optimum = [[-0.68255758, -0.36070859]]
         self.fglob = -195.62902825923879
 
@@ -185,7 +185,7 @@ class Alpine01(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = 0.0
         self.change_dimensionality = True
@@ -225,7 +225,7 @@ class Alpine02(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [10.0] * self.N))
         self.global_optimum = [[7.91705268, 4.81584232]]
         self.fglob = -6.12950
         self.change_dimensionality = True
@@ -264,7 +264,7 @@ class AMGM(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [10.0] * self.N))
         self.global_optimum = [[1, 1]]
         self.fglob = 0.0
         self.change_dimensionality = True

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_B.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_B.py
@@ -32,7 +32,7 @@ class BartelsConn(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-500.] * self.N, [500.] * self.N)
+        self._bounds = list(zip([-500.] * self.N, [500.] * self.N))
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = 1.0
 
@@ -70,7 +70,7 @@ class Beale(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-4.5] * self.N, [4.5] * self.N)
+        self._bounds = list(zip([-4.5] * self.N, [4.5] * self.N))
         self.global_optimum = [[3.0, 0.5]]
         self.fglob = 0.0
 
@@ -113,8 +113,8 @@ class BiggsExp02(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0] * 2,
-                           [20] * 2)
+        self._bounds = list(zip([0] * 2,
+                                [20] * 2))
         self.global_optimum = [[1., 10.]]
         self.fglob = 0
 
@@ -158,8 +158,8 @@ class BiggsExp03(Benchmark):
     def __init__(self, dimensions=3):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0] * 3,
-                           [20] * 3)
+        self._bounds = list(zip([0] * 3,
+                                [20] * 3))
         self.global_optimum = [[1., 10., 5.]]
         self.fglob = 0
 
@@ -203,8 +203,8 @@ class BiggsExp04(Benchmark):
     def __init__(self, dimensions=4):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.] * 4,
-                           [20.] * 4)
+        self._bounds = list(zip([0.] * 4,
+                                [20.] * 4))
         self.global_optimum = [[1., 10., 1., 5.]]
         self.fglob = 0
 
@@ -248,8 +248,8 @@ class BiggsExp05(Benchmark):
     def __init__(self, dimensions=5):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.] * 5,
-                           [20.] * 5)
+        self._bounds = list(zip([0.] * 5,
+                                [20.] * 5))
         self.global_optimum = [[1., 10., 1., 5., 4.]]
         self.fglob = 0
 
@@ -292,8 +292,8 @@ class Bird(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-2.0 * pi] * self.N,
-                           [2.0 * pi] * self.N)
+        self._bounds = list(zip([-2.0 * pi] * self.N,
+                                [2.0 * pi] * self.N))
         self.global_optimum = [[4.701055751981055, 3.152946019601391],
                                [-1.582142172055011, -3.130246799635430]]
         self.fglob = -106.7645367198034
@@ -335,7 +335,7 @@ class Bohachevsky1(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-100.0] * self.N, [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N, [100.0] * self.N))
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = 0.0
 
@@ -377,7 +377,7 @@ class Bohachevsky2(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-100.0] * self.N, [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N, [100.0] * self.N))
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = 0.0
 
@@ -418,7 +418,7 @@ class Bohachevsky3(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-100.0] * self.N, [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N, [100.0] * self.N))
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = 0.0
 
@@ -587,7 +587,7 @@ class Brent(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = ([-10, 2], [-10, 2])
 
         self.global_optimum = [[-10.0, -10.0]]
@@ -628,7 +628,7 @@ class Brown(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-1.0] * self.N, [4.0] * self.N)
+        self._bounds = list(zip([-1.0] * self.N, [4.0] * self.N))
         self.custom_bounds = ([-1.0, 1.0], [-1.0, 1.0])
 
         self.global_optimum = [[0 for _ in range(self.N)]]

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_C.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_C.py
@@ -37,7 +37,7 @@ class CarromTable(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.global_optimum = [(9.646157266348881, 9.646134286497169),
                                (-9.646157266348881, 9.646134286497169),
                                (9.646157266348881, -9.646134286497169),
@@ -86,7 +86,7 @@ class Chichinadze(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-30.0] * self.N, [30.0] * self.N)
+        self._bounds = list(zip([-30.0] * self.N, [30.0] * self.N))
         self.custom_bounds = [(-10, 10), (-10, 10)]
 
         self.global_optimum = [[6.189866586965680, 0.5]]
@@ -125,8 +125,8 @@ class Cigar(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                                [100.0] * self.N))
         self.custom_bounds = [(-5, 5), (-5, 5)]
 
         self.global_optimum = [[0 for _ in range(self.N)]]
@@ -189,7 +189,7 @@ class Cola(Benchmark):
         Benchmark.__init__(self, dimensions)
 
         self._bounds = [[0.0, 4.0]] + list(zip([-4.0] * (self.N - 1),
-                 [4.0] * (self.N - 1)))
+                                               [4.0] * (self.N - 1)))
 
         self.global_optimum = [[0.651906, 1.30194, 0.099242, -0.883791,
                                 -0.8796, 0.204651, -3.28414, 0.851188,
@@ -257,7 +257,7 @@ class Colville(Benchmark):
     def __init__(self, dimensions=4):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[1 for _ in range(self.N)]]
         self.fglob = 0.0
@@ -306,7 +306,7 @@ class Corana(Benchmark):
     def __init__(self, dimensions=4):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0] * self.N, [5.0] * self.N)
+        self._bounds = list(zip([-5.0] * self.N, [5.0] * self.N))
 
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = 0.0
@@ -358,7 +358,7 @@ class CosineMixture(Benchmark):
         Benchmark.__init__(self, dimensions)
 
         self.change_dimensionality = True
-        self._bounds = zip([-1.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([-1.0] * self.N, [1.0] * self.N))
 
         self.global_optimum = [[-1. for _ in range(self.N)]]
         self.fglob = -0.9 * self.N
@@ -397,7 +397,7 @@ class CrossInTray(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [(1.349406685353340, 1.349406608602084),
                                (-1.349406685353340, 1.349406608602084),
@@ -441,7 +441,7 @@ class CrossLegTable(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[0., 0.]]
         self.fglob = -1.0
@@ -482,7 +482,7 @@ class CrownedCross(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[0, 0]]
         self.fglob = 0.0001
@@ -524,7 +524,7 @@ class Csendes(Benchmark):
         Benchmark.__init__(self, dimensions)
 
         self.change_dimensionality = True
-        self._bounds = zip([-1.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([-1.0] * self.N, [1.0] * self.N))
 
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = np.nan
@@ -580,7 +580,7 @@ class Cube(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = ([0, 2], [0, 2])
 
         self.global_optimum = [[1.0, 1.0]]

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_D.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_D.py
@@ -36,7 +36,7 @@ class Damavandi(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, 2)
 
-        self._bounds = zip([0.0] * self.N, [14.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [14.0] * self.N))
 
         self.global_optimum = [[2 for _ in range(self.N)]]
         self.fglob = np.nan
@@ -97,7 +97,7 @@ class Deb01(Benchmark):
 
         self.change_dimensionality = True
 
-        self._bounds = zip([-1.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([-1.0] * self.N, [1.0] * self.N))
 
         self.global_optimum = [[0.3, -0.3]]
         self.fglob = -1.0
@@ -138,7 +138,7 @@ class Deb03(Benchmark):
 
         self.change_dimensionality = True
 
-        self._bounds = zip([-1.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([-1.0] * self.N, [1.0] * self.N))
 
         self.global_optimum = [[0.93388314, 0.68141781]]
         self.fglob = -1.0
@@ -176,7 +176,7 @@ class Decanomial(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = [(0, 2.5), (-2, -4)]
 
         self.global_optimum = [[2.0, -3.0]]
@@ -240,7 +240,7 @@ class Deceptive(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [1.0] * self.N))
 
         alpha = arange(1.0, self.N + 1.0) / (self.N + 1.0)
 
@@ -302,7 +302,7 @@ class DeckkersAarts(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-20.0] * self.N, [20.0] * self.N)
+        self._bounds = list(zip([-20.0] * self.N, [20.0] * self.N))
         self.custom_bounds = ([-1, 1], [14, 16])
 
         self.global_optimum = [[0.0, 14.9451209]]
@@ -349,7 +349,7 @@ class DeflectedCorrugatedSpring(Benchmark):
         Benchmark.__init__(self, dimensions)
 
         alpha = 5.0
-        self._bounds = zip([0] * self.N, [2 * alpha] * self.N)
+        self._bounds = list(zip([0] * self.N, [2 * alpha] * self.N))
 
         self.global_optimum = [[alpha for _ in range(self.N)]]
         self.fglob = -1.0
@@ -395,7 +395,7 @@ class DeVilliersGlasser01(Benchmark):
     def __init__(self, dimensions=4):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([1.0] * self.N, [100.0] * self.N)
+        self._bounds = list(zip([1.0] * self.N, [100.0] * self.N))
 
         self.global_optimum = [[60.137, 1.371, 3.112, 1.761]]
         self.fglob = 0.0
@@ -441,7 +441,7 @@ class DeVilliersGlasser02(Benchmark):
     def __init__(self, dimensions=5):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([1.0] * self.N, [60.0] * self.N)
+        self._bounds = list(zip([1.0] * self.N, [60.0] * self.N))
 
         self.global_optimum = [[53.81, 1.27, 3.012, 2.13, 0.507]]
         self.fglob = 0.0
@@ -487,7 +487,7 @@ class DixonPrice(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = [(-2, 3), (-2, 3)]
 
         self.global_optimum = [[2.0 ** (-(2.0 ** i - 2.0) / 2.0 ** i)
@@ -531,8 +531,8 @@ class Dolan(Benchmark):
     def __init__(self, dimensions=5):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                                [100.0] * self.N))
 
         self.global_optimum = [[-74.10522498, 44.33511286, 6.21069214,
                                18.42772233, -16.5839403]]
@@ -570,7 +570,7 @@ class DropWave(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.12] * self.N, [5.12] * self.N)
+        self._bounds = list(zip([-5.12] * self.N, [5.12] * self.N))
 
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = -1.0

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_E.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_E.py
@@ -36,8 +36,8 @@ class Easom(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
 
         self.global_optimum = [[pi for _ in range(self.N)]]
         self.fglob = -1.0
@@ -63,8 +63,8 @@ class Eckerle4(Benchmark):
     def __init__(self, dimensions=3):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0., 1., 10.],
-                           [20, 20., 600.])
+        self._bounds = list(zip([0., 1., 10.],
+                           [20, 20., 600.]))
         self.global_optimum = [[1.5543827178, 4.0888321754, 4.5154121844e2]]
         self.fglob = 1.4635887487E-03
 
@@ -127,7 +127,7 @@ class EggCrate(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0] * self.N, [5.0] * self.N)
+        self._bounds = list(zip([-5.0] * self.N, [5.0] * self.N))
 
         self.global_optimum = [[0.0, 0.0]]
         self.fglob = 0.0
@@ -168,8 +168,8 @@ class EggHolder(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-512.1] * self.N,
-                           [512.0] * self.N)
+        self._bounds = list(zip([-512.1] * self.N,
+                           [512.0] * self.N))
 
         self.global_optimum = [[512.0, 404.2319]]
         self.fglob = -959.640662711
@@ -209,8 +209,8 @@ class ElAttarVidyasagarDutta(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
         self.custom_bounds = [(-4, 4), (-4, 4)]
 
         self.global_optimum = [[3.40918683, -2.17143304]]
@@ -249,7 +249,7 @@ class Exp2(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [20.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [20.0] * self.N))
         self.custom_bounds = [(0, 2), (0, 20)]
 
         self.global_optimum = [[1.0, 10.]]
@@ -294,7 +294,7 @@ class Exponential(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-1.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([-1.0] * self.N, [1.0] * self.N))
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
         self.fglob = -1.0

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_F.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_F.py
@@ -31,7 +31,7 @@ class FreudensteinRoth(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = [(-3, 3), (-5, 5)]
 
         self.global_optimum = [[5.0, 4.0]]

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_G.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_G.py
@@ -33,7 +33,7 @@ class Gear(Benchmark):
     def __init__(self, dimensions=4):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([12.0] * self.N, [60.0] * self.N)
+        self._bounds = list(zip([12.0] * self.N, [60.0] * self.N))
         self.global_optimum = [[16, 19, 43, 49]]
         self.fglob = 2.7e-12
 
@@ -75,7 +75,7 @@ class Giunta(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-1.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([-1.0] * self.N, [1.0] * self.N))
 
         self.global_optimum = [[0.4673200277395354, 0.4673200169591304]]
         self.fglob = 0.06447042053690566
@@ -115,7 +115,7 @@ class GoldsteinPrice(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-2.0] * self.N, [2.0] * self.N)
+        self._bounds = list(zip([-2.0] * self.N, [2.0] * self.N))
 
         self.global_optimum = [[0., -1.]]
         self.fglob = 3.0
@@ -160,8 +160,8 @@ class Griewank(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
         self.custom_bounds = [(-50, 50), (-50, 50)]
 
         self.global_optimum = [[0 for _ in range(self.N)]]
@@ -209,7 +209,7 @@ class Gulf(Benchmark):
     def __init__(self, dimensions=3):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [50.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [50.0] * self.N))
 
         self.global_optimum = [[50.0, 25.0, 1.5]]
         self.fglob = 0.0

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_H.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_H.py
@@ -36,7 +36,7 @@ class Hansen(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[-7.58989583, -7.70831466]]
         self.fglob = -176.54179
@@ -96,7 +96,7 @@ class Hartmann3(Benchmark):
     def __init__(self, dimensions=3):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [1.0] * self.N))
 
         self.global_optimum = [[0.11461292, 0.55564907, 0.85254697]]
         self.fglob = -3.8627821478
@@ -180,7 +180,7 @@ class Hartmann6(Benchmark):
     def __init__(self, dimensions=6):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [1.0] * self.N))
 
         self.global_optimum = [[0.20168952, 0.15001069, 0.47687398, 0.27533243,
                                 0.31165162, 0.65730054]]
@@ -244,7 +244,7 @@ class HelicalValley(Benchmark):
     def __init__(self, dimensions=3):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.] * self.N, [10.] * self.N)
+        self._bounds = list(zip([-10.] * self.N, [10.] * self.N))
 
         self.global_optimum = [[1.0, 0.0, 0.0]]
         self.fglob = 0.0
@@ -283,7 +283,7 @@ class HimmelBlau(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.] * self.N, [5.] * self.N)
+        self._bounds = list(zip([-5.] * self.N, [5.] * self.N))
 
         self.global_optimum = [[3.0, 2.0]]
         self.fglob = 0.0
@@ -323,7 +323,7 @@ class HolderTable(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [(8.055023472141116, 9.664590028909654),
                                (-8.055023472141116, 9.664590028909654),

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_I.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_I.py
@@ -31,7 +31,7 @@ class Infinity(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-1.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([-1.0] * self.N, [1.0] * self.N))
 
         self.global_optimum = [[1e-16 for _ in range(self.N)]]
         self.fglob = 0.0

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_J.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_J.py
@@ -32,7 +32,7 @@ class JennrichSampson(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-1.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([-1.0] * self.N, [1.0] * self.N))
 
         self.global_optimum = [[0.257825, 0.257825]]
         self.custom_bounds = [(-1, 0.34), (-1, 0.34)]
@@ -87,7 +87,7 @@ class Judge(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[0.86479, 1.2357]]
         self.custom_bounds = [(-2.0, 2.0), (-2.0, 2.0)]

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_K.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_K.py
@@ -38,7 +38,7 @@ class Katsuura(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [100.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [100.0] * self.N))
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
         self.custom_bounds = [(0, 1), (0, 1)]
@@ -85,7 +85,7 @@ class Keane(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[7.85396153, 7.85396135]]
         self.custom_bounds = [(-1, 0.34), (-1, 0.34)]
@@ -134,7 +134,7 @@ class Kowalik(Benchmark):
     def __init__(self, dimensions=4):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0] * self.N, [5.0] * self.N)
+        self._bounds = list(zip([-5.0] * self.N, [5.0] * self.N))
         self.global_optimum = [[0.192833, 0.190836, 0.123117, 0.135766]]
         self.fglob = 0.00030748610
 

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_L.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_L.py
@@ -45,7 +45,7 @@ class Langermann(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[2.00299219, 1.006096]]
         self.fglob = -5.1621259
@@ -112,7 +112,7 @@ class LennardJones(Benchmark):
     def __init__(self, dimensions=6):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-4.0] * self.N, [4.0] * self.N)
+        self._bounds = list(zip([-4.0] * self.N, [4.0] * self.N))
 
         self.global_optimum = [[]]
 
@@ -174,7 +174,7 @@ class Leon(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-1.2] * self.N, [1.2] * self.N)
+        self._bounds = list(zip([-1.2] * self.N, [1.2] * self.N))
 
         self.global_optimum = [[1 for _ in range(self.N)]]
         self.fglob = 0.0
@@ -221,7 +221,7 @@ class Levy03(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = [(-5, 5), (-5, 5)]
 
         self.global_optimum = [[1 for _ in range(self.N)]]
@@ -260,7 +260,7 @@ class Levy05(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = ([-2.0, 2.0], [-2.0, 2.0])
 
         self.global_optimum = [[-1.30685, -1.42485]]
@@ -304,7 +304,7 @@ class Levy13(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = [(-5, 5), (-5, 5)]
 
         self.global_optimum = [[1 for _ in range(self.N)]]

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_L.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_L.py
@@ -112,7 +112,7 @@ class LennardJones(Benchmark):
     def __init__(self, dimensions=6):
         # dimensions is in [6:60]
         # max dimensions is going to be 60.
-        if not dimensions in range(6, 61):
+        if dimensions not in range(6, 61):
             raise ValueError("LJ dimensions must be in (6, 60)")
 
         Benchmark.__init__(self, dimensions)
@@ -132,7 +132,7 @@ class LennardJones(Benchmark):
         self.change_dimensionality = True
 
     def change_dimensions(self, ndim):
-        if not ndim in range(6, 61):
+        if ndim not in range(6, 61):
             raise ValueError("LJ dimensions must be in (6, 60)")
 
         Benchmark.change_dimensions(self, ndim)

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_L.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_L.py
@@ -110,22 +110,33 @@ class LennardJones(Benchmark):
     """
 
     def __init__(self, dimensions=6):
+        # dimensions is in [6:60]
+        # max dimensions is going to be 60.
+        if not dimensions in range(6, 61):
+            raise ValueError("LJ dimensions must be in (6, 60)")
+
         Benchmark.__init__(self, dimensions)
 
         self._bounds = list(zip([-4.0] * self.N, [4.0] * self.N))
 
         self.global_optimum = [[]]
 
-        minima = [
-            -1.0, -3.0, -6.0, -9.103852, -12.712062, -
-            16.505384, -19.821489, -24.113360, -28.422532,
-            -32.765970, -37.967600, -44.326801, -
-            47.845157, -52.322627, -56.815742, -61.317995,
-            -66.530949, -72.659782, -77.1777043]
+        self.minima = [-1.0, -3.0, -6.0, -9.103852, -12.712062,
+                       -16.505384, -19.821489, -24.113360, -28.422532,
+                       -32.765970, -37.967600, -44.326801, -47.845157,
+                       -52.322627, -56.815742, -61.317995, -66.530949,
+                       -72.659782, -77.1777043]
 
         k = int(dimensions / 3)
-        self.fglob = minima[k - 2]
+        self.fglob = self.minima[k - 2]
         self.change_dimensionality = True
+
+    def change_dimensions(self, ndim):
+        if not ndim in range(6, 61):
+            raise ValueError("LJ dimensions must be in (6, 60)")
+
+        Benchmark.change_dimensions(self, ndim)
+        self.fglob = self.minima[int(self.N / 3) - 2]
 
     def fun(self, x, *args):
         self.nfev += 1

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_M.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_M.py
@@ -37,7 +37,7 @@ class Matyas(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = 0.0
@@ -99,8 +99,8 @@ class Meyer(Benchmark):
     def __init__(self, dimensions=3):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0., 100., 100.],
-                           [1, 1000., 500.])
+        self._bounds = list(zip([0., 100., 100.],
+                           [1, 1000., 500.]))
         self.global_optimum = [[5.6096364710e-3, 6.1813463463e3,
                                 3.4522363462e2]]
         self.fglob = 8.7945855171e1
@@ -149,7 +149,7 @@ class Michalewicz(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [pi] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [pi] * self.N))
 
         self.global_optimum = [[2.20290555, 1.570796]]
         self.fglob = -1.8013
@@ -188,7 +188,7 @@ class MieleCantrell(Benchmark):
     def __init__(self, dimensions=4):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-1.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([-1.0] * self.N, [1.0] * self.N))
 
         self.global_optimum = [[0.0, 1.0, 1.0, 1.0]]
         self.fglob = 0.0
@@ -233,8 +233,8 @@ class Mishra01(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N,
-                           [1.0 + 1e-9] * self.N)
+        self._bounds = list(zip([0.0] * self.N,
+                           [1.0 + 1e-9] * self.N))
 
         self.global_optimum = [[1.0 for _ in range(self.N)]]
         self.fglob = 2.0
@@ -281,8 +281,8 @@ class Mishra02(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N,
-                           [1.0 + 1e-9] * self.N)
+        self._bounds = list(zip([0.0] * self.N,
+                           [1.0 + 1e-9] * self.N))
 
         self.global_optimum = [[1.0 for _ in range(self.N)]]
         self.fglob = 2.0
@@ -325,7 +325,7 @@ class Mishra03(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[-9.99378322, -9.99918927]]
         self.fglob = -0.19990562
@@ -365,7 +365,7 @@ class Mishra04(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[-8.88055269734, -8.89097599857]]
         self.fglob = -0.177715264826
@@ -405,7 +405,7 @@ class Mishra05(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[-1.98682, -10.0]]
         self.fglob = -1.019829519930646
@@ -447,7 +447,7 @@ class Mishra06(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[2.88631, 1.82326]]
         self.fglob = -2.28395
@@ -488,7 +488,7 @@ class Mishra07(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = [(-2, 2), (-2, 2)]
         self.global_optimum = [[sqrt(self.N)
                                for i in range(self.N)]]
@@ -531,7 +531,7 @@ class Mishra08(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = [(1.0, 2.0), (-4.0, 1.0)]
         self.global_optimum = [[2.0, -3.0]]
         self.fglob = 0.0
@@ -585,7 +585,7 @@ class Mishra09(Benchmark):
     def __init__(self, dimensions=3):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.global_optimum = [[1.0, 2.0, 3.0]]
         self.fglob = 0.0
 
@@ -629,7 +629,7 @@ class Mishra10(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.global_optimum = [[2.0, 2.0]]
         self.fglob = 0.0
 
@@ -671,7 +671,7 @@ class Mishra11(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = [(-3, 3), (-3, 3)]
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
@@ -711,7 +711,7 @@ class MultiModal(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = [(-5, 5), (-5, 5)]
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_N.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_N.py
@@ -39,7 +39,7 @@ class NeedleEye(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
         self.fglob = 1.0
@@ -93,7 +93,7 @@ class NewFunction01(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[-8.46668984648, -9.99980944557]]
         self.fglob = -0.184648852475
@@ -136,7 +136,7 @@ class NewFunction02(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[-9.94114736324, -9.99997128772]]
         self.fglob = -0.199409030092

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_O.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_O.py
@@ -46,8 +46,8 @@ class OddSquare(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0 * pi] * self.N,
-                           [5.0 * pi] * self.N)
+        self._bounds = list(zip([-5.0 * pi] * self.N,
+                           [5.0 * pi] * self.N))
         self.custom_bounds = ([-2.0, 4.0], [-2.0, 4.0])
         self.a = asarray([1, 1.3, 0.8, -0.4, -1.3, 1.6, -0.2, -0.6, 0.5, 1.4]
                          * 2)

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_P.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_P.py
@@ -36,7 +36,7 @@ class Parsopoulos(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0] * self.N, [5.0] * self.N)
+        self._bounds = list(zip([-5.0] * self.N, [5.0] * self.N))
 
         self.global_optimum = [[pi / 2.0, pi]]
         self.fglob = 0
@@ -76,8 +76,8 @@ class Pathological(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
 
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = 0.
@@ -122,7 +122,7 @@ class Paviani(Benchmark):
     def __init__(self, dimensions=10):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([2.001] * self.N, [9.999] * self.N)
+        self._bounds = list(zip([2.001] * self.N, [9.999] * self.N))
 
         self.global_optimum = [[9.350266 for _ in range(self.N)]]
         self.fglob = -45.7784684040686
@@ -179,7 +179,7 @@ class Penalty01(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-50.0] * self.N, [50.0] * self.N)
+        self._bounds = list(zip([-50.0] * self.N, [50.0] * self.N))
         self.custom_bounds = ([-5.0, 5.0], [-5.0, 5.0])
 
         self.global_optimum = [[-1.0 for _ in range(self.N)]]
@@ -241,7 +241,7 @@ class Penalty02(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-50.0] * self.N, [50.0] * self.N)
+        self._bounds = list(zip([-50.0] * self.N, [50.0] * self.N))
         self.custom_bounds = ([-4.0, 4.0], [-4.0, 4.0])
 
         self.global_optimum = [[1.0 for _ in range(self.N)]]
@@ -290,7 +290,7 @@ class PenHolder(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-11.0] * self.N, [11.0] * self.N)
+        self._bounds = list(zip([-11.0] * self.N, [11.0] * self.N))
 
         self.global_optimum = [[-9.646167708023526, 9.646167671043401]]
         self.fglob = -0.9635348327265058
@@ -333,10 +333,10 @@ class PermFunction01(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-self.N] * self.N,
-                           [self.N + 1] * self.N)
+        self._bounds = list(zip([-self.N] * self.N,
+                           [self.N + 1] * self.N))
 
-        self.global_optimum = [range(1, self.N + 1)]
+        self.global_optimum = [list(range(1, self.N + 1))]
         self.fglob = 0.0
         self.change_dimensionality = True
 
@@ -381,8 +381,8 @@ class PermFunction02(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-self.N] * self.N,
-                           [self.N + 1] * self.N)
+        self._bounds = list(zip([-self.N] * self.N,
+                           [self.N + 1] * self.N))
         self.custom_bounds = ([0, 1.5], [0, 1.0])
 
         self.global_optimum = [1. / arange(1, self.N + 1)]
@@ -438,7 +438,7 @@ class Pinter(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
         self.fglob = 0.0
@@ -484,7 +484,7 @@ class Plateau(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.12] * self.N, [5.12] * self.N)
+        self._bounds = list(zip([-5.12] * self.N, [5.12] * self.N))
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
         self.fglob = 30.0
@@ -523,7 +523,7 @@ class Powell(Benchmark):
     def __init__(self, dimensions=4):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-4.0] * self.N, [5.0] * self.N)
+        self._bounds = list(zip([-4.0] * self.N, [5.0] * self.N))
         self.global_optimum = [[0, 0, 0, 0]]
         self.fglob = 0
 
@@ -560,8 +560,8 @@ class PowerSum(Benchmark):
     def __init__(self, dimensions=4):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N,
-                           [4.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N,
+                           [4.0] * self.N))
 
         self.global_optimum = [[1.0, 2.0, 2.0, 3.0]]
         self.fglob = 0.0
@@ -601,8 +601,8 @@ class Price01(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-500.0] * self.N,
-                           [500.0] * self.N)
+        self._bounds = list(zip([-500.0] * self.N,
+                           [500.0] * self.N))
         self.custom_bounds = ([-10.0, 10.0], [-10.0, 10.0])
 
         self.global_optimum = [[5.0, 5.0]]
@@ -639,7 +639,7 @@ class Price02(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[0.0, 0.0]]
         self.fglob = 0.9
@@ -677,7 +677,7 @@ class Price03(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0] * self.N, [5.0] * self.N)
+        self._bounds = list(zip([-5.0] * self.N, [5.0] * self.N))
         self.custom_bounds = ([0, 2], [0, 2])
 
         self.global_optimum = [[1.0, 1.0]]
@@ -715,7 +715,7 @@ class Price04(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-50.0] * self.N, [50.0] * self.N)
+        self._bounds = list(zip([-50.0] * self.N, [50.0] * self.N))
         self.custom_bounds = ([0, 2], [0, 2])
 
         self.global_optimum = [[2.0, 4.0]]

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Q.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Q.py
@@ -33,8 +33,8 @@ class Qing(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-500.0] * self.N,
-                           [500.0] * self.N)
+        self._bounds = list(zip([-500.0] * self.N,
+                           [500.0] * self.N))
         self.custom_bounds = [(-2, 2), (-2, 2)]
         self.global_optimum = [[sqrt(_) for _ in range(1, self.N + 1)]]
         self.fglob = 0
@@ -75,7 +75,7 @@ class Quadratic(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = [(0, 1), (0, 1)]
         self.global_optimum = [[0.19388, 0.48513]]
         self.fglob = -3873.72418
@@ -116,7 +116,7 @@ class Quintic(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = [(-2, 2), (-2, 2)]
 
         self.global_optimum = [[-1.0 for _ in range(self.N)]]

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_R.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_R.py
@@ -39,8 +39,8 @@ class Rana(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-500.000001] * self.N,
-                           [500.000001] * self.N)
+        self._bounds = list(zip([-500.000001] * self.N,
+                           [500.000001] * self.N))
 
         self.global_optimum = [[-300.3376, 500.]]
         self.fglob = -500.8021602966615
@@ -79,7 +79,7 @@ class Rastrigin(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([-5.12] * self.N, [5.12] * self.N)
+        self._bounds = list(zip([-5.12] * self.N, [5.12] * self.N))
 
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = 0.0
@@ -103,8 +103,8 @@ class Ratkowsky01(Benchmark):
     def __init__(self, dimensions=4):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0., 1., 0., 0.1],
-                           [1000, 20., 3., 6.])
+        self._bounds = list(zip([0., 1., 0., 0.1],
+                           [1000, 20., 3., 6.]))
         self.global_optimum = [[6.996415127e2, 5.2771253025, 7.5962938329e-1,
                                 1.2792483859]]
         self.fglob = 8.786404908e3
@@ -154,8 +154,8 @@ class Ratkowsky02(Benchmark):
     def __init__(self, dimensions=3):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([10, 0.5, 0.01],
-                           [200, 5., 0.5])
+        self._bounds = list(zip([10, 0.5, 0.01],
+                           [200, 5., 0.5]))
         self.global_optimum = [[7.2462237576e1, 2.6180768402, 6.7359200066e-2]]
         self.fglob = 8.0565229338
         self.a = asarray([8.93, 10.8, 18.59, 22.33, 39.35, 56.11, 61.73, 64.62,
@@ -196,7 +196,7 @@ class Ripple01(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([0.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [1.0] * self.N))
 
         self.global_optimum = [[0.1 for _ in range(self.N)]]
         self.fglob = -2.2
@@ -237,7 +237,7 @@ class Ripple25(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([0.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [1.0] * self.N))
 
         self.global_optimum = [[0.1 for _ in range(self.N)]]
         self.fglob = -2.0
@@ -278,7 +278,7 @@ class Rosenbrock(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-30.] * self.N, [30.0] * self.N)
+        self._bounds = list(zip([-30.] * self.N, [30.0] * self.N))
         self.custom_bounds = [(-2, 2), (-2, 2)]
 
         self.global_optimum = [[1 for _ in range(self.N)]]
@@ -321,7 +321,7 @@ class RosenbrockModified(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-2.0] * self.N, [2.0] * self.N)
+        self._bounds = list(zip([-2.0] * self.N, [2.0] * self.N))
         self.custom_bounds = ([-1.0, 0.5], [-1.0, 1.0])
 
         self.global_optimum = [[-0.90955374, -0.95057172]]
@@ -359,8 +359,8 @@ class RotatedEllipse01(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-500.0] * self.N,
-                           [500.0] * self.N)
+        self._bounds = list(zip([-500.0] * self.N,
+                           [500.0] * self.N))
         self.custom_bounds = ([-2.0, 2.0], [-2.0, 2.0])
 
         self.global_optimum = [[0.0, 0.0]]
@@ -397,8 +397,8 @@ class RotatedEllipse02(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-500.0] * self.N,
-                           [500.0] * self.N)
+        self._bounds = list(zip([-500.0] * self.N,
+                           [500.0] * self.N))
         self.custom_bounds = ([-2.0, 2.0], [-2.0, 2.0])
 
         self.global_optimum = [[0.0, 0.0]]

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_S.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_S.py
@@ -34,8 +34,8 @@ class Salomon(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
         self.custom_bounds = [(-50, 50), (-50, 50)]
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
@@ -76,8 +76,8 @@ class Sargan(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
         self.custom_bounds = [(-5, 5), (-5, 5)]
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
@@ -119,8 +119,8 @@ class Schaffer01(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
         self.custom_bounds = [(-10, 10), (-10, 10)]
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
@@ -161,8 +161,8 @@ class Schaffer02(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
         self.custom_bounds = [(-10, 10), (-10, 10)]
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
@@ -201,8 +201,8 @@ class Schaffer03(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
         self.custom_bounds = [(-10, 10), (-10, 10)]
 
         self.global_optimum = [[0.0, 1.253115]]
@@ -241,8 +241,8 @@ class Schaffer04(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
         self.custom_bounds = [(-10, 10), (-10, 10)]
 
         self.global_optimum = [[0.0, 1.253115]]
@@ -321,8 +321,8 @@ class Schwefel01(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
         self.custom_bounds = ([-4.0, 4.0], [-4.0, 4.0])
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
@@ -363,8 +363,8 @@ class Schwefel02(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
         self.custom_bounds = ([-4.0, 4.0], [-4.0, 4.0])
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
@@ -406,7 +406,7 @@ class Schwefel04(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([0.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [10.0] * self.N))
         self.custom_bounds = ([0.0, 2.0], [0.0, 2.0])
 
         self.global_optimum = [[1.0 for _ in range(self.N)]]
@@ -444,8 +444,8 @@ class Schwefel06(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
         self.custom_bounds = ([-10.0, 10.0], [-10.0, 10.0])
 
         self.global_optimum = [[1.0, 3.0]]
@@ -485,8 +485,8 @@ class Schwefel20(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
         self.fglob = 0.0
@@ -525,8 +525,8 @@ class Schwefel21(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
         self.fglob = 0.0
@@ -565,8 +565,8 @@ class Schwefel22(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
         self.custom_bounds = ([-10.0, 10.0], [-10.0, 10.0])
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
@@ -603,8 +603,8 @@ class Schwefel26(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([-500.0] * self.N,
-                           [500.0] * self.N)
+        self._bounds = list(zip([-500.0] * self.N,
+                           [500.0] * self.N))
 
         self.global_optimum = [[420.968746 for _ in range(self.N)]]
         self.fglob = 0.0
@@ -640,7 +640,7 @@ class Schwefel36(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([0.0] * self.N, [500.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [500.0] * self.N))
         self.custom_bounds = ([0.0, 20.0], [0.0, 20.0])
 
         self.global_optimum = [[12.0, 12.0]]
@@ -697,7 +697,7 @@ class Shekel05(Benchmark):
     def __init__(self, dimensions=4):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[4.00003715092,
                                 4.00013327435,
@@ -769,7 +769,7 @@ class Shekel07(Benchmark):
     def __init__(self, dimensions=4):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[4.00057291078,
                                 4.0006893679,
@@ -842,7 +842,7 @@ class Shekel10(Benchmark):
     def __init__(self, dimensions=4):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[4.0007465377266271,
                                 4.0005929234621407,
@@ -895,7 +895,7 @@ class Shubert01(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.global_optimum = [[-7.0835, 4.8580]]
 
         self.fglob = -186.7309
@@ -938,7 +938,7 @@ class Shubert03(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[5.791794, 5.791794]]
         self.fglob = -24.062499
@@ -981,7 +981,7 @@ class Shubert04(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[-0.80032121, -7.08350592]]
         self.fglob = -29.016015
@@ -1025,8 +1025,8 @@ class SineEnvelope(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
         self.custom_bounds = [(-20, 20), (-20, 20)]
 
         self.global_optimum = [[0 for _ in range(self.N)]]
@@ -1070,7 +1070,7 @@ class SixHumpCamel(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0] * self.N, [5.0] * self.N)
+        self._bounds = list(zip([-5.0] * self.N, [5.0] * self.N))
         self.custom_bounds = [(-2, 2), (-1.5, 1.5)]
 
         self.global_optimum = [(0.08984201368301331, -0.7126564032704135),
@@ -1107,7 +1107,7 @@ class Sodp(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-1.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([-1.0] * self.N, [1.0] * self.N))
 
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = 0.0
@@ -1147,7 +1147,7 @@ class Sphere(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([-5.12] * self.N, [5.12] * self.N)
+        self._bounds = list(zip([-5.12] * self.N, [5.12] * self.N))
 
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = 0.0
@@ -1185,8 +1185,8 @@ class Step(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
         self.custom_bounds = ([-5, 5], [-5, 5])
 
         self.global_optimum = [[0. for _ in range(self.N)]]
@@ -1223,8 +1223,8 @@ class Step2(Benchmark):
 
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
         self.custom_bounds = ([-5, 5], [-5, 5])
 
         self.global_optimum = [[0.5 for _ in range(self.N)]]
@@ -1265,7 +1265,7 @@ class Stochastic(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0] * self.N, [5.0] * self.N)
+        self._bounds = list(zip([-5.0] * self.N, [5.0] * self.N))
 
         self.global_optimum = [[1.0 / _ for _ in range(1, self.N + 1)]]
         self.fglob = 0.0
@@ -1317,7 +1317,7 @@ class StretchedV(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10] * self.N, [10] * self.N)
+        self._bounds = list(zip([-10] * self.N, [10] * self.N))
 
         self.global_optimum = [[0, 0]]
         self.fglob = 0.0
@@ -1357,7 +1357,7 @@ class StyblinskiTang(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0] * self.N, [5.0] * self.N)
+        self._bounds = list(zip([-5.0] * self.N, [5.0] * self.N))
 
         self.global_optimum = [[-2.903534018185960 for _ in range(self.N)]]
         self.fglob = -39.16616570377142 * self.N

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_T.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_T.py
@@ -38,7 +38,7 @@ class TestTubeHolder(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[-pi / 2, 0.0]]
         self.fglob = -10.87229990155800
@@ -62,9 +62,9 @@ class Thurber(Benchmark):
     def __init__(self, dimensions=7):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip(
+        self._bounds = list(zip(
             [500., 500., 100., 10., 0.1, 0.1, 0.],
-            [2000., 2000., 1000., 150., 2., 1., 0.2])
+            [2000., 2000., 1000., 150., 2., 1., 0.2]))
         self.global_optimum = [[1.288139680e3, 1.4910792535e3, 5.8323836877e2,
                                 75.416644291, 0.96629502864, 0.39797285797,
                                 4.9727297349e-2]]
@@ -119,7 +119,7 @@ class Treccani(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0] * self.N, [5.0] * self.N)
+        self._bounds = list(zip([-5.0] * self.N, [5.0] * self.N))
         self.custom_bounds = [(-2, 2), (-2, 2)]
 
         self.global_optimum = [[-2.0, 0.0]]
@@ -162,7 +162,7 @@ class Trefethen(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = [(-5, 5), (-5, 5)]
 
         self.global_optimum = [[-0.02440307923, 0.2106124261]]
@@ -205,7 +205,7 @@ class ThreeHumpCamel(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0] * self.N, [5.0] * self.N)
+        self._bounds = list(zip([-5.0] * self.N, [5.0] * self.N))
         self.custom_bounds = [(-2, 2), (-1.5, 1.5)]
 
         self.global_optimum = [[0.0, 0.0]]
@@ -247,7 +247,7 @@ class Trid(Benchmark):
     def __init__(self, dimensions=6):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-20.0] * self.N, [20.0] * self.N)
+        self._bounds = list(zip([-20.0] * self.N, [20.0] * self.N))
 
         self.global_optimum = [[6, 10, 12, 12, 10, 6]]
         self.fglob = -50.0
@@ -291,7 +291,7 @@ class Trigonometric01(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [pi] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [pi] * self.N))
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
         self.fglob = 0.0
@@ -333,8 +333,8 @@ class Trigonometric02(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-500.0] * self.N,
-                           [500.0] * self.N)
+        self._bounds = list(zip([-500.0] * self.N,
+                           [500.0] * self.N))
         self.custom_bounds = [(0, 2), (0, 2)]
 
         self.global_optimum = [[0.9 for _ in range(self.N)]]
@@ -377,8 +377,8 @@ class Tripod(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-100.0] * self.N,
-                           [100.0] * self.N)
+        self._bounds = list(zip([-100.0] * self.N,
+                           [100.0] * self.N))
 
         self.global_optimum = [[0.0, -50.0]]
         self.fglob = 0.0

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_U.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_U.py
@@ -112,7 +112,7 @@ class Ursem04(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-2.0] * self.N, [2.0] * self.N)
+        self._bounds = list(zip([-2.0] * self.N, [2.0] * self.N))
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
         self.fglob = -1.5

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_V.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_V.py
@@ -36,7 +36,7 @@ class VenterSobiezcczanskiSobieski(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-50.0] * self.N, [50.0] * self.N)
+        self._bounds = list(zip([-50.0] * self.N, [50.0] * self.N))
         self.custom_bounds = ([-10, 10], [-10, 10])
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
@@ -75,7 +75,7 @@ class Vincent(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.25] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([0.25] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[7.70628098 for _ in range(self.N)]]
         self.fglob = -float(self.N)

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_W.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_W.py
@@ -41,7 +41,7 @@ class Watson(Benchmark):
     def __init__(self, dimensions=6):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0] * self.N, [5.0] * self.N)
+        self._bounds = list(zip([-5.0] * self.N, [5.0] * self.N))
 
         self.global_optimum = [[-0.0158, 1.012, -0.2329, 1.260, -1.513,
                                 0.9928]]
@@ -92,7 +92,7 @@ class Wavy(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-pi] * self.N, [pi] * self.N)
+        self._bounds = list(zip([-pi] * self.N, [pi] * self.N))
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
         self.fglob = 0.0
@@ -130,7 +130,7 @@ class WayburnSeader01(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0] * self.N, [5.0] * self.N)
+        self._bounds = list(zip([-5.0] * self.N, [5.0] * self.N))
         self.custom_bounds = ([-2, 2], [-2, 2])
 
         self.global_optimum = [[1.0, 2.0]]
@@ -169,8 +169,8 @@ class WayburnSeader02(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-500.0] * self.N,
-                           [500.0] * self.N)
+        self._bounds = list(zip([-500.0] * self.N,
+                           [500.0] * self.N))
         self.custom_bounds = ([-1, 2], [-1, 2])
 
         self.global_optimum = [[0.2, 1.0]]
@@ -221,7 +221,7 @@ class Weierstrass(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-0.5] * self.N, [0.5] * self.N)
+        self._bounds = list(zip([-0.5] * self.N, [0.5] * self.N))
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
         self.fglob = 0
@@ -270,8 +270,8 @@ class Whitley(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.24] * self.N,
-                           [10.24] * self.N)
+        self._bounds = list(zip([-10.24] * self.N,
+                           [10.24] * self.N))
         self.custom_bounds = ([-1, 2], [-1, 2])
 
         self.global_optimum = [[1.0 for _ in range(self.N)]]
@@ -314,7 +314,7 @@ class Wolfe(Benchmark):
     def __init__(self, dimensions=3):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [2.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [2.0] * self.N))
 
         self.global_optimum = [[0.0 for _ in range(self.N)]]
         self.fglob = 0.0

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_X.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_X.py
@@ -37,7 +37,7 @@ class XinSheYang01(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0] * self.N, [5.0] * self.N)
+        self._bounds = list(zip([-5.0] * self.N, [5.0] * self.N))
         self.custom_bounds = ([-2, 2], [-2, 2])
 
         self.global_optimum = [[0 for _ in range(self.N)]]
@@ -79,8 +79,8 @@ class XinSheYang02(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-2 * pi] * self.N,
-                           [2 * pi] * self.N)
+        self._bounds = list(zip([-2 * pi] * self.N,
+                           [2 * pi] * self.N))
 
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = 0.0
@@ -123,7 +123,7 @@ class XinSheYang03(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-20.0] * self.N, [20.0] * self.N)
+        self._bounds = list(zip([-20.0] * self.N, [20.0] * self.N))
 
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = -1.0
@@ -169,7 +169,7 @@ class XinSheYang04(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = -1.0
@@ -218,7 +218,7 @@ class Xor(Benchmark):
     def __init__(self, dimensions=9):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-1.0] * self.N, [1.0] * self.N)
+        self._bounds = list(zip([-1.0] * self.N, [1.0] * self.N))
 
         self.global_optimum = [[1.0, -1.0, 1.0,
                                -1.0, -1.0, 1.0, 1.0, -1.0, 0.421134]]

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Y.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Y.py
@@ -35,7 +35,7 @@ class YaoLiu04(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = 0.0
@@ -74,7 +74,7 @@ class YaoLiu09(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.12] * self.N, [5.12] * self.N)
+        self._bounds = list(zip([-5.12] * self.N, [5.12] * self.N))
 
         self.global_optimum = [[0 for _ in range(self.N)]]
         self.fglob = 0.0

--- a/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Z.py
+++ b/benchmarks/benchmarks/go_benchmark_functions/go_funcs_Z.py
@@ -34,7 +34,7 @@ class Zacharov(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-5.0] * self.N, [10.0] * self.N))
         self.custom_bounds = ([-1, 1], [-1, 1])
 
         self.global_optimum = [[0 for _ in range(self.N)]]
@@ -76,7 +76,7 @@ class ZeroSum(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[]]
         self.fglob = 0.0
@@ -116,7 +116,7 @@ class Zettl(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-5.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-5.0] * self.N, [10.0] * self.N))
 
         self.global_optimum = [[-0.02989597760285287, 0.0]]
         self.fglob = -0.003791237220468656
@@ -170,7 +170,7 @@ class Zimmerman(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([0.0] * self.N, [100.0] * self.N)
+        self._bounds = list(zip([0.0] * self.N, [100.0] * self.N))
         self.custom_bounds = ([0.0, 8.0], [0.0, 8.0])
 
         self.global_optimum = [[7.0, 2.0]]
@@ -216,7 +216,7 @@ class Zirilli(Benchmark):
     def __init__(self, dimensions=2):
         Benchmark.__init__(self, dimensions)
 
-        self._bounds = zip([-10.0] * self.N, [10.0] * self.N)
+        self._bounds = list(zip([-10.0] * self.N, [10.0] * self.N))
         self.custom_bounds = ([-2.0, 2.0], [-2.0, 2.0])
 
         self.global_optimum = [[-1.0465, 0.0]]

--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -404,11 +404,12 @@ class BenchGlobal(Benchmark):
     ])
 
     if _func_names:
-        _functions = OrderedDict([
-            (name, _functions.get(name)) 
-            for name in _func_names
-            if name in _functions
-        ])
+        _filtered_funcs = OrderedDict()
+        for name in _func_names:
+            if name in _functions:
+                _filtered_funcs[name] = _functions.get(name)
+        _functions = _filtered_funcs
+
     if not slow:
         _functions = {'AMGM': None}
 

--- a/benchmarks/benchmarks/optimize.py
+++ b/benchmarks/benchmarks/optimize.py
@@ -387,7 +387,8 @@ except ValueError:
 
 _func_names = os.environ.get('SCIPY_GLOBAL_BENCH', [])
 if _func_names:
-    slow = 1
+    if not slow:
+        slow = 100
     _func_names = [x.strip() for x in _func_names.split(',')]
 
 
@@ -399,7 +400,7 @@ class BenchGlobal(Benchmark):
     _functions = OrderedDict([
         item for item in inspect.getmembers(gbf, inspect.isclass)
         if (issubclass(item[1], gbf.Benchmark) and
-            item[0] not in ('Benchmark', 'LennardJones') and
+            item[0] not in ('Benchmark') and
             not item[0].startswith('Problem'))
     ])
 
@@ -425,7 +426,8 @@ class BenchGlobal(Benchmark):
 
     def setup(self, *a):
         if not self.enabled:
-            print("BenchGlobal.track_all not enabled --- export SCIPY_XSLOW=1 to enable\n"
+            print("BenchGlobal.track_all not enabled --- export SCIPY_XSLOW=slow to enable,\n"
+                  "slow iterations of each benchmark will be run.\n"
                   "Note that it can take several hours to run; intermediate output\n"
                   "can be found under benchmarks/global-bench-results.json\n"
                   "You can specify functions to benchmark via SCIPY_GLOBAL_BENCH=AMGM,Adjiman,...")
@@ -445,7 +447,7 @@ class BenchGlobal(Benchmark):
         if not self.enabled:
             return {}
 
-        numtrials = 100
+        numtrials = slow
 
         results = {}
         solvers = ['DE', 'basinh.']

--- a/benchmarks/benchmarks/test_go_benchmark_functions.py
+++ b/benchmarks/benchmarks/test_go_benchmark_functions.py
@@ -22,6 +22,8 @@ class TestGoBenchmarkFunctions(TestCase):
         # Check that the function returns the global minimum if given
         # the optimal solution
         for name, klass in self.benchmark_functions:
+            # LennardJones is filtered here because there are many global
+            # optimima that give the same minimum energy
             if (name in ['Benchmark', 'LennardJones'] or
                  name.startswith('Problem')):
                 continue
@@ -44,12 +46,28 @@ class TestGoBenchmarkFunctions(TestCase):
         # In Python 2 zip returns a list which is subscriptable
         # In Python 3 zip returns a zip object, which is not subscriptable
         for name, klass in self.benchmark_functions:
-            if (name in ['Benchmark', 'LennardJones'] or
-                    name.startswith('Problem')):
+            if (name == 'Benchmark' or name.startswith('Problem')):
                 continue
 
             f = klass()
             bounds = f.bounds[0]
+
+    def test_redimension(self):
+        # check that problems can be redimensioned, use LJ for this.
+        LJ = self.benchmark_functions['LennardJones']
+        L = LJ()
+        L.change_dimensions(10)
+
+        # if we change the size of the problem then the initial vector has to
+        # resize
+        x0 = L.initial_vector()
+        assert_(len(x0) == 10)
+
+        # the bounds should be the correct length now.
+        bounds = L.bounds
+        assert_(len(bounds) == 10)
+
+        assert_(L.N == 10)
 
 
 if __name__ == '__main__':

--- a/benchmarks/benchmarks/test_go_benchmark_functions.py
+++ b/benchmarks/benchmarks/test_go_benchmark_functions.py
@@ -40,6 +40,17 @@ class TestGoBenchmarkFunctions(TestCase):
             # should result in an attribute error if it doesn't exist
             val = f.fglob
 
+    def test_bounds_access_subscriptable(self):
+        # In Python 2 zip returns a list which is subscriptable
+        # In Python 3 zip returns a zip object, which is not subscriptable
+        for name, klass in self.benchmark_functions:
+            if (name in ['Benchmark', 'LennardJones'] or
+                    name.startswith('Problem')):
+                continue
+
+            f = klass()
+            bounds = f.bounds[0]
+
 
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
Running of the global benchmarking code was being performed in `BenchGlobal.setup_cache`. However, I was experiencing a timeout of 600 s when trying to run the benchmarks (if `setup_cache` takes more than 600 s the benchmarking is terminated). This meant i couldn't run a large number of repeats and examine all the problem functions. I couldn't figure out how to increase this limit of 600 s.
I therefore moved the running of each of the problem functions into `BenchGlobal.track_all`. The timeout can be controlled precisely for each call of `track_all`, which allows all of the benchmark functions to be run with a large number of repeats.
As before the results for a given problem/solver combination are cached in a file. This enables different ret_values to be retrieved and returned, rather than running the problems again.
This PR is branched off the PR in #6388, and #6388 should be merged first. @pv, you first put these benchmarking code for this in setup_cache, do you think these modifications are a good idea?
