### PR TITLE
[DOC] Fix incorrect error message in medfilt2d

### DIFF
--- a/scipy/signal/sigtoolsmodule.c
+++ b/scipy/signal/sigtoolsmodule.c
@@ -1318,7 +1318,7 @@ static PyObject *sigtools_median2d(PyObject *NPY_UNUSED(dummy), PyObject *args)
                        PyArray_DIMS(a_image));
 	    break;
 	default:
-	  PYERR("2D median filter only supports Int8, Float32, and Float64.");
+	  PYERR("2D median filter only supports uint8, float32, and float64.");
 	}
     }
 


### PR DESCRIPTION
Currently `medfilt2d' only accepts`uint8`whereas the error thrown on bad input says it accepts`Int8`. Fix this. Also fix capitalisation on`Float32`and`Float64` in the same error message.  References #6542 . 
