### PR TITLE
scipy.sparse.base.__mul__ non-numpy/scipy objects with 'shape' attribute.

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -388,16 +388,20 @@ class spmatrix(object):
             if other.shape[0] != self.shape[1]:
                 raise ValueError('dimension mismatch')
 
-            other = np.asarray(other)
 
-            if other.ndim == 0:
-                return NotImplemented
+            if isinstance(other,np.matrix):
 
-            result = self._mul_multivector(other)
-
-            if isinstance(other, np.matrix):
+            	result = self._mul_multivector(np.asarray(other))
                 result = np.asmatrix(result)
 
+            else:
+                other = np.asarray(other)
+
+                if other.ndim == 0:
+                    return NotImplemented
+
+                result = self._mul_multivector(other)
+            
             return result
         else:
             raise ValueError('could not interpret dimensions')

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -385,10 +385,12 @@ class spmatrix(object):
             ##
             # dense 2D array or matrix ("multivector")
 
-            if other.shape[0] != self.shape[1]:
-                raise ValueError('dimension mismatch')
+            other = np.asarray(other)
 
-            result = self._mul_multivector(np.asarray(other))
+            if other.ndim == 0:
+                return NotImplemented
+
+            result = self._mul_multivector(other)
 
             if isinstance(other, np.matrix):
                 result = np.asmatrix(result)

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -385,6 +385,9 @@ class spmatrix(object):
             ##
             # dense 2D array or matrix ("multivector")
 
+            if other.shape[0] != self.shape[1]:
+                raise ValueError('dimension mismatch')
+
             other = np.asarray(other)
 
             if other.ndim == 0:

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -352,26 +352,23 @@ class spmatrix(object):
                 raise ValueError('dimension mismatch')
             return self._mul_sparse_matrix(other)
 
+        # If it's a list or whatever, treat it like a matrix
+        other_a = np.asanyarray(other)
+
+        if other_a.ndim == 0 and other_a.dtype == np.object_:
+            # Not interpretable as an array; return NotImplemented so that
+            # other's __rmul__ can kick in if that's implemented.
+            return NotImplemented
+
         try:
             other.shape
         except AttributeError:
-            # If it's a list or whatever, treat it like a matrix
-            other_a = np.asanyarray(other)
-
-            if other_a.ndim == 0 and other_a.dtype == np.object_:
-                # Not interpretable as an array; return NotImplemented so that
-                # other's __rmul__ can kick in if that's implemented.
-                return NotImplemented
-
             other = other_a
 
         if other.ndim == 1 or other.ndim == 2 and other.shape[1] == 1:
             # dense row or column vector
             if other.shape != (N,) and other.shape != (N, 1):
                 raise ValueError('dimension mismatch')
-
-            if np.asarray(other).ndim == 0:
-                return NotImplemented
 
             result = self._mul_vector(np.ravel(other))
 
@@ -391,16 +388,12 @@ class spmatrix(object):
             if other.shape[0] != self.shape[1]:
                 raise ValueError('dimension mismatch')
 
-            if np.asarray(other).ndim == 0:
-                return NotImplemented
-
             result = self._mul_multivector(np.asarray(other))
 
             if isinstance(other,np.matrix):
                 result = np.asmatrix(result)
 
             return result
-
         else:
             raise ValueError('could not interpret dimensions')
 

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -367,10 +367,16 @@ class spmatrix(object):
 
         if other.ndim == 1 or other.ndim == 2 and other.shape[1] == 1:
             # dense row or column vector
-            if other.shape != (N,) and other.shape != (N, 1):
+            if other.shape[0] != self.shape[1]:
                 raise ValueError('dimension mismatch')
 
-            result = self._mul_vector(np.ravel(other))
+            other = np.asarray(other)
+
+            if other.ndim == 0:
+                return NotImplemented
+
+            result = self._mul_multivector(other)
+
 
             if isinstance(other, np.matrix):
                 result = np.asmatrix(result)

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -367,16 +367,10 @@ class spmatrix(object):
 
         if other.ndim == 1 or other.ndim == 2 and other.shape[1] == 1:
             # dense row or column vector
-            if other.shape[0] != self.shape[1]:
+            if other.shape != (N,) and other.shape != (N, 1):
                 raise ValueError('dimension mismatch')
 
-            other = np.asarray(other)
-
-            if other.ndim == 0:
-                return NotImplemented
-
-            result = self._mul_multivector(other)
-
+            result = self._mul_vector(np.ravel(other))
 
             if isinstance(other, np.matrix):
                 result = np.asmatrix(result)

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -394,6 +394,7 @@ class spmatrix(object):
                 result = np.asmatrix(result)
 
             return result
+
         else:
             raise ValueError('could not interpret dimensions')
 

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -390,7 +390,7 @@ class spmatrix(object):
 
             result = self._mul_multivector(np.asarray(other))
 
-            if isinstance(other,np.matrix):
+            if isinstance(other, np.matrix):
                 result = np.asmatrix(result)
 
             return result

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -370,6 +370,9 @@ class spmatrix(object):
             if other.shape != (N,) and other.shape != (N, 1):
                 raise ValueError('dimension mismatch')
 
+            if np.asarray(other).ndim == 0:
+                return NotImplemented
+
             result = self._mul_vector(np.ravel(other))
 
             if isinstance(other, np.matrix):
@@ -388,21 +391,16 @@ class spmatrix(object):
             if other.shape[0] != self.shape[1]:
                 raise ValueError('dimension mismatch')
 
+            if np.asarray(other).ndim == 0:
+                return NotImplemented
+
+            result = self._mul_multivector(np.asarray(other))
 
             if isinstance(other,np.matrix):
-                
-                result = self._mul_multivector(np.asarray(other))
                 result = np.asmatrix(result)
-                
-            else:
-                other = np.asarray(other)
-                
-                if other.ndim == 0:
-                    return NotImplemented
-                
-                result = self._mul_multivector(other)
-            
+
             return result
+
         else:
             raise ValueError('could not interpret dimensions')
 

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -390,16 +390,16 @@ class spmatrix(object):
 
 
             if isinstance(other,np.matrix):
-
-            	result = self._mul_multivector(np.asarray(other))
+                
+                result = self._mul_multivector(np.asarray(other))
                 result = np.asmatrix(result)
-
+                
             else:
                 other = np.asarray(other)
-
+                
                 if other.ndim == 0:
                     return NotImplemented
-
+                
                 result = self._mul_multivector(other)
             
             return result

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -194,8 +194,8 @@ class BinopTester_with_shape(object):
     def shape(self):
         return self._shape
 
-	def ndim(self):
-		return len(self._shape)
+    def ndim(self):
+        return len(self._shape)
 
     def __add__(self, mat):
         return "matrix on the right"
@@ -1446,7 +1446,6 @@ class _TestCommon:
         if TEST_MATMUL:
             assert_equal(eval('A @ B'), "matrix on the left")
             assert_equal(eval('B @ A'), "matrix on the right")
-
 
     def test_matmul(self):
         if not TEST_MATMUL:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -185,6 +185,42 @@ class BinopTester(object):
     def __rmatmul__(self, mat):
         return "matrix on the left"
 
+class BinopTester_with_shape(object):
+    # Custom type to test binary operations on sparse matrices
+    # with object which has shape attribute.
+    def __init__(self,shape):
+        self._shape = shape
+
+    def shape(self):
+        return self._shape
+
+	def ndim(self):
+		return len(self._shape)
+
+    def __add__(self, mat):
+        return "matrix on the right"
+
+    def __mul__(self, mat):
+        return "matrix on the right"
+
+    def __sub__(self, mat):
+        return "matrix on the right"
+
+    def __radd__(self, mat):
+        return "matrix on the left"
+
+    def __rmul__(self, mat):
+        return "matrix on the left"
+
+    def __rsub__(self, mat):
+        return "matrix on the left"
+
+    def __matmul__(self, mat):
+        return "matrix on the right"
+
+    def __rmatmul__(self, mat):
+        return "matrix on the left"
+
 
 #------------------------------------------------------------------------------
 # Generic tests
@@ -1396,6 +1432,21 @@ class _TestCommon:
         if TEST_MATMUL:
             assert_equal(eval('A @ B'), "matrix on the left")
             assert_equal(eval('B @ A'), "matrix on the right")
+
+    def test_binop_custom_type_with_shape(self):
+        A = self.spmatrix([[1], [2], [3]])
+        B = BinopTester_with_shape((3,1))
+        assert_equal(A + B, "matrix on the left")
+        assert_equal(A - B, "matrix on the left")
+        assert_equal(A * B, "matrix on the left")
+        assert_equal(B + A, "matrix on the right")
+        assert_equal(B - A, "matrix on the right")
+        assert_equal(B * A, "matrix on the right")
+
+        if TEST_MATMUL:
+            assert_equal(eval('A @ B'), "matrix on the left")
+            assert_equal(eval('B @ A'), "matrix on the right")
+
 
     def test_matmul(self):
         if not TEST_MATMUL:


### PR DESCRIPTION
if other has 'shape' and 'ndim' attributes but `numpy.asarray(other)` returns a 0-dim array, then `__mul__` should return NotImplemented so that python calls `__rmul__` of other. 
