### PR TITLE
BUG: SphericalVoronoi Space Complexity (Fixes #6811)

### DIFF
--- a/doc/release/0.19.0-notes.rst
+++ b/doc/release/0.19.0-notes.rst
@@ -41,6 +41,9 @@ Moreover, both gained a ``balanced`` keyword to turn balancing on and off.
 `SphericalVoronoi.sort_vertices_of_regions()` has been re-written in
 cython to improve performance
 
+`SphericalVoronoi` can handle > 200 k points (at least 10 million) & has
+improved performance
+
 `scipy.ndimage` improvements
 ----------------------------
 

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -259,10 +259,9 @@ class SphericalVoronoi:
             simplex_indices]).ravel()
         point_indices = self._tri.simplices.ravel()
 
-        list_tuples_associations = zip(point_indices,
-                                       tri_indices)
+        array_associations = np.dstack((point_indices, tri_indices))[0]
 
-        list_tuples_associations = sorted(list_tuples_associations,
+        list_tuples_associations = sorted(array_associations,
                                           key=lambda t: t[0])
 
         # group by generator indices to produce

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -235,6 +235,7 @@ class SphericalVoronoi:
 
         # add the center to each of the simplices in tri to get the same
         # tetrahedrons we'd have gotten from Delaunay tetrahedralization
+        # tetrahedrons will have shape: (2N-4, 4, 3)
         tetrahedrons = self._tri.points[self._tri.simplices]
         tetrahedrons = np.insert(
             tetrahedrons,
@@ -244,9 +245,11 @@ class SphericalVoronoi:
         )
 
         # produce circumcenters of tetrahedrons from 3D Delaunay
+        # circumcenters will have shape: (2N-4, 3)
         circumcenters = calc_circumcenters(tetrahedrons)
 
         # project tetrahedron circumcenters to the surface of the sphere
+        # self.vertices will have shape: (2N-4, 3)
         self.vertices = project_to_sphere(
             circumcenters,
             self.center,
@@ -254,13 +257,18 @@ class SphericalVoronoi:
         )
 
         # calculate regions from triangulation
+        # simplex_indices will have shape: (2N-4,)
         simplex_indices = np.arange(self._tri.simplices.shape[0])
+        # tri_indices will have shape: (6N-12,)
         tri_indices = np.column_stack([simplex_indices, simplex_indices,
             simplex_indices]).ravel()
+        # point_indices will have shape: (6N-12,)
         point_indices = self._tri.simplices.ravel()
 
+        # array_associations will have shape: (6N-12, 2)
         array_associations = np.dstack((point_indices, tri_indices))[0]
 
+        # list_tuples_associations will have shape: (6N-12, 2)
         list_tuples_associations = \
         array_associations[np.argsort(array_associations[...,0])]
 

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -254,12 +254,13 @@ class SphericalVoronoi:
         )
 
         # calculate regions from triangulation
-        generator_indices = np.arange(self.points.shape[0])
-        filter_tuple = np.where((np.expand_dims(self._tri.simplices,
-                                -1) == generator_indices).any(axis=1))
+        simplex_indices = np.arange(self._tri.simplices.shape[0])
+        tri_indices = np.stack([simplex_indices, simplex_indices,
+            simplex_indices], axis=-1).ravel()
+        point_indices = self._tri.simplices.ravel()
 
-        list_tuples_associations = zip(filter_tuple[1],
-                                       filter_tuple[0])
+        list_tuples_associations = zip(point_indices,
+                                       tri_indices)
 
         list_tuples_associations = sorted(list_tuples_associations,
                                           key=lambda t: t[0])

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -275,7 +275,7 @@ class SphericalVoronoi:
         groups = []
         for k, g in itertools.groupby(array_associations,
                                       lambda t: t[0]):
-            groups.append([element[1] for element in list(g)])
+            groups.append(list(zip(*list(g))[1]))
 
         self.regions = groups
 

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -255,8 +255,8 @@ class SphericalVoronoi:
 
         # calculate regions from triangulation
         simplex_indices = np.arange(self._tri.simplices.shape[0])
-        tri_indices = np.stack([simplex_indices, simplex_indices,
-            simplex_indices], axis=-1).ravel()
+        tri_indices = np.column_stack([simplex_indices, simplex_indices,
+            simplex_indices]).ravel()
         point_indices = self._tri.simplices.ravel()
 
         list_tuples_associations = zip(point_indices,

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -276,7 +276,7 @@ class SphericalVoronoi:
         groups = []
         for k, g in itertools.groupby(array_associations,
                                       lambda t: t[0]):
-            groups.append(list(zip(*list(g))[1]))
+            groups.append(list(list(zip(*list(g)))[1]))
 
         self.regions = groups
 

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -261,8 +261,8 @@ class SphericalVoronoi:
 
         array_associations = np.dstack((point_indices, tri_indices))[0]
 
-        list_tuples_associations = sorted(array_associations,
-                                          key=lambda t: t[0])
+        list_tuples_associations = \
+        array_associations[np.argsort(array_associations[...,0])]
 
         # group by generator indices to produce
         # unsorted regions in nested list

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -267,8 +267,9 @@ class SphericalVoronoi:
 
         # array_associations will have shape: (6N-12, 2)
         array_associations = np.dstack((point_indices, tri_indices))[0]
-        array_associations = array_associations[np.argsort(
-                                                array_associations[...,0])]
+        array_associations = array_associations[np.lexsort((
+                                                array_associations[...,1],
+                                                array_associations[...,0]))]
 
         # group by generator indices to produce
         # unsorted regions in nested list

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -267,15 +267,13 @@ class SphericalVoronoi:
 
         # array_associations will have shape: (6N-12, 2)
         array_associations = np.dstack((point_indices, tri_indices))[0]
-
-        # list_tuples_associations will have shape: (6N-12, 2)
-        list_tuples_associations = \
-        array_associations[np.argsort(array_associations[...,0])]
+        array_associations = array_associations[np.argsort(
+                                                array_associations[...,0])]
 
         # group by generator indices to produce
         # unsorted regions in nested list
         groups = []
-        for k, g in itertools.groupby(list_tuples_associations,
+        for k, g in itertools.groupby(array_associations,
                                       lambda t: t[0]):
             groups.append([element[1] for element in list(g)])
 

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import numpy as np
 import itertools
 from numpy.testing import (TestCase,
+                           assert_equal,
                            assert_almost_equal,
                            assert_array_equal,
                            assert_array_almost_equal)
@@ -120,6 +121,17 @@ class TestSphericalVoronoi(TestCase):
         sv.sort_vertices_of_regions()
         actual = list(itertools.chain(*sorted(sv.regions)))
         assert_array_equal(actual, expected)
+
+    def test_num_vertices(self):
+        # for any n >= 3, a spherical Voronoi diagram has 2n - 4
+        # vertices; this is a direct consequence of Euler's formula
+        # as explained by Dinis and Mamede (2010) Proceedings of the
+        # 2010 International Symposium on Voronoi Diagrams in Science
+        # and Engineering
+        sv = SphericalVoronoi(self.points)
+        expected = self.points.shape[0] * 2 - 4
+        actual = sv.vertices.shape[0]
+        assert_equal(actual, expected)
 
     def test_voronoi_circles(self):
         sv = spherical_voronoi.SphericalVoronoi(self.points)


### PR DESCRIPTION
### Background

Issue #6811 describes a limitation of `SphericalVoronoi` -- in its current state the space complexity of the algorithm is apparently prohibitive with 2e5 input points, N. The algorithm was generating an array of shape (2N-4, 3, N), which was enormous.

### Fix Implemented Here

I appear to have vastly reduced the space complexity of the algorithm by generating data structures that have shapes of (2N-4, 3) and (N,), respectively. Let's check the performance of `SphericalVoronoi` with these modifications against the tip of master: `asv continuous --bench SphericalVor 9cec221e 94e1a681 -e`

```
    before     after       ratio
  [9cec221e] [94e1a681]
-    2.45ms     2.14ms      0.87  spatial.SphericalVor.time_spherical_voronoi_calculation(100)
-   32.50ms    16.69ms      0.51  spatial.SphericalVor.time_spherical_voronoi_calculation(1000)
-  598.06ms    89.15ms      0.15  spatial.SphericalVor.time_spherical_voronoi_calculation(5000)
-     2.23s   207.27ms      0.09  spatial.SphericalVor.time_spherical_voronoi_calculation(10000)
```
Notice how the performance differential is greater as the number of input points increases. If I had to speculate, this is likely related to the increasing alleviation of memory issues as you increase N -- allowing the machine to avoid paying rapidly-growing physical memory costs at high N.

So, there's a performance bonus, which is nice, but what about the maximum number of input points we can handle now? Using the setup provided in the issue by @ktritz to do some very *informal* tests with differing `num_points`:

```python
  import numpy as np                                                              
  import scipy                                                                    
  from scipy.spatial import SphericalVoronoi                                      
  import time                                                                     
                                                                                   
  start = time.time()                                                             
  num_points = int(2e6)                                                           
  print 'num_points:', num_points                                                 
                                                                                 
  def uniform(num):                                                               
      vec = np.random.randn(3, num)                                               
      vec /= np.linalg.norm(vec, axis=0)                                          
      return vec.T              
                                                                                                                                   
  SphericalVoronoi(uniform(num_points))                                           
  print 'Finished; execution time (minutes):', (time.time() - start) / 60.   
```
Table: `SphericalVoronoi` execution times on macbook with 16 GB RAM [and space complexity stress test]

| `num_points`  | time (minutes) |
|--------------------|---------------------|
| 1e5                |   0.04          |
| 2e5                |   0.10          |
| 2e6                |  1.35           |
| 1e7           |    9.49          |

The performance times and input size limits for `SphericalVoronoi` appear to now be vastly superior to those reported in the issue above, though it may be nice if @ktritz could confirm using this branch. 

These changes are not going to change the quadratic time complexity -- that requires more consultation with the primary literature, etc., which is eventually planned, but at least this enables some performance improvement and the possibility of working with data sets far larger than the previous 200,000 input limit. I haven't yet tried to stress `SphericalVoronoi` to the 238 million point limit of `ConvexHull`, but even if it did work, you probably wouldn't want to wait for it. 10 million is a good improvement over 200k, I think, though not quite up to i.e., CGAL type standards (yet).

### Additional Improvements

I suspect that there is still potential for substantial improvement (without changing the fundamental algorithm). The creation of the column stacked array you can see in the diff could probably be avoided with some creativity -- it is, after all, just a duplication of the indices of all the Delaunay triangles, and there are a lot of neat tricks in `itertools` that might be exploited. Still, this is a decent start. Also, it may be more sensible to focus future efforts on getting to loglinear time rather than the time sink of optimizing an algorithm that will explode at large data sizes regardless.

### Testing / Preventing Regression of Space Complexity

My original idea was to take the code adjusted in this PR, abstract it to a function, and then do a small unit test of the shape of the output of that function, to make sure it is appropriate & prevent regression of space complexity. If we do it for this part of the code, I suspect we'd feel somewhat compelled to do this for other parts of the control flow as well, which might be a bit ugly.

In practice it may be more practical to simply place comments at key points in the SphericalVoronoi code that summarize the shapes of the data structures produced. Indeed, I think experienced algorithm developers can formally analyze the space complexity without executing the code. We could at least tag the key areas so that if someone goes in and makes changes, they might be more likely to ensure that the shapes remain roughly the same.

