### PR TITLE
MAINT: 'new' module is deprecated, don't use it

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -4,7 +4,7 @@
 #
 from __future__ import division, print_function, absolute_import
 
-from scipy._lib.six import string_types, exec_
+from scipy._lib.six import string_types, exec_, PY3
 from scipy._lib._util import getargspec_no_self as _getargspec
 
 import sys
@@ -39,12 +39,11 @@ import numpy as np
 
 from ._constants import _XMAX
 
-try:
-    from new import instancemethod
-except ImportError:
-    # Python 3
+if PY3:
     def instancemethod(func, obj, cls):
         return types.MethodType(func, obj)
+else:
+    instancemethod = types.MethodType
 
 
 # These are the docstring parts used for substitution in specific


### PR DESCRIPTION
Don't import `new` module, it's deprecated.  We don't need it and it can cause users to inadvertently step on this particular landmine:

```
$ echo Boom > new.py
$ python
>>> from scipy import stats
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/wglenn/.local/lib/python2.7/site-packages/scipy/stats/__init__.py", line 321, in <module>
    from .stats import *
  File "/home/wglenn/.local/lib/python2.7/site-packages/scipy/stats/stats.py", line 184, in <module>
    from . import distributions
  File "/home/wglenn/.local/lib/python2.7/site-packages/scipy/stats/distributions.py", line 10, in <module>
    from ._distn_infrastructure import (entropy, rv_discrete, rv_continuous,
  File "/home/wglenn/.local/lib/python2.7/site-packages/scipy/stats/_distn_infrastructure.py", line 44, in <module>
    from new import instancemethod
  File "new.py", line 1, in <module>
    Boom
NameError: name 'Boom' is not defined

```
