### PR TITLE
ENH: Added scipy.spatial.distance.directed_hausdorff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,7 @@ scipy/sparse/sparsetools/other_impl.h
 scipy/sparse/sparsetools/sparsetools_impl.h
 scipy/spatial/ckdtree.cxx
 scipy/spatial/ckdtree.h
+scipy/spatial/_hausdorff.c
 scipy/spatial/qhull.c
 scipy/spatial/_voronoi.c
 scipy/special/_comb.c

--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -230,6 +230,7 @@ class Cdist(Benchmark):
         """
         distance.cdist(self.points, self.points, metric)
 
+
 class ConvexHullBench(Benchmark):
     params = ([10, 100, 1000, 5000], [True, False])
     param_names = ['num_points', 'incremental']
@@ -244,6 +245,7 @@ class ConvexHullBench(Benchmark):
         """
         ConvexHull(self.points, incremental)
 
+
 class VoronoiBench(Benchmark):
     params = ([10, 100, 1000, 5000, 10000], [False, True])
     param_names = ['num_points', 'furthest_site']
@@ -255,3 +257,18 @@ class VoronoiBench(Benchmark):
     def time_voronoi_calculation(self, num_points, furthest_site):
         """Time conventional Voronoi diagram calculation."""
         Voronoi(self.points, furthest_site=furthest_site)
+
+class Hausdorff(Benchmark):
+    params = [10, 100, 1000]
+    param_names = ['num_points']
+
+    def setup(self, num_points):
+        np.random.seed(123)
+        self.points1 = np.random.random_sample((num_points, 3))
+        np.random.seed(71890)
+        self.points2 = np.random.random_sample((num_points, 3))
+
+    def time_directed_hausdorff(self, num_points):
+        # time directed_hausdorff code in 3 D
+        distance.directed_hausdorff(self.points1, self.points2)
+

--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -44,6 +44,9 @@ cython to improve performance
 `SphericalVoronoi` can handle > 200 k points (at least 10 million) & has
 improved performance
 
+The function `scipy.spatial.distance.directed_hausdorff` was
+added to calculate the directed Hausdorff distance.
+
 `scipy.ndimage` improvements
 ----------------------------
 

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -34,8 +34,8 @@ def directed_hausdorff(np.ndarray[np.float64_t, ndim =2] ar1,
     # performance of the algorithm
     np.random.shuffle(ar1)
     np.random.shuffle(ar2)
-                                                                                                                                                                                                     
-    cmax = 0 
+
+    cmax = 0
     for i in range(N1):
         break_occurred = 0
         cmin = np.inf

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -25,13 +25,19 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2):
     cdef int N1 = ar1.shape[0]
     cdef int N2 = ar2.shape[0]
     cdef int data_dims = ar1.shape[1]
-    cdef unsigned int i, j, k
+    cdef unsigned int i, j, k, i_store, j_store, i_ret, j_ret
+    cdef long[:] resort1, resort2
 
     # shuffling the points in each array generally increases the likelihood of
     # an advantageous break in the inner search loop and never decreases the
     # performance of the algorithm
+    np.random.seed(123)
     np.random.shuffle(np.asarray(ar1))
     np.random.shuffle(np.asarray(ar2))
+    resort1 = np.arange(N1)
+    resort2 = np.arange(N2)
+    np.random.shuffle(np.asarray(resort1))
+    np.random.shuffle(np.asarray(resort2))
 
     cmax = 0
     for i in range(N1):
@@ -48,6 +54,10 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2):
                 break
             if d < cmin:
                 cmin = d
+                i_store = i
+                j_store = j
         if cmin > cmax and cmin != np.inf and break_occurred == 0:
             cmax = cmin
-    return sqrt(cmax)
+            i_ret = i_store
+            j_ret = j_store
+    return (sqrt(cmax), resort1[i_ret], resort2[j_ret])

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -21,7 +21,7 @@ __all__ = ['directed_hausdorff']
 def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
 
     cdef double cmax, cmin, d
-    cdef int break_occurred
+    cdef bint no_break_occurred
     cdef int N1 = ar1.shape[0]
     cdef int N2 = ar2.shape[0]
     cdef int data_dims = ar1.shape[1]
@@ -42,7 +42,7 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
 
     cmax = 0
     for i in range(N1):
-        break_occurred = 0
+        no_break_occurred = True
         cmin = np.inf
         for j in range(N2):
             d = 0
@@ -50,16 +50,18 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
 	    # avoid sqrt until very end
             for k in range(data_dims):
                 d += (ar1[i, k] - ar2[j, k])**2
-            if d < cmax: # early break
-                break_occurred += 1
+            if d < cmax: # break out of `for j` loop
+                no_break_occurred = False
                 break
 
-            if d < cmin:
+            if d < cmin: # always true on first iteration of for-j loop
                 cmin = d
                 i_store = i
                 j_store = j
 
-        if cmin > cmax and break_occurred == 0:
+        # always true on first iteration of for-j loop, after that only
+        # if d >= cmax
+        if cmin > cmax and no_break_occurred == True:
             cmax = cmin
             i_ret = i_store
             j_ret = j_store

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -61,7 +61,7 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
 
         # always true on first iteration of for-j loop, after that only
         # if d >= cmax
-        if cmin > cmax and cmin != np.inf and no_break_occurred == True:
+        if cmin != np.inf and cmin > cmax and no_break_occurred == True:
             cmax = cmin
             i_ret = i_store
             j_ret = j_store

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -59,7 +59,7 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
                 i_store = i
                 j_store = j
 
-        if cmin > cmax and cmin != np.inf and break_occurred == 0:
+        if cmin > cmax and break_occurred == 0:
             cmax = cmin
             i_ret = i_store
             j_ret = j_store

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -5,7 +5,7 @@ Directed Hausdorff Code
 
 """
 #
-# Copyright (C)  Tyler Reddy and Richard Gowers, 2016
+# Copyright (C)  Tyler Reddy, Richard Gowers, and Max Linke, 2016
 #
 # Distributed under the same BSD license as Scipy.
 #

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -18,7 +18,7 @@ from libc.math cimport sqrt
 __all__ = ['directed_hausdorff']
 
 @cython.boundscheck(False)
-def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2):
+def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
 
     cdef double cmax, cmin, d
     cdef int break_occurred
@@ -32,10 +32,11 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2):
     # shuffling the points in each array generally increases the likelihood of
     # an advantageous break in the inner search loop and never decreases the
     # performance of the algorithm
+    rng = np.random.RandomState(seed)
     resort1 = np.arange(N1)
     resort2 = np.arange(N2)
-    np.random.shuffle(resort1)
-    np.random.shuffle(resort2)
+    rng.shuffle(resort1)
+    rng.shuffle(resort2)
     ar1 = np.asarray(ar1)[resort1]
     ar2 = np.asarray(ar2)[resort2]
 

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -25,19 +25,19 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2):
     cdef int N1 = ar1.shape[0]
     cdef int N2 = ar2.shape[0]
     cdef int data_dims = ar1.shape[1]
-    cdef unsigned int i, j, k, i_store, j_store, i_ret, j_ret
+    cdef unsigned int i, j, k
+    cdef unsigned int i_store, j_store, i_ret, j_ret = 0
     cdef long[:] resort1, resort2
 
     # shuffling the points in each array generally increases the likelihood of
     # an advantageous break in the inner search loop and never decreases the
     # performance of the algorithm
-    np.random.seed(123)
-    np.random.shuffle(np.asarray(ar1))
-    np.random.shuffle(np.asarray(ar2))
     resort1 = np.arange(N1)
     resort2 = np.arange(N2)
-    np.random.shuffle(np.asarray(resort1))
-    np.random.shuffle(np.asarray(resort2))
+    np.random.shuffle(resort1)
+    np.random.shuffle(resort2)
+    ar1 = np.asarray(ar1)[resort1]
+    ar2 = np.asarray(ar2)[resort2]
 
     cmax = 0
     for i in range(N1):

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -18,22 +18,20 @@ from libc.math cimport sqrt
 __all__ = ['directed_hausdorff']
 
 @cython.boundscheck(False)
-def directed_hausdorff(np.ndarray[np.float64_t, ndim =2] ar1,
-                       np.ndarray[np.float64_t, ndim =2] ar2):
+def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2):
 
-    cdef double cmax, cmin
+    cdef double cmax, cmin, d
     cdef int break_occurred
     cdef int N1 = ar1.shape[0]
     cdef int N2 = ar2.shape[0]
     cdef int data_dims = ar1.shape[1]
-    cdef np.float64_t d
     cdef unsigned int i, j, k
 
     # shuffling the points in each array generally increases the likelihood of
     # an advantageous break in the inner search loop and never decreases the
     # performance of the algorithm
-    np.random.shuffle(ar1)
-    np.random.shuffle(ar2)
+    np.random.shuffle(np.asarray(ar1))
+    np.random.shuffle(np.asarray(ar2))
 
     cmax = 0
     for i in range(N1):

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -53,12 +53,15 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
             if d < cmax: # early break
                 break_occurred += 1
                 break
+
             if d < cmin:
                 cmin = d
                 i_store = i
                 j_store = j
+
         if cmin > cmax and cmin != np.inf and break_occurred == 0:
             cmax = cmin
             i_ret = i_store
             j_ret = j_store
+
     return (sqrt(cmax), resort1[i_ret], resort2[j_ret])

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -49,7 +49,7 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
 	    # faster performance with square of distance
 	    # avoid sqrt until very end
             for k in range(data_dims):
-                d += (ar1[i, k] - ar2[j, k]) * (ar1[i, k] - ar2[j, k])
+                d += (ar1[i, k] - ar2[j, k])**2
             if d < cmax: # early break
                 break_occurred += 1
                 break

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -61,7 +61,7 @@ def directed_hausdorff(double[:,::1] ar1, double[:,::1] ar2, seed=0):
 
         # always true on first iteration of for-j loop, after that only
         # if d >= cmax
-        if cmin > cmax and no_break_occurred == True:
+        if cmin > cmax and cmin != np.inf and no_break_occurred == True:
             cmax = cmin
             i_ret = i_store
             j_ret = j_store

--- a/scipy/spatial/_hausdorff.pyx
+++ b/scipy/spatial/_hausdorff.pyx
@@ -1,0 +1,55 @@
+"""
+Directed Hausdorff Code
+
+.. versionadded:: 0.19.0
+
+"""
+#
+# Copyright (C)  Tyler Reddy and Richard Gowers, 2016
+#
+# Distributed under the same BSD license as Scipy.
+#
+
+import numpy as np
+cimport numpy as np
+cimport cython
+from libc.math cimport sqrt
+
+__all__ = ['directed_hausdorff']
+
+@cython.boundscheck(False)
+def directed_hausdorff(np.ndarray[np.float64_t, ndim =2] ar1,
+                       np.ndarray[np.float64_t, ndim =2] ar2):
+
+    cdef double cmax, cmin
+    cdef int break_occurred
+    cdef int N1 = ar1.shape[0]
+    cdef int N2 = ar2.shape[0]
+    cdef int data_dims = ar1.shape[1]
+    cdef np.float64_t d
+    cdef unsigned int i, j, k
+
+    # shuffling the points in each array generally increases the likelihood of
+    # an advantageous break in the inner search loop and never decreases the
+    # performance of the algorithm
+    np.random.shuffle(ar1)
+    np.random.shuffle(ar2)
+                                                                                                                                                                                                     
+    cmax = 0 
+    for i in range(N1):
+        break_occurred = 0
+        cmin = np.inf
+        for j in range(N2):
+            d = 0
+	    # faster performance with square of distance
+	    # avoid sqrt until very end
+            for k in range(data_dims):
+                d += (ar1[i, k] - ar2[j, k]) * (ar1[i, k] - ar2[j, k])
+            if d < cmax: # early break
+                break_occurred += 1
+                break
+            if d < cmin:
+                cmin = d
+        if cmin > cmax and cmin != np.inf and break_occurred == 0:
+            cmax = cmin
+    return sqrt(cmax)

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -150,7 +150,7 @@ def directed_hausdorff(u, v):
     """
     Computes the directed Hausdorff distance between two N-D arrays.
 
-    Distance between pairs are calculated using a Euclidean metric.
+    Distances between pairs are calculated using a Euclidean metric.
     
     Parameters
     ----------

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -161,8 +161,10 @@ def directed_hausdorff(u, v):
 
     Returns
     -------
-    d : float
-        The directed Hausdorff distance between arrays `u` and `v`.
+    out : tuple
+        The directed Hausdorff distance between arrays `u` and `v`,
+        followed by indices of the Hausdorff pair in `u` and `v`,
+        respectively.
 
     Notes
     ----------
@@ -201,22 +203,28 @@ def directed_hausdorff(u, v):
     ...               (-2.0, 0.0),
     ...               (0.0, -4.0)])
 
-    >>> directed_hausdorff(u, v)
+    >>> directed_hausdorff(u, v)[0]
     2.23606797749979
-    >>> directed_hausdorff(v, u)
+    >>> directed_hausdorff(v, u)[0]
     3.0
 
     Find the general (symmetric) Hausdorff distance between two 2-D
     arrays of coordinates:
 
-    >>> max(directed_hausdorff(u, v), directed_hausdorff(v, u))
+    >>> max(directed_hausdorff(u, v)[0], directed_hausdorff(v, u)[0])
     3.0
+
+    Find the indices of the points that generate the Hausdorff distance
+    (the Hausdorff pair):
+
+    >>> directed_hausdorff(v, u)[1:]
+    (3, 3)
 
     """
     u = np.asarray(u, dtype=np.float64, order='c')
     v = np.asarray(v, dtype=np.float64, order='c')
-    dist = _hausdorff.directed_hausdorff(u, v)
-    return dist
+    result = _hausdorff.directed_hausdorff(u, v)
+    return result
 
 def minkowski(u, v, p):
     """

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -146,7 +146,7 @@ def _validate_vector(u, dtype=None):
         raise ValueError("Input vector should be 1-D.")
     return u
 
-def directed_hausdorff(u, v):
+def directed_hausdorff(u, v, seed=0):
     """
     Computes the directed Hausdorff distance between two N-D arrays.
 
@@ -158,6 +158,9 @@ def directed_hausdorff(u, v):
         Input array.
     v : (O,N) ndarray
         Input array.
+    seed : int or None
+        Local `RandomState` seed. Deafult is 0, a random shuffling of
+        u and v that guarantees reproducibility.
 
     Returns
     -------
@@ -223,7 +226,7 @@ def directed_hausdorff(u, v):
     """
     u = np.asarray(u, dtype=np.float64, order='c')
     v = np.asarray(v, dtype=np.float64, order='c')
-    result = _hausdorff.directed_hausdorff(u, v)
+    result = _hausdorff.directed_hausdorff(u, v, seed)
     return result
 
 def minkowski(u, v, p):

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -148,11 +148,10 @@ def _validate_vector(u, dtype=None):
 
 def directed_hausdorff(u, v):
     """
-    Computes the directed Hausdorff distance between N-dimensional
-    point sets using a Euclidean metric.
-    
-    .. versionadded:: 0.19.0
+    Computes the directed Hausdorff distance between two N-D arrays.
 
+    Distance between pairs are calculated using a Euclidean metric.
+    
     Parameters
     ----------
     u : (M,N) ndarray
@@ -162,50 +161,57 @@ def directed_hausdorff(u, v):
 
     Returns
     -------
-    d : double
+    d : float
         The directed Hausdorff distance between arrays `u` and `v`.
 
     Notes
     ----------
-    Uses the early break technique and the random sampling approach described
-    by [Taha2015]_. Although worst-case performance is polynomial (as with the
-    brute force algorithm), this is exceedingly unlikely in practice, and
-    almost-linear time complexity performance can normally be expected for the
-    average case.
+    Uses the early break technique and the random sampling approach
+    described by [1]_. Although worst-case performance is polynomial
+    (as with the brute force algorithm), this is exceedingly unlikely
+    in practice, and almost-linear time complexity performance can
+    normally be expected for the average case.
+
+    .. versionadded:: 0.19.0
 
     References
     ----------
-    
-    .. [Taha2015] Taha and Hanbury (2015) An efficient algorithm
-                          for calculating the exact Hausdorff distance.
-                          IEEE Transactions On Pattern Analysis And
-                          Machine Intelligence 37: 2153-63. 
+
+    .. [1] A. A. Taha and A. Hanbury, "An efficient algorithm for
+       calculating the exact Hausdorff distance." IEEE Transactions On
+       Pattern Analysis And Machine Intelligence, vol. 37 pp. 2153-63,
+       2015.
 
     Examples
     --------
-    Find the directed Hausdorff distance between
-    two 2-D arrays of coordinates:
+    Find the directed Hausdorff distance between two 2-D arrays of
+    coordinates:
 
     >>> from scipy.spatial.distance import directed_hausdorff
-    >>> u = np.array([(35.0456, -85.2672),
-    ...               (35.1174, -89.9711),
-    ...               (35.9728, -83.9422)])
-    >>> v = np.array([(22.0456, 12.2672),
-    ...               (95.1174, 89.9711),
-    ...               (5.4567, 4.9422)])
-    >>> directed_hausdorff(u,v)
-    99.43988958853485
+    >>> u = np.array([(1.0, 0.0),
+    ...               (0.0, 1.0),
+    ...               (-1.0, 0.0),
+    ...               (0.0, -1.0)])
+    >>> v = np.array([(2.0, 0.0),
+    ...               (0.0, 2.0),
+    ...               (-2.0, 0.0),
+    ...               (0.0, -4.0)])
 
-    Find the general (symmetric) Hausdorff
-    distance between two 2-D arrays of 
-    coordinates:
-    
-    >>> max(directed_hausdorff(u,v),
-            directed_hausdorff(v,u))
-    183.69518128151867
+    >>> directed_hausdorff(u, v)
+    2.23606797749979
+    >>> directed_hausdorff(v, u)
+    3.0
+
+    Find the general (symmetric) Hausdorff distance between two 2-D
+    arrays of coordinates:
+
+    >>> max(directed_hausdorff(u, v), directed_hausdorff(v, u))
+    3.0
 
     """
-    dist = _hausdorff.directed_hausdorff(u,v)
+    u = np.asarray(u, dtype=np.float64, order='c')
+    v = np.asarray(v, dtype=np.float64, order='c')
+    dist = _hausdorff.directed_hausdorff(u, v)
     return dist
 
 def minkowski(u, v, p):

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -17,6 +17,7 @@ stored in a rectangular array.
    pdist   -- pairwise distances between observation vectors.
    cdist   -- distances between two collections of observation vectors
    squareform -- convert distance matrix to a condensed one and vice versa
+   directed_hausdorff -- directed Hausdorff distance between arrays
 
 Predicates for checking the validity of distance matrices, both
 condensed and redundant. Also contained in this module are functions
@@ -84,6 +85,7 @@ __all__ = [
     'correlation',
     'cosine',
     'dice',
+    'directed_hausdorff',
     'euclidean',
     'hamming',
     'is_valid_dm',
@@ -115,8 +117,8 @@ from scipy._lib.six import callable, string_types
 from scipy._lib.six import xrange
 
 from . import _distance_wrap
+from . import _hausdorff
 from ..linalg import norm
-
 
 def _copy_array_if_base_present(a):
     """
@@ -144,6 +146,67 @@ def _validate_vector(u, dtype=None):
         raise ValueError("Input vector should be 1-D.")
     return u
 
+def directed_hausdorff(u, v):
+    """
+    Computes the directed Hausdorff distance between N-dimensional
+    point sets using a Euclidean metric.
+    
+    .. versionadded:: 0.19.0
+
+    Parameters
+    ----------
+    u : (M,N) ndarray
+        Input array.
+    v : (O,N) ndarray
+        Input array.
+
+    Returns
+    -------
+    d : double
+        The directed Hausdorff distance between arrays `u` and `v`.
+
+    Notes
+    ----------
+    Uses the early break technique and the random sampling approach described
+    by [Taha2015]_. Although worst-case performance is polynomial (as with the
+    brute force algorithm), this is exceedingly unlikely in practice, and
+    almost-linear time complexity performance can normally be expected for the
+    average case.
+
+    References
+    ----------
+    
+    .. [Taha2015] Taha and Hanbury (2015) An efficient algorithm
+                          for calculating the exact Hausdorff distance.
+                          IEEE Transactions On Pattern Analysis And
+                          Machine Intelligence 37: 2153-63. 
+
+    Examples
+    --------
+    Find the directed Hausdorff distance between
+    two 2-D arrays of coordinates:
+
+    >>> from scipy.spatial.distance import directed_hausdorff
+    >>> u = np.array([(35.0456, -85.2672),
+    ...               (35.1174, -89.9711),
+    ...               (35.9728, -83.9422)])
+    >>> v = np.array([(22.0456, 12.2672),
+    ...               (95.1174, 89.9711),
+    ...               (5.4567, 4.9422)])
+    >>> directed_hausdorff(u,v)
+    99.43988958853485
+
+    Find the general (symmetric) Hausdorff
+    distance between two 2-D arrays of 
+    coordinates:
+    
+    >>> max(directed_hausdorff(u,v),
+            directed_hausdorff(v,u))
+    183.69518128151867
+
+    """
+    dist = _hausdorff.directed_hausdorff(u,v)
+    return dist
 
 def minkowski(u, v, p):
     """

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -167,10 +167,14 @@ def directed_hausdorff(u, v):
     Notes
     ----------
     Uses the early break technique and the random sampling approach
-    described by [1]_. Although worst-case performance is polynomial
-    (as with the brute force algorithm), this is exceedingly unlikely
-    in practice, and almost-linear time complexity performance can
-    normally be expected for the average case.
+    described by [1]_. Although worst-case performance is O(m * o)
+    (as with the brute force algorithm), this is unlikely in practice
+    as the input data would have to require the algorithm to explore
+    every single point interaction, and after the algorithm shuffles
+    the input points at that. The best case performance is O(m), which
+    is satisfied by selecting an inner loop distance that is less than
+    cmax and leads to an early break as often as possible. The authors
+    have formally shown that the average runtime is closer to O(m).
 
     .. versionadded:: 0.19.0
 

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -159,20 +159,24 @@ def directed_hausdorff(u, v, seed=0):
     v : (O,N) ndarray
         Input array.
     seed : int or None
-        Local `RandomState` seed. Deafult is 0, a random shuffling of
+        Local `np.random.RandomState` seed. Default is 0, a random shuffling of
         u and v that guarantees reproducibility.
 
     Returns
     -------
-    out : tuple
+    d : double
         The directed Hausdorff distance between arrays `u` and `v`,
-        followed by indices of the Hausdorff pair in `u` and `v`,
-        respectively.
+
+    index_1 : int
+        index of point contributing to Hausdorff pair in `u`
+
+    index_2 : int
+        index of point contributing to Hausdorff pair in `v`
 
     Notes
-    ----------
+    -----
     Uses the early break technique and the random sampling approach
-    described by [1]_. Although worst-case performance is O(m * o)
+    described by [1]_. Although worst-case performance is ``O(m * o)``
     (as with the brute force algorithm), this is unlikely in practice
     as the input data would have to require the algorithm to explore
     every single point interaction, and after the algorithm shuffles
@@ -185,11 +189,10 @@ def directed_hausdorff(u, v, seed=0):
 
     References
     ----------
-
     .. [1] A. A. Taha and A. Hanbury, "An efficient algorithm for
-       calculating the exact Hausdorff distance." IEEE Transactions On
-       Pattern Analysis And Machine Intelligence, vol. 37 pp. 2153-63,
-       2015.
+           calculating the exact Hausdorff distance." IEEE Transactions On
+           Pattern Analysis And Machine Intelligence, vol. 37 pp. 2153-63,
+           2015.
 
     Examples
     --------

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -82,6 +82,9 @@ def configuration(parent_package='', top_path=None):
     config.add_extension('_voronoi',
                          sources=['_voronoi.c'])
 
+    config.add_extension('_hausdorff',
+                         sources=['_hausdorff.c'])
+
     return config
 
 if __name__ == '__main__':

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -3,7 +3,6 @@ from numpy.testing import (TestCase,
                            assert_almost_equal,
                            assert_array_equal,
                            assert_equal)
-import scipy
 from scipy.spatial.distance import directed_hausdorff
 from scipy.spatial import distance
 from scipy._lib._util import check_random_state
@@ -30,12 +29,6 @@ class TestHausdorff(TestCase):
         self.path_1_4d = np.insert(self.path_1, 3, 5, axis=1)
         self.path_2_4d = np.insert(self.path_2, 3, 27, axis=1)
 
-    def tearDown(self):
-        del self.path_1
-        del self.path_2
-        del self.path_1_4d
-        del self.path_2_4d
-
     def test_symmetry(self):
         # Ensure that the directed (asymmetric) Hausdorff distance is
         # actually asymmetric
@@ -46,7 +39,7 @@ class TestHausdorff(TestCase):
 
     def test_brute_force_comparison_forward(self):
         # Ensure that the algorithm for directed_hausdorff gives the
-        # sameresult as the simple / brute force approach in the
+        # same result as the simple / brute force approach in the
         # forward direction.
         actual = directed_hausdorff(self.path_1, self.path_2)[0]
         # brute force over rows:
@@ -108,23 +101,13 @@ class TestHausdorff(TestCase):
         new_global_state = rs2.get_state()
         assert_equal(new_global_state, old_global_state)
 
-    def test_random_state_None(self):
-        # check that a seed value of None does not alter global random
-        # state
-        rs = check_random_state(None)
-        old_global_state = rs.get_state()
-        directed_hausdorff(self.path_1, self.path_2, None)
-        rs2 = check_random_state(None)
-        new_global_state = rs2.get_state()
-        assert_equal(new_global_state, old_global_state)
-
-    def test_random_state_int(self):
-        # check that a seed value of int does not alter global random
-        # state
-        integer = 27870671
-        rs = check_random_state(None)
-        old_global_state = rs.get_state()
-        directed_hausdorff(self.path_1, self.path_2, integer)
-        rs2 = check_random_state(None)
-        new_global_state = rs2.get_state()
-        assert_equal(new_global_state, old_global_state)
+    def test_random_state_None_int(self):
+        # check that seed values of None or int do not alter global
+        # random state
+        for seed in [None, 27870671]:
+            rs = check_random_state(None)
+            old_global_state = rs.get_state()
+            directed_hausdorff(self.path_1, self.path_2, seed)
+            rs2 = check_random_state(None)
+            new_global_state = rs2.get_state()
+            assert_equal(new_global_state, old_global_state)

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -90,8 +90,8 @@ class TestHausdorff(TestCase):
     def test_indices(self):
         # Ensure that correct point indices are returned -- they should
         # correspond to the Hausdorff pair
-        path_simple_1 = np.array([[0,0], [1,1]])
-        path_simple_2 = np.array([[0,0], [1,1], [4,100]])
+        path_simple_1 = np.array([[-1,-12],[0,0], [1,1], [3,7], [1,2]])
+        path_simple_2 = np.array([[0,0], [1,1], [4,100], [10,9]])
         actual = directed_hausdorff(path_simple_2, path_simple_1)[1:]
-        expected = (2, 1)
+        expected = (2, 3)
         assert_array_equal(actual, expected)

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -1,0 +1,98 @@
+import numpy as np
+from numpy.testing import (TestCase,
+                           assert_almost_equal)
+import scipy
+from scipy.spatial.distance import directed_hausdorff
+
+class TestHausdorff(TestCase):
+    '''Test various properties of the directed Hausdorff code.'''
+   
+    def setUp(self):
+        self.random_angles = np.random.random((100,)) * np.pi * 2
+        self.random_columns = np.column_stack((self.random_angles,
+                                               self.random_angles,
+                                               np.zeros((100,))))
+        self.random_columns[...,0] = np.cos(self.random_columns[...,0])
+        self.random_columns[...,1] = np.sin(self.random_columns[...,1])
+        self.random_columns_2 = np.column_stack((self.random_angles,
+                                                 self.random_angles,
+                                                 np.zeros((100,))))
+        self.random_columns_2[1:,0] = np.cos(self.random_columns_2[1:,0]) * 2.0
+        self.random_columns_2[1:,1] = np.sin(self.random_columns_2[1:,1]) * 2.0
+        # move one point farther out so we don't have two perfect circles
+        self.random_columns_2[0,0] = np.cos(self.random_columns_2[0,0]) * 3.3
+        self.random_columns_2[0,1] = np.sin(self.random_columns_2[0,1]) * 3.3
+        self.path_1 = self.random_columns
+        self.path_2 = self.random_columns_2
+        self.path_1_4d = np.insert(self.path_1, 3, 5, axis = 1)
+        self.path_2_4d = np.insert(self.path_2, 3, 27, axis = 1)
+
+    def tearDown(self):
+        del self.random_angles
+        del self.random_columns
+        del self.random_columns_2
+        del self.path_1
+        del self.path_2
+        del self.path_1_4d
+        del self.path_2_4d
+
+    def test_symmetry(self):
+        '''Ensure that the directed (asymmetric)
+        Hausdorff distance is actually asymmetric
+        '''
+        forward = directed_hausdorff(self.path_1, self.path_2)
+        reverse = directed_hausdorff(self.path_2, self.path_1)
+        self.assertNotEqual(forward, reverse)
+
+    def test_brute_force_comparison_forward(self):
+        '''Ensure that the algorithm for 
+        directed_hausdorff gives the same
+        result as the simple / brute force
+        approach in the forward direction.'''
+        actual = directed_hausdorff(self.path_1, self.path_2)   
+        # brute force over rows:
+        expected = max(np.amin(scipy.spatial.distance.cdist(self.path_1,
+                                                            self.path_2), 
+                                                            axis = 1))
+        assert_almost_equal(actual, expected, decimal=9)
+
+    def test_brute_force_comparison_reverse(self):
+        '''Ensure that the algorithm for 
+        directed_hausdorff gives the same
+        result as the simple / brute force
+        approach in the reverse direction.'''
+        actual = directed_hausdorff(self.path_2, self.path_1)
+        # brute force over columns:
+        expected = max(np.amin(scipy.spatial.distance.cdist(self.path_1,
+                                                            self.path_2), 
+                                                            axis = 0))
+        assert_almost_equal(actual, expected, decimal=9)
+
+    def test_degenerate_case(self):
+        '''The directed Hausdorff distance must be zero
+        if both input data arrays match.'''
+        actual = directed_hausdorff(self.path_1, self.path_1)
+        assert_almost_equal(actual, 0.0, decimal=9)
+
+    def test_2d_data_forward(self):
+        '''Ensure that 2D data is handled
+        properly for a simple case relative
+        to brute force approach.'''
+        actual = directed_hausdorff(self.path_1[...,:2],
+                                    self.path_2[...,:2])
+        expected = max(np.amin(scipy.spatial.distance.cdist(
+                                                      self.path_1[...,:2],
+                                                      self.path_2[...,:2]), 
+                                                      axis = 1))
+        assert_almost_equal(actual, expected, decimal=9)
+
+    def test_4d_data_reverse(self):
+        '''Ensure that 4D data is handled
+        properly for a simple case relative
+        to brute force approach.'''
+        actual = directed_hausdorff(self.path_2_4d, self.path_1_4d)
+        # brute force over columns:
+        expected = max(np.amin(scipy.spatial.distance.cdist(self.path_1_4d,
+                                                            self.path_2_4d), 
+                                                            axis = 0))
+        assert_almost_equal(actual, expected, decimal=9)

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -1,10 +1,12 @@
 import numpy as np
 from numpy.testing import (TestCase,
                            assert_almost_equal,
-                           assert_array_equal)
+                           assert_array_equal,
+                           assert_equal)
 import scipy
 from scipy.spatial.distance import directed_hausdorff
 from scipy.spatial import distance
+from scipy._lib._util import check_random_state
 
 class TestHausdorff(TestCase):
     # Test various properties of the directed Hausdorff code.
@@ -95,3 +97,13 @@ class TestHausdorff(TestCase):
         actual = directed_hausdorff(path_simple_2, path_simple_1)[1:]
         expected = (2, 3)
         assert_array_equal(actual, expected)
+
+    def test_random_state(self):
+        # ensure that the global random state is not modified because
+        # the directed Hausdorff algorithm uses randomization
+        rs = check_random_state(None)
+        old_global_state = rs.get_state()
+        directed_hausdorff(self.path_1, self.path_2)
+        rs2 = check_random_state(None)
+        new_global_state = rs2.get_state()
+        assert_equal(new_global_state, old_global_state)

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -107,3 +107,24 @@ class TestHausdorff(TestCase):
         rs2 = check_random_state(None)
         new_global_state = rs2.get_state()
         assert_equal(new_global_state, old_global_state)
+
+    def test_random_state_None(self):
+        # check that a seed value of None does not alter global random
+        # state
+        rs = check_random_state(None)
+        old_global_state = rs.get_state()
+        directed_hausdorff(self.path_1, self.path_2, None)
+        rs2 = check_random_state(None)
+        new_global_state = rs2.get_state()
+        assert_equal(new_global_state, old_global_state)
+
+    def test_random_state_int(self):
+        # check that a seed value of int does not alter global random
+        # state
+        integer = 27870671
+        rs = check_random_state(None)
+        old_global_state = rs.get_state()
+        directed_hausdorff(self.path_1, self.path_2, integer)
+        rs2 = check_random_state(None)
+        new_global_state = rs2.get_state()
+        assert_equal(new_global_state, old_global_state)

--- a/scipy/spatial/tests/test_hausdorff.py
+++ b/scipy/spatial/tests/test_hausdorff.py
@@ -3,96 +3,85 @@ from numpy.testing import (TestCase,
                            assert_almost_equal)
 import scipy
 from scipy.spatial.distance import directed_hausdorff
+from scipy.spatial import distance
 
 class TestHausdorff(TestCase):
-    '''Test various properties of the directed Hausdorff code.'''
-   
+    # Test various properties of the directed Hausdorff code.
+
     def setUp(self):
-        self.random_angles = np.random.random((100,)) * np.pi * 2
-        self.random_columns = np.column_stack((self.random_angles,
-                                               self.random_angles,
-                                               np.zeros((100,))))
-        self.random_columns[...,0] = np.cos(self.random_columns[...,0])
-        self.random_columns[...,1] = np.sin(self.random_columns[...,1])
-        self.random_columns_2 = np.column_stack((self.random_angles,
-                                                 self.random_angles,
-                                                 np.zeros((100,))))
-        self.random_columns_2[1:,0] = np.cos(self.random_columns_2[1:,0]) * 2.0
-        self.random_columns_2[1:,1] = np.sin(self.random_columns_2[1:,1]) * 2.0
+        np.random.seed(1234)
+        random_angles = np.random.random(100) * np.pi * 2
+        random_columns = np.column_stack(
+            (random_angles, random_angles, np.zeros(100)))
+        random_columns[..., 0] = np.cos(random_columns[..., 0])
+        random_columns[..., 1] = np.sin(random_columns[..., 1])
+        random_columns_2 = np.column_stack(
+            (random_angles, random_angles, np.zeros(100)))
+        random_columns_2[1:, 0] = np.cos(random_columns_2[1:, 0]) * 2.0
+        random_columns_2[1:, 1] = np.sin(random_columns_2[1:, 1]) * 2.0
         # move one point farther out so we don't have two perfect circles
-        self.random_columns_2[0,0] = np.cos(self.random_columns_2[0,0]) * 3.3
-        self.random_columns_2[0,1] = np.sin(self.random_columns_2[0,1]) * 3.3
-        self.path_1 = self.random_columns
-        self.path_2 = self.random_columns_2
-        self.path_1_4d = np.insert(self.path_1, 3, 5, axis = 1)
-        self.path_2_4d = np.insert(self.path_2, 3, 27, axis = 1)
+        random_columns_2[0, 0] = np.cos(random_columns_2[0, 0]) * 3.3
+        random_columns_2[0, 1] = np.sin(random_columns_2[0, 1]) * 3.3
+        self.path_1 = random_columns
+        self.path_2 = random_columns_2
+        self.path_1_4d = np.insert(self.path_1, 3, 5, axis=1)
+        self.path_2_4d = np.insert(self.path_2, 3, 27, axis=1)
 
     def tearDown(self):
-        del self.random_angles
-        del self.random_columns
-        del self.random_columns_2
         del self.path_1
         del self.path_2
         del self.path_1_4d
         del self.path_2_4d
 
     def test_symmetry(self):
-        '''Ensure that the directed (asymmetric)
-        Hausdorff distance is actually asymmetric
-        '''
+        # Ensure that the directed (asymmetric) Hausdorff distance is
+        # actually asymmetric
+
         forward = directed_hausdorff(self.path_1, self.path_2)
         reverse = directed_hausdorff(self.path_2, self.path_1)
         self.assertNotEqual(forward, reverse)
 
     def test_brute_force_comparison_forward(self):
-        '''Ensure that the algorithm for 
-        directed_hausdorff gives the same
-        result as the simple / brute force
-        approach in the forward direction.'''
-        actual = directed_hausdorff(self.path_1, self.path_2)   
+        # Ensure that the algorithm for directed_hausdorff gives the
+        # sameresult as the simple / brute force approach in the
+        # forward direction.
+        actual = directed_hausdorff(self.path_1, self.path_2)
         # brute force over rows:
-        expected = max(np.amin(scipy.spatial.distance.cdist(self.path_1,
-                                                            self.path_2), 
-                                                            axis = 1))
+        expected = max(np.amin(distance.cdist(self.path_1, self.path_2),
+                               axis=1))
         assert_almost_equal(actual, expected, decimal=9)
 
     def test_brute_force_comparison_reverse(self):
-        '''Ensure that the algorithm for 
-        directed_hausdorff gives the same
-        result as the simple / brute force
-        approach in the reverse direction.'''
+        # Ensure that the algorithm for directed_hausdorff gives the
+        # same result as the simple / brute force approach in the
+        # reverse direction.
         actual = directed_hausdorff(self.path_2, self.path_1)
         # brute force over columns:
-        expected = max(np.amin(scipy.spatial.distance.cdist(self.path_1,
-                                                            self.path_2), 
-                                                            axis = 0))
+        expected = max(np.amin(distance.cdist(self.path_1, self.path_2), 
+                               axis=0))
         assert_almost_equal(actual, expected, decimal=9)
 
     def test_degenerate_case(self):
-        '''The directed Hausdorff distance must be zero
-        if both input data arrays match.'''
+        # The directed Hausdorff distance must be zero if both input
+        # data arrays match.
         actual = directed_hausdorff(self.path_1, self.path_1)
         assert_almost_equal(actual, 0.0, decimal=9)
 
     def test_2d_data_forward(self):
-        '''Ensure that 2D data is handled
-        properly for a simple case relative
-        to brute force approach.'''
-        actual = directed_hausdorff(self.path_1[...,:2],
-                                    self.path_2[...,:2])
-        expected = max(np.amin(scipy.spatial.distance.cdist(
-                                                      self.path_1[...,:2],
-                                                      self.path_2[...,:2]), 
-                                                      axis = 1))
+        # Ensure that 2D data is handled properly for a simple case
+        # relative to brute force approach.
+        actual = directed_hausdorff(self.path_1[..., :2],
+                                    self.path_2[..., :2])
+        expected = max(np.amin(distance.cdist(self.path_1[..., :2],
+                                              self.path_2[..., :2]),
+                               axis=1))
         assert_almost_equal(actual, expected, decimal=9)
 
     def test_4d_data_reverse(self):
-        '''Ensure that 4D data is handled
-        properly for a simple case relative
-        to brute force approach.'''
+        # Ensure that 4D data is handled properly for a simple case
+        # relative to brute force approach.
         actual = directed_hausdorff(self.path_2_4d, self.path_1_4d)
         # brute force over columns:
-        expected = max(np.amin(scipy.spatial.distance.cdist(self.path_1_4d,
-                                                            self.path_2_4d), 
-                                                            axis = 0))
+        expected = max(np.amin(distance.cdist(self.path_1_4d, self.path_2_4d), 
+                               axis=0))
         assert_almost_equal(actual, expected, decimal=9)


### PR DESCRIPTION
### Background

This PR aims to implement a fast algorithm for the [Hausdorff distance](https://en.wikipedia.org/wiki/Hausdorff_distance), which is used in a variety of scientific fields including computer vision ([Huttenlocher et al. (1993)](https://www.google.co.uk/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&ved=0ahUKEwiL9Peb0LzPAhWLBsAKHdVWDsIQFggjMAA&url=https%3A%2F%2Fwww.cs.cornell.edu%2F~dph%2Fpapers%2FHKR-TPAMI-93.pdf&usg=AFQjCNFXidN3QOnPbRF-wsQdmE1rrZk96A&sig2=NukZj6cI0cUNZ5Ex7TyArg)), computer graphics, path similarity analysis ([Seyler et al. (2015)](http://dx.doi.org/10.1371/journal.pcbi.1004568)), and many others.

The concept is perhaps most clearly explained with a simple example of two 2-D point sets (or paths) that are being compared:
![hausdorff](https://cloud.githubusercontent.com/assets/7903078/19022298/2dbef0a8-88cd-11e6-82bc-54777d1892cd.png)

The **directed** Hausdorff distance is effectively the maximum closest distance between a point in one data set and a point in the other. So, from path 1 to path 2 the **directed** Hausdorff distance is very close to 1.0, because all points on that inner circle will never have a closest distance to a point in the outer data set that is much greater than that (the outlier in path 2 is never closest to a point in path 1). 

Conversely, the **directed** Hausdorff distance from path 2 to path 1 is much greater than 1.0 because the outlier will have a minimum distance to a point in path 1 that is quite large.

This asymmetric property of the **directed** Hausdorff distance is typical of "maximini" functions, but it is important to note that it far more common for an end user to be interested in the **symmetric** or undirected Hausdorff distance. The reason I'm proposing to implement `directed_hausdorff` is because it has its own specific uses in some cases, and it is more general -- you can use it twice to calculate the symmetric (general) Hausdorff as follows: 

```
d (symmetric) = max ( d (directed a->b) , d (directed b->a))
```

Which was indeed one of the docstring examples I wrote.
### Implementation Details

There are relatively straightforward brute force approaches to calculating the **directed** Hausdorff distance using scientific Python:

``` python
def directed_hausdorff_brute_force(u, v):
    return max(np.amin(scipy.spatial.distance.cdist(u,v), axis = 1))
```

However, the above approach obviously has polynomial time complexity -- you have to calculate all possible distances. As discussed by [Taha and Hanbury (2015)](http://publik.tuwien.ac.at/files/PubDat_247739.pdf), you can write an algorithm that (on average) performs far better, by incorporating a break into the distance calculation and shuffling the input data to increase the likelihood of a performance-boosting inner loop break. That is the approach I've used here for `scipy.spatial.distance.directed_hausdorff`, so let's see how it performs compared to the competition.
### Benchmarking and Python Competitors

There is a Python implementation of the symmetric Hausdorff distance in [MDAnalysis](https://github.com/MDAnalysis/mdanalysis/blob/develop/package/MDAnalysis/analysis/psa.py#L340) (another project I work on), and I was actually writing unit tests for that when I thought about how efficient it actually was, and whether we really want multiple python libraries trying to reimplement this. Let's see how brute force approaches, the MDAnalysis algorithm (adapted to the **directed** calculation), and the Cython version I've written (with some helpful feedback from others) compare. There's a fourth condition where the innermost loop has been hardcoded (on the assumption that only 3D data is handled -- so it has an advantage over my general implementation proposed here).

![hausdorff_bench](https://cloud.githubusercontent.com/assets/7903078/19022397/dce6ca04-88cf-11e6-8116-e4d1e7d6e7cd.png)

And zooming in for the competing Cython implementations I've written:

![hausdorff_bench_zoom](https://cloud.githubusercontent.com/assets/7903078/19022435/cdb6b944-88d0-11e6-9c80-a2750ceb2d4a.png)

Remember that there is a stochastic component to the performance (whether the inner loop breaks often) -- which may partly explain the roughness in places.

I'm not sure whether you think it might be worth hardcoding the square distance calculation loop for say 3 to 5 dimensional (column) data and falling back to the loop for higher (less common) dimensions. For now I've just left it in the more general (and perhaps arguably more maintainable) form that iterates through columns / dimensions.

Reference: [Jupyter notebook with benchmarking code](https://github.com/tylerjereddy/hausdorff_bench/blob/master/hausdorff_bench.ipynb)

The only other Python implementation I know of is the [medpy Hausdorff distance code](http://pythonhosted.org/MedPy/generated/medpy.metric.binary.hd.html) -- though it appears to be using a brute force approach, I can't say for sure based on initial inspection.

You can easily find stack overflow questions where users are [interested in using python to calculate the Hausdorff distance](http://stackoverflow.com/q/30706079) and the answers suggest there's no easy way to do this in scientific python.
### Considerations

Of course, I still have to link this to the mailing list to see if the community is actually interested -- will do that shortly. This is my first de novo Cython module, so you may find some things you don't like in there. My integration into the rather large `distance.py` is sure to require at least a minor revision -- I know I don't do the same checks on the input data arrays that most other scipy distance calculations seem to do -- they have to be `np.ndarray` or else at the moment!

It is also worth considering that the scipy distance design is very modular, and allows for say 'euclidean' to be switched with many other distance metrics for a given function. The same could be done for `directed_hausdorff` -- it is currently only dealing with Euclidean, but perhaps that is the more obvious case at the moment and we might just sensibly leave the door open to other metrics (any valid norm would be possible in theory).
