### PR TITLE
ENH: A method to return the numerical inverse of a function

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -165,6 +165,7 @@ on data.
 Antonio Ribeiro for implementing irrnotch and iirpeak functions.
 Ilhan Polat for bug fixes on Riccati solvers.
 Sebastiano Vigna for code in the stats package related to Kendall's tau.
+Alvaro Sanchez-Gonzalez for the inversefunc function in misc.
 
 Institutions
 ------------

--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -98,6 +98,12 @@ spline given data points and boundary conditions.
 New function `scipy.interpolate.make_lsq_spline` constructs a least-squares
 spline approximation given data points.
 
+`scipy.misc` improvements
+--------------------------------
+
+New function `scipy.misc.inversefunc` returns a callable implementing the
+inverse of an input function.
+
 
 Deprecated features
 ===================

--- a/doc/source/tutorial/basic.rst
+++ b/doc/source/tutorial/basic.rst
@@ -251,6 +251,8 @@ functions compute :math:`n!` and :math:`n!/k!(n-k)!` using either
 exact integer arithmetic (thanks to Python's Long integer object), or
 by using floating-point precision and the gamma function. Another
 function returns a common image used in image processing: :obj:`lena`.
+Also :obj:`inversefunc` can be used to calculate the numerical inverse
+of a function.
 
 Finally, two functions are provided that are useful for approximating
 derivatives of functions using discrete-differences. The function

--- a/scipy/misc/__init__.py
+++ b/scipy/misc/__init__.py
@@ -31,6 +31,7 @@ below are not available without it.
    imsave - Save an array to an image file [requires Pillow] 
    imshow - Simple showing of an image through an external viewer [requires Pillow]
    info - Get help information for a function, class, or module
+   inversefunc - Obtain the numerical inverse of a function
    lena - Get classic image processing example image Lena
    logsumexp - Compute the log of the sum of exponentials of input elements
    pade - Pade approximation to function as the ratio of two polynomials

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -484,10 +484,10 @@ def inversefunc(f, vmin=None, vmax=None,
     array([  4.31643739e-06,   1.57079633e+00,   3.14158845e+00])
     >>> tan = (lambda x: np.tan(x))
     >>> invtan = scipy.misc.inversefunc(tan,
-    >>>                                 vmin=-np.pi / 2,
-    >>>                                 vmax=np.pi / 2,
-    >>>                                 vminopen=True,
-    >>>                                 vmaxopen=True)
+    ...                                 vmin=-np.pi / 2,
+    ...                                 vmax=np.pi / 2,
+    ...                                 vminopen=True,
+    ...                                 vmaxopen=True)
     >>> invtan([1, 0, -1]) # Should give [pi / 4, 0, -pi / 4]
     array([ 0.78539955,  0.        , -0.78539955])
 

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -455,6 +455,11 @@ def inversefunc(f,vmin=None,vmax=None,vminopen=False,vmaxopen=False,accuracy=2):
         Inverse function of `f`. It can take scalars or ndarrays, and return
         objects of the same kind with the calculated inverse values.
 
+    Notes
+    -----
+
+    .. versionadded:: 0.19.0
+
     Examples
     --------
     >>> import scipy.misc

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -16,8 +16,8 @@ from numpy import (exp, log, asarray, arange, newaxis, hstack, product, array,
 from scipy._lib._util import _asarray_validated
 from scipy.optimize import minimize_scalar
 
-__all__ = ['logsumexp', 'inversefunc', 'central_diff_weights', 'derivative', 'pade', 'lena',
-           'ascent', 'face']
+__all__ = ['logsumexp', 'central_diff_weights', 'derivative', 'pade', 'lena',
+           'ascent', 'face', 'inversefunc']
 
 
 def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
@@ -421,34 +421,36 @@ def face(gray=False):
     return face
 
 
-def inversefunc(f,vmin=None,vmax=None,vminopen=False,vmaxopen=False,accuracy=2):
+def inversefunc(f, vmin=None, vmax=None,
+                vminopen=False, vmaxopen=False,
+                accuracy=2):
     r"""Obtain the inverse of a function.
-    
+
     Returns a callable that calculates the numerical inverse of the function
-    `f`. In order for the enumerical inverse to exist in an interval, the 
-    input function must have monotonic behavior i.e. be a purely decreasing 
+    `f`. In order for the enumerical inverse to exist in an interval, the
+    input function must have monotonic behavior i.e. be a purely decreasing
     or purely increasing in that interval. By default the interval spans all
     the real numbers, howevere it can be restricted with the `vmin` and `vmax`
-    arguments to [`vmin`, `vmax`],  (`vmin`, `vmax`],  [`vmin`, `vmax`) or  
+    arguments to [`vmin`, `vmax`],  [`vmin`, `vmax`), (`vmin`, `vmax`] or
     (`vmin`, `vmax`) depending on `vminopen` and `vmaxopen`.
-    
+
     Parameters
     ----------
     f : callable
         Callable representing the function to be inverted, able to take a
-        ndarray or an scalar and return an object of the same kind with the 
-        evaluation of the function. The function must not diverge and have a 
+        ndarray or an scalar and return an object of the same kind with the
+        evaluation of the function. The function must not diverge and have a
         monotonic behavior in the chosen interval.
     vmin : float, optional
         Lower side of the interval. Default None (-Inf).
     vminopen : bool, optional
-        Whether the interval has an open end at `vmin`. Default False.  
+        Whether the interval has an open end at `vmin`. Default False.
     vmax : float, optional
-        Higher side of the interval. It must be strictly larger than `vmin`. 
+        Higher side of the interval. It must be strictly larger than `vmin`.
         Default None (-Inf).
     vminopen : bool, optional
-        Whether the interval has an open end at `vmax`. Default False.   
-    
+        Whether the interval has an open end at `vmax`. Default False.
+
     Returns
     -------
     callable
@@ -464,100 +466,101 @@ def inversefunc(f,vmin=None,vmax=None,vminopen=False,vmaxopen=False,accuracy=2):
     --------
     >>> import scipy.misc
     >>> import numpy as np
-    >>> cube = lambda x: x**3
+    >>> cube = (lambda x: x**3)
     >>> invcube = scipy.misc.inversefunc(cube)
     >>> invcube(27) # Should give 3
     array(3.0000000063797567)
-    >>> square = lambda x: x**2
+    >>> square = (lambda x: x**2)
     >>> invsquare = scipy.misc.inversefunc(square, vmin=0, accuracy=4)
-    >>> invsquare([4,16,64]) # Should give [2, 4, 8]
+    >>> invsquare([4, 16, 64]) # Should give [2, 4, 8]
     array([ 2.        ,  4.00096317,  8.00028687])
-    >>> log = lambda x: np.log10(x)
+    >>> log = (lambda x: np.log10(x))
     >>> invlog = scipy.misc.inversefunc(log, vmin=0, vminopen=True)
     >>> invlog(-2.) # Should give 0.01
     array(0.010001898156620113)
-    >>> cos = lambda x: np.cos(x)
+    >>> cos = (lambda x: np.cos(x))
     >>> invcos = scipy.misc.inversefunc(cos, vmin=0, vmax=np.pi)
-    >>> invcos([1,0,-1]) # Should give [0, pi/2, pi]
+    >>> invcos([1, 0, -1]) # Should give [0, pi / 2, pi]
     array([  4.31643739e-06,   1.57079633e+00,   3.14158845e+00])
-    >>> tan = lambda x: np.tan(x)
-    >>> invtan = scipy.misc.inversefunc(tan, 
-                                    vmin=-np.pi/2, 
-                                    vmax=np.pi/2, 
-                                    vminopen=True, 
+    >>> tan = (lambda x: np.tan(x))
+    >>> invtan = scipy.misc.inversefunc(tan,
+                                    vmin=-np.pi / 2,
+                                    vmax=np.pi / 2,
+                                    vminopen=True,
                                     vmaxopen=True)
-    >>> invtan([1,0,-1]) # Should give [pi/4, 0, -pi/4]
+    >>> invtan([1, 0, -1]) # Should give [pi / 4, 0, -pi / 4]
     array([ 0.78539955,  0.        , -0.78539955])
-    
-    """
 
+    """
     if vmin is not None:
-        vmin=float(vmin)
+        vmin = float(vmin)
     if vmax is not None:
-        vmax=float(vmax)
-    
+        vmax = float(vmax)
+
     if vmin is not None and vmax is not None:
         if vmin >= vmax:
             raise ValueError("vmin must be less than vmax")
-    
-    min_kwargs={}
-    constraint=None
-    
+
+    min_kwargs = {}
+    constraint = None
+
     if vmin is not None and vmax is not None:
-        min_kwargs['method']='bounded'
-        min_kwargs['bounds']=(vmin,vmax)
+        min_kwargs['method'] = 'bounded'
+        min_kwargs['bounds'] = (vmin, vmax)
         if vminopen:
-            constraint=lambda x: (x-vmin>0)
+            constraint = (lambda x: (x - vmin > 0))
         if vmaxopen:
-            constraint=lambda x: (vmax-x>0)
-        if vminopen and vminopen:
-            constraint=lambda x: (vmax-x>0)*(x-vmin>0)
+            constraint = (lambda x: (vmax - x > 0))
+        if vminopen and vmaxopen:
+            constraint = (lambda x: (vmax - x > 0) * (x - vmin > 0))
     elif vmin is not None:
         if vminopen:
-            constraint=lambda x: x-vmin>0
-            min_kwargs['bracket']=(vmin+1,vmin+2)
+            constraint = (lambda x: x - vmin > 0)
+            min_kwargs['bracket'] = (vmin + 1, vmin + 2)
         else:
-            constraint=lambda x: x-vmin>=0
-            min_kwargs['bracket']=(vmin,vmin+2)
-        min_kwargs['tol']=10.**(-accuracy-1)
+            constraint = (lambda x: x - vmin >= 0)
+            min_kwargs['bracket'] = (vmin, vmin + 2)
+        min_kwargs['tol'] = 10.**(-accuracy - 1)
     elif vmax is not None:
         if vmaxopen:
-            constraint=lambda x: vmax-x>0
-            min_kwargs['bracket']=(vmax-2,vmax-1)
+            constraint = (lambda x: vmax - x > 0)
+            min_kwargs['bracket'] = (vmax - 2, vmax - 1)
         else:
-            constraint=lambda x: vmax-x>=0
-            min_kwargs['bracket']=(vmax-2,vmax)
-        min_kwargs['tol']=10.**(-accuracy-1)
+            constraint = (lambda x: vmax - x >= 0)
+            min_kwargs['bracket'] = (vmax - 2, vmax)
+        min_kwargs['tol'] = 10.**(-accuracy - 1)
 
     def inv(xin):
-        xin=np.asarray(xin, dtype=np.float64)
-        shapein=xin.shape
-        xin=xin.flatten()
-        results=xin.copy()*np.nan
-        resultsmask=np.zeros(xin.shape,dtype=np.bool)
-        
+        xin = np.asarray(xin, dtype=np.float64)
+        shapein = xin.shape
+        xin = xin.flatten()
+        results = xin.copy() * np.nan
+        resultsmask = np.zeros(xin.shape, dtype=np.bool)
+
         for j in range(xin.size):
-            if constraint:    
-                optimizer=lambda x, j=j,f=f: ((((f(x)-xin[j]))**2).sum() 
-                                              if constraint(x) else np.inf)
+            if constraint:
+                optimizer = (lambda x, j=j, f=f: ((((f(x) - xin[j]))**2)
+                                                  if constraint(x)
+                                                  else np.inf))
             else:
-                optimizer=lambda x, j=j,f=f: (((f(x)-xin[j]))**2).sum()
-            result=minimize_scalar(optimizer,**min_kwargs)
+                optimizer = (lambda x, j=j, f=f: (((f(x) - xin[j]))**2))
+            result = minimize_scalar(optimizer, **min_kwargs)
             try:
-                results[j]=result.x
-                resultsmask[j]=result.success
+                results[j] = result.x
+                resultsmask[j] = result.success
             except:
-                resultsmask[j]=False
-        if any(resultsmask==False):
+                resultsmask[j] = False
+        if any(~resultsmask):
             warnings.warn("Trouble calculating inverse for values: "
-                          "%s" % str(xin[~resultsmask]),RuntimeWarning)
-        
+                          "%s" % str(xin[~resultsmask]), RuntimeWarning)
+
         try:
-            np.testing.assert_array_almost_equal(xin,f(results), decimal=accuracy)
-        except AssertionError:        
-            warnings.warn("Results obtained with less than %g "  
+            np.testing.assert_array_almost_equal(xin, f(results),
+                                                 decimal=accuracy)
+        except AssertionError:
+            warnings.warn("Results obtained with less than %g "
                           "decimal digits of accuracy"
-                          %accuracy,RuntimeWarning)
-            
+                          % accuracy, RuntimeWarning)
+
         return results.reshape(shapein)
     return inv

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -430,7 +430,7 @@ def inversefunc(f, vmin=None, vmax=None,
     `f`. In order for the enumerical inverse to exist in an interval, the
     input function must have monotonic behavior i.e. be a purely decreasing
     or purely increasing in that interval. By default the interval spans all
-    the real numbers, howevere it can be restricted with the `vmin` and `vmax`
+    the real numbers, however it can be restricted with the `vmin` and `vmax`
     arguments to [`vmin`, `vmax`],  [`vmin`, `vmax`), (`vmin`, `vmax`] or
     (`vmin`, `vmax`) depending on `vminopen` and `vmaxopen`.
 
@@ -484,10 +484,10 @@ def inversefunc(f, vmin=None, vmax=None,
     array([  4.31643739e-06,   1.57079633e+00,   3.14158845e+00])
     >>> tan = (lambda x: np.tan(x))
     >>> invtan = scipy.misc.inversefunc(tan,
-                                    vmin=-np.pi / 2,
-                                    vmax=np.pi / 2,
-                                    vminopen=True,
-                                    vmaxopen=True)
+    >>>                                 vmin=-np.pi / 2,
+    >>>                                 vmax=np.pi / 2,
+    >>>                                 vminopen=True,
+    >>>                                 vmaxopen=True)
     >>> invtan([1, 0, -1]) # Should give [pi / 4, 0, -pi / 4]
     array([ 0.78539955,  0.        , -0.78539955])
 

--- a/scipy/misc/common.py
+++ b/scipy/misc/common.py
@@ -421,18 +421,21 @@ def face(gray=False):
     return face
 
 
-def inversefunc(f, vmin=None, vmax=None,
-                vminopen=False, vmaxopen=False,
+def inversefunc(f,
+                domain=None,
+                image=None,
+                open_domain=None,
                 accuracy=2):
     r"""Obtain the inverse of a function.
 
     Returns a callable that calculates the numerical inverse of the function
-    `f`. In order for the enumerical inverse to exist in an interval, the
-    input function must have monotonic behavior i.e. be a purely decreasing
-    or purely increasing in that interval. By default the interval spans all
-    the real numbers, however it can be restricted with the `vmin` and `vmax`
-    arguments to [`vmin`, `vmax`],  [`vmin`, `vmax`), (`vmin`, `vmax`] or
-    (`vmin`, `vmax`) depending on `vminopen` and `vmaxopen`.
+    `f`. In order for the numerical inverse to exist in its domain, the
+    input function must have, continuous, strictly monotonic behavior i.e. be a
+    purely decreasing or purely increasing in that domain. By default the
+    domain interval spans all the real numbers, however it can be restricted
+    with the `domain` and `open_domain` arguments. The image of the function
+    in the interval may be provided, for cases where the function is non
+    non continuous right at the end of an open interval.
 
     Parameters
     ----------
@@ -441,15 +444,26 @@ def inversefunc(f, vmin=None, vmax=None,
         ndarray or an scalar and return an object of the same kind with the
         evaluation of the function. The function must not diverge and have a
         monotonic behavior in the chosen interval.
-    vmin : float, optional
-        Lower side of the interval. Default None (-Inf).
-    vminopen : bool, optional
-        Whether the interval has an open end at `vmin`. Default False.
-    vmax : float, optional
-        Higher side of the interval. It must be strictly larger than `vmin`.
-        Default None (-Inf).
-    vminopen : bool, optional
-        Whether the interval has an open end at `vmax`. Default False.
+    domain : float, ndarray, optional
+        Boundaries of the domain (`domain[0]`, `domain[1]`).
+        `domain[1]` must be larger than `domain[0]`.
+        None values are assumed to be no boundary in that direction.
+        A single scalar value will set it to [`domain`, None].
+        Default None (-Inf, Inf).
+    open_domain : bool, ndarray, optional
+        Whether the domain is an open interval at each of the ends.
+        A single scalar boolean will set it to [`open_domain`, `open_domain`].
+        Default None [False, False].
+    image : float, ndarray, optional
+        Image of the function in the domain (`image[0]`, `image[1]`).
+        `image[1]` must be larger than `image[0]`.
+        None values are assumed to be no boundary in that direction.
+        Default None, this is (-Inf, Inf) if domain is None, or the limits
+        set by f(domain[0]) and f(domain[1]).
+    accuracy : int, optional
+        Number of digits for the desired accuracy. It will give a warning
+        if the accuracy is worse than this.
+        Default 2.
 
     Returns
     -------
@@ -471,91 +485,178 @@ def inversefunc(f, vmin=None, vmax=None,
     >>> invcube(27) # Should give 3
     array(3.0000000063797567)
     >>> square = (lambda x: x**2)
-    >>> invsquare = scipy.misc.inversefunc(square, vmin=0, accuracy=4)
+    >>> invsquare = scipy.misc.inversefunc(square, domain=0)
     >>> invsquare([4, 16, 64]) # Should give [2, 4, 8]
-    array([ 2.        ,  4.00096317,  8.00028687])
+    array([ 2.,  4.,  8.])
     >>> log = (lambda x: np.log10(x))
-    >>> invlog = scipy.misc.inversefunc(log, vmin=0, vminopen=True)
+    >>> invlog = scipy.misc.inversefunc(log, domain=0, open_domain=True)
     >>> invlog(-2.) # Should give 0.01
-    array(0.010001898156620113)
+    array(0.0099999999882423)
     >>> cos = (lambda x: np.cos(x))
-    >>> invcos = scipy.misc.inversefunc(cos, vmin=0, vmax=np.pi)
+    >>> invcos = scipy.misc.inversefunc(cos, domain=[0, np.pi])
     >>> invcos([1, 0, -1]) # Should give [0, pi / 2, pi]
-    array([  4.31643739e-06,   1.57079633e+00,   3.14158845e+00])
+    array([  5.44203736e-09,   1.57079632e+00,   3.14159265e+00])
     >>> tan = (lambda x: np.tan(x))
     >>> invtan = scipy.misc.inversefunc(tan,
-    ...                                 vmin=-np.pi / 2,
-    ...                                 vmax=np.pi / 2,
-    ...                                 vminopen=True,
-    ...                                 vmaxopen=True)
+    ...                                 domain=[-np.pi / 2, np.pi / 2],
+    ...                                 open_domain=True)
     >>> invtan([1, 0, -1]) # Should give [pi / 4, 0, -pi / 4]
-    array([ 0.78539955,  0.        , -0.78539955])
+    array([  7.85398163e-01,   1.29246971e-26,  -7.85398163e-01])
 
     """
-    if vmin is not None:
-        vmin = float(vmin)
-    if vmax is not None:
-        vmax = float(vmax)
+    error_domain = ("domain must be a single scalar, or a have two "
+                    "elements [xmin, xmax]. Set None, to leave it "
+                    "unlimited on one side.")
 
-    if vmin is not None and vmax is not None:
-        if vmin >= vmax:
-            raise ValueError("vmin must be less than vmax")
+    # Homogenizing parameters
+    if domain is None:
+        xmin = None
+        xmax = None
+    else:
+        domain = np.asarray(domain)
+        if domain.ndim == 0:
+            xmin = float(domain)
+            xmax = None
+        elif domain.ndim == 1 and domain.size != 2:
+            raise ValueError(error_domain)
+        elif domain.ndim > 1:
+            raise ValueError(error_domain)
+        else:
+            xmin = (float(domain[0]) if domain[0] is not None else None)
+            xmax = (float(domain[1]) if domain[1] is not None else None)
+
+    error_open_domain = ("open_domain must be a single scalar, or a have two "
+                         "bool elements [open_xmin, open_xmax].")
+    if open_domain is None:
+        xmin_open = False
+        xmax_open = False
+    else:
+        open_domain = np.asarray(open_domain)
+        if open_domain.ndim == 0:
+            xmin_open = bool(open_domain)
+            xmax_open = bool(open_domain)
+        elif open_domain.ndim == 1 and domain.size != 2:
+            raise ValueError(error_open_domain)
+        elif open_domain.ndim > 1:
+            raise ValueError(error_open_domain)
+        else:
+            xmin_open = bool(open_domain[0])
+            xmax_open = bool(open_domain[1])
+
+    error_image = ("image must be a single scalar, or a have two "
+                   "bool elements [ymin, ymax].")
+    if image is None:
+        ymin = None
+        ymax = None
+    else:
+        image = np.asarray(image)
+        if image.ndim != 1 or image.size != 2:
+            raise ValueError(error_image)
+        else:
+            ymin = (float(image[0]) if image[0] is not None else None)
+            ymax = (float(image[1]) if image[1] is not None else None)
+
+    if xmin is not None and xmax is not None:
+        if xmin >= xmax:
+            raise ValueError("domain[0] min must be less than domain[1]")
+
+    if ymin is not None and ymax is not None:
+        if ymin >= ymax:
+            raise ValueError("image[0] min must be less than image[1]")
+
+    # Calculating if the function is increasing or decreasing, using ref points
+    # anywhere in the valid range (Function has to be strictly monotonic)
+    if xmin is not None and xmax is not None:
+        d = xmax-xmin
+        ref1 = xmin + d/4.
+        ref2 = xmax - d/4.
+    elif xmin is not None:
+        ref1 = xmin+1.
+        ref2 = xmin+2.
+    elif xmax is not None:
+        ref1 = xmax-2.
+        ref2 = xmax-1.
+    else:
+        ref1 = 0.
+        ref2 = 1.
+    trend = np.sign(f(ref2)-f(ref1))
+
+    if trend == 0:
+        raise ValueError("Function is not strictly monotonic")
+
+    # Calculating the image by default
+    if ymin is None and ((xmin is not None and trend == 1) or
+                         (xmax is not None and trend == -1)):
+        try:
+            with warnings.catch_warnings(record=True):
+                ymin = f(xmin) if trend == 1 else f(xmax)
+        except:
+            raise ValueError("Cannot automatically calculate the lower limit "
+                             "of the image please inclue it as a parameter")
+    if ymax is None and ((xmax is not None and trend == 1) or
+                         (xmin is not None and trend == -1)):
+        try:
+            with warnings.catch_warnings(record=True):
+                ymax = f(xmax) if trend == 1 else f(xmin)
+        except:
+            raise ValueError("Cannot automatically calculate the upper limit "
+                             "of the image please include it as a parameter")
+
+    # Creating bounded function
+    def bounded_f(x):
+        if xmin is not None and (x < xmin or (x == xmin and xmin_open)):
+                val = -1*np.inf*trend
+        elif xmax is not None and (x > xmax or (x == xmax and xmax_open)):
+                val = np.inf*trend
+        else:
+            val = f(x)
+        return val
 
     min_kwargs = {}
-    constraint = None
+    min_kwargs['bracket'] = (ref1, ref2)
+    min_kwargs['tol'] = 1.48e-08
+    min_kwargs['method'] = 'Brent'
 
-    if vmin is not None and vmax is not None:
-        min_kwargs['method'] = 'bounded'
-        min_kwargs['bounds'] = (vmin, vmax)
-        if vminopen:
-            constraint = (lambda x: (x - vmin > 0))
-        if vmaxopen:
-            constraint = (lambda x: (vmax - x > 0))
-        if vminopen and vmaxopen:
-            constraint = (lambda x: (vmax - x > 0) * (x - vmin > 0))
-    elif vmin is not None:
-        if vminopen:
-            constraint = (lambda x: x - vmin > 0)
-            min_kwargs['bracket'] = (vmin + 1, vmin + 2)
-        else:
-            constraint = (lambda x: x - vmin >= 0)
-            min_kwargs['bracket'] = (vmin, vmin + 2)
-        min_kwargs['tol'] = 10.**(-accuracy - 1)
-    elif vmax is not None:
-        if vmaxopen:
-            constraint = (lambda x: vmax - x > 0)
-            min_kwargs['bracket'] = (vmax - 2, vmax - 1)
-        else:
-            constraint = (lambda x: vmax - x >= 0)
-            min_kwargs['bracket'] = (vmax - 2, vmax)
-        min_kwargs['tol'] = 10.**(-accuracy - 1)
+    def inv(yin):
+        yin = np.asarray(yin, dtype=np.float64)
+        shapein = yin.shape
+        yin = yin.flatten()
 
-    def inv(xin):
-        xin = np.asarray(xin, dtype=np.float64)
-        shapein = xin.shape
-        xin = xin.flatten()
-        results = xin.copy() * np.nan
-        resultsmask = np.zeros(xin.shape, dtype=np.bool)
-
-        for j in range(xin.size):
-            if constraint:
-                optimizer = (lambda x, j=j, f=f: ((((f(x) - xin[j]))**2)
-                                                  if constraint(x)
-                                                  else np.inf))
+        if ymin is not None:
+            if xmin_open:
+                mask = yin <= ymin
             else:
-                optimizer = (lambda x, j=j, f=f: (((f(x) - xin[j]))**2))
-            result = minimize_scalar(optimizer, **min_kwargs)
+                mask = yin < ymin
+            if yin[mask].size > 0:
+                ValueError("Requested values %s lower than the lower limit"
+                           "%g of the image" % (yin[mask], ymin))
+        if ymax is not None:
+            if xmax_open:
+                mask = yin >= ymax
+            else:
+                mask = yin > ymax
+            if yin[mask].size > 0:
+                ValueError("Requested values %s higher than the higher limit"
+                           "%g of the image" % (yin[mask], ymax))
+
+        results = yin.copy() * np.nan
+        resultsmask = np.zeros(yin.shape, dtype=np.bool)
+
+        for j in range(yin.size):
+            optimizer = (lambda x, j=j, f=f: (((bounded_f(x) - yin[j]))**2))
             try:
+                with warnings.catch_warnings(record=True):
+                    result = minimize_scalar(optimizer, **min_kwargs)
                 results[j] = result.x
                 resultsmask[j] = result.success
             except:
                 resultsmask[j] = False
         if any(~resultsmask):
             warnings.warn("Trouble calculating inverse for values: "
-                          "%s" % str(xin[~resultsmask]), RuntimeWarning)
+                          "%s" % str(yin[~resultsmask]), RuntimeWarning)
 
         try:
-            np.testing.assert_array_almost_equal(xin, f(results),
+            np.testing.assert_array_almost_equal(yin, f(results),
                                                  decimal=accuracy)
         except AssertionError:
             warnings.warn("Results obtained with less than %g "

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -180,7 +180,7 @@ def test_inversefunc_infinite():
                               [-3, -2, -1, 0, 1, 2, 3], accuracy)
 
 def test_inversefunc_vminclosed():
-    accuracy = 4
+    accuracy = 2
     square = (lambda x: x**2)
     invsquare = inversefunc(square, vmin=0, accuracy=accuracy)
     assert_array_almost_equal(invsquare([4, 16, 64]), [2, 4, 8], accuracy)
@@ -192,7 +192,7 @@ def test_inversefunc_vminopen():
     assert_array_almost_equal(invlog([-2., -3.]), [0.01, 0.001], accuracy)
 
 def test_inversefunc_vmaxclosed():
-    accuracy = 4
+    accuracy = 2
     square = (lambda x: x**2)
     invsquare = inversefunc(square, vmax=0, accuracy=accuracy)
     assert_array_almost_equal(invsquare([4, 16, 64]), [-2, -4, -8], accuracy)

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -173,64 +173,66 @@ def test_ascent():
 
 
 def test_inversefunc_infinite():
-    accuracy = 4
+    accuracy = 2
     cube = (lambda x: x**3)
-    invcube = inversefunc(cube, accuracy=accuracy)
+    invcube = inversefunc(cube)
     assert_array_almost_equal(invcube([-27, -8, -1, 0, 1, 8, 27]),
                               [-3, -2, -1, 0, 1, 2, 3], accuracy)
 
 def test_inversefunc_vminclosed():
     accuracy = 2
     square = (lambda x: x**2)
-    invsquare = inversefunc(square, vmin=0, accuracy=accuracy)
+    invsquare = inversefunc(square, domain=0)
     assert_array_almost_equal(invsquare([4, 16, 64]), [2, 4, 8], accuracy)
 
 def test_inversefunc_vminopen():
-    accuracy = 4
+    accuracy = 2
     log = (lambda x: np.log10(x))
-    invlog = inversefunc(log, vmin=0, vminopen=True)
+    invlog = inversefunc(log, domain=0,
+                         open_domain=True,
+                         image=[-np.inf, None])
     assert_array_almost_equal(invlog([-2., -3.]), [0.01, 0.001], accuracy)
 
 def test_inversefunc_vmaxclosed():
     accuracy = 2
     square = (lambda x: x**2)
-    invsquare = inversefunc(square, vmax=0, accuracy=accuracy)
+    invsquare = inversefunc(square, domain=[None, 0])
     assert_array_almost_equal(invsquare([4, 16, 64]), [-2, -4, -8], accuracy)
 
 def test_inversefunc_vmaxopen():
-    accuracy = 4
+    accuracy = 2
     log = (lambda x: np.log10(-x))
-    invlog = inversefunc(log, vmax=0., vmaxopen=True)
+    invlog = inversefunc(log, domain=[None, 0],
+                         open_domain=True,
+                         image=[-np.inf, None])
     assert_array_almost_equal(invlog([-2., -3.]), [-0.01, -0.001], accuracy)
 
 def test_inversefunc_vminclosedvmaxclosed():
-    accuracy = 4
+    accuracy = 2
     cos = (lambda x: np.cos(x))
-    invcos = inversefunc(cos, vmin=0, vmax=np.pi)
+    invcos = inversefunc(cos, domain=[0, np.pi])
     assert_array_almost_equal(invcos([1, 0, -1]),
                               [0., np.pi / 2, np.pi], accuracy)
 
 def test_inversefunc_vminopenvmaxclosed():
-    accuracy = 4
+    accuracy = 2
     cos = (lambda x: np.cos(x))
-    invcos = inversefunc(cos, vmin=0, vmax=np.pi, vminopen=True)
+    invcos = inversefunc(cos, domain=[0, np.pi], open_domain=[True, False])
     assert_array_almost_equal(invcos([1 / np.sqrt(2), 0, -1 / np.sqrt(2)]),
                               [np.pi / 4, np.pi / 2, 3 * np.pi / 4], accuracy)
 
 def test_inversefunc_vminclosedvmaxopen():
-    accuracy = 4
+    accuracy = 2
     cos = (lambda x: np.cos(x))
-    invcos = inversefunc(cos, vmin=0, vmax=np.pi, vmaxopen=True)
+    invcos = inversefunc(cos, domain=[0, np.pi], open_domain=[False, True])
     assert_array_almost_equal(invcos([1 / np.sqrt(2), 0, -1 / np.sqrt(2)]),
                               [np.pi / 4, np.pi / 2, 3 * np.pi / 4], accuracy)
 
 def test_inversefunc_vminopenvmaxopen():
-    accuracy = 4
+    accuracy = 2
     tan = (lambda x: np.tan(x))
     invtan = inversefunc(tan,
-                         vmin=-np.pi / 2,
-                         vmax=np.pi / 2,
-                         vminopen=True,
-                         vmaxopen=True)
+                         domain=[-np.pi/2, np.pi/2],
+                         open_domain=True)
     assert_array_almost_equal(invtan([1, 0, -1]),
                               [np.pi / 4, 0., -np.pi / 4], accuracy)

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -211,9 +211,9 @@ def test_inversefunc_vminvmaxclosed():
 def test_inversefunc_vminvmaxopen():
     accuracy=4
     tan = lambda x: np.tan(x)
-    invtan = inversefunc(tan, 
-                         vmin=-np.pi/2, 
-                         vmax=np.pi/2, 
-                         vminopen=True, 
+    invtan = inversefunc(tan,
+                         vmin=-np.pi/2,
+                         vmax=np.pi/2,
+                         vminopen=True,
                          vmaxopen=True)
     assert_array_almost_equal(invtan([1,0,-1]),[np.pi/4,0.,-np.pi/4],accuracy)

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import (assert_array_equal, assert_almost_equal,
                            assert_array_almost_equal, assert_equal, assert_)
 
-from scipy.misc import pade, logsumexp, face, ascent
+from scipy.misc import pade, logsumexp, face, ascent, inversefunc
 
 
 def test_pade_trivial():
@@ -170,3 +170,50 @@ def test_face():
 
 def test_ascent():
     assert_equal(ascent().shape, (512, 512))
+
+        
+def test_inversefunc_infinite():
+    accuracy=4
+    cube = lambda x: x**3
+    invcube = inversefunc(cube, accuracy=accuracy)
+    assert_array_almost_equal(invcube([-27,-8,-1,0,1, 8, 27,]),[-3,-2,-1,0,1,2,3], accuracy)
+    
+def test_inversefunc_vminclosed():
+    accuracy=4
+    square = lambda x: x**2
+    invsquare = inversefunc(square, vmin=0, accuracy=accuracy)
+    assert_array_almost_equal(invsquare([4,16,64]),[2,4,8],accuracy)
+    
+def test_inversefunc_vminopen():
+    accuracy=4
+    log = lambda x: np.log10(x)
+    invlog = inversefunc(log, vmin=0, vminopen=True)
+    assert_array_almost_equal(invlog([-2.,-3.]),[0.01,0.001],accuracy)
+    
+def test_inversefunc_vmaxclosed():
+    accuracy=4
+    square = lambda x: x**2
+    invsquare = inversefunc(square, vmax=0, accuracy=accuracy)
+    assert_array_almost_equal(invsquare([4,16,64]),[-2,-4,-8],accuracy)
+    
+def test_inversefunc_vmaxopen():
+    accuracy=4
+    log = lambda x: np.log10(-x)
+    invlog = inversefunc(log, vmax=0., vmaxopen=True)
+    assert_array_almost_equal(invlog([-2.,-3.]),[-0.01,-0.001],accuracy)
+
+def test_inversefunc_vminvmaxclosed():
+    accuracy=4
+    cos = lambda x: np.cos(x)
+    invcos = inversefunc(cos, vmin=0, vmax=np.pi)
+    assert_array_almost_equal(invcos([1,0,-1]),[0.,np.pi/2,np.pi],accuracy)
+
+def test_inversefunc_vminvmaxopen():
+    accuracy=4
+    tan = lambda x: np.tan(x)
+    invtan = inversefunc(tan, 
+                         vmin=-np.pi/2, 
+                         vmax=np.pi/2, 
+                         vminopen=True, 
+                         vmaxopen=True)
+    assert_array_almost_equal(invtan([1,0,-1]),[np.pi/4,0.,-np.pi/4],accuracy)

--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -171,49 +171,66 @@ def test_face():
 def test_ascent():
     assert_equal(ascent().shape, (512, 512))
 
-        
+
 def test_inversefunc_infinite():
-    accuracy=4
-    cube = lambda x: x**3
+    accuracy = 4
+    cube = (lambda x: x**3)
     invcube = inversefunc(cube, accuracy=accuracy)
-    assert_array_almost_equal(invcube([-27,-8,-1,0,1, 8, 27,]),[-3,-2,-1,0,1,2,3], accuracy)
-    
+    assert_array_almost_equal(invcube([-27, -8, -1, 0, 1, 8, 27]),
+                              [-3, -2, -1, 0, 1, 2, 3], accuracy)
+
 def test_inversefunc_vminclosed():
-    accuracy=4
-    square = lambda x: x**2
+    accuracy = 4
+    square = (lambda x: x**2)
     invsquare = inversefunc(square, vmin=0, accuracy=accuracy)
-    assert_array_almost_equal(invsquare([4,16,64]),[2,4,8],accuracy)
-    
+    assert_array_almost_equal(invsquare([4, 16, 64]), [2, 4, 8], accuracy)
+
 def test_inversefunc_vminopen():
-    accuracy=4
-    log = lambda x: np.log10(x)
+    accuracy = 4
+    log = (lambda x: np.log10(x))
     invlog = inversefunc(log, vmin=0, vminopen=True)
-    assert_array_almost_equal(invlog([-2.,-3.]),[0.01,0.001],accuracy)
-    
+    assert_array_almost_equal(invlog([-2., -3.]), [0.01, 0.001], accuracy)
+
 def test_inversefunc_vmaxclosed():
-    accuracy=4
-    square = lambda x: x**2
+    accuracy = 4
+    square = (lambda x: x**2)
     invsquare = inversefunc(square, vmax=0, accuracy=accuracy)
-    assert_array_almost_equal(invsquare([4,16,64]),[-2,-4,-8],accuracy)
-    
+    assert_array_almost_equal(invsquare([4, 16, 64]), [-2, -4, -8], accuracy)
+
 def test_inversefunc_vmaxopen():
-    accuracy=4
-    log = lambda x: np.log10(-x)
+    accuracy = 4
+    log = (lambda x: np.log10(-x))
     invlog = inversefunc(log, vmax=0., vmaxopen=True)
-    assert_array_almost_equal(invlog([-2.,-3.]),[-0.01,-0.001],accuracy)
+    assert_array_almost_equal(invlog([-2., -3.]), [-0.01, -0.001], accuracy)
 
-def test_inversefunc_vminvmaxclosed():
-    accuracy=4
-    cos = lambda x: np.cos(x)
+def test_inversefunc_vminclosedvmaxclosed():
+    accuracy = 4
+    cos = (lambda x: np.cos(x))
     invcos = inversefunc(cos, vmin=0, vmax=np.pi)
-    assert_array_almost_equal(invcos([1,0,-1]),[0.,np.pi/2,np.pi],accuracy)
+    assert_array_almost_equal(invcos([1, 0, -1]),
+                              [0., np.pi / 2, np.pi], accuracy)
 
-def test_inversefunc_vminvmaxopen():
-    accuracy=4
-    tan = lambda x: np.tan(x)
+def test_inversefunc_vminopenvmaxclosed():
+    accuracy = 4
+    cos = (lambda x: np.cos(x))
+    invcos = inversefunc(cos, vmin=0, vmax=np.pi, vminopen=True)
+    assert_array_almost_equal(invcos([1 / np.sqrt(2), 0, -1 / np.sqrt(2)]),
+                              [np.pi / 4, np.pi / 2, 3 * np.pi / 4], accuracy)
+
+def test_inversefunc_vminclosedvmaxopen():
+    accuracy = 4
+    cos = (lambda x: np.cos(x))
+    invcos = inversefunc(cos, vmin=0, vmax=np.pi, vmaxopen=True)
+    assert_array_almost_equal(invcos([1 / np.sqrt(2), 0, -1 / np.sqrt(2)]),
+                              [np.pi / 4, np.pi / 2, 3 * np.pi / 4], accuracy)
+
+def test_inversefunc_vminopenvmaxopen():
+    accuracy = 4
+    tan = (lambda x: np.tan(x))
     invtan = inversefunc(tan,
-                         vmin=-np.pi/2,
-                         vmax=np.pi/2,
+                         vmin=-np.pi / 2,
+                         vmax=np.pi / 2,
                          vminopen=True,
                          vmaxopen=True)
-    assert_array_almost_equal(invtan([1,0,-1]),[np.pi/4,0.,-np.pi/4],accuracy)
+    assert_array_almost_equal(invtan([1, 0, -1]),
+                              [np.pi / 4, 0., -np.pi / 4], accuracy)


### PR DESCRIPTION
Updated: 01/11/2016

EDIT: While decision is being taken I have uploaded the current implementation as a [standalone PyPI package](https://pypi.python.org/pypi/pynverse).

A method specialized on calculating the numerical inverse of any invertible continuous function.

DISCLAIMER: The problem of calculating the numerical inverse of an arbitrary function in unlimited or open intervals is still an open question in applied mathematics. The main purpose of this package is not to be fast, or as accurate as it could be if the inverse was calculated specifically for a known function, using more specialised techniques. It is essentially a very user-friendly wrapper that uses the existing tools in scipy to solve the particular problem of finding the inverse of a function meeting the continuity and monotonicity conditions, but while it performs really well it may fail under certain conditions. For example when inverting a `log10` it is known to start giving inccacurate values when being asked to invert -10, which should correspond to 0.0000000001 (1e-10), but gives instead 0.0000000000978 (0.978e-10). [This message](https://github.com/scipy/scipy/pull/6725#issuecomment-256722654) from @josef-pkt decribes the decision that needs to be made very well.

Examples:

It can be used to calculate the inverse function at certain `y_values` points:
```python
    >>> cube = (lambda x: x**3)
    >>> invcube = inversefunc(cube, y_values=3)
    array(3.0000000063797567)
```

Or to obtain a callable that will calculate the inverse values at any other points if `y_values` is not provided:
```python
    >>> invcube = inversefunc(cube)
    >>> invcube(27)
    array(3.0000000063797567)
```

It requires the function to be continuous and strictly monotonic (i.e. purely decreasing or purely increasing) within the domain of the function. By default, the domain includes all real numbers, but it can be restricted to an inverval using the `domain` argument:
```python
    >>> import numpy as np
    >>> inversefunc(np.cos, y_values=[1, 0, -1], # Should give [0, pi / 2, pi]
    ...             domain=[0, np.pi])
    array([ 0.        ,  1.57079632,  3.14159265])
```

Additionally, the argument `open_domain` can be used to specify the open/closed character of each of the ends of the domain interval:
```python
    >>> inversefunc(np.log10, y_values=-2, # Should give 0.01
    ...             domain=0, open_domain=[True, False])
    array(0.0099999999882423)
```

Or on both ends simultaneously:
```python
    >>> invtan = inversefunc(np.tan,
    ...                      domain=[-np.pi / 2, np.pi / 2],
    ...                      open_domain=True)
    >>> invtan([1, 0, -1]) # Should give [pi / 4, 0, -pi / 4]
    array([  7.85398163e-01,   1.29246971e-26,  -7.85398163e-01])
```

Additional parameters may be passed to the function for easier reusability of callables using the `args` argument:

```python
    >>> invsquare = inversefunc(np.power, args=(2), domain=0)
    >>> invsquare([4, 16, 64])
    array([ 2.,  4.,  8.])
```

The image of the function in the interval may be also provided for cases where the function is non continuous right at the end of an open interval with the `image` argument:

```python
    >>> invmod = inversefunc(np.mod, args=(1), domain=[5,6], 
    ...                      open_domain=[False,True], image=[0,1])
    >>> invmod([0.,0.3,0.5])
    array([ 5. ,  5.3,  5.5])
```

Additionally an argument can be used to check for the number of digits of accuracy in the results, giving a warning in case this is not meet:
```python
    >>> inversefunc(np.log10, y_values=-8, # Should give 0.01
    ...             domain=0, open_domain=True, accuracy=6)
    pynverse\inverse.py:195: RuntimeWarning: Results obtained with less than 6 decimal digits of accuracy
    array(9.999514710830838e-09)
```

Examples of using the callables with vectors to make plots, and compare to the analytical inverse:

![examples](https://cloud.githubusercontent.com/assets/12649253/19738042/cf22460a-9bad-11e6-9c17-6fdd6cda0991.png)

Each of those calculated as simply as:

``` python
log = lambda x: np.log10(x)
invlog = scipy.misc.inversefunc(log, domain=0, open_domain=True)
x1=np.linspace(0.00001,10,100)
x2=np.linspace(-5,1,100)
ax1.plot(x1,log(y1),'b-')
ax2.plot(x2,invlog(x2),'b-')

invlog_a = lambda x: 10**x
ax2.plot(x2,invlog_a(x2),'r--')
```

The good thing about this is that checking the result of the inverse function is as easy as checking that f(finv(x))==x, so even if the user inputs a non valid function, they can always make sure that the output is consistent or good enough, in fact the function checks this internally automatically. 
I see two type of users:
- Users who need a quick way to get the inverse of a function, so they do not have to invest time on doing it themselves. They could use it, check if the results, and if it does not work, then decide to invest the time to do it manually with more sophisticated approaches. Nevertheless for many cases this will be good enough (See examples above).
- Other functions that deal with monotonic functions, such as inverting cdf to ppf, or the normalization classes from matplotlib, which takes data intervals and map them linearly or non linearly to the 0-1 interval, using different non-linear functions. Essentially, any function that takes a callable of this characteristics, and may need at any point the inverse function, could very easily make use of this numerical approximation of the inverse.

The summarized internal strategy is the following:
0. Homogenize and normalize the input parameters.
1. Figure out if the function is increasing or decreasing. For this two reference points ref1 and ref2 are needed:
    * In case of a finite interval, the points ref points are 1/4 and 3/4 through the interval.
    * In an infinite interval any two values work really.
    * If f(ref1)<f(ref2), the function is increasing, otherwise is decreasing.
2. Figure out the image of the function in the interval. 
    * If values are provided, then those are used.
    * In a closed interval just calculate f(a) and f(b), where a and b are the ends of the interval.
    * In an open interval try to calculate f(a) and f(b), if this works those are used, otherwise it will be assume to be (-Inf, Inf).
3. Built a bounded function with the following conditions:
    * bounded_f(x):
        * return -Inf if x below interval, and f is increasing.
        * return +Inf if x below interval, and f is decreasing.
        * return +Inf if x above interval, and f is increasing.
        * return -Inf if x above interval, and f is decreasing.
        * return f(x) otherwise
4. If the required number y0 for the inverse is outside the image, raise an exception.
5. Find roots for bounded_f(x)-y0, by minimizing (bounded_f(x)-y0)**2, using the `Brent` method, making sure that the algorithm for minimising starts in a point inside the original interval by setting ref1, ref2 as brackets. As soon as if goes outside the allowed intervals, bounded_f returns infinite, forcing the algorithm to go back to search inside the interval.
6. Check that the solutions are accurate and they meet f(x0)=y0 to some desired precision, raising a warning otherwise. 

Summary of the discussion:

Arguments to include it:
1. The use case is important and it would be good that scipy included this.
2. The wrapper is very user friendly and easy to use.
3. The current implementation works well in most cases (see examples) and even for extreme numbers, e.g. inverting a log10 the provided function `invlog = scipy.misc.inversefunc(lambda x: np.log10(x), domain=0, open_domain=True)` it is as accurate as `invlog(-10.)==9.786080337061437e-11`.

Arguments to not include it:
1. The function adds more as a wrapper that uses other scipy tools to perform the calculations, so it really is not a new numerical technique.
2. There are a lots of caveats regarding achieving a desired precision, specially for open domains, or infinite domains, as this is still an open problem in maths.
3. It is impossible to check that the callable provided by the users meets the required input conditions of monotonicity and continuity, and this can lead to bad behavior.

Responses to the arguments against
1. I agree, this is why I included it in the misc folder.
2. The accuracy of the results can always be checked using the original functions by making sure that f(finv(x))==x, if the accuracy is not good enough, the user can always try to go to a fancier implementation specialized for each case.
3. In general any function taking a callable is exposed to this risk, as there are only so many checks that one can do for a callable.
