### PR TITLE
ENH: Add covariance functionality to scipy.optimize.curve_fit

### DIFF
--- a/scipy/optimize/minpack.py
+++ b/scipy/optimize/minpack.py
@@ -8,7 +8,7 @@ from numpy import (atleast_1d, dot, take, triu, shape, eye,
                    transpose, zeros, product, greater, array,
                    all, where, isscalar, asarray, inf, abs,
                    finfo, inexact, issubdtype, dtype)
-from scipy.linalg import svd
+from scipy.linalg import svd, cholesky, solve_triangular, LinAlgError
 from scipy._lib._util import _asarray_validated, _lazywhere
 from .optimize import OptimizeResult, _check_unknown_options, OptimizeWarning
 from ._lsq import least_squares
@@ -436,7 +436,6 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
         cov_x = None
         if info in [1, 2, 3, 4]:
             from numpy.dual import inv
-            from numpy.linalg import LinAlgError
             perm = take(eye(n), retval[1]['ipvt'] - 1, 0)
             r = triu(transpose(retval[1]['fjac'])[:n, :])
             R = dot(r, perm)
@@ -449,23 +448,37 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=0,
         return (retval[0], info)
 
 
-def _wrap_func(func, xdata, ydata, weights):
-    if weights is None:
+def _wrap_func(func, xdata, ydata, transform):
+    if transform is None:
         def func_wrapped(params):
             return func(xdata, *params) - ydata
-    else:
+    elif transform.ndim == 1:
         def func_wrapped(params):
-            return weights * (func(xdata, *params) - ydata)
+            return transform * (func(xdata, *params) - ydata)
+    else:
+        # Chisq = (y - yd)^T C^{-1} (y-yd)
+        # transform = L such that C = L L^T
+        # C^{-1} = L^{-T} L^{-1}
+        # Chisq = (y - yd)^T L^{-T} L^{-1} (y-yd)
+        # Define (y-yd)' = L^{-1} (y-yd)
+        # by solving
+        # L (y-yd)' = (y-yd)
+        # and minimize (y-yd)'^T (y-yd)'
+        def func_wrapped(params):
+            return solve_triangular(transform, func(xdata, *params) - ydata, lower=True)
     return func_wrapped
 
 
-def _wrap_jac(jac, xdata, weights):
-    if weights is None:
+def _wrap_jac(jac, xdata, transform):
+    if transform is None:
         def jac_wrapped(params):
             return jac(xdata, *params)
+    elif transform.ndim == 1:
+        def jac_wrapped(params):
+            return transform[:, np.newaxis] * np.asarray(jac(xdata, *params))
     else:
         def jac_wrapped(params):
-            return weights[:, np.newaxis] * np.asarray(jac(xdata, *params))
+            return solve_triangular(transform, np.asarray(jac(xdata, *params)), lower=True)
     return jac_wrapped
 
 
@@ -476,10 +489,10 @@ def _initialize_feasible(lb, ub):
 
     mask = lb_finite & ub_finite
     p0[mask] = 0.5 * (lb[mask] + ub[mask])
-    
+
     mask = lb_finite & ~ub_finite
     p0[mask] = lb[mask] + 1
-    
+
     mask = ~lb_finite & ub_finite
     p0[mask] = ub[mask] - 1
 
@@ -500,8 +513,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         The model function, f(x, ...).  It must take the independent
         variable as the first argument and the parameters to fit as
         separate remaining arguments.
-    xdata : An M-length sequence or an (k,M)-shaped array
-        for functions with k predictors.
+    xdata : An M-length sequence or an (k,M)-shaped array for functions with k predictors
         The independent variable where the data is measured.
     ydata : M-length sequence
         The dependent data --- nominally f(xdata, ...)
@@ -510,28 +522,41 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         values will all be 1 (if the number of parameters for the function
         can be determined using introspection, otherwise a ValueError
         is raised).
-    sigma : None or M-length sequence, optional
-        If not None, the uncertainties in the ydata array. These are used as
-        weights in the least-squares problem
-        i.e. minimising ``np.sum( ((f(xdata, *popt) - ydata) / sigma)**2 )``
-        If None, the uncertainties are assumed to be 1.
-    absolute_sigma : bool, optional
-        If False, `sigma` denotes relative weights of the data points.
-        The returned covariance matrix `pcov` is based on *estimated*
-        errors in the data, and is not affected by the overall
-        magnitude of the values in `sigma`. Only the relative
-        magnitudes of the `sigma` values matter.
+    sigma : None or M-length sequence or MxM array, optional
+        Determines the uncertainty in `ydata`. If we define residuals as
+        ``r = ydata - f(xdata, *popt)``, then the interpretation of `sigma`
+        depends on its number of dimensions:
 
-        If True, `sigma` describes one standard deviation errors of
-        the input data points. The estimated covariance in `pcov` is
-        based on these values.
+            - A 1-d `sigma` should contain values of standard deviations of
+              errors in `ydata`. In this case, the optimized function is
+              ``chisq = sum((r / sigma) ** 2)``.
+
+            - A 2-d `sigma` should contain the covariance matrix of
+              errors in `ydata`. In this case, the optimized function is
+              ``chisq = r.T @ inv(sigma) @ r``.
+
+              .. versionadded:: 0.19
+
+        None (default) is equivalent of 1-d `sigma` filled with ones.
+    absolute_sigma : bool, optional
+        If True, `sigma` is used in an absolute sense and the estimated parameter
+        covariance `pcov` reflects these absolute values.
+
+        If False, only the relative magnitudes of the `sigma` values matter.
+        The returned parameter covariance matrix `pcov` is based on scaling
+        `sigma` by a constant factor. This constant is set by demanding that the
+        reduced `chisq` for the optimal parameters `popt` when using the
+        *scaled* `sigma` equals unity. In other words, `sigma` is scaled to
+        match the sample variance of the residuals after the fit.
+        Mathematically,
+        ``pcov(absolute_sigma=False) = pcov(absolute_sigma=True) * chisq(popt)/(M-N)``
     check_finite : bool, optional
         If True, check that the input arrays do not contain nans of infs,
         and raise a ValueError if they do. Setting this parameter to
         False may silently produce nonsensical results if the input arrays
         do contain nans. Default is True.
     bounds : 2-tuple of array_like, optional
-        Lower and upper bounds on independent variables. Defaults to no bounds.        
+        Lower and upper bounds on independent variables. Defaults to no bounds.
         Each element of the tuple must be either an array with the length equal
         to the number of parameters, or a scalar (in which case the bound is
         taken to be the same for all parameters.) Use ``np.inf`` with an
@@ -562,8 +587,8 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     Returns
     -------
     popt : array
-        Optimal values for the parameters so that the sum of the squared error
-        of ``f(xdata, *popt) - ydata`` is minimized
+        Optimal values for the parameters so that the sum of the squared
+        residuals of ``f(xdata, *popt) - ydata`` is minimized
     pcov : 2d array
         The estimated covariance of popt. The diagonals provide the variance
         of the parameter estimate. To compute one standard deviation errors
@@ -663,10 +688,29 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
         else:
             xdata = np.asarray(xdata)
 
-    weights = 1.0 / asarray(sigma) if sigma is not None else None
-    func = _wrap_func(f, xdata, ydata, weights)
+    # Determine type of sigma
+    if sigma is not None:
+        sigma = np.asarray(sigma)
+
+        # if 1-d, sigma are errors, define transform = 1/sigma
+        if sigma.shape == (ydata.size, ):
+            transform = 1.0 / sigma
+        # if 2-d, sigma is the covariance matrix,
+        # define transform = L such that L L^T = C
+        elif sigma.shape == (ydata.size, ydata.size):
+            try:
+                # scipy.linalg.cholesky requires lower=True to return L L^T = A
+                transform = cholesky(sigma, lower=True)
+            except LinAlgError:
+                raise ValueError("`sigma` must be positive definite.")
+        else:
+            raise ValueError("`sigma` has incorrect shape.")
+    else:
+        transform = None
+
+    func = _wrap_func(f, xdata, ydata, transform)
     if callable(jac):
-        jac = _wrap_jac(jac, xdata, weights)
+        jac = _wrap_jac(jac, xdata, transform)
     elif jac is None and method != 'lm':
         jac = '2-point'
 

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -517,6 +517,77 @@ class TestCurveFit(TestCase):
         assert_allclose(popt1, 2, atol=1e-14)
         assert_allclose(popt2, 2, atol=1e-14)
 
+    def test_curvefit_simplecovariance(self):
+
+        def func(x, a, b):
+            return a * np.exp(-b*x)
+
+        def jac(x, a, b):
+            e = np.exp(-b*x)
+            return np.vstack((e, -a * x * e)).T
+
+        np.random.seed(0)
+        xdata = np.linspace(0, 4, 50)
+        y = func(xdata, 2.5, 1.3)
+        ydata = y + 0.2 * np.random.normal(size=len(xdata))
+
+        sigma = np.zeros(len(xdata)) + 0.2
+        covar = np.diag(sigma**2)
+
+        for jac1, jac2 in [(jac, jac), (None, None)]:
+            for absolute_sigma in [False, True]:
+                popt1, pcov1 = curve_fit(func, xdata, ydata, sigma=sigma,
+                        jac=jac1, absolute_sigma=absolute_sigma)
+                popt2, pcov2 = curve_fit(func, xdata, ydata, sigma=covar,
+                        jac=jac2, absolute_sigma=absolute_sigma)
+
+                assert_allclose(popt1, popt2, atol=1e-14)
+                assert_allclose(pcov1, pcov2, atol=1e-14)
+
+    def test_curvefit_covariance(self):
+
+        def funcp(x, a, b):
+            rotn = np.array([[1./np.sqrt(2), -1./np.sqrt(2), 0], [1./np.sqrt(2), 1./np.sqrt(2), 0], [0, 0, 1.0]])
+            return rotn.dot(a * np.exp(-b*x))
+
+        def jacp(x, a, b):
+            rotn = np.array([[1./np.sqrt(2), -1./np.sqrt(2), 0], [1./np.sqrt(2), 1./np.sqrt(2), 0], [0, 0, 1.0]])
+            e = np.exp(-b*x)
+            return rotn.dot(np.vstack((e, -a * x * e)).T)
+
+        def func(x, a, b):
+            return a * np.exp(-b*x)
+
+        def jac(x, a, b):
+            e = np.exp(-b*x)
+            return np.vstack((e, -a * x * e)).T
+
+        np.random.seed(0)
+        xdata = np.arange(1, 4)
+        y = func(xdata, 2.5, 1.0)
+        ydata = y + 0.2 * np.random.normal(size=len(xdata))
+        sigma = np.zeros(len(xdata)) + 0.2
+        covar = np.diag(sigma**2)
+        # Get a rotation matrix, and obtain ydatap = R ydata
+        # Chisq = ydata^T C^{-1} ydata
+        #       = ydata^T R^T R C^{-1} R^T R ydata
+        #       = ydatap^T Cp^{-1} ydatap
+        # Cp^{-1} = R C^{-1} R^T
+        # Cp      = R C R^T, since R^-1 = R^T
+        rotn = np.array([[1./np.sqrt(2), -1./np.sqrt(2), 0], [1./np.sqrt(2), 1./np.sqrt(2), 0], [0, 0, 1.0]])
+        ydatap = rotn.dot(ydata)
+        covarp = rotn.dot(covar).dot(rotn.T)
+
+        for jac1, jac2 in [(jac, jacp), (None, None)]:
+            for absolute_sigma in [False, True]:
+                popt1, pcov1 = curve_fit(func, xdata, ydata, sigma=sigma,
+                        jac=jac1, absolute_sigma=absolute_sigma)
+                popt2, pcov2 = curve_fit(funcp, xdata, ydatap, sigma=covarp,
+                        jac=jac2, absolute_sigma=absolute_sigma)
+
+                assert_allclose(popt1, popt2, atol=1e-14)
+                assert_allclose(pcov1, pcov2, atol=1e-14)
+
 
 class TestFixedPoint(TestCase):
 


### PR DESCRIPTION
The current version of curve_fit does not support data with covariant errors. This pull request modifies curve_fit to account for covariant errors.
