### PR TITLE
DOC: add links to the release notes 0.19.0

### DIFF
--- a/doc/source/release.0.19.0.rst
+++ b/doc/source/release.0.19.0.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/0.19.0-notes.rst

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
    :maxdepth: 1
 
+   release.0.19.0
    release.0.18.0
    release.0.17.1
    release.0.17.0


### PR DESCRIPTION
Add some more forgotten links to release notes. Hopefully this is the last batch.
