### PR TITLE
ENH: add initial guess to sparse.linalg.lsqr

### DIFF
--- a/scipy/sparse/linalg/isolve/lsqr.py
+++ b/scipy/sparse/linalg/isolve/lsqr.py
@@ -96,7 +96,7 @@ def _sym_ortho(a, b):
 
 
 def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
-         iter_lim=None, show=False, calc_var=False):
+         iter_lim=None, show=False, calc_var=False, x0=None):
     """Find the least-squares solution to a large, sparse, linear system
     of equations.
 
@@ -145,6 +145,10 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
         Display an iteration log.
     calc_var : bool, optional
         Whether to estimate diagonals of ``(A'A + damp^2*I)^{-1}``.
+    x0 : array_like, shape (n,), optional
+        Initial guess of x, if None zeros are used.
+
+        .. versionadded:: 0.19.0
 
     Returns
     -------
@@ -298,27 +302,32 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
 
     """
     Set up the first vectors u and v for the bidiagonalization.
-    These satisfy  beta*u = b,  alfa*v = A'u.
+    These satisfy  beta*u = b - A*x,  alfa*v = A'*u.
     """
-    v = np.zeros(n)
     u = b
-    x = np.zeros(n)
-    alfa = 0
-    beta = np.linalg.norm(u)
-    w = np.zeros(n)
+    bnorm = np.linalg.norm(b)
+    if x0 is None:
+        x = np.zeros(n)
+        beta = bnorm.copy()
+    else:
+        x = np.asarray(x0)
+        u = u - A.matvec(x)
+        beta = np.linalg.norm(u)
 
     if beta > 0:
         u = (1/beta) * u
         v = A.rmatvec(u)
         alfa = np.linalg.norm(v)
+    else:
+        v = x.copy()
+        alfa = 0
 
     if alfa > 0:
         v = (1/alfa) * v
-        w = v.copy()
+    w = v.copy()
 
     rhobar = alfa
     phibar = beta
-    bnorm = beta
     rnorm = beta
     r1norm = rnorm
     r2norm = rnorm

--- a/scipy/sparse/linalg/isolve/lsqr.py
+++ b/scipy/sparse/linalg/isolve/lsqr.py
@@ -148,7 +148,7 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
     x0 : array_like, shape (n,), optional
         Initial guess of x, if None zeros are used.
 
-        .. versionadded:: 0.19.0
+        .. versionadded:: 1.0.0
 
     Returns
     -------

--- a/scipy/sparse/linalg/isolve/tests/test_lsqr.py
+++ b/scipy/sparse/linalg/isolve/tests/test_lsqr.py
@@ -30,11 +30,13 @@ maxit = None
 
 
 def test_basic():
-    svx = np.linalg.solve(G, b)
+    b_copy = b.copy()
     X = lsqr(G, b, show=show, atol=tol, btol=tol, iter_lim=maxit)
+    assert_(np.all(b_copy == b))
+
+    svx = np.linalg.solve(G, b)
     xo = X[0]
     assert_(norm(svx - xo) < 1e-5)
-
 
 def test_gh_2466():
     row = np.array([0, 0])
@@ -87,6 +89,22 @@ def test_b_shapes():
     b = np.ones((10, 1))
     x = lsqr(A, b)[0]
     assert_almost_equal(norm(A.dot(x) - b.ravel()), 0)
+
+
+def test_initialization():
+    # Test the default setting is the same as zeros
+    b_copy = b.copy()
+    x_ref = lsqr(G, b, show=show, atol=tol, btol=tol, iter_lim=maxit)
+    x0 = np.zeros(x_ref[0].shape)
+    x = lsqr(G, b, show=show, atol=tol, btol=tol, iter_lim=maxit, x0=x0)
+    assert_(np.all(b_copy == b))
+    assert_array_almost_equal(x_ref[0], x[0])
+
+    # Test warm-start with single iteration
+    x0 = lsqr(G, b, show=show, atol=tol, btol=tol, iter_lim=1)[0]
+    x = lsqr(G, b, show=show, atol=tol, btol=tol, iter_lim=maxit, x0=x0)
+    assert_array_almost_equal(x_ref[0], x[0])
+    assert_(np.all(b_copy == b))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Instead of always assuming an initial guess of zero for x, allow the user
to specify x0 as an initial guess to allow for potentially faster convergence.
