### PR TITLE
TST: fix timeout on TravisCI for sdist build, due to no output received.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ script:
         python setup.py sdist
         # Move out of source directory to avoid finding local scipy
         pushd dist
-        pip install scipy*
+        pip install scipy* -v
         popd
         USE_WHEEL_BUILD="--no-build"
     fi


### PR DESCRIPTION
pip >= 8.1 has a spinner to prevents timeouts, but older pip versions
are completely silent by default.  Therefore the verbose output is
needed to not make TravisCI time out after 10 min.
