### PR TITLE
BUG: interpolate: fix .roots method of PchipInterpolator

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -109,7 +109,7 @@ class PchipInterpolator(BPoly):
         """
         Return the roots of the interpolated function.
         """
-        return (PPoly.from_bernstein_basis(self._bpoly)).roots()
+        return (PPoly.from_bernstein_basis(self)).roots()
 
     @staticmethod
     def _edge_case(h0, h1, m0, m1):

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -444,6 +444,11 @@ class TestPCHIP(TestCase):
             pchip_interpolate([1,2,3], [4,5,6], [0.5], der=[0, 1]),
             [[3.5], [1]])
 
+    def test_roots(self):
+        # regression test for gh-6357: .roots method should work
+        p = pchip([0, 1], [-1, 1])
+        r = p.roots()
+        assert_allclose(r, 0.5)
 
 class TestCubicSpline(object):
     @staticmethod


### PR DESCRIPTION
fixes gh-6357

This is trivial enough, so I'd like to backport it.
