### PR TITLE
MAINT: more fixes in `loggamma`

### DIFF
--- a/scipy/special/_c99compat.h
+++ b/scipy/special/_c99compat.h
@@ -9,12 +9,25 @@
 
 
 #define sc_isnan(x) ((x) != (x))
+
+
 #ifdef _MSC_VER
-    #define sc_isfinite(x) _finite((x))
+#define sc_isfinite(x) _finite((x))
 #else
-    #define sc_isfinite(x) !sc_isnan((x) + (-x))
+#define sc_isfinite(x) !sc_isnan((x) + (-x))
 #endif
+
+
 #define sc_isinf(x) (!sc_isfinite(x) && !sc_isnan(x))
+
+
+#if __STDC_VERSION__ >= 199901L
+/* We have C99 */
+#define sc_fma(x, y, z) fma(x, y, z)
+#else
+/* No C99, define fma as (x*y) + z and maybe the compiler picks it up */
+#define sc_fma(x, y, z) ((x*y) + z)
+#endif
 
 
 #endif /* _c99compat.h */

--- a/scipy/special/_c99compat.h
+++ b/scipy/special/_c99compat.h
@@ -1,8 +1,8 @@
 /*
  * Portable versions of some C99 functions. In cmath they are only
- * available in C++11 and the npy_math versions don't work well (they
- * get undef'd by cmath; see gh-5689). Implementations based on
- * npy_math.h and friends.
+ * available in C++11 and the npy_math versions either don't work well
+ * (they get undef'd by cmath; see gh-5689) or aren't
+ * available. Implementations based on npy_math.h and friends.
  */
 #ifndef C99COMPAT_H
 #define C99COMPAT_H
@@ -25,8 +25,8 @@
 /* We have C99 */
 #define sc_fma(x, y, z) fma(x, y, z)
 #else
-/* No C99, define fma as (x*y) + z and maybe the compiler picks it up */
-#define sc_fma(x, y, z) ((x*y) + z)
+/* No C99, define fma as x*y + z and maybe the compiler picks it up */
+#define sc_fma(x, y, z) ((x)*(y) + (z))
 #endif
 
 

--- a/scipy/special/_evalpoly.pxd
+++ b/scipy/special/_evalpoly.pxd
@@ -1,0 +1,41 @@
+"""Evaluate polynomials.
+
+All of the coefficients are stored in reverse order, i.e. if the
+polynomial is
+
+    u_n x^n + u_{n - 1} x^{n - 1} + ... + u_0,
+
+then coeffs[0] = u_n, coeffs[1] = u_{n - 1}, ..., coeffs[n] = u_0.
+
+References
+----------
+[1] Knuth, "The Art of Computer Programming, Volume II"
+
+"""
+from _complexstuff cimport zabs
+
+cdef extern from "_c99compat.h":
+    double sc_fma(double x, double y, double z) nogil
+
+
+cdef inline double complex cevalpoly(double *coeffs, int degree,
+                                     double complex z) nogil:
+    """Evaluate a polynomial with real coefficients at a complex point.
+
+    Uses equation (3) in section 4.6.4 of [1]. Note that it is more
+    efficient than Horner's method.
+
+    """
+    cdef:
+        int j
+        double a = coeffs[0]
+        double b = coeffs[1]
+        double r = 2*z.real
+        double s = z.real*z.real + z.imag*z.imag
+        double tmp
+
+    for j in range(2, degree + 1):
+        tmp = b
+        b = sc_fma(-s, a, coeffs[j])
+        a = sc_fma(r, a, tmp)
+    return z*a + b

--- a/scipy/special/_precompute/loggamma.py
+++ b/scipy/special/_precompute/loggamma.py
@@ -28,9 +28,9 @@ def main():
     print(__doc__)
     print()
     stirling_coeffs = [mpmath.nstr(x, 20, min_fixed=0, max_fixed=0)
-                       for x in stirling_series(16)]
+                       for x in stirling_series(8)[::-1]]
     taylor_coeffs = [mpmath.nstr(x, 20, min_fixed=0, max_fixed=0)
-                     for x in taylor_series_at_1(16)]
+                     for x in taylor_series_at_1(23)[::-1]]
     print("Stirling series coefficients")
     print("----------------------------")
     print("\n".join(stirling_coeffs))

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -340,37 +340,44 @@ def test_beta():
 # loggamma
 # ------------------------------------------------------------------------------
 
+LOGGAMMA_TAYLOR_RADIUS = 0.2
+
+
 @check_version(mpmath, '0.19')
-def test_loggamma_taylor1():
+def test_loggamma_taylor_transition():
     # Make sure there isn't a big jump in accuracy when we move from
     # using the Taylor series to using the recurrence relation.
 
-    pts = [1 + 0.1j, 1 - 0.1j, 1.1, 0.9, 2 - 0.1j, 2 + 0.1j, 2.1, 1.9]
+    r = LOGGAMMA_TAYLOR_RADIUS + np.array([-0.1, -0.01, 0, 0.01, 0.1])
+    theta = np.linspace(0, 2*np.pi, 20)
+    r, theta = np.meshgrid(r, theta)
+    dz = r*np.exp(1j*theta)
+    z = np.r_[1 + dz, 2 + dz].flatten()
+
     dataset = []
-    for p in pts:
-        for eps in [1e-6, -1e-6, 1e-6j, -1e-6j]:
-            q = p + eps
-            dataset.append((q, complex(mpmath.loggamma(q))))
-        
+    for z0 in z:
+        dataset.append((z0, complex(mpmath.loggamma(z0))))    
     dataset = np.array(dataset)
-    FuncData(sc.loggamma, dataset, 0, 1, rtol=1e-13).check()
+
+    FuncData(sc.loggamma, dataset, 0, 1, rtol=5e-14).check()
 
 
 @check_version(mpmath, '0.19')
-def test_loggamma_taylor2():
+def test_loggamma_taylor():
     # Test around the zeros at z = 1, 2.
 
-    r = np.r_[-np.logspace(-1, -16, 10), np.logspace(-16, -1, 10)]
+    r = np.logspace(-16, np.log10(LOGGAMMA_TAYLOR_RADIUS), 10)
     theta = np.linspace(0, 2*np.pi, 20)
     r, theta = np.meshgrid(r, theta)
-    dz = r*(np.cos(theta) + 1j*np.sin(theta))
+    dz = r*np.exp(1j*theta)
     z = np.r_[1 + dz, 2 + dz].flatten()
+
     dataset = []
     for z0 in z:
         dataset.append((z0, complex(mpmath.loggamma(z0))))
-
     dataset = np.array(dataset)
-    FuncData(sc.loggamma, dataset, 0, 1, rtol=1e-13).check()
+    
+    FuncData(sc.loggamma, dataset, 0, 1, rtol=5e-14).check()
 
 
 # ------------------------------------------------------------------------------
@@ -1217,7 +1224,7 @@ class TestSystematic(with_metaclass(DecoratorMeta, object)):
     def test_gamma_complex(self):
         assert_mpmath_equal(sc.gamma,
                             exception_to_nan(mpmath.gamma),
-                            [ComplexArg()], rtol=1e-12)
+                            [ComplexArg()], rtol=5e-13)
 
     def test_gammainc(self):
         # Larger arguments are tested in test_data.py:test_local
@@ -1669,7 +1676,7 @@ class TestSystematic(with_metaclass(DecoratorMeta, object)):
         assert_mpmath_equal(sc.loggamma,
                             mpmath_loggamma,
                             [ComplexArg()], nan_ok=False,
-                            distinguish_nan_and_inf=False, rtol=1e-13)
+                            distinguish_nan_and_inf=False, rtol=5e-14)
 
     @knownfailure_overridable()
     def test_pcfd(self):
@@ -1716,7 +1723,7 @@ class TestSystematic(with_metaclass(DecoratorMeta, object)):
     def test_rgamma_complex(self):
         assert_mpmath_equal(sc.rgamma,
                             exception_to_nan(mpmath.rgamma),
-                            [ComplexArg()], rtol=1e-12)
+                            [ComplexArg()], rtol=5e-13)
 
     def test_rf(self):
         def mppoch(a, m):


### PR DESCRIPTION
This:

- Adds an internal function for evaluating complex polynomials
- Uses it for more efficient evaluation of the Taylor/asymptotic series in `loggamma`
- Adjusts the decision boundary for the Taylor series
- Tightens the tests slightly to account for accuracy gains from the above.