### PR TITLE
BLD: fix issue with mix of tabs and spaces in isolve/bscript

### DIFF
--- a/scipy/sparse/linalg/isolve/bscript
+++ b/scipy/sparse/linalg/isolve/bscript
@@ -16,7 +16,7 @@ def pre_build(context):
             info = {'extra_link_args': 'Accelerate'}
         else:
             info = {}
-	sources += [os.path.relpath(f, os.path.abspath(os.path.dirname(__file__)))
+        sources += [os.path.relpath(f, os.path.abspath(os.path.dirname(__file__)))
                     for f in get_g77_abi_wrappers(info)]
 
         return default_builder(extension,


### PR DESCRIPTION
Was present for a while already, but apparently only an issue for Python 3.x

[ci skip]
