### PR TITLE
Faster/shorter code for computation of discordances

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -164,6 +164,7 @@ Surhud More for enhancing scipy.optimize.curve_fit to accept covariant errors
 on data.
 Antonio Ribeiro for implementing irrnotch and iirpeak functions.
 Ilhan Polat for bug fixes on Riccati solvers.
+Sebastiano Vigna for code in the stats package related to Kendall's tau.
 
 Institutions
 ------------

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -71,26 +71,21 @@ def von_mises_cdf(k_obj, x_obj):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def _kendall_condis(intp_t[:] x, intp_t[:] y):
+def _kendall_dis(intp_t[:] x, intp_t[:] y):
     cdef:
         intp_t sup = 1 + np.max(y)
         intp_t[::1] arr = np.zeros(sup, dtype=np.intp)
         intp_t i = 0, k = 0, size = x.size, idx
-        int64_t con = 0, dis = 0
+        int64_t dis = 0
 
     with nogil:
         while i < size:
             while k < size and x[i] == x[k]:
-                idx = y[k] - 1
-                while idx != 0:
-                    con += arr[idx]
-                    idx -= idx & -idx
-
                 dis += i
                 idx = y[k]
                 while idx != 0:
                     dis -= arr[idx]
-                    idx -= idx & -idx
+                    idx = idx & (idx - 1)
 
                 k += 1
 
@@ -101,4 +96,4 @@ def _kendall_condis(intp_t[:] x, intp_t[:] y):
                     idx += idx & -idx
                 i += 1
 
-    return con, dis
+    return dis

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3442,8 +3442,8 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     Kendall's tau is a measure of the correspondence between two rankings.
     Values close to 1 indicate strong agreement, values close to -1 indicate
     strong disagreement.  This is the 1945 "tau-b" version of Kendall's
-    tau, which can accounts for ties and which reduces to the 1938 "tau-a"
-    version in absence of ties.
+    tau [2], which can accounts for ties and which reduces to the 1938 "tau-a"
+    version [1] in absence of ties.
 
     Parameters
     ----------
@@ -3485,14 +3485,15 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
 
     References
     ----------
-    Maurice G. Kendall, "A New Measure of Rank Correlation", Biometrika
+    [1] Maurice G. Kendall, "A New Measure of Rank Correlation", Biometrika
     Vol. 30, No. 1/2, pp. 81-93, 1938.
-    Maurice G. Kendall, "The treatment of ties in ranking problems",
+    [2] Maurice G. Kendall, "The treatment of ties in ranking problems",
     Biometrika Vol. 33, No. 3, pp. 239-251. 1945.
-    Gottfried E. Noether, "Elements of Nonparametric Statistics", John Wiley &
-    Sons, 1967.
-    Peter M. Fenwick, "A new data structure for cumulative frequency tables",
-    Software: Practice and Experience, Vol. 24, No. 3, pp. 327-336, 1994.
+    [3] Gottfried E. Noether, "Elements of Nonparametric Statistics", John 
+    Wiley & Sons, 1967.
+    [4] Peter M. Fenwick, "A new data structure for cumulative frequency 
+    tables", Software: Practice and Experience, Vol. 24, No. 3, pp. 327-336,
+    1994.
 
     Examples
     --------
@@ -3561,8 +3562,11 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     if xtie == tot or ytie == tot:
         return KendalltauResult(np.nan, np.nan)
 
+    # Note that the numerator gives exactly concordances minus discordances
+    tau = (tot - xtie - ytie + ntie
+        - 2 * dis) / np.sqrt(tot - xtie) / np.sqrt(tot - ytie)
     # Limit range to fix computational errors
-    tau = min(1., max(-1., (tot - xtie - ytie + ntie - 2 * dis) / np.sqrt(tot - xtie) / np.sqrt(tot - ytie)))
+    tau = min(1., max(-1., tau))
 
     # what follows reproduces the ending of Gary Strangman's original
     # stats.kendalltau() in SciPy

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3560,7 +3560,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     tot = (size * (size - 1)) // 2
 
     if xtie == tot or ytie == tot:
-         return KendalltauResult(np.nan, np.nan)
+        return KendalltauResult(np.nan, np.nan)
 
     # Limit range to fix computational errors
     tau = min(1., max(-1., (tot - xtie - ytie + ntie - 2 * dis) / np.sqrt(tot - xtie) / np.sqrt(tot - ytie)))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3562,7 +3562,8 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     if xtie == tot or ytie == tot:
         return KendalltauResult(np.nan, np.nan)
 
-    # Note that the numerator gives exactly concordances minus discordances
+    # Note that tot = con + dis + (xtie - ntie) + (ytie - ntie) + ntie
+    #               = con + dis + xtie + ytie - ntie
     tau = (tot - xtie - ytie + ntie
         - 2 * dis) / np.sqrt(tot - xtie) / np.sqrt(tot - ytie)
     # Limit range to fix computational errors

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3442,8 +3442,8 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     Kendall's tau is a measure of the correspondence between two rankings.
     Values close to 1 indicate strong agreement, values close to -1 indicate
     strong disagreement.  This is the 1945 "tau-b" version of Kendall's
-    tau [2], which can accounts for ties and which reduces to the 1938 "tau-a"
-    version [1] in absence of ties.
+    tau [2]_, which can accounts for ties and which reduces to the 1938 "tau-a"
+    version [1]_ in absence of ties.
 
     Parameters
     ----------
@@ -3474,7 +3474,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
 
     Notes
     -----
-    The definition of Kendall's tau that is used is::
+    The definition of Kendall's tau that is used is [2]_::
 
       tau = (P - Q) / sqrt((P + Q + T) * (P + Q + U))
 
@@ -3485,13 +3485,13 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
 
     References
     ----------
-    [1] Maurice G. Kendall, "A New Measure of Rank Correlation", Biometrika
+    .. [1] Maurice G. Kendall, "A New Measure of Rank Correlation", Biometrika
     Vol. 30, No. 1/2, pp. 81-93, 1938.
-    [2] Maurice G. Kendall, "The treatment of ties in ranking problems",
+    .. [2] Maurice G. Kendall, "The treatment of ties in ranking problems",
     Biometrika Vol. 33, No. 3, pp. 239-251. 1945.
-    [3] Gottfried E. Noether, "Elements of Nonparametric Statistics", John 
+    .. [3] Gottfried E. Noether, "Elements of Nonparametric Statistics", John
     Wiley & Sons, 1967.
-    [4] Peter M. Fenwick, "A new data structure for cumulative frequency 
+    .. [4] Peter M. Fenwick, "A new data structure for cumulative frequency
     tables", Software: Practice and Experience, Vol. 24, No. 3, pp. 327-336,
     1994.
 

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3489,11 +3489,10 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     Vol. 30, No. 1/2, pp. 81-93, 1938.
     Maurice G. Kendall, "The treatment of ties in ranking problems",
     Biometrika Vol. 33, No. 3, pp. 239-251. 1945.
-    W.R. Knight, "A Computer Method for Calculating Kendall's Tau with
-    Ungrouped Data", Journal of the American Statistical Association, Vol. 61,
-    No. 314, Part 1, pp. 436-439, 1966.
     Gottfried E. Noether, "Elements of Nonparametric Statistics", John Wiley &
     Sons, 1967.
+    Peter M. Fenwick, "A new data structure for cumulative frequency tables",
+    Software: Practice and Experience, Vol. 24, No. 3, pp. 327-336, 1994.
 
     Examples
     --------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3442,7 +3442,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     Kendall's tau is a measure of the correspondence between two rankings.
     Values close to 1 indicate strong agreement, values close to -1 indicate
     strong disagreement.  This is the 1945 "tau-b" version of Kendall's
-    tau [2]_, which can accounts for ties and which reduces to the 1938 "tau-a"
+    tau [2]_, which can account for ties and which reduces to the 1938 "tau-a"
     version [1]_ in absence of ties.
 
     Parameters
@@ -3486,14 +3486,14 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     References
     ----------
     .. [1] Maurice G. Kendall, "A New Measure of Rank Correlation", Biometrika
-    Vol. 30, No. 1/2, pp. 81-93, 1938.
+           Vol. 30, No. 1/2, pp. 81-93, 1938.
     .. [2] Maurice G. Kendall, "The treatment of ties in ranking problems",
-    Biometrika Vol. 33, No. 3, pp. 239-251. 1945.
+           Biometrika Vol. 33, No. 3, pp. 239-251. 1945.
     .. [3] Gottfried E. Noether, "Elements of Nonparametric Statistics", John
-    Wiley & Sons, 1967.
+           Wiley & Sons, 1967.
     .. [4] Peter M. Fenwick, "A new data structure for cumulative frequency
-    tables", Software: Practice and Experience, Vol. 24, No. 3, pp. 327-336,
-    1994.
+           tables", Software: Practice and Experience, Vol. 24, No. 3,
+           pp. 327-336, 1994.
 
     Examples
     --------


### PR DESCRIPTION
This patch simplifies and makes faster the Cython code used by scipy.stats.kendalltau(). Moreover, some of the fixes from #5754 have been included.
- The code now computes discordances only. It used to compute concordances, too, but this is redundant and causes an additional inner loop. The code is shorter and a few percents faster.
- The documentation has been fixed. References to the Kendall 1938 and 1945 papers have been added, as well as a clear explanation that this code computes tau-b, but tau-b reduces to tau-a if there are no ties. This "tau-a vs. tau-b" thing is a constant problem even in the scientific literature. I hope that this clarifies that they are the same thing. People can also check the papers.
- The result is min/max'd with 1/-1 so that it never happens that because of computational errors you get a value like -1.0000000001. In my experience this leads to all sorts of bizarre behaviour: for example, if you scale the result so that it is between 0 and 1 you can get a negative value anyway.
- It is now documented that using 'omit' for NaNs will result in delegation to another implementation.

The p-values are still broken in the presence of ties (see #6314 and #5755). I'm planning to create another pull request that fixes that issue, too, but I'd prefer to keep the modifications above separate.
