### PR TITLE
DOC: add CONTRIBUTING, which will be shown by Github when making a pull request

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,23 @@
+=============================
+SciPy pull request guidelines
+=============================
+
+Pull requests are always welcome, and the Scipy community appreciates
+any help you give.
+
+When submitting a pull request, we ask you check the following:
+
+1. **Unit tests**, **documentation**, and **code style** are in order. 
+   For details, please read
+   https://github.com/scipy/scipy/blob/master/HACKING.rst.txt
+
+   It's also OK to submit work in progress if you're unsure of what
+   this exactly means, in which case you'll likely be asked to make
+   some further changes.
+
+2. The contributed code will be **licensed under SciPy's license**,
+   https://github.com/scipy/scipy/blob/master/LICENSE.txt
+   If you did not write the code yourself, you ensure the existing
+   license is compatible and include the license information in the
+   contributed files, or obtain a permission from the original
+   author to relicense the contributed code.


### PR DESCRIPTION
Add a short explanation on what is expected on pull requests, which Github will show, cf https://help.github.com/articles/setting-guidelines-for-repository-contributors/
to remind contributors that we expect unit tests and documentation should be included.

The page should be quite short to avoid tl;dr 
