### PR TITLE
ENH: LDLt decomposition for indefinite symmetric/hermitian matrices.

### DIFF
--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -67,6 +67,7 @@ Decompositions
    svdvals - Singular values of a matrix
    diagsvd - Construct matrix of singular values from output of svd
    orth - Construct orthonormal basis for the range of A using svd
+   ldl - LDL.T decomposition of a Hermitian or a symmetric matrix.
    cholesky - Cholesky decomposition of a matrix
    cholesky_banded - Cholesky decomp. of a sym. or Hermitian banded matrix
    cho_factor - Cholesky decomposition for use in solving a linear system
@@ -189,6 +190,7 @@ from .special_matrices import *
 from ._solvers import *
 from ._procrustes import *
 from ._decomp_update import *
+from ._decomp_ldl import *
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 

--- a/scipy/linalg/_decomp_ldl.py
+++ b/scipy/linalg/_decomp_ldl.py
@@ -1,0 +1,339 @@
+#
+# Author: Ilhan Polat, December, 2016
+#
+
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+from numpy import atleast_2d
+from .decomp import _asarray_validated
+from .misc import LinAlgError
+from .lapack import get_lapack_funcs
+
+__all__ = ['ldl']
+
+
+def ldl(A, lower=True, rook_pivoting=False, only_sym=False,
+        overwrite_a=False, check_finite=True):
+    """ Computes the ``ldl`` or Bunch-Kaufman factorization of a symmetric/
+    hermitian matrix.
+
+    This function returns a block diagonal matrix D consisting blocks of size
+    at most 2x2 and also a possibly permuted unit lower triangular matrix
+    :math:`L` such that the factorization
+
+    .. math::
+
+                            A = L D L^H
+
+    holds.
+
+    Depending on the value of the boolean ``lower``, only upper or lower
+    triangular part of the input array is referenced. Hence a triangular
+    part of matrix on entry would give the same result as if the full matrix
+    is supplied.
+
+    Parameters
+    ----------
+    A : array_like
+        Symmetric/hermitian input matrix
+    lower : bool, optional
+        This switches between the lower and upper triangular outer factors of
+        the factorization. As the name implies lower triangular that is
+        (``lower=True``) is the default.
+    rook_pivoting : bool, optional
+        Switches between the pivoting algorithms. See Notes section below.
+    only_sym : bool, optional
+        In case the input matrix is complex valued and symmetric, by setting
+        this, the matrix is assumed to be only symmetric and not hermitian.
+    overwrite_a : bool, optional
+        Allow overwriting data in `a` (may enhance performance). The default
+        is False.
+    check_finite : bool, optional
+        Whether to check that the input matrices contain only finite numbers.
+        Disabling may give a performance gain, but may result in problems
+        (crashes, non-termination) if the inputs do contain infinities or NaNs.
+
+    Returns
+    -------
+    lu : ndarray
+        The permuted square outer factor of the factorization.
+    d : ndarray
+        The block diagonal multiplier of the factorization.
+    perm : ndarray
+        The permutation indices array.
+
+    Notes
+    -----
+    The main computational routines are LAPACK's ?SYTRF and, if an Hermitian
+    matrix is factorized, ?HETRF routines.
+
+    If ``only_sym`` is set instead of assuming the complex-valued array to
+    be hermitian and choosing the (C/Z)HETRF solvers, symmetric solvers
+    (C/Z)SYTRF are selected.
+
+    See also
+    --------
+    cholesky, lu
+
+    .. versionadded:: 0.19.0
+    """
+    a = atleast_2d(_asarray_validated(A, check_finite=check_finite))
+    if a.shape[0] != a.shape[1]:
+        raise ValueError('The input matrix should be square.')
+    n = a.shape[0]
+    r_or_c = complex if np.iscomplexobj(a) else float
+
+    # Get the low-level functions
+    if r_or_c is complex and not only_sym:
+        if np.any(np.imag(np.diag(a))):
+            raise ValueError('The matrix diagonal entries should be real '
+                             'for the hermitian decomposition. Otherwise '
+                             'set only_sym keyword to True for symmetric '
+                             'solution.')
+
+        s, sl = ('hetrf_rook', 'hetrf_rook_lwork') if rook_pivoting else (
+                                                    'hetrf', 'hetrf_lwork')
+    else:
+        s, sl = ('sytrf_rook', 'sytrf_rook_lwork') if rook_pivoting else (
+                                                    'sytrf', 'sytrf_lwork')
+
+    solver, solver_lwork = get_lapack_funcs((s, sl), (a,))
+    lwork, linfo = solver_lwork(n, lower=lower)
+    if linfo < 0:
+        raise ValueError('{} exited with the internal error '
+                         '"illegal value in argument number {}." while '
+                         'requesting the optimal block size LWORK. See '
+                         'LAPACK documentation for the error codes.'
+                         ''.format(s, -linfo)
+                         )
+
+    ldu, piv, sinfo = solver(a, lwork=lwork, lower=lower)
+    if sinfo < 0:
+        raise ValueError('{} exited with the internal error '
+                         '"illegal value in argument number {}". See '
+                         'LAPACK documentation for the error codes.'
+                         ''.format(s, -sinfo)
+                         )
+
+    swap_arr, pivot_arr = _ldl_sanitize_ipiv(piv, lower=lower,
+                                             rook=rook_pivoting)
+    d, l = _ldl_get_d_and_l(ldu, pivot_arr, lower=lower, only_sym=only_sym)
+    lu, perm = _ldl_construct_tri_factor(l, swap_arr, pivot_arr, lower=lower)
+
+    return lu, d, perm
+
+
+def _ldl_sanitize_ipiv(a, lower=True, rook=False):
+    """
+    This helper function takes the strangely encoded permutation array
+    returned by the LAPACK routines ?(HE/SY)TRF, ?(HE/SY)TRF_ROOK and
+    converts it into regularized permutation and diagonal pivot size format.
+
+    Since FORTRAN uses 1-indexing and LAPACK uses different start points for
+    upper and lower formats there are certain offsets in the indices used
+    below.
+
+    Let's assume a result where the matrix is 6x6 and there are two 2x2
+    and two 1x1 blocks reported by the routine. To ease the coding efforts,
+    we still populate a 6-sized array and fill zeros as the following ::
+
+        pivots = [2, 0, 2, 0, 1, 1]
+
+    This denotes a diagonal matrix of the form ::
+
+        [x x        ]
+        [x x        ]
+        [    x x    ]
+        [    x x    ]
+        [        x  ]
+        [          x]
+
+    In other words, we write 2 when the 2x2 block is first encountered and
+    automatically write 0 to the next entry and skip the next spin of the
+    loop. Thus, a separate counter or array appends to keep track of block
+    sizes are avoided. Zeros can be removed much easier instead.
+
+    Parameters
+    ----------
+    a : ndarray
+        The permutation array ipiv returned by LAPACK
+    lower : bool, optional
+        The switch to select whether upper or lower triangle is chosen in
+        the LAPACK call.
+    rook : bool, optional
+        The switch to select whether the partial or the rook pivoting method
+        is chosen in the LAPACK call.
+    Returns
+    -------
+    swap_ : ndarray
+        The array that defines the row/column swap operations. For example,
+        if row two is swapped with four the result is [0, 3, 2, 3].
+
+    """
+    n = a.size
+    swap_ = np.arange(n)
+    pivots = np.zeros_like(swap_, dtype=int)
+    skip_2x2 = False
+
+    # Some upper/lower dependent offset values
+    x, y, rs, re, ri = (1, 0, 0, n, 1) if lower else (-1, -1, n-1, -1, -1)
+
+    if rook:
+        for ind in range(rs, re, ri):
+            if skip_2x2:
+                skip_2x2 = False
+                continue
+
+            cur_val = a[ind]
+            # do have a 1x1 block or not?
+            if cur_val > 0:
+                if cur_val != ind + 1:
+                    swap_[ind] = swap_[cur_val - 1]
+                pivots[ind] = 1
+            # not.
+            elif cur_val < 0 and a[ind + x] < 0:
+                # first neg entry of 2x2 block identifier
+                if -cur_val != ind + 1:
+                    swap_[ind] = swap_[-cur_val - 1]
+                if -a[ind + x] != ind + x + 1:
+                    swap_[ind + x] = swap_[-a[ind + x] - 1]
+                pivots[ind + y] = 2
+                skip_2x2 = True
+            else:  # Doesn't make sense, give up
+                raise LinAlgError('While parsing the permutation array '
+                                  'in "scipy.linalg.ldl", invalid entries'
+                                  ' found.')
+    # rook = False
+    else:
+        for ind in range(rs, re, ri):
+            if skip_2x2:
+                skip_2x2 = False
+                continue
+
+            cur_val = a[ind]
+            # do we have a 1x1 block or not?
+            if cur_val > 0:
+                if cur_val != ind+1:
+                    # Index value != array value --> permutation required
+                    swap_[ind] = swap_[cur_val-1]
+                pivots[ind] = 1
+            # Not.
+            elif cur_val < 0 and cur_val == a[ind+x]:
+                # first neg entry of 2x2 block identifier
+                if -cur_val != ind+2:
+                    # Index value != array value --> permutation required
+                    swap_[ind+x] = swap_[-cur_val-1]
+                pivots[ind+y] = 2
+                skip_2x2 = True
+            else:  # Doesn't make sense, give up
+                raise LinAlgError('While parsing the permutation array '
+                                  'in "scipy.linalg.ldl", invalid entries'
+                                  ' found. Either "rook" key is not set'
+                                  ' properly or the array is invalid.')
+    return swap_, pivots
+
+
+def _ldl_get_d_and_l(ldu, pivs, lower=True, only_sym=False):
+    """
+    Helper function to extract the diagonal and triangular matrices for
+    LDL.T factorization.
+
+    Parameters
+    ----------
+    ldu : ndarray
+        The compact output returned by the LAPACK routing
+    pivs : ndarray
+        The sanitized array of {0, 1, 2} denoting the sizes of the pivots. For
+        every 2 there is a succeeding 0.
+    lower : bool, optional
+        If set to False, upper triangular part is considered.
+
+    Returns
+    -------
+    d : ndarray
+        The block diagonal matrix.
+    lu : ndarray
+        The upper/lower triangular matrix
+    """
+    is_c = np.iscomplexobj(ldu)
+    d = np.diag(np.diag(ldu))
+    n = d.shape[0]
+    blk_i = 0  # block index
+
+    # row/column offsets for selecting sub-, super-diagonal
+    x, y = (1, 0) if lower else (0, 1)
+
+    lu = np.tril(ldu, -1) if lower else np.triu(ldu, 1)
+    diag_inds = np.arange(n)
+    lu[diag_inds, diag_inds] = 1
+
+    for blk in pivs[pivs != 0]:
+        # increment the block index and check for 2s
+        # if 2 then copy the off diagonals depending on uplo
+        inc = blk_i + blk
+
+        if blk == 2:
+            if is_c and not only_sym:
+                d[[blk_i+x, blk_i+y], [blk_i+y, blk_i+x]] = [
+                    ldu[blk_i+x, blk_i+y], ldu[blk_i+x, blk_i+y].conj()]
+            else:
+                d[[blk_i+x, blk_i+y], [blk_i+y, blk_i+x]] = \
+                                                        ldu[blk_i+x, blk_i+y]
+            lu[blk_i+x, blk_i+y] = 0
+        blk_i = inc
+
+    return d, lu
+
+
+def _ldl_construct_tri_factor(lu, swap_vec, pivs, lower=True):
+    """
+    Helper function to construct explicit outer factors of LDL factorization.
+
+    If lower is True the permuted factors are multiplied as L(1)*L(2)*...*L(k).
+    Otherwise, the permuted factors are multiplied as L(k)*...*L(2)*L(1). See
+    LAPACK documentation for more details.
+
+    Parameters
+    ----------
+    lu : ndarray
+        The triangular array that is extracted from LAPACK routine call with
+        ones on the diagonals.
+    swap_vec : ndarray
+        The array that defines the row swapping indices. If k'th entry is m
+        then rows k,m are swapped. Notice that m'th entry is not necessarily
+        k to avoid undoing the swapping.
+    lower : bool, optional
+        The boolean to switch between lower and upper triangular structure.
+
+    Returns
+    -------
+    lu : ndarray
+        The square outer factor which satisfies the L * D * L.T = A
+    perm : ndarray
+        The permutation vector that brings the lu to the triangular form
+
+    Notes
+    -----
+    It should be noted that we overwrite the original argument "lu".
+    """
+    n = lu.shape[0]
+    perm = np.arange(n)
+    # Setup the reading order of the permutation matrix for upper/lower
+    rs, re, ri = (n-1, -1, -1) if lower else (0, n, 1)
+
+    for ind in range(rs, re, ri):
+        s_ind = swap_vec[ind]
+        if s_ind != ind:
+            # Column start and end positions
+            col_s = ind if lower else 0
+            col_e = n if lower else ind+1
+
+            # If we stumble upon a 2x2 block include both cols in the perm.
+            if pivs[ind] == (0 if lower else 2):
+                col_s += -1 if lower else 0
+                col_e += 0 if lower else 1
+            lu[[s_ind, ind], col_s:col_e] = lu[[ind, s_ind], col_s:col_e]
+            perm[[s_ind, ind]] = perm[[ind, s_ind]]
+
+    return lu, np.argsort(perm)

--- a/scipy/linalg/_decomp_ldl.py
+++ b/scipy/linalg/_decomp_ldl.py
@@ -123,7 +123,8 @@ def ldl(A, lower=True, rook_pivoting=False, only_sym=False,
                          ''.format(s, -linfo)
                          )
 
-    ldu, piv, sinfo = solver(a, lwork=lwork, lower=lower)
+    ldu, piv, sinfo = solver(a, lwork=lwork, lower=lower,
+                             overwrite_a=overwrite_a)
     if sinfo < 0:
         raise ValueError('{} exited with the internal error '
                          '"illegal value in argument number {}". See '

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -902,14 +902,14 @@ interface
      callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&s,&cond,&r,&work,&lwork,&info)
      callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*
 
-     integer intent(in):: m 
+     integer intent(in):: m
      integer intent(in):: n
      integer intent(hide),depend(m,n):: maxmn = MAX(m,n)
      <ftype2> intent(hide) :: a
 
      integer intent(in):: nrhs
      <ftype2> intent(hide) :: b
-     
+
      <ftype2> intent(in),optional :: cond = -1.0
      integer intent(hide) :: r
      <ftype2> intent(hide) :: s
@@ -953,23 +953,23 @@ interface
    end subroutine <prefix2c>gelss
 
    subroutine <prefix2>lasd4( n, i, d, z, delta, rho, sigma, work, info )
-    
+
 	! sigma, delta, work, info = lasd4(d,z,i,rho=1.0)
    	! Computes i-th square root of eigenvalue of rank one augmented diagonal matrix. Needed by SVD update procedure
-	
+
 	callstatement { i++; (*f2py_func)( &n, &i, d, z, delta, &rho, &sigma, work, &info); }
      callprotoargument int*, int*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, <ctype2>*, int*
-	
+
 	integer intent(hide),depend(d):: n = shape(d,0)
 	integer intent(in),depend(d),check(i>=0 && i<=(shape(d,0)-1)):: i
-	
+
 	<ftype2> dimension(n),intent(in)           :: d
 	<ftype2> dimension(n),intent(in),depend(n) :: z
-	
+
 	<ftype2> intent(out) :: sigma
 	<ftype2> dimension(n),intent(out),depend(n) :: delta
 	<ftype2> intent(in),optional:: rho = 1.0
-	
+
 	<ftype2> dimension(n),intent(out),depend(n) :: work
 	integer intent(out) :: info
 
@@ -991,7 +991,7 @@ interface
 
      integer intent(in):: nrhs
      <ftype2c> intent(hide) :: b
-     
+
      <ftype2> intent(in),optional :: cond = -1.0
      integer intent(hide) :: r
      <ftype2> intent(hide) :: s
@@ -1026,7 +1026,7 @@ interface
      integer intent(in,out,out=j),dimension(n),depend(n) :: jptv
 
      ! LWORK is obtained by the query call
-     integer intent(in),depend(nrhs,m,n,minmn) :: lwork 
+     integer intent(in),depend(nrhs,m,n,minmn) :: lwork
      check(lwork>=MAX(minmn+3*n+1, 2*minmn+nrhs)) :: lwork
      <ftype2> dimension(lwork),intent(cache,hide),depend(lwork) :: work
      integer intent(out)::info
@@ -1123,7 +1123,7 @@ interface
 
    ! x,s,rank,info = dgelsd(a,b,lwork,size_iwork,cond=-1.0,overwrite_a=True,overwrite_b=True)
    ! Solve Minimize 2-norm(A * X - B).
-    
+
      callstatement (*f2py_func)(&m,&n,&nrhs,a,&m,b,&maxmn,s,&cond,&r,work,&lwork,iwork,&info)
      callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
 
@@ -1140,14 +1140,14 @@ interface
      <ftype2> intent(in),optional :: cond=-1.0
      integer intent(out,out=rank) :: r
      <ftype2> intent(out),dimension(minmn),depend(minmn) :: s
-	
+
      integer intent(in),check(lwork>=1) :: lwork
      ! Impossible to calculate lwork explicitly, need to obtain it from query call first
      ! Same for size_iwork
      <ftype2> dimension(lwork),intent(cache,hide),depend(lwork) :: work
 
      integer intent(in) :: size_iwork
-     integer intent(cache,hide),dimension(MAX(1,size_iwork)),depend(size_iwork) :: iwork	
+     integer intent(cache,hide),dimension(MAX(1,size_iwork)),depend(size_iwork) :: iwork
      integer intent(out)::info
 
    end subroutine <prefix2>gelsd
@@ -1156,7 +1156,7 @@ interface
 
    ! work,iwork,info = dgelsd_lwork(m,n,nrhs,cond=-1.0)
    ! Query for optimal lwork size
-    
+
      fortranname <prefix2>gelsd
      callstatement (*f2py_func)(&m,&n,&nrhs,&a,&m,&b,&maxmn,&s,&cond,&r,&work,&lwork,&iwork,&info)
      callprotoargument int*,int*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,int*,int*
@@ -1172,11 +1172,11 @@ interface
      <ftype2> intent(in),optional :: cond=-1.0
      integer intent(hide) :: r
      <ftype2> intent(hide) :: s
-	
+
      integer intent(in),optional :: lwork = -1
      <ftype2> intent(out) :: work
 
-     integer intent(out) :: iwork	
+     integer intent(out) :: iwork
      integer intent(out)::info
 
    end subroutine <prefix2>gelsd_lwork
@@ -1202,7 +1202,7 @@ interface
      <ftype2> intent(in),optional :: cond=-1.0
      integer intent(out,out=rank) :: r
      <ftype2> intent(out),dimension(minmn),depend(minmn) :: s
-	
+
      integer intent(in),check(lwork>=1||lwork==-1) :: lwork
      ! Impossible to calculate lwork explicitly, need to obtain it from query call first
      ! Same for size_rwork, size_iwork
@@ -1212,7 +1212,7 @@ interface
      <ftype2> intent(cache,hide),dimension(MAX(1,size_rwork)),depend(size_rwork) :: rwork
 
      integer intent(in) :: size_iwork
-     integer intent(cache,hide),dimension(MAX(1,size_iwork)),depend(size_iwork) :: iwork	
+     integer intent(cache,hide),dimension(MAX(1,size_iwork)),depend(size_iwork) :: iwork
      integer intent(out)::info
 
    end subroutine <prefix2c>gelsd
@@ -1237,12 +1237,12 @@ interface
      <ftype2> intent(in),optional :: cond=-1.0
      integer intent(hide) :: r
      <ftype2> intent(hide) :: s
-	
+
      integer intent(in),optional :: lwork = -1
      <ftype2c> intent(out) :: work
      <ftype2> intent(out) :: rwork
 
-     integer intent(out) :: iwork	
+     integer intent(out) :: iwork
      integer intent(out)::info
 
    end subroutine <prefix2c>gelsd_lwork
@@ -1864,7 +1864,7 @@ interface
 
    subroutine <prefix>sytrf_lwork(lower,n,a,lda,ipiv,work,lwork,info)
      ! lwork computation for ?SYTRF
- 
+
      fortranname <prefix>sytrf
 
      callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&ipiv,&work,&lwork,&info)
@@ -1907,7 +1907,7 @@ interface
 
    subroutine <prefix>sytrf_rook_lwork(lower,n,a,lda,ipiv,work,lwork,info)
      ! lwork computation for ?SYTRF_ROOK
- 
+
      fortranname <prefix>sytrf_rook
 
      callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&ipiv,&work,&lwork,&info)
@@ -2057,7 +2057,7 @@ interface
 
    subroutine <prefix2c>hetrf_lwork(lower,n,a,lda,ipiv,work,lwork,info)
      ! lwork computation for ?HETRF
- 
+
      fortranname <prefix2c>hetrf
 
      callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&ipiv,&work,&lwork,&info)
@@ -2099,7 +2099,7 @@ interface
 
    subroutine <prefix2c>hetrf_rook_lwork(lower,n,a,lda,ipiv,work,lwork,info)
      ! lwork computation for ?HETRF_ROOK
- 
+
      fortranname <prefix2c>hetrf_rook
 
      callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&ipiv,&work,&lwork,&info)
@@ -3229,7 +3229,7 @@ subroutine ilaver(major, minor, patch)
     integer intent(out) :: minor
     integer intent(out) :: patch
 end subroutine ilaver
- 
+
 end interface
 
 end python module _flapack

--- a/scipy/linalg/flapack.pyf.src
+++ b/scipy/linalg/flapack.pyf.src
@@ -1804,6 +1804,127 @@ interface
      integer intent(out) :: info
    end subroutine <prefix2c>heevd
 
+   subroutine <prefix>sytf2(lower,n,a,lda,ipiv,info)
+
+     ! Compute the factorization of a symmetric matrix such that
+     ! A = L * D * L^T if lower = 1
+     ! A = U * D * U^T if lower = 0
+
+     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,ipiv,&info)
+     callprotoargument char*,int*,<ctype>*,int*,int*,int*
+
+     integer optional,intent(in),check(lower==0||lower==1):: lower = 1
+     integer depend(a),intent(hide):: n = shape(a,0)
+     <ftype> dimension(n,n),intent(in,out,copy,out=ldu):: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     integer dimension(n),depend(n),intent(out):: ipiv
+     integer intent(out):: info
+
+   end subroutine<prefix>sytf2
+
+   subroutine <prefix>sytf2_rook(lower,n,a,lda,ipiv,info)
+
+     ! Compute the factorization of a symmetric matrix such that
+     ! A = L * D * L^T if lower = 1
+     ! A = U * D * U^T if lower = 0
+     ! This is similar to ?SYTF2 but uses the "Rook pivoting" algorithm
+
+     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,ipiv,&info)
+     callprotoargument char*,int*,<ctype>*,int*,int*,int*
+
+     integer optional,intent(in),check(lower==0||lower==1):: lower = 1
+     integer depend(a),intent(hide):: n = shape(a,0)
+     <ftype> dimension(n,n),intent(in,out,copy,out=ldu):: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     integer dimension(n),depend(n),intent(out):: ipiv
+     integer intent(out):: info
+
+   end subroutine<prefix>sytf2_rook
+
+   subroutine <prefix>sytrf(lower,n,a,lda,ipiv,work,lwork,info)
+
+     ! Compute the factorization of a symmetric matrix such that
+     ! A = L * D * L^T if lower = 1
+     ! A = U * D * U^T if lower = 0
+     ! This is similar to ?SYTF2 but uses BLAS3 blocked calls
+
+     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,ipiv,work,&lwork,&info)
+     callprotoargument char*,int*,<ctype>*,int*,int*,<ctype>*,int*,int*
+
+     integer optional,intent(in),check(lower==0||lower==1):: lower = 1
+     integer depend(a),intent(hide):: n = shape(a,0)
+     <ftype> dimension(n,n),intent(in,out,copy,out=ldu):: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     integer dimension(n),depend(n),intent(out):: ipiv
+     integer optional,intent(in),depend(n),check(lwork>=n||lwork==-1):: lwork = n
+     <ftype> depend(lwork),dimension(MAX(lwork,1)),intent(hide,cache):: work
+     integer intent(out):: info
+
+   end subroutine <prefix>sytrf
+
+   subroutine <prefix>sytrf_lwork(lower,n,a,lda,ipiv,work,lwork,info)
+     ! lwork computation for ?SYTRF
+ 
+     fortranname <prefix>sytrf
+
+     callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&ipiv,&work,&lwork,&info)
+     callprotoargument char*,int*,<ctype>*,int*,int*,<ctype>*,int*,int*
+
+     integer intent(in):: n
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+
+     <ftype> intent(hide):: a
+     integer depend(n),intent(hide):: lda = n
+     integer intent(hide):: ipiv
+     integer intent(hide):: lwork = -1
+
+     <ftype> intent(out):: work
+     integer intent(out):: info
+
+   end subroutine <prefix>sytrf_lwork
+
+   subroutine <prefix>sytrf_rook(lower,n,a,lda,ipiv,work,lwork,info)
+
+     ! Compute the factorization of a symmetric matrix such that
+     ! A = L * D * L^T if lower = 1
+     ! A = U * D * U^T if lower = 0
+     ! This is similar to ?SYTRF but uses "rook" pivoting algorithm.
+     ! Also similar to ?SYTF2_ROOK but uses the BLAS3 blocked calls.
+
+     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,ipiv,work,&lwork,&info)
+     callprotoargument char*,int*,<ctype>*,int*,int*,<ctype>*,int*,int*
+
+     integer optional,intent(in),check(lower==0||lower==1):: lower = 1
+     integer depend(a),intent(hide):: n = shape(a,0)
+     <ftype> dimension(n,n),intent(in,out,copy,out=ldu):: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     integer dimension(n),depend(n),intent(out):: ipiv
+     integer optional,intent(in),depend(n),check(lwork>=n||lwork==-1):: lwork = n
+     <ftype> depend(lwork),dimension(MAX(lwork,1)),intent(hide,cache):: work
+     integer intent(out):: info
+
+   end subroutine <prefix>sytrf_rook
+
+   subroutine <prefix>sytrf_rook_lwork(lower,n,a,lda,ipiv,work,lwork,info)
+     ! lwork computation for ?SYTRF_ROOK
+ 
+     fortranname <prefix>sytrf_rook
+
+     callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&ipiv,&work,&lwork,&info)
+     callprotoargument char*,int*,<ctype>*,int*,int*,<ctype>*,int*,int*
+
+     integer intent(in):: n
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+
+     <ftype> intent(hide):: a
+     integer depend(n),intent(hide):: lda = n
+     integer intent(hide):: ipiv
+     integer intent(hide):: lwork = -1
+
+     <ftype> intent(out):: work
+     integer intent(out):: info
+
+   end subroutine <prefix>sytrf_rook_lwork
 
    subroutine <prefix>posv(n,nrhs,a,b,info,lower)
 
@@ -1913,6 +2034,89 @@ interface
      integer intent(out) :: info
    end subroutine <prefix>potri
 
+   subroutine <prefix2c>hetrf(lower,n,a,lda,ipiv,work,lwork,info)
+
+     ! Compute the factorization of a hermitian matrix such that
+     ! A = L * D * L^T if lower = 1
+     ! A = U * D * U^T if lower = 0
+     ! This is similar to ?HETF2 but uses BLAS3 blocked calls
+
+     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,ipiv,work,&lwork,&info)
+     callprotoargument char*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,int*
+
+     integer optional,intent(in),check(lower==0||lower==1):: lower = 1
+     integer depend(a),intent(hide):: n = shape(a,0)
+     <ftype2c> dimension(n,n),intent(in,out,copy,out=ldu):: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     integer dimension(n),depend(n),intent(out):: ipiv
+     integer optional,intent(in),depend(n),check(lwork>=n||lwork==-1):: lwork = n
+     <ftype2c> depend(lwork),dimension(MAX(lwork,1)),intent(hide,cache):: work
+     integer intent(out):: info
+
+   end subroutine <prefix2c>hetrf
+
+   subroutine <prefix2c>hetrf_lwork(lower,n,a,lda,ipiv,work,lwork,info)
+     ! lwork computation for ?HETRF
+ 
+     fortranname <prefix2c>hetrf
+
+     callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&ipiv,&work,&lwork,&info)
+     callprotoargument char*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,int*
+
+     integer intent(in):: n
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+
+     <ftype2c> intent(hide):: a
+     integer depend(n),intent(hide):: lda = n
+     integer intent(hide):: ipiv
+     integer intent(hide):: lwork = -1
+
+     <ftype2c> intent(out):: work
+     integer intent(out):: info
+
+   end subroutine <prefix2c>hetrf_lwork
+
+   subroutine <prefix2c>hetrf_rook(lower,n,a,lda,ipiv,work,lwork,info)
+
+     ! Compute the factorization of a hermitian matrix such that
+     ! A = L * D * L^T if lower = 1
+     ! A = U * D * U^T if lower = 0
+     ! This is similar to ?HETF2_ROOK but uses BLAS3 blocked calls
+
+     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,ipiv,work,&lwork,&info)
+     callprotoargument char*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,int*
+
+     integer optional,intent(in),check(lower==0||lower==1):: lower = 1
+     integer depend(a),intent(hide):: n = shape(a,0)
+     <ftype2c> dimension(n,n),intent(in,out,copy,out=ldu):: a
+     integer depend(a),intent(hide):: lda = shape(a,0)
+     integer dimension(n),depend(n),intent(out):: ipiv
+     integer optional,intent(in),depend(n),check(lwork>=n||lwork==-1):: lwork = n
+     <ftype2c> depend(lwork),dimension(MAX(lwork,1)),intent(hide,cache):: work
+     integer intent(out):: info
+
+   end subroutine <prefix2c>hetrf_rook
+
+   subroutine <prefix2c>hetrf_rook_lwork(lower,n,a,lda,ipiv,work,lwork,info)
+     ! lwork computation for ?HETRF_ROOK
+ 
+     fortranname <prefix2c>hetrf_rook
+
+     callstatement (*f2py_func)((lower?"L":"U"),&n,&a,&lda,&ipiv,&work,&lwork,&info)
+     callprotoargument char*,int*,<ctype2c>*,int*,int*,<ctype2c>*,int*,int*
+
+     integer intent(in):: n
+     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0
+
+     <ftype2c> intent(hide):: a
+     integer depend(n),intent(hide):: lda = n
+     integer intent(hide):: ipiv
+     integer intent(hide):: lwork = -1
+
+     <ftype2c> intent(out):: work
+     integer intent(out):: info
+
+   end subroutine <prefix2c>hetrf_rook_lwork
 
    subroutine <prefix>lauum(n,c,info,lower)
 

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -285,6 +285,48 @@ All functions
    ctrtrs
    ztrtrs
 
+   ssytf2
+   dsytf2
+   csytf2
+   zsytf2
+
+   ssytf2_rook
+   dsytf2_rook
+   csytf2_rook
+   zsytf2_rook
+
+   ssytrf
+   dsytrf
+   csytrf
+   zsytrf
+
+   ssytrf_rook
+   dsytrf_rook
+   csytrf_rook
+   zsytrf_rook
+
+   ssytrf_lwork
+   dsytrf_lwork
+   csytrf_lwork
+   zsytrf_lwork
+
+   ssytrf_rook_lwork
+   dsytrf_rook_lwork
+   csytrf_rook_lwork
+   zsytrf_rook_lwork
+
+   chetrf
+   zhetrf
+
+   chetrf_rook
+   zhetrf_rook
+
+   chetrf_lwork
+   zhetrf_lwork
+
+   chetrf_rook_lwork
+   zhetrf_rook_lwork
+
    cunghr
    zunghr
 

--- a/scipy/linalg/tests/test_decomp_ldl.py
+++ b/scipy/linalg/tests/test_decomp_ldl.py
@@ -14,7 +14,7 @@ class TestLDL(TestCase):
     def Test_args(self):
         A = eye(3)
         assert_raises(ValueError, ldl, A[:, :2])
-        assert_raises(ValueError, ldl, A*1j) 
+        assert_raises(ValueError, ldl, A*1j)
 
     def Test_simple(self):
         a = array([[-0.39-0.71j, 5.14-0.64j, -7.86-2.96j, 3.80+0.92j],
@@ -76,7 +76,7 @@ class TestLDL(TestCase):
     def Test_permutations(self):
         for _ in range(10):
             n = randint(1, 100)
-            x = rand(n,n)
+            x = rand(n, n)
             x = x + x.conj().T
             x += eye(n)*randint(5, 1e6)
             lu_ind = tril_indices_from(x, k=-1)

--- a/scipy/linalg/tests/test_decomp_ldl.py
+++ b/scipy/linalg/tests/test_decomp_ldl.py
@@ -1,0 +1,84 @@
+from __future__ import division, print_function, absolute_import
+
+from numpy.testing import (TestCase, assert_array_almost_equal,
+                           assert_raises, assert_)
+from numpy import array, eye, zeros_like, any, tril_indices_from
+from numpy.random import rand, randint, seed
+from scipy.linalg import ldl
+
+
+class TestLDL(TestCase):
+    def setUp(self):
+        seed(1234)
+
+    def Test_args(self):
+        A = eye(3)
+        assert_raises(ValueError, ldl, A[:, :2])
+        assert_raises(ValueError, ldl, A*1j) 
+
+    def Test_simple(self):
+        a = array([[-0.39-0.71j, 5.14-0.64j, -7.86-2.96j, 3.80+0.92j],
+                   [5.14-0.64j, 8.86+1.81j, -3.52+0.58j, 5.32-1.59j],
+                   [-7.86-2.96j, -3.52+0.58j, -2.83-0.03j, -1.54-2.86j],
+                   [3.80+0.92j, 5.32-1.59j, -1.54-2.86j, -0.56+0.12j]])
+        b = array([[5, 10, 1, 18],
+                   [10, 2, 11, 1],
+                   [1, 11, 19, 9],
+                   [18, 1, 9, 0]])
+        c = array([[52, 97, 112, 107, 50],
+                   [97, 114, 89, 98, 13],
+                   [112, 89, 64, 33, 6],
+                   [107, 98, 33, 60, 73],
+                   [50, 13, 6, 73, 77]])
+
+        d = array([[2, 2, -4, 0, 4],
+                   [2, -2, -2, 10, -8],
+                   [-4, -2, 6, -8, -4],
+                   [0, 10, -8, 6, -6],
+                   [4, -8, -4, -6, 10]])
+        for x in (b, c, d):
+            l, d, p = ldl(x)
+            assert_array_almost_equal(l.dot(d).dot(l.T)-x, zeros_like(x))
+            l, d, p = ldl(x, lower=False)
+            assert_array_almost_equal(l.dot(d).dot(l.T)-x, zeros_like(x))
+
+        l, d, p = ldl(a, only_sym=True)
+        assert_array_almost_equal(l.dot(d).dot(l.T)-a, zeros_like(a))
+
+    def Test_rook_pivoting(self):
+        a = array([[-0.39-0.71j, 5.14-0.64j, -7.86-2.96j, 3.80+0.92j],
+                   [5.14-0.64j, 8.86+1.81j, -3.52+0.58j, 5.32-1.59j],
+                   [-7.86-2.96j, -3.52+0.58j, -2.83-0.03j, -1.54-2.86j],
+                   [3.80+0.92j, 5.32-1.59j, -1.54-2.86j, -0.56+0.12j]])
+        b = array([[5, 10, 1, 18],
+                   [10, 2, 11, 1],
+                   [1, 11, 19, 9],
+                   [18, 1, 9, 0]])
+        c = array([[52, 97, 112, 107, 50],
+                   [97, 114, 89, 98, 13],
+                   [112, 89, 64, 33, 6],
+                   [107, 98, 33, 60, 73],
+                   [50, 13, 6, 73, 77]])
+        d = array([[2, 2, -4, 0, 4],
+                   [2, -2, -2, 10, -8],
+                   [-4, -2, 6, -8, -4],
+                   [0, 10, -8, 6, -6],
+                   [4, -8, -4, -6, 10]])
+
+        for x in (b, c, d):
+            l, d, p = ldl(x, rook_pivoting=True)
+            assert_array_almost_equal(l.dot(d).dot(l.T)-x, zeros_like(x))
+            l, d, p = ldl(x, lower=False, rook_pivoting=True)
+            assert_array_almost_equal(l.dot(d).dot(l.T)-x, zeros_like(x))
+        l, d, p = ldl(a, only_sym=True, rook_pivoting=True)
+        assert_array_almost_equal(l.dot(d).dot(l.T)-a, zeros_like(a))
+
+    def Test_permutations(self):
+        for _ in range(10):
+            n = randint(1, 100)
+            x = rand(n,n)
+            x = x + x.conj().T
+            x += eye(n)*randint(5, 1e6)
+            lu_ind = tril_indices_from(x, k=-1)
+            l, d, p = ldl(x, lower=0)
+            assert_(not any(l[p, :][lu_ind]), 'Spin {} failed'.format(_))


### PR DESCRIPTION
As discussed in #6202 on SciPy and https://github.com/numpy/numpy/pull/4078, https://github.com/numpy/numpy/pull/4079, https://github.com/numpy/numpy/issues/3960 on NumPy, this PR provides a wrapper around the solvers

```
?sytrf
?hetrf
?sytrf_rook
?hetrf_rook
```
and corresponding `lwork` computation routines. Compared to other implementations, some features are support of the rook pivoting algorithms, sanitized permutation information, symmetric (but not hermitian) complex-valued matrices. 

As one can see, the LAPACK output is so densely packed, getting the necessary information out with all exceptions requires quite some branching. Hence the length helper functions. This possibly explains why there are no open source implementations of the unpacking of these routines. We can also argue that these are rarely needed however since we have enough PRs and issues open for it, it seemed a valid contribution (not to mention I needed them).

I've also included the docstrings for the internal functions in case someone else wants to step in to optimize it further. The total cost of the unpacking is roughly about 10% of the actual time spent in the LAPACK call thus looks acceptable. 

I haven't spent too much time on the benchmarks since I kind of ran out of steam but from the few experiments, it looks like after 2k x 2k matrices the residual error of matlab in the frobenius norm sense gets unstable whereas this function though slower stays within the bounds. It might be due to a preconditioning step within matlab that I did not implement. 

The API requires essentially two keyword setting to choose between the correct solver with correct side of the triangular parts, `only_sym` as in *It is only symmetric but not hermitian*, and the switch for bounded BK algorithm `rook_pivoting`.