### PR TITLE
MAINT: ndimage: update callback function c api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,7 @@ scipy/linalg/fblas.pyf
 scipy/linalg/flapack.pyf
 scipy/linalg/src/id_dist/src/*_subr_*.f
 scipy/ndimage/src/_ni_label.c
+scipy/ndimage/src/_cytest.c
 scipy/optimize/cobyla/_cobylamodule.c
 scipy/optimize/lbfgsb/_lbfgsbmodule.c
 scipy/optimize/minpack2/minpack2module.c

--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -22,6 +22,11 @@ This release requires Python 2.7 or 3.4-3.5 and NumPy 1.7.1 or greater.
 New features
 ============
 
+`scipy.ndimage` improvements
+----------------------------
+
+The callback function C API supports PyCapsules in Python 2.7
+
 `scipy.signal` improvements
 ---------------------------
 
@@ -37,11 +42,6 @@ Deprecated features
 Backwards incompatible changes
 ==============================
 
-`scipy.ndimage`
----------------
-
-The callback function c api now uses PyCapsules for both Python 2 and
-Python 3.
 
 
 Other changes

--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -37,6 +37,11 @@ Deprecated features
 Backwards incompatible changes
 ==============================
 
+`scipy.ndimage`
+---------------
+
+The callback function c api now uses PyCapsules for both Python 2 and
+Python 3.
 
 
 Other changes

--- a/doc/source/tutorial/ndimage.rst
+++ b/doc/source/tutorial/ndimage.rst
@@ -43,7 +43,7 @@ argument is given, it is still possible to specify what the result
 of the output should be. This is done by simply assigning the
 desired `numpy` type object to the output argument. For example:
 
-::
+.. code:: python
 
     >>> from scipy.ndimage import correlate
     >>> correlate(np.arange(10), [1, 2.5])
@@ -56,8 +56,6 @@ desired `numpy` type object to the output argument. For example:
 Filter functions
 ----------------
 
-.. currentmodule:: scipy.ndimage.filters
-
 The functions described in this section all perform some type of spatial
 filtering of the input array: the elements in the output are some function
 of the values in the neighborhood of the corresponding input element. We refer
@@ -67,7 +65,7 @@ of the functions described below allow you to define the footprint
 of the kernel, by passing a mask through the *footprint* parameter.
 For example a cross shaped kernel can be defined as follows:
 
-::
+.. code:: python
 
     >>> footprint = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])
     >>> footprint
@@ -82,7 +80,7 @@ second element. Take for example the correlation of a
 one-dimensional array with a filter of length 3 consisting of
 ones:
 
-::
+.. code:: python
 
     >>> from scipy.ndimage import correlate1d
     >>> a = [0, 0, 0, 1, 0, 0, 0]
@@ -94,7 +92,7 @@ kernel. For this reason most functions support the *origin*
 parameter which gives the origin of the filter relative to its
 center. For example:
 
-::
+.. code:: python
 
     >>> a = [0, 0, 0, 1, 0, 0, 0]
     >>> correlate1d(a, [1, 1, 1], origin = -1)
@@ -105,7 +103,7 @@ will not be needed very often, but it may be useful especially for
 filters that have an even size. A good example is the calculation
 of backward and forward differences:
 
-::
+.. code:: python
 
     >>> a = [0, 0, 1, 1, 1, 0, 0]
     >>> correlate1d(a, [-1, 1])               # backward difference
@@ -115,7 +113,7 @@ of backward and forward differences:
 
 We could also have calculated the forward difference as follows:
 
-::
+.. code:: python
 
     >>> correlate1d(a, [0, -1, 1])
     array([ 0,  1,  0,  0, -1,  0,  0])
@@ -126,14 +124,14 @@ number, in which case the origin is assumed to be equal along all
 axes, or a sequence giving the origin along each axis.
 
 Since the output elements are a function of elements in the
-neighborhood of the input elements, the borders of the array need
-to be dealt with appropriately by providing the values outside the
-borders. This is done by assuming that the arrays are extended
-beyond their boundaries according certain boundary conditions. In
-the functions described below, the boundary conditions can be
-selected using the *mode* parameter which must be a string with the
-name of the boundary condition. Following boundary conditions are
-currently supported:
+neighborhood of the input elements, the borders of the array need to
+be dealt with appropriately by providing the values outside the
+borders. This is done by assuming that the arrays are extended beyond
+their boundaries according certain boundary conditions. In the
+functions described below, the boundary conditions can be selected
+using the *mode* parameter which must be a string with the name of the
+boundary condition. The following boundary conditions are currently
+supported:
 
  ==========   ====================================   ====================
  "nearest"    Use the value at the boundary          [1 2 3]->[1 1 2 3 3]
@@ -145,135 +143,153 @@ currently supported:
 The "constant" mode is special since it needs an additional
 parameter to specify the constant value that should be used.
 
-.. note:: The easiest way to implement such boundary conditions would be to copy the data to a larger array and extend the data at the borders according to the boundary conditions. For large arrays and large filter kernels, this would be very memory consuming, and the functions described below therefore use a different approach that does not require allocating large temporary buffers.
+.. note::
+
+   The easiest way to implement such boundary conditions would be to
+   copy the data to a larger array and extend the data at the borders
+   according to the boundary conditions. For large arrays and large
+   filter kernels, this would be very memory consuming, and the
+   functions described below therefore use a different approach that
+   does not require allocating large temporary buffers.
 
 Correlation and convolution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    The :func:`correlate1d` function calculates a one-dimensional correlation
-    along the given axis. The lines of the array along the given axis
-    are correlated with the given *weights*. The *weights* parameter
-    must be a one-dimensional sequences of numbers.
+- The :func:`correlate1d` function calculates a one-dimensional
+  correlation along the given axis. The lines of the array along the
+  given axis are correlated with the given *weights*. The *weights*
+  parameter must be a one-dimensional sequences of numbers.
 
+- The function :func:`correlate` implements multidimensional
+  correlation of the input array with a given kernel.
 
-    The function :func:`correlate` implements multidimensional correlation
-    of the input array with a given kernel.
+- The :func:`convolve1d` function calculates a one-dimensional
+  convolution along the given axis. The lines of the array along the
+  given axis are convoluted with the given *weights*. The *weights*
+  parameter must be a one-dimensional sequences of numbers.
 
+  .. note::
 
-    The :func:`convolve1d` function calculates a one-dimensional convolution
-    along the given axis. The lines of the array along the given axis
-    are convoluted with the given *weights*. The *weights* parameter
-    must be a one-dimensional sequences of numbers.
+     A convolution is essentially a correlation after mirroring the
+     kernel. As a result, the *origin* parameter behaves differently
+     than in the case of a correlation: the result is shifted in the
+     opposite directions.
 
-    .. note:: A convolution is essentially a correlation after mirroring the kernel. As a result, the *origin* parameter behaves differently than in the case of a correlation: the result is shifted in the opposite directions.
+- The function :func:`convolve` implements multidimensional
+  convolution of the input array with a given kernel.
 
-    The function :func:`convolve` implements multidimensional convolution of
-    the input array with a given kernel.
+  .. note::
 
-    .. note:: A convolution is essentially a correlation after mirroring the kernel. As a result, the *origin* parameter behaves differently than in the case of a correlation: the results is shifted in the opposite direction.
+     A convolution is essentially a correlation after mirroring the
+     kernel. As a result, the *origin* parameter behaves differently
+     than in the case of a correlation: the results is shifted in the
+     opposite direction.
 
 .. _ndimage-filter-functions-smoothing:
 
 Smoothing filters
 ^^^^^^^^^^^^^^^^^
 
+- The :func:`gaussian_filter1d` function implements a one-dimensional
+  Gaussian filter. The standard-deviation of the Gaussian filter is
+  passed through the parameter *sigma*. Setting *order* = 0
+  corresponds to convolution with a Gaussian kernel. An order of 1, 2,
+  or 3 corresponds to convolution with the first, second or third
+  derivatives of a Gaussian. Higher order derivatives are not
+  implemented.
 
-    The :func:`gaussian_filter1d` function implements a one-dimensional
-    Gaussian filter. The standard-deviation of the Gaussian filter is
-    passed through the parameter *sigma*. Setting *order* = 0 corresponds
-    to convolution with a Gaussian kernel. An order of 1, 2, or 3
-    corresponds to convolution with the first, second or third
-    derivatives of a Gaussian. Higher order derivatives are not
-    implemented.
+- The :func:`gaussian_filter` function implements a multidimensional
+  Gaussian filter. The standard-deviations of the Gaussian filter
+  along each axis are passed through the parameter *sigma* as a
+  sequence or numbers. If *sigma* is not a sequence but a single
+  number, the standard deviation of the filter is equal along all
+  directions. The order of the filter can be specified separately for
+  each axis. An order of 0 corresponds to convolution with a Gaussian
+  kernel. An order of 1, 2, or 3 corresponds to convolution with the
+  first, second or third derivatives of a Gaussian. Higher order
+  derivatives are not implemented. The *order* parameter must be a
+  number, to specify the same order for all axes, or a sequence of
+  numbers to specify a different order for each axis.
 
+  .. note::
 
-    The :func:`gaussian_filter` function implements a multidimensional
-    Gaussian filter. The standard-deviations of the Gaussian filter
-    along each axis are passed through the parameter *sigma* as a
-    sequence or numbers. If *sigma* is not a sequence but a single
-    number, the standard deviation of the filter is equal along all
-    directions. The order of the filter can be specified separately for
-    each axis. An order of 0 corresponds to convolution with a Gaussian
-    kernel. An order of 1, 2, or 3 corresponds to convolution with the
-    first, second or third derivatives of a Gaussian. Higher order
-    derivatives are not implemented. The *order* parameter must be a
-    number, to specify the same order for all axes, or a sequence of
-    numbers to specify a different order for each axis.
+     The multidimensional filter is implemented as a sequence of
+     one-dimensional Gaussian filters. The intermediate arrays are
+     stored in the same data type as the output.  Therefore, for
+     output types with a lower precision, the results may be imprecise
+     because intermediate results may be stored with insufficient
+     precision. This can be prevented by specifying a more precise
+     output type.
 
-    .. note:: The multidimensional filter is implemented as a sequence of one-dimensional Gaussian filters. The intermediate arrays are stored in  the same data type as the output.  Therefore, for output types with a lower precision, the results may be imprecise because intermediate results may be stored with insufficient precision. This can be prevented by specifying a more precise output type.
+- The :func:`uniform_filter1d` function calculates a one-dimensional
+  uniform filter of the given *size* along the given axis.
 
+- The :func:`uniform_filter` implements a multidimensional uniform
+  filter. The sizes of the uniform filter are given for each axis as a
+  sequence of integers by the *size* parameter. If *size* is not a
+  sequence, but a single number, the sizes along all axis are assumed
+  to be equal.
 
-    The :func:`uniform_filter1d` function calculates a one-dimensional
-    uniform filter of the given *size* along the given axis.
+  .. note::
 
-
-    The :func:`uniform_filter` implements a multidimensional uniform
-    filter. The sizes of the uniform filter are given for each axis as
-    a sequence of integers by the *size* parameter. If *size* is not a
-    sequence, but a single number, the sizes along all axis are assumed
-    to be equal.
-
-    .. note:: The multidimensional filter is implemented as a sequence of one-dimensional uniform filters. The intermediate arrays are stored in the same data type as the output. Therefore, for output types with a lower precision, the results may be imprecise because intermediate results may be stored with insufficient precision. This can be prevented by specifying a more precise output type.
-
+     The multidimensional filter is implemented as a sequence of
+     one-dimensional uniform filters. The intermediate arrays are
+     stored in the same data type as the output. Therefore, for output
+     types with a lower precision, the results may be imprecise
+     because intermediate results may be stored with insufficient
+     precision. This can be prevented by specifying a more precise
+     output type.
 
 Filters based on order statistics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    The :func:`minimum_filter1d` function calculates a one-dimensional
-    minimum filter of given *size* along the given axis.
+- The :func:`minimum_filter1d` function calculates a one-dimensional
+  minimum filter of given *size* along the given axis.
 
+- The :func:`maximum_filter1d` function calculates a one-dimensional
+  maximum filter of given *size* along the given axis.
 
-    The :func:`maximum_filter1d` function calculates a one-dimensional
-    maximum filter of given *size* along the given axis.
+- The :func:`minimum_filter` function calculates a multidimensional
+  minimum filter. Either the sizes of a rectangular kernel or the
+  footprint of the kernel must be provided. The *size* parameter, if
+  provided, must be a sequence of sizes or a single number in which
+  case the size of the filter is assumed to be equal along each axis.
+  The *footprint*, if provided, must be an array that defines the
+  shape of the kernel by its non-zero elements.
 
+- The :func:`maximum_filter` function calculates a multidimensional
+  maximum filter. Either the sizes of a rectangular kernel or the
+  footprint of the kernel must be provided. The *size* parameter, if
+  provided, must be a sequence of sizes or a single number in which
+  case the size of the filter is assumed to be equal along each axis.
+  The *footprint*, if provided, must be an array that defines the
+  shape of the kernel by its non-zero elements.
 
-    The :func:`minimum_filter` function calculates a multidimensional
-    minimum filter. Either the sizes of a rectangular kernel or the
-    footprint of the kernel must be provided. The *size* parameter, if
-    provided, must be a sequence of sizes or a single number in which
-    case the size of the filter is assumed to be equal along each axis.
-    The *footprint*, if provided, must be an array that defines the
-    shape of the kernel by its non-zero elements.
+- The :func:`rank_filter` function calculates a multidimensional rank
+  filter. The *rank* may be less then zero, i.e., *rank* = -1
+  indicates the largest element. Either the sizes of a rectangular
+  kernel or the footprint of the kernel must be provided. The *size*
+  parameter, if provided, must be a sequence of sizes or a single
+  number in which case the size of the filter is assumed to be equal
+  along each axis. The *footprint*, if provided, must be an array that
+  defines the shape of the kernel by its non-zero elements.
 
+- The :func:`percentile_filter` function calculates a multidimensional
+  percentile filter. The *percentile* may be less then zero, i.e.,
+  *percentile* = -20 equals *percentile* = 80. Either the sizes of a
+  rectangular kernel or the footprint of the kernel must be provided.
+  The *size* parameter, if provided, must be a sequence of sizes or a
+  single number in which case the size of the filter is assumed to be
+  equal along each axis. The *footprint*, if provided, must be an
+  array that defines the shape of the kernel by its non-zero elements.
 
-    The :func:`maximum_filter` function calculates a multidimensional
-    maximum filter. Either the sizes of a rectangular kernel or the
-    footprint of the kernel must be provided. The *size* parameter, if
-    provided, must be a sequence of sizes or a single number in which
-    case the size of the filter is assumed to be equal along each axis.
-    The *footprint*, if provided, must be an array that defines the
-    shape of the kernel by its non-zero elements.
-
-
-    The :func:`rank_filter` function calculates a multidimensional rank
-    filter. The *rank* may be less then zero, i.e., *rank* = -1 indicates
-    the largest element. Either the sizes of a rectangular kernel or
-    the footprint of the kernel must be provided. The *size* parameter,
-    if provided, must be a sequence of sizes or a single number in
-    which case the size of the filter is assumed to be equal along each
-    axis. The *footprint*, if provided, must be an array that defines
-    the shape of the kernel by its non-zero elements.
-
-
-    The :func:`percentile_filter` function calculates a multidimensional
-    percentile filter. The *percentile* may be less then zero, i.e.,
-    *percentile* = -20 equals *percentile* = 80. Either the sizes of a
-    rectangular kernel or the footprint of the kernel must be provided.
-    The *size* parameter, if provided, must be a sequence of sizes or a
-    single number in which case the size of the filter is assumed to be
-    equal along each axis. The *footprint*, if provided, must be an
-    array that defines the shape of the kernel by its non-zero
-    elements.
-
-
-    The :func:`median_filter` function calculates a multidimensional median
-    filter. Either the sizes of a rectangular kernel or the footprint
-    of the kernel must be provided. The *size* parameter, if provided,
-    must be a sequence of sizes or a single number in which case the
-    size of the filter is assumed to be equal along each axis. The
-    *footprint* if provided, must be an array that defines the shape of
-    the kernel by its non-zero elements.
-
+- The :func:`median_filter` function calculates a multidimensional
+  median filter. Either the sizes of a rectangular kernel or the
+  footprint of the kernel must be provided. The *size* parameter, if
+  provided, must be a sequence of sizes or a single number in which
+  case the size of the filter is assumed to be equal along each
+  axis. The *footprint* if provided, must be an array that defines the
+  shape of the kernel by its non-zero elements.
 
 Derivatives
 ^^^^^^^^^^^
@@ -284,371 +300,389 @@ Derivative filters can be constructed in several ways. The function
 derivatives along a given axis using the *order* parameter. Other
 derivative filters are the Prewitt and Sobel filters:
 
-    The :func:`prewitt` function calculates a derivative along the given
-    axis.
+- The :func:`prewitt` function calculates a derivative along the given
+  axis.
+- The :func:`sobel` function calculates a derivative along the given
+  axis.
 
+The Laplace filter is calculated by the sum of the second derivatives
+along all axes. Thus, different Laplace filters can be constructed
+using different second derivative functions. Therefore we provide a
+general function that takes a function argument to calculate the
+second derivative along a given direction.
 
-    The :func:`sobel` function calculates a derivative along the given
-    axis.
+- The function :func:`generic_laplace` calculates a laplace filter
+  using the function passed through :func:`derivative2` to calculate
+  second derivatives. The function :func:`derivative2` should have the
+  following signature
 
+  .. code:: python
+      
+     derivative2(input, axis, output, mode, cval, *extra_arguments, **extra_keywords)
 
-The Laplace filter is calculated by the sum of the second
-derivatives along all axes. Thus, different Laplace filters can be
-constructed using different second derivative functions. Therefore
-we provide a general function that takes a function argument to
-calculate the second derivative along a given direction and to
-construct the Laplace filter:
+  It should calculate the second derivative along the dimension
+  *axis*. If *output* is not ``None`` it should use that for the
+  output and return None, otherwise it should return the
+  result. *mode*, *cval* have the usual meaning.
 
-    The function :func:`generic_laplace` calculates a laplace filter using
-    the function passed through :func:`derivative2` to calculate second
-    derivatives. The function :func:`derivative2` should have the following
-    signature::
+  The *extra_arguments* and *extra_keywords* arguments can be used
+  to pass a tuple of extra arguments and a dictionary of named
+  arguments that are passed to :func:`derivative2` at each call.
 
-         derivative2(input, axis, output, mode, cval, *extra_arguments, **extra_keywords)
+  For example
 
-    It should calculate the second derivative along the dimension
-    *axis*. If *output* is not None it should use that for the output
-    and return None, otherwise it should return the result. *mode*,
-    *cval* have the usual meaning.
+  .. code:: python
 
-    The *extra_arguments* and *extra_keywords* arguments can be used
-    to pass a tuple of extra arguments and a dictionary of named
-    arguments that are passed to :func:`derivative2` at each call.
+     >>> def d2(input, axis, output, mode, cval):
+     ...     return correlate1d(input, [1, -2, 1], axis, output, mode, cval, 0)
+     ...
+     >>> a = np.zeros((5, 5))
+     >>> a[2, 2] = 1
+     >>> from scipy.ndimage import generic_laplace
+     >>> generic_laplace(a, d2)
+     array([[ 0.,  0.,  0.,  0.,  0.],
+	    [ 0.,  0.,  1.,  0.,  0.],
+	    [ 0.,  1., -4.,  1.,  0.],
+            [ 0.,  0.,  1.,  0.,  0.],
+            [ 0.,  0.,  0.,  0.,  0.]])
 
-    For example::
+  To demonstrate the use of the *extra_arguments* argument we could do
 
-        >>> def d2(input, axis, output, mode, cval):
-        ...     return correlate1d(input, [1, -2, 1], axis, output, mode, cval, 0)
-        ...
-        >>> a = np.zeros((5, 5))
-        >>> a[2, 2] = 1
-        >>> from scipy.ndimage import generic_laplace
-        >>> generic_laplace(a, d2)
-        array([[ 0.,  0.,  0.,  0.,  0.],
-               [ 0.,  0.,  1.,  0.,  0.],
-               [ 0.,  1., -4.,  1.,  0.],
-               [ 0.,  0.,  1.,  0.,  0.],
-               [ 0.,  0.,  0.,  0.,  0.]])
+  .. code:: python
 
-    To demonstrate the use of the *extra_arguments* argument we could
-    do::
+     >>> def d2(input, axis, output, mode, cval, weights):
+     ...     return correlate1d(input, weights, axis, output, mode, cval, 0,)
+     ...
+     >>> a = np.zeros((5, 5))
+     >>> a[2, 2] = 1
+     >>> generic_laplace(a, d2, extra_arguments = ([1, -2, 1],))
+     array([[ 0.,  0.,  0.,  0.,  0.],
+	    [ 0.,  0.,  1.,  0.,  0.],
+            [ 0.,  1., -4.,  1.,  0.],
+            [ 0.,  0.,  1.,  0.,  0.],
+            [ 0.,  0.,  0.,  0.,  0.]])
 
-        >>> def d2(input, axis, output, mode, cval, weights):
-        ...     return correlate1d(input, weights, axis, output, mode, cval, 0,)
-        ...
-        >>> a = np.zeros((5, 5))
-        >>> a[2, 2] = 1
-        >>> generic_laplace(a, d2, extra_arguments = ([1, -2, 1],))
-        array([[ 0.,  0.,  0.,  0.,  0.],
-               [ 0.,  0.,  1.,  0.,  0.],
-               [ 0.,  1., -4.,  1.,  0.],
-               [ 0.,  0.,  1.,  0.,  0.],
-               [ 0.,  0.,  0.,  0.,  0.]])
+  or
 
-    or::
+  .. code:: python
 
-        >>> generic_laplace(a, d2, extra_keywords = {'weights': [1, -2, 1]})
-        array([[ 0.,  0.,  0.,  0.,  0.],
-               [ 0.,  0.,  1.,  0.,  0.],
-               [ 0.,  1., -4.,  1.,  0.],
-               [ 0.,  0.,  1.,  0.,  0.],
-               [ 0.,  0.,  0.,  0.,  0.]])
-
+     >>> generic_laplace(a, d2, extra_keywords = {'weights': [1, -2, 1]})
+     array([[ 0.,  0.,  0.,  0.,  0.],
+	    [ 0.,  0.,  1.,  0.,  0.],
+	    [ 0.,  1., -4.,  1.,  0.],
+	    [ 0.,  0.,  1.,  0.,  0.],
+	    [ 0.,  0.,  0.,  0.,  0.]])
 
 The following two functions are implemented using
 :func:`generic_laplace` by providing appropriate functions for the
 second derivative function:
 
-    The function :func:`laplace` calculates the Laplace using discrete
-    differentiation for the second derivative (i.e. convolution with
-    :obj:`[1, -2, 1]`).
+- The function :func:`laplace` calculates the Laplace using discrete
+  differentiation for the second derivative (i.e. convolution with
+  ``[1, -2, 1]``).
+  
+- The function :func:`gaussian_laplace` calculates the Laplace filter
+  using :func:`gaussian_filter` to calculate the second
+  derivatives. The standard-deviations of the Gaussian filter along
+  each axis are passed through the parameter *sigma* as a sequence or
+  numbers. If *sigma* is not a sequence but a single number, the
+  standard deviation of the filter is equal along all directions.
 
+The gradient magnitude is defined as the square root of the sum of the
+squares of the gradients in all directions. Similar to the generic
+Laplace function there is a :func:`generic_gradient_magnitude`
+function that calculats the gradient magnitude of an array.
 
-    The function :func:`gaussian_laplace` calculates the Laplace using
-    :func:`gaussian_filter` to calculate the second derivatives. The
-    standard-deviations of the Gaussian filter along each axis are
-    passed through the parameter *sigma* as a sequence or numbers. If
-    *sigma* is not a sequence but a single number, the standard
-    deviation of the filter is equal along all directions.
+- The function :func:`generic_gradient_magnitude` calculates a
+  gradient magnitude using the function passed through
+  :func:`derivative` to calculate first derivatives. The function
+  :func:`derivative` should have the following signature
 
+  .. code:: python
+	    
+     derivative(input, axis, output, mode, cval, *extra_arguments, **extra_keywords)
 
-The gradient magnitude is defined as the square root of the sum of
-the squares of the gradients in all directions. Similar to the
-generic Laplace function there is a :func:`generic_gradient_magnitude`
-function that calculated the gradient magnitude of an array:
+  It should calculate the derivative along the dimension *axis*. If
+  *output* is not None it should use that for the output and return
+  None, otherwise it should return the result. *mode*, *cval* have the
+  usual meaning.
 
-    The function :func:`generic_gradient_magnitude` calculates a gradient
-    magnitude using the function passed through :func:`derivative` to
-    calculate first derivatives. The function :func:`derivative` should have
-    the following signature::
+  The *extra_arguments* and *extra_keywords* arguments can be used to
+  pass a tuple of extra arguments and a dictionary of named arguments
+  that are passed to *derivative* at each call.
 
-        derivative(input, axis, output, mode, cval, *extra_arguments, **extra_keywords)
+  For example, the :func:`sobel` function fits the required signature
 
+  .. code:: python
 
-    It should calculate the derivative along the dimension *axis*. If
-    *output* is not None it should use that for the output and return
-    None, otherwise it should return the result. *mode*, *cval* have
-    the usual meaning.
+     >>> a = np.zeros((5, 5))
+     >>> a[2, 2] = 1
+     >>> from scipy.ndimage import sobel, generic_gradient_magnitude
+     >>> generic_gradient_magnitude(a, sobel)
+     array([[ 0.        ,  0.        ,  0.        ,  0.        ,  0.        ],
+	    [ 0.        ,  1.41421356,  2.        ,  1.41421356,  0.        ],
+            [ 0.        ,  2.        ,  0.        ,  2.        ,  0.        ],
+            [ 0.        ,  1.41421356,  2.        ,  1.41421356,  0.        ],
+            [ 0.        ,  0.        ,  0.        ,  0.        ,  0.        ]])
 
-    The *extra_arguments* and *extra_keywords* arguments can be used
-    to pass a tuple of extra arguments and a dictionary of named
-    arguments that are passed to *derivative* at each call.
+  See the documentation of :func:`generic_laplace` for examples of
+  using the *extra_arguments* and *extra_keywords* arguments.
 
-    For example, the :func:`sobel` function fits the required signature::
+The :func:`sobel` and :func:`prewitt` functions fit the required
+signature and can therefore directly be used with
+:func:`generic_gradient_magnitude`.
 
-        >>> a = np.zeros((5, 5))
-        >>> a[2, 2] = 1
-        >>> from scipy.ndimage import sobel, generic_gradient_magnitude
-        >>> generic_gradient_magnitude(a, sobel)
-        array([[ 0.        ,  0.        ,  0.        ,  0.        ,  0.        ],
-               [ 0.        ,  1.41421356,  2.        ,  1.41421356,  0.        ],
-               [ 0.        ,  2.        ,  0.        ,  2.        ,  0.        ],
-               [ 0.        ,  1.41421356,  2.        ,  1.41421356,  0.        ],
-               [ 0.        ,  0.        ,  0.        ,  0.        ,  0.        ]])
-
-    See the documentation of :func:`generic_laplace` for examples of using
-    the *extra_arguments* and *extra_keywords* arguments.
-
-
-The :func:`sobel` and :func:`prewitt` functions fit the required signature and
-can therefore directly be used with :func:`generic_gradient_magnitude`.
-The following function implements the gradient magnitude using
-Gaussian derivatives:
-
-    The function :func:`gaussian_gradient_magnitude` calculates the
-    gradient magnitude using :func:`gaussian_filter` to calculate the first
-    derivatives. The standard-deviations of the Gaussian filter along
-    each axis are passed through the parameter *sigma* as a sequence or
-    numbers. If *sigma* is not a sequence but a single number, the
-    standard deviation of the filter is equal along all directions.
-
+- The function :func:`gaussian_gradient_magnitude` calculates the
+  gradient magnitude using :func:`gaussian_filter` to calculate the
+  first derivatives. The standard-deviations of the Gaussian filter
+  along each axis are passed through the parameter *sigma* as a
+  sequence or numbers. If *sigma* is not a sequence but a single
+  number, the standard deviation of the filter is equal along all
+  directions.
 
 .. _ndimage-genericfilters:
 
 Generic filter functions
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-To implement filter functions, generic functions can be used that accept a
-callable object that implements the filtering operation. The iteration over the
-input and output arrays is handled by these generic functions, along with such
-details as the implementation of the boundary conditions. Only a
-callable object implementing a callback function that does the
-actual filtering work must be provided. The callback function can
-also be written in C and passed using a :ctype:`PyCObject` (see
-:ref:`ndimage-ccallbacks` for more information).
+To implement filter functions, generic functions can be used that
+accept a callable object that implements the filtering operation. The
+iteration over the input and output arrays is handled by these generic
+functions, along with such details as the implementation of the
+boundary conditions. Only a callable object implementing a callback
+function that does the actual filtering work must be provided. The
+callback function can also be written in C and passed using a
+:ctype:`PyCapsule` (see :ref:`ndimage-ccallbacks` for more
+information).
 
-    The :func:`generic_filter1d` function implements a generic
-    one-dimensional filter function, where the actual filtering
-    operation must be supplied as a python function (or other callable
-    object). The :func:`generic_filter1d` function iterates over the lines
-    of an array and calls :func:`function` at each line. The arguments that
-    are passed to :func:`function` are one-dimensional arrays of the
-    :ctype:`tFloat64` type. The first contains the values of the current line.
-    It is extended at the beginning end the end, according to the
-    *filter_size* and *origin* arguments. The second array should be
-    modified in-place to provide the output values of the line. For
-    example consider a correlation along one dimension::
+- The :func:`generic_filter1d` function implements a generic
+  one-dimensional filter function, where the actual filtering
+  operation must be supplied as a python function (or other callable
+  object). The :func:`generic_filter1d` function iterates over the
+  lines of an array and calls :func:`function` at each line. The
+  arguments that are passed to :func:`function` are one-dimensional
+  arrays of the :ctype:`tFloat64` type. The first contains the values
+  of the current line.  It is extended at the beginning end the end,
+  according to the *filter_size* and *origin* arguments. The second
+  array should be modified in-place to provide the output values of
+  the line. For example consider a correlation along one dimension:
 
-        >>> a = np.arange(12).reshape(3,4)
-        >>> correlate1d(a, [1, 2, 3])
-        array([[ 3,  8, 14, 17],
-               [27, 32, 38, 41],
-               [51, 56, 62, 65]])
+  .. code:: python
 
-    The same operation can be implemented using :func:`generic_filter1d` as
-    follows::
+     >>> a = np.arange(12).reshape(3,4)
+     >>> correlate1d(a, [1, 2, 3])
+     array([[ 3,  8, 14, 17],
+	    [27, 32, 38, 41],
+            [51, 56, 62, 65]])
 
-        >>> def fnc(iline, oline):
-        ...     oline[...] = iline[:-2] + 2 * iline[1:-1] + 3 * iline[2:]
-        ...
-        >>> from scipy.ndimage import generic_filter1d
-        >>> generic_filter1d(a, fnc, 3)
-        array([[ 3,  8, 14, 17],
-               [27, 32, 38, 41],
-               [51, 56, 62, 65]])
+  The same operation can be implemented using :func:`generic_filter1d`
+  as follows:
 
-    Here the origin of the kernel was (by default) assumed to be in the
-    middle of the filter of length 3. Therefore, each input line was
-    extended by one value at the beginning and at the end, before the
-    function was called.
+  .. code:: python
 
-    Optionally extra arguments can be defined and passed to the filter
-    function. The *extra_arguments* and *extra_keywords* arguments
-    can be used to pass a tuple of extra arguments and/or a dictionary
-    of named arguments that are passed to derivative at each call. For
-    example, we can pass the parameters of our filter as an argument::
+     >>> def fnc(iline, oline):
+     ...     oline[...] = iline[:-2] + 2 * iline[1:-1] + 3 * iline[2:]
+     ...
+     >>> from scipy.ndimage import generic_filter1d
+     >>> generic_filter1d(a, fnc, 3)
+     array([[ 3,  8, 14, 17],
+	    [27, 32, 38, 41],
+            [51, 56, 62, 65]])
 
-        >>> def fnc(iline, oline, a, b):
-        ...     oline[...] = iline[:-2] + a * iline[1:-1] + b * iline[2:]
-        ...
-        >>> generic_filter1d(a, fnc, 3, extra_arguments = (2, 3))
-        array([[ 3,  8, 14, 17],
-               [27, 32, 38, 41],
-               [51, 56, 62, 65]])
+  Here the origin of the kernel was (by default) assumed to be in the
+  middle of the filter of length 3. Therefore, each input line was
+  extended by one value at the beginning and at the end, before the
+  function was called.
 
-    or::
+  Optionally extra arguments can be defined and passed to the filter
+  function. The *extra_arguments* and *extra_keywords* arguments can
+  be used to pass a tuple of extra arguments and/or a dictionary of
+  named arguments that are passed to derivative at each call. For
+  example, we can pass the parameters of our filter as an argument
 
-        >>> generic_filter1d(a, fnc, 3, extra_keywords = {'a':2, 'b':3})
-        array([[ 3,  8, 14, 17],
-               [27, 32, 38, 41],
-               [51, 56, 62, 65]])
+  .. code:: python
 
-    The :func:`generic_filter` function implements a generic filter
-    function, where the actual filtering operation must be supplied as
-    a python function (or other callable object). The :func:`generic_filter`
-    function iterates over the array and calls :func:`function` at each
-    element. The argument of :func:`function` is a one-dimensional array of
-    the :ctype:`tFloat64` type, that contains the values around the current
-    element that are within the footprint of the filter. The function
-    should return a single value that can be converted to a double
-    precision number. For example consider a correlation::
+     >>> def fnc(iline, oline, a, b):
+     ...     oline[...] = iline[:-2] + a * iline[1:-1] + b * iline[2:]
+     ...
+     >>> generic_filter1d(a, fnc, 3, extra_arguments = (2, 3))
+     array([[ 3,  8, 14, 17],
+	    [27, 32, 38, 41],
+            [51, 56, 62, 65]])
 
-        >>> a = np.arange(12).reshape(3,4)
-        >>> correlate(a, [[1, 0], [0, 3]])
-        array([[ 0,  3,  7, 11],
-               [12, 15, 19, 23],
-               [28, 31, 35, 39]])
+  or
 
-    The same operation can be implemented using *generic_filter* as
-    follows::
+  .. code:: python
 
-        >>> def fnc(buffer):
-        ...     return (buffer * np.array([1, 3])).sum()
-        ...
-        >>> from scipy.ndimage import generic_filter
-        >>> generic_filter(a, fnc, footprint = [[1, 0], [0, 1]])
-        array([[ 0,  3,  7, 11],
-               [12, 15, 19, 23],
-               [28, 31, 35, 39]])
+     >>> generic_filter1d(a, fnc, 3, extra_keywords = {'a':2, 'b':3})
+     array([[ 3,  8, 14, 17],
+	    [27, 32, 38, 41],
+            [51, 56, 62, 65]])
 
-    Here a kernel footprint was specified that contains only two
-    elements. Therefore the filter function receives a buffer of length
-    equal to two, which was multiplied with the proper weights and the
-    result summed.
+- The :func:`generic_filter` function implements a generic filter
+  function, where the actual filtering operation must be supplied as a
+  python function (or other callable object). The
+  :func:`generic_filter` function iterates over the array and calls
+  :func:`function` at each element. The argument of :func:`function`
+  is a one-dimensional array of the :ctype:`tFloat64` type, that
+  contains the values around the current element that are within the
+  footprint of the filter. The function should return a single value
+  that can be converted to a double precision number. For example
+  consider a correlation:
 
-    When calling :func:`generic_filter`, either the sizes of a rectangular
-    kernel or the footprint of the kernel must be provided. The *size*
-    parameter, if provided, must be a sequence of sizes or a single
-    number in which case the size of the filter is assumed to be equal
-    along each axis. The *footprint*, if provided, must be an array
-    that defines the shape of the kernel by its non-zero elements.
+  .. code:: python
 
-    Optionally extra arguments can be defined and passed to the filter
-    function. The *extra_arguments* and *extra_keywords* arguments
-    can be used to pass a tuple of extra arguments and/or a dictionary
-    of named arguments that are passed to derivative at each call. For
-    example, we can pass the parameters of our filter as an argument::
+     >>> a = np.arange(12).reshape(3,4)
+     >>> correlate(a, [[1, 0], [0, 3]])
+     array([[ 0,  3,  7, 11],
+	    [12, 15, 19, 23],
+            [28, 31, 35, 39]])
 
-        >>> def fnc(buffer, weights):
-        ...     weights = np.asarray(weights)
-        ...     return (buffer * weights).sum()
-        ...
-        >>> generic_filter(a, fnc, footprint = [[1, 0], [0, 1]], extra_arguments = ([1, 3],))
-        array([[ 0,  3,  7, 11],
-               [12, 15, 19, 23],
-               [28, 31, 35, 39]])
+  The same operation can be implemented using *generic_filter* as
+  follows:
 
-    or::
+  .. code:: python
 
-        >>> generic_filter(a, fnc, footprint = [[1, 0], [0, 1]], extra_keywords= {'weights': [1, 3]})
-        array([[ 0,  3,  7, 11],
-               [12, 15, 19, 23],
-               [28, 31, 35, 39]])
+     >>> def fnc(buffer):
+     ...     return (buffer * np.array([1, 3])).sum()
+     ...
+     >>> from scipy.ndimage import generic_filter
+     >>> generic_filter(a, fnc, footprint = [[1, 0], [0, 1]])
+     array([[ 0,  3,  7, 11],
+	    [12, 15, 19, 23],
+            [28, 31, 35, 39]])
 
+  Here a kernel footprint was specified that contains only two
+  elements. Therefore the filter function receives a buffer of length
+  equal to two, which was multiplied with the proper weights and the
+  result summed.
+
+  When calling :func:`generic_filter`, either the sizes of a
+  rectangular kernel or the footprint of the kernel must be
+  provided. The *size* parameter, if provided, must be a sequence of
+  sizes or a single number in which case the size of the filter is
+  assumed to be equal along each axis. The *footprint*, if provided,
+  must be an array that defines the shape of the kernel by its
+  non-zero elements.
+
+  Optionally extra arguments can be defined and passed to the filter
+  function. The *extra_arguments* and *extra_keywords* arguments can
+  be used to pass a tuple of extra arguments and/or a dictionary of
+  named arguments that are passed to derivative at each call. For
+  example, we can pass the parameters of our filter as an argument
+
+  .. code:: python
+
+     >>> def fnc(buffer, weights):
+     ...     weights = np.asarray(weights)
+     ...     return (buffer * weights).sum()
+     ...
+     >>> generic_filter(a, fnc, footprint = [[1, 0], [0, 1]], extra_arguments = ([1, 3],))
+     array([[ 0,  3,  7, 11],
+	    [12, 15, 19, 23],
+            [28, 31, 35, 39]])
+
+  or
+
+  .. code:: python
+
+     >>> generic_filter(a, fnc, footprint = [[1, 0], [0, 1]], extra_keywords= {'weights': [1, 3]})
+     array([[ 0,  3,  7, 11],
+	    [12, 15, 19, 23],
+	    [28, 31, 35, 39]])
 
 These functions iterate over the lines or elements starting at the
 last axis, i.e. the last index changes the fastest. This order of
-iteration is guaranteed for the case that it is important to adapt
-the filter depending on spatial location. Here is an example of
-using a class that implements the filter and keeps track of the
-current coordinates while iterating. It performs the same filter
-operation as described above for :func:`generic_filter`, but
-additionally prints the current coordinates:
+iteration is guaranteed for the case that it is important to adapt the
+filter depending on spatial location. Here is an example of using a
+class that implements the filter and keeps track of the current
+coordinates while iterating. It performs the same filter operation as
+described above for :func:`generic_filter`, but additionally prints
+the current coordinates:
 
-::
+.. code:: python
 
-    >>> a = np.arange(12).reshape(3,4)
-    >>>
-    >>> class fnc_class:
-    ...     def __init__(self, shape):
-    ...         # store the shape:
-    ...         self.shape = shape
-    ...         # initialize the coordinates:
-    ...         self.coordinates = [0] * len(shape)
-    ...
-    ...     def filter(self, buffer):
-    ...         result = (buffer * np.array([1, 3])).sum()
-    ...         print self.coordinates
-    ...         # calculate the next coordinates:
-    ...         axes = range(len(self.shape))
-    ...         axes.reverse()
-    ...         for jj in axes:
-    ...             if self.coordinates[jj] < self.shape[jj] - 1:
-    ...                 self.coordinates[jj] += 1
-    ...                 break
-    ...             else:
-    ...                 self.coordinates[jj] = 0
-    ...         return result
-    ...
-    >>> fnc = fnc_class(shape = (3,4))
-    >>> generic_filter(a, fnc.filter, footprint = [[1, 0], [0, 1]])
-    [0, 0]
-    [0, 1]
-    [0, 2]
-    [0, 3]
-    [1, 0]
-    [1, 1]
-    [1, 2]
-    [1, 3]
-    [2, 0]
-    [2, 1]
-    [2, 2]
-    [2, 3]
-    array([[ 0,  3,  7, 11],
-           [12, 15, 19, 23],
-           [28, 31, 35, 39]])
+   >>> a = np.arange(12).reshape(3,4)
+   >>>
+   >>> class fnc_class:
+   ...     def __init__(self, shape):
+   ...         # store the shape:
+   ...         self.shape = shape
+   ...         # initialize the coordinates:
+   ...         self.coordinates = [0] * len(shape)
+   ...
+   ...     def filter(self, buffer):
+   ...         result = (buffer * np.array([1, 3])).sum()
+   ...         print self.coordinates
+   ...         # calculate the next coordinates:
+   ...         axes = range(len(self.shape))
+   ...         axes.reverse()
+   ...         for jj in axes:
+   ...             if self.coordinates[jj] < self.shape[jj] - 1:
+   ...                 self.coordinates[jj] += 1
+   ...                 break
+   ...             else:
+   ...                 self.coordinates[jj] = 0
+   ...         return result
+   ...
+   >>> fnc = fnc_class(shape = (3,4))
+   >>> generic_filter(a, fnc.filter, footprint = [[1, 0], [0, 1]])
+   [0, 0]
+   [0, 1]
+   [0, 2]
+   [0, 3]
+   [1, 0]
+   [1, 1]
+   [1, 2]
+   [1, 3]
+   [2, 0]
+   [2, 1]
+   [2, 2]
+   [2, 3]
+   array([[ 0,  3,  7, 11],
+	  [12, 15, 19, 23],
+	  [28, 31, 35, 39]])
 
 For the :func:`generic_filter1d` function the same approach works,
-except that this function does not iterate over the axis that is
-being filtered. The example for :func:`generic_filter1d` then becomes
-this:
+except that this function does not iterate over the axis that is being
+filtered. The example for :func:`generic_filter1d` then becomes this:
 
-::
+.. code:: python
 
-    >>> a = np.arange(12).reshape(3,4)
-    >>>
-    >>> class fnc1d_class:
-    ...     def __init__(self, shape, axis = -1):
-    ...         # store the filter axis:
-    ...         self.axis = axis
-    ...         # store the shape:
-    ...         self.shape = shape
-    ...         # initialize the coordinates:
-    ...         self.coordinates = [0] * len(shape)
-    ...
-    ...     def filter(self, iline, oline):
-    ...         oline[...] = iline[:-2] + 2 * iline[1:-1] + 3 * iline[2:]
-    ...         print self.coordinates
-    ...         # calculate the next coordinates:
-    ...         axes = range(len(self.shape))
-    ...         # skip the filter axis:
-    ...         del axes[self.axis]
-    ...         axes.reverse()
-    ...         for jj in axes:
-    ...             if self.coordinates[jj] < self.shape[jj] - 1:
-    ...                 self.coordinates[jj] += 1
-    ...                 break
-    ...             else:
-    ...                 self.coordinates[jj] = 0
-    ...
-    >>> fnc = fnc1d_class(shape = (3,4))
-    >>> generic_filter1d(a, fnc.filter, 3)
-    [0, 0]
-    [1, 0]
-    [2, 0]
-    array([[ 3,  8, 14, 17],
-           [27, 32, 38, 41],
-           [51, 56, 62, 65]])
+   >>> a = np.arange(12).reshape(3,4)
+   >>>
+   >>> class fnc1d_class:
+   ...     def __init__(self, shape, axis = -1):
+   ...         # store the filter axis:
+   ...         self.axis = axis
+   ...         # store the shape:
+   ...         self.shape = shape
+   ...         # initialize the coordinates:
+   ...         self.coordinates = [0] * len(shape)
+   ...
+   ...     def filter(self, iline, oline):
+   ...         oline[...] = iline[:-2] + 2 * iline[1:-1] + 3 * iline[2:]
+   ...         print self.coordinates
+   ...         # calculate the next coordinates:
+   ...         axes = range(len(self.shape))
+   ...         # skip the filter axis:
+   ...         del axes[self.axis]
+   ...         axes.reverse()
+   ...         for jj in axes:
+   ...             if self.coordinates[jj] < self.shape[jj] - 1:
+   ...                 self.coordinates[jj] += 1
+   ...                 break
+   ...             else:
+   ...                 self.coordinates[jj] = 0
+   ...
+   >>> fnc = fnc1d_class(shape = (3,4))
+   >>> generic_filter1d(a, fnc.filter, 3)
+   [0, 0]
+   [1, 0]
+   [2, 0]
+   array([[ 3,  8, 14, 17],
+	  [27, 32, 38, 41],
+          [51, 56, 62, 65]])
 
 Fourier domain filters
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -669,183 +703,190 @@ assumed that the input array was the result of a complex Fourier
 transform. The parameter *axis* can be used to indicate along which
 axis the real transform was executed.
 
-    The :func:`fourier_shift` function multiplies the input array with the
-    multidimensional Fourier transform of a shift operation for the
-    given shift. The *shift* parameter is a sequences of shifts for
-    each dimension, or a single value for all dimensions.
+- The :func:`fourier_shift` function multiplies the input array with
+  the multidimensional Fourier transform of a shift operation for the
+  given shift. The *shift* parameter is a sequences of shifts for each
+  dimension, or a single value for all dimensions.
 
+- The :func:`fourier_gaussian` function multiplies the input array
+  with the multidimensional Fourier transform of a Gaussian filter
+  with given standard-deviations *sigma*. The *sigma* parameter is a
+  sequences of values for each dimension, or a single value for all
+  dimensions.
 
-    The :func:`fourier_gaussian` function multiplies the input array with
-    the multidimensional Fourier transform of a Gaussian filter with
-    given standard-deviations *sigma*. The *sigma* parameter is a
-    sequences of values for each dimension, or a single value for all
-    dimensions.
+- The :func:`fourier_uniform` function multiplies the input array with
+  the multidimensional Fourier transform of a uniform filter with
+  given sizes *size*. The *size* parameter is a sequences of values
+  for each dimension, or a single value for all dimensions.
 
-
-    The :func:`fourier_uniform` function multiplies the input array with the
-    multidimensional Fourier transform of a uniform filter with given
-    sizes *size*. The *size* parameter is a sequences of values for
-    each dimension, or a single value for all dimensions.
-
-
-    The :func:`fourier_ellipsoid` function multiplies the input array with
-    the multidimensional Fourier transform of a elliptically shaped
-    filter with given sizes *size*. The *size* parameter is a sequences
-    of values for each dimension, or a single value for all dimensions.
-    This function is only implemented for dimensions 1, 2, and 3.
-
+- The :func:`fourier_ellipsoid` function multiplies the input array
+  with the multidimensional Fourier transform of a elliptically shaped
+  filter with given sizes *size*. The *size* parameter is a sequences
+  of values for each dimension, or a single value for all dimensions.
+  This function is only implemented for dimensions 1, 2, and 3.
 
 .. _ndimage-interpolation:
 
 Interpolation functions
 -----------------------
 
-.. currentmodule:: scipy.ndimage.interpolation
-
-
-This section describes various interpolation functions that are
-based on B-spline theory. A good introduction to B-splines can be
-found in: M. Unser, "Splines: A Perfect Fit for Signal and Image
-Processing," IEEE Signal Processing Magazine, vol. 16, no. 6, pp.
-22-38, November 1999.
+This section describes various interpolation functions that are based
+on B-spline theory. A good introduction to B-splines can be found
+in [1]_.
 
 Spline pre-filters
 ^^^^^^^^^^^^^^^^^^
 
-Interpolation using
-splines of an order larger than 1 requires a pre- filtering step.
-The interpolation functions described in section
+Interpolation using splines of an order larger than 1 requires a
+pre-filtering step. The interpolation functions described in section
 :ref:`ndimage-interpolation` apply pre-filtering by calling
 :func:`spline_filter`, but they can be instructed not to do this by
-setting the *prefilter* keyword equal to False. This is useful if
-more than one interpolation operation is done on the same array. In
-this case it is more efficient to do the pre-filtering only once
-and use a prefiltered array as the input of the interpolation
-functions. The following two functions implement the
-pre-filtering:
+setting the *prefilter* keyword equal to False. This is useful if more
+than one interpolation operation is done on the same array. In this
+case it is more efficient to do the pre-filtering only once and use a
+prefiltered array as the input of the interpolation functions. The
+following two functions implement the pre-filtering:
 
-    The :func:`spline_filter1d` function calculates a one-dimensional spline
-    filter along the given axis. An output array can optionally be
-    provided. The order of the spline must be larger then 1 and less
-    than 6.
+- The :func:`spline_filter1d` function calculates a one-dimensional
+  spline filter along the given axis. An output array can optionally
+  be provided. The order of the spline must be larger then 1 and less
+  than 6.
 
+- The :func:`spline_filter` function calculates a multidimensional
+  spline filter.
 
-    The :func:`spline_filter` function calculates a multidimensional spline
-    filter.
+  .. note::
 
-    .. note:: The multidimensional filter is implemented as a sequence of one-dimensional spline filters. The intermediate arrays are stored in the same data type as the output. Therefore, if an output with a limited precision is requested, the results may be imprecise because intermediate results may be stored with insufficient precision. This can be prevented by specifying a output type of high precision.
-
+     The multidimensional filter is implemented as a sequence of
+     one-dimensional spline filters. The intermediate arrays are
+     stored in the same data type as the output. Therefore, if an
+     output with a limited precision is requested, the results may be
+     imprecise because intermediate results may be stored with
+     insufficient precision. This can be prevented by specifying a
+     output type of high precision.
 
 Interpolation functions
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Following functions all employ spline interpolation to effect some type of
-geometric transformation of the input array. This requires a mapping of the
-output coordinates to the input coordinates, and therefore the possibility
-arises that input values outside the boundaries are needed. This problem is
-solved in the same way as described in :ref:`ndimage-filter-functions`
-for the multidimensional filter functions. Therefore these functions all
-support a *mode* parameter that determines how the boundaries are handled, and
-a *cval* parameter that gives a constant value in case that the 'constant'
-mode is used.
+Following functions all employ spline interpolation to effect some
+type of geometric transformation of the input array. This requires a
+mapping of the output coordinates to the input coordinates, and
+therefore the possibility arises that input values outside the
+boundaries are needed. This problem is solved in the same way as
+described in :ref:`ndimage-filter-functions` for the multidimensional
+filter functions. Therefore these functions all support a *mode*
+parameter that determines how the boundaries are handled, and a *cval*
+parameter that gives a constant value in case that the 'constant' mode
+is used.
 
-    The :func:`geometric_transform` function applies an arbitrary geometric
-    transform to the input. The given *mapping* function is called at
-    each point in the output to find the corresponding coordinates in
-    the input. *mapping* must be a callable object that accepts a tuple
-    of length equal to the output array rank and returns the
-    corresponding input coordinates as a tuple of length equal to the
-    input array rank. The output shape and output type can optionally
-    be provided. If not given they are equal to the input shape and
-    type.
+- The :func:`geometric_transform` function applies an arbitrary
+  geometric transform to the input. The given *mapping* function is
+  called at each point in the output to find the corresponding
+  coordinates in the input. *mapping* must be a callable object that
+  accepts a tuple of length equal to the output array rank and returns
+  the corresponding input coordinates as a tuple of length equal to
+  the input array rank. The output shape and output type can
+  optionally be provided. If not given they are equal to the input
+  shape and type.
 
-    For example::
+  For example:
+  
+  .. code:: python
 
-        >>> a = np.arange(12).reshape(4,3).astype(np.float64)
-        >>> def shift_func(output_coordinates):
-        ...     return (output_coordinates[0] - 0.5, output_coordinates[1] - 0.5)
-        ...
-        >>> from scipy.ndimage import geometric_transform
-        >>> geometric_transform(a, shift_func)
-        array([[ 0.    ,  0.    ,  0.    ],
-               [ 0.    ,  1.3625,  2.7375],
-               [ 0.    ,  4.8125,  6.1875],
-               [ 0.    ,  8.2625,  9.6375]])
+     >>> a = np.arange(12).reshape(4,3).astype(np.float64)
+     >>> def shift_func(output_coordinates):
+     ...     return (output_coordinates[0] - 0.5, output_coordinates[1] - 0.5)
+     ...
+     >>> from scipy.ndimage import geometric_transform
+     >>> geometric_transform(a, shift_func)
+     array([[ 0.    ,  0.    ,  0.    ],
+	    [ 0.    ,  1.3625,  2.7375],
+            [ 0.    ,  4.8125,  6.1875],
+            [ 0.    ,  8.2625,  9.6375]])
 
-    Optionally extra arguments can be defined and passed to the filter
-    function. The *extra_arguments* and *extra_keywords* arguments
-    can be used to pass a tuple of extra arguments and/or a dictionary
-    of named arguments that are passed to derivative at each call. For
-    example, we can pass the shifts in our example as arguments::
+  Optionally extra arguments can be defined and passed to the filter
+  function. The *extra_arguments* and *extra_keywords* arguments can
+  be used to pass a tuple of extra arguments and/or a dictionary of
+  named arguments that are passed to derivative at each call. For
+  example, we can pass the shifts in our example as arguments
 
-        >>> def shift_func(output_coordinates, s0, s1):
-        ...     return (output_coordinates[0] - s0, output_coordinates[1] - s1)
-        ...
-        >>> geometric_transform(a, shift_func, extra_arguments = (0.5, 0.5))
-        array([[ 0.    ,  0.    ,  0.    ],
-               [ 0.    ,  1.3625,  2.7375],
-               [ 0.    ,  4.8125,  6.1875],
-               [ 0.    ,  8.2625,  9.6375]])
+  .. code:: python
 
-    or::
+     >>> def shift_func(output_coordinates, s0, s1):
+     ...     return (output_coordinates[0] - s0, output_coordinates[1] - s1)
+     ...
+     >>> geometric_transform(a, shift_func, extra_arguments = (0.5, 0.5))
+     array([[ 0.    ,  0.    ,  0.    ],
+	    [ 0.    ,  1.3625,  2.7375],
+            [ 0.    ,  4.8125,  6.1875],
+            [ 0.    ,  8.2625,  9.6375]])
 
-        >>> geometric_transform(a, shift_func, extra_keywords = {'s0': 0.5, 's1': 0.5})
-        array([[ 0.    ,  0.    ,  0.    ],
-               [ 0.    ,  1.3625,  2.7375],
-               [ 0.    ,  4.8125,  6.1875],
-               [ 0.    ,  8.2625,  9.6375]])
+  or
 
-    .. note:: The mapping function can also be written in C and passed using a :ctype:`PyCObject`. See :ref:`ndimage-ccallbacks` for more information.
+  .. code:: python
 
+     >>> geometric_transform(a, shift_func, extra_keywords = {'s0': 0.5, 's1': 0.5})
+     array([[ 0.    ,  0.    ,  0.    ],
+	    [ 0.    ,  1.3625,  2.7375],
+	    [ 0.    ,  4.8125,  6.1875],
+	    [ 0.    ,  8.2625,  9.6375]])
 
-    The function :func:`map_coordinates` applies an arbitrary coordinate
-    transformation using the given array of coordinates. The shape of
-    the output is derived from that of the coordinate array by dropping
-    the first axis. The parameter *coordinates* is used to find for
-    each point in the output the corresponding coordinates in the
-    input. The values of *coordinates* along the first axis are the
-    coordinates in the input array at which the output value is found.
-    (See also the numarray `coordinates` function.) Since the
-    coordinates may be non- integer coordinates, the value of the input
-    at these coordinates is determined by spline interpolation of the
-    requested order. Here is an example that interpolates a 2D array at
-    (0.5, 0.5) and (1, 2)::
+  .. note::
+     
+     The mapping function can also be written in C and passed using a
+     :ctype:`PyCapsule`. See :ref:`ndimage-ccallbacks` for more
+     information.
 
-        >>> a = np.arange(12).reshape(4,3).astype(np.float64)
-        >>> a
-        array([[  0.,   1.,   2.],
-               [  3.,   4.,   5.],
-               [  6.,   7.,   8.],
-               [  9.,  10.,  11.]])
-        >>> from scipy.ndimage import map_coordinates
-        >>> map_coordinates(a, [[0.5, 2], [0.5, 1]])
-        array([ 1.3625,  7.])
+- The function :func:`map_coordinates` applies an arbitrary coordinate
+  transformation using the given array of coordinates. The shape of
+  the output is derived from that of the coordinate array by dropping
+  the first axis. The parameter *coordinates* is used to find for each
+  point in the output the corresponding coordinates in the input. The
+  values of *coordinates* along the first axis are the coordinates in
+  the input array at which the output value is found.  (See also the
+  numarray `coordinates` function.) Since the coordinates may be non-
+  integer coordinates, the value of the input at these coordinates is
+  determined by spline interpolation of the requested order.
 
-    The :func:`affine_transform` function applies an affine transformation
-    to the input array. The given transformation *matrix* and *offset*
-    are used to find for each point in the output the corresponding
-    coordinates in the input. The value of the input at the calculated
-    coordinates is determined by spline interpolation of the requested
-    order. The transformation *matrix* must be two-dimensional or can
-    also be given as a one-dimensional sequence or array. In the latter
-    case, it is assumed that the matrix is diagonal. A more efficient
-    interpolation algorithm is then applied that exploits the
-    separability of the problem. The output shape and output type can
-    optionally be provided. If not given they are equal to the input
-    shape and type.
+  Here is an example that interpolates a 2D array at ``(0.5, 0.5)`` and
+  ``(1, 2)``:
 
-    The :func:`shift` function returns a shifted version of the input, using
-    spline interpolation of the requested *order*.
+  .. code:: python
 
-    The :func:`zoom` function returns a rescaled version of the input, using
-    spline interpolation of the requested *order*.
+     >>> a = np.arange(12).reshape(4,3).astype(np.float64)
+     >>> a
+     array([[  0.,   1.,   2.],
+	    [  3.,   4.,   5.],
+	    [  6.,   7.,   8.],
+	    [  9.,  10.,  11.]])
+     >>> from scipy.ndimage import map_coordinates
+     >>> map_coordinates(a, [[0.5, 2], [0.5, 1]])
+     array([ 1.3625,  7.])
 
-    The :func:`rotate` function returns the input array rotated in the plane
-    defined by the two axes given by the parameter *axes*, using spline
-    interpolation of the requested *order*. The angle must be given in
-    degrees. If *reshape* is true, then the size of the output array is
-    adapted to contain the rotated input.
+- The :func:`affine_transform` function applies an affine
+  transformation to the input array. The given transformation *matrix*
+  and *offset* are used to find for each point in the output the
+  corresponding coordinates in the input. The value of the input at
+  the calculated coordinates is determined by spline interpolation of
+  the requested order. The transformation *matrix* must be
+  two-dimensional or can also be given as a one-dimensional sequence
+  or array. In the latter case, it is assumed that the matrix is
+  diagonal. A more efficient interpolation algorithm is then applied
+  that exploits the separability of the problem. The output shape and
+  output type can optionally be provided. If not given they are equal
+  to the input shape and type.
 
+- The :func:`shift` function returns a shifted version of the input,
+  using spline interpolation of the requested *order*.
+
+- The :func:`zoom` function returns a rescaled version of the input,
+  using spline interpolation of the requested *order*.
+
+- The :func:`rotate` function returns the input array rotated in the
+  plane defined by the two axes given by the parameter *axes*, using
+  spline interpolation of the requested *order*. The angle must be
+  given in degrees. If *reshape* is true, then the size of the output
+  array is adapted to contain the rotated input.
 
 .. _ndimage-morphology:
 
@@ -857,727 +898,726 @@ Morphology
 Binary morphology
 ^^^^^^^^^^^^^^^^^
 
-.. currentmodule:: scipy.ndimage.morphology
+- The :func:`generate_binary_structure` functions generates a binary
+  structuring element for use in binary morphology operations. The
+  *rank* of the structure must be provided. The size of the structure
+  that is returned is equal to three in each direction. The value of
+  each element is equal to one if the square of the Euclidean distance
+  from the element to the center is less or equal to
+  *connectivity*. For instance, two dimensional 4-connected and
+  8-connected structures are generated as follows:
 
-Binary morphology (need something to put here).
+  .. code:: python
 
-    The :func:`generate_binary_structure` functions generates a binary
-    structuring element for use in binary morphology operations. The
-    *rank* of the structure must be provided. The size of the structure
-    that is returned is equal to three in each direction. The value of
-    each element is equal to one if the square of the Euclidean
-    distance from the element to the center is less or equal to
-    *connectivity*. For instance, two dimensional 4-connected and
-    8-connected structures are generated as follows::
-
-        >>> from scipy.ndimage import generate_binary_structure
-        >>> generate_binary_structure(2, 1)
-        array([[False,  True, False],
-               [ True,  True,  True],
-               [False,  True, False]], dtype=bool)
-        >>> generate_binary_structure(2, 2)
-        array([[ True,  True,  True],
-               [ True,  True,  True],
-               [ True,  True,  True]], dtype=bool)
+     >>> from scipy.ndimage import generate_binary_structure
+     >>> generate_binary_structure(2, 1)
+     array([[False,  True, False],
+	    [ True,  True,  True],
+            [False,  True, False]], dtype=bool)
+     >>> generate_binary_structure(2, 2)
+     array([[ True,  True,  True],
+	    [ True,  True,  True],
+            [ True,  True,  True]], dtype=bool)
 
 Most binary morphology functions can be expressed in terms of the
-basic operations erosion and dilation:
+basic operations erosion and dilation.
 
-    The :func:`binary_erosion` function implements binary erosion of arrays
-    of arbitrary rank with the given structuring element. The origin
-    parameter controls the placement of the structuring element as
-    described in :ref:`ndimage-filter-functions`. If no
-    structuring element is provided, an element with connectivity equal
-    to one is generated using :func:`generate_binary_structure`. The
-    *border_value* parameter gives the value of the array outside
-    boundaries. The erosion is repeated *iterations* times. If
-    *iterations* is less than one, the erosion is repeated until the
-    result does not change anymore. If a *mask* array is given, only
-    those elements with a true value at the corresponding mask element
-    are modified at each iteration.
+- The :func:`binary_erosion` function implements binary erosion of
+  arrays of arbitrary rank with the given structuring element. The
+  origin parameter controls the placement of the structuring element
+  as described in :ref:`ndimage-filter-functions`. If no structuring
+  element is provided, an element with connectivity equal to one is
+  generated using :func:`generate_binary_structure`. The
+  *border_value* parameter gives the value of the array outside
+  boundaries. The erosion is repeated *iterations* times. If
+  *iterations* is less than one, the erosion is repeated until the
+  result does not change anymore. If a *mask* array is given, only
+  those elements with a true value at the corresponding mask element
+  are modified at each iteration.
 
-    The :func:`binary_dilation` function implements binary dilation of
-    arrays of arbitrary rank with the given structuring element. The
-    origin parameter controls the placement of the structuring element
-    as described in :ref:`ndimage-filter-functions`. If no
-    structuring element is provided, an element with connectivity equal
-    to one is generated using :func:`generate_binary_structure`. The
-    *border_value* parameter gives the value of the array outside
-    boundaries. The dilation is repeated *iterations* times. If
-    *iterations* is less than one, the dilation is repeated until the
-    result does not change anymore. If a *mask* array is given, only
-    those elements with a true value at the corresponding mask element
-    are modified at each iteration.
+- The :func:`binary_dilation` function implements binary dilation of
+  arrays of arbitrary rank with the given structuring element. The
+  origin parameter controls the placement of the structuring element
+  as described in :ref:`ndimage-filter-functions`. If no structuring
+  element is provided, an element with connectivity equal to one is
+  generated using :func:`generate_binary_structure`. The
+  *border_value* parameter gives the value of the array outside
+  boundaries. The dilation is repeated *iterations* times. If
+  *iterations* is less than one, the dilation is repeated until the
+  result does not change anymore. If a *mask* array is given, only
+  those elements with a true value at the corresponding mask element
+  are modified at each iteration.
 
-    Here is an example of using :func:`binary_dilation` to find all elements
-    that touch the border, by repeatedly dilating an empty array from
-    the border using the data array as the mask::
+Here is an example of using :func:`binary_dilation` to find all elements
+that touch the border, by repeatedly dilating an empty array from
+the border using the data array as the mask:
 
-        >>> struct = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])
-        >>> a = np.array([[1,0,0,0,0], [1,1,0,1,0], [0,0,1,1,0], [0,0,0,0,0]])
-        >>> a
-        array([[1, 0, 0, 0, 0],
-               [1, 1, 0, 1, 0],
-               [0, 0, 1, 1, 0],
-               [0, 0, 0, 0, 0]])
-        >>> from scipy.ndimage import binary_dilation
-        >>> binary_dilation(np.zeros(a.shape), struct, -1, a, border_value=1)
-        array([[ True, False, False, False, False],
-               [ True,  True, False, False, False],
-               [False, False, False, False, False],
-               [False, False, False, False, False]], dtype=bool)
+.. code:: python
 
+   >>> struct = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])
+   >>> a = np.array([[1,0,0,0,0], [1,1,0,1,0], [0,0,1,1,0], [0,0,0,0,0]])
+   >>> a
+   array([[1, 0, 0, 0, 0],
+	  [1, 1, 0, 1, 0],
+          [0, 0, 1, 1, 0],
+          [0, 0, 0, 0, 0]])
+   >>> from scipy.ndimage import binary_dilation
+   >>> binary_dilation(np.zeros(a.shape), struct, -1, a, border_value=1)
+   array([[ True, False, False, False, False],
+	  [ True,  True, False, False, False],
+          [False, False, False, False, False],
+          [False, False, False, False, False]], dtype=bool)
 
-The :func:`binary_erosion` and :func:`binary_dilation` functions both have an
-*iterations* parameter which allows the erosion or dilation to be
-repeated a number of times. Repeating an erosion or a dilation with
-a given structure *n* times is equivalent to an erosion or a
-dilation with a structure that is *n-1* times dilated with itself.
-A function is provided that allows the calculation of a structure
-that is dilated a number of times with itself:
+The :func:`binary_erosion` and :func:`binary_dilation` functions both
+have an *iterations* parameter which allows the erosion or dilation to
+be repeated a number of times. Repeating an erosion or a dilation with
+a given structure *n* times is equivalent to an erosion or a dilation
+with a structure that is *n-1* times dilated with itself.  A function
+is provided that allows the calculation of a structure that is dilated
+a number of times with itself:
 
-    The :func:`iterate_structure` function returns a structure by dilation
-    of the input structure *iteration* - 1 times with itself. For
-    instance::
+- The :func:`iterate_structure` function returns a structure by dilation
+  of the input structure *iteration* - 1 times with itself.
 
-        >>> struct = generate_binary_structure(2, 1)
-        >>> struct
-        array([[False,  True, False],
-               [ True,  True,  True],
-               [False,  True, False]], dtype=bool)
-        >>> from scipy.ndimage import iterate_structure
-        >>> iterate_structure(struct, 2)
-        array([[False, False,  True, False, False],
-               [False,  True,  True,  True, False],
-               [ True,  True,  True,  True,  True],
-               [False,  True,  True,  True, False],
-               [False, False,  True, False, False]], dtype=bool)
+  For instance:
 
-    If the origin of the original structure is equal to 0, then it is
-    also equal to 0 for the iterated structure. If not, the origin must
-    also be adapted if the equivalent of the *iterations* erosions or
-    dilations must be achieved with the iterated structure. The adapted
-    origin is simply obtained by multiplying with the number of
-    iterations. For convenience the :func:`iterate_structure` also returns
-    the adapted origin if the *origin* parameter is not None::
+  .. code:: python
 
-        >>> iterate_structure(struct, 2, -1)
-        (array([[False, False,  True, False, False],
-               [False,  True,  True,  True, False],
-               [ True,  True,  True,  True,  True],
-               [False,  True,  True,  True, False],
-               [False, False,  True, False, False]], dtype=bool), [-2, -2])
+     >>> struct = generate_binary_structure(2, 1)
+     >>> struct
+     array([[False,  True, False],
+	    [ True,  True,  True],
+	    [False,  True, False]], dtype=bool)
+     >>> from scipy.ndimage import iterate_structure
+     >>> iterate_structure(struct, 2)
+     array([[False, False,  True, False, False],
+	    [False,  True,  True,  True, False],
+	    [ True,  True,  True,  True,  True],
+	    [False,  True,  True,  True, False],
+            [False, False,  True, False, False]], dtype=bool)
 
+     If the origin of the original structure is equal to 0, then it is
+     also equal to 0 for the iterated structure. If not, the origin
+     must also be adapted if the equivalent of the *iterations*
+     erosions or dilations must be achieved with the iterated
+     structure. The adapted origin is simply obtained by multiplying
+     with the number of iterations. For convenience the
+     :func:`iterate_structure` also returns the adapted origin if the
+     *origin* parameter is not ``None``:
 
-Other morphology operations can be defined in terms of erosion and
-d dilation. Following functions provide a few of these operations
+     .. code:: python
+
+	>>> iterate_structure(struct, 2, -1)
+	(array([[False, False,  True, False, False],
+	        [False,  True,  True,  True, False],
+		[ True,  True,  True,  True,  True],
+		[False,  True,  True,  True, False],
+		[False, False,  True, False, False]], dtype=bool), [-2, -2])
+
+Other morphology operations can be defined in terms of erosion and d
+dilation. The following functions provide a few of these operations
 for convenience:
 
-    The :func:`binary_opening` function implements binary opening of arrays
-    of arbitrary rank with the given structuring element. Binary
-    opening is equivalent to a binary erosion followed by a binary
-    dilation with the same structuring element. The origin parameter
-    controls the placement of the structuring element as described in
-    :ref:`ndimage-filter-functions`. If no structuring element is
-    provided, an element with connectivity equal to one is generated
-    using :func:`generate_binary_structure`. The *iterations* parameter
-    gives the number of erosions that is performed followed by the same
-    number of dilations.
+- The :func:`binary_opening` function implements binary opening of
+  arrays of arbitrary rank with the given structuring element. Binary
+  opening is equivalent to a binary erosion followed by a binary
+  dilation with the same structuring element. The origin parameter
+  controls the placement of the structuring element as described in
+  :ref:`ndimage-filter-functions`. If no structuring element is
+  provided, an element with connectivity equal to one is generated
+  using :func:`generate_binary_structure`. The *iterations* parameter
+  gives the number of erosions that is performed followed by the same
+  number of dilations.
 
+- The :func:`binary_closing` function implements binary closing of
+  arrays of arbitrary rank with the given structuring element. Binary
+  closing is equivalent to a binary dilation followed by a binary
+  erosion with the same structuring element. The origin parameter
+  controls the placement of the structuring element as described in
+  :ref:`ndimage-filter-functions`. If no structuring element is
+  provided, an element with connectivity equal to one is generated
+  using :func:`generate_binary_structure`. The *iterations* parameter
+  gives the number of dilations that is performed followed by the same
+  number of erosions.
 
-    The :func:`binary_closing` function implements binary closing of arrays
-    of arbitrary rank with the given structuring element. Binary
-    closing is equivalent to a binary dilation followed by a binary
-    erosion with the same structuring element. The origin parameter
-    controls the placement of the structuring element as described in
-    :ref:`ndimage-filter-functions`. If no structuring element is
-    provided, an element with connectivity equal to one is generated
-    using :func:`generate_binary_structure`. The *iterations* parameter
-    gives the number of dilations that is performed followed by the
-    same number of erosions.
+- The :func:`binary_fill_holes` function is used to close holes in
+  objects in a binary image, where the structure defines the
+  connectivity of the holes. The origin parameter controls the
+  placement of the structuring element as described in
+  :ref:`ndimage-filter-functions`. If no structuring element is
+  provided, an element with connectivity equal to one is generated
+  using :func:`generate_binary_structure`.
 
-
-    The :func:`binary_fill_holes` function is used to close holes in
-    objects in a binary image, where the structure defines the
-    connectivity of the holes. The origin parameter controls the
-    placement of the structuring element as described in
-    :ref:`ndimage-filter-functions`. If no structuring element is
-    provided, an element with connectivity equal to one is generated
-    using :func:`generate_binary_structure`.
-
-
-    The :func:`binary_hit_or_miss` function implements a binary
-    hit-or-miss transform of arrays of arbitrary rank with the given
-    structuring elements. The hit-or-miss transform is calculated by
-    erosion of the input with the first structure, erosion of the
-    logical *not* of the input with the second structure, followed by
-    the logical *and* of these two erosions. The origin parameters
-    control the placement of the structuring elements as described in
-    :ref:`ndimage-filter-functions`. If *origin2* equals None it
-    is set equal to the *origin1* parameter. If the first structuring
-    element is not provided, a structuring element with connectivity
-    equal to one is generated using :func:`generate_binary_structure`, if
-    *structure2* is not provided, it is set equal to the logical *not*
-    of *structure1*.
-
+- The :func:`binary_hit_or_miss` function implements a binary
+  hit-or-miss transform of arrays of arbitrary rank with the given
+  structuring elements. The hit-or-miss transform is calculated by
+  erosion of the input with the first structure, erosion of the
+  logical *not* of the input with the second structure, followed by
+  the logical *and* of these two erosions. The origin parameters
+  control the placement of the structuring elements as described in
+  :ref:`ndimage-filter-functions`. If *origin2* equals None it is set
+  equal to the *origin1* parameter. If the first structuring element
+  is not provided, a structuring element with connectivity equal to
+  one is generated using :func:`generate_binary_structure`, if
+  *structure2* is not provided, it is set equal to the logical *not*
+  of *structure1*.
 
 .. _ndimage-grey-morphology:
 
 Grey-scale morphology
 ^^^^^^^^^^^^^^^^^^^^^
 
-.. currentmodule:: scipy.ndimage.morphology
-
 Grey-scale morphology operations are the equivalents of binary
 morphology operations that operate on arrays with arbitrary values.
 Below we describe the grey-scale equivalents of erosion, dilation,
 opening and closing. These operations are implemented in a similar
-fashion as the filters described in
-:ref:`ndimage-filter-functions`, and we refer to this section for the
-description of filter kernels and footprints, and the handling of
-array borders. The grey-scale morphology operations optionally take
-a *structure* parameter that gives the values of the structuring
-element. If this parameter is not given the structuring element is
-assumed to be flat with a value equal to zero. The shape of the
-structure can optionally be defined by the *footprint* parameter.
-If this parameter is not given, the structure is assumed to be
-rectangular, with sizes equal to the dimensions of the *structure*
-array, or by the *size* parameter if *structure* is not given. The
-*size* parameter is only used if both *structure* and *footprint*
-are not given, in which case the structuring element is assumed to
-be rectangular and flat with the dimensions given by *size*. The
-*size* parameter, if provided, must be a sequence of sizes or a
-single number in which case the size of the filter is assumed to be
-equal along each axis. The *footprint* parameter, if provided, must
+fashion as the filters described in :ref:`ndimage-filter-functions`,
+and we refer to this section for the description of filter kernels and
+footprints, and the handling of array borders. The grey-scale
+morphology operations optionally take a *structure* parameter that
+gives the values of the structuring element. If this parameter is not
+given the structuring element is assumed to be flat with a value equal
+to zero. The shape of the structure can optionally be defined by the
+*footprint* parameter.  If this parameter is not given, the structure
+is assumed to be rectangular, with sizes equal to the dimensions of
+the *structure* array, or by the *size* parameter if *structure* is
+not given. The *size* parameter is only used if both *structure* and
+*footprint* are not given, in which case the structuring element is
+assumed to be rectangular and flat with the dimensions given by
+*size*. The *size* parameter, if provided, must be a sequence of sizes
+or a single number in which case the size of the filter is assumed to
+be equal along each axis. The *footprint* parameter, if provided, must
 be an array that defines the shape of the kernel by its non-zero
 elements.
 
 Similar to binary erosion and dilation there are operations for
 grey-scale erosion and dilation:
 
-    The :func:`grey_erosion` function calculates a multidimensional grey-
-    scale erosion.
+- The :func:`grey_erosion` function calculates a multidimensional
+  grey- scale erosion.
 
-
-    The :func:`grey_dilation` function calculates a multidimensional grey-
-    scale dilation.
-
+- The :func:`grey_dilation` function calculates a multidimensional
+  grey-scale dilation.
 
 Grey-scale opening and closing operations can be defined similar to
 their binary counterparts:
 
-    The :func:`grey_opening` function implements grey-scale opening of
-    arrays of arbitrary rank. Grey-scale opening is equivalent to a
-    grey-scale erosion followed by a grey-scale dilation.
+- The :func:`grey_opening` function implements grey-scale opening of
+  arrays of arbitrary rank. Grey-scale opening is equivalent to a
+  grey-scale erosion followed by a grey-scale dilation.
 
+- The :func:`grey_closing` function implements grey-scale closing of
+  arrays of arbitrary rank. Grey-scale opening is equivalent to a
+  grey-scale dilation followed by a grey-scale erosion.
 
-    The :func:`grey_closing` function implements grey-scale closing of
-    arrays of arbitrary rank. Grey-scale opening is equivalent to a
-    grey-scale dilation followed by a grey-scale erosion.
+- The :func:`morphological_gradient` function implements a grey-scale
+  morphological gradient of arrays of arbitrary rank. The grey-scale
+  morphological gradient is equal to the difference of a grey-scale
+  dilation and a grey-scale erosion.
 
+- The :func:`morphological_laplace` function implements a grey-scale
+  morphological laplace of arrays of arbitrary rank. The grey-scale
+  morphological laplace is equal to the sum of a grey-scale dilation
+  and a grey-scale erosion minus twice the input.
 
-    The :func:`morphological_gradient` function implements a grey-scale
-    morphological gradient of arrays of arbitrary rank. The grey-scale
-    morphological gradient is equal to the difference of a grey-scale
-    dilation and a grey-scale erosion.
+- The :func:`white_tophat` function implements a white top-hat filter
+  of arrays of arbitrary rank. The white top-hat is equal to the
+  difference of the input and a grey-scale opening.
 
-
-    The :func:`morphological_laplace` function implements a grey-scale
-    morphological laplace of arrays of arbitrary rank. The grey-scale
-    morphological laplace is equal to the sum of a grey-scale dilation
-    and a grey-scale erosion minus twice the input.
-
-
-    The :func:`white_tophat` function implements a white top-hat filter of
-    arrays of arbitrary rank. The white top-hat is equal to the
-    difference of the input and a grey-scale opening.
-
-
-    The :func:`black_tophat` function implements a black top-hat filter of
-    arrays of arbitrary rank. The black top-hat is equal to the
-    difference of a grey-scale closing and the input.
-
+- The :func:`black_tophat` function implements a black top-hat filter
+  of arrays of arbitrary rank. The black top-hat is equal to the
+  difference of a grey-scale closing and the input.
 
 .. _ndimage-distance-transforms:
 
 Distance transforms
 -------------------
 
-.. currentmodule:: scipy.ndimage.morphology
+Distance transforms are used to calculate the minimum distance from
+each element of an object to the background. The following functions
+implement distance transforms for three different distance metrics:
+Euclidean, City Block, and Chessboard distances.
 
-Distance transforms are used to
-calculate the minimum distance from each element of an object to
-the background. The following functions implement distance
-transforms for three different distance metrics: Euclidean, City
-Block, and Chessboard distances.
+- The function :func:`distance_transform_cdt` uses a chamfer type
+  algorithm to calculate the distance transform of the input, by
+  replacing each object element (defined by values larger than zero)
+  with the shortest distance to the background (all non-object
+  elements). The structure determines the type of chamfering that is
+  done. If the structure is equal to 'cityblock' a structure is
+  generated using :func:`generate_binary_structure` with a squared
+  distance equal to 1. If the structure is equal to 'chessboard', a
+  structure is generated using :func:`generate_binary_structure` with
+  a squared distance equal to the rank of the array. These choices
+  correspond to the common interpretations of the cityblock and the
+  chessboard distance metrics in two dimensions.
 
-    The function :func:`distance_transform_cdt` uses a chamfer type
-    algorithm to calculate the distance transform of the input, by
-    replacing each object element (defined by values larger than zero)
-    with the shortest distance to the background (all non-object
-    elements). The structure determines the type of chamfering that is
-    done. If the structure is equal to 'cityblock' a structure is
-    generated using :func:`generate_binary_structure` with a squared
-    distance equal to 1. If the structure is equal to 'chessboard', a
-    structure is generated using :func:`generate_binary_structure` with a
-    squared distance equal to the rank of the array. These choices
-    correspond to the common interpretations of the cityblock and the
-    chessboard distance metrics in two dimensions.
+  In addition to the distance transform, the feature transform can be
+  calculated. In this case the index of the closest background element
+  is returned along the first axis of the result. The
+  *return_distances*, and *return_indices* flags can be used to
+  indicate if the distance transform, the feature transform, or both
+  must be returned.
 
-    In addition to the distance transform, the feature transform can be
-    calculated. In this case the index of the closest background
-    element is returned along the first axis of the result. The
-    *return_distances*, and *return_indices* flags can be used to
-    indicate if the distance transform, the feature transform, or both
-    must be returned.
+  The *distances* and *indices* arguments can be used to give optional
+  output arrays that must be of the correct size and type (both
+  :ctype:`Int32`). The basics of the algorithm used to implement this
+  function is described in [2]_.
 
-    The *distances* and *indices* arguments can be used to give
-    optional output arrays that must be of the correct size and type
-    (both :ctype:`Int32`).
+- The function :func:`distance_transform_edt` calculates the exact
+  euclidean distance transform of the input, by replacing each object
+  element (defined by values larger than zero) with the shortest
+  euclidean distance to the background (all non-object elements).
 
-    The basics of the algorithm used to implement this function is
-    described in: G. Borgefors, "Distance transformations in arbitrary
-    dimensions.", Computer Vision, Graphics, and Image Processing,
-    27:321-345, 1984.
+  In addition to the distance transform, the feature transform can be
+  calculated. In this case the index of the closest background element
+  is returned along the first axis of the result. The
+  *return_distances*, and *return_indices* flags can be used to
+  indicate if the distance transform, the feature transform, or both
+  must be returned.
 
+  Optionally the sampling along each axis can be given by the
+  *sampling* parameter which should be a sequence of length equal to
+  the input rank, or a single number in which the sampling is assumed
+  to be equal along all axes.
 
-    The function :func:`distance_transform_edt` calculates the exact
-    euclidean distance transform of the input, by replacing each object
-    element (defined by values larger than zero) with the shortest
-    euclidean distance to the background (all non-object elements).
+  The *distances* and *indices* arguments can be used to give optional
+  output arrays that must be of the correct size and type
+  (:ctype:`Float64` and :ctype:`Int32`).The algorithm used to
+  implement this function is described in [3]_.
 
-    In addition to the distance transform, the feature transform can be
-    calculated. In this case the index of the closest background
-    element is returned along the first axis of the result. The
-    *return_distances*, and *return_indices* flags can be used to
-    indicate if the distance transform, the feature transform, or both
-    must be returned.
+- The function :func:`distance_transform_bf` uses a brute-force
+  algorithm to calculate the distance transform of the input, by
+  replacing each object element (defined by values larger than zero)
+  with the shortest distance to the background (all non-object
+  elements). The metric must be one of "euclidean", "cityblock", or
+  "chessboard".
 
-    Optionally the sampling along each axis can be given by the
-    *sampling* parameter which should be a sequence of length equal to
-    the input rank, or a single number in which the sampling is assumed
-    to be equal along all axes.
+  In addition to the distance transform, the feature transform can be
+  calculated. In this case the index of the closest background element
+  is returned along the first axis of the result. The
+  *return_distances*, and *return_indices* flags can be used to
+  indicate if the distance transform, the feature transform, or both
+  must be returned.
 
-    The *distances* and *indices* arguments can be used to give
-    optional output arrays that must be of the correct size and type
-    (:ctype:`Float64` and :ctype:`Int32`).
+  Optionally the sampling along each axis can be given by the
+  *sampling* parameter which should be a sequence of length equal to
+  the input rank, or a single number in which the sampling is assumed
+  to be equal along all axes. This parameter is only used in the case
+  of the euclidean distance transform.
 
-    The algorithm used to implement this function is described in: C.
-    R. Maurer, Jr., R. Qi, and V. Raghavan, "A linear time algorithm
-    for computing exact euclidean distance transforms of binary images
-    in arbitrary dimensions. IEEE Trans. PAMI 25, 265-270, 2003.
+  The *distances* and *indices* arguments can be used to give optional
+  output arrays that must be of the correct size and type
+  (:ctype:`Float64` and :ctype:`Int32`).
 
+  .. note::
 
-    The function :func:`distance_transform_bf` uses a brute-force algorithm
-    to calculate the distance transform of the input, by replacing each
-    object element (defined by values larger than zero) with the
-    shortest distance to the background (all non-object elements). The
-    metric must be one of "euclidean", "cityblock", or
-    "chessboard".
-
-    In addition to the distance transform, the feature transform can be
-    calculated. In this case the index of the closest background
-    element is returned along the first axis of the result. The
-    *return_distances*, and *return_indices* flags can be used to
-    indicate if the distance transform, the feature transform, or both
-    must be returned.
-
-    Optionally the sampling along each axis can be given by the
-    *sampling* parameter which should be a sequence of length equal to
-    the input rank, or a single number in which the sampling is assumed
-    to be equal along all axes. This parameter is only used in the case
-    of the euclidean distance transform.
-
-    The *distances* and *indices* arguments can be used to give
-    optional output arrays that must be of the correct size and type
-    (:ctype:`Float64` and :ctype:`Int32`).
-
-    .. note:: This function uses a slow brute-force algorithm, the function :func:`distance_transform_cdt` can be used to more efficiently calculate cityblock and chessboard distance transforms. The function :func:`distance_transform_edt` can be used to more efficiently calculate the exact euclidean distance transform.
-
+     This function uses a slow brute-force algorithm, the function
+     :func:`distance_transform_cdt` can be used to more efficiently
+     calculate cityblock and chessboard distance transforms. The
+     function :func:`distance_transform_edt` can be used to more
+     efficiently calculate the exact euclidean distance transform.
 
 Segmentation and labeling
 -------------------------
 
 Segmentation is the process of separating objects of interest from
 the background. The most simple approach is probably intensity
-thresholding, which is easily done with :mod:`numpy` functions::
+thresholding, which is easily done with :mod:`numpy` functions:
 
-    >>> a = np.array([[1,2,2,1,1,0],
-    ...               [0,2,3,1,2,0],
-    ...               [1,1,1,3,3,2],
-    ...               [1,1,1,1,2,1]])
-    >>> np.where(a > 1, 1, 0)
-    array([[0, 1, 1, 0, 0, 0],
-           [0, 1, 1, 0, 1, 0],
-           [0, 0, 0, 1, 1, 1],
-           [0, 0, 0, 0, 1, 0]])
+.. code:: python
+
+   >>> a = np.array([[1,2,2,1,1,0],
+   ...               [0,2,3,1,2,0],
+   ...               [1,1,1,3,3,2],
+   ...               [1,1,1,1,2,1]])
+   >>> np.where(a > 1, 1, 0)
+   array([[0, 1, 1, 0, 0, 0],
+	  [0, 1, 1, 0, 1, 0],
+	  [0, 0, 0, 1, 1, 1],
+	  [0, 0, 0, 0, 1, 0]])
 
 The result is a binary image, in which the individual objects still
-need to be identified and labeled. The function :func:`label` generates
-an array where each object is assigned a unique number:
+need to be identified and labeled. The function :func:`label`
+generates an array where each object is assigned a unique number:
 
-    The :func:`label` function generates an array where the objects in the
-    input are labeled with an integer index. It returns a tuple
-    consisting of the array of object labels and the number of objects
-    found, unless the *output* parameter is given, in which case only
-    the number of objects is returned. The connectivity of the objects
-    is defined by a structuring element. For instance, in two
-    dimensions using a four-connected structuring element gives::
+- The :func:`label` function generates an array where the objects in
+  the input are labeled with an integer index. It returns a tuple
+  consisting of the array of object labels and the number of objects
+  found, unless the *output* parameter is given, in which case only
+  the number of objects is returned. The connectivity of the objects
+  is defined by a structuring element. For instance, in two dimensions
+  using a four-connected structuring element gives:
 
-        >>> a = np.array([[0,1,1,0,0,0],[0,1,1,0,1,0],[0,0,0,1,1,1],[0,0,0,0,1,0]])
-        >>> s = [[0, 1, 0], [1,1,1], [0,1,0]]
-        >>> from scipy.ndimage import label
-        >>> label(a, s)
-        (array([[0, 1, 1, 0, 0, 0],
-               [0, 1, 1, 0, 2, 0],
-               [0, 0, 0, 2, 2, 2],
-               [0, 0, 0, 0, 2, 0]]), 2)
+  .. code:: python
 
-    These two objects are not connected because there is no way in
-    which we can place the structuring element such that it overlaps
-    with both objects. However, an 8-connected structuring element
-    results in only a single object::
+     >>> a = np.array([[0,1,1,0,0,0],[0,1,1,0,1,0],[0,0,0,1,1,1],[0,0,0,0,1,0]])
+     >>> s = [[0, 1, 0], [1,1,1], [0,1,0]]
+     >>> from scipy.ndimage import label
+     >>> label(a, s)
+     (array([[0, 1, 1, 0, 0, 0],
+	     [0, 1, 1, 0, 2, 0],
+	     [0, 0, 0, 2, 2, 2],
+	     [0, 0, 0, 0, 2, 0]]), 2)
 
-        >>> a = np.array([[0,1,1,0,0,0],[0,1,1,0,1,0],[0,0,0,1,1,1],[0,0,0,0,1,0]])
-        >>> s = [[1,1,1], [1,1,1], [1,1,1]]
-        >>> label(a, s)[0]
-        array([[0, 1, 1, 0, 0, 0],
-               [0, 1, 1, 0, 1, 0],
-               [0, 0, 0, 1, 1, 1],
-               [0, 0, 0, 0, 1, 0]])
+  These two objects are not connected because there is no way in which
+  we can place the structuring element such that it overlaps with both
+  objects. However, an 8-connected structuring element results in only
+  a single object:
 
-    If no structuring element is provided, one is generated by calling
-    :func:`generate_binary_structure` (see
-    :ref:`ndimage-binary-morphology`)
-    using a connectivity of one (which in 2D is the 4-connected
-    structure of the first example). The input can be of any type, any
-    value not equal to zero is taken to be part of an object. This is
-    useful if you need to 're-label' an array of object indices, for
-    instance after removing unwanted objects. Just apply the label
-    function again to the index array. For instance::
+  .. code:: python
 
-        >>> l, n = label([1, 0, 1, 0, 1])
-        >>> l
-        array([1, 0, 2, 0, 3])
-        >>> l = np.where(l != 2, l, 0)
-        >>> l
-        array([1, 0, 0, 0, 3])
-        >>> label(l)[0]
-        array([1, 0, 0, 0, 2])
+     >>> a = np.array([[0,1,1,0,0,0],[0,1,1,0,1,0],[0,0,0,1,1,1],[0,0,0,0,1,0]])
+     >>> s = [[1,1,1], [1,1,1], [1,1,1]]
+     >>> label(a, s)[0]
+     array([[0, 1, 1, 0, 0, 0],
+	    [0, 1, 1, 0, 1, 0],
+            [0, 0, 0, 1, 1, 1],
+            [0, 0, 0, 0, 1, 0]])
 
-    .. note:: The structuring element used by :func:`label` is assumed to be symmetric.
+  If no structuring element is provided, one is generated by calling
+  :func:`generate_binary_structure` (see
+  :ref:`ndimage-binary-morphology`) using a connectivity of one (which
+  in 2D is the 4-connected structure of the first example). The input
+  can be of any type, any value not equal to zero is taken to be part
+  of an object. This is useful if you need to 're-label' an array of
+  object indices, for instance after removing unwanted objects. Just
+  apply the label function again to the index array. For instance:
 
+  .. code:: python
+
+     >>> l, n = label([1, 0, 1, 0, 1])
+     >>> l
+     array([1, 0, 2, 0, 3])
+     >>> l = np.where(l != 2, l, 0)
+     >>> l
+     array([1, 0, 0, 0, 3])
+     >>> label(l)[0]
+     array([1, 0, 0, 0, 2])
+
+  .. note::
+
+     The structuring element used by :func:`label` is assumed to be
+     symmetric.
 
 There is a large number of other approaches for segmentation, for
-instance from an estimation of the borders of the objects that can
-be obtained for instance by derivative filters. One such an
-approach is watershed segmentation. The function :func:`watershed_ift`
-generates an array where each object is assigned a unique label,
-from an array that localizes the object borders, generated for
-instance by a gradient magnitude filter. It uses an array
-containing initial markers for the objects:
+instance from an estimation of the borders of the objects that can be
+obtained for instance by derivative filters. One such an approach is
+watershed segmentation. The function :func:`watershed_ift` generates
+an array where each object is assigned a unique label, from an array
+that localizes the object borders, generated for instance by a
+gradient magnitude filter. It uses an array containing initial markers
+for the objects:
 
-    The :func:`watershed_ift` function applies a watershed from markers
-    algorithm, using an Iterative Forest Transform, as described in: P.
-    Felkel, R. Wegenkittl, and M. Bruckschwaiger, "Implementation and
-    Complexity of the Watershed-from-Markers Algorithm Computed as a
-    Minimal Cost Forest.", Eurographics 2001, pp. C:26-35.
+- The :func:`watershed_ift` function applies a watershed from markers
+  algorithm, using an Iterative Forest Transform, as described in
+  [4]_.
+    
+- The inputs of this function are the array to which the transform is
+  applied, and an array of markers that designate the objects by a
+  unique label, where any non-zero value is a marker. For instance:
 
-    The inputs of this function are the array to which the transform is
-    applied, and an array of markers that designate the objects by a
-    unique label, where any non-zero value is a marker. For instance::
+  .. code:: python
 
-        >>> input = np.array([[0, 0, 0, 0, 0, 0, 0],
-        ...                   [0, 1, 1, 1, 1, 1, 0],
-        ...                   [0, 1, 0, 0, 0, 1, 0],
-        ...                   [0, 1, 0, 0, 0, 1, 0],
-        ...                   [0, 1, 0, 0, 0, 1, 0],
-        ...                   [0, 1, 1, 1, 1, 1, 0],
-        ...                   [0, 0, 0, 0, 0, 0, 0]], np.uint8)
-        >>> markers = np.array([[1, 0, 0, 0, 0, 0, 0],
-        ...                     [0, 0, 0, 0, 0, 0, 0],
-        ...                     [0, 0, 0, 0, 0, 0, 0],
-        ...                     [0, 0, 0, 2, 0, 0, 0],
-        ...                     [0, 0, 0, 0, 0, 0, 0],
-        ...                     [0, 0, 0, 0, 0, 0, 0],
-        ...                     [0, 0, 0, 0, 0, 0, 0]], np.int8)
-        >>> from scipy.ndimage import watershed_ift
-        >>> watershed_ift(input, markers)
-        array([[1, 1, 1, 1, 1, 1, 1],
-               [1, 1, 2, 2, 2, 1, 1],
-               [1, 2, 2, 2, 2, 2, 1],
-               [1, 2, 2, 2, 2, 2, 1],
-               [1, 2, 2, 2, 2, 2, 1],
-               [1, 1, 2, 2, 2, 1, 1],
-               [1, 1, 1, 1, 1, 1, 1]], dtype=int8)
+     >>> input = np.array([[0, 0, 0, 0, 0, 0, 0],
+     ...                   [0, 1, 1, 1, 1, 1, 0],
+     ...                   [0, 1, 0, 0, 0, 1, 0],
+     ...                   [0, 1, 0, 0, 0, 1, 0],
+     ...                   [0, 1, 0, 0, 0, 1, 0],
+     ...                   [0, 1, 1, 1, 1, 1, 0],
+     ...                   [0, 0, 0, 0, 0, 0, 0]], np.uint8)
+     >>> markers = np.array([[1, 0, 0, 0, 0, 0, 0],
+     ...                     [0, 0, 0, 0, 0, 0, 0],
+     ...                     [0, 0, 0, 0, 0, 0, 0],
+     ...                     [0, 0, 0, 2, 0, 0, 0],
+     ...                     [0, 0, 0, 0, 0, 0, 0],
+     ...                     [0, 0, 0, 0, 0, 0, 0],
+     ...                     [0, 0, 0, 0, 0, 0, 0]], np.int8)
+     >>> from scipy.ndimage import watershed_ift
+     >>> watershed_ift(input, markers)
+     array([[1, 1, 1, 1, 1, 1, 1],
+	    [1, 1, 2, 2, 2, 1, 1],
+            [1, 2, 2, 2, 2, 2, 1],
+            [1, 2, 2, 2, 2, 2, 1],
+            [1, 2, 2, 2, 2, 2, 1],
+            [1, 1, 2, 2, 2, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1]], dtype=int8)
 
-    Here two markers were used to designate an object (*marker* = 2) and
-    the background (*marker* = 1). The order in which these are processed
-    is arbitrary: moving the marker for the background to the lower
-    right corner of the array yields a different result::
+  Here two markers were used to designate an object (*marker* = 2) and
+  the background (*marker* = 1). The order in which these are
+  processed is arbitrary: moving the marker for the background to the
+  lower right corner of the array yields a different result:
 
-        >>> markers = np.array([[0, 0, 0, 0, 0, 0, 0],
-        ...                     [0, 0, 0, 0, 0, 0, 0],
-        ...                     [0, 0, 0, 0, 0, 0, 0],
-        ...                     [0, 0, 0, 2, 0, 0, 0],
-        ...                     [0, 0, 0, 0, 0, 0, 0],
-        ...                     [0, 0, 0, 0, 0, 0, 0],
-        ...                     [0, 0, 0, 0, 0, 0, 1]], np.int8)
-        >>> watershed_ift(input, markers)
-        array([[1, 1, 1, 1, 1, 1, 1],
-               [1, 1, 1, 1, 1, 1, 1],
-               [1, 1, 2, 2, 2, 1, 1],
-               [1, 1, 2, 2, 2, 1, 1],
-               [1, 1, 2, 2, 2, 1, 1],
-               [1, 1, 1, 1, 1, 1, 1],
-               [1, 1, 1, 1, 1, 1, 1]], dtype=int8)
+  .. code:: python
 
-    The result is that the object (*marker* = 2) is smaller because the
-    second marker was processed earlier. This may not be the desired
-    effect if the first marker was supposed to designate a background
-    object. Therefore :func:`watershed_ift` treats markers with a negative
-    value explicitly as background markers and processes them after the
-    normal markers. For instance, replacing the first marker by a
-    negative marker gives a result similar to the first example::
+     >>> markers = np.array([[0, 0, 0, 0, 0, 0, 0],
+     ...                     [0, 0, 0, 0, 0, 0, 0],
+     ...                     [0, 0, 0, 0, 0, 0, 0],
+     ...                     [0, 0, 0, 2, 0, 0, 0],
+     ...                     [0, 0, 0, 0, 0, 0, 0],
+     ...                     [0, 0, 0, 0, 0, 0, 0],
+     ...                     [0, 0, 0, 0, 0, 0, 1]], np.int8)
+     >>> watershed_ift(input, markers)
+     array([[1, 1, 1, 1, 1, 1, 1],
+	    [1, 1, 1, 1, 1, 1, 1],
+	    [1, 1, 2, 2, 2, 1, 1],
+	    [1, 1, 2, 2, 2, 1, 1],
+            [1, 1, 2, 2, 2, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1]], dtype=int8)
 
-        >>> markers = np.array([[0, 0, 0, 0, 0, 0, 0],
-        ...                     [0, 0, 0, 0, 0, 0, 0],
-        ...                     [0, 0, 0, 0, 0, 0, 0],
-        ...                     [0, 0, 0, 2, 0, 0, 0],
-        ...                     [0, 0, 0, 0, 0, 0, 0],
-        ...                     [0, 0, 0, 0, 0, 0, 0],
-        ...                     [0, 0, 0, 0, 0, 0, -1]], np.int8)
-        >>> watershed_ift(input, markers)
-        array([[-1, -1, -1, -1, -1, -1, -1],
-               [-1, -1,  2,  2,  2, -1, -1],
-               [-1,  2,  2,  2,  2,  2, -1],
-               [-1,  2,  2,  2,  2,  2, -1],
-               [-1,  2,  2,  2,  2,  2, -1],
-               [-1, -1,  2,  2,  2, -1, -1],
-               [-1, -1, -1, -1, -1, -1, -1]], dtype=int8)
+  The result is that the object (*marker* = 2) is smaller because the
+  second marker was processed earlier. This may not be the desired
+  effect if the first marker was supposed to designate a background
+  object. Therefore :func:`watershed_ift` treats markers with a
+  negative value explicitly as background markers and processes them
+  after the normal markers. For instance, replacing the first marker
+  by a negative marker gives a result similar to the first example:
 
-    The connectivity of the objects is defined by a structuring
-    element. If no structuring element is provided, one is generated by
-    calling :func:`generate_binary_structure` (see
-    :ref:`ndimage-binary-morphology`) using a connectivity of one
-    (which in 2D is a 4-connected structure.) For example, using
-    an 8-connected structure with the last example yields a different object::
+  .. code:: python
 
-        >>> watershed_ift(input, markers,
-        ...               structure = [[1,1,1], [1,1,1], [1,1,1]])
-        array([[-1, -1, -1, -1, -1, -1, -1],
-               [-1,  2,  2,  2,  2,  2, -1],
-               [-1,  2,  2,  2,  2,  2, -1],
-               [-1,  2,  2,  2,  2,  2, -1],
-               [-1,  2,  2,  2,  2,  2, -1],
-               [-1,  2,  2,  2,  2,  2, -1],
-               [-1, -1, -1, -1, -1, -1, -1]], dtype=int8)
+     >>> markers = np.array([[0, 0, 0, 0, 0, 0, 0],
+     ...                     [0, 0, 0, 0, 0, 0, 0],
+     ...                     [0, 0, 0, 0, 0, 0, 0],
+     ...                     [0, 0, 0, 2, 0, 0, 0],
+     ...                     [0, 0, 0, 0, 0, 0, 0],
+     ...                     [0, 0, 0, 0, 0, 0, 0],
+     ...                     [0, 0, 0, 0, 0, 0, -1]], np.int8)
+     >>> watershed_ift(input, markers)
+     array([[-1, -1, -1, -1, -1, -1, -1],
+	    [-1, -1,  2,  2,  2, -1, -1],
+	    [-1,  2,  2,  2,  2,  2, -1],
+	    [-1,  2,  2,  2,  2,  2, -1],
+            [-1,  2,  2,  2,  2,  2, -1],
+            [-1, -1,  2,  2,  2, -1, -1],
+            [-1, -1, -1, -1, -1, -1, -1]], dtype=int8)
 
-    .. note:: The implementation of :func:`watershed_ift` limits the data types of the input to :ctype:`UInt8` and :ctype:`UInt16`.
+  The connectivity of the objects is defined by a structuring
+  element. If no structuring element is provided, one is generated by
+  calling :func:`generate_binary_structure` (see
+  :ref:`ndimage-binary-morphology`) using a connectivity of one (which
+  in 2D is a 4-connected structure.) For example, using an 8-connected
+  structure with the last example yields a different object:
 
+  .. code:: python
+
+     >>> watershed_ift(input, markers,
+     ...               structure = [[1,1,1], [1,1,1], [1,1,1]])
+     array([[-1, -1, -1, -1, -1, -1, -1],
+	    [-1,  2,  2,  2,  2,  2, -1],
+            [-1,  2,  2,  2,  2,  2, -1],
+            [-1,  2,  2,  2,  2,  2, -1],
+            [-1,  2,  2,  2,  2,  2, -1],
+            [-1,  2,  2,  2,  2,  2, -1],
+            [-1, -1, -1, -1, -1, -1, -1]], dtype=int8)
+
+  .. note::
+
+     The implementation of :func:`watershed_ift` limits the data types
+     of the input to :ctype:`UInt8` and :ctype:`UInt16`.
 
 .. _ndimage-object-measurements:
 
 Object measurements
 -------------------
 
-.. currentmodule:: scipy.ndimage.measurements
-
 Given an array of labeled objects, the properties of the individual
 objects can be measured. The :func:`find_objects` function can be used
 to generate a list of slices that for each object, give the
 smallest sub-array that fully contains the object:
 
-    The :func:`find_objects` function finds all objects in a labeled array and
-    returns a list of slices that correspond to the smallest regions in
-    the array that contains the object. For instance::
+- The :func:`find_objects` function finds all objects in a labeled
+  array and returns a list of slices that correspond to the smallest
+  regions in the array that contains the object.
 
-        >>> a = np.array([[0,1,1,0,0,0],[0,1,1,0,1,0],[0,0,0,1,1,1],[0,0,0,0,1,0]])
-        >>> l, n = label(a)
-        >>> from scipy.ndimage import find_objects
-        >>> f = find_objects(l)
-        >>> a[f[0]]
-        array([[1, 1],
-               [1, 1]])
-        >>> a[f[1]]
-        array([[0, 1, 0],
-               [1, 1, 1],
-               [0, 1, 0]])
+  For instance:
 
-    :func:`find_objects` returns slices for all objects, unless the
-    *max_label* parameter is larger then zero, in which case only the
-    first *max_label* objects are returned. If an index is missing in
-    the *label* array, None is return instead of a slice. For
-    example::
+  .. code:: python
 
-        >>> from scipy.ndimage import find_objects
-        >>> find_objects([1, 0, 3, 4], max_label = 3)
-        [(slice(0, 1, None),), None, (slice(2, 3, None),)]
+     >>> a = np.array([[0,1,1,0,0,0],[0,1,1,0,1,0],[0,0,0,1,1,1],[0,0,0,0,1,0]])
+     >>> l, n = label(a)
+     >>> from scipy.ndimage import find_objects
+     >>> f = find_objects(l)
+     >>> a[f[0]]
+     array([[1, 1],
+	    [1, 1]])
+     >>> a[f[1]]
+     array([[0, 1, 0],
+	    [1, 1, 1],
+	    [0, 1, 0]])
 
+  The function :func:`find_objects` returns slices for all objects,
+  unless the *max_label* parameter is larger then zero, in which case
+  only the first *max_label* objects are returned. If an index is
+  missing in the *label* array, ``None`` is return instead of a
+  slice. For example:
+
+  .. code:: python
+
+     >>> from scipy.ndimage import find_objects
+     >>> find_objects([1, 0, 3, 4], max_label = 3)
+     [(slice(0, 1, None),), None, (slice(2, 3, None),)]
 
 The list of slices generated by :func:`find_objects` is useful to find
-the position and dimensions of the objects in the array, but can
-also be used to perform measurements on the individual objects. Say
-we want to find the sum of the intensities of an object in image::
+the position and dimensions of the objects in the array, but can also
+be used to perform measurements on the individual objects. Say we want
+to find the sum of the intensities of an object in image:
 
-    >>> image = np.arange(4 * 6).reshape(4, 6)
-    >>> mask = np.array([[0,1,1,0,0,0],[0,1,1,0,1,0],[0,0,0,1,1,1],[0,0,0,0,1,0]])
-    >>> labels = label(mask)[0]
-    >>> slices = find_objects(labels)
+.. code:: python
 
-Then we can calculate the sum of the elements in the second
-object::
+   >>> image = np.arange(4 * 6).reshape(4, 6)
+   >>> mask = np.array([[0,1,1,0,0,0],[0,1,1,0,1,0],[0,0,0,1,1,1],[0,0,0,0,1,0]])
+   >>> labels = label(mask)[0]
+   >>> slices = find_objects(labels)
 
-    >>> np.where(labels[slices[1]] == 2, image[slices[1]], 0).sum()
-    80
+Then we can calculate the sum of the elements in the second object:
+
+.. code:: python
+
+   >>> np.where(labels[slices[1]] == 2, image[slices[1]], 0).sum()
+   80
 
 That is however not particularly efficient, and may also be more
 complicated for other types of measurements. Therefore a few
 measurements functions are defined that accept the array of object
 labels and the index of the object to be measured. For instance
-calculating the sum of the intensities can be done by::
+calculating the sum of the intensities can be done by:
 
-    >>> from scipy.ndimage import sum as ndi_sum
-    >>> ndi_sum(image, labels, 2)
-    80
+.. code:: python
+
+   >>> from scipy.ndimage import sum as ndi_sum
+   >>> ndi_sum(image, labels, 2)
+   80
 
 For large arrays and small objects it is more efficient to call the
-measurement functions after slicing the array::
+measurement functions after slicing the array:
 
-    >>> ndi_sum(image[slices[1]], labels[slices[1]], 2)
-    80
+.. code:: python
 
-Alternatively, we can do the measurements for a number of labels
-with a single function call, returning a list of results. For
-instance, to measure the sum of the values of the background and
-the second object in our example we give a list of labels::
+   >>> ndi_sum(image[slices[1]], labels[slices[1]], 2)
+   80
 
-    >>> ndi_sum(image, labels, [0, 2])
-    array([178.0, 80.0])
+Alternatively, we can do the measurements for a number of labels with
+a single function call, returning a list of results. For instance, to
+measure the sum of the values of the background and the second object
+in our example we give a list of labels:
+
+.. code:: python
+
+   >>> ndi_sum(image, labels, [0, 2])
+   array([178.0, 80.0])
 
 The measurement functions described below all support the *index*
-parameter to indicate which object(s) should be measured. The
-default value of *index* is None. This indicates that all
-elements where the label is larger than zero should be treated as a
-single object and measured. Thus, in this case the *labels* array
-is treated as a mask defined by the elements that are larger than
-zero. If *index* is a number or a sequence of numbers it gives the
-labels of the objects that are measured. If *index* is a sequence,
-a list of the results is returned. Functions that return more than
-one result, return their result as a tuple if *index* is a single
-number, or as a tuple of lists, if *index* is a sequence.
+parameter to indicate which object(s) should be measured. The default
+value of *index* is None. This indicates that all elements where the
+label is larger than zero should be treated as a single object and
+measured. Thus, in this case the *labels* array is treated as a mask
+defined by the elements that are larger than zero. If *index* is a
+number or a sequence of numbers it gives the labels of the objects
+that are measured. If *index* is a sequence, a list of the results is
+returned. Functions that return more than one result, return their
+result as a tuple if *index* is a single number, or as a tuple of
+lists, if *index* is a sequence.
 
-    The :func:`sum` function calculates the sum of the elements of the object
-    with label(s) given by *index*, using the *labels* array for the
-    object labels. If *index* is None, all elements with a non-zero
-    label value are treated as a single object. If *label* is None,
-    all elements of *input* are used in the calculation.
+- The :func:`sum` function calculates the sum of the elements of the
+  object with label(s) given by *index*, using the *labels* array for
+  the object labels. If *index* is ``None``, all elements with a
+  non-zero label value are treated as a single object. If *label* is
+  ``None``, all elements of *input* are used in the calculation.
 
+- The :func:`mean` function calculates the mean of the elements of the
+  object with label(s) given by *index*, using the *labels* array for
+  the object labels. If *index* is ``None``, all elements with a
+  non-zero label value are treated as a single object. If *label* is
+  ``None``, all elements of *input* are used in the calculation.
 
-    The :func:`mean` function calculates the mean of the elements of the
-    object with label(s) given by *index*, using the *labels* array for
-    the object labels. If *index* is None, all elements with a
-    non-zero label value are treated as a single object. If *label* is
-    None, all elements of *input* are used in the calculation.
+- The :func:`variance` function calculates the variance of the
+  elements of the object with label(s) given by *index*, using the
+  *labels* array for the object labels. If *index* is ``None``, all
+  elements with a non-zero label value are treated as a single
+  object. If *label* is ``None``, all elements of *input* are used in
+  the calculation.
 
+- The :func:`standard_deviation` function calculates the standard
+  deviation of the elements of the object with label(s) given by
+  *index*, using the *labels* array for the object labels. If *index*
+  is ``None``, all elements with a non-zero label value are treated as
+  a single object. If *label* is ``None``, all elements of *input* are
+  used in the calculation.
 
-    The :func:`variance` function calculates the variance of the elements of
-    the object with label(s) given by *index*, using the *labels* array
-    for the object labels. If *index* is None, all elements with a
-    non-zero label value are treated as a single object. If *label* is
-    None, all elements of *input* are used in the calculation.
+- The :func:`minimum` function calculates the minimum of the elements
+  of the object with label(s) given by *index*, using the *labels*
+  array for the object labels. If *index* is ``None``, all elements
+  with a non-zero label value are treated as a single object. If
+  *label* is ``None``, all elements of *input* are used in the
+  calculation.
 
+- The :func:`maximum` function calculates the maximum of the elements
+  of the object with label(s) given by *index*, using the *labels*
+  array for the object labels. If *index* is ``None``, all elements
+  with a non-zero label value are treated as a single object. If
+  *label* is ``None``, all elements of *input* are used in the
+  calculation.
 
-    The :func:`standard_deviation` function calculates the standard
-    deviation of the elements of the object with label(s) given by
-    *index*, using the *labels* array for the object labels. If *index*
-    is None, all elements with a non-zero label value are treated as
-    a single object. If *label* is None, all elements of *input* are
-    used in the calculation.
+- The :func:`minimum_position` function calculates the position of the
+  minimum of the elements of the object with label(s) given by
+  *index*, using the *labels* array for the object labels. If *index*
+  is ``None``, all elements with a non-zero label value are treated as
+  a single object. If *label* is ``None``, all elements of *input* are
+  used in the calculation.
 
+- The :func:`maximum_position` function calculates the position of the
+  maximum of the elements of the object with label(s) given by
+  *index*, using the *labels* array for the object labels. If *index*
+  is ``None``, all elements with a non-zero label value are treated as
+  a single object. If *label* is ``None``, all elements of *input* are
+  used in the calculation.
 
-    The :func:`minimum` function calculates the minimum of the elements of
-    the object with label(s) given by *index*, using the *labels* array
-    for the object labels. If *index* is None, all elements with a
-    non-zero label value are treated as a single object. If *label* is
-    None, all elements of *input* are used in the calculation.
+- The :func:`extrema` function calculates the minimum, the maximum,
+  and their positions, of the elements of the object with label(s)
+  given by *index*, using the *labels* array for the object labels. If
+  *index* is ``None``, all elements with a non-zero label value are
+  treated as a single object. If *label* is ``None``, all elements of
+  *input* are used in the calculation. The result is a tuple giving
+  the minimum, the maximum, the position of the minimum and the
+  position of the maximum. The result is the same as a tuple formed by
+  the results of the functions *minimum*, *maximum*,
+  *minimum_position*, and *maximum_position* that are described above.
 
+- The :func:`center_of_mass` function calculates the center of mass of
+  the of the object with label(s) given by *index*, using the *labels*
+  array for the object labels. If *index* is ``None``, all elements
+  with a non-zero label value are treated as a single object. If
+  *label* is ``None``, all elements of *input* are used in the
+  calculation.
 
-    The :func:`maximum` function calculates the maximum of the elements of
-    the object with label(s) given by *index*, using the *labels* array
-    for the object labels. If *index* is None, all elements with a
-    non-zero label value are treated as a single object. If *label* is
-    None, all elements of *input* are used in the calculation.
-
-
-    The :func:`minimum_position` function calculates the position of the
-    minimum of the elements of the object with label(s) given by
-    *index*, using the *labels* array for the object labels. If *index*
-    is None, all elements with a non-zero label value are treated as
-    a single object. If *label* is None, all elements of *input* are
-    used in the calculation.
-
-
-    The :func:`maximum_position` function calculates the position of the
-    maximum of the elements of the object with label(s) given by
-    *index*, using the *labels* array for the object labels. If *index*
-    is None, all elements with a non-zero label value are treated as
-    a single object. If *label* is None, all elements of *input* are
-    used in the calculation.
-
-
-    The :func:`extrema` function calculates the minimum, the maximum, and
-    their positions, of the elements of the object with label(s) given
-    by *index*, using the *labels* array for the object labels. If
-    *index* is None, all elements with a non-zero label value are
-    treated as a single object. If *label* is None, all elements of
-    *input* are used in the calculation. The result is a tuple giving
-    the minimum, the maximum, the position of the minimum and the
-    position of the maximum. The result is the same as a tuple formed
-    by the results of the functions *minimum*, *maximum*,
-    *minimum_position*, and *maximum_position* that are described
-    above.
-
-
-    The :func:`center_of_mass` function calculates the center of mass of
-    the of the object with label(s) given by *index*, using the
-    *labels* array for the object labels. If *index* is None, all
-    elements with a non-zero label value are treated as a single
-    object. If *label* is None, all elements of *input* are used in
-    the calculation.
-
-
-    The :func:`histogram` function calculates a histogram of the of the
-    object with label(s) given by *index*, using the *labels* array for
-    the object labels. If *index* is None, all elements with a
-    non-zero label value are treated as a single object. If *label* is
-    None, all elements of *input* are used in the calculation.
-    Histograms are defined by their minimum (*min*), maximum (*max*)
-    and the number of bins (*bins*). They are returned as
-    one-dimensional arrays of type :ctype:`Int32`.
-
+- The :func:`histogram` function calculates a histogram of the of the
+  object with label(s) given by *index*, using the *labels* array for
+  the object labels. If *index* is ``None``, all elements with a
+  non-zero label value are treated as a single object. If *label* is
+  ``None``, all elements of *input* are used in the calculation.
+  Histograms are defined by their minimum (*min*), maximum (*max*) and
+  the number of bins (*bins*). They are returned as one-dimensional
+  arrays of type :ctype:`Int32`.
 
 .. _ndimage-ccallbacks:
 
-Extending :py:mod:`~scipy.ndimage` in C
------------------------------
+Extending :mod:`scipy.ndimage` in C
+-----------------------------------
 
-A few functions in :py:mod:`~scipy.ndimage` take a callback
-argument. This can be either a python function or a :ctype:`PyCapsule`
-containing a pointer to a C function. Using a C function will
-generally be more efficient since it avoids the overhead of calling a
-python function on many elements of an array. To use a C function you
-must write a C extension that contains the callback function and a
-Python function that returns a :ctype:`PyCapsule` containing a pointer
-to the callback.
+A few functions in :mod:`scipy.ndimage` take a callback argument. This
+can be either a python function or a :ctype:`PyCapsule` containing a
+pointer to a C function. Using a C function will generally be more
+efficient since it avoids the overhead of calling a python function on
+many elements of an array. To use a C function you must write a C
+extension that contains the callback function and a Python function
+that returns a :ctype:`PyCapsule` containing a pointer to the
+callback.
 
 An example of a function that supports callbacks is
-:py:func:`~scipy.ndimage.geometric_transform`, which accepts a
-callback function that defines a mapping from all output coordinates
-to corresponding coordinates in the input array. Consider the
-following python example which uses
-:py:func:`~scipy.ndimage.geometric_transform` to implement a shift
-function.
+:func:`geometric_transform`, which accepts a callback function that
+defines a mapping from all output coordinates to corresponding
+coordinates in the input array. Consider the following python example
+which uses :func:`geometric_transform` to implement a shift function.
 
 .. code:: python
 
@@ -1602,7 +1642,7 @@ We can also implement the callback function with the following C code.
    static void _destructor(PyObject *obj)
    {
        void *callback_data = PyCapsule_GetContext(obj);
-       free(callback_data);
+       PyMem_Free(callback_data);
    }
 
 
@@ -1623,7 +1663,7 @@ We can also implement the callback function with the following C code.
    static PyObject *
    py_transform(PyObject *obj, PyObject *args)
    {
-       double *callback_data = malloc(sizeof(double));
+       double *callback_data = PyMem_Malloc(sizeof(double));
        PyObject *capsule = NULL;
 
        if (!callback_data) {
@@ -1637,7 +1677,7 @@ We can also implement the callback function with the following C code.
        if (PyCapsule_SetContext(capsule, callback_data) != 0) goto error;
        return capsule;
      error:
-       free(callback_data);
+       PyMem_Free(callback_data);
        Py_XDECREF(capsule);
        return NULL;
     }
@@ -1730,16 +1770,16 @@ The function ``py_transform`` wraps the callback function in a
   the callback function and the third argument is a destructor
   function which knows how to clean up memory associated with the
   capsule's context pointer (see next step). The second argument is
-  the name of the capsule, but as :py:mod:`~scipy.ndimage` has no way
-  of knowing that it is set to ``NULL``.
+  the name of the capsule, but as :mod:`ndimage` has no way of knowing
+  that it is set to ``NULL``.
+
 - Use :c:func:`PyCapsule_SetContext` to add any necessary data to the
   capsule. This data is passed to the callback function through
   ``callback_data``, and in our example is used to set ``shift``.
 
-C callback functions for :mod:`~scipy.ndimage` all follow this
-scheme. The next section lists the :mod:`~scipy.ndimage` functions
-that accept a C callback function and gives the prototype of the
-function.
+C callback functions for :mod:`ndimage` all follow this scheme. The
+next section lists the :mod:`ndimage` functions that accept a C
+callback function and gives the prototype of the function.
 
 Finally, the same code can be written in Cython with less
 overhead as follows.
@@ -1788,20 +1828,20 @@ overhead as follows.
 Functions that support C callback functions
 -------------------------------------------
 
-The :mod:`~scipy.ndimage` functions that support C callback functions
-are described here along with prototypes of the callback functions
-they expect. All callback functions must be wrapped in a
-:ctype:`PyCapsule` and accept a ``callback_data`` parameter which is
-set using :c:func:`PyCapsule_SetContext`. The capsule's destructor
-must know how to free memory associated with its context pointer. The
-callback functions must return an integer error status that is zero if
+The :mod:`ndimage` functions that support C callback functions are
+described here along with prototypes of the callback functions they
+expect. All callback functions must be wrapped in a :ctype:`PyCapsule`
+and accept a ``callback_data`` parameter which is set using
+:c:func:`PyCapsule_SetContext`. The capsule's destructor must know how
+to free memory associated with its context pointer. The callback
+functions must return an integer error status that is zero if
 something went wrong and one otherwise. If an error occurs, you should
 normally set the python error status with an informative message
 before returning, otherwise a default error message is set by the
 calling function.
 
-The function :py:func:`~scipy.ndimage.generic_filter` accepts a
-callback function with the following prototype:
+The function :func:`generic_filter` accepts a callback function with
+the following prototype:
 
 .. code:: c
 
@@ -1814,8 +1854,8 @@ passed through the ``buffer`` parameter, and the number of elements
 within the footprint through ``filter_size``. The calculated value is
 returned in ``return_value``.
 
-The function :py:func:`~scipy.ndimage.generic_filter1d` accepts a
-callback function with the following prototype:
+The function :func:`generic_filter1d` accepts a callback function with
+the following prototype:
 
 .. code:: c
 
@@ -1831,8 +1871,8 @@ the filter and store the result in the array passed through
 ``output_line``. The length of the output line is passed through
 ``output_length``.
 
-The function :py:func:`~scipy.ndimage.geometric_transform` expects a
-function with the following prototype:
+The function :func:`geometric_transform` expects a function with the
+following prototype:
 
 .. code:: c
 
@@ -1845,3 +1885,22 @@ callback function must return the coordinates at which the input must
 be interpolated in ``input_coordinates``. The rank of the input and
 output arrays are given by ``input_rank`` and ``output_rank``
 respectively.
+
+.. rubric:: References
+
+.. [1] M. Unser, "Splines: A Perfect Fit for Signal and Image
+       Processing," IEEE Signal Processing Magazine, vol. 16, no. 6, pp.
+       22-38, November 1999.
+
+.. [2] G. Borgefors, "Distance transformations in arbitrary
+       dimensions.", Computer Vision, Graphics, and Image Processing,
+       27:321-345, 1984.
+
+.. [3] C. R. Maurer, Jr., R. Qi, and V. Raghavan, "A linear time
+       algorithm for computing exact euclidean distance transforms of
+       binary images in arbitrary dimensions. IEEE Trans. PAMI 25,
+       265-270, 2003.
+
+.. [4] P. Felkel, R. Wegenkittl, and M. Bruckschwaiger,
+       "Implementation and Complexity of the Watershed-from-Markers Algorithm
+       Computed as a Minimal Cost Forest.", Eurographics 2001, pp. C:26-35.

--- a/doc/source/tutorial/ndimage.rst
+++ b/doc/source/tutorial/ndimage.rst
@@ -1638,6 +1638,7 @@ We can also implement the callback function with the following C code.
        return capsule;
      error:
        free(callback_data);
+       Py_XDECREF(capsule);
        return NULL;
     }
 

--- a/scipy/ndimage/setup.py
+++ b/scipy/ndimage/setup.py
@@ -14,23 +14,19 @@ def configuration(parent_package='', top_path=None):
                  "src/ni_fourier.c","src/ni_interpolation.c",
                  "src/ni_measure.c",
                  "src/ni_morphology.c","src/ni_support.c"],
-        include_dirs=['src']+[get_include()],
-    )
+        include_dirs=['src']+[get_include()])
 
     # Cython wants the .c and .pyx to have the underscore.
     config.add_extension("_ni_label",
                          sources=["src/_ni_label.c",],
-                         include_dirs=['src']+[get_include()],
-    )
+                         include_dirs=['src']+[get_include()])
 
     config.add_extension("_ctest",
                          sources=["src/_ctest.c"],
-                         include_dirs=[get_include()],
-    )
+                         include_dirs=[get_include()])
 
     config.add_extension("_cytest",
-                         sources=["src/_cytest.c"],
-    )
+                         sources=["src/_cytest.c"])
     
     config.add_data_dir('tests')
 

--- a/scipy/ndimage/setup.py
+++ b/scipy/ndimage/setup.py
@@ -21,8 +21,13 @@ def configuration(parent_package='', top_path=None):
     config.add_extension("_ni_label",
                          sources=["src/_ni_label.c",],
                          include_dirs=['src']+[get_include()],
-                         )
+    )
 
+    config.add_extension("_ctest",
+                         sources=["src/_ctest.c"],
+                         include_dirs=[get_include()],
+    )
+    
     config.add_data_dir('tests')
 
     return config

--- a/scipy/ndimage/setup.py
+++ b/scipy/ndimage/setup.py
@@ -27,6 +27,10 @@ def configuration(parent_package='', top_path=None):
                          sources=["src/_ctest.c"],
                          include_dirs=[get_include()],
     )
+
+    config.add_extension("_cytest",
+                         sources=["src/_cytest.c"],
+    )
     
     config.add_data_dir('tests')
 

--- a/scipy/ndimage/setup.py
+++ b/scipy/ndimage/setup.py
@@ -25,6 +25,11 @@ def configuration(parent_package='', top_path=None):
                          sources=["src/_ctest.c"],
                          include_dirs=[get_include()])
 
+    config.add_extension("_ctest_oldapi",
+                         sources=["src/_ctest.c"],
+                         include_dirs=[get_include()],
+                         define_macros=[("OLDAPI", 1)])
+
     config.add_extension("_cytest",
                          sources=["src/_cytest.c"])
     

--- a/scipy/ndimage/src/_ctest.c
+++ b/scipy/ndimage/src/_ctest.c
@@ -19,7 +19,7 @@
 static void
 _destructor(void *cobject, void *callback_data)
 {
-    free(callback_data);
+    PyMem_Free(callback_data);
 }    
 
 
@@ -28,7 +28,7 @@ static void
 _destructor(PyObject *obj)
 {
     void *callback_data = PyCapsule_GetContext(obj);
-    free(callback_data);
+    PyMem_Free(callback_data);
 }
 #endif
 
@@ -57,7 +57,7 @@ py_filter1d(PyObject *obj, PyObject *args)
     npy_intp *callback_data = NULL;
     PyObject *capsule = NULL;
     
-    callback_data = malloc(sizeof(npy_intp));
+    callback_data = PyMem_Malloc(sizeof(npy_intp));
     if (!callback_data) {
 	PyErr_NoMemory();
 	goto error;
@@ -77,7 +77,7 @@ py_filter1d(PyObject *obj, PyObject *args)
 #endif
     return capsule;
  error:
-    free(callback_data);
+    PyMem_Free(callback_data);
     return NULL;
 }
 
@@ -108,7 +108,7 @@ py_filter2d(PyObject *obj, PyObject *args)
     
     size = PySequence_Length(seq);
     if (size == -1) goto error;
-    callback_data = malloc(size*sizeof(double));
+    callback_data = PyMem_Malloc(size*sizeof(double));
     if (!callback_data) {
 	PyErr_NoMemory();
 	goto error;
@@ -137,7 +137,7 @@ py_filter2d(PyObject *obj, PyObject *args)
 #endif
     return capsule;
  error:
-    free(callback_data);
+    PyMem_Free(callback_data);
     return NULL;
 }
 
@@ -159,7 +159,7 @@ _transform(npy_intp *output_coordinates, double *input_coordinates,
 static PyObject *
 py_transform(PyObject *obj, PyObject *args)
 {
-    double *callback_data = malloc(sizeof(double));
+    double *callback_data = PyMem_Malloc(sizeof(double));
     PyObject *capsule = NULL;
 
     if (!callback_data) {
@@ -181,7 +181,7 @@ py_transform(PyObject *obj, PyObject *args)
 #endif
     return capsule;
  error:
-    free(callback_data);
+    PyMem_Free(callback_data);
     return NULL;
 }
 

--- a/scipy/ndimage/src/_ctest.c
+++ b/scipy/ndimage/src/_ctest.c
@@ -1,0 +1,178 @@
+#include <Python.h>
+#include <numpy/npy_common.h>
+
+
+static void _destructor(PyObject *obj)
+{
+    void *callback_data = PyCapsule_GetContext(obj);
+
+    free(callback_data);
+}
+
+
+static int
+_filter1d(double *input_line, npy_intp input_length, double *output_line,
+	  npy_intp output_length, void *callback_data)
+{
+    npy_intp i, j;
+    npy_intp filter_size = *(npy_intp *)callback_data;
+
+    for (i = 0; i < output_length; i++) {
+	output_line[i] = 0;
+	for (j = 0; j < filter_size; j++) {
+	    output_line[i] += input_line[i+j];
+	}
+	output_line[i] /= filter_size;
+    }
+    return 1;
+}
+
+
+static PyObject *
+py_filter1d(PyObject *obj, PyObject *args)
+{
+    npy_intp *callback_data = NULL;
+    PyObject *capsule = NULL;
+    
+    callback_data = malloc(sizeof(npy_intp));
+    if (!callback_data) {
+	PyErr_NoMemory();
+	goto error;
+    }
+    if (!PyArg_ParseTuple(args, "n", callback_data)) goto error;
+
+    capsule = PyCapsule_New(_filter1d, NULL, _destructor);
+    if (!capsule) goto error;
+    if (PyCapsule_SetContext(capsule, callback_data) != 0) goto error;
+    return capsule;
+ error:
+    free(callback_data);
+    return NULL;
+}
+
+
+static int
+_filter2d(double *buffer, npy_intp filter_size, double *res,
+	  void *callback_data)
+{
+    npy_intp i;
+    double *weights = (double *)callback_data;
+
+    *res = 0;
+    for (i = 0; i < filter_size; i++) {
+	*res += weights[i]*buffer[i];
+    }
+    return 1;
+}
+
+
+static PyObject *
+py_filter2d(PyObject *obj, PyObject *args)
+{
+    Py_ssize_t i, size;
+    double *callback_data = NULL;
+    PyObject *seq = NULL, *item = NULL, *capsule = NULL;
+
+    if (!PyArg_ParseTuple(args, "O", &seq)) goto error;
+    
+    size = PySequence_Length(seq);
+    if (size == -1) goto error;
+    callback_data = malloc(size*sizeof(double));
+    if (!callback_data) {
+	PyErr_NoMemory();
+	goto error;
+    }
+
+    for (i = 0; i < size; i++) {
+	item = PySequence_GetItem(seq, i);
+	if (!item) {
+	    PyErr_SetString(PyExc_IndexError, "failed to get item");
+	    goto error;
+	}
+	callback_data[i] = PyFloat_AsDouble(item);
+	if (PyErr_Occurred()) goto error;
+    }
+    
+    capsule = PyCapsule_New(_filter2d, NULL, _destructor);
+    if (!capsule) goto error;
+    if (PyCapsule_SetContext(capsule, callback_data) != 0) goto error;
+    return capsule;
+ error:
+    free(callback_data);
+    return NULL;
+}
+
+
+static int
+_transform(npy_intp *output_coordinates, double *input_coordinates,
+	   npy_intp output_rank, npy_intp input_rank, void *callback_data)
+{
+    npy_intp i;
+    double shift = *(double *)callback_data;
+
+    for (i = 0; i < input_rank; i++) {
+	input_coordinates[i] = output_coordinates[i] - shift;
+    }
+    return 1;
+}
+
+
+static PyObject *
+py_transform(PyObject *obj, PyObject *args)
+{
+    double *callback_data = malloc(sizeof(double));
+    PyObject *capsule = NULL;
+
+    if (!callback_data) {
+	PyErr_NoMemory();
+	goto error;
+    }
+    if (!PyArg_ParseTuple(args, "d", callback_data)) goto error;
+
+    capsule = PyCapsule_New(_transform, NULL, _destructor);
+    if (!capsule) goto error;
+    if (PyCapsule_SetContext(capsule, callback_data) != 0) goto error;
+    return capsule;
+ error:
+    free(callback_data);
+    return NULL;
+}
+
+
+static PyMethodDef _CTestMethods[] = {
+    {"transform", (PyCFunction)py_transform, METH_VARARGS, ""},
+    {"filter1d", (PyCFunction)py_filter1d, METH_VARARGS, ""},
+    {"filter2d", (PyCFunction)py_filter2d, METH_VARARGS, ""},
+    {NULL, NULL, 0, NULL}
+};
+				      
+				      
+/* Initialize the module */
+#if PY_VERSION_HEX >= 0x03000000
+static struct PyModuleDef _ctest = {
+    PyModuleDef_HEAD_INIT,
+    "_ctest",
+    NULL,
+    -1,
+    _CTestMethods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+
+PyMODINIT_FUNC
+PyInit__ctest(void)
+{
+    return PyModule_Create(&_ctest);
+}
+
+
+#else
+PyMODINIT_FUNC
+init_ctest(void)
+{
+    Py_InitModule("_ctest", _CTestMethods);
+}
+#endif

--- a/scipy/ndimage/src/_cytest.pyx
+++ b/scipy/ndimage/src/_cytest.pyx
@@ -1,0 +1,72 @@
+from libc.stdlib cimport malloc, free
+from cpython.pycapsule cimport (
+    PyCapsule_New, PyCapsule_SetContext, PyCapsule_GetContext
+)
+
+cimport numpy as np
+from numpy cimport npy_intp as intp
+
+
+cdef void _destructor(obj):
+    cdef void *callback_data = PyCapsule_GetContext(obj)
+    free(callback_data)
+
+
+cdef int _filter1d(double *input_line, intp input_length, double *output_line,
+	           intp output_length, void *callback_data):
+    cdef intp i, j
+    cdef intp filter_size = (<intp *>callback_data)[0]
+
+    for i in range(output_length):
+        output_line[i] = 0
+        for j in range(filter_size):
+            output_line[i] += input_line[i+j]
+        output_line[i] /= filter_size
+    return 1
+    
+
+def filter1d(intp filter_size):
+    cdef intp *callback_data = <intp *>malloc(sizeof(intp))
+    callback_data[0] = filter_size
+    capsule = PyCapsule_New(<void *>_filter1d, NULL, _destructor)
+    PyCapsule_SetContext(capsule, callback_data)
+    return capsule
+
+
+cdef int _filter2d(double *buffer, intp filter_size, double *res,
+	           void *callback_data):
+    cdef intp i
+    cdef double *weights = <double *>callback_data
+
+    res[0] = 0
+    for i in range(filter_size):
+        res[0] += weights[i]*buffer[i]
+    return 1
+    
+    
+def filter2d(seq):
+    cdef double *callback_data = <double *>malloc(len(seq)*sizeof(double))
+    for i, item in enumerate(seq):
+        callback_data[i] = float(item)
+
+    capsule = PyCapsule_New(<void *>_filter2d, NULL, _destructor)
+    PyCapsule_SetContext(capsule, callback_data)
+    return capsule
+
+
+cdef int _transform(intp *output_coordinates, double *input_coordinates,
+	            intp output_rank, intp input_rank, void *callback_data):
+    cdef intp i
+    cdef double shift = (<double *>callback_data)[0]
+
+    for i in range(input_rank):
+        input_coordinates[i] = output_coordinates[i] - shift
+    return 1
+
+
+def transform(double shift):
+    cdef double *callback_data = <double *>malloc(sizeof(double))
+    callback_data[0] = shift
+    capsule = PyCapsule_New(<void *>_transform, NULL, _destructor)
+    PyCapsule_SetContext(capsule, callback_data)
+    return capsule

--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -337,6 +337,14 @@ static PyObject *Py_GenericFilter1D(PyObject *obj, PyObject *args)
     if (PyCapsule_CheckExact(fnc)) {
         func = PyCapsule_GetPointer(fnc, NULL);
         data = PyCapsule_GetContext(fnc);
+    } else if (NpyCapsule_Check(fnc)) {
+	/*
+	 * NpyCapsules are PyCObjects in Py2k and PyCapsules in Py3k,
+	 * so this check is redundant in Py3k but lets the user pass
+	 * in PyCObects in Py2k.
+	 */
+	func = NpyCapsule_AsVoidPtr(fnc);
+	data = NpyCapsule_GetDesc(fnc);
     } else if (PyCallable_Check(fnc)) {
         cbdata.function = fnc;
         cbdata.extra_arguments = extra_arguments;
@@ -415,6 +423,14 @@ static PyObject *Py_GenericFilter(PyObject *obj, PyObject *args)
     if (PyCapsule_CheckExact(fnc)) {
         func = PyCapsule_GetPointer(fnc, NULL);
         data = PyCapsule_GetContext(fnc);
+    } else if (NpyCapsule_Check(fnc)) {
+	/*
+	 * NpyCapsules are PyCObjects in Py2k and PyCapsules in Py3k,
+	 * so this check is redundant in Py3k but lets the user pass
+	 * in PyCObects in Py2k.
+	 */
+	func = NpyCapsule_AsVoidPtr(fnc);
+	data = NpyCapsule_GetDesc(fnc);
     } else if (PyCallable_Check(fnc)) {
         cbdata.function = fnc;
         cbdata.extra_arguments = extra_arguments;
@@ -576,6 +592,14 @@ static PyObject *Py_GeometricTransform(PyObject *obj, PyObject *args)
         if (PyCapsule_CheckExact(fnc)) {
 	    func = PyCapsule_GetPointer(fnc, NULL);
             data = PyCapsule_GetContext(fnc);
+	} else if (NpyCapsule_Check(fnc)) {
+	    /*
+	     * NpyCapsules are PyCObjects in Py2k and PyCapsules in Py3k,
+	     * so this check is redundant in Py3k but lets the user pass
+	     * in PyCObects in Py2k.
+	     */
+	    func = NpyCapsule_AsVoidPtr(fnc);
+	    data = NpyCapsule_GetDesc(fnc);
         } else if (PyCallable_Check(fnc)) {
             func = Py_Map;
             cbdata.function = fnc;

--- a/scipy/ndimage/src/nd_image.c
+++ b/scipy/ndimage/src/nd_image.c
@@ -334,9 +334,9 @@ static PyObject *Py_GenericFilter1D(PyObject *obj, PyObject *args)
                                         "extra_keywords must be a dictionary");
         goto exit;
     }
-    if (NpyCapsule_Check(fnc)) {
-        func = NpyCapsule_AsVoidPtr(fnc);
-        data = NpyCapsule_GetDesc(fnc);
+    if (PyCapsule_CheckExact(fnc)) {
+        func = PyCapsule_GetPointer(fnc, NULL);
+        data = PyCapsule_GetContext(fnc);
     } else if (PyCallable_Check(fnc)) {
         cbdata.function = fnc;
         cbdata.extra_arguments = extra_arguments;
@@ -412,9 +412,9 @@ static PyObject *Py_GenericFilter(PyObject *obj, PyObject *args)
                                         "extra_keywords must be a dictionary");
         goto exit;
     }
-    if (NpyCapsule_Check(fnc)) {
-        func = NpyCapsule_AsVoidPtr(fnc);
-        data = NpyCapsule_GetDesc(fnc);
+    if (PyCapsule_CheckExact(fnc)) {
+        func = PyCapsule_GetPointer(fnc, NULL);
+        data = PyCapsule_GetContext(fnc);
     } else if (PyCallable_Check(fnc)) {
         cbdata.function = fnc;
         cbdata.extra_arguments = extra_arguments;
@@ -573,9 +573,9 @@ static PyObject *Py_GeometricTransform(PyObject *obj, PyObject *args)
                                             "extra_keywords must be a dictionary");
             goto exit;
         }
-        if (NpyCapsule_Check(fnc)) {
-            func = NpyCapsule_AsVoidPtr(fnc);
-            data = NpyCapsule_GetDesc(fnc);
+        if (PyCapsule_CheckExact(fnc)) {
+	    func = PyCapsule_GetPointer(fnc, NULL);
+            data = PyCapsule_GetContext(fnc);
         } else if (PyCallable_Check(fnc)) {
             func = Py_Map;
             cbdata.function = fnc;

--- a/scipy/ndimage/tests/test_c_api.py
+++ b/scipy/ndimage/tests/test_c_api.py
@@ -5,9 +5,10 @@ from numpy.testing import assert_allclose
 
 from scipy import ndimage
 from scipy.ndimage import _ctest
+from scipy.ndimage import _ctest_oldapi
 from scipy.ndimage import _cytest
 
-MODULES = [_ctest, _cytest]
+MODULES = [_ctest, _ctest_oldapi, _cytest]
 
 
 def test_generic_filter():

--- a/scipy/ndimage/tests/test_c_api.py
+++ b/scipy/ndimage/tests/test_c_api.py
@@ -1,0 +1,51 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from scipy import ndimage
+from scipy.ndimage import _ctest
+
+
+def test_generic_filter():
+    def filter2d(footprint_elements, weights):
+        return (weights*footprint_elements).sum()
+
+    im = np.ones((20, 20))
+    im[:10,:10] = 0
+    footprint = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])
+    footprint_size = np.count_nonzero(footprint)
+    weights = np.full(footprint_size, 1/footprint_size)
+    res = ndimage.generic_filter(im, _ctest.filter2d(weights),
+                                 footprint=footprint)
+    std = ndimage.generic_filter(im, filter2d, footprint=footprint,
+                                 extra_arguments=(weights,))
+    assert_allclose(res, std)
+
+
+def test_generic_filter1d():
+    def filter1d(input_line, output_line, filter_size):
+        for i in range(output_line.size):
+            output_line[i] = 0
+            for j in range(filter_size):
+                output_line[i] += input_line[i+j]
+        output_line /= filter_size
+
+    im = np.tile(np.hstack((np.zeros(10), np.ones(10))), (10, 1))
+    filter_size = 3
+    res = ndimage.generic_filter1d(im, _ctest.filter1d(filter_size),
+                                   filter_size)
+    std = ndimage.generic_filter1d(im, filter1d, filter_size,
+                                   extra_arguments=(filter_size,))
+    assert_allclose(res, std)
+
+
+def test_geometric_transform():
+    def transform(output_coordinates, shift):
+        return output_coordinates[0] - shift, output_coordinates[1] - shift
+
+    im = np.arange(12).reshape(4, 3).astype(np.float64)
+    shift = 0.5
+    res = ndimage.geometric_transform(im, _ctest.transform(shift))
+    std = ndimage.geometric_transform(im, transform, extra_arguments=(shift,))
+    assert_allclose(res, std)

--- a/scipy/ndimage/tests/test_c_api.py
+++ b/scipy/ndimage/tests/test_c_api.py
@@ -18,7 +18,7 @@ def test_generic_filter():
     im[:10,:10] = 0
     footprint = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])
     footprint_size = np.count_nonzero(footprint)
-    weights = np.full(footprint_size, 1/footprint_size)
+    weights = np.ones(footprint_size)/footprint_size
     for mod in MODULES:
         res = ndimage.generic_filter(im, mod.filter2d(weights),
                                      footprint=footprint)

--- a/scipy/ndimage/tests/test_c_api.py
+++ b/scipy/ndimage/tests/test_c_api.py
@@ -5,6 +5,9 @@ from numpy.testing import assert_allclose
 
 from scipy import ndimage
 from scipy.ndimage import _ctest
+from scipy.ndimage import _cytest
+
+MODULES = [_ctest, _cytest]
 
 
 def test_generic_filter():
@@ -16,11 +19,12 @@ def test_generic_filter():
     footprint = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])
     footprint_size = np.count_nonzero(footprint)
     weights = np.full(footprint_size, 1/footprint_size)
-    res = ndimage.generic_filter(im, _ctest.filter2d(weights),
-                                 footprint=footprint)
-    std = ndimage.generic_filter(im, filter2d, footprint=footprint,
-                                 extra_arguments=(weights,))
-    assert_allclose(res, std)
+    for mod in MODULES:
+        res = ndimage.generic_filter(im, mod.filter2d(weights),
+                                     footprint=footprint)
+        std = ndimage.generic_filter(im, filter2d, footprint=footprint,
+                                     extra_arguments=(weights,))
+        assert_allclose(res, std, err_msg="{} failed".format(mod.__name__))
 
 
 def test_generic_filter1d():
@@ -33,11 +37,12 @@ def test_generic_filter1d():
 
     im = np.tile(np.hstack((np.zeros(10), np.ones(10))), (10, 1))
     filter_size = 3
-    res = ndimage.generic_filter1d(im, _ctest.filter1d(filter_size),
-                                   filter_size)
-    std = ndimage.generic_filter1d(im, filter1d, filter_size,
-                                   extra_arguments=(filter_size,))
-    assert_allclose(res, std)
+    for mod in MODULES:
+        res = ndimage.generic_filter1d(im, mod.filter1d(filter_size),
+                                       filter_size)
+        std = ndimage.generic_filter1d(im, filter1d, filter_size,
+                                       extra_arguments=(filter_size,))
+        assert_allclose(res, std, err_msg="{} failed".format(mod.__name__))
 
 
 def test_geometric_transform():
@@ -46,6 +51,7 @@ def test_geometric_transform():
 
     im = np.arange(12).reshape(4, 3).astype(np.float64)
     shift = 0.5
-    res = ndimage.geometric_transform(im, _ctest.transform(shift))
-    std = ndimage.geometric_transform(im, transform, extra_arguments=(shift,))
-    assert_allclose(res, std)
+    for mod in MODULES:
+        res = ndimage.geometric_transform(im, _ctest.transform(shift))
+        std = ndimage.geometric_transform(im, transform, extra_arguments=(shift,))
+        assert_allclose(res, std, err_msg="{} failed".format(mod.__name__))


### PR DESCRIPTION
This pull request:
- Updates the callback function c api to always use `PyCapsules`. Previously it used `PyCObjects` for Py2k which were deprecated in 2.7. This unifies the Py2k and Py3k interfaces.
- Adds tests for calling the api from c and cython.
- Updates the tutorial to reflect these changes and adds an example of calling the api from cython.

Closes gh-4938.
