### PR TITLE
MAINT: clean up mpmath imports

### DIFF
--- a/scipy/interpolate/interpnd_info.py
+++ b/scipy/interpolate/interpnd_info.py
@@ -5,7 +5,7 @@ interpolation routines in `interpnd.pyx`.
 """
 from __future__ import division, print_function, absolute_import
 
-from sympy import *
+from sympy import symbols, binomial, Matrix
 
 
 def _estimate_gradients_2d_global():

--- a/scipy/signal/tests/mpsig.py
+++ b/scipy/signal/tests/mpsig.py
@@ -7,10 +7,7 @@ from __future__ import division
 try:
     import mpmath
 except ImportError:
-    try:
-        import sympy.mpmath as mpmath
-    except ImportError:
-        mpmath = None
+    mpmath = None
 
 
 def _prod(seq):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -24,10 +24,7 @@ from scipy.signal.filter_design import (_cplxreal, _cplxpair, _norm_factor,
 try:
     import mpmath
 except ImportError:
-    try:
-        import sympy.mpmath as mpmath
-    except ImportError:
-        mpmath = None
+    mpmath = None
 
 
 def mpmath_check(min_ver):

--- a/scipy/special/_mptestutils.py
+++ b/scipy/special/_mptestutils.py
@@ -12,10 +12,7 @@ from scipy.special._testutils import assert_func_equal
 try:
     import mpmath
 except ImportError:
-    try:
-        import sympy.mpmath as mpmath
-    except ImportError:
-        pass
+    pass
 
 
 # ------------------------------------------------------------------------------

--- a/scipy/special/_precompute/gammainc_asy.py
+++ b/scipy/special/_precompute/gammainc_asy.py
@@ -16,10 +16,7 @@ from scipy.special._precompute.utils import lagrange_inversion
 try:
     import mpmath as mp
 except ImportError:
-    try:
-        import sympy.mpmath as mp
-    except ImportError:
-        pass
+    pass
 
 
 def compute_a(n):

--- a/scipy/special/_precompute/gammainc_data.py
+++ b/scipy/special/_precompute/gammainc_data.py
@@ -29,10 +29,7 @@ from scipy.special._mptestutils import mpf2float
 try:
     import mpmath as mp
 except ImportError:
-    try:
-        import sympy.mpmath as mp
-    except ImportError:
-        pass
+    pass
 
 
 def gammainc(a, x, dps=50, maxterms=10**8):

--- a/scipy/special/_precompute/utils.py
+++ b/scipy/special/_precompute/utils.py
@@ -5,10 +5,7 @@ import warnings
 try:
     import mpmath as mp
 except ImportError:
-    try:
-        import sympy.mpmath as mp
-    except ImportError:
-        pass
+    pass
 
 try:
     # Can remove when sympy #11255 is resolved; see

--- a/scipy/special/c_misc/struve_convergence.py
+++ b/scipy/special/c_misc/struve_convergence.py
@@ -36,11 +36,7 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 import matplotlib.pyplot as plt
 
-
-try:
-    import mpmath
-except:
-    from sympy import mpmath
+import mpmath
 
 
 def err_metric(a, b, atol=1e-290):

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -35,10 +35,7 @@ from scipy.special._mptestutils import (
 try:
     import mpmath
 except ImportError:
-    try:
-        import sympy.mpmath as mpmath
-    except ImportError:
-        mpmath = MissingModule('mpmath')
+    mpmath = MissingModule('mpmath')
 
 
 class ProbArg(object):

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -25,10 +25,7 @@ from scipy.special._ufuncs import (
 try:
     import mpmath
 except ImportError:
-    try:
-        import sympy.mpmath as mpmath
-    except ImportError:
-        mpmath = MissingModule('mpmath')
+    mpmath = MissingModule('mpmath')
 
 
 # ------------------------------------------------------------------------------

--- a/scipy/special/tests/test_precompute_gammainc.py
+++ b/scipy/special/tests/test_precompute_gammainc.py
@@ -18,10 +18,7 @@ except ImportError:
 try:
     import mpmath as mp
 except ImportError:
-    try:
-        from sympy import mpmath as mp
-    except ImportError:
-        mp = MissingModule('mpmath')
+    mp = MissingModule('mpmath')
 
 
 @check_version(mp, '0.19')
@@ -35,6 +32,7 @@ def test_g():
 
 
 @dec.slow
+@check_version(mp, '0.19')
 @check_version(sympy, '0.7')
 def test_alpha():
     # Test data for the alpha_k. See DLMF 8.12.14.
@@ -46,6 +44,7 @@ def test_alpha():
 
 
 @xslow
+@check_version(mp, '0.19')
 @check_version(sympy, '0.7')
 def test_d():
     # Compare the d_{k, n} to the results in appendix F of [1].

--- a/scipy/special/tests/test_precompute_utils.py
+++ b/scipy/special/tests/test_precompute_utils.py
@@ -14,10 +14,7 @@ except ImportError:
 try:
     import mpmath as mp
 except ImportError:
-    try:
-        from sympy import mpmath as mp
-    except ImportError:
-        mp = MissingModule('mpmath')
+    mp = MissingModule('mpmath')
 
 
 class TestInversion(with_metaclass(DecoratorMeta, object)):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -538,7 +538,7 @@ class TestLogser(TestCase):
     def test_pmf_small_p(self):
         m = stats.logser.pmf(4, 1e-20)
         # The expected value was computed using mpmath:
-        #   >>> from sympy import mpmath
+        #   >>> import mpmath
         #   >>> mpmath.mp.dps = 64
         #   >>> k = 4
         #   >>> p = mpmath.mpf('1e-20')
@@ -552,7 +552,7 @@ class TestLogser(TestCase):
     def test_mean_small_p(self):
         m = stats.logser.mean(1e-8)
         # The expected mean was computed using mpmath:
-        #   >>> from sympy import mpmath
+        #   >>> import mpmath
         #   >>> mpmath.dps = 60
         #   >>> p = mpmath.mpf('1e-8')
         #   >>> float(-p / ((1 - p)*mpmath.log(1 - p)))
@@ -2954,7 +2954,7 @@ def test_genextreme_entropy():
 def test_genextreme_sf_isf():
     # Expected values were computed using mpmath:
     #
-    #    from sympy import mpmath
+    #    import mpmath
     #
     #    def mp_genextreme_sf(x, xi, mu=0, sigma=1):
     #        # Formula from wikipedia, which has a sign convention for xi that
@@ -2999,7 +2999,7 @@ def test_burr12_ppf_small_arg():
     prob = 1e-16
     quantile = stats.burr12.ppf(prob, 2, 3)
     # The expected quantile was computed using mpmath:
-    #   >>> from sympy import mpmath
+    #   >>> import mpmath
     #   >>> prob = mpmath.mpf('1e-16')
     #   >>> c = mpmath.mpf(2)
     #   >>> d = mpmath.mpf(3)


### PR DESCRIPTION
`sympy.mpmath` no longer exists (see [this message](http://stackoverflow.com/questions/34214635/sympy-installed-however-sympy-mpmath-not-found) from Aaron Meurer for example), so shouldn't be tried as a fallback.

This PR follows up on https://github.com/scipy/scipy/pull/6626#issuecomment-250093606

This leaves a single test that uses `sympy`: `test_generate_A` in special/tests/test_precompute_expn_asy.py`. That tests doesn't test anything in`scipy`itself however, it's just a consistency test for`sympy.Poly`behavior. Therefore it's not needed to add`sympy`` to the optional test packages to add to TravisCI runs.
