### PR TITLE
reset scipy.signal.resample window shape to 1-D

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2211,6 +2211,7 @@ def resample(x, num, t=None, axis=0, window=None):
         newshape[axis] = len(W)
         W.shape = newshape
         X = X * W
+        W.shape = (Nx,)
     sl = [slice(None)] * x.ndim
     newshape = list(x.shape)
     newshape[axis] = num

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import division, print_function, absolute_import
 
 import sys
@@ -533,6 +534,11 @@ class TestResample(TestCase):
         # Other degenerate conditions
         assert_raises(ValueError, signal.resample_poly, sig, 'yo', 1)
         assert_raises(ValueError, signal.resample_poly, sig, 1, 0)
+
+        # test for issue #6505 - should not modify window.shape when axis ≠ 0
+        sig2 = np.tile(np.arange(160), (2,1))
+        signal.resample(sig2, num, axis=-1, window=win)
+        assert_(win.shape == (160,))
 
     def test_fft(self):
         # Test FFT-based resampling


### PR DESCRIPTION
if one passes `resample` an `ndarray` window to use it unexpectedly modifies the window shape for broadcasting purposes [here](https://github.com/scipy/scipy/blob/31ec2b4421716e9035ec94278c14af23d205a2e4/scipy/signal/signaltools.py#L1883). This prevents multiple calls to resample with the same window.

``` python
test_data = np.random.randn(1024,8192)
test_data2 = np.random.randn(1024,8192)
window = fft(firwin(64, 0.1), test_data.shape[-1])
filtered_data = resample(test_data, test_data.shape[1] // 4, axis=-1, window=window)
resample(test_data, test_data.shape[1] // 4, axis=-1, window=window)
resample(test_data, test_data.shape[1] // 4, axis=-1, window=window) #fails because window wrong shape
```
