### PR TITLE
MAINT: optimize.least_squares: Raise an exception if the initial guess x0 is complex

### DIFF
--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -238,7 +238,7 @@ def least_squares(
         jac_sparsity=None, max_nfev=None, verbose=0, args=(), kwargs={}):
     """Solve a nonlinear least-squares problem with bounds on the variables.
 
-    Given the residuals f(x) (an m-dimensional function of n variables) and
+    Given the residuals f(x) (an m-dimensional function of n real variables) and
     the loss function rho(s) (a scalar function), `least_squares` finds a
     local minimum of the cost function F(x)::
 
@@ -735,6 +735,9 @@ def least_squares(
 
     if max_nfev is not None and max_nfev <= 0:
         raise ValueError("`max_nfev` must be None or positive integer.")
+
+    if np.iscomplexobj(x0):
+        raise ValueError("`x0` must be real.")
 
     x0 = np.atleast_1d(x0).astype(float)
 

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -336,6 +336,16 @@ class BaseMixin(object):
         assert_raises(ValueError, least_squares, fun_trivial, x0,
                       method=self.method)
 
+    def test_x0_complex_scalar(self):
+        x0 = 2.0 + 0.0*1j
+        assert_raises(ValueError, least_squares, fun_trivial, x0,
+                      method=self.method)
+
+    def test_x0_complex_array(self):
+        x0 = [1.0, 2.0 + 0.0*1j]
+        assert_raises(ValueError, least_squares, fun_trivial, x0,
+                      method=self.method)
+
     def test_bvp(self):
         # This test was introduced with fix #5556. It turned out that
         # dogbox solver had a bug with trust-region radius update, which


### PR DESCRIPTION
See #6506

Should I also add similar checks to other solvers?

Edit: Sorry, wrong issue number.
