### PR TITLE
BLD: increase minimum Cython version to 0.23.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ before_install:
   - export LD_LIBRARY_PATH=$HOME/.local/lib
   # End install gmpy2 dependencies
   # Speed up install by not compiling Cython
-  - travis_retry pip install --install-option="--no-cython-compile" Cython==0.22
+  - travis_retry pip install --install-option="--no-cython-compile" Cython==0.23.4
   - travis_retry pip install $NUMPYSPEC
   - travis_retry pip install nose mpmath argparse Pillow codecov
   - travis_retry pip install --upgrade pip setuptools

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -35,7 +35,7 @@ SciPy requires the following software installed for your platform:
 
 __ http://www.python.org
 
-2) NumPy__ >= 1.7.1
+2) NumPy__ >= 1.8.2
 
 __ http://www.numpy.org/
 
@@ -49,7 +49,7 @@ __ http://sphinx-doc.org/
 
 5) If you want to build SciPy master or other unreleased version from source
    (Cython-generated C sources are included in official releases):
-   Cython__ >= 0.22
+   Cython__ >= 0.23.4
 
 __ http://cython.org/
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 dependencies:
   override:
     - sudo apt-get install libatlas-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libfreetype6-dev libpng-dev zlib1g-dev texlive-fonts-recommended
-    - pip install -q --install-option="--no-cython-compile" Cython==0.22
+    - pip install -q --install-option="--no-cython-compile" Cython==0.23.4
     - pip install -q numpy
     - pip install -q nose mpmath argparse Pillow codecov matplotlib Sphinx==1.2.3
     - git submodule init

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -54,8 +54,8 @@ def process_pyx(fromfile, tofile):
     try:
         from Cython.Compiler.Version import version as cython_version
         from distutils.version import LooseVersion
-        if LooseVersion(cython_version) < LooseVersion('0.22'):
-            raise Exception('Building SciPy requires Cython >= 0.22')
+        if LooseVersion(cython_version) < LooseVersion('0.23.4'):
+            raise Exception('Building SciPy requires Cython >= 0.23.4')
 
     except ImportError:
         pass


### PR DESCRIPTION
This is due to gh-6763, which uses a lambda function with
fused types that isn't supported in earlier Cython versions.

Also fix a forgotten min version for NumPy in INSTALL.txt