### PR TITLE
general.rst: Fix a typo

### DIFF
--- a/doc/source/tutorial/general.rst
+++ b/doc/source/tutorial/general.rst
@@ -110,7 +110,7 @@ documentation string for the object passed to the ``help`` command are
 printed to standard output (or to a writeable object passed as the
 third argument). The second keyword argument of ``numpy.info`` defines
 the maximum width of the line for printing. If a module is passed as
-the argument to help than a list of the functions and classes defined
+the argument to ``help`` then a list of the functions and classes defined
 in that module is printed. For example:
 
 .. literalinclude:: examples/1-1


### PR DESCRIPTION
I’m not a native speaker; but I think this `than` is a typo. Also, `help` should be shown as code.
