### PR TITLE
Signal spectral window default fix

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -169,6 +169,7 @@ John Draper for bug fixes.
 Alvaro Sanchez-Gonzalez for axis-dependent modes in multidimensional filters.
 Alessandro Pietro Bardelli for improvements to pdist/cdist and to related tests.
 Jonathan T. Siebert for bug fixes.
+David Nicholson for bug fixes in spectral functions.
 
 Institutions
 ------------

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -998,10 +998,15 @@ def _triage_segments(window, nperseg,input_length):
         if nperseg is None:
             nperseg = 256  # then change to default
             if nperseg > input_length:
-                raise ValueError('Default value for nperseg, {0:d}, is greater'
-                                 ' than input length = {1:d}. Please specify a '
-                                 'value for nperseg equal to or less than {1:d}'
-                                 .format(nperseg,input_length))
+                warnings.warn('nperseg = {0:d}, is greater than input length '
+                              ' = {1:d}, using nperseg = {1:d}'
+                              .format(nperseg, input_length))
+                nperseg = input_length
+        if nperseg > input_length:
+            raise ValueError('Default value for nperseg, {0:d}, is greater'
+                             ' than input length = {1:d}. Please specify a '
+                             'value for nperseg equal to or less than {1:d}'
+                             .format(nperseg,input_length))
         win = get_window(window, nperseg)
     else:
         win = np.asarray(window)

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -971,7 +971,6 @@ def _triage_segments(window, nperseg):
         Length of each segment.  Defaults to 256.
     """
     
-    
     #parse window; if array like, then set nperseg = win.shape
     if isinstance(window, string_types) or isinstance(window, tuple):
         # if nperseg not specified

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -162,7 +162,9 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         directly as the window and its length will be used for nperseg.
         Defaults to 'hann'.
     nperseg : int, optional
-        Length of each segment.  Defaults to 256.
+        Length of each segment. Defaults to None, but if window is str or
+        tuple, is set to 256, and if window is array_like, is set to the
+        length of the window.
     noverlap : int, optional
         Number of points to overlap between segments. If None,
         ``noverlap = nperseg // 2``.  Defaults to None.
@@ -294,12 +296,14 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         directly as the window and its length will be used for nperseg.
         Defaults to 'hann'.
     nperseg : int, optional
-        Length of each segment.  Defaults to 256.
+        Length of each segment. Defaults to None, but if window is str or
+        tuple, is set to 256, and if window is array_like, is set to the
+        length of the window.
     noverlap: int, optional
         Number of points to overlap between segments. If None,
         ``noverlap = nperseg // 2``.  Defaults to None.
     nfft : int, optional
-        Length of the FFT used, if a zero padded FFT is desired.  If None,
+        Length of the FFT used, if a zero padded FFT is desired. If None,
         the FFT length is `nperseg`. Defaults to None.
     detrend : str or function or False, optional
         Specifies how to detrend each segment. If `detrend` is a string,
@@ -421,7 +425,9 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=None, noverlap=None,
         directly as the window and its length will be used for nperseg.
         Defaults to a Tukey window with shape parameter of 0.25.
     nperseg : int, optional
-        Length of each segment.  Defaults to 256.
+        Length of each segment. Defaults to None, but if window is str or
+        tuple, is set to 256, and if window is array_like, is set to the
+        length of the window.
     noverlap : int, optional
         Number of points to overlap between segments. If None,
         ``noverlap = nperseg // 8``.  Defaults to None.
@@ -546,7 +552,9 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         directly as the window and its length will be used for nperseg.
         Defaults to 'hann'.
     nperseg : int, optional
-        Length of each segment.  Defaults to 256.
+        Length of each segment. Defaults to None, but if window is str or
+        tuple, is set to 256, and if window is array_like, is set to the
+        length of the window.
     noverlap: int, optional
         Number of points to overlap between segments. If None,
         ``noverlap = nperseg // 2``.  Defaults to None.
@@ -661,7 +669,9 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None,
         directly as the window and its length will be used for nperseg.
         Defaults to 'hann'.
     nperseg : int, optional
-        Length of each segment.  Defaults to 256.
+        Length of each segment. Defaults to None, but if window is str or
+        tuple, is set to 256, and if window is array_like, is set to the
+        length of the window.
     noverlap : int, optional
         Number of points to overlap between segments. If None,
         ``noverlap = nperseg // 2``.  Defaults to None.
@@ -978,8 +988,10 @@ def _triage_segments(window, nperseg):
         the actual array used as a window.
 
     nperseg : int
-        Length of each segment. Defaults to 256 (if called with None).
-    
+        Length of each segment. If window is str or tuple, nperseg is set to
+        256. If window is array_like, nperseg is set to the length of the
+        6
+        window.
     """
 
     #parse window; if array like, then set nperseg = win.shape

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -508,7 +508,7 @@ def spectrogram(x, fs=1.0, window=('tukey',.25), nperseg=None, noverlap=None,
     >>> plt.show()
     """
 
-    #parse window; if array like, then set nperseg = win.shape
+    # need to set default for nperseg before setting default for noverlap below
     window, nperseg = _triage_segments(window, nperseg)   
             
     # Less overlap than welch, so samples are more statisically independent
@@ -770,7 +770,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None,
                 pad_shape[-1] = x.shape[-1] - y.shape[-1]
                 y = np.concatenate((y, np.zeros(pad_shape)), -1)
 
-    #parse window; if array like, then set nperseg = win.shape
+    # parse window; if array like, then set nperseg = win.shape
     win, nperseg = _triage_segments(window, nperseg)              
         
     # X and Y are same length now, can test nperseg with either
@@ -971,8 +971,9 @@ def _triage_segments(window, nperseg):
     
     #parse window; if array like, then set nperseg = win.shape
     if isinstance(window, string_types) or isinstance(window, tuple):
-        if nperseg is None: # if nperseg not specified
-            nperseg = 256 # then change to default
+        # if nperseg not specified
+        if nperseg is None:  
+            nperseg = 256  # then change to default
         win = get_window(window, nperseg)
     else:
         win = np.asarray(window)

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -778,6 +778,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None,
         warnings.warn('nperseg = {0:d}, is greater than input length = {1:d}, '
                       'using nperseg = {1:d}'.format(nperseg, x.shape[-1]))
         nperseg = x.shape[-1]
+        win, nperseg = _triage_segments(window, nperseg) 
 
     nperseg = int(nperseg)
     if nperseg < 1:
@@ -966,8 +967,10 @@ def _triage_segments(window, nperseg):
     window : ndarray
         Array of FFT data
     
-    nperseg : 
+    nperseg : int, optional
+        Length of each segment.  Defaults to 256.
     """
+    
     
     #parse window; if array like, then set nperseg = win.shape
     if isinstance(window, string_types) or isinstance(window, tuple):
@@ -981,5 +984,8 @@ def _triage_segments(window, nperseg):
             raise ValueError('window must be 1-D')
         if nperseg is None:
             nperseg = win.shape[0]
-    
+        elif nperseg is not None:
+            if nperseg != win.shape[0]:
+                raise ValueError("Value specified for nperseg is different from"
+                                 " length of ndarray provided as window.")
     return win, nperseg

--- a/scipy/signal/spectral.py
+++ b/scipy/signal/spectral.py
@@ -997,16 +997,11 @@ def _triage_segments(window, nperseg,input_length):
         # if nperseg not specified
         if nperseg is None:
             nperseg = 256  # then change to default
-            if nperseg > input_length:
-                warnings.warn('nperseg = {0:d}, is greater than input length '
+        if nperseg > input_length:
+            warnings.warn('nperseg = {0:d} is greater than input length '
                               ' = {1:d}, using nperseg = {1:d}'
                               .format(nperseg, input_length))
-                nperseg = input_length
-        if nperseg > input_length:
-            raise ValueError('Default value for nperseg, {0:d}, is greater'
-                             ' than input length = {1:d}. Please specify a '
-                             'value for nperseg equal to or less than {1:d}'
-                             .format(nperseg,input_length))
+            nperseg = input_length
         win = get_window(window, nperseg)
     else:
         win = np.asarray(window)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -122,7 +122,7 @@ class TestPeriodogram(TestCase):
         fe, pe = periodogram(x, 10, win)
         assert_array_almost_equal_nulp(p, pe)
         assert_array_almost_equal_nulp(f, fe)
-        
+
     def test_padded_fft(self):
         x = np.zeros(16)
         x[0] = 1
@@ -359,7 +359,7 @@ class TestWelch(TestCase):
         assert_array_almost_equal_nulp(p, pe)
         assert_array_almost_equal_nulp(f, fe)
         assert_raises(ValueError, welch, x,
-                      10, win, nperseg=4) 
+                      10, win, nperseg=4)  # because nperseg != win.shape[-1]
 
     def test_empty_input(self):
         f, p = welch([])
@@ -663,7 +663,7 @@ class TestCSD:
         assert_array_almost_equal_nulp(p, pe)
         assert_array_almost_equal_nulp(f, fe)
         assert_raises(ValueError, csd, x, x,
-                      10, win, nperseg=256) 
+                      10, win, nperseg=256)  # because nperseg != win.shape[-1]
 
     def test_empty_input(self):
         f, p = csd([],np.zeros(10))

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -387,7 +387,7 @@ class TestWelch(TestCase):
     def test_short_data(self):
         x = np.zeros(8)
         x[0] = 1
-        assert_raises(ValueError, welch, x) # default nperseg > x.shape[-1]
+        assert_raises(ValueError, welch, x)  # default nperseg > x.shape[-1]
 
     def test_window_long_or_nd(self):
         with warnings.catch_warnings():
@@ -712,7 +712,7 @@ class TestCSD:
     def test_short_data(self):
         x = np.zeros(8)
         x[0] = 1
-        assert_raises(ValueError, csd, x, x) # default nperseg > x.shape[-1]
+        assert_raises(ValueError, csd, x, x)  # default nperseg > x.shape[-1]
 
     def test_window_long_or_nd(self):
         with warnings.catch_warnings():

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -122,6 +122,9 @@ class TestPeriodogram(TestCase):
         fe, pe = periodogram(x, 10, win)
         assert_array_almost_equal_nulp(p, pe)
         assert_array_almost_equal_nulp(f, fe)
+        win_err = signal.get_window('hann', 32)
+        assert_raises(ValueError, periodogram, x,
+                      10, win_err)  # win longer than signal
 
     def test_padded_fft(self):
         x = np.zeros(16)
@@ -362,6 +365,9 @@ class TestWelch(TestCase):
         assert_array_equal(pe.shape, (5,))
         assert_raises(ValueError, welch, x,
                       10, win, nperseg=4)  # because nperseg != win.shape[-1]
+        win_err = signal.get_window('hann', 32)
+        assert_raises(ValueError, welch, x,
+                      10, win_err, nperseg=None)  # win longer than signal      
 
     def test_empty_input(self):
         f, p = welch([])
@@ -381,13 +387,7 @@ class TestWelch(TestCase):
     def test_short_data(self):
         x = np.zeros(8)
         x[0] = 1
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', UserWarning)
-            f, p = welch(x)
-
-        f1, p1 = welch(x, nperseg=8)
-        assert_allclose(f, f1)
-        assert_allclose(p, p1)
+        assert_raises(ValueError, welch, x) # default nperseg > x.shape[-1]
 
     def test_window_long_or_nd(self):
         with warnings.catch_warnings():
@@ -669,6 +669,9 @@ class TestCSD:
         assert_array_equal(pe.shape, (5,))
         assert_raises(ValueError, csd, x, x,
                       10, win, nperseg=256)  # because nperseg != win.shape[-1]
+        win_err = signal.get_window('hann', 32)
+        assert_raises(ValueError, csd, x, x,
+              10, win_err, nperseg=None)  # because win longer than signal
 
     def test_empty_input(self):
         f, p = csd([],np.zeros(10))
@@ -709,13 +712,7 @@ class TestCSD:
     def test_short_data(self):
         x = np.zeros(8)
         x[0] = 1
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', UserWarning)
-            f, p = csd(x, x)
-
-        f1, p1 = csd(x, x, nperseg=8)
-        assert_allclose(f, f1)
-        assert_allclose(p, p1)
+        assert_raises(ValueError, csd, x, x) # default nperseg > x.shape[-1]
 
     def test_window_long_or_nd(self):
         with warnings.catch_warnings():
@@ -860,7 +857,9 @@ class TestSpectrogram:
         assert_array_equal(Pe.shape, (9,73))
         assert_raises(ValueError, spectrogram, x,
                       fs, win, nperseg=8)  # because nperseg != win.shape[-1]
-
+        win_err = signal.get_window(('tukey', 0.25), 2048)
+        assert_raises(ValueError, spectrogram, x,
+                      fs, win_err, nperseg=None)  # win longer than signal
 
 class TestLombscargle:
     def test_frequency(self):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -387,7 +387,17 @@ class TestWelch(TestCase):
     def test_short_data(self):
         x = np.zeros(8)
         x[0] = 1
-        assert_raises(ValueError, welch, x)  # default nperseg > x.shape[-1]
+        #default nperseg with x.shape[-1] < default nperseg value raises Warning
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            f, p = welch(x)
+
+        f1, p1 = welch(x, nperseg=8)
+        assert_allclose(f, f1)
+        assert_allclose(p, p1)
+     
+        # user-specified nperseg > x.shape[-1] raises ValueError
+        assert_raises(ValueError, welch, x, nperseg=256)
 
     def test_window_long_or_nd(self):
         with warnings.catch_warnings():
@@ -712,7 +722,20 @@ class TestCSD:
     def test_short_data(self):
         x = np.zeros(8)
         x[0] = 1
-        assert_raises(ValueError, csd, x, x)  # default nperseg > x.shape[-1]
+
+        #default nperseg with x.shape[-1] < default nperseg value raises Warning
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            f, p = csd(x, x)
+
+        f1, p1 = csd(x, x, nperseg=8)
+        assert_allclose(f, f1)
+        assert_allclose(p, p1)
+
+        # user-specified nperseg > x.shape[-1] raises ValueError        
+        x = np.zeros(8)
+        x[0] = 1
+        assert_raises(ValueError, csd, x, x, nperseg=256)
 
     def test_window_long_or_nd(self):
         with warnings.catch_warnings():

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -122,7 +122,7 @@ class TestPeriodogram(TestCase):
         fe, pe = periodogram(x, 10, win)
         assert_array_almost_equal_nulp(p, pe)
         assert_array_almost_equal_nulp(f, fe)
-
+        
     def test_padded_fft(self):
         x = np.zeros(16)
         x[0] = 1
@@ -358,6 +358,8 @@ class TestWelch(TestCase):
         fe, pe = welch(x, 10, win, 8)
         assert_array_almost_equal_nulp(p, pe)
         assert_array_almost_equal_nulp(f, fe)
+        assert_raises(ValueError, welch, x,
+                      10, win, nperseg=4) 
 
     def test_empty_input(self):
         f, p = welch([])
@@ -660,6 +662,8 @@ class TestCSD:
         fe, pe = csd(x, x, 10, win, 8)
         assert_array_almost_equal_nulp(p, pe)
         assert_array_almost_equal_nulp(f, fe)
+        assert_raises(ValueError, csd, x, x,
+                      10, win, nperseg=256) 
 
     def test_empty_input(self):
         f, p = csd([],np.zeros(10))

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -476,7 +476,7 @@ class TestWelch(TestCase):
     def test_window_correction(self):
         A = 20
         fs = 1e4
-        nperseg = fs//10
+        nperseg = int(fs//10)
         fsig = 300
         ii = int(fsig*nperseg//fs)  # Freq index of fsig
 


### PR DESCRIPTION
Resolves issue #6817 (hopefully). The _spectral_helper function now checks whether window is array_like and if so changes nperseg to the length of that array. Otherwise, if nperseg was not specified, then it is set to the default of 256. This means that that all functions with an nperseg argument that call _spectral_helper now have the default nperseg=None (i.e. not specified) in their argument lists instead of nperseg=256.

Tested with example code from the docs and everything looks the same. Examples also look as I would expect when using the default 256 instead of nperseg=1024 in the examples.