### PR TITLE
BUG: Use MST algorithm instead of SLINK for single linkage clustering

### DIFF
--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -368,45 +368,6 @@ def cophenetic_distances(double[:, :] Z, double[:] d, int n):
     PyMem_Free(visited)
 
 
-cdef from_pointer_representation(double[:, :] Z, double[:] Lambda, int[:] Pi,
-                                 int n):
-    """
-    Generate a linkage matrix from its pointer representation.
-
-    Parameters
-    ----------
-    Z : ndarray
-        An array to store the linkage matrix.
-    Lambda : ndarray
-        The :math:`\\Lambda` array of the pointer representation.
-    Pi : ndarray
-        The :math:`\\Pi` array of the pointer representation.
-    n : int
-        The number of observations.
-    """
-    cdef int i, current_leaf, pi
-    cdef np.intp_t[:] sorted_idx = np.argsort(Lambda)
-    cdef int[:] node_ids = np.ndarray(n, dtype=np.intc)
-
-    for i in range(n):
-        node_ids[i] = i
-
-    for i in range(n - 1):
-        current_leaf = sorted_idx[i]
-        pi = Pi[current_leaf]
-        if node_ids[current_leaf] < node_ids[pi]:
-            Z[i, 0] = node_ids[current_leaf]
-            Z[i, 1] = node_ids[pi]
-        else:
-            Z[i, 0] = node_ids[pi]
-            Z[i, 1] = node_ids[current_leaf]
-        Z[i, 2] = Lambda[current_leaf]
-        node_ids[pi] = n + i
-
-    Z[:, 3] = 0
-    calculate_cluster_sizes(Z, Z[:, 3], n)
-
-
 cpdef void get_max_Rfield_for_each_cluster(double[:, :] Z, double[:, :] R,
                                            double[:] max_rfs, int n, int rf):
     """
@@ -813,7 +774,7 @@ def nn_chain(double[:] dists, int n, int method):
     cdef double[:, :] Z = Z_arr
 
     cdef double[:] D = dists.copy()  # Distances between clusters.
-    cdef int [:] size = np.ones(n, dtype=np.intc)  # Sizes of clusters.
+    cdef int[:] size = np.ones(n, dtype=np.intc)  # Sizes of clusters.
 
     cdef linkage_distance_update new_dist = linkage_methods[method]
 
@@ -888,18 +849,82 @@ def nn_chain(double[:] dists, int n, int method):
     return Z_arr
 
 
+def mst_single_linkage(double[:] dists, int n):
+    """Perform hierarchy clustering using MST algorithm for single linkage.
+
+    Parameters
+    ----------
+    dists : ndarray
+        A condensed matrix stores the pairwise distances of the observations.
+    n : int
+        The number of observations.
+
+    Returns
+    -------
+    Z : ndarray, shape (n - 1, 4)
+        Computed linkage matrix.
+    """
+    Z_arr = np.empty((n - 1, 4))
+    cdef double[:, :] Z = Z_arr
+
+    # Which clusters were already merged.
+    cdef int[:] merged = np.zeros(n, dtype=np.intc)
+
+    cdef double[:] D = np.empty(n)
+    D[:] = NPY_INFINITYF
+
+    cdef int i, k, x, y
+    cdef double dist, current_min
+
+    x = 0
+    for k in range(n - 1):
+        current_min = NPY_INFINITYF
+        merged[x] = 1
+        for i in range(n):
+            if merged[i] == 1:
+                continue
+
+            dist = dists[condensed_index(n, x, i)]
+            if D[i] > dist:
+                D[i] = dist
+
+            if D[i] < current_min:
+                y = i
+                current_min = D[i]
+
+        Z[k, 0] = x
+        Z[k, 1] = y
+        Z[k, 2] = current_min
+        x = y
+
+    # Sort Z by cluster distances.
+    order = np.argsort(Z_arr[:, 2], kind='mergesort')
+    Z_arr = Z_arr[order]
+
+    # Find correct cluster labels and compute cluster sizes inplace.
+    label(Z_arr, n)
+
+    return Z_arr
+
+
 cdef class LinkageUnionFind:
-    cdef int [:] parent
+    """Structure for fast cluster labeling in unsorted dendrogram."""
+    cdef int[:] parent
+    cdef int[:] size
     cdef int next_label
 
     def __init__(self, int n):
         self.parent = np.arange(2 * n - 1, dtype=np.intc)
         self.next_label = n
+        self.size = np.ones(2 * n - 1, dtype=np.intc)
 
-    cdef merge(self, int x, int y):
+    cdef int merge(self, int x, int y):
         self.parent[x] = self.next_label
         self.parent[y] = self.next_label
+        cdef int size = self.size[x] + self.size[y]
+        self.size[self.next_label] = size
         self.next_label += 1
+        return size
 
     cdef find(self, int x):
         cdef int p = x
@@ -914,16 +939,17 @@ cdef class LinkageUnionFind:
 
 
 cdef label(double[:, :] Z, int n):
+    """Correctly label clusters in unsorted dendrogram."""
     cdef LinkageUnionFind uf = LinkageUnionFind(n)
     cdef int i, x, y, x_root, y_root
     for i in range(n - 1):
         x, y = int(Z[i, 0]), int(Z[i, 1])
         x_root, y_root = uf.find(x), uf.find(y)
-        uf.merge(x, y)
         if x_root < y_root:
             Z[i, 0], Z[i, 1] = x_root, y_root
         else:
             Z[i, 0], Z[i, 1] = y_root, x_root
+        Z[i, 3] = uf.merge(x_root, y_root)
 
 
 def prelist(double[:, :] Z, int[:] members, int n):
@@ -980,57 +1006,3 @@ def prelist(double[:, :] Z, int[:] members, int n):
         k -= 1
 
     PyMem_Free(visited)
-
-
-def slink(double[:] dists, int n):
-    """
-    The SLINK algorithm. Single linkage in O(n^2) time complexity.
-
-    Parameters
-    ----------
-    dists : ndarray
-        A condensed matrix stores the pairwise distances of the observations.
-    n : int
-        The number of observations.
-
-    Returns
-    -------
-    Z : ndarray, shape (n - 1, 4)
-        Compute linkage matrix.
-
-    References
-    ----------
-    R. Sibson, "SLINK: An optimally efficient algorithm for the single-link
-    cluster method", The Computer Journal 1973 16: 30-34.
-    """
-    Z_arr = np.empty((n - 1, 4))
-    cdef double[:, :] Z = Z_arr
-
-    cdef int i, j
-    cdef double[:] M = np.ndarray(n, dtype=np.double)
-    cdef double[:] Lambda = np.ndarray(n, dtype=np.double)
-    cdef int[:] Pi = np.ndarray(n, dtype=np.intc)
-
-    Pi[0] = 0
-    Lambda[0] = NPY_INFINITYF
-    for i in range(1, n):
-        Pi[i] = i
-        Lambda[i] = NPY_INFINITYF
-
-        for j in range(i):
-            M[j] = dists[condensed_index(n, i, j)]
-
-        for j in range(i):
-            if Lambda[j] >= M[j]:
-                M[Pi[j]] = min(M[Pi[j]], Lambda[j])
-                Lambda[j] = M[j]
-                Pi[j] = i
-            else:
-                M[Pi[j]] = min(M[Pi[j]], M[j])
-
-        for j in range(i):
-            if Lambda[j] >= Lambda[Pi[j]]:
-                Pi[j] = i
-
-    from_pointer_representation(Z, Lambda, Pi, n)
-    return Z_arr

--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -867,7 +867,7 @@ def mst_single_linkage(double[:] dists, int n):
     Z_arr = np.empty((n - 1, 4))
     cdef double[:, :] Z = Z_arr
 
-    # Which clusters were already merged.
+    # Which nodes were already merged.
     cdef int[:] merged = np.zeros(n, dtype=np.intc)
 
     cdef double[:] D = np.empty(n)

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -627,10 +627,10 @@ def linkage(y, method='single', metric='euclidean'):
 
     Notes
     -----
-    1. For method 'single' an optimized algorithm called SLINK is implemented,
-       which has :math:`O(n^2)` time complexity.
+    1. For method 'single' an optimized algorithm based on minimum spanning
+       tree is implemented. It has time complexity :math:`O(n^2)`.
        For methods 'complete', 'average', 'weighted' and 'ward' an algorithm
-       called nearest-neighbors chain is implemented, which too has time
+       called nearest-neighbors chain is implemented. It also has time
        complexity :math:`O(n^2)`.
        For other methods a naive algorithm is implemented with :math:`O(n^3)`
        time complexity.
@@ -672,7 +672,7 @@ def linkage(y, method='single', metric='euclidean'):
     n = int(distance.num_obs_y(y))
     method_code = _LINKAGE_METHODS[method]
     if method == 'single':
-        return _hierarchy.slink(y, n)
+        return _hierarchy.mst_single_linkage(y, n)
     elif method in ['complete', 'average', 'weighted', 'ward']:
         return _hierarchy.nn_chain(y, n, method_code)
     else:

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -138,36 +138,6 @@ class TestInconsistent(object):
                         hierarchy_test_data.inconsistent_ytdist[depth])
 
 
-class TestLinkageTies(object):
-    _expectations = {
-        'single': np.array([[0, 1, 1.41421356, 2],
-                            [2, 3, 1.41421356, 3]]),
-        'complete': np.array([[0, 1, 1.41421356, 2],
-                              [2, 3, 2.82842712, 3]]),
-        'average': np.array([[0, 1, 1.41421356, 2],
-                             [2, 3, 2.12132034, 3]]),
-        'weighted': np.array([[0, 1, 1.41421356, 2],
-                              [2, 3, 2.12132034, 3]]),
-        'centroid': np.array([[0, 1, 1.41421356, 2],
-                              [2, 3, 2.12132034, 3]]),
-        'median': np.array([[0, 1, 1.41421356, 2],
-                            [2, 3, 2.12132034, 3]]),
-        'ward': np.array([[0, 1, 1.41421356, 2],
-                          [2, 3, 2.44948974, 3]]),
-    }
-
-    def test_linkage_ties(self):
-        for method in ['single', 'complete', 'average', 'weighted',
-                       'centroid', 'median', 'ward']:
-            yield self.check_linkage_ties, method
-
-    def check_linkage_ties(self, method):
-        X = np.array([[-1, -1], [0, 0], [1, 1]])
-        Z = linkage(X, method=method)
-        expectedZ = self._expectations[method]
-        assert_allclose(Z, expectedZ, atol=1e-06)
-
-
 class TestCopheneticDistance(object):
     def test_linkage_cophenet_tdist_Z(self):
         # Tests cophenet(Z) on tdist data set.

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -109,6 +109,36 @@ class TestInconsistent(object):
                         hierarchy_test_data.inconsistent_ytdist[depth])
 
 
+class TestLinkageTies(object):
+    _expectations = {
+        'single': np.array([[0, 1, 1.41421356, 2],
+                            [2, 3, 1.41421356, 3]]),
+        'complete': np.array([[0, 1, 1.41421356, 2],
+                              [2, 3, 2.82842712, 3]]),
+        'average': np.array([[0, 1, 1.41421356, 2],
+                             [2, 3, 2.12132034, 3]]),
+        'weighted': np.array([[0, 1, 1.41421356, 2],
+                              [2, 3, 2.12132034, 3]]),
+        'centroid': np.array([[0, 1, 1.41421356, 2],
+                              [2, 3, 2.12132034, 3]]),
+        'median': np.array([[0, 1, 1.41421356, 2],
+                            [2, 3, 2.12132034, 3]]),
+        'ward': np.array([[0, 1, 1.41421356, 2],
+                          [2, 3, 2.44948974, 3]]),
+    }
+
+    def test_linkage_ties(self):
+        for method in ['single', 'complete', 'average', 'weighted',
+                       'centroid', 'median', 'ward']:
+            yield self.check_linkage_ties, method
+
+    def check_linkage_ties(self, method):
+        X = np.array([[-1, -1], [0, 0], [1, 1]])
+        Z = linkage(X, method=method)
+        expectedZ = self._expectations[method]
+        assert_allclose(Z, expectedZ, atol=1e-06)
+
+
 class TestCopheneticDistance(object):
     def test_linkage_cophenet_tdist_Z(self):
         # Tests cophenet(Z) on tdist data set.

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -98,6 +98,35 @@ class TestLinkage(object):
         assert_allclose(Z, expectedZ, atol=1e-06)
 
 
+class TestLinkageTies(object):
+    _expectations = {
+        'single': np.array([[0, 1, 1.41421356, 2],
+                            [2, 3, 1.41421356, 3]]),
+        'complete': np.array([[0, 1, 1.41421356, 2],
+                              [2, 3, 2.82842712, 3]]),
+        'average': np.array([[0, 1, 1.41421356, 2],
+                             [2, 3, 2.12132034, 3]]),
+        'weighted': np.array([[0, 1, 1.41421356, 2],
+                              [2, 3, 2.12132034, 3]]),
+        'centroid': np.array([[0, 1, 1.41421356, 2],
+                              [2, 3, 2.12132034, 3]]),
+        'median': np.array([[0, 1, 1.41421356, 2],
+                            [2, 3, 2.12132034, 3]]),
+        'ward': np.array([[0, 1, 1.41421356, 2],
+                          [2, 3, 2.44948974, 3]]),
+    }
+
+    def test_linkage_ties(self):
+        for method in ['single', 'complete', 'average', 'weighted', 'centroid', 'median', 'ward']:
+            yield self.check_linkage_ties, method
+
+    def check_linkage_ties(self, method):
+        X = np.array([[-1, -1], [0, 0], [1, 1]])
+        Z = linkage(X, method=method)
+        expectedZ = self._expectations[method]
+        assert_allclose(Z, expectedZ, atol=1e-06)
+
+
 class TestInconsistent(object):
     def test_inconsistent_tdist(self):
         for depth in hierarchy_test_data.inconsistent_ytdist:


### PR DESCRIPTION
Following #5960 I replaced SLINK algorithm with MST. It was rather straightforward to implement, except that post-labeling algorithm had to be changed slightly as well.

Timings show that MST is slightly faster on a random input and NN-CHAIN is about 2 times slower (so using MST makes sense).

Tests with ties (the very reason to replace SLINK) were taken from #5960.
