### PR TITLE
ENH: add a function for Gauss-Hermite quadrature

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -17,6 +17,7 @@ Robert Cimrman for UMFpack wrapper for sparse matrix module.
 David M. Cooke for improvements to system_info, and LBFGSB wrapper.
 Aric Hagberg for ARPACK wrappers, help with splinalg.eigen.
 Chuck Harris for Zeros package in optimize (1d root-finding algorithms).
+David J. Harris for Gauss-Hermite quadrature.
 Prabhu Ramachandran for improvements to gui_thread.
 Robert Kern for improvements to stats and bug-fixes.
 Jean-Sebastien Roy for fmin_tnc code which he adapted from Stephen Nash's
@@ -130,7 +131,7 @@ Jörg Dietrich for the k-sample Anderson Darling test.
 Blake Griffith for improvements to scipy.sparse.
 Andrew Nelson for scipy.optimize.differential_evolution.
 Brian Newsom for work on ctypes multivariate integration.
-Nathan Woods for work on multivariate integration. 
+Nathan Woods for work on multivariate integration.
 Brianna Laugher for bug fixes.
 Johannes Kulick for the Dirichlet distribution.
 Bastian Venthur for bug fixes.

--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -43,6 +43,11 @@ response from second-order sections.
 The function `scipy.signal.unit_impulse` was added to conveniently
 generate an impulse function.
 
+`scipy.integrate` improvements
+---------------------------
+
+The function `scipy.integrate.gh_quad` was added to estimate indefinite
+integrals with Gauss-Hermite quadrature.
 
 Deprecated features
 ===================
@@ -72,4 +77,3 @@ Issues closed for 0.19.0
 
 Pull requests for 0.19.0
 ------------------------
-

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -7,10 +7,9 @@ import warnings
 # trapz is a public function for scipy.integrate,
 # even though it's actually a numpy function.
 from numpy import trapz
-from scipy.special.orthogonal import p_roots
+from scipy.special.orthogonal import p_roots, h_roots
 from scipy.special import gammaln
 from scipy._lib.six import xrange
-from numpy.polynomial.hermite import hermgauss
 
 __all__ = ['fixed_quad', 'quadrature', 'romberg', 'trapz', 'simps', 'romb',
            'cumtrapz', 'newton_cotes', 'gh_quad']
@@ -877,9 +876,7 @@ def gh_quad(func, n, args=(), mu_hat=0, sigma_hat=1, zero_nan=False):
         For best results, `func` should approximately equal a Gaussian
         density times a low-order polynomial.
     n : int
-        Order of quadrature integration. This function relies on
-        `numpy.polynomial.hermite.hermgauss`, which has not been tested for
-        order larger than 100.
+        Order of quadrature integration.
     args : tuple, optional
         Extra arguments to pass to `func`, if any.
     mu_hat : float, optional
@@ -913,6 +910,8 @@ def gh_quad(func, n, args=(), mu_hat=0, sigma_hat=1, zero_nan=False):
     cumtrapz : cumulative integration for sampled data
     ode : ODE integrator
     odeint : ODE integrator
+    scipy.special.h_roots : for coefficients and roots of Hermite polynomials
+
 
     Notes
     -----
@@ -955,7 +954,7 @@ def gh_quad(func, n, args=(), mu_hat=0, sigma_hat=1, zero_nan=False):
     >>> print(gh_quad(func, n=99, mu_hat=mu_hat, sigma_hat=sigma_hat))
 
     """
-    x, w = hermgauss(deg=n)
+    x, w = h_roots(n)
     w_star = w * np.exp(x**2)
     g_x_star = func(mu_hat + np.sqrt(2) * sigma_hat * x, *args)
     if zero_nan:

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -914,6 +914,10 @@ def gh_quad(func, n, args=(), mu_hat=0, sigma_hat=1, zero_nan=False):
     ode : ODE integrator
     odeint : ODE integrator
 
+    Notes
+    -----
+    .. versionadded:: 0.19.0
+
     References
     ----------
     .. [1] Liu, Q. and Pierce, D. A. (1994). 'A Note on Gauss-Hermite

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -10,9 +10,10 @@ from numpy import trapz
 from scipy.special.orthogonal import p_roots
 from scipy.special import gammaln
 from scipy._lib.six import xrange
+from numpy.polynomial.hermite import hermgauss
 
 __all__ = ['fixed_quad', 'quadrature', 'romberg', 'trapz', 'simps', 'romb',
-           'cumtrapz', 'newton_cotes']
+           'cumtrapz', 'newton_cotes', 'gh_quad']
 
 
 class AccuracyWarning(Warning):
@@ -71,6 +72,7 @@ def fixed_quad(func, a, b, args=(), n=5):
     cumtrapz : cumulative integration for sampled data
     ode : ODE integrator
     odeint : ODE integrator
+    gh_quad : Gauss-Hermite quadrature
 
     """
     x, w = _cached_p_roots(n)
@@ -175,6 +177,7 @@ def quadrature(func, a, b, args=(), tol=1.49e-8, rtol=1.49e-8, maxiter=50,
     cumtrapz: cumulative integration for sampled data
     ode: ODE integrator
     odeint: ODE integrator
+    gh_quad : Gauss-Hermite quadrature
 
     """
     if not isinstance(args, tuple):
@@ -244,6 +247,7 @@ def cumtrapz(y, x=None, dx=1.0, axis=-1, initial=None):
     romb: integrators for sampled data
     ode: ODE integrators
     odeint: ODE integrators
+    gh_quad : Gauss-Hermite quadrature
 
     Examples
     --------
@@ -369,6 +373,7 @@ def simps(y, x=None, dx=1, axis=-1, even='avg'):
     cumtrapz: cumulative integration for sampled data
     ode: ODE integrators
     odeint: ODE integrators
+    gh_quad : Gauss-Hermite quadrature
 
     Notes
     -----
@@ -466,7 +471,8 @@ def romb(y, dx=1.0, axis=-1, show=False):
     simps : integrators for sampled data
     cumtrapz : cumulative integration for sampled data
     ode : ODE integrators
-    odeint : ODE integrators
+    odeint : ODE integrator
+    gh_quad : Gauss-Hermite quadratures
 
     """
     y = np.asarray(y)
@@ -642,7 +648,8 @@ def romberg(function, a, b, args=(), tol=1.48e-8, rtol=1.48e-8, show=False,
     simps : Integrators for sampled data.
     cumtrapz : Cumulative integration for sampled data.
     ode : ODE integrator.
-    odeint : ODE integrator.
+    odeint : ODE integrator
+    gh_quad : Gauss-Hermite quadrature.
 
     References
     ----------
@@ -853,3 +860,99 @@ def newton_cotes(rn, equal=0):
     fac = power*math.log(N) - gammaln(p1)
     fac = math.exp(fac)
     return ai, BN*fac
+
+
+def gh_quad(func, n, args=(), mu_hat=0, sigma_hat=1, zero_nan=False):
+    """
+    Gauss-Hermite quadrature
+
+    Compute an indefinite integral using Gauss-Hermite quadrature of order `n`,
+    optionally shifting and scaling the quadrature points to focus on the
+    high-density region.
+
+    Parameters
+    ----------
+    func : callable
+        A Python function or method to integrate (must accept vector inputs).
+        For best results, `func` should approximately equal a Gaussian
+        density times a low-order polynomial.
+    n : int
+        Order of quadrature integration. This function relies on
+        `numpy.polynomial.hermite.hermgauss`, which has not been tested for
+        order larger than 100.
+    args : tuple, optional
+        Extra arguments to pass to `func`, if any.
+    mu_hat : float, optional
+        Location parameter, used to center the quadrature nodes near
+        the high-density region.
+    sigma_hat : float, optional
+        Scale parameter, used to determine how much to spread out the quadrature
+        nodes.
+    zero_nan : bool, optional
+        If `func(x)` returns `nan` (e.g. if a quadrature point falls outside the
+        domain of x), should this value be coerced to zero? Default is False.
+
+    Returns
+    -------
+    val : float
+        Gauss-Hermite quadrature approximation to the indefinite integral of
+        `func`.
+
+    See Also
+    --------
+    fixed_quad : fixed-order Gaussian quadrature
+    quad : adaptive quadrature using QUADPACK
+    dblquad : double integrals
+    tplquad : triple integrals
+    romberg : adaptive Romberg quadrature
+    quadrature : adaptive Gaussian quadrature
+    romb : integrators for sampled data
+    simps : integrators for sampled data
+    cumtrapz : cumulative integration for sampled data
+    ode : ODE integrator
+    odeint : ODE integrator
+
+    References
+    ----------
+    .. [1] Liu, Q. and Pierce, D. A. (1994). 'A Note on Gauss-Hermite
+        Quadrature'. Biometrika, 81(3) 624-629.
+
+    Examples
+    --------
+    >>> from scipy import integrate
+    >>> from scipy.stats import t
+    >>> from scipy.optimize import minimize
+
+    Find the area under a Student-t distribution with 8 degrees of freedom
+    (which should approach one as the number of quadrature points increases):
+
+    >>> print(gh_quad(t.pdf, n=1, args=(8,)))
+    >>> print(gh_quad(t.pdf, n=10, args=(8,)))
+    >>> print(gh_quad(t.pdf, n=99, args=(8,)))
+
+    With inappropriate values of `mu_hat` and `sigma_hat`, the quadrature points
+    will be poorly placed and the approximate area under a curve (such as this
+    shifted and scaled Student-t distribution) may be very inaccurate:
+
+    >>> def func(x):
+    ... t.pdf((x + 25) / 4.0, df=8) / 4.0
+    ...
+    >>> print(gh_quad(func, n=99))
+
+    One efficient way to choose `mu_hat` and `sigma_hat` is with Laplace
+    approximation to the density's first two moments, as discussed in Liu and
+    Pierce (1994):
+
+    >>> opt = minimize(lambda x: -np.log(func(x)), 0)
+    >>> mu_hat = opt.x[0]
+    >>> sigma_hat = np.sqrt(opt.hess_inv[0,0])
+    >>> print(gh_quad(func, n=99, mu_hat=mu_hat, sigma_hat=sigma_hat))
+
+    """
+    x, w = hermgauss(deg=n)
+    w_star = w * np.exp(x**2)
+    g_x_star = func(mu_hat + np.sqrt(2) * sigma_hat * x, *args)
+    if zero_nan:
+        g_x_star[np.isnan(g_x_star)] = 0
+    val = np.sqrt(2) * sigma_hat * np.sum(w_star * g_x_star)
+    return val

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -884,10 +884,12 @@ def gh_quad(func, n, args=(), mu_hat=0, sigma_hat=1, zero_nan=False):
         Extra arguments to pass to `func`, if any.
     mu_hat : float, optional
         Location parameter, used to center the quadrature nodes near
-        the high-density region.
+        the high-density region (e.g. the mean or mode if `func` is proportional
+        to a probability density).
     sigma_hat : float, optional
         Scale parameter, used to determine how much to spread out the quadrature
-        nodes.
+        nodes (e.g. the standard deviation if `func` is proportional to a
+        probability density).
     zero_nan : bool, optional
         If `func(x)` returns `nan` (e.g. if a quadrature point falls outside the
         domain of x), should this value be coerced to zero? Default is False.

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -150,20 +150,20 @@ class TestQuadrature(TestCase):
         assert_equal(gh_quad(lambda x: norm.pdf(x/2), 2, sigma_hat = 2), 2.0)
 
     def test_gh2(self):
-        """Compare with some results from the documentation of the fastGHQuad
+        """Compare with some results from the documentation of the `fastGHQuad`
         R package"""
 
         # Area under the Laplace (double-exponential) distribution
         def laplace(x):
             return np.exp(-np.abs(x))
-        assert_almost_equal(gh_quad(laplace, n=10, sigma_hat=2), 1.718700690246941, 14)
-        assert_almost_equal(gh_quad(laplace, n=100, sigma_hat=2), 1.967637483702098, 14)
+        assert_almost_equal(gh_quad(laplace, n=10, sigma_hat=2), 1.718700690246941)
+        assert_almost_equal(gh_quad(laplace, n=100, sigma_hat=2), 1.967637483702098)
 
         # Variance of the Laplace (double-exponential) distribution
         def var_laplace(x):
             return x**2 * np.exp(-np.abs(x)) / 2.0
-        assert_almost_equal(gh_quad(var_laplace, n=10, sigma_hat=2), 2.073013772758906, 14)
-        assert_almost_equal(gh_quad(var_laplace, n=100, sigma_hat=2), 2.001086971280583, 14)
+        assert_almost_equal(gh_quad(var_laplace, n=10, sigma_hat=2), 2.073013772758906)
+        assert_almost_equal(gh_quad(var_laplace, n=100, sigma_hat=2), 2.001086971280583)
 
 
 class TestCumtrapz(TestCase):

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import warnings
 import numpy as np
 from numpy import cos, sin, pi
-from numpy.stats import norm
+from scipy.stats import norm
 from numpy.testing import TestCase, run_module_suite, assert_equal, \
     assert_almost_equal, assert_allclose, assert_
 

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -150,8 +150,9 @@ class TestQuadrature(TestCase):
         assert_equal(gh_quad(lambda x: norm.pdf(x/2), 2, sigma_hat = 2), 2.0)
 
     def test_gh2(self):
-        """Compare with some results from the documentation of the `fastGHQuad`
-        R package"""
+        """Compare with some results from the documentation of Alexander W
+        Blocker's `fastGHQuad` package (version 0.2), available from
+        https://CRAN.R-project.org/package=fastGHQuad"""
 
         # Area under the Laplace (double-exponential) distribution
         def laplace(x):


### PR DESCRIPTION
[Gauss-Hermite quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Hermite_quadrature) is useful for indefinite intervals involving probability distributions, especially in contexts with infinite mixtures such as generalized linear mixed models. The submitted function is designed to allow users to use this technique without manually shifting and scaling the output of ~~numpy.polynomial.hermite.hermgauss~~ `scipy.special.h_roots`.

This is my first time submitting to a large Python project, and I apologize in advance if there's anything wrong with this PR.  I hope it's useful.
