### PR TITLE
BUG: misc: allow both cmin/cmax and low/high params in bytescale

### DIFF
--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -94,10 +94,10 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
         cscale = 1
 
     scale = float(high - low) / cscale
-    bytedata = (data * 1.0 - cmin) * scale + 0.4999
+    bytedata = (data * 1.0 - cmin) * scale + low
     bytedata[bytedata > high] = high
-    bytedata[bytedata < 0] = 0
-    return cast[uint8](bytedata) + cast[uint8](low)
+    bytedata[bytedata < low] = low
+    return cast[uint8](bytedata.round())
 
 
 def imread(name, flatten=False, mode=None):

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -94,7 +94,7 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
         cscale = 1
 
     scale = float(high - low) / cscale
-    bytedata = (data * 1.0 - cmin) * scale + low
+    bytedata = (data - cmin) * scale + low
     bytedata[bytedata > high] = high
     bytedata[bytedata < low] = low
     return cast[uint8](bytedata.round())

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -95,9 +95,7 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
 
     scale = float(high - low) / cscale
     bytedata = (data - cmin) * scale + low
-    bytedata[bytedata > high] = high
-    bytedata[bytedata < low] = low
-    return (bytedata + 0.5).astype(uint8)
+    return (bytedata.clip(low, high) + 0.5).astype(uint8)
 
 
 def imread(name, flatten=False, mode=None):

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -79,8 +79,12 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
     if data.dtype == uint8:
         return data
 
+    if high > 255:
+        raise ValueError("`high` should be less than or equal to 255.")
+    if low < 0:
+        raise ValueError("`low` should be greater than or equal to 0.")
     if high < low:
-        raise ValueError("`high` should be larger than `low`.")
+        raise ValueError("`high` should be greater than or equal to `low`.")
 
     if cmin is None:
         cmin = data.min()

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -97,7 +97,7 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
     bytedata = (data - cmin) * scale + low
     bytedata[bytedata > high] = high
     bytedata[bytedata < low] = low
-    return bytedata.round().astype(uint8)
+    return (bytedata + 0.5).astype(uint8)
 
 
 def imread(name, flatten=False, mode=None):

--- a/scipy/misc/pilutil.py
+++ b/scipy/misc/pilutil.py
@@ -97,7 +97,7 @@ def bytescale(data, cmin=None, cmax=None, high=255, low=0):
     bytedata = (data - cmin) * scale + low
     bytedata[bytedata > high] = high
     bytedata[bytedata < low] = low
-    return cast[uint8](bytedata.round())
+    return bytedata.round().astype(uint8)
 
 
 def imread(name, flatten=False, mode=None):

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -12,6 +12,7 @@ from numpy.testing import (assert_equal, dec, decorate_methods,
                            assert_array_equal)
 
 from scipy import misc
+from numpy.ma.testutils import assert_mask_equal
 
 try:
     import PIL.Image
@@ -79,6 +80,14 @@ class TestPILUtil(TestCase):
         actual = misc.bytescale(a, cmin=3, cmax=6, low=100, high=200)
         expected = [100, 100, 100, 100, 133, 167, 200, 200, 200, 200]
         assert_equal(actual, expected)
+
+    def test_bytescale_mask(self):
+        a = np.ma.MaskedArray(data=[1, 2, 3], mask=[False, False, True])
+        actual = misc.bytescale(a)
+        expected = [0, 255, 3]
+        assert_equal(expected, actual)
+        assert_mask_equal(a.mask, actual.mask)
+        self.assertTrue(isinstance(actual, np.ma.MaskedArray))
 
     def test_imsave(self):
         picdir = os.path.join(datapath, "data")

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -9,7 +9,7 @@ import glob
 
 from numpy.testing import (assert_equal, dec, decorate_methods,
                            TestCase, run_module_suite, assert_allclose,
-                           assert_array_equal)
+                           assert_array_equal, assert_raises)
 
 from scipy import misc
 from numpy.ma.testutils import assert_mask_equal
@@ -93,6 +93,24 @@ class TestPILUtil(TestCase):
         a = np.array([-0.5, 0.5, 1.5, 2.5, 3.5])
         actual = misc.bytescale(a, cmin=0, cmax=10, low=0, high=10)
         expected = [0, 1, 2, 3, 4]
+        assert_equal(actual, expected)
+
+    def test_bytescale_low_greaterthan_high(self):
+        with assert_raises(ValueError):
+            misc.bytescale(np.arange(3), low=10, high=5)
+
+    def test_bytescale_low_lessthan_0(self):
+        with assert_raises(ValueError):
+            misc.bytescale(np.arange(3), low=-1)
+
+    def test_bytescale_high_greaterthan_255(self):
+        with assert_raises(ValueError):
+            misc.bytescale(np.arange(3), high=256)
+
+    def test_bytescale_low_equals_high(self):
+        a = np.arange(3)
+        actual = misc.bytescale(a, low=10, high=10)
+        expected = [10, 10, 10]
         assert_equal(actual, expected)
 
     def test_imsave(self):

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -64,7 +64,7 @@ class TestPILUtil(TestCase):
         x = np.array([0, 1, 2], np.uint8)
         y = np.array([0, 1, 2])
         assert_equal(misc.bytescale(x), x)
-        assert_equal(misc.bytescale(y), [0, 127, 255])
+        assert_equal(misc.bytescale(y), [0, 128, 255])
 
     def test_bytescale_keywords(self):
         x = np.array([40, 60, 120, 200, 300, 500])

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -74,6 +74,12 @@ class TestPILUtil(TestCase):
         assert_equal(res_cmincmax, [0, 0, 64, 149, 255, 255])
         assert_equal(misc.bytescale(np.array([3, 3, 3]), low=4), [4, 4, 4])
 
+    def test_bytescale_cscale_lowhigh(self):
+        a = np.arange(10)
+        actual = misc.bytescale(a, cmin=3, cmax=6, low=100, high=200)
+        expected = [100, 100, 100, 100, 133, 167, 200, 200, 200, 200]
+        assert_equal(actual, expected)
+
     def test_imsave(self):
         picdir = os.path.join(datapath, "data")
         for png in glob.iglob(picdir + "/*.png"):

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -89,6 +89,12 @@ class TestPILUtil(TestCase):
         assert_mask_equal(a.mask, actual.mask)
         self.assertTrue(isinstance(actual, np.ma.MaskedArray))
 
+    def test_bytescale_rounding(self):
+        a = np.array([-0.5, 0.5, 1.5, 2.5, 3.5])
+        actual = misc.bytescale(a, cmin=0, cmax=10, low=0, high=10)
+        expected = [0, 1, 2, 3, 4]
+        assert_equal(actual, expected)
+
     def test_imsave(self):
         picdir = os.path.join(datapath, "data")
         for png in glob.iglob(picdir + "/*.png"):


### PR DESCRIPTION
Resolves issue #6552 where bytescaling an array using both cmin/cmax and low/high parameters resulted in an unexpected array.
