### PR TITLE
BUG: modify signal.find_peaks_cwt() to return array and accept sequence.

### DIFF
--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -65,7 +65,8 @@ Deprecated features
 
 Backwards incompatible changes
 ==============================
-
+The function `scipy.signal.find_peaks_cwt()` now returns an array instead of
+a list.
 
 
 Other changes

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -504,6 +504,8 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
     ([32], array([ 1.6]), array([ 0.9995736]))
 
     """
+    widths = np.asarray(widths)
+
     if gap_thresh is None:
         gap_thresh = np.ceil(widths[0])
     if max_distances is None:
@@ -515,5 +517,7 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
     ridge_lines = _identify_ridge_lines(cwt_dat, max_distances, gap_thresh)
     filtered = _filter_ridge_lines(cwt_dat, ridge_lines, min_length=min_length,
                                    min_snr=min_snr, noise_perc=noise_perc)
-    max_locs = [x[1][0] for x in filtered]
-    return sorted(max_locs)
+    max_locs = np.asarray([x[1][0] for x in filtered])
+    max_locs.sort()
+
+    return max_locs


### PR DESCRIPTION
This change makes two modifications to `signal.find_peaks_cwt()`. First, it changes the type of the return value to array, and second it allows for the `widths` parameter to be any sequence. The documentation has claimed that `widths` can be a sequence, despite passing a list causing an exception.

This resolves gh-6560.
