### PR TITLE
MAINT: replace author name map in tools/authors.py with git .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,211 @@
+#
+# Canonical author name mapping for git and tools/authors.py, in format:
+#
+#     Canonical Name <canonical.email@somewhere> Alias Name <alias.email@somewhere>
+#
+# The email address parts should match what is in git log. The tools/authors.py does
+# not care about them, so it is possible to leave the email part empty, but in this
+# case git commands won't recognize the alias.
+#
+# This file is up-to-date if the command git log --format="%aN <%aE>" | sort -u
+# does not list the same person multiple times.
+#
+@axiru <axiru@users.noreply.gihub.com> axiru <axiru@users.noreply.gihub.com>
+@cel4 <cel4@users.noreply.github.com> cel4 <cel4@users.noreply.github.com>
+@chemelnucfin <aw@sp3.com> aw <aw@sp3.com>
+@endolith <endolith@gmail.com> Endolith <endolith@gmail.com>
+@endolith <endolith@gmail.com> endolith <endolith@gmail.com>
+@mamrehn <mamrehn@users.noreply.github.com> mamrehn <mamrehn@users.noreply.github.com>
+Aldrian Obaja <> ubuntu <>
+Alex Griffing <argriffi@ncsu.edu> alex <argriffi@ncsu.edu>
+Alex Griffing <argriffi@ncsu.edu> argriffing <argriffing@gmail.com>
+Alex Griffing <argriffi@ncsu.edu> argriffing <argriffing@users.noreply.github.com>
+Aman Singh <bewithaman@outlook.com> bewithaman <bewithaman@outlook.com>
+Aman Thakral <aman.thakral@gmail.com> aman-thakral <aman.thakral@gmail.com>
+Amato Kasahara <thisisdummy@example.com> kshramt <thisisdummy@example.com>
+Anders Bech Borchersen <anb@es.aau.dk> andbo <anb@es.aau.dk>
+Andreas Hilboll <andreas@hilboll.de> Andreas H <andreas@hilboll.de>
+Andreas Hilboll <andreas@hilboll.de> Andreas Hilboll <andreas-h@users.noreply.github.com>
+Andreea Georgescu <ageorgescu@ucla.edu> Andreea_G <ageorgescu@ucla.edu>
+Andrew Fowlie <andrew.j.fowlie@googlemail.com> andrew <andrew.j.fowlie@googlemail.com>
+Andrew Nelson <andyfaff@gmail.com> Andrew Nelson <andrew@Andrews-MacBook-Pro.local>
+Andrew Nelson <andyfaff@gmail.com> Andrew Nelson <anz@d121131.ncnr.nist.gov>
+Andrew Sczesnak <andrewscz@gmail.com> polyatail <andrewscz@gmail.com>
+Anne Archibald <peridot.faceted@gmail.com> aarchiba <peridot.faceted@gmail.com>
+Anne Archibald <peridot.faceted@gmail.com> Anne Archibald <archibald@astron.nl>
+Ariel Rokem <arokem@gmail.com> ariel.rokem <ariel.rokem@localhost>
+Behzad Nouri <behzadnouri@gmail.com> behzad nouri <behzadnouri@gmail.com>
+Benjamin Root <> weathergod <>
+Benny Malengier <benny.malengier@gmail.com> Benny <benny.malengier@gmail.com>
+Bhavika Tekwani <bhavicka.7992@gmail.com> bhavikat <bhavicka.7992@gmail.com>
+Brett R. Murphy <bmurphy@enthought.com> brettrmurphy <bmurphy@enthought.com>
+Brian Hawthorne <brian.hawthorne@localhost> brian.hawthorne <brian.hawthorne@localhost>
+Brian Newsom <brian.newsom@colorado.edu> Brian Newsom <Brian.Newsom@Colorado.edu>
+Chris Burns <chris.burns@localhost> chris.burns <chris.burns@localhost>
+Chris Lasher <> gotgenes <>
+Christoph Gohlke <cgohlke@uci.edu> cgohlke <cgohlke@uci.edu>
+Christoph Gohlke <cgohlke@uci.edu> Christolph Gohlke <>
+Christoph Gohlke <cgohlke@uci.edu> cgholke <>
+Christopher Kuster <ckuster@carrollu.edu> ckuster <ckuster@carrollu.edu>
+Clemens Novak <clemens@familie-novak.net> cnovak <clemens@familie-novak.net>
+Clemens Novak <clemens@familie-novak.net> Clemens <clemens@familie-novak.net>
+Collin RM Stocks <> Collin Stocks <>
+Collin Tokheim <collintokheim@gmail.com> ctokheim <collintokheim@gmail.com>
+Daan Wynen <black.puppydog@gmx.de> Daan Wynen <black-puppydog@users.noreply.github.com>
+Damian Eads <damian.eads@localhost> damian.eads <damian.eads@localhost>
+Daniel B. Smith <smith.daniel.br@gmail.com> Daniel Smith <smith.daniel.br@gmail.com>
+Daniel B. Smith <smith.daniel.br@gmail.com> Daniel Smith <smithd.daniel.br@gmail.com>
+Daniel B. Smith <smith.daniel.br@gmail.com> Daniel Smith <smithd@daniel-laptop.(none)>
+Daniel B. Smith <smith.daniel.br@gmail.com> Daniel B. Smith <Daniel.Smith.Br@gmail.com>
+Daniel B. Smith <smith.daniel.br@gmail.com> Daniel B. Smith <neuromathdan@gmail.com>
+Daniel B. Smith <smith.daniel.br@gmail.com> Daniel <smith.daniel.br@gmail.com>
+Danilo Horta <danilo.horta@gmail.com> Horta <danilo.horta@gmail.com>
+David Huard <dhuard@localhost> dhuard <dhuard@localhost>
+David Simcha <> dsimcha <>
+David Menéndez Hurtado <davidmenhur@gmail.com> Dapid <davidmenhur@gmail.com>
+David Menéndez Hurtado <davidmenhur@gmail.com> David Menéndez Hurtado <david.menendez.hurtado@scilifelab.se>
+David Menéndez Hurtado <davidmenhur@gmail.com> David Menendez Hurtado <davidmenhur@gmail.com>
+David Warde-Farley <wardefar@iro.umontreal.ca> david.warde-farley <david.warde-farley@localhost>
+Denis Laxalde <denis@laxalde.org> Denis Laxalde <denis.laxalde@logilab.fr>
+Denis Laxalde <denis@laxalde.org> Denis Laxalde <denis.laxalde@mcgill.ca>
+Denis Laxalde <denis@laxalde.org> Denis Laxalde <denis@mail.laxalde.org>
+Derek Homeier <> Derek Homeir <>
+Derek Homeier <> Derek Homier <>
+Dmitrey Kroshko <dmitrey.kroshko@localhost> dmitrey.kroshko <dmitrey.kroshko@localhost>
+Dávid Bodnár <david.bodnar@st.ovgu.de> bdvd <david.bodnar@st.ovgu.de>
+Ed Schofield <edschofield@localhost> edschofield <edschofield@localhost>
+Eric Larson <larson.eric.d@gmail.com> Eric89GXL <larson.eric.d@gmail.com>
+Eric Quintero <eric.antonio.quintero@gmail.com> e-q <eric.antonio.quintero@gmail.com>
+Eric Quintero <eric.antonio.quintero@gmail.com> Eric Quintero <e-q@users.noreply.github.com>
+Eric Soroos <eric-github@soroos.net> wiredfool <eric-github@soroos.net>
+Evgeni Burovski <evgeny.burovskiy@gmail.com> Zhenya <evgeni@burovski.me>
+Evgeni Burovski <evgeny.burovskiy@gmail.com> Evgeni Burovski <evgeni@burovski.me>
+Fabian Pedregosa <fabian@fseoane.net> Fabian Pedregosa <fabian.pedregosa@inria.fr>
+Felix Berkenkamp <befelix@ethz.ch> Felix <befelix@ethz.ch>
+Felix Berkenkamp <befelix@ethz.ch> Felix Berkenkamp <fberkenkamp@gmail.com>
+Florian Wilhelm <Florian.Wilhelm@gmail.com> Florian Wilhelm <Florian.Wilhelm@blue-yonder.com>
+François Boulogne <fboulogne sciunto org> François Boulogne <fboulogne at april dot org>
+François Boulogne <fboulogne sciunto org> François Boulogne <fboulogne@sciunto.org>
+Fukumu Tsutsumi <levelfourslv@gmail.com> levelfour <levelfourslv@gmail.com>
+G Young <gfyoung17@gmail.com> gfyoung <gfyoung17@gmail.com>
+G Young <gfyoung17@gmail.com> gfyoung <gfyoung@mit.edu>
+Garrett Reynolds <garrettreynolds5@gmail.com> Garrett-R <garrettreynolds5@gmail.com>
+Gaël Varoquaux <gael.varoquaux@normalesup.org> Gael varoquaux <gael.varoquaux@normalesup.org>
+Giorgio Patrini <giorgio.patrini@anu.edu.au> giorgiop <giorgio.patrini@anu.edu.au>
+Giorgio Patrini <giorgio.patrini@anu.edu.au> giorgiop <giorgio.patrini@nicta.com.au>
+Golnaz Irannejad <golnazirannejad@gmail.com> golnazir <golnazirannejad@gmail.com>
+Han Genuit <> 87 <>
+Han Genuit <> Han <>
+Helder Cesar <heldercro@gmail.com> Helder <heldercro@gmail.com>
+Helmut Toplitzer <helmut.toplitzer@ait.ac.at> HelmutAIT <helmut.toplitzer@ait.ac.at>
+Henry Lin <hlin117@gmail.com> hlin117 <hlin117@gmail.com>
+Ion Elberdin <ionelberdin@gmail.com> Ion <ionelberdin@gmail.com>
+Irvin Probst <irvin.probst@ensta-bretagne.fr> I--P <irvin.probst@ensta-bretagne.fr>
+Jacob Carey <jacobcvt12@gmail.com> Jacob Carey <Jacobcvt12@users.noreply.github.com>
+Jacob Vanderplas <jakevdp@gmail.com> Jake VanderPlas <jakevdp@gmail.com>
+Jacob Vanderplas <jakevdp@gmail.com> Jake Vanderplas <jakevdp@gmail.com>
+Jacob Vanderplas <jakevdp@gmail.com> Jake Vanderplas <jakevdp@yahoo.com>
+Jacob Vanderplas <jakevdp@gmail.com> Jake Vanderplas <vanderplas@astro.washington.edu>
+Jacob Vanderplas <jakevdp@gmail.com> Jacob Vanderplas <jakevdp@yahoo.com>
+Jaime Fernandez del Rio <jaime.frio@gmail.com> jaimefrio <jaime.frio@gmail.com>
+Jaime Fernandez del Rio <jaime.frio@gmail.com> Jaime <jaime.frio@gmail.com>
+James T. Webber <jamestwebber@gmail.com> jamestwebber <jamestwebber@gmail.com>
+Janani Padmanabhan <jenny.stone125@gmail.com> janani <janani@janani-Vostro-3446.(none)>
+Janani Padmanabhan <jenny.stone125@gmail.com> Janani <jenny.stone125@gmail.com>
+Jeff Armstrong <jeff@approximatrix.com> ArmstrongJ <approximatrix@gmail.com>
+Jeff Armstrong <jeff@approximatrix.com> Jeff Armstrong <jeff@approximatrix.com>
+Jesse Engel <jesse.engel@gmail.com> jesseengel <jesse.engel@gmail.com>
+Joel Nothman <joel.nothman@gmail.com> jnothman <jnothman@student.usyd.edu.au>
+Joel Nothman <joel.nothman@gmail.com> Joel Nothman <jnothman@student.usyd.edu.au>
+Jona Sassenhagen <jona.sassenhagen@gmail.com> jona-sassenhagen <jona.sassenhagen@gmail.com>
+Jonathan Taylor <jonathan.taylor@localhost> jonathan.taylor <jonathan.taylor@localhost>
+Joris Vankerschaver <joris.vankerschaver@gmail.com> Joris Vankerschaver <jvankerschaver@enthought.com>
+Joscha Reimer <jor@informatik.uni-kiel.de> jor <jor@informatik.uni-kiel.de>
+Josef Perktold <josef.pktd@gmail.com> josef-pktd <josef.pktd@gmail.com>
+Josef Perktold <josef.pktd@gmail.com> josef <josef@localhost>
+Joseph Fox-Rabinovitz <joseph.r.fox-rabinovitz@nasa.gov> Mad Physicist <madphysicist@users.noreply.github.com>
+Joseph Fox-Rabinovitz <joseph.r.fox-rabinovitz@nasa.gov> Joseph Fox-Rabinovitz <madphysicist@users.noreply.github.com>
+Josh Lawrence <josh.k.lawrence@gmail.com> wa03 <josh.k.lawrence@gmail.com>
+Josh Wilson <person142@users.noreply.github.com> Josh <person142@users.noreply.github.com>
+Juha Remes <jremes@outlook.com> newman101 <jremes@outlook.com>
+Kat Huang <kat@aya.yale.edu> kat <kat@aya.yale.edu>
+Lars Buitinck <larsmans@gmail.com> Lars <larsmans@users.noreply.github.com>
+Lars Buitinck <larsmans@gmail.com> Lars Buitinck <larsmans@users.noreply.github.com>
+Lars Buitinck <larsmans@gmail.com> Lars Buitinck <l.buitinck@esciencecenter.nl>
+Lars Buitinck <larsmans@gmail.com> Lars Buitinck <L.J.Buitinck@uva.nl>
+Lei Ma <emptymalei@qq.com> OctoMiao <emptymalei@qq.com>
+Liam Damewood <damewood@physics.ucdavis.edu> ldamewood <damewood@physics.ucdavis.edu>
+Liming Wang <lmwang@gmail.com> lmwang <lmwang@gmail.com>
+Lorenzo Luengo <> loluengo <>
+Luke Zoltan Kelley <lkelley@cfa.harvard.edu> lzkelley <lkelley@cfa.harvard.edu>
+Maniteja Nandana <manitejanmt@gmail.com> maniteja123 <manitejanmt@gmail.com>
+Marc Honnorat <marc.honnorat@gmail.com> honnorat <marc.honnorat@gmail.com>
+Marcello Seri <mseri@users.noreply.github.com> mseri <mseri@users.noreply.github.com>
+Mark Wiebe <> Mark <>
+Martin Manns <mmanns@gmx.net> manns <mmanns@gmx.net>
+Matteo Visconti <matteo.visconti.gr@dartmouth.edu> Matteo Visconti dOC <matteo.visconti.gr@dartmouth.edu>
+Max Bolingbroke <batterseapower@hotmail.com> DSG User <>
+Max Bolingbroke <batterseapower@hotmail.com> Max Bolingbroke <Max.Bolingbroke@gsacapital.com>
+Michael Droettboom <> mdroe <>
+Michael Hirsch <scienceopen@noreply.github.com> michael <scienceopen@noreply.github.com>
+Michael Hirsch <scienceopen@noreply.github.com> Michael Hirsch <scienceopen@users.noreply.github.com>
+Nathan Woods <woodscn@lanl.gov> Charles Nathan Woods <woodscn@pn1504346.lanl.gov>
+Nathan Woods <woodscn@lanl.gov> Nathan Woods <charlesnwoods@gmail.com>
+Nathan Woods <woodscn@lanl.gov> Nathan Woods <woodscn@pn1504346.lanl.gov>
+Neil Girdhar <mistersheik@gmail.com> Neil <mistersheik@gmail.com>
+Nicola Montecchio <nicola.montecchio@gmail.com> nicola montecchio <nicola.montecchio@gmail.com>
+Nikolai Nowaczyk <mail@nikno.de> Nikolai <mail@nikno.de>
+Nikolas Moya <nikolasmoya@gmail.com> nmoya <nikolasmoya@gmail.com>
+Nikolay Mayorov <nikolay.mayorov@zoho.com> Nikolay Mayorov <n59_ru@hotmail.com>
+Nikolay Mayorov <nikolay.mayorov@zoho.com> Nikolay Mayorov <nmayorov@users.noreply.github.com>
+Pablo Winant <pablo.winant@gmail.com> pablo.winant@gmail.com <Pablo Winant>
+Patrick Snape <patricksnape@gmail.com> patricksnape <patricksnape@gmail.com>
+Pedro López-Adeva Fernández-Layos <plopezadeva@gmail.com> plafl <plopezadeva@gmail.com>
+Pedro López-Adeva Fernández-Layos <plopezadeva@gmail.com> Pedro López-Adeva Fernández-Layos <plafl@users.noreply.github.com>
+Per Brodtkorb <per.andreas.brodtkorb@gmail.com> pbrod <per.andreas.brodtkorb@gmail.com>
+Perry Lee <mclee@aftercollege.com> Perry <mclee@aftercollege.com>
+Pete Bunch <pete.bunch@gmail.com> Pete <pete.bunch@gmail.com>
+Pierre GM <pierregm@localhost> pierregm <pierregm@localhost>
+Ralf Gommers <ralf.gommers@gmail.com> rgommers <ralf.gommers@googlemail.com>
+Ralf Gommers <ralf.gommers@gmail.com> Ralf Gommers <ralf.gommers@googlemail.com>
+Raphael Wettinger <ra@phael.org> raphael <ra@phael.org>
+Raphael Wettinger <ra@phael.org> raphaelw <raphael.wettinger@googlemail.com>
+Rob Falck <robfalck@gmail.com> rob.falck <rob.falck@localhost>
+Robert David Grant <rgrant@enthought.com> Robert David Grant <robert.david.grant@gmail.com>
+Robert Kern <rkern@enthought.com> Robert Kern <robert.kern@gmail.com>
+Rupak Das <dr10ru@yahoo.co.in> Rupak <dr10ru@yahoo.co.in>
+Sam Lewis <sam.vr.lewis@gmail.com> Sam Lewis <samvrlewis@users.noreply.github.com>
+Sam Mason <sam@samason.uk> Sam Mason <sam.mason@warwick.ac.uk>
+Scott Sievert <me@scottsievert.com> scottsievert <sieve121@umn.edu>
+Sebastian Haase <> sebhaase <>
+Sebastian Pucilowski <smopucilowski@gmail.com> Sebastian Pucilowski <smopucilowski@users.noreply.github.com>
+Sebastian Skoupý <sebastian.skoupy@gmail.com> Sebascn <sebastian.skoupy@gmail.com>
+Skipper Seabold <jsseabold@gmail.com> skip <skip@localhost>
+Stefan van der Walt <stefanv@berkeley.edu> Stefan van der Walt <sjvdwalt@gmail.com>
+Stefan van der Walt <stefanv@berkeley.edu> Stefan van der Walt <stefan@sun.ac.za>
+Steve Richardson <arichar6@gmail.com> arichar6 <arichar6@gmail.com>
+Sturla Molden <sturla@molden.no> sturlamolden <sturla@molden.no>
+Sturla Molden <sturla@molden.no> Sturla Molden <sturlamolden@users.noreply.github.com>
+Sumit Binnani <sumitbinnani.developer@gmail.com> sumitbinnani <sumitbinnani.developer@gmail.com>
+Sylvain Bellemare <sbellem@gmail.com> Sylvain Bellemare <sylvain.bellemare@ezeep.com>
+Sytse Knypstra <S.Knypstra@rug.nl> SytseK <S.Knypstra@rug.nl>
+Takuya Oshima <oshima@eng.niigata-u.ac.jp> Takuya OSHIMA <oshima@eng.niigata-u.ac.jp>
+Terry Jones <terry@fluidinfo.com> terrycojones <terry@fluidinfo.com>
+Thouis (Ray) Jones <thouis@gmail.com> Thouis (Ray) Jones <thouis@seas.harvard.edu>
+Tiago M.D. Pereira <tiagomdp@gmail.com> tiagopereira <tiagomdp@gmail.com>
+Tim Cera <tim@cerazone.net> timcera <tim@cerazone.net>
+Tim Leslie <tim.leslie@gmail.com> Tim Leslie <timl@breakawayconsulting.com.au>
+Tobias Schmidt <royalts@gmail.com> RoyalTS <royalts@gmail.com>
+Todd Goodall <beyondmetis@gmail.com> Todd <beyondmetis@gmail.com>
+Tom Waite <tom.waite@localhost> tom.waite <tom.waite@localhost>
+Tony S. Yu <tsyu80@gmail.com> tonysyu <tsyu80@gmail.com>
+Tony S. Yu <tsyu80@gmail.com> Tony S Yu <tsyu80@gmail.com>
+Travis Oliphant <teoliphant@gmail.com> Travis E. Oliphant <teoliphant@gmail.com>
+Travis Oliphant <teoliphant@gmail.com> Travis Oliphant <oliphant@enthought.com>
+Uwe Schmitt <uwe.schmitt@localhost> uwe.schmitt <uwe.schmitt@localhost>
+Warren Weckesser <warren.weckesser@gmail.com> warren.weckesser <warren.weckesser@localhost>
+Warren Weckesser <warren.weckesser@gmail.com> Warren Weckesser <warren.weckesser@enthought.com>
+Warren Weckesser <warren.weckesser@gmail.com> Warren Weckesser <warren.weckesser@localhost>
+Wendy Liu <ilostwaldo@gmail.com> dellsystem <ilostwaldo@gmail.com>
+Yu Feng <rainwoodman@gmail.com> Yu Feng <yfeng1@waterfall.dyn.berkeley.edu>
+Yves-Rémi Van Eycke <yves-remi@hotmail.com> vanpact <yves-remi@hotmail.com>

--- a/tools/authors.py
+++ b/tools/authors.py
@@ -5,6 +5,9 @@ git-authors [OPTIONS] REV1..REV2
 
 List the authors who contributed within a given revision interval.
 
+To change the name mapping, edit .mailmap on the top-level of the
+repository.
+
 """
 # Author: Pauli Virtanen <pav@iki.fi>. This script is in the public domain.
 
@@ -14,144 +17,23 @@ import optparse
 import re
 import sys
 import os
+import io
 import subprocess
 
 try:
-    from scipy._lib.six import u, PY3
+    from scipy._lib.six import PY3
 except ImportError:
     sys.path.insert(0, os.path.join(os.path.dirname(__file__),
                                     os.pardir, 'scipy', 'lib'))
-    from six import u, PY3
+    from six import PY3
 if PY3:
     stdout_b = sys.stdout.buffer
 else:
     stdout_b = sys.stdout
 
 
-NAME_MAP = {
-    u('87'): u('Han Genuit'),
-    u('aarchiba'): u('Anne Archibald'),
-    u('alex'): u('Alex Griffing'),
-    u('aman-thakral'): u('Aman Thakral'),
-    u('andbo'): u('Anders Bech Borchersen'),
-    u('andrew'): u('Andrew Fowlie'),
-    u('Andreea_G'): u('Andreea Georgescu'),
-    u('Andreas H'): u('Andreas Hilboll'),
-    u('argriffing'): u('Alex Griffing'),
-    u('arichar6'): u('Steve Richardson'),
-    u('ArmstrongJ'): u('Jeff Armstrong'),
-    u('aw'): u('@chemelnucfin'),
-    u('axiru'): u('@axiru'),
-    u('bdvd'): u('Dávid Bodnár'),
-    u('bhavikat'): u('Bhavika Tekwani'),
-    u('Benny'): u('Benny Malengier'),
-    u('behzad nouri'): u('Behzad Nouri'),
-    u('bewithaman'): u('Aman Singh'),
-    u('brettrmurphy'): u('Brett R. Murphy'),
-    u('Charles Nathan Woods'): u('Nathan Woods'),
-    u('cel4'): u('@cel4'),
-    u('cgholke'): u('Christoph Gohlke'),
-    u('cgohlke'): u('Christoph Gohlke'),
-    u('chris.burns'): u('Chris Burns'),
-    u('Christolph Gohlke'): u('Christoph Gohlke'),
-    u('ckuster'): u('Christopher Kuster'),
-    u('Collin Stocks'): u('Collin RM Stocks'),
-    u('cnovak'): u('Clemens Novak'),
-    u('ctokheim'): u('Collin Tokheim'),
-    u('Daniel Smith'): u('Daniel B. Smith'),
-    u('Dapid'): u('David Menendez Hurtado'),
-    u('dellsystem'): u('Wendy Liu'),
-    u('Derek Homeir'): u('Derek Homeier'),
-    u('Derek Homier'): u('Derek Homeier'),
-    u('DSG User'): u('Max Bolingbroke'),
-    u('dhuard'): u('David Huard'),
-    u('dsimcha'): u('David Simcha'),
-    u('edschofield'): u('Ed Schofield'),
-    u('endolith'): u('@endolith'),
-    u('Endolith'): u('@endolith'),
-    u('e-q'): u('Eric Quintero'),
-    u('Eric89GXL'): u('Eric Larson'),
-    u('Gael varoquaux'): u('Gaël Varoquaux'),
-    u('Garrett-R'): u('Garrett Reynolds'),
-    u('gfyoung'): u('G Young'),
-    u('giorgiop'): u('Giorgio Patrini'),
-    u('gotgenes'): u('Chris Lasher'),
-    u('golnazir'): u('Golnaz Irannejad'),
-    u('Han'): u('Han Genuit'),
-    u('Helder'): u('Helder Cesar'),
-    u('HelmutAIT'): u('Helmut Toplitzer'),
-    u('hlin117'): u('Henry Lin'),
-    u('honnorat'): u('Marc Honnorat'),
-    u('Horta'): u('Danilo Horta'),
-    u('I--P'): u('Irvin Probst'),
-    u('Ion'): u('Ion Elberdin'),
-    u('Jake Vanderplas'): u('Jacob Vanderplas'),
-    u('Jake VanderPlas'): u('Jacob Vanderplas'),
-    u('jamestwebber'): u('James T. Webber'),
-    u('jaimefrio'): u('Jaime Fernandez del Rio'),
-    u('Jaime'): u('Jaime Fernandez del Rio'),
-    u('janani'): u('Janani Padmanabhan'),
-    u('Janani'): u('Janani Padmanabhan'),
-    u('jnothman'): u('Joel Nothman'),
-    u('jona-sassenhagen'): u('Jona Sassenhagen'),
-    u('jor'): u('Joscha Reimer'),
-    u('jesseengel'): u('Jesse Engel'),
-    u('josef'): u('Josef Perktold'),
-    u('josef-pktd'): u('Josef Perktold'),
-    u('Josh'): u('Josh Wilson'),
-    u('kat'): u('Kat Huang'),
-    u('kshramt'): u('Amato Kasahara'),
-    u('Lars'): u('Lars Buitinck'),
-    u('ldamewood'): u('Liam Damewood'),
-    u('levelfour'): u('Fukumu Tsutsumi'),
-    u('lmwang'): u('Liming Wang'),
-    u('loluengo'): u('Lorenzo Luengo'),
-    u('lzkelley'): u('Luke Zoltan Kelley'),
-    u('Mad Physicist'): u('Joseph Fox-Rabinovitz'),
-    u('mamrehn'): u('@mamrehn'),
-    u('manns'): u('Martin Manns'),
-    u('Mark'): u('Mark Wiebe'),
-    u('mdroe'): u('Michael Droettboom'),
-    u('maniteja123'): u('Maniteja Nandana'),
-    u('mseri'): u('Marcello Seri'),
-    u('Matteo Visconti dOC'): u('Matteo Visconti'),
-    u('michael'): u('Michael Hirsch'),     # @scienceopen @ GH
-    u('Neil'): u('Neil Girdhar'),
-    u('newman101'): u('Juha Remes'),
-    u('nicola montecchio'): u('Nicola Montecchio'),
-    u('Nikolai'): u('Nikolai Nowaczyk'),
-    u('nmoya'): u('Nikolas Moya'),
-    u('OctoMiao'): u('Lei Ma'),
-    u('patricksnape'): u('Patrick Snape'),
-    u('pbrod'): u('Per Brodtkorb'),
-    u('Pete'): u('Pete Bunch'),
-    u('Perry'): u('Perry Lee'),
-    u('pierregm'): u('Pierre GM'),
-    u('plafl'): u('Pedro López-Adeva Fernández-Layos'),
-    u('polyatail'): u('Andrew Sczesnak'),
-    u('raphael'): u('Raphael Wettinger'),
-    u('raphaelw'): u('Raphael Wettinger'),
-    u('rgommers'): u('Ralf Gommers'),
-    u('RoyalTS'): u('Tobias Schmidt'),
-    u('Rupak'): u('Rupak Das'),
-    u('Sebascn'): u('Sebastian Skoupý'),
-    u('sebhaase'): u('Sebastian Haase'),
-    u('sumitbinnani'): u('Sumit Binnani'),
-    u('SytseK'): u('Sytse Knypstra'),
-    u('Takuya OSHIMA'): u('Takuya Oshima'),
-    u('terrycojones'): u('Terry Jones'),
-    u('tiagopereira'): u('Tiago M.D. Pereira'),
-    u('tonysyu'): u('Tony S. Yu'),
-    u('Travis E. Oliphant'): u('Travis Oliphant'),
-    u('Todd'): u('Todd Goodall'),   # @beyondmetis @ GH
-    u('vanpact'): u('Yves-Rémi Van Eycke'),
-    u('ubuntu'): u('Aldrian Obaja'),
-    u('wa03'): u('Josh Lawrence'),
-    u('warren.weckesser'): u('Warren Weckesser'),
-    u('weathergod'): u('Benjamin Root'),
-    u('wiredfool'): u('Eric Soroos'),
-    u('Zhenya'): u('Evgeni Burovski'),
-}
+MAILMAP_FILE = os.path.join(os.path.dirname(__file__), "..", ".mailmap")
+
 
 def main():
     p = optparse.OptionParser(__doc__.strip())
@@ -167,6 +49,8 @@ def main():
     except ValueError:
         p.error("argument is not a revision range")
 
+    NAME_MAP = load_name_map(MAILMAP_FILE)
+
     # Analyze log data
     all_authors = set()
     authors = set()
@@ -175,7 +59,7 @@ def main():
         line = line.strip().decode('utf-8')
 
         # Check the commit author name
-        m = re.match(u('^@@@([^@]*)@@@'), line)
+        m = re.match(u'^@@@([^@]*)@@@', line)
         if m:
             name = m.group(1)
             line = line[m.end():]
@@ -186,17 +70,17 @@ def main():
             names.add(name)
 
         # Look for "thanks to" messages in the commit log
-        m = re.search(u(r'([Tt]hanks to|[Cc]ourtesy of) ([A-Z][A-Za-z]*? [A-Z][A-Za-z]*? [A-Z][A-Za-z]*|[A-Z][A-Za-z]*? [A-Z]\. [A-Z][A-Za-z]*|[A-Z][A-Za-z ]*? [A-Z][A-Za-z]*|[a-z0-9]+)($|\.| )'), line)
+        m = re.search(r'([Tt]hanks to|[Cc]ourtesy of) ([A-Z][A-Za-z]*? [A-Z][A-Za-z]*? [A-Z][A-Za-z]*|[A-Z][A-Za-z]*? [A-Z]\. [A-Z][A-Za-z]*|[A-Z][A-Za-z ]*? [A-Z][A-Za-z]*|[a-z0-9]+)($|\.| )', line)
         if m:
             name = m.group(2)
-            if name not in (u('this'),):
+            if name not in (u'this',):
                 if disp:
                     stdout_b.write("    - Log   : %s\n" % line.strip().encode('utf-8'))
                 name = NAME_MAP.get(name, name)
                 names.add(name)
 
             line = line[m.end():].strip()
-            line = re.sub(u(r'^(and|, and|, ) '), u('Thanks to '), line)
+            line = re.sub(r'^(and|, and|, ) ', u'Thanks to ', line)
             analyze_line(line.encode('utf-8'), names)
 
     # Find all authors before the named range
@@ -211,18 +95,18 @@ def main():
 
     # Sort
     def name_key(fullname):
-        m = re.search(u(' [a-z ]*[A-Za-z-]+$'), fullname)
+        m = re.search(u' [a-z ]*[A-Za-z-]+$', fullname)
         if m:
             forename = fullname[:m.start()].strip()
             surname = fullname[m.start():].strip()
         else:
             forename = ""
             surname = fullname.strip()
-        if surname.startswith(u('van der ')):
+        if surname.startswith(u'van der '):
             surname = surname[8:]
-        if surname.startswith(u('de ')):
+        if surname.startswith(u'de '):
             surname = surname[3:]
-        if surname.startswith(u('von ')):
+        if surname.startswith(u'von '):
             surname = surname[4:]
         return (surname.lower(), forename.lower())
 
@@ -251,6 +135,30 @@ This list of names is automatically generated, and may not be fully complete.
 
     stdout_b.write(("\nNOTE: Check this list manually! It is automatically generated "
                     "and some names\n      may be missing.\n").encode('utf-8'))
+
+
+def load_name_map(filename):
+    name_map = {}
+
+    with io.open(filename, 'r', encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith(u"#") or not line:
+                continue
+
+            m = re.match(u'^(.*?)\s*<(.*?)>(.*?)\s*<(.*?)>\s*$', line)
+            if not m:
+                print("Invalid line in .mailmap: '{!r}'".format(line), file=sys.stderr)
+                sys.exit(1)
+
+            new_name = m.group(1).strip()
+            old_name = m.group(3).strip()
+
+            if old_name and new_name:
+                name_map[old_name] = new_name
+
+    return name_map
+
 
 #------------------------------------------------------------------------------
 # Communicating with Git


### PR DESCRIPTION
Git has a standard format for author name/email aliases, so use that
instead of a custom approach.

The information used to generate the .mailmap came from 'git log' and
the current contents of tools/authors.py (which was user-provided
information). Both of these are information publicly provided by the
authors for the purpose of identifying them.

I'm not sure, but some third-party tools (e.g. Zenodo) may also make use of
this information, so it's best to provide it in a standard format to ensure
better attribution.
