### PR TITLE
BUG: linkage: Raise exception if y contains non-finite elements

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -609,7 +609,8 @@ def linkage(y, method='single', metric='euclidean'):
         is a flat array containing the upper triangular of the distance matrix.
         This is the form that ``pdist`` returns. Alternatively, a collection of
         :math:`m` observation vectors in n dimensions may be passed as an
-        :math:`m` by :math:`n` array.
+        :math:`m` by :math:`n` array. All elements of `y` must be finite,
+        i.e. no NaNs or infs.
     method : str, optional
         The linkage algorithm to use. See the ``Linkage Methods`` section below
         for full descriptions.
@@ -668,6 +669,9 @@ def linkage(y, method='single', metric='euclidean'):
         y = distance.pdist(y, metric)
     else:
         raise ValueError("`y` must be 1 or 2 dimensional.")
+
+    if not np.all(np.isfinite(y)):
+        raise ValueError("`y` must contain only finite values.")
 
     n = int(distance.num_obs_y(y))
     method_code = _LINKAGE_METHODS[method]

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -67,6 +67,13 @@ except:
 
 
 class TestLinkage(object):
+    def test_linkage_non_finite_elements_in_distance_matrix(self):
+        # Tests linkage(Y) where Y contains a non-finite element (e.g. NaN or Inf).
+        # Exception expected.
+        y = np.zeros((6,))
+        y[0] = np.nan
+        assert_raises(ValueError, linkage, y)
+
     def test_linkage_empty_distance_matrix(self):
         # Tests linkage(Y) where Y is a 0x4 linkage matrix. Exception expected.
         y = np.zeros((0,))


### PR DESCRIPTION
Added a unit test and input validation for distance vectors with non-finite elements.
Currently, `linkage` segfaults if all elements of `y` are `np.nan`s or `np.inf`s.

Specifically, `_hierarchy.pyx/linkage` segfaults if all elements of `y` are `np.nan`s or `np.inf`s while `_hierarchy.pyx/nn_chain` segfaults only if `y` has only one element that is `np.nan` or `np.inf`.

See #5142 for discussion.
