### PR TITLE
MAINT: stats: change some instances of `special` to `sc`

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -487,7 +487,7 @@ class beta_gen(rv_continuous):
             # s1 and s2 are used in the extra arguments passed to _beta_mle_ab
             # by optimize.fsolve.
             s1 = np.log(data).sum()
-            s2 = special.log1p(-data).sum()
+            s2 = sc.log1p(-data).sum()
 
             # Use the "method of moments" to estimate the initial
             # guess for a and b.
@@ -733,7 +733,7 @@ class burr12_gen(rv_continuous):
         # The following is an implementation of
         #   ((1 - q)**(-1.0/d) - 1)**(1.0/c)
         # that does a better job handling small values of q.
-        return special.expm1(-1/d * special.log1p(-q))**(1/c)
+        return sc.expm1(-1/d * sc.log1p(-q))**(1/c)
 
     def _munp(self, n, c, d):
         nc = 1. * n / c


### PR DESCRIPTION
In gh-6294 references to `special` were shortened to `sc`, but before
it was merged some further references to `special` were added. This
changes the new references to also be `sc`.
