### PR TITLE
BUG: fix issue with duplicate values used in cluster.vq.kmeans

### DIFF
--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -1,10 +1,7 @@
 #! /usr/bin/env python
 
-# David Cournapeau
-# Last Change: Wed Nov 05 07:00 PM 2008 J
 from __future__ import division, print_function, absolute_import
 
-import os.path
 import warnings
 import sys
 
@@ -208,13 +205,14 @@ class TestKMean(TestCase):
         kmeans(data, 2)
 
     def test_kmeans_simple(self):
+        np.random.seed(54321)
         initc = np.concatenate(([[X[0]], [X[1]], [X[2]]]))
         for tp in np.array, np.matrix:
             code1 = kmeans(tp(X), tp(initc), iter=1)[0]
             assert_array_almost_equal(code1, CODET2)
 
     def test_kmeans_lost_cluster(self):
-        # This will cause kmean to have a cluster with no points.
+        # This will cause kmeans to have a cluster with no points.
         data = TESTDATA_2D
         initk = np.array([[-1.8127404, -0.67128041],
                          [2.04621601, 0.07401111],
@@ -228,6 +226,7 @@ class TestKMean(TestCase):
         assert_raises(ClusterError, kmeans2, data, initk, missing='raise')
 
     def test_kmeans2_simple(self):
+        np.random.seed(12345678)
         initc = np.concatenate(([[X[0]], [X[1]], [X[2]]]))
         for tp in np.array, np.matrix:
             code1 = kmeans2(tp(X), tp(initc), iter=1)[0]
@@ -298,6 +297,18 @@ class TestKMean(TestCase):
         res = kmeans(x, 1, thresh=1e16)
         assert_allclose(res[0], np.array([4.]))
         assert_allclose(res[1], 2.3999999999999999)
+
+    def test_kmeans_no_duplicates(self):
+        # Regression test for gh-4044
+        np.random.seed(23495)
+        features = np.linspace(1, 2, num=20).reshape(10, 2)
+        # randint(0, 10, 3) will give a duplicate with this seed ([7, 7, 5])
+        codebook, distortion = kmeans(features, k_or_guess=3)
+        expected = np.array([[1.15789474, 1.21052632],
+                             [1.52631579, 1.57894737],
+                             [1.84210526, 1.89473684]])
+        assert_allclose(codebook, expected)
+        assert_allclose(distortion, 0.11909166841036592)
 
 
 if __name__ == "__main__":

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -556,7 +556,14 @@ def kmeans(obs, k_or_guess, iter=20, thresh=1e-5, check_finite=True):
             raise ValueError("Asked for 0 cluster ? ")
         for i in range(iter):
             # the initial code book is randomly selected from observations
-            guess = np.take(obs, np.random.randint(0, No, k), 0)
+            k_random_indices = np.random.randint(0, No, k)
+            if np.any(np.unique(k_random_indices, return_counts=True)[1] > 1):
+                # randint can give duplicates, which is incorrect.  Only fix
+                # the issue if it occurs, to not change results for users who
+                #  use a random seed and get no duplicates.
+                k_random_indices = np.random.permutation(No)[:k]
+
+            guess = np.take(obs, k_random_indices, 0)
             book, dist = _kmeans(obs, guess, thresh=thresh)
             if dist < best_dist:
                 best_book = book

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -83,6 +83,7 @@ import warnings
 
 import numpy as np
 from scipy._lib._util import _asarray_validated
+from scipy._lib import _numpy_compat
 
 from . import _vq
 
@@ -557,7 +558,8 @@ def kmeans(obs, k_or_guess, iter=20, thresh=1e-5, check_finite=True):
         for i in range(iter):
             # the initial code book is randomly selected from observations
             k_random_indices = np.random.randint(0, No, k)
-            if np.any(np.unique(k_random_indices, return_counts=True)[1] > 1):
+            if np.any(_numpy_compat.unique(k_random_indices,
+                                           return_counts=True)[1] > 1):
                 # randint can give duplicates, which is incorrect.  Only fix
                 # the issue if it occurs, to not change results for users who
                 #  use a random seed and get no duplicates.


### PR DESCRIPTION
Closes gh-4044.

Also add random seeds to tests that check return values, because
`kmeans` and `kmeans2` use `np.random` functions.
