### PR TITLE
ENH: Weighted tau

### DIFF
--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -70,6 +70,12 @@ polynomials. For example, `scipy.special.j_roots` has been renamed
 functions `scipy.special.jacobi` and `scipy.special.eval_jacobi`. To
 preserve back-compatibility the old names have been left as aliases.
 
+`scipy.stats` improvements
+--------------------------
+
+The function `scipy.stats.weightedtau` was added.  It provides a weighted
+version of Kendall's tau.
+
 `scipy.interpolate` improvements
 --------------------------------
 

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -231,6 +231,7 @@ which work for masked arrays.
    spearmanr
    pointbiserialr
    kendalltau
+   weightedtau
    linregress
    theilslopes
    f_value

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -103,13 +103,7 @@ def _kendall_dis(intp_t[:] x, intp_t[:] y):
 # The weighted tau will be computed directly between these types.
 # Arrays of other types will be turned into a rank array using _toranks().
 
-ctypedef fused ordered0:
-    np.int32_t
-    np.int64_t
-    np.float32_t
-    np.float64_t
-
-ctypedef fused ordered1:
+ctypedef fused ordered:
     np.int32_t
     np.int64_t
     np.float32_t
@@ -157,7 +151,7 @@ def _toranks(x):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def _weightedrankedtau(ordered0[:] x, ordered1[:] y, intp_t[:] rank, weigher, bool additive):
+def _weightedrankedtau(ordered[:] x, ordered[:] y, intp_t[:] rank, weigher, bool additive):
     cdef int64_t n = np.int64(len(x))
 
     # initial sort on values of x and, if tied, on values of y

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -104,10 +104,10 @@ def _kendall_dis(intp_t[:] x, intp_t[:] y):
 # Arrays of other types will be turned into a rank array using _toranks().
 
 ctypedef fused ordered:
-#    np.int32_t
+    np.int32_t
     np.int64_t
-#    np.float32_t
-#    np.float64_t
+    np.float32_t
+    np.float64_t
 
 
 # Inverts a permutation in place [B. H. Boonstra, Comm. ACM 8(2):104, 1965].

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -104,10 +104,10 @@ def _kendall_dis(intp_t[:] x, intp_t[:] y):
 # Arrays of other types will be turned into a rank array using _toranks().
 
 ctypedef fused ordered:
-    np.int32_t
+#    np.int32_t
     np.int64_t
-    np.float32_t
-    np.float64_t
+#    np.float32_t
+#    np.float64_t
 
 
 # Inverts a permutation in place [B. H. Boonstra, Comm. ACM 8(2):104, 1965].

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -157,7 +157,7 @@ def _toint64(x):
             j += 1
 
     result[perm[i + 1]] = j
-    return result
+    return np.array(result, dtype=np.int64)
 
 
 @cython.wraparound(False)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3457,7 +3457,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     --------
     spearmanr : Calculates a Spearman rank-order correlation coefficient.
     theilslopes : Computes the Theil-Sen estimator for a set of points (x, y).
-    weightedtau: Computes the weighted version of Kendall's tau.
+    weightedtau : Computes a weighted version of Kendall's tau.
 
     Notes
     -----
@@ -3573,13 +3573,13 @@ WeightedTauResult = namedtuple('WeightedTauResult', ('correlation', 'pvalue'))
 
 def weightedtau(x, y, rank=True, weigher=lambda x: 1./(x+1), additive=True):
     """
-    Computes the weighted tau, a correlation measure for ordinal data.
+    Computes a weighted version of Kendall's tau.
 
-    It is a weighted version of Kendall's tau in which exchanges of high
-    weight are more influent than exchanges of low weight. The default
-    parameters compute the additive hyperbolic version of the index,
-    tau_h, which has been shown to provide the best balance between
-    important and unimportant elements [1]_.
+    The weighted tau is a weighted version of Kendall's tau in which
+    exchanges of high weight are more influent than exchanges of low
+    weight. The default parameters compute the additive hyperbolic version
+    of the index, tau_h, which has been shown to provide the best balance
+    between important and unimportant elements [1]_.
 
     The weight of an exchange is defined by means of a rank array, which
     assigns a nonnegative rank to each element, and a weigher function,

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3573,21 +3573,21 @@ WeightedTauResult = namedtuple('WeightedTauResult', ('correlation', 'pvalue'))
 
 def weightedtau(x, y, rank=True, weigher=lambda x: 1./(x+1), additive=True):
     """
-    Computes the weighted tau, a correlation measure for ordinal data. It
-    is a weighted version of Kendall's tau in which exchanges of high
-    weight are more influent than exchanges of low weight.
+    Computes the weighted tau, a correlation measure for ordinal data.
 
-    The default parameters compute the additive hyperbolic version
-    of the index, tau_h, which has been shown to provide the best
-    balance between important and unimportant elements [1]_.
+    It is a weighted version of Kendall's tau in which exchanges of high
+    weight are more influent than exchanges of low weight. The default
+    parameters compute the additive hyperbolic version of the index,
+    tau_h, which has been shown to provide the best balance between
+    important and unimportant elements [1]_.
 
     The weight of an exchange is defined by means of a rank array, which
     assigns a nonnegative rank to each element, and a weigher function,
     which assigns a weight based from the rank to each element. The weight
-    of an exchange is the sum or the product of the weights of the ranks
-    of the exchanged elements. The default parameters compute the additive
-    hyperbolic tau: an exchange between elements with rank r and s
-    (starting from zero) has has weight 1/(r+1) + 1/(s+1).
+    of an exchange is then the sum or the product of the weights of the
+    ranks of the exchanged elements. The default parameters compute the
+    additive hyperbolic tau: an exchange between elements with rank r and
+    s (starting from zero) has has weight 1/(r+1) + 1/(s+1).
 
     Specifying a rank array is meaningful only if you have in mind an
     external criterion of importance. If, as it usually happens, you do
@@ -3595,6 +3595,11 @@ def weightedtau(x, y, rank=True, weigher=lambda x: 1./(x+1), additive=True):
     averaging the values obtained using the decreasing lexicographical
     rank by (x,y) and by (y,x). This is the behavior with default
     parameters.
+
+    Note that if you are computing the weighted tau on arrays of ranks,
+    rather than of scores (i.e., a larger value implies a lower rank) you
+    must negate the ranks, so that elements of higher rank are associated
+    with a larger value.
 
     Parameters
     ----------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3568,6 +3568,8 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     # Limit range to fix computational errors
     return KendalltauResult(min(1., max(-1., tau)), pvalue)
 
+WeightedTauResult = namedtuple('WeightedTauResult', ('correlation', 'pvalue'))
+
 
 def weightedtau(x, y, rank=True, weigher=lambda x: 1./(x+1), additive=True):
     """
@@ -3674,8 +3676,6 @@ def weightedtau(x, y, rank=True, weigher=lambda x: 1./(x+1), additive=True):
     """
     x = np.asarray(x).ravel()
     y = np.asarray(y).ravel()
-
-    WeightedTauResult = namedtuple('WeightedTauResult', ('correlation', 'pvalue'))
 
     if x.size != y.size:
         raise ValueError("All inputs to `weightedtau` must be of the same size, "

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3569,7 +3569,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     return KendalltauResult(min(1., max(-1., tau)), pvalue)
 
 
-def weightedrankedtau(x, y, rank=None, weigher=lambda x : 1./(x+1), additive=True):
+def weightedrankedtau(x, y, rank=None, weigher=lambda x: 1./(x+1), additive=True):
     """
     Calculates the weighted-ranked tau, a correlation measure for ordinal data.
     It is a weighted version of Kendall's tau in which exchanges of high
@@ -3626,7 +3626,7 @@ def weightedrankedtau(x, y, rank=None, weigher=lambda x : 1./(x+1), additive=Tru
     ----------
     .. [1] Sebastiano Vigna "A weighted correlation index for rankings with ties".
            In Proceedings of the 24th international conference on World Wide Web,
-           pages 1166−1176. ACM, 2015.
+           pages 1166-1176. ACM, 2015.
     .. [2] W.R. Knight, "A Computer Method for Calculating Kendall's Tau with
            Ungrouped Data", Journal of the American Statistical Association,
            Vol. 61, No. 314, Part 1, pp. 436-439, 1966.
@@ -3670,11 +3670,16 @@ def weightedrankedtau(x, y, rank=None, weigher=lambda x : 1./(x+1), additive=Tru
         x = _toranks(x)
     if y.dtype not in (np.int32, np.int64, np.float32, np.float64):
         y = _toranks(y)
+    if x.dtype != y.dtype:
+        if x.dtype != np.int64:
+            x = _toranks(x)
+        if y.dtype != np.int64:
+            y = _toranks(y)
 
     return WeightedRankedTauResult(_weightedrankedtau(x, y, rank, weigher, additive), np.nan)
 
 
-def weightedtau(x, y, weigher=lambda x : 1./(x+1), additive=True):
+def weightedtau(x, y, weigher=lambda x: 1./(x+1), additive=True):
     """
     Calculates the weighted tau, a correlation measure
     for ordinal data. It is a weighted version of Kendall's tau in
@@ -3717,24 +3722,24 @@ def weightedtau(x, y, weigher=lambda x : 1./(x+1), additive=True):
     ----------
     .. [1] Sebastiano Vigna "A weighted correlation index for rankings with ties".
            In Proceedings of the 24th international conference on World Wide Web,
-           pages 1166−1176. ACM, 2015.
+           pages 1166-1176. ACM, 2015.
     Examples
     --------
     >>> from scipy import stats
     >>> x = [12, 2, 1, 12, 2]
     >>> y = [1, 4, 7, 1, 0]
-    >>> tau, p_value = stats.weightedtaukedtau(x, y)
+    >>> tau, p_value = stats.weightedrankedtau(x, y)
     >>> tau
     -0.56694968153682723
     >>> p_value
     nan
-    >>> tau, p_value = stats.weightedtaukedtau(x, y, additive=False)
+    >>> tau, p_value = stats.weightedrankedtau(x, y, additive=False)
     >>> tau
     -0.62205716951801038
     >>> x = [12, 2, 1, 12, 2]
     >>> y = [1, 4, 7, 1, 0]
     >>> # This is exactly Kendall's tau
-    >>> tau, p_value = stats.weightedtaukedtau(x, y, weigher=lambda x: 1)
+    >>> tau, p_value = stats.weightedrankedtau(x, y, weigher=lambda x: 1)
     >>> tau
     -0.47140452079103173
     """
@@ -3754,6 +3759,11 @@ def weightedtau(x, y, weigher=lambda x : 1./(x+1), additive=True):
         x = _toranks(x)
     if y.dtype not in (np.int32, np.int64, np.float32, np.float64):
         y = _toranks(y)
+    if x.dtype != y.dtype:
+        if x.dtype != np.int64:
+            x = _toranks(x)
+        if y.dtype != np.int64:
+            y = _toranks(y)
 
     return WeightedTauResult((
         _weightedrankedtau(x, y, None, weigher, additive) +

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3623,6 +3623,7 @@ def weightedtau(x, y, rank=True, weigher=lambda x: 1./(x+1), additive=True):
         If true, the weight of an exchange is computed by adding the
         weights of the ranks of the exchanged elements; otherwise, the weights
         are multiplied. The default is True.
+
     Returns
     -------
     correlation : float
@@ -3630,11 +3631,13 @@ def weightedtau(x, y, rank=True, weigher=lambda x: 1./(x+1), additive=True):
     pvalue : float
        Presently np.nan, as the null statistics for the weighted tau is
        unknown (even in the additive hyperbolic case).
+
     See also
     --------
     kendalltau : Calculates Kendall's tau
     spearmanr : Calculates a Spearman rank-order correlation coefficient.
     theilslopes : Computes the Theil-Sen estimator for a set of points (x, y).
+
     References
     ----------
     .. [1] Sebastiano Vigna "A weighted correlation index for rankings with ties".

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3703,9 +3703,9 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
         return WeightedTauResult(np.nan, np.nan)  # Return NaN if arrays are empty
 
     # Reduce to ranks unsupported types
-    if x.dtype not in (np.int32, np.int64, np.float32, np.float64):
+    if x.dtype not in (np.int64): # (np.int32, np.int64, np.float32, np.float64):
         x = _toranks(x)
-    if y.dtype not in (np.int32, np.int64, np.float32, np.float64):
+    if y.dtype not in (np.int64): # (np.int32, np.int64, np.float32, np.float64):
         y = _toranks(y)
     if x.dtype != y.dtype:
         if x.dtype != np.int64:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3593,15 +3593,15 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
 
     Specifying a rank array is meaningful only if you have in mind an
     external criterion of importance. If, as it usually happens, you do
-    not have in mind a specific rank, the weighted tau is defined by
-    averaging the values obtained using the decreasing lexicographical
-    rank by (`x`, `y`) and by (`y`, `x`). This is the behavior with default
-    parameters.
+    not have in mind a specific rank, the weighted :math:`\\tau` is
+    defined by averaging the values obtained using the decreasing
+    lexicographical rank by (`x`, `y`) and by (`y`, `x`). This is the
+    behavior with default parameters.
 
-    Note that if you are computing the weighted tau on arrays of ranks,
-    rather than of scores (i.e., a larger value implies a lower rank) you
-    must negate the ranks, so that elements of higher rank are associated
-    with a larger value.
+    Note that if you are computing the weighted :math:`\\tau` on arrays of
+    ranks, rather than of scores (i.e., a larger value implies a lower
+    rank) you must negate the ranks, so that elements of higher rank are
+    associated with a larger value.
 
     Parameters
     ----------
@@ -3617,20 +3617,20 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
         directly as ranks. The default is None, in which case this
         function returns the average of the values obtained using the
         decreasing lexicographical rank by (`x`, `y`) and by (`y`, `x`).
-    weigher : callable or False, optional
+    weigher : callable or None, optional
         The weigher function. Must map nonnegative integers (zero
         representing the most important element) to a nonnegative weight.
-        The default, False, provides hyperbolic weighing, that is,
-        :math:`r` is mapped to :math:`1/(r+1)`.
+        The default, None, provides hyperbolic weighing, that is,
+        rank :math:`r` is mapped to weight :math:`1/(r+1)`.
     additive : bool, optional
-        If true, the weight of an exchange is computed by adding the
+        If True, the weight of an exchange is computed by adding the
         weights of the ranks of the exchanged elements; otherwise, the weights
         are multiplied. The default is True.
 
     Returns
     -------
     correlation : float
-       The weighted tau correlation index.
+       The weighted :math:`\\tau` correlation index.
     pvalue : float
        Presently `np.nan`, as the null statistics is unknown (even in the
        additive hyperbolic case).

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3703,9 +3703,9 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
         return WeightedTauResult(np.nan, np.nan)  # Return NaN if arrays are empty
 
     # Reduce to ranks unsupported types
-    if x.dtype not in (np.int64): # (np.int32, np.int64, np.float32, np.float64):
+    if x.dtype not in (np.int64):  # (np.int32, np.int64, np.float32, np.float64):
         x = _toranks(x)
-    if y.dtype not in (np.int64): # (np.int32, np.int64, np.float32, np.float64):
+    if y.dtype not in (np.int64):  # (np.int32, np.int64, np.float32, np.float64):
         y = _toranks(y)
     if x.dtype != y.dtype:
         if x.dtype != np.int64:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3571,29 +3571,31 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
 WeightedTauResult = namedtuple('WeightedTauResult', ('correlation', 'pvalue'))
 
 
-def weightedtau(x, y, rank=True, weigher=lambda x: 1./(x+1), additive=True):
+def weightedtau(x, y, rank=True, weigher=None, additive=True):
     """
-    Computes a weighted version of Kendall's tau.
+    Computes a weighted version of Kendall's :math:`\\tau`.
 
-    The weighted tau is a weighted version of Kendall's tau in which
-    exchanges of high weight are more influent than exchanges of low
-    weight. The default parameters compute the additive hyperbolic version
-    of the index, tau_h, which has been shown to provide the best balance
-    between important and unimportant elements [1]_.
+    The weighted :math:`\\tau` is a weighted version of Kendall's
+    :math:`\\tau` in which exchanges of high weight are more influent than
+    exchanges of low weight. The default parameters compute the additive
+    hyperbolic version of the index, :math:`\\tau_\\mathrm h`, which has
+    been shown to provide the best balance between important and
+    unimportant elements [1]_.
 
-    The weight of an exchange is defined by means of a rank array, which
-    assigns a nonnegative rank to each element, and a weigher function,
-    which assigns a weight based from the rank to each element. The weight
-    of an exchange is then the sum or the product of the weights of the
-    ranks of the exchanged elements. The default parameters compute the
-    additive hyperbolic tau: an exchange between elements with rank r and
-    s (starting from zero) has has weight 1/(r+1) + 1/(s+1).
+    The weighting is defined by means of a rank array, which assigns a
+    nonnegative rank to each element, and a weigher function, which
+    assigns a weight based from the rank to each element. The weight of an
+    exchange is then the sum or the product of the weights of the ranks of
+    the exchanged elements. The default parameters compute
+    :math:`\\tau_\\mathrm h`: an exchange between elements with rank
+    :math:`r` and :math:`s` (starting from zero) has weight
+    :math:`1/(r+1) + 1/(s+1)`.
 
     Specifying a rank array is meaningful only if you have in mind an
     external criterion of importance. If, as it usually happens, you do
     not have in mind a specific rank, the weighted tau is defined by
     averaging the values obtained using the decreasing lexicographical
-    rank by (x,y) and by (y,x). This is the behavior with default
+    rank by (`x`, `y`) and by (`y`, `x`). This is the behavior with default
     parameters.
 
     Note that if you are computing the weighted tau on arrays of ranks,
@@ -3606,20 +3608,21 @@ def weightedtau(x, y, rank=True, weigher=lambda x: 1./(x+1), additive=True):
     x, y : array_like
         Arrays of rankings, of the same shape. If arrays are not 1-D, they will
         be flattened to 1-D.
-    rank: array_like of ints or False or True, optional
+    rank: array_like of ints or bool, optional
         A nonnegative rank assigned to each element. If it is None, the
-        decreasing lexicographical rank by (x,y) will be used: elements of
-        higher rank will be those with larger x-values, using y-values to
-        break ties (in particular, swapping x and y will give a different
+        decreasing lexicographical rank by (`x`, `y`) will be used: elements of
+        higher rank will be those with larger `x`-values, using `y`-values to
+        break ties (in particular, swapping `x` and `y` will give a different
         result). If you use False, the element indices will be used
-        directly as ranks. The default is True, in which case this
+        directly as ranks. The default is None, in which case this
         function returns the average of the values obtained using the
-        decreasing lexicographical rank by (x,y) and by (y,x).
-    weigher : function, optional
-        The weigher function. Must map nonnegative integers (zero representing
-        the most important element) to a nonnegative weight. The default is
-        hyperbolic weighing, that is, x -> 1/(x+1).
-    additive : boolean, optional
+        decreasing lexicographical rank by (`x`, `y`) and by (`y`, `x`).
+    weigher : callable or False, optional
+        The weigher function. Must map nonnegative integers (zero
+        representing the most important element) to a nonnegative weight.
+        The default, False, provides hyperbolic weighing, that is,
+        :math:`r` is mapped to :math:`1/(r+1)`.
+    additive : bool, optional
         If true, the weight of an exchange is computed by adding the
         weights of the ranks of the exchanged elements; otherwise, the weights
         are multiplied. The default is True.
@@ -3629,14 +3632,23 @@ def weightedtau(x, y, rank=True, weigher=lambda x: 1./(x+1), additive=True):
     correlation : float
        The weighted tau correlation index.
     pvalue : float
-       Presently np.nan, as the null statistics for the weighted tau is
-       unknown (even in the additive hyperbolic case).
+       Presently `np.nan`, as the null statistics is unknown (even in the
+       additive hyperbolic case).
 
     See also
     --------
-    kendalltau : Calculates Kendall's tau
+    kendalltau : Calculates Kendall's tau.
     spearmanr : Calculates a Spearman rank-order correlation coefficient.
     theilslopes : Computes the Theil-Sen estimator for a set of points (x, y).
+
+    Notes
+    -----
+    This function uses an :math:`O(n \\log n)`, mergesort-based algorithm
+    [1]_ that is a weighted extension of Knight's algorithm for Kendall's
+    :math:`\\tau` [2]_. It can compute Shieh's weighted :math:`\\tau` [3]_
+    between rankings without ties (i.e., permutations) by setting
+    `additive` and `rank` to False, as the definition given in [1]_ is a
+    generalization of Shieh's.
 
     References
     ----------
@@ -3645,12 +3657,9 @@ def weightedtau(x, y, rank=True, weigher=lambda x: 1./(x+1), additive=True):
            pages 1166-1176. ACM, 2015.
     .. [2] W.R. Knight, "A Computer Method for Calculating Kendall's Tau with
            Ungrouped Data", Journal of the American Statistical Association,
-           Vol. 61, No. 314, Part 1, pp. 436-439, 1966.
-
-    Notes
-    -----
-    This function uses an O(n log n), mergesort-based algorithm [1]_ that is a
-    weighted extension of Knight's algorithm for Kendall's tau [2]_.
+           Vol. 61, No. 314, Part 1, pages 436-439, 1966.
+    .. [3] Grace S. Shieh. "A weighted Kendall's tau statistic", Statistics & 
+           Probability Letters, Vol. 39, No. 1, pages 17-24, 1998.
 
     Examples
     --------

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3703,14 +3703,14 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
         return WeightedTauResult(np.nan, np.nan)  # Return NaN if arrays are empty
 
     # Reduce to ranks unsupported types
-    if x.dtype not in (np.int64):  # (np.int32, np.int64, np.float32, np.float64):
-        x = _toranks(x)
-    if y.dtype not in (np.int64):  # (np.int32, np.int64, np.float32, np.float64):
-        y = _toranks(y)
     if x.dtype != y.dtype:
         if x.dtype != np.int64:
             x = _toranks(x)
         if y.dtype != np.int64:
+            y = _toranks(y)
+    else:
+        if x.dtype != np.int64:  # not in (np.int32, np.int64, np.float32, np.float64):
+            x = _toranks(x)
             y = _toranks(y)
 
     if rank is True:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3646,10 +3646,12 @@ def weightedtau(x, y, rank=True, weigher=lambda x: 1./(x+1), additive=True):
     .. [2] W.R. Knight, "A Computer Method for Calculating Kendall's Tau with
            Ungrouped Data", Journal of the American Statistical Association,
            Vol. 61, No. 314, Part 1, pp. 436-439, 1966.
+
     Notes
     -----
     This function uses an O(n log n), mergesort-based algorithm [1]_ that is a
     weighted extension of Knight's algorithm for Kendall's tau [2]_.
+
     Examples
     --------
     >>> from scipy import stats

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3613,8 +3613,8 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
         decreasing lexicographical rank by (`x`, `y`) will be used: elements of
         higher rank will be those with larger `x`-values, using `y`-values to
         break ties (in particular, swapping `x` and `y` will give a different
-        result). If you use False, the element indices will be used
-        directly as ranks. The default is None, in which case this
+        result). If it is False, the element indices will be used
+        directly as ranks. The default is True, in which case this
         function returns the average of the values obtained using the
         decreasing lexicographical rank by (`x`, `y`) and by (`y`, `x`).
     weigher : callable or None, optional
@@ -3709,7 +3709,7 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
         if y.dtype != np.int64:
             y = _toranks(y)
     else:
-        if x.dtype != np.int64:  # not in (np.int32, np.int64, np.float32, np.float64):
+        if x.dtype not in (np.int32, np.int64, np.float32, np.float64):
             x = _toranks(x)
             y = _toranks(y)
 
@@ -3721,9 +3721,8 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
 
     if rank is False:
         rank = np.arange(x.size, dtype=np.intp)
-
-    if rank is not None:
-        rank = np.asarray(rank)
+    elif rank is not None:
+        rank = np.asarray(rank).ravel()
         if rank.size != x.size:
             raise ValueError("All inputs to `weightedtau` must be of the same size, "
                          "found x-size %s and rank-size %s" % (x.size, rank.size))

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -105,7 +105,6 @@ Correlation Functions
    spearmanr
    pointbiserialr
    kendalltau
-   weightedrankedtau
    weightedtau
    linregress
    theilslopes
@@ -179,7 +178,7 @@ from . import distributions
 from . import mstats_basic
 from ._distn_infrastructure import _lazywhere
 from ._stats_mstats_common import _find_repeats, linregress, theilslopes
-from ._stats import _kendall_dis, _weightedrankedtau
+from ._stats import _kendall_dis, _toranks, _weightedrankedtau
 
 
 __all__ = ['find_repeats', 'gmean', 'hmean', 'mode', 'tmean', 'tvar',
@@ -191,7 +190,7 @@ __all__ = ['find_repeats', 'gmean', 'hmean', 'mode', 'tmean', 'tvar',
            'signaltonoise', 'sem', 'zmap', 'zscore', 'iqr', 'threshold',
            'sigmaclip', 'trimboth', 'trim1', 'trim_mean', 'f_oneway',
            'pearsonr', 'fisher_exact', 'spearmanr', 'pointbiserialr',
-           'kendalltau', 'weightedrankedtau', 'weightedtau',
+           'kendalltau', 'weightedtau',
            'linregress', 'theilslopes', 'ttest_1samp',
            'ttest_ind', 'ttest_ind_from_stats', 'ttest_rel', 'kstest',
            'chisquare', 'power_divergence', 'ks_2samp', 'mannwhitneyu',
@@ -3458,6 +3457,7 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     --------
     spearmanr : Calculates a Spearman rank-order correlation coefficient.
     theilslopes : Computes the Theil-Sen estimator for a set of points (x, y).
+    weightedtau: Computes the weighted version of Kendall's tau.
 
     Notes
     -----
@@ -3569,38 +3569,45 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     return KendalltauResult(min(1., max(-1., tau)), pvalue)
 
 
-def weightedrankedtau(x, y, rank=None, weigher=lambda x: 1./(x+1), additive=True):
+def weightedtau(x, y, rank=True, weigher=lambda x: 1./(x+1), additive=True):
     """
-    Calculates the weighted-ranked tau, a correlation measure for ordinal data.
-    It is a weighted version of Kendall's tau in which exchanges of high
-    weight are more influent than exchanges of low weight. The weight is
-    defined by means of a rank array, which assigns a rank to each element,
-    and a weigher function, which assigns a weight starting from the rank
-    The weight of an exchange is the sum or the product of the weights of
-    the ranks of the exchanged elements. The default parameters compute
-    the additive hyperbolic tau: an exchange between elements with rank r
-    and s (starting from zero) has has weight 1/(r+1) + 1/(s+1).
+    Computes the weighted tau, a correlation measure for ordinal data. It
+    is a weighted version of Kendall's tau in which exchanges of high
+    weight are more influent than exchanges of low weight.
 
-    If no rank array is specified, this function will use the
-    lexicographical rank (x,y); that is, it will assume that the rank is
-    obtained sorting by decreasing x (and, in case of a tie, y). As a
-    consequence, swapping x and y will return in general a different
-    result.
+    The default parameters compute the additive hyperbolic version
+    of the index, tau_h, which has been shown to provide the best
+    balance between important and unimportant elements [1]_.
+
+    The weight of an exchange is defined by means of a rank array, which
+    assigns a nonnegative rank to each element, and a weigher function,
+    which assigns a weight based from the rank to each element. The weight
+    of an exchange is the sum or the product of the weights of the ranks
+    of the exchanged elements. The default parameters compute the additive
+    hyperbolic tau: an exchange between elements with rank r and s
+    (starting from zero) has has weight 1/(r+1) + 1/(s+1).
 
     Specifying a rank array is meaningful only if you have in mind an
-    external criterion of importance. If, as it usually happens,
-    you do not have in mind a specific rank, you should use weightedtau().
+    external criterion of importance. If, as it usually happens, you do
+    not have in mind a specific rank, the weighted tau is defined by
+    averaging the values obtained using the decreasing lexicographical
+    rank by (x,y) and by (y,x). This is the behavior with default
+    parameters.
+
     Parameters
     ----------
     x, y : array_like
         Arrays of rankings, of the same shape. If arrays are not 1-D, they will
         be flattened to 1-D.
-    rank: array_like of ints
-        a nonnegative rank assigned to each element, over which weights will
-        be computed. The default is None, which means that the rank will be
-        computed by sorting by decreasing value first by x and then by y.
-        If you want to use the element indices directly as ranks, you must
-        pass an identity rank array, that is, [0, 1, ..., n - 1].
+    rank: array_like of ints or False or True, optional
+        A nonnegative rank assigned to each element. If it is None, the
+        decreasing lexicographical rank by (x,y) will be used: elements of
+        higher rank will be those with larger x-values, using y-values to
+        break ties (in particular, swapping x and y will give a different
+        result). If you use False, the element indices will be used
+        directly as ranks. The default is True, in which case this
+        function returns the average of the values obtained using the
+        decreasing lexicographical rank by (x,y) and by (y,x).
     weigher : function, optional
         The weigher function. Must map nonnegative integers (zero representing
         the most important element) to a nonnegative weight. The default is
@@ -3612,14 +3619,13 @@ def weightedrankedtau(x, y, rank=None, weigher=lambda x: 1./(x+1), additive=True
     Returns
     -------
     correlation : float
-       The weighted-ranked tau correlation index.
+       The weighted tau correlation index.
     pvalue : float
-       Presently np.nan, as the null statistics for the weighted-ranked tau is
+       Presently np.nan, as the null statistics for the weighted tau is
        unknown (even in the additive hyperbolic case).
     See also
     --------
     kendalltau : Calculates Kendall's tau
-    weightedtau: Calculates the weighted tau.
     spearmanr : Calculates a Spearman rank-order correlation coefficient.
     theilslopes : Computes the Theil-Sen estimator for a set of points (x, y).
     References
@@ -3639,109 +3645,32 @@ def weightedrankedtau(x, y, rank=None, weigher=lambda x: 1./(x+1), additive=True
     >>> from scipy import stats
     >>> x = [12, 2, 1, 12, 2]
     >>> y = [1, 4, 7, 1, 0]
-    >>> tau, p_value = stats.weightedrankedtau(x, y)
-    >>> tau
-    -0.4157652301037516
-    >>> p_value
-    nan
-    >>> tau, p_value = stats.weightedrankedtau(y, x)
-    >>> tau
-    -0.71813413296990281
-    >>> p_value
-    nan
-    """
-    x = np.asarray(x).ravel()
-    y = np.asarray(y).ravel()
-
-    WeightedRankedTauResult = namedtuple('WeightedRankedTauResult', ('correlation', 'pvalue'))
-
-    if x.size != y.size:
-        raise ValueError("All inputs to `weightedrankedtau` must be of the same size, "
-                         "found x-size %s and y-size %s" % (x.size, y.size))
-    if not x.size:
-        return WeightedRankedTauResult(np.nan, np.nan)  # Return NaN if arrays are empty
-
-    if rank is not None and len(rank) != x.size:
-        raise ValueError("All inputs to `weightedrankedtau` must be of the same size, "
-                         "found x-size %s and rank-len %s" % (x.size, len(rank)))
-
-    # Reduce to ranks unsupported types
-    if x.dtype not in (np.int32, np.int64, np.float32, np.float64):
-        x = _toranks(x)
-    if y.dtype not in (np.int32, np.int64, np.float32, np.float64):
-        y = _toranks(y)
-    if x.dtype != y.dtype:
-        if x.dtype != np.int64:
-            x = _toranks(x)
-        if y.dtype != np.int64:
-            y = _toranks(y)
-
-    return WeightedRankedTauResult(_weightedrankedtau(x, y, rank, weigher, additive), np.nan)
-
-
-def weightedtau(x, y, weigher=lambda x: 1./(x+1), additive=True):
-    """
-    Calculates the weighted tau, a correlation measure
-    for ordinal data. It is a weighted version of Kendall's tau in
-    which exchanges of high weight are more influent than exchanges
-    of low weight. It is defined in terms of the weighted-ranked tau:
-    one averages the values returned by the weighted-ranked tau with
-    rank given by the order induced lexicographically by (x, y), and
-    then by (y, x).
-
-    The default parameters compute the additive hyperbolic version
-    of the index, tau_h, which has been shown to provide the best
-    balance between important and unimportant elements [1]_.
-    Parameters
-    ----------
-    x, y : array_like
-        Arrays of rankings, of the same shape. If arrays are not 1-D, they will
-        be flattened to 1-D.
-    weigher : function, optional
-        The weigher function. Must map nonnegative integers (zero representing
-        the most important element) to a nonnegative weight. The default is
-        hyperbolic weighing, that is, x -> 1/(x+1).
-    additive : boolean, optional
-        If true, the weight of an exchange is computed by adding the
-        weights of the ranks of the exchanged elements; otherwise, the weights
-        are multiplied. The default is True.
-    Returns
-    -------
-    correlation : float
-       The weighted tau correlation index.
-    pvalue : float
-       Presently np.nan, as the null statistics for the weighted tau is
-       unknown (even in the additive hyperbolic case).
-    See also
-    --------
-    weightedrankedtau: Calculates the weighted-ranked tau.
-    kendalltau : Calculates Kendall's tau.
-    spearmanr : Calculates a Spearman rank-order correlation coefficient.
-    theilslopes : Computes the Theil-Sen estimator for a set of points (x, y).
-    References
-    ----------
-    .. [1] Sebastiano Vigna "A weighted correlation index for rankings with ties".
-           In Proceedings of the 24th international conference on World Wide Web,
-           pages 1166-1176. ACM, 2015.
-    Examples
-    --------
-    >>> from scipy import stats
-    >>> x = [12, 2, 1, 12, 2]
-    >>> y = [1, 4, 7, 1, 0]
-    >>> tau, p_value = stats.weightedrankedtau(x, y)
+    >>> tau, p_value = stats.weightedtau(x, y)
     >>> tau
     -0.56694968153682723
     >>> p_value
     nan
-    >>> tau, p_value = stats.weightedrankedtau(x, y, additive=False)
+    >>> tau, p_value = stats.weightedtau(x, y, additive=False)
     >>> tau
     -0.62205716951801038
     >>> x = [12, 2, 1, 12, 2]
     >>> y = [1, 4, 7, 1, 0]
     >>> # This is exactly Kendall's tau
-    >>> tau, p_value = stats.weightedrankedtau(x, y, weigher=lambda x: 1)
+    >>> tau, p_value = stats.weightedtau(x, y, weigher=lambda x: 1)
     >>> tau
     -0.47140452079103173
+    >>> x = [12, 2, 1, 12, 2]
+    >>> y = [1, 4, 7, 1, 0]
+    >>> tau, p_value = stats.weightedtau(x, y, rank=None)
+    >>> tau
+    -0.4157652301037516
+    >>> p_value
+    nan
+    >>> tau, p_value = stats.weightedtau(y, x, rank=None)
+    >>> tau
+    -0.71813413296990281
+    >>> p_value
+    nan
     """
     x = np.asarray(x).ravel()
     y = np.asarray(y).ravel()
@@ -3765,10 +3694,22 @@ def weightedtau(x, y, weigher=lambda x: 1./(x+1), additive=True):
         if y.dtype != np.int64:
             y = _toranks(y)
 
-    return WeightedTauResult((
-        _weightedrankedtau(x, y, None, weigher, additive) +
-        _weightedrankedtau(y, x, None, weigher, additive)
-        ) / 2, np.nan)
+    if rank is True:
+        return WeightedTauResult((
+            _weightedrankedtau(x, y, None, weigher, additive) +
+            _weightedrankedtau(y, x, None, weigher, additive)
+            ) / 2, np.nan)
+
+    if rank is False:
+        rank = np.arange(x.size, dtype=np.intp)
+
+    if rank is not None:
+        rank = np.asarray(rank)
+        if rank.size != x.size:
+            raise ValueError("All inputs to `weightedtau` must be of the same size, "
+                         "found x-size %s and rank-size %s" % (x.size, rank.size))
+
+    return WeightedTauResult(_weightedrankedtau(x, y, rank, weigher, additive), np.nan)
 
 
 #####################################

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3715,14 +3715,10 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
         return WeightedTauResult(np.nan, np.nan)  # Return NaN if arrays are empty
 
     # If there are NaNs we apply _toint64()
-    for i in range(x.size):
-        if np.isnan(x[i]):
+    if np.isnan(np.min(x)):
             x = _toint64(x)
-            break
-    for i in range(y.size):
-        if np.isnan(y[i]):
+    if np.isnan(np.min(y)):
             y = _toint64(y)
-            break
 
     # Reduce to ranks unsupported types
     if x.dtype != y.dtype:

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3715,11 +3715,11 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
         return WeightedTauResult(np.nan, np.nan)  # Return NaN if arrays are empty
 
     # If there are NaNs we apply _toint64()
-    for i in xrange(x.size):
+    for i in range(x.size):
         if np.isnan(x[i]):
             x = np.array(_toint64(x), dtype=np.int64)
             break
-    for i in xrange(y.size):
+    for i in range(y.size):
         if np.isnan(y[i]):
             y = np.array(_toint64(y), dtype=np.int64)
             break

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3608,7 +3608,7 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
     Parameters
     ----------
     x, y : array_like
-        Arrays of rankings, of the same shape. If arrays are not 1-D, they will
+        Arrays of scores, of the same shape. If arrays are not 1-D, they will
         be flattened to 1-D.
     rank: array_like of ints or bool, optional
         A nonnegative rank assigned to each element. If it is None, the

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3717,11 +3717,11 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
     # If there are NaNs we apply _toint64()
     for i in range(x.size):
         if np.isnan(x[i]):
-            x = np.array(_toint64(x), dtype=np.int64)
+            x = _toint64(x)
             break
     for i in range(y.size):
         if np.isnan(y[i]):
-            y = np.array(_toint64(y), dtype=np.int64)
+            y = _toint64(y)
             break
 
     # Reduce to ranks unsupported types

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3418,6 +3418,7 @@ def pointbiserialr(x, y):
     rpb, prob = pearsonr(x, y)
     return PointbiserialrResult(rpb, prob)
 
+
 KendalltauResult = namedtuple('KendalltauResult', ('correlation', 'pvalue'))
 
 
@@ -3568,17 +3569,18 @@ def kendalltau(x, y, initial_lexsort=None, nan_policy='propagate'):
     # Limit range to fix computational errors
     return KendalltauResult(min(1., max(-1., tau)), pvalue)
 
+
 WeightedTauResult = namedtuple('WeightedTauResult', ('correlation', 'pvalue'))
 
 
 def weightedtau(x, y, rank=True, weigher=None, additive=True):
-    """
-    Computes a weighted version of Kendall's :math:`\\tau`.
+    r"""
+    Computes a weighted version of Kendall's :math:`\tau`.
 
-    The weighted :math:`\\tau` is a weighted version of Kendall's
-    :math:`\\tau` in which exchanges of high weight are more influent than
+    The weighted :math:`\tau` is a weighted version of Kendall's
+    :math:`\tau` in which exchanges of high weight are more influential than
     exchanges of low weight. The default parameters compute the additive
-    hyperbolic version of the index, :math:`\\tau_\\mathrm h`, which has
+    hyperbolic version of the index, :math:`\tau_\mathrm h`, which has
     been shown to provide the best balance between important and
     unimportant elements [1]_.
 
@@ -3587,18 +3589,18 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
     assigns a weight based from the rank to each element. The weight of an
     exchange is then the sum or the product of the weights of the ranks of
     the exchanged elements. The default parameters compute
-    :math:`\\tau_\\mathrm h`: an exchange between elements with rank
+    :math:`\tau_\mathrm h`: an exchange between elements with rank
     :math:`r` and :math:`s` (starting from zero) has weight
     :math:`1/(r+1) + 1/(s+1)`.
 
     Specifying a rank array is meaningful only if you have in mind an
     external criterion of importance. If, as it usually happens, you do
-    not have in mind a specific rank, the weighted :math:`\\tau` is
+    not have in mind a specific rank, the weighted :math:`\tau` is
     defined by averaging the values obtained using the decreasing
     lexicographical rank by (`x`, `y`) and by (`y`, `x`). This is the
     behavior with default parameters.
 
-    Note that if you are computing the weighted :math:`\\tau` on arrays of
+    Note that if you are computing the weighted :math:`\tau` on arrays of
     ranks, rather than of scores (i.e., a larger value implies a lower
     rank) you must negate the ranks, so that elements of higher rank are
     associated with a larger value.
@@ -3617,7 +3619,7 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
         directly as ranks. The default is True, in which case this
         function returns the average of the values obtained using the
         decreasing lexicographical rank by (`x`, `y`) and by (`y`, `x`).
-    weigher : callable or None, optional
+    weigher : callable, optional
         The weigher function. Must map nonnegative integers (zero
         representing the most important element) to a nonnegative weight.
         The default, None, provides hyperbolic weighing, that is,
@@ -3630,9 +3632,9 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
     Returns
     -------
     correlation : float
-       The weighted :math:`\\tau` correlation index.
+       The weighted :math:`\tau` correlation index.
     pvalue : float
-       Presently `np.nan`, as the null statistics is unknown (even in the
+       Presently ``np.nan``, as the null statistics is unknown (even in the
        additive hyperbolic case).
 
     See also
@@ -3643,23 +3645,25 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
 
     Notes
     -----
-    This function uses an :math:`O(n \\log n)`, mergesort-based algorithm
+    This function uses an :math:`O(n \log n)`, mergesort-based algorithm
     [1]_ that is a weighted extension of Knight's algorithm for Kendall's
-    :math:`\\tau` [2]_. It can compute Shieh's weighted :math:`\\tau` [3]_
+    :math:`\tau` [2]_. It can compute Shieh's weighted :math:`\tau` [3]_
     between rankings without ties (i.e., permutations) by setting
     `additive` and `rank` to False, as the definition given in [1]_ is a
     generalization of Shieh's.
 
+    .. versionadded:: 0.19.0
+
     References
     ----------
-    .. [1] Sebastiano Vigna "A weighted correlation index for rankings with ties".
-           In Proceedings of the 24th international conference on World Wide Web,
-           pages 1166-1176. ACM, 2015.
+    .. [1] Sebastiano Vigna, "A weighted correlation index for rankings with
+           ties", Proceedings of the 24th international conference on World
+           Wide Web, pp. 1166-1176, ACM, 2015.
     .. [2] W.R. Knight, "A Computer Method for Calculating Kendall's Tau with
            Ungrouped Data", Journal of the American Statistical Association,
-           Vol. 61, No. 314, Part 1, pages 436-439, 1966.
-    .. [3] Grace S. Shieh. "A weighted Kendall's tau statistic", Statistics & 
-           Probability Letters, Vol. 39, No. 1, pages 17-24, 1998.
+           Vol. 61, No. 314, Part 1, pp. 436-439, 1966.
+    .. [3] Grace S. Shieh. "A weighted Kendall's tau statistic", Statistics &
+           Probability Letters, Vol. 39, No. 1, pp. 17-24, 1998.
 
     Examples
     --------
@@ -3674,24 +3678,22 @@ def weightedtau(x, y, rank=True, weigher=None, additive=True):
     >>> tau, p_value = stats.weightedtau(x, y, additive=False)
     >>> tau
     -0.62205716951801038
+
+    This is exactly Kendall's tau:
+
     >>> x = [12, 2, 1, 12, 2]
     >>> y = [1, 4, 7, 1, 0]
-    >>> # This is exactly Kendall's tau
-    >>> tau, p_value = stats.weightedtau(x, y, weigher=lambda x: 1)
+    >>> tau, _ = stats.weightedtau(x, y, weigher=lambda x: 1)
     >>> tau
     -0.47140452079103173
+
     >>> x = [12, 2, 1, 12, 2]
     >>> y = [1, 4, 7, 1, 0]
-    >>> tau, p_value = stats.weightedtau(x, y, rank=None)
-    >>> tau
-    -0.4157652301037516
-    >>> p_value
-    nan
-    >>> tau, p_value = stats.weightedtau(y, x, rank=None)
-    >>> tau
-    -0.71813413296990281
-    >>> p_value
-    nan
+    >>> stats.weightedtau(x, y, rank=None)
+    WeightedTauResult(correlation=-0.4157652301037516, pvalue=nan)
+    >>> stats.weightedtau(y, x, rank=None)
+    WeightedTauResult(correlation=-0.71813413296990281, pvalue=nan)
+
     """
     x = np.asarray(x).ravel()
     y = np.asarray(y).ravel()
@@ -5073,7 +5075,7 @@ def friedmanchisquare(*args):
     """
     k = len(args)
     if k < 3:
-        raise ValueError('\nLess than 3 levels.  Friedman test not appropriate.\n')
+        raise ValueError('Less than 3 levels.  Friedman test not appropriate.')
 
     n = len(args[0])
     for i in range(1, k):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -644,30 +644,6 @@ def test_kendalltau_nan_2nd_arg():
     assert_allclose(r1.correlation, r2.correlation, atol=1e-15)
 
 
-def test_weightedrankedtau():
-    x = [12, 2, 1, 12, 2]
-    y = [1, 4, 7, 1, 0]
-    tau, p_value = stats.weightedrankedtau(x, y)
-    assert_approx_equal(-0.4157652301037516, tau)
-    assert_equal(np.nan, p_value)
-    tau, p_value = stats.weightedrankedtau(y, x)
-    assert_approx_equal(-0.7181341329699029, tau)
-    assert_equal(np.nan, p_value)
-    tau, p_value = stats.weightedrankedtau(x, y, additive=False)
-    assert_approx_equal(-0.40644850966246893, tau)
-    assert_equal(np.nan, p_value)
-    tau, p_value = stats.weightedrankedtau(y, x, additive=False)
-    assert_approx_equal(-0.83766582937355172, tau)
-    assert_equal(np.nan, p_value)
-    # This must be exactly Kendall's tau
-    tau, p_value = stats.weightedrankedtau(x, y, weigher=lambda x: 1)
-    assert_approx_equal(-0.47140452079103173, tau)
-    assert_equal(np.nan, p_value)
-    tau, p_value = stats.weightedrankedtau(y, x, weigher=lambda x: 1)
-    assert_approx_equal(-0.47140452079103173, tau)
-    assert_equal(np.nan, p_value)
-
-
 def test_weightedtau():
     x = [12, 2, 1, 12, 2]
     y = [1, 4, 7, 1, 0]
@@ -681,6 +657,35 @@ def test_weightedtau():
     tau, p_value = stats.weightedtau(x, y, weigher=lambda x: 1)
     assert_approx_equal(-0.47140452079103173, tau)
     assert_equal(np.nan, p_value)
+
+    # Asymmatric, ranked version
+    tau, p_value = stats.weightedtau(x, y, rank=None)
+    assert_approx_equal(-0.4157652301037516, tau)
+    assert_equal(np.nan, p_value)
+    tau, p_value = stats.weightedtau(y, x, rank=None)
+    assert_approx_equal(-0.7181341329699029, tau)
+    assert_equal(np.nan, p_value)
+    tau, p_value = stats.weightedtau(x, y, rank=None, additive=False)
+    assert_approx_equal(-0.40644850966246893, tau)
+    assert_equal(np.nan, p_value)
+    tau, p_value = stats.weightedtau(y, x, rank=None, additive=False)
+    assert_approx_equal(-0.83766582937355172, tau)
+    assert_equal(np.nan, p_value)
+    tau, p_value = stats.weightedtau(x, y, rank=False)
+    assert_approx_equal(-0.51604397940261848, tau)
+    assert_equal(np.nan, p_value)
+    # This must be exactly Kendall's tau
+    tau, p_value = stats.weightedtau(x, y, rank=True, weigher=lambda x: 1)
+    assert_approx_equal(-0.47140452079103173, tau)
+    assert_equal(np.nan, p_value)
+    tau, p_value = stats.weightedtau(y, x, rank=True, weigher=lambda x: 1)
+    assert_approx_equal(-0.47140452079103173, tau)
+    assert_equal(np.nan, p_value)
+    # Test argument conversion
+    tau, p_value = stats.weightedtau(np.asarray(x, dtype=np.float64), y)
+    assert_approx_equal(-0.56694968153682723, tau)
+    tau, p_value = stats.weightedtau(np.asarray(x, dtype=np.float64), np.asarray(y, dtype=np.float64))
+    assert_approx_equal(-0.56694968153682723, tau)
 
 
 class TestFindRepeats(TestCase):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -618,8 +618,17 @@ def test_kendalltau():
     y = np.arange(20.)
     assert_raises(ValueError, stats.kendalltau, x, y)
 
+    # test all ties
+    tau, p_value = stats.kendalltau([], [])
+    assert_equal(np.nan, tau)
+    assert_equal(np.nan, p_value)
+    tau, p_value = stats.kendalltau([0], [0])
+    assert_equal(np.nan, tau)
+    assert_equal(np.nan, p_value)
+
 
 def test_kendalltau_vs_mstats_basic():
+    np.random.seed(42)
     for s in range(2,10):
         a = []
         # Generate rankings with ties
@@ -658,7 +667,7 @@ def test_weightedtau():
     assert_approx_equal(-0.47140452079103173, tau)
     assert_equal(np.nan, p_value)
 
-    # Asymmatric, ranked version
+    # Asymmetric, ranked version
     tau, p_value = stats.weightedtau(x, y, rank=None)
     assert_approx_equal(-0.4157652301037516, tau)
     assert_equal(np.nan, p_value)
@@ -686,6 +695,16 @@ def test_weightedtau():
     assert_approx_equal(-0.56694968153682723, tau)
     tau, p_value = stats.weightedtau(np.asarray(x, dtype=np.float64), np.asarray(y, dtype=np.float64))
     assert_approx_equal(-0.56694968153682723, tau)
+    # All ties
+    tau, p_value = stats.weightedtau([], [])
+    assert_equal(np.nan, tau)
+    assert_equal(np.nan, p_value)
+    tau, p_value = stats.weightedtau([0], [0])
+    assert_equal(np.nan, tau)
+    assert_equal(np.nan, p_value)
+    # Size mismatches
+    assert_raises(ValueError, stats.weightedtau, [0, 1], [0, 1, 2])
+    assert_raises(ValueError, stats.weightedtau, [0, 1], [0, 1], [0])
 
 
 def test_weightedtau_vs_quadratic():
@@ -706,6 +725,7 @@ def test_weightedtau_vs_quadratic():
                     disc += w
         return (conc - disc) / np.sqrt(tot - u) / np.sqrt(tot - v)
 
+    np.random.seed(42)
     for s in range(3,10):
         a = []
         # Generate rankings with ties
@@ -716,7 +736,7 @@ def test_weightedtau_vs_quadratic():
         np.random.shuffle(b)
         # First pass: use element indices as ranks
         rank = np.arange(len(a), dtype=np.intp)
-        for i in range(2):
+        for _ in range(2):
             for add in [True, False]:
                 expected = wkq(a, b, rank, lambda x: 1./(x+1), add)
                 actual = stats.weightedtau(a, b, rank, lambda x: 1./(x+1), add).correlation

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -644,6 +644,45 @@ def test_kendalltau_nan_2nd_arg():
     assert_allclose(r1.correlation, r2.correlation, atol=1e-15)
 
 
+def test_weightedrankedtau():
+    x = [12, 2, 1, 12, 2]
+    y = [1, 4, 7, 1, 0]
+    tau, p_value = stats.weightedrankedtau(x, y)
+    assert_approx_equal(-0.4157652301037516, tau)
+    assert_equal(np.nan, p_value)
+    tau, p_value = stats.weightedrankedtau(y, x)
+    assert_approx_equal(-0.7181341329699029, tau)
+    assert_equal(np.nan, p_value)
+    tau, p_value = stats.weightedrankedtau(x, y, additive=False)
+    assert_approx_equal(-0.40644850966246893, tau)
+    assert_equal(np.nan, p_value)
+    tau, p_value = stats.weightedrankedtau(y, x, additive=False)
+    assert_approx_equal(-0.83766582937355172, tau)
+    assert_equal(np.nan, p_value)
+    # This must be exactly Kendall's tau
+    tau, p_value = stats.weightedrankedtau(x, y, weigher=lambda x: 1)
+    assert_approx_equal(-0.47140452079103173, tau)
+    assert_equal(np.nan, p_value)
+    tau, p_value = stats.weightedrankedtau(y, x, weigher=lambda x: 1)
+    assert_approx_equal(-0.47140452079103173, tau)
+    assert_equal(np.nan, p_value)
+
+
+def test_weightedtau():
+    x = [12, 2, 1, 12, 2]
+    y = [1, 4, 7, 1, 0]
+    tau, p_value = stats.weightedtau(x, y)
+    assert_approx_equal(-0.56694968153682723, tau)
+    assert_equal(np.nan, p_value)
+    tau, p_value = stats.weightedtau(x, y, additive=False)
+    assert_approx_equal(-0.62205716951801038, tau)
+    assert_equal(np.nan, p_value)
+    # This must be exactly Kendall's tau
+    tau, p_value = stats.weightedtau(x, y, weigher=lambda x: 1)
+    assert_approx_equal(-0.47140452079103173, tau)
+    assert_equal(np.nan, p_value)
+
+
 class TestFindRepeats(TestCase):
 
     def test_basic(self):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -693,6 +693,8 @@ def test_weightedtau():
     # Test argument conversion
     tau, p_value = stats.weightedtau(np.asarray(x, dtype=np.float64), y)
     assert_approx_equal(-0.56694968153682723, tau)
+    tau, p_value = stats.weightedtau(np.asarray(x, dtype=np.int16), y)
+    assert_approx_equal(-0.56694968153682723, tau)
     tau, p_value = stats.weightedtau(np.asarray(x, dtype=np.float64), np.asarray(y, dtype=np.float64))
     assert_approx_equal(-0.56694968153682723, tau)
     # All ties

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -701,9 +701,9 @@ def test_weightedtau_vs_quadratic():
                 if y[i] == y[j]:
                     v += w
                 if x[i] < x[j] and y[i] < y[j] or x[i] > x[j] and y[i] > y[j]:
-                    conc += w;
+                    conc += w
                 elif x[i] < x[j] and y[i] > y[j] or x[i] > x[j] and y[i] < y[j]:
-                    disc += w;
+                    disc += w
         return (conc - disc) / np.sqrt(tot - u) / np.sqrt(tot - v)
 
     for s in range(3,10):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -639,8 +639,8 @@ def test_kendalltau_vs_mstats_basic():
         np.random.shuffle(b)
         expected = mstats_basic.kendalltau(a, b)
         actual = stats.kendalltau(a, b)
-        assert_approx_equal(expected[0], actual[0])
-        assert_approx_equal(expected[1], actual[1])
+        assert_approx_equal(actual[0], expected[0])
+        assert_approx_equal(actual[1], expected[1])
 
 
 def test_kendalltau_nan_2nd_arg():
@@ -657,46 +657,46 @@ def test_weightedtau():
     x = [12, 2, 1, 12, 2]
     y = [1, 4, 7, 1, 0]
     tau, p_value = stats.weightedtau(x, y)
-    assert_approx_equal(-0.56694968153682723, tau)
+    assert_approx_equal(tau, -0.56694968153682723)
     assert_equal(np.nan, p_value)
     tau, p_value = stats.weightedtau(x, y, additive=False)
-    assert_approx_equal(-0.62205716951801038, tau)
+    assert_approx_equal(tau, -0.62205716951801038)
     assert_equal(np.nan, p_value)
     # This must be exactly Kendall's tau
     tau, p_value = stats.weightedtau(x, y, weigher=lambda x: 1)
-    assert_approx_equal(-0.47140452079103173, tau)
+    assert_approx_equal(tau, -0.47140452079103173)
     assert_equal(np.nan, p_value)
 
     # Asymmetric, ranked version
     tau, p_value = stats.weightedtau(x, y, rank=None)
-    assert_approx_equal(-0.4157652301037516, tau)
+    assert_approx_equal(tau, -0.4157652301037516)
     assert_equal(np.nan, p_value)
     tau, p_value = stats.weightedtau(y, x, rank=None)
-    assert_approx_equal(-0.7181341329699029, tau)
+    assert_approx_equal(tau, -0.7181341329699029)
     assert_equal(np.nan, p_value)
     tau, p_value = stats.weightedtau(x, y, rank=None, additive=False)
-    assert_approx_equal(-0.40644850966246893, tau)
+    assert_approx_equal(tau, -0.40644850966246893)
     assert_equal(np.nan, p_value)
     tau, p_value = stats.weightedtau(y, x, rank=None, additive=False)
-    assert_approx_equal(-0.83766582937355172, tau)
+    assert_approx_equal(tau, -0.83766582937355172)
     assert_equal(np.nan, p_value)
     tau, p_value = stats.weightedtau(x, y, rank=False)
-    assert_approx_equal(-0.51604397940261848, tau)
+    assert_approx_equal(tau, -0.51604397940261848)
     assert_equal(np.nan, p_value)
     # This must be exactly Kendall's tau
     tau, p_value = stats.weightedtau(x, y, rank=True, weigher=lambda x: 1)
-    assert_approx_equal(-0.47140452079103173, tau)
+    assert_approx_equal(tau, -0.47140452079103173)
     assert_equal(np.nan, p_value)
     tau, p_value = stats.weightedtau(y, x, rank=True, weigher=lambda x: 1)
-    assert_approx_equal(-0.47140452079103173, tau)
+    assert_approx_equal(tau, -0.47140452079103173)
     assert_equal(np.nan, p_value)
     # Test argument conversion
     tau, p_value = stats.weightedtau(np.asarray(x, dtype=np.float64), y)
-    assert_approx_equal(-0.56694968153682723, tau)
+    assert_approx_equal(tau, -0.56694968153682723)
     tau, p_value = stats.weightedtau(np.asarray(x, dtype=np.int16), y)
-    assert_approx_equal(-0.56694968153682723, tau)
+    assert_approx_equal(tau, -0.56694968153682723)
     tau, p_value = stats.weightedtau(np.asarray(x, dtype=np.float64), np.asarray(y, dtype=np.float64))
-    assert_approx_equal(-0.56694968153682723, tau)
+    assert_approx_equal(tau, -0.56694968153682723)
     # All ties
     tau, p_value = stats.weightedtau([], [])
     assert_equal(np.nan, tau)
@@ -707,6 +707,14 @@ def test_weightedtau():
     # Size mismatches
     assert_raises(ValueError, stats.weightedtau, [0, 1], [0, 1, 2])
     assert_raises(ValueError, stats.weightedtau, [0, 1], [0, 1], [0])
+    # NaNs
+    x = [12, 2, 1, 12, 2]
+    y = [1, 4, 7, 1, np.nan]
+    tau, p_value = stats.weightedtau(x, y)
+    assert_approx_equal(tau, -0.56694968153682723)
+    x = [12, 2, np.nan, 12, 2]
+    tau, p_value = stats.weightedtau(x, y)
+    assert_approx_equal(tau, -0.56694968153682723)
 
 
 def test_weightedtau_vs_quadratic():


### PR DESCRIPTION
This pull request implements a weighted version of Kendall's 𝛕: in the weighted 𝛕, exchanges have different importance, and in general having important elements in the wrong order creates more discordance than having unimportant elements in the wrong order.

DISCLAIMER: albeit definitions of weighted versions of Kendall's 𝛕 go back at least to Shieh's 1997 paper, the definition and algorithm implemented here appeared in a paper I wrote published at WWW 2015. The definition I give encompasses all previous attempts (so one can, say, use this code to compute Shieh's variant) and is meaningful also in the presence of ties.

I was lecturing about the weighted 𝛕 at ISI in Turin recently and someone in the audience said "oh that's so nice but we will use it only if it's in SciPy". So here I am.

I understand that it might not be considered a good idea to add to SciPy something so new (and possibly useless). But I think it's interesting, in particular for big data analysis. Our use case is comparing complex centralities with indegrees: there are tons of ties, and moreover you're not really interested in what happens in the large tail of very-low-indegree nodes—you want to know whether there is correlation on the important nodes.

Note that the null distribution is not known, so there's no p-value: the code computes only the measure of correlation (the p-value is always NaN).

The code is by and large a rework of my code for #5754. Comments are more than welcome. Presently the I'm using fused types to generate 16 compiled variants handling 32/64-bits float/ints, but maybe we can reduce the choice to two types instead of four.