### PR TITLE
TST DOC Window docs, tests, etc.

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -34,6 +34,75 @@ window_funcs = [
     ]
 
 
+class TestBartHann(object):
+
+    def test_basic(self):
+        assert_allclose(signal.barthann(6, sym=True),
+                        [0, 0.35857354213752, 0.8794264578624801,
+                         0.8794264578624801, 0.3585735421375199, 0])
+        assert_allclose(signal.barthann(7),
+                        [0, 0.27, 0.73, 1.0, 0.73, 0.27, 0])
+        assert_allclose(signal.barthann(6, False),
+                        [0, 0.27, 0.73, 1.0, 0.73, 0.27])
+
+
+class TestBartlett(object):
+
+    def test_basic(self):
+        assert_allclose(signal.bartlett(6), [0, 0.4, 0.8, 0.8, 0.4, 0])
+        assert_allclose(signal.bartlett(7), [0, 1/3, 2/3, 1.0, 2/3, 1/3, 0])
+        assert_allclose(signal.bartlett(6, False),
+                        [0, 1/3, 2/3, 1.0, 2/3, 1/3])
+
+
+class TestBlackman(object):
+
+    def test_basic(self):
+        assert_allclose(signal.blackman(6, sym=False),
+                        [0, 0.13, 0.63, 1.0, 0.63, 0.13], atol=1e-14)
+        assert_allclose(signal.blackman(6),
+                        [0, 0.2007701432625305, 0.8492298567374694,
+                         0.8492298567374694, 0.2007701432625305, 0],
+                        atol=1e-14)
+        assert_allclose(signal.blackman(7, True),
+                        [0, 0.13, 0.63, 1.0, 0.63, 0.13, 0], atol=1e-14)
+
+
+class TestBlackmanHarris(object):
+
+    def test_basic(self):
+        assert_allclose(signal.blackmanharris(6, False),
+                        [6.0e-05, 0.055645, 0.520575, 1.0, 0.520575, 0.055645])
+        assert_allclose(signal.blackmanharris(6),
+                        [6.0e-05, 0.1030114893456638, 0.7938335106543362,
+                         0.7938335106543364, 0.1030114893456638, 6.0e-05])
+        assert_allclose(signal.blackmanharris(7, sym=True),
+                        [6.0e-05, 0.055645, 0.520575, 1.0, 0.520575, 0.055645,
+                         6.0e-05])
+
+
+class TestBohman(object):
+
+    def test_basic(self):
+        assert_allclose(signal.bohman(6),
+                        [0, 0.1791238937062839, 0.8343114522576858,
+                         0.8343114522576858, 0.1791238937062838, 0])
+        assert_allclose(signal.bohman(7, sym=True),
+                        [0, 0.1089977810442293, 0.6089977810442293, 1.0,
+                         0.6089977810442295, 0.1089977810442293, 0])
+        assert_allclose(signal.bohman(6, False),
+                        [0, 0.1089977810442293, 0.6089977810442293, 1.0,
+                         0.6089977810442295, 0.1089977810442293])
+
+
+class TestBoxcar(object):
+
+    def test_basic(self):
+        assert_allclose(signal.boxcar(6), [1, 1, 1, 1, 1, 1])
+        assert_allclose(signal.boxcar(7), [1, 1, 1, 1, 1, 1, 1])
+        assert_allclose(signal.boxcar(6, False), [1, 1, 1, 1, 1, 1])
+
+
 cheb_odd_true = array([0.200938, 0.107729, 0.134941, 0.165348,
                        0.198891, 0.235450, 0.274846, 0.316836,
                        0.361119, 0.407338, 0.455079, 0.503883,
@@ -70,6 +139,26 @@ cheb_even_true = array([0.203894, 0.107279, 0.133904,
 
 
 class TestChebWin(object):
+
+    def test_basic(self):
+        assert_allclose(signal.chebwin(6, 100),
+                        [0.1046401879356917, 0.5075781475823447, 1.0, 1.0,
+                         0.5075781475823447, 0.1046401879356917])
+        assert_allclose(signal.chebwin(7, 100),
+                        [0.05650405062850233, 0.316608530648474,
+                         0.7601208123539079, 1.0, 0.7601208123539079,
+                         0.316608530648474, 0.05650405062850233])
+        assert_allclose(signal.chebwin(6, 10),
+                        [1.0, 0.6071201674458373, 0.6808391469897297,
+                         0.6808391469897297, 0.6071201674458373, 1.0])
+        assert_allclose(signal.chebwin(7, 10),
+                        [1.0, 0.5190521247588651, 0.5864059018130382,
+                         0.6101519801307441, 0.5864059018130382,
+                         0.5190521247588651, 1.0])
+        assert_allclose(signal.chebwin(6, 10, False),
+                        [1.0, 0.5190521247588651, 0.5864059018130382,
+                         0.6101519801307441, 0.5864059018130382,
+                         0.5190521247588651])
 
     def test_cheb_odd_high_attenuation(self):
         with warnings.catch_warnings():
@@ -152,6 +241,133 @@ def test_exponential():
             assert_allclose(win, v, rtol=1e-14)
 
 
+class TestFlatTop(object):
+
+    def test_basic(self):
+        assert_allclose(signal.flattop(6, sym=False),
+                        [-0.000421051, -0.051263156, 0.19821053, 1.0,
+                         0.19821053, -0.051263156])
+        assert_allclose(signal.flattop(6),
+                        [-0.000421051, -0.0677142520762119, 0.6068721525762117,
+                         0.6068721525762117, -0.0677142520762119,
+                         -0.000421051])
+        assert_allclose(signal.flattop(7, True),
+                        [-0.000421051, -0.051263156, 0.19821053, 1.0,
+                         0.19821053, -0.051263156, -0.000421051])
+
+
+class TestGaussian(object):
+
+    def test_basic(self):
+        assert_allclose(signal.gaussian(6, 1.0),
+                        [0.04393693362340742, 0.3246524673583497,
+                         0.8824969025845955, 0.8824969025845955,
+                         0.3246524673583497, 0.04393693362340742])
+        assert_allclose(signal.gaussian(7, 1.2),
+                        [0.04393693362340742, 0.2493522087772962,
+                         0.7066482778577162, 1.0, 0.7066482778577162,
+                         0.2493522087772962, 0.04393693362340742])
+        assert_allclose(signal.gaussian(7, 3),
+                        [0.6065306597126334, 0.8007374029168081,
+                         0.9459594689067654, 1.0, 0.9459594689067654,
+                         0.8007374029168081, 0.6065306597126334])
+        assert_allclose(signal.gaussian(6, 3, False),
+                        [0.6065306597126334, 0.8007374029168081,
+                         0.9459594689067654, 1.0, 0.9459594689067654,
+                         0.8007374029168081])
+
+
+class TestHamming(object):
+
+    def test_basic(self):
+        assert_allclose(signal.hamming(6, False),
+                        [0.08, 0.31, 0.77, 1.0, 0.77, 0.31])
+        assert_allclose(signal.hamming(6),
+                        [0.08, 0.3978521825875242, 0.9121478174124757,
+                         0.9121478174124757, 0.3978521825875242, 0.08])
+        assert_allclose(signal.hamming(7, sym=True),
+                        [0.08, 0.31, 0.77, 1.0, 0.77, 0.31, 0.08])
+
+
+class TestHann(object):
+
+    def test_basic(self):
+        assert_allclose(signal.hann(6, sym=False),
+                        [0, 0.25, 0.75, 1.0, 0.75, 0.25])
+        assert_allclose(signal.hann(6, True),
+                        [0, 0.3454915028125263, 0.9045084971874737,
+                         0.9045084971874737, 0.3454915028125263, 0])
+        assert_allclose(signal.hann(7),
+                        [0, 0.25, 0.75, 1.0, 0.75, 0.25, 0])
+
+
+class TestKaiser(object):
+
+    def test_basic(self):
+        assert_allclose(signal.kaiser(6, 0.5),
+                        [0.9403061933191572, 0.9782962393705389,
+                         0.9975765035372042, 0.9975765035372042,
+                         0.9782962393705389, 0.9403061933191572])
+        assert_allclose(signal.kaiser(7, 0.5),
+                        [0.9403061933191572, 0.9732402256999829,
+                         0.9932754654413773, 1.0, 0.9932754654413773,
+                         0.9732402256999829, 0.9403061933191572])
+        assert_allclose(signal.kaiser(6, 2.7),
+                        [0.2603047507678832, 0.6648106293528054,
+                         0.9582099802511439, 0.9582099802511439,
+                         0.6648106293528054, 0.2603047507678832])
+        assert_allclose(signal.kaiser(7, 2.7),
+                        [0.2603047507678832, 0.5985765418119844,
+                         0.8868495172060835, 1.0, 0.8868495172060835,
+                         0.5985765418119844, 0.2603047507678832])
+        assert_allclose(signal.kaiser(6, 2.7, False),
+                        [0.2603047507678832, 0.5985765418119844,
+                         0.8868495172060835, 1.0, 0.8868495172060835,
+                         0.5985765418119844])
+
+
+class TestNuttall(object):
+
+    def test_basic(self):
+        assert_allclose(signal.nuttall(6, sym=False),
+                        [0.0003628, 0.0613345, 0.5292298, 1.0, 0.5292298,
+                         0.0613345])
+        assert_allclose(signal.nuttall(6),
+                        [0.0003628, 0.1105152530498718, 0.7982580969501282,
+                         0.7982580969501283, 0.1105152530498719, 0.0003628])
+        assert_allclose(signal.nuttall(7, True),
+                        [0.0003628, 0.0613345, 0.5292298, 1.0, 0.5292298,
+                         0.0613345, 0.0003628])
+
+
+class TestParzen(object):
+
+    def test_basic(self):
+        assert_allclose(signal.parzen(6),
+                        [0.009259259259259254, 0.25, 0.8611111111111112,
+                         0.8611111111111112, 0.25, 0.009259259259259254])
+        assert_allclose(signal.parzen(7, sym=True),
+                        [0.00583090379008747, 0.1574344023323616,
+                         0.6501457725947521, 1.0, 0.6501457725947521,
+                         0.1574344023323616, 0.00583090379008747])
+        assert_allclose(signal.parzen(6, False),
+                        [0.00583090379008747, 0.1574344023323616,
+                         0.6501457725947521, 1.0, 0.6501457725947521,
+                         0.1574344023323616])
+
+
+class TestTriang(object):
+
+    def test_basic(self):
+
+        assert_allclose(signal.triang(6, True),
+                        [1/6, 1/2, 5/6, 5/6, 1/2, 1/6])
+        assert_allclose(signal.triang(7),
+                        [1/4, 1/2, 3/4, 1, 3/4, 1/2, 1/4])
+        assert_allclose(signal.triang(6, sym=False),
+                        [1/4, 1/2, 3/4, 1, 3/4, 1/2])
+
+
 tukey_data = {
     (4, 0.5, True): array([0.0, 1.0, 1.0, 0.0]),
     (4, 0.9, True): array([0.0, 0.84312081893436686,
@@ -165,25 +381,42 @@ tukey_data = {
     (5, 0.8, True): array([0.0, 0.69134171618254492,
                            1.0, 0.69134171618254492, 0.0]),
     (5, 1.0, True): array([0.0, 0.5, 1.0, 0.5, 0.0]),
+
+    (6, 0): [1, 1, 1, 1, 1, 1],
+    (7, 0): [1, 1, 1, 1, 1, 1, 1],
+    (6, .25): [0, 1, 1, 1, 1, 0],
+    (7, .25): [0, 1, 1, 1, 1, 1, 0],
+    (6,): [0, 0.9045084971874737, 1.0, 1.0, 0.9045084971874735, 0],
+    (7,): [0, 0.75, 1.0, 1.0, 1.0, 0.75, 0],
+    (6, .75): [0, 0.5522642316338269, 1.0, 1.0, 0.5522642316338267, 0],
+    (7, .75): [0, 0.4131759111665348, 0.9698463103929542, 1.0,
+               0.9698463103929542, 0.4131759111665347, 0],
+    (6, 1): [0, 0.3454915028125263, 0.9045084971874737, 0.9045084971874737,
+             0.3454915028125263, 0],
+    (7, 1): [0, 0.25, 0.75, 1.0, 0.75, 0.25, 0],
 }
 
 
-def test_tukey():
-    # Test against hardcoded data
-    for k, v in tukey_data.items():
-        if v is None:
-            assert_raises(ValueError, signal.tukey, *k)
-        else:
-            win = signal.tukey(*k)
-            assert_allclose(win, v, rtol=1e-14)
+class TestTukey(object):
 
-    # Test extremes of alpha correspond to boxcar and hann
-    tuk0 = signal.tukey(100, 0)
-    tuk1 = signal.tukey(100, 1)
-    box0 = signal.boxcar(100)
-    han1 = signal.hann(100)
-    assert_array_almost_equal(tuk0, box0)
-    assert_array_almost_equal(tuk1, han1)
+    def test_basic(self):
+        # Test against hardcoded data
+        for k, v in tukey_data.items():
+            if v is None:
+                assert_raises(ValueError, signal.tukey, *k)
+            else:
+                win = signal.tukey(*k)
+                assert_allclose(win, v, rtol=1e-14)
+
+    def test_extremes(self):
+        # Test extremes of alpha correspond to boxcar and hann
+        tuk0 = signal.tukey(100, 0)
+        box0 = signal.boxcar(100)
+        assert_array_almost_equal(tuk0, box0)
+
+        tuk1 = signal.tukey(100, 1)
+        han1 = signal.hann(100)
+        assert_array_almost_equal(tuk1, han1)
 
 
 class TestGetWindow(object):
@@ -270,7 +503,8 @@ def test_windowfunc_basics():
 
             # Check periodic spectrum
             assert_allclose(fftpack.fft(window(10, *params, sym=False)).imag,
-                            0, atol=1e-8)
+                            0, atol=1e-14)
+
 
 def test_needs_params():
     for winstr in ['kaiser', 'ksr', 'gaussian', 'gauss', 'gss',

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -497,6 +497,20 @@ def flattop(M, sym=True):
         The window, with the maximum value normalized to 1 (though the value 1
         does not appear if `M` is even and `sym` is True).
 
+    Notes
+    -----
+    Flat top windows are used for taking accurate measurements of signal
+    amplitude in the frequency domain, with minimal scalloping error from the
+    center of a frequency bin to its edges, compared to others.  This is a
+    5th-order cosine window, with the 5 terms optimized to make the main lobe
+    maximally flat. [1]_
+
+    References
+    ----------
+    .. [1] D'Antona, Gabriele, and A. Ferrero, "Digital Signal Processing for
+           Measurement Systems", Springer Media, 2006, p. 70
+           doi: 10.1007/0-387-28666-7
+
     Examples
     --------
     Plot the window and its frequency response:
@@ -526,7 +540,7 @@ def flattop(M, sym=True):
         return np.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    a = [0.2156, 0.4160, 0.2781, 0.0836, 0.0069]
+    a = [0.21557895, 0.41663158, 0.277263158, 0.083578947, 0.006947368]
     w = _cos_win(M, a)
 
     return _truncate(w, needs_trunc)

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -65,7 +65,8 @@ def _cos_win(M, a):
 def boxcar(M, sym=True):
     """Return a boxcar or rectangular window.
 
-    Included for completeness, this is equivalent to no window at all.
+    Also known as a rectangular window or Dirichlet window, this is equivalent
+    to no window at all.
 
     Parameters
     ----------
@@ -196,6 +197,11 @@ def parzen(M, sym=True):
         The window, with the maximum value normalized to 1 (though the value 1
         does not appear if `M` is even and `sym` is True).
 
+    References
+    ----------
+    .. [1] E. Parzen, "Mathematical Considerations in the Estimation of
+           Spectra", Technometrics,  Vol. 3, No. 2 (May, 1961), pp. 167-190
+
     Examples
     --------
     Plot the window and its frequency response:
@@ -322,6 +328,12 @@ def blackman(M, sym=True):
 
     .. math::  w(n) = 0.42 - 0.5 \cos(2\pi n/M) + 0.08 \cos(4\pi n/M)
 
+    The "exact Blackman" window was designed to null out the third and fourth
+    sidelobes, but has discontinuities at the boundaries, resulting in a
+    6 dB/oct fall-off.  This window is an approximation of the "exact" window,
+    which does not null the sidelobes as well, but is smooth at the edges,
+    improving the fall-off rate to 18 dB/oct. [3]_
+
     Most references to the Blackman window come from the signal processing
     literature, where it is used as one of many windowing functions for
     smoothing values.  It is also known as an apodization (which means
@@ -336,6 +348,9 @@ def blackman(M, sym=True):
            spectra, Dover Publications, New York.
     .. [2] Oppenheim, A.V., and R.W. Schafer. Discrete-Time Signal Processing.
            Upper Saddle River, NJ: Prentice-Hall, 1999, pp. 468-471.
+    .. [3] Harris, Fredric J. (Jan 1978). "On the use of Windows for Harmonic
+           Analysis with the Discrete Fourier Transform". Proceedings of the
+           IEEE 66 (1): 51-83. doi:10.1109/PROC.1978.10837
 
     Examples
     --------
@@ -375,6 +390,8 @@ def blackman(M, sym=True):
 def nuttall(M, sym=True):
     """Return a minimum 4-term Blackman-Harris window according to Nuttall.
 
+    This variation is called "Nuttall4c" by Heinzel. [2]_
+
     Parameters
     ----------
     M : int
@@ -390,6 +407,16 @@ def nuttall(M, sym=True):
     w : ndarray
         The window, with the maximum value normalized to 1 (though the value 1
         does not appear if `M` is even and `sym` is True).
+
+    References
+    ----------
+    .. [1] A. Nuttall, "Some windows with very good sidelobe behavior," IEEE
+           Transactions on Acoustics, Speech, and Signal Processing, vol. 29,
+           no. 1, pp. 84-91, Feb 1981. doi: 10.1109/TASSP.1981.1163506
+    .. [2] Heinzel G. et al., "Spectrum and spectral density estimation by the
+           Discrete Fourier transform (DFT), including a comprehensive list of
+           window functions and some new flat-top windows", February 15, 2002
+           https://holometer.fnal.gov/GH_FFT.pdf
 
     Examples
     --------
@@ -1000,8 +1027,8 @@ def kaiser(M, beta, sym=True):
     maximizes the energy in the main lobe of the window relative to total
     energy.
 
-    The Kaiser can approximate many other windows by varying the beta
-    parameter.
+    The Kaiser can approximate other windows by varying the beta parameter.
+    (Some literature uses alpha = beta/pi.) [4]_
 
     ====  =======================
     beta  Window shape
@@ -1015,7 +1042,7 @@ def kaiser(M, beta, sym=True):
     A beta value of 14 is probably a good starting point. Note that as beta
     gets large, the window narrows, and so the number of samples needs to be
     large enough to sample the increasingly narrow spike, otherwise NaNs will
-    get returned.
+    be returned.
 
     Most references to the Kaiser window come from the signal processing
     literature, where it is used as one of many windowing functions for
@@ -1032,6 +1059,9 @@ def kaiser(M, beta, sym=True):
            University of Alberta Press, 1975, pp. 177-178.
     .. [3] Wikipedia, "Window function",
            http://en.wikipedia.org/wiki/Window_function
+    .. [4] F. J. Harris, "On the use of windows for harmonic analysis with the
+           discrete Fourier transform," Proceedings of the IEEE, vol. 66,
+           no. 1, pp. 51-83, Jan. 1978. doi: 10.1109/PROC.1978.10837
 
     Examples
     --------
@@ -1353,6 +1383,15 @@ def slepian(M, width, sym=True):
     -------
     w : ndarray
         The window, with the maximum value always normalized to 1
+
+    References
+    ----------
+    .. [1] D. Slepian & H. O. Pollak: "Prolate spheroidal wave functions,
+           Fourier analysis and uncertainty-I," Bell Syst. Tech. J., vol.40,
+           pp.43-63, 1961. https://archive.org/details/bstj40-1-43
+    .. [2] H. J. Landau & H. O. Pollak: "Prolate spheroidal wave functions,
+           Fourier analysis and uncertainty-II," Bell Syst. Tech. J. , vol.40,
+           pp.65-83, 1961. https://archive.org/details/bstj40-1-65
 
     Examples
     --------

--- a/scipy/signal/windows.py
+++ b/scipy/signal/windows.py
@@ -37,6 +37,31 @@ def _truncate(w, needed):
         return w
 
 
+def _cos_win(M, a):
+    """
+    Generic weighted sum of cosine terms window
+
+    Parameters
+    ----------
+    M : int
+        Number of points in the output window
+    a : array_like
+        Sequence of weighting coefficients
+
+    References
+    ----------
+    .. [1] A. Nuttall, "Some windows with very good sidelobe behavior," IEEE
+           Transactions on Acoustics, Speech, and Signal Processing, vol. 29,
+           no. 1, pp. 84-91, Feb 1981. doi: 10.1109/TASSP.1981.1163506
+    """
+    n = np.arange(0, M)
+    fac = n * 2 * np.pi / (M - 1.0)
+    w = np.zeros(M)
+    for k in range(len(a)):
+        w += (-1)**k * a[k] * np.cos(k * fac)
+    return w
+
+
 def boxcar(M, sym=True):
     """Return a boxcar or rectangular window.
 
@@ -342,9 +367,7 @@ def blackman(M, sym=True):
         return np.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = np.arange(0, M)
-    w = (0.42 - 0.5 * np.cos(2.0 * np.pi * n / (M - 1)) +
-         0.08 * np.cos(4.0 * np.pi * n / (M - 1)))
+    w = _cos_win(M, [0.42, 0.50, 0.08])
 
     return _truncate(w, needs_trunc)
 
@@ -397,11 +420,7 @@ def nuttall(M, sym=True):
         return np.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    a = [0.3635819, 0.4891775, 0.1365995, 0.0106411]
-    n = np.arange(0, M)
-    fac = n * 2 * np.pi / (M - 1.0)
-    w = (a[0] - a[1] * np.cos(fac) +
-         a[2] * np.cos(2 * fac) - a[3] * np.cos(3 * fac))
+    w = _cos_win(M, [0.3635819, 0.4891775, 0.1365995, 0.0106411])
 
     return _truncate(w, needs_trunc)
 
@@ -454,11 +473,7 @@ def blackmanharris(M, sym=True):
         return np.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    a = [0.35875, 0.48829, 0.14128, 0.01168]
-    n = np.arange(0, M)
-    fac = n * 2 * np.pi / (M - 1.0)
-    w = (a[0] - a[1] * np.cos(fac) +
-         a[2] * np.cos(2 * fac) - a[3] * np.cos(3 * fac))
+    w = _cos_win(M, [0.35875, 0.48829, 0.14128, 0.01168])
 
     return _truncate(w, needs_trunc)
 
@@ -512,11 +527,7 @@ def flattop(M, sym=True):
     M, needs_trunc = _extend(M, sym)
 
     a = [0.2156, 0.4160, 0.2781, 0.0836, 0.0069]
-    n = np.arange(0, M)
-    fac = n * 2 * np.pi / (M - 1.0)
-    w = (a[0] - a[1] * np.cos(fac) +
-         a[2] * np.cos(2 * fac) - a[3] * np.cos(3 * fac) +
-         a[4] * np.cos(4 * fac))
+    w = _cos_win(M, a)
 
     return _truncate(w, needs_trunc)
 
@@ -701,8 +712,7 @@ def hann(M, sym=True):
         return np.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = np.arange(0, M)
-    w = 0.5 - 0.5 * np.cos(2.0 * np.pi * n / (M - 1))
+    w = _cos_win(M, [0.5, 0.5])
 
     return _truncate(w, needs_trunc)
 
@@ -927,8 +937,7 @@ def hamming(M, sym=True):
         return np.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = np.arange(0, M)
-    w = 0.54 - 0.46 * np.cos(2.0 * np.pi * n / (M - 1))
+    w = _cos_win(M, [0.54, 0.46])
 
     return _truncate(w, needs_trunc)
 


### PR DESCRIPTION
This should fix https://github.com/scipy/scipy/issues/4234 and improve coverage of exceptions, etc. shown by codecov.

Combined several window functions into a generic sum-of-cosines function, since that's how most references describe the different functions anyway:

> This kind of optimization leads to the definition of the so-called flat-top windows. If a
> third order window is considered, this optimization yields the following coefficients: A<sub>0</sub> = 0.2811, A<sub>1</sub> = -0.5209, A<sub>2</sub> = 0.1980.

So now you can reproduce this window with  `_cos_win(M, [0.2811, 0.5209, 0.1980])`.
