### PR TITLE
MAINT: fix test failures from `assert_allclose`

### DIFF
--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2609,7 +2609,7 @@ class TestInterpN(TestCase):
 
             v2 = interpn(points, values, sample,
                          method=method, bounds_error=False)
-            assert_allclose(v1, v2.reshape(v1.shape))
+            assert_allclose(v1, v2.reshape(v1.shape), equal_nan=True)
 
     def test_nonscalar_values(self):
         # Verify that non-scalar valued values also works

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2259,7 +2259,7 @@ class TestOrdQZ(TestCase):
                 x[azero & bzero] = np.nan
                 x[~azero & bzero] = np.inf
                 x[~bzero] = alpha[~bzero]/beta[~bzero]
-                assert_allclose(expected_eigvals, x)
+                assert_allclose(expected_eigvals, x, equal_nan=True)
 
 
 class TestOrdQZWorkspaceSize(TestCase):

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -94,7 +94,7 @@ class TestExpmActionSimple(TestCase):
                     B = np.random.randn(n, k)
                     observed = _expm_multiply_simple(A, B, t=t)
                     expected = np.dot(scipy.linalg.expm(t*A), B)
-                    assert_allclose(observed, expected)
+                    assert_allclose(observed, expected, equal_nan=True)
 
     def test_scaled_expm_multiply_single_timepoint(self):
         np.random.seed(1234)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1633,32 +1633,38 @@ class TestErf(TestCase):
     def test_erf_nan_inf(self):
         vals = [np.nan, -np.inf, np.inf]
         expected = [np.nan, -1, 1]
-        assert_allclose(special.erf(vals), expected, rtol=1e-15)
+        assert_allclose(special.erf(vals), expected, rtol=1e-15,
+                        equal_nan=True)
 
     def test_erfc_nan_inf(self):
         vals = [np.nan, -np.inf, np.inf]
         expected = [np.nan, 2, 0]
-        assert_allclose(special.erfc(vals), expected, rtol=1e-15)
+        assert_allclose(special.erfc(vals), expected, rtol=1e-15,
+                        equal_nan=True)
 
     def test_erfcx_nan_inf(self):
         vals = [np.nan, -np.inf, np.inf]
         expected = [np.nan, np.inf, 0]
-        assert_allclose(special.erfcx(vals), expected, rtol=1e-15)
+        assert_allclose(special.erfcx(vals), expected, rtol=1e-15,
+                        equal_nan=True)
 
     def test_erfi_nan_inf(self):
         vals = [np.nan, -np.inf, np.inf]
         expected = [np.nan, -np.inf, np.inf]
-        assert_allclose(special.erfi(vals), expected, rtol=1e-15)
+        assert_allclose(special.erfi(vals), expected, rtol=1e-15,
+                        equal_nan=True)
 
     def test_dawsn_nan_inf(self):
         vals = [np.nan, -np.inf, np.inf]
         expected = [np.nan, -0.0, 0.0]
-        assert_allclose(special.dawsn(vals), expected, rtol=1e-15)
+        assert_allclose(special.dawsn(vals), expected, rtol=1e-15,
+                        equal_nan=True)
 
     def test_wofz_nan_inf(self):
         vals = [np.nan, -np.inf, np.inf]
         expected = [np.nan + np.nan * 1.j, 0.-0.j, 0.+0.j]
-        assert_allclose(special.wofz(vals), expected, rtol=1e-15)
+        assert_allclose(special.wofz(vals), expected, rtol=1e-15,
+                        equal_nan=True)
 
 
 class TestEuler(TestCase):

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -324,7 +324,8 @@ def test_cython_api():
             for pt in pts:
                 pyval = pyfunc(*pt)
                 cyval = cy_spec_func(*pt)
-                assert_allclose(cyval, pyval, err_msg="{} {} {}".format(pt, typecodes, signature))
+                assert_allclose(cyval, pyval, equal_nan=True,
+                                err_msg="{} {} {}".format(pt, typecodes, signature))
 
     for param in params:
         yield check, param

--- a/scipy/special/tests/test_spherical_bessel.py
+++ b/scipy/special/tests/test_spherical_bessel.py
@@ -115,7 +115,8 @@ class TestSphericalYn:
         # (-inf + nan*j)
         n = np.array([0, 1, 2, 5, 10, 100])
         x = 0 + 0j
-        assert_allclose(spherical_yn(n, x), nan*np.ones(shape=n.shape))
+        assert_allclose(spherical_yn(n, x), nan*np.ones(shape=n.shape),
+                        equal_nan=True)
 
 
 class TestSphericalJnYnCrossProduct:
@@ -174,7 +175,8 @@ class TestSphericalIn:
         # the correct return value.
         n = 7
         x = np.array([-inf + 0j, inf + 0j, inf*(1+1j)])
-        assert_allclose(spherical_in(n, x), np.array([-inf, inf, nan]))
+        assert_allclose(spherical_in(n, x), np.array([-inf, inf, nan]),
+                        equal_nan=True)
 
     def test_spherical_in_at_zero(self):
         # http://dlmf.nist.gov/10.52.E1
@@ -218,7 +220,8 @@ class TestSphericalKn:
         # z*inf.  This distinction cannot be captured, so we return nan.
         n = 7
         x = np.array([-inf + 0j, inf + 0j, inf*(1+1j)])
-        assert_allclose(spherical_kn(n, x), np.array([-inf, 0, nan]))
+        assert_allclose(spherical_kn(n, x), np.array([-inf, 0, nan]),
+                        equal_nan=True)
 
     def test_spherical_kn_at_zero(self):
         # http://dlmf.nist.gov/10.52.E2
@@ -230,7 +233,8 @@ class TestSphericalKn:
         # http://dlmf.nist.gov/10.52.E2
         n = np.array([0, 1, 2, 5, 10, 100])
         x = 0 + 0j
-        assert_allclose(spherical_kn(n, x), nan*np.ones(shape=n.shape))
+        assert_allclose(spherical_kn(n, x), nan*np.ones(shape=n.shape),
+                        equal_nan=True)
 
 
 class SphericalDerivativesTestCase:

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -241,8 +241,8 @@ class TestBinnedStatistic(object):
         stat2, binx2, biny2, bc2 = binned_statistic_2d(
             x, y, [v, w], 'mean', bins=8)
 
-        assert_allclose(stat2[0], stat1v)
-        assert_allclose(stat2[1], stat1w)
+        assert_allclose(stat2[0], stat1v, equal_nan=True)
+        assert_allclose(stat2[1], stat1w, equal_nan=True)
         assert_allclose(binx1v, binx2)
         assert_allclose(biny1w, biny2)
         assert_allclose(bc1v, bc2)
@@ -351,8 +351,8 @@ class TestBinnedStatistic(object):
         stat1w, edges1w, bc1w = binned_statistic_dd(X, w, np.std, bins=8)
         stat2, edges2, bc2 = binned_statistic_dd(X, [v, w], np.std, bins=8)
 
-        assert_allclose(stat2[0], stat1v)
-        assert_allclose(stat2[1], stat1w)
+        assert_allclose(stat2[0], stat1v, equal_nan=True)
+        assert_allclose(stat2[1], stat1w, equal_nan=True)
         assert_allclose(edges1v, edges2)
         assert_allclose(edges1w, edges2)
         assert_allclose(bc1v, bc2)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -406,8 +406,8 @@ def check_vecentropy(distfn, args):
 def check_loc_scale(distfn, arg, m, v, msg):
     loc, scale = 10.0, 10.0
     mt, vt = distfn.stats(loc=loc, scale=scale, *arg)
-    npt.assert_allclose(m*scale + loc, mt)
-    npt.assert_allclose(v*scale*scale, vt)
+    npt.assert_allclose(m*scale + loc, mt, equal_nan=True)
+    npt.assert_allclose(v*scale*scale, vt, equal_nan=True)
 
 
 def check_ppf_private(distfn, arg, msg):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1802,7 +1802,7 @@ class TestFrozen(TestCase):
         gm_val = gm.expect(func, lb=1, ub=2, conditional=True)
         gamma_val = stats.gamma.expect(func, args=(2,), loc=3, scale=4,
                                        lb=1, ub=2, conditional=True)
-        assert_allclose(gm_val, gamma_val)
+        assert_allclose(gm_val, gamma_val, equal_nan=True)
 
         p = stats.poisson(3, loc=4)
         p_val = p.expect(func)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1873,7 +1873,8 @@ class TestMoments(TestCase):
         a = np.arange(8).reshape(2, -1).astype(float)
         a[1, 0] = np.nan
         mm = stats.moment(a, 2, axis=1, nan_policy="propagate")
-        np.testing.assert_allclose(mm, [1.25, np.nan], atol=1e-15)
+        np.testing.assert_allclose(mm, [1.25, np.nan], atol=1e-15,
+                                   equal_nan=True)
 
     def test_variation(self):
         # variation = samplestd / mean
@@ -1896,7 +1897,8 @@ class TestMoments(TestCase):
         a = np.arange(8).reshape(2, -1).astype(float)
         a[1, 0] = np.nan
         vv = stats.variation(a, axis=1, nan_policy="propagate")
-        np.testing.assert_allclose(vv, [0.7453559924999299, np.nan], atol=1e-15)
+        np.testing.assert_allclose(vv, [0.7453559924999299, np.nan],
+                                   atol=1e-15, equal_nan=True)
 
     def test_skewness(self):
         # Scalar test case
@@ -1928,7 +1930,8 @@ class TestMoments(TestCase):
         a = np.arange(8).reshape(2, -1).astype(float)
         a[1, 0] = np.nan
         s = stats.skew(a, axis=1, nan_policy="propagate")
-        np.testing.assert_allclose(s, [0, np.nan], atol=1e-15)
+        np.testing.assert_allclose(s, [0, np.nan], atol=1e-15,
+                                   equal_nan=True)
 
     def test_kurtosis(self):
         # Scalar test case
@@ -1966,7 +1969,8 @@ class TestMoments(TestCase):
         a = np.arange(8).reshape(2, -1).astype(float)
         a[1, 0] = np.nan
         k = stats.kurtosis(a, axis=1, nan_policy="propagate")
-        np.testing.assert_allclose(k, [-1.36, np.nan], atol=1e-15)
+        np.testing.assert_allclose(k, [-1.36, np.nan], atol=1e-15,
+                                   equal_nan=True)
 
     def test_moment_accuracy(self):
         # 'moment' must have a small enough error compared to the slower
@@ -2220,7 +2224,7 @@ class TestPowerDivergence(object):
         ddof = np.asarray(ddof)
         expected_p = stats.distributions.chi2.sf(expected_stat,
                                                  num_obs - 1 - ddof)
-        assert_allclose(p, expected_p)
+        assert_allclose(p, expected_p, equal_nan=True)
 
     def test_basic(self):
         for case in power_div_1d_cases:


### PR DESCRIPTION
Recently NumPy fixed a bug that made the `equal_nan` flag in
`assert_allclose` work, which made some tests in SciPy that relied on
the buggy behavior fail. This sets the `equal_nan` flag where
necessary to get the tests to pass again. Closes gh-6696.
