### PR TITLE
ENH:  speed up upfirdn and resample_poly for n-dimensional arrays

### DIFF
--- a/benchmarks/benchmarks/signal.py
+++ b/benchmarks/benchmarks/signal.py
@@ -23,7 +23,7 @@ class CalculateWindowedFFT(Benchmark):
 
     def time_welch(self):
         signal.welch(self.x)
-    
+
     def time_csd(self):
         signal.csd(self.x, self.y)
 
@@ -38,7 +38,7 @@ class CalculateWindowedFFT(Benchmark):
 
 
 class Convolve2D(Benchmark):
-    param_names = ['mode', 'boundary']    
+    param_names = ['mode', 'boundary']
     params = [
         ['full', 'valid', 'same'],
         ['fill', 'wrap', 'symm']
@@ -70,7 +70,7 @@ class Convolve2D(Benchmark):
 
 
 class FFTConvolve(Benchmark):
-    param_names = ['mode']    
+    param_names = ['mode']
     params = [
         ['full', 'valid', 'same']
     ]
@@ -93,7 +93,7 @@ class FFTConvolve(Benchmark):
 
 
 class Convolve(Benchmark):
-    param_names = ['mode']    
+    param_names = ['mode']
     params = [
         ['full', 'valid', 'same']
     ]
@@ -141,3 +141,50 @@ class LTI(Benchmark):
 
     def time_bode(self):
         signal.bode(self.system)
+
+
+class Upfirdn1D(Benchmark):
+    param_names = ['up', 'down']
+    params = [
+        [1, 4],
+        [1, 4]
+    ]
+
+    def setup(self, up, down):
+        np.random.seed(1234)
+        # sample a bunch of pairs of 2d arrays
+        pairs = []
+        for nfilt in [8, ]:
+            for n in [32, 128, 512, 2048]:
+                    h = np.random.randn(nfilt)
+                    x = np.random.randn(n)
+                    pairs.append((h, x))
+        self.pairs = pairs
+
+    def time_upfirdn1d(self, up, down):
+        for h, x in self.pairs:
+            signal.upfirdn(h, x, up=up, down=down)
+
+
+class Upfirdn2D(Benchmark):
+    param_names = ['up', 'down', 'axis']
+    params = [
+        [1, 4],
+        [1, 4],
+        [0, -1],
+    ]
+
+    def setup(self, up, down, axis):
+        np.random.seed(1234)
+        # sample a bunch of pairs of 2d arrays
+        pairs = []
+        for nfilt in [8, ]:
+            for n in [32, 128, 512]:
+                    h = np.random.randn(nfilt)
+                    x = np.random.randn(n, n)
+                    pairs.append((h, x))
+        self.pairs = pairs
+
+    def time_upfirdn2d(self, up, down, axis):
+        for h, x in self.pairs:
+            signal.upfirdn(h, x, up=up, down=down, axis=axis)

--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -54,6 +54,11 @@ compute the coeficients of a second-order IIR peak (resonant) filter.
 The function `scipy.signal.minimum_phase` was added to convert linear-phase
 FIR filters to minimum phase.
 
+The functions `scipy.signal.upfirdn` and `scipy.signal.resample_poly` are now
+substantially faster when operating on some n-dimensional arrays when n > 1.
+The largest reduction in computation time is realized in cases where the size
+of the array is small (<1k samples or so) along the axis to be filtered.
+
 `scipy.sparse` improvements
 ---------------------------
 
@@ -88,7 +93,7 @@ consistent with FITPACK, so that one can do, for example::
 For multidimensional splines, ``c.ndim > 1``, ``BSpline`` objects are consistent
 with piecewise polynomials, `scipy.interpolate.PPoly`. This means that
 ``BSpline`` objects are not immediately consistent with
-`scipy.interpolate.splprep`, and one *cannot* do 
+`scipy.interpolate.splprep`, and one *cannot* do
 ``>>> BSpline(*splprep([x, y])[0])``. Consult the `scipy.interpolate` test suite
 for examples of the precise equivalence.
 


### PR DESCRIPTION
I was pleased to see that `upfirdn` was added to scipy.  This PR, improves its performance on n-dimensional arrays by replacing the call to `np.apply_along_axis` with equivalent behavior within the Cython code.  The performance gains can be very large in some cases and are equivalent to the prior code in the 1D case.  No changes were made to the public API or the underlying filtering routine.

The Cython implementation is adapted from similar C-code developed by @kwohlfahrt to apply axis-specific convolutions in `PyWavelets`.  If interested, the specific routine that was modified is here: https://github.com/PyWavelets/pywt/blob/8c6cbe91f4096fcffc11be1d930697c52bd64a47/pywt/_extensions/c/wt.template.c#L23 .  (PyWavelets has a scipy-compatible MIT license)

The largest gains are seen for arrays with a higher number of dimensions and relatively small sizes.
For example, for a 3D array of size 32x32x32 and a filter length of 8, the speed gain is more than a factor of 60 on my machine.  At 32x32 2D array, it is nearly 20.
For larger arrays/filters, there is less relative overhead involved in using `np.apply_along_axis`.  However even for size 1024x1024 arrays with filter size 8, I still see approximately a 2 fold speedup.

I also updated the usage of `upfirdn` within `resample_poly` to avoid `np.apply_along_axis` there as well.  In that case there may be a minor memory overhead as the excess samples produced are all removed once at the end rather than on a row-by-row basis.

In the first commit here, both the old and new implementations of `upfirdn` are present simultaneously.  The redundant code was removed in a later commit (where the newly introduced  `_apply_axis`, was renamed just `_apply` as in the prior implementation).