### PR TITLE
ENH: stats: Histogram distribution

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -169,6 +169,7 @@ John Draper for bug fixes.
 Alvaro Sanchez-Gonzalez for axis-dependent modes in multidimensional filters.
 Alessandro Pietro Bardelli for improvements to pdist/cdist and to related tests.
 Jonathan T. Siebert for bug fixes.
+Thomas Keck for adding new scipy.stats distributions used in HEP
 
 Institutions
 ------------

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -16,6 +16,7 @@ Each univariate distribution is an instance of a subclass of `rv_continuous`
 
    rv_continuous
    rv_discrete
+   rv_histogram
 
 Continuous distributions
 ========================

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5263,8 +5263,127 @@ class argus_gen(rv_continuous):
 argus = argus_gen(name='argus', longname="An Argus Function", a=0.0, b=1.0)
 
 
+class rv_histogram(rv_continuous):
+    """
+    Generates a distribution given by a histogram.
+    This is useful to generate a template distribution from a binned datasample.
+
+    %(before_notes)s
+
+    Notes
+    -----
+    There are no additional shape parameters except for the loc and scale.
+    The pdf is defined as a stepwise function from the provided histogram
+    The cdf is a linear interpolation of the pdf.
+
+    %(after_notes)s
+
+    Examples
+    --------
+
+    Create a scipy.stats distribution from a numpy histogram
+    >>> import scipy.stats
+    >>> import numpy as np
+    >>> data = scipy.stats.norm.rvs(size=100000, loc=0, scale=1.5, random_state=123)
+    >>> hist = np.histogram(data, bins=100)
+    >>> hist_dist = scipy.stats.rv_histogram(hist)
+
+    Behaves like an ordinary scipy rv_continuous distribution
+    >>> hist_dist.pdf(1.0)
+    0.20538577847618705
+    >>> hist_dist.cdf(2.0)
+    0.90818568543056499
+
+    PDF is zero above (below) the highest (lowest) bin of the histogram,
+    defined by the max (min) of the original dataset
+    >>> hist_dist.pdf(np.max(data))
+    0.0
+    >>> hist_dist.cdf(np.max(data))
+    1.0
+    >>> hist_dist.pdf(np.min(data))
+    7.7591907244498314e-05
+    >>> hist_dist.cdf(np.min(data))
+    0.0
+
+    PDF and CDF follow the histogram
+    >>> import matplotlib.pyplot as plt
+    >>> X = np.linspace(-5.0, 5.0, 100)
+    >>> plt.title("PDF from Template")
+    >>> plt.hist(data, normed=True, bins=100)
+    >>> plt.plot(X, hist_dist.pdf(X), label='PDF')
+    >>> plt.plot(X, hist_dist.cdf(X), label='CDF')
+    >>> plt.show()
+
+    """
+    _support_mask = rv_continuous._support_mask
+
+    def __init__(self, histogram, *args, **kwargs):
+        """
+        Create a new distribution using the given histogram
+
+        Parameters
+        ----------
+        histogram : tuple of array_like
+          Tuple containing two array_like objects
+          The first containing the content of n bins
+          The second containing the (n+1) bin boundaries
+          In particular the return value np.histogram is accepted
+        """
+        self._histogram = histogram
+        if len(histogram) != 2:
+            raise ValueError("Expected length 2 for parameter histogram")
+        self._hpdf = np.asarray(histogram[0])
+        self._hbins = np.asarray(histogram[1])
+        if len(self._hpdf) + 1 != len(self._hbins):
+            raise ValueError("Number of elements in histogram content and histogram boundaries do not match, expected n and n+1")
+        self._hbin_widths = self._hbins[1:] - self._hbins[:-1]
+        self._hpdf = self._hpdf / float(np.sum(self._hpdf * self._hbin_widths))
+        self._hcdf = np.cumsum(self._hpdf * self._hbin_widths)
+        self._hpdf = np.hstack([0.0, self._hpdf, 0.0])
+        self._hcdf = np.hstack([0.0, self._hcdf])
+        # Set support
+        kwargs['a'] = self._hbins[0]
+        kwargs['b'] = self._hbins[-1]
+        super(rv_histogram, self).__init__(*args, **kwargs)
+
+    def _pdf(self, x):
+        """
+        PDF of the histogram
+        """
+        return self._hpdf[np.digitize(x, bins=self._hbins)]
+
+    def _cdf(self, x):
+        """
+        CDF calculated from the histogram
+        """
+        return np.interp(x, self._hbins, self._hcdf)
+
+    def _ppf(self, x):
+        """
+        Percentile function calculated from the histogram
+        """
+        return np.interp(x, self._hcdf, self._hbins)
+
+    def _munp(self, n):
+        """Compute the n-th non-central moment."""
+        integrals = (self._hbins[1:]**(n+1) - self._hbins[:-1]**(n+1)) / (n+1)
+        return np.sum(self._hpdf[1:-1] * integrals)
+
+    def _entropy(self):
+        """Compute entropy of distribution"""
+        return - np.sum(self._hpdf[1:-1] * _lazywhere(self._hpdf[1:-1] > 0.0, (self._hpdf[1:-1],), np.log, 0.0) * self._hbin_widths)
+
+    def _updated_ctor_param(self):
+        """
+        Set the histogram as additional constructor argument
+        """
+        dct = super(rv_histogram, self)._updated_ctor_param()
+        dct['histogram'] = self._histogram
+        return dct
+
+
 # Collect names of classes and objects in this module.
 pairs = list(globals().items())
 _distn_names, _distn_gen_names = get_distribution_names(pairs, rv_continuous)
 
-__all__ = _distn_names + _distn_gen_names
+__all__ = _distn_names + _distn_gen_names + ['rv_histogram']

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5239,6 +5239,8 @@ class argus_gen(rv_continuous):
            https://en.wikipedia.org/wiki/ARGUS_distribution
 
     %(after_notes)s
+    
+    .. versionadded:: 0.19.0
 
     %(example)s
     """
@@ -5277,6 +5279,8 @@ class rv_histogram(rv_continuous):
     The cdf is a linear interpolation of the pdf.
 
     %(after_notes)s
+    
+    .. versionadded:: 0.19.0
 
     Examples
     --------
@@ -5352,7 +5356,7 @@ class rv_histogram(rv_continuous):
         """
         PDF of the histogram
         """
-        return self._hpdf[np.digitize(x, bins=self._hbins)]
+        return self._hpdf[np.searchsorted(self._hbins, x, side='right')]
 
     def _cdf(self, x):
         """

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5335,7 +5335,9 @@ class rv_histogram(rv_continuous):
         self._hpdf = np.asarray(histogram[0])
         self._hbins = np.asarray(histogram[1])
         if len(self._hpdf) + 1 != len(self._hbins):
-            raise ValueError("Number of elements in histogram content and histogram boundaries do not match, expected n and n+1")
+            raise ValueError("Number of elements in histogram content "
+                             "and histogram boundaries do not match, "
+                             "expected n and n+1.")
         self._hbin_widths = self._hbins[1:] - self._hbins[:-1]
         self._hpdf = self._hpdf / float(np.sum(self._hpdf * self._hbin_widths))
         self._hcdf = np.cumsum(self._hpdf * self._hbin_widths)
@@ -5371,7 +5373,11 @@ class rv_histogram(rv_continuous):
 
     def _entropy(self):
         """Compute entropy of distribution"""
-        return - np.sum(self._hpdf[1:-1] * _lazywhere(self._hpdf[1:-1] > 0.0, (self._hpdf[1:-1],), np.log, 0.0) * self._hbin_widths)
+        res = _lazywhere(self._hpdf[1:-1] > 0.0,
+                         (self._hpdf[1:-1],),
+                         np.log,
+                         0.0)
+        return -np.sum(self._hpdf[1:-1] * res * self._hbin_widths)
 
     def _updated_ctor_param(self):
         """

--- a/scipy/stats/distributions.py
+++ b/scipy/stats/distributions.py
@@ -17,7 +17,7 @@ from ._continuous_distns import *
 from ._discrete_distns import *
 
 # For backwards compatibility e.g. pymc expects distributions.__all__.
-__all__ = ['entropy', 'rv_discrete', 'rv_continuous']
+__all__ = ['entropy', 'rv_discrete', 'rv_continuous', 'rv_histogram']
 
 # Add only the distribution names, not the *_gen names.
 __all__ += _continuous_distns._distn_names

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -65,7 +65,7 @@ fails_cmplx = set(['beta', 'betaprime', 'chi', 'chi2', 'dgamma', 'dweibull',
                    'pearson3', 'rice', 't', 'skewnorm', 'tukeylambda',
                    'vonmises', 'vonmises_line', 'rv_histogram_instance'])
 
-_h = np.histogram([1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5 , 5, 5, 5, 5, 6,
+_h = np.histogram([1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6,
                    6, 6, 6, 7, 7, 7, 8, 8, 9], bins=8)
 test_histogram_instance = stats.rv_histogram(_h)
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -63,14 +63,18 @@ fails_cmplx = set(['beta', 'betaprime', 'chi', 'chi2', 'dgamma', 'dweibull',
                    'ksone', 'kstwobign', 'levy_l', 'loggamma', 'logistic',
                    'maxwell', 'nakagami', 'ncf', 'nct', 'ncx2',
                    'pearson3', 'rice', 't', 'skewnorm', 'tukeylambda',
-                   'vonmises', 'vonmises_line',])
+                   'vonmises', 'vonmises_line', 'test_histogram_instance'])
+
+stats.test_histogram_instance = stats.rv_histogram(np.histogram([1,2,2,3,3,3,4,4,4,4,5,5,5,5,5,6,6,6,6,7,7,7,8,8,9], bins=8))
+stats.distributions.test_histogram_instance = stats.test_histogram_instance
 
 def test_cont_basic():
     # this test skips slow distributions
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore',
                                 category=integrate.IntegrationWarning)
-        for distname, arg in distcont[:]:
+        
+        for distname, arg in distcont[:] + [('test_histogram_instance', tuple())]:
             if distname in distslow:
                 continue
             if distname is 'levy_stable':
@@ -100,7 +104,7 @@ def test_cont_basic():
                      distfn.logsf]
             # make sure arguments are within support
             spec_x = {'frechet_l': -0.5, 'weibull_max': -0.5, 'levy_l': -0.5,
-                      'pareto': 1.5, 'tukeylambda': 0.3}
+                      'pareto': 1.5, 'tukeylambda': 0.3, 'test_histogram_instance': 5.0}
             x = spec_x.get(distname, 0.5)
             yield check_named_args, distfn, x, arg, locscale_defaults, meths
             yield check_random_state_property, distfn, arg
@@ -203,7 +207,7 @@ def test_moments():
         knf = npt.dec.knownfailureif
         fail_normalization = set(['vonmises', 'ksone'])
         fail_higher = set(['vonmises', 'ksone', 'ncf'])
-        for distname, arg in distcont[:]:
+        for distname, arg in distcont[:] + [('test_histogram_instance', tuple())]:
             if distname is 'levy_stable':
                 continue
             distfn = getattr(stats, distname)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3024,5 +3024,92 @@ def test_argus_function():
         assert_equal(stats.argus.cdf(1.0, chi=i), 1.0 - stats.argus.sf(1.0, chi=i))
 
 
+class TestHistogram(TestCase):
+    def setUp(self):
+        # We have 8 bins
+        # [1,2), [2,3), [3,4), [4,5), [5,6), [6,7), [7,8), [8,9)
+        # But actually np.histogram will put the last 9 also in the [8,9) bin!
+        # Therefore there is a slight difference below for the last bin, from what you might
+        # have expected.
+        histogram = np.histogram([1,2,2,3,3,3,4,4,4,4,5,5,5,5,5,6,6,6,6,7,7,7,8,8,9], bins=8)
+        self.template = stats.rv_histogram(histogram)
+        
+        norm_histogram = np.histogram(stats.norm.rvs(loc=1.0, scale=2.5, size=10000, random_state=123), bins=50)
+        self.norm_template = stats.rv_histogram(norm_histogram)
+
+    def test_pdf(self):
+        values = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5,
+                           5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5])
+        pdf_values = np.asarray([0.0/25.0, 0.0/25.0, 1.0/25.0, 1.0/25.0, 2.0/25.0, 2.0/25.0,
+                                 3.0/25.0, 3.0/25.0, 4.0/25.0, 4.0/25.0, 5.0/25.0, 5.0/25.0,
+                                 4.0/25.0, 4.0/25.0, 3.0/25.0, 3.0/25.0, 3.0/25.0, 3.0/25.0,
+                                 0.0/25.0, 0.0/25.0])
+        assert_allclose(self.template.pdf(values), pdf_values)
+
+        # Test explicitly the corner cases:
+        # As stated above the pdf in the bin [8,9) is greater than
+        # one would naively expect because np.histogram putted the 9
+        # into the [8,9) bin.
+        assert_almost_equal(self.template.pdf(8.0), 3.0/25.0)
+        assert_almost_equal(self.template.pdf(8.5), 3.0/25.0)
+        # 9 is outside our defined bins [8,9) hence the pdf is already 0
+        # for a continuous distribution this is fine, because a single value
+        # does not have a finite probability!
+        assert_almost_equal(self.template.pdf(9.0), 0.0/25.0)
+        assert_almost_equal(self.template.pdf(10.0), 0.0/25.0)
+
+        x = np.linspace(-2, 2, 10)
+        assert_allclose(self.norm_template.pdf(x), stats.norm.pdf(x, loc=1.0, scale=2.5), rtol=0.1)
+
+    def test_cdf_ppf(self):
+        values = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5,
+                           5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5])
+        cdf_values = np.asarray([0.0/25.0, 0.0/25.0, 0.0/25.0, 0.5/25.0, 1.0/25.0, 2.0/25.0,
+                                 3.0/25.0, 4.5/25.0, 6.0/25.0, 8.0/25.0, 10.0/25.0, 12.5/25.0,
+                                 15.0/25.0, 17.0/25.0, 19.0/25.0, 20.5/25.0, 22.0/25.0, 23.5/25.0,
+                                 25.0/25.0, 25.0/25.0])
+        assert_allclose(self.template.cdf(values), cdf_values)
+        # First three and last two values in cdf_value are not unique
+        assert_allclose(self.template.ppf(cdf_values[2:-1]), values[2:-1])
+
+        # Test of cdf and ppf are inverse functions
+        x = np.linspace(1.0, 9.0, 100)
+        assert_allclose(self.template.ppf(self.template.cdf(x)), x)
+        x = np.linspace(0.0, 1.0, 100)
+        assert_allclose(self.template.cdf(self.template.ppf(x)), x)
+        
+        x = np.linspace(-2, 2, 10)
+        assert_allclose(self.norm_template.cdf(x), stats.norm.cdf(x, loc=1.0, scale=2.5), rtol=0.1)
+
+    def test_rvs(self):
+        N = 10000
+        sample = self.template.rvs(size=N, random_state=123)
+        assert_equal(np.sum(sample < 1.0), 0.0)
+        assert_allclose(np.sum(sample <= 2.0), 1.0/25.0 * N, rtol=0.2)
+        assert_allclose(np.sum(sample <= 2.5), 2.0/25.0 * N, rtol=0.2)
+        assert_allclose(np.sum(sample <= 3.0), 3.0/25.0 * N, rtol=0.1)
+        assert_allclose(np.sum(sample <= 3.5), 4.5/25.0 * N, rtol=0.1)
+        assert_allclose(np.sum(sample <= 4.0), 6.0/25.0 * N, rtol=0.1)
+        assert_allclose(np.sum(sample <= 4.5), 8.0/25.0 * N, rtol=0.1)
+        assert_allclose(np.sum(sample <= 5.0), 10.0/25.0 * N, rtol=0.05)
+        assert_allclose(np.sum(sample <= 5.5), 12.5/25.0 * N, rtol=0.05)
+        assert_allclose(np.sum(sample <= 6.0), 15.0/25.0 * N, rtol=0.05)
+        assert_allclose(np.sum(sample <= 6.5), 17.0/25.0 * N, rtol=0.05)
+        assert_allclose(np.sum(sample <= 7.0), 19.0/25.0 * N, rtol=0.05)
+        assert_allclose(np.sum(sample <= 7.5), 20.5/25.0 * N, rtol=0.05)
+        assert_allclose(np.sum(sample <= 8.0), 22.0/25.0 * N, rtol=0.05)
+        assert_allclose(np.sum(sample <= 8.5), 23.5/25.0 * N, rtol=0.05)
+        assert_allclose(np.sum(sample <= 9.0), 25.0/25.0 * N, rtol=0.05)
+        assert_allclose(np.sum(sample <= 9.0), 25.0/25.0 * N, rtol=0.05)
+        assert_equal(np.sum(sample > 9.0), 0.0)
+
+    def test_munp(self):
+        for n in range(4):
+            assert_allclose(self.norm_template._munp(n), stats.norm._munp(n, 1.0, 2.5), rtol=0.05)
+    
+    def test_entropy(self):
+        assert_allclose(self.norm_template.entropy(), stats.norm.entropy(loc=1.0, scale=2.5), rtol=0.05)
+
+
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3029,21 +3029,24 @@ class TestHistogram(TestCase):
         # We have 8 bins
         # [1,2), [2,3), [3,4), [4,5), [5,6), [6,7), [7,8), [8,9)
         # But actually np.histogram will put the last 9 also in the [8,9) bin!
-        # Therefore there is a slight difference below for the last bin, from what you might
-        # have expected.
-        histogram = np.histogram([1,2,2,3,3,3,4,4,4,4,5,5,5,5,5,6,6,6,6,7,7,7,8,8,9], bins=8)
+        # Therefore there is a slight difference below for the last bin, from
+        # what you might have expected.
+        histogram = np.histogram([1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5,
+                                  6, 6, 6, 6, 7, 7, 7, 8, 8, 9], bins=8)
         self.template = stats.rv_histogram(histogram)
         
-        norm_histogram = np.histogram(stats.norm.rvs(loc=1.0, scale=2.5, size=10000, random_state=123), bins=50)
+        data = stats.norm.rvs(loc=1.0, scale=2.5,size=10000, random_state=123)
+        norm_histogram = np.histogram(data, bins=50)
         self.norm_template = stats.rv_histogram(norm_histogram)
 
     def test_pdf(self):
         values = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5,
                            5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5])
-        pdf_values = np.asarray([0.0/25.0, 0.0/25.0, 1.0/25.0, 1.0/25.0, 2.0/25.0, 2.0/25.0,
-                                 3.0/25.0, 3.0/25.0, 4.0/25.0, 4.0/25.0, 5.0/25.0, 5.0/25.0,
-                                 4.0/25.0, 4.0/25.0, 3.0/25.0, 3.0/25.0, 3.0/25.0, 3.0/25.0,
-                                 0.0/25.0, 0.0/25.0])
+        pdf_values = np.asarray([0.0/25.0, 0.0/25.0, 1.0/25.0, 1.0/25.0,
+                                 2.0/25.0, 2.0/25.0, 3.0/25.0, 3.0/25.0,
+                                 4.0/25.0, 4.0/25.0, 5.0/25.0, 5.0/25.0,
+                                 4.0/25.0, 4.0/25.0, 3.0/25.0, 3.0/25.0,
+                                 3.0/25.0, 3.0/25.0, 0.0/25.0, 0.0/25.0])
         assert_allclose(self.template.pdf(values), pdf_values)
 
         # Test explicitly the corner cases:
@@ -3059,15 +3062,17 @@ class TestHistogram(TestCase):
         assert_almost_equal(self.template.pdf(10.0), 0.0/25.0)
 
         x = np.linspace(-2, 2, 10)
-        assert_allclose(self.norm_template.pdf(x), stats.norm.pdf(x, loc=1.0, scale=2.5), rtol=0.1)
+        assert_allclose(self.norm_template.pdf(x),
+                        stats.norm.pdf(x, loc=1.0, scale=2.5), rtol=0.1)
 
     def test_cdf_ppf(self):
         values = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5,
                            5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5])
-        cdf_values = np.asarray([0.0/25.0, 0.0/25.0, 0.0/25.0, 0.5/25.0, 1.0/25.0, 2.0/25.0,
-                                 3.0/25.0, 4.5/25.0, 6.0/25.0, 8.0/25.0, 10.0/25.0, 12.5/25.0,
-                                 15.0/25.0, 17.0/25.0, 19.0/25.0, 20.5/25.0, 22.0/25.0, 23.5/25.0,
-                                 25.0/25.0, 25.0/25.0])
+        cdf_values = np.asarray([0.0/25.0, 0.0/25.0, 0.0/25.0, 0.5/25.0,
+                                 1.0/25.0, 2.0/25.0, 3.0/25.0, 4.5/25.0,
+                                 6.0/25.0, 8.0/25.0, 10.0/25.0, 12.5/25.0,
+                                 15.0/25.0, 17.0/25.0, 19.0/25.0, 20.5/25.0,
+                                 22.0/25.0, 23.5/25.0, 25.0/25.0, 25.0/25.0])
         assert_allclose(self.template.cdf(values), cdf_values)
         # First three and last two values in cdf_value are not unique
         assert_allclose(self.template.ppf(cdf_values[2:-1]), values[2:-1])
@@ -3079,7 +3084,8 @@ class TestHistogram(TestCase):
         assert_allclose(self.template.cdf(self.template.ppf(x)), x)
         
         x = np.linspace(-2, 2, 10)
-        assert_allclose(self.norm_template.cdf(x), stats.norm.cdf(x, loc=1.0, scale=2.5), rtol=0.1)
+        assert_allclose(self.norm_template.cdf(x),
+                        stats.norm.cdf(x, loc=1.0, scale=2.5), rtol=0.1)
 
     def test_rvs(self):
         N = 10000
@@ -3105,10 +3111,12 @@ class TestHistogram(TestCase):
 
     def test_munp(self):
         for n in range(4):
-            assert_allclose(self.norm_template._munp(n), stats.norm._munp(n, 1.0, 2.5), rtol=0.05)
+            assert_allclose(self.norm_template._munp(n),
+                            stats.norm._munp(n, 1.0, 2.5), rtol=0.05)
     
     def test_entropy(self):
-        assert_allclose(self.norm_template.entropy(), stats.norm.entropy(loc=1.0, scale=2.5), rtol=0.05)
+        assert_allclose(self.norm_template.entropy(),
+                        stats.norm.entropy(loc=1.0, scale=2.5), rtol=0.05)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
histogram_gen can be used to create a scipy distribution out of a given histogram.
This is often used to incorporate distributions which can be measured or simulated. The techniques is sometimes called "template fit". For reference: ROOT implements it using a class called RooHistPdf
https://root.cern.ch/doc/master/classRooHistPdf.html

rv_arbitrary in https://github.com/scipy/scipy/pull/6466 provides similar functionality.
However, I think a specialized implementation just for histograms does make sense.

This is a split of, of another PR which contained several other distributions #6795 and was originally named template_gen
