### PR TITLE
DOC: Expand odd_ext even_ext const_ext docstrings

### DIFF
--- a/scipy/signal/_arraytools.py
+++ b/scipy/signal/_arraytools.py
@@ -55,23 +55,39 @@ def axis_reverse(a, axis=-1):
 
 
 def odd_ext(x, n, axis=-1):
-    """Generate a new ndarray by making an odd extension of x along an axis.
+    """
+    Odd extension at the boundaries of an array
+
+    Generate a new ndarray by making an odd extension of `x` along an axis.
 
     Parameters
     ----------
     x : ndarray
         The array to be extended.
     n : int
-        The number of elements by which to extend x at each end of the axis.
+        The number of elements by which to extend `x` at each end of the axis.
     axis : int, optional
-        The axis along which to extend x.  Default is -1.
+        The axis along which to extend `x`.  Default is -1.
 
     Examples
     --------
-    >>> a = array([[1.0,2.0,3.0,4.0,5.0], [0.0, 1.0, 4.0, 9.0, 16.0]])
-    >>> _odd_ext(a, 2)
-    array([[-1.,  0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.],
-           [-4., -1,   0.,  1.,  4.,  9., 16., 23., 28.]])
+    >>> from scipy.signal._arraytools import odd_ext
+    >>> a = np.array([[1, 2, 3, 4, 5], [0, 1, 4, 9, 16]])
+    >>> odd_ext(a, 2)
+    array([[-1,  0,  1,  2,  3,  4,  5,  6,  7],
+           [-4, -1,  0,  1,  4,  9, 16, 23, 28]])
+
+    Odd extension is a "180 degree rotation" at the endpoints of the original
+    array:
+
+    >>> t = np.linspace(0, 1.5, 100)
+    >>> a = 0.9 * np.sin(2 * np.pi * t**2)
+    >>> b = odd_ext(a, 40)
+    >>> import matplotlib.pyplot as plt
+    >>> plt.plot(arange(-40, 140), b, 'b', lw=1, label='odd extension')
+    >>> plt.plot(arange(100), a, 'r', lw=2, label='original')
+    >>> plt.legend(loc='best')
+    >>> plt.show()
     """
     if n < 1:
         return x
@@ -91,23 +107,38 @@ def odd_ext(x, n, axis=-1):
 
 
 def even_ext(x, n, axis=-1):
-    """Create an ndarray that is an even extension of x along an axis.
+    """
+    Even extension at the boundaries of an array
+
+    Generate a new ndarray by making an even extension of `x` along an axis.
 
     Parameters
     ----------
     x : ndarray
         The array to be extended.
     n : int
-        The number of elements by which to extend x at each end of the axis.
+        The number of elements by which to extend `x` at each end of the axis.
     axis : int, optional
-        The axis along which to extend x.  Default is -1.
+        The axis along which to extend `x`.  Default is -1.
 
     Examples
     --------
-    >>> a = array([[1.0,2.0,3.0,4.0,5.0], [0.0, 1.0, 4.0, 9.0, 16.0]])
-    >>> _even_ext(a, 2)
-    array([[  3.,   2.,   1.,   2.,   3.,   4.,   5.,   4.,   3.],
-           [  4.,   1.,   0.,   1.,   4.,   9.,  16.,   9.,   4.]])
+    >>> from scipy.signal._arraytools import even_ext
+    >>> a = np.array([[1, 2, 3, 4, 5], [0, 1, 4, 9, 16]])
+    >>> even_ext(a, 2)
+    array([[ 3,  2,  1,  2,  3,  4,  5,  4,  3],
+           [ 4,  1,  0,  1,  4,  9, 16,  9,  4]])
+
+    Even extension is a "mirror image" at the boundaries of the original array:
+
+    >>> t = np.linspace(0, 1.5, 100)
+    >>> a = 0.9 * np.sin(2 * np.pi * t**2)
+    >>> b = even_ext(a, 40)
+    >>> import matplotlib.pyplot as plt
+    >>> plt.plot(arange(-40, 140), b, 'b', lw=1, label='even extension')
+    >>> plt.plot(arange(100), a, 'r', lw=2, label='original')
+    >>> plt.legend(loc='best')
+    >>> plt.show()
     """
     if n < 1:
         return x
@@ -125,7 +156,10 @@ def even_ext(x, n, axis=-1):
 
 
 def const_ext(x, n, axis=-1):
-    """Create an ndarray that is a constant extension of x along an axis.
+    """
+    Constant extension at the boundaries of an array
+
+    Generate a new ndarray that is a constant extension of `x` along an axis.
 
     The extension repeats the values at the first and last element of
     the axis.
@@ -135,16 +169,29 @@ def const_ext(x, n, axis=-1):
     x : ndarray
         The array to be extended.
     n : int
-        The number of elements by which to extend x at each end of the axis.
+        The number of elements by which to extend `x` at each end of the axis.
     axis : int, optional
-        The axis along which to extend x.  Default is -1.
+        The axis along which to extend `x`.  Default is -1.
 
     Examples
     --------
-    >>> a = array([[1.0,2.0,3.0,4.0,5.0], [0.0, 1.0, 4.0, 9.0, 16.0]])
-    >>> _const_ext(a, 2)
-    array([[  1.,   1.,   1.,   2.,   3.,   4.,   5.,   5.,   5.],
-           [  0.,   0.,   0.,   1.,   4.,   9.,  16.,  16.,  16.]])
+    >>> from scipy.signal._arraytools import const_ext
+    >>> a = np.array([[1, 2, 3, 4, 5], [0, 1, 4, 9, 16]])
+    >>> const_ext(a, 2)
+    array([[ 1,  1,  1,  2,  3,  4,  5,  5,  5],
+           [ 0,  0,  0,  1,  4,  9, 16, 16, 16]])
+
+    Constant extension continues with the same values as the endpoints of the
+    array:
+
+    >>> t = np.linspace(0, 1.5, 100)
+    >>> a = 0.9 * np.sin(2 * np.pi * t**2)
+    >>> b = const_ext(a, 40)
+    >>> import matplotlib.pyplot as plt
+    >>> plt.plot(arange(-40, 140), b, 'b', lw=1, label='constant extension')
+    >>> plt.plot(arange(100), a, 'r', lw=2, label='original')
+    >>> plt.legend(loc='best')
+    >>> plt.show()
     """
     if n < 1:
         return x


### PR DESCRIPTION
Add "A one-line summary that does not use variable names or the
function name"

Add graphical examples

Simplify text examples

From https://github.com/scipy/scipy/pull/6058#issuecomment-254061700
