### PR TITLE
ENH: cythonized spherical Voronoi region polygon vertex sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,7 @@ scipy/sparse/sparsetools/sparsetools_impl.h
 scipy/spatial/ckdtree.cxx
 scipy/spatial/ckdtree.h
 scipy/spatial/qhull.c
+scipy/spatial/_voronoi.c
 scipy/special/_comb.c
 scipy/spatial/qhull_misc_config.h
 scipy/special/_ellip_harm_2.c

--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -35,6 +35,12 @@ The functions `scipy.linalg.solve_continuous_are` and
 These functions can also solve generalized algebraic matrix Riccati equations.
 Moreover, both gained a ``balanced`` keyword to turn balancing on and off.
 
+`scipy.spatial` improvements
+----------------------------
+
+`SphericalVoronoi.sort_vertices_of_regions()` has been re-written in
+cython to improve performance
+
 `scipy.ndimage` improvements
 ----------------------------
 

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -15,7 +15,7 @@ import numpy as np
 import numpy.matlib
 import scipy
 import itertools
-from . import _sv_sort_vertices
+from . import _voronoi
 
 __all__ = ['SphericalVoronoi']
 
@@ -295,5 +295,5 @@ class SphericalVoronoi:
          of its surrounding region.
         """
 
-        _sv_sort_vertices.sort_vertices_of_regions(self._tri.simplices,
+        _voronoi.sort_vertices_of_regions(self._tri.simplices,
                                                    self.regions)

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -15,6 +15,7 @@ import numpy as np
 import numpy.matlib
 import scipy
 import itertools
+from . import _sv_sort_vertices
 
 __all__ = ['SphericalVoronoi']
 
@@ -294,23 +295,5 @@ class SphericalVoronoi:
          of its surrounding region.
         """
 
-        for n in range(0, len(self.regions)):
-            remaining = self.regions[n][:]
-            sorted_vertices = []
-            current_simplex = remaining[0]
-            current_vertex = [k for k in self._tri.simplices[current_simplex]
-                              if k != n][0]
-            remaining.remove(current_simplex)
-            sorted_vertices.append(current_simplex)
-            while remaining:
-                current_simplex = [
-                    s for s in remaining
-                    if current_vertex in self._tri.simplices[s]
-                    ][0]
-                current_vertex = [
-                    s for s in self._tri.simplices[current_simplex]
-                    if s != n and s != current_vertex
-                    ][0]
-                remaining.remove(current_simplex)
-                sorted_vertices.append(current_simplex)
-            self.regions[n] = sorted_vertices
+        _sv_sort_vertices.sort_vertices_of_regions(self._tri.simplices,
+                                                   self.regions)

--- a/scipy/spatial/_sv_sort_vertices.pyx
+++ b/scipy/spatial/_sv_sort_vertices.pyx
@@ -1,0 +1,59 @@
+import numpy as np
+cimport numpy as np
+cimport cython
+
+__all__ = ['sort_vertices_of_regions']
+
+cdef void remaining_filter(int shape, long[:] remaining, int current_simplex):
+   cdef unsigned int i
+   for i in range(shape):
+     if remaining[i] == current_simplex:
+       remaining[i] = -2
+    
+@cython.boundscheck(False)
+def sort_vertices_of_regions(int[:,::1] simplices, regions):
+  cdef unsigned int n, k, s, i
+  cdef int num_regions = len(regions)
+  cdef int current_simplex, current_vertex, remaining_count
+  cdef int cs_identified, remaining_size
+  cdef long[:] remaining
+  cdef long[:] sorted_vertices = np.zeros(max([len(region) for region in
+	  regions]), dtype = np.int64)
+
+  for n in range(num_regions):
+    remaining_count = 0
+    remaining = np.asarray(regions[n][:])
+    remaining_size = remaining.shape[0]
+    sorted_vertices[:] = -2
+    current_simplex = remaining[0]
+    for i in range(3):
+      k = simplices[current_simplex][i]
+      if k != n:
+        current_vertex = k
+        break
+    sorted_vertices[remaining_count] = current_simplex
+    remaining_count += 1
+    remaining_filter(remaining.shape[0], remaining, current_simplex)
+    while remaining_size > remaining_count:
+      cs_identified = 0
+      for i in range(remaining_size):
+        if remaining[i] == -2:
+          continue
+        s = remaining[i]
+        for j in range(3):
+          if current_vertex == simplices[s,j]:
+            current_simplex = remaining[i]
+            cs_identified += 1
+            break
+        if cs_identified > 0:
+          break
+      for i in range(3):
+        s = simplices[current_simplex, i]
+        if s != n and s != current_vertex:
+          current_vertex = s
+          break
+      sorted_vertices[remaining_count] = current_simplex
+      remaining_count += 1
+      remaining_filter(remaining.shape[0], remaining, current_simplex)
+    regions_arr = np.asarray(sorted_vertices)
+    regions[n] = regions_arr[regions_arr > -2].tolist()

--- a/scipy/spatial/_voronoi.pyx
+++ b/scipy/spatial/_voronoi.pyx
@@ -1,3 +1,15 @@
+"""
+Spherical Voronoi Cython Code
+
+.. versionadded:: 0.19.0
+
+"""
+#
+# Copyright (C)  Tyler Reddy, 2016
+#
+# Distributed under the same BSD license as Scipy.
+#
+
 import numpy as np
 cimport numpy as np
 cimport cython

--- a/scipy/spatial/_voronoi.pyx
+++ b/scipy/spatial/_voronoi.pyx
@@ -5,56 +5,58 @@ cimport cython
 __all__ = ['sort_vertices_of_regions']
 
 cdef void remaining_filter(np.npy_intp shape, np.npy_intp[:] remaining,
-		np.npy_intp current_simplex):
-   cdef np.npy_intp i
-   for i in range(shape):
-     if remaining[i] == current_simplex:
-       remaining[i] = -2
-    
+                           np.npy_intp current_simplex):
+    cdef np.npy_intp i
+    for i in range(shape):
+        if remaining[i] == current_simplex:
+            remaining[i] = -2
+
+
 @cython.boundscheck(False)
 def sort_vertices_of_regions(int[:,::1] simplices, regions):
-  cdef np.npy_intp n, k, s, i
-  cdef np.npy_intp num_regions = len(regions)
-  cdef np.npy_intp current_simplex, current_vertex, remaining_count
-  cdef np.npy_intp cs_identified, remaining_size
-  cdef np.npy_intp[:] remaining
-  cdef np.npy_intp[:] sorted_vertices = np.zeros(max([len(region) for region in
-	  regions]), dtype = np.int64)
+    cdef np.npy_intp n, k, s, i
+    cdef np.npy_intp num_regions = len(regions)
+    cdef np.npy_intp current_simplex, current_vertex, remaining_count
+    cdef np.npy_intp cs_identified, remaining_size
+    cdef np.npy_intp[:] remaining
+    cdef np.npy_intp[:] sorted_vertices = np.zeros(max([len(region) for region
+                                                   in regions]),
+                                                   dtype=np.int64)
 
-  for n in range(num_regions):
-    remaining_count = 0
-    remaining = np.asarray(regions[n][:])
-    remaining_size = remaining.shape[0]
-    sorted_vertices[:] = -2
-    current_simplex = remaining[0]
-    for i in range(3):
-      k = simplices[current_simplex][i]
-      if k != n:
-        current_vertex = k
-        break
-    sorted_vertices[remaining_count] = current_simplex
-    remaining_count += 1
-    remaining_filter(remaining.shape[0], remaining, current_simplex)
-    while remaining_size > remaining_count:
-      cs_identified = 0
-      for i in range(remaining_size):
-        if remaining[i] == -2:
-          continue
-        s = remaining[i]
-        for j in range(3):
-          if current_vertex == simplices[s,j]:
-            current_simplex = remaining[i]
-            cs_identified += 1
-            break
-        if cs_identified > 0:
-          break
-      for i in range(3):
-        s = simplices[current_simplex, i]
-        if s != n and s != current_vertex:
-          current_vertex = s
-          break
-      sorted_vertices[remaining_count] = current_simplex
-      remaining_count += 1
-      remaining_filter(remaining.shape[0], remaining, current_simplex)
-    regions_arr = np.asarray(sorted_vertices)
-    regions[n] = regions_arr[regions_arr > -2].tolist()
+    for n in range(num_regions):
+        remaining_count = 0
+        remaining = np.asarray(regions[n][:])
+        remaining_size = remaining.shape[0]
+        sorted_vertices[:] = -2
+        current_simplex = remaining[0]
+        for i in range(3):
+            k = simplices[current_simplex][i]
+            if k != n:
+                current_vertex = k
+                break
+        sorted_vertices[remaining_count] = current_simplex
+        remaining_count += 1
+        remaining_filter(remaining.shape[0], remaining, current_simplex)
+        while remaining_size > remaining_count:
+            cs_identified = 0
+            for i in range(remaining_size):
+                if remaining[i] == -2:
+                    continue
+                s = remaining[i]
+                for j in range(3):
+                    if current_vertex == simplices[s, j]:
+                        current_simplex = remaining[i]
+                        cs_identified += 1
+                        break
+                if cs_identified > 0:
+                    break
+            for i in range(3):
+                s = simplices[current_simplex, i]
+                if s != n and s != current_vertex:
+                    current_vertex = s
+                    break
+            sorted_vertices[remaining_count] = current_simplex
+            remaining_count += 1
+            remaining_filter(remaining.shape[0], remaining, current_simplex)
+        regions_arr = np.asarray(sorted_vertices)
+        regions[n] = regions_arr[regions_arr > -2].tolist()

--- a/scipy/spatial/_voronoi.pyx
+++ b/scipy/spatial/_voronoi.pyx
@@ -4,20 +4,21 @@ cimport cython
 
 __all__ = ['sort_vertices_of_regions']
 
-cdef void remaining_filter(int shape, long[:] remaining, int current_simplex):
-   cdef unsigned int i
+cdef void remaining_filter(np.npy_intp shape, np.npy_intp[:] remaining,
+		np.npy_intp current_simplex):
+   cdef np.npy_intp i
    for i in range(shape):
      if remaining[i] == current_simplex:
        remaining[i] = -2
     
 @cython.boundscheck(False)
 def sort_vertices_of_regions(int[:,::1] simplices, regions):
-  cdef unsigned int n, k, s, i
-  cdef int num_regions = len(regions)
-  cdef int current_simplex, current_vertex, remaining_count
-  cdef int cs_identified, remaining_size
-  cdef long[:] remaining
-  cdef long[:] sorted_vertices = np.zeros(max([len(region) for region in
+  cdef np.npy_intp n, k, s, i
+  cdef np.npy_intp num_regions = len(regions)
+  cdef np.npy_intp current_simplex, current_vertex, remaining_count
+  cdef np.npy_intp cs_identified, remaining_size
+  cdef np.npy_intp[:] remaining
+  cdef np.npy_intp[:] sorted_vertices = np.zeros(max([len(region) for region in
 	  regions]), dtype = np.int64)
 
   for n in range(num_regions):

--- a/scipy/spatial/_voronoi.pyx
+++ b/scipy/spatial/_voronoi.pyx
@@ -16,16 +16,15 @@ cimport cython
 
 __all__ = ['sort_vertices_of_regions']
 
-cdef enum:
-    # array-filling placeholder that can never occur
-    array_filler = -2
+# array-filling placeholder that can never occur
+DEF ARRAY_FILLER = -2
 
 cdef void remaining_filter(np.npy_intp shape, np.npy_intp[:] remaining,
                            np.npy_intp current_simplex):
     cdef np.npy_intp i
     for i in range(shape):
         if remaining[i] == current_simplex:
-            remaining[i] = array_filler
+            remaining[i] = ARRAY_FILLER
 
 
 @cython.boundscheck(False)
@@ -43,7 +42,7 @@ def sort_vertices_of_regions(int[:,::1] simplices, regions):
         remaining_count = 0
         remaining = np.asarray(regions[n][:])
         remaining_size = remaining.shape[0]
-        sorted_vertices[:] = array_filler
+        sorted_vertices[:] = ARRAY_FILLER
         current_simplex = remaining[0]
         for i in range(3):
             k = simplices[current_simplex][i]
@@ -56,7 +55,7 @@ def sort_vertices_of_regions(int[:,::1] simplices, regions):
         while remaining_size > remaining_count:
             cs_identified = 0
             for i in range(remaining_size):
-                if remaining[i] == array_filler:
+                if remaining[i] == ARRAY_FILLER:
                     continue
                 s = remaining[i]
                 for j in range(3):
@@ -75,4 +74,4 @@ def sort_vertices_of_regions(int[:,::1] simplices, regions):
             remaining_count += 1
             remaining_filter(remaining.shape[0], remaining, current_simplex)
         regions_arr = np.asarray(sorted_vertices)
-        regions[n] = regions_arr[regions_arr > array_filler].tolist()
+        regions[n] = regions_arr[regions_arr > ARRAY_FILLER].tolist()

--- a/scipy/spatial/_voronoi.pyx
+++ b/scipy/spatial/_voronoi.pyx
@@ -16,12 +16,16 @@ cimport cython
 
 __all__ = ['sort_vertices_of_regions']
 
+cdef enum:
+    # array-filling placeholder that can never occur
+    array_filler = -2
+
 cdef void remaining_filter(np.npy_intp shape, np.npy_intp[:] remaining,
                            np.npy_intp current_simplex):
     cdef np.npy_intp i
     for i in range(shape):
         if remaining[i] == current_simplex:
-            remaining[i] = -2
+            remaining[i] = array_filler
 
 
 @cython.boundscheck(False)
@@ -39,7 +43,7 @@ def sort_vertices_of_regions(int[:,::1] simplices, regions):
         remaining_count = 0
         remaining = np.asarray(regions[n][:])
         remaining_size = remaining.shape[0]
-        sorted_vertices[:] = -2
+        sorted_vertices[:] = array_filler
         current_simplex = remaining[0]
         for i in range(3):
             k = simplices[current_simplex][i]
@@ -52,7 +56,7 @@ def sort_vertices_of_regions(int[:,::1] simplices, regions):
         while remaining_size > remaining_count:
             cs_identified = 0
             for i in range(remaining_size):
-                if remaining[i] == -2:
+                if remaining[i] == array_filler:
                     continue
                 s = remaining[i]
                 for j in range(3):
@@ -71,4 +75,4 @@ def sort_vertices_of_regions(int[:,::1] simplices, regions):
             remaining_count += 1
             remaining_filter(remaining.shape[0], remaining, current_simplex)
         regions_arr = np.asarray(sorted_vertices)
-        regions[n] = regions_arr[regions_arr > -2].tolist()
+        regions[n] = regions_arr[regions_arr > array_filler].tolist()

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -79,6 +79,9 @@ def configuration(parent_package='', top_path=None):
         include_dirs=[get_numpy_include_dirs()],
         extra_info=get_misc_info("npymath"))
 
+    config.add_extension('_sv_sort_vertices',
+                         sources=['_sv_sort_vertices.c'])
+
     return config
 
 if __name__ == '__main__':

--- a/scipy/spatial/setup.py
+++ b/scipy/spatial/setup.py
@@ -79,8 +79,8 @@ def configuration(parent_package='', top_path=None):
         include_dirs=[get_numpy_include_dirs()],
         extra_info=get_misc_info("npymath"))
 
-    config.add_extension('_sv_sort_vertices',
-                         sources=['_sv_sort_vertices.c'])
+    config.add_extension('_voronoi',
+                         sources=['_voronoi.c'])
 
     return config
 

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import numpy as np
+import itertools
 from numpy.testing import (TestCase,
                            assert_almost_equal,
                            assert_array_equal,
@@ -109,6 +110,16 @@ class TestSphericalVoronoi(TestCase):
         unsorted_regions = sv.regions
         sv.sort_vertices_of_regions()
         assert_array_equal(sorted(sv.regions), sorted(unsorted_regions))
+
+    def test_sort_vertices_of_regions_flattened(self):
+        expected = sorted([[0, 6, 5, 2, 3], [2, 3, 10, 11, 8, 7], [0, 6, 4, 1], [4, 8,
+            7, 5, 6], [9, 11, 10], [2, 7, 5], [1, 4, 8, 11, 9], [0, 3, 10, 9,
+                1]])
+        expected = list(itertools.chain(*sorted(expected)))
+        sv = SphericalVoronoi(self.points)
+        sv.sort_vertices_of_regions()
+        actual = list(itertools.chain(*sorted(sv.regions)))
+        assert_array_equal(actual, expected)
 
     def test_voronoi_circles(self):
         sv = spherical_voronoi.SphericalVoronoi(self.points)


### PR DESCRIPTION
### Purpose
The objective is to increase the speed of the polygon (spherical Voronoi region) vertex sorting code used by `SphericalVoronoi.sort_vertices_of_regions()` by cythonizing the pure Python implementation.

### Initial Results
Benchmarking against the tip of master on my machine:
`asv continuous --bench SphericalVorSort b48f233299116226a4a2f4648dcddd975c2725ba ba32cf965e8336556a1a8eac3d79cae99ef30093`

```
· Creating environments
· Discovering benchmarks
·· Uninstalling from virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six.
·· Installing into virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six..
· Running 2 total benchmarks (2 commits * 1 environments * 1 benchmarks)
[  0.00%] · For scipy commit hash ba32cf96:
[  0.00%] ·· Building for virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six.........................................................................................................................................................................
[  0.00%] ·· Benchmarking virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six
[ 50.00%] ··· Running spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting                                                                                                            92.25μs;...
[ 50.00%] · For scipy commit hash b48f2332:
[ 50.00%] ·· Building for virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six....................................................................................................................................................................
[ 50.00%] ·· Benchmarking virtualenv-py2.7-Cython0.22-Tempita0.5.2-numpy1.8.2-six
[100.00%] ··· Running spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting                                                                                                           797.58μs;...    
    before     after       ratio
  [b48f2332] [ba32cf96]
-  797.58μs    92.25μs      0.12  spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting(10)
-     1.04s    96.45ms      0.09  spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting(10000)
-  544.51ms    47.08ms      0.09  spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting(5000)
-  125.51ms     8.40ms      0.07  spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting(1000)
-   13.64ms   870.80μs      0.06  spatial.SphericalVorSort.time_spherical_polygon_vertex_sorting(100)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```
-------------
`line_profiler` result for cython function:
```
Timer unit: 1e-06 s

Total time: 0.154271 s
File: /Users/treddy/.ipython/cython/_cython_magic_f8b3bd94f0b62b2e37e528dd3bc55e1d.pyx
Function: sort_vertices_of_regions at line 15

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    15                                           def sort_vertices_of_regions(int[:,::1] simplices, regions):
    16                                             cdef unsigned int n, k, s, i
    17         1            4      4.0      0.0    cdef int num_regions = len(regions)
    18                                             cdef int current_simplex, current_vertex, remaining_count
    19                                             cdef int cs_identified, remaining_size
    20                                             cdef long[:] remaining
    21      2002          978      0.5      0.6    cdef long[:] sorted_vertices = np.zeros(max([len(region) for region in
    22         2            7      3.5      0.0  	  regions]), dtype = np.int64)
    23                                           
    24         1            5      5.0      0.0    for n in range(num_regions):
    25      2000          773      0.4      0.5      remaining_count = 0
    26      2000        15808      7.9     10.2      remaining = np.asarray(regions[n][:])
    27      2000          723      0.4      0.5      remaining_size = remaining.shape[0]
    28      2000          722      0.4      0.5      sorted_vertices[:] = -2
    29      2000          706      0.4      0.5      current_simplex = remaining[0]
    30      2000          713      0.4      0.5      for i in range(3):
    31      3271         1298      0.4      0.8        k = simplices[current_simplex][i]
    32      3271         1133      0.3      0.7        if k != n:
    33      2000          684      0.3      0.4          current_vertex = k
    34      2000          716      0.4      0.5          break
    35      2000          708      0.4      0.5      sorted_vertices[remaining_count] = current_simplex
    36      2000          665      0.3      0.4      remaining_count += 1
    37      2000         1994      1.0      1.3      remaining_filter(remaining.shape[0], remaining, current_simplex)
    38      2000          740      0.4      0.5      while remaining_size > remaining_count:
    39      9988         3277      0.3      2.1        cs_identified = 0
    40      9988         3492      0.3      2.3        for i in range(remaining_size):
    41     41730        14471      0.3      9.4          if remaining[i] == -2:
    42     31742        10729      0.3      7.0            continue
    43      9988         3402      0.3      2.2          s = remaining[i]
    44      9988         3334      0.3      2.2          for j in range(3):
    45     19033         7036      0.4      4.6            if current_vertex == simplices[s,j]:
    46      9988         3375      0.3      2.2              current_simplex = remaining[i]
    47      9988         3391      0.3      2.2              cs_identified += 1
    48      9988         3386      0.3      2.2              break
    49      9988         3424      0.3      2.2          if cs_identified > 0:
    50      9988         3394      0.3      2.2            break
    51      9988         3389      0.3      2.2        for i in range(3):
    52     20007         6778      0.3      4.4          s = simplices[current_simplex, i]
    53     20007         7040      0.4      4.6          if s != n and s != current_vertex:
    54      9988         3232      0.3      2.1            current_vertex = s
    55      9988         3373      0.3      2.2            break
    56      9988         3550      0.4      2.3        sorted_vertices[remaining_count] = current_simplex
    57      9988         3243      0.3      2.1        remaining_count += 1
    58      9988         9806      1.0      6.4        remaining_filter(remaining.shape[0], remaining, current_simplex)
    59      2000        14468      7.2      9.4      regions_arr = np.asarray(sorted_vertices)
    60      2000         8304      4.2      5.4      regions[n] = regions_arr[regions_arr > -2].tolist()
```

### To-do list:

- [x] Add appropriate header info / versionadded / changelog type stuff if we decide to incorporate some form of this optimization
- [x] Consider renaming `_sv_sort_vertices.pyx` to something more general so that the spherical Voronoi code proper may eventually be cythonized in the same file without bloating `spatial` with cython source files? or maybe use a subfolder?
- [ ] Look for other optimization opportunities? There's a bit of awkwardness with [memoryview coercion to numpy arrays](http://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html#coercion-to-numpy). My basic idea was to pre-allocate arrays as much as possible and use filter values (-2 in my code) to accommodate cases where smaller arrays are used in the control flow.

### Why has a new unit test been added with this enhancement?
Because the only unit test that currently verifies vertex sorting behaviour did not seem to be sufficiently sensitive to detect certain issues. In particular, when the nested lists had matching lengths but different contents, the original test could pass in some instances. I suspect this relates to the heterogeneity (`dtype=object`) for nested list data structures although quick interactive testing suggests that `np.testing.assert_array_equal()` does ok with these cases too. In any case, an additional test where the data has been flattened  was added (the old test was retained too), as this would always find an issue during the development process.