### PR TITLE
ENH: Add lanczos window to scipy.signal.windows

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -537,15 +537,18 @@ class TestLanczos(object):
         assert_allclose(windows.lanczos(6, False),
                         [0., 0.413496672,
                          0.826993343, 1., 0.826993343,
-                         0.413496672])
+                         0.413496672],
+                        atol=1e-9)
         assert_allclose(windows.lanczos(6),
                         [0., 0.504551152,
                          0.935489284, 0.935489284,
-                         0.504551152, 0.])
+                         0.504551152, 0.],
+                        atol=1e-9)
         assert_allclose(windows.lanczos(7, sym=True),
                         [0., 0.413496672,
                          0.826993343, 1., 0.826993343,
-                         0.413496672, 0.])
+                         0.413496672, 0.],
+                        atol=1e-9)
 
 
 class TestGetWindow(object):

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -37,6 +37,7 @@ window_funcs = [
     ('hann', ()),
     ('exponential', ()),
     ('tukey', (0.5,)),
+    ('lanczos', ())
     ]
 
 
@@ -520,6 +521,31 @@ class TestDPSS(object):
         assert_raises(ValueError, windows.dpss, 3, -1, 3)  # NW must be pos
         assert_raises(ValueError, windows.dpss, 3, 0, 3)
         assert_raises(ValueError, windows.dpss, -1, 1, 3)  # negative M
+
+
+class TestLanczos(object):
+
+    def test_basic(self):
+        # Analytical results:
+        # sinc(x) = sinc(-x)
+        # sinc(pi) = 0, sinc(0) = 1
+        # Hand computation on WolframAlpha:
+        # sinc(2 pi / 3) = 0.413496672
+        # sinc(pi / 3) = 0.826993343
+        # sinc(3 pi / 5) = 0.504551152
+        # sinc(pi / 5) = 0.935489284
+        assert_allclose(windows.lanczos(6, False),
+                        [0., 0.413496672,
+                         0.826993343, 1., 0.826993343,
+                         0.413496672])
+        assert_allclose(windows.lanczos(6),
+                        [0., 0.504551152,
+                         0.935489284, 0.935489284,
+                         0.504551152, 0.])
+        assert_allclose(windows.lanczos(7, sym=True),
+                        [0., 0.413496672,
+                         0.826993343, 1., 0.826993343,
+                         0.413496672, 0.])
 
 
 class TestGetWindow(object):

--- a/scipy/signal/windows/__init__.py
+++ b/scipy/signal/windows/__init__.py
@@ -30,6 +30,7 @@ The suite of window functions for filtering and spectral estimation.
    hann              -- Hann window
    hanning           -- Hann window
    kaiser            -- Kaiser window
+   lanczos           -- Lanczos window
    nuttall           -- Nuttall's minimum 4-term Blackman-Harris window
    parzen            -- Parzen window
    slepian           -- Slepian window
@@ -44,4 +45,4 @@ __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
            'blackmanharris', 'flattop', 'bartlett', 'hanning', 'barthann',
            'hamming', 'kaiser', 'gaussian', 'general_gaussian', 'general_cosine',
            'general_hamming', 'chebwin', 'slepian', 'cosine', 'hann',
-           'exponential', 'tukey', 'get_window', 'dpss']
+           'exponential', 'tukey', 'lanczos', 'get_window', 'dpss']


### PR DESCRIPTION
I have added the Lanczos window in `scipy.signal.windows` following the definition of other windows. I have added documentation, references and tests for this window. The reason why I added this window is because it is widely used among the climate research community for time and space filtering.