### PR TITLE
Revert  gh-5938, restore ks_2samp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,6 +216,7 @@ scipy/stats/mvn-f2pywrappers.f
 scipy/stats/mvnmodule.c
 scipy/stats/statlibmodule.c
 scipy/stats/vonmises_cython.c
+scipy/stats/_stats.c
 scipy/version.py
 scipy/special/_exprel.c
 scipy/optimize/_group_columns.c

--- a/.gitignore
+++ b/.gitignore
@@ -216,7 +216,6 @@ scipy/stats/mvn-f2pywrappers.f
 scipy/stats/mvnmodule.c
 scipy/stats/statlibmodule.c
 scipy/stats/vonmises_cython.c
-scipy/stats/_stats.c
 scipy/version.py
 scipy/special/_exprel.c
 scipy/optimize/_group_columns.c

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -8,42 +8,6 @@ import numpy as np
 import scipy.stats, scipy.special
 
 
-ctypedef fused dtype:
-    np.uint8_t
-    np.uint16_t
-    np.uint32_t
-    np.uint64_t
-    np.int8_t
-    np.int16_t
-    np.int32_t
-    np.int64_t
-    np.float32_t
-    np.float64_t
-    np.longdouble_t
-
-
-@cython.boundscheck(False)
-@cython.nonecheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
-cpdef double ks_2samp(dtype[:] data1, dtype[:] data2):
-    cdef:
-        size_t i = 0, j = 0, n1 = data1.shape[0], n2 = data2.shape[0]
-        dtype d1i, d2j
-        double d = 0, maxd = 0, inv_n1 = 1. / n1, inv_n2 = 1. / n2
-    while i < n1 and j < n2:
-        d1i = data1[i]
-        d2j = data2[j]
-        if d1i <= d2j:
-            d += inv_n1
-            i += 1
-        if d1i >= d2j:
-            d -= inv_n2
-            j += 1
-        maxd = max(maxd, math.fabs(d))
-    return maxd
-
-
 cdef double von_mises_cdf_series(double k, double x, unsigned int p):
     cdef double s, c, sn, cn, R, V
     cdef unsigned int n

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -162,9 +162,11 @@ References
 
 from __future__ import division, print_function, absolute_import
 
-from collections import namedtuple
-import math
 import warnings
+import math
+from collections import namedtuple
+
+from scipy._lib.six import xrange
 
 # Scipy imports.
 from scipy._lib.six import callable, string_types, xrange
@@ -173,7 +175,8 @@ from numpy import array, asarray, ma, zeros
 import scipy.special as special
 import scipy.linalg as linalg
 import numpy as np
-from . import distributions, mstats_basic, _stats
+from . import distributions
+from . import mstats_basic
 from ._distn_infrastructure import _lazywhere
 from ._stats_mstats_common import _find_repeats, linregress, theilslopes
 from ._stats import _kendall_condis
@@ -4550,21 +4553,13 @@ def ks_2samp(data1, data2):
     """
     data1 = np.sort(data1)
     data2 = np.sort(data2)
-    n1, = data1.shape
-    n2, = data2.shape
-    common_type = np.find_common_type([], [data1.dtype, data2.dtype])
-    if not (np.issubdtype(common_type, np.number) and
-            not np.issubdtype(common_type, np.complexfloating)):
-        raise ValueError('ks_2samp only accepts real inputs')
-    # nans, if any, are at the end after sorting.
-    if np.isnan(data1[-1]) or np.isnan(data2[-1]):
-        raise ValueError('ks_2samp only accepts non-nan inputs')
-    # Absolute KS distance can be computed (less efficiently) as follows:
-    # data_all = np.concatenate([data1, data2])
-    # d = np.max(np.abs(data1.searchsorted(data_all, side='right') / n1 -
-    #                   data2.searchsorted(data_all, side='right') / n2))
-    d = _stats.ks_2samp(np.asarray(data1, common_type),
-                        np.asarray(data2, common_type))
+    n1 = data1.shape[0]
+    n2 = data2.shape[0]
+    data_all = np.concatenate([data1, data2])
+    cdf1 = np.searchsorted(data1, data_all, side='right') / (1.0*n1)
+    cdf2 = np.searchsorted(data2, data_all, side='right') / (1.0*n2)
+    d = np.max(np.absolute(cdf1 - cdf2))
+    # Note: d absolute not signed distance
     en = np.sqrt(n1 * n2 / float(n1 + n2))
     try:
         prob = distributions.kstwobign.sf((en + 0.12 + 0.11 / en) * d)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -166,8 +166,6 @@ import warnings
 import math
 from collections import namedtuple
 
-from scipy._lib.six import xrange
-
 # Scipy imports.
 from scipy._lib.six import callable, string_types, xrange
 from scipy._lib._version import NumpyVersion


### PR DESCRIPTION
As discussed in gh-6435,
1. gh-5938 changed `ks_2samp` for scipy 0.18.0,
2. the change was supposed to be a moderate speed up only, but it changed the behavior in case of ties in the data
3. both "old" (0.17.0) and "new" (0.18.0) behavior is somewhat ad hoc, and the "new" is not clearly better than the "old"
4. figuring out what is the obviously correct behavior is not trivial and nobody seems to have time/energy for it.

Therefore, this PR simply reverts gh-5938 and restores the implementation of `stats.ks_2samp` from scipy 0.17.0 so that we keep backwards compatibility until someone steps up for 4. above.

Points to consider:
- gh-6435 has an example which can be used for testing the result against scipy 0.17.0 and older. ISTM a test like this is going to be confusing in the long run, but I'd be fine adding one if there are strong opinions.
- So far I kept the cython implementation of `ks_2samp` in `_stats.pyx` which is there but unused. Do we want to keep it in the source code, or we're fine with it surviving in the git history only?
