### PR TITLE
MAINT: Fix a potential problem in nn_chain linkage algorithm

### DIFF
--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -798,7 +798,14 @@ def nn_chain(double[:] dists, int n, int method):
         # Go through chain of neighbors until two mutual neighbors are found.
         while True:
             x = cluster_chain[chain_length - 1]
-            current_min = NPY_INFINITYF
+
+            # We want to prefer the previous element in the chain as the
+            # minimum, to avoid potentially going in cycles.
+            if chain_length > 1:
+                y = cluster_chain[chain_length - 2]
+                current_min = D[condensed_index(n, x, y)]
+            else:
+                current_min = NPY_INFINITYF
 
             for i in range(n):
                 if size[i] == 0 or x == i:
@@ -817,6 +824,10 @@ def nn_chain(double[:] dists, int n, int method):
 
         # Merge clusters x and y and pop them from stack.
         chain_length -= 2
+
+        # This is a convention used in fastcluster.
+        if x > y:
+            x, y = y, x
 
         # get the original numbers of points in clusters x and y
         nx = size[x]


### PR DESCRIPTION
Motivated by #6788 

Theoretically the previous algorithm could go in cycles, but I wasn't able to find an example data to trigger this. It seems nontrivial or maybe it even can't happen (but I can't prove it either). So I just followed the advice in the paper (by D. Müllner) which suggest to account for it. This change certainly can't violate correctness.

Another change is to make the algorithm follow the convention from fastcluster, again doesn't violate the correctness, but make results identical (if floating point computations works exactly the same) with fastcluster package.

I guess I will wait for couple of days and merge myself, if no one comments.