### PR TITLE
MAINT: be more liberal in requiring numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -352,16 +352,16 @@ def setup_package():
     # We don't want to do that unconditionally, because we risk updating
     # an installed numpy which fails too often.  Just if it's not installed, we
     # may give it a try.  See gh-3379.
-    build_requires = []
     try:
         import numpy
-        if (len(sys.argv) >= 2 and sys.argv[1] == 'bdist_wheel' and
-                sys.platform == 'darwin'):
-            # We're ony building wheels for platforms where we know there's
-            # also a Numpy wheel, so do this unconditionally.  See gh-5184.
-            build_requires = ['numpy>=1.7.1']
-    except:
+    except ImportError:  # We do not have numpy installed
         build_requires = ['numpy>=1.7.1']
+    else:
+        # If we're building a wheel, assume there already exist numpy wheels
+        # for this platform, so it is safe to add numpy to build requirements.
+        # See gh-5184.
+        build_requires = (['numpy>=1.7.1'] if 'bdist_wheel' in sys.argv[1:]
+                          else [])
 
     metadata = dict(
         name='scipy',


### PR DESCRIPTION
Now we have numpy wheels for the common platforms, and pip caches wheels
by default, assume there exists a numpy wheel if we are building a scipy
wheel, and add it to the wheel install requirements.

See also: https://github.com/scipy/scipy.org/pull/17
