### PR TITLE
MAINT: change type declaration in cluster.linkage, prevent overflow

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -127,6 +127,7 @@ Josef Perktold <josef.pktd@gmail.com> josef <josef@localhost>
 Joseph Fox-Rabinovitz <joseph.r.fox-rabinovitz@nasa.gov> Mad Physicist <madphysicist@users.noreply.github.com>
 Joseph Fox-Rabinovitz <joseph.r.fox-rabinovitz@nasa.gov> Joseph Fox-Rabinovitz <madphysicist@users.noreply.github.com>
 Josh Lawrence <josh.k.lawrence@gmail.com> wa03 <josh.k.lawrence@gmail.com>
+Josh Lefler <jlefty94@gmail.com> jlefty <jlefty94@gmail.com>
 Josh Wilson <person142@users.noreply.github.com> Josh <person142@users.noreply.github.com>
 Juha Remes <jremes@outlook.com> newman101 <jremes@outlook.com>
 Kat Huang <kat@aya.yale.edu> kat <kat@aya.yale.edu>

--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -672,7 +672,7 @@ def leaders(double[:, :] Z, int[:] T, int[:] L, int[:] M, int nc, int n):
     return result  # -1 means success here
 
 
-def linkage(double[:] dists, int n, int method):
+def linkage(double[:] dists, np.npy_int64 n, int method):
     """
     Perform hierarchy clustering.
 

--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -19,7 +19,7 @@ cdef linkage_distance_update *linkage_methods = [
     _single, _complete, _average, _centroid, _median, _ward, _weighted]
 
 
-cdef inline int condensed_index(int n, int i, int j):
+cdef inline np.int64_t condensed_index(np.int64_t n, np.int64_t i, np.int64_t j):
     """
     Calculate the condensed index of element (i, j) in an n x n condensed
     matrix.
@@ -694,7 +694,8 @@ def linkage(double[:] dists, np.npy_int64 n, int method):
     Z_arr = np.empty((n - 1, 4))
     cdef double[:, :] Z = Z_arr
 
-    cdef int i, j, k, x, y, i_start, nx, ny, ni, id_x, id_y, id_i
+    cdef int i, j, k, x, y, nx, ny, ni, id_x, id_y, id_i
+    cdef np.int64_t i_start 
     cdef double current_min
     # inter-cluster dists
     cdef double[:] D = np.ndarray(n * (n - 1) / 2, dtype=np.double)

--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -19,7 +19,8 @@ cdef linkage_distance_update *linkage_methods = [
     _single, _complete, _average, _centroid, _median, _ward, _weighted]
 
 
-cdef inline np.int64_t condensed_index(np.int64_t n, np.int64_t i, np.int64_t j):
+cdef inline np.npy_int64 condensed_index(np.npy_int64 n, np.npy_int64 i,
+                                         np.npy_int64 j):
     """
     Calculate the condensed index of element (i, j) in an n x n condensed
     matrix.
@@ -695,7 +696,7 @@ def linkage(double[:] dists, np.npy_int64 n, int method):
     cdef double[:, :] Z = Z_arr
 
     cdef int i, j, k, x, y, nx, ny, ni, id_x, id_y, id_i
-    cdef np.int64_t i_start 
+    cdef np.npy_int64 i_start
     cdef double current_min
     # inter-cluster dists
     cdef double[:] D = np.ndarray(n * (n - 1) / 2, dtype=np.double)


### PR DESCRIPTION
Closes gh-6107, closes gh-2089.
