### PR TITLE
DOC: Improve docstrings of sparse matrices

### DIFF
--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -617,7 +617,12 @@ class spmatrix(object):
 
     # Renamed conjtranspose() -> getH() for compatibility with dense matrices
     def getH(self):
-        """Hermitian transpose of a matrix."""
+        """Return the Hermitian transpose of this matrix.
+
+        See Also
+        --------
+        np.matrix.getH : NumPy's implementation of `getH` for matrices
+        """
         return self.transpose().conj()
 
     def _real(self):

--- a/scipy/sparse/base.py
+++ b/scipy/sparse/base.py
@@ -75,6 +75,7 @@ class spmatrix(object):
         self.maxprint = maxprint
 
     def set_shape(self, shape):
+        """See `reshape`."""
         shape = tuple(shape)
 
         if len(shape) != 2:
@@ -97,6 +98,7 @@ class spmatrix(object):
         self._shape = shape
 
     def get_shape(self):
+        """Get shape of a matrix."""
         return self._shape
 
     shape = property(fget=get_shape, fset=set_shape)
@@ -126,6 +128,15 @@ class spmatrix(object):
                                   self.__class__.__name__)
 
     def astype(self, t):
+        """Cast the matrix elements to a specified type.
+
+        The data will be copied.
+
+        Parameters
+        ----------
+        t : string or numpy dtype
+            Typecode or data-type to which to cast the data.
+        """
         return self.tocsr().astype(t).asformat(self.format)
 
     def asfptype(self):
@@ -148,6 +159,7 @@ class spmatrix(object):
             yield self[r, :]
 
     def getmaxprint(self):
+        """Maximum number of elements to display when printed."""
         return self.maxprint
 
     def count_nonzero(self):
@@ -189,6 +201,7 @@ class spmatrix(object):
         return self.getnnz()
 
     def getformat(self):
+        """Format of a matrix representation as a string."""
         return getattr(self, 'format', 'und')
 
     def __repr__(self):
@@ -266,9 +279,11 @@ class spmatrix(object):
         return self.tocsr().multiply(other)
 
     def maximum(self, other):
+        """Element-wise maximum between this and another matrix."""
         return self.tocsr().maximum(other)
 
     def minimum(self, other):
+        """Element-wise minimum between this and another matrix."""
         return self.tocsr().minimum(other)
 
     def dot(self, other):
@@ -287,6 +302,7 @@ class spmatrix(object):
         return self * other
 
     def power(self, n, dtype=None):
+        """Element-wise power."""
         return self.tocsr().power(n, dtype=dtype)
 
     def __eq__(self, other):
@@ -587,13 +603,21 @@ class spmatrix(object):
         return self.tocsr().transpose(axes=axes, copy=copy)
 
     def conj(self):
+        """Element-wise complex conjugation.
+
+        If the matrix is of non-complex data type, then this method does
+        nothing and the data is not copied.
+        """
         return self.tocsr().conj()
 
     def conjugate(self):
         return self.conj()
 
+    conjugate.__doc__ = conj.__doc__
+
     # Renamed conjtranspose() -> getH() for compatibility with dense matrices
     def getH(self):
+        """Hermitian transpose of a matrix."""
         return self.transpose().conj()
 
     def _real(self):

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -327,7 +327,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
         return self * other
 
     def matmat(self, other):
-        """Multiply matrix by matrix."""
+        """Multiply this sparse matrix by other matrix."""
         return self * other
 
     def _mul_vector(self, other):

--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -309,6 +309,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
     ##########################
 
     def getdata(self,ind):
+        """Not implemented method."""
         raise NotImplementedError
 
     def __getitem__(self,key):
@@ -322,9 +323,11 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
     ######################
 
     def matvec(self, other):
+        """Multiply matrix by vector."""
         return self * other
 
     def matmat(self, other):
+        """Multiply matrix by matrix."""
         return self * other
 
     def _mul_vector(self, other):
@@ -507,6 +510,7 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
     ##############################################################
 
     def eliminate_zeros(self):
+        """Remove zero elements in-place."""
         R,C = self.blocksize
         M,N = self.shape
 

--- a/scipy/sparse/compressed.py
+++ b/scipy/sparse/compressed.py
@@ -546,8 +546,12 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
     def maximum(self, other):
         return self._maximum_minimum(other, np.maximum, '_maximum_', lambda x: np.asarray(x) > 0)
 
+    maximum.__doc__ = spmatrix.maximum.__doc__
+
     def minimum(self, other):
         return self._maximum_minimum(other, np.minimum, '_minimum_', lambda x: np.asarray(x) < 0)
+
+    minimum.__doc__ = spmatrix.minimum.__doc__
 
     #####################
     # Reduce operations #

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -169,7 +169,6 @@ class csr_matrix(_cs_matrix, IndexMixin):
     tocsr.__doc__ = spmatrix.tocsr.__doc__
 
     def tocsc(self, copy=False):
-        """Convert this matrix to Compressed Sparse Column format."""
         idx_dtype = get_index_dtype((self.indptr, self.indices),
                                     maxval=max(self.nnz, self.shape[0]))
         indptr = np.empty(self.shape[1] + 1, dtype=idx_dtype)
@@ -189,7 +188,7 @@ class csr_matrix(_cs_matrix, IndexMixin):
         A.has_sorted_indices = True
         return A
 
-    tocsr.__doc__ = spmatrix.tocsr.__doc__
+    tocsc.__doc__ = spmatrix.tocsc.__doc__
 
     def tobsr(self, blocksize=None, copy=True):
         from .bsr import bsr_matrix

--- a/scipy/sparse/csr.py
+++ b/scipy/sparse/csr.py
@@ -169,6 +169,7 @@ class csr_matrix(_cs_matrix, IndexMixin):
     tocsr.__doc__ = spmatrix.tocsr.__doc__
 
     def tocsc(self, copy=False):
+        """Convert this matrix to Compressed Sparse Column format."""
         idx_dtype = get_index_dtype((self.indptr, self.indices),
                                     maxval=max(self.nnz, self.shape[0]))
         indptr = np.empty(self.shape[1] + 1, dtype=idx_dtype)

--- a/scipy/sparse/data.py
+++ b/scipy/sparse/data.py
@@ -67,11 +67,17 @@ class _data_matrix(spmatrix):
     def astype(self, t):
         return self._with_data(self._deduped_data().astype(t))
 
+    astype.__doc__ = spmatrix.astype.__doc__
+
     def conj(self):
         return self._with_data(self.data.conj())
 
+    conj.__doc__ = spmatrix.conj.__doc__
+
     def copy(self):
         return self._with_data(self.data.copy(), copy=True)
+
+    copy.__doc__ = spmatrix.copy.__doc__
 
     def count_nonzero(self):
         return np.count_nonzero(self._deduped_data())

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -111,41 +111,6 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             self.shape = arg1.shape
             self.dtype = d.dtype
 
-    def clear(self):
-        """Remove all non-zero elements.
-
-        This is the method of the underlying dict object.
-        """
-        super(dok_matrix, self).clear()
-        
-    def items(self):
-        """A set-like object containing ((i, j)-index, value) pairs.
-
-        This is the method of the underlying dict object.
-        """
-        return super(dok_matrix, self).items()
-
-    def keys(self):
-        """A set-like object containing index pairs of non-zero elements.
-
-        This is the method of the underlying dict object.
-        """
-        return super(dok_matrix, self).keys()
-
-    def values(self):
-        """A set-like object containing values of non-zero elements.
-
-        This is the method of the underlying dict object.
-        """
-        return super(dok_matrix, self).values()
-
-    def setdefault(self, key, default=None):
-        """See setdefault method of Python dict.
-
-        This is the method of the underlying dict object.
-        """
-        super(dok_matrix, self).setdefault(key, default=default)
-
     def getnnz(self, axis=None):
         if axis is not None:
             raise NotImplementedError("getnnz over an axis is not implemented "

--- a/scipy/sparse/dok.py
+++ b/scipy/sparse/dok.py
@@ -111,6 +111,41 @@ class dok_matrix(spmatrix, IndexMixin, dict):
             self.shape = arg1.shape
             self.dtype = d.dtype
 
+    def clear(self):
+        """Remove all non-zero elements.
+
+        This is the method of the underlying dict object.
+        """
+        super(dok_matrix, self).clear()
+        
+    def items(self):
+        """A set-like object containing ((i, j)-index, value) pairs.
+
+        This is the method of the underlying dict object.
+        """
+        return super(dok_matrix, self).items()
+
+    def keys(self):
+        """A set-like object containing index pairs of non-zero elements.
+
+        This is the method of the underlying dict object.
+        """
+        return super(dok_matrix, self).keys()
+
+    def values(self):
+        """A set-like object containing values of non-zero elements.
+
+        This is the method of the underlying dict object.
+        """
+        return super(dok_matrix, self).values()
+
+    def setdefault(self, key, default=None):
+        """See setdefault method of Python dict.
+
+        This is the method of the underlying dict object.
+        """
+        super(dok_matrix, self).setdefault(key, default=default)
+
     def getnnz(self, axis=None):
         if axis is not None:
             raise NotImplementedError("getnnz over an axis is not implemented "

--- a/scipy/sparse/lil.py
+++ b/scipy/sparse/lil.py
@@ -149,6 +149,8 @@ class lil_matrix(spmatrix, IndexMixin):
                                           self.__class__.__name__)
         self._shape = shape
 
+    set_shape.__doc__ = spmatrix.set_shape.__doc__
+
     shape = property(fget=spmatrix.get_shape, fset=set_shape)
 
     def __iadd__(self,other):
@@ -447,6 +449,8 @@ class lil_matrix(spmatrix, IndexMixin):
 
     def transpose(self, axes=None, copy=False):
         return self.tocsr().transpose(axes=axes, copy=copy).tolil()
+
+    transpose.__doc__ = spmatrix.transpose.__doc__
 
     def tolil(self, copy=False):
         if copy:


### PR DESCRIPTION
I always was bothered that some methods in sparse matrices had just empty docstrings. So initially I tried to provide a docstring for each method.

I also changed method docstring in `dok_matrix` which weren't rendered reasonably by Sphinx (these are methods inherited from dict). I think farther improvements can be made in this direction, i.e. write docstrings more to the point for each method inherited from dict.

Besides adding missing docstrings, I think we can also make them generally better and more consistent. I suggest to work on all that in this PR. 