### PR TITLE
MAINT: sparse: start removing old BSR methods

### DIFF
--- a/scipy/sparse/bsr.py
+++ b/scipy/sparse/bsr.py
@@ -308,10 +308,6 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
     # NotImplemented methods #
     ##########################
 
-    def getdata(self,ind):
-        """Not implemented method."""
-        raise NotImplementedError
-
     def __getitem__(self,key):
         raise NotImplementedError
 
@@ -322,10 +318,14 @@ class bsr_matrix(_cs_matrix, _minmax_mixin):
     # Arithmetic methods #
     ######################
 
+    @np.deprecate(message="BSR matvec is deprecated in scipy 0.19.0. "
+                          "Use * operator instead.")
     def matvec(self, other):
         """Multiply matrix by vector."""
         return self * other
 
+    @np.deprecate(message="BSR matmat is deprecated in scipy 0.19.0. "
+                          "Use * operator instead.")
     def matmat(self, other):
         """Multiply this sparse matrix by other matrix."""
         return self * other

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4139,13 +4139,11 @@ class TestBSR(sparse_test_class(getset=False,
         A = bsr_matrix(arange(2*3*4*5).reshape(2*4,3*5), blocksize=(4,5))
         x = arange(A.shape[1]).reshape(-1,1)
         assert_equal(A*x, A.todense()*x)
-        assert_equal(A.matvec(x), A.todense()*x)
 
     def test_bsr_matvecs(self):
         A = bsr_matrix(arange(2*3*4*5).reshape(2*4,3*5), blocksize=(4,5))
         x = arange(A.shape[1]*6).reshape(-1,6)
         assert_equal(A*x, A.todense()*x)
-        assert_equal(A.matmat(x), A.todense()*x)
 
     @dec.knownfailureif(True, 'BSR does not have a __getitem__')
     def test_iterator(self):


### PR DESCRIPTION
See https://github.com/scipy/scipy/pull/6762#issuecomment-265321400 for the backstory.

I removed `getdata` right away because it currently just raises a `NotImplementedError`. `matvec` and `matmat` could potentially be in active use somewhere, so they get deprecation warnings.