### PR TITLE
BUG: optimize: add sufficient descent condition check to CG line search

### DIFF
--- a/scipy/optimize/linesearch.py
+++ b/scipy/optimize/linesearch.py
@@ -192,7 +192,8 @@ line_search = line_search_wolfe1
 #------------------------------------------------------------------------------
 
 def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
-                       old_old_fval=None, args=(), c1=1e-4, c2=0.9, amax=50):
+                       old_old_fval=None, args=(), c1=1e-4, c2=0.9, amax=50,
+                       extra_condition=None):
     """Find alpha that satisfies strong Wolfe conditions.
 
     Parameters
@@ -220,6 +221,15 @@ def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
         Parameter for curvature condition rule.
     amax : float, optional
         Maximum step size
+    extra_condition : callable, optional
+        A callable of the form ``extra_condition(alpha, x, f, g)``
+        returning a boolean. Arguments are the proposed step ``alpha``
+        and the corresponding ``x``, ``f`` and ``g`` values. The line search 
+        accepts the value of ``alpha`` only if this 
+        callable returns ``True``. If the callable returns ``False`` 
+        for the step length, the algorithm will continue with 
+        new iterates. The callable is only called for iterates 
+        satisfying the strong Wolfe conditions.
 
     Returns
     -------
@@ -253,6 +263,7 @@ def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
     fc = [0]
     gc = [0]
     gval = [None]
+    gval_alpha = [None]
 
     def phi(alpha):
         fc[0] += 1
@@ -265,6 +276,7 @@ def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
             fprime = myfprime[0]
             newargs = (f, eps) + args
             gval[0] = fprime(xk + alpha * pk, *newargs)  # store for later use
+            gval_alpha[0] = alpha
             return np.dot(gval[0], pk)
     else:
         fprime = myfprime
@@ -272,14 +284,27 @@ def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
         def derphi(alpha):
             gc[0] += 1
             gval[0] = fprime(xk + alpha * pk, *args)  # store for later use
+            gval_alpha[0] = alpha
             return np.dot(gval[0], pk)
 
     if gfk is None:
         gfk = fprime(xk, *args)
     derphi0 = np.dot(gfk, pk)
 
+    if extra_condition is not None:
+        # Add the current gradient as argument, to avoid needless
+        # re-evaluation
+        def extra_condition2(alpha, phi):
+            if gval_alpha[0] != alpha:
+                derphi(alpha)
+            x = xk + alpha * pk
+            return extra_condition(alpha, x, phi, gval[0])
+    else:
+        extra_condition2 = None
+
     alpha_star, phi_star, old_fval, derphi_star = scalar_search_wolfe2(
-            phi, derphi, old_fval, old_old_fval, derphi0, c1, c2, amax)
+            phi, derphi, old_fval, old_old_fval, derphi0, c1, c2, amax,
+            extra_condition2)
 
     if derphi_star is None:
         warn('The line search algorithm did not converge', LineSearchWarning)
@@ -295,7 +320,8 @@ def line_search_wolfe2(f, myfprime, xk, pk, gfk=None, old_fval=None,
 
 def scalar_search_wolfe2(phi, derphi=None, phi0=None,
                          old_phi0=None, derphi0=None,
-                         c1=1e-4, c2=0.9, amax=50):
+                         c1=1e-4, c2=0.9, amax=50,
+                         extra_condition=None):
     """Find alpha that satisfies strong Wolfe conditions.
 
     alpha > 0 is assumed to be a descent direction.
@@ -318,6 +344,14 @@ def scalar_search_wolfe2(phi, derphi=None, phi0=None,
         Parameter for curvature condition rule.
     amax : float, optional
         Maximum step size
+    extra_condition : callable, optional
+        A callable of the form ``extra_condition(alpha, phi_value)``
+        returning a boolean. The line search accepts the value
+        of ``alpha`` only if this callable returns ``True``.
+        If the callable returns ``False`` for the step length,
+        the algorithm will continue with new iterates.
+        The callable is only called for iterates satisfying
+        the strong Wolfe conditions.
 
     Returns
     -------
@@ -371,6 +405,9 @@ def scalar_search_wolfe2(phi, derphi=None, phi0=None,
     phi_a0 = phi0
     derphi_a0 = derphi0
 
+    if extra_condition is None:
+        extra_condition = lambda alpha, phi: True
+
     i = 1
     maxiter = 10
     for i in xrange(maxiter):
@@ -381,21 +418,22 @@ def scalar_search_wolfe2(phi, derphi=None, phi0=None,
             alpha_star, phi_star, derphi_star = \
                         _zoom(alpha0, alpha1, phi_a0,
                               phi_a1, derphi_a0, phi, derphi,
-                              phi0, derphi0, c1, c2)
+                              phi0, derphi0, c1, c2, extra_condition)
             break
 
         derphi_a1 = derphi(alpha1)
         if (abs(derphi_a1) <= -c2*derphi0):
-            alpha_star = alpha1
-            phi_star = phi_a1
-            derphi_star = derphi_a1
-            break
+            if extra_condition(alpha1, phi_a1):
+                alpha_star = alpha1
+                phi_star = phi_a1
+                derphi_star = derphi_a1
+                break
 
         if (derphi_a1 >= 0):
             alpha_star, phi_star, derphi_star = \
                         _zoom(alpha1, alpha0, phi_a1,
                               phi_a0, derphi_a1, phi, derphi,
-                              phi0, derphi0, c1, c2)
+                              phi0, derphi0, c1, c2, extra_condition)
             break
 
         alpha2 = 2 * alpha1   # increase by factor of two on each iteration
@@ -472,7 +510,7 @@ def _quadmin(a, fa, fpa, b, fb):
 
 
 def _zoom(a_lo, a_hi, phi_lo, phi_hi, derphi_lo,
-          phi, derphi, phi0, derphi0, c1, c2):
+          phi, derphi, phi0, derphi0, c1, c2, extra_condition):
     """
     Part of the optimization algorithm in `scalar_search_wolfe2`.
     """
@@ -525,7 +563,7 @@ def _zoom(a_lo, a_hi, phi_lo, phi_hi, derphi_lo,
             phi_hi = phi_aj
         else:
             derphi_aj = derphi(a_j)
-            if abs(derphi_aj) <= -c2*derphi0:
+            if abs(derphi_aj) <= -c2*derphi0 and extra_condition(a_j, phi_aj):
                 a_star = a_j
                 val_star = phi_aj
                 valprime_star = derphi_aj

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -124,6 +124,17 @@ class CheckOptimizeParameterized(CheckOptimize):
                          [0, -5.05700028e-01, 4.95985862e-01]],
                         atol=1e-14, rtol=1e-7)
 
+    def test_cg_cornercase(self):
+        def f(r):
+            return 2.5 * (1 - np.exp(-1.5*(r - 0.5)))**2
+
+        # Check several initial guesses. (Too far away from the
+        # minimum, the function ends up in the flat region of exp.)
+        for x0 in np.linspace(-0.75, 3, 71):
+            sol = optimize.minimize(f, [x0], method='CG')
+            assert_(sol.success)
+            assert_allclose(sol.x, [0.5], rtol=1e-5)
+
     @suppressed_stdout
     def test_bfgs(self):
         # Broyden-Fletcher-Goldfarb-Shanno optimization routine


### PR DESCRIPTION
Polak-Ribiere CG with inexact strong Wolfe line search does not
guarantee pk points to descent direction (unlike Fletcher-Reeves).
If this happens, the line search fails, and the algorithm bails out with 
warnflag/non-success set, so that some problems that
could in principle be solvable become non-solvable.

Fix the CG line search by adding a sufficient descent condition check,
based on discussion in Gilbert & Nocedal, SIAM J. Optimization 2, 21 (1992).

The MINPACK line search does not seem to be as easily modified, so add
the check to the pure-Python search. The condition is probably not very
common, so the performance is not as important.

Fixes gh-6767

I didn't re-read this through carefully so the WIP tag is there to remind that
I haven't checked this completely --- basically the suspicious thing is whether
modification of the line search algo is OK. The test coverage
of `minimize_cg` also seems quite crappy, it's pretty much in its original form since 2002