### PR TITLE
fix parameter name doc for discrete distributions

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -66,11 +66,11 @@ _doc_logpdf = """\
     Log of the probability density function.
 """
 _doc_pmf = """\
-``pmf(x, %(shapes)s, loc=0, scale=1)``
+``pmf(k, %(shapes)s, loc=0, scale=1)``
     Probability mass function.
 """
 _doc_logpmf = """\
-``logpmf(x, %(shapes)s, loc=0, scale=1)``
+``logpmf(k, %(shapes)s, loc=0, scale=1)``
     Log of the probability mass function.
 """
 _doc_cdf = """\
@@ -265,6 +265,11 @@ _doc_disc_methods = ['rvs', 'pmf', 'logpmf', 'cdf', 'logcdf', 'sf', 'logsf',
                      'mean', 'var', 'std', 'interval']
 for obj in _doc_disc_methods:
     docdict_discrete[obj] = docdict_discrete[obj].replace(', scale=1', '')
+
+_doc_disc_methods_err_varname = ['cdf', 'logcdf', 'sf', 'logsf']
+for obj in _doc_disc_methods_err_varname :
+    docdict_discrete[obj] = docdict_discrete[obj].replace('(x, ', '(k, ')
+
 docdict_discrete.pop('pdf')
 docdict_discrete.pop('logpdf')
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -267,7 +267,7 @@ for obj in _doc_disc_methods:
     docdict_discrete[obj] = docdict_discrete[obj].replace(', scale=1', '')
 
 _doc_disc_methods_err_varname = ['cdf', 'logcdf', 'sf', 'logsf']
-for obj in _doc_disc_methods_err_varname :
+for obj in _doc_disc_methods_err_varname:
     docdict_discrete[obj] = docdict_discrete[obj].replace('(x, ', '(k, ')
 
 docdict_discrete.pop('pdf')


### PR DESCRIPTION
See also discussions in this PR: https://github.com/scipy/scipy/issues/6628

As recommended by @ev-br  the actual signature of the methods have not be touched to guarantee backward compatibility, I’m just aligning the documentation to the reality.

I tried to test the change as documented [here](https://penandpants.com/2014/08/20/if-you-want-to-build-the-numpy-and-scipy-docs/) thought that procedure failed on my machine, I'm hoping I can do that after the Travis build?
