### PR TITLE
ENH: Integrating LAPACK "expert" routines with conditioning warnings for linalg.solve_ family

### DIFF
--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -23,6 +23,7 @@ Basics
 
    inv - Find the inverse of a square matrix
    solve - Solve a linear system of equations
+   solve_x - Solve a linear system of equations with conditioning/error info
    solve_banded - Solve a banded linear system
    solveh_banded - Solve a Hermitian or symmetric banded system
    solve_circulant - Solve a circulant system

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -23,7 +23,6 @@ Basics
 
    inv - Find the inverse of a square matrix
    solve - Solve a linear system of equations
-   solve_x - Solve a linear system of equations with conditioning/error info
    solve_banded - Solve a banded linear system
    solveh_banded - Solve a Hermitian or symmetric banded system
    solve_circulant - Solve a circulant system

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -121,7 +121,7 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
 
     if n != b1.shape[0]:
         # Last chance to catch 1x1 scalar a and 1D b arrays
-        if not (n == 1 and b.size != 0):
+        if not (n == 1 and b1.size != 0):
             raise ValueError('Input b has to have same number of rows as '
                              'input a')
 

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -23,7 +23,7 @@ __all__ = ['solve', 'solve_triangular', 'solveh_banded', 'solve_banded',
 
 # Linear equations
 def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
-          overwrite_b=False, check_finite=True, assume_a='gen',
+          overwrite_b=False, debug=False, check_finite=True, assume_a='gen',
           transposed=False):
     """
     Solves the linear equation set ``a * x = b`` for the unknown ``x``
@@ -168,7 +168,7 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
                                        )
     elif _structure == 'sym':
         sysvx, sysvx_lw = get_lapack_funcs(('sysvx', 'sysvx_lwork'), (a1, b1))
-        lwork, _ = sysvx_lw(n, lower)
+        lwork = _compute_lwork(sysvx_lw, n, lower)
         _, _, _, _, x, rcond, _, _, info = sysvx(a1, b1, lwork=lwork,
                                                  lower=lower,
                                                  overwrite_a=overwrite_a,
@@ -176,7 +176,7 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
                                                  )
     elif _structure == 'her':
         hesvx, hesvx_lw = get_lapack_funcs(('hesvx', 'hesvx_lwork'), (a1, b1))
-        lwork, _ = hesvx_lw(n, lower)
+        lwork = _compute_lwork(hesvx_lw, n, lower)
         _, _, x, rcond, _, _, info = hesvx(a1, b1, lwork=lwork,
                                            lower=lower,
                                            overwrite_a=overwrite_a,

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -52,7 +52,7 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
     a : (N, N) array_like
         Square input data
     b : (N, NRHS) array_like
-        Input data for the right hand side. For single column right hand side
+        Input data for the right hand side.
     sym_pos : bool, optional
         Assume `a` is symmetric and positive definite. This key is deprecated
         and assume_a = 'pos' keyword is recommended instead. The functionality
@@ -97,12 +97,20 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
     >>> from scipy import linalg
     >>> x = linalg.solve(a, b)
     >>> x
-    array([[ 2.],
-           [-2.],
-           [ 9.]])
+    array([ 2., -2.,  9.])
     >>> np.dot(a, x) == b
     array([ True,  True,  True], dtype=bool)
 
+    Notes
+    -----
+    If the input b matrix is a 1D array with N elements, when supplied
+    together with an NxN input a, it is assumed as a valid column vector
+    despite the apparent size mismatch. This is compatible with the
+    numpy.dot() behavior and the returned result is still 1D array.
+
+    The generic, symmetric, hermitian and positive definite solutions are
+    obtained via calling ?GESVX, ?SYSVX, ?HESVX, and ?POSVX routines of
+    LAPACK respectively.
     """
     a1 = atleast_2d(_asarray_validated(a, check_finite=check_finite))
     b1 = _asarray_validated(b, check_finite=check_finite)

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -207,10 +207,9 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False,
     elif 0 < info <= n:
         raise LinAlgError('Matrix is singular.')
     elif info > n:
-        warnings.warn('scipy.linalg.solve : Ill-conditioned matrix '
-                      'detected.\nResult is not guaranteed to be '
-                      'accurate.\nReciprocal condition number: {}'
-                      ''.format(rcond), RuntimeWarning)
+        warnings.warn('scipy.linalg.solve\nIll-conditioned matrix detected.'
+                      ' Result is not guaranteed to be accurate.\nReciprocal'
+                      ' condition number: {}'.format(rcond), RuntimeWarning)
         return x
 
 

--- a/scipy/linalg/basic.py
+++ b/scipy/linalg/basic.py
@@ -8,7 +8,7 @@ from __future__ import division, print_function, absolute_import
 
 import warnings
 import numpy as np
-from numpy import atleast_2d
+from numpy import atleast_1d, atleast_2d
 from .flinalg import get_flinalg_funcs
 from .lapack import get_lapack_funcs, _compute_lwork
 from .misc import LinAlgError, _datacopied

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -570,7 +570,7 @@ interface
      character optional,intent(in):: fact = "E"
      integer depend(a),intent(hide):: n = shape(a,0)
      integer depend(b),intent(hide):: nrhs = shape(b,1)
-     <ftype2> dimension(n,n),intent(in,out,copy,out=as):: a
+     <ftype2> dimension(n,n),check(shape(a,0)==shape(a,1)),intent(in,out,copy,out=as):: a
      integer depend(a),intent(hide):: lda = shape(a,0)
      <ftype2> optional,dimension(n,n),intent(in,out,out=lu):: af
      integer optional,depend(af),intent(hide):: ldaf = shape(af,0)
@@ -578,7 +578,7 @@ interface
      character optional,intent(in,out):: equed = "B"
      <ftype2> optional,dimension(n),depend(n),intent(in,out,out=rs):: r
      <ftype2> optional,dimension(n),depend(n),intent(in,out,out=cs):: c
-     <ftype2> dimension(n,nrhs),intent(in,out,copy,out=bs):: b
+     <ftype2> depend(n),dimension(n,nrhs),intent(in,out,copy,out=bs):: b
      integer depend(b),intent(hide):: ldb = shape(b,0)
      <ftype2> dimension(n,nrhs),depend(n,nrhs),intent(out):: x
      integer depend(n),intent(hide):: ldx = n
@@ -604,7 +604,7 @@ interface
      character optional,intent(in):: fact = "E"
      integer depend(a),intent(hide):: n = shape(a,0)
      integer depend(b),intent(hide):: nrhs = shape(b,1)
-     <ftype2c> dimension(n,n),intent(in,out,copy,out=as):: a
+     <ftype2c> dimension(n,n),check(shape(a,0)==shape(a,1)),intent(in,out,copy,out=as):: a
      integer depend(a),intent(hide):: lda = shape(a,0)
      <ftype2c> optional,dimension(n,n),depend(n),intent(in,out,out=lu):: af
      integer optional,depend(af),intent(hide):: ldaf = shape(af,0)
@@ -612,7 +612,7 @@ interface
      character optional,intent(in,out):: equed = "B"
      <ftype2> optional,dimension(n),depend(n),intent(in,out,out=rs):: r
      <ftype2> optional,dimension(n),depend(n),intent(in,out,out=cs):: c
-     <ftype2c> dimension(n,nrhs),intent(in,out,copy,out=bs):: b
+     <ftype2c> depend(n),dimension(n,nrhs),intent(in,out,copy,out=bs):: b
      integer depend(b),intent(hide):: ldb = shape(b,0)
      <ftype2c> dimension(n,nrhs),depend(n,nrhs),intent(out):: x
      integer depend(n),intent(hide):: ldx = n
@@ -702,12 +702,12 @@ interface
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
      integer depend(a),intent(hide):: n = shape(a,0)
      integer depend(b),intent(hide):: nrhs = shape(b,1)
-     <ftype> dimension(n,n),intent(in,copy,out,out=a_s):: a
+     <ftype> dimension(n,n),check(shape(a,0)==shape(a,1)),intent(in,copy,out,out=a_s):: a
      integer depend(a),intent(hide):: lda = shape(a,0)
      <ftype> optional,dimension(n,n),depend(n),intent(in,out,out=udut):: af
      integer optional,depend(af),intent(hide):: ldaf = shape(af,0)
      integer optional,dimension(n),depend(n),intent(in,out):: ipiv
-     <ftype> dimension(n,nrhs),intent(in,copy,out,out=b_s):: b
+     <ftype> depend(n),dimension(n,nrhs),intent(in,copy,out,out=b_s):: b
      integer depend(b),intent(hide):: ldb = shape(b,0)
      <ftype> dimension(n,nrhs),intent(out):: x
      integer depend(b),intent(hide):: ldx = n
@@ -817,14 +817,14 @@ interface
      integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
      integer depend(a),intent(hide):: n = shape(a,0)
      integer depend(b),intent(hide):: nrhs = shape(b,1)
-     <ftype2c> dimension(n,n),intent(in,copy) :: a
+     <ftype2c> dimension(n,n),check(shape(a,0)==shape(a,1)),intent(in,copy) :: a
      integer depend(a),intent(hide):: lda = shape(a,0)
      <ftype2c> optional,dimension(n,n),depend(n),intent(in,out,out=uduh) :: af
      integer optional,depend(af),intent(hide):: ldaf = shape(af,0)
      integer optional,depend(n),dimension(n),intent(in,out):: ipiv
-     <ftype2c> dimension(n,nrhs),intent(in,copy) :: b
+     <ftype2c> depend(n),dimension(n,nrhs),intent(in,copy) :: b
      integer depend(b),intent(hide):: ldb = shape(b,0)
-     <ftype2c> dimension(n,nrhs),intent(out) :: x
+     <ftype2c> depend(n,nrhs),dimension(n,nrhs),intent(out) :: x
      integer depend(x),intent(hide):: ldx = shape(x,0)
      <ftype2> intent(out):: rcond
      <ftype2> intent(out),dimension(nrhs),depend(nrhs):: ferr

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -562,7 +562,7 @@ interface
    ! Solve A * X = B using LU decomposition
    ! The expert driver of ?GESV with condition number, backward/forward error estimates, and iterative refinement
    ! This part takes care of the data types, single and double reals (sgesvx and dgesvx)
-
+     threadsafe
      callstatement {int i;(*f2py_func)(fact,trans,&n,&nrhs,a,&lda,af,&ldaf,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,iwork,&info);for(i=0;i\<n;--ipiv[i++]);}
      callprotoargument char*,char*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,char*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
 
@@ -596,7 +596,7 @@ interface
    ! Solve A * X = B using LU decomposition
    ! The expert driver of ?GESV with condition number, backward/forward error estimates, and iterative refinement
    ! This part takes care of the data types, complex and double complex (cgesvx and zgesvx)
-
+     threadsafe
      callstatement {int i;(*f2py_func)(fact,trans,&n,&nrhs,a,&lda,af,&ldaf,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,rwork,&info);for(i=0;i\<n;--ipiv[i++]);}
      callprotoargument char*,char*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,char*,<ctype2>*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2>*,int*
 
@@ -628,7 +628,7 @@ interface
    subroutine <prefix>gecon(norm,n,a,lda,anorm,rcond,work,irwork,info)
 
    ! Computes the 1- or inf- norm reciprocal condition number estimate.
-
+     threadsafe
      callstatement (*f2py_func)(norm,&n,a,&lda,&anorm,&rcond,work,irwork,&info)
      callprotoargument char*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctype>*,<int,int,float,double>*,int*
 
@@ -694,7 +694,7 @@ interface
    ! Solve A * X = B for symmetric A matrix
    ! The expert driver of ?SYSV with condition number, backward,forward error estimates and iterative refinement
    ! The <c,z> versions assume only symmetric complex matrices. For Hermitian matrices, routine <c,z>HESVX is used
-
+     threadsafe
      callstatement (*f2py_func)((factored?"F":"N"),(lower?"L":"U"),&n,&nrhs,a,&lda,af,&ldaf,ipiv,b,&ldb,x,&ldx,&rcond,ferr,berr,work,&lwork,irwork,&info)
      callprotoargument char*,char*,int*,int*,<ctype>*,int*,<ctype>*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctype>*,int*,<int,int,float,double>*,int*
 
@@ -760,7 +760,7 @@ interface
    ! A is hermitian. For symmetric A see ?SYSV
    ! A = U * D * U**H if lower = 0
    ! A = L * D * L**H if lower = 1
-
+     threadsafe
      callstatement (*f2py_func)((lower?"L":"U"),&n,&nrhs,a,&lda,ipiv,b,&ldb,work,&lwork,&info)
      callprotoargument char*,int*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*
 
@@ -809,7 +809,7 @@ interface
    ! A is hermitian. For symmetric A see ?SYSVX
    ! A = U * D * U**H if lower = 0
    ! A = L * D * L**H if lower = 1
-
+     threadsafe
      callstatement (*f2py_func)((factored?"F":"N"),(lower?"L":"U"),&n,&nrhs,a,&lda,af,&ldaf,ipiv,b,&ldb,x,&ldx,&rcond,ferr,berr,work,&lwork,rwork,&info)
      callprotoargument char*,char*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*
 
@@ -2157,7 +2157,7 @@ interface
 
    ! Solve A * X = B for Symmetric/Hermitian A
    ! "expert" version of the ?POSV routines
-
+     threadsafe
      callstatement (*f2py_func)(fact,(lower?"L":"U"),&n,&nrhs,a,&lda,af,&ldaf,equed,s,b,&ldb,x,&ldx,&rcond,ferr,berr,work,irwork,&info)
      callprotoargument char*,char*,int*,int*,<ctype>*,int*,<ctype>*,int*,char*,<ctypereal>*,<ctype>*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctype>*,<int,int,float,double>*,int*
 
@@ -2188,7 +2188,7 @@ interface
 
    ! Computes the 1- or inf- norm reciprocal condition number estimate
    ! for a positive definite symmetric/hermitian matrix.
-
+     threadsafe
      callstatement (*f2py_func)(uplo,&n,a,&lda,&anorm,&rcond,work,irwork,&info)
      callprotoargument char*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctype>*,<int,int,float,double>*,int*
 

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -6,10 +6,25 @@
 ! $Revision$ $Date$
 !
 ! Additions by Travis Oliphant, Tiziano Zito, Collin RM Stocks, Fabian Pedregosa
-!              Skipper Seabold
+!              Skipper Seabold,
+!              Ilhan Polat - ?gesvx,?sysv,?sysvx,?posvx,?hesvx,?gecon,?pocon
 !
-! <prefix2=s,d> <ctype2=float,double> <ftype2=real,double precision> <wrap2=ws,d>
-! <prefix2c=c,z> <ftype2c=complex,double complex> <ctype2c=complex_float,complex_double> <wrap2c=wc,z>
+! Shorthand Notations:
+! --------------------
+! <prefix=s,d,c,z>
+! <prefix2=s,d>
+! <prefix2c=c,z>
+! <ftype=real,double precision,complex,double complex>
+! <ftype2=real,double precision>
+! <ftype2c=complex,double complex>
+! <ftypereal=real,double precision,real,double precision>
+! <ctype=float,double,complex_float,complex_double>
+! <ctype2=float,double>
+! <ctype2c=complex_float,complex_double>
+! <ctypereal=float,double,float,double>
+! <wrap2=ws,d>
+! <wrap2c=wc,z>
+!
 
 python module _flapack
 interface
@@ -542,6 +557,317 @@ interface
 
    end subroutine <prefix>gesv
 
+   subroutine <prefix2>gesvx(fact,trans,n,nrhs,a,lda,af,ldaf,ipiv,equed,r,c,b,ldb,x,ldx,rcond,ferr,berr,work,iwork,info)
+
+   ! Solve A * X = B using LU decomposition
+   ! The expert driver of ?GESV with condition number, backward/forward error estimates, and iterative refinement
+   ! This part takes care of the data types, single and double reals (sgesvx and dgesvx)
+
+     callstatement {int i;(*f2py_func)(fact,trans,&n,&nrhs,a,&lda,af,&ldaf,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,iwork,&info);for(i=0;i\<n;--ipiv[i++]);}
+     callprotoargument char*,char*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,int*,char*,<ctype2>*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2>*,int*,int*
+
+     character optional,intent(in):: trans = "N"
+     character optional,intent(in):: fact = "E"
+     integer depend(a),intent(hide):: n = shape(a,0)
+     integer depend(b),intent(hide):: nrhs = shape(b,1)
+     <ftype2> dimension(n,n),intent(in,out,copy,out=as):: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     <ftype2> optional,dimension(n,n),intent(in,out,out=lu):: af
+     integer optional,depend(af),intent(hide):: ldaf = shape(af,0)
+     integer optional,dimension(n),depend(n),intent(in,out):: ipiv
+     character optional,intent(in,out):: equed = "B"
+     <ftype2> optional,dimension(n),depend(n),intent(in,out,out=rs):: r
+     <ftype2> optional,dimension(n),depend(n),intent(in,out,out=cs):: c
+     <ftype2> dimension(n,nrhs),intent(in,out,copy,out=bs):: b
+     integer depend(b),intent(hide):: ldb = shape(b,0)
+     <ftype2> dimension(n,nrhs),depend(n,nrhs),intent(out):: x
+     integer depend(n),intent(hide):: ldx = n
+     <ftype2> intent(out):: rcond
+     <ftype2> intent(out),dimension(nrhs),depend(nrhs):: ferr
+     <ftype2> intent(out),dimension(nrhs),depend(nrhs):: berr
+     <ftype2> dimension(4*n),depend(n),intent(hide,cache):: work
+     integer intent(hide,cache),dimension(n),depend(n) :: iwork
+     integer intent(out):: info
+
+   end subroutine <prefix2>gesvx
+
+   subroutine <prefix2c>gesvx(fact,trans,n,nrhs,a,lda,af,ldaf,ipiv,equed,r,c,b,ldb,x,ldx,rcond,ferr,berr,work,rwork,info)
+
+   ! Solve A * X = B using LU decomposition
+   ! The expert driver of ?GESV with condition number, backward/forward error estimates, and iterative refinement
+   ! This part takes care of the data types, complex and double complex (cgesvx and zgesvx)
+
+     callstatement {int i;(*f2py_func)(fact,trans,&n,&nrhs,a,&lda,af,&ldaf,ipiv,equed,r,c,b,&ldb,x,&ldx,&rcond,ferr,berr,work,rwork,&info);for(i=0;i\<n;--ipiv[i++]);}
+     callprotoargument char*,char*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,char*,<ctype2>*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,<ctype2>*,int*
+
+     character optional,intent(in):: trans = "N"
+     character optional,intent(in):: fact = "E"
+     integer depend(a),intent(hide):: n = shape(a,0)
+     integer depend(b),intent(hide):: nrhs = shape(b,1)
+     <ftype2c> dimension(n,n),intent(in,out,copy,out=as):: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     <ftype2c> optional,dimension(n,n),depend(n),intent(in,out,out=lu):: af
+     integer optional,depend(af),intent(hide):: ldaf = shape(af,0)
+     integer optional,dimension(n),depend(n),intent(in,out):: ipiv
+     character optional,intent(in,out):: equed = "B"
+     <ftype2> optional,dimension(n),depend(n),intent(in,out,out=rs):: r
+     <ftype2> optional,dimension(n),depend(n),intent(in,out,out=cs):: c
+     <ftype2c> dimension(n,nrhs),intent(in,out,copy,out=bs):: b
+     integer depend(b),intent(hide):: ldb = shape(b,0)
+     <ftype2c> dimension(n,nrhs),depend(n,nrhs),intent(out):: x
+     integer depend(n),intent(hide):: ldx = n
+     <ftype2> intent(out):: rcond
+     <ftype2> intent(out),dimension(nrhs),depend(nrhs):: ferr
+     <ftype2> intent(out),dimension(nrhs),depend(nrhs):: berr
+     <ftype2c> dimension(2*n),depend(n),intent(hide,cache):: work
+     <ftype2> intent(hide,cache),dimension(2*n),depend(n) :: rwork
+     integer intent(out):: info
+
+   end subroutine <prefix2c>gesvx
+
+   subroutine <prefix>gecon(norm,n,a,lda,anorm,rcond,work,irwork,info)
+
+   ! Computes the 1- or inf- norm reciprocal condition number estimate.
+
+     callstatement (*f2py_func)(norm,&n,a,&lda,&anorm,&rcond,work,irwork,&info)
+     callprotoargument char*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctype>*,<int,int,float,double>*,int*
+
+     character optional,intent(in):: norm = '1'
+     integer depend(a),intent(hide):: n = shape(a,0)
+     <ftype> dimension(n,n),check(shape(a,0)==shape(a,1)),intent(in):: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     <ftypereal> intent(in):: anorm
+     <ftypereal> intent(out):: rcond
+     <ftype> depend(n),dimension(<4*n,4*n,2*n,2*n>),intent(hide,cache):: work
+     <integer,integer,real, double precision> depend(n),dimension(<n,n,2*n,2*n>),intent(hide,cache):: irwork
+     integer intent(out):: info
+
+   end subroutine <prefix>gecon
+
+   subroutine <prefix>sysv(n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info,lower)
+
+   ! Solve A * X = B for symmetric A matrix
+
+     callstatement (*f2py_func)((lower?"L":"U"),&n,&nrhs,a,&lda,ipiv,b,&ldb,work,&lwork,&info)
+     callprotoargument char*,int*,int*,<ctype>*,int*,int*,<ctype>*,int*,<ctype>*,int*,int*
+
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+     integer depend(a),intent(hide):: n = shape(a,0)
+     integer depend(b),intent(hide):: nrhs = shape(b,1)
+     <ftype> dimension(n,n),check(shape(a,0)==shape(a,1)),intent(in,out,copy,out=udut):: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     integer dimension(n),depend(n),intent(out):: ipiv
+     <ftype> dimension(n,nrhs),check(shape(b,0)==n),depend(n),intent(in,out,copy,out=x):: b
+     integer depend(b),intent(hide):: ldb = shape(b,0)
+     integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1):: lwork = n
+     <ftype> depend(lwork),dimension(MAX(lwork,1)),intent(hide,cache):: work
+     integer intent(out):: info
+
+   end subroutine <prefix>sysv
+
+   subroutine <prefix>sysv_lwork(n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info,lower)
+
+   ! lwork computation for ?SYSV
+
+     fortranname <prefix>sysv
+     callstatement (*f2py_func)((lower?"L":"U"),&n,&nrhs,&a,&lda,&ipiv,&b,&ldb,&work,&lwork,&info)
+     callprotoargument char*,int*,int*,<ctype>*,int*,int*,<ctype>*,int*,<ctype>*,int*,int*
+
+     integer intent(in):: n
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+
+     integer intent(hide):: nrhs = 1
+     <ftype> intent(hide):: a
+     integer depend(n),intent(hide):: lda = n
+     integer intent(hide):: ipiv
+     <ftype> intent(hide):: b
+     integer depend(n),intent(hide):: ldb = n
+     integer intent(hide):: lwork = -1
+
+     <ftype> intent(out):: work
+     integer intent(out):: info
+
+   end subroutine <prefix>sysv_lwork
+
+   subroutine <prefix>sysvx(n,nrhs,a,lda,af,ldaf,ipiv,b,ldb,x,ldx,rcond,ferr,berr,work,lwork,irwork,info,factored,lower)
+
+   ! Solve A * X = B for symmetric A matrix
+   ! The expert driver of ?SYSV with condition number, backward,forward error estimates and iterative refinement
+   ! The <c,z> versions assume only symmetric complex matrices. For Hermitian matrices, routine <c,z>HESVX is used
+
+     callstatement (*f2py_func)((factored?"F":"N"),(lower?"L":"U"),&n,&nrhs,a,&lda,af,&ldaf,ipiv,b,&ldb,x,&ldx,&rcond,ferr,berr,work,&lwork,irwork,&info)
+     callprotoargument char*,char*,int*,int*,<ctype>*,int*,<ctype>*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctype>*,int*,<int,int,float,double>*,int*
+
+     integer optional,intent(in),check(factored==0||factored==1) :: factored = 0
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+     integer depend(a),intent(hide):: n = shape(a,0)
+     integer depend(b),intent(hide):: nrhs = shape(b,1)
+     <ftype> dimension(n,n),intent(in,copy,out,out=a_s):: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     <ftype> optional,dimension(n,n),depend(n),intent(in,out,out=udut):: af
+     integer optional,depend(af),intent(hide):: ldaf = shape(af,0)
+     integer optional,dimension(n),depend(n),intent(in,out):: ipiv
+     <ftype> dimension(n,nrhs),intent(in,copy,out,out=b_s):: b
+     integer depend(b),intent(hide):: ldb = shape(b,0)
+     <ftype> dimension(n,nrhs),intent(out):: x
+     integer depend(b),intent(hide):: ldx = n
+     <ftypereal> intent(out):: rcond
+     <ftypereal> intent(out),dimension(nrhs),depend(nrhs):: ferr
+     <ftypereal> intent(out),dimension(nrhs),depend(nrhs):: berr
+     integer optional,intent(in),check(lwork>=<3*n,3*n,2*n,2*n>||lwork==-1):: lwork = 3*n
+     <ftype> dimension(MAX(lwork,1)),intent(hide,cache),depend(lwork) :: work
+     <integer,integer,real,double precision> intent(hide,cache),dimension(n),depend(n) :: irwork
+     integer intent(out):: info
+
+   end subroutine <prefix>sysvx
+
+   subroutine <prefix>sysvx_lwork(n,nrhs,a,lda,af,ldaf,ipiv,b,ldb,x,ldx,rcond,ferr,berr,work,lwork,irwork,info,factored,lower)
+
+   ! lwork computation for ?SYSVX
+
+     fortranname <prefix>sysvx
+     callstatement (*f2py_func)((factored?"F":"N"),(lower?"L":"U"),&n,&nrhs,&a,&lda,&af,&ldaf,&ipiv,&b,&ldb,&x,&ldx,&rcond,&ferr,&berr,&work,&lwork,&irwork,&info)
+     callprotoargument char*,char*,int*,int*,<ctype>*,int*,<ctype>*,int*,int*,<ctype>*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctype>*,int*,<int,int,float,double>*,int*
+
+     integer intent(in):: n
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+
+     integer intent(hide) :: factored = 0
+     integer intent(hide):: nrhs = 1
+     <ftype> intent(hide):: a
+     integer depend(n),intent(hide):: lda = n
+     <ftype> intent(hide):: af
+     integer depend(n),intent(hide):: ldaf = n
+     integer intent(hide):: ipiv
+     <ftype> intent(hide):: b
+     integer depend(n),intent(hide):: ldb = n
+     <ftype> intent(hide):: x
+     integer depend(n),intent(hide):: ldx = n
+     <ftypereal> intent(hide):: rcond
+     <ftypereal> intent(hide):: ferr
+     <ftypereal> intent(hide):: berr
+     integer intent(hide):: lwork = -1
+     <integer,integer,real,double precision> intent(hide):: irwork
+
+     <ftype> intent(out) :: work
+     integer intent(out):: info
+
+   end subroutine <prefix>sysvx_lwork
+
+   subroutine <prefix2c>hesv(n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info,lower)
+
+   ! Solves A * X = B for X
+   ! A is hermitian. For symmetric A see ?SYSV
+   ! A = U * D * U**H if lower = 0
+   ! A = L * D * L**H if lower = 1
+
+     callstatement (*f2py_func)((lower?"L":"U"),&n,&nrhs,a,&lda,ipiv,b,&ldb,work,&lwork,&info)
+     callprotoargument char*,int*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*
+
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+     integer depend(a),intent(hide):: n = shape(a,0)
+     integer depend(b),intent(hide):: nrhs = shape(b,1)
+     <ftype2c> dimension(n,n),check(shape(a,0)==shape(a,1)),intent(in,out,copy,out=uduh):: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     integer dimension(n),depend(n),intent(out):: ipiv
+     <ftype2c> dimension(n,nrhs),check(shape(b,0)==n),depend(n),intent(in,out,copy,out=x):: b
+     integer depend(b),intent(hide):: ldb = shape(b,0)
+     integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1):: lwork = n
+     <ftype2c> depend(lwork),dimension(MAX(lwork,1)),intent(hide,cache):: work
+     integer intent(out):: info
+
+   end subroutine <prefix2c>hesv
+
+   subroutine <prefix2c>hesv_lwork(n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info,lower)
+
+   ! lwork computation for C/ZHESV
+
+     fortranname <prefix2c>hesv
+     callstatement (*f2py_func)((lower?"L":"U"),&n,&nrhs,&a,&lda,&ipiv,&b,&ldb,&work,&lwork,&info)
+     callprotoargument char*,int*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*
+
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+     integer intent(in):: n
+
+     integer intent(hide):: nrhs = 1
+     <ftype2c> intent(hide):: a
+     integer intent(hide),depend(n):: lda = n
+     integer intent(hide):: ipiv
+     <ftype2c> intent(hide):: b
+     integer intent(hide),depend(n):: ldb = n
+     integer intent(hide):: lwork = -1
+
+     <ftype2c> intent(out):: work
+     integer intent(out):: info
+
+   end subroutine <prefix2c>hesv_lwork
+
+   subroutine <prefix2c>hesvx(n,nrhs,a,lda,af,ldaf,ipiv,b,ldb,x,ldx,rcond,ferr,berr,work,lwork,rwork,info,factored,lower)
+
+   ! Solves A * X = B for X
+   ! Expert driver for ?HESV
+   ! A is hermitian. For symmetric A see ?SYSVX
+   ! A = U * D * U**H if lower = 0
+   ! A = L * D * L**H if lower = 1
+
+     callstatement (*f2py_func)((factored?"F":"N"),(lower?"L":"U"),&n,&nrhs,a,&lda,af,&ldaf,ipiv,b,&ldb,x,&ldx,&rcond,ferr,berr,work,&lwork,rwork,&info)
+     callprotoargument char*,char*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*
+
+     integer optional,intent(in),check(factored==0||factored==1) :: factored = 0
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+     integer depend(a),intent(hide):: n = shape(a,0)
+     integer depend(b),intent(hide):: nrhs = shape(b,1)
+     <ftype2c> dimension(n,n),intent(in,copy) :: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     <ftype2c> optional,dimension(n,n),depend(n),intent(in,out,out=uduh) :: af
+     integer optional,depend(af),intent(hide):: ldaf = shape(af,0)
+     integer optional,depend(n),dimension(n),intent(in,out):: ipiv
+     <ftype2c> dimension(n,nrhs),intent(in,copy) :: b
+     integer depend(b),intent(hide):: ldb = shape(b,0)
+     <ftype2c> dimension(n,nrhs),intent(out) :: x
+     integer depend(x),intent(hide):: ldx = shape(x,0)
+     <ftype2> intent(out):: rcond
+     <ftype2> intent(out),dimension(nrhs),depend(nrhs):: ferr
+     <ftype2> intent(out),dimension(nrhs),depend(nrhs):: berr
+     <ftype2c> dimension(MAX(1,lwork)),depend(lwork),intent(hide,cache):: work
+     integer optional,intent(in),depend(n),check(lwork>=1||lwork==-1):: lwork = 2*n
+     <ftype2> intent(hide,cache),dimension(n),depend(n) :: rwork
+     integer intent(out):: info
+
+   end subroutine <prefix2c>hesvx
+
+   subroutine <prefix2c>hesvx_lwork(n,nrhs,a,lda,af,ldaf,ipiv,b,ldb,x,ldx,rcond,ferr,berr,work,lwork,rwork,info,factored,lower)
+
+   ! lwork computation for ?HESVX
+     fortranname <prefix2c>hesvx
+     callstatement (*f2py_func)((factored?"F":"N"),(lower?"L":"U"),&n,&nrhs,&a,&lda,&af,&ldaf,&ipiv,&b,&ldb,&x,&ldx,&rcond,&ferr,&berr,&work,&lwork,&rwork,&info)
+     callprotoargument char*,char*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2>*,<ctype2>*,<ctype2c>*,int*,<ctype2>*,int*
+
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+     integer intent(in):: n
+
+     integer intent(hide) :: factored = 0
+     integer depend(b),intent(hide):: nrhs = 1
+     <ftype2c> intent(hide) :: a
+     integer depend(n),intent(hide):: lda = n
+     <ftype2c> intent(hide) :: af
+     integer depend(n),intent(hide):: ldaf = n
+     integer intent(hide):: ipiv
+     <ftype2c> intent(hide) :: b
+     integer depend(n),intent(hide):: ldb = n
+     <ftype2c> intent(hide) :: x
+     integer depend(n),intent(hide):: ldx = n
+     <ftype2> intent(hide):: rcond
+     <ftype2> intent(hide):: ferr
+     <ftype2> intent(hide):: berr
+     integer intent(hide):: lwork = -1
+     <ftype2> intent(hide):: rwork
+
+     <ftype2c> intent(out):: work
+     integer intent(out):: info
+
+   end subroutine <prefix2c>hesvx_lwork
+
    subroutine <prefix>getrf(m,n,a,piv,info)
 
    ! lu,piv,info = getrf(a,overwrite_a=0)
@@ -900,14 +1226,14 @@ interface
      callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&s,&cond,&r,&work,&lwork,&info)
      callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*
 
-     integer intent(in):: m 
+     integer intent(in):: m
      integer intent(in):: n
      integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
      <ftype2> intent(hide) :: a
 
      integer intent(in):: nrhs
      <ftype2> intent(hide) :: b
-     
+
      <ftype2> intent(in),optional :: cond = -1.0
      integer intent(hide) :: r
      <ftype2> intent(hide) :: s
@@ -951,23 +1277,23 @@ interface
    end subroutine <prefix2c>gelss
 
    subroutine <prefix2>lasd4( n, i, d, z, delta, rho, sigma, work, info )
-    
+
 	! sigma, delta, work, info = lasd4(d,z,i,rho=1.0)
    	! Computes i-th square root of eigenvalue of rank one augmented diagonal matrix. Needed by SVD update procedure
-	
+
 	callstatement { i++; (*f2py_func)( &n, &i, d, z, delta, &rho, &sigma, work, &info); }
      callprotoargument int*, int*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, int*
-	
+
 	integer intent(hide),depend(d):: n = shape(d,0)
 	integer intent(in),depend(d),check(i>=0 && i<=(shape(d,0)-1)):: i
-	
+
 	<ftype2> dimension(n),intent(in)           :: d
 	<ftype2> dimension(n),intent(in),depend(n) :: z
-	
+
 	<ftype2> intent(out) :: sigma
 	<ftype2> dimension(n),intent(out),depend(n) :: delta
 	<ftype2> intent(in),optional:: rho = 1.0
-	
+
 	<ftype2> dimension(n),intent(out),depend(n) :: work
 	integer intent(out) :: info
 
@@ -989,7 +1315,7 @@ interface
 
      integer intent(in):: nrhs
      <ftype2c> intent(hide) :: b
-     
+
      <ftype2> intent(in),optional :: cond = -1.0
      integer intent(hide) :: r
      <ftype2> intent(hide) :: s
@@ -1024,7 +1350,7 @@ interface
      integer intent(in,out,out=j),dimension(n),depend(n) :: jptv
 
      ! LWORK is obtained by the query call
-     integer intent(in),depend(nrhs,m,n,minmn) :: lwork 
+     integer intent(in),depend(nrhs,m,n,minmn) :: lwork
      check(lwork>=MAX(minmn+3*n+1, 2*minmn+nrhs)) :: lwork
      <ftype2> dimension(lwork),intent(cache,hide),depend(lwork) :: work
      integer intent(out)::info
@@ -1121,7 +1447,7 @@ interface
 
    ! x,s,rank,info = dgelsd(a,b,lwork,size_iwork,cond=-1.0,overwrite_a=True,overwrite_b=True)
    ! Solve Minimize 2-norm(A * X - B).
-    
+
      callstatement (*f2py_func)(&m,&n,&nrhs,a,&m,b,&maxmn,s,&cond,&r,work,&lwork,iwork,&info)
      callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
 
@@ -1138,14 +1464,14 @@ interface
      <ftype2> intent(in),optional :: cond=-1.0
      integer intent(out,out=rank) :: r
      <ftype2> intent(out),dimension(minmn),depend(minmn) :: s
-	
+
      integer intent(in),check(lwork>=1) :: lwork
      ! Impossible to calculate lwork explicitly, need to obtain it from query call first
      ! Same for size_iwork
      <ftype2> dimension(lwork),intent(cache,hide),depend(lwork) :: work
 
      integer intent(in) :: size_iwork
-     integer intent(cache,hide),dimension(MAX(1,size_iwork)),depend(size_iwork) :: iwork	
+     integer intent(cache,hide),dimension(MAX(1,size_iwork)),depend(size_iwork) :: iwork
      integer intent(out)::info
 
    end subroutine <prefix2>gelsd
@@ -1154,7 +1480,7 @@ interface
 
    ! work,iwork,info = dgelsd_lwork(m,n,nrhs,cond=-1.0)
    ! Query for optimal lwork size
-    
+
      fortranname <prefix2>gelsd
      callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&s,&cond,&r,&work,&lwork,&iwork,&info)
      callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
@@ -1170,11 +1496,11 @@ interface
      <ftype2> intent(in),optional :: cond=-1.0
      integer intent(hide) :: r
      <ftype2> intent(hide) :: s
-	
+
      integer intent(in),optional :: lwork = -1
      <ftype2> intent(out) :: work
 
-     integer intent(out) :: iwork	
+     integer intent(out) :: iwork
      integer intent(out)::info
 
    end subroutine <prefix2>gelsd_lwork
@@ -1200,7 +1526,7 @@ interface
      <ftype2> intent(in),optional :: cond=-1.0
      integer intent(out,out=rank) :: r
      <ftype2> intent(out),dimension(minmn),depend(minmn) :: s
-	
+
      integer intent(in),check(lwork>=1||lwork==-1) :: lwork
      ! Impossible to calculate lwork explicitly, need to obtain it from query call first
      ! Same for size_rwork, size_iwork
@@ -1210,7 +1536,7 @@ interface
      <ftype2> intent(cache,hide),dimension(MAX(1,size_rwork)),depend(size_rwork) :: rwork
 
      integer intent(in) :: size_iwork
-     integer intent(cache,hide),dimension(MAX(1,size_iwork)),depend(size_iwork) :: iwork	
+     integer intent(cache,hide),dimension(MAX(1,size_iwork)),depend(size_iwork) :: iwork
      integer intent(out)::info
 
    end subroutine <prefix2c>gelsd
@@ -1235,12 +1561,12 @@ interface
      <ftype2> intent(in),optional :: cond=-1.0
      integer intent(hide) :: r
      <ftype2> intent(hide) :: s
-	
+
      integer intent(in),optional :: lwork = -1
      <ftype2c> intent(out) :: work
      <ftype2> intent(out) :: rwork
 
-     integer intent(out) :: iwork	
+     integer intent(out) :: iwork
      integer intent(out)::info
 
    end subroutine <prefix2c>gelsd_lwork
@@ -1826,6 +2152,57 @@ interface
      integer intent(out) :: info
 
    end subroutine <prefix>posv
+
+   subroutine <prefix>posvx(fact,n,nrhs,a,lda,af,ldaf,equed,s,b,ldb,x,ldx,rcond,ferr,berr,work,irwork,info,lower)
+
+   ! Solve A * X = B for Symmetric/Hermitian A
+   ! "expert" version of the ?POSV routines
+
+     callstatement (*f2py_func)(fact,(lower?"L":"U"),&n,&nrhs,a,&lda,af,&ldaf,equed,s,b,&ldb,x,&ldx,&rcond,ferr,berr,work,irwork,&info)
+     callprotoargument char*,char*,int*,int*,<ctype>*,int*,<ctype>*,int*,char*,<ctypereal>*,<ctype>*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctypereal>*,<ctype>*,<int,int,float,double>*,int*
+
+     character optional,intent(in):: fact = "E"
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+     integer depend(a),intent(hide):: n = shape(a,0)
+     integer depend(b),intent(hide):: nrhs = shape(b,1)
+     <ftype> dimension(n,n),check(shape(a,0)==shape(a,1)),intent(in,copy,out,out=a_s):: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     <ftype> optional,intent(in,out,out=lu),dimension(n,n),depend(n):: af
+     integer depend(af),intent(hide):: ldaf = shape(af,0)
+     character optional,intent(in,out):: equed = "Y"
+     <ftypereal> optional,dimension(n),depend(n),intent(in,out):: s
+     <ftype> dimension(n,nrhs),check(shape(b,0)==n),depend(n),intent(in,copy,out,out=b_s):: b
+     integer depend(b),intent(hide):: ldb = shape(b,0)
+     <ftype> dimension(n,nrhs),depend(n,nrhs),intent(out):: x
+     integer depend(x),intent(hide):: ldx = shape(x,0)
+     <ftypereal> intent(out):: rcond
+     <ftypereal> intent(out),dimension(nrhs),depend(nrhs):: ferr
+     <ftypereal> intent(out),dimension(nrhs),depend(nrhs):: berr
+     <ftype> intent(hide),dimension(<3*n,3*n,2*n,2*n>),depend(n):: work
+     <integer,integer,real,double precision> intent(hide),dimension(n),depend(n):: irwork
+     integer intent(out):: info
+
+   end subroutine <prefix>posvx
+
+   subroutine <prefix>pocon(uplo,n,a,lda,anorm,rcond,work,irwork,info)
+
+   ! Computes the 1- or inf- norm reciprocal condition number estimate
+   ! for a positive definite symmetric/hermitian matrix.
+
+     callstatement (*f2py_func)(uplo,&n,a,&lda,&anorm,&rcond,work,irwork,&info)
+     callprotoargument char*,int*,<ctype>*,int*,<ctypereal>*,<ctypereal>*,<ctype>*,<int,int,float,double>*,int*
+
+     character optional,intent(in):: uplo = 'U'
+     integer depend(a),intent(hide):: n = shape(a,0)
+     <ftype> dimension(n,n),check(shape(a,0)==shape(a,1)),intent(in):: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     <ftypereal> intent(in):: anorm
+     <ftypereal> intent(out):: rcond
+     <ftype> depend(n),dimension(<3*n,3*n,2*n,2*n>),intent(hide,cache):: work
+     <integer,integer,real, double precision> depend(n),dimension(n),intent(hide,cache):: irwork
+     integer intent(out):: info
+
+   end subroutine <prefix>pocon
 
    subroutine <prefix2>potrf(n,a,info,lower,clean)
 
@@ -3024,7 +3401,7 @@ subroutine ilaver(major, minor, patch)
     integer intent(out) :: minor
     integer intent(out) :: patch
 end subroutine ilaver
- 
+
 end interface
 
 end python module _flapack

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -150,6 +150,48 @@ All functions
    cgesv
    zgesv
 
+   sgesvx
+   dgesvx
+   cgesvx
+   zgesvx
+
+   sgecon
+   dgecon
+   cgecon
+   zgecon
+
+   ssysv
+   dsysv
+   csysv
+   zsysv
+
+   ssysv_lwork
+   dsysv_lwork
+   csysv_lwork
+   zsysv_lwork
+
+   ssysvx
+   dsysvx
+   csysvx
+   zsysvx
+
+   ssysvx_lwork
+   dsysvx_lwork
+   csysvx_lwork
+   zsysvx_lwork
+
+   chesv
+   zhesv
+
+   chesv_lwork
+   zhesv_lwork
+
+   chesvx
+   zhesvx
+
+   chesvx_lwork
+   zhesvx_lwork
+
    sgetrf
    dgetrf
    cgetrf
@@ -251,6 +293,16 @@ All functions
    dposv
    cposv
    zposv
+
+   sposvx
+   dposvx
+   cposvx
+   zposvx
+
+   spocon
+   dpocon
+   cpocon
+   zpocon
 
    spotrf
    dpotrf

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -609,6 +609,7 @@ class TestSolve(TestCase):
         b = [1, 2, 3]
         x = solve(a, b)
         assert_array_almost_equal(x.ravel(), b)
+        assert_(x.shape == (3,), 'Scalar_a_1D_b test returned wrong shape')
 
     def test_simple2(self):
         a = np.array([[1.80, 2.88, 2.05, -0.89],
@@ -662,6 +663,13 @@ class TestSolve(TestCase):
         x = solve(a.conj().T, b, assume_a='her', lower=True)
         assert_array_almost_equal(x, res)
 
+    def test_pos_and_sym(self):
+        A = np.arange(1,10).reshape(3, 3)
+        x = solve(np.tril(A)/9,np.ones(3), assume_a='pos')
+        assert_array_almost_equal(x, [9., 1.8, 1.])
+        x = solve(np.tril(A)/9,np.ones(3), assume_a='sym')
+        assert_array_almost_equal(x, [9., 1.8, 1.])
+
     def test_singularity(self):
         a = np.array([[1, 0, 0, 0, 0, 0, 1, 0, 1],
                       [1, 1, 1, 0, 0, 0, 1, 0, 1],
@@ -695,6 +703,13 @@ class TestSolve(TestCase):
         x = solve(a, b)
         assert_array_almost_equal(x, b)
 
+    def test_transposed_keyword(self):
+        A = np.arange(9).reshape(3, 3) + 1
+        x = solve(np.tril(A)/9,np.ones(3), transposed=1)
+        assert_array_almost_equal(x, [1.2, 0.2, 1])
+        x = solve(np.tril(A)/9,np.ones(3), transposed=0)
+        assert_array_almost_equal(x, [9, -5.4, -1.2])
+        
 
 class TestSolveTriangular(TestCase):
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -22,7 +22,7 @@ from numpy.testing import (TestCase, run_module_suite, assert_raises,
 from scipy.linalg import (solve, inv, det, lstsq, pinv, pinv2, pinvh, norm,
                           solve_banded, solveh_banded, solve_triangular,
                           solve_circulant, circulant, LinAlgError, block_diag,
-                          matrix_balance, solve_x)
+                          matrix_balance)
 
 from scipy.linalg.basic import LstsqLapackError
 from scipy.linalg._testutils import assert_no_overwrite
@@ -621,7 +621,7 @@ class TestSolve(TestCase):
                       [0.77, -13.28],
                       [-6.22, -6.21]])
 
-        x = solve_x(a, b)
+        x = solve(a, b)
         assert_array_almost_equal(x, np.array([[1., -1, 3, -5],
                                                [3, 2, 4, 1]]).T)
 
@@ -636,7 +636,7 @@ class TestSolve(TestCase):
                       [-5.75+25.31j, -2.15+30.19j],
                       [1.16+2.57j, -2.56+7.55j]])
 
-        x = solve_x(a, b)
+        x = solve(a, b)
         assert_array_almost_equal(x, np. array([[1+1.j, -1-2.j],
                                                 [2-3.j, 5+1.j],
                                                 [-4-5.j, -3+4.j],
@@ -656,10 +656,10 @@ class TestSolve(TestCase):
                         [3.-2j, 7-2j],
                         [-1+2j, -1+5j],
                         [1.-1j, 3-4j]])
-        x = solve_x(a, b, assume_a='her')
+        x = solve(a, b, assume_a='her')
         assert_array_almost_equal(x, res)
         # Also conjugate a and test for lower triangular data
-        x = solve_x(a.conj().T, b, assume_a='her', lower=True)
+        x = solve(a.conj().T, b, assume_a='her', lower=True)
         assert_array_almost_equal(x, res)
 
     def test_singularity(self):
@@ -673,14 +673,14 @@ class TestSolve(TestCase):
                       [1, 1, 1, 1, 1, 1, 1, 1, 1],
                       [1, 1, 1, 1, 1, 1, 1, 1, 1]])
         b = np.arange(9)[:, None]
-        assert_raises(LinAlgError, solve_x, a, b)
+        assert_raises(LinAlgError, solve, a, b)
 
     def test_ill_condition_warning(self):
         a = np.arange(1, 10).reshape(3, 3)
         b = np.array([[15], [15], [15]])
         with warnings.catch_warnings():
             warnings.simplefilter('error')
-            assert_raises(RuntimeWarning, solve_x, a, b)
+            assert_raises(RuntimeWarning, solve, a, b)
 
 
 class TestSolveTriangular(TestCase):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -586,7 +586,8 @@ class TestSolve(TestCase):
     def test_random_sym_complex(self):
         n = 20
         a = random([n, n])
-        # a  = a + 1j*random([n,n]) # XXX: with this the accuracy will be very low
+        # XXX: with the following addition the accuracy will be very low
+        a = a + 1j*random([n, n])
         for i in range(n):
             a[i, i] = abs(20*(.1+a[i, i]))
             for j in range(i):
@@ -603,125 +604,11 @@ class TestSolve(TestCase):
             x = solve(a, b, check_finite=False)
             assert_array_almost_equal(dot(a, x), b)
 
-
-class TestSolveX(TestCase):
-    def setUp(self):
-        np.random.seed(1234)
-
-    def test_20Feb04_bug(self):
-        a = [[1, 1], [1.0, 0]]  # ok
-        x0 = solve_x(a, [[1], [0j]])
-        assert_array_almost_equal(dot(a, x0), [[1], [0]])
-
-        # gives failure with clapack.zgesv(..,rowmajor=0)
-        a = [[1, 1], [1.2, 0]]
-        b = [[1], [0j]]
-        x0 = solve_x(a, b)
-        assert_array_almost_equal(dot(a, x0), [[1], [0]])
-
-    def test_simple(self):
-        a = [[1, 20], [-30, 4]]
-        for b in ([[1, 0], [0, 1]], [[1], [0]],
-                  [[2, 1], [-30, 4]]):
-            x = solve_x(a, b)
-            assert_array_almost_equal(dot(a, x), b)
-
-    def test_simple_sym(self):
-        a = [[2, 3], [3, 5]]
-        for lower in [0, 1]:
-            for b in ([[1, 0], [0, 1]], [[1], [0]]):
-                x = solve_x(a, b, assume_a='sym', lower=lower)
-                assert_array_almost_equal(dot(a, x), b)
-
-    def test_simple_pos(self):
-        a = [[2, 3], [3, 5]]
-        for lower in [0, 1]:
-            for b in ([[1, 0], [0, 1]], [[1], [0]]):
-                x = solve_x(a, b, assume_a='pos', lower=lower)
-                assert_array_almost_equal(dot(a, x), b)
-
-    def test_simple_sym_complex(self):
-        a = [[5, 2], [2, 4]]
-        for b in ([[1j], [0]],
-                  [[1j, 1j],
-                   [0, 2]],
-                  ):
-            x = solve_x(a, b, assume_a='sym')
-            assert_array_almost_equal(dot(a, x), b)
-
-    def test_simple_complex(self):
-        a = array([[5, 2], [2j, 4]], 'D')
-        for b in ([[1j], [0]],
-                  [[1j, 1j],
-                   [0, 2]],
-                  [[1], [0j]],
-                  array([[1], [0]], 'D'),
-                  ):
-            x = solve_x(a, b)
-            assert_array_almost_equal(dot(a, x), b)
-
-    def test_nils_20Feb04(self):
-        n = 2
-        A = random([n, n])+random([n, n])*1j
-        X = zeros((n, n), 'D')
-        Ainv = inv(A)
-        R = np.eye(n, dtype='D')
-        for i in arange(0, n):
-            r = R[:, [i]]
-            X[:, [i]] = solve_x(A, r)
-        assert_array_almost_equal(X, Ainv)
-
-    def test_random(self):
-        n = 20
-        a = random([n, n])
-        for i in range(n):
-            a[i, i] = 20*(.1+a[i, i])
-        for i in range(4):
-            b = random([n, 3])
-            x = solve_x(a, b)
-            assert_array_almost_equal(dot(a, x), b)
-
-    def test_random_complex(self):
-        n = 20
-        a = random([n, n]) + 1j * random([n, n])
-        for i in range(n):
-            a[i, i] = 20*(.1+a[i, i])
-        for i in range(2):
-            b = random([n, 3])
-            x = solve_x(a, b)
-            assert_array_almost_equal(dot(a, x), b)
-
-    def test_random_sym(self):
-        n = 20
-        a = random([n, n])
-        for i in range(n):
-            a[i, i] = abs(20*(.1+a[i, i]))
-            for j in range(i):
-                a[i, j] = a[j, i]
-        for i in range(4):
-            b = random([n,1])
-            x = solve_x(a, b, assume_a='pos')
-            assert_array_almost_equal(dot(a, x), b)
-
-    def test_random_sym_complex(self):
-        n = 20
-        a = random([n, n])
-        # a  = a + 1j*random([n,n]) # XXX: with this the accuracy will be very low
-        for i in range(n):
-            a[i, i] = abs(20*(.1+a[i, i]))
-            for j in range(i):
-                a[i, j] = conjugate(a[j, i])
-        b = random([n,1])+2j*random([n,1])
-        for i in range(2):
-            x = solve_x(a, b, assume_a='pos')
-            assert_array_almost_equal(dot(a, x), b)
-
-    def test_check_finite(self):
-        a = [[1, 20], [-30, 4]]
-        for b in ([[1, 0], [0, 1]], [[1], [0]],
-                  [[2, 1], [-30, 4]]):
-            x = solve_x(a, b, check_finite=False)
-            assert_array_almost_equal(dot(a, x), b)
+    def test_scalar_a_and_1D_b(self):
+        a = 1
+        b = [1, 2, 3]
+        x = solve(a, b)
+        assert_array_almost_equal(x.ravel(), b)
 
     def test_simple2(self):
         a = np.array([[1.80, 2.88, 2.05, -0.89],

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -682,6 +682,19 @@ class TestSolve(TestCase):
             warnings.simplefilter('error')
             assert_raises(RuntimeWarning, solve, a, b)
 
+    def test_empty_rhs(self):
+        a = np.eye(2)
+        b = [[], []]
+        x = solve(a, b)
+        assert_(x.size == 0, 'Returned array is not empty')
+        assert_(x.shape == (2, 0), 'Returned empty array shape is wrong')
+
+    def test_multiple_rhs(self):
+        a = np.eye(2)
+        b = np.random.rand(2, 3, 4)
+        x = solve(a, b)
+        assert_array_almost_equal(x, b)
+
 
 class TestSolveTriangular(TestCase):
 


### PR DESCRIPTION
**This is a rework of #6693** 

As briefly discussed in #6634, in this PR the ?GESVX routine of LAPACK is exposed for generic use. They are the so-called eXpert versions of the already existing ?GESV routine family which are used in `sp.linalg.solve` (also ?SYSVX, ?HESVX, ?POSVX, ?GECON, ?POCON) are also exposed).

The use case for these routines are many-fold 
- The most important case is to finally change the silent singular matrix handling. With the condition number and error estimates, a warning/error/msg can be emitted (needs-decision).
- Ill-conditioned matrices can be checked before inversion steps and nonsensical results can be avoided
- cond and rcond functions can now use estimates for comparison
- the lu factorization comes with a bonus (as is with ?GESV too but the API throws it away currently)
- The numerical accuracy is improved thanks to the balancing and iterative refinement (Lapack prefers the term `equilibration` for this particular instance). 
- The right inversion is currently a bit annoying, that is to say if we would like to compute, say, `A B⁻¹ `, then the user has to explicitly transpose the explicitly transposed equation to avoid using an explicit  `inv` whose use should be discouraged anyways: 
             ` x = scipy.linalg.solve(B.T,A.T).T` 
Since expert drivers come with a `trans` switch that can internally handle whether to solve the transposed or the regular equation, these routines avoid the `A.T` off-the-shelf. 

However, in the future, together with a low-level implicit transpose operation this can be handled rather more elegantly. Hence it can act like a forward or backward slash operator.

There will be a a few phases for this PR to come to fruition and I would really appreciate all the feedback from the wizards.
- [x] Make sure the f2py interface is correct. 
- [x] Make sure that the input-output arguments are handled correctly.
- [x] Make sure that the varying number of I/O arguments are not exposed to the user and the decision tree should not lead to confusion. In other words, if out of inexperience a user selects two conflicting keyword arguments (as it is extremely easy to fall into those traps) the behavior should be unambiguous override or err out directly. 
- [x] Make sure that the tests cover sufficient examples
- [x] Decide on the numerical bound formula to accept numerical singularity
- [x]  Decide on where this functionality goes into, existing `sp.linalg.solve` as an addition or a standalone solver and so on.

-----------------------

Example use-case, with warning

```
import numpy as np
import scipy.linalg as la
A = np.array([[1,2,3],[4,5,6],[7,8,9]],dtype=float)
b = np.array([[15,15,15]]).T
la.solve_x(A,b)

/usr/local/lib/python3.5/dist-packages/scipy/linalg/basic.py:224: 
RuntimeWarning: Ill-conditioned matrix detected.
Result is not guaranteed to be accurate.
Reciprocal condition number: 1.5419764230904951e-18

array([[-39.],
       [ 63.],
       [-24.]])
```

----------------------------------

Here are the speed comparison calling directly `sp.linalg.lapack.dgesvx(A,B)` and `sp.linalg.lapack.dgesv(A,B)` with 
```
A = np.random.rand(n, n)
B = np.random.rand(n, 3)
```

horizontal axis is `n` and vertical axis is seconds in the first one. In the second it's just the ratio of two curves. The numbers are averages of 25 runs for each n. (The blue one is the current DGESV and the other one is the proposed DGESVX)

![1](https://cloud.githubusercontent.com/assets/1303842/20037654/540d643e-a424-11e6-9d6b-860c47e7b5d6.png)
![2](https://cloud.githubusercontent.com/assets/1303842/20037655/56a1215e-a424-11e6-8569-b629fcd4cada.png)
