### PR TITLE
TST: Added airspeed velocity benchmarks for scipy.spatial.distance.cdist

### DIFF
--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -3,7 +3,7 @@ from __future__ import division, absolute_import, print_function
 import numpy as np
 
 try:
-    from scipy.spatial import cKDTree, KDTree, SphericalVoronoi
+    from scipy.spatial import cKDTree, KDTree, SphericalVoronoi, distance
 except ImportError:
     pass
 
@@ -163,3 +163,20 @@ class SphericalVorSort(Benchmark):
         code.
         """
         self.sv.sort_vertices_of_regions()
+
+class Cdist(Benchmark):
+    params = ([10, 100, 1000, 5000], ['euclidean', 'minkowski', 'cityblock',
+    'seuclidean', 'sqeuclidean', 'cosine', 'correlation', 'hamming', 'jaccard',
+    'chebyshev', 'canberra', 'braycurtis', 'mahalanobis', 'yule', 'dice',
+    'kulsinski', 'rogerstanimoto', 'russellrao', 'sokalmichener',
+    'sokalsneath', 'wminkowski'])
+    param_names = ['num_points', 'metric']
+
+    def setup(self, num_points, metric):
+        self.points = np.random.random_sample((num_points, 3))
+
+    def time_cdist(self, num_points, metric):
+        """Time scipy.spatial.distance.cdist over a range of input data
+        sizes and metrics.
+        """
+        distance.cdist(self.points, self.points, metric)

--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -173,6 +173,7 @@ class Cdist(Benchmark):
     param_names = ['num_points', 'metric']
 
     def setup(self, num_points, metric):
+        np.random.seed(123)
         self.points = np.random.random_sample((num_points, 3))
 
     def time_cdist(self, num_points, metric):

--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -165,7 +165,7 @@ class SphericalVorSort(Benchmark):
         self.sv.sort_vertices_of_regions()
 
 class Cdist(Benchmark):
-    params = ([10, 100, 1000, 5000], ['euclidean', 'minkowski', 'cityblock',
+    params = ([10, 100, 1000], ['euclidean', 'minkowski', 'cityblock',
     'seuclidean', 'sqeuclidean', 'cosine', 'correlation', 'hamming', 'jaccard',
     'chebyshev', 'canberra', 'braycurtis', 'mahalanobis', 'yule', 'dice',
     'kulsinski', 'rogerstanimoto', 'russellrao', 'sokalmichener',


### PR DESCRIPTION
### Purpose

`scipy.spatial.distance.cdist` is not currently covered by airspeed velocity benchmarks to prevent performance regressions, so I've drafted some simple (default arguments & 3 dimensions) benchmarks in this PR.
### Results

I tested the benchmarks on my machine as follows (at path: `scipy/benchmarks`):

```
asv run --bench Cdist -e
```

with the following output:

```
               ============ ================ ==========
                num_points       metric                
               ------------ ---------------- ----------
                    10         euclidean       9.15μs  
                    10         minkowski      21.12μs  
                    10         cityblock       8.80μs  
                    10         seuclidean     42.93μs  
                    10        sqeuclidean      9.57μs  
                    10           cosine       32.58μs  
                    10        correlation     60.58μs  
                    10          hamming       10.05μs  
                    10          jaccard       11.01μs  
                    10         chebyshev       8.86μs  
                    10          canberra       9.39μs  
                    10         braycurtis      8.90μs  
                    10        mahalanobis     69.32μs  
                    10            yule        10.74μs  
                    10            dice        10.39μs  
                    10         kulsinski      10.47μs  
                    10       rogerstanimoto   10.60μs  
                    10         russellrao     10.38μs  
                    10       sokalmichener    10.51μs  
                    10        sokalsneath     10.61μs  
                    10         wminkowski     16.98μs  
                   100         euclidean      50.82μs  
                   100         minkowski       1.08ms  
                   100         cityblock      40.47μs  
                   100         seuclidean     215.08μs 
                   100        sqeuclidean     40.18μs  
                   100           cosine       110.24μs 
                   100        correlation     144.77μs 
                   100          hamming       52.80μs  
                   100          jaccard       104.82μs 
                   100         chebyshev      40.33μs  
                   100          canberra      132.67μs 
                   100         braycurtis     52.42μs  
                   100        mahalanobis     202.93μs 
                   100            yule        101.72μs 
                   100            dice        71.39μs  
                   100         kulsinski      73.30μs  
                   100       rogerstanimoto   58.20μs  
                   100         russellrao     56.80μs  
                   100       sokalmichener    57.71μs  
                   100        sokalsneath     76.62μs  
                   100         wminkowski     657.17μs 
                   1000        euclidean       4.42ms  
                   1000        minkowski      108.66ms 
                   1000        cityblock       3.21ms  
                   1000        seuclidean     16.92ms  
                   1000       sqeuclidean      3.34ms  
                   1000          cosine        7.86ms  
                   1000       correlation      7.88ms  
                   1000         hamming        4.41ms  
                   1000         jaccard        9.82ms  
                   1000        chebyshev       3.27ms  
                   1000         canberra      12.49ms  
                   1000        braycurtis      4.41ms  
                   1000       mahalanobis     13.16ms  
                   1000           yule         9.20ms  
                   1000           dice         6.16ms  
                   1000        kulsinski       6.34ms  
                   1000      rogerstanimoto    4.83ms  
                   1000        russellrao      4.71ms  
                   1000      sokalmichener     4.86ms  
                   1000       sokalsneath      6.10ms  
                   1000        wminkowski     26.61ms  
                   5000        euclidean      177.87ms 
                   5000        minkowski       2.83s   
                   5000        cityblock      149.30ms 
                   5000        seuclidean     488.39ms 
                   5000       sqeuclidean     149.97ms 
                   5000          cosine       440.17ms 
                   5000       correlation     423.31ms 
                   5000         hamming       176.27ms 
                   5000         jaccard       309.46ms 
                   5000        chebyshev      148.93ms 
                   5000         canberra      382.66ms 
                   5000        braycurtis     182.34ms 
                   5000       mahalanobis     396.37ms 
                   5000           yule        298.97ms 
                   5000           dice        219.53ms 
                   5000        kulsinski      222.56ms 
                   5000      rogerstanimoto   190.20ms 
                   5000        russellrao     189.20ms 
                   5000      sokalmichener    187.58ms 
                   5000       sokalsneath     224.23ms 
                   5000        wminkowski      4.06s   
               ============ ================ ==========
```
### Considerations
- It would be nice if we could avoid writing the explicit names of all the valid distance metrics; I experimented with some of the data structures in `scipy.spatial.distance` and found that `distance._SIMPLE_CDIST.keys()` was promising to pull in some of the names, but it also contains synonyms (redundant in a testing context -- i.e., `eu`, `euclid`, `euclidean`). I figured that, at the end of the day, the code required to filter the redundancies probably wouldn't be much shorter than writing out the names explicitly
- Some of the distance metrics are intended for use with boolean arrays, but they work just fine here without any special treatment, so I guess that's ok
- There may be no compelling reason to get up to 5000 x 5000 matrix tests if those are deemed rather time consuming
