### PR TITLE
BUG: fix ``linalg.block_diag`` to support zero-sized matrices.

### DIFF
--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -128,6 +128,8 @@ input contains ties. The p-value is also identical to that computed by
 `scipy.stats.mstats_basic.kendalltau` and by R. If the input does not
 contain ties there is no change w.r.t. the previous implementation.
 
+The function `scipy.linalg.block_diag` will not ignore zero-sized matrices anymore.
+
 
 Other changes
 =============

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -498,7 +498,8 @@ def block_diag(*arrs):
     If all the input arrays are square, the output is known as a
     block diagonal matrix.
 
-    Empty sequences (i.e., array-likes of zero size) are ignored.
+    Empty sequences (i.e., array-likes of zero size) will not be ignored.
+    Noteworthy, both [] and [[]] are treated as matrices with shape ``(1,0)``.
 
     Examples
     --------
@@ -508,9 +509,18 @@ def block_diag(*arrs):
     >>> B = [[3, 4, 5],
     ...      [6, 7, 8]]
     >>> C = [[7]]
+    >>> P = np.zeros((2, 0), dtype='int32')
     >>> block_diag(A, B, C)
     array([[1, 0, 0, 0, 0, 0],
            [0, 1, 0, 0, 0, 0],
+           [0, 0, 3, 4, 5, 0],
+           [0, 0, 6, 7, 8, 0],
+           [0, 0, 0, 0, 0, 7]])
+    >>> block_diag(A, P, B, C)
+    array([[1, 0, 0, 0, 0, 0],
+           [0, 1, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0],
            [0, 0, 3, 4, 5, 0],
            [0, 0, 6, 7, 8, 0],
            [0, 0, 0, 0, 0, 7]])
@@ -530,7 +540,7 @@ def block_diag(*arrs):
         raise ValueError("arguments in the following positions have dimension "
                          "greater than 2: %s" % bad_args)
 
-    shapes = np.array([a.shape if a.size > 0 else [0, 0] for a in arrs])
+    shapes = np.array([a.shape for a in arrs])
     out_dtype = np.find_common_type([arr.dtype for arr in arrs], [])
     out = np.zeros(np.sum(shapes, axis=0), dtype=out_dtype)
 

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -266,16 +266,33 @@ class TestBlockDiag:
         assert_equal(a.nbytes, 0)
     
     def test_empty_matrix_arg(self):
-        # regression test for gh-4596: check the shape of the result for empty matrix inputs
+        # regression test for gh-4596: check the shape of the result
+        # for empty matrix inputs. Empty matrices are no longer ignored
+        # (gh-4908) it is viewed as a shape (1, 0) matrix.
         a = block_diag([[1, 0], [0, 1]],
                        [],
                        [[2, 3], [4, 5], [6, 7]])
         assert_array_equal(a, [[1, 0, 0, 0],
                                [0, 1, 0, 0],
+                               [0, 0, 0, 0],
                                [0, 0, 2, 3],
                                [0, 0, 4, 5],
                                [0, 0, 6, 7]])
 
+    def test_zerosized_matrix_arg(self):
+        # test for gh-4908: check the shape of the result for 
+        # zero-sized matrix inputs, i.e. matrices with shape (0,n) or (n,0).
+        # note that [[]] takes shape (1,0)
+        a = block_diag([[1, 0], [0, 1]],
+                       [[]],
+                       [[2, 3], [4, 5], [6, 7]],
+                       np.zeros([0,2],dtype='int32'))
+        assert_array_equal(a, [[1, 0, 0, 0, 0, 0],
+                               [0, 1, 0, 0, 0, 0],
+                               [0, 0, 0, 0, 0, 0],
+                               [0, 0, 2, 3, 0, 0],
+                               [0, 0, 4, 5, 0, 0],
+                               [0, 0, 6, 7, 0, 0]])
 
 class TestKron:
 


### PR DESCRIPTION
1. Modify function block_diag to remove overzealous check.
2. A test for zero-sized input.
3. An example in the doc, and some warning about empty list input [],[[]].

Closes gh-4908
