### PR TITLE
address performance regressions in interp1d

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -619,7 +619,8 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     # special-case k=0 right away
     if k == 0:
         if any(_ is not None for _ in (t, deriv_l, deriv_r)):
-            raise ValueError("Too much info for k=0.")
+            raise ValueError("Too much info for k=0: t and bc_type can only "
+                             "be None.")
         x = _as_float_array(x, check_finite)
         t = np.r_[x, x[-1]]
         c = np.asarray(y)
@@ -629,7 +630,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     # special-case k=1 (e.g., Lyche and Morken, Eq.(2.16))
     if k == 1 and t is None:
         if not (deriv_l is None and deriv_r is None):
-            raise ValueError("Too much info for k=1.")
+            raise ValueError("Too much info for k=1: bc_type can only be None.")
         x = _as_float_array(x, check_finite)
         t = np.r_[x[0], x, x[-1]]
         c = np.asarray(y)

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -21,6 +21,14 @@ def prod(x):
     return functools.reduce(operator.mul, x)
 
 
+def _get_dtype(dtype):
+    """Return np.complex128 for complex dtypes, np.float64 otherwise."""
+    if np.issubdtype(dtype, np.complexfloating):
+        return np.complex_
+    else:
+        return np.float_
+
+
 class BSpline(object):
     r"""Univariate spline in the B-spline basis.
 
@@ -197,14 +205,8 @@ class BSpline(object):
         if self.c.shape[0] < n:
             raise ValueError("Knots, coefficients and degree are inconsistent.")
 
-        dt = self._get_dtype(self.c.dtype)
+        dt = _get_dtype(self.c.dtype)
         self.c = np.ascontiguousarray(self.c, dtype=dt)
-
-    def _get_dtype(self, dtype):
-        if np.issubdtype(dtype, np.complexfloating):
-            return np.complex_
-        else:
-            return np.float_
 
     @classmethod
     def construct_fast(cls, t, c, k, extrapolate=True, axis=0):
@@ -621,10 +623,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         x = _as_float_array(x, check_finite)
         t = np.r_[x, x[-1]]
         c = np.asarray(y)
-        if c.dtype == np.complex64:
-            c = c.astype(np.complex_)
-        elif c.dtype == np.float32:
-            c = c.astype(float)
+        c = np.ascontiguousarray(c, dtype=_get_dtype(c.dtype))
         return BSpline.construct_fast(t, c, k, axis=axis)
 
     # special-case k=1 (e.g., Lyche and Morken, Eq.(2.16))
@@ -634,10 +633,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         x = _as_float_array(x, check_finite)
         t = np.r_[x[0], x, x[-1]]
         c = np.asarray(y)
-        if c.dtype == np.complex64:
-            c = c.astype(np.complex_)
-        elif c.dtype == np.float32:
-            c = c.astype(float)
+        c = np.ascontiguousarray(c, dtype=_get_dtype(c.dtype))
         return BSpline.construct_fast(t, c, k, axis=axis)
 
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -618,9 +618,14 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     if k == 0:
         if any(_ is not None for _ in (t, deriv_l, deriv_r)):
             raise ValueError("Too much info for k=0.")
+        x = _as_float_array(x, check_finite)
         t = np.r_[x, x[-1]]
-        c = y
-        return BSpline(t, c, k, axis=axis)
+        c = np.asarray(y)
+        if c.dtype == np.complex64:
+            c = c.astype(np.complex_)
+        elif c.dtype == np.float32:
+            c = c.astype(float)
+        return BSpline.construct_fast(t, c, k, axis=axis)
 
     # come up with a sensible knot vector, if needed
     if t is None:

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -664,14 +664,14 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         deriv_l_ords, deriv_l_vals = zip(*deriv_l)
     else:
         deriv_l_ords, deriv_l_vals = [], []
-    deriv_l_ords, deriv_l_vals = map(np.atleast_1d, (deriv_l_ords, deriv_l_vals))
+    deriv_l_ords, deriv_l_vals = np.atleast_1d(deriv_l_ords, deriv_l_vals)
     nleft = deriv_l_ords.shape[0]
 
     if deriv_r is not None:
         deriv_r_ords, deriv_r_vals = zip(*deriv_r)
     else:
         deriv_r_ords, deriv_r_vals = [], []
-    deriv_r_ords, deriv_r_vals = map(np.atleast_1d, (deriv_r_ords, deriv_r_vals))
+    deriv_r_ords, deriv_r_vals = np.atleast_1d(deriv_r_ords, deriv_r_vals)
     nright = deriv_r_ords.shape[0]
 
     # have `n` conditions for `nt` coefficients; need nt-n derivatives

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -636,7 +636,6 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         c = np.ascontiguousarray(c, dtype=_get_dtype(c.dtype))
         return BSpline.construct_fast(t, c, k, axis=axis)
 
-
     # come up with a sensible knot vector, if needed
     if t is None:
         if deriv_l is None and deriv_r is None:
@@ -660,18 +659,18 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     axis = axis % y.ndim
     y = np.rollaxis(y, axis)    # now internally interp axis is zero
 
-    if x.ndim != 1 or np.any(x[1:] - x[:-1] <= 0):
+    if x.ndim != 1 or np.any(x[1:] <= x[:-1]):
         raise ValueError("Expect x to be a 1-D sorted array_like.")
     if k < 0:
         raise ValueError("Expect non-negative k.")
-    if t.ndim != 1 or np.any(t[1:] - t[:-1] < 0):
+    if t.ndim != 1 or np.any(t[1:] < t[:-1]):
         raise ValueError("Expect t to be a 1-D sorted array_like.")
     if x.size != y.shape[0]:
         raise ValueError('x and y are incompatible.')
     if t.size < x.size + k + 1:
         raise ValueError('Got %d knots, need at least %d.' %
                          (t.size, x.size + k + 1))
-    if k > 0 and np.any((x < t[k]) | (x > t[-k])):
+    if (x[0] < t[k]) or (x[-1] > t[-k]):
         raise ValueError('Out of bounds w/ x = %s.' % x)
 
     # Here : deriv_l, r = [(nu, value), ...]

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -627,6 +627,20 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
             c = c.astype(float)
         return BSpline.construct_fast(t, c, k, axis=axis)
 
+    # special-case k=1 (e.g., Lyche and Morken, Eq.(2.16))
+    if k == 1 and t is None:
+        if not (deriv_l is None and deriv_r is None):
+            raise ValueError("Too much info for k=1.")
+        x = _as_float_array(x, check_finite)
+        t = np.r_[x[0], x, x[-1]]
+        c = np.asarray(y)
+        if c.dtype == np.complex64:
+            c = c.astype(np.complex_)
+        elif c.dtype == np.float32:
+            c = c.astype(float)
+        return BSpline.construct_fast(t, c, k, axis=axis)
+
+
     # come up with a sensible knot vector, if needed
     if t is None:
         if deriv_l is None and deriv_r is None:

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -481,7 +481,9 @@ class interp1d(_Interpolator1D):
                     self._call = self.__class__._call_linear
         else:
             minval = order + 1
-            self._spline = make_interp_spline(self.x, self._y, k=order)
+            check_finite = True if order > 0 else False
+            self._spline = make_interp_spline(self.x, self._y, k=order,
+                                              check_finite=check_finite)
             self._call = self.__class__._call_spline
 
         if len(self.x) < minval:

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -375,7 +375,7 @@ class interp1d(_Interpolator1D):
 
           .. versionadded:: 0.17.0
         - If "extrapolate", then points outside the data range will be
-          extrapolated. ("nearest" and "linear" kinds only.)
+          extrapolated.
 
           .. versionadded:: 0.17.0
     assume_sorted : bool, optional
@@ -499,10 +499,6 @@ class interp1d(_Interpolator1D):
     def fill_value(self, fill_value):
         # extrapolation only works for nearest neighbor and linear methods
         if _do_extrapolate(fill_value):
-            if self._kind not in ('nearest', 'linear'):
-                raise ValueError("Extrapolation does not work with "
-                                 "kind=%s" % self._kind)
-
             if self.bounds_error:
                 raise ValueError("Cannot extrapolate and raise "
                                  "at the same time.")

--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -481,7 +481,7 @@ class interp1d(_Interpolator1D):
                     self._call = self.__class__._call_linear
         else:
             minval = order + 1
-            check_finite = True if order > 0 else False
+            check_finite = True if order > 1 else False
             self._spline = make_interp_spline(self.x, self._y, k=order,
                                               check_finite=check_finite)
             self._call = self.__class__._call_spline

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -807,12 +807,20 @@ class TestInterp(TestCase):
         assert_allclose([b(xx[0], 1), b(xx[-1], 1)],
                         [der_l[0][1], der_r[0][1]], atol=1e-14, rtol=1e-14)
 
+        # also test zero and first order
+        for k in (0, 1):
+            b = make_interp_spline(xx, yy, k=k)
+            assert_allclose(b(xx), yy, atol=1e-14, rtol=1e-14)
+
     def test_int_xy(self):
         x = np.arange(10).astype(np.int_)
         y = np.arange(10).astype(np.int_)
 
-        # cython chokes on "buffer type mismatch"
-        make_interp_spline(x, y, k=1)
+        # cython chokes on "buffer type mismatch" (construction) or
+        # "no matching signature found" (evaluation)
+        for k in (0, 1, 2, 3):
+            b = make_interp_spline(x, y, k=k)
+            b(x)
 
     def test_sliced_input(self):
         # cython code chokes on non C contiguous arrays
@@ -821,7 +829,8 @@ class TestInterp(TestCase):
         x = xx[::5]
         y = xx[::5]
 
-        make_interp_spline(x, y, k=1)
+        for k in (0, 1, 2, 3):
+            make_interp_spline(x, y, k=k)
 
     def test_check_finite(self):
         # check_finite defaults to True; nans and such trigger a ValueError

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -619,6 +619,24 @@ class TestInterp1D(object):
             vals = ir([4.9, 7.0])
             assert_(np.isfinite(vals).all())
 
+    def test_spline_nans(self):
+        # Backwards compat: a single nan makes the whole spline interpolation
+        # return nans in an array of the correct shape. And it doesn't raise,
+        # just quiet nans because of backcompat.
+        x = np.arange(8).astype(float)
+        y = x.copy()
+        yn = y.copy()
+        yn[3] = np.nan
+
+        for kind in ['quadratic', 'cubic']:
+            ir = interp1d(x, y, kind=kind)
+            irn = interp1d(x, yn, kind=kind)
+            for xnew in (6, [1, 6], [[1, 6], [3, 5]]):
+                xnew = np.asarray(xnew)
+                out, outn = ir(x), irn(x)
+                assert_(np.isnan(outn).all())
+                assert_equal(out.shape, outn.shape)
+
 
 class TestLagrange(TestCase):
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -134,14 +134,9 @@ class TestInterp1D(object):
         # are given to the constructor.
 
         # These should all work.
-        interp1d(self.x10, self.y10, kind='linear')
-        interp1d(self.x10, self.y10, kind='cubic')
-        interp1d(self.x10, self.y10, kind='slinear')
-        interp1d(self.x10, self.y10, kind='quadratic')
-        interp1d(self.x10, self.y10, kind='zero')
-        interp1d(self.x10, self.y10, kind='nearest')
-        interp1d(self.x10, self.y10, kind='nearest', fill_value="extrapolate")
-        interp1d(self.x10, self.y10, kind='linear', fill_value="extrapolate")
+        for kind in ('nearest', 'zero', 'linear', 'slinear', 'quadratic', 'cubic'):
+            interp1d(self.x10, self.y10, kind=kind)
+            interp1d(self.x10, self.y10, kind=kind, fill_value="extrapolate")
         interp1d(self.x10, self.y10, kind='linear', fill_value=(-1, 1))
         interp1d(self.x10, self.y10, kind='linear',
                  fill_value=np.array([-1]))
@@ -163,11 +158,6 @@ class TestInterp1D(object):
                  fill_value=(np.ones(10), np.ones(10)))
         interp1d(self.x2, self.y210, kind='linear', axis=0,
                  fill_value=(np.ones(10), -1))
-
-        # extrapolation is only allowed for nearest & linear methods
-        for kind in ('cubic', 'slinear', 'zero', 'quadratic'):
-            assert_raises(ValueError, interp1d, self.x10, self.y10, kind=kind,
-                          fill_value="extrapolate")
 
         # x array must be 1D.
         assert_raises(ValueError, interp1d, self.x25, self.y10)
@@ -253,20 +243,24 @@ class TestInterp1D(object):
                                   interp10_y_2d_unsorted(self.x10))
 
     def test_linear(self):
+        for kind in ['linear', 'slinear']:
+            self._check_linear(kind)
+
+    def _check_linear(self, kind):
         # Check the actual implementation of linear interpolation.
-        interp10 = interp1d(self.x10, self.y10)
+        interp10 = interp1d(self.x10, self.y10, kind=kind)
         assert_array_almost_equal(interp10(self.x10), self.y10)
         assert_array_almost_equal(interp10(1.2), np.array([1.2]))
         assert_array_almost_equal(interp10([2.4, 5.6, 6.0]),
                                   np.array([2.4, 5.6, 6.0]))
 
         # test fill_value="extrapolate"
-        extrapolator = interp1d(self.x10, self.y10, kind='linear',
+        extrapolator = interp1d(self.x10, self.y10, kind=kind,
                                 fill_value='extrapolate')
         assert_allclose(extrapolator([-1., 0, 9, 11]),
                         [-1, 0, 9, 11], rtol=1e-14)
 
-        opts = dict(kind='linear',
+        opts = dict(kind=kind,
                     fill_value='extrapolate',
                     bounds_error=True)
         assert_raises(ValueError, interp1d, self.x10, self.y10, **opts)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -608,6 +608,18 @@ class TestInterp1D(object):
         ii = interp1d(x, x, kind='nearest')
         assert_array_almost_equal(ii(x), x)
 
+    def test_local_nans(self):
+        # check that for local interpolation kinds (slinear, zero) a single nan
+        # only affects its local neighborhood
+        x = np.arange(10).astype(float)
+        y = x.copy()
+        y[6] = np.nan
+        for kind in ('zero', 'slinear'):
+            ir = interp1d(x, y, kind=kind)
+            vals = ir([4.9, 7.0])
+            assert_(np.isfinite(vals).all())
+
+
 class TestLagrange(TestCase):
 
     def test_lagrange(self):


### PR DESCRIPTION
Apparently, construction of "zero" and "slinear" modes of `interp1d` got slower after refactoring splmake out, https://github.com/scipy/scipy/pull/3174#issuecomment-255842372.

The numbers look scary (200% slower etc), but AFAICS that is only for construction, not evaluation. So even that could have been tolerable.

This PR starts to address these regressions by special-casing orders zero and one. So far, zero order seems trivial, and gets most of the speed back. 

Actually, there is one actual regression for "slinear" mode for when input arrays contain nans. Previous behavior was to return some nans, the current master simply raises.

For cubic and quadratic modes, the only choices are all nans (previous behavior) or raise (current master). I'd argue the current behavior is OK. 

For the slinear mode however, there is no need to raise and we can actually return some meaningful results (as a nan only taints its neighborhood, not the whole fitting), so this is a regression which I'm going to look into fixing. 
