### PR TITLE
bracket doc now says f(xa) >= f(xb) <= f(xc)

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2133,7 +2133,7 @@ def bracket(func, xa=0.0, xb=1.0, args=(), grow_limit=110.0, maxiter=1000):
     Given a function and distinct initial points, search in the
     downhill direction (as defined by the initital points) and return
     new points xa, xb, xc that bracket the minimum of the function
-    f(xa) > f(xb) < f(xc). It doesn't always mean that obtained
+    f(xa) >= f(xb) <= f(xc). It doesn't always mean that obtained
     solution will satisfy xa<=x<=xb
 
     Parameters

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1225,7 +1225,6 @@ def test_bracket():
         return (x - a)**2 - 0.8
 
     xa, xb, xc, fa, fb, fc, _ = optimize.bracket(fun, -1/2, +1/2, (0,))
-    print(fa, fb, fc)
     assert_(not (fa > fb and fb < fc))
     assert_(fa >= fb and fb <= fc)
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1220,5 +1220,14 @@ class TestIterationLimits(TestCase):
                     assert_(res["nfev"] >= default_iters*2 or
                         res["nit"] >= default_iters*2)
 
+def test_bracket():
+    def fun(x, a):
+        return (x - a)**2 - 0.8
+
+    xa, xb, xc, fa, fb, fc, _ = optimize.bracket(fun, -1/2, +1/2, (0,))
+    print(fa, fb, fc)
+    assert_(not (fa > fb and fb < fc))
+    assert_(fa >= fb and fb <= fc)
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Bracket doc claimed that it returns f(xa) > f(xb) < f(xc),
whereas it can indeed return f(xa) == f(xb) or f(xb) == f(xc).
I've added a test that shows it.
