### PR TITLE
[DOC] Correct bounds for v in RectSphereBivariateSpline

### DIFF
--- a/scipy/interpolate/fitpack2.py
+++ b/scipy/interpolate/fitpack2.py
@@ -1529,7 +1529,7 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
         (0, pi).
     v : array_like
         1-D array of longitude coordinates in strictly ascending order.
-        Coordinates must be given in radians, and must lie within (0, 2pi).
+        Coordinates must be given in radians, and must lie within (-pi, pi).
     r : array_like
         2-D array of data with shape ``(u.size, v.size)``.
     s : float, optional


### PR DESCRIPTION
This is a fix for #6556 . I changed the SciPy documentation to reflect the actual functionality of fftpack. 
