### PR TITLE
BUG: Fixes computation of p-values.

### DIFF
--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -86,6 +86,11 @@ the input, instead of always float64.
 The function `scipy.signal.find_peaks_cwt()` now returns an array instead of
 a list.
 
+`scipy.stats.kendalltau()` now computes the correct p-value in case the
+input contains ties. The p-value is also identical to that computed by
+`scipy.stats.mstats_basic.kendalltau()`. If the input does not contain
+ties there is no change w.r.t. the previous implementation.
+
 
 Other changes
 =============

--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -86,10 +86,10 @@ the input, instead of always float64.
 The function `scipy.signal.find_peaks_cwt()` now returns an array instead of
 a list.
 
-`scipy.stats.kendalltau()` now computes the correct p-value in case the
+`scipy.stats.kendalltau` now computes the correct p-value in case the
 input contains ties. The p-value is also identical to that computed by
-`scipy.stats.mstats_basic.kendalltau()`. If the input does not contain
-ties there is no change w.r.t. the previous implementation.
+`scipy.stats.mstats_basic.kendalltau` and by R. If the input does not
+contain ties there is no change w.r.t. the previous implementation.
 
 
 Other changes

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3486,8 +3486,6 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     >>> x1 = [12, 2, 1, 12, 2]
     >>> x2 = [1, 4, 7, 1, 0]
     >>> tau, p_value = stats.kendalltau(x1, x2)
-    >>> # Cross-check with R:
-    >>> # cor.test(c(12,2,1,12,2),c(1,4,7,1,0),method="kendall",exact=FALSE)
     >>> tau
     -0.47140452079103173
     >>> p_value

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3489,7 +3489,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     >>> tau
     -0.47140452079103173
     >>> p_value
-    0.24821309157521476
+    0.2827454599327748
 
     """
     x = np.asarray(x).ravel()
@@ -3521,7 +3521,10 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
 
     def count_rank_tie(ranks):
         cnt = np.bincount(ranks).astype('int64', copy=False)
-        return (cnt * (cnt - 1) // 2).sum()
+        cnt = cnt[cnt > 1]
+        return ((cnt * (cnt - 1) // 2).sum(),
+            (cnt * (cnt - 1.) * (cnt - 2)).sum(),
+            (cnt * (cnt - 1.) * (2*cnt + 5)).sum())
 
     size = x.size
     perm = np.argsort(y)  # sort on y and convert y to dense ranks
@@ -3539,8 +3542,8 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     cnt = np.diff(np.where(obs)[0]).astype('int64', copy=False)
 
     ntie = (cnt * (cnt - 1) // 2).sum()  # joint ties
-    xtie = count_rank_tie(x)             # ties in x
-    ytie = count_rank_tie(y)             # ties in y
+    xtie, x0, x1 = count_rank_tie(x)     # ties in x, stats
+    ytie, y0, y1 = count_rank_tie(y)     # ties in y, stats
 
     tot = (size * (size - 1)) // 2
 
@@ -3549,18 +3552,19 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
 
     # Note that tot = con + dis + (xtie - ntie) + (ytie - ntie) + ntie
     #               = con + dis + xtie + ytie - ntie
-    tau = (tot - xtie - ytie + ntie
-        - 2 * dis) / np.sqrt(tot - xtie) / np.sqrt(tot - ytie)
+    con_minus_dis = tot - xtie - ytie + ntie - 2 * dis
+    tau = con_minus_dis / np.sqrt(tot - xtie) / np.sqrt(tot - ytie)
     # Limit range to fix computational errors
     tau = min(1., max(-1., tau))
 
-    # what follows reproduces the ending of Gary Strangman's original
-    # stats.kendalltau() in SciPy
-    svar = (4.0 * size + 10.0) / (9.0 * size * (size - 1))
-    z = tau / np.sqrt(svar)
-    prob = special.erfc(np.abs(z) / 1.4142136)
+    # con_minus_dis is approx normally distributed with this variance [3]_
+    var = (size * (size - 1) * (2.*size + 5) - x1 - y1) / 18. + (
+        2. * xtie * ytie) / (size * (size - 1)) + x0 * y0 / (9. *
+        size * (size - 1) * (size - 2))
+    pvalue = special.erfc(np.abs(con_minus_dis) / np.sqrt(var) / np.sqrt(2))
 
-    return KendalltauResult(tau, prob)
+    # Limit range to fix computational errors
+    return KendalltauResult(min(1., max(-1., tau)), pvalue)
 
 
 #####################################

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3486,6 +3486,8 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     >>> x1 = [12, 2, 1, 12, 2]
     >>> x2 = [1, 4, 7, 1, 0]
     >>> tau, p_value = stats.kendalltau(x1, x2)
+    >>> # Cross-check with R:
+    >>> # cor.test(c(12,2,1,12,2),c(1,4,7,1,0),method="kendall",exact=FALSE)
     >>> tau
     -0.47140452079103173
     >>> p_value

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -568,7 +568,7 @@ def test_kendalltau():
     # with some ties
     x1 = [12, 2, 1, 12, 2]
     x2 = [1, 4, 7, 1, 0]
-    expected = (-0.47140452079103173, 0.24821309157521476)
+    expected = (-0.47140452079103173, 0.28274545993277478)
     res = stats.kendalltau(x1, x2)
     assert_approx_equal(res[0], expected[0])
     assert_approx_equal(res[1], expected[1])
@@ -586,20 +586,14 @@ def test_kendalltau():
     # empty arrays provided as input
     assert_equal(stats.kendalltau([], []), (np.nan, np.nan))
 
-    # check two different sort methods
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', UserWarning)
-        assert_approx_equal(stats.kendalltau(x1, x2, initial_lexsort=False)[1],
-                            stats.kendalltau(x1, x2, initial_lexsort=True)[1])
-
-    # and with larger arrays
+    # check with larger arrays
     np.random.seed(7546)
     x = np.array([np.random.normal(loc=1, scale=1, size=500),
                 np.random.normal(loc=1, scale=1, size=500)])
     corr = [[1.0, 0.3],
             [0.3, 1.0]]
     x = np.dot(np.linalg.cholesky(corr), x)
-    expected = (0.19291382765531062, 1.1337108207276285e-10)
+    expected = (0.19291382765531062, 1.1337095377742629e-10)
     res = stats.kendalltau(x[0], x[1])
     assert_approx_equal(res[0], expected[0])
     assert_approx_equal(res[1], expected[1])

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -25,6 +25,7 @@ import numpy as np
 
 import scipy.stats as stats
 import scipy.stats.mstats as mstats
+import scipy.stats.mstats_basic as mstats_basic
 from scipy._lib._version import NumpyVersion
 from scipy._lib.six import xrange
 from common_tests import check_named_results
@@ -614,6 +615,21 @@ def test_kendalltau():
     x = np.arange(10.)
     y = np.arange(20.)
     assert_raises(ValueError, stats.kendalltau, x, y)
+
+
+def test_kendalltau_vs_mstats_basic():
+    for s in range(2,10):
+        a = []
+        # Generate rankings with ties
+        for i in range(s):
+            a += [i]*i
+        b = list(a)
+        np.random.shuffle(a)
+        np.random.shuffle(b)
+        expected = mstats_basic.kendalltau(a, b)
+        actual = stats.kendalltau(a, b)
+        assert_approx_equal(expected[0], actual[0])
+        assert_approx_equal(expected[1], actual[1])
 
 
 def test_kendalltau_nan_2nd_arg():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -567,6 +567,8 @@ class TestCorrSpearmanrTies(TestCase):
 
 def test_kendalltau():
     # with some ties
+    # Cross-check with R:
+    # cor.test(c(12,2,1,12,2),c(1,4,7,1,0),method="kendall",exact=FALSE)
     x1 = [12, 2, 1, 12, 2]
     x2 = [1, 4, 7, 1, 0]
     expected = (-0.47140452079103173, 0.28274545993277478)


### PR DESCRIPTION
This pull request fixes the computation of p-values in stats.kendalltau(). The values computed are now the same returne by mstats_basic.kendalltau(), R, etc., fixing #6314 and #5755.

Additionally, we fix all existing unit tests (which were comparing the result against the wrong p-value).
