### PR TITLE
MAINT: cython_special: remove `errprint`

### DIFF
--- a/scipy/special/cython_special.pyx
+++ b/scipy/special/cython_special.pyx
@@ -25,8 +25,8 @@ The module is usable from Cython via::
 Error Handling
 ==============
 
-Error handling works the same as in `scipy.special`; in particular
-error messages can be controlled by ``cython_special.errprint``.
+Functions can indicate an error by returning ``nan``; however they
+cannot emit warnings like their counterparts in ``scipy.special``.
 
 Available Functions
 ===================
@@ -1010,14 +1010,6 @@ ctypedef long double long_double
 ctypedef float complex float_complex
 ctypedef double complex double_complex
 ctypedef long double complex long_double_complex
-
-def errprint(inflag=None):
-    """See the documentation for scipy.special.errprint"""
-    if inflag is not None:
-        scipy.special._ufuncs_cxx._set_errprint(int(bool(inflag)))
-        return bool(sf_error.set_print(int(bool(inflag))))
-    else:
-        return bool(sf_error.get_print())
 
 cdef extern from "_ufuncs_defs.h":
     cdef npy_int _func_airy_wrap "airy_wrap"(npy_double, npy_double *, npy_double *, npy_double *, npy_double *)nogil

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -371,9 +371,7 @@ cdef int _set_errprint(int flag) nogil:
 
 UFUNCS_EXTRA_CODE = """\
 cimport scipy.special._ufuncs_cxx
-"""
 
-UFUNCS_ERRPRINT_CODE = """\
 def errprint(inflag=None):
     \"\"\"
     errprint(inflag=None)
@@ -412,16 +410,6 @@ def errprint(inflag=None):
     SpecialFunctionWarning('scipy.special/bdtr: domain error',)
 
     \"\"\"
-    if inflag is not None:
-        scipy.special._ufuncs_cxx._set_errprint(int(bool(inflag)))
-        return bool(sf_error.set_print(int(bool(inflag))))
-    else:
-        return bool(sf_error.get_print())
-"""
-
-CYTHON_SPECIAL_ERRPRINT_CODE = """\
-def errprint(inflag=None):
-    \"\"\"See the documentation for scipy.special.errprint\"\"\"
     if inflag is not None:
         scipy.special._ufuncs_cxx._set_errprint(int(bool(inflag)))
         return bool(sf_error.set_print(int(bool(inflag))))
@@ -469,8 +457,8 @@ The module is usable from Cython via::
 Error Handling
 ==============
 
-Error handling works the same as in `scipy.special`; in particular
-error messages can be controlled by ``cython_special.errprint``.
+Functions can indicate an error by returning ``nan``; however they
+cannot emit warnings like their counterparts in ``scipy.special``.
 
 Available Functions
 ===================
@@ -1609,8 +1597,6 @@ def generate_ufuncs(fn_prefix, cxx_fn_prefix, ufuncs):
         f.write(UFUNCS_EXTRA_CODE_COMMON)
         f.write("\n")
         f.write(UFUNCS_EXTRA_CODE)
-        f.write("\n")
-        f.write(UFUNCS_ERRPRINT_CODE)
         f.write(toplevel)
         f.write(UFUNCS_EXTRA_CODE_BOTTOM)
 
@@ -1698,8 +1684,6 @@ def generate_fused_funcs(modname, ufunc_fn_prefix, fused_funcs):
         header = CYTHON_SPECIAL_PYX
         header = header.replace("FUNCLIST", "\n".join(doc))
         f.write(header)
-        f.write("\n")
-        f.write(CYTHON_SPECIAL_ERRPRINT_CODE)
         f.write("\n")
         f.write("\n".join(defs))
         f.write("\n\n")

--- a/scipy/special/setup.py
+++ b/scipy/special/setup.py
@@ -113,10 +113,11 @@ def configuration(parent_package='',top_path=None):
     cython_special_dep = (headers + ufuncs_src + ufuncs_cxx_src + amos_src
                           + c_misc_src + cephes_src + mach_src + cdf_src
                           + specfun_src)
+    cfg = dict(get_system_info('lapack_opt'))
     cfg.setdefault('include_dirs', []).extend([curdir] + inc_dirs + [numpy.get_include()])
     cfg.setdefault('libraries', []).extend(['sc_amos','sc_c_misc','sc_cephes','sc_mach',
                                             'sc_cdf', 'sc_specfun'])
-    cfg.setdefault('define_macros', []).extend(define_macros + [('CYTHON_SPECIAL', 1)])
+    cfg.setdefault('define_macros', []).extend(define_macros)
     config.add_extension('cython_special',
                          depends=cython_special_dep,
                          sources=cython_special_src,

--- a/scipy/special/sf_error.c
+++ b/scipy/special/sf_error.c
@@ -97,17 +97,6 @@ void sf_error(const char *func_name, sf_error_t code, const char *fmt, ...)
              * fact that the Ufunc loop will call PyErr_Occurred()
              * later on.
              */
-#ifdef CYTHON_SPECIAL
-	    /*
-	     * For cython_special if an exception occurs while
-	     * processing the warning we ignore it. This is done
-	     * because the functions calling sf_error don't have a way
-	     * to clean up if sf_error fails.
-	     */
-	    if (res == -1) {
-		PyErr_Clear();
-	    }
-#endif
         }
 
     skip_warn:

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -275,7 +275,7 @@ def test_cython_api():
     ]
 
     # Check that everything is tested
-    skip = ['errprint']
+    skip = []
     for name in dir(cython_special):
         func = getattr(cython_special, name)
         if callable(func) and not (name.startswith('_bench') or name in skip):

--- a/scipy/special/tests/test_errprint.py
+++ b/scipy/special/tests/test_errprint.py
@@ -4,24 +4,15 @@ import warnings
 
 from numpy.testing import assert_
 
-from scipy import special
-from scipy.special import cython_special
+import scipy. special as sc
 
 
-def _check_errprint(mod):
-    flag = mod.errprint(True)
+def test_errprint():
+    flag = sc.errprint(True)
     try:
         assert_(isinstance(flag, bool))
         with warnings.catch_warnings(record=True) as w:
-            mod.loggamma(0)
-            assert_(w[-1].category is special.SpecialFunctionWarning)
+            sc.loggamma(0)
+            assert_(w[-1].category is sc.SpecialFunctionWarning)
     finally:
-        mod.errprint(flag)
-
-
-def test_special_errprint():
-    _check_errprint(special)
-
-
-def test_cython_special_errprint():
-    _check_errprint(cython_special)
+        sc.errprint(flag)


### PR DESCRIPTION
It is buggy, and as of now a good fix is not clear. See https://github.com/scipy/scipy/pull/6722 for more discussion.
