### PR TITLE
ENH: spatial: enable non-double dtypes in squareform

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -124,26 +124,15 @@ def _copy_array_if_base_present(a):
     """
     if a.base is not None:
         return a.copy()
-    elif np.issubsctype(a, np.float32):
-        return np.array(a, dtype=np.double)
-    else:
-        return a
+    return a
 
 
 def _convert_to_bool(X):
-    if X.dtype != bool:
-        X = X.astype(bool)
-    if not X.flags.contiguous:
-        X = X.copy()
-    return X
+    return np.ascontiguousarray(X, dtype=bool)
 
 
 def _convert_to_double(X):
-    if X.dtype != np.double:
-        X = X.astype(np.double)
-    if not X.flags.contiguous:
-        X = X.copy()
-    return X
+    return np.ascontiguousarray(X, dtype=np.double)
 
 
 def _validate_vector(u, dtype=None):
@@ -1447,7 +1436,7 @@ def squareform(X, force="no", checks=True):
 
     """
 
-    X = _convert_to_double(np.asarray(X, order='c'))
+    X = np.ascontiguousarray(X)
 
     s = X.shape
 
@@ -1462,21 +1451,21 @@ def squareform(X, force="no", checks=True):
 
     # X = squareform(v)
     if len(s) == 1:
-        if X.shape[0] == 0:
-            return np.zeros((1, 1), dtype=np.double)
+        if s[0] == 0:
+            return np.zeros((1, 1), dtype=X.dtype)
 
         # Grab the closest value to the square root of the number
         # of elements times 2 to see if the number of elements
         # is indeed a binomial coefficient.
-        d = int(np.ceil(np.sqrt(X.shape[0] * 2)))
+        d = int(np.ceil(np.sqrt(s[0] * 2)))
 
         # Check that v is of valid dimensions.
-        if d * (d - 1) / 2 != int(s[0]):
+        if d * (d - 1) != s[0] * 2:
             raise ValueError('Incompatible vector size. It must be a binomial '
                              'coefficient n choose 2 for some integer n >= 2.')
 
         # Allocate memory for the distance matrix.
-        M = np.zeros((d, d), dtype=np.double)
+        M = np.zeros((d, d), dtype=X.dtype)
 
         # Since the C code does not support striding using strides.
         # The dimensions are used instead.
@@ -1497,10 +1486,10 @@ def squareform(X, force="no", checks=True):
         d = s[0]
 
         if d <= 1:
-            return np.array([], dtype=np.double)
+            return np.array([], dtype=X.dtype)
 
         # Create a vector.
-        v = np.zeros((d * (d - 1)) // 2, dtype=np.double)
+        v = np.zeros((d * (d - 1)) // 2, dtype=X.dtype)
 
         # Since the C code does not support striding using strides.
         # The dimensions are used instead.
@@ -1511,16 +1500,16 @@ def squareform(X, force="no", checks=True):
         return v
     else:
         raise ValueError(('The first argument must be one or two dimensional '
-                         'array. A %d-dimensional array is not '
-                         'permitted') % len(s))
+                          'array. A %d-dimensional array is not '
+                          'permitted') % len(s))
 
 
 def is_valid_dm(D, tol=0.0, throw=False, name="D", warning=False):
     """
     Returns True if input array is a valid distance matrix.
 
-    Distance matrices must be 2-dimensional numpy arrays containing
-    doubles. They must have a zero-diagonal, and they must be symmetric.
+    Distance matrices must be 2-dimensional numpy arrays.
+    They must have a zero-diagonal, and they must be symmetric.
 
     Parameters
     ----------
@@ -1556,13 +1545,6 @@ def is_valid_dm(D, tol=0.0, throw=False, name="D", warning=False):
     valid = True
     try:
         s = D.shape
-        if D.dtype != np.double:
-            if name:
-                raise TypeError(('Distance matrix \'%s\' must contain doubles '
-                                 '(double).') % name)
-            else:
-                raise TypeError('Distance matrix must contain doubles '
-                                '(double).')
         if len(D.shape) != 2:
             if name:
                 raise ValueError(('Distance matrix \'%s\' must have shape=2 '
@@ -1614,9 +1596,9 @@ def is_valid_y(y, warning=False, throw=False, name=None):
     """
     Returns True if the input array is a valid condensed distance matrix.
 
-    Condensed distance matrices must be 1-dimensional
-    numpy arrays containing doubles. Their length must be a binomial
-    coefficient :math:`{n \\choose 2}` for some positive integer n.
+    Condensed distance matrices must be 1-dimensional numpy arrays.
+    Their length must be a binomial coefficient :math:`{n \\choose 2}`
+    for some positive integer n.
 
     Parameters
     ----------
@@ -1638,13 +1620,6 @@ def is_valid_y(y, warning=False, throw=False, name=None):
     y = np.asarray(y, order='c')
     valid = True
     try:
-        if y.dtype != np.double:
-            if name:
-                raise TypeError(('Condensed distance matrix \'%s\' must '
-                                 'contain doubles (double).') % name)
-            else:
-                raise TypeError('Condensed distance matrix must contain '
-                                'doubles (double).')
         if len(y.shape) != 1:
             if name:
                 raise ValueError(('Condensed distance matrix \'%s\' must '

--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -799,30 +799,31 @@ static PyObject *pdist_sokalsneath_bool_wrap(PyObject *self, PyObject *args) {
 
 static PyObject *to_squareform_from_vector_wrap(PyObject *self, PyObject *args) {
   PyArrayObject *M_, *v_;
-  int n;
-  const double *v;
-  double *M;
+  int n, elsize;
   if (!PyArg_ParseTuple(args, "O!O!",
 			&PyArray_Type, &M_,
 			&PyArray_Type, &v_)) {
     return 0;
   }
-  else {
-    NPY_BEGIN_ALLOW_THREADS;
-    M = (double*)M_->data;
-    v = (const double*)v_->data;
-    n = M_->dimensions[0];
-    dist_to_squareform_from_vector(M, v, n);
-    NPY_END_ALLOW_THREADS;
+  NPY_BEGIN_ALLOW_THREADS;
+  n = M_->dimensions[0];
+  elsize = M_->descr->elsize;
+  if (elsize == 8) {
+    dist_to_squareform_from_vector_double(
+        (double*)M_->data, (const double*)v_->data, n);
+  } else {
+    dist_to_squareform_from_vector_generic(
+        (char*)M_->data, (const char*)v_->data, n, elsize);
   }
-  return Py_BuildValue("d", 0.0);
+  NPY_END_ALLOW_THREADS;
+  return Py_BuildValue("");
 }
 
 static PyObject *to_vector_from_squareform_wrap(PyObject *self, PyObject *args) {
   PyArrayObject *M_, *v_;
-  int n;
-  double *v;
-  const double *M;
+  int n, s;
+  char *v;
+  const char *M;
   if (!PyArg_ParseTuple(args, "O!O!",
 			&PyArray_Type, &M_,
 			&PyArray_Type, &v_)) {
@@ -830,13 +831,14 @@ static PyObject *to_vector_from_squareform_wrap(PyObject *self, PyObject *args) 
   }
   else {
     NPY_BEGIN_ALLOW_THREADS;
-    M = (const double*)M_->data;
-    v = (double*)v_->data;
+    M = (const char*)M_->data;
+    v = (char*)v_->data;
     n = M_->dimensions[0];
-    dist_to_vector_from_squareform(M, v, n);
+    s = M_->descr->elsize;
+    dist_to_vector_from_squareform(M, v, n, s);
     NPY_END_ALLOW_THREADS;
   }
-  return Py_BuildValue("d", 0.0);
+  return Py_BuildValue("");
 }
 
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1213,50 +1213,50 @@ class TestSomeDistanceFunctions(TestCase):
             assert_almost_equal(dist, np.sqrt(6.0))
 
 
-class TestSquareForm(TestCase):
+class TestSquareForm(object):
+    checked_dtypes = [np.float64, np.float32, np.int32, np.int8, bool]
 
-    def test_squareform_empty_matrix(self):
-        A = np.zeros((0,0))
-        rA = squareform(np.array(A, dtype='double'))
+    def test_squareform_matrix(self):
+        for dtype in self.checked_dtypes:
+            yield self.check_squareform_matrix, dtype
+
+    def test_squareform_vector(self):
+        for dtype in self.checked_dtypes:
+            yield self.check_squareform_vector, dtype
+
+    def check_squareform_matrix(self, dtype):
+        A = np.zeros((0,0), dtype=dtype)
+        rA = squareform(A)
         assert_equal(rA.shape, (0,))
+        assert_equal(rA.dtype, dtype)
 
-    def test_squareform_empty_vector(self):
-        v = np.zeros((0,))
-        rv = squareform(np.array(v, dtype='double'))
+        A = np.zeros((1,1), dtype=dtype)
+        rA = squareform(A)
+        assert_equal(rA.shape, (0,))
+        assert_equal(rA.dtype, dtype)
+
+        A = np.array([[0,4.2],[4.2,0]], dtype=dtype)
+        rA = squareform(A)
+        assert_equal(rA.shape, (1,))
+        assert_equal(rA.dtype, dtype)
+        assert_array_equal(rA, np.array([4.2], dtype=dtype))
+
+    def check_squareform_vector(self, dtype):
+        v = np.zeros((0,), dtype=dtype)
+        rv = squareform(v)
         assert_equal(rv.shape, (1,1))
-        assert_equal(rv[0, 0], 0)
+        assert_equal(rv.dtype, dtype)
+        assert_array_equal(rv, [[0]])
 
-    def test_squareform_1by1_matrix(self):
-        A = np.zeros((1,1))
-        rA = squareform(np.array(A, dtype='double'))
-        assert_equal(rA.shape, (0,))
-
-    def test_squareform_one_vector(self):
-        v = np.ones((1,)) * 8.3
-        rv = squareform(np.array(v, dtype='double'))
-        assert_equal(rv.shape, (2,2))
-        assert_equal(rv[0,1], 8.3)
-        assert_equal(rv[1,0], 8.3)
-
-    def test_squareform_one_binary_vector(self):
-        # Tests squareform on a 1x1 binary matrix; conversion to double was
-        # causing problems (see pull request 73).
-        v = np.ones((1,), dtype=bool)
+        v = np.array([8.3], dtype=dtype)
         rv = squareform(v)
         assert_equal(rv.shape, (2,2))
-        assert_(rv[0,1])
-
-    def test_squareform_2by2_matrix(self):
-        A = np.zeros((2,2))
-        A[0,1] = 0.8
-        A[1,0] = 0.8
-        rA = squareform(np.array(A, dtype='double'))
-        assert_equal(rA.shape, (1,))
-        assert_equal(rA[0], 0.8)
+        assert_equal(rv.dtype, dtype)
+        assert_array_equal(rv, np.array([[0,8.3],[8.3,0]], dtype=dtype))
 
     def test_squareform_multi_matrix(self):
         for n in xrange(2, 5):
-            yield self.check_squareform_multi_matrix(n)
+            yield self.check_squareform_multi_matrix, n
 
     def check_squareform_multi_matrix(self, n):
         X = np.random.rand(n, 4)
@@ -1373,15 +1373,6 @@ def is_valid_dm_throw(D):
 
 class TestIsValidDM(TestCase):
 
-    def test_is_valid_dm_int16_array_E(self):
-        # Tests is_valid_dm(*) on an int16 array. Exception expected.
-        D = np.zeros((5, 5), dtype='i')
-        assert_raises(TypeError, is_valid_dm_throw, (D))
-
-    def test_is_valid_dm_int16_array_F(self):
-        D = np.zeros((5, 5), dtype='i')
-        assert_equal(is_valid_dm(D), False)
-
     def test_is_valid_dm_improper_shape_1D_E(self):
         D = np.zeros((5,), dtype=np.double)
         assert_raises(ValueError, is_valid_dm_throw, (D))
@@ -1457,14 +1448,6 @@ class TestIsValidY(TestCase):
     # If test case name ends on "_E" then an exception is expected for the
     # given input, if it ends in "_F" then False is expected for the is_valid_y
     # check.  Otherwise the input is expected to be valid.
-
-    def test_is_valid_y_int16_array_E(self):
-        y = np.zeros((10,), dtype='i')
-        assert_raises(TypeError, is_valid_y_throw, (y))
-
-    def test_is_valid_y_int16_array_F(self):
-        y = np.zeros((10,), dtype='i')
-        assert_equal(is_valid_y(y), False)
 
     def test_is_valid_y_improper_shape_2D_E(self):
         y = np.zeros((3,3,), dtype=np.double)


### PR DESCRIPTION
This change makes the underlying C code for `scipy.spatial.distance.squareform` dtype-agnostic, and removes the checks and casts which previously would force all inputs to a double dtype.
Fixes gh-6433.

Informal timings show that (for double dtypes) expanding to the redundant matrix representation got about 2x slower, while condensing to the vector representation stayed about the same:

**this PR**

``` python
v = np.random.random(4950)
m = squareform(v)
%timeit squareform(v)  # 10000 loops, best of 3: 62.9 µs per loop
%timeit squareform(m)  # 10000 loops, best of 3: 97.3 µs per loop
```

**current master**

``` python
%timeit squareform(v)  # 10000 loops, best of 3: 32.6 µs per loop
%timeit squareform(m)  # 10000 loops, best of 3: 98.5 µs per loop
```

It's possible that there's a better way to write the vector->matrix transformation with `memcpy`, similar to what I did for the reverse operation, that will close this gap.

Finally, there is one back-compat concern: I removed the dtype checks from `is_valid_dm` and `is_valid_y`. I doubt that many users were relying on that particular case, but it's definitely a change to a public API.
