### PR TITLE
ENH: Clearer error when fmin_slsqp obj doesn't return scalar

### DIFF
--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -80,7 +80,7 @@ def fmin_slsqp(func, x0, eqcons=(), f_eqcons=None, ieqcons=(), f_ieqcons=None,
     Parameters
     ----------
     func : callable f(x,*args)
-        Objective function.
+        Objective function.  Must return a scalar.
     x0 : 1-D ndarray of float
         Initial guess for the independent variable(s).
     eqcons : list, optional
@@ -364,7 +364,10 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
         if mode == 0 or mode == 1:  # objective and constraint evaluation requird
 
             # Compute objective function
-            fx = func(x)
+            try:
+                fx = float(func(x))
+            except:
+                raise ValueError("Objective function must return a scalar")
             # Compute the constraints
             if cons['eq']:
                 c_eq = concatenate([atleast_1d(con['fun'](x, *con['args']))

--- a/scipy/optimize/slsqp.py
+++ b/scipy/optimize/slsqp.py
@@ -365,7 +365,7 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
 
             # Compute objective function
             try:
-                fx = float(func(x))
+                fx = float(np.asarray(func(x)))
             except:
                 raise ValueError("Objective function must return a scalar")
             # Compute the constraints

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -4,7 +4,8 @@ Unit test for SLSQP optimization.
 from __future__ import division, print_function, absolute_import
 
 from numpy.testing import (assert_, assert_array_almost_equal, TestCase,
-                           assert_allclose, assert_equal, run_module_suite)
+                           assert_allclose, assert_equal, run_module_suite,
+                           assert_raises)
 import numpy as np
 
 from scipy._lib._testutils import knownfailure_overridable
@@ -304,6 +305,11 @@ class TestSLSQP(TestCase):
     def test_integer_bounds(self):
         # This should not raise an exception
         fmin_slsqp(lambda z: z**2 - 1, [0], bounds=[[0, 1]], iprint=0)
+
+    def test_obj_must_return_scalar(self):
+        # If objective function does not return a scalar, raises ValueError
+        with assert_raises(ValueError):
+            fmin_slsqp(lambda x: [0, 1], [1,2,3])
 
     def test_callback(self):
         # Minimize, method='SLSQP': unbounded, approximated jacobian. Check for callback

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -307,6 +307,7 @@ class TestSLSQP(TestCase):
         fmin_slsqp(lambda z: z**2 - 1, [0], bounds=[[0, 1]], iprint=0)
 
     def test_obj_must_return_scalar(self):
+        # Regression test for Github Issue #5433
         # If objective function does not return a scalar, raises ValueError
         with assert_raises(ValueError):
             fmin_slsqp(lambda x: [0, 1], [1,2,3])

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -310,7 +310,13 @@ class TestSLSQP(TestCase):
         # Regression test for Github Issue #5433
         # If objective function does not return a scalar, raises ValueError
         with assert_raises(ValueError):
-            fmin_slsqp(lambda x: [0, 1], [1,2,3])
+            fmin_slsqp(lambda x: [0, 1], [1, 2, 3])
+
+    def test_obj_returns_scalar_in_list(self):
+        # Test for Github Issue #5433 and PR #6691
+        # Objective function should be able to return length-1 Python list
+        #  containing the scalar
+        fmin_slsqp(lambda x: [0], [1, 2, 3])
 
     def test_callback(self):
         # Minimize, method='SLSQP': unbounded, approximated jacobian. Check for callback


### PR DESCRIPTION
See #5433 

ValueError with a clear message is raised when the objective function in `fmin_slsqp` doesn't return a scalar.

Also updates docstring to add that objective function must return a scalar and adds a test for look for the ValueError.
