### PR TITLE
MAINT: special: avoid implicit float->int conv.

### DIFF
--- a/scipy/special/tests/test_sici.py
+++ b/scipy/special/tests/test_sici.py
@@ -29,7 +29,8 @@ def test_shichi_consistency():
         return shi.real, chi.real
 
     # Overflow happens quickly, so limit range
-    x = np.r_[-np.logspace(np.log10(700), -30, 200), 0, np.logspace(-30, 2, np.log10(700))]
+    x = np.r_[-np.logspace(np.log10(700), -30, 200), 0,
+              np.logspace(-30, np.log10(700), 200)]
     shi, chi = sc.shichi(x)
     dataset = np.column_stack((x, shi, chi))
     FuncData(shichi, dataset, 0, (1, 2), rtol=1e-14).check()


### PR DESCRIPTION
Before this change, the test would throw:

```
DeprecationWarning: object of type <type 'numpy.float64'> cannot be safely interpreted as an integer.
```

Of course, one could also just replace the whole `int(np.log10(700))` expression with `2`.

cc: @person142 
