### PR TITLE
Add Eigenvalue Range Functionality for Symmetric Eigenvalue Problems

### DIFF
--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -6,7 +6,7 @@
 ! $Revision$ $Date$
 !
 ! Additions by Travis Oliphant, Tiziano Zito, Collin RM Stocks, Fabian Pedregosa
-!              Skipper Seabold
+!              Skipper Seabold, Alex Papanicolaou
 !
 ! <prefix2=s,d> <ctype2=float,double> <ftype2=real,double precision> <wrap2=ws,d>
 ! <prefix2c=c,z> <ftype2c=complex,double complex> <ctype2c=complex_float,complex_double> <wrap2c=wc,z>
@@ -2531,122 +2531,67 @@ end subroutine <prefix>gbtrs
 !
 ! RRR routines for standard eigenvalue problem
 !
-subroutine ssyevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,iwork,liwork,info)
+
+subroutine <prefix2>syevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,iwork,liwork,info)
     ! Standard Eigenvalue Problem
     ! simple/expert driver: all eigenvectors or optionally selected eigenvalues
     ! algorithm: Relatively Robust Representation
     ! matrix storage
-    ! Real - Single precision
+    ! Real - Single/Double precision
     character intent(in) :: jobz='V'
     character intent(in) :: range='A'
     character intent(in) :: uplo='L'
     integer intent(hide) :: n=shape(a,0)
-    real intent(in,copy,aligned8),dimension(n,n) :: a
+    <ftype2> intent(in,copy,aligned8),dimension(n,n) :: a
     integer intent(hide),depend(n,a) :: lda=n
-    real intent(hide) :: vl=0
-    real intent(hide) :: vu=1
+    <ftype2> optional,intent(in) :: vl=0
+    <ftype2> optional,intent(in) :: vu=1
     integer optional,intent(in) :: il=1
     integer optional,intent(in),depend(n) :: iu=n
-    real intent(hide) :: abstol=0.
+    <ftype2> intent(hide) :: abstol=0.
     integer  intent(hide),depend(iu) :: m=iu-il+1
-    real intent(out),dimension(n),depend(n) :: w
-    real intent(out),dimension(n,m),depend(n,m) :: z
+    <ftype2> intent(out),dimension(n),depend(n) :: w
+    <ftype2> intent(out),dimension(n,m),depend(n,m) :: z
     integer intent(hide),check(shape(z,0)==ldz),depend(n,z) :: ldz=n
     integer intent(hide),dimension(2*m) :: isuppz
     integer intent(in),depend(n) :: lwork=26*n
-    real  intent(hide),dimension(lwork) :: work
+    <ftype2>  intent(hide),dimension(lwork) :: work
     integer intent(hide),depend(n):: liwork=10*n
     integer intent(hide),dimension(liwork) :: iwork
     integer  intent(out) :: info
-end subroutine ssyevr
-subroutine dsyevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,iwork,liwork,info)
+end subroutine <prefix2>syevr
+
+subroutine <prefix2c>heevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,rwork,lrwork,iwork,liwork,info)
     ! Standard Eigenvalue Problem
     ! simple/expert driver: all eigenvectors or optionally selected eigenvalues
     ! algorithm: Relatively Robust Representation
     ! matrix storage
-    ! Real - Double precision
+    ! Real - Single/Double precision
     character intent(in) :: jobz='V'
     character intent(in) :: range='A'
     character intent(in) :: uplo='L'
     integer intent(hide) :: n=shape(a,0)
-    double precision intent(in,copy,aligned8),dimension(n,n) :: a
+    <ftype2c> intent(in,copy,aligned8),dimension(n,n) :: a
     integer intent(hide),depend(n,a) :: lda=n
-    double precision intent(hide) :: vl=0
-    double precision intent(hide) :: vu=1
+    <ftype2> optional,intent(in) :: vl=0
+    <ftype2> optional,intent(in) :: vu=1
     integer optional,intent(in) :: il=1
     integer optional,intent(in),depend(n) :: iu=n
-    double precision intent(hide) :: abstol=0.
+    <ftype2> intent(hide) :: abstol=0.
     integer  intent(hide),depend(iu) :: m=iu-il+1
-    double precision intent(out),dimension(n),depend(n) :: w
-    double precision intent(out),dimension(n,m),depend(n,m) :: z
+    <ftype2> intent(out),dimension(n),depend(n) :: w
+    <ftype2c> intent(out),dimension(n,m),depend(n,m) :: z
     integer intent(hide),check(shape(z,0)==ldz),depend(n,z) :: ldz=n
     integer intent(hide),dimension(2*m) :: isuppz
     integer intent(in),depend(n) :: lwork=26*n
-    double precision intent(hide),dimension(lwork) :: work
-    integer intent(hide),depend(n):: liwork=10*n
-    integer intent(hide),dimension(liwork) :: iwork
-    integer  intent(out) :: info
-end subroutine dsyevr
-subroutine cheevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,rwork,lrwork,iwork,liwork,info)
-    ! Standard Eigenvalue Problem
-    ! simple/expert driver: all eigenvectors or optionally selected eigenvalues
-    ! algorithm: Relatively Robust Representation
-    ! matrix storage
-    ! Complex - Single precision
-    character intent(in) :: jobz='V'
-    character intent(in) :: range='A'
-    character intent(in) :: uplo='L'
-    integer intent(hide) :: n=shape(a,0)
-    complex intent(in,copy,aligned8),dimension(n,n) :: a
-    integer intent(hide),depend(n,a) :: lda=n
-    real intent(hide) :: vl=0
-    real intent(hide) :: vu=1
-    integer optional,intent(in) :: il=1
-    integer optional,intent(in),depend(n) :: iu=n
-    real intent(hide) :: abstol=0.
-    integer  intent(hide),depend(iu) :: m=iu-il+1
-    real intent(out),dimension(n),depend(n) :: w
-    complex intent(out),dimension(n,m),depend(n,m) :: z
-    integer intent(hide),check(shape(z,0)==ldz),depend(n,z) :: ldz=n
-    integer intent(hide),dimension(2*m) :: isuppz
-    integer intent(in),depend(n) :: lwork=18*n
-    complex  intent(hide),dimension(lwork) :: work
+    <ftype2c>  intent(hide),dimension(lwork) :: work
     integer intent(hide),depend(n) :: lrwork=24*n
     real  intent(hide),dimension(lrwork) :: rwork
     integer intent(hide),depend(n):: liwork=10*n
     integer intent(hide),dimension(liwork) :: iwork
     integer  intent(out) :: info
-end subroutine cheevr
-subroutine zheevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,isuppz,work,lwork,rwork,lrwork,iwork,liwork,info)
-    ! Standard Eigenvalue Problem
-    ! simple/expert driver: all eigenvectors or optionally selected eigenvalues
-    ! algorithm: Relatively Robust Representation
-    ! matrix storage
-    ! Complex - Double precision
-    character intent(in) :: jobz='V'
-    character intent(in) :: range='A'
-    character intent(in) :: uplo='L'
-    integer intent(hide) :: n=shape(a,0)
-    complex*16 intent(in,copy,aligned8),dimension(n,n) :: a
-    integer intent(hide),depend(n,a) :: lda=n
-    double precision intent(hide) :: vl=0
-    double precision intent(hide) :: vu=1
-    integer optional,intent(in) :: il=1
-    integer optional,intent(in),depend(n) :: iu=n
-    double precision intent(hide) :: abstol=0.
-    integer  intent(hide),depend(iu) :: m=iu-il+1
-    double precision  intent(out),dimension(n),depend(n) :: w
-    complex*16 intent(out),dimension(n,m),depend(n,m) :: z
-    integer intent(hide),check(shape(z,0)==ldz),depend(n,z) :: ldz=n
-    integer intent(hide),dimension(2*m) :: isuppz
-    integer intent(in),depend(n) :: lwork=18*n
-    complex*16  intent(hide),dimension(lwork) :: work
-    integer intent(hide),depend(n) :: lrwork=24*n
-    double precision  intent(hide),dimension(lrwork) :: rwork
-    integer intent(hide),depend(n):: liwork=10*n
-    integer intent(hide),dimension(liwork) :: iwork
-    integer  intent(out) :: info
-end subroutine zheevr
+end subroutine <prefix2c>heevr
+
 subroutine ssygv(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,info)
     ! Generalized Eigenvalue Problem
     ! simple driver (all eigenvectors)

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -2566,7 +2566,7 @@ subroutine <prefix2c>heevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,
     ! simple/expert driver: all eigenvectors or optionally selected eigenvalues
     ! algorithm: Relatively Robust Representation
     ! matrix storage
-    ! Real - Single/Double precision
+    ! Complex - Single/Double precision
     character intent(in) :: jobz='V'
     character intent(in) :: range='A'
     character intent(in) :: uplo='L'
@@ -2586,7 +2586,7 @@ subroutine <prefix2c>heevr(jobz,range,uplo,n,a,lda,vl,vu,il,iu,abstol,m,w,z,ldz,
     integer intent(in),depend(n) :: lwork=26*n
     <ftype2c>  intent(hide),dimension(lwork) :: work
     integer intent(hide),depend(n) :: lrwork=24*n
-    real  intent(hide),dimension(lrwork) :: rwork
+    <ftype2>  intent(hide),dimension(lrwork) :: rwork
     integer intent(hide),depend(n):: liwork=10*n
     integer intent(hide),dimension(liwork) :: iwork
     integer  intent(out) :: info

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -765,8 +765,6 @@ def test_eigh_range_invalid():
     assert_raises(ValueError, eigh, a, eigrng=(1, 0))
 
 
-
-
 def test_eigh_integer():
     a = array([[1,2],[2,7]])
     b = array([[3,1],[1,5]])


### PR DESCRIPTION
_Updated, renamed, and cleaned up. @apapanico 2016-08-25_
### Add Eigenvalue Range Functionality for Symmetric Eigenvalue Problems

This PR does the following:
- As discussed in  #6502, changes the interface the `-evr` LAPACK methods to allow for computing eigenvalues only in a half-open interval specified by the parameters `vl` and `vu`.
- As discussed in  #6502, backwards compatibility is ensured by further wrapping the `-evr` wrappers to reorder the arguments such that `vl` and `vu` come at the end of the optional argument list.   In `scipy/linalg/lapack.py`, the Fortran routines are wrapped after import and provided a new doc string to match the appropriate signature.  Moreover, a bug is addressed where `il` and `iu` are NOT properly ignored in `-evr` methods when not setting `range='I'` despite the claims of the LAPACK documentation.  For example, if `il` and `iu` are set to 1 and `range='A'`, then all eigenvalues are returned but only 1 eigenvector.  This is fixed by setting `il=1` and `iu = n` (the size of the matrix) when `range='A'` or `range='V'` so that there are no missing eigenvectors.  This approach is an improvement on #6503 which could not ensure a truly preserved ordering of input arguments.
- A new keyword argument, `eigrng`, is added to `scipy.linalg.eigh` that allows specifying this mode of use.  `eigrng` must be a tuple of length 2 and the first value must be less than the second value.  It cannot be specified in conjunction with `eigvals`.  Finally, the return values are all eigenvalues, and eigenvectors if desired, within the range.
- Tests are written that ensure the wrapper does not break backward compatibility, `eigh` functionality is as it should be, and that this new mode is incompatible with the mode specified by the parameter `eigvals` which computes eigenvalues corresponding to an index range.
