### PR TITLE
Bugfix/6552 misc.bytescale

### DIFF
--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -32,6 +32,7 @@ __all__ = ['fromimage', 'toimage', 'imsave', 'imread', 'bytescale',
 def _scale(data, low, high, cmin=None, cmax=None):
     """
     Scales an array from an input range of [cmin, cmax] to an output range of [low, high].
+    If cmin and cmax are equal, don't apply any scaling as this scaling is undefined.
 
     Parameters
     ----------
@@ -53,21 +54,19 @@ def _scale(data, low, high, cmin=None, cmax=None):
 
     """
     if high < low:
-        raise ValueError("`high` should be larger than `low`.")
+        raise ValueError("`high` should be larger than or equal to `low`.")
 
     if cmin is None:
         cmin = data.min()
     if cmax is None:
         cmax = data.max()
 
-    cscale = cmax - cmin
-    if cscale < 0:
-        raise ValueError("`cmax` should be larger than `cmin`.")
-    elif cscale == 0:
-        cscale = 1
+    if cmax < cmin:
+        raise ValueError("`cmax` should be larger than or equal to `cmin`.")
+    elif cmax == cmin:  # this scaling is undefined, so don't apply any scaling
+        return data
 
-    outrange = float(high - low)
-    return (data * 1.0 - cmin) * outrange / cscale + low
+    return (data * 1.0 - cmin) * (high - low) / (cmax - cmin) + low
 
 
 # Returns a byte-scaled image

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -31,8 +31,9 @@ __all__ = ['fromimage', 'toimage', 'imsave', 'imread', 'bytescale',
 
 def _scale(data, low, high, cmin=None, cmax=None):
     """
-    Scales an array from an input range of [cmin, cmax] to an output range of [low, high].
-    If cmin and cmax are equal, don't apply any scaling as this scaling is undefined.
+    Scales an array from an input range of [cmin, cmax] to an output range of 
+    [low, high]. If cmin and cmax are equal, no scaling is applied as this 
+    scaling is undefined.
 
     Parameters
     ----------

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -100,6 +100,17 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
     Examples
     --------
     >>> from scipy.misc import bytescale
+    >>> a = np.arange(10)
+    >>> a
+    array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    >>> bytescale(a)
+    array([  0,  28,  57,  85, 113, 142, 170, 198, 227, 255], dtype=uint8)
+    >>> bytescale(a, cmin=3, cmax=6)
+    array([  0,   0,   0,   0,  85, 170, 255, 255, 255, 255], dtype=uint8)
+    >>> bytescale(a, low=100, high=200)
+    array([100, 111, 122, 133, 144, 156, 167, 178, 189, 200], dtype=uint8)
+    >>> bytescale(a, cmin=3, cmax=6, low=100, high=200)
+    array([100, 100, 100, 100, 133, 167, 200, 200, 200, 200], dtype=uint8)
     >>> img = np.array([[ 91.06794177,   3.39058326,  84.4221549 ],
     ...                 [ 73.88003259,  80.91433048,   4.88878881],
     ...                 [ 51.53875334,  34.45808177,  27.5873488 ]])

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -345,7 +345,11 @@ def toimage(arr, high=255, low=0, cmin=None, cmax=None, pal=None,
             bytedata = (data > high)
             image = Image.frombytes('1', shape, bytedata.tostring())
             return image
-        data = _scale(data, low, high, cmin, cmax)
+        if cmin is None:
+            cmin = amin(ravel(data))
+        if cmax is None:
+            cmax = amax(ravel(data))
+        data = (data*1.0 - cmin)*(high - low)/(cmax - cmin) + low
         if mode == 'I':
             data32 = data.astype(numpy.uint32)
             image = Image.frombytes(mode, shape, data32.tostring())

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -120,10 +120,10 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
     if data.dtype == uint8:
         return data
 
-    bytedata = _scale(data, low, high, cmin, cmax)
-    bytedata[bytedata > high] = high
-    bytedata[bytedata < low] = low
-    return cast[uint8](bytedata.round())
+    scaled_data = _scale(data, low, high, cmin, cmax)
+    scaled_data[scaled_data > high] = high
+    scaled_data[scaled_data < low] = low
+    return cast[uint8](scaled_data.round())
 
 
 def imread(name, flatten=False, mode=None):

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -93,11 +93,11 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
     elif cscale == 0:
         cscale = 1
 
-    scale = float(high - low) / cscale
-    bytedata = (data * 1.0 - cmin) * scale + 0.4999
+    outrange = float(high - low)
+    bytedata = (data * 1.0 - cmin) * outrange / cscale + low
     bytedata[bytedata > high] = high
-    bytedata[bytedata < 0] = 0
-    return cast[uint8](bytedata) + cast[uint8](low)
+    bytedata[bytedata < low] = low
+    return cast[uint8](bytedata.round())
 
 
 def imread(name, flatten=False, mode=None):

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -132,43 +132,6 @@ class Test_bytescale(TestCase):
             expected = scale(inVal)
             self.assertEqual(outVal, expected)
 
-    def test_bytescale_ex1(self):
-        # Testing first example in misc.bytescale docstring
-        expected = np.array([[255, 0, 236],
-                            [205, 225, 4],
-                            [140, 90, 70]], dtype=np.uint8)
-
-        out = misc.bytescale(self.img)
-
-        self.assertValidOutput(self.img, out)
-        self.assertArrayEquals(out, expected)
-
-    def test_bytescale_ex2(self):
-        # Testing second example in misc.bytescale docstring
-        low = 100
-        high = 200
-        expected = np.array([[200, 100, 192],
-                            [180, 188, 102],
-                            [155, 135, 128]], dtype=np.uint8)
-
-        out = misc.bytescale(self.img, high=high, low=low)
-
-        self.assertValidOutput(self.img, out, low=low, high=high)
-        self.assertArrayEquals(out, expected)
-
-    def test_bytescale_ex3(self):
-        # Testing third example in misc.bytescale docstring
-        cmin = 0
-        cmax = 255
-        expected = np.array([[91, 3, 84],
-                            [74, 81, 5],
-                            [52, 34, 28]], dtype=np.uint8)
-
-        out = misc.bytescale(self.img, cmin=cmin, cmax=cmax)
-
-        self.assertValidOutput(self.img, out, cmin=cmin, cmax=cmax)
-        self.assertArrayEquals(out, expected)
-
     def test_bytescale_low1_high255(self):
         # Testing misc.bytescale with low and high params
         low = 1

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -93,9 +93,9 @@ class Test_bytescale(TestCase):
     def setUpClass(cls):
 
         # straight out of the scipy.misc.bytescale docstring
-        cls.img = np.array([[91.06794177, 3.39058326, 84.4221549 ],
+        cls.img = np.array([[91.06794177, 3.39058326, 84.4221549],
                             [73.88003259, 80.91433048, 4.88878881],
-                            [51.53875334, 34.45808177, 27.5873488 ]])
+                            [51.53875334, 34.45808177, 27.5873488]])
 
     def assertArrayEquals(self, actual, expected):
         '''

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -133,9 +133,7 @@ class Test_bytescale(TestCase):
             self.assertEqual(outVal, expected)
 
     def test_bytescale_ex1(self):
-        '''
-        Testing first example in misc.bytescale docstring
-        '''
+        # Testing first example in misc.bytescale docstring
         expected = np.array([[255, 0, 236],
                             [205, 225, 4],
                             [140, 90, 70]], dtype=np.uint8)
@@ -146,9 +144,7 @@ class Test_bytescale(TestCase):
         self.assertArrayEquals(out, expected)
 
     def test_bytescale_ex2(self):
-        '''
-        Testing second example in misc.bytescale docstring
-        '''
+        # Testing second example in misc.bytescale docstring
         low = 100
         high = 200
         expected = np.array([[200, 100, 192],
@@ -161,9 +157,7 @@ class Test_bytescale(TestCase):
         self.assertArrayEquals(out, expected)
 
     def test_bytescale_ex3(self):
-        '''
-        Testing third example in misc.bytescale docstring
-        '''
+        # Testing third example in misc.bytescale docstring
         cmin = 0
         cmax = 255
         expected = np.array([[91, 3, 84],
@@ -176,9 +170,7 @@ class Test_bytescale(TestCase):
         self.assertArrayEquals(out, expected)
 
     def test_bytescale_low1_high255(self):
-        '''
-        Testing misc.bytescale with low and high params
-        '''
+        # Testing misc.bytescale with low and high params
         low = 1
         high = 255
 
@@ -189,9 +181,7 @@ class Test_bytescale(TestCase):
         self.assertEquals(out.max(), high)
 
     def test_bytescale_cmin5_cmax85(self):
-        '''
-        Testing misc.bytescale with cmin and cmax params
-        '''
+        # Testing misc.bytescale with cmin and cmax params
         cmin = 5
         cmax = 85
 
@@ -200,9 +190,7 @@ class Test_bytescale(TestCase):
         self.assertValidOutput(self.img, out, cmin=cmin, cmax=cmax)
 
     def test_bytescale_cmincmax_lowhigh(self):
-        '''
-        Testing misc.bytescale with cmin, cmax, low and high params
-        '''
+        # Testing misc.bytescale with cmin, cmax, low and high params
         cmin = 5
         cmax = 85
         high = 255

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -64,7 +64,7 @@ class TestPILUtil(TestCase):
         x = np.array([0, 1, 2], np.uint8)
         y = np.array([0, 1, 2])
         assert_equal(misc.bytescale(x), x)
-        assert_equal(misc.bytescale(y), [0, 127, 255])
+        assert_equal(misc.bytescale(y), [0, 128, 255])
 
     def test_bytescale_keywords(self):
         x = np.array([40, 60, 120, 200, 300, 500])

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -104,11 +104,12 @@ class Test_bytescale(TestCase):
         assert_array_equal(actual, expected)
         self.assertEquals(actual.dtype, expected.dtype)
 
-    def assertValidOutput(self, inputArray, outputArray, cmin=None, cmax=None, high=255, low=0):
+    def assertValidOutput(self, inputArray, outputArray, cmin=None, cmax=None,
+                          high=255, low=0):
         '''
-        Assert that every array element is properly scaled based on cmin, cmax, low,
-        and high parameters used. It's like an independent check that the scaling is being done
-        right.
+        Assert that every array element is properly scaled based on cmin, cmax,
+        low, and high parameters used. It's like an independent check that the
+        scaling is being done right.
         '''
         def scale(val):
             '''
@@ -159,9 +160,11 @@ class Test_bytescale(TestCase):
         high = 255
         low = 1
 
-        out = misc.bytescale(self.img, cmin=cmin, cmax=cmax, high=high, low=low)
+        out = misc.bytescale(self.img, cmin=cmin, cmax=cmax,
+                             high=high, low=low)
 
-        self.assertValidOutput(self.img, out, cmin=cmin, cmax=cmax, high=high, low=low)
+        self.assertValidOutput(self.img, out, cmin=cmin, cmax=cmax,
+                               high=high, low=low)
         self.assertEquals(out.min(), low)
         self.assertEquals(out.max(), high)
 
@@ -181,16 +184,31 @@ class Test_bytescale(TestCase):
 
     def test_bytescale_cmin_equals_cmax(self):
         # Undefined scaling (cmin==cmax), so don't scale
-        assert_equal(misc.bytescale(np.array([3, 3, 3])), [3, 3, 3])
-        assert_equal(misc.bytescale(np.array([1, 2, 3]), cmin=2, cmax=2), [1, 2, 3])
+        actual = misc.bytescale(np.array([3, 3, 3]))
+        expected = [3, 3, 3]
+        assert_equal(actual, expected)
 
-        # Undefined scaling (cmin==cmax), but low is specified. Cap lower bounds
-        assert_equal(misc.bytescale(np.array([1, 2, 3]), cmin=2, cmax=2, low=4), [4, 4, 4])
-        assert_equal(misc.bytescale(np.array([1, 2, 3]), cmin=2, cmax=2, low=2), [2, 2, 3])
+        actual = misc.bytescale(np.array([1, 2, 3]), cmin=2, cmax=2)
+        expected = [1, 2, 3]
+        assert_equal(actual, expected)
 
-        # Undefined scaling (cmin==cmax), but high is specified. Cap upper bounds
-        assert_equal(misc.bytescale(np.array([1, 2, 3]), cmin=2, cmax=2, high=0), [0, 0, 0])
-        assert_equal(misc.bytescale(np.array([1, 2, 3]), cmin=2, cmax=2, high=2), [1, 2, 2])
+        # Undefined scaling (cmin==cmax), but low is given. Cap lower bounds
+        actual = misc.bytescale(np.array([1, 2, 3]), cmin=2, cmax=2, low=4)
+        expected = [4, 4, 4]
+        assert_equal(actual, expected)
+
+        actual = misc.bytescale(np.array([1, 2, 3]), cmin=2, cmax=2, low=2)
+        expected = [2, 2, 3]
+        assert_equal(actual, expected)
+
+        # Undefined scaling (cmin==cmax), but high is given. Cap upper bounds
+        actual = misc.bytescale(np.array([1, 2, 3]), cmin=2, cmax=2, high=0)
+        expected = [0, 0, 0]
+        assert_equal(actual, expected)
+
+        actual = misc.bytescale(np.array([1, 2, 3]), cmin=2, cmax=2, high=2)
+        expected = [1, 2, 2]
+        assert_equal(actual, expected)
 
     def test_cmax_lessthan_cmin(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Resolves issue #6552 where bytescaling an array using both cmin/cmax and low/high parameters resulted in an unexpected array.

It's worth noting that `misc.toimage` uses `misc.bytescale`. And `misc.toimage` is used by `misc.imsave`, `misc.imrotate`, `misc.imshow`, `misc.imresize`, and `misc.imfilter`. So this PR touches a few public functions.
