### PR TITLE
MAINT: linalg: turn a `solve_discrete_are` test back on

### DIFF
--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -319,11 +319,11 @@ def test_solve_discrete_are():
          np.array([[0.25]]),
          "Bad absolute accuracy"),
         # darex #15
-        (np.eye(100,k=1),
-         np.flipud(np.eye(100,1)),
+        (np.eye(100, k=1),
+         np.flipud(np.eye(100, 1)),
          np.eye(100),
          np.array([[1]]),
-         "Fails to find a valid solution")
+         None)
         ]
 
     def _test_factory(case):


### PR DESCRIPTION
Guessing that fixing the in-place numpy operation fixed this one.

cc @ilayn 
