### PR TITLE
MAINT: fix circular import after moving functions out of misc

### DIFF
--- a/scipy/misc/tests/test_common.py
+++ b/scipy/misc/tests/test_common.py
@@ -1,12 +1,11 @@
 from __future__ import division, print_function, absolute_import
 
-import numpy as np
-from numpy.testing import (assert_array_equal, assert_almost_equal,
-                           assert_array_almost_equal, assert_equal, assert_)
+from numpy.testing import assert_equal, assert_
 
 from scipy.misc import pade, logsumexp, face, ascent
 from scipy.special import logsumexp as sc_logsumexp
 from scipy.interpolate import pade as i_pade
+
 
 def test_logsumexp():
     # make sure logsumexp can be imported from either scipy.misc or

--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -3,19 +3,19 @@
 from __future__ import division, print_function, absolute_import
 
 import warnings
+import math
 
 import numpy
-from numpy import (atleast_1d, poly, polyval, roots, real, asarray, allclose,
+import numpy as np
+from numpy import (atleast_1d, poly, polyval, roots, real, asarray,
                    resize, pi, absolute, logspace, r_, sqrt, tan, log10,
                    arctan, arcsinh, sin, exp, cosh, arccosh, ceil, conjugate,
-                   zeros, sinh, append, concatenate, prod, ones, array)
-from numpy import mintypecode
-import numpy as np
-from scipy import special, optimize
-from scipy.special import comb
-from scipy.misc import factorial
+                   zeros, sinh, append, concatenate, prod, ones, array,
+                   mintypecode)
 from numpy.polynomial.polynomial import polyval as npp_polyval
-import math
+
+from scipy import special, optimize
+from scipy.special import comb, factorial
 
 
 __all__ = ['findfreqs', 'freqs', 'freqz', 'tf2zpk', 'zpk2tf', 'normalize',

--- a/scipy/sparse/linalg/matfuncs.py
+++ b/scipy/sparse/linalg/matfuncs.py
@@ -16,7 +16,7 @@ import math
 
 import numpy as np
 
-import scipy.misc
+import scipy.special
 from scipy.linalg.basic import solve, solve_triangular
 
 from scipy.sparse.base import isspmatrix
@@ -813,7 +813,7 @@ def _ell(A, m):
 
     # The c_i are explained in (2.2) and (2.6) of the 2005 expm paper.
     # They are coefficients of terms of a generating function series expansion.
-    choose_2p_p = scipy.misc.comb(2*p, p, exact=True)
+    choose_2p_p = scipy.special.comb(2*p, p, exact=True)
     abs_c_recip = float(choose_2p_p * math.factorial(2*p + 1))
 
     # This is explained after Eq. (1.2) of the 2009 expm paper.

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -58,7 +58,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
 
     Examples
     --------
-    >>> from scipy.misc import logsumexp
+    >>> from scipy.special import logsumexp
     >>> a = np.arange(10)
     >>> np.log(np.sum(np.exp(a)))
     9.4586297444267107


### PR DESCRIPTION
``import scipy.special`` will fail on master right now.