### PR TITLE
Fixes #6602 - Typo in docs

### DIFF
--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -78,11 +78,12 @@ This integral can be evaluated by using the following code:
 
 >>> from scipy.integrate import quad
 >>> def integrand(x, a, b):
-...     return (a * x**2) + b
+...     return a*x**2 + b
 >>> a = 2
 >>> b = 1
 >>> I = quad(integrand, 0, 1, args=(a,b))
->>> I = (2.0, 2.220446049250313e-14)
+>>> I
+(1.6666666666666667, 1.8503717077085944e-14)
 
 
 Infinite inputs are also allowed in :obj:`quad` by using :math:`\pm`

--- a/doc/source/tutorial/integrate.rst
+++ b/doc/source/tutorial/integrate.rst
@@ -78,7 +78,7 @@ This integral can be evaluated by using the following code:
 
 >>> from scipy.integrate import quad
 >>> def integrand(x, a, b):
-...     return a * x + b
+...     return (a * x**2) + b
 >>> a = 2
 >>> b = 1
 >>> I = quad(integrand, 0, 1, args=(a,b))


### PR DESCRIPTION
I updated the code to reflect the Latex in an example from `scipy.integrate.quad`. 
