### PR TITLE
TST - DO NOT MERGE: Test master with numpy 1.8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,63 +4,16 @@ language: python
 sudo: false
 matrix:
   include:
-    - python: 2.7
-      env:
-        - PYFLAKES=1
-        - PEP8=1
-        - NUMPYSPEC=numpy
-      before_install:
-        - pip install pep8==1.7.0
-        - pip install pyflakes==1.1.0
-      script:
-        - PYFLAKES_NODOCTEST=1 pyflakes scipy benchmarks/benchmarks | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused|may be undefined, or defined from star imports' > test.out; cat test.out; test \! -s test.out
-        - pep8 scipy benchmarks/benchmarks
-    - python: 2.7
-      env:
-        - TESTMODE=fast
-        - REFGUIDE_CHECK=1
-        - COVERAGE=
-        - NPY_RELAXED_STRIDES_CHECKING=1
-        - NUMPYSPEC="--upgrade git+git://github.com/numpy/numpy.git@v1.10.4"
-      addons:
-        apt:
-          packages:
-            - libatlas-dev
-            - libatlas-base-dev
-            - liblapack-dev
-            - gfortran
-            - libgmp-dev
-            - libmpfr-dev
-            - ccache
-            - libfreetype6-dev
-            - libpng-dev
-            - zlib1g-dev
-            - texlive-fonts-recommended
-    - python: 3.5
-      env:
-        - TESTMODE=fast
-        - COVERAGE=
-        # We do not have a TLS cert for the Rackspace CDN that hosts travis-dev-wheels.scipy.org
-        - NUMPYSPEC="--pre --upgrade --no-index --timeout=60 --trusted-host travis-dev-wheels.scipy.org -f http://travis-dev-wheels.scipy.org/ numpy"
-        - USE_WHEEL=1
-        - UPLOAD_DEV_WHEEL=1
-        - WHEELHOUSE_UPLOADER_USERNAME=travis.numpy
-        # The following is generated with the command:
-        # travis encrypt -r scipy/scipy WHEELHOUSE_UPLOADER_SECRET=tH3AP1KeY
-        - secure: "cZtB3kMSAY4iYN60SF/Euw2YJvd7FjrjDAkPjQnr8DUxobgjYsdVxtLu2l\
-                   KPt5ZfX5poTFI4kDnPoI6zjvbDvMvVhxp8L9psi19h6mVS+BjAfQ06HYfz\
-                   jdPPiyTOhxfxRQ60SC+617kZSLrP6AeIiPdb+IFcM/987oYBDYOoVb0="
     - python: 3.4
       env:
-        - TESTMODE=fast
-        - COVERAGE=
-        - NUMPYSPEC="numpy==1.7.2"
-        - USE_SDIST=1
+        - TESTMODE=full
+        - COVERAGE=--coverage
+        - NUMPYSPEC="numpy==1.8.2"
     - python: 2.7
       env:
         - TESTMODE=full
         - COVERAGE=--coverage
-        - NUMPYSPEC=numpy
+        - NUMPYSPEC="numpy==1.8.2"
 addons:
   apt:
     packages:


### PR DESCRIPTION
I ran into some test failures in gh-6601, but also see the same failures on master on my local machine with numpy 1.8.2. I want to see what travis gets with python 2.7/3.4 and numpy 1.8.2 with master, so this PR is just a change to the travis configuration, but isn't intended to ever be merged.
