### PR TITLE
ENH: Add standard deviation of welch

### DIFF
--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -220,11 +220,12 @@ class TestWelch(TestCase):
         x = np.zeros(16)
         x[0] = 1
         x[8] = 1
-        f, p = welch(x, nperseg=8)
+        f, p, s = welch(x, nperseg=8, return_std=True)
         assert_allclose(f, np.linspace(0, 0.5, 5))
         q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
                       0.11111111])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        assert_allclose(s, [0., 0.157, 0.314, 0.314, 0.157], atol=1e-2)
 
     def test_real_onesided_odd(self):
         x = np.zeros(16)


### PR DESCRIPTION
This adds standard deviation output for `scipy.signal.welch` and related functions. Can be useful for getting confidence intervals from the method.
