### PR TITLE
DEP: Raise minimum numpy version to 1.8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
       env:
         - TESTMODE=fast
         - COVERAGE=
-        - NUMPYSPEC="numpy==1.7.2"
+        - NUMPYSPEC="numpy==1.8.2"
         - USE_SDIST=1
     - python: 2.7
       env:

--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -15,7 +15,7 @@ of bug-fixes and optimizations.  Moreover, our development attention
 will now shift to bug-fix releases on the 0.20.x branch, and on adding
 new features on the master branch.
 
-This release requires Python 2.7 or 3.4-3.5 and NumPy 1.7.1 or greater.
+This release requires Python 2.7 or 3.4-3.5 and NumPy 1.8.2 or greater.
 
 
 

--- a/pavement.py
+++ b/pavement.py
@@ -548,9 +548,9 @@ def _build_mpkg(pyver):
     numver = parse_numpy_version(MPKG_PYTHON[pyver])
     numverstr = ".".join(["%i" % i for i in numver])
     if pyver < "3.3":
-        if not numver == (1, 7, 2):
-            raise ValueError("Scipy 0.18.x should be built against numpy "
-                             "1.7.2, (detected %s) for Python >= 3.3" % numverstr)
+        if not numver == (1, 8, 2):
+            raise ValueError("Scipy 0.19.x should be built against numpy "
+                             "1.8.2, (detected %s) for Python >= 3.4" % numverstr)
 
     prepare_static_gfortran_runtime("build")
     # account for differences between Python 2.7.1 versions from python.org

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -104,9 +104,9 @@ else:
 
     from scipy.version import version as __version__
     from scipy._lib._version import NumpyVersion as _NumpyVersion
-    if _NumpyVersion(__numpy_version__) < '1.7.1':
+    if _NumpyVersion(__numpy_version__) < '1.8.2':
         import warnings
-        warnings.warn("Numpy 1.7.1 or above is recommended for this version of "
+        warnings.warn("Numpy 1.8.2 or above is recommended for this version of "
                       "scipy (detected version %s)" % __numpy_version__,
                       UserWarning)
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1161,7 +1161,6 @@ class TestVectorNorms(object):
         assert_equal(norm([1,0,3], 0), 2)
         assert_equal(norm([1,2,3], 0), 3)
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_axis_kwd(self):
         a = np.array([[[2, 1], [3, 4]]] * 2, 'd')
         assert_allclose(norm(a, axis=1), [[3.60555128, 4.12310563]] * 2)
@@ -1198,7 +1197,6 @@ class TestMatrixNorms(object):
                         desired = np.linalg.norm(A.astype(t_high), ord=order)
                         np.assert_allclose(actual, desired)
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_axis_kwd(self):
         a = np.array([[[2, 1], [3, 4]]] * 2, 'd')
         b = norm(a, ord=np.inf, axis=(1, 0))

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -26,8 +26,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
         Input array.
     axis : None or int or tuple of ints, optional
         Axis or axes over which the sum is taken. By default `axis` is None,
-        and all elements are summed. Tuple of ints is not accepted if NumPy
-        version is lower than 1.7.0.
+        and all elements are summed.
 
         .. versionadded:: 0.11.0
     keepdims : bool, optional

--- a/scipy/misc/tests/test_pilutil.py
+++ b/scipy/misc/tests/test_pilutil.py
@@ -192,10 +192,7 @@ def test_imread_4bit():
     with open(filename, 'rb') as f:
         im = misc.imread(f)
     assert_equal(im.dtype, np.uint8)
-    # When the oldest supported version of numpy is 1.7, the following
-    # line can be change to
-    #   j, i = np.meshgrid(np.arange(12), np.arange(31), indexing='ij')
-    j, i = [k.T for k in np.meshgrid(np.arange(12), np.arange(31))]
+    j, i = np.meshgrid(np.arange(12), np.arange(31), indexing='ij')
     expected = 17*(np.maximum(j, i) % 16).astype(np.uint8)
     assert_equal(im, expected)
 

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -123,12 +123,7 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
         x = x[::-1]
 
     order = np.arange(polyorder + 1).reshape(-1, 1)
-    if order.size == 1:
-        # Avoid spurious DeprecationWarning in numpy 1.8.0 for
-        # ``[1] ** [[2]]``, see numpy gh-4145.
-        A = np.atleast_2d(x ** order[0, 0])
-    else:
-        A = x ** order
+    A = x ** order
 
     # y determines which order derivative is returned.
     y = np.zeros(polyorder + 1)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -192,7 +192,6 @@ class TestPeriodogram(TestCase):
         assert_allclose(p, q, atol=1e-7)
         assert_(p.dtype == q.dtype)
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_real_twosided_32(self):
         x = np.zeros(16, 'f')
         x[0] = 1
@@ -203,7 +202,6 @@ class TestPeriodogram(TestCase):
         assert_allclose(p, q)
         assert_(p.dtype == q.dtype)
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_complex_32(self):
         x = np.zeros(16, 'F')
         x[0] = 1.0 + 2.0j
@@ -431,7 +429,6 @@ class TestWelch(TestCase):
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_real_twosided_32(self):
         x = np.zeros(16, 'f')
         x[0] = 1
@@ -444,7 +441,6 @@ class TestWelch(TestCase):
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_complex_32(self):
         x = np.zeros(16, 'F')
         x[0] = 1.0 + 2.0j
@@ -758,7 +754,6 @@ class TestCSD:
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_real_twosided_32(self):
         x = np.zeros(16, 'f')
         x[0] = 1
@@ -771,7 +766,6 @@ class TestCSD:
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
         assert_(p.dtype == q.dtype)
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_complex_32(self):
         x = np.zeros(16, 'F')
         x[0] = 1.0 + 2.0j

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -596,12 +596,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             Reduce result for nonzeros in each major_index
         """
         major_index = np.flatnonzero(np.diff(self.indptr))
-        if self.data.size == 0 and major_index.size == 0:
-            # Numpy < 1.8.0 don't handle empty arrays in reduceat
-            value = np.zeros_like(self.data)
-        else:
-            value = ufunc.reduceat(self.data,
-                                   downcast_intp_index(self.indptr[major_index]))
+        value = ufunc.reduceat(self.data,
+                               downcast_intp_index(self.indptr[major_index]))
         return major_index, value
 
     #######################

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -743,9 +743,7 @@ greater than %d - this is not supported on this machine
 
     # Use the algorithm from python's random.sample for k < mn/3.
     if mn < 3*k:
-        # We should use this line, but choice is only available in numpy >= 1.7
-        # ind = random_state.choice(mn, size=k, replace=False)
-        ind = random_state.permutation(mn)[:k]
+        ind = random_state.choice(mn, size=k, replace=False)
     else:
         ind = np.empty(k, dtype=tp)
         selected = set()

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -88,7 +88,6 @@ class TestVsNumpyNorm(TestCase):
                 [-1, 1, 4j]],
             )
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_sparse_matrix_norms(self):
         for sparse_type in self._sparse_types:
             for M in self._test_matrices:
@@ -100,7 +99,6 @@ class TestVsNumpyNorm(TestCase):
                 assert_allclose(spnorm(S, 1), npnorm(M, 1))
                 assert_allclose(spnorm(S, -1), npnorm(M, -1))
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_sparse_matrix_norms_with_axis(self):
         for sparse_type in self._sparse_types:
             for M in self._test_matrices:
@@ -118,7 +116,6 @@ class TestVsNumpyNorm(TestCase):
                     assert_allclose(spnorm(S, 'fro', axis=axis),
                                     npnorm(M, 'fro', axis=axis))
 
-    @dec.skipif(NumpyVersion(np.__version__) < '1.8.0')
     def test_sparse_vector_norms(self):
         for sparse_type in self._sparse_types:
             for M in self._test_matrices:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -396,16 +396,15 @@ class _TestCommon:
             assert_array_equal((-1 < datsp).todense(), -1 < dat)
             assert_array_equal((-2 < datsp).todense(), -2 < dat)
 
-            if NumpyVersion(np.__version__) >= '1.8.0':
-                # data
-                dat = self.dat_dtypes[dtype]
-                datsp = self.datsp_dtypes[dtype]
-                dat2 = dat.copy()
-                dat2[:,0] = 0
-                datsp2 = self.spmatrix(dat2)
+            # data
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+            dat2 = dat.copy()
+            dat2[:,0] = 0
+            datsp2 = self.spmatrix(dat2)
 
-                # dense rhs
-                assert_array_equal(dat < datsp2, datsp < dat2)
+            # dense rhs
+            assert_array_equal(dat < datsp2, datsp < dat2)
 
         msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
         fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))
@@ -462,16 +461,15 @@ class _TestCommon:
             assert_array_equal((-1 > datsp).todense(), -1 > dat)
             assert_array_equal((-2 > datsp).todense(), -2 > dat)
 
-            if NumpyVersion(np.__version__) >= '1.8.0':
-                # data
-                dat = self.dat_dtypes[dtype]
-                datsp = self.datsp_dtypes[dtype]
-                dat2 = dat.copy()
-                dat2[:,0] = 0
-                datsp2 = self.spmatrix(dat2)
+            # data
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+            dat2 = dat.copy()
+            dat2[:,0] = 0
+            datsp2 = self.spmatrix(dat2)
 
-                # dense rhs
-                assert_array_equal(dat > datsp2, datsp > dat2)
+            # dense rhs
+            assert_array_equal(dat > datsp2, datsp > dat2)
 
         msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
         fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))
@@ -523,16 +521,15 @@ class _TestCommon:
             assert_array_equal((-1 <= datsp).todense(), -1 <= dat)
             assert_array_equal((-2 <= datsp).todense(), -2 <= dat)
 
-            if NumpyVersion(np.__version__) >= '1.8.0':
-                # data
-                dat = self.dat_dtypes[dtype]
-                datsp = self.datsp_dtypes[dtype]
-                dat2 = dat.copy()
-                dat2[:,0] = 0
-                datsp2 = self.spmatrix(dat2)
+            # data
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+            dat2 = dat.copy()
+            dat2[:,0] = 0
+            datsp2 = self.spmatrix(dat2)
 
-                # dense rhs
-                assert_array_equal(dat <= datsp2, datsp <= dat2)
+            # dense rhs
+            assert_array_equal(dat <= datsp2, datsp <= dat2)
 
         msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
         fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))
@@ -585,16 +582,15 @@ class _TestCommon:
             assert_array_equal((-1 >= datsp).todense(), -1 >= dat)
             assert_array_equal((-2 >= datsp).todense(), -2 >= dat)
 
-            if NumpyVersion(np.__version__) >= '1.8.0':
-                # dense data
-                dat = self.dat_dtypes[dtype]
-                datsp = self.datsp_dtypes[dtype]
-                dat2 = dat.copy()
-                dat2[:,0] = 0
-                datsp2 = self.spmatrix(dat2)
+            # dense data
+            dat = self.dat_dtypes[dtype]
+            datsp = self.datsp_dtypes[dtype]
+            dat2 = dat.copy()
+            dat2[:,0] = 0
+            datsp2 = self.spmatrix(dat2)
 
-                # dense rhs
-                assert_array_equal(dat >= datsp2, datsp >= dat2)
+            # dense rhs
+            assert_array_equal(dat >= datsp2, datsp >= dat2)
 
         msg = "Bool comparisons only implemented for BSR, CSC, and CSR."
         fails = not isinstance(self, (TestBSR, TestCSC, TestCSR))

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -15,10 +15,6 @@ import numpy as np
 import numpy.matlib
 import scipy
 import itertools
-from scipy._lib._version import NumpyVersion
-
-# Whether Numpy has stacked matrix linear algebra
-HAS_NUMPY_VEC_DET = (NumpyVersion(np.__version__) >= '1.8.0')
 
 __all__ = ['SphericalVoronoi']
 
@@ -50,16 +46,10 @@ def calc_circumcenters(tetrahedrons):
     dy = np.delete(d, 2, axis=2)
     dz = np.delete(d, 3, axis=2)
 
-    if HAS_NUMPY_VEC_DET:
-        dx = np.linalg.det(dx)
-        dy = -np.linalg.det(dy)
-        dz = np.linalg.det(dz)
-        a = np.linalg.det(a)
-    else:
-        dx = np.array([np.linalg.det(m) for m in dx])
-        dy = -np.array([np.linalg.det(m) for m in dy])
-        dz = np.array([np.linalg.det(m) for m in dz])
-        a = np.array([np.linalg.det(m) for m in a])
+    dx = np.linalg.det(dx)
+    dy = -np.linalg.det(dy)
+    dz = np.linalg.det(dz)
+    a = np.linalg.det(a)
 
     nominator = np.vstack((dx, dy, dz))
     denominator = 2*a

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -255,9 +255,7 @@ class TestCdist(TestCase):
 
         # Naive implementation
         def norms(X):
-            # NumPy 1.7: np.linalg.norm(X, axis=1).reshape(-1, 1)
-            return np.asarray([np.linalg.norm(row)
-                               for row in X]).reshape(-1, 1)
+            return np.linalg.norm(X, axis=1).reshape(-1, 1)
 
         Y2 = 1 - np.dot((X1 / norms(X1)), (X2 / norms(X2)).T)
 

--- a/scipy/special/_ellip_harm.py
+++ b/scipy/special/_ellip_harm.py
@@ -103,11 +103,7 @@ def ellip_harm(h2, k2, n, p, s, signm=1, signn=1):
     return _ellip_harm(h2, k2, n, p, s, signm, signn)
 
 
-# np.vectorize does not work on Cython functions on Numpy < 1.8, so a wrapper is needed
-def _ellip_harm_2_vec(h2, k2, n, p, s):
-    return _ellipsoid(h2, k2, n, p, s)
-
-_ellip_harm_2_vec = np.vectorize(_ellip_harm_2_vec, otypes='d')
+_ellip_harm_2_vec = np.vectorize(_ellipsoid, otypes='d')
 
 
 def ellip_harm_2(h2, k2, n, p, s):

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -2730,12 +2730,7 @@ def trimboth(a, proportiontocut, axis=0):
     if (lowercut >= uppercut):
         raise ValueError("Proportion too big.")
 
-    # np.partition is preferred but it only exist in numpy 1.8.0 and higher,
-    # in those cases we use np.sort
-    try:
-        atmp = np.partition(a, (lowercut, uppercut - 1), axis)
-    except AttributeError:
-        atmp = np.sort(a, axis)
+    atmp = np.partition(a, (lowercut, uppercut - 1), axis)
 
     sl = [slice(None)] * atmp.ndim
     sl[axis] = slice(lowercut, uppercut)
@@ -2790,12 +2785,7 @@ def trim1(a, proportiontocut, tail='right', axis=0):
         lowercut = int(proportiontocut * nobs)
         uppercut = nobs
 
-    # np.partition is preferred but it only exist in numpy 1.8.0 and higher,
-    # in those cases we use np.sort
-    try:
-        atmp = np.partition(a, (lowercut, uppercut - 1), axis)
-    except AttributeError:
-        atmp = np.sort(a, axis)
+    atmp = np.partition(a, (lowercut, uppercut - 1), axis)
 
     return atmp[lowercut:uppercut]
 
@@ -2863,12 +2853,7 @@ def trim_mean(a, proportiontocut, axis=0):
     if (lowercut > uppercut):
         raise ValueError("Proportion too big.")
 
-    # np.partition is preferred but it only exist in numpy 1.8.0 and higher,
-    # in those cases we use np.sort
-    try:
-        atmp = np.partition(a, (lowercut, uppercut - 1), axis)
-    except AttributeError:
-        atmp = np.sort(a, axis)
+    atmp = np.partition(a, (lowercut, uppercut - 1), axis)
 
     sl = [slice(None)] * atmp.ndim
     sl[axis] = slice(lowercut, uppercut)

--- a/setup.py
+++ b/setup.py
@@ -355,12 +355,12 @@ def setup_package():
     try:
         import numpy
     except ImportError:  # We do not have numpy installed
-        build_requires = ['numpy>=1.7.1']
+        build_requires = ['numpy>=1.8.2']
     else:
         # If we're building a wheel, assume there already exist numpy wheels
         # for this platform, so it is safe to add numpy to build requirements.
         # See gh-5184.
-        build_requires = (['numpy>=1.7.1'] if 'bdist_wheel' in sys.argv[1:]
+        build_requires = (['numpy>=1.8.2'] if 'bdist_wheel' in sys.argv[1:]
                           else [])
 
     metadata = dict(


### PR DESCRIPTION
As discussed on the mailing list, it seems that the time has come to increase the minimum supported numpy version to 1.8. This is an _incomplete_ first pass at pulling out the roots. I have not yet replaced `scipy._lib._assert_warns`, which replaces/wraps `np.testing.assert_warns`. There are almost certainly other important things I have missed.

I have been able to successfully build this on my machine with anaconda python 2.7.12, numpy 1.8.2, cython 0.24.1. I get one test error; namely the same test as in gh-6288 but with different erroneous values. However, I also get this test failure on `master` so I suspect that this might not be due to my changes in this PR.

```
AssertionError:
Arrays are not equal

(mismatch 33.3333333333%)
 x: array(['NaT', '2004-12-01T15:59-0800', 'NaT', 'NaT',
       '2013-11-29T20:55-0800', '1631-10-15T20:04Z'], dtype='datetime64[m]')
 y: array(['NaT', '2004-12-01T23:59-0800', 'NaT', 'NaT',
       '2013-11-30T04:55-0800', '1631-10-15T20:04Z'], dtype='datetime64[m]')
```
