### PR TITLE
BUG Issue #6421: scipy.linalg.solve_banded overwrites input 'b' when...

### DIFF
--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -230,7 +230,7 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
 
     overwrite_b = overwrite_b or _datacopied(b1, b)
     if a1.shape[-1] == 1:
-        b2 = np.array(b1, copy=overwrite_b)
+        b2 = np.array(b1, copy=(not overwrite_b))
         b2 /= a1[1, 0]
         return b2
     if l == u == 1:

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -171,9 +171,11 @@ class TestSolveBanded(TestCase):
         assert_raises(ValueError, solve_banded, (1, 1), ab, [1.0, 2.0])
 
     def test_1x1(self):
-        x = solve_banded((1, 1), [[0], [1], [0]], [[1, 2, 3]])
-        assert_array_equal(x, [[1.0, 2.0, 3.0]])
+        b = array([[1., 2., 3.]])
+        x = solve_banded((1, 1), [[0], [2], [0]], b)
+        assert_array_equal(x, [[0.5, 1.0, 1.5]])
         assert_equal(x.dtype, np.dtype('f8'))
+        assert_array_equal(b, [[1.0, 2.0, 3.0]])
 
 
 class TestSolveHBanded(TestCase):


### PR DESCRIPTION
Updated the unit test to detect the bug reported in Issue #6421, then fixed the code in scipy.linalg.solve_banded to solve the issue.
