### PR TITLE
MAINT: add a name to .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -117,6 +117,7 @@ Jeff Armstrong <jeff@approximatrix.com> Jeff Armstrong <jeff@approximatrix.com>
 Jesse Engel <jesse.engel@gmail.com> jesseengel <jesse.engel@gmail.com>
 Joel Nothman <joel.nothman@gmail.com> jnothman <jnothman@student.usyd.edu.au>
 Joel Nothman <joel.nothman@gmail.com> Joel Nothman <jnothman@student.usyd.edu.au>
+Johannes Schmitz <johannes.schmitz1@gmail.com> johschmitz <johannes.schmitz1@gmail.com>
 Jona Sassenhagen <jona.sassenhagen@gmail.com> jona-sassenhagen <jona.sassenhagen@gmail.com>
 Jonathan Taylor <jonathan.taylor@localhost> jonathan.taylor <jonathan.taylor@localhost>
 Joris Vankerschaver <joris.vankerschaver@gmail.com> Joris Vankerschaver <jvankerschaver@enthought.com>


### PR DESCRIPTION
To mirror the addition to authors.py in a maintenance branch.

[ci skip]
