### PR TITLE
DOC: Negative binomial distribution clarification

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -142,13 +142,17 @@ class nbinom_gen(rv_discrete):
 
     Notes
     -----
-    The probability mass function for `nbinom` is::
+    Negative binomial distribution describes a sequence of i.i.d. Bernoulli 
+    trials, repeated until a predefined, non-random number of successes occurs.
 
-         nbinom.pmf(k) = choose(k+n-1, n-1) * p**n * (1-p)**k
+    The probability mass function of the number of failures for `nbinom` is::
+
+       nbinom.pmf(k) = choose(k+n-1, n-1) * p**n * (1-p)**k
 
     for ``k >= 0``.
 
-    `nbinom` takes ``n`` and ``p`` as shape parameters.
+    `nbinom` takes ``n`` and ``p`` as shape parameters where n is the number of
+    successes, whereas p is the probability of a single success.
 
     %(after_notes)s
 


### PR DESCRIPTION
 The negative binomial distribution can be parametrized with either
the number of succeses or failures. The tutorial explains what was
chosen in the scipy implementation, but the reference does not.

 In my opinion it's worth to describe it here, to me it is a must have
to be able to look it up quickly in the reference.
