### PR TITLE
Updating LAPACK -syevr methods

### DIFF
--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -6,7 +6,7 @@
 ! $Revision$ $Date$
 !
 ! Additions by Travis Oliphant, Tiziano Zito, Collin RM Stocks, Fabian Pedregosa
-!              Skipper Seabold
+!              Skipper Seabold, Alex Papanicolaou
 !
 ! <prefix2=s,d> <ctype2=float,double> <ftype2=real,double precision> <wrap2=ws,d>
 ! <prefix2c=c,z> <ftype2c=complex,double complex> <ctype2c=complex_float,complex_double> <wrap2c=wc,z>

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -2531,122 +2531,77 @@ end subroutine <prefix>gbtrs
 !
 ! RRR routines for standard eigenvalue problem
 !
-subroutine ssyevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,iwork,liwork,info)
+
+subroutine <prefix2>syevr(jobz,range,uplo,n,a,lda,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,iwork,liwork,info,vl,vu)
     ! Standard Eigenvalue Problem
     ! simple/expert driver: all eigenvectors or optionally selected eigenvalues
     ! algorithm: Relatively Robust Representation
     ! matrix storage
-    ! Real - Single precision
+    ! Real - Single/Double precision
+
+    fortranname <prefix2>syevr
+    callstatement (*f2py_func)(jobz,range,uplo,&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,work,&lwork,iwork,&liwork,&info)
+    callprotoargument char*,char*,char*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,int*,int*,int*
+
     character intent(in) :: jobz='V'
     character intent(in) :: range='A'
     character intent(in) :: uplo='L'
     integer intent(hide) :: n=shape(a,0)
-    real intent(in,copy,aligned8),dimension(n,n) :: a
+    <ftype2> intent(in,copy,aligned8),dimension(n,n) :: a
     integer intent(hide),depend(n,a) :: lda=n
-    real optional,intent(in) :: vl=0
-    real optional,intent(in) :: vu=1
+    <ftype2> optional,intent(in) :: vl=0
+    <ftype2> optional,intent(in) :: vu=1
     integer optional,intent(in) :: il=1
     integer optional,intent(in),depend(n) :: iu=n
-    real intent(hide) :: abstol=0.
+    <ftype2> intent(hide) :: abstol=0.
     integer  intent(hide),depend(iu) :: m=iu-il+1
-    real intent(out),dimension(n),depend(n) :: w
-    real intent(out),dimension(n,m),depend(n,m) :: z
+    <ftype2> intent(out),dimension(n),depend(n) :: w
+    <ftype2> intent(out),dimension(n,m),depend(n,m) :: z
     integer intent(hide),check(shape(z,0)==ldz),depend(n,z) :: ldz=n
     integer intent(hide),dimension(2*m) :: isuppz
     integer intent(in),depend(n) :: lwork=26*n
-    real  intent(hide),dimension(lwork) :: work
+    <ftype2>  intent(hide),dimension(lwork) :: work
     integer intent(hide),depend(n):: liwork=10*n
     integer intent(hide),dimension(liwork) :: iwork
     integer  intent(out) :: info
-end subroutine ssyevr
-subroutine dsyevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,iwork,liwork,info)
+end subroutine <prefix2>syevr
+
+subroutine <prefix2c>heevr(jobz,range,uplo,n,a,lda,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,rwork,lrwork,iwork,liwork,info,vl,vu)
     ! Standard Eigenvalue Problem
     ! simple/expert driver: all eigenvectors or optionally selected eigenvalues
     ! algorithm: Relatively Robust Representation
     ! matrix storage
-    ! Real - Double precision
+    ! Real - Single/Double precision
+
+    fortranname <prefix2c>heevr
+    callstatement (*f2py_func)(jobz,range,uplo,&n,a,&lda,&vl,&vu,&il,&iu,&abstol,&m,w,z,&ldz,isuppz,work,&lwork,rwork,&lrwork,iwork,&liwork,&info)
+    callprotoargument char*,char*,char*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2>*,int*,int*,int*,int*
+
     character intent(in) :: jobz='V'
     character intent(in) :: range='A'
     character intent(in) :: uplo='L'
     integer intent(hide) :: n=shape(a,0)
-    double precision intent(in,copy,aligned8),dimension(n,n) :: a
+    <ftype2c> intent(in,copy,aligned8),dimension(n,n) :: a
     integer intent(hide),depend(n,a) :: lda=n
-    double precision optional,intent(in) :: vl=0
-    double precision optional,intent(in) :: vu=1
+    <ftype2> optional,intent(in) :: vl=0
+    <ftype2> optional,intent(in) :: vu=1
     integer optional,intent(in) :: il=1
     integer optional,intent(in),depend(n) :: iu=n
-    double precision intent(hide) :: abstol=0.
+    <ftype2> intent(hide) :: abstol=0.
     integer  intent(hide),depend(iu) :: m=iu-il+1
-    double precision intent(out),dimension(n),depend(n) :: w
-    double precision intent(out),dimension(n,m),depend(n,m) :: z
+    <ftype2> intent(out),dimension(n),depend(n) :: w
+    <ftype2c> intent(out),dimension(n,m),depend(n,m) :: z
     integer intent(hide),check(shape(z,0)==ldz),depend(n,z) :: ldz=n
     integer intent(hide),dimension(2*m) :: isuppz
     integer intent(in),depend(n) :: lwork=26*n
-    double precision intent(hide),dimension(lwork) :: work
-    integer intent(hide),depend(n):: liwork=10*n
-    integer intent(hide),dimension(liwork) :: iwork
-    integer  intent(out) :: info
-end subroutine dsyevr
-subroutine cheevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,rwork,lrwork,iwork,liwork,info)
-    ! Standard Eigenvalue Problem
-    ! simple/expert driver: all eigenvectors or optionally selected eigenvalues
-    ! algorithm: Relatively Robust Representation
-    ! matrix storage
-    ! Complex - Single precision
-    character intent(in) :: jobz='V'
-    character intent(in) :: range='A'
-    character intent(in) :: uplo='L'
-    integer intent(hide) :: n=shape(a,0)
-    complex intent(in,copy,aligned8),dimension(n,n) :: a
-    integer intent(hide),depend(n,a) :: lda=n
-    real optional,intent(in) :: vl=0
-    real optional,intent(in) :: vu=1
-    integer optional,intent(in) :: il=1
-    integer optional,intent(in),depend(n) :: iu=n
-    real intent(hide) :: abstol=0.
-    integer  intent(hide),depend(iu) :: m=iu-il+1
-    real intent(out),dimension(n),depend(n) :: w
-    complex intent(out),dimension(n,m),depend(n,m) :: z
-    integer intent(hide),check(shape(z,0)==ldz),depend(n,z) :: ldz=n
-    integer intent(hide),dimension(2*m) :: isuppz
-    integer intent(in),depend(n) :: lwork=18*n
-    complex  intent(hide),dimension(lwork) :: work
+    <ftype2c>  intent(hide),dimension(lwork) :: work
     integer intent(hide),depend(n) :: lrwork=24*n
     real  intent(hide),dimension(lrwork) :: rwork
     integer intent(hide),depend(n):: liwork=10*n
     integer intent(hide),dimension(liwork) :: iwork
     integer  intent(out) :: info
-end subroutine cheevr
-subroutine zheevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,rwork,lrwork,iwork,liwork,info)
-    ! Standard Eigenvalue Problem
-    ! simple/expert driver: all eigenvectors or optionally selected eigenvalues
-    ! algorithm: Relatively Robust Representation
-    ! matrix storage
-    ! Complex - Double precision
-    character intent(in) :: jobz='V'
-    character intent(in) :: range='A'
-    character intent(in) :: uplo='L'
-    integer intent(hide) :: n=shape(a,0)
-    complex*16 intent(in,copy,aligned8),dimension(n,n) :: a
-    integer intent(hide),depend(n,a) :: lda=n
-    double precision optional,intent(in) :: vl=0
-    double precision optional,intent(in) :: vu=1
-    integer optional,intent(in) :: il=1
-    integer optional,intent(in),depend(n) :: iu=n
-    double precision intent(hide) :: abstol=0.
-    integer  intent(hide),depend(iu) :: m=iu-il+1
-    double precision  intent(out),dimension(n),depend(n) :: w
-    complex*16 intent(out),dimension(n,m),depend(n,m) :: z
-    integer intent(hide),check(shape(z,0)==ldz),depend(n,z) :: ldz=n
-    integer intent(hide),dimension(2*m) :: isuppz
-    integer intent(in),depend(n) :: lwork=18*n
-    complex*16  intent(hide),dimension(lwork) :: work
-    integer intent(hide),depend(n) :: lrwork=24*n
-    double precision  intent(hide),dimension(lrwork) :: rwork
-    integer intent(hide),depend(n):: liwork=10*n
-    integer intent(hide),dimension(liwork) :: iwork
-    integer  intent(out) :: info
-end subroutine zheevr
+end subroutine <prefix2c>heevr
+
 subroutine ssygv(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,info)
     ! Generalized Eigenvalue Problem
     ! simple driver (all eigenvectors)

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -2543,8 +2543,8 @@ subroutine ssyevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,wo
     integer intent(hide) :: n=shape(a,0)
     real intent(in,copy,aligned8),dimension(n,n) :: a
     integer intent(hide),depend(n,a) :: lda=n
-    real intent(hide) :: vl=0
-    real intent(hide) :: vu=1
+    real optional,intent(in) :: vl=0
+    real optional,intent(in) :: vu=1
     integer optional,intent(in) :: il=1
     integer optional,intent(in),depend(n) :: iu=n
     real intent(hide) :: abstol=0.
@@ -2571,8 +2571,8 @@ subroutine dsyevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,wo
     integer intent(hide) :: n=shape(a,0)
     double precision intent(in,copy,aligned8),dimension(n,n) :: a
     integer intent(hide),depend(n,a) :: lda=n
-    double precision intent(hide) :: vl=0
-    double precision intent(hide) :: vu=1
+    double precision optional,intent(in) :: vl=0
+    double precision optional,intent(in) :: vu=1
     integer optional,intent(in) :: il=1
     integer optional,intent(in),depend(n) :: iu=n
     double precision intent(hide) :: abstol=0.
@@ -2599,8 +2599,8 @@ subroutine cheevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,wo
     integer intent(hide) :: n=shape(a,0)
     complex intent(in,copy,aligned8),dimension(n,n) :: a
     integer intent(hide),depend(n,a) :: lda=n
-    real intent(hide) :: vl=0
-    real intent(hide) :: vu=1
+    real optional,intent(in) :: vl=0
+    real optional,intent(in) :: vu=1
     integer optional,intent(in) :: il=1
     integer optional,intent(in),depend(n) :: iu=n
     real intent(hide) :: abstol=0.
@@ -2629,8 +2629,8 @@ subroutine zheevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,wo
     integer intent(hide) :: n=shape(a,0)
     complex*16 intent(in,copy,aligned8),dimension(n,n) :: a
     integer intent(hide),depend(n,a) :: lda=n
-    double precision intent(hide) :: vl=0
-    double precision intent(hide) :: vu=1
+    double precision optional,intent(in) :: vl=0
+    double precision optional,intent(in) :: vu=1
     integer optional,intent(in) :: il=1
     integer optional,intent(in),depend(n) :: iu=n
     double precision intent(hide) :: abstol=0.


### PR DESCRIPTION
Discussed in #6502.  Previously, -syevr methods suppressed the input variables `vu` and `vl` preventing the ability to compute eigenvalues in an interval.  This is now fixed as in example in line 2546:

`real intent(hide) :: vl=0`

becomes

`real optional,intent(in) :: vl=0`
