### PR TITLE
TST: special: silence some deprecation warnings

### DIFF
--- a/scipy/special/_precompute/expn_asy.py
+++ b/scipy/special/_precompute/expn_asy.py
@@ -10,11 +10,16 @@ Sources
 from __future__ import division, print_function, absolute_import
 
 import os
+import warnings
 
 try:
-    import sympy
-    from sympy import Poly
-    x = sympy.symbols('x')
+    # Can remove when sympy #11255 is resolved; see
+    # https://github.com/sympy/sympy/issues/11255
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        import sympy
+        from sympy import Poly
+        x = sympy.symbols('x')
 except ImportError:
     pass
 

--- a/scipy/special/_precompute/utils.py
+++ b/scipy/special/_precompute/utils.py
@@ -1,5 +1,7 @@
 from __future__ import division, print_function, absolute_import
 
+import warnings
+
 try:
     import mpmath as mp
 except ImportError:
@@ -9,7 +11,11 @@ except ImportError:
         pass
 
 try:
-    from sympy.abc import x
+    # Can remove when sympy #11255 is resolved; see
+    # https://github.com/sympy/sympy/issues/11255
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from sympy.abc import x
 except ImportError:
     pass
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -3206,10 +3206,10 @@ class TestSpherical(TestCase):
             warnings.simplefilter("ignore", DeprecationWarning)
             sy1 = special.sph_yn(2,.2)[0][2]
             sy2 = special.sph_yn(0,.2)[0][0]
+            sy3 = special.sph_yn(1,.2)[1][1]
             sphpy = (special.sph_yn(1,.2)[0][0]-2*special.sph_yn(2,.2)[0][2])/3  # correct derivative value
         assert_almost_equal(sy1,-377.52483,5)  # previous values in the system
         assert_almost_equal(sy2,-4.9003329,5)
-        sy3 = special.sph_yn(1,.2)[1][1]
         assert_almost_equal(sy3,sphpy,4)  # compare correct derivative val. (correct =-system val).
 
 


### PR DESCRIPTION
One is from the deprecated `sph_yn`, and the others occur when importing sympy in Python 3 (see https://github.com/sympy/sympy/issues/11255).

Note that the sympy ones won't show up on Travis since sympy isn't installed. Maybe that should be changed so that the sympy tests always run?
