### PR TITLE
MAINT: special: make `errprint` return a boolean

### DIFF
--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -69,6 +69,8 @@ Backwards incompatible changes
 `scipy.spatial.distance.squareform` now returns arrays of the same dtype as
 the input, instead of always float64.
 
+`scipy.special.errprint` now returns a boolean.
+
 The function `scipy.signal.find_peaks_cwt()` now returns an array instead of
 a list.
 

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -17,21 +17,14 @@ noted.
 Error handling
 ==============
 
-Errors are handled by returning nans, or other appropriate values.
-Some of the special function routines will emit warnings when an error
-occurs.  By default this is disabled.  To enable such messages use
-``errprint(1)``, and to disable such messages use ``errprint(0)``.
-
-Example:
-
-    >>> print scipy.special.bdtr(-1,10,0.3)
-    >>> scipy.special.errprint(1)
-    >>> print scipy.special.bdtr(-1,10,0.3)
+Errors are handled by returning NaNs or other appropriate values.
+Some of the special function routines can emit warnings when an error
+occurs. By default this is disabled; to enable it use `errprint`.
 
 .. autosummary::
    :toctree: generated/
 
-   errprint
+   errprint               -- Set or return the error printing flag for special functions.
    SpecialFunctionWarning -- Warning that can be issued with ``errprint(True)``
 
 Available functions

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -46,26 +46,45 @@ def errprint(inflag=None):
     """
     errprint(inflag=None)
 
-    Sets or returns the error printing flag for special functions.
+    Set or return the error printing flag for special functions.
 
     Parameters
     ----------
     inflag : bool, optional
         Whether warnings concerning evaluation of special functions in
-        scipy.special are shown. If omitted, no change is made to the
-        current setting.
+        ``scipy.special`` are shown. If omitted, no change is made to
+        the current setting.
 
     Returns
     -------
-    old_flag
+    old_flag : bool
         Previous value of the error flag
+
+    Examples
+    --------
+    Turn on error printing.
+
+    >>> import warnings
+    >>> import scipy.special as sc
+    >>> sc.bdtr(-1, 10, 0.3)
+    nan
+    >>> sc.errprint(True)
+    False
+    >>> with warnings.catch_warnings(record=True) as w:
+    ...     sc.bdtr(-1, 10, 0.3)
+    ...
+    nan
+    >>> len(w)
+    1
+    >>> w[0].message
+    SpecialFunctionWarning('scipy.special/bdtr: domain error',)
 
     """
     if inflag is not None:
         scipy.special._ufuncs_cxx._set_errprint(int(bool(inflag)))
-        return sf_error.set_print(int(bool(inflag)))
+        return bool(sf_error.set_print(int(bool(inflag))))
     else:
-        return sf_error.get_print()
+        return bool(sf_error.get_print())
 cdef void loop_D_DD__As_DD_D(char **args, np.npy_intp *dims, np.npy_intp *steps, void *data) nogil:
     cdef np.npy_intp i, n = dims[0]
     cdef void *func = (<void**>data)[0]

--- a/scipy/special/cython_special.pyx
+++ b/scipy/special/cython_special.pyx
@@ -1008,29 +1008,12 @@ ctypedef double complex double_complex
 ctypedef long double complex long_double_complex
 
 def errprint(inflag=None):
-    """
-    errprint(inflag=None)
-
-    Sets or returns the error printing flag for special functions.
-
-    Parameters
-    ----------
-    inflag : bool, optional
-        Whether warnings concerning evaluation of special functions in
-        scipy.special are shown. If omitted, no change is made to the
-        current setting.
-
-    Returns
-    -------
-    old_flag
-        Previous value of the error flag
-
-    """
+    """See the documentation for scipy.special.errprint"""
     if inflag is not None:
         scipy.special._ufuncs_cxx._set_errprint(int(bool(inflag)))
-        return sf_error.set_print(int(bool(inflag)))
+        return bool(sf_error.set_print(int(bool(inflag))))
     else:
-        return sf_error.get_print()
+        return bool(sf_error.get_print())
 
 cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_airy_wrap "airy_wrap"(npy_double, npy_double *, npy_double *, npy_double *, npy_double *)nogil

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -372,7 +372,7 @@ UFUNCS_EXTRA_CODE = """\
 cimport scipy.special._ufuncs_cxx
 """
 
-ERRPRINT_CODE = """\
+UFUNCS_ERRPRINT_CODE = """\
 def errprint(inflag=None):
     \"\"\"
     errprint(inflag=None)
@@ -411,6 +411,16 @@ def errprint(inflag=None):
     SpecialFunctionWarning('scipy.special/bdtr: domain error',)
 
     \"\"\"
+    if inflag is not None:
+        scipy.special._ufuncs_cxx._set_errprint(int(bool(inflag)))
+        return bool(sf_error.set_print(int(bool(inflag))))
+    else:
+        return bool(sf_error.get_print())
+"""
+
+CYTHON_SPECIAL_ERRPRINT_CODE = """\
+def errprint(inflag=None):
+    \"\"\"See the documentation for scipy.special.errprint\"\"\"
     if inflag is not None:
         scipy.special._ufuncs_cxx._set_errprint(int(bool(inflag)))
         return bool(sf_error.set_print(int(bool(inflag))))
@@ -1599,7 +1609,7 @@ def generate_ufuncs(fn_prefix, cxx_fn_prefix, ufuncs):
         f.write("\n")
         f.write(UFUNCS_EXTRA_CODE)
         f.write("\n")
-        f.write(ERRPRINT_CODE)
+        f.write(UFUNCS_ERRPRINT_CODE)
         f.write(toplevel)
         f.write(UFUNCS_EXTRA_CODE_BOTTOM)
 
@@ -1688,7 +1698,7 @@ def generate_fused_funcs(modname, ufunc_fn_prefix, fused_funcs):
         header = header.replace("FUNCLIST", "\n".join(doc))
         f.write(header)
         f.write("\n")
-        f.write(ERRPRINT_CODE)
+        f.write(CYTHON_SPECIAL_ERRPRINT_CODE)
         f.write("\n")
         f.write("\n".join(defs))
         f.write("\n\n")

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -377,26 +377,39 @@ def errprint(inflag=None):
     \"\"\"
     errprint(inflag=None)
 
-    Sets or returns the error printing flag for special functions.
+    Set or return the error printing flag for special functions.
 
     Parameters
     ----------
     inflag : bool, optional
         Whether warnings concerning evaluation of special functions in
-        scipy.special are shown. If omitted, no change is made to the
-        current setting.
+        ``scipy.special`` are shown. If omitted, no change is made to
+        the current setting.
 
     Returns
     -------
-    old_flag
+    old_flag : bool
         Previous value of the error flag
+
+    Examples
+    --------
+    Turn on error printing.
+
+    >>> import scipy.special as sc
+    >>> print(sc.bdtr(-1, 10, 0.3))
+    nan
+    >>> sc.errprint(True)
+    False
+    >>> print(sc.bdtr(-1, 10, 0.3))
+    __main__:1: SpecialFunctionWarning: scipy.special/bdtr: domain error
+    nan
 
     \"\"\"
     if inflag is not None:
         scipy.special._ufuncs_cxx._set_errprint(int(bool(inflag)))
-        return sf_error.set_print(int(bool(inflag)))
+        return bool(sf_error.set_print(int(bool(inflag))))
     else:
-        return sf_error.get_print()
+        return bool(sf_error.get_print())
 """
 
 UFUNCS_EXTRA_CODE_BOTTOM = """\

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -395,14 +395,20 @@ def errprint(inflag=None):
     --------
     Turn on error printing.
 
+    >>> import warnings
     >>> import scipy.special as sc
-    >>> print(sc.bdtr(-1, 10, 0.3))
+    >>> sc.bdtr(-1, 10, 0.3)
     nan
     >>> sc.errprint(True)
     False
-    >>> print(sc.bdtr(-1, 10, 0.3))
-    __main__:1: SpecialFunctionWarning: scipy.special/bdtr: domain error
+    >>> with warnings.catch_warnings(record=True) as w:
+    ...     sc.bdtr(-1, 10, 0.3)
+    ...
     nan
+    >>> len(w)
+    1
+    >>> w[0].message
+    SpecialFunctionWarning('scipy.special/bdtr: domain error',)
 
     \"\"\"
     if inflag is not None:

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -1,9 +1,8 @@
 from __future__ import division, print_function, absolute_import
 
-import warnings
 from itertools import product
 
-from numpy.testing import assert_, assert_allclose
+from numpy.testing import assert_allclose
 from numpy.testing.noseclasses import KnownFailureTest
 
 from scipy import special
@@ -328,13 +327,3 @@ def test_cython_api():
 
     for param in params:
         yield check, param
-
-
-def test_errprint():
-    flag = cython_special.errprint(1)
-    try:
-        with warnings.catch_warnings(record=True) as w:
-            cython_special.loggamma(0)
-            assert_(w[-1].category is special.SpecialFunctionWarning)
-    finally:
-        cython_special.errprint(flag)

--- a/scipy/special/tests/test_errprint.py
+++ b/scipy/special/tests/test_errprint.py
@@ -1,0 +1,27 @@
+from __future__ import division, print_function, absolute_import
+
+import warnings
+
+from numpy.testing import assert_
+
+from scipy import special
+from scipy.special import cython_special
+
+
+def _check_errprint(mod):
+    flag = mod.errprint(True)
+    try:
+        assert_(isinstance(flag, bool))
+        with warnings.catch_warnings(record=True) as w:
+            mod.loggamma(0)
+            assert_(w[-1].category is special.SpecialFunctionWarning)
+    finally:
+        mod.errprint(flag)
+
+
+def test_special_errprint():
+    _check_errprint(special)
+
+
+def test_cython_special_errprint():
+    _check_errprint(cython_special)


### PR DESCRIPTION
The documentation says the input flag is a boolean (though it also
accepts an int), but the output flag is an int. This makes the output
flag also a boolean.

Also tweaks the `errprint` documentation.
