### PR TITLE
added Normal inverse gamma distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ _configtest.c
 
 # Python files #
 ################
+# dev directory
+scipy-dev
 # setup.py working directory
 build
 # sphinx build directory

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -133,6 +133,7 @@ Multivariate distributions
    special_ortho_group   -- SO(N) group
    ortho_group           -- O(N) group
    random_correlation    -- random correlation matrices
+   normal_invgamma       -- Normal inverse gamma distribution
 
 Discrete distributions
 ======================

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3524,8 +3524,114 @@ class random_correlation_gen(multi_rv_generic):
 random_correlation = random_correlation_gen()
 
 
+_nig_doc_default_callparams = """\
+loc : scalar, optional
+    Mean of the distribution (default zero)
+variance_scale : positive scalar, optional
+    Scale on normal distribution prior (default one)
+shape : positive scalar, optional
+    Shape of the distribution (default one)
+scale : positive scalar, optional
+    Scale on inverse gamma distribution prior (default one)
+"""
+
+_nig_doc_callparams_note = \
+    """The parameters `loc` and `variance_scale` serves as the
+    hyperparameters for normal distribution which models the
+    unknown mean. The parameters `shape` and `scale` serves as
+    the hyperparameters for inverse gamma distribution which
+    models the unknown variance.
+    """
+
+_nig_doc_frozen_callparams = ""
+
+_nig_doc_frozen_callparams_note = \
+    """See class definition for a detailed description of parameters."""
+
+nig_docdict_params = {
+    '_nig_doc_default_callparams': _nig_doc_default_callparams,
+    '_nig_doc_callparams_note': _nig_doc_callparams_note,
+    '_doc_random_state': _doc_random_state
+}
+
+nig_docdict_noparams = {
+    '_nig_doc_default_callparams': _nig_doc_frozen_callparams,
+    '_nig_doc_callparams_note': _nig_doc_frozen_callparams_note,
+    '_doc_random_state': _doc_random_state
+}
+
+
 class normal_invgamma_gen(multi_rv_generic):
-    
+    r"""
+    A normal inverse gamma random variable.
+
+    Methods
+    -------
+    ``pdf(x, sig2, loc=0, variance_scale=1, shape=1, scale=1)``
+        Probability density function.
+    ``logpdf(x, sig2, loc=0, variance_scale=1, shape=1, scale=1)``
+        Log of the probability density function.
+    ``rvs(loc=0, variance_scale=1, shape=1, scale=1, size=1, random_state=None)``
+        Draw random samples from normal and inverse gamma distribution.
+    ``mean(loc=0, variance_scale=1, shape=1, scale=1)``
+        Mean of the random variates.
+    ``mode(loc=0, variance_scale=1, shape=1, scale=1)``
+        Mode of the random variates.
+
+    Parameters
+    ----------
+    x : array
+            One-dimensional array.
+    sig2 : array
+            One-dimensional array.
+    %(_nig_doc_default_callparams)s
+    %(_doc_random_state)s
+
+    Alternatively, the object may be called (as a function) to fix the
+    loc, variance_scale, shape, scale parameters, returning a "frozen"
+    normal inverse gamma random variable:
+
+    rv = normal_invgamma(loc=0, variance_scale=1, shape=1, scale=1)
+        - Frozen object with the same methods but holding the given
+          loc, variance_scale, shape, scale.
+
+    Notes
+    -----
+    %(_nig_doc_callparams_note)s
+
+    The probability density function for `normal_invgamma` is
+
+    .. math::
+
+        f(x,\sigma^2) = \frac {1} {\sigma\sqrt{2\pi\nu} } \, \frac{\beta^\alpha}
+                        {\Gamma(\alpha)} \, \left( \frac{1}{\sigma^2} \right)^
+                        {\alpha + 1}\exp \left( \frac { -\beta}{\sigma^2} -
+                        \frac{(x - \mu)^2} {2\sigma^2\nu}  \right),
+
+    where :math:`\mu` is the loc, :math:`\nu` the variance scale,
+    :math:`\alpha` the shape, :math:`\beta` the scale and :math:`x` and
+    `\sigma^2` takes values.
+
+    .. versionadded:: 0.19.0
+
+    Examples
+    --------
+    >>> import matplotlib.pyplot as plt
+    >>> from mpl_toolkits.mplot3d import axes3d
+    >>> from scipy.stats import normal_invgamma
+    >>> x = np.linspace(0, 5, 10, endpoint=False)
+    >>> sig2 = np.linspace(5, 10, 10, endpoint=False)
+    >>> z = normal_invgamma.pdf(x, sig2, loc=2,
+                                    variance_scale=3, shape=5, scale=2); z
+    array([  5.15655226e-06,   3.07181064e-06,   1.87273568e-06,
+         1.16664399e-06,   7.41424234e-07,   4.79916138e-07,
+         3.15923431e-07,   2.11211796e-07,   1.43229349e-07,
+         9.84088858e-08])
+    >>> fig = plt.figure()
+    >>> ax = fig.add_subplot(111, projection='3d')
+    >>> ax.plot_surface(x, sig2, z)
+
+    """   
     def __init__(self, seed=None):
         super(normal_invgamma_gen, self).__init__(seed)
         self.__doc__ = doccer.docformat(self.__doc__, nig_docdict_params)
@@ -3698,6 +3804,43 @@ normal_invgamma = normal_invgamma_gen()
 
 
 class normal_invgamma_frozen(multi_rv_frozen):
+    """
+    Create a frozen normal inverse gamma distribution.
+
+    Parameters
+    ----------
+    loc : float, optional
+        Mean of the distribution (default zero)
+    variance_scale : positive float, optional
+        Scale on normal distribution prior (default one)
+    shape : positive float, optional
+        Shape of the distribution (default one)
+    scale : positive float, optional
+        Scale on inverse gamma distribution prior (default one)
+    seed : None or int or np.random.RandomState instance, optional
+        This parameter defines the RandomState object to use for drawing
+        random variates.
+        If None (or np.random), the global np.random state is used.
+        If integer, it is used to seed the local RandomState instance
+        Default is None.
+
+    Examples
+    --------
+    When called with the default parameters, this will create a 2D random
+    variable with loc 0, variance_scale 1, shape 1, scale 1:
+
+    >>> from scipy.stats import normal_invgamma
+    >>> r = normal_invgamma()
+    >>> r.loc
+    0
+    >>> r.variance_scale
+    1
+    >>> r.shape
+    1
+    >>> r.scale
+    1
+
+    """
     def __init__(self, loc=0, variance_scale=1, shape=1, scale=1, seed=None):
         
         self._dist = normal_invgamma_gen(seed)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -21,7 +21,8 @@ __all__ = ['multivariate_normal',
            'multinomial',
            'special_ortho_group',
            'ortho_group',
-           'random_correlation']
+           'random_correlation',
+           'normal_invgamma']
 
 _LOG_2PI = np.log(2 * np.pi)
 _LOG_2 = np.log(2)
@@ -3521,3 +3522,210 @@ class random_correlation_gen(multi_rv_generic):
         return m
 
 random_correlation = random_correlation_gen()
+
+
+class normal_invgamma_gen(multi_rv_generic):
+    
+    def __init__(self, seed=None):
+        super(normal_invgamma_gen, self).__init__(seed)
+        self.__doc__ = doccer.docformat(self.__doc__, nig_docdict_params)
+
+    def __call__(self, loc=0, variance_scale=1, shape=1, scale=1, seed=None):
+        """
+        Create a frozen normal inverse gamma distribution.
+
+        See `normal_invgamma_frozen` for more information.
+
+        """
+        return normal_invgamma_frozen(loc, variance_scale, shape, scale,
+                                    seed=seed)
+
+    def _check_parameters(self, loc, variance_scale, shape, scale):
+        if not np.isscalar(loc):
+            raise ValueError("""loc must be a scalar""")
+        if not np.isscalar(variance_scale) or variance_scale < 0:
+            raise ValueError("""variance_scale must be a positive scalar""")
+        if not np.isscalar(shape) or shape < 0:
+            raise ValueError("""shape must be a positive scalar""")
+        if not np.isscalar(scale) or scale < 0:
+            raise ValueError("""scale must be a positive scalar""")
+        return loc, variance_scale, shape, scale
+
+    def _check_input(self, x, sig2):
+        if x.ndim != 1:
+            raise ValueError("""array must be one dimensional""")
+        if sig2.ndim != 1:
+            raise ValueError("""array must be one dimensional""")
+        if any(sig2 < 0):
+            raise ValueError("""array must consist of positive values,
+                                as it represents variance""")
+        return x, sig2
+
+    def logpdf(self, x, sig2, loc=0, variance_scale=1, shape=1, scale=1):
+        """
+        Log of the Normal inverse gamma probability density function.
+
+        Parameters
+        ----------
+        x : array
+            One-dimensional array.
+        sig2 : array
+            One-dimensional array.
+        %(_nig_doc_default_callparams)s
+
+        Returns
+        -------
+        pdf : ndarray
+            Log of the probability density function evaluated at `(x, sig2)`.
+
+        """
+        loc, variance_scale, shape, scale = self._check_parameters(
+                                                    loc, variance_scale, shape, scale)
+        x, sig2 = self._check_input(x, sig2)
+
+        Zinv = shape * np.log(scale) - gammaln(shape) - 0.5 * (np.log(variance_scale) + _LOG_2PI)
+        out = Zinv - 0.5 * np.log(sig2) - (shape + 1.) * np.log(sig2) -\
+                scale/sig2 - 0.5/(sig2 * variance_scale) * (x-loc)**2
+        return out
+
+    def pdf(self, x, sig2, loc=0, variance_scale=1, shape=1, scale=1):
+        """
+        Normal inverse gamma probability density function.
+
+        Parameters
+        ----------
+        x : array
+            One-dimensional array.
+        sig2 : array
+            One-dimensional array.
+        %(_nig_doc_default_callparams)s
+
+        Returns
+        -------
+        pdf : ndarray
+            Probability density function evaluated at `(x, sig2)`.
+
+        Notes
+        -----
+        %(_nig_doc_callparams_note)s
+
+        """
+        out = np.exp(self.logpdf(x, sig2, loc, variance_scale, shape, scale))
+        return out
+
+    def rvs(self, loc=0, variance_scale=1, shape=1, scale=1, size=1, random_state=None):
+        """
+        Draw random samples from normal and inverse gamma distributions.
+
+        Parameters
+        ----------
+        %(_nig_doc_default_callparams)s
+        size : integer, optional
+            Number of samples to draw (default 1).
+        %(_doc_random_state)s
+
+        Returns
+        -------
+        rvs : ndarray or scalar
+            Random variates of size (`size`, `2`).
+
+        Notes
+        -----
+        %(_nig_doc_callparams_note)s
+
+        """
+        loc, variance_scale, shape, scale = self._check_parameters(
+                                                loc, variance_scale, shape, scale)
+        random_state = self._get_random_state(random_state)
+
+        sig2_rv = 1/random_state.gamma(shape, scale, size)
+        x_rv = random_state.normal(loc, np.sqrt(sig2_rv * variance_scale), size)
+        return np.array(list(zip(x_rv, sig2_rv)))
+
+    def mean(self, loc=0, variance_scale=1, shape=1, scale=1):
+        """
+        Compute the mean for input random variates.
+
+        Parameters
+        ----------
+        %(_nig_doc_default_callparams)s
+
+        Returns
+        -------
+        (x, s) : tuple of scalar values
+            Mean of the random variates
+
+        Notes
+        -----
+        %(_nig_doc_callparams_note)s
+
+        """
+        loc, variance_scale, shape, scale = self._check_parameters(
+                                                loc, variance_scale, shape, scale)
+        x_mean = loc
+        if shape > 1:
+            sig2_mean = scale / (shape - 1)
+        else:
+            sig2_mean = np.inf
+        return x_mean, sig2_mean
+
+    def mode(self, loc=0, variance_scale=1, shape=1, scale=1):
+        """
+        Compute the mode for input random variates.
+
+        Parameters
+        ----------
+        %(_nig_doc_default_callparams)s
+
+        Returns
+        -------
+        (x, s) : tuple of scalar values
+            Mode of the random variates
+
+        Notes
+        -----
+        %(_nig_doc_callparams_note)s
+
+        """
+        loc, variance_scale, shape, scale = self._check_parameters(
+                                                loc, variance_scale, shape, scale)
+        x_mode = loc
+        sig2_mode = scale / (shape + 1)
+        return x_mode, sig2_mode
+
+
+normal_invgamma = normal_invgamma_gen()
+
+
+class normal_invgamma_frozen(multi_rv_frozen):
+    def __init__(self, loc=0, variance_scale=1, shape=1, scale=1, seed=None):
+        
+        self._dist = normal_invgamma_gen(seed)
+        self.loc, self.variance_scale, self.shape, self.scale = self._dist._check_parameters(
+                                                            loc, variance_scale, shape, scale)
+
+    def logpdf(self, x, sig2):
+        x, sig2 = self._dist._check_input(x, sig2)
+        out = self._dist.logpdf(x, sig2, self.loc, self.variance_scale, self.shape, self.scale)
+        return out
+
+    def pdf(self, x, sig2):
+        return np.exp(self.logpdf(x, sig2))
+
+    def rvs(self, size=1, random_state=None):
+        return self._dist.rvs(self.loc, self.variance_scale,
+                            self.shape, self.scale, size, random_state)
+
+    def mean(self):
+        return self._dist.mean(self.loc, self.variance_scale, self.shape, self.scale)
+
+    def mode(self):
+        return self._dist.mode(self.loc, self.variance_scale, self.shape, self.scale)
+
+# Set frozen generator docstrings from corresponding docstrings in
+# normal_invgamma_gen and fill in default strings in class docstrings
+for name in ['logpdf', 'pdf', 'rvs']:
+    method = normal_invgamma_gen.__dict__[name]
+    method_frozen = normal_invgamma_frozen.__dict__[name]
+    method_frozen.__doc__ = doccer.docformat(method.__doc__, nig_docdict_noparams)
+    method.__doc__ = doccer.docformat(method.__doc__, nig_docdict_params)


### PR DESCRIPTION
This PR implements the Normal inverse gamma distribution which is a conjugate prior for Normal distribution with unknown mean and variance. I have added it under _multivariate.py as suggested by @josef-pkt in [#6528](https://github.com/scipy/scipy/issues/6528) with few basic methods. As it's a bivariate distribution i've addressed the unknown mean's variate as `x` and unknown variance's variate as `sig2` separately instead of using a 2D variate for now.
Please suggest any changes required for improving this class.
I will write the documentation and unit tests as soon as the methods are finalised for this distribution.
