### PR TITLE
BUG: added check for optional param scipy.stats.spearmanr

### DIFF
--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3310,14 +3310,12 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
 
         b_contains_nan, nan_policy = _contains_nan(b, nan_policy)
 
-        if b_contains_nan and nan_policy == 'omit':
-            b = ma.masked_invalid(b)
-
         if a_contains_nan or b_contains_nan:
             if nan_policy == 'propagate':
                 return SpearmanrResult(np.nan, np.nan)
 
             if nan_policy == 'omit':
+                b = ma.masked_invalid(b)
                 return mstats_basic.spearmanr(a, b, axis)
 
         br = np.apply_along_axis(rankdata, axisout, b)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3294,26 +3294,31 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
     """
     a, axisout = _chk_asarray(a, axis)
 
-    contains_nan, nan_policy = _contains_nan(a, nan_policy)
+    a_contains_nan, nan_policy = _contains_nan(a, nan_policy)
 
-    if contains_nan and nan_policy == 'omit' and b is not None:
+    if a_contains_nan and nan_policy == 'omit':
         a = ma.masked_invalid(a)
-        b = ma.masked_invalid(b)
-        return mstats_basic.spearmanr(a, b, axis)
 
-    if a.size <= 1:
+    if a.size <= 1 or (a_contains_nan and nan_policy == 'propagate'):
         return SpearmanrResult(np.nan, np.nan)
+        
     ar = np.apply_along_axis(rankdata, axisout, a)
 
     br = None
     if b is not None:
         b, axisout = _chk_asarray(b, axis)
 
-        contains_nan, nan_policy = _contains_nan(b, nan_policy)
+        b_contains_nan, nan_policy = _contains_nan(b, nan_policy)
 
-        if contains_nan and nan_policy == 'omit':
+        if b_contains_nan and nan_policy == 'omit':
             b = ma.masked_invalid(b)
-            return mstats_basic.spearmanr(a, b, axis)
+
+        if a_contains_nan or b_contains_nan:
+            if nan_policy == 'propagate':
+                return SpearmanrResult(np.nan, np.nan)
+
+            if nan_policy == 'omit':
+                return mstats_basic.spearmanr(a, b, axis)
 
         br = np.apply_along_axis(rankdata, axisout, b)
     n = a.shape[axisout]

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3296,7 +3296,7 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
 
     contains_nan, nan_policy = _contains_nan(a, nan_policy)
 
-    if contains_nan and nan_policy == 'omit':
+    if contains_nan and nan_policy == 'omit' and b is not None:
         a = ma.masked_invalid(a)
         b = ma.masked_invalid(b)
         return mstats_basic.spearmanr(a, b, axis)

--- a/scipy/stats/stats.py
+++ b/scipy/stats/stats.py
@@ -3296,10 +3296,10 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
 
     a_contains_nan, nan_policy = _contains_nan(a, nan_policy)
 
-    if a_contains_nan and nan_policy == 'omit':
+    if a_contains_nan:
         a = ma.masked_invalid(a)
 
-    if a.size <= 1 or (a_contains_nan and nan_policy == 'propagate'):
+    if a.size <= 1:
         return SpearmanrResult(np.nan, np.nan)
         
     ar = np.apply_along_axis(rankdata, axisout, a)
@@ -3311,11 +3311,13 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate'):
         b_contains_nan, nan_policy = _contains_nan(b, nan_policy)
 
         if a_contains_nan or b_contains_nan:
+            b = ma.masked_invalid(b)
+
             if nan_policy == 'propagate':
-                return SpearmanrResult(np.nan, np.nan)
+                rho, pval = mstats_basic.spearmanr(a, b, axis)
+                return SpearmanrResult(rho * np.nan, pval * np.nan)
 
             if nan_policy == 'omit':
-                b = ma.masked_invalid(b)
                 return mstats_basic.spearmanr(a, b, axis)
 
         br = np.apply_along_axis(rankdata, axisout, b)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -422,6 +422,7 @@ class TestCorrSpearmanr(TestCase):
     def test_nan_policy(self):
         x = np.arange(10.)
         x[9] = np.nan
+        assert_array_equal(stats.spearmanr(x, x), (np.nan, np.nan))
         assert_array_equal(stats.spearmanr(x, x, nan_policy='omit'),
                            (1.0, 0.0))
         assert_raises(ValueError, stats.spearmanr, x, x, nan_policy='raise')
@@ -536,6 +537,11 @@ class TestCorrSpearmanr(TestCase):
         res = stats.spearmanr(X, X)
         attributes = ('correlation', 'pvalue')
         check_named_results(res, attributes)
+
+    def test_spearmanr_optional_param(self):
+        x = np.reshape(range(1,10,1), (3,3))
+        res = (np.ones((3,3)), np.zeros((3,3)))
+        assert_array_equal(stats.spearmanr(x), res)
 
 
 class TestCorrSpearmanrTies(TestCase):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -538,10 +538,61 @@ class TestCorrSpearmanr(TestCase):
         attributes = ('correlation', 'pvalue')
         check_named_results(res, attributes)
 
-    def test_spearmanr_optional_param(self):
-        x = np.reshape(range(1,10,1), (3,3))
-        res = (np.ones((3,3)), np.zeros((3,3)))
-        assert_array_equal(stats.spearmanr(x), res)
+def test_spearmanr():
+    # Cross-check with R:
+    # cor.test(c(1,2,3,4,5),c(5,6,7,8,7),method="spearmanr")
+    x1 = [1, 2, 3, 4, 5]
+    x2 = [5, 6, 7, 8, 7]
+    expected = (0.82078268166812329, 0.088587005313543798)
+    res = stats.spearmanr(x1, x2)
+    assert_approx_equal(res[0], expected[0])
+    assert_approx_equal(res[1], expected[1])
+
+    attributes = ('correlation', 'pvalue')
+    res = stats.spearmanr(x1, x2)
+    check_named_results(res, attributes)
+
+    # with only ties in one or both inputs
+    assert_equal(stats.spearmanr([2,2,2], [2,2,2]), (np.nan, np.nan))
+    assert_equal(stats.spearmanr([2,0,2], [2,2,2]), (np.nan, np.nan))
+    assert_equal(stats.spearmanr([2,2,2], [2,0,2]), (np.nan, np.nan))
+
+    # empty arrays provided as input
+    assert_equal(stats.spearmanr([], []), (np.nan, np.nan))
+
+    np.random.seed(7546)
+    x = np.array([np.random.normal(loc=1, scale=1, size=500),
+                np.random.normal(loc=1, scale=1, size=500)])
+    corr = [[1.0, 0.3],
+            [0.3, 1.0]]
+    x = np.dot(np.linalg.cholesky(corr), x)
+    expected = (0.28659685838743354, 6.579862219051161e-11)
+    res = stats.spearmanr(x[0], x[1])
+    assert_approx_equal(res[0], expected[0])
+    assert_approx_equal(res[1], expected[1])
+
+    assert_approx_equal(stats.spearmanr([1,1,2], [1,1,2])[0], 1.0)
+
+    # test nan_policy
+    x = np.arange(10.)
+    x[9] = np.nan
+    assert_array_equal(stats.spearmanr(x, x), (np.nan, np.nan))
+    assert_allclose(stats.spearmanr(x, x, nan_policy='omit'),
+                    (1.0, 0))
+    assert_raises(ValueError, stats.spearmanr, x, x, nan_policy='raise')
+    assert_raises(ValueError, stats.spearmanr, x, x, nan_policy='foobar')
+
+    # test unequal length inputs
+    x = np.arange(10.)
+    y = np.arange(20.)
+    assert_raises(ValueError, stats.spearmanr, x, y)
+
+    #test paired value
+    x1 = [1, 2, 3, 4]
+    x2 = [8, 7, 6, np.nan]
+    res1 = stats.spearmanr(x1, x2, nan_policy='omit')
+    res2 = stats.spearmanr(x1[:3], x2[:3], nan_policy='omit')
+    assert_equal(res1, res2)
 
 
 class TestCorrSpearmanrTies(TestCase):


### PR DESCRIPTION
Fix for issue #6841 
`nan_policy='omit'` and `nan_policy='propagate'` correspond to documentation now(Fix for #6530 )
