### PR TITLE
MAINT: special: rename `*_roots` functions

### DIFF
--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -57,6 +57,16 @@ compute the coeficients of a second-order IIR peak (resonant) filter.
 The functions `scipy.sparse.save_npz` and `scipy.sparse.load_npz` were added,
 providing simple serialization for some sparse formats.
 
+`scipy.special` improvements
+----------------------------
+
+The names of orthogonal polynomial root functions have been changed to
+be consistent with other functions relating to orthogonal
+polynomials. For example, `scipy.special.j_roots` has been renamed
+`scipy.special.roots_jacobi` for consistency with the related
+functions `scipy.special.jacobi` and `scipy.special.eval_jacobi`. To
+preserve back-compatibility the old names have been left as aliases.
+
 
 Deprecated features
 ===================

--- a/scipy/integrate/quadrature.py
+++ b/scipy/integrate/quadrature.py
@@ -7,7 +7,7 @@ import warnings
 # trapz is a public function for scipy.integrate,
 # even though it's actually a numpy function.
 from numpy import trapz
-from scipy.special.orthogonal import p_roots
+from scipy.special import roots_legendre
 from scipy.special import gammaln
 from scipy._lib.six import xrange
 
@@ -19,16 +19,17 @@ class AccuracyWarning(Warning):
     pass
 
 
-def _cached_p_roots(n):
+def _cached_roots_legendre(n):
     """
-    Cache p_roots results to speed up calls of the fixed_quad function.
+    Cache roots_legendre results to speed up calls of the fixed_quad
+    function.
     """
-    if n in _cached_p_roots.cache:
-        return _cached_p_roots.cache[n]
+    if n in _cached_roots_legendre.cache:
+        return _cached_roots_legendre.cache[n]
 
-    _cached_p_roots.cache[n] = p_roots(n)
-    return _cached_p_roots.cache[n]
-_cached_p_roots.cache = dict()
+    _cached_roots_legendre.cache[n] = roots_legendre(n)
+    return _cached_roots_legendre.cache[n]
+_cached_roots_legendre.cache = dict()
 
 
 def fixed_quad(func, a, b, args=(), n=5):
@@ -73,7 +74,7 @@ def fixed_quad(func, a, b, args=(), n=5):
     odeint : ODE integrator
 
     """
-    x, w = _cached_p_roots(n)
+    x, w = _cached_roots_legendre(n)
     x = np.real(x)
     if np.isinf(a) or np.isinf(b):
         raise ValueError("Gaussian quadrature is only available for "

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -377,6 +377,28 @@ The following functions evaluate values of orthogonal polynomials:
    eval_sh_chebyu   -- Evaluate shifted Chebyshev polynomial of the second kind at a point.
    eval_sh_jacobi   -- Evaluate shifted Jacobi polynomial at a point.
 
+The following functions compute roots and quadrature weights for
+orthogonal polynomials:
+
+.. autosummary::
+   :toctree: generated/
+
+   roots_legendre    -- Gauss-Legendre quadrature.
+   roots_chebyt      -- Gauss-Chebyshev (first kind) quadrature.
+   roots_chebyu      -- Gauss-Chebyshev (second kind) quadrature.
+   roots_chebyc      -- Gauss-Chebyshev (first kind) quadrature.
+   roots_chebys      -- Gauss-Chebyshev (second kind) quadrature.
+   roots_jacobi      -- Gauss-Jacobi quadrature.
+   roots_laguerre    -- Gauss-Laguerre quadrature.
+   roots_genlaguerre -- Gauss-generalized Laguerre quadrature.
+   roots_hermite     -- Gauss-Hermite (physicst's) quadrature.
+   roots_hermitenorm -- Gauss-Hermite (statistician's) quadrature.
+   roots_gegenbauer  -- Gauss-Gegenbauer quadrature.
+   roots_sh_legendre -- Gauss-Legendre (shifted) quadrature.
+   roots_sh_chebyt   -- Gauss-Chebyshev (first kind, shifted) quadrature.
+   roots_sh_chebyu   -- Gauss-Chebyshev (second kind, shifted) quadrature.
+   roots_sh_jacobi   -- Gauss-Jacobi (shifted) quadrature.
+
 The functions below, in turn, return the polynomial coefficients in
 :class:`~.orthopoly1d` objects, which function similarly as :ref:`numpy.poly1d`.
 The :class:`~.orthopoly1d` class also has an attribute ``weights`` which returns
@@ -410,27 +432,6 @@ arithmetic, and lose information of the original orthogonal polynomial.
    Computing values of high-order polynomials (around ``order > 20``) using
    polynomial coefficients is numerically unstable. To evaluate polynomial
    values, the ``eval_*`` functions should be used instead.
-
-Roots and weights for orthogonal polynomials
-
-.. autosummary::
-   :toctree: generated/
-
-   c_roots  -- Gauss-Chebyshev (first kind) quadrature.
-   cg_roots -- Gauss-Gegenbauer quadrature.
-   h_roots  -- Gauss-Hermite (physicst's) quadrature.
-   he_roots -- Gauss-Hermite (statistician's) quadrature.
-   j_roots  -- Gauss-Jacobi quadrature.
-   js_roots -- Gauss-Jacobi (shifted) quadrature.
-   l_roots  -- Gauss-Laguerre quadrature.
-   la_roots -- Gauss-generalized Laguerre quadrature.
-   p_roots  -- Gauss-Legendre quadrature.
-   ps_roots -- Gauss-Legendre (shifted) quadrature.
-   s_roots  -- Gauss-Chebyshev (second kind) quadrature.
-   t_roots  -- Gauss-Chebyshev (first kind) quadrature.
-   ts_roots -- Gauss-Chebyshev (first kind, shifted) quadrature.
-   u_roots  -- Gauss-Chebyshev (second kind) quadrature.
-   us_roots -- Gauss-Chebyshev (second kind, shifted) quadrature.
 
 
 Hypergeometric Functions

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -4686,8 +4686,8 @@ cdef char *ufunc_eval_chebyc_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "c_roots : roots and quadrature weights of Chebyshev polynomials of\n"
-    "          the first kind on [-2, 2]\n"
+    "roots_chebyc : roots and quadrature weights of Chebyshev\n"
+    "               polynomials of the first kind on [-2, 2]\n"
     "chebyc : Chebyshev polynomial object\n"
     "numpy.polynomial.chebyshev.Chebyshev : Chebyshev series\n"
     "eval_chebyt : evaluate Chebycshev polynomials of the first kind")
@@ -4761,8 +4761,8 @@ cdef char *ufunc_eval_chebys_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "s_roots : roots and quadrature weights of Chebyshev polynomials of\n"
-    "          the second kind on [-2, 2]\n"
+    "roots_chebys : roots and quadrature weights of Chebyshev\n"
+    "               polynomials of the second kind on [-2, 2]\n"
     "chebys : Chebyshev polynomial object\n"
     "eval_chebyu : evaluate Chebyshev polynomials of the second kind")
 ufunc_eval_chebys_loops[0] = <np.PyUFuncGenericFunction>loop_d_ld__As_ld_d
@@ -4837,8 +4837,8 @@ cdef char *ufunc_eval_chebyt_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "t_roots : roots and quadrature weights of Chebyshev polynomials of\n"
-    "          the first kind\n"
+    "roots_chebyt : roots and quadrature weights of Chebyshev\n"
+    "               polynomials of the first kind\n"
     "chebyu : Chebychev polynomial object\n"
     "eval_chebyu : evaluate Chebyshev polynomials of the second kind\n"
     "hyp2f1 : Gauss hypergeometric function\n"
@@ -4920,8 +4920,8 @@ cdef char *ufunc_eval_chebyu_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "u_roots : roots and quadrature weights of Chebyshev polynomials of\n"
-    "          the second kind\n"
+    "roots_chebyu : roots and quadrature weights of Chebyshev\n"
+    "               polynomials of the second kind\n"
     "chebyu : Chebyshev polynomial object\n"
     "eval_chebyt : evaluate Chebyshev polynomials of the first kind\n"
     "hyp2f1 : Gauss hypergeometric function")
@@ -5000,7 +5000,8 @@ cdef char *ufunc_eval_gegenbauer_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "cg_roots : roots and quadrature weights of Gegenbauer polynomials\n"
+    "roots_gegenbauer : roots and quadrature weights of Gegenbauer\n"
+    "                   polynomials\n"
     "gegenbauer : Gegenbauer polynomial object\n"
     "hyp2f1 : Gauss hypergeometric function")
 ufunc_eval_gegenbauer_loops[0] = <np.PyUFuncGenericFunction>loop_d_ldd__As_ldd_d
@@ -5085,8 +5086,8 @@ cdef char *ufunc_eval_genlaguerre_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "la_roots : roots and quadrature weights of generalized Laguerre\n"
-    "           polynomials\n"
+    "roots_genlaguerre : roots and quadrature weights of generalized\n"
+    "                    Laguerre polynomials\n"
     "genlaguerre : generalized Laguerre polynomial object\n"
     "hyp1f1 : confluent hypergeometric function\n"
     "eval_laguerre : evaluate Laguerre polynomials")
@@ -5163,8 +5164,8 @@ cdef char *ufunc_eval_hermite_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "h_roots : roots and quadrature weights of physicist's Hermite\n"
-    "          polynomials\n"
+    "roots_hermite : roots and quadrature weights of physicist's\n"
+    "                Hermite polynomials\n"
     "hermite : physicist's Hermite polynomial object\n"
     "numpy.polynomial.hermite.Hermite : Physicist's Hermite series\n"
     "eval_hermitenorm : evaluate Probabilist's Hermite polynomials")
@@ -5209,8 +5210,8 @@ cdef char *ufunc_eval_hermitenorm_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "he_roots : roots and quadrature weights of probabilist's\n"
-    "           Hermite polynomials\n"
+    "roots_hermitenorm : roots and quadrature weights of probabilist's\n"
+    "                    Hermite polynomials\n"
     "hermitenorm : probabilist's Hermite polynomial object\n"
     "numpy.polynomial.hermite_e.HermiteE : Probabilist's Hermite series\n"
     "eval_hermite : evaluate physicist's Hermite polynomials")
@@ -5264,7 +5265,7 @@ cdef char *ufunc_eval_jacobi_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "j_roots : roots and quadrature weights of Jacobi polynomials\n"
+    "roots_jacobi : roots and quadrature weights of Jacobi polynomials\n"
     "jacobi : Jacobi polynomial object\n"
     "hyp2f1 : Gauss hypergeometric function")
 ufunc_eval_jacobi_loops[0] = <np.PyUFuncGenericFunction>loop_d_lddd__As_lddd_d
@@ -5349,7 +5350,8 @@ cdef char *ufunc_eval_laguerre_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "l_roots : roots and quadrature weights of Laguerre polynomials\n"
+    "roots_laguerre : roots and quadrature weights of Laguerre\n"
+    "                 polynomials\n"
     "laguerre : Laguerre polynomial object\n"
     "numpy.polynomial.laguerre.Laguerre : Laguerre series\n"
     "eval_genlaguerre : evaluate generalized Laguerre polynomials")
@@ -5425,7 +5427,8 @@ cdef char *ufunc_eval_legendre_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "p_roots : roots and quadrature weights of Legendre polynomials\n"
+    "roots_legendre : roots and quadrature weights of Legendre\n"
+    "                 polynomials\n"
     "legendre : Legendre polynomial object\n"
     "hyp2f1 : Gauss hypergeometric function\n"
     "numpy.polynomial.legendre.Legendre : Legendre series")
@@ -5499,8 +5502,8 @@ cdef char *ufunc_eval_sh_chebyt_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "ts_roots : roots and quadrature weights of shifted Chebychev\n"
-    "           polynomials of the first kind\n"
+    "roots_sh_chebyt : roots and quadrature weights of shifted\n"
+    "                  Chebyshev polynomials of the first kind\n"
     "sh_chebyt : shifted Chebyshev polynomial object\n"
     "eval_chebyt : evalaute Chebyshev polynomials of the first kind\n"
     "numpy.polynomial.chebyshev.Chebyshev : Chebyshev series")
@@ -5574,8 +5577,8 @@ cdef char *ufunc_eval_sh_chebyu_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "us_roots : roots and quadrature weights of shifted Chebychev\n"
-    "           polynomials of the second kind\n"
+    "roots_sh_chebyu : roots and quadrature weights of shifted\n"
+    "                  Chebychev polynomials of the second kind\n"
     "sh_chebyu : shifted Chebyshev polynomial object\n"
     "eval_chebyu : evaluate Chebyshev polynomials of the second kind")
 ufunc_eval_sh_chebyu_loops[0] = <np.PyUFuncGenericFunction>loop_d_ld__As_ld_d
@@ -5650,8 +5653,8 @@ cdef char *ufunc_eval_sh_jacobi_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "js_roots : roots and quadrature weights of shifted Jacobi\n"
-    "           polynomials\n"
+    "roots_sh_jacobi : roots and quadrature weights of shifted Jacobi\n"
+    "                  polynomials\n"
     "sh_jacobi : shifted Jacobi polynomial object\n"
     "eval_jacobi : evaluate Jacobi polynomials")
 ufunc_eval_sh_jacobi_loops[0] = <np.PyUFuncGenericFunction>loop_d_lddd__As_lddd_d
@@ -5733,8 +5736,8 @@ cdef char *ufunc_eval_sh_legendre_doc = (
     "\n"
     "See Also\n"
     "--------\n"
-    "ps_roots : roots and quadrature weights of shifted Legendre\n"
-    "           polynomials\n"
+    "roots_sh_legendre : roots and quadrature weights of shifted\n"
+    "                    Legendre polynomials\n"
     "sh_legendre : shifted Legendre polynomial object\n"
     "eval_legendre : evaluate Legendre polynomials\n"
     "numpy.polynomial.legendre.Legendre : Legendre series")

--- a/scipy/special/add_newdocs.py
+++ b/scipy/special/add_newdocs.py
@@ -1429,7 +1429,7 @@ add_newdoc("scipy.special", "eval_jacobi",
 
     See Also
     --------
-    j_roots : roots and quadrature weights of Jacobi polynomials
+    roots_jacobi : roots and quadrature weights of Jacobi polynomials
     jacobi : Jacobi polynomial object
     hyp2f1 : Gauss hypergeometric function
     """)
@@ -1466,8 +1466,8 @@ add_newdoc("scipy.special", "eval_sh_jacobi",
 
     See Also
     --------
-    js_roots : roots and quadrature weights of shifted Jacobi
-               polynomials
+    roots_sh_jacobi : roots and quadrature weights of shifted Jacobi
+                      polynomials
     sh_jacobi : shifted Jacobi polynomial object
     eval_jacobi : evaluate Jacobi polynomials
     """)
@@ -1507,7 +1507,8 @@ add_newdoc("scipy.special", "eval_gegenbauer",
 
     See Also
     --------
-    cg_roots : roots and quadrature weights of Gegenbauer polynomials
+    roots_gegenbauer : roots and quadrature weights of Gegenbauer
+                       polynomials
     gegenbauer : Gegenbauer polynomial object
     hyp2f1 : Gauss hypergeometric function
     """)
@@ -1544,8 +1545,8 @@ add_newdoc("scipy.special", "eval_chebyt",
 
     See Also
     --------
-    t_roots : roots and quadrature weights of Chebyshev polynomials of
-              the first kind
+    roots_chebyt : roots and quadrature weights of Chebyshev
+                   polynomials of the first kind
     chebyu : Chebychev polynomial object
     eval_chebyu : evaluate Chebyshev polynomials of the second kind
     hyp2f1 : Gauss hypergeometric function
@@ -1589,8 +1590,8 @@ add_newdoc("scipy.special", "eval_chebyu",
 
     See Also
     --------
-    u_roots : roots and quadrature weights of Chebyshev polynomials of
-              the second kind
+    roots_chebyu : roots and quadrature weights of Chebyshev
+                   polynomials of the second kind
     chebyu : Chebyshev polynomial object
     eval_chebyt : evaluate Chebyshev polynomials of the first kind
     hyp2f1 : Gauss hypergeometric function
@@ -1626,8 +1627,8 @@ add_newdoc("scipy.special", "eval_chebys",
 
     See Also
     --------
-    s_roots : roots and quadrature weights of Chebyshev polynomials of
-              the second kind on [-2, 2]
+    roots_chebys : roots and quadrature weights of Chebyshev
+                   polynomials of the second kind on [-2, 2]
     chebys : Chebyshev polynomial object
     eval_chebyu : evaluate Chebyshev polynomials of the second kind
     """)
@@ -1662,8 +1663,8 @@ add_newdoc("scipy.special", "eval_chebyc",
 
     See Also
     --------
-    c_roots : roots and quadrature weights of Chebyshev polynomials of
-              the first kind on [-2, 2]
+    roots_chebyc : roots and quadrature weights of Chebyshev
+                   polynomials of the first kind on [-2, 2]
     chebyc : Chebyshev polynomial object
     numpy.polynomial.chebyshev.Chebyshev : Chebyshev series
     eval_chebyt : evaluate Chebycshev polynomials of the first kind
@@ -1699,8 +1700,8 @@ add_newdoc("scipy.special", "eval_sh_chebyt",
 
     See Also
     --------
-    ts_roots : roots and quadrature weights of shifted Chebychev
-               polynomials of the first kind
+    roots_sh_chebyt : roots and quadrature weights of shifted
+                      Chebyshev polynomials of the first kind
     sh_chebyt : shifted Chebyshev polynomial object
     eval_chebyt : evalaute Chebyshev polynomials of the first kind
     numpy.polynomial.chebyshev.Chebyshev : Chebyshev series
@@ -1736,8 +1737,8 @@ add_newdoc("scipy.special", "eval_sh_chebyu",
 
     See Also
     --------
-    us_roots : roots and quadrature weights of shifted Chebychev
-               polynomials of the second kind
+    roots_sh_chebyu : roots and quadrature weights of shifted
+                      Chebychev polynomials of the second kind
     sh_chebyu : shifted Chebyshev polynomial object
     eval_chebyu : evaluate Chebyshev polynomials of the second kind
     """)
@@ -1774,7 +1775,8 @@ add_newdoc("scipy.special", "eval_legendre",
 
     See Also
     --------
-    p_roots : roots and quadrature weights of Legendre polynomials
+    roots_legendre : roots and quadrature weights of Legendre
+                     polynomials
     legendre : Legendre polynomial object
     hyp2f1 : Gauss hypergeometric function
     numpy.polynomial.legendre.Legendre : Legendre series
@@ -1809,8 +1811,8 @@ add_newdoc("scipy.special", "eval_sh_legendre",
 
     See Also
     --------
-    ps_roots : roots and quadrature weights of shifted Legendre
-               polynomials
+    roots_sh_legendre : roots and quadrature weights of shifted
+                        Legendre polynomials
     sh_legendre : shifted Legendre polynomial object
     eval_legendre : evaluate Legendre polynomials
     numpy.polynomial.legendre.Legendre : Legendre series
@@ -1853,8 +1855,8 @@ add_newdoc("scipy.special", "eval_genlaguerre",
 
     See Also
     --------
-    la_roots : roots and quadrature weights of generalized Laguerre
-               polynomials
+    roots_genlaguerre : roots and quadrature weights of generalized
+                        Laguerre polynomials
     genlaguerre : generalized Laguerre polynomial object
     hyp1f1 : confluent hypergeometric function
     eval_laguerre : evaluate Laguerre polynomials
@@ -1892,7 +1894,8 @@ add_newdoc("scipy.special", "eval_laguerre",
 
      See Also
      --------
-     l_roots : roots and quadrature weights of Laguerre polynomials
+     roots_laguerre : roots and quadrature weights of Laguerre
+                      polynomials
      laguerre : Laguerre polynomial object
      numpy.polynomial.laguerre.Laguerre : Laguerre series
      eval_genlaguerre : evaluate generalized Laguerre polynomials
@@ -1926,8 +1929,8 @@ add_newdoc("scipy.special", "eval_hermite",
 
     See Also
     --------
-    h_roots : roots and quadrature weights of physicist's Hermite
-              polynomials
+    roots_hermite : roots and quadrature weights of physicist's
+                    Hermite polynomials
     hermite : physicist's Hermite polynomial object
     numpy.polynomial.hermite.Hermite : Physicist's Hermite series
     eval_hermitenorm : evaluate Probabilist's Hermite polynomials
@@ -1962,8 +1965,8 @@ add_newdoc("scipy.special", "eval_hermitenorm",
 
     See Also
     --------
-    he_roots : roots and quadrature weights of probabilist's
-               Hermite polynomials
+    roots_hermitenorm : roots and quadrature weights of probabilist's
+                        Hermite polynomials
     hermitenorm : probabilist's Hermite polynomial object
     numpy.polynomial.hermite_e.HermiteE : Probabilist's Hermite series
     eval_hermite : evaluate physicist's Hermite polynomials

--- a/scipy/special/orthogonal.py
+++ b/scipy/special/orthogonal.py
@@ -46,26 +46,8 @@ assume:
 For the mathematical background, see [golub.welsch-1969-mathcomp]_ and
 [abramowitz.stegun-1965]_.
 
-Functions::
-
-  gen_roots_and_weights  -- Generic roots and weights.
-  j_roots                -- Jacobi
-  js_roots               -- Shifted Jacobi
-  la_roots               -- Generalized Laguerre
-  h_roots                -- Hermite
-  he_roots               -- Hermite (unit-variance)
-  cg_roots               -- Ultraspherical (Gegenbauer)
-  t_roots                -- Chebyshev of the first kind
-  u_roots                -- Chebyshev of the second kind
-  c_roots                -- Chebyshev of the first kind ([-2,2] interval)
-  s_roots                -- Chebyshev of the second kind ([-2,2] interval)
-  ts_roots               -- Shifted Chebyshev of the first kind.
-  us_roots               -- Shifted Chebyshev of the second kind.
-  p_roots                -- Legendre
-  ps_roots               -- Shifted Legendre
-  l_roots                -- Laguerre
-
-
+References
+----------
 .. [golub.welsch-1969-mathcomp]
    Golub, Gene H, and John H Welsch. 1969. Calculation of Gauss
    Quadrature Rules. *Mathematics of Computation* 23, 221-230+s1--s10.
@@ -106,21 +88,36 @@ from . import _ufuncs as cephes
 _gam = cephes.gamma
 from . import specfun
 
-__all__ = ['legendre', 'chebyt', 'chebyu', 'chebyc', 'chebys',
-           'jacobi', 'laguerre', 'genlaguerre', 'hermite', 'hermitenorm',
-           'gegenbauer', 'sh_legendre', 'sh_chebyt', 'sh_chebyu', 'sh_jacobi',
-           'p_roots', 'ps_roots', 'j_roots', 'js_roots', 'l_roots', 'la_roots',
-           'he_roots', 'ts_roots', 'us_roots', 's_roots',
-           't_roots', 'u_roots', 'c_roots', 'cg_roots', 'h_roots',
-           'eval_legendre', 'eval_chebyt', 'eval_chebyu', 'eval_chebyc',
-           'eval_chebys', 'eval_jacobi', 'eval_laguerre', 'eval_genlaguerre',
-           'eval_hermite', 'eval_hermitenorm', 'eval_gegenbauer',
-           'eval_sh_legendre', 'eval_sh_chebyt', 'eval_sh_chebyu',
-           'eval_sh_jacobi', 'poch', 'binom']
+_polyfuns = ['legendre', 'chebyt', 'chebyu', 'chebyc', 'chebys',
+             'jacobi', 'laguerre', 'genlaguerre', 'hermite',
+             'hermitenorm', 'gegenbauer', 'sh_legendre', 'sh_chebyt',
+             'sh_chebyu', 'sh_jacobi']
 
+# Correspondence between new and old names of root functions
+_rootfuns_map = {'roots_legendre': 'p_roots',
+               'roots_chebyt': 't_roots',
+               'roots_chebyu': 'u_roots',
+               'roots_chebyc': 'c_roots',
+               'roots_chebys': 's_roots',
+               'roots_jacobi': 'j_roots',
+               'roots_laguerre': 'l_roots',
+               'roots_genlaguerre': 'la_roots',
+               'roots_hermite': 'h_roots',
+               'roots_hermitenorm': 'he_roots',
+               'roots_gegenbauer': 'cg_roots',
+               'roots_sh_legendre': 'ps_roots',
+               'roots_sh_chebyt': 'ts_roots',
+               'roots_sh_chebyu': 'us_roots',
+               'roots_sh_jacobi': 'js_roots'}
 
-# For backward compatibility
-poch = cephes.poch
+_evalfuns = ['eval_legendre', 'eval_chebyt', 'eval_chebyu',
+             'eval_chebyc', 'eval_chebys', 'eval_jacobi',
+             'eval_laguerre', 'eval_genlaguerre', 'eval_hermite',
+             'eval_hermitenorm', 'eval_gegenbauer',
+             'eval_sh_legendre', 'eval_sh_chebyt', 'eval_sh_chebyu',
+             'eval_sh_jacobi']
+
+__all__ = _polyfuns + list(_rootfuns_map.keys()) + _evalfuns + ['poch', 'binom']
 
 
 class orthopoly1d(np.poly1d):
@@ -208,7 +205,7 @@ def _gen_roots_and_weights(n, mu0, an_func, bn_func, f, df, symmetrize, mu):
 # Jacobi Polynomials 1               P^(alpha,beta)_n(x)
 
 
-def j_roots(n, alpha, beta, mu=False):
+def roots_jacobi(n, alpha, beta, mu=False):
     r"""Gauss-Jacobi quadrature.
 
     Computes the sample points and weights for Gauss-Jacobi quadrature. The
@@ -250,9 +247,9 @@ def j_roots(n, alpha, beta, mu=False):
         raise ValueError("alpha and beta must be greater than -1.")
 
     if alpha == 0.0 and beta == 0.0:
-        return p_roots(m, mu)
+        return roots_legendre(m, mu)
     if alpha == beta:
-        return cg_roots(m, alpha+0.5, mu)
+        return roots_gegenbauer(m, alpha+0.5, mu)
 
     mu0 = 2.0**(alpha+beta+1)*cephes.beta(alpha+1, beta+1)
     a = alpha
@@ -317,7 +314,7 @@ def jacobi(n, alpha, beta, monic=False):
     if n == 0:
         return orthopoly1d([], [], 1.0, 1.0, wfunc, (-1, 1), monic,
                            eval_func=np.ones_like)
-    x, w, mu = j_roots(n, alpha, beta, mu=True)
+    x, w, mu = roots_jacobi(n, alpha, beta, mu=True)
     ab1 = alpha + beta + 1.0
     hn = 2**ab1 / (2 * n + ab1) * _gam(n + alpha + 1)
     hn *= _gam(n + beta + 1.0) / _gam(n + 1) / _gam(n + ab1)
@@ -330,7 +327,7 @@ def jacobi(n, alpha, beta, monic=False):
 # Jacobi Polynomials shifted         G_n(p,q,x)
 
 
-def js_roots(n, p1, q1, mu=False):
+def roots_sh_jacobi(n, p1, q1, mu=False):
     """Gauss-Jacobi (shifted) quadrature.
 
     Computes the sample points and weights for Gauss-Jacobi (shifted)
@@ -367,7 +364,7 @@ def js_roots(n, p1, q1, mu=False):
     """
     if (p1-q1) <= -1 or q1 <= 0:
         raise ValueError("(p - q) must be greater than -1, and q must be greater than 0.")
-    x, w, m = j_roots(n, p1-q1, q1-1, True)
+    x, w, m = roots_jacobi(n, p1-q1, q1-1, True)
     x = (x + 1) / 2
     scale = 2.0**p1
     w /= scale
@@ -421,7 +418,7 @@ def sh_jacobi(n, p, q, monic=False):
         return orthopoly1d([], [], 1.0, 1.0, wfunc, (-1, 1), monic,
                            eval_func=np.ones_like)
     n1 = n
-    x, w, mu0 = js_roots(n1, p, q, mu=True)
+    x, w, mu0 = roots_sh_jacobi(n1, p, q, mu=True)
     hn = _gam(n + 1) * _gam(n + q) * _gam(n + p) * _gam(n + p - q + 1)
     hn /= (2 * n + p) * (_gam(2 * n + p)**2)
     # kn = 1.0 in standard form so monic is redundant.  Kept for compatibility.
@@ -433,7 +430,7 @@ def sh_jacobi(n, p, q, monic=False):
 # Generalized Laguerre               L^(alpha)_n(x)
 
 
-def la_roots(n, alpha, mu=False):
+def roots_genlaguerre(n, alpha, mu=False):
     r"""Gauss-generalized Laguerre quadrature.
 
     Computes the sample points and weights for Gauss-generalized Laguerre
@@ -541,7 +538,7 @@ def genlaguerre(n, alpha, monic=False):
         n1 = n + 1
     else:
         n1 = n
-    x, w, mu0 = la_roots(n1, alpha, mu=True)
+    x, w, mu0 = roots_genlaguerre(n1, alpha, mu=True)
     wfunc = lambda x: exp(-x) * x**alpha
     if n == 0:
         x, w = [], []
@@ -554,7 +551,7 @@ def genlaguerre(n, alpha, monic=False):
 # Laguerre                      L_n(x)
 
 
-def l_roots(n, mu=False):
+def roots_laguerre(n, mu=False):
     r"""Gauss-Laguerre quadrature.
 
     Computes the sample points and weights for Gauss-Laguerre quadrature.
@@ -585,7 +582,7 @@ def l_roots(n, mu=False):
     scipy.integrate.fixed_quad
     numpy.polynomial.laguerre.laggauss
     """
-    return la_roots(n, 0.0, mu=mu)
+    return roots_genlaguerre(n, 0.0, mu=mu)
 
 
 def laguerre(n, monic=False):
@@ -624,7 +621,7 @@ def laguerre(n, monic=False):
         n1 = n + 1
     else:
         n1 = n
-    x, w, mu0 = l_roots(n1, mu=True)
+    x, w, mu0 = roots_laguerre(n1, mu=True)
     if n == 0:
         x, w = [], []
     hn = 1.0
@@ -636,7 +633,7 @@ def laguerre(n, monic=False):
 # Hermite  1                         H_n(x)
 
 
-def h_roots(n, mu=False):
+def roots_hermite(n, mu=False):
     r"""Gauss-Hermite (physicst's) quadrature.
 
     Computes the sample points and weights for Gauss-Hermite quadrature.
@@ -678,7 +675,7 @@ def h_roots(n, mu=False):
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
     numpy.polynomial.hermite.hermgauss
-    he_roots
+    roots_hermitenorm
 
     References
     ----------
@@ -706,7 +703,7 @@ def h_roots(n, mu=False):
         df = lambda n, x: 2.0 * n * cephes.eval_hermite(n-1, x)
         return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, True, mu)
     else:
-        nodes, weights = _h_roots_asy(m)
+        nodes, weights = _roots_hermite_asy(m)
         if mu:
             return nodes, weights, mu0
         else:
@@ -737,7 +734,7 @@ def _compute_tauk(n, k, maxit=5):
     See Also
     --------
     initial_nodes_a
-    h_roots_asy
+    roots_hermite_asy
     """
     a = n % 2 - 0.5
     c = (4.0*floor(n/2.0) - 4.0*k + 3.0)*pi / (4.0*floor(n/2.0) + 2.0*a + 2.0)
@@ -773,7 +770,7 @@ def _initial_nodes_a(n, k):
     See Also
     --------
     initial_nodes
-    h_roots_asy
+    roots_hermite_asy
     """
     tauk = _compute_tauk(n, k)
     sigk = cos(0.5*tauk)**2
@@ -808,7 +805,7 @@ def _initial_nodes_b(n, k):
     See Also
     --------
     initial_nodes
-    h_roots_asy
+    roots_hermite_asy
     """
     a = n % 2 - 0.5
     nu = 4.0*floor(n/2.0) + 2.0*a + 2.0
@@ -844,7 +841,7 @@ def _initial_nodes(n):
 
     See Also
     --------
-    h_roots_asy
+    roots_hermite_asy
     """
     # Turnover point
     # linear polynomial fit to error of 10, 25, 40, ..., 1000 point rules
@@ -890,7 +887,7 @@ def _pbcf(n, theta):
 
     See Also
     --------
-    h_roots_asy
+    roots_hermite_asy
 
     References
     ----------
@@ -997,7 +994,7 @@ def _newton(n, x_initial, maxit=5):
 
     See Also
     --------
-    h_roots_asy
+    roots_hermite_asy
     """
     # Variable transformation
     mu = sqrt(2.0*n + 1.0)
@@ -1020,7 +1017,7 @@ def _newton(n, x_initial, maxit=5):
     return x, w
 
 
-def _h_roots_asy(n):
+def _roots_hermite_asy(n):
     r"""Gauss-Hermite (physicst's) quadrature for large n.
 
     Computes the sample points and weights for Gauss-Hermite quadrature.
@@ -1047,7 +1044,7 @@ def _h_roots_asy(n):
 
     See Also
     --------
-    h_roots
+    roots_hermite
 
     References
     ----------
@@ -1114,7 +1111,7 @@ def hermite(n, monic=False):
         n1 = n + 1
     else:
         n1 = n
-    x, w, mu0 = h_roots(n1, mu=True)
+    x, w, mu0 = roots_hermite(n1, mu=True)
     wfunc = lambda x: exp(-x * x)
     if n == 0:
         x, w = [], []
@@ -1127,7 +1124,7 @@ def hermite(n, monic=False):
 # Hermite  2                         He_n(x)
 
 
-def he_roots(n, mu=False):
+def roots_hermitenorm(n, mu=False):
     r"""Gauss-Hermite (statistician's) quadrature.
 
     Computes the sample points and weights for Gauss-Hermite quadrature.
@@ -1182,7 +1179,7 @@ def he_roots(n, mu=False):
         df = lambda n, x: n * cephes.eval_hermitenorm(n-1, x)
         return _gen_roots_and_weights(m, mu0, an_func, bn_func, f, df, True, mu)
     else:
-        nodes, weights = _h_roots_asy(m)
+        nodes, weights = _roots_hermite_asy(m)
         # Transform
         nodes *= sqrt(2)
         weights *= sqrt(2)
@@ -1230,7 +1227,7 @@ def hermitenorm(n, monic=False):
         n1 = n + 1
     else:
         n1 = n
-    x, w, mu0 = he_roots(n1, mu=True)
+    x, w, mu0 = roots_hermitenorm(n1, mu=True)
     wfunc = lambda x: exp(-x * x / 2.0)
     if n == 0:
         x, w = [], []
@@ -1245,7 +1242,7 @@ def hermitenorm(n, monic=False):
 # Ultraspherical (Gegenbauer)        C^(alpha)_n(x)
 
 
-def cg_roots(n, alpha, mu=False):
+def roots_gegenbauer(n, alpha, mu=False):
     r"""Gauss-Gegenbauer quadrature.
 
     Computes the sample points and weights for Gauss-Gegenbauer quadrature.
@@ -1288,7 +1285,7 @@ def cg_roots(n, alpha, mu=False):
         # strictly, we should just error out here, since the roots are not
         # really defined, but we used to return something useful, so let's
         # keep doing so.
-        return t_roots(n, mu)
+        return roots_chebyt(n, mu)
 
     mu0 = np.sqrt(np.pi) * cephes.gamma(alpha + 0.5) / cephes.gamma(alpha + 1)
     an_func = lambda k: 0.0 * k
@@ -1348,7 +1345,7 @@ def gegenbauer(n, alpha, monic=False):
 # Computed anew.
 
 
-def t_roots(n, mu=False):
+def roots_chebyt(n, mu=False):
     r"""Gauss-Chebyshev (first kind) quadrature.
 
     Computes the sample points and weights for Gauss-Chebyshev quadrature.
@@ -1432,7 +1429,7 @@ def chebyt(n, monic=False):
         return orthopoly1d([], [], pi, 1.0, wfunc, (-1, 1), monic,
                            lambda x: eval_chebyt(n, x))
     n1 = n
-    x, w, mu = t_roots(n1, mu=True)
+    x, w, mu = roots_chebyt(n1, mu=True)
     hn = pi / 2
     kn = 2**(n - 1)
     p = orthopoly1d(x, w, hn, kn, wfunc, (-1, 1), monic,
@@ -1443,7 +1440,7 @@ def chebyt(n, monic=False):
 #    U_n(x) = (n+1)! sqrt(pi) / (2*_gam(n+3./2)) * P^(1/2,1/2)_n(x)
 
 
-def u_roots(n, mu=False):
+def roots_chebyu(n, mu=False):
     r"""Gauss-Chebyshev (second kind) quadrature.
 
     Computes the sample points and weights for Gauss-Chebyshev quadrature.
@@ -1529,7 +1526,7 @@ def chebyu(n, monic=False):
 # Chebyshev of the first kind        C_n(x)
 
 
-def c_roots(n, mu=False):
+def roots_chebyc(n, mu=False):
     r"""Gauss-Chebyshev (first kind) quadrature.
 
     Computes the sample points and weights for Gauss-Chebyshev quadrature.
@@ -1559,7 +1556,7 @@ def c_roots(n, mu=False):
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
     """
-    x, w, m = t_roots(n, True)
+    x, w, m = roots_chebyt(n, True)
     x *= 2
     w *= 2
     m *= 2
@@ -1610,7 +1607,7 @@ def chebyc(n, monic=False):
         n1 = n + 1
     else:
         n1 = n
-    x, w, mu0 = c_roots(n1, mu=True)
+    x, w, mu0 = roots_chebyc(n1, mu=True)
     if n == 0:
         x, w = [], []
     hn = 4 * pi * ((n == 0) + 1)
@@ -1626,7 +1623,7 @@ def chebyc(n, monic=False):
 # Chebyshev of the second kind       S_n(x)
 
 
-def s_roots(n, mu=False):
+def roots_chebys(n, mu=False):
     r"""Gauss-Chebyshev (second kind) quadrature.
 
     Computes the sample points and weights for Gauss-Chebyshev quadrature.
@@ -1656,7 +1653,7 @@ def s_roots(n, mu=False):
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
     """
-    x, w, m = u_roots(n, True)
+    x, w, m = roots_chebyu(n, True)
     x *= 2
     w *= 2
     m *= 2
@@ -1707,7 +1704,7 @@ def chebys(n, monic=False):
         n1 = n + 1
     else:
         n1 = n
-    x, w, mu0 = s_roots(n1, mu=True)
+    x, w, mu0 = roots_chebys(n1, mu=True)
     if n == 0:
         x, w = [], []
     hn = pi
@@ -1724,7 +1721,7 @@ def chebys(n, monic=False):
 # Shifted Chebyshev of the first kind     T^*_n(x)
 
 
-def ts_roots(n, mu=False):
+def roots_sh_chebyt(n, mu=False):
     r"""Gauss-Chebyshev (first kind, shifted) quadrature.
 
     Computes the sample points and weights for Gauss-Chebyshev quadrature.
@@ -1755,7 +1752,7 @@ def ts_roots(n, mu=False):
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
     """
-    xw = t_roots(n, mu)
+    xw = roots_chebyt(n, mu)
     return ((xw[0] + 1) / 2,) + xw[1:]
 
 
@@ -1796,7 +1793,7 @@ def sh_chebyt(n, monic=False):
 
 
 # Shifted Chebyshev of the second kind    U^*_n(x)
-def us_roots(n, mu=False):
+def roots_sh_chebyu(n, mu=False):
     r"""Gauss-Chebyshev (second kind, shifted) quadrature.
 
     Computes the sample points and weights for Gauss-Chebyshev quadrature.
@@ -1827,7 +1824,7 @@ def us_roots(n, mu=False):
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
     """
-    x, w, m = u_roots(n, True)
+    x, w, m = roots_chebyu(n, True)
     x = (x + 1) / 2
     m_us = cephes.beta(1.5, 1.5)
     w *= m_us / m
@@ -1872,7 +1869,7 @@ def sh_chebyu(n, monic=False):
 # Legendre
 
 
-def p_roots(n, mu=False):
+def roots_legendre(n, mu=False):
     r"""Gauss-Legendre quadrature.
 
     Computes the sample points and weights for Gauss-Legendre quadrature.
@@ -1961,7 +1958,7 @@ def legendre(n, monic=False):
         n1 = n + 1
     else:
         n1 = n
-    x, w, mu0 = p_roots(n1, mu=True)
+    x, w, mu0 = roots_legendre(n1, mu=True)
     if n == 0:
         x, w = [], []
     hn = 2.0 / (2 * n + 1)
@@ -1973,7 +1970,7 @@ def legendre(n, monic=False):
 # Shifted Legendre              P^*_n(x)
 
 
-def ps_roots(n, mu=False):
+def roots_sh_legendre(n, mu=False):
     r"""Gauss-Legendre (shifted) quadrature.
 
     Computes the sample points and weights for Gauss-Legendre quadrature.
@@ -2003,7 +2000,7 @@ def ps_roots(n, mu=False):
     scipy.integrate.quadrature
     scipy.integrate.fixed_quad
     """
-    x, w = p_roots(n)
+    x, w = roots_legendre(n)
     x = (x + 1) / 2
     w /= 2
     if mu:
@@ -2043,18 +2040,30 @@ def sh_legendre(n, monic=False):
     if n == 0:
         return orthopoly1d([], [], 1.0, 1.0, wfunc, (0, 1), monic,
                            lambda x: eval_sh_legendre(n, x))
-    x, w, mu0 = ps_roots(n, mu=True)
+    x, w, mu0 = roots_sh_legendre(n, mu=True)
     hn = 1.0 / (2 * n + 1.0)
     kn = _gam(2 * n + 1) / _gam(n + 1)**2
     p = orthopoly1d(x, w, hn, kn, wfunc, limits=(0, 1), monic=monic,
                     eval_func=lambda x: eval_sh_legendre(n, x))
     return p
 
+
 # -----------------------------------------------------------------------------
-# Vectorized functions for evaluation
+# Code for backwards compatibility
 # -----------------------------------------------------------------------------
+
+# Import functions in case someone is still calling the orthogonal
+# module directly. (They shouldn't be; it's not in the public API).
+poch = cephes.poch
+
 from ._ufuncs import (binom, eval_jacobi, eval_sh_jacobi, eval_gegenbauer,
                       eval_chebyt, eval_chebyu, eval_chebys, eval_chebyc,
                       eval_sh_chebyt, eval_sh_chebyu, eval_legendre,
                       eval_sh_legendre, eval_genlaguerre, eval_laguerre,
                       eval_hermite, eval_hermitenorm)
+
+# Make the old root function names an alias for the new ones
+_modattrs = globals()
+for newfun, oldfun in _rootfuns_map.items():
+    _modattrs[oldfun] = _modattrs[newfun]
+    __all__.append(oldfun)

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -1,15 +1,16 @@
 from __future__ import division, print_function, absolute_import
 
+import numpy as np
+from numpy import array, sqrt
 from numpy.testing import (TestCase, assert_array_almost_equal,
                            assert_almost_equal, assert_allclose, assert_raises,
                            run_module_suite)
 
 from scipy._lib.six import xrange
-import numpy as np
-from numpy import array, sqrt
-import scipy.special.orthogonal as orth
-from scipy.special import gamma
 from scipy import integrate
+import scipy.special as sc
+from scipy.special import gamma
+import scipy.special.orthogonal as orth
 
 
 class TestCheby(TestCase):
@@ -295,8 +296,8 @@ def verify_gauss_quad(root_func, eval_func, weight_func, a, b, N,
         rtol = 1e-6 if 1e-6 < resI[1] else resI[1] * 10
         assert_allclose(resI[0], resG, rtol=rtol)
 
-def test_j_roots():
-    rf = lambda a, b: lambda n, mu: orth.j_roots(n, a, b, mu)
+def test_roots_jacobi():
+    rf = lambda a, b: lambda n, mu: sc.roots_jacobi(n, a, b, mu)
     ef = lambda a, b: lambda n, x: orth.eval_jacobi(n, a, b, x)
     wf = lambda a, b: lambda x: (1 - x)**a * (1 + x)**b
 
@@ -335,33 +336,33 @@ def test_j_roots():
         100, atol=1e-13)
 
     # when alpha == beta == 0, P_n^{a,b}(x) == P_n(x)
-    xj, wj = orth.j_roots(6, 0.0, 0.0)
-    xl, wl = orth.p_roots(6)
+    xj, wj = sc.roots_jacobi(6, 0.0, 0.0)
+    xl, wl = sc.roots_legendre(6)
     assert_allclose(xj, xl, 1e-14, 1e-14)
     assert_allclose(wj, wl, 1e-14, 1e-14)
 
     # when alpha == beta != 0, P_n^{a,b}(x) == C_n^{alpha+0.5}(x)
-    xj, wj = orth.j_roots(6, 4.0, 4.0)
-    xc, wc = orth.cg_roots(6, 4.5)
+    xj, wj = sc.roots_jacobi(6, 4.0, 4.0)
+    xc, wc = sc.roots_gegenbauer(6, 4.5)
     assert_allclose(xj, xc, 1e-14, 1e-14)
     assert_allclose(wj, wc, 1e-14, 1e-14)
 
-    x, w = orth.j_roots(5, 2, 3, False)
-    y, v, m = orth.j_roots(5, 2, 3, True)
+    x, w = sc.roots_jacobi(5, 2, 3, False)
+    y, v, m = sc.roots_jacobi(5, 2, 3, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
 
     muI, muI_err = integrate.quad(wf(2,3), -1, 1)
     assert_allclose(m, muI, rtol=muI_err)
 
-    assert_raises(ValueError, orth.j_roots, 0, 1, 1)
-    assert_raises(ValueError, orth.j_roots, 3.3, 1, 1)
-    assert_raises(ValueError, orth.j_roots, 3, -2, 1)
-    assert_raises(ValueError, orth.j_roots, 3, 1, -2)
-    assert_raises(ValueError, orth.j_roots, 3, -2, -2)
+    assert_raises(ValueError, sc.roots_jacobi, 0, 1, 1)
+    assert_raises(ValueError, sc.roots_jacobi, 3.3, 1, 1)
+    assert_raises(ValueError, sc.roots_jacobi, 3, -2, 1)
+    assert_raises(ValueError, sc.roots_jacobi, 3, 1, -2)
+    assert_raises(ValueError, sc.roots_jacobi, 3, -2, -2)
 
-def test_js_roots():
-    rf = lambda a, b: lambda n, mu: orth.js_roots(n, a, b, mu)
+def test_roots_sh_jacobi():
+    rf = lambda a, b: lambda n, mu: sc.roots_sh_jacobi(n, a, b, mu)
     ef = lambda a, b: lambda n, x: orth.eval_sh_jacobi(n, a, b, x)
     wf = lambda a, b: lambda x: (1. - x)**(a - b) * (x)**(b - 1.)
 
@@ -398,22 +399,22 @@ def test_js_roots():
     vgq(rf(68.9, 2.25), ef(68.9, 2.25), wf(68.9, 2.25), 0., 1.,
         100, atol=1e-12)
 
-    x, w = orth.js_roots(5, 3, 2, False)
-    y, v, m = orth.js_roots(5, 3, 2, True)
+    x, w = sc.roots_sh_jacobi(5, 3, 2, False)
+    y, v, m = sc.roots_sh_jacobi(5, 3, 2, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
 
     muI, muI_err = integrate.quad(wf(3,2), 0, 1)
     assert_allclose(m, muI, rtol=muI_err)
 
-    assert_raises(ValueError, orth.js_roots, 0, 1, 1)
-    assert_raises(ValueError, orth.js_roots, 3.3, 1, 1)
-    assert_raises(ValueError, orth.js_roots, 3, 1, 2)    # p - q <= -1
-    assert_raises(ValueError, orth.js_roots, 3, 2, -1)   # q <= 0
-    assert_raises(ValueError, orth.js_roots, 3, -2, -1)  # both
+    assert_raises(ValueError, sc.roots_sh_jacobi, 0, 1, 1)
+    assert_raises(ValueError, sc.roots_sh_jacobi, 3.3, 1, 1)
+    assert_raises(ValueError, sc.roots_sh_jacobi, 3, 1, 2)    # p - q <= -1
+    assert_raises(ValueError, sc.roots_sh_jacobi, 3, 2, -1)   # q <= 0
+    assert_raises(ValueError, sc.roots_sh_jacobi, 3, -2, -1)  # both
 
-def test_h_roots():
-    rootf = orth.h_roots
+def test_roots_hermite():
+    rootf = sc.roots_hermite
     evalf = orth.eval_hermite
     weightf = orth.hermite(5).weight_func
 
@@ -422,8 +423,8 @@ def test_h_roots():
     verify_gauss_quad(rootf, evalf, weightf, -np.inf, np.inf, 100, atol=1e-12)
 
     # Golub-Welsch branch
-    x, w = orth.h_roots(5, False)
-    y, v, m = orth.h_roots(5, True)
+    x, w = sc.roots_hermite(5, False)
+    y, v, m = sc.roots_hermite(5, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
 
@@ -431,16 +432,16 @@ def test_h_roots():
     assert_allclose(m, muI, rtol=muI_err)
 
     # Asymptotic branch (switch over at n >= 150)
-    x, w = orth.h_roots(200, False)
-    y, v, m = orth.h_roots(200, True)
+    x, w = sc.roots_hermite(200, False)
+    y, v, m = sc.roots_hermite(200, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
     assert_allclose(sum(v), m, 1e-14, 1e-14)
 
-    assert_raises(ValueError, orth.h_roots, 0)
-    assert_raises(ValueError, orth.h_roots, 3.3)
+    assert_raises(ValueError, sc.roots_hermite, 0)
+    assert_raises(ValueError, sc.roots_hermite, 3.3)
 
-def test_h_roots_asy():
+def test_roots_hermite_asy():
     # Recursion for Hermite functions
     def hermite_recursion(n, nodes):
         H = np.zeros((n, nodes.size))
@@ -453,7 +454,7 @@ def test_h_roots_asy():
 
     # This tests only the nodes
     def test(N, rtol=1e-15, atol=1e-14):
-        x, w = orth._h_roots_asy(N)
+        x, w = orth._roots_hermite_asy(N)
         H = hermite_recursion(N+1, x)
         assert_allclose(H[-1,:], np.zeros(N), rtol, atol)
         assert_allclose(sum(w), sqrt(np.pi), rtol, atol)
@@ -469,8 +470,8 @@ def test_h_roots_asy():
     test(2000, atol=1e-12)
     test(5000, atol=1e-12)
 
-def test_he_roots():
-    rootf = orth.he_roots
+def test_roots_hermitenorm():
+    rootf = sc.roots_hermitenorm
     evalf = orth.eval_hermitenorm
     weightf = orth.hermitenorm(5).weight_func
 
@@ -478,19 +479,19 @@ def test_he_roots():
     verify_gauss_quad(rootf, evalf, weightf, -np.inf, np.inf, 25, atol=1e-13)
     verify_gauss_quad(rootf, evalf, weightf, -np.inf, np.inf, 100, atol=1e-12)
 
-    x, w = orth.he_roots(5, False)
-    y, v, m = orth.he_roots(5, True)
+    x, w = sc.roots_hermitenorm(5, False)
+    y, v, m = sc.roots_hermitenorm(5, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
 
     muI, muI_err = integrate.quad(weightf, -np.inf, np.inf)
     assert_allclose(m, muI, rtol=muI_err)
 
-    assert_raises(ValueError, orth.he_roots, 0)
-    assert_raises(ValueError, orth.he_roots, 3.3)
+    assert_raises(ValueError, sc.roots_hermitenorm, 0)
+    assert_raises(ValueError, sc.roots_hermitenorm, 3.3)
 
-def test_cg_roots():
-    rootf = lambda a: lambda n, mu: orth.cg_roots(n, a, mu)
+def test_roots_gegenbauer():
+    rootf = lambda a: lambda n, mu: sc.roots_gegenbauer(n, a, mu)
     evalf = lambda a: lambda n, x: orth.eval_gegenbauer(n, a, x)
     weightf = lambda a: lambda x: (1 - x**2)**(a - 0.5)
 
@@ -522,181 +523,181 @@ def test_cg_roots():
     vgq(rootf(0), orth.eval_chebyt, weightf(0), -1., 1., 25)
     vgq(rootf(0), orth.eval_chebyt, weightf(0), -1., 1., 100)
 
-    x, w = orth.cg_roots(5, 2, False)
-    y, v, m = orth.cg_roots(5, 2, True)
+    x, w = sc.roots_gegenbauer(5, 2, False)
+    y, v, m = sc.roots_gegenbauer(5, 2, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
 
     muI, muI_err = integrate.quad(weightf(2), -1, 1)
     assert_allclose(m, muI, rtol=muI_err)
 
-    assert_raises(ValueError, orth.cg_roots, 0, 2)
-    assert_raises(ValueError, orth.cg_roots, 3.3, 2)
-    assert_raises(ValueError, orth.cg_roots, 3, -.75)
+    assert_raises(ValueError, sc.roots_gegenbauer, 0, 2)
+    assert_raises(ValueError, sc.roots_gegenbauer, 3.3, 2)
+    assert_raises(ValueError, sc.roots_gegenbauer, 3, -.75)
 
-def test_t_roots():
+def test_roots_chebyt():
     weightf = orth.chebyt(5).weight_func
-    verify_gauss_quad(orth.t_roots, orth.eval_chebyt, weightf, -1., 1., 5)
-    verify_gauss_quad(orth.t_roots, orth.eval_chebyt, weightf, -1., 1., 25)
-    verify_gauss_quad(orth.t_roots, orth.eval_chebyt, weightf, -1., 1., 100)
+    verify_gauss_quad(sc.roots_chebyt, orth.eval_chebyt, weightf, -1., 1., 5)
+    verify_gauss_quad(sc.roots_chebyt, orth.eval_chebyt, weightf, -1., 1., 25)
+    verify_gauss_quad(sc.roots_chebyt, orth.eval_chebyt, weightf, -1., 1., 100)
 
-    x, w = orth.t_roots(5, False)
-    y, v, m = orth.t_roots(5, True)
+    x, w = sc.roots_chebyt(5, False)
+    y, v, m = sc.roots_chebyt(5, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
 
     muI, muI_err = integrate.quad(weightf, -1, 1)
     assert_allclose(m, muI, rtol=muI_err)
 
-    assert_raises(ValueError, orth.t_roots, 0)
-    assert_raises(ValueError, orth.t_roots, 3.3)
+    assert_raises(ValueError, sc.roots_chebyt, 0)
+    assert_raises(ValueError, sc.roots_chebyt, 3.3)
 
-def test_u_roots():
+def test_roots_chebyu():
     weightf = orth.chebyu(5).weight_func
-    verify_gauss_quad(orth.u_roots, orth.eval_chebyu, weightf, -1., 1., 5)
-    verify_gauss_quad(orth.u_roots, orth.eval_chebyu, weightf, -1., 1., 25)
-    verify_gauss_quad(orth.u_roots, orth.eval_chebyu, weightf, -1., 1., 100)
+    verify_gauss_quad(sc.roots_chebyu, orth.eval_chebyu, weightf, -1., 1., 5)
+    verify_gauss_quad(sc.roots_chebyu, orth.eval_chebyu, weightf, -1., 1., 25)
+    verify_gauss_quad(sc.roots_chebyu, orth.eval_chebyu, weightf, -1., 1., 100)
 
-    x, w = orth.u_roots(5, False)
-    y, v, m = orth.u_roots(5, True)
+    x, w = sc.roots_chebyu(5, False)
+    y, v, m = sc.roots_chebyu(5, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
 
     muI, muI_err = integrate.quad(weightf, -1, 1)
     assert_allclose(m, muI, rtol=muI_err)
 
-    assert_raises(ValueError, orth.u_roots, 0)
-    assert_raises(ValueError, orth.u_roots, 3.3)
+    assert_raises(ValueError, sc.roots_chebyu, 0)
+    assert_raises(ValueError, sc.roots_chebyu, 3.3)
 
-def test_c_roots():
+def test_roots_chebyc():
     weightf = orth.chebyc(5).weight_func
-    verify_gauss_quad(orth.c_roots, orth.eval_chebyc, weightf, -2., 2., 5)
-    verify_gauss_quad(orth.c_roots, orth.eval_chebyc, weightf, -2., 2., 25)
-    verify_gauss_quad(orth.c_roots, orth.eval_chebyc, weightf, -2., 2., 100)
+    verify_gauss_quad(sc.roots_chebyc, orth.eval_chebyc, weightf, -2., 2., 5)
+    verify_gauss_quad(sc.roots_chebyc, orth.eval_chebyc, weightf, -2., 2., 25)
+    verify_gauss_quad(sc.roots_chebyc, orth.eval_chebyc, weightf, -2., 2., 100)
 
-    x, w = orth.c_roots(5, False)
-    y, v, m = orth.c_roots(5, True)
+    x, w = sc.roots_chebyc(5, False)
+    y, v, m = sc.roots_chebyc(5, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
 
     muI, muI_err = integrate.quad(weightf, -2, 2)
     assert_allclose(m, muI, rtol=muI_err)
 
-    assert_raises(ValueError, orth.c_roots, 0)
-    assert_raises(ValueError, orth.c_roots, 3.3)
+    assert_raises(ValueError, sc.roots_chebyc, 0)
+    assert_raises(ValueError, sc.roots_chebyc, 3.3)
 
-def test_s_roots():
+def test_roots_chebys():
     weightf = orth.chebys(5).weight_func
-    verify_gauss_quad(orth.s_roots, orth.eval_chebys, weightf, -2., 2., 5)
-    verify_gauss_quad(orth.s_roots, orth.eval_chebys, weightf, -2., 2., 25)
-    verify_gauss_quad(orth.s_roots, orth.eval_chebys, weightf, -2., 2., 100)
+    verify_gauss_quad(sc.roots_chebys, orth.eval_chebys, weightf, -2., 2., 5)
+    verify_gauss_quad(sc.roots_chebys, orth.eval_chebys, weightf, -2., 2., 25)
+    verify_gauss_quad(sc.roots_chebys, orth.eval_chebys, weightf, -2., 2., 100)
 
-    x, w = orth.s_roots(5, False)
-    y, v, m = orth.s_roots(5, True)
+    x, w = sc.roots_chebys(5, False)
+    y, v, m = sc.roots_chebys(5, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
 
     muI, muI_err = integrate.quad(weightf, -2, 2)
     assert_allclose(m, muI, rtol=muI_err)
 
-    assert_raises(ValueError, orth.s_roots, 0)
-    assert_raises(ValueError, orth.s_roots, 3.3)
+    assert_raises(ValueError, sc.roots_chebys, 0)
+    assert_raises(ValueError, sc.roots_chebys, 3.3)
 
-def test_ts_roots():
+def test_roots_sh_chebyt():
     weightf = orth.sh_chebyt(5).weight_func
-    verify_gauss_quad(orth.ts_roots, orth.eval_sh_chebyt, weightf, 0., 1., 5)
-    verify_gauss_quad(orth.ts_roots, orth.eval_sh_chebyt, weightf, 0., 1., 25)
-    verify_gauss_quad(orth.ts_roots, orth.eval_sh_chebyt, weightf, 0., 1.,
+    verify_gauss_quad(sc.roots_sh_chebyt, orth.eval_sh_chebyt, weightf, 0., 1., 5)
+    verify_gauss_quad(sc.roots_sh_chebyt, orth.eval_sh_chebyt, weightf, 0., 1., 25)
+    verify_gauss_quad(sc.roots_sh_chebyt, orth.eval_sh_chebyt, weightf, 0., 1.,
                       100, atol=1e-13)
 
-    x, w = orth.ts_roots(5, False)
-    y, v, m = orth.ts_roots(5, True)
+    x, w = sc.roots_sh_chebyt(5, False)
+    y, v, m = sc.roots_sh_chebyt(5, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
 
     muI, muI_err = integrate.quad(weightf, 0, 1)
     assert_allclose(m, muI, rtol=muI_err)
 
-    assert_raises(ValueError, orth.ts_roots, 0)
-    assert_raises(ValueError, orth.ts_roots, 3.3)
+    assert_raises(ValueError, sc.roots_sh_chebyt, 0)
+    assert_raises(ValueError, sc.roots_sh_chebyt, 3.3)
 
-def test_us_roots():
+def test_roots_sh_chebyu():
     weightf = orth.sh_chebyu(5).weight_func
-    verify_gauss_quad(orth.us_roots, orth.eval_sh_chebyu, weightf, 0., 1., 5)
-    verify_gauss_quad(orth.us_roots, orth.eval_sh_chebyu, weightf, 0., 1., 25)
-    verify_gauss_quad(orth.us_roots, orth.eval_sh_chebyu, weightf, 0., 1.,
+    verify_gauss_quad(sc.roots_sh_chebyu, orth.eval_sh_chebyu, weightf, 0., 1., 5)
+    verify_gauss_quad(sc.roots_sh_chebyu, orth.eval_sh_chebyu, weightf, 0., 1., 25)
+    verify_gauss_quad(sc.roots_sh_chebyu, orth.eval_sh_chebyu, weightf, 0., 1.,
                       100, atol=1e-13)
 
-    x, w = orth.us_roots(5, False)
-    y, v, m = orth.us_roots(5, True)
+    x, w = sc.roots_sh_chebyu(5, False)
+    y, v, m = sc.roots_sh_chebyu(5, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
 
     muI, muI_err = integrate.quad(weightf, 0, 1)
     assert_allclose(m, muI, rtol=muI_err)
 
-    assert_raises(ValueError, orth.us_roots, 0)
-    assert_raises(ValueError, orth.us_roots, 3.3)
+    assert_raises(ValueError, sc.roots_sh_chebyu, 0)
+    assert_raises(ValueError, sc.roots_sh_chebyu, 3.3)
 
-def test_p_roots():
+def test_roots_legendre():
     weightf = orth.legendre(5).weight_func
-    verify_gauss_quad(orth.p_roots, orth.eval_legendre, weightf, -1., 1., 5)
-    verify_gauss_quad(orth.p_roots, orth.eval_legendre, weightf, -1., 1.,
+    verify_gauss_quad(sc.roots_legendre, orth.eval_legendre, weightf, -1., 1., 5)
+    verify_gauss_quad(sc.roots_legendre, orth.eval_legendre, weightf, -1., 1.,
                       25, atol=1e-13)
-    verify_gauss_quad(orth.p_roots, orth.eval_legendre, weightf, -1., 1.,
+    verify_gauss_quad(sc.roots_legendre, orth.eval_legendre, weightf, -1., 1.,
                       100, atol=1e-12)
 
-    x, w = orth.p_roots(5, False)
-    y, v, m = orth.p_roots(5, True)
+    x, w = sc.roots_legendre(5, False)
+    y, v, m = sc.roots_legendre(5, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
 
     muI, muI_err = integrate.quad(weightf, -1, 1)
     assert_allclose(m, muI, rtol=muI_err)
 
-    assert_raises(ValueError, orth.p_roots, 0)
-    assert_raises(ValueError, orth.p_roots, 3.3)
+    assert_raises(ValueError, sc.roots_legendre, 0)
+    assert_raises(ValueError, sc.roots_legendre, 3.3)
 
-def test_ps_roots():
+def test_roots_sh_legendre():
     weightf = orth.sh_legendre(5).weight_func
-    verify_gauss_quad(orth.ps_roots, orth.eval_sh_legendre, weightf, 0., 1., 5)
-    verify_gauss_quad(orth.ps_roots, orth.eval_sh_legendre, weightf, 0., 1.,
+    verify_gauss_quad(sc.roots_sh_legendre, orth.eval_sh_legendre, weightf, 0., 1., 5)
+    verify_gauss_quad(sc.roots_sh_legendre, orth.eval_sh_legendre, weightf, 0., 1.,
                       25, atol=1e-13)
-    verify_gauss_quad(orth.ps_roots, orth.eval_sh_legendre, weightf, 0., 1.,
+    verify_gauss_quad(sc.roots_sh_legendre, orth.eval_sh_legendre, weightf, 0., 1.,
                       100, atol=1e-12)
 
-    x, w = orth.ps_roots(5, False)
-    y, v, m = orth.ps_roots(5, True)
+    x, w = sc.roots_sh_legendre(5, False)
+    y, v, m = sc.roots_sh_legendre(5, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
 
     muI, muI_err = integrate.quad(weightf, 0, 1)
     assert_allclose(m, muI, rtol=muI_err)
 
-    assert_raises(ValueError, orth.ps_roots, 0)
-    assert_raises(ValueError, orth.ps_roots, 3.3)
+    assert_raises(ValueError, sc.roots_sh_legendre, 0)
+    assert_raises(ValueError, sc.roots_sh_legendre, 3.3)
 
-def test_l_roots():
+def test_roots_laguerre():
     weightf = orth.laguerre(5).weight_func
-    verify_gauss_quad(orth.l_roots, orth.eval_laguerre, weightf, 0., np.inf, 5)
-    verify_gauss_quad(orth.l_roots, orth.eval_laguerre, weightf, 0., np.inf,
+    verify_gauss_quad(sc.roots_laguerre, orth.eval_laguerre, weightf, 0., np.inf, 5)
+    verify_gauss_quad(sc.roots_laguerre, orth.eval_laguerre, weightf, 0., np.inf,
                       25, atol=1e-13)
-    verify_gauss_quad(orth.l_roots, orth.eval_laguerre, weightf, 0., np.inf,
+    verify_gauss_quad(sc.roots_laguerre, orth.eval_laguerre, weightf, 0., np.inf,
                       100, atol=1e-12)
 
-    x, w = orth.l_roots(5, False)
-    y, v, m = orth.l_roots(5, True)
+    x, w = sc.roots_laguerre(5, False)
+    y, v, m = sc.roots_laguerre(5, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
 
     muI, muI_err = integrate.quad(weightf, 0, np.inf)
     assert_allclose(m, muI, rtol=muI_err)
 
-    assert_raises(ValueError, orth.l_roots, 0)
-    assert_raises(ValueError, orth.l_roots, 3.3)
+    assert_raises(ValueError, sc.roots_laguerre, 0)
+    assert_raises(ValueError, sc.roots_laguerre, 3.3)
 
-def test_la_roots():
-    rootf = lambda a: lambda n, mu: orth.la_roots(n, a, mu)
+def test_roots_genlaguerre():
+    rootf = lambda a: lambda n, mu: sc.roots_genlaguerre(n, a, mu)
     evalf = lambda a: lambda n, x: orth.eval_genlaguerre(n, a, x)
     weightf = lambda a: lambda x: x**a * np.exp(-x)
 
@@ -721,17 +722,17 @@ def test_la_roots():
     vgq(rootf(50), evalf(50), weightf(50), 0., np.inf, 25, atol=1e-13)
     vgq(rootf(50), evalf(50), weightf(50), 0., np.inf, 100, rtol=1e-14, atol=2e-13)
 
-    x, w = orth.la_roots(5, 2, False)
-    y, v, m = orth.la_roots(5, 2, True)
+    x, w = sc.roots_genlaguerre(5, 2, False)
+    y, v, m = sc.roots_genlaguerre(5, 2, True)
     assert_allclose(x, y, 1e-14, 1e-14)
     assert_allclose(w, v, 1e-14, 1e-14)
 
     muI, muI_err = integrate.quad(weightf(2.), 0., np.inf)
     assert_allclose(m, muI, rtol=muI_err)
 
-    assert_raises(ValueError, orth.la_roots, 0, 2)
-    assert_raises(ValueError, orth.la_roots, 3.3, 2)
-    assert_raises(ValueError, orth.la_roots, 3, -1.1)
+    assert_raises(ValueError, sc.roots_genlaguerre, 0, 2)
+    assert_raises(ValueError, sc.roots_genlaguerre, 3.3, 2)
+    assert_raises(ValueError, sc.roots_genlaguerre, 3, -1.1)
 
 
 if __name__ == "__main__":

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -112,6 +112,12 @@ REFGUIDE_ALL_SKIPLIST = [
     r'scipy\.linalg\.lapack\.[sdczi].*',
 ]
 
+# these names are not required to be in an autosummary:: listing
+# despite being in ALL
+REFGUIDE_AUTOSUMMARY_SKIPLIST = [
+    r'scipy\.special\..*_roots' # old aliases for scipy.special.*_roots
+]
+
 
 HAVE_MATPLOTLIB = False
 
@@ -207,7 +213,11 @@ def compare(all_dict, others, names, module_name):
     only_all = set()
     for name in all_dict:
         if name not in names:
-            only_all.add(name)
+            for pat in REFGUIDE_AUTOSUMMARY_SKIPLIST:
+                if re.match(pat, module_name + '.' + name):
+                    break
+            else:
+                only_all.add(name)
 
     only_ref = set()
     missing = set()


### PR DESCRIPTION
A function like `j_roots` is renamed to `roots_jacobi` so that it
has a more descriptive name and matches the functions `jacobi` and
`eval_jacobi`. The old names are kept as aliases, so all changes are
backwards compatible.
