### PR TITLE
BLD: Strip carriage return in .pyx processing

### DIFF
--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -155,7 +155,7 @@ def get_pxi_dependencies(fullfrompath):
     dependencies = []
     with open(fullfrompath, 'r') as f:
         for line in f:
-            line = [token.strip('\'\" \n') for token in line.split(' ')]
+            line = [token.strip('\'\" \r\n') for token in line.split(' ')]
             if line[0] == "include":
                 dependencies.append(os.path.join(fullfromdir, line[1]))
     return dependencies


### PR DESCRIPTION
I was attempting to build `scipy` with `Cygwin`, when I got the following error:
~~~
Traceback (most recent call last):
  File "/cygdrive/c/Users/gfyoung/Repositories/scipy/tools/cythonize.py", line 233, in <module>
    main()
  File "/cygdrive/c/Users/gfyoung/Repositories/scipy/tools/cythonize.py", line 229, in main
    find_process_files(root_dir)
  File "/cygdrive/c/Users/gfyoung/Repositories/scipy/tools/cythonize.py", line 220, in find_process_files
    process(cur_dir, fromfile, tofile, function, hash_db, pxi_hashes)
  File "/cygdrive/c/Users/gfyoung/Repositories/scipy/tools/cythonize.py", line 175, in process
    pxi_hash = get_hash(pxi, None)
  File "/cygdrive/c/Users/gfyoung/Repositories/scipy/tools/cythonize.py", line 146, in get_hash
    from_hash = sha1_of_file(frompath)
  File "/cygdrive/c/Users/gfyoung/Repositories/scipy/tools/cythonize.py", line 131, in sha1_of_file
    with open(filename, "rb") as f:
IOError: [Errno 2] No such file or directory: "scipy/sparse/csgraph/parameters.pxi'\r"
Traceback (most recent call last):
  File "setup.py", line 415, in <module>
    setup_package()
  File "setup.py", line 399, in setup_package
    generate_cython()
  File "setup.py", line 205, in generate_cython
    raise RuntimeError("Running cythonize failed!")
RuntimeError: Running cythonize failed!
~~~
When iterating through lines of the `file` object, there was a stray carriage return that wasn't getting removed, causing the file searching in `get_pxi_hash` to break, as you can see above.  This PR fixes that.  Afterwards, `scipy` builds just fine on `master`.