### PR TITLE
ENH: signal: added irrnotch and iirpeak functions.

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -162,6 +162,7 @@ Bill Sacks for fixes to netcdf i/o.
 Kolja Glogowski for a bug fix in scipy.special.
 Surhud More for enhancing scipy.optimize.curve_fit to accept covariant errors
 on data.
+Antonio Ribeiro for implementing irrnotch and iirpeak functions.
 
 Institutions
 ------------

--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -46,6 +46,11 @@ response from second-order sections.
 The function `scipy.signal.unit_impulse` was added to conveniently
 generate an impulse function.
 
+The function `scipy.signal.irrnotch` was added to design second-order
+IIR notch filters that can be used to remove a frequency component from
+a signal. The dual function  `scipy.signal.irrpeak` was added to
+compute the coeficients of a second-order IIR peak (resonant) filter.
+
 `scipy.sparse` improvements
 ---------------------------
 

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -145,6 +145,8 @@ Matlab-style IIR filter design
    ellip -- Elliptic (Cauer)
    ellipord
    bessel -- Bessel (no order selection available -- try butterod)
+   iirnotch      -- Design second-order IIR notch digital filter.
+   iirpeak       -- Design second-order IIR peak (resonant) digital filter.
 
 Continuous-Time Linear Systems
 ==============================

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -25,7 +25,7 @@ __all__ = ['findfreqs', 'freqs', 'freqz', 'tf2zpk', 'zpk2tf', 'normalize',
            'buttap', 'cheb1ap', 'cheb2ap', 'ellipap', 'besselap',
            'BadCoefficients',
            'tf2sos', 'sos2tf', 'zpk2sos', 'sos2zpk', 'group_delay',
-           'sosfreqz']
+           'sosfreqz', 'iirnotch', 'iirpeak']
 
 
 class BadCoefficients(UserWarning):
@@ -3653,6 +3653,233 @@ def besselap(N, norm='phase'):
     return asarray([]), asarray(p, dtype=complex), float(k)
 
 
+def iirnotch(w0, Q):
+    """
+    Design second-order IIR notch digital filter.
+
+    A notch filter is a band-stop filter with a narrow bandwidth
+    (high quality factor). It rejects a narrow frequency band and
+    leaves the rest of the spectrum little changed.
+
+    Parameters
+    ----------
+    w0 : float
+        Normalized frequency to remove from a signal. It is a
+        scalar that must satisfy  ``0 < w0 < 1``, with ``w0 = 1``
+        corresponding to half of the sampling frequency.
+    Q : float
+        Quality factor. Dimensionless parameter that characterizes
+        notch filter -3 dB bandwidth ``bw`` relative to its center
+        frequency, ``Q = w0/bw``.
+
+    Returns
+    -------
+    b, a : ndarray, ndarray
+        Numerator (``b``) and denominator (``a``) polynomials
+        of the IIR filter.
+
+    See Also
+    --------
+    iirpeak
+
+    Notes
+    -----
+    .. versionadded: 0.19.0
+
+    References
+    ----------
+    .. [1] Sophocles J. Orfanidis, "Introduction To Signal Processing",
+           Prentice-Hall, 1996
+
+    Examples
+    --------
+    Design and plot filter to remove the 60Hz component from a
+    signal sampled at 200Hz, using a quality factor Q = 30
+
+    >>> from scipy import signal
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+
+    >>> fs = 200.0  # Sample frequency (Hz)
+    >>> f0 = 60.0  # Frequency to be removed from signal (Hz)
+    >>> Q = 30.0  # Quality factor
+    >>> w0 = f0/(fs/2)  # Normalized Frequency
+    >>> # Design notch filter
+    >>> b, a = signal.iirnotch(w0, Q)
+
+    >>> # Frequency response
+    >>> w, h = signal.freqz(b, a)
+    >>> # Generate frequency axis
+    >>> freq = w*fs/(2*np.pi)
+    >>> # Plot
+    >>> fig, ax = plt.subplots(2, 1, figsize=(8, 6))
+    >>> ax[0].plot(freq, 20*np.log10(abs(h)), color='blue')
+    >>> ax[0].set_title("Frequency Response")
+    >>> ax[0].set_ylabel("Amplitude (dB)", color='blue')
+    >>> ax[0].set_xlim([0, 100])
+    >>> ax[0].set_ylim([-25, 10])
+    >>> ax[0].grid()
+    >>> ax[1].plot(freq, np.unwrap(np.angle(h))*180/np.pi, color='green')
+    >>> ax[1].set_ylabel("Angle (degrees)", color='green')
+    >>> ax[1].set_xlabel("Frequency (Hz)")
+    >>> ax[1].set_xlim([0, 100])
+    >>> ax[1].set_yticks([-90, -60, -30, 0, 30, 60, 90])
+    >>> ax[1].set_ylim([-90, 90])
+    >>> ax[1].grid()
+    >>> plt.show()
+    """
+
+    return _design_notch_peak_filter(w0, Q, "notch")
+
+
+def iirpeak(w0, Q):
+    """
+    Design second-order IIR peak (resonant) digital filter.
+
+    A peak filter is a band-pass filter with a narrow bandwidth
+    (high quality factor). It rejects components outside a narrow
+    frequency band.
+
+    Parameters
+    ----------
+    w0 : float
+        Normalized frequency to be retained in a signal. It is a
+        scalar that must satisfy  ``0 < w0 < 1``, with ``w0 = 1`` corresponding
+        to half of the sampling frequency.
+    Q : float
+        Quality factor. Dimensionless parameter that characterizes
+        peak filter -3 dB bandwidth ``bw`` relative to its center
+        frequency, ``Q = w0/bw``.
+
+    Returns
+    -------
+    b, a : ndarray, ndarray
+        Numerator (``b``) and denominator (``a``) polynomials
+        of the IIR filter.
+
+    See Also
+    --------
+    iirnotch
+
+    Notes
+    -----
+    .. versionadded: 0.19.0
+
+    References
+    ----------
+    .. [1] Sophocles J. Orfanidis, "Introduction To Signal Processing",
+           Prentice-Hall, 1996
+
+    Examples
+    --------
+    Design and plot filter to remove the frequencies other than the 300Hz
+    component from a signal sampled at 1000Hz, using a quality factor Q = 30
+
+    >>> from scipy import signal
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+
+    >>> fs = 1000.0  # Sample frequency (Hz)
+    >>> f0 = 300.0  # Frequency to be retained (Hz)
+    >>> Q = 30.0  # Quality factor
+    >>> w0 = f0/(fs/2)  # Normalized Frequency
+    >>> # Design peak filter
+    >>> b, a = signal.iirpeak(w0, Q)
+
+    >>> # Frequency response
+    >>> w, h = signal.freqz(b, a)
+    >>> # Generate frequency axis
+    >>> freq = w*fs/(2*np.pi)
+    >>> # Plot
+    >>> fig, ax = plt.subplots(2, 1, figsize=(8, 6))
+    >>> ax[0].plot(freq, 20*np.log10(abs(h)), color='blue')
+    >>> ax[0].set_title("Frequency Response")
+    >>> ax[0].set_ylabel("Amplitude (dB)", color='blue')
+    >>> ax[0].set_xlim([0, 500])
+    >>> ax[0].set_ylim([-50, 10])
+    >>> ax[0].grid()
+    >>> ax[1].plot(freq, np.unwrap(np.angle(h))*180/np.pi, color='green')
+    >>> ax[1].set_ylabel("Angle (degrees)", color='green')
+    >>> ax[1].set_xlabel("Frequency (Hz)")
+    >>> ax[1].set_xlim([0, 500])
+    >>> ax[1].set_yticks([-90, -60, -30, 0, 30, 60, 90])
+    >>> ax[1].set_ylim([-90, 90])
+    >>> ax[1].grid()
+    >>> plt.show()
+    """
+
+    return _design_notch_peak_filter(w0, Q, "peak")
+
+
+def _design_notch_peak_filter(w0, Q, ftype):
+    """
+    Design notch or peak digital filter.
+
+    Parameters
+    ----------
+    w0 : float
+        Normalized frequency to remove from a signal. It is a
+        scalar that must satisfy  ``0 < w0 < 1``, with ``w0 = 1``
+        corresponding to half of the sampling frequency.
+    Q : float
+        Quality factor. Dimensionless parameter that characterizes
+        notch filter -3 dB bandwidth ``bw`` relative to its center
+        frequency, ``Q = w0/bw``.
+    ftype : str
+        The type of IIR filter to design:
+
+            - notch filter : ``notch``
+            - peak filter  : ``peak``
+
+    Returns
+    -------
+    b, a : ndarray, ndarray
+        Numerator (``b``) and denominator (``a``) polynomials
+        of the IIR filter.
+    """
+
+    # Guarantee that the inputs are floats
+    w0 = float(w0)
+    Q = float(Q)
+
+    # Checks if w0 is within the range
+    if w0 > 1.0 or w0 < 0.0:
+        raise ValueError("w0 should be such that 0 < w0 < 1")
+
+    # Get bandwidth
+    bw = w0/Q
+
+    # Normalize inputs
+    bw = bw*np.pi
+    w0 = w0*np.pi
+
+    # Compute -3dB atenuation
+    gb = 1/np.sqrt(2)
+
+    if ftype == "notch":
+        # Compute beta: formula 11.3.4 (p.575) from reference [1]
+        beta = (np.sqrt(1.0-gb**2.0)/gb)*np.tan(bw/2.0)
+    elif ftype == "peak":
+        # Compute beta: formula 11.3.19 (p.579) from reference [1]
+        beta = (gb/np.sqrt(1.0-gb**2.0))*np.tan(bw/2.0)
+    else:
+        raise ValueError("Unknown ftype.")
+
+    # Compute gain: formula 11.3.6 (p.575) from reference [1]
+    gain = 1.0/(1.0+beta)
+
+    # Compute numerator b and denominator a
+    # formulas 11.3.7 (p.575) and 11.3.21 (p.579)
+    # from reference [1]
+    if ftype == "notch":
+        b = gain*np.array([1.0, -2.0*np.cos(w0), 1.0])
+    else:
+        b = (1.0-gain)*np.array([1.0, 0.0, -1.0])
+    a = np.array([1.0, -2.0*gain*np.cos(w0), (2.0*gain-1.0)])
+
+    return b, a
+
+
 filter_dict = {'butter': [buttap, buttord],
                'butterworth': [buttap, buttord],
 
@@ -3699,3 +3926,4 @@ bessel_norms = {'bessel': 'phase',
                 'bessel_phase': 'phase',
                 'bessel_delay': 'delay',
                 'bessel_mag': 'mag'}
+

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -15,9 +15,9 @@ from scipy.signal import (tf2zpk, zpk2tf, tf2sos, sos2tf, sos2zpk, zpk2sos,
                           BadCoefficients, freqz, sosfreqz, normalize,
                           buttord, cheby1, cheby2, ellip, cheb1ord, cheb2ord,
                           ellipord, butter, bessel, buttap, besselap,
-                          cheb1ap, cheb2ap, ellipap, iirfilter, freqs,
-                          lp2lp, lp2hp, lp2bp, lp2bs, bilinear, group_delay,
-                          firwin)
+                          iirnotch, iirpeak, cheb1ap, cheb2ap, ellipap, iirfilter,
+                          freqs, lp2lp, lp2hp, lp2bp, lp2bs, bilinear,
+                          group_delay, firwin)
 from scipy.signal.filter_design import (_cplxreal, _cplxpair, _norm_factor,
                                         _bessel_poly, _bessel_zeros)
 
@@ -2573,6 +2573,127 @@ def test_sos_consistency():
         zpk = func(4, *args, output='zpk')
         sos = func(4, *args, output='sos')
         assert_allclose(sos, zpk2sos(*zpk), err_msg="%s(4,...)" % name)
+
+
+class TestIIRNotch(TestCase):
+
+    def test_ba_output(self):
+        # Compare coeficients with Matlab ones
+        # for the equivalent input:
+        b, a = iirnotch(0.06, 30)
+        b2 = [
+             9.9686824e-01, -1.9584219e+00,
+             9.9686824e-01
+             ]
+        a2 = [
+             1.0000000e+00, -1.9584219e+00,
+             9.9373647e-01
+             ]
+
+        assert_allclose(b, b2, rtol=1e-8)
+        assert_allclose(a, a2, rtol=1e-8)
+
+    def test_frequency_response(self):
+        # Get filter coeficients
+        b, a = iirnotch(0.3, 30)
+
+        # Get frequency response
+        w, h = freqz(b, a, 1000)
+
+        # Pick 5 point
+        p = [200,  # w0 = 0.200
+             295,  # w0 = 0.295
+             300,  # w0 = 0.300
+             305,  # w0 = 0.305
+             400]  # w0 = 0.400
+
+        # Get frequency response correspondent to each of those points
+        hp = h[p]
+
+        # Check if the frequency response fulfil the specifications:
+        # hp[0] and hp[4]  correspond to frequencies distant from
+        # w0 = 0.3 and should be close to 1
+        assert_allclose(abs(hp[0]), 1, rtol=1e-2)
+        assert_allclose(abs(hp[4]), 1, rtol=1e-2)
+
+        # hp[1] and hp[3] correspond to frequencies approximately
+        # on the edges of the passband and should be close to -3dB
+        assert_allclose(abs(hp[1]), 1/np.sqrt(2), rtol=1e-2)
+        assert_allclose(abs(hp[3]), 1/np.sqrt(2), rtol=1e-2)
+
+        # hp[2] correspond to the frequency that should be removed
+        # the frequency response should be very close to 0
+        assert_allclose(abs(hp[2]), 0, atol=1e-10)
+
+    def test_errors(self):
+        # Exception should be raised if w0 > 1 or w0 <0
+        assert_raises(ValueError, iirnotch, w0=2, Q=30)
+        assert_raises(ValueError, iirnotch, w0=-1, Q=30)
+
+        # Exception should be raised if any of the parameters
+        # are not float (or cannot be converted to one)
+        assert_raises(ValueError, iirnotch, w0="blabla", Q=30)
+        assert_raises(TypeError, iirnotch, w0=-1, Q=[1, 2, 3])
+
+
+class TestIIRPeak(TestCase):
+
+    def test_ba_output(self):
+        # Compare coeficients with Matlab ones
+        # for the equivalent input:
+        b, a = iirpeak(0.06, 30)
+        b2 = [
+             3.131764229e-03, 0,
+             -3.131764229e-03
+             ]
+        a2 = [
+             1.0000000e+00, -1.958421917e+00,
+             9.9373647e-01
+             ]
+        assert_allclose(b, b2, rtol=1e-8)
+        assert_allclose(a, a2, rtol=1e-8)
+
+    def test_frequency_response(self):
+        # Get filter coeficients
+        b, a = iirpeak(0.3, 30)
+
+        # Get frequency response
+        w, h = freqz(b, a, 1000)
+
+        # Pick 5 point
+        p = [30,  # w0 = 0.030
+             295,  # w0 = 0.295
+             300,  # w0 = 0.300
+             305,  # w0 = 0.305
+             800]  # w0 = 0.800
+
+        # Get frequency response correspondent to each of those points
+        hp = h[p]
+
+        # Check if the frequency response fulfil the specifications:
+        # hp[0] and hp[4]  correspond to frequencies distant from
+        # w0 = 0.3 and should be close to 0
+        assert_allclose(abs(hp[0]), 0, atol=1e-2)
+        assert_allclose(abs(hp[4]), 0, atol=1e-2)
+
+        # hp[1] and hp[3] correspond to frequencies approximately
+        # on the edges of the passband and should be close to 10**(-3/20)
+        assert_allclose(abs(hp[1]), 1/np.sqrt(2), rtol=1e-2)
+        assert_allclose(abs(hp[3]), 1/np.sqrt(2), rtol=1e-2)
+
+        # hp[2] correspond to the frequency that should be retained and
+        # the frequency response should be very close to 1
+        assert_allclose(abs(hp[2]), 1, rtol=1e-10)
+
+    def test_errors(self):
+        # Exception should be raised if w0 > 1 or w0 <0
+        assert_raises(ValueError, iirpeak, w0=2, Q=30)
+        assert_raises(ValueError, iirpeak, w0=-1, Q=30)
+
+        # Exception should be raised if any of the parameters
+        # are not float (or cannot be converted to one)
+        assert_raises(ValueError, iirpeak, w0="blabla", Q=30)
+        assert_raises(TypeError, iirpeak, w0=-1, Q=[1, 2, 3])
 
 
 class TestIIRFilter(TestCase):


### PR DESCRIPTION
Hello, my name is Antonio and I am a Brazilian electrical engineer currently pursuing my master degree. This would be my first contribution to scipy. 

I have implemented and included two new functions to scipy: `iirnotch` and `iirpeak` which are
corespondent to the matlab functions with the same names ([iirnotch](http://www.mathworks.com/help/dsp/ref/iirnotch.html?s_tid=gn_loc_drop) and [iirpeak](http://www.mathworks.com/help/dsp/ref/iirpeak.html)).

The notch filter can be used to remove a frequency component from signal and can be useful, for instance, if you want to remove power-line interference from a signal. The peak filter is dual to the notch filter, attenuating every frequency component except the specified one.

Thanks for taking the time to consider my pull request.
