### PR TITLE
TST: Added Airspeed Velocity benchmarks for SphericalVoronoi

### DIFF
--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -128,38 +128,37 @@ class Neighbors(Benchmark):
         """
         self.T1.count_neighbors(self.T2, probe_radius, p=p)
 
+def generate_spherical_points(num_points):
+        # generate uniform points on sphere (see:
+        # http://stackoverflow.com/a/23785326/2942522)
+        np.random.seed(123)
+        points = np.random.normal(size=(num_points, 3))
+        points /= np.linalg.norm(points, axis=1)[:, np.newaxis]
+        return points
+
 class SphericalVor(Benchmark):
     params = [10, 100, 1000, 5000, 10000]
     param_names = ['num_points']
 
     def setup(self, num_points):
-        # generate uniform points on sphere (see:
-        # http://stackoverflow.com/a/23785326/2942522)
-        np.random.seed(123)
-        self.points = np.random.normal(size=(num_points, 3))
-        self.points /= np.linalg.norm(self.points, axis=1)[:, np.newaxis]
-
-    def teardown(self, num_points):
-        del self.points
+        self.points = generate_spherical_points(num_points)
 
     def time_spherical_voronoi_calculation(self, num_points):
         """Perform spherical Voronoi calculation, but not the sorting of
         vertices in the Voronoi polygons.
         """
-        SphericalVoronoi(self.points, radius = 1, center = np.zeros(3))
+        SphericalVoronoi(self.points, radius=1, center=np.zeros(3))
 
-class SphericalVorSort(SphericalVor):
+class SphericalVorSort(Benchmark):
+    params = [10, 100, 1000, 5000, 10000]
+    param_names = ['num_points']
 
     def setup(self, num_points):
-        super(SphericalVorSort, self).setup(num_points)
-        self.sv = SphericalVoronoi(self.points, radius = 1,
-                                   center = np.zeros(3))
+        self.points = generate_spherical_points(num_points)
+        self.sv = SphericalVoronoi(self.points, radius=1,
+                                   center=np.zeros(3))
 
-    def teardown(self, num_points):
-        super(SphericalVorSort, self).teardown(num_points)
-        del self.sv
-
-    def time_spherical_voronoi_calculation(self, num_points):
+    def time_spherical_polygon_vertex_sorting(self, num_points):
         """Time the vertex sorting operation in the Spherical Voronoi
         code.
         """


### PR DESCRIPTION
### Purpose

This PR adds [airspeed velocity](http://asv.readthedocs.io/en/latest/index.html) benchmarks to the [scipy benchmarks suite](https://github.com/scipy/scipy/tree/master/benchmarks) for `scipy.spatial.SphericalVoronoi`. The latter class has so far not been covered by performance benchmarks at all after Nikolai and I contributed it. The idea is to prevent performance regressions and also to lower the barrier to performance improvements by providing a convenient platform for benchmark comparison if / when I or others improve that code.
### Testing these new benchmarks

Here is how I tested the new benchmarks to check for issues:
At path `scipy/benchmarks`:

```
asv run --bench SphericalVor* -e
asv publish
asv preview
```

This is a very limited test, but allowed me to squash the issues that cropped up. The graphical output looked ok and the text output was:

```
[ 50.00%] ··· Running spatial.SphericalVor.time_spherical_voronoi_calculation                                                                                                                            ok
[ 50.00%] ···· 
               ============ ==========
                num_points            
               ------------ ----------
                    10       742.22μs 
                   100        2.29ms  
                   1000      45.83ms  
                   5000      596.71ms 
                  10000       2.22s   
               ============ ==========

[100.00%] ··· Running spatial.SphericalVorSort.time_spherical_voronoi_calculation                                                                                                                        ok
[100.00%] ···· 
               ============ ==========
                num_points            
               ------------ ----------
                    10       764.01μs 
                   100       10.36ms  
                   1000      106.75ms 
                   5000      528.48ms 
                  10000       1.12s   
               ============ ==========
```
### Considerations
- It is slightly awkward that I used the same test method name in each of the new classes -- this was to allow inheritance / recycling of code without re-running the method of the base class. Better approach?
- The 10k point test is rather slow compared to the 0.25 s goal time. Ideally, I'd want to go up to even more points so that any future PRs improving the performance of the class could basically just use `asv compare` to conveniently measure progress between commit hashes over a broad range of values, but I suspect that the time cost would be too great over the span of the project.
- I assume someone else (looks like Pauli here: https://pv.github.io/scipy-bench/) runs the benchmark suite periodically and publishes those online now and then; it certainly seems to take a long time on my laptop to do the full run though
