### PR TITLE
TST: asv.conf.json now clones from the local scipy repo

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -11,7 +11,7 @@
 
     // The URL of the source code repository for the project being
     // benchmarked
-    "repo": "https://github.com/scipy/scipy.git",
+    "repo": "..",
     "dvcs": "git",
     "branches": ["master", "maintenance/0.15.x", "maintenance/0.14.x"],
 

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -38,19 +38,8 @@ def main():
     sys.exit(run_asv(args.asv_command))
 
 
-def run_asv(args, current_repo=False):
+def run_asv(args):
     cwd = os.path.abspath(os.path.dirname(__file__))
-
-    if current_repo:
-        try:
-            from asv.util import load_json, write_json
-            conf = load_json(os.path.join(cwd, 'asv.conf.json'))
-            conf['repo'] = os.path.normpath(os.path.join(cwd, '..'))
-            cfg_fn = os.path.join(cwd, '.asvconf.tmp')
-            write_json(cfg_fn, conf)
-            args = ['--config', cfg_fn] + args
-        except ImportError:
-            pass
 
     repo_dir = os.path.join(cwd, 'scipy')
 

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -32,14 +32,10 @@ def main():
     p = argparse.ArgumentParser(usage=__doc__.strip())
     p.add_argument('--help-asv', nargs=0, action=ASVHelpAction,
         help="""show ASV help""")
-    p.add_argument("--current-repo", action="store_true",
-        help="""use current repository as the upstream repository,
-        rather than cloning it from the internet; enables running
-        benchmarks on e.g. your own branches""")
     p.add_argument('asv_command', nargs=argparse.REMAINDER)
     args = p.parse_args()
 
-    sys.exit(run_asv(args.asv_command, current_repo=args.current_repo))
+    sys.exit(run_asv(args.asv_command))
 
 
 def run_asv(args, current_repo=False):
@@ -57,13 +53,6 @@ def run_asv(args, current_repo=False):
             pass
 
     repo_dir = os.path.join(cwd, 'scipy')
-    if is_git_repo_root(repo_dir):
-        if current_repo:
-            url = os.path.normpath(os.path.join(cwd, '..'))
-        else:
-            url = "https://github.com/scipy/scipy.git"
-        subprocess.call(['git', 'remote', 'set-url', "origin", url],
-                        cwd=repo_dir)
 
     cmd = ['asv'] + list(args)
     env = dict(os.environ)
@@ -103,19 +92,6 @@ def run_asv(args, current_repo=False):
             print("to run Scipy benchmarks")
             return 1
         raise
-
-
-def is_git_repo_root(path):
-    try:
-        p = subprocess.Popen(['git', '-C', path, 'rev-parse', '--git-dir'],
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        out, err = p.communicate()
-        if p.returncode != 0:
-            return False
-        return (out.strip() == '.git')
-    except OSError:
-        return False
-
 
 def drop_bad_flags(flags):
     """

--- a/runtests.py
+++ b/runtests.py
@@ -234,7 +234,7 @@ def main(argv):
             commit_a = out.strip()
 
             cmd = [os.path.join(ROOT_DIR, 'benchmarks', 'run.py'),
-                   '--current-repo', 'continuous', '-e', '-f', '1.05',
+                   'continuous', '-e', '-f', '1.05',
                    commit_a, commit_b] + bench_args
             os.execv(sys.executable, [sys.executable] + cmd)
             sys.exit(1)


### PR DESCRIPTION
### Background

As discussed with @pv [in another thread](https://github.com/spacetelescope/asv/issues/297#issuecomment-257382750), `scipy` currently has `asv` settings in `asv.conf.json` which (by default; for historical reasons that are apparently no longer valid) clone the `scipy` github repo proper rather than the local repo on a given machine. This means that when using the native `asv` benchmarking commands in `scipy/benchmarks` any commits a developer makes on a `scipy` feature branch cannot be accessed by the benchmarking suite for comparison.

Conversely, there are other ways to run the `asv` benchmarks [described in the scipy docs](https://github.com/scipy/scipy/tree/master/benchmarks#usage) which apparently will circumvent the issue without the fix. Nonetheless, the docs indicate that native `asv` commands are also usable for the benchmarking suite so it would be nice if we supported that.

### The Fix

My patch for the json file is explicitly described in the [official docs for the repo field of the json file](http://asv.readthedocs.io/en/latest/asv.conf.json.html#repo). Testing the single commit (917664d) used for this PR branch against the tip of master (027af12) using the three approaches described in the docs:

From within `scipy/benchmarks` using native `asv`:
 `asv continuous --bench SphericalVorSort 027af12 917664d`
```
· Running 2 total benchmarks (2 commits * 1 environments * 1 benchmarks)
[  0.00%] · For scipy commit hash 917664df:
[  0.00%] ·· Building for virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six........................................................................................................................................................................
[  0.00%] ·· Benchmarking virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six
[ 50.00%] ··· Running spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting                                                                                                           797.09μs;...
[ 50.00%] · For scipy commit hash 027af120:
[ 50.00%] ·· Building for virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six......................................................................................................................................................................
[ 50.00%] ·· Benchmarking virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six
[100.00%] ··· Running spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting                                                                                                           804.30μs;...
BENCHMARKS NOT SIGNIFICANTLY CHANGED.
``` 
At the same path as above using the `run.py` wrapper script provided in `scipy`:
`./run.py continuous --bench SphericalVorSort 027af12 917664d`
```
· Running 2 total benchmarks (2 commits * 1 environments * 1 benchmarks)
[  0.00%] · For scipy commit hash 917664df:
[  0.00%] ·· Building for virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six...
[  0.00%] ·· Benchmarking virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six
[ 50.00%] ··· Running spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting                                                                                                           810.62μs;...
[ 50.00%] · For scipy commit hash 027af120:
[ 50.00%] ·· Building for virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six...
[ 50.00%] ·· Benchmarking virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six
[100.00%] ··· Running spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting                                                                                                           799.40μs;...
BENCHMARKS NOT SIGNIFICANTLY CHANGED.
```
And finally from the `scipy` root directory:
`python runtests.py --bench-compare 027af12 SphericalVorSort`
```
· Running 2 total benchmarks (2 commits * 1 environments * 1 benchmarks)
[  0.00%] · For scipy commit hash 917664df:
[  0.00%] ·· Building for virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six...
[  0.00%] ·· Benchmarking virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six
[ 50.00%] ··· Running spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting                                                                                                                     ok
[ 50.00%] ···· 
               ============ ==========
                num_points            
               ------------ ----------
                    10       791.72μs 
                   100       16.02ms  
                   1000      105.72ms 
                   5000      527.90ms 
                  10000       1.07s   
               ============ ==========

[ 50.00%] · For scipy commit hash 027af120:
[ 50.00%] ·· Building for virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six...
[ 50.00%] ·· Benchmarking virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six
[100.00%] ··· Running spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting                                                                                                                     ok
[100.00%] ···· 
               ============ ==========
                num_points            
               ------------ ----------
                    10       774.39μs 
                   100       10.81ms  
                   1000      102.59ms 
                   5000      539.15ms 
                  10000       1.05s   
               ============ ==========
    before     after       ratio
  [027af120] [917664df]
+   10.81ms    16.02ms      1.48  spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting(100)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```

### Considerations

- It is a good thing that all three approaches described in the docs now have access to new feature branch commits, though these tests are rather simple
- I don't know why the benchmark using `runtests.py` seems a bit more volatile than the other two, but hey it is real data and that happened on a repeat attempt as well -- at least it just one of the data points I guess
- I don't think we can easily unit test for this "fix" -- I'm not sure that there is any unit testing done for benchmark suite behaviour (nor am I suggesting it would be needed)