### PR TITLE
TST: Added ConvexHull asv benchmark code

### DIFF
--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -3,7 +3,8 @@ from __future__ import division, absolute_import, print_function
 import numpy as np
 
 try:
-    from scipy.spatial import cKDTree, KDTree, SphericalVoronoi, distance
+    from scipy.spatial import (cKDTree, KDTree, SphericalVoronoi, distance,
+    ConvexHull)
 except ImportError:
     pass
 
@@ -228,3 +229,17 @@ class Cdist(Benchmark):
         sizes and metrics.
         """
         distance.cdist(self.points, self.points, metric)
+
+class ConvexHullBench(Benchmark):
+    params = ([10, 100, 1000, 5000], [True, False])
+    param_names = ['num_points', 'incremental']
+
+    def setup(self, num_points, incremental):
+        np.random.seed(123)
+        self.points = np.random.random_sample((num_points, 3))
+
+    def time_convex_hull(self, num_points, incremental):
+        """Time scipy.spatial.ConvexHull over a range of input data sizes
+        and settings.
+        """
+        ConvexHull(self.points, incremental)


### PR DESCRIPTION
I've added `asv` benchmarks for `scipy.spatial.ConvexHull`. Testing against the tip of master on my machine with `asv continuous --bench ConvexHull* 517b375 -e` produces:

```
· Running 2 total benchmarks (2 commits * 1 environments * 1 benchmarks)
[  0.00%] · For scipy commit hash 517b3758:
[  0.00%] ·· Building for virtualenv-py2.7-Cython0.23.4-Tempita0.5.2-numpy1.8.2-six.............................................................................................................................................................................
[  0.00%] ·· Benchmarking virtualenv-py2.7-Cython0.23.4-Tempita0.5.2-numpy1.8.2-six
[ 50.00%] ··· Running spatial.ConvexHullBench.time_convex_hull                                                                                                                                           ok
[ 50.00%] ···· 
               ============ ========== ==========
               --                incremental     
               ------------ ---------------------
                num_points     True      False   
               ============ ========== ==========
                    10       374.19μs   298.06μs 
                   100       427.37μs   400.48μs 
                   1000      744.14μs   766.18μs 
                   5000       1.82ms     1.83ms  
               ============ ========== ==========

[ 50.00%] · For scipy commit hash b6701e04:
[ 50.00%] ·· Building for virtualenv-py2.7-Cython0.23.4-Tempita0.5.2-numpy1.8.2-six.......................................................................................................................................................................
[ 50.00%] ·· Benchmarking virtualenv-py2.7-Cython0.23.4-Tempita0.5.2-numpy1.8.2-six
[100.00%] ··· Running spatial.ConvexHullBench.time_convex_hull                                                                                                                                           ok
[100.00%] ···· 
               ============ ========== ==========
               --                incremental     
               ------------ ---------------------
                num_points     True      False   
               ============ ========== ==========
                    10       311.93μs   298.13μs 
                   100       408.36μs   394.36μs 
                   1000      735.87μs   731.83μs 
                   5000       1.79ms     1.76ms  
               ============ ========== ==========
    before     after       ratio
  [b6701e04] [517b3758]
+  311.93μs   374.19μs      1.20  spatial.ConvexHullBench.time_convex_hull(10, True)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.

```
I suspect the variation for the small number of points is to be expected.