### PR TITLE
Fix bug in cKDTree constructor and allow mixed periodic and non-periodic dimensions

### DIFF
--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -503,13 +503,13 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             self.boxsize_data = None
         else:
             boxsize_arr = np.empty(2 * self.m, dtype=np.float64)
-            boxsize_arr[:] = boxsize
+            boxsize_arr[:self.m] = boxsize
             boxsize_arr[self.m:] = 0.5 * boxsize_arr[:self.m]
             # FIXME: how to use a matching del if new is used?
             self.boxsize_data = boxsize_arr
             self.raw_boxsize_data = <np.float64_t*> np.PyArray_DATA(boxsize_arr)
             self.boxsize = boxsize_arr[:self.m].copy()
-            if (self.data >= self.boxsize[None, :]).any():
+            if (self.data >= self.boxsize[None, self.boxsize > 0]).any():
                 raise ValueError("Some input data are greater than the size of the periodic box.")
             if (self.data < 0).any():
                 raise ValueError("Negative input data are outside of the periodic box.")

--- a/scipy/spatial/ckdtree.pyx
+++ b/scipy/spatial/ckdtree.pyx
@@ -509,9 +509,10 @@ cdef public class cKDTree [object ckdtree, type ckdtree_type]:
             self.boxsize_data = boxsize_arr
             self.raw_boxsize_data = <np.float64_t*> np.PyArray_DATA(boxsize_arr)
             self.boxsize = boxsize_arr[:self.m].copy()
-            if (self.data >= self.boxsize[None, self.boxsize > 0]).any():
+            periodic_mask = self.boxsize > 0
+            if ((self.data >= self.boxsize[None, :])[:, periodic_mask]).any():
                 raise ValueError("Some input data are greater than the size of the periodic box.")
-            if (self.data < 0).any():
+            if ((self.data < 0)[:, periodic_mask]).any():
                 raise ValueError("Negative input data are outside of the periodic box.")
 
         self.maxes = np.ascontiguousarray(np.amax(self.data,axis=0), dtype=np.float64)

--- a/scipy/spatial/ckdtree/src/distance_box.h
+++ b/scipy/spatial/ckdtree/src/distance_box.h
@@ -22,6 +22,29 @@ struct BoxDist1D {
          *
          * We will fix the convention later.
          * */
+        if (NPY_UNLIKELY(full <= 0)) {
+            /* A non-periodic dimension */
+            /* \/     */
+            if(max <= 0 || min >= 0) {
+                /* do not pass though 0 */
+                min = dabs(min);
+                max = dabs(max);
+                if(min < max) {
+                    *realmin = min;
+                    *realmax = max;
+                } else {
+                    *realmin = max;
+                    *realmax = min;
+                }
+            } else {
+                min = dabs(min);
+                max = dabs(max);
+                *realmax = fmax(max, min);
+                *realmin = 0;
+            }
+            /* done with non-periodic dimension */
+            return;
+        }
         if(max <= 0 || min >= 0) {
             /* do not pass through 0 */
             min = dabs(min);

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1064,12 +1064,21 @@ def test_ckdtree_box():
     assert_equal(ii, ii2)
 
 def test_ckdtree_box_upper_bounds():
-    data = np.linspace(0, 2, 10).reshape(-1, 1)
+    data = np.linspace(0, 2, 10).reshape(-1, 2)
+    data[:, 1] += 10
     try:
-        cKDTree(data, leafsize=1, boxsize=1.0)
+        cKDTree(data, leafsize=1, boxsize=2.0)
+        raise AssertionError("ValueError is not raised")
     except ValueError:
-        return
-    raise AssertionError("ValueError is not raised")
+        pass
+    try:
+        cKDTree(data, leafsize=1, boxsize=(0.0, 2.0))
+        raise AssertionError("ValueError is not raised")
+    except ValueError:
+        pass
+
+    # skip a dimension.
+    cKDTree(data, leafsize=1, boxsize=(2.0, 0.0))
 
 def test_ckdtree_box_lower_bounds():
     data = np.linspace(-1, 1, 10)


### PR DESCRIPTION
This patch fixes a bug in the `cKDTree` constructor. The `boxsize` keyword requires an array two times larger than the size it should be. This is addressed by the first line in the patch.

The second line in the patch allows the user to mix periodic and non-periodic dimensions in `boxsize` by setting the size of each non-periodic dimension to a non-positive value. The function `side_distance_from_min_max` in ckdtree_methods.h will treat those dimensions as non-periodic.
