### PR TITLE
TST: upgrade pip and setuptools on TravisCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,8 @@ before_install:
   # Speed up install by not compiling Cython
   - travis_retry pip install --install-option="--no-cython-compile" Cython==0.22
   - travis_retry pip install $NUMPYSPEC
-  - travis_retry pip install nose mpmath argparse Pillow codecov setuptools
+  - travis_retry pip install nose mpmath argparse Pillow codecov
+  - travis_retry pip install --upgrade pip setuptools
   - travis_retry pip install gmpy2  # speeds up mpmath (scipy.special tests)
   - if [ "${TESTMODE}" == "full" ]; then pip install coverage; fi
   - if [ "${USE_WHEEL}" == "1" ]; then pip install wheel; fi


### PR DESCRIPTION
The current version for pip (6.0.7) has broken verbose output, which causes
build timeouts.
