### PR TITLE
TST: test again with -OO on TravisCI.  Got lost on the way.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ matrix:
         - COVERAGE=
         - NUMPYSPEC="numpy==1.8.2"
         - USE_SDIST=1
+        - OPTIMIZE=-OO
     - python: 2.7
       env:
         - TESTMODE=full


### PR DESCRIPTION
This was tested before in the Python 2.6 entry in the build
matrix, so it got deleted by accident recently.
