### PR TITLE
ENH: Faster linkage for 'centroid' and 'median' methods

### DIFF
--- a/scipy/cluster/_heap.pxi
+++ b/scipy/cluster/_heap.pxi
@@ -1,0 +1,73 @@
+# cython: boundscheck=False, wraparound=False, cdivision=True
+import numpy as np
+
+
+cdef class Heap:
+    cdef int[:] index_by_key
+    cdef int[:] key_by_index
+    cdef double[:] values
+    cdef int size
+
+    def __init__(self, double[:] values):
+        self.size = values.shape[0]
+        self.index_by_key = np.arange(self.size, dtype=np.intc)
+        self.key_by_index = np.arange(self.size, dtype=np.intc)
+        self.values = values.copy()
+        cdef int i
+        for i in reversed(range(self.size / 2)):
+            self.sift_down(i)
+
+    cdef get_min(self):
+        return self.key_by_index[0], self.values[0]
+
+    cdef remove_min(self):
+        self.swap(0, self.size - 1)
+        self.size -= 1
+        self.sift_down(0)
+
+    cdef change_value(self, int key, double value):
+        cdef int index = self.index_by_key[key]
+        cdef double old_value = self.values[index]
+        self.values[index] = value
+        if value < old_value:
+            self.sift_up(index)
+        else:
+            self.sift_down(index)
+
+    cdef sift_up(self, int index):
+        cdef int parent = Heap.parent(index)
+        while index > 0 and self.values[parent] > self.values[index]:
+            self.swap(index, parent)
+            index = parent
+            parent = Heap.parent(index)
+
+    cdef sift_down(self, int index):
+        cdef int child = Heap.left_child(index)
+        while child < self.size:
+            if (child + 1 < self.size and
+                    self.values[child + 1] < self.values[child]):
+                child += 1
+
+            if self.values[index] > self.values[child]:
+                self.swap(index, child)
+                index = child
+                child = Heap.left_child(index)
+            else:
+                break
+
+    @staticmethod
+    cdef left_child(int parent):
+        return (parent << 1) + 1
+
+    @staticmethod
+    cdef parent(int child):
+        return (child - 1) >> 1
+
+    cdef swap(self, int i, int j):
+        self.values[i], self.values[j] = self.values[j], self.values[i]
+        cdef int key_i = self.key_by_index[i]
+        cdef int key_j = self.key_by_index[j]
+        self.key_by_index[i] = key_j
+        self.key_by_index[j] = key_i
+        self.index_by_key[key_i] = j
+        self.index_by_key[key_j] = i

--- a/scipy/cluster/_heap.pxi
+++ b/scipy/cluster/_heap.pxi
@@ -17,15 +17,15 @@ cdef class Heap:
         for i in reversed(range(self.size / 2)):
             self.sift_down(i)
 
-    cdef get_min(self):
+    cdef tuple get_min(self):
         return self.key_by_index[0], self.values[0]
 
-    cdef remove_min(self):
+    cdef void remove_min(self):
         self.swap(0, self.size - 1)
         self.size -= 1
         self.sift_down(0)
 
-    cdef change_value(self, int key, double value):
+    cdef void change_value(self, int key, double value):
         cdef int index = self.index_by_key[key]
         cdef double old_value = self.values[index]
         self.values[index] = value
@@ -34,14 +34,14 @@ cdef class Heap:
         else:
             self.sift_down(index)
 
-    cdef sift_up(self, int index):
+    cdef void sift_up(self, int index):
         cdef int parent = Heap.parent(index)
         while index > 0 and self.values[parent] > self.values[index]:
             self.swap(index, parent)
             index = parent
             parent = Heap.parent(index)
 
-    cdef sift_down(self, int index):
+    cdef void sift_down(self, int index):
         cdef int child = Heap.left_child(index)
         while child < self.size:
             if (child + 1 < self.size and
@@ -56,14 +56,14 @@ cdef class Heap:
                 break
 
     @staticmethod
-    cdef left_child(int parent):
+    cdef int left_child(int parent):
         return (parent << 1) + 1
 
     @staticmethod
-    cdef parent(int child):
+    cdef int parent(int child):
         return (child - 1) >> 1
 
-    cdef swap(self, int i, int j):
+    cdef void swap(self, int i, int j):
         self.values[i], self.values[j] = self.values[j], self.values[i]
         cdef int key_i = self.key_by_index[i]
         cdef int key_j = self.key_by_index[j]

--- a/scipy/cluster/_heap.pxi
+++ b/scipy/cluster/_heap.pxi
@@ -56,11 +56,11 @@ cdef class Heap:
                 break
 
     @staticmethod
-    cdef int left_child(int parent):
+    cdef inline int left_child(int parent):
         return (parent << 1) + 1
 
     @staticmethod
-    cdef int parent(int child):
+    cdef inline int parent(int child):
         return (child - 1) >> 1
 
     cdef void swap(self, int i, int j):

--- a/scipy/cluster/_hierarchy.pyx
+++ b/scipy/cluster/_hierarchy.pyx
@@ -17,7 +17,7 @@ ctypedef unsigned char uchar
 include "_hierarchy_distance_update.pxi"
 cdef linkage_distance_update *linkage_methods = [
     _single, _complete, _average, _centroid, _median, _ward, _weighted]
-
+include "_heap.pxi"
 
 cdef inline np.npy_int64 condensed_index(np.npy_int64 n, np.npy_int64 i,
                                          np.npy_int64 j):
@@ -753,6 +753,153 @@ def linkage(double[:] dists, np.npy_int64 n, int method):
             if i < x:
                 D[condensed_index(n, i, x)] = NPY_INFINITYF
     return Z_arr
+
+
+cdef find_min_dist(int n, double[:] D, int[:] size, int x):
+    cdef double current_min = NPY_INFINITYF
+    cdef int y = -1
+    cdef int i
+    cdef double dist
+
+    for i in range(x + 1, n):
+        if size[i] == 0:
+            continue
+
+        dist = D[condensed_index(n, x, i)]
+        if dist < current_min:
+            current_min = dist
+            y = i
+
+    return y, current_min
+
+
+def fast_linkage(double[:] dists, int n, int method):
+    """Perform hierarchy clustering.
+
+    It implements "Generic Clustering Algorithm" from [1]. The worst case
+    time complexity is O(N^3), but the best case time complexity is O(N^2) and
+    it usually works quite close to the best case.
+
+    Parameters
+    ----------
+    dists : ndarray
+        A condensed matrix stores the pairwise distances of the observations.
+    n : int
+        The number of observations.
+    method : int
+        The linkage method. 0: single 1: complete 2: average 3: centroid
+        4: median 5: ward 6: weighted
+
+    Returns
+    -------
+    Z : ndarray, shape (n - 1, 4)
+        Computed linkage matrix.
+
+    References
+    ----------
+    .. [1] Daniel Mullner, "Modern hierarchical, agglomerative clustering
+       algorithms", :arXiv:`1109.2378v1`.
+    """
+    cdef double[:, :] Z = np.empty((n - 1, 4))
+
+    cdef double[:] D = dists.copy()  # Distances between clusters.
+    cdef int[:] size = np.ones(n, dtype=np.intc)  # Sizes of clusters.
+    # ID of a cluster to put into linkage matrix.
+    cdef int[:] cluster_id = np.arange(n, dtype=np.intc)
+
+    # Nearest neighbor candidate and lower bound of the distance to the
+    # true nearest neighbor for each cluster among clusters with higher
+    # indices (thus size is n - 1).
+    cdef int[:] neighbor = np.empty(n - 1, dtype=np.intc)
+    cdef double[:] min_dist = np.empty(n - 1)
+
+    cdef linkage_distance_update new_dist = linkage_methods[method]
+
+    cdef int i, k
+    cdef int x, y, z
+    cdef int nx, ny, nz
+    cdef int id_x, id_y
+    cdef double dist
+
+    for x in range(n - 1):
+        y, dist = find_min_dist(n, D, size, x)
+        neighbor[x] = y
+        min_dist[x] = dist
+    cdef Heap min_dist_heap = Heap(min_dist)
+
+    for k in range(n - 1):
+        # Theoretically speaking, this can be implemented as "while True", but
+        # having a fixed size loop when floating point computations involved
+        # looks more reliable. The idea that we should find the two closest
+        # clusters in no more that n - k (1 for the last iteration) distance
+        # updates.
+        for i in range(n - k):
+            x, dist = min_dist_heap.get_min()
+            y = neighbor[x]
+
+            if dist == D[condensed_index(n, x, y)]:
+                break
+
+            y, dist = find_min_dist(n, D, size, x)
+            neighbor[x] = y
+            min_dist[x] = dist
+            min_dist_heap.change_value(x, dist)
+        min_dist_heap.remove_min()
+
+        id_x = cluster_id[x]
+        id_y = cluster_id[y]
+        nx = size[x]
+        ny = size[y]
+
+        if id_x > id_y:
+            id_x, id_y = id_y, id_x
+
+        Z[k, 0] = id_x
+        Z[k, 1] = id_y
+        Z[k, 2] = dist
+        Z[k, 3] = nx + ny
+
+        size[x] = 0  # Cluster x will be dropped.
+        size[y] = nx + ny  # Cluster y will be replaced with the new cluster.
+        cluster_id[y] = n + k  # Update ID of y.
+
+        # Update the distance matrix.
+        for z in range(n):
+            nz = size[z]
+            if nz == 0 or z == y:
+                continue
+
+            D[condensed_index(n, z, y)] = new_dist(
+                D[condensed_index(n, z, x)], D[condensed_index(n, z, y)],
+                dist, nx, ny, nz)
+
+        # Reassign neighbor candidates from x to y.
+        # This reassignment is just a (logical) guess.
+        for z in range(x):
+            if size[z] > 0 and neighbor[z] == x:
+                neighbor[z] = y
+
+        # Update lower bounds of distance.
+        for z in range(y):
+            if size[z] == 0:
+                continue
+
+            dist = D[condensed_index(n, z, y)]
+            if dist < min_dist[z]:
+                neighbor[z] = y
+                min_dist[z] = dist
+                min_dist_heap.change_value(z, dist)
+
+        # Find nearest neighbor for y.
+        if y < n - 1:
+            z, dist = find_min_dist(n, D, size, y)
+            if z != -1:
+                neighbor[y] = z
+                min_dist[y] = dist
+                min_dist_heap.change_value(y, dist)
+
+    return Z.base
+
 
 def nn_chain(double[:] dists, int n, int method):
     """Perform hierarchy clustering using nearest-neighbor chain algorithm.

--- a/scipy/cluster/_structures.pxi
+++ b/scipy/cluster/_structures.pxi
@@ -21,15 +21,15 @@ cdef class Heap:
         for i in reversed(range(self.size / 2)):
             self.sift_down(i)
 
-    cdef Pair get_min(self):
+    cpdef Pair get_min(self):
         return Pair(self.key_by_index[0], self.values[0])
 
-    cdef void remove_min(self):
+    cpdef void remove_min(self):
         self.swap(0, self.size - 1)
         self.size -= 1
         self.sift_down(0)
 
-    cdef void change_value(self, int key, double value):
+    cpdef void change_value(self, int key, double value):
         cdef int index = self.index_by_key[key]
         cdef double old_value = self.values[index]
         self.values[index] = value

--- a/scipy/cluster/_structures.pxi
+++ b/scipy/cluster/_structures.pxi
@@ -1,5 +1,9 @@
-# cython: boundscheck=False, wraparound=False, cdivision=True
 import numpy as np
+
+
+ctypedef struct Pair:
+    int key
+    double value
 
 
 cdef class Heap:
@@ -17,8 +21,8 @@ cdef class Heap:
         for i in reversed(range(self.size / 2)):
             self.sift_down(i)
 
-    cdef tuple get_min(self):
-        return self.key_by_index[0], self.values[0]
+    cdef Pair get_min(self):
+        return Pair(self.key_by_index[0], self.values[0])
 
     cdef void remove_min(self):
         self.swap(0, self.size - 1)

--- a/scipy/cluster/_structures.pxi
+++ b/scipy/cluster/_structures.pxi
@@ -7,6 +7,18 @@ ctypedef struct Pair:
 
 
 cdef class Heap:
+    """Binary heap.
+
+    Heap stores values and keys. Values are passed explicitly, whereas keys
+    are assigned implicitly to natural numbers (from 0 to n - 1).
+
+    The supported operations (all have O(log n) time complexity):
+
+        * Return the current minimum value and the corresponding key.
+        * Remove the current minimum value.
+        * Change the value of the given key. Note that the key must be still
+          in the heap.
+    """
     cdef int[:] index_by_key
     cdef int[:] key_by_index
     cdef double[:] values

--- a/scipy/cluster/_structures.pxi
+++ b/scipy/cluster/_structures.pxi
@@ -18,6 +18,11 @@ cdef class Heap:
         * Remove the current minimum value.
         * Change the value of the given key. Note that the key must be still
           in the heap.
+
+    The heap is stored as an array, where children of parent i have indices
+    2 * i + 1 and 2 * i + 2. All public methods are based on  `sift_down` and
+    `sift_up` methods, which restore the heap property by moving an element
+    down or up in the heap.
     """
     cdef int[:] index_by_key
     cdef int[:] key_by_index
@@ -30,6 +35,9 @@ cdef class Heap:
         self.key_by_index = np.arange(self.size, dtype=np.intc)
         self.values = values.copy()
         cdef int i
+
+        # Create the heap in a linear time. The algorithm sequentially sifts
+        # down items starting from lower levels.
         for i in reversed(range(self.size / 2)):
             self.sift_down(i)
 

--- a/scipy/cluster/_structures.pxi
+++ b/scipy/cluster/_structures.pxi
@@ -1,3 +1,4 @@
+# cython: boundscheck=False, wraparound=False, cdivision=True
 import numpy as np
 
 

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -681,7 +681,7 @@ def linkage(y, method='single', metric='euclidean'):
         return _hierarchy.mst_single_linkage(y, n)
     elif method in ['complete', 'average', 'weighted', 'ward']:
         return _hierarchy.nn_chain(y, n, method_code)
-    elif method in ['centroid', 'median']:
+    else:
         return _hierarchy.fast_linkage(y, n, method_code)
 
 

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -650,7 +650,6 @@ def linkage(y, method='single', metric='euclidean'):
     ----------
     .. [1] Daniel Mullner, "Modern hierarchical, agglomerative clustering
            algorithms", :arXiv:`1109.2378v1`.
-
     """
     if method not in _LINKAGE_METHODS:
         raise ValueError("Invalid method: {0}".format(method))
@@ -682,8 +681,8 @@ def linkage(y, method='single', metric='euclidean'):
         return _hierarchy.mst_single_linkage(y, n)
     elif method in ['complete', 'average', 'weighted', 'ward']:
         return _hierarchy.nn_chain(y, n, method_code)
-    else:
-        return _hierarchy.linkage(y, n, method_code)
+    elif method in ['centroid', 'median']:
+        return _hierarchy.fast_linkage(y, n, method_code)
 
 
 class ClusterNode:

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -49,6 +49,7 @@ from scipy.cluster.hierarchy import (
     is_valid_linkage, is_valid_im, to_tree, leaves_list, dendrogram,
     set_link_color_palette, cut_tree, _order_cluster_tree)
 from scipy.spatial.distance import pdist
+from scipy.cluster._hierarchy import Heap
 
 import hierarchy_test_data
 
@@ -991,6 +992,38 @@ def test_cut_tree():
                  cut_tree(Z, height=[5, 10]))
     assert_equal(cutree[:, np.searchsorted(heights, [10, 5])],
                  cut_tree(Z, height=[10, 5]))
+
+
+def test_Heap():
+    values = np.array([2, -1, 0, -1.5, 3])
+    heap = Heap(values)
+
+    pair = heap.get_min()
+    assert_equal(pair['key'], 3)
+    assert_equal(pair['value'], -1.5)
+
+    heap.remove_min()
+    pair = heap.get_min()
+    assert_equal(pair['key'], 1)
+    assert_equal(pair['value'], -1)
+
+    heap.change_value(1, 2.5)
+    pair = heap.get_min()
+    assert_equal(pair['key'], 2)
+    assert_equal(pair['value'], 0)
+
+    heap.remove_min()
+    heap.remove_min()
+
+    heap.change_value(1, 10)
+    pair = heap.get_min()
+    assert_equal(pair['key'], 4)
+    assert_equal(pair['value'], 3)
+
+    heap.remove_min()
+    pair = heap.get_min()
+    assert_equal(pair['key'], 1)
+    assert_equal(pair['value'], 10)
 
 
 if __name__ == "__main__":

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -47,7 +47,8 @@ from scipy.cluster.hierarchy import (
     is_isomorphic, single, leaders, complete, weighted, centroid,
     correspond, is_monotonic, maxdists, maxinconsts, maxRstat,
     is_valid_linkage, is_valid_im, to_tree, leaves_list, dendrogram,
-    set_link_color_palette, cut_tree, _order_cluster_tree)
+    set_link_color_palette, cut_tree, _order_cluster_tree,
+    _hierarchy, _LINKAGE_METHODS)
 from scipy.spatial.distance import pdist
 from scipy.cluster._hierarchy import Heap
 
@@ -104,6 +105,17 @@ class TestLinkage(object):
                                          metric="euclidean")
         Z = linkage(y, method)
         assert_allclose(Z, expectedZ, atol=1e-06)
+
+    def test_compare_with_trivial(self):
+        rng = np.random.RandomState(0)
+        n = 20
+        X = rng.rand(n, 2)
+        d = pdist(X)
+
+        for method, code in _LINKAGE_METHODS.items():
+            Z_trivial = _hierarchy.linkage(d, n, code)
+            Z = linkage(d, method)
+            assert_allclose(Z_trivial, Z, rtol=1e-14, atol=1e-15)
 
 
 class TestLinkageTies(object):


### PR DESCRIPTION
As mentioned in #6802, the trivial algorithm can be improved significantly to run as O(N^2) in the best case, which often happens in practice.

So I implemented this modification, rather straightforward. But some more experimenting / reviewing will be useful.

Here is a comparison example:

```Python
from time import time
import numpy as np
from scipy.cluster.hierarchy import linkage
from scipy.spatial.distance import pdist
from fastcluster import linkage as linkage_fc

np.random.seed(0)
X = np.random.randn(3000, 2)
d = pdist(X)


def cluster_and_time(d, fun, method):
    t1 = time()
    Z = fun(d, method=method)
    t2 = time()
    return Z, t2 - t1


cases = [
    ('new', linkage, 'median'),
    ('old', linkage, 'median_old'),
    ('fc', linkage_fc, 'median')
]

dts = {}
Zs = {}

for name, fun, method in cases:
    Z, dt = cluster_and_time(d, fun, method)
    dts[name] = dt
    Zs[name] = Z
    
for name, dt in dts.items():
    print(name, dt)
    
print(np.allclose(Zs['new'], Zs['old']))
print(np.allclose(Zs['new'], Zs['fc']))
print(np.allclose(Zs['old'], Zs['fc']))
```
```
old 11.613052129745483
new 0.2184290885925293
fc 0.09301209449768066
True
True
True
```

I think it's worth keeping the original `linkage` forever for reference and comparison.

@rgommers @richardtsai 