### PR TITLE
MAINT: use xrange for iteration in differential_evolution fixes #6559

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy.optimize import OptimizeResult, minimize
 from scipy.optimize.optimize import _status_message
 from scipy._lib._util import check_random_state
+from scipy._lib.six import xrange
 import warnings
 
 
@@ -510,7 +511,7 @@ class DifferentialEvolutionSolver(object):
             self._calculate_population_energies()
 
         # do the optimisation.
-        for nit in range(1, self.maxiter + 1):
+        for nit in xrange(1, self.maxiter + 1):
             # evolve the population by a generation
             try:
                 next(self)


### PR DESCRIPTION
If really large numbers are used for `maxiter` in `differential_evolution` there are memory problems with a call to `range`.  Fix is to swap `range` for `six.xrange`.
