### PR TITLE
RealData docstring correction

### DIFF
--- a/scipy/odr/odrpack.py
+++ b/scipy/odr/odrpack.py
@@ -306,7 +306,7 @@ class RealData(Data):
         If array-like, observed data for the dependent variable of the
         regression. A scalar input implies that the model to be used on
         the data is implicit.
-    sx, sy : array_like, optional
+    sx : array_like, optional
         Standard deviations of `x`.
         `sx` are standard deviations of `x` and are converted to weights by
         dividing 1.0 by their squares.


### PR DESCRIPTION
The docstring for `scipy.odr.RealData` contains parameter descriptions for `sx` and `sy`, but the description for the `sx` parameter incorrectly has an `sy` in it. 