### PR TITLE
commited changes that I originally submitted for scipy.signal.cspline…

### DIFF
--- a/scipy/signal/bsplines.py
+++ b/scipy/signal/bsplines.py
@@ -322,7 +322,7 @@ def cspline1d_eval(cj, newx, dx=1.0, x0=0):
 
     """
     newx = (asarray(newx) - x0) / float(dx)
-    res = zeros_like(newx)
+    res = zeros_like(newx, dtype=cj.dtype)
     if res.size == 0:
         return res
     N = len(cj)
@@ -335,7 +335,7 @@ def cspline1d_eval(cj, newx, dx=1.0, x0=0):
     newx = newx[cond3]
     if newx.size == 0:
         return res
-    result = zeros_like(newx)
+    result = zeros_like(newx, dtype=cj.dtype)
     jlower = floor(newx - 2).astype(int) + 1
     for i in range(4):
         thisj = jlower + i

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -652,7 +652,23 @@ class TestCSpline1DEval(TestCase):
         # make sure interpolated values are on knot points
         assert_array_almost_equal(y2[::10], y, decimal=5)
 
+    def test_complex(self):
+        #  create some smoothly varying complex signal to interpolate
+        x = np.arange(2)
+        y = np.zeros(x.shape, dtype=np.complex64)
+        T = 10.0
+        f = 1.0 / T
+        y = np.exp(2.0J * np.pi * f * x)
 
+        # get the cspline transform
+        cy = signal.cspline1d(y)
+
+        # determine new test x value and interpolate
+        xnew = np.array([0.5])
+        ynew = signal.cspline1d_eval(cy, xnew)
+
+        assert_equal(ynew.dtype, y.dtype)
+        
 class TestOrderFilt(TestCase):
 
     def test_basic(self):


### PR DESCRIPTION
…1d_eval cannot return complex results (Trac #1260) #1787. The bspline interpolator can produce complex results, but will only work correctly if the output uses complex values.

I originally made the trac ticket mentioned above. I have the changes implemented in this pull request. 

The basic issue is that the bspline interpolator can produce correct complex results, but must use complex coefficients. In order for this to work, the zeros_like function has to be changed because in the case of a complex interpolator the bspline interpolation coefficients are complex while input x-values that are interpolated to may be real. (The zeros_like function operators on the x-values that are interpolated to.)
