### PR TITLE
MAINT: _differentialevolution now uses _lib._util.check_random_state

### DIFF
--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -1,9 +1,9 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_equal, assert_
+from numpy.testing import assert_equal, assert_, assert_raises
 
-from scipy._lib._util import _aligned_zeros
+from scipy._lib._util import _aligned_zeros, check_random_state
 
 
 def test__aligned_zeros():
@@ -36,6 +36,20 @@ def test__aligned_zeros():
         for n in [0, 1, 3, 11]:
             for order in ["C", "F", None]:
                 for dtype in [np.uint8, np.float64]:
-                    for shape in [n, (1,2,3,n)]:
+                    for shape in [n, (1, 2, 3, n)]:
                         for j in range(niter):
                             check(shape, dtype, order, align)
+
+
+def test_check_random_state():
+    # If seed is None, return the RandomState singleton used by np.random.
+    # If seed is an int, return a new RandomState instance seeded with seed.
+    # If seed is already a RandomState instance, return it.
+    # Otherwise raise ValueError.
+    rsi = check_random_state(1)
+    assert_equal(type(rsi), np.random.RandomState)
+    rsi = check_random_state(rsi)
+    assert_equal(type(rsi), np.random.RandomState)
+    rsi = check_random_state(None)
+    assert_equal(type(rsi), np.random.RandomState)
+    assert_raises(ValueError, check_random_state, 'a')

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -6,7 +6,9 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from scipy.optimize import OptimizeResult, minimize
 from scipy.optimize.optimize import _status_message
-import numbers
+from scipy._lib._util import check_random_state
+import warnings
+
 
 __all__ = ['differential_evolution']
 
@@ -376,7 +378,7 @@ class DifferentialEvolutionSolver(object):
 
         self.parameter_count = np.size(self.limits, 1)
 
-        self.random_number_generator = _make_random_gen(seed)
+        self.random_number_generator = check_random_state(seed)
 
         # default population initialization is a latin hypercube design, but
         # there are other population initializations possible.
@@ -770,20 +772,3 @@ class DifferentialEvolutionSolver(object):
         idxs = idxs[:number_samples]
         return idxs
 
-
-def _make_random_gen(seed):
-    """Turn seed into a np.random.RandomState instance
-
-    If seed is None, return the RandomState singleton used by np.random.
-    If seed is an int, return a new RandomState instance seeded with seed.
-    If seed is already a RandomState instance, return it.
-    Otherwise raise ValueError.
-    """
-    if seed is None or seed is np.random:
-        return np.random.mtrand._rand
-    if isinstance(seed, (numbers.Integral, np.integer)):
-        return np.random.RandomState(seed)
-    if isinstance(seed, np.random.RandomState):
-        return seed
-    raise ValueError('%r cannot be used to seed a numpy.random.RandomState'
-                     ' instance' % seed)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -345,20 +345,6 @@ class TestDifferentialEvolutionSolver(TestCase):
 
         solver.solve()
 
-    def test__make_random_gen(self):
-        # If seed is None, return the RandomState singleton used by np.random.
-        # If seed is an int, return a new RandomState instance seeded with seed.
-        # If seed is already a RandomState instance, return it.
-        # Otherwise raise ValueError.
-        rsi = _differentialevolution._make_random_gen(1)
-        assert_equal(type(rsi), np.random.RandomState)
-        rsi = _differentialevolution._make_random_gen(rsi)
-        assert_equal(type(rsi), np.random.RandomState)
-        rsi = _differentialevolution._make_random_gen(None)
-        assert_equal(type(rsi), np.random.RandomState)
-        self.assertRaises(
-            ValueError, _differentialevolution._make_random_gen, 'a')
-
     def test_gh_4511_regression(self):
         # This modification of the differential evolution docstring example
         # uses a custom popsize that had triggered an off-by-one error.


### PR DESCRIPTION
`_differentialevolution` had its own version of `_lib._util.check_random_state`. It doesn't make sense to use two different versions of the same thing, so I've deprecated the version in `_differentialevolution.py` and changed the differential evolution code to use the version in `_lib._util`. I also added some tests to check that `check_random_state` is returning the right output.
