### PR TITLE
TST: Ensure tests for scipy._lib are run by scipy.test()

### DIFF
--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -113,5 +113,19 @@ else:
     del _NumpyVersion
 
     from numpy.testing import Tester
-    test = Tester().test
-    bench = Tester().bench
+
+    def test(*a, **kw):
+        # Nose never recurses into directories with underscores prefix, so we
+        # need to list those explicitly. Note that numpy.testing.Tester inserts
+        # the top-level package path determined from __file__ to argv unconditionally,
+        # so we only need to add the part that is not otherwise recursed into.
+        import os
+        underscore_modules = ['_lib']
+        base_dir = os.path.abspath(os.path.dirname(__file__))
+        underscore_paths = [os.path.join(base_dir, name) for name in underscore_modules]
+        kw['extra_argv'] = list(kw.get('extra_argv', [])) + underscore_paths
+        return test._tester.test(*a, **kw)
+    test._tester = Tester()
+    test.__doc__ = test._tester.test.__doc__
+    test.__test__ = False  # Prevent nose from treating test() as a test
+    bench = test._tester.bench


### PR DESCRIPTION
Nose does not recurse into directories with underscore prefixes
(hardcoded behavior). Ensure this does not prevent running the tests of
scipy._lib, by explicitly listing the subpackage in scipy.test().

Fixes gh-6541
