### PR TITLE
ENH: sparse: canonicalize on initialization

### DIFF
--- a/scipy/io/harwell_boeing/hb.py
+++ b/scipy/io/harwell_boeing/hb.py
@@ -327,7 +327,8 @@ def _read_hb_data(content, header):
 
     try:
         return csc_matrix((val, ind-1, ptr-1),
-                          shape=(header.nrows, header.ncols))
+                          shape=(header.nrows, header.ncols),
+                          copy=False, canonicalize=False)
     except ValueError as e:
         raise e
 

--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -260,13 +260,15 @@ def eye(m, n=None, k=0, dtype=float, format=None):
             indices = np.arange(n, dtype=idx_dtype)
             data = np.ones(n, dtype=dtype)
             cls = {'csr': csr_matrix, 'csc': csc_matrix}[format]
-            return cls((data,indices,indptr),(n,n))
+            return cls((data,indices,indptr), shape=(n,n), copy=False,
+                       canonicalize=False)
         elif format == 'coo':
             idx_dtype = get_index_dtype(maxval=n)
             row = np.arange(n, dtype=idx_dtype)
             col = np.arange(n, dtype=idx_dtype)
             data = np.ones(n, dtype=dtype)
-            return coo_matrix((data,(row,col)),(n,n))
+            return coo_matrix((data,(row,col)), shape=(n,n), copy=False,
+                              canonicalize=False)
 
     diags = np.ones((1, max(0, min(m + k, n))), dtype=dtype)
     return spdiags(diags, k, m, n).asformat(format)
@@ -351,7 +353,8 @@ def kron(A, B, format=None):
         data = data.reshape(-1,B.nnz) * B.data
         data = data.reshape(-1)
 
-        return coo_matrix((data,(row,col)), shape=output_shape).asformat(format)
+        return coo_matrix((data, (row,col)), shape=output_shape, copy=False,
+                          canonicalize=False).asformat(format)
 
 
 def kronsum(A, B, format=None):
@@ -419,10 +422,12 @@ def _compressed_sparse_stack(blocks, axis):
     indptr = np.concatenate(indptr)
     if axis == 0:
         return csr_matrix((data, indices, indptr),
-                          shape=(sum_dim, constant_dim))
+                          shape=(sum_dim, constant_dim), copy=False,
+                          canonicalize=False)
     else:
         return csc_matrix((data, indices, indptr),
-                          shape=(constant_dim, sum_dim))
+                          shape=(constant_dim, sum_dim), copy=False,
+                          canonicalize=False)
 
 
 def hstack(blocks, format=None, dtype=None):
@@ -605,7 +610,8 @@ def bmat(blocks, format=None, dtype=None):
         col[idx] = B.col + col_offsets[j]
         nnz += B.nnz
 
-    return coo_matrix((data, (row, col)), shape=shape).asformat(format)
+    return coo_matrix((data, (row, col)), shape=shape, copy=False,
+                      canonicalize=False).asformat(format)
 
 
 def block_diag(mats, format=None, dtype=None):
@@ -759,7 +765,8 @@ greater than %d - this is not supported on this machine
     j = np.floor(ind * 1. / m).astype(tp)
     i = (ind - j * m).astype(tp)
     vals = data_rvs(k).astype(dtype)
-    return coo_matrix((vals, (i, j)), shape=(m, n)).asformat(format)
+    return coo_matrix((vals, (i, j)), shape=(m, n), copy=False,
+                      canonicalize=False).asformat(format)
 
 
 def rand(m, n, density=0.01, format="coo", dtype=None, random_state=None):

--- a/scipy/sparse/csc.py
+++ b/scipy/sparse/csc.py
@@ -118,8 +118,8 @@ class csc_matrix(_cs_matrix, IndexMixin):
         M, N = self.shape
 
         from .csr import csr_matrix
-        return csr_matrix((self.data, self.indices,
-                           self.indptr), (N, M), copy=copy)
+        return csr_matrix((self.data, self.indices, self.indptr), (N, M),
+                          copy=copy, canonicalize=False)
 
     transpose.__doc__ = spmatrix.transpose.__doc__
 
@@ -153,7 +153,8 @@ class csc_matrix(_cs_matrix, IndexMixin):
                   data)
 
         from .csr import csr_matrix
-        A = csr_matrix((data, indices, indptr), shape=self.shape)
+        A = csr_matrix((data, indices, indptr), shape=self.shape,
+                       copy=False, canonicalize=False)
         A.has_sorted_indices = True
         return A
 

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -192,7 +192,7 @@ def csgraph_to_dense(csgraph, null_value=0):
     >>> data = np.array([2, 3])
     >>> indices = np.array([1, 1])
     >>> indptr = np.array([0, 2, 2])
-    >>> M = csr_matrix((data, indices, indptr), shape=(2, 2))
+    >>> M = csr_matrix((data,indices,indptr), shape=(2,2), canonicalize=False)
     >>> M.toarray()
     array([[0, 5],
            [0, 0]])

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -137,8 +137,8 @@ class csr_matrix(_cs_matrix, IndexMixin):
         M, N = self.shape
 
         from .csc import csc_matrix
-        return csc_matrix((self.data, self.indices,
-                           self.indptr), shape=(N, M), copy=copy)
+        return csc_matrix((self.data, self.indices, self.indptr), shape=(N, M),
+                          copy=copy, canonicalize=False)
 
     transpose.__doc__ = spmatrix.transpose.__doc__
 
@@ -146,7 +146,6 @@ class csr_matrix(_cs_matrix, IndexMixin):
         from .lil import lil_matrix
         lil = lil_matrix(self.shape,dtype=self.dtype)
 
-        self.sum_duplicates()
         ptr,ind,dat = self.indptr,self.indices,self.data
         rows, data = lil.rows, lil.data
 
@@ -184,7 +183,8 @@ class csr_matrix(_cs_matrix, IndexMixin):
                   data)
 
         from .csc import csc_matrix
-        A = csc_matrix((data, indices, indptr), shape=self.shape)
+        A = csc_matrix((data, indices, indptr), shape=self.shape, copy=False,
+                       canonicalize=False)
         A.has_sorted_indices = True
         return A
 
@@ -199,7 +199,8 @@ class csr_matrix(_cs_matrix, IndexMixin):
 
         elif blocksize == (1,1):
             arg1 = (self.data.reshape(-1,1,1),self.indices,self.indptr)
-            return bsr_matrix(arg1, shape=self.shape, copy=copy)
+            return bsr_matrix(arg1, shape=self.shape, copy=copy,
+                              canonicalize=False)
 
         else:
             R,C = blocksize
@@ -222,7 +223,8 @@ class csr_matrix(_cs_matrix, IndexMixin):
                       self.data,
                       indptr, indices, data.ravel())
 
-            return bsr_matrix((data,indices,indptr), shape=self.shape)
+            return bsr_matrix((data,indices,indptr), shape=self.shape,
+                              canonicalize=False)
 
     tobsr.__doc__ = spmatrix.tobsr.__doc__
 
@@ -277,7 +279,8 @@ class csr_matrix(_cs_matrix, IndexMixin):
             data = np.ones(len(indices), dtype=self.dtype)
             shape = (len(indices),N)
 
-            return csr_matrix((data,indices,indptr), shape=shape)
+            return csr_matrix((data,indices,indptr), shape=shape, copy=False,
+                              canonicalize=False)
 
         row, col = self._unpack_index(key)
 
@@ -404,7 +407,7 @@ class csr_matrix(_cs_matrix, IndexMixin):
             shape = (1, int(np.ceil(float(stop - start) / stride)))
 
             row_slice = csr_matrix((row_data, row_indices, row_indptr),
-                                   shape=shape)
+                                   shape=shape, copy=False, canonicalize=False)
 
         return row_slice
 

--- a/scipy/sparse/dia.py
+++ b/scipy/sparse/dia.py
@@ -338,7 +338,7 @@ class dia_matrix(_data_matrix):
         indices = row.T[mask.T].astype(idx_dtype, copy=False)
         data = self.data.T[mask.T]
         return csc_matrix((data, indices, indptr), shape=self.shape,
-                          dtype=self.dtype)
+                          dtype=self.dtype, copy=False, canonicalize=True)
 
     tocsc.__doc__ = spmatrix.tocsc.__doc__
 
@@ -357,9 +357,8 @@ class dia_matrix(_data_matrix):
         data = self.data[mask]
 
         from .coo import coo_matrix
-        A = coo_matrix((data,(row,col)), shape=self.shape, dtype=self.dtype)
-        A.has_canonical_format = True
-        return A
+        return coo_matrix((data,(row,col)), shape=self.shape, dtype=self.dtype,
+                          copy=False, canonicalize=False)
 
     tocoo.__doc__ = spmatrix.tocoo.__doc__
 

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -476,9 +476,8 @@ class dok_matrix(spmatrix, IndexMixin, dict):
         idx_dtype = get_index_dtype(maxval=max(self.shape))
         data = np.asarray(_list(self.values()), dtype=self.dtype)
         indices = np.asarray(_list(self.keys()), dtype=idx_dtype).T
-        A = coo_matrix((data, indices), shape=self.shape, dtype=self.dtype)
-        A.has_canonical_format = True
-        return A
+        return coo_matrix((data, indices), shape=self.shape, dtype=self.dtype,
+                          copy=False, canonicalize=False)
 
     tocoo.__doc__ = spmatrix.tocoo.__doc__
 

--- a/scipy/sparse/extract.py
+++ b/scipy/sparse/extract.py
@@ -35,8 +35,7 @@ def find(A):
 
     """
 
-    A = coo_matrix(A, copy=True)
-    A.sum_duplicates()
+    A = coo_matrix(A, copy=False)
     # remove explicit zeros
     nz_mask = A.data != 0
     return A.row[nz_mask], A.col[nz_mask], A.data[nz_mask]
@@ -168,4 +167,5 @@ def _masked_coo(A, mask):
     row = A.row[mask]
     col = A.col[mask]
     data = A.data[mask]
-    return coo_matrix((data, (row, col)), shape=A.shape, dtype=A.dtype)
+    return coo_matrix((data, (row, col)), shape=A.shape, dtype=A.dtype,
+                      copy=False, canonicalize=False)


### PR DESCRIPTION
Duplicates entries are still allowed in COO/CSR/CSC/BSR constructors, but are not handled anywhere else. See gh-5807 for the initial discussion.
