### PR TITLE
BUG: Complex matrices not handled correctly by expm_multiply (Issue #6377)

### DIFF
--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -553,7 +553,7 @@ def _expm_multiply_interval(A, B, start=None, stop=None,
     # Use an ndim=3 shape, such that the last two indices
     # are the ones that may be involved in level 3 BLAS operations.
     X_shape = (nsamples,) + B.shape
-    X = np.empty(X_shape, dtype=float)
+    X = np.empty(X_shape, dtype=np.promote_types(A.dtype, B.dtype))
     t = t_q - t_0
     A = A - mu * ident
     A_1_norm = _exact_1_norm(A)
@@ -606,7 +606,7 @@ def _expm_multiply_interval_core_1(A, X, h, mu, m_star, s, q, tol):
     d = q // s
     input_shape = X.shape[1:]
     K_shape = (m_star + 1, ) + input_shape
-    K = np.empty(K_shape, dtype=float)
+    K = np.empty(K_shape, dtype=X.dtype)
     for i in range(s):
         Z = X[i*d]
         K[0] = Z
@@ -637,7 +637,7 @@ def _expm_multiply_interval_core_2(A, X, h, mu, m_star, s, q, tol):
     r = q - d * j
     input_shape = X.shape[1:]
     K_shape = (m_star + 1, ) + input_shape
-    K = np.empty(K_shape, dtype=float)
+    K = np.empty(K_shape, dtype=X.dtype)
     for i in range(j + 1):
         Z = X[i*d]
         K[0] = Z

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -553,7 +553,7 @@ def _expm_multiply_interval(A, B, start=None, stop=None,
     # Use an ndim=3 shape, such that the last two indices
     # are the ones that may be involved in level 3 BLAS operations.
     X_shape = (nsamples,) + B.shape
-    X = np.empty(X_shape, dtype=np.promote_types(A.dtype, B.dtype))
+    X = np.empty(X_shape, dtype=np.result_type(A.dtype, B.dtype, float))
     t = t_q - t_0
     A = A - mu * ident
     A_1_norm = _exact_1_norm(A)

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -190,6 +190,25 @@ class TestExpmActionInterval(TestCase):
                     for solution, t in zip(X, samples):
                         assert_allclose(solution, scipy.linalg.expm(t*A).dot(B))
 
+    def test_sparse_expm_multiply_interval_dtypes(self):
+        # Test A & B int
+        A = scipy.sparse.diags(np.arange(5),format='csr', dtype=int)
+        B = np.ones(5, dtype=int)
+        Aexpm = scipy.sparse.diags(np.exp(np.arange(5)),format='csr')
+        assert_allclose(expm_multiply(A,B,0,1)[-1], Aexpm.dot(B))
+    
+        # Test A complex, B int
+        A = scipy.sparse.diags(-1j*np.arange(5),format='csr', dtype=complex)
+        B = np.ones(5, dtype=int)
+        Aexpm = scipy.sparse.diags(np.exp(-1j*np.arange(5)),format='csr')
+        assert_allclose(expm_multiply(A,B,0,1)[-1], Aexpm.dot(B))
+    
+        # Test A int, B complex
+        A = scipy.sparse.diags(np.arange(5),format='csr', dtype=int)
+        B = 1j*np.ones(5, dtype=complex)
+        Aexpm = scipy.sparse.diags(np.exp(np.arange(5)),format='csr')
+        assert_allclose(expm_multiply(A,B,0,1)[-1], Aexpm.dot(B))
+
     def test_expm_multiply_interval_status_0(self):
         self._help_test_specific_expm_interval_status(0)
 


### PR DESCRIPTION
The issue in #6377 was that the `dtype` of the output array was hardcoded to be `float`.  This Pull  makes the `dtype` of output array the largest type amongst the input matrix A and
vector B.
