### PR TITLE
MAINT: sparse.csgraph: updating old cython loops

### DIFF
--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -283,8 +283,8 @@ cdef void _floyd_warshall(
     dist_matrix[dist_matrix == 0] = INFINITY
     dist_matrix.flat[::N + 1] = 0
     if not directed:
-        for i from 0 <= i < N:
-            for j from i + 1 <= j < N:
+        for i in range(N):
+            for j in range(i + 1, N):
                 if dist_matrix[j, i] <= dist_matrix[i, j]:
                     dist_matrix[i, j] = dist_matrix[j, i]
                 else:
@@ -310,21 +310,21 @@ cdef void _floyd_warshall(
     # In each loop, this finds the shortest path from point i
     #  to point j using intermediate nodes 0 ... k
     if store_predecessors:
-        for k from 0 <= k < N:
-            for i from 0 <= i < N:
+        for k in range(N):
+            for i in range(N):
                 if dist_matrix[i, k] == INFINITY:
                     continue
-                for j from 0 <= j < N:
+                for j in range(N):
                     d_ijk = dist_matrix[i, k] + dist_matrix[k, j]
                     if d_ijk < dist_matrix[i, j]:
                         dist_matrix[i, j] = d_ijk
                         predecessor_matrix[i, j] = predecessor_matrix[k, j]
     else:
-        for k from 0 <= k < N:
-            for i from 0 <= i < N:
+        for k in range(N):
+            for i in range(N):
                 if dist_matrix[i, k] == INFINITY:
                     continue
-                for j from 0 <= j < N:
+                for j in range(N):
                     d_ijk = dist_matrix[i, k] + dist_matrix[k, j]
                     if d_ijk < dist_matrix[i, j]:
                         dist_matrix[i, j] = d_ijk
@@ -490,10 +490,10 @@ cdef _dijkstra_directed(
     cdef FibonacciNode* nodes = <FibonacciNode*> malloc(N *
                                                         sizeof(FibonacciNode))
 
-    for i from 0 <= i < Nind:
+    for i in range(Nind):
         j_source = source_indices[i]
 
-        for k from 0 <= k < N:
+        for k in range(N):
             initialize_node(&nodes[k], k)
 
         dist_matrix[i, j_source] = 0
@@ -504,7 +504,7 @@ cdef _dijkstra_directed(
             v = remove_min(&heap)
             v.state = SCANNED
 
-            for j from csr_indptr[v.index] <= j < csr_indptr[v.index + 1]:
+            for j in range(csr_indptr[v.index], csr_indptr[v.index + 1]):
                 j_current = csr_indices[j]
                 current_node = &nodes[j_current]
                 if current_node.state != SCANNED:
@@ -554,10 +554,10 @@ cdef _dijkstra_undirected(
     cdef FibonacciNode* nodes = <FibonacciNode*> malloc(N *
                                                         sizeof(FibonacciNode))
 
-    for i from 0 <= i < Nind:
+    for i in range(Nind):
         j_source = source_indices[i]
 
-        for k from 0 <= k < N:
+        for k in range(N):
             initialize_node(&nodes[k], k)
 
         dist_matrix[i, j_source] = 0
@@ -568,7 +568,7 @@ cdef _dijkstra_undirected(
             v = remove_min(&heap)
             v.state = SCANNED
 
-            for j from csr_indptr[v.index] <= j < csr_indptr[v.index + 1]:
+            for j in range(csr_indptr[v.index], csr_indptr[v.index + 1]):
                 j_current = csr_indices[j]
                 current_node = &nodes[j_current]
                 if current_node.state != SCANNED:
@@ -586,7 +586,7 @@ cdef _dijkstra_undirected(
                             if return_pred:
                                 pred[i, j_current] = v.index
 
-            for j from csrT_indptr[v.index] <= j < csrT_indptr[v.index + 1]:
+            for j in range(csrT_indptr[v.index], csrT_indptr[v.index + 1]):
                 j_current = csrT_indices[j]
                 current_node = &nodes[j_current]
                 if current_node.state != SCANNED:
@@ -743,14 +743,14 @@ cdef int _bellman_ford_directed(
 
     cdef int return_pred = (pred.size > 0)
 
-    for i from 0 <= i < Nind:
+    for i in range(Nind):
         j_source = source_indices[i]
 
         # relax all edges N-1 times
-        for count from 0 <= count < N - 1:
-            for j from 0 <= j < N:
+        for count in range(N - 1):
+            for j in range(N):
                 d1 = dist_matrix[i, j]
-                for k from csr_indptr[j] <= k < csr_indptr[j + 1]:
+                for k in range(csr_indptr[j], csr_indptr[j + 1]):
                     w12 = csr_weights[k]
                     d2 = dist_matrix[i, csr_indices[k]]
                     if d1 + w12 < d2:
@@ -759,9 +759,9 @@ cdef int _bellman_ford_directed(
                             pred[i, csr_indices[k]] = j
 
         # check for negative-weight cycles
-        for j from 0 <= j < N:
+        for j in range(N):
             d1 = dist_matrix[i, j]
-            for k from csr_indptr[j] <= k < csr_indptr[j + 1]:
+            for k in range(csr_indptr[j], csr_indptr[j + 1]):
                 w12 = csr_weights[k]
                 d2 = dist_matrix[i, csr_indices[k]]
                 if d1 + w12 + DTYPE_EPS < d2:
@@ -785,14 +785,14 @@ cdef int _bellman_ford_undirected(
 
     cdef int return_pred = (pred.size > 0)
 
-    for i from 0 <= i < Nind:
+    for i in range(Nind):
         j_source = source_indices[i]
 
         # relax all edges N-1 times
-        for count from 0 <= count < N - 1:
-            for j from 0 <= j < N:
+        for count in range(N - 1):
+            for j in range(N):
                 d1 = dist_matrix[i, j]
-                for k from csr_indptr[j] <= k < csr_indptr[j + 1]:
+                for k in range(csr_indptr[j], csr_indptr[j + 1]):
                     w12 = csr_weights[k]
                     ind_k = csr_indices[k]
                     d2 = dist_matrix[i, ind_k]
@@ -806,9 +806,9 @@ cdef int _bellman_ford_undirected(
                             pred[i, j] = ind_k
 
         # check for negative-weight cycles
-        for j from 0 <= j < N:
+        for j in range(N):
             d1 = dist_matrix[i, j]
-            for k from csr_indptr[j] <= k < csr_indptr[j + 1]:
+            for k in range(csr_indptr[j], csr_indptr[j + 1]):
                 w12 = csr_weights[k]
                 d2 = dist_matrix[i, csr_indices[k]]
                 if abs(d2 - d1) > w12 + DTYPE_EPS:
@@ -977,8 +977,8 @@ cdef void _johnson_add_weights(
     # let w(u, v) = w(u, v) + h(u) - h(v)
     cdef unsigned int j, k, N = dist_array.shape[0]
 
-    for j from 0 <= j < N:
-        for k from csr_indptr[j] <= k < csr_indptr[j + 1]:
+    for j in range(N):
+        for k in range(csr_indptr[j], csr_indptr[j + 1]):
             csr_weights[k] += dist_array[j]
             csr_weights[k] -= dist_array[csr_indices[k]]
 
@@ -994,23 +994,23 @@ cdef int _johnson_directed(
     cdef DTYPE_t d1, d2, w12
 
     # relax all edges (N+1) - 1 times
-    for count from 0 <= count < N:
-        for k from 0 <= k < N:
+    for count in range(N):
+        for k in range(N):
             if dist_array[k] < 0:
                 dist_array[k] = 0
 
-        for j from 0 <= j < N:
+        for j in range(N):
             d1 = dist_array[j]
-            for k from csr_indptr[j] <= k < csr_indptr[j + 1]:
+            for k in range(csr_indptr[j], csr_indptr[j + 1]):
                 w12 = csr_weights[k]
                 d2 = dist_array[csr_indices[k]]
                 if d1 + w12 < d2:
                     dist_array[csr_indices[k]] = d1 + w12
 
     # check for negative-weight cycles
-    for j from 0 <= j < N:
+    for j in range(N):
         d1 = dist_array[j]
-        for k from csr_indptr[j] <= k < csr_indptr[j + 1]:
+        for k in range(csr_indptr[j], csr_indptr[j + 1]):
             w12 = csr_weights[k]
             d2 = dist_array[csr_indices[k]]
             if d1 + w12 + DTYPE_EPS < d2:
@@ -1030,14 +1030,14 @@ cdef int _johnson_undirected(
     cdef DTYPE_t d1, d2, w12
 
     # relax all edges (N+1) - 1 times
-    for count from 0 <= count < N:
-        for k from 0 <= k < N:
+    for count in range(N):
+        for k in range(N):
             if dist_array[k] < 0:
                 dist_array[k] = 0
 
-        for j from 0 <= j < N:
+        for j in range(N):
             d1 = dist_array[j]
-            for k from csr_indptr[j] <= k < csr_indptr[j + 1]:
+            for k in range(csr_indptr[j], csr_indptr[j + 1]):
                 w12 = csr_weights[k]
                 ind_k = csr_indices[k]
                 d2 = dist_array[ind_k]
@@ -1047,9 +1047,9 @@ cdef int _johnson_undirected(
                     dist_array[j] = d1 = d2 + w12
 
     # check for negative-weight cycles
-    for j from 0 <= j < N:
+    for j in range(N):
         d1 = dist_array[j]
-        for k from csr_indptr[j] <= k < csr_indptr[j + 1]:
+        for k in range(csr_indptr[j], csr_indptr[j + 1]):
             w12 = csr_weights[k]
             d2 = dist_array[csr_indices[k]]
             if abs(d2 - d1) > w12 + DTYPE_EPS:
@@ -1265,7 +1265,7 @@ cdef FibonacciNode* remove_min(FibonacciHeap* heap):
     heap.min_node = temp
 
     # re-link the heap
-    for i from 0 <= i < 100:
+    for i in range(100):
         heap.roots_by_rank[i] = NULL
 
     while temp:

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -283,8 +283,8 @@ cdef void _populate_graph(np.ndarray[DTYPE_t, ndim=1, mode='c'] data,
     cdef np.npy_bool* null_ptr = <np.npy_bool*> null_flag.data
     cdef unsigned int row, col, i
 
-    for row from 0 <= row < N:
-        for i from indptr[row] <= i < indptr[row + 1]:
+    for row in range(N):
+        for i in range(indptr[row], indptr[row + 1]):
             col = indices[i]
             null_ptr[col] = 0
             # in case of multiple edges, we'll choose the smallest
@@ -430,16 +430,16 @@ cdef void _construct_dist_matrix(np.ndarray[DTYPE_t, ndim=2] graph,
     # symmetrize matrix if necessary
     if not directed:
         graph[graph == 0] = np.inf
-        for i from 0 <= i < N:
-            for j from i + 1 <= j < N:
+        for i in range(N):
+            for j in range(i + 1, N):
                 if graph[j, i] <= graph[i, j]:
                     graph[i, j] = graph[j, i]
                 else:
                     graph[j, i] = graph[i, j]
     #------------------------------------------
 
-    for i from 0 <= i < N:
-        for j from 0 <= j < N:
+    for i in range(N):
+        for j in range(N):
             null_path = True
             k2 = j
             while k2 != i:

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -328,7 +328,7 @@ cdef unsigned int _breadth_first_directed(
     while i_nl < i_nl_end:
         pnode = node_list[i_nl]
 
-        for i from indptr[pnode] <= i < indptr[pnode + 1]:
+        for i in range(indptr[pnode], indptr[pnode + 1]):
             cnode = indices[i]
             if (cnode == head_node):
                 continue
@@ -372,7 +372,7 @@ cdef unsigned int _breadth_first_undirected(
     while i_nl < i_nl_end:
         pnode = node_list[i_nl]
 
-        for i from indptr1[pnode] <= i < indptr1[pnode + 1]:
+        for i in range(indptr1[pnode], indptr1[pnode + 1]):
             cnode = indices1[i]
             if (cnode == head_node):
                 continue
@@ -381,7 +381,7 @@ cdef unsigned int _breadth_first_undirected(
                 predecessors[cnode] = pnode
                 i_nl_end += 1
 
-        for i from indptr2[pnode] <= i < indptr2[pnode + 1]:
+        for i in range(indptr2[pnode], indptr2[pnode + 1]):
             cnode = indices2[i]
             if (cnode == head_node):
                 continue
@@ -488,7 +488,7 @@ cdef unsigned int _depth_first_directed(
     while i_root >= 0:
         pnode = root_list[i_root]
         no_children = True
-        for i from indptr[pnode] <= i < indptr[pnode + 1]:
+        for i in range(indptr[pnode], indptr[pnode + 1]):
             cnode = indices[i]
             if flag[cnode]:
                 continue
@@ -535,7 +535,7 @@ cdef unsigned int _depth_first_undirected(
         pnode = root_list[i_root]
         no_children = True
 
-        for i from indptr1[pnode] <= i < indptr1[pnode + 1]:
+        for i in range(indptr1[pnode], indptr1[pnode + 1]):
             cnode = indices1[i]
             if flag[cnode]:
                 continue
@@ -550,7 +550,7 @@ cdef unsigned int _depth_first_undirected(
                 break
 
         if no_children:
-            for i from indptr2[pnode] <= i < indptr2[pnode + 1]:
+            for i in range(indptr2[pnode], indptr2[pnode + 1]):
                 cnode = indices2[i]
                 if flag[cnode]:
                     continue
@@ -636,7 +636,7 @@ cdef int _connected_components_directed(
                     index += 1
 
                     # Add successor nodes
-                    for j from indptr[v] <= j < indptr[v+1]:
+                    for j in range(indptr[v], indptr[v+1]):
                         w = indices[j]
                         if lowlinks[w] == VOID:
                             with cython.boundscheck(False):
@@ -666,7 +666,7 @@ cdef int _connected_components_directed(
 
                     root = 1 # True
                     low_v = lowlinks[v]
-                    for j from indptr[v] <= j < indptr[v+1]:
+                    for j in range(indptr[v], indptr[v+1]):
                         low_w = lowlinks[indices[j]]
                         if low_w < low_v:
                             low_v = low_w
@@ -728,12 +728,12 @@ cdef int _connected_components_undirected(
 
                 # Push children onto the stack if they havn't been
                 # seen at all yet.
-                for j from indptr1[v] <= j < indptr1[v+1]:
+                for j in range(indptr1[v], indptr1[v+1]):
                     w = indices1[j]
                     if SS[w] == VOID:
                         SS[w] = SS_head
                         SS_head = w
-                for j from indptr2[v] <= j < indptr2[v+1]:
+                for j in range(indptr2[v], indptr2[v+1]):
                     w = indices2[j]
                     if SS[w] == VOID:
                         SS[w] = SS_head


### PR DESCRIPTION
The old `for i from a <= i < b` syntax is deprecated, so this PR changes them to `for i in range(a,b)` syntax.

A casual inspection of the generated C files shows that the difference between the two styles is negligible.
