### PR TITLE
MAINT: special: simplify `loggamma` code

### DIFF
--- a/scipy/special/_loggamma.pxd
+++ b/scipy/special/_loggamma.pxd
@@ -1,216 +1,94 @@
-# An implementation of the principal branch of the logarithm of gamma
-# based on the paper "Computing the Principal Branch of log-Gamma"
-# (1997) by D.E.G. Hare. Also contains implementations of gamma and
-# 1/gamma which are easily computed from loggamma.
+# An implementation of the principal branch of the logarithm of
+# Gamma. Also contains implementations of Gamma and 1/Gamma which are
+# easily computed from log-Gamma.
 #
 # Author: Josh Wilson
 #
 # Distributed under the same license as Scipy.
-
-import cython
+#
+# References
+# ----------
+# [1] Hare, "Computing the Principal Branch of log-Gamma",
+#     Journal of Algorithms, 1997.
+#
+# [2] Julia,
+#     https://github.com/JuliaLang/julia/blob/master/base/special/gamma.jl
+#
+cimport cython
 cimport sf_error
-from libc.math cimport M_PI, ceil, sin, log
+from libc.math cimport M_PI, floor, fabs
 from _complexstuff cimport (
-    nan, zisnan, zabs, zlog, zlog1, zsin, zarg, zexp, zlog, zdiv
+    nan, zisnan, zabs, zlog, zlog1, zsin, zexp, zdiv, zpack
 )
 from _trig cimport sinpi
 
 cdef extern from "numpy/npy_math.h":
+    double npy_copysign(double x, double y) nogil
     int npy_signbit(double x) nogil
     double NPY_EULER
 
 cdef extern from "cephes.h":
     double zeta(double x, double q) nogil
 
-# log(2*pi)/2
-DEF HLOG2PI = 0.918938533204672742
-# Use the recurrence relation to make |z| bigger than smallz before
-# using the asymptotic series. See (4.3) for information about picking
-# it.
-DEF smallz = 16
-# Can use the asymptotic series in the left halfplane if the imaginary
-# part of z is above this value. The number 16 comes from the number
-# of digits of desired precision; see (4.4).
-DEF smallimag = 0.37*16
-# Relative tolerance for series expansions
-DEF tol = 2.2204460492503131e-16
+DEF TWOPI = 6.2831853071795864769252842 # 2*pi
+DEF LOGPI = 1.1447298858494001741434262 # log(pi)
+DEF HLOG2PI = 0.918938533204672742 # log(2*pi)/2
+DEF SMALLX = 7
+DEF SMALLY = 7
+DEF TOL = 2.2204460492503131e-16
 
 
 @cython.cdivision(True)
 cdef inline double complex loggamma(double complex z) nogil:
-    """
-    The strategy for computing loggamma is:
-    - If z is in a small strip around the negative axis, use the
-    reflection formula.
-    - If z has negative imaginary part, conjugate it and use the
-    relation loggamma(z*)* = loggamma(z)
-    - If z is close to the zero at 1, use a Taylor series.
-    - If z is close to 0 or 2, use a recurence relation and the Taylor
-    series at 1.
-    - If abs(z) is large, use an asymptotic series.
-    - Else use a recurrence relation to make z larger and then use
-    the asymptotic series.
-
-    """
-    cdef:
-        int conjugated = 0
-        int reflected = 0
-        int n
-        double rz = z.real
-        double iz = z.imag
-        double absz = zabs(z)
-        double m
-        double complex res = 0
-        double complex init, logarg, argterm, logterm
+    """Compute the principal branch of log-Gamma."""
+    cdef double tmp
 
     if zisnan(z):
-        return z
-    elif rz <= 0 and z == ceil(rz):
-        # Poles
+        return zpack(nan, nan)
+    elif z.real <= 0 and z == floor(z.real):
         sf_error.error("loggamma", sf_error.SINGULAR, NULL)
-        return nan + 1J*nan
-
-    if rz < 0 and -smallimag <= iz and iz <= smallimag:
-        # Reflection formula for loggamma; see Proposition 3.1. This
-        # part computes the terms log(pi/sin(pi*z)) + 2*s*k*pi*i. The
-        # strategy is:
-        # - If Im(z) < 0, conjugate z. This only negates the imaginary
-        # part of the result.
-        # - Compute pi/sin(pi*z).
-        # - Compute real and imaginary parts of log(pi/sin(pi*z)).
-        # - If Im(z) > 0, every point of the form m - 0.5 for even m
-        # between Re(z) and 0 contributes a factor of -2*pi*i. (These
-        # are the points where log(pi/sin(pi*z)) hits branch cuts.)
-        # - Because of rounding errors log(pi/sin(pi*z)) might cross
-        # the branch cut after z passes m - 0.5. Fix these cases.
-        # - If Im(z) = 0, use Corollary 3.3.
-        if iz > 0:
-            logarg = M_PI/sinpi(z)
-        elif iz == 0:
-            # If we don't treat this case seperately the imaginary
-            # part will come out to be -0j, which puts us on the wrong
-            # side of the branch cut in clog.
-            logarg = M_PI/sinpi(z.real)
-        else:
-            logarg = M_PI/sinpi(z.conjugate())
-        res += log(zabs(logarg))
-        argterm = zarg(logarg)
-
-        if iz == 0:
-            argterm += 2*M_PI*ceil(rz/2 - 1)
-        elif rz <= -0.5:
-            m = find_m(rz)
-            argterm += (m - 2)*M_PI
-            if rz > m - 1.5 and logarg.real < 0 and logarg.imag < 0:
-                # rz crossed the branch cut but due to rounding errors
-                # log(pi/sin(pi*z)) didn't.
-                argterm += 2*M_PI
-
-        if npy_signbit(iz) == 0:
-            res += 1j*argterm
-        else:
-            res -= 1j*argterm
-        z = 1 - z
-        rz, iz, absz = z.real, z.imag, zabs(z)
-        reflected = 1
-    if iz < 0:
-        # loggamma(z) = loggamma(z*)*
-        z = z.conjugate()
-        rz, iz, absz = z.real, z.imag, zabs(z)
-        conjugated = 1
-
-    if rz >= 0:
-        if zabs(z - 1) <= 0.5:
-            logterm = taylor(z)
-        elif zabs(z - 2) < 0.5:
-            # Use the recurrence relation and Taylor series around 1.
-            logterm = zlog1(z - 1) + taylor(z - 1)
-        elif absz < 0.5:
-            # Use the recurrence relation and Taylor series around 1.
-            logterm = -zlog(z) + taylor(z + 1)
-        elif absz >= smallz:
-            logterm = asymptotic_series(z)
-        else:
-            n = <int>ceil(smallz - rz)
-            init = asymptotic_series(z + n)
-            logterm = recurrence(z + n, init, n, -1)
+        return zpack(nan, nan)
+    elif z.real > SMALLX or fabs(z.imag) > SMALLY:
+        return loggamma_stirling(z)
+    elif zabs(z - 1) <= 0.5:
+        return loggamma_taylor(z)
+    elif zabs(z - 2) < 0.5:
+        # Recurrence relation and the Taylor series around 1
+        return zlog1(z - 1) + loggamma_taylor(z - 1)
+    elif z.real < 0.1:
+        # Reflection formula; see Proposition 3.1 in [1]
+        tmp = npy_copysign(TWOPI, z.imag)*floor(0.5*z.real + 0.25)
+        return zpack(LOGPI, tmp) - zlog(sinpi(z)) - loggamma(1 - z)
+    elif npy_signbit(z.imag) == 0:
+        # z.imag >= 0 but is not -0.0
+        return loggamma_recurrence(z)
     else:
-        # Case where creal(z) < 0 and cimag(z) > smallimag.
-        if absz >= smallz:
-            logterm = asymptotic_series(z)
-        else:
-            n = <int>ceil(smallz + rz)
-            init = asymptotic_series(z - n)
-            logterm = recurrence(z - n, init, n, 1)
-
-    if conjugated:
-        logterm = logterm.conjugate()
-    if reflected:
-        res -= logterm
-    else:
-        res = logterm
-    return res
-
-
-cdef inline double find_m(double x) nogil:
-    """
-    Find the smallest m = 2*j so that x <= m - 0.5. In theory m is an
-    integer, make it a double to avoid overflow.
-
-    """
-    cdef:
-        double m = ceil(x)
-        double hm = m/2
-
-    if hm == ceil(hm):
-        if m - x >= 0.5:
-            return m
-        else:
-            return m + 2
-    else:
-        return m + 1
-
-
-cdef inline int imag_sgncmp(double complex z1, double complex z2) nogil:
-    return 1 if z1.imag >= 0 and z2.imag < 0 else 0
-
+        return loggamma_recurrence(z.conjugate()).conjugate()
+        
 
 @cython.cdivision(True)
-cdef inline double complex recurrence(double complex z, double complex
-                                      init, int n, int s) nogil:
-    """
-    Forward recursion if s = 1 and backward recursion if s = -1. See
-    Proposition 2.2.
-
-    """
+cdef inline double complex loggamma_recurrence(double complex z) nogil:
+    """Backward recurrence relation; see Proposition 2.2 in [1]."""
     cdef:
-        int k = 0
+        int n = <int>(SMALLX - z.real) + 1
+        int signflips = 0
         int i
         double complex po, pn
 
-    if s == 1:
-        po = z
-        # Make sure pn is set even if we don't go through the loop.
-        pn = po
-        for i in range(1, n):
-            pn = po*(z + i)
-            k += imag_sgncmp(po, pn)
-            po = pn
-    else:
-        po = z - 1
-        pn = po
-        for i in range(2, n + 1):
-            pn = po*(z - i)
-            k += imag_sgncmp(po, pn)
-            po = pn
-    return init + s*(zlog(pn) + 2*k*M_PI*1J)
+    po = z + n - 1
+    pn = po
+    for i in range(2, n + 1):
+        pn = po*(z + n - i)
+        signflips += 1 if po.imag >=0 and pn.imag < 0 else 0
+        po = pn
+    return loggamma_stirling(z + n) - (zlog(pn) + signflips*TWOPI*1J)
 
 
 @cython.cdivision(True)
-cdef inline double complex asymptotic_series(double complex z) nogil:
+cdef inline double complex loggamma_stirling(double complex z) nogil:
     cdef:
         int n = 1
-        # The Bernoulli numbers B_2k for 1 <= k <= 16.
+        # Bernoulli numbers B_{2k} for 1 <= k <= 16
         double *bernoulli2k = [0.166666666666666667,
                                -0.0333333333333333333,
                                0.0238095238095238095,
@@ -229,21 +107,21 @@ cdef inline double complex asymptotic_series(double complex z) nogil:
                                -15116315767.0921569]
         double complex res = (z - 0.5)*zlog(z) - z + HLOG2PI
         double complex coeff = zdiv(1.0, z)
-        double complex rsqz = zdiv(coeff, z)
+        double complex rzz = zdiv(coeff, z)
         double complex term
 
     res += coeff*bernoulli2k[n-1]/(2*n*(2*n - 1))
     for n in range(2, 17):
-        coeff *= rsqz
+        coeff *= rzz
         term = coeff*bernoulli2k[n-1]/(2*n*(2*n - 1))
         res += term
-        if zabs(term) <= tol*zabs(res):
+        if zabs(term) <= TOL*zabs(res):
             break
     return res
 
 
 @cython.cdivision(True)
-cdef inline double complex taylor(double complex z) nogil:
+cdef inline double complex loggamma_taylor(double complex z) nogil:
     """
     Taylor series around z = 1. Derived from the Taylor series for the
     digamma function at 1:
@@ -269,14 +147,14 @@ cdef inline double complex taylor(double complex z) nogil:
         zfac *= -z
         coeff = zeta(n, 1)*zfac/n
         res += coeff
-        if zabs(coeff/res) < tol:
+        if zabs(coeff/res) < TOL:
             break
     return res
 
 
 cdef inline double complex cgamma(double complex z) nogil:
     """Compute Gamma(z) using loggamma."""
-    if z.real <= 0 and z == ceil(z.real):
+    if z.real <= 0 and z == floor(z.real):
         # Poles
         sf_error.error("gamma", sf_error.SINGULAR, NULL)
         return nan + 1J*nan
@@ -285,7 +163,7 @@ cdef inline double complex cgamma(double complex z) nogil:
 
 cdef inline double complex crgamma(double complex z) nogil:
     """Compute 1/Gamma(z) using loggamma."""
-    if z.real <= 0 and z == ceil(z.real):
+    if z.real <= 0 and z == floor(z.real):
         # Zeros at 0, -1, -2, ...
         return 0
     return zexp(-loggamma(z))

--- a/scipy/special/_precompute/loggamma.py
+++ b/scipy/special/_precompute/loggamma.py
@@ -1,0 +1,46 @@
+"""Precompute series coefficients for log-Gamma."""
+from __future__ import division, print_function, absolute_import
+
+try:
+    import mpmath
+except ImportError:
+    pass
+
+
+def stirling_series(N):
+    coeffs = []
+    with mpmath.workdps(100):
+        for n in range(1, N + 1):
+            coeffs.append(mpmath.bernoulli(2*n)/(2*n*(2*n - 1)))
+    return coeffs
+
+
+def taylor_series_at_1(N):
+    coeffs = []
+    with mpmath.workdps(100):
+        coeffs.append(-mpmath.euler)
+        for n in range(2, N + 1):
+            coeffs.append((-1)**n*mpmath.zeta(n)/n)
+    return coeffs
+
+
+def main():
+    print(__doc__)
+    print()
+    stirling_coeffs = [mpmath.nstr(x, 20, min_fixed=0, max_fixed=0)
+                       for x in stirling_series(16)]
+    taylor_coeffs = [mpmath.nstr(x, 20, min_fixed=0, max_fixed=0)
+                     for x in taylor_series_at_1(16)]
+    print("Stirling series coefficients")
+    print("----------------------------")
+    print("\n".join(stirling_coeffs))
+    print()
+    print("Taylor series coefficients")
+    print("--------------------------")
+    print("\n".join(taylor_coeffs))
+    print()
+
+
+if __name__ == '__main__':
+    main()
+    

--- a/scipy/special/_trig.pxd
+++ b/scipy/special/_trig.pxd
@@ -2,70 +2,158 @@
 # of these functions are integral (and thus better representable in
 # floating point), it's possible to compute them with greater accuracy
 # than sin(z), cos(z).
+#
+from libc.math cimport sin, cos, sinh, cosh, exp, fabs, ceil, M_PI
+from _complexstuff cimport number_t, double_complex, zpack
 
-from libc.math cimport ceil, floor, M_PI
-from _complexstuff cimport number_t, zreal, zsin, zcos, zabs
+cdef extern from "numpy/npy_math.h":
+    double npy_copysign(double x, double y) nogil
+    double NPY_INFINITY
 
-DEF tol = 2.220446049250313e-16
+DEF TOL = 2.220446049250313e-16
 
 
-cdef inline number_t sinpi(number_t z) nogil:
-    """Compute sin(pi*z) by shifting z to (-0.5, 0.5]."""
+cdef inline double dsinpi(double x) nogil:
+    """Compute sin(pi*x) for real arguments."""
     cdef:
-        double p = ceil(zreal(z))
+        double p = ceil(x)
         double hp = p/2
 
-    # Make p the even integer closest to z
+    # Make p the even integer closest to x
     if hp != ceil(hp):
         p -= 1
-    # zn.real is in (-1, 1]
-    z -= p
-    # Reflect zn.real in (0.5, 1] to [0, 0.5).
-    if zreal(z) > 0.5:
-        z = 1 - z
-    # Reflect zn.real in (-1, -0.5) to (-0.5, 0)
-    if zreal(z) < -0.5:
-        z = -1 - z
-    return zsin(M_PI*z)
+    # x is in (-1, 1]
+    x -= p
+    # Reflect x in (0.5, 1] to [0, 0.5).
+    if x > 0.5:
+        x = 1 - x
+    # Reflect x in (-1, -0.5) to (-0.5, 0)
+    if x < -0.5:
+        x = -1 - x
+    return sin(M_PI*x)
 
 
-cdef inline number_t cospi(number_t z) nogil:
-    """Compute cos(pi*z) by shifting z to (-1, 1]."""
-    cdef:
-        double p = ceil(zreal(z))
-        double hp = p/2
-
-    # Make p the even integer closest to z
-    if hp != ceil(hp):
-        p -= 1
-    # zn.real is in (-1, 1].
-    z -= p
-    if zabs(z - 0.5) < 0.2:
-        return cospi_taylor(z)
-    elif zabs(z + 0.5) < 0.2:
-        return cospi_taylor(-z)
-    else:
-        return zcos(M_PI*z)
-
-
-cdef inline number_t cospi_taylor(number_t z) nogil:
+cdef inline double cospi_taylor(double x) nogil:
     """
-    Taylor series for cos(pi*z) around z = 0.5. Since the root is
+    Taylor series for cos(pi*x) around x = 0.5. Since the root is
     exactly representable in double precision we get gains over
     just using cos(z) here.
 
     """
     cdef:
         int n
-        number_t zz, term, res
+        double xx, term, res
 
-    z = M_PI*(z - 0.5)
-    zz = z*z
-    term = -z
+    x = M_PI*(x - 0.5)
+    xx = x*x
+    term = -x
     res = term
     for n in range(1, 20):
-        term *= -zz/((2*n + 1)*(2*n))
+        term *= -xx/((2*n + 1)*(2*n))
         res += term
-        if zabs(term) <= tol*zabs(res):
+        if fabs(term) <= TOL*fabs(res):
             break
     return res
+
+
+cdef inline double dcospi(double x) nogil:
+    """Compute cos(pi*x) for real arguments."""
+    cdef:
+        double p = ceil(x)
+        double hp = p/2
+
+    # Make p the even integer closest to x
+    if hp != ceil(hp):
+        p -= 1
+    # x is in (-1, 1].
+    x -= p
+    if fabs(x - 0.5) < 0.2:
+        return cospi_taylor(x)
+    elif fabs(x + 0.5) < 0.2:
+        return cospi_taylor(-x)
+    else:
+        return cos(M_PI*x)
+
+
+cdef inline double complex csinpi(double complex z) nogil:
+    """Compute sin(pi*z) for complex arguments."""
+    cdef:
+        double x = z.real
+        double piy = M_PI*z.imag
+        double abspiy = fabs(piy)
+        double sinpix = sinpi(x)
+        double cospix = cospi(x)
+        double exphpiy, coshfac, sinhfac
+
+    if abspiy < 700:
+        return zpack(sinpix*cosh(piy), cospix*sinh(piy))
+
+    # Have to be careful--sinh/cosh could overflow while cos/sin are
+    # small. At this large of values
+    #
+    # cosh(y) ~ exp(y)/2
+    # sinh(y) ~ sgn(y)*exp(y)/2
+    #
+    # so we can compute exp(y/2), scale by the right factor of sin/cos
+    # and then multiply by exp(y/2) to avoid overflow.
+    exphpiy = exp(abspiy/2)
+    if exphpiy == NPY_INFINITY:
+        if sinpix == 0:
+            # Preserve the sign of zero
+            coshfac = npy_copysign(0.0, sinpix)
+        else:
+            coshfac = npy_copysign(NPY_INFINITY, sinpix)
+        if cospix == 0:
+            sinhfac = npy_copysign(0.0, cospix)
+        else:
+            sinhfac = npy_copysign(NPY_INFINITY, cospix)
+        return zpack(coshfac, sinhfac)
+
+    coshfac = 0.5*sinpix*exphpiy
+    sinhfac = 0.5*cospix*exphpiy
+    return zpack(coshfac*exphpiy, sinhfac*exphpiy)
+
+
+cdef inline double complex ccospi(double complex z) nogil:
+    """Compute cos(pi*z) for complex arguments."""
+    cdef:
+        double x = z.real
+        double piy = M_PI*z.imag
+        double abspiy = fabs(piy)
+        double sinpix = sinpi(x)
+        double cospix = cospi(x)
+        double exphpiy, coshfac, sinhfac
+
+    if abspiy < 700:
+        return zpack(cospix*cosh(piy), -sinpix*sinh(piy))
+
+    # See csinpi(z) for an idea of what's going on here
+    exphpiy = exp(abspiy/2)
+    if exphpiy == NPY_INFINITY:
+        if sinpix == 0:
+            coshfac = npy_copysign(0.0, cospix)
+        else:
+            coshfac = npy_copysign(NPY_INFINITY, cospix)
+        if cospix == 0:
+            sinhfac = npy_copysign(0.0, sinpix)
+        else:
+            sinhfac = npy_copysign(NPY_INFINITY, sinpix)
+        return zpack(coshfac, sinhfac)
+
+    coshfac = 0.5*cospix*exphpiy
+    sinhfac = 0.5*sinpix*exphpiy
+    return zpack(coshfac*exphpiy, sinhfac*exphpiy)
+
+
+cdef inline number_t sinpi(number_t z) nogil:
+    if number_t is double:
+        return dsinpi(z)
+    else:
+        return csinpi(z)
+
+
+cdef inline number_t cospi(number_t z) nogil:
+    if number_t is double:
+        return dcospi(z)
+    else:
+        return ccospi(z)

--- a/scipy/special/_ufuncs.pyx
+++ b/scipy/special/_ufuncs.pyx
@@ -1171,12 +1171,12 @@ cdef void loop_i_ddddd_dd_As_fffff_ff(char **args, np.npy_intp *dims, np.npy_int
         op1 += steps[6]
     sf_error.check_fpe(func_name)
 
-from _trig cimport cospi as _func_cospi
-ctypedef double _proto_cospi_double__t(double) nogil
-cdef _proto_cospi_double__t *_proto_cospi_double__t_var = &_func_cospi[double]
-from _trig cimport cospi as _func_cospi
-ctypedef double complex _proto_cospi_double_complex__t(double complex) nogil
-cdef _proto_cospi_double_complex__t *_proto_cospi_double_complex__t_var = &_func_cospi[double_complex]
+from _trig cimport dcospi as _func_dcospi
+ctypedef double _proto_dcospi_t(double) nogil
+cdef _proto_dcospi_t *_proto_dcospi_t_var = &_func_dcospi
+from _trig cimport ccospi as _func_ccospi
+ctypedef double complex _proto_ccospi_t(double complex) nogil
+cdef _proto_ccospi_t *_proto_ccospi_t_var = &_func_ccospi
 from _ellip_harm cimport ellip_harmonic as _func_ellip_harmonic
 ctypedef double _proto_ellip_harmonic_t(double, double, int, int, double, double, double) nogil
 cdef _proto_ellip_harmonic_t *_proto_ellip_harmonic_t_var = &_func_ellip_harmonic
@@ -1198,12 +1198,12 @@ cdef extern from "_ufuncs_defs.h":
     cdef double _func_lgam1p "lgam1p"(double) nogil
 cdef extern from "_ufuncs_defs.h":
     cdef double _func_log1pmx "log1pmx"(double) nogil
-from _trig cimport sinpi as _func_sinpi
-ctypedef double _proto_sinpi_double__t(double) nogil
-cdef _proto_sinpi_double__t *_proto_sinpi_double__t_var = &_func_sinpi[double]
-from _trig cimport sinpi as _func_sinpi
-ctypedef double complex _proto_sinpi_double_complex__t(double complex) nogil
-cdef _proto_sinpi_double_complex__t *_proto_sinpi_double_complex__t_var = &_func_sinpi[double_complex]
+from _trig cimport dsinpi as _func_dsinpi
+ctypedef double _proto_dsinpi_t(double) nogil
+cdef _proto_dsinpi_t *_proto_dsinpi_t_var = &_func_dsinpi
+from _trig cimport csinpi as _func_csinpi
+ctypedef double complex _proto_csinpi_t(double complex) nogil
+cdef _proto_csinpi_t *_proto_csinpi_t_var = &_func_csinpi
 from _spherical_bessel cimport spherical_in_real as _func_spherical_in_real
 ctypedef double _proto_spherical_in_real_t(long, double) nogil
 cdef _proto_spherical_in_real_t *_proto_spherical_in_real_t_var = &_func_spherical_in_real
@@ -1931,13 +1931,13 @@ ufunc__cospi_types[4] = <char>NPY_CFLOAT
 ufunc__cospi_types[5] = <char>NPY_CFLOAT
 ufunc__cospi_types[6] = <char>NPY_CDOUBLE
 ufunc__cospi_types[7] = <char>NPY_CDOUBLE
-ufunc__cospi_ptr[2*0] = <void*>_func_cospi[double]
+ufunc__cospi_ptr[2*0] = <void*>_func_dcospi
 ufunc__cospi_ptr[2*0+1] = <void*>(<char*>"_cospi")
-ufunc__cospi_ptr[2*1] = <void*>_func_cospi[double]
+ufunc__cospi_ptr[2*1] = <void*>_func_dcospi
 ufunc__cospi_ptr[2*1+1] = <void*>(<char*>"_cospi")
-ufunc__cospi_ptr[2*2] = <void*>_func_cospi[double_complex]
+ufunc__cospi_ptr[2*2] = <void*>_func_ccospi
 ufunc__cospi_ptr[2*2+1] = <void*>(<char*>"_cospi")
-ufunc__cospi_ptr[2*3] = <void*>_func_cospi[double_complex]
+ufunc__cospi_ptr[2*3] = <void*>_func_ccospi
 ufunc__cospi_ptr[2*3+1] = <void*>(<char*>"_cospi")
 ufunc__cospi_data[0] = &ufunc__cospi_ptr[2*0]
 ufunc__cospi_data[1] = &ufunc__cospi_ptr[2*1]
@@ -2137,13 +2137,13 @@ ufunc__sinpi_types[4] = <char>NPY_CFLOAT
 ufunc__sinpi_types[5] = <char>NPY_CFLOAT
 ufunc__sinpi_types[6] = <char>NPY_CDOUBLE
 ufunc__sinpi_types[7] = <char>NPY_CDOUBLE
-ufunc__sinpi_ptr[2*0] = <void*>_func_sinpi[double]
+ufunc__sinpi_ptr[2*0] = <void*>_func_dsinpi
 ufunc__sinpi_ptr[2*0+1] = <void*>(<char*>"_sinpi")
-ufunc__sinpi_ptr[2*1] = <void*>_func_sinpi[double]
+ufunc__sinpi_ptr[2*1] = <void*>_func_dsinpi
 ufunc__sinpi_ptr[2*1+1] = <void*>(<char*>"_sinpi")
-ufunc__sinpi_ptr[2*2] = <void*>_func_sinpi[double_complex]
+ufunc__sinpi_ptr[2*2] = <void*>_func_csinpi
 ufunc__sinpi_ptr[2*2+1] = <void*>(<char*>"_sinpi")
-ufunc__sinpi_ptr[2*3] = <void*>_func_sinpi[double_complex]
+ufunc__sinpi_ptr[2*3] = <void*>_func_csinpi
 ufunc__sinpi_ptr[2*3+1] = <void*>(<char*>"_sinpi")
 ufunc__sinpi_data[0] = &ufunc__sinpi_ptr[2*0]
 ufunc__sinpi_data[1] = &ufunc__sinpi_ptr[2*1]

--- a/scipy/special/generate_ufuncs.py
+++ b/scipy/special/generate_ufuncs.py
@@ -313,8 +313,8 @@ _spherical_jn_d -- spherical_jn_d_real: ld->d, spherical_jn_d_complex: lD->D -- 
 _spherical_in_d -- spherical_in_d_real: ld->d, spherical_in_d_complex: lD->D -- _spherical_bessel.pxd
 _spherical_kn_d -- spherical_kn_d_real: ld->d, spherical_kn_d_complex: lD->D -- _spherical_bessel.pxd
 loggamma -- loggamma: D->D                                 -- _loggamma.pxd
-_sinpi -- sinpi[double]: d->d, sinpi[double_complex]: D->D -- _trig.pxd
-_cospi -- cospi[double]: d->d, cospi[double_complex]: D->D -- _trig.pxd
+_sinpi -- dsinpi: d->d, csinpi: D->D                       -- _trig.pxd
+_cospi -- dcospi: d->d, ccospi: D->D                       -- _trig.pxd
 _lgam1p -- lgam1p: d->d                                    -- cephes.h
 _lanczos_sum_expg_scaled -- lanczos_sum_expg_scaled: d->d  -- cephes.h
 _log1pmx -- log1pmx: d->d                                  -- cephes.h

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -967,12 +967,14 @@ class TestSystematic(with_metaclass(DecoratorMeta, object)):
         # an rdiff of ~6e-16. Neither the Taylor series nor the system
         # cosine are accurate enough here.
         eps = np.finfo(float).eps
-        assert_mpmath_equal(_cospi, mpmath.cospi,
-                            [Arg()], rtol=4*eps)
+        assert_mpmath_equal(_cospi,
+                            mpmath.cospi,
+                            [Arg()], nan_ok=False, rtol=4*eps)
 
     def test_cospi_complex(self):
-        assert_mpmath_equal(_cospi, mpmath.cospi,
-                            [ComplexArg()], rtol=1e-13)
+        assert_mpmath_equal(_cospi,
+                            mpmath.cospi,
+                            [ComplexArg()], nan_ok=False, rtol=1e-13)
 
     def test_digamma(self):
         assert_mpmath_equal(sc.digamma,
@@ -1735,11 +1737,11 @@ class TestSystematic(with_metaclass(DecoratorMeta, object)):
     def test_sinpi(self):
         eps = np.finfo(float).eps
         assert_mpmath_equal(_sinpi, mpmath.sinpi,
-                            [Arg()], rtol=2*eps)
+                            [Arg()], nan_ok=False, rtol=2*eps)
 
     def test_sinpi_complex(self):
         assert_mpmath_equal(_sinpi, mpmath.sinpi,
-                            [ComplexArg()], rtol=2e-14)
+                            [ComplexArg()], nan_ok=False, rtol=2e-14)
 
     def test_shi(self):
         def shi(x):

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -345,8 +345,7 @@ def test_loggamma_taylor1():
     # Make sure there isn't a big jump in accuracy when we move from
     # using the Taylor series to using the recurrence relation.
 
-    pts = [-0.5, 0.5j, -0.5j, 0.5, 1 + 0.5j, 1 - 0.5j, 1.5, 2 - 0.5j,
-           2 + 0.5j, 2.5]
+    pts = [1 + 0.1j, 1 - 0.1j, 1.1, 0.9, 2 - 0.1j, 2 + 0.1j, 2.1, 1.9]
     dataset = []
     for p in pts:
         for eps in [1e-6, -1e-6, 1e-6j, -1e-6j]:
@@ -361,10 +360,10 @@ def test_loggamma_taylor1():
 def test_loggamma_taylor2():
     # Test around the zeros at z = 1, 2.
 
-    dx = np.r_[-np.logspace(-1, -16, 10), np.logspace(-16, -1, 10)]
-    dy = dx.copy()
-    dx, dy = np.meshgrid(dx, dy)
-    dz = dx + 1j*dy
+    r = np.r_[-np.logspace(-1, -16, 10), np.logspace(-16, -1, 10)]
+    theta = np.linspace(0, 2*np.pi, 20)
+    r, theta = np.meshgrid(r, theta)
+    dz = r*(np.cos(theta) + 1j*np.sin(theta))
     z = np.r_[1 + dz, 2 + dz].flatten()
     dataset = []
     for z0 in z:

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1658,15 +1658,17 @@ class TestSystematic(with_metaclass(DecoratorMeta, object)):
                             param_filter=param_filter)
         
     def test_loggamma(self):
+        def mpmath_loggamma(z):
+            try:
+                res = mpmath.loggamma(z)
+            except ValueError:
+                res = complex(np.nan, np.nan)
+            return res
+        
         assert_mpmath_equal(sc.loggamma,
-                            exception_to_nan(lambda x: mpmath.loggamma(x, **HYPERKW)),
-                            [Arg()], rtol=1e-13)
-
-    def test_loggamma_complex(self):
-        assert_mpmath_equal(sc.loggamma,
-                            exception_to_nan(lambda z: mpmath.loggamma(z, **HYPERKW)),
-                            [ComplexArg()], nan_ok=False, distinguish_nan_and_inf=False,
-                            rtol=1e-13)
+                            mpmath_loggamma,
+                            [ComplexArg()], nan_ok=False,
+                            distinguish_nan_and_inf=False, rtol=1e-13)
 
     @knownfailure_overridable()
     def test_pcfd(self):

--- a/scipy/special/tests/test_trig.py
+++ b/scipy/special/tests/test_trig.py
@@ -1,0 +1,48 @@
+import numpy as np
+from numpy.testing import assert_equal, assert_allclose
+
+from scipy.special._ufuncs import _sinpi as sinpi
+from scipy.special._ufuncs import _cospi as cospi
+
+
+def test_integer_real_part():
+    x = np.arange(-100, 101)
+    y = np.hstack((-np.linspace(310, -30, 10), np.linspace(-30, 310, 10)))
+    x, y = np.meshgrid(x, y)
+    z = x + 1j*y
+    # In the following we should be *exactly* right
+    res = sinpi(z)
+    assert_equal(res.real, 0.0)
+    res = cospi(z)
+    assert_equal(res.imag, 0.0)
+
+
+def test_half_integer_real_part():
+    x = np.arange(-100, 101) + 0.5
+    y = np.hstack((-np.linspace(310, -30, 10), np.linspace(-30, 310, 10)))
+    x, y = np.meshgrid(x, y)
+    z = x + 1j*y
+    # In the following we should be *exactly* right
+    res = sinpi(z)
+    assert_equal(res.imag, 0.0)
+    res = cospi(z)
+    assert_equal(res.real, 0.0)
+
+
+def test_intermediate_overlow():
+    # Make sure we avoid overflow in situations where cosh/sinh would
+    # overflow but the product with sin/cos would not
+    sinpi_pts = [complex(1 + 1e-14, 227),
+                 complex(1e-35, 250),
+                 complex(1e-301, 445)]
+    # Data generated with mpmath
+    sinpi_std = [complex(-8.113438309924894e+295, -np.inf),
+                 complex(1.9507801934611995e+306, np.inf),
+                 complex(2.205958493464539e+306, np.inf)]
+    for p, std in zip(sinpi_pts, sinpi_std):
+        assert_allclose(sinpi(p), std)
+
+    # Test for cosine, less interesting because cos(0) = 1.
+    p = complex(0.5 + 1e-14, 227)
+    std = complex(-8.113438309924894e+295, -np.inf)
+    assert_allclose(cospi(p), std)


### PR DESCRIPTION
- Large hunks of code unnecessarily messing with branch cuts were eliminated.
- Internal functions `_sinpi` and `_cospi` are improved; these changes were necessary to achieve less messing with branch cuts.
- Decision boundaries for different algorithms simplified.
- Precomputed coefficients used for the Taylor series--it's faster than calling `zeta` a bunch of times.
- Implementation of the recurrence relation is simplified.

Still need to do more work to get gains in accuracy, but I think that this time I'll actually be able to read what I wrote six months from now.