### PR TITLE
BUG: sparse: fix elementwise divide for CSR/CSC

### DIFF
--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -1102,10 +1102,13 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
         if np.issubdtype(r.dtype, np.inexact):
             # Eldiv leaves entries outside the combined sparsity
-            # pattern empty, so they must be filled manually. They are
-            # always nan, so that the matrix is completely full.
+            # pattern empty, so they must be filled manually.
+            # Everything outside of other's sparsity is NaN, and everything
+            # inside it is either zero or defined by eldiv.
             out = np.empty(self.shape, dtype=self.dtype)
             out.fill(np.nan)
+            row, col = other.nonzero()
+            out[row, col] = 0
             r = r.tocoo()
             out[r.row, r.col] = r.data
             out = np.matrix(out)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1314,12 +1314,16 @@ class _TestCommon:
                     assert_almost_equal(sp_mult, dense_mult)
 
     def test_elementwise_divide(self):
-        expected = [[1,np.nan,np.nan,1],[1,np.nan,1,np.nan],[np.nan,1,np.nan,np.nan]]
+        expected = [[1,np.nan,np.nan,1],
+                    [1,np.nan,1,np.nan],
+                    [np.nan,1,np.nan,np.nan]]
         assert_array_equal(todense(self.datsp / self.datsp),expected)
 
         denom = self.spmatrix(matrix([[1,0,0,4],[-1,0,0,0],[0,8,0,-5]],'d'))
-        res = matrix([[1,np.nan,np.nan,0.5],[-3,np.nan,inf,np.nan],[np.nan,0.25,np.nan,np.nan]],'d')
-        assert_array_equal(todense(self.datsp / denom),res)
+        expected = [[1,np.nan,np.nan,0.5],
+                    [-3,np.nan,inf,np.nan],
+                    [np.nan,0.25,np.nan,0]]
+        assert_array_equal(todense(self.datsp / denom), expected)
 
         # complex
         A = array([[1-2j,0+5j,-1+0j],[4-3j,-3+6j,5]])
@@ -1335,6 +1339,14 @@ class _TestCommon:
         Bsp = self.spmatrix(B)
         with np.errstate(divide='ignore'):
             assert_array_equal(todense(Asp / Bsp), A / B)
+
+        # mismatching sparsity patterns
+        A = array([[0,1],[1,0]])
+        B = array([[1,0],[1,0]])
+        Asp = self.spmatrix(A)
+        Bsp = self.spmatrix(B)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            assert_array_equal(np.array(todense(Asp / Bsp)), A / B)
 
     def test_pow(self):
         A = matrix([[1,0,2,0],[0,3,4,0],[0,5,0,0],[0,6,7,8]])


### PR DESCRIPTION
Fixes gh-6401, adding a new test case and fixing an incorrect existing test.

The fix will slow down elementwise division for sparse/sparse operands, but those operations are fairly rare and already pretty expensive, so the overall impact should be low.
