### PR TITLE
DOC: Replace 'first' by 'smallest' in mode

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -378,7 +378,7 @@ def mode(a, axis=0, nan_policy='propagate'):
     """
     Returns an array of the modal (most common) value in the passed array.
 
-    If there is more than one such value, only the first is returned.
+    If there is more than one such value, only the smallest is returned.
     The bin-count for the modal bins is also returned.
 
     Parameters


### PR DESCRIPTION
This is in response to #6526 . Basically the mode function returns the smallest value when there are repeats as in the example in the #6526 thread. 
